### PR TITLE
feat(#1213): RBMLayer lazy ctor — first composite-layer reference impl

### DIFF
--- a/src/NeuralNetworks/Layers/ConditionalRandomFieldLayer.cs
+++ b/src/NeuralNetworks/Layers/ConditionalRandomFieldLayer.cs
@@ -600,6 +600,31 @@ public partial class ConditionalRandomFieldLayer<T> : LayerBase<T>
         if (!IsShapeResolved) OnFirstForward(input);
         EnsureInitialized();
 
+        // Validate input shape on every call, not just the first.
+        // OnFirstForward only fires once; later inputs with different
+        // sequence-length or class-count would otherwise reach the
+        // Viterbi loops below and silently truncate or index out of
+        // range. Numbers-of-classes is architectural (fixed at
+        // construction), sequence-length is shape-dependent (varies
+        // between inputs), but both must match what the layer was
+        // constructed for.
+        int seenRank = input.Shape.Length;
+        if (seenRank < 2)
+            throw new ArgumentException(
+                $"ConditionalRandomFieldLayer requires rank>=2 input [seqLen, numClasses] " +
+                $"or [batch, seqLen, numClasses]; got rank {seenRank}.", nameof(input));
+        int seenClasses = input.Shape[seenRank - 1];
+        if (seenClasses != _numClasses)
+            throw new ArgumentException(
+                $"ConditionalRandomFieldLayer's numClasses mismatch: layer was constructed " +
+                $"with {_numClasses} classes, but input shape's last axis is {seenClasses}. " +
+                $"numClasses is architectural and cannot vary across inputs.", nameof(input));
+        int seenSeqLen = input.Shape[seenRank - 2];
+        if (seenSeqLen <= 0)
+            throw new ArgumentException(
+                $"ConditionalRandomFieldLayer's sequence length must be positive; got " +
+                $"{seenSeqLen} from input shape.", nameof(input));
+
         // Store original shape for any-rank tensor support
         _originalInputShape = input._shape;
         int rank = input.Shape.Length;

--- a/src/NeuralNetworks/Layers/ConditionalRandomFieldLayer.cs
+++ b/src/NeuralNetworks/Layers/ConditionalRandomFieldLayer.cs
@@ -67,7 +67,11 @@ public partial class ConditionalRandomFieldLayer<T> : LayerBase<T>
     private Tensor<T>? _endScoresGradient;
 
     private readonly int _numClasses;
-    private readonly int _sequenceLength;
+    // Non-readonly: lazy ctor leaves _sequenceLength = -1 until
+    // OnFirstForward resolves it from input.Shape[0]. Eager ctor sets
+    // it at construction.
+    private int _sequenceLength;
+    private bool _isInitialized;
 
     /// <summary>
     /// Gets a value indicating whether this layer supports training.
@@ -353,6 +357,38 @@ public partial class ConditionalRandomFieldLayer<T> : LayerBase<T>
         _endScores = new Tensor<T>([_numClasses]);
 
         InitializeParameters();
+        _isInitialized = true;
+    }
+
+    /// <summary>
+    /// Lazy constructor: resolves <c>sequenceLength</c> from
+    /// <c>input.Shape[0]</c> on first <see cref="Forward"/>.
+    /// <paramref name="numClasses"/> (label vocabulary size) is
+    /// architectural and stays required; only sequence length is
+    /// shape-dependent. Note: parameter tensors (transition matrix,
+    /// start/end scores) only depend on numClasses, not sequenceLength,
+    /// so they're allocated eagerly here; only the base layer's
+    /// InputShape / OutputShape are deferred.
+    /// </summary>
+    /// <param name="numClasses">Number of label classes (vocabulary size).</param>
+    /// <param name="scalarActivation">Optional scalar activation (defaults to identity).</param>
+    public ConditionalRandomFieldLayer(int numClasses, IActivationFunction<T>? scalarActivation = null)
+        : base([-1, numClasses], [-1, numClasses], scalarActivation ?? new IdentityActivation<T>())
+    {
+        if (numClasses <= 0)
+            throw new ArgumentOutOfRangeException(nameof(numClasses), "numClasses must be greater than 0.");
+
+        _numClasses = numClasses;
+        _sequenceLength = -1;
+        _transitionMatrix = new Tensor<T>([_numClasses, _numClasses]);
+        _startScores = new Tensor<T>([_numClasses]);
+        _endScores = new Tensor<T>([_numClasses]);
+
+        // Parameters do not depend on sequenceLength, so initialize
+        // eagerly. _isInitialized stays false so EnsureInitialized's
+        // sequenceLength validation runs once on first forward.
+        InitializeParameters();
+        _isInitialized = false;
     }
 
     /// <summary>
@@ -393,6 +429,77 @@ public partial class ConditionalRandomFieldLayer<T> : LayerBase<T>
         _endScores = new Tensor<T>([_numClasses]);
 
         InitializeParameters();
+        _isInitialized = true;
+    }
+
+    /// <summary>
+    /// Lazy constructor with vector activation — resolves
+    /// <c>sequenceLength</c> from <c>input.Shape[0]</c> on first
+    /// <see cref="Forward"/>. See the scalar-activation lazy ctor for
+    /// design notes on why parameters initialize eagerly.
+    /// </summary>
+    /// <param name="numClasses">Number of label classes (vocabulary size).</param>
+    /// <param name="vectorActivation">Optional vector activation (defaults to identity).</param>
+    public ConditionalRandomFieldLayer(int numClasses, IVectorActivationFunction<T>? vectorActivation)
+        : base([-1, numClasses], [-1, numClasses], vectorActivation ?? new IdentityActivation<T>())
+    {
+        if (numClasses <= 0)
+            throw new ArgumentOutOfRangeException(nameof(numClasses), "numClasses must be greater than 0.");
+
+        _numClasses = numClasses;
+        _sequenceLength = -1;
+        _transitionMatrix = new Tensor<T>([_numClasses, _numClasses]);
+        _startScores = new Tensor<T>([_numClasses]);
+        _endScores = new Tensor<T>([_numClasses]);
+
+        InitializeParameters();
+        _isInitialized = false;
+    }
+
+    /// <inheritdoc />
+    /// <remarks>
+    /// Reads the sequence length from <c>input.Shape[0]</c>. Per-batch
+    /// inputs come in as <c>[sequenceLength, numClasses]</c> in this
+    /// layer's contract.
+    /// </remarks>
+    protected override void OnFirstForward(Tensor<T> input)
+    {
+        int rank = input.Shape.Length;
+        if (rank < 2)
+            throw new ArgumentException(
+                $"ConditionalRandomFieldLayer requires rank>=2 input [seqLen, numClasses]; got rank {rank}.", nameof(input));
+
+        int sequenceLength = input.Shape[rank - 2];
+        if (sequenceLength <= 0)
+            throw new ArgumentException(
+                $"ConditionalRandomFieldLayer's sequence length must be positive; got {sequenceLength} from input shape.",
+                nameof(input));
+
+        int seenClasses = input.Shape[rank - 1];
+        if (seenClasses != _numClasses)
+            throw new ArgumentException(
+                $"ConditionalRandomFieldLayer's numClasses mismatch: layer was constructed with {_numClasses} classes, " +
+                $"but input shape's last axis is {seenClasses}.", nameof(input));
+
+        _sequenceLength = sequenceLength;
+        ResolveShapes(new[] { sequenceLength, _numClasses }, new[] { sequenceLength, _numClasses });
+    }
+
+    /// <inheritdoc />
+    /// <remarks>
+    /// CRF parameters (transition matrix, start/end scores) only depend
+    /// on <c>numClasses</c>, not <c>sequenceLength</c>, so they were
+    /// allocated eagerly in the lazy ctor. EnsureInitialized just flips
+    /// the initialized flag once shape is resolved.
+    /// </remarks>
+    protected override void EnsureInitialized()
+    {
+        if (_isInitialized) return;
+        if (_sequenceLength <= 0)
+            throw new InvalidOperationException(
+                "ConditionalRandomFieldLayer cannot initialize until OnFirstForward has resolved the sequence length from input shape.");
+
+        _isInitialized = true;
     }
 
     /// <summary>
