### PR TITLE
fix(#1355): auto-record per-thread allocations on ProfilerSession scopes

### DIFF
--- a/src/Diagnostics/ProfilerSession.cs
+++ b/src/Diagnostics/ProfilerSession.cs
@@ -446,6 +446,13 @@ public class ProfilerSessionTimer : IDisposable
     // (either ProfilingConfig.TrackAllocations=false OR running on net471
     // where GC.GetAllocatedBytesForCurrentThread is not available).
     private readonly long _allocBytesAtStart;
+    // AiDotNet#1355: capture the managed thread the scope was opened on
+    // so Stop() can refuse to record an allocation delta when the timer
+    // crossed an `await` and resumed on a different thread. The per-
+    // thread allocation counters at start vs. end would then belong to
+    // unrelated threads and produce nonsense (or wildly negative)
+    // deltas. Better to skip the recording than to publish bad data.
+    private readonly int _threadIdAtStart;
 
     /// <summary>
     /// Gets the name of this profiler timer.
@@ -458,6 +465,7 @@ public class ProfilerSessionTimer : IDisposable
         _name = name;
         _stopwatch = Stopwatch.StartNew();
         _stopped = false;
+        _threadIdAtStart = Environment.CurrentManagedThreadId;
         _allocBytesAtStart = session.Config.TrackAllocations
             ? TryGetThreadAllocatedBytes()
             : -1L;
@@ -502,7 +510,15 @@ public class ProfilerSessionTimer : IDisposable
         // This matches PyTorch's torch.profiler.profile(profile_memory=True)
         // semantics — parent timings always cover child timings — and is
         // documented as such on ProfilingConfig.TrackAllocations.
-        if (_allocBytesAtStart >= 0)
+        // Skip the allocation delta when the timer crossed an `await`
+        // and resumed on a different managed thread — comparing the
+        // start-thread's per-thread allocation counter with the
+        // resume-thread's counter is comparing unrelated values and
+        // can publish wildly wrong numbers (or negative deltas). The
+        // timing measurement still records correctly because Stopwatch
+        // is wall-clock and thread-agnostic.
+        if (_allocBytesAtStart >= 0
+            && Environment.CurrentManagedThreadId == _threadIdAtStart)
         {
             long allocBytesAtEnd = TryGetThreadAllocatedBytes();
             if (allocBytesAtEnd >= 0)

--- a/src/Diagnostics/ProfilerSession.cs
+++ b/src/Diagnostics/ProfilerSession.cs
@@ -441,6 +441,11 @@ public class ProfilerSessionTimer : IDisposable
     private readonly Stopwatch _stopwatch;
     private readonly string? _parentName;
     private bool _stopped;
+    // AiDotNet#1355: snapshot per-thread allocation counter at scope entry
+    // so Stop() can report the delta. Negative sentinel == "not tracked"
+    // (either ProfilingConfig.TrackAllocations=false OR running on net471
+    // where GC.GetAllocatedBytesForCurrentThread is not available).
+    private readonly long _allocBytesAtStart;
 
     /// <summary>
     /// Gets the name of this profiler timer.
@@ -453,10 +458,27 @@ public class ProfilerSessionTimer : IDisposable
         _name = name;
         _stopwatch = Stopwatch.StartNew();
         _stopped = false;
+        _allocBytesAtStart = session.Config.TrackAllocations
+            ? TryGetThreadAllocatedBytes()
+            : -1L;
 
         var stack = session.GetCallStack();
         _parentName = stack.Count > 0 ? stack.Peek().Name : null;
         stack.Push(this);
+    }
+
+    /// <summary>
+    /// AiDotNet#1355 helper: sample <c>GC.GetAllocatedBytesForCurrentThread</c>
+    /// on platforms that ship it (.NET Core 3.0+ / .NET 5+ / .NET 10) and
+    /// return -1 on net471 which has no per-thread allocation API.
+    /// </summary>
+    private static long TryGetThreadAllocatedBytes()
+    {
+#if NETCOREAPP3_0_OR_GREATER
+        return GC.GetAllocatedBytesForCurrentThread();
+#else
+        return -1L;
+#endif
     }
 
     /// <summary>
@@ -469,6 +491,29 @@ public class ProfilerSessionTimer : IDisposable
 
         _stopwatch.Stop();
         _session.RecordTiming(_name, _stopwatch.Elapsed, _parentName);
+
+        // AiDotNet#1355: emit memory-allocation delta when tracking is on
+        // and the platform exposed a baseline at scope entry. The negative
+        // sentinel guards both the disabled-tracking path and the
+        // platform-without-API path.
+        //
+        // Note: the per-thread counter aggregates ALL allocations on this
+        // thread, so nested scopes will double-count parent allocations.
+        // This matches PyTorch's torch.profiler.profile(profile_memory=True)
+        // semantics — parent timings always cover child timings — and is
+        // documented as such on ProfilingConfig.TrackAllocations.
+        if (_allocBytesAtStart >= 0)
+        {
+            long allocBytesAtEnd = TryGetThreadAllocatedBytes();
+            if (allocBytesAtEnd >= 0)
+            {
+                long delta = allocBytesAtEnd - _allocBytesAtStart;
+                if (delta > 0)
+                {
+                    _session.RecordAllocation(_name, delta);
+                }
+            }
+        }
 
         // Clean up from call stack - handle case where nested timers were not stopped in order
         // (e.g., due to exceptions causing early exit)


### PR DESCRIPTION
## Summary

Closes **#1355** — `ProfilingConfig.TrackAllocations=true` had no observable effect on `ProfilerSession.Scope(name)`. `RecordAllocation` was `internal`, and no code path sampled `GC.GetAllocatedBytesForCurrentThread` inside the timer's lifecycle. Consumers configuring `TrackAllocations` got zero allocation telemetry.

## Fix

`ProfilerSessionTimer` now:
- **Constructor**: snapshot the per-thread allocation counter (when `TrackAllocations` is on AND the runtime exposes the API)
- **Stop()**: sample again, emit the positive delta to `session.RecordAllocation(name, bytes)`

Negative sentinel (`-1L`) handles two off-paths:
- `TrackAllocations=false` (no overhead — single bool check)
- net471 (no per-thread allocation API; compile-time gated via `NETCOREAPP3_0_OR_GREATER`)

## Semantics

Matches PyTorch `torch.profiler.profile(profile_memory=true)` — nested scopes double-count parent allocations because the per-thread counter is monotonic. Documented in `ProfilingConfig.TrackAllocations` XML doc.

## Discovered by

HarmonicEngine consumer audit when wiring `ConfigureProfiling` — measured `peak managed MB +91.7 / +92.3` from `Process.WorkingSet64` deltas but the `ProfileReport.GetStats("predict")` allocation field was always zero. Filed as part of the "stored config never consumed" family (#1354 Mixed Precision, #1357 Adversarial, Tensors#363 PerformanceProfiler CPU path).

## Closes

#1355

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Profiler sessions now optionally record per-thread memory allocations on supported platforms. The profiler captures a baseline at scope start, verifies thread consistency at stop, computes positive allocation deltas, and records them when available—offering improved visibility into thread-specific allocation behavior during profiling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ooples/AiDotNet/pull/1365?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->