### PR TITLE
perf: lazy init in diffusion noise predictors + GC between tests

### DIFF
--- a/src/Diffusion/NoisePredictors/AsymmDiTPredictor.cs
+++ b/src/Diffusion/NoisePredictors/AsymmDiTPredictor.cs
@@ -107,13 +107,14 @@ public class AsymmDiTPredictor<T> : NoisePredictorBase<T>
     private void InitializeLayers(int? seed)
     {
         int patchDim = _inputChannels * 4;
-        _patchEmbed = new DenseLayer<T>(patchDim, _hiddenSize, (IActivationFunction<T>)new GELUActivation<T>());
+        // LazyDense defers weight allocation to first Forward() call.
+        _patchEmbed = LazyDense(patchDim, _hiddenSize, new GELUActivation<T>());
 
         _blocks = new DenseLayer<T>[_numLayers];
         for (int i = 0; i < _numLayers; i++)
-            _blocks[i] = new DenseLayer<T>(_hiddenSize, _hiddenSize, (IActivationFunction<T>)new GELUActivation<T>());
+            _blocks[i] = LazyDense(_hiddenSize, _hiddenSize, new GELUActivation<T>());
 
-        _finalLayer = new DenseLayer<T>(_hiddenSize, patchDim, (IActivationFunction<T>?)null);
+        _finalLayer = LazyDense(_hiddenSize, patchDim);
     }
 
     private int CalculateParameterCount()

--- a/src/Diffusion/NoisePredictors/DiTNoisePredictor.cs
+++ b/src/Diffusion/NoisePredictors/DiTNoisePredictor.cs
@@ -288,7 +288,13 @@ public class DiTNoisePredictor<T> : NoisePredictorBase<T>
 
         _blocks = new List<DiTBlock>();
         _numClasses = numClasses;
-        _customBlocks = customBlocks;
+        // Defensive copy of the caller-owned list — without this, a caller who
+        // mutates customBlocks after construction would silently change this
+        // model's block graph at the deferred init point. The lazy-init shift
+        // turned a constructor-time read into a first-use read, so the list
+        // contents must be snapshotted here to preserve construction-time
+        // semantics.
+        _customBlocks = customBlocks == null ? null : new List<DiTBlock>(customBlocks);
         // Defer heavy layer allocation to first use (lazy initialization)
     }
 

--- a/src/Diffusion/NoisePredictors/DiTNoisePredictor.cs
+++ b/src/Diffusion/NoisePredictors/DiTNoisePredictor.cs
@@ -328,27 +328,24 @@ public class DiTNoisePredictor<T> : NoisePredictorBase<T>
         var patchDim = _inputChannels * _patchSize * _patchSize;
         var timeEmbedDim = _hiddenSize * 4;
 
-        // Always create patch embedding, time embedding, and final layers
-        _patchEmbed = new DenseLayer<T>(patchDim, _hiddenSize, activationFunction: null);
+        // Always create patch embedding, time embedding, and final layers. Use
+        // LazyDense so weight tensors stay unallocated until the first Forward()
+        // pass — DiT-XL's default 4 GB of weights would otherwise OOM the CI
+        // runner just from `new DiTNoisePredictor()`.
+        _patchEmbed = LazyDense(patchDim, _hiddenSize);
 
-        _timeEmbed1 = new DenseLayer<T>(
-            _hiddenSize,
-            timeEmbedDim,
-            (IActivationFunction<T>)new SiLUActivation<T>());
-        _timeEmbed2 = new DenseLayer<T>(
-            timeEmbedDim,
-            timeEmbedDim,
-            (IActivationFunction<T>)new SiLUActivation<T>());
+        _timeEmbed1 = LazyDense(_hiddenSize, timeEmbedDim, new SiLUActivation<T>());
+        _timeEmbed2 = LazyDense(timeEmbedDim, timeEmbedDim, new SiLUActivation<T>());
 
         // Class embedding (optional)
         if (numClasses > 0)
         {
-            _labelEmbed = new DenseLayer<T>(numClasses, _hiddenSize, activationFunction: null);
+            _labelEmbed = LazyDense(numClasses, _hiddenSize);
         }
 
         _finalNorm = new LayerNormalizationLayer<T>(_hiddenSize);
-        _adaln_modulation = new DenseLayer<T>(timeEmbedDim, _hiddenSize * 2, activationFunction: null);
-        _outputProj = new DenseLayer<T>(_hiddenSize, patchDim, activationFunction: null);
+        _adaln_modulation = LazyDense(timeEmbedDim, _hiddenSize * 2);
+        _outputProj = LazyDense(_hiddenSize, patchDim);
 
         // Priority 1: Use custom blocks passed directly
         if (customBlocks != null && customBlocks.Count > 0)
@@ -367,8 +364,7 @@ public class DiTNoisePredictor<T> : NoisePredictorBase<T>
                 // Note: if the provided DenseLayer has different dimensions, it will auto-resize
                 // weights on the first forward pass via EnsureWeightShapeForInput.
                 var mlp1 = layer as DenseLayer<T>
-                    ?? new DenseLayer<T>(_hiddenSize, (int)(_hiddenSize * _mlpRatio),
-                        (IActivationFunction<T>)new GELUActivation<T>());
+                    ?? LazyDense(_hiddenSize, (int)(_hiddenSize * _mlpRatio), new GELUActivation<T>());
 
                 _blocks.Add(new DiTBlock
                 {
@@ -376,13 +372,13 @@ public class DiTNoisePredictor<T> : NoisePredictorBase<T>
                     Attention = CreateAttentionLayer(),
                     Norm2 = new LayerNormalizationLayer<T>(_hiddenSize),
                     MLP1 = mlp1,
-                    MLP2 = new DenseLayer<T>((int)(_hiddenSize * _mlpRatio), _hiddenSize, activationFunction: null),
-                    AdaLNModulation = new DenseLayer<T>(timeEmbedDim, _hiddenSize * 6, activationFunction: null),
+                    MLP2 = LazyDense((int)(_hiddenSize * _mlpRatio), _hiddenSize),
+                    AdaLNModulation = LazyDense(timeEmbedDim, _hiddenSize * 6),
                     CrossAttnNorm = new LayerNormalizationLayer<T>(_hiddenSize),
-                    CrossAttnQ = new DenseLayer<T>(_hiddenSize, _hiddenSize, activationFunction: null),
-                    CrossAttnK = new DenseLayer<T>(_contextDim, _hiddenSize, activationFunction: null),
-                    CrossAttnV = new DenseLayer<T>(_contextDim, _hiddenSize, activationFunction: null),
-                    CrossAttnOut = new DenseLayer<T>(_hiddenSize, _hiddenSize, activationFunction: null)
+                    CrossAttnQ = LazyDense(_hiddenSize, _hiddenSize),
+                    CrossAttnK = LazyDense(_contextDim, _hiddenSize),
+                    CrossAttnV = LazyDense(_contextDim, _hiddenSize),
+                    CrossAttnOut = LazyDense(_hiddenSize, _hiddenSize)
                 });
             }
             return;
@@ -406,14 +402,14 @@ public class DiTNoisePredictor<T> : NoisePredictorBase<T>
                 Norm1 = new LayerNormalizationLayer<T>(_hiddenSize),
                 Attention = CreateAttentionLayer(),
                 Norm2 = new LayerNormalizationLayer<T>(_hiddenSize),
-                MLP1 = new DenseLayer<T>(_hiddenSize, mlpHidden, (IActivationFunction<T>)new GELUActivation<T>()),
-                MLP2 = new DenseLayer<T>(mlpHidden, _hiddenSize, activationFunction: null),
-                AdaLNModulation = new DenseLayer<T>(timeEmbedDim, _hiddenSize * 6, activationFunction: null),
+                MLP1 = LazyDense(_hiddenSize, mlpHidden, new GELUActivation<T>()),
+                MLP2 = LazyDense(mlpHidden, _hiddenSize),
+                AdaLNModulation = LazyDense(timeEmbedDim, _hiddenSize * 6),
                 CrossAttnNorm = new LayerNormalizationLayer<T>(_hiddenSize),
-                CrossAttnQ = new DenseLayer<T>(_hiddenSize, _hiddenSize, activationFunction: null),
-                CrossAttnK = new DenseLayer<T>(_contextDim, _hiddenSize, activationFunction: null),
-                CrossAttnV = new DenseLayer<T>(_contextDim, _hiddenSize, activationFunction: null),
-                CrossAttnOut = new DenseLayer<T>(_hiddenSize, _hiddenSize, activationFunction: null)
+                CrossAttnQ = LazyDense(_hiddenSize, _hiddenSize),
+                CrossAttnK = LazyDense(_contextDim, _hiddenSize),
+                CrossAttnV = LazyDense(_contextDim, _hiddenSize),
+                CrossAttnOut = LazyDense(_hiddenSize, _hiddenSize)
             });
         }
     }

--- a/src/Diffusion/NoisePredictors/DiTNoisePredictor.cs
+++ b/src/Diffusion/NoisePredictors/DiTNoisePredictor.cs
@@ -470,6 +470,10 @@ public class DiTNoisePredictor<T> : NoisePredictorBase<T>
     /// </summary>
     private Tensor<T> Forward(Tensor<T> x, Tensor<T> timeEmbed, Tensor<T>? conditioning)
     {
+        // Trigger lazy allocation if not yet done — callers like
+        // PredictNoiseWithEmbedding reach Forward directly on a fresh instance.
+        EnsureLayersInitialized();
+
         if (_patchEmbed == null || _finalNorm == null || _outputProj == null || _adaln_modulation == null)
             throw new InvalidOperationException("Layers not initialized.");
 

--- a/src/Diffusion/NoisePredictors/DiTNoisePredictor.cs
+++ b/src/Diffusion/NoisePredictors/DiTNoisePredictor.cs
@@ -286,23 +286,13 @@ public class DiTNoisePredictor<T> : NoisePredictorBase<T>
         _mlpRatio = mlpRatio;
         _latentSpatialSize = latentSpatialSize;
 
-        // Class-conditional DiT is not yet wired end-to-end: _labelEmbed is
-        // created when numClasses > 0 and participates in param/grad/serialize
-        // plumbing, but no call path injects the class index into the forward
-        // pass, so the embedding weights would train against zero gradient
-        // signal. Fail fast here with a clear error rather than silently
-        // storing weights that never learn. The dead-branch plumbing stays
-        // so a future PR can wire the class-injection path (add classIndex
-        // to PredictNoise, fuse into projected time embedding like the DiT
-        // paper §3.2) without re-adding the infrastructure.
-        if (numClasses > 0)
-        {
-            throw new NotSupportedException(
-                $"DiTNoisePredictor: class-conditional generation (numClasses={numClasses}) is not " +
-                "yet wired into the forward pass. Use numClasses=0 (text-conditional or unconditional) " +
-                "or open an issue to prioritize class-conditional support.");
-        }
-
+        // Class-conditional DiT is fully wired end-to-end per Peebles & Xie 2022
+        // §3.2: when numClasses > 0, _labelEmbed projects one-hot class labels
+        // [B, numClasses] into the time-embedding space and the Forward() path
+        // sums (timeEmbed + classEmbed) into adaLnEmbed, which feeds every
+        // block-level AdaLN modulation and the final-layer AdaLN. See Forward()
+        // for the routing. When numClasses == 0, the `conditioning` argument
+        // instead feeds cross-attention (text-conditional path).
         _blocks = new List<DiTBlock>();
         _numClasses = numClasses;
         // Defensive copy of the caller-owned list — without this, a caller who
@@ -376,10 +366,16 @@ public class DiTNoisePredictor<T> : NoisePredictorBase<T>
         _timeEmbed1 = LazyDense(_hiddenSize, timeEmbedDim, new SiLUActivation<T>());
         _timeEmbed2 = LazyDense(timeEmbedDim, timeEmbedDim, new SiLUActivation<T>());
 
-        // Class embedding (optional)
+        // Class conditioning embedding (Peebles & Xie 2022 §3.2 / Appendix C).
+        // LabelEmbedder: one-hot class labels [B, numClasses] → [B, timeEmbedDim],
+        // added to the projected time embedding in Forward(). The paper's reference
+        // code keeps class and time embeddings in the same space (hidden_size there,
+        // timeEmbedDim here since our time MLP projects up to timeEmbedDim).
+        // Classifier-free guidance reserves an additional "null" class — the caller
+        // is expected to pass a zero one-hot to represent the unconditional token.
         if (numClasses > 0)
         {
-            _labelEmbed = LazyDense(numClasses, _hiddenSize);
+            _labelEmbed = LazyDense(numClasses, timeEmbedDim);
         }
 
         _finalNorm = new LayerNormalizationLayer<T>(_hiddenSize);
@@ -517,7 +513,6 @@ public class DiTNoisePredictor<T> : NoisePredictorBase<T>
             throw new InvalidOperationException("Layers not initialized.");
 
         var shape = x._shape;
-        var batch = shape[0];
         var height = shape[2];
         var width = shape[3];
 
@@ -531,17 +526,43 @@ public class DiTNoisePredictor<T> : NoisePredictorBase<T>
         // Add position embeddings
         hidden = AddPositionEmbedding(hidden, numPatches);
 
-        // Get conditioning embedding if available
-        var condEmbed = conditioning;
-
-        // Process through transformer blocks
-        foreach (var block in _blocks)
+        // Class conditioning (Peebles & Xie 2022 §3.2): when the model was
+        // constructed with numClasses > 0, `conditioning` is the class-label
+        // tensor (one-hot, shape [B, numClasses]). We project it through the
+        // label embedder and ADD it to the time embedding — the sum feeds
+        // every AdaLN modulation in every block AND the final-layer AdaLN.
+        //
+        // When numClasses == 0 (non-class-conditional DiT), `conditioning` is
+        // instead used for cross-attention inside each block — that's the
+        // text/free-form conditioning path used by Stable-Diffusion-style
+        // variants. The two roles are mutually exclusive in the original
+        // DiT paper (class-conditional ImageNet DiT had no text path).
+        var adaLnEmbed = timeEmbed;
+        Tensor<T>? crossAttnCond = conditioning;
+        if (_numClasses > 0 && conditioning != null)
         {
-            hidden = ForwardBlock(hidden, timeEmbed, condEmbed, block);
+            if (_labelEmbed == null)
+                throw new InvalidOperationException("Class embedding layer not initialized despite numClasses > 0.");
+            if (conditioning.Shape.Length < 2 || conditioning.Shape[^1] != _numClasses)
+                throw new ArgumentException(
+                    $"Class-conditional DiT expects `conditioning` to be one-hot class labels with last dim {_numClasses}; got shape [{string.Join(",", conditioning.Shape)}].",
+                    nameof(conditioning));
+
+            var classEmbed = _labelEmbed.Forward(conditioning);
+            adaLnEmbed = Engine.TensorAdd(timeEmbed, classEmbed);
+            // Class conditioning consumed as class labels — don't also pass into cross-attention.
+            crossAttnCond = null;
         }
 
-        // Final norm and projection with AdaLN
-        hidden = FinalLayerWithAdaLN(hidden, timeEmbed);
+        // Process through transformer blocks — every block's AdaLN reads
+        // `adaLnEmbed` (= timeEmbed + classEmbed when class-conditional).
+        foreach (var block in _blocks)
+        {
+            hidden = ForwardBlock(hidden, adaLnEmbed, crossAttnCond, block);
+        }
+
+        // Final norm and projection with AdaLN (also uses the combined embedding)
+        hidden = FinalLayerWithAdaLN(hidden, adaLnEmbed);
 
         // Unpatchify back to image
         var output = Unpatchify(hidden, height, width);

--- a/src/Diffusion/NoisePredictors/DiTNoisePredictor.cs
+++ b/src/Diffusion/NoisePredictors/DiTNoisePredictor.cs
@@ -178,7 +178,8 @@ public class DiTNoisePredictor<T> : NoisePredictorBase<T>
     // Lazy initialization state
     private int _numClasses;
     private List<DiTBlock>? _customBlocks;
-    private bool _layersInitialized;
+    private volatile bool _layersInitialized;
+    private readonly object _initLock = new();
 
     /// <summary>
     /// Position embeddings (learnable).
@@ -296,8 +297,10 @@ public class DiTNoisePredictor<T> : NoisePredictorBase<T>
     /// </summary>
     private void EnsureLayersInitialized()
     {
-        if (!_layersInitialized)
+        if (_layersInitialized) return;
+        lock (_initLock)
         {
+            if (_layersInitialized) return; // double-checked locking
             InitializeLayers(_architecture, _numClasses, _customBlocks);
             _layersInitialized = true;
         }

--- a/src/Diffusion/NoisePredictors/DiTNoisePredictor.cs
+++ b/src/Diffusion/NoisePredictors/DiTNoisePredictor.cs
@@ -286,6 +286,23 @@ public class DiTNoisePredictor<T> : NoisePredictorBase<T>
         _mlpRatio = mlpRatio;
         _latentSpatialSize = latentSpatialSize;
 
+        // Class-conditional DiT is not yet wired end-to-end: _labelEmbed is
+        // created when numClasses > 0 and participates in param/grad/serialize
+        // plumbing, but no call path injects the class index into the forward
+        // pass, so the embedding weights would train against zero gradient
+        // signal. Fail fast here with a clear error rather than silently
+        // storing weights that never learn. The dead-branch plumbing stays
+        // so a future PR can wire the class-injection path (add classIndex
+        // to PredictNoise, fuse into projected time embedding like the DiT
+        // paper §3.2) without re-adding the infrastructure.
+        if (numClasses > 0)
+        {
+            throw new NotSupportedException(
+                $"DiTNoisePredictor: class-conditional generation (numClasses={numClasses}) is not " +
+                "yet wired into the forward pass. Use numClasses=0 (text-conditional or unconditional) " +
+                "or open an issue to prioritize class-conditional support.");
+        }
+
         _blocks = new List<DiTBlock>();
         _numClasses = numClasses;
         // Defensive copy of the caller-owned list — without this, a caller who

--- a/src/Diffusion/NoisePredictors/DiTNoisePredictor.cs
+++ b/src/Diffusion/NoisePredictors/DiTNoisePredictor.cs
@@ -295,12 +295,25 @@ public class DiTNoisePredictor<T> : NoisePredictorBase<T>
     /// <summary>
     /// Ensures layers are initialized (lazy init on first use).
     /// </summary>
+    /// <remarks>
+    /// Retry-safe: if <see cref="InitializeLayers"/> throws after partially
+    /// populating <c>_blocks</c>, the next call must rebuild from a clean
+    /// slate. Without the pre-clear, a retry would append a second set of
+    /// blocks on top of the partial state, doubling the layer graph.
+    /// <c>_layersInitialized = true</c> is the LAST step inside the lock so
+    /// observers never see a partially-built graph.
+    /// </remarks>
     private void EnsureLayersInitialized()
     {
         if (_layersInitialized) return;
         lock (_initLock)
         {
             if (_layersInitialized) return; // double-checked locking
+            // Clear any partial state from a prior failed init attempt.
+            // _blocks is the only mutable collection touched by InitializeLayers;
+            // other fields (_patchEmbed, _timeEmbed1, etc.) are reassigned
+            // wholesale by InitializeLayers so partial state there isn't a hazard.
+            _blocks.Clear();
             InitializeLayers(_architecture, _numClasses, _customBlocks);
             _layersInitialized = true;
         }

--- a/src/Diffusion/NoisePredictors/DiffusionResBlock.cs
+++ b/src/Diffusion/NoisePredictors/DiffusionResBlock.cs
@@ -1,5 +1,6 @@
 ﻿#pragma warning disable CS0649, CS0414, CS0169
 using AiDotNet.Helpers;
+using AiDotNet.Initialization;
 using AiDotNet.NeuralNetworks.Layers;
 
 namespace AiDotNet.Diffusion.NoisePredictors;
@@ -93,7 +94,9 @@ public class DiffusionResBlock<T> : LayerBase<T>
         int groups1 = ComputeNumGroups(inChannels, numGroups);
         int groups2 = ComputeNumGroups(outChannels, numGroups);
 
-        // First block: GroupNorm(in) → SiLU → Conv3x3(in→out)
+        // First block: GroupNorm(in) → SiLU → Conv3x3(in→out). Pass the Lazy strategy
+        // so kernel tensors stay unallocated until the first Forward() call — diffusion
+        // U-Nets contain dozens of these blocks and eager allocation OOMs CI.
         _norm1 = new GroupNormalizationLayer<T>(groups1, inChannels);
         _conv1 = new ConvolutionalLayer<T>(
             inputDepth: inChannels,
@@ -103,13 +106,15 @@ public class DiffusionResBlock<T> : LayerBase<T>
             kernelSize: 3,
             stride: 1,
             padding: 1,
-            activationFunction: new IdentityActivation<T>());
+            activationFunction: new IdentityActivation<T>(),
+            initializationStrategy: InitializationStrategies<T>.Lazy);
 
         // Time embedding projection: projects time embed to outChannels for additive conditioning
         _timeMlp = new DenseLayer<T>(
             timeEmbedDim > 0 ? timeEmbedDim : 1,
             outChannels,
-            (IActivationFunction<T>)new SiLUActivation<T>());
+            (IActivationFunction<T>)new SiLUActivation<T>(),
+            InitializationStrategies<T>.Lazy);
 
         // Second block: GroupNorm(out) → SiLU → Conv3x3(out→out)
         _norm2 = new GroupNormalizationLayer<T>(groups2, outChannels);
@@ -121,7 +126,8 @@ public class DiffusionResBlock<T> : LayerBase<T>
             kernelSize: 3,
             stride: 1,
             padding: 1,
-            activationFunction: new IdentityActivation<T>());
+            activationFunction: new IdentityActivation<T>(),
+            initializationStrategy: InitializationStrategies<T>.Lazy);
 
         // Skip connection: 1x1 conv if channels differ
         if (inChannels != outChannels)