@@ -487,6 +594,12 @@ public partial class ConditionalRandomFieldLayer<T> : LayerBase<T>
     /// </remarks>
     public override Tensor<T> Forward(Tensor<T> input)
     {
+        // Lazy-ctor instances start with _sequenceLength = -1; resolve
+        // from input.Shape on first call. Eager-ctor instances are
+        // already initialized so both calls are no-ops.
+        if (!IsShapeResolved) OnFirstForward(input);
+        EnsureInitialized();
+
         // Store original shape for any-rank tensor support
         _originalInputShape = input._shape;
         int rank = input.Shape.Length;

--- a/src/NeuralNetworks/Layers/ConditionalRandomFieldLayer.cs
+++ b/src/NeuralNetworks/Layers/ConditionalRandomFieldLayer.cs
@@ -109,11 +109,47 @@ public partial class ConditionalRandomFieldLayer<T> : LayerBase<T>
         if (inputs.Length == 0) throw new ArgumentException("CRF requires an input tensor.");
         var input = inputs[0];
 
+        // Lazy ctors leave IsShapeResolved == false until OnFirstForward
+        // / EnsureInitialized run. The CPU Forward path drives that
+        // resolution; if a layer's first execution is on the GPU it must
+        // do the same here, otherwise InputShape/OutputShape stay null
+        // and ParameterCount/serialization break for GPU-only callers.
+        if (!IsShapeResolved) OnFirstForward(input);
+        EnsureInitialized();
+
         if (Engine is not DirectGpuTensorEngine gpuEngine)
             throw new InvalidOperationException("ForwardGpu requires DirectGpuTensorEngine.");
 
-        // Input normalization [Batch, Seq, Class]
+        // Input normalization [Batch, Seq, Class]. Mirror the CPU Forward
+        // contract: validate rank, numClasses, sequence length BEFORE
+        // touching the Viterbi loops below — the GPU kernels assume the
+        // tensor is already in [B, S, C] with S == _sequenceLength and
+        // C == _numClasses.
         int rank = input.Shape.Length;
+        if (rank < 2)
+            throw new ArgumentException(
+                $"ConditionalRandomFieldLayer.ForwardGpu requires rank>=2 input " +
+                $"[seqLen, numClasses] or [batch, seqLen, numClasses]; got rank " +
+                $"{rank}.", nameof(inputs));
+        int gpuSeenClasses = input.Shape[rank - 1];
+        if (gpuSeenClasses != _numClasses)
+            throw new ArgumentException(
+                $"ConditionalRandomFieldLayer.ForwardGpu numClasses mismatch: layer " +
+                $"was constructed with {_numClasses} classes, but input shape's last " +
+                $"axis is {gpuSeenClasses}.", nameof(inputs));
+        int gpuSeenSeqLen = input.Shape[rank - 2];
+        if (gpuSeenSeqLen <= 0)
+            throw new ArgumentException(
+                $"ConditionalRandomFieldLayer.ForwardGpu sequence length must be " +
+                $"positive; got {gpuSeenSeqLen}.", nameof(inputs));
+        if (gpuSeenSeqLen != _sequenceLength)
+            throw new ArgumentException(
+                $"ConditionalRandomFieldLayer.ForwardGpu sequence length mismatch: " +
+                $"layer was resolved with sequenceLength={_sequenceLength}, but " +
+                $"this input's sequence dimension is {gpuSeenSeqLen}. CRF transition " +
+                $"buffer and Viterbi backpointers are sized to _sequenceLength.",
+                nameof(inputs));
+
         int batchSize, seqLen, numClasses;
         Tensor<T> input3D;
 
@@ -624,6 +660,16 @@ public partial class ConditionalRandomFieldLayer<T> : LayerBase<T>
             throw new ArgumentException(
                 $"ConditionalRandomFieldLayer's sequence length must be positive; got " +
                 $"{seenSeqLen} from input shape.", nameof(input));
+        if (seenSeqLen != _sequenceLength)
+            throw new ArgumentException(
+                $"ConditionalRandomFieldLayer's sequence length mismatch: layer was " +
+                $"resolved with sequenceLength={_sequenceLength} (from constructor or " +
+                $"first forward pass), but this input's sequence dimension is " +
+                $"{seenSeqLen}. Viterbi decoding, transitions buffer, and gradient " +
+                $"reshape are all sized to _sequenceLength; a different value would " +
+                $"silently truncate or run out of bounds. If you need variable-length " +
+                $"sequences, pad to a fixed length and mask, or construct one CRF per " +
+                $"length bucket.", nameof(input));
 
         // Store original shape for any-rank tensor support
         _originalInputShape = input._shape;

--- a/src/NeuralNetworks/Layers/DigitCapsuleLayer.cs
+++ b/src/NeuralNetworks/Layers/DigitCapsuleLayer.cs
@@ -334,18 +334,55 @@ public partial class DigitCapsuleLayer<T> : LayerBase<T>
 
     /// <inheritdoc />
     /// <remarks>
-    /// Reads input capsule structure from <c>input.Shape[^2..]</c>:
-    /// the last two axes are [inputCapsules, inputCapsuleDimension].
+    /// Resolves <c>_inputCapsules</c> and <c>_inputCapsuleDimension</c>
+    /// from input shape using the same rank-aware contract that
+    /// <see cref="Forward"/>'s reshape path uses:
+    /// <list type="bullet">
+    /// <item><b>rank-2 [I, D_in]</b>: no batch — capsules from axis 0,
+    /// dimension from axis 1.</item>
+    /// <item><b>rank-3 [B, I, D_in]</b>: batched — capsules from axis 1,
+    /// dimension from axis 2.</item>
+    /// <item><b>rank-4+ [B, H, W, ..., C, D_in]</b> (e.g. PrimaryCapsule
+    /// output [B, H, W, C, D]): the last axis is dimension, all middle
+    /// axes (excluding batch) collapse into the capsule count. So for
+    /// [B, H, W, C, D], <c>_inputCapsules = H*W*C</c>, matching how
+    /// Forward's higher-rank branch reshapes the tensor.</item>
+    /// </list>
+    /// Pre-fix this method just read <c>input.Shape[^2]</c> regardless of
+    /// rank, which would mis-resolve a [B, H, W, C, D] input as
+    /// <c>_inputCapsules = C</c> and trip the reshape on Line 513
+    /// (see DigitCapsuleLayer Forward, rank&gt;3 branch).
     /// </remarks>
     protected override void OnFirstForward(Tensor<T> input)
     {
         int rank = input.Shape.Length;
         if (rank < 2)
             throw new ArgumentException(
-                $"DigitCapsuleLayer requires rank>=2 input [...,inputCapsules,inputDimension]; got rank {rank}.", nameof(input));
+                $"DigitCapsuleLayer requires rank>=2 input; got rank {rank}.", nameof(input));
 
-        int inputCapsules = input.Shape[rank - 2];
         int inputCapsuleDimension = input.Shape[rank - 1];
+        int inputCapsules;
+        if (rank == 2)
+        {
+            // [inputCapsules, inputCapsuleDimension] — no batch axis.
+            inputCapsules = input.Shape[0];
+        }
+        else if (rank == 3)
+        {
+            // [batch, inputCapsules, inputCapsuleDimension].
+            inputCapsules = input.Shape[1];
+        }
+        else
+        {
+            // Rank >= 4 (e.g., [B, H, W, C, D] from PrimaryCapsule). The
+            // capsule count is the product of every axis except the
+            // leading batch and trailing dimension. Forward's reshape
+            // does the same collapse via totalElements/batch arithmetic,
+            // so this stays consistent.
+            inputCapsules = 1;
+            for (int d = 1; d < rank - 1; d++) inputCapsules *= input.Shape[d];
+        }
+
         if (inputCapsules <= 0)
             throw new ArgumentException(
                 $"DigitCapsuleLayer's inputCapsules must be positive; got {inputCapsules} from input shape.", nameof(input));
@@ -606,6 +643,14 @@ public partial class DigitCapsuleLayer<T> : LayerBase<T>
             throw new InvalidOperationException("GPU backend unavailable.");
 
         var input = inputs[0];
+
+        // Mirror the CPU Forward's lazy-init dispatch — without this, a
+        // lazy-ctor DigitCapsuleLayer that takes the GPU path on first
+        // use would reshape with -1 input dims and reach
+        // CapsulePredictionsGpu with a [0,0,0,0] weight tensor.
+        if (!IsShapeResolved) OnFirstForward(input);
+        EnsureInitialized();
+
         var inputShape = input._shape;
         int rank = inputShape.Length;
 

--- a/src/NeuralNetworks/Layers/DigitCapsuleLayer.cs
+++ b/src/NeuralNetworks/Layers/DigitCapsuleLayer.cs
@@ -364,8 +364,23 @@ public partial class DigitCapsuleLayer<T> : LayerBase<T>
         int inputCapsules;
         if (rank == 2)
         {
-            // [inputCapsules, inputCapsuleDimension] — no batch axis.
-            inputCapsules = input.Shape[0];
+            // Rank-2 is genuinely ambiguous for lazy shape resolution:
+            // Forward accepts both [inputCapsules, inputCapsuleDimension]
+            // (unbatched) and [batch, inputCapsules*inputCapsuleDimension]
+            // (batched/flat). With no other signal we cannot tell which
+            // interpretation the caller intended, and picking one
+            // silently misroutes the other. Force the caller to disambiguate
+            // by constructing the layer eagerly with known dimensions, or
+            // by passing rank>=3 input on the lazy first forward.
+            throw new ArgumentException(
+                $"DigitCapsuleLayer cannot lazy-resolve a rank-2 input of shape " +
+                $"[{input.Shape[0]}, {input.Shape[1]}]: this is ambiguous between " +
+                $"[inputCapsules, inputCapsuleDimension] and [batch, " +
+                $"inputCapsules*inputCapsuleDimension]. Either construct the layer " +
+                $"eagerly with explicit (inputCapsules, inputCapsuleDimension), or " +
+                $"reshape the first forward input to rank>=3 so OnFirstForward can " +
+                $"resolve unambiguously. Subsequent calls may use rank-2 once the " +
+                $"layer is resolved.", nameof(input));
         }
         else if (rank == 3)
         {
@@ -735,9 +750,16 @@ public partial class DigitCapsuleLayer<T> : LayerBase<T>
             _lastCouplings = couplings;
         }
 
-        // Dispose intermediate tensors
+        // Dispose intermediate tensors. Critical: only dispose `couplings`
+        // when we did NOT cache it on _lastCouplings — otherwise the
+        // backward pass reads a disposed tensor and reports a use-after-
+        // free (or a zeroed-out buffer if the pool reused it). predictions
+        // is never cached so it's always safe to drop.
         predictions.Dispose();
-        couplings.Dispose();
+        if (!IsTrainingMode)
+        {
+            couplings.Dispose();
+        }
 
         // Flatten output for compatibility with downstream layers
         // [B, C, D_out] -> [B, C*D_out]

--- a/src/NeuralNetworks/Layers/DigitCapsuleLayer.cs
+++ b/src/NeuralNetworks/Layers/DigitCapsuleLayer.cs
@@ -153,7 +153,11 @@ public partial class DigitCapsuleLayer<T> : LayerBase<T>
     /// - These features are combined to recognize more complex patterns
     /// </para>
     /// </remarks>
-    private readonly int _inputCapsules;
+    // Non-readonly: lazy ctor leaves _inputCapsules = -1 until
+    // OnFirstForward resolves it from input.Shape[^2]. Eager ctor
+    // sets it at construction.
+    private int _inputCapsules;
+    private bool _isInitialized;
 
     /// <summary>
     /// The dimension (number of values) of each input capsule vector.
@@ -171,7 +175,9 @@ public partial class DigitCapsuleLayer<T> : LayerBase<T>
     /// - More dimensions allow for more detailed feature representation
     /// </para>
     /// </remarks>
-    private readonly int _inputCapsuleDimension;
+    // Non-readonly: lazy ctor leaves _inputCapsuleDimension = -1 until
+    // OnFirstForward resolves it from input.Shape[^1].
+    private int _inputCapsuleDimension;
 
     /// <summary>
     /// The number of classes (output capsules) that this layer can identify.
@@ -294,6 +300,82 @@ public partial class DigitCapsuleLayer<T> : LayerBase<T>
         _weights = new Tensor<T>([inputCapsules, numClasses, inputCapsuleDimension, outputCapsuleDimension]);
 
         InitializeParameters();
+        _isInitialized = true;
+    }
+
+    /// <summary>
+    /// Lazy constructor: resolves <c>inputCapsules</c> and
+    /// <c>inputCapsuleDimension</c> from <c>input.Shape[^2..]</c> on
+    /// first <see cref="Forward"/>. Output structure (numClasses ×
+    /// outputCapsuleDimension) and routing iterations are architectural
+    /// and stay required.
+    /// </summary>
+    /// <param name="numClasses">Number of output classes (output capsules).</param>
+    /// <param name="outputCapsuleDimension">Dimension of each output capsule's vector.</param>
+    /// <param name="routingIterations">Number of dynamic-routing iterations.</param>
+    public DigitCapsuleLayer(int numClasses, int outputCapsuleDimension, int routingIterations)
+        : base([-1, -1], [numClasses, outputCapsuleDimension], (IVectorActivationFunction<T>)new SquashActivation<T>())
+    {
+        if (numClasses <= 0)
+            throw new ArgumentOutOfRangeException(nameof(numClasses), "numClasses must be positive.");
+        if (outputCapsuleDimension <= 0)
+            throw new ArgumentOutOfRangeException(nameof(outputCapsuleDimension), "outputCapsuleDimension must be positive.");
+        if (routingIterations < 1)
+            throw new ArgumentOutOfRangeException(nameof(routingIterations), "routingIterations must be at least 1.");
+
+        _inputCapsules = -1;
+        _inputCapsuleDimension = -1;
+        _numClasses = numClasses;
+        _outputCapsuleDimension = outputCapsuleDimension;
+        _routingIterations = routingIterations;
+        _weights = new Tensor<T>([0, 0, 0, 0]);
+        _isInitialized = false;
+    }
+
+    /// <inheritdoc />
+    /// <remarks>
+    /// Reads input capsule structure from <c>input.Shape[^2..]</c>:
+    /// the last two axes are [inputCapsules, inputCapsuleDimension].
+    /// </remarks>
+    protected override void OnFirstForward(Tensor<T> input)
+    {
+        int rank = input.Shape.Length;
+        if (rank < 2)
+            throw new ArgumentException(
+                $"DigitCapsuleLayer requires rank>=2 input [...,inputCapsules,inputDimension]; got rank {rank}.", nameof(input));
+
+        int inputCapsules = input.Shape[rank - 2];
+        int inputCapsuleDimension = input.Shape[rank - 1];
+        if (inputCapsules <= 0)
+            throw new ArgumentException(
+                $"DigitCapsuleLayer's inputCapsules must be positive; got {inputCapsules} from input shape.", nameof(input));
+        if (inputCapsuleDimension <= 0)
+            throw new ArgumentException(
+                $"DigitCapsuleLayer's inputCapsuleDimension must be positive; got {inputCapsuleDimension} from input shape.", nameof(input));
+
+        _inputCapsules = inputCapsules;
+        _inputCapsuleDimension = inputCapsuleDimension;
+        ResolveShapes(new[] { inputCapsules, inputCapsuleDimension }, new[] { _numClasses, _outputCapsuleDimension });
+    }
+
+    /// <inheritdoc />
+    /// <remarks>
+    /// Lazy initialization: allocate the routing weight tensor against
+    /// the resolved <c>[inputCapsules, numClasses, inputCapsuleDimension,
+    /// outputCapsuleDimension]</c> shape and run the standard parameter
+    /// initialization. Eager-ctor instances bypass this path because
+    /// <see cref="_isInitialized"/> is set to true at construction.
+    /// </remarks>
+    protected override void EnsureInitialized()
+    {
+        if (_isInitialized) return;
+        if (_inputCapsules <= 0 || _inputCapsuleDimension <= 0)
+            throw new InvalidOperationException(
+                "DigitCapsuleLayer cannot initialize until OnFirstForward has resolved the input capsule structure from input shape.");
+
+        _weights = new Tensor<T>([_inputCapsules, _numClasses, _inputCapsuleDimension, _outputCapsuleDimension]);
+        InitializeParameters();
+        _isInitialized = true;
     }
 
     /// <summary>
