### PR TITLE
fix(security): replace new Random() with RandomHelper for thread safety

### DIFF
--- a/src/ActiveLearning/BALD.cs
+++ b/src/ActiveLearning/BALD.cs
@@ -176,7 +176,7 @@ public class BALD<T> : IActiveLearningStrategy<T>
     /// </summary>
     private Tensor<T> AddDropoutNoise(Tensor<T> predictions, double dropoutRate, int seed)
     {
-        var random = new Random(seed);
+        var random = RandomHelper.CreateSeededRandom(seed);
         var noisyPredictions = new Tensor<T>(predictions.Shape);
 
         for (int i = 0; i < predictions.Length; i++)

--- a/src/ActiveLearning/BatchBALD.cs
+++ b/src/ActiveLearning/BatchBALD.cs
@@ -373,7 +373,7 @@ public class BatchBALD<T> : IActiveLearningStrategy<T>
     /// </summary>
     private Tensor<T> AddDropoutNoise(Tensor<T> predictions, double dropoutRate, int seed)
     {
-        var random = new Random(seed);
+        var random = RandomHelper.CreateSeededRandom(seed);
         var noisyPredictions = new Tensor<T>(predictions.Shape);
 
         for (int i = 0; i < predictions.Length; i++)

--- a/src/ActiveLearning/Core/ActiveLearner.cs
+++ b/src/ActiveLearning/Core/ActiveLearner.cs
@@ -111,7 +111,7 @@ public class ActiveLearner<T, TInput, TOutput> : IActiveLearner<T, TInput, TOutp
 
         _stopwatch = new Stopwatch();
         _learningCurvePoints = new List<LearningCurvePoint<T>>();
-        _random = _config.Seed.HasValue ? new Random(_config.Seed.Value) : RandomHelper.Shared;
+        _random = _config.Seed.HasValue ? RandomHelper.CreateSeededRandom(_config.Seed.Value) : RandomHelper.Shared;
 
         _labeledPool = null!;
         _unlabeledPool = null!;

--- a/src/ActiveLearning/RandomSampling.cs
+++ b/src/ActiveLearning/RandomSampling.cs
@@ -39,7 +39,7 @@ public class RandomSampling<T> : IActiveLearningStrategy<T>
     public RandomSampling(int? seed = null)
     {
         _numOps = MathHelper.GetNumericOperations<T>();
-        _random = seed.HasValue ? new Random(seed.Value) : new Random();
+        _random = seed.HasValue ? RandomHelper.CreateSeededRandom(seed.Value) : RandomHelper.CreateSecureRandom();
         _useBatchDiversity = false;
         _lastMinScore = _numOps.Zero;
         _lastMaxScore = _numOps.Zero;

--- a/src/ContinualLearning/AveragedGEM.cs
+++ b/src/ContinualLearning/AveragedGEM.cs
@@ -56,7 +56,7 @@ public class AveragedGEM<T> : IContinualLearningStrategy<T>
         _memorySize = memorySize;
         _sampleSize = sampleSize;
         _lambda = lambda;
-        _random = seed.HasValue ? new Random(seed.Value) : new Random();
+        _random = seed.HasValue ? RandomHelper.CreateSeededRandom(seed.Value) : RandomHelper.CreateSecureRandom();
     }
 
     /// <inheritdoc />

--- a/src/ContinualLearning/ExperienceReplay.cs
+++ b/src/ContinualLearning/ExperienceReplay.cs
@@ -84,7 +84,7 @@ public class ExperienceReplay<T> : IContinualLearningStrategy<T>
         _replayRatio = replayRatio;
         _strategy = strategy;
         _lambda = lambda;
-        _random = seed.HasValue ? new Random(seed.Value) : new Random();
+        _random = seed.HasValue ? RandomHelper.CreateSeededRandom(seed.Value) : RandomHelper.CreateSecureRandom();
         _totalSamplesSeen = 0;
     }
 

--- a/src/ContinualLearning/GenerativeReplay.cs
+++ b/src/ContinualLearning/GenerativeReplay.cs
@@ -68,7 +68,7 @@ public class GenerativeReplay<T> : IContinualLearningStrategy<T>
         _replayRatio = replayRatio;
         _lambda = lambda;
         _taskCount = 0;
-        _random = seed.HasValue ? new Random(seed.Value) : new Random();
+        _random = seed.HasValue ? RandomHelper.CreateSeededRandom(seed.Value) : RandomHelper.CreateSecureRandom();
     }
 
     /// <inheritdoc />

