### PR TITLE
feat(data): NCHW layout option for vision data loaders

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -47,6 +47,7 @@
     <PackageVersion Include="Google.Protobuf" Version="3.34.1" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageVersion Include="Parquet.Net" Version="5.5.0" />
+    <PackageVersion Include="Xunit.SkippableFact" Version="1.5.61" />
     <PackageVersion Include="YamlDotNet" Version="16.3.0" />
     <!-- Infrastructure -->
     <PackageVersion Include="Elastic.Clients.Elasticsearch" Version="9.3.4" />

--- a/src/Data/Vision/Benchmarks/Cifar100DataLoader.cs
+++ b/src/Data/Vision/Benchmarks/Cifar100DataLoader.cs
@@ -89,22 +89,17 @@ public class Cifar100DataLoader<T> : InputOutputDataLoaderBase<T, Tensor<T>, Ten
             int label = _options.UseFineLabels ? data[sampleOffset + 1] : data[sampleOffset];
 
             int featureOffset = i * 32 * 32 * 3;
-            for (int h = 0; h < 32; h++)
-            {
-                for (int w = 0; w < 32; w++)
-                {
-                    for (int c = 0; c < 3; c++)
-                    {
-                        int srcIdx = sampleOffset + 2 + c * 1024 + h * 32 + w;
-                        int dstIdx = nchw
-                            ? featureOffset + c * 1024 + h * 32 + w
-                            : featureOffset + (h * 32 + w) * 3 + c;
-                        double value = data[srcIdx];
-                        if (_options.Normalize) value /= 255.0;
-                        featuresData[dstIdx] = NumOps.FromDouble(value);
-                    }
-                }
-            }
+            int pixelStart = sampleOffset + 2;
+            const int ppi = 32 * 32 * 3;
+            var sampleTensor = new Tensor<T>([3, 32, 32]);
+            double scale = _options.Normalize ? 1.0 / 255.0 : 1.0;
+            for (int p = 0; p < ppi; p++)
+                sampleTensor[p] = NumOps.FromDouble(data[pixelStart + p] * scale);
+
+            if (!nchw)
+                sampleTensor = AiDotNetEngine.Current.TensorPermute(sampleTensor, [1, 2, 0]);
+
+            sampleTensor.AsSpan().CopyTo(featuresData.AsSpan(featureOffset, ppi));
 
             if (label >= 0 && label < _numClasses)
                 labelsData[i * _numClasses + label] = NumOps.One;

--- a/src/Data/Vision/Benchmarks/Cifar100DataLoader.cs
+++ b/src/Data/Vision/Benchmarks/Cifar100DataLoader.cs
@@ -80,6 +80,7 @@ public class Cifar100DataLoader<T> : InputOutputDataLoaderBase<T, Tensor<T>, Ten
         var featuresData = new T[totalSamples * 32 * 32 * 3];
         var labelsData = new T[totalSamples * _numClasses];
 
+        bool nchw = _options.Layout == ImageTensorLayout.NCHW;
         for (int i = 0; i < totalSamples; i++)
         {
             cancellationToken.ThrowIfCancellationRequested();
@@ -95,7 +96,9 @@ public class Cifar100DataLoader<T> : InputOutputDataLoaderBase<T, Tensor<T>, Ten
                     for (int c = 0; c < 3; c++)
                     {
                         int srcIdx = sampleOffset + 2 + c * 1024 + h * 32 + w;
-                        int dstIdx = featureOffset + (h * 32 + w) * 3 + c;
+                        int dstIdx = nchw
+                            ? featureOffset + c * 1024 + h * 32 + w
+                            : featureOffset + (h * 32 + w) * 3 + c;
                         double value = data[srcIdx];
                         if (_options.Normalize) value /= 255.0;
                         featuresData[dstIdx] = NumOps.FromDouble(value);
@@ -107,7 +110,10 @@ public class Cifar100DataLoader<T> : InputOutputDataLoaderBase<T, Tensor<T>, Ten
                 labelsData[i * _numClasses + label] = NumOps.One;
         }
 
-        LoadedFeatures = new Tensor<T>(featuresData, new[] { totalSamples, 32, 32, 3 });
+        int[] shape = nchw
+            ? new[] { totalSamples, 3, 32, 32 }
+            : new[] { totalSamples, 32, 32, 3 };
+        LoadedFeatures = new Tensor<T>(featuresData, shape);
         LoadedLabels = new Tensor<T>(labelsData, new[] { totalSamples, _numClasses });
         InitializeIndices(totalSamples);
     }

--- a/src/Data/Vision/Benchmarks/Cifar100DataLoaderOptions.cs
+++ b/src/Data/Vision/Benchmarks/Cifar100DataLoaderOptions.cs
@@ -17,6 +17,11 @@ public sealed class Cifar100DataLoaderOptions
     public bool Normalize { get; set; } = true;
     /// <summary>Whether to use fine labels (100 classes) or coarse labels (20 superclasses). Default is true (fine).</summary>
     public bool UseFineLabels { get; set; } = true;
+    /// <summary>
+    /// Axis ordering for the image tensor. Default is NHWC <c>[B, 32, 32, 3]</c>.
+    /// Set to NCHW for <c>[B, 3, 32, 32]</c>.
+    /// </summary>
+    public ImageTensorLayout Layout { get; set; } = ImageTensorLayout.NHWC;
     /// <summary>Optional maximum number of samples to load.</summary>
     public int? MaxSamples { get; set; }
 }

--- a/src/Data/Vision/Benchmarks/Cifar10DataLoader.cs
+++ b/src/Data/Vision/Benchmarks/Cifar10DataLoader.cs
@@ -103,22 +103,16 @@ public class Cifar10DataLoader<T> : InputOutputDataLoaderBase<T, Tensor<T>, Tens
             int label = sample[0];
 
             int featureOffset = i * pixelsPerImage;
-            for (int h = 0; h < 32; h++)
-            {
-                for (int w = 0; w < 32; w++)
-                {
-                    for (int c = 0; c < 3; c++)
-                    {
-                        int srcIdx = 1 + c * 1024 + h * 32 + w; // CHW in source
-                        int dstIdx = nchw
-                            ? featureOffset + c * 1024 + h * 32 + w  // NCHW
-                            : featureOffset + (h * 32 + w) * 3 + c;  // NHWC
-                        double value = sample[srcIdx];
-                        if (_options.Normalize) value /= 255.0;
-                        featuresData[dstIdx] = NumOps.FromDouble(value);
-                    }
-                }
-            }
+            // Build CHW tensor from raw bytes, permute to HWC if needed
+            var sampleTensor = new Tensor<T>([3, 32, 32]);
+            double scale = _options.Normalize ? 1.0 / 255.0 : 1.0;
+            for (int p = 0; p < pixelsPerImage; p++)
+                sampleTensor[p] = NumOps.FromDouble(sample[1 + p] * scale);
+
+            if (!nchw)
+                sampleTensor = AiDotNetEngine.Current.TensorPermute(sampleTensor, [1, 2, 0]);
+
+            sampleTensor.AsSpan().CopyTo(featuresData.AsSpan(featureOffset, pixelsPerImage));
 
             if (label >= 0 && label < 10)
                 labelsData[i * 10 + label] = NumOps.One;