@@ -363,6 +445,13 @@ public partial class DigitCapsuleLayer<T> : LayerBase<T>
     /// </remarks>
     public override Tensor<T> Forward(Tensor<T> input)
     {
+        // Lazy-ctor instances start with _inputCapsules =
+        // _inputCapsuleDimension = -1; resolve from input.Shape on first
+        // call. Eager-ctor instances are already initialized so both
+        // calls are no-ops.
+        if (!IsShapeResolved) OnFirstForward(input);
+        EnsureInitialized();
+
         // Store original shape for any-rank tensor support
         _originalInputShape = input._shape;
         int rank = input.Shape.Length;

--- a/src/NeuralNetworks/Layers/ExpertLayer.cs
+++ b/src/NeuralNetworks/Layers/ExpertLayer.cs
@@ -310,6 +310,14 @@ public class ExpertLayer<T> : LayerBase<T>
         if (Engine is not DirectGpuTensorEngine gpuEngine)
             throw new InvalidOperationException("ForwardGpu requires a DirectGpuTensorEngine.");
 
+        // Mirror the CPU Forward's lazy-init dispatch — without this, an
+        // ExpertLayer constructed with [-1] inputShape that takes the GPU
+        // path on first use would chain into unresolved child layers and
+        // either throw or silently produce wrong output. OnFirstForward
+        // chain-resolves inner sub-layers from input.Shape; subsequent
+        // calls short-circuit via IsShapeResolved.
+        if (!IsShapeResolved) OnFirstForward(inputs[0]);
+
         var output = inputs[0];
 
         // Chain through each layer's ForwardGpu

--- a/src/NeuralNetworks/Layers/ExpertLayer.cs
+++ b/src/NeuralNetworks/Layers/ExpertLayer.cs
@@ -214,6 +214,16 @@ public class ExpertLayer<T> : LayerBase<T>
     /// </remarks>
     public override Tensor<T> Forward(Tensor<T> input)
     {
+        // Lazy-shape support: if construction-time inputShape contained
+        // sentinel -1 dims, the chain-resolve in the ctor was skipped
+        // and inner lazy layers (Dense / Conv / Attention) are still
+        // unresolved. Walk the chain now using the actual input.Shape
+        // so each lazy sub-layer's OnFirstForward fires with a real
+        // shape on its own first Forward — and propagate the resolved
+        // input/output to the outer ExpertLayer so IsShapeResolved
+        // flips to true.
+        if (!IsShapeResolved) OnFirstForward(input);
+
         var output = input;
 
         // Pass through each layer sequentially
@@ -227,6 +237,59 @@ public class ExpertLayer<T> : LayerBase<T>
 
         // Apply the expert's activation function if specified
         return ApplyActivation(output);
+    }
+
+    /// <inheritdoc />
+    /// <remarks>
+    /// Chain-resolves each inner layer's input shape from the actual
+    /// runtime input. This is the lazy counterpart to the ctor's eager
+    /// resolution path — it runs only when at least one inner layer is
+    /// still unresolved (ie ctor was passed a -1 sentinel input shape).
+    /// </remarks>
+    protected override void OnFirstForward(Tensor<T> input)
+    {
+        if (input._shape.Length == 0)
+            throw new ArgumentException("ExpertLayer requires non-empty input shape.", nameof(input));
+
+        // Strip leading batch dim — sub-layers are configured against
+        // per-sample feature shapes, matching the eager path's contract
+        // where the caller passes inputShape without a batch axis.
+        int[] runningShape;
+        if (input._shape.Length > 1)
+        {
+            runningShape = new int[input._shape.Length - 1];
+            for (int i = 0; i < runningShape.Length; i++) runningShape[i] = input._shape[i + 1];
+        }
+        else
+        {
+            runningShape = new int[input._shape.Length];
+            for (int i = 0; i < runningShape.Length; i++) runningShape[i] = input._shape[i];
+        }
+
+        foreach (var layer in _layers)
+        {
+            if (layer is LayerBase<T> lb && !lb.IsShapeResolved)
+            {
+                lb.ResolveFromShape(runningShape);
+            }
+            runningShape = layer.GetOutputShape();
+        }
+
+        // Outer-layer shapes: input from the actual tensor (per-sample,
+        // no batch axis), output from the last sub-layer's resolved
+        // output.
+        int[] outerInput;
+        if (input._shape.Length > 1)
+        {
+            outerInput = new int[input._shape.Length - 1];
+            for (int i = 0; i < outerInput.Length; i++) outerInput[i] = input._shape[i + 1];
+        }
+        else
+        {
+            outerInput = new int[input._shape.Length];
+            for (int i = 0; i < outerInput.Length; i++) outerInput[i] = input._shape[i];
+        }
+        ResolveShapes(outerInput, runningShape);
     }
 
     /// <summary>

--- a/src/NeuralNetworks/Layers/ExpertLayer.cs
+++ b/src/NeuralNetworks/Layers/ExpertLayer.cs
@@ -251,18 +251,72 @@ public class ExpertLayer<T> : LayerBase<T>
         if (input._shape.Length == 0)
             throw new ArgumentException("ExpertLayer requires non-empty input shape.", nameof(input));
 
-        // Strip leading batch dim — sub-layers are configured against
-        // per-sample feature shapes, matching the eager path's contract
-        // where the caller passes inputShape without a batch axis.
-        int[] runningShape;
-        if (input._shape.Length > 1)
+        // Determine whether axis 0 is a batch dimension. The eager
+        // constructor receives a per-sample feature shape (no batch),
+        // so sub-layers are configured against that. The lazy path has
+        // to disambiguate at first forward:
+        //
+        //  * If any inner layer is already shape-resolved, its
+        //    expected InputShape tells us the per-sample rank; axis 0
+        //    is batch iff the actual input has exactly one extra
+        //    leading dim.
+        //  * Otherwise, default to the convention that axis 0 is
+        //    batch (rank>=2). For rank-1 unbatched, treat the whole
+        //    shape as features. We can't reliably distinguish a
+        //    truly unbatched [H, W, C] from a batched [B=H, W, C]
+        //    without a hint, so we document the contract: lazy
+        //    ExpertLayers expect a batch axis on first forward, OR
+        //    at least one eagerly-constructed inner layer to anchor
+        //    the per-sample rank.
+        int inputRank = input._shape.Length;
+        int? perSampleRank = null;
+        foreach (var layer in _layers)
         {
-            runningShape = new int[input._shape.Length - 1];
+            if (layer is LayerBase<T> lb && lb.IsShapeResolved)
+            {
+                var resolved = lb.GetInputShape();
+                if (resolved != null && resolved.Length > 0 && resolved.All(d => d > 0))
+                {
+                    perSampleRank = resolved.Length;
+                    break;
+                }
+            }
+        }
+
+        bool stripBatch;
+        if (perSampleRank.HasValue)
+        {
+            if (inputRank == perSampleRank.Value)
+            {
+                stripBatch = false;
+            }
+            else if (inputRank == perSampleRank.Value + 1)
+            {
+                stripBatch = true;
+            }
+            else
+            {
+                throw new ArgumentException(
+                    $"ExpertLayer's first inner layer expects rank-{perSampleRank.Value} " +
+                    $"per-sample input, but the runtime input has rank {inputRank}. " +
+                    $"Expected rank {perSampleRank.Value} (unbatched) or rank " +
+                    $"{perSampleRank.Value + 1} (batched).", nameof(input));
+            }
+        }
+        else
+        {
+            stripBatch = inputRank > 1;
+        }
+
+        int[] runningShape;
+        if (stripBatch)
+        {
+            runningShape = new int[inputRank - 1];
             for (int i = 0; i < runningShape.Length; i++) runningShape[i] = input._shape[i + 1];
         }
         else
         {
-            runningShape = new int[input._shape.Length];
+            runningShape = new int[inputRank];
             for (int i = 0; i < runningShape.Length; i++) runningShape[i] = input._shape[i];
         }
 
@@ -275,18 +329,18 @@ public class ExpertLayer<T> : LayerBase<T>
             runningShape = layer.GetOutputShape();
         }
 
-        // Outer-layer shapes: input from the actual tensor (per-sample,
-        // no batch axis), output from the last sub-layer's resolved
-        // output.
+        // Outer-layer shapes: input is the per-sample shape we just
+        // resolved (regardless of whether axis 0 was batch), output is
+        // the last sub-layer's resolved output.
         int[] outerInput;
-        if (input._shape.Length > 1)
+        if (stripBatch)
         {
-            outerInput = new int[input._shape.Length - 1];
+            outerInput = new int[inputRank - 1];
             for (int i = 0; i < outerInput.Length; i++) outerInput[i] = input._shape[i + 1];
         }
         else
         {
-            outerInput = new int[input._shape.Length];
+            outerInput = new int[inputRank];
             for (int i = 0; i < outerInput.Length; i++) outerInput[i] = input._shape[i];
         }
         ResolveShapes(outerInput, runningShape);

--- a/src/NeuralNetworks/Layers/MixtureOfExpertsLayer.cs
+++ b/src/NeuralNetworks/Layers/MixtureOfExpertsLayer.cs
@@ -503,29 +503,50 @@ public partial class MixtureOfExpertsLayer<T> : LayerBase<T>, IAuxiliaryLossLaye
     /// and <c>IsShapeResolved</c> is true at construction time.
     /// (2) <b>Lazy:</b> caller passed <c>[-1]</c> or any shape containing
     /// a negative dim; sub-layers stayed unresolved. On first forward we
-    /// read <c>input.Shape[^1]</c> as the feature dimension (router and
-    /// experts share the same input shape for vanilla MoE) and propagate
-    /// it to every sub-layer.
+    /// derive the per-sample shape (input shape minus the leading batch
+    /// axis) and propagate it to every sub-layer.
+    ///
+    /// <para>The full per-sample shape is preserved — vanilla MoE may use
+    /// a feature-vector input but the layer's existing <see cref="Forward"/>
+    /// path explicitly supports any-rank tensors, so a Switch
+    /// Transformer / per-token MoE / multi-axis use case must see the
+    /// same shape resolution that the eager constructor delivered. Pre-
+    /// fix this method collapsed every input to <c>[featureDim]</c>,
+    /// which silently broke any expert / router that expected
+    /// multi-axis per-sample inputs.</para>
     /// </remarks>
     protected override void OnFirstForward(Tensor<T> input)
     {
-        int rank = input.Shape.Length;
+        int rank = input._shape.Length;
         if (rank < 1)
             throw new ArgumentException(
                 $"MixtureOfExpertsLayer requires rank>=1 input; got rank {rank}.", nameof(input));
 
-        int featureDim = input.Shape[rank - 1];
-        if (featureDim <= 0)
-            throw new ArgumentException(
-                $"MixtureOfExpertsLayer's input feature dimension must be positive; got {featureDim} from input shape.",
-                nameof(input));
+        // Strip the leading batch axis when present — sub-layers are
+        // configured against per-sample shapes (matching the ctor's
+        // ResolveSubLayer contract where the caller passed inputShape
+        // without batch).
+        int[] resolvedInputShape;
+        if (rank == 1)
+        {
+            // [features] — no batch axis; whole shape is per-sample.
+            resolvedInputShape = new int[] { input._shape[0] };
+        }
+        else
+        {
+            resolvedInputShape = new int[rank - 1];
+            for (int i = 0; i < resolvedInputShape.Length; i++)
+                resolvedInputShape[i] = input._shape[i + 1];
+        }
 
-        // Feature-dim-only resolved shape; sub-layers receive a 1-D
-        // shape because vanilla MoE treats input as a per-sample feature
-        // vector. Switch Transformer / per-token MoE variants would
-        // pass the full multi-axis input here, but those are out of
-        // scope for this base class — they should subclass and override.
-        var resolvedInputShape = new[] { featureDim };
+        for (int i = 0; i < resolvedInputShape.Length; i++)
+        {
+            if (resolvedInputShape[i] <= 0)
+                throw new ArgumentException(
+                    $"MixtureOfExpertsLayer's per-sample shape axis {i} must be positive; " +
+                    $"got {resolvedInputShape[i]} from input shape.", nameof(input));
+        }
+
         ResolveSubLayer(_router, resolvedInputShape);
         foreach (var expert in _experts)
         {
@@ -533,21 +554,14 @@ public partial class MixtureOfExpertsLayer<T> : LayerBase<T>, IAuxiliaryLossLaye
         }
 
         // Output shape inherits from the first expert's resolved output
-        // (all experts share the same output shape by MoE contract).
-        int[] resolvedOutputShape;
-        if (_experts[0] is LayerBase<T> firstExpert && firstExpert.IsShapeResolved)
-        {
-            resolvedOutputShape = firstExpert.GetOutputShape();
-        }
-        else
-        {
-            // Sub-layer didn't expose a resolved output — fall back to
-            // the OutputShape provided at construction (may still
-            // contain -1 sentinels which would break downstream tape
-            // accounting; surfaced as a runtime error rather than
-            // silent corruption).
-            resolvedOutputShape = OutputShape;
-        }
+        // (all experts share the same output shape by MoE contract). Use
+        // the ILayer<T> contract directly — GetOutputShape is on the
+        // interface, so any ILayer<T> impl can report its resolved
+        // output shape, not just LayerBase<T> subclasses. Falling back
+        // to the constructor's OutputShape was unnecessary since
+        // ILayer<T> mandates GetOutputShape; the previous LayerBase
+        // typecheck rejected legitimate ILayer<T> impls.
+        int[] resolvedOutputShape = _experts[0].GetOutputShape();
 
         ResolveShapes(resolvedInputShape, resolvedOutputShape);
     }
@@ -1848,6 +1862,14 @@ public partial class MixtureOfExpertsLayer<T> : LayerBase<T>, IAuxiliaryLossLaye
             throw new InvalidOperationException("ForwardGpu requires a DirectGpuTensorEngine.");
 
         var input = inputs[0];
+
+        // Mirror the CPU Forward's lazy-init dispatch — without this, a
+        // lazy MoE that takes the GPU path on first use would reach
+        // _router and _experts with unresolved shapes / zero-sized
+        // parameter tensors. OnFirstForward propagates resolved feature
+        // dim into router + experts.
+        if (!IsShapeResolved) OnFirstForward(input);
+
         int batchSize = input.Shape[0];
         int numExperts = _experts.Count;
 

--- a/src/NeuralNetworks/Layers/MixtureOfExpertsLayer.cs
+++ b/src/NeuralNetworks/Layers/MixtureOfExpertsLayer.cs
@@ -495,6 +495,63 @@ public partial class MixtureOfExpertsLayer<T> : LayerBase<T>, IAuxiliaryLossLaye
         }
     }
 
+    /// <inheritdoc />
+    /// <remarks>
+    /// MoE supports two construction patterns:
+    /// (1) <b>Eager:</b> caller passed positive <c>inputShape</c>; ctor
+    /// already eagerly resolved router and experts via <c>ResolveSubLayer</c>
+    /// and <c>IsShapeResolved</c> is true at construction time.
+    /// (2) <b>Lazy:</b> caller passed <c>[-1]</c> or any shape containing
+    /// a negative dim; sub-layers stayed unresolved. On first forward we
+    /// read <c>input.Shape[^1]</c> as the feature dimension (router and
+    /// experts share the same input shape for vanilla MoE) and propagate
+    /// it to every sub-layer.
+    /// </remarks>
+    protected override void OnFirstForward(Tensor<T> input)
+    {
+        int rank = input.Shape.Length;
+        if (rank < 1)
+            throw new ArgumentException(
+                $"MixtureOfExpertsLayer requires rank>=1 input; got rank {rank}.", nameof(input));
+
+        int featureDim = input.Shape[rank - 1];
+        if (featureDim <= 0)
+            throw new ArgumentException(
+                $"MixtureOfExpertsLayer's input feature dimension must be positive; got {featureDim} from input shape.",
+                nameof(input));
+
+        // Feature-dim-only resolved shape; sub-layers receive a 1-D
+        // shape because vanilla MoE treats input as a per-sample feature
+        // vector. Switch Transformer / per-token MoE variants would
+        // pass the full multi-axis input here, but those are out of
+        // scope for this base class — they should subclass and override.
+        var resolvedInputShape = new[] { featureDim };
+        ResolveSubLayer(_router, resolvedInputShape);
+        foreach (var expert in _experts)
+        {
+            ResolveSubLayer(expert, resolvedInputShape);
+        }
+
+        // Output shape inherits from the first expert's resolved output
+        // (all experts share the same output shape by MoE contract).
+        int[] resolvedOutputShape;
+        if (_experts[0] is LayerBase<T> firstExpert && firstExpert.IsShapeResolved)
+        {
+            resolvedOutputShape = firstExpert.GetOutputShape();
+        }
+        else
+        {
+            // Sub-layer didn't expose a resolved output — fall back to
+            // the OutputShape provided at construction (may still
+            // contain -1 sentinels which would break downstream tape
+            // accounting; surfaced as a runtime error rather than
+            // silent corruption).
+            resolvedOutputShape = OutputShape;
+        }
+
+        ResolveShapes(resolvedInputShape, resolvedOutputShape);
+    }
+
     /// <summary>
     /// Performs the forward pass through the MoE layer.
     /// </summary>
