### PR TITLE
perf: fused fwd+bwd+optimizer as one compiled kernel in TrainWithTape

### DIFF
--- a/src/NeuralNetworks/NeuralNetworkBase.cs
+++ b/src/NeuralNetworks/NeuralNetworkBase.cs
@@ -2456,6 +2456,19 @@ public abstract class NeuralNetworkBase<T> : INeuralNetworkModel<T>, IInterpreta
     protected void TrainWithTape(Tensor<T> input, Tensor<T> expected,
         IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>>? optimizer = null)
     {
+        var resolvedOptimizer = optimizer ?? GetOrCreateBaseOptimizer();
+
+        // Fused-compiled fast path: forward + backward + parameter update all
+        // in one compiled kernel, SIMD-accelerated, zero materialized gradient
+        // tensors between backward and the optimizer step. Engages when the
+        // optimizer is a plain Adam/AdamW/SGD with constant hyperparameters
+        // AND the numeric type is float (Tensors-side fused optimizer kernels
+        // operate on float* directly). Returns false if any condition isn't
+        // met or tracing fails; we then fall through to the eager tape path
+        // below with behavior unchanged.
+        if (TryTrainWithFusedOptimizer(input, expected, resolvedOptimizer))
+            return;
+
         // Initialize parameter buffer — replaces layer tensors with buffer-backed views.
         // try/finally MUST cover this so views are restored even if setup throws.
         var initialParams = Training.TapeTrainingStep<T>.CollectParameters(Layers, _parameterBuffer is null ? -1 : _layerStructureVersion);
@@ -2549,6 +2562,151 @@ public abstract class NeuralNetworkBase<T> : INeuralNetworkModel<T>, IInterpreta
     {
         // Use the default optimizer (which respects configured LR) rather than creating a throwaway one
         TrainWithTape(input, expected, optimizer: null);
+    }
+
+    /// <summary>
+    /// Attempts the fused-compiled training path — forward + backward + fused
+    /// optimizer update all in one compiled kernel. Engages when conditions
+    /// permit, returns <c>false</c> to signal the caller to fall back to the
+    /// eager tape path otherwise.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Conditions for fused path:
+    /// <list type="bullet">
+    /// <item><c>TensorCodecOptions.Current.EnableCompilation</c> is true (user
+    /// opted into JIT via <see cref="AiModelBuilder{T,TInput,TOutput}.ConfigureJitCompilation"/>).</item>
+    /// <item><c>T</c> is <see cref="float"/> — the Tensors-side fused optimizer
+    /// operates on <c>float*</c> buffers directly.</item>
+    /// <item>The resolved optimizer is a plain <see cref="AdamOptimizer{T,TInput,TOutput}"/>,
+    /// <see cref="AdamWOptimizer{T,TInput,TOutput}"/>, or
+    /// <see cref="StochasticGradientDescentOptimizer{T,TInput,TOutput}"/> without
+    /// adaptive-rate machinery that would mutate hyperparameters between steps.
+    /// LR schedulers and adaptive rates fall back to the eager path — the fused
+    /// kernel bakes hyperparameters into the compiled plan and reconfiguring
+    /// them per step would reset Adam's moment buffers, destroying training.</item>
+    /// <item>At least one trainable layer participates in the graph (no-op models fall back).</item>
+    /// </list>
+    /// </para>
+    /// <para>
+    /// When all hold, <see cref="Training.CompiledTapeTrainingStep{T}.TryStepWithFusedOptimizer"/>
+    /// runs the compiled fwd+bwd+update kernel and updates <see cref="LastLoss"/>.
+    /// Behavior matches eager Adam/AdamW/SGD closely enough that training converges
+    /// identically on standard benchmarks (the fused kernels use the same formulas).
+    /// </para>
+    /// </remarks>
+    private bool TryTrainWithFusedOptimizer(
+        Tensor<T> input,
+        Tensor<T> expected,
+        IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>> resolvedOptimizer)
+    {
+        if (!AiDotNet.Tensors.Engines.Optimization.TensorCodecOptions.Current.EnableCompilation)
+            return false;
+        if (typeof(T) != typeof(float))
+            return false;
+
+        if (!TryMapToFusedOptimizerConfig(
+                resolvedOptimizer, out var fusedType, out float lr, out float b1, out float b2, out float eps, out float wd))
+            return false;
+
+        var trainableLayers = new List<ITrainableLayer<T>>();
+        foreach (var layer in Layers)
+            if (layer is ITrainableLayer<T> trainable)
+                trainableLayers.Add(trainable);
+        if (trainableLayers.Count == 0) return false;
+
+        var loss = LossFunction as LossFunctions.LossFunctionBase<T>;
+        if (loss is null) return false;
+
+        Tensor<T> AlignShape(Tensor<T> fwd, Tensor<T> tgt)
+        {
+            if (fwd.Rank > tgt.Rank && fwd.Shape[0] == 1 && fwd.Length == tgt.Length)
+                return Engine.Reshape(fwd, tgt._shape);
+            return fwd;
+        }
+
+        var ran = Training.CompiledTapeTrainingStep<T>.TryStepWithFusedOptimizer(
+            trainableLayers,
+            input,
+            expected,
+            forward: inp => AlignShape(ForwardForTraining(inp), expected),
+            computeLoss: (pred, tgt) => loss.ComputeTapeLoss(pred, tgt),
+            optimizerType: fusedType,
+            learningRate: lr,
+            beta1: b1,
+            beta2: b2,
+            epsilon: eps,
+            weightDecay: wd,
+            out T lossValue);
+
+        if (ran)
+            LastLoss = lossValue;
+        return ran;
+    }
+
+    /// <summary>
+    /// Inspects a pluggable optimizer and maps it onto the fixed set supported
+    /// by the Tensors-side fused kernel (<c>SGD</c>, <c>Adam</c>, <c>AdamW</c>).
+    /// Returns <c>false</c> for any optimizer type outside that set, for any
+    /// optimizer with a learning-rate scheduler attached, or for any
+    /// configuration that mutates hyperparameters between steps (adaptive rates).
+    /// </summary>
+    private static bool TryMapToFusedOptimizerConfig(
+        IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>> optimizer,
+        out AiDotNet.Tensors.Engines.Compilation.OptimizerType optimizerType,
+        out float learningRate,
+        out float beta1,
+        out float beta2,
+        out float epsilon,
+        out float weightDecay)
+    {
+        optimizerType = default;
+        learningRate = 0f;
+        beta1 = 0f;
+        beta2 = 0f;
+        epsilon = 0f;
+        weightDecay = 0f;
+
+        switch (optimizer)
+        {
+            case Optimizers.AdamOptimizer<T, Tensor<T>, Tensor<T>> adam:
+            {
+                if (adam.GetOptions() is not Models.Options.AdamOptimizerOptions<T, Tensor<T>, Tensor<T>> opts)
+                    return false;
+                if (opts.UseAdaptiveLearningRate) return false;
+                optimizerType = AiDotNet.Tensors.Engines.Compilation.OptimizerType.Adam;
+                learningRate = (float)adam.GetCurrentLearningRate();
+                beta1 = (float)opts.Beta1;
+                beta2 = (float)opts.Beta2;
+                epsilon = (float)opts.Epsilon;
+                weightDecay = 0f;
+                return true;
+            }
+            case Optimizers.AdamWOptimizer<T, Tensor<T>, Tensor<T>> adamW:
+            {
+                if (adamW.GetOptions() is not Models.Options.AdamWOptimizerOptions<T, Tensor<T>, Tensor<T>> opts)
+                    return false;
+                if (opts.UseAdaptiveLearningRate) return false;
+                optimizerType = AiDotNet.Tensors.Engines.Compilation.OptimizerType.AdamW;
+                learningRate = (float)adamW.GetCurrentLearningRate();
+                beta1 = (float)opts.Beta1;
+                beta2 = (float)opts.Beta2;
+                epsilon = (float)opts.Epsilon;
+                weightDecay = (float)opts.WeightDecay;
+                return true;
+            }
+            case Optimizers.StochasticGradientDescentOptimizer<T, Tensor<T>, Tensor<T>> sgd:
+            {
+                if (sgd.GetOptions() is not Models.Options.StochasticGradientDescentOptimizerOptions<T, Tensor<T>, Tensor<T>> opts)
+                    return false;
+                if (opts.UseAdaptiveLearningRate) return false;
+                optimizerType = AiDotNet.Tensors.Engines.Compilation.OptimizerType.SGD;
+                learningRate = (float)sgd.GetCurrentLearningRate();
+                return true;
+            }
+            default:
+                return false;
+        }
     }
 
     /// <summary>

--- a/src/NeuralNetworks/NeuralNetworkBase.cs
+++ b/src/NeuralNetworks/NeuralNetworkBase.cs
@@ -2570,6 +2570,17 @@ public abstract class NeuralNetworkBase<T> : INeuralNetworkModel<T>, IInterpreta
     }
 
     /// <summary>
+    /// Sticky disable for the fused training path on this model instance. Set
+    /// when <see cref="TryTrainWithFusedOptimizer"/> falls back so subsequent
+    /// steps stay on the eager path. Mixing fused (closure-captured m/v) and
+    /// eager (optimizer-instance state) updates within one training run would
+    /// reset Adam moments at the next successful fused step. Stickiness keeps
+    /// optimizer state consistent for the rest of the run. Cleared in
+    /// <see cref="ResetState"/> and <see cref="InvalidateParameterCountCache"/>.
+    /// </summary>
+    private bool _fusedTrainingDisabled;
+
+    /// <summary>
     /// Attempts the fused-compiled training path — forward + backward + fused
     /// optimizer update all in one compiled kernel. Engages when conditions
     /// permit, returns <c>false</c> to signal the caller to fall back to the
@@ -2600,16 +2611,6 @@ public abstract class NeuralNetworkBase<T> : INeuralNetworkModel<T>, IInterpreta
     /// identically on standard benchmarks (the fused kernels use the same formulas).
     /// </para>
     /// </remarks>