@@ -134,7 +140,8 @@ public class DiffusionResBlock<T> : LayerBase<T>
                 kernelSize: 1,
                 stride: 1,
                 padding: 0,
-                activationFunction: new IdentityActivation<T>());
+                activationFunction: new IdentityActivation<T>(),
+                initializationStrategy: InitializationStrategies<T>.Lazy);
         }
     }
 

--- a/src/Diffusion/NoisePredictors/EMMDiTPredictor.cs
+++ b/src/Diffusion/NoisePredictors/EMMDiTPredictor.cs
@@ -104,13 +104,15 @@ public class EMMDiTPredictor<T> : NoisePredictorBase<T>
     private void InitializeLayers(int? seed)
     {
         int patchDim = _inputChannels * 4;
-        _patchEmbed = new DenseLayer<T>(patchDim, EMMDIT_HIDDEN_SIZE, (IActivationFunction<T>)new GELUActivation<T>());
+        // LazyDense: weight tensors stay unallocated until first Forward() — avoids
+        // eagerly materializing ~GB of weights at construction time.
+        _patchEmbed = LazyDense(patchDim, EMMDIT_HIDDEN_SIZE, new GELUActivation<T>());
 
         _blocks = new DenseLayer<T>[EMMDIT_NUM_LAYERS];
         for (int i = 0; i < EMMDIT_NUM_LAYERS; i++)
-            _blocks[i] = new DenseLayer<T>(EMMDIT_HIDDEN_SIZE, EMMDIT_HIDDEN_SIZE, (IActivationFunction<T>)new GELUActivation<T>());
+            _blocks[i] = LazyDense(EMMDIT_HIDDEN_SIZE, EMMDIT_HIDDEN_SIZE, new GELUActivation<T>());
 
-        _finalLayer = new DenseLayer<T>(EMMDIT_HIDDEN_SIZE, patchDim, (IActivationFunction<T>?)null);
+        _finalLayer = LazyDense(EMMDIT_HIDDEN_SIZE, patchDim);
     }
 
     private int CalculateParameterCount()

--- a/src/Diffusion/NoisePredictors/FlagDiTPredictor.cs
+++ b/src/Diffusion/NoisePredictors/FlagDiTPredictor.cs
@@ -106,13 +106,14 @@ public class FlagDiTPredictor<T> : NoisePredictorBase<T>
     private void InitializeLayers(int? seed)
     {
         int patchDim = _inputChannels * 4;
-        _patchEmbed = new DenseLayer<T>(patchDim, _hiddenSize, (IActivationFunction<T>)new GELUActivation<T>());
+        // LazyDense defers weight allocation to first Forward() call.
+        _patchEmbed = LazyDense(patchDim, _hiddenSize, new GELUActivation<T>());
 
         _blocks = new DenseLayer<T>[_numLayers];
         for (int i = 0; i < _numLayers; i++)
-            _blocks[i] = new DenseLayer<T>(_hiddenSize, _hiddenSize, (IActivationFunction<T>)new GELUActivation<T>());
+            _blocks[i] = LazyDense(_hiddenSize, _hiddenSize, new GELUActivation<T>());
 
-        _finalLayer = new DenseLayer<T>(_hiddenSize, patchDim, (IActivationFunction<T>?)null);
+        _finalLayer = LazyDense(_hiddenSize, patchDim);
     }
 
     private int CalculateParameterCount()

--- a/src/Diffusion/NoisePredictors/FluxDoubleStreamPredictor.cs
+++ b/src/Diffusion/NoisePredictors/FluxDoubleStreamPredictor.cs
@@ -108,17 +108,18 @@ public class FluxDoubleStreamPredictor<T> : NoisePredictorBase<T>
     private void InitializeLayers(int? seed)
     {
         int patchDim = _inputChannels * 4; // 2x2 patches
-        _patchEmbed = new DenseLayer<T>(patchDim, _hiddenSize, (IActivationFunction<T>)new GELUActivation<T>());
+        // LazyDense defers weight allocation to first Forward() call.
+        _patchEmbed = LazyDense(patchDim, _hiddenSize, new GELUActivation<T>());
 
         _doubleBlocks = new DenseLayer<T>[_numJointLayers];
         for (int i = 0; i < _numJointLayers; i++)
-            _doubleBlocks[i] = new DenseLayer<T>(_hiddenSize, _hiddenSize, (IActivationFunction<T>)new GELUActivation<T>());
+            _doubleBlocks[i] = LazyDense(_hiddenSize, _hiddenSize, new GELUActivation<T>());
 
         _singleBlocks = new DenseLayer<T>[_numSingleLayers];
         for (int i = 0; i < _numSingleLayers; i++)
-            _singleBlocks[i] = new DenseLayer<T>(_hiddenSize, _hiddenSize, (IActivationFunction<T>)new GELUActivation<T>());
+            _singleBlocks[i] = LazyDense(_hiddenSize, _hiddenSize, new GELUActivation<T>());
 
-        _finalLayer = new DenseLayer<T>(_hiddenSize, patchDim, (IActivationFunction<T>?)null);
+        _finalLayer = LazyDense(_hiddenSize, patchDim);
     }
 
     private int CalculateParameterCount()

--- a/src/Diffusion/NoisePredictors/MMDiTNoisePredictor.cs
+++ b/src/Diffusion/NoisePredictors/MMDiTNoisePredictor.cs
@@ -253,26 +253,23 @@ public class MMDiTNoisePredictor<T> : NoisePredictorBase<T>
         var patchDim = _inputChannels * _patchSize * _patchSize;
         var timeEmbedDim = _hiddenSize * 4;
 
-        // Patch embedding: linear projection from flattened patch to hidden dim
-        _patchEmbed = new DenseLayer<T>(patchDim, _hiddenSize, activationFunction: null);
+        // Patch embedding: linear projection from flattened patch to hidden dim.
+        // Use LazyDense so weight tensors stay unallocated until Forward() — full
+        // MMDiT (~2 GB of weights at default sizes) would otherwise OOM the CI
+        // runner just from `new MMDiTNoisePredictor()`.
+        _patchEmbed = LazyDense(patchDim, _hiddenSize);
 
         // Time embedding MLP
-        _timeEmbed1 = new DenseLayer<T>(
-            _hiddenSize,
-            timeEmbedDim,
-            (IActivationFunction<T>)new SiLUActivation<T>());
-        _timeEmbed2 = new DenseLayer<T>(
-            timeEmbedDim,
-            timeEmbedDim,
-            (IActivationFunction<T>)new SiLUActivation<T>());
+        _timeEmbed1 = LazyDense(_hiddenSize, timeEmbedDim, new SiLUActivation<T>());
+        _timeEmbed2 = LazyDense(timeEmbedDim, timeEmbedDim, new SiLUActivation<T>());
 
         // Context projection: project text embeddings to hidden dim
-        _contextProj = new DenseLayer<T>(_contextDim, _hiddenSize, activationFunction: null);
+        _contextProj = LazyDense(_contextDim, _hiddenSize);
 
         // Final layers
         _finalNorm = new LayerNormalizationLayer<T>(_hiddenSize);
-        _adalnModulation = new DenseLayer<T>(timeEmbedDim, _hiddenSize * 2, activationFunction: null);
-        _outputProj = new DenseLayer<T>(_hiddenSize, patchDim, activationFunction: null);
+        _adalnModulation = LazyDense(timeEmbedDim, _hiddenSize * 2);
+        _outputProj = LazyDense(_hiddenSize, patchDim);
 
         // Priority 1: Use custom blocks passed directly
         if (customJointBlocks != null && customJointBlocks.Count > 0)
@@ -317,27 +314,27 @@ public class MMDiTNoisePredictor<T> : NoisePredictorBase<T>
             // Image stream
             ImageNorm1 = new LayerNormalizationLayer<T>(_hiddenSize),
             ImageNorm2 = new LayerNormalizationLayer<T>(_hiddenSize),
-            ImageMLP1 = new DenseLayer<T>(_hiddenSize, mlpHidden, (IActivationFunction<T>)new GELUActivation<T>()),
-            ImageMLP2 = new DenseLayer<T>(mlpHidden, _hiddenSize, activationFunction: null),
-            ImageAdaLN = new DenseLayer<T>(timeEmbedDim, _hiddenSize * 6, activationFunction: null),
+            ImageMLP1 = LazyDense(_hiddenSize, mlpHidden, new GELUActivation<T>()),
+            ImageMLP2 = LazyDense(mlpHidden, _hiddenSize),
+            ImageAdaLN = LazyDense(timeEmbedDim, _hiddenSize * 6),
 
             // Text stream
             TextNorm1 = new LayerNormalizationLayer<T>(_hiddenSize),
             TextNorm2 = new LayerNormalizationLayer<T>(_hiddenSize),
-            TextMLP1 = new DenseLayer<T>(_hiddenSize, mlpHidden, (IActivationFunction<T>)new GELUActivation<T>()),
-            TextMLP2 = new DenseLayer<T>(mlpHidden, _hiddenSize, activationFunction: null),
-            TextAdaLN = new DenseLayer<T>(timeEmbedDim, _hiddenSize * 6, activationFunction: null),
+            TextMLP1 = LazyDense(_hiddenSize, mlpHidden, new GELUActivation<T>()),
+            TextMLP2 = LazyDense(mlpHidden, _hiddenSize),
+            TextAdaLN = LazyDense(timeEmbedDim, _hiddenSize * 6),
 
             // Joint attention Q/K/V projections
-            ImageQProj = new DenseLayer<T>(_hiddenSize, _hiddenSize, activationFunction: null),
-            ImageKProj = new DenseLayer<T>(_hiddenSize, _hiddenSize, activationFunction: null),
-            ImageVProj = new DenseLayer<T>(_hiddenSize, _hiddenSize, activationFunction: null),
-            ImageOutProj = new DenseLayer<T>(_hiddenSize, _hiddenSize, activationFunction: null),
+            ImageQProj = LazyDense(_hiddenSize, _hiddenSize),
+            ImageKProj = LazyDense(_hiddenSize, _hiddenSize),
+            ImageVProj = LazyDense(_hiddenSize, _hiddenSize),
+            ImageOutProj = LazyDense(_hiddenSize, _hiddenSize),
 
-            TextQProj = new DenseLayer<T>(_hiddenSize, _hiddenSize, activationFunction: null),
-            TextKProj = new DenseLayer<T>(_hiddenSize, _hiddenSize, activationFunction: null),
-            TextVProj = new DenseLayer<T>(_hiddenSize, _hiddenSize, activationFunction: null),
-            TextOutProj = new DenseLayer<T>(_hiddenSize, _hiddenSize, activationFunction: null)
+            TextQProj = LazyDense(_hiddenSize, _hiddenSize),
+            TextKProj = LazyDense(_hiddenSize, _hiddenSize),
+            TextVProj = LazyDense(_hiddenSize, _hiddenSize),
+            TextOutProj = LazyDense(_hiddenSize, _hiddenSize)
         };
     }
 
@@ -350,13 +347,13 @@ public class MMDiTNoisePredictor<T> : NoisePredictorBase<T>
             _singleBlocks.Add(new MMDiTSingleBlock
             {
                 Norm = new LayerNormalizationLayer<T>(_hiddenSize),
-                QProj = new DenseLayer<T>(_hiddenSize, _hiddenSize, activationFunction: null),
-                KProj = new DenseLayer<T>(_hiddenSize, _hiddenSize, activationFunction: null),
-                VProj = new DenseLayer<T>(_hiddenSize, _hiddenSize, activationFunction: null),
-                OutProj = new DenseLayer<T>(_hiddenSize, _hiddenSize, activationFunction: null),
-                MLP1 = new DenseLayer<T>(_hiddenSize, mlpHidden, (IActivationFunction<T>)new GELUActivation<T>()),
-                MLP2 = new DenseLayer<T>(mlpHidden, _hiddenSize, activationFunction: null),
-                AdaLN = new DenseLayer<T>(timeEmbedDim, _hiddenSize * 3, activationFunction: null)
+                QProj = LazyDense(_hiddenSize, _hiddenSize),
+                KProj = LazyDense(_hiddenSize, _hiddenSize),
+                VProj = LazyDense(_hiddenSize, _hiddenSize),
+                OutProj = LazyDense(_hiddenSize, _hiddenSize),
+                MLP1 = LazyDense(_hiddenSize, mlpHidden, new GELUActivation<T>()),
+                MLP2 = LazyDense(mlpHidden, _hiddenSize),
+                AdaLN = LazyDense(timeEmbedDim, _hiddenSize * 3)
             });
         }
     }

--- a/src/Diffusion/NoisePredictors/MMDiTXNoisePredictor.cs
+++ b/src/Diffusion/NoisePredictors/MMDiTXNoisePredictor.cs
@@ -115,13 +115,15 @@ public class MMDiTXNoisePredictor<T> : NoisePredictorBase<T>
     private void InitializeLayers(int? seed)
     {
         int patchDim = _inputChannels * _patchSize * _patchSize;
-        _patchEmbed = new DenseLayer<T>(patchDim, _hiddenSize, (IActivationFunction<T>)new GELUActivation<T>());
+        // LazyDense keeps weight tensors unallocated until Forward() — avoids
+        // OOM at construction time under production-scale defaults.
+        _patchEmbed = LazyDense(patchDim, _hiddenSize, new GELUActivation<T>());
 
         _jointBlocks = new DenseLayer<T>[_numJointLayers];
         for (int i = 0; i < _numJointLayers; i++)
-            _jointBlocks[i] = new DenseLayer<T>(_hiddenSize, _hiddenSize, (IActivationFunction<T>)new GELUActivation<T>());
+            _jointBlocks[i] = LazyDense(_hiddenSize, _hiddenSize, new GELUActivation<T>());
 
-        _finalLayer = new DenseLayer<T>(_hiddenSize, patchDim, (IActivationFunction<T>?)null);
+        _finalLayer = LazyDense(_hiddenSize, patchDim);
         _posEmbed = new Vector<T>(1024 * _hiddenSize);
         var rng = seed.HasValue ? RandomHelper.CreateSeededRandom(seed.Value) : RandomHelper.CreateSecureRandom();
         for (int i = 0; i < _posEmbed.Length; i++)

--- a/src/Diffusion/NoisePredictors/NoisePredictorBase.cs
+++ b/src/Diffusion/NoisePredictors/NoisePredictorBase.cs
@@ -1,8 +1,10 @@
 ﻿using AiDotNet.Autodiff;
 using AiDotNet.Engines;
 using AiDotNet.Extensions;
+using AiDotNet.Initialization;
 using AiDotNet.Interfaces;
 using AiDotNet.LossFunctions;
+using AiDotNet.NeuralNetworks.Layers;
 using AiDotNet.Tensors.Engines.Autodiff;
 using AiDotNet.Models;
 using AiDotNet.Models.Options;
@@ -100,6 +102,56 @@ public abstract class NoisePredictorBase<T> : INoisePredictor<T>, IModelShape
             ? RandomHelper.CreateSeededRandom(seed.Value)
             : RandomHelper.CreateSecureRandom();
     }
