### PR TITLE
fix(website): unblock /auth/callback e2e smoke tests in deploy

### DIFF
--- a/scripts/vercel-ignore-api.sh
+++ b/scripts/vercel-ignore-api.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Vercel ignoreCommand for the aidotnet-playground-api project.
+#
+# Exit codes (per Vercel):
+#   0 = ignore the build (skip)
+#   1 = proceed with the build
+#
+# Policy:
+# - master / main pushes always build (production deploys).
+# - On preview deploys with a prior build SHA available, build only when
+#   files under api/ or vercel.json itself changed. This avoids spinning
+#   up a Vercel build for PRs that touch only website/, src/, etc.
+# - Without a previous SHA (first deploy of a branch), default to build
+#   so we don't silently skip.
+#
+# Lives in scripts/ rather than inlined in vercel.json because Vercel
+# enforces a 256-character cap on ignoreCommand strings.
+
+set -u
+
+if [ "${VERCEL_GIT_COMMIT_REF:-}" = master ] || [ "${VERCEL_GIT_COMMIT_REF:-}" = main ]; then
+  exit 1
+fi
+
+PREV="${VERCEL_GIT_PREVIOUS_SHA:-}"
+CURR="${VERCEL_GIT_COMMIT_SHA:-HEAD}"
+
+if [ -z "$PREV" ]; then
+  exit 1
+fi
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+if git -C "$REPO_ROOT" diff --quiet "$PREV" "$CURR" -- 'api/' 'vercel.json'; then
+  exit 0
+else
+  exit 1
+fi

--- a/vercel.json
+++ b/vercel.json
@@ -2,7 +2,7 @@
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "version": 2,
   "name": "aidotnet-playground-api",
