### PR TITLE
fix: resolve System.Numerics.Tensors version conflict for PR #535

### DIFF
--- a/src/AiDotNet.Tensors/AiDotNet.Tensors.csproj
+++ b/src/AiDotNet.Tensors/AiDotNet.Tensors.csproj
@@ -48,7 +48,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Numerics.Tensors" Version="10.0.0" />
+    <PackageReference Include="System.Numerics.Tensors" Version="10.0.1" />
   </ItemGroup>
 
   <!-- ILGPU packages for GPU acceleration -->

--- a/src/AiDotNet.csproj
+++ b/src/AiDotNet.csproj
@@ -58,7 +58,7 @@
 	  <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
 	  <PackageReference Include="Pinecone.Client" Version="4.0.2" />
 	  <PackageReference Include="StackExchange.Redis" Version="2.10.1" />
-	  <PackageReference Include="System.Numerics.Tensors" Version="10.0.0" />
+	  <PackageReference Include="System.Numerics.Tensors" Version="10.0.1" />
 	  <PackageReference Include="System.ValueTuple" Version="4.6.1" />
 	  <PackageReference Include="TreeSitter.DotNet" Version="1.2.0" />
 	</ItemGroup>


### PR DESCRIPTION
## Summary
Fixes the package version conflict causing CI/CD failures in PR #535.

## Problem
- PR #535 (dependabot) updated `AiDotNet.Tensors` to use `System.Numerics.Tensors 10.0.1`
- But `AiDotNet.csproj` still had a direct reference to `10.0.0`
- This caused a downgrade conflict: `Detected package downgrade: System.Numerics.Tensors from 10.0.1 to 10.0.0`
- CI/CD pipeline failures in CodeQL Analysis and SonarCloud Analysis

## Solution  
- Update both `AiDotNet.csproj` and `AiDotNet.Tensors.csproj` to use `System.Numerics.Tensors 10.0.1`
- Ensures consistent package versions across all projects
- Resolves the NU1605 warning-as-error that was blocking builds

## Test Plan
- [x] Local build verification with `dotnet build`
- [x] Package restore completes without errors
- [x] CI/CD pipeline should now pass for this fix

## Impact
This fix unblocks PR #535 to merge successfully, bringing in the System.Numerics.Tensors security/bug fixes from version 10.0.1.

No functional changes to the codebase - only package version alignment.