### PR TITLE
fix(#1332 cluster 4): preprocess Train input to MaxSequenceLength in BiLSTMCRF / CNNBiLSTMCRF

### DIFF
--- a/src/NER/SequenceLabeling/BiLSTMCRF.cs
+++ b/src/NER/SequenceLabeling/BiLSTMCRF.cs
@@ -811,7 +811,22 @@ public class BiLSTMCRF<T> : SequenceLabelingNERBase<T>, INERModel<T>
         SetTrainingMode(true);
         try
         {
-            TrainWithTape(input, expected);
+            // Pad/truncate inputs and labels to MaxSequenceLength before the
+            // tape forward — the ConditionalRandomFieldLayer locks its
+            // internal Viterbi/transition buffers to the sequence length seen
+            // on construction (default MaxSequenceLength = 256), and the
+            // PredictLabels / PredictBatch paths already preprocess for that
+            // contract. The training path previously fed the raw input shape
+            // straight through, which exploded with
+            // "ConditionalRandomFieldLayer's sequence length mismatch" the
+            // moment any caller supplied a shorter sequence than the
+            // configured MaxSequenceLength.
+            var preprocessedInput = PreprocessTokens(input);
+            int targetSeqLen = preprocessedInput.Rank == 3
+                ? preprocessedInput.Shape[1]
+                : preprocessedInput.Shape[0];
+            var preprocessedExpected = PreprocessLabels(expected, targetSeqLen);
+            TrainWithTape(preprocessedInput, preprocessedExpected);
         }
         finally
         {

--- a/src/NER/SequenceLabeling/BiLSTMCRF.cs
+++ b/src/NER/SequenceLabeling/BiLSTMCRF.cs
@@ -565,7 +565,16 @@ public class BiLSTMCRF<T> : SequenceLabelingNERBase<T>, INERModel<T>
                 try
                 {
                     var preprocessed = PreprocessTokens(tokenEmbeddings);
-                    var preprocessedLabels = PreprocessLabels(labels, preprocessed.Shape[0]);
+                    // Rank-aware seq-len lookup — for rank-3 batched inputs
+                    // [batch, seq, embed] Shape[0] is the batch size, not
+                    // the sequence length, and PreprocessLabels then sized
+                    // labels to the batch count and the CRF layer's
+                    // sequence-length contract was violated. Mirror Train's
+                    // logic so async and sync paths agree.
+                    int targetSeqLen = preprocessed.Rank == 3
+                        ? preprocessed.Shape[1]
+                        : preprocessed.Shape[0];
+                    var preprocessedLabels = PreprocessLabels(labels, targetSeqLen);
                     var output = Forward(preprocessed);
                     double loss = NumOps.ToDouble(LossFunction.CalculateLoss(
                         output.ToVector(), preprocessedLabels.ToVector()));

--- a/src/NER/SequenceLabeling/CNNBiLSTMCRF.cs
+++ b/src/NER/SequenceLabeling/CNNBiLSTMCRF.cs
@@ -379,7 +379,18 @@ public class CNNBiLSTMCRF<T> : SequenceLabelingNERBase<T>, INERModel<T>
         if (IsOnnxMode) throw new NotSupportedException("Training is not supported in ONNX mode.");
         if (_optimizer is null) throw new InvalidOperationException("Optimizer is not initialized.");
         SetTrainingMode(true);
-        try { TrainWithTape(input, expected); }
+        try
+        {
+            // Mirror PredictLabels' preprocessing into Train so the CRF
+            // layer sees the locked sequence length it was constructed with
+            // (see BiLSTMCRF.Train for the longer-form rationale).
+            var preprocessedInput = PreprocessTokens(input);
+            int targetSeqLen = preprocessedInput.Rank == 3
+                ? preprocessedInput.Shape[1]
+                : preprocessedInput.Shape[0];
+            var preprocessedExpected = PreprocessLabels(expected, targetSeqLen);
+            TrainWithTape(preprocessedInput, preprocessedExpected);
+        }
         finally { SetTrainingMode(false); }
     }
 

--- a/src/NER/SequenceLabeling/CNNBiLSTMCRF.cs
+++ b/src/NER/SequenceLabeling/CNNBiLSTMCRF.cs
@@ -262,7 +262,15 @@ public class CNNBiLSTMCRF<T> : SequenceLabelingNERBase<T>, INERModel<T>
                 try
                 {
                     var preprocessed = PreprocessTokens(tokenEmbeddings);
-                    var preprocessedLabels = PreprocessLabels(labels, preprocessed.Shape[0]);
+                    // Rank-aware seq-len lookup, mirroring Train. Shape[0]
+                    // is the batch size for rank-3 inputs and labels were
+                    // being sized to the batch count, violating the CRF
+                    // layer's sequence-length contract. See BiLSTMCRF.Train
+                    // for the full rationale.
+                    int targetSeqLen = preprocessed.Rank == 3
+                        ? preprocessed.Shape[1]
+                        : preprocessed.Shape[0];
+                    var preprocessedLabels = PreprocessLabels(labels, targetSeqLen);
                     var output = Forward(preprocessed);
                     double loss = NumOps.ToDouble(LossFunction.CalculateLoss(
                         output.ToVector(), preprocessedLabels.ToVector()));


### PR DESCRIPTION
## Summary

- BiLSTMCRFTests + CNNBiLSTMCRFTests: **18 failed / 36 passed** (was **28 failed / 26 passed**) — 10 newly-passing tests.
- Single root cause for the catastrophic CRF sequence-length mismatch that was blocking every Train-exercising invariant.

## Why

`ConditionalRandomFieldLayer` locks its internal sequence-length on construction (Viterbi decoding, transitions buffer, and gradient reshape are all sized to `_sequenceLength`) and throws

> System.ArgumentException : ConditionalRandomFieldLayer's sequence length mismatch: layer was resolved with sequenceLength=256, but this input's sequence dimension is 8.

the moment any caller supplies a different sequence length. The `PredictLabels` / `PredictBatch` paths already preprocess input via `PreprocessTokens` (pad/truncate to `MaxSequenceLength`) — documented as part of the contract since the CRF needs to know the sequence length in advance. But the `Train` method was calling `TrainWithTape` directly on the raw input, bypassing preprocessing. Same regression in `CNNBiLSTMCRF`.

## Fix

In both `BiLSTMCRF.Train` and `CNNBiLSTMCRF.Train`:
1. Pad/truncate input via `PreprocessTokens` (existing private method).
2. Pad/truncate labels via `PreprocessLabels(..., targetSeqLen)` to match.
3. Pass the preprocessed pair to `TrainWithTape`.

Mirrors the existing `PredictLabels` contract.

## Remaining work

18 failures are deeper issues that need per-test investigation and aren't trivially related to this sequence-length blocker:
- `Training_ShouldReduceLoss` (loss goes up not down — optimizer/init issue)
- `Training_ShouldChangeParameters` (likely related)
- `Clone_*` (`SetParameters` byte-offset misalignment in serialized CRF — `Expected 8 parameters, but got 99` suggests the Clone-deserialize path doesn't track `_numClasses` correctly)
- `MoreData_ShouldNotDegrade`, `LossStrictlyDecreasesOnMemorizationTask`, `DifferentInputs_AfterTraining_ShouldProduceDifferentOutputs`, `GradientFlow_ShouldBeNonZeroAndFinite`, `NamedLayerActivations_ShouldBeNonEmpty`, `SequenceLabeling_ShouldBeDeterministic`

These each warrant a focused fix; tracked as follow-up on #1332 cluster 4.

## Test plan

- [x] `dotnet test --filter "FullyQualifiedName~BiLSTMCRFTests"` — 36 passed / 18 failed (was 26 passed / 28 failed)
- [x] Solution builds clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed sequence-length mismatch errors during training by ensuring inputs and labels are preprocessed and aligned to the actual token sequence length for both synchronous and asynchronous training paths.
  * Applies to sequence-labeling training so shorter-than-configured sequences no longer cause training failures.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ooples/AiDotNet/pull/1339?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->