### PR TITLE
test(transformer): regression coverage for flashattentionlayer drop-in custom-layer stack

### DIFF
--- a/tests/AiDotNet.Tests/IntegrationTests/NeuralNetworks/TransformerCustomLayerValidationIssue1317IntegrationTests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/NeuralNetworks/TransformerCustomLayerValidationIssue1317IntegrationTests.cs
@@ -222,10 +222,10 @@ public class TransformerCustomLayerValidationIssue1317IntegrationTests
             new EmbeddingLayer<float>(vocab, dModel),
             new FlashAttentionLayer<float>(seqLen, dModel, heads),
             new LayerNormalizationLayer<float>(),
-            new DenseLayer<float>(dModel, new ReLUActivation<float>() as IActivationFunction<float>),
+            new DenseLayer<float>(dModel, new ReLUActivation<float>()),
             new LayerNormalizationLayer<float>(),
             new SequenceTokenSliceLayer<float>(SequenceTokenSliceLayer<float>.Position.Last),
-            new DenseLayer<float>(vocab, new IdentityActivation<float>() as IActivationFunction<float>)
+            new DenseLayer<float>(vocab, new IdentityActivation<float>())
         };
 
         var arch = new TransformerArchitecture<float>(

--- a/tests/AiDotNet.Tests/IntegrationTests/NeuralNetworks/TransformerCustomLayerValidationIssue1317IntegrationTests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/NeuralNetworks/TransformerCustomLayerValidationIssue1317IntegrationTests.cs
@@ -222,10 +222,10 @@ public class TransformerCustomLayerValidationIssue1317IntegrationTests
             new EmbeddingLayer<float>(vocab, dModel),
             new FlashAttentionLayer<float>(seqLen, dModel, heads),
             new LayerNormalizationLayer<float>(),
-            new DenseLayer<float>(dModel, new ReLUActivation<float>()),
+            new DenseLayer<float>(dModel, (IActivationFunction<float>)new ReLUActivation<float>()),
             new LayerNormalizationLayer<float>(),
             new SequenceTokenSliceLayer<float>(SequenceTokenSliceLayer<float>.Position.Last),
-            new DenseLayer<float>(vocab, new IdentityActivation<float>())
+            new DenseLayer<float>(vocab, (IActivationFunction<float>)new IdentityActivation<float>())
         };
 
         var arch = new TransformerArchitecture<float>(

--- a/tests/AiDotNet.Tests/IntegrationTests/NeuralNetworks/TransformerCustomLayerValidationIssue1317IntegrationTests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/NeuralNetworks/TransformerCustomLayerValidationIssue1317IntegrationTests.cs
@@ -1,3 +1,4 @@
+using AiDotNet.ActivationFunctions;
 using AiDotNet.Enums;
 using AiDotNet.Interfaces;
 using AiDotNet.NeuralNetworks;
@@ -197,6 +198,79 @@ public class TransformerCustomLayerValidationIssue1317IntegrationTests
 
         Assert.Contains(model.Layers, layer => layer is MultiHeadAttentionLayer<float>);
         Assert.Contains(model.Layers, layer => layer is LayerNormalizationLayer<float>);
+    }
+
+    [Fact]
+    public void CustomTransformerLayerStack_AcceptsFlashAttentionLayerAsDropInReplacement()
+    {
+        // Regression coverage: FlashAttentionLayer is documented as a drop-in
+        // replacement for MultiHeadAttentionLayer ("FlashAttentionLayer provides
+        // the same functionality as MultiHeadAttentionLayer but uses the Flash
+        // Attention algorithm which is 2-4x faster and uses significantly less
+        // memory. It can be used as a drop-in replacement in transformer
+        // architectures.") The relaxed ValidateCustomLayers contract (#1317 /
+        // #1320) accepts shape-compatible layer stacks; this test pins down
+        // that the type-based "must include MultiHeadAttentionLayer" check is
+        // gone for good and FlashAttention specifically rides the same path.
+        const int seqLen = 16;
+        const int dModel = 16;
+        const int heads = 2;
+        const int vocab = 256;
+
+        var layers = new List<ILayer<float>>
+        {
+            new EmbeddingLayer<float>(vocab, dModel),
+            new FlashAttentionLayer<float>(seqLen, dModel, heads),
+            new LayerNormalizationLayer<float>(),
+            new DenseLayer<float>(dModel, new ReLUActivation<float>() as IActivationFunction<float>),
+            new LayerNormalizationLayer<float>(),
+            new SequenceTokenSliceLayer<float>(SequenceTokenSliceLayer<float>.Position.Last),
+            new DenseLayer<float>(vocab, new IdentityActivation<float>() as IActivationFunction<float>)
+        };
+
+        var arch = new TransformerArchitecture<float>(
+            inputType: InputType.TwoDimensional,
+            taskType: NeuralNetworkTaskType.SequenceClassification,
+            numEncoderLayers: 1,
+            numDecoderLayers: 0,
+            numHeads: heads,
+            modelDimension: dModel,
+            feedForwardDimension: dModel,
+            complexity: NetworkComplexity.Medium,
+            inputSize: seqLen,
+            outputSize: vocab,
+            dropoutRate: 0.0,
+            maxSequenceLength: seqLen,
+            vocabularySize: vocab,
+            usePositionalEncoding: true,
+            temperature: 1.0,
+            sequencePooling: null,
+            layers: layers);
+
+        var model = new Transformer<float>(arch);
+
+        Assert.Contains(model.Layers, layer => layer is FlashAttentionLayer<float>);
+        Assert.DoesNotContain(model.Layers, layer => layer is MultiHeadAttentionLayer<float>);
+    }
+
+    [Fact]
+    public void CustomTransformerArchitecture_WithoutAnyAttentionLayer_StillPassesValidation()
+    {
+        // The validator contract is shape-based, not type-based — a research
+        // architecture that replaces attention with, e.g., an SSM/MLP-only
+        // stack must be accepted as long as the shapes line up. This test
+        // pins down that no concrete-attention-type requirement leaks back
+        // in.
+        var layers = new List<ILayer<float>>
+        {
+            new ProjectingCustomLayer([1, 16], [1, 32]),
+            new ProjectingCustomLayer([32], [1, 256])
+        };
+
+        var model = new Transformer<float>(CreateCustomLayerArchitecture(layers));
+
+        Assert.DoesNotContain(model.Layers, layer => layer is MultiHeadAttentionLayer<float>);
+        Assert.DoesNotContain(model.Layers, layer => layer is FlashAttentionLayer<float>);
     }
 
     private static TransformerArchitecture<float> CreateCustomLayerArchitecture(List<ILayer<float>> layers)


