### PR TITLE
feat: expose GPU diagnostics toggle via AiDotNet builder (#1122)

### DIFF
--- a/src/AiModelBuilder.cs
+++ b/src/AiModelBuilder.cs
@@ -4748,6 +4748,32 @@ public partial class AiModelBuilder<T, TInput, TOutput> : IAiModelBuilder<T, TIn
     }
 
     /// <summary>
+    /// Controls whether GPU backend diagnostic output is written to Console.
+    /// </summary>
+    /// <remarks>
+    /// Forwards to <see cref="AiDotNet.Configuration.GpuDiagnosticsConfig.Verbose"/>
+    /// which in turn forwards to the underlying Tensors-package flag. The flag
+    /// is process-global — setting it here affects every AiDotNet call in the
+    /// process. Default is <c>false</c> (quiet); env var
+    /// <c>AIDOTNET_GPU_VERBOSE=1</c> also enables it.
+    /// </remarks>
+    /// <param name="options">
+    /// The GPU-diagnostics options, or <c>null</c> to leave the current
+    /// settings unchanged. When <see cref="AiDotNet.Configuration.GpuDiagnosticsOptions.Verbose"/>
+    /// is <c>null</c>, this method is a no-op (preserves env-var / prior setting).
+    /// </param>
+    /// <returns>The builder instance for method chaining.</returns>
+    public IAiModelBuilder<T, TInput, TOutput> ConfigureGpuDiagnostics(
+        AiDotNet.Configuration.GpuDiagnosticsOptions? options = null)
+    {
+        if (options?.Verbose is bool verbose)
+        {
+            AiDotNet.Configuration.GpuDiagnosticsConfig.Verbose = verbose;
+        }
+        return this;
+    }
+
+    /// <summary>
     /// Configures benchmarking to run standardized benchmark suites and attach a structured report to the built model.
     /// </summary>
     /// <param name="options">Benchmarking options (suites, sampling, failure policy). If null, sensible defaults are used.</param>

--- a/src/AiModelBuilder.cs
+++ b/src/AiModelBuilder.cs
@@ -4748,28 +4748,44 @@ public partial class AiModelBuilder<T, TInput, TOutput> : IAiModelBuilder<T, TIn
     }
 
     /// <summary>
-    /// Controls whether GPU backend diagnostic output is written to Console.
+    /// Controls whether GPU backend diagnostic output is written to
+    /// <see cref="System.Console"/> or routed through a custom sink.
+    /// Addresses all three controls from github.com/ooples/AiDotNet#1122.
     /// </summary>
     /// <remarks>
-    /// Forwards to <see cref="AiDotNet.Configuration.GpuDiagnosticsConfig.Verbose"/>
-    /// which in turn forwards to the underlying Tensors-package flag. The flag
-    /// is process-global — setting it here affects every AiDotNet call in the
-    /// process. Default is <c>false</c> (quiet); env var
-    /// <c>AIDOTNET_GPU_VERBOSE=1</c> also enables it.
+    /// Forwards to <see cref="AiDotNet.Configuration.GpuDiagnosticsConfig"/>
+    /// which in turn forwards to the underlying Tensors-package flag. The
+    /// settings are process-global — setting here affects every AiDotNet
+    /// call in the process. <see cref="AiDotNet.Configuration.GpuDiagnosticsOptions.Level"/>
+    /// takes precedence over <see cref="AiDotNet.Configuration.GpuDiagnosticsOptions.Verbose"/>
+    /// when both are set.
     /// </remarks>
     /// <param name="options">
-    /// The GPU-diagnostics options, or <c>null</c> to leave the current
-    /// settings unchanged. When <see cref="AiDotNet.Configuration.GpuDiagnosticsOptions.Verbose"/>
-    /// is <c>null</c>, this method is a no-op (preserves env-var / prior setting).
+    /// The GPU-diagnostics options, or <c>null</c> to leave all current
+    /// settings unchanged. Each options property is nullable and only
+    /// applied when non-null (preserve semantics).
     /// </param>
     /// <returns>The builder instance for method chaining.</returns>
     public IAiModelBuilder<T, TInput, TOutput> ConfigureGpuDiagnostics(
         AiDotNet.Configuration.GpuDiagnosticsOptions? options = null)
     {
-        if (options?.Verbose is bool verbose)
+        if (options is null) return this;
+
+        // Level wins over Verbose when both set — Level is the richer API.
+        if (options.Level is AiDotNet.Configuration.GpuDiagnosticLevel level)
+        {
+            AiDotNet.Configuration.GpuDiagnosticsConfig.Level = level;
+        }
+        else if (options.Verbose is bool verbose)
         {
             AiDotNet.Configuration.GpuDiagnosticsConfig.Verbose = verbose;
         }
+
+        if (options.Sink is AiDotNet.Configuration.GpuDiagnosticSink sink)
+        {
+            AiDotNet.Configuration.GpuDiagnosticsConfig.Sink = sink;
+        }
+
         return this;
     }
 

--- a/src/Configuration/GpuDiagnosticLevel.cs
+++ b/src/Configuration/GpuDiagnosticLevel.cs
@@ -1,0 +1,54 @@
+namespace AiDotNet.Configuration;
+
+/// <summary>
+/// Verbosity level for GPU backend diagnostic output.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Addresses github.com/ooples/AiDotNet#1122. AiDotNet's GPU backends
+/// (OpenCL, HIP, CUDA) emit status messages during device discovery,
+/// kernel compilation, and availability checks. Historically these were
+/// always written to <see cref="System.Console.WriteLine"/>, producing
+/// ~40 lines of output on every <c>AiModelBuilder.BuildAsync()</c>. This
+/// enum gives applications fine-grained control over that output.
+/// </para>
+/// <para><b>For Beginners:</b> Think of this like the log level in any
+/// logging framework: <see cref="Silent"/> is OFF, <see cref="Minimal"/>
+/// is "just the important stuff", <see cref="Verbose"/> is "tell me
+/// everything".
+/// </para>
+/// </remarks>
+public enum GpuDiagnosticLevel
+{
+    /// <summary>
+    /// No GPU backend output written to Console or any sink. Use for
+    /// clean-TUI applications (Spectre.Console) or batch jobs where
+    /// diagnostic noise obscures results.
+    /// </summary>
+    Silent = 0,
+
+    /// <summary>
+    /// Only critical GPU backend output — device selected, compilation
+    /// failures, OpenCL DLL-not-found errors. Suitable for production
+    /// applications that want a one-line "GPU initialized" signal but
+    /// not the full 40-line init dump.
+    /// </summary>
+    /// <remarks>
+    /// Minimal-level filtering is fully honored only when the underlying
+    /// AiDotNet.Tensors package supports per-message level tagging. On
+    /// v0.38.0 and earlier, <see cref="Minimal"/> behaves as
+    /// <see cref="Silent"/> (any non-Verbose value suppresses all output
+    /// at the Tensors layer). The <see cref="GpuDiagnosticSink"/> sink
+    /// delegate, when registered, receives level-tagged messages once
+    /// the Tensors package honors them.
+    /// </remarks>
+    Minimal = 1,
+
+    /// <summary>
+    /// All GPU backend diagnostic output — device discovery, every kernel
+    /// compilation step, OpenCL platform queries, GEMM tuning progress.
+    /// Use when troubleshooting GPU driver/OpenCL issues or writing up
+    /// a hardware-specific bug report.
+    /// </summary>
+    Verbose = 2,
+}

--- a/src/Configuration/GpuDiagnosticSink.cs
+++ b/src/Configuration/GpuDiagnosticSink.cs
@@ -1,0 +1,38 @@
+namespace AiDotNet.Configuration;
+
+/// <summary>
+/// Delegate that receives GPU backend diagnostic messages in lieu of
+/// <see cref="System.Console.WriteLine"/>. Applications register a sink
+/// to route GPU diagnostics through their logging framework of choice
+/// (Spectre.Console, Serilog, Microsoft.Extensions.Logging, structured
+/// logs, etc.).
+/// </summary>
+/// <param name="level">
+/// The severity of the message. When an application's sink only wants
+/// to forward warnings and above, it can filter on this parameter.
+/// </param>
+/// <param name="message">The diagnostic message text.</param>
+/// <remarks>
+/// <para>
+/// Addresses Option C of github.com/ooples/AiDotNet#1122:
+/// "Use ILogger instead of Console.WriteLine — Then applications control
+/// output through their logging framework."
+/// </para>
+/// <para>
+/// Forward-compatibility: the sink is captured in
+/// <see cref="GpuDiagnosticsConfig.Sink"/> immediately. When the underlying
+/// AiDotNet.Tensors package supports sink routing (v0.39+), the diagnostic
+/// messages are delivered to the sink WITH level tagging. On current
+/// Tensors v0.38.0, the sink is stored but the Console.WriteLine calls
+/// in the Tensors layer still go to Console directly; the bool-level
+/// gate (<see cref="GpuDiagnosticsConfig.Verbose"/>) still suppresses
+/// them when <see cref="GpuDiagnosticLevel.Silent"/> or
+/// <see cref="GpuDiagnosticLevel.Minimal"/>.
+/// </para>
+/// <para>
+/// For Microsoft.Extensions.Logging integration, see
+/// <see cref="GpuDiagnosticsLoggerExtensions.ToSink(Microsoft.Extensions.Logging.ILogger)"/>
+/// which wraps an <c>ILogger</c> instance as a sink.
+/// </para>
+/// </remarks>
+public delegate void GpuDiagnosticSink(GpuDiagnosticLevel level, string message);

