### PR TITLE
feat: wire JIT compilation through AiModelBuilder

### DIFF
--- a/src/AiModelBuilder.cs
+++ b/src/AiModelBuilder.cs
@@ -1156,6 +1156,125 @@ public partial class AiModelBuilder<T, TInput, TOutput> : IAiModelBuilder<T, TIn
     /// </remarks>
     public Task<AiModelResult<T, TInput, TOutput>> BuildAsync() => BuildAsync(CancellationToken.None);
 
+    /// <summary>
+    /// Wraps a trained model's <c>Predict</c> in a <c>CompiledModelCache</c>-backed
+    /// function matching the <c>JitCompiledFunction</c> shape expected by
+    /// <see cref="AiModelResult{T, TInput, TOutput}"/>.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This is how JIT compilation reaches every model whose <c>Predict</c> override
+    /// bypasses the base class. The wrapper traces the model's forward pass under
+    /// GraphMode on the first call at each input shape, compiles it into a flat
+    /// replay plan, and re-executes the plan for subsequent calls.
+    /// </para>
+    /// <para>
+    /// Nested-GraphMode defense: during tracing the wrapper temporarily sets
+    /// <c>TensorCodecOptions.EnableCompilation = false</c> so any call into
+    /// <c>NeuralNetworkBase{T}.PredictCompiled</c> from within the model's own
+    /// <c>Predict</c> falls through to <c>PredictEager</c> instead of opening a
+    /// second, conflicting GraphMode scope.
+    /// </para>
+    /// <para>
+    /// Scope: only wraps <see cref="NeuralNetworks.NeuralNetworkBase{T}"/>
+    /// descendants. Diffusion models (extend <c>DiffusionModelBase</c>, not
+    /// <c>NeuralNetworkBase</c>) and non-neural models (regression, trees) return
+    /// <c>null</c> so the result's Predict path stays on its existing code path.
+    /// Multi-step inference (autoregressive text, RNN unroll) that relies on
+    /// per-step scalar control flow will either trace correctly if the loop is
+    /// unrolled at compile time, or fall through to eager via the try/catch —
+    /// if it traces correctly but produces wrong results on replay (a real risk
+    /// for models with non-Engine tensor access), set
+    /// <see cref="AiDotNet.Configuration.JitCompilationConfig.ThrowOnFailure"/>
+    /// in tests to catch silent divergence.
+    /// </para>
+    /// </remarks>
+    private Func<Tensor<T>[], Tensor<T>[]>? BuildCompiledPredictFunction(
+        IFullModel<T, TInput, TOutput>? model)
+    {
+        if (model is null) return null;
+        if (_jitCompilationConfig is null || !_jitCompilationConfig.Enabled) return null;
+
+        // Only NeuralNetworkBase<T> models go through the Engine-op forward pass
+        // that GraphMode can record. Regression/tree models use scalar math that
+        // wouldn't benefit from graph compilation even if it were traceable.
+        if (model is not NeuralNetworks.NeuralNetworkBase<T> nnModel) return null;
+
+        var cache = new AiDotNet.Tensors.Engines.Compilation.CompiledModelCache<T>();
+        bool throwOnFailure = _jitCompilationConfig.ThrowOnFailure;
+        var jitConfig = _jitCompilationConfig;
+
+        return (inputs) =>
+        {
+            if (inputs is null || inputs.Length == 0)
+            {
+                throw new ArgumentException(
+                    "JitCompiledFunction requires at least one input tensor.",
+                    nameof(inputs));
+            }
+
+            var input = inputs[0];
+
+            // Each call applies the JIT config to this thread's TensorCodecOptions
+            // — request-pool workers don't inherit the thread-static state set on
+            // the builder thread.
+            jitConfig.ApplyToTensorCodec();
+
+            try
+            {
+                var plan = cache.GetOrCompileInference(input, () =>
+                {
+                    // Guard against nested-GraphMode. When the trace lambda invokes
+                    // nnModel.Predict, any subclass still using the base default
+                    // would re-enter PredictCompiled which opens a second GraphMode
+                    // scope — the inner compile would drop the outer trace's ops.
+                    // Forcing EnableCompilation=false here makes PredictCompiled
+                    // fall through to PredictEager, recording the ops into our
+                    // outer trace instead.
+                    var savedOptions = AiDotNet.Tensors.Engines.Optimization.TensorCodecOptions.Current;
+                    var traceOptions = new AiDotNet.Tensors.Engines.Optimization.TensorCodecOptions
+                    {
+                        EnableCompilation = false,
+                        EnableDataflowFusion = savedOptions.EnableDataflowFusion,
+                        EnableAlgebraicBackward = savedOptions.EnableAlgebraicBackward,
+                        EnableSpectralDecomposition = savedOptions.EnableSpectralDecomposition,
+                        SpectralErrorTolerance = savedOptions.SpectralErrorTolerance,
+                        DataflowFusionMaxHidden = savedOptions.DataflowFusionMaxHidden,
+                        EnableConvBnFusion = savedOptions.EnableConvBnFusion,
+                        EnableAttentionFusion = savedOptions.EnableAttentionFusion,
+                        EnablePointwiseFusion = savedOptions.EnablePointwiseFusion,
+                        EnableConstantFolding = savedOptions.EnableConstantFolding,
+                        EnableForwardCSE = savedOptions.EnableForwardCSE,
+                        EnableBlasBatch = savedOptions.EnableBlasBatch,
+                        EnableMixedPrecision = savedOptions.EnableMixedPrecision
+                    };
+                    AiDotNet.Tensors.Engines.Optimization.TensorCodecOptions.SetCurrent(traceOptions);
+                    try
+                    {
+                        using var noGrad = new AiDotNet.Tensors.Engines.Autodiff.NoGradScope<T>();
+                        // Discard return: CompiledModelCache treats the last recorded
+                        // op's output tensor as the plan's output.
+                        nnModel.Predict(input);
+                    }
+                    finally
+                    {
+                        AiDotNet.Tensors.Engines.Optimization.TensorCodecOptions.SetCurrent(savedOptions);
+                    }
+                });
+
+                return new[] { plan.Execute() };
+            }
+            catch when (!throwOnFailure)
+            {
+                // Compilation blew up OR replay couldn't rebind inputs cleanly.
+                // Fall back to eager Predict — the call succeeds, just slower.
+                // Next call retries compilation because the cache didn't store a
+                // plan for the failed shape.
+                return new[] { nnModel.Predict(input) };
+            }
+        };
+    }
+
     public async Task<AiModelResult<T, TInput, TOutput>> BuildAsync(CancellationToken cancellationToken)
     {
         cancellationToken.ThrowIfCancellationRequested();
@@ -2858,7 +2977,7 @@ public partial class AiModelBuilder<T, TInput, TOutput> : IAiModelBuilder<T, TIn
             AgentRecommendation = agentRecommendation,
             DeploymentConfiguration = deploymentConfig,
             QuantizationInfo = quantizationInfo,
-            JitCompiledFunction = null,
+            JitCompiledFunction = BuildCompiledPredictFunction(optimizationResult.BestSolution),
             InferenceOptimizationConfig = _inferenceOptimizationConfig,
             JitCompilationConfig = _jitCompilationConfig,
             AugmentationConfig = _augmentationConfig,

--- a/src/AiModelBuilder.cs
+++ b/src/AiModelBuilder.cs
@@ -1200,12 +1200,13 @@ public partial class AiModelBuilder<T, TInput, TOutput> : IAiModelBuilder<T, TIn
         // wouldn't benefit from graph compilation even if it were traceable.
         if (model is not NeuralNetworks.NeuralNetworkBase<T> nnModel) return null;
 
-        // Thread strict-mode through to the model-instance flag so the lower-level
-        // PredictCompiled path (called from the model's own Predict default) ALSO
-        // honors ThrowOnFailure. Without this, the wrapper would throw on the
-        // outer trace while the inner PredictCompiled would silently fall back —
-        // inconsistent strict-mode behavior for the same configured policy.
-        nnModel.ThrowOnJitFailure = _jitCompilationConfig.ThrowOnFailure;
+        // ThrowOnFailure is enforced at THIS wrapper level (the catch below).
+        // We deliberately do NOT push it onto the model instance — multiple
+        // results may share one model with different strict-mode policies, and
+        // writing per-result config onto a shared instance would race. The
+        // lower-level NeuralNetworkBase.PredictCompiled keeps its own silent-
+        // fallback-with-Trace behavior; strict mode applies only to the
+        // builder-wrapped path that consults ThrowOnFailure here.
 
         var cache = new AiDotNet.Tensors.Engines.Compilation.CompiledModelCache<T>();
         bool throwOnFailure = _jitCompilationConfig.ThrowOnFailure;
@@ -3177,6 +3178,14 @@ public partial class AiModelBuilder<T, TInput, TOutput> : IAiModelBuilder<T, TIn
         {
             MetaLearner = _metaLearner,
             MetaTrainingResult = metaResult,
+            // Propagate JIT config to meta-learning results so
+            // ConfigureJitCompilation is honored consistently across all builder
+            // paths (supervised / inference-only / RL / meta-learning). The
+            // compiled-Predict wrapper isn't built here because IMetaLearner
+            // doesn't expose an IFullModel surface — meta-learning Predict
+            // routes through the meta-learner's own dispatch, which has its
+            // own opportunities for compilation in a follow-up.
+            JitCompilationConfig = _jitCompilationConfig,
             LoRAConfiguration = _loraConfiguration,
             BiasDetector = _biasDetector,
             FairnessEvaluator = _fairnessEvaluator,

--- a/src/AiModelBuilder.cs
+++ b/src/AiModelBuilder.cs
@@ -184,6 +184,7 @@ public partial class AiModelBuilder<T, TInput, TOutput> : IAiModelBuilder<T, TIn
     private KnowledgeDistillationOptions<T, TInput, TOutput>? _knowledgeDistillationOptions;
     private MixedPrecisionConfig? _mixedPrecisionConfig;
     private AiDotNet.Configuration.InferenceOptimizationConfig? _inferenceOptimizationConfig;
+    private AiDotNet.Configuration.JitCompilationConfig? _jitCompilationConfig;
     private RLTrainingOptions<T>? _rlOptions;
     private IAutoMLModel<T, TInput, TOutput>? _autoMLModel;
     private AutoMLOptions<T, TInput, TOutput>? _autoMLOptions;
@@ -264,6 +265,7 @@ public partial class AiModelBuilder<T, TInput, TOutput> : IAiModelBuilder<T, TIn
     internal IOptimizer<T, TInput, TOutput>? ConfiguredOptimizer => _optimizer;
     internal CacheConfig? ConfiguredCaching => _cacheConfig;
     internal AiDotNet.Configuration.InferenceOptimizationConfig? ConfiguredInferenceOptimizations => _inferenceOptimizationConfig;
+    internal AiDotNet.Configuration.JitCompilationConfig? ConfiguredJitCompilation => _jitCompilationConfig;
     internal InterpretabilityOptions? ConfiguredInterpretability => _interpretabilityOptions;
     internal Training.Memory.TrainingMemoryConfig? ConfiguredMemoryManagement => _memoryConfig;
     internal AiDotNetLicenseKey? ConfiguredLicenseKey => _licenseKey;
@@ -888,6 +890,68 @@ public partial class AiModelBuilder<T, TInput, TOutput> : IAiModelBuilder<T, TIn
         return this;
     }
 
+    /// <summary>
+    /// Enables JIT (Just-In-Time) compilation for the built model's forward and
+    /// backward passes.
+    /// </summary>
+    /// <param name="config">JIT compilation configuration. If <c>null</c>, uses
+    /// <see cref="AiDotNet.Configuration.JitCompilationConfig.Default"/>.</param>
+    /// <returns>This builder instance for fluent chaining.</returns>
+    /// <remarks>
+    /// <para>
+    /// JIT compilation traces the model's computation graph on the first call at
+    /// each input shape and replays the compiled plan on subsequent calls,
+    /// eliminating virtual dispatch, per-op allocation, and bounds-checking
+    /// overhead. Typical gains are 1.5-3× on CPU and up to 10× on GPU.
+    /// </para>
+    /// <para>
+    /// <b>Scope:</b> the flags configured here are written into the thread-local
+    /// <c>TensorCodecOptions</c> during <c>Build()</c>. From that point on the
+    /// built model's <c>Predict</c> (routed through
+    /// <c>NeuralNetworkBase{T}.PredictCompiled</c>) and the tape-based training
+    /// path both pick up the compiled plans via <c>CompiledModelCache</c> in the
+    /// Tensors package — no further per-model wiring is needed. Concrete models
+    /// whose <c>Predict</c> override bypasses the base (e.g., diffusion models
+    /// running multi-step denoising loops) still benefit from the AutoTracer
+    /// auto-compilation layer, which reads the same flags.
+    /// </para>
+    /// <para>
+    /// <b>For Beginners:</b> think of this as turning your model from an
+    /// interpreter into a compiled binary. The first prediction is a little
+    /// slower (while the library studies your model). Every prediction after
+    /// that is much faster. If anything goes wrong during compilation, the
+    /// library silently falls back to the original execution path — so enabling
+    /// this is safe.
+    /// </para>
+    /// <para>
+    /// Example:
+    /// <code>
+    /// // Simple — enable with library defaults
+    /// var result = await new AiModelBuilder&lt;float, Tensor&lt;float&gt;, Tensor&lt;float&gt;&gt;()
+    ///     .ConfigureModel(myModel)
+    ///     .ConfigureJitCompilation()
+    ///     .BuildAsync();
+    ///
+    /// // Aggressive — all fusion/CSE passes on (good for benchmarking)
+    /// await builder
+    ///     .ConfigureJitCompilation(JitCompilationConfig.Aggressive)
+    ///     .BuildAsync();
+    ///
+    /// // Strict — throw on any compilation failure (good for tests)
+    /// var cfg = JitCompilationConfig.Default;
+    /// cfg.ThrowOnFailure = true;
+    /// await builder.ConfigureJitCompilation(cfg).BuildAsync();
+    /// </code>
+    /// </para>
+    /// </remarks>
+    public IAiModelBuilder<T, TInput, TOutput> ConfigureJitCompilation(
+        AiDotNet.Configuration.JitCompilationConfig? config = null)
+    {
+        _jitCompilationConfig = config ?? AiDotNet.Configuration.JitCompilationConfig.Default;
+        _jitCompilationConfig.Validate();
+        return this;
+    }
+
     // Uncertainty quantification configuration lives in AiModelBuilder.UncertaintyQuantification.cs to keep this file focused.
 
     /// <summary>
@@ -1100,6 +1164,14 @@ public partial class AiModelBuilder<T, TInput, TOutput> : IAiModelBuilder<T, TIn
         // validate during serialize/deserialize operations within BuildAsync.
         using var licenseScope = Helpers.ModelPersistenceGuard.SetActiveLicenseKey(_licenseKey);
 
+        // Apply JIT compilation config FIRST so every subsequent step in BuildAsync
+        // — training, fine-tuning, quantization calibration, cross-validation —
+        // sees the configured TensorCodecOptions. When Enabled=true (default on
+        // library side anyway) the auto-compilation layer + CompiledModelCache
+        // engage automatically; when Enabled=false the entire stack short-circuits
+        // to eager execution for A/B diffing.
+        _jitCompilationConfig?.ApplyToTensorCodec();
+
         // Validate RAG pipeline composition if any RAG components were configured
         bool hasAnyRAG = _ragRetriever != null || _ragReranker != null || _ragGenerator != null
             || _queryProcessors != null || _graphStore != null || _knowledgeGraph != null;
@@ -1242,6 +1314,7 @@ public partial class AiModelBuilder<T, TInput, TOutput> : IAiModelBuilder<T, TIn
             ProgramSynthesisServingClient = _programSynthesisServingClient,
             ProgramSynthesisServingClientOptions = _programSynthesisServingClientOptions,
             InferenceOptimizationConfig = _inferenceOptimizationConfig,
+            JitCompilationConfig = _jitCompilationConfig,
             AugmentationConfig = _augmentationConfig,
             ReasoningConfig = _reasoningConfig,
             DeploymentConfiguration = deploymentConfig,
@@ -1594,6 +1667,7 @@ public partial class AiModelBuilder<T, TInput, TOutput> : IAiModelBuilder<T, TIn
             ProgramSynthesisServingClient = _programSynthesisServingClient,
             ProgramSynthesisServingClientOptions = _programSynthesisServingClientOptions,
             InferenceOptimizationConfig = _inferenceOptimizationConfig,
+            JitCompilationConfig = _jitCompilationConfig,
             AugmentationConfig = _augmentationConfig,
             ReasoningConfig = _reasoningConfig,
             DeploymentConfiguration = deploymentConfig,
@@ -2786,6 +2860,7 @@ public partial class AiModelBuilder<T, TInput, TOutput> : IAiModelBuilder<T, TIn
             QuantizationInfo = quantizationInfo,
             JitCompiledFunction = null,
             InferenceOptimizationConfig = _inferenceOptimizationConfig,
+            JitCompilationConfig = _jitCompilationConfig,
             AugmentationConfig = _augmentationConfig,
             ReasoningConfig = _reasoningConfig,
             KnowledgeGraph = _knowledgeGraph,
@@ -3274,6 +3349,7 @@ public partial class AiModelBuilder<T, TInput, TOutput> : IAiModelBuilder<T, TIn
             AgentConfig = _agentConfig,
             DeploymentConfiguration = deploymentConfig,
             InferenceOptimizationConfig = _inferenceOptimizationConfig,
+            JitCompilationConfig = _jitCompilationConfig,
             ReasoningConfig = _reasoningConfig,
             KnowledgeGraph = _knowledgeGraph,
             GraphStore = _graphStore,

--- a/src/AiModelBuilder.cs
+++ b/src/AiModelBuilder.cs
@@ -1264,12 +1264,21 @@ public partial class AiModelBuilder<T, TInput, TOutput> : IAiModelBuilder<T, TIn
 
                 return new[] { plan.Execute() };
             }
