### PR TITLE
chore(audit): address AiDotNet_Audit_Summary.docx findings

### DIFF
--- a/.github/workflows/automated-release.yml
+++ b/.github/workflows/automated-release.yml
@@ -291,10 +291,26 @@ jobs:
         if: steps.version.outputs.should_release == 'true'
         run: dotnet build -c Release --no-restore
 
-  # NOTE: Tests are NOT run in the release pipeline because:
-  # 1. Tests are already required to pass before PRs can be merged
-  # 2. This avoids duplicate test runs and speeds up releases
-  # 3. SDK version conflicts between CI runners and project requirements are avoided
+      # Smoke-test gate before pack/publish. Master-CI gating IS the
+      # primary safety net (PRs cannot merge if tests fail), but a
+      # release-time smoke test catches:
+      #   - master-CI flakiness that landed a passing-by-retry commit
+      #   - drift between CI test SDK and release-runner SDK
+      #   - last-minute pre-publish commits (auto-commit version bumps,
+      #     CHANGELOG generation) that altered behavior without
+      #     re-triggering CI
+      # The filter `Category=Smoke|FullyQualifiedName~SmokeTests` selects
+      # a fast subset (~< 1 minute target). When no smoke-tagged tests
+      # exist, the test discovery completes successfully with zero tests
+      # run — the gate passes without blocking releases that haven't yet
+      # adopted the Category=Smoke convention.
+      - name: Smoke tests (release gate)
+        if: steps.version.outputs.should_release == 'true'
+        run: |
+          dotnet test tests/AiDotNet.Tests/AiDotNetTests.csproj \
+            --no-build -c Release --framework net10.0 \
+            --filter "Category=Smoke|FullyQualifiedName~SmokeTests" \
+            --logger "console;verbosity=normal"
 
   # Pack NuGet after version-and-build completes
   pack:

--- a/README.md
+++ b/README.md
@@ -1166,6 +1166,44 @@ Key namespaces:
 
 ---
 
+## Feature Maturity
+
+The repository ships a wide surface; not every subsystem is at the same
+maturity level. The labels below set expectations for enterprise
+consumers — `stable` features are appropriate for production use today;
+`beta` features are functional but may have visible rough edges or API
+churn; `experimental` features are exploratory and should not be relied
+on in production; `preview` indicates work-in-progress that may not yet
+be feature-complete; `stub` indicates an interface present for forward
+compatibility but without a substantial implementation.
+
+| Subsystem | Maturity | Notes |
+|-----------|----------|-------|
+| Classical ML (regression, classification, clustering, time series) | stable | Long-standing surface, extensive tests. |
+| Neural networks core (training, inference, autodiff tape) | stable | Active hardening; recent fixes for #1380 / #1382 mode-collapse + facade gradient bridge. |
+| Optimizers (Adam, AdamW, SGD, etc.) | stable | Per-tensor + flat-vector paths; gradient clipping and mixed precision supported. |
+| Layers + activations + losses | stable | Bottom-up invariant tests at 94% pass rate. |
+| Diffusion / image generation | beta | Implementation present; sample-quality benchmarks pending. |
+| Reinforcement learning agents | beta | API stable; broader benchmark suite in progress. |
+| Federated learning (DP-SGD, secure aggregation) | beta | Privacy primitives present; production deployments should validate threat model. |
+| RAG / retrieval | beta | Retriever + generator + chunking are functional; LangChain-style orchestration is lighter. |
+| LoRA fine-tuning | beta | Adapter wiring works; quantized LoRA path is newer. |
+| AiDotNet.Serving (REST API for inference) | beta | Default-allow-list auth and CORS hardened in this PR; observability + audit logging still developing. |
+| Program synthesis (sandboxed code generation) | experimental | High-risk surface — disable unless explicitly required and isolated. |
+| ONNX / external-model interop | beta | Import covered; export coverage is partial. |
+| Native acceleration (OpenBLAS, BLAS, fused kernels) | beta | CPU SIMD paths shipped; GPU determinism is being pinned (see GpuTransformerDeterminismTests). |
+| Telemetry (opt-in via `AIDOTNET_TELEMETRY=true`) | stable | No PII or model data collected; collects usage metrics only. |
+| Licensing (BSL 1.1 + commercial tiers) | stable | API-key hashing (PBKDF2-SHA256), AES-GCM-encrypted model artifacts on supported frameworks. |
+| OpenTelemetry integration (serving) | preview | Opt-in scaffold added in this audit-hardening PR; full meters/traces in progress. |
+| Speculative decoding REST endpoint | stub | Endpoint returns 501; implementation deferred. |
+| LoRA fine-tuning REST endpoint | stub | Endpoint returns 501; use the in-process API directly. |
+
+> The labels reflect a static review of the public repository. They are
+> informational only — production adopters should validate against
+> their own threat model and SLA requirements.
+
+---
+
 ## Platform Support
 
 | Platform | Status |

--- a/docs/MODEL_CARD_TEMPLATE.md
+++ b/docs/MODEL_CARD_TEMPLATE.md
@@ -1,0 +1,79 @@
+# Model Card — `<model name>`
+
+> Fill out one card per trained model artifact your team ships or relies on.
+> A model card documents what a model is, how it was built, and where it is
+> safe to use. Reviewers, auditors, and downstream consumers should be able
+> to read one to decide whether the model is fit for purpose.
+
+## Summary
+
+| Field | Value |
+|---|---|
+| Model name | _e.g._ `byte-lm-transformer-v2` |
+| Version / hash | _commit SHA, weight hash, or release tag_ |
+| Author / owner | _team or individual responsible_ |
+| Last updated | _YYYY-MM-DD_ |
+| License | _e.g._ BSL 1.1, Apache 2.0, proprietary |
+| Intended use | _one sentence: what the model is for_ |
+
+## Architecture
+
+- Family: _e.g._ Transformer / CNN / Diffusion / RL agent
+- Layers / parameters: _e.g._ 12 encoder blocks, dModel=512, 25 M params
+- Input shape: _e.g._ `[batch, ctxLen=512]` byte tokens (vocab=256)
+- Output shape: _e.g._ `[batch, ctxLen, vocab]` logits
+- Notable architectural choices: _e.g._ rotary position embeddings, ALiBi,
+  pre-norm, weight tying, etc.
+
+## Training
+
+- Dataset(s): _name, version, license, size, source_
+- Splits: _train / val / test ratios + any held-out evaluation sets_
+- Preprocessing: _tokenization, normalization, augmentation, sampling_
+- Optimizer + schedule: _e.g._ AdamW(lr=3e-4, β=(0.9, 0.98)) + NoamSchedule(warmup=4000)
+- Hardware + duration: _GPUs/CPUs used, wall-clock_
+- Seed(s): _RNG seeds that produced the published artifact_
+
+## Evaluation
+
+- Metrics tracked: _e.g._ top-1, top-5, perplexity, F1, AUC, BLEU, ROUGE
+- Benchmark results: _table comparing this version to prior versions_
+- Slice analysis: _performance per relevant input slice (language, domain, length, etc.)_
+- Fairness / bias evaluation: _what was tested, what the result was_
+
+## Limitations
+
+- Out-of-distribution behavior: _known failure modes when inputs drift_
+- Hallucination / fabrication: _for generative models, document rate + examples_
+- Adversarial robustness: _what attacks were tested, what they did_
+- Compute / memory ceilings: _practical limits at inference time_
+
+## Intended use & out-of-scope use
+
+- ✅ Use it for: _bounded, validated tasks_
+- ❌ Do NOT use it for: _high-risk, regulated, or untested deployments_
+
+## Data governance
+
+- PII handling: _what PII the training data contained and how it was treated_
+- Consent / provenance: _how the training data was sourced_
+- Retention / deletion: _can the model "forget" specific training examples?_
+- Telemetry: _what runtime data the model emits and where it goes_
+
+## Versioning + supply chain
+
+- Artifact location: _e.g._ `models/byte-lm-transformer-v2.bin` (S3 / HuggingFace / etc.)
+- Artifact hash: _SHA256 of the weights file_
+- Build provenance: _link to the CI run that produced the artifact_
+- Dependencies: _AiDotNet version, native accelerator versions, etc._
+
+## Change log
+
+| Version | Date | Author | Notes |
+|---|---|---|---|
+| v0.1 | _YYYY-MM-DD_ | _name_ | _summary of changes vs. prior version_ |
+
+---
+
+> This template is informational. Maintaining it is your responsibility;
+> the AiDotNet runtime does not enforce a card per artifact.

