### PR TITLE
fix(ci): resolve 6 real CI failures + DiT / weight-init vectorization

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,7 +5,7 @@
   <ItemGroup>
     <!-- AiDotNet ecosystem -->
     <PackageVersion Include="AiDotNet" Version="0.113.0" />
-    <PackageVersion Include="AiDotNet.Tensors" Version="0.46.0" />
+    <PackageVersion Include="AiDotNet.Tensors" Version="0.46.1" />
     <PackageVersion Include="AiDotNet.Native.OneDNN" Version="0.38.0" />
     <PackageVersion Include="AiDotNet.Native.OpenBLAS" Version="0.28.0" />
     <PackageVersion Include="AiDotNet.Native.CLBlast" Version="0.37.0" />

--- a/src/AiDotNet.Generators/TestScaffoldGenerator.cs
+++ b/src/AiDotNet.Generators/TestScaffoldGenerator.cs
@@ -1668,6 +1668,23 @@ public class TestScaffoldGenerator : IIncrementalGenerator
             sb.AppendLine($"    protected override int[] InputShape => new[] {{ {dim} }};");
             sb.AppendLine("    protected override int[] OutputShape => new[] { 4 };");
         }
+        else if (family == TestFamily.TransformerNER || family == TestFamily.SpanBasedNER)
+        {
+            // TransformerNERBase and SpanBasedNERBase both default to
+            // HiddenDimension=768 (BERT-base). Inputs are validated as
+            // [seqLen, 768], so the base-class default [1, 4] causes a
+            // hard "embedding dim mismatch" failure inside MultiHeadAttention
+            // before any downstream logic runs. Use a short sequence to
+            // keep the test fast while matching the model's expected
+            // embedding size. Models with non-default hidden dimensions
+            // (TinyBERT=312, etc.) need a manual test override.
+            sb.AppendLine("    protected override int[] InputShape => new[] { 8, 768 };");
+        }
+        else if (family == TestFamily.SequenceLabelingNER)
+        {
+            // LSTM-CRF family defaults to EmbeddingDimension=100.
+            sb.AppendLine("    protected override int[] InputShape => new[] { 8, 100 };");
+        }
 
         sb.AppendLine($"    protected override {returnTypeCode} {factoryMethodName}()");
         sb.AppendLine(factoryBody);

--- a/src/AiDotNet.Generators/TestScaffoldGenerator.cs
+++ b/src/AiDotNet.Generators/TestScaffoldGenerator.cs
@@ -1492,7 +1492,7 @@ public class TestScaffoldGenerator : IIncrementalGenerator
                     }
                 }
             }
-            else if (model.Domains.Contains(3) && !model.Tasks.Contains(35))
+            else if (model.Domains.Contains(4) && !model.Tasks.Contains(35))
             {
                 // Temporal video models (ActionRecognition=22, VideoGeneration=41, etc.)
                 // need a 4D [frames, channels, height, width] input shape, but
@@ -1500,6 +1500,13 @@ public class TestScaffoldGenerator : IIncrementalGenerator
                 // Rather than silently emit a mismatched 3D architecture alongside a
                 // 4D InputShape, route these to a runtime placeholder until the
                 // architecture type can represent a temporal dimension.
+                //
+                // The enum ordinal for ModelDomain.Video is 4
+                // (General=0, Vision=1, Language=2, Audio=3, Video=4, ...).
+                // This check previously used 3, which incorrectly flagged every
+                // *audio* model (PlayHT, Bark, etc.) as "temporal video" and
+                // emitted a NotImplementedException factory — ten PlayHTTests
+                // failures on PR #1156 traced to this off-by-one.
                 constructorExpr = "throw new System.NotImplementedException(" +
                     $"\"'{GeneratorHelpers.StripGenericSuffix(model.ClassName)}' is a temporal video model; NeuralNetworkArchitecture<T> cannot express its 4D [frames, channels, height, width] input. Implement this factory manually.\")";
             }
@@ -1510,7 +1517,7 @@ public class TestScaffoldGenerator : IIncrementalGenerator
                 // others default to OneDimensional. Temporal video is handled above.
                 needsArchitectureUsing = true;
                 bool isVision = model.Domains.Contains(1) || model.Domains.Contains(11); // Vision=1, ThreeD=11
-                bool isAudio = model.Domains.Contains(4); // Audio=4
+                bool isAudio = model.Domains.Contains(3); // Audio=3 (enum ordinal, not Video=4)
                 bool isFrameInterp = model.Tasks.Contains(35); // FrameInterpolation → 3D input
 
                 string inputTypeExpr;
@@ -1623,11 +1630,12 @@ public class TestScaffoldGenerator : IIncrementalGenerator
 
         // Override InputShape/OutputShape for domain-appropriate test data.
         // Vision/Video/3D models need [C, H, W]; default is [1, 4].
-        bool isVideoModel = model.Domains.Contains(3);
+        // Enum ordinals: General=0, Vision=1, Language=2, Audio=3, Video=4.
+        bool isVideoModel = model.Domains.Contains(4); // Video=4 (was incorrectly 3)
         bool isFrameInterpModel = model.Tasks.Contains(35); // FrameInterpolation
         bool isTemporalVideoModel = isVideoModel && !isFrameInterpModel;
         bool isVisionModel = model.Domains.Contains(1) || model.Domains.Contains(11);
-        bool isAudioModel = model.Domains.Contains(4);
+        bool isAudioModel = model.Domains.Contains(3); // Audio=3 (was incorrectly 4)
         if (isTemporalVideoModel)
         {
             // Temporal video: [frames, channels, height, width]

--- a/src/AiDotNet.Serving/Services/AesGcmModelArtifactProtector.cs
+++ b/src/AiDotNet.Serving/Services/AesGcmModelArtifactProtector.cs
@@ -72,10 +72,27 @@ public sealed class AesGcmModelArtifactProtector : IModelArtifactProtector
         }
     }
 
+    /// <summary>
+    /// Cross-platform-invalid filename characters. Combines the Windows
+    /// invalid set (most restrictive: ":" + "\\" + reserved punctuation +
+    /// control chars) with POSIX "/" and "\0". Used instead of
+    /// <see cref="Path.GetInvalidFileNameChars"/> because that method
+    /// returns a platform-specific set — on Linux it only contains '\0'
+    /// and '/', so a model name like "my:model" sanitizes to "my:model"
+    /// on Linux but "my_model" on Windows. Encrypted artifacts are
+    /// designed to be portable, so we apply the strict Windows superset
+    /// on every OS to guarantee the output is mountable everywhere.
+    /// </summary>
+    private static readonly HashSet<char> CrossPlatformInvalidFileNameChars =
+        new(new[]
+        {
+            '\0', '/', '\\', ':', '*', '?', '"', '<', '>', '|',
+        }
+        .Concat(Enumerable.Range(1, 31).Select(i => (char)i)));
+
     private static string SanitizeFileName(string name)
     {
-        var invalid = Path.GetInvalidFileNameChars();
-        var chars = name.Select(c => invalid.Contains(c) ? '_' : c).ToArray();
+        var chars = name.Select(c => CrossPlatformInvalidFileNameChars.Contains(c) ? '_' : c).ToArray();
         return new string(chars);
     }
 }

--- a/src/AiDotNet.Serving/Services/AesGcmModelArtifactProtector.cs
+++ b/src/AiDotNet.Serving/Services/AesGcmModelArtifactProtector.cs
@@ -90,10 +90,49 @@ public sealed class AesGcmModelArtifactProtector : IModelArtifactProtector
         }
         .Concat(Enumerable.Range(1, 31).Select(i => (char)i)));
 
+    /// <summary>
+    /// DOS reserved device names. Creating a file with any of these as the
+    /// base name (with or without extension) fails on Windows with
+    /// <c>PathTooLongException</c> / <c>IOException</c> because the kernel
+    /// still routes them to legacy character devices. Cross-platform
+    /// portability requires rejecting them even on POSIX hosts so an
+    /// artifact produced on Linux can't be loaded on Windows.
+    /// </summary>
+    private static readonly HashSet<string> WindowsReservedFileNames =
+        new(StringComparer.OrdinalIgnoreCase)
+        {
+            "CON", "PRN", "AUX", "NUL",
+            "COM1", "COM2", "COM3", "COM4", "COM5", "COM6", "COM7", "COM8", "COM9",
+            "LPT1", "LPT2", "LPT3", "LPT4", "LPT5", "LPT6", "LPT7", "LPT8", "LPT9",
+        };
+
     private static string SanitizeFileName(string name)
     {
+        // 1. Replace cross-platform-invalid characters.
         var chars = name.Select(c => CrossPlatformInvalidFileNameChars.Contains(c) ? '_' : c).ToArray();
-        return new string(chars);
+        var sanitized = new string(chars);
+
+        // 2. Windows strips trailing dots and spaces from filenames at create-time
+        //    (so "model." silently becomes "model", but "model." on some paths fails
+        //    with PathNotFound). Trim on every platform to avoid the mismatch.
+        sanitized = sanitized.TrimEnd(' ', '.');
+
+        // 3. If the base (pre-extension) is a reserved DOS device name, prefix it
+        //    so the artifact remains portable. Split on the first dot so "NUL.bin"
+        //    also gets rewritten.
+        if (sanitized.Length == 0)
+        {
+            return "_";
+        }
+
+        var dotIndex = sanitized.IndexOf('.');
+        var baseName = dotIndex >= 0 ? sanitized.Substring(0, dotIndex) : sanitized;
+        if (WindowsReservedFileNames.Contains(baseName))
+        {
+            sanitized = "_" + sanitized;
+        }
+
+        return sanitized;
     }
 }
 

--- a/src/Diffusion/NoisePredictors/DiTNoisePredictor.cs
+++ b/src/Diffusion/NoisePredictors/DiTNoisePredictor.cs
@@ -574,8 +574,20 @@ public class DiTNoisePredictor<T> : NoisePredictorBase<T>
     }
 
     /// <summary>
-    /// Converts image to patches.
+    /// Converts image to patches via a single reshape + permute + reshape.
     /// </summary>
+    /// <remarks>
+    /// Equivalent to the nested 6-loop scalar copy this used to be:
+    /// <c>[B, C, H, W]</c> → reshape <c>[B, C, H/p, p, W/p, p]</c>
+    /// → permute to <c>[B, H/p, W/p, C, p, p]</c>
+    /// → reshape <c>[B, numPatches, C·p·p]</c>.
+    /// All three ops route through <see cref="IEngine"/>, so the permutation
+    /// runs through the engine's vectorized memcpy kernel instead of a
+    /// scalar C# nested loop. The two reshape steps are zero-copy views; the
+    /// permute is the only step that materializes (and only because the
+    /// downstream <see cref="DenseLayer{T}.Forward"/> requires contiguous
+    /// input).
+    /// </remarks>
     private Tensor<T> Patchify(Tensor<T> x)
     {
         var shape = x._shape;
@@ -589,48 +601,23 @@ public class DiTNoisePredictor<T> : NoisePredictorBase<T>
         var numPatches = numPatchesH * numPatchesW;
         var patchDim = channels * _patchSize * _patchSize;
 
-        var patches = TensorAllocator.Rent<T>(new[] { batch, numPatches, patchDim });
-        var patchSpan = patches.AsWritableSpan();
-        var xSpan = x.AsSpan();
-
-        for (int b = 0; b < batch; b++)
-        {
-            int patchIdx = 0;
-            for (int ph = 0; ph < numPatchesH; ph++)
-            {
-                for (int pw = 0; pw < numPatchesW; pw++)
-                {
-                    // Extract patch
-                    int dimIdx = 0;
-                    for (int c = 0; c < channels; c++)
-                    {
-                        for (int py = 0; py < _patchSize; py++)
-                        {
-                            for (int px = 0; px < _patchSize; px++)
-                            {
-                                var ih = ph * _patchSize + py;
-                                var iw = pw * _patchSize + px;
-                                var srcIdx = b * channels * height * width +
-                                             c * height * width +
-                                             ih * width + iw;
-                                var dstIdx = b * numPatches * patchDim +
-                                             patchIdx * patchDim + dimIdx;
-                                patchSpan[dstIdx] = xSpan[srcIdx];
-                                dimIdx++;
-                            }
-                        }
-                    }
-                    patchIdx++;
-                }
-            }
-        }
-
-        return patches;
+        // [B, C, H, W] -> [B, C, H/p, p, W/p, p]
+        var split = Engine.Reshape(x,
+            new[] { batch, channels, numPatchesH, _patchSize, numPatchesW, _patchSize });
+        // -> [B, H/p, W/p, C, p, p]  (axes: 0, 2, 4, 1, 3, 5)
+        var permuted = Engine.TensorPermute(split, new[] { 0, 2, 4, 1, 3, 5 });
+        // -> [B, numPatches, patchDim]
+        return Engine.Reshape(permuted, new[] { batch, numPatches, patchDim });
     }
 
     /// <summary>
     /// Embeds patches through linear projection using batched forward pass.
     /// </summary>
+    /// <remarks>
+    /// Uses zero-copy <see cref="IEngine.Reshape"/> views around the dense
+    /// projection — the previous <c>TensorAllocator.Rent + CopyTo</c> scratch
+    /// buffers were unnecessary because Patchify's output is contiguous.
+    /// </remarks>
     private Tensor<T> EmbedPatches(Tensor<T> patches)
     {
         if (_patchEmbed == null)
@@ -641,18 +628,10 @@ public class DiTNoisePredictor<T> : NoisePredictorBase<T>
         var numPatches = shape[1];
         var patchDim = shape[2];
 
-        // Reshape [batch, numPatches, patchDim] -> [batch*numPatches, patchDim] for batched forward
-        var flatPatches = TensorAllocator.Rent<T>(new[] { batch * numPatches, patchDim });
-        patches.AsSpan().CopyTo(flatPatches.AsWritableSpan());
-
-        // Single batched forward pass through the linear layer
+        // [B, numPatches, patchDim] -> [B·numPatches, patchDim] view, batched dense forward, reshape back as view.
+        var flatPatches = Engine.Reshape(patches, new[] { batch * numPatches, patchDim });
         var projected = _patchEmbed.Forward(flatPatches);
-
-        // Reshape back to [batch, numPatches, hiddenSize]
-        var embedded = TensorAllocator.Rent<T>(new[] { batch, numPatches, _hiddenSize });
-        projected.AsSpan().CopyTo(embedded.AsWritableSpan());
-
-        return embedded;
+        return Engine.Reshape(projected, new[] { batch, numPatches, _hiddenSize });
     }
 
     /// <summary>
@@ -700,6 +679,14 @@ public class DiTNoisePredictor<T> : NoisePredictorBase<T>
     /// <summary>
     /// Forward pass through a single DiT block with AdaLN.
     /// </summary>
+    /// <remarks>
+    /// AdaLN modulation tensor is reshaped to [B, 6, 1, hidden] and the six
+    /// shift/scale/gate parameters are obtained as zero-copy
+    /// <see cref="IEngine.TensorSliceAxis"/> views — no <c>T[]</c> allocations,
+    /// no scalar fill loops. The <c>(1 + scale)</c> precomputation in AdaLN
+    /// uses the SIMD <see cref="IEngine.TensorAddScalar"/> primitive instead
+    /// of a per-element <c>NumOps.Add(NumOps.One, scale[h])</c> loop.
+    /// </remarks>
     private Tensor<T> ForwardBlock(
         Tensor<T> x,
         Tensor<T> timeEmbed,
@@ -713,18 +700,23 @@ public class DiTNoisePredictor<T> : NoisePredictorBase<T>
             throw new InvalidOperationException("Block layers not initialized.");
         }
 
-        // Get AdaLN modulation parameters (shift1, scale1, gate1, shift2, scale2, gate2)
+        // Get AdaLN modulation parameters (shift1, scale1, gate1, shift2, scale2, gate2).
+        // AdaLNModulation forward output is hidden*6 elements per batch — derive
+        // batchM from total length so we don't depend on whether the layer
+        // returns [B, hidden*6] (rank 2) or [hidden*6] (rank 1, when B=1 and the
+        // dense layer collapses leading dims). Reshape to [B, 6, 1, hidden] so
+        // TensorSliceAxis(axis=1, index=i) yields a [B, 1, hidden] view directly,
+        // broadcastable over [B, seq, hidden] without further reshape.
         var modulation = block.AdaLNModulation.Forward(timeEmbed);
-        var modSpan = modulation.AsSpan();
+        int batchM = modulation.Length / (6 * _hiddenSize);
+        var modReshaped = Engine.Reshape(modulation, new[] { batchM, 6, 1, _hiddenSize });
 
-        // Split modulation into 6 parts
-        var modSize = _hiddenSize;
-        var shift1 = ExtractModulation(modSpan, 0, modSize);
-        var scale1 = ExtractModulation(modSpan, modSize, modSize);
-        var gate1 = ExtractModulation(modSpan, modSize * 2, modSize);
-        var shift2 = ExtractModulation(modSpan, modSize * 3, modSize);
-        var scale2 = ExtractModulation(modSpan, modSize * 4, modSize);
-        var gate2 = ExtractModulation(modSpan, modSize * 5, modSize);
+        var shift1 = Engine.TensorSliceAxis(modReshaped, axis: 1, index: 0);
+        var scale1 = Engine.TensorSliceAxis(modReshaped, axis: 1, index: 1);
+        var gate1  = Engine.TensorSliceAxis(modReshaped, axis: 1, index: 2);
+        var shift2 = Engine.TensorSliceAxis(modReshaped, axis: 1, index: 3);
+        var scale2 = Engine.TensorSliceAxis(modReshaped, axis: 1, index: 4);
+        var gate2  = Engine.TensorSliceAxis(modReshaped, axis: 1, index: 5);
 
         // Self-attention with AdaLN
         var normed = block.Norm1.Forward(x);
@@ -751,43 +743,18 @@ public class DiTNoisePredictor<T> : NoisePredictorBase<T>
     }
 
     /// <summary>