-            catch when (!throwOnFailure)
+            catch (Exception ex) when (!throwOnFailure)
             {
                 // Compilation blew up OR replay couldn't rebind inputs cleanly.
-                // Fall back to eager Predict — the call succeeds, just slower.
-                // Next call retries compilation because the cache didn't store a
-                // plan for the failed shape.
+                // Log via Trace so the failure is observable in production telemetry
+                // — silent fallback would make JIT regressions invisible until perf
+                // surveys catch them. Then fall back to eager Predict so the call
+                // succeeds. Wrap the fallback in NoGradScope to match the trace's
+                // inference semantics (no tape recording during Predict). Next call
+                // retries compilation since the cache didn't store a plan for the
+                // failed shape.
+                System.Diagnostics.Trace.TraceWarning(
+                    $"JIT fallback for {nnModel.GetType().FullName} " +
+                    $"with input shape [{string.Join(", ", input.Shape)}]: {ex.GetType().Name}: {ex.Message}");
+
+                using var noGrad = new AiDotNet.Tensors.Engines.Autodiff.NoGradScope<T>();
                 return new[] { nnModel.Predict(input) };
             }
         };
@@ -1283,12 +1292,20 @@ public partial class AiModelBuilder<T, TInput, TOutput> : IAiModelBuilder<T, TIn
         // validate during serialize/deserialize operations within BuildAsync.
         using var licenseScope = Helpers.ModelPersistenceGuard.SetActiveLicenseKey(_licenseKey);
 
