### PR TITLE
fix(#1349): SIMD-vectorize INT8 dequant-on-fly matmul in QuantizedDenseLayer + QuantizedAttentionLayer

### DIFF
--- a/src/Inference/Quantization/Int8WeightOnlyMatMul.cs
+++ b/src/Inference/Quantization/Int8WeightOnlyMatMul.cs
@@ -62,19 +62,67 @@ internal static class Int8WeightOnlyMatMul
         int inputSize,
         int outputSize)
     {
-        if (weightsInt8.Length < (long)outputSize * inputSize)
-            throw new ArgumentException("weightsInt8 too small for [outputSize, inputSize].", nameof(weightsInt8));
+        if (rows < 0)
+            throw new ArgumentOutOfRangeException(nameof(rows), rows, "rows must be non-negative.");
+        if (inputSize < 0)
+            throw new ArgumentOutOfRangeException(nameof(inputSize), inputSize, "inputSize must be non-negative.");
+        if (outputSize < 0)
+            throw new ArgumentOutOfRangeException(nameof(outputSize), outputSize, "outputSize must be non-negative.");
+
+        long expectedWeights = (long)outputSize * inputSize;
+        if (weightsInt8.Length < expectedWeights)
+            throw new ArgumentException(
+                $"weightsInt8 too small for [outputSize={outputSize}, inputSize={inputSize}]: " +
+                $"expected at least {expectedWeights} entries, got {weightsInt8.Length}.",
+                nameof(weightsInt8));
         if (rowScales.Length < outputSize)
-            throw new ArgumentException("rowScales must have outputSize entries.", nameof(rowScales));
+            throw new ArgumentException(
+                $"rowScales must have at least outputSize={outputSize} entries, got {rowScales.Length}.",
+                nameof(rowScales));
         if (biases != null && biases.Length < outputSize)
-            throw new ArgumentException("biases (when non-null) must have outputSize entries.", nameof(biases));
-        if (input.Length < (long)rows * inputSize)
-            throw new ArgumentException("input span too small for [rows, inputSize].", nameof(input));
-        if (output.Length < (long)rows * outputSize)
-            throw new ArgumentException("output span too small for [rows, outputSize].", nameof(output));
+            throw new ArgumentException(
+                $"biases (when non-null) must have at least outputSize={outputSize} entries, got {biases.Length}.",
+                nameof(biases));
+
+        long expectedInput = (long)rows * inputSize;
+        if (input.Length < expectedInput)
+            throw new ArgumentException(
+                $"input span too small for [rows={rows}, inputSize={inputSize}]: " +
+                $"expected at least {expectedInput} entries, got {input.Length}.",
+                nameof(input));
+
+        long expectedOutput = (long)rows * outputSize;
+        if (output.Length < expectedOutput)
+            throw new ArgumentException(
+                $"output span too small for [rows={rows}, outputSize={outputSize}]: " +
+                $"expected at least {expectedOutput} entries, got {output.Length}.",
+                nameof(output));
+
+        // No-op when the logical output is empty. Do NOT clear `output` here —
+        // the caller's span may be larger than the logical [rows, outputSize]
+        // region and `output.Clear()` would zero stale-but-valid data outside
+        // the region this call is responsible for.
         if (rows == 0 || outputSize == 0)
+            return;
+
+        // Guard the inputSize == 0 case explicitly. SgemmAddInternal's behaviour
+        // with k=0 is unspecified by the IEngine contract; with no inner-dim
+        // contribution the matmul result is the zero matrix (plus bias, if any).
+        if (inputSize == 0)
         {
-            output.Clear();
+            for (int r = 0; r < rows; r++)
+            {
+                int dstRow = r * outputSize;
+                if (biases != null)
+                {
+                    for (int o = 0; o < outputSize; o++)
+                        output[dstRow + o] = biases[o];
+                }
+                else
+                {
+                    output.Slice(dstRow, outputSize).Clear();
+                }
+            }
             return;
         }
 
@@ -94,7 +142,10 @@ internal static class Int8WeightOnlyMatMul
 
                 // Dequantize tileN consecutive rows of int8 weights with per-row
                 // scale into the scratch buffer. Each call uses AVX2 internally
-                // when supported (see Int8Quantizer.DequantizeInt8ToFloat32).
+                // when supported (see Int8Quantizer.DequantizeInt8ToFloat32) and
+                // fully writes its destination row from the int8 source, so the
+                // ArrayPool-returned uninitialized scratch is safe even though
+                // ArrayPool<T>.Shared.Rent does not zero on rent.
                 for (int oo = 0; oo < tileN; oo++)
                 {
                     int o = oBase + oo;
@@ -109,6 +160,17 @@ internal static class Int8WeightOnlyMatMul
                 // C_tile [rows, tileN] = A [rows, inputSize] @ B_tile^T,
                 // where B_tile [tileN, inputSize] row-major is the logical
                 // transpose of the matmul operand [inputSize, tileN].
+                //
+                // SimdGemm.Sgemm has C = A·B semantics (no β·C accumulation —
+                // see SimdGemm.cs Sgemm overload at line 962) and calls
+                // c.Clear() before writing, so the ArrayPool-rented
+                // `tileOutput` does NOT need to be pre-cleared even though
+                // Rent returns uninitialized memory. The explicit Clear
+                // below is belt-and-braces against a future SimdGemm
+                // refactor that drops the implicit clear; the cost is one
+                // Span<float>.Clear() per tile and is dwarfed by the GEMM.
+                var tileSpan = tileOutput.AsSpan(0, tileOutLen);
+                tileSpan.Clear();
                 SimdGemm.Sgemm(
                     a: input,
                     lda: inputSize,
@@ -116,13 +178,19 @@ internal static class Int8WeightOnlyMatMul
                     b: new ReadOnlySpan<float>(dequantScratch, 0, dequantLen),
                     ldb: inputSize,
                     transB: true,
-                    c: tileOutput.AsSpan(0, tileOutLen),
+                    c: tileSpan,
                     m: rows,
                     k: inputSize,
                     n: tileN);
 
                 // Scatter tile into the strided output [rows, outputSize],
-                // adding the bias for this output-column block.
+                // adding the bias for this output-column block. Bias-add is
+                // a per-element scalar loop: for FFN-wide biases (e.g. 2048)
+                // this becomes non-trivial relative to the SGEMM body. A
+                // vectorized in-place AddRow primitive on the Tensors engine
+                // would be the natural follow-up; deferred here because at
+                // the canary shapes covered by tests the GEMM body still
+                // dominates the scatter cost.
                 for (int r = 0; r < rows; r++)
                 {
                     int srcRow = r * tileN;

--- a/src/Inference/Quantization/Int8WeightOnlyMatMul.cs
+++ b/src/Inference/Quantization/Int8WeightOnlyMatMul.cs
@@ -117,7 +117,11 @@ internal static class Int8WeightOnlyMatMul
             throw new ArgumentOutOfRangeException(
                 nameof(inputSize), 0,
                 "inputSize must be positive when rows > 0 and outputSize > 0; " +
-                "the empty-output early-return covers the rows==0 / outputSize==0 cases.");
+                "the empty-output early-return covers the rows==0 / outputSize==0 cases. " +
+                "Note: this is a BEHAVIOR CHANGE from the prior #1348 surface, which silently " +
+                "produced a zero-or-bias-only output for inputSize==0. Callers that relied on " +
+                "that fall-through must now either guard the call themselves or pre-fill the " +
+                "output span with the bias values before invocation (review #1363 C8QXn).");
 
         int outputTile = ChooseTileSize(outputSize, inputSize);
 
@@ -128,12 +132,23 @@ internal static class Int8WeightOnlyMatMul
         // canary shapes covered by tests these products stay well under
         // 2 GiB / 4 bytes per float, but the bound check matters once
         // wider FFN / longer sequences land.
+        //
+        // Both products are guaranteed > 0 here (rows >= 1 by the
+        // outputSize/rows==0 early-return; inputSize > 0 by the
+        // inputSize==0 throw above; outputTile > 0 by ChooseTileSize's
+        // ≥ 1 contract). So this check is purely an overflow ceiling,
+        // not a positivity check (review #1363 C8QY_).
         long dequantScratchLen = (long)outputTile * inputSize;
         long tileOutputLen = (long)rows * outputTile;
         if (dequantScratchLen > int.MaxValue || tileOutputLen > int.MaxValue)
             throw new InvalidOperationException(
-                $"Tiled INT8 matmul exceeded int.MaxValue per-tile buffer ({dequantScratchLen}, {tileOutputLen}). " +
-                "Reduce outputTile or split rows externally before calling MultiplyAddBias.");
+                $"Tiled INT8 matmul exceeded int.MaxValue per-tile buffer (" +
+                $"dequantScratch={dequantScratchLen} from outputTile={outputTile}*inputSize={inputSize}; " +
+                $"tileOutput={tileOutputLen} from rows={rows}*outputTile={outputTile}). " +
+                "outputTile is chosen internally by ChooseTileSize; the caller-actionable knob is to " +
+                "split the call into smaller row batches (rows-by-rows external loop) before invoking " +
+                "MultiplyAddBias, OR to reduce inputSize / outputSize at the layer-shape level " +
+                "(review #1363 C8QXT).");
 
         var pool = ArrayPool<float>.Shared;
         // Both rents inside the try block so that if the SECOND rent
@@ -195,10 +210,19 @@ internal static class Int8WeightOnlyMatMul
                 // accelerated SIMD primitive SimdGemm uses. Per the
                 // project-level rule, AiDotNet.Tensors is the in-tree
                 // SIMD library (full PyTorch parity); System.Numerics is
-                // banned. VectorAdd is one call per output row; tileN is
-                // a multiple of 16 per ChooseTileSize's alignment
-                // contract, keeping the kernel on its best-case path
-                // (review #1363 C6XGD).
+                // banned. VectorAdd is one call per output row.
+                //
+                // tileN alignment: INTERIOR tiles (where oBase + outputTile
+                // < outputSize) are exactly outputTile elements wide,
+                // which ChooseTileSize sizes as a multiple of 16 for the
+                // AVX2 best-case path. The TAIL tile (last iteration when
+                // outputSize % outputTile != 0) is the remainder
+                // outputSize - oBase, which may not be a multiple of 16 —
+                // VectorAdd's scalar epilogue handles the unaligned tail
+                // correctly, just without the best-case throughput
+                // (review #1363 C8QW7 — earlier comment claimed all
+                // tiles are 16-aligned which was only true for interior
+                // tiles).
                 for (int r = 0; r < rows; r++)
                 {
                     int srcRow = r * tileN;

--- a/src/Inference/Quantization/Int8WeightOnlyMatMul.cs
+++ b/src/Inference/Quantization/Int8WeightOnlyMatMul.cs
@@ -1,0 +1,149 @@
+using System.Buffers;
+using AiDotNet.Tensors.Engines.Simd;
+
+namespace AiDotNet.Inference.Quantization;
+
+/// <summary>
+/// Per-output-row INT8 weight-only matmul accelerated via the AiDotNet.Tensors
+/// SIMD GEMM. Replaces the scalar dequant-on-fly inner loop used by
+/// <see cref="QuantizedDenseLayer"/> and <see cref="QuantizedAttentionLayer"/>.
+///
+/// <para>The shape contract matches both consumers' existing layout:
+///   C[m, n] = bias[n] + A[m, k] · dequant(B_int8[n, k], rowScales[n])
+/// where dequant(B[r, c], rowScales[r]) = B[r, c] * rowScales[r]. B is stored
+/// row-major as [n, k] (one int8 row per output column, the same convention
+/// <see cref="Int8WeightOnlyQuantization.QuantizePerRow(Tensor{float})"/>
+/// produces).</para>
+///
+/// <para>Implementation strategy: tile the output dimension so that each
+/// dequant-tile of B fits in L2 (≤192 KB by default), call the
+/// AVX2-vectorized <see cref="Int8Quantizer.DequantizeInt8ToFloat32"/> per row
+/// using that row's scale, then dispatch the FP32 tile through the public
+/// <see cref="SimdGemm.Sgemm"/> kernel (transposed B). This composes existing
+/// engine-level SIMD primitives — no System.Numerics, no scalar inner loop.
+/// Weights stay int8 in DRAM; only the active tile is materialized in FP32.</para>
+/// </summary>
+internal static class Int8WeightOnlyMatMul
+{
+    private const int TargetTileBytes = 192 * 1024;
+    private const int MinOutputTile = 16;
+
+    /// <summary>
+    /// Choose an output-row tile size that keeps the dequant scratch in L2 and
+    /// stays a multiple of 16 (matches the BLIS micro-kernel's <c>Nr</c>).
+    /// </summary>
+    internal static int ChooseTileSize(int outputSize, int inputSize)
+    {
+        if (outputSize <= 0 || inputSize <= 0) return outputSize;
+        long rowBytes = (long)inputSize * sizeof(float);
+        if (rowBytes <= 0) return outputSize;
+        int candidate = (int)(TargetTileBytes / rowBytes);
+        if (candidate < MinOutputTile) candidate = MinOutputTile;
+        candidate = candidate / 16 * 16;
+        if (candidate < MinOutputTile) candidate = MinOutputTile;
+        if (candidate > outputSize) candidate = outputSize;
+        return candidate;
+    }
+
+    /// <summary>
+    /// Compute <c>output[r, o] = (biases?[o] ?? 0) + sum_i input[r, i] * weightsInt8[o, i] * rowScales[o]</c>
+    /// for all <c>r in [0, rows)</c> and <c>o in [0, outputSize)</c>. Uses
+    /// AiDotNet.Tensors' tiled SGEMM + AVX2 INT8 dequantizer; correctness path
+    /// when AVX is unavailable is the engine's scalar fallback (still vector-
+    /// register friendly via the BLIS micro-kernel).
+    /// </summary>
+    public static void MultiplyAddBias(
+        ReadOnlySpan<float> input,
+        sbyte[] weightsInt8,
+        float[] rowScales,
+        float[]? biases,
+        Span<float> output,
+        int rows,
+        int inputSize,
+        int outputSize)
+    {
+        if (weightsInt8.Length < (long)outputSize * inputSize)
+            throw new ArgumentException("weightsInt8 too small for [outputSize, inputSize].", nameof(weightsInt8));
+        if (rowScales.Length < outputSize)
+            throw new ArgumentException("rowScales must have outputSize entries.", nameof(rowScales));
+        if (biases != null && biases.Length < outputSize)
+            throw new ArgumentException("biases (when non-null) must have outputSize entries.", nameof(biases));
+        if (input.Length < (long)rows * inputSize)
+            throw new ArgumentException("input span too small for [rows, inputSize].", nameof(input));
+        if (output.Length < (long)rows * outputSize)
+            throw new ArgumentException("output span too small for [rows, outputSize].", nameof(output));
+        if (rows == 0 || outputSize == 0)
+        {
+            output.Clear();
+            return;
+        }
+
+        int outputTile = ChooseTileSize(outputSize, inputSize);
+
+        var pool = ArrayPool<float>.Shared;
+        float[] dequantScratch = pool.Rent(outputTile * inputSize);
+        float[] tileOutput = pool.Rent(rows * outputTile);
+
+        try
+        {
+            for (int oBase = 0; oBase < outputSize; oBase += outputTile)
+            {
+                int tileN = Math.Min(outputTile, outputSize - oBase);
+                int dequantLen = tileN * inputSize;
+                int tileOutLen = rows * tileN;
+
+                // Dequantize tileN consecutive rows of int8 weights with per-row
+                // scale into the scratch buffer. Each call uses AVX2 internally
+                // when supported (see Int8Quantizer.DequantizeInt8ToFloat32).
+                for (int oo = 0; oo < tileN; oo++)
+                {
+                    int o = oBase + oo;
+                    int srcStart = o * inputSize;
+                    int dstStart = oo * inputSize;
+                    Int8Quantizer.DequantizeInt8ToFloat32(
+                        new ReadOnlySpan<sbyte>(weightsInt8, srcStart, inputSize),
+                        dequantScratch.AsSpan(dstStart, inputSize),
+                        rowScales[o]);
+                }
+
+                // C_tile [rows, tileN] = A [rows, inputSize] @ B_tile^T,
+                // where B_tile [tileN, inputSize] row-major is the logical
+                // transpose of the matmul operand [inputSize, tileN].
+                SimdGemm.Sgemm(
+                    a: input,
+                    lda: inputSize,
+                    transA: false,
+                    b: new ReadOnlySpan<float>(dequantScratch, 0, dequantLen),
+                    ldb: inputSize,
+                    transB: true,
+                    c: tileOutput.AsSpan(0, tileOutLen),
+                    m: rows,
+                    k: inputSize,
+                    n: tileN);
+
+                // Scatter tile into the strided output [rows, outputSize],
+                // adding the bias for this output-column block.
+                for (int r = 0; r < rows; r++)
+                {
+                    int srcRow = r * tileN;
+                    int dstRow = r * outputSize + oBase;
+                    if (biases != null)
+                    {
+                        for (int oo = 0; oo < tileN; oo++)
+                            output[dstRow + oo] = tileOutput[srcRow + oo] + biases[oBase + oo];
+                    }
+                    else
+                    {
+                        var src = tileOutput.AsSpan(srcRow, tileN);
+                        src.CopyTo(output.Slice(dstRow, tileN));
+                    }
+                }
+            }
+        }
+        finally
+        {
+            pool.Return(dequantScratch);
+            pool.Return(tileOutput);
+        }
+    }
+}

--- a/src/Inference/Quantization/Int8WeightOnlyMatMul.cs
+++ b/src/Inference/Quantization/Int8WeightOnlyMatMul.cs
@@ -105,35 +105,48 @@ internal static class Int8WeightOnlyMatMul
         if (rows == 0 || outputSize == 0)
             return;
 
-        // Guard the inputSize == 0 case explicitly. SgemmAddInternal's behaviour
-        // with k=0 is unspecified by the IEngine contract; with no inner-dim
-        // contribution the matmul result is the zero matrix (plus bias, if any).
+        // Reject inputSize == 0 explicitly. The two production callers
+        // (QuantizedDenseLayer, QuantizedAttentionLayer Q/K/V/O projections)
+        // validate input dim upstream; an inputSize of 0 only arrives via a
+        // misconfigured caller, never via legitimate workloads. Failing
+        // fast surfaces the misconfiguration at the matmul call instead of
+        // producing a silent zero-matrix result that would mask the upstream
+        // bug (review #1363 C6XGR: prior permissive bias-or-zero return
+        // turned this edge case into a silent no-op).
         if (inputSize == 0)
-        {
-            for (int r = 0; r < rows; r++)
-            {
-                int dstRow = r * outputSize;
-                if (biases != null)
-                {
-                    for (int o = 0; o < outputSize; o++)
-                        output[dstRow + o] = biases[o];
-                }
-                else
-                {
-                    output.Slice(dstRow, outputSize).Clear();
-                }
-            }
-            return;
-        }
+            throw new ArgumentOutOfRangeException(
+                nameof(inputSize), 0,
+                "inputSize must be positive when rows > 0 and outputSize > 0; " +
+                "the empty-output early-return covers the rows==0 / outputSize==0 cases.");
 
         int outputTile = ChooseTileSize(outputSize, inputSize);
 
-        var pool = ArrayPool<float>.Shared;
-        float[] dequantScratch = pool.Rent(outputTile * inputSize);
-        float[] tileOutput = pool.Rent(rows * outputTile);
+        // Allocate using long-typed sizes so overflow against int.MaxValue
+        // surfaces explicitly (e.g. outputTile=3000 × inputSize=4096 +
+        // future scale-up to 1M-row batches would silently wrap to a
+        // negative int and pass to Rent — review #1363 C6XFg). At the
+        // canary shapes covered by tests these products stay well under
+        // 2 GiB / 4 bytes per float, but the bound check matters once
+        // wider FFN / longer sequences land.
+        long dequantScratchLen = (long)outputTile * inputSize;
+        long tileOutputLen = (long)rows * outputTile;
+        if (dequantScratchLen > int.MaxValue || tileOutputLen > int.MaxValue)
+            throw new InvalidOperationException(
+                $"Tiled INT8 matmul exceeded int.MaxValue per-tile buffer ({dequantScratchLen}, {tileOutputLen}). " +
+                "Reduce outputTile or split rows externally before calling MultiplyAddBias.");
 
+        var pool = ArrayPool<float>.Shared;
+        // Both rents inside the try block so that if the SECOND rent
+        // throws (rare: pool exhaustion / OOM), the first buffer is
+        // still returned to the pool by the finally (review #1363
+        // C6XF6 — prior code rented before try and leaked dequantScratch
+        // on a tileOutput rent throw).
+        float[]? dequantScratch = null;
+        float[]? tileOutput = null;
         try
         {
+            dequantScratch = pool.Rent((int)dequantScratchLen);
+            tileOutput = pool.Rent((int)tileOutputLen);
             for (int oBase = 0; oBase < outputSize; oBase += outputTile)
             {
                 int tileN = Math.Min(outputTile, outputSize - oBase);
@@ -157,18 +170,11 @@ internal static class Int8WeightOnlyMatMul
                         rowScales[o]);
                 }
 
-                // C_tile [rows, tileN] = A [rows, inputSize] @ B_tile^T,
-                // where B_tile [tileN, inputSize] row-major is the logical
-                // transpose of the matmul operand [inputSize, tileN].
-                //
-                // SimdGemm.Sgemm has C = A·B semantics (no β·C accumulation —
-                // see SimdGemm.cs Sgemm overload at line 962) and calls
-                // c.Clear() before writing, so the ArrayPool-rented
-                // `tileOutput` does NOT need to be pre-cleared even though
-                // Rent returns uninitialized memory. The explicit Clear
-                // below is belt-and-braces against a future SimdGemm
-                // refactor that drops the implicit clear; the cost is one
-                // Span<float>.Clear() per tile and is dwarfed by the GEMM.
+                // C_tile [rows, tileN] = A [rows, inputSize] @ B_tile^T (Sgemm
+                // overload with transB=true). Explicit tileSpan.Clear() is
+                // belt-and-braces against a future SimdGemm.Sgemm refactor
+                // that drops its implicit clear of c (review #1363 C6XGz
+                // shortened from the 8-line line-number reference).
                 var tileSpan = tileOutput.AsSpan(0, tileOutLen);
                 tileSpan.Clear();
                 SimdGemm.Sgemm(
@@ -184,34 +190,39 @@ internal static class Int8WeightOnlyMatMul
                     n: tileN);
 
                 // Scatter tile into the strided output [rows, outputSize],
-                // adding the bias for this output-column block. Bias-add is
-                // a per-element scalar loop: for FFN-wide biases (e.g. 2048)
-                // this becomes non-trivial relative to the SGEMM body. A
-                // vectorized in-place AddRow primitive on the Tensors engine
-                // would be the natural follow-up; deferred here because at
-                // the canary shapes covered by tests the GEMM body still
-                // dominates the scatter cost.
+                // adding the bias for this output-column block via
+                // AiDotNet.Tensors' SimdKernels.VectorAdd — the same
+                // accelerated SIMD primitive SimdGemm uses. Per the
+                // project-level rule, AiDotNet.Tensors is the in-tree
+                // SIMD library (full PyTorch parity); System.Numerics is
+                // banned. VectorAdd is one call per output row; tileN is
+                // a multiple of 16 per ChooseTileSize's alignment
+                // contract, keeping the kernel on its best-case path
+                // (review #1363 C6XGD).
                 for (int r = 0; r < rows; r++)
                 {
                     int srcRow = r * tileN;
                     int dstRow = r * outputSize + oBase;
+                    var srcSpan = tileOutput.AsSpan(srcRow, tileN);
+                    var dstSpan = output.Slice(dstRow, tileN);
                     if (biases != null)
                     {
-                        for (int oo = 0; oo < tileN; oo++)
-                            output[dstRow + oo] = tileOutput[srcRow + oo] + biases[oBase + oo];
+                        var biasSpan = new ReadOnlySpan<float>(biases, oBase, tileN);
+                        AiDotNet.Tensors.Engines.Simd.SimdKernels.VectorAdd(srcSpan, biasSpan, dstSpan);
                     }
                     else
                     {
-                        var src = tileOutput.AsSpan(srcRow, tileN);
-                        src.CopyTo(output.Slice(dstRow, tileN));
+                        srcSpan.CopyTo(dstSpan);
                     }
                 }
             }
         }
         finally
         {
-            pool.Return(dequantScratch);
-            pool.Return(tileOutput);
+            // Null-conditional Return so a mid-rent throw (only the FIRST
+            // rent succeeded) still returns what we have without an NRE.
+            if (dequantScratch is not null) pool.Return(dequantScratch);
+            if (tileOutput is not null) pool.Return(tileOutput);
         }
     }
 }

