### PR TITLE
Fix issue #331 in AiDotNet

### DIFF
--- a/src/LossFunctions/RootMeanSquaredErrorLoss.cs
+++ b/src/LossFunctions/RootMeanSquaredErrorLoss.cs
@@ -29,7 +29,7 @@ public class RootMeanSquaredErrorLoss<T> : LossFunctionBase<T>
     public override T CalculateLoss(Vector<T> predicted, Vector<T> actual)
     {
         ValidateVectorLengths(predicted, actual);
-        return StatisticsHelper<T>.CalculateRootMeanSquaredError(actual, predicted);
+        return StatisticsHelper<T>.CalculateRootMeanSquaredError(predicted, actual);
     }
 
     /// <summary>
@@ -44,7 +44,7 @@ public class RootMeanSquaredErrorLoss<T> : LossFunctionBase<T>
         ValidateVectorLengths(predicted, actual);
 
         // Calculate RMSE for use in derivative calculation
-        T rmse = StatisticsHelper<T>.CalculateRootMeanSquaredError(actual, predicted);
+        T rmse = StatisticsHelper<T>.CalculateRootMeanSquaredError(predicted, actual);
 
         // Avoid division by zero - if RMSE is zero, all predictions are perfect
         if (NumOps.Equals(rmse, NumOps.Zero))

--- a/src/LossFunctions/SparseCategoricalCrossEntropyLoss.cs
+++ b/src/LossFunctions/SparseCategoricalCrossEntropyLoss.cs
@@ -52,20 +52,25 @@ public class SparseCategoricalCrossEntropyLoss<T> : LossFunctionBase<T>
     /// <summary>
     /// Calculates the Sparse Categorical Cross Entropy loss between predicted probabilities and class indices.
     /// </summary>
-    /// <param name="predicted">The predicted probability values for all classes.</param>
-    /// <param name="actual">The actual class indices as floating-point values.</param>
+    /// <param name="predicted">The predicted probability values for all classes (length = num_classes).</param>
+    /// <param name="actual">The actual class indices as floating-point values (length = batch_size or 1 for single sample).</param>
     /// <returns>The sparse categorical cross entropy loss value.</returns>
     /// <remarks>
     /// For single-sample usage, if predicted has N classes and actual[0] = k (class index k),
     /// the loss is -log(predicted[k]).
     ///
-    /// For consistency with the ILossFunction interface, both vectors should have compatible lengths.
-    /// A common pattern is: predicted contains all class probabilities, and actual[0] contains the class index.
+    /// Unlike other loss functions, predicted and actual can have different lengths:
+    /// - predicted.Length = number of classes (N)
+    /// - actual.Length = number of samples in batch (M)
+    /// Each actual[i] contains the class index for sample i.
     /// </remarks>
-    /// <exception cref="ArgumentException">Thrown when vectors have incompatible lengths or class indices are invalid.</exception>
+    /// <exception cref="ArgumentException">Thrown when class indices are invalid or vectors are empty.</exception>
     public override T CalculateLoss(Vector<T> predicted, Vector<T> actual)
     {
-        ValidateVectorLengths(predicted, actual);
+        // Note: We do NOT validate that predicted and actual have the same length
+        // In sparse categorical cross-entropy, they can differ:
+        // - predicted contains N class probabilities
+        // - actual contains M class indices (where M can differ from N)
 
         if (predicted.Length == 0)
         {
@@ -107,8 +112,8 @@ public class SparseCategoricalCrossEntropyLoss<T> : LossFunctionBase<T>
     /// <summary>
     /// Calculates the derivative of the Sparse Categorical Cross Entropy loss function.
     /// </summary>
-    /// <param name="predicted">The predicted probability values for all classes.</param>
-    /// <param name="actual">The actual class indices as floating-point values.</param>
+    /// <param name="predicted">The predicted probability values for all classes (length = num_classes).</param>
+    /// <param name="actual">The actual class indices as floating-point values (length = batch_size or 1 for single sample).</param>
     /// <returns>A vector containing the derivatives for each class probability.</returns>
     /// <remarks>
     /// The derivative is:
@@ -118,10 +123,11 @@ public class SparseCategoricalCrossEntropyLoss<T> : LossFunctionBase<T>
     /// When used with softmax activation, this combines with the softmax derivative
     /// to produce the simplified gradient (predicted - one_hot_actual).
     /// </remarks>
-    /// <exception cref="ArgumentException">Thrown when vectors have incompatible lengths or class indices are invalid.</exception>
+    /// <exception cref="ArgumentException">Thrown when class indices are invalid or vectors are empty.</exception>
     public override Vector<T> CalculateDerivative(Vector<T> predicted, Vector<T> actual)
     {
-        ValidateVectorLengths(predicted, actual);
+        // Note: We do NOT validate that predicted and actual have the same length
+        // In sparse categorical cross-entropy, they can differ
 
         if (predicted.Length == 0)
         {


### PR DESCRIPTION
…tropyLoss

This commit implements two new loss functions requested in issue #331:

1. RootMeanSquaredErrorLoss:
   - Leverages existing StatisticsHelper.CalculateRootMeanSquaredError() method
   - Implements proper derivative calculation: (predicted - actual) / (n * RMSE)
   - Includes numerical stability check to avoid division by zero

2. SparseCategoricalCrossEntropyLoss:
   - Memory-efficient alternative to categorical cross-entropy for multi-class classification
   - Accepts class indices instead of one-hot encoded vectors
   - Implements proper gradient calculation for backpropagation
   - Includes epsilon clamping for numerical stability

Both implementations:
- Follow the established LossFunctionBase<T> pattern
- Use CalculateLoss() and CalculateDerivative() methods (not Forward/Backward)
- Maintain consistency with Vector<T> interface
- Include comprehensive XML documentation
- Support generic numeric types through INumericOperations<T>

Fixes #331

## User Story / Context
- Reference: [US-XXX] (if applicable)
- Base branch: `merge-dev2-to-master`

## Summary
- What changed and why (scoped strictly to the user story / PR intent)

## Verification
- [ ] Builds succeed (scoped to changed projects)
- [ ] Unit tests pass locally
- [ ] Code coverage >= 90% for touched code
- [ ] Codecov upload succeeded (if token configured)
- [ ] TFM verification (net46, net6.0, net8.0) passes (if packaging)
- [ ] No unresolved Copilot comments on HEAD

## Copilot Review Loop (Outcome-Based)
Record counts before/after your last push:
- Comments on HEAD BEFORE: [N]
- Comments on HEAD AFTER (60s): [M]
- Final HEAD SHA: [sha]

## Files Modified
- [ ] List files changed (must align with scope)

## Notes
- Any follow-ups, caveats, or migration details
