### PR TITLE
fix: fix #1317: relax Transformer custom layer validation

### DIFF
--- a/src/NeuralNetworks/NeuralNetworkBase.cs
+++ b/src/NeuralNetworks/NeuralNetworkBase.cs
@@ -2124,17 +2124,6 @@ public abstract class NeuralNetworkBase<T> : INeuralNetworkModel<T>, IInterpreta
         return expectedWithoutLeadingUnits.SequenceEqual(actualWithoutLeadingUnits);
     }
 
-    private static bool AreElementCountsCompatibleAcrossExplicitShapeBoundary(
-        ILayer<T> prevLayer,
-        ILayer<T> currentLayer,
-        int[] prevOutputShape,
-        int[] currentInputShape)
-    {
-        bool explicitShapeBoundary = prevLayer is ReshapeLayer<T> or FlattenLayer<T>
-                                     || currentLayer is ReshapeLayer<T> or FlattenLayer<T>;
-        return explicitShapeBoundary && FlattenedSize(prevOutputShape) == FlattenedSize(currentInputShape);
-    }
-
     private static int[] TrimLeadingUnitDimensions(int[] shape)
     {
         int start = 0;
@@ -2147,15 +2136,6 @@ public abstract class NeuralNetworkBase<T> : INeuralNetworkModel<T>, IInterpreta
         var trimmed = new int[shape.Length - start];
         Array.Copy(shape, start, trimmed, 0, trimmed.Length);
         return trimmed;
-    }
-
-    private static int FlattenedSize(int[] shape)
-    {
-        int size = 1;
-        for (int i = 0; i < shape.Length; i++)
-            size *= shape[i];
-
-        return size;
     }
 
     /// <summary>
@@ -2288,12 +2268,7 @@ public abstract class NeuralNetworkBase<T> : INeuralNetworkModel<T>, IInterpreta
         bool currentIsLazy = IsDeferredOrAgnosticShape(currentInputShape);
         if (!currentIsLazy
             && !IsDeferredOrAgnosticShape(prevOutputShape)
-            && !AreShapesCompatible(prevOutputShape!, currentInputShape!)
-            && !AreElementCountsCompatibleAcrossExplicitShapeBoundary(
-                prevLayer,
-                currentLayer,
-                prevOutputShape!,
-                currentInputShape!))
+            && !AreShapesCompatible(prevOutputShape!, currentInputShape!))
             return false;
 
         // Special checks for specific layer combinations

--- a/src/NeuralNetworks/NeuralNetworkBase.cs
+++ b/src/NeuralNetworks/NeuralNetworkBase.cs
@@ -2087,9 +2087,11 @@ public abstract class NeuralNetworkBase<T> : INeuralNetworkModel<T>, IInterpreta
         {
             return Architecture.GetInputShape();
         }
-        catch
+        catch (Exception ex)
         {
-            return null;
+            throw new ArgumentException(
+                "Failed to resolve the architecture input shape for custom-layer validation.",
+                ex);
         }
     }
 
@@ -2099,9 +2101,11 @@ public abstract class NeuralNetworkBase<T> : INeuralNetworkModel<T>, IInterpreta
         {
             return shapeSelector(layer);
         }
-        catch
+        catch (Exception ex)
         {
-            return null;
+            throw new ArgumentException(
+                $"Failed to resolve shape metadata from layer '{layer.GetType().Name}' during custom-layer validation.",
+                ex);
         }
     }
 
@@ -2117,10 +2121,18 @@ public abstract class NeuralNetworkBase<T> : INeuralNetworkModel<T>, IInterpreta
 
         var expectedWithoutLeadingUnits = TrimLeadingUnitDimensions(expectedShape);
         var actualWithoutLeadingUnits = TrimLeadingUnitDimensions(actualShape);
-        if (expectedWithoutLeadingUnits.SequenceEqual(actualWithoutLeadingUnits))
-            return true;
+        return expectedWithoutLeadingUnits.SequenceEqual(actualWithoutLeadingUnits);
+    }
 
-        return FlattenedSize(expectedShape) == FlattenedSize(actualShape);
+    private static bool AreElementCountsCompatibleAcrossExplicitShapeBoundary(
+        ILayer<T> prevLayer,
+        ILayer<T> currentLayer,
+        int[] prevOutputShape,
+        int[] currentInputShape)
+    {
+        bool explicitShapeBoundary = prevLayer is ReshapeLayer<T> or FlattenLayer<T>
+                                     || currentLayer is ReshapeLayer<T> or FlattenLayer<T>;
+        return explicitShapeBoundary && FlattenedSize(prevOutputShape) == FlattenedSize(currentInputShape);
     }
 
     private static int[] TrimLeadingUnitDimensions(int[] shape)
@@ -2271,10 +2283,17 @@ public abstract class NeuralNetworkBase<T> : INeuralNetworkModel<T>, IInterpreta
         // DropoutLayer, ActivationLayer constructed without an explicit
         // InputShape) and would have been incorrectly rejected by the
         // SequenceEqual check otherwise.
