### PR TITLE
fix(loss): sum over class axis in CategoricalCrossEntropyLoss tape (closes #1191)

### DIFF
--- a/src/LossFunctions/CategoricalCrossEntropyLoss.cs
+++ b/src/LossFunctions/CategoricalCrossEntropyLoss.cs
@@ -145,15 +145,28 @@ public class CategoricalCrossEntropyLoss<T> : LossFunctionBase<T>
     public override Tensor<T> ComputeTapeLoss(Tensor<T> predicted, Tensor<T> target)
     {
         target = EnsureTargetMatchesPredicted(predicted, target);
-        // Categorical CE = -mean(target * log(predicted + eps)). The
-        // model's last layer is responsible for producing a proper
-        // probability distribution — we only add a small epsilon to
-        // avoid log(0) on any class the target happens to ignore.
+        // Categorical CE per sample = -Σ_class target * log(predicted + eps),
+        // summed over the class (last) axis, then averaged over any remaining
+        // batch / sequence axes. This matches PyTorch's
+        // nn.CrossEntropyLoss(reduction='mean') and the scalar
+        // CalculateLoss(Vector, Vector) above — both of which sum (do not
+        // average) across classes. Averaging over the class axis here would
+        // silently divide the loss and the back-propagated gradient by V,
+        // which is the 1/V scaling reported in issue #1191.
         var safePredicted = Engine.TensorAddScalar(predicted, NumOps.FromDouble(1e-7));
         var logP = Engine.TensorLog(safePredicted);
         var product = Engine.TensorMultiply(target, logP);
-        var allAxes = Enumerable.Range(0, product.Shape.Length).ToArray();
-        var mean = Engine.ReduceMean(product, allAxes, keepDims: false);
+
+        int lastAxis = product.Shape.Length - 1;
+        var perSample = Engine.ReduceSum(product, new[] { lastAxis }, keepDims: false);
+
+        // For 1D inputs (a single unbatched sample), perSample is rank-0 —
+        // there are no batch axes to average over.
+        if (perSample.Shape.Length == 0)
+            return Engine.TensorNegate(perSample);
+
+        var batchAxes = Enumerable.Range(0, perSample.Shape.Length).ToArray();
+        var mean = Engine.ReduceMean(perSample, batchAxes, keepDims: false);
         return Engine.TensorNegate(mean);
     }
 }

--- a/tests/AiDotNet.Tests/IntegrationTests/LossFunctions/CategoricalCrossEntropyTapeIssue1191Tests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/LossFunctions/CategoricalCrossEntropyTapeIssue1191Tests.cs
@@ -273,6 +273,20 @@ public class CategoricalCrossEntropyTapeIssue1191Tests
         const int modelDim = 16;
         const int ffDim = 32;
         const int numFacts = vocabSize; // identity task: input k → class k
+        const int totalIters = 400;
+        const int window = 40;
+        const int trials = 5;
+        // Multi-trial pass criterion: at least 4/5 trials must satisfy
+        // every guard. The Transformer has no exposed seed for weight
+        // init, so a single stochastic run can flake on CI even when
+        // the fix is correct. Across 5 trials we tolerate 1 unlucky
+        // run while still rejecting any genuine regression — the pre-
+        // fix 1/V bug fails *every* trial because it's deterministic
+        // (the loss reporting bug is independent of init).
+        const int requiredPasses = 4;
+
+        float lnV = (float)Math.Log(vocabSize);   // 2.0794
+        float lnVOverV = lnV / vocabSize;          // 0.2599
 
         var architecture = new TransformerArchitecture<float>(
             inputType: InputType.TwoDimensional,
@@ -287,27 +301,7 @@ public class CategoricalCrossEntropyTapeIssue1191Tests
             maxSequenceLength: seqLen,
             vocabularySize: vocabSize);
 
-        // Use Adam at a conservative LR. After the #1191 fix, tape
-        // gradients are V× larger than the buggy 1/V version, so a
-        // higher LR would over-shoot on this small model. Adam's
-        // per-parameter step adaptation keeps the trajectory sane
-        // regardless of which parameter is dominant.
-        var optimizerOptions = new AdamOptimizerOptions<float, Tensor<float>, Tensor<float>>
-        {
-            InitialLearningRate = 0.005,
-            Beta1 = 0.9,
-            Beta2 = 0.999,
-            Epsilon = 1e-8,
-            UseAdaptiveBetas = false
-        };
-        var optimizer = new AdamOptimizer<float, Tensor<float>, Tensor<float>>(null, optimizerOptions);
-
-        var transformer = new Transformer<float>(
-            architecture,
-            lossFunction: new CategoricalCrossEntropyLoss<float>(),
-            optimizer: optimizer);
-
-        // Build the identity dataset: input [k,k,k,k] → class k.
+        // Build the identity dataset once: input [k,k,k,k] → class k.
         var inputs = new Tensor<float>[numFacts];
         var targets = new Tensor<float>[numFacts];
         for (int k = 0; k < numFacts; k++)
@@ -321,104 +315,123 @@ public class CategoricalCrossEntropyTapeIssue1191Tests
             targets[k] = tgt;
         }
 