+
+    #region Lazy Layer Factories
+
+    // Large diffusion noise predictors (DiT-XL: 28 layers × 1152 hidden × 4× MLP ratio)
+    // allocate ~4 GB of weight tensors at construction time when layers eagerly call
+    // TensorAllocator.Rent from their ctors. That crushes CI and masks real test
+    // failures behind OOM. These helpers wire every layer with
+    // InitializationStrategies<T>.Lazy so weight tensors stay at size 0 until the
+    // first Forward() pass actually needs them — construction becomes O(1) and
+    // allocation scales with the actual tests that exercise the model.
+
+    /// <summary>
+    /// Creates a <see cref="DenseLayer{T}"/> with lazy weight allocation —
+    /// weight/bias tensors stay zero-sized until the first Forward() call.
+    /// </summary>
+    protected static DenseLayer<T> LazyDense(
+        int inputSize,
+        int outputSize,
+        IActivationFunction<T>? activation = null)
+        => new DenseLayer<T>(inputSize, outputSize, activation, InitializationStrategies<T>.Lazy);
+
+    /// <summary>
+    /// Creates a <see cref="DenseLayer{T}"/> with a vector activation and lazy weight
+    /// allocation. Distinct name from <see cref="LazyDense(int, int, IActivationFunction{T}?)"/>
+    /// because the two ctor overloads otherwise collide on overload resolution for
+    /// activations that implement both scalar and vector interfaces.
+    /// </summary>
+    protected static DenseLayer<T> LazyDenseVec(
+        int inputSize,
+        int outputSize,
+        IVectorActivationFunction<T> vectorActivation)
+        => new DenseLayer<T>(inputSize, outputSize, vectorActivation, InitializationStrategies<T>.Lazy);
+
+    /// <summary>
+    /// Creates a <see cref="ConvolutionalLayer{T}"/> with lazy weight allocation.
+    /// </summary>
+    protected static ConvolutionalLayer<T> LazyConv2D(
+        int inputDepth,
+        int inputHeight,
+        int inputWidth,
+        int outputDepth,
+        int kernelSize,
+        int stride = 1,
+        int padding = 0,
+        IActivationFunction<T>? activation = null)
+        => new ConvolutionalLayer<T>(
+            inputDepth, inputHeight, inputWidth, outputDepth,
+            kernelSize, stride, padding, activation, InitializationStrategies<T>.Lazy);
+
+    #endregion
 
     #region INoisePredictor<T> Implementation
 

--- a/src/Diffusion/NoisePredictors/SiTPredictor.cs
+++ b/src/Diffusion/NoisePredictors/SiTPredictor.cs
@@ -102,13 +102,14 @@ public class SiTPredictor<T> : NoisePredictorBase<T>
         if (!_initialized)
         {
             int patchDim = _inputChannels * 4;
-            _patchEmbed = new DenseLayer<T>(patchDim, _hiddenSize, (IActivationFunction<T>)new GELUActivation<T>());
+            // LazyDense defers weight allocation to first Forward() call.
+            _patchEmbed = LazyDense(patchDim, _hiddenSize, new GELUActivation<T>());
 
             _blocks = new DenseLayer<T>[_numLayers];
             for (int i = 0; i < _numLayers; i++)
-                _blocks[i] = new DenseLayer<T>(_hiddenSize, _hiddenSize, (IActivationFunction<T>)new GELUActivation<T>());
+                _blocks[i] = LazyDense(_hiddenSize, _hiddenSize, new GELUActivation<T>());
 
-            _finalLayer = new DenseLayer<T>(_hiddenSize, patchDim, (IActivationFunction<T>?)null);
+            _finalLayer = LazyDense(_hiddenSize, patchDim);
             _initialized = true;
         }
 

--- a/src/Diffusion/NoisePredictors/UNetNoisePredictor.cs
+++ b/src/Diffusion/NoisePredictors/UNetNoisePredictor.cs
@@ -727,15 +727,16 @@ public class UNetNoisePredictor<T> : NoisePredictorBase<T>
 
     private ILayer<T> CreateDownsample(int channels, int spatialSize)
     {
-        return new ConvolutionalLayer<T>(
+        // LazyConv2D: kernel tensor stays unallocated until first Forward() call.
+        return LazyConv2D(
             inputDepth: channels,
-            outputDepth: channels,
-            kernelSize: 3,
             inputHeight: spatialSize,
             inputWidth: spatialSize,
+            outputDepth: channels,
+            kernelSize: 3,
             stride: 2,
             padding: 1,
-            activationFunction: new IdentityActivation<T>());
+            activation: new IdentityActivation<T>());
     }
 
     private ILayer<T> CreateUpsample(int channels, int spatialSize)

--- a/src/Diffusion/NoisePredictors/UViTNoisePredictor.cs
+++ b/src/Diffusion/NoisePredictors/UViTNoisePredictor.cs
@@ -170,14 +170,12 @@ public class UViTNoisePredictor<T> : NoisePredictorBase<T>
         int timeEmbedDim = _hiddenSize * 4;
         int halfLayers = _numLayers / 2;
 
-        // Patch embedding
-        _patchEmbed = new DenseLayer<T>(patchDim, _hiddenSize, activationFunction: null);
+        // Patch embedding — lazy weight allocation defers ~2+ GB until Forward().
+        _patchEmbed = LazyDense(patchDim, _hiddenSize);
 
         // Time embedding MLP
-        _timeEmbed1 = new DenseLayer<T>(
-            _hiddenSize, timeEmbedDim,
-            (IActivationFunction<T>)new SiLUActivation<T>());
-        _timeEmbed2 = new DenseLayer<T>(timeEmbedDim, _hiddenSize, activationFunction: null);
+        _timeEmbed1 = LazyDense(_hiddenSize, timeEmbedDim, new SiLUActivation<T>());
+        _timeEmbed2 = LazyDense(timeEmbedDim, _hiddenSize);
 
         // Encoder blocks
         for (int i = 0; i < halfLayers; i++)
@@ -193,13 +191,13 @@ public class UViTNoisePredictor<T> : NoisePredictorBase<T>
         {
             _decoderBlocks.Add(CreateBlock());
             // Skip projection: [2*hidden] → [hidden]
-            _skipProjections.Add(new DenseLayer<T>(_hiddenSize * 2, _hiddenSize, activationFunction: null));
+            _skipProjections.Add(LazyDense(_hiddenSize * 2, _hiddenSize));
         }
 
         // Final norm and output
         _finalNorm = new LayerNormalizationLayer<T>(_hiddenSize);
         int outPatchDim = _inputChannels * _patchSize * _patchSize;
-        _outputProj = new DenseLayer<T>(_hiddenSize, outPatchDim, activationFunction: null);
+        _outputProj = LazyDense(_hiddenSize, outPatchDim);
 
         // Position embeddings (computed from latent spatial size and patch size)
         var posEmbData = new T[_maxPatches * _hiddenSize];
@@ -220,8 +218,8 @@ public class UViTNoisePredictor<T> : NoisePredictorBase<T>
             Norm1 = new LayerNormalizationLayer<T>(_hiddenSize),
             Attention = new SelfAttentionLayer<T>(_maxPatches, _hiddenSize, _numHeads, activationFunction: null),
             Norm2 = new LayerNormalizationLayer<T>(_hiddenSize),
-            MLP1 = new DenseLayer<T>(_hiddenSize, _hiddenSize * 4, (IActivationFunction<T>)new GELUActivation<T>()),
-            MLP2 = new DenseLayer<T>(_hiddenSize * 4, _hiddenSize, activationFunction: null)
+            MLP1 = LazyDense(_hiddenSize, _hiddenSize * 4, new GELUActivation<T>()),
+            MLP2 = LazyDense(_hiddenSize * 4, _hiddenSize)
         };
     }
 

--- a/src/Diffusion/NoisePredictors/VideoUNetPredictor.cs
+++ b/src/Diffusion/NoisePredictors/VideoUNetPredictor.cs
@@ -977,8 +977,11 @@ public class VideoUNetPredictor<T> : NoisePredictorBase<T>
         // The layer operates on the temporal axis (numFrames), not the channel axis.
         // Each spatial-channel position has its own numFrames-long vector that this
         // layer learns to mix — analogous to a depthwise-temporal 1x1 convolution
-        // in the time dimension.
-        return new DenseLayer<T>(_numFrames, _numFrames, (IActivationFunction<T>)new SiLUActivation<T>());
+        // in the time dimension. LazyDense defers weight allocation until first
+        // Forward — critical because TimeCondProjection + TemporalResBlock are
+        // added to EVERY encoder, middle, and decoder block, multiplying the
+        // memory pressure that lazy init was meant to relieve.
+        return LazyDense(_numFrames, _numFrames, new SiLUActivation<T>());
     }
 
     /// <summary>
@@ -987,7 +990,10 @@ public class VideoUNetPredictor<T> : NoisePredictorBase<T>
     /// </summary>
     private DenseLayer<T> CreateTimeCondProjection(int channels)
     {
-        return new DenseLayer<T>(_timeEmbeddingDim, channels * 2, activationFunction: null);
+        // LazyDense — see CreateTemporalResBlock comment. Without lazy init this
+        // factory eagerly allocates timeEmbeddingDim*(channels*2) parameters per
+        // block × N blocks per VideoUNet, defeating the PR's lazy-init goal.
+        return LazyDense(_timeEmbeddingDim, channels * 2, activation: null);
     }
 
     private ILayer<T> CreateSpatialAttention(int channels)

--- a/src/Diffusion/NoisePredictors/VideoUNetPredictor.cs
+++ b/src/Diffusion/NoisePredictors/VideoUNetPredictor.cs
@@ -642,20 +642,20 @@ public class VideoUNetPredictor<T> : NoisePredictorBase<T>
         int channels = condVec.Shape[^1] / 2;
         int batchSize = condVec.Shape[0];
 
-        // Split into scale [B, C] and shift [B, C]
-        var scaleData = new T[batchSize * channels];
-        var shiftData = new T[batchSize * channels];
-        var condSpan = condVec.AsSpan();
-        for (int b = 0; b < batchSize; b++)
-        {
-            int srcBase = b * channels * 2;
-            int dstBase = b * channels;
-            for (int c = 0; c < channels; c++)
-            {
-                scaleData[dstBase + c] = condSpan[srcBase + c];
-                shiftData[dstBase + c] = condSpan[srcBase + channels + c];
-            }
-        }
+        // Split [B, channels*2] → scale [B, channels] and shift [B, channels]
+        // via tape-tracked Engine ops. The previous implementation copied data
+        // into raw managed arrays via AsSpan() and built fresh Tensor<T>
+        // instances from them — that detaches the autograd tape, so gradients
+        // wouldn't flow back into projection's weights and the FiLM layer
+        // never learned. TensorSlice keeps the split inside the Engine graph.
+        var scale2D = Engine.TensorSlice(
+            condVec,
+            start: new[] { 0, 0 },
+            length: new[] { batchSize, channels });
+        var shift2D = Engine.TensorSlice(
+            condVec,
+            start: new[] { 0, channels },
+            length: new[] { batchSize, channels });
 
         // Reshape scale/shift to broadcast over spatial (+ temporal) dims.
         // Image: x is [B, C, H, W] → scale/shift [B, C, 1, 1]
@@ -664,8 +664,8 @@ public class VideoUNetPredictor<T> : NoisePredictorBase<T>
             ? new[] { batchSize, channels, 1, 1, 1 }
             : new[] { batchSize, channels, 1, 1 };
 
-        var scaleTensor = new Tensor<T>(scaleData, broadcastShape);
-        var shiftTensor = new Tensor<T>(shiftData, broadcastShape);
+        var scaleTensor = Engine.Reshape(scale2D, broadcastShape);
+        var shiftTensor = Engine.Reshape(shift2D, broadcastShape);
 
         // x = x * (1 + scale) + shift
         var onePlusScale = Engine.TensorBroadcastAdd(
@@ -712,23 +712,36 @@ public class VideoUNetPredictor<T> : NoisePredictorBase<T>
     /// </remarks>
     private Tensor<T> ApplyTemporalProcessing(ILayer<T> temporalLayer, Tensor<T> video)
     {
-        // Video shape: [B, C, F, H, W]
-        var shape = video._shape;
+        // Video shape: [B, C, F, H, W]. Clone the shape array — video._shape is
+        // the tensor's mutable backing storage, sharing it would let downstream
+        // mutations corrupt the source tensor.
+        var shape = (int[])video._shape.Clone();
         int batch = shape[0];
         int channels = shape[1];
         int frames = shape[2];
         int height = shape[3];
         int width = shape[4];
 
-        // Reshape to [B*C*H*W, F] — each row is a temporal vector at one spatial-channel position.
+        // Move F to the innermost axis BEFORE flattening — without this permute,
+        // a direct Reshape of [B, C, F, H, W] to [B*C*H*W, F] groups contiguous
+        // spatial elements into the F slot instead of one temporal vector per
+        // (b, c, h, w) position. The temporal Dense would then mix the wrong
+        // values (spatial neighbors instead of frames). Layout after permute:
+        //   [B, C, F, H, W]  → permute(0,1,3,4,2) → [B, C, H, W, F]
+        // → reshape → [B*C*H*W, F] (now correctly one temporal vector per row).
+        var permuted = Engine.TensorPermute(video, new[] { 0, 1, 3, 4, 2 });
+
         int spatialChannelPositions = batch * channels * height * width;
-        var flat = Engine.Reshape(video, new[] { spatialChannelPositions, frames });
+        var flat = Engine.Reshape(permuted, new[] { spatialChannelPositions, frames });
 
         // Apply temporal mixing layer: [B*C*H*W, F] → [B*C*H*W, F]
         var mixed = temporalLayer.Forward(flat);
 
-        // Reshape back to [B, C, F, H, W]
-        var mixedVideo = Engine.Reshape(mixed, shape);
+        // Reshape back to [B, C, H, W, F] then permute axes back to [B, C, F, H, W]
+        // — must invert the earlier permute so the residual add lines up with
+        // the original frame ordering.
+        var mixedPermuted = Engine.Reshape(mixed, new[] { batch, channels, height, width, frames });
+        var mixedVideo = Engine.TensorPermute(mixedPermuted, new[] { 0, 1, 4, 2, 3 });
 
         // Residual connection: output = input + temporalDelta
         // Per the paper, the residual ensures the temporal block only needs to learn
@@ -1109,6 +1122,11 @@ public class VideoUNetPredictor<T> : NoisePredictorBase<T>
         AddLayerParameters(parameters, block.SpatialAttention);
         AddLayerParameters(parameters, block.TemporalAttention);
         AddLayerParameters(parameters, block.CrossAttention);
+        // TimeCondProjection is a trainable DenseLayer added to every block —
+        // omitting it from the param/grad/serialize plumbing would mean its
+        // weights silently miss optimizer updates and don't survive
+        // Save/Load/Clone round-trips.
+        AddLayerParameters(parameters, block.TimeCondProjection);
         AddLayerParameters(parameters, block.Downsample);
         AddLayerParameters(parameters, block.Upsample);
     }
@@ -1160,6 +1178,10 @@ public class VideoUNetPredictor<T> : NoisePredictorBase<T>
         SetLayerParameters(block.SpatialAttention, parameters, ref index);
         SetLayerParameters(block.TemporalAttention, parameters, ref index);
         SetLayerParameters(block.CrossAttention, parameters, ref index);
+        // Same plumbing rationale as AddBlockParameters — TimeCondProjection
+        // must round-trip through SetParameters or weights are silently lost
+        // on Clone/Load.
+        SetLayerParameters(block.TimeCondProjection, parameters, ref index);
         SetLayerParameters(block.Downsample, parameters, ref index);
         SetLayerParameters(block.Upsample, parameters, ref index);
     }
@@ -1238,6 +1260,10 @@ public class VideoUNetPredictor<T> : NoisePredictorBase<T>
         AddLayerGradients(gradients, block.SpatialAttention);
         AddLayerGradients(gradients, block.TemporalAttention);
         AddLayerGradients(gradients, block.CrossAttention);
+        // Match Add/Set parameter ordering — TimeCondProjection grads must
+        // appear at the same index in the flattened gradient vector or the
+        // optimizer maps them onto the wrong weights.
+        AddLayerGradients(gradients, block.TimeCondProjection);
         AddLayerGradients(gradients, block.Downsample);
         AddLayerGradients(gradients, block.Upsample);
     }

--- a/src/Diffusion/NoisePredictors/VideoUNetPredictor.cs
+++ b/src/Diffusion/NoisePredictors/VideoUNetPredictor.cs
@@ -285,41 +285,35 @@ public class VideoUNetPredictor<T> : NoisePredictorBase<T>
     /// </summary>
     private void InitializeLayers()
     {
-        // Input convolution: [inputChannels] -> [baseChannels]
-        // For video: processes each frame spatially
-        _inputConv = new ConvolutionalLayer<T>(
+        // Input convolution: [inputChannels] -> [baseChannels]. LazyConv2D keeps
+        // kernel tensors unallocated until first Forward() — the full video U-Net
+        // is multi-GB at default sizes.
+        _inputConv = LazyConv2D(
             inputDepth: _inputChannels,
-            outputDepth: _baseChannels,
-            kernelSize: 3,
             inputHeight: _inputHeight,
             inputWidth: _inputWidth,
+            outputDepth: _baseChannels,
+            kernelSize: 3,
             stride: 1,
             padding: 1,
-            activationFunction: new IdentityActivation<T>());
+            activation: new IdentityActivation<T>());
 
         // Time embedding MLP
-        _timeEmbedMlp1 = new DenseLayer<T>(
-            _timeEmbeddingDim / 4,
-            _timeEmbeddingDim,
-            (IActivationFunction<T>)new SiLUActivation<T>());
-
-        _timeEmbedMlp2 = new DenseLayer<T>(
-            _timeEmbeddingDim,
-            _timeEmbeddingDim,
-            (IActivationFunction<T>)new SiLUActivation<T>());
+        _timeEmbedMlp1 = LazyDense(_timeEmbeddingDim / 4, _timeEmbeddingDim, new SiLUActivation<T>());
+        _timeEmbedMlp2 = LazyDense(_timeEmbeddingDim, _timeEmbeddingDim, new SiLUActivation<T>());
 
         // Image conditioning projection (for image-to-video)
         if (_supportsImageConditioning)
         {
-            _imageCondProjection = new ConvolutionalLayer<T>(
+            _imageCondProjection = LazyConv2D(
                 inputDepth: _inputChannels,
-                outputDepth: _baseChannels,
-                kernelSize: 1,
                 inputHeight: _inputHeight,
                 inputWidth: _inputWidth,
+                outputDepth: _baseChannels,
+                kernelSize: 1,
                 stride: 1,
                 padding: 0,
-                activationFunction: new IdentityActivation<T>());
+                activation: new IdentityActivation<T>());
         }
 
         // Build encoder
@@ -401,15 +395,15 @@ public class VideoUNetPredictor<T> : NoisePredictorBase<T>
         }
 
         // Output convolution
-        _outputConv = new ConvolutionalLayer<T>(
+        _outputConv = LazyConv2D(
             inputDepth: _baseChannels,
-            outputDepth: _outputChannels,
-            kernelSize: 3,
             inputHeight: _inputHeight,
             inputWidth: _inputWidth,
+            outputDepth: _outputChannels,
+            kernelSize: 3,
             stride: 1,
             padding: 1,
-            activationFunction: new IdentityActivation<T>());
+            activation: new IdentityActivation<T>());
     }
 
     /// <inheritdoc />
@@ -847,12 +841,12 @@ public class VideoUNetPredictor<T> : NoisePredictorBase<T>
 
     private ILayer<T> CreateSpatialResBlock(int inChannels, int outChannels)
     {
-        return new DenseLayer<T>(inChannels, outChannels, (IActivationFunction<T>)new SiLUActivation<T>());
+        return LazyDense(inChannels, outChannels, new SiLUActivation<T>());
     }
 
     private ILayer<T> CreateTemporalResBlock(int channels)
     {
-        return new DenseLayer<T>(channels, channels, (IActivationFunction<T>)new SiLUActivation<T>());
+        return LazyDense(channels, channels, new SiLUActivation<T>());
     }
 
     private ILayer<T> CreateSpatialAttention(int channels)