-        // Apply JIT compilation config FIRST so every subsequent step in BuildAsync
-        // — training, fine-tuning, quantization calibration, cross-validation —
-        // sees the configured TensorCodecOptions. When Enabled=true (default on
-        // library side anyway) the auto-compilation layer + CompiledModelCache
-        // engage automatically; when Enabled=false the entire stack short-circuits
-        // to eager execution for A/B diffing.
+        // Apply JIT compilation config FIRST so every subsequent SYNCHRONOUS step
+        // in BuildAsync sees the configured TensorCodecOptions. When Enabled=true
+        // (default on library side anyway) the auto-compilation layer +
+        // CompiledModelCache engage automatically; when Enabled=false the entire
+        // stack short-circuits to eager execution for A/B diffing.
+        //
+        // Cross-await caveat: TensorCodecOptions.Current is [ThreadStatic] on the
+        // Tensors side and does NOT flow across `await` continuations — async work
+        // resumed on a different worker thread will see the thread's previous
+        // codec state. This Apply gives the synchronous setup phase the right
+        // options; downstream consumers that need cross-thread persistence
+        // (AiModelResult.Predict re-asserts on every call) bridge it themselves.
+        // A follow-up Tensors-side change to migrate Current to AsyncLocal<T>
+        // would close this gap globally — tracked as a separate issue.
         _jitCompilationConfig?.ApplyToTensorCodec();
 
         // Validate RAG pipeline composition if any RAG components were configured
@@ -1434,6 +1451,12 @@ public partial class AiModelBuilder<T, TInput, TOutput> : IAiModelBuilder<T, TIn
             ProgramSynthesisServingClientOptions = _programSynthesisServingClientOptions,
             InferenceOptimizationConfig = _inferenceOptimizationConfig,
             JitCompilationConfig = _jitCompilationConfig,
+            // Build the compiled-Predict wrapper at every result-creation site —
+            // not just the supervised path. Without this, RL/inference-only/streaming
+            // results that persist JitCompilationConfig still bypass the wrapper for
+            // models that override Predict, defeating ConfigureJitCompilation() for
+            // those build paths.
+            JitCompiledFunction = BuildCompiledPredictFunction(optimizationResult.BestSolution),
             AugmentationConfig = _augmentationConfig,
             ReasoningConfig = _reasoningConfig,
             DeploymentConfiguration = deploymentConfig,
@@ -1787,6 +1810,12 @@ public partial class AiModelBuilder<T, TInput, TOutput> : IAiModelBuilder<T, TIn
             ProgramSynthesisServingClientOptions = _programSynthesisServingClientOptions,
             InferenceOptimizationConfig = _inferenceOptimizationConfig,
             JitCompilationConfig = _jitCompilationConfig,
+            // Build the compiled-Predict wrapper at every result-creation site —
+            // not just the supervised path. Without this, RL/inference-only/streaming
+            // results that persist JitCompilationConfig still bypass the wrapper for
+            // models that override Predict, defeating ConfigureJitCompilation() for
+            // those build paths.
+            JitCompiledFunction = BuildCompiledPredictFunction(optimizationResult.BestSolution),
             AugmentationConfig = _augmentationConfig,
             ReasoningConfig = _reasoningConfig,
             DeploymentConfiguration = deploymentConfig,
@@ -2977,9 +3006,14 @@ public partial class AiModelBuilder<T, TInput, TOutput> : IAiModelBuilder<T, TIn
             AgentRecommendation = agentRecommendation,
             DeploymentConfiguration = deploymentConfig,
             QuantizationInfo = quantizationInfo,
-            JitCompiledFunction = BuildCompiledPredictFunction(optimizationResult.BestSolution),
             InferenceOptimizationConfig = _inferenceOptimizationConfig,
             JitCompilationConfig = _jitCompilationConfig,
+            // Build the compiled-Predict wrapper at every result-creation site —
+            // not just the supervised path. Without this, RL/inference-only/streaming
+            // results that persist JitCompilationConfig still bypass the wrapper for
+            // models that override Predict, defeating ConfigureJitCompilation() for
+            // those build paths.
+            JitCompiledFunction = BuildCompiledPredictFunction(optimizationResult.BestSolution),
             AugmentationConfig = _augmentationConfig,
             ReasoningConfig = _reasoningConfig,
             KnowledgeGraph = _knowledgeGraph,
@@ -3469,6 +3503,12 @@ public partial class AiModelBuilder<T, TInput, TOutput> : IAiModelBuilder<T, TIn
             DeploymentConfiguration = deploymentConfig,
             InferenceOptimizationConfig = _inferenceOptimizationConfig,
             JitCompilationConfig = _jitCompilationConfig,
+            // Build the compiled-Predict wrapper at every result-creation site —
+            // not just the supervised path. Without this, RL/inference-only/streaming
+            // results that persist JitCompilationConfig still bypass the wrapper for
+            // models that override Predict, defeating ConfigureJitCompilation() for
+            // those build paths.
+            JitCompiledFunction = BuildCompiledPredictFunction(optimizationResult.BestSolution),
             ReasoningConfig = _reasoningConfig,
             KnowledgeGraph = _knowledgeGraph,
             GraphStore = _graphStore,

--- a/src/AiModelBuilder.cs
+++ b/src/AiModelBuilder.cs
@@ -1200,6 +1200,13 @@ public partial class AiModelBuilder<T, TInput, TOutput> : IAiModelBuilder<T, TIn
         // wouldn't benefit from graph compilation even if it were traceable.
         if (model is not NeuralNetworks.NeuralNetworkBase<T> nnModel) return null;
 
+        // Thread strict-mode through to the model-instance flag so the lower-level
+        // PredictCompiled path (called from the model's own Predict default) ALSO
+        // honors ThrowOnFailure. Without this, the wrapper would throw on the
+        // outer trace while the inner PredictCompiled would silently fall back —
+        // inconsistent strict-mode behavior for the same configured policy.
+        nnModel.ThrowOnJitFailure = _jitCompilationConfig.ThrowOnFailure;
+
         var cache = new AiDotNet.Tensors.Engines.Compilation.CompiledModelCache<T>();
         bool throwOnFailure = _jitCompilationConfig.ThrowOnFailure;
         var jitConfig = _jitCompilationConfig;

--- a/src/Configuration/JitCompilationConfig.cs
+++ b/src/Configuration/JitCompilationConfig.cs
@@ -176,10 +176,16 @@ public sealed class JitCompilationConfig
     /// <exception cref="InvalidOperationException">Thrown when values are out of range.</exception>
     public void Validate()
     {
-        if (SpectralErrorTolerance < 0f || SpectralErrorTolerance >= 1f)
+        // NaN passes both `< 0` and `>= 1` comparisons (NaN is unordered with
+        // every value), so the explicit IsNaN check is required to reject it.
+        // Without this guard a NaN tolerance would silently become the SVD
+        // energy threshold and corrupt every spectral compilation downstream.
+        if (float.IsNaN(SpectralErrorTolerance)
+            || SpectralErrorTolerance < 0f
+            || SpectralErrorTolerance >= 1f)
         {
             throw new InvalidOperationException(
-                $"SpectralErrorTolerance must be in [0, 1). Got: {SpectralErrorTolerance}");
+                $"SpectralErrorTolerance must be in [0, 1) and not NaN. Got: {SpectralErrorTolerance}");
         }
 
         if (DataflowFusionMaxHidden <= 0)

--- a/src/Configuration/JitCompilationConfig.cs
+++ b/src/Configuration/JitCompilationConfig.cs
@@ -97,10 +97,26 @@ public sealed class JitCompilationConfig
     public bool Enabled { get; set; } = true;
 
     /// <summary>
-    /// When <c>true</c>, a compilation failure propagates as an exception instead of
-    /// silently falling back to the eager path. Use in tests to catch regressions;
-    /// leave <c>false</c> in production so a misbehaving op doesn't take down inference.
+    /// When <c>true</c>, a compilation failure in the builder's <c>JitCompiledFunction</c>
+    /// wrapper (the one populated by <c>AiModelBuilder.BuildCompiledPredictFunction</c>)
+    /// propagates as an exception instead of silently falling back to the eager
+    /// Predict path. Use in tests to catch regressions.
     /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Scope: this flag is currently consulted only by the builder-level wrapper
+    /// — the lower-level <c>NeuralNetworkBase{T}.PredictCompiled</c> and
+    /// <c>CompiledTapeTrainingStep{T}.Step</c> have their own catch-all fallbacks
+    /// (with Trace warnings logged on the wrapper). Threading strict-mode through
+    /// those internal helpers is tracked as a follow-up; for tests, exercising
+    /// the wrapper path (built via <c>AiModelBuilder</c>) is sufficient.
+    /// </para>
+    /// <para>
+    /// Leave <c>false</c> in production so a misbehaving op doesn't take down
+    /// inference — fallback runs eager + emits a <c>Trace.TraceWarning</c> so
+    /// the regression is observable in telemetry.
+    /// </para>
+    /// </remarks>
     public bool ThrowOnFailure { get; set; }
 
     /// <summary>