--- a/src/AiDotNet.Serving/AssemblyInfo.cs
+++ b/src/AiDotNet.Serving/AssemblyInfo.cs
@@ -1,0 +1,6 @@
+using System.Runtime.CompilerServices;
+
+// Expose internal members of AiDotNet.Serving to the test assembly.
+// Currently used by OpenTelemetryRegistration.DisposeTelemetry, which is
+// an internal test-teardown hook that production code should not call.
+[assembly: InternalsVisibleTo("AiDotNet.Serving.Tests")]

--- a/src/AiDotNet.Serving/Controllers/LicenseValidationController.cs
+++ b/src/AiDotNet.Serving/Controllers/LicenseValidationController.cs
@@ -1,15 +1,19 @@
 using AiDotNet.Serving.Security.Licensing;
 using AiDotNet.Validation;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
 namespace AiDotNet.Serving.Controllers;
 
 /// <summary>
 /// Public endpoint for license key validation. No authentication required — the license key itself
-/// is the credential.
+/// is the credential. Marked [AllowAnonymous] so the serving FallbackPolicy
+/// (RequireAuthenticatedUser) doesn't block clients whose entire purpose for hitting this endpoint
+/// is to validate their license before they have an authenticated session.
 /// </summary>
 [ApiController]
 [Route("api/licenses")]
+[AllowAnonymous]
 public sealed class LicenseValidationController : ControllerBase
 {
     private readonly ILicenseService _licenses;

--- a/src/AiDotNet.Serving/Controllers/StripeController.cs
+++ b/src/AiDotNet.Serving/Controllers/StripeController.cs
@@ -27,6 +27,7 @@ public sealed class StripeController : ControllerBase
     /// <summary>
     /// Creates a Stripe Checkout session and returns the URL to redirect the customer to.
     /// </summary>
+    [AllowAnonymous]
     [HttpPost("checkout/session")]
     [ProducesResponseType(typeof(CheckoutResponse), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
@@ -101,7 +102,11 @@ public sealed class StripeController : ControllerBase
 
     /// <summary>
     /// Stripe webhook endpoint. Validates the webhook signature and processes events.
+    /// Authenticated via the Stripe-Signature header (HMAC over body + signing secret) —
+    /// not via the serving app's API-key scheme — so this endpoint is anonymous
+    /// from the framework's perspective and the FallbackPolicy doesn't apply.
     /// </summary>
+    [AllowAnonymous]
     [HttpPost("webhooks/stripe")]
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]

--- a/src/AiDotNet.Serving/Observability/OpenTelemetryRegistration.cs
+++ b/src/AiDotNet.Serving/Observability/OpenTelemetryRegistration.cs
@@ -1,0 +1,89 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
+
+namespace AiDotNet.Serving.Observability;
+
+/// <summary>
+/// Opt-in OpenTelemetry registration scaffold for the AiDotNet serving host.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The serving project deliberately does NOT take a hard dependency on
+/// <c>OpenTelemetry.Extensions.Hosting</c> or its exporters — those
+/// packages add a non-trivial transitive surface that consumers who
+/// don't want OpenTelemetry shouldn't pay for. Instead, this class
+/// exposes the <see cref="ActivitySource"/> + <see cref="Meter"/>
+/// instances the serving stack emits to, and an opt-in registration
+/// hook the host can call after adding its own OpenTelemetry
+/// configuration.
+/// </para>
+/// <para>
+/// Typical consumer wiring in their own <c>Program.cs</c> (after adding
+/// the OpenTelemetry NuGet packages they want):
+/// <code>
+/// builder.Services.AddOpenTelemetry()
+///     .ConfigureResource(r =&gt; r.AddService("AiDotNet.Serving"))
+///     .WithTracing(t =&gt; t.AddSource(AiDotNetServingTelemetry.ActivitySourceName))
+///     .WithMetrics(m =&gt; m.AddMeter(AiDotNetServingTelemetry.MeterName));
+/// </code>
+/// </para>
+/// <para>
+/// The serving controllers and pipeline middleware should emit to
+/// <see cref="AiDotNetServingTelemetry.ActivitySource"/> for spans and
+/// <see cref="AiDotNetServingTelemetry.Meter"/> for counters / histograms.
+/// As of the audit-hardening PR these instruments are wired up but not
+/// yet broadly instrumented across every controller — full coverage is
+/// tracked as a separate work item under the audit follow-up family.
+/// </para>
+/// </remarks>
+public static class AiDotNetServingTelemetry
+{
+    /// <summary>
+    /// Name of the ActivitySource for tracing serving operations.
+    /// Consumers wire this into their OpenTelemetry tracing pipeline.
+    /// </summary>
+    public const string ActivitySourceName = "AiDotNet.Serving";
+
+    /// <summary>
+    /// Name of the Meter for serving metrics (counters, histograms).
+    /// Consumers wire this into their OpenTelemetry metrics pipeline.
+    /// </summary>
+    public const string MeterName = "AiDotNet.Serving";
+
+    /// <summary>
+    /// Shared ActivitySource for the serving host. Controllers and
+    /// middleware should call <c>ActivitySource.StartActivity(...)</c>
+    /// at request boundaries.
+    /// </summary>
+    public static readonly ActivitySource ActivitySource = new(ActivitySourceName);
+
+    /// <summary>
+    /// Shared Meter for the serving host. Use this to create counters,
+    /// histograms, gauges, etc. for metric emission.
+    /// </summary>
+    public static readonly Meter Meter = new(MeterName);
+
+    /// <summary>
+    /// Registers a small set of always-on instruments + a configuration
+    /// section binding for telemetry-related options. The actual
+    /// OpenTelemetry SDK registration (exporters, samplers, processors)
+    /// is the consumer's responsibility — see the class remarks.
+    /// </summary>
+    /// <param name="services">The serving host's service collection.</param>
+    /// <param name="configuration">The serving host's configuration.</param>
+    /// <returns>The same service collection for chaining.</returns>
+    public static IServiceCollection AddAiDotNetServingObservability(
+        this IServiceCollection services,
+        IConfiguration configuration)
+    {
+        // Future: bind a TelemetryOptions section from configuration here
+        // (e.g., toggles for high-cardinality span attributes, redaction
+        // policies, sampling overrides). Intentionally minimal in this
+        // audit-hardening PR — the contract this method establishes is
+        // the names (ActivitySourceName / MeterName) consumers wire
+        // their OpenTelemetry pipeline to.
+        return services;
+    }
+}

--- a/src/AiDotNet.Serving/Observability/OpenTelemetryRegistration.cs
+++ b/src/AiDotNet.Serving/Observability/OpenTelemetryRegistration.cs
@@ -70,7 +70,7 @@ public static class AiDotNetServingTelemetry
     /// <see cref="Meter"/> singletons. Reserved for test-teardown
     /// scenarios where the serving host is repeatedly created and torn
     /// down inside the same process; production hosts rely on
-    /// app-domain teardown for cleanup and should NOT call this.
+    /// app-domain teardown for cleanup and MUST NOT call this.
     /// </summary>
     /// <remarks>
     /// Both <see cref="ActivitySource"/> and <see cref="Meter"/>
@@ -83,9 +83,13 @@ public static class AiDotNetServingTelemetry
     /// remain referenced — re-entering the host without restarting
     /// the process will use the disposed instances, so this is
     /// strictly a "test teardown right before app-domain exit" hook,
-    /// not a "reset between tests" hook.
+    /// not a "reset between tests" hook. Visibility is intentionally
+    /// <c>internal</c> (with
+    /// <see cref="System.Runtime.CompilerServices.InternalsVisibleToAttribute"/>
+    /// exposing it to <c>AiDotNet.Serving.Tests</c>) so production code
+    /// can't accidentally call it.
     /// </remarks>
-    public static void DisposeTelemetry()
+    internal static void DisposeTelemetry()
     {
         ActivitySource.Dispose();
         Meter.Dispose();

--- a/src/AiDotNet.Serving/Observability/OpenTelemetryRegistration.cs
+++ b/src/AiDotNet.Serving/Observability/OpenTelemetryRegistration.cs
@@ -66,11 +66,31 @@ public static class AiDotNetServingTelemetry
     public static readonly Meter Meter = new(MeterName);
 
     /// <summary>
-    /// Registers a small set of always-on instruments + a configuration
-    /// section binding for telemetry-related options. The actual
-    /// OpenTelemetry SDK registration (exporters, samplers, processors)
-    /// is the consumer's responsibility — see the class remarks.
+    /// Reserved opt-in registration point for AiDotNet.Serving's
+    /// OpenTelemetry-facing configuration. Currently a no-op — the
+    /// instruments consumers actually wire into their OpenTelemetry
+    /// pipeline are the static <see cref="ActivitySource"/> and
+    /// <see cref="Meter"/> fields above (referenced by name via
+    /// <see cref="ActivitySourceName"/> / <see cref="MeterName"/>).
     /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This method exists so consumers can call
+    /// <c>services.AddAiDotNetServingObservability(configuration)</c>
+    /// from their host setup TODAY and have that call automatically
+    /// pick up future wiring (TelemetryOptions binding, dependency-
+    /// injected redaction policies, sampling-override services) without
+    /// the consumer needing to add a second registration line then.
+    /// </para>
+    /// <para>
+    /// Until that wiring lands the method does NOT bind configuration,
+    /// register hosted services, add named-options, or register
+    /// instruments — it returns the supplied service collection
+    /// unchanged. The XML doc here matches that contract exactly so a
+    /// consumer reading IntelliSense isn't misled about what calling
+    /// the method does today.
+    /// </para>
+    /// </remarks>
     /// <param name="services">The serving host's service collection.</param>
     /// <param name="configuration">The serving host's configuration.</param>
     /// <returns>The same service collection for chaining.</returns>
@@ -78,12 +98,9 @@ public static class AiDotNetServingTelemetry
         this IServiceCollection services,
         IConfiguration configuration)
     {
-        // Future: bind a TelemetryOptions section from configuration here
-        // (e.g., toggles for high-cardinality span attributes, redaction
-        // policies, sampling overrides). Intentionally minimal in this
-        // audit-hardening PR — the contract this method establishes is
-        // the names (ActivitySourceName / MeterName) consumers wire
-        // their OpenTelemetry pipeline to.
+        // No-op today; the method exists so consumers can register
+        // against a stable opt-in point now and pick up future wiring
+        // automatically. See the XML doc above for the contract.
         return services;
     }
 }

--- a/src/AiDotNet.Serving/Observability/OpenTelemetryRegistration.cs
+++ b/src/AiDotNet.Serving/Observability/OpenTelemetryRegistration.cs
@@ -66,6 +66,32 @@ public static class AiDotNetServingTelemetry
     public static readonly Meter Meter = new(MeterName);
 
     /// <summary>
+    /// Disposes the static <see cref="ActivitySource"/> and
+    /// <see cref="Meter"/> singletons. Reserved for test-teardown
+    /// scenarios where the serving host is repeatedly created and torn
+    /// down inside the same process; production hosts rely on
+    /// app-domain teardown for cleanup and should NOT call this.
+    /// </summary>
+    /// <remarks>
+    /// Both <see cref="ActivitySource"/> and <see cref="Meter"/>
+    /// implement <see cref="System.IDisposable"/> but are exposed as
+    /// static readonly singletons because the OpenTelemetry SDK
+    /// expects long-lived instruments. Repeated factory-create /
+    /// dispose cycles in integration tests can otherwise leak
+    /// instrument-side listeners; tests that exercise that lifecycle
+    /// should call this at teardown. After disposal the singletons
+    /// remain referenced — re-entering the host without restarting
+    /// the process will use the disposed instances, so this is
+    /// strictly a "test teardown right before app-domain exit" hook,
+    /// not a "reset between tests" hook.
+    /// </remarks>
+    public static void DisposeTelemetry()
+    {
+        ActivitySource.Dispose();
+        Meter.Dispose();
+    }
+
+    /// <summary>
     /// Reserved opt-in registration point for AiDotNet.Serving's
     /// OpenTelemetry-facing configuration. Currently a no-op — the
     /// instruments consumers actually wire into their OpenTelemetry

--- a/src/AiDotNet.Serving/Program.cs
+++ b/src/AiDotNet.Serving/Program.cs
@@ -139,6 +139,20 @@ public class Program
         {
             options.AddPolicy("AiDotNetAdmin", policy =>
                 policy.RequireClaim(ApiKeyClaimTypes.Scope, ApiKeyScopes.Admin.ToString()));
+
+            // Default authorization is REQUIRED for every endpoint that
+            // doesn't explicitly opt out with [AllowAnonymous]. Without
+            // this fallback, the AddAuthentication registration above
+            // only takes effect on controllers/actions that carry an
+            // [Authorize] attribute — leaving inference, embeddings,
+            // federated, models, license-validation, and program-synthesis
+            // controllers reachable without credentials. The
+            // /health endpoint and Swagger UI (development only) are
+            // tagged below with [AllowAnonymous] / MapGet so this
+            // fallback doesn't break readiness probes or doc browsing.
+            options.FallbackPolicy = new Microsoft.AspNetCore.Authorization.AuthorizationPolicyBuilder()
+                .RequireAuthenticatedUser()
+                .Build();
         });
 
         // Register services as singletons for thread-safe shared access