@@ -544,6 +601,14 @@ public partial class MixtureOfExpertsLayer<T> : LayerBase<T>, IAuxiliaryLossLaye
     /// </remarks>
     public override Tensor<T> Forward(Tensor<T> input)
     {
+        // Lazy-shape support: if the layer (or its sub-layers) wasn't
+        // eagerly resolved at construction (caller passed [-1] or
+        // shape with negative dims), resolve from input.Shape now.
+        // OnFirstForward propagates the resolved shape into router +
+        // experts, then ResolveShapes flips IsShapeResolved on the
+        // outer layer.
+        if (!IsShapeResolved) OnFirstForward(input);
+
         // Store original shape for any-rank tensor support
         _originalInputShape = input._shape;
         int rank = input.Shape.Length;

--- a/src/NeuralNetworks/Layers/MixtureOfExpertsLayer.cs
+++ b/src/NeuralNetworks/Layers/MixtureOfExpertsLayer.cs
@@ -1870,7 +1870,38 @@ public partial class MixtureOfExpertsLayer<T> : LayerBase<T>, IAuxiliaryLossLaye
         // dim into router + experts.
         if (!IsShapeResolved) OnFirstForward(input);
 
-        int batchSize = input.Shape[0];
+        // Mirror the CPU Forward's any-rank → 2D collapse contract.
+        // _router and each _expert are configured against [B, features]
+        // — feeding them a rank-1 or rank>2 tensor diverges from the
+        // CPU path (different routing batch granularity) and trips
+        // shape mismatches inside expert sub-layers. Collapse leading
+        // dims into a flat batch, run on 2D, then restore the original
+        // leading dims at the end like the CPU path does on lines
+        // 754–768.
+        _originalInputShape = input._shape;
+        int rank = input.Shape.Length;
+        Tensor<T> input2D;
+        int batchSize;
+        if (rank == 1)
+        {
+            batchSize = 1;
+            input2D = gpuEngine.ReshapeGpu(input, new[] { 1, input.Shape[0] });
+        }
+        else if (rank == 2)
+        {
+            batchSize = input.Shape[0];
+            input2D = input;
+        }
+        else
+        {
+            int flatBatch = 1;
+            for (int d = 0; d < rank - 1; d++) flatBatch *= input.Shape[d];
+            batchSize = flatBatch;
+            input2D = gpuEngine.ReshapeGpu(input, new[] { flatBatch, input.Shape[rank - 1] });
+        }
+        // From here on, treat input2D as the canonical [batch, features]
+        // tensor for routing and expert dispatch.
+        input = input2D;
         int numExperts = _experts.Count;
 
         // Step 1: Route input through router to get logits (GPU-resident)
@@ -2013,6 +2044,24 @@ public partial class MixtureOfExpertsLayer<T> : LayerBase<T>, IAuxiliaryLossLaye
             _lastRoutingWeights = routingWeightsGpu;
             _lastPreActivation = combinedGpu;
             _lastExpertOutputs = expertOutputsGpu.Select(e => e).ToList();
+        }
+
+        // Restore the original leading dims to match the CPU path's
+        // contract on lines 754–768. The 2D output is [flatBatch,
+        // outputFeatures]; for rank>2 input we re-expand the batch
+        // axes, for rank-1 input we drop the synthetic batch dim.
+        if (_originalInputShape != null && _originalInputShape.Length > 2)
+        {
+            int outputFeatures = resultGpu.Shape[1];
+            int[] newShape = new int[_originalInputShape.Length];
+            for (int d = 0; d < _originalInputShape.Length - 1; d++)
+                newShape[d] = _originalInputShape[d];
+            newShape[_originalInputShape.Length - 1] = outputFeatures;
+            resultGpu = gpuEngine.ReshapeGpu(resultGpu, newShape);
+        }
+        else if (_originalInputShape != null && _originalInputShape.Length == 1)
+        {
+            resultGpu = gpuEngine.ReshapeGpu(resultGpu, new[] { resultGpu.Shape[1] });
         }
 
         return resultGpu;

--- a/src/NeuralNetworks/Layers/ObliviousDecisionTreeLayer.cs
+++ b/src/NeuralNetworks/Layers/ObliviousDecisionTreeLayer.cs
@@ -372,8 +372,22 @@ public partial class ObliviousDecisionTreeLayer<T> : LayerBase<T>
     /// <summary>
     /// Gets feature importance based on selection weights.
     /// </summary>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown if the layer was constructed with the lazy ctor and has not yet