-        var currentInputShape = currentLayer.GetInputShape();
-        bool currentIsLazy = currentInputShape.Length == 0
-                             || currentInputShape.Any(d => d <= 0);
-        if (!currentIsLazy && !AreShapesCompatible(prevLayer.GetOutputShape(), currentInputShape))
+        var currentInputShape = TryGetLayerShape(currentLayer, shapeSelector: static l => l.GetInputShape());
+        var prevOutputShape = TryGetLayerShape(prevLayer, shapeSelector: static l => l.GetOutputShape());
+        bool currentIsLazy = IsDeferredOrAgnosticShape(currentInputShape);
+        if (!currentIsLazy
+            && !IsDeferredOrAgnosticShape(prevOutputShape)
+            && !AreShapesCompatible(prevOutputShape!, currentInputShape!)
+            && !AreElementCountsCompatibleAcrossExplicitShapeBoundary(
+                prevLayer,
+                currentLayer,
+                prevOutputShape!,
+                currentInputShape!))
             return false;
 
         // Special checks for specific layer combinations
@@ -2295,7 +2314,7 @@ public abstract class NeuralNetworkBase<T> : INeuralNetworkModel<T>, IInterpreta
         if (prevLayer is ReshapeLayer<T> reshapeLayer && !currentIsLazy)
         {
             return reshapeLayer.GetOutputShape().Aggregate((a, b) => a * b) ==
-                   currentLayer.GetInputShape().Aggregate((a, b) => a * b);
+                   currentInputShape!.Aggregate((a, b) => a * b);
         }
 
         // If no incompatibilities found, layers are considered compatible

--- a/src/NeuralNetworks/NeuralNetworkBase.cs
+++ b/src/NeuralNetworks/NeuralNetworkBase.cs
@@ -2006,10 +2006,12 @@ public abstract class NeuralNetworkBase<T> : INeuralNetworkModel<T>, IInterpreta
 
         var errors = new List<string>();
 
-        // Check input layer
-        if (!IsValidInputLayer(layers[0]))
+        // Check input shape. Custom layers should be accepted by contract,
+        // not by concrete layer type: if the first layer can consume the
+        // architecture input shape, it is a valid boundary layer.
+        if (!IsFirstLayerShapeCompatible(layers[0]))
         {
-            errors.Add("The first layer must be a valid input layer.");
+            errors.Add("The first layer's input shape must be compatible with the architecture input shape.");
         }
 
         // Check layer connections
@@ -2027,10 +2029,12 @@ public abstract class NeuralNetworkBase<T> : INeuralNetworkModel<T>, IInterpreta
             }
         }
 
-        // Check output layer
-        if (!IsValidOutputLayer(layers[layers.Count - 1]))
+        // Check output shape. The final layer may be a custom readout that
+        // produces the expected target representation without being a Dense
+        // or activation layer.
+        if (!IsLastLayerShapeCompatible(layers[layers.Count - 1], out var outputShapeError))
         {
-            errors.Add("The last layer must be a valid output layer.");
+            errors.Add(outputShapeError);
         }
 
         // Throw exception if any errors were found
@@ -2038,6 +2042,108 @@ public abstract class NeuralNetworkBase<T> : INeuralNetworkModel<T>, IInterpreta
         {
             throw new ArgumentException($"Invalid layer configuration:\n{string.Join("\n", errors)}");
         }
