### PR TITLE
feat(website): attribute bulk-issued training licenses by customer email

### DIFF
--- a/website/src/pages/admin/licenses/index.astro
+++ b/website/src/pages/admin/licenses/index.astro
@@ -148,7 +148,7 @@ const productsJson = JSON.stringify(PRODUCTS);
             </select>
           </div>
           <div>
-            <label class="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-1">User Email</label>
+            <label class="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-1">Customer Email</label>
             <input
               id="issue-email"
               type="email"
@@ -156,6 +156,21 @@ const productsJson = JSON.stringify(PRODUCTS);
               placeholder="user@example.com"
               class="w-full px-4 py-2.5 rounded-xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-900 text-sm text-slate-900 dark:text-white placeholder-slate-400 focus:outline-none focus:ring-2 focus:ring-brand-blue/50"
             />
+            <p class="mt-1 text-xs text-slate-500 dark:text-slate-400">
+              OK if the customer hasn't signed up yet — the license will show in the admin UI and auto-link to their account when they sign up with this email.
+            </p>
+          </div>
+          <div>
+            <label class="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-1">Customer Full Name (optional)</label>
+            <input
+              id="issue-customer-name"
+              type="text"
+              placeholder="Jane Doe"
+              class="w-full px-4 py-2.5 rounded-xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-900 text-sm text-slate-900 dark:text-white placeholder-slate-400 focus:outline-none focus:ring-2 focus:ring-brand-blue/50"
+            />
+            <p class="mt-1 text-xs text-slate-500 dark:text-slate-400">
+              Leave blank to fall back to the signed-up user's profile name.
+            </p>
           </div>
           <div>
             <label class="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-1">Tier</label>
@@ -329,14 +344,15 @@ const productsJson = JSON.stringify(PRODUCTS);
 
     async function loadLicenses() {
       // Load profiles for name lookup. Fall back through full_name -> email
-      // -> 'Unknown' so licenses issued to bot accounts (e.g. CI) that never
-      // set a display name still show a meaningful owner label instead of
-      // collapsing to 'Unknown'.
+      // -> undefined so profiles with neither signal don't store a literal
+      // 'Unknown' string — that would be truthy and outrank a perfectly
+      // good customer_email on the license row in the precedence chain
+      // below.
       const profiles = await fetchAllPaginated<{ id: string; full_name: string | null; email: string | null }>('profiles', 'id, full_name, email', 'id');
 
-      const nameMap = new Map<string, string>();
+      const nameMap = new Map<string, string | undefined>();
       for (const p of profiles) {
-        const label = (p.full_name && p.full_name.trim()) || p.email || 'Unknown';
+        const label = (p.full_name && p.full_name.trim()) || (p.email && p.email.trim()) || undefined;
         nameMap.set(p.id, label);
       }
 
@@ -695,6 +711,7 @@ const productsJson = JSON.stringify(PRODUCTS);
       const errorEl = document.getElementById('issue-error');
 
       const email = (document.getElementById('issue-email') as HTMLInputElement).value.trim();
+      const customerName = (document.getElementById('issue-customer-name') as HTMLInputElement).value.trim();
       const product = (document.getElementById('issue-product') as HTMLSelectElement).value;
       const tier = (document.getElementById('issue-tier') as HTMLSelectElement).value;
       const maxActivations = parseInt((document.getElementById('issue-max-activations') as HTMLInputElement).value);
@@ -710,22 +727,56 @@ const productsJson = JSON.stringify(PRODUCTS);
         return;
       }
 
-      // Look up user by email
+      // Look up the customer's profile by email. Two outcomes:
+      //   - profile exists  → use their user_id so their /account/licenses/
+      //                        page shows this license on first load.
+      //   - no profile yet  → fall back to the synthetic bootstrap user
+      //                        (ci@aidotnet.dev) and rely on the
+      //                        customer_email column to attribute the row.
+      //                        A later reconciliation pass flips user_id
+      //                        over when the real customer signs up.
       const { data: profiles, error: profileError } = await supabase
         .from('profiles')
-        .select('id')
+        .select('id, full_name')
         .eq('email', email)
         .limit(1);
 