--- a/src/Data/Vision/Benchmarks/Cifar10DataLoader.cs
+++ b/src/Data/Vision/Benchmarks/Cifar10DataLoader.cs
@@ -101,8 +101,8 @@ public class Cifar10DataLoader<T> : InputOutputDataLoaderBase<T, Tensor<T>, Tens
             byte[] sample = allData[i];
             int label = sample[0];
 
-            // Convert CHW to HWC format for consistency
             int featureOffset = i * pixelsPerImage;
+            bool nchw = _options.Layout == ImageTensorLayout.NCHW;
             for (int h = 0; h < 32; h++)
             {
                 for (int w = 0; w < 32; w++)
@@ -110,7 +110,9 @@ public class Cifar10DataLoader<T> : InputOutputDataLoaderBase<T, Tensor<T>, Tens
                     for (int c = 0; c < 3; c++)
                     {
                         int srcIdx = 1 + c * 1024 + h * 32 + w; // CHW in source
-                        int dstIdx = featureOffset + (h * 32 + w) * 3 + c; // HWC in dest
+                        int dstIdx = nchw
+                            ? featureOffset + c * 1024 + h * 32 + w  // NCHW
+                            : featureOffset + (h * 32 + w) * 3 + c;  // NHWC
                         double value = sample[srcIdx];
                         if (_options.Normalize) value /= 255.0;
                         featuresData[dstIdx] = NumOps.FromDouble(value);
@@ -122,7 +124,10 @@ public class Cifar10DataLoader<T> : InputOutputDataLoaderBase<T, Tensor<T>, Tens
                 labelsData[i * 10 + label] = NumOps.One;
         }
 
-        LoadedFeatures = new Tensor<T>(featuresData, new[] { totalSamples, 32, 32, 3 });
+        int[] shape = _options.Layout == ImageTensorLayout.NCHW
+            ? new[] { totalSamples, 3, 32, 32 }
+            : new[] { totalSamples, 32, 32, 3 };
+        LoadedFeatures = new Tensor<T>(featuresData, shape);
         LoadedLabels = new Tensor<T>(labelsData, new[] { totalSamples, 10 });
         InitializeIndices(totalSamples);
     }

--- a/src/Data/Vision/Benchmarks/Cifar10DataLoader.cs
+++ b/src/Data/Vision/Benchmarks/Cifar10DataLoader.cs
@@ -94,6 +94,7 @@ public class Cifar10DataLoader<T> : InputOutputDataLoaderBase<T, Tensor<T>, Tens
         var featuresData = new T[totalSamples * pixelsPerImage];
         var labelsData = new T[totalSamples * 10];
 
+        bool nchw = _options.Layout == ImageTensorLayout.NCHW;
         for (int i = 0; i < totalSamples; i++)
         {
             cancellationToken.ThrowIfCancellationRequested();
@@ -102,7 +103,6 @@ public class Cifar10DataLoader<T> : InputOutputDataLoaderBase<T, Tensor<T>, Tens
             int label = sample[0];
 
             int featureOffset = i * pixelsPerImage;
-            bool nchw = _options.Layout == ImageTensorLayout.NCHW;
             for (int h = 0; h < 32; h++)
             {
                 for (int w = 0; w < 32; w++)

--- a/src/Data/Vision/Benchmarks/Cifar10DataLoader.cs
+++ b/src/Data/Vision/Benchmarks/Cifar10DataLoader.cs
@@ -124,7 +124,7 @@ public class Cifar10DataLoader<T> : InputOutputDataLoaderBase<T, Tensor<T>, Tens
                 labelsData[i * 10 + label] = NumOps.One;
         }
 
-        int[] shape = _options.Layout == ImageTensorLayout.NCHW
+        int[] shape = nchw
             ? new[] { totalSamples, 3, 32, 32 }
             : new[] { totalSamples, 32, 32, 3 };
         LoadedFeatures = new Tensor<T>(featuresData, shape);

--- a/src/Data/Vision/Benchmarks/Cifar10DataLoaderOptions.cs
+++ b/src/Data/Vision/Benchmarks/Cifar10DataLoaderOptions.cs
@@ -15,6 +15,12 @@ public sealed class Cifar10DataLoaderOptions
     public bool AutoDownload { get; set; } = true;
     /// <summary>Normalize pixel values to [0, 1]. Default is true.</summary>
     public bool Normalize { get; set; } = true;
+    /// <summary>
+    /// Axis ordering for the image tensor. Default is <see cref="ImageTensorLayout.NHWC"/>
+    /// (<c>[B, 32, 32, 3]</c>). Set to <see cref="ImageTensorLayout.NCHW"/> for
+    /// <c>[B, 3, 32, 32]</c>.
+    /// </summary>
+    public ImageTensorLayout Layout { get; set; } = ImageTensorLayout.NHWC;
     /// <summary>Optional maximum number of samples to load.</summary>
     public int? MaxSamples { get; set; }
 }

--- a/src/Data/Vision/Benchmarks/EuroSatDataLoader.cs
+++ b/src/Data/Vision/Benchmarks/EuroSatDataLoader.cs
@@ -121,14 +121,29 @@ public class EuroSatDataLoader<T> : InputOutputDataLoaderBase<T, Tensor<T>, Tens
             var pixels = VisionLoaderHelper.LoadAndResizeImage<T>(imgPath, ImageSize, ImageSize, 3, _options.Normalize);
 
             int featureOffset = i * pixelsPerImage;
-            int copyLen = Math.Min(pixels.Length, pixelsPerImage);
-            Array.Copy(pixels, 0, featuresData, featureOffset, copyLen);
+            if (_options.Layout == ImageTensorLayout.NCHW)
+            {
+                // VisionLoaderHelper returns HWC; remap to CHW
+                for (int y = 0; y < ImageSize; y++)
+                    for (int x = 0; x < ImageSize; x++)
+                        for (int c = 0; c < 3; c++)
+                            featuresData[featureOffset + c * ImageSize * ImageSize + y * ImageSize + x]
+                                = pixels[(y * ImageSize + x) * 3 + c];
+            }
+            else
+            {
+                int copyLen = Math.Min(pixels.Length, pixelsPerImage);
+                Array.Copy(pixels, 0, featuresData, featureOffset, copyLen);
+            }
 
             if (label >= 0 && label < NumClasses)
                 labelsData[i * NumClasses + label] = NumOps.One;
         }
 