-    /// <summary>
-    /// Sticky disable for the fused training path on this model instance. Set
-    /// when <see cref="TryTrainWithFusedOptimizer"/> falls back so subsequent
-    /// steps stay on the eager path. Mixing fused (closure-captured m/v) and
-    /// eager (optimizer-instance state) updates within one training run would
-    /// reset Adam moments at the next successful fused step. Stickiness keeps
-    /// optimizer state consistent for the rest of the run.
-    /// </summary>
-    private bool _fusedTrainingDisabled;
-
     private bool TryTrainWithFusedOptimizer(
         Tensor<T> input,
         Tensor<T> expected,

--- a/src/NeuralNetworks/NeuralNetworkBase.cs
+++ b/src/NeuralNetworks/NeuralNetworkBase.cs
@@ -2636,29 +2636,34 @@ public abstract class NeuralNetworkBase<T> : INeuralNetworkModel<T>, IInterpreta
         var loss = LossFunction as LossFunctions.LossFunctionBase<T>;
         if (loss is null) return false;
 
-        // Mirror the eager path's bidirectional shape alignment — handle BOTH
-        // (a) forward output has extra leading batch dim vs target, AND
-        // (b) target has extra leading batch dim vs forward output.
-        // Fused path failures abandon optimizer state, so triggering one of
-        // these via missing-direction reshape would be costlier than the extra
-        // branch here.
-        Tensor<T> AlignShape(Tensor<T> fwd, Tensor<T> tgt)
-        {
-            if (fwd.Rank > tgt.Rank && fwd.Shape[0] == 1 && fwd.Length == tgt.Length)
-                return Engine.Reshape(fwd, tgt._shape);
-            // Note: when target has the extra dim we reshape the FORWARD output
-            // to match the target's shape so loss broadcast works either way.
-            if (tgt.Rank > fwd.Rank && tgt.Shape[0] == 1 && tgt.Length == fwd.Length)
-                return Engine.Reshape(fwd, tgt._shape);
-            return fwd;
-        }
-
+        // Mirror the eager path's bidirectional shape alignment exactly:
+        // (a) forward has extra leading dim → reshape FORWARD to target shape
+        // (b) target has extra leading dim → reshape TARGET to forward shape
+        // The eager path at TrainWithTape reshapes target down to forward's
+        // shape in branch (b); doing it the other way (reshape forward up to
+        // target's shape) makes the loss compute in a different space and
+        // produces different gradients. Apply the same direction-aware fix
+        // inside computeLoss where both tensors are in scope.
         var ran = Training.CompiledTapeTrainingStep<T>.TryStepWithFusedOptimizer(
             trainableLayers,
             input,
             expected,
-            forward: inp => AlignShape(ForwardForTraining(inp), expected),
-            computeLoss: (pred, tgt) => loss.ComputeTapeLoss(pred, tgt),
+            forward: inp =>
+            {
+                var fwd = ForwardForTraining(inp);
+                // Branch (a): fwd has extra leading batch dim.
+                if (fwd.Rank > expected.Rank && fwd.Shape[0] == 1 && fwd.Length == expected.Length)
+                    return Engine.Reshape(fwd, expected._shape);
+                return fwd;
+            },
+            computeLoss: (pred, tgt) =>
+            {
+                // Branch (b): target has extra leading batch dim → reshape TARGET
+                // (matches the eager path's direction at TrainWithTape:2509-2512).
+                if (tgt.Rank > pred.Rank && tgt.Shape[0] == 1 && tgt.Length == pred.Length)
+                    tgt = Engine.Reshape(tgt, pred._shape);
+                return loss.ComputeTapeLoss(pred, tgt);
+            },
             optimizerType: fusedType,
             learningRate: lr,
             beta1: b1,
@@ -3044,6 +3049,10 @@ public abstract class NeuralNetworkBase<T> : INeuralNetworkModel<T>, IInterpreta
         {
             layer.ResetState();
         }
+        // Give the fused-training path a fresh chance after ResetState — the
+        // user typically calls this between training runs, which is exactly
+        // when the sticky-disable from a prior fallback should be cleared.
+        _fusedTrainingDisabled = false;
     }
 
     /// <summary>

--- a/src/NeuralNetworks/NeuralNetworkBase.cs
+++ b/src/NeuralNetworks/NeuralNetworkBase.cs
@@ -1756,6 +1756,10 @@ public abstract class NeuralNetworkBase<T> : INeuralNetworkModel<T>, IInterpreta
         // training run gets a fresh chance at the fused path with the new graph.
         Training.CompiledTapeTrainingStep<T>.Invalidate();
         _fusedTrainingDisabled = false;
+        // Structure change invalidates the compiled plan and its embedded
+        // optimizer state, so the fused-commitment is also cleared — the
+        // next training session starts fresh with either path available.
+        _fusedTrainingCommitted = false;
     }
 
     /// <summary>
@@ -2571,14 +2575,30 @@ public abstract class NeuralNetworkBase<T> : INeuralNetworkModel<T>, IInterpreta
 
     /// <summary>
     /// Sticky disable for the fused training path on this model instance. Set
-    /// when <see cref="TryTrainWithFusedOptimizer"/> falls back so subsequent
-    /// steps stay on the eager path. Mixing fused (closure-captured m/v) and
-    /// eager (optimizer-instance state) updates within one training run would
-    /// reset Adam moments at the next successful fused step. Stickiness keeps
-    /// optimizer state consistent for the rest of the run. Cleared in
+    /// when <see cref="TryTrainWithFusedOptimizer"/> falls back BEFORE the
+    /// fused path has ever successfully run. Subsequent steps stay on the
+    /// eager path. Mixing fused (plan-embedded m/v) and eager (optimizer-
+    /// instance state) updates within one training run would reset Adam
+    /// moments at the next successful fused step. Stickiness keeps optimizer
+    /// state consistent for the rest of the run. Cleared in
     /// <see cref="ResetState"/> and <see cref="InvalidateParameterCountCache"/>.
     /// </summary>
     private bool _fusedTrainingDisabled;
+
+    /// <summary>
+    /// Tracks whether the fused compiled training path has EVER successfully
+    /// run on this model. Once true, Adam/AdamW/SGD moment buffers live
+    /// exclusively inside the compiled plan — falling back to eager would
+    /// silently lose that state (<c>resolvedOptimizer</c> has empty m/v).
+    /// So once committed, any condition that would force a fallback
+    /// (optimizer-config drift, input-shape change producing a new plan)
+    /// throws an explicit exception instead of silently diverging from the
+    /// reference Adam trajectory. Cleared in <see cref="ResetState"/> and
+    /// <see cref="InvalidateParameterCountCache"/> — both are explicit
+    /// reset points where the caller has acknowledged state changes and
+    /// both fused and eager optimizer states start fresh.
+    /// </summary>
+    private bool _fusedTrainingCommitted;
 
     /// <summary>
     /// Attempts the fused-compiled training path — forward + backward + fused
@@ -2676,6 +2696,37 @@ public abstract class NeuralNetworkBase<T> : INeuralNetworkModel<T>, IInterpreta
         if (ran)
         {
             LastLoss = lossValue;
+            // First successful fused step commits this model to the fused
+            // path for the rest of the training session — Adam m/v are now
+            // inside the compiled plan and transferring them to the eager
+            // optimizer isn't possible without API we don't have.
+            _fusedTrainingCommitted = true;
+        }
+        else if (_fusedTrainingCommitted)
+        {
+            // We've previously run fused successfully, so Adam/SGD moments
+            // live inside the compiled plan. Falling back to eager now would
+            // silently reset optimizer state and produce a trajectory that
+            // diverges from the previous fused steps. Surface the problem
+            // explicitly rather than corrupt training. Common causes:
+            //   - variable {input, target} shape produced a new compiled
+            //     plan (strict single-plan policy refused to configure it)
+            //   - mutated optimizer hyperparameters between steps
+            //     (attached LR scheduler, changed betas, etc.)
+            // Resolution: call ResetState() or InvalidateParameterCountCache()
+            // to fully reset training state, then retrain with stable
+            // shapes + fixed hyperparameters. Or disable compilation via
+            // AllowNondeterminism / Configure(JitCompilationConfig.Disabled)
+            // so training runs entirely on the eager path from the start.
+            throw new InvalidOperationException(
+                "Fused compiled training has already run successfully, but the current step cannot " +
+                "engage the fused path. The plan-embedded Adam/AdamW/SGD state cannot be transferred " +
+                "to the eager optimizer, so falling back silently would produce a trajectory that " +
+                "diverges from the previous fused steps. Common causes: variable input/target shape " +
+                "(new compiled plan), LR scheduler or adaptive-rate changes, attached AMSGrad. " +
+                "Resolution: keep shapes and optimizer hyperparameters stable across steps, OR call " +
+                "ResetState() / InvalidateParameterCountCache() to explicitly reset training state, " +
+                "OR disable compilation (AiModelBuilder.ConfigureJitCompilation(JitCompilationConfig.Disabled)).");
         }
         else
         {
@@ -3053,7 +3104,11 @@ public abstract class NeuralNetworkBase<T> : INeuralNetworkModel<T>, IInterpreta
         // Give the fused-training path a fresh chance after ResetState — the
         // user typically calls this between training runs, which is exactly
         // when the sticky-disable from a prior fallback should be cleared.
+        // Also clear the fused-commitment: ResetState is an explicit
+        // "start training over" signal, so any plan-embedded Adam/SGD state
+        // is no longer needed, and the next run can engage fused fresh.
         _fusedTrainingDisabled = false;
+        _fusedTrainingCommitted = false;
     }
 
     /// <summary>

--- a/src/NeuralNetworks/NeuralNetworkBase.cs
+++ b/src/NeuralNetworks/NeuralNetworkBase.cs
@@ -1751,6 +1751,11 @@ public abstract class NeuralNetworkBase<T> : INeuralNetworkModel<T>, IInterpreta
         _parameterBuffer = null;
         Training.TapeTrainingStep<T>.InvalidateCache();
         InvalidateLayerInfoCache();
+        // Layer graph mutated — drop any compiled fused training plans cached
+        // against the old structure. Also clear the sticky-disable so the next
+        // training run gets a fresh chance at the fused path with the new graph.
+        Training.CompiledTapeTrainingStep<T>.Invalidate();
+        _fusedTrainingDisabled = false;
     }
 
     /// <summary>
@@ -2595,11 +2600,22 @@ public abstract class NeuralNetworkBase<T> : INeuralNetworkModel<T>, IInterpreta
     /// identically on standard benchmarks (the fused kernels use the same formulas).
     /// </para>
     /// </remarks>
+    /// <summary>
+    /// Sticky disable for the fused training path on this model instance. Set
+    /// when <see cref="TryTrainWithFusedOptimizer"/> falls back so subsequent
+    /// steps stay on the eager path. Mixing fused (closure-captured m/v) and
+    /// eager (optimizer-instance state) updates within one training run would
+    /// reset Adam moments at the next successful fused step. Stickiness keeps
+    /// optimizer state consistent for the rest of the run.
+    /// </summary>
+    private bool _fusedTrainingDisabled;
+
     private bool TryTrainWithFusedOptimizer(
         Tensor<T> input,
         Tensor<T> expected,
         IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>> resolvedOptimizer)
     {
+        if (_fusedTrainingDisabled) return false;
         if (!AiDotNet.Tensors.Engines.Optimization.TensorCodecOptions.Current.EnableCompilation)
             return false;
         if (typeof(T) != typeof(float))
@@ -2609,18 +2625,30 @@ public abstract class NeuralNetworkBase<T> : INeuralNetworkModel<T>, IInterpreta
                 resolvedOptimizer, out var fusedType, out float lr, out float b1, out float b2, out float eps, out float wd))
             return false;
 