@@ -185,6 +201,14 @@ public sealed class JitCompilationConfig
     /// </remarks>
     public void ApplyToTensorCodec()
     {
+        // Validate at the boundary — we're about to install these values into
+        // thread-static codec options where a bad value (negative
+        // DataflowFusionMaxHidden, out-of-range SpectralErrorTolerance) would
+        // silently corrupt compilation paths instead of failing fast. Running
+        // Validate() on every Apply is cheap (simple range checks) and catches
+        // deserialized or mutated config before any plan is compiled against it.
+        Validate();
+
         var opts = new AiDotNet.Tensors.Engines.Optimization.TensorCodecOptions
         {
             EnableCompilation = Enabled,

--- a/src/Configuration/JitCompilationConfig.cs
+++ b/src/Configuration/JitCompilationConfig.cs
@@ -1,0 +1,206 @@
+namespace AiDotNet.Configuration;
+
+/// <summary>
+/// Configuration for JIT (Just-In-Time) compilation of model forward/backward passes.
+/// </summary>
+/// <remarks>
+/// <para>
+/// JIT compilation traces the model's computation graph on the first call and
+/// replays the compiled plan on subsequent calls, eliminating virtual dispatch,
+/// per-op allocation, and bounds-checking overhead. Typical speedup is 1.5-3x on
+/// CPU and up to 10x on GPU for small batches where dispatch dominates.
+/// </para>
+/// <para>
+/// Under the hood this binds to the <c>TensorCodecOptions</c> in the Tensors
+/// package. The builder writes the options into the thread-local codec config
+/// before the built model sees any work; <see cref="NeuralNetworks.NeuralNetworkBase{T}.Predict"/>
+/// and the tape-based training path then route through their compiled variants
+/// via <c>CompiledModelCache</c>.
+/// </para>
+/// <para><b>For Beginners:</b> JIT compilation is like building a shortcut for your
+/// model. The first time you call <c>Predict</c> the library watches which math
+/// operations happen in what order, compiles that pattern into a flat fast
+/// pipeline, and from then on just replays the pipeline. Your model doesn't
+/// change — only the plumbing around it gets faster.</para>
+/// <para>
+/// When to enable:
+/// <list type="bullet">
+/// <item>Production inference where Predict is called many times at the same shape.</item>
+/// <item>Training loops where the forward+backward is invoked each iteration.</item>
+/// <item>Diffusion/autoregressive generation where a sub-network runs tens of times per call.</item>
+/// </list>
+/// </para>
+/// <para>
+/// When to disable / when to keep <see cref="ThrowOnFailure"/> off:
+/// <list type="bullet">
+/// <item>Debugging a model whose forward path has non-Engine tensor accesses
+/// (direct span writes, scalar control flow) — those bake at trace time and will
+/// replay stale data. The default fallback to eager execution hides this.</item>
+/// <item>Tiny models where the compile cost isn't amortized (rare — overhead is
+/// one traced forward).</item>
+/// </list>
+/// </para>
+/// <para>
+/// Example YAML (binds through <c>YamlConfigApplier</c>):
+/// <code>
+/// jitCompilation:
+///   enabled: true
+///   throwOnFailure: false
+///   enableDataflowFusion: true
+///   enableAttentionFusion: true
+/// </code>
+/// </para>
+/// <para>
+/// Example code:
+/// <code>
+/// var result = await new AiModelBuilder&lt;float, Tensor&lt;float&gt;, Tensor&lt;float&gt;&gt;()
+///     .ConfigureModel(myModel)
+///     .ConfigureJitCompilation()            // enable with library defaults
+///     .BuildAsync();
+/// </code>
+/// </para>
+/// </remarks>
+public sealed class JitCompilationConfig
+{
+    /// <summary>Default config — compilation enabled, failures fall back silently to eager.</summary>
+    public static JitCompilationConfig Default => new()
+    {
+        Enabled = true,
+        ThrowOnFailure = false
+    };
+
+    /// <summary>Aggressive config — all fusion and constant-folding passes on. Good for benchmarking.</summary>
+    public static JitCompilationConfig Aggressive => new()
+    {
+        Enabled = true,
+        ThrowOnFailure = false,
+        EnableDataflowFusion = true,
+        EnableAlgebraicBackward = true,
+        EnableConvBnFusion = true,
+        EnableAttentionFusion = true,
+        EnablePointwiseFusion = true,
+        EnableConstantFolding = true,
+        EnableForwardCSE = true,
+        EnableBlasBatch = true
+    };
+
+    /// <summary>Explicitly disabled — compiled paths short-circuit to eager. Useful for A/B diffs.</summary>
+    public static JitCompilationConfig Disabled => new()
+    {
+        Enabled = false
+    };
+
+    /// <summary>
+    /// Master switch. When <c>false</c>, all compilation paths disable themselves and
+    /// execution falls through to the eager path (<c>TensorCodecOptions.EnableCompilation = false</c>).
+    /// </summary>
+    public bool Enabled { get; set; } = true;
+
+    /// <summary>
+    /// When <c>true</c>, a compilation failure propagates as an exception instead of
+    /// silently falling back to the eager path. Use in tests to catch regressions;
+    /// leave <c>false</c> in production so a misbehaving op doesn't take down inference.
+    /// </summary>
+    public bool ThrowOnFailure { get; set; }
+
+    /// <summary>
+    /// Phase B: Fuse consecutive linear layers into a single multi-layer kernel
+    /// that keeps data in registers / L1 across layer boundaries.
+    /// </summary>
+    public bool EnableDataflowFusion { get; set; } = true;
+
+    /// <summary>
+    /// Phase C: Symbolically simplify the backward graph at compile time
+    /// (CSE, double-transpose elimination, associative regrouping).
+    /// </summary>
+    public bool EnableAlgebraicBackward { get; set; } = true;
+
+    /// <summary>
+    /// Phase A: SVD-factorize frozen weight matrices for faster inference.
+    /// Opt-in because it introduces bounded approximation error.
+    /// </summary>
+    public bool EnableSpectralDecomposition { get; set; }
+
+    /// <summary>
+    /// Maximum approximation error per element for spectral decomposition
+    /// (used as <c>energyThreshold = 1.0 - tolerance</c> for SVD rank selection).
+    /// </summary>
+    public float SpectralErrorTolerance { get; set; } = 1e-5f;
+
+    /// <summary>Maximum hidden dimension for dataflow fusion L1 residency.</summary>
+    public int DataflowFusionMaxHidden { get; set; } = 512;
+
+    /// <summary>Phase 4.1: Fold BatchNorm into Conv2D weights at compile time.</summary>
+    public bool EnableConvBnFusion { get; set; } = true;
+
+    /// <summary>Phase 4.2: Fuse attention Q@K^T → Softmax → V patterns.</summary>
+    public bool EnableAttentionFusion { get; set; } = true;
+
+    /// <summary>Phase 4.3: Merge consecutive pointwise ops into fewer dispatch steps.</summary>
+    public bool EnablePointwiseFusion { get; set; } = true;
+
+    /// <summary>Phase 4.5: Precompute static subgraphs at compile time.</summary>
+    public bool EnableConstantFolding { get; set; } = true;
+
+    /// <summary>Phase 6.2: Deduplicate identical computations across layers.</summary>
+    public bool EnableForwardCSE { get; set; } = true;
+
+    /// <summary>Phase 7.1: Group independent MatMuls into batched calls.</summary>
+    public bool EnableBlasBatch { get; set; } = true;
+
+    /// <summary>
+    /// Phase 7.3: Mixed precision (fp16 forward, fp32 backward). Opt-in because it
+    /// can introduce small numerical drift vs pure fp32.
+    /// </summary>
+    public bool EnableMixedPrecisionCompilation { get; set; }
+
+    /// <summary>
+    /// Validates the config and throws if settings are inconsistent.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">Thrown when values are out of range.</exception>
+    public void Validate()
+    {
+        if (SpectralErrorTolerance < 0f || SpectralErrorTolerance >= 1f)
+        {
+            throw new InvalidOperationException(
+                $"SpectralErrorTolerance must be in [0, 1). Got: {SpectralErrorTolerance}");
+        }
+
+        if (DataflowFusionMaxHidden <= 0)
+        {
+            throw new InvalidOperationException(
+                $"DataflowFusionMaxHidden must be positive. Got: {DataflowFusionMaxHidden}");
+        }
+    }
+
+    /// <summary>
+    /// Projects this config onto the Tensors-package <c>TensorCodecOptions</c> and
+    /// installs it as the current thread-local config.
+    /// </summary>
+    /// <remarks>
+    /// Called by <see cref="AiModelBuilder{T, TInput, TOutput}"/>.Build() so that
+    /// every compiled path the built model touches (<c>CompiledModelCache</c>,
+    /// <c>AutoTracer</c>, <c>CompiledTapeTrainingStep</c>) reads the flags
+    /// configured here.
+    /// </remarks>
+    public void ApplyToTensorCodec()
+    {
+        var opts = new AiDotNet.Tensors.Engines.Optimization.TensorCodecOptions
+        {
+            EnableCompilation = Enabled,
+            EnableDataflowFusion = EnableDataflowFusion,
+            EnableAlgebraicBackward = EnableAlgebraicBackward,
+            EnableSpectralDecomposition = EnableSpectralDecomposition,
+            SpectralErrorTolerance = SpectralErrorTolerance,
+            DataflowFusionMaxHidden = DataflowFusionMaxHidden,
+            EnableConvBnFusion = EnableConvBnFusion,
+            EnableAttentionFusion = EnableAttentionFusion,
+            EnablePointwiseFusion = EnablePointwiseFusion,
+            EnableConstantFolding = EnableConstantFolding,
+            EnableForwardCSE = EnableForwardCSE,
+            EnableBlasBatch = EnableBlasBatch,
+            EnableMixedPrecision = EnableMixedPrecisionCompilation
+        };
+        AiDotNet.Tensors.Engines.Optimization.TensorCodecOptions.SetCurrent(opts);
+    }
+}

--- a/src/Configuration/YamlConfigApplier.cs
+++ b/src/Configuration/YamlConfigApplier.cs
@@ -134,6 +134,11 @@ internal static partial class YamlConfigApplier<T, TInput, TOutput>
             builder.ConfigureInferenceOptimizations(config.InferenceOptimizations);
         }
 
+        if (config.JitCompilation is not null)
+        {
+            builder.ConfigureJitCompilation(config.JitCompilation);
+        }
+
         if (config.Interpretability is not null)
         {
             builder.ConfigureInterpretability(config.Interpretability);

--- a/src/Configuration/YamlModelConfig.cs
+++ b/src/Configuration/YamlModelConfig.cs
@@ -102,6 +102,13 @@ public partial class YamlModelConfig
     public InferenceOptimizationConfig? InferenceOptimizations { get; set; }
 
     /// <summary>
+    /// JIT compilation configuration — toggles
+    /// <c>TensorCodecOptions.EnableCompilation</c> plus fusion/CSE phase flags
+    /// on the returned model. Keyed as <c>jitCompilation</c> in YAML.
+    /// </summary>
+    public JitCompilationConfig? JitCompilation { get; set; }
+
+    /// <summary>
     /// Interpretability configuration for model explainability (SHAP, LIME, etc.).
     /// </summary>
     public InterpretabilityOptions? Interpretability { get; set; }

--- a/src/Interfaces/IAiModelBuilder.cs
+++ b/src/Interfaces/IAiModelBuilder.cs
@@ -1350,7 +1350,7 @@ public interface IAiModelBuilder<T, TInput, TOutput>
     /// Enables JIT (Just-In-Time) compilation for the built model's forward-pass
     /// replay by installing the configured
     /// <see cref="AiDotNet.Configuration.JitCompilationConfig"/> into
-    /// <c>TensorCodecOptions</c> during <c>Build()</c>.
+    /// <c>TensorCodecOptions</c> during <c>BuildAsync()</c>.
     /// </summary>
     /// <param name="config">JIT config. <c>null</c> → library defaults (enabled + silent fallback).</param>
     /// <returns>This builder for fluent chaining.</returns>

--- a/src/Interfaces/IAiModelBuilder.cs
+++ b/src/Interfaces/IAiModelBuilder.cs
@@ -1347,8 +1347,8 @@ public interface IAiModelBuilder<T, TInput, TOutput>
     IAiModelBuilder<T, TInput, TOutput> ConfigureInferenceOptimizations(AiDotNet.Configuration.InferenceOptimizationConfig? config = null);
 
     /// <summary>
-    /// Enables JIT (Just-In-Time) compilation for the built model's forward and
-    /// backward passes by installing the configured
+    /// Enables JIT (Just-In-Time) compilation for the built model's forward-pass
+    /// replay by installing the configured
     /// <see cref="AiDotNet.Configuration.JitCompilationConfig"/> into
     /// <c>TensorCodecOptions</c> during <c>Build()</c>.
     /// </summary>

--- a/src/Interfaces/IAiModelBuilder.cs
+++ b/src/Interfaces/IAiModelBuilder.cs
@@ -1347,6 +1347,35 @@ public interface IAiModelBuilder<T, TInput, TOutput>
     IAiModelBuilder<T, TInput, TOutput> ConfigureInferenceOptimizations(AiDotNet.Configuration.InferenceOptimizationConfig? config = null);
 
     /// <summary>
+    /// Enables JIT (Just-In-Time) compilation for the built model's forward and
+    /// backward passes by installing the configured
+    /// <see cref="AiDotNet.Configuration.JitCompilationConfig"/> into
+    /// <c>TensorCodecOptions</c> during <c>Build()</c>.
+    /// </summary>
+    /// <param name="config">JIT config. <c>null</c> → library defaults (enabled + silent fallback).</param>
+    /// <returns>This builder for fluent chaining.</returns>
+    /// <remarks>
+    /// <para>
+    /// JIT compilation traces the model's graph on the first call at each input
+    /// shape and replays the compiled plan on subsequent calls — typical speedup
+    /// is 1.5-3× on CPU. The configured flags are persisted onto the returned
+    /// <c>AiModelResult</c> and re-applied on every Predict call so cross-thread
+    /// usage (request pools) sees the same compilation behavior.
+    /// </para>
+    /// <para>
+    /// Example:
+    /// <code>
+    /// await new AiModelBuilder&lt;float, Tensor&lt;float&gt;, Tensor&lt;float&gt;&gt;()
+    ///     .ConfigureModel(model)
+    ///     .ConfigureJitCompilation()
+    ///     .BuildAsync();
+    /// </code>
+    /// </para>
+    /// </remarks>
+    IAiModelBuilder<T, TInput, TOutput> ConfigureJitCompilation(
+        AiDotNet.Configuration.JitCompilationConfig? config = null);
+
+    /// <summary>
     /// Configures mixed-precision training for faster neural network training with reduced memory usage.
     /// </summary>
     /// <param name="config">Mixed precision configuration (optional, uses defaults if null).</param>

--- a/src/Models/Options/AiModelResultOptions.cs
+++ b/src/Models/Options/AiModelResultOptions.cs
@@ -593,6 +593,22 @@ public class AiModelResultOptions<T, TInput, TOutput> : ModelOptions
     /// </remarks>
     public InferenceOptimizationConfig? InferenceOptimizationConfig { get; set; }
 
+    /// <summary>
+    /// Gets or sets the JIT compilation configuration applied on every
+    /// Predict/Train call made through the result.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// When set, the result pushes these flags onto <c>TensorCodecOptions.Current</c>
+    /// at the top of each Predict/Train so subsequent cross-thread calls (e.g., from
+    /// a request handler pool) see the same compilation behavior the builder was
+    /// configured with. <c>TensorCodecOptions.Current</c> is <c>[ThreadStatic]</c>,
+    /// so without this bridge a call on a fresh worker thread would execute against
+    /// the Tensors-package defaults instead of the builder's configured flags.
+    /// </para>
+    /// </remarks>
+    public AiDotNet.Configuration.JitCompilationConfig? JitCompilationConfig { get; set; }
+
     // ============================================================================
     // Augmentation Properties
     // ============================================================================

--- a/src/Models/Options/AiModelResultOptions.cs
+++ b/src/Models/Options/AiModelResultOptions.cs
@@ -599,6 +599,12 @@ public class AiModelResultOptions<T, TInput, TOutput> : ModelOptions
     /// <c>AiModelResult</c> always throws — the result is a frozen snapshot —
     /// so JIT config is only re-asserted on inference entrypoints.)
     /// </summary>
+    /// <value>
+    /// The <see cref="AiDotNet.Configuration.JitCompilationConfig"/> instance
+    /// the builder produced via <c>ConfigureJitCompilation</c>, or <c>null</c>
+    /// if the user never opted in (in which case <c>Predict</c> installs the
+    /// library's default <c>TensorCodecOptions</c> on the calling thread).
+    /// </value>
     /// <remarks>
     /// <para>
     /// When set, the result pushes these flags onto <c>TensorCodecOptions.Current</c>
@@ -608,6 +614,12 @@ public class AiModelResultOptions<T, TInput, TOutput> : ModelOptions
     /// <c>[ThreadStatic]</c>, so without this bridge a Predict on a fresh
     /// worker thread would execute against whatever a previous unrelated caller
     /// left on the thread instead of the builder's configured flags.
+    /// </para>
+    /// <para>
+    /// <b>For Beginners:</b> JIT compilation is turned on or off via the
+    /// builder's <c>ConfigureJitCompilation</c>. This property carries that
+    /// choice with the trained model so predictions on any thread behave the
+    /// same way.
     /// </para>
     /// </remarks>
     public AiDotNet.Configuration.JitCompilationConfig? JitCompilationConfig { get; set; }

--- a/src/Models/Options/AiModelResultOptions.cs
+++ b/src/Models/Options/AiModelResultOptions.cs
@@ -595,16 +595,19 @@ public class AiModelResultOptions<T, TInput, TOutput> : ModelOptions
 
     /// <summary>
     /// Gets or sets the JIT compilation configuration applied on every
-    /// Predict/Train call made through the result.
+    /// <c>Predict</c> call made through the result. (<c>Train</c> on
+    /// <c>AiModelResult</c> always throws — the result is a frozen snapshot —
+    /// so JIT config is only re-asserted on inference entrypoints.)
     /// </summary>
     /// <remarks>
     /// <para>
     /// When set, the result pushes these flags onto <c>TensorCodecOptions.Current</c>
-    /// at the top of each Predict/Train so subsequent cross-thread calls (e.g., from
-    /// a request handler pool) see the same compilation behavior the builder was
-    /// configured with. <c>TensorCodecOptions.Current</c> is <c>[ThreadStatic]</c>,
-    /// so without this bridge a call on a fresh worker thread would execute against
-    /// the Tensors-package defaults instead of the builder's configured flags.
+    /// at the top of each <c>Predict</c> so cross-thread inference calls (e.g.,
+    /// from a request handler pool) see the same compilation behavior the
+    /// builder was configured with. <c>TensorCodecOptions.Current</c> is
+    /// <c>[ThreadStatic]</c>, so without this bridge a Predict on a fresh
+    /// worker thread would execute against whatever a previous unrelated caller
+    /// left on the thread instead of the builder's configured flags.
     /// </para>
     /// </remarks>
     public AiDotNet.Configuration.JitCompilationConfig? JitCompilationConfig { get; set; }

--- a/src/Models/Results/AiModelResult.cs
+++ b/src/Models/Results/AiModelResult.cs
@@ -641,6 +641,15 @@ public partial class AiModelResult<T, TInput, TOutput> : IFullModel<T, TInput, T
     [JsonProperty]
     private AiDotNet.Configuration.InferenceOptimizationConfig? InferenceOptimizationConfig { get; set; }
 
+    /// <summary>
+    /// JIT compilation config carried from the builder. Applied on every
+    /// Predict/Train call so cross-thread invocations (e.g., from a request
+    /// handler pool) see the same compilation behavior the builder was
+    /// configured with. <c>TensorCodecOptions.Current</c> is thread-static.
+    /// </summary>
+    [JsonProperty]
+    private AiDotNet.Configuration.JitCompilationConfig? JitCompilationConfig { get; set; }
+
     [JsonIgnore]
     private readonly object _inferenceOptimizationLock = new();
 
@@ -1269,6 +1278,7 @@ public partial class AiModelResult<T, TInput, TOutput> : IFullModel<T, TInput, T
         DeploymentConfiguration = options.DeploymentConfiguration;
         JitCompiledFunction = options.JitCompiledFunction;
         InferenceOptimizationConfig = options.InferenceOptimizationConfig;
+        JitCompilationConfig = options.JitCompilationConfig;
         QuantizationInfo = options.QuantizationInfo;
 
         // Layer metadata (populated if the model supports layer-level access)
@@ -1811,6 +1821,12 @@ public partial class AiModelResult<T, TInput, TOutput> : IFullModel<T, TInput, T
         {
             throw new InvalidOperationException("Model is not initialized.");
         }
+
+        // Bridge the builder-configured JIT compilation flags into the current
+        // thread's TensorCodecOptions so CompiledModelCache / AutoTracer pick them
+        // up. TensorCodecOptions.Current is [ThreadStatic] — without this push, a
+        // Predict on a fresh worker thread would see library defaults instead.
+        JitCompilationConfig?.ApplyToTensorCodec();
 
         var dataForPrediction = newData;
         if (SafetyFilter != null && newData is Vector<T> vectorInput && typeof(TInput) == typeof(Vector<T>))

--- a/src/Models/Results/AiModelResult.cs
+++ b/src/Models/Results/AiModelResult.cs
@@ -643,9 +643,13 @@ public partial class AiModelResult<T, TInput, TOutput> : IFullModel<T, TInput, T
 
     /// <summary>
     /// JIT compilation config carried from the builder. Applied on every
-    /// Predict/Train call so cross-thread invocations (e.g., from a request
-    /// handler pool) see the same compilation behavior the builder was
-    /// configured with. <c>TensorCodecOptions.Current</c> is thread-static.
+    /// <see cref="Predict"/> call so cross-thread inference invocations (e.g.,
+    /// from a request handler pool) see the same compilation behavior the
+    /// builder was configured with. <c>Train</c> on <c>AiModelResult</c> always
+    /// throws (the result is a snapshot), so there's no Train entrypoint to
+    /// bridge. <c>TensorCodecOptions.Current</c> is <c>[ThreadStatic]</c> —
+    /// without this bridge a fresh worker thread inherits whatever a prior
+    /// caller left on it.
     /// </summary>
     [JsonProperty]
     private AiDotNet.Configuration.JitCompilationConfig? JitCompilationConfig { get; set; }
@@ -1825,8 +1829,19 @@ public partial class AiModelResult<T, TInput, TOutput> : IFullModel<T, TInput, T
         // Bridge the builder-configured JIT compilation flags into the current
         // thread's TensorCodecOptions so CompiledModelCache / AutoTracer pick them
         // up. TensorCodecOptions.Current is [ThreadStatic] — without this push, a
-        // Predict on a fresh worker thread would see library defaults instead.
-        JitCompilationConfig?.ApplyToTensorCodec();
+        // Predict on a fresh worker thread would see whatever a previous caller
+        // left behind. When the result has no explicit JIT config, install the
+        // library default to give a known-good baseline rather than silently
+        // inheriting stale codec options from a prior unrelated configuration.
+        if (JitCompilationConfig is { } jit)
+        {
+            jit.ApplyToTensorCodec();
+        }
+        else
+        {
+            AiDotNet.Tensors.Engines.Optimization.TensorCodecOptions.SetCurrent(
+                AiDotNet.Tensors.Engines.Optimization.TensorCodecOptions.Default);
+        }
 
         var dataForPrediction = newData;
         if (SafetyFilter != null && newData is Vector<T> vectorInput && typeof(TInput) == typeof(Vector<T>))
@@ -2902,6 +2917,11 @@ public partial class AiModelResult<T, TInput, TOutput> : IFullModel<T, TInput, T
             DeploymentConfiguration = DeploymentConfiguration,
             // JIT compilation is parameter-specific, don't copy
             InferenceOptimizationConfig = InferenceOptimizationConfig,
+            // Propagate builder-time JIT config through clone paths so the copy
+            // re-applies the same TensorCodecOptions on its own Predict calls
+            // — without this the original keeps JIT but the clone falls back to
+            // library defaults silently.
+            JitCompilationConfig = JitCompilationConfig,
             ReasoningConfig = ReasoningConfig,
             KnowledgeGraph = KnowledgeGraph,
             GraphStore = GraphStore,
@@ -4639,6 +4659,11 @@ public partial class AiModelResult<T, TInput, TOutput> : IFullModel<T, TInput, T
             DeploymentConfiguration = DeploymentConfiguration,
             // JIT compilation is model-specific, don't copy
             InferenceOptimizationConfig = InferenceOptimizationConfig,
+            // Propagate builder-time JIT config through clone paths so the copy
+            // re-applies the same TensorCodecOptions on its own Predict calls
+            // — without this the original keeps JIT but the clone falls back to
+            // library defaults silently.
+            JitCompilationConfig = JitCompilationConfig,
             ReasoningConfig = ReasoningConfig,
             KnowledgeGraph = KnowledgeGraph,
             GraphStore = GraphStore,
@@ -4828,6 +4853,11 @@ public partial class AiModelResult<T, TInput, TOutput> : IFullModel<T, TInput, T
                 BiasDetector = deserializedObject.BiasDetector;
                 FairnessEvaluator = deserializedObject.FairnessEvaluator;
                 InferenceOptimizationConfig = deserializedObject.InferenceOptimizationConfig;
+                // Restore JIT config so a saved-and-reloaded result keeps re-applying
+                // its builder-time JIT flags on every Predict — without this assignment
+                // the [JsonProperty] field is populated on `deserializedObject` but
+                // never copied onto `this`, and post-load behavior silently diverges.
+                JitCompilationConfig = deserializedObject.JitCompilationConfig;
                 SerializedModelData = deserializedObject.SerializedModelData;
 
                 // Model is intentionally facade-hidden and is not serialized directly.

--- a/src/NeuralNetworks/NeuralNetworkBase.cs
+++ b/src/NeuralNetworks/NeuralNetworkBase.cs
@@ -2139,8 +2139,15 @@ public abstract class NeuralNetworkBase<T> : INeuralNetworkModel<T>, IInterpreta
                 () => PredictEager(input)); // Use same path as eager for consistency
             return plan.Execute();
         }