--- a/src/Configuration/GpuDiagnosticsConfig.cs
+++ b/src/Configuration/GpuDiagnosticsConfig.cs
@@ -1,0 +1,57 @@
+namespace AiDotNet.Configuration;
+
+/// <summary>
+/// Process-global control for GPU backend diagnostic output visibility.
+/// </summary>
+/// <remarks>
+/// <para>
+/// AiDotNet's GPU backends (OpenCL, HIP, CUDA) emit status messages during device
+/// discovery, kernel compilation, and availability checks. Historically these were
+/// always written to <see cref="System.Console.WriteLine"/>, producing ~40 lines of
+/// output on every <c>AiModelBuilder.BuildAsync()</c>. This clutters the console for
+/// applications using rich terminal UI (Spectre.Console), batch processing, or
+/// structured logging.
+/// </para>
+/// <para>
+/// Since github.com/ooples/AiDotNet#1122, applications can suppress the output
+/// discoverably via this class. Use <see cref="Verbose"/> to read or toggle the
+/// setting. The value is forwarded to <see cref="AiDotNet.Tensors.Engines.DirectGpu.OpenCL.OpenClBackend.DiagnosticOutput"/>
+/// which already existed in the Tensors package but lived on a low-level backend
+/// class with no discoverability from AiDotNet application code.
+/// </para>
+/// <para><b>For Beginners:</b> If your AI application was printing lots of messages like
+/// <c>[OpenClBackend] Compiling kernels...</c>, you can suppress them by setting
+/// <see cref="Verbose"/> to <c>false</c>. If something isn't working and you want
+/// to see what the GPU backend is doing, set it to <c>true</c>.</para>
+/// </remarks>
+/// <example>
+/// <code>
+/// // Suppress GPU diagnostics for a quiet terminal.
+/// AiDotNet.Configuration.GpuDiagnosticsConfig.Verbose = false;
+///
+/// // Restore verbose output for troubleshooting.
+/// AiDotNet.Configuration.GpuDiagnosticsConfig.Verbose = true;
+///
+/// // Read the current setting.
+/// bool isVerbose = AiDotNet.Configuration.GpuDiagnosticsConfig.Verbose;
+/// </code>
+/// </example>
+public static class GpuDiagnosticsConfig
+{
+    /// <summary>
+    /// Whether GPU backends emit verbose diagnostic output (device discovery,
+    /// kernel compilation progress, availability checks).
+    /// </summary>
+    /// <remarks>
+    /// Forwards to <see cref="AiDotNet.Tensors.Engines.DirectGpu.OpenCL.OpenClBackend.DiagnosticOutput"/>.
+    /// The initial value is read once from the <c>AIDOTNET_GPU_VERBOSE</c>
+    /// environment variable at process start: <c>false</c>/<c>0</c>/<c>no</c>/<c>off</c>
+    /// → quiet, anything else (including unset) → verbose. Programmatic
+    /// assignment overrides the env-var value for the lifetime of the process.
+    /// </remarks>
+    public static bool Verbose
+    {
+        get => AiDotNet.Tensors.Engines.DirectGpu.OpenCL.OpenClBackend.DiagnosticOutput;
+        set => AiDotNet.Tensors.Engines.DirectGpu.OpenCL.OpenClBackend.DiagnosticOutput = value;
+    }
+}

--- a/src/Configuration/GpuDiagnosticsConfig.cs
+++ b/src/Configuration/GpuDiagnosticsConfig.cs
@@ -2,56 +2,172 @@ namespace AiDotNet.Configuration;
 
 /// <summary>
 /// Process-global control for GPU backend diagnostic output visibility.
+/// Exposes three orthogonal knobs matching
+/// github.com/ooples/AiDotNet#1122's requested-change checklist:
+/// environment variable, static configuration, and ILogger / custom sink.
 /// </summary>
 /// <remarks>
 /// <para>
-/// AiDotNet's GPU backends (OpenCL, HIP, CUDA) emit status messages during device
-/// discovery, kernel compilation, and availability checks. Historically these were
-/// always written to <see cref="System.Console.WriteLine"/>, producing ~40 lines of
-/// output on every <c>AiModelBuilder.BuildAsync()</c>. This clutters the console for
-/// applications using rich terminal UI (Spectre.Console), batch processing, or
-/// structured logging.
+/// AiDotNet's GPU backends (OpenCL, HIP, CUDA) emit status messages during
+/// device discovery, kernel compilation, and availability checks.
+/// Historically these were always written to <see cref="System.Console.WriteLine"/>,
+/// producing ~40 lines of output on every <c>AiModelBuilder.BuildAsync()</c>.
+/// This class provides the AiDotNet-side facade for controlling that output.
 /// </para>
-/// <para>
-/// Since github.com/ooples/AiDotNet#1122, applications can suppress the output
-/// discoverably via this class. Use <see cref="Verbose"/> to read or toggle the
-/// setting. The value is forwarded to <see cref="AiDotNet.Tensors.Engines.DirectGpu.OpenCL.OpenClBackend.DiagnosticOutput"/>
-/// which already existed in the Tensors package but lived on a low-level backend
-/// class with no discoverability from AiDotNet application code.
-/// </para>
-/// <para><b>For Beginners:</b> If your AI application was printing lots of messages like
-/// <c>[OpenClBackend] Compiling kernels...</c>, you can suppress them by setting
-/// <see cref="Verbose"/> to <c>false</c>. If something isn't working and you want
-/// to see what the GPU backend is doing, set it to <c>true</c>.</para>
+/// <para><b>Three orthogonal controls (all work simultaneously):</b></para>
+/// <list type="number">
+/// <item><b>Environment variable</b> — <c>AIDOTNET_GPU_VERBOSE=1</c>,
+/// <c>=true</c>, or <c>=verbose</c> at process start enables
+/// <see cref="GpuDiagnosticLevel.Verbose"/>. <c>=minimal</c> sets
+/// <see cref="GpuDiagnosticLevel.Minimal"/>. Anything else (including
+/// unset) leaves the level at <see cref="GpuDiagnosticLevel.Silent"/>.</item>
+/// <item><b>Static configuration</b> — set <see cref="Level"/> to
+/// <see cref="GpuDiagnosticLevel.Silent"/>, <see cref="GpuDiagnosticLevel.Minimal"/>,
+/// or <see cref="GpuDiagnosticLevel.Verbose"/>. Assignment takes effect
+/// immediately for subsequent diagnostic emissions.</item>
+/// <item><b>Sink / ILogger</b> — assign <see cref="Sink"/> to route
+/// diagnostic messages through your logging framework instead of
+/// <see cref="System.Console"/>. See
+/// <see cref="GpuDiagnosticsLoggerExtensions.ToSink(Microsoft.Extensions.Logging.ILogger)"/>
+/// for ILogger integration.</item>
+/// </list>
 /// </remarks>
 /// <example>
 /// <code>
-/// // Suppress GPU diagnostics for a quiet terminal.
-/// AiDotNet.Configuration.GpuDiagnosticsConfig.Verbose = false;
+/// // Option A: Environment variable — set before starting the process.
+/// //   AIDOTNET_GPU_VERBOSE=1
 ///
-/// // Restore verbose output for troubleshooting.
-/// AiDotNet.Configuration.GpuDiagnosticsConfig.Verbose = true;
+/// // Option B: Static configuration
+/// AiDotNet.Configuration.GpuDiagnosticsConfig.Level = GpuDiagnosticLevel.Silent;
 ///
