### PR TITLE
test(audioldm): align test latent channels with paper (4 -> 8) — partial #1136

### DIFF
--- a/tests/AiDotNet.Tests/ModelFamilyTests/Diffusion/AudioLDMModelTests.cs
+++ b/tests/AiDotNet.Tests/ModelFamilyTests/Diffusion/AudioLDMModelTests.cs
@@ -15,13 +15,15 @@ public class AudioLDMModelTests : DiffusionModelTestBase
     // caused LatentDiffusionModelBase.Generate to reshape the input to
     // [1, 8, ...] before handing it to a UNet expecting 4, throwing
     // "Expected input depth 4, but got 8" during forward.
-    protected override int[] InputShape => [1, 8, 16, 16];
-    protected override int[] OutputShape => [1, 8, 16, 16];
+    private const int LatentChannels = AudioLDMModel<double>.AUDIOLDM_LATENT_CHANNELS;
+
+    protected override int[] InputShape => [1, LatentChannels, 16, 16];
+    protected override int[] OutputShape => [1, LatentChannels, 16, 16];
 
     protected override IDiffusionModel<double> CreateModel()
     {
         var unet = new UNetNoisePredictor<double>(
-            inputChannels: 8, outputChannels: 8,
+            inputChannels: LatentChannels, outputChannels: LatentChannels,
             baseChannels: 64, channelMultipliers: [1, 2, 4],
             numResBlocks: 1, attentionResolutions: [1, 2],
             contextDim: 0, numHeads: 4, inputHeight: 16, seed: 42);

--- a/tests/AiDotNet.Tests/ModelFamilyTests/Diffusion/AudioLDMModelTests.cs
+++ b/tests/AiDotNet.Tests/ModelFamilyTests/Diffusion/AudioLDMModelTests.cs
@@ -7,13 +7,21 @@ namespace AiDotNet.Tests.ModelFamilyTests.Diffusion;
 
 public class AudioLDMModelTests : DiffusionModelTestBase
 {
-    protected override int[] InputShape => [1, 4, 16, 16];
-    protected override int[] OutputShape => [1, 4, 16, 16];
+    // AudioLDM (Liu et al. 2023, Table 7) operates in an 8-channel latent
+    // space — DOUBLE the 4-channel latent that image diffusion (Stable
+    // Diffusion) uses, to capture audio's temporal complexity. The model's
+    // AUDIOLDM_LATENT_CHANNELS constant and LatentDiffusionModelBase.Generate
+    // both rely on this. Using 4 channels here was paper-incorrect and
+    // caused LatentDiffusionModelBase.Generate to reshape the input to
+    // [1, 8, ...] before handing it to a UNet expecting 4, throwing
+    // "Expected input depth 4, but got 8" during forward.
+    protected override int[] InputShape => [1, 8, 16, 16];
+    protected override int[] OutputShape => [1, 8, 16, 16];
 
     protected override IDiffusionModel<double> CreateModel()
     {
         var unet = new UNetNoisePredictor<double>(
-            inputChannels: 4, outputChannels: 4,
+            inputChannels: 8, outputChannels: 8,
             baseChannels: 64, channelMultipliers: [1, 2, 4],
             numResBlocks: 1, attentionResolutions: [1, 2],
             contextDim: 0, numHeads: 4, inputHeight: 16, seed: 42);


### PR DESCRIPTION
## Summary
- AudioLDMModelTests was using 4 latent channels (Stable Diffusion convention) but AudioLDM (Liu et al. 2023, Table 7) operates in **8 latent channels** for audio.
- The mismatch caused every Predict-driven test to throw `Expected input depth 4, but got 8` inside the UNet's first conv before reaching its assertion — 10/13 AudioLDM tests failed identically on master.
- Switch the test's UNet `inputChannels`/`outputChannels` to 8 and `InputShape`/`OutputShape` to `[1, 8, 16, 16]` to match the paper's latent dimensionality. Result: **10/13 pass (was 0/13)**.

The 3 remaining failures (`OutputShape_ShouldMatchInputShape`, `NoiseSchedule_ShouldBeMonotonic`, `Clone_ShouldProduceIdenticalOutput` timeout) are not channel-related — they affect other latent diffusion models too (verified: ARDiffusion's `OutputShape_ShouldMatchInputShape` also times out). Those are tracked under #1136 for separate investigation.

Partial fix for #1136 (AudioLDM cluster of Diffusion A-I shard).

## Test plan
- [x] Local: `dotnet test --filter "FullyQualifiedName~AudioLDMModelTests"` — 10/13 pass (was 0/13)
- [ ] CI Diffusion A-I shard transitions from 10 AudioLDM failures → 3

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed AudioLDM channel mismatch: tests and model configuration now use the model’s defined latent channel count (previously hardcoded), aligning shapes and UNet channels to prevent forwarding errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->