### PR TITLE
fix(#1332 cluster 3): wire ColBERTRetriever tests with deterministic embedder

### DIFF
--- a/tests/AiDotNet.Tests/UnitTests/RetrievalAugmentedGeneration/ColBERTRetrieverTests.cs
+++ b/tests/AiDotNet.Tests/UnitTests/RetrievalAugmentedGeneration/ColBERTRetrieverTests.cs
@@ -111,6 +111,24 @@ namespace AiDotNetTests.UnitTests.RetrievalAugmentedGeneration
             return store;
         }
 
+        /// <summary>
+        /// Constructs a ColBERTRetriever wired with <see cref="TestColBertEmbedder{T}"/>.
+        /// Use for every <c>Retrieve_*</c> test that exercises the scoring path —
+        /// ColBERTRetriever throws <see cref="NotSupportedException"/> by design
+        /// when constructed without an embedder, and these unit tests run without
+        /// a real ColBERT ONNX checkpoint.
+        /// </summary>
+        private static ColBERTRetriever<double> CreateRetriever(
+            IDocumentStore<double> store,
+            int maxDocLength = 512,
+            int maxQueryLength = 32) =>
+            new ColBERTRetriever<double>(
+                store,
+                modelPath: "model.onnx",
+                maxDocLength: maxDocLength,
+                maxQueryLength: maxQueryLength,
+                embedder: new TestColBertEmbedder<double>());
+
         private MockDocumentStore CreateStoreWithDocumentsAndMetadata(
             params (string id, string content, Dictionary<string, object> metadata)[] docs)
         {
@@ -287,8 +305,7 @@ namespace AiDotNetTests.UnitTests.RetrievalAugmentedGeneration
         {
             // Arrange
             var store = new MockDocumentStore();
-            var retriever = new ColBERTRetriever<double>(
-                store, "model.onnx", maxDocLength: 512, maxQueryLength: 32);
+            var retriever = CreateRetriever(store);
 
             // Act
             var results = retriever.Retrieve("test query").ToList();
@@ -303,8 +320,7 @@ namespace AiDotNetTests.UnitTests.RetrievalAugmentedGeneration
             // Arrange
             var store = CreateStoreWithDocuments(
                 ("doc1", "The quick brown fox jumps over the lazy dog"));
-            var retriever = new ColBERTRetriever<double>(
-                store, "model.onnx", maxDocLength: 512, maxQueryLength: 32);
+            var retriever = CreateRetriever(store);
 
             // Act
             var results = retriever.Retrieve("quick brown fox").ToList();
@@ -320,8 +336,7 @@ namespace AiDotNetTests.UnitTests.RetrievalAugmentedGeneration
             // Arrange
             var store = CreateStoreWithDocuments(
                 ("doc1", "The quick brown fox"));
-            var retriever = new ColBERTRetriever<double>(
-                store, "model.onnx", maxDocLength: 512, maxQueryLength: 32);
+            var retriever = CreateRetriever(store);
 
             // Act - query tokens don't match but store still returns documents
             var results = retriever.Retrieve("elephant giraffe").ToList();
@@ -338,8 +353,7 @@ namespace AiDotNetTests.UnitTests.RetrievalAugmentedGeneration
                 ("doc1", "The quick brown fox jumps"),
                 ("doc2", "A lazy dog sleeps all day"),
                 ("doc3", "Climate change impacts"));
-            var retriever = new ColBERTRetriever<double>(
-                store, "model.onnx", maxDocLength: 512, maxQueryLength: 32);
+            var retriever = CreateRetriever(store);
 
             // Act
             var results = retriever.Retrieve("quick fox dog").ToList();
@@ -358,8 +372,7 @@ namespace AiDotNetTests.UnitTests.RetrievalAugmentedGeneration
                 ("doc3", "fox three"),
                 ("doc4", "fox four"),
                 ("doc5", "fox five"));
-            var retriever = new ColBERTRetriever<double>(
-                store, "model.onnx", maxDocLength: 512, maxQueryLength: 32);
+            var retriever = CreateRetriever(store);
 
             // Act
             var results = retriever.Retrieve("fox", topK: 3).ToList();
