### PR TITLE
fix(docs): fix documentation workflow and DocFX configuration

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -33,13 +33,19 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
 
-    - name: Setup .NET 8.0
+    - name: Setup .NET 10.0
       uses: actions/setup-dotnet@baa11fbfe1d6520db94683bd5c7a3818018e4309 # v5
       with:
-        dotnet-version: '8.0.x'
+        dotnet-version: '10.0.x'
 
     - name: Install DocFX
       run: dotnet tool install --global docfx || true
+
+    - name: Restore dependencies
+      run: dotnet restore
+
+    - name: Build solution for DocFX metadata extraction
+      run: dotnet build -c Release --no-restore -p:TreatWarningsAsErrors=false
 
     - name: Create DocFX project if not exists
       run: |
@@ -50,8 +56,7 @@ jobs:
             {
               "src": [
                 {
-                  "files": [ "src/**/*.csproj" ],
-                  "exclude": [ "src/AiDotNet.Playground/**" ],
+                  "files": [ "src/AiDotNet.csproj", "src/AiDotNet.Tensors/AiDotNet.Tensors.csproj" ],
                   "src": "."
                 }
               ],
@@ -59,10 +64,13 @@ jobs:
               "includePrivateMembers": false,
               "disableGitFeatures": false,
               "disableDefaultFilter": false,
-              "noRestore": false,
+              "noRestore": true,
               "namespaceLayout": "nested",
               "memberLayout": "samePage",
-              "EnumSortOrder": "alphabetic"
+              "EnumSortOrder": "alphabetic",
+              "properties": {
+                "TargetFramework": "net10.0"
+              }
             }
           ],
           "build": {

--- a/docfx.json
+++ b/docfx.json
@@ -3,15 +3,16 @@
     {
       "src": [
         {
-          "files": ["src/**/*.csproj"],
+          "files": ["src/AiDotNet.csproj", "src/AiDotNet.Tensors/AiDotNet.Tensors.csproj"],
           "exclude": ["**/bin/**", "**/obj/**", "**/tests/**"]
         }
       ],
       "dest": "api",
       "disableGitFeatures": false,
       "disableDefaultFilter": false,
+      "noRestore": true,
       "properties": {
-        "TargetFramework": "net8.0"
+        "TargetFramework": "net10.0"
       }
     }
   ],

--- a/docs/getting-started/toc.yml
+++ b/docs/getting-started/toc.yml
@@ -1,0 +1,6 @@
+- name: Overview
+  href: index.md
+- name: Installation
+  href: installation.md
+- name: Quickstart
+  href: quickstart.md

--- a/docs/toc.yml
+++ b/docs/toc.yml
@@ -1,0 +1,14 @@
+- name: Home
+  href: index.md
+- name: Getting Started
+  href: getting-started/
+- name: Tutorials
+  href: tutorials/
+- name: API Reference
+  href: ../api/
+- name: Examples
+  href: examples/
+- name: Reference
+  href: reference/
+- name: Community
+  href: community/

--- a/docs/tutorials/toc.yml
+++ b/docs/tutorials/toc.yml
@@ -1,0 +1,16 @@
+- name: Overview
+  href: index.md
+- name: Classification
+  href: classification/
+- name: Computer Vision
+  href: computer-vision/
+- name: NLP
+  href: nlp/
+- name: LLM Fine-tuning
+  href: llm-fine-tuning/
+- name: Reinforcement Learning
+  href: reinforcement-learning/
+- name: Distributed Training
+  href: distributed-training/
+- name: Deployment
+  href: deployment/


### PR DESCRIPTION
## Summary
- Upgraded docs workflow from .NET 8.0 to .NET 10.0 to match the project's target framework
- Added restore and build steps before DocFX metadata extraction (DocFX needs compiled assemblies)
- Updated docfx.json to use net10.0 target framework
- Added `noRestore: true` since we build separately
- Focused API generation on main packages (AiDotNet, AiDotNet.Tensors)
- Added toc.yml files for proper DocFX navigation structure

## Problem
The documentation workflow was failing because:
1. It used .NET 8.0 but the project targets net10.0/net471
2. DocFX couldn't resolve dependencies (Newtonsoft, MKLNET, System.Numerics.Tensors)
3. No API documentation was being generated
4. Missing toc.yml files caused navigation errors

## Test plan
- [ ] Verify Documentation workflow passes
- [ ] Verify API Reference link works on GitHub Pages
- [ ] Verify Interactive Playground link works

---
Generated with [Claude Code](https://claude.com/claude-code)