-        var trainableLayers = new List<ITrainableLayer<T>>();
-        foreach (var layer in Layers)
-            if (layer is ITrainableLayer<T> trainable)
-                trainableLayers.Add(trainable);
-        if (trainableLayers.Count == 0) return false;
+        // Use the existing recursive trainable-layer collector instead of the
+        // top-level-only scan — composite layers with trainable children (e.g.,
+        // residual blocks, transformer layers) expose those children via
+        // GetSubLayers() but aren't ITrainableLayer themselves. Without
+        // recursion the fused path silently stops updating part of the model.
+        var trainableLayers = Training.TapeTrainingStep<T>.CollectTrainableLayers(Layers, _layerStructureVersion);
+        if (trainableLayers.Length == 0) return false;
 
         var loss = LossFunction as LossFunctions.LossFunctionBase<T>;
         if (loss is null) return false;
 
+        // Mirror the eager path's bidirectional shape alignment — handle BOTH
+        // (a) forward output has extra leading batch dim vs target, AND
+        // (b) target has extra leading batch dim vs forward output.
+        // Fused path failures abandon optimizer state, so triggering one of
+        // these via missing-direction reshape would be costlier than the extra
+        // branch here.
         Tensor<T> AlignShape(Tensor<T> fwd, Tensor<T> tgt)
         {
             if (fwd.Rank > tgt.Rank && fwd.Shape[0] == 1 && fwd.Length == tgt.Length)
+                return Engine.Reshape(fwd, tgt._shape);
+            // Note: when target has the extra dim we reshape the FORWARD output
+            // to match the target's shape so loss broadcast works either way.
+            if (tgt.Rank > fwd.Rank && tgt.Shape[0] == 1 && tgt.Length == fwd.Length)
                 return Engine.Reshape(fwd, tgt._shape);
             return fwd;
         }
@@ -2640,16 +2668,26 @@ public abstract class NeuralNetworkBase<T> : INeuralNetworkModel<T>, IInterpreta
             out T lossValue);
 
         if (ran)
+        {
             LastLoss = lossValue;
+        }
+        else
+        {
+            // Sticky disable: subsequent training steps in this run stay on the
+            // eager path so we don't reset Adam moments by re-engaging fused
+            // mid-run. Cleared on next ResetState/InvalidateParameterCountCache.
+            _fusedTrainingDisabled = true;
+        }
         return ran;
     }
 
     /// <summary>
     /// Inspects a pluggable optimizer and maps it onto the fixed set supported
     /// by the Tensors-side fused kernel (<c>SGD</c>, <c>Adam</c>, <c>AdamW</c>).
-    /// Returns <c>false</c> for any optimizer type outside that set, for any
-    /// optimizer with a learning-rate scheduler attached, or for any
-    /// configuration that mutates hyperparameters between steps (adaptive rates).
+    /// Returns <c>false</c> when the optimizer is outside that set OR when
+    /// per-step hyperparameter mutation would defeat the fused plan's
+    /// configure-once contract: adaptive learning rates, attached LR schedulers,
+    /// or AMSGrad mode (which the fused kernel doesn't model).
     /// </summary>
     private static bool TryMapToFusedOptimizerConfig(
         IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>> optimizer,
@@ -2666,6 +2704,13 @@ public abstract class NeuralNetworkBase<T> : INeuralNetworkModel<T>, IInterpreta
         beta2 = 0f;
         epsilon = 0f;
         weightDecay = 0f;
+
+        // Reject when an LR scheduler is attached — GetCurrentLearningRate()
+        // would change between steps but the fused plan bakes the LR at first
+        // ConfigureOptimizer, so subsequent rate changes silently disappear.
+        if (optimizer is Optimizers.GradientBasedOptimizerBase<T, Tensor<T>, Tensor<T>> gradBase
+            && gradBase.LearningRateScheduler is not null)
+            return false;
 
         switch (optimizer)
         {
@@ -2687,6 +2732,10 @@ public abstract class NeuralNetworkBase<T> : INeuralNetworkModel<T>, IInterpreta
                 if (adamW.GetOptions() is not Models.Options.AdamWOptimizerOptions<T, Tensor<T>, Tensor<T>> opts)
                     return false;
                 if (opts.UseAdaptiveLearningRate) return false;
+                // Fused AdamW kernel does not implement AMSGrad's max-of-second-moment
+                // update rule. If the user enabled it, fall back to eager so the
+                // configured update rule isn't silently swapped for standard AdamW.
+                if (adamW.UseAMSGrad) return false;
                 optimizerType = AiDotNet.Tensors.Engines.Compilation.OptimizerType.AdamW;
                 learningRate = (float)adamW.GetCurrentLearningRate();
                 beta1 = (float)opts.Beta1;

--- a/src/Training/CompiledTapeTrainingStep.cs
+++ b/src/Training/CompiledTapeTrainingStep.cs
@@ -63,6 +63,22 @@ public static class CompiledTapeTrainingStep<T>
     private static (int OptType, float Lr, float B1, float B2, float Eps, float Wd)? _configuredOptimizerConfig;
 
     /// <summary>
+    /// Counter of successful fused-step executions on this thread. Exposed
+    /// via <see cref="GetFusedStepCount"/>/<see cref="ResetFusedStepCount"/>
+    /// so integration tests can assert that the fused compiled path
+    /// <i>actually engaged</i> rather than silently falling back to eager
+    /// (a test that only checks "finite loss" cannot distinguish the two).
+    /// </summary>
+    [ThreadStatic]
+    private static long _fusedStepCount;
+
+    /// <summary>Gets the count of successful fused-step executions on the calling thread.</summary>
+    public static long GetFusedStepCount() => _fusedStepCount;
+
+    /// <summary>Resets the fused-step counter on the calling thread to zero.</summary>
+    public static void ResetFusedStepCount() { _fusedStepCount = 0; }
+
+    /// <summary>
     /// Executes a single compiled training step.
     /// First call traces and compiles; subsequent calls replay the compiled plan.
     /// Falls back to eager execution if compilation fails.
@@ -151,6 +167,10 @@ public static class CompiledTapeTrainingStep<T>
         _cachedParameters = null;
         _configuredPlan = null;
         _configuredOptimizerConfig = null;
+        // Reset the fused-engagement counter — from this point on, any
+        // assertion about "fused ran at least N times" should reflect the
+        // new lifecycle.
+        _fusedStepCount = 0;
     }
 
     /// <summary>
@@ -304,17 +324,23 @@ public static class CompiledTapeTrainingStep<T>
             // Execute forward + backward + fused parameter update in one replay.
             var lossOutput = plan.Step();
             lossValue = lossOutput.Length > 0 ? lossOutput[0] : MathHelper.GetNumericOperations<T>().Zero;
+            // Signal successful fused engagement so tests/diagnostics can
+            // assert the compiled path actually ran — distinguishing it from
+            // a silent fallback to the eager path.
+            _fusedStepCount++;
             return true;
         }
         catch (Exception ex)
         {
             // Trace the failure so fused-path regressions are observable in
-            // production telemetry. Clear the per-plan config cache so any
-            // next attempt reconfigures fresh — we can't know which plan
-            // (if any) ended up in a partial state, so drop them all.
+            // production telemetry. Include ex.ToString() so stack trace +
+            // inner exceptions reach telemetry — without these, diagnosing
+            // a fused-path regression from logs requires reproducing the
+            // failure locally. Clear the single-slot config state so any
+            // next attempt reconfigures fresh.
             System.Diagnostics.Trace.TraceWarning(
                 $"CompiledTapeTrainingStep.TryStepWithFusedOptimizer failed, falling back to eager: " +
-                $"{ex.GetType().Name}: {ex.Message}");
+                $"{ex}");
             _configuredPlan = null;
             _configuredOptimizerConfig = null;
             return false;

--- a/src/Training/CompiledTapeTrainingStep.cs
+++ b/src/Training/CompiledTapeTrainingStep.cs
@@ -199,8 +199,22 @@ public static class CompiledTapeTrainingStep<T>
             foreach (var layer in layers)
                 layer.ZeroGrad();
 