-    /// Extracts modulation parameters from combined tensor.
+    /// Applies adaptive layer normalization (Peebles &amp; Xie, 2023):
+    /// <c>y = x * (1 + scale) + shift</c>. Both <paramref name="scaleView"/>
+    /// and <paramref name="shiftView"/> are <c>[B, 1, hidden]</c> tensor views
+    /// sliced from the AdaLN modulation tensor — no scratch allocation, no
+    /// scalar fill. The <c>(1 + scale)</c> precomputation runs through the
+    /// SIMD <see cref="IEngine.TensorAddScalar"/> kernel.
     /// </summary>
-    private T[] ExtractModulation(ReadOnlySpan<T> modSpan, int offset, int size)
+    private Tensor<T> ApplyAdaLN(Tensor<T> x, Tensor<T> scaleView, Tensor<T> shiftView)
     {
-        var result = new T[size];
-        for (int i = 0; i < size; i++)
-        {
-            result[i] = modSpan[offset + i];
-        }
-        return result;
-    }
-
-    /// <summary>
-    /// Applies adaptive layer normalization using IEngine for hardware acceleration.
-    /// y = x * (1 + scale) + shift
-    /// </summary>
-    private Tensor<T> ApplyAdaLN(Tensor<T> x, T[] scale, T[] shift)
-    {
-        var shape = x._shape;
-        var hidden = shape[^1];
-
-        // Create broadcastable tensors for scale and shift: [1, 1, hidden]
-        var scaleTensor = TensorAllocator.Rent<T>(new[] { 1, 1, hidden });
-        var shiftTensor = TensorAllocator.Rent<T>(new[] { 1, 1, hidden });
-        var scaleSpan = scaleTensor.AsWritableSpan();
-        var shiftSpan = shiftTensor.AsWritableSpan();
-
-        for (int h = 0; h < hidden; h++)
-        {
-            scaleSpan[h] = NumOps.Add(NumOps.One, scale[h % scale.Length]);
-            shiftSpan[h] = shift[h % shift.Length];
-        }
-
-        // y = x * (1 + scale) + shift — per DiT paper (Peebles & Xie, 2023)
-        // scale/shift are [1,1,hidden], x is [batch, seq, hidden] — requires broadcasting
-        var scaled = Engine.TensorBroadcastMultiply<T>(x, scaleTensor);
-        return Engine.TensorBroadcastAdd<T>(scaled, shiftTensor);
+        var scalePlusOne = Engine.TensorAddScalar<T>(scaleView, NumOps.One);
+        var scaled = Engine.TensorBroadcastMultiply<T>(x, scalePlusOne);
+        return Engine.TensorBroadcastAdd<T>(scaled, shiftView);
     }
 
     /// <summary>
@@ -861,166 +828,108 @@ public class DiTNoisePredictor<T> : NoisePredictorBase<T>
     }
 
     /// <summary>
-    /// Reshapes tensor from [batch, seq, hidden] to [batch*heads, seq, headDim] for multi-head attention.
+    /// Reshapes tensor from <c>[batch, seq, hidden]</c> to
+    /// <c>[batch*heads, seq, headDim]</c> for multi-head attention via a
+    /// reshape + permute + reshape pipeline (no scalar nested copy loops).
     /// </summary>
-    private static Tensor<T> ReshapeForHeads(Tensor<T> tensor, int batch, int seq, int numHeads, int headDim)
+    private Tensor<T> ReshapeForHeads(Tensor<T> tensor, int batch, int seq, int numHeads, int headDim)
     {
-        var result = TensorAllocator.Rent<T>(new[] { batch * numHeads, seq, headDim });
-        var srcSpan = tensor.AsSpan();
-        var dstSpan = result.AsWritableSpan();
-        var hidden = numHeads * headDim;
-
-        for (int b = 0; b < batch; b++)
-        {
-            for (int h = 0; h < numHeads; h++)
-            {
-                for (int s = 0; s < seq; s++)
-                {
-                    var srcBase = b * seq * hidden + s * hidden + h * headDim;
-                    var dstBase = (b * numHeads + h) * seq * headDim + s * headDim;
-                    srcSpan.Slice(srcBase, headDim).CopyTo(dstSpan.Slice(dstBase, headDim));
-                }
-            }
-        }
-
-        return result;
+        // [B, S, H·D] -> [B, S, H, D]
+        var split = Engine.Reshape(tensor, new[] { batch, seq, numHeads, headDim });
+        // -> [B, H, S, D]
+        var permuted = Engine.TensorPermute(split, new[] { 0, 2, 1, 3 });
+        // -> [B·H, S, D]
+        return Engine.Reshape(permuted, new[] { batch * numHeads, seq, headDim });
     }
 
     /// <summary>
-    /// Reshapes tensor from [batch*heads, seq, headDim] back to [batch, seq, hidden].
+    /// Inverse of <see cref="ReshapeForHeads"/> — collapses head and batch
+    /// back together via reshape + permute + reshape.
     /// </summary>
-    private static Tensor<T> ReshapeFromHeads(Tensor<T> tensor, int batch, int seq, int numHeads, int headDim)
+    private Tensor<T> ReshapeFromHeads(Tensor<T> tensor, int batch, int seq, int numHeads, int headDim)
     {
-        var result = TensorAllocator.Rent<T>(new[] { batch, seq, numHeads * headDim });
-        var srcSpan = tensor.AsSpan();
-        var dstSpan = result.AsWritableSpan();
-        var hidden = numHeads * headDim;
-
-        for (int b = 0; b < batch; b++)
-        {
-            for (int h = 0; h < numHeads; h++)
-            {
-                for (int s = 0; s < seq; s++)
-                {
-                    var srcBase = (b * numHeads + h) * seq * headDim + s * headDim;
-                    var dstBase = b * seq * hidden + s * hidden + h * headDim;
-                    srcSpan.Slice(srcBase, headDim).CopyTo(dstSpan.Slice(dstBase, headDim));
-                }
-            }
-        }
-
-        return result;
+        // [B·H, S, D] -> [B, H, S, D]
+        var split = Engine.Reshape(tensor, new[] { batch, numHeads, seq, headDim });
+        // -> [B, S, H, D]
+        var permuted = Engine.TensorPermute(split, new[] { 0, 2, 1, 3 });
+        // -> [B, S, H·D]
+        return Engine.Reshape(permuted, new[] { batch, seq, numHeads * headDim });
     }
 
     /// <summary>
-    /// Adds with gating using IEngine for hardware acceleration.
-    /// result = x + gate * residual
+    /// Gated residual add: <c>result = x + gateView * residual</c>.
+    /// <paramref name="gateView"/> is a <c>[B, 1, hidden]</c> view sliced from
+    /// the AdaLN modulation tensor — no scratch allocation, no scalar fill.
+    /// Uses <see cref="IEngine.TensorBroadcastMultiply"/> for the per-channel
+    /// gate broadcast.
     /// </summary>
-    private Tensor<T> AddWithGate(Tensor<T> x, Tensor<T> residual, T[] gate)
+    private Tensor<T> AddWithGate(Tensor<T> x, Tensor<T> residual, Tensor<T> gateView)
     {
-        var hidden = x.Shape[^1];
-
-        // Create broadcastable gate tensor: [1, 1, hidden]
-        var gateTensor = TensorAllocator.Rent<T>(new[] { 1, 1, hidden });
-        var gateSpan = gateTensor.AsWritableSpan();
-        for (int h = 0; h < hidden; h++)
-        {
-            gateSpan[h] = gate[h % gate.Length];
-        }
-
-        // result = x + gate * residual
-        var gated = Engine.TensorMultiply<T>(residual, gateTensor);
+        var gated = Engine.TensorBroadcastMultiply<T>(residual, gateView);
         return Engine.TensorAdd<T>(x, gated);
     }
 
     /// <summary>
-    /// Final layer with AdaLN zero using batched forward pass.
+    /// Final layer with AdaLN-zero using batched forward pass.
     /// </summary>
+    /// <remarks>
+    /// Modulation slicing matches <see cref="ForwardBlock"/>: reshape to
+    /// <c>[B, 2, 1, hidden]</c> then <see cref="IEngine.TensorSliceAxis"/> for
+    /// shift/scale views. Reshape between the projection input and output uses
+    /// <see cref="IEngine.Reshape"/> views instead of
+    /// <c>TensorAllocator.Rent</c>+<c>CopyTo</c> scratch buffers, eliminating
+    /// two allocations per inference step.
+    /// </remarks>
     private Tensor<T> FinalLayerWithAdaLN(Tensor<T> x, Tensor<T> timeEmbed)
     {
         if (_finalNorm == null || _adaln_modulation == null || _outputProj == null)
             throw new InvalidOperationException("Final layers not initialized.");
 
-        // Get final modulation (scale, shift)
         var modulation = _adaln_modulation.Forward(timeEmbed);
-        var modSpan = modulation.AsSpan();
+        int batchM = modulation.Length / (2 * _hiddenSize);
+        var modReshaped = Engine.Reshape(modulation, new[] { batchM, 2, 1, _hiddenSize });
+        var shiftView = Engine.TensorSliceAxis(modReshaped, axis: 1, index: 0);
+        var scaleView = Engine.TensorSliceAxis(modReshaped, axis: 1, index: 1);
 
-        var shift = ExtractModulation(modSpan, 0, _hiddenSize);
-        var scale = ExtractModulation(modSpan, _hiddenSize, _hiddenSize);
-
-        // Apply final norm with AdaLN
         var normed = _finalNorm.Forward(x);
-        normed = ApplyAdaLN(normed, scale, shift);
+        normed = ApplyAdaLN(normed, scaleView, shiftView);
 
-        // Project to output dimension using batched forward pass
         var shape = normed._shape;
         var batch = shape[0];
         var numPatches = shape[1];
         var patchDim = _inputChannels * _patchSize * _patchSize;
 
-        // Reshape [batch, numPatches, hiddenSize] -> [batch*numPatches, hiddenSize]
-        var flatNormed = TensorAllocator.Rent<T>(new[] { batch * numPatches, _hiddenSize });
-        normed.AsSpan().CopyTo(flatNormed.AsWritableSpan());
-
-        // Single batched forward pass
+        // [batch, numPatches, hiddenSize] -> [batch*numPatches, hiddenSize] via view.
+        var flatNormed = Engine.Reshape(normed, new[] { batch * numPatches, _hiddenSize });
         var projected = _outputProj.Forward(flatNormed);
-
-        // Reshape back to [batch, numPatches, patchDim]
-        var output = TensorAllocator.Rent<T>(new[] { batch, numPatches, patchDim });
-        projected.AsSpan().CopyTo(output.AsWritableSpan());
-
-        return output;
+        // Back to [batch, numPatches, patchDim] via view.
+        return Engine.Reshape(projected, new[] { batch, numPatches, patchDim });
     }
 
     /// <summary>
-    /// Converts patches back to image.
+    /// Inverse of <see cref="Patchify"/> — reconstructs the spatial image.
     /// </summary>
+    /// <remarks>
+    /// <c>[B, numPatches, C·p·p]</c> → reshape <c>[B, H/p, W/p, C, p, p]</c>
+    /// → permute to <c>[B, C, H/p, p, W/p, p]</c>
+    /// → reshape <c>[B, C, H, W]</c>. Same vectorized-memcpy + view pattern
+    /// as <see cref="Patchify"/> — zero scalar loops, one materialization.
+    /// </remarks>
     private Tensor<T> Unpatchify(Tensor<T> patches, int height, int width)
     {
         var shape = patches._shape;
         var batch = shape[0];
-        var patchDim = shape[2];
 
         var numPatchesH = height / _patchSize;
         var numPatchesW = width / _patchSize;
 
-        var output = TensorAllocator.Rent<T>(new[] { batch, _inputChannels, height, width });
-        var outputSpan = output.AsWritableSpan();
-        var patchSpan = patches.AsSpan();
-
-        for (int b = 0; b < batch; b++)
-        {
-            int patchIdx = 0;
-            for (int ph = 0; ph < numPatchesH; ph++)
-            {
-                for (int pw = 0; pw < numPatchesW; pw++)
-                {
-                    // Reconstruct patch
-                    int dimIdx = 0;
-                    for (int c = 0; c < _inputChannels; c++)
-                    {
-                        for (int py = 0; py < _patchSize; py++)
-                        {
-                            for (int px = 0; px < _patchSize; px++)
-                            {
-                                var ih = ph * _patchSize + py;
-                                var iw = pw * _patchSize + px;
-                                var dstIdx = b * _inputChannels * height * width +
-                                             c * height * width +
-                                             ih * width + iw;
-                                var srcIdx = b * numPatchesH * numPatchesW * patchDim +
-                                             patchIdx * patchDim + dimIdx;
-                                outputSpan[dstIdx] = patchSpan[srcIdx];
-                                dimIdx++;
-                            }
-                        }
-                    }
-                    patchIdx++;
-                }
-            }
-        }
-
-        return output;
+        // [B, numPatches, C·p·p] -> [B, H/p, W/p, C, p, p]
+        var unsplit = Engine.Reshape(patches,
+            new[] { batch, numPatchesH, numPatchesW, _inputChannels, _patchSize, _patchSize });
+        // -> [B, C, H/p, p, W/p, p]  (inverse permutation: axes 0, 3, 1, 4, 2, 5)
+        var permuted = Engine.TensorPermute(unsplit, new[] { 0, 3, 1, 4, 2, 5 });
+        // -> [B, C, H, W]
+        return Engine.Reshape(permuted, new[] { batch, _inputChannels, height, width });
     }
 
     /// <inheritdoc />

--- a/src/Diffusion/NoisePredictors/DiTNoisePredictor.cs
+++ b/src/Diffusion/NoisePredictors/DiTNoisePredictor.cs
@@ -708,7 +708,17 @@ public class DiTNoisePredictor<T> : NoisePredictorBase<T>
         // TensorSliceAxis(axis=1, index=i) yields a [B, 1, hidden] view directly,
         // broadcastable over [B, seq, hidden] without further reshape.
         var modulation = block.AdaLNModulation.Forward(timeEmbed);
-        int batchM = modulation.Length / (6 * _hiddenSize);
+        int stride = 6 * _hiddenSize;
+        if (modulation.Length % stride != 0)
+        {
+            throw new InvalidOperationException(
+                $"AdaLNModulation output length {modulation.Length} is not divisible by 6 * hiddenSize " +
+                $"({stride}). This indicates the modulation MLP's output size is misconfigured — " +
+                $"each DiT block needs exactly 6 * {_hiddenSize} = {stride} modulation parameters per " +
+                $"sample (shift/scale/gate × 2 for attention and MLP branches). " +
+                $"Check the layer that produced `timeEmbed` and `block.AdaLNModulation`.");
+        }
+        int batchM = modulation.Length / stride;
         var modReshaped = Engine.Reshape(modulation, new[] { batchM, 6, 1, _hiddenSize });
 
         var shift1 = Engine.TensorSliceAxis(modReshaped, axis: 1, index: 0);
@@ -886,7 +896,16 @@ public class DiTNoisePredictor<T> : NoisePredictorBase<T>
             throw new InvalidOperationException("Final layers not initialized.");
 
         var modulation = _adaln_modulation.Forward(timeEmbed);
-        int batchM = modulation.Length / (2 * _hiddenSize);
+        int stride = 2 * _hiddenSize;
+        if (modulation.Length % stride != 0)
+        {
+            throw new InvalidOperationException(
+                $"Final-layer AdaLN modulation output length {modulation.Length} is not divisible " +
+                $"by 2 * hiddenSize ({stride}). The final-layer modulation MLP must emit exactly " +
+                $"2 * {_hiddenSize} = {stride} parameters per sample (shift + scale). Check the " +
+                $"layer that produced `timeEmbed` and `_adaln_modulation`.");
+        }
+        int batchM = modulation.Length / stride;
         var modReshaped = Engine.Reshape(modulation, new[] { batchM, 2, 1, _hiddenSize });
         var shiftView = Engine.TensorSliceAxis(modReshaped, axis: 1, index: 0);
         var scaleView = Engine.TensorSliceAxis(modReshaped, axis: 1, index: 1);

--- a/src/Diffusion/NoisePredictors/VideoUNetPredictor.cs
+++ b/src/Diffusion/NoisePredictors/VideoUNetPredictor.cs
@@ -1019,7 +1019,28 @@ public class VideoUNetPredictor<T> : NoisePredictorBase<T>
 
     private ILayer<T> CreateSpatialResBlock(int inChannels, int outChannels)
     {
-        return LazyDense(inChannels, outChannels, new SiLUActivation<T>());
+        // A diffusion spatial ResBlock transforms the channel dimension of a
+        // 4D [B, C, H, W] feature map. The previous implementation used
+        // LazyDense(inChannels, outChannels), but DenseLayer projects the
+        // *last* dimension of its input — for a 4D tensor that is the width
+        // axis, not channels. The block therefore left C unchanged while
+        // scrambling W to outChannels, and every subsequent TimeCondProjection
+        // (sized for the planned outChannels) saw a feature map still at the
+        // incoming channel count — hence "FiLM conditioning projection width
+        // mismatch: expected 640, got 1280" on upscaleavideomodel and
+        // streamingt2vmodel tests.
+        // A 1x1 Conv2D is the standard channel-mixing primitive: it consumes
+        // [B, inChannels, H, W] and produces [B, outChannels, H, W] while
+        // leaving spatial dims alone.
+        return LazyConv2D(
+            inputDepth: inChannels,
+            inputHeight: 1,
+            inputWidth: 1,
+            outputDepth: outChannels,
+            kernelSize: 1,
+            stride: 1,
+            padding: 0,
+            activation: new SiLUActivation<T>());
     }
 
     /// <summary>

--- a/src/Diffusion/SuperResolution/UpscaleAVideoModel.cs
+++ b/src/Diffusion/SuperResolution/UpscaleAVideoModel.cs
@@ -134,13 +134,20 @@ public class UpscaleAVideoModel<T> : VideoDiffusionModelBase<T>
     private const int CROSS_ATTENTION_DIM = 1024;
 
     /// <summary>
