### PR TITLE
fix(supabase): unbreak deploy pipeline — drop prior validate_license_key overload

### DIFF
--- a/website/supabase/migrations/20260427000000_add_capabilities_to_validate_license.sql
+++ b/website/supabase/migrations/20260427000000_add_capabilities_to_validate_license.sql
@@ -40,6 +40,19 @@ comment on column public.license_activations.last_seen_package is
     '(e.g., "AiDotNet", "AiDotNet.Tensors"). NULL for clients on SDK versions that pre-date issue #1195. '
     'NOT used for authorisation — capability gating happens client-side.';
 
+-- Drop the prior 4-arg overload before redefining. `create or replace
+-- function` only matches an exact parameter signature; this migration
+-- adds a fifth parameter (`p_package`), which would otherwise create a
+-- second overload alongside the old one. Two overloads would (a) make
+-- subsequent `comment on function public.validate_license_key`
+-- ambiguous (SQLSTATE 42725 — "function name is not unique", which is
+-- exactly how this migration first failed in the deploy pipeline on
+-- 2026-04-28), and (b) cause runtime ambiguity on calls that match
+-- both signatures via defaults. Old callers that pass 2–4 arguments
+-- still resolve cleanly to the new 5-arg function via the
+-- `p_package default null` default, so this is backwards-compatible.
+drop function if exists public.validate_license_key(text, text, text, text);
+
 create or replace function public.validate_license_key(
     p_license_key text,
     p_machine_id_hash text,
@@ -172,5 +185,14 @@ begin
 end;
 $$;
 
-comment on function public.validate_license_key is
+-- DROP wipes the ACL grant from the prior migration
+-- (`20260314000002_license_activations.sql`). Re-apply the same
+-- service_role-only execution policy on the new 5-arg overload so
+-- the validation endpoint keeps working; anon callers stay denied.
+revoke execute on function public.validate_license_key(text, text, text, text, text) from anon;
+grant execute on function public.validate_license_key(text, text, text, text, text) to service_role;
+
+-- Explicit argument list disambiguates the COMMENT even if a future
+-- migration adds another overload before this one is dropped.
+comment on function public.validate_license_key(text, text, text, text, text) is
     'Validates a license key and registers/updates a machine activation. Returns JSON with valid, tier, capabilities, error fields. Capabilities array shape introduced for AiDotNet.Tensors capability-scoped enforcement (issue #1195).';


### PR DESCRIPTION
## Summary

Unblocks the **Deploy Marketing Website** workflow's `Apply Supabase Migrations` step, which has been failing on every master push since 2026-04-21 (visible across PRs #1183, #1196, etc.). The 2026-04-28 run on master failed with:

```
ERROR: function name "public.validate_license_key" is not unique (SQLSTATE 42725)
At statement: 3
comment on function public.validate_license_key is ...
```

## Root cause

The prior migration `20260314000002_license_activations.sql` defined `validate_license_key(text, text, text, text)`. The new migration `20260427000000_add_capabilities_to_validate_license.sql` (merged in #1196) added a fifth parameter `p_package`, but `create or replace function` only replaces a function with the **exact** same parameter signature — so instead of replacing the 4-arg version it created a **second overload** alongside it. The trailing `comment on function public.validate_license_key` then had two candidates and PostgreSQL rejected it as ambiguous.

## State of production

The migration is wrapped in a transaction by the Supabase CLI, so the COMMENT failure rolled back the entire migration. Production currently has:

- ❌ `last_seen_package` column NOT added
- ❌ New 5-arg `validate_license_key` overload NOT created
- ❌ Migration NOT recorded in `supabase_migrations.schema_migrations`

Editing the migration in place is therefore safe: the next deploy re-runs it from a clean baseline, in one transaction.

## Fix

1. `drop function if exists public.validate_license_key(text, text, text, text)` removes the 4-arg overload before the create-or-replace runs. The new 5-arg function with `p_package default null` is backwards-compatible — callers passing 2–4 arguments still resolve to it via the default.

2. `drop function` wipes the ACL grant from the prior migration, so re-apply `revoke execute … from anon` and `grant execute … to service_role` on the new 5-arg overload to keep the validation endpoint working.

3. `comment on function public.validate_license_key(text, text, text, text, text)` uses the explicit argument list — already unambiguous now that the old overload is gone, but forward-safe for future overloads.

## Test plan

- [x] Migration file syntactically valid (no schema-version drift)
- [x] Backwards-compatibility verified: 2-arg, 4-arg, 5-arg callers all resolve to the new function
- [ ] Deploy Marketing Website workflow runs green on this PR's preview
- [ ] Post-merge: master deploy applies the migration cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced license validation system with updated parameters and improved access control permissions to ensure proper security boundaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->