+    }
+
+    private bool IsFirstLayerShapeCompatible(ILayer<T> layer)
+    {
+        int[]? layerInputShape = TryGetLayerShape(layer, shapeSelector: static l => l.GetInputShape());
+        if (IsDeferredOrAgnosticShape(layerInputShape))
+            return true;
+
+        int[]? architectureInputShape = TryGetArchitectureDeclaredInputShape();
+        if (IsDeferredOrAgnosticShape(architectureInputShape))
+            return true;
+
+        return AreShapesCompatible(architectureInputShape!, layerInputShape!);
+    }
+
+    private bool IsLastLayerShapeCompatible(ILayer<T> layer, out string error)
+    {
+        int[]? layerOutputShape = TryGetLayerShape(layer, shapeSelector: static l => l.GetOutputShape());
+        if (IsDeferredOrAgnosticShape(layerOutputShape))
+        {
+            error = string.Empty;
+            return true;
+        }
+
+        int[] outputShape = layerOutputShape!;
+
+        if (Architecture.OutputSize > 0 && !AreShapesCompatible([Architecture.OutputSize], outputShape))
+        {
+            error = $"The last layer's output shape [{string.Join(", ", outputShape)}] must match the architecture output size ({Architecture.OutputSize}).";
+            return false;
+        }
+
+        error = string.Empty;
+        return true;
+    }
+
+    private int[]? TryGetArchitectureDeclaredInputShape()
+    {
+        if (Architecture.IsLayerOnly)
+            return null;
+
+        try
+        {
+            return Architecture.GetInputShape();
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    private static int[]? TryGetLayerShape(ILayer<T> layer, Func<ILayer<T>, int[]> shapeSelector)
+    {
+        try
+        {
+            return shapeSelector(layer);
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    private static bool IsDeferredOrAgnosticShape(int[]? shape)
+    {
+        return shape is null || shape.Length == 0 || shape.Any(d => d <= 0);
+    }
+
+    private static bool AreShapesCompatible(int[] expectedShape, int[] actualShape)
+    {
+        if (expectedShape.SequenceEqual(actualShape))
+            return true;
+
+        var expectedWithoutLeadingUnits = TrimLeadingUnitDimensions(expectedShape);
+        var actualWithoutLeadingUnits = TrimLeadingUnitDimensions(actualShape);
+        if (expectedWithoutLeadingUnits.SequenceEqual(actualWithoutLeadingUnits))
+            return true;
+
+        return FlattenedSize(expectedShape) == FlattenedSize(actualShape);
+    }
+
+    private static int[] TrimLeadingUnitDimensions(int[] shape)
+    {
+        int start = 0;
+        while (start < shape.Length - 1 && shape[start] == 1)
+            start++;
+
+        if (start == 0)
+            return shape;
+
+        var trimmed = new int[shape.Length - start];
+        Array.Copy(shape, start, trimmed, 0, trimmed.Length);
+        return trimmed;
+    }
+
+    private static int FlattenedSize(int[] shape)
+    {
+        int size = 1;
+        for (int i = 0; i < shape.Length; i++)
+            size *= shape[i];
+
+        return size;
     }
 
     /// <summary>
@@ -2168,7 +2274,7 @@ public abstract class NeuralNetworkBase<T> : INeuralNetworkModel<T>, IInterpreta
         var currentInputShape = currentLayer.GetInputShape();
         bool currentIsLazy = currentInputShape.Length == 0
                              || currentInputShape.Any(d => d <= 0);
-        if (!currentIsLazy && !Enumerable.SequenceEqual(prevLayer.GetOutputShape(), currentInputShape))
+        if (!currentIsLazy && !AreShapesCompatible(prevLayer.GetOutputShape(), currentInputShape))
             return false;
 
         // Special checks for specific layer combinations

--- a/src/NeuralNetworks/NeuralNetworkBase.cs
+++ b/src/NeuralNetworks/NeuralNetworkBase.cs
@@ -2308,8 +2308,14 @@ public abstract class NeuralNetworkBase<T> : INeuralNetworkModel<T>, IInterpreta
         // Lazy current layers carry -1 placeholders; defer the product check to first forward.
         if (prevLayer is ReshapeLayer<T> reshapeLayer && !currentIsLazy)
         {
-            return reshapeLayer.GetOutputShape().Aggregate((a, b) => a * b) ==
-                   currentInputShape!.Aggregate((a, b) => a * b);
+            var reshapeOutputShape = TrimLeadingBatchLikeDimensions(reshapeLayer.GetOutputShape());
+            var normalizedCurrentInputShape = TrimLeadingBatchLikeDimensions(currentInputShape!);
+
+            if (reshapeOutputShape.Any(d => d <= 0) || normalizedCurrentInputShape.Any(d => d <= 0))
+                return true;
+
+            return reshapeOutputShape.Aggregate((a, b) => a * b) ==
+                   normalizedCurrentInputShape.Aggregate((a, b) => a * b);
         }
 
         // If no incompatibilities found, layers are considered compatible

--- a/src/NeuralNetworks/NeuralNetworkBase.cs
+++ b/src/NeuralNetworks/NeuralNetworkBase.cs
@@ -2119,9 +2119,15 @@ public abstract class NeuralNetworkBase<T> : INeuralNetworkModel<T>, IInterpreta
         if (ShapesMatchKnownDimensions(expectedShape, actualShape))
             return true;
 
-        var expectedWithoutLeadingUnits = TrimLeadingUnitDimensions(expectedShape);
-        var actualWithoutLeadingUnits = TrimLeadingUnitDimensions(actualShape);
-        return ShapesMatchKnownDimensions(expectedWithoutLeadingUnits, actualWithoutLeadingUnits);
+        var expectedWithoutLeadingBatch = TrimLeadingBatchLikeDimensions(expectedShape);
+        if (ShapesMatchKnownDimensions(expectedWithoutLeadingBatch, actualShape))
+            return true;
+
+        var actualWithoutLeadingBatch = TrimLeadingBatchLikeDimensions(actualShape);
+        if (ShapesMatchKnownDimensions(expectedShape, actualWithoutLeadingBatch))
+            return true;
+
+        return ShapesMatchKnownDimensions(expectedWithoutLeadingBatch, actualWithoutLeadingBatch);
     }
 
     private static bool ShapesMatchKnownDimensions(int[] expectedShape, int[] actualShape)
@@ -2138,10 +2144,10 @@ public abstract class NeuralNetworkBase<T> : INeuralNetworkModel<T>, IInterpreta
         return true;
     }
 
-    private static int[] TrimLeadingUnitDimensions(int[] shape)
+    private static int[] TrimLeadingBatchLikeDimensions(int[] shape)
     {
         int start = 0;
-        while (start < shape.Length - 1 && shape[start] == 1)
+        while (start < shape.Length - 1 && shape[start] <= 1)
             start++;
 
         if (start == 0)

--- a/src/NeuralNetworks/NeuralNetworkBase.cs
+++ b/src/NeuralNetworks/NeuralNetworkBase.cs
@@ -2111,17 +2111,31 @@ public abstract class NeuralNetworkBase<T> : INeuralNetworkModel<T>, IInterpreta
 
     private static bool IsDeferredOrAgnosticShape(int[]? shape)
     {
-        return shape is null || shape.Length == 0 || shape.Any(d => d <= 0);
+        return shape is null || shape.Length == 0 || shape.All(d => d <= 0);
     }
 
     private static bool AreShapesCompatible(int[] expectedShape, int[] actualShape)
     {
-        if (expectedShape.SequenceEqual(actualShape))
+        if (ShapesMatchKnownDimensions(expectedShape, actualShape))
             return true;
 
         var expectedWithoutLeadingUnits = TrimLeadingUnitDimensions(expectedShape);
         var actualWithoutLeadingUnits = TrimLeadingUnitDimensions(actualShape);
-        return expectedWithoutLeadingUnits.SequenceEqual(actualWithoutLeadingUnits);
+        return ShapesMatchKnownDimensions(expectedWithoutLeadingUnits, actualWithoutLeadingUnits);
+    }
+
+    private static bool ShapesMatchKnownDimensions(int[] expectedShape, int[] actualShape)
+    {
+        if (expectedShape.Length != actualShape.Length)
+            return false;
+
+        for (int i = 0; i < expectedShape.Length; i++)
+        {
+            if (expectedShape[i] > 0 && actualShape[i] > 0 && expectedShape[i] != actualShape[i])
+                return false;
+        }
+
+        return true;
     }
 
     private static int[] TrimLeadingUnitDimensions(int[] shape)

--- a/src/NeuralNetworks/Transformer.cs
+++ b/src/NeuralNetworks/Transformer.cs
@@ -350,57 +350,31 @@ public class Transformer<T> : NeuralNetworkBase<T>, IAuxiliaryLossLayer<T>
     }
 
     /// <summary>
-    /// Ensures that custom layers provided for the Transformer meet the minimum requirements.
+    /// Ensures that custom layers provided for the Transformer are shape-compatible.
     /// </summary>
     /// <param name="layers">The list of layers to validate.</param>
     /// <remarks>
     /// <para>
-    /// A valid Transformer must include at least one attention layer and one normalization layer.
-    /// Attention layers allow the model to focus on different parts of the input sequence.
-    /// Normalization layers help stabilize training by normalizing the activations.
+    /// Custom Transformer layer lists are validated by input/output shape compatibility.
+    /// This allows research architectures to replace the standard attention, normalization,
+    /// and readout substrate with domain-specific layers while still catching broken
+    /// layer-to-layer shape contracts.
     /// </para>
-    /// <para><b>For Beginners:</b> This method checks if your custom layers will actually work as a Transformer.
-    /// 
-    /// For a Transformer to function properly, it needs at minimum:
-    /// - An attention layer (which helps the model focus on important parts of the input)
-    /// - A normalization layer (which keeps the numbers stable during training)
-    /// 
-    /// If either of these is missing, it's like trying to build a house without walls or a foundation - it won't work!
-    /// 
-    /// This method checks for these essential components and raises an error if they're missing.
+    /// <para><b>For Beginners:</b> This method checks whether your custom layers fit together.
+    /// It verifies that each layer can receive the previous layer's output and that the final
+    /// layer produces the expected output size.
     /// </para>
     /// </remarks>
     /// <exception cref="InvalidOperationException">
-    /// Thrown when the custom layers don't include required layer types.
+    /// Thrown when derived Transformer implementations add additional validation failures.
     /// </exception>
     protected override void ValidateCustomLayers(List<ILayer<T>> layers)
     {
+        // Custom Transformer layer lists may replace the classical
+        // attention/norm/readout substrate with domain-specific layers.
+        // The framework contract is shape compatibility; concrete layer-type
+        // identity is not a valid extensibility boundary.
         base.ValidateCustomLayers(layers);
-
-        bool hasAttentionLayer = false;
-        bool hasLayerNorm = false;
-
-        for (int i = 0; i < layers.Count; i++)
-        {
-            if (layers[i] is MultiHeadAttentionLayer<T>)
-            {
-                hasAttentionLayer = true;
-            }
-            else if (layers[i] is LayerNormalizationLayer<T>)
-            {
-                hasLayerNorm = true;
-            }
-        }
-
-        if (!hasAttentionLayer)
-        {
-            throw new InvalidOperationException("Custom Transformer must include at least one MultiHeadAttentionLayer.");
-        }
-
-        if (!hasLayerNorm)
-        {
-            throw new InvalidOperationException("Custom Transformer must include at least one LayerNormalizationLayer.");
-        }
     }
 
     /// <summary>

--- a/tests/AiDotNet.Tests/IntegrationTests/NeuralNetworks/TransformerCustomLayerValidationIssue1317IntegrationTests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/NeuralNetworks/TransformerCustomLayerValidationIssue1317IntegrationTests.cs
@@ -1,0 +1,129 @@
+using AiDotNet.Enums;
+using AiDotNet.Interfaces;
+using AiDotNet.NeuralNetworks;
+using AiDotNet.NeuralNetworks.Layers;
+using AiDotNet.Tensors.Helpers;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNetTests.IntegrationTests.NeuralNetworks;
+
+/// <summary>
+/// Integration coverage for issue #1317: custom Transformer layer lists must
+/// be validated by shape contract rather than concrete built-in layer types.
+/// </summary>
+public class TransformerCustomLayerValidationIssue1317IntegrationTests
+{
+    [Fact]
+    public void CustomTransformerLayerStack_ForwardsWithoutBuiltInAttentionOrNormLayers()
+    {
+        var layers = new List<ILayer<float>>
+        {
+            new ProjectingCustomLayer([1, 16], [1, 32]),
+            new ProjectingCustomLayer([32], [1, 256])
+        };
+
+        var model = new Transformer<float>(CreateArchitecture(layers));
+
+        var input = new Tensor<float>([1, 16]);
+        for (int i = 0; i < 16; i++)
+            input[0, i] = i + 1;
+
+        var output = model.Predict(input);
+
+        Assert.Equal([1, 256], output.Shape);
+        Assert.DoesNotContain(model.Layers, layer => layer is MultiHeadAttentionLayer<float>);
+        Assert.DoesNotContain(model.Layers, layer => layer is LayerNormalizationLayer<float>);
+        Assert.True(output[0, 1] > output[0, 0]);
+    }
+
+    [Fact]
+    public void CustomTransformerLayerStack_RejectsIncompatibleLayerTransition()
+    {
+        var layers = new List<ILayer<float>>
+        {
+            new ProjectingCustomLayer([1, 16], [1, 32]),
+            new ProjectingCustomLayer([1, 31], [1, 256])
+        };
+
+        var ex = Assert.Throws<ArgumentException>(() => new Transformer<float>(CreateArchitecture(layers)));
+        Assert.Contains("Layer 0 is not compatible with Layer 1", ex.Message);
+    }
+
+    [Fact]
+    public void CustomTransformerLayerStack_RejectsOutputSizeMismatch()
+    {
+        var layers = new List<ILayer<float>>
+        {
+            new ProjectingCustomLayer([1, 16], [1, 128])
+        };
+
+        var ex = Assert.Throws<ArgumentException>(() => new Transformer<float>(CreateArchitecture(layers)));
+        Assert.Contains("must match the architecture output size (256)", ex.Message);
+    }
+
+    [Fact]
+    public void DefaultTransformerArchitecture_StillBuildsStandardTransformerLayers()
+    {
+        var model = new Transformer<float>(CreateArchitecture(layers: null));
+
+        Assert.Contains(model.Layers, layer => layer is MultiHeadAttentionLayer<float>);
+        Assert.Contains(model.Layers, layer => layer is LayerNormalizationLayer<float>);
+    }
+
+    private static TransformerArchitecture<float> CreateArchitecture(List<ILayer<float>>? layers)
+        => new(
+            inputType: InputType.TwoDimensional,
+            taskType: NeuralNetworkTaskType.SequenceClassification,
+            numEncoderLayers: 1,
+            numDecoderLayers: 0,
+            numHeads: 2,
+            modelDimension: 16,
+            feedForwardDimension: 32,
+            complexity: NetworkComplexity.Medium,
+            inputSize: 16,
+            outputSize: 256,
+            dropoutRate: 0.0,
+            maxSequenceLength: 16,
+            vocabularySize: 256,
+            usePositionalEncoding: true,
+            temperature: 1.0,
+            sequencePooling: null,
+            layers: layers);
+
+    private sealed class ProjectingCustomLayer(int[] inputShape, int[] outputShape)
+        : LayerBase<float>(inputShape, outputShape)
+    {
+        public override bool SupportsTraining => false;
+
+        public override Tensor<float> Forward(Tensor<float> input)
+        {
+            int batch = input.Shape.Length == 0 ? 1 : input.Shape[0];
+            int outputWidth = GetOutputShape()[^1];
+            var output = new Tensor<float>([batch, outputWidth]);
+
+            float sum = 0f;
+            for (int i = 0; i < input.Length; i++)
+                sum += input[i];
+
+            for (int b = 0; b < batch; b++)
+            for (int j = 0; j < outputWidth; j++)
+                output[b, j] = sum + j;
+
+            return output;
+        }
+
+        public override void UpdateParameters(float learningRate)
+        {
+        }
+
+        public override Vector<float> GetParameters()
+        {
+            return Vector<float>.Empty();
+        }
+
+        public override void ResetState()
+        {
+        }
+    }
+}

--- a/tests/AiDotNet.Tests/IntegrationTests/NeuralNetworks/TransformerCustomLayerValidationIssue1317IntegrationTests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/NeuralNetworks/TransformerCustomLayerValidationIssue1317IntegrationTests.cs
@@ -104,6 +104,22 @@ public class TransformerCustomLayerValidationIssue1317IntegrationTests
     }
 
     [Fact]
+    public void CustomTransformerLayerStack_AllowsExplicitReshapeBeforeDynamicLeadingBatchAxis()
+    {
+        var layers = new List<ILayer<float>>
+        {
+            new ProjectingCustomLayer([1, 16], [2, 8]),
+            new ReshapeLayer<float>([16]),
+            new ProjectingCustomLayer([-1, 16], [1, 256])
+        };
+
+        var model = new Transformer<float>(CreateCustomLayerArchitecture(layers));
+
+        Assert.Same(layers[1], model.Layers[1]);
+        Assert.Same(layers[2], model.Layers[2]);
+    }
+
+    [Fact]
     public void CustomTransformerLayerStack_AllowsDynamicLeadingBatchAxis()
     {
         var layers = new List<ILayer<float>>

--- a/tests/AiDotNet.Tests/IntegrationTests/NeuralNetworks/TransformerCustomLayerValidationIssue1317IntegrationTests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/NeuralNetworks/TransformerCustomLayerValidationIssue1317IntegrationTests.cs
@@ -31,10 +31,23 @@ public class TransformerCustomLayerValidationIssue1317IntegrationTests
 
         var output = model.Predict(input);
 
-        Assert.Equal([1, 256], output.Shape);
+        Assert.Equal(new[] { 1, 256 }, output.Shape.ToArray());
         Assert.DoesNotContain(model.Layers, layer => layer is MultiHeadAttentionLayer<float>);
         Assert.DoesNotContain(model.Layers, layer => layer is LayerNormalizationLayer<float>);
         Assert.True(output[0, 1] > output[0, 0]);
+    }
+
+    [Fact]
+    public void CustomTransformerLayerStack_RejectsFirstLayerInputShapeMismatch()
+    {
+        var layers = new List<ILayer<float>>
+        {
+            new ProjectingCustomLayer([2, 8], [1, 32]),
+            new ProjectingCustomLayer([32], [1, 256])
+        };
+
+        var ex = Assert.Throws<ArgumentException>(() => new Transformer<float>(CreateCustomLayerArchitecture(layers)));
+        Assert.Contains("first layer's input shape", ex.Message);
     }
 
     [Fact]
@@ -87,6 +100,21 @@ public class TransformerCustomLayerValidationIssue1317IntegrationTests
 
         var model = new Transformer<float>(CreateCustomLayerArchitecture(layers));
 
+        Assert.Same(layers[1], model.Layers[1]);
+    }
+
+    [Fact]
+    public void CustomTransformerLayerStack_AllowsDynamicLeadingBatchAxis()
+    {
+        var layers = new List<ILayer<float>>
+        {
+            new ProjectingCustomLayer([-1, 16], [-1, 32]),
+            new ProjectingCustomLayer([32], [1, 256])
+        };
+
+        var model = new Transformer<float>(CreateCustomLayerArchitecture(layers));
+
+        Assert.Same(layers[0], model.Layers[0]);
         Assert.Same(layers[1], model.Layers[1]);
     }
 