@@ -202,15 +216,42 @@ public class Program
             }
         });
 
-        // Configure CORS for development
+        // Configure CORS. Wide-open (AllowAnyOrigin/Method/Header) is
+        // appropriate for local development but a real attack surface
+        // in production — a misconfigured proxy + this policy is enough
+        // for cross-origin POST against unprotected serving endpoints.
+        // Production reads an allow-list from configuration
+        // ("Cors:AllowedOrigins": ["https://app.example.com", ...]) and
+        // applies it ONLY to that origin list. The dev fallback stays
+        // unchanged so local hacking experience is unaffected.
         builder.Services.AddCors(options =>
         {
-            options.AddDefaultPolicy(policy =>
+            if (builder.Environment.IsDevelopment())
             {
-                policy.AllowAnyOrigin()
-                      .AllowAnyMethod()
-                      .AllowAnyHeader();
-            });
+                options.AddDefaultPolicy(policy =>
+                {
+                    policy.AllowAnyOrigin()
+                          .AllowAnyMethod()
+                          .AllowAnyHeader();
+                });
+            }
+            else
+            {
+                var allowedOrigins = builder.Configuration
+                    .GetSection("Cors:AllowedOrigins")
+                    .Get<string[]>() ?? System.Array.Empty<string>();
+                options.AddDefaultPolicy(policy =>
+                {
+                    if (allowedOrigins.Length > 0)
+                    {
+                        policy.WithOrigins(allowedOrigins)
+                              .AllowAnyMethod()
+                              .AllowAnyHeader();
+                    }
+                    // else: no CORS at all in production unless explicitly
+                    // configured — fail closed.
+                });
+            }
         });
 
         var app = builder.Build();
@@ -240,8 +281,12 @@ public class Program
         app.UseAuthorization();
         app.MapControllers();
 
-        // Health check endpoint for Azure warmup probes
-        app.MapGet("/health", () => Results.Ok(new { status = "healthy" }));
+        // Health check endpoint for Azure warmup probes. AllowAnonymous
+        // so the FallbackPolicy (RequireAuthenticatedUser) doesn't block
+        // load-balancer / Azure App Service health probes that arrive
+        // without credentials.
+        app.MapGet("/health", () => Results.Ok(new { status = "healthy" }))
+            .AllowAnonymous();
 
         // Log startup information
         var logger = app.Services.GetRequiredService<ILogger<Program>>();

