### PR TITLE
fix(us-ci-004): refine TransferLearning cross-domain exception messages

### DIFF
--- a/src/TransferLearning/Algorithms/TransferNeuralNetwork.cs
+++ b/src/TransferLearning/Algorithms/TransferNeuralNetwork.cs
@@ -57,10 +57,8 @@ public class TransferNeuralNetwork<T> : TransferLearningBase<T, Matrix<T>, Vecto
         Vector<T> targetLabels)
     {
         throw new InvalidOperationException(
-            "Cross-domain transfer requires source domain data for proper feature mapping. " +
-            "The protected TransferCrossDomain method cannot access source data due to API limitations. " +
-            "Please use the public Transfer(sourceModel, sourceData, targetData, targetLabels) method instead, " +
-            "or pre-train the FeatureMapper with source data before calling this method.");
+            "Cross-domain transfer cannot be performed directly through this protected method due to the need for source domain data. " +
+            "Please use the public 'Transfer(sourceModel, sourceData, targetData, targetLabels)' method which accepts both source and target domain data for feature mapping and transfer.");
     }
 
     /// <summary>

--- a/src/TransferLearning/Algorithms/TransferRandomForest.cs
+++ b/src/TransferLearning/Algorithms/TransferRandomForest.cs
@@ -78,10 +78,8 @@ public class TransferRandomForest<T> : TransferLearningBase<T, Matrix<T>, Vector
         Vector<T> targetLabels)
     {
         throw new InvalidOperationException(
-            "Cross-domain transfer requires source domain data for proper feature mapping and domain adaptation. " +
-            "The protected TransferCrossDomain method cannot access source data due to API limitations. " +
-            "Please use the public Transfer(sourceModel, sourceData, targetData, targetLabels) method instead, " +
-            "or pre-train the FeatureMapper and DomainAdapter with source data before calling this method.");
+            "Cross-domain transfer cannot be performed directly through this protected method due to the need for source domain data. " +
+            "Please use the public 'Transfer(sourceModel, sourceData, targetData, targetLabels)' method which accepts both source and target domain data for feature mapping and transfer.");
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary
- Refined InvalidOperationException messages in TransferNeuralNetwork.cs and TransferRandomForest.cs
- Simplified messages to align with user story Option 2 guidance
- Clearer API direction: directs users to public Transfer() method that accepts source data
- Removed redundant technical details about API limitations
- Messages now more concise and actionable

## Changes Made
**TransferNeuralNetwork.cs**:
- Updated TransferCrossDomain exception message to be more concise
- Focuses on the solution (use public Transfer method) rather than the problem

**TransferRandomForest.cs**:
- Updated TransferCrossDomain exception message to match TransferNeuralNetwork
- Consistent messaging across both transfer learning implementations

## Test Plan
- [x] Build passes with 0 errors in modified files (net8.0 target)
- [x] Exception messages are clear and actionable
- [x] Public Transfer() methods provide proper cross-domain functionality
- [ ] Transfer learning API works correctly across domains (existing functionality)

## Acceptance Criteria Met
- [x] TransferCrossDomain methods throw InvalidOperationException (not NotImplementedException)
- [x] Exception messages provide clear explanation and guidance
- [x] API for cross-domain transfer learning is clear and usable via public Transfer() method

🤖 Generated with [Claude Code](https://claude.com/claude-code)