### PR TITLE
feat: Add Google Speech Commands v2 data loader

### DIFF
--- a/src/Data/Audio/Benchmarks/SpeechCommandsDataLoader.cs
+++ b/src/Data/Audio/Benchmarks/SpeechCommandsDataLoader.cs
@@ -247,6 +247,13 @@ public class SpeechCommandsDataLoader<T> : InputOutputDataLoaderBase<T, Tensor<T
             foreach (string nonCoreWord in AllWordsArray)
             {
                 if (coreSet.Contains(nonCoreWord)) continue;
+                // Cap already hit from a prior non-core word — stop enumerating
+                // remaining directories entirely rather than opening each one just to
+                // immediately `break` out of its inner loop.
+                if (_options.MaxSamplesPerClass.HasValue &&
+                    classCounts[_unknownClassIndex] >= _options.MaxSamplesPerClass.Value)
+                    break;
+
                 string wordDir = Path.Combine(_dataPath, nonCoreWord);
                 if (!Directory.Exists(wordDir)) continue;
 
@@ -459,8 +466,10 @@ public class SpeechCommandsDataLoader<T> : InputOutputDataLoaderBase<T, Tensor<T
             // _silence_ class. Slice a distinct crop of one of the background-noise
             // WAVs using a deterministic per-sample offset (derived from SyntheticIndex)
             // so that consecutive silence samples are NOT duplicate prefixes of the
-            // same waveform. When no background-noise directory is present, leave the
-            // destination zero-filled — pure silence is still a valid training input.
+            // same waveform. Normal loading always populates _backgroundNoiseFiles
+            // (LoadDataCoreAsync fails fast when _background_noise_/ is empty) — the
+            // zero-fill branch below is only a defensive fallback for states where
+            // no silence entries could have been emitted in the first place.
             if (_backgroundNoiseFiles is { Count: > 0 })
             {
                 int fileIdx = entry.SyntheticIndex % _backgroundNoiseFiles.Count;
@@ -487,8 +496,13 @@ public class SpeechCommandsDataLoader<T> : InputOutputDataLoaderBase<T, Tensor<T
                 if (noiseBuffer.Length > nativeWindow)
                 {
                     int maxOffset = noiseBuffer.Length - nativeWindow;
+                    // Modulo (maxOffset + 1) — maxOffset is itself a *valid* starting
+                    // offset, so the cohort range must be inclusive of it. Using
+                    // `% maxOffset` excluded the last valid window and biased the
+                    // sampler away from the tail of each background file.
+                    int offsetRange = maxOffset + 1;
                     int cohort = entry.SyntheticIndex / _backgroundNoiseFiles.Count;
-                    cropOffsetNative = (cohort * SilenceCropHopNativeSamples) % Math.Max(1, maxOffset);
+                    cropOffsetNative = (cohort * SilenceCropHopNativeSamples) % offsetRange;
                 }
 
                 ResampleIntoDestination(noiseBuffer, cropOffsetNative, dst, dstOffset, targetLen, nativeRate, targetRate);

--- a/src/Data/Audio/Benchmarks/SpeechCommandsDataLoader.cs
+++ b/src/Data/Audio/Benchmarks/SpeechCommandsDataLoader.cs
@@ -54,16 +54,23 @@ public class SpeechCommandsDataLoader<T> : InputOutputDataLoaderBase<T, Tensor<T
     public static readonly string DownloadUrl =
         "https://download.tensorflow.org/data/speech_commands_v0.02.tar.gz";
 
-    /// <summary>Core 10 spoken words (the standard benchmark subset).</summary>
-    public static readonly string[] CoreWords =
+    // Internal backing arrays — NEVER expose these directly. The public API exposes
+    // IReadOnlyList<string> views so callers can't mutate (or cast-then-mutate) the
+    // canonical class ordering, which would corrupt directory → class-index mapping
+    // for every loader instance.
+    private static readonly string[] CoreWordsArray =
         ["yes", "no", "up", "down", "left", "right", "on", "off", "stop", "go"];
-
-    /// <summary>All 35 word classes in the full dataset.</summary>
-    public static readonly string[] AllWords =
+    private static readonly string[] AllWordsArray =
         ["backward", "bed", "bird", "cat", "dog", "down", "eight", "five", "follow",
          "forward", "four", "go", "happy", "house", "learn", "left", "marvin", "nine",
          "no", "off", "on", "one", "right", "seven", "sheila", "six", "stop", "three",
          "tree", "two", "up", "visual", "wow", "yes", "zero"];
+
+    /// <summary>Core 10 spoken words (the standard benchmark subset). Read-only view.</summary>
+    public static IReadOnlyList<string> CoreWords { get; } = Array.AsReadOnly(CoreWordsArray);
+
+    /// <summary>All 35 word classes in the full dataset. Read-only view.</summary>
+    public static IReadOnlyList<string> AllWords { get; } = Array.AsReadOnly(AllWordsArray);
 
     /// <summary>Synthetic class label for non-keyword speech in the 12-class subset.</summary>
     public const string UnknownLabel = "_unknown_";
@@ -87,6 +94,23 @@ public class SpeechCommandsDataLoader<T> : InputOutputDataLoaderBase<T, Tensor<T
     // memory, which is what makes the full 35-class path safe on commodity hardware.
     private readonly List<SampleEntry> _samples = new();
     private List<string>? _backgroundNoiseFiles; // null until LoadDataCoreAsync runs
+
+    // Lazy cache of fully-decoded background-noise waveforms, keyed by file path.
+    // Each entry holds the full native-rate decoded audio as a T[] so synthetic
+    // silence samples can be sliced at distinct offsets without reloading from disk.
+    private readonly Dictionary<string, T[]> _backgroundNoiseBuffers = new();
+
+    // How many native samples we pre-decode from each background-noise WAV. Speech
+    // Commands background files are ~60 s at 16 kHz; 30 s is more than enough to
+    // give us many distinct 1-second crops per file while keeping the cache small
+    // (~1.8 MB per file for float32).
+    private const int BackgroundNoisePrefetchSamples = 30 * SpeechCommandsDataLoaderOptions.NativeSampleRate;
+
+    // Step between consecutive silence crop offsets, in native-rate samples.
+    // 0.5 s gives plenty of variety (60 unique crops per 30-second buffer) while
+    // still leaving the crops partially overlapping — the benchmark expects
+    // neighboring noise windows to look similar, not i.i.d.
+    private const int SilenceCropHopNativeSamples = SpeechCommandsDataLoaderOptions.NativeSampleRate / 2;
 
     /// <inheritdoc/>
     public override string Name => "SpeechCommands";
@@ -121,16 +145,21 @@ public class SpeechCommandsDataLoader<T> : InputOutputDataLoaderBase<T, Tensor<T
         if (_options.UseCoreSubset)
         {
             // Per Warden 2018: 10 keywords + silence + unknown = 12 classes.
-            _wordList = new string[CoreWords.Length + 2];
-            Array.Copy(CoreWords, _wordList, CoreWords.Length);
-            _wordList[CoreWords.Length] = SilenceLabel;
-            _wordList[CoreWords.Length + 1] = UnknownLabel;
-            _silenceClassIndex = CoreWords.Length;
-            _unknownClassIndex = CoreWords.Length + 1;
+            // Use the internal array directly to avoid paying for ReadOnlyCollection
+            // enumerator overhead on a hot path that runs once per loader.
+            int coreLen = CoreWordsArray.Length;
+            _wordList = new string[coreLen + 2];
+            Array.Copy(CoreWordsArray, _wordList, coreLen);
+            _wordList[coreLen] = SilenceLabel;
+            _wordList[coreLen + 1] = UnknownLabel;
+            _silenceClassIndex = coreLen;
+            _unknownClassIndex = coreLen + 1;
         }
         else
         {
-            _wordList = AllWords;
+            // Clone so an external caller can't mutate our internal AllWordsArray via
+            // any side-channel that might cast _wordList back to string[].
+            _wordList = (string[])AllWordsArray.Clone();
             _silenceClassIndex = -1;
             _unknownClassIndex = -1;
         }
@@ -175,7 +204,7 @@ public class SpeechCommandsDataLoader<T> : InputOutputDataLoaderBase<T, Tensor<T
         var classCounts = new int[_numClasses];
 
         // 3a) Keyword classes (10 in core mode, 35 in full mode).
-        int keywordEnd = _options.UseCoreSubset ? CoreWords.Length : _wordList.Length;
+        int keywordEnd = _options.UseCoreSubset ? CoreWordsArray.Length : _wordList.Length;
         for (int c = 0; c < keywordEnd; c++)
         {
             string word = _wordList[c];
@@ -190,7 +219,13 @@ public class SpeechCommandsDataLoader<T> : InputOutputDataLoaderBase<T, Tensor<T
 
                 if (_options.MaxSamplesPerClass.HasValue &&
                     classCounts[c] >= _options.MaxSamplesPerClass.Value)
-                    continue;
+                {
+                    // Cap reached for this class — stop scanning the rest of the
+                    // directory (tens of thousands of files for some classes).
+                    // `continue` here would keep iterating the full Directory.GetFiles
+                    // result set, wasting IO and startup time for no benefit.
+                    break;
+                }
 
                 _samples.Add(new SampleEntry(wavFile, c, SampleSource.WavFile));
                 classCounts[c]++;
@@ -200,8 +235,8 @@ public class SpeechCommandsDataLoader<T> : InputOutputDataLoaderBase<T, Tensor<T
         // 3b) Synthetic _unknown_ class: collapse every non-core word directory.
         if (_options.UseCoreSubset && _unknownClassIndex >= 0)
         {
-            var coreSet = new HashSet<string>(CoreWords, StringComparer.OrdinalIgnoreCase);
-            foreach (string nonCoreWord in AllWords)
+            var coreSet = new HashSet<string>(CoreWordsArray, StringComparer.OrdinalIgnoreCase);
+            foreach (string nonCoreWord in AllWordsArray)
             {
                 if (coreSet.Contains(nonCoreWord)) continue;
                 string wordDir = Path.Combine(_dataPath, nonCoreWord);
@@ -325,7 +360,16 @@ public class SpeechCommandsDataLoader<T> : InputOutputDataLoaderBase<T, Tensor<T
         for (int i = 0; i < indices.Length; i++)
         {
             int sampleIdx = indices[i];
-            if (sampleIdx < 0 || sampleIdx >= _samples.Count) continue;
+            if (sampleIdx < 0 || sampleIdx >= _samples.Count)
+            {
+                // Fail loud on an out-of-range index — silently skipping would leave
+                // this batch row zero-filled while the corresponding label row is
+                // whatever random class happens to sit at index i in the label
+                // tensor. That's a data/logic bug we never want to mask.
+                throw new ArgumentOutOfRangeException(
+                    nameof(indices),
+                    $"Index {sampleIdx} at position {i} is outside the valid range [0, {_samples.Count - 1}].");
+            }
 
             var entry = _samples[sampleIdx];
             DecodeSampleInto(entry, featuresData, i * targetLen, targetLen);
@@ -350,40 +394,89 @@ public class SpeechCommandsDataLoader<T> : InputOutputDataLoaderBase<T, Tensor<T
 
         if (entry.Source == SampleSource.Silence)
         {
-            // _silence_ class. If background noise files are available, sample a
-            // random crop of one of them; otherwise leave the slot zero-filled
-            // (acceptable degenerate behavior — pure silence is still valid input).
+            // _silence_ class. Slice a distinct crop of one of the background-noise
+            // WAVs using a deterministic per-sample offset (derived from SyntheticIndex)
+            // so that consecutive silence samples are NOT duplicate prefixes of the
+            // same waveform. When no background-noise directory is present, leave the
+            // destination zero-filled — pure silence is still a valid training input.
             if (_backgroundNoiseFiles is { Count: > 0 })
             {
-                // Deterministic per-sample picker so reload + reshuffle yields stable
-                // training data (the dataset class index alone disambiguates samples,
-                // and we want the test fixture to be reproducible).
                 int fileIdx = entry.SyntheticIndex % _backgroundNoiseFiles.Count;
                 string path = _backgroundNoiseFiles[fileIdx];
-                if (File.Exists(path))
+                if (!File.Exists(path))
                 {
-                    DecodeFileWithResample(path, dst, dstOffset, targetLen, nativeRate, targetRate);
+                    // Expected synthesized-silence source file is gone — surface this
+                    // explicitly rather than silently emitting a zero-filled row that
+                    // would pose as a legitimate silence label.
+                    throw new FileNotFoundException(
+                        $"Expected background-noise WAV was not found while decoding a synthetic _silence_ sample: '{path}'.",
+                        path);
                 }
+
+                var noiseBuffer = GetOrLoadBackgroundNoiseBuffer(path);
+
+                // Derive a deterministic native-rate crop offset so each SyntheticIndex
+                // produces a DIFFERENT 1-second window. Using integer division by the
+                // file count means the first `files.Count` silence samples each pick
+                // offset 0 (one per file), the next cohort picks offset
+                // SilenceCropHopNativeSamples, and so on.
+                int nativeWindow = checked((int)Math.Ceiling((double)targetLen * nativeRate / targetRate)) + 1;
+                int cropOffsetNative = 0;
+                if (noiseBuffer.Length > nativeWindow)
+                {
+                    int maxOffset = noiseBuffer.Length - nativeWindow;
+                    int cohort = entry.SyntheticIndex / _backgroundNoiseFiles.Count;
+                    cropOffsetNative = (cohort * SilenceCropHopNativeSamples) % Math.Max(1, maxOffset);
+                }
+
+                ResampleIntoDestination(noiseBuffer, cropOffsetNative, dst, dstOffset, targetLen, nativeRate, targetRate);
             }
             // Else: dst[dstOffset..dstOffset+targetLen] stays at default(T) which is 0.
             return;
         }
 
-        if (!File.Exists(entry.AudioPath)) return;
-        DecodeFileWithResample(entry.AudioPath, dst, dstOffset, targetLen, nativeRate, targetRate);
+        if (!File.Exists(entry.AudioPath))
+        {
+            // Loader scanned this file during LoadAsync but it disappeared before
+            // ExtractBatch reached it. Silent zero-fill would mislabel the row as
+            // "real class + silence waveform" — throw instead so the data issue is
+            // visible to the caller.
+            throw new FileNotFoundException(
+                $"Expected Speech Commands WAV file was not found during batch decoding: '{entry.AudioPath}'. " +
+                "The file may have been removed or renamed after LoadAsync scanned the dataset.",
+                entry.AudioPath);
+        }
+        byte[] audioBytes = File.ReadAllBytes(entry.AudioPath);
+        DecodeBytesWithResample(audioBytes, dst, dstOffset, targetLen, nativeRate, targetRate);
     }
 
     /// <summary>
-    /// Decodes a WAV file and writes <paramref name="targetLen"/> samples into
-    /// <paramref name="dst"/> starting at <paramref name="dstOffset"/>, resampling
-    /// from <paramref name="nativeRate"/> to <paramref name="targetRate"/> via
-    /// linear interpolation when the rates differ.
+    /// Returns a cached fully-decoded waveform for the given background-noise file,
+    /// loading and caching it on first access. All synthetic _silence_ samples for a
+    /// particular background file share this buffer so per-sample crop offsets can be
+    /// sliced without repeated file I/O or WAV decoding.
     /// </summary>
-    private void DecodeFileWithResample(
-        string path, T[] dst, int dstOffset, int targetLen, int nativeRate, int targetRate)
+    private T[] GetOrLoadBackgroundNoiseBuffer(string path)
     {
-        byte[] audioBytes = File.ReadAllBytes(path);
+        if (_backgroundNoiseBuffers.TryGetValue(path, out var cached))
+            return cached;
 
+        byte[] audioBytes = File.ReadAllBytes(path);
+        var buffer = new T[BackgroundNoisePrefetchSamples];
+        AudioLoaderHelper.LoadAudioSamples(audioBytes, buffer, 0, BackgroundNoisePrefetchSamples, NumOps);
+        _backgroundNoiseBuffers[path] = buffer;
+        return buffer;
+    }
+
+    /// <summary>
+    /// Decodes a WAV byte payload, then writes <paramref name="targetLen"/> samples
+    /// into <paramref name="dst"/> starting at <paramref name="dstOffset"/>, resampling
+    /// from <paramref name="nativeRate"/> to <paramref name="targetRate"/> via linear
+    /// interpolation when the rates differ.
+    /// </summary>
+    private void DecodeBytesWithResample(
+        byte[] audioBytes, T[] dst, int dstOffset, int targetLen, int nativeRate, int targetRate)
+    {
         if (nativeRate == targetRate)
         {
             // Fast path: no resampling, decode straight into the destination buffer.
@@ -397,12 +490,35 @@ public class SpeechCommandsDataLoader<T> : InputOutputDataLoaderBase<T, Tensor<T
         int neededNative = checked((int)Math.Ceiling((double)targetLen * nativeRate / targetRate)) + 1;
         var nativeBuf = new T[neededNative];
         AudioLoaderHelper.LoadAudioSamples(audioBytes, nativeBuf, 0, neededNative, NumOps);
+        ResampleIntoDestination(nativeBuf, nativeOffset: 0, dst, dstOffset, targetLen, nativeRate, targetRate);
+    }
+
+    /// <summary>
+    /// Linear-interpolation resample of <paramref name="nativeBuf"/> starting at
+    /// <paramref name="nativeOffset"/> into <paramref name="dst"/>[<paramref name="dstOffset"/>..].
+    /// When <paramref name="nativeRate"/> equals <paramref name="targetRate"/> this
+    /// collapses to a plain copy loop (still honors nativeOffset for silence crops).
+    /// </summary>
+    private void ResampleIntoDestination(
+        T[] nativeBuf, int nativeOffset, T[] dst, int dstOffset, int targetLen, int nativeRate, int targetRate)
+    {
+        int lastIdx = nativeBuf.Length - 1;
+        if (nativeRate == targetRate)
+        {
+            // No resampling — still respect the offset (used for silence crops).
+            for (int t = 0; t < targetLen; t++)
+            {
+                int idx = nativeOffset + t;
+                if (idx > lastIdx) idx = lastIdx;
+                dst[dstOffset + t] = nativeBuf[idx];
+            }
+            return;
+        }
 
         double rateRatio = (double)nativeRate / targetRate;
-        int lastIdx = neededNative - 1;
         for (int t = 0; t < targetLen; t++)
         {
-            double srcPos = t * rateRatio;
+            double srcPos = nativeOffset + t * rateRatio;
             int floorIdx = (int)Math.Floor(srcPos);
             int ceilIdx = floorIdx + 1;
             if (floorIdx > lastIdx) floorIdx = lastIdx;
@@ -416,6 +532,18 @@ public class SpeechCommandsDataLoader<T> : InputOutputDataLoaderBase<T, Tensor<T
     }
 
     /// <inheritdoc/>
+    /// <remarks>
+    /// Speech Commands is a streaming loader — see class remarks. Splitting the full
+    /// dataset via this base-class API would require eagerly decoding every clip into
+    /// a contiguous <c>Tensor&lt;T&gt;</c>, which is ~4 GB of float32 features for the
+    /// 35-class mode (or ~500 MB for a 70 % train split). That would defeat the whole
+    /// reason the loader went streaming in the first place, and would quietly OOM on
+    /// commodity hardware. Use the dataset's official Train/Validation/Test splits
+    /// via the <c>DatasetSplit</c> option + one loader per split, or iterate
+    /// <see cref="GetBatches"/>/<see cref="GetBatchesAsync"/> directly and partition
+    /// indices yourself.
+    /// </remarks>
+    /// <exception cref="NotSupportedException">Always thrown — see remarks.</exception>
     public override (IInputOutputDataLoader<T, Tensor<T>, Tensor<T>> Train,
         IInputOutputDataLoader<T, Tensor<T>, Tensor<T>> Validation,
         IInputOutputDataLoader<T, Tensor<T>, Tensor<T>> Test) Split(
@@ -423,30 +551,13 @@ public class SpeechCommandsDataLoader<T> : InputOutputDataLoaderBase<T, Tensor<T
         double validationRatio = 0.15,
         int? seed = null)
     {
-        EnsureLoaded();
-        ValidateSplitRatios(trainRatio, validationRatio);
-        var (trainSize, valSize, _) = ComputeSplitSizes(_sampleCount, trainRatio, validationRatio);
-        var random = seed.HasValue
-            ? Tensors.Helpers.RandomHelper.CreateSeededRandom(seed.Value)
-            : Tensors.Helpers.RandomHelper.CreateSecureRandom();
-        var shuffled = Enumerable.Range(0, _sampleCount).OrderBy(_ => random.Next()).ToArray();
-
-        var trainIdx = shuffled.Take(trainSize).ToArray();
-        var valIdx = shuffled.Skip(trainSize).Take(valSize).ToArray();
-        var testIdx = shuffled.Skip(trainSize + valSize).ToArray();
-
-        // Each split eagerly materializes its own (smaller) batch — this is fine for
-        // typical 70/15/15 splits because the per-split memory is bounded by
-        // splitSize * targetLength, which is much smaller than the full-dataset case.
-        var trainBatch = ExtractBatch(trainIdx);
-        var valBatch = ExtractBatch(valIdx);
-        var testBatch = ExtractBatch(testIdx);
-
-        return (
-            new InMemoryDataLoader<T, Tensor<T>, Tensor<T>>(trainBatch.Features, trainBatch.Labels),
-            new InMemoryDataLoader<T, Tensor<T>, Tensor<T>>(valBatch.Features, valBatch.Labels),
-            new InMemoryDataLoader<T, Tensor<T>, Tensor<T>>(testBatch.Features, testBatch.Labels)
-        );
+        throw new NotSupportedException(
+            "SpeechCommandsDataLoader is a streaming loader — Split() is not supported because " +
+            "it would eagerly decode and materialize every clip into memory (~4 GB for the full " +
+            "35-class dataset), defeating the point of streaming. " +
+            "Instead: construct separate loaders with SpeechCommandsDataLoaderOptions.Split set to " +
+            "Train / Validation / Test (which honours the official Warden 2018 split lists), or " +
+            "iterate GetBatches()/GetBatchesAsync() and partition indices yourself.");
     }
 
     /// <summary>What kind of source a particular sample entry references.</summary>

--- a/src/Data/Audio/Benchmarks/SpeechCommandsDataLoader.cs
+++ b/src/Data/Audio/Benchmarks/SpeechCommandsDataLoader.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using AiDotNet.Data;
 using AiDotNet.Data.Geometry;
 using AiDotNet.Data.Loaders;
@@ -87,6 +88,7 @@ public class SpeechCommandsDataLoader<T> : InputOutputDataLoaderBase<T, Tensor<T
     private int _sampleCount;
     private readonly int _numClasses;
     private readonly string[] _wordList;
+    private readonly IReadOnlyList<string> _wordListReadOnly; // cached AsReadOnly wrapper
     private readonly int _silenceClassIndex; // -1 when not in 12-class core mode
     private readonly int _unknownClassIndex; // -1 when not in 12-class core mode
 
@@ -99,7 +101,10 @@ public class SpeechCommandsDataLoader<T> : InputOutputDataLoaderBase<T, Tensor<T
     // Lazy cache of fully-decoded background-noise waveforms, keyed by file path.
     // Each entry holds the full native-rate decoded audio as a T[] so synthetic
     // silence samples can be sliced at distinct offsets without reloading from disk.
-    private readonly Dictionary<string, T[]> _backgroundNoiseBuffers = new();
+    // ConcurrentDictionary because ExtractBatch is called from parallel batch
+    // prefetchers and multi-threaded input pipelines — a plain Dictionary would
+    // race between concurrent silence-decode calls.
+    private readonly ConcurrentDictionary<string, T[]> _backgroundNoiseBuffers = new();
 
     // How many native samples we pre-decode from each background-noise WAV. Speech
     // Commands background files are ~60 s at 16 kHz; 30 s is more than enough to
@@ -137,9 +142,10 @@ public class SpeechCommandsDataLoader<T> : InputOutputDataLoaderBase<T, Tensor<T
     /// <remarks>
     /// Wrapped via <see cref="Array.AsReadOnly{T}(T[])"/> so callers can't downcast back to
     /// <c>string[]</c> and mutate the canonical class ordering — that would corrupt the
-    /// directory→class-index mapping for every loader instance.
+    /// directory→class-index mapping for every loader instance. The wrapper is cached in
+    /// the constructor so repeated <see cref="WordList"/> access doesn't re-allocate.
     /// </remarks>
-    public IReadOnlyList<string> WordList => Array.AsReadOnly(_wordList);
+    public IReadOnlyList<string> WordList => _wordListReadOnly;
 
     /// <summary>Creates a new Speech Commands data loader.</summary>
     public SpeechCommandsDataLoader(SpeechCommandsDataLoaderOptions? options = null)
@@ -170,6 +176,7 @@ public class SpeechCommandsDataLoader<T> : InputOutputDataLoaderBase<T, Tensor<T
             _unknownClassIndex = -1;
         }
         _numClasses = _wordList.Length;
+        _wordListReadOnly = Array.AsReadOnly(_wordList);
     }
 
     /// <inheritdoc/>
@@ -534,14 +541,17 @@ public class SpeechCommandsDataLoader<T> : InputOutputDataLoaderBase<T, Tensor<T
     /// </summary>
     private T[] GetOrLoadBackgroundNoiseBuffer(string path)
     {
-        if (_backgroundNoiseBuffers.TryGetValue(path, out var cached))
-            return cached;
-
-        byte[] audioBytes = File.ReadAllBytes(path);
-        var buffer = new T[BackgroundNoisePrefetchSamples];
-        AudioLoaderHelper.LoadAudioSamples(audioBytes, buffer, 0, BackgroundNoisePrefetchSamples, NumOps);
-        _backgroundNoiseBuffers[path] = buffer;
-        return buffer;
+        // GetOrAdd is atomic across concurrent callers; the value factory may run
+        // more than once for the same key under heavy contention, but only one
+        // result is installed. That's acceptable here — duplicate decode work is
+        // bounded (a few MB) and cheaper than holding a lock across file I/O.
+        return _backgroundNoiseBuffers.GetOrAdd(path, p =>
+        {
+            byte[] audioBytes = File.ReadAllBytes(p);
+            var buffer = new T[BackgroundNoisePrefetchSamples];
+            AudioLoaderHelper.LoadAudioSamples(audioBytes, buffer, 0, BackgroundNoisePrefetchSamples, NumOps);
+            return buffer;
+        });
     }
 
     /// <summary>
@@ -596,11 +606,13 @@ public class SpeechCommandsDataLoader<T> : InputOutputDataLoaderBase<T, Tensor<T
         {
             double srcPos = nativeOffset + t * rateRatio;
             int floorIdx = (int)Math.Floor(srcPos);
+            // frac = srcPos - floor(srcPos); reuse floorIdx to avoid a second
+            // Math.Floor call per sample in this hot resampling loop.
+            double frac = srcPos - floorIdx;
             int ceilIdx = floorIdx + 1;
             if (floorIdx > lastIdx) floorIdx = lastIdx;
             if (ceilIdx > lastIdx) ceilIdx = lastIdx;
 
-            double frac = srcPos - Math.Floor(srcPos);
             double v0 = NumOps.ToDouble(nativeBuf[floorIdx]);
             double v1 = NumOps.ToDouble(nativeBuf[ceilIdx]);
             dst[dstOffset + t] = NumOps.FromDouble(v0 * (1.0 - frac) + v1 * frac);

--- a/src/Data/Audio/Benchmarks/SpeechCommandsDataLoader.cs
+++ b/src/Data/Audio/Benchmarks/SpeechCommandsDataLoader.cs
@@ -31,8 +31,9 @@ namespace AiDotNet.Data.Audio.Benchmarks;
 /// <see cref="ExtractBatch"/>. This is intentional: the full 35-class dataset would
 /// allocate ~4 GB of float32 features in memory, so eager loading was guaranteed to OOM.
 /// Use <see cref="GetBatches"/> / <see cref="GetBatchesAsync"/> for training; direct
-/// <see cref="Features"/>/<see cref="Labels"/> access on this loader is intentionally
-/// not supported.
+/// <see cref="Features"/> access on this loader is intentionally not supported (features
+/// are decoded lazily per batch). <see cref="Labels"/> is a small <c>[N, numClasses]</c>
+/// one-hot tensor and is materialized during <c>LoadAsync</c>, so it remains available.
 /// </para>
 /// <para>
 /// <b>Class scheme:</b> the "core" 12-class subset (default) follows Warden 2018:
@@ -133,7 +134,12 @@ public class SpeechCommandsDataLoader<T> : InputOutputDataLoaderBase<T, Tensor<T
     public int NumClasses => _numClasses;
 
     /// <summary>Gets the word list being used (10/35 word names plus the two synthetic labels in core mode).</summary>
-    public IReadOnlyList<string> WordList => _wordList;
+    /// <remarks>
+    /// Wrapped via <see cref="Array.AsReadOnly{T}(T[])"/> so callers can't downcast back to
+    /// <c>string[]</c> and mutate the canonical class ordering — that would corrupt the
+    /// directory→class-index mapping for every loader instance.
+    /// </remarks>
+    public IReadOnlyList<string> WordList => Array.AsReadOnly(_wordList);
 
     /// <summary>Creates a new Speech Commands data loader.</summary>
     public SpeechCommandsDataLoader(SpeechCommandsDataLoaderOptions? options = null)
@@ -211,7 +217,11 @@ public class SpeechCommandsDataLoader<T> : InputOutputDataLoaderBase<T, Tensor<T
             string wordDir = Path.Combine(_dataPath, word);
             if (!Directory.Exists(wordDir)) continue;
 
-            foreach (string wavFile in Directory.GetFiles(wordDir, "*.wav"))
+            // EnumerateFiles so the `break` below can short-circuit the directory
+            // scan once MaxSamplesPerClass is hit; GetFiles would materialize the
+            // entire file list up-front (tens of thousands of paths for some classes)
+            // regardless of how many we actually keep.
+            foreach (string wavFile in Directory.EnumerateFiles(wordDir, "*.wav"))
             {
                 cancellationToken.ThrowIfCancellationRequested();
                 if (!IsInRequestedSplit(wavFile, word, testFiles, valFiles))
@@ -221,9 +231,7 @@ public class SpeechCommandsDataLoader<T> : InputOutputDataLoaderBase<T, Tensor<T
                     classCounts[c] >= _options.MaxSamplesPerClass.Value)
                 {
                     // Cap reached for this class — stop scanning the rest of the
-                    // directory (tens of thousands of files for some classes).
-                    // `continue` here would keep iterating the full Directory.GetFiles
-                    // result set, wasting IO and startup time for no benefit.
+                    // directory.
                     break;
                 }
 
@@ -242,7 +250,9 @@ public class SpeechCommandsDataLoader<T> : InputOutputDataLoaderBase<T, Tensor<T
                 string wordDir = Path.Combine(_dataPath, nonCoreWord);
                 if (!Directory.Exists(wordDir)) continue;
 
-                foreach (string wavFile in Directory.GetFiles(wordDir, "*.wav"))
+                // EnumerateFiles so the cap-reached break can short-circuit, same
+                // rationale as the keyword loop above.
+                foreach (string wavFile in Directory.EnumerateFiles(wordDir, "*.wav"))
                 {
                     cancellationToken.ThrowIfCancellationRequested();
                     if (!IsInRequestedSplit(wavFile, nonCoreWord, testFiles, valFiles))
@@ -277,6 +287,19 @@ public class SpeechCommandsDataLoader<T> : InputOutputDataLoaderBase<T, Tensor<T
             var allBgFiles = Directory.Exists(bgDir)
                 ? Directory.GetFiles(bgDir, "*.wav").ToList()
                 : new List<string>();
+
+            // Fail fast if the whole _background_noise_ pool is missing — silently
+            // emitting zero-filled silence would turn an incomplete dataset into a
+            // different benchmark without the caller noticing. The per-split pool
+            // can still fall back to the full set when one designated file is
+            // missing (handled below); this check only guards the all-empty case.
+            if (allBgFiles.Count == 0)
+            {
+                throw new InvalidOperationException(
+                    $"Speech Commands core mode requires at least one WAV under '{bgDir}' " +
+                    "to synthesize '_silence_' samples. Re-download the dataset or disable " +
+                    "the silence class by setting SilenceSampleCount to 0.");
+            }
 
             const string ValidationBackgroundFile = "running_tap.wav";
             bool IsValidationBg(string path) => string.Equals(
@@ -381,6 +404,10 @@ public class SpeechCommandsDataLoader<T> : InputOutputDataLoaderBase<T, Tensor<T
         Indices = null;
         _samples.Clear();
         _backgroundNoiseFiles = null;
+        // Decoded background-noise clips can be ~30s of float32 audio each. Clearing
+        // the cache here ensures Unload() actually releases the largest buffers and
+        // prevents stale audio from being reused if the dataset changes on disk.
+        _backgroundNoiseBuffers.Clear();
         _sampleCount = 0;
     }
 

--- a/src/Data/Audio/Benchmarks/SpeechCommandsDataLoader.cs
+++ b/src/Data/Audio/Benchmarks/SpeechCommandsDataLoader.cs
@@ -1,0 +1,238 @@
+using AiDotNet.Data.Geometry;
+using AiDotNet.Data.Loaders;
+
+namespace AiDotNet.Data.Audio.Benchmarks;
+
+/// <summary>
+/// Loads the Google Speech Commands v2 dataset (65K clips, 35 words, 16kHz).
+/// </summary>
+/// <typeparam name="T">The numeric type.</typeparam>
+/// <remarks>
+/// <para>
+/// Speech Commands v2 expects the following directory structure after extraction:
+/// <code>
+/// {DataPath}/
+///   yes/
+///     {speaker_id}_nohash_{index}.wav
+///   no/
+///     ...
+///   up/
+///     ...
+///   validation_list.txt
+///   testing_list.txt
+/// </code>
+/// Each subdirectory is a word class. WAV files are 16-bit PCM mono at 16kHz, ~1 second each.
+/// Features are raw waveform Tensor[N, TargetLength]. Labels are one-hot Tensor[N, NumClasses].
+/// </para>
+/// <para>
+/// The "core" 12-class subset (default) uses: yes, no, up, down, left, right, on, off,
+/// stop, go + silence + unknown. The full 35-class mode uses all word directories.
+/// </para>
+/// </remarks>
+public class SpeechCommandsDataLoader<T> : InputOutputDataLoaderBase<T, Tensor<T>, Tensor<T>>
+{
+    private static readonly string DownloadUrl =
+        "http://download.tensorflow.org/data/speech_commands_v0.02.tar.gz";
+
+    /// <summary>Core 10 spoken words (the standard benchmark subset).</summary>
+    public static readonly string[] CoreWords =
+        ["yes", "no", "up", "down", "left", "right", "on", "off", "stop", "go"];
+
+    /// <summary>All 35 word classes in the full dataset.</summary>
+    public static readonly string[] AllWords =
+        ["backward", "bed", "bird", "cat", "dog", "down", "eight", "five", "follow",
+         "forward", "four", "go", "happy", "house", "learn", "left", "marvin", "nine",
+         "no", "off", "on", "one", "right", "seven", "sheila", "six", "stop", "three",
+         "tree", "two", "up", "visual", "wow", "yes", "zero"];
+
+    private readonly SpeechCommandsDataLoaderOptions _options;
+    private readonly string _dataPath;
+    private int _sampleCount;
+    private readonly int _numClasses;
+    private readonly string[] _wordList;
+
+    /// <inheritdoc/>
+    public override string Name => "SpeechCommands";
+
+    /// <inheritdoc/>
+    public override string Description => _options.UseCoreSubset
+        ? "Google Speech Commands v2 (core 10 words)"
+        : "Google Speech Commands v2 (all 35 words)";
+
+    /// <inheritdoc/>
+    public override int TotalCount => _sampleCount;
+
+    /// <inheritdoc/>
+    public override int FeatureCount => _options.TargetLength;
+
+    /// <inheritdoc/>
+    public override int OutputDimension => _numClasses;
+
+    /// <summary>Number of word classes.</summary>
+    public int NumClasses => _numClasses;
+
+    /// <summary>Gets the word list being used.</summary>
+    public IReadOnlyList<string> WordList => _wordList;
+
+    /// <summary>Creates a new Speech Commands data loader.</summary>
+    public SpeechCommandsDataLoader(SpeechCommandsDataLoaderOptions? options = null)
+    {
+        _options = options ?? new SpeechCommandsDataLoaderOptions();
+        _dataPath = _options.DataPath ?? DatasetDownloader.GetDefaultDataPath("speech_commands");
+        _wordList = _options.UseCoreSubset ? CoreWords : AllWords;
+        _numClasses = _wordList.Length;
+    }
+
+    /// <inheritdoc/>
+    protected override async Task LoadDataCoreAsync(CancellationToken cancellationToken)
+    {
+        // Build file list from directory structure
+        var testingListPath = Path.Combine(_dataPath, "testing_list.txt");
+        var validationListPath = Path.Combine(_dataPath, "validation_list.txt");
+
+        // Load official split lists if available
+        var testFiles = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var valFiles = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        if (File.Exists(testingListPath))
+        {
+            foreach (var line in await FilePolyfill.ReadAllLinesAsync(testingListPath, cancellationToken))
+            {
+                string trimmed = line.Trim();
+                if (!string.IsNullOrEmpty(trimmed))
+                    testFiles.Add(trimmed.Replace('/', Path.DirectorySeparatorChar));
+            }
+        }
+
+        if (File.Exists(validationListPath))
+        {
+            foreach (var line in await FilePolyfill.ReadAllLinesAsync(validationListPath, cancellationToken))
+            {
+                string trimmed = line.Trim();
+                if (!string.IsNullOrEmpty(trimmed))
+                    valFiles.Add(trimmed.Replace('/', Path.DirectorySeparatorChar));
+            }
+        }
+
+        // Collect samples
+        var samples = new List<(string AudioPath, int ClassIndex)>();
+        var classCounts = new int[_numClasses];
+
+        for (int c = 0; c < _numClasses; c++)
+        {
+            string wordDir = Path.Combine(_dataPath, _wordList[c]);
+            if (!Directory.Exists(wordDir)) continue;
+
+            foreach (string wavFile in Directory.GetFiles(wordDir, "*.wav"))
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                // Determine which split this file belongs to
+                string relPath = Path.Combine(_wordList[c], Path.GetFileName(wavFile));
+                bool isTest = testFiles.Contains(relPath);
+                bool isVal = valFiles.Contains(relPath);
+                bool isTrain = !isTest && !isVal;
+
+                bool include = _options.Split switch
+                {
+                    DatasetSplit.Test => isTest,
+                    DatasetSplit.Validation => isVal,
+                    _ => isTrain
+                };
+
+                if (!include) continue;
+
+                // Respect per-class limit
+                if (_options.MaxSamplesPerClass.HasValue &&
+                    classCounts[c] >= _options.MaxSamplesPerClass.Value)
+                    continue;
+
+                samples.Add((wavFile, c));
+                classCounts[c]++;
+            }
+        }
+
+        int totalSamples = samples.Count;
+        _sampleCount = totalSamples;
+
+        if (totalSamples == 0)
+            throw new InvalidOperationException(
+                $"No Speech Commands data found at {_dataPath}. " +
+                $"Download from {DownloadUrl} and extract to {_dataPath}.");
+
+        // Load audio data
+        int targetLen = _options.TargetLength;
+        var featuresData = new T[totalSamples * targetLen];
+        var labelsData = new T[totalSamples * _numClasses];
+
+        for (int i = 0; i < totalSamples; i++)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var (audioPath, classIndex) = samples[i];
+
+            if (File.Exists(audioPath))
+            {
+                byte[] audioBytes = await FilePolyfill.ReadAllBytesAsync(audioPath, cancellationToken);
+                AudioLoaderHelper.LoadAudioSamples(audioBytes, featuresData,
+                    i * targetLen, targetLen, NumOps);
+            }
+
+            // One-hot encode class
+            if (classIndex >= 0 && classIndex < _numClasses)
+                labelsData[i * _numClasses + classIndex] = NumOps.FromDouble(1.0);
+        }
+
+        LoadedFeatures = new Tensor<T>(featuresData, [totalSamples, targetLen]);
+        LoadedLabels = new Tensor<T>(labelsData, [totalSamples, _numClasses]);
+        InitializeIndices(totalSamples);
+    }
+
+    /// <inheritdoc/>
+    protected override void UnloadDataCore()
+    {
+        LoadedFeatures = default;
+        LoadedLabels = default;
+        Indices = null;
+        _sampleCount = 0;
+    }
+
+    /// <inheritdoc/>
+    protected override (Tensor<T> Features, Tensor<T> Labels) ExtractBatch(int[] indices)
+    {
+        var features = LoadedFeatures ?? throw new InvalidOperationException("Features not loaded.");
+        var labels = LoadedLabels ?? throw new InvalidOperationException("Labels not loaded.");
+        return (AudioLoaderHelper.ExtractTensorBatch(features, indices),
+                AudioLoaderHelper.ExtractTensorBatch(labels, indices));
+    }
+
+    /// <inheritdoc/>
+    public override (IInputOutputDataLoader<T, Tensor<T>, Tensor<T>> Train,
+        IInputOutputDataLoader<T, Tensor<T>, Tensor<T>> Validation,
+        IInputOutputDataLoader<T, Tensor<T>, Tensor<T>> Test) Split(
+        double trainRatio = 0.7,
+        double validationRatio = 0.15,
+        int? seed = null)
+    {
+        EnsureLoaded();
+        ValidateSplitRatios(trainRatio, validationRatio);
+        var (trainSize, valSize, _) = ComputeSplitSizes(_sampleCount, trainRatio, validationRatio);
+        var random = seed.HasValue
+            ? Tensors.Helpers.RandomHelper.CreateSeededRandom(seed.Value)
+            : Tensors.Helpers.RandomHelper.CreateSecureRandom();
+        var shuffled = Enumerable.Range(0, _sampleCount).OrderBy(_ => random.Next()).ToArray();
+        var features = LoadedFeatures ?? throw new InvalidOperationException("Features not loaded.");
+        var labels = LoadedLabels ?? throw new InvalidOperationException("Labels not loaded.");
+
+        return (
+            new InMemoryDataLoader<T, Tensor<T>, Tensor<T>>(
+                AudioLoaderHelper.ExtractTensorBatch(features, shuffled.Take(trainSize).ToArray()),
+                AudioLoaderHelper.ExtractTensorBatch(labels, shuffled.Take(trainSize).ToArray())),
+            new InMemoryDataLoader<T, Tensor<T>, Tensor<T>>(
+                AudioLoaderHelper.ExtractTensorBatch(features, shuffled.Skip(trainSize).Take(valSize).ToArray()),
+                AudioLoaderHelper.ExtractTensorBatch(labels, shuffled.Skip(trainSize).Take(valSize).ToArray())),
+            new InMemoryDataLoader<T, Tensor<T>, Tensor<T>>(
+                AudioLoaderHelper.ExtractTensorBatch(features, shuffled.Skip(trainSize + valSize).ToArray()),
+                AudioLoaderHelper.ExtractTensorBatch(labels, shuffled.Skip(trainSize + valSize).ToArray()))
+        );
+    }
+}

--- a/src/Data/Audio/Benchmarks/SpeechCommandsDataLoader.cs
+++ b/src/Data/Audio/Benchmarks/SpeechCommandsDataLoader.cs
@@ -258,18 +258,53 @@ public class SpeechCommandsDataLoader<T> : InputOutputDataLoaderBase<T, Tensor<T
             }
         }
 
-        // 3c) Synthetic _silence_ class: random crops of the background-noise WAVs,
-        // or pure silence when the directory is missing (degenerate but never crashes).
+        // 3c) Synthetic _silence_ class: split-aware crops of the background-noise
+        // WAVs per Warden 2018 §6 (Speech Commands v2):
+        //  - Train draws overlapping 1-second crops from all background files except
+        //    the one reserved for validation.
+        //  - Validation uses a single designated file (running_tap.wav by convention)
+        //    so the val set stays speaker/noise-source-independent.
+        //  - Test draws from the remaining background files (same pool as train but
+        //    with a proportionally smaller sample count).
+        // The generated silence count is scaled by the split proportion so silence
+        // stays at ~8.3% of samples across splits (the 12-class balanced setting
+        // from the TFDS reference implementation). Previously the same
+        // SilenceSampleCount was emitted regardless of Split, producing test/val
+        // distributions that skewed heavily toward silence.
         if (_options.UseCoreSubset && _silenceClassIndex >= 0 && _options.SilenceSampleCount > 0)
         {
             string bgDir = Path.Combine(_dataPath, BackgroundNoiseDir);
-            _backgroundNoiseFiles = Directory.Exists(bgDir)
+            var allBgFiles = Directory.Exists(bgDir)
                 ? Directory.GetFiles(bgDir, "*.wav").ToList()
                 : new List<string>();
 
-            int silenceCount = _options.MaxSamplesPerClass.HasValue
-                ? Math.Min(_options.SilenceSampleCount, _options.MaxSamplesPerClass.Value)
-                : _options.SilenceSampleCount;
+            const string ValidationBackgroundFile = "running_tap.wav";
+            bool IsValidationBg(string path) => string.Equals(
+                Path.GetFileName(path), ValidationBackgroundFile, StringComparison.OrdinalIgnoreCase);
+
+            _backgroundNoiseFiles = _options.Split switch
+            {
+                DatasetSplit.Validation => allBgFiles.Where(IsValidationBg).ToList(),
+                _                       => allBgFiles.Where(f => !IsValidationBg(f)).ToList(),
+            };
+            // If the designated per-split pool is empty (e.g., running_tap.wav is
+            // missing from the archive), fall back to the full background file list
+            // so we emit silence samples instead of collapsing the class to size 0.
+            if (_backgroundNoiseFiles.Count == 0) _backgroundNoiseFiles = allBgFiles;
+
+            // Split sizes from Warden 2018 §4 (TFDS reference, 12-class benchmark):
+            // train ≈ 85,511, val ≈ 10,102, test ≈ 4,890. Scale silence per split to
+            // preserve the target class ratio across splits.
+            double splitScale = _options.Split switch
+            {
+                DatasetSplit.Validation => 10102.0 / 85511.0,
+                DatasetSplit.Test       => 4890.0 / 85511.0,
+                _                       => 1.0,
+            };
+            int silenceCount = (int)Math.Round(_options.SilenceSampleCount * splitScale);
+            if (_options.MaxSamplesPerClass.HasValue)
+                silenceCount = Math.Min(silenceCount, _options.MaxSamplesPerClass.Value);
+
             for (int i = 0; i < silenceCount; i++)
             {
                 _samples.Add(new SampleEntry(string.Empty, _silenceClassIndex, SampleSource.Silence, syntheticIndex: i));

--- a/src/Data/Audio/Benchmarks/SpeechCommandsDataLoader.cs
+++ b/src/Data/Audio/Benchmarks/SpeechCommandsDataLoader.cs
@@ -1,10 +1,11 @@
+using AiDotNet.Data;
 using AiDotNet.Data.Geometry;
 using AiDotNet.Data.Loaders;
 
 namespace AiDotNet.Data.Audio.Benchmarks;
 
 /// <summary>
-/// Loads the Google Speech Commands v2 dataset (65K clips, 35 words, 16kHz).
+/// Loads the Google Speech Commands v2 dataset (~65K clips, 35 words, 16kHz).
 /// </summary>
 /// <typeparam name="T">The numeric type.</typeparam>
 /// <remarks>
@@ -16,23 +17,42 @@ namespace AiDotNet.Data.Audio.Benchmarks;
 ///     {speaker_id}_nohash_{index}.wav
 ///   no/
 ///     ...
-///   up/
+///   _background_noise_/      (used to synthesize the _silence_ class)
 ///     ...
 ///   validation_list.txt
 ///   testing_list.txt
 /// </code>
 /// Each subdirectory is a word class. WAV files are 16-bit PCM mono at 16kHz, ~1 second each.
-/// Features are raw waveform Tensor[N, TargetLength]. Labels are one-hot Tensor[N, NumClasses].
 /// </para>
 /// <para>
-/// The "core" 12-class subset (default) uses: yes, no, up, down, left, right, on, off,
-/// stop, go + silence + unknown. The full 35-class mode uses all word directories.
+/// <b>Streaming behaviour:</b> the loader does NOT preload audio waveforms into memory.
+/// File paths and class indices are scanned eagerly during <c>LoadAsync</c>, but the
+/// actual WAV decoding (and resampling, if configured) happens per-batch in
+/// <see cref="ExtractBatch"/>. This is intentional: the full 35-class dataset would
+/// allocate ~4 GB of float32 features in memory, so eager loading was guaranteed to OOM.
+/// Use <see cref="GetBatches"/> / <see cref="GetBatchesAsync"/> for training; direct
+/// <see cref="Features"/>/<see cref="Labels"/> access on this loader is intentionally
+/// not supported.
+/// </para>
+/// <para>
+/// <b>Class scheme:</b> the "core" 12-class subset (default) follows Warden 2018:
+/// the 10 keyword classes (yes, no, up, down, left, right, on, off, stop, go) plus
+/// <c>_silence_</c> (sampled from <c>_background_noise_/</c>) and <c>_unknown_</c>
+/// (collapses every non-core word directory). The full 35-class mode uses all word
+/// directories with no synthetic classes.
+/// </para>
+/// <para>
+/// <b>Auto-download:</b> when <see cref="SpeechCommandsDataLoaderOptions.AutoDownload"/>
+/// is true (default), the loader fetches and extracts the tarball from
+/// <see cref="DownloadUrl"/> if the data directory is empty, mirroring
+/// <c>LibriSpeechDataLoader</c>.
 /// </para>
 /// </remarks>
 public class SpeechCommandsDataLoader<T> : InputOutputDataLoaderBase<T, Tensor<T>, Tensor<T>>
 {
-    private static readonly string DownloadUrl =
-        "http://download.tensorflow.org/data/speech_commands_v0.02.tar.gz";
+    /// <summary>HTTPS URL of the Speech Commands v2 archive.</summary>
+    public static readonly string DownloadUrl =
+        "https://download.tensorflow.org/data/speech_commands_v0.02.tar.gz";
 
     /// <summary>Core 10 spoken words (the standard benchmark subset).</summary>
     public static readonly string[] CoreWords =
@@ -45,18 +65,35 @@ public class SpeechCommandsDataLoader<T> : InputOutputDataLoaderBase<T, Tensor<T
          "no", "off", "on", "one", "right", "seven", "sheila", "six", "stop", "three",
          "tree", "two", "up", "visual", "wow", "yes", "zero"];
 
+    /// <summary>Synthetic class label for non-keyword speech in the 12-class subset.</summary>
+    public const string UnknownLabel = "_unknown_";
+
+    /// <summary>Synthetic class label for background-noise / silence in the 12-class subset.</summary>
+    public const string SilenceLabel = "_silence_";
+
+    /// <summary>Subdirectory containing the long background-noise WAVs distributed with the dataset.</summary>
+    public const string BackgroundNoiseDir = "_background_noise_";
+
     private readonly SpeechCommandsDataLoaderOptions _options;
     private readonly string _dataPath;
     private int _sampleCount;
     private readonly int _numClasses;
     private readonly string[] _wordList;
+    private readonly int _silenceClassIndex; // -1 when not in 12-class core mode
+    private readonly int _unknownClassIndex; // -1 when not in 12-class core mode
+
+    // Per-sample metadata captured during LoadDataCoreAsync. The actual audio is
+    // decoded per-batch inside ExtractBatch — we never materialize all waveforms in
+    // memory, which is what makes the full 35-class path safe on commodity hardware.
+    private readonly List<SampleEntry> _samples = new();
+    private List<string>? _backgroundNoiseFiles; // null until LoadDataCoreAsync runs
 
     /// <inheritdoc/>
     public override string Name => "SpeechCommands";
 
     /// <inheritdoc/>
     public override string Description => _options.UseCoreSubset
-        ? "Google Speech Commands v2 (core 10 words)"
+        ? "Google Speech Commands v2 (core 12 classes: 10 keywords + silence + unknown)"
         : "Google Speech Commands v2 (all 35 words)";
 
     /// <inheritdoc/>
@@ -68,29 +105,48 @@ public class SpeechCommandsDataLoader<T> : InputOutputDataLoaderBase<T, Tensor<T
     /// <inheritdoc/>
     public override int OutputDimension => _numClasses;
 
-    /// <summary>Number of word classes.</summary>
+    /// <summary>Number of word classes (12 in core mode, 35 in full mode).</summary>
     public int NumClasses => _numClasses;
 
-    /// <summary>Gets the word list being used.</summary>
+    /// <summary>Gets the word list being used (10/35 word names plus the two synthetic labels in core mode).</summary>
     public IReadOnlyList<string> WordList => _wordList;
 
     /// <summary>Creates a new Speech Commands data loader.</summary>
     public SpeechCommandsDataLoader(SpeechCommandsDataLoaderOptions? options = null)
     {
         _options = options ?? new SpeechCommandsDataLoaderOptions();
+        _options.Validate();
         _dataPath = _options.DataPath ?? DatasetDownloader.GetDefaultDataPath("speech_commands");
-        _wordList = _options.UseCoreSubset ? CoreWords : AllWords;
+
+        if (_options.UseCoreSubset)
+        {
+            // Per Warden 2018: 10 keywords + silence + unknown = 12 classes.
+            _wordList = new string[CoreWords.Length + 2];
+            Array.Copy(CoreWords, _wordList, CoreWords.Length);
+            _wordList[CoreWords.Length] = SilenceLabel;
+            _wordList[CoreWords.Length + 1] = UnknownLabel;
+            _silenceClassIndex = CoreWords.Length;
+            _unknownClassIndex = CoreWords.Length + 1;
+        }
+        else
+        {
+            _wordList = AllWords;
+            _silenceClassIndex = -1;
+            _unknownClassIndex = -1;
+        }
         _numClasses = _wordList.Length;
     }
 
     /// <inheritdoc/>
     protected override async Task LoadDataCoreAsync(CancellationToken cancellationToken)
     {
-        // Build file list from directory structure
+        // 1) Make sure the dataset is on disk. Mirrors LibriSpeechDataLoader.
+        await EnsureDatasetPresentAsync(cancellationToken);
+
         var testingListPath = Path.Combine(_dataPath, "testing_list.txt");
         var validationListPath = Path.Combine(_dataPath, "validation_list.txt");
 
-        // Load official split lists if available
+        // 2) Load official split lists if available.
         var testFiles = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         var valFiles = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
@@ -114,77 +170,137 @@ public class SpeechCommandsDataLoader<T> : InputOutputDataLoaderBase<T, Tensor<T
             }
         }
 
-        // Collect samples
-        var samples = new List<(string AudioPath, int ClassIndex)>();
+        // 3) Build the per-class entry list (paths only, NO audio decoding here).
+        _samples.Clear();
         var classCounts = new int[_numClasses];
 
-        for (int c = 0; c < _numClasses; c++)
+        // 3a) Keyword classes (10 in core mode, 35 in full mode).
+        int keywordEnd = _options.UseCoreSubset ? CoreWords.Length : _wordList.Length;
+        for (int c = 0; c < keywordEnd; c++)
         {
-            string wordDir = Path.Combine(_dataPath, _wordList[c]);
+            string word = _wordList[c];
+            string wordDir = Path.Combine(_dataPath, word);
             if (!Directory.Exists(wordDir)) continue;
 
             foreach (string wavFile in Directory.GetFiles(wordDir, "*.wav"))
             {
                 cancellationToken.ThrowIfCancellationRequested();
+                if (!IsInRequestedSplit(wavFile, word, testFiles, valFiles))
+                    continue;
 
-                // Determine which split this file belongs to
-                string relPath = Path.Combine(_wordList[c], Path.GetFileName(wavFile));
-                bool isTest = testFiles.Contains(relPath);
-                bool isVal = valFiles.Contains(relPath);
-                bool isTrain = !isTest && !isVal;
-
-                bool include = _options.Split switch
-                {
-                    DatasetSplit.Test => isTest,
-                    DatasetSplit.Validation => isVal,
-                    _ => isTrain
-                };
-
-                if (!include) continue;
-
-                // Respect per-class limit
                 if (_options.MaxSamplesPerClass.HasValue &&
                     classCounts[c] >= _options.MaxSamplesPerClass.Value)
                     continue;
 
-                samples.Add((wavFile, c));
+                _samples.Add(new SampleEntry(wavFile, c, SampleSource.WavFile));
                 classCounts[c]++;
             }
         }
 
-        int totalSamples = samples.Count;
-        _sampleCount = totalSamples;
-
-        if (totalSamples == 0)
-            throw new InvalidOperationException(
-                $"No Speech Commands data found at {_dataPath}. " +
-                $"Download from {DownloadUrl} and extract to {_dataPath}.");
-
-        // Load audio data
-        int targetLen = _options.TargetLength;
-        var featuresData = new T[totalSamples * targetLen];
-        var labelsData = new T[totalSamples * _numClasses];
-
-        for (int i = 0; i < totalSamples; i++)
+        // 3b) Synthetic _unknown_ class: collapse every non-core word directory.
+        if (_options.UseCoreSubset && _unknownClassIndex >= 0)
         {
-            cancellationToken.ThrowIfCancellationRequested();
-            var (audioPath, classIndex) = samples[i];
-
-            if (File.Exists(audioPath))
+            var coreSet = new HashSet<string>(CoreWords, StringComparer.OrdinalIgnoreCase);
+            foreach (string nonCoreWord in AllWords)
             {
-                byte[] audioBytes = await FilePolyfill.ReadAllBytesAsync(audioPath, cancellationToken);
-                AudioLoaderHelper.LoadAudioSamples(audioBytes, featuresData,
-                    i * targetLen, targetLen, NumOps);
-            }
+                if (coreSet.Contains(nonCoreWord)) continue;
+                string wordDir = Path.Combine(_dataPath, nonCoreWord);
+                if (!Directory.Exists(wordDir)) continue;
 
-            // One-hot encode class
-            if (classIndex >= 0 && classIndex < _numClasses)
-                labelsData[i * _numClasses + classIndex] = NumOps.FromDouble(1.0);
+                foreach (string wavFile in Directory.GetFiles(wordDir, "*.wav"))
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+                    if (!IsInRequestedSplit(wavFile, nonCoreWord, testFiles, valFiles))
+                        continue;
+
+                    if (_options.MaxSamplesPerClass.HasValue &&
+                        classCounts[_unknownClassIndex] >= _options.MaxSamplesPerClass.Value)
+                        break;
+
+                    _samples.Add(new SampleEntry(wavFile, _unknownClassIndex, SampleSource.WavFile));
+                    classCounts[_unknownClassIndex]++;
+                }
+            }
         }
 
-        LoadedFeatures = new Tensor<T>(featuresData, [totalSamples, targetLen]);
-        LoadedLabels = new Tensor<T>(labelsData, [totalSamples, _numClasses]);
-        InitializeIndices(totalSamples);
+        // 3c) Synthetic _silence_ class: random crops of the background-noise WAVs,
+        // or pure silence when the directory is missing (degenerate but never crashes).
+        if (_options.UseCoreSubset && _silenceClassIndex >= 0 && _options.SilenceSampleCount > 0)
+        {
+            string bgDir = Path.Combine(_dataPath, BackgroundNoiseDir);
+            _backgroundNoiseFiles = Directory.Exists(bgDir)
+                ? Directory.GetFiles(bgDir, "*.wav").ToList()
+                : new List<string>();
+
+            int silenceCount = _options.MaxSamplesPerClass.HasValue
+                ? Math.Min(_options.SilenceSampleCount, _options.MaxSamplesPerClass.Value)
+                : _options.SilenceSampleCount;
+            for (int i = 0; i < silenceCount; i++)
+            {
+                _samples.Add(new SampleEntry(string.Empty, _silenceClassIndex, SampleSource.Silence, syntheticIndex: i));
+                classCounts[_silenceClassIndex]++;
+            }
+        }
+
+        _sampleCount = _samples.Count;
+        if (_sampleCount == 0)
+        {
+            throw new InvalidOperationException(
+                $"No Speech Commands data found at {_dataPath}. " +
+                $"Set AutoDownload=true (the default) or download manually from {DownloadUrl}.");
+        }
+
+        // 4) Pre-compute the labels tensor (cheap, small — N * NumClasses).
+        var labelsData = new T[_sampleCount * _numClasses];
+        for (int i = 0; i < _sampleCount; i++)
+            labelsData[i * _numClasses + _samples[i].ClassIndex] = NumOps.FromDouble(1.0);
+        LoadedLabels = new Tensor<T>(labelsData, [_sampleCount, _numClasses]);
+
+        // 5) Features tensor stays null — see the class remarks. Audio is decoded
+        // lazily per-batch in ExtractBatch.
+        LoadedFeatures = default;
+
+        InitializeIndices(_sampleCount);
+    }
+
+    /// <summary>
+    /// Decides whether a given WAV path falls into the requested split based on the
+    /// official testing_list.txt / validation_list.txt files (Warden 2018 spec).
+    /// </summary>
+    private bool IsInRequestedSplit(string wavFile, string word, HashSet<string> testFiles, HashSet<string> valFiles)
+    {
+        string relPath = Path.Combine(word, Path.GetFileName(wavFile));
+        bool isTest = testFiles.Contains(relPath);
+        bool isVal = valFiles.Contains(relPath);
+        bool isTrain = !isTest && !isVal;
+
+        return _options.Split switch
+        {
+            DatasetSplit.Test => isTest,
+            DatasetSplit.Validation => isVal,
+            _ => isTrain
+        };
+    }
+
+    /// <summary>
+    /// Triggers <see cref="DatasetDownloader.DownloadAndExtractTarGzAsync"/> when the data
+    /// directory is empty AND <see cref="SpeechCommandsDataLoaderOptions.AutoDownload"/>
+    /// is enabled. Throws a clear error otherwise so users aren't stuck wondering why
+    /// LoadAsync returns "no data found".
+    /// </summary>
+    private async Task EnsureDatasetPresentAsync(CancellationToken cancellationToken)
+    {
+        bool hasAnyData = Directory.Exists(_dataPath) && Directory.EnumerateFileSystemEntries(_dataPath).Any();
+        if (hasAnyData) return;
+
+        if (!_options.AutoDownload)
+        {
+            throw new InvalidOperationException(
+                $"No Speech Commands data found at {_dataPath} and AutoDownload is disabled. " +
+                $"Either set AutoDownload=true or manually download from {DownloadUrl} and extract to {_dataPath}.");
+        }
+
+        await DatasetDownloader.DownloadAndExtractTarGzAsync(DownloadUrl, _dataPath, cancellationToken);
     }
 
     /// <inheritdoc/>
@@ -193,16 +309,110 @@ public class SpeechCommandsDataLoader<T> : InputOutputDataLoaderBase<T, Tensor<T
         LoadedFeatures = default;
         LoadedLabels = default;
         Indices = null;
+        _samples.Clear();
+        _backgroundNoiseFiles = null;
         _sampleCount = 0;
     }
 
     /// <inheritdoc/>
     protected override (Tensor<T> Features, Tensor<T> Labels) ExtractBatch(int[] indices)
     {
-        var features = LoadedFeatures ?? throw new InvalidOperationException("Features not loaded.");
-        var labels = LoadedLabels ?? throw new InvalidOperationException("Labels not loaded.");
-        return (AudioLoaderHelper.ExtractTensorBatch(features, indices),
-                AudioLoaderHelper.ExtractTensorBatch(labels, indices));
+        // Streaming path: decode WAV (and resample if configured) for just this batch.
+        // Total memory is O(batchSize * targetLength), independent of dataset size.
+        int targetLen = _options.TargetLength;
+        var featuresData = new T[indices.Length * targetLen];
+
+        for (int i = 0; i < indices.Length; i++)
+        {
+            int sampleIdx = indices[i];
+            if (sampleIdx < 0 || sampleIdx >= _samples.Count) continue;
+
+            var entry = _samples[sampleIdx];
+            DecodeSampleInto(entry, featuresData, i * targetLen, targetLen);
+        }
+        var features = new Tensor<T>(featuresData, [indices.Length, targetLen]);
+
+        var allLabels = LoadedLabels ?? throw new InvalidOperationException(
+            "Labels not loaded — call LoadAsync() before ExtractBatch().");
+        var labels = AudioLoaderHelper.ExtractTensorBatch(allLabels, indices);
+        return (features, labels);
+    }
+
+    /// <summary>
+    /// Decodes a single sample (real WAV or synthesized silence) into the destination
+    /// span at the given offset, applying resampling when the configured target rate
+    /// differs from the dataset's native 16kHz rate.
+    /// </summary>
+    private void DecodeSampleInto(SampleEntry entry, T[] dst, int dstOffset, int targetLen)
+    {
+        int nativeRate = SpeechCommandsDataLoaderOptions.NativeSampleRate;
+        int targetRate = _options.SampleRate;
+
+        if (entry.Source == SampleSource.Silence)
+        {
+            // _silence_ class. If background noise files are available, sample a
+            // random crop of one of them; otherwise leave the slot zero-filled
+            // (acceptable degenerate behavior — pure silence is still valid input).
+            if (_backgroundNoiseFiles is { Count: > 0 })
+            {
+                // Deterministic per-sample picker so reload + reshuffle yields stable
+                // training data (the dataset class index alone disambiguates samples,
+                // and we want the test fixture to be reproducible).
+                int fileIdx = entry.SyntheticIndex % _backgroundNoiseFiles.Count;
+                string path = _backgroundNoiseFiles[fileIdx];
+                if (File.Exists(path))
+                {
+                    DecodeFileWithResample(path, dst, dstOffset, targetLen, nativeRate, targetRate);
+                }
+            }
+            // Else: dst[dstOffset..dstOffset+targetLen] stays at default(T) which is 0.
+            return;
+        }
+
+        if (!File.Exists(entry.AudioPath)) return;
+        DecodeFileWithResample(entry.AudioPath, dst, dstOffset, targetLen, nativeRate, targetRate);
+    }
+
+    /// <summary>
+    /// Decodes a WAV file and writes <paramref name="targetLen"/> samples into
+    /// <paramref name="dst"/> starting at <paramref name="dstOffset"/>, resampling
+    /// from <paramref name="nativeRate"/> to <paramref name="targetRate"/> via
+    /// linear interpolation when the rates differ.
+    /// </summary>
+    private void DecodeFileWithResample(
+        string path, T[] dst, int dstOffset, int targetLen, int nativeRate, int targetRate)
+    {
+        byte[] audioBytes = File.ReadAllBytes(path);
+
+        if (nativeRate == targetRate)
+        {
+            // Fast path: no resampling, decode straight into the destination buffer.
+            AudioLoaderHelper.LoadAudioSamples(audioBytes, dst, dstOffset, targetLen, NumOps);
+            return;
+        }
+
+        // Resample: load into a native-rate temp buffer sized for `targetLen` of output.
+        // We need ceil(targetLen * nativeRate / targetRate) native samples to cover
+        // the full target window, plus +1 slack for the linear-interp ceiling lookup.
+        int neededNative = checked((int)Math.Ceiling((double)targetLen * nativeRate / targetRate)) + 1;
+        var nativeBuf = new T[neededNative];
+        AudioLoaderHelper.LoadAudioSamples(audioBytes, nativeBuf, 0, neededNative, NumOps);
+
+        double rateRatio = (double)nativeRate / targetRate;
+        int lastIdx = neededNative - 1;
+        for (int t = 0; t < targetLen; t++)
+        {
+            double srcPos = t * rateRatio;
+            int floorIdx = (int)Math.Floor(srcPos);
+            int ceilIdx = floorIdx + 1;
+            if (floorIdx > lastIdx) floorIdx = lastIdx;
+            if (ceilIdx > lastIdx) ceilIdx = lastIdx;
+
+            double frac = srcPos - Math.Floor(srcPos);
+            double v0 = NumOps.ToDouble(nativeBuf[floorIdx]);
+            double v1 = NumOps.ToDouble(nativeBuf[ceilIdx]);
+            dst[dstOffset + t] = NumOps.FromDouble(v0 * (1.0 - frac) + v1 * frac);
+        }
     }
 
     /// <inheritdoc/>
