### PR TITLE
fix(website): pass Supabase env to Astro build + harden supabase.ts

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -63,6 +63,13 @@ jobs:
         run: npx astro build
         env:
           VERCEL: '1'
+          # Astro bakes import.meta.env.PUBLIC_* values at build time. Without these
+          # the client-side Supabase client throws "Missing Supabase environment
+          # variables" at page load, which in turn means every script that imports
+          # src/lib/supabase.ts crashes — sign-in buttons silently become no-ops.
+          # Keep these in lockstep with the Vercel project env vars.
+          PUBLIC_SUPABASE_URL: ${{ secrets.PUBLIC_SUPABASE_URL }}
+          PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.PUBLIC_SUPABASE_ANON_KEY }}
 
       - name: Verify build output
         run: |

--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -59,6 +59,17 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Verify required build secrets
+        env:
+          PUBLIC_SUPABASE_URL: ${{ secrets.PUBLIC_SUPABASE_URL }}
+          PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.PUBLIC_SUPABASE_ANON_KEY }}
+        run: |
+          # Fail the job here rather than deploying a site that silently
+          # disables auth. Astro bakes these at build time — a missing or
+          # rotated secret would otherwise produce a broken production bundle.
+          : "${PUBLIC_SUPABASE_URL:?Missing PUBLIC_SUPABASE_URL GitHub secret}"
+          : "${PUBLIC_SUPABASE_ANON_KEY:?Missing PUBLIC_SUPABASE_ANON_KEY GitHub secret}"
+
       - name: Build website
         run: npx astro build
         env:

--- a/website/src/lib/supabase.ts
+++ b/website/src/lib/supabase.ts
@@ -31,19 +31,28 @@ function createDisabledClient(): SupabaseClient {
     console.error('[AiDotNet] Supabase env vars missing — auth disabled.', err.message);
   }
 
-  const rejectingPromise = () => Promise.reject(err);
+  // Match Supabase's result-shape contract: every terminal call resolves to
+  // { data: null, error } instead of rejecting. That lets unguarded call sites
+  // like `const { error } = await supabase.auth.signInWithPassword(...)`
+  // destructure normally and fall through to their error-display paths without
+  // needing try/catch or an explicit supabaseConfigured check. Logout/sign-in
+  // flows that DO gate on supabaseConfigured still work the same way.
+  const disabledResult = { data: null, error: err };
+  const resolvingPromise = () => Promise.resolve(disabledResult);
+
   const handler: ProxyHandler<object> = {
     get(_target, prop) {
       if (prop === 'then') return undefined; // don't accidentally become awaitable
       // Nested access (e.g. supabase.auth.getSession) returns another proxy so the
-      // chain keeps working syntactically; terminal calls return rejecting promises.
-      return new Proxy(rejectingPromise, handler);
+      // chain keeps working syntactically; terminal calls resolve to the
+      // disabled-result shape.
+      return new Proxy(resolvingPromise, handler);
     },
     apply() {
-      return rejectingPromise();
+      return resolvingPromise();
     },
   };
-  return new Proxy(rejectingPromise, handler) as unknown as SupabaseClient;
+  return new Proxy(resolvingPromise, handler) as unknown as SupabaseClient;
 }
 
 export const supabase: SupabaseClient = supabaseConfigured

--- a/website/src/lib/supabase.ts
+++ b/website/src/lib/supabase.ts
@@ -56,6 +56,31 @@ function createDisabledClient(): SupabaseClient {
     }
   };
 
