### PR TITLE
perf: deterministic-by-default on AiModelBuilder + .AllowNondeterminism() opt-out

### DIFF
--- a/src/AiModelBuilder.cs
+++ b/src/AiModelBuilder.cs
@@ -1163,15 +1163,24 @@ public partial class AiModelBuilder<T, TInput, TOutput> : IAiModelBuilder<T, TIn
 
         // Deterministic-by-default: force bitwise-reproducible kernels unless the
         // caller opted out via AllowNondeterminism(). Applied BEFORE training +
-        // quantization + JIT compile, so every subsequent step records into the
-        // same deterministic kernel universe. Tensors' deterministic matmul
-        // (landed in #136) is no slower than the non-deterministic path, so
-        // making this the default is a category win — PyTorch's `deterministic`
-        // mode is opt-in AND slower; ours is default AND free.
-        if (!_allowNondeterminism)
-        {
-            AiDotNet.Tensors.Engines.AiDotNetEngine.SetDeterministicMode(true);
-        }
+        // quantization + JIT compile, so every subsequent SYNCHRONOUS step
+        // records into the same deterministic kernel universe. Always assert
+        // BOTH directions explicitly — if a previous build on this thread set
+        // deterministic=true and the user calls AllowNondeterminism() now,
+        // we need to actively flip it off, not just skip the set-true call.
+        // Tensors' deterministic matmul (landed in #136) is no slower than the
+        // non-deterministic path, so making this the default is a category win
+        // — PyTorch's `deterministic` mode is opt-in AND slower; ours is
+        // default AND free.
+        //
+        // Cross-await caveat: AiDotNetEngine.DeterministicMode is thread-local
+        // on the Tensors side and does NOT flow across `await` continuations —
+        // async steps resumed on a different worker thread see whatever the
+        // thread had before. AiModelResult.Predict re-asserts on every call
+        // to bridge across thread boundaries. A follow-up Tensors-side
+        // migration to AsyncLocal<T> would close this gap globally (tracked
+        // as ooples/AiDotNet.Tensors#164).
+        AiDotNet.Tensors.Engines.AiDotNetEngine.SetDeterministicMode(!_allowNondeterminism);
 
         // Validate RAG pipeline composition if any RAG components were configured
         bool hasAnyRAG = _ragRetriever != null || _ragReranker != null || _ragGenerator != null
@@ -3018,6 +3027,11 @@ public partial class AiModelBuilder<T, TInput, TOutput> : IAiModelBuilder<T, TIn
         {
             MetaLearner = _metaLearner,
             MetaTrainingResult = metaResult,
+            // Propagate determinism policy so meta-learning results re-assert
+            // the same policy as supervised/RL paths — without this, callers
+            // who opt out via AllowNondeterminism() silently get deterministic
+            // behavior back on meta-learning Predict.
+            AllowNondeterminism = _allowNondeterminism,
             LoRAConfiguration = _loraConfiguration,
             BiasDetector = _biasDetector,
             FairnessEvaluator = _fairnessEvaluator,

--- a/src/AiModelBuilder.cs
+++ b/src/AiModelBuilder.cs
@@ -184,6 +184,15 @@ public partial class AiModelBuilder<T, TInput, TOutput> : IAiModelBuilder<T, TIn
     private KnowledgeDistillationOptions<T, TInput, TOutput>? _knowledgeDistillationOptions;
     private MixedPrecisionConfig? _mixedPrecisionConfig;
     private AiDotNet.Configuration.InferenceOptimizationConfig? _inferenceOptimizationConfig;
+
+    /// <summary>
+    /// When <c>true</c>, <see cref="BuildAsync"/> does NOT force deterministic
+    /// math on the engine. Default <c>false</c> — the builder makes the model
+    /// deterministic-by-default (matches bitwise across runs) and users opt out
+    /// via <see cref="AllowNondeterminism"/> for throughput gains on workloads
+    /// where reproducibility doesn't matter.
+    /// </summary>
+    private bool _allowNondeterminism;
     private RLTrainingOptions<T>? _rlOptions;
     private IAutoMLModel<T, TInput, TOutput>? _autoMLModel;
     private AutoMLOptions<T, TInput, TOutput>? _autoMLOptions;
@@ -888,6 +897,58 @@ public partial class AiModelBuilder<T, TInput, TOutput> : IAiModelBuilder<T, TIn
         return this;
     }
 
