### PR TITLE
test: add integration tests for engines module gpu configuration

### DIFF
--- a/tests/AiDotNet.Tests/IntegrationTests/Engines/GpuAccelerationConfigIntegrationTests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/Engines/GpuAccelerationConfigIntegrationTests.cs
@@ -119,7 +119,7 @@ public class GpuAccelerationConfigIntegrationTests
     public void GpuDeviceType_EnumValuesAreDistinct()
     {
         // Verify all enum values are unique
-        var values = Enum.GetValues<GpuDeviceType>();
+        var values = (GpuDeviceType[])Enum.GetValues(typeof(GpuDeviceType));
         var uniqueValues = values.Distinct().ToArray();
 
         Assert.Equal(values.Length, uniqueValues.Length);
@@ -129,7 +129,7 @@ public class GpuAccelerationConfigIntegrationTests
     public void GpuDeviceType_HasExpectedCount()
     {
         // 4 device types: Auto, CUDA, OpenCL, CPU
-        var values = Enum.GetValues<GpuDeviceType>();
+        var values = (GpuDeviceType[])Enum.GetValues(typeof(GpuDeviceType));
         Assert.Equal(4, values.Length);
     }
 
@@ -155,7 +155,7 @@ public class GpuAccelerationConfigIntegrationTests
     [Fact]
     public void GpuUsageLevel_EnumValuesAreDistinct()
     {
-        var values = Enum.GetValues<GpuUsageLevel>();
+        var values = (GpuUsageLevel[])Enum.GetValues(typeof(GpuUsageLevel));
         var uniqueValues = values.Distinct().ToArray();
 
         Assert.Equal(values.Length, uniqueValues.Length);
@@ -165,7 +165,7 @@ public class GpuAccelerationConfigIntegrationTests
     public void GpuUsageLevel_HasExpectedCount()
     {
         // 5 usage levels: Conservative, Default, Aggressive, AlwaysGpu, AlwaysCpu
-        var values = Enum.GetValues<GpuUsageLevel>();
+        var values = (GpuUsageLevel[])Enum.GetValues(typeof(GpuUsageLevel));
         Assert.Equal(5, values.Length);
     }
 
@@ -190,7 +190,7 @@ public class GpuAccelerationConfigIntegrationTests
     [Fact]
     public void GpuExecutionModeConfig_EnumValuesAreDistinct()
     {
-        var values = Enum.GetValues<GpuExecutionModeConfig>();
+        var values = (GpuExecutionModeConfig[])Enum.GetValues(typeof(GpuExecutionModeConfig));
         var uniqueValues = values.Distinct().ToArray();
 
         Assert.Equal(values.Length, uniqueValues.Length);
@@ -200,7 +200,7 @@ public class GpuAccelerationConfigIntegrationTests
     public void GpuExecutionModeConfig_HasExpectedCount()
     {
         // 4 modes: Auto, Eager, Deferred, ScopedDeferred
-        var values = Enum.GetValues<GpuExecutionModeConfig>();
+        var values = (GpuExecutionModeConfig[])Enum.GetValues(typeof(GpuExecutionModeConfig));
         Assert.Equal(4, values.Length);
     }
 

--- a/tests/AiDotNet.Tests/IntegrationTests/Engines/GpuExecutionOptionsIntegrationTests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/Engines/GpuExecutionOptionsIntegrationTests.cs
@@ -111,7 +111,7 @@ public class GpuExecutionOptionsIntegrationTests
     [Fact]
     public void GpuExecutionMode_EnumValuesAreDistinct()
     {
-        var values = Enum.GetValues<GpuExecutionMode>();
+        var values = (GpuExecutionMode[])Enum.GetValues(typeof(GpuExecutionMode));
         var uniqueValues = values.Distinct().ToArray();
 
         Assert.Equal(values.Length, uniqueValues.Length);
@@ -121,7 +121,7 @@ public class GpuExecutionOptionsIntegrationTests
     public void GpuExecutionMode_HasExpectedCount()
     {
         // 4 modes: Eager, Deferred, ScopedDeferred, Auto
-        var values = Enum.GetValues<GpuExecutionMode>();
+        var values = (GpuExecutionMode[])Enum.GetValues(typeof(GpuExecutionMode));
         Assert.Equal(4, values.Length);
     }
 


### PR DESCRIPTION
## Summary
- Add comprehensive integration tests for the Engines module GPU configuration
- Tests cover `GpuAccelerationConfig` and `GpuExecutionOptions` classes
- Total of 94 tests added, all passing

## Test Coverage

### GpuAccelerationConfigIntegrationTests (55 tests)
- Default configuration tests
- All enum value tests (GpuDeviceType, GpuUsageLevel, GpuExecutionModeConfig)
- ToExecutionOptions conversion tests
- ToString tests
- Scenario tests (high performance, debugging, CPU-only, memory-constrained)
- Multi-GPU setup tests
- Edge case tests (zero/large values)

### GpuExecutionOptionsIntegrationTests (39 tests)
- Default configuration tests
- GpuExecutionMode enum tests
- Validation tests (positive and negative cases)
- Clone tests
- FromEnvironment tests
- Scenario tests (high performance, debugging, memory-constrained)

## Test plan
- [x] All 94 tests pass locally
- [x] Build succeeds on net10.0
- [x] No breaking changes to existing code

Addresses Issue #627

🤖 Generated with [Claude Code](https://claude.com/claude-code)