-/// // Read the current setting.
-/// bool isVerbose = AiDotNet.Configuration.GpuDiagnosticsConfig.Verbose;
+/// // Option C: Custom sink (route to any logging framework).
+/// AiDotNet.Configuration.GpuDiagnosticsConfig.Sink =
+///     (level, msg) => myLogger.LogInformation("[gpu:{Level}] {Msg}", level, msg);
+///
+/// // Or via ILogger extension
+/// AiDotNet.Configuration.GpuDiagnosticsConfig.Sink = myLogger.ToSink();
 /// </code>
 /// </example>
 public static class GpuDiagnosticsConfig
 {
+    private static GpuDiagnosticLevel _level = InitLevelFromEnvironment();
+    private static GpuDiagnosticSink? _sink;
+
     /// <summary>
-    /// Whether GPU backends emit verbose diagnostic output (device discovery,
-    /// kernel compilation progress, availability checks).
+    /// Current verbosity level. Reads and writes are synchronized at the
+    /// primitive-assignment level — a concurrent producer/consumer race
+    /// produces only one stale-read message, never corruption.
     /// </summary>
     /// <remarks>
-    /// Forwards to <see cref="AiDotNet.Tensors.Engines.DirectGpu.OpenCL.OpenClBackend.DiagnosticOutput"/>.
-    /// The initial value is read once from the <c>AIDOTNET_GPU_VERBOSE</c>
-    /// environment variable at process start: <c>false</c>/<c>0</c>/<c>no</c>/<c>off</c>
-    /// → quiet, anything else (including unset) → verbose. Programmatic
-    /// assignment overrides the env-var value for the lifetime of the process.
+    /// Setting <see cref="Level"/> synchronously forwards to
+    /// <see cref="AiDotNet.Tensors.Engines.DirectGpu.OpenCL.OpenClBackend.DiagnosticOutput"/>
+    /// so the underlying Tensors package honors the level on its next
+    /// diagnostic emission. <see cref="GpuDiagnosticLevel.Silent"/> and
+    /// <see cref="GpuDiagnosticLevel.Minimal"/> both map to <c>false</c>
+    /// on the current Tensors v0.38.0 (which supports bool-level only);
+    /// <see cref="GpuDiagnosticLevel.Verbose"/> maps to <c>true</c>.
+    /// </remarks>
+    public static GpuDiagnosticLevel Level
+    {
+        get => _level;
+        set
+        {
+            _level = value;
+            // Forward to Tensors layer. Silent/Minimal both suppress because
+            // Tensors v0.38.0 only has a bool toggle — it doesn't yet support
+            // per-message level tagging. Minimal-specific filtering becomes
+            // meaningful once the Tensors package adds sink-based routing.
+            AiDotNet.Tensors.Engines.DirectGpu.OpenCL.OpenClBackend.DiagnosticOutput =
+                value == GpuDiagnosticLevel.Verbose;
+        }
+    }
+
+    /// <summary>
+    /// Legacy bool flag. Kept for source compatibility with callers written
+    /// against the first iteration of this API.
+    /// <c>true</c> ≡ <see cref="GpuDiagnosticLevel.Verbose"/>;
+    /// <c>false</c> ≡ <see cref="GpuDiagnosticLevel.Silent"/>.
+    /// </summary>
+    /// <remarks>
+    /// Setting <see cref="Verbose"/> to <c>true</c> is equivalent to
+    /// <c>Level = GpuDiagnosticLevel.Verbose</c>. Setting to <c>false</c>
+    /// collapses both Silent and Minimal onto <see cref="GpuDiagnosticLevel.Silent"/> —
+    /// prefer the <see cref="Level"/> property when the distinction matters.
     /// </remarks>
     public static bool Verbose
     {
-        get => AiDotNet.Tensors.Engines.DirectGpu.OpenCL.OpenClBackend.DiagnosticOutput;
-        set => AiDotNet.Tensors.Engines.DirectGpu.OpenCL.OpenClBackend.DiagnosticOutput = value;
+        get => _level == GpuDiagnosticLevel.Verbose;
+        set => Level = value ? GpuDiagnosticLevel.Verbose : GpuDiagnosticLevel.Silent;
+    }
+
+    /// <summary>
+    /// Optional sink that receives diagnostic messages when set. When
+    /// <c>null</c>, diagnostic output goes directly to
+    /// <see cref="System.Console.WriteLine"/> at the Tensors layer.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>Forward-compatibility:</b> the sink is stored immediately, but the
+    /// Tensors v0.38.0 backend writes to Console directly. On Tensors
+    /// v0.39+ (when sink routing lands), emissions will be delivered to
+    /// the sink WITH level tagging. For now, setting a sink AND
+    /// <see cref="Level"/> = <c>Verbose</c> produces duplicate output
+    /// (Console AND future-sink invocation); combine the sink with
+    /// <see cref="Level"/> = <c>Silent</c> to route only through the sink.
+    /// </para>
+    /// <para>
+    /// For <see cref="Microsoft.Extensions.Logging.ILogger"/> integration,
+    /// use
+    /// <see cref="GpuDiagnosticsLoggerExtensions.ToSink(Microsoft.Extensions.Logging.ILogger)"/>.
+    /// </para>
+    /// </remarks>
+    public static GpuDiagnosticSink? Sink
+    {
+        get => _sink;
+        set => _sink = value;
+    }
+
+    /// <summary>
+    /// Emits a diagnostic message, respecting the current <see cref="Level"/>
+    /// and routing through <see cref="Sink"/> if set (else Console).
+    /// Callable from AiDotNet-side diagnostic code that wants to participate
+    /// in the same level/sink pipeline the Tensors-side ultimately will.
+    /// </summary>
+    /// <param name="level">
+    /// The severity of this message. Emission is suppressed when
+    /// <paramref name="level"/> is less severe than <see cref="Level"/>
+    /// (numerically lower enum value). Levels ranked Silent &lt; Minimal &lt; Verbose.
+    /// </param>
+    /// <param name="message">The diagnostic message text.</param>
+    public static void Emit(GpuDiagnosticLevel level, string message)
+    {
+        // Suppress when the active Level is more restrictive than the message's level.
+        // Silent = 0 suppresses everything (including Minimal messages).
+        // Minimal = 1 permits Minimal + Verbose? No — Minimal permits Minimal-severity
+        //   messages only. Verbose messages need level=Verbose.
+        // So emit if current level >= message level in severity (numerically >=).
+        if (_level < level) return;
+        var sink = _sink;
+        if (sink is not null)
+        {
+            sink(level, message);
+            return;
+        }
+        System.Console.WriteLine(message);
+    }
+
+    private static GpuDiagnosticLevel InitLevelFromEnvironment()
+    {
+        var val = System.Environment.GetEnvironmentVariable("AIDOTNET_GPU_VERBOSE");
+        if (string.IsNullOrWhiteSpace(val)) return GpuDiagnosticLevel.Silent;
+        if (val!.Equals("1", System.StringComparison.OrdinalIgnoreCase) ||
+            val.Equals("true", System.StringComparison.OrdinalIgnoreCase) ||
+            val.Equals("yes", System.StringComparison.OrdinalIgnoreCase) ||
+            val.Equals("on", System.StringComparison.OrdinalIgnoreCase) ||
+            val.Equals("verbose", System.StringComparison.OrdinalIgnoreCase))
+            return GpuDiagnosticLevel.Verbose;
+        if (val.Equals("minimal", System.StringComparison.OrdinalIgnoreCase))
+            return GpuDiagnosticLevel.Minimal;
+        return GpuDiagnosticLevel.Silent;
     }
 }

--- a/src/Configuration/GpuDiagnosticsLoggerExtensions.cs
+++ b/src/Configuration/GpuDiagnosticsLoggerExtensions.cs
@@ -1,0 +1,71 @@
+using System;
+using Microsoft.Extensions.Logging;
+
+namespace AiDotNet.Configuration;
+
+/// <summary>
+/// Extension methods that adapt
+/// <see cref="Microsoft.Extensions.Logging.ILogger"/> into a
+/// <see cref="GpuDiagnosticSink"/>. Addresses Option C of
+/// github.com/ooples/AiDotNet#1122:
+/// "Use ILogger instead of Console.WriteLine — Then applications control
+/// output through their logging framework."
+/// </summary>
+public static class GpuDiagnosticsLoggerExtensions
+{
+    /// <summary>
+    /// Wraps an <see cref="ILogger"/> as a
+    /// <see cref="GpuDiagnosticSink"/>, mapping
+    /// <see cref="GpuDiagnosticLevel"/> onto <see cref="Microsoft.Extensions.Logging.LogLevel"/>:
+    /// <see cref="GpuDiagnosticLevel.Silent"/> → no emission (sink
+    /// never fires when level is Silent because the level-gate
+    /// upstream drops the message),
+    /// <see cref="GpuDiagnosticLevel.Minimal"/> → <see cref="Microsoft.Extensions.Logging.LogLevel.Information"/>,
+    /// <see cref="GpuDiagnosticLevel.Verbose"/> → <see cref="Microsoft.Extensions.Logging.LogLevel.Debug"/>.
+    /// </summary>
+    /// <param name="logger">
+    /// The logger to route GPU diagnostics through. Must not be null.
+    /// </param>
+    /// <returns>
+    /// A sink delegate that can be assigned to
+    /// <see cref="GpuDiagnosticsConfig.Sink"/>.
+    /// </returns>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown when <paramref name="logger"/> is null.
+    /// </exception>
+    /// <example>
+    /// <code>
+    /// services.AddLogging();
+    /// var logger = serviceProvider.GetRequiredService&lt;ILogger&lt;MyApp&gt;&gt;();
+    /// AiDotNet.Configuration.GpuDiagnosticsConfig.Sink = logger.ToSink();
+    /// </code>
+    /// </example>
+    /// <remarks>
+    /// The mapping rationale:
+    /// <list type="bullet">
+    /// <item><see cref="GpuDiagnosticLevel.Minimal"/> is surfaced at
+    /// <see cref="Microsoft.Extensions.Logging.LogLevel.Information"/> because "GPU initialized: NVIDIA RTX"
+    /// is useful operational info — default log levels include Information,
+    /// so Minimal messages survive most filters.</item>
+    /// <item><see cref="GpuDiagnosticLevel.Verbose"/> is surfaced at
+    /// <see cref="Microsoft.Extensions.Logging.LogLevel.Debug"/> because kernel-compile progress /
+    /// GEMM-tuning dumps are implementation-detail chatter — default
+    /// log levels filter Debug, so Verbose messages only surface when
+    /// the application explicitly enables Debug logging.</item>
+    /// </list>
+    /// </remarks>
+    public static GpuDiagnosticSink ToSink(this ILogger logger)
+    {
+        if (logger is null) throw new ArgumentNullException(nameof(logger));
+        return (level, message) =>
+        {
+            Microsoft.Extensions.Logging.LogLevel logLevel = level switch
+            {
+                GpuDiagnosticLevel.Verbose => Microsoft.Extensions.Logging.LogLevel.Debug,
+                GpuDiagnosticLevel.Minimal => Microsoft.Extensions.Logging.LogLevel.Information,
+                _ => Microsoft.Extensions.Logging.LogLevel.Trace, // Silent shouldn't actually reach the sink
+            };
+            logger.Log(logLevel, message);
+        };
+    }
+}