--- a/src/AiDotNet.Serving/Program.cs
+++ b/src/AiDotNet.Serving/Program.cs
@@ -237,6 +237,18 @@ public class Program
         // ("Cors:AllowedOrigins": ["https://app.example.com", ...]) and
         // applies it ONLY to that origin list. The dev fallback stays
         // unchanged so local hacking experience is unaffected.
+        // Resolve the production CORS allow-list once during service
+        // registration so we can both (a) bind it into the AddCors
+        // policy and (b) log a startup warning via the host logger AFTER
+        // builder.Build() when the list is empty. The warning lives on
+        // the host logger (not System.Diagnostics.Trace) so it shows up
+        // in standard ASP.NET Core logging pipelines that operators
+        // configure (e.g. Serilog / OpenTelemetry log exporters).
+        string[] productionCorsOrigins = builder.Environment.IsDevelopment()
+            ? System.Array.Empty<string>()
+            : builder.Configuration.GetSection("Cors:AllowedOrigins")
+                .Get<string[]>() ?? System.Array.Empty<string>();
+
         builder.Services.AddCors(options =>
         {
             if (builder.Environment.IsDevelopment())
@@ -250,37 +262,35 @@ public class Program
             }
             else
             {
-                var allowedOrigins = builder.Configuration
-                    .GetSection("Cors:AllowedOrigins")
-                    .Get<string[]>() ?? System.Array.Empty<string>();
-                if (allowedOrigins.Length == 0)
-                {
-                    // Surface the fail-closed default so an operator who
-                    // deployed without configuring CORS sees a clear log
-                    // line instead of debugging "why does my cross-origin
-                    // request silently fail in production".
-                    System.Diagnostics.Trace.TraceWarning(
-                        "AiDotNet.Serving CORS: Cors:AllowedOrigins is empty in a non-Development " +
-                        "environment. Cross-origin requests will be REJECTED. Configure " +
-                        "Cors:AllowedOrigins (e.g. [\"https://app.example.com\"]) to enable CORS " +
-                        "from specific origins, or accept the fail-closed default for same-origin-only " +
-                        "deployments.");
-                }
                 options.AddDefaultPolicy(policy =>
                 {
-                    if (allowedOrigins.Length > 0)
+                    if (productionCorsOrigins.Length > 0)
                     {
-                        policy.WithOrigins(allowedOrigins)
+                        policy.WithOrigins(productionCorsOrigins)
                               .AllowAnyMethod()
                               .AllowAnyHeader();
                     }
                     // else: no CORS at all in production unless explicitly
-                    // configured — fail closed (warning logged above).
+                    // configured — fail closed (warning logged below).
                 });
             }
         });
 
         var app = builder.Build();
+
+        // Surface the fail-closed default through the host logger so
+        // operators who deployed without configuring Cors:AllowedOrigins
+        // see a clear startup warning in their standard logs instead of
+        // debugging "why does my cross-origin request silently fail in
+        // production".
+        if (!app.Environment.IsDevelopment() && productionCorsOrigins.Length == 0)
+        {
+            app.Logger.LogWarning(
+                "CORS Cors:AllowedOrigins is empty in a non-Development environment. " +
+                "Cross-origin requests will be REJECTED. Configure Cors:AllowedOrigins " +
+                "(e.g. [\"https://app.example.com\"]) to enable CORS from specific origins, " +
+                "or accept the fail-closed default for same-origin-only deployments.");
+        }
 
         // Apply migrations on startup (configurable)
         if (persistenceOptions.MigrateOnStartup)

--- a/src/AiDotNet.Serving/Program.cs
+++ b/src/AiDotNet.Serving/Program.cs
@@ -145,11 +145,24 @@ public class Program
             // this fallback, the AddAuthentication registration above
             // only takes effect on controllers/actions that carry an
             // [Authorize] attribute — leaving inference, embeddings,
-            // federated, models, license-validation, and program-synthesis
-            // controllers reachable without credentials. The
-            // /health endpoint and Swagger UI (development only) are
-            // tagged below with [AllowAnonymous] / MapGet so this
-            // fallback doesn't break readiness probes or doc browsing.
+            // federated, models, and program-synthesis controllers
+            // reachable without credentials.
+            //
+            // Endpoints that legitimately serve anonymous traffic:
+            //   - /health (minimal API below, tagged .AllowAnonymous())
+            //   - Stripe checkout-session creation + webhook
+            //     (StripeController, [AllowAnonymous] on those actions —
+            //     webhook authenticates via Stripe-Signature header,
+            //     checkout-session is intentionally public)
+            //   - License-key validation (LicenseValidationController,
+            //     [AllowAnonymous] on the class — the license key itself
+            //     IS the credential, so requiring an API key first would
+            //     be circular)
+            //
+            // Swagger UI is registered via UseSwagger/UseSwaggerUI
+            // middleware (NOT an MVC endpoint), so it bypasses the
+            // FallbackPolicy entirely — and Swagger is only mounted in
+            // Development environments anyway (see UseSwagger gate below).
             options.FallbackPolicy = new Microsoft.AspNetCore.Authorization.AuthorizationPolicyBuilder()
                 .RequireAuthenticatedUser()
                 .Build();
@@ -240,6 +253,19 @@ public class Program
                 var allowedOrigins = builder.Configuration
                     .GetSection("Cors:AllowedOrigins")
                     .Get<string[]>() ?? System.Array.Empty<string>();
+                if (allowedOrigins.Length == 0)
+                {
+                    // Surface the fail-closed default so an operator who
+                    // deployed without configuring CORS sees a clear log
+                    // line instead of debugging "why does my cross-origin
+                    // request silently fail in production".
+                    System.Diagnostics.Trace.TraceWarning(
+                        "AiDotNet.Serving CORS: Cors:AllowedOrigins is empty in a non-Development " +
+                        "environment. Cross-origin requests will be REJECTED. Configure " +
+                        "Cors:AllowedOrigins (e.g. [\"https://app.example.com\"]) to enable CORS " +
+                        "from specific origins, or accept the fail-closed default for same-origin-only " +
+                        "deployments.");
+                }
                 options.AddDefaultPolicy(policy =>
                 {
                     if (allowedOrigins.Length > 0)
@@ -249,7 +275,7 @@ public class Program
                               .AllowAnyHeader();
                     }
                     // else: no CORS at all in production unless explicitly
-                    // configured — fail closed.
+                    // configured — fail closed (warning logged above).
                 });
             }
         });

--- a/src/AiDotNet.csproj
+++ b/src/AiDotNet.csproj
@@ -1,10 +1,25 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+	  <!--
+	    net10.0 is the latest .NET; net471 covers legacy Framework consumers.
+	    net8.0 LTS is intentionally NOT yet in the target list — the
+	    AiDotNet.Tensors transitive dependency does not currently ship an
+	    explicit net8.0 build, so adding the target produces NU1701 warnings.
+	    Tracked as a follow-up: bump AiDotNet.Tensors to a release with
+	    explicit net8.0 support, then add net8.0 here.
+	  -->
 	  <TargetFrameworks>net10.0;net471</TargetFrameworks>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
-		<Version>0.0.5-preview</Version>
+		<!-- Static fallback only. The automated-release workflow injects
+		     the real package version via -p:PackageVersion=$version at
+		     pack time; this static <Version> is what `dotnet build`
+		     stamps onto assemblies when consumers build from source.
+		     Kept in sync with the latest published NuGet version so
+		     source-built binaries don't appear "older" than the
+		     published package. -->
+		<Version>0.204.0</Version>
 		<Title>Ai for .Net</Title>
 		<Description>A comprehensive .NET library for machine learning, deep learning, NLP, computer vision, and AI model serving. Licensed under BSL 1.1 — free for non-commercial use, community license available at aidotnet.dev. Model save/load requires a free or paid license after a 10-operation trial. Optional anonymous telemetry (opt-in via AIDOTNET_TELEMETRY=true) collects usage metrics — no PII or model data is collected.</Description>
 		<Company>Ooples Finance</Company>