+    /// seen a Forward call — feature importance can't be computed without a
+    /// resolved <c>_inputDim</c> and allocated <c>_featureSelectionWeights</c>.
+    /// </exception>
     public Vector<T> GetFeatureImportance()
     {
+        if (_inputDim <= 0)
+        {
+            throw new InvalidOperationException(
+                "ObliviousDecisionTreeLayer.GetFeatureImportance(): the layer was " +
+                "constructed via the lazy ctor (no inputDim arg) and has not yet seen " +
+                "a Forward call, so the input dimension and parameter tensors are not " +
+                "yet resolved. Run at least one Forward(input) before querying feature " +
+                "importance, or construct via the eager ctor with an explicit inputDim.");
+        }
         var importance = new Vector<T>(_inputDim);
 
         if (_featureSelectionsCache != null)

--- a/src/NeuralNetworks/Layers/ObliviousDecisionTreeLayer.cs
+++ b/src/NeuralNetworks/Layers/ObliviousDecisionTreeLayer.cs
@@ -157,9 +157,18 @@ public partial class ObliviousDecisionTreeLayer<T> : LayerBase<T>
     protected override void OnFirstForward(Tensor<T> input)
     {
         int rank = input.Shape.Length;
-        if (rank < 1)
+        // ODT Forward indexes the tensor as a flat [batch, _inputDim]
+        // matrix (see ComputeSplitDecisions); rank-1 input would alias
+        // batch onto the feature axis and silently produce garbage. Lock
+        // the contract here so lazy first forward fails fast instead of
+        // resolving _inputDim from the wrong axis.
+        if (rank != 2)
             throw new ArgumentException(
-                $"ObliviousDecisionTreeLayer requires rank>=1 input; got rank {rank}.", nameof(input));
+                $"ObliviousDecisionTreeLayer requires rank-2 input [batch, features]; " +
+                $"got rank {rank} with shape [{string.Join(", ", input.Shape)}]. If your " +
+                $"data is unbatched, add a leading batch axis (e.g. tensor.Reshape([1, " +
+                $"features])); higher-rank inputs must be flattened to [batch, features] " +
+                $"upstream.", nameof(input));
 
         int inputDim = input.Shape[rank - 1];
         if (inputDim <= 0)
@@ -229,6 +238,20 @@ public partial class ObliviousDecisionTreeLayer<T> : LayerBase<T>
         // _isInitialized=true) so both calls are no-ops.
         if (!IsShapeResolved) OnFirstForward(input);
         EnsureInitialized();
+
+        // Re-validate the shape contract on every call, not just the
+        // lazy-first one. OnFirstForward only fires once; subsequent
+        // inputs with a different rank or feature count would otherwise
+        // index past _featureSelectionWeights[level*_inputDim+f].
+        if (input.Shape.Length != 2)
+            throw new ArgumentException(
+                $"ObliviousDecisionTreeLayer requires rank-2 input [batch, features]; " +
+                $"got rank {input.Shape.Length}.", nameof(input));
+        if (input.Shape[1] != _inputDim)
+            throw new ArgumentException(
+                $"ObliviousDecisionTreeLayer's input feature dimension mismatch: layer " +
+                $"was resolved with _inputDim={_inputDim}, but input has " +
+                $"{input.Shape[1]} features.", nameof(input));
 
         _inputCache = input;
         int batchSize = input.Shape[0];

--- a/src/NeuralNetworks/Layers/ObliviousDecisionTreeLayer.cs
+++ b/src/NeuralNetworks/Layers/ObliviousDecisionTreeLayer.cs
@@ -27,9 +27,13 @@ namespace AiDotNet.NeuralNetworks.Layers;
 /// <typeparam name="T">The numeric type used for calculations.</typeparam>
 public partial class ObliviousDecisionTreeLayer<T> : LayerBase<T>
 {
-    private readonly int _inputDim;
+    // Non-readonly: lazy ctor leaves _inputDim = -1 until OnFirstForward
+    // resolves it from input.Shape[^1]. Eager ctor sets it at construction.
+    private int _inputDim;
     private readonly int _depth;
     private readonly int _outputDim;
+    private readonly double _initScale;
+    private bool _isInitialized;
 
     // Each level has one feature selection and one threshold
     [TrainableParameter(Role = PersistentTensorRole.Weights)]
@@ -65,9 +69,11 @@ public partial class ObliviousDecisionTreeLayer<T> : LayerBase<T>
 
     /// <inheritdoc/>
     public override int ParameterCount =>
-        _depth * _inputDim +      // feature selection weights
-        _depth +                   // thresholds
-        _numLeaves * _outputDim;   // leaf values
+        _inputDim > 0
+            ? _depth * _inputDim +      // feature selection weights
+              _depth +                   // thresholds
+              _numLeaves * _outputDim    // leaf values
+            : 0;                         // lazy: no params allocated yet
 
     /// <summary>
     /// Initializes an oblivious decision tree.
@@ -89,6 +95,7 @@ public partial class ObliviousDecisionTreeLayer<T> : LayerBase<T>
         _inputDim = inputDim;
         _depth = depth;
         _outputDim = outputDim;
+        _initScale = initScale;
         _numLeaves = 1 << depth;  // 2^depth
 
         // Initialize parameters
@@ -102,6 +109,90 @@ public partial class ObliviousDecisionTreeLayer<T> : LayerBase<T>
         _leafValuesGrad = new Tensor<T>([_numLeaves, outputDim]);
 
         InitializeParameters(initScale);
+        _isInitialized = true;
+    }
+
+    /// <summary>
+    /// Lazy constructor: resolves <c>inputDim</c> from <c>input.Shape[^1]</c>
+    /// on first <see cref="Forward"/>. <paramref name="depth"/> and
+    /// <paramref name="outputDim"/> are architectural and stay required;
+    /// only the input feature dimension is shape-dependent.
+    /// </summary>
+    /// <param name="depth">Tree depth (number of split levels).</param>
+    /// <param name="outputDim">Output dimension per leaf.</param>
+    /// <param name="initScale">Initialization scale.</param>
+    public ObliviousDecisionTreeLayer(int depth = 6, int outputDim = 1, double initScale = 0.01)
+        : base([-1], [outputDim])
+    {
+        if (depth <= 0 || depth > 30)
+            throw new ArgumentOutOfRangeException(nameof(depth), "Depth must be between 1 and 30.");
+        if (outputDim <= 0)
+            throw new ArgumentOutOfRangeException(nameof(outputDim), "Output dimension must be positive.");
+
+        _inputDim = -1;
+        _depth = depth;
+        _outputDim = outputDim;
+        _initScale = initScale;
+        _numLeaves = 1 << depth;
+
+        // Empty placeholders — EnsureInitialized will re-allocate against
+        // the resolved inputDim once OnFirstForward fires. Keeping the
+        // not-null reference contract intact for code paths that walk
+        // these fields unconditionally (GetParameters, ClearGradients).
+        _featureSelectionWeights = new Tensor<T>([0, 0]);
+        _thresholds = new Tensor<T>([0]);
+        _leafValues = new Tensor<T>([0, 0]);
+        _featureSelectionGrad = new Tensor<T>([0, 0]);
+        _thresholdsGrad = new Tensor<T>([0]);
+        _leafValuesGrad = new Tensor<T>([0, 0]);
+        _isInitialized = false;
+    }
+
+    /// <inheritdoc />
+    /// <remarks>
+    /// Reads the input feature count from <c>input.Shape[^1]</c> and
+    /// resolves the lazy shape so the rest of the forward pass + parameter
+    /// access can index against a real <c>InputShape[0]</c>.
+    /// </remarks>
+    protected override void OnFirstForward(Tensor<T> input)
+    {
+        int rank = input.Shape.Length;
+        if (rank < 1)
+            throw new ArgumentException(
+                $"ObliviousDecisionTreeLayer requires rank>=1 input; got rank {rank}.", nameof(input));
+
+        int inputDim = input.Shape[rank - 1];
+        if (inputDim <= 0)
+            throw new ArgumentException(
+                $"ObliviousDecisionTreeLayer's input feature dimension must be positive; got {inputDim} from input shape.",
+                nameof(input));
+
+        _inputDim = inputDim;
+        ResolveShapes(new[] { inputDim }, OutputShape);
+    }
+
+    /// <inheritdoc />
+    /// <remarks>
+    /// Lazy initialization: allocate parameter and gradient tensors against
+    /// the resolved <c>_inputDim</c> and run the standard ODT initialization.
+    /// Eager-ctor instances bypass this path because <see cref="_isInitialized"/>
+    /// is set to true at construction.
+    /// </remarks>
+    protected override void EnsureInitialized()
+    {
+        if (_isInitialized) return;
+        if (_inputDim <= 0)
+            throw new InvalidOperationException(
+                "ObliviousDecisionTreeLayer cannot initialize until OnFirstForward has resolved the input dimension from input shape.");
+
+        _featureSelectionWeights = new Tensor<T>([_depth, _inputDim]);
+        _thresholds = new Tensor<T>([_depth]);
+        _leafValues = new Tensor<T>([_numLeaves, _outputDim]);
+        _featureSelectionGrad = new Tensor<T>([_depth, _inputDim]);
+        _thresholdsGrad = new Tensor<T>([_depth]);
+        _leafValuesGrad = new Tensor<T>([_numLeaves, _outputDim]);
+        InitializeParameters(_initScale);
+        _isInitialized = true;
     }
 
     private void InitializeParameters(double scale)
@@ -132,6 +223,13 @@ public partial class ObliviousDecisionTreeLayer<T> : LayerBase<T>
     /// <returns>Tree output [batchSize, outputDim].</returns>
     public override Tensor<T> Forward(Tensor<T> input)
     {
+        // Lazy-ctor instances start with _inputDim = -1; resolve from
+        // input.Shape on first call, then materialize parameter tensors.
+        // Eager-ctor instances are already initialized (IsShapeResolved=true,
+        // _isInitialized=true) so both calls are no-ops.
+        if (!IsShapeResolved) OnFirstForward(input);
+        EnsureInitialized();
+
         _inputCache = input;
         int batchSize = input.Shape[0];
 

--- a/src/NeuralNetworks/Layers/PrimaryCapsuleLayer.cs
+++ b/src/NeuralNetworks/Layers/PrimaryCapsuleLayer.cs
@@ -353,19 +353,61 @@ public partial class PrimaryCapsuleLayer<T> : LayerBase<T>
 
     /// <inheritdoc />
     /// <remarks>
-    /// Reads the input channel count from <c>input.Shape[1]</c> (NCHW
-    /// convention: [batch, channels, height, width]). Capsule conv geometry
-    /// (kernel × kernel × inputChannels) is what we need to materialize the
-    /// weight tensor.
+    /// Resolves <c>_inputChannels</c> from input shape using the same
+    /// rank-aware reshape contract that <see cref="Forward"/> uses, so
+    /// the lazy contract matches the eager behavior:
+    /// <list type="bullet">
+    /// <item><b>rank-1 [C]</b>: channels = shape[0] (Forward expands to
+    /// [1,1,1,C], NHWC).</item>
+    /// <item><b>rank-2 [W, C]</b>: channels = shape[1] (Forward expands
+    /// to [1,1,W,C], NHWC).</item>
+    /// <item><b>rank-3 [H, W, C]</b>: channels = shape[2] (Forward expands
+    /// to [1,H,W,C], NHWC). Note: Forward's NCHW [C,H,W] disambiguation
+    /// requires <c>_inputChannels</c> to already be known, so it can't
+    /// be detected lazily — rank-3 inputs are always treated as NHWC
+    /// in the lazy path. Callers needing rank-3 NCHW must use the
+    /// eager ctor.</item>
+    /// <item><b>rank-4 [B, C, H, W]</b>: channels = shape[1] (NCHW —
+    /// Forward's primary 4D path; matches the
+    /// <c>[LayerProperty(TestInputShape="1, 1, 8, 8")]</c> contract).</item>
+    /// <item><b>rank-5+ [B1, ..., H, W, C]</b>: channels = last axis
+    /// (Forward's higher-rank branch reshapes to [flatBatch, H, W, C],
+    /// NHWC).</item>
+    /// </list>
+    /// Pre-fix this method hard-required rank-4 and always read
+    /// shape[1], which both rejected valid rank-1/2/3 inputs that
+    /// Forward already handled, AND mis-resolved NHWC [B,H,W,C] inputs
+    /// by treating height as channels.
     /// </remarks>
     protected override void OnFirstForward(Tensor<T> input)
     {
         int rank = input.Shape.Length;
-        if (rank < 4)
+        if (rank < 1)
             throw new ArgumentException(
-                $"PrimaryCapsuleLayer requires rank-4 NCHW input [batch, channels, h, w]; got rank {rank}.", nameof(input));
+                $"PrimaryCapsuleLayer requires rank>=1 input; got rank {rank}.", nameof(input));
 
-        int inputChannels = input.Shape[1];
+        int inputChannels;
+        if (rank <= 3)
+        {
+            // rank-1/2/3: channels is the last axis (NHWC convention,
+            // matches Forward's shape4D expansion path).
+            inputChannels = input.Shape[rank - 1];
+        }
+        else if (rank == 4)
+        {
+            // Standard NCHW [B, C, H, W] — channel axis is at index 1.
+            // This is the primary 4D path Forward uses when shape[1]
+            // matches _inputChannels (which is what the lazy ctor will
+            // see by definition once _inputChannels is set here).
+            inputChannels = input.Shape[1];
+        }
+        else
+        {
+            // rank-5+: Forward's higher-rank branch reshapes to
+            // [flatBatch, H, W, C] (NHWC). Channels is the last axis.
+            inputChannels = input.Shape[rank - 1];
+        }
+
         if (inputChannels <= 0)
             throw new ArgumentException(
                 $"PrimaryCapsuleLayer's input channel count must be positive; got {inputChannels} from input shape.",
@@ -646,6 +688,15 @@ public partial class PrimaryCapsuleLayer<T> : LayerBase<T>
             throw new InvalidOperationException("GPU backend unavailable.");
 
         var input = inputs[0];
+
+        // Mirror the CPU Forward's lazy-init dispatch — without this, a
+        // lazy-ctor PrimaryCapsuleLayer that takes the GPU path on first
+        // use would dereference the [0,0] / [0] zero-sized convWeights
+        // / convBias tensors. OnFirstForward resolves _inputChannels
+        // from input.Shape and EnsureInitialized allocates the conv
+        // tensors at the right size.
+        if (!IsShapeResolved) OnFirstForward(input);
+        EnsureInitialized();
 
         // Detect input format: NCHW [B, C, H, W] vs NHWC [B, H, W, C]
         // NCHW has channels in dim 1, NHWC has channels in dim 3

--- a/src/NeuralNetworks/Layers/PrimaryCapsuleLayer.cs
+++ b/src/NeuralNetworks/Layers/PrimaryCapsuleLayer.cs
@@ -115,7 +115,11 @@ public partial class PrimaryCapsuleLayer<T> : LayerBase<T>
     /// <remarks>
     /// This field stores the number of channels in the input tensor.
     /// </remarks>
-    private readonly int _inputChannels;
+    // Non-readonly: lazy ctor leaves _inputChannels = -1 until
+    // OnFirstForward resolves it from input.Shape[1] (NCHW). Eager
+    // ctor sets it at construction.
+    private int _inputChannels;
+    private bool _isInitialized;
 
     /// <summary>
     /// The number of capsule channels.
@@ -231,6 +235,43 @@ public partial class PrimaryCapsuleLayer<T> : LayerBase<T>
         _convBias = new Tensor<T>([outputChannels]);
 
         InitializeParameters();
+        _isInitialized = true;
+    }
+
+    /// <summary>
+    /// Lazy constructor (scalar activation): resolves <c>inputChannels</c>
+    /// from <c>input.Shape[1]</c> (NCHW) on first <see cref="Forward"/>.
+    /// Capsule architecture (channels × dimension) and conv geometry
+    /// (kernelSize, stride) are architectural and stay required.
+    /// </summary>
+    /// <param name="capsuleChannels">Number of capsule channels.</param>
+    /// <param name="capsuleDimension">Dimension of each capsule's output vector.</param>
+    /// <param name="kernelSize">Convolution kernel size (square).</param>
+    /// <param name="stride">Convolution stride.</param>
+    /// <param name="scalarActivation">Optional scalar activation (defaults to Squash).</param>
+    public PrimaryCapsuleLayer(int capsuleChannels, int capsuleDimension, int kernelSize, int stride, IActivationFunction<T>? scalarActivation = null)
+        : base([-1], [capsuleChannels * capsuleDimension], scalarActivation ?? new SquashActivation<T>())
+    {
+        if (capsuleChannels <= 0)
+            throw new ArgumentOutOfRangeException(nameof(capsuleChannels), "capsuleChannels must be positive.");
+        if (capsuleDimension <= 0)
+            throw new ArgumentOutOfRangeException(nameof(capsuleDimension), "capsuleDimension must be positive.");
+        if (kernelSize <= 0)
+            throw new ArgumentOutOfRangeException(nameof(kernelSize), "kernelSize must be positive.");
+        if (stride <= 0)
+            throw new ArgumentOutOfRangeException(nameof(stride), "stride must be positive.");
+
+        _inputChannels = -1;
+        _capsuleChannels = capsuleChannels;
+        _capsuleDimension = capsuleDimension;
+        _kernelSize = kernelSize;
+        _stride = stride;
+
+        // Empty placeholders — EnsureInitialized re-allocates against
+        // resolved _inputChannels.
+        _convWeights = new Tensor<T>([0, 0]);
+        _convBias = new Tensor<T>([0]);
+        _isInitialized = false;
     }
 
     /// <summary>
@@ -275,6 +316,86 @@ public partial class PrimaryCapsuleLayer<T> : LayerBase<T>
         _convBias = new Tensor<T>([outputChannels]);
 
         InitializeParameters();
+        _isInitialized = true;
+    }
+
+    /// <summary>
+    /// Lazy constructor (vector activation): resolves <c>inputChannels</c>
+    /// from <c>input.Shape[1]</c> (NCHW) on first <see cref="Forward"/>.
+    /// See the scalar-activation lazy ctor for design notes.
+    /// </summary>
+    /// <param name="capsuleChannels">Number of capsule channels.</param>
+    /// <param name="capsuleDimension">Dimension of each capsule's output vector.</param>
+    /// <param name="kernelSize">Convolution kernel size (square).</param>
+    /// <param name="stride">Convolution stride.</param>
+    /// <param name="vectorActivation">Optional vector activation (defaults to Squash).</param>
+    public PrimaryCapsuleLayer(int capsuleChannels, int capsuleDimension, int kernelSize, int stride, IVectorActivationFunction<T>? vectorActivation)
+        : base([-1], [capsuleChannels * capsuleDimension], vectorActivation ?? new SquashActivation<T>())
+    {
+        if (capsuleChannels <= 0)
+            throw new ArgumentOutOfRangeException(nameof(capsuleChannels), "capsuleChannels must be positive.");
+        if (capsuleDimension <= 0)
+            throw new ArgumentOutOfRangeException(nameof(capsuleDimension), "capsuleDimension must be positive.");
+        if (kernelSize <= 0)
+            throw new ArgumentOutOfRangeException(nameof(kernelSize), "kernelSize must be positive.");
+        if (stride <= 0)
+            throw new ArgumentOutOfRangeException(nameof(stride), "stride must be positive.");
+
+        _inputChannels = -1;
+        _capsuleChannels = capsuleChannels;
+        _capsuleDimension = capsuleDimension;
+        _kernelSize = kernelSize;
+        _stride = stride;
+        _convWeights = new Tensor<T>([0, 0]);
+        _convBias = new Tensor<T>([0]);
+        _isInitialized = false;
+    }
+
+    /// <inheritdoc />
+    /// <remarks>
+    /// Reads the input channel count from <c>input.Shape[1]</c> (NCHW
+    /// convention: [batch, channels, height, width]). Capsule conv geometry
+    /// (kernel × kernel × inputChannels) is what we need to materialize the
+    /// weight tensor.
+    /// </remarks>
+    protected override void OnFirstForward(Tensor<T> input)
+    {
+        int rank = input.Shape.Length;
+        if (rank < 4)
+            throw new ArgumentException(
+                $"PrimaryCapsuleLayer requires rank-4 NCHW input [batch, channels, h, w]; got rank {rank}.", nameof(input));
+
+        int inputChannels = input.Shape[1];
+        if (inputChannels <= 0)
+            throw new ArgumentException(
+                $"PrimaryCapsuleLayer's input channel count must be positive; got {inputChannels} from input shape.",
+                nameof(input));
+
+        _inputChannels = inputChannels;
+        ResolveShapes(new[] { inputChannels }, OutputShape);
+    }
+
+    /// <inheritdoc />
+    /// <remarks>
+    /// Lazy initialization: allocate conv weights against the resolved
+    /// <c>_inputChannels × kernelSize × kernelSize</c> input dim and run
+    /// the standard parameter initialization. Eager-ctor instances bypass
+    /// this path because <see cref="_isInitialized"/> is set to true at
+    /// construction.
+    /// </remarks>
+    protected override void EnsureInitialized()
+    {
+        if (_isInitialized) return;
+        if (_inputChannels <= 0)
+            throw new InvalidOperationException(
+                "PrimaryCapsuleLayer cannot initialize until OnFirstForward has resolved the input channel count from input shape.");
+
+        int outputChannels = _capsuleChannels * _capsuleDimension;
+        int inputSize = _inputChannels * _kernelSize * _kernelSize;
+        _convWeights = new Tensor<T>([outputChannels, inputSize]);
+        _convBias = new Tensor<T>([outputChannels]);
+        InitializeParameters();
+        _isInitialized = true;
     }
 
     /// <summary>
@@ -354,6 +475,12 @@ public partial class PrimaryCapsuleLayer<T> : LayerBase<T>
     /// </remarks>
     public override Tensor<T> Forward(Tensor<T> input)
     {
+        // Lazy-ctor instances start with _inputChannels = -1; resolve from
+        // input.Shape on first call. Eager-ctor instances are already
+        // initialized so both calls are no-ops.
+        if (!IsShapeResolved) OnFirstForward(input);
+        EnsureInitialized();
+
         // Store original shape for any-rank tensor support
         _originalInputShape = input._shape;
         int rank = input.Shape.Length;

--- a/src/NeuralNetworks/Layers/RBFLayer.cs
+++ b/src/NeuralNetworks/Layers/RBFLayer.cs
@@ -119,9 +119,18 @@ public partial class RBFLayer<T> : LayerBase<T>
     private readonly int _numCenters;
 
     /// <summary>
+    /// Lazy-init flag. False after the lazy ctor until OnFirstForward
+    /// resolves _inputSize and EnsureInitialized allocates parameter
+    /// tensors. True after construction for the eager ctor path.
+    /// </summary>
+    private bool _isInitialized;
+
+    /// <summary>
     /// Number of input features.
     /// </summary>
-    private readonly int _inputSize;
+    // Non-readonly: the lazy ctor leaves this as -1 until OnFirstForward
+    // resolves it from input.Shape[^1]. Eager ctor sets it at construction.
+    private int _inputSize;
 
     /// <summary>
     /// Gets a value indicating whether this layer supports training.
@@ -216,6 +225,78 @@ public partial class RBFLayer<T> : LayerBase<T>
         _rbf = rbf;
 
         InitializeParameters();
+        _isInitialized = true;
+    }
+
+    /// <summary>
+    /// Lazy constructor: resolves <c>inputSize</c> from <c>input.Shape[^1]</c>
+    /// on first <see cref="Forward"/>. <paramref name="outputSize"/> (the
+    /// number of RBF centers / output neurons) is architectural and stays
+    /// required; only the input feature dimension is shape-dependent.
+    /// </summary>
+    /// <param name="outputSize">Number of RBF neurons (centers).</param>
+    /// <param name="rbf">Radial basis function implementation.</param>
+    /// <param name="initializationStrategy">Optional weight init strategy.</param>
+    public RBFLayer(int outputSize, IRadialBasisFunction<T> rbf,
+        IInitializationStrategy<T>? initializationStrategy = null)
+        : base([-1], [outputSize])
+    {
+        if (outputSize <= 0)
+            throw new ArgumentOutOfRangeException(nameof(outputSize), "Output size (number of RBF centers) must be positive.");
+
+        InitializationStrategy = initializationStrategy ?? Initialization.InitializationStrategies<T>.Eager;
+        _inputSize = -1;
+        _numCenters = outputSize;
+        // Empty placeholders — EnsureInitialized re-allocates against
+        // resolved _inputSize. Keeping the not-null reference contract
+        // intact for code paths that walk these fields unconditionally.
+        _centers = new Tensor<T>([0, 0]);
+        _widths = new Tensor<T>([0]);
+        _rbf = rbf;
+        _isInitialized = false;
+    }
+
+    /// <inheritdoc />
+    /// <remarks>
+    /// Reads the input feature count from <c>input.Shape[^1]</c> and
+    /// resolves the lazy shape so the rest of the forward pass + parameter
+    /// access can index against a real <c>InputShape[0]</c>.
+    /// </remarks>
+    protected override void OnFirstForward(Tensor<T> input)
+    {
+        int rank = input.Shape.Length;
+        if (rank < 1)
+            throw new ArgumentException(
+                $"RBFLayer requires rank>=1 input; got rank {rank}.", nameof(input));
+
+        int inputSize = input.Shape[rank - 1];
+        if (inputSize <= 0)
+            throw new ArgumentException(
+                $"RBFLayer's input feature dimension must be positive; got {inputSize} from input shape.",
+                nameof(input));
+
+        _inputSize = inputSize;
+        ResolveShapes(new[] { inputSize }, OutputShape);
+    }
+
+    /// <inheritdoc />
+    /// <remarks>
+    /// Lazy initialization: allocate centers and widths against the resolved
+    /// <c>_inputSize</c> and run RBF parameter initialization. Eager-ctor
+    /// instances bypass this path because <see cref="_isInitialized"/> is
+    /// set to true at construction.
+    /// </remarks>
+    protected override void EnsureInitialized()
+    {
+        if (_isInitialized) return;
+        if (_inputSize <= 0)
+            throw new InvalidOperationException(
+                "RBFLayer cannot initialize until OnFirstForward has resolved the input feature dimension from input shape.");
+
+        _centers = new Tensor<T>([_numCenters, _inputSize]);
+        _widths = new Tensor<T>([_numCenters]);
+        InitializeParameters();
+        _isInitialized = true;
     }
 
     /// <summary>
@@ -246,6 +327,12 @@ public partial class RBFLayer<T> : LayerBase<T>
     /// </remarks>
     public override Tensor<T> Forward(Tensor<T> input)
     {
+        // Lazy-ctor instances start with _inputSize = -1; resolve from
+        // input.Shape on first call, then materialize parameter tensors.
+        // Eager-ctor instances are already initialized so both calls no-op.
+        if (!IsShapeResolved) OnFirstForward(input);
+        EnsureInitialized();
+
         // Handle unbatched input (1D) by adding batch dimension
         bool wasUnbatched = input.Rank == 1;
         var processedInput = wasUnbatched

--- a/src/NeuralNetworks/Layers/RBFLayer.cs
+++ b/src/NeuralNetworks/Layers/RBFLayer.cs
@@ -170,6 +170,15 @@ public partial class RBFLayer<T> : LayerBase<T>
         if (Engine is not DirectGpuTensorEngine gpuEngine)
             throw new InvalidOperationException("ForwardGpu requires DirectGpuTensorEngine.");
 
+        // Mirror the CPU Forward's lazy-init dispatch — without this, a
+        // lazy-ctor RBFLayer that takes the GPU path on first use would
+        // send the [0,0] / [0] zero-sized centers / widths placeholders
+        // into RbfKernelGpu. OnFirstForward resolves _inputSize from
+        // input.Shape and EnsureInitialized allocates the parameter
+        // tensors at the right size.
+        if (!IsShapeResolved) OnFirstForward(input);
+        EnsureInitialized();
+
         // Input: [batch, inputSize] (ensure 2D)
         int batch = input.Shape[0];
         var input2D = input.Shape.Length == 1 ? gpuEngine.ReshapeGpu(input, [1, input.Shape[0]]) : input;
@@ -492,6 +501,22 @@ public partial class RBFLayer<T> : LayerBase<T>
     /// </remarks>
     public override void SetParameters(Vector<T> parameters)
     {
+        // Lazy-state guard: the lazy ctor leaves _inputSize = -1 until
+        // OnFirstForward fires. Without this check, a caller passing an
+        // empty Vector that matches the lazy-state ParameterCount==0
+        // would still hit `_numCenters * -1` below and trip a negative-
+        // length slice. Surface a clear contract violation instead so
+        // users know to run a Forward first.
+        if (_inputSize <= 0)
+        {
+            throw new InvalidOperationException(
+                "RBFLayer.SetParameters(): the layer was constructed via the lazy ctor " +
+                "(no inputSize arg) and has not yet seen a Forward call, so its parameter " +
+                "tensors are not yet allocated. Run at least one Forward(input) to resolve " +
+                "the input dimension before loading parameters, or construct via the " +
+                "eager ctor with an explicit inputSize.");
+        }
+
         int centersSize = _numCenters * _inputSize;
         int totalParams = centersSize + _numCenters;
 

--- a/src/NeuralNetworks/Layers/RBMLayer.cs
+++ b/src/NeuralNetworks/Layers/RBMLayer.cs
@@ -51,7 +51,24 @@ public partial class RBMLayer<T> : LayerBase<T>
     /// This number must match the dimensionality of your input data.
     /// </para>
     /// </remarks>
-    private readonly int _visibleUnits;
+    /// <summary>
+    /// Visible-unit count. Non-readonly so the lazy ctor can leave it
+    /// uninitialised (sentinel <c>-1</c>) and the first <c>Forward</c>
+    /// fills it from <c>input.Shape[^1]</c> via <see cref="OnFirstForward"/>.
+    /// Eager ctors set it immediately so the <c>Forward</c> path's
+    /// <see cref="EnsureInitialized"/> call is a no-op.
+    /// </summary>
+    private int _visibleUnits;
+
+    /// <summary>
+    /// Tracks whether weights / biases have been materialized. Lazy ctor
+    /// defers materialization until first <c>Forward</c> resolves the
+    /// visible-unit count from input shape.
+    /// </summary>
+    private bool _isInitialized;
+
+    /// <inheritdoc />
+    public override bool IsInitialized => _isInitialized;
 
     /// <summary>
     /// Gets the number of units in the hidden layer.
@@ -288,6 +305,76 @@ public partial class RBMLayer<T> : LayerBase<T>
         _hiddenBiases = new Tensor<T>([_hiddenUnits]);
 
         InitializeParameters();
+        _isInitialized = true;
+    }
+
+    /// <summary>
+    /// Lazy ctor — visible-unit count is resolved from <c>input.Shape[^1]</c>
+    /// on the first <c>Forward</c> call. Use this for new code that should
+    /// adopt the PyTorch-style lazy shape inference pattern; the eager
+    /// <c>(int visibleUnits, ...)</c> overload remains for callers that
+    /// know the visible dim at construction time.
+    /// </summary>
+    /// <param name="hiddenUnits">Number of hidden units (architectural,
+    /// independent of input shape).</param>
+    /// <param name="scalarActivation">Activation function (defaults to
+    /// <see cref="SigmoidActivation{T}"/>).</param>
+    public RBMLayer(int hiddenUnits, IActivationFunction<T>? scalarActivation = null)
+        : base([-1], [hiddenUnits], scalarActivation ?? new SigmoidActivation<T>())
+    {
+        if (hiddenUnits <= 0)
+            throw new ArgumentOutOfRangeException(nameof(hiddenUnits), "Hidden unit count must be positive.");
+
+        _visibleUnits = -1;
+        _hiddenUnits = hiddenUnits;
+        _weights = new Tensor<T>([0, 0]);
+        _visibleBiases = new Tensor<T>([0]);
+        _hiddenBiases = new Tensor<T>([_hiddenUnits]);
+        _isInitialized = false;
+    }
+
+    /// <inheritdoc />
+    /// <remarks>
+    /// Reads the visible-unit count from <c>input.Shape[^1]</c> and resolves
+    /// the lazy shape so subsequent forward / parameter / serialization
+    /// paths can index against a real <c>InputShape[0]</c>.
+    /// </remarks>
+    protected override void OnFirstForward(Tensor<T> input)
+    {
+        int rank = input.Shape.Length;
+        if (rank < 1)
+            throw new ArgumentException(
+                $"RBMLayer requires rank>=1 input; got rank {rank}.", nameof(input));
+
+        int visibleUnits = input.Shape[rank - 1];
+        if (visibleUnits <= 0)
+            throw new ArgumentException(
+                $"RBMLayer's visible-unit count must be positive; got {visibleUnits} from input shape.",
+                nameof(input));
+
+        _visibleUnits = visibleUnits;
+        ResolveShapes(new[] { visibleUnits }, OutputShape);
+    }
+
+    /// <inheritdoc />
+    /// <remarks>
+    /// Lazy initialization: allocate weights / biases against the resolved
+    /// visible-unit count and run Xavier initialization. Eager-ctor
+    /// instances bypass this path because <see cref="_isInitialized"/> is
+    /// set to true at construction.
+    /// </remarks>
+    protected override void EnsureInitialized()
+    {
+        if (_isInitialized) return;
+        if (_visibleUnits <= 0)
+            throw new InvalidOperationException(
+                "RBMLayer cannot initialize until OnFirstForward has resolved the visible-unit count from input shape.");
+
+        _weights = new Tensor<T>([_hiddenUnits, _visibleUnits]);
+        _visibleBiases = new Tensor<T>([_visibleUnits]);
+        _hiddenBiases = new Tensor<T>([_hiddenUnits]);
+        InitializeParameters();
+        _isInitialized = true;
     }
 
     /// <summary>
@@ -324,6 +411,7 @@ public partial class RBMLayer<T> : LayerBase<T>
         _hiddenBiases = new Tensor<T>([_hiddenUnits]);
 
         InitializeParameters();
+        _isInitialized = true;
     }
 
     /// <summary>
@@ -394,6 +482,12 @@ public partial class RBMLayer<T> : LayerBase<T>
     /// </remarks>
     public override Tensor<T> Forward(Tensor<T> input)
     {
+        // Lazy ctor uses _visibleUnits = -1 sentinel until first forward.
+        // OnFirstForward + EnsureInitialized run from the base's
+        // IsShapeResolved guard for layers that have lazy state.
+        if (!IsShapeResolved) OnFirstForward(input);
+        EnsureInitialized();
+
         _originalInputShape = input._shape;
         int rank = input.Shape.Length;
         if (rank < 1)
@@ -443,6 +537,9 @@ public partial class RBMLayer<T> : LayerBase<T>
             throw new InvalidOperationException("ForwardGpu requires a DirectGpuTensorEngine.");
 
         var input = inputs[0];
+        // Lazy-ctor guard: same as CPU Forward.
+        if (!IsShapeResolved) OnFirstForward(input);
+        EnsureInitialized();
         _originalInputShape = input._shape;
 
         int rank = input.Shape.Length;
@@ -543,6 +640,11 @@ public partial class RBMLayer<T> : LayerBase<T>
     /// </summary>
     private void TrainWithContrastiveDivergenceTensor(Tensor<T> input, T learningRate, int kSteps = 1)
     {
+        // Lazy-ctor guard: ContrastiveDivergence training reads _visibleUnits
+        // and the weight matrices, so they need to be resolved+materialized.
+        if (!IsShapeResolved) OnFirstForward(input);
+        EnsureInitialized();
+
         int rank = input.Shape.Length;
         if (rank < 1)
             throw new ArgumentException("Input must have at least one dimension.", nameof(input));
@@ -944,7 +1046,13 @@ public partial class RBMLayer<T> : LayerBase<T>
     /// <summary>
     /// Gets the total number of trainable parameters in the layer.
     /// </summary>
-    public override int ParameterCount => _visibleUnits * _hiddenUnits + _visibleUnits + _hiddenUnits;
+    public override int ParameterCount =>
+        _visibleUnits > 0
+            ? _visibleUnits * _hiddenUnits + _visibleUnits + _hiddenUnits
+            // Lazy-ctor instance hasn't seen its first Forward yet — visible
+            // dim is unknown, so the only parameter we can count is the
+            // hidden-bias vector that the ctor allocates eagerly.
+            : _hiddenUnits;
 
     /// <summary>
     /// Indicates whether this layer supports training.

--- a/src/NeuralNetworks/Layers/RBMLayer.cs
+++ b/src/NeuralNetworks/Layers/RBMLayer.cs
@@ -327,9 +327,16 @@ public partial class RBMLayer<T> : LayerBase<T>
 
         _visibleUnits = -1;
         _hiddenUnits = hiddenUnits;
+        // All parameter tensors get re-allocated in EnsureInitialized once
+        // the visible dimension is resolved on first forward; allocate
+        // empty placeholders here so the not-null reference contract holds
+        // (GetParameters / ClearGradients walk these fields unconditionally)
+        // without doing duplicate work the lazy path will redo. Pre-fix the
+        // hidden-bias was allocated at full size here AND re-allocated in
+        // EnsureInitialized, leaking the first tensor.
         _weights = new Tensor<T>([0, 0]);
         _visibleBiases = new Tensor<T>([0]);
-        _hiddenBiases = new Tensor<T>([_hiddenUnits]);
+        _hiddenBiases = new Tensor<T>([0]);
         _isInitialized = false;
     }
 
@@ -1050,9 +1057,13 @@ public partial class RBMLayer<T> : LayerBase<T>
         _visibleUnits > 0
             ? _visibleUnits * _hiddenUnits + _visibleUnits + _hiddenUnits
             // Lazy-ctor instance hasn't seen its first Forward yet — visible
-            // dim is unknown, so the only parameter we can count is the
-            // hidden-bias vector that the ctor allocates eagerly.
-            : _hiddenUnits;
+            // dim is unknown, all parameter tensors are zero-sized
+            // placeholders, and EnsureInitialized hasn't run. Reporting a
+            // count that doesn't match the actual GetParameters().Length
+            // would break the optimizer's per-parameter state allocation
+            // (it sizes its bookkeeping arrays from ParameterCount and
+            // walks GetParameters() to fill them).
+            : 0;
 
     /// <summary>
     /// Indicates whether this layer supports training.

--- a/tests/AiDotNet.Tests/IntegrationTests/NeuralNetworks/CompositeLayerLazyCtorIssue1213Tests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/NeuralNetworks/CompositeLayerLazyCtorIssue1213Tests.cs
@@ -59,6 +59,11 @@ public class CompositeLayerLazyCtorIssue1213Tests
         Assert.False(layer.IsShapeResolved);
         Assert.Equal(-1, layer.GetInputShape()[0]);
         Assert.Equal(4, layer.GetOutputShape()[0]);
+        // Pre-Forward: parameters not yet allocated. ParameterCount must
+        // equal GetParameters().Length so the optimizer doesn't size its
+        // bookkeeping for state that doesn't yet exist.
+        Assert.Equal(0, layer.ParameterCount);
+        Assert.Equal(0, layer.GetParameters().Length);
 
         var input = new Tensor<float>(new[] { 2, 6 });
         for (int i = 0; i < input.Length; i++) input[i] = (float)(i * 0.05);
@@ -80,6 +85,12 @@ public class CompositeLayerLazyCtorIssue1213Tests
         Assert.False(layer.IsShapeResolved);
         Assert.Equal(-1, layer.GetInputShape()[0]);
         Assert.Equal(5, layer.GetInputShape()[1]);
+        // CRF's parameters depend only on numClasses (architectural), so
+        // they ARE allocated eagerly in the lazy ctor — only InputShape /
+        // OutputShape are deferred. ParameterCount is the full numClasses-
+        // based total before first forward.
+        Assert.Equal(5 * 5 + 5 + 5, layer.ParameterCount);
+        Assert.Equal(layer.ParameterCount, layer.GetParameters().Length);
 
         // CRF expects [seqLen, numClasses] per-batch input.
         var input = new Tensor<float>(new[] { 7, 5 });
@@ -106,6 +117,9 @@ public class CompositeLayerLazyCtorIssue1213Tests
         Assert.False(layer.IsShapeResolved);
         Assert.Equal(-1, layer.GetInputShape()[0]);
         Assert.Equal(4 * 2, layer.GetOutputShape()[0]);
+        // Pre-Forward: conv weights / bias not yet allocated.
+        Assert.Equal(0, layer.ParameterCount);
+        Assert.Equal(0, layer.GetParameters().Length);
 
         // NCHW input: [batch, channels, h, w]
         var input = new Tensor<float>(new[] { 1, 3, 5, 5 });
@@ -130,6 +144,9 @@ public class CompositeLayerLazyCtorIssue1213Tests
         Assert.False(layer.IsShapeResolved);
         Assert.Equal(-1, layer.GetInputShape()[0]);
         Assert.Equal(-1, layer.GetInputShape()[1]);
+        // Pre-Forward: routing weights not yet allocated.
+        Assert.Equal(0, layer.ParameterCount);
+        Assert.Equal(0, layer.GetParameters().Length);
 
         // Input: [batch, inputCapsules, inputCapsuleDimension]
         var input = new Tensor<float>(new[] { 1, 6, 8 });
@@ -158,6 +175,9 @@ public class CompositeLayerLazyCtorIssue1213Tests
             outputShape: new[] { 8 });
 
         Assert.False(expert.IsShapeResolved);
+        // Pre-Forward: inner Dense layers are unresolved, so each
+        // reports ParameterCount=0; the outer Expert sums to 0.
+        Assert.Equal(0, expert.ParameterCount);
 
         var input = new Tensor<float>(new[] { 2, 32 });
         for (int i = 0; i < input.Length; i++) input[i] = (float)(i * 0.01);
@@ -188,6 +208,8 @@ public class CompositeLayerLazyCtorIssue1213Tests
             outputShape: new[] { 8 });
 
         Assert.False(moe.IsShapeResolved);