--- a/src/Inference/Quantization/QuantizedAttentionLayer.cs
+++ b/src/Inference/Quantization/QuantizedAttentionLayer.cs
@@ -4,6 +4,7 @@ using AiDotNet.Enums;
 using AiDotNet.NeuralNetworks.Attention;
 using AiDotNet.NeuralNetworks.Layers;
 using AiDotNet.Tensors.LinearAlgebra;
+using SimdVector = System.Numerics.Vector<float>;
 
 namespace AiDotNet.Inference.Quantization;
 
@@ -415,19 +416,48 @@ internal sealed class QuantizedAttentionLayer : LayerBase<float>
             ?? throw new InvalidOperationException("Int8 scales not initialized for quantized projection.");
         var output = new Tensor<float>(new[] { rows, outDim });
 
+        // SIMD-vectorize the int8 dequant-on-fly matmul over input dimension.
+        // Mirror of the fix in QuantizedDenseLayer.Forward — see that file for
+        // detailed rationale + numerical-equivalence notes. Closes the
+        // attention-side gap of AiDotNet#1349.
+        int vecSize = SimdVector.Count;
+        Span<float> weightChunk = stackalloc float[vecSize];
         for (int r = 0; r < rows; r++)
         {
             int inputBase = r * inDim;
             int outputBase = r * outDim;
             for (int o = 0; o < outDim; o++)
             {
-                float sum = 0f;
                 float scale = scales[o];
                 int wBase = o * inDim;
-                for (int i = 0; i < inDim; i++)
+
+                var sumVec = SimdVector.Zero;
+                var scaleVec = new SimdVector(scale);
+                int vectorLimit = inDim - (inDim % vecSize);
+                int i = 0;
+                for (; i < vectorLimit; i += vecSize)
+                {
+                    for (int j = 0; j < vecSize; j++)
+                    {
+                        weightChunk[j] = weights[wBase + i + j];
+                    }
+                    var inputVec = new SimdVector(input.Slice(inputBase + i, vecSize));
+                    var weightVec = new SimdVector(weightChunk);
+                    sumVec += inputVec * weightVec * scaleVec;
+                }
+
+                float laneSum = 0;
+                for (int j = 0; j < vecSize; j++)
+                {
+                    laneSum += sumVec[j];
+                }
+                float sum = laneSum;
+
+                for (; i < inDim; i++)
                 {
                     sum += input[inputBase + i] * (weights[wBase + i] * scale);
                 }
+
                 output.SetFlat(outputBase + o, sum);
             }
         }

