### PR TITLE
fix(licenses): email-on-issuance + admin copy-key & resend-email controls

### DIFF
--- a/src/Helpers/LicenseValidator.cs
+++ b/src/Helpers/LicenseValidator.cs
@@ -101,12 +101,23 @@ internal sealed class LicenseValidator
             // key. Until that lands, AIDN-* keys are server-only.
             if (!IsSignedKeyFormat(_licenseKey.Key))
             {
-                return new LicenseValidationResult(
-                    LicenseKeyStatus.Invalid,
-                    message: "Offline-only mode requires a signed license key (aidn.{id}.{signature} format). " +
-                             "Server-validated keys (AIDN-PROD-*, AIDN-DEV-*) require online validation — set ServerUrl " +
-                             "to null (default endpoint) or to a custom URL. To enable air-gapped operation, " +
-                             "request a signed license key from support.");
+                // Cache the rejection so the sync path matches ValidateAsync()
+                // (line ~461) and CachedResult is non-null after the first call.
+                // Without this, repeated Validate() calls allocate a fresh
+                // Invalid result each time and CachedResult stays null even
+                // though we've already decided this key can't validate.
+                lock (_cacheLock)
+                {
+                    if (_cached is not null) return _cached;
+                    var rejected = new LicenseValidationResult(
+                        LicenseKeyStatus.Invalid,
+                        message: "Offline-only mode requires a signed license key (aidn.{id}.{signature} format). " +
+                                 "Server-validated keys (AIDN-PROD-*, AIDN-DEV-*) require online validation — set ServerUrl " +
+                                 "to null (default endpoint) or to a custom URL. To enable air-gapped operation, " +
+                                 "request a signed license key from support.");
+                    _cached = rejected;
+                    return rejected;
+                }
             }
 
             // Return the cached result on repeat calls so reference equality holds —

--- a/src/Helpers/LicenseValidator.cs
+++ b/src/Helpers/LicenseValidator.cs
@@ -84,29 +84,45 @@ internal sealed class LicenseValidator
 
         if (explicitOfflineOnly)
         {
-            // Explicit offline mode — only signed keys (aidn.{id}.{sig}) are accepted.
-            // Return the cached result on repeat calls so reference equality
-            // holds: the public LicenseValidationResult API surfaces a
-            // defensive-copy DecryptionToken / Capabilities, and tests
-            // (and consumers) rely on Assert.Same(result1, result2) to
-            // distinguish "fresh validation" from "cache hit". Without
-            // this short-circuit, every call would re-run ValidateOffline
-            // and return a new instance even though nothing changed.
+            // Explicit offline mode — only HMAC-signed keys (aidn.{id}.{sig}) are
+            // accepted. Server-validated keys (AIDN-PROD-*, AIDN-DEV-*, etc.) MUST
+            // go through online validation against the license server because they
+            // carry no cryptographic signature the SDK can verify locally — the
+            // server is the only source of truth for their valid-vs-revoked status.
+            //
+            // Previously the offline path ALSO accepted AIDN-* keys (treated them
+            // as "valid format" and returned LicenseKeyStatus.Active without any
+            // cryptographic check), which is the security gap PR #1256 review
+            // flagged: anyone who guessed/forged a well-formed AIDN-PROD-* key
+            // would be granted Active status indefinitely in offline-only mode.
+            //
+            // Future work: add Ed25519-signed AIDN-{ENV}-{TIER}-{V}-{ID}-{SIG}
+            // format that CAN be validated offline against a SDK-shipped public
+            // key. Until that lands, AIDN-* keys are server-only.
+            if (!IsSignedKeyFormat(_licenseKey.Key))
+            {
+                return new LicenseValidationResult(
+                    LicenseKeyStatus.Invalid,
+                    message: "Offline-only mode requires a signed license key (aidn.{id}.{signature} format). " +
+                             "Server-validated keys (AIDN-PROD-*, AIDN-DEV-*) require online validation — set ServerUrl " +
+                             "to null (default endpoint) or to a custom URL. To enable air-gapped operation, " +
+                             "request a signed license key from support.");
+            }
+
+            // Return the cached result on repeat calls so reference equality holds —
+            // tests (and consumers) rely on Assert.Same(result1, result2) to
+            // distinguish "fresh validation" from "cache hit".
             lock (_cacheLock)
             {
-                if (_cached is not null)
-                {
-                    return _cached;
-                }
+                if (_cached is not null) return _cached;
             }
 
             var offlineResult = ValidateOffline();
             lock (_cacheLock)
             {
-                // Double-checked locking: another thread may have
-                // populated the cache while we were validating. Honour
-                // their instance to keep reference equality stable
-                // across concurrent first calls.
+                // Double-checked locking: another thread may have populated the
+                // cache while we were validating. Honour their instance to keep
+                // reference equality stable across concurrent first calls.
                 _cached ??= offlineResult;
                 return _cached;
             }
@@ -428,9 +444,23 @@ internal sealed class LicenseValidator
     public async System.Threading.Tasks.Task<LicenseValidationResult> ValidateAsync(
         System.Threading.CancellationToken cancellationToken = default)
     {
-        // Offline mode: when no server URL is configured (null) or explicitly empty
-        if (_licenseKey.ServerUrl is null || _licenseKey.ServerUrl.Trim().Length == 0)
+        // Offline mode: only when ServerUrl is EXPLICITLY empty string (caller
+        // opted out of server validation). ServerUrl=null still uses the default
+        // server URL — only ""=opt-out skips online validation. Same security
+        // gate as Validate(): AIDN-* server-validated keys are rejected here
+        // because the SDK can't cryptographically verify them; only the
+        // HMAC-signed `aidn.{id}.{sig}` format is accepted offline.
+        if (_licenseKey.ServerUrl is not null && _licenseKey.ServerUrl.Trim().Length == 0)
         {
+            if (!IsSignedKeyFormat(_licenseKey.Key))
+            {
+                var rejected = new LicenseValidationResult(
+                    LicenseKeyStatus.Invalid,
+                    message: "Offline-only mode requires a signed license key (aidn.{id}.{signature} format). " +
+                             "Server-validated keys (AIDN-PROD-*) require online validation.");
+                lock (_cacheLock) { _cached = rejected; }
+                return rejected;
+            }
             var offlineResult = ValidateOffline();
             lock (_cacheLock) { _cached = offlineResult; }
             return offlineResult;

--- a/src/Helpers/ModelPersistenceGuard.cs
+++ b/src/Helpers/ModelPersistenceGuard.cs
@@ -342,11 +342,15 @@ internal static class ModelPersistenceGuard
                 }
                 else
                 {
-                    // Env var or file — offline-only validation (format/signature check, no server call)
-                    keyConfig = new AiDotNetLicenseKey(licenseKey)
-                    {
-                        ServerUrl = string.Empty // explicit empty = offline-only mode
-                    };
+                    // Env var or file — let the validator pick the right path:
+                    //   - HMAC-signed `aidn.{id}.{sig}` keys: validate offline against build key.
+                    //   - Server-validated `AIDN-PROD-*` keys: hit the default server endpoint.
+                    // Leaving ServerUrl=null routes through the validator's auto-detect logic
+                    // (default URL for online keys, offline path for signed keys). The previous
+                    // code forced ServerUrl="" which made the validator's offline-only branch
+                    // reject AIDN-* keys outright AND, before the offline-mode signed-key gate
+                    // landed, accepted them WITHOUT cryptographic verification — both wrong.
+                    keyConfig = new AiDotNetLicenseKey(licenseKey);
                 }
 
                 _validator = new LicenseValidator(keyConfig);

--- a/src/Helpers/ModelPersistenceGuard.cs
+++ b/src/Helpers/ModelPersistenceGuard.cs
@@ -342,15 +342,30 @@ internal static class ModelPersistenceGuard
                 }
                 else
                 {
-                    // Env var or file — let the validator pick the right path:
-                    //   - HMAC-signed `aidn.{id}.{sig}` keys: validate offline against build key.
-                    //   - Server-validated `AIDN-PROD-*` keys: hit the default server endpoint.
-                    // Leaving ServerUrl=null routes through the validator's auto-detect logic
-                    // (default URL for online keys, offline path for signed keys). The previous
-                    // code forced ServerUrl="" which made the validator's offline-only branch
-                    // reject AIDN-* keys outright AND, before the offline-mode signed-key gate
-                    // landed, accepted them WITHOUT cryptographic verification — both wrong.
+                    // Env var or file — route by key format. The validator does
+                    // NOT auto-detect: ServerUrl=null always means "use the
+                    // default server URL" regardless of key format. We have to
+                    // choose explicitly here:
+                    //   - HMAC-signed `aidn.{id}.{sig}` keys → ServerUrl="" so
+                    //     the validator's offline-only branch verifies the key
+                    //     locally against the build key (no network needed).
+                    //   - Server-validated `AIDN-PROD-*`/`AIDN-DEV-*` keys →
+                    //     ServerUrl=null so the validator hits the default
+                    //     license-server endpoint. These carry no signature
+                    //     the SDK can verify locally; the server is the only
+                    //     source of truth for valid-vs-revoked status.
+                    // Picking the wrong branch here is a behavioral regression:
+                    // a signed key would suddenly require network reachability,
+                    // and an AIDN-* key would be rejected outright by the
+                    // offline-only signed-key gate.
+                    //
+                    // Construct first so AiDotNetLicenseKey's Guard.NotNullOrWhiteSpace
+                    // runs on the raw string before anything else inspects it.
                     keyConfig = new AiDotNetLicenseKey(licenseKey);
+                    if (LicenseValidator.IsSignedKeyFormat(licenseKey))
+                    {
+                        keyConfig.ServerUrl = string.Empty;
+                    }
                 }
 
                 _validator = new LicenseValidator(keyConfig);

--- a/src/Models/AiDotNetLicenseKey.cs
+++ b/src/Models/AiDotNetLicenseKey.cs
@@ -36,8 +36,17 @@ public sealed class AiDotNetLicenseKey
 
     /// <summary>
     /// Gets or sets the URL of the license validation server.
-    /// When null, the license operates in offline-only mode (no server validation).
     /// </summary>
+    /// <remarks>
+    /// <list type="bullet">
+    ///   <item><c>null</c> (default) — the validator uses the built-in
+    ///         <see cref="Helpers.LicenseValidator.DefaultServerUrl"/> for online validation.</item>
+    ///   <item><c>""</c> (explicit empty) — opt into offline-only mode. Only HMAC-signed
+    ///         <c>aidn.{id}.{sig}</c> keys are accepted; <c>AIDN-PROD-*</c> server-validated
+    ///         keys are rejected since the SDK can't cryptographically verify them.</item>
+    ///   <item>Custom URL — online validation against your own license endpoint.</item>
+    /// </list>
+    /// </remarks>
     public string? ServerUrl { get; set; }
 
     /// <summary>

--- a/src/Models/AiDotNetLicenseKey.cs
+++ b/src/Models/AiDotNetLicenseKey.cs
@@ -12,10 +12,21 @@ namespace AiDotNet.Models;
 ///
 /// <para><b>Usage:</b></para>
 /// <code>
-/// // Minimal: just the key (offline-only, no server validation)
+/// // Default: validate against the built-in AiDotNet license server.
+/// // (ServerUrl defaults to null, which routes to LicenseValidator.DefaultServerUrl —
+/// // it does NOT mean "offline." If the server is unreachable, validation falls back
+/// // through the OfflineGracePeriod cache window.)
 /// var license = new AiDotNetLicenseKey("aidn.abc123.secretXYZ");
 ///
-/// // Full: with server validation
+/// // Offline-only: no network at all. Only signed `aidn.{id}.{sig}` keys are accepted;
+/// // server-validated `AIDN-PROD-*` / `AIDN-DEV-*` keys are rejected because the SDK
+/// // can't cryptographically verify them locally.
+/// var license = new AiDotNetLicenseKey("aidn.abc123.secretXYZ")
+/// {
+///     ServerUrl = "",  // explicit empty string == offline-only
+/// };
+///
+/// // Custom server: validate against your own license endpoint.
 /// var license = new AiDotNetLicenseKey("aidn.abc123.secretXYZ")
 /// {
 ///     ServerUrl = "https://license.example.com",

--- a/tests/AiDotNet.Tests/Helpers/LicenseValidatorTests.cs
+++ b/tests/AiDotNet.Tests/Helpers/LicenseValidatorTests.cs
@@ -54,8 +54,45 @@ public class LicenseValidatorTests
     }
 
     [Fact(Timeout = 60000)]