--- a/src/Configuration/GpuDiagnosticsOptions.cs
+++ b/src/Configuration/GpuDiagnosticsOptions.cs
@@ -1,0 +1,41 @@
+namespace AiDotNet.Configuration;
+
+/// <summary>
+/// Options for controlling GPU backend diagnostic output visibility.
+/// </summary>
+/// <remarks>
+/// <para>
+/// AiDotNet's GPU backends (OpenCL, HIP, CUDA) emit status messages during
+/// device discovery, kernel compilation, and availability checks. Historically
+/// these were always written to <see cref="System.Console.WriteLine"/>,
+/// producing ~40 lines of output on every <c>AiModelBuilder.BuildAsync()</c>.
+/// This clutters the console for applications using rich terminal UI
+/// (Spectre.Console), batch processing, or structured logging.
+/// </para>
+/// <para>
+/// Since github.com/ooples/AiDotNet#1122, output is suppressed by default.
+/// Applications that want the diagnostic dump opt in either via this options
+/// class (passed to <c>AiModelBuilder.ConfigureGpuDiagnostics(...)</c>), via
+/// <see cref="GpuDiagnosticsConfig.Verbose"/> directly, or via the
+/// <c>AIDOTNET_GPU_VERBOSE</c> environment variable.
+/// </para>
+/// <para><b>For Beginners:</b> If your AI application was printing lots of
+/// <c>[OpenClBackend] Compiling kernels...</c> messages, that's now hidden by
+/// default. If you want to see them (for troubleshooting), set
+/// <see cref="Verbose"/> to <c>true</c>.</para>
+/// </remarks>
+public class GpuDiagnosticsOptions
+{
+    /// <summary>
+    /// Whether GPU backends emit verbose diagnostic output. When <c>null</c>,
+    /// the existing <see cref="GpuDiagnosticsConfig.Verbose"/> value (set by
+    /// env var or prior programmatic assignment) is preserved. Default:
+    /// <c>false</c>.
+    /// </summary>
+    /// <remarks>
+    /// Nullable to match the AiDotNet config pattern — <c>null</c> means
+    /// "don't change the current setting" rather than "set to false", so
+    /// passing an empty options instance is a no-op.
+    /// </remarks>
+    public bool? Verbose { get; set; }
+}

--- a/src/Configuration/GpuDiagnosticsOptions.cs
+++ b/src/Configuration/GpuDiagnosticsOptions.cs
@@ -13,29 +13,39 @@ namespace AiDotNet.Configuration;
 /// (Spectre.Console), batch processing, or structured logging.
 /// </para>
 /// <para>
-/// Since github.com/ooples/AiDotNet#1122, output is suppressed by default.
-/// Applications that want the diagnostic dump opt in either via this options
-/// class (passed to <c>AiModelBuilder.ConfigureGpuDiagnostics(...)</c>), via
-/// <see cref="GpuDiagnosticsConfig.Verbose"/> directly, or via the
-/// <c>AIDOTNET_GPU_VERBOSE</c> environment variable.
+/// Since github.com/ooples/AiDotNet#1122, applications can suppress the output
+/// discoverably via this options class or
+/// <see cref="GpuDiagnosticsConfig.Verbose"/>. The default behavior depends
+/// on the underlying AiDotNet.Tensors package version — as of v0.38.0 the
+/// default is verbose (on), and applications must opt out. A follow-up
+/// AiDotNet.Tensors release will flip the default to quiet; this options
+/// class is forward-compatible with that change.
 /// </para>
-/// <para><b>For Beginners:</b> If your AI application was printing lots of
-/// <c>[OpenClBackend] Compiling kernels...</c> messages, that's now hidden by
-/// default. If you want to see them (for troubleshooting), set
-/// <see cref="Verbose"/> to <c>true</c>.</para>
+/// <para>Three ways to suppress:</para>
+/// <list type="bullet">
+/// <item><c>AiModelBuilder.ConfigureGpuDiagnostics(new() { Verbose = false })</c></item>
+/// <item><c>GpuDiagnosticsConfig.Verbose = false</c> (direct)</item>
+/// <item><c>AIDOTNET_GPU_VERBOSE=0</c> environment variable</item>
+/// </list>
+/// <para><b>For Beginners:</b> If your AI application is printing lots of
+/// <c>[OpenClBackend] Compiling kernels...</c> messages, pass
+/// <c>new GpuDiagnosticsOptions { Verbose = false }</c> to the builder's
+/// <c>ConfigureGpuDiagnostics</c> method to hide them.</para>
 /// </remarks>
 public class GpuDiagnosticsOptions
 {
     /// <summary>
-    /// Whether GPU backends emit verbose diagnostic output. When <c>null</c>,
-    /// the existing <see cref="GpuDiagnosticsConfig.Verbose"/> value (set by
-    /// env var or prior programmatic assignment) is preserved. Default:
-    /// <c>false</c>.
+    /// Whether GPU backends emit verbose diagnostic output. Default:
+    /// <c>null</c> (preserve the existing process-global setting —
+    /// <see cref="GpuDiagnosticsConfig.Verbose"/>, set by env var or
+    /// prior programmatic assignment). Explicit <c>true</c> / <c>false</c>
+    /// values override it.
     /// </summary>
     /// <remarks>
     /// Nullable to match the AiDotNet config pattern — <c>null</c> means
     /// "don't change the current setting" rather than "set to false", so
-    /// passing an empty options instance is a no-op.
+    /// passing an empty options instance to
+    /// <c>AiModelBuilder.ConfigureGpuDiagnostics(...)</c> is a no-op.
     /// </remarks>
     public bool? Verbose { get; set; }
 }

--- a/src/Configuration/GpuDiagnosticsOptions.cs
+++ b/src/Configuration/GpuDiagnosticsOptions.cs
@@ -2,50 +2,78 @@ namespace AiDotNet.Configuration;
 
 /// <summary>
 /// Options for controlling GPU backend diagnostic output visibility.
+/// Addresses github.com/ooples/AiDotNet#1122 — all three requested
+/// controls (environment variable, static configuration, ILogger /
+/// custom sink) are reachable through this options class or the
+/// underlying <see cref="GpuDiagnosticsConfig"/> static facade.
 /// </summary>
 /// <remarks>
 /// <para>
 /// AiDotNet's GPU backends (OpenCL, HIP, CUDA) emit status messages during
-/// device discovery, kernel compilation, and availability checks. Historically
-/// these were always written to <see cref="System.Console.WriteLine"/>,
-/// producing ~40 lines of output on every <c>AiModelBuilder.BuildAsync()</c>.
-/// This clutters the console for applications using rich terminal UI
-/// (Spectre.Console), batch processing, or structured logging.
+/// device discovery, kernel compilation, and availability checks. This
+/// options class lets applications configure the verbosity and routing
+/// of that output via the fluent
+/// <see cref="AiDotNet.Interfaces.IAiModelBuilder{T, TInput, TOutput}.ConfigureGpuDiagnostics(GpuDiagnosticsOptions)"/>
+/// builder method.
 /// </para>
 /// <para>
-/// Since github.com/ooples/AiDotNet#1122, applications can suppress the output
-/// discoverably via this options class or
-/// <see cref="GpuDiagnosticsConfig.Verbose"/>. The default behavior depends
-/// on the underlying AiDotNet.Tensors package version — as of v0.38.0 the
-/// default is verbose (on), and applications must opt out. A follow-up
-/// AiDotNet.Tensors release will flip the default to quiet; this options
-/// class is forward-compatible with that change.
+/// All properties are nullable — <c>null</c> means "don't change the
+/// current setting", so passing an empty options instance is a no-op.
+/// This matches the AiDotNet facade pattern
+/// (<c>TelemetryConfig</c> / <c>ProfilingConfig</c>).
 /// </para>
-/// <para>Three ways to suppress:</para>
-/// <list type="bullet">
-/// <item><c>AiModelBuilder.ConfigureGpuDiagnostics(new() { Verbose = false })</c></item>
-/// <item><c>GpuDiagnosticsConfig.Verbose = false</c> (direct)</item>
-/// <item><c>AIDOTNET_GPU_VERBOSE=0</c> environment variable</item>
-/// </list>
 /// <para><b>For Beginners:</b> If your AI application is printing lots of
 /// <c>[OpenClBackend] Compiling kernels...</c> messages, pass
-/// <c>new GpuDiagnosticsOptions { Verbose = false }</c> to the builder's
-/// <c>ConfigureGpuDiagnostics</c> method to hide them.</para>
+/// <c>new GpuDiagnosticsOptions { Level = GpuDiagnosticLevel.Silent }</c>
+/// to the builder's <c>ConfigureGpuDiagnostics</c> method. If you want
+/// them routed through your logger instead, set <see cref="Sink"/>.</para>
 /// </remarks>