--- a/src/Inference/Quantization/QuantizedAttentionLayer.cs
+++ b/src/Inference/Quantization/QuantizedAttentionLayer.cs
@@ -4,7 +4,6 @@ using AiDotNet.Enums;
 using AiDotNet.NeuralNetworks.Attention;
 using AiDotNet.NeuralNetworks.Layers;
 using AiDotNet.Tensors.LinearAlgebra;
-using SimdVector = System.Numerics.Vector<float>;
 
 namespace AiDotNet.Inference.Quantization;
 
@@ -416,57 +415,12 @@ internal sealed class QuantizedAttentionLayer : LayerBase<float>
             ?? throw new InvalidOperationException("Int8 scales not initialized for quantized projection.");
         var output = new Tensor<float>(new[] { rows, outDim });
 
-        // SIMD-vectorize the int8 dequant-on-fly matmul over input dimension.
-        // Mirror of the fix in QuantizedDenseLayer.Forward — see that file for
-        // detailed rationale + numerical-equivalence notes. Closes the
-        // attention-side gap of AiDotNet#1349.
-        //
-        // TFM gating: Vector<float>(Span<float>) is .NET Core 3.0+ only;
-        // net471 falls back to the scalar inner loop (status quo).
-#if NETCOREAPP3_0_OR_GREATER
-        int vecSize = SimdVector.Count;
-        Span<float> weightChunk = stackalloc float[vecSize];
-        for (int r = 0; r < rows; r++)
-        {
-            int inputBase = r * inDim;
-            int outputBase = r * outDim;
-            for (int o = 0; o < outDim; o++)
-            {
-                float scale = scales[o];
-                int wBase = o * inDim;
-
-                var sumVec = SimdVector.Zero;
-                var scaleVec = new SimdVector(scale);
-                int vectorLimit = inDim - (inDim % vecSize);
-                int i = 0;
-                for (; i < vectorLimit; i += vecSize)
-                {
-                    for (int j = 0; j < vecSize; j++)
-                    {
-                        weightChunk[j] = weights[wBase + i + j];
-                    }
-                    var inputVec = new SimdVector(input.Slice(inputBase + i, vecSize));
-                    var weightVec = new SimdVector(weightChunk);
-                    sumVec += inputVec * weightVec * scaleVec;
-                }
-
-                float laneSum = 0;
-                for (int j = 0; j < vecSize; j++)
-                {
-                    laneSum += sumVec[j];
-                }
-                float sum = laneSum;
-
-                for (; i < inDim; i++)
-                {
-                    sum += input[inputBase + i] * (weights[wBase + i] * scale);
-                }
-
-                output.SetFlat(outputBase + o, sum);
-            }
-        }
-#else
-        // net471 scalar fallback — Vector<float>(Span<float>) ctor isn't available.
+        // Scalar dequant-on-fly matmul. The proper SIMD speedup belongs in
+        // AiDotNet.Tensors (which has full PyTorch-parity custom SIMD/AVX-512
+        // acceleration faster than the System.Numerics primitives). Tracked
+        // in AiDotNet#1349 — once Tensors exposes a public INT8 weight matmul
+        // entry point this loop should be replaced with a call to that engine
+        // op.
         for (int r = 0; r < rows; r++)
         {
             int inputBase = r * inDim;
@@ -483,7 +437,6 @@ internal sealed class QuantizedAttentionLayer : LayerBase<float>
                 output.SetFlat(outputBase + o, sum);
             }
         }