-        LoadedFeatures = new Tensor<T>(featuresData, new[] { totalSamples, ImageSize, ImageSize, 3 });
+        int[] shape = _options.Layout == ImageTensorLayout.NCHW
+            ? new[] { totalSamples, 3, ImageSize, ImageSize }
+            : new[] { totalSamples, ImageSize, ImageSize, 3 };
+        LoadedFeatures = new Tensor<T>(featuresData, shape);
         LoadedLabels = new Tensor<T>(labelsData, new[] { totalSamples, NumClasses });
         InitializeIndices(totalSamples);
     }

--- a/src/Data/Vision/Benchmarks/EuroSatDataLoader.cs
+++ b/src/Data/Vision/Benchmarks/EuroSatDataLoader.cs
@@ -121,26 +121,30 @@ public class EuroSatDataLoader<T> : InputOutputDataLoaderBase<T, Tensor<T>, Tens
             var pixels = VisionLoaderHelper.LoadAndResizeImage<T>(imgPath, ImageSize, ImageSize, 3, _options.Normalize);
 
             int featureOffset = i * pixelsPerImage;
-            if (_options.Layout == ImageTensorLayout.NCHW)
+            bool nchw = _options.Layout == ImageTensorLayout.NCHW;
+            int available = Math.Min(pixels.Length, pixelsPerImage);
+            if (nchw)
             {
                 // VisionLoaderHelper returns HWC; remap to CHW
-                for (int y = 0; y < ImageSize; y++)
-                    for (int x = 0; x < ImageSize; x++)
+                int h = ImageSize, w = ImageSize;
+                int maxY = Math.Min(h, available / (w * 3));
+                for (int y = 0; y < maxY; y++)
+                    for (int x = 0; x < w; x++)
                         for (int c = 0; c < 3; c++)
-                            featuresData[featureOffset + c * ImageSize * ImageSize + y * ImageSize + x]
-                                = pixels[(y * ImageSize + x) * 3 + c];
+                            featuresData[featureOffset + c * h * w + y * w + x]
+                                = pixels[(y * w + x) * 3 + c];
             }
             else
             {
-                int copyLen = Math.Min(pixels.Length, pixelsPerImage);
-                Array.Copy(pixels, 0, featuresData, featureOffset, copyLen);
+                Array.Copy(pixels, 0, featuresData, featureOffset, available);
             }
 
             if (label >= 0 && label < NumClasses)
                 labelsData[i * NumClasses + label] = NumOps.One;
         }
 
-        int[] shape = _options.Layout == ImageTensorLayout.NCHW
+        bool nchwLayout = _options.Layout == ImageTensorLayout.NCHW;
+        int[] shape = nchwLayout
             ? new[] { totalSamples, 3, ImageSize, ImageSize }
             : new[] { totalSamples, ImageSize, ImageSize, 3 };
         LoadedFeatures = new Tensor<T>(featuresData, shape);

--- a/src/Data/Vision/Benchmarks/EuroSatDataLoader.cs
+++ b/src/Data/Vision/Benchmarks/EuroSatDataLoader.cs
@@ -121,18 +121,15 @@ public class EuroSatDataLoader<T> : InputOutputDataLoaderBase<T, Tensor<T>, Tens
             var pixels = VisionLoaderHelper.LoadAndResizeImage<T>(imgPath, ImageSize, ImageSize, 3, _options.Normalize);
 
             int featureOffset = i * pixelsPerImage;
-            bool nchw = _options.Layout == ImageTensorLayout.NCHW;
             int available = Math.Min(pixels.Length, pixelsPerImage);
+            bool nchw = _options.Layout == ImageTensorLayout.NCHW;
             if (nchw)
             {
-                // VisionLoaderHelper returns HWC; remap to CHW
-                int h = ImageSize, w = ImageSize;
-                int maxY = Math.Min(h, available / (w * 3));
-                for (int y = 0; y < maxY; y++)
-                    for (int x = 0; x < w; x++)
-                        for (int c = 0; c < 3; c++)
-                            featuresData[featureOffset + c * h * w + y * w + x]
-                                = pixels[(y * w + x) * 3 + c];
+                // VisionLoaderHelper returns HWC [H,W,3]; permute to CHW [3,H,W]
+                var hwcTensor = new Tensor<T>([ImageSize, ImageSize, 3]);
+                pixels.AsSpan(0, available).CopyTo(hwcTensor.AsWritableSpan());
+                var chwTensor = AiDotNetEngine.Current.TensorPermute(hwcTensor, [2, 0, 1]);
+                chwTensor.AsSpan().CopyTo(featuresData.AsSpan(featureOffset, pixelsPerImage));
             }
             else
             {

--- a/src/Data/Vision/Benchmarks/EuroSatDataLoaderOptions.cs
+++ b/src/Data/Vision/Benchmarks/EuroSatDataLoaderOptions.cs
@@ -26,6 +26,12 @@ public sealed class EuroSatDataLoaderOptions
     /// <summary>Normalize pixel values to [0, 1]. Default is true.</summary>
     public bool Normalize { get; set; } = true;
 
+    /// <summary>
+    /// Axis ordering for the image tensor. Default is NHWC <c>[B, 64, 64, 3]</c>.
+    /// Set to NCHW for <c>[B, 3, 64, 64]</c>.
+    /// </summary>
+    public ImageTensorLayout Layout { get; set; } = ImageTensorLayout.NHWC;
+
     /// <summary>Optional maximum number of samples to load.</summary>
     public int? MaxSamples { get; set; }
 }

--- a/src/Data/Vision/Benchmarks/FashionMnistDataLoader.cs
+++ b/src/Data/Vision/Benchmarks/FashionMnistDataLoader.cs
@@ -124,6 +124,11 @@ public class FashionMnistDataLoader<T> : InputOutputDataLoaderBase<T, Tensor<T>,
             featuresData = new T[samplesToLoad * pixelsPerImage];
             featureShape = new[] { samplesToLoad, pixelsPerImage };
         }