+    public async Task OfflineMode_ServerValidatedKey_IsRejected()
+    {
+        // Closes the security gap from PR #1256 review: server-validated
+        // AIDN-PROD-* keys carry no cryptographic signature the SDK can
+        // verify locally. Offline-only mode (ServerUrl="") MUST reject
+        // them so a leaked key can't be used air-gapped.
+        await Task.Yield();
+        var key = new AiDotNetLicenseKey("AIDN-PROD-COMMUNITY-1234567890ABCDEF1234567890ABCDEF")
+        {
+            ServerUrl = string.Empty // offline-only
+        };
+
+        var validator = new LicenseValidator(key);
+        var result = validator.Validate();
+
+        Assert.Equal(LicenseKeyStatus.Invalid, result.Status);
+        Assert.Contains("aidn.{id}.{signature}", result.Message);
+    }
+
+    [Fact(Timeout = 60000)]
+    public async Task OfflineMode_ServerValidatedKey_AsyncPath_IsRejected()
+    {
+        // Same gate on the async path as the sync path.
+        var key = new AiDotNetLicenseKey("AIDN-PROD-PRO-1234567890ABCDEF1234567890ABCDEF12")
+        {
+            ServerUrl = string.Empty
+        };
+
+        var validator = new LicenseValidator(key);
+        var result = await validator.ValidateAsync();
+
+        Assert.Equal(LicenseKeyStatus.Invalid, result.Status);
+        Assert.Contains("aidn.{id}.{signature}", result.Message);
+    }
+
+    [Fact(Timeout = 60000)]
     public async Task DefaultServerUrl_IsSet()
     {
+        await Task.Yield();
         Assert.False(string.IsNullOrWhiteSpace(LicenseValidator.DefaultServerUrl));
         Assert.Contains("supabase.co", LicenseValidator.DefaultServerUrl);
         Assert.Contains("validate-license", LicenseValidator.DefaultServerUrl);

--- a/tests/AiDotNet.Tests/Helpers/LicenseValidatorTests.cs
+++ b/tests/AiDotNet.Tests/Helpers/LicenseValidatorTests.cs
@@ -101,6 +101,9 @@ public class LicenseValidatorTests
         Assert.Same(first, cached);
     }
 
+#if !NET471
+    // ValidateAsync only exists on net10+ (the LicenseValidator source has
+    // its async path under `#if !NET471`). Gate the test to match.
     [Fact(Timeout = 60000)]
     public async Task OfflineMode_ServerValidatedKey_AsyncPath_IsRejected()
     {
@@ -116,6 +119,7 @@ public class LicenseValidatorTests
         Assert.Equal(LicenseKeyStatus.Invalid, result.Status);
         Assert.Contains("aidn.{id}.{signature}", result.Message);
     }
+#endif
 
     [Fact(Timeout = 60000)]
     public async Task DefaultServerUrl_IsSet()

--- a/tests/AiDotNet.Tests/Helpers/LicenseValidatorTests.cs
+++ b/tests/AiDotNet.Tests/Helpers/LicenseValidatorTests.cs
@@ -74,6 +74,34 @@ public class LicenseValidatorTests
     }
 
     [Fact(Timeout = 60000)]
