### PR TITLE
fix(#1325): add InputLayer(int[] outputShape) ctor for InputLayer→MultiHeadAttention chains

### DIFF
--- a/src/NeuralNetworks/Layers/InputLayer.cs
+++ b/src/NeuralNetworks/Layers/InputLayer.cs
@@ -116,23 +116,24 @@ public class InputLayer<T> : LayerBase<T>
     /// <exception cref="ArgumentException">Thrown when <paramref name="inputShape"/> is empty
     /// or contains a non-positive dimension.</exception>
     public InputLayer(int[] inputShape)
-        : base(ValidateAndCloneShape(inputShape), ValidateAndCloneShape(inputShape),
+        : base(ValidateAndCloneShape(inputShape, nameof(inputShape)),
+               ValidateAndCloneShape(inputShape, nameof(inputShape)),
                new IdentityActivation<T>() as IActivationFunction<T>)
     {
     }
 
-    private static int[] ValidateAndCloneShape(int[] shape)
+    private static int[] ValidateAndCloneShape(int[] shape, string paramName)
     {
         if (shape is null)
-            throw new ArgumentNullException(nameof(shape));
+            throw new ArgumentNullException(paramName);
         if (shape.Length == 0)
-            throw new ArgumentException("InputLayer shape must have at least one dimension.", nameof(shape));
+            throw new ArgumentException("InputLayer shape must have at least one dimension.", paramName);
         for (int i = 0; i < shape.Length; i++)
         {
             if (shape[i] <= 0)
                 throw new ArgumentException(
                     $"InputLayer shape dimensions must be positive (got shape[{i}] = {shape[i]}).",
-                    nameof(shape));
+                    paramName);
         }
         return (int[])shape.Clone();
     }

--- a/src/NeuralNetworks/Layers/InputLayer.cs
+++ b/src/NeuralNetworks/Layers/InputLayer.cs
@@ -92,6 +92,52 @@ public class InputLayer<T> : LayerBase<T>
     }
 
     /// <summary>
+    /// Initializes a new instance of the <see cref="InputLayer{T}"/> class with an explicit
+    /// multi-dimensional input shape.
+    /// </summary>
+    /// <param name="inputShape">The full shape of each input sample, excluding the batch dimension.
+    /// For example, a 2D input of shape [seq_len, embed_dim] would be passed as
+    /// <c>new[] { seq_len, embed_dim }</c>.</param>
+    /// <remarks>
+    /// <para>
+    /// This constructor lets callers declare a non-flat input shape natively, so that downstream
+    /// rank-aware layers (e.g. <see cref="MultiHeadAttentionLayer{T}"/> which expects
+    /// <c>[seq_len, embed_dim]</c>) see a matching <see cref="LayerBase{T}.GetOutputShape"/>
+    /// and the strict <c>AreLayersCompatible</c> check passes without requiring an intermediate
+    /// <c>ReshapeLayer</c>. Closes #1325.
+    /// </para>
+    /// <para><b>For Beginners:</b> The other constructor (<c>InputLayer(int inputSize)</c>) declares
+    /// a 1D input shape <c>[inputSize]</c>. Use this constructor instead when your downstream layer
+    /// expects multi-dimensional input — for example pre-encoded sequence data
+    /// <c>[seq_len, embed_dim]</c> feeding directly into an attention layer.
+    /// </para>
+    /// </remarks>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="inputShape"/> is null.</exception>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="inputShape"/> is empty
+    /// or contains a non-positive dimension.</exception>
+    public InputLayer(int[] inputShape)
+        : base(ValidateAndCloneShape(inputShape), ValidateAndCloneShape(inputShape),
+               new IdentityActivation<T>() as IActivationFunction<T>)
+    {
+    }
+
+    private static int[] ValidateAndCloneShape(int[] shape)
+    {
+        if (shape is null)
+            throw new ArgumentNullException(nameof(shape));
+        if (shape.Length == 0)
+            throw new ArgumentException("InputLayer shape must have at least one dimension.", nameof(shape));
+        for (int i = 0; i < shape.Length; i++)
+        {
+            if (shape[i] <= 0)
+                throw new ArgumentException(
+                    $"InputLayer shape dimensions must be positive (got shape[{i}] = {shape[i]}).",
+                    nameof(shape));
+        }
+        return (int[])shape.Clone();
+    }
+
+    /// <summary>
     /// Performs the forward pass of the input layer, simply returning the input unchanged.
     /// </summary>
     /// <param name="input">The input tensor to process.</param>

