### PR TITLE
refactor(conditioner): TripleTextConditioner uses CompositeConditioningBase for engine access

### DIFF
--- a/src/Diffusion/Conditioning/CompositeConditioningBase.cs
+++ b/src/Diffusion/Conditioning/CompositeConditioningBase.cs
@@ -1,0 +1,80 @@
+using AiDotNet.Engines;
+using AiDotNet.Helpers;
+using AiDotNet.Interfaces;
+
+namespace AiDotNet.Diffusion.Conditioning;
+
+/// <summary>
+/// Base class for conditioning modules that compose other conditioners rather than
+/// owning their own learnable weights. Examples: <see cref="DualTextConditioner{T}"/>
+/// and <see cref="TripleTextConditioner{T}"/>, which delegate encoding work to one or
+/// more inner CLIP / T5 / OpenCLIP encoders and then merge their outputs.
+/// </summary>
+/// <typeparam name="T">The numeric type used for calculations.</typeparam>
+/// <remarks>
+/// <para>
+/// This base intentionally does not allocate token / position / transformer weights
+/// (unlike <see cref="TextConditioningBase{T}"/>, whose constructor sizes weight
+/// vectors against a single transformer). Composite conditioners hold their inner
+/// conditioners as fields and forward calls to them, so all that is shared between
+/// composites is the boilerplate every conditioner needs:
+/// </para>
+/// <list type="bullet">
+///   <item>The hardware-accelerated <see cref="IEngine"/> instance accessor used for
+///   tensor merging operations like concat / add / matmul on the merged outputs.</item>
+///   <item>The <see cref="INumericOperations{T}"/> dispatcher for type-generic
+///   arithmetic.</item>
+/// </list>
+/// <para>
+/// The <see cref="Engine"/> property is exposed as a protected instance member to
+/// match the convention used by the rest of AiDotNet's base classes (see
+/// <c>NeuralNetworkBase</c>, <c>AdversarialAttackBase</c>, <c>AugmentationBase</c>,
+/// etc.). Subclasses MUST route all engine-dispatched tensor operations through this
+/// property rather than calling <c>AiDotNetEngine.Current</c> directly, so that
+/// future per-instance engine overrides remain a single-point change.
+/// </para>
+/// </remarks>
+public abstract class CompositeConditioningBase<T> : IConditioningModule<T>
+{
+    /// <summary>
+    /// Provides numeric operations for the specific type T.
+    /// </summary>
+    protected static readonly INumericOperations<T> NumOps = MathHelper.GetNumericOperations<T>();
+
+    /// <summary>
+    /// Hardware-accelerated engine for vector/tensor operations. Subclasses MUST
+    /// route all engine dispatched operations through this property rather than
+    /// calling <c>AiDotNetEngine.Current</c> directly.
+    /// </summary>
+    protected IEngine Engine => AiDotNetEngine.Current;
+
+    /// <inheritdoc />
+    public abstract int EmbeddingDimension { get; }
+
+    /// <inheritdoc />
+    public abstract ConditioningType ConditioningType { get; }
+
+    /// <inheritdoc />
+    public abstract bool ProducesPooledOutput { get; }
+
+    /// <inheritdoc />
+    public abstract int MaxSequenceLength { get; }
+
+    /// <inheritdoc />
+    public abstract Tensor<T> Encode(Tensor<T> input);
+
+    /// <inheritdoc />
+    public abstract Tensor<T> EncodeText(Tensor<T> tokenIds, Tensor<T>? attentionMask = null);
+
+    /// <inheritdoc />
+    public abstract Tensor<T> GetPooledEmbedding(Tensor<T> sequenceEmbeddings);
+
+    /// <inheritdoc />
+    public abstract Tensor<T> GetUnconditionalEmbedding(int batchSize);
+
+    /// <inheritdoc />
+    public abstract Tensor<T> Tokenize(string text);
+
+    /// <inheritdoc />
+    public abstract Tensor<T> TokenizeBatch(string[] texts);
+}