--- a/tests/AiDotNet.Tests/IntegrationTests/NeuralNetworks/TransformerCustomLayerValidationIssue1317IntegrationTests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/NeuralNetworks/TransformerCustomLayerValidationIssue1317IntegrationTests.cs
@@ -91,6 +91,33 @@ public class TransformerCustomLayerValidationIssue1317IntegrationTests
     }
 
     [Fact]
+    public void CustomTransformerLayerStack_RejectsPartiallyKnownShapeMismatch()
+    {
+        var layers = new List<ILayer<float>>
+        {
+            new ProjectingCustomLayer([1, 16], [64, -1]),
+            new ProjectingCustomLayer([128, -1], [1, 256])
+        };
+
+        var ex = Assert.Throws<ArgumentException>(() => new Transformer<float>(CreateCustomLayerArchitecture(layers)));
+        Assert.Contains("Layer 0 is not compatible with Layer 1", ex.Message);
+    }
+
+    [Fact]
+    public void CustomTransformerLayerStack_AllowsPartiallyKnownShapeWhenKnownDimensionsMatch()
+    {
+        var layers = new List<ILayer<float>>
+        {
+            new ProjectingCustomLayer([1, 16], [64, -1]),
+            new ProjectingCustomLayer([64, -1], [1, 256])
+        };
+
+        var model = new Transformer<float>(CreateCustomLayerArchitecture(layers));
+
+        Assert.Same(layers[1], model.Layers[1]);
+    }
+
+    [Fact]
     public void CustomTransformerLayerStack_RejectsTransitionInputShapeMetadataFailures()
     {
         var layers = new List<ILayer<float>>

--- a/tests/AiDotNet.Tests/IntegrationTests/NeuralNetworks/TransformerCustomLayerValidationIssue1317IntegrationTests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/NeuralNetworks/TransformerCustomLayerValidationIssue1317IntegrationTests.cs
@@ -23,7 +23,7 @@ public class TransformerCustomLayerValidationIssue1317IntegrationTests
             new ProjectingCustomLayer([32], [1, 256])
         };
 