+        // Pre-Forward: router and experts unresolved; outer MoE sums to 0.
+        Assert.Equal(0, moe.ParameterCount);
 
         // Vanilla MoE input: [batch, features].
         var input = new Tensor<float>(new[] { 1, 12 });

--- a/tests/AiDotNet.Tests/IntegrationTests/NeuralNetworks/CompositeLayerLazyCtorIssue1213Tests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/NeuralNetworks/CompositeLayerLazyCtorIssue1213Tests.cs
@@ -1,0 +1,202 @@
+using AiDotNet.ActivationFunctions;
+using AiDotNet.Interfaces;
+using AiDotNet.NeuralNetworks.Layers;
+using AiDotNet.RadialBasisFunctions;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tests.IntegrationTests.NeuralNetworks;
+
+/// <summary>
+/// Regression coverage for issue #1213's lazy-ctor migration of the
+/// remaining composite layers (ObliviousDecisionTree, RBF, CRF,
+/// PrimaryCapsule, DigitCapsule, MoE, ExpertLayer). RBMLayer is covered
+/// separately by <see cref="RBMLayerLazyCtorIssue1213Tests"/>.
+///
+/// Each test follows the same shape-resolve contract:
+///   1. Construct via the architectural-only lazy ctor (no input-dim
+///      args, just architectural params: capsule counts, output classes,
+///      tree depth, etc.).
+///   2. Assert <see cref="LayerBase{T}.IsShapeResolved"/> is false and
+///      ParameterCount is 0 (no parameters allocated yet).
+///   3. Run a Forward with a real input tensor.
+///   4. Assert IsShapeResolved is now true, ParameterCount matches the
+///      full materialized count, and the output shape matches the
+///      architectural expectation.
+/// </summary>
+public class CompositeLayerLazyCtorIssue1213Tests
+{
+    [Fact]
+    public void ObliviousDecisionTree_LazyCtor_ResolvesShape_OnFirstForward()
+    {
+        using var layer = new ObliviousDecisionTreeLayer<float>(depth: 3, outputDim: 2);
+
+        Assert.False(layer.IsShapeResolved);
+        Assert.Equal(-1, layer.GetInputShape()[0]);
+        Assert.Equal(2, layer.GetOutputShape()[0]);
+        Assert.Equal(0, layer.ParameterCount);
+
+        var input = new Tensor<float>(new[] { 4, 5 });
+        for (int i = 0; i < input.Length; i++) input[i] = (float)((i + 1) * 0.1);
+
+        var output = layer.Forward(input);
+
+        Assert.True(layer.IsShapeResolved);
+        Assert.Equal(5, layer.GetInputShape()[0]);
+        Assert.Equal(2, layer.GetOutputShape()[0]);
+        // Expected: depth*inputDim + depth + numLeaves*outputDim
+        //         = 3*5      +     3 + 8*2 = 34.
+        Assert.Equal(3 * 5 + 3 + 8 * 2, layer.ParameterCount);
+        Assert.Equal(2, output.Shape[1]);
+    }
+
+    [Fact]
+    public void RBF_LazyCtor_ResolvesShape_OnFirstForward()
+    {
+        var rbf = new GaussianRBF<float>();
+        using var layer = new RBFLayer<float>(outputSize: 4, rbf: rbf);
+
+        Assert.False(layer.IsShapeResolved);
+        Assert.Equal(-1, layer.GetInputShape()[0]);
+        Assert.Equal(4, layer.GetOutputShape()[0]);
+
+        var input = new Tensor<float>(new[] { 2, 6 });
+        for (int i = 0; i < input.Length; i++) input[i] = (float)(i * 0.05);
+
+        var output = layer.Forward(input);
+
+        Assert.True(layer.IsShapeResolved);
+        Assert.Equal(6, layer.GetInputShape()[0]);
+        Assert.Equal(4, layer.GetOutputShape()[0]);
+        // RBF parameters = numCenters * inputSize (centers) + numCenters (widths)
+        Assert.Equal(4 * 6 + 4, layer.ParameterCount);
+    }
+
+    [Fact]
+    public void CRF_LazyCtor_ResolvesShape_OnFirstForward()
+    {
+        using var layer = new ConditionalRandomFieldLayer<float>(numClasses: 5);
+
+        Assert.False(layer.IsShapeResolved);
+        Assert.Equal(-1, layer.GetInputShape()[0]);
+        Assert.Equal(5, layer.GetInputShape()[1]);
+
+        // CRF expects [seqLen, numClasses] per-batch input.
+        var input = new Tensor<float>(new[] { 7, 5 });
+        for (int i = 0; i < input.Length; i++) input[i] = (float)(i * 0.01);
+
+        var output = layer.Forward(input);
+
+        Assert.True(layer.IsShapeResolved);
+        Assert.Equal(7, layer.GetInputShape()[0]);
+        Assert.Equal(5, layer.GetInputShape()[1]);
+        // CRF parameters: numClasses^2 (transition) + numClasses (start) + numClasses (end)
+        Assert.Equal(5 * 5 + 5 + 5, layer.ParameterCount);
+    }
+
+    [Fact]
+    public void PrimaryCapsule_LazyCtor_ResolvesShape_OnFirstForward()
+    {
+        using var layer = new PrimaryCapsuleLayer<float>(
+            capsuleChannels: 4,
+            capsuleDimension: 2,
+            kernelSize: 3,
+            stride: 1);
+
+        Assert.False(layer.IsShapeResolved);
+        Assert.Equal(-1, layer.GetInputShape()[0]);
+        Assert.Equal(4 * 2, layer.GetOutputShape()[0]);
+
+        // NCHW input: [batch, channels, h, w]
+        var input = new Tensor<float>(new[] { 1, 3, 5, 5 });
+        for (int i = 0; i < input.Length; i++) input[i] = (float)(i * 0.001);
+
+        var output = layer.Forward(input);
+
+        Assert.True(layer.IsShapeResolved);
+        Assert.Equal(3, layer.GetInputShape()[0]);
+        // PrimaryCapsule conv: outputChannels * (inputChannels * kernelSize^2) + outputChannels
+        Assert.Equal((4 * 2) * (3 * 3 * 3) + (4 * 2), layer.ParameterCount);
+    }
+
+    [Fact]
+    public void DigitCapsule_LazyCtor_ResolvesShape_OnFirstForward()
+    {
+        using var layer = new DigitCapsuleLayer<float>(
+            numClasses: 10,
+            outputCapsuleDimension: 4,
+            routingIterations: 2);
+
+        Assert.False(layer.IsShapeResolved);
+        Assert.Equal(-1, layer.GetInputShape()[0]);
+        Assert.Equal(-1, layer.GetInputShape()[1]);
+
+        // Input: [batch, inputCapsules, inputCapsuleDimension]
+        var input = new Tensor<float>(new[] { 1, 6, 8 });
+        for (int i = 0; i < input.Length; i++) input[i] = (float)(i * 0.001);
+
+        var output = layer.Forward(input);
+
+        Assert.True(layer.IsShapeResolved);
+        Assert.Equal(6, layer.GetInputShape()[0]);
+        Assert.Equal(8, layer.GetInputShape()[1]);
+        // DigitCapsule weight: inputCapsules * numClasses * inputCapsuleDimension * outputCapsuleDimension
+        Assert.Equal(6 * 10 * 8 * 4, layer.ParameterCount);
+    }
+
+    [Fact]
+    public void ExpertLayer_LazyInnerLayers_ResolveOnFirstForward()
+    {
+        // ExpertLayer with lazy DenseLayer children — caller passes
+        // [-1] as inputShape so chain-resolve in the ctor is skipped
+        // and inner layers stay unresolved until first Forward.
+        var dense1 = new DenseLayer<float>(outputSize: 16, activationFunction: new IdentityActivation<float>());
+        var dense2 = new DenseLayer<float>(outputSize: 8, activationFunction: new IdentityActivation<float>());
+        using var expert = new ExpertLayer<float>(
+            new System.Collections.Generic.List<ILayer<float>> { dense1, dense2 },
+            inputShape: new[] { -1 },
+            outputShape: new[] { 8 });
+
+        Assert.False(expert.IsShapeResolved);
+
+        var input = new Tensor<float>(new[] { 2, 32 });
+        for (int i = 0; i < input.Length; i++) input[i] = (float)(i * 0.01);
+
+        var output = expert.Forward(input);
+
+        Assert.True(expert.IsShapeResolved);
+        Assert.Equal(32, expert.GetInputShape()[0]);
+        Assert.Equal(8, expert.GetOutputShape()[0]);
+        Assert.Equal(2, output.Shape[0]);
+        Assert.Equal(8, output.Shape[1]);
+    }
+
+    [Fact]
+    public void MoE_LazyCtor_ResolvesSubLayerShapes_OnFirstForward()
+    {
+        // Two trivial expert sub-layers, plus a router. All Dense, all
+        // lazy. Caller passes [-1] as inputShape so the MoE ctor's
+        // eager-resolve gate skips and sub-layers remain unresolved.
+        var expert1 = new DenseLayer<float>(outputSize: 8, activationFunction: new IdentityActivation<float>());
+        var expert2 = new DenseLayer<float>(outputSize: 8, activationFunction: new IdentityActivation<float>());
+        var router = new DenseLayer<float>(outputSize: 2, activationFunction: new IdentityActivation<float>());
+
+        using var moe = new MixtureOfExpertsLayer<float>(
+            experts: new System.Collections.Generic.List<ILayer<float>> { expert1, expert2 },
+            router: router,
+            inputShape: new[] { -1 },
+            outputShape: new[] { 8 });
+
+        Assert.False(moe.IsShapeResolved);
+
+        // Vanilla MoE input: [batch, features].
+        var input = new Tensor<float>(new[] { 1, 12 });
+        for (int i = 0; i < input.Length; i++) input[i] = (float)(i * 0.01);
+
+        var output = moe.Forward(input);
+
+        Assert.True(moe.IsShapeResolved);
+        Assert.Equal(12, moe.GetInputShape()[0]);
+        Assert.Equal(1, output.Shape[0]);
+    }
+}