+        else if (_options.Layout == ImageTensorLayout.NCHW)
+        {
+            featuresData = new T[samplesToLoad * 1 * rows * cols];
+            featureShape = new[] { samplesToLoad, 1, rows, cols };
+        }
         else
         {
             featuresData = new T[samplesToLoad * rows * cols * 1];

--- a/src/Data/Vision/Benchmarks/FashionMnistDataLoaderOptions.cs
+++ b/src/Data/Vision/Benchmarks/FashionMnistDataLoaderOptions.cs
@@ -15,7 +15,8 @@ public sealed class FashionMnistDataLoaderOptions
     public bool AutoDownload { get; set; } = true;
     /// <summary>Normalize pixel values to [0, 1]. Default is true.</summary>
     public bool Normalize { get; set; } = true;
-    /// <summary>Flatten images to 1D (784) instead of 2D (28x28). Default is false.</summary>
+    /// <summary>Flatten images to 1D (784) instead of 2D (28x28, 1 channel).
+    /// When true, <see cref="Layout"/> is ignored. Default is false.</summary>
     public bool Flatten { get; set; }
     /// <summary>
     /// Axis ordering for the image tensor. Default is NHWC <c>[B, 28, 28, 1]</c>.

--- a/src/Data/Vision/Benchmarks/FashionMnistDataLoaderOptions.cs
+++ b/src/Data/Vision/Benchmarks/FashionMnistDataLoaderOptions.cs
@@ -17,6 +17,11 @@ public sealed class FashionMnistDataLoaderOptions
     public bool Normalize { get; set; } = true;
     /// <summary>Flatten images to 1D (784) instead of 2D (28x28). Default is false.</summary>
     public bool Flatten { get; set; }
+    /// <summary>
+    /// Axis ordering for the image tensor. Default is NHWC <c>[B, 28, 28, 1]</c>.
+    /// Set to NCHW for <c>[B, 1, 28, 28]</c>. Ignored when Flatten is true.
+    /// </summary>
+    public ImageTensorLayout Layout { get; set; } = ImageTensorLayout.NHWC;
     /// <summary>Optional maximum number of samples to load.</summary>
     public int? MaxSamples { get; set; }
 }

--- a/src/Data/Vision/Benchmarks/ImageTensorLayout.cs
+++ b/src/Data/Vision/Benchmarks/ImageTensorLayout.cs
@@ -1,0 +1,19 @@
+namespace AiDotNet.Data.Vision.Benchmarks;
+
+/// <summary>
+/// Specifies the axis ordering for image tensors returned by vision data loaders.
+/// </summary>
+public enum ImageTensorLayout
+{
+    /// <summary>
+    /// Channel-last layout: <c>[B, H, W, C]</c>. TensorFlow/Keras convention.
+    /// This is the default for AiDotNet vision data loaders.
+    /// </summary>
+    NHWC,
+
+    /// <summary>
+    /// Channel-first layout: <c>[B, C, H, W]</c>. PyTorch convention.
+    /// Used by <c>ConvolutionalLayer&lt;T&gt;</c> and all HRE vision layers.
+    /// </summary>
+    NCHW,
+}

--- a/src/Data/Vision/Benchmarks/ImageTensorLayout.cs
+++ b/src/Data/Vision/Benchmarks/ImageTensorLayout.cs
@@ -13,7 +13,7 @@ public enum ImageTensorLayout
 
     /// <summary>
     /// Channel-first layout: <c>[B, C, H, W]</c>. PyTorch convention.
-    /// Used by <c>ConvolutionalLayer&lt;T&gt;</c> and all HRE vision layers.
+    /// Used by <c>ConvolutionalLayer&lt;T&gt;</c> and other channel-first models.
     /// </summary>
     NCHW,
 }

--- a/src/Data/Vision/Benchmarks/MnistDataLoader.cs
+++ b/src/Data/Vision/Benchmarks/MnistDataLoader.cs
@@ -179,6 +179,11 @@ public class MnistDataLoader<T> : InputOutputDataLoaderBase<T, Tensor<T>, Tensor
             featuresData = new T[samplesToLoad * pixelsPerImage];
             featureShape = new[] { samplesToLoad, pixelsPerImage };
         }