@@ -220,19 +430,50 @@ public class SpeechCommandsDataLoader<T> : InputOutputDataLoaderBase<T, Tensor<T
             ? Tensors.Helpers.RandomHelper.CreateSeededRandom(seed.Value)
             : Tensors.Helpers.RandomHelper.CreateSecureRandom();
         var shuffled = Enumerable.Range(0, _sampleCount).OrderBy(_ => random.Next()).ToArray();
-        var features = LoadedFeatures ?? throw new InvalidOperationException("Features not loaded.");
-        var labels = LoadedLabels ?? throw new InvalidOperationException("Labels not loaded.");
+
+        var trainIdx = shuffled.Take(trainSize).ToArray();
+        var valIdx = shuffled.Skip(trainSize).Take(valSize).ToArray();
+        var testIdx = shuffled.Skip(trainSize + valSize).ToArray();
+
+        // Each split eagerly materializes its own (smaller) batch — this is fine for
+        // typical 70/15/15 splits because the per-split memory is bounded by
+        // splitSize * targetLength, which is much smaller than the full-dataset case.
+        var trainBatch = ExtractBatch(trainIdx);
+        var valBatch = ExtractBatch(valIdx);
+        var testBatch = ExtractBatch(testIdx);
 
         return (
-            new InMemoryDataLoader<T, Tensor<T>, Tensor<T>>(
-                AudioLoaderHelper.ExtractTensorBatch(features, shuffled.Take(trainSize).ToArray()),
-                AudioLoaderHelper.ExtractTensorBatch(labels, shuffled.Take(trainSize).ToArray())),
-            new InMemoryDataLoader<T, Tensor<T>, Tensor<T>>(
-                AudioLoaderHelper.ExtractTensorBatch(features, shuffled.Skip(trainSize).Take(valSize).ToArray()),
-                AudioLoaderHelper.ExtractTensorBatch(labels, shuffled.Skip(trainSize).Take(valSize).ToArray())),
-            new InMemoryDataLoader<T, Tensor<T>, Tensor<T>>(
-                AudioLoaderHelper.ExtractTensorBatch(features, shuffled.Skip(trainSize + valSize).ToArray()),
-                AudioLoaderHelper.ExtractTensorBatch(labels, shuffled.Skip(trainSize + valSize).ToArray()))
+            new InMemoryDataLoader<T, Tensor<T>, Tensor<T>>(trainBatch.Features, trainBatch.Labels),
+            new InMemoryDataLoader<T, Tensor<T>, Tensor<T>>(valBatch.Features, valBatch.Labels),
+            new InMemoryDataLoader<T, Tensor<T>, Tensor<T>>(testBatch.Features, testBatch.Labels)
         );
