### PR TITLE
US-BF-005: Add missing evaluation metrics to ErrorStats<T> and PredictionStats<T>

### DIFF
--- a/src/Enums/MetricType.cs
+++ b/src/Enums/MetricType.cs
@@ -10,22 +10,34 @@ public enum MetricType
     /// </summary>
     /// <remarks>
     /// <para>
-    /// <b>For Beginners:</b> R² (R-squared) tells you how well your model fits the data, on a scale from 0 to 1.
+    /// <b>For Beginners:</b> Rï¿½ (R-squared) tells you how well your model fits the data, on a scale from 0 to 1.
     /// A value of 1 means your model perfectly predicts the data, while 0 means it's no better than
-    /// just guessing the average value. For example, an R² of 0.75 means your model explains 75% of
+    /// just guessing the average value. For example, an Rï¿½ of 0.75 means your model explains 75% of
     /// the variation in the data.
     /// </para>
     /// </remarks>
     R2,
-    
+
     /// <summary>
-    /// A modified version of R² that accounts for the number of predictors in the model.
+    /// R-Squared (alias for R2) - Coefficient of determination.
     /// </summary>
     /// <remarks>
     /// <para>
-    /// <b>For Beginners:</b> Adjusted R² is similar to R², but it penalizes you for adding too many input variables
+    /// <b>For Beginners:</b> RSquared is another name for R2. They mean exactly the same thing.
+    /// Some frameworks use "RSquared" while others use "R2". This is the proportion of variance
+    /// in the dependent variable explained by the model. Values range from 0 to 1, with higher being better.
+    /// </para>
+    /// </remarks>
+    RSquared,
+
+    /// <summary>
+    /// A modified version of Rï¿½ that accounts for the number of predictors in the model.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>For Beginners:</b> Adjusted Rï¿½ is similar to Rï¿½, but it penalizes you for adding too many input variables
     /// that don't help much. This prevents "overfitting" - when your model becomes too complex and starts
-    /// memorizing the training data rather than learning general patterns. Use this instead of regular R²
+    /// memorizing the training data rather than learning general patterns. Use this instead of regular Rï¿½
     /// when comparing models with different numbers of input variables.
     /// </para>
     /// </remarks>
@@ -37,8 +49,8 @@ public enum MetricType
     /// <remarks>
     /// <para>
     /// <b>For Beginners:</b> Explained Variance Score measures how much of the variation in your data is captured
-    /// by your model. Like R², it ranges from 0 to 1, with higher values being better. The main difference
-    /// is that this metric focuses purely on variance explained, while R² also considers how far predictions
+    /// by your model. Like Rï¿½, it ranges from 0 to 1, with higher values being better. The main difference
+    /// is that this metric focuses purely on variance explained, while Rï¿½ also considers how far predictions
     /// are from the actual values.
     /// </para>
     /// </remarks>
@@ -138,9 +150,9 @@ public enum MetricType
     /// <para>
     /// <b>For Beginners:</b> Pearson Correlation measures how well the relationship between your predictions and
     /// actual values can be described with a straight line. It ranges from -1 to 1, where:
-    /// • 1 means perfect positive correlation (when actual values increase, predictions increase)
-    /// • 0 means no correlation
-    /// • -1 means perfect negative correlation (when actual values increase, predictions decrease)
+    /// ï¿½ 1 means perfect positive correlation (when actual values increase, predictions increase)
+    /// ï¿½ 0 means no correlation
+    /// ï¿½ -1 means perfect negative correlation (when actual values increase, predictions decrease)
     /// A high positive value indicates your model is capturing the right patterns, even if the exact values differ.
     /// </para>
     /// </remarks>
@@ -881,6 +893,19 @@ public enum MetricType
     /// </para>
     /// </remarks>
     AUCROC,
+
+    /// <summary>
+    /// AUC (alias for AUCROC) - Area Under the Curve (ROC).
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>For Beginners:</b> AUC is another name for AUCROC. They mean exactly the same thing.
+    /// Some frameworks use "AUC" while others use "AUCROC". In most contexts, "AUC" specifically
+    /// refers to the area under the ROC curve, which is a common metric for classification models.
+    /// Values range from 0 to 1, with higher values indicating better performance.
+    /// </para>
+    /// </remarks>
+    AUC,
 
     /// <summary>
     /// Symmetric Mean Absolute Percentage Error - A variant of MAPE that handles zero or near-zero values better.

--- a/src/Models/Inputs/ErrorStatsInputs.cs
+++ b/src/Models/Inputs/ErrorStatsInputs.cs
@@ -5,4 +5,5 @@ internal class ErrorStatsInputs<T>
     public Vector<T> Actual { get; set; } = Vector<T>.Empty();
     public Vector<T> Predicted { get; set; } = Vector<T>.Empty();
     public int FeatureCount { get; set; }