+            // Compile key must include BOTH input AND target shapes. The traced
+            // lambda captures target shape via computeLoss — a plan compiled for
+            // input=[B,D], target=[B,C] would silently replay wrong ops if the
+            // next call arrives with input=[B,D], target=[1,B,C] (different
+            // reshape/loss graph). Concatenate input + separator + target into
+            // one synthetic shape key so distinct {input, target} pairs hit
+            // distinct cache entries.
+            var inputShape = input._shape;
+            var targetShape = target._shape;
+            var compositeKey = new int[inputShape.Length + 1 + targetShape.Length];
+            Array.Copy(inputShape, 0, compositeKey, 0, inputShape.Length);
+            compositeKey[inputShape.Length] = -1; // separator sentinel (no real dim is negative)
+            Array.Copy(targetShape, 0, compositeKey, inputShape.Length + 1, targetShape.Length);
+
             var plan = cache.GetOrCompileTraining(
-                (int[])input._shape.Clone(),
+                compositeKey,
                 () =>
                 {
                     var predicted = forward(input);

--- a/src/Training/CompiledTapeTrainingStep.cs
+++ b/src/Training/CompiledTapeTrainingStep.cs
@@ -37,6 +37,16 @@ public static class CompiledTapeTrainingStep<T>
     private static object? _lastConfiguredPlan;
 
     /// <summary>
+    /// Snapshot of the optimizer hyperparameters the last <see cref="TryStepWithFusedOptimizer"/>
+    /// call configured on <see cref="_lastConfiguredPlan"/>. Plan identity alone
+    /// is insufficient — the same plan can be configured with SGD then Adam, or
+    /// Adam-with-LR-1e-3 then Adam-with-LR-1e-4. Detecting any drift here forces
+    /// a fallback so the caller doesn't silently train against stale moments.
+    /// </summary>
+    [ThreadStatic]
+    private static (int OptType, float Lr, float B1, float B2, float Eps, float Wd)? _lastOptimizerConfig;
+
+    /// <summary>
     /// Executes a single compiled training step.
     /// First call traces and compiles; subsequent calls replay the compiled plan.
     /// Falls back to eager execution if compilation fails.
@@ -104,6 +114,7 @@ public static class CompiledTapeTrainingStep<T>
         _cache?.Invalidate();
         _cachedParameters = null;
         _lastConfiguredPlan = null;
+        _lastOptimizerConfig = null;
     }
 
     /// <summary>
@@ -140,7 +151,7 @@ public static class CompiledTapeTrainingStep<T>
     /// </para>
     /// </remarks>
     /// <returns><c>true</c> when the fused compiled step ran successfully.</returns>
-    public static bool TryStepWithFusedOptimizer(
+    internal static bool TryStepWithFusedOptimizer(
         IReadOnlyList<ITrainableLayer<T>> layers,
         Tensor<T> input,
         Tensor<T> target,
@@ -174,7 +185,11 @@ public static class CompiledTapeTrainingStep<T>
             if (_cachedParameters is null)
                 forward(input);
 
-            var parameters = _cachedParameters ??= CollectParameterArray(layers);
+            // Use the dedup-aware collector for the fused path. Shared/tied
+            // weights (same Tensor<T> instance referenced by multiple layers)
+            // would otherwise drive the fused kernel's m/v buffers to update
+            // the same parameter twice per step, breaking Adam's moment math.
+            var parameters = _cachedParameters ??= CollectDeduplicatedParameters(layers);
 
             foreach (var layer in layers)
                 layer.ZeroGrad();
@@ -188,10 +203,17 @@ public static class CompiledTapeTrainingStep<T>
                 },
                 parameters);
 
-            // Configure the fused optimizer exactly once per compiled plan.
-            // Re-calling ConfigureOptimizer resets the Adam m/v buffers — we must
-            // not do that per step. Track plan identity via ThreadStatic.
-            if (!ReferenceEquals(_lastConfiguredPlan, plan))
+            // Configure the fused optimizer when EITHER the plan changed
+            // (recompile) OR any optimizer hyperparameter drifted from the last
+            // call. Plan identity alone is insufficient — the same plan can be
+            // configured with SGD then Adam, or Adam-with-different-LR. Detecting
+            // drift forces reconfigure (which resets m/v buffers — necessary
+            // when the math changed) instead of silently running stale moments.
+            var currentConfig = ((int)optimizerType, learningRate, beta1, beta2, epsilon, weightDecay);
+            bool needsReconfigure = !ReferenceEquals(_lastConfiguredPlan, plan)
+                || _lastOptimizerConfig is null
+                || !_lastOptimizerConfig.Value.Equals(currentConfig);
+            if (needsReconfigure)
             {
                 plan.ConfigureOptimizer(
                     optimizerType,
@@ -201,6 +223,7 @@ public static class CompiledTapeTrainingStep<T>
                     epsilon,
                     weightDecay);
                 _lastConfiguredPlan = plan;
+                _lastOptimizerConfig = currentConfig;
             }
 
             // Execute forward + backward + fused parameter update in one replay.
@@ -208,12 +231,38 @@ public static class CompiledTapeTrainingStep<T>
             lossValue = lossOutput.Length > 0 ? lossOutput[0] : MathHelper.GetNumericOperations<T>().Zero;
             return true;
         }
-        catch
+        catch (Exception ex)
         {
-            // Clear the configured-plan cache so next attempt reconfigures fresh.
+            // Trace the failure so fused-path regressions are observable in
+            // production telemetry. Clear the configured-plan cache so next
+            // attempt reconfigures fresh.
+            System.Diagnostics.Trace.TraceWarning(
+                $"CompiledTapeTrainingStep.TryStepWithFusedOptimizer failed, falling back to eager: " +
+                $"{ex.GetType().Name}: {ex.Message}");
             _lastConfiguredPlan = null;
+            _lastOptimizerConfig = null;
             return false;
         }
+    }
+
+    /// <summary>
+    /// Deduplicates trainable parameter tensors by reference identity. The eager
+    /// <see cref="TapeTrainingStep{T}"/> path also dedupes (shared/tied weights
+    /// must be updated once per step, not once per layer that holds the alias).
+    /// </summary>
+    private static Tensor<T>[] CollectDeduplicatedParameters(IReadOnlyList<ITrainableLayer<T>> layers)
+    {
+        var seen = new HashSet<Tensor<T>>(AiDotNet.Helpers.TensorReferenceComparer<Tensor<T>>.Instance);
+        var result = new List<Tensor<T>>();
+        foreach (var layer in layers)
+        {
+            foreach (var p in layer.GetTrainableParameters())
+            {
+                if (p is not null && seen.Add(p))
+                    result.Add(p);
+            }
+        }
+        return result.ToArray();
     }
 
     private static Tensor<T>[] CollectParameterArray(IReadOnlyList<ITrainableLayer<T>> layers)

--- a/src/Training/CompiledTapeTrainingStep.cs
+++ b/src/Training/CompiledTapeTrainingStep.cs
@@ -208,18 +208,18 @@ public static class CompiledTapeTrainingStep<T>
                 },
                 parameters);
 
-            // Configure the fused optimizer when EITHER the plan changed
-            // (recompile) OR any optimizer hyperparameter drifted from the last
-            // call. Plan identity alone is insufficient — the same plan can be
-            // configured with SGD then Adam, or Adam-with-different-LR. Detecting
-            // drift forces reconfigure (which resets m/v buffers — necessary
-            // when the math changed) instead of silently running stale moments.
+            // Configure once per fresh plan. Re-calling ConfigureOptimizer
+            // on the SAME plan re-allocates Adam's m/v buffers — so if the
+            // caller changes LR/betas mid-training we MUST NOT silently
+            // reconfigure (the resulting reset would corrupt training).
+            // Instead we return false → caller falls back to eager (which
+            // preserves the user's optimizer state via TapeStepContext) and
+            // marks the fused path as drift-incompatible for this run.
             var currentConfig = ((int)optimizerType, learningRate, beta1, beta2, epsilon, weightDecay);
-            bool needsReconfigure = !ReferenceEquals(_lastConfiguredPlan, plan)
-                || _lastOptimizerConfig is null
-                || !_lastOptimizerConfig.Value.Equals(currentConfig);
-            if (needsReconfigure)
+            if (!ReferenceEquals(_lastConfiguredPlan, plan))
             {
+                // New plan (first call OR plan was recompiled after invalidation).
+                // Configuring fresh m/v is correct here.
                 plan.ConfigureOptimizer(
                     optimizerType,
                     learningRate,
@@ -229,6 +229,17 @@ public static class CompiledTapeTrainingStep<T>
                     weightDecay);
                 _lastConfiguredPlan = plan;
                 _lastOptimizerConfig = currentConfig;
+            }
+            else if (_lastOptimizerConfig is null
+                || !_lastOptimizerConfig.Value.Equals(currentConfig))
+            {
+                // Same plan but optimizer config drifted between steps.
+                // Reconfiguring would reset m/v buffers and silently corrupt
+                // Adam training. Fall back to eager so the caller's pluggable
+                // optimizer (which owns its state) handles the LR change
+                // correctly. The caller's sticky-disable will keep subsequent
+                // steps on eager so we don't oscillate between the two.
+                return false;
             }
 
             // Execute forward + backward + fused parameter update in one replay.

--- a/src/Training/CompiledTapeTrainingStep.cs
+++ b/src/Training/CompiledTapeTrainingStep.cs
@@ -33,18 +33,25 @@ public static class CompiledTapeTrainingStep<T>
     private static CompiledModelCache<T>? _cache;
     [ThreadStatic]
     private static Tensor<T>[]? _cachedParameters;
-    [ThreadStatic]
-    private static object? _lastConfiguredPlan;
 
     /// <summary>
-    /// Snapshot of the optimizer hyperparameters the last <see cref="TryStepWithFusedOptimizer"/>
-    /// call configured on <see cref="_lastConfiguredPlan"/>. Plan identity alone
-    /// is insufficient — the same plan can be configured with SGD then Adam, or
-    /// Adam-with-LR-1e-3 then Adam-with-LR-1e-4. Detecting any drift here forces
-    /// a fallback so the caller doesn't silently train against stale moments.
+    /// Per-plan optimizer configuration tracker. Keyed by plan reference so
+    /// each compiled plan is configured <i>exactly once</i>, even when the
+    /// training loop alternates between multiple plans (e.g., last partial
+    /// batch, variable sequence lengths, or variable {input, target} shape
+    /// pairs). Without this, a single-slot tracker would call
+    /// <c>ConfigureOptimizer</c> again every time control returned to a
+    /// previously-configured plan, resetting Adam's m/v buffers and silently
+    /// corrupting training.
+    /// <para>
+    /// <see cref="ThreadStaticAttribute"/> so the dict is per-thread (no lock
+    /// overhead); <see cref="TensorReferenceComparer{T}"/> gives us reference
+    /// equality in net471-compatible form (no <c>ReferenceEqualityComparer</c>
+    /// dependency).
+    /// </para>
     /// </summary>
     [ThreadStatic]
-    private static (int OptType, float Lr, float B1, float B2, float Eps, float Wd)? _lastOptimizerConfig;
+    private static Dictionary<object, (int OptType, float Lr, float B1, float B2, float Eps, float Wd)>? _planOptimizerConfigs;
 
     /// <summary>
     /// Executes a single compiled training step.
@@ -86,9 +93,24 @@ public static class CompiledTapeTrainingStep<T>
             foreach (var layer in layers)
                 layer.ZeroGrad();
 
