### PR TITLE
deps: bump AiDotNet.Tensors + AiDotNet.Native.OpenBLAS to 0.50.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,7 +5,7 @@
   <ItemGroup>
     <!-- AiDotNet ecosystem -->
     <PackageVersion Include="AiDotNet" Version="0.113.0" />
-    <PackageVersion Include="AiDotNet.Tensors" Version="0.50.0" />
+    <PackageVersion Include="AiDotNet.Tensors" Version="0.50.1" />
     <PackageVersion Include="AiDotNet.Native.OneDNN" Version="0.50.0" />
     <PackageVersion Include="AiDotNet.Native.OpenBLAS" Version="0.50.0" />
     <PackageVersion Include="AiDotNet.Native.CLBlast" Version="0.50.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,9 +5,9 @@
   <ItemGroup>
     <!-- AiDotNet ecosystem -->
     <PackageVersion Include="AiDotNet" Version="0.113.0" />
-    <PackageVersion Include="AiDotNet.Tensors" Version="0.46.1" />
+    <PackageVersion Include="AiDotNet.Tensors" Version="0.50.0" />
     <PackageVersion Include="AiDotNet.Native.OneDNN" Version="0.50.0" />
-    <PackageVersion Include="AiDotNet.Native.OpenBLAS" Version="0.28.0" />
+    <PackageVersion Include="AiDotNet.Native.OpenBLAS" Version="0.50.0" />
     <PackageVersion Include="AiDotNet.Native.CLBlast" Version="0.50.0" />
     <!-- Microsoft / .NET -->
     <PackageVersion Include="Microsoft.CSharp" Version="4.7.0" />

--- a/src/AiModelBuilder.cs
+++ b/src/AiModelBuilder.cs
@@ -1371,9 +1371,11 @@ public partial class AiModelBuilder<T, TInput, TOutput> : IAiModelBuilder<T, TIn
                     try
                     {
                         using var noGrad = new AiDotNet.Tensors.Engines.Autodiff.NoGradScope<T>();
-                        // Discard return: CompiledModelCache treats the last recorded
-                        // op's output tensor as the plan's output.
-                        nnModel.Predict(input);
+                        // Tensors 0.50.1 changed GetOrCompileInference from Action to
+                        // Func<Tensor<T>> — the tracer now binds the plan output to
+                        // whatever the lambda returns, rather than inferring it from
+                        // the last recorded op. Return the Predict result explicitly.
+                        return nnModel.Predict(input);
                     }
                     finally
                     {

--- a/src/Training/CompiledTapeTrainingStep.cs
+++ b/src/Training/CompiledTapeTrainingStep.cs
@@ -138,8 +138,12 @@ public static class CompiledTapeTrainingStep<T>
                 compositeKey,
                 () =>
                 {
+                    // Tensors 0.50.1 changed GetOrCompileTraining to take a
+                    // Func<Tensor<T>> — the trace lambda must return the
+                    // scalar output (loss) so the compile-graph has a single
+                    // terminal node to differentiate from.
                     var predicted = forward(input);
-                    computeLoss(predicted, target);
+                    return computeLoss(predicted, target);
                 },
                 parameters);
 
@@ -268,8 +272,12 @@ public static class CompiledTapeTrainingStep<T>
                 compositeKey,
                 () =>
                 {
+                    // Tensors 0.50.1 changed GetOrCompileTraining to take a
+                    // Func<Tensor<T>> — the trace lambda must return the
+                    // scalar output (loss) so the compile-graph has a single
+                    // terminal node to differentiate from.
                     var predicted = forward(input);
-                    computeLoss(predicted, target);
+                    return computeLoss(predicted, target);
                 },
                 parameters);
 


### PR DESCRIPTION
## Summary

Bumps the two remaining AiDotNet ecosystem packages still behind the 0.50.0 line:

- `AiDotNet.Tensors`              0.46.1 → **0.50.0**
- `AiDotNet.Native.OpenBLAS`      0.28.0 → **0.50.0**

`OneDNN` and `CLBlast` were already at 0.50.0 on master.

## Why this, not the dependabot PRs

Supersedes **#1170** and **#1171** (both dependabot-authored). Rebasing those branches onto current master would have produced valid results, but dependabot's anti-tamper auto-closes any PR whose branch is force-pushed by a non-bot account — which it did when I tried. Bundling both bumps into one human PR is the only workable path.

## Test plan

- [x] `dotnet build src/AiDotNet.csproj -f net10.0` → 0 errors
- [x] `dotnet build src/AiDotNet.csproj -f net471` → 0 errors
- [ ] CI: full test matrix on the PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated numerical computing and linear algebra library versions.

* **Bug Fixes**
  * Fixed tensor output propagation in compiled model prediction to ensure inference results are correctly returned.
  * Corrected compiled training step output handling to ensure loss values are properly computed and used during optimization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->