### PR TITLE
fix: recognise embedding-category layers in custom-chain validators (#1321/#1322/#1323)

### DIFF
--- a/src/FitDetectors/CalibratedProbabilityFitDetector.cs
+++ b/src/FitDetectors/CalibratedProbabilityFitDetector.cs
@@ -365,11 +365,23 @@ public class CalibratedProbabilityFitDetector<T, TInput, TOutput> : FitDetectorB
     {
         // Empty calibration vectors arise when CalculateCalibration could
         // not reconcile predicted-vs-actual shapes (see #1322). Avoid the
-        // 0/0 NaN that the divide-by-Length below would produce; return
-        // zero error so DetermineFitType / CalculateConfidenceLevel see a
-        // "no signal" baseline rather than a NaN-poisoned fit type.
+        // 0/0 NaN that the divide-by-Length below would produce.
+        //
+        // Return MaxCalibrationError so the no-data case is interpreted as
+        // a worst-case fit rather than a perfect one. Returning Zero here
+        // would route DetermineFitType to FitType.GoodFit (error <
+        // GoodFitThreshold) and CalculateConfidenceLevel to 1.0
+        // (1 - 0/MaxError = 1) — i.e. "the model is perfectly calibrated
+        // with maximum confidence" exactly when we have no calibration
+        // data to verify that. With MaxCalibrationError instead,
+        // DetermineFitType returns FitType.Overfit (error > OverfitThreshold)
+        // and CalculateConfidenceLevel returns 0 (1 - MaxError/MaxError),
+        // which the optimizer correctly reads as "low-confidence
+        // worst-case verdict" — pair this with the Trace warning emitted
+        // by CalculateCalibration's mismatch branch to surface the real
+        // shape-contract issue without falsely flattering the model.
         if (expected.Length == 0)
-            return NumOps.Zero;
+            return NumOps.FromDouble(_options.MaxCalibrationError);
 
         var squaredErrors = new Vector<T>(expected.Length);
         for (int i = 0; i < expected.Length; i++)

--- a/src/FitDetectors/CalibratedProbabilityFitDetector.cs
+++ b/src/FitDetectors/CalibratedProbabilityFitDetector.cs
@@ -270,13 +270,39 @@ public class CalibratedProbabilityFitDetector<T, TInput, TOutput> : FitDetectorB
         }
         else if (predicted.Length != actual.Length)
         {
-            // Non-multiclass mismatch (e.g. rank-discordant tensors). Guard
-            // with a clear error rather than an opaque OOR from the bin loop.
-            throw new InvalidOperationException(
+            // Non-multiclass mismatch (e.g. rank-discordant tensors, or
+            // model emits per-sample output while batch labels are stacked
+            // — the inverse of the multiclass case above). Two scenarios
+            // we surface gracefully here so the optimizer's per-iteration
+            // loop doesn't unconditionally throw:
+            //
+            //   1. actual.Length is an integer multiple of predicted.Length
+            //      (the inverse-multiclass case from #1322 — model returns
+            //      one sample's output but labels carry the full batch).
+            //      Calibration is genuinely undefined here: we have one
+            //      prediction and many ground-truth values, so binning
+            //      cannot align them. Return EMPTY calibration vectors so
+            //      DetermineFitType / CalculateConfidenceLevel see a
+            //      no-data signal rather than a thrown exception.
+            //   2. Anything else (rank-discordant tensors, off-by-one
+            //      shape drift). Same handling — empty calibration —
+            //      with a Trace warning so the developer can find the
+            //      shape-contract issue without losing the training run.
+            //
+            // The earlier always-throw behaviour blocked legitimate
+            // research / custom-architecture training under the default
+            // FitDetector setting (#1322). Industry-standard pattern:
+            // lenient default + diagnostic trace + the strict gate only
+            // applies when shape can be reconciled. Closes #1322.
+            System.Diagnostics.Trace.WriteLine(
                 $"CalibratedProbabilityFitDetector: predicted length ({predicted.Length}) and actual "
-                + $"length ({actual.Length}) are incompatible. Either predicted-probability length must "
-                + "equal actual length (binary calibration), or predicted.Length must be an integer "
-                + "multiple of actual.Length (multiclass probabilities + class-index labels).");
+                + $"length ({actual.Length}) cannot be reconciled. Calibration metrics will be empty "
+                + "for this evaluation step. Either the model's Predict output and the labels disagree "
+                + "on batch axis (per-sample vs stacked), or the prediction tensor rank doesn't match "
+                + "the label tensor rank. Override OptimizationAlgorithmOptions.FitDetector with a "
+                + "task-appropriate detector (or null, if calibration isn't meaningful for this model) "
+                + "to silence this warning.");
+            return (Vector<T>.Empty(), Vector<T>.Empty());
         }
 
         var numBins = _options.NumCalibrationBins;
@@ -337,6 +363,14 @@ public class CalibratedProbabilityFitDetector<T, TInput, TOutput> : FitDetectorB
     /// </remarks>
     private T CalculateCalibrationError(Vector<T> expected, Vector<T> observed)
     {
+        // Empty calibration vectors arise when CalculateCalibration could
+        // not reconcile predicted-vs-actual shapes (see #1322). Avoid the
+        // 0/0 NaN that the divide-by-Length below would produce; return
+        // zero error so DetermineFitType / CalculateConfidenceLevel see a
+        // "no signal" baseline rather than a NaN-poisoned fit type.
+        if (expected.Length == 0)
+            return NumOps.Zero;
+
         var squaredErrors = new Vector<T>(expected.Length);
         for (int i = 0; i < expected.Length; i++)
         {

--- a/src/NeuralNetworks/NeuralNetworkArchitecture.cs
+++ b/src/NeuralNetworks/NeuralNetworkArchitecture.cs
@@ -1078,8 +1078,34 @@ public class NeuralNetworkArchitecture<T>
     /// validator stays self-contained without introducing a new dependency
     /// on NeuralNetworkBase. Closes #1321.
     /// </summary>
+    /// <remarks>
+    /// Recognition is intentionally broader than the LayerBase&lt;T&gt;
+    /// category check alone. Custom embedding / positional layers that
+    /// implement <see cref="ILayer{T}"/> directly (i.e. don't inherit from
+    /// LayerBase&lt;T&gt;) wouldn't expose <c>GetLayerCategory()</c> at
+    /// all, so a category-only check would still reject them and the
+    /// #1321 / #1323 use case (substrate-correct custom embeddings outside
+    /// LayerBase&lt;T&gt;) would still throw. A name-based fallback
+    /// matches the same convention LayerBase.GetLayerCategory itself uses
+    /// for its name-based default classification, so the two paths agree
+    /// on what counts as an "Embedding" layer.
+    /// </remarks>
     private static bool IsBroadcastInputLayerCategory(ILayer<T> layer)
-        => layer is Layers.LayerBase<T> lb && lb.GetLayerCategory() == Interfaces.LayerCategory.Embedding;
+    {
+        if (layer is Layers.LayerBase<T> lb &&
+            lb.GetLayerCategory() == Interfaces.LayerCategory.Embedding)
+        {
+            return true;
+        }
+
+        // Name-based fallback for custom ILayer<T> implementations that
+        // don't inherit from LayerBase<T>. Matches the same heuristic
+        // LayerBase.GetLayerCategory uses for its default classification
+        // (typeName.Contains "Embedding" / "Positional", case-insensitive).
+        var layerName = layer.GetType().Name;
+        return layerName.Contains("Embedding", System.StringComparison.OrdinalIgnoreCase)
+            || layerName.Contains("Positional", System.StringComparison.OrdinalIgnoreCase);
+    }
 
     /// <summary>
     /// Indicates whether this architecture declares dynamic (lazy) spatial dimensions —

--- a/src/NeuralNetworks/NeuralNetworkArchitecture.cs
+++ b/src/NeuralNetworks/NeuralNetworkArchitecture.cs
@@ -1042,6 +1042,19 @@ public class NeuralNetworkArchitecture<T>
         if (Layers != null && Layers.Count > 0)
         {
             var firstLayer = Layers[0];
+
+            // Embedding-category layers (token / positional / patch / time)
+            // declare their input shape as a per-element broadcast contract
+            // (e.g. EmbeddingLayer<T> reports [1] = "I take one token at a
+            // time" while EmbeddingLayer<T>.Forward actually accepts any-rank
+            // token tensor [seqLen] / [batch, seqLen] / [batch, seqLen, 1]).
+            // The strict product-vs-InputSize check would reject this
+            // legitimate broadcast contract; recognise the category up front
+            // and let the runtime shape inference handle dimensional
+            // compatibility. Closes #1321.
+            if (IsBroadcastInputLayerCategory(firstLayer))
+                return;
+
             var firstShape = firstLayer.GetInputShape();
             // Lazy layers carry -1 placeholders until first Forward; skip the strict
             // size check and let runtime shape resolution validate the dimensions.
@@ -1056,6 +1069,17 @@ public class NeuralNetworkArchitecture<T>
             }
         }
     }
+
+    /// <summary>
+    /// True when <paramref name="layer"/> is an Embedding-category layer
+    /// whose declared input shape is a per-element broadcast contract.
+    /// Mirrors <c>NeuralNetworkBase&lt;T&gt;.IsBroadcastInputCategory</c> —
+    /// kept here as a static private helper so the architecture-level
+    /// validator stays self-contained without introducing a new dependency
+    /// on NeuralNetworkBase. Closes #1321.
+    /// </summary>
+    private static bool IsBroadcastInputLayerCategory(ILayer<T> layer)
+        => layer is Layers.LayerBase<T> lb && lb.GetLayerCategory() == Interfaces.LayerCategory.Embedding;
 
     /// <summary>
     /// Indicates whether this architecture declares dynamic (lazy) spatial dimensions —

--- a/src/NeuralNetworks/NeuralNetworkBase.cs
+++ b/src/NeuralNetworks/NeuralNetworkBase.cs
@@ -2046,6 +2046,18 @@ public abstract class NeuralNetworkBase<T> : INeuralNetworkModel<T>, IInterpreta
 
     private bool IsFirstLayerShapeCompatible(ILayer<T> layer)
     {
+        // Embedding-category layers (token / positional / patch / time
+        // embeddings) declare their input shape as the per-element lookup
+        // contract (typically [1] = "I take one token at a time"), even
+        // though Forward broadcasts over upstream rank — see
+        // EmbeddingLayer<T>.Forward which accepts [seqLen], [batch, seqLen],
+        // [batch, seqLen, 1] and returns embedded results in matching rank.
+        // The strict architecture-input-shape check would reject this
+        // legitimate broadcast contract; recognise the category and skip
+        // the strict shape match. Closes #1321.
+        if (IsBroadcastInputCategory(layer))
+            return true;
+
         int[]? layerInputShape = TryGetLayerShape(layer, shapeSelector: static l => l.GetInputShape());
         if (IsDeferredOrAgnosticShape(layerInputShape))
             return true;
@@ -2056,6 +2068,23 @@ public abstract class NeuralNetworkBase<T> : INeuralNetworkModel<T>, IInterpreta
 
         return AreShapesCompatible(architectureInputShape!, layerInputShape!);
     }
+
+    /// <summary>
+    /// True when <paramref name="layer"/> is an Embedding-category layer
+    /// whose declared input shape is a per-element broadcast contract
+    /// (e.g. <c>EmbeddingLayer&lt;T&gt;</c> reports input shape <c>[1]</c>
+    /// for per-token lookup; positional encodings report similar
+    /// broadcast-friendly shapes).
+    /// </summary>
+    /// <remarks>
+    /// Used by both first-layer-vs-architecture and layer-to-layer
+    /// compatibility checks so a custom chain like
+    /// <c>InputLayer(64) → EmbeddingLayer(vocab, dim) → ...</c> validates
+    /// without false rejection — the <c>[64]</c>-vs-<c>[1]</c> mismatch is
+    /// a contract feature, not a bug. Closes #1321 / #1323.
+    /// </remarks>
+    private static bool IsBroadcastInputCategory(ILayer<T> layer)
+        => layer is LayerBase<T> lb && lb.GetLayerCategory() == LayerCategory.Embedding;
 
     private bool IsLastLayerShapeCompatible(ILayer<T> layer, out string error)
     {
@@ -2277,6 +2306,16 @@ public abstract class NeuralNetworkBase<T> : INeuralNetworkModel<T>, IInterpreta
     /// </remarks>
     protected virtual bool AreLayersCompatible(ILayer<T> prevLayer, ILayer<T> currentLayer)
     {
+        // Embedding-category layers (token / positional / patch / time)
+        // declare their input shape as a per-element lookup contract — the
+        // current rank-aware Forward (see EmbeddingLayer<T>.Forward) accepts
+        // any-rank token tensor and broadcasts the embedding lookup over it.
+        // Skip the strict prev-output ↔ current-input shape match for these
+        // layers so a chain like InputLayer(64) → EmbeddingLayer(vocab, dim)
+        // validates correctly. Closes #1323.
+        if (IsBroadcastInputCategory(currentLayer))
+            return true;
+
         // Lazy layers report InputShape = [-1] (or empty) until first Forward —
         // skip the strict shape-equality check; resolution happens at first
         // forward. Empty-shape layers are shape-agnostic by design (e.g.

--- a/src/NeuralNetworks/NeuralNetworkBase.cs
+++ b/src/NeuralNetworks/NeuralNetworkBase.cs
@@ -2077,14 +2077,37 @@ public abstract class NeuralNetworkBase<T> : INeuralNetworkModel<T>, IInterpreta
     /// broadcast-friendly shapes).
     /// </summary>
     /// <remarks>
+    /// <para>
     /// Used by both first-layer-vs-architecture and layer-to-layer
     /// compatibility checks so a custom chain like
     /// <c>InputLayer(64) → EmbeddingLayer(vocab, dim) → ...</c> validates
     /// without false rejection — the <c>[64]</c>-vs-<c>[1]</c> mismatch is
     /// a contract feature, not a bug. Closes #1321 / #1323.
+    /// </para>
+    /// <para>
+    /// Recognition is intentionally broader than the LayerBase&lt;T&gt;
+    /// category check alone: custom embedding / positional layers that
+    /// implement <see cref="ILayer{T}"/> directly (without inheriting
+    /// LayerBase&lt;T&gt;) don't expose <c>GetLayerCategory()</c>, so a
+    /// category-only check would still reject the broadcast-input
+    /// contract for them. The name-based fallback matches the same
+    /// convention LayerBase.GetLayerCategory uses for its default
+    /// classification, so the two recognition paths agree.
+    /// </para>
     /// </remarks>
     private static bool IsBroadcastInputCategory(ILayer<T> layer)
-        => layer is LayerBase<T> lb && lb.GetLayerCategory() == LayerCategory.Embedding;
+    {
+        if (layer is LayerBase<T> lb && lb.GetLayerCategory() == LayerCategory.Embedding)
+            return true;
+
+        // Name-based fallback for custom ILayer<T> implementations not
+        // derived from LayerBase<T>. Matches the same heuristic
+        // LayerBase.GetLayerCategory uses (typeName.Contains "Embedding" /
+        // "Positional", case-insensitive).
+        var layerName = layer.GetType().Name;
+        return layerName.Contains("Embedding", StringComparison.OrdinalIgnoreCase)
+            || layerName.Contains("Positional", StringComparison.OrdinalIgnoreCase);
+    }
 
     private bool IsLastLayerShapeCompatible(ILayer<T> layer, out string error)
     {

--- a/tests/AiDotNet.Tests/IntegrationTests/NeuralNetworks/EmbeddingLayerValidatorIssues1321_1322_1323IntegrationTests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/NeuralNetworks/EmbeddingLayerValidatorIssues1321_1322_1323IntegrationTests.cs
@@ -272,7 +272,21 @@ public class EmbeddingLayerValidatorIssues1321_1322_1323IntegrationTests
             layers: layers);
 
         var network = new FeedForwardNeuralNetwork<float>(arch);
-        Assert.NotEmpty(network.Layers);
+        Assert.Equal(2, network.Layers.Count);
+
+        // Assert first layer is PositionalEncodingLayer with correct config
+        var posLayer = Assert.IsType<PositionalEncodingLayer<float>>(network.Layers[0]);
+        Assert.Equal(Dim, posLayer.OutputShape[^1]); // embeddingSize/OutputDimension is last dimension
+
+        // Assert second layer is DenseLayer with correct shape
+        var denseLayer = Assert.IsAssignableFrom<DenseLayer<float>>(network.Layers[1]);
+        Assert.Equal(CtxLen, denseLayer.OutputShape[0]);
+
+        // Assert architecture properties match
+        Assert.Equal(InputType.OneDimensional, arch.InputType);
+        Assert.Equal(NeuralNetworkTaskType.Regression, arch.TaskType);
+        Assert.Equal(CtxLen, arch.InputSize);
+        Assert.Equal(CtxLen, arch.OutputSize);
     }
 
     [Fact]
@@ -306,28 +320,17 @@ public class EmbeddingLayerValidatorIssues1321_1322_1323IntegrationTests
     [Fact]
     public void EdgeCase_NonLayerBaseEmbedding_RecognisedByNameFallback()
     {
-        // Custom layer whose category-via-LayerBase recognition is BLOCKED
-        // (the layer doesn't override GetLayerCategory and its type name
-        // wouldn't normally hit the LayerBase name heuristic — but we DO
-        // name it so that the Embedding-name fallback in the validators
-        // can recognise it). This proves the broader recognition path
-        // covers custom embeddings whose authors didn't override
-        // GetLayerCategory.
+        // Custom layer that implements ILayer<float> directly WITHOUT
+        // inheriting from LayerBase<float>. This proves the name-based
+        // fallback works for true ILayer implementations (not just
+        // LayerBase subclasses). The layer's name contains "Embedding"
+        // so the validators' name-based fallback should recognize it.
         const int VocabSize = 32;
         const int CtxLen = 8;
 
-        // Use a name that explicitly contains "Embedding" so the name-based
-        // fallback path fires. The type itself derives from LayerBase but
-        // does NOT override GetLayerCategory — so reaching the name-based
-        // recognition exercises the ILayer-side fallback we added per the
-        // CodeRabbit review (custom embeddings outside LayerBase still
-        // pass through, since the name match is the safety net).
-        var firstLayer = new NameOnlyEmbeddingLayer(VocabSize);
-        Assert.NotEqual(LayerCategory.Embedding,
-            // sanity: this layer's GetLayerCategory does NOT report Embedding,
-            // so the only path the validator can use to bypass strict shape
-            // is the name-based fallback.
-            new ProbeForCategoryReporter(firstLayer).Reported);
+        // Use the non-LayerBase implementation to exercise the name-based
+        // fallback for a true ILayer<float> (not a LayerBase subclass).
+        var firstLayer = new NameOnlyEmbeddingLayerNonLayerBase(VocabSize);
 
         var layers = new List<ILayer<float>>
         {
@@ -337,9 +340,10 @@ public class EmbeddingLayerValidatorIssues1321_1322_1323IntegrationTests
 
         // ValidateInputDimensions runs in the NeuralNetworkArchitecture
         // constructor — its bypass via IsBroadcastInputLayerCategory must
-        // accept the name-matched embedding layer even when the category
-        // override doesn't say Embedding. If the bypass were category-only,
-        // this construction would throw the #1321 strict-size error.
+        // accept the name-matched embedding layer even when the layer
+        // doesn't inherit from LayerBase and can't report a category.
+        // If the bypass were category-only, this construction would throw
+        // the #1321 strict-size error.
         var arch = new NeuralNetworkArchitecture<float>(
             inputType: InputType.OneDimensional,
             taskType: NeuralNetworkTaskType.MultiClassClassification,
@@ -349,6 +353,30 @@ public class EmbeddingLayerValidatorIssues1321_1322_1323IntegrationTests
 
         Assert.NotNull(arch);
         Assert.Same(firstLayer, arch.Layers![0]);
+
+        // Also test with the LayerBase-derived version to ensure both paths work
+        var layerBaseDerived = new NameOnlyEmbeddingLayer(VocabSize);
+        Assert.NotEqual(LayerCategory.Embedding,
+            // sanity: this layer's GetLayerCategory does NOT report Embedding,
+            // so the only path the validator can use to bypass strict shape
+            // is the name-based fallback.
+            new ProbeForCategoryReporter(layerBaseDerived).Reported);
+
+        var layers2 = new List<ILayer<float>>
+        {
+            layerBaseDerived,
+            new DenseLayer<float>(VocabSize, (IActivationFunction<float>)new IdentityActivation<float>()),
+        };
+
+        var arch2 = new NeuralNetworkArchitecture<float>(
+            inputType: InputType.OneDimensional,
+            taskType: NeuralNetworkTaskType.MultiClassClassification,
+            inputSize: CtxLen,
+            outputSize: VocabSize,
+            layers: layers2);
+
+        Assert.NotNull(arch2);
+        Assert.Same(layerBaseDerived, arch2.Layers![0]);
     }
 
     // ====================================================================
@@ -559,6 +587,54 @@ public class EmbeddingLayerValidatorIssues1321_1322_1323IntegrationTests
         public override Vector<float> GetParameters() => Vector<float>.Empty();
 
         public override void ResetState() { }
+    }
+
+    /// <summary>
+    /// A test double that implements ILayer&lt;float&gt; directly WITHOUT
+    /// inheriting from LayerBase&lt;float&gt;. This exercises the name-based
+    /// fallback for a true ILayer&lt;float&gt; (not a LayerBase subclass).
+    /// </summary>
+    private sealed class NameOnlyEmbeddingLayerNonLayerBase : ILayer<float>
+    {
+        private readonly int _vocabSize;
+
+        public NameOnlyEmbeddingLayerNonLayerBase(int vocabSize)
+        {
+            _vocabSize = vocabSize;
+        }
+
+        public int[] GetInputShape() => [1];
+        public int[] GetOutputShape() => [_vocabSize];
+        public bool IsShapeResolved => true;
+        public Tensor<float>? GetWeights() => null;
+        public Tensor<float>? GetBiases() => null;
+        public Tensor<float> Forward(Tensor<float> input) => new Tensor<float>([_vocabSize]);
+        public Tensor<float> ForwardWithPrecisionCheck(Tensor<float> input) => Forward(input);
+        public string LayerName => "NameOnlyEmbeddingLayerNonLayerBase";
+        public Tensor<float> ForwardGpu(params Tensor<float>[] inputs) => throw new NotSupportedException();
+        public bool CanExecuteOnGpu => false;
+        public void UpdateParameters(float learningRate) { }
+        public void UpdateParameters(Vector<float> parameters) { }
+        public long ParameterCount => 0;
+        public void Serialize(BinaryWriter writer) { }
+        public void Deserialize(BinaryReader reader) { }
+        public IEnumerable<ActivationFunction> GetActivationTypes() => Array.Empty<ActivationFunction>();
+        public Vector<float> GetParameters() => Vector<float>.Empty();
+        public bool SupportsTraining => false;
+        public void SetTrainingMode(bool isTraining) { }
+        public IReadOnlyList<ILayer<float>> GetSubLayers() => Array.Empty<ILayer<float>>();
+        public Vector<float> GetParameterGradients() => Vector<float>.Empty();
+        public void ClearGradients() { }
+        public void SetParameters(Vector<float> parameters) { }
+        public void ResetState() { }
+        public bool SupportsGpuTraining => false;
+        public void UpdateParametersGpu(IGpuOptimizerConfig config) => throw new NotSupportedException();
+        public void UploadWeightsToGpu() => throw new NotSupportedException();
+        public void DownloadWeightsFromGpu() => throw new NotSupportedException();
+        public void ZeroGradientsGpu() => throw new NotSupportedException();
+        public Dictionary<string, string> GetDiagnostics() => new Dictionary<string, string>();
+        public void LoadWeights(string path) { }
+        public void SaveWeights(string path) { }
     }
 
     /// <summary>

--- a/tests/AiDotNet.Tests/IntegrationTests/NeuralNetworks/EmbeddingLayerValidatorIssues1321_1322_1323IntegrationTests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/NeuralNetworks/EmbeddingLayerValidatorIssues1321_1322_1323IntegrationTests.cs
@@ -274,13 +274,16 @@ public class EmbeddingLayerValidatorIssues1321_1322_1323IntegrationTests
         var network = new FeedForwardNeuralNetwork<float>(arch);
         Assert.Equal(2, network.Layers.Count);
 
-        // Assert first layer is PositionalEncodingLayer with correct config
+        // Assert first layer is PositionalEncodingLayer with correct config.
+        // GetOutputShape() is the public API; OutputShape is protected.
         var posLayer = Assert.IsType<PositionalEncodingLayer<float>>(network.Layers[0]);
-        Assert.Equal(Dim, posLayer.OutputShape[^1]); // embeddingSize/OutputDimension is last dimension
+        var posOutShape = posLayer.GetOutputShape();
+        Assert.Equal(Dim, posOutShape[^1]); // embeddingSize/OutputDimension is last dimension
 
-        // Assert second layer is DenseLayer with correct shape
+        // Assert second layer is DenseLayer with correct shape.
         var denseLayer = Assert.IsAssignableFrom<DenseLayer<float>>(network.Layers[1]);
-        Assert.Equal(CtxLen, denseLayer.OutputShape[0]);
+        var denseOutShape = denseLayer.GetOutputShape();
+        Assert.Equal(CtxLen, denseOutShape[0]);
 
         // Assert architecture properties match
         Assert.Equal(InputType.OneDimensional, arch.InputType);
@@ -635,6 +638,29 @@ public class EmbeddingLayerValidatorIssues1321_1322_1323IntegrationTests
         public Dictionary<string, string> GetDiagnostics() => new Dictionary<string, string>();
         public void LoadWeights(string path) { }
         public void SaveWeights(string path) { }
+
+        // IWeightLoadable<float> members. This stub layer has no named
+        // parameters — the validator-bypass test path doesn't exercise
+        // weight loading, so empty / no-op responses keep the contract
+        // satisfied without inventing a parameter namespace.
+        public IEnumerable<string> GetParameterNames() => Array.Empty<string>();
+        public bool TryGetParameter(string name, out Tensor<float>? tensor)
+        {
+            tensor = null;
+            return false;
+        }
+        public bool SetParameter(string name, Tensor<float> value) => false;
+        public int[]? GetParameterShape(string name) => null;
+        public int NamedParameterCount => 0;
+        public AiDotNet.Interfaces.WeightLoadValidation ValidateWeights(
+            IEnumerable<string> weightNames,
+            Func<string, string?>? mapping = null)
+            => new AiDotNet.Interfaces.WeightLoadValidation();
+        public AiDotNet.Interfaces.WeightLoadResult LoadWeights(
+            Dictionary<string, Tensor<float>> weights,
+            Func<string, string?>? mapping = null,
+            bool strict = false)
+            => new AiDotNet.Interfaces.WeightLoadResult { Success = true };
     }
 
     /// <summary>

--- a/tests/AiDotNet.Tests/IntegrationTests/NeuralNetworks/EmbeddingLayerValidatorIssues1321_1322_1323IntegrationTests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/NeuralNetworks/EmbeddingLayerValidatorIssues1321_1322_1323IntegrationTests.cs
@@ -303,6 +303,54 @@ public class EmbeddingLayerValidatorIssues1321_1322_1323IntegrationTests
         Assert.Equal(3, network.Layers.Count);
     }
 
+    [Fact]
+    public void EdgeCase_NonLayerBaseEmbedding_RecognisedByNameFallback()
+    {
+        // Custom layer whose category-via-LayerBase recognition is BLOCKED
+        // (the layer doesn't override GetLayerCategory and its type name
+        // wouldn't normally hit the LayerBase name heuristic — but we DO
+        // name it so that the Embedding-name fallback in the validators
+        // can recognise it). This proves the broader recognition path
+        // covers custom embeddings whose authors didn't override
+        // GetLayerCategory.
+        const int VocabSize = 32;
+        const int CtxLen = 8;
+
+        // Use a name that explicitly contains "Embedding" so the name-based
+        // fallback path fires. The type itself derives from LayerBase but
+        // does NOT override GetLayerCategory — so reaching the name-based
+        // recognition exercises the ILayer-side fallback we added per the
+        // CodeRabbit review (custom embeddings outside LayerBase still
+        // pass through, since the name match is the safety net).
+        var firstLayer = new NameOnlyEmbeddingLayer(VocabSize);
+        Assert.NotEqual(LayerCategory.Embedding,
+            // sanity: this layer's GetLayerCategory does NOT report Embedding,
+            // so the only path the validator can use to bypass strict shape
+            // is the name-based fallback.
+            new ProbeForCategoryReporter(firstLayer).Reported);
+
+        var layers = new List<ILayer<float>>
+        {
+            firstLayer,
+            new DenseLayer<float>(VocabSize, (IActivationFunction<float>)new IdentityActivation<float>()),
+        };
+
+        // ValidateInputDimensions runs in the NeuralNetworkArchitecture
+        // constructor — its bypass via IsBroadcastInputLayerCategory must
+        // accept the name-matched embedding layer even when the category
+        // override doesn't say Embedding. If the bypass were category-only,
+        // this construction would throw the #1321 strict-size error.
+        var arch = new NeuralNetworkArchitecture<float>(
+            inputType: InputType.OneDimensional,
+            taskType: NeuralNetworkTaskType.MultiClassClassification,
+            inputSize: CtxLen,
+            outputSize: VocabSize,
+            layers: layers);
+
+        Assert.NotNull(arch);
+        Assert.Same(firstLayer, arch.Layers![0]);
+    }
+
     // ====================================================================
     // ISSUE #1322 — CalibratedProbabilityFitDetector returns empty
     //               calibration (instead of throwing) when predicted-vs-
@@ -334,14 +382,21 @@ public class EmbeddingLayerValidatorIssues1321_1322_1323IntegrationTests
         var result = detector.DetectFit(evalData);
 
         Assert.NotNull(result);
-        Assert.Equal(FitType.GoodFit, result.FitType);
+        // Empty-calibration sentinel: error = MaxCalibrationError → FitType
+        // routes to Overfit (worst-case) and ConfidenceLevel = 0 (no signal).
+        // This pair is the explicit "we can't evaluate calibration here"
+        // verdict — never the false-perfect FitType.GoodFit + confidence=1
+        // that the previous Zero-error fallback would have produced.
+        Assert.Equal(FitType.Overfit, result.FitType);
+        Assert.Equal(0f, result.ConfidenceLevel, precision: 5);
     }
 
     [Fact]
     public void Issue1322_FitDetector_RankDiscordantTensors_DoesNotThrow()
     {
         // Off-by-one shape drift — predicted [10], actual [13]. Not
-        // multiclass-divisible, not equal. Same lenient handling.
+        // multiclass-divisible, not equal. Same lenient handling: empty
+        // calibration → MaxCalibrationError → Overfit + zero confidence.
         var detector = new CalibratedProbabilityFitDetector<float, Tensor<float>, Tensor<float>>();
 
         var predicted = new Tensor<float>([10]);
@@ -354,7 +409,8 @@ public class EmbeddingLayerValidatorIssues1321_1322_1323IntegrationTests
         var result = detector.DetectFit(evalData);
 
         Assert.NotNull(result);
-        Assert.Equal(FitType.GoodFit, result.FitType);
+        Assert.Equal(FitType.Overfit, result.FitType);
+        Assert.Equal(0f, result.ConfidenceLevel, precision: 5);
     }
 
     [Fact]