-        catch
+        catch (Exception ex)
         {
+            // Emit a Trace warning so the JIT regression is observable in production
+            // telemetry — silent fallback would let perf surveys be the first signal.
+            // Then run eager so the call still succeeds. The cache didn't store a
+            // plan for the failed shape, so the next call will retry compilation.
+            System.Diagnostics.Trace.TraceWarning(
+                $"PredictCompiled fallback for {GetType().FullName} " +
+                $"with input shape [{string.Join(", ", input.Shape)}]: {ex.GetType().Name}: {ex.Message}");
             return PredictEager(input);
         }
     }

--- a/src/NeuralNetworks/NeuralNetworkBase.cs
+++ b/src/NeuralNetworks/NeuralNetworkBase.cs
@@ -2870,12 +2870,14 @@ public abstract class NeuralNetworkBase<T> : INeuralNetworkModel<T>, IInterpreta
         // rebuild cost every iteration — critical for large models like VideoCLIP.
         if (anyStructureChanged)
         {
-            _parameterBuffer = null;
-            _layerStructureVersion++;
-            // Invalidate the compiled inference cache — the layer graph changed
-            // (e.g., lazy init resized a weight tensor), so any plan traced
-            // before is now pointing at dead tensor references.
-            _compiledInferenceCache?.Invalidate();
+            // Reuse the full structural invalidation path so every cache that
+            // depends on layer structure (parameter count, parameter buffer,
+            // tape collector, layer-info, compiled inference plans, known-bad
+            // compile shapes) is reset together. Maintaining a partial path
+            // here would let _knownBadCompileShapes / _cachedParameterCount
+            // stay stale after a lazy-init resize and lock the model into
+            // permanently-eager Predict for shapes that previously failed.
+            InvalidateParameterCountCache();
         }
     }
 

