### PR TITLE
fix(BuildAsync): call RegisterModel before CreateModelVersion

### DIFF
--- a/src/AiModelBuilder.cs
+++ b/src/AiModelBuilder.cs
@@ -3295,6 +3295,23 @@ public partial class AiModelBuilder<T, TInput, TOutput> : IAiModelBuilder<T, TIn
                 }
             }
 
+            // Register the model name first — CreateModelVersion requires a
+            // pre-existing registration. Without this call, the upstream
+            // CreateModelVersion throws ArgumentException ("Model not found
+            // in registry"). Discovered by AiDotNet#1345's integration-test
+            // framework (Bucket3_QualityOfLifeTests
+            // ConfigureModelRegistry_AndBuildAsync_TracksTrainedModel).
+            _modelRegistry.RegisterModel(
+                name: registeredModelName,
+                model: optimizationResult.BestSolution,
+                metadata: modelMetadata,
+                tags: new Dictionary<string, string>
+                {
+                    ["auto-registered"] = "true",
+                    ["source"] = "build-async",
+                    ["registered-at"] = trainingStartTime.ToString("yyyy-MM-ddTHH:mm:ssZ")
+                });
+
             modelVersion = _modelRegistry.CreateModelVersion(
                 modelName: registeredModelName,
                 model: optimizationResult.BestSolution,


### PR DESCRIPTION
## Summary

`AiModelBuilder.BuildSupervisedInternalAsync` (line 3298) called `_modelRegistry.CreateModelVersion(...)` without first calling `RegisterModel(...)`. Per `IModelRegistry<T,TInput,TOutput>`, `CreateModelVersion` creates additional versions of an **already-registered** model name. Without a prior `RegisterModel`, the implementation throws `ArgumentException("Model not found in registry")`.

## Discovery

Filed by AiDotNet#1345's integration-test framework when wiring `ConfigureModelRegistry`. The test `Bucket3_QualityOfLifeTests.ConfigureModelRegistry_AndBuildAsync_TracksTrainedModel` was marked `[Skip]` documenting the bug.

## Fix

Insert `RegisterModel(...)` call immediately before `CreateModelVersion` with auto-registered metadata + provenance tags:

```csharp
_modelRegistry.RegisterModel(
    name: registeredModelName,
    model: optimizationResult.BestSolution,
    metadata: modelMetadata,
    tags: new Dictionary<string, string> {
        ["auto-registered"] = "true",
        ["source"] = "build-async",
        ["registered-at"] = trainingStartTime.ToString("yyyy-MM-ddTHH:mm:ssZ")
    });

modelVersion = _modelRegistry.CreateModelVersion(...);
```

## Verification

Build clean on net10.0. The skipped test in PR #1345 can be un-Skip'd after this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where model version creation would fail due to improper model registration. Models are now automatically registered with relevant metadata before version creation, ensuring the process completes successfully.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ooples/AiDotNet/pull/1367?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->