### PR TITLE
fix(validator): rank-mismatch + flatten-boundary + custom-layer DeepCopy

### DIFF
--- a/src/Models/Options/GradientBasedOptimizerOptions.cs
+++ b/src/Models/Options/GradientBasedOptimizerOptions.cs
@@ -1,3 +1,4 @@
+using System;
 using AiDotNet.Caching;
 using AiDotNet.Interfaces;
 using AiDotNet.LearningRateSchedulers;
@@ -60,7 +61,7 @@ public class GradientBasedOptimizerOptions<T, TInput, TOutput> : OptimizationAlg
         get => _lossFunction;
         set
         {
-            _lossFunction = value;
+            _lossFunction = value ?? throw new ArgumentNullException(nameof(value));
             LossFunctionExplicitlySet = true;
         }
     }
@@ -88,7 +89,7 @@ public class GradientBasedOptimizerOptions<T, TInput, TOutput> : OptimizationAlg
     /// </summary>
     internal void SetLossFunctionFromAutoSync(ILossFunction<T> lossFunction)
     {
-        _lossFunction = lossFunction;
+        _lossFunction = lossFunction ?? throw new ArgumentNullException(nameof(lossFunction));
     }
 
     /// <summary>

--- a/src/Models/Options/GradientBasedOptimizerOptions.cs
+++ b/src/Models/Options/GradientBasedOptimizerOptions.cs
@@ -55,7 +55,41 @@ public class GradientBasedOptimizerOptions<T, TInput, TOutput> : OptimizationAlg
     /// A higher loss means worse performance, so the optimizer tries to find model parameters that minimize this loss.
     /// </para>
     /// </remarks>
-    public ILossFunction<T> LossFunction { get; set; } = new MeanSquaredErrorLoss<T>();
+    public ILossFunction<T> LossFunction
+    {
+        get => _lossFunction;
+        set
+        {
+            _lossFunction = value;
+            LossFunctionExplicitlySet = true;
+        }
+    }
+
+    private ILossFunction<T> _lossFunction = new MeanSquaredErrorLoss<T>();
+
+    /// <summary>
+    /// True when <see cref="LossFunction"/> was explicitly set by the caller; false
+    /// while it still holds the default <see cref="MeanSquaredErrorLoss{T}"/>.
+    /// </summary>
+    /// <remarks>
+    /// The <see cref="GradientBasedOptimizerBase{T, TInput, TOutput}.OnModelChanged"/>
+    /// hook uses this flag to auto-sync the optimizer's loss from the model's
+    /// <see cref="IFullModel{T, TInput, TOutput}.DefaultLossFunction"/> when the caller
+    /// configured a loss on the model but not on the optimizer. If the caller set the
+    /// optimizer's loss explicitly (even to <see cref="MeanSquaredErrorLoss{T}"/>),
+    /// the auto-sync is skipped so the caller's choice wins.
+    /// </remarks>
+    internal bool LossFunctionExplicitlySet { get; private set; }
+
+    /// <summary>
+    /// Internal: assign <see cref="LossFunction"/> without flipping
+    /// <see cref="LossFunctionExplicitlySet"/>. Used by the
+    /// model-default auto-sync so a subsequent re-SetModel still re-syncs.
+    /// </summary>
+    internal void SetLossFunctionFromAutoSync(ILossFunction<T> lossFunction)
+    {
+        _lossFunction = lossFunction;
+    }
 
     /// <summary>
     /// Gets or sets the regularization method to use for preventing overfitting.

--- a/src/NeuralNetworks/NeuralNetworkBase.cs
+++ b/src/NeuralNetworks/NeuralNetworkBase.cs
@@ -2252,16 +2252,28 @@ public abstract class NeuralNetworkBase<T> : INeuralNetworkModel<T>, IInterpreta
         //
         // exercised by NeuralNetworkBase.DeepCopy → Transformer..ctor →
         // ValidateCustomLayers re-running on an already-forwarded chain
-        // (HarmonicEngine PR #149 / #1333 repro). Try stripping a single
-        // positive leading dim from the higher-rank side and re-comparing.
-        if (expectedShape.Length + 1 == actualShape.Length && actualShape[0] >= 1)
+        // (HarmonicEngine PR #149 / #1333 repro).
+        //
+        // Crucially, the shorter side MUST explicitly declare a wildcard (-1)
+        // leading dim. Otherwise we'd bless unrelated shapes — e.g.
+        // [32, 32] (a concrete rank-2) vs [3, 32, 32] (a concrete rank-3)
+        // would silently pass by stripping the leading 3. The wildcard guard
+        // restricts the strip to the genuine "I accept any batch" contract
+        // that MHA/Slice/etc actually declare.
+        if (expectedShape.Length + 1 == actualShape.Length
+            && actualShape[0] >= 1
+            && expectedShape.Length > 0
+            && expectedShape[0] <= 0)
         {
             var actualNoBatch = new int[actualShape.Length - 1];
             Array.Copy(actualShape, 1, actualNoBatch, 0, actualNoBatch.Length);
             if (ShapesMatchKnownDimensions(expectedShape, actualNoBatch))
                 return true;
         }
-        if (actualShape.Length + 1 == expectedShape.Length && expectedShape[0] >= 1)
+        if (actualShape.Length + 1 == expectedShape.Length
+            && expectedShape[0] >= 1
+            && actualShape.Length > 0
+            && actualShape[0] <= 0)
         {
             var expectedNoBatch = new int[expectedShape.Length - 1];
             Array.Copy(expectedShape, 1, expectedNoBatch, 0, expectedNoBatch.Length);

--- a/src/NeuralNetworks/NeuralNetworkBase.cs
+++ b/src/NeuralNetworks/NeuralNetworkBase.cs
@@ -2011,7 +2011,12 @@ public abstract class NeuralNetworkBase<T> : INeuralNetworkModel<T>, IInterpreta
         // architecture input shape, it is a valid boundary layer.
         if (!IsFirstLayerShapeCompatible(layers[0]))
         {
-            errors.Add("The first layer's input shape must be compatible with the architecture input shape.");
+            var firstLayerShape = TryGetLayerShape(layers[0], static l => l.GetInputShape());
+            var archShape = TryGetArchitectureDeclaredInputShape();
+            errors.Add(
+                $"The first layer's input shape must be compatible with the architecture input shape. " +
+                $"(first layer = {layers[0].GetType().Name}, input shape = {FormatShape(firstLayerShape)}; " +
+                $"architecture input shape = {FormatShape(archShape)}).");
         }
 
         // Check layer connections
@@ -2024,7 +2029,12 @@ public abstract class NeuralNetworkBase<T> : INeuralNetworkModel<T>, IInterpreta
 
                 if (!AreLayersCompatible(prevLayer, currentLayer))
                 {
-                    errors.Add($"Layer {i - 1} is not compatible with Layer {i}.");
+                    var prevOut = TryGetLayerShape(prevLayer, static l => l.GetOutputShape());
+                    var currIn = TryGetLayerShape(currentLayer, static l => l.GetInputShape());
+                    errors.Add(
+                        $"Layer {i - 1} ({prevLayer.GetType().Name}, output {FormatShape(prevOut)}) " +
+                        $"is not compatible with Layer {i} ({currentLayer.GetType().Name}, " +
+                        $"input {FormatShape(currIn)}).");
                 }
             }
         }
@@ -2066,7 +2076,46 @@ public abstract class NeuralNetworkBase<T> : INeuralNetworkModel<T>, IInterpreta
         if (IsDeferredOrAgnosticShape(architectureInputShape))
             return true;
 
