### PR TITLE
fix(us-bf-006): fix LinearFeatureMapper training and usage issues

### DIFF
--- a/src/TransferLearning/FeatureMapping/LinearFeatureMapper.cs
+++ b/src/TransferLearning/FeatureMapping/LinearFeatureMapper.cs
@@ -71,12 +71,13 @@ public class LinearFeatureMapper<T> : IFeatureMapper<T>
         _projectionMatrix = ComputeProjectionMatrix(centeredSource, sourceDim, targetDim);
         _reverseProjectionMatrix = ComputeProjectionMatrix(centeredTarget, targetDim, sourceDim);
 
+        // Mark as trained before computing confidence (which uses MapToTarget/MapToSource)
+        IsTrained = true;
+
         // Compute mapping confidence based on reconstruction error
         var reconstructed = MapToTarget(sourceData, targetDim);
         var reverseReconstructed = MapToSource(reconstructed, sourceDim);
         _confidence = ComputeReconstructionConfidence(sourceData, reverseReconstructed);
-
-        IsTrained = true;
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary
Fixes the timing issue in `LinearFeatureMapper.Train()` where the `IsTrained` flag was being set after calls to `MapToTarget` and `MapToSource`, causing `InvalidOperationException` during training.

## Problem
The `Train` method was calling `MapToTarget` and `MapToSource` (lines 75-76) to compute reconstruction confidence BEFORE setting `IsTrained = true` (line 79). Since both mapping methods check `if (!IsTrained)` and throw an exception, training always failed.

## Changes Made
- Moved `IsTrained = true;` assignment to line 75, immediately after projection matrices are computed
- Added explanatory comment about why the flag must be set before the confidence computation
- This ensures MapToTarget/MapToSource can execute during the confidence calculation

## Files Changed
- `src/TransferLearning/FeatureMapping/LinearFeatureMapper.cs`

## Testing Done
Due to widespread compilation errors in the merge-dev2-to-master branch (820+ errors unrelated to this change), full test execution was not possible. However, the fix is logically sound:

**Expected Results** (once broader compilation issues are resolved):
- `LinearFeatureMapper_TrainsSuccessfully` test will pass
- `LinearFeatureMapper_MapToTarget_WorksAfterTraining` test will pass

**Fix Logic**:
1. Projection matrices are computed (lines 71-72)
2. `IsTrained` is set to `true` (line 75)
3. Confidence computation using MapToTarget/MapToSource succeeds (lines 78-80)

## Related Issues
- Resolves US-BF-006
- Fixes tests in `tests/UnitTests/TransferLearning/FeatureMapperTests.cs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)