+    public PredictionType PredictionType { get; set; } = PredictionType.Regression;
 }

--- a/src/Statistics/ErrorStats.cs
+++ b/src/Statistics/ErrorStats.cs
@@ -261,11 +261,127 @@ public class ErrorStats<T>
     /// For Beginners:
     /// MeanSquaredLogError is useful when you care more about relative errors than absolute ones.
     /// It's calculated by applying logarithms to actual and predicted values before computing MSE.
-    /// 
+    ///
     /// MSLE penalizes underestimation (predicting too low) more heavily than overestimation.
     /// This is useful in scenarios where underestimating would be more problematic, like inventory forecasting.
     /// </remarks>
     public T MeanSquaredLogError { get; private set; }
+
+    /// <summary>
+    /// Mean Absolute Error - Alias for MAE property.
+    /// </summary>
+    /// <remarks>
+    /// For Beginners:
+    /// This is an alternative name for the MAE property, providing the same value.
+    /// Some frameworks and documentation prefer the full name "MeanAbsoluteError" while others use "MAE".
+    /// Both refer to the average absolute difference between predicted and actual values.
+    /// </remarks>
+    public T MeanAbsoluteError => MAE;
+
+    /// <summary>
+    /// Mean Squared Error - Alias for MSE property.
+    /// </summary>
+    /// <remarks>
+    /// For Beginners:
+    /// This is an alternative name for the MSE property, providing the same value.
+    /// Some frameworks and documentation prefer the full name "MeanSquaredError" while others use "MSE".
+    /// Both refer to the average of squared differences between predicted and actual values.
+    /// </remarks>
+    public T MeanSquaredError => MSE;
+
+    /// <summary>
+    /// Root Mean Squared Error - Alias for RMSE property.
+    /// </summary>
+    /// <remarks>
+    /// For Beginners:
+    /// This is an alternative name for the RMSE property, providing the same value.
+    /// Some frameworks and documentation prefer the full name "RootMeanSquaredError" while others use "RMSE".
+    /// Both refer to the square root of the Mean Squared Error.
+    /// </remarks>
+    public T RootMeanSquaredError => RMSE;
+
+    /// <summary>
+    /// Area Under the Curve (ROC) - Alias for AUCROC property.
+    /// </summary>
+    /// <remarks>
+    /// For Beginners:
+    /// This is an alternative name for the AUCROC property, providing the same value.
+    /// In many contexts, "AUC" specifically refers to the area under the ROC curve.
+    /// This metric is commonly used to evaluate classification models.
+    /// </remarks>
+    public T AUC => AUCROC;
+
+    /// <summary>
+    /// Classification accuracy - The proportion of correct predictions (for classification tasks).
+    /// </summary>
+    /// <remarks>
+    /// For Beginners:
+    /// Accuracy is a simple metric for classification problems. It's the percentage of predictions
+    /// that match the actual values.
+    ///
+    /// For example, if your model correctly classifies 90 out of 100 samples, the accuracy is 0.9 or 90%.
+    ///
+    /// Note: This property is typically used for classification tasks. For regression tasks,
+    /// other metrics like MAE, MSE, or R² are more appropriate.
+    ///
+    /// While intuitive, accuracy can be misleading for imbalanced classes. For example, if 95% of your
+    /// data belongs to class A, a model that always predicts class A would have 95% accuracy
+    /// despite being useless for class B.
+    /// </remarks>
+    public T Accuracy { get; private set; }
+
+    /// <summary>
+    /// The proportion of positive predictions that were actually correct (for classification).
+    /// </summary>
+    /// <remarks>
+    /// For Beginners:
+    /// Precision answers the question: "Of all the items labeled as positive, how many actually were positive?"
+    ///
+    /// It ranges from 0 to 1, with 1 being perfect.
+    ///
+    /// For example, if your model identifies 100 emails as spam, and 90 of them actually are spam,
+    /// the precision is 0.9 or 90%.
+    ///
+    /// Precision is important when the cost of false positives is high. In the spam example,
+    /// high precision means fewer important emails mistakenly marked as spam.
+    /// </remarks>
+    public T Precision { get; private set; }
+
+    /// <summary>
+    /// The proportion of actual positive cases that were correctly identified (for classification).
+    /// </summary>
+    /// <remarks>
+    /// For Beginners:
+    /// Recall answers the question: "Of all the actual positive items, how many did the model identify?"
+    ///
+    /// It ranges from 0 to 1, with 1 being perfect.
+    ///
+    /// For example, if there are 100 spam emails, and your model identifies 80 of them,
+    /// the recall is 0.8 or 80%.
+    ///
+    /// Recall is important when the cost of false negatives is high. In a medical context,
+    /// high recall means catching most cases of a disease, even if it means some false alarms.
+    /// </remarks>
+    public T Recall { get; private set; }
+
+    /// <summary>
+    /// The harmonic mean of precision and recall (for classification).
+    /// </summary>
+    /// <remarks>
+    /// For Beginners:
+    /// F1Score balances precision and recall in a single metric, which is helpful because
+    /// there's often a trade-off between them.
+    ///
+    /// It ranges from 0 to 1, with 1 being perfect.
+    ///
+    /// F1Score is particularly useful when:
+    /// - You need a single metric to compare models
+    /// - Classes are imbalanced (one class is much more common than others)
+    /// - You care equally about false positives and false negatives
+    ///
+    /// It's calculated as 2 * (precision * recall) / (precision + recall).
+    /// </remarks>
+    public T F1Score { get; private set; }
 
     /// <summary>
     /// Creates a new ErrorStats instance and calculates all error metrics.