-            // Get or compile training plan (cached by shape internally)
+            // Compile key must include BOTH input AND target shapes — the
+            // traced lambda captures target via computeLoss. A plan compiled
+            // for input=[B,D], target=[B,C] would otherwise silently replay
+            // the wrong op graph if the next call arrives with the same
+            // input shape but a different target shape (e.g., a regression
+            // output scalar vs. a classification class-index). Build a
+            // composite synthetic key (input + separator + target) matching
+            // the TryStepWithFusedOptimizer convention so distinct
+            // {input, target} pairs hit distinct cache entries.
+            var inputShape = input._shape;
+            var targetShape = target._shape;
+            var compositeKey = new int[inputShape.Length + 1 + targetShape.Length];
+            Array.Copy(inputShape, 0, compositeKey, 0, inputShape.Length);
+            compositeKey[inputShape.Length] = -1; // separator sentinel (no real dim is negative)
+            Array.Copy(targetShape, 0, compositeKey, inputShape.Length + 1, targetShape.Length);
+
             var plan = cache.GetOrCompileTraining(
-                (int[])input._shape.Clone(),
+                compositeKey,
                 () =>
                 {
                     var predicted = forward(input);
@@ -118,8 +140,7 @@ public static class CompiledTapeTrainingStep<T>
     {
         _cache?.Invalidate();
         _cachedParameters = null;
-        _lastConfiguredPlan = null;
-        _lastOptimizerConfig = null;
+        _planOptimizerConfigs?.Clear();
     }
 
     /// <summary>
@@ -226,14 +247,24 @@ public static class CompiledTapeTrainingStep<T>
             // on the SAME plan re-allocates Adam's m/v buffers — so if the
             // caller changes LR/betas mid-training we MUST NOT silently
             // reconfigure (the resulting reset would corrupt training).
-            // Instead we return false → caller falls back to eager (which
-            // preserves the user's optimizer state via TapeStepContext) and
-            // marks the fused path as drift-incompatible for this run.
+            //
+            // Track configuration per-plan (not single-slot). A training
+            // loop that alternates between multiple compiled plans (e.g.,
+            // full batches and a trailing partial batch, or variable
+            // sequence lengths) would otherwise re-configure every time
+            // control returned to a previously-seen plan. With the
+            // per-plan dictionary, each plan is configured exactly once,
+            // and drift on any one plan triggers the eager fallback for
+            // that plan without disturbing the others.
             var currentConfig = ((int)optimizerType, learningRate, beta1, beta2, epsilon, weightDecay);
-            if (!ReferenceEquals(_lastConfiguredPlan, plan))
+            var planConfigs = _planOptimizerConfigs
+                ??= new Dictionary<object, (int, float, float, float, float, float)>(
+                    AiDotNet.Helpers.TensorReferenceComparer<object>.Instance);
+
+            if (!planConfigs.TryGetValue(plan, out var priorConfig))
             {
-                // New plan (first call OR plan was recompiled after invalidation).
-                // Configuring fresh m/v is correct here.
+                // First time seeing this plan on this thread. Configure
+                // fresh m/v buffers and record the config.
                 plan.ConfigureOptimizer(
                     optimizerType,
                     learningRate,
@@ -241,11 +272,9 @@ public static class CompiledTapeTrainingStep<T>
                     beta2,
                     epsilon,
                     weightDecay);
-                _lastConfiguredPlan = plan;
-                _lastOptimizerConfig = currentConfig;
+                planConfigs[plan] = currentConfig;
             }
-            else if (_lastOptimizerConfig is null
-                || !_lastOptimizerConfig.Value.Equals(currentConfig))
+            else if (!priorConfig.Equals(currentConfig))
             {
                 // Same plan but optimizer config drifted between steps.
                 // Reconfiguring would reset m/v buffers and silently corrupt
@@ -264,13 +293,13 @@ public static class CompiledTapeTrainingStep<T>
         catch (Exception ex)
         {
             // Trace the failure so fused-path regressions are observable in
-            // production telemetry. Clear the configured-plan cache so next
-            // attempt reconfigures fresh.
+            // production telemetry. Clear the per-plan config cache so any
+            // next attempt reconfigures fresh — we can't know which plan
+            // (if any) ended up in a partial state, so drop them all.
             System.Diagnostics.Trace.TraceWarning(
                 $"CompiledTapeTrainingStep.TryStepWithFusedOptimizer failed, falling back to eager: " +
                 $"{ex.GetType().Name}: {ex.Message}");
-            _lastConfiguredPlan = null;
-            _lastOptimizerConfig = null;
+            _planOptimizerConfigs?.Clear();
             return false;
         }
     }

--- a/src/Training/CompiledTapeTrainingStep.cs
+++ b/src/Training/CompiledTapeTrainingStep.cs
@@ -33,6 +33,8 @@ public static class CompiledTapeTrainingStep<T>
     private static CompiledModelCache<T>? _cache;
     [ThreadStatic]
     private static Tensor<T>[]? _cachedParameters;
+    [ThreadStatic]
+    private static object? _lastConfiguredPlan;
 
     /// <summary>
     /// Executes a single compiled training step.
@@ -101,6 +103,117 @@ public static class CompiledTapeTrainingStep<T>
     {
         _cache?.Invalidate();
         _cachedParameters = null;
+        _lastConfiguredPlan = null;
+    }
+
+    /// <summary>
+    /// Compiled training step with <b>fused optimizer</b> — forward + backward +
+    /// parameter update all run in one compiled kernel. No materialized gradient
+    /// tensors between backward and the optimizer step. SIMD-accelerated update
+    /// via <see cref="FusedOptimizer"/> (float-only).
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This is faster than <see cref="Step"/> even for SGD because the parameter
+    /// update happens inside the compiled plan's replay kernel — zero allocation,
+    /// zero dispatch between backward and update, tight SIMD inner loop.
+    /// </para>
+    /// <para>
+    /// <b>Constraints:</b>
+    /// <list type="bullet">
+    /// <item>Only <c>T = float</c> is supported (Tensors-side limitation — the
+    /// fused optimizer kernels operate on <c>float*</c> directly).</item>
+    /// <item>Only SGD, Adam, and AdamW are supported by
+    /// <see cref="CompiledTrainingPlan{T}.ConfigureOptimizer"/>. Other optimizer
+    /// types must use the plain <see cref="Step"/> method or the eager tape path.</item>
+    /// <item>Hyperparameters (LR, betas, eps, weight decay) are <b>baked at the
+    /// first configure call per compile</b>. Re-calling with different LR would
+    /// reset the Adam momentum buffers — so callers that use learning-rate
+    /// schedulers or adaptive rates should use <see cref="Step"/> instead.</item>
+    /// </list>
+    /// </para>
+    /// <para>
+    /// The method returns <c>false</c> on compilation failure OR when the fused
+    /// path isn't applicable, letting the caller fall through to the eager path.
+    /// The out <paramref name="lossValue"/> is meaningful only when the return
+    /// is <c>true</c>.
+    /// </para>
+    /// </remarks>
+    /// <returns><c>true</c> when the fused compiled step ran successfully.</returns>
+    public static bool TryStepWithFusedOptimizer(
+        IReadOnlyList<ITrainableLayer<T>> layers,
+        Tensor<T> input,
+        Tensor<T> target,
+        Func<Tensor<T>, Tensor<T>> forward,
+        Func<Tensor<T>, Tensor<T>, Tensor<T>> computeLoss,
+        AiDotNet.Tensors.Engines.Compilation.OptimizerType optimizerType,
+        float learningRate,
+        float beta1,
+        float beta2,
+        float epsilon,
+        float weightDecay,
+        out T lossValue)
+    {
+        lossValue = MathHelper.GetNumericOperations<T>().Zero;
+
+        if (!TensorCodecOptions.Current.EnableCompilation) return false;
+        // Fused optimizer kernels are float-only on the Tensors side.
+        if (typeof(T) != typeof(float)) return false;
+        // Only SGD, Adam, AdamW are wired through ConfigureOptimizer.
+        if (optimizerType is not (AiDotNet.Tensors.Engines.Compilation.OptimizerType.SGD
+            or AiDotNet.Tensors.Engines.Compilation.OptimizerType.Adam
+            or AiDotNet.Tensors.Engines.Compilation.OptimizerType.AdamW))
+            return false;
+
+        try
+        {
+            var cache = _cache ??= new CompiledModelCache<T>();
+
+            // Force layer initialization before collecting parameters — DenseLayer
+            // replaces _weights with a new tensor on first Forward.
+            if (_cachedParameters is null)
+                forward(input);
+
+            var parameters = _cachedParameters ??= CollectParameterArray(layers);
+
+            foreach (var layer in layers)
+                layer.ZeroGrad();
+
+            var plan = cache.GetOrCompileTraining(
+                (int[])input._shape.Clone(),
+                () =>
+                {
+                    var predicted = forward(input);
+                    computeLoss(predicted, target);
+                },
+                parameters);
+
+            // Configure the fused optimizer exactly once per compiled plan.
+            // Re-calling ConfigureOptimizer resets the Adam m/v buffers — we must
+            // not do that per step. Track plan identity via ThreadStatic.
+            if (!ReferenceEquals(_lastConfiguredPlan, plan))
+            {
+                plan.ConfigureOptimizer(
+                    optimizerType,
+                    learningRate,
+                    beta1,
+                    beta2,
+                    epsilon,
+                    weightDecay);
+                _lastConfiguredPlan = plan;
+            }
+
+            // Execute forward + backward + fused parameter update in one replay.
+            var lossOutput = plan.Step();
+            lossValue = lossOutput.Length > 0 ? lossOutput[0] : MathHelper.GetNumericOperations<T>().Zero;
+            return true;
+        }
+        catch
+        {
+            // Clear the configured-plan cache so next attempt reconfigures fresh.
+            _lastConfiguredPlan = null;
+            return false;
+        }
     }
 
     private static Tensor<T>[] CollectParameterArray(IReadOnlyList<ITrainableLayer<T>> layers)

--- a/src/Training/CompiledTapeTrainingStep.cs
+++ b/src/Training/CompiledTapeTrainingStep.cs
@@ -35,23 +35,32 @@ public static class CompiledTapeTrainingStep<T>
     private static Tensor<T>[]? _cachedParameters;
 
     /// <summary>
-    /// Per-plan optimizer configuration tracker. Keyed by plan reference so
-    /// each compiled plan is configured <i>exactly once</i>, even when the
-    /// training loop alternates between multiple plans (e.g., last partial
-    /// batch, variable sequence lengths, or variable {input, target} shape
-    /// pairs). Without this, a single-slot tracker would call
-    /// <c>ConfigureOptimizer</c> again every time control returned to a
-    /// previously-configured plan, resetting Adam's m/v buffers and silently
-    /// corrupting training.
-    /// <para>
-    /// <see cref="ThreadStaticAttribute"/> so the dict is per-thread (no lock
-    /// overhead); <see cref="TensorReferenceComparer{T}"/> gives us reference
-    /// equality in net471-compatible form (no <c>ReferenceEqualityComparer</c>
-    /// dependency).
-    /// </para>
+    /// The single plan that has been configured with an optimizer on this
+    /// thread. <b>Strict single-plan semantics</b>: Adam/AdamW/SGD moment
+    /// buffers live INSIDE the compiled plan (via
+    /// <c>ICompiledTrainingPlan.ConfigureOptimizer</c>), so allowing multiple
+    /// plans to each accumulate their own state would silently fork
+    /// optimizer state across variable-shape batches and diverge from the
+    /// reference eager semantics (one optimizer, one state vector). Any
+    /// attempt to engage a DIFFERENT plan on the same thread returns
+    /// <c>false</c> from <see cref="TryStepWithFusedOptimizer"/> — the
+    /// caller must decide whether to halt or continue via eager (the
+    /// NeuralNetworkBase caller enforces a strict commitment so the
+    /// state-loss cannot happen silently).
     /// </summary>
     [ThreadStatic]
-    private static Dictionary<object, (int OptType, float Lr, float B1, float B2, float Eps, float Wd)>? _planOptimizerConfigs;
+    private static object? _configuredPlan;
+
+    /// <summary>
+    /// Snapshot of the hyperparameters passed to
+    /// <c>ICompiledTrainingPlan.ConfigureOptimizer</c> on
+    /// <see cref="_configuredPlan"/>. Used to detect drift on the same
+    /// plan (LR change between steps, beta change) — reconfiguring would
+    /// reset m/v buffers and silently corrupt training, so on drift we
+    /// also return <c>false</c>.
+    /// </summary>
+    [ThreadStatic]
+    private static (int OptType, float Lr, float B1, float B2, float Eps, float Wd)? _configuredOptimizerConfig;
 
     /// <summary>
     /// Executes a single compiled training step.
@@ -140,7 +149,8 @@ public static class CompiledTapeTrainingStep<T>
     {
         _cache?.Invalidate();
         _cachedParameters = null;
-        _planOptimizerConfigs?.Clear();
+        _configuredPlan = null;
+        _configuredOptimizerConfig = null;
     }
 
     /// <summary>
@@ -243,28 +253,27 @@ public static class CompiledTapeTrainingStep<T>
                 },
                 parameters);
 