+/// <example>
+/// <code>
+/// // Silence all GPU diagnostics.
+/// builder.ConfigureGpuDiagnostics(new() { Level = GpuDiagnosticLevel.Silent });
+///
+/// // Verbose for troubleshooting.
+/// builder.ConfigureGpuDiagnostics(new() { Level = GpuDiagnosticLevel.Verbose });
+///
+/// // Route through an ILogger.
+/// builder.ConfigureGpuDiagnostics(new()
+/// {
+///     Level = GpuDiagnosticLevel.Minimal,
+///     Sink = logger.ToSink()
+/// });
+/// </code>
+/// </example>
 public class GpuDiagnosticsOptions
 {
     /// <summary>
-    /// Whether GPU backends emit verbose diagnostic output. Default:
-    /// <c>null</c> (preserve the existing process-global setting —
-    /// <see cref="GpuDiagnosticsConfig.Verbose"/>, set by env var or
-    /// prior programmatic assignment). Explicit <c>true</c> / <c>false</c>
-    /// values override it.
+    /// Verbosity level. <c>null</c> preserves the current
+    /// <see cref="GpuDiagnosticsConfig.Level"/> (set by env var or prior
+    /// programmatic assignment). Explicit values override.
+    /// </summary>
+    public GpuDiagnosticLevel? Level { get; set; }
+
+    /// <summary>
+    /// Optional sink that receives diagnostic messages. <c>null</c>
+    /// preserves the current <see cref="GpuDiagnosticsConfig.Sink"/>.
+    /// Pass a non-null delegate to register a custom sink (e.g.
+    /// <c>logger.ToSink()</c>); setting to <c>null</c> does NOT clear an
+    /// already-registered sink (preservation semantics). To UNREGISTER
+    /// a sink, set <see cref="GpuDiagnosticsConfig.Sink"/> directly.
+    /// </summary>
+    public GpuDiagnosticSink? Sink { get; set; }
+
+    /// <summary>
+    /// Legacy bool-level flag. Kept for source compatibility with
+    /// callers written against the first iteration of this API.
+    /// <c>true</c> ≡ <see cref="GpuDiagnosticLevel.Verbose"/>.
+    /// <c>false</c> ≡ <see cref="GpuDiagnosticLevel.Silent"/>.
+    /// <c>null</c> preserves.
     /// </summary>
     /// <remarks>
-    /// Nullable to match the AiDotNet config pattern — <c>null</c> means
-    /// "don't change the current setting" rather than "set to false", so
-    /// passing an empty options instance to
-    /// <c>AiModelBuilder.ConfigureGpuDiagnostics(...)</c> is a no-op.
+    /// When BOTH <see cref="Verbose"/> and <see cref="Level"/> are set,
+    /// <see cref="Level"/> wins — it's the richer API. Applications
+    /// should prefer <see cref="Level"/> in new code.
     /// </remarks>
     public bool? Verbose { get; set; }
 }

--- a/src/Interfaces/IAiModelBuilder.cs
+++ b/src/Interfaces/IAiModelBuilder.cs
@@ -1202,6 +1202,29 @@ public interface IAiModelBuilder<T, TInput, TOutput>
     IAiModelBuilder<T, TInput, TOutput> ConfigureTelemetry(TelemetryConfig? config = null);
 
     /// <summary>
+    /// Controls whether GPU backend diagnostic output (device discovery, kernel
+    /// compilation, availability checks) is written to <see cref="System.Console"/>.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Defaults to quiet — AiDotNet suppresses GPU init output by default as of
+    /// github.com/ooples/AiDotNet#1122. Set <see cref="AiDotNet.Configuration.GpuDiagnosticsOptions.Verbose"/>
+    /// to <c>true</c> when troubleshooting GPU driver/OpenCL issues, or
+    /// equivalently set the <c>AIDOTNET_GPU_VERBOSE=1</c> environment variable.
+    /// </para>
+    /// <para><b>For Beginners:</b> If you're building a model and want to see the
+    /// detailed GPU init messages (useful if something isn't working), call
+    /// <c>.ConfigureGpuDiagnostics(new() { Verbose = true })</c>. Otherwise leave
+    /// it alone — the library runs quietly by default.</para>
+    /// </remarks>
+    /// <param name="options">
+    /// The GPU-diagnostics options, or <c>null</c> to leave the current
+    /// settings unchanged.
+    /// </param>
+    /// <returns>The builder instance for method chaining.</returns>
+    IAiModelBuilder<T, TInput, TOutput> ConfigureGpuDiagnostics(AiDotNet.Configuration.GpuDiagnosticsOptions? options = null);
+
+    /// <summary>
     /// Configures the comprehensive safety pipeline for input validation and output filtering.
     /// </summary>
     /// <param name="configure">Action to configure safety settings. If null, safety is enabled with defaults.</param>

--- a/src/Interfaces/IAiModelBuilder.cs
+++ b/src/Interfaces/IAiModelBuilder.cs
@@ -1202,34 +1202,43 @@ public interface IAiModelBuilder<T, TInput, TOutput>
     IAiModelBuilder<T, TInput, TOutput> ConfigureTelemetry(TelemetryConfig? config = null);
 
     /// <summary>
-    /// Controls whether GPU backend diagnostic output (device discovery, kernel
-    /// compilation, availability checks) is written to <see cref="System.Console"/>.
+    /// Controls GPU backend diagnostic output visibility and routing.
+    /// Exposes all three controls from github.com/ooples/AiDotNet#1122:
+    /// verbosity level, environment variable, and ILogger/custom sink.
     /// </summary>
     /// <remarks>
     /// <para>
-    /// The default-behavior depends on the consumed AiDotNet.Tensors version —
-    /// v0.38.0 defaults to verbose (output on) and requires explicit opt-out.
-    /// Set <see cref="AiDotNet.Configuration.GpuDiagnosticsOptions.Verbose"/>
-    /// to <c>false</c> to silence, or to <c>true</c> to re-enable (or set
-    /// the <c>AIDOTNET_GPU_VERBOSE</c> environment variable).
+    /// AiDotNet's GPU backends (OpenCL, HIP, CUDA) emit status messages
+    /// during device discovery, kernel compilation, and availability checks.
+    /// This method is the fluent entry point for all three
+    /// configuration approaches:
     /// </para>
-    /// <para>
-    /// See github.com/ooples/AiDotNet#1122. This method exposes the existing
-    /// Tensors-package flag via a discoverable AiDotNet-side facade so
-    /// applications don't need to reach into
-    /// <c>OpenClBackend.DiagnosticOutput</c> directly.
-    /// </para>
+    /// <list type="bullet">
+    /// <item><b>Level</b> —
+    /// <see cref="AiDotNet.Configuration.GpuDiagnosticsOptions.Level"/>
+    /// sets <see cref="AiDotNet.Configuration.GpuDiagnosticLevel.Silent"/>,
+    /// <see cref="AiDotNet.Configuration.GpuDiagnosticLevel.Minimal"/>, or
+    /// <see cref="AiDotNet.Configuration.GpuDiagnosticLevel.Verbose"/>.</item>
+    /// <item><b>Environment variable</b> — <c>AIDOTNET_GPU_VERBOSE=1</c>,
+    /// <c>=verbose</c>, or <c>=minimal</c> seeds the initial level at
+    /// process start.</item>
+    /// <item><b>Sink</b> —
+    /// <see cref="AiDotNet.Configuration.GpuDiagnosticsOptions.Sink"/>
+    /// routes diagnostic messages through a custom delegate. Use
+    /// <c>logger.ToSink()</c> (from
+    /// <see cref="AiDotNet.Configuration.GpuDiagnosticsLoggerExtensions"/>)
+    /// to wrap a <see cref="Microsoft.Extensions.Logging.ILogger"/>.</item>
+    /// </list>
     /// <para><b>For Beginners:</b> If your AI application is printing lots of
     /// <c>[OpenClBackend]</c> status messages, call
-    /// <c>.ConfigureGpuDiagnostics(new() { Verbose = false })</c> to silence
-    /// them. If something isn't working and you want more info, call it with
-    /// <c>Verbose = true</c>.</para>
+    /// <c>.ConfigureGpuDiagnostics(new() { Level = GpuDiagnosticLevel.Silent })</c>
+    /// to silence them. To route through your own logging framework, set
+    /// <see cref="AiDotNet.Configuration.GpuDiagnosticsOptions.Sink"/>.</para>
     /// </remarks>
     /// <param name="options">
-    /// The GPU-diagnostics options, or <c>null</c> to leave the current
-    /// settings unchanged. When
-    /// <see cref="AiDotNet.Configuration.GpuDiagnosticsOptions.Verbose"/>
-    /// is <c>null</c>, this method is a no-op.
+    /// The GPU-diagnostics options, or <c>null</c> to leave all current
+    /// settings unchanged. Each options property is nullable and only
+    /// applied when non-null (preserve semantics).
     /// </param>
     /// <returns>The builder instance for method chaining.</returns>
     IAiModelBuilder<T, TInput, TOutput> ConfigureGpuDiagnostics(AiDotNet.Configuration.GpuDiagnosticsOptions? options = null);

--- a/src/Interfaces/IAiModelBuilder.cs
+++ b/src/Interfaces/IAiModelBuilder.cs
@@ -1207,19 +1207,29 @@ public interface IAiModelBuilder<T, TInput, TOutput>
     /// </summary>
     /// <remarks>
     /// <para>
-    /// Defaults to quiet — AiDotNet suppresses GPU init output by default as of
-    /// github.com/ooples/AiDotNet#1122. Set <see cref="AiDotNet.Configuration.GpuDiagnosticsOptions.Verbose"/>
-    /// to <c>true</c> when troubleshooting GPU driver/OpenCL issues, or
-    /// equivalently set the <c>AIDOTNET_GPU_VERBOSE=1</c> environment variable.
+    /// The default-behavior depends on the consumed AiDotNet.Tensors version —
+    /// v0.38.0 defaults to verbose (output on) and requires explicit opt-out.
+    /// Set <see cref="AiDotNet.Configuration.GpuDiagnosticsOptions.Verbose"/>
+    /// to <c>false</c> to silence, or to <c>true</c> to re-enable (or set
+    /// the <c>AIDOTNET_GPU_VERBOSE</c> environment variable).
     /// </para>
-    /// <para><b>For Beginners:</b> If you're building a model and want to see the
-    /// detailed GPU init messages (useful if something isn't working), call
-    /// <c>.ConfigureGpuDiagnostics(new() { Verbose = true })</c>. Otherwise leave
-    /// it alone — the library runs quietly by default.</para>
+    /// <para>
+    /// See github.com/ooples/AiDotNet#1122. This method exposes the existing
+    /// Tensors-package flag via a discoverable AiDotNet-side facade so
+    /// applications don't need to reach into
+    /// <c>OpenClBackend.DiagnosticOutput</c> directly.
+    /// </para>
+    /// <para><b>For Beginners:</b> If your AI application is printing lots of
+    /// <c>[OpenClBackend]</c> status messages, call
+    /// <c>.ConfigureGpuDiagnostics(new() { Verbose = false })</c> to silence
+    /// them. If something isn't working and you want more info, call it with
+    /// <c>Verbose = true</c>.</para>
     /// </remarks>
     /// <param name="options">
     /// The GPU-diagnostics options, or <c>null</c> to leave the current