-#endif
         return output;
     }
 

--- a/src/Inference/Quantization/QuantizedAttentionLayer.cs
+++ b/src/Inference/Quantization/QuantizedAttentionLayer.cs
@@ -420,6 +420,10 @@ internal sealed class QuantizedAttentionLayer : LayerBase<float>
         // Mirror of the fix in QuantizedDenseLayer.Forward — see that file for
         // detailed rationale + numerical-equivalence notes. Closes the
         // attention-side gap of AiDotNet#1349.
+        //
+        // TFM gating: Vector<float>(Span<float>) is .NET Core 3.0+ only;
+        // net471 falls back to the scalar inner loop (status quo).
+#if NETCOREAPP3_0_OR_GREATER
         int vecSize = SimdVector.Count;
         Span<float> weightChunk = stackalloc float[vecSize];
         for (int r = 0; r < rows; r++)
@@ -461,6 +465,25 @@ internal sealed class QuantizedAttentionLayer : LayerBase<float>
                 output.SetFlat(outputBase + o, sum);
             }
         }
+#else
+        // net471 scalar fallback — Vector<float>(Span<float>) ctor isn't available.
+        for (int r = 0; r < rows; r++)
+        {
+            int inputBase = r * inDim;
+            int outputBase = r * outDim;
+            for (int o = 0; o < outDim; o++)
+            {
+                float sum = 0f;
+                float scale = scales[o];
+                int wBase = o * inDim;
+                for (int i = 0; i < inDim; i++)
+                {
+                    sum += input[inputBase + i] * (weights[wBase + i] * scale);
+                }
+                output.SetFlat(outputBase + o, sum);
+            }
+        }
+#endif
         return output;
     }
 

--- a/src/Inference/Quantization/QuantizedAttentionLayer.cs
+++ b/src/Inference/Quantization/QuantizedAttentionLayer.cs
@@ -415,14 +415,9 @@ internal sealed class QuantizedAttentionLayer : LayerBase<float>
             ?? throw new InvalidOperationException("Int8 scales not initialized for quantized projection.");
         var output = new Tensor<float>(new[] { rows, outDim });
 
-        // Q/K/V/O projections have no bias here — the attention output bias
-        // (_outputBias) is applied separately in the Forward pass after the
-        // O-projection scatter. Passing biases=null is safe because
-        // Int8WeightOnlyMatMul.MultiplyAddBias short-circuits the per-element
-        // bias-add scatter into a span-to-span CopyTo, so there is no implicit
-        // "where does this bias come from" branch a future change could trip
-        // by accident — adding a per-projection bias here would require
-        // explicitly populating the biases array at this call site.
+        // Q/K/V/O projections have no per-projection bias — attention's
+        // _outputBias is applied separately in Forward after the
+        // O-projection scatter (review #1363 C6XGz).
         Int8WeightOnlyMatMul.MultiplyAddBias(
             input: input,
             weightsInt8: weights,

--- a/src/Inference/Quantization/QuantizedAttentionLayer.cs
+++ b/src/Inference/Quantization/QuantizedAttentionLayer.cs
@@ -415,28 +415,18 @@ internal sealed class QuantizedAttentionLayer : LayerBase<float>
             ?? throw new InvalidOperationException("Int8 scales not initialized for quantized projection.");
         var output = new Tensor<float>(new[] { rows, outDim });
 
-        // Scalar dequant-on-fly matmul. The proper SIMD speedup belongs in
-        // AiDotNet.Tensors (which has full PyTorch-parity custom SIMD/AVX-512
-        // acceleration faster than the System.Numerics primitives). Tracked
-        // in AiDotNet#1349 — once Tensors exposes a public INT8 weight matmul
-        // entry point this loop should be replaced with a call to that engine
-        // op.
-        for (int r = 0; r < rows; r++)
-        {
-            int inputBase = r * inDim;
-            int outputBase = r * outDim;
-            for (int o = 0; o < outDim; o++)
-            {
-                float sum = 0f;
-                float scale = scales[o];
-                int wBase = o * inDim;
-                for (int i = 0; i < inDim; i++)
-                {
-                    sum += input[inputBase + i] * (weights[wBase + i] * scale);
-                }
-                output.SetFlat(outputBase + o, sum);
-            }
-        }
+        // Q/K/V/O projections have no bias here — the attention output bias
+        // is applied separately in the Forward pass.
+        Int8WeightOnlyMatMul.MultiplyAddBias(
+            input: input,
+            weightsInt8: weights,
+            rowScales: scales,
+            biases: null,
+            output: output.AsWritableSpan(),
+            rows: rows,
+            inputSize: inDim,
+            outputSize: outDim);
+
         return output;
     }
 

--- a/src/Inference/Quantization/QuantizedAttentionLayer.cs
+++ b/src/Inference/Quantization/QuantizedAttentionLayer.cs
@@ -416,7 +416,13 @@ internal sealed class QuantizedAttentionLayer : LayerBase<float>
         var output = new Tensor<float>(new[] { rows, outDim });
 
         // Q/K/V/O projections have no bias here — the attention output bias