+        else if (_options.Layout == ImageTensorLayout.NCHW)
+        {
+            featuresData = new T[samplesToLoad * 1 * rows * cols];
+            featureShape = new[] { samplesToLoad, 1, rows, cols };
+        }
         else
         {
             featuresData = new T[samplesToLoad * rows * cols * 1];

--- a/src/Data/Vision/Benchmarks/MnistDataLoaderOptions.cs
+++ b/src/Data/Vision/Benchmarks/MnistDataLoaderOptions.cs
@@ -29,8 +29,18 @@ public sealed class MnistDataLoaderOptions
 
     /// <summary>
     /// Whether to flatten images to 1D vectors (784) instead of 2D (28x28). Default is false.
+    /// When true, the <see cref="Layout"/> option is ignored.
     /// </summary>
     public bool Flatten { get; set; }
+
+    /// <summary>
+    /// Axis ordering for the image tensor. Default is <see cref="ImageTensorLayout.NHWC"/>
+    /// (<c>[B, 28, 28, 1]</c>). Set to <see cref="ImageTensorLayout.NCHW"/> for
+    /// <c>[B, 1, 28, 28]</c>, which is the convention used by
+    /// <c>ConvolutionalLayer&lt;T&gt;</c> and PyTorch-style models.
+    /// Ignored when <see cref="Flatten"/> is true.
+    /// </summary>
+    public ImageTensorLayout Layout { get; set; } = ImageTensorLayout.NHWC;
 
     /// <summary>
     /// Optional maximum number of samples to load.

--- a/src/Data/Vision/Benchmarks/MnistDataLoaderOptions.cs
+++ b/src/Data/Vision/Benchmarks/MnistDataLoaderOptions.cs
@@ -28,8 +28,9 @@ public sealed class MnistDataLoaderOptions
     public bool Normalize { get; set; } = true;
 
     /// <summary>
-    /// Whether to flatten images to 1D vectors (784) instead of 2D (28x28). Default is false.
-    /// When true, the <see cref="Layout"/> option is ignored.
+    /// Whether to flatten images to 1D vectors (784) instead of the spatial layout
+    /// (<c>[B, 28, 28, 1]</c> NHWC or <c>[B, 1, 28, 28]</c> NCHW). Default is false.
+    /// When true, <see cref="Layout"/> is ignored.
     /// </summary>
     public bool Flatten { get; set; }
 

--- a/tests/AiDotNet.Tests/AiDotNetTests.csproj
+++ b/tests/AiDotNet.Tests/AiDotNetTests.csproj
@@ -29,6 +29,7 @@
     <PackageReference Include="BenchmarkDotNet" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" />
     <PackageReference Include="Moq" />
+    <PackageReference Include="Xunit.SkippableFact" />
   </ItemGroup>
 
   <ItemGroup>
@@ -37,9 +38,7 @@
 
   <!-- Source generator for auto-generating test scaffolds for untested models -->
   <ItemGroup>
-    <ProjectReference Include="..\..\src\AiDotNet.Generators\AiDotNet.Generators.csproj"
-                       OutputItemType="Analyzer"
-                       ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\..\src\AiDotNet.Generators\AiDotNet.Generators.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">

--- a/tests/AiDotNet.Tests/Data/ImageTensorLayoutTests.cs
+++ b/tests/AiDotNet.Tests/Data/ImageTensorLayoutTests.cs
@@ -3,12 +3,12 @@ using AiDotNet.Data.Geometry;
 using AiDotNet.Data.Vision.Benchmarks;
 using Xunit;
 
-namespace AiDotNetTests.Data;
+namespace AiDotNetTests.UnitTests.Data;
 
 /// <summary>
 /// Tests for the ImageTensorLayout option on vision data loaders.
-/// Uses AutoDownload=false and SkippableFact — reports as SKIP (not PASS)
-/// when datasets aren't cached, so CI output clearly shows missing coverage.
+/// Uses AutoDownload=false and SkippableFact — reports SKIP when
+/// datasets aren't cached so CI output clearly shows missing coverage.
 /// </summary>
 public class ImageTensorLayoutTests
 {
@@ -22,13 +22,29 @@ public class ImageTensorLayoutTests
     private static bool Cifar10CacheExists()
     {
         string cachePath = DatasetDownloader.GetDefaultDataPath("cifar-10");
-        string batchesDir = Path.Combine(cachePath, "cifar-10-batches-bin");
-        return (Directory.Exists(cachePath) && Directory.GetFiles(cachePath, "data_batch*").Length > 0)
-            || (Directory.Exists(batchesDir) && Directory.GetFiles(batchesDir, "data_batch*").Length > 0);
+        return Directory.Exists(cachePath)
+            && Directory.EnumerateFiles(cachePath, "data_batch*", SearchOption.AllDirectories).Any();
     }
 
+    private static bool FashionMnistCacheExists()
+    {
+        string cachePath = DatasetDownloader.GetDefaultDataPath("fashion-mnist");
+        return File.Exists(Path.Combine(cachePath, "train-images-idx3-ubyte"))
+            && File.Exists(Path.Combine(cachePath, "train-labels-idx1-ubyte"));
+    }
+
+    private static void AssertShape(Tensor<float> tensor, params int[] expected)
+    {
+        var shape = tensor.Shape;
+        Assert.Equal(expected.Length, shape.Length);
+        for (int i = 0; i < expected.Length; i++)
+            Assert.Equal(expected[i], shape[i]);
+    }
+
+    // --- MNIST ---
+
     [SkippableFact]
-    public async Task MnistNHWC_DefaultShape_Is_B28281()
+    public async Task MnistNHWC_DefaultShape()
     {
         Skip.IfNot(MnistCacheExists(), "MNIST not cached locally");
         var loader = new MnistDataLoader<float>(new MnistDataLoaderOptions
@@ -36,12 +52,14 @@ public class ImageTensorLayoutTests
             Split = DatasetSplit.Train, AutoDownload = false, MaxSamples = 2,
         });
         await loader.LoadAsync();
-        var batch = loader.GetBatches(batchSize: 2).First();
-        Assert.Equal(new[] { 2, 28, 28, 1 }, batch.Features.Shape.ToArray());
+        Assert.True(loader.TotalCount > 0, "Loader returned no samples");
+        using var enumerator = loader.GetBatches(batchSize: 2).GetEnumerator();
+        Assert.True(enumerator.MoveNext(), "No batches returned");
+        AssertShape(enumerator.Current.Features, 2, 28, 28, 1);
     }
 
     [SkippableFact]
-    public async Task MnistNCHW_Shape_Is_B1_28_28()
+    public async Task MnistNCHW_Shape()
     {
         Skip.IfNot(MnistCacheExists(), "MNIST not cached locally");
         var loader = new MnistDataLoader<float>(new MnistDataLoaderOptions
@@ -50,8 +68,10 @@ public class ImageTensorLayoutTests
             Layout = ImageTensorLayout.NCHW,
         });
         await loader.LoadAsync();
-        var batch = loader.GetBatches(batchSize: 2).First();
-        Assert.Equal(new[] { 2, 1, 28, 28 }, batch.Features.Shape.ToArray());
+        Assert.True(loader.TotalCount > 0, "Loader returned no samples");
+        using var enumerator = loader.GetBatches(batchSize: 2).GetEnumerator();
+        Assert.True(enumerator.MoveNext(), "No batches returned");
+        AssertShape(enumerator.Current.Features, 2, 1, 28, 28);
     }
 
     [SkippableFact]
@@ -64,12 +84,16 @@ public class ImageTensorLayoutTests
             Flatten = true, Layout = ImageTensorLayout.NCHW,
         });
         await loader.LoadAsync();
-        var batch = loader.GetBatches(batchSize: 2).First();
-        Assert.Equal(new[] { 2, 784 }, batch.Features.Shape.ToArray());
+        Assert.True(loader.TotalCount > 0, "Loader returned no samples");
+        using var enumerator = loader.GetBatches(batchSize: 2).GetEnumerator();
+        Assert.True(enumerator.MoveNext(), "No batches returned");
+        AssertShape(enumerator.Current.Features, 2, 784);
     }
 
+    // --- CIFAR-10 ---
+
     [SkippableFact]
-    public async Task Cifar10NCHW_ShapeAndChannelOrder()
+    public async Task Cifar10NCHW_Shape()
     {
         Skip.IfNot(Cifar10CacheExists(), "CIFAR-10 not cached locally");
         var loader = new Cifar10DataLoader<float>(new Cifar10DataLoaderOptions
@@ -78,7 +102,27 @@ public class ImageTensorLayoutTests
             Normalize = false, Layout = ImageTensorLayout.NCHW,
         });
         await loader.LoadAsync();
-        var batch = loader.GetBatches(batchSize: 1).First();
-        Assert.Equal(new[] { 1, 3, 32, 32 }, batch.Features.Shape.ToArray());
+        Assert.True(loader.TotalCount > 0, "Loader returned no samples");
+        using var enumerator = loader.GetBatches(batchSize: 1).GetEnumerator();
+        Assert.True(enumerator.MoveNext(), "No batches returned");
+        AssertShape(enumerator.Current.Features, 1, 3, 32, 32);
+    }
+
+    // --- FashionMNIST ---
+
+    [SkippableFact]
+    public async Task FashionMnistNCHW_Shape()
+    {
+        Skip.IfNot(FashionMnistCacheExists(), "FashionMNIST not cached locally");
+        var loader = new FashionMnistDataLoader<float>(new FashionMnistDataLoaderOptions
+        {
+            Split = DatasetSplit.Train, AutoDownload = false, MaxSamples = 2,
+            Layout = ImageTensorLayout.NCHW,
+        });
+        await loader.LoadAsync();
+        Assert.True(loader.TotalCount > 0, "Loader returned no samples");
+        using var enumerator = loader.GetBatches(batchSize: 2).GetEnumerator();
+        Assert.True(enumerator.MoveNext(), "No batches returned");
+        AssertShape(enumerator.Current.Features, 2, 1, 28, 28);
     }
 }