### PR DESCRIPTION
## Context

PR #1320 (closes #1317) relaxed `Transformer<T>.ValidateCustomLayers` from a type-based check (\"must include `MultiHeadAttentionLayer<T>`\") to a shape-based check (validates only that custom layer shapes line up). The existing #1317 integration coverage uses a `ProjectingCustomLayer` mock — it pins down the contract abstractly but doesn't actually exercise a real production attention layer that should ride the same path.

`FlashAttentionLayer<T>` is documented as a drop-in replacement for `MultiHeadAttentionLayer<T>`:

> FlashAttentionLayer provides the same functionality as MultiHeadAttentionLayer but uses the Flash Attention algorithm which is 2-4x faster and uses significantly less memory. It can be used as a drop-in replacement in transformer architectures.

But there was no regression test pinning that down. This PR adds two integration tests to `TransformerCustomLayerValidationIssue1317IntegrationTests`:

1. **`CustomTransformerLayerStack_AcceptsFlashAttentionLayerAsDropInReplacement`** — builds a real Transformer with `EmbeddingLayer` + `FlashAttentionLayer` + `LayerNormalizationLayer` + `DenseLayer` + readout, constructs the model, and asserts `FlashAttentionLayer<float>` is present in `model.Layers` and `MultiHeadAttentionLayer<float>` is not.

2. **`CustomTransformerArchitecture_WithoutAnyAttentionLayer_StillPassesValidation`** — pins down that an MLP-only stack (no attention layer of ANY concrete type) passes the validator. The validator contract is shape-based, not type-based; this guards against a future regression where someone re-introduces a type-based requirement.

## Why this matters

A downstream consumer (HarmonicEngine PAPER-A Path B) needs to swap `MultiHeadAttentionLayer` for `FlashAttentionLayer` to scale to longer contexts (FlashAttention is O(N) activation memory vs O(N²) softmax). Without #1320 the swap would throw on construction; with #1320 it works, but the regression-coverage gap meant a future tightening of the validator could re-break the path without CI catching it. These two tests close that gap.

## Scope

Tests-only. No production-code changes. Mirrors the existing test pattern in `TransformerCustomLayerValidationIssue1317IntegrationTests.cs`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added integration tests validating that custom transformer architectures properly support FlashAttentionLayer as a drop-in replacement and pass validation without attention layers.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ooples/AiDotNet/pull/1343?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->