+    }
+
+    /// <summary>What kind of source a particular sample entry references.</summary>
+    private enum SampleSource
+    {
+        WavFile,
+        Silence,
+    }
+
+    /// <summary>
+    /// Compact per-sample record stored in <see cref="_samples"/>. Holds only
+    /// metadata — no audio bytes — so the full 35-class manifest fits comfortably
+    /// in memory and ExtractBatch decodes on demand.
+    /// </summary>
+    private readonly struct SampleEntry
+    {
+        public string AudioPath { get; }
+        public int ClassIndex { get; }
+        public SampleSource Source { get; }
+        public int SyntheticIndex { get; }
+
+        public SampleEntry(string audioPath, int classIndex, SampleSource source, int syntheticIndex = 0)
+        {
+            AudioPath = audioPath;
+            ClassIndex = classIndex;
+            Source = source;
+            SyntheticIndex = syntheticIndex;
+        }
     }
 }

--- a/src/Data/Audio/Benchmarks/SpeechCommandsDataLoaderOptions.cs
+++ b/src/Data/Audio/Benchmarks/SpeechCommandsDataLoaderOptions.cs
@@ -13,39 +13,67 @@ namespace AiDotNet.Data.Audio.Benchmarks;
 /// standard benchmark, with CNN baselines achieving ~95% accuracy.
 /// </para>
 /// <para>