--- a/src/Diffusion/Conditioning/TripleTextConditioner.cs
+++ b/src/Diffusion/Conditioning/TripleTextConditioner.cs
@@ -1,4 +1,3 @@
-using AiDotNet.Engines;
 using AiDotNet.Interfaces;
 using AiDotNet.Models;
 using AiDotNet.Attributes;
@@ -41,10 +40,8 @@ namespace AiDotNet.Diffusion.Conditioning;
 /// </remarks>
 [ComponentType(ComponentType.Encoder)]
 [PipelineStage(PipelineStage.Preprocessing)]
-public class TripleTextConditioner<T> : IConditioningModule<T>
+public class TripleTextConditioner<T> : CompositeConditioningBase<T>
 {
-    private static readonly INumericOperations<T> NumOps = MathHelper.GetNumericOperations<T>();
-
     /// <summary>
     /// The first CLIP text encoder (ViT-L/14, 768-dim).
     /// </summary>
@@ -63,20 +60,20 @@ public class TripleTextConditioner<T> : IConditioningModule<T>
     /// <summary>
     /// Gets the T5 context dimension for cross-attention (4096 for T5-XXL).
     /// </summary>
-    public int EmbeddingDimension => _t5Encoder.EmbeddingDimension;
+    public override int EmbeddingDimension => _t5Encoder.EmbeddingDimension;
 
     /// <inheritdoc />
-    public ConditioningType ConditioningType => ConditioningType.MultiModal;
+    public override ConditioningType ConditioningType => ConditioningType.MultiModal;
 
     /// <summary>
     /// Gets whether this module produces pooled output (yes, from both CLIP encoders).
     /// </summary>
-    public bool ProducesPooledOutput => true;
+    public override bool ProducesPooledOutput => true;
 
     /// <summary>
     /// Gets the maximum sequence length (uses T5's longer sequence length).
     /// </summary>
-    public int MaxSequenceLength => _t5Encoder.MaxSequenceLength;
+    public override int MaxSequenceLength => _t5Encoder.MaxSequenceLength;
 
     /// <summary>
     /// Gets the first CLIP encoder's embedding dimension (768 for ViT-L/14).
@@ -131,14 +128,14 @@ public class TripleTextConditioner<T> : IConditioningModule<T>
     }
 
     /// <inheritdoc />
-    public Tensor<T> Encode(Tensor<T> input)
+    public override Tensor<T> Encode(Tensor<T> input)
     {
         // Default: use T5 for cross-attention embeddings
         return _t5Encoder.Encode(input);
     }
 
     /// <inheritdoc />
-    public Tensor<T> EncodeText(Tensor<T> tokenIds, Tensor<T>? attentionMask = null)
+    public override Tensor<T> EncodeText(Tensor<T> tokenIds, Tensor<T>? attentionMask = null)
     {
         // Use T5 for the primary cross-attention embeddings
         return _t5Encoder.EncodeText(tokenIds, attentionMask);
@@ -185,7 +182,7 @@ public class TripleTextConditioner<T> : IConditioningModule<T>
     }
 
     /// <inheritdoc />
-    public Tensor<T> GetPooledEmbedding(Tensor<T> sequenceEmbeddings)
+    public override Tensor<T> GetPooledEmbedding(Tensor<T> sequenceEmbeddings)
     {
         // For the standard interface, get pooled from the first CLIP encoder
         // For the full combined pooled, use EncodeTriple() instead
@@ -212,7 +209,7 @@ public class TripleTextConditioner<T> : IConditioningModule<T>
     }
 
     /// <inheritdoc />
-    public Tensor<T> GetUnconditionalEmbedding(int batchSize)
+    public override Tensor<T> GetUnconditionalEmbedding(int batchSize)
     {
         // Use T5 unconditional for cross-attention
         return _t5Encoder.GetUnconditionalEmbedding(batchSize);
@@ -244,14 +241,14 @@ public class TripleTextConditioner<T> : IConditioningModule<T>
     }
 
     /// <inheritdoc />
-    public Tensor<T> Tokenize(string text)
+    public override Tensor<T> Tokenize(string text)
     {
         // Default to T5 tokenization (longer sequences)
         return _t5Encoder.Tokenize(text);
     }
 
     /// <inheritdoc />