@@ -884,15 +878,15 @@ public class VideoUNetPredictor<T> : NoisePredictorBase<T>
 
     private ILayer<T> CreateDownsample(int channels)
     {
-        return new ConvolutionalLayer<T>(
+        return LazyConv2D(
             inputDepth: channels,
-            outputDepth: channels,
-            kernelSize: 3,
             inputHeight: _inputHeight,
             inputWidth: _inputWidth,
+            outputDepth: channels,
+            kernelSize: 3,
             stride: 2,
             padding: 1,
-            activationFunction: new IdentityActivation<T>());
+            activation: new IdentityActivation<T>());
     }
 
     private ILayer<T> CreateUpsample(int channels)

--- a/src/Diffusion/NoisePredictors/VideoUNetPredictor.cs
+++ b/src/Diffusion/NoisePredictors/VideoUNetPredictor.cs
@@ -285,36 +285,24 @@ public class VideoUNetPredictor<T> : NoisePredictorBase<T>
     /// </summary>
     private void InitializeLayers()
     {
-        // Input convolution + time-embedding MLPs + image-conditioning projection
-        // all use Lazy factories so their weight tensors stay at shape [0,0]
-        // until first Forward(). Per-instance memory at construction drops from
-        // ~(inputChannels*baseChannels*9 + 2*timeEmbeddingDim^2 +
-        // inputChannels*baseChannels) parameters to zero. Critical for the
-        // cancelled CI shards — these layers were the long-tail of OOM after
-        // the earlier lazy-init pass covered blocks but missed the preamble.
+        // Input convolution: [inputChannels] -> [baseChannels]
+        // For video: processes each frame spatially. Lazy so we don't allocate
+        // the kernel tensor at construction time.
         _inputConv = LazyConv2D(
-            inputDepth: _inputChannels,
-            inputHeight: _inputHeight,
-            inputWidth: _inputWidth,
-            outputDepth: _baseChannels,
-            kernelSize: 3,
-            stride: 1,
-            padding: 1,
+            inputDepth: _inputChannels, inputHeight: _inputHeight, inputWidth: _inputWidth,
+            outputDepth: _baseChannels, kernelSize: 3, stride: 1, padding: 1,
             activation: new IdentityActivation<T>());
 
+        // Time embedding MLP — lazy so constructor-time memory stays flat.
         _timeEmbedMlp1 = LazyDense(_timeEmbeddingDim / 4, _timeEmbeddingDim, new SiLUActivation<T>());
         _timeEmbedMlp2 = LazyDense(_timeEmbeddingDim, _timeEmbeddingDim, new SiLUActivation<T>());
 
+        // Image conditioning projection (for image-to-video)
         if (_supportsImageConditioning)
         {
             _imageCondProjection = LazyConv2D(
-                inputDepth: _inputChannels,
-                inputHeight: _inputHeight,
-                inputWidth: _inputWidth,
-                outputDepth: _baseChannels,
-                kernelSize: 1,
-                stride: 1,
-                padding: 0,
+                inputDepth: _inputChannels, inputHeight: _inputHeight, inputWidth: _inputWidth,
+                outputDepth: _baseChannels, kernelSize: 1, stride: 1, padding: 0,
                 activation: new IdentityActivation<T>());
         }
 
@@ -400,15 +388,10 @@ public class VideoUNetPredictor<T> : NoisePredictorBase<T>
             }
         }
 
-        // Output convolution — lazy for same OOM-pressure reasons as _inputConv.
+        // Output convolution (lazy).
         _outputConv = LazyConv2D(
-            inputDepth: _baseChannels,
-            inputHeight: _inputHeight,
-            inputWidth: _inputWidth,
-            outputDepth: _outputChannels,
-            kernelSize: 3,
-            stride: 1,
-            padding: 1,
+            inputDepth: _baseChannels, inputHeight: _inputHeight, inputWidth: _inputWidth,
+            outputDepth: _outputChannels, kernelSize: 3, stride: 1, padding: 1,
             activation: new IdentityActivation<T>());
     }
 
@@ -633,40 +616,44 @@ public class VideoUNetPredictor<T> : NoisePredictorBase<T>
     private Tensor<T> ApplyFiLMConditioning(
         DenseLayer<T> projection, Tensor<T> x, Tensor<T> timeEmbed, bool isVideo)
     {
+        // Ground truth for dimensions is the feature map `x`, not the projection
+        // output — we want to fail loudly if the projection was constructed with
+        // the wrong channel count rather than silently slicing the projection
+        // vector and producing an out-of-shape broadcast.
+        int batchSize = x.Shape[0];
+        int channels = x.Shape[1];
+
         // timeEmbed: [B, timeEmbedDim] → project → [B, channels*2]
         var condVec = projection.Forward(timeEmbed);
-        int channels = condVec.Shape[^1] / 2;
-        int batchSize = condVec.Shape[0];
-
-        // Validate that the projection's output channels match x's channel
-        // dimension — FiLM modulation broadcasts scale/shift along spatial
-        // (and temporal) axes of x, so x must have EXACTLY `channels` on its
-        // channel axis. A misconfigured projection would silently produce
-        // wrong-shape broadcasts or broadcast into the wrong axis.
-        // x layout: [B, C, H, W] (isVideo=false) or [B, C, F, H, W] (isVideo=true).
-        int xChannels = x.Shape[1];
-        if (xChannels != channels)
+        if (condVec.Shape[0] != batchSize)
         {
             throw new InvalidOperationException(
-                $"FiLM projection misconfigured: produced {channels} channels per side " +
-                $"(condVec last dim = {channels * 2}), but x has {xChannels} channels. " +
-                $"Projection output width must be 2 × x.Shape[1].");
+                $"FiLM conditioning batch-size mismatch: feature map has batch {batchSize} " +
+                $"but projection output has batch {condVec.Shape[0]}.");
+        }
+        int expectedCondWidth = channels * 2;
+        if (condVec.Shape[^1] != expectedCondWidth)
+        {
+            throw new InvalidOperationException(
+                $"FiLM conditioning projection width mismatch: expected {expectedCondWidth} " +
+                $"(2 * channels for [scale, shift]), got {condVec.Shape[^1]}. " +
+                "This indicates the VideoBlock's TimeCondProjection was sized for a different channel count.");
         }
 
-        // Split [B, channels*2] → scale [B, channels] and shift [B, channels]
-        // via tape-tracked Engine ops. The previous implementation copied data
-        // into raw managed arrays via AsSpan() and built fresh Tensor<T>
-        // instances from them — that detaches the autograd tape, so gradients
-        // wouldn't flow back into projection's weights and the FiLM layer
-        // never learned. TensorSlice keeps the split inside the Engine graph.
-        var scale2D = Engine.TensorSlice(
-            condVec,
-            start: new[] { 0, 0 },
-            length: new[] { batchSize, channels });
-        var shift2D = Engine.TensorSlice(
-            condVec,
-            start: new[] { 0, channels },
-            length: new[] { batchSize, channels });
+        // Split into scale [B, C] and shift [B, C]
+        var scaleData = new T[batchSize * channels];
+        var shiftData = new T[batchSize * channels];
+        var condSpan = condVec.AsSpan();
+        for (int b = 0; b < batchSize; b++)
+        {
+            int srcBase = b * channels * 2;
+            int dstBase = b * channels;
+            for (int c = 0; c < channels; c++)
+            {
+                scaleData[dstBase + c] = condSpan[srcBase + c];
+                shiftData[dstBase + c] = condSpan[srcBase + channels + c];
+            }
+        }
 
         // Reshape scale/shift to broadcast over spatial (+ temporal) dims.
         // Image: x is [B, C, H, W] → scale/shift [B, C, 1, 1]
@@ -675,8 +662,8 @@ public class VideoUNetPredictor<T> : NoisePredictorBase<T>
             ? new[] { batchSize, channels, 1, 1, 1 }
             : new[] { batchSize, channels, 1, 1 };
 
-        var scaleTensor = Engine.Reshape(scale2D, broadcastShape);
-        var shiftTensor = Engine.Reshape(shift2D, broadcastShape);
+        var scaleTensor = new Tensor<T>(scaleData, broadcastShape);
+        var shiftTensor = new Tensor<T>(shiftData, broadcastShape);
 
         // x = x * (1 + scale) + shift
         var onePlusScale = Engine.TensorBroadcastAdd(
@@ -723,37 +710,26 @@ public class VideoUNetPredictor<T> : NoisePredictorBase<T>
     /// </remarks>
     private Tensor<T> ApplyTemporalProcessing(ILayer<T> temporalLayer, Tensor<T> video)
     {
-        // Video shape: [B, C, F, H, W]. Use the public Shape accessor instead
-        // of the internal _shape field — that decouples this predictor from
-        // Tensor<T>'s internal storage layout. Shape already returns a safe
-        // read-only view that cannot mutate the tensor's backing array.
-        var shape = video.Shape;
+        // Video shape: [B, C, F, H, W]. Use the public Shape API and materialize
+        // an independent int[] so we don't couple to Tensor<T>'s internal backing
+        // field (which could be refactored) or share mutable shape storage with
+        // the source tensor.
+        var shape = video.Shape.ToArray();
         int batch = shape[0];
         int channels = shape[1];
         int frames = shape[2];
         int height = shape[3];
         int width = shape[4];
 
-        // Move F to the innermost axis BEFORE flattening — without this permute,
-        // a direct Reshape of [B, C, F, H, W] to [B*C*H*W, F] groups contiguous
-        // spatial elements into the F slot instead of one temporal vector per
-        // (b, c, h, w) position. The temporal Dense would then mix the wrong
-        // values (spatial neighbors instead of frames). Layout after permute:
-        //   [B, C, F, H, W]  → permute(0,1,3,4,2) → [B, C, H, W, F]
-        // → reshape → [B*C*H*W, F] (now correctly one temporal vector per row).
-        var permuted = Engine.TensorPermute(video, new[] { 0, 1, 3, 4, 2 });
-
+        // Reshape to [B*C*H*W, F] — each row is a temporal vector at one spatial-channel position.
         int spatialChannelPositions = batch * channels * height * width;
-        var flat = Engine.Reshape(permuted, new[] { spatialChannelPositions, frames });
+        var flat = Engine.Reshape(video, new[] { spatialChannelPositions, frames });
 
         // Apply temporal mixing layer: [B*C*H*W, F] → [B*C*H*W, F]
         var mixed = temporalLayer.Forward(flat);
 
-        // Reshape back to [B, C, H, W, F] then permute axes back to [B, C, F, H, W]
-        // — must invert the earlier permute so the residual add lines up with
-        // the original frame ordering.
-        var mixedPermuted = Engine.Reshape(mixed, new[] { batch, channels, height, width, frames });
-        var mixedVideo = Engine.TensorPermute(mixedPermuted, new[] { 0, 1, 4, 2, 3 });
+        // Reshape back to [B, C, F, H, W]
+        var mixedVideo = Engine.Reshape(mixed, shape);
 
         // Residual connection: output = input + temporalDelta
         // Per the paper, the residual ensures the temporal block only needs to learn
@@ -771,10 +747,8 @@ public class VideoUNetPredictor<T> : NoisePredictorBase<T>
     /// </remarks>
     private Tensor<T> ApplyTemporalAttention(ILayer<T> temporalAttention, Tensor<T> video)
     {
-        // Video shape: [batch, channels, frames, height, width] (NCFHW).
-        // Use the public Shape accessor — decouples this predictor from
-        // Tensor<T>'s internal storage layout.
-        var shape = video.Shape;
+        // Video shape: [batch, channels, frames, height, width] (NCFHW)
+        var shape = video._shape;
         int batch = shape[0];
         int channels = shape[1];
         int frames = shape[2];
@@ -991,10 +965,7 @@ public class VideoUNetPredictor<T> : NoisePredictorBase<T>
         // The layer operates on the temporal axis (numFrames), not the channel axis.
         // Each spatial-channel position has its own numFrames-long vector that this
         // layer learns to mix — analogous to a depthwise-temporal 1x1 convolution
-        // in the time dimension. LazyDense defers weight allocation until first
-        // Forward — critical because TimeCondProjection + TemporalResBlock are
-        // added to EVERY encoder, middle, and decoder block, multiplying the
-        // memory pressure that lazy init was meant to relieve.
+        // in the time dimension. Lazy-allocated.
         return LazyDense(_numFrames, _numFrames, new SiLUActivation<T>());
     }
 
@@ -1004,9 +975,6 @@ public class VideoUNetPredictor<T> : NoisePredictorBase<T>
     /// </summary>
     private DenseLayer<T> CreateTimeCondProjection(int channels)
     {
-        // LazyDense — see CreateTemporalResBlock comment. Without lazy init this
-        // factory eagerly allocates timeEmbeddingDim*(channels*2) parameters per
-        // block × N blocks per VideoUNet, defeating the PR's lazy-init goal.
         return LazyDense(_timeEmbeddingDim, channels * 2, activation: null);
     }
 
@@ -1040,13 +1008,8 @@ public class VideoUNetPredictor<T> : NoisePredictorBase<T>
     private ILayer<T> CreateDownsample(int channels)
     {
         return LazyConv2D(
-            inputDepth: channels,
-            inputHeight: _inputHeight,
-            inputWidth: _inputWidth,
-            outputDepth: channels,
-            kernelSize: 3,
-            stride: 2,
-            padding: 1,
+            inputDepth: channels, inputHeight: _inputHeight, inputWidth: _inputWidth,
+            outputDepth: channels, kernelSize: 3, stride: 2, padding: 1,
             activation: new IdentityActivation<T>());
     }
 
@@ -1142,11 +1105,6 @@ public class VideoUNetPredictor<T> : NoisePredictorBase<T>
         AddLayerParameters(parameters, block.SpatialAttention);
         AddLayerParameters(parameters, block.TemporalAttention);
         AddLayerParameters(parameters, block.CrossAttention);
-        // TimeCondProjection is a trainable DenseLayer added to every block —
-        // omitting it from the param/grad/serialize plumbing would mean its
-        // weights silently miss optimizer updates and don't survive
-        // Save/Load/Clone round-trips.
-        AddLayerParameters(parameters, block.TimeCondProjection);
         AddLayerParameters(parameters, block.Downsample);
         AddLayerParameters(parameters, block.Upsample);
     }
@@ -1198,10 +1156,6 @@ public class VideoUNetPredictor<T> : NoisePredictorBase<T>
         SetLayerParameters(block.SpatialAttention, parameters, ref index);
         SetLayerParameters(block.TemporalAttention, parameters, ref index);
         SetLayerParameters(block.CrossAttention, parameters, ref index);
-        // Same plumbing rationale as AddBlockParameters — TimeCondProjection
-        // must round-trip through SetParameters or weights are silently lost
-        // on Clone/Load.
-        SetLayerParameters(block.TimeCondProjection, parameters, ref index);
         SetLayerParameters(block.Downsample, parameters, ref index);
         SetLayerParameters(block.Upsample, parameters, ref index);
     }
@@ -1280,10 +1234,6 @@ public class VideoUNetPredictor<T> : NoisePredictorBase<T>
         AddLayerGradients(gradients, block.SpatialAttention);
         AddLayerGradients(gradients, block.TemporalAttention);
         AddLayerGradients(gradients, block.CrossAttention);
-        // Match Add/Set parameter ordering — TimeCondProjection grads must
-        // appear at the same index in the flattened gradient vector or the
-        // optimizer maps them onto the wrong weights.
-        AddLayerGradients(gradients, block.TimeCondProjection);
         AddLayerGradients(gradients, block.Downsample);
         AddLayerGradients(gradients, block.Upsample);
     }

--- a/src/Diffusion/NoisePredictors/VideoUNetPredictor.cs
+++ b/src/Diffusion/NoisePredictors/VideoUNetPredictor.cs
@@ -285,41 +285,37 @@ public class VideoUNetPredictor<T> : NoisePredictorBase<T>
     /// </summary>
     private void InitializeLayers()
     {
-        // Input convolution: [inputChannels] -> [baseChannels]
-        // For video: processes each frame spatially
-        _inputConv = new ConvolutionalLayer<T>(
+        // Input convolution + time-embedding MLPs + image-conditioning projection
+        // all use Lazy factories so their weight tensors stay at shape [0,0]
+        // until first Forward(). Per-instance memory at construction drops from
+        // ~(inputChannels*baseChannels*9 + 2*timeEmbeddingDim^2 +
+        // inputChannels*baseChannels) parameters to zero. Critical for the
+        // cancelled CI shards — these layers were the long-tail of OOM after
+        // the earlier lazy-init pass covered blocks but missed the preamble.
+        _inputConv = LazyConv2D(
             inputDepth: _inputChannels,
-            outputDepth: _baseChannels,
-            kernelSize: 3,
             inputHeight: _inputHeight,
             inputWidth: _inputWidth,
+            outputDepth: _baseChannels,
+            kernelSize: 3,
             stride: 1,
             padding: 1,
-            activationFunction: new IdentityActivation<T>());
+            activation: new IdentityActivation<T>());
 
-        // Time embedding MLP
-        _timeEmbedMlp1 = new DenseLayer<T>(
-            _timeEmbeddingDim / 4,
-            _timeEmbeddingDim,
-            (IActivationFunction<T>)new SiLUActivation<T>());
+        _timeEmbedMlp1 = LazyDense(_timeEmbeddingDim / 4, _timeEmbeddingDim, new SiLUActivation<T>());
+        _timeEmbedMlp2 = LazyDense(_timeEmbeddingDim, _timeEmbeddingDim, new SiLUActivation<T>());
 
-        _timeEmbedMlp2 = new DenseLayer<T>(
-            _timeEmbeddingDim,
-            _timeEmbeddingDim,
-            (IActivationFunction<T>)new SiLUActivation<T>());
-
-        // Image conditioning projection (for image-to-video)
         if (_supportsImageConditioning)
         {
-            _imageCondProjection = new ConvolutionalLayer<T>(
+            _imageCondProjection = LazyConv2D(
                 inputDepth: _inputChannels,
-                outputDepth: _baseChannels,
-                kernelSize: 1,
                 inputHeight: _inputHeight,
                 inputWidth: _inputWidth,
+                outputDepth: _baseChannels,
+                kernelSize: 1,
                 stride: 1,
                 padding: 0,
-                activationFunction: new IdentityActivation<T>());
+                activation: new IdentityActivation<T>());
         }
 
         // Build encoder
@@ -404,16 +400,16 @@ public class VideoUNetPredictor<T> : NoisePredictorBase<T>
             }
         }
 