--- a/tests/AiDotNet.Tests/IntegrationTests/NeuralNetworks/InputLayerMultiDimShapeIssue1325IntegrationTests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/NeuralNetworks/InputLayerMultiDimShapeIssue1325IntegrationTests.cs
@@ -1,0 +1,220 @@
+using AiDotNet.ActivationFunctions;
+using AiDotNet.Enums;
+using AiDotNet.Interfaces;
+using AiDotNet.Models.Inputs;
+using AiDotNet.NeuralNetworks;
+using AiDotNet.NeuralNetworks.Layers;
+using Xunit;
+
+namespace AiDotNetTests.IntegrationTests.NeuralNetworks;
+
+/// <summary>
+/// Integration coverage for issue #1325 — InputLayer needs to be able to
+/// declare a multi-dimensional input shape so that the strict
+/// <c>AreLayersCompatible</c> SequenceEqual check passes for chains like
+/// <c>InputLayer → MultiHeadAttentionLayer</c> (where MHA expects 2D
+/// <c>[seq_len, embed_dim]</c> input).
+///
+/// Bug class: PR #1324 (closing #1321/#1322/#1323) relaxed shape
+/// validation for Embedding-category targets via
+/// <c>IsBroadcastInputCategory</c>. MultiHeadAttentionLayer is NOT
+/// Embedding-category, so chains where the user pre-encodes a 2D tensor
+/// outside the network and feeds it into MHA via <c>InputLayer(N)</c>
+/// still failed: InputLayer's declared output shape <c>[N]</c> is 1D
+/// rank while MHA's declared input shape <c>[seq_len, embed_dim]</c>
+/// is 2D rank, and <c>AreShapesCompatible</c> rejects rank-mismatched
+/// shapes even when their total element count matches.
+///
+/// Fix: a new <c>InputLayer(int[] inputShape)</c> constructor lets the
+/// user declare the multi-dimensional shape natively. The validator then
+/// sees matching ranks and shapes — no semantic relaxation needed.
+/// </summary>
+public class InputLayerMultiDimShapeIssue1325IntegrationTests
+{
+    // ====================================================================
+    // ISSUE #1325 — main repro: InputLayer → MultiHeadAttention works
+    //               when InputLayer is constructed with the matching 2D
+    //               shape declared explicitly.
+    // ====================================================================
+
+    [Fact]
+    public void Issue1325_InputLayerWithShape_AcceptsMultiHeadAttention()
+    {
+        const int CtxLen = 64;
+        const int EmbedDim = 128;
+        const int Heads = 2;
+        const int VocabSize = 256;
+
+        // Pre-encoded float input is [CtxLen, EmbedDim] = [64, 128].
+        // The old 1D constructor InputLayer(CtxLen * EmbedDim) = InputLayer(8192)
+        // produced output shape [8192] (rank 1), which was incompatible with
+        // MultiHeadAttention's expected [64, 128] (rank 2) input shape under
+        // the strict SequenceEqual check.
+        //
+        // The new int[] constructor lets the user declare [CtxLen, EmbedDim]
+        // natively so the rank matches the downstream layer's contract.
+        var layers = new List<ILayer<float>>
+        {
+            new InputLayer<float>(new[] { CtxLen, EmbedDim }),
+            new MultiHeadAttentionLayer<float>(Heads, EmbedDim / Heads,
+                activationFunction: (IActivationFunction<float>)new IdentityActivation<float>()),
+            new SequenceTokenSliceLayer<float>(SequenceTokenSliceLayer<float>.Position.Last),
+            new DenseLayer<float>(VocabSize, (IActivationFunction<float>)new IdentityActivation<float>()),
+        };
+
+        var arch = new NeuralNetworkArchitecture<float>(
+            inputType: InputType.TwoDimensional,
+            taskType: NeuralNetworkTaskType.MultiClassClassification,
+            inputHeight: CtxLen,
+            inputWidth: EmbedDim,
+            outputSize: VocabSize,
+            layers: layers);
+
+        // Issue repro from #1325: previously threw
+        //   "Layer 0 is not compatible with Layer 1." because InputLayer(8192)
+        //   output [8192] mismatched MHA input [64, 128] under strict check.
+        var network = new FeedForwardNeuralNetwork<float>(arch);
+
+        Assert.Equal(layers.Count, network.Layers.Count);
+        Assert.IsType<InputLayer<float>>(network.Layers[0]);
+        Assert.IsType<MultiHeadAttentionLayer<float>>(network.Layers[1]);
+
+        // Verify the InputLayer's declared shape matches what was passed.
+        Assert.Equal(new[] { CtxLen, EmbedDim }, network.Layers[0].GetOutputShape());
+    }
+
+    [Fact]
+    public void Issue1325_InputLayerWithShape_ProducesDeclaredOutputShape()
+    {
+        // The new constructor's output shape must match exactly the int[]
+        // passed in (modulo defensive cloning).
+        var layer = new InputLayer<float>(new[] { 8, 16, 32 });
+        Assert.Equal(new[] { 8, 16, 32 }, layer.GetOutputShape());
+        Assert.Equal(new[] { 8, 16, 32 }, layer.GetInputShape());
+    }
+
+    [Fact]
+    public void Issue1325_InputLayerWithShape_ForwardPassThroughUnchanged()
+    {
+        // InputLayer is a pure pass-through. The new constructor must
+        // preserve that semantics — Forward returns the input tensor
+        // unchanged regardless of declared shape.
+        var layer = new InputLayer<float>(new[] { 4, 8 });
+        var input = new Tensor<float>([1, 4, 8]);
+        for (int i = 0; i < input.Data.Length; i++) input.Data.Span[i] = i;
+
+        var output = layer.Forward(input);
+        Assert.Same(input, output);
+    }
+
+    [Fact]
+    public void Issue1325_InputLayerWithShape_ClonesArrayDefensively()
+    {
+        // The constructor must clone its int[] argument so that external
+        // mutation of the caller's array doesn't bleed into the layer's
+        // internal state — guards against accidental shape corruption.
+        var shape = new[] { 4, 8 };
+        var layer = new InputLayer<float>(shape);
+        shape[0] = 999;
+
+        Assert.Equal(new[] { 4, 8 }, layer.GetOutputShape());
+    }
+
+    [Fact]
+    public void Issue1325_InputLayerWithShape_CtorThrowsOnNull()
+    {
+        Assert.Throws<ArgumentNullException>(() => new InputLayer<float>((int[])null!));
+    }
+
+    [Fact]
+    public void Issue1325_InputLayerWithShape_CtorThrowsOnEmpty()
+    {
+        var ex = Assert.Throws<ArgumentException>(() => new InputLayer<float>(Array.Empty<int>()));
+        Assert.Contains("at least one dimension", ex.Message);
+    }
+
+    [Fact]
+    public void Issue1325_InputLayerWithShape_CtorThrowsOnZeroDim()
+    {
+        var ex = Assert.Throws<ArgumentException>(() => new InputLayer<float>(new[] { 4, 0, 16 }));
+        Assert.Contains("must be positive", ex.Message);
+    }
+
+    [Fact]
+    public void Issue1325_InputLayerWithShape_CtorThrowsOnNegativeDim()
+    {
+        var ex = Assert.Throws<ArgumentException>(() => new InputLayer<float>(new[] { 4, -2, 16 }));
+        Assert.Contains("must be positive", ex.Message);
+    }
+
+    // ====================================================================
+    // REGRESSION GUARDS — the existing int constructor still works the
+    // same way (produces 1D [inputSize] shape).
+    // ====================================================================
+
+    [Fact]
+    public void Issue1325_RegressionGuard_IntConstructorStillProducesFlatShape()
+    {
+        // The existing InputLayer(int inputSize) constructor must keep its
+        // 1D semantics — back-compat for every chain that used it.
+        var layer = new InputLayer<float>(64);
+        Assert.Equal(new[] { 64 }, layer.GetOutputShape());
+        Assert.Equal(new[] { 64 }, layer.GetInputShape());
+    }
+
+    [Fact]
+    public void Issue1325_RegressionGuard_IntConstructor_InputLayerToEmbeddingLayerStillWorks()
+    {
+        // The #1323 fix path (InputLayer(int) → EmbeddingLayer via the
+        // broadcast-input bypass) must still pass after the new constructor
+        // is added — no regression to PR #1324's behaviour.
+        const int VocabSize = 256;
+        const int EmbDim = 64;
+        const int CtxLen = 64;
+
+        var layers = new List<ILayer<float>>
+        {
+            new InputLayer<float>(CtxLen),
+            new EmbeddingLayer<float>(vocabularySize: VocabSize, embeddingDimension: EmbDim),
+            new DenseLayer<float>(VocabSize, (IActivationFunction<float>)new IdentityActivation<float>()),
+        };
+
+        var arch = new NeuralNetworkArchitecture<float>(
+            inputType: InputType.OneDimensional,
+            taskType: NeuralNetworkTaskType.MultiClassClassification,
+            inputSize: CtxLen,
+            outputSize: VocabSize,
+            layers: layers);
+
+        var network = new FeedForwardNeuralNetwork<float>(arch);
+        Assert.Equal(3, network.Layers.Count);
+    }
+
+    // ====================================================================
+    // EDGE CASES — verify the shape constructor works for higher ranks
+    // and in chains that mix with other rank-aware layers.
+    // ====================================================================
+
+    [Fact]
+    public void Issue1325_EdgeCase_ThreeDInput_Works()
+    {
+        // A 3D input shape, e.g. for a video / volumetric processing path.
+        // The constructor must accept any positive rank.
+        var layer = new InputLayer<float>(new[] { 16, 8, 4 });
+        Assert.Equal(new[] { 16, 8, 4 }, layer.GetOutputShape());
+        Assert.Equal(3, layer.GetOutputShape().Length);
+    }
+
+    [Fact]
+    public void Issue1325_EdgeCase_SingleDimViaShapeCtor_EquivalentToIntCtor()
+    {
+        // InputLayer(new[] { N }) should behave identically to
+        // InputLayer(N) — both produce 1D shape [N]. Verifies the new
+        // ctor is a strict generalization, not a divergent path.
+        var shapeCtor = new InputLayer<float>(new[] { 42 });
+        var intCtor = new InputLayer<float>(42);
+
+        Assert.Equal(intCtor.GetOutputShape(), shapeCtor.GetOutputShape());
+        Assert.Equal(intCtor.GetInputShape(), shapeCtor.GetInputShape());
+    }
+}