-    public Tensor<T> TokenizeBatch(string[] texts)
+    public override Tensor<T> TokenizeBatch(string[] texts)
     {
         return _t5Encoder.TokenizeBatch(texts);
     }
@@ -264,10 +261,11 @@ public class TripleTextConditioner<T> : IConditioningModule<T>
     /// <returns>Combined pooled embedding [batchSize, 2048].</returns>
     private Tensor<T> ConcatenatePooledEmbeddings(Tensor<T> clipLPooled, Tensor<T> clipGPooled)
     {
-        // Pooled tensors arrive as [batchSize, embedDim]; the upstream Tensor
-        // implementation rejects negative axis values, so resolve to the explicit
-        // last-dim index here rather than passing axis=-1.
-        int axis = clipLPooled._shape.Length - 1;
-        return AiDotNetEngine.Current.TensorConcatenate<T>(new[] { clipLPooled, clipGPooled }, axis: axis);
+        // SD3 paper: concat CLIP-L and CLIP-G pooled embeddings along the feature axis
+        // (last axis), regardless of input rank. We dispatch through the protected
+        // base-class Engine accessor (CompositeConditioningBase.Engine) so that
+        // future per-instance engine overrides become a single-point change.
+        int axis = clipLPooled.Rank - 1;
+        return Engine.TensorConcatenate<T>(new[] { clipLPooled, clipGPooled }, axis: axis);
     }
 }


### PR DESCRIPTION
## Summary

- Adds a small `CompositeConditioningBase<T>` for conditioning modules that compose other conditioners (no own learnable weights), exposing the protected `IEngine Engine` accessor that matches the convention used by every other base class in the codebase (see `NeuralNetworkBase`, `AdversarialAttackBase`, `AugmentationBase`, etc.)
- Migrates `TripleTextConditioner<T>` to extend `CompositeConditioningBase<T>` so it routes its `TensorConcatenate` call through the inherited protected `Engine` property instead of calling `AiDotNetEngine.Current` directly.

## Why

`TripleTextConditioner` was implementing `IConditioningModule<T>` directly and calling `AiDotNetEngine.Current.TensorConcatenate(...)`. That violates the project's "engine instance comes from the base class" convention — future per-instance engine overrides would have to chase every direct `AiDotNetEngine.Current` site instead of one base-class override point.

`TextConditioningBase<T>` already exists, but it's a leaf-encoder base whose constructor allocates token / position / transformer weight vectors against a single transformer config — that doesn't fit a composite that delegates to three inner conditioners. Hence the new `CompositeConditioningBase<T>`.

## Related upstream issue

Filed [ooples/AiDotNet.Tensors#291](https://github.com/ooples/AiDotNet.Tensors/issues/291) for the underlying concurrency bug surfaced by this code path: `engine.TensorConcatenate(rank-2 tensors, axis=Rank-1)` intermittently throws `Invalid axis. Must be between 0 and 1.` when xunit runs many test classes in parallel in the same test host. The same call passes in isolation and in standalone multi-threaded probes, so the trigger is shared engine state across sibling test classes — fix belongs upstream in AiDotNet.Tensors.

This PR does NOT add a workaround in AiDotNet for the upstream bug — every workaround we considered either ducked under the engine API entirely (manual row-copy, breaks rank-agnostic contract) or papered over the symptom. The refactor here is purely the architectural cleanup that the maintainer flagged independently while we were investigating.

## Test plan

- [x] Build clean: `dotnet build src/AiDotNet.csproj --framework net10.0 -c Release` (0 errors)
- [x] Build clean: `dotnet build tests/AiDotNet.Tests/AiDotNetTests.csproj --framework net10.0 -c Release` (0 errors)
- [ ] Unit-03 Diffusion/Encoding test job to confirm the refactor compiles and runs the same as before. (The intermittent upstream failure is independent of this PR — it'll continue surfacing until #291 lands.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured conditioning module architecture by introducing a shared base class for conditioning implementations. Existing text conditioning functionality remains unchanged and operates as before.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->