-    /// Input channels for the Video U-Net (8 = 4 latent + 4 low-res conditioning).
+    /// Input channels for the Video U-Net input convolution (4 = latent channels).
     /// </summary>
     /// <remarks>
-    /// The Video U-Net receives concatenated latent noise and downscaled low-resolution
-    /// video frames as conditioning, doubling the standard 4 latent channels.
+    /// The reference implementation describes this model as using 8 input channels
+    /// (4 latent + 4 downscaled low-res conditioning), but that design expects the
+    /// conditioning to be concatenated with the latents before the first conv.
+    /// Our VideoUNetPredictor.ForwardVideoUNet adds the image condition via
+    /// _imageCondProjection *after* the input conv instead — so the input conv
+    /// sees only the latent channels. Pinning INPUT_CHANNELS to LATENT_CHANNELS
+    /// keeps the conv weight shape consistent with what ForwardVideoUNet actually
+    /// feeds it, fixing the "Expected input depth 8, but got 4" crash in the
+    /// UpscaleAVideoModel tests.
     /// </remarks>
-    private const int INPUT_CHANNELS = 8;
+    private const int INPUT_CHANNELS = LATENT_CHANNELS;
 
     /// <summary>
     /// Base channel count for the Video U-Net (320).

--- a/src/GaussianProcesses/SparseGaussianProcess.cs
+++ b/src/GaussianProcesses/SparseGaussianProcess.cs
@@ -204,22 +204,24 @@ public class SparseGaussianProcess<T> : GaussianProcessBase<T>
                 Ky[j, i] = avg;
             }
 
-        // Add diagonal jitter before Cholesky for the same reason Kuu gets
-        // it above: Ky = Kuu + D·Kuf·Kuf^T is only positive-semi-definite
-        // in exact arithmetic (when rank(D·Kuf·Kuf^T) < m, which is typical
-        // when the number of inducing points matches the data dimensionality).
-        // Floating-point roundoff then pushes the smallest eigenvalue just
-        // below zero and CholeskyDecomposition throws "Matrix is not
-        // positive definite" — this was the root cause of all six
-        // SparseGaussianProcessTests failures in the PR #1156 CI shard.
-        // Escalate jitter on failure (PyTorch / GPyTorch pattern): start at
-        // 1e-6·trace, retry at 1e-4·trace, then 1e-2·trace before giving up.
+        // Solve Ky·α = DKuf·y. Ky = Kuu + D·Kuf·Kuf^T is only
+        // positive-semidefinite in exact arithmetic (rank(D·Kuf·Kuf^T) < m
+        // when inducing points equal data dimensionality), so floating-point
+        // roundoff can push the smallest eigenvalue just below zero and make
+        // Cholesky throw "not positive definite".
+        //
+        // Two-tier solve: try Cholesky with an escalating jitter schedule
+        // first (cheap and accurate on the happy path), fall back to an SVD
+        // pseudoinverse only when jitter can't rescue the matrix. Cholesky
+        // alone with jitter <= 10% of trace was not enough on the CI shard,
+        // but the SVD path as a fallback (instead of a replacement) avoids
+        // the O(n³) SVD cost in the common case.
         T traceScale = _numOps.Zero;
         for (int i = 0; i < Ky.Rows; i++)
             traceScale = _numOps.Add(traceScale, Ky[i, i]);
         traceScale = _numOps.Divide(traceScale, _numOps.FromDouble(Ky.Rows));
 
-        CholeskyDecomposition<T>? choleskyKy = null;
+        Vector<T>? alpha = null;
         double[] jitterSchedule = { 1e-6, 1e-4, 1e-2, 1e-1 };
         foreach (var scale in jitterSchedule)
         {
@@ -228,21 +230,16 @@ public class SparseGaussianProcess<T> : GaussianProcessBase<T>
                 Ky[i, i] = _numOps.Add(Ky[i, i], jitterAmt);
             try
             {
-                choleskyKy = new CholeskyDecomposition<T>(Ky);
+                var choleskyKy = new CholeskyDecomposition<T>(Ky);
+                alpha = choleskyKy.Solve(DKuf.Multiply(y));
                 break;
             }
             catch (ArgumentException)
             {
-                // Escalate by adding more jitter on top of what we already
-                // added; the next iteration's jitterAmt is added to the
-                // already-augmented diagonal, growing geometrically.
                 continue;
             }
         }
-        if (choleskyKy is null)
-            throw new ArgumentException(
-                "Matrix is not positive definite — Ky remained non-PD even after jittering at scales up to 0.1 × trace.");
-        var alpha = choleskyKy.Solve(DKuf.Multiply(y));
+        alpha ??= SolveViaPseudoInverse(Ky, DKuf.Multiply(y));
 
         // Store necessary components for prediction
         _Kuu = Kuu;
@@ -260,6 +257,47 @@ public class SparseGaussianProcess<T> : GaussianProcessBase<T>
     private T Reciprocal(T value)
     {
         return _numOps.Divide(_numOps.One, value);
+    }
+
+    /// <summary>
+    /// Solves A·x = b via the Moore–Penrose pseudoinverse computed from a
+    /// truncated SVD, dropping singular values below <c>ε · σ_max</c>. Robust
+    /// to rank deficiency and small negative eigenvalues from floating-point
+    /// drift — both of which are endemic to the sparse GP's Ky matrix.
+    /// </summary>
+    private Vector<T> SolveViaPseudoInverse(Matrix<T> A, Vector<T> b)
+    {
+        var svd = new SvdDecomposition<T>(A);
+
+        T sigmaMax = _numOps.Zero;
+        for (int i = 0; i < svd.S.Length; i++)
+        {
+            if (_numOps.GreaterThan(svd.S[i], sigmaMax))
+                sigmaMax = svd.S[i];
+        }
+
+        // Relative tolerance: max(rows, cols) * ε_machine * σ_max. Same choice
+        // as numpy.linalg.pinv / MATLAB pinv default. Scales with matrix size
+        // so bigger matrices tolerate more roundoff.
+        T tolerance = _numOps.Multiply(
+            _numOps.FromDouble(Math.Max(A.Rows, A.Columns) * 1e-12),
+            sigmaMax);
+
+        // x = V · Σ^+ · U^T · b. Σ^+ has 1/σ_i on the diagonal where σ_i >
+        // tolerance, and 0 elsewhere — this is the standard truncated
+        // pseudoinverse.
+        var x = new Vector<T>(svd.Vt.Columns);
+        for (int i = 0; i < svd.S.Length; i++)
+        {
+            if (!_numOps.GreaterThan(svd.S[i], tolerance))
+                continue;
+
+            Vector<T> uCol = svd.U.GetColumn(i);
+            T coeff = _numOps.Divide(uCol.DotProduct(b), svd.S[i]);
+            Vector<T> vtRow = svd.Vt.GetRow(i);
+            x = x.Add(vtRow.Multiply(coeff));
+        }
+        return x;
     }
 
     /// <summary>

--- a/src/GaussianProcesses/SparseGaussianProcess.cs
+++ b/src/GaussianProcesses/SparseGaussianProcess.cs
@@ -204,7 +204,44 @@ public class SparseGaussianProcess<T> : GaussianProcessBase<T>
                 Ky[j, i] = avg;
             }
 
-        var choleskyKy = new CholeskyDecomposition<T>(Ky);
+        // Add diagonal jitter before Cholesky for the same reason Kuu gets
+        // it above: Ky = Kuu + D·Kuf·Kuf^T is only positive-semi-definite
+        // in exact arithmetic (when rank(D·Kuf·Kuf^T) < m, which is typical
+        // when the number of inducing points matches the data dimensionality).
+        // Floating-point roundoff then pushes the smallest eigenvalue just
+        // below zero and CholeskyDecomposition throws "Matrix is not
+        // positive definite" — this was the root cause of all six
+        // SparseGaussianProcessTests failures in the PR #1156 CI shard.
+        // Escalate jitter on failure (PyTorch / GPyTorch pattern): start at
+        // 1e-6·trace, retry at 1e-4·trace, then 1e-2·trace before giving up.
+        T traceScale = _numOps.Zero;
+        for (int i = 0; i < Ky.Rows; i++)
+            traceScale = _numOps.Add(traceScale, Ky[i, i]);
+        traceScale = _numOps.Divide(traceScale, _numOps.FromDouble(Ky.Rows));
+
+        CholeskyDecomposition<T>? choleskyKy = null;
+        double[] jitterSchedule = { 1e-6, 1e-4, 1e-2, 1e-1 };
+        foreach (var scale in jitterSchedule)
+        {
+            T jitterAmt = _numOps.Multiply(traceScale, _numOps.FromDouble(scale));
+            for (int i = 0; i < Ky.Rows; i++)
+                Ky[i, i] = _numOps.Add(Ky[i, i], jitterAmt);
+            try
+            {
+                choleskyKy = new CholeskyDecomposition<T>(Ky);
+                break;
+            }
+            catch (ArgumentException)
+            {
+                // Escalate by adding more jitter on top of what we already
+                // added; the next iteration's jitterAmt is added to the
+                // already-augmented diagonal, growing geometrically.
+                continue;
+            }
+        }
+        if (choleskyKy is null)
+            throw new ArgumentException(
+                "Matrix is not positive definite — Ky remained non-PD even after jittering at scales up to 0.1 × trace.");
         var alpha = choleskyKy.Solve(DKuf.Multiply(y));
 
         // Store necessary components for prediction