-        var model = new Transformer<float>(CreateArchitecture(layers));
+        var model = new Transformer<float>(CreateCustomLayerArchitecture(layers));
 
         var input = new Tensor<float>([1, 16]);
         for (int i = 0; i < 16; i++)
@@ -46,7 +46,7 @@ public class TransformerCustomLayerValidationIssue1317IntegrationTests
             new ProjectingCustomLayer([1, 31], [1, 256])
         };
 
-        var ex = Assert.Throws<ArgumentException>(() => new Transformer<float>(CreateArchitecture(layers)));
+        var ex = Assert.Throws<ArgumentException>(() => new Transformer<float>(CreateCustomLayerArchitecture(layers)));
         Assert.Contains("Layer 0 is not compatible with Layer 1", ex.Message);
     }
 
@@ -58,22 +58,85 @@ public class TransformerCustomLayerValidationIssue1317IntegrationTests
             new ProjectingCustomLayer([1, 16], [1, 128])
         };
 
-        var ex = Assert.Throws<ArgumentException>(() => new Transformer<float>(CreateArchitecture(layers)));
+        var ex = Assert.Throws<ArgumentException>(() => new Transformer<float>(CreateCustomLayerArchitecture(layers)));
         Assert.Contains("must match the architecture output size (256)", ex.Message);
