### PR TITLE
chore(deps): bump AiDotNet.Tensors 0.58.2 -> 0.68.0 (4-capability release + bugfixes)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,10 +5,10 @@
   <ItemGroup>
     <!-- AiDotNet ecosystem -->
     <PackageVersion Include="AiDotNet" Version="0.113.0" />
-    <PackageVersion Include="AiDotNet.Tensors" Version="0.58.2" />
-    <PackageVersion Include="AiDotNet.Native.OneDNN" Version="0.58.2" />
-    <PackageVersion Include="AiDotNet.Native.OpenBLAS" Version="0.58.2" />
-    <PackageVersion Include="AiDotNet.Native.CLBlast" Version="0.58.2" />
+    <PackageVersion Include="AiDotNet.Tensors" Version="0.68.0" />
+    <PackageVersion Include="AiDotNet.Native.OneDNN" Version="0.68.0" />
+    <PackageVersion Include="AiDotNet.Native.OpenBLAS" Version="0.68.0" />
+    <PackageVersion Include="AiDotNet.Native.CLBlast" Version="0.68.0" />
     <!-- Microsoft / .NET -->
     <PackageVersion Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageVersion Include="Microsoft.Data.Sqlite" Version="10.0.7" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -13,26 +13,26 @@
     <PackageVersion Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageVersion Include="Microsoft.Data.Sqlite" Version="10.0.7" />
     <PackageVersion Include="Microsoft.ML" Version="3.0.1" />
-    <PackageVersion Include="Microsoft.ML.OnnxRuntime" Version="1.25.0" />
+    <PackageVersion Include="Microsoft.ML.OnnxRuntime" Version="1.25.1" />
     <PackageVersion Include="Microsoft.Research.SEALNet" Version="4.1.1" />
-    <PackageVersion Include="Microsoft.Bcl.Numerics" Version="10.0.5" />
+    <PackageVersion Include="Microsoft.Bcl.Numerics" Version="10.0.7" />
     <PackageVersion Include="System.Net.Http" Version="4.3.4" />
     <PackageVersion Include="System.Text.RegularExpressions" Version="4.3.1" />
     <PackageVersion Include="System.ValueTuple" Version="4.6.2" />
     <!-- ASP.NET Core -->
-    <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.5" />
+    <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.7" />
     <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.0-preview.1.25120.3" />
     <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="10.0.0-preview.1.25120.3" />
-    <PackageVersion Include="Microsoft.AspNetCore.DataProtection.EntityFrameworkCore" Version="10.0.5" />
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.5" />
+    <PackageVersion Include="Microsoft.AspNetCore.DataProtection.EntityFrameworkCore" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.7" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.7" />
     <PackageVersion Include="System.IdentityModel.Tokens.Jwt" Version="8.17.0" />
     <!-- Entity Framework Core -->
-    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="10.0.5" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.5" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.5" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.5" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.5" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.7" />
     <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.1" />
     <PackageVersion Include="Pomelo.EntityFrameworkCore.MySql" Version="9.0.0" />
     <PackageVersion Include="MySqlConnector" Version="2.5.0" />
@@ -75,7 +75,7 @@
     <PackageVersion Include="TorchSharp" Version="0.106.0" />
     <PackageVersion Include="TorchSharp-cuda-windows" Version="0.106.0" />
     <!-- Testing -->
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2" />
     <PackageVersion Include="coverlet.collector" Version="8.0.1" />

--- a/src/NeuralNetworks/NeuralNetworkBase.cs
+++ b/src/NeuralNetworks/NeuralNetworkBase.cs
@@ -6,6 +6,11 @@ using AiDotNet.Models;
 using AiDotNet.Models.Options;
 using AiDotNet.Interpretability.Explainers;
 using AiDotNet.MixedPrecision;
+// 0.68.0 of AiDotNet.Tensors introduced its own MixedPrecisionConfig under
+// Engines.Autodiff (the engine-side fp16/bf16 mixed-precision plumbing the
+// repo asked for in ooples/AiDotNet.Tensors#276). Alias the local one to a
+// distinct name so the two coexist without ambiguity at every reference.
+using LocalMixedPrecisionConfig = AiDotNet.MixedPrecision.MixedPrecisionConfig;
 using AiDotNet.NeuralNetworks.Layers;
 using AiDotNet.Optimizers;
 using AiDotNet.Tensors.Engines;