-      if (profileError || !profiles || profiles.length === 0) {
+      if (profileError) {
         if (errorEl) {
-          errorEl.textContent = 'User not found. They must sign up first.';
+          errorEl.textContent = `Profile lookup failed: ${profileError.message}`;
           errorEl.classList.remove('hidden');
         }
+        console.error('Profile lookup error:', profileError);
         return;
       }
 
-      const userId = profiles[0].id;
+      let userId: string | null = null;
+      let profileFullName: string | null = null;
+      if (profiles && profiles.length > 0) {
+        userId = profiles[0].id;
+        profileFullName = profiles[0].full_name ?? null;
+      } else {
+        // Resolve the bootstrap placeholder on demand. Looking it up by
+        // email instead of hardcoding the UUID keeps the migration/fresh-
+        // install path sane — anyone seeding a new environment can rename
+        // the placeholder as long as the email stays stable.
+        const { data: bootstrap, error: bootstrapError } = await supabase
+          .from('profiles')
+          .select('id')
+          .eq('email', 'ci@aidotnet.dev')
+          .limit(1);
+        if (bootstrapError || !bootstrap || bootstrap.length === 0) {
+          if (errorEl) {
+            errorEl.textContent =
+              'No profile for this email, and the ci@aidotnet.dev bootstrap account is missing. ' +
+              'Create the bootstrap profile before issuing pre-signup licenses.';
+            errorEl.classList.remove('hidden');
+          }
+          console.error('Bootstrap profile missing:', bootstrapError);
+          return;
+        }
+        userId = bootstrap[0].id;
+      }
 
       // Generate a license key: {productPrefix}.{random12}.{random16}.
       // Product prefix (aidn / harm / ...) comes from PRODUCT_META so the
@@ -733,6 +784,13 @@ const productsJson = JSON.stringify(PRODUCTS);
       const keyPart1 = crypto.randomUUID().replace(/-/g, '').substring(0, 12);
       const keyPart2 = crypto.randomUUID().replace(/-/g, '').substring(0, 16);
       const licenseKey = `${productMeta.prefix}.${keyPart1}.${keyPart2}`;
+
+      // customer_full_name precedence: admin-typed name > profile name
+      // (when one exists) > null. We deliberately store the form-supplied
+      // name even when a profile exists so the admin can correct stale
+      // profile data (e.g., a customer signed up with just an email and
+      // the profile has no display name yet).
+      const customerFullName = customerName || profileFullName || null;
 
       const { error: insertError } = await supabase
         .from('license_keys')
@@ -745,6 +803,10 @@ const productsJson = JSON.stringify(PRODUCTS);
           max_activations: maxActivations,
           organization_name: org || null,
           notes: notes || null,
+          // Always persist customer_email so the admin table + search
+          // work even when user_id points at the bootstrap placeholder.
+          customer_email: email,
+          customer_full_name: customerFullName,
         });
 
       if (insertError) {

--- a/website/src/pages/admin/licenses/index.astro
+++ b/website/src/pages/admin/licenses/index.astro
@@ -157,7 +157,7 @@ const productsJson = JSON.stringify(PRODUCTS);
               class="w-full px-4 py-2.5 rounded-xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-900 text-sm text-slate-900 dark:text-white placeholder-slate-400 focus:outline-none focus:ring-2 focus:ring-brand-blue/50"
             />
             <p class="mt-1 text-xs text-slate-500 dark:text-slate-400">
-              OK if the customer hasn't signed up yet — the license will show in the admin UI and auto-link to their account when they sign up with this email.
+              OK if the customer hasn't signed up yet — the license will appear in the admin UI now and can be reassigned to their real account once the signup-reconciliation step ships.
             </p>
           </div>
           <div>

--- a/website/src/pages/admin/licenses/index.astro
+++ b/website/src/pages/admin/licenses/index.astro
@@ -258,7 +258,14 @@ const productsJson = JSON.stringify(PRODUCTS);
       issued_at: string;
       expires_at: string | null;
       created_at: string;
+      // Admin-populated attribution fields. Used when a license was
+      // issued directly by an admin (e.g., training cohort bulk-issue)
+      // before the real customer has signed up, so the UI can show the
+      // real person instead of the synthetic bootstrap user_id.
+      customer_email: string | null;
+      customer_full_name: string | null;
       ownerName?: string;
+      ownerEmail?: string;
       activationCount?: number;
     }
 
@@ -336,7 +343,7 @@ const productsJson = JSON.stringify(PRODUCTS);
       // Load all license keys
       let licenses: LicenseKey[];
       try {
-        licenses = await fetchAllPaginated<LicenseKey>('license_keys', 'id, user_id, license_key, product, tier, status, max_activations, organization_name, notes, stripe_subscription_id, issued_at, expires_at, created_at', 'created_at');
+        licenses = await fetchAllPaginated<LicenseKey>('license_keys', 'id, user_id, license_key, product, tier, status, max_activations, organization_name, notes, stripe_subscription_id, issued_at, expires_at, created_at, customer_email, customer_full_name', 'created_at');
       } catch (err) {
         const loading = document.getElementById('licenses-loading');
         if (loading) loading.innerHTML = '<p class="text-sm text-red-500">Failed to load licenses.</p>';
@@ -358,11 +365,32 @@ const productsJson = JSON.stringify(PRODUCTS);
         }
       }
 