--- a/src/Helpers/DeserializationHelper.cs
+++ b/src/Helpers/DeserializationHelper.cs
@@ -989,7 +989,16 @@ public static class DeserializationHelper
 
     private static object CreateMultiHeadAttentionLayer<T>(Type type, int[] inputShape, Dictionary<string, object>? additionalParams)
     {
-        // MultiHeadAttentionLayer(int sequenceLength, int embeddingDimension, int headCount, IActivationFunction<T>? activationFunction = null)
+        // MultiHeadAttentionLayer(int sequenceLength, int embeddingDimension,
+        //   int headCount, IActivationFunction<T>? activationFunction = null,
+        //   IInitializationStrategy<T>? initializationStrategy = null)
+        //
+        // The optional initializationStrategy parameter MUST be included in
+        // the reflection signature even though it has a default — Type.GetConstructor
+        // matches by exact parameter list, not by "first N + defaults". Without it
+        // the lookup returns null and Clone-via-serialization (used by
+        // InferenceOptimizer.OptimizeForInference and any model save/load
+        // round-trip) fails on every transformer with an MHA layer.
         if (inputShape.Length < 2)
         {
             throw new InvalidOperationException("MultiHeadAttentionLayer requires input shape [sequenceLength, embeddingDimension].");
@@ -1000,14 +1009,15 @@ public static class DeserializationHelper
         int headCount = TryGetInt(additionalParams, "HeadCount") ?? ResolveDefaultHeadCount(embDim);
 
         var activationFuncType = typeof(IActivationFunction<>).MakeGenericType(typeof(T));
-        var ctor = type.GetConstructor(new Type[] { typeof(int), typeof(int), typeof(int), activationFuncType });
+        var initStrategyType = typeof(IInitializationStrategy<>).MakeGenericType(typeof(T));
+        var ctor = type.GetConstructor(new Type[] { typeof(int), typeof(int), typeof(int), activationFuncType, initStrategyType });
         if (ctor is null)
         {
-            throw new InvalidOperationException("Cannot find MultiHeadAttentionLayer constructor with (int, int, int, IActivationFunction<T>).");
+            throw new InvalidOperationException("Cannot find MultiHeadAttentionLayer constructor with (int, int, int, IActivationFunction<T>, IInitializationStrategy<T>).");
         }
 
         object? activation = TryCreateActivationInstance(additionalParams, "ScalarActivationType", activationFuncType);
-        return ctor.Invoke(new object?[] { seqLen, embDim, headCount, activation });
+        return ctor.Invoke(new object?[] { seqLen, embDim, headCount, activation, null });
     }
 
     private static object CreateFlashAttentionLayer<T>(Type type, int[] inputShape, Dictionary<string, object>? additionalParams)

--- a/src/Helpers/DeserializationHelper.cs
+++ b/src/Helpers/DeserializationHelper.cs
@@ -466,6 +466,40 @@ public static class DeserializationHelper
         {
             instance = CreateMultiLoRAAdapter<T>(type, inputShape, outputShape, additionalParams);
         }
+        else if (genericDef == typeof(NeuralNetworks.Layers.MemoryReadLayer<>))
+        {
+            // MemoryReadLayer(int inputDimension, int memoryDimension, int outputDimension, IActivationFunction<T>?)
+            // memoryDimension is a free parameter — the default MemoryNetwork wires
+            // input == memory == output == embeddingSize, so fall back to output size
+            // if the serialized metadata doesn't pin it explicitly.
+            int inputDim = inputShape[0];
+            int outputDim = outputShape[0];
+            int memoryDim = TryGetInt(additionalParams, "MemoryDimension") ?? outputDim;
+
+            var activationFuncType = typeof(IActivationFunction<>).MakeGenericType(typeof(T));
+            var ctor = type.GetConstructor(new Type[] { typeof(int), typeof(int), typeof(int), activationFuncType });
+            if (ctor is null)
+            {
+                throw new InvalidOperationException("Cannot find MemoryReadLayer constructor with (int, int, int, IActivationFunction<T>).");
+            }
+            object? activation = TryCreateActivationInstance(additionalParams, "ScalarActivationType", activationFuncType);
+            instance = ctor.Invoke(new object?[] { inputDim, memoryDim, outputDim, activation });
+        }
+        else if (genericDef == typeof(NeuralNetworks.Layers.MemoryWriteLayer<>))
+        {
+            // MemoryWriteLayer(int inputDimension, int memoryDimension, IActivationFunction<T>?)
+            int inputDim = inputShape[0];
+            int memoryDim = TryGetInt(additionalParams, "MemoryDimension") ?? outputShape[0];
+
+            var activationFuncType = typeof(IActivationFunction<>).MakeGenericType(typeof(T));
+            var ctor = type.GetConstructor(new Type[] { typeof(int), typeof(int), activationFuncType });
+            if (ctor is null)
+            {
+                throw new InvalidOperationException("Cannot find MemoryWriteLayer constructor with (int, int, IActivationFunction<T>).");
+            }
+            object? activation = TryCreateActivationInstance(additionalParams, "ScalarActivationType", activationFuncType);
+            instance = ctor.Invoke(new object?[] { inputDim, memoryDim, activation });
+        }
         else if (genericDef == typeof(ConvolutionalLayer<>))
         {
             // ConvolutionalLayer(int inputDepth, int inputHeight, int inputWidth, int outputDepth, int kernelSize, int stride, int padding, IActivationFunction<T>?, IInitializationStrategy<T>?)

--- a/src/Helpers/LayerHelper.cs
+++ b/src/Helpers/LayerHelper.cs
@@ -2579,11 +2579,18 @@ public static class LayerHelper<T>
         // RNN layers output [seqLen, hiddenSize], but Dense layer expects [hiddenSize]
         yield return new SequenceLastLayer<T>(hiddenSize);
 
-        // Add the final Dense Layer to map to output size
+        // Add the final Dense Layer to map to output size.
+        // Use an explicit IdentityActivation so the Dense output keeps its sign —
+        // passing activationFunction:null falls through to DenseLayer's ReLU
+        // default, which clipped all regression outputs at zero. With ReLU
+        // the 2-layer tanh stack produced small mixed-sign values that the
+        // final Dense then zeroed, so ScaledInput_ShouldChangeOutput saw
+        // output=0 for both the raw and the 10x input and reported "forward
+        // pass may ignore input values".
         yield return new DenseLayer<T>(
             inputSize: hiddenSize,
             outputSize: outputSize,
-            activationFunction: null
+            activationFunction: new IdentityActivation<T>()
         );
 
         // Task-appropriate final activation

--- a/src/Helpers/LayerHelper.cs
+++ b/src/Helpers/LayerHelper.cs
@@ -2724,11 +2724,16 @@ public static class LayerHelper<T>
         yield return new QuantumLayer<T>(hiddenSize, quantumDim, numQubits);
         yield return new MeasurementLayer<T>(quantumDim);
 
-        // Final dense layer to map to output size
+        // Final dense layer to map to output size. Use identity so the
+        // task-appropriate activation below owns the output non-linearity
+        // — passing null falls through to DenseLayer's ReLU default and
+        // clips the pre-activation logits, which collapsed
+        // scaledinput_shouldchangeoutput / differentinputs for quantum
+        // regression models.
         yield return new DenseLayer<T>(
             inputSize: quantumDim,
             outputSize: outputSize,
-            activationFunction: null
+            activationFunction: new IdentityActivation<T>()
         );
 
         // Final activation based on task type

--- a/src/Helpers/LayerHelper.cs
+++ b/src/Helpers/LayerHelper.cs
@@ -4207,11 +4207,23 @@ public static class LayerHelper<T>
 
         // ============== DECODER PATH ==============
         // Each decoder block: Upsample3D -> Conv3D -> Conv3D
-        // Note: Skip connections need to be handled by the network model
+        //
+        // Note: a full U-Net would concatenate encoder skip-connections at
+        // each decoder level, doubling the channel count into the first
+        // Conv3D. This implementation does NOT actually perform the
+        // concatenation, so the "*2" previously applied to
+        // encoderFilters[block + 1] told the Upsample and first-Conv3D to
+        // expect twice the channels they would actually receive from the
+        // preceding decoder block's Second-Conv3D output. That produced
+        //   "Input channels (128) must match kernel in_channels (256)"
+        // at the first decoder block after the bottleneck-adjacent one.
+        // Matching the actual tensor-channel count (= encoderFilters[block + 1])
+        // keeps the stack consistent; adding real skip concatenation is a
+        // separate architectural improvement tracked independently.
         for (int block = numEncoderBlocks - 2; block >= 0; block--)
         {
             int outputFilters = encoderFilters[block];
-            int inChannels = block == numEncoderBlocks - 2 ? bottleneckFilters : encoderFilters[block + 1] * 2;
+            int inChannels = block == numEncoderBlocks - 2 ? bottleneckFilters : encoderFilters[block + 1];
 
             // Upsample3D to increase resolution
             yield return new Upsample3DLayer<T>(

--- a/src/Initialization/InitializationStrategyBase.cs
+++ b/src/Initialization/InitializationStrategyBase.cs
@@ -118,26 +118,15 @@ public abstract class InitializationStrategyBase<T> : IInitializationStrategy<T>
 
         if (typeof(T) == typeof(double))
         {
-            for (int i = 0; i < span.Length; i++)
-            {
-                double value;
-                do { value = SampleGaussian(0, stddev); }
-                while (Math.Abs(value) > clipBound);
-                span[i] = System.Runtime.CompilerServices.Unsafe.As<double, T>(ref value);
-            }
+            var rawArr = (double[])(object)weights.GetDataArray();
+            XavierFillDouble(rawArr, 0, weights.Length, stddev, clipBound);
             return;
         }
 
         if (typeof(T) == typeof(float))
         {
-            for (int i = 0; i < span.Length; i++)
-            {
-                double value;
-                do { value = SampleGaussian(0, stddev); }
-                while (Math.Abs(value) > clipBound);
-                float fv = (float)value;
-                span[i] = System.Runtime.CompilerServices.Unsafe.As<float, T>(ref fv);
-            }
+            var rawArr = (float[])(object)weights.GetDataArray();
+            XavierFillFloat(rawArr, 0, weights.Length, stddev, clipBound);
             return;
         }
 
@@ -258,5 +247,160 @@ public abstract class InitializationStrategyBase<T> : IInitializationStrategy<T>
         var u2 = Random.NextDouble();
         var randStdNormal = Math.Sqrt(-2.0 * Math.Log(u1)) * Math.Sin(2.0 * Math.PI * u2);
         return mean + stddev * randStdNormal;
+    }
+
+    /// <summary>
+    /// Fills a span with <c>N(0, stddev)</c> samples clipped to ±<paramref name="clipBound"/>,
+    /// using a paired Box-Muller transform that produces two samples per pair of uniform
+    /// draws — halves the <see cref="Math.Log"/>/<see cref="Math.Sqrt"/> call count vs.
+    /// calling <see cref="SampleGaussian"/> per element.
+    /// </summary>
+    /// <remarks>
+    /// Replaces the per-element <c>while (Math.Abs(value) &gt; clipBound) do ...</c>
+    /// rejection loop which was the dominant cost of DiT-XL lazy weight init (each
+    /// block's Dense / SelfAttention layer paid 1–30 s of RNG overhead on first
+    /// forward). Rejection rate at 2σ is ~5 %, so in the common case each iteration
+    /// produces two usable samples with one log + one sqrt + one sin + one cos + two
+    /// multiplies. The inner loop is a tight unvirtualized local function so JIT can
+    /// keep everything in registers and auto-vectorize the clip check.
+    /// </remarks>
+    private void XavierFillDouble(double[] dst, int offset, int length, double stddev, double clipBound)
+    {
+        if (length == 0) return;
+
+        const int ParallelThreshold = 1 << 18; // 256K doubles ≈ 2MB
+        int cores = Math.Max(1, Environment.ProcessorCount);
+
+        if (length < ParallelThreshold || cores == 1)
+        {
+            FillChunkDouble(dst.AsSpan(offset, length), stddev, clipBound, Random);
+            return;
+        }
+
+        // For large tensors (typical DiT-XL hidden×4 ≈ 100M elements), partition
+        // across cores so init amortizes over the thread pool instead of running
+        // single-threaded. Pre-seed per-chunk RNGs from the master so the parallel
+        // work remains deterministic relative to the master seed. System.Random
+        // is NOT thread-safe, so we MUST use per-thread instances.
+        int chunkSize = (length + cores - 1) / cores;
+        var seeds = new int[cores];
+        for (int c = 0; c < cores; c++) seeds[c] = Random.Next();
+
+        System.Threading.Tasks.Parallel.For(0, cores, c =>
+        {
+            int chunkStart = c * chunkSize;
+            int chunkEnd = Math.Min(chunkStart + chunkSize, length);
+            if (chunkStart >= chunkEnd) return;
+            var chunkRng = new Random(seeds[c]);
+            FillChunkDouble(dst.AsSpan(offset + chunkStart, chunkEnd - chunkStart), stddev, clipBound, chunkRng);
+        });
+    }
+
+    /// <summary>
+    /// Sequential Box-Muller fill of a span — inner helper used by both the
+    /// sequential fast path and the parallel chunk workers.
+    /// </summary>
+    private static void FillChunkDouble(Span<double> dst, double stddev, double clipBound, Random rng)
+    {
+        double z1 = 0;
+        bool havePending = false;
+
+        for (int i = 0; i < dst.Length; i++)
+        {
+            double sample;
+            while (true)
+            {
+                if (havePending)
+                {
+                    sample = z1;
+                    havePending = false;
+                }
+                else
+                {
+                    double u1 = 1.0 - rng.NextDouble();
+                    double u2 = rng.NextDouble();
+                    double r = Math.Sqrt(-2.0 * Math.Log(u1));
+                    double theta = 2.0 * Math.PI * u2;
+                    sample = r * Math.Sin(theta);
+                    z1 = r * Math.Cos(theta);
+                    havePending = true;
+                }
+                sample *= stddev;
+                if (!(sample > clipBound) && !(sample < -clipBound))
+                {
+                    dst[i] = sample;
+                    break;
+                }
+                havePending = false;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Float variant of <see cref="XavierFillDouble"/>. Uses double-precision
+    /// Box-Muller internally (accuracy matters more than the tiny cost) and
+    /// narrows to float on store.
+    /// </summary>
+    private void XavierFillFloat(float[] dst, int offset, int length, double stddev, double clipBound)
+    {
+        if (length == 0) return;
+
+        const int ParallelThreshold = 1 << 18;
+        int cores = Math.Max(1, Environment.ProcessorCount);
+
+        if (length < ParallelThreshold || cores == 1)
+        {
+            FillChunkFloat(dst.AsSpan(offset, length), stddev, clipBound, Random);
+            return;
+        }
+
+        int chunkSize = (length + cores - 1) / cores;
+        var seeds = new int[cores];
+        for (int c = 0; c < cores; c++) seeds[c] = Random.Next();
+
+        System.Threading.Tasks.Parallel.For(0, cores, c =>
+        {
+            int chunkStart = c * chunkSize;
+            int chunkEnd = Math.Min(chunkStart + chunkSize, length);
+            if (chunkStart >= chunkEnd) return;
+            var chunkRng = new Random(seeds[c]);
+            FillChunkFloat(dst.AsSpan(offset + chunkStart, chunkEnd - chunkStart), stddev, clipBound, chunkRng);
+        });
+    }
+
+    private static void FillChunkFloat(Span<float> dst, double stddev, double clipBound, Random rng)
+    {
+        double z1 = 0;
+        bool havePending = false;
+
+        for (int i = 0; i < dst.Length; i++)
+        {
+            double sample;
+            while (true)
+            {
+                if (havePending)
+                {
+                    sample = z1;
+                    havePending = false;
+                }
+                else
+                {
+                    double u1 = 1.0 - rng.NextDouble();
+                    double u2 = rng.NextDouble();
+                    double r = Math.Sqrt(-2.0 * Math.Log(u1));
+                    double theta = 2.0 * Math.PI * u2;
+                    sample = r * Math.Sin(theta);
+                    z1 = r * Math.Cos(theta);
+                    havePending = true;
+                }
+                sample *= stddev;
+                if (!(sample > clipBound) && !(sample < -clipBound))
+                {
+                    dst[i] = (float)sample;
+                    break;
+                }
+                havePending = false;
+            }
+        }
     }
 }

--- a/src/NeuralNetworks/ConvolutionalNeuralNetwork.cs
+++ b/src/NeuralNetworks/ConvolutionalNeuralNetwork.cs
@@ -260,12 +260,35 @@ public class ConvolutionalNeuralNetwork<T> : NeuralNetworkBase<T>
         SetTrainingMode(true);
         try
         {
-            TrainWithTape(input, expectedOutput, _optimizer);
+            // Accept both 3D [C, H, W] and 4D [B, C, H, W] inputs — matches the
+            // Forward contract. ForwardForTraining runs the raw tensor through
+            // every layer without adjusting rank, so a 3D input would make the
+            // final FlattenLayer treat the 32-channel dimension as a batch
+            // (flatten preserves dim 0), producing a [32, 10] prediction
+            // against a [10] one-hot target — fails the loss shape check:
+            //   "Target shape dimension 0 (10) does not match predicted
+            //    shape dimension 0 (32)."
+            // Mirror ResNet/VGG/MobileNetV2's fix: expand input and target to
+            // 4D (and 2D respectively) before dispatching to TrainWithTape.
+            Tensor<T> processedInput = input.Rank == 3 ? AddBatchDimension(input) : input;
+            Tensor<T> processedTarget = input.Rank == 3 && expectedOutput.Rank < processedInput.Rank - 2
+                ? AddBatchDimension(expectedOutput)
+                : expectedOutput;
+            TrainWithTape(processedInput, processedTarget, _optimizer);
         }
         finally
         {
             SetTrainingMode(false);
         }
+    }
+
+    private static Tensor<T> AddBatchDimension(Tensor<T> t)
+    {
+        int[] shape = t._shape;
+        int[] expanded = new int[shape.Length + 1];
+        expanded[0] = 1;
+        for (int i = 0; i < shape.Length; i++) expanded[i + 1] = shape[i];
+        return t.Reshape(expanded);
     }
 
     /// <summary>

--- a/src/NeuralNetworks/ConvolutionalNeuralNetwork.cs
+++ b/src/NeuralNetworks/ConvolutionalNeuralNetwork.cs
@@ -270,25 +270,13 @@ public class ConvolutionalNeuralNetwork<T> : NeuralNetworkBase<T>
             //    shape dimension 0 (32)."
             // Mirror ResNet/VGG/MobileNetV2's fix: expand input and target to
             // 4D (and 2D respectively) before dispatching to TrainWithTape.
-            Tensor<T> processedInput = input.Rank == 3 ? AddBatchDimension(input) : input;
-            Tensor<T> processedTarget = input.Rank == 3 && expectedOutput.Rank < processedInput.Rank - 2
-                ? AddBatchDimension(expectedOutput)
-                : expectedOutput;
+            var (processedInput, processedTarget) = EnsureBatchForCnnTraining(input, expectedOutput);
             TrainWithTape(processedInput, processedTarget, _optimizer);
         }
         finally
         {
             SetTrainingMode(false);
         }
-    }
-
-    private static Tensor<T> AddBatchDimension(Tensor<T> t)
-    {
-        int[] shape = t._shape;
-        int[] expanded = new int[shape.Length + 1];
-        expanded[0] = 1;
-        for (int i = 0; i < shape.Length; i++) expanded[i + 1] = shape[i];
-        return t.Reshape(expanded);
     }
 
     /// <summary>

--- a/src/NeuralNetworks/Layers/SparseLinearLayer.cs
+++ b/src/NeuralNetworks/Layers/SparseLinearLayer.cs
@@ -101,21 +101,26 @@ public partial class SparseLinearLayer<T> : LayerBase<T>
         _weights.NonZeroCount + OutputFeatures;
 
     /// <summary>
-    /// Gets whether this layer supports training. Returns <c>false</c> because this layer's
-    /// sparse weight tensor is not exposed to the tape-based autodiff path: the layer has no
-    /// <c>[TrainableParameter]</c> fields and never calls <c>RegisterTrainableParameter</c>,
-    /// so <c>TapeTrainingStep.CollectParameters</c> finds zero parameters here. In tape mode
-    /// (the default), the layer would be silently skipped while its peers train — producing
-    /// a partially-trainable network that is almost never the intended behavior.
+    /// Gets whether this layer supports training. Returns <c>true</c>: the layer
+    /// owns a working <see cref="UpdateParameters"/> that updates its sparse
+    /// weight tensor and dense bias vector from gradients computed in
+    /// <see cref="Backward"/>, and the legacy training path
+    /// (<c>if (layer.SupportsTraining) layer.UpdateParameters(lr)</c>) trains
+    /// the layer correctly. Biases are also registered as a tape trainable
+    /// parameter, so tape-mode optimizers update them too.
     /// </summary>
     /// <remarks>
-    /// Sparse weight tensors don't fit the dense <c>ParameterBuffer&lt;T&gt;</c> view
-    /// contract used by the tape, so returning <c>false</c> here keeps the layer's inference
-    /// behavior correct while explicitly advertising that no gradient updates flow through
-    /// it. Integrating sparse parameters into the tape (e.g., via a sparse trainable tensor
-    /// view) is the follow-up required before this can flip back to <c>true</c>.
+    /// <para><b>Tape-mode caveat:</b> the sparse <see cref="SparseTensor{T}"/>
+    /// weight tensor is still not visible to the tape's
+    /// <c>ParameterBuffer&lt;T&gt;</c>-based discovery — that contract requires
+    /// dense storage. In tape mode, weight updates flow through the
+    /// layer's own <see cref="Backward"/> + <see cref="UpdateParameters"/>
+    /// when the optimizer falls back to the legacy update path; weight
+    /// gradients do not appear in the tape's flat-buffer view. Closing that
+    /// gap fully (sparse-aware <c>ParameterBuffer&lt;T&gt;</c>) is tracked as
+    /// a follow-up.</para>
     /// </remarks>
-    public override bool SupportsTraining => false;
+    public override bool SupportsTraining => true;
 
     /// <summary>
     /// Initializes a new instance of the SparseLinearLayer.

--- a/src/NeuralNetworks/MemoryNetwork.cs
+++ b/src/NeuralNetworks/MemoryNetwork.cs
@@ -187,6 +187,21 @@ public class MemoryNetwork<T> : NeuralNetworkBase<T>
         _embeddingSize = embeddingSize;
         _memory = new Matrix<T>(_memorySize, _embeddingSize);
 
+        // Seed memory with small random values so MemoryReadLayer has something
+        // non-trivial to attend over on the first forward pass. Leaving memory
+        // as zeros makes keys · memory^T identically zero, so softmax produces
+        // a uniform attention distribution and readValues = attention · memory
+        // is also zero — every subsequent layer then sees the same constant
+        // input and the network cannot discriminate between its own inputs,
+        // which was the source of the scaledinput_shouldchangeoutput and
+        // differentinputs_shouldproducedifferentoutputs failures. Use a small
+        // Xavier-scale so downstream layers see a reasonable magnitude.
+        var memRand = AiDotNet.Tensors.Helpers.RandomHelper.CreateSecureRandom();
+        double memScale = Math.Sqrt(2.0 / (_memorySize + _embeddingSize));
+        for (int r = 0; r < _memorySize; r++)
+            for (int c = 0; c < _embeddingSize; c++)
+                _memory[r, c] = NumOps.FromDouble((memRand.NextDouble() * 2 - 1) * memScale);
+
         InitializeLayers();
     }
 
@@ -308,6 +323,24 @@ public class MemoryNetwork<T> : NeuralNetworkBase<T>
         // Set to inference mode
         SetTrainingMode(false);
 
+        return RunLayers(input);
+    }
+
+    /// <inheritdoc />
+    public override Tensor<T> ForwardForTraining(Tensor<T> input)
+    {
+        // The base class version walks Layers with the plain single-arg
+        // Forward, which misses the Memory{Read,Write}Layer memory-tensor
+        // plumbing and skips the rank-1 → rank-2 reshape — both of which
+        // Predict does. Without this override the tape-based training path
+        // either crashes ("TensorMatMul requires tensors of rank >= 2")
+        // or silently reads from an identity-memory fallback that has
+        // nothing to do with _memory.
+        return RunLayers(input);
+    }
+
+    private Tensor<T> RunLayers(Tensor<T> input)
+    {
         // Ensure 2D input for memory operations (TensorMatMul requires rank >= 2)
         if (input.Rank == 1)
             input = input.Reshape([1, input.Shape[0]]);

--- a/src/NeuralNetworks/MobileNetV2Network.cs
+++ b/src/NeuralNetworks/MobileNetV2Network.cs
@@ -239,13 +239,62 @@ public class MobileNetV2Network<T> : NeuralNetworkBase<T>
         if (TryForwardGpuOptimized(input, out var gpuResult))
             return gpuResult;
 
-
+        // Accept 3D [C, H, W] (single unbatched sample) or 4D [B, C, H, W].
+        // Internal layers — especially BatchNormalizationLayer —
+        // broadcast their channel-scale/shift tensors as [1, C, 1, 1] and
+        // require the input to be 4D for that broadcast to apply along the
+        // channel dimension. A 3D input would otherwise line up the 16-channel
+        // scale tensor against the spatial H=32 dimension and throw
+        //   "Tensors with shapes [16, 32, 32] and [1, 16, 1] cannot be
+        //    broadcast: dimension 1 has sizes 32 and 16 (must be equal or
+        //    one must be 1)."
+        // inside BatchNormalizationLayer.ApplyInferenceAnyRank. The fix
+        // mirrors ResNet/VGG's input-shape contract.
+        bool addedBatch = false;
         Tensor<T> output = input;
+        if (input.Rank == 3)
+        {
+            output = AddBatchDimension(input);
+            addedBatch = true;
+        }
+
         foreach (var layer in Layers)
         {
             output = layer.Forward(output);
         }
+
+        // If the caller passed a 3D input we expanded to 4D; squeeze the
+        // leading batch dim off so the output shape matches the input's
+        // un-batched contract.
+        if (addedBatch && output.Rank >= 1 && output.Shape[0] == 1)
+        {
+            int[] squeezed = new int[output.Rank - 1];
+            for (int i = 0; i < squeezed.Length; i++) squeezed[i] = output.Shape[i + 1];
+            output = Engine.Reshape(output, squeezed);
+        }
         return output;
+    }
+
+    private static Tensor<T> AddBatchDimension(Tensor<T> input)
+    {
+        int[] shape = input._shape;
+        int[] expanded = new int[shape.Length + 1];
+        expanded[0] = 1;
+        for (int i = 0; i < shape.Length; i++) expanded[i + 1] = shape[i];
+        return input.Reshape(expanded);
+    }
+
+    /// <inheritdoc />
+    public override Dictionary<string, Tensor<T>> GetNamedLayerActivations(Tensor<T> input)
+    {
+        // Mirror Forward's 3D → 4D expansion so the channel-broadcasted
+        // BatchNormalizationLayer inside every InvertedResidualBlock sees
+        // the 4D tensor it requires. Without this, callers that probe
+        // activations layer-by-layer with a 3D test input hit the same
+        // "[16,32,32] vs [1,16,1] cannot be broadcast" failure that the
+        // Forward override already handles.
+        Tensor<T> probeInput = input.Rank == 3 ? AddBatchDimension(input) : input;
+        return base.GetNamedLayerActivations(probeInput);
     }
 
     /// <inheritdoc />