-        return AreShapesCompatible(architectureInputShape!, layerInputShape!);
+        if (AreShapesCompatible(architectureInputShape!, layerInputShape!))
+            return true;
+
+        // Flat-reshape boundary: architecture may declare a structured
+        // shape (e.g. [H, W] image, [batch, ctxLen]) while a flatten-style
+        // first layer like InputLayer<T>(N) declares a single flat dim.
+        // Accept when the total element count matches and all dims are
+        // known positive values — this is exactly the "flatten" boundary
+        // (TransformerArchitecture with inputType=TwoDimensional + inputSize=64
+        // yields shape [8, 8]; a custom chain starting with InputLayer(64)
+        // expects the same 64 elements arriving as rank-1). Without this
+        // path the validator rejects a legitimate flatten contract that
+        // the layer would have happily accepted at first forward.
+        if (TotalElementsMatch(architectureInputShape!, layerInputShape!))
+            return true;
+
+        return false;
+    }
+
+    /// <summary>
+    /// Two shape arrays have the same total element count, with all dims
+    /// known and positive. Used at the architecture / first-layer boundary
+    /// to recognise legitimate flatten / reshape contracts that
+    /// <see cref="AreShapesCompatible"/>'s rank-strict check would reject.
+    /// </summary>
+    private static bool TotalElementsMatch(int[] a, int[] b)
+    {
+        if (a is null || b is null || a.Length == 0 || b.Length == 0) return false;
+        long pa = 1, pb = 1;
+        for (int i = 0; i < a.Length; i++)
+        {
+            if (a[i] <= 0) return false;
+            pa *= a[i];
+        }
+        for (int i = 0; i < b.Length; i++)
+        {
+            if (b[i] <= 0) return false;
+            pb *= b[i];
+        }
+        return pa == pb;
     }
 
     /// <summary>
@@ -2166,6 +2215,14 @@ public abstract class NeuralNetworkBase<T> : INeuralNetworkModel<T>, IInterpreta
         return shape is null || shape.Length == 0 || shape.All(d => d <= 0);
     }
 
+    /// <summary>Renders a shape array as <c>[d0, d1, ...]</c> for validator error messages.</summary>
+    private static string FormatShape(int[]? shape)
+    {
+        if (shape is null) return "<null>";
+        if (shape.Length == 0) return "[]";
+        return "[" + string.Join(", ", shape) + "]";
+    }
+
     private static bool AreShapesCompatible(int[] expectedShape, int[] actualShape)
     {
         if (ShapesMatchKnownDimensions(expectedShape, actualShape))
@@ -2179,7 +2236,40 @@ public abstract class NeuralNetworkBase<T> : INeuralNetworkModel<T>, IInterpreta
         if (ShapesMatchKnownDimensions(expectedShape, actualWithoutLeadingBatch))
             return true;
 
-        return ShapesMatchKnownDimensions(expectedWithoutLeadingBatch, actualWithoutLeadingBatch);
+        if (ShapesMatchKnownDimensions(expectedWithoutLeadingBatch, actualWithoutLeadingBatch))
+            return true;
+
+        // Rank-N declared vs rank-(N+1) post-forward-resolved batch path.
+        // TrimLeadingBatchLikeDimensions only strips dims <= 1, so a layer
+        // whose OnFirstForward resolved its input shape to a concrete
+        // [batch>=2, ...rest] keeps the batch dim in place — and the rank
+        // ends up off by one against an upstream layer that declares
+        // [-1, ...rest]. This is the path
+        //
+        //   MultiHeadAttentionLayer.GetOutputShape() == [-1, embDim]   (rank 2 declared)
+        //   SequenceTokenSliceLayer.GetInputShape()  == [batch, seq, embDim]
+        //                                              (rank 3, resolved by OnFirstForward)
+        //
+        // exercised by NeuralNetworkBase.DeepCopy → Transformer..ctor →
+        // ValidateCustomLayers re-running on an already-forwarded chain
+        // (HarmonicEngine PR #149 / #1333 repro). Try stripping a single
+        // positive leading dim from the higher-rank side and re-comparing.
+        if (expectedShape.Length + 1 == actualShape.Length && actualShape[0] >= 1)
+        {
+            var actualNoBatch = new int[actualShape.Length - 1];
+            Array.Copy(actualShape, 1, actualNoBatch, 0, actualNoBatch.Length);
+            if (ShapesMatchKnownDimensions(expectedShape, actualNoBatch))
+                return true;
+        }
+        if (actualShape.Length + 1 == expectedShape.Length && expectedShape[0] >= 1)
+        {
+            var expectedNoBatch = new int[expectedShape.Length - 1];
+            Array.Copy(expectedShape, 1, expectedNoBatch, 0, expectedNoBatch.Length);
+            if (ShapesMatchKnownDimensions(expectedNoBatch, actualShape))
+                return true;
+        }
+
+        return false;
     }
 
     private static bool ShapesMatchKnownDimensions(int[] expectedShape, int[] actualShape)
@@ -6869,14 +6959,27 @@ public abstract class NeuralNetworkBase<T> : INeuralNetworkModel<T>, IInterpreta
         // redundant double-conversion loop — so we also take it whenever
         // the new instance has an identically-shaped Layers list.
         long paramBytes = 0;
+        bool hasCustomLayer = false;
         for (int i = 0; i < _layers.Count; i++)
         {
             paramBytes += (long)_layers[i].ParameterCount * sizeof(double);
             if (_layers[i] is AiDotNet.NeuralNetworks.Layers.ILayerSerializationExtras<T> ext)
                 paramBytes += (long)ext.ExtraParameterCount * sizeof(double);
+
+            // Detect layers whose concrete type lives outside AiDotNet — the
+            // DeserializationHelper's hard-coded type registry only knows the
+            // built-in layers, so a custom external layer would fail the
+            // serialize/deserialize roundtrip path with NotSupportedException.
+            // Force the per-layer copy path for these chains. (We can't
+            // enumerate the registry directly from a static helper, so the
+            // check is by assembly identity: anything outside the AiDotNet
+            // core assembly is treated as custom.)
+            var layerAssembly = _layers[i].GetType().Assembly;
+            if (layerAssembly != typeof(NeuralNetworkBase<T>).Assembly)
+                hasCustomLayer = true;
         }
 
-        if (paramBytes > (long)MaxArrayLength)
+        if (paramBytes > (long)MaxArrayLength || hasCustomLayer)
         {
             var largeCopy = CreateNewInstance();
             if (largeCopy is NeuralNetworkBase<T> largeBase && largeBase._layers.Count == _layers.Count)

--- a/src/Optimizers/GradientBasedOptimizerBase.cs
+++ b/src/Optimizers/GradientBasedOptimizerBase.cs
@@ -105,6 +105,14 @@ public abstract class GradientBasedOptimizerBase<T, TInput, TOutput> : Optimizer
     protected ILossFunction<T> LossFunction;
 
     /// <summary>
+    /// The loss function currently used by the optimizer's gradient path.
+    /// Public, read-only — exposed mainly so callers and regression tests can
+    /// verify the result of the model-default auto-sync in
+    /// <see cref="OnModelChanged"/>.
+    /// </summary>
+    public ILossFunction<T> CurrentLossFunction => LossFunction;
+
+    /// <summary>
     /// A method used to regularize the parameters so they don't get out of control.
     /// </summary>
     protected IRegularization<T, TInput, TOutput> Regularization;
@@ -204,6 +212,64 @@ public abstract class GradientBasedOptimizerBase<T, TInput, TOutput> : Optimizer
         // Sync both learning rate fields so derived classes using either will get the correct value
         SetLearningRate(_learningRateScheduler?.CurrentLearningRate
             ?? GradientOptions.InitialLearningRate);
+    }
+
+    /// <summary>
+    /// When the optimizer's model is (re-)set and the caller did NOT explicitly configure
+    /// <see cref="GradientBasedOptimizerOptions{T, TInput, TOutput}.LossFunction"/>, adopt
+    /// the model's <see cref="IFullModel{T, TInput, TOutput}.DefaultLossFunction"/>.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Without this, a model configured with e.g. <c>CategoricalCrossEntropyLoss&lt;float&gt;</c>
+    /// silently trains under the optimizer-options default
+    /// <c>MeanSquaredErrorLoss&lt;float&gt;</c>, because
+    /// <see cref="GradientBasedOptimizerBase{T, TInput, TOutput}"/> reads its loss from the
+    /// optimizer options at construction time. The shape mismatch (one-hot
+    /// <c>[batch, vocab]</c> target vs MSE-on-<c>[batch, vocab]</c> prediction) typically
+    /// blows up downstream in <c>TensorSubtract</c>.
+    /// </para>
+    /// <para>
+    /// The caller's explicit choice always wins: if the options' loss was set explicitly
+    /// (tracked by <see cref="GradientBasedOptimizerOptions{T, TInput, TOutput}.LossFunctionExplicitlySet"/>),
+    /// we don't touch it. This means a user who genuinely wants to optimize a CCE-model
+    /// under MSE can still do so by setting the optimizer's loss themselves.
+    /// </para>
+    /// </remarks>
+    protected override void OnModelChanged(
+        IFullModel<T, TInput, TOutput>? oldModel,
+        IFullModel<T, TInput, TOutput> newModel)
+    {
+        base.OnModelChanged(oldModel, newModel);
+
+        if (GradientOptions.LossFunctionExplicitlySet)
+        {
+            return;
+        }
+
+        ILossFunction<T>? modelDefault = null;
+        try
+        {
+            modelDefault = newModel.DefaultLossFunction;
+        }
+        catch (InvalidOperationException)
+        {
+            // Some IFullModel implementations throw if accessed before configuration;
+            // treat that as "no model-side default available" and keep the optimizer's
+            // default (MSE).
+        }
+
+        if (modelDefault is null)
+        {
+            return;
+        }
+
+        LossFunction = modelDefault;
+        // Mirror to the options so consumers that read GradientOptions.LossFunction
+        // (e.g. AiModelBuilder facade, debug logging) see the synced value too.
+        // The back-door setter does NOT flip LossFunctionExplicitlySet, so a future
+        // SetModel call still re-syncs from the new model's default.
+        GradientOptions.SetLossFunctionFromAutoSync(modelDefault);
     }
 
     /// <summary>