-            // Configure once per fresh plan. Re-calling ConfigureOptimizer
-            // on the SAME plan re-allocates Adam's m/v buffers — so if the
-            // caller changes LR/betas mid-training we MUST NOT silently
-            // reconfigure (the resulting reset would corrupt training).
+            // STRICT SINGLE-PLAN POLICY: optimizer state lives inside the
+            // compiled plan (ConfigureOptimizer attaches m/v buffers directly
+            // to the plan object). Letting multiple plans each accumulate
+            // their own m/v would fork Adam state across variable-shape
+            // batches and silently diverge from eager semantics (where one
+            // optimizer holds one state vector across all shapes).
             //
-            // Track configuration per-plan (not single-slot). A training
-            // loop that alternates between multiple compiled plans (e.g.,
-            // full batches and a trailing partial batch, or variable
-            // sequence lengths) would otherwise re-configure every time
-            // control returned to a previously-seen plan. With the
-            // per-plan dictionary, each plan is configured exactly once,
-            // and drift on any one plan triggers the eager fallback for
-            // that plan without disturbing the others.
+            // So: the FIRST plan we see on this thread is the only plan we'll
+            // configure. Any subsequent call with a different plan (e.g., a
+            // new {input, target} shape combo producing a new compiled plan)
+            // returns false — the caller (NeuralNetworkBase) then enforces
+            // its commitment rule so state loss cannot happen silently.
+            //
+            // Drift on the SAME plan (LR or beta change between steps) also
+            // returns false — reconfiguring would reset m/v.
             var currentConfig = ((int)optimizerType, learningRate, beta1, beta2, epsilon, weightDecay);
-            var planConfigs = _planOptimizerConfigs
-                ??= new Dictionary<object, (int, float, float, float, float, float)>(
-                    AiDotNet.Helpers.TensorReferenceComparer<object>.Instance);
 
-            if (!planConfigs.TryGetValue(plan, out var priorConfig))
+            if (_configuredPlan is null)
             {
-                // First time seeing this plan on this thread. Configure
-                // fresh m/v buffers and record the config.
+                // First fused call on this thread. Configure the plan and
+                // commit to single-plan semantics from here on.
                 plan.ConfigureOptimizer(
                     optimizerType,
                     learningRate,
@@ -272,16 +281,23 @@ public static class CompiledTapeTrainingStep<T>
                     beta2,
                     epsilon,
                     weightDecay);
-                planConfigs[plan] = currentConfig;
+                _configuredPlan = plan;
+                _configuredOptimizerConfig = currentConfig;
             }
-            else if (!priorConfig.Equals(currentConfig))
+            else if (!ReferenceEquals(_configuredPlan, plan))
             {
-                // Same plan but optimizer config drifted between steps.
-                // Reconfiguring would reset m/v buffers and silently corrupt
-                // Adam training. Fall back to eager so the caller's pluggable
-                // optimizer (which owns its state) handles the LR change
-                // correctly. The caller's sticky-disable will keep subsequent
-                // steps on eager so we don't oscillate between the two.
+                // Plan switch → different shape or structure produced a new
+                // compiled plan. Using a fresh plan would fork optimizer
+                // state, so refuse and let the caller handle it (the
+                // NeuralNetworkBase caller throws once fused has committed).
+                return false;
+            }
+            else if (_configuredOptimizerConfig is null
+                || !_configuredOptimizerConfig.Value.Equals(currentConfig))
+            {
+                // Same plan, drifted hyperparameters between steps. Refuse
+                // to re-configure (would reset m/v) and let the caller
+                // handle the drift.
                 return false;
             }
 
@@ -299,7 +315,8 @@ public static class CompiledTapeTrainingStep<T>
             System.Diagnostics.Trace.TraceWarning(
                 $"CompiledTapeTrainingStep.TryStepWithFusedOptimizer failed, falling back to eager: " +
                 $"{ex.GetType().Name}: {ex.Message}");
-            _planOptimizerConfigs?.Clear();
+            _configuredPlan = null;
+            _configuredOptimizerConfig = null;
             return false;
         }
     }

--- a/src/Training/CompiledTapeTrainingStep.cs
+++ b/src/Training/CompiledTapeTrainingStep.cs
@@ -75,7 +75,12 @@ public static class CompiledTapeTrainingStep<T>
             if (_cachedParameters is null)
                 forward(input);
 
-            var parameters = _cachedParameters ??= CollectParameterArray(layers);
+            // Use the dedup-aware collector here too so the cached array is
+            // safe to reuse if a subsequent caller routes through
+            // TryStepWithFusedOptimizer. Shared/tied weights would otherwise
+            // appear twice in the array — wrong for both eager-SGD here AND
+            // wrong for the fused kernel's m/v buffers downstream.
+            var parameters = _cachedParameters ??= CollectDeduplicatedParameters(layers);
 
             // Zero gradients before forward pass
             foreach (var layer in layers)

--- a/tests/AiDotNet.Tests/IntegrationTests/NeuralNetworks/FusedOptimizerIntegrationTests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/NeuralNetworks/FusedOptimizerIntegrationTests.cs
@@ -21,10 +21,22 @@ using Xunit;
 namespace AiDotNet.Tests.IntegrationTests.NeuralNetworks;
 
 /// <summary>
+/// Collection definition that groups integration tests mutating the
+/// thread-static <see cref="TensorCodecOptions.Current"/>/fused-step
+/// counter into a single non-parallel sequence. xUnit's default
+/// per-class parallelization would race SetCurrent / Invalidate across
+/// tests, producing flaky results (one test's EnableCompilation=true
+/// would leak into another's EnableCompilation=false assertions).
+/// </summary>
+[CollectionDefinition("FusedOptimizerGlobalState", DisableParallelization = true)]
+public sealed class FusedOptimizerCollection { }
+
+/// <summary>
 /// Integration tests for the fused forward+backward+optimizer compiled training path
 /// wired through <see cref="NeuralNetworkBase{T}.TrainWithTape(Tensor{T}, Tensor{T}, IGradientBasedOptimizer{T, Tensor{T}, Tensor{T}}?)"/>.
 /// Exercises the <c>TryTrainWithFusedOptimizer</c> engage/fallback decision tree end-to-end.
 /// </summary>
