### PR TITLE
fix(#1221): Transformer.Predict bypassed eval-mode wrapper, Dropout fired at inference

### DIFF
--- a/src/NeuralNetworks/Transformer.cs
+++ b/src/NeuralNetworks/Transformer.cs
@@ -474,18 +474,18 @@ public class Transformer<T> : NeuralNetworkBase<T>, IAuxiliaryLossLayer<T>
     /// </remarks>
     /// <inheritdoc />
     /// <remarks>
-    /// Transformer's eager forward routes the special-case encoder/decoder
-    /// cross-attention pattern (DecoderLayer needs the encoder's output as
-    /// a second input; AttentionLayer needs the attention mask as a second
-    /// input). The wrapping <see cref="NeuralNetworkBase{T}.Predict"/>
-    /// handles training-mode toggle, no-grad scope, batch-dim promotion,
-    /// and output squeeze — issue #1221 was caused by overriding
-    /// <see cref="NeuralNetworkBase{T}.Predict"/> directly and losing all
-    /// of those wrappers, in particular the <c>SetTrainingMode(false)</c>
-    /// that disables Dropout. Without it, every Predict call randomly
-    /// zero-masked features, eventually pushing the trained output Dense
-    /// into a degenerate steady state where eval-time logits collapse to
-    /// uniform-over-V (NLL = ln(|V|) exactly, top-1 = 0% on byte-LM).
+    /// Transformer's eager forward routes the encoder/decoder
+    /// cross-attention pattern: <see cref="DecoderLayer{T}"/> takes the
+    /// encoder's output as a second input, <see cref="AttentionLayer{T}"/>
+    /// takes the attention mask as a second input, and other layers are
+    /// invoked through the standard single-input
+    /// <see cref="ILayer{T}.Forward(Tensor{T})"/>. The encoder output is
+    /// captured at the last <see cref="MultiHeadAttentionLayer{T}"/>
+    /// before any decoder layer in the chain. The public
+    /// <see cref="NeuralNetworkBase{T}.Predict"/> wrapper handles
+    /// training-mode toggle, no-grad scope, batch-dim promotion, and
+    /// output squeeze — see that method's remarks for the inference-
+    /// scaffolding contract (issue #1221).
     /// </remarks>
     protected override Tensor<T> PredictEager(Tensor<T> input)
     {

--- a/src/NeuralNetworks/Transformer.cs
+++ b/src/NeuralNetworks/Transformer.cs
@@ -495,6 +495,7 @@ public class Transformer<T> : NeuralNetworkBase<T>, IAuxiliaryLossLayer<T>
 
         Tensor<T> output = input;
         Tensor<T>? encoderOutput = null;
+        bool seenDecoder = false;
         Tensor<T> mask = AttentionMask ?? Tensor<T>.CreateDefault(input._shape, NumOps.One); // Default to all ones if no mask is provided
 
         // Process all layers sequentially
@@ -503,6 +504,7 @@ public class Transformer<T> : NeuralNetworkBase<T>, IAuxiliaryLossLayer<T>
         {
             if (Layers[i] is DecoderLayer<T> decoderLayer)
             {
+                seenDecoder = true;
                 // Decoder layer with cross-attention needs encoder output
                 output = decoderLayer.Forward(output, encoderOutput ?? output, mask);
             }
@@ -515,11 +517,20 @@ public class Transformer<T> : NeuralNetworkBase<T>, IAuxiliaryLossLayer<T>
                 output = Layers[i].Forward(output);
             }
 
-            // Track encoder output for cross-attention in decoders
-            // The last attention layer before any decoder layer is the encoder output
-            if (Layers[i] is MultiHeadAttentionLayer<T> && encoderOutput is null)
+            // Track encoder output for cross-attention in decoders.
+            // The encoder output we want is the LAST MultiHeadAttention
+            // output before any DecoderLayer in the chain — for an
+            // encoder stack with multiple blocks, decoder cross-attention
+            // should consume the fully-encoded representation, not the
+            // first encoder block's output. Keep updating `encoderOutput`
+            // on every encoder-block attention until we hit the first
+            // decoder; after that, freeze it (subsequent decoder blocks
+            // share the same encoder context).
+            if (!seenDecoder && Layers[i] is MultiHeadAttentionLayer<T>)
             {
-                // Check if there are decoder layers ahead
+                // Only capture if there's a decoder downstream — otherwise
+                // there's no consumer for this state and we'd be retaining
+                // a tensor reference unnecessarily.
                 for (int j = i + 1; j < Layers.Count; j++)
                 {
                     if (Layers[j] is DecoderLayer<T>)

--- a/src/NeuralNetworks/Transformer.cs
+++ b/src/NeuralNetworks/Transformer.cs
@@ -472,7 +472,22 @@ public class Transformer<T> : NeuralNetworkBase<T>, IAuxiliaryLossLayer<T>
     /// This is used when you want to use a trained Transformer to process new data.
     /// </para>
     /// </remarks>
-    public override Tensor<T> Predict(Tensor<T> input)
+    /// <inheritdoc />
+    /// <remarks>
+    /// Transformer's eager forward routes the special-case encoder/decoder
+    /// cross-attention pattern (DecoderLayer needs the encoder's output as
+    /// a second input; AttentionLayer needs the attention mask as a second
+    /// input). The wrapping <see cref="NeuralNetworkBase{T}.Predict"/>
+    /// handles training-mode toggle, no-grad scope, batch-dim promotion,
+    /// and output squeeze — issue #1221 was caused by overriding
+    /// <see cref="NeuralNetworkBase{T}.Predict"/> directly and losing all
+    /// of those wrappers, in particular the <c>SetTrainingMode(false)</c>
+    /// that disables Dropout. Without it, every Predict call randomly
+    /// zero-masked features, eventually pushing the trained output Dense
+    /// into a degenerate steady state where eval-time logits collapse to
+    /// uniform-over-V (NLL = ln(|V|) exactly, top-1 = 0% on byte-LM).
+    /// </remarks>
+    protected override Tensor<T> PredictEager(Tensor<T> input)
     {
         // GPU-resident optimization: use TryForwardGpuOptimized for speedup
         if (TryForwardGpuOptimized(input, out var gpuResult))

--- a/tests/AiDotNet.Tests/IntegrationTests/NeuralNetworks/TransformerProductionScaleConvergenceIssue1221Tests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/NeuralNetworks/TransformerProductionScaleConvergenceIssue1221Tests.cs
@@ -363,4 +363,76 @@ public class TransformerProductionScaleConvergenceIssue1221Tests
             $"scale despite the V=8 case working) — the user-reported " +
             $"smoking gun for #1221.");
     }
+
+    /// <summary>
+    /// Force training mode ON before Predict and verify the Predict path
+    /// still produces deterministic, non-uniform output. This catches the
+    /// failure mode where <see cref="Transformer{T}.Predict"/> bypasses
+    /// the base's <c>SetTrainingMode(false)</c> wrapper — pre-fix the
+    /// override skipped it; post-fix the override is at <c>PredictEager</c>
+    /// so the base's wrapper applies.
+    ///
+    /// <para>
+    /// Why this catches the bug even when Train's <c>finally</c> already
+    /// flips eval mode off: this test EXPLICITLY restores training mode
+    /// AFTER Train and BEFORE Predict, simulating any caller that
+    /// re-enables training between train/eval (e.g., interleaved
+    /// train-then-monitor-loss loops). With the pre-fix Predict, Dropout
+    /// runs at training rate and outputs are stochastic; with the post-fix
+    /// override at PredictEager, the base's eval-mode toggle disables
+    /// Dropout regardless of caller state.
+    /// </para>
+    /// </summary>
+    [Fact(Timeout = 60000)]
+    public async Task Predict_WithExternalTrainingModeOn_StillDeterministic()
+    {
+        await Task.Yield();
+        const int vocab = 256;
+        const int seqLen = 32;
+        var model = BuildTransformer(
+            vocab: vocab, modelDim: 64, feedForwardDim: 256, seqLen: seqLen,
+            numEncoderLayers: 2, numHeads: 4, learningRate: 0.0003);
+
+        // Train so weights aren't zero-init.
+        model.SetTrainingMode(true);
+        for (int k = 0; k < 16; k++)
+        {
+            model.Train(
+                BuildIdentityInput(k, seqLen: seqLen),
+                BuildOneHotTarget(k, vocab: vocab));
+        }
+
+        // EXPLICITLY restore training mode after Train. Train's finally
+        // would have flipped it off; we're simulating the case where the
+        // caller wants training mode on (e.g., for an in-loop train-step
+        // followed by a Predict-based loss check). Predict must internally
+        // override this for stateful layers, otherwise Dropout fires at
+        // inference and outputs become stochastic.
+        model.SetTrainingMode(true);
+        Assert.True(model.IsTrainingMode);
+
+        // Two Predict calls on the same input. With Dropout properly
+        // disabled at inference (via the base Predict's SetTrainingMode
+        // wrapper), the two calls must be bit-identical. Pre-fix the
+        // Transformer.Predict override skipped the wrapper, leaving
+        // Dropout in training mode and producing stochastic outputs.
+        var input = BuildIdentityInput(0, seqLen: seqLen);
+        var pred1 = model.Predict(input);
+        var pred2 = model.Predict(input);
+
+        Assert.Equal(pred1.Length, pred2.Length);
+        double maxDelta = 0.0;
+        for (int i = 0; i < pred1.Length; i++)
+        {
+            double d = Math.Abs(pred1[i] - pred2[i]);
+            if (d > maxDelta) maxDelta = d;
+        }
+        _output.WriteLine($"Two Predict calls (training mode forced ON beforehand): max abs diff = {maxDelta:E3}");
+
+        Assert.True(maxDelta < 1e-6,
+            $"Two Predict calls on the same input produced different outputs " +
+            $"(max abs diff = {maxDelta:E3}, tolerance 1e-6). #1221 root " +
+            $"cause: Transformer.Predict bypassed the base's eval-mode " +
+            $"toggle, so Dropout ran with stochastic masks at inference.");
+    }
 }

--- a/tests/AiDotNet.Tests/IntegrationTests/NeuralNetworks/TransformerProductionScaleConvergenceIssue1221Tests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/NeuralNetworks/TransformerProductionScaleConvergenceIssue1221Tests.cs
@@ -420,6 +420,14 @@ public class TransformerProductionScaleConvergenceIssue1221Tests
         var pred1 = model.Predict(input);
         var pred2 = model.Predict(input);
 
+        // Predict must restore the caller's training-mode state after
+        // running. The base.Predict's try/finally toggles eval mode for
+        // the duration of the forward pass and restores the prior state
+        // on exit; this assertion locks in that save/restore contract.
+        Assert.True(model.IsTrainingMode,
+            "Predict should restore the caller's training-mode state after inference. " +
+            "If this fails, the wrapper's finally block isn't running.");
+
         Assert.Equal(pred1.Length, pred2.Length);
         double maxDelta = 0.0;
         for (int i = 0; i < pred1.Length; i++)
@@ -429,10 +437,20 @@ public class TransformerProductionScaleConvergenceIssue1221Tests
         }
         _output.WriteLine($"Two Predict calls (training mode forced ON beforehand): max abs diff = {maxDelta:E3}");
 
-        Assert.True(maxDelta < 1e-6,
+        // Tolerance: pre-fix the failure produces diffs in the ~1e-2 range
+        // (Dropout's stochastic mask reroll randomizes ~10% of features per
+        // call). 1e-3 is comfortably below that and well above any GPU
+        // floating-point nondeterminism (kernel scheduling, reduction-order
+        // variance). The previous 1e-6 was tighter than CPU/GPU
+        // float-rounding can guarantee across CI agents and would cause
+        // spurious failures on a deterministic-Dropout eval forward.
+        const double tolerance = 1e-3;
+        Assert.True(maxDelta < tolerance,
             $"Two Predict calls on the same input produced different outputs " +
-            $"(max abs diff = {maxDelta:E3}, tolerance 1e-6). #1221 root " +
-            $"cause: Transformer.Predict bypassed the base's eval-mode " +
-            $"toggle, so Dropout ran with stochastic masks at inference.");
+            $"(max abs diff = {maxDelta:E3}, tolerance {tolerance:E1}). #1221 " +
+            $"root cause: Transformer.Predict bypassed the base's eval-mode " +
+            $"toggle, so Dropout ran with stochastic masks at inference. " +
+            $"Pre-fix diff is ~1e-2 (one Dropout zero-out per ~10 hidden " +
+            $"units); post-fix Dropout is a no-op and the diff is float noise.");
     }
 }