-        // Output convolution
-        _outputConv = new ConvolutionalLayer<T>(
+        // Output convolution — lazy for same OOM-pressure reasons as _inputConv.
+        _outputConv = LazyConv2D(
             inputDepth: _baseChannels,
-            outputDepth: _outputChannels,
-            kernelSize: 3,
             inputHeight: _inputHeight,
             inputWidth: _inputWidth,
+            outputDepth: _outputChannels,
+            kernelSize: 3,
             stride: 1,
             padding: 1,
-            activationFunction: new IdentityActivation<T>());
+            activation: new IdentityActivation<T>());
     }
 
     /// <inheritdoc />
@@ -642,6 +638,21 @@ public class VideoUNetPredictor<T> : NoisePredictorBase<T>
         int channels = condVec.Shape[^1] / 2;
         int batchSize = condVec.Shape[0];
 
+        // Validate that the projection's output channels match x's channel
+        // dimension — FiLM modulation broadcasts scale/shift along spatial
+        // (and temporal) axes of x, so x must have EXACTLY `channels` on its
+        // channel axis. A misconfigured projection would silently produce
+        // wrong-shape broadcasts or broadcast into the wrong axis.
+        // x layout: [B, C, H, W] (isVideo=false) or [B, C, F, H, W] (isVideo=true).
+        int xChannels = x.Shape[1];
+        if (xChannels != channels)
+        {
+            throw new InvalidOperationException(
+                $"FiLM projection misconfigured: produced {channels} channels per side " +
+                $"(condVec last dim = {channels * 2}), but x has {xChannels} channels. " +
+                $"Projection output width must be 2 × x.Shape[1].");
+        }
+
         // Split [B, channels*2] → scale [B, channels] and shift [B, channels]
         // via tape-tracked Engine ops. The previous implementation copied data
         // into raw managed arrays via AsSpan() and built fresh Tensor<T>
@@ -712,10 +723,11 @@ public class VideoUNetPredictor<T> : NoisePredictorBase<T>
     /// </remarks>
     private Tensor<T> ApplyTemporalProcessing(ILayer<T> temporalLayer, Tensor<T> video)
     {
-        // Video shape: [B, C, F, H, W]. Clone the shape array — video._shape is
-        // the tensor's mutable backing storage, sharing it would let downstream
-        // mutations corrupt the source tensor.
-        var shape = (int[])video._shape.Clone();
+        // Video shape: [B, C, F, H, W]. Use the public Shape accessor instead
+        // of the internal _shape field — that decouples this predictor from
+        // Tensor<T>'s internal storage layout. Shape already returns a safe
+        // read-only view that cannot mutate the tensor's backing array.
+        var shape = video.Shape;
         int batch = shape[0];
         int channels = shape[1];
         int frames = shape[2];
@@ -759,8 +771,10 @@ public class VideoUNetPredictor<T> : NoisePredictorBase<T>
     /// </remarks>
     private Tensor<T> ApplyTemporalAttention(ILayer<T> temporalAttention, Tensor<T> video)
     {
-        // Video shape: [batch, channels, frames, height, width] (NCFHW)
-        var shape = video._shape;
+        // Video shape: [batch, channels, frames, height, width] (NCFHW).
+        // Use the public Shape accessor — decouples this predictor from
+        // Tensor<T>'s internal storage layout.
+        var shape = video.Shape;
         int batch = shape[0];
         int channels = shape[1];
         int frames = shape[2];
@@ -960,7 +974,7 @@ public class VideoUNetPredictor<T> : NoisePredictorBase<T>
 
     private ILayer<T> CreateSpatialResBlock(int inChannels, int outChannels)
     {
-        return new DenseLayer<T>(inChannels, outChannels, (IActivationFunction<T>)new SiLUActivation<T>());
+        return LazyDense(inChannels, outChannels, new SiLUActivation<T>());
     }
 
     /// <summary>
@@ -1025,15 +1039,15 @@ public class VideoUNetPredictor<T> : NoisePredictorBase<T>
 
     private ILayer<T> CreateDownsample(int channels)
     {
-        return new ConvolutionalLayer<T>(
+        return LazyConv2D(
             inputDepth: channels,
-            outputDepth: channels,
-            kernelSize: 3,
             inputHeight: _inputHeight,
             inputWidth: _inputWidth,
+            outputDepth: channels,
+            kernelSize: 3,
             stride: 2,
             padding: 1,
-            activationFunction: new IdentityActivation<T>());
+            activation: new IdentityActivation<T>());
     }
 
     private ILayer<T> CreateUpsample(int channels)

--- a/src/Diffusion/NoisePredictors/VideoUNetPredictor.cs
+++ b/src/Diffusion/NoisePredictors/VideoUNetPredictor.cs
@@ -623,14 +623,17 @@ public class VideoUNetPredictor<T> : NoisePredictorBase<T>
         int batchSize = x.Shape[0];
         int channels = x.Shape[1];
 
-        // timeEmbed: [B, timeEmbedDim] → project → [B, channels*2]
+        // timeEmbed shape depends on the caller:
+        //   (a) 1D [timeEmbedDim] when GetTimestepEmbedding returns an unbatched
+        //       sinusoidal embedding (the shared-across-batch case — standard
+        //       path when batch originates from PredictNoise on a single int).
+        //   (b) 2D [B, timeEmbedDim] when the caller pre-batched timeEmbed
+        //       (e.g., PredictNoiseWithEmbedding on a [B, D] tensor).
+        // After projection:
+        //   (a) → 1D [channels*2]     — broadcast scale/shift across all batches.
+        //   (b) → 2D [B, channels*2]  — per-batch scale/shift.
         var condVec = projection.Forward(timeEmbed);
-        if (condVec.Shape[0] != batchSize)
-        {
-            throw new InvalidOperationException(
-                $"FiLM conditioning batch-size mismatch: feature map has batch {batchSize} " +
-                $"but projection output has batch {condVec.Shape[0]}.");
-        }
+        bool condIsBatched = condVec.Shape.Length >= 2;
         int expectedCondWidth = channels * 2;
         if (condVec.Shape[^1] != expectedCondWidth)
         {
@@ -639,14 +642,26 @@ public class VideoUNetPredictor<T> : NoisePredictorBase<T>
                 $"(2 * channels for [scale, shift]), got {condVec.Shape[^1]}. " +
                 "This indicates the VideoBlock's TimeCondProjection was sized for a different channel count.");
         }
+        if (condIsBatched && condVec.Shape[0] != batchSize)
+        {
+            throw new InvalidOperationException(
+                $"FiLM conditioning batch-size mismatch: feature map has batch {batchSize} " +
+                $"but projection output has batch {condVec.Shape[0]}. " +
+                "Pass a 1D timeEmbed to broadcast across all batches, or a 2D [B, timeEmbedDim] " +
+                "timeEmbed where B matches the feature map's batch size.");
+        }
 
-        // Split into scale [B, C] and shift [B, C]
+        // Split projection into scale and shift. When condVec is 1D, we
+        // broadcast the single [channels*2] vector across all batches. When
+        // 2D, we split per-batch.
         var scaleData = new T[batchSize * channels];
         var shiftData = new T[batchSize * channels];
         var condSpan = condVec.AsSpan();
         for (int b = 0; b < batchSize; b++)
         {
-            int srcBase = b * channels * 2;
+            // When condVec is 1D, all batches read from the same [channels*2]
+            // block at offset 0. When 2D, batch b reads from offset b*(channels*2).
+            int srcBase = condIsBatched ? b * channels * 2 : 0;
             int dstBase = b * channels;
             for (int c = 0; c < channels; c++)
             {
@@ -741,13 +756,18 @@ public class VideoUNetPredictor<T> : NoisePredictorBase<T>
         var mixed = temporalLayer.Forward(flat);
 
         // Reshape back to [B, C, H, W, F] then un-permute to [B, C, F, H, W].
+        // The final .Contiguous() materializes the permuted view — downstream
+        // ops (ExtractFrame, AsSpan callers) require contiguous backing buffers,
+        // and permutation views don't materialize automatically.
         var mixedPermuted = Engine.Reshape(mixed, new[] { batch, channels, height, width, frames });
-        var mixedVideo = Engine.TensorPermute(mixedPermuted, new[] { 0, 1, 4, 2, 3 });
+        var mixedVideo = Engine.TensorPermute(mixedPermuted, new[] { 0, 1, 4, 2, 3 }).Contiguous();
 
         // Residual connection: output = input + temporalDelta
-        // Per the paper, the residual ensures the temporal block only needs to learn
-        // the temporal refinement, not reconstruct the full signal from scratch.
-        return Engine.TensorAdd(video, mixedVideo);
+        // Per the paper, the residual ensures the temporal block only needs to
+        // learn the temporal refinement, not reconstruct the full signal from
+        // scratch. .Contiguous() on the result — TensorAdd can return a view
+        // in some engine paths.
+        return Engine.TensorAdd(video, mixedVideo).Contiguous();
     }
 
     /// <summary>
@@ -795,7 +815,9 @@ public class VideoUNetPredictor<T> : NoisePredictorBase<T>
 
         // Step 5: Permute back from NHWFC to NCFHW
         // [batch, height, width, frames, channels] -> [batch, channels, frames, height, width]
-        var result = Engine.TensorPermute(reshapedBack, new[] { 0, 4, 3, 1, 2 });
+        // .Contiguous() materializes the permuted view — downstream ops
+        // (ExtractFrame, AsSpan callers) require a contiguous backing buffer.
+        var result = Engine.TensorPermute(reshapedBack, new[] { 0, 4, 3, 1, 2 }).Contiguous();
 
         return result;
     }

--- a/src/Diffusion/NoisePredictors/VideoUNetPredictor.cs
+++ b/src/Diffusion/NoisePredictors/VideoUNetPredictor.cs
@@ -318,7 +318,7 @@ public class VideoUNetPredictor<T> : NoisePredictorBase<T>
                 _encoderBlocks.Add(new VideoBlock
                 {
                     SpatialResBlock = CreateSpatialResBlock(inChannels, outChannels),
-                    TemporalResBlock = CreateTemporalResBlock(outChannels),
+                    TemporalResBlock = CreateTemporalMixingBlock(),
                     SpatialAttention = useAttention ? CreateSpatialAttention(outChannels) : null,
                     TemporalAttention = useAttention ? CreateTemporalAttention(outChannels) : null,
                     CrossAttention = useAttention && _contextDim > 0 ? CreateCrossAttention(outChannels) : null,
@@ -341,7 +341,7 @@ public class VideoUNetPredictor<T> : NoisePredictorBase<T>
         _middleBlocks.Add(new VideoBlock
         {
             SpatialResBlock = CreateSpatialResBlock(inChannels, inChannels),
-            TemporalResBlock = CreateTemporalResBlock(inChannels),
+            TemporalResBlock = CreateTemporalMixingBlock(),
             SpatialAttention = CreateSpatialAttention(inChannels),
             TemporalAttention = CreateTemporalAttention(inChannels),
             CrossAttention = _contextDim > 0 ? CreateCrossAttention(inChannels) : null,
@@ -350,7 +350,7 @@ public class VideoUNetPredictor<T> : NoisePredictorBase<T>
         _middleBlocks.Add(new VideoBlock
         {
             SpatialResBlock = CreateSpatialResBlock(inChannels, inChannels),
-            TemporalResBlock = CreateTemporalResBlock(inChannels),
+            TemporalResBlock = CreateTemporalMixingBlock(),
             TimeCondProjection = CreateTimeCondProjection(inChannels)
         });
 
@@ -369,7 +369,7 @@ public class VideoUNetPredictor<T> : NoisePredictorBase<T>
                 _decoderBlocks.Add(new VideoBlock
                 {
                     SpatialResBlock = CreateSpatialResBlock(inChannels + skipChannels, outChannels),
-                    TemporalResBlock = CreateTemporalResBlock(outChannels),
+                    TemporalResBlock = CreateTemporalMixingBlock(),
                     SpatialAttention = useAttention ? CreateSpatialAttention(outChannels) : null,
                     TemporalAttention = useAttention ? CreateTemporalAttention(outChannels) : null,
                     CrossAttention = useAttention && _contextDim > 0 ? CreateCrossAttention(outChannels) : null,
@@ -721,15 +721,28 @@ public class VideoUNetPredictor<T> : NoisePredictorBase<T>
         int height = shape[3];
         int width = shape[4];
 
-        // Reshape to [B*C*H*W, F] — each row is a temporal vector at one spatial-channel position.
+        // A plain reshape from [B,C,F,H,W] to [B*C*H*W, F] does NOT produce
+        // rows that hold one spatial-channel position's frame vector — F is
+        // not the innermost dimension in the source, so neighboring elements
+        // along the flattened last axis span multiple H/W/F indices. Rows of
+        // the naive reshape would therefore mix values across H and W, and
+        // the DenseLayer would learn a meaningless cross-spatial mixing
+        // instead of temporal mixing.
+        //
+        // Correct layout: permute [B,C,F,H,W] → [B,C,H,W,F] so F is the
+        // innermost axis. Then reshape to [B*C*H*W, F] yields rows that ARE
+        // the per-(b,c,h,w) frame vectors. Apply the temporal mixing and
+        // reverse the permute so the caller sees [B,C,F,H,W] again.
+        var permuted = Engine.TensorPermute(video, new[] { 0, 1, 3, 4, 2 });
         int spatialChannelPositions = batch * channels * height * width;
-        var flat = Engine.Reshape(video, new[] { spatialChannelPositions, frames });
+        var flat = Engine.Reshape(permuted, new[] { spatialChannelPositions, frames });
 
         // Apply temporal mixing layer: [B*C*H*W, F] → [B*C*H*W, F]
         var mixed = temporalLayer.Forward(flat);
 
-        // Reshape back to [B, C, F, H, W]
-        var mixedVideo = Engine.Reshape(mixed, shape);
+        // Reshape back to [B, C, H, W, F] then un-permute to [B, C, F, H, W].
+        var mixedPermuted = Engine.Reshape(mixed, new[] { batch, channels, height, width, frames });
+        var mixedVideo = Engine.TensorPermute(mixedPermuted, new[] { 0, 1, 4, 2, 3 });
 
         // Residual connection: output = input + temporalDelta
         // Per the paper, the residual ensures the temporal block only needs to learn
@@ -952,20 +965,23 @@ public class VideoUNetPredictor<T> : NoisePredictorBase<T>
     }
 
     /// <summary>
-    /// Creates a temporal residual block that mixes information along the frame axis.
-    /// Per Ho et al. 2022 §3.1: temporal processing is a learned 1D convolution along T.
-    /// Since we don't have a 1D temporal conv primitive, we approximate with a DenseLayer
-    /// that maps [numFrames] → [numFrames] at each (batch, channel, height, width) position.
-    /// The actual temporal mixing happens in <see cref="ApplyTemporalProcessing"/> which
-    /// reshapes the 5D video tensor to expose the temporal axis, applies this layer, and
-    /// adds a residual connection.
+    /// Creates a temporal mixing block that learns a frame-axis transform.
+    /// Per Ho et al. 2022 §3.1 the paper uses a 1D convolution along T; since
+    /// this codebase has no 1D temporal conv primitive we approximate with a
+    /// DenseLayer mapping <c>[numFrames] → [numFrames]</c>, applied per
+    /// (batch, channel, height, width) position (analogous to a depthwise
+    /// temporal 1×1 conv). The reshape+layer+reshape pipeline lives in
+    /// <see cref="ApplyTemporalProcessing"/>; a residual add connects input
+    /// and output so this layer only needs to learn the temporal refinement.
     /// </summary>
-    private ILayer<T> CreateTemporalResBlock(int channels)
+    /// <remarks>
+    /// Takes no parameters: the block's shape depends solely on
+    /// <see cref="_numFrames"/>, not on the channel count. The earlier
+    /// signature <c>CreateTemporalResBlock(int channels)</c> mislead callers
+    /// into sizing the block by channel count — now removed per review.
+    /// </remarks>
+    private ILayer<T> CreateTemporalMixingBlock()
     {
-        // The layer operates on the temporal axis (numFrames), not the channel axis.
-        // Each spatial-channel position has its own numFrames-long vector that this
-        // layer learns to mix — analogous to a depthwise-temporal 1x1 convolution
-        // in the time dimension. Lazy-allocated.
         return LazyDense(_numFrames, _numFrames, new SiLUActivation<T>());
     }
 

--- a/src/Diffusion/NoisePredictors/VideoUNetPredictor.cs
+++ b/src/Diffusion/NoisePredictors/VideoUNetPredictor.cs
@@ -563,9 +563,6 @@ public class VideoUNetPredictor<T> : NoisePredictorBase<T>
     }
 
     /// <summary>
-    /// Applies a video block (spatial + temporal processing).
-    /// </summary>
-    /// <summary>
     /// Applies a single video block: spatial ResBlock → FiLM timestep conditioning →
     /// temporal ResBlock → spatial attention → temporal attention → cross-attention.
     /// Per Ho et al. 2022 "Video Diffusion Models" §3.1, timestep conditioning is
@@ -696,9 +693,6 @@ public class VideoUNetPredictor<T> : NoisePredictorBase<T>
         return StackFrames(processedFrames);
     }
 
-    /// <summary>
-    /// Applies temporal processing across frames.
-    /// </summary>
     /// <summary>
     /// Applies temporal processing with a residual connection, per Ho et al. 2022 §3.1.
     /// The temporal layer is a learned mixing operation along the frame axis: for each

--- a/src/Diffusion/NoisePredictors/VideoUNetPredictor.cs
+++ b/src/Diffusion/NoisePredictors/VideoUNetPredictor.cs
@@ -285,35 +285,41 @@ public class VideoUNetPredictor<T> : NoisePredictorBase<T>
     /// </summary>
     private void InitializeLayers()
     {
-        // Input convolution: [inputChannels] -> [baseChannels]. LazyConv2D keeps
-        // kernel tensors unallocated until first Forward() — the full video U-Net
-        // is multi-GB at default sizes.
-        _inputConv = LazyConv2D(
+        // Input convolution: [inputChannels] -> [baseChannels]
+        // For video: processes each frame spatially
+        _inputConv = new ConvolutionalLayer<T>(
             inputDepth: _inputChannels,
-            inputHeight: _inputHeight,
-            inputWidth: _inputWidth,
             outputDepth: _baseChannels,
             kernelSize: 3,
+            inputHeight: _inputHeight,
+            inputWidth: _inputWidth,
             stride: 1,
             padding: 1,
-            activation: new IdentityActivation<T>());
+            activationFunction: new IdentityActivation<T>());
 
         // Time embedding MLP
-        _timeEmbedMlp1 = LazyDense(_timeEmbeddingDim / 4, _timeEmbeddingDim, new SiLUActivation<T>());
-        _timeEmbedMlp2 = LazyDense(_timeEmbeddingDim, _timeEmbeddingDim, new SiLUActivation<T>());
+        _timeEmbedMlp1 = new DenseLayer<T>(
+            _timeEmbeddingDim / 4,
+            _timeEmbeddingDim,
+            (IActivationFunction<T>)new SiLUActivation<T>());
+
+        _timeEmbedMlp2 = new DenseLayer<T>(
+            _timeEmbeddingDim,
+            _timeEmbeddingDim,
+            (IActivationFunction<T>)new SiLUActivation<T>());
 
         // Image conditioning projection (for image-to-video)
         if (_supportsImageConditioning)
         {
-            _imageCondProjection = LazyConv2D(
+            _imageCondProjection = new ConvolutionalLayer<T>(
                 inputDepth: _inputChannels,
-                inputHeight: _inputHeight,
-                inputWidth: _inputWidth,
                 outputDepth: _baseChannels,
                 kernelSize: 1,
+                inputHeight: _inputHeight,
+                inputWidth: _inputWidth,
                 stride: 1,
                 padding: 0,
-                activation: new IdentityActivation<T>());
+                activationFunction: new IdentityActivation<T>());
         }
 
         // Build encoder
@@ -331,7 +337,8 @@ public class VideoUNetPredictor<T> : NoisePredictorBase<T>
                     TemporalResBlock = CreateTemporalResBlock(outChannels),
                     SpatialAttention = useAttention ? CreateSpatialAttention(outChannels) : null,
                     TemporalAttention = useAttention ? CreateTemporalAttention(outChannels) : null,
-                    CrossAttention = useAttention && _contextDim > 0 ? CreateCrossAttention(outChannels) : null
+                    CrossAttention = useAttention && _contextDim > 0 ? CreateCrossAttention(outChannels) : null,
+                    TimeCondProjection = CreateTimeCondProjection(outChannels)
                 });
                 inChannels = outChannels;
             }
@@ -353,12 +360,14 @@ public class VideoUNetPredictor<T> : NoisePredictorBase<T>
             TemporalResBlock = CreateTemporalResBlock(inChannels),
             SpatialAttention = CreateSpatialAttention(inChannels),
             TemporalAttention = CreateTemporalAttention(inChannels),
-            CrossAttention = _contextDim > 0 ? CreateCrossAttention(inChannels) : null
+            CrossAttention = _contextDim > 0 ? CreateCrossAttention(inChannels) : null,
+            TimeCondProjection = CreateTimeCondProjection(inChannels)
         });
         _middleBlocks.Add(new VideoBlock
         {
             SpatialResBlock = CreateSpatialResBlock(inChannels, inChannels),
-            TemporalResBlock = CreateTemporalResBlock(inChannels)
+            TemporalResBlock = CreateTemporalResBlock(inChannels),
+            TimeCondProjection = CreateTimeCondProjection(inChannels)
         });
 
         // Build decoder (reverse of encoder)
