### PR TITLE
test(#1341): regression test for GradientCheckpointing shape mismatch on Transformer<T>

### DIFF
--- a/tests/AiDotNet.Tests/IntegrationTests/Training/GradientCheckpointingTransformerIssue1341Tests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/Training/GradientCheckpointingTransformerIssue1341Tests.cs
@@ -160,7 +160,12 @@ public class GradientCheckpointingTransformerIssue1341Tests
             var target = new Tensor<float>(new[] { 1, vocabSize });
             target[0, rng.Next(vocabSize)] = 1.0f;
 
-            transformer.Train(input, target);
+            // Use Record.Exception (same pattern as the sibling test at
+            // line ~103) so an unexpected throw produces a clearly
+            // attributed assertion failure instead of bubbling up as a
+            // raw exception that hides which step failed.
+            var ex = Record.Exception(() => transformer.Train(input, target));
+            Assert.Null(ex);
             var lastLoss = transformer.GetLastLoss();
             Assert.True(!float.IsNaN(lastLoss) && !float.IsInfinity(lastLoss),
                 $"step={step}: LastLoss must be finite, was {lastLoss}");

--- a/tests/AiDotNet.Tests/IntegrationTests/Training/GradientCheckpointingTransformerIssue1341Tests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/Training/GradientCheckpointingTransformerIssue1341Tests.cs
@@ -1,0 +1,171 @@
+using System;
+using AiDotNet.Enums;
+using AiDotNet.LossFunctions;
+using AiDotNet.NeuralNetworks;
+using AiDotNet.Tensors.Helpers;
+using AiDotNet.Tensors.LinearAlgebra;
+using AiDotNet.Training.Memory;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace AiDotNetTests.IntegrationTests.Training;
+
+/// <summary>
+/// Regression tests for AiDotNet#1341: <c>GradientCheckpointing&lt;T&gt;.Checkpoint</c>
+/// backward closure was computing the inner-tape gradient with an implicit
+/// ones-seed (treating the segment output as if it were the scalar loss) and
+/// then attempting to chain-rule via an elementwise <c>TensorMultiply</c>
+/// against <c>gradOutput</c>. That product can only succeed when the segment
+/// is a shape-preserving elementwise op; on a real Transformer the head-side
+/// gradient <c>[B, V]</c> meets an encoder-segment output of <c>[B, L, D]</c>
+/// and the broadcast fails with <c>ArgumentException</c>:
+///
+/// <para><i>"Tensors with shapes [1, 256] and [1, 64, 128] cannot be broadcast:
+/// dimension 2 has sizes 256 and 128 (must be equal or one must be 1)."</i></para>
+///
+/// <para>The fix re-seeds the inner tape with a scalar pseudo-loss
+/// <c>sum(reOutput * gradOutput)</c>, so the inner backward produces the
+/// proper VJP <c>d(reOutput)/d(reInput)^T @ gradOutput</c> regardless of
+/// whether the segment changes shape.</para>
+/// </summary>
+public class GradientCheckpointingTransformerIssue1341Tests
+{
+    private readonly ITestOutputHelper _output;
+
+    public GradientCheckpointingTransformerIssue1341Tests(ITestOutputHelper output)
+    {
+        _output = output;
+    }
+
+    /// <summary>
+    /// Exact configuration reported in the issue: 2-layer encoder, dModel=128,
+    /// dFf=256, ctxLen=64, vocab=256, per-sample Train, AdamOptimizer,
+    /// CategoricalCrossEntropyLoss, ForTransformers() preset (segment size 1
+    /// across attention + residual blocks).
+    /// </summary>
+    /// <remarks>
+    /// Skipped until the paired AiDotNet.Tensors PR
+    /// (https://github.com/ooples/AiDotNet.Tensors/pull/361) merges and the
+    /// new Tensors NuGet is published. Bump
+    /// <c>Directory.Packages.props</c>'s AiDotNet.Tensors version and remove
+    /// the Skip attribute once the upstream fix is consumable.
+    /// </remarks>
+    [Fact(Skip = "Blocked on ooples/AiDotNet.Tensors#361 — GradientCheckpointing vjp seeding fix. Un-skip after the Tensors NuGet that includes the fix is referenced in Directory.Packages.props.")]
+    public void Transformer_Train_with_ForTransformers_checkpointing_does_not_throw_on_shape_mismatch()
+    {
+        const int vocabSize = 256;
+        const int dModel = 128;
+        const int dFf = 256;
+        const int ctxLen = 64;
+        const int heads = 2;
+        const int layers = 2;
+        const int outputSize = vocabSize;
+
+        var architecture = new TransformerArchitecture<float>(
+            inputType: InputType.TwoDimensional,
+            taskType: NeuralNetworkTaskType.SequenceClassification,
+            numEncoderLayers: layers,
+            numDecoderLayers: 0,
+            numHeads: heads,
+            modelDimension: dModel,
+            feedForwardDimension: dFf,
+            inputSize: ctxLen,
+            outputSize: outputSize,
+            maxSequenceLength: ctxLen,
+            vocabularySize: vocabSize);
+
+        var transformer = new Transformer<float>(
+            architecture,
+            lossFunction: new CategoricalCrossEntropyLoss<float>());
+
+        // Enable the memory-management preset that turns on per-block
+        // checkpointing for attention + residual segments. Before the fix
+        // for #1341, the first call to Train() below throws inside the
+        // Checkpoint backward closure when the head's [B, V] gradient
+        // meets an encoder segment output of [B, L, D].
+        transformer.EnableMemoryManagement(TrainingMemoryConfig.ForTransformers());
+
+        var rng = RandomHelper.CreateSeededRandom(0);
+
+        // Per-sample shapes that reproduce the issue exactly: input
+        // [1, ctxLen] of token IDs, target [1, vocab] one-hot.
+        var input = new Tensor<float>(new[] { 1, ctxLen });
+        for (int t = 0; t < ctxLen; t++)
+            input[0, t] = rng.Next(vocabSize);
+
+        var target = new Tensor<float>(new[] { 1, vocabSize });
+        target[0, rng.Next(vocabSize)] = 1.0f;
+
+        // The act: a single Train() call. Before the fix this threw
+        // ArgumentException("Tensors with shapes [1, 256] and [1, 64, 128]
+        // cannot be broadcast ..."). After the fix, it must complete and
+        // the loss must be a finite number.
+        var ex = Record.Exception(() => transformer.Train(input, target));
+
+        Assert.Null(ex);
+        var lastLoss = transformer.GetLastLoss();
+        Assert.True(!float.IsNaN(lastLoss) && !float.IsInfinity(lastLoss),
+            $"LastLoss must be finite, was {lastLoss}");
+        _output.WriteLine(
+            $"Transformer.Train under ForTransformers() checkpointing succeeded; LastLoss={lastLoss}");
+    }
+
+    /// <summary>
+    /// Three consecutive per-sample Train calls under checkpointing — guards
+    /// against a regression that only surfaces after the first cached-plan
+    /// replay (the original failure cascaded through CompiledDelegateChain
+    /// the second time the same shape pattern was seen).
+    /// </summary>
+    /// <remarks>
+    /// Skipped until the paired AiDotNet.Tensors PR
+    /// (https://github.com/ooples/AiDotNet.Tensors/pull/361) merges and the
+    /// new Tensors NuGet is published. Bump
+    /// <c>Directory.Packages.props</c>'s AiDotNet.Tensors version and remove
+    /// the Skip attribute once the upstream fix is consumable.
+    /// </remarks>
+    [Fact(Skip = "Blocked on ooples/AiDotNet.Tensors#361 — GradientCheckpointing vjp seeding fix. Un-skip after the Tensors NuGet that includes the fix is referenced in Directory.Packages.props.")]
+    public void Transformer_Train_with_checkpointing_succeeds_for_repeated_calls()
+    {
+        const int vocabSize = 32;
+        const int dModel = 16;
+        const int dFf = 32;
+        const int ctxLen = 8;
+        const int heads = 2;
+        const int layers = 2;
+
+        var architecture = new TransformerArchitecture<float>(
+            inputType: InputType.TwoDimensional,
+            taskType: NeuralNetworkTaskType.SequenceClassification,
+            numEncoderLayers: layers,
+            numDecoderLayers: 0,
+            numHeads: heads,
+            modelDimension: dModel,
+            feedForwardDimension: dFf,
+            inputSize: ctxLen,
+            outputSize: vocabSize,
+            maxSequenceLength: ctxLen,
+            vocabularySize: vocabSize);
+
+        var transformer = new Transformer<float>(
+            architecture,
+            lossFunction: new CategoricalCrossEntropyLoss<float>());
+        transformer.EnableMemoryManagement(TrainingMemoryConfig.ForTransformers());
+
+        var rng = RandomHelper.CreateSeededRandom(1);
+
+        for (int step = 0; step < 3; step++)
+        {
+            var input = new Tensor<float>(new[] { 1, ctxLen });
+            for (int t = 0; t < ctxLen; t++) input[0, t] = rng.Next(vocabSize);
+            var target = new Tensor<float>(new[] { 1, vocabSize });
+            target[0, rng.Next(vocabSize)] = 1.0f;
+
+            transformer.Train(input, target);
+            var lastLoss = transformer.GetLastLoss();
+            Assert.True(!float.IsNaN(lastLoss) && !float.IsInfinity(lastLoss),
+                $"step={step}: LastLoss must be finite, was {lastLoss}");
+        }
+
+        _output.WriteLine("Three consecutive checkpointed Train calls succeeded.");
+    }
+}


### PR DESCRIPTION
## Summary

Consumer-side regression test for [#1341](https://github.com/ooples/AiDotNet/issues/1341). The actual fix is upstream in the paired Tensors PR: [ooples/AiDotNet.Tensors#361](https://github.com/ooples/AiDotNet.Tensors/pull/361).

Adds two integration tests under \`tests/AiDotNet.Tests/IntegrationTests/Training/\`:

1. \`Transformer_Train_with_ForTransformers_checkpointing_does_not_throw_on_shape_mismatch\` — reproduces the issue's exact config (2 encoder layers, dModel=128, dFf=256, ctxLen=64, vocab=256, per-sample Train, \`CategoricalCrossEntropyLoss\`, \`ForTransformers()\` preset) and asserts no exception + finite \`LastLoss\`.
2. \`Transformer_Train_with_checkpointing_succeeds_for_repeated_calls\` — runs three consecutive checkpointed Train calls at tiny dims to guard against a \`CompiledDelegateChain\` cached-plan replay regression after the first step (the upstream fix also touches that path).

Both tests are \`[Fact(Skip = ...)]\` until the Tensors PR merges and the new NuGet ships — at which point bumping \`Directory.Packages.props\` and removing the Skip attribute lights up the regression coverage.

## Root cause (full write-up in the Tensors PR)

\`GradientCheckpointing<T>.Checkpoint\`'s backward closure was running the inner-tape gradient with the implicit ones-seed and then attempting to \"chain-rule\" via an elementwise \`TensorMultiply\` against \`gradOutput\`. That only works when the segment is a shape-preserving elementwise op; on a real Transformer the head-side \`gradOutput\` \`[B, V]\` meets an encoder-segment output of \`[B, L, D]\` and the broadcast fails with \"cannot be broadcast: dimension 2 has sizes 256 and 128\".

The Tensors-side fix re-seeds the inner tape with a scalar pseudo-loss \`sum(reOutput * gradOutput.detach())\` whose gradient is exactly the vjp the segment owes to \`dL/dreInput\`. It also switches the inner recompute tape to \`Persistent=false\` so \`AutoTrainingCompiler\`'s plan cache doesn't bind a stale \`CompiledBackwardGraph\` to the per-step throwaway tape (which surfaced as a NRE in \`SymbolicBackwardGraphBuilder.Analyze\` once the broadcast issue was unblocked).

## Validation

- Both tests pass locally against the patched Tensors built from \`fix/1341-checkpoint-vjp-seed\`.
- 144 existing checkpoint-related tests in \`tests/AiDotNet.Tests\` continue to pass.
- Broader \`IntegrationTests/Training\` + \`UnitTests/Autodiff\` show no new regressions introduced by the test additions.

## Test plan

- [x] Build the test project clean
- [x] Tests pass with the patched Tensors NuGet
- [x] No regressions in adjacent checkpoint / training tests
- [ ] After ooples/AiDotNet.Tensors#361 merges and the Tensors NuGet publishes, follow up with a bump to \`Directory.Packages.props\` and \`Skip\` removal so the regression actively gates regressions.

Refs ooples/AiDotNet#1341.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added regression test for gradient checkpointing transformer stability to help ensure reliability of checkpointing functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ooples/AiDotNet/pull/1344?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->