--- a/tests/AiDotNet.Serving.Tests/FederatedCoordinatorIntegrationTests.cs
+++ b/tests/AiDotNet.Serving.Tests/FederatedCoordinatorIntegrationTests.cs
@@ -25,7 +25,7 @@ using System.Threading.Tasks;
 namespace AiDotNet.Serving.Tests;
 
 [Collection("ServingIntegrationTests")]
-public class FederatedCoordinatorIntegrationTests : IClassFixture<WebApplicationFactory<Program>>, IAsyncLifetime
+public class FederatedCoordinatorIntegrationTests : IClassFixture<ServingTestWebApplicationFactory>, IAsyncLifetime
 {
     private const string ApiKeyHeaderName = "X-AiDotNet-ApiKey";
 
@@ -34,12 +34,12 @@ public class FederatedCoordinatorIntegrationTests : IClassFixture<WebApplication
         Converters = { new StringEnumConverter(new CamelCaseNamingStrategy(), allowIntegerValues: false) }
     };
 
-    private readonly WebApplicationFactory<Program> _factory;
+    private readonly ServingTestWebApplicationFactory _factory;
     private readonly HttpClient _client;
     private readonly List<string> _createdModelFiles = new();
     private readonly List<string> _loadedModels = new();
 
-    public FederatedCoordinatorIntegrationTests(WebApplicationFactory<Program> factory)
+    public FederatedCoordinatorIntegrationTests(ServingTestWebApplicationFactory factory)
     {
         _factory = factory;
         _client = _factory.CreateClient();
@@ -109,7 +109,7 @@ public class FederatedCoordinatorIntegrationTests : IClassFixture<WebApplication
         Assert.NotNull(createResponse);
 
         var enterpriseApiKey = await CreateApiKeyAsync(SubscriptionTier.Enterprise);
-        SetApiKey(enterpriseApiKey);
+        SetApiKey(enterpriseApiKey, SubscriptionTier.Enterprise);
         var join = await PostAsJsonAsync($"/api/federated/runs/{createResponse.RunId}/join", new JoinFederatedRunRequest
         {
             ClientId = null,
@@ -207,12 +207,12 @@ public class FederatedCoordinatorIntegrationTests : IClassFixture<WebApplication
         Assert.Equal(2.0, after.Parameters[after.Parameters.Length - 1], precision: 6);
 
         // Option A (Free) forbids artifact download.
-        SetApiKey(null);
+        SetApiKey(null, SubscriptionTier.Free);
         var freeArtifact = await _client.GetAsync($"/api/federated/runs/{createResponse.RunId}/artifact");
         Assert.Equal(HttpStatusCode.Forbidden, freeArtifact.StatusCode);
 
         // Option B (Pro) returns an encrypted artifact; key release is allowed without attestation.
-        SetApiKey(proApiKey);
+        SetApiKey(proApiKey, SubscriptionTier.Pro);
         var proArtifact = await _client.GetAsync($"/api/federated/runs/{createResponse.RunId}/artifact");
         proArtifact.EnsureSuccessStatusCode();
         Assert.Equal("true", proArtifact.Headers.GetValues("X-AiDotNet-Artifact-Encrypted").Single());
@@ -245,7 +245,7 @@ public class FederatedCoordinatorIntegrationTests : IClassFixture<WebApplication
         }
 
         // Option C (Enterprise) returns encrypted artifact and requires key release via attestation.
-        SetApiKey(enterpriseApiKey);
+        SetApiKey(enterpriseApiKey, SubscriptionTier.Enterprise);
         var enterpriseArtifact = await _client.GetAsync($"/api/federated/runs/{createResponse.RunId}/artifact");
         enterpriseArtifact.EnsureSuccessStatusCode();
         Assert.Equal("true", enterpriseArtifact.Headers.GetValues("X-AiDotNet-Artifact-Encrypted").Single());
@@ -284,13 +284,25 @@ public class FederatedCoordinatorIntegrationTests : IClassFixture<WebApplication
         Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
     }
 
-    private void SetApiKey(string? apiKey)
+    private void SetApiKey(string? apiKey, SubscriptionTier? tier = null)
     {
         _client.DefaultRequestHeaders.Remove(ApiKeyHeaderName);
+        _client.DefaultRequestHeaders.Remove(TestAuthenticationHandler.TestTierHeader);
 
         if (!string.IsNullOrWhiteSpace(apiKey))
         {
             _client.DefaultRequestHeaders.Add(ApiKeyHeaderName, apiKey);
+        }
+        // Pin the test-handler's Tier claim. The production handler
+        // would derive this from the API key; the test handler ignores
+        // the API key and reads the X-Test-Tier header instead. Tests
+        // that rely on tier-gated endpoints pass the matching tier
+        // here so both production and test paths agree.
+        if (tier.HasValue)
+        {
+            _client.DefaultRequestHeaders.Add(
+                TestAuthenticationHandler.TestTierHeader,
+                tier.Value.ToString());
         }
     }
 

--- a/tests/AiDotNet.Serving.Tests/InferenceControllerNotImplementedEndpointsTests.cs
+++ b/tests/AiDotNet.Serving.Tests/InferenceControllerNotImplementedEndpointsTests.cs
@@ -16,18 +16,18 @@ using System.Threading.Tasks;
 namespace AiDotNet.Serving.Tests;
 
 [Collection("ServingIntegrationTests")]
-public class InferenceControllerNotImplementedEndpointsTests : IClassFixture<WebApplicationFactory<Program>>, IAsyncLifetime
+public class InferenceControllerNotImplementedEndpointsTests : IClassFixture<ServingTestWebApplicationFactory>, IAsyncLifetime
 {
     private static readonly JsonSerializerSettings JsonSettings = new()
     {
         Converters = { new StringEnumConverter(new CamelCaseNamingStrategy(), allowIntegerValues: false) }
     };
 
-    private readonly WebApplicationFactory<Program> _factory;
+    private readonly ServingTestWebApplicationFactory _factory;
     private readonly HttpClient _client;
     private readonly List<string> _loadedModels = new();
 
-    public InferenceControllerNotImplementedEndpointsTests(WebApplicationFactory<Program> factory)
+    public InferenceControllerNotImplementedEndpointsTests(ServingTestWebApplicationFactory factory)
     {
         _factory = factory;
         _client = _factory.CreateClient();

--- a/tests/AiDotNet.Serving.Tests/ProgramSandboxTestFactory.cs
+++ b/tests/AiDotNet.Serving.Tests/ProgramSandboxTestFactory.cs
@@ -1,7 +1,10 @@
 using AiDotNet.Serving.Sandboxing.Execution;
+using AiDotNet.Serving.Security.ApiKeys;
 using AiDotNet.Serving.Tests.Fakes;
+using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 
@@ -15,6 +18,23 @@ public sealed class ProgramSandboxTestFactory : WebApplicationFactory<Program>
         {
             services.RemoveAll<IProgramSandboxExecutor>();
             services.AddSingleton<IProgramSandboxExecutor, FakeProgramSandboxExecutor>();
+        });
+
+        // Register a test auth handler under its own scheme name and
+        // make it the default — needed after PR #1384 made
+        // authentication the default for previously-public controllers.
+        builder.ConfigureTestServices(services =>
+        {
+            services.AddAuthentication(TestAuthenticationHandler.Scheme)
+                .AddScheme<ApiKeyAuthenticationOptions, TestAuthenticationHandler>(
+                    TestAuthenticationHandler.Scheme,
+                    _ => { });
+            services.Configure<AuthenticationOptions>(options =>
+            {
+                options.DefaultScheme = TestAuthenticationHandler.Scheme;
+                options.DefaultAuthenticateScheme = TestAuthenticationHandler.Scheme;
+                options.DefaultChallengeScheme = TestAuthenticationHandler.Scheme;
+            });
         });
     }
 }

--- a/tests/AiDotNet.Serving.Tests/ServingIntegrationTestCollection.cs
+++ b/tests/AiDotNet.Serving.Tests/ServingIntegrationTestCollection.cs
@@ -1,4 +1,3 @@
-using Microsoft.AspNetCore.Mvc.Testing;
 using Xunit;
 
 namespace AiDotNet.Serving.Tests;
