### PR TITLE
perf: lazy init for VGG + CapsuleNetwork to unblock NeuralNetworks ModelFamily shard

### DIFF
--- a/src/Helpers/LayerHelper.cs
+++ b/src/Helpers/LayerHelper.cs
@@ -1,4 +1,5 @@
 ﻿using AiDotNet.Diffusion.VAE;
+using AiDotNet.Initialization;
 using AiDotNet.NeuralNetworks.Layers;
 using AiDotNet.NeuralNetworks.Layers.SSM;
 using AiDotNet.PhysicsInformed.NeuralOperators;
@@ -586,7 +587,10 @@ public static class LayerHelper<T>
             {
                 int outputChannels = block[convIdx];
 
-                // Convolutional layer with 3x3 kernel
+                // Convolutional layer with 3x3 kernel. Lazy weight init defers the
+                // kernel tensor allocation to first Forward() — VGG16BN at 224×224×3
+                // production defaults is ~1.1 GB of weights, and eager allocation at
+                // ctor time OOMs CI before tests even run.
                 yield return new ConvolutionalLayer<T>(
                     inputDepth: currentChannels,
                     inputHeight: currentHeight,
@@ -595,7 +599,8 @@ public static class LayerHelper<T>
                     kernelSize: 3,
                     stride: 1,
                     padding: 1,  // Same padding to preserve spatial dimensions
-                    activationFunction: new ReLUActivation<T>()
+                    activationFunction: new ReLUActivation<T>(),
+                    initializationStrategy: InitializationStrategies<T>.Lazy
                 );
 
                 // Optional batch normalization (per-channel normalization)
@@ -624,14 +629,18 @@ public static class LayerHelper<T>
         int flattenedSize = currentChannels * currentHeight * currentWidth;
         yield return new FlattenLayer<T>(inputShape: [currentChannels, currentHeight, currentWidth]);
 
-        // Classifier (fully connected layers) - only if included
+        // Classifier (fully connected layers) - only if included. The three FC
+        // layers are the dominant memory cost of VGG (FC1 alone is ~822 MB at
+        // 224×224 input → 7×7×512 = 25088 × 4096 float64 weights); lazy init
+        // defers those allocations to first Forward().
         if (configuration.IncludeClassifier)
         {
             // FC1: flattenedSize -> 4096
             yield return new DenseLayer<T>(
                 inputSize: flattenedSize,
                 outputSize: 4096,
-                activationFunction: new ReLUActivation<T>()
+                activationFunction: new ReLUActivation<T>(),
+                initializationStrategy: InitializationStrategies<T>.Lazy
             );
             yield return new DropoutLayer<T>((float)configuration.DropoutRate);
 
@@ -639,7 +648,8 @@ public static class LayerHelper<T>
             yield return new DenseLayer<T>(
                 inputSize: 4096,
                 outputSize: 4096,
-                activationFunction: new ReLUActivation<T>()
+                activationFunction: new ReLUActivation<T>(),
+                initializationStrategy: InitializationStrategies<T>.Lazy
             );
             yield return new DropoutLayer<T>((float)configuration.DropoutRate);
 
@@ -647,7 +657,8 @@ public static class LayerHelper<T>
             yield return new DenseLayer<T>(
                 inputSize: 4096,
                 outputSize: configuration.NumClasses,
-                activationFunction: new SoftmaxActivation<T>() as IActivationFunction<T>
+                activationFunction: new SoftmaxActivation<T>() as IActivationFunction<T>,
+                initializationStrategy: InitializationStrategies<T>.Lazy
             );
         }
     }
@@ -1272,7 +1283,9 @@ public static class LayerHelper<T>
         int inputHeight = architecture.InputHeight;
         int inputWidth = architecture.InputWidth;
 