--- a/tests/AiDotNet.Tests/IntegrationTests/NeuralNetworks/TransformerProductionScaleConvergenceIssue1221Tests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/NeuralNetworks/TransformerProductionScaleConvergenceIssue1221Tests.cs
@@ -66,7 +66,8 @@ public class TransformerProductionScaleConvergenceIssue1221Tests
         int seqLen,
         int numEncoderLayers,
         int numHeads,
-        double learningRate)
+        double learningRate,
+        double dropoutRate = 0.1)
     {
         var arch = new TransformerArchitecture<float>(
             inputType: InputType.TwoDimensional,
@@ -78,6 +79,7 @@ public class TransformerProductionScaleConvergenceIssue1221Tests
             feedForwardDimension: feedForwardDim,
             inputSize: seqLen,
             outputSize: vocab,
+            dropoutRate: dropoutRate,
             maxSequenceLength: seqLen,
             vocabularySize: vocab);
 
@@ -389,9 +391,29 @@ public class TransformerProductionScaleConvergenceIssue1221Tests
         await Task.Yield();
         const int vocab = 256;
         const int seqLen = 32;
+        // Pin an explicit non-zero dropout rate. The reviewer flagged that
+        // letting this default through TransformerArchitecture's framework
+        // default (currently 0.1) makes the test silently no-op if that
+        // default ever drops to 0.0. Pinning 0.2 here keeps Dropout's
+        // training-mode branch active regardless of framework defaults
+        // and gives the stochastic-mask divergence a clear signal.
+        const double dropoutRate = 0.2;
         var model = BuildTransformer(
             vocab: vocab, modelDim: 64, feedForwardDim: 256, seqLen: seqLen,
-            numEncoderLayers: 2, numHeads: 4, learningRate: 0.0003);
+            numEncoderLayers: 2, numHeads: 4, learningRate: 0.0003,
+            dropoutRate: dropoutRate);
+
+        // Confirm at least one DropoutLayer exists with a non-zero rate.
+        // Without this precondition, the rest of the test is a tautology:
+        // if Dropout is absent or disabled, two Predict calls would always
+        // be bit-identical even pre-fix and the regression would be useless.
+        bool hasActiveDropout = model.Layers
+            .OfType<DropoutLayer<float>>()
+            .Any(d => d.SupportsTraining);
+        Assert.True(hasActiveDropout,
+            "Test precondition: model must contain at least one DropoutLayer that " +
+            "supports training-mode behavior. Without an active Dropout, this test " +
+            "cannot detect #1221's symptom (Predict failing to disable Dropout).");
 
         // Train so weights aren't zero-init.
         model.SetTrainingMode(true);