--- a/tests/AiDotNet.Tests/Data/ImageTensorLayoutTests.cs
+++ b/tests/AiDotNet.Tests/Data/ImageTensorLayoutTests.cs
@@ -1,0 +1,66 @@
+using AiDotNet.Data.Geometry;
+using AiDotNet.Data.Vision.Benchmarks;
+using Xunit;
+
+namespace AiDotNetTests.Data;
+
+public class ImageTensorLayoutTests
+{
+    [Fact]
+    public async Task MnistNHWC_DefaultShape_Is_B28281()
+    {
+        var loader = new MnistDataLoader<float>(new MnistDataLoaderOptions
+        {
+            Split = DatasetSplit.Train,
+            AutoDownload = true,
+            MaxSamples = 2,
+        });
+        await loader.LoadAsync();
+        var batch = loader.GetBatches(batchSize: 2).First();
+        var shape = batch.Features.Shape.ToArray();
+        Assert.Equal(4, shape.Length);
+        Assert.Equal(2, shape[0]);
+        Assert.Equal(28, shape[1]);
+        Assert.Equal(28, shape[2]);
+        Assert.Equal(1, shape[3]);
+    }
+
+    [Fact]
+    public async Task MnistNCHW_Shape_Is_B1_28_28()
+    {
+        var loader = new MnistDataLoader<float>(new MnistDataLoaderOptions
+        {
+            Split = DatasetSplit.Train,
+            AutoDownload = true,
+            MaxSamples = 2,
+            Layout = ImageTensorLayout.NCHW,
+        });
+        await loader.LoadAsync();
+        var batch = loader.GetBatches(batchSize: 2).First();
+        var shape = batch.Features.Shape.ToArray();
+        Assert.Equal(4, shape.Length);
+        Assert.Equal(2, shape[0]);
+        Assert.Equal(1, shape[1]);
+        Assert.Equal(28, shape[2]);
+        Assert.Equal(28, shape[3]);
+    }
+
+    [Fact]
+    public async Task MnistFlatten_IgnoresLayout()
+    {
+        var loader = new MnistDataLoader<float>(new MnistDataLoaderOptions
+        {
+            Split = DatasetSplit.Train,
+            AutoDownload = true,
+            MaxSamples = 2,
+            Flatten = true,
+            Layout = ImageTensorLayout.NCHW,
+        });
+        await loader.LoadAsync();
+        var batch = loader.GetBatches(batchSize: 2).First();
+        var shape = batch.Features.Shape.ToArray();
+        Assert.Equal(2, shape.Length);
+        Assert.Equal(2, shape[0]);
+        Assert.Equal(784, shape[1]);
+    }
+}

--- a/tests/AiDotNet.Tests/Data/ImageTensorLayoutTests.cs
+++ b/tests/AiDotNet.Tests/Data/ImageTensorLayoutTests.cs
@@ -8,7 +8,7 @@ namespace AiDotNetTests.Data;
 
 /// <summary>
 /// Tests for the ImageTensorLayout option on vision data loaders.
-/// Uses AutoDownload=false; logs a skip message when MNIST isn't cached.
+/// Uses AutoDownload=false; logs explicit SKIP when data isn't cached.
 /// </summary>
 public class ImageTensorLayoutTests
 {
@@ -21,7 +21,7 @@ public class ImageTensorLayoutTests
         string cachePath = DatasetDownloader.GetDefaultDataPath("mnist");
         if (File.Exists(Path.Combine(cachePath, "train-images-idx3-ubyte")))
             return true;
-        _output.WriteLine("SKIPPED: MNIST not cached locally. Run with AutoDownload=true once to populate.");
+        _output.WriteLine("SKIPPED: MNIST not cached. Run once with AutoDownload=true to populate.");
         return false;
     }
 
@@ -76,15 +76,16 @@ public class ImageTensorLayoutTests
     private bool RequireCifar10Cache()
     {
         string cachePath = DatasetDownloader.GetDefaultDataPath("cifar-10");
-        bool exists = Directory.Exists(cachePath) &&
-            Directory.GetFiles(cachePath, "data_batch*").Length > 0;
+        string batchesDir = Path.Combine(cachePath, "cifar-10-batches-bin");
+        bool exists = (Directory.Exists(cachePath) && Directory.GetFiles(cachePath, "data_batch*").Length > 0)
+            || (Directory.Exists(batchesDir) && Directory.GetFiles(batchesDir, "data_batch*").Length > 0);
         if (!exists)
             _output.WriteLine("SKIPPED: CIFAR-10 not cached locally.");
         return exists;
     }
 
     [Fact]
-    public async Task Cifar10NCHW_Shape_Is_B3_32_32()
+    public async Task Cifar10NCHW_ShapeAndChannelOrder()
     {
         if (!RequireCifar10Cache()) return;
         var loader = new Cifar10DataLoader<float>(new Cifar10DataLoaderOptions
@@ -92,6 +93,7 @@ public class ImageTensorLayoutTests
             Split = DatasetSplit.Train,
             AutoDownload = false,
             MaxSamples = 2,
+            Normalize = false,
             Layout = ImageTensorLayout.NCHW,
         });
         await loader.LoadAsync();

--- a/tests/AiDotNet.Tests/Data/ImageTensorLayoutTests.cs
+++ b/tests/AiDotNet.Tests/Data/ImageTensorLayoutTests.cs
@@ -1,66 +1,68 @@
+using AiDotNet.Data;
 using AiDotNet.Data.Geometry;
 using AiDotNet.Data.Vision.Benchmarks;
 using Xunit;
 
 namespace AiDotNetTests.Data;
 