-    /// settings unchanged.
+    /// settings unchanged. When
+    /// <see cref="AiDotNet.Configuration.GpuDiagnosticsOptions.Verbose"/>
+    /// is <c>null</c>, this method is a no-op.
     /// </param>
     /// <returns>The builder instance for method chaining.</returns>
     IAiModelBuilder<T, TInput, TOutput> ConfigureGpuDiagnostics(AiDotNet.Configuration.GpuDiagnosticsOptions? options = null);

--- a/tests/AiDotNet.Tests/UnitTests/Configuration/GpuDiagnosticsConfigTests.cs
+++ b/tests/AiDotNet.Tests/UnitTests/Configuration/GpuDiagnosticsConfigTests.cs
@@ -1,20 +1,25 @@
+using System;
 using AiDotNet.Configuration;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
 
 namespace AiDotNet.Tests.UnitTests.Configuration;
 
 /// <summary>
-/// Unit tests for <see cref="GpuDiagnosticsConfig"/> and <see cref="GpuDiagnosticsOptions"/> —
-/// the discoverable AiDotNet facade over the Tensors-package GPU diagnostic flag.
-/// Verifies the round-trip read/write contract and the
-/// <c>ConfigureGpuDiagnostics</c> builder forwarder behavior.
+/// Unit tests for <see cref="GpuDiagnosticsConfig"/>,
+/// <see cref="GpuDiagnosticsOptions"/>, and
+/// <see cref="GpuDiagnosticsLoggerExtensions"/> — the discoverable
+/// AiDotNet facade over the Tensors-package GPU diagnostic flag, covering
+/// all three controls requested by github.com/ooples/AiDotNet#1122
+/// (env var, static config, ILogger/sink).
 /// </summary>
 /// <remarks>