-        // is applied separately in the Forward pass.
+        // (_outputBias) is applied separately in the Forward pass after the
+        // O-projection scatter. Passing biases=null is safe because
+        // Int8WeightOnlyMatMul.MultiplyAddBias short-circuits the per-element
+        // bias-add scatter into a span-to-span CopyTo, so there is no implicit
+        // "where does this bias come from" branch a future change could trip
+        // by accident — adding a per-projection bias here would require
+        // explicitly populating the biases array at this call site.
         Int8WeightOnlyMatMul.MultiplyAddBias(
             input: input,
             weightsInt8: weights,

--- a/src/Inference/Quantization/QuantizedDenseLayer.cs
+++ b/src/Inference/Quantization/QuantizedDenseLayer.cs
@@ -1,7 +1,6 @@
 ﻿using AiDotNet.Autodiff;
 using AiDotNet.NeuralNetworks.Layers;
 using AiDotNet.Tensors.LinearAlgebra;
-using SimdVector = System.Numerics.Vector<float>;
 
 namespace AiDotNet.Inference.Quantization;
 
@@ -115,77 +114,18 @@ internal sealed class QuantizedDenseLayer : LayerBase<float>
         var output = new Tensor<float>(new[] { batchSize, _outputSize });
         var inputSpan = flat.AsSpan();
 
-        // SIMD-vectorize the inner dequant-on-fly matmul over input dimension.
-        // Closes part of AiDotNet#1349 (consumer-side wiring of int8 weight-only
-        // matmul to a vectorized hot path). Previously this triple loop did one
-        // scalar load + one sbyte→float widen + one fma per inner iteration; the
-        // measured wall-clock was ~20× slower than FP32 matmul (PR #1348 follow-
-        // up benchmark). The vectorized form processes Vector<float>.Count
-        // elements per iteration (8 on AVX2, 16 on AVX-512), with a per-chunk
-        // sbyte→float widen via a small stackalloc buffer + a portable
-        // Vector<float> accumulator.
-        //
-        // TFM gating: the Vector<float>(Span<float>) ctor is .NET Core 3.0+
-        // only. net471's Vector<T> only has (T value) broadcast and
-        // (T[] values, int startIndex) array overloads. Rather than allocate
-        // a float[] per chunk on net471 (which would defeat the SIMD win), we
-        // fall back to the original scalar inner loop on that TFM. net10.0
-        // production hosts get the full speedup; net471 legacy hosts get the
-        // status-quo scalar path.
-        //
-        // Numerical equivalence: SIMD changes the order of accumulation
-        // (associativity is approximate for FP32), so the result differs from
-        // the scalar path by ~1 ULP per K elements summed. For the inference-
-        // only use case this is well below the INT8 quantization noise floor
-        // (~35-40 dB SNR on typical transformer weights, ~1e-2 relative error).
-#if NETCOREAPP3_0_OR_GREATER
-        int vecSize = SimdVector.Count;
-        Span<float> weightChunk = stackalloc float[vecSize];
-        for (int b = 0; b < batchSize; b++)
-        {
-            int inputBase = b * featuresIn;
-            int outputBase = b * _outputSize;
-            for (int o = 0; o < _outputSize; o++)
-            {
-                float scale = _rowScales[o];
-                int wBase = o * _inputSize;
-
-                var sumVec = SimdVector.Zero;
-                var scaleVec = new SimdVector(scale);
-                int vectorLimit = _inputSize - (_inputSize % vecSize);
-                int i = 0;
-                for (; i < vectorLimit; i += vecSize)
-                {
-                    // Widen Vector<float>.Count contiguous sbyte weights to FP32.
-                    for (int j = 0; j < vecSize; j++)
-                    {
-                        weightChunk[j] = _weightsInt8[wBase + i + j];
-                    }
-                    var inputVec = new SimdVector(inputSpan.Slice(inputBase + i, vecSize));
-                    var weightVec = new SimdVector(weightChunk);
-                    sumVec += inputVec * weightVec * scaleVec;
-                }
-
-                // Reduce the SIMD accumulator to scalar. Vector.Sum is .NET 7+;
-                // sum lanes explicitly for net10.0 compatibility.
-                float laneSum = 0;
-                for (int j = 0; j < vecSize; j++)
-                {
-                    laneSum += sumVec[j];
-                }
-                float sum = _biases[o] + laneSum;
-
-                // Tail: remaining (_inputSize % vecSize) elements via scalar.
-                for (; i < _inputSize; i++)
-                {
-                    sum += inputSpan[inputBase + i] * (_weightsInt8[wBase + i] * scale);
-                }
-
-                output.SetFlat(outputBase + o, sum);
-            }
-        }
-#else
-        // net471 scalar fallback — Vector<float>(Span<float>) ctor isn't available.
+        // Scalar dequant-on-fly matmul. The proper SIMD speedup for INT8
+        // weight-only inference belongs in AiDotNet.Tensors (which has full
+        // PyTorch-parity custom SIMD/AVX-512 acceleration faster than the
+        // System.Numerics primitives). Specifically, AiDotNet.Tensors already
+        // has `SimdGemm.SgemmWithInt8CachedB` for this exact use case, but it's
+        // currently internal to the Tensors-namespace. Once Tensors exposes a
+        // public INT8 weight matmul entry point (tracked in AiDotNet#1349),
+        // this loop should be replaced with a call to that engine op. Until
+        // then, the scalar path remains correct (just slow) — the inference-
+        // side perf gap is the same scope as #1349 and shouldn't be patched
+        // here with a third-party-library workaround that diverges from the
+        // engine layer's official SIMD path.
         for (int b = 0; b < batchSize; b++)
         {
             int inputBase = b * featuresIn;
@@ -202,7 +142,6 @@ internal sealed class QuantizedDenseLayer : LayerBase<float>
                 output.SetFlat(outputBase + o, sum);
             }
         }
-#endif
 
         var activated = ApplyActivation(output);
         if (inputWas1D)

--- a/src/Inference/Quantization/QuantizedDenseLayer.cs
+++ b/src/Inference/Quantization/QuantizedDenseLayer.cs
@@ -1,6 +1,8 @@
 ﻿using AiDotNet.Autodiff;
 using AiDotNet.NeuralNetworks.Layers;
 using AiDotNet.Tensors.LinearAlgebra;
+using SimdVector = System.Numerics.Vector<float>;
+using SimdVectorOps = System.Numerics.Vector;
 
 namespace AiDotNet.Inference.Quantization;
 
@@ -114,19 +116,70 @@ internal sealed class QuantizedDenseLayer : LayerBase<float>
         var output = new Tensor<float>(new[] { batchSize, _outputSize });
         var inputSpan = flat.AsSpan();
 
+        // SIMD-vectorize the inner dequant-on-fly matmul over input dimension.
+        // Closes part of AiDotNet#1349 (consumer-side wiring of int8 weight-only
+        // matmul to a vectorized hot path). Previously this triple loop did one
+        // scalar load + one sbyte→float widen + one fma per inner iteration; the
+        // measured wall-clock was ~20× slower than FP32 matmul (PR #1348 follow-
+        // up benchmark). The vectorized form processes Vector<float>.Count
+        // elements per iteration (8 on AVX2, 16 on AVX-512), with a per-chunk
+        // sbyte→float widen via a small stackalloc buffer + a portable
+        // Vector<float> accumulator.
+        //
+        // Numerical equivalence: SIMD changes the order of accumulation
+        // (associativity is approximate for FP32), so the result differs from
+        // the scalar path by ~1 ULP per K elements summed. For the inference-
+        // only use case this is well below the INT8 quantization noise floor
+        // (~35-40 dB SNR on typical transformer weights, ~1e-2 relative error).
+        int vecSize = SimdVector.Count;
+        Span<float> weightChunk = stackalloc float[vecSize];
         for (int b = 0; b < batchSize; b++)
         {
             int inputBase = b * featuresIn;
             int outputBase = b * _outputSize;
             for (int o = 0; o < _outputSize; o++)
             {
-                float sum = _biases[o];
                 float scale = _rowScales[o];
                 int wBase = o * _inputSize;
-                for (int i = 0; i < _inputSize; i++)
+
+                var sumVec = SimdVector.Zero;
+                var scaleVec = new SimdVector(scale);
+                int vectorLimit = _inputSize - (_inputSize % vecSize);
+                int i = 0;
+                for (; i < vectorLimit; i += vecSize)
+                {
+                    // Widen Vector<float>.Count contiguous sbyte weights to FP32.
+                    // (Manual widen is the portable path; intrinsics-specific
+                    // ConvertToVector*Int32 + ConvertToVector*Single paths are
+                    // CPU-feature-gated and not portable to net471 without
+                    // additional version branches. The scalar widen is the
+                    // only non-vectorized op in the inner loop; the dominant
+                    // cost — the fma — is fully vectorized.)
+                    for (int j = 0; j < vecSize; j++)
+                    {
+                        weightChunk[j] = _weightsInt8[wBase + i + j];
+                    }
+                    var inputVec = new SimdVector(inputSpan.Slice(inputBase + i, vecSize));
+                    var weightVec = new SimdVector(weightChunk);
+                    sumVec += inputVec * weightVec * scaleVec;
+                }
+
+                // Reduce the SIMD accumulator to scalar. Vector.Sum is .NET 7+;
+                // since this assembly targets net471 as well we sum lanes
+                // explicitly.
+                float laneSum = 0;
+                for (int j = 0; j < vecSize; j++)
+                {
+                    laneSum += sumVec[j];
+                }
+                float sum = _biases[o] + laneSum;
+
+                // Tail: remaining (_inputSize % vecSize) elements via scalar.
+                for (; i < _inputSize; i++)
                 {
                     sum += inputSpan[inputBase + i] * (_weightsInt8[wBase + i] * scale);
                 }
+
                 output.SetFlat(outputBase + o, sum);
             }
         }

--- a/src/Inference/Quantization/QuantizedDenseLayer.cs
+++ b/src/Inference/Quantization/QuantizedDenseLayer.cs
@@ -125,11 +125,20 @@ internal sealed class QuantizedDenseLayer : LayerBase<float>
         // sbyte→float widen via a small stackalloc buffer + a portable
         // Vector<float> accumulator.
         //
+        // TFM gating: the Vector<float>(Span<float>) ctor is .NET Core 3.0+
+        // only. net471's Vector<T> only has (T value) broadcast and
+        // (T[] values, int startIndex) array overloads. Rather than allocate
+        // a float[] per chunk on net471 (which would defeat the SIMD win), we
+        // fall back to the original scalar inner loop on that TFM. net10.0
+        // production hosts get the full speedup; net471 legacy hosts get the
+        // status-quo scalar path.
+        //
         // Numerical equivalence: SIMD changes the order of accumulation
         // (associativity is approximate for FP32), so the result differs from
         // the scalar path by ~1 ULP per K elements summed. For the inference-
         // only use case this is well below the INT8 quantization noise floor
         // (~35-40 dB SNR on typical transformer weights, ~1e-2 relative error).
+#if NETCOREAPP3_0_OR_GREATER
         int vecSize = SimdVector.Count;
         Span<float> weightChunk = stackalloc float[vecSize];
         for (int b = 0; b < batchSize; b++)
@@ -148,12 +157,6 @@ internal sealed class QuantizedDenseLayer : LayerBase<float>
                 for (; i < vectorLimit; i += vecSize)
                 {
                     // Widen Vector<float>.Count contiguous sbyte weights to FP32.
-                    // (Manual widen is the portable path; intrinsics-specific
-                    // ConvertToVector*Int32 + ConvertToVector*Single paths are
-                    // CPU-feature-gated and not portable to net471 without
-                    // additional version branches. The scalar widen is the
-                    // only non-vectorized op in the inner loop; the dominant
-                    // cost — the fma — is fully vectorized.)
                     for (int j = 0; j < vecSize; j++)
                     {
                         weightChunk[j] = _weightsInt8[wBase + i + j];
@@ -164,8 +167,7 @@ internal sealed class QuantizedDenseLayer : LayerBase<float>
                 }
 
                 // Reduce the SIMD accumulator to scalar. Vector.Sum is .NET 7+;
-                // since this assembly targets net471 as well we sum lanes
-                // explicitly.
+                // sum lanes explicitly for net10.0 compatibility.
                 float laneSum = 0;
                 for (int j = 0; j < vecSize; j++)
                 {
@@ -182,6 +184,25 @@ internal sealed class QuantizedDenseLayer : LayerBase<float>
                 output.SetFlat(outputBase + o, sum);
             }
         }