### PR DESCRIPTION
Closes #1221.

## Summary

Root cause for #1221's "Transformer training completes but eval logits are uniform-over-V" reproducer: `Transformer<T>.Predict()` overrode `NeuralNetworkBase.Predict()` directly, bypassing the wrappers introduced in `6bf657c45`:
- `SetTrainingMode(false)` for the forward pass
- `NoGradScope` to suppress autograd
- `NormalizeInputBatchDim`
- Output squeeze on unbatched inputs

For a Phase A4 byte-LM config (V=256, d=64, L=2, ctx=32) the layer chain contains ~5 `DropoutLayer` instances. With training mode left on at inference (which happened any time a caller re-enabled training between train and eval), Dropout's stochastic mask reroll fired on every Predict call, pushing the trained output Dense into a configuration where eval logits collapse to uniform-over-V (NLL = ln(V), top-1 = 0%).

## Fix

Move the special-case layer routing (DecoderLayer cross-attention, AttentionLayer mask, MultiHeadAttention encoder-output tracking) from `Predict()` to `PredictEager()`. The base `Predict()` now wraps the override with its standard inference scaffolding — eval mode, no-grad, batch promote, output squeeze — and Dropout becomes a no-op at inference automatically.

## Test plan
- [x] New regression test `Predict_WithExternalTrainingModeOn_StillDeterministic` fails pre-fix with max abs diff = 9.84e-3 (Dropout firing), passes post-fix with diff < 1e-6
- [x] Existing #1221 tests (V=8/LR=0.001, V=256/d=64/L=2, embedding-gradient) still pass
- [x] Broader Transformer test set went 412 → 370 failures (42 tests recovered, no regressions). Remaining 370 are pre-existing #1224 cluster.
- [x] Build clean on net10.0 + net471

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prediction now preserves evaluation-mode semantics so Dropout and training-mode toggles behave consistently during inference, yielding stable outputs.
  * Improved encoder–decoder attention routing and attention-mask defaulting to preserve correct cross-attention behavior.

* **Tests**
  * Added an integration regression test that verifies deterministic predictions when the model is left in training mode and confirms training-mode is preserved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->