-/// Dataset: http://download.tensorflow.org/data/speech_commands_v0.02.tar.gz (2.3GB)
+/// Dataset: https://download.tensorflow.org/data/speech_commands_v0.02.tar.gz (2.3GB)
 /// Paper: https://arxiv.org/abs/1804.03209
 /// License: Creative Commons BY 4.0
 /// </para>
 /// </remarks>
 public sealed class SpeechCommandsDataLoaderOptions
 {
+    /// <summary>Native sample rate of the Speech Commands corpus (16kHz).</summary>
+    public const int NativeSampleRate = 16000;
+
     /// <summary>Dataset split to load. Default is Train.</summary>
     public DatasetSplit Split { get; set; } = DatasetSplit.Train;
 
     /// <summary>Root data path. When null, uses default cache path.</summary>
     public string? DataPath { get; set; }
 
-    /// <summary>Automatically download if not present. Default is true.</summary>
+    /// <summary>
+    /// Automatically download and extract the dataset if it isn't present at
+    /// <see cref="DataPath"/>. Default is true. When false, missing data raises
+    /// an <see cref="InvalidOperationException"/> instead.
+    /// </summary>
     public bool AutoDownload { get; set; } = true;
 
     /// <summary>Optional maximum number of samples to load per class.</summary>
     public int? MaxSamplesPerClass { get; set; }
 
-    /// <summary>Sample rate in Hz. Default is 16000 (native Speech Commands rate).</summary>
-    public int SampleRate { get; set; } = 16000;
+    /// <summary>
+    /// Target audio sample rate in Hz. Default is 16000 (the Speech Commands native rate).
+    /// When this differs from <see cref="NativeSampleRate"/> the loader resamples each
+    /// clip via linear interpolation before truncation/padding to <see cref="TargetLength"/>.
+    /// </summary>
+    public int SampleRate { get; set; } = NativeSampleRate;
 
     /// <summary>
     /// Use the core 12-class subset (yes, no, up, down, left, right, on, off, stop, go,
-    /// silence, unknown) instead of all 35 classes. Default is true.
+    /// <c>_silence_</c>, <c>_unknown_</c>) instead of all 35 classes. Default is true.
     /// </summary>
+    /// <remarks>
+    /// The two synthetic classes follow the Warden 2018 benchmark spec: <c>_silence_</c>
+    /// is sampled from the dataset's <c>_background_noise_/</c> directory (or zero-padded
+    /// when that directory is absent), and <c>_unknown_</c> collapses every non-core word
+    /// directory so the classifier learns an "out-of-vocabulary" bucket.
+    /// </remarks>
     public bool UseCoreSubset { get; set; } = true;
 
     /// <summary>
-    /// Target audio length in samples. Clips shorter than this are zero-padded;
-    /// clips longer are truncated. Default is 16000 (1 second at 16kHz).
+    /// Target audio length in samples at <see cref="SampleRate"/>. Clips shorter than
+    /// this are zero-padded; clips longer are truncated. Default is 16000 (1 second at
+    /// the native 16kHz rate). When you change <see cref="SampleRate"/>, also adjust
+    /// this value to keep the per-clip duration consistent (e.g. 8000 for 1 second
+    /// at 8kHz).
     /// </summary>
     public int TargetLength { get; set; } = 16000;
+
+    /// <summary>
+    /// How many <c>_silence_</c> clips to synthesize from the background-noise
+    /// directory when the core 12-class subset is in use. Default is 2300, which
+    /// matches the per-class ratio in the official 12-class split. Ignored when
+    /// <see cref="UseCoreSubset"/> is false.
+    /// </summary>
+    public int SilenceSampleCount { get; set; } = 2300;
 
     /// <summary>Validates that all option values are within acceptable ranges.</summary>
     /// <exception cref="ArgumentOutOfRangeException">Thrown when any option is invalid.</exception>
@@ -54,5 +82,6 @@ public sealed class SpeechCommandsDataLoaderOptions
         if (SampleRate <= 0) throw new ArgumentOutOfRangeException(nameof(SampleRate), "Sample rate must be positive.");
         if (TargetLength <= 0) throw new ArgumentOutOfRangeException(nameof(TargetLength), "TargetLength must be positive.");
         if (MaxSamplesPerClass is <= 0) throw new ArgumentOutOfRangeException(nameof(MaxSamplesPerClass), "MaxSamplesPerClass must be positive when specified.");
+        if (SilenceSampleCount < 0) throw new ArgumentOutOfRangeException(nameof(SilenceSampleCount), "SilenceSampleCount must be non-negative.");
     }
 }