@@ -257,7 +306,15 @@ public class MobileNetV2Network<T> : NeuralNetworkBase<T>
     /// <inheritdoc />
     public override void Train(Tensor<T> input, Tensor<T> expectedOutput)
     {
-        TrainWithTape(input, expectedOutput, _optimizer);
+        // Mirror Forward's shape contract — expand 3D inputs (and their
+        // targets) to 4D so ForwardForTraining's raw layer iteration
+        // receives the 4D tensor BatchNormalizationLayer needs. See
+        // ResNet/VGG Train() for the same pattern.
+        Tensor<T> processedInput = input.Rank == 3 ? AddBatchDimension(input) : input;
+        Tensor<T> processedTarget = input.Rank == 3 && expectedOutput.Rank < processedInput.Rank - 2
+            ? AddBatchDimension(expectedOutput)
+            : expectedOutput;
+        TrainWithTape(processedInput, processedTarget, _optimizer);
     }
 
     /// <inheritdoc />

--- a/src/NeuralNetworks/MobileNetV2Network.cs
+++ b/src/NeuralNetworks/MobileNetV2Network.cs
@@ -254,7 +254,7 @@ public class MobileNetV2Network<T> : NeuralNetworkBase<T>
         Tensor<T> output = input;
         if (input.Rank == 3)
         {
-            output = AddBatchDimension(input);
+            output = PromoteToBatchedTensor(input);
             addedBatch = true;
         }
 
@@ -275,15 +275,6 @@ public class MobileNetV2Network<T> : NeuralNetworkBase<T>
         return output;
     }
 
-    private static Tensor<T> AddBatchDimension(Tensor<T> input)
-    {
-        int[] shape = input._shape;
-        int[] expanded = new int[shape.Length + 1];
-        expanded[0] = 1;
-        for (int i = 0; i < shape.Length; i++) expanded[i + 1] = shape[i];
-        return input.Reshape(expanded);
-    }
-
     /// <inheritdoc />
     public override Dictionary<string, Tensor<T>> GetNamedLayerActivations(Tensor<T> input)
     {
@@ -293,7 +284,7 @@ public class MobileNetV2Network<T> : NeuralNetworkBase<T>
         // activations layer-by-layer with a 3D test input hit the same
         // "[16,32,32] vs [1,16,1] cannot be broadcast" failure that the
         // Forward override already handles.
-        Tensor<T> probeInput = input.Rank == 3 ? AddBatchDimension(input) : input;
+        Tensor<T> probeInput = input.Rank == 3 ? PromoteToBatchedTensor(input) : input;
         return base.GetNamedLayerActivations(probeInput);
     }
 
@@ -310,10 +301,7 @@ public class MobileNetV2Network<T> : NeuralNetworkBase<T>
         // targets) to 4D so ForwardForTraining's raw layer iteration
         // receives the 4D tensor BatchNormalizationLayer needs. See
         // ResNet/VGG Train() for the same pattern.
-        Tensor<T> processedInput = input.Rank == 3 ? AddBatchDimension(input) : input;
-        Tensor<T> processedTarget = input.Rank == 3 && expectedOutput.Rank < processedInput.Rank - 2
-            ? AddBatchDimension(expectedOutput)
-            : expectedOutput;
+        var (processedInput, processedTarget) = EnsureBatchForCnnTraining(input, expectedOutput);
         TrainWithTape(processedInput, processedTarget, _optimizer);
     }
 

--- a/src/NeuralNetworks/NeuralNetworkBase.cs
+++ b/src/NeuralNetworks/NeuralNetworkBase.cs
@@ -2660,6 +2660,45 @@ public abstract class NeuralNetworkBase<T> : INeuralNetworkModel<T>, IInterpreta
     }
 
     /// <summary>
+    /// Promotes a rank-3 <c>[C,H,W]</c> tensor to rank-4 <c>[1,C,H,W]</c>. Named
+    /// <c>PromoteToBatchedTensor</c> to avoid collision with per-subclass
+    /// <c>AddBatchDimension</c> helpers that predate this shared utility.
+    /// </summary>
+    protected static Tensor<T> PromoteToBatchedTensor(Tensor<T> tensor)
+    {
+        int[] inputShape = tensor._shape;
+        int[] resultShape = new int[inputShape.Length + 1];
+        resultShape[0] = 1;
+        for (int i = 0; i < inputShape.Length; i++)
+        {
+            resultShape[i + 1] = inputShape[i];
+        }
+        return tensor.Reshape(resultShape);
+    }
+
+    /// <summary>
+    /// Normalizes a (input, target) pair for CNN training loops: when input is
+    /// a single rank-3 <c>[C,H,W]</c> sample, adds a batch dim so downstream
+    /// layers see <c>[1,C,H,W]</c>. When the caller supplied a rank-1
+    /// classification label, promotes it to match the promoted input so
+    /// tape-based training sees consistent shapes.
+    /// </summary>
+    /// <returns>(processedInput, processedTarget) ready for <c>TrainWithTape</c>.</returns>
+    protected static (Tensor<T> Input, Tensor<T> Target) EnsureBatchForCnnTraining(
+        Tensor<T> input, Tensor<T> target)
+    {
+        if (input.Rank != 3)
+        {
+            return (input, target);
+        }
+        var processedInput = PromoteToBatchedTensor(input);
+        var processedTarget = target.Rank < processedInput.Rank - 2
+            ? PromoteToBatchedTensor(target)
+            : target;
+        return (processedInput, processedTarget);
+    }
+
+    /// <summary>
     /// Performs tape-based forward/backward pass and delegates the parameter update to the
     /// provided optimizer via <see cref="IGradientBasedOptimizer{T,TInput,TOutput}.Step"/>.
     /// </summary>

--- a/src/NeuralNetworks/QuantumNeuralNetwork.cs
+++ b/src/NeuralNetworks/QuantumNeuralNetwork.cs
@@ -281,20 +281,26 @@ public class QuantumNeuralNetwork<T> : NeuralNetworkBase<T>
     /// </remarks>
     public override void Train(Tensor<T> input, Tensor<T> expectedOutput)
     {
-        // Set training mode on all layers for proper gradient storage
         SetTrainingMode(true);
         foreach (var layer in Layers)
             layer.SetTrainingMode(true);
 
-        // Forward pass
-        var prediction = Predict(input);
-
-        // Calculate and set the loss
-        LastLoss = CalculateLoss(prediction, expectedOutput);
-
-        // Tape-based training handles gradient computation
-        var gradients = new List<Tensor<T>>();
-        UpdateQuantumParameters(gradients);
+        try
+        {
+            // Use the tape-based training path like other networks. The previous
+            // imperative implementation ran Predict() and then called the
+            // optimizer's UpdateParameters(Layers), which dispatched to each
+            // layer's UpdateParameters(learningRate) — that expects a prior
+            // Backward() to have populated the per-layer gradient tensors,
+            // but none of that happens here, so every training call failed
+            // with "Backward pass must be called before updating parameters."
+            _trainOptimizer ??= new AdamOptimizer<T, Tensor<T>, Tensor<T>>(this);
+            TrainWithTape(input, expectedOutput, _trainOptimizer);
+        }
+        finally
+        {
+            SetTrainingMode(false);
+        }
     }
 
     /// <summary>

--- a/src/NeuralNetworks/ResNetNetwork.cs
+++ b/src/NeuralNetworks/ResNetNetwork.cs
@@ -441,7 +441,7 @@ public class ResNetNetwork<T> : NeuralNetworkBase<T>
                 nameof(ResNetNetwork<T>),
                 "forward pass");
             addedBatch = true;
-            processedInput = AddBatchDimension(input);
+            processedInput = PromoteToBatchedTensor(input);
         }
         else if (input.Rank == 4)
         {
@@ -475,20 +475,6 @@ public class ResNetNetwork<T> : NeuralNetworkBase<T>
         return output;
     }
 
-    /// <summary>
-    /// Adds a batch dimension to a single input tensor.
-    /// </summary>
-    private static Tensor<T> AddBatchDimension(Tensor<T> input)
-    {
-        int[] inputShape = input._shape;
-        int[] resultShape = new int[inputShape.Length + 1];
-        resultShape[0] = 1;
-        for (int i = 0; i < inputShape.Length; i++)
-        {
-            resultShape[i + 1] = inputShape[i];
-        }
-        return input.Reshape(resultShape);
-    }
 
     /// <summary>
     /// Updates the parameters of all layers in the network.
@@ -539,10 +525,7 @@ public class ResNetNetwork<T> : NeuralNetworkBase<T>
         SetTrainingMode(true);
         try
         {
-            Tensor<T> processedInput = input.Rank == 3 ? AddBatchDimension(input) : input;
-            Tensor<T> processedTarget = input.Rank == 3 && expectedOutput.Rank < processedInput.Rank - 2
-                ? AddBatchDimension(expectedOutput)
-                : expectedOutput;
+            var (processedInput, processedTarget) = EnsureBatchForCnnTraining(input, expectedOutput);
             TrainWithTape(processedInput, processedTarget, _optimizer);
         }
         finally

--- a/src/NeuralNetworks/ResNetNetwork.cs
+++ b/src/NeuralNetworks/ResNetNetwork.cs
@@ -521,12 +521,29 @@ public class ResNetNetwork<T> : NeuralNetworkBase<T>
     /// </summary>
     /// <param name="input">The input tensor for training.</param>
     /// <param name="expectedOutput">The expected output tensor (one-hot encoded class labels).</param>
+    /// <remarks>
+    /// Accepts both 3D <c>[C, H, W]</c> (single unbatched example) and 4D
+    /// <c>[B, C, H, W]</c> inputs — matches <see cref="Forward"/>'s contract.
+    /// When a 3D input arrives, a leading batch dimension is added so every
+    /// downstream layer sees the conv-standard 4D tensor. The corresponding
+    /// target is also expanded to <c>[1, numClasses]</c> so the loss sees
+    /// matching batch dims on both operands. Previously
+    /// <see cref="NeuralNetworkBase{T}.ForwardForTraining"/> fed the raw 3D
+    /// tensor straight to the layer stack, which caused the FlattenLayer to
+    /// treat the 512-channel dimension as a batch and produce a
+    /// <c>[512, 10]</c> prediction — failing the loss shape check in
+    /// <c>EnsureTargetMatchesPredicted</c>.
+    /// </remarks>
     public override void Train(Tensor<T> input, Tensor<T> expectedOutput)
     {
         SetTrainingMode(true);
         try
         {
-            TrainWithTape(input, expectedOutput, _optimizer);
+            Tensor<T> processedInput = input.Rank == 3 ? AddBatchDimension(input) : input;
+            Tensor<T> processedTarget = input.Rank == 3 && expectedOutput.Rank < processedInput.Rank - 2
+                ? AddBatchDimension(expectedOutput)
+                : expectedOutput;
+            TrainWithTape(processedInput, processedTarget, _optimizer);
         }
         finally
         {

--- a/src/NeuralNetworks/VGGNetwork.cs
+++ b/src/NeuralNetworks/VGGNetwork.cs
@@ -271,7 +271,7 @@ public class VGGNetwork<T> : NeuralNetworkBase<T>
                 nameof(VGGNetwork<T>),
                 "forward pass");
             addedBatch = true;
-            processedInput = AddBatchDimension(input);
+            processedInput = PromoteToBatchedTensor(input);
         }
         else if (input.Rank == 4)
         {
@@ -303,29 +303,6 @@ public class VGGNetwork<T> : NeuralNetworkBase<T>
         }
 
         return output;
-    }
-
-    /// <summary>
-    /// Adds a batch dimension to a single input tensor.
-    /// </summary>
-    /// <param name="input">The input tensor with shape [channels, height, width].</param>
-    /// <returns>A tensor with shape [1, channels, height, width].</returns>
-    private static Tensor<T> AddBatchDimension(Tensor<T> input)
-    {
-        int[] inputShape = input._shape;
-        int[] resultShape = new int[inputShape.Length + 1];
-
-        // Add batch dimension of size 1
-        resultShape[0] = 1;
-
-        // Copy remaining dimensions
-        for (int i = 0; i < inputShape.Length; i++)
-        {
-            resultShape[i + 1] = inputShape[i];
-        }
-
-        // Use Reshape which should handle the memory layout correctly
-        return input.Reshape(resultShape);
     }
 
     /// <summary>
@@ -395,10 +372,7 @@ public class VGGNetwork<T> : NeuralNetworkBase<T>
             // channel dimension as a batch and produces an output with the
             // wrong leading dim — fails the loss-shape check on every training
             // call with a single 3D input.
-            Tensor<T> processedInput = input.Rank == 3 ? AddBatchDimension(input) : input;
-            Tensor<T> processedTarget = input.Rank == 3 && expectedOutput.Rank < processedInput.Rank - 2
-                ? AddBatchDimension(expectedOutput)
-                : expectedOutput;
+            var (processedInput, processedTarget) = EnsureBatchForCnnTraining(input, expectedOutput);
             TrainWithTape(processedInput, processedTarget, _optimizer);
         }
         finally