@@ -381,10 +437,16 @@ public class EmbeddingLayerValidatorIssues1321_1322_1323IntegrationTests
         var result = detector.DetectFit(evalData);
 
         Assert.NotNull(result);
-        // Well-calibrated random data should land in GoodFit (default
-        // thresholds are loose enough that non-pathological calibration
-        // passes).
-        Assert.Contains(result.FitType, new[] { FitType.GoodFit, FitType.Underfit, FitType.Overfit });
+        // The empty-calibration fallback (predicted/actual shape mismatch)
+        // produces a known sentinel: ConfidenceLevel == 0 exactly. Real
+        // calibration on well-formed binary data must NOT hit that sentinel
+        // — assert ConfidenceLevel is strictly positive to prove we exercised
+        // the real binning loop, not the empty fallback regressing through.
+        Assert.True(result.ConfidenceLevel > 0f,
+            $"Matched-shape calibration should produce a real (non-empty) signal, " +
+            $"not the empty-calibration sentinel (ConfidenceLevel == 0). " +
+            $"Got ConfidenceLevel = {result.ConfidenceLevel}, FitType = {result.FitType}.");
+        Assert.InRange(result.ConfidenceLevel, 0f, 1f);
     }
 
     [Fact]
@@ -414,7 +476,19 @@ public class EmbeddingLayerValidatorIssues1321_1322_1323IntegrationTests
 
         // Should NOT throw — existing multiclass reduction path still applies.
         var result = detector.DetectFit(evalData);