--- a/src/NeuralNetworks/NeuralNetworkBase.cs
+++ b/src/NeuralNetworks/NeuralNetworkBase.cs
@@ -2122,6 +2122,15 @@ public abstract class NeuralNetworkBase<T> : INeuralNetworkModel<T>, IInterpreta
     private AiDotNet.Tensors.Engines.Compilation.CompiledModelCache<T>? _compiledInferenceCache;
 
     /// <summary>
+    /// JIT strict-mode flag — when <c>true</c>, <see cref="PredictCompiled"/>
+    /// rethrows compile/replay exceptions instead of falling back to eager.
+    /// Set by <see cref="AiModelBuilder{T,TInput,TOutput}"/> when the user
+    /// configures <c>JitCompilationConfig.ThrowOnFailure = true</c>. Default
+    /// <c>false</c> for production safety (Trace warning logged on fallback).
+    /// </summary>
+    internal bool ThrowOnJitFailure { get; set; }
+
+    /// <summary>
     /// Executes the forward pass using a compiled plan for maximum performance.
     /// First call traces and compiles; subsequent calls replay the compiled plan.
     /// Falls back to eager execution if compilation fails.
@@ -2139,12 +2148,15 @@ public abstract class NeuralNetworkBase<T> : INeuralNetworkModel<T>, IInterpreta
                 () => PredictEager(input)); // Use same path as eager for consistency
             return plan.Execute();
         }