-      allLicenses = licenses.map(l => ({
-        ...l,
-        ownerName: nameMap.get(l.user_id) || 'Unknown',
-        activationCount: activationCounts.get(l.id) || 0,
-      }));
+      // Owner-attribution precedence:
+      //   1. customer_full_name (admin-set, e.g. bulk training issuance)
+      //   2. profile.full_name
+      //   3. profile.email
+      //   4. customer_email (when no profile exists yet)
+      //   5. 'Unknown'
+      //
+      // customer_full_name wins over profile.full_name deliberately: when
+      // an admin issued a license to someone whose profile is a synthetic
+      // bootstrap account (ci@aidotnet.dev, etc.), the admin-entered name
+      // is the authoritative label — it represents the real human this
+      // license was granted to, not the bot that inserted the row.
+      allLicenses = licenses.map(l => {
+        const profileLabel = nameMap.get(l.user_id);
+        const ownerName =
+          (l.customer_full_name && l.customer_full_name.trim()) ||
+          profileLabel ||
+          (l.customer_email && l.customer_email.trim()) ||
+          'Unknown';
+        return {
+          ...l,
+          ownerName,
+          ownerEmail: l.customer_email || undefined,
+          activationCount: activationCounts.get(l.id) || 0,
+        };
+      });
 
       // Stats
       const activeCount = allLicenses.filter(l => l.status === 'active').length;
