### PR TITLE
ci: fix concurrency groups to prevent queued run pileup

### DIFF
--- a/.github/workflows/automated-release.yml
+++ b/.github/workflows/automated-release.yml
@@ -15,7 +15,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: false  # Don't cancel release in progress
+  cancel-in-progress: true  # Cancel stale release when new push to master arrives
 
 permissions:
   contents: write

--- a/.github/workflows/azure-functions-deploy.yml
+++ b/.github/workflows/azure-functions-deploy.yml
@@ -10,6 +10,10 @@ on:
       - '.github/workflows/azure-functions-deploy.yml'
   workflow_dispatch:  # Allow manual trigger
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   AZURE_FUNCTIONAPP_NAME: aidotnet-playground
   AZURE_FUNCTIONAPP_PACKAGE_PATH: src/AiDotNet.Playground.Functions

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -8,7 +8,7 @@ on:
 
 concurrency:
   group: "pages"
-  cancel-in-progress: false
+  cancel-in-progress: true  # Allow rebuild cancellation
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary
- Fixes the root cause of 48+ GitHub Actions runs getting stuck in queued status
- Adds/fixes concurrency groups across 3 workflow files

## Changes

**automated-release.yml**: `cancel-in-progress: false` -> `true`
- Only the latest push to master needs a release — intermediate versions get superseded
- Stale release runs were blocking new ones from the same concurrency group

**azure-functions-deploy.yml**: Added missing concurrency group
- Had no concurrency group at all — every push queued independently

**docs.yml**: `cancel-in-progress: false` -> `true`
- Manual rebuild workflow doesn't need to protect against cancellation

## Root cause
48+ workflow runs were stuck in queued status across this repo because:
1. `automated-release.yml` had `cancel-in-progress: false` — stale releases blocked new ones
2. `azure-functions-deploy.yml` had no concurrency group — runs piled up
3. Multiple dependabot PRs + manual PRs + master pushes all triggered simultaneously

## Test plan
- [x] YAML syntax validated
- [ ] Verify next push to master cancels stale queued release runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)