### PR TITLE
perf: DiffusionUnitTestBase forces GC between Unit-03 tests (#1136)

### DIFF
--- a/tests/AiDotNet.Tests/UnitTests/Diffusion/AudioProcessingTests.cs
+++ b/tests/AiDotNet.Tests/UnitTests/Diffusion/AudioProcessingTests.cs
@@ -11,7 +11,7 @@ namespace AiDotNet.Tests.UnitTests.Diffusion;
 /// <summary>
 /// Tests for audio processing components used in diffusion models.
 /// </summary>
-public class AudioProcessingTests
+public class AudioProcessingTests : DiffusionUnitTestBase
 {
     #region Window Function Tests
 

--- a/tests/AiDotNet.Tests/UnitTests/Diffusion/DiffusionUnitTestBase.cs
+++ b/tests/AiDotNet.Tests/UnitTests/Diffusion/DiffusionUnitTestBase.cs
@@ -1,0 +1,108 @@
+using System;
+using System.Runtime;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace AiDotNet.Tests.UnitTests.Diffusion;
+
+/// <summary>
+/// Shared base class for diffusion unit tests that forces a full two-pass
+/// GC cycle WITH Large Object Heap compaction between tests. Addresses the
+/// CI shard cancellations tracked in github.com/ooples/AiDotNet#1136.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The <c>Unit - 03 Diffusion/Encoding</c> CI shard repeatedly hit the 45-min
+/// wall-clock timeout on 16 GB Windows runners because ~200 sequential
+/// diffusion-model unit tests each construct a production-default model
+/// (DiT-XL, SD15, SD3, Flux1, etc.) with eagerly-allocated weight tensors
+/// and let the reference fall out of scope without forcing a compacting
+/// collection. .NET's generational GC waits for memory pressure to trigger
+/// a gen-2 pass — but the tests allocate fast enough to hit the wall clock
+/// before memory pressure kicks in.
+/// </para>
+/// <para>
+/// Implementing <see cref="IAsyncLifetime"/> gives xunit a per-test teardown
+/// hook. The teardown runs a blocking compacting Gen-2 collection with
+/// explicit Large Object Heap compaction between tests. Two collections
+/// around <see cref="GC.WaitForPendingFinalizers"/> ensure finalizer-owned
+/// resources (GPU-backing-buffer finalizers return pooled memory) also
+/// get reclaimed.
+/// </para>
+/// <para><b>Why LOH compaction matters specifically:</b> diffusion model
+/// weight tensors are typically several hundred MB each, well above the
+/// 85KB LOH threshold. Plain <see cref="GC.Collect"/> sweeps the LOH but
+/// does NOT compact it — freed regions stay fragmented. Over ~200 sequential
+/// tests, LOH fragmentation accumulates until the next allocation can't find
+/// a contiguous region even though free bytes exist, producing an
+/// <see cref="OutOfMemoryException"/> on a runner that APPEARS to have
+/// plenty of memory. Setting <see cref="GCLargeObjectHeapCompactionMode.CompactOnce"/>
+/// on the next Gen-2 collection forces the LOH to compact, eliminating
+/// fragmentation as an OOM vector. The compaction flag auto-resets to
+/// <see cref="GCLargeObjectHeapCompactionMode.Default"/> after each use —
+/// safe for test teardowns.
+/// </para>
+/// <para>
+/// This is not a fix for the allocation cost itself — that's the Tensors-
+/// side and layer-side lazy-init work tracked in the #1136 PR chain. It's
+/// a lifecycle hygiene fix that lets the existing tests fit within the
+/// wall-clock budget while the deeper allocation work lands.
+/// </para>
+/// </remarks>
+public abstract class DiffusionUnitTestBase : IAsyncLifetime
+{
+    /// <summary>
+    /// Static lock serializing concurrent teardowns. xunit parallelizes across
+    /// test-classes by default (methods in the same class stay sequential),
+    /// so two test classes that both inherit from this base can hit
+    /// <see cref="DisposeAsync"/> concurrently on different threads.
+    /// <see cref="GCSettings.LargeObjectHeapCompactionMode"/> is process-
+    /// global, so concurrent toggles race — thread A's set-to-CompactOnce
+    /// can be observed by thread B's GC.Collect, or vice versa, producing
+    /// non-deterministic LOH behavior. Serializing the whole
+    /// mode-set → collect → wait → mode-set → collect sequence keeps LOH
+    /// compaction deterministic per teardown.
+    /// </summary>
+    private static readonly object _lohCompactionGate = new();
+
+    /// <summary>
+    /// Before-test hook. No-op — the base has no ambient state to initialize.
+    /// </summary>
+    public Task InitializeAsync() => Task.CompletedTask;
+
+    /// <summary>
+    /// After-test hook. Forces a blocking compacting Gen-2 GC (with explicit
+    /// LOH compaction) to reclaim undisposed model weight tensors AND
+    /// defragment the LOH between tests. Essential for sequential
+    /// diffusion-model unit tests to fit within the 45-min CI wall clock —
+    /// without LOH compaction, the heap APPEARS to have free memory but
+    /// can't satisfy the next test's multi-hundred-MB weight allocation
+    /// because the free bytes are split across fragmented regions.
+    /// </summary>
+    /// <remarks>
+    /// The entire GC sequence runs under <see cref="_lohCompactionGate"/>
+    /// so concurrent teardowns from parallel test classes don't race on the
+    /// process-global <see cref="GCSettings.LargeObjectHeapCompactionMode"/>
+    /// flag.
+    /// </remarks>
+    public Task DisposeAsync()
+    {
+        lock (_lohCompactionGate)
+        {
+            // Compact the LOH on the next Gen-2 collection. CompactOnce auto-resets
+            // to Default after each compacting Gen-2 pass, so this is scoped to
+            // the single test-teardown call — no process-wide side-effect beyond
+            // the lock's critical section.
+            GCSettings.LargeObjectHeapCompactionMode = GCLargeObjectHeapCompactionMode.CompactOnce;
+            GC.Collect(generation: 2, mode: GCCollectionMode.Forced, blocking: true, compacting: true);
+            GC.WaitForPendingFinalizers();
+
+            // Second pass reclaims memory freed by finalizers (GPU-pool return
+            // paths, for instance). Also compacting so a LOH-allocating finalizer
+            // doesn't refragment immediately.
+            GCSettings.LargeObjectHeapCompactionMode = GCLargeObjectHeapCompactionMode.CompactOnce;
+            GC.Collect(generation: 2, mode: GCCollectionMode.Forced, blocking: true, compacting: true);
+        }
+        return Task.CompletedTask;
+    }
+}

--- a/tests/AiDotNet.Tests/UnitTests/Diffusion/MemoryManagementTests.cs
+++ b/tests/AiDotNet.Tests/UnitTests/Diffusion/MemoryManagementTests.cs
@@ -11,7 +11,7 @@ namespace AiDotNet.Tests.UnitTests.Diffusion;
 /// <summary>
 /// Tests for memory management components used in diffusion models.
 /// </summary>
-public class MemoryManagementTests
+public class MemoryManagementTests : DiffusionUnitTestBase
 {
     #region ActivationPool Tests
 

--- a/tests/AiDotNet.Tests/UnitTests/Diffusion/Models/ControlModelContractTests.cs
+++ b/tests/AiDotNet.Tests/UnitTests/Diffusion/Models/ControlModelContractTests.cs
@@ -8,7 +8,7 @@ namespace AiDotNet.Tests.UnitTests.Diffusion.Models;
 /// <summary>
 /// Contract tests for Phase 3 guidance methods and control models.
 /// </summary>
-public class ControlModelContractTests
+public class ControlModelContractTests : DiffusionUnitTestBase
 {
     #region Guidance Method Tests
 

--- a/tests/AiDotNet.Tests/UnitTests/Diffusion/Models/DDPMModelTests.cs
+++ b/tests/AiDotNet.Tests/UnitTests/Diffusion/Models/DDPMModelTests.cs
@@ -9,7 +9,7 @@ namespace AiDotNet.Tests.UnitTests.Diffusion.Models;
 /// <summary>
 /// Comprehensive unit tests for <see cref="DDPMModel{T}"/>.
 /// </summary>
-public class DDPMModelTests
+public class DDPMModelTests : DiffusionUnitTestBase
 {
     #region Construction Tests
 

--- a/tests/AiDotNet.Tests/UnitTests/Diffusion/Models/DiffusionModelContractTests.cs
+++ b/tests/AiDotNet.Tests/UnitTests/Diffusion/Models/DiffusionModelContractTests.cs
@@ -16,7 +16,7 @@ namespace AiDotNet.Tests.UnitTests.Diffusion.Models;
 /// Contract tests verifying that all diffusion models follow the golden constructor pattern
 /// and implement the required interfaces correctly.
 /// </summary>
-public class DiffusionModelContractTests
+public class DiffusionModelContractTests : DiffusionUnitTestBase
 {
     #region Golden Constructor Pattern Tests - New Models
 

--- a/tests/AiDotNet.Tests/UnitTests/Diffusion/Models/EditingModelContractTests.cs
+++ b/tests/AiDotNet.Tests/UnitTests/Diffusion/Models/EditingModelContractTests.cs
@@ -18,7 +18,7 @@ namespace AiDotNet.Tests.UnitTests.Diffusion.Models;
 /// Contract tests for Phase 5 editing, inpainting, style transfer, virtual try-on,
 /// panorama, and motion generation models, plus Phase 8 SR, alignment, and safety.
 /// </summary>
-public class EditingModelContractTests
+public class EditingModelContractTests : DiffusionUnitTestBase
 {
     #region Inpainting Models (Phase 5b)
 

--- a/tests/AiDotNet.Tests/UnitTests/Diffusion/Models/FastGenContractTests.cs
+++ b/tests/AiDotNet.Tests/UnitTests/Diffusion/Models/FastGenContractTests.cs
@@ -10,7 +10,7 @@ namespace AiDotNet.Tests.UnitTests.Diffusion.Models;
 /// <summary>
 /// Contract tests for Phases 4, 6, and 7: T2I models, fast generation, schedulers, and VAEs.
 /// </summary>
-public class FastGenContractTests
+public class FastGenContractTests : DiffusionUnitTestBase
 {
     #region Phase 4 — New T2I Models
 

--- a/tests/AiDotNet.Tests/UnitTests/Diffusion/Models/NewConditionerContractTests.cs
+++ b/tests/AiDotNet.Tests/UnitTests/Diffusion/Models/NewConditionerContractTests.cs
@@ -8,7 +8,7 @@ namespace AiDotNet.Tests.UnitTests.Diffusion.Models;
 /// <summary>
 /// Contract tests for Phase 1 conditioning infrastructure: text conditioners and noise predictors.
 /// </summary>
-public class NewConditionerContractTests
+public class NewConditionerContractTests : DiffusionUnitTestBase
 {
     #region Text Conditioner Constructor Tests
 

--- a/tests/AiDotNet.Tests/UnitTests/Diffusion/Models/PreprocessorContractTests.cs
+++ b/tests/AiDotNet.Tests/UnitTests/Diffusion/Models/PreprocessorContractTests.cs
@@ -7,7 +7,7 @@ namespace AiDotNet.Tests.UnitTests.Diffusion.Models;
 /// <summary>
 /// Contract tests for Phase 2 condition preprocessors.
 /// </summary>
-public class PreprocessorContractTests
+public class PreprocessorContractTests : DiffusionUnitTestBase
 {
     #region Constructor Tests
 

--- a/tests/AiDotNet.Tests/UnitTests/Diffusion/SchedulerTests.cs
+++ b/tests/AiDotNet.Tests/UnitTests/Diffusion/SchedulerTests.cs
@@ -8,7 +8,7 @@ namespace AiDotNet.Tests.UnitTests.Diffusion;
 /// <summary>
 /// Tests for diffusion model schedulers.
 /// </summary>
-public class SchedulerTests
+public class SchedulerTests : DiffusionUnitTestBase
 {
     #region DDIM Scheduler Tests
 


### PR DESCRIPTION
## Summary

Refs #1136. Targets the `Tests (net10.0) - Unit - 03 Diffusion/Encoding` CI shard cancellation. Adds `DiffusionUnitTestBase : IAsyncLifetime` and wires all heavy Unit-03 Diffusion test classes to inherit from it — each test method now triggers a full two-pass GC cycle (`GC.Collect → WaitForPendingFinalizers → GC.Collect`) after it returns, reclaiming undisposed model weight tensors between sequential tests.

## Why forced GC helps

Each test in `DiffusionModelContractTests`, `DDPMModelTests`, etc. constructs a production-default diffusion model (`new StableDiffusion15Model<double>()`, `new DDPMModel<double>()`, etc.) with eagerly-allocated ~300-4000 MB of weight tensors per instance. The test holds the reference in a local `var`, does a few assertions, and lets the reference fall out of scope.

.NET's generational GC waits for memory pressure before running a gen-2 compacting pass — but ~200 sequential tests on a 16 GB Windows CI runner allocate fast enough to hit the 45-min wall clock before pressure triggers collection. The forced GC between tests reclaims immediately.

Pattern lifted from `DiffusionModelTestBase` (#1143 does the same for the ModelFamily Diffusion shards).

## Scope

9 test classes now inherit from `DiffusionUnitTestBase`:

- `DiffusionModelContractTests` (1181 lines, 98+ model constructions)
- `DDPMModelTests` (638 lines)
- `EditingModelContractTests` (919 lines)
- `FastGenContractTests` (776 lines)
- `ControlModelContractTests` (267 lines)
- `NewConditionerContractTests` (146 lines)
- `PreprocessorContractTests` (177 lines)
- `AudioProcessingTests` (574 lines)
- `MemoryManagementTests` (411 lines)
- `SchedulerTests` (395 lines — for consistency; schedulers are light)

Not touched: `Conditioning/ConditioningModuleTests.cs` (no model allocations), `Schedulers/*Tests.cs` in the subfolder (lightweight scheduler-only tests), `UnitTests/Encoding/*.cs` (UTF-8 encoding, not diffusion).

## Test plan

- [x] Local build on net10.0 passes with 0 errors
- [ ] CI: `Tests (net10.0) - Unit - 03 Diffusion/Encoding` shard finishes within 45-min wall clock (vs. cancelled on baseline run [24398739627](https://github.com/ooples/AiDotNet/actions/runs/24398739627))
- [ ] CI: no regressions in passing tests (all tests should still produce the same assertions; only lifecycle changed)

## Not in scope

This PR is deliberately scoped to the Unit-03 Diffusion shard lifecycle only. The underlying eagerly-allocated weight tensor problem is addressed by the parent #1136 PR chain (#1137, #1138, #1140, #1141, #1143) which adds lazy init to noise predictors, MHA, and LayerNorm. This PR is a complementary lifecycle hygiene fix — even with full lazy init, sequential tests still allocate on first use, and GC between tests keeps memory flat instead of monotonically climbing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a new xUnit test base class that enforces deterministic memory cleanup during test teardown to reduce flaky or resource-related test failures.
  * Updated multiple diffusion-related test classes to inherit from this base, standardizing per-test teardown and memory-management behavior across the suite.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->