### PR TITLE
ci: use AUTOFIX_PAT for commitlint force-push

### DIFF
--- a/.github/workflows/commitlint-fix.yml
+++ b/.github/workflows/commitlint-fix.yml
@@ -214,8 +214,8 @@ jobs:
           if [ -n "$AUTOFIX_PAT" ]; then
             git push "https://x-access-token:${AUTOFIX_PAT}@github.com/${GITHUB_REPOSITORY}.git" "HEAD:$BRANCH" --force-with-lease
           else
-            git push origin "HEAD:$BRANCH" --force-with-lease
             echo "::warning::AUTOFIX_PAT is not set. The force-push may not trigger CI workflows."
+            git push origin "HEAD:$BRANCH" --force-with-lease
           fi
 
       - name: Comment on PR
@@ -328,8 +328,8 @@ jobs:
           if [ -n "$AUTOFIX_PAT" ]; then
             git push "https://x-access-token:${AUTOFIX_PAT}@github.com/${GITHUB_REPOSITORY}.git" "HEAD:$BRANCH" --force-with-lease
           else
-            git push origin "HEAD:$BRANCH" --force-with-lease
             echo "::warning::AUTOFIX_PAT is not set. The force-push may not trigger CI workflows."
+            git push origin "HEAD:$BRANCH" --force-with-lease
           fi
 
       - name: Comment on PR


### PR DESCRIPTION
## Summary\n- push commitlint autofix changes with AUTOFIX_PAT when available\n- warn and fall back to GITHUB_TOKEN if missing\n\n## Testing\n- not run (workflow-only change)