+    }
+
+    [Fact]
+    public void CustomTransformerLayerStack_RejectsFlattenedSizeOnlyTransitionWithoutExplicitReshape()
+    {
+        var layers = new List<ILayer<float>>
+        {
+            new ProjectingCustomLayer([1, 16], [2, 8]),
+            new ProjectingCustomLayer([16], [1, 256])
+        };
+
+        var ex = Assert.Throws<ArgumentException>(() => new Transformer<float>(CreateCustomLayerArchitecture(layers)));
+        Assert.Contains("Layer 0 is not compatible with Layer 1", ex.Message);
+    }
+
+    [Fact]
+    public void CustomTransformerLayerStack_AllowsFlattenedTransitionThroughExplicitReshapeLayer()
+    {
+        var layers = new List<ILayer<float>>
+        {
+            new ProjectingCustomLayer([1, 16], [2, 8]),
+            new ReshapeLayer<float>([16]),
+            new ProjectingCustomLayer([16], [1, 256])
+        };
+
+        var model = new Transformer<float>(CreateCustomLayerArchitecture(layers));
+
+        Assert.Same(layers[1], model.Layers[1]);
+    }
+
+    [Fact]
+    public void CustomTransformerLayerStack_RejectsTransitionInputShapeMetadataFailures()
+    {
+        var layers = new List<ILayer<float>>
+        {
+            new ProjectingCustomLayer([1, 16], [1, 32]),
+            new ThrowingInputShapeLayer([1, 32], [1, 256])
+        };
+
+        var ex = Assert.Throws<ArgumentException>(() => new Transformer<float>(CreateCustomLayerArchitecture(layers)));
+
+        Assert.Contains("Failed to resolve shape metadata from layer", ex.Message);
+        Assert.IsType<InvalidOperationException>(ex.InnerException);
+    }
+
+    [Fact]
+    public void CustomTransformerLayerStack_RejectsOutputShapeMetadataFailures()
+    {
+        var layers = new List<ILayer<float>>
+        {
+            new ThrowingOutputShapeLayer([1, 16], [1, 256])
+        };
+
+        var ex = Assert.Throws<ArgumentException>(() => new Transformer<float>(CreateCustomLayerArchitecture(layers)));
+
+        Assert.Contains("Failed to resolve shape metadata from layer", ex.Message);
+        Assert.IsType<InvalidOperationException>(ex.InnerException);
     }
 
     [Fact]
     public void DefaultTransformerArchitecture_StillBuildsStandardTransformerLayers()
     {
-        var model = new Transformer<float>(CreateArchitecture(layers: null));
+        var model = new Transformer<float>(CreateDefaultTransformerArchitecture());
 
         Assert.Contains(model.Layers, layer => layer is MultiHeadAttentionLayer<float>);
         Assert.Contains(model.Layers, layer => layer is LayerNormalizationLayer<float>);
     }
 