-/// These tests mutate a process-global setting
-/// (<see cref="AiDotNet.Tensors.Engines.DirectGpu.OpenCL.OpenClBackend.DiagnosticOutput"/>),
-/// so they save and restore the original value in try/finally blocks. No parallel
-/// execution issues arise because the tests only assert their own writes, never
-/// the ambient state.
+/// These tests mutate process-global settings (<c>GpuDiagnosticsConfig.Level</c>
+/// and <c>GpuDiagnosticsConfig.Sink</c>, both of which forward to the
+/// Tensors-package flag), so they save and restore the original values
+/// in try/finally blocks. No parallel execution issues arise because the
+/// tests only assert their own writes, never the ambient state.
 /// </remarks>
 public class GpuDiagnosticsConfigTests
 {
@@ -27,115 +32,315 @@ public class GpuDiagnosticsConfigTests
     [Fact]
     public void Verbose_RoundTripsThroughUnderlyingFlag()
     {
-        var original = GpuDiagnosticsConfig.Verbose;
+        var original = GpuDiagnosticsConfig.Level;
         try
         {
             GpuDiagnosticsConfig.Verbose = true;
             Assert.True(GpuDiagnosticsConfig.Verbose);
+            Assert.Equal(GpuDiagnosticLevel.Verbose, GpuDiagnosticsConfig.Level);
             Assert.True(AiDotNet.Tensors.Engines.DirectGpu.OpenCL.OpenClBackend.DiagnosticOutput);
 
             GpuDiagnosticsConfig.Verbose = false;
             Assert.False(GpuDiagnosticsConfig.Verbose);
+            Assert.Equal(GpuDiagnosticLevel.Silent, GpuDiagnosticsConfig.Level);
             Assert.False(AiDotNet.Tensors.Engines.DirectGpu.OpenCL.OpenClBackend.DiagnosticOutput);
         }
         finally
         {
-            GpuDiagnosticsConfig.Verbose = original;
+            GpuDiagnosticsConfig.Level = original;
         }
     }
 
     /// <summary>
-    /// Verifies that setting the underlying Tensors flag directly is visible
-    /// via the AiDotNet facade — the forwarder is bidirectional. Applications
-    /// that already call into the low-level Tensors API continue to work.
-    /// </summary>
-    [Fact]
-    public void Verbose_ReflectsUnderlyingTensorsFlag()
-    {
-        var original = AiDotNet.Tensors.Engines.DirectGpu.OpenCL.OpenClBackend.DiagnosticOutput;
-        try
-        {
-            AiDotNet.Tensors.Engines.DirectGpu.OpenCL.OpenClBackend.DiagnosticOutput = true;
-            Assert.True(GpuDiagnosticsConfig.Verbose);
-
-            AiDotNet.Tensors.Engines.DirectGpu.OpenCL.OpenClBackend.DiagnosticOutput = false;
-            Assert.False(GpuDiagnosticsConfig.Verbose);
-        }
-        finally
-        {
-            AiDotNet.Tensors.Engines.DirectGpu.OpenCL.OpenClBackend.DiagnosticOutput = original;
-        }
-    }
-
-    /// <summary>
-    /// Options with <see cref="GpuDiagnosticsOptions.Verbose"/> = <c>null</c>
-    /// must leave the current setting unchanged (a "don't-care" signal).
-    /// Important because users might configure some GPU options without
-    /// wanting to override the verbose state.
-    /// </summary>
-    [Fact]
-    public void Options_NullVerbose_PreservesExistingSetting()
-    {
-        var original = GpuDiagnosticsConfig.Verbose;
-        try
-        {
-            GpuDiagnosticsConfig.Verbose = true;
-
-            // Simulate the builder applying null-Verbose options.
-            var options = new GpuDiagnosticsOptions { Verbose = null };
-            if (options.Verbose is bool v)
-            {
-                GpuDiagnosticsConfig.Verbose = v;
-            }
-            // Above branch must not fire.
-            Assert.True(GpuDiagnosticsConfig.Verbose,
-                "null Verbose must not overwrite the existing process-global setting");
-        }
-        finally
-        {
-            GpuDiagnosticsConfig.Verbose = original;
-        }
-    }
-
-    /// <summary>
-    /// Options with explicit <see cref="GpuDiagnosticsOptions.Verbose"/> = <c>true</c>
-    /// or <c>false</c> must apply to the process-global flag. Verifies the
-    /// nullable-unwrap semantic.
+    /// Level property must round-trip all three enum values and correctly
+    /// forward to the bool-level Tensors flag.
     /// </summary>
     [Theory]
-    [InlineData(true)]
-    [InlineData(false)]
-    public void Options_ExplicitVerbose_AppliesToFlag(bool expected)
+    [InlineData(GpuDiagnosticLevel.Silent, false)]
+    [InlineData(GpuDiagnosticLevel.Minimal, false)] // Minimal maps to false on Tensors v0.38.0 bool toggle
+    [InlineData(GpuDiagnosticLevel.Verbose, true)]
+    public void Level_RoundTripsAndForwardsToTensorsFlag(GpuDiagnosticLevel level, bool expectedTensorsFlag)
     {
-        var original = GpuDiagnosticsConfig.Verbose;
+        var original = GpuDiagnosticsConfig.Level;
         try
         {
-            GpuDiagnosticsConfig.Verbose = !expected; // start at opposite
-
-            var options = new GpuDiagnosticsOptions { Verbose = expected };
-            if (options.Verbose is bool v)
-            {
-                GpuDiagnosticsConfig.Verbose = v;
-            }
-
-            Assert.Equal(expected, GpuDiagnosticsConfig.Verbose);
+            GpuDiagnosticsConfig.Level = level;
+            Assert.Equal(level, GpuDiagnosticsConfig.Level);
+            Assert.Equal(expectedTensorsFlag, AiDotNet.Tensors.Engines.DirectGpu.OpenCL.OpenClBackend.DiagnosticOutput);
         }
         finally
         {
-            GpuDiagnosticsConfig.Verbose = original;
+            GpuDiagnosticsConfig.Level = original;
         }
     }
 
     /// <summary>
-    /// Default-constructed <see cref="GpuDiagnosticsOptions"/> has null Verbose —
-    /// ensures the "no-op when no property is set" invariant. A user who writes
-    /// <c>new GpuDiagnosticsOptions()</c> without setting anything should not
-    /// accidentally mutate process state.
+    /// The AiDotNet <see cref="GpuDiagnosticsConfig"/> facade is now
+    /// authoritative — Level/Verbose writes forward to the Tensors flag,
+    /// but direct Tensors-flag writes do NOT update the cached Level
+    /// (otherwise the Silent/Minimal distinction would be lost on any
+    /// external write). Applications should prefer
+    /// <see cref="GpuDiagnosticsConfig.Level"/> over direct
+    /// <c>OpenClBackend.DiagnosticOutput</c> writes.
     /// </summary>
     [Fact]
-    public void Options_DefaultConstructor_HasNullVerbose()
+    public void TensorsFlag_WriteDoesNotOverwriteLocalLevel_ByDesign()
     {
-        var options = new GpuDiagnosticsOptions();
-        Assert.Null(options.Verbose);
+        var originalLevel = GpuDiagnosticsConfig.Level;
+        try
+        {
+            GpuDiagnosticsConfig.Level = GpuDiagnosticLevel.Minimal;
+            // Minimal maps to Tensors.DiagnosticOutput = false.
+            Assert.False(AiDotNet.Tensors.Engines.DirectGpu.OpenCL.OpenClBackend.DiagnosticOutput);
+
+            // External write to Tensors flag — AiDotNet Level should NOT change;
+            // preserving Minimal vs Silent is the feature.
+            AiDotNet.Tensors.Engines.DirectGpu.OpenCL.OpenClBackend.DiagnosticOutput = true;
+            Assert.Equal(GpuDiagnosticLevel.Minimal, GpuDiagnosticsConfig.Level);
+        }
+        finally
+        {
+            GpuDiagnosticsConfig.Level = originalLevel;
+        }
+    }
+
+    /// <summary>
+    /// Sink delegate must be storable and retrievable — the AiDotNet side
+    /// captures the sink immediately even before the Tensors side honors it.
+    /// </summary>
+    [Fact]
+    public void Sink_RoundTripsAndCanBeCleared()
+    {
+        var originalSink = GpuDiagnosticsConfig.Sink;
+        try
+        {
+            int callCount = 0;
+            GpuDiagnosticSink mySink = (_, _) => callCount++;
+            GpuDiagnosticsConfig.Sink = mySink;
+            Assert.Same(mySink, GpuDiagnosticsConfig.Sink);
+
+            GpuDiagnosticsConfig.Sink = null;
+            Assert.Null(GpuDiagnosticsConfig.Sink);
+        }
+        finally
+        {
+            GpuDiagnosticsConfig.Sink = originalSink;
+        }
+    }
+
+    /// <summary>
+    /// Emit() must call the sink with the correct level and message when
+    /// the active Level permits it; must suppress when the Level is more
+    /// restrictive than the message's level.
+    /// </summary>
+    [Fact]
+    public void Emit_RoutesToSinkWhenSetAndLevelPermits()
+    {
+        var originalLevel = GpuDiagnosticsConfig.Level;
+        var originalSink = GpuDiagnosticsConfig.Sink;
+        try
+        {
+            var received = new System.Collections.Generic.List<(GpuDiagnosticLevel, string)>();
+            GpuDiagnosticsConfig.Sink = (level, msg) => received.Add((level, msg));
+
+            // Level = Verbose permits all messages.
+            GpuDiagnosticsConfig.Level = GpuDiagnosticLevel.Verbose;
+            GpuDiagnosticsConfig.Emit(GpuDiagnosticLevel.Minimal, "minimal msg");
+            GpuDiagnosticsConfig.Emit(GpuDiagnosticLevel.Verbose, "verbose msg");
+            Assert.Equal(2, received.Count);
+            Assert.Equal((GpuDiagnosticLevel.Minimal, "minimal msg"), received[0]);
+            Assert.Equal((GpuDiagnosticLevel.Verbose, "verbose msg"), received[1]);
+
+            // Level = Minimal permits Minimal but not Verbose.
+            received.Clear();
+            GpuDiagnosticsConfig.Level = GpuDiagnosticLevel.Minimal;
+            GpuDiagnosticsConfig.Emit(GpuDiagnosticLevel.Minimal, "minimal msg");
+            GpuDiagnosticsConfig.Emit(GpuDiagnosticLevel.Verbose, "verbose msg");
+            Assert.Single(received);
+            Assert.Equal("minimal msg", received[0].Item2);
+
+            // Level = Silent suppresses everything.
+            received.Clear();
+            GpuDiagnosticsConfig.Level = GpuDiagnosticLevel.Silent;
+            GpuDiagnosticsConfig.Emit(GpuDiagnosticLevel.Minimal, "minimal msg");
+            GpuDiagnosticsConfig.Emit(GpuDiagnosticLevel.Verbose, "verbose msg");
+            Assert.Empty(received);
+        }
+        finally
+        {
+            GpuDiagnosticsConfig.Sink = originalSink;
+            GpuDiagnosticsConfig.Level = originalLevel;
+        }
+    }
+
+    /// <summary>
+    /// Options with all-null properties must leave current settings
+    /// unchanged (preserve semantics).
+    /// </summary>
+    [Fact]
+    public void Options_AllNull_PreservesExistingSettings()
+    {
+        var originalLevel = GpuDiagnosticsConfig.Level;
+        var originalSink = GpuDiagnosticsConfig.Sink;
+        try
+        {
+            GpuDiagnosticsConfig.Level = GpuDiagnosticLevel.Verbose;
+            GpuDiagnosticSink mySink = (_, _) => { };
+            GpuDiagnosticsConfig.Sink = mySink;
+
+            // Simulate builder applying all-null options.
+            var options = new GpuDiagnosticsOptions();
+            ApplyOptions(options);
+
+            Assert.Equal(GpuDiagnosticLevel.Verbose, GpuDiagnosticsConfig.Level);
+            Assert.Same(mySink, GpuDiagnosticsConfig.Sink);
+        }
+        finally
+        {
+            GpuDiagnosticsConfig.Sink = originalSink;
+            GpuDiagnosticsConfig.Level = originalLevel;
+        }
+    }
+
+    /// <summary>
+    /// Options.Level wins over Options.Verbose when both are set — Level is
+    /// the richer API. Catches a regression where the Verbose path shadows
+    /// the Level path.
+    /// </summary>
+    [Fact]
+    public void Options_LevelWinsOverVerbose_WhenBothSet()
+    {
+        var originalLevel = GpuDiagnosticsConfig.Level;
+        try
+        {
+            GpuDiagnosticsConfig.Level = GpuDiagnosticLevel.Silent;
+
+            // Both set: Level says Minimal, Verbose says true (which alone would set Verbose).
+            var options = new GpuDiagnosticsOptions
+            {
+                Level = GpuDiagnosticLevel.Minimal,
+                Verbose = true,
+            };
+            ApplyOptions(options);
+
+            Assert.Equal(GpuDiagnosticLevel.Minimal, GpuDiagnosticsConfig.Level);
+        }
+        finally
+        {
+            GpuDiagnosticsConfig.Level = originalLevel;
+        }
+    }
+
+    /// <summary>
+    /// ILogger.ToSink() returns a sink that invokes the logger with
+    /// level-mapped <see cref="Microsoft.Extensions.Logging.LogLevel"/>.
+    /// Verbose → Debug, Minimal → Information.
+    /// </summary>
+    [Fact]
+    public void LoggerToSink_RoutesWithCorrectLogLevel()
+    {
+        var recorded = new System.Collections.Generic.List<(Microsoft.Extensions.Logging.LogLevel, string)>();
+        var logger = new RecordingLogger(recorded);
+
+        var sink = logger.ToSink();
+
+        sink(GpuDiagnosticLevel.Verbose, "verbose msg");
+        sink(GpuDiagnosticLevel.Minimal, "minimal msg");
+
+        Assert.Equal(2, recorded.Count);
+        Assert.Equal(Microsoft.Extensions.Logging.LogLevel.Debug, recorded[0].Item1);
+        Assert.Equal("verbose msg", recorded[0].Item2);
+        Assert.Equal(Microsoft.Extensions.Logging.LogLevel.Information, recorded[1].Item1);
+        Assert.Equal("minimal msg", recorded[1].Item2);
+    }
+
+    /// <summary>
+    /// ILogger.ToSink() throws ArgumentNullException on null logger.
+    /// Fail-fast rather than returning a null sink that'd NRE later.
+    /// </summary>
+    [Fact]
+    public void LoggerToSink_ThrowsOnNullLogger()
+    {
+        ILogger? logger = null;
+        Assert.Throws<ArgumentNullException>(() => logger!.ToSink());
+    }
+
+    /// <summary>
+    /// End-to-end: builder-style options application with sink +
+    /// Minimal level + an ILogger adapter.
+    /// </summary>
+    [Fact]
+    public void EndToEnd_BuilderApplyOptions_WithLoggerSink()
+    {
+        var originalLevel = GpuDiagnosticsConfig.Level;
+        var originalSink = GpuDiagnosticsConfig.Sink;
+        try
+        {
+            var recorded = new System.Collections.Generic.List<(Microsoft.Extensions.Logging.LogLevel, string)>();
+            var logger = new RecordingLogger(recorded);
+
+            var options = new GpuDiagnosticsOptions
+            {
+                Level = GpuDiagnosticLevel.Minimal,
+                Sink = logger.ToSink(),
+            };
+            ApplyOptions(options);
+
+            Assert.Equal(GpuDiagnosticLevel.Minimal, GpuDiagnosticsConfig.Level);
+            Assert.NotNull(GpuDiagnosticsConfig.Sink);
+
+            // Emit — Verbose message should be suppressed by Minimal level;
+            // Minimal message should reach the logger as Information.
+            GpuDiagnosticsConfig.Emit(GpuDiagnosticLevel.Minimal, "gpu ready");
+            GpuDiagnosticsConfig.Emit(GpuDiagnosticLevel.Verbose, "compiling kernels");
+
+            Assert.Single(recorded);
+            Assert.Equal(Microsoft.Extensions.Logging.LogLevel.Information, recorded[0].Item1);
+            Assert.Equal("gpu ready", recorded[0].Item2);
+        }
+        finally
+        {
+            GpuDiagnosticsConfig.Sink = originalSink;
+            GpuDiagnosticsConfig.Level = originalLevel;
+        }
+    }
+
+    // Mirrors the builder's ConfigureGpuDiagnostics body.
+    private static void ApplyOptions(GpuDiagnosticsOptions? options)
+    {
+        if (options is null) return;
+
+        if (options.Level is GpuDiagnosticLevel level)
+        {
+            GpuDiagnosticsConfig.Level = level;
+        }
+        else if (options.Verbose is bool verbose)
+        {
+            GpuDiagnosticsConfig.Verbose = verbose;
+        }
+
+        if (options.Sink is GpuDiagnosticSink sink)
+        {
+            GpuDiagnosticsConfig.Sink = sink;
+        }
+    }
+
+    /// <summary>Minimal ILogger implementation that records Log calls.</summary>
+    private sealed class RecordingLogger : ILogger
+    {
+        private readonly System.Collections.Generic.List<(Microsoft.Extensions.Logging.LogLevel, string)> _recorded;
+
+        public RecordingLogger(System.Collections.Generic.List<(Microsoft.Extensions.Logging.LogLevel, string)> recorded)
+        {
+            _recorded = recorded;
+        }
+
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+        public bool IsEnabled(Microsoft.Extensions.Logging.LogLevel logLevel) => true;
+        public void Log<TState>(Microsoft.Extensions.Logging.LogLevel logLevel, EventId eventId, TState state,
+            Exception? exception, Func<TState, Exception?, string> formatter)
+        {
+            _recorded.Add((logLevel, formatter(state, exception)));
+        }
     }
 }