-        transformer.SetTrainingMode(true);
-
-        // First call exposes the random-init loss. Pre-fix this is
-        // ~ln(V)/V ≈ 0.26 at V=8 instead of ~ln(V) ≈ 2.08.
-        transformer.Train(inputs[0], targets[0]);
-        float initialLoss = transformer.GetLastLoss();
-        _output.WriteLine($"V={vocabSize}  initial loss after 1 iter = {initialLoss:F6}");
-
-        float lnV = (float)Math.Log(vocabSize);   // 2.0794
-        float lnVOverV = lnV / vocabSize;          // 0.2599
-
-        Assert.True(!float.IsNaN(initialLoss) && !float.IsInfinity(initialLoss),
-            $"Initial loss must be finite; got {initialLoss}");
-
-        // Initial loss should be in the same ballpark as ln(V). Allow a
-        // wide window because (a) the model isn't perfectly uniform at
-        // init, and (b) the first gradient step has already happened.
-        // The pre-fix 1/V value of 0.26 is 8× smaller than the lower
-        // bound here — it can't pass.
-        Assert.True(initialLoss > 0.5f * lnV,
-            $"Initial loss {initialLoss:F6} is suspiciously below ln(V)={lnV:F6}. " +
-            $"The 1/V scaling bug from issue #1191 produces ~{lnVOverV:F6} here.");
-
-        // Run a stochastic per-sample training loop. The issue's pre-fix
-        // repro had loss bouncing in the tight band [0.228, 0.272] —
-        // every value within ~10% of ln(V)/V ≈ 0.26, unable to escape
-        // the 1/V plateau. The post-fix model must demonstrably escape
-        // that region, both upward (correct loss reporting) and
-        // downward (gradients drive learning toward correct
-        // configurations).
-        var lossesOverTime = new System.Collections.Generic.List<float>();
-        const int totalIters = 400;
-        for (int iter = 0; iter < totalIters; iter++)
+        int passed = 0;
+        var failureMessages = new System.Collections.Generic.List<string>();
+        for (int trial = 0; trial < trials; trial++)
         {
-            int k = iter % numFacts;
-            transformer.Train(inputs[k], targets[k]);
-            lossesOverTime.Add(transformer.GetLastLoss());
+            // Use Adam at a conservative LR. After the #1191 fix, tape
+            // gradients are V× larger than the buggy 1/V version, so a
+            // higher LR would over-shoot on this small model. Adam's
+            // per-parameter step adaptation keeps the trajectory sane
+            // regardless of which parameter is dominant. Each trial
+            // gets a fresh optimizer + transformer so weight init is
+            // independent.
+            var optimizerOptions = new AdamOptimizerOptions<float, Tensor<float>, Tensor<float>>
+            {
+                InitialLearningRate = 0.005,
+                Beta1 = 0.9,
+                Beta2 = 0.999,
+                Epsilon = 1e-8,
+                UseAdaptiveBetas = false
+            };
+            var optimizer = new AdamOptimizer<float, Tensor<float>, Tensor<float>>(null, optimizerOptions);
+            var transformer = new Transformer<float>(
+                architecture,
+                lossFunction: new CategoricalCrossEntropyLoss<float>(),
+                optimizer: optimizer);
+
+            transformer.SetTrainingMode(true);
+
+            // First call exposes the random-init loss. Pre-fix this is
+            // ~ln(V)/V ≈ 0.26 at V=8 instead of ~ln(V) ≈ 2.08.
+            transformer.Train(inputs[0], targets[0]);
+            float initialLoss = transformer.GetLastLoss();
+
+            // initialLoss after one training step depends on init — it
+            // can drift toward 0.5 × ln(V) on lucky inits even though
+            // the 1/V plateau (~ln(V)/V ≈ 0.26) is structurally
+            // impossible after the fix. Use a wide floor so that any
+            // reasonable post-fix value passes; the buggy value is
+            // 4× below this floor.
+            bool initialOk =
+                !float.IsNaN(initialLoss)
+                && !float.IsInfinity(initialLoss)
+                && initialLoss > 0.5f * lnV;
+
+            // Run a stochastic per-sample training loop. The issue's pre-fix
+            // repro had loss bouncing in the tight band [0.228, 0.272] —
+            // every value within ~10% of ln(V)/V ≈ 0.26, unable to escape
+            // the 1/V plateau. The post-fix model must demonstrably escape
+            // that region, both upward (correct loss reporting) and
+            // downward (gradients drive learning toward correct
+            // configurations).
+            var lossesOverTime = new System.Collections.Generic.List<float>(totalIters);
+            for (int iter = 0; iter < totalIters; iter++)
+            {
+                int k = iter % numFacts;
+                transformer.Train(inputs[k], targets[k]);
+                lossesOverTime.Add(transformer.GetLastLoss());
+            }
+
+            float minLoss = lossesOverTime.Min();
+            float maxLoss = lossesOverTime.Max();
+            float spread = maxLoss - minLoss;
+            float firstWindowMean = Average(lossesOverTime, 0, window);
+            float lastWindowMean = Average(lossesOverTime, totalIters - window, window);
+
+            _output.WriteLine(
+                $"trial {trial + 1}/{trials}: initial={initialLoss:F4}  min={minLoss:F4}  max={maxLoss:F4}  " +
+                $"spread={spread:F4}  first_window={firstWindowMean:F4}  last_window={lastWindowMean:F4}");
+
+            // Guard 1: early-training mean in ln(V) ballpark (not 1/V plateau).
+            // Guard 2: model REACHES low loss (gradient flow proof).
+            // Guard 3: max loss escapes the 1/V plateau region.
+            // Guard 4: spread > tolerance (no Cycle-30 bit-identical signature).
+            bool trialPass =
+                initialOk
+                && firstWindowMean > 0.5f * lnV
+                && minLoss < 0.85f * lnV
+                && maxLoss > 0.5f * lnV
+                && spread > 1e-2f;
+            if (trialPass)
+            {
+                passed++;
+            }
+            else
+            {
+                failureMessages.Add(
+                    $"trial {trial + 1}: initial={initialLoss:F4}, " +
+                    $"firstWin={firstWindowMean:F4} (>{0.5f * lnV:F4}? {firstWindowMean > 0.5f * lnV}), " +
+                    $"min={minLoss:F4} (<{0.85f * lnV:F4}? {minLoss < 0.85f * lnV}), " +
+                    $"max={maxLoss:F4} (>{0.5f * lnV:F4}? {maxLoss > 0.5f * lnV}), " +
+                    $"spread={spread:F4} (>1e-2? {spread > 1e-2f})");
+            }
         }
 
-        float minLoss = lossesOverTime.Min();
-        float maxLoss = lossesOverTime.Max();
-        float spread = maxLoss - minLoss;
-        const int window = 40;
-        float firstWindowMean = Average(lossesOverTime, 0, window);
-        float lastWindowMean = Average(lossesOverTime, totalIters - window, window);
-        _output.WriteLine(
-            $"Loss range over {totalIters} iters: min={minLoss:F6}  max={maxLoss:F6}  spread={spread:F6}  " +
-            $"first_window={firstWindowMean:F6}  last_window={lastWindowMean:F6}");
+        _output.WriteLine($"Aggregate: {passed}/{trials} trials passed all guards.");
 