+/// <summary>
+/// Tests for the ImageTensorLayout option on vision data loaders.
+/// Uses AutoDownload=false + skips if MNIST isn't cached locally,
+/// so these tests never hit the network and are CI-safe.
+/// </summary>
 public class ImageTensorLayoutTests
 {
+    private static bool MnistCacheExists()
+    {
+        string cachePath = DatasetDownloader.GetDefaultDataPath("mnist");
+        return File.Exists(Path.Combine(cachePath, "train-images-idx3-ubyte"));
+    }
+
     [Fact]
     public async Task MnistNHWC_DefaultShape_Is_B28281()
     {
+        if (!MnistCacheExists()) return;
         var loader = new MnistDataLoader<float>(new MnistDataLoaderOptions
         {
             Split = DatasetSplit.Train,
-            AutoDownload = true,
+            AutoDownload = false,
             MaxSamples = 2,
         });
         await loader.LoadAsync();
         var batch = loader.GetBatches(batchSize: 2).First();
-        var shape = batch.Features.Shape.ToArray();
-        Assert.Equal(4, shape.Length);
-        Assert.Equal(2, shape[0]);
-        Assert.Equal(28, shape[1]);
-        Assert.Equal(28, shape[2]);
-        Assert.Equal(1, shape[3]);
+        Assert.Equal(new[] { 2, 28, 28, 1 }, batch.Features.Shape.ToArray());
     }
 
     [Fact]
     public async Task MnistNCHW_Shape_Is_B1_28_28()
     {
+        if (!MnistCacheExists()) return;
         var loader = new MnistDataLoader<float>(new MnistDataLoaderOptions
         {
             Split = DatasetSplit.Train,
-            AutoDownload = true,
+            AutoDownload = false,
             MaxSamples = 2,
             Layout = ImageTensorLayout.NCHW,
         });
         await loader.LoadAsync();
         var batch = loader.GetBatches(batchSize: 2).First();
-        var shape = batch.Features.Shape.ToArray();
-        Assert.Equal(4, shape.Length);
-        Assert.Equal(2, shape[0]);
-        Assert.Equal(1, shape[1]);
-        Assert.Equal(28, shape[2]);
-        Assert.Equal(28, shape[3]);
+        Assert.Equal(new[] { 2, 1, 28, 28 }, batch.Features.Shape.ToArray());
     }
 
     [Fact]
     public async Task MnistFlatten_IgnoresLayout()
     {
+        if (!MnistCacheExists()) return;
         var loader = new MnistDataLoader<float>(new MnistDataLoaderOptions
         {
             Split = DatasetSplit.Train,
-            AutoDownload = true,
+            AutoDownload = false,
             MaxSamples = 2,
             Flatten = true,
             Layout = ImageTensorLayout.NCHW,
         });
         await loader.LoadAsync();
         var batch = loader.GetBatches(batchSize: 2).First();
-        var shape = batch.Features.Shape.ToArray();
-        Assert.Equal(2, shape.Length);
-        Assert.Equal(2, shape[0]);
-        Assert.Equal(784, shape[1]);
+        Assert.Equal(new[] { 2, 784 }, batch.Features.Shape.ToArray());
     }
 }

--- a/tests/AiDotNet.Tests/Data/ImageTensorLayoutTests.cs
+++ b/tests/AiDotNet.Tests/Data/ImageTensorLayoutTests.cs
@@ -2,26 +2,33 @@ using AiDotNet.Data;
 using AiDotNet.Data.Geometry;
 using AiDotNet.Data.Vision.Benchmarks;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace AiDotNetTests.Data;
 
 /// <summary>
 /// Tests for the ImageTensorLayout option on vision data loaders.
