### PR TITLE
fix(auth): surface OAuth errors on /auth/callback instead of silent timeout

### DIFF
--- a/website/playwright.config.ts
+++ b/website/playwright.config.ts
@@ -94,6 +94,19 @@ export default defineConfig({
       testMatch: /admin\.setup\.ts/,
     },
 
+    // ---------- Anonymous auth specs ----------
+    //
+    // Auth flow specs that DON'T need a logged-in session — error
+    // handling on /auth/callback, sign-in form validation, etc.
+    // Stays separate from anon-desktop so the auth folder's setup
+    // files (user.setup.ts, admin.setup.ts) don't get picked up here.
+    {
+      name: 'auth-anon',
+      testDir: './tests/e2e/auth',
+      testIgnore: ['**/*.setup.ts'],
+      use: { viewport: { width: 1440, height: 900 } },
+    },
+
     // ---------- Authenticated projects ----------
     {
       name: 'user-auth',

--- a/website/src/pages/auth/callback.astro
+++ b/website/src/pages/auth/callback.astro
@@ -75,19 +75,33 @@ const base = import.meta.env.BASE_URL;
           : window.location.hash,
       );
 
-      // Hash takes precedence over search: implicit-flow errors are more
-      // specific (they include error_code from the IdP) than code-flow
-      // errors which Supabase rewrites into the search string.
-      const pick = (key: string) => hash.get(key) ?? search.get(key) ?? undefined;
-
-      const error = pick('error');
-      if (!error) return null;
-
-      return {
-        error,
-        errorCode: pick('error_code'),
-        errorDescription: pick('error_description'),
-      };
+      // Per-SOURCE precedence: if the hash carries any `error`, use ALL
+      // hash fields together; otherwise use ALL search fields together.
+      // The previous per-field merge (`hash.get(key) ?? search.get(key)`)
+      // could splice an `error` from one source with an
+      // `error_description` from the OTHER, producing a synthetic error
+      // that didn't actually arrive from any single OAuth callback layer.
+      // Hash → implicit flow (IdP returns directly to the browser).
+      // Search → code flow (Supabase rewrites hash into ?error after the
+      // PKCE token swap). They're different protocol layers and the
+      // fields within one shouldn't mix with the fields of another.
+      const hashError = hash.get('error');
+      if (hashError) {
+        return {
+          error: hashError,
+          errorCode: hash.get('error_code') ?? undefined,
+          errorDescription: hash.get('error_description') ?? undefined,
+        };
+      }
+      const searchError = search.get('error');
+      if (searchError) {
+        return {
+          error: searchError,
+          errorCode: search.get('error_code') ?? undefined,
+          errorDescription: search.get('error_description') ?? undefined,
+        };
+      }
+      return null;
     }
 
     function showFatalError(headline: string, details: string, hint?: string) {

--- a/website/src/pages/auth/callback.astro
+++ b/website/src/pages/auth/callback.astro
@@ -85,23 +85,65 @@ const base = import.meta.env.BASE_URL;
       // Search → code flow (Supabase rewrites hash into ?error after the
       // PKCE token swap). They're different protocol layers and the
       // fields within one shouldn't mix with the fields of another.
-      const hashError = hash.get('error');
-      if (hashError) {
+      // Treat any of `error`, `error_code`, `error_description` as a
+      // failure marker — some IdP / Supabase code paths omit `error`
+      // and return only `error_code` (e.g. `?error_code=otp_expired`)
+      // or `error_description` alone. The PR description's contract is
+      // "surface every URL-level OAuth failure", so we can't gate on
+      // `error` being present or those callbacks fall through to the
+      // 10-second timeout with no actionable feedback.
+      const hashHasFailure =
+        hash.get('error') !== null ||
+        hash.get('error_code') !== null ||
+        hash.get('error_description') !== null;
+      if (hashHasFailure) {
         return {
-          error: hashError,
+          error: hash.get('error') ?? undefined,
           errorCode: hash.get('error_code') ?? undefined,
           errorDescription: hash.get('error_description') ?? undefined,
         };
       }
-      const searchError = search.get('error');
-      if (searchError) {
+      const searchHasFailure =
+        search.get('error') !== null ||
+        search.get('error_code') !== null ||
+        search.get('error_description') !== null;
+      if (searchHasFailure) {
         return {
-          error: searchError,
+          error: search.get('error') ?? undefined,
           errorCode: search.get('error_code') ?? undefined,
           errorDescription: search.get('error_description') ?? undefined,
         };
       }
       return null;
+    }
+
+    /**
+     * Reduces a user-supplied `?redirect=` value to a same-origin path.
+     *
+     * Without sanitization, an attacker can craft a phishing link of the
+     * form `/auth/callback?redirect=https://attacker.example/fake-account`.
+     * The user signs in successfully, the script assigns
+     * `window.location.href = '<attacker URL>'`, and the browser
+     * navigates off-domain — but the user just typed their password into
+     * what looked like our legitimate sign-in flow. The attacker's
+     * landing page can then mimic our /account/ UI and harvest tokens
+     * or trigger follow-up actions.
+     *
+     * Strategy:
+     *   - Reject anything that doesn't start with `/` (absolute or
+     *     protocol-relative URLs go elsewhere by construction).
+     *   - Reject `//` (protocol-relative — `//evil.example` resolves to
+     *     `https://evil.example`).
+     *   - Fall back to the default `${base}account/` for empty / null
+     *     / disallowed input.
+     */
+    function sanitizeRedirect(raw: string | null): string {
+      const fallback = `${base}account/`;
+      if (!raw) return fallback;
+      // Same-origin paths only: must start with a single '/' (not '//').
+      if (raw.startsWith('//')) return fallback;
+      if (!raw.startsWith('/')) return fallback;
+      return raw;
     }
 
     function showFatalError(headline: string, details: string, hint?: string) {
@@ -115,16 +157,30 @@ const base = import.meta.env.BASE_URL;
       if (spinner) spinner.classList.add('hidden');
 
       if (errorDiv) {
-        // Build a structured error block so the message is readable AND the
-        // technical details are visible for support / debugging. Browsers
-        // will render the <pre> block in a monospace font so error_description
-        // strings (which often include URLs and config keys) stay scannable.
+        // Build a structured error block. Browsers render the <pre>
+        // block in a monospace font so error_description strings (which
+        // often include URLs and config keys) stay scannable.
+        //
+        // Phishing surface: the IdP-controlled `details` text is
+        // user-controlled (anyone can craft /auth/callback?error=...) and
+        // reflecting it verbatim on a first-party sign-in page lets an
+        // attacker write branded support-scam messages on our domain.
+        // Hide the raw provider text behind a <details> disclosure
+        // ("Show technical details") so the default sign-in-failed page
+        // shows only our mapped headline + hint copy. HTML-escaping is
+        // still applied (safe()) so XSS is blocked even when expanded.
         const safe = (s: string) => s.replace(/[&<>]/g, (c) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;' }[c] ?? c));
         const hintHtml = hint ? `<p class="mt-3 text-xs text-slate-600 dark:text-slate-400">${safe(hint)}</p>` : '';
+        const detailsHtml = details
+          ? `<details class="mt-3 text-xs text-slate-600 dark:text-slate-400">
+               <summary class="cursor-pointer select-none">Show technical details</summary>
+               <pre class="mt-2 whitespace-pre-wrap break-words bg-red-100/40 dark:bg-red-900/30 p-2 rounded">${safe(details)}</pre>
+             </details>`
+          : '';
         errorDiv.innerHTML = `
           <p class="font-semibold text-red-700 dark:text-red-300">${safe(headline)}</p>
-          <pre class="mt-2 text-xs whitespace-pre-wrap break-words bg-red-100/40 dark:bg-red-900/30 p-2 rounded">${safe(details)}</pre>
           ${hintHtml}
+          ${detailsHtml}
           <p class="mt-3"><a href="${base}login/" class="underline font-medium">Back to login</a></p>
         `;
         errorDiv.classList.remove('hidden');
@@ -141,8 +197,11 @@ const base = import.meta.env.BASE_URL;
         // containing a literal '%' (e.g. a value previously encoded as
         // %25 → '%' that decodes once but then trips a second decode)
         // and (b) corrupt literal '+' characters from the IdP message.
+        // urlError.error can now be undefined (parser accepts callbacks
+        // that send only error_code or error_description). Skip the
+        // `error: …` line in that case rather than emit `error: undefined`.
         const detailLines = [
-          `error: ${urlError.error}`,
+          urlError.error ? `error: ${urlError.error}` : null,
           urlError.errorCode ? `error_code: ${urlError.errorCode}` : null,
           urlError.errorDescription ? `error_description: ${urlError.errorDescription}` : null,
         ].filter(Boolean) as string[];
@@ -188,7 +247,7 @@ const base = import.meta.env.BASE_URL;
 
         if (data.session) {
           const params = new URLSearchParams(window.location.search);
-          const redirectTo = params.get('redirect') || `${base}account/`;
+          const redirectTo = sanitizeRedirect(params.get('redirect'));
           window.location.href = redirectTo;
           return;
         }
@@ -203,11 +262,19 @@ const base = import.meta.env.BASE_URL;
         let timeoutId: ReturnType<typeof setTimeout> | undefined;
 
         const { data: { subscription } } = supabase.auth.onAuthStateChange((event, session) => {
-          if (event === 'SIGNED_IN' && session) {
+          // Accept both SIGNED_IN and INITIAL_SESSION. Supabase emits
+          // INITIAL_SESSION right after the client constructor finishes
+          // loading the session from storage; if the prior getSession()
+          // returned null because the storage read hadn't completed yet,
+          // INITIAL_SESSION is the event that fires once it has, and
+          // ignoring it would let valid sessions fall through to the
+          // 10s timeout. (Documented:
+          // supabase.com/docs/reference/javascript/auth-onauthstatechange.)
+          if (session && (event === 'SIGNED_IN' || event === 'INITIAL_SESSION')) {
             subscription.unsubscribe();
             if (timeoutId !== undefined) clearTimeout(timeoutId);
             const params = new URLSearchParams(window.location.search);
-            const redirectTo = params.get('redirect') || `${base}account/`;
+            const redirectTo = sanitizeRedirect(params.get('redirect'));
             window.location.href = redirectTo;
           }
         });
@@ -235,11 +302,18 @@ const base = import.meta.env.BASE_URL;
         // useful fields instead. Error.message is the readable text;
         // a fallback JSON.stringify catches non-Error throws (some
         // Supabase SDK paths reject with a plain object).
+        // JSON.stringify can return `undefined` (not a string) when given
+        // a top-level symbol, function, or undefined value — the type is
+        // string|undefined, so we coalesce to String(err) when it does.
+        // The try/catch covers circular refs which throw TypeError.
         let detail: string;
         if (err instanceof Error) {
           detail = err.message || err.toString();
         } else {
-          try { detail = JSON.stringify(err); }
+          try {
+            const json = JSON.stringify(err);
+            detail = json ?? String(err);
+          }
           catch { detail = String(err); }
         }
         showFatalError('An unexpected error occurred.', detail);

--- a/website/src/pages/auth/callback.astro
+++ b/website/src/pages/auth/callback.astro
@@ -108,10 +108,16 @@ const base = import.meta.env.BASE_URL;
       // Layer 1+2: provider/redirect-level error embedded in the URL.
       const urlError = parseAuthError();
       if (urlError) {
+        // URLSearchParams.get() already percent-decodes its return value
+        // and converts '+' to space, so the error fields here are plain
+        // text. Decoding again would (a) throw on legitimate messages
+        // containing a literal '%' (e.g. a value previously encoded as
+        // %25 → '%' that decodes once but then trips a second decode)
+        // and (b) corrupt literal '+' characters from the IdP message.
         const detailLines = [
           `error: ${urlError.error}`,
           urlError.errorCode ? `error_code: ${urlError.errorCode}` : null,
-          urlError.errorDescription ? `error_description: ${decodeURIComponent(urlError.errorDescription).replace(/\+/g, ' ')}` : null,
+          urlError.errorDescription ? `error_description: ${urlError.errorDescription}` : null,
         ].filter(Boolean) as string[];
 
         // Best-effort hint: most common cause of error_code=server_error on
@@ -126,7 +132,14 @@ const base = import.meta.env.BASE_URL;
         } else if (urlError.error === 'access_denied') {
           hint = 'You declined to grant the requested permissions. '
             + 'Try again and approve the requested scopes, or use a different sign-in method.';
-        } else if (urlError.errorCode === 'unsupported_provider' || urlError.errorDescription?.includes('not enabled')) {
+        } else if (urlError.errorCode === 'unsupported_provider'
+            || urlError.error === 'unsupported_provider'
+            || urlError.errorDescription?.includes('not enabled')) {
+          // Check both fields: providers split inconsistently — some put
+          // the disabled-provider name in error_code, others in error.
+          // Missing the latter would have left a callback like
+          // ?error=unsupported_provider&error_description=... with the
+          // generic message instead of the actionable hint.
           hint = 'This sign-in provider is currently disabled on the server. '
             + 'Use a different method (e.g. Google or email + password).';
         }
@@ -154,9 +167,18 @@ const base = import.meta.env.BASE_URL;
         }
 
         // No session yet, no URL error — wait for auth state change.
+        // Hold the timeout id so the SIGNED_IN handler can clear it
+        // before the redirect — otherwise a near-deadline success
+        // (event at ~9.9s) would still fire the timeout's
+        // showFatalError after the redirect has already started, and
+        // the user would briefly see the "did not complete in time"
+        // message before navigation completes.
+        let timeoutId: ReturnType<typeof setTimeout> | undefined;
+
         const { data: { subscription } } = supabase.auth.onAuthStateChange((event, session) => {
           if (event === 'SIGNED_IN' && session) {
             subscription.unsubscribe();
+            if (timeoutId !== undefined) clearTimeout(timeoutId);
             const params = new URLSearchParams(window.location.search);
             const redirectTo = params.get('redirect') || `${base}account/`;
             window.location.href = redirectTo;
@@ -166,7 +188,7 @@ const base = import.meta.env.BASE_URL;
         // Hard timeout. The 10s window is intentional: if the session-storage
         // write hasn't fired by now, the browser is almost certainly blocking
         // third-party cookies, and the user needs an explicit message.
-        setTimeout(() => {
+        timeoutId = setTimeout(() => {
           subscription.unsubscribe();
           showFatalError(
             'Sign-in did not complete in time.',

--- a/website/src/pages/auth/callback.astro
+++ b/website/src/pages/auth/callback.astro
@@ -15,7 +15,20 @@ const base = import.meta.env.BASE_URL;
       <h1 id="auth-heading" class="text-xl font-semibold text-slate-900 dark:text-white mb-2">Signing you in...</h1>
       <p id="auth-subtext" class="text-sm text-slate-500 dark:text-slate-400">Please wait while we complete authentication.</p>
 
-      <div id="auth-error" class="hidden mt-6 p-4 text-sm text-left text-red-600 dark:text-red-400 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-xl max-w-xl mx-auto">
+      <!--
+        role="alert" + aria-live="assertive" + aria-atomic="true" make the
+        error container accessible to screen readers — without these the
+        dynamically-injected error message would be announced silently to
+        AT users (the container is a hidden div until showFatalError fills
+        it). aria-atomic ensures the entire block re-announces on update
+        instead of just the diff.
+      -->
+      <div
+        id="auth-error"
+        role="alert"
+        aria-live="assertive"
+        aria-atomic="true"
+        class="hidden mt-6 p-4 text-sm text-left text-red-600 dark:text-red-400 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-xl max-w-xl mx-auto">
       </div>
     </div>
   </div>
@@ -190,6 +203,11 @@ const base = import.meta.env.BASE_URL;
         // third-party cookies, and the user needs an explicit message.
         timeoutId = setTimeout(() => {
           subscription.unsubscribe();
+          // The PR description says every failure path is logged to
+          // console so devtools captures it for support / debugging;
+          // the timeout path was the one exception. Log explicitly here
+          // so the symptom ("sign-in just stalls") leaves a stack trace.
+          console.error('[auth/callback] timed out waiting for SIGNED_IN event after 10s');
           showFatalError(
             'Sign-in did not complete in time.',
             'Supabase did not surface a SIGNED_IN event within 10 seconds.',
@@ -199,7 +217,18 @@ const base = import.meta.env.BASE_URL;
         }, 10000);
       } catch (err) {
         console.error('[auth/callback] unexpected exception:', err);
-        showFatalError('An unexpected error occurred.', String(err));
+        // Don't render Object's "[object Object]" toString — surface the
+        // useful fields instead. Error.message is the readable text;
+        // a fallback JSON.stringify catches non-Error throws (some
+        // Supabase SDK paths reject with a plain object).
+        let detail: string;
+        if (err instanceof Error) {
+          detail = err.message || err.toString();
+        } else {
+          try { detail = JSON.stringify(err); }
+          catch { detail = String(err); }
+        }
+        showFatalError('An unexpected error occurred.', detail);
       }
     }
 

--- a/website/src/pages/auth/callback.astro
+++ b/website/src/pages/auth/callback.astro
@@ -6,16 +6,16 @@ const base = import.meta.env.BASE_URL;
 <BaseLayout title="Authenticating... - AiDotNet" description="Processing your authentication.">
   <div class="pt-24 pb-16 min-h-screen flex items-center justify-center">
     <div class="text-center">
-      <div class="inline-flex items-center justify-center w-16 h-16 mb-6 rounded-full bg-gradient-to-r from-brand-blue/10 to-brand-purple/10">
+      <div id="auth-spinner" class="inline-flex items-center justify-center w-16 h-16 mb-6 rounded-full bg-gradient-to-r from-brand-blue/10 to-brand-purple/10">
         <svg class="w-8 h-8 text-brand-blue animate-spin" fill="none" viewBox="0 0 24 24">
           <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
           <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
         </svg>
       </div>
-      <h1 class="text-xl font-semibold text-slate-900 dark:text-white mb-2">Signing you in...</h1>
-      <p class="text-sm text-slate-500 dark:text-slate-400">Please wait while we complete authentication.</p>
+      <h1 id="auth-heading" class="text-xl font-semibold text-slate-900 dark:text-white mb-2">Signing you in...</h1>
+      <p id="auth-subtext" class="text-sm text-slate-500 dark:text-slate-400">Please wait while we complete authentication.</p>
 
-      <div id="auth-error" class="hidden mt-6 p-4 text-sm text-red-600 dark:text-red-400 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-xl max-w-md mx-auto">
+      <div id="auth-error" class="hidden mt-6 p-4 text-sm text-left text-red-600 dark:text-red-400 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-xl max-w-xl mx-auto">
       </div>
     </div>
   </div>
@@ -25,48 +25,159 @@ const base = import.meta.env.BASE_URL;
 
     const base = import.meta.env.BASE_URL || '/';
 
+    /**
+     * OAuth providers can fail at three different layers, each surfacing
+     * the error in a different place:
+     *
+     *   1. PKCE / code-flow error → URL search params: ?error=...&error_description=...
+     *   2. Implicit-flow error    → URL hash params:   #error=...&error_description=...
+     *   3. Session-exchange error → returned from supabase.auth.getSession()
+     *
+     * The previous version of this page only checked (3), so any error
+     * routed through (1) or (2) — which is what every Supabase-side
+     * provider config failure produces — landed on a 10-second silent
+     * timeout that printed only "Authentication timed out". That made
+     * "GitHub OAuth doesn't work" effectively undebuggable from the
+     * client.
+     *
+     * Read all three layers and surface whichever fires first. Keeps the
+     * 10-second fallback for the case where the redirect lands here
+     * without any error param AND the session never materializes (e.g.
+     * a third-party cookie block).
+     */
+
+    type AuthErrorParts = {
+      error?: string;
+      errorCode?: string;
+      errorDescription?: string;
+    };
+
+    function parseAuthError(): AuthErrorParts | null {
+      const search = new URLSearchParams(window.location.search);
+      const hash = new URLSearchParams(
+        // Hash starts with '#'; URLSearchParams expects no leading marker.
+        // Strip it before parsing so /auth/callback#error=... resolves.
+        window.location.hash.startsWith('#')
+          ? window.location.hash.slice(1)
+          : window.location.hash,
+      );
+
+      // Hash takes precedence over search: implicit-flow errors are more
+      // specific (they include error_code from the IdP) than code-flow
+      // errors which Supabase rewrites into the search string.
+      const pick = (key: string) => hash.get(key) ?? search.get(key) ?? undefined;
+
+      const error = pick('error');
+      if (!error) return null;
+
+      return {
+        error,
+        errorCode: pick('error_code'),
+        errorDescription: pick('error_description'),
+      };
+    }
+
+    function showFatalError(headline: string, details: string, hint?: string) {
+      const errorDiv = document.getElementById('auth-error');
+      const spinner = document.getElementById('auth-spinner');
+      const heading = document.getElementById('auth-heading');
+      const subtext = document.getElementById('auth-subtext');
+
+      if (heading) heading.textContent = 'Sign-in failed';
+      if (subtext) subtext.textContent = '';
+      if (spinner) spinner.classList.add('hidden');
+
+      if (errorDiv) {
+        // Build a structured error block so the message is readable AND the
+        // technical details are visible for support / debugging. Browsers
+        // will render the <pre> block in a monospace font so error_description
+        // strings (which often include URLs and config keys) stay scannable.
+        const safe = (s: string) => s.replace(/[&<>]/g, (c) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;' }[c] ?? c));
+        const hintHtml = hint ? `<p class="mt-3 text-xs text-slate-600 dark:text-slate-400">${safe(hint)}</p>` : '';
+        errorDiv.innerHTML = `
+          <p class="font-semibold text-red-700 dark:text-red-300">${safe(headline)}</p>
+          <pre class="mt-2 text-xs whitespace-pre-wrap break-words bg-red-100/40 dark:bg-red-900/30 p-2 rounded">${safe(details)}</pre>
+          ${hintHtml}
+          <p class="mt-3"><a href="${base}login/" class="underline font-medium">Back to login</a></p>
+        `;
+        errorDiv.classList.remove('hidden');
+      }
+    }
+
     async function handleCallback() {
+      // Layer 1+2: provider/redirect-level error embedded in the URL.
+      const urlError = parseAuthError();
+      if (urlError) {
+        const detailLines = [
+          `error: ${urlError.error}`,
+          urlError.errorCode ? `error_code: ${urlError.errorCode}` : null,
+          urlError.errorDescription ? `error_description: ${decodeURIComponent(urlError.errorDescription).replace(/\+/g, ' ')}` : null,
+        ].filter(Boolean) as string[];
+
+        // Best-effort hint: most common cause of error_code=server_error on
+        // a previously-working provider is a missing client secret on the
+        // Supabase auth provider config. Surface that to the user without
+        // pretending we know it for certain.
+        let hint: string | undefined;
+        if (urlError.errorCode === 'server_error' || urlError.error === 'server_error') {
+          hint = 'This usually means the OAuth provider is misconfigured on the server side '
+            + '(client secret rotated, callback URL drift, or provider disabled). '
+            + 'Try a different sign-in method while we investigate.';
+        } else if (urlError.error === 'access_denied') {
+          hint = 'You declined to grant the requested permissions. '
+            + 'Try again and approve the requested scopes, or use a different sign-in method.';
+        } else if (urlError.errorCode === 'unsupported_provider' || urlError.errorDescription?.includes('not enabled')) {
+          hint = 'This sign-in provider is currently disabled on the server. '
+            + 'Use a different method (e.g. Google or email + password).';
+        }
+
+        console.error('[auth/callback] OAuth returned an error:', urlError);
+        showFatalError('We couldn\'t complete the sign-in.', detailLines.join('\n'), hint);
+        return;
+      }
+
       try {
-        // Supabase processes the hash fragment from the OAuth redirect
+        // Layer 3: session-exchange (PKCE token swap) error.
         const { data, error } = await supabase.auth.getSession();
 
         if (error) {
-          showError(error.message);
+          console.error('[auth/callback] getSession() error:', error);
+          showFatalError('Session exchange failed.', error.message);
           return;
         }
 
         if (data.session) {
-          // Get redirect parameter
           const params = new URLSearchParams(window.location.search);
           const redirectTo = params.get('redirect') || `${base}account/`;
           window.location.href = redirectTo;
-        } else {
-          // No session yet, wait for auth state change
-          const { data: { subscription } } = supabase.auth.onAuthStateChange((event, session) => {
-            if (event === 'SIGNED_IN' && session) {
-              subscription.unsubscribe();
-              const params = new URLSearchParams(window.location.search);
-              const redirectTo = params.get('redirect') || `${base}account/`;
-              window.location.href = redirectTo;
-            }
-          });
-
-          // Timeout after 10 seconds
-          setTimeout(() => {
-            subscription.unsubscribe();
-            showError('Authentication timed out. Please try signing in again.');
-          }, 10000);
+          return;
         }
-      } catch (err) {
-        showError('An unexpected error occurred. Please try signing in again.');
-      }
-    }
 
-    function showError(message: string) {
-      const errorDiv = document.getElementById('auth-error');
-      if (errorDiv) {
-        errorDiv.innerHTML = `${message} <a href="${base}login/" class="underline font-medium">Back to login</a>`;
-        errorDiv.classList.remove('hidden');
+        // No session yet, no URL error — wait for auth state change.
+        const { data: { subscription } } = supabase.auth.onAuthStateChange((event, session) => {
+          if (event === 'SIGNED_IN' && session) {
+            subscription.unsubscribe();
+            const params = new URLSearchParams(window.location.search);
+            const redirectTo = params.get('redirect') || `${base}account/`;
+            window.location.href = redirectTo;
+          }
+        });
+
+        // Hard timeout. The 10s window is intentional: if the session-storage
+        // write hasn't fired by now, the browser is almost certainly blocking
+        // third-party cookies, and the user needs an explicit message.
+        setTimeout(() => {
+          subscription.unsubscribe();
+          showFatalError(
+            'Sign-in did not complete in time.',
+            'Supabase did not surface a SIGNED_IN event within 10 seconds.',
+            'If you have third-party cookies blocked, allow them for *.supabase.co and try again. '
+            + 'Alternatively, switch to the email + password method.',
+          );
+        }, 10000);
+      } catch (err) {
+        console.error('[auth/callback] unexpected exception:', err);
+        showFatalError('An unexpected error occurred.', String(err));
       }
     }
 

--- a/website/tests/e2e/auth/callback.spec.ts
+++ b/website/tests/e2e/auth/callback.spec.ts
@@ -1,0 +1,74 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * Regression coverage for /auth/callback's URL-error handling. The
+ * page reads three layers of failure (search-param error, hash-param
+ * error, getSession exception) and surfaces them as actionable user
+ * messages — these specs pin the surfaced text + hints so a regression
+ * that drops a branch back to the silent-timeout state fails CI.
+ *
+ * No login required: every assertion exercises the unauthenticated
+ * error-rendering path. Runs under the auth-anon project (see
+ * playwright.config.ts) so it picks up no storageState.
+ */
+
+test.describe('/auth/callback URL-error handling', () => {
+  test('search-param server_error renders fatal-error UI with provider-misconfig hint', async ({ page }) => {
+    await page.goto('/auth/callback/?error=server_error&error_code=server_error&error_description=Invalid%20client%20secret');
+
+    // Headline + technical details visible.
+    await expect(page.getByText('Sign-in failed')).toBeVisible();
+    await expect(page.getByText('error: server_error')).toBeVisible();
+    await expect(page.getByText('error_code: server_error')).toBeVisible();
+    // URLSearchParams already percent-decodes — assert the *decoded*
+    // form to confirm we're not double-decoding.
+    await expect(page.getByText('error_description: Invalid client secret')).toBeVisible();
+
+    // Server-error hint mentions client-secret rotation / callback drift.
+    await expect(page.getByText(/OAuth provider is misconfigured/)).toBeVisible();
+  });
+
+  test('search-param access_denied renders the user-cancelled hint', async ({ page }) => {
+    await page.goto('/auth/callback/?error=access_denied&error_description=The%20user%20declined');
+
+    await expect(page.getByText('Sign-in failed')).toBeVisible();
+    await expect(page.getByText('error: access_denied')).toBeVisible();
+    await expect(page.getByText(/declined to grant the requested permissions/)).toBeVisible();
+  });
+
+  test('error=unsupported_provider (no error_code) still surfaces disabled-provider hint', async ({ page }) => {
+    // Pins the fix from PR #1258 review comment #4: the disabled-
+    // provider hint must trigger when the field is on `error` not just
+    // `error_code`. Some IdPs / Supabase configs split the two
+    // inconsistently.
+    await page.goto('/auth/callback/?error=unsupported_provider&error_description=GitHub%20provider%20not%20enabled');
+
+    await expect(page.getByText(/sign-in provider is currently disabled/)).toBeVisible();
+  });
+
+  test('hash-param error takes precedence over search-param error', async ({ page }) => {
+    // Implicit-flow errors arrive in the URL hash. parseAuthError()
+    // gives them precedence over search params because the hash form
+    // is more specific (carries error_code from the IdP).
+    await page.goto('/auth/callback/?error=ignored#error=hash_error&error_description=Hash%20wins');
+
+    await expect(page.getByText('error: hash_error')).toBeVisible();
+    await expect(page.getByText('error_description: Hash wins')).toBeVisible();
+  });
+
+  test('error_description with literal % does not crash the handler', async ({ page }) => {
+    // PR #1258 review comment #1+#3: the previous code called
+    // decodeURIComponent on a value URLSearchParams had already
+    // decoded, so a description containing a literal '%' (e.g. an
+    // encoded '%25') would throw URIError on the second decode and
+    // fall into the generic "An unexpected error occurred" branch.
+    // The fix removes the second decode entirely; this spec pins
+    // that the literal '%' message renders intact.
+    await page.goto('/auth/callback/?error=server_error&error_description=quota%2025%25%20exceeded');
+
+    // After URLSearchParams.get(), the value is "quota 25% exceeded".
+    await expect(page.getByText('error_description: quota 25% exceeded')).toBeVisible();
+    // Critically, NOT the generic fallback message.
+    await expect(page.getByText('An unexpected error occurred')).toHaveCount(0);
+  });
+});

--- a/website/tests/e2e/auth/callback.spec.ts
+++ b/website/tests/e2e/auth/callback.spec.ts
@@ -16,24 +16,29 @@ test.describe('/auth/callback URL-error handling', () => {
   test('search-param server_error renders fatal-error UI with provider-misconfig hint', async ({ page }) => {
     await page.goto('/auth/callback/?error=server_error&error_code=server_error&error_description=Invalid%20client%20secret');
 
-    // Headline + technical details visible.
+    // Headline + hint always visible (mapped, not raw IdP text).
     await expect(page.getByText('Sign-in failed')).toBeVisible();
+    await expect(page.getByText(/OAuth provider is misconfigured/)).toBeVisible();
+    // Per PR #1258 review #5: raw IdP text now lives behind a
+    // <details> "Show technical details" disclosure to mitigate
+    // phishing — the technical lines aren't in the rendered DOM
+    // until the summary is clicked.
+    await expect(page.getByText('Show technical details')).toBeVisible();
+    await page.getByText('Show technical details').click();
     await expect(page.getByText('error: server_error')).toBeVisible();
     await expect(page.getByText('error_code: server_error')).toBeVisible();
     // URLSearchParams already percent-decodes — assert the *decoded*
     // form to confirm we're not double-decoding.
     await expect(page.getByText('error_description: Invalid client secret')).toBeVisible();
-
-    // Server-error hint mentions client-secret rotation / callback drift.
-    await expect(page.getByText(/OAuth provider is misconfigured/)).toBeVisible();
   });
 
   test('search-param access_denied renders the user-cancelled hint', async ({ page }) => {
     await page.goto('/auth/callback/?error=access_denied&error_description=The%20user%20declined');
 
     await expect(page.getByText('Sign-in failed')).toBeVisible();
-    await expect(page.getByText('error: access_denied')).toBeVisible();
     await expect(page.getByText(/declined to grant the requested permissions/)).toBeVisible();
+    await page.getByText('Show technical details').click();
+    await expect(page.getByText('error: access_denied')).toBeVisible();
   });
 
   test('error=unsupported_provider (no error_code) still surfaces disabled-provider hint', async ({ page }) => {
@@ -52,6 +57,7 @@ test.describe('/auth/callback URL-error handling', () => {
     // is more specific (carries error_code from the IdP).
     await page.goto('/auth/callback/?error=ignored#error=hash_error&error_description=Hash%20wins');
 
+    await page.getByText('Show technical details').click();
     await expect(page.getByText('error: hash_error')).toBeVisible();
     await expect(page.getByText('error_description: Hash wins')).toBeVisible();
   });
@@ -66,9 +72,130 @@ test.describe('/auth/callback URL-error handling', () => {
     // `error_description`.
     await page.goto('/auth/callback/?error=search_err&error_description=search%20description#error=hash_err');
 
+    await page.getByText('Show technical details').click();
     await expect(page.getByText('error: hash_err')).toBeVisible();
     // Critically, the search-side description must NOT appear.
     await expect(page.getByText('error_description: search description')).toHaveCount(0);
+  });
+
+  test('errorCode-only callback (no error field) still renders fatal-error UI', async ({ page }) => {
+    // PR #1258 review comment #4: the parser now treats any of
+    // `error`, `error_code`, `error_description` as a failure marker.
+    // A callback that returns ONLY `error_code` (e.g. otp_expired
+    // recovery flows) must NOT fall through to the 10-second timeout.
+    await page.goto('/auth/callback/?error_code=otp_expired&error_description=Magic%20link%20expired');
+
+    await expect(page.getByText('Sign-in failed')).toBeVisible();
+    await page.getByText('Show technical details').click();
+    await expect(page.getByText('error_code: otp_expired')).toBeVisible();
+    await expect(page.getByText('error_description: Magic link expired')).toBeVisible();
+  });
+
+  test('errorCode === unsupported_provider variant surfaces the disabled-provider hint', async ({ page }) => {
+    // PR #1258 review comment #8: the implementation accepts the
+    // disabled-provider marker in EITHER `error` or `error_code` (some
+    // IdPs split inconsistently). The existing spec covers the `error`
+    // path; this one pins the `error_code` path so a regression that
+    // drops one branch fails CI.
+    await page.goto('/auth/callback/?error=oauth_failure&error_code=unsupported_provider&error_description=GitHub%20provider%20not%20enabled');
+
+    await expect(page.getByText(/sign-in provider is currently disabled/)).toBeVisible();
+  });
+
+  test('error_description with HTML metacharacters is HTML-escaped (no XSS)', async ({ page }) => {
+    // PR #1258 review comment #7: the safe() escaping helper is now a
+    // security-critical guardrail because URL-controlled text is
+    // rendered via innerHTML. Pin that `<` / `>` survive as escaped
+    // entities — a regression that bypassed safe() would render the
+    // <script> as actual markup.
+    await page.goto('/auth/callback/?error=server_error&error_description=%3Cscript%3Ealert(1)%3C%2Fscript%3E');
+
+    await page.getByText('Show technical details').click();
+    // The literal escaped text appears verbatim in the DOM.
+    await expect(page.getByText('<script>alert(1)</script>', { exact: false })).toBeVisible();
+    // No alert dialog fired (script tag was escaped, not parsed).
+    let dialogFired = false;
+    page.on('dialog', () => { dialogFired = true; });
+    // Give any (broken) script a tick to dispatch alert before asserting.
+    await page.waitForTimeout(200);
+    expect(dialogFired).toBe(false);
+  });
+});
+
+test.describe('/auth/callback success paths', () => {
+  // PR #1258 review comment #6: the e2e suite previously only covered
+  // failure + timeout. The PR also changes both the immediate-session
+  // redirect and the SIGNED_IN/clearTimeout race, so the success paths
+  // need pinning too.
+
+  test('immediate getSession() success redirects to default account page', async ({ page }) => {
+    // Force getSession() to return a valid session synchronously so the
+    // page hits the "data.session" branch (line ~189) and redirects
+    // without waiting for an auth-state event.
+    await page.route('**/lib/supabase*', async route => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/javascript',
+        body: `
+          export const supabase = {
+            auth: {
+              getSession: async () => ({ data: { session: { access_token: 't', user: { id: 'u' } } }, error: null }),
+              onAuthStateChange: () => ({ data: { subscription: { unsubscribe: () => {} } } }),
+            },
+          };
+        `,
+      });
+    });
+    await page.goto('/auth/callback/');
+    // Sanitized fallback redirect = ${base}account/. Wait for the URL
+    // change rather than asserting on /account/ content (which would
+    // require auth state we don't actually have in this stub).
+    await expect(page).toHaveURL(/\/account\/?$/, { timeout: 5_000 });
+  });
+
+  test('redirect query param routing honours same-origin paths only', async ({ page }) => {
+    // sanitizeRedirect must accept ?redirect=/foo/ but reject
+    // protocol-relative (//evil.com) and absolute URLs.
+    await page.route('**/lib/supabase*', async route => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/javascript',
+        body: `
+          export const supabase = {
+            auth: {
+              getSession: async () => ({ data: { session: { access_token: 't', user: { id: 'u' } } }, error: null }),
+              onAuthStateChange: () => ({ data: { subscription: { unsubscribe: () => {} } } }),
+            },
+          };
+        `,
+      });
+    });
+
+    // Whitelisted same-origin path → respected.
+    await page.goto('/auth/callback/?redirect=/settings/api-keys/');
+    await expect(page).toHaveURL(/\/settings\/api-keys\/?$/, { timeout: 5_000 });
+  });
+
+  test('redirect with protocol-relative URL falls back to default account page (open-redirect guard)', async ({ page }) => {
+    // PR #1258 review comment #1: open-redirect guard must reject
+    // //evil.example which would otherwise resolve to https://evil.example.
+    await page.route('**/lib/supabase*', async route => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/javascript',
+        body: `
+          export const supabase = {
+            auth: {
+              getSession: async () => ({ data: { session: { access_token: 't', user: { id: 'u' } } }, error: null }),
+              onAuthStateChange: () => ({ data: { subscription: { unsubscribe: () => {} } } }),
+            },
+          };
+        `,
+      });
+    });
+    await page.goto('/auth/callback/?redirect=//evil.example/phish');
+    // Must land on default /account/ — NOT navigate off-domain.
+    await expect(page).toHaveURL(/\/account\/?$/, { timeout: 5_000 });
   });
 });
 

--- a/website/tests/e2e/auth/callback.spec.ts
+++ b/website/tests/e2e/auth/callback.spec.ts
@@ -56,6 +56,94 @@ test.describe('/auth/callback URL-error handling', () => {
     await expect(page.getByText('error_description: Hash wins')).toBeVisible();
   });
 
+  test('per-source precedence: hash error_description wins, search description ignored', async ({ page }) => {
+    // PR #1258 review: per-FIELD merge could splice an `error` from
+    // hash with `error_description` from search. Per-SOURCE precedence
+    // (current behaviour after the precedence-rewrite commit) MUST take
+    // ALL fields from hash when hash carries an error, ignoring search
+    // entirely. This spec pins that contract: a hash `error` with NO
+    // hash `error_description` must NOT pick up the search's
+    // `error_description`.
+    await page.goto('/auth/callback/?error=search_err&error_description=search%20description#error=hash_err');
+
+    await expect(page.getByText('error: hash_err')).toBeVisible();
+    // Critically, the search-side description must NOT appear.
+    await expect(page.getByText('error_description: search description')).toHaveCount(0);
+  });
+});
+
+test.describe('/auth/callback non-URL failure paths', () => {
+  // PR #1258 review #6/#7: every failure layer is supposed to leave a
+  // console.error trace and surface the fatal-error UI. Previously the
+  // tests only exercised URL-param failures; these specs cover the
+  // session-exchange error path and the 10-second timeout path that
+  // gated the silent-stall regression #1258 was created to fix.
+
+  test('getSession() error renders "Session exchange failed."', async ({ page }) => {
+    // Intercept the Supabase client lib that the page imports and force
+    // its `auth.getSession()` to return an error tuple. Routing the
+    // import to a small inline shim is sufficient — the page only uses
+    // `auth.getSession()` and `auth.onAuthStateChange()` from the lib.
+    await page.route('**/lib/supabase*', async route => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/javascript',
+        body: `
+          export const supabase = {
+            auth: {
+              getSession: async () => ({ data: { session: null }, error: { message: 'Forced session-exchange failure for test' } }),
+              onAuthStateChange: () => ({ data: { subscription: { unsubscribe: () => {} } } }),
+            },
+          };
+        `,
+      });
+    });
+
+    const consoleErrors: string[] = [];
+    page.on('console', m => { if (m.type() === 'error') consoleErrors.push(m.text()); });
+
+    await page.goto('/auth/callback/');
+
+    await expect(page.getByText('Session exchange failed.')).toBeVisible();
+    await expect(page.getByText('Forced session-exchange failure for test')).toBeVisible();
+    // PR #1258 promise: every failure path leaves a console.error.
+    expect(consoleErrors.some(e => e.includes('getSession() error'))).toBeTruthy();
+  });
+
+  test('10-second timeout renders fatal-error UI when no SIGNED_IN event fires', async ({ page }) => {
+    // Force getSession() to return an empty session AND the auth-state
+    // listener to never fire — the only escape hatch is the 10-second
+    // setTimeout fallback. Use page.clock.fastForward to skip the wall-
+    // clock wait so the spec runs in <1s.
+    await page.clock.install();
+    await page.route('**/lib/supabase*', async route => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/javascript',
+        body: `
+          export const supabase = {
+            auth: {
+              getSession: async () => ({ data: { session: null }, error: null }),
+              onAuthStateChange: () => ({ data: { subscription: { unsubscribe: () => {} } } }),
+            },
+          };
+        `,
+      });
+    });
+
+    const consoleErrors: string[] = [];
+    page.on('console', m => { if (m.type() === 'error') consoleErrors.push(m.text()); });
+
+    await page.goto('/auth/callback/');
+    // Skip the 10-second hard timeout deterministically.
+    await page.clock.fastForward(10_500);
+
+    await expect(page.getByText('Sign-in did not complete in time.')).toBeVisible();
+    await expect(page.getByText(/SIGNED_IN event within 10 seconds/)).toBeVisible();
+    // PR #1258 review #2/#7: timeout path must console.error too.
+    expect(consoleErrors.some(e => e.includes('timed out waiting for SIGNED_IN'))).toBeTruthy();
+  });
+
   test('error_description with literal % does not crash the handler', async ({ page }) => {
     // PR #1258 review comment #1+#3: the previous code called
     // decodeURIComponent on a value URLSearchParams had already


### PR DESCRIPTION
## Summary

Diagnostic complement to #1257 (GitHub OAuth broken on aidotnet.dev). The redirect to GitHub itself works — the failure is downstream, in the post-GitHub callback. The current \`/auth/callback\` page silently swallows URL-parameter errors, so any Supabase-side provider failure surfaces as a generic 10-second timeout with no actionable detail.

OAuth providers can fail at **three** different layers, each surfacing the error in a different place:

1. **PKCE / code-flow error** → URL search params: \`?error=...&error_description=...\`
2. **Implicit-flow error** → URL hash params: \`#error=...&error_description=...\`
3. **Session-exchange error** → returned from \`supabase.auth.getSession()\`

The old code only checked layer 3 — that's why hitting \`Continue with GitHub\` could land here with \`?error=server_error&error_description=...\` and the user would still just see \"Authentication timed out\" after 10 seconds.

This PR:

- Parses BOTH search and hash params for \`error\`, \`error_code\`, \`error_description\`
- Renders the raw \`error_description\` in a monospace block so support / customer can copy it
- Adds best-effort hints for the most common failure modes:
  - \`server_error\` → \"OAuth provider misconfigured server-side; client secret rotated, callback URL drift, or provider disabled\"
  - \`access_denied\` → \"You declined permissions; try again or use a different method\"
  - \`unsupported_provider\` / \"not enabled\" → \"This sign-in provider is currently disabled on the server\"
- Keeps the 10-second fallback for the third-party-cookie-block case, but gives an actionable hint
- \`console.error\`s every failure path so devtools captures it

## Diagnostic data captured during this investigation

Headless probe of \`/login\` clicking \`Continue with GitHub\` from incognito:

- ✅ Supabase URL the website talks to: \`https://yfkqwpgjahoamlgckjib.supabase.co\`
- ✅ \`signInWithOAuth({ provider: 'github' })\` 302s correctly to \`https://yfkqwpgjahoamlgckjib.supabase.co/auth/v1/authorize?provider=github&redirect_to=https%3A%2F%2Fwww.aidotnet.dev%2Fauth%2Fcallback%2F\`
- ✅ Supabase 302s correctly to GitHub: \`https://github.com/login/oauth/authorize?client_id=Ov23liyJTdKbxKrUl9lR&...&redirect_uri=https%3A%2F%2Fyfkqwpgjahoamlgckjib.supabase.co%2Fauth%2Fv1%2Fcallback&response_type=code&scope=user%3Aemail&state=...\`
- ✅ GitHub renders the login page (200)

So the **first half** of the OAuth flow is correct. The bug is in the post-GitHub callback. Most likely causes (cannot verify without dashboard access):

1. **GitHub OAuth app's \`Authorization callback URL\` doesn't match \`https://yfkqwpgjahoamlgckjib.supabase.co/auth/v1/callback\` exactly** — common after a Supabase project rename or regeneration. **Fix:** GitHub OAuth app settings → Authorization callback URL.
2. **Client secret rotated on the GitHub side and Supabase still has the old one.** **Fix:** regenerate secret on GitHub, paste into Supabase Auth → Providers → GitHub → Client Secret.
3. **GitHub user has no public email AND the GitHub app doesn't request \`read:user\`.** **Fix:** in Supabase auth provider config or in the OAuth app permissions, ensure email is requested.

After this PR ships, the user will SEE which of those three is firing on their next sign-in attempt — the page will display the actual \`error_description\` from Supabase instead of the generic timeout.

## Test plan

- [ ] Regression: trigger a normal Google sign-in; verify the redirect-and-session-exchange path still works (no behavior change when \`error\` is absent from the URL).
- [ ] Manually navigate to \`/auth/callback?error=server_error&error_description=test\` — verify the error block renders with the description in a monospace block and the \"server_error\" hint.
- [ ] Manually navigate to \`/auth/callback#error=access_denied&error_description=user+denied\` — verify hash params are parsed and the \"access_denied\" hint shows.
- [ ] Trigger a real GitHub sign-in attempt (after dashboard fix per #1257) — verify the sign-in completes successfully (callback page redirects to \`/account/\`).

## Out of scope

- The actual root cause of #1257 lives in the Supabase Auth dashboard (provider config) or the GitHub OAuth app config — neither of which is in the repo. This PR is the code-side mitigation that makes the failure visible.
- Email-on-issuance fix is in #1256.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection/precedence of OAuth/provider errors from both URL query and fragment; explicit handling for session-exchange failures and 10s timeout with clear messaging.

* **UI/UX Improvements**
  * New HTML-safe fatal error view with contextual hints, “Back to login” link, spinner/heading/subtext stability, and wider error container for readability.

* **Tests**
  * Added E2E tests for callback error rendering, precedence rules, session errors, timeout behavior, and edge-case decoding.

* **Chores**
  * Added a dedicated auth e2e project to isolate auth flow tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->