### PR TITLE
fix(us-bf-028): add model parameter to metaheuristic optimizer constructors

### DIFF
--- a/src/Optimizers/AntColonyOptimizer.cs
+++ b/src/Optimizers/AntColonyOptimizer.cs
@@ -36,14 +36,17 @@ public class AntColonyOptimizer<T, TInput, TOutput> : OptimizerBase<T, TInput, T
     /// <summary>
     /// Initializes a new instance of the AntColonyOptimizer class.
     /// </summary>
+    /// <param name="model">The model to be optimized.</param>
     /// <param name="options">The options for configuring the Ant Colony Optimization algorithm.</param>
     /// <remarks>
     /// <para><b>For Beginners:</b> This sets up the Ant Colony Optimizer with its initial configuration.
     /// You can customize various aspects of how it works, or use default settings.
     /// </para>
     /// </remarks>
-    public AntColonyOptimizer(AntColonyOptimizationOptions<T, TInput, TOutput>? options = null)
-        : base(options ?? new())
+    public AntColonyOptimizer(
+        IFullModel<T, TInput, TOutput> model,
+        AntColonyOptimizationOptions<T, TInput, TOutput>? options = null)
+        : base(model, options ?? new())
     {
         _antColonyOptions = options ?? new AntColonyOptimizationOptions<T, TInput, TOutput>();
         _currentPheromoneEvaporationRate = NumOps.Zero;

--- a/src/Optimizers/DifferentialEvolutionOptimizer.cs
+++ b/src/Optimizers/DifferentialEvolutionOptimizer.cs
@@ -66,6 +66,7 @@ public class DifferentialEvolutionOptimizer<T, TInput, TOutput> : OptimizerBase<
     /// <summary>
     /// Initializes a new instance of the DifferentialEvolutionOptimizer class.
     /// </summary>
+    /// <param name="model">The model to be optimized.</param>
     /// <param name="options">The options for configuring the Differential Evolution algorithm.</param>
     /// <remarks>
     /// <para><b>For Beginners:</b> This constructor sets up the Differential Evolution optimizer with its initial configuration.
@@ -73,8 +74,9 @@ public class DifferentialEvolutionOptimizer<T, TInput, TOutput> : OptimizerBase<
     /// </para>
     /// </remarks>
     public DifferentialEvolutionOptimizer(
+        IFullModel<T, TInput, TOutput> model,
         DifferentialEvolutionOptions<T, TInput, TOutput>? options = null)
-        : base(options ?? new())
+        : base(model, options ?? new())
     {
         _deOptions = options ?? new DifferentialEvolutionOptions<T, TInput, TOutput>();
         _currentCrossoverRate = NumOps.Zero;

--- a/src/Optimizers/GeneticAlgorithmOptimizer.cs
+++ b/src/Optimizers/GeneticAlgorithmOptimizer.cs
@@ -53,13 +53,15 @@ public class GeneticAlgorithmOptimizer<T, TInput, TOutput> : OptimizerBase<T, TI
     /// You can customize various aspects of how it works, or use default settings if you're unsure.
     /// </para>
     /// </remarks>
+    /// <param name="model">The model to be optimized.</param>
     /// <param name="options">The options for configuring the genetic algorithm.</param>
     public GeneticAlgorithmOptimizer(
+        IFullModel<T, TInput, TOutput> model,
         GeneticAlgorithmOptimizerOptions<T, TInput, TOutput>? options = null,
         GeneticBase<T, TInput, TOutput>? geneticAlgorithm = null,
         IFitnessCalculator<T, TInput, TOutput>? fitnessCalculator = null,
         IModelEvaluator<T, TInput, TOutput>? modelEvaluator = null)
-        : base(options ?? new())
+        : base(model, options ?? new())
     {
         _geneticOptions = options ?? new GeneticAlgorithmOptimizerOptions<T, TInput, TOutput>();
         _currentCrossoverRate = NumOps.Zero;

--- a/src/Optimizers/ParticleSwarmOptimizer.cs
+++ b/src/Optimizers/ParticleSwarmOptimizer.cs
@@ -56,10 +56,12 @@ public class ParticleSwarmOptimizer<T, TInput, TOutput> : OptimizerBase<T, TInpu
     /// <summary>
     /// Initializes a new instance of the ParticleSwarmOptimizer class with the specified options.
     /// </summary>
+    /// <param name="model">The model to be optimized.</param>
     /// <param name="options">The particle swarm optimization options, or null to use default options.</param>
     public ParticleSwarmOptimizer(
+        IFullModel<T, TInput, TOutput> model,
         ParticleSwarmOptimizationOptions<T, TInput, TOutput>? options = null)
-        : base(options ?? new())
+        : base(model, options ?? new())
     {
         _random = new Random();
         _psoOptions = options ?? new ParticleSwarmOptimizationOptions<T, TInput, TOutput>();

--- a/src/Optimizers/SimulatedAnnealingOptimizer.cs
+++ b/src/Optimizers/SimulatedAnnealingOptimizer.cs
@@ -91,6 +91,7 @@ public class SimulatedAnnealingOptimizer<T, TInput, TOutput> : OptimizerBase<T, 
     /// <summary>
     /// Initializes a new instance of the <see cref="SimulatedAnnealingOptimizer{T}"/> class with the specified options and components.
     /// </summary>
+    /// <param name="model">The model to be optimized.</param>
     /// <param name="options">The simulated annealing options, or null to use default options.</param>
     /// <param name="predictionOptions">The prediction statistics options, or null to use default options.</param>
     /// <param name="modelOptions">The model statistics options, or null to use default options.</param>
@@ -105,19 +106,20 @@ public class SimulatedAnnealingOptimizer<T, TInput, TOutput> : OptimizerBase<T, 
     /// number generator, options, and starting temperature.
     /// </para>
     /// <para><b>For Beginners:</b> This is the starting point for creating a new optimizer.
-    /// 
+    ///
     /// Think of it like preparing for a hiking expedition:
     /// - You can provide custom settings (options) or use the default ones
     /// - You can provide specialized tools (evaluators, calculators) or use the basic ones
     /// - It initializes the random number generator for making probabilistic decisions
     /// - It sets the starting temperature to begin the annealing process
-    /// 
+    ///
     /// This constructor gets everything ready so you can start the optimization process.
     /// </para>
     /// </remarks>
     public SimulatedAnnealingOptimizer(
+        IFullModel<T, TInput, TOutput> model,
         SimulatedAnnealingOptions<T, TInput, TOutput>? options = null)
-        : base(options ?? new())
+        : base(model, options ?? new())
     {
         _random = new Random();
         _saOptions = options ?? new SimulatedAnnealingOptions<T, TInput, TOutput>();

--- a/src/Optimizers/TabuSearchOptimizer.cs
+++ b/src/Optimizers/TabuSearchOptimizer.cs
@@ -50,14 +50,16 @@ public class TabuSearchOptimizer<T, TInput, TOutput> : OptimizerBase<T, TInput, 
     /// <summary>
     /// Initializes a new instance of the TabuSearchOptimizer class.
     /// </summary>
+    /// <param name="model">The model to be optimized.</param>
     /// <param name="options">Options specific to the Tabu Search algorithm.</param>
     /// <param name="geneticAlgorithm">The genetic algorithm to use for mutations. If null, a StandardGeneticAlgorithm will be used.</param>
     public TabuSearchOptimizer(
+        IFullModel<T, TInput, TOutput> model,
         TabuSearchOptions<T, TInput, TOutput>? options = null,
         GeneticBase<T, TInput, TOutput>? geneticAlgorithm = null,
         IFitnessCalculator<T, TInput, TOutput>? fitnessCalculator = null,
         IModelEvaluator<T, TInput, TOutput>? modelEvaluator = null)
-        : base(options ?? new())
+        : base(model, options ?? new())
     {
         _tabuOptions = options ?? new TabuSearchOptions<T, TInput, TOutput>();
 


### PR DESCRIPTION
## User Story
References: US-BF-028

## Summary
Fixed constructor signatures in 6 metaheuristic optimizer classes to accept a model parameter and pass it along with options to the OptimizerBase constructor, resolving CS7036 compilation errors.

## Changes Made
- Added `IFullModel<T, TInput, TOutput> model` as the first parameter to all metaheuristic optimizer constructors
- Updated base class calls from `base(options ?? new())` to `base(model, options ?? new())`
- Affects: Genetic Algorithm, PSO, Differential Evolution, ACO, Simulated Annealing, Tabu Search optimizers

## Files Modified
- src/Optimizers/GeneticAlgorithmOptimizer.cs
- src/Optimizers/ParticleSwarmOptimizer.cs
- src/Optimizers/DifferentialEvolutionOptimizer.cs
- src/Optimizers/AntColonyOptimizer.cs
- src/Optimizers/SimulatedAnnealingOptimizer.cs
- src/Optimizers/TabuSearchOptimizer.cs

## Note
HarmonySearchOptimizer.cs and FireflyOptimizer.cs mentioned in the user story do not exist in the codebase, so only 6 files were updated instead of 8.

## Acceptance Criteria
- [x] All 6 optimizer constructors updated with model parameter
- [x] Base class calls pass both model and options parameters
- [x] No compilation errors in these optimizer files

🤖 Generated with [Claude Code](https://claude.com/claude-code)