-/// Uses AutoDownload=false + skips if MNIST isn't cached locally,
-/// so these tests never hit the network and are CI-safe.
+/// Uses AutoDownload=false; logs a skip message when MNIST isn't cached.
 /// </summary>
 public class ImageTensorLayoutTests
 {
-    private static bool MnistCacheExists()
+    private readonly ITestOutputHelper _output;
+
+    public ImageTensorLayoutTests(ITestOutputHelper output) => _output = output;
+
+    private bool RequireMnistCache()
     {
         string cachePath = DatasetDownloader.GetDefaultDataPath("mnist");
-        return File.Exists(Path.Combine(cachePath, "train-images-idx3-ubyte"));
+        if (File.Exists(Path.Combine(cachePath, "train-images-idx3-ubyte")))
+            return true;
+        _output.WriteLine("SKIPPED: MNIST not cached locally. Run with AutoDownload=true once to populate.");
+        return false;
     }
 
     [Fact]
     public async Task MnistNHWC_DefaultShape_Is_B28281()
     {
-        if (!MnistCacheExists()) return;
+        if (!RequireMnistCache()) return;
         var loader = new MnistDataLoader<float>(new MnistDataLoaderOptions
         {
             Split = DatasetSplit.Train,
@@ -36,7 +43,7 @@ public class ImageTensorLayoutTests
     [Fact]
     public async Task MnistNCHW_Shape_Is_B1_28_28()
     {
-        if (!MnistCacheExists()) return;
+        if (!RequireMnistCache()) return;
         var loader = new MnistDataLoader<float>(new MnistDataLoaderOptions
         {
             Split = DatasetSplit.Train,
@@ -52,7 +59,7 @@ public class ImageTensorLayoutTests
     [Fact]
     public async Task MnistFlatten_IgnoresLayout()
     {
-        if (!MnistCacheExists()) return;
+        if (!RequireMnistCache()) return;
         var loader = new MnistDataLoader<float>(new MnistDataLoaderOptions
         {
             Split = DatasetSplit.Train,
@@ -64,5 +71,31 @@ public class ImageTensorLayoutTests
         await loader.LoadAsync();
         var batch = loader.GetBatches(batchSize: 2).First();
         Assert.Equal(new[] { 2, 784 }, batch.Features.Shape.ToArray());
+    }
+
+    private bool RequireCifar10Cache()
+    {
+        string cachePath = DatasetDownloader.GetDefaultDataPath("cifar-10");
+        bool exists = Directory.Exists(cachePath) &&
+            Directory.GetFiles(cachePath, "data_batch*").Length > 0;
+        if (!exists)
+            _output.WriteLine("SKIPPED: CIFAR-10 not cached locally.");
+        return exists;
+    }
+
+    [Fact]
+    public async Task Cifar10NCHW_Shape_Is_B3_32_32()
+    {
+        if (!RequireCifar10Cache()) return;
+        var loader = new Cifar10DataLoader<float>(new Cifar10DataLoaderOptions
+        {
+            Split = DatasetSplit.Train,
+            AutoDownload = false,
+            MaxSamples = 2,
+            Layout = ImageTensorLayout.NCHW,
+        });
+        await loader.LoadAsync();
+        var batch = loader.GetBatches(batchSize: 2).First();
+        Assert.Equal(new[] { 2, 3, 32, 32 }, batch.Features.Shape.ToArray());
     }
 }

--- a/tests/AiDotNet.Tests/Data/ImageTensorLayoutTests.cs
+++ b/tests/AiDotNet.Tests/Data/ImageTensorLayoutTests.cs
@@ -2,53 +2,51 @@ using AiDotNet.Data;
 using AiDotNet.Data.Geometry;
 using AiDotNet.Data.Vision.Benchmarks;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace AiDotNetTests.Data;
 
 /// <summary>
 /// Tests for the ImageTensorLayout option on vision data loaders.
-/// Uses AutoDownload=false; logs explicit SKIP when data isn't cached.
+/// Uses AutoDownload=false and SkippableFact — reports as SKIP (not PASS)
+/// when datasets aren't cached, so CI output clearly shows missing coverage.
 /// </summary>
 public class ImageTensorLayoutTests
 {
-    private readonly ITestOutputHelper _output;
-
-    public ImageTensorLayoutTests(ITestOutputHelper output) => _output = output;
-
-    private bool RequireMnistCache()
+    private static bool MnistCacheExists()
     {
         string cachePath = DatasetDownloader.GetDefaultDataPath("mnist");
-        if (File.Exists(Path.Combine(cachePath, "train-images-idx3-ubyte")))
-            return true;
-        _output.WriteLine("SKIPPED: MNIST not cached. Run once with AutoDownload=true to populate.");
-        return false;
+        return File.Exists(Path.Combine(cachePath, "train-images-idx3-ubyte"))
+            && File.Exists(Path.Combine(cachePath, "train-labels-idx1-ubyte"));
     }
 
-    [Fact]
+    private static bool Cifar10CacheExists()
+    {
+        string cachePath = DatasetDownloader.GetDefaultDataPath("cifar-10");
+        string batchesDir = Path.Combine(cachePath, "cifar-10-batches-bin");
+        return (Directory.Exists(cachePath) && Directory.GetFiles(cachePath, "data_batch*").Length > 0)
+            || (Directory.Exists(batchesDir) && Directory.GetFiles(batchesDir, "data_batch*").Length > 0);
+    }
+
+    [SkippableFact]
     public async Task MnistNHWC_DefaultShape_Is_B28281()
     {
-        if (!RequireMnistCache()) return;
+        Skip.IfNot(MnistCacheExists(), "MNIST not cached locally");
         var loader = new MnistDataLoader<float>(new MnistDataLoaderOptions
         {
-            Split = DatasetSplit.Train,
-            AutoDownload = false,
-            MaxSamples = 2,
+            Split = DatasetSplit.Train, AutoDownload = false, MaxSamples = 2,
         });
         await loader.LoadAsync();
         var batch = loader.GetBatches(batchSize: 2).First();
         Assert.Equal(new[] { 2, 28, 28, 1 }, batch.Features.Shape.ToArray());
     }
 
-    [Fact]
+    [SkippableFact]
     public async Task MnistNCHW_Shape_Is_B1_28_28()
     {
-        if (!RequireMnistCache()) return;
+        Skip.IfNot(MnistCacheExists(), "MNIST not cached locally");
         var loader = new MnistDataLoader<float>(new MnistDataLoaderOptions
         {
-            Split = DatasetSplit.Train,
-            AutoDownload = false,
-            MaxSamples = 2,
+            Split = DatasetSplit.Train, AutoDownload = false, MaxSamples = 2,
             Layout = ImageTensorLayout.NCHW,
         });
         await loader.LoadAsync();
@@ -56,48 +54,31 @@ public class ImageTensorLayoutTests
         Assert.Equal(new[] { 2, 1, 28, 28 }, batch.Features.Shape.ToArray());
     }
 
-    [Fact]
+    [SkippableFact]
     public async Task MnistFlatten_IgnoresLayout()
     {
-        if (!RequireMnistCache()) return;
+        Skip.IfNot(MnistCacheExists(), "MNIST not cached locally");
         var loader = new MnistDataLoader<float>(new MnistDataLoaderOptions
         {
-            Split = DatasetSplit.Train,
-            AutoDownload = false,
-            MaxSamples = 2,
-            Flatten = true,
-            Layout = ImageTensorLayout.NCHW,
+            Split = DatasetSplit.Train, AutoDownload = false, MaxSamples = 2,
+            Flatten = true, Layout = ImageTensorLayout.NCHW,
         });
         await loader.LoadAsync();
         var batch = loader.GetBatches(batchSize: 2).First();
         Assert.Equal(new[] { 2, 784 }, batch.Features.Shape.ToArray());
     }
 
-    private bool RequireCifar10Cache()
-    {
-        string cachePath = DatasetDownloader.GetDefaultDataPath("cifar-10");
-        string batchesDir = Path.Combine(cachePath, "cifar-10-batches-bin");
-        bool exists = (Directory.Exists(cachePath) && Directory.GetFiles(cachePath, "data_batch*").Length > 0)
-            || (Directory.Exists(batchesDir) && Directory.GetFiles(batchesDir, "data_batch*").Length > 0);
-        if (!exists)
-            _output.WriteLine("SKIPPED: CIFAR-10 not cached locally.");
-        return exists;
-    }
-
-    [Fact]
+    [SkippableFact]
     public async Task Cifar10NCHW_ShapeAndChannelOrder()
     {
-        if (!RequireCifar10Cache()) return;
+        Skip.IfNot(Cifar10CacheExists(), "CIFAR-10 not cached locally");
         var loader = new Cifar10DataLoader<float>(new Cifar10DataLoaderOptions
         {
-            Split = DatasetSplit.Train,
-            AutoDownload = false,
-            MaxSamples = 2,
-            Normalize = false,
-            Layout = ImageTensorLayout.NCHW,
+            Split = DatasetSplit.Train, AutoDownload = false, MaxSamples = 1,
+            Normalize = false, Layout = ImageTensorLayout.NCHW,
         });
         await loader.LoadAsync();
-        var batch = loader.GetBatches(batchSize: 2).First();
-        Assert.Equal(new[] { 2, 3, 32, 32 }, batch.Features.Shape.ToArray());
+        var batch = loader.GetBatches(batchSize: 1).First();
+        Assert.Equal(new[] { 1, 3, 32, 32 }, batch.Features.Shape.ToArray());
     }
 }


### PR DESCRIPTION
## Summary

Adds `ImageTensorLayout` enum and `Layout` property to all major vision data loaders so consumers can request NCHW `[B, C, H, W]` tensors directly.

Closes #1109

## Changes

- **New:** `ImageTensorLayout` enum (`NHWC`, `NCHW`)
- **MnistDataLoader:** `Layout` property (NCHW is shape-only for single channel)
- **FashionMnistDataLoader:** Same as MNIST
- **Cifar10DataLoader:** `Layout` property, NCHW keeps native CHW byte order
- **Cifar100DataLoader:** Same as CIFAR-10
- **EuroSatDataLoader:** `Layout` property, NCHW remaps HWC pixels from VisionLoaderHelper to CHW
- **Tests:** 5 SkippableFact tests with zero-allocation shape assertions
- **Tensors bump:** 0.30.1 → 0.35.0
- **CI fix:** Narrowed artifact upload glob (was timing out on **/obj/)

## Test plan

- [x] Build succeeds (net10.0 + net471)
- [x] Zero-allocation shape checks via Shape[i] indexer
- [x] Explicit enumerator + MoveNext (no .First() on potentially empty)
- [x] Tests report SKIP when datasets aren't cached

🤖 Generated with [Claude Code](https://claude.com/claude-code)