@@ -7,7 +6,14 @@ namespace AiDotNet.Serving.Tests;
 /// Collection definition for serving integration tests to ensure proper test isolation.
 /// This ensures all tests in this collection run sequentially and clean up the singleton repository.
 /// </summary>
+/// <remarks>
+/// Uses <see cref="ServingTestWebApplicationFactory"/> (a derivative of
+/// <c>WebApplicationFactory&lt;Program&gt;</c>) so the test auth handler
+/// is wired in. Necessary after PR #1384 added a default-auth
+/// FallbackPolicy to the serving host — without the test handler every
+/// existing integration-test request would return 401.
+/// </remarks>
 [CollectionDefinition("ServingIntegrationTests")]
-public class ServingIntegrationTestCollection : ICollectionFixture<WebApplicationFactory<Program>>
+public class ServingIntegrationTestCollection : ICollectionFixture<ServingTestWebApplicationFactory>
 {
 }

--- a/tests/AiDotNet.Serving.Tests/ServingIntegrationTests.cs
+++ b/tests/AiDotNet.Serving.Tests/ServingIntegrationTests.cs
@@ -27,17 +27,17 @@ namespace AiDotNet.Serving.Tests;
 /// including model management, request batching, and inference endpoints.
 /// </summary>
 [Collection("ServingIntegrationTests")]
-public class ServingIntegrationTests : IClassFixture<WebApplicationFactory<Program>>, IAsyncLifetime
+public class ServingIntegrationTests : IClassFixture<ServingTestWebApplicationFactory>, IAsyncLifetime
 {
     private static readonly JsonSerializerSettings JsonSettings = new()
     {
         Converters = { new StringEnumConverter(new CamelCaseNamingStrategy(), allowIntegerValues: false) }
     };
 
-    private readonly WebApplicationFactory<Program> _factory;
+    private readonly ServingTestWebApplicationFactory _factory;
     private readonly HttpClient _client;
 
-    public ServingIntegrationTests(WebApplicationFactory<Program> factory)
+    public ServingIntegrationTests(ServingTestWebApplicationFactory factory)
     {
         _factory = factory;
         _client = _factory.CreateClient();
@@ -446,6 +446,11 @@ public class ServingIntegrationTests : IClassFixture<WebApplicationFactory<Progr
         repository.LoadModel(modelName, CreateSimpleTestModel(modelName), sourcePath: artifactPath);
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/api/models/{modelName}/artifact");
+        // Pin the principal's tier claim to Free for this test —
+        // TestAuthenticationHandler defaults to Enterprise (so the bulk
+        // of integration tests don't need any per-request setup), and
+        // this test specifically verifies the Free-tier rejection path.
+        request.Headers.Add(TestAuthenticationHandler.TestTierHeader, SubscriptionTier.Free.ToString());
 
         var response = await _client.SendAsync(request);
         Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
@@ -475,6 +480,12 @@ public class ServingIntegrationTests : IClassFixture<WebApplicationFactory<Progr
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/api/models/{modelName}/artifact");
         request.Headers.Add("X-AiDotNet-ApiKey", proApiKey);
+        // Pin the test handler's Tier claim to Pro for this request —
+        // the production X-AiDotNet-ApiKey header is preserved for the
+        // tier resolver to see, but the test factory swaps in
+        // TestAuthenticationHandler as the default scheme so we
+        // explicitly carry the Tier through the test-header path.
+        request.Headers.Add(TestAuthenticationHandler.TestTierHeader, SubscriptionTier.Pro.ToString());
 
         var response = await _client.SendAsync(request);
         response.EnsureSuccessStatusCode();
@@ -487,6 +498,7 @@ public class ServingIntegrationTests : IClassFixture<WebApplicationFactory<Progr
 
         var keyRequest = new HttpRequestMessage(HttpMethod.Post, $"/api/models/{modelName}/artifact/key");
         keyRequest.Headers.Add("X-AiDotNet-ApiKey", proApiKey);
+        keyRequest.Headers.Add(TestAuthenticationHandler.TestTierHeader, SubscriptionTier.Pro.ToString());
         var keyResponse = await _client.SendAsync(keyRequest);
         keyResponse.EnsureSuccessStatusCode();
 

--- a/tests/AiDotNet.Serving.Tests/ServingTestWebApplicationFactory.cs
+++ b/tests/AiDotNet.Serving.Tests/ServingTestWebApplicationFactory.cs
@@ -1,0 +1,52 @@
+using AiDotNet.Serving.Security.ApiKeys;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace AiDotNet.Serving.Tests;
+
+/// <summary>
+/// WebApplicationFactory derivative that replaces the production
+/// <see cref="ApiKeyAuthenticationHandler"/> with
+/// <see cref="TestAuthenticationHandler"/> so integration tests can
+/// drive the serving host without provisioning a real API key.
+/// </summary>
+/// <remarks>
+/// PR #1384 added a <c>FallbackPolicy = RequireAuthenticatedUser</c> to
+/// the serving host so previously-unprotected controllers (Inference,
+/// Embeddings, Federated, Models, ProgramSynthesis/*) now require
+/// authentication. Tests bound to this factory get a stubbed auth
+/// handler that succeeds for every request, so they exercise the
+/// production endpoint code without needing the real API-key
+/// provisioning flow. Tests that specifically want to verify the
+/// unauthenticated rejection path should construct
+/// <see cref="WebApplicationFactory{Program}"/> directly instead of
+/// using this factory.
+/// </remarks>
+public sealed class ServingTestWebApplicationFactory : WebApplicationFactory<Program>
+{
+    protected override void ConfigureWebHost(IWebHostBuilder builder)
+    {
+        builder.ConfigureTestServices(services =>
+        {
+            // Register the test handler under its own scheme name, then
+            // override the AuthenticationOptions to make TestAuth the
+            // default for every challenge. The production scheme stays
+            // registered (so a re-set-default can't accidentally call
+            // AddScheme twice on the same name), it just becomes a
+            // dormant alternative the test code doesn't drive.
+            services.AddAuthentication(TestAuthenticationHandler.Scheme)
+                .AddScheme<ApiKeyAuthenticationOptions, TestAuthenticationHandler>(
+                    TestAuthenticationHandler.Scheme,
+                    _ => { });
+            services.Configure<AuthenticationOptions>(options =>
+            {
+                options.DefaultScheme = TestAuthenticationHandler.Scheme;
+                options.DefaultAuthenticateScheme = TestAuthenticationHandler.Scheme;
+                options.DefaultChallengeScheme = TestAuthenticationHandler.Scheme;
+            });
+        });
+    }
+}

--- a/tests/AiDotNet.Serving.Tests/SqlSandboxTestFactory.cs
+++ b/tests/AiDotNet.Serving.Tests/SqlSandboxTestFactory.cs
@@ -1,6 +1,10 @@
+using AiDotNet.Serving.Security.ApiKeys;
+using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace AiDotNet.Serving.Tests;
 
@@ -13,6 +17,23 @@ public sealed class SqlSandboxTestFactory : WebApplicationFactory<Program>
             config.AddInMemoryCollection(new Dictionary<string, string?>
             {
                 ["ServingSqlSandbox:EnableDockerFallback"] = "false"
+            });
+        });
+
+        // Register a test auth handler under its own scheme name and
+        // make it the default — needed after PR #1384 made
+        // authentication the default for previously-public controllers.
+        builder.ConfigureTestServices(services =>
+        {
+            services.AddAuthentication(TestAuthenticationHandler.Scheme)
+                .AddScheme<ApiKeyAuthenticationOptions, TestAuthenticationHandler>(
+                    TestAuthenticationHandler.Scheme,
+                    _ => { });
+            services.Configure<AuthenticationOptions>(options =>
+            {
+                options.DefaultScheme = TestAuthenticationHandler.Scheme;
+                options.DefaultAuthenticateScheme = TestAuthenticationHandler.Scheme;
+                options.DefaultChallengeScheme = TestAuthenticationHandler.Scheme;
             });
         });
     }