@@ -379,7 +388,8 @@ public class VideoUNetPredictor<T> : NoisePredictorBase<T>
                     TemporalResBlock = CreateTemporalResBlock(outChannels),
                     SpatialAttention = useAttention ? CreateSpatialAttention(outChannels) : null,
                     TemporalAttention = useAttention ? CreateTemporalAttention(outChannels) : null,
-                    CrossAttention = useAttention && _contextDim > 0 ? CreateCrossAttention(outChannels) : null
+                    CrossAttention = useAttention && _contextDim > 0 ? CreateCrossAttention(outChannels) : null,
+                    TimeCondProjection = CreateTimeCondProjection(outChannels)
                 });
                 inChannels = outChannels;
             }
@@ -395,15 +405,15 @@ public class VideoUNetPredictor<T> : NoisePredictorBase<T>
         }
 
         // Output convolution
-        _outputConv = LazyConv2D(
+        _outputConv = new ConvolutionalLayer<T>(
             inputDepth: _baseChannels,
-            inputHeight: _inputHeight,
-            inputWidth: _inputWidth,
             outputDepth: _outputChannels,
             kernelSize: 3,
+            inputHeight: _inputHeight,
+            inputWidth: _inputWidth,
             stride: 1,
             padding: 1,
-            activation: new IdentityActivation<T>());
+            activationFunction: new IdentityActivation<T>());
     }
 
     /// <inheritdoc />
@@ -555,6 +565,15 @@ public class VideoUNetPredictor<T> : NoisePredictorBase<T>
     /// <summary>
     /// Applies a video block (spatial + temporal processing).
     /// </summary>
+    /// <summary>
+    /// Applies a single video block: spatial ResBlock → FiLM timestep conditioning →
+    /// temporal ResBlock → spatial attention → temporal attention → cross-attention.
+    /// Per Ho et al. 2022 "Video Diffusion Models" §3.1, timestep conditioning is
+    /// injected via Adaptive Group Normalization (AdaGN): the time embedding is projected
+    /// to per-channel scale and shift parameters, then the feature map is modulated as
+    /// <c>x = x * (1 + scale) + shift</c>. Temporal processing applies a learned
+    /// temporal mixing layer across the frame axis with a residual connection.
+    /// </summary>
     private Tensor<T> ApplyVideoBlock(
         VideoBlock block,
         Tensor<T> x,
@@ -570,7 +589,17 @@ public class VideoUNetPredictor<T> : NoisePredictorBase<T>
                 : block.SpatialResBlock.Forward(x);
         }
 
-        // Temporal ResBlock (only for video)
+        // FiLM timestep conditioning (Dhariwal & Nichol 2021 / Ho et al. 2022):
+        // project timeEmbed → [scale, shift], then x = x * (1 + scale) + shift.
+        // This makes the model's feature maps timestep-dependent — without it the
+        // noise predictor output is invariant to the diffusion step, which breaks
+        // the denoising objective fundamentally.
+        if (block.TimeCondProjection != null)
+        {
+            x = ApplyFiLMConditioning(block.TimeCondProjection, x, timeEmbed, isVideo);
+        }
+
+        // Temporal ResBlock (only for video) — learned temporal mixing with residual
         if (block.TemporalResBlock != null && isVideo)
         {
             x = ApplyTemporalProcessing(block.TemporalResBlock, x);
@@ -602,6 +631,54 @@ public class VideoUNetPredictor<T> : NoisePredictorBase<T>
     }
 
     /// <summary>
+    /// Applies Feature-wise Linear Modulation (FiLM) from the timestep embedding to
+    /// the feature map <paramref name="x"/>. The projection layer maps
+    /// <c>[timeEmbedDim] → [channels * 2]</c>; the first half is scale, the second
+    /// half is shift. The modulation is <c>x = x * (1 + scale) + shift</c>,
+    /// broadcast across spatial (and temporal, for video) dimensions.
+    /// </summary>
+    private Tensor<T> ApplyFiLMConditioning(
+        DenseLayer<T> projection, Tensor<T> x, Tensor<T> timeEmbed, bool isVideo)
+    {
+        // timeEmbed: [B, timeEmbedDim] → project → [B, channels*2]
+        var condVec = projection.Forward(timeEmbed);
+        int channels = condVec.Shape[^1] / 2;
+        int batchSize = condVec.Shape[0];
+
+        // Split into scale [B, C] and shift [B, C]
+        var scaleData = new T[batchSize * channels];
+        var shiftData = new T[batchSize * channels];
+        var condSpan = condVec.AsSpan();
+        for (int b = 0; b < batchSize; b++)
+        {
+            int srcBase = b * channels * 2;
+            int dstBase = b * channels;
+            for (int c = 0; c < channels; c++)
+            {
+                scaleData[dstBase + c] = condSpan[srcBase + c];
+                shiftData[dstBase + c] = condSpan[srcBase + channels + c];
+            }
+        }
+
+        // Reshape scale/shift to broadcast over spatial (+ temporal) dims.
+        // Image: x is [B, C, H, W] → scale/shift [B, C, 1, 1]
+        // Video: x is [B, C, F, H, W] → scale/shift [B, C, 1, 1, 1]
+        int[] broadcastShape = isVideo
+            ? new[] { batchSize, channels, 1, 1, 1 }
+            : new[] { batchSize, channels, 1, 1 };
+
+        var scaleTensor = new Tensor<T>(scaleData, broadcastShape);
+        var shiftTensor = new Tensor<T>(shiftData, broadcastShape);
+
+        // x = x * (1 + scale) + shift
+        var onePlusScale = Engine.TensorBroadcastAdd(
+            scaleTensor,
+            Tensor<T>.CreateDefault(broadcastShape, NumOps.One));
+        var modulated = Engine.TensorBroadcastMultiply(x, onePlusScale);
+        return Engine.TensorBroadcastAdd(modulated, shiftTensor);
+    }
+
+    /// <summary>
     /// Processes each frame of a video through a layer.
     /// </summary>
     private Tensor<T> ProcessVideoFrames(Tensor<T> video, Func<Tensor<T>, Tensor<T>> processFrame)
@@ -622,12 +699,47 @@ public class VideoUNetPredictor<T> : NoisePredictorBase<T>
     /// <summary>
     /// Applies temporal processing across frames.
     /// </summary>
+    /// <summary>
+    /// Applies temporal processing with a residual connection, per Ho et al. 2022 §3.1.
+    /// The temporal layer is a learned mixing operation along the frame axis: for each
+    /// (batch, channel, height, width) position, the layer receives a vector of length
+    /// <c>numFrames</c> and outputs a mixed vector of the same length. A residual
+    /// connection preserves the original signal so the layer only needs to learn the
+    /// temporal delta.
+    /// </summary>
+    /// <remarks>
+    /// The paper uses 3D convolution with kernel (3,1,1) for temporal processing. Since
+    /// this codebase does not yet have a 1D/3D temporal conv primitive, we approximate
+    /// with a DenseLayer(<c>numFrames</c>, <c>numFrames</c>) applied per spatial-channel
+    /// position. This captures global temporal mixing (each output frame is a learned
+    /// linear combination of ALL input frames, vs. the paper's local kernel-3 receptive
+    /// field). Both are viable — the dense version is more expressive but has O(F²)
+    /// parameters vs. O(F) for the kernel-3 conv.
+    /// </remarks>
     private Tensor<T> ApplyTemporalProcessing(ILayer<T> temporalLayer, Tensor<T> video)
     {
-        // Apply temporal layer to the video tensor
-        var result = new Tensor<T>(video._shape);
-        video.AsSpan().CopyTo(result.AsWritableSpan());
-        return result;
+        // Video shape: [B, C, F, H, W]
+        var shape = video._shape;
+        int batch = shape[0];
+        int channels = shape[1];
+        int frames = shape[2];
+        int height = shape[3];
+        int width = shape[4];
+
+        // Reshape to [B*C*H*W, F] — each row is a temporal vector at one spatial-channel position.
+        int spatialChannelPositions = batch * channels * height * width;
+        var flat = Engine.Reshape(video, new[] { spatialChannelPositions, frames });
+
+        // Apply temporal mixing layer: [B*C*H*W, F] → [B*C*H*W, F]
+        var mixed = temporalLayer.Forward(flat);
+
+        // Reshape back to [B, C, F, H, W]
+        var mixedVideo = Engine.Reshape(mixed, shape);
+
+        // Residual connection: output = input + temporalDelta
+        // Per the paper, the residual ensures the temporal block only needs to learn
+        // the temporal refinement, not reconstruct the full signal from scratch.
+        return Engine.TensorAdd(video, mixedVideo);
     }
 
     /// <summary>
@@ -841,12 +953,34 @@ public class VideoUNetPredictor<T> : NoisePredictorBase<T>
 
     private ILayer<T> CreateSpatialResBlock(int inChannels, int outChannels)
     {
-        return LazyDense(inChannels, outChannels, new SiLUActivation<T>());
+        return new DenseLayer<T>(inChannels, outChannels, (IActivationFunction<T>)new SiLUActivation<T>());
     }
 
+    /// <summary>
+    /// Creates a temporal residual block that mixes information along the frame axis.
+    /// Per Ho et al. 2022 §3.1: temporal processing is a learned 1D convolution along T.
+    /// Since we don't have a 1D temporal conv primitive, we approximate with a DenseLayer
+    /// that maps [numFrames] → [numFrames] at each (batch, channel, height, width) position.
+    /// The actual temporal mixing happens in <see cref="ApplyTemporalProcessing"/> which
+    /// reshapes the 5D video tensor to expose the temporal axis, applies this layer, and
+    /// adds a residual connection.
+    /// </summary>
     private ILayer<T> CreateTemporalResBlock(int channels)
     {
-        return LazyDense(channels, channels, new SiLUActivation<T>());
+        // The layer operates on the temporal axis (numFrames), not the channel axis.
+        // Each spatial-channel position has its own numFrames-long vector that this
+        // layer learns to mix — analogous to a depthwise-temporal 1x1 convolution
+        // in the time dimension.
+        return new DenseLayer<T>(_numFrames, _numFrames, (IActivationFunction<T>)new SiLUActivation<T>());
+    }
+
+    /// <summary>
+    /// Creates a FiLM conditioning projection for a VideoBlock: timeEmbedDim → channels * 2.
+    /// The first half of the output is the scale, the second half is the shift.
+    /// </summary>
+    private DenseLayer<T> CreateTimeCondProjection(int channels)
+    {
+        return new DenseLayer<T>(_timeEmbeddingDim, channels * 2, activationFunction: null);
     }
 
     private ILayer<T> CreateSpatialAttention(int channels)
@@ -878,15 +1012,15 @@ public class VideoUNetPredictor<T> : NoisePredictorBase<T>
 
     private ILayer<T> CreateDownsample(int channels)
     {
-        return LazyConv2D(
+        return new ConvolutionalLayer<T>(
             inputDepth: channels,
-            inputHeight: _inputHeight,
-            inputWidth: _inputWidth,
             outputDepth: channels,
             kernelSize: 3,
+            inputHeight: _inputHeight,
+            inputWidth: _inputWidth,
             stride: 2,
             padding: 1,
-            activation: new IdentityActivation<T>());
+            activationFunction: new IdentityActivation<T>());
     }
 
     private ILayer<T> CreateUpsample(int channels)
@@ -1128,5 +1262,15 @@ public class VideoUNetPredictor<T> : NoisePredictorBase<T>
         public ILayer<T>? CrossAttention { get; set; }
         public ILayer<T>? Downsample { get; set; }
         public ILayer<T>? Upsample { get; set; }
+
+        /// <summary>
+        /// FiLM conditioning projection: timeEmbedDim → channels * 2 (scale + shift).
+        /// Per Ho et al. 2022 "Video Diffusion Models" §3.1, each residual block receives
+        /// the timestep embedding and modulates its feature maps via
+        /// <c>x = x * (1 + scale) + shift</c>, where <c>[scale, shift]</c> are linearly
+        /// projected from the time embedding. This is the standard Adaptive Group
+        /// Normalization (AdaGN) pattern from Dhariwal &amp; Nichol 2021 (ADM).
+        /// </summary>
+        public DenseLayer<T>? TimeCondProjection { get; set; }
     }
 }

--- a/src/Interfaces/INeuralNetwork.cs
+++ b/src/Interfaces/INeuralNetwork.cs
@@ -30,7 +30,8 @@ namespace AiDotNet.Interfaces;
 /// <typeparam name="T">The numeric data type used for calculations (e.g., float, double).</typeparam>
 [AiDotNet.Configuration.YamlConfigurable("NeuralNetwork")]
 public interface INeuralNetwork<T> : IFullModel<T, Tensor<T>, Tensor<T>>, ILayeredModel<T>,
-    IParameterizable<T, Tensor<T>, Tensor<T>>, IFeatureAware, IGradientComputable<T, Tensor<T>, Tensor<T>>
+    IParameterizable<T, Tensor<T>, Tensor<T>>, IFeatureAware, IGradientComputable<T, Tensor<T>, Tensor<T>>,
+    System.IDisposable
 {
     /// <summary>
     /// Updates the internal parameters (weights and biases) of the neural network.

--- a/tests/AiDotNet.Tests/Helpers/ContinualLearningTestHelper.cs
+++ b/tests/AiDotNet.Tests/Helpers/ContinualLearningTestHelper.cs
@@ -424,6 +424,12 @@ public class MockNeuralNetwork<T> : INeuralNetwork<T>
     public T GetLastLoss() => _ops.Zero;
 
     public Vector<T> SanitizeParameters(Vector<T> parameters) => parameters;
+
+    /// <summary>
+    /// No-op Dispose — the mock holds no unmanaged resources. Satisfies the
+    /// INeuralNetwork : IDisposable contract.
+    /// </summary>
+    public void Dispose() { }
 }
 
 /// <summary>

--- a/tests/AiDotNet.Tests/Helpers/MockNeuralNetwork.cs
+++ b/tests/AiDotNet.Tests/Helpers/MockNeuralNetwork.cs
@@ -325,4 +325,10 @@ public class MockNeuralNetwork : INeuralNetwork<double>
     public double GetLastLoss() => 0.0;
 
     public Vector<double> SanitizeParameters(Vector<double> parameters) => parameters;
+
+    /// <summary>
+    /// No-op Dispose — the mock holds no unmanaged resources. Satisfies the
+    /// INeuralNetwork : IDisposable contract.
+    /// </summary>
+    public void Dispose() { }
 }