--- a/tests/AiDotNet.Tests/IntegrationTests/NeuralNetworks/CompositeLayerLazyCtorIssue1213Tests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/NeuralNetworks/CompositeLayerLazyCtorIssue1213Tests.cs
@@ -189,6 +189,14 @@ public class CompositeLayerLazyCtorIssue1213Tests
         Assert.Equal(8, expert.GetOutputShape()[0]);
         Assert.Equal(2, output.Shape[0]);
         Assert.Equal(8, output.Shape[1]);
+
+        // Verify parameters were materialized post-forward, complementing
+        // the pre-forward `ParameterCount == 0` assertion above. Without
+        // this check the test would still pass even if lazy resolution
+        // silently failed to allocate weights.
+        // dense1: 32→16 (32*16 + 16 bias = 528). dense2: 16→8 (16*8 + 8 bias = 136).
+        int expectedParams = (32 * 16 + 16) + (16 * 8 + 8);
+        Assert.Equal(expectedParams, expert.ParameterCount);
     }
 
     [Fact]
@@ -220,5 +228,17 @@ public class CompositeLayerLazyCtorIssue1213Tests
         Assert.True(moe.IsShapeResolved);
         Assert.Equal(12, moe.GetInputShape()[0]);
         Assert.Equal(1, output.Shape[0]);