+#else
+        // net471 scalar fallback — Vector<float>(Span<float>) ctor isn't available.
+        for (int b = 0; b < batchSize; b++)
+        {
+            int inputBase = b * featuresIn;
+            int outputBase = b * _outputSize;
+            for (int o = 0; o < _outputSize; o++)
+            {
+                float sum = _biases[o];
+                float scale = _rowScales[o];
+                int wBase = o * _inputSize;
+                for (int i = 0; i < _inputSize; i++)
+                {
+                    sum += inputSpan[inputBase + i] * (_weightsInt8[wBase + i] * scale);
+                }
+                output.SetFlat(outputBase + o, sum);
+            }
+        }
+#endif
 
         var activated = ApplyActivation(output);
         if (inputWas1D)

--- a/src/Inference/Quantization/QuantizedDenseLayer.cs
+++ b/src/Inference/Quantization/QuantizedDenseLayer.cs
@@ -112,36 +112,19 @@ internal sealed class QuantizedDenseLayer : LayerBase<float>
             throw new ArgumentException($"QuantizedDenseLayer input size mismatch. Expected {_inputSize}, got {featuresIn}.");
 
         var output = new Tensor<float>(new[] { batchSize, _outputSize });
-        var inputSpan = flat.AsSpan();
 
-        // Scalar dequant-on-fly matmul. The proper SIMD speedup for INT8
-        // weight-only inference belongs in AiDotNet.Tensors (which has full
-        // PyTorch-parity custom SIMD/AVX-512 acceleration faster than the
-        // System.Numerics primitives). Specifically, AiDotNet.Tensors already
-        // has `SimdGemm.SgemmWithInt8CachedB` for this exact use case, but it's
-        // currently internal to the Tensors-namespace. Once Tensors exposes a
-        // public INT8 weight matmul entry point (tracked in AiDotNet#1349),
-        // this loop should be replaced with a call to that engine op. Until
-        // then, the scalar path remains correct (just slow) — the inference-
-        // side perf gap is the same scope as #1349 and shouldn't be patched
-        // here with a third-party-library workaround that diverges from the
-        // engine layer's official SIMD path.
-        for (int b = 0; b < batchSize; b++)
-        {
-            int inputBase = b * featuresIn;
-            int outputBase = b * _outputSize;
-            for (int o = 0; o < _outputSize; o++)
-            {
-                float sum = _biases[o];
-                float scale = _rowScales[o];
-                int wBase = o * _inputSize;
-                for (int i = 0; i < _inputSize; i++)
-                {
-                    sum += inputSpan[inputBase + i] * (_weightsInt8[wBase + i] * scale);
-                }
-                output.SetFlat(outputBase + o, sum);
-            }
-        }
+        // INT8 weight-only matmul routed through AiDotNet.Tensors' tiled SGEMM
+        // + AVX2 dequant primitives. See Int8WeightOnlyMatMul for the layout
+        // contract and tile sizing strategy.
+        Int8WeightOnlyMatMul.MultiplyAddBias(
+            input: flat.AsSpan(),
+            weightsInt8: _weightsInt8,
+            rowScales: _rowScales,
+            biases: _biases,
+            output: output.AsWritableSpan(),
+            rows: batchSize,
+            inputSize: _inputSize,
+            outputSize: _outputSize);
 
         var activated = ApplyActivation(output);
         if (inputWas1D)

--- a/src/Inference/Quantization/QuantizedDenseLayer.cs
+++ b/src/Inference/Quantization/QuantizedDenseLayer.cs
@@ -2,7 +2,6 @@
 using AiDotNet.NeuralNetworks.Layers;
 using AiDotNet.Tensors.LinearAlgebra;
 using SimdVector = System.Numerics.Vector<float>;
-using SimdVectorOps = System.Numerics.Vector;
 
 namespace AiDotNet.Inference.Quantization;
 

--- a/tests/AiDotNet.Tests/UnitTests/Inference/Int8WeightOnlyMatMulTests.cs
+++ b/tests/AiDotNet.Tests/UnitTests/Inference/Int8WeightOnlyMatMulTests.cs
@@ -1,4 +1,5 @@
 using AiDotNet.Inference.Quantization;
+using AiDotNet.Tensors.Helpers;
 using Xunit;
 
 namespace AiDotNet.Tests.UnitTests.Inference;
@@ -51,7 +52,7 @@ public class Int8WeightOnlyMatMulTests
     public void MultiplyAddBias_MatchesScalarReference(
         int rows, int inputSize, int outputSize, bool withBias)
     {
-        var rng = new Random(0xC0DE);
+        var rng = RandomHelper.CreateSeededRandom(0xC0DE); // CSPRNG-aware seeded Random per RandomHelper contract; deterministic seed retained for test reproducibility
 
         var input = new float[rows * inputSize];
         for (int i = 0; i < input.Length; i++)
@@ -244,7 +245,7 @@ public class Int8WeightOnlyMatMulTests
         for (int o = 0; o < outputSize; o++) scales[o] = 0.5f; // every scale = 0.5
 
         var biases = new float[outputSize];
-        for (int o = 0; o < outputSize; o++) biases[o] = (float)o * 0.25f; // distinct per-row bias
+        for (int o = 0; o < outputSize; o++) biases[o] = (float)o * 0.25f; // distinct per-output-column bias (length == outputSize; indexed by output column o in [0, outputSize), NOT by row — review #1363 C8QYR)
 
         var output = new float[rows * outputSize];
 
@@ -279,16 +280,28 @@ public class Int8WeightOnlyMatMulTests
         // happens to choose dimensions where ChooseTileSize returns outputSize
         // and only one tile runs. inputSize=8192 → ChooseTileSize ≈ 16; with
         // outputSize=64 we get 4 tiles.
+        //
+        // Test-fixture invariant: this test EXPLICITLY depends on
+        // ChooseTileSize's current heuristic returning a value < outputSize
+        // for (outputSize=64, inputSize=8192). If a future tuning of
+        // ChooseTileSize raises the multi-tile threshold past this point,
+        // the assert below will fire with a clear "test fixture invariant"
+        // message — the failing test then signals "pick a larger
+        // outputSize / inputSize to force tiling" rather than the test
+        // silently degrading to a single-tile path (review #1363 C8QYu).
         const int rows = 2;
         const int inputSize = 8192;
         const int outputSize = 64;
 
         int chosen = Int8WeightOnlyMatMul.ChooseTileSize(outputSize, inputSize);
         Assert.True(chosen < outputSize,
-            $"Test fixture invariant: ChooseTileSize({outputSize}, {inputSize}) = {chosen} " +
-            $"must be < outputSize so the multi-tile scatter path runs.");
+            $"Test fixture invariant broken: ChooseTileSize({outputSize}, {inputSize}) = {chosen} " +
+            $"must be < outputSize so the multi-tile scatter path runs. Either ChooseTileSize's " +
+            $"tile-selection heuristic changed (raise outputSize / inputSize in this test to force " +
+            $"tiling), or the heuristic is intentionally collapsing single-tile for these dims " +
+            $"(then split this test into a separate fixture that hits the multi-tile path).");
 
-        var rng = new Random(0xC0DE);
+        var rng = RandomHelper.CreateSeededRandom(0xC0DE); // CSPRNG-aware seeded Random per RandomHelper contract; deterministic seed retained for test reproducibility
         var input = new float[rows * inputSize];
         for (int i = 0; i < input.Length; i++) input[i] = (float)(rng.NextDouble() * 2 - 1);
         var weights = new sbyte[outputSize * inputSize];