+
         Assert.NotNull(result);
+        // Same anti-fallback assertion as the binary regression guard above:
+        // multiclass reduction MUST yield real calibration, not silently
+        // regress to the empty-calibration sentinel (ConfidenceLevel == 0).
+        // For a strongly-confident-and-correct synthetic classifier (0.7
+        // for true class, 0.1 for others), expected & observed calibration
+        // should both populate at least one bin → ConfidenceLevel > 0.
+        Assert.True(result.ConfidenceLevel > 0f,
+            $"Multiclass reduction should yield real calibration, " +
+            $"not the empty-calibration sentinel (ConfidenceLevel == 0). " +
+            $"Got ConfidenceLevel = {result.ConfidenceLevel}, FitType = {result.FitType}.");
+        Assert.InRange(result.ConfidenceLevel, 0f, 1f);
     }
 
     // ====================================================================
@@ -451,6 +525,57 @@ public class EmbeddingLayerValidatorIssues1321_1322_1323IntegrationTests
     // the stock EmbeddingLayer<T>. Naming triggers the name-based fallback
     // in LayerBase.GetLayerCategory; an explicit override would also work.
     // ====================================================================
+
+    /// <summary>
+    /// A custom embedding-like layer whose only signal of "Embedding"-ness
+    /// is its CLASS NAME ("...EmbeddingLayer"). Critically, it overrides
+    /// GetLayerCategory to return something OTHER than Embedding so we can
+    /// prove the validator's name-based fallback (added per CodeRabbit
+    /// review on PR #1324) is what's recognising it — not the
+    /// category-based path.
+    /// </summary>
+    private sealed class NameOnlyEmbeddingLayer : LayerBase<float>
+    {
+        private readonly int _vocabSize;
+
+        public NameOnlyEmbeddingLayer(int vocabSize)
+            : base([1], [vocabSize])
+        {
+            _vocabSize = vocabSize;
+        }
+
+        public override bool SupportsTraining => false;
+
+        // Deliberately NOT Embedding — proves the name-based fallback is
+        // the recognition path. If only the category-based check existed,
+        // this layer would fail #1321's outer-input-size validation.
+        public override LayerCategory GetLayerCategory() => LayerCategory.Other;
+
+        public override Tensor<float> Forward(Tensor<float> input)
+            => new Tensor<float>([_vocabSize]);
+
+        public override void UpdateParameters(float learningRate) { }
+
+        public override Vector<float> GetParameters() => Vector<float>.Empty();
+
+        public override void ResetState() { }
+    }
+
+    /// <summary>
+    /// Helper to read back a layer's reported category for the
+    /// <see cref="EdgeCase_NonLayerBaseEmbedding_RecognisedByNameFallback"/>
+    /// sanity assertion — keeps the test's intent visible (we WANT the
+    /// reported category to NOT be Embedding so the name-based fallback
+    /// is the only path that could possibly accept this layer).
+    /// </summary>
+    private sealed class ProbeForCategoryReporter
+    {
+        public LayerCategory Reported { get; }
+        public ProbeForCategoryReporter(LayerBase<float> layer)
+        {
+            Reported = layer.GetLayerCategory();
+        }
+    }
 
     private sealed class CustomTokenEmbeddingLayer : LayerBase<float>
     {

--- a/tests/AiDotNet.Tests/IntegrationTests/NeuralNetworks/EmbeddingLayerValidatorIssues1321_1322_1323IntegrationTests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/NeuralNetworks/EmbeddingLayerValidatorIssues1321_1322_1323IntegrationTests.cs
@@ -1,0 +1,488 @@
+using AiDotNet.ActivationFunctions;
+using AiDotNet.Enums;
+using AiDotNet.FitDetectors;
+using AiDotNet.Helpers;
+using AiDotNet.Interfaces;
+using AiDotNet.Models;
+using AiDotNet.Models.Inputs;
+using AiDotNet.NeuralNetworks;
+using AiDotNet.NeuralNetworks.Layers;
+using AiDotNet.Statistics;
+using AiDotNet.Tensors.Helpers;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNetTests.IntegrationTests.NeuralNetworks;
+
+/// <summary>
+/// Integration coverage for issues #1321, #1322, #1323 — collectively the
+/// "Embedding-as-first-custom-layer" series following PR #1320 (#1317).
+///
+/// Bug class: validators in NeuralNetworkArchitecture (#1321) and
+/// NeuralNetworkBase (#1323) compared <c>EmbeddingLayer&lt;T&gt;</c>'s
+/// declared input shape <c>[1]</c> (per-token broadcast contract) against
+/// either the architecture's flattened InputSize or the previous layer's
+/// output shape. Both rejected a legitimate broadcast contract.
+/// CalibratedProbabilityFitDetector (#1322) then unconditionally threw on
+/// any predicted-vs-actual shape mismatch even when the model was perfectly
+/// trainable — calibration is genuinely undefined for some custom layouts,
+/// but the optimizer was unconditionally killed by the throw.
+///
+/// All three are now lenient at the right layer: validators recognize
+/// LayerCategory.Embedding as broadcast-input; the fit detector returns
+/// empty calibration with a Trace warning instead of throwing.
+/// </summary>
+public class EmbeddingLayerValidatorIssues1321_1322_1323IntegrationTests
+{
+    // ====================================================================
+    // ISSUE #1321 — TransformerArchitecture.ValidateInputDimensions
+    //               accepts custom Transformer chains starting with
+    //               EmbeddingLayer<T> (or any LayerCategory.Embedding layer).
+    // ====================================================================
+
+    [Fact]
+    public void Issue1321_TransformerArchitecture_AcceptsEmbeddingLayerAsFirstCustomLayer()
+    {
+        const int VocabSize = 256;
+        const int DModel = 64;
+        const int CtxLen = 64;
+        const int Heads = 2;
+
+        var layers = new List<ILayer<float>>
+        {
+            new EmbeddingLayer<float>(vocabularySize: VocabSize, embeddingDimension: DModel),
+            new MultiHeadAttentionLayer<float>(Heads, DModel / Heads, activationFunction: (IActivationFunction<float>)new IdentityActivation<float>()),
+            new SequenceTokenSliceLayer<float>(SequenceTokenSliceLayer<float>.Position.Last),
+            new DenseLayer<float>(VocabSize, (IActivationFunction<float>)new IdentityActivation<float>()),
+        };
+
+        // Issue repro from #1321: this previously threw
+        //   "The first layer's input size (1) must match the input size (64)."
+        var arch = new TransformerArchitecture<float>(
+            inputType: InputType.TwoDimensional,
+            taskType: NeuralNetworkTaskType.SequenceClassification,
+            numEncoderLayers: 2,
+            numDecoderLayers: 0,
+            numHeads: Heads,
+            modelDimension: DModel,
+            feedForwardDimension: 2 * DModel,
+            inputSize: CtxLen,
+            outputSize: VocabSize,
+            maxSequenceLength: CtxLen,
+            vocabularySize: VocabSize,
+            layers: layers);
+
+        Assert.NotNull(arch);
+        Assert.Same(layers[0], arch.Layers![0]);
+    }
+
+    [Fact]
+    public void Issue1321_NeuralNetworkArchitecture_AcceptsEmbeddingLayerAsFirstCustomLayer()
+    {
+        const int VocabSize = 256;
+        const int EmbDim = 32;
+        const int CtxLen = 64;
+
+        var layers = new List<ILayer<float>>
+        {
+            new EmbeddingLayer<float>(vocabularySize: VocabSize, embeddingDimension: EmbDim),
+            new DenseLayer<float>(VocabSize, (IActivationFunction<float>)new IdentityActivation<float>()),
+        };
+
+        // Same broken validator path applies to the base architecture too —
+        // the strict size check should also recognise EmbeddingLayer.
+        var arch = new NeuralNetworkArchitecture<float>(
+            inputType: InputType.OneDimensional,
+            taskType: NeuralNetworkTaskType.MultiClassClassification,
+            inputSize: CtxLen,
+            outputSize: VocabSize,
+            layers: layers);
+
+        Assert.NotNull(arch);
+        Assert.Same(layers[0], arch.Layers![0]);
+    }
+
+    [Fact]
+    public void Issue1321_RegressionGuard_NonEmbeddingFirstLayerStillValidatesInputSize()
+    {
+        // Classical chain — first layer is InputLayer<float>(16) with
+        // explicit input shape [16] that DOES NOT match architecture
+        // InputSize=64. Validator must still reject this; the relaxation
+        // is per-category, not blanket.
+        var layers = new List<ILayer<float>>
+        {
+            new InputLayer<float>(16),
+            new DenseLayer<float>(4, (IActivationFunction<float>)new IdentityActivation<float>()),
+        };
+
+        var ex = Assert.Throws<ArgumentException>(() =>
+            new NeuralNetworkArchitecture<float>(
+                inputType: InputType.OneDimensional,
+                taskType: NeuralNetworkTaskType.Regression,
+                inputSize: 64, // intentional mismatch with InputLayer's [16]
+                outputSize: 4,
+                layers: layers));
+
+        Assert.Contains("first layer's input size", ex.Message);
+    }
+
+    // ====================================================================
+    // ISSUE #1323 — NeuralNetworkBase.AreLayersCompatible accepts
+    //               InputLayer → EmbeddingLayer (and any prev → Embedding
+    //               transition) by recognising LayerCategory.Embedding as
+    //               broadcast-input.
+    // ====================================================================
+
+    [Fact]
+    public void Issue1323_InputLayerToEmbeddingLayer_PassesCompatibilityCheck()
+    {
+        const int VocabSize = 256;
+        const int EmbDim = 64;
+        const int CtxLen = 64;
+
+        var layers = new List<ILayer<float>>
+        {
+            new InputLayer<float>(CtxLen),
+            new EmbeddingLayer<float>(vocabularySize: VocabSize, embeddingDimension: EmbDim),
+            new DenseLayer<float>(VocabSize, (IActivationFunction<float>)new IdentityActivation<float>()),
+        };
+
+        var arch = new NeuralNetworkArchitecture<float>(
+            inputType: InputType.OneDimensional,
+            taskType: NeuralNetworkTaskType.MultiClassClassification,
+            inputSize: CtxLen,
+            outputSize: VocabSize,
+            layers: layers);
+
+        // Issue repro from #1323: previously threw
+        //   "Layer 0 is not compatible with Layer 1."
+        var network = new FeedForwardNeuralNetwork<float>(arch);
+
+        Assert.Equal(layers.Count, network.Layers.Count);
+        Assert.IsType<InputLayer<float>>(network.Layers[0]);
+        Assert.IsType<EmbeddingLayer<float>>(network.Layers[1]);
+    }
+
+    [Fact]
+    public void Issue1323_DenseToEmbeddingLayer_PassesCompatibilityCheck()
+    {
+        // Embedding-as-second-layer with a Dense feeding it. Same broadcast
+        // contract — the strict shape check would fail because Dense outputs
+        // [16] and Embedding declares input [1]. Recognised category bypass.
+        const int VocabSize = 32;
+        const int EmbDim = 16;
+
+        var layers = new List<ILayer<float>>
+        {
+            new DenseLayer<float>(16, (IActivationFunction<float>)new IdentityActivation<float>()),
+            new EmbeddingLayer<float>(vocabularySize: VocabSize, embeddingDimension: EmbDim),
+            new DenseLayer<float>(VocabSize, (IActivationFunction<float>)new IdentityActivation<float>()),
+        };
+
+        var arch = new NeuralNetworkArchitecture<float>(
+            inputType: InputType.OneDimensional,
+            taskType: NeuralNetworkTaskType.MultiClassClassification,
+            inputSize: 4,
+            outputSize: VocabSize,
+            layers: layers);
+
+        var network = new FeedForwardNeuralNetwork<float>(arch);
+        Assert.Equal(3, network.Layers.Count);
+    }
+
+    [Fact]
+    public void Issue1323_RegressionGuard_NonEmbeddingTransitionStillRejectedOnShapeMismatch()
+    {
+        // Classical chain with mismatched explicit-shape layer transition —
+        // InputLayer outputs [16] then a second InputLayer expects [31].
+        // Both carry explicit shapes the compatibility check sees as
+        // incompatible. The Embedding bypass is category-gated, so this
+        // non-Embedding transition must still throw.
+        var layers = new List<ILayer<float>>
+        {
+            new InputLayer<float>(16),
+            new InputLayer<float>(31),
+            new DenseLayer<float>(4, (IActivationFunction<float>)new IdentityActivation<float>()),
+        };
+
+        var arch = new NeuralNetworkArchitecture<float>(
+            inputType: InputType.OneDimensional,
+            taskType: NeuralNetworkTaskType.Regression,
+            inputSize: 16,
+            outputSize: 4,
+            layers: layers);
+
+        var ex = Assert.Throws<ArgumentException>(() => new FeedForwardNeuralNetwork<float>(arch));
+        Assert.Contains("Layer 0 is not compatible with Layer 1", ex.Message);
+    }
+
+    // ====================================================================
+    // EDGE CASE COVERAGE — recognise category, not concrete type, and
+    // honour custom subclasses + multiple embeddings + non-first position.
+    // ====================================================================
+
+    [Fact]
+    public void EdgeCase_CustomEmbeddingSubclass_RecognisedByCategory()
+    {
+        // A user-defined embedding (e.g. token + structural priors). The
+        // base GetLayerCategory() name-based check matches "Embedding" in
+        // the type name; subclasses can also override the virtual method.
+        // Either path should make the validator treat it as broadcast input.
+        const int VocabSize = 64;
+        const int EmbDim = 16;
+        const int CtxLen = 8;
+
+        var layers = new List<ILayer<float>>
+        {
+            new CustomTokenEmbeddingLayer(VocabSize, EmbDim),
+            new DenseLayer<float>(VocabSize, (IActivationFunction<float>)new IdentityActivation<float>()),
+        };
+
+        var arch = new NeuralNetworkArchitecture<float>(
+            inputType: InputType.OneDimensional,
+            taskType: NeuralNetworkTaskType.MultiClassClassification,
+            inputSize: CtxLen,
+            outputSize: VocabSize,
+            layers: layers);
+
+        var network = new FeedForwardNeuralNetwork<float>(arch);
+        Assert.IsType<CustomTokenEmbeddingLayer>(network.Layers[0]);
+    }
+
+    [Fact]
+    public void EdgeCase_PositionalEncodingFirst_AlsoRecognisedByCategory()
+    {
+        // PositionalEmbeddingLayer has "Positional" in the type name which
+        // the LayerBase.GetLayerCategory() name-matcher maps to
+        // LayerCategory.Embedding. So the same broadcast-input path applies.
+        const int CtxLen = 64;
+        const int Dim = 16;
+
+        var layers = new List<ILayer<float>>
+        {
+            new PositionalEncodingLayer<float>(maxSequenceLength: CtxLen, embeddingSize: Dim),
+            new DenseLayer<float>(CtxLen, (IActivationFunction<float>)new IdentityActivation<float>()),
+        };
+
+        var arch = new NeuralNetworkArchitecture<float>(
+            inputType: InputType.OneDimensional,
+            taskType: NeuralNetworkTaskType.Regression,
+            inputSize: CtxLen,
+            outputSize: CtxLen,
+            layers: layers);
+
+        var network = new FeedForwardNeuralNetwork<float>(arch);
+        Assert.NotEmpty(network.Layers);
+    }
+
+    [Fact]
+    public void EdgeCase_TwoEmbeddingLayersInChain_BothAccepted()
+    {
+        // Token embedding + positional embedding stacked. Each individually
+        // declares broadcast input shape; both should pass the layer-to-layer
+        // compatibility check.
+        const int VocabSize = 32;
+        const int Dim = 16;
+        const int CtxLen = 8;
+
+        var layers = new List<ILayer<float>>
+        {
+            new EmbeddingLayer<float>(vocabularySize: VocabSize, embeddingDimension: Dim),
+            new PositionalEncodingLayer<float>(maxSequenceLength: CtxLen, embeddingSize: Dim),
+            new DenseLayer<float>(VocabSize, (IActivationFunction<float>)new IdentityActivation<float>()),
+        };
+
+        var arch = new NeuralNetworkArchitecture<float>(
+            inputType: InputType.OneDimensional,
+            taskType: NeuralNetworkTaskType.MultiClassClassification,
+            inputSize: CtxLen,
+            outputSize: VocabSize,
+            layers: layers);
+
+        var network = new FeedForwardNeuralNetwork<float>(arch);
+        Assert.Equal(3, network.Layers.Count);
+    }
+
+    // ====================================================================
+    // ISSUE #1322 — CalibratedProbabilityFitDetector returns empty
+    //               calibration (instead of throwing) when predicted-vs-
+    //               actual shapes can't be reconciled. The optimizer keeps
+    //               training rather than dying mid-iteration.
+    // ====================================================================
+
+    [Fact]
+    public void Issue1322_FitDetector_ReverseShapeMismatch_DoesNotThrow_GracefulEmptyCalibration()
+    {
+        // Repro shape ratio from #1322: predicted=256 (single sample's vocab
+        // distribution), actual=43776 (171 samples × 256 vocab classes flat).
+        // Previously: InvalidOperationException from CalculateCalibration.
+        // After fix: no throw, calibration returns lenient FitType verdict.
+        var detector = new CalibratedProbabilityFitDetector<float, Tensor<float>, Tensor<float>>();
+
+        var predicted = new Tensor<float>([256]);
+        for (int i = 0; i < 256; i++) predicted[i] = 0.5f;
+
+        var actual = new Tensor<float>([171, 256]);
+        for (int i = 0; i < 171 * 256; i++) actual.Data.Span[i] = 0.5f;
+
+        var evalData = BuildEvaluationData(predicted, actual);
+
+        // The DetectFit entry point cascades through DetermineFitType /
+        // CalculateConfidenceLevel / GenerateRecommendations, all of which
+        // call CalculateCalibration internally. The whole stack must stay
+        // throw-free for the optimizer's per-iteration loop to keep going.
+        var result = detector.DetectFit(evalData);
+
+        Assert.NotNull(result);
+        Assert.Equal(FitType.GoodFit, result.FitType);
+    }
+
+    [Fact]
+    public void Issue1322_FitDetector_RankDiscordantTensors_DoesNotThrow()
+    {
+        // Off-by-one shape drift — predicted [10], actual [13]. Not
+        // multiclass-divisible, not equal. Same lenient handling.
+        var detector = new CalibratedProbabilityFitDetector<float, Tensor<float>, Tensor<float>>();
+
+        var predicted = new Tensor<float>([10]);
+        for (int i = 0; i < 10; i++) predicted[i] = 0.3f;
+
+        var actual = new Tensor<float>([13]);
+        for (int i = 0; i < 13; i++) actual[i] = 1.0f;
+
+        var evalData = BuildEvaluationData(predicted, actual);
+        var result = detector.DetectFit(evalData);
+
+        Assert.NotNull(result);
+        Assert.Equal(FitType.GoodFit, result.FitType);
+    }
+
+    [Fact]
+    public void Issue1322_FitDetector_MatchedShapes_StillProducesRealCalibration()
+    {
+        // Regression guard: the existing binary-calibration path
+        // (predicted.Length == actual.Length) must continue to compute real
+        // calibration metrics — the lenient fallback only fires on shape
+        // mismatch, not on every call.
+        var detector = new CalibratedProbabilityFitDetector<float, Tensor<float>, Tensor<float>>();
+        var rng = RandomHelper.CreateSeededRandom(42);
+
+        const int N = 200;
+        var predicted = new Tensor<float>([N]);
+        var actual = new Tensor<float>([N]);
+        for (int i = 0; i < N; i++)
+        {
+            predicted[i] = (float)rng.NextDouble();
+            // Label is 1 with probability ~ predicted[i] — well-calibrated.
+            actual[i] = rng.NextDouble() < predicted[i] ? 1f : 0f;
+        }
+
+        var evalData = BuildEvaluationData(predicted, actual);
+        var result = detector.DetectFit(evalData);
+
+        Assert.NotNull(result);
+        // Well-calibrated random data should land in GoodFit (default
+        // thresholds are loose enough that non-pathological calibration
+        // passes).
+        Assert.Contains(result.FitType, new[] { FitType.GoodFit, FitType.Underfit, FitType.Overfit });
+    }
+
+    [Fact]
+    public void Issue1322_FitDetector_MulticlassPredictedLargerThanActual_StillReducesCorrectly()
+    {
+        // Regression guard for the existing multiclass reduction path
+        // (predicted.Length == numClasses * actual.Length, with class-index
+        // labels). Must continue to work — the new shape-mismatch fallback
+        // only fires when the existing reduction can't apply.
+        var detector = new CalibratedProbabilityFitDetector<float, Tensor<float>, Tensor<float>>();
+
+        const int N = 50;
+        const int NumClasses = 4;
+        var predicted = new Tensor<float>([N * NumClasses]);
+        var actual = new Tensor<float>([N]);
+        for (int i = 0; i < N; i++)
+        {
+            int trueClass = i % NumClasses;
+            actual[i] = trueClass;
+            for (int c = 0; c < NumClasses; c++)
+            {
+                predicted[i * NumClasses + c] = c == trueClass ? 0.7f : 0.1f;
+            }
+        }
+
+        var evalData = BuildEvaluationData(predicted, actual);
+
+        // Should NOT throw — existing multiclass reduction path still applies.
+        var result = detector.DetectFit(evalData);
+        Assert.NotNull(result);
+    }
+
+    // ====================================================================
+    // Helpers — build a minimal ModelEvaluationData carrying the predicted
+    // and actual tensors the detector reads.
+    // ====================================================================
+
+    private static ModelEvaluationData<float, Tensor<float>, Tensor<float>> BuildEvaluationData(
+        Tensor<float> predicted,
+        Tensor<float> actual)
+    {
+        // ModelStats wraps Predicted / Actual; the fit detector reads from
+        // evaluationData.ModelStats.Predicted / .Actual via ConversionsHelper.
+        // We don't need a real model here — just plumb the tensors in.
+        var modelStats = new ModelStats<float, Tensor<float>, Tensor<float>>(
+            new ModelStatsInputs<float, Tensor<float>, Tensor<float>>
+            {
+                XMatrix = new Tensor<float>([1]),
+                FeatureCount = 1,
+                Actual = actual,
+                Predicted = predicted,
+                Model = null,
+            });
+
+        return new ModelEvaluationData<float, Tensor<float>, Tensor<float>>
+        {
+            ModelStats = modelStats,
+        };
+    }
+
+    // ====================================================================
+    // Custom Embedding subclass for the EdgeCase test — verifies the
+    // category-based recognition handles user-defined embeddings, not just
+    // the stock EmbeddingLayer<T>. Naming triggers the name-based fallback
+    // in LayerBase.GetLayerCategory; an explicit override would also work.
+    // ====================================================================
+
+    private sealed class CustomTokenEmbeddingLayer : LayerBase<float>
+    {
+        private readonly int _vocabSize;
+        private readonly int _embeddingDim;
+
+        public CustomTokenEmbeddingLayer(int vocabSize, int embeddingDim)
+            : base([1], [embeddingDim])
+        {
+            _vocabSize = vocabSize;
+            _embeddingDim = embeddingDim;
+        }
+
+        public override bool SupportsTraining => false;
+
+        public override LayerCategory GetLayerCategory() => LayerCategory.Embedding;
+
+        public override Tensor<float> Forward(Tensor<float> input)
+        {
+            // Stub forward: return zeros of the per-token embedding shape
+            // for any-rank input. Test cares about validator passthrough,
+            // not numerical correctness.
+            var outShape = new int[input.Rank + 1];
+            for (int i = 0; i < input.Rank; i++) outShape[i] = input.Shape[i];
+            outShape[input.Rank] = _embeddingDim;
+            return new Tensor<float>(outShape);
+        }
+
+        public override void UpdateParameters(float learningRate) { }
+
+        public override Vector<float> GetParameters() => Vector<float>.Empty();
+
+        public override void ResetState() { }
+    }
+}


### PR DESCRIPTION
## Summary

Three follow-up issues to PR #1320 (#1317) — same root cause cluster, lumped into one PR per request.

- **#1321** — `TransformerArchitecture.ValidateInputDimensions` rejected `EmbeddingLayer<T>` as the first custom layer because `EmbeddingLayer.GetInputShape()` returns `[1]` (per-token lookup contract) and the validator did a strict product-vs-`InputSize` check.
- **#1323** — `NeuralNetworkBase.AreLayersCompatible` rejected `InputLayer(64) → EmbeddingLayer(...)` for the same reason — strict shape compare against the `[1]` per-token contract.
- **#1322** — `CalibratedProbabilityFitDetector.CalculateCalibration` unconditionally threw on the inverse shape mismatch (model emits per-sample output but labels carry the full batch). The fit detector is the default in `OptimizationAlgorithmOptions`, so this killed every `optimizer.Step` that hit the mismatch even when the model was perfectly trainable.

## Fix

Recognise `LayerCategory.Embedding` (which `EmbeddingLayer<T>`, `PositionalEncodingLayer<T>`, any user-named `*Embedding*`/`*Positional*` layer, and any layer that explicitly overrides `GetLayerCategory()` carries) as a **broadcast-input contract**. Skip the strict input-shape match for Embedding-category layers in three places:

1. `NeuralNetworkBase.IsFirstLayerShapeCompatible` — first-layer-vs-arch
2. `NeuralNetworkBase.AreLayersCompatible` — prev-layer-vs-current
3. `NeuralNetworkArchitecture.ValidateInputDimensions` — outer architecture pre-check

For #1322 — instead of throwing on unreconcilable shapes, the fit detector now returns EMPTY calibration vectors with a `Trace` warning and lets `DetermineFitType` / `CalculateConfidenceLevel` see a no-data signal (graceful default fit type rather than thrown exception). Also guards `CalculateCalibrationError` against the resulting empty-input divide-by-zero. Lenient default + diagnostic trace + escape hatch (override `OptimizationAlgorithmOptions.FitDetector`) follows the industry-standard pattern.

## Audit (Bucket D — \"didn't miss anything\")

Per-model `ValidateCustomLayers` overrides:

- `Autoencoder` / `EchoStateNetwork` / `VariationalAutoencoder` / `Transformer` — all call `base.ValidateCustomLayers(layers)` first, then add legitimate model-specific contracts (symmetry, reservoir presence, mean/log-var heads, etc.). My base-level relaxation flows through their base call. No additional shape-strict overrides found.

## Tests

`tests/AiDotNet.Tests/IntegrationTests/NeuralNetworks/EmbeddingLayerValidatorIssues1321_1322_1323IntegrationTests.cs` — 13 tests:

**Issue verification (3 issues):**
- `Issue1321_TransformerArchitecture_AcceptsEmbeddingLayerAsFirstCustomLayer`
- `Issue1321_NeuralNetworkArchitecture_AcceptsEmbeddingLayerAsFirstCustomLayer`
- `Issue1323_InputLayerToEmbeddingLayer_PassesCompatibilityCheck`
- `Issue1323_DenseToEmbeddingLayer_PassesCompatibilityCheck`
- `Issue1322_FitDetector_ReverseShapeMismatch_DoesNotThrow_GracefulEmptyCalibration`
- `Issue1322_FitDetector_RankDiscordantTensors_DoesNotThrow`

**Edge cases (Bucket C):**
- `EdgeCase_CustomEmbeddingSubclass_RecognisedByCategory` — user-defined embedding via `GetLayerCategory()` override
- `EdgeCase_PositionalEncodingFirst_AlsoRecognisedByCategory` — name-based category match
- `EdgeCase_TwoEmbeddingLayersInChain_BothAccepted` — token + positional stacked

**Regression guards:**
- `Issue1321_RegressionGuard_NonEmbeddingFirstLayerStillValidatesInputSize`
- `Issue1323_RegressionGuard_NonEmbeddingTransitionStillRejectedOnShapeMismatch`
- `Issue1322_FitDetector_MatchedShapes_StillProducesRealCalibration`
- `Issue1322_FitDetector_MulticlassPredictedLargerThanActual_StillReducesCorrectly`

## Test plan

- [x] `dotnet build src/AiDotNet.csproj --framework net10.0 -c Release` — 0 errors
- [x] `dotnet build tests/AiDotNet.Tests/AiDotNetTests.csproj --framework net10.0 -c Release` — 0 errors
- [x] New tests: 13/13 passing locally
- [x] PR #1320 (#1317) tests still pass: 14/14
- [x] Direct-related areas (TransformerCustomLayerValidation / EmbeddingLayerValidator / CalibratedProbabilityFitDetector): 41/41
- [ ] Full CI sweep verifies on PR

Closes #1321
Closes #1322
Closes #1323

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Embedding-style layers are now recognized as broadcast-input embedding-category layers (including name-based fallbacks) and accepted as first/custom layers and in layer-to-layer transitions where appropriate.
  * Calibration mismatches for predicted vs actual shapes no longer throw; they log a warning, return empty calibration vectors, and are treated as worst-case (lowest) confidence.

* **Tests**
  * Added integration tests covering embedding recognition paths and lenient calibration behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ooples/AiDotNet/pull/1324)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->