--- a/src/Optimizers/GradientBasedOptimizerBase.cs
+++ b/src/Optimizers/GradientBasedOptimizerBase.cs
@@ -106,11 +106,12 @@ public abstract class GradientBasedOptimizerBase<T, TInput, TOutput> : Optimizer
 
     /// <summary>
     /// The loss function currently used by the optimizer's gradient path.
-    /// Public, read-only — exposed mainly so callers and regression tests can
-    /// verify the result of the model-default auto-sync in
-    /// <see cref="OnModelChanged"/>.
+    /// Internal — exposed so regression tests in <c>AiDotNetTests</c> can verify
+    /// the result of the model-default auto-sync in <see cref="OnModelChanged"/>
+    /// without expanding the public optimizer surface (optimizers are an
+    /// implementation detail; users should interact via <c>AiModelBuilder</c>).
     /// </summary>
-    public ILossFunction<T> CurrentLossFunction => LossFunction;
+    internal ILossFunction<T> CurrentLossFunction => LossFunction;
 
     /// <summary>
     /// A method used to regularize the parameters so they don't get out of control.

--- a/tests/AiDotNet.Tests/IntegrationTests/NeuralNetworks/EmbeddingLayerValidatorIssues1321_1322_1323IntegrationTests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/NeuralNetworks/EmbeddingLayerValidatorIssues1321_1322_1323IntegrationTests.cs
@@ -213,7 +213,14 @@ public class EmbeddingLayerValidatorIssues1321_1322_1323IntegrationTests
             layers: layers);
 
         var ex = Assert.Throws<ArgumentException>(() => new FeedForwardNeuralNetwork<float>(arch));
-        Assert.Contains("Layer 0 is not compatible with Layer 1", ex.Message);
+        // The shape-enriched error message format (per the validator's diagnostic
+        // upgrade in this same PR) reads e.g.
+        //   "Layer 0 (InputLayer, output [16]) is not compatible with Layer 1 (InputLayer, input [31])."
+        // The test's invariant is "a compatibility violation between Layer 0 and Layer 1
+        // is reported," which we verify on the two structural tokens rather than the
+        // exact substring (the prior substring spanned the now-injected shape info).
+        Assert.Contains("Layer 0", ex.Message);
+        Assert.Contains("is not compatible with Layer 1", ex.Message);
     }
 
     // ====================================================================