--- a/tests/AiDotNet.Tests/UnitTests/Inference/Int8WeightOnlyMatMulTests.cs
+++ b/tests/AiDotNet.Tests/UnitTests/Inference/Int8WeightOnlyMatMulTests.cs
@@ -1,0 +1,165 @@
+using AiDotNet.Inference.Quantization;
+using Xunit;
+
+namespace AiDotNet.Tests.UnitTests.Inference;
+
+/// <summary>
+/// Regression test for AiDotNet#1363 — the scalar dequant-on-fly matmul in
+/// <c>QuantizedDenseLayer</c> / <c>QuantizedAttentionLayer</c> was replaced
+/// with a tiled SGEMM + AVX2 dequant path through <c>Int8WeightOnlyMatMul</c>.
+/// These tests verify the new helper agrees with the original scalar
+/// reference at FP32 precision (≤ 1 ULP per element typical, well below the
+/// per-row symmetric int8 quantization noise floor).
+/// </summary>
+public class Int8WeightOnlyMatMulTests
+{
+    private static void ScalarReference(
+        ReadOnlySpan<float> input,
+        sbyte[] weightsInt8,
+        float[] rowScales,
+        float[]? biases,
+        Span<float> output,
+        int rows,
+        int inputSize,
+        int outputSize)
+    {
+        for (int r = 0; r < rows; r++)
+        {
+            int inputBase = r * inputSize;
+            int outputBase = r * outputSize;
+            for (int o = 0; o < outputSize; o++)
+            {
+                float sum = biases != null ? biases[o] : 0f;
+                float scale = rowScales[o];
+                int wBase = o * inputSize;
+                for (int i = 0; i < inputSize; i++)
+                {
+                    sum += input[inputBase + i] * (weightsInt8[wBase + i] * scale);
+                }
+                output[outputBase + o] = sum;
+            }
+        }
+    }
+
+    [Theory]
+    [InlineData(1, 16, 16, true)]    // smaller-than-tile
+    [InlineData(4, 32, 64, true)]    // normal small
+    [InlineData(8, 128, 256, true)]  // multi-tile typical transformer FFN
+    [InlineData(2, 512, 2048, true)] // BERT FFN scale
+    [InlineData(3, 33, 47, true)]    // unaligned shapes
+    [InlineData(4, 128, 64, false)]  // no bias
+    public void MultiplyAddBias_MatchesScalarReference(
+        int rows, int inputSize, int outputSize, bool withBias)
+    {
+        var rng = new Random(0xC0DE);
+
+        var input = new float[rows * inputSize];
+        for (int i = 0; i < input.Length; i++)
+            input[i] = (float)(rng.NextDouble() * 2 - 1);
+
+        var weightsInt8 = new sbyte[outputSize * inputSize];
+        for (int i = 0; i < weightsInt8.Length; i++)
+            weightsInt8[i] = (sbyte)rng.Next(-127, 128);
+
+        var rowScales = new float[outputSize];
+        for (int o = 0; o < outputSize; o++)
+            rowScales[o] = (float)(rng.NextDouble() * 0.01 + 0.001);
+
+        float[]? biases = null;
+        if (withBias)
+        {
+            biases = new float[outputSize];
+            for (int o = 0; o < outputSize; o++)
+                biases[o] = (float)(rng.NextDouble() * 0.1);
+        }
+
+        var expected = new float[rows * outputSize];
+        ScalarReference(input, weightsInt8, rowScales, biases, expected,
+            rows, inputSize, outputSize);
+
+        var actual = new float[rows * outputSize];
+        Int8WeightOnlyMatMul.MultiplyAddBias(
+            input, weightsInt8, rowScales, biases, actual,
+            rows, inputSize, outputSize);
+
+        // The SIMD path and the scalar reference compute the same mathematical
+        // expression; the only divergence is float-summation order (BLIS k-loop
+        // packing vs naive sequential). Allow a tolerance proportional to the
+        // accumulation magnitude — ≈ 2 × max|value| × √K × 1e-6 (single ULP at
+        // each FMA, accumulated in sqrt-mean over independent paths).
+        double maxAbs = 0;
+        for (int i = 0; i < expected.Length; i++)
+        {
+            double a = Math.Abs(expected[i]);
+            if (a > maxAbs) maxAbs = a;
+        }
+        double absTol = 2.0 * Math.Max(1e-3, maxAbs) * Math.Sqrt(inputSize) * 1.5e-6;
+
+        for (int i = 0; i < expected.Length; i++)
+        {
+            double diff = Math.Abs(expected[i] - actual[i]);
+            Assert.True(
+                diff <= absTol,
+                $"Element {i}: expected {expected[i]}, got {actual[i]}, diff={diff}, absTol={absTol}, maxAbs={maxAbs}");
+        }
+    }
+
+    [Fact]
+    public void MultiplyAddBias_NoBias_ClearsOutputBetweenTiles()
+    {
+        // Single-row sanity check: with all weights = 0 and no bias, the
+        // tile-output scatter must not leak prior contents into the destination.
+        int rows = 1, inputSize = 64, outputSize = 256;
+
+        var input = new float[rows * inputSize];
+        for (int i = 0; i < input.Length; i++) input[i] = 1.0f;
+
+        var weightsInt8 = new sbyte[outputSize * inputSize]; // all zeros
+        var rowScales = new float[outputSize];
+        for (int o = 0; o < outputSize; o++) rowScales[o] = 0.123f;
+
+        // Pre-fill output with sentinel so we can detect any leak from
+        // ArrayPool-rented tile scratch into the user-visible buffer.
+        var output = new float[rows * outputSize];
+        for (int i = 0; i < output.Length; i++) output[i] = 999.0f;
+
+        Int8WeightOnlyMatMul.MultiplyAddBias(
+            input, weightsInt8, rowScales, biases: null, output,
+            rows, inputSize, outputSize);
+
+        for (int i = 0; i < output.Length; i++)
+        {
+            Assert.True(output[i] == 0f,
+                $"Expected 0 at index {i}, got {output[i]} — tile scratch leaked into output.");
+        }
+    }
+
+    [Fact]
+    public void MultiplyAddBias_ZeroRows_DoesNotThrow()
+    {
+        var input = Array.Empty<float>();
+        var weights = new sbyte[16];
+        var scales = new float[4];
+        var output = Array.Empty<float>();
+
+        Int8WeightOnlyMatMul.MultiplyAddBias(
+            input, weights, scales, biases: null, output,
+            rows: 0, inputSize: 4, outputSize: 4);
+        // No assertion needed — the contract is "do not throw / segfault".
+    }
+
+    [Theory]
+    [InlineData(16, 16)]
+    [InlineData(64, 4096)]
+    [InlineData(128, 1)]
+    [InlineData(8192, 32)]
+    public void ChooseTileSize_StaysWithinBounds(int outputSize, int inputSize)
+    {
+        int tile = Int8WeightOnlyMatMul.ChooseTileSize(outputSize, inputSize);
+        Assert.True(tile > 0, "Tile size must be positive.");
+        Assert.True(tile <= outputSize, $"Tile {tile} must not exceed outputSize {outputSize}.");
+        // Either we returned at most outputSize (tiny case) or a 16-aligned tile.
+        Assert.True(tile == outputSize || tile % 16 == 0,
+            $"Tile {tile} must be a multiple of 16 unless it equals outputSize.");
+    }
+}

--- a/tests/AiDotNet.Tests/UnitTests/Inference/Int8WeightOnlyMatMulTests.cs
+++ b/tests/AiDotNet.Tests/UnitTests/Inference/Int8WeightOnlyMatMulTests.cs
@@ -148,6 +148,123 @@ public class Int8WeightOnlyMatMulTests
         // No assertion needed — the contract is "do not throw / segfault".
     }
 
+    [Fact]
+    public void MultiplyAddBias_ZeroRows_OversizedOutputBuffer_PreservesSentinels()
+    {
+        // The early-return for rows == 0 must NOT zero the caller's span when
+        // the span is larger than the logical (rows*outputSize == 0) region.
+        // Pre-fill an oversized buffer with sentinels and assert they survive.
+        var input = Array.Empty<float>();
+        var weights = new sbyte[16];
+        var scales = new float[4];
+        var output = new float[8];
+        for (int i = 0; i < output.Length; i++) output[i] = 12345.0f;
+
+        Int8WeightOnlyMatMul.MultiplyAddBias(
+            input, weights, scales, biases: null, output.AsSpan(),
+            rows: 0, inputSize: 4, outputSize: 4);
+
+        for (int i = 0; i < output.Length; i++)
+        {
+            Assert.Equal(12345.0f, output[i]);
+        }
+    }
+
+    [Fact]
+    public void MultiplyAddBias_OutputSizeZero_OversizedOutputBuffer_PreservesSentinels()
+    {
+        // Same as above but for the outputSize == 0 early-return branch.
+        var input = new float[8];
+        var weights = Array.Empty<sbyte>();
+        var scales = Array.Empty<float>();
+        var output = new float[8];
+        for (int i = 0; i < output.Length; i++) output[i] = 54321.0f;
+
+        Int8WeightOnlyMatMul.MultiplyAddBias(
+            input, weights, scales, biases: null, output.AsSpan(),
+            rows: 2, inputSize: 4, outputSize: 0);
+
+        for (int i = 0; i < output.Length; i++)
+        {
+            Assert.Equal(54321.0f, output[i]);
+        }
+    }
+
+    [Fact]
+    public void MultiplyAddBias_InputSizeZero_FillsOutputWithBias()
+    {
+        // The inputSize == 0 branch must populate output with biases (or zero
+        // when biases is null) and skip the Sgemm call entirely. rowScales is
+        // still required at length outputSize (per-row scales exist
+        // independently of the inner dim).
+        var input = Array.Empty<float>();
+        var weights = Array.Empty<sbyte>();
+        var scales = new[] { 0.1f, 0.2f, 0.3f };
+        var biases = new[] { 1.5f, 2.5f, 3.5f };
+        var output = new float[6]; // 2 rows * 3 outputs
+
+        Int8WeightOnlyMatMul.MultiplyAddBias(
+            input, weights, scales, biases, output.AsSpan(),
+            rows: 2, inputSize: 0, outputSize: 3);
+
+        Assert.Equal(1.5f, output[0]);
+        Assert.Equal(2.5f, output[1]);
+        Assert.Equal(3.5f, output[2]);
+        Assert.Equal(1.5f, output[3]);
+        Assert.Equal(2.5f, output[4]);
+        Assert.Equal(3.5f, output[5]);
+
+        // No biases -> zero
+        var outputNoBias = new float[3];
+        for (int i = 0; i < outputNoBias.Length; i++) outputNoBias[i] = 99.0f;
+        Int8WeightOnlyMatMul.MultiplyAddBias(
+            input, weights, scales, biases: null, outputNoBias.AsSpan(),
+            rows: 1, inputSize: 0, outputSize: 3);
+        Assert.Equal(0f, outputNoBias[0]);
+        Assert.Equal(0f, outputNoBias[1]);
+        Assert.Equal(0f, outputNoBias[2]);
+    }
+
+    [Fact]
+    public void MultiplyAddBias_MultiTile_ActuallyTilesOutput()
+    {
+        // Force an outputSize that exceeds ChooseTileSize so the multi-tile
+        // scatter path is exercised — the existing "scatter doesn't leak" test
+        // happens to choose dimensions where ChooseTileSize returns outputSize
+        // and only one tile runs. inputSize=8192 → ChooseTileSize ≈ 16; with
+        // outputSize=64 we get 4 tiles.
+        const int rows = 2;
+        const int inputSize = 8192;
+        const int outputSize = 64;
+
+        int chosen = Int8WeightOnlyMatMul.ChooseTileSize(outputSize, inputSize);
+        Assert.True(chosen < outputSize,
+            $"Test fixture invariant: ChooseTileSize({outputSize}, {inputSize}) = {chosen} " +
+            $"must be < outputSize so the multi-tile scatter path runs.");
+
+        var rng = new Random(0xC0DE);
+        var input = new float[rows * inputSize];
+        for (int i = 0; i < input.Length; i++) input[i] = (float)(rng.NextDouble() * 2 - 1);
+        var weights = new sbyte[outputSize * inputSize];
+        for (int i = 0; i < weights.Length; i++) weights[i] = (sbyte)rng.Next(-127, 128);
+        var scales = new float[outputSize];
+        for (int o = 0; o < outputSize; o++) scales[o] = (float)(rng.NextDouble() * 0.01 + 0.001);
+
+        var output = new float[rows * outputSize];
+        // Pre-fill with sentinel so an unwritten tile would surface.
+        for (int i = 0; i < output.Length; i++) output[i] = 9999.0f;
+
+        Int8WeightOnlyMatMul.MultiplyAddBias(
+            input, weights, scales, biases: null, output,
+            rows, inputSize, outputSize);
+
+        // Every output element must have been overwritten — sentinel cannot survive.
+        for (int i = 0; i < output.Length; i++)
+        {
+            Assert.NotEqual(9999.0f, output[i]);
+        }
+    }
+
     [Theory]
     [InlineData(16, 16)]
     [InlineData(64, 4096)]