--- a/tests/AiDotNet.Tests/IntegrationTests/NeuralNetworks/InputLayerMultiDimShapeIssue1325IntegrationTests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/NeuralNetworks/InputLayerMultiDimShapeIssue1325IntegrationTests.cs
@@ -123,7 +123,10 @@ public class InputLayerMultiDimShapeIssue1325IntegrationTests
     [Fact]
     public void Issue1325_InputLayerWithShape_CtorThrowsOnNull()
     {
-        Assert.Throws<ArgumentNullException>(() => new InputLayer<float>((int[])null!));
+        // ParamName should match the public constructor parameter name ("inputShape"),
+        // not the private helper's internal name ("shape"). CodeRabbit feedback on PR #1326.
+        var ex = Assert.Throws<ArgumentNullException>(() => new InputLayer<float>((int[])null!));
+        Assert.Equal("inputShape", ex.ParamName);
     }
 
     [Fact]
@@ -131,6 +134,7 @@ public class InputLayerMultiDimShapeIssue1325IntegrationTests
     {
         var ex = Assert.Throws<ArgumentException>(() => new InputLayer<float>(Array.Empty<int>()));
         Assert.Contains("at least one dimension", ex.Message);
+        Assert.Equal("inputShape", ex.ParamName);
     }
 
     [Fact]