@@ -300,10 +416,14 @@ public class ErrorStats<T>
         AUCPR = _numOps.Zero;
         AUCROC = _numOps.Zero;
         SMAPE = _numOps.Zero;
+        Accuracy = _numOps.Zero;
+        Precision = _numOps.Zero;
+        Recall = _numOps.Zero;
+        F1Score = _numOps.Zero;
 
         ErrorList = [];
 
-        CalculateErrorStats(inputs.Actual, inputs.Predicted, inputs.FeatureCount);
+        CalculateErrorStats(inputs.Actual, inputs.Predicted, inputs.FeatureCount, inputs.PredictionType);
     }
 
     /// <summary>
@@ -327,19 +447,21 @@ public class ErrorStats<T>
     /// <param name="actual">Vector of actual values (ground truth).</param>
     /// <param name="predicted">Vector of predicted values from your model.</param>
     /// <param name="numberOfParameters">Number of features or parameters in your model.</param>
+    /// <param name="predictionType">The type of prediction task (regression or classification).</param>
     /// <remarks>
     /// For Beginners:
     /// This private method does the actual work of calculating all the error metrics.
-    /// 
+    ///
     /// - actual: These are the true values you're trying to predict
     /// - predicted: These are your model's predictions
-    /// - numberOfParameters: This is how many input features your model uses, which is needed 
+    /// - numberOfParameters: This is how many input features your model uses, which is needed
     ///   for metrics that account for model complexity (like AIC, BIC)
-    /// 
-    /// The method calculates each error metric using specialized helper methods and 
+    /// - predictionType: Whether this is a regression or classification task
+    ///
+    /// The method calculates each error metric using specialized helper methods and
     /// stores the results in the corresponding properties.
     /// </remarks>
-    private void CalculateErrorStats(Vector<T> actual, Vector<T> predicted, int numberOfParameters)
+    private void CalculateErrorStats(Vector<T> actual, Vector<T> predicted, int numberOfParameters, PredictionType predictionType = PredictionType.Regression)
     {
         int n = actual.Length;
 
@@ -369,6 +491,10 @@ public class ErrorStats<T>
         AIC = StatisticsHelper<T>.CalculateAIC(n, numberOfParameters, RSS);
         BIC = StatisticsHelper<T>.CalculateBIC(n, numberOfParameters, RSS);
         AICAlt = StatisticsHelper<T>.CalculateAICAlternative(n, numberOfParameters, RSS);
+
+        // Calculate classification metrics
+        Accuracy = StatisticsHelper<T>.CalculateAccuracy(actual, predicted, predictionType);
+        (Precision, Recall, F1Score) = StatisticsHelper<T>.CalculatePrecisionRecallF1(actual, predicted, predictionType);
 
         // Populate error list
         ErrorList = [..StatisticsHelper<T>.CalculateResiduals(actual, predicted)];
@@ -418,6 +544,14 @@ public class ErrorStats<T>
             MetricType.AUCROC => AUCROC,
             MetricType.SMAPE => SMAPE,
             MetricType.MeanSquaredLogError => MeanSquaredLogError,
+            MetricType.MeanAbsoluteError => MeanAbsoluteError,
+            MetricType.MeanSquaredError => MeanSquaredError,
+            MetricType.RootMeanSquaredError => RootMeanSquaredError,
+            MetricType.AUC => AUC,
+            MetricType.Accuracy => Accuracy,
+            MetricType.Precision => Precision,
+            MetricType.Recall => Recall,
+            MetricType.F1Score => F1Score,
             _ => throw new ArgumentException($"Metric {metricType} is not available in ErrorStats.", nameof(metricType)),
         };
     }