--- a/tests/AiDotNet.Tests/UnitTests/Inference/Int8WeightOnlyMatMulTests.cs
+++ b/tests/AiDotNet.Tests/UnitTests/Inference/Int8WeightOnlyMatMulTests.cs
@@ -191,38 +191,84 @@ public class Int8WeightOnlyMatMulTests
     }
 
     [Fact]
-    public void MultiplyAddBias_InputSizeZero_FillsOutputWithBias()
+    public void MultiplyAddBias_InputSizeZero_ThrowsArgumentOutOfRange()
     {
-        // The inputSize == 0 branch must populate output with biases (or zero
-        // when biases is null) and skip the Sgemm call entirely. rowScales is
-        // still required at length outputSize (per-row scales exist
-        // independently of the inner dim).
+        // The inputSize == 0 case is now rejected explicitly (review #1363
+        // C6XGR) — production callers validate input dim upstream and
+        // a positive rows/outputSize combined with inputSize=0 only arrives
+        // from a misconfigured caller. Failing fast surfaces the upstream
+        // bug at the matmul call instead of producing a silent
+        // zero-or-bias-only result.
         var input = Array.Empty<float>();
         var weights = Array.Empty<sbyte>();
         var scales = new[] { 0.1f, 0.2f, 0.3f };
         var biases = new[] { 1.5f, 2.5f, 3.5f };
         var output = new float[6]; // 2 rows * 3 outputs
 
+        var ex = Assert.Throws<ArgumentOutOfRangeException>(() =>
+        {
+            Int8WeightOnlyMatMul.MultiplyAddBias(
+                input, weights, scales, biases, output.AsSpan(),
+                rows: 2, inputSize: 0, outputSize: 3);
+        });
+        Assert.Equal("inputSize", ex.ParamName);
+        Assert.Contains("must be positive", ex.Message);
+    }
+
+    [Fact]
+    public void MultiplyAddBias_MultiTile_WithBias_BiasAppliedInEveryTile()
+    {
+        // Exercises the `biases != null` branch in the MULTI-tile path
+        // (review #1363 C6XHK — the prior MultiTile test had biases=null
+        // and the prior MatchesScalarReference cases used inputSize<=512
+        // where ChooseTileSize returned outputSize, so the multi-tile
+        // bias-add scatter loop was never tested in isolation).
+        //
+        // inputSize=8192 forces ChooseTileSize ≈ 16; with outputSize=64
+        // that's 4 tiles. Bias is row-shaped (length outputSize) so the
+        // scatter must offset by oBase on each tile and produce the
+        // correct sum per output column.
+        const int rows = 2;
+        const int inputSize = 8192;
+        const int outputSize = 64;
+
+        // Deterministic small weights and biases so we can compute the
+        // expected output exactly without an SIMD-equivalence reference.
+        var input = new float[rows * inputSize];
+        for (int i = 0; i < input.Length; i++) input[i] = 1.0f; // every input element = 1
+
+        var weights = new sbyte[outputSize * inputSize];
+        for (int i = 0; i < weights.Length; i++) weights[i] = 1; // every weight = 1
+
+        var scales = new float[outputSize];
+        for (int o = 0; o < outputSize; o++) scales[o] = 0.5f; // every scale = 0.5
+
+        var biases = new float[outputSize];
+        for (int o = 0; o < outputSize; o++) biases[o] = (float)o * 0.25f; // distinct per-row bias
+
+        var output = new float[rows * outputSize];
+
         Int8WeightOnlyMatMul.MultiplyAddBias(
             input, weights, scales, biases, output.AsSpan(),
-            rows: 2, inputSize: 0, outputSize: 3);
+            rows: rows, inputSize: inputSize, outputSize: outputSize);
 
-        Assert.Equal(1.5f, output[0]);
-        Assert.Equal(2.5f, output[1]);
-        Assert.Equal(3.5f, output[2]);
-        Assert.Equal(1.5f, output[3]);
-        Assert.Equal(2.5f, output[4]);
-        Assert.Equal(3.5f, output[5]);
-
-        // No biases -> zero
-        var outputNoBias = new float[3];
-        for (int i = 0; i < outputNoBias.Length; i++) outputNoBias[i] = 99.0f;
-        Int8WeightOnlyMatMul.MultiplyAddBias(
-            input, weights, scales, biases: null, outputNoBias.AsSpan(),
-            rows: 1, inputSize: 0, outputSize: 3);
-        Assert.Equal(0f, outputNoBias[0]);
-        Assert.Equal(0f, outputNoBias[1]);
-        Assert.Equal(0f, outputNoBias[2]);
+        // Each output cell = sum_k(input[r,k] * (weights[o,k]*scale[o])) + bias[o]
+        //                 = inputSize * (1 * 0.5) + 0.25 * o
+        //                 = 4096 + 0.25 * o
+        // Note: SimdGemm uses fp32 arithmetic — for inputSize=8192 the
+        // exact result is well within float precision.
+        float baseDot = inputSize * 0.5f; // 4096
+        for (int r = 0; r < rows; r++)
+        {
+            for (int o = 0; o < outputSize; o++)
+            {
+                float expected = baseDot + biases[o];
+                Assert.True(
+                    Math.Abs(output[r * outputSize + o] - expected) < 1e-2f,
+                    $"At [{r},{o}] expected ≈{expected}, got {output[r * outputSize + o]}. " +
+                    $"Multi-tile bias scatter offset by oBase per tile must apply biases[{o}]={biases[o]}.");
+            }
+        }
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Partial fix for **#1349** — INT8 inference is currently **20.6× slower** than FP32 baseline (per PR #1348 measurement: 4.16ms vs 0.20ms on the canary Transformer). Root cause: both `QuantizedDenseLayer.Forward` and `QuantizedAttentionLayer.DequantizeMatMulInt8` use a scalar 3-loop dequant-on-fly:

\`\`\`csharp
for (int i = 0; i < inputSize; i++)
    sum += input[i] * (weightsInt8[i] * scale);  // sbyte→float widen + fma per iter, scalar
\`\`\`

This PR vectorizes the inner loop using portable `System.Numerics.Vector<float>`:
- Process `Vector<float>.Count` contiguous (input, weight) pairs per iteration (8 lanes on AVX2, 16 on AVX-512)
- Widen `sbyte` chunk to FP32 via a small `stackalloc` buffer
- Accumulate into a Vector register, reduce to scalar at the end
- Preserve tail handling for `inputSize % Vector<float>.Count`

## Numerical equivalence

SIMD changes the order of accumulation (FP32 associativity is approximate), so the result differs from the scalar path by ~1 ULP per K elements summed. For the inference-only use case this is well below the INT8 quantization noise floor (~35-40 dB SNR on typical transformer weights, ~1e-2 relative error).

## Files

- `src/Inference/Quantization/QuantizedDenseLayer.cs` — Forward inner loop vectorized
- `src/Inference/Quantization/QuantizedAttentionLayer.cs` — DequantizeMatMulInt8 inner loop vectorized

## Expected impact

The widen step is still scalar (the only non-vectorized op in the inner loop); the dominant cost — the FMA — is fully vectorized. Expected speedup: 4-8× on AVX2 hosts, 8-16× on AVX-512 hosts. Won't reach FP32 parity (still need pre-packed cached B + cache-blocked tiling per SimdGemm.SgemmWithInt8CachedB), but closes the bulk of the gap.

## Partial fix scope

Full fix (cached pre-packed INT8 B + cache-blocked SimdGemm path) remains tracked in #1349 for follow-up. That requires either:
- A Tensors-side API that accepts pre-quantized weights + scales (vs the current FP32-input variant that quantizes internally)
- Or refactoring `QuantizedDenseLayer` / `QuantizedAttentionLayer` to keep FP32 weights and let SimdGemm cache the INT8 version internally (defeats the 4× memory savings)

## Closes (partial)

Partial: #1349

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved INT8 quantized inference path to use an accelerated weight-only matrix multiply for better performance.

* **Bug Fixes**
  * Ensures outputs are correctly cleared between processing tiles, handles zero-row/output cases, and correctly applies per-output biases for zero-input-size.

* **Tests**
  * Added unit tests validating INT8 matmul correctness, boundary shapes, bias behavior, and output isolation.

* **Documentation**
  * Added clarifying notes about current scalar behavior and planned SIMD/tensor-math improvements.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ooples/AiDotNet/pull/1363?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->