+    /// <summary>
+    /// Opts out of the builder's deterministic-by-default policy. Call this when
+    /// you want the engine to pick the fastest available kernels even if they
+    /// produce slightly different floating-point results across runs or hardware.
+    /// </summary>
+    /// <returns>This builder for fluent chaining.</returns>
+    /// <remarks>
+    /// <para>
+    /// By default, <see cref="BuildAsync"/> calls
+    /// <c>AiDotNetEngine.SetDeterministicMode(true)</c> so every model built by
+    /// this library produces bitwise-identical results across runs on the same
+    /// hardware. This is the production-safe default — PyTorch's <c>deterministic</c>
+    /// mode is opt-in and slower than its default, so deterministic training
+    /// typically has a measurable throughput tax. AiDotNet's deterministic kernels
+    /// (landed in Tensors #136) close that gap — deterministic is free, so it's
+    /// the default.
+    /// </para>
+    /// <para>
+    /// Call this method when:
+    /// <list type="bullet">
+    /// <item>You're hyper-tuning and squeezing the last 1-3% of throughput where
+    /// kernel-order variance across runs is acceptable.</item>
+    /// <item>You're on a platform/backend where some operations haven't yet been
+    /// implemented with deterministic kernels and the fallback slows you down.</item>
+    /// </list>
+    /// </para>
+    /// <para>
+    /// <b>Do NOT call this in production serving</b> where reproducibility
+    /// matters for debugging, regression tests, or regulatory compliance.
+    /// </para>
+    /// <para>
+    /// Example:
+    /// <code>
+    /// // Deterministic by default — no action needed
+    /// var deterministic = await new AiModelBuilder&lt;float, ...&gt;()
+    ///     .ConfigureModel(myModel)
+    ///     .BuildAsync();
+    ///
+    /// // Opt out when chasing max throughput on a benchmark
+    /// var fast = await new AiModelBuilder&lt;float, ...&gt;()
+    ///     .ConfigureModel(myModel)
+    ///     .AllowNondeterminism()
+    ///     .BuildAsync();
+    /// </code>
+    /// </para>
+    /// </remarks>
+    public IAiModelBuilder<T, TInput, TOutput> AllowNondeterminism()
+    {
+        _allowNondeterminism = true;
+        return this;
+    }
+
     // Uncertainty quantification configuration lives in AiModelBuilder.UncertaintyQuantification.cs to keep this file focused.
 
     /// <summary>
@@ -1100,6 +1161,18 @@ public partial class AiModelBuilder<T, TInput, TOutput> : IAiModelBuilder<T, TIn
         // validate during serialize/deserialize operations within BuildAsync.
         using var licenseScope = Helpers.ModelPersistenceGuard.SetActiveLicenseKey(_licenseKey);
 
+        // Deterministic-by-default: force bitwise-reproducible kernels unless the
+        // caller opted out via AllowNondeterminism(). Applied BEFORE training +
+        // quantization + JIT compile, so every subsequent step records into the
+        // same deterministic kernel universe. Tensors' deterministic matmul
+        // (landed in #136) is no slower than the non-deterministic path, so
+        // making this the default is a category win — PyTorch's `deterministic`
+        // mode is opt-in AND slower; ours is default AND free.
+        if (!_allowNondeterminism)
+        {
+            AiDotNet.Tensors.Engines.AiDotNetEngine.SetDeterministicMode(true);
+        }
+
         // Validate RAG pipeline composition if any RAG components were configured
         bool hasAnyRAG = _ragRetriever != null || _ragReranker != null || _ragGenerator != null
             || _queryProcessors != null || _graphStore != null || _knowledgeGraph != null;
@@ -1242,6 +1315,7 @@ public partial class AiModelBuilder<T, TInput, TOutput> : IAiModelBuilder<T, TIn
             ProgramSynthesisServingClient = _programSynthesisServingClient,
             ProgramSynthesisServingClientOptions = _programSynthesisServingClientOptions,
             InferenceOptimizationConfig = _inferenceOptimizationConfig,
+            AllowNondeterminism = _allowNondeterminism,
             AugmentationConfig = _augmentationConfig,
             ReasoningConfig = _reasoningConfig,
             DeploymentConfiguration = deploymentConfig,
@@ -1594,6 +1668,7 @@ public partial class AiModelBuilder<T, TInput, TOutput> : IAiModelBuilder<T, TIn
             ProgramSynthesisServingClient = _programSynthesisServingClient,
             ProgramSynthesisServingClientOptions = _programSynthesisServingClientOptions,
             InferenceOptimizationConfig = _inferenceOptimizationConfig,