@@ -138,6 +142,7 @@ public class InputLayerMultiDimShapeIssue1325IntegrationTests
     {
         var ex = Assert.Throws<ArgumentException>(() => new InputLayer<float>(new[] { 4, 0, 16 }));
         Assert.Contains("must be positive", ex.Message);
+        Assert.Equal("inputShape", ex.ParamName);
     }
 
     [Fact]
@@ -145,6 +150,7 @@ public class InputLayerMultiDimShapeIssue1325IntegrationTests
     {
         var ex = Assert.Throws<ArgumentException>(() => new InputLayer<float>(new[] { 4, -2, 16 }));
         Assert.Contains("must be positive", ex.Message);
+        Assert.Equal("inputShape", ex.ParamName);
     }
 
     // ====================================================================


### PR DESCRIPTION
## Summary

Follow-on to PR #1324 (closing #1321/#1322/#1323). PR #1324 relaxed `AreLayersCompatible` for **Embedding-category targets** via `IsBroadcastInputCategory`, unblocking `InputLayer(N) → EmbeddingLayer` chains. This PR handles the sibling case `InputLayer(N) → MultiHeadAttentionLayer`, which is NOT Embedding-category — MHA declares a concrete 2D input shape `[seq_len, embed_dim]`.

When the user pre-encodes a 2D tensor outside the network and passes it through a flat `InputLayer(seq_len * embed_dim)`, the strict `SequenceEqual` shape check in `AreShapesCompatible` rejects `[N]` vs `[seq_len, embed_dim]` even though the total element count matches — `1D` ≠ `2D` under rank-equality.