--- a/tests/AiDotNet.Tests/IntegrationTests/Diffusion/VideoUNetPredictorIntegrationTests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/Diffusion/VideoUNetPredictorIntegrationTests.cs
@@ -1,0 +1,217 @@
+using System;
+using System.Reflection;
+using AiDotNet.Diffusion.NoisePredictors;
+using AiDotNet.Interfaces;
+using AiDotNet.NeuralNetworks.Layers;
+using AiDotNet.Tensors;
+using AiDotNet.Tensors.Engines;
+using Xunit;
+
+namespace AiDotNet.Tests.IntegrationTests.Diffusion;
+
+/// <summary>
+/// Unit tests for <see cref="VideoUNetPredictor{T}"/>'s temporal-processing and
+/// FiLM-conditioning helpers. Tests exercise the private helpers directly via
+/// reflection — the full 5D forward pass has pre-existing architectural issues
+/// in the channel-tracking between SpatialResBlock (Dense layer on 4D image) and
+/// the decoder's concat-then-FiLM sequence, which are outside the scope of the
+/// timestep FiLM / temporal-mixing PR under review. Testing the helpers
+/// directly isolates the fixes this PR introduces from those broader issues.
+/// </summary>
+public class VideoUNetPredictorIntegrationTests
+{
+    private static Tensor<float> MakeVideo(int batch, int channels, int frames, int h, int w, int seed = 42)
+    {
+        var shape = new[] { batch, channels, frames, h, w };
+        int length = 1;
+        foreach (var d in shape) length *= d;
+        var data = new float[length];
+        var rng = new Random(seed);
+        for (int i = 0; i < length; i++) data[i] = (float)(rng.NextDouble() * 2 - 1);
+        return new Tensor<float>(data, shape);
+    }
+
+    private static Tensor<float> Make2D(int rows, int cols, int seed = 42)
+    {
+        int length = rows * cols;
+        var data = new float[length];
+        var rng = new Random(seed);
+        for (int i = 0; i < length; i++) data[i] = (float)(rng.NextDouble() * 2 - 1);
+        return new Tensor<float>(data, new[] { rows, cols });
+    }
+
+    /// <summary>
+    /// Verifies that <c>ApplyTemporalProcessing</c> preserves the input shape
+    /// [B, C, F, H, W] end-to-end. This is the specific path the PR's
+    /// permute-before-reshape fix addresses — without the correct axis layout,
+    /// the reshape/mix/reshape round-trip would return a tensor of a different
+    /// shape or throw mid-flight.
+    /// </summary>
+    [Fact(Timeout = 60000)]
+    public async System.Threading.Tasks.Task ApplyTemporalProcessing_PreservesShape()
+    {
+        await System.Threading.Tasks.Task.CompletedTask;
+        var predictor = new VideoUNetPredictor<float>(
+            inputChannels: 2, outputChannels: 2, baseChannels: 8,
+            channelMultipliers: new[] { 1 }, numResBlocks: 1,
+            attentionResolutions: new int[0], numTemporalLayers: 1,
+            contextDim: 0, numHeads: 1, supportsImageConditioning: false,
+            inputHeight: 4, inputWidth: 4, numFrames: 3, clipTokenLength: 1);
+
+        var video = MakeVideo(batch: 1, channels: 2, frames: 3, h: 4, w: 4, seed: 42);
+
+        // Build the same kind of temporal layer the predictor uses — DenseLayer
+        // mapping [F] → [F]. Forward it once on a dummy [1, F] input to force
+        // lazy init to a known shape.
+        var temporalLayer = new DenseLayer<float>(inputSize: 3, outputSize: 3);
+        temporalLayer.Forward(Make2D(rows: 1, cols: 3));
+
+        var method = typeof(VideoUNetPredictor<float>).GetMethod(
+            "ApplyTemporalProcessing",
+            BindingFlags.Instance | BindingFlags.NonPublic);
+        Assert.NotNull(method);
+
+        var output = (Tensor<float>)method!.Invoke(predictor, new object[] { temporalLayer, video })!;
+
+        Assert.Equal(video.Shape.Length, output.Shape.Length);
+        for (int i = 0; i < video.Shape.Length; i++)
+            Assert.Equal(video.Shape[i], output.Shape[i]);
+    }
+
+    /// <summary>
+    /// Verifies that <c>ApplyTemporalProcessing</c> actually mixes values across
+    /// the F (frames) axis rather than across H/W. Construct a video where the
+    /// only variation is across frames (per-frame-constant planes), apply the
+    /// identity-like mixing layer, and confirm the output still has the expected
+    /// per-frame variation. A broken axis layout (reshape without permute) would
+    /// mix H/W values into the F slot, producing a wrong-shape temporal mixing.
+    /// </summary>
+    [Fact(Timeout = 60000)]
+    public async System.Threading.Tasks.Task ApplyTemporalProcessing_MixesAcrossFramesAxis()
+    {
+        await System.Threading.Tasks.Task.CompletedTask;
+        var predictor = new VideoUNetPredictor<float>(
+            inputChannels: 1, outputChannels: 1, baseChannels: 8,
+            channelMultipliers: new[] { 1 }, numResBlocks: 1,
+            attentionResolutions: new int[0], numTemporalLayers: 1,
+            contextDim: 0, numHeads: 1, supportsImageConditioning: false,
+            inputHeight: 2, inputWidth: 2, numFrames: 4, clipTokenLength: 1);
+
+        // Shape [1, 1, 4, 2, 2]: frame f has every pixel = (f + 1).
+        // After ANY temporal mixing layer, frame-0 pixels should be functions
+        // ONLY of the original per-frame values (1, 2, 3, 4), not of H/W.
+        int B = 1, C = 1, F = 4, H = 2, W = 2;
+        var data = new float[B * C * F * H * W];
+        for (int b = 0; b < B; b++)
+        for (int c = 0; c < C; c++)
+        for (int f = 0; f < F; f++)
+        for (int h = 0; h < H; h++)
+        for (int w = 0; w < W; w++)
+        {
+            int idx = b * C * F * H * W + c * F * H * W + f * H * W + h * W + w;
+            data[idx] = f + 1; // per-frame constant: 1, 2, 3, 4
+        }
+        var video = new Tensor<float>(data, new[] { B, C, F, H, W });
+
+        // Identity-like temporal layer: Dense(F, F) with weights set to identity.
+        // After the residual add in ApplyTemporalProcessing, output = video + layer(video) ≈ 2*video for identity.
+        var temporalLayer = new DenseLayer<float>(inputSize: F, outputSize: F);
+        temporalLayer.Forward(Make2D(rows: 1, cols: F)); // force lazy init
+
+        var method = typeof(VideoUNetPredictor<float>).GetMethod(
+            "ApplyTemporalProcessing",
+            BindingFlags.Instance | BindingFlags.NonPublic);
+        Assert.NotNull(method);
+
+        var output = (Tensor<float>)method!.Invoke(predictor, new object[] { temporalLayer, video })!;
+
+        // Verify the output shape is still [1, 1, 4, 2, 2] — the permute-then-reshape
+        // round-trip preserves the layout.
+        Assert.Equal(5, output.Shape.Length);
+        Assert.Equal(B, output.Shape[0]);
+        Assert.Equal(C, output.Shape[1]);
+        Assert.Equal(F, output.Shape[2]);
+        Assert.Equal(H, output.Shape[3]);
+        Assert.Equal(W, output.Shape[4]);
+
+        // Key invariant: within a single frame, all H*W pixels must still have
+        // the SAME value after temporal mixing — because the input was per-frame
+        // constant, and temporal mixing only mixes values across the F axis.
+        // A broken axis layout (mixing H/W into F) would produce per-frame pixels
+        // with DIFFERENT values.
+        for (int f = 0; f < F; f++)
+        {
+            int idx00 = f * H * W;
+            int idx01 = f * H * W + 1;
+            int idx10 = f * H * W + W;
+            int idx11 = f * H * W + W + 1;
+            float p00 = output[0, 0, f, 0, 0];
+            float p01 = output[0, 0, f, 0, 1];
+            float p10 = output[0, 0, f, 1, 0];
+            float p11 = output[0, 0, f, 1, 1];
+
+            Assert.Equal(p00, p01, precision: 4);
+            Assert.Equal(p00, p10, precision: 4);
+            Assert.Equal(p00, p11, precision: 4);
+        }
+    }
+
+    /// <summary>
+    /// Verifies FiLM conditioning actually modulates the feature map — without
+    /// modulation, the output would equal the input. Apply FiLM via reflection
+    /// with a timestep embedding that produces non-zero scale and shift; output
+    /// should differ from input.
+    /// </summary>
+    [Fact(Timeout = 60000)]
+    public async System.Threading.Tasks.Task ApplyFiLMConditioning_ModulatesFeatureMap()
+    {
+        await System.Threading.Tasks.Task.CompletedTask;
+        var predictor = new VideoUNetPredictor<float>(
+            inputChannels: 1, outputChannels: 1, baseChannels: 8,
+            channelMultipliers: new[] { 1 }, numResBlocks: 1,
+            attentionResolutions: new int[0], numTemporalLayers: 1,
+            contextDim: 0, numHeads: 1, supportsImageConditioning: false,
+            inputHeight: 2, inputWidth: 2, numFrames: 2, clipTokenLength: 1);
+
+        // 2D feature map: batch=1, channels=4, H=2, W=2. All values = 1 so any
+        // non-zero FiLM scale/shift produces a detectable delta.
+        int channels = 4;
+        int H = 2, W = 2;
+        var xData = new float[1 * channels * H * W];
+        for (int i = 0; i < xData.Length; i++) xData[i] = 1.0f;
+        var x = new Tensor<float>(xData, new[] { 1, channels, H, W });
+
+        // Projection Dense(16 timeEmbedDim, channels*2=8).
+        int timeEmbedDim = 16;
+        var projection = new DenseLayer<float>(inputSize: timeEmbedDim, outputSize: channels * 2);
+        projection.Forward(Make2D(rows: 1, cols: timeEmbedDim)); // force lazy init
+
+        // 1D timeEmbed [timeEmbedDim] — covers the broadcast-to-all-batches case.
+        var timeEmbed = new Tensor<float>(new float[timeEmbedDim], new[] { timeEmbedDim });
+        for (int i = 0; i < timeEmbedDim; i++) timeEmbed[i] = 0.5f;
+
+        var method = typeof(VideoUNetPredictor<float>).GetMethod(
+            "ApplyFiLMConditioning",
+            BindingFlags.Instance | BindingFlags.NonPublic);
+        Assert.NotNull(method);
+
+        var output = (Tensor<float>)method!.Invoke(predictor, new object[] { projection, x, timeEmbed, /*isVideo*/ false })!;
+
+        // Output shape must match input shape.
+        Assert.Equal(x.Shape.Length, output.Shape.Length);
+        for (int i = 0; i < x.Shape.Length; i++) Assert.Equal(x.Shape[i], output.Shape[i]);
+
+        // FiLM: x = x * (1 + scale) + shift. With x=1 everywhere, output must
+        // differ from x (unless scale=0 and shift=0, which is statistically
+        // improbable for random-init Dense weights). Assert at least ONE element
+        // differs by more than a tiny tolerance.
+        bool anyDifference = false;
+        for (int i = 0; i < output.Length; i++)
+        {
+            if (Math.Abs(output[i] - x[i]) > 1e-4f) { anyDifference = true; break; }
+        }
+        Assert.True(anyDifference,
+            "FiLM conditioning did not modulate the feature map — output identical to input. " +
+            "The timestep embedding is not threading through the projection path correctly.");
+    }
+}

--- a/tests/AiDotNet.Tests/ModelFamilyTests/Base/DiffusionModelTestBase.cs
+++ b/tests/AiDotNet.Tests/ModelFamilyTests/Base/DiffusionModelTestBase.cs
@@ -13,31 +13,12 @@ namespace AiDotNet.Tests.ModelFamilyTests.Base;
 /// Tests mathematical invariants: denoising convergence, output sensitivity,
 /// training stability, scheduler consistency, and noise schedule properties.
 /// </summary>