-        // Guard 1: early-training mean must be in the ln(V) ballpark,
-        // NOT the buggy ln(V)/V plateau. The 0.5 × ln(V) floor is 4×
-        // the buggy value, so this can't pass with the 1/V regression.
-        Assert.True(firstWindowMean > 0.5f * lnV,
-            $"Early training loss {firstWindowMean:F6} is suspiciously below ln(V)={lnV:F6}. " +
-            $"Issue #1191's 1/V scaling produces ~{lnVOverV:F6} on this task.");
-
-        // Guard 2 (real-improvement assertion): the model must REACH a
-        // per-iteration loss strictly below the random-init floor
-        // ln(V). This is the canonical proof that gradients flow with
-        // correct magnitude — the pre-fix issue repro had loss
-        // bouncing in [0.228, 0.272], unable to escape the plateau.
-        // Empirically, with the 1/V fix this Transformer reliably
-        // reaches min < 1.5 (≈ 0.72×ln(V)) within 400 stochastic
-        // single-sample iterations across many runs (observed range
-        // 0.50–1.31). The 0.85 threshold gives margin against the
-        // worst observed run while still proving learning occurred.
-        // The per-sample SGD noise on a tiny model means windowed
-        // means stay near the run-mean (≈ ln(V)) — the trajectory
-        // visits low-loss configurations but oscillates, so MIN is
-        // the right convergence proxy here, not the window mean.
-        Assert.True(minLoss < 0.85f * lnV,
-            $"Model never reached low loss across {totalIters} iters " +
-            $"(issue #1191): min={minLoss:F6}, threshold={0.85f * lnV:F6} = 0.85×ln(V). " +
-            $"Pre-fix repro had min=0.228 (within 10% of the {lnVOverV:F6} 1/V plateau). " +
-            $"Reaching low loss is the canonical proof gradients drive the model " +
-            $"toward correct configurations.");
-
-        // Guard 3 (escape-from-plateau): the maximum loss must also
-        // visibly exceed ln(V)/V — the pre-fix Cycle-30 run was bit-
-        // identical at 0.0217 across 56k SGD steps. Any value above
-        // 0.5×ln(V) on any iteration disproves that signature.
-        Assert.True(maxLoss > 0.5f * lnV,
-            $"Loss never escaped the 1/V plateau region (issue #1191): " +
-            $"max={maxLoss:F6}, ln(V)/V={lnVOverV:F6}, " +
-            $"required max > {0.5f * lnV:F6}.");
-
-        // Guard 4 (movement): bit-identical loss across iterations is
-        // the Cycle-30 plateau signature. Empirically the post-fix
-        // spread is 2.0–6.1 (typical run); 1e-2 is a paranoid floor.
-        Assert.True(spread > 1e-2f,
-            $"Loss is too flat across {totalIters} iters (issue #1191 plateau symptom): " +
-            $"min={minLoss:F6}, max={maxLoss:F6}, spread={spread:F6}.");
+        // Multi-trial pass criterion: a clear majority must satisfy
+        // every guard. The 1/V regression would fail every trial
+        // (the bug is deterministic — pre-fix loss is structurally
+        // ~ln(V)/V ≈ {0.2599} regardless of init), so the threshold
+        // distinguishes "fix is correct" from "fix has regressed"
+        // even with 1–2 unlucky weight-init trials.
+        Assert.True(passed >= requiredPasses,
+            $"Convergence checks were unstable: passed {passed}/{trials} trials, " +
+            $"required {requiredPasses}. The 1/V bug from issue #1191 would fail " +
+            $"every trial deterministically. Per-trial failure detail:\n  " +
+            string.Join("\n  ", failureMessages));
     }
 
     private static float Average(System.Collections.Generic.List<float> xs, int start, int count)
     {
         float s = 0f;
-        for (int i = start; i < start + count && i < xs.Count; i++) s += xs[i];
-        return s / count;
+        int n = 0;
+        for (int i = start; i < start + count && i < xs.Count; i++)
+        {
+            s += xs[i];
+            n++;
+        }
+        return n == 0 ? 0f : s / n;
     }
 }

--- a/tests/AiDotNet.Tests/IntegrationTests/LossFunctions/CategoricalCrossEntropyTapeIssue1191Tests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/LossFunctions/CategoricalCrossEntropyTapeIssue1191Tests.cs
@@ -287,14 +287,11 @@ public class CategoricalCrossEntropyTapeIssue1191Tests
             maxSequenceLength: seqLen,
             vocabularySize: vocabSize);
 
-        // Use Adam at a low LR so the test isn't sensitive to the exact
-        // gradient magnitude. After the #1191 fix, tape gradients are
-        // V× larger than the buggy 1/V version — a default-LR plain SGD
-        // run that "barely converged" pre-fix would now over-shoot. Adam
-        // adapts step size per-parameter from the running variance, so
-        // this test pins the *direction* of training (loss decreases,
-        // accuracy beats random) without coupling to a specific LR
-        // tuning regime.
+        // Use Adam at a conservative LR. After the #1191 fix, tape
+        // gradients are V× larger than the buggy 1/V version, so a
+        // higher LR would over-shoot on this small model. Adam's
+        // per-parameter step adaptation keeps the trajectory sane
+        // regardless of which parameter is dominant.
         var optimizerOptions = new AdamOptimizerOptions<float, Tensor<float>, Tensor<float>>
         {
             InitialLearningRate = 0.005,
@@ -347,23 +344,15 @@ public class CategoricalCrossEntropyTapeIssue1191Tests
             $"Initial loss {initialLoss:F6} is suspiciously below ln(V)={lnV:F6}. " +
             $"The 1/V scaling bug from issue #1191 produces ~{lnVOverV:F6} here.");
 
-        // Run a short training loop and check loss trajectory. The
-        // assertions deliberately focus on what issue #1191 directly
-        // proves, not on full convergence:
-        //
-        // 1. Reported loss must be in the ln(V) ballpark across the
-        //    entire run (not the ln(V)/V ≈ 0.26 plateau).
-        // 2. The mean loss must move (spread > tolerance) — bit-
-        //    identical loss across iterations is the defining symptom
-        //    of the issue's Cycle-30 plateau, where the 1/V gradient
-        //    attenuation made effective steps near zero.
-        //
-        // We do NOT assert end-state accuracy here. After fixing the
-        // 1/V scaling, gradients are V× larger; a default-LR run that
-        // 'barely moved' pre-fix may now move too aggressively or
-        // require LR tuning. That is downstream of #1191's scope.
+        // Run a stochastic per-sample training loop. The issue's pre-fix
+        // repro had loss bouncing in the tight band [0.228, 0.272] —
+        // every value within ~10% of ln(V)/V ≈ 0.26, unable to escape
+        // the 1/V plateau. The post-fix model must demonstrably escape
+        // that region, both upward (correct loss reporting) and
+        // downward (gradients drive learning toward correct
+        // configurations).
         var lossesOverTime = new System.Collections.Generic.List<float>();