-        catch (Exception ex)
+        catch (Exception ex) when (!ThrowOnJitFailure)
         {
             // Emit a Trace warning so the JIT regression is observable in production
             // telemetry — silent fallback would let perf surveys be the first signal.
             // Then run eager so the call still succeeds. The cache didn't store a
             // plan for the failed shape, so the next call will retry compilation.
+            // Strict-mode (ThrowOnJitFailure=true, set by AiModelBuilder when the
+            // user configures JitCompilationConfig.ThrowOnFailure) skips this catch
+            // entirely so tests catch regressions instead of silently degrading.
             System.Diagnostics.Trace.TraceWarning(
                 $"PredictCompiled fallback for {GetType().FullName} " +
                 $"with input shape [{string.Join(", ", input.Shape)}]: {ex.GetType().Name}: {ex.Message}");

--- a/src/NeuralNetworks/NeuralNetworkBase.cs
+++ b/src/NeuralNetworks/NeuralNetworkBase.cs
@@ -1751,6 +1751,10 @@ public abstract class NeuralNetworkBase<T> : INeuralNetworkModel<T>, IInterpreta
         _parameterBuffer = null;
         Training.TapeTrainingStep<T>.InvalidateCache();
         InvalidateLayerInfoCache();
+        // Layer structure changed — any compiled inference plan captured from the
+        // prior layer graph is stale. Drop the cache so the next Predict call
+        // re-traces and recompiles against the new layer structure.
+        _compiledInferenceCache?.Invalidate();
     }
 
     /// <summary>
@@ -2070,11 +2074,28 @@ public abstract class NeuralNetworkBase<T> : INeuralNetworkModel<T>, IInterpreta
     /// <param name="input">The input data to process.</param>
     /// <returns>The network's prediction.</returns>
     /// <remarks>
-    /// <b>For Beginners:</b> This is the main method you'll use to get results from your trained neural network. 
-    /// You provide some input data (like an image or text), and the network processes it through all its 
+    /// <b>For Beginners:</b> This is the main method you'll use to get results from your trained neural network.
+    /// You provide some input data (like an image or text), and the network processes it through all its
     /// layers to produce an output (like a classification or prediction).
+    /// <para>
+    /// The default implementation routes through the compiled inference path
+    /// (<see cref="PredictCompiled"/>), which auto-compiles the forward pass on the first call and replays
+    /// the compiled plan on subsequent calls for near-zero overhead. On compilation failure it falls back
+    /// to eager execution via <see cref="PredictEager"/>. The call is wrapped in a <see cref="NoGradScope{T}"/>
+    /// so inference never records onto the gradient tape (matches PyTorch <c>torch.no_grad()</c> semantics).
+    /// </para>
+    /// <para>
+    /// Subclasses that need custom inference behavior (e.g., diffusion models that run a multi-step
+    /// denoising loop, GANs that sample from a generator, networks that produce structured outputs) should
+    /// override this method. Subclasses whose inference is just a flat forward pass through Layers should
+    /// leave the default in place to pick up compiled replay automatically.
+    /// </para>
     /// </remarks>
-    public abstract Tensor<T> Predict(Tensor<T> input);
+    public virtual Tensor<T> Predict(Tensor<T> input)
+    {
+        using var _ = new NoGradScope<T>();
+        return PredictCompiled(input);
+    }
 
     /// <summary>
     /// Runs the forward pass through all layers WITHOUT suppressing tape recording.
@@ -2801,6 +2822,10 @@ public abstract class NeuralNetworkBase<T> : INeuralNetworkModel<T>, IInterpreta
         {
             _parameterBuffer = null;
             _layerStructureVersion++;
+            // Invalidate the compiled inference cache — the layer graph changed
+            // (e.g., lazy init resized a weight tensor), so any plan traced
+            // before is now pointing at dead tensor references.
+            _compiledInferenceCache?.Invalidate();
         }
     }
 

--- a/src/NeuralNetworks/NeuralNetworkBase.cs
+++ b/src/NeuralNetworks/NeuralNetworkBase.cs
@@ -1753,8 +1753,11 @@ public abstract class NeuralNetworkBase<T> : INeuralNetworkModel<T>, IInterpreta
         InvalidateLayerInfoCache();
         // Layer structure changed — any compiled inference plan captured from the
         // prior layer graph is stale. Drop the cache so the next Predict call
-        // re-traces and recompiles against the new layer structure.
+        // re-traces and recompiles against the new layer structure. Also clear
+        // the bad-compile cache so shapes that previously failed get a fresh
+        // chance against the new graph.
         _compiledInferenceCache?.Invalidate();
+        _knownBadCompileShapes.Clear();
     }
 
     /// <summary>
@@ -2122,22 +2125,51 @@ public abstract class NeuralNetworkBase<T> : INeuralNetworkModel<T>, IInterpreta
     private AiDotNet.Tensors.Engines.Compilation.CompiledModelCache<T>? _compiledInferenceCache;
 
     /// <summary>
-    /// JIT strict-mode flag — when <c>true</c>, <see cref="PredictCompiled"/>
-    /// rethrows compile/replay exceptions instead of falling back to eager.
-    /// Set by <see cref="AiModelBuilder{T,TInput,TOutput}"/> when the user
-    /// configures <c>JitCompilationConfig.ThrowOnFailure = true</c>. Default
-    /// <c>false</c> for production safety (Trace warning logged on fallback).
+    /// Tracks input shapes whose compilation has previously failed on this
+    /// model instance. Once a shape is in this set, <see cref="PredictCompiled"/>
+    /// short-circuits to <see cref="PredictEager"/> without re-attempting
+    /// compilation — re-trying every Predict would re-burn the same trace cost
+    /// for no benefit and re-emit the same Trace warning on every call.
     /// </summary>
-    internal bool ThrowOnJitFailure { get; set; }
+    private readonly HashSet<long> _knownBadCompileShapes = new();
+
+    /// <summary>
+    /// Computes a deterministic 64-bit shape key (FNV-1a) for the bad-compile
+    /// cache. Using a numeric key keeps the set entries cheap to hash without
+    /// allocating a wrapper object per Predict call.
+    /// </summary>
+    private static long ComputeShapeKey(int[] shape)
+    {
+        long hash = unchecked((long)0xcbf29ce484222325L);
+        for (int i = 0; i < shape.Length; i++)
+        {
+            hash ^= shape[i];
+            hash *= unchecked((long)0x100000001b3L);
+        }
+        return hash;
+    }
 
     /// <summary>
     /// Executes the forward pass using a compiled plan for maximum performance.
     /// First call traces and compiles; subsequent calls replay the compiled plan.
-    /// Falls back to eager execution if compilation fails.
+    /// Falls back to eager execution if compilation fails. Shapes that have
+    /// already failed compilation are skipped on subsequent calls (no retry
+    /// loop) so a known-bad shape doesn't burn the trace cost on every Predict.
     /// </summary>
+    /// <remarks>
+    /// Strict-mode (rethrow on compile failure) is provided by the
+    /// <c>AiModelBuilder.BuildCompiledPredictFunction</c> wrapper which honors
+    /// <c>JitCompilationConfig.ThrowOnFailure</c>. This lower-level path always
+    /// falls back silently with a Trace warning so direct
+    /// (non-builder) callers don't get surprised by exceptions.
+    /// </remarks>
     protected Tensor<T> PredictCompiled(Tensor<T> input)
     {
         if (!AiDotNet.Tensors.Engines.Optimization.TensorCodecOptions.Current.EnableCompilation)
+            return PredictEager(input);
+
+        var shapeKey = ComputeShapeKey(input._shape);
+        if (_knownBadCompileShapes.Contains(shapeKey))
             return PredictEager(input);
 
         try
@@ -2148,15 +2180,14 @@ public abstract class NeuralNetworkBase<T> : INeuralNetworkModel<T>, IInterpreta
                 () => PredictEager(input)); // Use same path as eager for consistency
             return plan.Execute();
         }