+            AllowNondeterminism = _allowNondeterminism,
             AugmentationConfig = _augmentationConfig,
             ReasoningConfig = _reasoningConfig,
             DeploymentConfiguration = deploymentConfig,
@@ -2786,6 +2861,7 @@ public partial class AiModelBuilder<T, TInput, TOutput> : IAiModelBuilder<T, TIn
             QuantizationInfo = quantizationInfo,
             JitCompiledFunction = null,
             InferenceOptimizationConfig = _inferenceOptimizationConfig,
+            AllowNondeterminism = _allowNondeterminism,
             AugmentationConfig = _augmentationConfig,
             ReasoningConfig = _reasoningConfig,
             KnowledgeGraph = _knowledgeGraph,
@@ -3274,6 +3350,7 @@ public partial class AiModelBuilder<T, TInput, TOutput> : IAiModelBuilder<T, TIn
             AgentConfig = _agentConfig,
             DeploymentConfiguration = deploymentConfig,
             InferenceOptimizationConfig = _inferenceOptimizationConfig,
+            AllowNondeterminism = _allowNondeterminism,
             ReasoningConfig = _reasoningConfig,
             KnowledgeGraph = _knowledgeGraph,
             GraphStore = _graphStore,

--- a/src/Interfaces/IAiModelBuilder.cs
+++ b/src/Interfaces/IAiModelBuilder.cs
@@ -1347,6 +1347,19 @@ public interface IAiModelBuilder<T, TInput, TOutput>
     IAiModelBuilder<T, TInput, TOutput> ConfigureInferenceOptimizations(AiDotNet.Configuration.InferenceOptimizationConfig? config = null);
 
     /// <summary>
+    /// Opts out of the builder's deterministic-by-default policy. By default
+    /// <see cref="BuildAsync"/> forces bitwise-reproducible kernels on the engine.
+    /// Call this to let the engine pick the fastest available kernels even if
+    /// that introduces cross-run floating-point variance.
+    /// </summary>
+    /// <returns>This builder for fluent chaining.</returns>
+    /// <remarks>
+    /// Do not call this in production serving where reproducibility matters for
+    /// debugging, regression tests, or regulatory compliance.
+    /// </remarks>
+    IAiModelBuilder<T, TInput, TOutput> AllowNondeterminism();
+
+    /// <summary>
     /// Configures mixed-precision training for faster neural network training with reduced memory usage.
     /// </summary>
     /// <param name="config">Mixed precision configuration (optional, uses defaults if null).</param>

--- a/src/Models/Options/AiModelResultOptions.cs
+++ b/src/Models/Options/AiModelResultOptions.cs
@@ -593,6 +593,14 @@ public class AiModelResultOptions<T, TInput, TOutput> : ModelOptions
     /// </remarks>
     public InferenceOptimizationConfig? InferenceOptimizationConfig { get; set; }
 
+    /// <summary>
+    /// Gets or sets the builder's determinism policy. When <c>false</c> (the
+    /// builder default), <c>AiModelResult.Predict</c> re-asserts deterministic
+    /// mode on the current thread's engine. Bridges the builder's deterministic-
+    /// by-default policy across thread boundaries (e.g., request pools).
+    /// </summary>
+    public bool AllowNondeterminism { get; set; }
+
     // ============================================================================
     // Augmentation Properties
     // ============================================================================

--- a/src/Models/Options/AiModelResultOptions.cs
+++ b/src/Models/Options/AiModelResultOptions.cs
@@ -599,6 +599,22 @@ public class AiModelResultOptions<T, TInput, TOutput> : ModelOptions
     /// mode on the current thread's engine. Bridges the builder's deterministic-
     /// by-default policy across thread boundaries (e.g., request pools).
     /// </summary>
+    /// <value>
+    /// <c>true</c> to allow the engine to pick the fastest available kernels
+    /// even when they introduce cross-run floating-point variance; <c>false</c>
+    /// (default) to enforce bitwise-reproducible kernels on every Predict.
+    /// </value>
+    /// <remarks>
+    /// <para>
+    /// <b>For Beginners:</b> Determinism means "running the same input through
+    /// the same model produces the same output, every time, on every machine."
+    /// Production systems typically want this for reproducibility — debugging,
+    /// regression tests, and regulatory audits all rely on it. Keep this
+    /// <c>false</c> (the default) unless you specifically need maximum throughput
+    /// and accept that a kernel might pick a different summation order across
+    /// runs (which can flip the last few floating-point bits of the result).
+    /// </para>
+    /// </remarks>
     public bool AllowNondeterminism { get; set; }
 
     // ============================================================================