-        // Add initial convolutional layer
+        // Add initial convolutional layer — lazy weight init defers the kernel
+        // tensor (9×9×inputDepth×256 = ~150 KB per input channel) to first Forward().
+        // CapsuleNetwork tests repeatedly instantiate this at production defaults.
         yield return new ConvolutionalLayer<T>(
             inputDepth: inputDepth,
             outputDepth: 256,
@@ -1281,7 +1294,8 @@ public static class LayerHelper<T>
             inputWidth: inputWidth,
             stride: 1,
             padding: 0,
-            activationFunction: new ReLUActivation<T>()
+            activationFunction: new ReLUActivation<T>(),
+            initializationStrategy: InitializationStrategies<T>.Lazy
         );
 
         // Add PrimaryCapsules layer

--- a/src/NeuralNetworks/Layers/ConvolutionalLayer.cs
+++ b/src/NeuralNetworks/Layers/ConvolutionalLayer.cs
@@ -1315,11 +1315,14 @@ public partial class ConvolutionalLayer<T> : LayerBase<T>
     /// This provides access to all the "knowledge" the layer has learned.
     /// </para>
     /// </remarks>
-    public override int ParameterCount => _kernels.Length + _biases.Shape[0];
+    public override int ParameterCount => _isInitialized
+        ? _kernels.Length + _biases.Shape[0]
+        : OutputDepth * InputDepth * KernelSize * KernelSize + OutputDepth;
 
     /// <inheritdoc/>
     public override Vector<T> GetParameters()
     {
+        EnsureInitialized();
         // Bulk copy from contiguous tensor storage — replaces 4-nested scalar loops
         return Vector<T>.Concatenate(
             Vector<T>.FromMemory(_kernels.Data),
@@ -1339,6 +1342,7 @@ public partial class ConvolutionalLayer<T> : LayerBase<T>
     /// <returns>A vector containing all parameter gradients (kernel gradients followed by bias gradients).</returns>
     public override Vector<T> GetParameterGradients()
     {
+        EnsureInitialized();
         // If gradients haven't been computed yet, return zero gradients
         if (_kernelsGradient == null || _biasesGradient == null)
         {
@@ -1377,6 +1381,7 @@ public partial class ConvolutionalLayer<T> : LayerBase<T>
     /// </remarks>
     public override void SetParameters(Vector<T> parameters)
     {
+        EnsureInitialized();
         int kernelLen = _kernels.Length;
         int biasLen = _biases.Shape[0];
         if (parameters.Length != kernelLen + biasLen)

--- a/src/NeuralNetworks/Layers/ConvolutionalLayer.cs
+++ b/src/NeuralNetworks/Layers/ConvolutionalLayer.cs
@@ -725,6 +725,10 @@ public partial class ConvolutionalLayer<T> : LayerBase<T>
         // Reinitialize _lastInput and _lastOutput
         _lastInput = new Tensor<T>([OutputDepth, InputDepth, KernelSize, KernelSize]);
         _lastOutput = new Tensor<T>([OutputDepth, InputDepth, KernelSize, KernelSize]);
+
+        // Mark as initialized so EnsureInitialized() doesn't re-randomize the
+        // just-deserialized weights on the next Forward/GetParameters call.
+        _isInitialized = true;
     }
 
     /// <summary>

--- a/src/NeuralNetworks/Layers/ConvolutionalLayer.cs
+++ b/src/NeuralNetworks/Layers/ConvolutionalLayer.cs
@@ -726,6 +726,15 @@ public partial class ConvolutionalLayer<T> : LayerBase<T>
         _lastInput = new Tensor<T>([OutputDepth, InputDepth, KernelSize, KernelSize]);
         _lastOutput = new Tensor<T>([OutputDepth, InputDepth, KernelSize, KernelSize]);
 
+        // Re-register the freshly-created tensors as trainable parameters so
+        // optimizers and tape training target these objects (not the stale ones
+        // from a prior EnsureInitialized or constructor call). Without this,
+        // the registered list points at the old tensors while Forward uses the
+        // new ones — gradient updates silently go to dead references.
+        ClearRegisteredParameters();
+        RegisterTrainableParameter(_kernels, PersistentTensorRole.Weights);
+        RegisterTrainableParameter(_biases, PersistentTensorRole.Biases);
+
         // Mark as initialized so EnsureInitialized() doesn't re-randomize the
         // just-deserialized weights on the next Forward/GetParameters call.
         _isInitialized = true;
@@ -1346,12 +1355,16 @@ public partial class ConvolutionalLayer<T> : LayerBase<T>
     /// <returns>A vector containing all parameter gradients (kernel gradients followed by bias gradients).</returns>
     public override Vector<T> GetParameterGradients()
     {
-        EnsureInitialized();
-        // If gradients haven't been computed yet, return zero gradients
+        // If gradients haven't been computed yet, return zero gradients without
+        // forcing initialization — ParameterCount already computes the correct
+        // size from constructor-time shapes when the layer is uninitialized,
+        // so there's no need to allocate/randomize the full weight tensors
+        // just to return a zero vector.
         if (_kernelsGradient == null || _biasesGradient == null)
         {
             return new Vector<T>(ParameterCount);
         }
+        EnsureInitialized();
 
         // Bulk copy from contiguous tensor storage — replaces 4-nested scalar loops
         return Vector<T>.Concatenate(


### PR DESCRIPTION
## Summary

Second PR in the #1136 series, targeting the cancelled `Tests (net10.0) - ModelFamily - NeuralNetworks` shard on CI. Baseline run [24398739627](https://github.com/ooples/AiDotNet/actions/runs/24398739627) cancelled that shard at 45 min with 14 VGG timeouts, 8 Capsule timeouts, 110 FastText OOMs, and several others stacked up in a shared xunit process.

## What's in this PR

Applies the same `InitializationStrategies<T>.Lazy` pattern introduced in PR #1137 for diffusion noise predictors, but to the two biggest per-instance OOM offenders in the NeuralNetworks shard.

**VGGNetwork** (14 timeouts + 3 OOMs on baseline): VGG16BN at 224×224×3 with 1000 classes allocates ~1.1 GB of weights per instance. The three fully connected classifier layers alone are ~1 GB (FC1 at 25088×4096 = ~822 MB). Each `ModelFamilyTests.NeuralNetworks.VGGNetworkTests.*` was eagerly renting those tensors in `new DenseLayer<T>(...)`.

**CapsuleNetwork** (8 timeouts + 1 OOM): Same eager-rent pattern on the initial 9×9 convolutional layer at production spatial sizes.

Changes `LayerHelper<T>.CreateDefaultVGGLayers` and `LayerHelper<T>.CreateDefaultCapsuleNetworkLayers` to thread `InitializationStrategies<T>.Lazy` into the relevant `ConvolutionalLayer` and `DenseLayer` constructions. Weight tensors stay at shape `[0,…,0]` until the first `Forward()` call.

## Intentionally out of scope

- **FastText's 110 OOMs** were caused by per-test accumulation, not a single large alloc. PR #1137's `IAsyncLifetime.DisposeAsync` hook on `NeuralNetworkModelTestBase` forces a full GC between test methods, which covers this.
- **VoxelCNN's 3 OOMs** go through `Conv3DLayer`, which doesn't have a lazy-init branch yet. Deferred to the follow-up MHA/LayerNorm/Conv3D lazy-init PR tracked in #1136.
- **NEAT's 12 failures** are evolutionary-topology-driven and don't have a single eager-alloc hot path to fix the same way.

## Verification

- Local build: `dotnet build src/AiDotNet.csproj --framework net10.0 -c Release` — 0 errors.
- CI target: `Tests (net10.0) - ModelFamily - NeuralNetworks` should transition CANCELLED → SUCCESS or FAILURE. Pre-existing test failures are acceptable at this stage — the goal is unblocking the CI signal.

Depends on: none (branched off master). Does not conflict with PR #1137 (different files).

Refs #1136

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Layer initialization now defers heavy weight/tensor allocations until first use, reducing upfront memory and improving startup efficiency.
  * Parameter counting is initialization-aware to reflect deferred allocation.

* **Bug Fixes**
  * Serialization/deserialization and parameter access now reliably preserve or trigger initialization to avoid stale or mismatched parameters and gradients.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->