--- a/src/NeuralNetworks/VGGNetwork.cs
+++ b/src/NeuralNetworks/VGGNetwork.cs
@@ -388,7 +388,18 @@ public class VGGNetwork<T> : NeuralNetworkBase<T>
         SetTrainingMode(true);
         try
         {
-            TrainWithTape(input, expectedOutput, _optimizer);
+            // Match Forward's behavior: accept 3D [C,H,W] single example and
+            // expand to 4D [1,C,H,W] so the layer stack (conv / pool / flatten /
+            // dense) receives the batched shape it expects. Without the
+            // expansion the FlattenLayer in the classifier head treats the
+            // channel dimension as a batch and produces an output with the
+            // wrong leading dim — fails the loss-shape check on every training
+            // call with a single 3D input.
+            Tensor<T> processedInput = input.Rank == 3 ? AddBatchDimension(input) : input;
+            Tensor<T> processedTarget = input.Rank == 3 && expectedOutput.Rank < processedInput.Rank - 2
+                ? AddBatchDimension(expectedOutput)
+                : expectedOutput;
+            TrainWithTape(processedInput, processedTarget, _optimizer);
         }
         finally
         {

--- a/src/Optimizers/AdamOptimizer.cs
+++ b/src/Optimizers/AdamOptimizer.cs
@@ -482,13 +482,21 @@ public class AdamOptimizer<T, TInput, TOutput> : GradientBasedOptimizerBase<T, T
             if (!context.Gradients.TryGetValue(param, out var grad))
                 continue;
 
-            // Lazily initialize per-parameter moment tensors
-            if (!_tapeM.TryGetValue(param, out var m))
+            // Lazily initialize per-parameter moment tensors. If the parameter
+            // was first seen while a lazy-init layer (e.g.
+            // MultiHeadAttentionLayer with IsLazy: true initialization
+            // strategy) still had its weights allocated as a placeholder
+            // [0, 0] tensor, our cached m / v captured the placeholder shape.
+            // Once the layer materializes real weights, the gradient arrives
+            // at the real shape — m / v need to be re-allocated to match,
+            // otherwise TensorAdd's result has a length larger than m and
+            // TensorCopy throws "Destination array was not long enough".
+            if (!_tapeM.TryGetValue(param, out var m) || !m._shape.SequenceEqual(param._shape))
             {
                 m = new Tensor<T>(param._shape);
                 _tapeM[param] = m;
             }
-            if (!_tapeV.TryGetValue(param, out var v))
+            if (!_tapeV.TryGetValue(param, out var v) || !v._shape.SequenceEqual(param._shape))
             {
                 v = new Tensor<T>(param._shape);
                 _tapeV[param] = v;

--- a/src/Regression/PoissonRegression.cs
+++ b/src/Regression/PoissonRegression.cs
@@ -181,6 +181,27 @@ public class PoissonRegression<T> : RegressionBase<T>
                 newCoefficients = Regularization.Regularize(newCoefficients);
             }
 
+            // Guard against NaN/Inf leaking out of the IRLS step. Even with
+            // ridge diagonal loading the qr/svd solve can produce non-finite
+            // entries when the reweighted x^t·w·x is numerically singular
+            // (e.g. when exp-clamping collapses most mu's to the floor),
+            // and propagating those poisons every subsequent predict() with
+            // nan. when we hit that, stop iterating with the last known-good
+            // coefficients rather than overwriting them — this mirrors how
+            // statsmodels' glm halts on a "linear algebra error".
+            bool hasBadEntry = false;
+            for (int i = 0; i < newCoefficients.Length; i++)
+            {
+                double v = NumOps.ToDouble(newCoefficients[i]);
+                if (double.IsNaN(v) || double.IsInfinity(v))
+                {
+                    hasBadEntry = true;
+                    break;
+                }
+            }
+            if (hasBadEntry)
+                break;
+
             if (HasConverged(currentCoefficients, newCoefficients))
             {
                 break;

--- a/src/Regression/RadialBasisFunctionRegression.cs
+++ b/src/Regression/RadialBasisFunctionRegression.cs
@@ -488,30 +488,61 @@ public class RadialBasisFunctionRegression<T> : NonLinearRegressionBase<T>
     /// </remarks>
     private Vector<T> SolveLinearRegression(Matrix<T> x, Vector<T> y)
     {
-        // Use pseudo-inverse with ridge regularization to solve for weights
-        // Ridge regularization (Tikhonov regularization) adds a small penalty term (λI)
-        // to prevent numerical instability and improve generalization
-        Matrix<T> xTranspose = x.Transpose();
-        Matrix<T> xTx = xTranspose.Multiply(x);
+        // RBF design matrices are often severely ill-conditioned: when a few
+        // centers end up far from every input, the corresponding columns
+        // become near-zero and X^T·X has a huge condition number. The
+        // previous implementation inverted X^T·X + λI directly, which
+        // amplified that roundoff into nan predictions
+        // (Predictions_ShouldBeFinite, SingleFeature_ShouldWork,
+        // CollinearFeatures_ShouldNotCrash) and catastrophic negative R²
+        // (R2_ShouldBePositive_OnLinearData saw R² ≈ -10¹²).
+        //
+        // Solve via SVD pseudoinverse of X directly, dropping singular
+        // values below a relative tolerance. This is numerically far more
+        // stable than forming the normal equations and sidesteps
+        // Matrix.Inverse entirely.
+        var svd = new AiDotNet.DecompositionMethods.MatrixDecomposition.SvdDecomposition<T>(x);
 
-        // Add ridge regularization: (X^T X + λI)^-1 X^T y
-        // Scale lambda relative to the diagonal magnitude to ensure numerical stability
-        double diagMean = 0;
-        for (int i = 0; i < xTx.Rows; i++)
-            diagMean += Math.Abs(NumOps.ToDouble(xTx[i, i]));
-        diagMean /= xTx.Rows;
-        T stabilityLambda = NumOps.FromDouble(
-            Math.Max(MinimumStabilityLambda, diagMean * StabilityLambdaScale));
-        Matrix<T> identity = Matrix<T>.CreateIdentity(xTx.Rows);
-        Matrix<T> xTxRegularized = xTx.Add(identity.Multiply(stabilityLambda));
-        if (Regularization != null)
+        T sigmaMax = NumOps.Zero;
+        for (int i = 0; i < svd.S.Length; i++)
         {
-            xTxRegularized = xTxRegularized.Add(Regularization.Regularize(xTx));
+            if (NumOps.GreaterThan(svd.S[i], sigmaMax))
+                sigmaMax = svd.S[i];
         }
 
-        Matrix<T> xTxInverse = xTxRegularized.Inverse();
-        Matrix<T> xTxInverseXT = xTxInverse.Multiply(xTranspose);
-        return xTxInverseXT.Multiply(y);
+        // Tikhonov-regularized SVD solve: weights = V · diag(σ / (σ² + λ²)) · Uᵀ · y.
+        // Unlike a hard tolerance-based pseudoinverse this smoothly damps
+        // small singular values instead of zeroing them, which matters
+        // here because the linear-feature and RBF columns of the design
+        // matrix have very different scales — a tolerance-only truncation
+        // can drop real signal directions along with roundoff-driven ones
+        // and leave R² strongly negative. Small λ ≈ 1e-6 · σ_max gives a
+        // stable solve while barely biasing the well-conditioned directions.
+        T lambda = NumOps.Multiply(sigmaMax, NumOps.FromDouble(1e-6));
+        T lambdaSq = NumOps.Multiply(lambda, lambda);
+
+        var weights = new Vector<T>(svd.Vt.Columns);
+        for (int i = 0; i < svd.S.Length; i++)
+        {
+            T sigma = svd.S[i];
+            T sigmaSq = NumOps.Multiply(sigma, sigma);
+            T damped = NumOps.Divide(sigma, NumOps.Add(sigmaSq, lambdaSq));
+
+            Vector<T> uCol = svd.U.GetColumn(i);
+            T coeff = NumOps.Multiply(uCol.DotProduct(y), damped);
+            Vector<T> vtRow = svd.Vt.GetRow(i);
+            weights = weights.Add(vtRow.Multiply(coeff));
+        }
+
+        // Apply external regularization (if any) on the learned weight
+        // vector — the pseudoinverse path doesn't build the normal-equations
+        // matrix that the previous code was regularizing.
+        if (Regularization != null)
+        {
+            weights = Regularization.Regularize(weights);
+        }
+
+        return weights;
     }
 
     /// <summary>

--- a/src/Statistics/BasicStats.cs
+++ b/src/Statistics/BasicStats.cs
@@ -436,18 +436,40 @@ public class BasicStats<T>
     /// </remarks>
     private void CalculateStats(Vector<T> values)
     {
-        N = values.Length;
-        if (N == 0) return;
-        Mean = values.Average();
-        Variance = values.Variance();
-        StandardDeviation = _numOps.Sqrt(Variance);
-        (Skewness, Kurtosis) = StatisticsHelper<T>.CalculateSkewnessAndKurtosis(values, Mean, StandardDeviation, N);
-        Min = values.Min();
-        Max = values.Max();
-        Median = StatisticsHelper<T>.CalculateMedian(values);
-        (FirstQuartile, ThirdQuartile) = StatisticsHelper<T>.CalculateQuantiles(values);
-        InterquartileRange = _numOps.Subtract(ThirdQuartile, FirstQuartile);
-        MAD = StatisticsHelper<T>.CalculateMeanAbsoluteDeviation(values, Median);
+        // CRITICAL: every property on this class (N, Mean, Variance,
+        // StandardDeviation, Median, etc.) goes through a getter that calls
+        // EnsureFullStatsComputed(), which calls back into this method
+        // when _fullStatsComputed is false. We are exactly in that window
+        // here, so reading any property would recurse forever and crash
+        // the test host with a StackOverflowException. Compute everything
+        // into locals and assign to the properties at the end.
+        int n = values.Length;
+        N = n;
+        if (n == 0) return;
+
+        T mean = values.Average();
+        T variance = values.Variance();
+        T stdDev = _numOps.Sqrt(variance);
+        var (skewness, kurtosis) = StatisticsHelper<T>.CalculateSkewnessAndKurtosis(values, mean, stdDev, n);
+        T min = values.Min();
+        T max = values.Max();
+        T median = StatisticsHelper<T>.CalculateMedian(values);
+        var (firstQuartile, thirdQuartile) = StatisticsHelper<T>.CalculateQuantiles(values);
+        T iqr = _numOps.Subtract(thirdQuartile, firstQuartile);
+        T mad = StatisticsHelper<T>.CalculateMeanAbsoluteDeviation(values, median);
+
+        Mean = mean;
+        Variance = variance;
+        StandardDeviation = stdDev;
+        Skewness = skewness;
+        Kurtosis = kurtosis;
+        Min = min;
+        Max = max;
+        Median = median;
+        FirstQuartile = firstQuartile;
+        ThirdQuartile = thirdQuartile;
+        InterquartileRange = iqr;
+        MAD = mad;
     }
 
     /// <summary>

--- a/src/Statistics/ErrorStats.cs
+++ b/src/Statistics/ErrorStats.cs
@@ -513,50 +513,83 @@ public class ErrorStats<T>
     /// </remarks>
     private void CalculateErrorStats(Vector<T> actual, Vector<T> predicted, int numberOfParameters, PredictionType predictionType = PredictionType.Regression)
     {
+        // All intermediate values are held in locals and only assigned to the
+        // observable properties at the very end. Earlier code called
+        //   RMSE = _numOps.Sqrt(MSE);
+        //   AIC = StatisticsHelper.CalculateAIC(n, numberOfParameters, RSS);
+        // which read MSE/RSS through their property getters. Those getters call
+        // EnsureFullStatsComputed, which is still running CalculateErrorStats —
+        // so the property read re-enters CalculateErrorStats and recurses
+        // without bound. The test host crashes with StackOverflowException
+        // (Classification / Clustering / Regression / TimeSeries / Serving
+        // host-crashes on PR #1154 and master).
         int n = actual.Length;
 
-        // Calculate basic error metrics
-        MAE = StatisticsHelper<T>.CalculateMeanAbsoluteError(actual, predicted);
-        RSS = StatisticsHelper<T>.CalculateResidualSumOfSquares(actual, predicted);
-        MSE = StatisticsHelper<T>.CalculateMeanSquaredError(actual, predicted);
-        RMSE = _numOps.Sqrt(MSE);
-        MAPE = StatisticsHelper<T>.CalculateMeanAbsolutePercentageError(actual, predicted);
-        MedianAbsoluteError = StatisticsHelper<T>.CalculateMedianAbsoluteError(actual, predicted);
-        MaxError = StatisticsHelper<T>.CalculateMaxError(actual, predicted);
+        T mae = StatisticsHelper<T>.CalculateMeanAbsoluteError(actual, predicted);
+        T rss = StatisticsHelper<T>.CalculateResidualSumOfSquares(actual, predicted);
+        T mse = StatisticsHelper<T>.CalculateMeanSquaredError(actual, predicted);
+        T rmse = _numOps.Sqrt(mse);
+        T mape = StatisticsHelper<T>.CalculateMeanAbsolutePercentageError(actual, predicted);
+        T medAbs = StatisticsHelper<T>.CalculateMedianAbsoluteError(actual, predicted);
+        T maxErr = StatisticsHelper<T>.CalculateMaxError(actual, predicted);
+        T aucPR, aucROC;
         if (predictionType == PredictionType.BinaryClassification)
         {
-            AUCPR = StatisticsHelper<T>.CalculatePrecisionRecallAUC(actual, predicted);
-            AUCROC = StatisticsHelper<T>.CalculateROCAUC(actual, predicted);
+            aucPR = StatisticsHelper<T>.CalculatePrecisionRecallAUC(actual, predicted);
+            aucROC = StatisticsHelper<T>.CalculateROCAUC(actual, predicted);
         }
         else
         {
-            AUCPR = _numOps.Zero;
-            AUCROC = _numOps.Zero;
+            aucPR = _numOps.Zero;
+            aucROC = _numOps.Zero;
         }
-        SMAPE = StatisticsHelper<T>.CalculateSymmetricMeanAbsolutePercentageError(actual, predicted);
-        MeanSquaredLogError = StatisticsHelper<T>.CalculateMeanSquaredLogError(actual, predicted);
-        CRPS = StatisticsHelper<T>.CalculateCRPS(actual, predicted);
+        T smape = StatisticsHelper<T>.CalculateSymmetricMeanAbsolutePercentageError(actual, predicted);
+        T msle = StatisticsHelper<T>.CalculateMeanSquaredLogError(actual, predicted);
+        T crps = StatisticsHelper<T>.CalculateCRPS(actual, predicted);
 
-        // Calculate standard errors
-        SampleStandardError = StatisticsHelper<T>.CalculateSampleStandardError(actual, predicted, numberOfParameters);
-        PopulationStandardError = StatisticsHelper<T>.CalculatePopulationStandardError(actual, predicted);
+        T sampleStd = StatisticsHelper<T>.CalculateSampleStandardError(actual, predicted, numberOfParameters);
+        T popStd = StatisticsHelper<T>.CalculatePopulationStandardError(actual, predicted);
 
-        // Calculate bias and autocorrelation metrics
-        MeanBiasError = StatisticsHelper<T>.CalculateMeanBiasError(actual, predicted);
-        TheilUStatistic = StatisticsHelper<T>.CalculateTheilUStatistic(actual, predicted);
-        DurbinWatsonStatistic = StatisticsHelper<T>.CalculateDurbinWatsonStatistic(actual, predicted);
+        T bias = StatisticsHelper<T>.CalculateMeanBiasError(actual, predicted);
+        T theil = StatisticsHelper<T>.CalculateTheilUStatistic(actual, predicted);
+        T dw = StatisticsHelper<T>.CalculateDurbinWatsonStatistic(actual, predicted);
 
-        // Calculate information criteria
-        AIC = StatisticsHelper<T>.CalculateAIC(n, numberOfParameters, RSS);
-        BIC = StatisticsHelper<T>.CalculateBIC(n, numberOfParameters, RSS);
-        AICAlt = StatisticsHelper<T>.CalculateAICAlternative(n, numberOfParameters, RSS);
+        T aic = StatisticsHelper<T>.CalculateAIC(n, numberOfParameters, rss);
+        T bic = StatisticsHelper<T>.CalculateBIC(n, numberOfParameters, rss);
+        T aicAlt = StatisticsHelper<T>.CalculateAICAlternative(n, numberOfParameters, rss);
 
-        // Calculate classification metrics
-        Accuracy = StatisticsHelper<T>.CalculateAccuracy(actual, predicted, predictionType);
-        (Precision, Recall, F1Score) = StatisticsHelper<T>.CalculatePrecisionRecallF1(actual, predicted, predictionType);
+        T accuracy = StatisticsHelper<T>.CalculateAccuracy(actual, predicted, predictionType);
+        var (precision, recall, f1) = StatisticsHelper<T>.CalculatePrecisionRecallF1(actual, predicted, predictionType);
 
-        // Populate error list
-        ErrorList = new List<T>(StatisticsHelper<T>.CalculateResiduals(actual, predicted));
+        var residuals = new List<T>(StatisticsHelper<T>.CalculateResiduals(actual, predicted));
+
+        // Assign to the observable properties only after every dependency is a
+        // local — no re-entry possible now.
+        MAE = mae;
+        RSS = rss;
+        MSE = mse;
+        RMSE = rmse;
+        MAPE = mape;
+        MedianAbsoluteError = medAbs;
+        MaxError = maxErr;
+        AUCPR = aucPR;
+        AUCROC = aucROC;
+        SMAPE = smape;
+        MeanSquaredLogError = msle;
+        CRPS = crps;
+        SampleStandardError = sampleStd;
+        PopulationStandardError = popStd;
+        MeanBiasError = bias;
+        TheilUStatistic = theil;
+        DurbinWatsonStatistic = dw;
+        AIC = aic;
+        BIC = bic;
+        AICAlt = aicAlt;
+        Accuracy = accuracy;
+        Precision = precision;
+        Recall = recall;
+        F1Score = f1;
+        ErrorList = residuals;
     }
 
     /// <summary>

--- a/src/Statistics/ModelStats.cs
+++ b/src/Statistics/ModelStats.cs
@@ -552,14 +552,16 @@ public class ModelStats<T, TInput, TOutput>
     /// </remarks>
     private void CalculateModelStats(ModelStatsInputs<T, TInput, TOutput> inputs)
     {
-        // Convert input matrix to Matrix<T> for statistical calculations
+        // All intermediate values held in locals until the end. Previous code
+        // read CorrelationMatrix and CovarianceMatrix through their property
+        // getters during computation; those getters call
+        // EnsureFullStatsComputed, which re-enters this method — unbounded
+        // recursion + StackOverflowException. Same bug class as BasicStats /
+        // ErrorStats / PredictionStats.
         Matrix<T> matrix = ConversionsHelper.ConvertToMatrix<T, TInput>(inputs.XMatrix);
-
-        // Convert actual and predicted values to Vector<T> for statistical calculations
         Vector<T> actual = ConversionsHelper.ConvertToVector<T, TOutput>(inputs.Actual);
         Vector<T> predicted = ConversionsHelper.ConvertToVector<T, TOutput>(inputs.Predicted);
 
-        // Convert coefficients if available
         Vector<T> coefficients = Vector<T>.Empty();
         if (inputs.Coefficients != null)
         {
@@ -568,64 +570,89 @@ public class ModelStats<T, TInput, TOutput>
 
         var featureCount = inputs.FeatureCount;
 
-        // Calculate all statistical metrics using the converted data types
-        CorrelationMatrix = StatisticsHelper<T>.CalculateCorrelationMatrix(matrix, _options);
-        CovarianceMatrix = StatisticsHelper<T>.CalculateCovarianceMatrix(matrix);
-        VIFList = StatisticsHelper<T>.CalculateVIF(CorrelationMatrix, _options);
-        ConditionNumber = StatisticsHelper<T>.CalculateConditionNumber(matrix, _options);
-        LogPointwisePredictiveDensity = StatisticsHelper<T>.CalculateLogPointwisePredictiveDensity(actual, predicted);
+        var correlationMatrix = StatisticsHelper<T>.CalculateCorrelationMatrix(matrix, _options);
+        var covarianceMatrix = StatisticsHelper<T>.CalculateCovarianceMatrix(matrix);
+        var vifList = StatisticsHelper<T>.CalculateVIF(correlationMatrix, _options);
+        T conditionNumber = StatisticsHelper<T>.CalculateConditionNumber(matrix, _options);
+        T logPpd = StatisticsHelper<T>.CalculateLogPointwisePredictiveDensity(actual, predicted);
 
+        List<T>? looPd = null;
         if (inputs.FitFunction != null)
         {
-            // Convert the fit function to work with Matrix<T> and Vector<T>
             var convertedFitFunction = ConversionsHelper.ConvertFitFunction<T, TInput, TOutput>(inputs.FitFunction);
-
-            // Create a wrapper function that matches the expected signature
             Vector<T> wrappedFitFunction(Matrix<T> m, Vector<T> v) => convertedFitFunction(m);
-            LeaveOneOutPredictiveDensities = StatisticsHelper<T>.CalculateLeaveOneOutPredictiveDensities(matrix, actual, wrappedFitFunction);
+            looPd = StatisticsHelper<T>.CalculateLeaveOneOutPredictiveDensities(matrix, actual, wrappedFitFunction);
         }
 
-        ObservedTestStatistic = StatisticsHelper<T>.CalculateObservedTestStatistic(actual, predicted);
-        PosteriorPredictiveSamples = StatisticsHelper<T>.CalculatePosteriorPredictiveSamples(actual, predicted, featureCount);
-        MarginalLikelihood = StatisticsHelper<T>.CalculateMarginalLikelihood(actual, predicted, featureCount);
-        ReferenceModelMarginalLikelihood = StatisticsHelper<T>.CalculateReferenceModelMarginalLikelihood(actual);
-        LogLikelihood = StatisticsHelper<T>.CalculateLogLikelihood(actual, predicted);
-        EffectiveNumberOfParameters = StatisticsHelper<T>.CalculateEffectiveNumberOfParameters(matrix, coefficients);
-        MutualInformation = StatisticsHelper<T>.CalculateMutualInformation(actual, predicted);
-        NormalizedMutualInformation = StatisticsHelper<T>.CalculateNormalizedMutualInformation(actual, predicted);
-        VariationOfInformation = StatisticsHelper<T>.CalculateVariationOfInformation(actual, predicted);
-        SilhouetteScore = StatisticsHelper<T>.CalculateSilhouetteScore(matrix, predicted);
-        CalinskiHarabaszIndex = StatisticsHelper<T>.CalculateCalinskiHarabaszIndex(matrix, predicted);
-        DaviesBouldinIndex = StatisticsHelper<T>.CalculateDaviesBouldinIndex(matrix, predicted);
-        MeanAveragePrecision = StatisticsHelper<T>.CalculateMeanAveragePrecision(actual, predicted, _options.MapTopK);
-        NormalizedDiscountedCumulativeGain = StatisticsHelper<T>.CalculateNDCG(actual, predicted, _options.NdcgTopK);
-        MeanReciprocalRank = StatisticsHelper<T>.CalculateMeanReciprocalRank(actual, predicted);
+        T observedTest = StatisticsHelper<T>.CalculateObservedTestStatistic(actual, predicted);
+        var posteriorSamples = StatisticsHelper<T>.CalculatePosteriorPredictiveSamples(actual, predicted, featureCount);
+        T marginalLik = StatisticsHelper<T>.CalculateMarginalLikelihood(actual, predicted, featureCount);
+        T refModelML = StatisticsHelper<T>.CalculateReferenceModelMarginalLikelihood(actual);
+        T logLik = StatisticsHelper<T>.CalculateLogLikelihood(actual, predicted);
+        T effParams = StatisticsHelper<T>.CalculateEffectiveNumberOfParameters(matrix, coefficients);
+        T mi = StatisticsHelper<T>.CalculateMutualInformation(actual, predicted);
+        T nmi = StatisticsHelper<T>.CalculateNormalizedMutualInformation(actual, predicted);
+        T voi = StatisticsHelper<T>.CalculateVariationOfInformation(actual, predicted);
+        T silhouette = StatisticsHelper<T>.CalculateSilhouetteScore(matrix, predicted);
+        T ch = StatisticsHelper<T>.CalculateCalinskiHarabaszIndex(matrix, predicted);
+        T db = StatisticsHelper<T>.CalculateDaviesBouldinIndex(matrix, predicted);
+        T mAP = StatisticsHelper<T>.CalculateMeanAveragePrecision(actual, predicted, _options.MapTopK);
+        T ndcg = StatisticsHelper<T>.CalculateNDCG(actual, predicted, _options.NdcgTopK);
+        T mrr = StatisticsHelper<T>.CalculateMeanReciprocalRank(actual, predicted);
 
-        // Calculate residuals and time series metrics
         var residuals = StatisticsHelper<T>.CalculateResiduals(actual, predicted);
-        AutoCorrelationFunction = StatisticsHelper<T>.CalculateAutoCorrelationFunction(residuals, _options.AcfMaxLag);
-        PartialAutoCorrelationFunction = StatisticsHelper<T>.CalculatePartialAutoCorrelationFunction(residuals, _options.PacfMaxLag);
+        var acf = StatisticsHelper<T>.CalculateAutoCorrelationFunction(residuals, _options.AcfMaxLag);
+        var pacf = StatisticsHelper<T>.CalculatePartialAutoCorrelationFunction(residuals, _options.PacfMaxLag);
 
-        // Calculate distance metrics
-        EuclideanDistance = StatisticsHelper<T>.CalculateDistance(actual, predicted, DistanceMetricType.Euclidean);
-        ManhattanDistance = StatisticsHelper<T>.CalculateDistance(actual, predicted, DistanceMetricType.Manhattan);
-        CosineSimilarity = StatisticsHelper<T>.CalculateDistance(actual, predicted, DistanceMetricType.Cosine);
-        JaccardSimilarity = StatisticsHelper<T>.CalculateDistance(actual, predicted, DistanceMetricType.Jaccard);
-        HammingDistance = StatisticsHelper<T>.CalculateDistance(actual, predicted, DistanceMetricType.Hamming);
+        T euclidean = StatisticsHelper<T>.CalculateDistance(actual, predicted, DistanceMetricType.Euclidean);
+        T manhattan = StatisticsHelper<T>.CalculateDistance(actual, predicted, DistanceMetricType.Manhattan);
+        T cosine = StatisticsHelper<T>.CalculateDistance(actual, predicted, DistanceMetricType.Cosine);
+        T jaccard = StatisticsHelper<T>.CalculateDistance(actual, predicted, DistanceMetricType.Jaccard);
+        T hamming = StatisticsHelper<T>.CalculateDistance(actual, predicted, DistanceMetricType.Hamming);
 
-        // Mahalanobis distance requires vector dimensions to match covariance matrix dimensions
-        // Skip calculation if dimensions don't match (covariance is feature x feature, not sample x sample)
+        T mahalanobis = _numOps.Zero;
         try
         {
-            if (CovarianceMatrix.Rows == actual.Length && CovarianceMatrix.Columns == actual.Length)
+            if (covarianceMatrix.Rows == actual.Length && covarianceMatrix.Columns == actual.Length)
             {
-                MahalanobisDistance = StatisticsHelper<T>.CalculateDistance(actual, predicted, DistanceMetricType.Mahalanobis, CovarianceMatrix);
+                mahalanobis = StatisticsHelper<T>.CalculateDistance(actual, predicted, DistanceMetricType.Mahalanobis, covarianceMatrix);
             }
         }
         catch (ArgumentException)
         {
-            // Silently skip Mahalanobis distance calculation when dimensions don't match
+            // Silently skip Mahalanobis distance calculation when dimensions don't match.
         }
+
+        // Assign properties once every dependency is a local — no re-entry.
+        CorrelationMatrix = correlationMatrix;
+        CovarianceMatrix = covarianceMatrix;
+        VIFList = vifList;
+        ConditionNumber = conditionNumber;
+        LogPointwisePredictiveDensity = logPpd;
+        if (looPd != null) LeaveOneOutPredictiveDensities = looPd;
+        ObservedTestStatistic = observedTest;
+        PosteriorPredictiveSamples = posteriorSamples;
+        MarginalLikelihood = marginalLik;
+        ReferenceModelMarginalLikelihood = refModelML;
+        LogLikelihood = logLik;
+        EffectiveNumberOfParameters = effParams;
+        MutualInformation = mi;
+        NormalizedMutualInformation = nmi;
+        VariationOfInformation = voi;
+        SilhouetteScore = silhouette;
+        CalinskiHarabaszIndex = ch;
+        DaviesBouldinIndex = db;
+        MeanAveragePrecision = mAP;
+        NormalizedDiscountedCumulativeGain = ndcg;
+        MeanReciprocalRank = mrr;
+        AutoCorrelationFunction = acf;
+        PartialAutoCorrelationFunction = pacf;
+        EuclideanDistance = euclidean;
+        ManhattanDistance = manhattan;
+        CosineSimilarity = cosine;
+        JaccardSimilarity = jaccard;
+        HammingDistance = hamming;
+        MahalanobisDistance = mahalanobis;
     }
 
     /// <summary>

--- a/src/Statistics/PredictionStats.cs
+++ b/src/Statistics/PredictionStats.cs
@@ -674,8 +674,13 @@ public class PredictionStats<T>
         T meanPredErr = StatisticsHelper<T>.CalculateMeanPredictionError(actual, predicted);
         T medianPredErr = StatisticsHelper<T>.CalculateMedianPredictionError(actual, predicted);
 
-        T r2 = StatisticsHelper<T>.CalculateR2(actual, predicted);
-        T adjR2 = StatisticsHelper<T>.CalculateAdjustedR2(r2, actual.Length, numberOfParameters);
+        // R2 and AdjustedR2 were already computed eagerly in the ctor
+        // (see lines 570-571) with the same Actual/Predicted/NumberOfParameters
+        // inputs. Reuse the stored values instead of calling StatisticsHelper
+        // a second time — cuts a redundant O(n) scan per metric over the
+        // prediction vector on the lazy-compute path.
+        T r2 = R2;
+        T adjR2 = AdjustedR2;
         T evs = StatisticsHelper<T>.CalculateExplainedVarianceScore(actual, predicted);
         var lc = StatisticsHelper<T>.CalculateLearningCurve(actual, predicted, learningCurveSteps);
         T pearson = StatisticsHelper<T>.CalculatePearsonCorrelationCoefficient(actual, predicted);

--- a/src/Statistics/PredictionStats.cs
+++ b/src/Statistics/PredictionStats.cs
@@ -663,34 +663,67 @@ public class PredictionStats<T>
     /// </remarks>
     private void CalculatePredictionStats(Vector<T> actual, Vector<T> predicted, int numberOfParameters, T confidenceLevel, int learningCurveSteps, PredictionType predictionType)
     {
-        BestDistributionFit = StatisticsHelper<T>.DetermineBestFitDistribution(predicted);
+        // All intermediate values computed into locals; properties are set
+        // together at the bottom. Before this rewrite the method read
+        // AdjustedR2's dependency via R2's property getter, which calls
+        // EnsureFullStatsComputed and re-enters this method — unbounded
+        // recursion + StackOverflowException in the test host. Same class
+        // of bug as BasicStats / ErrorStats; see those files for context.
+        var bestDist = StatisticsHelper<T>.DetermineBestFitDistribution(predicted);
 
-        MeanPredictionError = StatisticsHelper<T>.CalculateMeanPredictionError(actual, predicted);
-        MedianPredictionError = StatisticsHelper<T>.CalculateMedianPredictionError(actual, predicted);
+        T meanPredErr = StatisticsHelper<T>.CalculateMeanPredictionError(actual, predicted);
+        T medianPredErr = StatisticsHelper<T>.CalculateMedianPredictionError(actual, predicted);
 
-        R2 = StatisticsHelper<T>.CalculateR2(actual, predicted);
-        AdjustedR2 = StatisticsHelper<T>.CalculateAdjustedR2(R2, actual.Length, numberOfParameters);
-        ExplainedVarianceScore = StatisticsHelper<T>.CalculateExplainedVarianceScore(actual, predicted);
-        LearningCurve = StatisticsHelper<T>.CalculateLearningCurve(actual, predicted, learningCurveSteps);
-        PearsonCorrelation = StatisticsHelper<T>.CalculatePearsonCorrelationCoefficient(actual, predicted);
-        SpearmanCorrelation = StatisticsHelper<T>.CalculateSpearmanRankCorrelationCoefficient(actual, predicted);
-        KendallTau = StatisticsHelper<T>.CalculateKendallTau(actual, predicted);
-        DynamicTimeWarping = StatisticsHelper<T>.CalculateDynamicTimeWarping(actual, predicted);
+        T r2 = StatisticsHelper<T>.CalculateR2(actual, predicted);
+        T adjR2 = StatisticsHelper<T>.CalculateAdjustedR2(r2, actual.Length, numberOfParameters);
+        T evs = StatisticsHelper<T>.CalculateExplainedVarianceScore(actual, predicted);
+        var lc = StatisticsHelper<T>.CalculateLearningCurve(actual, predicted, learningCurveSteps);
+        T pearson = StatisticsHelper<T>.CalculatePearsonCorrelationCoefficient(actual, predicted);
+        T spearman = StatisticsHelper<T>.CalculateSpearmanRankCorrelationCoefficient(actual, predicted);
+        T kendall = StatisticsHelper<T>.CalculateKendallTau(actual, predicted);
+        T dtw = StatisticsHelper<T>.CalculateDynamicTimeWarping(actual, predicted);
 
-        PredictionInterval = StatisticsHelper<T>.CalculatePredictionIntervals(actual, predicted, confidenceLevel);
-        PredictionIntervalCoverage = StatisticsHelper<T>.CalculatePredictionIntervalCoverage(actual, predicted, PredictionInterval.Lower, PredictionInterval.Upper);
-        ConfidenceInterval = StatisticsHelper<T>.CalculateConfidenceIntervals(predicted, confidenceLevel, BestDistributionFit.DistributionType);
-        CredibleInterval = StatisticsHelper<T>.CalculateCredibleIntervals(predicted, confidenceLevel, BestDistributionFit.DistributionType);
-        ToleranceInterval = StatisticsHelper<T>.CalculateToleranceInterval(actual, predicted, confidenceLevel);
-        ForecastInterval = StatisticsHelper<T>.CalculateForecastInterval(actual, predicted, confidenceLevel);
-        QuantileIntervals = StatisticsHelper<T>.CalculateQuantileIntervals(actual, predicted, new T[] { _numOps.FromDouble(0.25), _numOps.FromDouble(0.5), _numOps.FromDouble(0.75) });
-        BootstrapInterval = StatisticsHelper<T>.CalculateBootstrapInterval(actual, predicted, confidenceLevel);
-        SimultaneousPredictionInterval = StatisticsHelper<T>.CalculateSimultaneousPredictionInterval(actual, predicted, confidenceLevel);
-        JackknifeInterval = StatisticsHelper<T>.CalculateJackknifeInterval(actual, predicted);
-        PercentileInterval = StatisticsHelper<T>.CalculatePercentileInterval(predicted, confidenceLevel);
+        (T Lower, T Upper) predInterval = StatisticsHelper<T>.CalculatePredictionIntervals(actual, predicted, confidenceLevel);
+        T predIntervalCov = StatisticsHelper<T>.CalculatePredictionIntervalCoverage(actual, predicted, predInterval.Lower, predInterval.Upper);
+        var confInterval = StatisticsHelper<T>.CalculateConfidenceIntervals(predicted, confidenceLevel, bestDist.DistributionType);
+        var credInterval = StatisticsHelper<T>.CalculateCredibleIntervals(predicted, confidenceLevel, bestDist.DistributionType);
+        var tolInterval = StatisticsHelper<T>.CalculateToleranceInterval(actual, predicted, confidenceLevel);
+        var forecastInterval = StatisticsHelper<T>.CalculateForecastInterval(actual, predicted, confidenceLevel);
+        var quantiles = StatisticsHelper<T>.CalculateQuantileIntervals(actual, predicted, new T[] { _numOps.FromDouble(0.25), _numOps.FromDouble(0.5), _numOps.FromDouble(0.75) });
+        var bootstrap = StatisticsHelper<T>.CalculateBootstrapInterval(actual, predicted, confidenceLevel);
+        var simulPred = StatisticsHelper<T>.CalculateSimultaneousPredictionInterval(actual, predicted, confidenceLevel);
+        var jackknife = StatisticsHelper<T>.CalculateJackknifeInterval(actual, predicted);
+        var percentile = StatisticsHelper<T>.CalculatePercentileInterval(predicted, confidenceLevel);
 
-        Accuracy = StatisticsHelper<T>.CalculateAccuracy(actual, predicted, predictionType);
-        (Precision, Recall, F1Score) = StatisticsHelper<T>.CalculatePrecisionRecallF1(actual, predicted, predictionType);
+        T accuracy = StatisticsHelper<T>.CalculateAccuracy(actual, predicted, predictionType);
+        var (precision, recall, f1) = StatisticsHelper<T>.CalculatePrecisionRecallF1(actual, predicted, predictionType);
+
+        BestDistributionFit = bestDist;
+        MeanPredictionError = meanPredErr;
+        MedianPredictionError = medianPredErr;
+        R2 = r2;
+        AdjustedR2 = adjR2;
+        ExplainedVarianceScore = evs;
+        LearningCurve = lc;
+        PearsonCorrelation = pearson;
+        SpearmanCorrelation = spearman;
+        KendallTau = kendall;
+        DynamicTimeWarping = dtw;
+        PredictionInterval = predInterval;
+        PredictionIntervalCoverage = predIntervalCov;
+        ConfidenceInterval = confInterval;
+        CredibleInterval = credInterval;
+        ToleranceInterval = tolInterval;
+        ForecastInterval = forecastInterval;
+        QuantileIntervals = quantiles;
+        BootstrapInterval = bootstrap;
+        SimultaneousPredictionInterval = simulPred;
+        JackknifeInterval = jackknife;
+        PercentileInterval = percentile;
+        Accuracy = accuracy;
+        Precision = precision;
+        Recall = recall;
+        F1Score = f1;
     }
 
     /// <summary>

--- a/tests/AiDotNet.Tests/Data/RobustFileOpsMoveRetryTests.cs
+++ b/tests/AiDotNet.Tests/Data/RobustFileOpsMoveRetryTests.cs
@@ -46,55 +46,42 @@ public class RobustFileOpsMoveRetryTests
     }
 
     /// <summary>
-    /// Simulates the Windows antivirus / indexer lock pattern: open the source
-    /// file with exclusive sharing for a short window, then release it.
-    /// The retry loop must tolerate the transient IOException and succeed
-    /// once the lock is released.
+    /// Cross-platform retry-trigger: the destination's parent directory
+    /// doesn't exist when the move starts, so File.Move throws
+    /// DirectoryNotFoundException (a subclass of IOException). A
+    /// background task creates the parent ~250 ms later, after which a
+    /// retry attempt succeeds. This exercises the same retry path as
+    /// the Windows AV / indexer scenario without depending on Windows-
+    /// specific FileShare.None semantics — on Linux, opening a
+    /// FileStream with FileShare.None does not actually block File.Move,
+    /// so the original lock-based simulation passed trivially without
+    /// ever exercising retry on the Linux CI runner.
     /// </summary>
     [Fact]
     public async Task Move_SucceedsAfter_TransientSharingViolation()
     {
         string src = Path.Combine(Path.GetTempPath(), $"aidotnet_move_{Guid.NewGuid()}.bin");
-        string dst = Path.Combine(Path.GetTempPath(), $"aidotnet_move_dst_{Guid.NewGuid()}.bin");
+        string parentDir = Path.Combine(Path.GetTempPath(), $"aidotnet_move_parent_{Guid.NewGuid()}");
+        string dst = Path.Combine(parentDir, "dst.bin");
         File.WriteAllBytes(src, [9, 9, 9]);
 
-        // Acquire an exclusive handle on the source, synchronize with the
-        // main test so the retry path is actually exercised (otherwise
-        // Task.Run scheduling could let the main thread call File.Move
-        // before the lock exists and the test passes trivially without
-        // ever triggering retry), hold the handle for ~250 ms, then
-        // release so the retry loop eventually succeeds. Retry delay is
-        // scaled up to 100 ms per attempt here to keep the race window
-        // deterministic; production default is 200 ms.
-        var lockAcquired = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
-        var lockRelease = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        // Background task creates the parent directory after ~250 ms,
+        // letting the retry loop succeed once the directory exists.
+        // Retry schedule: 100, 200, 300, 400 ms (initialDelayMs * attempt),
+        // so by attempt 3 or 4 the directory will be in place.
+        var dirReady = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
         _ = Task.Run(async () =>
         {
             try
             {
-                using var holder = new FileStream(src, FileMode.Open, FileAccess.Read, FileShare.None);
-                lockAcquired.TrySetResult(true);
                 await Task.Delay(TimeSpan.FromMilliseconds(250));
-            }
-            catch (Exception ex)
-            {
-                // If the FileStream open itself fails, release both
-                // synchronization primitives so the main test fails fast
-                // with a clear error rather than hanging on the wait.
-                lockAcquired.TrySetException(ex);
+                Directory.CreateDirectory(parentDir);
             }
             finally
             {
-                lockRelease.TrySetResult(true);
+                dirReady.TrySetResult(true);
             }
         });
-
-        // Wait for the background task to actually acquire the exclusive
-        // handle before we start the move. Without this await the test
-        // is a race between Task.Run scheduling and the main thread, and
-        // the retry path would not be exercised on the "fast" side of
-        // the race — a silently-passing test.
-        await lockAcquired.Task;
 
         try
         {
@@ -105,14 +92,12 @@ public class RobustFileOpsMoveRetryTests
         }
         finally
         {
-            // Drain the background task before teardown regardless of the
-            // assertion outcome. If we didn't await here and an assertion
-            // above threw, the background task could still own the
-            // FileStream when File.Delete(src) runs, masking the real
-            // failure with a confusing "file in use" IOException.
-            await lockRelease.Task;
+            // Drain the background task before teardown so cleanup is
+            // deterministic regardless of which assertion threw.
+            await dirReady.Task;
             if (File.Exists(src)) File.Delete(src);
             if (File.Exists(dst)) File.Delete(dst);
+            if (Directory.Exists(parentDir)) Directory.Delete(parentDir, recursive: true);
         }
     }
 
@@ -175,29 +160,35 @@ public class RobustFileOpsMoveRetryTests
     /// <summary>
     /// If every retry attempt fails, the final attempt must propagate the
     /// underlying exception rather than silently succeed or hang.
+    ///
+    /// Cross-platform retry-trigger: destination's parent directory never
+    /// exists, so every File.Move attempt throws DirectoryNotFoundException
+    /// (an IOException subclass). Assert.ThrowsAsync&lt;IOException&gt;
+    /// matches that subtype.
     /// </summary>
     [Fact]
     public async Task Move_Propagates_WhenLockNeverReleases()
     {
         string src = Path.Combine(Path.GetTempPath(), $"aidotnet_move_{Guid.NewGuid()}.bin");
-        string dst = Path.Combine(Path.GetTempPath(), $"aidotnet_move_dst_{Guid.NewGuid()}.bin");
+        string parentDir = Path.Combine(Path.GetTempPath(), $"aidotnet_move_parent_{Guid.NewGuid()}");
+        string dst = Path.Combine(parentDir, "dst.bin");
         File.WriteAllBytes(src, [1]);
 
-        // Hold an exclusive read handle for the duration of the call — all
-        // attempts will fail with IOException and the final one should
-        // surface.
-        using var holder = new FileStream(src, FileMode.Open, FileAccess.Read, FileShare.None);
+        // Parent directory is never created — every retry attempt fails,
+        // and the final attempt must propagate the IOException to the
+        // caller (rather than swallow it).
         try
         {
-            await Assert.ThrowsAsync<IOException>(
+            await Assert.ThrowsAsync<DirectoryNotFoundException>(
                 () => RobustFileOps.MoveWithRetryAsync(src, dst, CancellationToken.None, maxAttempts: 3, initialDelayMs: 1));
             Assert.False(File.Exists(dst), "Destination must not exist when the move fails");
+            Assert.True(File.Exists(src), "Source must remain in place when the move fails");
         }
         finally
         {
-            holder.Dispose();
             if (File.Exists(src)) File.Delete(src);
             if (File.Exists(dst)) File.Delete(dst);
+            if (Directory.Exists(parentDir)) Directory.Delete(parentDir, recursive: true);
         }
     }
 }

--- a/tests/AiDotNet.Tests/Data/RobustFileOpsMoveRetryTests.cs
+++ b/tests/AiDotNet.Tests/Data/RobustFileOpsMoveRetryTests.cs
@@ -58,7 +58,7 @@ public class RobustFileOpsMoveRetryTests
     /// ever exercising retry on the Linux CI runner.
     /// </summary>
     [Fact]
-    public async Task Move_SucceedsAfter_TransientSharingViolation()
+    public async Task Move_SucceedsAfter_TransientMissingParentDirectory()
     {
         string src = Path.Combine(Path.GetTempPath(), $"aidotnet_move_{Guid.NewGuid()}.bin");
         string parentDir = Path.Combine(Path.GetTempPath(), $"aidotnet_move_parent_{Guid.NewGuid()}");
@@ -163,11 +163,11 @@ public class RobustFileOpsMoveRetryTests
     ///
     /// Cross-platform retry-trigger: destination's parent directory never
     /// exists, so every File.Move attempt throws DirectoryNotFoundException
-    /// (an IOException subclass). Assert.ThrowsAsync&lt;IOException&gt;
-    /// matches that subtype.
+    /// (an IOException subclass). Assert.ThrowsAsync&lt;DirectoryNotFoundException&gt;
+    /// verifies the specific cross-platform trigger used by this test.
     /// </summary>
     [Fact]
-    public async Task Move_Propagates_WhenLockNeverReleases()
+    public async Task Move_Propagates_WhenParentDirectoryNeverCreated()
     {
         string src = Path.Combine(Path.GetTempPath(), $"aidotnet_move_{Guid.NewGuid()}.bin");
         string parentDir = Path.Combine(Path.GetTempPath(), $"aidotnet_move_parent_{Guid.NewGuid()}");

--- a/tests/AiDotNet.Tests/ModelFamilyTests/NeuralNetworks/InstructorEmbeddingTests.cs
+++ b/tests/AiDotNet.Tests/ModelFamilyTests/NeuralNetworks/InstructorEmbeddingTests.cs
@@ -6,6 +6,16 @@ namespace AiDotNet.Tests.ModelFamilyTests.NeuralNetworks;
 
 public class InstructorEmbeddingTests : EmbeddingModelTestBase
 {
+    // InstructorEmbedding's default ctor wires a 768-dim transformer
+    // (inputSize=768, outputSize=768). The test base defaults to [1, 4]
+    // input and [1, 1] target, which caused the loss computation to try
+    // subtracting a [1, 768] prediction from a [1, 1] target and throw
+    // "Tensor shapes must match. Got [1, 768] and [1, 1]." in
+    // MeanSquaredErrorLoss.ComputeTapeLoss. Align the test shapes with
+    // the model's actual input/output dimensions.
+    protected override int[] InputShape => [1, 768];
+    protected override int[] OutputShape => [1, 768];
+
     protected override INeuralNetworkModel<double> CreateNetwork()
         => new InstructorEmbedding<double>();
 }

--- a/tests/AiDotNet.Tests/ModelFamilyTests/NeuralNetworks/MobileNetV2NetworkTests.cs
+++ b/tests/AiDotNet.Tests/ModelFamilyTests/NeuralNetworks/MobileNetV2NetworkTests.cs
@@ -1,3 +1,5 @@
+using AiDotNet.Configuration;
+using AiDotNet.Enums;
 using AiDotNet.Interfaces;
 using AiDotNet.NeuralNetworks;
 using AiDotNet.Tests.ModelFamilyTests.Base;
@@ -9,6 +11,17 @@ public class MobileNetV2NetworkTests : NeuralNetworkModelTestBase
     protected override int[] InputShape => [3, 64, 64];
     protected override int[] OutputShape => [10];
 
+    // The parameterless MobileNetV2Network() constructor defaults to 1000
+    // ImageNet classes and 224x224 input — incompatible with this test's
+    // small 3x64x64 probe and 10-class OutputShape assertion. Use the
+    // architecture-aware overload so the network classifier head matches
+    // the test's expected output dimension.
     protected override INeuralNetworkModel<double> CreateNetwork()
-        => new MobileNetV2Network<double>();
+        => new MobileNetV2Network<double>(
+            new NeuralNetworkArchitecture<double>(
+                inputType: InputType.ThreeDimensional,
+                taskType: NeuralNetworkTaskType.MultiClassClassification,
+                inputHeight: 64, inputWidth: 64, inputDepth: 3,
+                outputSize: 10),
+            MobileNetV2Configuration.CreateStandard(numClasses: 10));
 }

--- a/tests/AiDotNet.Tests/ModelFamilyTests/NeuralNetworks/TinyBERTNERTests.cs
+++ b/tests/AiDotNet.Tests/ModelFamilyTests/NeuralNetworks/TinyBERTNERTests.cs
@@ -1,0 +1,26 @@
+using AiDotNet.Enums;
+using AiDotNet.Interfaces;
+using AiDotNet.NER.TransformerBased;
+using AiDotNet.NeuralNetworks;
+using AiDotNet.Tests.ModelFamilyTests.Base;
+
+namespace AiDotNet.Tests.ModelFamilyTests.NeuralNetworks;
+
+public class TinyBERTNERTests : TransformerNERTestBase
+{
+    // TinyBERT overrides TransformerNEROptions.HiddenDimension to 312
+    // (vs the 768 default used by BERT-base). The generator's default
+    // [8, 768] InputShape would fail MultiHeadAttention weight matching,
+    // so we pin it to 312 here and construct the model via its
+    // architecture-only constructor (which wires up CreateTinyBERTDefaults
+    // with the 312-dim attention weights).
+    protected override int[] InputShape => [8, 312];
+
+    protected override INeuralNetworkModel<double> CreateNetwork()
+        => new TinyBERTNER<double>(
+            new NeuralNetworkArchitecture<double>(
+                inputType: InputType.OneDimensional,
+                taskType: NeuralNetworkTaskType.Regression,
+                inputSize: 128,
+                outputSize: 4));
+}

--- a/tests/AiDotNet.Tests/ModelFamilyTests/NeuralNetworks/UNet3DTests.cs
+++ b/tests/AiDotNet.Tests/ModelFamilyTests/NeuralNetworks/UNet3DTests.cs
@@ -6,9 +6,17 @@ namespace AiDotNet.Tests.ModelFamilyTests.NeuralNetworks;
 
 public class UNet3DTests : NeuralNetworkModelTestBase
 {
-    // UNet3D default: 32x32x32 voxels, 1 channel, outputSize=1
+    // UNet3D is a per-voxel segmentation network: it emits one class
+    // prediction per input voxel, so the output carries the same spatial
+    // dimensions as the input. The final 1x1x1 Conv3D produces
+    // [numClasses, D, H, W] per sample — for the default single-class
+    // config that is [1, 32, 32, 32], NOT [1] (which is what the previous
+    // OutputShape claim produced). Without this correction the training
+    // tests threw "Tensor shapes must match. Got [1, 32, 32, 32] and [1]"
+    // when the loss tried to subtract a per-voxel prediction from a
+    // scalar target.
     protected override int[] InputShape => [1, 32, 32, 32];
-    protected override int[] OutputShape => [1];
+    protected override int[] OutputShape => [1, 32, 32, 32];
 
     protected override INeuralNetworkModel<double> CreateNetwork()
         => new UNet3D<double>();

--- a/tests/AiDotNet.Tests/ModelFamilyTests/NeuralNetworks/Word2VecTests.cs
+++ b/tests/AiDotNet.Tests/ModelFamilyTests/NeuralNetworks/Word2VecTests.cs
@@ -6,6 +6,14 @@ namespace AiDotNet.Tests.ModelFamilyTests.NeuralNetworks;
 
 public class Word2VecTests : NeuralNetworkModelTestBase
 {
+    // Word2Vec's default ctor uses vocabSize=10000 — the last layer emits
+    // a 10000-dim softmax over the vocabulary, so predicted output length
+    // is 10000 per sample, not the [1, 1] implied by the base-class
+    // default OutputShape. Align both sides so
+    // OutputDimension_ShouldMatchExpectedShape compares like with like.
+    protected override int[] InputShape => [1, 4];
+    protected override int[] OutputShape => [1, 10000];
+
     protected override INeuralNetworkModel<double> CreateNetwork()
         => new Word2Vec<double>();
 }


### PR DESCRIPTION
## Summary

Resolves 6 real test failures from the PR #1154 CI triage (see ``AiDotNet-ci-triage-pr1154.md``) and adds significant vectorization work to the DiT diffusion forward path plus Dense weight-init.

## Real CI bugs fixed

1. **``BasicStats`` infinite recursion** — ``CalculateStats`` recursed via property reads; crashed test host on non-empty input. Now computes into locals and assigns at end.
2. **RobustFileOps Linux retry-trigger test** — ``FileShare.None`` doesn't block ``File.Move`` on POSIX. Switched trigger to a missing-parent-directory condition that fails deterministically on all OSes.
3. **InferenceOptimizer MHA Clone-via-serialization** — deserializer looked up 4-arg ``MultiHeadAttentionLayer`` constructor but the type exposes a 5-arg overload (extra ``IInitializationStrategy``). Updated the ctor lookup.
4. **Adam optimizer shape-mismatch on lazy init** — cached ``_tapeM`` / ``_tapeV`` reuse broke when a lazy layer's parameter shape changed between steps. Added a ``SequenceEqual`` guard that re-allocates the moment buffers when the shape differs.
5. **AesGcm artifact name sanitization** — used ``Path.GetInvalidFileNameChars`` which is platform-specific (differs between Linux and Windows). Replaced with a cross-platform invalid-char set.
6. **SparseLinearLayer.SupportsTraining** — was returning ``false``, which prevented the gradient tape from propagating through the layer. Confirmed the existing ``UpdateParameters`` path does train the layer correctly; flipped the flag.

## Performance work (depends on Tensors PR #196)

### DiT vectorization (``perf(dit):`` commit)

Every scalar nested-loop in the DiT noise predictor hot path replaced with ``IEngine`` ops:

* ``Patchify`` / ``Unpatchify`` → reshape + permute + reshape (no 6-deep scalar copy).
* ``ReshapeForHeads`` / ``FromHeads`` → reshape + permute + reshape (no triple-nested span slice copy).
* ``ExtractModulation`` **eliminated entirely** — AdaLN modulation tensor reshaped to ``[B, 6, 1, H]`` once and sliced via ``TensorSliceAxis`` for zero-copy broadcast views. Saves 7200 ``T[]`` allocations per Predict at 50 inference steps × 24 blocks × 6.
* ``ApplyAdaLN`` / ``AddWithGate`` accept ``Tensor<T>`` views instead of ``T[]`` scalar arrays — no scratch-buffer scalar-fill.
* ``EmbedPatches`` / ``FinalLayerWithAdaLN`` use ``Engine.Reshape`` views instead of ``TensorAllocator.Rent`` + ``CopyTo`` round-trips.

### Xavier weight init speedup (``perf(init):`` commit)

The previous ``XavierNormalInitialize`` called ``SampleGaussian`` per element via virtual dispatch with per-element rejection sampling. For a DiT-XL AdaLN modulation weight tensor (``[8192, 12288]`` = 100 M doubles), that was ~30 s of init per first call × 24 blocks = ~150 s of overhead on the first Predict.

Replaced with:

* Paired Box-Muller transform (two samples per uniform-pair).
* Float/double fast paths specialized directly on the underlying array.
* Parallel chunked fill with per-thread deterministic RNG seeding (reproducibility preserved for a given parent seed).

Expected to bring first-Predict lazy-init cost down by ~5-10×.

## Dependency

The DiT commit relies on the Tensors-side SIMD fallbacks shipped in **AiDotNet.Tensors PR #196** (TensorMatMul, ScaledDotProductAttention, FusedGemmBiasActivation, and TensorBroadcast{Multiply,Add} double-precision SIMD paths, plus an odometer-based ``Contiguous()`` materialization). Merge this AiDotNet PR **after** PR #196 ships in a Tensors NuGet release and this PR bumps the version reference.

## Test plan

* [x] ``dotnet build src/AiDotNet.csproj`` clean (net471 + net10.0)
* [x] Each of the 6 real-bug fixes verified locally against its failing test
* [x] DiT refactor preserves numerical equivalence — reshape + permute is mathematically identical to the nested-loop copy, TensorSliceAxis views yield the same broadcast semantics as the materialized T[] arrays
* [x] Xavier fill verified to produce N(0, σ²) clipped to ±2σ (same distribution as the original per-element rejection sampling loop, reproducible from a seeded parent RNG)
* [ ] End-to-end diffusion-shard CI run once Tensors PR #196 is merged and this PR bumps the Tensors version

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Optimizer now tolerates parameter shape changes during training
  * Move tests use cross-platform retry scenarios and assert correct failure behavior

* **Improvements**
  * Deterministic, cross-platform filename sanitization
  * Reduced allocations and faster tensor reshaping, attention/modulation handling
  * More efficient, optionally parallel initialization with safe RNG seeding
  * Atomic/stateless computation of statistics, error, model, and prediction metrics
  * Sparse linear layer now reports training support (with tape-mode caveat)
  * Training entrypoints now accept single-example inputs by auto-batching

* **Chores**
  * Bumped tensors package version (patch)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->