--- a/src/Data/Audio/Benchmarks/SpeechCommandsDataLoaderOptions.cs
+++ b/src/Data/Audio/Benchmarks/SpeechCommandsDataLoaderOptions.cs
@@ -1,0 +1,58 @@
+using AiDotNet.Data.Geometry;
+
+namespace AiDotNet.Data.Audio.Benchmarks;
+
+/// <summary>
+/// Configuration options for the Google Speech Commands v2 data loader.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Google Speech Commands v2 contains ~65,000 one-second audio clips of 35 spoken words
+/// recorded by thousands of different speakers at 16kHz. The "core" 12-class subset
+/// (yes, no, up, down, left, right, on, off, stop, go, silence, unknown) is the
+/// standard benchmark, with CNN baselines achieving ~95% accuracy.
+/// </para>
+/// <para>
+/// Dataset: http://download.tensorflow.org/data/speech_commands_v0.02.tar.gz (2.3GB)
+/// Paper: https://arxiv.org/abs/1804.03209
+/// License: Creative Commons BY 4.0
+/// </para>
+/// </remarks>
+public sealed class SpeechCommandsDataLoaderOptions
+{
+    /// <summary>Dataset split to load. Default is Train.</summary>
+    public DatasetSplit Split { get; set; } = DatasetSplit.Train;
+
+    /// <summary>Root data path. When null, uses default cache path.</summary>
+    public string? DataPath { get; set; }
+
+    /// <summary>Automatically download if not present. Default is true.</summary>
+    public bool AutoDownload { get; set; } = true;
+
+    /// <summary>Optional maximum number of samples to load per class.</summary>
+    public int? MaxSamplesPerClass { get; set; }
+
+    /// <summary>Sample rate in Hz. Default is 16000 (native Speech Commands rate).</summary>
+    public int SampleRate { get; set; } = 16000;
+
+    /// <summary>
+    /// Use the core 12-class subset (yes, no, up, down, left, right, on, off, stop, go,
+    /// silence, unknown) instead of all 35 classes. Default is true.
+    /// </summary>
+    public bool UseCoreSubset { get; set; } = true;
+
+    /// <summary>
+    /// Target audio length in samples. Clips shorter than this are zero-padded;
+    /// clips longer are truncated. Default is 16000 (1 second at 16kHz).
+    /// </summary>
+    public int TargetLength { get; set; } = 16000;
+
+    /// <summary>Validates that all option values are within acceptable ranges.</summary>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when any option is invalid.</exception>
+    public void Validate()
+    {
+        if (SampleRate <= 0) throw new ArgumentOutOfRangeException(nameof(SampleRate), "Sample rate must be positive.");
+        if (TargetLength <= 0) throw new ArgumentOutOfRangeException(nameof(TargetLength), "TargetLength must be positive.");
+        if (MaxSamplesPerClass is <= 0) throw new ArgumentOutOfRangeException(nameof(MaxSamplesPerClass), "MaxSamplesPerClass must be positive when specified.");
+    }
+}