+[Collection("FusedOptimizerGlobalState")]
 public class FusedOptimizerIntegrationTests
 {
     /// <summary>
@@ -52,6 +64,7 @@ public class FusedOptimizerIntegrationTests
         {
             TensorCodecOptions.SetCurrent(new TensorCodecOptions { EnableCompilation = true });
             CompiledTapeTrainingStep<float>.Invalidate();
+            CompiledTapeTrainingStep<float>.ResetFusedStepCount();
 
             var losses = new List<float>();
             for (int step = 0; step < 10; step++)
@@ -65,6 +78,15 @@ public class FusedOptimizerIntegrationTests
                 Assert.False(float.IsNaN(loss), "Fused path produced NaN loss");
                 Assert.False(float.IsInfinity(loss), "Fused path produced Inf loss");
             }
+
+            // Observable signal that the fused compiled kernel actually ran.
+            // Without this assertion, a silent fallback to the eager path
+            // would produce finite loss too and the "fused" test would pass
+            // against the wrong code path. Require that at least one fused
+            // step ran; in a healthy config on a supported MLP this should
+            // be all 10.
+            Assert.True(CompiledTapeTrainingStep<float>.GetFusedStepCount() > 0,
+                "Fused path never engaged — the test was silently falling back to eager.");
         }
         finally
         {

--- a/tests/AiDotNet.Tests/IntegrationTests/NeuralNetworks/FusedOptimizerIntegrationTests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/NeuralNetworks/FusedOptimizerIntegrationTests.cs
@@ -1,0 +1,492 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+using AiDotNet.Enums;
+using AiDotNet.Helpers;
+using AiDotNet.Interfaces;
+using AiDotNet.LearningRateSchedulers;
+using AiDotNet.LinearAlgebra;
+using AiDotNet.LossFunctions;
+using AiDotNet.Models;
+using AiDotNet.Models.Options;
+using AiDotNet.NeuralNetworks;
+using AiDotNet.NeuralNetworks.Layers;
+using AiDotNet.Optimizers;
+using AiDotNet.Tensors;
+using AiDotNet.Tensors.Engines.Optimization;
+using AiDotNet.Training;
+using Xunit;
+
+namespace AiDotNet.Tests.IntegrationTests.NeuralNetworks;
+
+/// <summary>
+/// Integration tests for the fused forward+backward+optimizer compiled training path
+/// wired through <see cref="NeuralNetworkBase{T}.TrainWithTape(Tensor{T}, Tensor{T}, IGradientBasedOptimizer{T, Tensor{T}, Tensor{T}}?)"/>.
+/// Exercises the <c>TryTrainWithFusedOptimizer</c> engage/fallback decision tree end-to-end.
+/// </summary>
+public class FusedOptimizerIntegrationTests
+{
+    /// <summary>
+    /// With <see cref="TensorCodecOptions.EnableCompilation"/> true, <c>T=float</c>, and a plain
+    /// Adam optimizer (no LR scheduler, no adaptive rates), <c>TryTrainWithFusedOptimizer</c>
+    /// engages the compiled fused fwd+bwd+update kernel. Training must complete without
+    /// crashing and produce finite losses across multiple steps — any NaN/Inf indicates a
+    /// broken kernel that silently corrupts training state.
+    /// </summary>
+    [Fact(Timeout = 120000)]
+    public async Task FusedAdam_TrainingCompletes_WithFiniteLossAcrossSteps()
+    {
+        await Task.CompletedTask;
+
+        var network = BuildMlp();
+        var input = CreateRandomTensor(new[] { 16, 4 }, seed: 42);
+        var target = CreateRandomTensor(new[] { 16, 2 }, seed: 43);
+
+        // Warmup forward to ensure layer tensors exist before we copy weights.
+        network.Predict(CreateRandomTensor(new[] { 1, 4 }, seed: 99));
+
+        var optimizer = BuildAdam(network, learningRate: 0.01);
+        var originalOptions = TensorCodecOptions.Current;
+        try
+        {
+            TensorCodecOptions.SetCurrent(new TensorCodecOptions { EnableCompilation = true });
+            CompiledTapeTrainingStep<float>.Invalidate();
+
+            var losses = new List<float>();
+            for (int step = 0; step < 10; step++)
+            {
+                network.TrainPublic(input, target, optimizer);
+                losses.Add(network.LastLossPublic);
+            }
+
+            foreach (var loss in losses)
+            {
+                Assert.False(float.IsNaN(loss), "Fused path produced NaN loss");
+                Assert.False(float.IsInfinity(loss), "Fused path produced Inf loss");
+            }
+        }
+        finally
+        {
+            TensorCodecOptions.SetCurrent(originalOptions);
+            CompiledTapeTrainingStep<float>.Invalidate();
+        }
+    }
+
+    /// <summary>
+    /// The eager tape fallback path (<see cref="TensorCodecOptions.EnableCompilation"/>=false)
+    /// must actually update parameters — this is the reference path that must always work,
+    /// independent of whether the fused path engages.
+    /// </summary>
+    [Fact(Timeout = 120000)]
+    public async Task EagerPath_UpdatesParameters_WhenCompilationDisabled()
+    {
+        await Task.CompletedTask;
+
+        var network = BuildMlp();
+        var input = CreateRandomTensor(new[] { 16, 4 }, seed: 42);
+        var target = CreateRandomTensor(new[] { 16, 2 }, seed: 43);
+
+        network.Predict(CreateRandomTensor(new[] { 1, 4 }, seed: 99));
+        var optimizer = BuildAdam(network, learningRate: 0.01);
+
+        var originalOptions = TensorCodecOptions.Current;
+        try
+        {
+            TensorCodecOptions.SetCurrent(new TensorCodecOptions { EnableCompilation = false });
+            CompiledTapeTrainingStep<float>.Invalidate();
+
+            var before = SnapshotParameters(network);
+            for (int step = 0; step < 5; step++)
+            {
+                network.TrainPublic(input, target, optimizer);
+            }
+            var after = SnapshotParameters(network);
+
+            Assert.True(AnyParameterDiffers(before, after, tolerance: 1e-6f),
+                "Eager fallback path did not update any parameters after 5 steps");
+            Assert.False(float.IsNaN(network.LastLossPublic), "Eager path produced NaN");
+        }
+        finally
+        {
+            TensorCodecOptions.SetCurrent(originalOptions);
+            CompiledTapeTrainingStep<float>.Invalidate();
+        }
+    }
+
+    /// <summary>
+    /// When an LR scheduler is attached, <c>TryMapToFusedOptimizerConfig</c> must refuse the
+    /// fused path (returning false → fallback to eager). The fused plan bakes the learning
+    /// rate at <c>ConfigureOptimizer</c> time, so per-step LR changes would silently
+    /// disappear. Verifies training still completes correctly and parameters update via
+    /// the eager fallback.
+    /// </summary>
+    [Fact(Timeout = 120000)]
+    public async Task LearningRateScheduler_ForcesSafeFallbackToEager_AndParametersUpdate()
+    {
+        await Task.CompletedTask;
+
+        var network = BuildMlp();
+        var input = CreateRandomTensor(new[] { 16, 4 }, seed: 42);
+        var target = CreateRandomTensor(new[] { 16, 2 }, seed: 43);
+
+        network.Predict(CreateRandomTensor(new[] { 1, 4 }, seed: 99));
+
+        var adamOptions = new AdamOptimizerOptions<float, Tensor<float>, Tensor<float>>
+        {
+            InitialLearningRate = 0.01,
+            Beta1 = 0.9,
+            Beta2 = 0.999,
+            Epsilon = 1e-8,
+            UseAdaptiveLearningRate = false,
+            LearningRateScheduler = new ConstantLRScheduler(0.01)
+        };
+        var optimizer = new AdamOptimizer<float, Tensor<float>, Tensor<float>>(network, adamOptions);
+
+        var originalOptions = TensorCodecOptions.Current;
+        try
+        {
+            // EnableCompilation=true — fused path would be tempted to engage but must
+            // refuse due to the attached LR scheduler.
+            TensorCodecOptions.SetCurrent(new TensorCodecOptions { EnableCompilation = true });
+            CompiledTapeTrainingStep<float>.Invalidate();
+
+            var before = SnapshotParameters(network);
+            for (int step = 0; step < 5; step++)
+            {
+                network.TrainPublic(input, target, optimizer);
+                Assert.False(float.IsNaN(network.LastLossPublic),
+                    $"Eager fallback produced NaN loss at step {step}");
+            }
+            var after = SnapshotParameters(network);
+
+            Assert.True(AnyParameterDiffers(before, after, tolerance: 1e-6f),
+                "LR-scheduler fallback to eager did not update any parameters after 5 steps");
+        }
+        finally
+        {
+            TensorCodecOptions.SetCurrent(originalOptions);
+            CompiledTapeTrainingStep<float>.Invalidate();
+        }
+    }
+
+    /// <summary>
+    /// When <c>UseAdaptiveLearningRate=true</c>, the optimizer mutates its own LR between
+    /// steps. The fused kernel bakes the LR at configure time, so we must refuse to map
+    /// and fall back to eager. Exercises the adaptive-rate branch of
+    /// <c>TryMapToFusedOptimizerConfig</c>.
+    /// </summary>
+    [Fact(Timeout = 120000)]
+    public async Task AdaptiveLearningRate_ForcesFallbackToEager_AndParametersUpdate()
+    {
+        await Task.CompletedTask;
+
+        var network = BuildMlp();
+        var input = CreateRandomTensor(new[] { 16, 4 }, seed: 42);
+        var target = CreateRandomTensor(new[] { 16, 2 }, seed: 43);
+
+        network.Predict(CreateRandomTensor(new[] { 1, 4 }, seed: 99));
+
+        var adamOptions = new AdamOptimizerOptions<float, Tensor<float>, Tensor<float>>
+        {
+            InitialLearningRate = 0.01,
+            Beta1 = 0.9,
+            Beta2 = 0.999,
+            Epsilon = 1e-8,
+            UseAdaptiveLearningRate = true
+        };
+        var optimizer = new AdamOptimizer<float, Tensor<float>, Tensor<float>>(network, adamOptions);
+
+        var originalOptions = TensorCodecOptions.Current;
+        try
+        {
+            TensorCodecOptions.SetCurrent(new TensorCodecOptions { EnableCompilation = true });
+            CompiledTapeTrainingStep<float>.Invalidate();
+
+            var before = SnapshotParameters(network);
+            for (int step = 0; step < 5; step++)
+            {
+                network.TrainPublic(input, target, optimizer);
+                Assert.False(float.IsNaN(network.LastLossPublic),
+                    $"Eager fallback produced NaN at step {step}");
+            }
+            var after = SnapshotParameters(network);
+
+            Assert.True(AnyParameterDiffers(before, after, tolerance: 1e-6f),
+                "Adaptive-LR fallback to eager did not update any parameters after 5 steps");
+        }
+        finally
+        {
+            TensorCodecOptions.SetCurrent(originalOptions);
+            CompiledTapeTrainingStep<float>.Invalidate();
+        }
+    }
+
+    /// <summary>
+    /// Double-typed networks (T=double) must fall back to eager — the Tensors-side fused
+    /// optimizer operates on <c>float*</c> buffers directly. Exercises the
+    /// <c>typeof(T) != typeof(float)</c> early-return branch.
+    /// </summary>
+    [Fact(Timeout = 120000)]
+    public async Task DoubleModel_ForcesFallbackToEager_AndParametersUpdate()
+    {
+        await Task.CompletedTask;
+
+        var network = BuildMlpDouble();
+        var input = CreateRandomTensorDouble(new[] { 16, 4 }, seed: 42);
+        var target = CreateRandomTensorDouble(new[] { 16, 2 }, seed: 43);
+
+        network.Predict(CreateRandomTensorDouble(new[] { 1, 4 }, seed: 99));
+
+        var adamOptions = new AdamOptimizerOptions<double, Tensor<double>, Tensor<double>>
+        {
+            InitialLearningRate = 0.01,
+            Beta1 = 0.9,
+            Beta2 = 0.999,
+            Epsilon = 1e-8,
+            UseAdaptiveLearningRate = false
+        };
+        var optimizer = new AdamOptimizer<double, Tensor<double>, Tensor<double>>(network, adamOptions);
+
+        var originalOptions = TensorCodecOptions.Current;
+        try
+        {
+            TensorCodecOptions.SetCurrent(new TensorCodecOptions { EnableCompilation = true });
+
+            var before = SnapshotParametersDouble(network);
+            for (int step = 0; step < 5; step++)
+            {
+                network.TrainPublic(input, target, optimizer);
+                Assert.False(double.IsNaN(network.LastLossPublic),
+                    $"Eager fallback produced NaN at step {step}");
+            }
+            var after = SnapshotParametersDouble(network);
+
+            Assert.True(AnyParameterDiffersDouble(before, after, tolerance: 1e-9),
+                "Double-type fallback to eager did not update any parameters after 5 steps");
+        }
+        finally
+        {
+            TensorCodecOptions.SetCurrent(originalOptions);
+        }
+    }
+
+    // ---------- helpers ----------
+
+    private static FusedTrainingTestNetwork BuildMlp()
+    {
+        var architecture = new NeuralNetworkArchitecture<float>(
+            inputType: InputType.OneDimensional,
+            taskType: NeuralNetworkTaskType.Regression,
+            complexity: NetworkComplexity.Simple,
+            inputSize: 4,
+            outputSize: 2);
+
+        var network = new FusedTrainingTestNetwork(architecture);
+        network.AddLayer(new DenseLayer<float>(4, 8));
+        network.AddLayer(new DenseLayer<float>(8, 2));
+        return network;
+    }
+
+    private static FusedTrainingTestNetworkDouble BuildMlpDouble()
+    {
+        var architecture = new NeuralNetworkArchitecture<double>(
+            inputType: InputType.OneDimensional,
+            taskType: NeuralNetworkTaskType.Regression,
+            complexity: NetworkComplexity.Simple,
+            inputSize: 4,
+            outputSize: 2);
+
+        var network = new FusedTrainingTestNetworkDouble(architecture);
+        network.AddLayer(new DenseLayer<double>(4, 8));
+        network.AddLayer(new DenseLayer<double>(8, 2));
+        return network;
+    }
+
+    private static AdamOptimizer<float, Tensor<float>, Tensor<float>> BuildAdam(
+        FusedTrainingTestNetwork network, double learningRate)
+    {
+        var options = new AdamOptimizerOptions<float, Tensor<float>, Tensor<float>>
+        {
+            InitialLearningRate = learningRate,
+            Beta1 = 0.9,
+            Beta2 = 0.999,
+            Epsilon = 1e-8,
+            UseAdaptiveLearningRate = false
+        };
+        return new AdamOptimizer<float, Tensor<float>, Tensor<float>>(network, options);
+    }
+
+    private static Tensor<float> CreateRandomTensor(int[] shape, int seed)
+    {
+        var random = RandomHelper.CreateSeededRandom(seed);
+        int length = 1;
+        foreach (var d in shape) length *= d;
+        var data = new float[length];
+        for (int i = 0; i < data.Length; i++)
+        {
+            data[i] = (float)(random.NextDouble() * 2 - 1);
+        }
+        return new Tensor<float>(data, shape);
+    }
+
+    private static Tensor<double> CreateRandomTensorDouble(int[] shape, int seed)
+    {
+        var random = RandomHelper.CreateSeededRandom(seed);
+        int length = 1;
+        foreach (var d in shape) length *= d;
+        var data = new double[length];
+        for (int i = 0; i < data.Length; i++)
+        {
+            data[i] = random.NextDouble() * 2 - 1;
+        }
+        return new Tensor<double>(data, shape);
+    }
+
+    private static float[] SnapshotParameters(FusedTrainingTestNetwork network)
+    {
+        var vec = network.GetParameters();
+        var result = new float[vec.Length];
+        for (int i = 0; i < vec.Length; i++) result[i] = vec[i];
+        return result;
+    }
+
+    private static double[] SnapshotParametersDouble(FusedTrainingTestNetworkDouble network)
+    {
+        var vec = network.GetParameters();
+        var result = new double[vec.Length];
+        for (int i = 0; i < vec.Length; i++) result[i] = vec[i];
+        return result;
+    }
+
+    private static bool AnyParameterDiffers(float[] a, float[] b, float tolerance)
+    {
+        if (a.Length != b.Length) return true;
+        for (int i = 0; i < a.Length; i++)
+        {
+            if (Math.Abs(a[i] - b[i]) > tolerance) return true;
+        }
+        return false;
+    }
+
+    private static bool AnyParameterDiffersDouble(double[] a, double[] b, double tolerance)
+    {
+        if (a.Length != b.Length) return true;
+        for (int i = 0; i < a.Length; i++)
+        {
+            if (Math.Abs(a[i] - b[i]) > tolerance) return true;
+        }
+        return false;
+    }
+
+    /// <summary>
+    /// Minimal <see cref="NeuralNetworkBase{T}"/> subclass that exposes <c>TrainWithTape</c>
+    /// with a custom optimizer and exposes <see cref="NeuralNetworkBase{T}.LastLoss"/>
+    /// for test assertions.
+    /// </summary>
+    internal sealed class FusedTrainingTestNetwork : NeuralNetworkBase<float>
+    {
+        public FusedTrainingTestNetwork(NeuralNetworkArchitecture<float> architecture)
+            : base(architecture, new MeanSquaredErrorLoss<float>())
+        {
+        }
+
+        public override bool SupportsTraining => true;
+
+        public void AddLayer(ILayer<float> layer) => AddLayerToCollection(layer);
+
+        public void TrainPublic(
+            Tensor<float> input, Tensor<float> target,
+            IGradientBasedOptimizer<float, Tensor<float>, Tensor<float>> optimizer)
+        {
+            TrainWithTape(input, target, optimizer);
+        }
+
+        public float LastLossPublic => Convert.ToSingle(LastLoss);
+
+        protected override void InitializeLayers() { }
+
+        public override Tensor<float> Predict(Tensor<float> input)
+        {
+            bool originalTrainingMode = IsTrainingMode;
+            SetTrainingMode(false);
+            Tensor<float> current = input;
+            foreach (var layer in Layers) current = layer.Forward(current);
+            SetTrainingMode(originalTrainingMode);
+            return current;
+        }
+
+        public override void UpdateParameters(Vector<float> parameters) => SetParameters(parameters);
+
+        public override void Train(Tensor<float> input, Tensor<float> expectedOutput)
+            => TrainWithTape(input, expectedOutput);
+
+        public override ModelMetadata<float> GetModelMetadata() =>
+            new ModelMetadata<float>
+            {
+                Name = "FusedTrainingTestNetwork",
+                Version = "1.0",
+                FeatureCount = Architecture.InputSize,
+                Complexity = ParameterCount
+            };
+
+        protected override void SerializeNetworkSpecificData(BinaryWriter writer) { }
+        protected override void DeserializeNetworkSpecificData(BinaryReader reader) { }
+
+        protected override IFullModel<float, Tensor<float>, Tensor<float>> CreateNewInstance()
+            => new FusedTrainingTestNetwork(Architecture);
+    }
+
+    internal sealed class FusedTrainingTestNetworkDouble : NeuralNetworkBase<double>
+    {
+        public FusedTrainingTestNetworkDouble(NeuralNetworkArchitecture<double> architecture)
+            : base(architecture, new MeanSquaredErrorLoss<double>())
+        {
+        }
+
+        public override bool SupportsTraining => true;
+
+        public void AddLayer(ILayer<double> layer) => AddLayerToCollection(layer);
+
+        public void TrainPublic(
+            Tensor<double> input, Tensor<double> target,
+            IGradientBasedOptimizer<double, Tensor<double>, Tensor<double>> optimizer)
+        {
+            TrainWithTape(input, target, optimizer);
+        }
+
+        public double LastLossPublic => Convert.ToDouble(LastLoss);
+
+        protected override void InitializeLayers() { }
+
+        public override Tensor<double> Predict(Tensor<double> input)
+        {
+            bool originalTrainingMode = IsTrainingMode;
+            SetTrainingMode(false);
+            Tensor<double> current = input;
+            foreach (var layer in Layers) current = layer.Forward(current);
+            SetTrainingMode(originalTrainingMode);
+            return current;
+        }
+
+        public override void UpdateParameters(Vector<double> parameters) => SetParameters(parameters);
+
+        public override void Train(Tensor<double> input, Tensor<double> expectedOutput)
+            => TrainWithTape(input, expectedOutput);
+
+        public override ModelMetadata<double> GetModelMetadata() =>
+            new ModelMetadata<double>
+            {
+                Name = "FusedTrainingTestNetworkDouble",
+                Version = "1.0",
+                FeatureCount = Architecture.InputSize,
+                Complexity = ParameterCount
+            };
+
+        protected override void SerializeNetworkSpecificData(BinaryWriter writer) { }
+        protected override void DeserializeNetworkSpecificData(BinaryReader reader) { }
+
+        protected override IFullModel<double, Tensor<double>, Tensor<double>> CreateNewInstance()
+            => new FusedTrainingTestNetworkDouble(Architecture);
+    }
+}


### PR DESCRIPTION
## Summary

Wires `ICompiledTrainingPlan.ConfigureOptimizer` through `NeuralNetworkBase.TrainWithTape` so forward + backward + parameter update run as ONE compiled replay kernel instead of three separate passes with materialized gradients between them. Beats PyTorch's separate `optimizer.step()` for plain Adam/AdamW/SGD training loops — the Adam moment update happens inside the plan's flat delegate array, SIMD-accelerated, zero allocation.

Opt-in via the same `TensorCodecOptions.EnableCompilation` gate the other compile features use, so a single `ConfigureJitCompilation()` on the builder (landed in PR #1142) unlocks both inference AND training compilation.

Plan reference: `~/.claude/plans/lucky-waddling-knuth.md` Part C PR 2.

## Tensors-side primitives (already shipped)

- `ICompiledTrainingPlan<T>.ConfigureOptimizer(OptimizerType, lr, betas, eps, wd)` — installs a closure over the per-parameter m/v buffers and delegates to `FusedOptimizer.AdamUpdateSimd` / `AdamWUpdateSimd` / `SgdUpdateSimd`.
- `Plan.Step()` now runs fwd → bwd → optimizer update as one kernel when `ConfigureOptimizer` has been called.

## Changes

### `src/Training/CompiledTapeTrainingStep.cs` — new `TryStepWithFusedOptimizer`

Mirrors the existing `Step()` but replaces the hardcoded `UpdateParametersSGD` with `plan.ConfigureOptimizer + plan.Step`. Tracks plan identity via `[ThreadStatic] _lastConfiguredPlan` so `ConfigureOptimizer` is called EXACTLY ONCE per compiled plan — re-calling would reset Adam's m/v buffers and destroy training. Returns `bool` + `out T lossValue` so the caller can distinguish success from fallback-needed.

### `src/NeuralNetworks/NeuralNetworkBase.cs` — `TrainWithTape` fast-path preamble

`TryTrainWithFusedOptimizer()` is called first. If it returns `true` the method returns without running the eager tape path. Otherwise eager tape runs as before.

`TryMapToFusedOptimizerConfig` gates on:
- `TensorCodecOptions.Current.EnableCompilation == true`
- `typeof(T) == typeof(float)` (Tensors-side limitation — fused kernels operate on `float*` directly)
- Optimizer is `AdamOptimizer` / `AdamWOptimizer` / `StochasticGradientDescentOptimizer` with `UseAdaptiveLearningRate == false` (adaptive rates mutate hyperparameters between steps, which would reset the compiled plan's closure-captured m/v buffers)
- At least one `ITrainableLayer` participates
- `LossFunction` derives from `LossFunctionBase<T>`

Any failure short-circuits to `false`, eager tape runs instead — no correctness risk for users outside the supported configuration.

## Behavior unchanged for

- double-precision models (fall through — Tensors doesn't fuse fp64 yet)
- users with custom optimizers (Nadam, RMSprop, Lion, etc.)
- users with learning-rate schedulers or adaptive rates
- users who haven't enabled compilation

## Expected impact on supported configurations

~10-20% training throughput improvement on Adam-trained float models, primarily from eliminating the materialized gradient tensor and the separate `optimizer.Step` call's dispatch overhead. Most notable on small-batch regimes where dispatch dominates.

## Build verification

- `dotnet build src/AiDotNet.csproj --framework net10.0 -c Release`: 0 errors
- `dotnet build src/AiDotNet.csproj --framework net471 -c Release`: 0 errors

## Stacking

Independent of #1142 (JIT wiring) and #1143 (CompiledModelHost foundation) — all branch off master. They'll rebase cleanly regardless of merge order. This PR is most valuable after #1142 since `ConfigureJitCompilation()` is the one-line enable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an accelerated fused/compiled training path for float models with supported optimizers (SGD, Adam, AdamW). Training now tries the fused fast-path first and falls back to the standard tape-based flow if unavailable.
  * Early optimizer resolution before training and deduplicated parameter handling to avoid double-updating shared weights.

* **Bug Fixes**
  * Fused-path state is fully cleared on reset and when invalidated so safe recompilation can occur.
  * Fused execution now disables itself after unsupported or failed attempts and falls back reliably, with safer detection of optimizer hyperparameter drift.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->