@@ -374,8 +387,7 @@ namespace AiDotNetTests.UnitTests.RetrievalAugmentedGeneration
             // Arrange
             var store = CreateStoreWithDocuments(
                 ("doc1", "The QUICK Brown FOX"));
-            var retriever = new ColBERTRetriever<double>(
-                store, "model.onnx", maxDocLength: 512, maxQueryLength: 32);
+            var retriever = CreateRetriever(store);
 
             // Act
             var results = retriever.Retrieve("quick fox").ToList();
@@ -390,8 +402,7 @@ namespace AiDotNetTests.UnitTests.RetrievalAugmentedGeneration
         {
             // Arrange
             var store = new MockDocumentStore();
-            var retriever = new ColBERTRetriever<double>(
-                store, "model.onnx", maxDocLength: 512, maxQueryLength: 32);
+            var retriever = CreateRetriever(store);
 
             // Act & Assert
             Assert.Throws<ArgumentException>(() =>
@@ -403,8 +414,7 @@ namespace AiDotNetTests.UnitTests.RetrievalAugmentedGeneration
         {
             // Arrange
             var store = new MockDocumentStore();
-            var retriever = new ColBERTRetriever<double>(
-                store, "model.onnx", maxDocLength: 512, maxQueryLength: 32);
+            var retriever = CreateRetriever(store);
 
             // Act & Assert
             Assert.Throws<ArgumentException>(() =>
@@ -416,8 +426,7 @@ namespace AiDotNetTests.UnitTests.RetrievalAugmentedGeneration
         {
             // Arrange
             var store = new MockDocumentStore();
-            var retriever = new ColBERTRetriever<double>(
-                store, "model.onnx", maxDocLength: 512, maxQueryLength: 32);
+            var retriever = CreateRetriever(store);
 
             // Act & Assert
             Assert.Throws<ArgumentException>(() =>
@@ -429,8 +438,7 @@ namespace AiDotNetTests.UnitTests.RetrievalAugmentedGeneration
         {
             // Arrange
             var store = new MockDocumentStore();
-            var retriever = new ColBERTRetriever<double>(
-                store, "model.onnx", maxDocLength: 512, maxQueryLength: 32);
+            var retriever = CreateRetriever(store);
 
             // Act & Assert
             Assert.Throws<ArgumentOutOfRangeException>(() =>
@@ -442,8 +450,7 @@ namespace AiDotNetTests.UnitTests.RetrievalAugmentedGeneration
         {
             // Arrange
             var store = new MockDocumentStore();
-            var retriever = new ColBERTRetriever<double>(
-                store, "model.onnx", maxDocLength: 512, maxQueryLength: 32);
+            var retriever = CreateRetriever(store);
 
             // Act & Assert
             Assert.Throws<ArgumentOutOfRangeException>(() =>
@@ -461,8 +468,7 @@ namespace AiDotNetTests.UnitTests.RetrievalAugmentedGeneration
             var store = CreateStoreWithDocuments(
                 ("doc1", "fox"),
                 ("doc2", "quick brown fox jumps"));
-            var retriever = new ColBERTRetriever<double>(
-                store, "model.onnx", maxDocLength: 512, maxQueryLength: 32);
+            var retriever = CreateRetriever(store);
 
             // Act
             var results = retriever.Retrieve("quick brown fox").ToList();
@@ -479,8 +485,7 @@ namespace AiDotNetTests.UnitTests.RetrievalAugmentedGeneration
             // Arrange
             var store = CreateStoreWithDocuments(
                 ("doc1", "The quick brown fox"));
-            var retriever = new ColBERTRetriever<double>(
-                store, "model.onnx", maxDocLength: 512, maxQueryLength: 32);
+            var retriever = CreateRetriever(store);
 
             // Act
             var results = retriever.Retrieve("fox").ToList();
@@ -496,8 +501,7 @@ namespace AiDotNetTests.UnitTests.RetrievalAugmentedGeneration
             // Arrange
             var store = CreateStoreWithDocuments(
                 ("doc1", "climate change solutions and impacts"));
-            var retriever = new ColBERTRetriever<double>(
-                store, "model.onnx", maxDocLength: 512, maxQueryLength: 32);
+            var retriever = CreateRetriever(store);
 
             // Act
             var results = retriever.Retrieve("climate change solutions").ToList();
@@ -518,8 +522,7 @@ namespace AiDotNetTests.UnitTests.RetrievalAugmentedGeneration
             var store = CreateStoreWithDocumentsAndMetadata(
                 ("doc1", "fox in the forest", new Dictionary<string, object> { { "category", "nature" } }),
                 ("doc2", "fox in the city", new Dictionary<string, object> { { "category", "urban" } }));
-            var retriever = new ColBERTRetriever<double>(
-                store, "model.onnx", maxDocLength: 512, maxQueryLength: 32);
+            var retriever = CreateRetriever(store);
 
             // Act
             var results = retriever.Retrieve("fox", topK: 5,
@@ -536,8 +539,7 @@ namespace AiDotNetTests.UnitTests.RetrievalAugmentedGeneration
             // Arrange
             var store = CreateStoreWithDocumentsAndMetadata(
                 ("doc1", "fox document", new Dictionary<string, object> { { "category", "nature" } }));
-            var retriever = new ColBERTRetriever<double>(
-                store, "model.onnx", maxDocLength: 512, maxQueryLength: 32);
+            var retriever = CreateRetriever(store);
 
             // Act
             var results = retriever.Retrieve("fox", topK: 5,
@@ -554,8 +556,7 @@ namespace AiDotNetTests.UnitTests.RetrievalAugmentedGeneration
             var store = CreateStoreWithDocuments(
                 ("doc1", "fox one"),
                 ("doc2", "fox two"));
-            var retriever = new ColBERTRetriever<double>(
-                store, "model.onnx", maxDocLength: 512, maxQueryLength: 32);
+            var retriever = CreateRetriever(store);
 
             // Act
             var results = retriever.Retrieve("fox", topK: 5,
@@ -571,8 +572,7 @@ namespace AiDotNetTests.UnitTests.RetrievalAugmentedGeneration
             // Arrange
             var store = CreateStoreWithDocuments(
                 ("doc1", "fox document"));
-            var retriever = new ColBERTRetriever<double>(
-                store, "model.onnx", maxDocLength: 512, maxQueryLength: 32);
+            var retriever = CreateRetriever(store);
 
             // Act & Assert - null metadata filters should throw
             Assert.Throws<ArgumentNullException>(() =>
@@ -588,8 +588,7 @@ namespace AiDotNetTests.UnitTests.RetrievalAugmentedGeneration
         {
             // Arrange
             var store = CreateStoreWithDocuments(("doc1", "fox"));
-            var retriever = new ColBERTRetriever<double>(
-                store, "model.onnx", maxDocLength: 512, maxQueryLength: 32);
+            var retriever = CreateRetriever(store);
 
             // Act
             var results = retriever.Retrieve("fox").ToList();
@@ -603,8 +602,7 @@ namespace AiDotNetTests.UnitTests.RetrievalAugmentedGeneration
         {
             // Arrange
             var store = CreateStoreWithDocuments(("doc1", "fox"));
-            var retriever = new ColBERTRetriever<double>(
-                store, "model.onnx", maxDocLength: 512, maxQueryLength: 32);
+            var retriever = CreateRetriever(store);
 
             // Act
             var results = retriever.Retrieve("quick brown fox").ToList();
@@ -619,8 +617,7 @@ namespace AiDotNetTests.UnitTests.RetrievalAugmentedGeneration
             // Arrange
             var longContent = string.Join(" ", Enumerable.Repeat("The quick brown fox jumps over the lazy dog.", 100));
             var store = CreateStoreWithDocuments(("doc1", longContent));
-            var retriever = new ColBERTRetriever<double>(
-                store, "model.onnx", maxDocLength: 50, maxQueryLength: 32);
+            var retriever = CreateRetriever(store, maxDocLength: 50, maxQueryLength: 32);
 
             // Act - document content exceeds maxDocLength
             var results = retriever.Retrieve("fox").ToList();
@@ -635,8 +632,7 @@ namespace AiDotNetTests.UnitTests.RetrievalAugmentedGeneration
         {
             // Arrange
             var store = CreateStoreWithDocuments(("doc1", "The quick brown fox"));
-            var retriever = new ColBERTRetriever<double>(
-                store, "model.onnx", maxDocLength: 512, maxQueryLength: 5);
+            var retriever = CreateRetriever(store, maxDocLength: 512, maxQueryLength: 5);
             var longQuery = "one two three four five six seven eight nine ten";
 
             // Act - query exceeds maxQueryLength
@@ -651,8 +647,7 @@ namespace AiDotNetTests.UnitTests.RetrievalAugmentedGeneration
         {
             // Arrange
             var store = CreateStoreWithDocuments(("doc1", "Hello, world! How are you?"));
-            var retriever = new ColBERTRetriever<double>(
-                store, "model.onnx", maxDocLength: 512, maxQueryLength: 32);
+            var retriever = CreateRetriever(store);
 
             // Act
             var results = retriever.Retrieve("hello world").ToList();
@@ -667,8 +662,7 @@ namespace AiDotNetTests.UnitTests.RetrievalAugmentedGeneration
             // Arrange
             var store = CreateStoreWithDocuments(
                 ("doc1", "Hello, world! Welcome to the test."));
-            var retriever = new ColBERTRetriever<double>(
-                store, "model.onnx", maxDocLength: 512, maxQueryLength: 32);
+            var retriever = CreateRetriever(store);
 
             // Act - should match "hello" and "world" despite punctuation
             var results = retriever.Retrieve("hello world test").ToList();
@@ -684,8 +678,7 @@ namespace AiDotNetTests.UnitTests.RetrievalAugmentedGeneration
             var store = CreateStoreWithDocuments(
                 ("doc1", "The quick brown fox"),
                 ("doc2", "A lazy dog"));
-            var retriever = new ColBERTRetriever<double>(
-                store, "model.onnx", maxDocLength: 512, maxQueryLength: 32);
+            var retriever = CreateRetriever(store);
 
             // Act
             var results1 = retriever.Retrieve("fox").ToList();
@@ -706,8 +699,7 @@ namespace AiDotNetTests.UnitTests.RetrievalAugmentedGeneration
             var store = CreateStoreWithDocuments(
                 ("doc1", "fox one"),
                 ("doc2", "fox two"));
-            var retriever = new ColBERTRetriever<double>(
-                store, "model.onnx", maxDocLength: 512, maxQueryLength: 32);
+            var retriever = CreateRetriever(store);
 
             // Act
             var results = retriever.Retrieve("fox", topK: 100).ToList();
@@ -722,8 +714,7 @@ namespace AiDotNetTests.UnitTests.RetrievalAugmentedGeneration
             // Arrange
             var store = CreateStoreWithDocuments(
                 ("doc1", "Line one\nLine two\nLine three"));
-            var retriever = new ColBERTRetriever<double>(
-                store, "model.onnx", maxDocLength: 512, maxQueryLength: 32);
+            var retriever = CreateRetriever(store);
 
             // Act
             var results = retriever.Retrieve("line one two").ToList();
@@ -738,8 +729,7 @@ namespace AiDotNetTests.UnitTests.RetrievalAugmentedGeneration
             // Arrange
             var store = CreateStoreWithDocuments(
                 ("doc1", "Column1\tColumn2\tColumn3"));
-            var retriever = new ColBERTRetriever<double>(
-                store, "model.onnx", maxDocLength: 512, maxQueryLength: 32);
+            var retriever = CreateRetriever(store);
 
             // Act
             var results = retriever.Retrieve("column1 column2").ToList();
@@ -758,8 +748,7 @@ namespace AiDotNetTests.UnitTests.RetrievalAugmentedGeneration
             // Arrange
             var store = CreateStoreWithDocuments(
                 ("doc1", "one two three four five six seven eight nine ten"));
-            var retriever = new ColBERTRetriever<double>(
-                store, "model.onnx", maxDocLength: 512, maxQueryLength: 3);
+            var retriever = CreateRetriever(store, maxDocLength: 512, maxQueryLength: 3);
 
             // Act - only first 3 tokens should be used
             var results = retriever.Retrieve("one two three four five").ToList();
@@ -773,8 +762,7 @@ namespace AiDotNetTests.UnitTests.RetrievalAugmentedGeneration
         {
             // Arrange
             var store = CreateStoreWithDocuments(("doc1", "fox"));
-            var retriever = new ColBERTRetriever<double>(
-                store, "model.onnx", maxDocLength: 512, maxQueryLength: 1);
+            var retriever = CreateRetriever(store, maxDocLength: 512, maxQueryLength: 1);
 
             // Act
             var results = retriever.Retrieve("fox jumps high").ToList();
@@ -789,8 +777,7 @@ namespace AiDotNetTests.UnitTests.RetrievalAugmentedGeneration
             // Arrange
             var store = CreateStoreWithDocuments(
                 ("doc1", "the quick brown fox jumps over lazy dog"));
-            var retriever = new ColBERTRetriever<double>(
-                store, "model.onnx", maxDocLength: 3, maxQueryLength: 32);
+            var retriever = CreateRetriever(store, maxDocLength: 3, maxQueryLength: 32);
 
             // Act - document truncated to 3 tokens
             var results = retriever.Retrieve("the quick brown").ToList();

--- a/tests/AiDotNet.Tests/UnitTests/RetrievalAugmentedGeneration/Retrievers/AdvancedRetrieverTests.cs
+++ b/tests/AiDotNet.Tests/UnitTests/RetrievalAugmentedGeneration/Retrievers/AdvancedRetrieverTests.cs
@@ -382,8 +382,14 @@ namespace AiDotNetTests.UnitTests.RetrievalAugmentedGeneration.Retrievers
         [Fact(Timeout = 60000)]
         public async Task Retrieve_WithEmptyDocumentStore_ReturnsEmptyResults()
         {
-            // Arrange
-            var retriever = new ColBERTRetriever<double>(_documentStore, "model.onnx", 512, 32);
+            // Arrange — pass a deterministic embedder so RetrieveCore takes the
+            // scoring path (it throws NotSupportedException when no embedder is
+            // supplied; ColBERT has no defensible lexical fallback per the
+            // class doc). HashColBertEmbedder isn't needed here because the
+            // store is empty, but the constructor surface still requires one.
+            var retriever = new ColBERTRetriever<double>(
+                _documentStore, "model.onnx", 512, 32,
+                embedder: new TestColBertEmbedder<double>());
 
             // Act
             var results = retriever.Retrieve("test query");

--- a/tests/AiDotNet.Tests/UnitTests/RetrievalAugmentedGeneration/TestColBertEmbedder.cs
+++ b/tests/AiDotNet.Tests/UnitTests/RetrievalAugmentedGeneration/TestColBertEmbedder.cs
@@ -1,0 +1,67 @@
+using System;
+using System.Security.Cryptography;
+using System.Text;
+using AiDotNet.Helpers;
+using AiDotNet.RetrievalAugmentedGeneration.Retrievers;
+using AiDotNet.Tensors.LinearAlgebra;
+
+namespace AiDotNetTests.UnitTests.RetrievalAugmentedGeneration;
+
+/// <summary>
+/// Deterministic <see cref="IColBertEmbedder{T}"/> for unit tests.
+/// Splits text on whitespace, lower-cases each token, hashes it with SHA-256,
+/// maps the first 32 hash bytes to a signed-unit-vector slot, and L2-normalises.
+/// Identical (case-folded) tokens produce identical unit vectors — cosine
+/// similarity = 1.0, the perfect MaxSim score per
+/// <c>Σ_q max_d cos(E_q, E_d)</c> — while non-identical tokens produce
+/// near-orthogonal vectors (cosine ≈ 0).
+/// </summary>
+/// <remarks>
+/// <para>
+/// Required because <see cref="ColBERTRetriever{T}.RetrieveCore"/> throws
+/// <see cref="NotSupportedException"/> when constructed without an embedder
+/// (ColBERT has no defensible lexical-overlap fallback per the class doc;
+/// the entire architecture is the token-level contextual representation).
+/// Unit tests run without an ONNX checkpoint, so they wire this in instead.
+/// </para>
+/// </remarks>
+internal sealed class TestColBertEmbedder<T> : IColBertEmbedder<T>
+{
+    private const int EmbedDim = 32;
+
+    public Tensor<T> EmbedQuery(string query) => Embed(query);
+    public Tensor<T> EmbedDocument(string document) => Embed(document);
+
+    private static Tensor<T> Embed(string text)
+    {
+        var numOps = MathHelper.GetNumericOperations<T>();
+        var tokens = (text ?? string.Empty).Split(
+            new[] { ' ', '\t', '\n', '\r' },
+            StringSplitOptions.RemoveEmptyEntries);
+        if (tokens.Length == 0) tokens = new[] { string.Empty };
+        var result = new Tensor<T>(new[] { tokens.Length, EmbedDim });
+        using var sha = SHA256.Create();
+        for (int t = 0; t < tokens.Length; t++)
+        {
+            var lower = tokens[t].ToLowerInvariant();
+            var bytes = Encoding.UTF8.GetBytes(lower);
+            var hash = sha.ComputeHash(bytes);
+            double sumSq = 0.0;
+            for (int d = 0; d < EmbedDim; d++)
+            {
+                double v = ((sbyte)hash[d % hash.Length]) / 127.0;
+                result[t, d] = numOps.FromDouble(v);
+                sumSq += v * v;
+            }
+            double norm = Math.Sqrt(sumSq);
+            if (norm > 0)
+            {
+                double invNorm = 1.0 / norm;
+                for (int d = 0; d < EmbedDim; d++)
+                    result[t, d] = numOps.FromDouble(
+                        numOps.ToDouble(result[t, d]) * invNorm);
+            }
+        }
+        return result;
+    }
+}


### PR DESCRIPTION
## Summary

- Adds a deterministic SHA-256-based `TestColBertEmbedder<T>` for unit tests.
- Wires it into every `Retrieve_*` test in `ColBERTRetrieverTests` (via a `CreateRetriever` helper) and the one `Retrieve_*` test in `AdvancedRetrieverTests`' ColBERT section.
- Result: 49/49 `ColBERTRetrieverTests` pass (was 23/49 before — 26 were failing on the embedder-required exception).

## Why

`ColBERTRetriever.RetrieveCore` intentionally throws `NotSupportedException` when constructed without an `IColBertEmbedder<T>` — the class doc rejects a lexical fallback because "the entire architecture is the token-level contextual representation" and a silent fallback would diverge from the paper's relevance signal. The unit tests, however, were constructing the retriever without an embedder and then calling `Retrieve()`, hitting the exception on every scoring-path test.

The fix is on the **test side**, not production code: production callers must still supply a real ColBERT/ColBERTv2/PLAID embedder. The new `TestColBertEmbedder<T>` is in the test assembly and uses a deterministic hash → unit-vector mapping so identical (case-folded) tokens get cosine similarity = 1.0 (perfect MaxSim) and distinct tokens get cosine ≈ 0. This lets the real MaxSim scoring path execute end-to-end without an ONNX checkpoint.

Addresses **cluster 3** of #1332 ("ColBERTRetrieverTests — ~15 tests").

## Test plan

- [x] `dotnet test --filter "FullyQualifiedName~ColBERTRetrieverTests"` — 49/49 pass.
- [x] Constructor-validation tests (null docstore, null modelPath, zero/negative maxLength) keep their pre-existing direct `new` constructor calls — they exercise the constructor surface and throw before reaching the embedder check, so adding the embedder there would be churn.
- [x] Solution builds clean: `dotnet build AiDotNet.sln -c Release` → 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced testing infrastructure for the retrieval system with improved test utilities
  * Refactored unit tests to consolidate common setup logic, improving maintainability and reducing code duplication across multiple test scenarios

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ooples/AiDotNet/pull/1336?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->