--- a/src/ContinualLearning/GradientEpisodicMemory.cs
+++ b/src/ContinualLearning/GradientEpisodicMemory.cs
@@ -169,9 +169,8 @@ public class GradientEpisodicMemory<T> : IContinualLearningStrategy<T>
         }
 
         // Random sampling
-        var random = new Random();
         var indices = Enumerable.Range(0, batchSize)
-            .OrderBy(_ => random.Next())
+            .OrderBy(_ => RandomHelper.Shared.Next())
             .Take(samplesToKeep)
             .ToArray();
 

--- a/src/ContinualLearning/VariationalContinualLearning.cs
+++ b/src/ContinualLearning/VariationalContinualLearning.cs
@@ -71,7 +71,7 @@ public class VariationalContinualLearning<T> : IContinualLearningStrategy<T>
         _lambda = lambda;
         _initialLogVar = initialLogVar;
         _taskCount = 0;
-        _random = seed.HasValue ? new Random(seed.Value) : new Random();
+        _random = seed.HasValue ? RandomHelper.CreateSeededRandom(seed.Value) : RandomHelper.CreateSecureRandom();
     }
 
     /// <inheritdoc />

--- a/src/CurriculumLearning/CurriculumLearner.cs
+++ b/src/CurriculumLearning/CurriculumLearner.cs
@@ -120,7 +120,7 @@ public class CurriculumLearner<T, TInput, TOutput> : ICurriculumLearner<T, TInpu
         _scheduler = scheduler ?? CreateSchedulerFromConfig(config);
         _phaseHistory = new List<CurriculumPhaseResult<T>>();
         _random = config.RandomSeed.HasValue
-            ? new Random(config.RandomSeed.Value)
+            ? RandomHelper.CreateSeededRandom(config.RandomSeed.Value)
             : RandomHelper.CreateSecureRandom();
 
         _isTraining = false;

--- a/src/CurriculumLearning/DifficultyEstimators/ExpertDefinedDifficultyEstimator.cs
+++ b/src/CurriculumLearning/DifficultyEstimators/ExpertDefinedDifficultyEstimator.cs
@@ -197,7 +197,7 @@ public class ExpertDefinedDifficultyEstimator<T, TInput, TOutput> : DifficultyEs
         int totalSamples,
         int? seed = null)
     {
-        var random = seed.HasValue ? new Random(seed.Value) : RandomHelper.Shared;
+        var random = seed.HasValue ? RandomHelper.CreateSeededRandom(seed.Value) : RandomHelper.Shared;
         var difficulties = new T[totalSamples];
         var numOps = MathHelper.GetNumericOperations<T>();
 


### PR DESCRIPTION
## Summary

This PR fixes a **security vulnerability** where `new Random()` was being used instead of the thread-safe `RandomHelper` utility. The default `System.Random` seeding based on `Environment.TickCount` can produce predictable sequences, which is problematic for machine learning algorithms that rely on randomness.

### Changes (11 files)

**Active Learning:**
- `BALD.cs` - MC Dropout simulation
- `BatchBALD.cs` - Dropout noise generation
- `RandomSampling.cs` - Sample selection
- `ActiveLearner.cs` - Configuration-based random initialization

**Continual Learning:**
- `VariationalContinualLearning.cs` - Variational inference sampling
- `GradientEpisodicMemory.cs` - Memory selection
- `AveragedGEM.cs` - Averaged gradient episodic memory
- `ExperienceReplay.cs` - Experience buffer sampling
- `GenerativeReplay.cs` - Generative model sampling

**Curriculum Learning:**
- `CurriculumLearner.cs` - Curriculum scheduling
- `ExpertDefinedDifficultyEstimator.cs` - Random difficulty generation

### RandomHelper API

The `RandomHelper` class provides thread-safe random number generation:

| Method | Use Case |
|--------|----------|
| `CreateSecureRandom()` | Cryptographically-seeded, thread-safe Random |
| `CreateSeededRandom(seed)` | Thread-safe Random with reproducible seed |
| `Shared` | Static thread-safe instance for one-off usage |

## Test plan

- [x] All 11 files compile without errors
- [x] Build passes with `dotnet build --no-restore`
- [x] Grep confirms no remaining `new Random(` instances in src/

🤖 Generated with [Claude Code](https://claude.com/claude-code)