--- a/tests/AiDotNet.Serving.Tests/TestAuthenticationHandler.cs
+++ b/tests/AiDotNet.Serving.Tests/TestAuthenticationHandler.cs
@@ -1,0 +1,81 @@
+using System.Security.Claims;
+using System.Text.Encodings.Web;
+using AiDotNet.Serving.Security;
+using AiDotNet.Serving.Security.ApiKeys;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace AiDotNet.Serving.Tests;
+
+/// <summary>
+/// Test-only authentication handler that succeeds for every incoming request
+/// with a fixed identity and the <see cref="ApiKeyScopes.Admin"/> scope.
+/// </summary>
+/// <remarks>
+/// <para>
+/// PR #1384 added a <c>FallbackPolicy = RequireAuthenticatedUser</c> to the
+/// serving host so unprotected controllers (Inference, Embeddings, Federated,
+/// Models, ProgramSynthesis/*) now require authentication. The existing
+/// integration test suite drives those endpoints with a bare
+/// <c>WebApplicationFactory.CreateClient()</c> — no API key in the request
+/// headers — which would otherwise return 401 against the new default.
+/// </para>
+/// <para>
+/// This handler replaces the real <see cref="ApiKeyAuthenticationHandler"/>
+/// in test runs so the existing tests stay green while the production
+/// host keeps its hardened defaults. Tests that specifically want to
+/// verify the unauthenticated-request rejection path should NOT use this
+/// handler and instead drive the host with the real auth scheme.
+/// </para>
+/// </remarks>
+public sealed class TestAuthenticationHandler : AuthenticationHandler<ApiKeyAuthenticationOptions>
+{
+    public const string Scheme = "TestAuth";
+    public const string TestKeyId = "test-key";
+
+    /// <summary>
+    /// Optional request header that lets a test pin the principal's
+    /// <see cref="SubscriptionTier"/> claim. When present, the value is
+    /// parsed (case-insensitively) and used as the Tier claim; when
+    /// absent, the default is <see cref="SubscriptionTier.Enterprise"/>
+    /// so tests don't need any setup for the common "do whatever, just
+    /// authenticate me" case.
+    /// </summary>
+    public const string TestTierHeader = "X-Test-Tier";
+
+    public TestAuthenticationHandler(
+        IOptionsMonitor<ApiKeyAuthenticationOptions> options,
+        ILoggerFactory logger,
+        UrlEncoder encoder)
+        : base(options, logger, encoder)
+    {
+    }
+
+    protected override Task<AuthenticateResult> HandleAuthenticateAsync()
+    {
+        // Default to Enterprise so the bulk of tests (that don't care
+        // about tier policy) succeed without any per-request setup.
+        // Tests that exercise tier-gated endpoints can set the
+        // X-Test-Tier header to pin a specific tier.
+        SubscriptionTier tier = SubscriptionTier.Enterprise;
+        if (Request.Headers.TryGetValue(TestTierHeader, out var tierHeader) &&
+            tierHeader.Count > 0 &&
+            System.Enum.TryParse<SubscriptionTier>(tierHeader[0], ignoreCase: true, out var parsed))
+        {
+            tier = parsed;
+        }
+
+        var claims = new[]
+        {
+            new Claim(ApiKeyClaimTypes.KeyId, TestKeyId),
+            new Claim(ApiKeyClaimTypes.Tier, tier.ToString()),
+            new Claim(ClaimTypes.NameIdentifier, TestKeyId),
+            new Claim(ApiKeyClaimTypes.Scope, ApiKeyScopes.Admin.ToString())
+        };
+        var identity = new ClaimsIdentity(claims, Scheme);
+        var principal = new ClaimsPrincipal(identity);
+        var ticket = new AuthenticationTicket(principal, Scheme);
+        return Task.FromResult(AuthenticateResult.Success(ticket));
+    }
+}

--- a/tests/AiDotNet.Serving.Tests/TestAuthenticationHandler.cs
+++ b/tests/AiDotNet.Serving.Tests/TestAuthenticationHandler.cs
@@ -66,8 +66,10 @@ public sealed class TestAuthenticationHandler : AuthenticationHandler<ApiKeyAuth
             // is not a defined member (e.g. "999"), which would let a
             // typo'd header silently assign an invalid Tier claim. Guard
             // with IsDefined so only the named members
-            // (Free / Pro / Enterprise / ...) are accepted.
-            System.Enum.IsDefined(typeof(SubscriptionTier), parsed))
+            // (Free / Pro / Enterprise / ...) are accepted. Uses the
+            // generic overload (.NET 5+) for compile-time type safety
+            // instead of typeof(SubscriptionTier).
+            System.Enum.IsDefined(parsed))
         {
             tier = parsed;
         }

--- a/tests/AiDotNet.Serving.Tests/TestAuthenticationHandler.cs
+++ b/tests/AiDotNet.Serving.Tests/TestAuthenticationHandler.cs
@@ -61,7 +61,13 @@ public sealed class TestAuthenticationHandler : AuthenticationHandler<ApiKeyAuth
         SubscriptionTier tier = SubscriptionTier.Enterprise;
         if (Request.Headers.TryGetValue(TestTierHeader, out var tierHeader) &&
             tierHeader.Count > 0 &&
-            System.Enum.TryParse<SubscriptionTier>(tierHeader[0], ignoreCase: true, out var parsed))
+            System.Enum.TryParse<SubscriptionTier>(tierHeader[0], ignoreCase: true, out var parsed) &&
+            // Enum.TryParse accepts numeric strings whose integral value
+            // is not a defined member (e.g. "999"), which would let a
+            // typo'd header silently assign an invalid Tier claim. Guard
+            // with IsDefined so only the named members
+            // (Free / Pro / Enterprise / ...) are accepted.
+            System.Enum.IsDefined(typeof(SubscriptionTier), parsed))
         {
             tier = parsed;
         }

--- a/tests/AiDotNet.Tests/UnitTests/SmokeTests/ReleaseSmokeTests.cs
+++ b/tests/AiDotNet.Tests/UnitTests/SmokeTests/ReleaseSmokeTests.cs
@@ -83,7 +83,7 @@ public class ReleaseSmokeTests
         // for a subsequent SetModel call (the contract the AiModelBuilder
         // facade relies on).
         var opts = new AiDotNet.Models.Options.AdamOptimizerOptions<float, Vector<float>, Vector<float>>();
-        var optimizer = new AdamOptimizer<float, Vector<float>, Vector<float>>(model: null, opts);
+        var optimizer = new AdamOptimizer<float, Vector<float>, Vector<float>>(model: null, options: opts);
 
         Assert.NotNull(optimizer);
         Assert.Null(optimizer.Model);

--- a/tests/AiDotNet.Tests/UnitTests/SmokeTests/ReleaseSmokeTests.cs
+++ b/tests/AiDotNet.Tests/UnitTests/SmokeTests/ReleaseSmokeTests.cs
@@ -72,16 +72,21 @@ public class ReleaseSmokeTests
     }
 
     [Fact]
-    public void AdamOptimizer_NullModelConstruction_DoesNotThrow()
+    public void AdamOptimizer_NullModelConstruction_RegistersOptionsAndDeferredModel()
     {
         // Smoke: the null-model ctor path AiModelBuilder uses (construct
         // optimizer first, SetModel later) does not throw at construction
-        // time. PR #1380 root-caused as an InvalidCastException on the
-        // hot path; this asserts the build-and-construct sequence stays
-        // exception-free.
+        // time AND lands in the expected initial state. PR #1380
+        // root-caused as an InvalidCastException; this asserts the
+        // build-and-construct sequence stays exception-free AND that the
+        // optimizer holds onto the supplied options + leaves Model null
+        // for a subsequent SetModel call (the contract the AiModelBuilder
+        // facade relies on).
         var opts = new AiDotNet.Models.Options.AdamOptimizerOptions<float, Vector<float>, Vector<float>>();
         var optimizer = new AdamOptimizer<float, Vector<float>, Vector<float>>(model: null, opts);
 
         Assert.NotNull(optimizer);
+        Assert.Null(optimizer.Model);
+        Assert.Same(opts, optimizer.GetOptions());
     }
 }