@@ -465,6 +599,14 @@ public class ErrorStats<T>
             MetricType.AUCROC => true,
             MetricType.SMAPE => true,
             MetricType.MeanSquaredLogError => true,
+            MetricType.MeanAbsoluteError => true,
+            MetricType.MeanSquaredError => true,
+            MetricType.RootMeanSquaredError => true,
+            MetricType.AUC => true,
+            MetricType.Accuracy => true,
+            MetricType.Precision => true,
+            MetricType.Recall => true,
+            MetricType.F1Score => true,
             _ => false,
         };
     }

--- a/src/Statistics/PredictionStats.cs
+++ b/src/Statistics/PredictionStats.cs
@@ -245,12 +245,23 @@ public class PredictionStats<T>
     /// - 1 means your model perfectly predicts all values
     /// - 0 means your model does no better than simply predicting the average for every case
     /// - Values in between indicate the percentage of variance your model explains
-    /// 
+    ///
     /// For example, an R² of 0.75 means your model explains 75% of the variability in the target variable.
-    /// 
+    ///
     /// Be careful: a high R² doesn't necessarily mean your model is good - it could be overfitting!
     /// </remarks>
     public T R2 { get; private set; }
+
+    /// <summary>
+    /// R-Squared - Alias for R2 property (Coefficient of determination).
+    /// </summary>
+    /// <remarks>
+    /// For Beginners:
+    /// This is an alternative name for the R2 property, providing the same value.
+    /// Some frameworks and documentation use "RSquared" while others use "R2".
+    /// Both refer to the proportion of variance in the dependent variable explained by the model.
+    /// </remarks>
+    public T RSquared => R2;
 
     /// <summary>
     /// R² adjusted for the number of predictors in the model.
@@ -607,6 +618,7 @@ public class PredictionStats<T>
         return metricType switch
         {
             MetricType.R2 => R2,
+            MetricType.RSquared => RSquared,
             MetricType.AdjustedR2 => AdjustedR2,
             MetricType.ExplainedVarianceScore => ExplainedVarianceScore,
             MetricType.MeanPredictionError => MeanPredictionError,
@@ -648,6 +660,7 @@ public class PredictionStats<T>
         return metricType switch
         {
             MetricType.R2 => true,
+            MetricType.RSquared => true,
             MetricType.AdjustedR2 => true,
             MetricType.ExplainedVarianceScore => true,
             MetricType.MeanPredictionError => true,


### PR DESCRIPTION
## Summary
This PR adds missing evaluation metrics to `ErrorStats<T>` and `PredictionStats<T>` classes to fix CS1061 compilation errors in AutoMLModelBase.cs.

### Changes Made
- ✅ Added classification metrics to `ErrorStats<T>`: Accuracy, Precision, Recall, F1Score
- ✅ Added metric aliases in `ErrorStats<T>`: MeanAbsoluteError (→ MAE), MeanSquaredError (→ MSE), RootMeanSquaredError (→ RMSE), AUC (→ AUCROC)
- ✅ Added RSquared alias to `PredictionStats<T>` (→ R2)
- ✅ Added RSquared and AUC enum values to `MetricType`
- ✅ Added PredictionType parameter to `ErrorStatsInputs<T>` for classification metrics calculation
- ✅ Updated GetMetric and HasMetric methods in both classes
- ✅ Initialize and calculate classification metrics in ErrorStats

### Errors Fixed
This PR resolves 36 CS1061 compilation errors in AutoMLModelBase.cs (lines 604-612):
- `ErrorStats<T>` does not contain definition for 'Accuracy'
- `ErrorStats<T>` does not contain definition for 'MeanSquaredError'
- `ErrorStats<T>` does not contain definition for 'RootMeanSquaredError'
- `ErrorStats<T>` does not contain definition for 'MeanAbsoluteError'
- `ErrorStats<T>` does not contain definition for 'F1Score'
- `ErrorStats<T>` does not contain definition for 'Precision'
- `ErrorStats<T>` does not contain definition for 'Recall'
- `ErrorStats<T>` does not contain definition for 'AUC'
- `PredictionStats<T>` does not contain definition for 'RSquared'

### Testing
- ✅ dotnet build succeeds (no CS1061 errors for the added properties)
- ✅ All new properties are properly initialized and calculated
- ✅ GetMetric and HasMetric methods support all new metrics

## Related Issue
Implements US-BF-005

🤖 Generated with [Claude Code](https://claude.com/claude-code)