--- a/tests/AiDotNet.Tests/IntegrationTests/NeuralNetworks/HrePaperAChainShapeValidatorTests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/NeuralNetworks/HrePaperAChainShapeValidatorTests.cs
@@ -106,17 +106,26 @@ public class HrePaperAChainShapeValidatorTests
     [Fact]
     public void HreChain_RankMismatchWithoutWildcard_RejectedByValidator()
     {
-        // Chain: InputLayer(64) → FixedShape([32, 32] in, [32, 32] out)
-        //        → FixedShape([3, 32, 32] in, [3, 32, 32] out)
+        // Chain crafted so that ONLY the 1→2 edge fails compatibility — every
+        // other transition (0→1, 2→3) is shape-compatible. Without this
+        // careful construction, a "Layer X is not compatible with Layer Y"
+        // assertion could be triggered by an unrelated edge and the regression
+        // we're guarding (rank-mismatch wildcard guard) would silently pass
+        // even if it broke.
         //
-        // The 2nd layer declares rank-2 output with a concrete leading 32; the
-        // 3rd declares rank-3 input with a concrete leading 3. These are
-        // unrelated shapes; the rank+1 strip branch must NOT bless them.
+        //   0: InputLayer(64)          out [64]
+        //   1: ProbeLayer [64] → [32, 32]                     ← 0→1 OK
+        //   2: ProbeLayer [3, 32, 32] → [3, 32, 32]           ← 1→2 FAILS:
+        //         Layer 1 out [32, 32] (rank 2, no wildcard) vs
+        //         Layer 2 in  [3, 32, 32] (rank 3, concrete leading 3).
+        //         Rank-mismatch wildcard guard MUST reject — without it the
+        //         validator would silently strip the leading 3 and accept.
+        //   3: ProbeLayer [3, 32, 32] → [vocab]                ← 2→3 OK
         var layers = new List<ILayer<float>>
         {
             new InputLayer<float>(64),
             new FixedShapeRank2Layer(
-                inputShape: new[] { 32, 32 },
+                inputShape: new[] { 64 },
                 outputShape: new[] { 32, 32 }),
             new FixedShapeRank2Layer(
                 inputShape: new[] { 3, 32, 32 },
@@ -142,10 +151,22 @@ public class HrePaperAChainShapeValidatorTests
 
         var ex = Assert.Throws<ArgumentException>(() =>
             new Transformer<float>(arch, lossFunction: new CategoricalCrossEntropyLoss<float>()));
-        // Be lenient about the exact wording (shape-enriched diagnostic upgrade
-        // injects shape info), but require the structural tokens identifying
-        // the rejected 1-2 edge.
-        Assert.Contains("not compatible", ex.Message);
+
+        // Pin the assertion to the SPECIFIC 1→2 rejection, with both the
+        // structural tokens AND the concrete shapes that surface in the
+        // shape-enriched diagnostic. Without these, the test would also
+        // pass on any other edge-N "not compatible" failure — meaning a
+        // regression of the rank-mismatch wildcard guard could ship while
+        // a different bug at edge 0→1 keeps the assertion green.
+        Assert.Contains("Layer 1", ex.Message);
+        Assert.Contains("output [32, 32]", ex.Message);
+        Assert.Contains("is not compatible with Layer 2", ex.Message);
+        Assert.Contains("input [3, 32, 32]", ex.Message);
+
+        // Also assert there is NO reported failure on the 0→1 edge — the
+        // chain is constructed so 0→1 ([64] → [64]) is compatible and we
+        // rely on that to isolate the 1→2 regression.
+        Assert.DoesNotContain("Layer 0", ex.Message);
     }
 
     // ============================================================================

--- a/tests/AiDotNet.Tests/IntegrationTests/NeuralNetworks/HrePaperAChainShapeValidatorTests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/NeuralNetworks/HrePaperAChainShapeValidatorTests.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using AiDotNet.ActivationFunctions;
 using AiDotNet.Enums;
 using AiDotNet.Interfaces;
+using AiDotNet.LossFunctions;
 using AiDotNet.NeuralNetworks;
 using AiDotNet.NeuralNetworks.Layers;
 using AiDotNet.Tensors.LinearAlgebra;
@@ -17,147 +18,158 @@ namespace AiDotNetTests.IntegrationTests.NeuralNetworks;
 /// <c>MultiHeadAttention -> SequenceTokenSliceLayer -> custom-readout(rank-2 specific shape)</c>
 /// the custom-chain validator rejects both pairs with "Layer N is not compatible with Layer N+1".
 ///
-/// We mock the HRE readout's shape contract with <see cref="FixedShapeRank2Layer"/> —
-/// a no-op layer declaring input shape <c>[ctxLen, 2*codeDim]</c> (rank-2 with two
-/// known positive dims). This exactly mirrors <c>HreReadoutLayer</c>'s
-/// declared input shape from HarmonicEngine.
+/// <para>The validator is exercised through its real entry points
+/// (<c>new Transformer&lt;float&gt;(arch)</c> at construction time and the
+/// post-forward <c>DeepCopy</c> revalidation path inside the optimizer
+/// pipeline), not by re-implementing the compatibility algorithm in the
+/// test. The mock readout layer (<see cref="FixedShapeRank2Layer"/>)
+/// declares the same shape contract as HarmonicEngine's <c>HreReadoutLayer</c>,
+/// which is what surfaces the validator regression.</para>
 /// </summary>
 public class HrePaperAChainShapeValidatorTests
 {
     /// <summary>
-    /// Reproduces the actual failure mode: DeepCopy revalidates the chain
-    /// AFTER first forward has run. SequenceTokenSliceLayer's input shape
-    /// resolves to the concrete `[batch, ctxLen, dim]` (rank 3, all positive)
-    /// while MHA's declared output stays `[-1, embDim]` (rank 2). The
-    /// validator's AreShapesCompatible can't reconcile rank-2 vs rank-3
-    /// when both shapes are mostly-known.
+    /// Validator runs at chain-construction time and rejects the chain if any
+    /// adjacent-layer pair fails <c>AreShapesCompatible</c>. This is the first
+    /// time the rank-N declared (MHA <c>[-1, embDim]</c>) vs rank-(N+1)
+    /// resolved (Slice <c>[batch, ctxLen, embDim]</c>) shape pair is checked.
+    /// Pre-fix the chain construction threw with
+    /// "Layer N (MultiHeadAttention) is not compatible with Layer N+1 (SequenceTokenSliceLayer)".
     /// </summary>
     [Fact]
-    public void HreChain_RevalidateAfterForward_RankMismatchOnSlice()
+    public void HreChain_ConstructTransformer_PassesValidator()
     {
-        const int CtxLen = 64;
-        const int EmbDim = 32;
-        const int Batch = 4;
+        var arch = BuildHreLikeArchitecture();
 
-        // Pre-resolve the slice layer's shapes to mimic what OnFirstForward
-        // does. After a real forward with input [Batch, CtxLen, EmbDim], the
-        // slice's input/output become concrete rank-3/rank-2.
-        var slice = new PreResolvedSliceMock(
-            inputShape: new[] { Batch, CtxLen, EmbDim },
-            outputShape: new[] { Batch, EmbDim });
+        // ctor runs the chain validator. A regression of the rank-mismatch
+        // fix would throw here with the "Layer N is not compatible with Layer M"
+        // diagnostic.
+        var model = new Transformer<float>(arch, lossFunction: new CategoricalCrossEntropyLoss<float>());
 
-        var mhaOut = new MultiHeadAttentionLayer<float>(
-            headCount: 4, headDimension: EmbDim / 4,
-            activationFunction: (IActivationFunction<float>)new IdentityActivation<float>());
-
-        // Direct compatibility query — mirrors AreLayersCompatible's input.
-        // Currently fails: MHA's [-1, embDim] (rank 2) vs Slice's
-        // [Batch, CtxLen, EmbDim] (rank 3 resolved). After the fix, the
-        // validator should accept rank-N declared vs rank-N+1 resolved when
-        // the missing leading dim looks like a batch.
-        var mhaOutShape = mhaOut.GetOutputShape();
-        var sliceInShape = slice.GetInputShape();
-        Assert.Equal(2, mhaOutShape.Length); // MHA declares rank 2
-        Assert.Equal(3, sliceInShape.Length); // Slice resolved to rank 3
-
-        // The full chain test: re-validating after forward shouldn't reject
-        // the chain. This is the failure HarmonicEngine PR #149 hit when
-        // AiModelBuilder.BuildAsync → AdamOptimizer.Optimize →
-        // OptimizerBase.PrepareAndEvaluateSolution → DeepCopy re-built the
-        // Transformer from the same arch and called ValidateCustomLayers
-        // against the (now resolved) layer shapes.
-        var compatible = TestableValidator.AreShapesCompatible_Public(mhaOutShape, sliceInShape);
-        Assert.True(compatible,
-            $"validator rejects MHA out {ShapeStr(mhaOutShape)} vs Slice resolved in {ShapeStr(sliceInShape)} — " +
-            "this blocks DeepCopy after first forward, which is exactly the HarmonicEngine PR #149 failure path.");
-    }
-
-    private static string ShapeStr(int[] s) => "[" + string.Join(",", s) + "]";
-
-    /// <summary>
-    /// Test-only mock that returns pre-set input/output shapes directly,
-    /// simulating a SequenceTokenSliceLayer whose OnFirstForward has run
-    /// and called ResolveShapes with concrete batch/seq/dim values.
-    /// </summary>
-    private sealed class PreResolvedSliceMock : LayerBase<float>
-    {
-        public PreResolvedSliceMock(int[] inputShape, int[] outputShape)
-            : base(inputShape, outputShape) { }
-        public override long ParameterCount => 0;
-        public override bool SupportsTraining => false;
-        public override Tensor<float> Forward(Tensor<float> input) => input;
-        public override void UpdateParameters(float learningRate) { }
-        public override Vector<float> GetParameters() => new Vector<float>(0);
-        public override void SetParameters(Vector<float> parameters) { }
-        public override Vector<float> GetParameterGradients() => new Vector<float>(0);
-        public override void ResetState() { }
-        public override LayerBase<float> Clone() => new PreResolvedSliceMock(GetInputShape(), GetOutputShape());
+        Assert.NotNull(model);
+        Assert.True(model.Layers.Count >= MinExpectedLayers,
+            $"expected ≥{MinExpectedLayers} layers in built chain, got {model.Layers.Count}");
     }
 
     /// <summary>
-    /// Exposes <see cref="NeuralNetworkBase{T}.AreShapesCompatible"/> for
-    /// targeted regression coverage. The production method is private static
-    /// inside NeuralNetworkBase; we re-implement the contract here by
-    /// constructing a minimal NeuralNetwork to host the check.
+    /// After a real <c>Forward</c> mutates the slice layer's shape from
+    /// <c>[-1, -1, -1]</c> to a concrete <c>[batch, ctxLen, embDim]</c>, a
+    /// downstream <c>DeepCopy</c> re-runs the validator on the (now resolved)
+    /// chain — this is the exact failure path from HarmonicEngine PR #149,
+    /// triggered by <c>AdamOptimizer.Optimize</c> →
+    /// <c>OptimizerBase.PrepareAndEvaluateSolution</c> → <c>DeepCopy</c>.
+    /// Pre-fix the post-forward revalidation threw because the validator
+    /// couldn't reconcile MHA's still-declared rank-2 output with Slice's
+    /// now-rank-3 resolved input.
     /// </summary>
-    private static class TestableValidator
+    [Fact]
+    public void HreChain_DeepCopyAfterForward_PassesRevalidation()
     {
-        public static bool AreShapesCompatible_Public(int[] expectedShape, int[] actualShape)
+        var arch = BuildHreLikeArchitecture();
+        var model = new Transformer<float>(arch, lossFunction: new CategoricalCrossEntropyLoss<float>());
+
+        // Real forward — this is what causes SequenceTokenSliceLayer to call
+        // ResolveShapes with a concrete batch dim, mutating the chain's
+        // observable shape state.
+        var input = new Tensor<float>(new[] { Batch, CtxLen });
+        var span = input.AsWritableSpan();
+        for (int i = 0; i < span.Length; i++) span[i] = i % VocabSize;
+        _ = model.Predict(input);
+
+        // DeepCopy re-instantiates the chain (and re-runs ValidateCustomLayers
+        // internally) against the same architecture but now with resolved
+        // upstream shape state. A regression here would throw
+        // ArgumentException with "Layer N is not compatible with Layer M".
+        var copy = (NeuralNetworkBase<float>)model.DeepCopy();
+
+        Assert.NotNull(copy);
+        // DeepCopy must return a distinct top-level model instance — without
+        // that, parameter updates on the copy would mutate the original.
+        Assert.NotSame(model, copy);
+        Assert.Equal(model.Layers.Count, copy.Layers.Count);
+        // The chain must be structurally equivalent — same layer types in the
+        // same positions. Per-instance reference-equality on individual layers
+        // is implementation-defined (parameter-less layers are legitimately
+        // shared) and not part of the DeepCopy contract.
+        for (int i = 0; i < model.Layers.Count; i++)
         {
-            // Mirror the production AreShapesCompatible logic exactly. Updating
-            // this when the production logic changes is the test's contract.
-            if (ShapesMatchKnownDimensions(expectedShape, actualShape)) return true;
-            var expectedTrim = TrimLeadingBatchLikeDimensions(expectedShape);
-            if (ShapesMatchKnownDimensions(expectedTrim, actualShape)) return true;
-            var actualTrim = TrimLeadingBatchLikeDimensions(actualShape);
-            if (ShapesMatchKnownDimensions(expectedShape, actualTrim)) return true;
-            if (ShapesMatchKnownDimensions(expectedTrim, actualTrim)) return true;
-            if (expectedShape.Length + 1 == actualShape.Length && actualShape[0] >= 1)
-            {
-                var actualNoBatch = new int[actualShape.Length - 1];
-                Array.Copy(actualShape, 1, actualNoBatch, 0, actualNoBatch.Length);
-                if (ShapesMatchKnownDimensions(expectedShape, actualNoBatch)) return true;
-            }
-            if (actualShape.Length + 1 == expectedShape.Length && expectedShape[0] >= 1)
-            {
-                var expectedNoBatch = new int[expectedShape.Length - 1];
-                Array.Copy(expectedShape, 1, expectedNoBatch, 0, expectedNoBatch.Length);
-                if (ShapesMatchKnownDimensions(expectedNoBatch, actualShape)) return true;
-            }
-            return false;
-        }
-        private static bool ShapesMatchKnownDimensions(int[] expected, int[] actual)
-        {
-            if (expected.Length != actual.Length) return false;
-            for (int i = 0; i < expected.Length; i++)
-                if (expected[i] > 0 && actual[i] > 0 && expected[i] != actual[i]) return false;
-            return true;
-        }
-        private static int[] TrimLeadingBatchLikeDimensions(int[] shape)
-        {
-            int start = 0;
-            while (start < shape.Length - 1 && shape[start] <= 1) start++;
-            if (start == 0) return shape;
-            var trimmed = new int[shape.Length - start];
-            Array.Copy(shape, start, trimmed, 0, trimmed.Length);
-            return trimmed;
+            Assert.Equal(model.Layers[i].GetType(), copy.Layers[i].GetType());
         }
     }
 
+    /// <summary>
+    /// Negative-direction guard: when the shorter shape's leading dim is a
+    /// concrete positive (not the wildcard <c>-1</c>), the validator must
+    /// still reject. Without this guard the rank-mismatch fix would bless
+    /// genuinely incompatible chains like <c>[32, 32]</c> vs <c>[3, 32, 32]</c>.
+    /// </summary>
     [Fact]
-    public void HreChain_MhaSliceReadout_ShouldValidate()
+    public void HreChain_RankMismatchWithoutWildcard_RejectedByValidator()
     {
-        const int CtxLen = 64;
-        const int EmbDim = 32;
-        const int Heads = 4;
-        const int VocabSize = 256;
+        // Chain: InputLayer(64) → FixedShape([32, 32] in, [32, 32] out)
+        //        → FixedShape([3, 32, 32] in, [3, 32, 32] out)
+        //
+        // The 2nd layer declares rank-2 output with a concrete leading 32; the
+        // 3rd declares rank-3 input with a concrete leading 3. These are
+        // unrelated shapes; the rank+1 strip branch must NOT bless them.
+        var layers = new List<ILayer<float>>
+        {
+            new InputLayer<float>(64),
+            new FixedShapeRank2Layer(
+                inputShape: new[] { 32, 32 },
+                outputShape: new[] { 32, 32 }),
+            new FixedShapeRank2Layer(
+                inputShape: new[] { 3, 32, 32 },
+                outputShape: new[] { 3, 32, 32 }),
+            new FixedShapeRank2Layer(
+                inputShape: new[] { 3, 32, 32 },
+                outputShape: new[] { VocabSize }),
+        };
 
-        // Mirror HarmonicEngine ApplesToApplesHreChain exactly:
-        // InputLayer → embed → PE → MHA × 2 → SequenceTokenSliceLayer → readout.
-        // HarmonicEngine prepends InputLayer per AiDotNet's IsValidInputLayer
-        // requirement. We use AiDotNet's EmbeddingLayer + DenseLayer to stand
-        // in for the HRE-side embed/PE/readout — the shape declarations are
-        // what matter for the validator, not the math inside.
+        var arch = new TransformerArchitecture<float>(
+            inputType: InputType.OneDimensional,
+            taskType: NeuralNetworkTaskType.SequenceClassification,
+            numEncoderLayers: 1,
+            numDecoderLayers: 0,
+            numHeads: 1,
+            modelDimension: 32,
+            feedForwardDimension: 64,
+            inputSize: 64,
+            outputSize: VocabSize,
+            maxSequenceLength: 64,
+            vocabularySize: VocabSize,
+            layers: layers);
+
+        var ex = Assert.Throws<ArgumentException>(() =>
+            new Transformer<float>(arch, lossFunction: new CategoricalCrossEntropyLoss<float>()));
+        // Be lenient about the exact wording (shape-enriched diagnostic upgrade
+        // injects shape info), but require the structural tokens identifying
+        // the rejected 1-2 edge.
+        Assert.Contains("not compatible", ex.Message);
+    }
+
+    // ============================================================================
+    // Test fixtures
+    // ============================================================================
+
+    private const int CtxLen = 8;
+    private const int EmbDim = 16;
+    private const int Heads = 2;
+    private const int VocabSize = 64;
+    private const int Batch = 2;
+    private const int MinExpectedLayers = 4;
+
+    /// <summary>
+    /// Builds an architecture isomorphic to HarmonicEngine's
+    /// <c>ApplesToApplesHreChain</c>: <c>InputLayer → embed → MHA × 2 →
+    /// SequenceTokenSliceLayer → readout</c>. We use AiDotNet's stock
+    /// <see cref="EmbeddingLayer{T}"/> as the embed and a
+    /// <see cref="FixedShapeRank2Layer"/> as the readout — the shape
+    /// declarations are what the validator checks; the math inside is
+    /// irrelevant for this regression.
+    /// </summary>
+    private static TransformerArchitecture<float> BuildHreLikeArchitecture()
+    {
         var layers = new List<ILayer<float>>
         {
             new InputLayer<float>(CtxLen),
@@ -167,15 +179,12 @@ public class HrePaperAChainShapeValidatorTests
             new MultiHeadAttentionLayer<float>(Heads, EmbDim / Heads,
                 activationFunction: (IActivationFunction<float>)new IdentityActivation<float>()),
             new SequenceTokenSliceLayer<float>(SequenceTokenSliceLayer<float>.Position.Last),
-            // The HreReadoutLayer in HarmonicEngine declares input shape
-            // [ctxLen, 2*codeDim] (rank-2 with both dims > 0) and output
-            // [vocabSize]. Stand in with a fixed-shape mock.
             new FixedShapeRank2Layer(
-                inputShape: new[] { CtxLen, EmbDim },
+                inputShape: new[] { -1, EmbDim },
                 outputShape: new[] { VocabSize }),
         };
 
-        var arch = new TransformerArchitecture<float>(
+        return new TransformerArchitecture<float>(
             inputType: InputType.TwoDimensional,
             taskType: NeuralNetworkTaskType.SequenceClassification,
             numEncoderLayers: 2,
@@ -188,15 +197,14 @@ public class HrePaperAChainShapeValidatorTests
             maxSequenceLength: CtxLen,
             vocabularySize: VocabSize,
             layers: layers);
-
-        Assert.NotNull(arch);
-        Assert.Same(layers[0], arch.Layers![0]);
     }
 
     /// <summary>
-    /// No-op layer with explicit rank-2 input shape and rank-1 output shape.
-    /// Mimics HarmonicEngine's <c>HreReadoutLayer</c> shape contract for
-    /// validator-only regression testing.
+    /// No-op layer with explicit input/output shapes. Mimics HarmonicEngine's
+    /// <c>HreReadoutLayer</c> shape contract (rank-2 input <c>[batch, embDim]</c>
+    /// or <c>[-1, embDim]</c>, rank-1 output <c>[vocabSize]</c>) for the
+    /// validator-only regression tests. Forward is identity so we can run a
+    /// real <c>Predict</c> through the chain without depending on HRE math.
     /// </summary>
     private sealed class FixedShapeRank2Layer : LayerBase<float>
     {
@@ -207,7 +215,35 @@ public class HrePaperAChainShapeValidatorTests
 
         public override long ParameterCount => 0;
         public override bool SupportsTraining => false;
-        public override Tensor<float> Forward(Tensor<float> input) => input;
+
+        public override Tensor<float> Forward(Tensor<float> input)
+        {
+            // Reshape the input flat-buffer to the declared output shape.
+            // The declared output is [vocabSize] (rank 1) for the readout-mock
+            // case, but for diagnostic chains we may have [-1, embDim] →
+            // [-1, embDim] etc. Producing the right rank/dims by reshape from
+            // the input's total element count keeps the chain well-formed.
+            var outShape = GetOutputShape();
+            // Resolve wildcards from the input shape's batch dim if needed.
+            var resolved = new int[outShape.Length];
+            int knownProduct = 1;
+            int wildcardIdx = -1;
+            for (int i = 0; i < outShape.Length; i++)
+            {
+                if (outShape[i] <= 0) { wildcardIdx = i; resolved[i] = -1; }
+                else { resolved[i] = outShape[i]; knownProduct *= outShape[i]; }
+            }
+            int inputElements = 1;
+            for (int i = 0; i < input.Shape.Length; i++) inputElements *= input.Shape[i];
+            if (wildcardIdx >= 0)
+            {
+                resolved[wildcardIdx] = Math.Max(1, inputElements / Math.Max(1, knownProduct));
+            }
+            // Produce a zero tensor of the resolved shape — this layer is a
+            // shape-contract stand-in, not a real layer.
+            return new Tensor<float>(resolved);
+        }
+
         public override void UpdateParameters(float learningRate) { }
         public override Vector<float> GetParameters() => new Vector<float>(0);
         public override void SetParameters(Vector<float> parameters) { }

--- a/tests/AiDotNet.Tests/IntegrationTests/NeuralNetworks/HrePaperAChainShapeValidatorTests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/NeuralNetworks/HrePaperAChainShapeValidatorTests.cs
@@ -1,0 +1,218 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using AiDotNet.ActivationFunctions;
+using AiDotNet.Enums;
+using AiDotNet.Interfaces;
+using AiDotNet.NeuralNetworks;
+using AiDotNet.NeuralNetworks.Layers;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNetTests.IntegrationTests.NeuralNetworks;
+
+/// <summary>
+/// Repro for the HRE PAPER-A chain shape-validator failure reported in
+/// HarmonicEngine PR #149: when a chain ends with
+/// <c>MultiHeadAttention -> SequenceTokenSliceLayer -> custom-readout(rank-2 specific shape)</c>
+/// the custom-chain validator rejects both pairs with "Layer N is not compatible with Layer N+1".
+///
+/// We mock the HRE readout's shape contract with <see cref="FixedShapeRank2Layer"/> —
+/// a no-op layer declaring input shape <c>[ctxLen, 2*codeDim]</c> (rank-2 with two
+/// known positive dims). This exactly mirrors <c>HreReadoutLayer</c>'s
+/// declared input shape from HarmonicEngine.
+/// </summary>
+public class HrePaperAChainShapeValidatorTests
+{
+    /// <summary>
+    /// Reproduces the actual failure mode: DeepCopy revalidates the chain
+    /// AFTER first forward has run. SequenceTokenSliceLayer's input shape
+    /// resolves to the concrete `[batch, ctxLen, dim]` (rank 3, all positive)
+    /// while MHA's declared output stays `[-1, embDim]` (rank 2). The
+    /// validator's AreShapesCompatible can't reconcile rank-2 vs rank-3
+    /// when both shapes are mostly-known.
+    /// </summary>
+    [Fact]
+    public void HreChain_RevalidateAfterForward_RankMismatchOnSlice()
+    {
+        const int CtxLen = 64;
+        const int EmbDim = 32;
+        const int Batch = 4;
+
+        // Pre-resolve the slice layer's shapes to mimic what OnFirstForward
+        // does. After a real forward with input [Batch, CtxLen, EmbDim], the
+        // slice's input/output become concrete rank-3/rank-2.
+        var slice = new PreResolvedSliceMock(
+            inputShape: new[] { Batch, CtxLen, EmbDim },
+            outputShape: new[] { Batch, EmbDim });
+
+        var mhaOut = new MultiHeadAttentionLayer<float>(
+            headCount: 4, headDimension: EmbDim / 4,
+            activationFunction: (IActivationFunction<float>)new IdentityActivation<float>());
+
+        // Direct compatibility query — mirrors AreLayersCompatible's input.
+        // Currently fails: MHA's [-1, embDim] (rank 2) vs Slice's
+        // [Batch, CtxLen, EmbDim] (rank 3 resolved). After the fix, the
+        // validator should accept rank-N declared vs rank-N+1 resolved when
+        // the missing leading dim looks like a batch.
+        var mhaOutShape = mhaOut.GetOutputShape();
+        var sliceInShape = slice.GetInputShape();
+        Assert.Equal(2, mhaOutShape.Length); // MHA declares rank 2
+        Assert.Equal(3, sliceInShape.Length); // Slice resolved to rank 3
+
+        // The full chain test: re-validating after forward shouldn't reject
+        // the chain. This is the failure HarmonicEngine PR #149 hit when
+        // AiModelBuilder.BuildAsync → AdamOptimizer.Optimize →
+        // OptimizerBase.PrepareAndEvaluateSolution → DeepCopy re-built the
+        // Transformer from the same arch and called ValidateCustomLayers
+        // against the (now resolved) layer shapes.
+        var compatible = TestableValidator.AreShapesCompatible_Public(mhaOutShape, sliceInShape);
+        Assert.True(compatible,
+            $"validator rejects MHA out {ShapeStr(mhaOutShape)} vs Slice resolved in {ShapeStr(sliceInShape)} — " +
+            "this blocks DeepCopy after first forward, which is exactly the HarmonicEngine PR #149 failure path.");
+    }
+
+    private static string ShapeStr(int[] s) => "[" + string.Join(",", s) + "]";
+
+    /// <summary>
+    /// Test-only mock that returns pre-set input/output shapes directly,
+    /// simulating a SequenceTokenSliceLayer whose OnFirstForward has run
+    /// and called ResolveShapes with concrete batch/seq/dim values.
+    /// </summary>
+    private sealed class PreResolvedSliceMock : LayerBase<float>
+    {
+        public PreResolvedSliceMock(int[] inputShape, int[] outputShape)
+            : base(inputShape, outputShape) { }
+        public override long ParameterCount => 0;
+        public override bool SupportsTraining => false;
+        public override Tensor<float> Forward(Tensor<float> input) => input;
+        public override void UpdateParameters(float learningRate) { }
+        public override Vector<float> GetParameters() => new Vector<float>(0);
+        public override void SetParameters(Vector<float> parameters) { }
+        public override Vector<float> GetParameterGradients() => new Vector<float>(0);
+        public override void ResetState() { }
+        public override LayerBase<float> Clone() => new PreResolvedSliceMock(GetInputShape(), GetOutputShape());
+    }
+
+    /// <summary>
+    /// Exposes <see cref="NeuralNetworkBase{T}.AreShapesCompatible"/> for
+    /// targeted regression coverage. The production method is private static
+    /// inside NeuralNetworkBase; we re-implement the contract here by
+    /// constructing a minimal NeuralNetwork to host the check.
+    /// </summary>
+    private static class TestableValidator
+    {
+        public static bool AreShapesCompatible_Public(int[] expectedShape, int[] actualShape)
+        {
+            // Mirror the production AreShapesCompatible logic exactly. Updating
+            // this when the production logic changes is the test's contract.
+            if (ShapesMatchKnownDimensions(expectedShape, actualShape)) return true;
+            var expectedTrim = TrimLeadingBatchLikeDimensions(expectedShape);
+            if (ShapesMatchKnownDimensions(expectedTrim, actualShape)) return true;
+            var actualTrim = TrimLeadingBatchLikeDimensions(actualShape);
+            if (ShapesMatchKnownDimensions(expectedShape, actualTrim)) return true;
+            if (ShapesMatchKnownDimensions(expectedTrim, actualTrim)) return true;
+            if (expectedShape.Length + 1 == actualShape.Length && actualShape[0] >= 1)
+            {
+                var actualNoBatch = new int[actualShape.Length - 1];
+                Array.Copy(actualShape, 1, actualNoBatch, 0, actualNoBatch.Length);
+                if (ShapesMatchKnownDimensions(expectedShape, actualNoBatch)) return true;
+            }
+            if (actualShape.Length + 1 == expectedShape.Length && expectedShape[0] >= 1)
+            {
+                var expectedNoBatch = new int[expectedShape.Length - 1];
+                Array.Copy(expectedShape, 1, expectedNoBatch, 0, expectedNoBatch.Length);
+                if (ShapesMatchKnownDimensions(expectedNoBatch, actualShape)) return true;
+            }
+            return false;
+        }
+        private static bool ShapesMatchKnownDimensions(int[] expected, int[] actual)
+        {
+            if (expected.Length != actual.Length) return false;
+            for (int i = 0; i < expected.Length; i++)
+                if (expected[i] > 0 && actual[i] > 0 && expected[i] != actual[i]) return false;
+            return true;
+        }
+        private static int[] TrimLeadingBatchLikeDimensions(int[] shape)
+        {
+            int start = 0;
+            while (start < shape.Length - 1 && shape[start] <= 1) start++;
+            if (start == 0) return shape;
+            var trimmed = new int[shape.Length - start];
+            Array.Copy(shape, start, trimmed, 0, trimmed.Length);
+            return trimmed;
+        }
+    }
+
+    [Fact]
+    public void HreChain_MhaSliceReadout_ShouldValidate()
+    {
+        const int CtxLen = 64;
+        const int EmbDim = 32;
+        const int Heads = 4;
+        const int VocabSize = 256;
+
+        // Mirror HarmonicEngine ApplesToApplesHreChain exactly:
+        // InputLayer → embed → PE → MHA × 2 → SequenceTokenSliceLayer → readout.
+        // HarmonicEngine prepends InputLayer per AiDotNet's IsValidInputLayer
+        // requirement. We use AiDotNet's EmbeddingLayer + DenseLayer to stand
+        // in for the HRE-side embed/PE/readout — the shape declarations are
+        // what matter for the validator, not the math inside.
+        var layers = new List<ILayer<float>>
+        {
+            new InputLayer<float>(CtxLen),
+            new EmbeddingLayer<float>(vocabularySize: VocabSize, embeddingDimension: EmbDim),
+            new MultiHeadAttentionLayer<float>(Heads, EmbDim / Heads,
+                activationFunction: (IActivationFunction<float>)new IdentityActivation<float>()),
+            new MultiHeadAttentionLayer<float>(Heads, EmbDim / Heads,
+                activationFunction: (IActivationFunction<float>)new IdentityActivation<float>()),
+            new SequenceTokenSliceLayer<float>(SequenceTokenSliceLayer<float>.Position.Last),
+            // The HreReadoutLayer in HarmonicEngine declares input shape
+            // [ctxLen, 2*codeDim] (rank-2 with both dims > 0) and output
+            // [vocabSize]. Stand in with a fixed-shape mock.
+            new FixedShapeRank2Layer(
+                inputShape: new[] { CtxLen, EmbDim },
+                outputShape: new[] { VocabSize }),
+        };
+
+        var arch = new TransformerArchitecture<float>(
+            inputType: InputType.TwoDimensional,
+            taskType: NeuralNetworkTaskType.SequenceClassification,
+            numEncoderLayers: 2,
+            numDecoderLayers: 0,
+            numHeads: Heads,
+            modelDimension: EmbDim,
+            feedForwardDimension: 2 * EmbDim,
+            inputSize: CtxLen,
+            outputSize: VocabSize,
+            maxSequenceLength: CtxLen,
+            vocabularySize: VocabSize,
+            layers: layers);
+
+        Assert.NotNull(arch);
+        Assert.Same(layers[0], arch.Layers![0]);
+    }
+
+    /// <summary>
+    /// No-op layer with explicit rank-2 input shape and rank-1 output shape.
+    /// Mimics HarmonicEngine's <c>HreReadoutLayer</c> shape contract for
+    /// validator-only regression testing.
+    /// </summary>
+    private sealed class FixedShapeRank2Layer : LayerBase<float>
+    {
+        public FixedShapeRank2Layer(int[] inputShape, int[] outputShape)
+            : base(inputShape, outputShape)
+        {
+        }
+
+        public override long ParameterCount => 0;
+        public override bool SupportsTraining => false;
+        public override Tensor<float> Forward(Tensor<float> input) => input;
+        public override void UpdateParameters(float learningRate) { }
+        public override Vector<float> GetParameters() => new Vector<float>(0);
+        public override void SetParameters(Vector<float> parameters) { }
+        public override Vector<float> GetParameterGradients() => new Vector<float>(0);
+        public override void ResetState() { }
+        public override LayerBase<float> Clone() => new FixedShapeRank2Layer(GetInputShape(), GetOutputShape());
+    }
+}

--- a/tests/AiDotNet.Tests/IntegrationTests/Optimizers/OptimizerLossSyncFromModelTests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/Optimizers/OptimizerLossSyncFromModelTests.cs
@@ -1,0 +1,142 @@
+#nullable disable
+using System;
+using System.Collections.Generic;
+using AiDotNet.ActivationFunctions;
+using AiDotNet.Enums;
+using AiDotNet.Helpers;
+using AiDotNet.Interfaces;
+using AiDotNet.LinearAlgebra;
+using AiDotNet.LossFunctions;
+using AiDotNet.Models.Options;
+using AiDotNet.NeuralNetworks;
+using AiDotNet.NeuralNetworks.Layers;
+using AiDotNet.Optimizers;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tests.IntegrationTests.Optimizers;
+
+/// <summary>
+/// Regression coverage for AiDotNet#1334:
+/// <c>GradientBasedOptimizerOptions.LossFunction</c> defaults to
+/// <see cref="MeanSquaredErrorLoss{T}"/>. Before the fix, when callers configured
+/// a non-MSE loss on their model (e.g. <see cref="CategoricalCrossEntropyLoss{T}"/>
+/// on a classification Transformer) and handed the model to an optimizer without
+/// also setting the optimizer's loss, training silently used MSE. With one-hot
+/// vocab targets <c>[batch, vocab]</c> the resulting shape mismatch crashed
+/// <c>TensorSubtract</c> inside the optimizer's gradient path.
+///
+/// The fix routes the auto-sync through
+/// <c>GradientBasedOptimizerBase.OnModelChanged</c> — when the model is (re-)set
+/// and the caller did NOT explicitly configure the optimizer's
+/// <c>LossFunction</c>, the optimizer adopts the model's
+/// <c>DefaultLossFunction</c>. An explicit set on the optimizer always wins.
+/// </summary>
+public class OptimizerLossSyncFromModelTests
+{
+    private static FeedForwardNeuralNetwork<float> BuildToyNetwork(ILossFunction<float> loss)
+    {
+        var layers = new List<ILayer<float>>
+        {
+            new DenseLayer<float>(2, (IActivationFunction<float>)new IdentityActivation<float>()),
+        };
+        var arch = new NeuralNetworkArchitecture<float>(
+            inputType: InputType.OneDimensional,
+            taskType: NeuralNetworkTaskType.BinaryClassification,
+            inputSize: 4,
+            outputSize: 2,
+            layers: layers);
+        return new FeedForwardNeuralNetwork<float>(arch, lossFunction: loss);
+    }
+
+    [Fact]
+    public void OptionsDefault_LossFunction_AdoptedFromModelOnSetModel()
+    {
+        // Build a model whose loss is CCE.
+        var modelLoss = new CategoricalCrossEntropyLoss<float>();
+        var model = BuildToyNetwork(modelLoss);
+
+        // Optimizer options where the caller did NOT set LossFunction.
+        var options = new AdamOptimizerOptions<float, Tensor<float>, Tensor<float>>
+        {
+            InitialLearningRate = 1e-3,
+        };
+        Assert.False(options.LossFunctionExplicitlySet,
+            "Sanity: default-constructed options must report LossFunctionExplicitlySet=false.");
+
+        var optimizer = new AdamOptimizer<float, Tensor<float>, Tensor<float>>(null, options);
+        optimizer.SetModel(model);
+
+        // The optimizer's runtime gradient path now uses CCE — this is the
+        // load-bearing assertion (it's what training reads).
+        Assert.IsType<CategoricalCrossEntropyLoss<float>>(optimizer.CurrentLossFunction);
+        // And the options object is mirrored so debug/serialization paths see
+        // the synced value too.
+        Assert.IsType<CategoricalCrossEntropyLoss<float>>(options.LossFunction);
+    }
+
+    [Fact]
+    public void OptionsExplicitMse_RespectedEvenWhenModelLossIsCce()
+    {
+        // Caller deliberately chooses MSE on the optimizer even though the model's
+        // default loss is CCE. The auto-sync MUST NOT overwrite the caller's choice.
+        var model = BuildToyNetwork(new CategoricalCrossEntropyLoss<float>());
+
+        var explicitOptimizerLoss = new MeanSquaredErrorLoss<float>();
+        var options = new AdamOptimizerOptions<float, Tensor<float>, Tensor<float>>
+        {
+            LossFunction = explicitOptimizerLoss,
+        };
+        Assert.True(options.LossFunctionExplicitlySet);
+
+        var optimizer = new AdamOptimizer<float, Tensor<float>, Tensor<float>>(null, options);
+        optimizer.SetModel(model);
+
+        // Caller's instance preserved exactly on both surfaces.
+        Assert.Same(explicitOptimizerLoss, optimizer.CurrentLossFunction);
+        Assert.Same(explicitOptimizerLoss, options.LossFunction);
+    }
+
+    [Fact]
+    public void OptionsExplicitCce_NotReplacedByModelMse()
+    {
+        // Inverse of the first test: model has MSE (the optimizer-default), but
+        // the caller explicitly wants CCE on the optimizer. The auto-sync must
+        // not silently replace it with the model's MSE.
+        var model = BuildToyNetwork(new MeanSquaredErrorLoss<float>());
+
+        var explicitOptimizerLoss = new CategoricalCrossEntropyLoss<float>();
+        var options = new AdamOptimizerOptions<float, Tensor<float>, Tensor<float>>
+        {
+            LossFunction = explicitOptimizerLoss,
+        };
+
+        var optimizer = new AdamOptimizer<float, Tensor<float>, Tensor<float>>(null, options);
+        optimizer.SetModel(model);
+
+        Assert.Same(explicitOptimizerLoss, optimizer.CurrentLossFunction);
+        Assert.Same(explicitOptimizerLoss, options.LossFunction);
+    }
+
+    [Fact]
+    public void SetModel_Twice_StillSyncsLossWhenNotExplicit()
+    {
+        // Plumbing detail: the auto-sync fires on every SetModel call, not just
+        // the first. So re-setting the model also re-syncs the loss.
+        var firstLoss = new MeanSquaredErrorLoss<float>();
+        var firstModel = BuildToyNetwork(firstLoss);
+
+        var options = new AdamOptimizerOptions<float, Tensor<float>, Tensor<float>>
+        {
+            InitialLearningRate = 1e-3,
+        };
+        var optimizer = new AdamOptimizer<float, Tensor<float>, Tensor<float>>(null, options);
+        optimizer.SetModel(firstModel);
+        Assert.IsType<MeanSquaredErrorLoss<float>>(optimizer.CurrentLossFunction);
+
+        var secondLoss = new CategoricalCrossEntropyLoss<float>();
+        var secondModel = BuildToyNetwork(secondLoss);
+        optimizer.SetModel(secondModel);
+        Assert.IsType<CategoricalCrossEntropyLoss<float>>(optimizer.CurrentLossFunction);
+    }
+}


### PR DESCRIPTION
## Summary

Four AiDotNet fixes surfaced by end-to-end verification against HarmonicEngine PR #149's `PAPER_A_ApplesToApples_HRE_Buildable`:

1. **Chain validator: rank-N vs rank-(N+1) post-forward mismatch.** `NeuralNetworkBase.DeepCopy` re-validates the chain AFTER first forward, by which point `SequenceTokenSliceLayer.OnFirstForward` has resolved to concrete `[batch, ctxLen, dim]` (rank 3), but `MultiHeadAttentionLayer` still declares `[-1, embDim]` (rank 2). Add a 5th branch to `AreShapesCompatible` that strips the leading positive batch dim before comparison.
2. **Chain validator: flatten-boundary first-layer compatibility.** `TransformerArchitecture(InputType.TwoDimensional, inputSize=64)` yields `[8, 8]`; a chain starting with `InputLayer<T>(64)` declares `[64]`. The strict rank check rejects, but the layer would happily flatten at first forward (the documented contract). Accept when total elements match and all dims are known positive.
3. **`DeepCopy` for custom (external-assembly) layers.** The serialize/deserialize round-trip path threw `NotSupportedException` for any layer outside the AiDotNet assembly because `DeserializationHelper.CreateLayerFromType` has a hard-coded built-in registry. The existing 2 GB-paramBytes fast path used per-layer `Clone` + `SetParameters` for any layer type, so generalise the gate: take that path whenever the chain contains an external layer.
4. **(#1334) Optimizer-side loss auto-sync.** `GradientBasedOptimizerOptions.LossFunction` defaults to `MeanSquaredErrorLoss<T>` and `GradientBasedOptimizerBase.CalculateGradient` uses that field — silently overriding the model's configured loss. New `OnModelChanged` override now plumbs the model's `DefaultLossFunction` into the optimizer on `SetModel` when the caller didn't explicitly set one; explicit choices on the optimizer always win (tracked by a new `LossFunctionExplicitlySet` flag on the options).

Diagnostic upgrade: validator error messages now include the concrete shapes that failed compatibility (the prior `"Layer N is not compatible with Layer M"` gave no actionable info). This made the original HarmonicEngine PR #149 failure diagnosable in one re-run instead of source-walking every layer.

## Test plan

- [x] **`HrePaperAChainShapeValidatorTests`** (2 new tests): rank-N-vs-rank-(N+1) + the original PAPER-A chain shape. Both pass.
- [x] **`OptimizerLossSyncFromModelTests`** (4 new tests): default options auto-sync from CCE-model; explicit MSE on options preserved against CCE model; explicit CCE on options preserved against MSE model; repeated `SetModel` keeps syncing.
- [x] **Existing `EmbeddingLayerValidatorIssues1321_1322_1323IntegrationTests`** (21 tests): all pass; one assertion narrowed to two structural-token substrings to accommodate the shape-enriched error format (invariant preserved).
- [x] **Existing `InferenceOptimizerIntegrationTests`** (similar chain): all pass.
- [x] **End-to-end**: HarmonicEngine PR #149's `PAPER_A_ApplesToApples_HRE_Buildable` PASSES (11s, finite metrics, no NaN propagation, no crashes) against this PR's build (0.197.999-localfix1334a) with no HarmonicEngine-side loss-plumbing workaround.

Closes #1334.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Validation messages now include formatted input/output shapes for clearer layer-compatibility diagnostics.
  * First-layer checks accept a flatten/reshape boundary when total elements match and dims are known.
  * Adjacent-layer and guarded rank-mismatch comparisons broadened to reduce false rejections while avoiding unsafe matches.

* **Behavior Changes**
  * Optimizers adopt a model’s default loss only when the caller hasn’t explicitly set one; explicit choices remain.

* **Performance**
  * Deep-copy falls back to a safer serialization path for large models or when layer types originate outside the core assembly.

* **Tests**
  * Added integration tests for chain shape validation and optimizer loss synchronization; updated a brittle assertion.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ooples/AiDotNet/pull/1333?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->