--- a/src/Models/Results/AiModelResult.cs
+++ b/src/Models/Results/AiModelResult.cs
@@ -1823,13 +1823,12 @@ public partial class AiModelResult<T, TInput, TOutput> : IFullModel<T, TInput, T
         // Re-assert the builder's determinism policy on this thread. Engine
         // determinism state is thread-local; without this bridge a Predict on
         // a fresh request-pool worker would use whatever the thread happened
-        // to have (usually non-deterministic). Only call when the builder set
-        // AllowNondeterminism=false (the default) — otherwise we respect the
-        // caller's explicit opt-out.
-        if (!AllowNondeterminism)
-        {
-            AiDotNet.Tensors.Engines.AiDotNetEngine.SetDeterministicMode(true);
-        }
+        // to have. Always assert BOTH directions explicitly — when the user
+        // opted into AllowNondeterminism=true we need to ACTIVELY clear any
+        // previous deterministic=true left by an earlier deterministic call
+        // on the same thread; just skipping the set-true call would leak the
+        // prior policy and silently make the opt-out ineffective.
+        AiDotNet.Tensors.Engines.AiDotNetEngine.SetDeterministicMode(!AllowNondeterminism);
 
         var dataForPrediction = newData;
         if (SafetyFilter != null && newData is Vector<T> vectorInput && typeof(TInput) == typeof(Vector<T>))
@@ -2905,6 +2904,11 @@ public partial class AiModelResult<T, TInput, TOutput> : IFullModel<T, TInput, T
             DeploymentConfiguration = DeploymentConfiguration,
             // JIT compilation is parameter-specific, don't copy
             InferenceOptimizationConfig = InferenceOptimizationConfig,
+            // Propagate the determinism policy through clone paths so the
+            // copy honors the same opt-out as the original — without this,
+            // a model the user opted out via AllowNondeterminism() silently
+            // flips back to deterministic at WithParameters/DeepCopy.
+            AllowNondeterminism = AllowNondeterminism,
             ReasoningConfig = ReasoningConfig,
             KnowledgeGraph = KnowledgeGraph,
             GraphStore = GraphStore,
@@ -4642,6 +4646,11 @@ public partial class AiModelResult<T, TInput, TOutput> : IFullModel<T, TInput, T
             DeploymentConfiguration = DeploymentConfiguration,
             // JIT compilation is model-specific, don't copy
             InferenceOptimizationConfig = InferenceOptimizationConfig,
+            // Propagate the determinism policy through clone paths so the
+            // copy honors the same opt-out as the original — without this,
+            // a model the user opted out via AllowNondeterminism() silently
+            // flips back to deterministic at WithParameters/DeepCopy.
+            AllowNondeterminism = AllowNondeterminism,
             ReasoningConfig = ReasoningConfig,
             KnowledgeGraph = KnowledgeGraph,
             GraphStore = GraphStore,
@@ -4831,6 +4840,10 @@ public partial class AiModelResult<T, TInput, TOutput> : IFullModel<T, TInput, T
                 BiasDetector = deserializedObject.BiasDetector;
                 FairnessEvaluator = deserializedObject.FairnessEvaluator;
                 InferenceOptimizationConfig = deserializedObject.InferenceOptimizationConfig;
+                // Restore determinism policy so a saved-and-reloaded result
+                // keeps re-asserting on every Predict — without this assignment
+                // a model saved with AllowNondeterminism() loads as deterministic.
+                AllowNondeterminism = deserializedObject.AllowNondeterminism;
                 SerializedModelData = deserializedObject.SerializedModelData;
 
                 // Model is intentionally facade-hidden and is not serialized directly.

--- a/src/Models/Results/AiModelResult.cs
+++ b/src/Models/Results/AiModelResult.cs
@@ -641,6 +641,13 @@ public partial class AiModelResult<T, TInput, TOutput> : IFullModel<T, TInput, T
     [JsonProperty]
     private AiDotNet.Configuration.InferenceOptimizationConfig? InferenceOptimizationConfig { get; set; }
 
+    /// <summary>
+    /// Builder's determinism policy, re-asserted on every Predict to bridge the
+    /// engine's thread-local state across request-pool workers.
+    /// </summary>
+    [JsonProperty]
+    private bool AllowNondeterminism { get; set; }
+
     [JsonIgnore]
     private readonly object _inferenceOptimizationLock = new();
 