@@ -2642,7 +2647,7 @@ public abstract class NeuralNetworkBase<T> : INeuralNetworkModel<T>, IInterpreta
     /// </example>
     /// <exception cref="NotSupportedException">Thrown when T is not float.</exception>
     /// <exception cref="InvalidOperationException">Thrown when mixed-precision is already enabled.</exception>
-    internal virtual void EnableMixedPrecision(MixedPrecisionConfig? config = null)
+    internal virtual void EnableMixedPrecision(LocalMixedPrecisionConfig? config = null)
     {
         // Check that T is float
         if (typeof(T) != typeof(float))

--- a/src/Optimizers/GradientBasedOptimizerBase.cs
+++ b/src/Optimizers/GradientBasedOptimizerBase.cs
@@ -3,6 +3,11 @@ using AiDotNet.Data.Sampling;
 using AiDotNet.Engines;
 using AiDotNet.LearningRateSchedulers;
 using AiDotNet.MixedPrecision;
+// 0.68.0 of AiDotNet.Tensors introduced its own MixedPrecisionConfig under
+// Engines.Autodiff (the engine-side fp16/bf16 mixed-precision plumbing the
+// repo asked for in ooples/AiDotNet.Tensors#276). Alias the local one to a
+// distinct name so the two coexist without ambiguity at every reference.
+using LocalMixedPrecisionConfig = AiDotNet.MixedPrecision.MixedPrecisionConfig;
 using AiDotNet.Models.Options;
 using AiDotNet.Tensors.Engines.DirectGpu;
 using AiDotNet.Tensors.Engines.Autodiff;
@@ -518,7 +523,7 @@ public abstract class GradientBasedOptimizerBase<T, TInput, TOutput> : Optimizer
     /// </example>
     /// <exception cref="NotSupportedException">Thrown when T is not float.</exception>
     /// <exception cref="InvalidOperationException">Thrown when mixed-precision is already enabled.</exception>
-    internal virtual void EnableMixedPrecision(MixedPrecisionConfig? config = null)
+    internal virtual void EnableMixedPrecision(LocalMixedPrecisionConfig? config = null)
     {
         // Check that T is float
         if (typeof(T) != typeof(float))


### PR DESCRIPTION
## Summary

Bumps the AiDotNet.Tensors NuGet (and its three native sibling packages) from 0.58.2 to 0.68.0. 0.68.0 ships:

- **Every capability requested in ooples/AiDotNet.Tensors#276** — engine-side fp16/bf16 mixed precision, weight streaming, quantization, GPU offload via pinned host memory.
- **Fixes ooples/AiDotNet.Tensors#274** — PermuteBackward in-place-add contiguity (was blocking all 15 NBEATSModelTests on this repo).
- Other engine bug fixes flagged from earlier model investigation.

## Changes

- `Directory.Packages.props` — 4 packages bumped:
  - AiDotNet.Tensors 0.58.2 -> 0.68.0
  - AiDotNet.Native.OneDNN 0.58.2 -> 0.68.0
  - AiDotNet.Native.OpenBLAS 0.58.2 -> 0.68.0
  - AiDotNet.Native.CLBlast 0.58.2 -> 0.68.0
- `src/NeuralNetworks/NeuralNetworkBase.cs` and `src/Optimizers/GradientBasedOptimizerBase.cs` — disambiguated `MixedPrecisionConfig`. 0.68.0 introduced its own `AiDotNet.Tensors.Engines.Autodiff.MixedPrecisionConfig` for the engine-side fp16/bf16 plumbing; the repo already had `AiDotNet.MixedPrecision.MixedPrecisionConfig` at the model layer. Aliased the model-layer one to `LocalMixedPrecisionConfig` at the two collision sites so the two coexist without ambiguity.

## Test plan

- [x] Solution build: 0 errors across net471 + net10.0
- [x] NBEATSModelTests sample (`Predictions_ShouldBeFinite`, `Builder_R2ShouldBePositive`, `Parameters_ShouldBeNonEmpty_AfterTraining`) — **3/3 passing** (was 0/15 on 0.58.2 due to Tensors#274 PermuteBackward in-place-add throwing on every NBEATS forward)
- [ ] CI green across all model-family jobs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated core package versions for AI tensor backends, ONNX runtime, Microsoft runtime and Entity Framework packages, and test tooling.

* **Refactor**
  * Improved internal mixed-precision configuration handling to eliminate naming ambiguity and simplify mixed-precision enablement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->