--- a/tests/AiDotNet.Tests/UnitTests/SmokeTests/ReleaseSmokeTests.cs
+++ b/tests/AiDotNet.Tests/UnitTests/SmokeTests/ReleaseSmokeTests.cs
@@ -1,0 +1,87 @@
+using AiDotNet.LossFunctions;
+using AiDotNet.Optimizers;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tests.UnitTests.SmokeTests;
+
+/// <summary>
+/// Release-gate smoke tests — selected by the automated-release pipeline's
+/// pre-publish gate via the filter
+/// <c>Category=Smoke|FullyQualifiedName~SmokeTests</c>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The release pipeline runs these tests after build, before
+/// <c>dotnet pack</c>. If any of them fails the package is not published.
+/// Keep them small and fast: every test in this class should run in well
+/// under a second so the release gate stays cheap. Cover thin slices of
+/// the public surface that, if broken, would render most user code
+/// non-functional:
+/// </para>
+/// <list type="bullet">
+///   <item>A loss function constructs and returns sensible values for
+///         trivial inputs (smoke-tests the LinearAlgebra surface +
+///         loss-function virtuals — the bottom of the gradient stack).</item>
+///   <item>An optimizer constructs against default options (smoke-tests
+///         the optimizer-options binding the regularization PR #1381
+///         touched + the parameter-bridge surface).</item>
+/// </list>
+/// <para>
+/// Bigger integration / model-training tests live in the IntegrationTests
+/// project and are filtered OUT of the release gate to keep it fast.
+/// </para>
+/// </remarks>
+[Trait("Category", "Smoke")]
+public class ReleaseSmokeTests
+{
+    [Fact]
+    public void MeanSquaredErrorLoss_OnIdenticalVectors_IsZero()
+    {
+        // Smoke: loss-function surface (constructor + CalculateLoss) is
+        // reachable and produces the expected scalar for the trivial case
+        // of predicted == actual. Verifies the LinearAlgebra Vector<T>
+        // path resolved correctly through the typical
+        // AiDotNet.LossFunctions namespace — a broken framework binding
+        // here would block every consumer.
+        var loss = new MeanSquaredErrorLoss<float>();
+        var values = new Vector<float>(new float[] { 0.5f, -0.25f, 1.0f, 0.0f });
+
+        float result = loss.CalculateLoss(values, values);
+
+        Assert.Equal(0.0f, result, precision: 6);
+    }
+
+    [Fact]
+    public void AdamOptimizerOptions_DefaultConstruction_HasSensibleDefaults()
+    {
+        // Smoke: optimizer-options ctor is reachable and the defaults
+        // PR #1381 hardened (gradient clipping + L2-strength default)
+        // round-trip through to a constructed options instance. A broken
+        // default-binding here would surface as a NullReferenceException
+        // in every gradient-based optimizer the consumer wires up.
+        var opts = new AiDotNet.Models.Options.AdamOptimizerOptions<float, Vector<float>, Vector<float>>();
+
+        Assert.Equal(32, opts.BatchSize);
+        Assert.Equal(0.001, opts.InitialLearningRate);
+        Assert.Equal(0.9, opts.Beta1);
+        Assert.Equal(0.999, opts.Beta2);
+        Assert.True(opts.EnableGradientClipping,
+            "AdamOptimizerOptions ctor should enable gradient clipping by default (PR #1364).");
+        Assert.Equal(1.0, opts.MaxGradientNorm);
+    }
+
+    [Fact]
+    public void AdamOptimizer_NullModelConstruction_DoesNotThrow()
+    {
+        // Smoke: the null-model ctor path AiModelBuilder uses (construct
+        // optimizer first, SetModel later) does not throw at construction
+        // time. PR #1380 root-caused as an InvalidCastException on the
+        // hot path; this asserts the build-and-construct sequence stays
+        // exception-free.
+        var opts = new AiDotNet.Models.Options.AdamOptimizerOptions<float, Vector<float>, Vector<float>>();
+        var optimizer = new AdamOptimizer<float, Vector<float>, Vector<float>>(model: null, opts);
+
+        Assert.NotNull(optimizer);
+    }
+}


### PR DESCRIPTION
## Summary

Addresses eight of the nine greenlit findings from `AiDotNet_Audit_Summary.docx` in a single PR per maintainer preference. LICENSE replacement is the ninth item and is being handled separately by the maintainer.

## Findings addressed

### Security

- **CORS** (audit P0 — verified). `src/AiDotNet.Serving/Program.cs` previously registered an unconditional `AllowAnyOrigin().AllowAnyMethod().AllowAnyHeader()` default policy. Production now reads an allow-list from configuration (`Cors:AllowedOrigins`); the wide-open policy only applies in `Development`. Falls closed in production when no allow-list is configured.
- **Default authorization** (audit P0 — verified). `AddAuthorization` now sets `FallbackPolicy = RequireAuthenticatedUser`. Endpoints that legitimately serve anonymous traffic — health probe, Stripe webhook (signature-authenticated), Stripe checkout session creation, license-key validation — are explicitly tagged `[AllowAnonymous]`. Inference, Embeddings, Federated, Models, ProgramSynthesis/*, and other previously-unprotected controllers now require authentication by default.

### Release pipeline

- **Smoke-test gate** (audit P0 — verified). `.github/workflows/automated-release.yml` previously had zero `dotnet test` invocations before `dotnet pack` and publish. Added a smoke-test gate filtered to `Category=Smoke|FullyQualifiedName~SmokeTests` — passes (zero tests run) until smoke-tagged tests are adopted, then enforces them automatically without slowing releases with the full ~64K-test suite.

### Metadata

- **Version sync** (audit verified). `src/AiDotNet.csproj` `<Version>` was `0.0.5-preview` while NuGet shipped `0.204.0`. Updated to `0.204.0`; the release pipeline still injects `-p:PackageVersion=...` at pack time, this static value is the source-built fallback.
- **LTS target** (audit P1). net8.0 LTS not added — the `AiDotNet.Tensors 0.81.3` transitive dependency doesn't ship an explicit net8.0 build (NU1701 falls back to net471). Documented inline as a follow-up; tracked in the csproj comment.

### Docs

- **Feature maturity matrix** (audit P1). README gains a "Feature Maturity" section labeling 16 subsystems as stable / beta / experimental / preview / stub. Surfaces the REST endpoints currently returning 501 (speculative decoding, LoRA fine-tuning) as `stub`.
- **Model card template** (audit P2). `docs/MODEL_CARD_TEMPLATE.md` added; covers architecture, training, evaluation, limitations, intended/out-of-scope use, data governance, versioning, and change log.

### Observability

- **OpenTelemetry scaffold** (audit P2). `src/AiDotNet.Serving/Observability/OpenTelemetryRegistration.cs` exposes named `ActivitySource` + `Meter` plus an opt-in registration hook. Deliberately no hard OTel package dependency — consumers wire their own exporters/samplers in their host project, then call `AddSource("AiDotNet.Serving")` / `AddMeter("AiDotNet.Serving")`. Full controller instrumentation is a follow-up.

## Not in this PR

- **LICENSE replacement** (audit P0): the LICENSE file is currently Apache 2.0 text while README and csproj Description say BSL 1.1. Maintainer is handling the BSL 1.1 text replacement directly.

## Test plan

- [x] `dotnet build src/AiDotNet.csproj --framework net10.0` — 0 errors
- [x] `dotnet build src/AiDotNet.Serving/AiDotNet.Serving.csproj` — 0 errors (warnings only, all pre-existing)
- [ ] CI on the audit branch
- [ ] Manual: serving app starts, /health probe still reachable, Stripe webhook still anonymous, admin endpoints still protected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * License validation and Stripe checkout/webhook endpoints are publicly reachable
  * Opt-in OpenTelemetry observability scaffold added

* **Documentation**
  * Added Feature Maturity section mapping subsystem stability
  * Added Model Card template for model documentation

* **Tests**
  * Release-gate smoke tests added and run during release pipeline
  * Test harness updated to simplify authenticated integration testing

* **Chores**
  * Package version bumped to 0.204.0
  * Tightened default auth fallback and environment-aware CORS; /health remains public

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ooples/AiDotNet/pull/1384?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->