### PR TITLE
fix(ci): use auto-detect for codacy instead of specific tools

### DIFF
--- a/.github/workflows/codacy.yml
+++ b/.github/workflows/codacy.yml
@@ -54,10 +54,7 @@ jobs:
           gh-code-scanning-compat: true
           max-allowed-issues: 2147483647
           skip-uncommitted-files-check: true
-          # Only run security-focused tools (faster)
-          tool: spotbugs,pmd,semgrep
-          # Enable parallel analysis
-          parallel: 4
+          # Auto-detect tools based on project files
         continue-on-error: true
 
       - name: Upload SARIF results file


### PR DESCRIPTION
## Summary

Remove Java/Go-specific tool specification from Codacy workflow and let it auto-detect appropriate tools for the C# codebase.

### Changes
- Removed `tool: spotbugs,pmd,semgrep` (these are for Java/Go, not C#)
- Removed `parallel: 4` (not needed without specific tools)
- Let Codacy auto-detect what it can analyze

### Why
The previous tools (spotbugs, pmd, semgrep) are designed for Java, Go, and Python - not C#. This was causing immediate failures because those tools don't apply to this codebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)