-        catch (Exception ex) when (!ThrowOnJitFailure)
+        catch (Exception ex)
         {
-            // Emit a Trace warning so the JIT regression is observable in production
-            // telemetry — silent fallback would let perf surveys be the first signal.
-            // Then run eager so the call still succeeds. The cache didn't store a
-            // plan for the failed shape, so the next call will retry compilation.
-            // Strict-mode (ThrowOnJitFailure=true, set by AiModelBuilder when the
-            // user configures JitCompilationConfig.ThrowOnFailure) skips this catch
-            // entirely so tests catch regressions instead of silently degrading.
+            // Mark this shape as known-bad so the next Predict skips the retry
+            // entirely. Then Trace.TraceWarning so the JIT regression is
+            // observable in production telemetry — silent fallback would let
+            // perf surveys be the first signal. Finally run eager so the call
+            // succeeds.
+            _knownBadCompileShapes.Add(shapeKey);
             System.Diagnostics.Trace.TraceWarning(
                 $"PredictCompiled fallback for {GetType().FullName} " +
                 $"with input shape [{string.Join(", ", input.Shape)}]: {ex.GetType().Name}: {ex.Message}");

--- a/src/NeuralNetworks/NeuralNetworkBase.cs
+++ b/src/NeuralNetworks/NeuralNetworkBase.cs
@@ -2130,8 +2130,12 @@ public abstract class NeuralNetworkBase<T> : INeuralNetworkModel<T>, IInterpreta
     /// short-circuits to <see cref="PredictEager"/> without re-attempting
     /// compilation — re-trying every Predict would re-burn the same trace cost
     /// for no benefit and re-emit the same Trace warning on every call.
+    /// Uses <see cref="System.Collections.Concurrent.ConcurrentDictionary{TKey, TValue}"/>
+    /// (value type <see cref="byte"/> is unused) so concurrent Predict calls
+    /// on the same model instance (request-pool sharing) can safely add and
+    /// read without external synchronization.
     /// </summary>
-    private readonly HashSet<long> _knownBadCompileShapes = new();
+    private readonly System.Collections.Concurrent.ConcurrentDictionary<long, byte> _knownBadCompileShapes = new();
 
     /// <summary>
     /// Computes a deterministic 64-bit shape key (FNV-1a) for the bad-compile
@@ -2169,7 +2173,7 @@ public abstract class NeuralNetworkBase<T> : INeuralNetworkModel<T>, IInterpreta
             return PredictEager(input);
 
         var shapeKey = ComputeShapeKey(input._shape);
-        if (_knownBadCompileShapes.Contains(shapeKey))
+        if (_knownBadCompileShapes.ContainsKey(shapeKey))
             return PredictEager(input);
 
         try
@@ -2187,7 +2191,7 @@ public abstract class NeuralNetworkBase<T> : INeuralNetworkModel<T>, IInterpreta
             // observable in production telemetry — silent fallback would let
             // perf surveys be the first signal. Finally run eager so the call
             // succeeds.
-            _knownBadCompileShapes.Add(shapeKey);
+            _knownBadCompileShapes.TryAdd(shapeKey, 0);
             System.Diagnostics.Trace.TraceWarning(
                 $"PredictCompiled fallback for {GetType().FullName} " +
                 $"with input shape [{string.Join(", ", input.Shape)}]: {ex.GetType().Name}: {ex.Message}");
@@ -4400,8 +4404,21 @@ public abstract class NeuralNetworkBase<T> : INeuralNetworkModel<T>, IInterpreta
     /// <inheritdoc/>
     /// <remarks>
     /// <para>
-    /// Neural networks support JIT compilation for accelerated inference.
-    /// The computation graph represents the forward pass through all layers.
+    /// Default is <c>true</c> because the base class's <see cref="Predict"/> now
+    /// routes through <see cref="PredictCompiled"/>, which auto-compiles when
+    /// <c>TensorCodecOptions.EnableCompilation</c> is on AND the model's op
+    /// graph is traceable, falling back to eager otherwise. So every
+    /// <see cref="NeuralNetworkBase{T}"/> subclass is "JIT-capable" in the
+    /// effective sense: JIT is attempted, and failures degrade gracefully
+    /// to eager without the user noticing.
+    /// </para>
+    /// <para>
+    /// Subclasses whose forward path is known to be incompatible with graph
+    /// capture (non-Engine tensor access, scalar control flow that bakes at
+    /// trace time, layers whose outputs depend on mutable instance state)
+    /// should override this to return <c>false</c> — that signals "don't even
+    /// try" so tooling can short-circuit and users know to expect eager-only
+    /// performance.
     /// </para>
     /// <para><b>For Beginners:</b> JIT (Just-In-Time) compilation optimizes neural networks for faster predictions.
     ///
@@ -4415,12 +4432,9 @@ public abstract class NeuralNetworkBase<T> : INeuralNetworkModel<T>, IInterpreta
     /// - Production deployment (real-time predictions)
     /// - Batch inference (processing many examples)
     /// - Edge devices (mobile, embedded systems)
-    ///
-    /// Note: Not all layer types support JIT compilation yet. The SupportsJitCompilation
-    /// property indicates whether this specific network configuration can be JIT compiled.
     /// </para>
     /// </remarks>
-    public virtual bool SupportsJitCompilation => false;
+    public virtual bool SupportsJitCompilation => true;
 
     /// <inheritdoc/>
     /// <remarks>


### PR DESCRIPTION
## Summary

Plugs the `AiDotNet.Tensors` compiled-plan infrastructure into `AiModelBuilder` so a single `.ConfigureJitCompilation()` call on the builder delivers auto-compiled forward-pass replay to every neural network. The Tensors package has shipped `CompiledModelCache`, `CompiledInferencePlan`, `CompiledTapeTrainingStep`, and the TensorCodec optimization pipeline (dataflow fusion / attention fusion / algebraic backward / CSE / BLAS batching) — but AiDotNet had no builder-level surface to configure it. The builder's YAML schema already documented a `jitCompilation` section but nothing populated the knob.

## Three commits

### 1. `NeuralNetworkBase.Predict` virtual default routes through `PredictCompiled`

`Predict` changes from `abstract` to `virtual` with a default that wraps `PredictCompiled(input)` in `NoGradScope<T>`. All 246 existing subclass overrides continue unchanged (their `override` still binds), so this is a non-breaking API evolution. Subclasses with trivial `Predict(x) => Forward(x)` bodies can drop their override to pick up compiled inference.

Cache invalidation plumbed into `InvalidateParameterCountCache` and `RestoreOriginalParameters` so a lazy-init resize or structure change drops any plan captured against the old layer graph.

### 2. `AiModelBuilder.ConfigureJitCompilation` + `JitCompilationConfig` + result persistence

- New `src/Configuration/JitCompilationConfig.cs` — POCO mirroring the `TensorCodecOptions` phase flags (EnableCompilation, EnableDataflowFusion, EnableAttentionFusion, EnableConstantFolding, EnableForwardCSE, EnableBlasBatch, etc.) plus a `ThrowOnFailure` strict-mode switch. Presets: `Default`, `Aggressive`, `Disabled`. `ApplyToTensorCodec()` projects onto and installs the Tensors-package options on the current thread.

- `AiModelBuilder.ConfigureJitCompilation(JitCompilationConfig?)` — follows the `ConfigureMixedPrecision` / `ConfigureReasoning` pattern. Config applied at the top of `BuildAsync` so every subsequent step (training, quantization calibration, cross-validation, RL rollouts) runs under the configured codec flags.

- Config persisted onto `AiModelResultOptions` and `AiModelResult`, and re-applied on every `Predict` call. `TensorCodecOptions.Current` is `[ThreadStatic]` — without this bridge, cross-thread inference (request pools, ASP.NET handlers) would see library defaults instead of the builder's flags.

- YAML wiring: added `JitCompilation` property on `YamlModelConfig` and `YamlConfigApplier` binding. The source generator's `existingSections` set already listed `"JitCompilation"` so the hand-written property takes precedence cleanly.

- `IAiModelBuilder` interface updated so every implementation gets the new method signature.

### 3. Populate `JitCompiledFunction` so JIT reaches `Predict`-override models

The previous two commits only set `TensorCodecOptions` flags. That's enough when a model uses the base `NeuralNetworkBase.Predict` default (from commit #1). It's NOT enough when a concrete model overrides `Predict` — and most do: VGG, CNN, FeedForwardNeuralNetwork, etc. return `Forward(input)` directly, bypassing `PredictCompiled`. Only AutoTracer (Layer 2, capped at 128 recorded ops) benefits them — too short for deep transformers.

This commit populates the `JitCompiledFunction` slot on `AiModelResult` at build time via a new `BuildCompiledPredictFunction` helper. The helper wraps the model's `Predict` in a `CompiledModelCache` regardless of how the concrete override is written. `AiModelResult.Predict` already checks `JitCompiledFunction` at line 1877 and routes to the compiled path when set.

Key implementation details:
- Gated on `_jitCompilationConfig.Enabled` and `model is NeuralNetworkBase<T>`. Diffusion models (DiffusionModelBase does not extend NeuralNetworkBase) and non-neural models (regression, trees) return `null` — JIT doesn't engage and the result's Predict stays on its existing path. _Diffusion coverage is tracked as a structural refactor in a follow-up PR._
- One `CompiledModelCache` per wrapper. `GetOrCompileInference(Tensor, Action)` traces on miss, rebinds input data on hit — no per-call allocation.
- **Nested-GraphMode defense**: during tracing, temporarily set `TensorCodecOptions.EnableCompilation = false` so any call into `NeuralNetworkBase.PredictCompiled` from within the model's own `Predict` falls through to `PredictEager` instead of opening a second, conflicting GraphMode scope. Without this guard the inner compile drops the outer trace's ops and replay produces wrong results.
- Applies JIT config to the current thread on every call.
- Try/catch with `ThrowOnFailure` behavior: by default, compilation failures fall back silently to eager. Setting `JitCompilationConfig.ThrowOnFailure = true` propagates them — use in tests.

## Known limitations (documented inline)

- **Diffusion models bypass**: `DiffusionModelBase` doesn't extend `NeuralNetworkBase`, so the wrapper returns `null` for diffusion. Closing this requires a structural change (`CompiledModelHost<T>` composition component) that's scoped as its own follow-up PR.
- **Silent wrong-results risk**: If a covered model has non-Engine tensor access (direct `AsSpan` writes, scalar control flow) in its forward, trace succeeds but replay reads stale data. Try/catch catches hard failures; silent divergence won't trigger. Users opting into JIT should flip `ThrowOnFailure = true` in tests and diff compiled vs eager outputs.

## Build verification

- `dotnet build src/AiDotNet.csproj --framework net10.0 -c Release`: 0 errors
- `dotnet build src/AiDotNet.csproj --framework net471 -c Release`: 0 errors

## Usage

```csharp
// Enable with defaults (silent fallback to eager on failure)
var result = await new AiModelBuilder<float, Tensor<float>, Tensor<float>>()
    .ConfigureModel(myModel)
    .ConfigureJitCompilation()
    .BuildAsync();

// Aggressive (all fusion/CSE passes on)
await builder.ConfigureJitCompilation(JitCompilationConfig.Aggressive).BuildAsync();

// Strict mode for tests
var cfg = JitCompilationConfig.Default;
cfg.ThrowOnFailure = true;
await builder.ConfigureJitCompilation(cfg).BuildAsync();
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable JIT compilation with a fluent builder option and three presets (Default, Aggressive, Disabled). Settings persist with built models, survive cloning/serialization, and can be loaded from YAML.

* **Bug Fixes / Improvements**
  * Safer JIT: per-shape failure short-circuiting, automatic fallbacks to eager execution, configurable failure behavior, and invalidation of compiled caches when model structure changes. JIT settings are reapplied per prediction for consistent behavior across threads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->