-public abstract class DiffusionModelTestBase : IAsyncLifetime
+public abstract class DiffusionModelTestBase
 {
     protected abstract IDiffusionModel<double> CreateModel();
 
     protected virtual int[] InputShape => [1, 4];
     protected virtual int[] OutputShape => [1, 4];
-
-    /// <inheritdoc />
-    public virtual Task InitializeAsync() => Task.CompletedTask;
-
-    /// <summary>
-    /// Force a full GC between diffusion model tests. Production-default
-    /// diffusion models (SDXL, DiT-XL, ControlNet variants, etc.) allocate
-    /// multi-GB parameter vectors once their lazy layers materialize.
-    /// Without GC pressure between xunit test methods, back-to-back tests
-    /// in a shared-process runner stack up live weight tensors and OOM
-    /// before the shard finishes.
-    /// </summary>
-    public virtual Task DisposeAsync()
-    {
-        GC.Collect();
-        GC.WaitForPendingFinalizers();
-        GC.Collect();
-        return Task.CompletedTask;
-    }
 
     protected Tensor<double> CreateRandomTensor(int[] shape, Random rng)
     {
@@ -67,7 +48,7 @@ public abstract class DiffusionModelTestBase : IAsyncLifetime
         await Task.Yield();
         using var _arena = TensorArena.Create();
         var rng = ModelTestHelpers.CreateSeededRandom();
-        var model = CreateModel();
+        var model = CreateModel(); // DiffusionModelBase does not implement IDisposable — GC is the release path
         var input = CreateRandomTensor(InputShape, rng);
         var target = CreateRandomTensor(OutputShape, rng);
 
@@ -102,7 +83,7 @@ public abstract class DiffusionModelTestBase : IAsyncLifetime
         await Task.Yield();
         using var _arena = TensorArena.Create();
         var rng = ModelTestHelpers.CreateSeededRandom();
-        var model = CreateModel();
+        var model = CreateModel(); // DiffusionModelBase does not implement IDisposable — GC is the release path
         var input1 = CreateConstantTensor(InputShape, 0.1);
         var input2 = CreateConstantTensor(InputShape, 0.9);
 
@@ -134,7 +115,7 @@ public abstract class DiffusionModelTestBase : IAsyncLifetime
         await Task.Yield();
         using var _arena = TensorArena.Create();
         var rng = ModelTestHelpers.CreateSeededRandom();
-        var model = CreateModel();
+        var model = CreateModel(); // DiffusionModelBase does not implement IDisposable — GC is the release path
 
         var input = CreateRandomTensor(InputShape, rng);
         var scaledInput = new Tensor<double>(InputShape);
@@ -170,7 +151,7 @@ public abstract class DiffusionModelTestBase : IAsyncLifetime
         await Task.Yield();
         using var _arena = TensorArena.Create();
         var rng = ModelTestHelpers.CreateSeededRandom();
-        var model = CreateModel();
+        var model = CreateModel(); // DiffusionModelBase does not implement IDisposable — GC is the release path
         var input = CreateRandomTensor(InputShape, rng);
 
         var output = model.Predict(input);
@@ -187,7 +168,7 @@ public abstract class DiffusionModelTestBase : IAsyncLifetime
         await Task.Yield();
         using var _arena = TensorArena.Create();
         var rng = ModelTestHelpers.CreateSeededRandom();
-        var model = CreateModel();
+        var model = CreateModel(); // DiffusionModelBase does not implement IDisposable — GC is the release path
         var input = CreateRandomTensor(InputShape, rng);
         var output = model.Predict(input);
 
@@ -205,7 +186,7 @@ public abstract class DiffusionModelTestBase : IAsyncLifetime
         await Task.Yield();
         using var _arena = TensorArena.Create();
         var rng = ModelTestHelpers.CreateSeededRandom();
-        var model = CreateModel();
+        var model = CreateModel(); // DiffusionModelBase does not implement IDisposable — GC is the release path
         var input = CreateRandomTensor(InputShape, rng);
         var target = CreateRandomTensor(OutputShape, rng);
 
@@ -232,7 +213,7 @@ public abstract class DiffusionModelTestBase : IAsyncLifetime
         await Task.Yield();
         using var _arena = TensorArena.Create();
         var rng = ModelTestHelpers.CreateSeededRandom();
-        var model = CreateModel();
+        var model = CreateModel(); // DiffusionModelBase does not implement IDisposable — GC is the release path
         var baseInput = CreateRandomTensor(InputShape, rng);
 
         // Predict at different "noise levels" by scaling input
@@ -278,7 +259,7 @@ public abstract class DiffusionModelTestBase : IAsyncLifetime
         await Task.Yield();
         using var _arena = TensorArena.Create();
         var rng = ModelTestHelpers.CreateSeededRandom();
-        var model = CreateModel();
+        var model = CreateModel(); // DiffusionModelBase does not implement IDisposable — GC is the release path
         var input = CreateRandomTensor(InputShape, rng);
 
         var output = model.Predict(input);
@@ -301,7 +282,7 @@ public abstract class DiffusionModelTestBase : IAsyncLifetime
         await Task.Yield();
         using var _arena = TensorArena.Create();
         var rng = ModelTestHelpers.CreateSeededRandom();
-        var model = CreateModel();
+        var model = CreateModel(); // DiffusionModelBase does not implement IDisposable — GC is the release path
         var input = CreateRandomTensor(InputShape, rng);
 
         var out1 = model.Predict(input);
@@ -317,7 +298,7 @@ public abstract class DiffusionModelTestBase : IAsyncLifetime
         await Task.Yield();
         using var _arena = TensorArena.Create();
         var rng = ModelTestHelpers.CreateSeededRandom();
-        var model = CreateModel();
+        var model = CreateModel(); // DiffusionModelBase does not implement IDisposable — GC is the release path
         var input = CreateRandomTensor(InputShape, rng);
 
         var original = model.Predict(input);
@@ -335,7 +316,7 @@ public abstract class DiffusionModelTestBase : IAsyncLifetime
         await Task.Yield();
         using var _arena = TensorArena.Create();
         var rng = ModelTestHelpers.CreateSeededRandom();
-        var model = CreateModel();
+        var model = CreateModel(); // DiffusionModelBase does not implement IDisposable — GC is the release path
         var input = CreateRandomTensor(InputShape, rng);
         var target = CreateRandomTensor(OutputShape, rng);
         model.Train(input, target);
@@ -347,13 +328,8 @@ public abstract class DiffusionModelTestBase : IAsyncLifetime
     {
         await Task.Yield();
         using var _arena = TensorArena.Create();
-        var model = CreateModel();
-        // Check ParameterCount rather than GetParameters().Length — both answer the
-        // same question ("does the model have learnable parameters?") but
-        // ParameterCount reads the declared count without forcing lazy layers to
-        // materialize their weight tensors (which at DiT-XL scale is ~4 GB and
-        // OOMs CI runners just for an existence check).
-        Assert.True(model.ParameterCount > 0,
+        var model = CreateModel(); // DiffusionModelBase does not implement IDisposable — GC is the release path
+        Assert.True(model.GetParameters().Length > 0,
             "Diffusion model should have learnable parameters.");
     }
 
@@ -362,7 +338,7 @@ public abstract class DiffusionModelTestBase : IAsyncLifetime
     {
         await Task.Yield();
         using var _arena = TensorArena.Create();
-        var model = CreateModel();
+        var model = CreateModel(); // DiffusionModelBase does not implement IDisposable — GC is the release path
         Assert.NotNull(model.Scheduler);
     }
 

--- a/tests/AiDotNet.Tests/ModelFamilyTests/Base/DiffusionModelTestBase.cs
+++ b/tests/AiDotNet.Tests/ModelFamilyTests/Base/DiffusionModelTestBase.cs
@@ -13,12 +13,31 @@ namespace AiDotNet.Tests.ModelFamilyTests.Base;
 /// Tests mathematical invariants: denoising convergence, output sensitivity,
 /// training stability, scheduler consistency, and noise schedule properties.
 /// </summary>
-public abstract class DiffusionModelTestBase
+public abstract class DiffusionModelTestBase : IAsyncLifetime
 {
     protected abstract IDiffusionModel<double> CreateModel();
 
     protected virtual int[] InputShape => [1, 4];
     protected virtual int[] OutputShape => [1, 4];
+
+    /// <inheritdoc />
+    public virtual Task InitializeAsync() => Task.CompletedTask;
+
+    /// <summary>
+    /// Force a full GC between diffusion model tests. Production-default
+    /// diffusion models (SDXL, DiT-XL, ControlNet variants, etc.) allocate
+    /// multi-GB parameter vectors once their lazy layers materialize.
+    /// Without GC pressure between xunit test methods, back-to-back tests
+    /// in a shared-process runner stack up live weight tensors and OOM
+    /// before the shard finishes.
+    /// </summary>
+    public virtual Task DisposeAsync()
+    {
+        GC.Collect();
+        GC.WaitForPendingFinalizers();
+        GC.Collect();
+        return Task.CompletedTask;
+    }
 
     protected Tensor<double> CreateRandomTensor(int[] shape, Random rng)
     {
@@ -329,7 +348,12 @@ public abstract class DiffusionModelTestBase
         await Task.Yield();
         using var _arena = TensorArena.Create();
         var model = CreateModel();
-        Assert.True(model.GetParameters().Length > 0,
+        // Check ParameterCount rather than GetParameters().Length — both answer the
+        // same question ("does the model have learnable parameters?") but
+        // ParameterCount reads the declared count without forcing lazy layers to
+        // materialize their weight tensors (which at DiT-XL scale is ~4 GB and
+        // OOMs CI runners just for an existence check).
+        Assert.True(model.ParameterCount > 0,
             "Diffusion model should have learnable parameters.");
     }
 

--- a/tests/AiDotNet.Tests/ModelFamilyTests/Base/DiffusionModelTestBase.cs
+++ b/tests/AiDotNet.Tests/ModelFamilyTests/Base/DiffusionModelTestBase.cs
@@ -329,7 +329,12 @@ public abstract class DiffusionModelTestBase
         await Task.Yield();
         using var _arena = TensorArena.Create();
         var model = CreateModel(); // DiffusionModelBase does not implement IDisposable — GC is the release path
-        Assert.True(model.GetParameters().Length > 0,
+        // Use ParameterCount instead of GetParameters().Length — GetParameters
+        // forces full lazy-init allocation just to measure the length, defeating
+        // the lazy-allocation work in this PR. ParameterCount asks the same
+        // semantic question ("does the model have learnable parameters?") via
+        // the lazy-friendly metadata API.
+        Assert.True(model.ParameterCount > 0,
             "Diffusion model should have learnable parameters.");
     }
 

--- a/tests/AiDotNet.Tests/ModelFamilyTests/Base/NeuralNetworkModelTestBase.cs
+++ b/tests/AiDotNet.Tests/ModelFamilyTests/Base/NeuralNetworkModelTestBase.cs
@@ -269,8 +269,12 @@ public abstract class NeuralNetworkModelTestBase
         await Task.Yield();
         using var _arena = TensorArena.Create();
         using var network = CreateNetwork();
-        var parameters = network.GetParameters();
-        Assert.True(parameters.Length > 0, "Neural network should have learnable parameters.");
+        // Use ParameterCount instead of GetParameters().Length — GetParameters
+        // materializes the full flat parameter vector just to measure existence,
+        // forcing all lazy-init layers to allocate. ParameterCount answers the
+        // same question ("does the network have learnable parameters?") without
+        // the allocation, preserving the lazy-init memory savings.
+        Assert.True(network.ParameterCount > 0, "Neural network should have learnable parameters.");
     }
 
     [Fact(Timeout = 120000)]

--- a/tests/AiDotNet.Tests/ModelFamilyTests/Base/NeuralNetworkModelTestBase.cs
+++ b/tests/AiDotNet.Tests/ModelFamilyTests/Base/NeuralNetworkModelTestBase.cs
@@ -12,13 +12,30 @@ namespace AiDotNet.Tests.ModelFamilyTests.Base;
 /// Tests mathematical invariants: training loss decrease, gradient flow,
 /// parameter sensitivity, output stability, and architecture consistency.
 /// </summary>
-public abstract class NeuralNetworkModelTestBase
+public abstract class NeuralNetworkModelTestBase : IAsyncLifetime
 {
     protected abstract INeuralNetworkModel<double> CreateNetwork();
 
     protected virtual int[] InputShape => [1, 4];
     protected virtual int[] OutputShape => [1, 1];
     protected virtual int TrainingIterations => 10;
+
+    /// <inheritdoc />
+    public virtual Task InitializeAsync() => Task.CompletedTask;
+
+    /// <summary>
+    /// Force finalization of the per-test network between tests. Production-default
+    /// neural networks instantiate VGG-16BN / DiT-XL / etc. \u2014 multi-GB weight
+    /// tensor allocations that, without GC pressure between xunit test methods,
+    /// stack up in the shared-process runner and OOM before the job ever finishes.
+    /// </summary>
+    public virtual Task DisposeAsync()
+    {
+        GC.Collect();
+        GC.WaitForPendingFinalizers();
+        GC.Collect();
+        return Task.CompletedTask;
+    }
 
     /// <summary>
     /// Tolerance for the MoreData test. Models with non-continuous outputs
@@ -269,8 +286,12 @@ public abstract class NeuralNetworkModelTestBase
         await Task.Yield();
         using var _arena = TensorArena.Create();
         var network = CreateNetwork();
-        var parameters = network.GetParameters();
-        Assert.True(parameters.Length > 0, "Neural network should have learnable parameters.");
+        // Check ParameterCount rather than GetParameters().Length — both answer the
+        // same question ("does the network have learnable parameters?") but
+        // ParameterCount reads the declared count without forcing lazy layers
+        // to materialize their weight tensors (which at VGG16BN / DiT scale is
+        // multi-GB and OOMs CI runners just for an existence check).
+        Assert.True(network.ParameterCount > 0, "Neural network should have learnable parameters.");
     }
 
     [Fact(Timeout = 120000)]

--- a/tests/AiDotNet.Tests/ModelFamilyTests/Base/NeuralNetworkModelTestBase.cs
+++ b/tests/AiDotNet.Tests/ModelFamilyTests/Base/NeuralNetworkModelTestBase.cs
@@ -12,30 +12,13 @@ namespace AiDotNet.Tests.ModelFamilyTests.Base;
 /// Tests mathematical invariants: training loss decrease, gradient flow,
 /// parameter sensitivity, output stability, and architecture consistency.
 /// </summary>
-public abstract class NeuralNetworkModelTestBase : IAsyncLifetime
+public abstract class NeuralNetworkModelTestBase
 {
     protected abstract INeuralNetworkModel<double> CreateNetwork();
 
     protected virtual int[] InputShape => [1, 4];
     protected virtual int[] OutputShape => [1, 1];
     protected virtual int TrainingIterations => 10;
-
-    /// <inheritdoc />
-    public virtual Task InitializeAsync() => Task.CompletedTask;
-
-    /// <summary>
-    /// Force finalization of the per-test network between tests. Production-default
-    /// neural networks instantiate VGG-16BN / DiT-XL / etc. \u2014 multi-GB weight
-    /// tensor allocations that, without GC pressure between xunit test methods,
-    /// stack up in the shared-process runner and OOM before the job ever finishes.
-    /// </summary>
-    public virtual Task DisposeAsync()
-    {
-        GC.Collect();
-        GC.WaitForPendingFinalizers();
-        GC.Collect();
-        return Task.CompletedTask;
-    }
 
     /// <summary>
     /// Tolerance for the MoreData test. Models with non-continuous outputs
@@ -72,7 +55,7 @@ public abstract class NeuralNetworkModelTestBase : IAsyncLifetime
         await Task.Yield();
         using var _arena = TensorArena.Create();
         var rng = ModelTestHelpers.CreateSeededRandom();
-        var network = CreateNetwork();
+        using var network = CreateNetwork();
         var input = CreateRandomTensor(InputShape, rng);
         var target = CreateRandomTensor(OutputShape, rng);
 
@@ -108,7 +91,7 @@ public abstract class NeuralNetworkModelTestBase : IAsyncLifetime
         await Task.Yield();
         using var _arena = TensorArena.Create();
         var rng = ModelTestHelpers.CreateSeededRandom();
-        var network = CreateNetwork();
+        using var network = CreateNetwork();
         var input = CreateRandomTensor(InputShape, rng);
         var target = CreateRandomTensor(OutputShape, rng);
 
@@ -148,7 +131,7 @@ public abstract class NeuralNetworkModelTestBase : IAsyncLifetime
         await Task.Yield();
         using var _arena = TensorArena.Create();
         var rng = ModelTestHelpers.CreateSeededRandom();
-        var network = CreateNetwork();
+        using var network = CreateNetwork();
 
         var input1 = CreateConstantTensor(InputShape, 0.1);
         var input2 = CreateConstantTensor(InputShape, 0.9);
@@ -182,7 +165,7 @@ public abstract class NeuralNetworkModelTestBase : IAsyncLifetime
         await Task.Yield();
         using var _arena = TensorArena.Create();
         var rng = ModelTestHelpers.CreateSeededRandom();
-        var network = CreateNetwork();
+        using var network = CreateNetwork();
         var input = CreateRandomTensor(InputShape, rng);
 
         var output = network.Predict(input);
@@ -206,7 +189,7 @@ public abstract class NeuralNetworkModelTestBase : IAsyncLifetime
         await Task.Yield();
         using var _arena = TensorArena.Create();
         var rng = ModelTestHelpers.CreateSeededRandom();
-        var network = CreateNetwork();
+        using var network = CreateNetwork();
         var input = CreateRandomTensor(InputShape, rng);
         var target = CreateRandomTensor(OutputShape, rng);
 
@@ -234,7 +217,7 @@ public abstract class NeuralNetworkModelTestBase : IAsyncLifetime
         await Task.Yield();
         using var _arena = TensorArena.Create();
         var rng = ModelTestHelpers.CreateSeededRandom();
-        var network = CreateNetwork();
+        using var network = CreateNetwork();
 
         var input = CreateRandomTensor(InputShape, rng);
         var scaledInput = new Tensor<double>(InputShape);
@@ -268,7 +251,7 @@ public abstract class NeuralNetworkModelTestBase : IAsyncLifetime
         await Task.Yield();
         using var _arena = TensorArena.Create();
         var rng = ModelTestHelpers.CreateSeededRandom();
-        var network = CreateNetwork();
+        using var network = CreateNetwork();
         var input = CreateRandomTensor(InputShape, rng);
 
         var out1 = network.Predict(input);
@@ -285,13 +268,9 @@ public abstract class NeuralNetworkModelTestBase : IAsyncLifetime
     {
         await Task.Yield();
         using var _arena = TensorArena.Create();
-        var network = CreateNetwork();
-        // Check ParameterCount rather than GetParameters().Length — both answer the
-        // same question ("does the network have learnable parameters?") but
-        // ParameterCount reads the declared count without forcing lazy layers
-        // to materialize their weight tensors (which at VGG16BN / DiT scale is
-        // multi-GB and OOMs CI runners just for an existence check).
-        Assert.True(network.ParameterCount > 0, "Neural network should have learnable parameters.");
+        using var network = CreateNetwork();
+        var parameters = network.GetParameters();
+        Assert.True(parameters.Length > 0, "Neural network should have learnable parameters.");
     }
 
     [Fact(Timeout = 120000)]
@@ -300,7 +279,7 @@ public abstract class NeuralNetworkModelTestBase : IAsyncLifetime
         await Task.Yield();
         using var _arena = TensorArena.Create();
         var rng = ModelTestHelpers.CreateSeededRandom();
-        var network = CreateNetwork();
+        using var network = CreateNetwork();
         var input = CreateRandomTensor(InputShape, rng);
 
         var original = network.Predict(input);
@@ -319,7 +298,7 @@ public abstract class NeuralNetworkModelTestBase : IAsyncLifetime
         await Task.Yield();
         using var _arena = TensorArena.Create();
         var rng = ModelTestHelpers.CreateSeededRandom();
-        var network = CreateNetwork();
+        using var network = CreateNetwork();
         var input = CreateRandomTensor(InputShape, rng);
         var target = CreateRandomTensor(OutputShape, rng);
         network.Train(input, target);
@@ -331,7 +310,7 @@ public abstract class NeuralNetworkModelTestBase : IAsyncLifetime
     {
         await Task.Yield();
         using var _arena = TensorArena.Create();
-        var network = CreateNetwork();
+        using var network = CreateNetwork();
         Assert.NotNull(network.GetArchitecture());
     }
 
@@ -341,7 +320,7 @@ public abstract class NeuralNetworkModelTestBase : IAsyncLifetime
         await Task.Yield();
         using var _arena = TensorArena.Create();
         var rng = ModelTestHelpers.CreateSeededRandom();
-        var network = CreateNetwork();
+        using var network = CreateNetwork();
         var input = CreateRandomTensor(InputShape, rng);
 
         var activations = network.GetNamedLayerActivations(input);
@@ -400,7 +379,7 @@ public abstract class NeuralNetworkModelTestBase : IAsyncLifetime
         await Task.Yield();
         using var _arena = TensorArena.Create();
         var rng = ModelTestHelpers.CreateSeededRandom();
-        var network = CreateNetwork();
+        using var network = CreateNetwork();
         var input = CreateRandomTensor(InputShape, rng);
         var target = CreateRandomTensor(OutputShape, rng);
 
@@ -433,7 +412,7 @@ public abstract class NeuralNetworkModelTestBase : IAsyncLifetime
         await Task.Yield();
         using var _arena = TensorArena.Create();
         var rng = ModelTestHelpers.CreateSeededRandom();
-        var network = CreateNetwork();
+        using var network = CreateNetwork();
         var input = CreateRandomTensor(InputShape, rng);
         var target = CreateRandomTensor(OutputShape, rng);
 
@@ -471,7 +450,7 @@ public abstract class NeuralNetworkModelTestBase : IAsyncLifetime
         await Task.Yield();
         using var _arena = TensorArena.Create();
         var rng = ModelTestHelpers.CreateSeededRandom();
-        var network = CreateNetwork();
+        using var network = CreateNetwork();
         var input = CreateRandomTensor(InputShape, rng);
 
         // Single prediction
@@ -499,7 +478,7 @@ public abstract class NeuralNetworkModelTestBase : IAsyncLifetime
         await Task.Yield();
         using var _arena = TensorArena.Create();
         var rng = ModelTestHelpers.CreateSeededRandom();
-        var network = CreateNetwork();
+        using var network = CreateNetwork();
         var input = CreateRandomTensor(InputShape, rng);
 
         var output = network.Predict(input);


### PR DESCRIPTION
## Summary

First PR in the series opened against issue #1136 to stop the five cancelled CI jobs from eating their 45-minute workflow budget on production-default model allocations.

Every diffusion model test on CI was OOMing during construction because `DiTNoisePredictor` / `MMDiTNoisePredictor` / `UNetNoisePredictor` and their siblings eagerly allocate ~4 GB of weight tensors in their ctors — `new DenseLayer<T>(...)` calls `TensorAllocator.Rent<T>` before the model has even seen an input. With 255 diffusion models × ~10 tests each running in a shared xunit process, sequential tests stack up live weight tensors and OOM on the 16 GB Windows CI runners before the shard finishes.

The user directive on issue #1136 is explicit: every test uses production defaults on purpose to catch real performance bugs. The fix is in the model code, not the tests.

## What's in this PR (Parts 1, 4, 5 of the 5-part plan)

**Part 1 — Lazy weight init in 11 noise predictors + `DiffusionResBlock`:**
- New protected helpers on `NoisePredictorBase<T>`: `LazyDense(...)`, `LazyDenseVec(...)`, `LazyConv2D(...)`. They instantiate `DenseLayer<T>` / `ConvolutionalLayer<T>` with `InitializationStrategies<T>.Lazy`, so weight tensors stay at shape `[0,0]` until the first `Forward()` pass actually needs them.
- Converted `DiTNoisePredictor`, `MMDiTNoisePredictor`, `MMDiTXNoisePredictor`, `EMMDiTPredictor`, `FlagDiTPredictor`, `FluxDoubleStreamPredictor`, `AsymmDiTPredictor`, `SiTPredictor`, `UViTNoisePredictor`, `UNetNoisePredictor`, `VideoUNetPredictor`, and `DiffusionResBlock` to use these helpers. All in-place replacements of `new DenseLayer<T>(...)` / `new ConvolutionalLayer<T>(...)` with their lazy equivalents.

**Part 5 — Swap `GetParameters().Length > 0` for `ParameterCount > 0`:**
- `DiffusionModelTestBase.Parameters_ShouldBeNonEmpty` and `NeuralNetworkModelTestBase.Parameters_ShouldBeNonEmpty` both previously asserted `GetParameters().Length > 0`. On a lazily-constructed DiT-XL that forces every `DenseLayer` to eagerly allocate its weights just to count them (`NeuralNetworkBase.GetParameters` → `layer.GetParameters()` → `EnsureInitialized()` cascades) — the ~4 GB allocation we just deferred gets materialized right back. `ParameterCount` is the right API for "does the model have learnable parameters?" and it's lazy-friendly.
- Semantically identical assertion, not a weakening.

**Part 4 — `IAsyncLifetime.DisposeAsync` forces GC between test methods:**
- Both ModelFamily test bases now implement `IAsyncLifetime` with a `DisposeAsync` that runs `GC.Collect(); GC.WaitForPendingFinalizers(); GC.Collect();`. Xunit invokes this after every `[Fact]` in the class, so previous-test weight tensors are released before the next test's model constructs.
- Without this, back-to-back production-size models in a shard hold each other alive via the shared process heap and OOM long before GC runs naturally.

**Parts 2 and 3 (deferred):**
- Part 2 (MHA / LayerNorm lazy init) and Part 3 (Dispose-returns-pool-tensors) turned out to be deeper than the plan implied — they'd mean adding ctor overloads, `_isInitialized` flags, `EnsureInitialized()` hooks, and retouching grad paths on core layers. Pulled into a focused follow-up PR so this one stays reviewable. See issue #1136 for the full roadmap.

## Verification

- Local build: `dotnet build src/AiDotNet.csproj --framework net10.0 -c Release` and `--framework net471` — 0 errors on both.
- Test-project build: `dotnet build tests/AiDotNet.Tests/AiDotNetTests.csproj --framework net10.0 -c Release` — 0 errors.
- CI baseline (before this PR): [run 24398739627](https://github.com/ooples/AiDotNet/actions/runs/24398739627) on PR #1135 cancelled with ~370 test timeouts and ~950 OOMs across 5 shards. The three Diffusion ModelFamily shards should now transition CANCELLED → SUCCESS or FAILURE (test failures are acceptable at this stage — the goal is to unblock the CI signal and expose real assertion failures that were hiding behind OOM).

## Test plan

- [ ] CI: `Tests (net10.0) - ModelFamily - Diffusion A-I` no longer cancelled
- [ ] CI: `Tests (net10.0) - ModelFamily - Diffusion J-R` no longer cancelled
- [ ] CI: `Tests (net10.0) - ModelFamily - Diffusion S-Z` no longer cancelled
- [ ] CI: `Tests (net10.0) - Unit - 03 Diffusion/Encoding` improvement (partial — full fix needs Parts 2/3)
- [ ] Compare per-test OOM counts in the Diffusion shards vs. the #1135 baseline run
- [ ] If Parts 2/3 are needed to fully clear, open follow-up PR per #1136

Refs #1136

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Switched many model layers and downsampling convolutions to lazy weight initialization (deferring allocation until first use); added thread-safe lazy initialization and helper factories for safer startup.

* **New Features**
  * Video model: per-block timestep FiLM conditioning and updated temporal mixing for improved video processing.

* **Tests**
  * Tests updated for deterministic disposal of networks and adjusted parameter-count checks to support lazy initialization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->