-    private static TransformerArchitecture<float> CreateArchitecture(List<ILayer<float>>? layers)
+    private static TransformerArchitecture<float> CreateCustomLayerArchitecture(List<ILayer<float>> layers)
+        => CreateArchitecture(InputType.OneDimensional, layers);
+
+    private static TransformerArchitecture<float> CreateDefaultTransformerArchitecture()
+        => CreateArchitecture(InputType.TwoDimensional, layers: null);
+
+    private static TransformerArchitecture<float> CreateArchitecture(InputType inputType, List<ILayer<float>>? layers)
         => new(
-            inputType: InputType.TwoDimensional,
+            inputType: inputType,
             taskType: NeuralNetworkTaskType.SequenceClassification,
             numEncoderLayers: 1,
             numDecoderLayers: 0,
@@ -91,24 +154,21 @@ public class TransformerCustomLayerValidationIssue1317IntegrationTests
             sequencePooling: null,
             layers: layers);
 
-    private sealed class ProjectingCustomLayer(int[] inputShape, int[] outputShape)
+    private class ProjectingCustomLayer(int[] inputShape, int[] outputShape)
         : LayerBase<float>(inputShape, outputShape)
     {
         public override bool SupportsTraining => false;
 
         public override Tensor<float> Forward(Tensor<float> input)
         {
-            int batch = input.Shape.Length == 0 ? 1 : input.Shape[0];
-            int outputWidth = GetOutputShape()[^1];
-            var output = new Tensor<float>([batch, outputWidth]);
+            var output = new Tensor<float>(GetOutputShape());
 
             float sum = 0f;
             for (int i = 0; i < input.Length; i++)
                 sum += input[i];
 
-            for (int b = 0; b < batch; b++)
-            for (int j = 0; j < outputWidth; j++)
-                output[b, j] = sum + j;
+            for (int i = 0; i < output.Length; i++)
+                output[i] = sum + i;
 
             return output;
         }
@@ -124,6 +184,24 @@ public class TransformerCustomLayerValidationIssue1317IntegrationTests
 
         public override void ResetState()
         {
+        }
+    }
+
+    private sealed class ThrowingInputShapeLayer(int[] inputShape, int[] outputShape)
+        : ProjectingCustomLayer(inputShape, outputShape)
+    {
+        public override int[] GetInputShape()
+        {
+            throw new InvalidOperationException("Input shape metadata is unavailable.");
+        }
+    }
+
+    private sealed class ThrowingOutputShapeLayer(int[] inputShape, int[] outputShape)
+        : ProjectingCustomLayer(inputShape, outputShape), ILayer<float>
+    {
+        int[] ILayer<float>.GetOutputShape()
+        {
+            throw new InvalidOperationException("Output shape metadata is unavailable.");
         }
     }
 }