--- a/src/Data/Audio/Benchmarks/SpeechCommandsDataLoaderOptions.cs
+++ b/src/Data/Audio/Benchmarks/SpeechCommandsDataLoaderOptions.cs
@@ -71,10 +71,13 @@ public sealed class SpeechCommandsDataLoaderOptions
     public int TargetLength { get; set; } = 16000;
 
     /// <summary>
-    /// How many <c>_silence_</c> clips to synthesize from the background-noise
-    /// directory when the core 12-class subset is in use. Default is 2300, which
-    /// matches the per-class ratio in the official 12-class split. Ignored when
-    /// <see cref="UseCoreSubset"/> is false.
+    /// Train-equivalent number of <c>_silence_</c> clips to synthesize from the
+    /// background-noise directory when the core 12-class subset is in use. Default
+    /// is 2300, which matches the per-class ratio in the official 12-class training
+    /// split. The loader scales the emitted silence count by <see cref="Split"/>
+    /// (training ≈ full count, validation ≈ 12%, test ≈ 6%), so Validation/Test
+    /// produce proportionally fewer silence samples than this configured value.
+    /// Ignored when <see cref="UseCoreSubset"/> is false.
     /// </summary>
     public int SilenceSampleCount { get; set; } = 2300;
 

--- a/src/Data/Audio/Benchmarks/SpeechCommandsDataLoaderOptions.cs
+++ b/src/Data/Audio/Benchmarks/SpeechCommandsDataLoaderOptions.cs
@@ -52,9 +52,12 @@ public sealed class SpeechCommandsDataLoaderOptions
     /// </summary>
     /// <remarks>
     /// The two synthetic classes follow the Warden 2018 benchmark spec: <c>_silence_</c>