+        // Confirm the output's feature dim matches what the resolved
+        // experts produce (8), not just any rank-2 tensor — the layer's
+        // shape contract guarantees [batch, outputFeatures].
+        Assert.Equal(8, output.Shape[1]);
+
+        // Verify parameters were materialized post-forward. Pre-forward
+        // ParameterCount==0 only confirms lazy resolution was deferred;
+        // a positive count after the first Forward proves the chained
+        // resolution actually allocated weights for router + experts.
+        // expert1/2: 12→8 (12*8 + 8 bias = 104 each). router: 12→2 (12*2 + 2 = 26).
+        int expectedParams = 2 * (12 * 8 + 8) + (12 * 2 + 2);
+        Assert.Equal(expectedParams, moe.ParameterCount);
     }
 }

--- a/tests/AiDotNet.Tests/IntegrationTests/NeuralNetworks/RBMLayerLazyCtorIssue1213Tests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/NeuralNetworks/RBMLayerLazyCtorIssue1213Tests.cs
@@ -27,13 +27,15 @@ public class RBMLayerLazyCtorIssue1213Tests
         using var layer = new RBMLayer<float>(hiddenUnits: 8);
 
         // Pre-Forward: lazy state. Visible dim is unknown → InputShape
-        // contains the -1 sentinel, weights matrix is [0, 0], and
-        // ParameterCount counts only the hidden-bias vector.
+        // contains the -1 sentinel, all parameter tensors are zero-sized
+        // placeholders, and ParameterCount returns 0 — matching the
+        // actual GetParameters().Length so the optimizer's per-parameter
+        // bookkeeping isn't sized for state that doesn't yet exist.
         Assert.False(layer.IsShapeResolved);
         Assert.False(layer.IsInitialized);
         Assert.Equal(-1, layer.GetInputShape()[0]);
         Assert.Equal(8, layer.GetOutputShape()[0]);
-        Assert.Equal(8, layer.ParameterCount);
+        Assert.Equal(0, layer.ParameterCount);
 
         // First Forward: rank-2 input [batch=2, visible=4]. Layer must
         // resolve visibleUnits = 4 from input.Shape[^1] and materialize
@@ -110,17 +112,36 @@ public class RBMLayerLazyCtorIssue1213Tests
     }
 
     /// <summary>
-    /// Lazy ctor rejects degenerate input shape. A rank-0 (scalar) or
-    /// rank-1 with non-positive last dim can't be a valid RBM input —
-    /// surface this as ArgumentException at first Forward instead of
-    /// silently allocating a 0-sized weight matrix.
+    /// Lazy ctor rejects degenerate input shape. A rank-1 tensor with shape
+    /// [0] (zero visible units) can't be a valid RBM input — surface this
+    /// as ArgumentException at first Forward instead of silently
+    /// allocating a 0-sized weight matrix. Note: this exercises only the
+    /// non-positive-visible-units branch of OnFirstForward; the
+    /// rank&lt;1 branch is exercised by
+    /// <see cref="LazyCtor_RejectsScalarInput"/>.
     /// </summary>
     [Fact]
-    public void LazyCtor_RejectsDegenerateInput()
+    public void LazyCtor_RejectsZeroVisibleUnitsInput()
     {
         using var layer = new RBMLayer<float>(hiddenUnits: 8);
 
-        var rank0 = new Tensor<float>(new int[] { 0 });
-        Assert.Throws<System.ArgumentException>(() => layer.Forward(rank0));
+        var rank1ZeroLength = new Tensor<float>(new int[] { 0 });
+        Assert.Throws<System.ArgumentException>(() => layer.Forward(rank1ZeroLength));
+    }
+
+    /// <summary>
+    /// Lazy ctor rejects rank-0 (true scalar) input. OnFirstForward's
+    /// rank&lt;1 guard fires before the visible-unit check, since a
+    /// scalar has no last dimension to read a visible-unit count from.
+    /// Pairs with <see cref="LazyCtor_RejectsZeroVisibleUnitsInput"/> to
+    /// cover both degenerate-input branches.
+    /// </summary>
+    [Fact]
+    public void LazyCtor_RejectsScalarInput()
+    {
+        using var layer = new RBMLayer<float>(hiddenUnits: 8);
+
+        var scalar = new Tensor<float>(System.Array.Empty<int>());
+        Assert.Throws<System.ArgumentException>(() => layer.Forward(scalar));
     }
 }

--- a/tests/AiDotNet.Tests/IntegrationTests/NeuralNetworks/RBMLayerLazyCtorIssue1213Tests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/NeuralNetworks/RBMLayerLazyCtorIssue1213Tests.cs
@@ -1,0 +1,126 @@
+using AiDotNet.NeuralNetworks.Layers;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tests.IntegrationTests.NeuralNetworks;
+
+/// <summary>
+/// Regression coverage for issue #1213's lazy-ctor migration of composite
+/// layers — first reference impl is <see cref="RBMLayer{T}"/>. The new
+/// constructor takes only the architectural hidden-unit count; visible-unit
+/// count is resolved from <c>input.Shape[^1]</c> on first
+/// <see cref="ILayer{T}.Forward(Tensor{T})"/>.
+/// </summary>
+public class RBMLayerLazyCtorIssue1213Tests
+{
+    /// <summary>
+    /// Lazy ctor: pre-Forward instance reports hidden-bias-only
+    /// <see cref="LayerBase{T}.ParameterCount"/>; first Forward resolves
+    /// visible dim from input shape and the count jumps to the full
+    /// (visible×hidden + visible + hidden) total. This is the canonical
+    /// lazy-shape contract from #1209 applied to a composite layer.
+    /// </summary>
+    [Fact]
+    public void LazyCtor_ResolvesShape_OnFirstForward()
+    {
+        // Architectural-only ctor — no visibleUnits arg.
+        using var layer = new RBMLayer<float>(hiddenUnits: 8);
+
+        // Pre-Forward: lazy state. Visible dim is unknown → InputShape
+        // contains the -1 sentinel, weights matrix is [0, 0], and
+        // ParameterCount counts only the hidden-bias vector.
+        Assert.False(layer.IsShapeResolved);
+        Assert.False(layer.IsInitialized);
+        Assert.Equal(-1, layer.GetInputShape()[0]);
+        Assert.Equal(8, layer.GetOutputShape()[0]);
+        Assert.Equal(8, layer.ParameterCount);
+
+        // First Forward: rank-2 input [batch=2, visible=4]. Layer must
+        // resolve visibleUnits = 4 from input.Shape[^1] and materialize
+        // the [hidden, visible] weight matrix + visible-bias vector.
+        var input = new Tensor<float>(new[] { 2, 4 });
+        for (int i = 0; i < input.Length; i++) input[i] = (float)((i + 1) * 0.1);
+
+        var output = layer.Forward(input);
+
+        // Post-Forward: shape resolved.
+        Assert.True(layer.IsShapeResolved);
+        Assert.True(layer.IsInitialized);
+        Assert.Equal(4, layer.GetInputShape()[0]);
+        Assert.Equal(8, layer.GetOutputShape()[0]);
+
+        // ParameterCount jumps to full RBM total: weights (8×4 = 32)
+        // + visible biases (4) + hidden biases (8) = 44.
+        Assert.Equal(44, layer.ParameterCount);
+
+        // Output shape: [batch=2, hidden=8] — same rank as input,
+        // last axis swapped from visible to hidden.
+        Assert.Equal(2, output.Rank);
+        Assert.Equal(2, output.Shape[0]);
+        Assert.Equal(8, output.Shape[1]);
+    }
+
+    /// <summary>
+    /// Lazy and eager ctors must produce identical outputs once both have
+    /// the same visible dim resolved. This proves the lazy path doesn't
+    /// regress numerics — it only defers shape resolution, not changes the
+    /// math. Same seed via the layer's internal initializer so weight init
+    /// is identical between the two instances.
+    /// </summary>
+    [Fact]
+    public void LazyCtor_MatchesEagerCtor_AfterSameForward()
+    {
+        const int visible = 4;
+        const int hidden = 8;
+
+        var input = new Tensor<float>(new[] { 1, visible });
+        for (int i = 0; i < input.Length; i++) input[i] = (float)((i + 1) * 0.1);
+
+        // Eager: visible dim known at ctor time. Pass null activation
+        // explicitly typed to disambiguate from the IVectorActivationFunction
+        // overload (both ctors take three int + nullable-activation params).
+        using var eager = new RBMLayer<float>(visible, hidden, (AiDotNet.Interfaces.IActivationFunction<float>?)null);
+        // Lazy: visible dim resolved on first Forward.
+        using var lazy = new RBMLayer<float>(hidden);
+
+        // Match parameters between the two instances so the math is
+        // bit-identical regardless of init RNG. RBMLayer's eager ctor
+        // runs Xavier init at construction; lazy runs Xavier in
+        // EnsureInitialized triggered by first Forward. Force the lazy
+        // path to materialize first, then copy eager's params over.
+        _ = lazy.Forward(input);
+        lazy.SetParameters(eager.GetParameters());
+
+        var eagerOut = eager.Forward(input);
+        var lazyOut = lazy.Forward(input);
+
+        Assert.Equal(eagerOut.Length, lazyOut.Length);
+        for (int i = 0; i < eagerOut.Length; i++)
+        {
+            // Sigmoid output: bounded [0, 1]. Tolerance 1e-5 is
+            // comfortably below any float-rounding drift between the two
+            // forward paths (which run identical engine ops on identical
+            // tensors).
+            Assert.True(System.Math.Abs(eagerOut[i] - lazyOut[i]) < 1e-5f,
+                $"Lazy ctor output[{i}] = {lazyOut[i]:G7} differs from eager " +
+                $"output[{i}] = {eagerOut[i]:G7} after parameter sync. " +
+                $"The lazy path should produce numerically identical " +
+                $"results once shape is resolved and parameters match.");
+        }
+    }
+
+    /// <summary>
+    /// Lazy ctor rejects degenerate input shape. A rank-0 (scalar) or
+    /// rank-1 with non-positive last dim can't be a valid RBM input —
+    /// surface this as ArgumentException at first Forward instead of
+    /// silently allocating a 0-sized weight matrix.
+    /// </summary>
+    [Fact]
+    public void LazyCtor_RejectsDegenerateInput()
+    {
+        using var layer = new RBMLayer<float>(hiddenUnits: 8);
+
+        var rank0 = new Tensor<float>(new int[] { 0 });
+        Assert.Throws<System.ArgumentException>(() => layer.Forward(rank0));
+    }
+}


### PR DESCRIPTION
Closes #1213.

Migrates all ~9 composite/specialized layers from issue #1213 to PyTorch-style lazy shape inference: shape-dependent params resolved on first `Forward` via `OnFirstForward(input)` + `EnsureInitialized()` overrides, mirroring the pattern #1209 established for spatial- and feature-rigid layers.

## Layers migrated

- **RBMLayer** — `(int hiddenUnits, IActivationFunction<T>?)`; `_visibleUnits` resolved from `input.Shape[^1]`.
- **CapsuleLayer** — already migrated in #1209's tail; verified the `[-1, -1]` placeholder + `OnFirstForward` are in place. Listed here for completeness.
- **PrimaryCapsuleLayer** *(pending in this PR)* — `_inputChannels` from `input.Shape[1]` (NCHW).
- **DigitCapsuleLayer** *(pending)* — `_inputCapsules`, `_inputCapsuleDimension` from `input.Shape[^2..]`.
- **RBFLayer** *(pending)* — `_inputSize` from `input.Shape[^1]`.
- **ConditionalRandomFieldLayer** *(pending)* — `_sequenceLength` from `input.Shape[1]`.
- **ObliviousDecisionTreeLayer** *(pending)* — `_inputDim` from `input.Shape[^1]`.
- **ExpertLayer** *(pending)* — already accepts `[-1]` shapes via the `inputShape.All(d => d > 0)` gate; verified no further migration needed.
- **MixtureOfExpertsLayer** *(pending)* — `_inputDimension` resolved from `input.Shape[^1]`; per-expert input dim propagates to constituent ExpertLayer/Dense sub-layers.

## Approach

Per the issue's design guidance, **architectural** params (number of experts, capsule count, vocabulary size, depth, RBF count, output dim) stay required at construction. **Shape-dependent** params (input feature/channel/sequence dims) become lazy.

For each layer:
1. New ctor without the shape-dependent param(s).
2. `_isInitialized` flag + non-readonly shape fields so `OnFirstForward` can fill them.
3. `OnFirstForward(input)` reads shape from input and calls `ResolveShapes`.
4. `EnsureInitialized()` allocates parameter tensors against resolved shape and runs initialization.
5. Lazy regression tests verifying shape resolution, parameter materialization, ParameterCount-vs-GetParameters alignment, and degenerate-input rejection.

## Test plan
- [x] Build clean on net10.0 (0 errors).
- [x] All existing layer tests pass.
- [x] Lazy regression tests pass for each migrated layer.
- [x] No call-site breakage in src/ — eager ctors retained.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Layers (RBM, CRF, Digit/Primary Capsules, RBF, Oblivious Decision Tree, Expert, Mixture-of-Experts) gain lazy initialization: construct with architecture-only params, resolve input dimensions on first forward, and defer parameter allocation until needed. Parameter counts reflect unresolved state until materialization.

* **Bug Fixes**
  * First-forward guards added (including GPU path) and clearer errors for degenerate inputs or premature parameter sets.

* **Tests**
  * Added integration tests covering lazy construction, resolution, parameter sync, and error cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->