@@ -1269,6 +1276,7 @@ public partial class AiModelResult<T, TInput, TOutput> : IFullModel<T, TInput, T
         DeploymentConfiguration = options.DeploymentConfiguration;
         JitCompiledFunction = options.JitCompiledFunction;
         InferenceOptimizationConfig = options.InferenceOptimizationConfig;
+        AllowNondeterminism = options.AllowNondeterminism;
         QuantizationInfo = options.QuantizationInfo;
 
         // Layer metadata (populated if the model supports layer-level access)
@@ -1810,6 +1818,17 @@ public partial class AiModelResult<T, TInput, TOutput> : IFullModel<T, TInput, T
         if (Model == null)
         {
             throw new InvalidOperationException("Model is not initialized.");
+        }
+
+        // Re-assert the builder's determinism policy on this thread. Engine
+        // determinism state is thread-local; without this bridge a Predict on
+        // a fresh request-pool worker would use whatever the thread happened
+        // to have (usually non-deterministic). Only call when the builder set
+        // AllowNondeterminism=false (the default) — otherwise we respect the
+        // caller's explicit opt-out.
+        if (!AllowNondeterminism)
+        {
+            AiDotNet.Tensors.Engines.AiDotNetEngine.SetDeterministicMode(true);
         }
 
         var dataForPrediction = newData;


### PR DESCRIPTION
## Summary

Makes deterministic math the builder default. `BuildAsync` calls `AiDotNetEngine.SetDeterministicMode(true)` unless the caller opts out via `.AllowNondeterminism()`. `AiModelResult.Predict` re-asserts the same policy so cross-thread usage (request pools) stays deterministic too — engine determinism state is thread-local, so a fresh worker thread would otherwise see whatever the OS gave it (usually non-deterministic).

Plan reference: `~/.claude/plans/lucky-waddling-knuth.md` Part C PR 3.

## Why this is a category win vs PyTorch

PyTorch's `deterministic` mode is opt-in **and** slower. Production teams typically leave it off for training throughput, then struggle with irreproducible bugs. AiDotNet's deterministic matmul (landed in Tensors #136) is no slower than the non-deterministic path — so making it the default is a product differentiator: production builds are reproducible by default with zero perf cost. Debug sessions, regression harnesses, and regulatory-compliance audits all Just Work.

## Changes

- `src/AiModelBuilder.cs`: `_allowNondeterminism` field, `AllowNondeterminism()` fluent method, `BuildAsync` applies `SetDeterministicMode(true)` unless opt-out. Config threaded through to `AiModelResultOptions` at all 4 result-creation sites.
- `src/Interfaces/IAiModelBuilder.cs`: `AllowNondeterminism()` interface signature.
- `src/Models/Options/AiModelResultOptions.cs`: `AllowNondeterminism` slot.
- `src/Models/Results/AiModelResult.cs`: `[JsonProperty]` on `AllowNondeterminism` (survives serialization), constructor reads it, `Predict` re-asserts the engine state on entry for cross-thread correctness.

## Usage

```csharp
// Deterministic by default — no action needed
var result = await new AiModelBuilder<float, Tensor<float>, Tensor<float>>()
    .ConfigureModel(myModel)
    .BuildAsync();

// Opt out for the last 1-3% of throughput where cross-run variance is OK
var fast = await new AiModelBuilder<float, Tensor<float>, Tensor<float>>()
    .ConfigureModel(myModel)
    .AllowNondeterminism()
    .BuildAsync();
```

## Ordering note

This lands **before** the CUDA Graph scope PR on purpose — CUDA graph capture replays badly against non-deterministic kernels (different stream orderings reproduce differently), so the determinism contract needs to be locked in before the capture surface grows.

## Follow-up Tensors-side work

A separate issue on `ooples/AiDotNet.Tensors` will flip the engine's default to deterministic, plus add a `TensorCodecOptions.Deterministic` flag that participates in compile-cache keys. Once that lands, this AiDotNet-side override becomes defense-in-depth rather than the primary switch.

## Build verification

- `dotnet build src/AiDotNet.csproj --framework net10.0 -c Release`: 0 errors
- `dotnet build src/AiDotNet.csproj --framework net471 -c Release`: 0 errors

Behavior unchanged for users who explicitly call `.AllowNondeterminism()`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added AllowNondeterminism() builder option to control model execution behavior during build and prediction.
  * Models remain deterministic (bitwise-reproducible) by default for consistent results across runs and threads.
  * Users can opt out to enable faster kernels that may introduce cross-run floating-point variance.
  * The nondeterminism preference is persisted with the model configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->