-    /// is sampled from the dataset's <c>_background_noise_/</c> directory (or zero-padded
-    /// when that directory is absent), and <c>_unknown_</c> collapses every non-core word
-    /// directory so the classifier learns an "out-of-vocabulary" bucket.
+    /// is sampled from the dataset's <c>_background_noise_/</c> directory (which is
+    /// required when <see cref="SilenceSampleCount"/> is positive — the loader fails
+    /// fast with <see cref="InvalidOperationException"/> if the directory is missing
+    /// or empty, since a zero-filled silence class would silently create a different
+    /// benchmark than the spec describes). <c>_unknown_</c> collapses every non-core
+    /// word directory so the classifier learns an "out-of-vocabulary" bucket.
     /// </remarks>
     public bool UseCoreSubset { get; set; } = true;
 

--- a/src/Data/Audio/Benchmarks/SpeechCommandsDataLoaderOptions.cs
+++ b/src/Data/Audio/Benchmarks/SpeechCommandsDataLoaderOptions.cs
@@ -77,11 +77,17 @@ public sealed class SpeechCommandsDataLoaderOptions
 
     /// <summary>Validates that all option values are within acceptable ranges.</summary>
     /// <exception cref="ArgumentOutOfRangeException">Thrown when any option is invalid.</exception>
+    /// <exception cref="ArgumentException">Thrown when <see cref="DataPath"/> is the empty string.</exception>
     public void Validate()
     {
         if (SampleRate <= 0) throw new ArgumentOutOfRangeException(nameof(SampleRate), "Sample rate must be positive.");
         if (TargetLength <= 0) throw new ArgumentOutOfRangeException(nameof(TargetLength), "TargetLength must be positive.");
         if (MaxSamplesPerClass is <= 0) throw new ArgumentOutOfRangeException(nameof(MaxSamplesPerClass), "MaxSamplesPerClass must be positive when specified.");
         if (SilenceSampleCount < 0) throw new ArgumentOutOfRangeException(nameof(SilenceSampleCount), "SilenceSampleCount must be non-negative.");
+        // null means "use the default cache path" (set up by the loader constructor).
+        // Empty/whitespace would be silently treated as the current working directory,
+        // which is almost never what the caller intended.
+        if (DataPath is not null && string.IsNullOrWhiteSpace(DataPath))
+            throw new ArgumentException("DataPath must be null (for the default cache) or a non-empty, non-whitespace path.", nameof(DataPath));
     }
 }

--- a/tests/AiDotNet.Tests/IntegrationTests/Data/AudioBenchmarkTests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/Data/AudioBenchmarkTests.cs
@@ -445,6 +445,177 @@ public class AudioBenchmarkTests
         Assert.Equal("v3.0.0", options.Version);
     }
 
+    [Fact(Timeout = 120000)]
+    public async Task SpeechCommandsLoader_CoreSubset_LoadsSyntheticDataWith12Classes()
+    {
+        // Locks down the Warden-2018 12-class core scheme: 10 keywords + _silence_ + _unknown_,
+        // per-class limiting, official-split honouring, and one-hot label shape.
+        string tempDir = CreateTempDirectory();
+        try
+        {
+            // Two keyword dirs (yes/no) + one non-core dir (cat → _unknown_) + the
+            // background-noise dir (→ _silence_), each with a couple of WAV files.
+            CreateSpeechCommandsDir(tempDir, "yes",  count: 3);
+            CreateSpeechCommandsDir(tempDir, "no",   count: 3);
+            CreateSpeechCommandsDir(tempDir, "cat",  count: 2); // collapsed to _unknown_
+            CreateSpeechCommandsBackgroundNoise(tempDir, count: 2);
+
+            // No testing/validation lists: every WAV is "train".
+            var options = new SpeechCommandsDataLoaderOptions
+            {
+                DataPath = tempDir,
+                AutoDownload = false,
+                UseCoreSubset = true,
+                MaxSamplesPerClass = 5,
+                SilenceSampleCount = 2,
+                TargetLength = 1600 // 100ms at 16kHz, keeps the test fast
+            };
+
+            var loader = new SpeechCommandsDataLoader<float>(options);
+            await loader.LoadAsync();
+
+            Assert.Equal(12, loader.NumClasses);
+            Assert.Equal(12, loader.OutputDimension);
+            Assert.Equal(1600, loader.FeatureCount);
+
+            // Sample count = 3 yes + 3 no + 2 unknown + 2 silence = 10
+            Assert.Equal(10, loader.TotalCount);
+
+            // Word list ends in the two synthetic labels.
+            Assert.Equal("_silence_", loader.WordList[10]);
+            Assert.Equal("_unknown_", loader.WordList[11]);
+
+            // Pulling a batch goes through the streaming ExtractBatch path:
+            // confirms the on-demand WAV decode works and the label shape is correct.
+            var split = loader.Split(trainRatio: 0.6, validationRatio: 0.2, seed: 42);
+            Assert.True(split.Train.TotalCount > 0);
+            Assert.Equal(12, split.Train.OutputDimension);
+        }
+        finally
+        {
+            CleanupDirectory(tempDir);
+        }
+    }
+
+    [Fact(Timeout = 120000)]
+    public async Task SpeechCommandsLoader_FullMode_AllowsAll35Classes()
+    {
+        // Verifies the full 35-class path doesn't accidentally inject silence/unknown.
+        string tempDir = CreateTempDirectory();
+        try
+        {
+            CreateSpeechCommandsDir(tempDir, "yes", count: 1);
+            CreateSpeechCommandsDir(tempDir, "no",  count: 1);
+            CreateSpeechCommandsDir(tempDir, "cat", count: 1);
+
+            var options = new SpeechCommandsDataLoaderOptions
+            {
+                DataPath = tempDir,
+                AutoDownload = false,
+                UseCoreSubset = false,
+                TargetLength = 1600
+            };
+
+            var loader = new SpeechCommandsDataLoader<float>(options);
+            await loader.LoadAsync();
+
+            Assert.Equal(35, loader.NumClasses);
+            Assert.Equal(35, loader.OutputDimension);
+            // Only the three populated keyword dirs contribute samples in full mode.
+            Assert.Equal(3, loader.TotalCount);
+        }
+        finally
+        {
+            CleanupDirectory(tempDir);
+        }
+    }
+
+    [Fact(Timeout = 120000)]
+    public async Task SpeechCommandsLoader_Resampling_ProducesTargetLengthOutput()
+    {
+        // Confirms the linear-interp resampling path runs end-to-end and the
+        // resulting batch tensor has shape [N, TargetLength] at the requested rate.
+        string tempDir = CreateTempDirectory();
+        try
+        {
+            CreateSpeechCommandsDir(tempDir, "yes", count: 2);
+
+            var options = new SpeechCommandsDataLoaderOptions
+            {
+                DataPath = tempDir,
+                AutoDownload = false,
+                UseCoreSubset = false,        // skip silence/unknown for a focused resample test
+                SampleRate = 8000,            // half of native 16kHz
+                TargetLength = 800,           // 100ms at 8kHz
+            };
+
+            var loader = new SpeechCommandsDataLoader<float>(options);
+            await loader.LoadAsync();
+
+            Assert.Equal(2, loader.TotalCount);
+            Assert.Equal(800, loader.FeatureCount);
+
+            // Use a 50/25/25 split (trainRatio must be in (0,1) exclusive). With 2 samples
+            // that yields 1 train sample, which is enough to verify the post-resample shape.
+            var split = loader.Split(trainRatio: 0.5, validationRatio: 0.25, seed: 0);
+            // InMemoryDataLoader still requires LoadAsync before its Features accessor works.
+            await split.Train.LoadAsync();
+            // The Features tensor exposed by the in-memory split should have the resampled
+            // length, proving the resample path produced TargetLength samples per clip.
+            Assert.Equal(800, split.Train.Features.Shape[1]);
+        }
+        finally
+        {
+            CleanupDirectory(tempDir);
+        }
+    }
+
+    [Fact(Timeout = 120000)]
+    public async Task SpeechCommandsLoader_AutoDownloadDisabled_ThrowsOnMissingData()
+    {
+        // Verifies that AutoDownload=false now actually throws (the previous loader
+        // ignored the flag and emitted a misleading "no data found" error).
+        string tempDir = CreateTempDirectory();
+        try
+        {
+            // Note: empty directory — no Speech Commands files at all.
+            var options = new SpeechCommandsDataLoaderOptions
+            {
+                DataPath = tempDir,
+                AutoDownload = false,
+                UseCoreSubset = true,
+            };
+
+            var loader = new SpeechCommandsDataLoader<float>(options);
+            await Assert.ThrowsAsync<InvalidOperationException>(() => loader.LoadAsync());
+        }
+        finally
+        {
+            CleanupDirectory(tempDir);
+        }
+    }
+
+    private static void CreateSpeechCommandsDir(string root, string word, int count)
+    {
+        string dir = Path.Combine(root, word);
+        Directory.CreateDirectory(dir);
+        for (int i = 0; i < count; i++)
+        {
+            string fileName = $"speaker{i}_nohash_0.wav";
+            File.WriteAllBytes(Path.Combine(dir, fileName), CreateSyntheticWav(16000, 1.0));
+        }
+    }
+
+    private static void CreateSpeechCommandsBackgroundNoise(string root, int count)
+    {
+        string dir = Path.Combine(root, "_background_noise_");
+        Directory.CreateDirectory(dir);
+        for (int i = 0; i < count; i++)
+        {
+            File.WriteAllBytes(Path.Combine(dir, $"noise{i}.wav"), CreateSyntheticWav(16000, 1.0));
+        }
+    }
+
     /// <summary>
     /// Creates a minimal synthetic WAV file with a 44-byte header and 16-bit PCM samples.
     /// </summary>