-  "ignoreCommand": "if [ \"$VERCEL_GIT_COMMIT_REF\" = master ] || [ \"$VERCEL_GIT_COMMIT_REF\" = main ]; then exit 1; fi; PREV=\"${VERCEL_GIT_PREVIOUS_SHA:-}\"; CURR=\"${VERCEL_GIT_COMMIT_SHA:-HEAD}\"; if [ -z \"$PREV\" ]; then exit 1; fi; git -C \"$(git rev-parse --show-toplevel)\" diff --quiet \"$PREV\" \"$CURR\" -- 'api/' 'vercel.json' && exit 0 || exit 1",
+  "ignoreCommand": "bash scripts/vercel-ignore-api.sh",
   "functions": {
     "api/execute.ts": {
       "maxDuration": 30,

--- a/website/scripts/vercel-ignore.sh
+++ b/website/scripts/vercel-ignore.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Vercel ignoreCommand for the aidotnet_website project.
+#
+# Exit codes (per Vercel):
+#   0 = ignore the build (skip)
+#   1 = proceed with the build
+#
+# Policy:
+# - master / main pushes always build (production deploys).
+# - On preview deploys with a prior build SHA, only build when files
+#   inside the project root (website/) changed. Vercel runs this from
+#   the website/ directory (rootDirectory in the Vercel project config),
+#   so 'git diff -- .' restricts the diff to that subtree.
+# - Without a previous SHA (first deploy of a branch), default to build
+#   so we don't silently skip.
+#
+# Lives in scripts/ rather than inlined in vercel.json because Vercel
+# enforces a 256-character cap on ignoreCommand strings.
+
+set -u
+
+if [ "${VERCEL_GIT_COMMIT_REF:-}" = master ] || [ "${VERCEL_GIT_COMMIT_REF:-}" = main ]; then
+  exit 1
+fi
+
+PREV="${VERCEL_GIT_PREVIOUS_SHA:-}"
+CURR="${VERCEL_GIT_COMMIT_SHA:-HEAD}"
+
+if [ -z "$PREV" ]; then
+  exit 1
+fi
+
+if git diff --quiet "$PREV" "$CURR" -- .; then
+  exit 0
+else
+  exit 1
+fi

--- a/website/src/pages/auth/callback.astro
+++ b/website/src/pages/auth/callback.astro
@@ -34,9 +34,37 @@ const base = import.meta.env.BASE_URL;
   </div>
 
   <script>
-    import { supabase } from '../../lib/supabase';
+    import { supabase as defaultSupabase } from '../../lib/supabase';
 
     const base = import.meta.env.BASE_URL || '/';
+
+    /**
+     * E2E test seam.
+     *
+     * The post-deploy Playwright smoke specs in
+     * tests/e2e/auth/callback.spec.ts need to drive this page through
+     * each branch (immediate-session redirect, getSession() error,
+     * SIGNED_IN-event-never-fires timeout, etc.) without mounting a real
+     * Supabase project just for the smoke run.
+     *
+     * Astro/Vite bundles the supabase import into a hashed
+     * `_astro/<chunk>.js` file in production, so the previous
+     * `page.route('lib/supabase')` glob never matched the bundled URL.
+     * Instead we read a single
+     * runtime override that the test plants via `page.addInitScript`
+     * BEFORE the navigation, then fall back to the real client when the
+     * override isn't set.
+     *
+     * The override is a no-op in production: nothing in the codebase or
+     * docs tells real users to set `window.__authTestStub`, and the
+     * fallback is the real client. The escape hatch is the
+     * minimum-viable surface (one nullish-coalesce, no extra entry
+     * points, no `if (DEV)` gates) — enough to unblock the smoke job
+     * without leaking a configurable surface to end users.
+     */
+    const supabase: typeof defaultSupabase =
+      (window as unknown as { __authTestStub?: typeof defaultSupabase })
+        .__authTestStub ?? defaultSupabase;
 
     /**
      * OAuth providers can fail at three different layers, each surfacing

--- a/website/tests/e2e/auth/callback.spec.ts
+++ b/website/tests/e2e/auth/callback.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect, type Page } from '@playwright/test';
 
 /**
  * Regression coverage for /auth/callback's URL-error handling. The
@@ -11,6 +11,65 @@ import { test, expect } from '@playwright/test';
  * error-rendering path. Runs under the auth-anon project (see
  * playwright.config.ts) so it picks up no storageState.
  */
+
+/**
+ * Plants a `window.__authTestStub` BEFORE page navigation so the
+ * callback page picks it up instead of the real Supabase client.
+ *
+ * We can't use `page.route('**\/lib/supabase*')`: Astro/Vite bundles
+ * the supabase import into a hashed `_astro/*.js` chunk in production,
+ * and the route pattern never matches the bundled URL. The page-side
+ * test seam (`window.__authTestStub ?? defaultSupabase`) sidesteps
+ * bundling entirely.
+ */
+/**
+ * Replaces the destination pages (`/account/`, `/settings/api-keys/`)
+ * with no-op HTML so they don't run their own auth-state checks and
+ * bounce the assertion off to `/login/`. The success-path tests only
+ * care that the callback page set `window.location.href = redirectTo`;
+ * the destination's behaviour is out of scope.
+ */
+async function stubRedirectTargets(page: Page) {
+  await page.route(/\/(?:account|settings)\/.*/, async route => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'text/html',
+      body: '<!doctype html><html><body>stub destination</body></html>',
+    });
+  });
+}
+
+async function installAuthStub(page: Page, stub: {
+  getSession: 'success' | 'error' | 'empty';
+  errorMessage?: string;
+  emitSignedIn?: boolean;
+}) {
+  await page.addInitScript(({ kind, errorMessage, emitSignedIn }) => {
+    let onChangeCb: ((event: string, session: unknown) => void) | undefined;
+    (window as unknown as { __authTestStub: unknown }).__authTestStub = {
+      auth: {
+        getSession: async () => {
+          if (kind === 'success') {
+            return { data: { session: { access_token: 't', user: { id: 'u' } } }, error: null };
+          }
+          if (kind === 'error') {
+            return { data: { session: null }, error: { message: errorMessage ?? 'Forced error' } };
+          }
+          // 'empty' — no session, no error; page falls through to onAuthStateChange.
+          return { data: { session: null }, error: null };
+        },
+        onAuthStateChange: (cb: (event: string, session: unknown) => void) => {
+          onChangeCb = cb;
+          if (emitSignedIn) {
+            // Defer one microtask so the page's getSession() resolves first.
+            queueMicrotask(() => cb('SIGNED_IN', { access_token: 't', user: { id: 'u' } }));
+          }
+          return { data: { subscription: { unsubscribe: () => { onChangeCb = undefined; } } } };
+        },
+      },
+    };
+  }, { kind: stub.getSession, errorMessage: stub.errorMessage, emitSignedIn: stub.emitSignedIn });
+}
 
 test.describe('/auth/callback URL-error handling', () => {
   test('search-param server_error renders fatal-error UI with provider-misconfig hint', async ({ page }) => {
@@ -130,47 +189,23 @@ test.describe('/auth/callback success paths', () => {
 
   test('immediate getSession() success redirects to default account page', async ({ page }) => {
     // Force getSession() to return a valid session synchronously so the
-    // page hits the "data.session" branch (line ~189) and redirects
-    // without waiting for an auth-state event.
-    await page.route('**/lib/supabase*', async route => {
-      await route.fulfill({
-        status: 200,
-        contentType: 'application/javascript',
-        body: `
-          export const supabase = {
-            auth: {
-              getSession: async () => ({ data: { session: { access_token: 't', user: { id: 'u' } } }, error: null }),
-              onAuthStateChange: () => ({ data: { subscription: { unsubscribe: () => {} } } }),
-            },
-          };
-        `,
-      });
-    });
+    // page hits the "data.session" branch and redirects without waiting
+    // for an auth-state event. Stub the destination so its own
+    // auth-state check doesn't bounce us off to /login/ before the
+    // assertion runs.
+    await installAuthStub(page, { getSession: 'success' });
+    await stubRedirectTargets(page);
     await page.goto('/auth/callback/');
     // Sanitized fallback redirect = ${base}account/. Wait for the URL
-    // change rather than asserting on /account/ content (which would
-    // require auth state we don't actually have in this stub).
+    // change rather than asserting on /account/ content.
     await expect(page).toHaveURL(/\/account\/?$/, { timeout: 5_000 });
   });
 
   test('redirect query param routing honours same-origin paths only', async ({ page }) => {
     // sanitizeRedirect must accept ?redirect=/foo/ but reject
     // protocol-relative (//evil.com) and absolute URLs.
-    await page.route('**/lib/supabase*', async route => {
-      await route.fulfill({
-        status: 200,
-        contentType: 'application/javascript',
-        body: `
-          export const supabase = {
-            auth: {
-              getSession: async () => ({ data: { session: { access_token: 't', user: { id: 'u' } } }, error: null }),
-              onAuthStateChange: () => ({ data: { subscription: { unsubscribe: () => {} } } }),
-            },
-          };
-        `,
-      });
-    });
-
+    await installAuthStub(page, { getSession: 'success' });
+    await stubRedirectTargets(page);
     // Whitelisted same-origin path → respected.
     await page.goto('/auth/callback/?redirect=/settings/api-keys/');
     await expect(page).toHaveURL(/\/settings\/api-keys\/?$/, { timeout: 5_000 });
@@ -179,20 +214,8 @@ test.describe('/auth/callback success paths', () => {
   test('redirect with protocol-relative URL falls back to default account page (open-redirect guard)', async ({ page }) => {
     // PR #1258 review comment #1: open-redirect guard must reject
     // //evil.example which would otherwise resolve to https://evil.example.
-    await page.route('**/lib/supabase*', async route => {
-      await route.fulfill({
-        status: 200,
-        contentType: 'application/javascript',
-        body: `
-          export const supabase = {
-            auth: {
-              getSession: async () => ({ data: { session: { access_token: 't', user: { id: 'u' } } }, error: null }),
-              onAuthStateChange: () => ({ data: { subscription: { unsubscribe: () => {} } } }),
-            },
-          };
-        `,
-      });
-    });
+    await installAuthStub(page, { getSession: 'success' });
+    await stubRedirectTargets(page);
     await page.goto('/auth/callback/?redirect=//evil.example/phish');
     // Must land on default /account/ — NOT navigate off-domain.
     await expect(page).toHaveURL(/\/account\/?$/, { timeout: 5_000 });
@@ -207,23 +230,12 @@ test.describe('/auth/callback non-URL failure paths', () => {
   // gated the silent-stall regression #1258 was created to fix.
 
   test('getSession() error renders "Session exchange failed."', async ({ page }) => {
-    // Intercept the Supabase client lib that the page imports and force
-    // its `auth.getSession()` to return an error tuple. Routing the
-    // import to a small inline shim is sufficient — the page only uses
-    // `auth.getSession()` and `auth.onAuthStateChange()` from the lib.
-    await page.route('**/lib/supabase*', async route => {
-      await route.fulfill({
-        status: 200,
-        contentType: 'application/javascript',
-        body: `
-          export const supabase = {
-            auth: {
-              getSession: async () => ({ data: { session: null }, error: { message: 'Forced session-exchange failure for test' } }),
-              onAuthStateChange: () => ({ data: { subscription: { unsubscribe: () => {} } } }),
-            },
-          };
-        `,
-      });
+    // Force `auth.getSession()` to return an error tuple via the
+    // page's __authTestStub seam (page.route can't intercept the
+    // bundled `_astro/*.js` chunk in production builds).
+    await installAuthStub(page, {
+      getSession: 'error',
+      errorMessage: 'Forced session-exchange failure for test',
     });
 
     const consoleErrors: string[] = [];
@@ -232,6 +244,10 @@ test.describe('/auth/callback non-URL failure paths', () => {
     await page.goto('/auth/callback/');
 
     await expect(page.getByText('Session exchange failed.')).toBeVisible();
+    // The error message lives inside the <details> "Show technical
+    // details" disclosure (added in PR #1258 review #5 to mitigate
+    // phishing). Open it before asserting on the body text.
+    await page.getByText('Show technical details').click();
     await expect(page.getByText('Forced session-exchange failure for test')).toBeVisible();
     // PR #1258 promise: every failure path leaves a console.error.
     expect(consoleErrors.some(e => e.includes('getSession() error'))).toBeTruthy();
@@ -243,20 +259,7 @@ test.describe('/auth/callback non-URL failure paths', () => {
     // setTimeout fallback. Use page.clock.fastForward to skip the wall-
     // clock wait so the spec runs in <1s.
     await page.clock.install();
-    await page.route('**/lib/supabase*', async route => {
-      await route.fulfill({
-        status: 200,
-        contentType: 'application/javascript',
-        body: `
-          export const supabase = {
-            auth: {
-              getSession: async () => ({ data: { session: null }, error: null }),
-              onAuthStateChange: () => ({ data: { subscription: { unsubscribe: () => {} } } }),
-            },
-          };
-        `,
-      });
-    });
+    await installAuthStub(page, { getSession: 'empty', emitSignedIn: false });
 
     const consoleErrors: string[] = [];
     page.on('console', m => { if (m.type() === 'error') consoleErrors.push(m.text()); });
@@ -266,6 +269,9 @@ test.describe('/auth/callback non-URL failure paths', () => {
     await page.clock.fastForward(10_500);
 
     await expect(page.getByText('Sign-in did not complete in time.')).toBeVisible();
+    // The detail line "Supabase did not surface a SIGNED_IN event…"
+    // sits inside <details>, so open the disclosure first.
+    await page.getByText('Show technical details').click();
     await expect(page.getByText(/SIGNED_IN event within 10 seconds/)).toBeVisible();
     // PR #1258 review #2/#7: timeout path must console.error too.
     expect(consoleErrors.some(e => e.includes('timed out waiting for SIGNED_IN'))).toBeTruthy();
@@ -281,6 +287,10 @@ test.describe('/auth/callback non-URL failure paths', () => {
     // that the literal '%' message renders intact.
     await page.goto('/auth/callback/?error=server_error&error_description=quota%2025%25%20exceeded');
 
+    // The error_description text is rendered inside the <details>
+    // disclosure block (PR #1258 review #5: phishing mitigation).
+    // Open it before asserting on the body text.
+    await page.getByText('Show technical details').click();
     // After URLSearchParams.get(), the value is "quota 25% exceeded".
     await expect(page.getByText('error_description: quota 25% exceeded')).toBeVisible();
     // Critically, NOT the generic fallback message.

--- a/website/vercel.json
+++ b/website/vercel.json
@@ -1,5 +1,5 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "version": 2,
-  "ignoreCommand": "if [ \"$VERCEL_GIT_COMMIT_REF\" = master ] || [ \"$VERCEL_GIT_COMMIT_REF\" = main ]; then exit 1; fi; PREV=\"${VERCEL_GIT_PREVIOUS_SHA:-}\"; CURR=\"${VERCEL_GIT_COMMIT_SHA:-HEAD}\"; if [ -z \"$PREV\" ]; then exit 1; fi; git diff --quiet \"$PREV\" \"$CURR\" -- . && exit 0 || exit 1"
+  "ignoreCommand": "bash scripts/vercel-ignore.sh"
 }


### PR DESCRIPTION
## Summary

The post-deploy "Deploy Marketing Website" workflow has been failing on every run since PR #1258 merged. 5 of the 14 `/auth/callback` E2E specs fail consistently — blocking every Vercel deploy from being marked green.

This PR fixes the failing specs (and the implementation seam they need) without any production behaviour change.

## Root causes

**Cause 1 — `page.route` glob doesn't match Astro's bundled output.** Four tests used `page.route('**/lib/supabase*')` to swap the supabase client with a stub. Astro/Vite bundles the `import { supabase } from '../../lib/supabase'` into a hashed `_astro/<chunk>.js` file, so the route never matched the bundled URL. The real supabase client always loaded, and the tests fell into the SIGNED_IN-event-never-fires timeout instead of exercising the branch under test.

**Cause 2 — `<details>` content asserted as visible without opening the disclosure.** The "literal % does not crash" test asserts on text inside the `<details>` *Show technical details* block PR #1258 added as a phishing mitigation. `<details>` content is collapsed by default — the test never clicked it open before asserting `toBeVisible()`.

## Changes

`website/src/pages/auth/callback.astro` — adds a single-line test seam:
```ts
const supabase = window.__authTestStub ?? defaultSupabase;
```
No-op in production (no docs/users tell anyone to set the global). The escape hatch is the minimum-viable surface (one nullish-coalesce, no `if (DEV)` gate, no extra entry points) needed to drive every code path from a Playwright spec.

`website/tests/e2e/auth/callback.spec.ts` —
- New `installAuthStub(page, ...)` helper plants `window.__authTestStub` via `page.addInitScript` BEFORE navigation (works regardless of bundling).
- New `stubRedirectTargets(page)` helper fulfills `/account/` and `/settings/` with no-op HTML, so the success-path assertions land on `/account/` instead of being bounced off to `/login/` by the destination's own auth-state check.
- The 4 stub-using tests switched from `page.route('lib/supabase')` → `installAuthStub` + `stubRedirectTargets`.
- The "literal %" + "session exchange failed" + "10s timeout" tests now click "Show technical details" before asserting on the `<details>` body text.

## Verification

Built locally with `VERCEL=1 npx astro build`, served via `npx astro preview`, ran the full callback suite:

```
Running 14 tests using 1 worker
  ok  1 … search-param server_error renders fatal-error UI with provider-misconfig hint
  ok  2 … search-param access_denied renders the user-cancelled hint
  ok  3 … error=unsupported_provider (no error_code) still surfaces disabled-provider hint
  ok  4 … hash-param error takes precedence over search-param error
  ok  5 … per-source precedence: hash error_description wins
  ok  6 … errorCode-only callback (no error field) still renders fatal-error UI
  ok  7 … errorCode === unsupported_provider variant surfaces disabled-provider hint
  ok  8 … error_description with HTML metacharacters is HTML-escaped (no XSS)
  ok  9 … immediate getSession() success redirects to default account page
  ok 10 … redirect query param routing honours same-origin paths only
  ok 11 … redirect with protocol-relative URL falls back to default account page
  ok 12 … getSession() error renders "Session exchange failed."
  ok 13 … 10-second timeout renders fatal-error UI when no SIGNED_IN event fires
  ok 14 … error_description with literal % does not crash the handler
  14 passed (14.4s)
```

Pre-fix: 5 failed / 9 passed.

## Test plan

- [x] `astro build` succeeds
- [x] All 14 callback specs pass against local `astro preview`
- [ ] Smoke run against Vercel preview deploy (will run automatically when this PR opens)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved end-to-end tests for the authentication callback flow with more reliable, deterministic stubs and corrected assertions for technical error details.

* **Chores**
  * Made the auth callback page testable via a runtime override to stabilize E2E behavior.
  * Replaced inline Vercel ignore logic with dedicated scripts and updated configs to better skip unnecessary preview builds.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ooples/AiDotNet/pull/1282)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->