+  // Methods that END a call chain — everything else is treated as an
+  // intermediate fluent builder (e.g. supabase.from('t').select('*').eq(...))
+  // so `.select(...)` called on the result of `.from(...)` still returns a
+  // proxy instead of crashing with "Cannot read property 'select' of Promise".
+  const terminalMethods = new Set<string>([
+    'getSession',
+    'getUser',
+    'onAuthStateChange',
+    'signInWithOAuth',
+    'signInWithPassword',
+    'signUp',
+    'signOut',
+    'resetPasswordForEmail',
+    'updateUser',
+    'exchangeCodeForSession',
+    'refreshSession',
+    // Query terminals — awaiting a Supabase PostgrestFilterBuilder runs the
+    // query, so anything the caller awaits must also resolve to a shape.
+    'then',
+    'single',
+    'maybeSingle',
+    'csv',
+    'explain',
+  ]);
+
   const createProxy = (path: PropertyKey[] = []): any =>
     new Proxy(() => undefined, {
       get(_target, prop) {
@@ -65,7 +90,12 @@ function createDisabledClient(): SupabaseClient {
         return createProxy([...path, prop]);
       },
       apply() {
-        return resolveDisabledCall(path[path.length - 1]);
+        const method = String(path[path.length - 1] ?? '');
+        // Terminal methods resolve to their shape; everything else returns
+        // another proxy so fluent chains keep working without TypeError.
+        return terminalMethods.has(method)
+          ? resolveDisabledCall(method)
+          : createProxy(path);
       },
     });
 

--- a/website/src/lib/supabase.ts
+++ b/website/src/lib/supabase.ts
@@ -1,12 +1,51 @@
-import { createClient } from '@supabase/supabase-js';
+import { createClient, type SupabaseClient } from '@supabase/supabase-js';
 
 const supabaseUrl = (import.meta.env.PUBLIC_SUPABASE_URL || '').trim();
 const supabaseAnonKey = (import.meta.env.PUBLIC_SUPABASE_ANON_KEY || '').trim();
 
-if (!supabaseUrl || !supabaseAnonKey) {
-  throw new Error(
-    'Missing Supabase environment variables. Set PUBLIC_SUPABASE_URL and PUBLIC_SUPABASE_ANON_KEY.'
+/**
+ * True when PUBLIC_SUPABASE_URL and PUBLIC_SUPABASE_ANON_KEY were supplied at
+ * build time. When false, every auth/DB call becomes a no-op that surfaces a
+ * user-visible error banner instead of crashing the entire script module —
+ * that way sign-in pages still render and users see a clear error instead of
+ * buttons that silently do nothing.
+ */
+export const supabaseConfigured = !!supabaseUrl && !!supabaseAnonKey;
+
+/**
+ * User-facing message shown when Supabase isn't configured. Login / signup /
+ * dashboard pages can surface this directly in the UI.
+ */
+export const supabaseMissingConfigMessage =
+  'Authentication is temporarily unavailable. Please try again in a few minutes. ' +
+  'If the problem persists, contact support@aidotnet.dev.';
+
+function createDisabledClient(): SupabaseClient {
+  const err = new Error(
+    'Supabase client is not configured. Set PUBLIC_SUPABASE_URL and ' +
+      'PUBLIC_SUPABASE_ANON_KEY at build time.',
   );
+  // Log once at module load so deployment issues are visible in browser devtools
+  // AND in server logs (Astro SSR paths).
+  if (typeof console !== 'undefined' && typeof console.error === 'function') {
+    console.error('[AiDotNet] Supabase env vars missing — auth disabled.', err.message);
+  }
+
+  const rejectingPromise = () => Promise.reject(err);
+  const handler: ProxyHandler<object> = {
+    get(_target, prop) {
+      if (prop === 'then') return undefined; // don't accidentally become awaitable
+      // Nested access (e.g. supabase.auth.getSession) returns another proxy so the
+      // chain keeps working syntactically; terminal calls return rejecting promises.
+      return new Proxy(rejectingPromise, handler);
+    },
+    apply() {
+      return rejectingPromise();
+    },
+  };
+  return new Proxy(rejectingPromise, handler) as unknown as SupabaseClient;
 }
 
-export const supabase = createClient(supabaseUrl, supabaseAnonKey);
+export const supabase: SupabaseClient = supabaseConfigured
+  ? createClient(supabaseUrl, supabaseAnonKey)
+  : createDisabledClient();

--- a/website/src/lib/supabase.ts
+++ b/website/src/lib/supabase.ts
@@ -31,28 +31,45 @@ function createDisabledClient(): SupabaseClient {
     console.error('[AiDotNet] Supabase env vars missing — auth disabled.', err.message);
   }
 
-  // Match Supabase's result-shape contract: every terminal call resolves to
-  // { data: null, error } instead of rejecting. That lets unguarded call sites
-  // like `const { error } = await supabase.auth.signInWithPassword(...)`
-  // destructure normally and fall through to their error-display paths without
-  // needing try/catch or an explicit supabaseConfigured check. Logout/sign-in
-  // flows that DO gate on supabaseConfigured still work the same way.
-  const disabledResult = { data: null, error: err };
-  const resolvingPromise = () => Promise.resolve(disabledResult);
-
-  const handler: ProxyHandler<object> = {
-    get(_target, prop) {
-      if (prop === 'then') return undefined; // don't accidentally become awaitable
-      // Nested access (e.g. supabase.auth.getSession) returns another proxy so the
-      // chain keeps working syntactically; terminal calls resolve to the
-      // disabled-result shape.
-      return new Proxy(resolvingPromise, handler);
-    },
-    apply() {
-      return resolvingPromise();
-    },
+  // Return auth-shaped no-op results so unguarded destructuring patterns stay
+  // safe. Multiple pages (Navbar, pricing, signup, login, licenses,
+  // AdminLayout, AccountLayout) do
+  //
+  //     const { data: { session } } = await supabase.auth.getSession()
+  //
+  // which crashes with "Cannot read property 'session' of null" if we return
+  // { data: null, ... }. Real Supabase returns:
+  //   - getSession()          → { data: { session: Session | null }, error }
+  //   - onAuthStateChange(cb) → { data: { subscription }, error: null }  (SYNC)
+  // Match those shapes so pages degrade gracefully.
+  const disabledSubscription = { unsubscribe() {} };
+  const resolveDisabledCall = (method?: PropertyKey): unknown => {
+    switch (method) {
+      case 'getSession':
+      case 'getUser':
+        return Promise.resolve({ data: { session: null, user: null }, error: err });
+      case 'onAuthStateChange':
+        // onAuthStateChange is synchronous in the real client, not thenable.
+        return { data: { subscription: disabledSubscription }, error: null };
+      default:
+        return Promise.resolve({ data: null, error: err });
+    }
   };
-  return new Proxy(resolvingPromise, handler) as unknown as SupabaseClient;
+
+  const createProxy = (path: PropertyKey[] = []): any =>
+    new Proxy(() => undefined, {
+      get(_target, prop) {
+        if (prop === 'then') return undefined; // don't accidentally become awaitable
+        // Walk the path (e.g. supabase.auth.getSession) so apply() knows which
+        // method was called and can return the right result shape.
+        return createProxy([...path, prop]);
+      },
+      apply() {
+        return resolveDisabledCall(path[path.length - 1]);
+      },
+    });
+
+  return createProxy() as SupabaseClient;
 }
 
 export const supabase: SupabaseClient = supabaseConfigured

--- a/website/src/pages/login/index.astro
+++ b/website/src/pages/login/index.astro
@@ -116,14 +116,32 @@ const base = import.meta.env.BASE_URL;
   </div>
 
   <script>
-    import { supabase } from '../../lib/supabase';
+    import { supabase, supabaseConfigured, supabaseMissingConfigMessage } from '../../lib/supabase';
 
     const base = import.meta.env.BASE_URL || '/';
     const params = new URLSearchParams(window.location.search);
     const redirectTo = params.get('redirect') || `${base}account/`;
 
+    // Fail loud when the build was missing Supabase env vars: show a user-visible
+    // banner AND disable the form buttons. Previous behavior threw inside
+    // supabase.ts at module load, crashing the entire script — every button
+    // became a silent no-op which is a much worse user experience than a clear
+    // "temporarily unavailable" message.
+    if (!supabaseConfigured) {
+      const errorDiv = document.getElementById('login-error');
+      if (errorDiv) {
+        errorDiv.textContent = supabaseMissingConfigMessage;
+        errorDiv.classList.remove('hidden');
+      }
+      document.querySelectorAll<HTMLButtonElement>('button').forEach(btn => {
+        btn.disabled = true;
+        btn.classList.add('opacity-50', 'cursor-not-allowed');
+      });
+    }
+
     // Check if already logged in
     async function checkExistingSession() {
+      if (!supabaseConfigured) return;
       const { data: { session } } = await supabase.auth.getSession();
       if (session) {
         window.location.href = redirectTo;

--- a/website/src/pages/login/index.astro
+++ b/website/src/pages/login/index.astro
@@ -133,10 +133,14 @@ const base = import.meta.env.BASE_URL;
         errorDiv.textContent = supabaseMissingConfigMessage;
         errorDiv.classList.remove('hidden');
       }
-      document.querySelectorAll<HTMLButtonElement>('button').forEach(btn => {
-        btn.disabled = true;
-        btn.classList.add('opacity-50', 'cursor-not-allowed');
-      });
+      document
+        .querySelectorAll<HTMLButtonElement>(
+          '#github-login, #google-login, #login-form button[type="submit"]',
+        )
+        .forEach(btn => {
+          btn.disabled = true;
+          btn.classList.add('opacity-50', 'cursor-not-allowed');
+        });
     }
 
     // Check if already logged in
@@ -153,6 +157,10 @@ const base = import.meta.env.BASE_URL;
     const githubBtn = document.getElementById('github-login');
     if (githubBtn) {
       githubBtn.addEventListener('click', async () => {
+        if (!supabaseConfigured) {
+          showError(supabaseMissingConfigMessage);
+          return;
+        }
         const { error } = await supabase.auth.signInWithOAuth({
           provider: 'github',
           options: {
@@ -167,6 +175,10 @@ const base = import.meta.env.BASE_URL;
     const googleBtn = document.getElementById('google-login');
     if (googleBtn) {
       googleBtn.addEventListener('click', async () => {
+        if (!supabaseConfigured) {
+          showError(supabaseMissingConfigMessage);
+          return;
+        }
         const { error } = await supabase.auth.signInWithOAuth({
           provider: 'google',
           options: {
@@ -182,6 +194,10 @@ const base = import.meta.env.BASE_URL;
     if (form) {
       form.addEventListener('submit', async (e) => {
         e.preventDefault();
+        if (!supabaseConfigured) {
+          showError(supabaseMissingConfigMessage);
+          return;
+        }
         const email = (document.getElementById('email') as HTMLInputElement).value;
         const password = (document.getElementById('password') as HTMLInputElement).value;
 


### PR DESCRIPTION
## Summary

aidotnet.dev sign-in was silently broken — every login option (GitHub / Google / email) did nothing on click. Console error:

\`\`\`
Error: Missing Supabase environment variables. Set PUBLIC_SUPABASE_URL and PUBLIC_SUPABASE_ANON_KEY.
  at https://www.aidotnet.dev/_astro/supabase.Dv2agzPK.js:43
\`\`\`

### Root cause

Astro bakes \`import.meta.env.PUBLIC_*\` at **build time**. \`deploy-website.yml\` runs \`npx astro build\` with only \`VERCEL='1'\` in the env block — no Supabase vars. The Vercel project has the vars configured, but Vercel isn't doing the build (\`vercel.json\` sets \`ignoreCommand: \"exit 0\"\`), so those never ran.

The \`PUBLIC_SUPABASE_URL\` and \`PUBLIC_SUPABASE_ANON_KEY\` secrets already exist in GitHub Actions (added 2026-04-06). The workflow just wasn't reading them.

## Fix

1. **Workflow**: pass both secrets to the \`Build website\` step.
2. **\`supabase.ts\`**: don't throw at top-of-module when env vars are missing — export a \`Proxy\`-based no-op client + \`supabaseConfigured: boolean\` + user-visible message. Previously the throw crashed every \`<script>\` that imported the module, which is why the buttons became silent no-ops.
3. **Login page**: detect \`supabaseConfigured === false\` and surface the user-visible banner + disable all buttons with \`opacity-50 cursor-not-allowed\` instead of letting them sit as broken silent no-ops.

## Test plan

- [x] Local \`npx astro build\` with fake env vars → 78 pages built, no errors.
- [ ] After merge, deploy-website.yml builds with real secrets baked in.
- [ ] Playwright on aidotnet.dev/login — no 'Missing Supabase' in console, GitHub/Google/email sign-in initiate correctly.
- [ ] Regression: if Supabase vars ever disappear from secrets, users see the 'temporarily unavailable' banner instead of silent dead buttons.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Clear error banner and disabled login controls when Supabase configuration is missing; prevents auth attempts and runtime failures.
  * Login flows short-circuit when backend config is unavailable, showing a friendly message instead of attempting network auth.

* **Chores**
  * Deployment now validates required environment variables before build so client-side runtime env values are available in production.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->