@@ -387,7 +415,11 @@ const productsJson = JSON.stringify(PRODUCTS);
 
       filteredLicenses = allLicenses.filter(l => {
         if (search) {
-          const haystack = `${l.license_key} ${l.ownerName || ''} ${l.organization_name || ''}`.toLowerCase();
+          // Include customer_email + customer_full_name in the search
+          // haystack so admins can find a bulk-issued training license
+          // by typing the student's name or email even when the row's
+          // user_id still points at the synthetic bootstrap account.
+          const haystack = `${l.license_key} ${l.ownerName || ''} ${l.ownerEmail || ''} ${l.customer_full_name || ''} ${l.organization_name || ''}`.toLowerCase();
           if (!haystack.includes(search)) return false;
         }
         if (productFilter && l.product !== productFilter) return false;
@@ -488,7 +520,7 @@ const productsJson = JSON.stringify(PRODUCTS);
             <button class="activations-btn font-mono text-xs text-brand-blue hover:underline" data-id="${l.id}" title="View activations">${escapeHtml(keyPreview)}</button>
           </td>
           <td class="py-3 px-4">${productBadge(l.product)}</td>
-          <td class="py-3 px-4 text-slate-700 dark:text-slate-300">${escapeHtml(l.ownerName || 'Unknown')}${l.organization_name ? `<br><span class="text-xs text-slate-400">${escapeHtml(l.organization_name)}</span>` : ''}</td>
+          <td class="py-3 px-4 text-slate-700 dark:text-slate-300">${escapeHtml(l.ownerName || 'Unknown')}${l.ownerEmail && l.ownerEmail !== l.ownerName ? `<br><span class="text-xs text-slate-400">${escapeHtml(l.ownerEmail)}</span>` : ''}${l.organization_name ? `<br><span class="text-xs text-slate-400">${escapeHtml(l.organization_name)}</span>` : ''}</td>
           <td class="py-3 px-4">${tierBadge(l.tier)}</td>
           <td class="py-3 px-4">${statusBadge(l.status)}</td>
           <td class="py-3 px-4 text-slate-500 dark:text-slate-400 text-sm">${activations}</td>

--- a/website/supabase/migrations/20260420204035_add_customer_fields_to_license_keys.sql
+++ b/website/supabase/migrations/20260420204035_add_customer_fields_to_license_keys.sql
@@ -1,0 +1,55 @@
+-- Adds customer_email + customer_full_name to license_keys so an admin
+-- can attribute a license to a real person *before* that person has
+-- signed up on the website.
+--
+-- Context: 45 training-cohort licenses were issued directly via SQL
+-- (issued_at 2026-04-06) while the signup flow was still broken. They
+-- were all attributed to the synthetic ci@aidotnet.dev user_id since no
+-- real auth.users rows existed at the time. The real attendees' names
+-- ended up in the `notes` column as free text and their emails stayed
+-- only in the AiTraining Azure DevOps org.
+--
+-- Constraints the user pinned for this migration:
+--   - The `license_key` string column is immutable — customers have
+--     those strings baked into env vars / ~/.aidotnet/license.key files
+--     and anything that invalidates them breaks their workstations.
+--   - `user_id` stays ci@aidotnet.dev. If we created 46 fake auth.users
+--     rows to move the FK, any of those students signing up with their
+--     real email later would end up with two accounts (the one we
+--     pre-provisioned + the one Supabase just issued) and Supabase
+--     doesn't merge on email.
+--
+-- So: add two nullable columns that the admin UI can prefer for display,
+-- but that carry no FK weight. When the student does sign up, a separate
+-- reconciliation pass (future migration) can reassign user_id on the
+-- license row; the license key string and the customer_email column
+-- don't need to change when that happens.
+
+ALTER TABLE public.license_keys
+  ADD COLUMN IF NOT EXISTS customer_email     TEXT,
+  ADD COLUMN IF NOT EXISTS customer_full_name TEXT;
+
+-- Index the email column so the (future) reconciliation trigger can look
+-- up "which licenses belong to this brand-new auth.users row" in O(log n)
+-- when a new profile is created. No unique constraint — a single customer
+-- can legitimately hold multiple licenses, and the uniqueness invariant
+-- is license_key itself, not the email.
+CREATE INDEX IF NOT EXISTS idx_license_keys_customer_email
+  ON public.license_keys (customer_email)
+  WHERE customer_email IS NOT NULL;
+
+-- Lightweight sanity constraint: if customer_email is set, it must look
+-- like an email. This is deliberately *not* the full RFC 5322 regex —
+-- that's an O(1) sanity check, not an authenticator. The auth stack
+-- (Supabase) is the source of truth for address validity.
+ALTER TABLE public.license_keys
+  DROP CONSTRAINT IF EXISTS license_keys_customer_email_format;
+ALTER TABLE public.license_keys
+  ADD CONSTRAINT license_keys_customer_email_format
+  CHECK (customer_email IS NULL OR customer_email ~* '^[^@\s]+@[^@\s]+\.[^@\s]+$');
+
+COMMENT ON COLUMN public.license_keys.customer_email IS
+  'Contact email for the person this license was issued to. Set when a license is issued before the customer has signed up (e.g., training cohort). Separate from user_id/profile so admin UI can attribute rows without forging auth.users rows.';
+
+COMMENT ON COLUMN public.license_keys.customer_full_name IS
+  'Display name of the license owner when user_id points to a synthetic/bootstrap account (e.g., ci@aidotnet.dev for bulk-issued training licenses).';


### PR DESCRIPTION
## Summary

Adds `customer_email` + `customer_full_name` columns to `license_keys` so an admin can attribute a license to a real person before that person has signed up. Backfills the 44 training-cohort rows issued on 2026-04-06 with real `ivorycloud.com` addresses (pulled from the Ivory-Cloud Azure DevOps organization to match `notes`-column names to their email accounts).

**`license_key` strings are unchanged** — customers' existing env vars / `~/.aidotnet/license.key` files keep working.

## Changes

- **Migration `20260420204035_add_customer_fields_to_license_keys.sql`** — nullable columns, partial index on `customer_email` for the future signup-reconciliation trigger, sanity CHECK constraint on email shape. Already applied to prod via the Supabase management API; the file's stored version matches `supabase_migrations.schema_migrations.version` so the next deploy's `supabase db push` is a no-op.
- **`src/pages/admin/licenses/index.astro`**:
  - Owner-attribution precedence: `customer_full_name` → `profile.full_name` → `profile.email` → `customer_email` → `'Unknown'`. `customer_full_name` wins over a synthetic `ci@aidotnet.dev` profile so the admin table shows "Melissa Andrew" instead of "ci@aidotnet.dev" for training rows.
  - Owner cell now shows the customer email as a secondary line when it exists and differs from the name.
  - Search haystack includes `customer_email` + `customer_full_name` so an admin can find a training license by typing the student's name or email.

## Backfill result

- 44 rows → populated with real ivorycloud.com emails + full names
- 1 row → `AIDN-CI-2026-…` (the CI bot's own license) — legitimately stays attributed to `ci@aidotnet.dev`, both new columns NULL
- 1 row → the `harmonic_engine` license owned by `playwright-admin@aidotnet.dev` — untouched

## Future work (not in this PR)

A signup-reconciliation trigger: when a new `auth.users` row is created whose email matches a `license_keys.customer_email`, flip `license_keys.user_id` over so the customer sees their license on `/account/licenses/` from day one.

## Test plan

- [x] Astro build green
- [x] Backfill applied to prod Supabase — 44 of 45 ci@ rows populated (1 deliberately left)
- [ ] Admin dashboard shows real student names instead of `ci@aidotnet.dev` after deploy
- [ ] Admin search by student name or email returns the training license

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * License issuance form now includes an optional customer full name field and updated email labeling for improved customer attribution
  * License table owner information now displays customer email alongside owner name when available
  * Search functionality expanded to filter licenses by customer email and name in addition to existing criteria
<!-- end of auto-generated comment: release notes by coderabbit.ai -->