+    public async Task OfflineMode_ServerValidatedKey_RejectionIsCached()
+    {
+        // PR #1256 second-pass review: the sync path's offline-only
+        // rejection branch must populate _cached just like ValidateAsync()
+        // does. Otherwise CachedResult is null after a validation attempt
+        // and repeated Validate() calls allocate a fresh Invalid result
+        // each time, both of which diverge from the established caching
+        // contract (and from the async path).
+        await Task.Yield();
+        var key = new AiDotNetLicenseKey("AIDN-PROD-COMMUNITY-1234567890ABCDEF1234567890ABCDEF")
+        {
+            ServerUrl = string.Empty
+        };
+
+        var validator = new LicenseValidator(key);
+        var first = validator.Validate();
+        var second = validator.Validate();
+
+        var cached = validator.CachedResult;
+        Assert.NotNull(cached);
+        Assert.Equal(LicenseKeyStatus.Invalid, cached.Status);
+        // Reference equality: both calls return the cached instance,
+        // and the cached instance is the one returned by Validate().
+        Assert.Same(first, second);
+        Assert.Same(first, cached);
+    }
+
+    [Fact(Timeout = 60000)]
     public async Task OfflineMode_ServerValidatedKey_AsyncPath_IsRejected()
     {
         // Same gate on the async path as the sync path.

--- a/vercel.json
+++ b/vercel.json
@@ -2,7 +2,7 @@
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "version": 2,
   "name": "aidotnet-playground-api",
-  "ignoreCommand": "if [ \"$VERCEL_GIT_COMMIT_REF\" = master ] || [ \"$VERCEL_GIT_COMMIT_REF\" = main ]; then exit 1; fi; git -C \"$(git rev-parse --show-toplevel)\" diff --quiet HEAD^ HEAD -- 'api/' && exit 0 || exit 1",
+  "ignoreCommand": "if [ \"$VERCEL_GIT_COMMIT_REF\" = master ] || [ \"$VERCEL_GIT_COMMIT_REF\" = main ]; then exit 1; fi; PREV=\"${VERCEL_GIT_PREVIOUS_SHA:-}\"; CURR=\"${VERCEL_GIT_COMMIT_SHA:-HEAD}\"; if [ -z \"$PREV\" ]; then exit 1; fi; git -C \"$(git rev-parse --show-toplevel)\" diff --quiet \"$PREV\" \"$CURR\" -- 'api/' 'vercel.json' && exit 0 || exit 1",
   "functions": {
     "api/execute.ts": {
       "maxDuration": 30,

--- a/vercel.json
+++ b/vercel.json
@@ -2,7 +2,7 @@
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "version": 2,
   "name": "aidotnet-playground-api",
-  "ignoreCommand": "sh -c 'case \"$VERCEL_GIT_COMMIT_REF\" in master|main) exit 1 ;; *) exit 0 ;; esac'",
+  "ignoreCommand": "if [ \"$VERCEL_GIT_COMMIT_REF\" = master ] || [ \"$VERCEL_GIT_COMMIT_REF\" = main ]; then exit 1; fi; git -C \"$(git rev-parse --show-toplevel)\" diff --quiet HEAD^ HEAD -- 'api/' && exit 0 || exit 1",
   "functions": {
     "api/execute.ts": {
       "maxDuration": 30,

--- a/website/src/pages/admin/licenses/index.astro
+++ b/website/src/pages/admin/licenses/index.astro
@@ -531,13 +531,14 @@ const productsJson = JSON.stringify(PRODUCTS);
           actions = '<span class="text-xs text-slate-400">--</span>';
         }
 
-        // The admin-resend-license-email edge function rejects revoked
-        // licenses (the customer no longer has access — re-sending the
-        // key would be misleading). Hide the button on those rows so the
+        // The admin-resend-license-email edge function refuses to re-send
+        // anything except active licenses (it returns 409 for suspended,
+        // expired, revoked, etc. — see functions/admin-resend-license-email/
+        // index.ts:113). Hide the button on every non-active row so the
         // operator doesn't get a UI affordance for an action the backend
-        // will refuse anyway. Suspended licenses can still be resent
-        // since the email goes out for reactivation flows too.
-        const showResend = l.status !== 'revoked';
+        // will refuse. Reactivation flows reactivate the license first
+        // (status -> active), then resend; they don't bypass this check.
+        const showResend = l.status === 'active';
         const resendButton = showResend
           ? `<button class="resend-email-btn text-xs text-slate-400 hover:text-brand-blue transition-colors" data-id="${l.id}" title="Re-send the license-key email to the customer">resend</button>`
           : '';

--- a/website/src/pages/admin/licenses/index.astro
+++ b/website/src/pages/admin/licenses/index.astro
@@ -533,7 +533,11 @@ const productsJson = JSON.stringify(PRODUCTS);
 
         return `<tr class="hover:bg-slate-50 dark:hover:bg-slate-800/80 transition-colors">
           <td class="py-3 px-4">
-            <button class="activations-btn font-mono text-xs text-brand-blue hover:underline" data-id="${l.id}" title="View activations">${escapeHtml(keyPreview)}</button>
+            <div class="flex items-center gap-2">
+              <button class="copy-key-btn font-mono text-xs text-slate-700 dark:text-slate-200 hover:text-brand-blue transition-colors" data-key="${escapeHtml(l.license_key)}" title="Click to copy the full license key to the clipboard">${escapeHtml(keyPreview)}</button>
+              <button class="resend-email-btn text-xs text-slate-400 hover:text-brand-blue transition-colors" data-id="${l.id}" title="Re-send the license-key email to the customer">resend</button>
+              <button class="activations-btn text-xs text-slate-400 hover:text-brand-blue transition-colors" data-id="${l.id}" title="View activations">activations</button>
+            </div>
           </td>
           <td class="py-3 px-4">${productBadge(l.product)}</td>
           <td class="py-3 px-4 text-slate-700 dark:text-slate-300">${escapeHtml(l.ownerName || 'Unknown')}${l.ownerEmail && l.ownerEmail !== l.ownerName ? `<br><span class="text-xs text-slate-400">${escapeHtml(l.ownerEmail)}</span>` : ''}${l.organization_name ? `<br><span class="text-xs text-slate-400">${escapeHtml(l.organization_name)}</span>` : ''}</td>
@@ -583,6 +587,59 @@ const productsJson = JSON.stringify(PRODUCTS);
           const id = (btn as HTMLElement).dataset.id;
           if (!id) return;
           await showActivations(id);
+        });
+      });
+
+      // Copy-key button: writes the FULL license key (not the truncated
+      // preview) to the clipboard. The full key is stored on the button's
+      // data-key attribute so the table can keep showing the obfuscated
+      // preview without losing access to the original. Briefly flashes
+      // "Copied!" feedback so the admin knows it worked without having to
+      // open a paste target.
+      tbody.querySelectorAll('.copy-key-btn').forEach(btn => {
+        btn.addEventListener('click', async () => {
+          const fullKey = (btn as HTMLElement).dataset.key;
+          if (!fullKey) return;
+          try {
+            await navigator.clipboard.writeText(fullKey);
+            const orig = btn.innerHTML;
+            btn.innerHTML = '<span class="text-green-500">copied</span>';
+            setTimeout(() => { btn.innerHTML = orig; }, 1500);
+          } catch (err) {
+            console.error('Clipboard copy failed:', err);
+            alert('Copy failed — your browser may have blocked clipboard access. Reveal the key via the activations modal as a workaround.');
+          }
+        });
+      });
+
+      // Re-send email button: calls the admin-resend-license-email edge
+      // function which re-issues a key-delivery email to the customer's
+      // address on file. Used when the original Stripe-checkout email was
+      // dropped (no Resend key configured at the time, recipient bounced,
+      // or transport hiccupped). The license itself is unchanged — only
+      // the email is re-sent.
+      tbody.querySelectorAll('.resend-email-btn').forEach(btn => {
+        btn.addEventListener('click', async () => {
+          const id = (btn as HTMLElement).dataset.id;
+          if (!id) return;
+          if (!confirm('Re-send the license-key email to the customer?')) return;
+          const orig = btn.innerHTML;
+          btn.innerHTML = '<span class="text-slate-400">sending...</span>';
+          try {
+            const { error } = await supabase.functions.invoke('admin-resend-license-email', {
+              body: { license_id: id },
+            });
+            if (error) {
+              console.error('Resend failed:', error);
+              btn.innerHTML = '<span class="text-red-500">failed</span>';
+            } else {
+              btn.innerHTML = '<span class="text-green-500">sent</span>';
+            }
+          } catch (err) {
+            console.error('Resend invoke threw:', err);
+            btn.innerHTML = '<span class="text-red-500">failed</span>';
+          }
+          setTimeout(() => { btn.innerHTML = orig; }, 2500);
         });
       });
     }

--- a/website/src/pages/admin/licenses/index.astro
+++ b/website/src/pages/admin/licenses/index.astro
@@ -534,7 +534,7 @@ const productsJson = JSON.stringify(PRODUCTS);
         return `<tr class="hover:bg-slate-50 dark:hover:bg-slate-800/80 transition-colors">
           <td class="py-3 px-4">
             <div class="flex items-center gap-2">
-              <button class="copy-key-btn font-mono text-xs text-slate-700 dark:text-slate-200 hover:text-brand-blue transition-colors" data-key="${escapeHtml(l.license_key)}" title="Click to copy the full license key to the clipboard">${escapeHtml(keyPreview)}</button>
+              <button class="copy-key-btn font-mono text-xs text-slate-700 dark:text-slate-200 hover:text-brand-blue transition-colors" data-id="${l.id}" title="Click to copy the full license key to the clipboard">${escapeHtml(keyPreview)}</button>
               <button class="resend-email-btn text-xs text-slate-400 hover:text-brand-blue transition-colors" data-id="${l.id}" title="Re-send the license-key email to the customer">resend</button>
               <button class="activations-btn text-xs text-slate-400 hover:text-brand-blue transition-colors" data-id="${l.id}" title="View activations">activations</button>
             </div>
@@ -591,23 +591,32 @@ const productsJson = JSON.stringify(PRODUCTS);
       });
 
       // Copy-key button: writes the FULL license key (not the truncated
-      // preview) to the clipboard. The full key is stored on the button's
-      // data-key attribute so the table can keep showing the obfuscated
-      // preview without losing access to the original. Briefly flashes
-      // "Copied!" feedback so the admin knows it worked without having to
-      // open a paste target.
+      // preview) to the clipboard. The full key is looked up from the
+      // in-memory `allLicenses` array via data-id rather than embedded in
+      // the DOM via data-key — keeps sensitive strings out of HTML and
+      // shrinks the rendered table on large license sets.
       tbody.querySelectorAll('.copy-key-btn').forEach(btn => {
         btn.addEventListener('click', async () => {
-          const fullKey = (btn as HTMLElement).dataset.key;
-          if (!fullKey) return;
+          const id = (btn as HTMLElement).dataset.id;
+          if (!id) return;
+          const license = allLicenses.find(l => l.id === id);
+          if (!license) {
+            console.error('Copy: license row not found in memory for id', id);
+            alert('Could not find the license to copy. Refresh the page and try again.');
+            return;
+          }
           try {
-            await navigator.clipboard.writeText(fullKey);
+            await navigator.clipboard.writeText(license.license_key);
             const orig = btn.innerHTML;
             btn.innerHTML = '<span class="text-green-500">copied</span>';
             setTimeout(() => { btn.innerHTML = orig; }, 1500);
           } catch (err) {
             console.error('Clipboard copy failed:', err);
-            alert('Copy failed — your browser may have blocked clipboard access. Reveal the key via the activations modal as a workaround.');
+            alert(
+              'Copy failed — your browser blocked clipboard access. '
+              + 'Check site permissions for clipboard, try a different browser, '
+              + 'or run this page over HTTPS (clipboard API requires secure context).',
+            );
           }
         });
       });
@@ -626,12 +635,21 @@ const productsJson = JSON.stringify(PRODUCTS);
           const orig = btn.innerHTML;
           btn.innerHTML = '<span class="text-slate-400">sending...</span>';
           try {
-            const { error } = await supabase.functions.invoke('admin-resend-license-email', {
+            const { data, error } = await supabase.functions.invoke('admin-resend-license-email', {
               body: { license_id: id },
             });
+            // Distinguish server-side vs transport-side failures so admins
+            // can see WHICH category fired (config, malformed recipient,
+            // upstream send) instead of an opaque "failed". The edge
+            // function returns a `message` field on every non-2xx; surface
+            // it so the operator gets actionable detail without opening
+            // the network tab.
             if (error) {
-              console.error('Resend failed:', error);
-              btn.innerHTML = '<span class="text-red-500">failed</span>';
+              const serverMsg = (data as { message?: string } | null)?.message;
+              console.error('Resend failed:', { error, serverResponse: data });
+              btn.innerHTML = serverMsg
+                ? `<span class="text-red-500" title="${escapeHtml(serverMsg)}">failed</span>`
+                : '<span class="text-red-500">failed</span>';
             } else {
               btn.innerHTML = '<span class="text-green-500">sent</span>';
             }

--- a/website/src/pages/admin/licenses/index.astro
+++ b/website/src/pages/admin/licenses/index.astro
@@ -531,11 +531,21 @@ const productsJson = JSON.stringify(PRODUCTS);
           actions = '<span class="text-xs text-slate-400">--</span>';
         }
 
+        // The admin-resend-license-email edge function rejects revoked
+        // licenses (the customer no longer has access — re-sending the
+        // key would be misleading). Hide the button on those rows so the
+        // operator doesn't get a UI affordance for an action the backend
+        // will refuse anyway. Suspended licenses can still be resent
+        // since the email goes out for reactivation flows too.
+        const showResend = l.status !== 'revoked';
+        const resendButton = showResend
+          ? `<button class="resend-email-btn text-xs text-slate-400 hover:text-brand-blue transition-colors" data-id="${l.id}" title="Re-send the license-key email to the customer">resend</button>`
+          : '';
         return `<tr class="hover:bg-slate-50 dark:hover:bg-slate-800/80 transition-colors">
           <td class="py-3 px-4">
             <div class="flex items-center gap-2">
               <button class="copy-key-btn font-mono text-xs text-slate-700 dark:text-slate-200 hover:text-brand-blue transition-colors" data-id="${l.id}" title="Click to copy the full license key to the clipboard">${escapeHtml(keyPreview)}</button>
-              <button class="resend-email-btn text-xs text-slate-400 hover:text-brand-blue transition-colors" data-id="${l.id}" title="Re-send the license-key email to the customer">resend</button>
+              ${resendButton}
               <button class="activations-btn text-xs text-slate-400 hover:text-brand-blue transition-colors" data-id="${l.id}" title="View activations">activations</button>
             </div>
           </td>
@@ -651,7 +661,20 @@ const productsJson = JSON.stringify(PRODUCTS);
         btn.addEventListener('click', async () => {
           const id = (btn as HTMLElement).dataset.id;
           if (!id) return;
-          if (!confirm('Re-send the license-key email to the customer?')) return;
+          // Rapid re-click guard: bail if a previous click on this same
+          // button is still in flight. Without the dataset flag, an
+          // impatient operator clicking 3× would fire 3 send requests
+          // before any of them returned, deliver 3 emails to the
+          // customer, AND race-overwrite the button's innerHTML state.
+          const buttonEl = btn as HTMLButtonElement;
+          if (buttonEl.dataset.inFlight === 'true') return;
+          buttonEl.dataset.inFlight = 'true';
+          buttonEl.disabled = true;
+          if (!confirm('Re-send the license-key email to the customer?')) {
+            delete buttonEl.dataset.inFlight;
+            buttonEl.disabled = false;
+            return;
+          }
           const orig = btn.innerHTML;
           btn.innerHTML = '<span class="text-slate-400">sending...</span>';
           try {
@@ -695,6 +718,11 @@ const productsJson = JSON.stringify(PRODUCTS);
           } catch (err) {
             console.error('Resend invoke threw:', err);
             btn.innerHTML = '<span class="text-red-500">failed</span>';
+          } finally {
+            // Always release the in-flight guard so the operator can
+            // retry on transient failures without reloading the page.
+            delete buttonEl.dataset.inFlight;
+            buttonEl.disabled = false;
           }
           setTimeout(() => { btn.innerHTML = orig; }, 2500);
         });

--- a/website/src/pages/admin/licenses/index.astro
+++ b/website/src/pages/admin/licenses/index.astro
@@ -607,9 +607,29 @@ const productsJson = JSON.stringify(PRODUCTS);
           }
           try {
             await navigator.clipboard.writeText(license.license_key);
-            const orig = btn.innerHTML;
+            // Click-safe revert: capture the ORIGINAL label once per
+            // burst (only on the first click in a series of rapid
+            // clicks — subsequent clicks would otherwise overwrite the
+            // cache with the temporary 'copied' span). Cancel any
+            // in-flight revert from a previous click so its delayed
+            // callback doesn't fire after a newer click already
+            // refreshed the label. Net effect: N clicks in any 1.5s
+            // window all revert exactly once, to the real preview.
+            const el = btn as HTMLElement;
+            if (el.dataset.originalLabel === undefined) {
+              el.dataset.originalLabel = btn.innerHTML;
+            }
+            const existingId = el.dataset.revertTimeoutId;
+            if (existingId !== undefined) {
+              clearTimeout(Number.parseInt(existingId, 10));
+            }
             btn.innerHTML = '<span class="text-green-500">copied</span>';
-            setTimeout(() => { btn.innerHTML = orig; }, 1500);
+            const newId = window.setTimeout(() => {
+              btn.innerHTML = el.dataset.originalLabel ?? '';
+              delete el.dataset.originalLabel;
+              delete el.dataset.revertTimeoutId;
+            }, 1500);
+            el.dataset.revertTimeoutId = String(newId);
           } catch (err) {
             console.error('Clipboard copy failed:', err);
             alert(
@@ -645,8 +665,27 @@ const productsJson = JSON.stringify(PRODUCTS);
             // it so the operator gets actionable detail without opening
             // the network tab.
             if (error) {
-              const serverMsg = (data as { message?: string } | null)?.message;
-              console.error('Resend failed:', { error, serverResponse: data });
+              // Supabase JS sets `data` to null on non-2xx and stashes
+              // the actual Response on `error.context`. The edge function
+              // returns `message` in the body — read it from there, not
+              // from `data` (which never has it in the error path).
+              // Wrap in try/catch because error.context may be missing
+              // (network error before the response was received) or the
+              // body may not be JSON.
+              let serverMsg: string | undefined;
+              try {
+                const ctx = (error as { context?: Response }).context;
+                if (ctx && typeof ctx.json === 'function') {
+                  const body = await ctx.json();
+                  if (body && typeof body.message === 'string') {
+                    serverMsg = body.message;
+                  }
+                }
+              } catch {
+                // Body wasn't JSON / context missing — fall through to
+                // generic "failed" label.
+              }
+              console.error('Resend failed:', { error, serverMsg });
               btn.innerHTML = serverMsg
                 ? `<span class="text-red-500" title="${escapeHtml(serverMsg)}">failed</span>`
                 : '<span class="text-red-500">failed</span>';

--- a/website/supabase/functions/_shared/email.ts
+++ b/website/supabase/functions/_shared/email.ts
@@ -37,6 +37,30 @@ const RESEND_TIMEOUT_MS = 5000;
 // Resend rejects malformed addresses anyway, this is just an early-out.
 const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
+/**
+ * PII-redacting log helper. Edge-function logs are centralized and may
+ * be retained beyond what's necessary for transactional debugging, so
+ * raw recipient addresses must not appear in log lines. Keeps the
+ * domain (useful for transport debugging — bounces, MX issues) and
+ * masks the local-part beyond the first two characters.
+ *
+ * Examples:
+ *   "alice@example.com" → "al***@example.com"
+ *   "ab@example.com"    → "***@example.com"
+ *   "@example.com"      → "***@example.com"
+ *   "garbage"           → "***"
+ *   ""                  → "***"
+ */
+function redactEmail(email: string): string {
+  if (!email) return "***";
+  const at = email.indexOf("@");
+  if (at < 0) return "***";
+  const local = email.slice(0, at);
+  const domain = email.slice(at + 1);
+  const masked = local.length <= 2 ? "***" : `${local.slice(0, 2)}***`;
+  return domain ? `${masked}@${domain}` : "***";
+}
+
 export interface LicenseEmailInput {
   to: string;
   licenseKey: string;
@@ -63,7 +87,9 @@ export async function sendLicenseKeyEmail(input: LicenseEmailInput): Promise<Lic
   }
 
   if (!input.to || !EMAIL_RE.test(input.to)) {
-    console.warn(`sendLicenseKeyEmail: invalid or missing recipient '${input.to}' — skipping email.`);
+    console.warn(
+      `sendLicenseKeyEmail: invalid or missing recipient '${redactEmail(input.to ?? "")}' — skipping email.`,
+    );
     return { ok: false, reason: "no_recipient" };
   }
 
@@ -97,17 +123,24 @@ export async function sendLicenseKeyEmail(input: LicenseEmailInput): Promise<Lic
 
     if (!resp.ok) {
       const body = await resp.text();
-      console.error(`sendLicenseKeyEmail: Resend returned ${resp.status} for ${input.to}: ${body.slice(0, 500)}`);
+      // Body kept on the returned object (caller may persist it for
+      // ops triage) but NOT echoed into log output — Resend's error
+      // body sometimes includes the raw `to` address in error messages,
+      // and we don't want that in centralized logs.
+      console.error(
+        `sendLicenseKeyEmail: Resend returned ${resp.status} for ${redactEmail(input.to)}.`,
+      );
       return { ok: false, reason: "send_failed", status: resp.status, body };
     }
 
-    console.log(`sendLicenseKeyEmail: dispatched ${input.tier} key to ${input.to} (status ${resp.status}).`);
+    console.log(
+      `sendLicenseKeyEmail: dispatched ${input.tier} key to ${redactEmail(input.to)} (status ${resp.status}).`,
+    );
     return { ok: true, status: resp.status };
   } catch (err) {
     const isTimeout = (err as { name?: string })?.name === "AbortError";
     console.error(
-      `sendLicenseKeyEmail: ${isTimeout ? "timed out after " + RESEND_TIMEOUT_MS + "ms" : "fetch failed"} for ${input.to}:`,
-      err,
+      `sendLicenseKeyEmail: ${isTimeout ? "timed out after " + RESEND_TIMEOUT_MS + "ms" : "fetch failed"} for ${redactEmail(input.to)}.`,
     );
     return { ok: false, reason: "send_failed" };
   } finally {

--- a/website/supabase/functions/_shared/email.ts
+++ b/website/supabase/functions/_shared/email.ts
@@ -1,0 +1,148 @@
+// Shared email helper for Supabase edge functions.
+//
+// Sends transactional license-key emails via the Resend HTTPS API. The
+// alternative (SMTP) requires a long-lived TCP socket which Deno Deploy
+// edge runtimes don't reliably support; Resend's REST endpoint works
+// inside any HTTPS-capable runtime and has a free tier of 3000 emails/mo
+// at time of writing — adequate for the current scale of license issuance.
+//
+// Configuration is via Supabase project secrets (set with `supabase secrets
+// set` or the dashboard):
+//   RESEND_API_KEY    — required to send. If unset, email is skipped (logged).
+//   EMAIL_FROM        — optional override of the From: header. Default
+//                       "AiDotNet <licenses@aidotnet.dev>". Must be a verified
+//                       sender domain in the Resend dashboard or sends will
+//                       be rejected by Resend.
+//   ACCOUNT_URL       — optional override of the link in the email body.
+//                       Default "https://www.aidotnet.dev/account/licenses/".
+//
+// The send is BEST-EFFORT: failures are logged but never thrown. The license
+// row in Postgres is the source of truth — if email fails (Resend down, key
+// rotated, recipient bounces) the user can always retrieve the key by
+// signing in to /account/licenses. Failing the issuance request because the
+// email transport hiccupped would be a worse outcome than a missing email.
+
+const RESEND_ENDPOINT = "https://api.resend.com/emails";
+const DEFAULT_FROM = "AiDotNet <licenses@aidotnet.dev>";
+const DEFAULT_ACCOUNT_URL = "https://www.aidotnet.dev/account/licenses/";
+
+export interface LicenseEmailInput {
+  to: string;
+  licenseKey: string;
+  tier: string;
+  product: string;
+  isExisting?: boolean;
+}
+
+export interface LicenseEmailResult {
+  ok: boolean;
+  reason?: "no_api_key" | "no_recipient" | "send_failed";
+  status?: number;
+  body?: string;
+}
+
+export async function sendLicenseKeyEmail(input: LicenseEmailInput): Promise<LicenseEmailResult> {
+  const apiKey = Deno.env.get("RESEND_API_KEY");
+  if (!apiKey) {
+    console.warn(
+      "sendLicenseKeyEmail: RESEND_API_KEY not configured — skipping email "
+      + "(license was still issued in DB and is retrievable from /account/licenses).",
+    );
+    return { ok: false, reason: "no_api_key" };
+  }
+
+  if (!input.to || !input.to.includes("@")) {
+    console.warn(`sendLicenseKeyEmail: invalid or missing recipient '${input.to}' — skipping email.`);
+    return { ok: false, reason: "no_recipient" };
+  }
+
+  const from = Deno.env.get("EMAIL_FROM") ?? DEFAULT_FROM;
+  const accountUrl = Deno.env.get("ACCOUNT_URL") ?? DEFAULT_ACCOUNT_URL;
+
+  const subject = input.isExisting
+    ? `Your AiDotNet ${input.tier} license key`
+    : `Welcome to AiDotNet — your ${input.tier} license key`;
+
+  const text = renderText(input, accountUrl);
+  const html = renderHtml(input, accountUrl);
+
+  try {
+    const resp = await fetch(RESEND_ENDPOINT, {
+      method: "POST",
+      headers: {
+        "Authorization": `Bearer ${apiKey}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ from, to: input.to, subject, text, html }),
+    });
+
+    if (!resp.ok) {
+      const body = await resp.text();
+      console.error(`sendLicenseKeyEmail: Resend returned ${resp.status} for ${input.to}: ${body.slice(0, 500)}`);
+      return { ok: false, reason: "send_failed", status: resp.status, body };
+    }
+
+    console.log(`sendLicenseKeyEmail: dispatched ${input.tier} key to ${input.to} (status ${resp.status}).`);
+    return { ok: true, status: resp.status };
+  } catch (err) {
+    console.error(`sendLicenseKeyEmail: fetch failed for ${input.to}:`, err);
+    return { ok: false, reason: "send_failed" };
+  }
+}
+
+function renderText(i: LicenseEmailInput, accountUrl: string): string {
+  const verb = i.isExisting ? "Here is your existing" : "Here is your new";
+  return [
+    `Hi,`,
+    ``,
+    `${verb} AiDotNet ${i.tier} license key:`,
+    ``,
+    `    AIDOTNET_LICENSE_KEY=${i.licenseKey}`,
+    ``,
+    `Quick start:`,
+    `  • Set the environment variable above on your dev machine, or`,
+    `  • Save the key to ~/.aidotnet/license.key (one line, no quotes).`,
+    ``,
+    `You can always view, copy, or revoke this key at:`,
+    `  ${accountUrl}`,
+    ``,
+    `Product: ${i.product}`,
+    `Tier: ${i.tier}`,
+    ``,
+    `If you didn't request this license, please reply to this email so we can revoke it.`,
+    ``,
+    `— The AiDotNet team`,
+  ].join("\n");
+}
+
+function renderHtml(i: LicenseEmailInput, accountUrl: string): string {
+  const verb = i.isExisting ? "Here is your existing" : "Here is your new";
+  // Inline styles only — most email clients strip <style> blocks.
+  return `<!DOCTYPE html>
+<html>
+<body style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; color: #0f172a; max-width: 560px; margin: 0 auto; padding: 24px;">
+  <h2 style="margin-top: 0;">Your AiDotNet ${escapeHtml(i.tier)} license key</h2>
+  <p>${verb} AiDotNet <strong>${escapeHtml(i.tier)}</strong> license key for the <strong>${escapeHtml(i.product)}</strong> product:</p>
+  <pre style="background: #0f172a; color: #f1f5f9; padding: 16px; border-radius: 8px; overflow-x: auto; font-size: 13px;"><code>AIDOTNET_LICENSE_KEY=${escapeHtml(i.licenseKey)}</code></pre>
+  <p><strong>Quick start:</strong></p>
+  <ul>
+    <li>Set the environment variable above on your dev machine, or</li>
+    <li>Save the key to <code>~/.aidotnet/license.key</code> (one line, no quotes).</li>
+  </ul>
+  <p>You can always view, copy, or revoke this key at:<br>
+    <a href="${escapeHtml(accountUrl)}" style="color: #2563eb;">${escapeHtml(accountUrl)}</a>
+  </p>
+  <p style="color: #64748b; font-size: 13px; margin-top: 32px;">If you didn't request this license, please reply to this email so we can revoke it.</p>
+  <p style="color: #64748b; font-size: 13px;">— The AiDotNet team</p>
+</body>
+</html>`;
+}
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}

--- a/website/supabase/functions/_shared/email.ts
+++ b/website/supabase/functions/_shared/email.ts
@@ -96,9 +96,14 @@ export async function sendLicenseKeyEmail(input: LicenseEmailInput): Promise<Lic
   const from = Deno.env.get("EMAIL_FROM") ?? DEFAULT_FROM;
   const accountUrl = Deno.env.get("ACCOUNT_URL") ?? DEFAULT_ACCOUNT_URL;
 
+  // Use the actual product name, not the brand name, so the subject is
+  // accurate when AiDotNet ships multiple products (the wire format
+  // already passes a `product` field; the original copy was treating it
+  // as informational and hardcoding "AiDotNet").
+  const productName = input.product?.trim() || "AiDotNet";
   const subject = input.isExisting
-    ? `Your AiDotNet ${input.tier} license key`
-    : `Welcome to AiDotNet — your ${input.tier} license key`;
+    ? `Your ${productName} ${input.tier} license key`
+    : `Welcome to ${productName} — your ${input.tier} license key`;
 
   const text = renderText(input, accountUrl);
   const html = renderHtml(input, accountUrl);

--- a/website/supabase/functions/_shared/email.ts
+++ b/website/supabase/functions/_shared/email.ts
@@ -25,6 +25,17 @@
 const RESEND_ENDPOINT = "https://api.resend.com/emails";
 const DEFAULT_FROM = "AiDotNet <licenses@aidotnet.dev>";
 const DEFAULT_ACCOUNT_URL = "https://www.aidotnet.dev/account/licenses/";
+// Cap the Resend round-trip so a degraded provider doesn't pile latency
+// onto webhook callers (Stripe retries the webhook if we don't 200 within
+// ~10s). 5s is generous for a transactional REST call to Resend's NA
+// region; failures past that are treated as send_failed and the caller
+// proceeds without blocking issuance.
+const RESEND_TIMEOUT_MS = 5000;
+// Loose RFC-5322 sanity check matching the
+// `license_keys_customer_email_format` DB constraint pattern. Catches
+// obvious garbage ("@", "@@", "a@") without trying full RFC compliance —
+// Resend rejects malformed addresses anyway, this is just an early-out.
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
 export interface LicenseEmailInput {
   to: string;
@@ -51,7 +62,7 @@ export async function sendLicenseKeyEmail(input: LicenseEmailInput): Promise<Lic
     return { ok: false, reason: "no_api_key" };
   }
 
-  if (!input.to || !input.to.includes("@")) {
+  if (!input.to || !EMAIL_RE.test(input.to)) {
     console.warn(`sendLicenseKeyEmail: invalid or missing recipient '${input.to}' — skipping email.`);
     return { ok: false, reason: "no_recipient" };
   }
@@ -66,6 +77,13 @@ export async function sendLicenseKeyEmail(input: LicenseEmailInput): Promise<Lic
   const text = renderText(input, accountUrl);
   const html = renderHtml(input, accountUrl);
 
+  // AbortController-based timeout. AbortSignal.timeout() exists in modern
+  // Deno but a manual controller is portable to older runtimes and lets us
+  // distinguish a timeout from other fetch failures via the AbortError
+  // name in the catch.
+  const ac = new AbortController();
+  const timeoutHandle = setTimeout(() => ac.abort(), RESEND_TIMEOUT_MS);
+
   try {
     const resp = await fetch(RESEND_ENDPOINT, {
       method: "POST",
@@ -74,6 +92,7 @@ export async function sendLicenseKeyEmail(input: LicenseEmailInput): Promise<Lic
         "Content-Type": "application/json",
       },
       body: JSON.stringify({ from, to: input.to, subject, text, html }),
+      signal: ac.signal,
     });
 
     if (!resp.ok) {
@@ -85,8 +104,14 @@ export async function sendLicenseKeyEmail(input: LicenseEmailInput): Promise<Lic
     console.log(`sendLicenseKeyEmail: dispatched ${input.tier} key to ${input.to} (status ${resp.status}).`);
     return { ok: true, status: resp.status };
   } catch (err) {
-    console.error(`sendLicenseKeyEmail: fetch failed for ${input.to}:`, err);
+    const isTimeout = (err as { name?: string })?.name === "AbortError";
+    console.error(
+      `sendLicenseKeyEmail: ${isTimeout ? "timed out after " + RESEND_TIMEOUT_MS + "ms" : "fetch failed"} for ${input.to}:`,
+      err,
+    );
     return { ok: false, reason: "send_failed" };
+  } finally {
+    clearTimeout(timeoutHandle);
   }
 }
 

--- a/website/supabase/functions/admin-resend-license-email/index.ts
+++ b/website/supabase/functions/admin-resend-license-email/index.ts
@@ -104,6 +104,20 @@ serve(async (req: Request) => {
   if (!license) {
     return json({ success: false, error: "license_not_found" }, 404);
   }
+  // Refuse to re-email keys that aren't currently usable. The email
+  // template presents the key as something the customer should set
+  // immediately on their dev machine — sending a dead key (revoked,
+  // expired, suspended) would be actively misleading and report
+  // success to the admin. 409 because the row exists but its current
+  // state conflicts with the requested action.
+  if (license.status !== "active") {
+    return json({
+      success: false,
+      error: "license_not_active",
+      message: `Only active licenses can be re-sent. Current status: ${license.status}. `
+        + `Reactivate the license from the admin UI before re-sending its key.`,
+    }, 409);
+  }
 
   // Recipient resolution:
   //   1. license.customer_email (admin-typed at issuance, e.g. bulk training)

--- a/website/supabase/functions/admin-resend-license-email/index.ts
+++ b/website/supabase/functions/admin-resend-license-email/index.ts
@@ -131,7 +131,19 @@ serve(async (req: Request) => {
       .eq("id", license.user_id)
       .maybeSingle();
     if (profileError) {
+      // The profiles row should exist (the license has a user_id FK
+      // to it). A failure here is server-side — RLS misconfiguration,
+      // schema drift, or DB outage — not a user-correctable input
+      // error, so return 500 with the upstream message instead of
+      // silently falling through and reporting "no recipient" at the
+      // bottom of this handler.
       console.error("admin-resend-license-email: profile lookup failed:", profileError);
+      return json({
+        success: false,
+        error: "profile_lookup_failed",
+        message: `Database lookup for the license owner's profile failed: ${profileError.message ?? "unknown error"}. ` +
+          "This is a server-side issue — check Supabase RLS policies, the profiles table schema, and the database health.",
+      }, 500);
     } else if (profile?.email) {
       recipient = profile.email;
     }

--- a/website/supabase/functions/admin-resend-license-email/index.ts
+++ b/website/supabase/functions/admin-resend-license-email/index.ts
@@ -64,13 +64,24 @@ serve(async (req: Request) => {
     return json({ success: false, error: "forbidden", message: "Admin role required." }, 403);
   }
 
-  let body: { license_id?: string };
+  let body: unknown;
   try {
     body = await req.json();
   } catch {
     return json({ success: false, error: "invalid_json" }, 400);
   }
-  const licenseId = body?.license_id?.trim();
+  // Type-guard before calling string methods. Without this, a payload like
+  // `{ "license_id": 123 }` or `{ "license_id": ["abc"] }` would throw a
+  // TypeError on .trim() and bubble up as an opaque 500.
+  const rawId = (body as { license_id?: unknown })?.license_id;
+  if (typeof rawId !== "string") {
+    return json({
+      success: false,
+      error: "invalid_license_id",
+      message: "license_id must be a string.",
+    }, 400);
+  }
+  const licenseId = rawId.trim();
   if (!licenseId) {
     return json({ success: false, error: "missing_license_id" }, 400);
   }
@@ -130,12 +141,34 @@ serve(async (req: Request) => {
   });
 
   if (!result.ok) {
+    // Map failure reasons to actionable HTTP statuses:
+    //   - no_api_key   → 503 (server-side config missing; ops fix)
+    //   - no_recipient → 422 (bad address; admin must fix customer_email)
+    //   - send_failed  → 502 (genuine upstream provider failure / timeout)
+    let status: number;
+    let message: string;
+    switch (result.reason) {
+      case "no_api_key":
+        status = 503;
+        message = "Email is not configured on this Supabase project (RESEND_API_KEY missing). "
+          + "The license remains in DB but no email can be sent until ops sets the secret.";
+        break;
+      case "no_recipient":
+        status = 422;
+        message = "Recipient address is malformed. Edit the license's customer_email in the admin UI before retrying.";
+        break;
+      case "send_failed":
+      default:
+        status = 502;
+        message = "Resend rejected or timed out the email send. Check the Resend dashboard and the function logs.";
+        break;
+    }
     return json({
       success: false,
       error: result.reason ?? "send_failed",
       status: result.status,
-      message: "Failed to dispatch email. Check the Resend dashboard and the function logs.",
-    }, 502);
+      message,
+    }, status);
   }
 
   return json({

--- a/website/supabase/functions/admin-resend-license-email/index.ts
+++ b/website/supabase/functions/admin-resend-license-email/index.ts
@@ -1,0 +1,154 @@
+import { serve } from "https://deno.land/std@0.177.0/http/server.ts";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2.39.3";
+import { sendLicenseKeyEmail } from "../_shared/email.ts";
+
+// Admin-only endpoint that re-sends the license-key email for an existing
+// license_keys row. Used by the Resend button on /admin/licenses when the
+// original Stripe-checkout email never reached the customer (no Resend key
+// configured at the time, recipient bounced, transport hiccupped).
+//
+// Authorization model:
+//   1. Caller must present a valid Supabase JWT in the Authorization header.
+//   2. The corresponding profile must satisfy public.is_admin() — same
+//      function the existing /admin/* RLS policies key off.
+//
+// The license row itself is unchanged; only the email is re-sent.
+
+const ALLOWED_ORIGIN = Deno.env.get("ALLOWED_ORIGIN") ?? "https://www.aidotnet.dev";
+const corsHeaders = {
+  "Access-Control-Allow-Origin": ALLOWED_ORIGIN,
+  "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type",
+  "Access-Control-Allow-Methods": "POST, OPTIONS",
+};
+
+serve(async (req: Request) => {
+  if (req.method === "OPTIONS") {
+    return new Response(null, { status: 204, headers: corsHeaders });
+  }
+  if (req.method !== "POST") {
+    return json({ success: false, error: "method_not_allowed" }, 405);
+  }
+
+  const authHeader = req.headers.get("Authorization");
+  if (!authHeader) {
+    return json({ success: false, error: "unauthorized", message: "Authentication required." }, 401);
+  }
+
+  const supabaseUrl = Deno.env.get("SUPABASE_URL");
+  const supabaseAnonKey = Deno.env.get("SUPABASE_ANON_KEY");
+  const supabaseServiceKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY");
+  if (!supabaseUrl || !supabaseAnonKey || !supabaseServiceKey) {
+    console.error("admin-resend-license-email: missing supabase env (URL / ANON_KEY / SERVICE_ROLE_KEY)");
+    return json({ success: false, error: "server_configuration_error" }, 500);
+  }
+
+  // User-scoped client to verify the caller's identity. We use the same
+  // is_admin() SQL function that gates the RLS policies on /admin/* tables;
+  // running it as the user (not service-role) means an attacker who steals
+  // a non-admin JWT cannot bypass the check by hitting this endpoint.
+  const userClient = createClient(supabaseUrl, supabaseAnonKey, {
+    global: { headers: { Authorization: authHeader } },
+  });
+
+  const { data: { user }, error: authError } = await userClient.auth.getUser();
+  if (authError || !user) {
+    return json({ success: false, error: "unauthorized", message: "Invalid or expired session." }, 401);
+  }
+
+  const { data: isAdminResult, error: isAdminError } = await userClient.rpc("is_admin");
+  if (isAdminError) {
+    console.error("admin-resend-license-email: is_admin() rpc failed:", isAdminError);
+    return json({ success: false, error: "authorization_check_failed" }, 500);
+  }
+  if (!isAdminResult) {
+    return json({ success: false, error: "forbidden", message: "Admin role required." }, 403);
+  }
+
+  let body: { license_id?: string };
+  try {
+    body = await req.json();
+  } catch {
+    return json({ success: false, error: "invalid_json" }, 400);
+  }
+  const licenseId = body?.license_id?.trim();
+  if (!licenseId) {
+    return json({ success: false, error: "missing_license_id" }, 400);
+  }
+
+  // Service-role client for the cross-user license lookup. The is_admin()
+  // gate above is what authorizes this; service-role here just bypasses
+  // the per-user RLS so the row read works.
+  const serviceClient = createClient(supabaseUrl, supabaseServiceKey);
+
+  const { data: license, error: licenseError } = await serviceClient
+    .from("license_keys")
+    .select("id, user_id, license_key, product, tier, status, customer_email")
+    .eq("id", licenseId)
+    .maybeSingle();
+
+  if (licenseError) {
+    console.error("admin-resend-license-email: license lookup failed:", licenseError);
+    return json({ success: false, error: "license_lookup_failed" }, 500);
+  }
+  if (!license) {
+    return json({ success: false, error: "license_not_found" }, 404);
+  }
+
+  // Recipient resolution:
+  //   1. license.customer_email (admin-typed at issuance, e.g. bulk training)
+  //   2. profiles.email by license.user_id
+  //   3. fail with explicit error so the admin sees which row is missing data
+  let recipient: string | null = license.customer_email ?? null;
+  if (!recipient && license.user_id) {
+    const { data: profile, error: profileError } = await serviceClient
+      .from("profiles")
+      .select("email")
+      .eq("id", license.user_id)
+      .maybeSingle();
+    if (profileError) {
+      console.error("admin-resend-license-email: profile lookup failed:", profileError);
+    } else if (profile?.email) {
+      recipient = profile.email;
+    }
+  }
+
+  if (!recipient) {
+    return json({
+      success: false,
+      error: "no_recipient_email",
+      message: "Neither the license row's customer_email nor the linked profile has an email address. "
+        + "Edit the license in the admin UI to set customer_email before re-sending.",
+    }, 422);
+  }
+
+  const result = await sendLicenseKeyEmail({
+    to: recipient,
+    licenseKey: license.license_key,
+    tier: license.tier,
+    product: license.product,
+    isExisting: true,
+  });
+
+  if (!result.ok) {
+    return json({
+      success: false,
+      error: result.reason ?? "send_failed",
+      status: result.status,
+      message: "Failed to dispatch email. Check the Resend dashboard and the function logs.",
+    }, 502);
+  }
+
+  return json({
+    success: true,
+    recipient,
+    status: result.status,
+    message: `License-key email re-sent to ${recipient}.`,
+  }, 200);
+});
+
+function json(body: unknown, status: number): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { ...corsHeaders, "Content-Type": "application/json" },
+  });
+}

--- a/website/supabase/functions/register-community-license/index.ts
+++ b/website/supabase/functions/register-community-license/index.ts
@@ -1,5 +1,6 @@
 import { serve } from "https://deno.land/std@0.177.0/http/server.ts";
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2.39.3";
+import { sendLicenseKeyEmail } from "../_shared/email.ts";
 
 // Default matches the production origin the marketing site actually serves from.
 // Override via the ALLOWED_ORIGIN function secret for staging / preview envs.
@@ -179,6 +180,25 @@ serve(async (req: Request) => {
       return new Response(
         JSON.stringify({ success: false, error: "server_error", message: "Failed to create license. Please try again." }),
         { status: 500, headers: { ...corsHeaders, "Content-Type": "application/json" } }
+      );
+    }
+
+    // Best-effort key delivery email. The license row above is the source
+    // of truth; failure to email is logged but never thrown so a flaky
+    // transport doesn't reject a successful issuance (the user already has
+    // the key in the response body and on /account/licenses).
+    if (user.email) {
+      await sendLicenseKeyEmail({
+        to: user.email,
+        licenseKey,
+        tier: COMMUNITY_TIER,
+        product: COMMUNITY_PRODUCT,
+        isExisting: false,
+      });
+    } else {
+      console.warn(
+        `Community license ${licenseKey.substring(0, 12)}... issued for user ${user.id} `
+        + `but no email on profile — user must retrieve key from /account/licenses.`,
       );
     }
 

--- a/website/supabase/functions/register-community-license/index.ts
+++ b/website/supabase/functions/register-community-license/index.ts
@@ -18,7 +18,13 @@ const corsHeaders = {
 // string drift between the lookup and insert paths and makes
 // product-specific changes a one-liner.
 const COMMUNITY_PRODUCT = "aidotnet" as const;
-const COMMUNITY_PREFIX = "aidn" as const;
+// Key prefix that the AiDotNet client library parses. See
+// LicenseValidator.IsServerValidatedKeyFormat in src/Helpers/LicenseValidator.cs:
+// ≥4 dash-delimited segments, segment[0]=="AIDN", last segment is ≥8 hex chars.
+// The dotted `aidn.{id}.{sig}` form is also accepted but requires HMAC-SHA256
+// signing against a build key this function does not have access to — so the
+// dash form is the only viable issuance path here. See ooples/AiDotNet#1262.
+const COMMUNITY_PREFIX = "AIDN-PROD" as const;
 const COMMUNITY_TIER = "community" as const;
 // Unique partial index name that enforces at-most-one active license per
 // (user, product, tier). See migration
@@ -120,12 +126,13 @@ serve(async (req: Request) => {
       );
     }
 
-    // Generate a new license key: {prefix}.{12-char-random}.{16-char-random}.
-    // Prefix comes from COMMUNITY_PREFIX so the client library can classify
-    // the key by string alone without a DB round-trip.
-    const keyPart1 = crypto.randomUUID().replace(/-/g, "").substring(0, 12);
-    const keyPart2 = crypto.randomUUID().replace(/-/g, "").substring(0, 16);
-    const licenseKey = `${COMMUNITY_PREFIX}.${keyPart1}.${keyPart2}`;
+    // Generate a fresh AIDN-PROD-COMMUNITY-{32hex} key. Format must satisfy
+    // LicenseValidator.IsServerValidatedKeyFormat in the AiDotNet client
+    // library: ≥4 dash-delimited segments, segment[0]=="AIDN", last segment
+    // is ≥8 hex chars. Empirically verified that `AIDN-PROD-{TIER}-{32hex}`
+    // validates end-to-end through the online validate-license path.
+    const keyHex = crypto.randomUUID().replace(/-/g, "");
+    const licenseKey = `${COMMUNITY_PREFIX}-${COMMUNITY_TIER.toUpperCase()}-${keyHex}`;
 
     // Insert the new community license. The at-most-one-active partial
     // unique index (migration 20260419000000) guarantees atomicity: if a

--- a/website/supabase/functions/stripe-webhook/index.ts
+++ b/website/supabase/functions/stripe-webhook/index.ts
@@ -7,9 +7,14 @@ import { sendLicenseKeyEmail } from "../_shared/email.ts";
 // for aidotnet.dev route through here; Harmonic Engine (and any future
 // products) will get their own webhook + edge function path.
 const WEBHOOK_PRODUCT = "aidotnet" as const;
-// Key prefix must match what the client library parses; see
-// website/src/pages/admin/licenses/index.astro's PRODUCTS list.
-const WEBHOOK_PREFIX = "aidn" as const;
+// Key prefix that the AiDotNet client library parses for online-validated
+// keys. See LicenseValidator.IsServerValidatedKeyFormat in src/Helpers/
+// LicenseValidator.cs of this repo: keys must split into ≥4 dash-delimited
+// segments starting with "AIDN" and end with ≥8 hex chars. The dotted
+// `aidn.{id}.{sig}` form is also accepted by the library, but only with a
+// real HMAC signature against a build key the webhook doesn't have access
+// to — so the dash form is the only viable issuance path here.
+const WEBHOOK_PREFIX = "AIDN-PROD" as const;
 
 // Per-tier activation caps. Keeping them in one map so bumping a tier's
 // cap doesn't require hunting through the handlers.
@@ -216,10 +221,18 @@ async function handleCheckoutCompleted(
     return;
   }
 
-  // Generate a fresh {prefix}.{12rand}.{16rand} key.
-  const keyPart1 = crypto.randomUUID().replace(/-/g, "").substring(0, 12);
-  const keyPart2 = crypto.randomUUID().replace(/-/g, "").substring(0, 16);
-  const licenseKey = `${WEBHOOK_PREFIX}.${keyPart1}.${keyPart2}`;
+  // Generate a fresh AIDN-PROD-{TIER_UPPER}-{32hex} key. Format must
+  // satisfy LicenseValidator.IsServerValidatedKeyFormat in the AiDotNet
+  // client library: ≥4 dash-delimited segments, segment[0]=="AIDN", last
+  // segment is ≥8 hex chars. Empirically verified that
+  // `AIDN-PROD-PROFESSIONAL-{32hex}` validates end-to-end through the
+  // online validate-license edge function path.
+  //
+  // Previous format (`aidn.{id}.{sig}`) was rejected by the client
+  // library because the dotted form requires HMAC-SHA256 signing against
+  // a build key the webhook does not have access to. See ooples/AiDotNet#1262.
+  const keyHex = crypto.randomUUID().replace(/-/g, "");
+  const licenseKey = `${WEBHOOK_PREFIX}-${tier.toUpperCase()}-${keyHex}`;
 
   const { error: insertError } = await client
     .from("license_keys")

--- a/website/supabase/functions/stripe-webhook/index.ts
+++ b/website/supabase/functions/stripe-webhook/index.ts
@@ -1,6 +1,7 @@
 import { serve } from "https://deno.land/std@0.177.0/http/server.ts";
 import { createClient, SupabaseClient } from "https://esm.sh/@supabase/supabase-js@2.39.3";
 import Stripe from "https://esm.sh/stripe@14.14.0?target=deno";
+import { sendLicenseKeyEmail } from "../_shared/email.ts";
 
 // Product this webhook issues licenses for. All Stripe products created
 // for aidotnet.dev route through here; Harmonic Engine (and any future
@@ -240,6 +241,29 @@ async function handleCheckoutCompleted(
   }
 
   console.log(`Issued ${tier} license ${licenseKey.substring(0, 12)}... for user ${userId}`);
+
+  // Best-effort key delivery email. The license row above is the source
+  // of truth — failure here is logged but never thrown so a flaky email
+  // transport doesn't block license issuance (Stripe would retry the
+  // event and we'd then hit the duplicate-active short-circuit above).
+  // Recipient address is taken from session.customer_details.email,
+  // which Stripe collects as part of every checkout.
+  const recipient = session.customer_details?.email;
+  if (recipient) {
+    await sendLicenseKeyEmail({
+      to: recipient,
+      licenseKey,
+      tier,
+      product: WEBHOOK_PRODUCT,
+      isExisting: false,
+    });
+  } else {
+    console.warn(
+      `License ${licenseKey.substring(0, 12)}... issued for user ${userId} but `
+      + `no recipient email on the Stripe session (session.customer_details.email empty). `
+      + `User must retrieve the key from /account/licenses.`,
+    );
+  }
 }
 
 /**

--- a/website/supabase/migrations/20260504190000_fix_validate_license_advisory_lock_uuid.sql
+++ b/website/supabase/migrations/20260504190000_fix_validate_license_advisory_lock_uuid.sql
@@ -89,7 +89,24 @@ begin
             jsonb_build_array()
     end;
 
-    -- Check if this machine is already activated
+    -- Advisory lock on the license key id to prevent race conditions
+    -- when two concurrent validations try to activate the same license.
+    --
+    -- BUG FIX: pg_advisory_xact_lock takes bigint, but v_license.id is uuid.
+    -- The previous version called it with the raw uuid which threw
+    -- `function pg_advisory_xact_lock(uuid) does not exist` and broke
+    -- every new-machine activation in production. hashtextextended(text,
+    -- seed) returns bigint deterministically, so the same uuid always
+    -- maps to the same lock key — the serialization invariant holds.
+    --
+    -- Acquire BEFORE the existing-activation lookup so two concurrent
+    -- activations from the same machine_id_hash can't both pass the
+    -- "no existing activation" check with stale snapshots and end up
+    -- inserting duplicates. The serialization scope must cover both
+    -- the existence check AND the counting/insert below.
+    perform pg_advisory_xact_lock(hashtextextended(v_license.id::text, 0));
+
+    -- Check if this machine is already activated (serialized by the lock).
     select * into v_existing_activation
     from public.license_activations
     where license_key_id = v_license.id
@@ -118,18 +135,8 @@ begin
         );
     end if;
 
-    -- Advisory lock on the license key id to prevent race conditions
-    -- when two concurrent validations try to activate the same license.
-    --
-    -- BUG FIX: pg_advisory_xact_lock takes bigint, but v_license.id is uuid.
-    -- The previous version called it with the raw uuid which threw
-    -- `function pg_advisory_xact_lock(uuid) does not exist` and broke
-    -- every new-machine activation in production. hashtextextended(text,
-    -- seed) returns bigint deterministically, so the same uuid always
-    -- maps to the same lock key — the serialization invariant holds.
-    perform pg_advisory_xact_lock(hashtextextended(v_license.id::text, 0));
-
-    -- Re-count active activations after acquiring the lock
+    -- Count active activations under the same lock so the activation-limit
+    -- decision is consistent with the existence check above.
     select count(*) into v_activation_count
     from public.license_activations
     where license_key_id = v_license.id

--- a/website/supabase/migrations/20260504190000_fix_validate_license_advisory_lock_uuid.sql
+++ b/website/supabase/migrations/20260504190000_fix_validate_license_advisory_lock_uuid.sql
@@ -1,0 +1,160 @@
+-- Fix: validate_license_key RPC threw `pg_advisory_xact_lock(uuid) does not
+-- exist` on every new-machine activation, because the function takes only
+-- bigint or two int args while v_license.id is uuid. Existing-activation
+-- short-circuit hit the path before the lock, so the bug was invisible
+-- on machines that already had a row in license_activations — but every
+-- first-time activation on a fresh dev machine returned `server_error`
+-- back to the AiDotNet client library, surfacing as
+-- LicenseRequiredException to the customer.
+--
+-- See ooples/AiDotNet#1261 for the diagnostic trace.
+--
+-- Replace the lock argument with a deterministic bigint hash of the uuid:
+-- hashtextextended(text, seed) returns bigint, is deterministic across
+-- calls (same uuid always hashes to the same lock key), so concurrent
+-- validations on the same license_key still serialize correctly. Only the
+-- one broken line changes; the rest of the function body is unchanged.
+--
+-- This migration was applied to the production project (yfkqwpgjahoamlgckjib)
+-- via the Management API on 2026-05-04 to unblock the AiDotNet Transformer
+-- baseline runs in HarmonicEngine. This file commits the same fix so
+-- environment refreshes / fresh installs pick it up without manual SQL.
+
+CREATE OR REPLACE FUNCTION public.validate_license_key(
+    p_license_key text,
+    p_machine_id_hash text,
+    p_hostname text DEFAULT NULL::text,
+    p_os_description text DEFAULT NULL::text,
+    p_package text DEFAULT NULL::text
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $function$
+declare
+    v_license record;
+    v_activation_count int;
+    v_existing_activation record;
+    v_capabilities jsonb;
+begin
+    -- Look up the license key
+    select * into v_license
+    from public.license_keys
+    where license_key = p_license_key;
+
+    if not found then
+        return jsonb_build_object(
+            'valid', false,
+            'error', 'invalid_key',
+            'message', 'License key not found.'
+        );
+    end if;
+
+    -- Check license status
+    if v_license.status != 'active' then
+        return jsonb_build_object(
+            'valid', false,
+            'error', 'license_' || v_license.status::text,
+            'message', 'License is ' || v_license.status::text || '.'
+        );
+    end if;
+
+    -- Check expiration
+    if v_license.expires_at is not null and v_license.expires_at < now() then
+        return jsonb_build_object(
+            'valid', false,
+            'error', 'license_expired',
+            'message', 'License has expired.'
+        );
+    end if;
+
+    -- Resolve the per-tier capability set. Build the array once so success
+    -- paths (existing-activation update, new-activation insert) return the
+    -- same shape — divergence between the two paths would mean tensor-side
+    -- enforcement behaves differently for a returning machine vs a new one.
+    v_capabilities := case v_license.tier
+        when 'community' then
+            jsonb_build_array('tensors:load')
+        when 'professional' then
+            jsonb_build_array('tensors:save', 'tensors:load', 'model:save', 'model:load')
+        when 'enterprise' then
+            jsonb_build_array('tensors:save', 'tensors:load', 'model:save', 'model:load')
+        else
+            -- Defensive default: a tier that doesn't appear in this CASE
+            -- (e.g., a future enum value added without updating this
+            -- function) gets an empty capability set, so the tensor guard
+            -- denies operations until the mapping is filled in. Better than
+            -- silently granting full capabilities to an unrecognised tier.
+            jsonb_build_array()
+    end;
+
+    -- Check if this machine is already activated
+    select * into v_existing_activation
+    from public.license_activations
+    where license_key_id = v_license.id
+      and machine_id_hash = p_machine_id_hash
+      and is_active = true;
+
+    if found then
+        -- Update last_seen_at for existing activation
+        update public.license_activations
+        set last_seen_at = now(),
+            hostname = coalesce(p_hostname, hostname),
+            os_description = coalesce(p_os_description, os_description),
+            -- Overwrite (not coalesce) so a switch from one package to the
+            -- other shows up immediately. coalesce would freeze the value
+            -- to whichever package validated first on this activation.
+            last_seen_package = p_package
+        where id = v_existing_activation.id;
+
+        return jsonb_build_object(
+            'valid', true,
+            'tier', v_license.tier::text,
+            'capabilities', v_capabilities,
+            'license_id', v_license.id,
+            'activation_id', v_existing_activation.id,
+            'message', 'License validated (existing activation).'
+        );
+    end if;
+
+    -- Advisory lock on the license key id to prevent race conditions
+    -- when two concurrent validations try to activate the same license.
+    --
+    -- BUG FIX: pg_advisory_xact_lock takes bigint, but v_license.id is uuid.
+    -- The previous version called it with the raw uuid which threw
+    -- `function pg_advisory_xact_lock(uuid) does not exist` and broke
+    -- every new-machine activation in production. hashtextextended(text,
+    -- seed) returns bigint deterministically, so the same uuid always
+    -- maps to the same lock key — the serialization invariant holds.
+    perform pg_advisory_xact_lock(hashtextextended(v_license.id::text, 0));
+
+    -- Re-count active activations after acquiring the lock
+    select count(*) into v_activation_count
+    from public.license_activations
+    where license_key_id = v_license.id
+      and is_active = true;
+
+    if v_activation_count >= v_license.max_activations then
+        return jsonb_build_object(
+            'valid', false,
+            'error', 'activation_limit',
+            'message', 'Maximum activations (' || v_license.max_activations || ') reached. Deactivate a machine first.',
+            'current_activations', v_activation_count,
+            'max_activations', v_license.max_activations
+        );
+    end if;
+
+    -- Create new activation
+    insert into public.license_activations (license_key_id, machine_id_hash, hostname, os_description, last_seen_package)
+    values (v_license.id, p_machine_id_hash, p_hostname, p_os_description, p_package);
+
+    return jsonb_build_object(
+        'valid', true,
+        'tier', v_license.tier::text,
+        'capabilities', v_capabilities,
+        'license_id', v_license.id,
+        'message', 'License validated and activated on this machine.'
+    );
+end;
+$function$;

--- a/website/tests/e2e/admin/licenses-copy-and-resend.spec.ts
+++ b/website/tests/e2e/admin/licenses-copy-and-resend.spec.ts
@@ -49,8 +49,19 @@ test.describe('Admin — licenses copy + resend buttons', () => {
 
     await firstCopyBtn.click();
 
-    // Click flashes "copied" then reverts. Don't race the revert — assert
-    // on the captured clipboard text directly.
+    // page.click() dispatches the event but does NOT await the async
+    // handler — by the time control returns, navigator.clipboard.writeText
+    // may not have run yet. Poll until __copiedTexts is populated before
+    // reading it; otherwise the assertion can race the click handler and
+    // see length 0 on a fast machine. Same pattern the alert test below
+    // uses for window.alert.
+    await expect
+      .poll(
+        () => page.evaluate(() => (window as unknown as { __copiedTexts: string[] }).__copiedTexts.length),
+        { timeout: 3_000 },
+      )
+      .toBe(1);
+
     const copied = await page.evaluate(() => {
       return (window as unknown as { __copiedTexts: string[] }).__copiedTexts;
     });
@@ -65,9 +76,13 @@ test.describe('Admin — licenses copy + resend buttons', () => {
       .not.toContain('...');
     expect(copiedKey.length).toBeGreaterThan(preview.length);
 
-    // Brief feedback flash should fire and then revert. We check it
-    // appeared at least once (race-tolerant).
-    await expect(firstCopyBtn).toContainText(/copied|aidn|harm/i, { timeout: 2000 });
+    // The "copied" feedback flash must actually render. The previous
+    // regex `/copied|aidn|harm/i` was non-enforcing — it would pass even
+    // if the flash never fired, because the original button label
+    // contains a key preview that starts with `aidn` or `harm`. Tightened
+    // to require the literal "copied" text so a regression that drops
+    // the visual feedback fails the test.
+    await expect(firstCopyBtn).toContainText(/copied/i, { timeout: 2000 });
   });
 
   test('copy button surfaces a clipboard-permission alert when writeText throws', async ({ page }) => {
@@ -118,6 +133,17 @@ test.describe('Admin — licenses copy + resend buttons', () => {
   ): Promise<{ requests: Array<{ body: unknown }> }> {
     const captured: Array<{ body: unknown }> = [];
     await page.route('**/functions/v1/admin-resend-license-email**', async (route: Route) => {
+      // Filter to POST only. supabase.functions.invoke() sends an
+      // Authorization header which triggers a CORS preflight OPTIONS
+      // request before the actual POST; if we counted that too, the
+      // `expect(stub.requests).toHaveLength(1)` assertions below would
+      // intermittently see length 2 and fail. Reply 204 (no content) to
+      // the preflight without recording it.
+      if (route.request().method() !== 'POST') {
+        await route.fulfill({ status: 204 });
+        return;
+      }
+
       let parsed: unknown = null;
       try {
         parsed = JSON.parse(route.request().postData() ?? 'null');
@@ -194,6 +220,13 @@ test.describe('Admin — licenses copy + resend buttons', () => {
   test('resend button makes no request when the admin cancels the confirm dialog', async ({ page }) => {
     let invoked = false;
     await page.route('**/functions/v1/admin-resend-license-email**', async (route: Route) => {
+      // Same preflight filter as stubResend — without it, a CORS OPTIONS
+      // request from the browser would set invoked=true even when the
+      // user dismissed the confirm and the actual POST never fired.
+      if (route.request().method() !== 'POST') {
+        await route.fulfill({ status: 204 });
+        return;
+      }
       invoked = true;
       await route.fulfill({ status: 200, contentType: 'application/json', body: '{}' });
     });

--- a/website/tests/e2e/admin/licenses-copy-and-resend.spec.ts
+++ b/website/tests/e2e/admin/licenses-copy-and-resend.spec.ts
@@ -1,0 +1,216 @@
+import { test, expect, Route } from '@playwright/test';
+
+// Coverage for the per-row Copy and Resend controls added to /admin/licenses
+// in PR #1256. Each test stubs the side-effecting boundary it cares about
+// (clipboard for copy, the supabase functions endpoint for resend) so this
+// suite is safe to run against any seeded admin environment without
+// mutating real user state or sending real email.
+test.describe('Admin — licenses copy + resend buttons', () => {
+  // ---------------------------------------------------------------------
+  // Copy button
+  // ---------------------------------------------------------------------
+
+  test('copy button writes the FULL license key (not the truncated preview) to clipboard', async ({ page }) => {
+    // Stub navigator.clipboard.writeText BEFORE any page script attaches so
+    // the click handler picks up the stub. addInitScript runs in every
+    // frame on every navigation, which is what we need here.
+    await page.addInitScript(() => {
+      (window as unknown as { __copiedTexts: string[] }).__copiedTexts = [];
+      // Many environments expose navigator.clipboard read-only; redefine
+      // to be safe across browsers.
+      Object.defineProperty(navigator, 'clipboard', {
+        configurable: true,
+        value: {
+          writeText: async (text: string) => {
+            (window as unknown as { __copiedTexts: string[] }).__copiedTexts.push(text);
+          },
+        },
+      });
+    });
+
+    await page.goto('/admin/licenses/');
+
+    // Wait for the table to populate. The stat counter `#active-count`
+    // flipping off the placeholder `--` is the same readiness signal the
+    // sibling spec uses; reusing it keeps the readiness contract single-
+    // sourced.
+    await expect(page.locator('#active-count')).not.toHaveText('--', { timeout: 15_000 });
+
+    const firstCopyBtn = page.locator('.copy-key-btn').first();
+    await expect(firstCopyBtn).toBeVisible();
+
+    // The DOM only carries the truncated preview (e.g. `aidn.abc1...wxyz`).
+    // The full key lives in the in-memory allLicenses array and is only
+    // surfaced via clipboard. Snapshot the preview so we can verify the
+    // copied string is a SUPERSET of it (i.e., the full key, not the
+    // truncated form the page displays).
+    const preview = (await firstCopyBtn.textContent() ?? '').trim();
+    expect(preview, 'copy button should render a non-empty preview').not.toEqual('');
+
+    await firstCopyBtn.click();
+
+    // Click flashes "copied" then reverts. Don't race the revert — assert
+    // on the captured clipboard text directly.
+    const copied = await page.evaluate(() => {
+      return (window as unknown as { __copiedTexts: string[] }).__copiedTexts;
+    });
+    expect(copied).toHaveLength(1);
+    const copiedKey = copied[0];
+
+    // The copied string must NOT be just the preview — the whole point of
+    // the button is to recover the full key. The preview contains a `...`
+    // separator from the substring(0,8) + '...' + substring(-4) format;
+    // the full key never contains that ellipsis.
+    expect(copiedKey, 'clipboard should receive the full key, not the truncated preview')
+      .not.toContain('...');
+    expect(copiedKey.length).toBeGreaterThan(preview.length);
+
+    // Brief feedback flash should fire and then revert. We check it
+    // appeared at least once (race-tolerant).
+    await expect(firstCopyBtn).toContainText(/copied|aidn|harm/i, { timeout: 2000 });
+  });
+
+  test('copy button surfaces a clipboard-permission alert when writeText throws', async ({ page }) => {
+    await page.addInitScript(() => {
+      Object.defineProperty(navigator, 'clipboard', {
+        configurable: true,
+        value: {
+          writeText: async () => { throw new Error('Permission denied'); },
+        },
+      });
+    });
+
+    // Capture the alert text. window.alert is a blocking dialog — Playwright's
+    // dialog handler fires before the JS resumes so we both record the
+    // message and dismiss the modal.
+    const alerts: string[] = [];
+    page.on('dialog', async (d) => {
+      alerts.push(d.message());
+      await d.dismiss();
+    });
+
+    await page.goto('/admin/licenses/');
+    await expect(page.locator('#active-count')).not.toHaveText('--', { timeout: 15_000 });
+
+    await page.locator('.copy-key-btn').first().click();
+
+    // Allow the click handler's async catch path to run and dispatch alert().
+    await expect.poll(() => alerts.length, { timeout: 3_000 }).toBeGreaterThan(0);
+
+    const msg = alerts[0];
+    // Message must point at REAL workarounds. The earlier version
+    // suggested "Reveal the key via the activations modal" which the
+    // activations modal does not actually do; PR #1256 review feedback
+    // surfaced that as misleading and we fixed it. Lock the fix in.
+    expect(msg.toLowerCase()).not.toContain('activations modal');
+    expect(msg.toLowerCase()).toMatch(/permission|browser|https|secure/);
+  });
+
+  // ---------------------------------------------------------------------
+  // Resend button
+  // ---------------------------------------------------------------------
+
+  // Helper: route handler for the resend edge function. Captures every
+  // body that hits it and lets the caller specify a canned response.
+  async function stubResend(
+    page: import('@playwright/test').Page,
+    resp: { status: number; body: Record<string, unknown> },
+  ): Promise<{ requests: Array<{ body: unknown }> }> {
+    const captured: Array<{ body: unknown }> = [];
+    await page.route('**/functions/v1/admin-resend-license-email**', async (route: Route) => {
+      let parsed: unknown = null;
+      try {
+        parsed = JSON.parse(route.request().postData() ?? 'null');
+      } catch { /* leave null */ }
+      captured.push({ body: parsed });
+      await route.fulfill({
+        status: resp.status,
+        contentType: 'application/json',
+        body: JSON.stringify(resp.body),
+      });
+    });
+    return { requests: captured };
+  }
+
+  test('resend button POSTs license_id and shows "sent" on a 200 response', async ({ page }) => {
+    const stub = await stubResend(page, {
+      status: 200,
+      body: { success: true, recipient: 'test@example.com', message: 'OK' },
+    });
+
+    // Auto-accept the confirm() dialog the click handler shows before
+    // making the request. Without this, the request never fires.
+    page.on('dialog', (d) => d.accept());
+
+    await page.goto('/admin/licenses/');
+    await expect(page.locator('#active-count')).not.toHaveText('--', { timeout: 15_000 });
+
+    const firstResend = page.locator('.resend-email-btn').first();
+    await expect(firstResend).toBeVisible();
+    const expectedId = await firstResend.getAttribute('data-id');
+    expect(expectedId, 'resend button must carry the license row id on data-id').not.toBeNull();
+
+    await firstResend.click();
+
+    // Surface the "sent" feedback. The handler sets innerHTML to a span;
+    // assert by visible text rather than DOM structure to keep the test
+    // resilient to future UI tweaks.
+    await expect(firstResend).toContainText(/sent/i, { timeout: 5_000 });
+
+    // Exactly one POST should have hit the route, with our license id.
+    expect(stub.requests).toHaveLength(1);
+    expect(stub.requests[0].body).toEqual({ license_id: expectedId });
+  });
+
+  test('resend button shows "failed" + tooltip carrying the server message on a 422', async ({ page }) => {
+    const stub = await stubResend(page, {
+      status: 422,
+      body: {
+        success: false,
+        error: 'no_recipient_email',
+        message: 'Edit the license customer_email before retrying.',
+      },
+    });
+
+    page.on('dialog', (d) => d.accept());
+
+    await page.goto('/admin/licenses/');
+    await expect(page.locator('#active-count')).not.toHaveText('--', { timeout: 15_000 });
+
+    const firstResend = page.locator('.resend-email-btn').first();
+    await firstResend.click();
+
+    await expect(firstResend).toContainText(/failed/i, { timeout: 5_000 });
+
+    // The handler embeds the server message into the title attribute on
+    // the inner <span>, so the admin sees WHICH failure category fired
+    // (no_recipient → 422) on hover without opening devtools.
+    const failedSpan = firstResend.locator('span[title]').first();
+    await expect(failedSpan).toHaveAttribute('title', /customer_email/i, { timeout: 5_000 });
+
+    expect(stub.requests).toHaveLength(1);
+  });
+
+  test('resend button makes no request when the admin cancels the confirm dialog', async ({ page }) => {
+    let invoked = false;
+    await page.route('**/functions/v1/admin-resend-license-email**', async (route: Route) => {
+      invoked = true;
+      await route.fulfill({ status: 200, contentType: 'application/json', body: '{}' });
+    });
+
+    // Dismiss the confirm() dialog this time. The click handler should
+    // short-circuit and never enqueue a network call.
+    page.on('dialog', (d) => d.dismiss());
+
+    await page.goto('/admin/licenses/');
+    await expect(page.locator('#active-count')).not.toHaveText('--', { timeout: 15_000 });
+
+    await page.locator('.resend-email-btn').first().click();
+
+    // Give any (broken) request a tick to slip through before asserting it
+    // didn't. Without the small wait an immediate assertion could pass
+    // even if the dismiss path were broken.
+    await page.waitForTimeout(500);
+    expect(invoked, 'cancelled confirm must not invoke the resend endpoint').toBe(false);
+  });
+});

--- a/website/vercel.json
+++ b/website/vercel.json
@@ -1,5 +1,5 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "version": 2,
-  "ignoreCommand": "exit 0"
+  "ignoreCommand": "if [ \"$VERCEL_GIT_COMMIT_REF\" = master ] || [ \"$VERCEL_GIT_COMMIT_REF\" = main ]; then exit 1; fi; git -C \"$(git rev-parse --show-toplevel)\" diff --quiet HEAD^ HEAD -- 'website/' && exit 0 || exit 1"
 }

--- a/website/vercel.json
+++ b/website/vercel.json
@@ -1,5 +1,5 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "version": 2,
-  "ignoreCommand": "if [ \"$VERCEL_GIT_COMMIT_REF\" = master ] || [ \"$VERCEL_GIT_COMMIT_REF\" = main ]; then exit 1; fi; git diff --quiet HEAD^ HEAD -- . && exit 0 || exit 1"
+  "ignoreCommand": "if [ \"$VERCEL_GIT_COMMIT_REF\" = master ] || [ \"$VERCEL_GIT_COMMIT_REF\" = main ]; then exit 1; fi; PREV=\"${VERCEL_GIT_PREVIOUS_SHA:-}\"; CURR=\"${VERCEL_GIT_COMMIT_SHA:-HEAD}\"; if [ -z \"$PREV\" ]; then exit 1; fi; git diff --quiet \"$PREV\" \"$CURR\" -- . && exit 0 || exit 1"
 }

--- a/website/vercel.json
+++ b/website/vercel.json
@@ -1,5 +1,5 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "version": 2,
-  "ignoreCommand": "if [ \"$VERCEL_GIT_COMMIT_REF\" = master ] || [ \"$VERCEL_GIT_COMMIT_REF\" = main ]; then exit 1; fi; git -C \"$(git rev-parse --show-toplevel)\" diff --quiet HEAD^ HEAD -- 'website/' && exit 0 || exit 1"
+  "ignoreCommand": "if [ \"$VERCEL_GIT_COMMIT_REF\" = master ] || [ \"$VERCEL_GIT_COMMIT_REF\" = main ]; then exit 1; fi; git diff --quiet HEAD^ HEAD -- . && exit 0 || exit 1"
 }


### PR DESCRIPTION
## Summary

Two operational gaps in the license-issuance flow:

1. **No email on purchase or community-trial activation.** `stripe-webhook` (paid Stripe checkout) and `register-community-license` (free trial) both insert a `license_keys` row and return — they never email the user the key. A buyer who closes the success page or whose session expired had no way to retrieve the key short of going back through OAuth.
2. **Admin dashboard had no way to retrieve a customer's full key.** `/admin/licenses` only renders a truncated preview (`abc12...wxyz`) and the click action opens the activations modal. Support couldn't even copy a key to send manually, let alone re-trigger the issuance email.

This PR adds:

- **Resend HTTPS-API helper at `_shared/email.ts`.** Best-effort send; failures log but never throw. Configurable via Supabase secrets `RESEND_API_KEY`, `EMAIL_FROM`, `ACCOUNT_URL`.
- **Email dispatch in `stripe-webhook` after `handleCheckoutCompleted` issues the row.** Recipient comes from `session.customer_details.email`.
- **Email dispatch in `register-community-license` after the row is committed.** Recipient comes from `user.email`.
- **Admin row controls on `/admin/licenses`:**
  - **copy** — `navigator.clipboard.writeText(license_key)` of the FULL key with in-place \`copied\` flash.
  - **resend** — invokes new `admin-resend-license-email` edge function.
- **`admin-resend-license-email` edge function.** Two-factor admin gate (Supabase JWT + `is_admin()` RPC); recipient resolution prefers `license.customer_email` then falls back to the linked profile's email; fails 422 if neither is available with an actionable message.

## Operator setup required before this works in prod

- [ ] Set the Supabase project secret \`RESEND_API_KEY\` to a valid Resend key.
- [ ] (Optional) Override \`EMAIL_FROM\` if not using \`AiDotNet <licenses@aidotnet.dev>\`. Sender domain must be verified in the Resend dashboard.
- [ ] Deploy the new \`admin-resend-license-email\` edge function: \`supabase functions deploy admin-resend-license-email\`.
- [ ] Re-deploy \`stripe-webhook\` and \`register-community-license\` with the new shared module.

If \`RESEND_API_KEY\` is unset, all email paths log a warning and skip — issuance still succeeds, behavior is unchanged from current production.

## Test plan

- [ ] \`supabase functions serve\` locally; trigger the \`stripe-webhook\` with a recorded \`checkout.session.completed\` event; verify Resend logs show the dispatched email and the license row exists in DB.
- [ ] Hit \`register-community-license\` with a valid auth token; verify response contains \`license_key\` AND that the user receives an email matching the template.
- [ ] On \`/admin/licenses\`, click the per-row \`copy\` button; paste into a text field; verify the FULL key string copied (not the truncated preview).
- [ ] On \`/admin/licenses\`, click the per-row \`resend\` button as a logged-in admin; verify the customer receives a new email and the function log shows status 200.
- [ ] As a non-admin authenticated user, hit \`admin-resend-license-email\` directly with a valid JWT; verify 403.
- [ ] Edge case: license row has no \`customer_email\` AND no profile email — verify resend returns 422 with the explicit \`no_recipient_email\` error.

## Out of scope

- \`/account/licenses\` already has a working Copy Key button (lines 406, 443-456); not touched.
- The separate GitHub OAuth bug on \`/login\` (only Google works) is filed as its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Admin licenses table: per-row Copy (full key) and Resend Email actions with sending/sent/failed feedback.
  * Automatic license emails sent after community registrations and completed purchases.
  * License keys now use a new dash-delimited format visible in the UI.

* **Bug Fixes**
  * Fixed a server-side activation error so first-time machine activations no longer fail.

* **Tests**
  * Added end-to-end tests covering copy and resend flows, success/failure cases, and UI feedback.

* **Chores**
  * Refined deployment ignore logic for CI/preview builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->