## Fix

Add a new constructor **`InputLayer(int[] inputShape)`** that lets users declare the full multi-dimensional shape natively. The validator then sees matching ranks on both sides of the `InputLayer → MHA` boundary — **no semantic validator relaxation needed**, just an explicit shape declaration.

Surgical, non-breaking change:
- The existing `InputLayer(int inputSize)` constructor stays untouched (back-compat for every existing chain, including the #1323 path).
- The new constructor delegates to `LayerBase` with the user-declared shape as both input and output (InputLayer is a pure pass-through).
- Defensive cloning + validation: rejects null, empty, zero, and negative dimensions with clear error messages.
- Works for any rank ≥ 1: 2D for attention chains, 3D for video / volumetric paths, etc.

## Why this approach (not extending the category bypass)

Three options considered:
1. **Extend `IsBroadcastInputCategory` to recognize `LayerCategory.Attention`** — but attention layers DO care about input rank (they need 3D `[batch, seq, embed]`). Blanket-accepting any prev→Attention transition would mask real shape bugs.
2. **Special-case `InputLayer → AttentionLayer` in `AreLayersCompatible`** — adds a layer-pair-specific rule; doesn't generalize to other rank-mismatched chains.
3. **Native multi-rank `InputLayer` constructor** ← chosen. User-explicit, doesn't change validator semantics, future-proof (3D/4D inputs natively), generalizes beyond attention to any rank-aware layer.

## Tests

13 integration tests in `tests/AiDotNet.Tests/IntegrationTests/NeuralNetworks/InputLayerMultiDimShapeIssue1325IntegrationTests.cs`, all passing on net10.0 and net4.7.1:

**Main repro:**
- `Issue1325_InputLayerWithShape_AcceptsMultiHeadAttention` — builds `InputLayer([64,128]) → MHA → Slice → Dense` through `FeedForwardNeuralNetwork` and verifies no validator exception.

**Contract:**
- `Issue1325_InputLayerWithShape_ProducesDeclaredOutputShape`
- `Issue1325_InputLayerWithShape_ForwardPassThroughUnchanged`
- `Issue1325_InputLayerWithShape_ClonesArrayDefensively`

**Defensive constructor:**
- `Issue1325_InputLayerWithShape_CtorThrowsOnNull`
- `Issue1325_InputLayerWithShape_CtorThrowsOnEmpty`
- `Issue1325_InputLayerWithShape_CtorThrowsOnZeroDim`
- `Issue1325_InputLayerWithShape_CtorThrowsOnNegativeDim`

**Regression guards (PR #1324 back-compat):**
- `Issue1325_RegressionGuard_IntConstructorStillProducesFlatShape`
- `Issue1325_RegressionGuard_IntConstructor_InputLayerToEmbeddingLayerStillWorks`

**Edge cases:**
- `Issue1325_EdgeCase_ThreeDInput_Works`
- `Issue1325_EdgeCase_SingleDimViaShapeCtor_EquivalentToIntCtor`

Result: `Passed! - Failed: 0, Passed: 12` (one fact each, no theories; test count is 12 — I miscounted by one in the commit body).

## Test plan
- [x] All 12 new tests pass on net10.0
- [x] All 12 new tests pass on net4.7.1
- [x] `dotnet build` clean (0 errors, 11477 pre-existing warnings unchanged)
- [x] PR #1324's `Issue1323_InputLayerToEmbeddingLayer_PassesCompatibilityCheck` regression-guarded explicitly

Closes #1325

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * InputLayer gains a constructor to declare explicit multi-dimensional input shapes (2D+), with strict validation and defensive cloning to prevent external mutation; preserves pass-through behavior and compatibility with attention layers.

* **Tests**
  * Added integration tests covering multi-dim shapes, constructor validation (null/empty/zero/negative), cloning behavior, backward compatibility with 1D constructor, and edge cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ooples/AiDotNet/pull/1326)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->