### PR TITLE
fix(#1332 cluster 5): derive ContinualLearningTestBase.NumParameters from the actual network

### DIFF
--- a/tests/AiDotNet.Tests/ModelFamilyTests/Base/ContinualLearningTestBase.cs
+++ b/tests/AiDotNet.Tests/ModelFamilyTests/Base/ContinualLearningTestBase.cs
@@ -55,11 +55,21 @@ public abstract class ContinualLearningTestBase
         get
         {
             if (_cachedNumParameters is { } v) return v;
-            using var probeNet = CreateMockNetwork() as IDisposable;
-            var net = probeNet as INeuralNetwork<double> ?? CreateMockNetwork();
-            int count = net.GetParameters().Length;
-            _cachedNumParameters = count;
-            return count;
+            // Construct the probe network exactly once. The prior shape
+            // (CreateMockNetwork() ?? CreateMockNetwork()) called the
+            // factory twice on a cache miss — wasted work and risky for
+            // overrides whose factory does side-effectful setup (RNG
+            // advancement, lazy allocation, etc.).
+            var probe = CreateMockNetwork();
+            try
+            {
+                _cachedNumParameters = probe.GetParameters().Length;
+                return _cachedNumParameters.Value;
+            }
+            finally
+            {
+                (probe as IDisposable)?.Dispose();
+            }
         }
     }
 

--- a/tests/AiDotNet.Tests/ModelFamilyTests/Base/ContinualLearningTestBase.cs
+++ b/tests/AiDotNet.Tests/ModelFamilyTests/Base/ContinualLearningTestBase.cs
@@ -31,8 +31,37 @@ public abstract class ContinualLearningTestBase
             outputSize: 4));
     }
 
-    /// <summary>Number of model parameters for test data generation.</summary>
-    protected virtual int NumParameters => 10;
+    /// <summary>
+    /// Number of trainable parameters in the network returned by
+    /// <see cref="CreateMockNetwork"/>. Derived from an actual network instance
+    /// so synthetic gradient vectors produced in test bodies have the SAME
+    /// length the continual-learning strategy is going to operate on.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Hardcoding this to a small literal (the prior <c>=> 10</c> default) made
+    /// every strategy whose <c>ModifyGradients</c> path actually computes a
+    /// reference gradient on the live network (e.g. AveragedGEM, GEM,
+    /// SynapticIntelligence) throw on dimension-mismatch dot products — the
+    /// freshly computed reference gradient has the network's true parameter
+    /// count (4740 for the default 4→4 FFN), not the literal 10. Mirroring the
+    /// network's parameter count is the only correct shape for any test that
+    /// feeds a synthetic gradient into <c>strategy.ModifyGradients</c>.
+    /// </para>
+    /// </remarks>
+    private int? _cachedNumParameters;
+    protected virtual int NumParameters
+    {
+        get
+        {
+            if (_cachedNumParameters is { } v) return v;
+            using var probeNet = CreateMockNetwork() as IDisposable;
+            var net = probeNet as INeuralNetwork<double> ?? CreateMockNetwork();
+            int count = net.GetParameters().Length;
+            _cachedNumParameters = count;
+            return count;
+        }
+    }
 
     // AccumulatesAcrossTasks is checked via the IContinualLearningStrategy<T> interface property.
 


### PR DESCRIPTION
## Summary

- Fixes the 3 failing `AveragedGEMTests` (`ModifyGradients_AreFinite`, `ModifyGradients_DoesNotIncreaseNorm`, `ModifyGradients_PreservesLength`) by aligning `ContinualLearningTestBase.NumParameters` with the actual mock-network parameter count.

## Why

`AveragedGEM.ModifyGradients(network, gradients)` calls `network.ComputeGradients(memInputs, memTargets)` internally to get the reference gradient, then does a dot product:

```
var dotProduct = VectorHelper.DotProduct(gradients, refGradient);
```

The test base was constructing synthetic `gradients` of length 10 (the hardcoded `NumParameters => 10` default) while the mock 4→4 FFN's `ComputeGradients` returned a 4740-element reference gradient — `DotProduct(10, 4740)` threw `ArgumentException: Vectors must have the same length for dot product`. The same root cause hit any strategy whose `ModifyGradients` actually computes a live reference gradient (AveragedGEM, GEM, SynapticIntelligence).

The algorithm contract requires `gradients` and `refGradient` to share the same parameter dimension (they're for the same network). The fix is on the **test side**: probe `CreateMockNetwork().GetParameters().Length` once and cache it. The property stays `virtual` so individual test bases can still override.

Addresses **cluster 5** of #1332.

## Test plan

- [x] `AveragedGEMTests` — 10/10 pass (was 7/10).
- [x] All `~ContinualLearning&~ModifyGradients` tests — 28/28 pass.
- [x] No regression: the 14 still-failing tests in `ContinualLearningDeepMathIntegrationTests` are in a standalone class that doesn't extend `ContinualLearningTestBase` — pre-existing EWC-integration failures unrelated to this fix.
- [x] Build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved test robustness by computing model parameter counts dynamically (instead of a hardcoded value) and caching the result to avoid repeated setup, reducing risk of dimension mismatches in synthetic test data.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ooples/AiDotNet/pull/1337?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->