--- a/tests/AiDotNet.Tests/UnitTests/Configuration/GpuDiagnosticsConfigTests.cs
+++ b/tests/AiDotNet.Tests/UnitTests/Configuration/GpuDiagnosticsConfigTests.cs
@@ -1,0 +1,141 @@
+using AiDotNet.Configuration;
+using Xunit;
+
+namespace AiDotNet.Tests.UnitTests.Configuration;
+
+/// <summary>
+/// Unit tests for <see cref="GpuDiagnosticsConfig"/> and <see cref="GpuDiagnosticsOptions"/> —
+/// the discoverable AiDotNet facade over the Tensors-package GPU diagnostic flag.
+/// Verifies the round-trip read/write contract and the
+/// <c>ConfigureGpuDiagnostics</c> builder forwarder behavior.
+/// </summary>
+/// <remarks>
+/// These tests mutate a process-global setting
+/// (<see cref="AiDotNet.Tensors.Engines.DirectGpu.OpenCL.OpenClBackend.DiagnosticOutput"/>),
+/// so they save and restore the original value in try/finally blocks. No parallel
+/// execution issues arise because the tests only assert their own writes, never
+/// the ambient state.
+/// </remarks>
+public class GpuDiagnosticsConfigTests
+{
+    /// <summary>
+    /// The Verbose property must round-trip through the underlying Tensors flag:
+    /// writing <c>true</c> then reading must return <c>true</c>; same for <c>false</c>.
+    /// Catches a regression where the forwarder accidentally short-circuits or
+    /// routes to a different static field.
+    /// </summary>
+    [Fact]
+    public void Verbose_RoundTripsThroughUnderlyingFlag()
+    {
+        var original = GpuDiagnosticsConfig.Verbose;
+        try
+        {
+            GpuDiagnosticsConfig.Verbose = true;
+            Assert.True(GpuDiagnosticsConfig.Verbose);
+            Assert.True(AiDotNet.Tensors.Engines.DirectGpu.OpenCL.OpenClBackend.DiagnosticOutput);
+
+            GpuDiagnosticsConfig.Verbose = false;
+            Assert.False(GpuDiagnosticsConfig.Verbose);
+            Assert.False(AiDotNet.Tensors.Engines.DirectGpu.OpenCL.OpenClBackend.DiagnosticOutput);
+        }
+        finally
+        {
+            GpuDiagnosticsConfig.Verbose = original;
+        }
+    }
+
+    /// <summary>
+    /// Verifies that setting the underlying Tensors flag directly is visible
+    /// via the AiDotNet facade — the forwarder is bidirectional. Applications
+    /// that already call into the low-level Tensors API continue to work.
+    /// </summary>
+    [Fact]
+    public void Verbose_ReflectsUnderlyingTensorsFlag()
+    {
+        var original = AiDotNet.Tensors.Engines.DirectGpu.OpenCL.OpenClBackend.DiagnosticOutput;
+        try
+        {
+            AiDotNet.Tensors.Engines.DirectGpu.OpenCL.OpenClBackend.DiagnosticOutput = true;
+            Assert.True(GpuDiagnosticsConfig.Verbose);
+
+            AiDotNet.Tensors.Engines.DirectGpu.OpenCL.OpenClBackend.DiagnosticOutput = false;
+            Assert.False(GpuDiagnosticsConfig.Verbose);
+        }
+        finally
+        {
+            AiDotNet.Tensors.Engines.DirectGpu.OpenCL.OpenClBackend.DiagnosticOutput = original;
+        }
+    }
+
+    /// <summary>
+    /// Options with <see cref="GpuDiagnosticsOptions.Verbose"/> = <c>null</c>
+    /// must leave the current setting unchanged (a "don't-care" signal).
+    /// Important because users might configure some GPU options without
+    /// wanting to override the verbose state.
+    /// </summary>
+    [Fact]
+    public void Options_NullVerbose_PreservesExistingSetting()
+    {
+        var original = GpuDiagnosticsConfig.Verbose;
+        try
+        {
+            GpuDiagnosticsConfig.Verbose = true;
+
+            // Simulate the builder applying null-Verbose options.
+            var options = new GpuDiagnosticsOptions { Verbose = null };
+            if (options.Verbose is bool v)
+            {
+                GpuDiagnosticsConfig.Verbose = v;
+            }
+            // Above branch must not fire.
+            Assert.True(GpuDiagnosticsConfig.Verbose,
+                "null Verbose must not overwrite the existing process-global setting");
+        }
+        finally
+        {
+            GpuDiagnosticsConfig.Verbose = original;
+        }
+    }
+
+    /// <summary>
+    /// Options with explicit <see cref="GpuDiagnosticsOptions.Verbose"/> = <c>true</c>
+    /// or <c>false</c> must apply to the process-global flag. Verifies the
+    /// nullable-unwrap semantic.
+    /// </summary>
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void Options_ExplicitVerbose_AppliesToFlag(bool expected)
+    {
+        var original = GpuDiagnosticsConfig.Verbose;
+        try
+        {
+            GpuDiagnosticsConfig.Verbose = !expected; // start at opposite
+
+            var options = new GpuDiagnosticsOptions { Verbose = expected };
+            if (options.Verbose is bool v)
+            {
+                GpuDiagnosticsConfig.Verbose = v;
+            }
+
+            Assert.Equal(expected, GpuDiagnosticsConfig.Verbose);
+        }
+        finally
+        {
+            GpuDiagnosticsConfig.Verbose = original;
+        }
+    }
+
+    /// <summary>
+    /// Default-constructed <see cref="GpuDiagnosticsOptions"/> has null Verbose —
+    /// ensures the "no-op when no property is set" invariant. A user who writes
+    /// <c>new GpuDiagnosticsOptions()</c> without setting anything should not
+    /// accidentally mutate process state.
+    /// </summary>
+    [Fact]
+    public void Options_DefaultConstructor_HasNullVerbose()
+    {
+        var options = new GpuDiagnosticsOptions();
+        Assert.Null(options.Verbose);
+    }
+}


### PR DESCRIPTION
## Summary

Closes #1122 by adding a discoverable, AiDotNet-side facade for controlling GPU backend diagnostic output visibility. The underlying flag (`OpenClBackend.DiagnosticOutput`) was already added to AiDotNet.Tensors in PR ooples/AiDotNet.Tensors#158 but lived on a low-level backend class with no discoverability from AiDotNet application code — issue #1122 was filed because users couldn't find it.

## What's new

- `AiDotNet.Configuration.GpuDiagnosticsConfig` (static class) — the discoverable entry point. Forwards `Verbose` to the Tensors package.
- `AiDotNet.Configuration.GpuDiagnosticsOptions` (options class) — matches the AiModelBuilder nullable-options pattern (like `TelemetryConfig`, `ProfilingConfig`). A `null` `Verbose` preserves the existing process setting (env-var or prior programmatic assignment).
- `IAiModelBuilder.ConfigureGpuDiagnostics(options)` + implementation on `AiModelBuilder` — fluent builder method matching the existing `ConfigureTelemetry` / `ConfigureProfiling` / `ConfigureBenchmarking` pattern.

## Usage

```csharp
// Suppress GPU diagnostics for a quiet terminal.
AiDotNet.Configuration.GpuDiagnosticsConfig.Verbose = false;

// Opt into verbose output for troubleshooting.
var result = await builder
    .ConfigureGpuDiagnostics(new() { Verbose = true })
    .BuildAsync();
```

Alternatively set `AIDOTNET_GPU_VERBOSE=1` in the environment (existing convention preserved by the Tensors package).

## Scope notes

Intentionally scoped to the AiDotNet-side discoverability fix. The Tensors package already gates all `OpenClBackend` writes on `DiagnosticOutput`. Follow-up Tensors work to flip the DEFAULT to quiet and gate the remaining few ungated calls (`OpenClNativeBindings.IsAvailable`, `HipBackend`, `AiDotNetEngine.AutoDetectAndConfigureGpu`, `Engine.CreateOptimalEngine`) will be opened as a separate PR against ooples/AiDotNet.Tensors.

## Test plan

- [x] Local build on net10.0 passes with 0 errors
- [x] Local build on net471 passes with 0 errors
- [ ] CI: new tests in `GpuDiagnosticsConfigTests.cs` pass (5 tests covering round-trip, bidirectional sync, null-preserves-state, theory [true/false], default-ctor invariant)
- [ ] CI: no regressions in existing unit tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add configurable GPU diagnostic controls: set verbosity via options or environment variable, and optionally route diagnostic messages to a custom sink or logging adapter.
* **Tests**
  * New unit tests cover verbosity behavior, preservation of existing settings when options are null, sink routing, logger integration, and end-to-end emission behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->