### PR TITLE
feat(#1370): shape oracle TryDeclareShape() — eliminate LoRA warmup forward when ctor carries enough info

### DIFF
--- a/src/AiModelBuilder.cs
+++ b/src/AiModelBuilder.cs
@@ -2978,7 +2978,17 @@ public partial class AiModelBuilder<T, TInput, TOutput> : IAiModelBuilder<T, TIn
                 // Layers like MHA that allocate weights from ctor-known dims return true
                 // from TryDeclareShape even when InputShape still has a -1 seq placeholder
                 // — LoRA wraps weight matrices, the seq placeholder doesn't matter.
+                //
+                // PR #1388 follow-up review C9PtZ: only probe TryDeclareShape on
+                // layers that ApplyLoRA would actually wrap. A non-target lazy
+                // layer (e.g. a lazy ActivationLayer or DropoutLayer) would get
+                // its TryDeclareShape called, potentially allocating weights or
+                // emitting a Trace warning, only for ApplyLoRA below to return
+                // it unchanged. Gate on the same IsLoRATarget predicate the
+                // pre-scan loop uses so the side effects of TryDeclareShape
+                // only run for actual adaptation candidates.
                 if (originalLayer is NeuralNetworks.Layers.LayerBase<T> lazyCheck
+                    && (loraTargetProbe is null || loraTargetProbe.IsLoRATarget(lazyCheck))
                     && !TryDeclareShapeSafely(lazyCheck))
                 {
                     skippedLazyCount++;

--- a/src/AiModelBuilder.cs
+++ b/src/AiModelBuilder.cs
@@ -2813,73 +2813,114 @@ public partial class AiModelBuilder<T, TInput, TOutput> : IAiModelBuilder<T, TIn
         {
             System.Diagnostics.Trace.TraceInformation("Applying LoRA adapters to neural network layers...");
 
-            // Warmup forward to materialise lazy-init layers BEFORE LoRA
-            // wrapping. LoRAAdapterBase.CreateLoRALayer needs the
-            // layer's input/output dimensions at adapter-construction
-            // time; lazy layers (LayerNorm gamma/beta, MultiHeadAttention
-            // lazy weight banks) report (0, …) until first Forward
-            // materialises the shape. Without the warmup, LoRALayer's
-            // ctor would throw ArgumentOutOfRangeException("Output size
-            // must be positive"). Best-effort: if the warmup throws
-            // (e.g. the user wired a forward path that requires training
-            // mode), the ApplyLoRA-side IsShapeResolved guard silently
-            // skips still-unresolved layers so the wrap loop succeeds on
-            // the materialised ones. Discovered by AiDotNet#1345 Bucket10
-            // ConfigureLoRA test.
-            try
+            // AiDotNet#1370 shape oracle: pre-loop asks every layer to declare its
+            // shape from constructor args alone (TryDeclareShape). Layers like
+            // MultiHeadAttentionLayer (knows embeddingDim from ctor) and any
+            // layer constructed with explicit shape (e.g. LayerNormalizationLayer
+            // with the featureSize ctor) return true without needing input.
+            // Lazy convs / inferred-shape layers still return false and trigger
+            // the existing warmup forward as a fallback.
+            int declaredCount = 0;
+            int needsWarmupCount = 0;
+            for (int i = 0; i < neuralNetForLoRA.Layers.Count; i++)
             {
-                bool prevTrainingMode = neuralNetForLoRA.IsTrainingMode;
-                neuralNetForLoRA.SetTrainingMode(false);
+                if (neuralNetForLoRA.Layers[i] is NeuralNetworks.Layers.LayerBase<T> declarable)
+                {
+                    if (declarable.TryDeclareShape())
+                        declaredCount++;
+                    else
+                        needsWarmupCount++;
+                }
+                // Non-LayerBase<T> layers (rare, e.g. wrapper adapters from a
+                // prior pass) bypass the oracle entirely — the ApplyLoRA call
+                // handles its own shape probing.
+            }
+
+            // If every shape-aware layer declared successfully, skip the warmup
+            // forward entirely — this is the win that beats PyTorch / HuggingFace
+            // PEFT's construction-time shape requirement: we get the zero-warmup
+            // behavior when shapes are known, AND still support lazy layers via
+            // the warmup fallback below when needed.
+            bool skipWarmup = needsWarmupCount == 0;
+            if (skipWarmup)
+            {
+                System.Diagnostics.Trace.TraceInformation(
+                    $"LoRA warmup forward SKIPPED — all {declaredCount} shape-aware layer(s) " +
+                    "declared shape from constructor args (AiDotNet#1370 shape oracle).");
+            }
+            else
+            {
+                System.Diagnostics.Trace.TraceInformation(
+                    $"LoRA warmup forward required — {needsWarmupCount} layer(s) still need a forward " +
+                    $"pass to resolve shape ({declaredCount} declared from ctor).");
+
+                // Warmup forward to materialise lazy-init layers that didn't
+                // self-declare. LoRAAdapterBase.CreateLoRALayer needs the
+                // layer's input/output dimensions at adapter-construction
+                // time; lazy layers that fall through TryDeclareShape report
+                // (0, …) until first Forward materialises the shape.
+                // Without the warmup, LoRALayer's ctor would throw
+                // ArgumentOutOfRangeException("Output size must be positive").
+                // Best-effort: if the warmup throws (e.g. the user wired a
+                // forward path that requires training mode), the ApplyLoRA-side
+                // IsShapeResolved guard silently skips still-unresolved layers
+                // so the wrap loop succeeds on the materialised ones.
+                // Discovered by AiDotNet#1345 Bucket10 ConfigureLoRA test.
                 try
                 {
-                    // One sample is enough to resolve lazy-layer shapes;
-                    // a full-dataset forward would do O(N) work and
-                    // allocate a full pass of activation tensors just to
-                    // shape-resolve. Carve off a 1-row probe.
-                    var warmupProbe = TrySliceFirstSampleForLoRAWarmup(x);
-                    var warmupResult = _model.Predict(warmupProbe);
-                    System.GC.KeepAlive(warmupResult);
+                    bool prevTrainingMode = neuralNetForLoRA.IsTrainingMode;
+                    neuralNetForLoRA.SetTrainingMode(false);
+                    try
+                    {
+                        // One sample is enough to resolve lazy-layer shapes;
+                        // a full-dataset forward would do O(N) work and
+                        // allocate a full pass of activation tensors just to
+                        // shape-resolve. Carve off a 1-row probe.
+                        var warmupProbe = TrySliceFirstSampleForLoRAWarmup(x);
+                        var warmupResult = _model.Predict(warmupProbe);
+                        System.GC.KeepAlive(warmupResult);
+                    }
+                    finally
+                    {
+                        neuralNetForLoRA.SetTrainingMode(prevTrainingMode);
+                    }
                 }
-                finally
+                catch (OperationCanceledException)
                 {
-                    neuralNetForLoRA.SetTrainingMode(prevTrainingMode);
+                    // Cancellation propagates — caller wants out, not a swallowed warmup.
+                    throw;
                 }
-            }
-            catch (OperationCanceledException)
-            {
-                // Cancellation propagates — caller wants out, not a swallowed warmup.
-                throw;
-            }
-            catch (OutOfMemoryException)
-            {
-                // Critical: don't mask. The host may need to abort.
-                // StackOverflowException is intentionally NOT listed —
-                // modern .NET terminates the process on SOE rather than
-                // letting it propagate, so a catch clause for it is
-                // unreachable (review #1368 C7mpq).
-                throw;
-            }
-            catch (Exception ex)
-            {
-                // Best-effort warmup: documented forward-mode requirements
-                // (e.g. layers that need IsTrainingMode=true) can throw here.
-                // The ApplyLoRA-side IsShapeResolved guard silently skips
-                // still-unresolved layers so the wrap loop succeeds on
-                // materialized ones (review #1368 C6WOG: narrowed to let
-                // OperationCanceledException + OutOfMemoryException +
-                // StackOverflowException propagate; everything else is
-                // genuine warmup variance and stays as a Trace warning).
-                // Include ex.ToString() so the trace carries the full
-                // stack trace + inner exceptions, not just the top-frame
-                // message. Trace.TraceWarning is the only signal an
-                // operator has when the warmup fails silently (this PR's
-                // review C88M6: ex.Message dropped the origin frame and
-                // any chained inner exception, leaving a downstream
-                // skipped-lazy-layer mystery if the warmup actually
-                // failed inside an unrelated subsystem).
-                System.Diagnostics.Trace.TraceWarning(
-                    $"LoRA warmup forward failed (proceeding — layers that materialised get wrapped; " +
-                    $"lazy ones skipped via IsShapeResolved guard): {ex}");
+                catch (OutOfMemoryException)
+                {
+                    // Critical: don't mask. The host may need to abort.
+                    // StackOverflowException is intentionally NOT listed —
+                    // modern .NET terminates the process on SOE rather than
+                    // letting it propagate, so a catch clause for it is
+                    // unreachable (review #1368 C7mpq).
+                    throw;
+                }
+                catch (Exception ex)
+                {
+                    // Best-effort warmup: documented forward-mode requirements
+                    // (e.g. layers that need IsTrainingMode=true) can throw here.
+                    // The ApplyLoRA-side IsShapeResolved guard silently skips
+                    // still-unresolved layers so the wrap loop succeeds on
+                    // materialized ones (review #1368 C6WOG: narrowed to let
+                    // OperationCanceledException + OutOfMemoryException +
+                    // StackOverflowException propagate; everything else is
+                    // genuine warmup variance and stays as a Trace warning).
+                    // Include ex.ToString() so the trace carries the full
+                    // stack trace + inner exceptions, not just the top-frame
+                    // message. Trace.TraceWarning is the only signal an
+                    // operator has when the warmup fails silently (this PR's
+                    // review C88M6: ex.Message dropped the origin frame and
+                    // any chained inner exception, leaving a downstream
+                    // skipped-lazy-layer mystery if the warmup actually
+                    // failed inside an unrelated subsystem).
+                    System.Diagnostics.Trace.TraceWarning(
+                        $"LoRA warmup forward failed (proceeding — layers that materialised get wrapped; " +
+                        $"lazy ones skipped via IsShapeResolved guard): {ex}");
+                }
             }
 
             int adaptedCount = 0;
@@ -2888,8 +2929,12 @@ public partial class AiModelBuilder<T, TInput, TOutput> : IAiModelBuilder<T, TIn
             {
                 var originalLayer = neuralNetForLoRA.Layers[i];
 
+                // AiDotNet#1370: gate on TryDeclareShape() rather than IsShapeResolved.
+                // Layers like MHA that allocate weights from ctor-known dims return true
+                // from TryDeclareShape even when InputShape still has a -1 seq placeholder
+                // — LoRA wraps weight matrices, the seq placeholder doesn't matter.
                 if (originalLayer is NeuralNetworks.Layers.LayerBase<T> lazyCheck
-                    && !lazyCheck.IsShapeResolved)
+                    && !lazyCheck.TryDeclareShape())
                 {
                     skippedLazyCount++;
                     continue;

--- a/src/AiModelBuilder.cs
+++ b/src/AiModelBuilder.cs
@@ -2820,20 +2820,65 @@ public partial class AiModelBuilder<T, TInput, TOutput> : IAiModelBuilder<T, TIn
             // with the featureSize ctor) return true without needing input.
             // Lazy convs / inferred-shape layers still return false and trigger
             // the existing warmup forward as a fallback.
+            // PR #1388 review C7iL5: TryDeclareShape() is a public virtual
+            // extension point — a custom layer override can throw arbitrary
+            // exceptions. Treat non-fatal failures as "shape not declared"
+            // (falls back to the warmup forward below), but let cancellation
+            // and OOM propagate so the host can still abort. Trace the
+            // failure with the layer type + full exception so the operator
+            // can diagnose silently-skipped declarations.
+            static bool TryDeclareShapeSafely(NeuralNetworks.Layers.LayerBase<T> layer)
+            {
+                try
+                {
+                    return layer.TryDeclareShape();
+                }
+                catch (Exception ex) when (
+                    ex is not OperationCanceledException
+                    && ex is not OutOfMemoryException
+                    && ex is not StackOverflowException)
+                {
+                    System.Diagnostics.Trace.TraceWarning(
+                        $"TryDeclareShape failed for {layer.GetType().FullName} — " +
+                        $"treating as 'needs warmup': {ex}");
+                    return false;
+                }
+            }
+
+            // PR #1388 review C8mvN: only let LoRA-targeted layers drive the
+            // warmup-skip decision. A non-target lazy layer (e.g. a lazy
+            // ActivationLayer or DropoutLayer) won't be wrapped by ApplyLoRA
+            // anyway — counting it as "needs warmup" forces the warmup
+            // forward needlessly on mixed networks. Use the configuration's
+            // own non-mutating eligibility predicate when available; for a
+            // custom ILoRAConfiguration implementation that doesn't expose
+            // one, fall back to "every LayerBase counts" (conservative —
+            // may force an unnecessary warmup, but never skips one
+            // incorrectly).
+            var loraTargetProbe = _loraConfiguration as LoRA.DefaultLoRAConfiguration<T>;
+
             int declaredCount = 0;
             int needsWarmupCount = 0;
             for (int i = 0; i < neuralNetForLoRA.Layers.Count; i++)
             {
-                if (neuralNetForLoRA.Layers[i] is NeuralNetworks.Layers.LayerBase<T> declarable)
+                var layer = neuralNetForLoRA.Layers[i];
+                if (layer is not NeuralNetworks.Layers.LayerBase<T> declarable)
                 {
-                    if (declarable.TryDeclareShape())
-                        declaredCount++;
-                    else
-                        needsWarmupCount++;
+                    // Non-LayerBase<T> layers (rare, e.g. wrapper adapters from a
+                    // prior pass) bypass the oracle entirely — the ApplyLoRA call
+                    // handles its own shape probing.
+                    continue;
                 }
-                // Non-LayerBase<T> layers (rare, e.g. wrapper adapters from a
-                // prior pass) bypass the oracle entirely — the ApplyLoRA call
-                // handles its own shape probing.
+                if (loraTargetProbe is not null && !loraTargetProbe.IsLoRATarget(declarable))
+                {
+                    // Not a LoRA target — its shape doesn't gate the warmup-skip
+                    // decision. Skip without bumping either counter.
+                    continue;
+                }
+                if (TryDeclareShapeSafely(declarable))
+                    declaredCount++;
+                else
+                    needsWarmupCount++;
             }
 
             // If every shape-aware layer declared successfully, skip the warmup
@@ -2934,7 +2979,7 @@ public partial class AiModelBuilder<T, TInput, TOutput> : IAiModelBuilder<T, TIn
                 // from TryDeclareShape even when InputShape still has a -1 seq placeholder
                 // — LoRA wraps weight matrices, the seq placeholder doesn't matter.
                 if (originalLayer is NeuralNetworks.Layers.LayerBase<T> lazyCheck
-                    && !lazyCheck.TryDeclareShape())
+                    && !TryDeclareShapeSafely(lazyCheck))
                 {
                     skippedLazyCount++;
                     continue;

--- a/src/LoRA/DefaultLoRAConfiguration.cs
+++ b/src/LoRA/DefaultLoRAConfiguration.cs
@@ -276,70 +276,18 @@ public class DefaultLoRAConfiguration<T> : ILoRAConfiguration<T>
             return layer;
         }
 
-        // Check if this is a layer type that benefits from LoRA adaptation
-        // (layers with trainable weight matrices)
-
-        // Dense/Linear layers
-        if (layer is DenseLayer<T> || layer is FullyConnectedLayer<T> || layer is FeedForwardLayer<T>)
-        {
-            return CreateAdapter(layer);
-        }
-
-        // Convolutional layers
-        if (layer is ConvolutionalLayer<T> || layer is DeconvolutionalLayer<T> ||
-            layer is DepthwiseSeparableConvolutionalLayer<T> || layer is DilatedConvolutionalLayer<T> ||
-            layer is SeparableConvolutionalLayer<T> || layer is SubpixelConvolutionalLayer<T>)
-        {
-            return CreateAdapter(layer);
-        }
-
-        // Recurrent layers (LSTM, GRU, etc.)
-        if (layer is LSTMLayer<T> || layer is GRULayer<T> || layer is RecurrentLayer<T> ||
-            layer is ConvLSTMLayer<T> || layer is BidirectionalLayer<T>)
-        {
-            return CreateAdapter(layer);
-        }
-
-        // Attention layers
-        if (layer is AttentionLayer<T> || layer is MultiHeadAttentionLayer<T> || layer is SelfAttentionLayer<T>)
-        {
-            return CreateAdapter(layer);
-        }
-
-        // Transformer layers
-        if (layer is TransformerEncoderLayer<T> || layer is TransformerDecoderLayer<T>)
-        {
-            return CreateAdapter(layer);
-        }
-
-        // Embedding layers
-        if (layer is EmbeddingLayer<T> || layer is PatchEmbeddingLayer<T>)
-        {
-            return CreateAdapter(layer);
-        }
-
-        // Specialized layers with trainable weights
-        if (layer is LocallyConnectedLayer<T> || layer is HighwayLayer<T> ||
-            layer is GatedLinearUnitLayer<T> || layer is SqueezeAndExcitationLayer<T>)
-        {
-            return CreateAdapter(layer);
-        }
-
         // Graph convolutional layers - use specialized GraphConvolutionalLoRAAdapter
-        // which implements IGraphConvolutionLayer<T> and properly delegates graph methods
+        // which implements IGraphConvolutionLayer<T> and properly delegates graph methods.
+        // Kept separate from the IsLoRATargetType type-whitelist (which uses
+        // CreateAdapter for everything else) because the GraphConvolutionalLoRAAdapter
+        // ctor takes (layer, Rank, Alpha, FreezeBaseLayer) directly rather than going
+        // through the standard CreateAdapter dispatch.
         if (layer is IGraphConvolutionLayer<T>)
         {
             return new GraphConvolutionalLoRAAdapter<T>(layer, Rank, Alpha, FreezeBaseLayer);
         }
 
-        // Capsule layers
-        if (layer is CapsuleLayer<T> || layer is PrimaryCapsuleLayer<T> || layer is DigitCapsuleLayer<T>)
-        {
-            return CreateAdapter(layer);
-        }
-
-        // CRF and other advanced layers
-        if (layer is ConditionalRandomFieldLayer<T>)
+        if (IsLoRATargetType(layer))
         {
             return CreateAdapter(layer);
         }
@@ -347,6 +295,88 @@ public class DefaultLoRAConfiguration<T> : ILoRAConfiguration<T>
         // Return layers without trainable weights unchanged
         // (Activation, Pooling, Dropout, Flatten, Reshape, Normalization, etc.)
         return layer;
+    }
+
+    /// <summary>
+    /// Non-mutating predicate: returns <c>true</c> when this configuration would
+    /// wrap <paramref name="layer"/> with a LoRA adapter (modulo the
+    /// shape-resolved guard, which is independent of the layer type).
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Shares the same layer-type whitelist as <see cref="ApplyLoRA"/> so a
+    /// caller (typically <see cref="AiModelBuilder{T,TInput,TOutput}"/>'s
+    /// pre-wrap warmup-skip decision) can probe which layers will actually
+    /// participate in the LoRA pass without paying for adapter construction.
+    /// Returns <c>true</c> for graph-convolutional layers too — they route
+    /// through <see cref="GraphConvolutionalLoRAAdapter{T}"/> in
+    /// <see cref="ApplyLoRA"/>, but the warmup-skip pre-scan only needs to
+    /// know "would I wrap this", not which adapter type.
+    /// </para>
+    /// <para>
+    /// AiDotNet#1370 PR #1388 review C7iL5 — the pre-scan that decides
+    /// <c>skipWarmup</c> was treating every <see cref="LayerBase{T}"/> as a
+    /// LoRA candidate, which forced the warmup forward whenever ANY lazy
+    /// layer (even a non-target like a lazy Activation) hadn't declared.
+    /// This predicate lets the pre-scan restrict its count to actual LoRA
+    /// targets so non-target lazy layers don't block the zero-warmup path.
+    /// </para>
+    /// </remarks>
+    public bool IsLoRATarget(ILayer<T> layer)
+    {
+        if (layer is null) return false;
+        return layer is IGraphConvolutionLayer<T> || IsLoRATargetType(layer);
+    }
+
+    /// <summary>
+    /// Whitelist of concrete layer types that <see cref="ApplyLoRA"/> wraps via
+    /// <see cref="CreateAdapter"/>. Kept as a single private method so the
+    /// public <see cref="IsLoRATarget"/> probe and <see cref="ApplyLoRA"/>'s
+    /// dispatch can't drift.
+    /// </summary>
+    private static bool IsLoRATargetType(ILayer<T> layer)
+    {
+        // Dense/Linear layers
+        if (layer is DenseLayer<T> || layer is FullyConnectedLayer<T> || layer is FeedForwardLayer<T>)
+            return true;
+
+        // Convolutional layers
+        if (layer is ConvolutionalLayer<T> || layer is DeconvolutionalLayer<T> ||
+            layer is DepthwiseSeparableConvolutionalLayer<T> || layer is DilatedConvolutionalLayer<T> ||
+            layer is SeparableConvolutionalLayer<T> || layer is SubpixelConvolutionalLayer<T>)
+            return true;
+
+        // Recurrent layers (LSTM, GRU, etc.)
+        if (layer is LSTMLayer<T> || layer is GRULayer<T> || layer is RecurrentLayer<T> ||
+            layer is ConvLSTMLayer<T> || layer is BidirectionalLayer<T>)
+            return true;
+
+        // Attention layers
+        if (layer is AttentionLayer<T> || layer is MultiHeadAttentionLayer<T> || layer is SelfAttentionLayer<T>)
+            return true;
+
+        // Transformer layers
+        if (layer is TransformerEncoderLayer<T> || layer is TransformerDecoderLayer<T>)
+            return true;
+
+        // Embedding layers
+        if (layer is EmbeddingLayer<T> || layer is PatchEmbeddingLayer<T>)
+            return true;
+
+        // Specialized layers with trainable weights
+        if (layer is LocallyConnectedLayer<T> || layer is HighwayLayer<T> ||
+            layer is GatedLinearUnitLayer<T> || layer is SqueezeAndExcitationLayer<T>)
+            return true;
+
+        // Capsule layers
+        if (layer is CapsuleLayer<T> || layer is PrimaryCapsuleLayer<T> || layer is DigitCapsuleLayer<T>)
+            return true;
+
+        // CRF and other advanced layers
+        if (layer is ConditionalRandomFieldLayer<T>)
+            return true;
+
+        return false;
     }
 
     /// <summary>

--- a/src/NeuralNetworks/Layers/BatchNormalizationLayer.cs
+++ b/src/NeuralNetworks/Layers/BatchNormalizationLayer.cs
@@ -375,6 +375,52 @@ public partial class BatchNormalizationLayer<T> : LayerBase<T>, ILayerSerializat
     }
 
     /// <summary>
+    /// AiDotNet#1370 eager-init constructor. Pass <paramref name="numFeatures"/> at
+    /// construction (the channel count for image-like inputs OR the feature count
+    /// for MLP inputs) to allocate gamma/beta/running stats immediately and resolve
+    /// the layer's input + output shapes. Eliminates the need for a warmup forward
+    /// pass before downstream consumers (LoRA wrapping, parameter introspection,
+    /// ONNX export) can read shape-dependent state.
+    /// </summary>
+    /// <param name="numFeatures">
+    /// The channel count for image inputs (axis 1 of NCHW) or feature count for MLP
+    /// inputs (axis 1 of [B, F]). Must be positive. Per Ioffe &amp; Szegedy 2015 §3,
+    /// BatchNorm normalizes per-channel for images and per-feature for MLPs.
+    /// </param>
+    /// <param name="epsilon">A small value added to the variance for numerical stability.</param>
+    /// <param name="momentum">EMA momentum for running mean/variance updates.</param>
+    /// <remarks>
+    /// <para>
+    /// After this constructor returns, <see cref="LayerBase{T}.IsShapeResolved"/> is
+    /// <c>true</c> and <see cref="LayerBase{T}.TryDeclareShape"/> returns <c>true</c>
+    /// via the default implementation — no override needed on this layer.
+    /// </para>
+    /// </remarks>
+    /// <exception cref="ArgumentOutOfRangeException">When <paramref name="numFeatures"/> is not positive.</exception>
+    public BatchNormalizationLayer(int numFeatures, double epsilon = NumericalStabilityHelper.LargeEpsilon, double momentum = 0.9)
+        : base(new[] { numFeatures }, new[] { numFeatures })
+    {
+        if (numFeatures <= 0)
+            throw new ArgumentOutOfRangeException(nameof(numFeatures),
+                $"numFeatures must be positive, got {numFeatures}.");
+
+        _epsilon = NumericalStabilityHelper.GetEpsilon<T>(epsilon);
+        _momentum = NumOps.FromDouble(momentum);
+
+        // Eager allocation — same code path as OnFirstForward but driven from ctor.
+        // ZeroInitGamma deferral does not apply here (no first-forward to defer to).
+        _gamma = new Tensor<T>([numFeatures]);
+        _gamma.Fill(NumOps.One);
+        _beta = new Tensor<T>([numFeatures]);
+        _runningMean = new Tensor<T>([numFeatures]);
+        _runningVariance = new Tensor<T>([numFeatures]);
+        _runningVariance.Fill(NumOps.One);
+
+        RegisterTrainableParameter(_gamma, PersistentTensorRole.NormalizationParams);
+        RegisterTrainableParameter(_beta, PersistentTensorRole.NormalizationParams);
+    }
+
+    /// <summary>
     /// Resolves <c>numFeatures</c> on the first forward call by switching on
     /// the input rank, allocates gamma/beta + running mean/variance tensors,
     /// and registers gamma/beta as trainable parameters. Per the BatchNorm

--- a/src/NeuralNetworks/Layers/LayerBase.cs
+++ b/src/NeuralNetworks/Layers/LayerBase.cs
@@ -453,6 +453,50 @@ public abstract class LayerBase<T> : ILayer<T>, ITrainableLayer<T>, IDisposable
         InputShape is not null && !ShapeContainsSentinel(InputShape)
         && OutputShape is not null && !ShapeContainsSentinel(OutputShape);
 
+    /// <summary>
+    /// Proactively declares this layer's parameter shapes WITHOUT requiring a forward pass.
+    /// Returns <c>true</c> if the layer is in a state where shape-dependent post-processing
+    /// (LoRA wrapping, parameter introspection, ONNX export prep) can run successfully —
+    /// either because <see cref="IsShapeResolved"/> is already <c>true</c> OR because the
+    /// override has materialised enough internal state (e.g. allocated weight matrices from
+    /// constructor-known dims) for those downstream consumers.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// AiDotNet#1370: lets <see cref="AiModelBuilder{T, TInput, TOutput}"/>'s LoRA wrap path
+    /// skip its warmup forward when every layer in the network can declare shape from ctor
+    /// args alone — matching PyTorch / HuggingFace PEFT's construction-time-shape model
+    /// without giving up the lazy-shape flexibility AiDotNet needs for PyTorch-style
+    /// <c>LazyConv2d</c> / <c>LazyLinear</c> analogs.
+    /// </para>
+    /// <para>
+    /// <b>Default implementation:</b> returns <see cref="IsShapeResolved"/>. Layers whose
+    /// constructor carries the full shape (e.g. <see cref="FullyConnectedLayer{T}"/>) already
+    /// satisfy <see cref="IsShapeResolved"/> at construction time and need no override.
+    /// </para>
+    /// <para>
+    /// <b>Layers that should override:</b> lazy-init layers whose constructor carries enough
+    /// info to allocate their weight matrices (e.g. <see cref="MultiHeadAttentionLayer{T}"/>
+    /// with <c>headCount × headDimension</c> known but sequence length unknown). The override
+    /// should allocate weights, optionally call <see cref="ResolveShapes"/> if a usable input
+    /// shape can be synthesised, and return <c>true</c>. Returning <c>true</c> while
+    /// <see cref="IsShapeResolved"/> remains <c>false</c> is acceptable when the caller
+    /// (LoRA wrap, etc.) needs weight shapes rather than full I/O shapes — document the
+    /// asymmetry on the override.
+    /// </para>
+    /// <para>
+    /// <b>Layers that CANNOT override to return true:</b> any layer whose output shape
+    /// depends on input tensor properties beyond what the constructor captures (e.g.
+    /// PyTorch-style <c>LazyConv2d</c> that infers <c>inChannels</c> from the first input).
+    /// Those should leave the default behavior — the warmup forward stays as the fallback.
+    /// </para>
+    /// </remarks>
+    /// <returns>
+    /// <c>true</c> if the layer is ready for shape-dependent post-processing;
+    /// <c>false</c> if a forward pass is still required to materialise shape.
+    /// </returns>
+    public virtual bool TryDeclareShape() => IsShapeResolved;
+
     private static bool ShapeContainsSentinel(int[] shape)
     {
         for (int i = 0; i < shape.Length; i++)

--- a/src/NeuralNetworks/Layers/LayerBase.cs
+++ b/src/NeuralNetworks/Layers/LayerBase.cs
@@ -495,7 +495,14 @@ public abstract class LayerBase<T> : ILayer<T>, ITrainableLayer<T>, IDisposable
     /// <c>true</c> if the layer is ready for shape-dependent post-processing;
     /// <c>false</c> if a forward pass is still required to materialise shape.
     /// </returns>
-    public virtual bool TryDeclareShape() => IsShapeResolved;
+    /// <remarks>
+    /// Visibility: <c>internal</c>. This is shape-oracle orchestration plumbing
+    /// for <see cref="AiModelBuilder"/> and other in-assembly callers (LoRA
+    /// warmup elimination per #1370); end users interact with the builder/result
+    /// API only and should not see this hook on the public layer surface.
+    /// Per PR #1388 review.
+    /// </remarks>
+    internal virtual bool TryDeclareShape() => IsShapeResolved;
 
     private static bool ShapeContainsSentinel(int[] shape)
     {

--- a/src/NeuralNetworks/Layers/LayerNormalizationLayer.cs
+++ b/src/NeuralNetworks/Layers/LayerNormalizationLayer.cs
@@ -231,6 +231,49 @@ public partial class LayerNormalizationLayer<T> : LayerBase<T>
     }
 
     /// <summary>
+    /// AiDotNet#1370 eager-init constructor. Pass <paramref name="featureSize"/> at
+    /// construction to allocate gamma/beta immediately and resolve the layer's input
+    /// and output shapes — eliminating the need for a warmup forward pass before
+    /// downstream consumers (LoRA wrapping, parameter introspection, ONNX export)
+    /// can read shape-dependent state.
+    /// </summary>
+    /// <param name="featureSize">
+    /// The number of features in the input data. Must be positive. Normalization
+    /// happens along this last axis per the LayerNorm contract (Ba et al. 2016).
+    /// </param>
+    /// <param name="epsilon">A small value added to the variance for numerical stability.</param>
+    /// <remarks>
+    /// <para>
+    /// After this constructor returns, <see cref="LayerBase{T}.IsShapeResolved"/> is
+    /// <c>true</c> and <see cref="LayerBase{T}.TryDeclareShape"/> returns <c>true</c>
+    /// via its default implementation — no override needed on this layer.
+    /// </para>
+    /// <para>
+    /// Use this overload in transformer architectures and similar models where the
+    /// feature dimension is fixed by the architecture config (e.g. <c>modelDimension</c>
+    /// on <see cref="TransformerArchitecture{T}"/>). Use the parameter-less constructor
+    /// only when the feature dim is genuinely unknown at construction time.
+    /// </para>
+    /// </remarks>
+    /// <exception cref="ArgumentOutOfRangeException">When <paramref name="featureSize"/> is not positive.</exception>
+    public LayerNormalizationLayer(int featureSize, double epsilon = NumericalStabilityHelper.LargeEpsilon)
+        : base(new[] { featureSize }, new[] { featureSize })
+    {
+        if (featureSize <= 0)
+            throw new ArgumentOutOfRangeException(nameof(featureSize),
+                $"featureSize must be positive, got {featureSize}.");
+
+        _epsilon = NumericalStabilityHelper.GetEpsilon<T>(epsilon);
+
+        // Eager allocation — same code path as OnFirstForward but driven from ctor.
+        _gamma = Tensor<T>.CreateDefault([featureSize], NumOps.One);
+        _beta = Tensor<T>.CreateDefault([featureSize], NumOps.Zero);
+
+        RegisterTrainableParameter(_gamma, PersistentTensorRole.NormalizationParams);
+        RegisterTrainableParameter(_beta, PersistentTensorRole.NormalizationParams);
+    }
+
+    /// <summary>
     /// Resolves <c>featureSize</c> from <c>input.Shape[^1]</c> (last dim) on the first forward call,
     /// allocates gamma/beta tensors, and registers them as trainable parameters. Per the
     /// LayerNorm contract (Ba et al. 2016), normalization happens along the feature axis.

--- a/src/NeuralNetworks/Layers/MultiHeadAttentionLayer.cs
+++ b/src/NeuralNetworks/Layers/MultiHeadAttentionLayer.cs
@@ -499,7 +499,12 @@ public partial class MultiHeadAttentionLayer<T> : LayerBase<T>, IAuxiliaryLossLa
     // _alibiLayer are sub-layers that need sub-layer registration. Our lazy-init
     // logic lives in this differently-named private helper and gets explicitly
     // called from Forward / GetParameters / SetParameters.
-    private void EnsureWeightsAllocated()
+    //
+    // Made internal (AiDotNet#1370) so TryDeclareShape can call it to allocate
+    // the Q/K/V/O matrices from constructor-known _embeddingDimension without
+    // requiring a forward pass — enabling AiModelBuilder's LoRA wrap path to
+    // skip its warmup forward when every layer can declare from ctor args.
+    internal void EnsureWeightsAllocated()
     {
         if (_isInitialized) return;
 
@@ -549,6 +554,34 @@ public partial class MultiHeadAttentionLayer<T> : LayerBase<T>, IAuxiliaryLossLa
 
             _isInitialized = true;
         }
+    }
+
+    /// <summary>
+    /// AiDotNet#1370 shape oracle override: MultiHeadAttentionLayer's constructor
+    /// takes <c>(headCount, headDimension)</c> from which the embedding dim
+    /// <c>= headCount * headDimension</c> is fully determined, and the four
+    /// projection weight matrices (Q / K / V / O) all have shape
+    /// <c>[embeddingDim, embeddingDim]</c> — known without any input tensor.
+    /// Only the input sequence length is genuinely dynamic.
+    /// <para>
+    /// This override allocates the Q/K/V/O weight matrices via
+    /// <see cref="EnsureWeightsAllocated"/> and returns <c>true</c> so that
+    /// downstream consumers (LoRA wrapping, parameter introspection) can size
+    /// themselves from the weight matrices without a warmup forward pass.
+    /// </para>
+    /// <para>
+    /// <b>Asymmetry with <see cref="LayerBase{T}.IsShapeResolved"/>:</b> this
+    /// method returns <c>true</c> even though <see cref="LayerBase{T}.InputShape"/>
+    /// still contains a <c>-1</c> placeholder for the sequence dim. LoRA wrapping
+    /// needs only the weight matrix shape (which is fully concrete); the seq
+    /// placeholder is resolved by the first real forward call.
+    /// </para>
+    /// </summary>
+    public override bool TryDeclareShape()
+    {
+        if (_isInitialized) return true;
+        EnsureWeightsAllocated();
+        return _isInitialized;
     }
 
     /// <summary>

--- a/src/NeuralNetworks/Layers/MultiHeadAttentionLayer.cs
+++ b/src/NeuralNetworks/Layers/MultiHeadAttentionLayer.cs
@@ -581,7 +581,7 @@ public partial class MultiHeadAttentionLayer<T> : LayerBase<T>, IAuxiliaryLossLa
     /// placeholder is resolved by the first real forward call.
     /// </para>
     /// </summary>
-    public override bool TryDeclareShape()
+    internal override bool TryDeclareShape()
     {
         if (_isInitialized) return true;
         EnsureWeightsAllocated();

--- a/src/NeuralNetworks/Layers/MultiHeadAttentionLayer.cs
+++ b/src/NeuralNetworks/Layers/MultiHeadAttentionLayer.cs
@@ -500,11 +500,15 @@ public partial class MultiHeadAttentionLayer<T> : LayerBase<T>, IAuxiliaryLossLa
     // logic lives in this differently-named private helper and gets explicitly
     // called from Forward / GetParameters / SetParameters.
     //
-    // Made internal (AiDotNet#1370) so TryDeclareShape can call it to allocate
-    // the Q/K/V/O matrices from constructor-known _embeddingDimension without
-    // requiring a forward pass — enabling AiModelBuilder's LoRA wrap path to
-    // skip its warmup forward when every layer can declare from ctor args.
-    internal void EnsureWeightsAllocated()
+    // Called by TryDeclareShape() (AiDotNet#1370) to allocate the Q/K/V/O
+    // matrices from constructor-known _embeddingDimension without requiring
+    // a forward pass — enabling AiModelBuilder's LoRA wrap path to skip its
+    // warmup forward when every layer can declare from ctor args.
+    // Kept private because every caller is in this file (PR #1388 review
+    // C7e3Y — "Prefer private over internal when the member is only used
+    // within its own class"); TryDeclareShape lives in this same partial
+    // class so the visibility doesn't need to widen for that path.
+    private void EnsureWeightsAllocated()
     {
         if (_isInitialized) return;
 

--- a/src/NeuralNetworks/Layers/PReLULayer.cs
+++ b/src/NeuralNetworks/Layers/PReLULayer.cs
@@ -115,7 +115,7 @@ public class PReLULayer<T> : LayerBase<T>
     /// until the first real forward resolves the input rank) — same pattern
     /// as <see cref="MultiHeadAttentionLayer{T}.TryDeclareShape"/>.
     /// </summary>
-    public override bool TryDeclareShape() => true;
+    internal override bool TryDeclareShape() => true;
 
     /// <summary>
     /// Resolves broadcast shape and validates channel-count compatibility on first forward.

--- a/src/NeuralNetworks/Layers/PReLULayer.cs
+++ b/src/NeuralNetworks/Layers/PReLULayer.cs
@@ -104,6 +104,20 @@ public class PReLULayer<T> : LayerBase<T>
     }
 
     /// <summary>
+    /// AiDotNet#1370 shape oracle override: PReLU's α weight tensor is fully
+    /// determined by the constructor argument <c>numParameters</c> and is
+    /// allocated + registered as a trainable parameter at construction time
+    /// (line 98–103 above). The lazy bit is only the broadcast shape, which
+    /// is a forward-runtime concern, not a parameter-shape concern.
+    /// LoRA wrapping needs only the weight matrix shape, so this returns
+    /// <c>true</c> unconditionally. Asymmetric with
+    /// <see cref="LayerBase{T}.IsShapeResolved"/> (which stays <c>false</c>
+    /// until the first real forward resolves the input rank) — same pattern
+    /// as <see cref="MultiHeadAttentionLayer{T}.TryDeclareShape"/>.
+    /// </summary>
+    public override bool TryDeclareShape() => true;
+
+    /// <summary>
     /// Resolves broadcast shape and validates channel-count compatibility on first forward.
     /// </summary>
     protected override void OnFirstForward(Tensor<T> input)

--- a/src/NeuralNetworks/Layers/RMSNormalizationLayer.cs
+++ b/src/NeuralNetworks/Layers/RMSNormalizationLayer.cs
@@ -98,6 +98,35 @@ public partial class RMSNormalizationLayer<T> : LayerBase<T>
     }
 
     /// <summary>
+    /// AiDotNet#1370 eager-init constructor. Pass <paramref name="featureSize"/> at
+    /// construction to allocate γ immediately and resolve the layer's input + output
+    /// shapes — eliminating the need for a warmup forward pass before downstream
+    /// consumers (LoRA wrapping, parameter introspection, ONNX export) can read
+    /// shape-dependent state. Per Zhang &amp; Sennrich 2019, γ is initialised to 1
+    /// (the no-op identity).
+    /// </summary>
+    /// <param name="featureSize">The size of the last (feature) axis. Must be positive.</param>
+    /// <param name="epsilon">A small value added to the variance for numerical stability.</param>
+    /// <remarks>
+    /// After this constructor returns, <see cref="LayerBase{T}.IsShapeResolved"/> is
+    /// <c>true</c> and <see cref="LayerBase{T}.TryDeclareShape"/> returns <c>true</c>
+    /// via the default implementation — no override needed.
+    /// </remarks>
+    /// <exception cref="ArgumentOutOfRangeException">When <paramref name="featureSize"/> is not positive.</exception>
+    public RMSNormalizationLayer(int featureSize, double epsilon = 1e-6)
+        : base(new[] { featureSize }, new[] { featureSize })
+    {
+        if (featureSize <= 0)
+            throw new ArgumentOutOfRangeException(nameof(featureSize),
+                $"featureSize must be positive, got {featureSize}.");
+
+        _epsilon = NumericalStabilityHelper.GetEpsilon<T>(epsilon);
+
+        _gamma = Tensor<T>.CreateDefault([featureSize], NumOps.One);
+        RegisterTrainableParameter(_gamma, PersistentTensorRole.NormalizationParams);
+    }
+
+    /// <summary>
     /// Resolves <c>featureSize</c> from <c>input.Shape[^1]</c> on the first forward call
     /// and allocates the γ tensor. Per Zhang &amp; Sennrich 2019, γ is initialised to 1
     /// (the no-op identity) so the layer behaves as a pass-through before training.

--- a/src/NeuralNetworks/Layers/TransformerEncoderLayer.cs
+++ b/src/NeuralNetworks/Layers/TransformerEncoderLayer.cs
@@ -488,7 +488,22 @@ public class TransformerEncoderLayer<T> : LayerBase<T>, IAuxiliaryLossLayer<T>
     /// warmup-forward fallback in <see cref="AiModelBuilder{T, TInput, TOutput}"/>
     /// still runs for that path.
     /// </summary>
-    public override bool TryDeclareShape() => _isInitialized || IsShapeResolved;
+    internal override bool TryDeclareShape()
+    {
+        // Allocation state is the source of truth for "shape oracle ready".
+        // Previously this returned `_isInitialized || IsShapeResolved`, but
+        // IsShapeResolved can flip true (e.g. via a non-allocating shape
+        // declaration upstream) before sublayer weights exist — and LoRA
+        // wrapping needs the actual weight matrices, not just resolved
+        // dimensions. PR #1388 review.
+        if (_isInitialized) return true;
+        if (_embeddingSize > 0)
+        {
+            EnsureInitialized();
+            return _isInitialized;
+        }
+        return false;
+    }
 
     /// <summary>
     /// Resolves <see cref="_embeddingSize"/> from <c>input.Shape[^1]</c> and propagates

--- a/src/NeuralNetworks/Layers/TransformerEncoderLayer.cs
+++ b/src/NeuralNetworks/Layers/TransformerEncoderLayer.cs
@@ -476,6 +476,21 @@ public class TransformerEncoderLayer<T> : LayerBase<T>, IAuxiliaryLossLayer<T>
     private bool _isInitialized;
 
     /// <summary>
+    /// AiDotNet#1370 shape oracle override: when the eager-dimension ctor
+    /// (<c>(numHeads, feedForwardDim, embeddingSize)</c>) supplied a concrete
+    /// embedding width, sublayers were constructed at ctor time
+    /// (<see cref="EnsureInitialized"/> ran from the eager ctor). LoRA wrapping
+    /// can then introspect sublayer weights without a warmup forward.
+    /// Returns <c>true</c> when sublayers are allocated, even though
+    /// <see cref="LayerBase{T}.InputShape"/> still carries <c>[-1, -1, -1]</c>
+    /// (sequence + batch dims are genuinely dynamic and resolve at first forward).
+    /// The lazy ctor (<c>embeddingSize == -1</c>) returns <c>false</c> so the
+    /// warmup-forward fallback in <see cref="AiModelBuilder{T, TInput, TOutput}"/>
+    /// still runs for that path.
+    /// </summary>
+    public override bool TryDeclareShape() => _isInitialized || IsShapeResolved;
+
+    /// <summary>
     /// Resolves <see cref="_embeddingSize"/> from <c>input.Shape[^1]</c> and propagates
     /// the full input shape into the layer's resolved shapes (input == output for an
     /// encoder block).

--- a/tests/AiDotNet.Tests/IntegrationTests/NeuralNetworks/AdvancedLayersIntegrationTests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/NeuralNetworks/AdvancedLayersIntegrationTests.cs
@@ -86,11 +86,15 @@ public class AdvancedLayersIntegrationTests
     [Fact(Timeout = 120000)]
     public async Task TransformerEncoderLayer_ParameterCount_ReturnsPositiveValue()
     {
-        // Arrange
+        await Task.Yield();
+        // Arrange — use the eager-dimension ctor (AiDotNet#1370 made it the
+        // shape-oracle-friendly path: passing embeddingSize constructs sublayers
+        // at ctor time so ParameterCount reflects allocated weights without a
+        // warmup forward).
         int embeddingSize = 64;
         int numHeads = 4;
         int feedForwardDim = 256;
-        var layer = new TransformerEncoderLayer<float>( numHeads, feedForwardDim);
+        var layer = new TransformerEncoderLayer<float>(numHeads, feedForwardDim, embeddingSize);
 
         // Act
         int paramCount = (int)layer.ParameterCount;
@@ -2147,9 +2151,11 @@ public class AdvancedLayersIntegrationTests
     [Fact(Timeout = 120000)]
     public async Task BatchNormalizationLayer_ParameterCount_IsPositive()
     {
-        // Arrange
+        await Task.Yield();
+        // Arrange — AiDotNet#1370 eager ctor allocates gamma/beta immediately so
+        // ParameterCount reflects the materialised state without needing a forward.
         int numFeatures = 64;
-        var layer = new BatchNormalizationLayer<float>();
+        var layer = new BatchNormalizationLayer<float>(numFeatures);
 
         // Act
         int paramCount = (int)layer.ParameterCount;
@@ -2377,9 +2383,11 @@ public class AdvancedLayersIntegrationTests
     [Fact(Timeout = 120000)]
     public async Task LayerNormalizationLayer_ParameterCount_IsPositive()
     {
-        // Arrange
+        await Task.Yield();
+        // Arrange — AiDotNet#1370 eager ctor allocates gamma/beta immediately so
+        // ParameterCount reflects the materialised state without needing a forward.
         int featureSize = 64;
-        var layer = new LayerNormalizationLayer<float>();
+        var layer = new LayerNormalizationLayer<float>(featureSize);
 
         // Act
         int paramCount = (int)layer.ParameterCount;

--- a/tests/AiDotNet.Tests/IntegrationTests/NeuralNetworks/NormalizationLayersDeepMathIntegrationTests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/NeuralNetworks/NormalizationLayersDeepMathIntegrationTests.cs
@@ -442,7 +442,9 @@ public class NormalizationLayersDeepMathIntegrationTests
     [Fact(Timeout = 120000)]
     public async Task LayerNorm_ParameterCount_IsTwiceFeatureSize()
     {
-        var ln = new LayerNormalizationLayer<double>();
+        await Task.Yield();
+        // AiDotNet#1370 eager ctor — featureSize=7 → 2*7=14 (gamma + beta) at ctor time.
+        var ln = new LayerNormalizationLayer<double>(featureSize: 7);
         Assert.Equal(14, (int)ln.ParameterCount);
     }
 

--- a/tests/AiDotNet.Tests/IntegrationTests/NeuralNetworks/NormalizationLayersIntegrationTests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/NeuralNetworks/NormalizationLayersIntegrationTests.cs
@@ -116,9 +116,12 @@ public class NormalizationLayersIntegrationTests
     [Fact(Timeout = 120000)]
     public async Task BatchNormalizationLayer_ParameterCount_IncludesGammaAndBeta()
     {
-        // Arrange
+        await Task.Yield();
+        // Arrange — use the AiDotNet#1370 eager (numFeatures, ...) ctor so
+        // gamma/beta are allocated at construction time and ParameterCount
+        // returns the expected 2*numFeatures without needing a warmup forward.
         int numFeatures = 8;
-        var layer = new BatchNormalizationLayer<float>();
+        var layer = new BatchNormalizationLayer<float>(numFeatures);
 
         // Act
         int paramCount = (int)layer.ParameterCount;
@@ -190,9 +193,12 @@ public class NormalizationLayersIntegrationTests
     [Fact(Timeout = 120000)]
     public async Task LayerNormalizationLayer_ParameterCount_IncludesGammaAndBeta()
     {
-        // Arrange
+        await Task.Yield();
+        // Arrange — use the AiDotNet#1370 eager featureSize ctor so gamma/beta
+        // are allocated at construction time and ParameterCount returns the
+        // expected 2*featureSize without needing a warmup forward.
         int featureSize = 16;
-        var layer = new LayerNormalizationLayer<float>();
+        var layer = new LayerNormalizationLayer<float>(featureSize);
 
         // Act
         int paramCount = (int)layer.ParameterCount;

--- a/tests/AiDotNet.Tests/UnitTests/NeuralNetworks/Layers/ShapeOracleIssue1370Tests.cs
+++ b/tests/AiDotNet.Tests/UnitTests/NeuralNetworks/Layers/ShapeOracleIssue1370Tests.cs
@@ -1,0 +1,281 @@
+using AiDotNet.NeuralNetworks.Layers;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tests.UnitTests.NeuralNetworks.Layers;
+
+/// <summary>
+/// Unit tests for the AiDotNet#1370 shape oracle: <see cref="LayerBase{T}.TryDeclareShape"/>
+/// virtual + the high-value overrides on
+/// <see cref="MultiHeadAttentionLayer{T}"/> and the eager-init
+/// <see cref="LayerNormalizationLayer{T}"/> constructor.
+/// </summary>
+/// <remarks>
+/// Joined the <c>LayerSerializationCollection</c> so these tests don't run in
+/// parallel with the auto-generated <c>LayerTestBase.TapeGradient_ShouldMatchNumericalGradient</c>
+/// tests. The MHA TryDeclareShape override allocates weights via <c>SimdRandom</c>
+/// which uses a thread-local seed — concurrent execution with the generated
+/// TapeGradient tests shifts their seed and produces flaky finite-difference
+/// gradient comparisons. Serializing eliminates the interference without
+/// changing layer behavior.
+/// </remarks>
+[Collection(global::AiDotNet.Tests.Fixtures.LayerSerializationCollection.Name)]
+public class ShapeOracleIssue1370Tests
+{
+    /// <summary>
+    /// Default <see cref="LayerBase{T}.TryDeclareShape"/> impl returns
+    /// <see cref="LayerBase{T}.IsShapeResolved"/> verbatim. A
+    /// <see cref="LayerNormalizationLayer{T}"/> constructed with the eager
+    /// (featureSize) ctor is shape-resolved at ctor return, so the default
+    /// returns true without any override.
+    /// </summary>
+    [Fact]
+    public void TryDeclareShape_DefaultImpl_MatchesIsShapeResolved_EagerLayerNorm()
+    {
+        var layer = new LayerNormalizationLayer<float>(featureSize: 16);
+        Assert.True(layer.IsShapeResolved);
+        Assert.True(layer.TryDeclareShape());
+    }
+
+    /// <summary>
+    /// Parameter-less <see cref="LayerNormalizationLayer{T}"/> ctor leaves the
+    /// feature dim deferred until first forward — IsShapeResolved is false,
+    /// so the default <see cref="LayerBase{T}.TryDeclareShape"/> impl
+    /// (which mirrors IsShapeResolved) must also return false. This is the
+    /// contract that lets <see cref="AiDotNet.AiModelBuilder{T, TInput, TOutput}"/>'s
+    /// LoRA wrap path correctly fall back to the warmup forward when any
+    /// layer can't self-declare.
+    /// </summary>
+    [Fact]
+    public void TryDeclareShape_LazyLayerNormDefaultCtor_ReturnsFalse()
+    {
+        var layer = new LayerNormalizationLayer<float>();
+        Assert.False(layer.IsShapeResolved);
+        Assert.False(layer.TryDeclareShape());
+    }
+
+    /// <summary>
+    /// Eager-init <see cref="LayerNormalizationLayer{T}"/> ctor (AiDotNet#1370):
+    /// passing featureSize at construction allocates gamma/beta immediately and
+    /// resolves the layer's input + output shapes. <see cref="LayerBase{T}.IsShapeResolved"/>
+    /// is true at construction time, so the default <see cref="LayerBase{T}.TryDeclareShape"/>
+    /// impl returns true without needing an override on the layer.
+    /// </summary>
+    [Theory]
+    [InlineData(8)]
+    [InlineData(64)]
+    [InlineData(768)]
+    [InlineData(4096)]
+    public void TryDeclareShape_EagerLayerNormCtor_ReturnsTrueImmediately(int featureSize)
+    {
+        var layer = new LayerNormalizationLayer<float>(featureSize);
+        Assert.True(layer.IsShapeResolved);
+        Assert.True(layer.TryDeclareShape());
+
+        // Gamma/beta materialised at the requested feature dim — verifies the
+        // eager ctor actually allocated, not just set the shape metadata.
+        var gamma = layer.GetGammaTensor();
+        var beta = layer.GetBetaTensor();
+        Assert.Equal(featureSize, gamma.Length);
+        Assert.Equal(featureSize, beta.Length);
+    }
+
+    /// <summary>
+    /// Eager-init <see cref="LayerNormalizationLayer{T}"/> rejects non-positive
+    /// featureSize — wrap loop downstream would otherwise build a zero-sized
+    /// gamma/beta tensor that explodes on first use.
+    /// </summary>
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    [InlineData(-128)]
+    public void EagerLayerNormCtor_RejectsNonPositiveFeatureSize(int featureSize)
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => new LayerNormalizationLayer<float>(featureSize));
+    }
+
+    /// <summary>
+    /// <see cref="MultiHeadAttentionLayer{T}.TryDeclareShape"/> override:
+    /// the ctor takes <c>(headCount, headDimension)</c> so the embedding dim
+    /// is fully known and the four projection weight matrices (Q/K/V/O) all
+    /// have shape <c>[embed, embed]</c>. Calling TryDeclareShape must allocate
+    /// the weights AND return true even though the input sequence length is
+    /// still <c>-1</c> in InputShape.
+    /// </summary>
+    [Theory]
+    [InlineData(8, 16)]  // small
+    [InlineData(12, 64)] // BERT-base scale
+    [InlineData(16, 64)] // GPT-2 scale
+    public void MHA_TryDeclareShape_AllocatesWeights_AndReturnsTrue_BeforeAnyForward(int headCount, int headDimension)
+    {
+        var layer = new MultiHeadAttentionLayer<float>(
+            headCount: headCount,
+            headDimension: headDimension);
+
+        // Before TryDeclareShape: weights are placeholder [0, 0], IsShapeResolved
+        // is false (InputShape carries the -1 seq placeholder), and ParameterCount
+        // reflects the un-allocated state.
+        Assert.False(layer.IsShapeResolved);
+
+        // The shape oracle call.
+        bool declared = layer.TryDeclareShape();
+
+        Assert.True(declared,
+            "MHA must return true from TryDeclareShape — embedding dim is known from ctor.");
+
+        // After the call: weights allocated to [embed, embed] = [headCount*headDimension, ...].
+        int expectedEmbed = headCount * headDimension;
+        var qWeights = layer.GetQueryWeights();
+        Assert.Equal(expectedEmbed, qWeights.Shape[0]);
+        Assert.Equal(expectedEmbed, qWeights.Shape[1]);
+
+        // ParameterCount now reflects allocated state — 4 * embed*embed + embed (bias).
+        long expectedParams = 4L * expectedEmbed * expectedEmbed + expectedEmbed;
+        Assert.Equal(expectedParams, layer.ParameterCount);
+
+        // Asymmetry: IsShapeResolved remains false (InputShape still has -1 seq),
+        // but TryDeclareShape returned true. Both are correct under the AiDotNet#1370
+        // contract — TryDeclareShape means "ready for shape-dependent post-processing
+        // (e.g. LoRA wrap)", which only needs weight matrix shape.
+        Assert.False(layer.IsShapeResolved);
+    }
+
+    /// <summary>
+    /// <see cref="MultiHeadAttentionLayer{T}.TryDeclareShape"/> is idempotent:
+    /// calling it twice (or after a real forward has already resolved shapes)
+    /// must succeed without re-allocating weights.
+    /// </summary>
+    [Fact]
+    public void MHA_TryDeclareShape_Idempotent()
+    {
+        var layer = new MultiHeadAttentionLayer<float>(headCount: 4, headDimension: 16);
+
+        Assert.True(layer.TryDeclareShape());
+        var firstQ = layer.GetQueryWeights();
+        long firstParamCount = layer.ParameterCount;
+
+        // Second call must not re-allocate or change anything.
+        Assert.True(layer.TryDeclareShape());
+        var secondQ = layer.GetQueryWeights();
+
+        Assert.Same(firstQ, secondQ);
+        Assert.Equal(firstParamCount, layer.ParameterCount);
+    }
+
+    /// <summary>
+    /// Eager-init <see cref="BatchNormalizationLayer{T}"/> ctor (AiDotNet#1370):
+    /// passing numFeatures at construction allocates gamma/beta/runningMean/runningVariance
+    /// immediately and resolves the layer's input + output shapes.
+    /// </summary>
+    [Theory]
+    [InlineData(8)]
+    [InlineData(64)]
+    [InlineData(2048)]
+    public void TryDeclareShape_EagerBatchNormCtor_ReturnsTrueImmediately(int numFeatures)
+    {
+        var layer = new BatchNormalizationLayer<float>(numFeatures);
+        Assert.True(layer.IsShapeResolved);
+        Assert.True(layer.TryDeclareShape());
+
+        // ParameterCount = 2 * numFeatures (gamma + beta, running stats not trainable).
+        Assert.Equal(2L * numFeatures, layer.ParameterCount);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    [InlineData(-128)]
+    public void EagerBatchNormCtor_RejectsNonPositiveNumFeatures(int numFeatures)
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => new BatchNormalizationLayer<float>(numFeatures));
+    }
+
+    /// <summary>
+    /// Eager-init <see cref="RMSNormalizationLayer{T}"/> ctor (AiDotNet#1370):
+    /// passing featureSize at construction allocates gamma immediately.
+    /// </summary>
+    [Theory]
+    [InlineData(8)]
+    [InlineData(4096)]
+    public void TryDeclareShape_EagerRMSNormCtor_ReturnsTrueImmediately(int featureSize)
+    {
+        var layer = new RMSNormalizationLayer<float>(featureSize);
+        Assert.True(layer.IsShapeResolved);
+        Assert.True(layer.TryDeclareShape());
+
+        // ParameterCount = featureSize (gamma only; RMSNorm has no beta).
+        Assert.Equal((long)featureSize, layer.ParameterCount);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public void EagerRMSNormCtor_RejectsNonPositiveFeatureSize(int featureSize)
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => new RMSNormalizationLayer<float>(featureSize));
+    }
+
+    /// <summary>
+    /// <see cref="PReLULayer{T}.TryDeclareShape"/> override: α weight tensor is
+    /// fully allocated and registered in the constructor (line 98–103 of the
+    /// layer). The lazy bit is only the broadcast shape, which is a
+    /// forward-runtime concern. LoRA needs only the weight matrix shape, so
+    /// TryDeclareShape returns true unconditionally.
+    /// </summary>
+    [Theory]
+    [InlineData(1)]    // shared α
+    [InlineData(64)]   // per-channel α
+    [InlineData(256)]
+    public void PReLU_TryDeclareShape_ReturnsTrue_BeforeAnyForward(int numParameters)
+    {
+        var layer = new PReLULayer<float>(numParameters: numParameters);
+
+        // IsShapeResolved is false (InputShape still has -1 placeholder), but
+        // TryDeclareShape returns true because α is already allocated.
+        Assert.False(layer.IsShapeResolved);
+        Assert.True(layer.TryDeclareShape());
+
+        // ParameterCount = numParameters (α tensor).
+        Assert.Equal((long)numParameters, layer.ParameterCount);
+    }
+
+    /// <summary>
+    /// <see cref="TransformerEncoderLayer{T}.TryDeclareShape"/> override:
+    /// the eager-dimension ctor (passing <c>embeddingSize &gt; 0</c>)
+    /// constructs sublayers at ctor time. TryDeclareShape returns true
+    /// even though InputShape still has <c>[-1, -1, -1]</c> (sequence +
+    /// batch genuinely dynamic).
+    /// </summary>
+    [Theory]
+    [InlineData(2, 32, 16)]
+    [InlineData(4, 128, 64)]
+    [InlineData(8, 1024, 256)]
+    public void TransformerEncoder_TryDeclareShape_EagerCtor_ReturnsTrue(int numHeads, int feedForwardDim, int embeddingSize)
+    {
+        var layer = new TransformerEncoderLayer<float>(numHeads, feedForwardDim, embeddingSize);
+
+        // Sublayers (MHA + LayerNorm + FFN) constructed at ctor — TryDeclareShape true.
+        Assert.True(layer.TryDeclareShape());
+
+        // ParameterCount must reflect the eagerly-constructed sublayers' parameters,
+        // not zero (the previous lazy-ctor behavior).
+        Assert.True(layer.ParameterCount > 0,
+            $"Eager-ctor TransformerEncoderLayer must report ParameterCount > 0 at construction; got {layer.ParameterCount}.");
+    }
+
+    /// <summary>
+    /// Lazy-ctor TransformerEncoderLayer (no explicit embeddingSize) defers
+    /// sublayer construction to first forward → TryDeclareShape returns false →
+    /// AiModelBuilder falls back to the warmup forward, as before.
+    /// </summary>
+    [Fact]
+    public void TransformerEncoder_TryDeclareShape_LazyCtor_ReturnsFalse()
+    {
+        var layer = new TransformerEncoderLayer<float>(numHeads: 4, feedForwardDim: 128);
+        Assert.False(layer.IsShapeResolved);
+        Assert.False(layer.TryDeclareShape());
+    }
+}


### PR DESCRIPTION
## Summary

Closes #1370. Implements Phases 1–3 of the shape-oracle design: a layer-side `TryDeclareShape()` virtual that lets `AiModelBuilder.BuildSupervisedInternalAsync` skip its LoRA warmup forward when every layer can declare its parameter shapes from constructor args alone. Matches PyTorch / HuggingFace PEFT's construction-time shape model without giving up AiDotNet's lazy-shape flexibility — lazy convs / inferred-shape layers still fall through to the warmup fallback.

## Phase 1 — Foundation

`LayerBase<T>` adds:

```csharp
public virtual bool TryDeclareShape() => IsShapeResolved;
```

Default impl mirrors `IsShapeResolved` so layers whose ctor already resolves shape (e.g. `FullyConnectedLayer<T>` constructed with both input and output dims) need no override.

## Phase 2 — High-value overrides

**`LayerNormalizationLayer<T>`** — new eager ctor:
```csharp
public LayerNormalizationLayer(int featureSize, double epsilon = ...)
```
Allocates gamma/beta immediately + resolves input/output shapes. Uses the default `TryDeclareShape` impl (which returns true via `IsShapeResolved`). Existing parameter-less lazy ctor unchanged.

**`MultiHeadAttentionLayer<T>`** — overrides `TryDeclareShape`:
```csharp
public override bool TryDeclareShape()
{
    if (_isInitialized) return true;
    EnsureWeightsAllocated();   // now internal so we can call it
    return _isInitialized;
}
```
Allocates Q/K/V/O from ctor-known `embeddingDim`. **Documented asymmetry**: returns `true` even though `InputShape` still has `-1` for sequence length — LoRA wraps weight matrices, the seq placeholder doesn't matter.

## Phase 3 — Rewire `AiModelBuilder.BuildSupervisedInternalAsync`

Before the warmup forward, loop over layers and call `TryDeclareShape` on each. Count declared-vs-still-needs-warmup. Skip warmup entirely when all declare; fall back to the existing warmup forward when any need it. `Trace.TraceInformation` surfaces the skip so operators can verify the win. Wrap-loop gate switches from `IsShapeResolved` to `TryDeclareShape` so MHA (whose seq stays `-1` but weights are allocated) gets wrapped.

## Acceptance criteria

- [x] Phase 1 ships (`TryDeclareShape()` foundation + default impl)
- [x] Phase 2 ships (eager `LayerNormalizationLayer` ctor + `MultiHeadAttentionLayer` override)
- [x] Phase 3 ships (LoRA wrap path uses oracle, falls back to warmup for unresolved layers only)
- [x] `Trace.TraceInformation` observably shows the skip path when all layers declare shape
- [x] Bucket 10 LoRA test still passes — no regression on wrap-loop outcome
- [x] Phase 4 (sweep every `LayerBase<T>` subclass) deferred to a follow-up — the foundation + 2 high-value overrides + AiModelBuilder rewire is the load-bearing slice the issue called out

## Tests

New `ShapeOracleIssue1370Tests` (13 tests across 5 facts/theories):
- Default `TryDeclareShape` impl mirrors `IsShapeResolved` (eager LayerNorm path)
- Lazy parameter-less LayerNorm ctor: `TryDeclareShape` returns false
- Eager `(featureSize, ...)` LayerNorm ctor: gamma/beta allocated immediately, `TryDeclareShape` returns true via default impl
- Eager LayerNorm ctor rejects non-positive featureSize
- MHA `TryDeclareShape` allocates Q/K/V/O before any forward, returns true even with `-1` seq in InputShape (documented asymmetry)
- MHA `TryDeclareShape` is idempotent

Plus three pre-existing failing tests fixed by migration to the eager LayerNorm ctor:
- `AdvancedLayersIntegrationTests.LayerNormalizationLayer_ParameterCount_IsPositive`
- `NormalizationLayersIntegrationTests.LayerNormalizationLayer_ParameterCount_IncludesGammaAndBeta`
- `NormalizationLayersDeepMathIntegrationTests.LayerNorm_ParameterCount_IsTwiceFeatureSize`

These tests were testing parameter counts on the parameter-less ctor — impossible to satisfy before this PR. They now use the new eager ctor and pass.

## Test plan

- [x] `dotnet build src/AiDotNet.csproj --framework net10.0 -c Release` — 0 errors
- [x] `dotnet test ... --filter "FullyQualifiedName~ShapeOracleIssue1370Tests"` — 13/13 pass
- [x] `dotnet test ... --filter "FullyQualifiedName~Bucket10_LoRATests"` — 1/1 pass (acceptance gate)
- [x] `dotnet test ... --filter "FullyQualifiedName~Bucket10_LoRATests|FullyQualifiedName~LayerNormalizationLayer|FullyQualifiedName~MultiHeadAttentionLayer"` — 44/44 pass (full LoRA + LayerNorm + MHA sweep, including the previously-failing pre-existing tests)

## Test-isolation note

The new `ShapeOracleIssue1370Tests` joined the `LayerSerializationCollection` so its MHA weight allocations (which consume thread-local `SimdRandom` state) don't run in parallel with the auto-generated `LayerTestBase.TapeGradient_ShouldMatchNumericalGradient` tests. Without this, the seed shift produces flaky finite-difference gradient comparisons on LayerNorm and MHA generated tests. Behavior of the layers themselves is unchanged — this is purely a test-scheduling hygiene fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Layers can proactively declare shapes and allocate parameters at construction, reducing trial forward passes.
  * Added eager-init constructors for LayerNorm, BatchNorm, RMSNorm; PReLU, attention and transformer layers now support shape-oracle reporting.
  * LoRA build now probes layer shape readiness and may skip warmup forwards when all targets report shapes, improving startup behavior and diagnostics.

* **Tests**
  * Added and updated unit/integration tests for shape-declaration, eager initialization, parameter counts, and argument validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ooples/AiDotNet/pull/1388?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->