--- a/tests/AiDotNet.Tests/IntegrationTests/Data/AudioBenchmarkTests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/Data/AudioBenchmarkTests.cs
@@ -487,9 +487,11 @@ public class AudioBenchmarkTests
 
             // Pulling a batch goes through the streaming ExtractBatch path:
             // confirms the on-demand WAV decode works and the label shape is correct.
-            var split = loader.Split(trainRatio: 0.6, validationRatio: 0.2, seed: 42);
-            Assert.True(split.Train.TotalCount > 0);
-            Assert.Equal(12, split.Train.OutputDimension);
+            // (Split() is NotSupported on this streaming loader, so we iterate
+            // GetBatches directly to exercise the same codepath.)
+            var first = loader.GetBatches(batchSize: loader.TotalCount, shuffle: false).First();
+            Assert.Equal(new[] { loader.TotalCount, 1600 }, first.Features.Shape.ToArray());
+            Assert.Equal(new[] { loader.TotalCount, 12 }, first.Labels.Shape.ToArray());
         }
         finally
         {
@@ -555,14 +557,10 @@ public class AudioBenchmarkTests
             Assert.Equal(2, loader.TotalCount);
             Assert.Equal(800, loader.FeatureCount);
 
-            // Use a 50/25/25 split (trainRatio must be in (0,1) exclusive). With 2 samples
-            // that yields 1 train sample, which is enough to verify the post-resample shape.
-            var split = loader.Split(trainRatio: 0.5, validationRatio: 0.25, seed: 0);
-            // InMemoryDataLoader still requires LoadAsync before its Features accessor works.
-            await split.Train.LoadAsync();
-            // The Features tensor exposed by the in-memory split should have the resampled
-            // length, proving the resample path produced TargetLength samples per clip.
-            Assert.Equal(800, split.Train.Features.Shape[1]);
+            // Iterate a batch directly — Split() is NotSupported on this streaming
+            // loader, so GetBatches is the way to verify the post-resample shape.
+            var first = loader.GetBatches(batchSize: 2, shuffle: false).First();
+            Assert.Equal(new[] { 2, 800 }, first.Features.Shape.ToArray());
         }
         finally
         {
@@ -588,6 +586,125 @@ public class AudioBenchmarkTests
 
             var loader = new SpeechCommandsDataLoader<float>(options);
             await Assert.ThrowsAsync<InvalidOperationException>(() => loader.LoadAsync());
+        }
+        finally
+        {
+            CleanupDirectory(tempDir);
+        }
+    }
+
+    [Fact(Timeout = 120000)]
+    public async Task SpeechCommandsLoader_OfficialSplitLists_RouteSamplesToCorrectSplit()
+    {
+        // Regression test for the testing_list.txt / validation_list.txt parsing
+        // and the IsInRequestedSplit filter. Two test/val entries per word mean
+        // Train should see fewer samples than the full dir count while Validation
+        // and Test each expose their own dedicated entries.
+        string tempDir = CreateTempDirectory();
+        try
+        {
+            CreateSpeechCommandsDir(tempDir, "yes", count: 5);
+            CreateSpeechCommandsDir(tempDir, "no",  count: 5);
+
+            // Split-list format (relative path with forward slashes, matching the
+            // dataset's Unix-style listing files that the loader then normalises).
+            File.WriteAllLines(Path.Combine(tempDir, "validation_list.txt"), new[]
+            {
+                "yes/speaker0_nohash_0.wav",
+                "no/speaker0_nohash_0.wav",
+            });
+            File.WriteAllLines(Path.Combine(tempDir, "testing_list.txt"), new[]
+            {
+                "yes/speaker1_nohash_0.wav",
+                "no/speaker1_nohash_0.wav",
+            });
+
+            // Train split — expect 3 yes + 3 no = 6 (the 2+2 val/test entries dropped).
+            var trainOptions = new SpeechCommandsDataLoaderOptions
+            {
+                DataPath = tempDir, AutoDownload = false, UseCoreSubset = false,
+                SilenceSampleCount = 0, TargetLength = 1600,
+                Split = AiDotNet.Data.Geometry.DatasetSplit.Train,
+            };
+            var trainLoader = new SpeechCommandsDataLoader<float>(trainOptions);
+            await trainLoader.LoadAsync();
+            Assert.Equal(6, trainLoader.TotalCount);
+
+            // Validation split — expect 1 yes + 1 no = 2.
+            var valOptions = new SpeechCommandsDataLoaderOptions
+            {
+                DataPath = tempDir, AutoDownload = false, UseCoreSubset = false,
+                SilenceSampleCount = 0, TargetLength = 1600,
+                Split = AiDotNet.Data.Geometry.DatasetSplit.Validation,
+            };
+            var valLoader = new SpeechCommandsDataLoader<float>(valOptions);
+            await valLoader.LoadAsync();
+            Assert.Equal(2, valLoader.TotalCount);
+
+            // Test split — expect 1 yes + 1 no = 2.
+            var testOptions = new SpeechCommandsDataLoaderOptions
+            {
+                DataPath = tempDir, AutoDownload = false, UseCoreSubset = false,
+                SilenceSampleCount = 0, TargetLength = 1600,
+                Split = AiDotNet.Data.Geometry.DatasetSplit.Test,
+            };
+            var testLoader = new SpeechCommandsDataLoader<float>(testOptions);
+            await testLoader.LoadAsync();
+            Assert.Equal(2, testLoader.TotalCount);
+        }
+        finally
+        {
+            CleanupDirectory(tempDir);
+        }
+    }
+
+    [Fact(Timeout = 120000)]
+    public async Task SpeechCommandsLoader_MaxSamplesPerClass_EnforcesCap()
+    {
+        // Regression test for the per-class cap. Each keyword dir has 10 WAVs;
+        // with MaxSamplesPerClass=3 we expect exactly 6 samples (3 yes + 3 no).
+        string tempDir = CreateTempDirectory();
+        try
+        {
+            CreateSpeechCommandsDir(tempDir, "yes", count: 10);
+            CreateSpeechCommandsDir(tempDir, "no",  count: 10);
+
+            var options = new SpeechCommandsDataLoaderOptions
+            {
+                DataPath = tempDir, AutoDownload = false, UseCoreSubset = false,
+                SilenceSampleCount = 0, TargetLength = 1600,
+                MaxSamplesPerClass = 3,
+            };
+            var loader = new SpeechCommandsDataLoader<float>(options);
+            await loader.LoadAsync();
+            Assert.Equal(6, loader.TotalCount);
+        }
+        finally
+        {
+            CleanupDirectory(tempDir);
+        }
+    }
+
+    [Fact(Timeout = 120000)]
+    public async Task SpeechCommandsLoader_Split_ThrowsNotSupported()
+    {
+        // The loader is streaming-only; Split() must throw rather than silently
+        // materialising the whole dataset into memory.
+        string tempDir = CreateTempDirectory();
+        try
+        {
+            CreateSpeechCommandsDir(tempDir, "yes", count: 2);
+
+            var options = new SpeechCommandsDataLoaderOptions
+            {
+                DataPath = tempDir, AutoDownload = false, UseCoreSubset = false,
+                SilenceSampleCount = 0, TargetLength = 1600,
+            };
+            var loader = new SpeechCommandsDataLoader<float>(options);
+            await loader.LoadAsync();
+
+            Assert.Throws<NotSupportedException>(() =>
+                loader.Split(trainRatio: 0.5, validationRatio: 0.25, seed: 0));
         }
         finally
         {

--- a/vercel.json
+++ b/vercel.json
@@ -2,7 +2,8 @@
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "version": 2,
   "name": "aidotnet-playground-api",
-  "ignoreCommand": "git diff --quiet HEAD^ HEAD -- api/ vercel.json 2>/dev/null || exit 1",
+  "//": "ignoreCommand: only deploy on master/main pushes (production). Skip ALL preview deploys — PR commits don't need a Vercel preview of the playground API and this was burning the daily deployment quota.",
+  "ignoreCommand": "bash -c 'case \"$VERCEL_GIT_COMMIT_REF\" in master|main) exit 1 ;; *) exit 0 ;; esac'",
   "functions": {
     "api/execute.ts": {
       "maxDuration": 30,

--- a/vercel.json
+++ b/vercel.json
@@ -2,8 +2,7 @@
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "version": 2,
   "name": "aidotnet-playground-api",
-  "//": "ignoreCommand: only deploy on master/main pushes (production). Skip ALL preview deploys — PR commits don't need a Vercel preview of the playground API and this was burning the daily deployment quota.",
-  "ignoreCommand": "bash -c 'case \"$VERCEL_GIT_COMMIT_REF\" in master|main) exit 1 ;; *) exit 0 ;; esac'",
+  "ignoreCommand": "sh -c 'case \"$VERCEL_GIT_COMMIT_REF\" in master|main) exit 1 ;; *) exit 0 ;; esac'",
   "functions": {
     "api/execute.ts": {
       "maxDuration": 30,

--- a/website/vercel.json
+++ b/website/vercel.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "version": 2,
-  "ignoreCommand": "git diff --quiet HEAD^ HEAD -- website/src/ website/public/ website/package.json website/package-lock.json website/vercel.json website/astro.config.mjs website/tailwind.config.mjs website/tsconfig.json 2>/dev/null || exit 1"
+  "//": "ignoreCommand: always skip Vercel Git-integration deploys. Production deploys of this website go through .github/workflows/deploy-website.yml which calls 'vercel deploy --prod' directly, bypassing ignoreCommand. Skipping here avoids burning the daily Vercel deployment quota on every PR commit.",
+  "ignoreCommand": "exit 0"
 }

--- a/website/vercel.json
+++ b/website/vercel.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "version": 2,
-  "//": "ignoreCommand: always skip Vercel Git-integration deploys. Production deploys of this website go through .github/workflows/deploy-website.yml which calls 'vercel deploy --prod' directly, bypassing ignoreCommand. Skipping here avoids burning the daily Vercel deployment quota on every PR commit.",
   "ignoreCommand": "exit 0"
 }


### PR DESCRIPTION
## Summary
- Adds `SpeechCommandsDataLoader<T>` and `SpeechCommandsDataLoaderOptions` for the Google Speech Commands v2 dataset
- Follows the existing `Esc50DataLoader` pattern
- Supports core 12-class subset (default) and full 35-class mode
- Uses official train/validation/test split files

## Operational changes (bundled in this PR)
- **`vercel.json` / `website/vercel.json`**: tighten `ignoreCommand` so Vercel stops auto-deploying on every PR commit (the repo has been hitting Vercel's daily deployment rate limit). After this change:
  - `aidotnet-playground-api` deploys only on pushes to `master`/`main` (production). Skips all preview deploys. This project has no GitHub Actions workflow, so Vercel Git is still needed for production.
  - `aidotnet_website` skips Vercel Git deploys entirely. Production deploys go through `.github/workflows/deploy-website.yml`, which calls `vercel deploy --prod` directly and bypasses `ignoreCommand`.
- Bundled here per maintainer request rather than opened as a separate PR to ship the rate-limit fix faster.

## Test plan
- [x] Build succeeds on net10.0 and net471
- [x] Loader correctly parses directory structure
- [x] Official split lists (testing_list.txt, validation_list.txt) are respected
- [x] Per-class sample limiting works
- [x] WAV files are loaded and padded to target length

Closes #1134

🤖 Generated with [Claude Code](https://claude.com/claude-code)