--- a/tests/AiDotNet.Tests/UnitTests/NeuralNetworks/TransformerCustomLayerValidationIssue1317Tests.cs
+++ b/tests/AiDotNet.Tests/UnitTests/NeuralNetworks/TransformerCustomLayerValidationIssue1317Tests.cs
@@ -18,7 +18,7 @@ public class TransformerCustomLayerValidationIssue1317Tests
         };
 
         var architecture = new TransformerArchitecture<float>(
-            inputType: InputType.TwoDimensional,
+            inputType: InputType.OneDimensional,
             taskType: NeuralNetworkTaskType.SequenceClassification,
             numEncoderLayers: 1,
             numDecoderLayers: 0,

--- a/tests/AiDotNet.Tests/UnitTests/NeuralNetworks/TransformerCustomLayerValidationIssue1317Tests.cs
+++ b/tests/AiDotNet.Tests/UnitTests/NeuralNetworks/TransformerCustomLayerValidationIssue1317Tests.cs
@@ -1,0 +1,67 @@
+using AiDotNet.Enums;
+using AiDotNet.NeuralNetworks;
+using AiDotNet.NeuralNetworks.Layers;
+using AiDotNet.Tensors.Helpers;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tests.UnitTests.NeuralNetworks;
+
+public class TransformerCustomLayerValidationIssue1317Tests
+{
+    [Fact]
+    public void Constructor_CustomShapeCompatibleLayerList_DoesNotRequireBuiltInBoundaryLayerTypes()
+    {
+        var layers = new List<AiDotNet.Interfaces.ILayer<float>>
+        {
+            new ShapeCompatibleCustomLayer([1, 16], [1, 256])
+        };
+
+        var architecture = new TransformerArchitecture<float>(
+            inputType: InputType.TwoDimensional,
+            taskType: NeuralNetworkTaskType.SequenceClassification,
+            numEncoderLayers: 1,
+            numDecoderLayers: 0,
+            numHeads: 2,
+            modelDimension: 16,
+            feedForwardDimension: 32,
+            complexity: NetworkComplexity.Medium,
+            inputSize: 16,
+            outputSize: 256,
+            dropoutRate: 0.0,
+            maxSequenceLength: 16,
+            vocabularySize: 256,
+            usePositionalEncoding: true,
+            temperature: 1.0,
+            sequencePooling: null,
+            layers: layers);
+
+        var transformer = new Transformer<float>(architecture);
+
+        Assert.Same(layers[0], transformer.Layers[0]);
+    }
+
+    private sealed class ShapeCompatibleCustomLayer(int[] inputShape, int[] outputShape)
+        : LayerBase<float>(inputShape, outputShape)
+    {
+        public override bool SupportsTraining => false;
+
+        public override Tensor<float> Forward(Tensor<float> input)
+        {
+            return input;
+        }
+
+        public override void UpdateParameters(float learningRate)
+        {
+        }
+
+        public override Vector<float> GetParameters()
+        {
+            return Vector<float>.Empty();
+        }
+
+        public override void ResetState()
+        {
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Replace concrete input/output layer type checks in custom-layer validation with shape-compatible boundary checks.
- Relax `Transformer<T>.ValidateCustomLayers` so custom Transformer stacks are not required to contain built-in `MultiHeadAttentionLayer` and `LayerNormalizationLayer` types.
- Keep validation for broken custom stacks by checking first-layer input compatibility, layer-to-layer transitions, and final output size compatibility.

Closes #1317.

## Tests

- `dotnet test tests/AiDotNet.Tests/AiDotNetTests.csproj --no-restore --framework net10.0 --filter FullyQualifiedName~TransformerCustomLayerValidationIssue1317|FullyQualifiedName~TransformerDefaultOptimizerTests --nologo -v:quiet`

Coverage added:
- Unit regression for constructing a Transformer with a shape-compatible custom layer that is not a built-in boundary layer.
- Integration coverage for forwarding through a custom Transformer stack without built-in attention/norm layers.
- Integration guards for rejecting incompatible layer transitions and output-size mismatches.
- Integration guard that default Transformer construction still emits standard attention/norm layers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved layer validation to use shape-compatibility rules (accepts deferred/unknown shapes, tolerates unit-dimension differences, and provides clearer mismatch messages and exception wrapping), enabling more flexible custom layer stacks and correct reshape/flatten transitions.
  * Transformer no longer requires built-in attention or normalization when custom layers satisfy shape contracts; explicit reshape layers remain supported.

* **Tests**
  * Added unit and integration tests covering custom layer validation, reshape/flatten transitions, instance preservation, and error cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ooples/AiDotNet/pull/1320)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->