### PR TITLE
test: add comprehensive integration tests for Logging module

### DIFF
--- a/tests/AiDotNet.Tests/IntegrationTests/Logging/LoggingIntegrationTests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/Logging/LoggingIntegrationTests.cs
@@ -62,7 +62,9 @@ public class LoggingIntegrationTests : IDisposable
             writer = new SummaryWriter();
             logDir = writer.LogDir;
             Assert.NotNull(writer.LogDir);
-            Assert.StartsWith("runs", writer.LogDir);
+            // Check the parent directory name is "runs" (path-agnostic, works with absolute paths)
+            var parentDirName = Path.GetFileName(Path.GetDirectoryName(writer.LogDir));
+            Assert.Equal("runs", parentDirName);
             Assert.True(Directory.Exists(writer.LogDir));
         }
         finally


### PR DESCRIPTION
## Summary
- Adds 71 comprehensive integration tests for the Logging module
- Tests run on both .NET 10.0 and .NET Framework 4.7.1
- All tests pass

## Test Coverage

| Component | Tests | Coverage |
|-----------|-------|----------|
| SummaryWriter Constructor | 4 | Directory creation, auto-directory, comment handling, default step |
| SummaryWriter AddScalar | 4 | Float/double values, auto-increment step, edge values |
| SummaryWriter AddScalars | 2 | Multiple tags, empty dictionary |
| SummaryWriter AddHistogram | 5 | 1D/2D arrays, large arrays, negative values, single value |
| SummaryWriter AddImage | 5 | CHW/HWC formats, raw images, image grids, normalization |
| SummaryWriter AddText | 4 | Basic text, multiline, empty string, unicode |
| SummaryWriter AddHparams | 2 | Hyperparameters with metrics, empty hparams |
| SummaryWriter AddEmbedding | 2 | Basic embeddings, embeddings with metadata |
| SummaryWriter AddPrCurve | 3 | Mixed labels, all positive, all negative |
| SummaryWriter LogTrainingStep | 3 | Loss only, with accuracy, with learning rate |
| SummaryWriter LogValidationStep | 2 | Loss only, with accuracy |
| SummaryWriter LogWeights | 2 | Weights only, weights with gradients |
| SummaryWriter Flush/Dispose | 3 | Flush persistence, close alias, multiple dispose |
| TensorBoardWriter | 8 | Constructor, scalar/histogram/text writing, file path format |
| TensorBoardExtensions | 4 | Writer creation, run name, metrics logging |
| TensorBoardTrainingContext | 10 | Constructor, train/val steps, global step, elapsed time, model weights, hparams |
| Integration Scenarios | 2 | Full training loop with SummaryWriter and TensorBoardTrainingContext |

## Test Results
```
.NET 10.0:     Passed: 71, Failed: 0
.NET 4.7.1:    Passed: 71, Failed: 0
```

## Key Test Patterns
- Proper resource cleanup with try-finally to avoid file handle issues
- Tests for edge cases (empty inputs, special values)
- Tests for both CHW and HWC image formats
- Unicode text support verification

Closes #662

🤖 Generated with [Claude Code](https://claude.com/claude-code)