-        const int totalIters = 200;
+        const int totalIters = 400;
         for (int iter = 0; iter < totalIters; iter++)
         {
             int k = iter % numFacts;
@@ -374,20 +363,53 @@ public class CategoricalCrossEntropyTapeIssue1191Tests
         float minLoss = lossesOverTime.Min();
         float maxLoss = lossesOverTime.Max();
         float spread = maxLoss - minLoss;
-        float meanLoss = Average(lossesOverTime, 0, totalIters);
-        _output.WriteLine($"Loss range over {totalIters} iters: min={minLoss:F6}  max={maxLoss:F6}  spread={spread:F6}  mean={meanLoss:F6}");
+        const int window = 40;
+        float firstWindowMean = Average(lossesOverTime, 0, window);
+        float lastWindowMean = Average(lossesOverTime, totalIters - window, window);
+        _output.WriteLine(
+            $"Loss range over {totalIters} iters: min={minLoss:F6}  max={maxLoss:F6}  spread={spread:F6}  " +
+            $"first_window={firstWindowMean:F6}  last_window={lastWindowMean:F6}");
 
-        // Mean loss across the run should be in the ln(V) ballpark.
-        // The buggy ln(V)/V value at V=8 is 0.26 — anything above 0.5
-        // proves the 1/V scaling is gone.
-        Assert.True(meanLoss > 0.5f * lnV,
-            $"Mean training loss {meanLoss:F6} is suspiciously below ln(V)={lnV:F6}. " +
+        // Guard 1: early-training mean must be in the ln(V) ballpark,
+        // NOT the buggy ln(V)/V plateau. The 0.5 × ln(V) floor is 4×
+        // the buggy value, so this can't pass with the 1/V regression.
+        Assert.True(firstWindowMean > 0.5f * lnV,
+            $"Early training loss {firstWindowMean:F6} is suspiciously below ln(V)={lnV:F6}. " +
             $"Issue #1191's 1/V scaling produces ~{lnVOverV:F6} on this task.");
 
-        // Spread guard: bit-identical loss across iterations is the
-        // signature of the issue's Cycle-30 plateau. With gradients
-        // flowing at correct magnitude after the fix, 200 iters on a
-        // 8-fact identity task produces loss that visibly moves.
+        // Guard 2 (real-improvement assertion): the model must REACH a
+        // per-iteration loss strictly below the random-init floor
+        // ln(V). This is the canonical proof that gradients flow with
+        // correct magnitude — the pre-fix issue repro had loss
+        // bouncing in [0.228, 0.272], unable to escape the plateau.
+        // Empirically, with the 1/V fix this Transformer reliably
+        // reaches min < 1.5 (≈ 0.72×ln(V)) within 400 stochastic
+        // single-sample iterations across many runs (observed range
+        // 0.50–1.31). The 0.85 threshold gives margin against the
+        // worst observed run while still proving learning occurred.
+        // The per-sample SGD noise on a tiny model means windowed
+        // means stay near the run-mean (≈ ln(V)) — the trajectory
+        // visits low-loss configurations but oscillates, so MIN is
+        // the right convergence proxy here, not the window mean.
+        Assert.True(minLoss < 0.85f * lnV,
+            $"Model never reached low loss across {totalIters} iters " +
+            $"(issue #1191): min={minLoss:F6}, threshold={0.85f * lnV:F6} = 0.85×ln(V). " +
+            $"Pre-fix repro had min=0.228 (within 10% of the {lnVOverV:F6} 1/V plateau). " +
+            $"Reaching low loss is the canonical proof gradients drive the model " +
+            $"toward correct configurations.");
+
+        // Guard 3 (escape-from-plateau): the maximum loss must also
+        // visibly exceed ln(V)/V — the pre-fix Cycle-30 run was bit-
+        // identical at 0.0217 across 56k SGD steps. Any value above
+        // 0.5×ln(V) on any iteration disproves that signature.
+        Assert.True(maxLoss > 0.5f * lnV,
+            $"Loss never escaped the 1/V plateau region (issue #1191): " +
+            $"max={maxLoss:F6}, ln(V)/V={lnVOverV:F6}, " +
+            $"required max > {0.5f * lnV:F6}.");
+
+        // Guard 4 (movement): bit-identical loss across iterations is
+        // the Cycle-30 plateau signature. Empirically the post-fix
+        // spread is 2.0–6.1 (typical run); 1e-2 is a paranoid floor.
         Assert.True(spread > 1e-2f,
             $"Loss is too flat across {totalIters} iters (issue #1191 plateau symptom): " +
             $"min={minLoss:F6}, max={maxLoss:F6}, spread={spread:F6}.");

--- a/tests/AiDotNet.Tests/IntegrationTests/LossFunctions/CategoricalCrossEntropyTapeIssue1191Tests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/LossFunctions/CategoricalCrossEntropyTapeIssue1191Tests.cs
@@ -1,0 +1,402 @@
+using System;
+using AiDotNet.Enums;
+using AiDotNet.LossFunctions;
+using AiDotNet.Models.Options;
+using AiDotNet.NeuralNetworks;
+using AiDotNet.Optimizers;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace AiDotNetTests.IntegrationTests.LossFunctions;
+
+/// <summary>
+/// Regression suite for issue #1191 — Categorical cross-entropy tape
+/// loss was averaged across the class axis, producing a loss value
+/// (and a back-propagated gradient) that was 1/V of the true CE.
+///
+/// The pre-fix <see cref="CategoricalCrossEntropyLoss{T}.ComputeTapeLoss"/>
+/// did <c>ReduceMean(product, allAxes)</c>. For a one-hot target the
+/// product tensor has exactly one non-zero entry per sample, so taking
+/// the mean over the class axis silently divided by V. At V=8 this
+/// produced a reported loss of ~0.26 at uniform softmax (vs. true
+/// ln(8) ≈ 2.08); at V=256 it produced 0.0217 (vs. true ln(256) ≈
+/// 5.55), matching exactly the bit-identical loss reported in the
+/// issue's Cycle-30 run.
+///
+/// These tests pin both halves of the bug:
+/// 1. The direct-tape tests assert the loss tensor produced by
+///    <c>ComputeTapeLoss</c> matches the standard
+///    <c>-Σ_class target * log(predicted)</c> formula across 1D / 2D /
+///    3D shapes — they fail with a 1/V relative error on the buggy
+///    code.
+/// 2. The end-to-end Transformer test mirrors issue #1191's V=8
+///    identity-mapping repro and asserts the model both reports a
+///    loss near ln(V) at random init and learns the task — the
+///    pre-fix code reports ln(V)/V and never escapes random.
+/// </summary>
+public class CategoricalCrossEntropyTapeIssue1191Tests
+{
+    private readonly ITestOutputHelper _output;
+
+    public CategoricalCrossEntropyTapeIssue1191Tests(ITestOutputHelper output)
+    {
+        _output = output;
+    }
+
+    /// <summary>
+    /// Direct reproducer: a uniform softmax over V classes against a
+    /// one-hot target should yield exactly ln(V), the cross-entropy of
+    /// the uniform distribution. With the 1/V scaling bug the value is
+    /// ln(V)/V.
+    /// </summary>
+    /// <remarks>
+    /// V=8 is chosen to match the minimal reproducer the issue links
+    /// to (HarmonicEngine PR #80 / Phase_A4_AiDotNet_1187_Reproducer).
+    /// </remarks>
+    [Fact]
+    public void ComputeTapeLoss_UniformSoftmax_OneHotTarget_ReturnsLnV_NotLnV_OverV()
+    {
+        const int v = 8;
+        const float uniform = 1f / v; // 0.125 — softmax over 8 equal logits
+
+        // predicted: [V] — single-sample uniform distribution.
+        var predicted = new Tensor<float>([v]);
+        for (int i = 0; i < v; i++)
+            predicted[i] = uniform;
+
+        // target: [V] — one-hot at class 3 (any class works; pick a
+        // non-edge class so a future implementation that special-cases
+        // class 0 doesn't pass by accident).
+        var target = new Tensor<float>([v]);
+        target[3] = 1f;
+
+        var loss = new CategoricalCrossEntropyLoss<float>();
+        var result = loss.ComputeTapeLoss(predicted, target);
+
+        Assert.True(result.Length > 0, "Loss tensor should be non-empty");
+        float actualLoss = result[0];
+
+        // Standard CE for uniform softmax over V classes against a
+        // one-hot target = ln(V). This is independent of which class
+        // the one-hot picks because every probability equals 1/V.
+        float expectedLoss = (float)Math.Log(v);   // ≈ 2.0794
+        float buggyLoss = expectedLoss / v;        // ≈ 0.2599 — what the
+                                                   // 1/V scaling produced.
+
+        _output.WriteLine($"V={v}  expected={expectedLoss:F6}  buggy={buggyLoss:F6}  actual={actualLoss:F6}");
+
+        Assert.True(!float.IsNaN(actualLoss) && !float.IsInfinity(actualLoss),
+            $"Loss must be finite; got {actualLoss}");
+
+        // Tolerance comes from the 1e-7 epsilon added inside
+        // ComputeTapeLoss to avoid log(0). Effect on log(0.125 + 1e-7)
+        // is < 1e-6, so a 5e-4 tolerance is two orders of magnitude
+        // looser than required and still catches the 1/V regression
+        // (which is off by a factor of 8 — error ≈ 1.82, hundreds of
+        // times the tolerance).
+        Assert.Equal(expectedLoss, actualLoss, 3);
+
+        // Defense in depth: also assert we are not within tolerance of
+        // the buggy ln(V)/V value. This makes the failure message
+        // explicit if a future regression reintroduces the 1/V bug.
+        float diffFromBuggy = Math.Abs(actualLoss - buggyLoss);
+        Assert.True(diffFromBuggy > 1f,
+            $"Loss is suspiciously close to the buggy ln(V)/V value " +
+            $"({buggyLoss:F6}). Issue #1191 regression suspected. " +
+            $"actual={actualLoss:F6}, expected={expectedLoss:F6}.");
+    }
+
+    /// <summary>
+    /// Same shape regression at the V=256 scale that issue #1191
+    /// observed in its Cycle-30 production run, where the bit-identical
+    /// loss across 56k SGD steps × 3 epochs at 0.0217 = ln(256)/256
+    /// pinned the bug. With the fix the per-sample loss is ln(256) ≈
+    /// 5.5452.
+    /// </summary>
+    [Fact]
+    public void ComputeTapeLoss_UniformSoftmax_V256_ReturnsLn256_NotLn256_OverV()
+    {
+        const int v = 256;
+        const float uniform = 1f / v;
+
+        var predicted = new Tensor<float>([v]);
+        for (int i = 0; i < v; i++) predicted[i] = uniform;
+
+        var target = new Tensor<float>([v]);
+        target[42] = 1f;
+
+        var loss = new CategoricalCrossEntropyLoss<float>();
+        var result = loss.ComputeTapeLoss(predicted, target);
+
+        float actualLoss = result[0];
+        float expected = (float)Math.Log(v); // 5.5452
+        float buggy = expected / v;          // 0.02166 — Cycle-30 plateau
+
+        _output.WriteLine($"V={v}  expected={expected:F6}  buggy={buggy:F6}  actual={actualLoss:F6}");
+
+        // Wider tolerance at V=256 because the 1e-7 log-epsilon's
+        // contribution scales with V (we add 1e-7 to each of 256 values
+        // but only 1 contributes via the one-hot mask, so the bias is
+        // bounded by log(1/256 + 1e-7) - log(1/256) ≈ 2.5e-5 — still
+        // far below this tolerance).
+        Assert.Equal(expected, actualLoss, 2);
+
+        // Hard guard against the bit-identical Cycle-30 value.
+        Assert.True(Math.Abs(actualLoss - buggy) > 1f,
+            $"Loss matches the bit-identical Cycle-30 plateau {buggy:F6} — issue #1191 regressed.");
+    }
+
+    /// <summary>
+    /// Edge case: a [B=2, V=4] batched prediction where each row is a
+    /// distinct probability distribution. The expected per-sample CE is
+    /// computed by hand and averaged over the batch, exactly matching
+    /// PyTorch's <c>nn.CrossEntropyLoss(reduction='mean')</c> semantics.
+    /// </summary>
+    [Fact]
+    public void ComputeTapeLoss_TwoDimensional_BatchMean_MatchesHandComputation()
+    {
+        // Two distinct samples to make the batch-mean step observable.
+        // Sample 0 (target class 0):   probs [0.7, 0.1, 0.1, 0.1]  →  CE = -log(0.7) ≈ 0.3567
+        // Sample 1 (target class 2):   probs [0.1, 0.2, 0.4, 0.3]  →  CE = -log(0.4) ≈ 0.9163
+        // Expected batch mean = (0.3567 + 0.9163) / 2 = 0.6365
+        var predicted = new Tensor<float>([2, 4]);
+        predicted[0, 0] = 0.7f; predicted[0, 1] = 0.1f; predicted[0, 2] = 0.1f; predicted[0, 3] = 0.1f;
+        predicted[1, 0] = 0.1f; predicted[1, 1] = 0.2f; predicted[1, 2] = 0.4f; predicted[1, 3] = 0.3f;
+
+        var target = new Tensor<float>([2, 4]);
+        target[0, 0] = 1f;
+        target[1, 2] = 1f;
+
+        var loss = new CategoricalCrossEntropyLoss<float>();
+        var result = loss.ComputeTapeLoss(predicted, target);
+
+        float actual = result[0];
+        float expected = (float)((-Math.Log(0.7) + -Math.Log(0.4)) / 2.0); // 0.6365
+        float buggy = expected / 4f; // ≈ 0.1591 — what allAxes-mean produced
+
+        _output.WriteLine($"[B=2, V=4]  expected={expected:F6}  buggy={buggy:F6}  actual={actual:F6}");
+
+        // 1e-7 epsilon contribution: log(0.7 + 1e-7) - log(0.7) ≈ 1.4e-7,
+        // log(0.4 + 1e-7) - log(0.4) ≈ 2.5e-7 — both well below tolerance.
+        Assert.Equal(expected, actual, 4);
+    }
+
+    /// <summary>
+    /// Edge case: [B=2, T=3, V=4] sequence shape. Standard PyTorch
+    /// behavior is to compute per-token CE then average over both batch
+    /// and sequence axes. Verify the implementation reduces every
+    /// non-class axis and only the class axis is summed.
+    /// </summary>
+    [Fact]
+    public void ComputeTapeLoss_ThreeDimensional_BatchSequenceMean_MatchesHandComputation()
+    {
+        const int b = 2, t = 3, v = 4;
+        const float uniform = 1f / v; // 0.25 — uniform per token
+
+        var predicted = new Tensor<float>([b, t, v]);
+        for (int i = 0; i < predicted.Length; i++)
+            predicted[i] = uniform;
+
+        // One-hot target at varying class per token. Choice of class
+        // doesn't matter for uniform predictions — each token CE = ln(V).
+        var target = new Tensor<float>([b, t, v]);
+        for (int bi = 0; bi < b; bi++)
+            for (int ti = 0; ti < t; ti++)
+                target[bi, ti, (bi + ti) % v] = 1f;
+
+        var loss = new CategoricalCrossEntropyLoss<float>();
+        var result = loss.ComputeTapeLoss(predicted, target);
+
+        float actual = result[0];
+        float expected = (float)Math.Log(v); // every token contributes ln(V), mean = ln(V)
+        float buggy = expected / v;          // 1/V regression
+
+        _output.WriteLine($"[B={b}, T={t}, V={v}]  expected={expected:F6}  buggy={buggy:F6}  actual={actual:F6}");
+
+        Assert.Equal(expected, actual, 3);
+        Assert.True(Math.Abs(actual - buggy) > 1f,
+            $"3D batched loss matches 1/V buggy value ({buggy:F6}) — issue #1191 regressed.");
+    }
+
+    /// <summary>
+    /// Sanity edge: a (nearly-)perfect prediction must produce a loss
+    /// near 0, regardless of V. The pre-fix code also satisfies this
+    /// (perfect prediction → -log(1) = 0 either summed or meaned), so
+    /// this protects the bound rather than the symptom — a future
+    /// regression that, say, multiplies by a stray V would fail here
+    /// while the 1/V regression would not.
+    /// </summary>
+    [Fact]
+    public void ComputeTapeLoss_PerfectPrediction_ReturnsNearZero()
+    {
+        const int v = 16;
+        var predicted = new Tensor<float>([v]);
+        // Place ~1.0 on class 7 with tiny mass everywhere else so the
+        // distribution still sums to ~1 (matches the function contract).
+        const float spread = 1e-4f;
+        float main = 1f - spread * (v - 1);
+        for (int i = 0; i < v; i++) predicted[i] = spread;
+        predicted[7] = main;
+
+        var target = new Tensor<float>([v]);
+        target[7] = 1f;
+
+        var loss = new CategoricalCrossEntropyLoss<float>();
+        var result = loss.ComputeTapeLoss(predicted, target);
+
+        float actual = result[0];
+        // -log(1 - 1.5e-3) ≈ 1.5e-3 — well under 0.01 even with float32 noise.
+        Assert.True(actual < 0.01f,
+            $"Near-perfect prediction should yield near-zero loss; got {actual:F6}.");
+        Assert.True(actual >= 0f,
+            $"CE must be non-negative; got {actual:F6}.");
+        _output.WriteLine($"Perfect prediction: loss = {actual:F6}");
+    }
+
+    /// <summary>
+    /// Issue #1191 end-to-end repro. Mirrors the V=8 identity-mapping
+    /// task from HarmonicEngine PR #80 / Phase_A4_AiDotNet_1187_Reproducer
+    /// at slightly larger iteration count to stay well above the noise
+    /// floor of a stochastic Transformer optimizer.
+    ///
+    /// Pre-fix, this test fails on two distinct assertions:
+    /// 1. The reported initial loss is ~0.26, not ~ln(8)=2.08, because
+    ///    the tape value is divided by V before the optimizer sees it.
+    /// 2. The model never converges — accuracy stays at 1/V = 12.5%
+    ///    after 200 iterations because gradients are V× too small.
+    /// </summary>
+    [Fact]
+    public void Transformer_Train_V8_LossNearLnV_AndConverges_Issue1191Repro()
+    {
+        const int vocabSize = 8;       // V from issue
+        const int seqLen = 4;          // matches issue's [k,k,k,k] input pattern
+        const int modelDim = 16;
+        const int ffDim = 32;
+        const int numFacts = vocabSize; // identity task: input k → class k
+
+        var architecture = new TransformerArchitecture<float>(
+            inputType: InputType.TwoDimensional,
+            taskType: NeuralNetworkTaskType.SequenceClassification,
+            numEncoderLayers: 1,
+            numDecoderLayers: 0,
+            numHeads: 2,
+            modelDimension: modelDim,
+            feedForwardDimension: ffDim,
+            inputSize: seqLen,
+            outputSize: vocabSize,
+            maxSequenceLength: seqLen,
+            vocabularySize: vocabSize);
+
+        // Use Adam at a low LR so the test isn't sensitive to the exact
+        // gradient magnitude. After the #1191 fix, tape gradients are
+        // V× larger than the buggy 1/V version — a default-LR plain SGD
+        // run that "barely converged" pre-fix would now over-shoot. Adam
+        // adapts step size per-parameter from the running variance, so
+        // this test pins the *direction* of training (loss decreases,
+        // accuracy beats random) without coupling to a specific LR
+        // tuning regime.
+        var optimizerOptions = new AdamOptimizerOptions<float, Tensor<float>, Tensor<float>>
+        {
+            InitialLearningRate = 0.005,
+            Beta1 = 0.9,
+            Beta2 = 0.999,
+            Epsilon = 1e-8,
+            UseAdaptiveBetas = false
+        };
+        var optimizer = new AdamOptimizer<float, Tensor<float>, Tensor<float>>(null, optimizerOptions);
+
+        var transformer = new Transformer<float>(
+            architecture,
+            lossFunction: new CategoricalCrossEntropyLoss<float>(),
+            optimizer: optimizer);
+
+        // Build the identity dataset: input [k,k,k,k] → class k.
+        var inputs = new Tensor<float>[numFacts];
+        var targets = new Tensor<float>[numFacts];
+        for (int k = 0; k < numFacts; k++)
+        {
+            var inp = new Tensor<float>([1, seqLen]);
+            for (int s = 0; s < seqLen; s++) inp[0, s] = k;
+            inputs[k] = inp;
+
+            var tgt = new Tensor<float>([1, vocabSize]);
+            tgt[0, k] = 1f;
+            targets[k] = tgt;
+        }
+
+        transformer.SetTrainingMode(true);
+
+        // First call exposes the random-init loss. Pre-fix this is
+        // ~ln(V)/V ≈ 0.26 at V=8 instead of ~ln(V) ≈ 2.08.
+        transformer.Train(inputs[0], targets[0]);
+        float initialLoss = transformer.GetLastLoss();
+        _output.WriteLine($"V={vocabSize}  initial loss after 1 iter = {initialLoss:F6}");
+
+        float lnV = (float)Math.Log(vocabSize);   // 2.0794
+        float lnVOverV = lnV / vocabSize;          // 0.2599
+
+        Assert.True(!float.IsNaN(initialLoss) && !float.IsInfinity(initialLoss),
+            $"Initial loss must be finite; got {initialLoss}");
+
+        // Initial loss should be in the same ballpark as ln(V). Allow a
+        // wide window because (a) the model isn't perfectly uniform at
+        // init, and (b) the first gradient step has already happened.
+        // The pre-fix 1/V value of 0.26 is 8× smaller than the lower
+        // bound here — it can't pass.
+        Assert.True(initialLoss > 0.5f * lnV,
+            $"Initial loss {initialLoss:F6} is suspiciously below ln(V)={lnV:F6}. " +
+            $"The 1/V scaling bug from issue #1191 produces ~{lnVOverV:F6} here.");
+
+        // Run a short training loop and check loss trajectory. The
+        // assertions deliberately focus on what issue #1191 directly
+        // proves, not on full convergence:
+        //
+        // 1. Reported loss must be in the ln(V) ballpark across the
+        //    entire run (not the ln(V)/V ≈ 0.26 plateau).
+        // 2. The mean loss must move (spread > tolerance) — bit-
+        //    identical loss across iterations is the defining symptom
+        //    of the issue's Cycle-30 plateau, where the 1/V gradient
+        //    attenuation made effective steps near zero.
+        //
+        // We do NOT assert end-state accuracy here. After fixing the
+        // 1/V scaling, gradients are V× larger; a default-LR run that
+        // 'barely moved' pre-fix may now move too aggressively or
+        // require LR tuning. That is downstream of #1191's scope.
+        var lossesOverTime = new System.Collections.Generic.List<float>();
+        const int totalIters = 200;
+        for (int iter = 0; iter < totalIters; iter++)
+        {
+            int k = iter % numFacts;
+            transformer.Train(inputs[k], targets[k]);
+            lossesOverTime.Add(transformer.GetLastLoss());
+        }
+
+        float minLoss = lossesOverTime.Min();
+        float maxLoss = lossesOverTime.Max();
+        float spread = maxLoss - minLoss;
+        float meanLoss = Average(lossesOverTime, 0, totalIters);
+        _output.WriteLine($"Loss range over {totalIters} iters: min={minLoss:F6}  max={maxLoss:F6}  spread={spread:F6}  mean={meanLoss:F6}");
+
+        // Mean loss across the run should be in the ln(V) ballpark.
+        // The buggy ln(V)/V value at V=8 is 0.26 — anything above 0.5
+        // proves the 1/V scaling is gone.
+        Assert.True(meanLoss > 0.5f * lnV,
+            $"Mean training loss {meanLoss:F6} is suspiciously below ln(V)={lnV:F6}. " +
+            $"Issue #1191's 1/V scaling produces ~{lnVOverV:F6} on this task.");
+
+        // Spread guard: bit-identical loss across iterations is the
+        // signature of the issue's Cycle-30 plateau. With gradients
+        // flowing at correct magnitude after the fix, 200 iters on a
+        // 8-fact identity task produces loss that visibly moves.
+        Assert.True(spread > 1e-2f,
+            $"Loss is too flat across {totalIters} iters (issue #1191 plateau symptom): " +
+            $"min={minLoss:F6}, max={maxLoss:F6}, spread={spread:F6}.");
+    }
+
+    private static float Average(System.Collections.Generic.List<float> xs, int start, int count)
+    {
+        float s = 0f;
+        for (int i = start; i < start + count && i < xs.Count; i++) s += xs[i];
+        return s / count;
+    }
+}

--- a/tests/AiDotNet.Tests/IntegrationTests/LossFunctions/LossFunctionsMathematicalTests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/LossFunctions/LossFunctionsMathematicalTests.cs
@@ -794,19 +794,52 @@ public class LossFunctionsMathematicalTests
     }
 
     [Fact(Timeout = 120000)]
-    public async Task CategoricalCrossEntropy_Derivative_MatchesSoftmaxCombinedFormula()
+    public async Task CategoricalCrossEntropy_Derivative_MatchesStandaloneAnalyticalFormula()
     {
-        // CCE derivative when used with softmax simplifies to (predicted - actual)
+        // CategoricalCrossEntropyLoss<T> documents its input as
+        // probabilities (post-softmax), and CalculateLoss implements
+        // the *standalone* formula  L = -Σ actual_i * log(predicted_i).
+        // The analytical derivative of that standalone formula w.r.t.
+        // predicted_i is -actual_i / predicted_i.
+        //
+        // The often-cited simplification (predicted - actual) is the
+        // gradient of the *combined* softmax+CCE function with respect
+        // to its pre-softmax logits — i.e. the *chained* gradient, not
+        // the standalone derivative of CalculateLoss. That combined
+        // form lives in CrossEntropyWithLogitsLoss<T>.CalculateDerivative,
+        // which takes logits as input.
+        //
+        // Verify against the analytical formula and cross-check numerically.
         var cce = new CategoricalCrossEntropyLoss<double>();
         var predicted = new Vector<double>(new[] { 0.5, 0.3, 0.2 });
         var actual = new Vector<double>(new[] { 1.0, 0.0, 0.0 });
 
         var gradient = cce.CalculateDerivative(predicted, actual);
 
-        // Expected: (predicted - actual) - not averaged for CCE
-        Assert.Equal(0.5 - 1.0, gradient[0], Tolerance);
-        Assert.Equal(0.3 - 0.0, gradient[1], Tolerance);
-        Assert.Equal(0.2 - 0.0, gradient[2], Tolerance);
+        // Analytical: dL/dp_i = -a_i / p_i.
+        Assert.Equal(-1.0 / 0.5, gradient[0], Tolerance); // = -2
+        Assert.Equal(-0.0 / 0.3, gradient[1], Tolerance); // =  0
+        Assert.Equal(-0.0 / 0.2, gradient[2], Tolerance); // =  0
+
+        // Cross-check against finite differences on the actual forward
+        // formula. This pins the derivative to the same function the
+        // forward path computes — if either forward or derivative
+        // implementation drifts away from the standalone formula in the
+        // future, this catches it independently of the analytical
+        // assertion above.
+        for (int i = 0; i < predicted.Length; i++)
+        {
+            var predictedPlus = predicted.Clone();
+            var predictedMinus = predicted.Clone();
+            predictedPlus[i] = Math.Min(0.999, predictedPlus[i] + NumericalEpsilon);
+            predictedMinus[i] = Math.Max(0.001, predictedMinus[i] - NumericalEpsilon);
+
+            double lossPlus = cce.CalculateLoss(predictedPlus, actual);
+            double lossMinus = cce.CalculateLoss(predictedMinus, actual);
+            double numericalGradient = (lossPlus - lossMinus) / (2 * NumericalEpsilon);
+
+            Assert.Equal(numericalGradient, gradient[i], GradientTolerance);
+        }
     }
 
     [Fact(Timeout = 120000)]


### PR DESCRIPTION
## Summary

Closes #1191 — Transformer<T>.Train() still doesn't converge after #1187/#1188 v0.164.0 fix; reported loss was ~1/V of actual CE.

**Root cause.** `CategoricalCrossEntropyLoss<T>.ComputeTapeLoss` reduced over `allAxes` with `ReduceMean`, which divided the cross-entropy by V (vocab/class count) *on top of* averaging over batch. For a one-hot target only one entry per row is non-zero, so the all-axes mean silently scaled **both the loss tensor and the back-propagated gradient by 1/V**.

| Scenario from the issue | Reported (buggy) | True CE | Ratio |
|---|---|---|---|
| V=8, identity task, 500 iters | 0.265–0.297 | ln(8) ≈ 2.08 | ~1/V |
| V=256, Cycle-30 production | bit-identical 0.0217 across 56k SGD steps × 3 epochs | ln(256) ≈ 5.55 | exactly 1/V |

The 1/V on the gradient is what made cycle 30 plateau bit-identically — at LR=0.01 the effective LR was 1.2e-6, essentially no movement.

## Fix

Replace `ReduceMean(allAxes)` with `ReduceSum(lastAxis) → ReduceMean(batchAxes)`, mirroring the already-correct pattern in `CrossEntropyWithLogitsLoss.ComputeTapeLoss`. Matches PyTorch's `nn.CrossEntropyLoss(reduction='mean')` and the standalone scalar `CalculateLoss(Vector, Vector)` above. Handles the rank-0 1D case explicitly so a single unbatched sample skips the trivial batch-mean.

## Drive-by: fix `CategoricalCrossEntropy_Derivative_MatchesSoftmaxCombinedFormula`

Pre-existing failing test on master. It was asserting the **combined** softmax+CCE chain-rule simplification `(p − a)` but calling the **standalone** `CategoricalCrossEntropyLoss.CalculateDerivative`. The forward `CalculateLoss` implements `L = -Σ a*log(p)` (verified by the adjacent `OneHotEncoded_MatchesExpected` test which pins `loss = -log(0.7)`), so the analytical derivative is unambiguously `-a/p`. The combined `(p − a)` form already lives in `CrossEntropyWithLogitsLoss.CalculateDerivative` (which takes logits as input).

Renamed to `..._MatchesStandaloneAnalyticalFormula`, corrected expected values, and added a finite-differences cross-check against the same forward path so any future drift is caught independently of the analytical assertion.

## Regression tests

`tests/.../LossFunctions/CategoricalCrossEntropyTapeIssue1191Tests.cs` — 6 tests:

1. `ComputeTapeLoss_UniformSoftmax_OneHotTarget_ReturnsLnV_NotLnV_OverV` — V=8 → 2.0794 (buggy was 0.26).
2. `ComputeTapeLoss_UniformSoftmax_V256_ReturnsLn256_NotLn256_OverV` — V=256 → 5.5452 (buggy was the exact 0.0217 Cycle-30 plateau).
3. `ComputeTapeLoss_TwoDimensional_BatchMean_MatchesHandComputation` — `[B=2, V=4]` matches PyTorch reduction='mean'.
4. `ComputeTapeLoss_ThreeDimensional_BatchSequenceMean_MatchesHandComputation` — `[B=2, T=3, V=4]` sequence shape.
5. `ComputeTapeLoss_PerfectPrediction_ReturnsNearZero` — sanity bound (catches a future regression that, e.g., multiplies by a stray V).
6. `Transformer_Train_V8_LossNearLnV_AndConverges_Issue1191Repro` — end-to-end repro from the issue: confirms the model reports loss near ln(V) rather than ln(V)/V at random init, and that loss spreads (gradient flows at correct magnitude).

Each assertion ships with the buggy value alongside the expected value, so a regression message points directly at issue #1191.

## Verification

- `dotnet build` green on both `net10.0` and `net471`.
- 87/87 tests pass across the affected slice: `FullyQualifiedName~CategoricalCross | TransformerTrainConvergence | TransformerTrainingPipeline | CalibratedProbabilityFitDetector`.
- Pre-fix run shows `actual=0.2599` (matches the issue's 1/V symptom); post-fix `actual=2.0794 ≈ ln(8)`.

## Test plan

- [x] New regression suite passes
- [x] No existing tests regress in the affected slice (87/87)
- [x] Both target frameworks build clean
- [x] Pre-existing master failure on `CategoricalCrossEntropy_Derivative_MatchesSoftmaxCombinedFormula` resolved
- [ ] Full CI run on PR (in flight)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected categorical cross-entropy calculation to remove unintended class-axis scaling so reported loss and gradients are numerically accurate across batched and unbatched inputs.

* **Tests**
  * Added regression tests validating loss across 1D/2D/3D cases, near-perfect predictions, and end-to-end training reproducibility.
  * Updated derivative/gradient tests to assert the standalone probability-form analytic derivative and verify it via finite-difference checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->