### PR TITLE
fix(#1309): cluster-1 DCGAN — restore deferred-shape guard + lazy-conv deserialize fallback

### DIFF
--- a/src/Helpers/DeserializationHelper.cs
+++ b/src/Helpers/DeserializationHelper.cs
@@ -835,20 +835,70 @@ public static class DeserializationHelper
             // legacy paths serialize without the batch dim, so accept rank 3 too.
             if (instance is ConvolutionalLayer<T> conv && inputShape != null && inputShape.Length >= 3)
             {
-                int inDepth, inH, inW;
+                // Saved-record axes: rank-4 = [batch, channels, H, W],
+                // rank-3 = [channels, H, W] (legacy unbatched).
+                int savedInDepth, savedInH, savedInW;
                 if (inputShape.Length == 4)
                 {
-                    inDepth = inputShape[1] > 0 ? inputShape[1] : 1;
-                    inH = inputShape[2] > 0 ? inputShape[2] : 1;
-                    inW = inputShape[3] > 0 ? inputShape[3] : 1;
+                    savedInDepth = inputShape[1];
+                    savedInH = inputShape[2];
+                    savedInW = inputShape[3];
                 }
                 else
                 {
-                    inDepth = inputShape[0] > 0 ? inputShape[0] : 1;
-                    inH = inputShape[1] > 0 ? inputShape[1] : 1;
-                    inW = inputShape[2] > 0 ? inputShape[2] : 1;
+                    savedInDepth = inputShape[0];
+                    savedInH = inputShape[1];
+                    savedInW = inputShape[2];
                 }
-                conv.ResolveShapesOnly(new[] { inDepth, inH, inW });
+
+                // Three branches based on what the saved inputShape resolved
+                // by serialize time:
+                //
+                // (a) InputDepth concrete: pre-resolve so SetParameters sees
+                //     the correct InputDepth and the kernel/bias counts match
+                //     the saved parameter vector exactly. Without this the
+                //     auto-resolve heuristic in ConvolutionalLayer.SetParameters
+                //     can pick a different InputDepth than the original
+                //     (especially when outputDepth × kernelSize² happens to
+                //     factor the saved parameter count more than one way),
+                //     and Clone()/DeepCopy() throw "Expected N parameters,
+                //     but got M". Spatial dims that were never forwarded
+                //     fall back to Math.Max(1, kernelSize) so
+                //     ConvolutionalLayer.OnFirstForward's kernel-size
+                //     constraint (inH + 2*Padding >= KernelSize) passes —
+                //     DCGAN's discriminator (kernel=4, padding=1, needs
+                //     inH >= 2) is the canary. The stored OutputShape after
+                //     this resolve is a placeholder; the first real Forward
+                //     call recomputes the actual output tensor dimensions
+                //     from the real input.
+                //
+                // (b) InputDepth deferred (saved as -1 because the layer
+                //     was serialized before its first Forward): skip the
+                //     pre-resolve entirely. ConvolutionalLayer.SetParameters
+                //     has its own auto-resolve fallback (~ line 1598) that
+                //     derives InputDepth from the saved parameter vector's
+                //     length — (length - OutputDepth) / (OutputDepth *
+                //     KernelSize²) — and that fallback uses KernelSize as
+                //     the spatial placeholder. Pre-resolving with a
+                //     placeholder InputDepth=1 would have locked
+                //     InputDepth=1 into the layer's state, then Forward
+                //     with the real RGB-3 input would throw
+                //     "Expected input depth 1, but got 3" before the lazy
+                //     resolve had a chance to fire. This is the failure
+                //     mode that surfaced on DCGAN clones where the
+                //     discriminator's layers had never seen the
+                //     [3, 64, 64] image input at clone time (the test's
+                //     pre-clone Predict only runs the generator).
+                //
+                // (c) inputShape supplied but malformed (rank < 3 case
+                //     handled by the outer guard).
+                if (savedInDepth > 0)
+                {
+                    int spatialFallback = Math.Max(1, kernelSize);
+                    int inH = savedInH > 0 ? savedInH : spatialFallback;
+                    int inW = savedInW > 0 ? savedInW : spatialFallback;
+                    conv.ResolveShapesOnly(new[] { savedInDepth, inH, inW });
+                }
             }
         }
         else if (genericDef == typeof(Conv3DLayer<>))

--- a/src/Helpers/DeserializationHelper.cs
+++ b/src/Helpers/DeserializationHelper.cs
@@ -836,19 +836,33 @@ public static class DeserializationHelper
             if (instance is ConvolutionalLayer<T> conv && inputShape != null && inputShape.Length >= 3)
             {
                 // Saved-record axes: rank-4 = [batch, channels, H, W],
-                // rank-3 = [channels, H, W] (legacy unbatched).
+                // rank-3 = [channels, H, W] (legacy unbatched). Any other
+                // rank is malformed and must fail fast — silently
+                // reinterpreting a rank-5 or rank-6 payload's leading
+                // axes as the legacy [C, H, W] layout would deserialize
+                // ConvolutionalLayer with the wrong channels/InputDepth
+                // and produce a Clone that disagrees with the original
+                // model's contract several layers downstream.
                 int savedInDepth, savedInH, savedInW;
-                if (inputShape.Length == 4)
+                switch (inputShape.Length)
                 {
-                    savedInDepth = inputShape[1];
-                    savedInH = inputShape[2];
-                    savedInW = inputShape[3];
-                }
-                else
-                {
-                    savedInDepth = inputShape[0];
-                    savedInH = inputShape[1];
-                    savedInW = inputShape[2];
+                    case 4:
+                        savedInDepth = inputShape[1];
+                        savedInH = inputShape[2];
+                        savedInW = inputShape[3];
+                        break;
+                    case 3:
+                        savedInDepth = inputShape[0];
+                        savedInH = inputShape[1];
+                        savedInW = inputShape[2];
+                        break;
+                    default:
+                        throw new InvalidOperationException(
+                            $"ConvolutionalLayer deserialize: saved inputShape rank must be 3 ([C, H, W]) " +
+                            $"or 4 ([N, C, H, W]); got rank {inputShape.Length} ([{string.Join(", ", inputShape)}]). " +
+                            "This usually indicates a corrupted layer record or a forward-incompatible " +
+                            "newer-format payload — abort deserialize rather than silently misinterpret " +
+                            "the trailing axes.");
                 }
 
                 // Three branches based on what the saved inputShape resolved

--- a/src/Helpers/DeserializationHelper.cs
+++ b/src/Helpers/DeserializationHelper.cs
@@ -833,7 +833,17 @@ public static class DeserializationHelper
             // "Expected N parameters, but got M".
             // Saved inputShape format: [batch, channels, height, width] (NCHW); some
             // legacy paths serialize without the batch dim, so accept rank 3 too.
-            if (instance is ConvolutionalLayer<T> conv && inputShape != null && inputShape.Length >= 3)
+            // Note: the rank-validation switch below now handles ALL ranks (not
+            // just >= 3) — rank-1 and rank-2 payloads fall through to the
+            // default branch and throw, instead of silently bypassing the
+            // ConvolutionalLayer pre-resolve when inputShape.Length < 3 left
+            // the layer in its lazy state (PR #1389 review C8oz1 — gate moved
+            // from inputShape.Length >= 3 to inputShape != null so malformed
+            // ranks fail fast). The previous `>= 3` guard was a relic from
+            // when the switch only had the rank-3/rank-4 cases and rank-1/2
+            // would have crashed on `inputShape[2]` — now they're explicitly
+            // rejected with a clear error.
+            if (instance is ConvolutionalLayer<T> conv && inputShape != null)
             {
                 // Saved-record axes: rank-4 = [batch, channels, H, W],
                 // rank-3 = [channels, H, W] (legacy unbatched). Any other

--- a/src/NeuralNetworks/GenerativeAdversarialNetwork.cs
+++ b/src/NeuralNetworks/GenerativeAdversarialNetwork.cs
@@ -1,6 +1,7 @@
 ﻿using AiDotNet.Attributes;
 using AiDotNet.Enums;
 using AiDotNet.NeuralNetworks.Options;
+using AiDotNet.Tensors.Engines.Autodiff;
 
 namespace AiDotNet.NeuralNetworks;
 
@@ -901,11 +902,38 @@ public class GenerativeAdversarialNetwork<T> : NeuralNetworkBase<T>, IAuxiliaryL
 
         // ------------ Train Discriminator ------------
 
-        // Generate fake images (detached from the generator's gradient path —
-        // Generator.Predict wraps in NoGradScope). The disc step below trains
-        // against these detached fakes; the separate generator-step backward
-        // re-runs the forward with tape to update generator weights.
-        var fakeImages = Generator.Predict(input);
+        // Issue #1390 perf fix: run the generator forward ONCE per Train()
+        // call instead of twice. Previously the disc step received a
+        // Generator.Predict(input) output (eval mode, NoGradScope) and the
+        // gen step ran ForwardForTraining(input) inside TrainWithCustomLoss
+        // — two full generator forwards per iteration (~19 ms wasted on the
+        // DCGAN MoreData fixture per the issue's substep profile).
+        //
+        // New flow:
+        //   1. Open the generator's gradient tape here.
+        //   2. Run ForwardForTraining ONCE on the tape -> fakeTapeTracked.
+        //   3. Take a value-copy detached snapshot for the disc step.
+        //   4. Disc step opens its own nested tape (independent of gen tape
+        //      because ThreadStatic _current save/restore in GradientTape).
+        //   5. Gen step reuses fakeTapeTracked (still attached to the open
+        //      gen tape) and calls BackwardAndStepOnPrecomputedLoss to drive
+        //      the optimizer without a second ForwardForTraining call.
+        //
+        // Behavior note: the disc now trains on train-mode generator output
+        // (uses batch BN stats, would apply Dropout if any) rather than the
+        // eval-mode Predict output. This matches the PyTorch DCGAN tutorial
+        // convention (`fake = G(z); fake_detached = fake.detach()`). DCGAN
+        // architecture has no Dropout; the BN distribution shift is the
+        // standard adversarial behavior, not a regression.
+        using var genTape = new GradientTape<T>();
+        var fakeTapeTracked = ((NeuralNetworkBase<T>)Generator).ForwardForTraining(input);
+
+        // Detached value-copy for the discriminator step. A fresh Tensor<T>
+        // with no GradNode chain — ops touching it record no parent link to
+        // the gen tape, so the disc step can't leak gradients into the
+        // generator's parameters.
+        var fakeImages = new Tensor<T>(fakeTapeTracked.Shape.ToArray());
+        fakeTapeTracked.AsSpan().CopyTo(fakeImages.AsWritableSpan());
 
         // Cache real / fake batches only when an auxiliary loss path needs
         // them. Previously this clone ran unconditionally for UseFeatureMatching;
@@ -1021,35 +1049,38 @@ public class GenerativeAdversarialNetwork<T> : NeuralNetworkBase<T>, IAuxiliaryL
         T generatorLoss;
         try
         {
-            generatorLoss = trainableGen.TrainWithCustomLoss(input, genOutput =>
-            {
-                // genOutput = generated fake images from ForwardForTraining (tape-tracked).
-                // Run the discriminator layer-by-layer so each Forward call records
-                // on the same active GradientTape that the generator's
-                // TrainWithCustomLoss opened. This keeps the discriminator weights
-                // fixed (we only collect generator gradients) while letting the
-                // adversarial signal propagate through every BN / Conv / activation
-                // back to genOutput → Generator's weights.
-                var discScore = genOutput;
-                foreach (var layer in Discriminator.Layers)
-                    discScore = layer.Forward(discScore);
-                // Generator loss: non-saturating BCE-with-logits per Goodfellow
-                // 2014 §3, matching the BCE-with-logits criterion that this base
-                // class wires into the Discriminator (lines 405-419 above —
-                // GetDefaultLossFunction(BinaryClassification) = BCE-with-logits).
-                // The previous LSGAN-style MSE((discScore − 1)²) here was a
-                // different objective (Mao 2017 LSGAN) and silently changed
-                // training semantics for every derived GAN.
-                //
-                // -log σ(discScore) is the per-sample non-saturating generator
-                // term. Implemented via the numerically-stable LogSigmoid identity
-                // -log σ(x) = softplus(-x), where softplus is the tape-tracked
-                // Engine.Softplus op. ReduceMean over all axes gives the scalar
-                // loss the tape requires.
-                var allAxes = Enumerable.Range(0, discScore.Shape.Length).ToArray();
-                var negLogSigmoid = Engine.Softplus(Engine.TensorNegate(discScore));
-                return Engine.ReduceMean(negLogSigmoid, allAxes, keepDims: false);
-            });
+            // Issue #1390: reuse the tape-tracked generator output from the
+            // step start (line ~929) instead of re-running ForwardForTraining
+            // inside TrainWithCustomLoss. The gen tape opened earlier
+            // (genTape) is still active; the disc-layer Forward calls below
+            // continue to record on it, then BackwardAndStepOnPrecomputedLoss
+            // drives gradient compute + optimizer step on the shared tape.
+            //
+            // Walk the discriminator layer-by-layer in eval mode (but WITHOUT
+            // NoGradScope) so each Forward call records on genTape. This
+            // keeps disc weights fixed (only gen params are passed to
+            // ComputeGradients inside BackwardAndStepOnPrecomputedLoss) while
+            // letting the adversarial signal propagate through every BN /
+            // Conv / activation back to fakeTapeTracked → Generator's weights.
+            var discScore = fakeTapeTracked;
+            foreach (var layer in Discriminator.Layers)
+                discScore = layer.Forward(discScore);
+
+            // Generator loss: non-saturating BCE-with-logits per Goodfellow
+            // 2014 §3, matching the BCE-with-logits criterion that this base
+            // class wires into the Discriminator (GetDefaultLossFunction(
+            // BinaryClassification) = BCE-with-logits).
+            //
+            // -log σ(discScore) is the per-sample non-saturating generator
+            // term. Implemented via the numerically-stable LogSigmoid identity
+            // -log σ(x) = softplus(-x), where softplus is the tape-tracked
+            // Engine.Softplus op. ReduceMean over all axes gives the scalar
+            // loss the tape requires.
+            var allAxes = Enumerable.Range(0, discScore.Shape.Length).ToArray();
+            var negLogSigmoid = Engine.Softplus(Engine.TensorNegate(discScore));
+            var lossTensor = Engine.ReduceMean(negLogSigmoid, allAxes, keepDims: false);
+
+            generatorLoss = trainableGen.BackwardAndStepOnPrecomputedLoss(genTape, lossTensor);
         }
         finally
         {

--- a/src/NeuralNetworks/NeuralNetworkBase.cs
+++ b/src/NeuralNetworks/NeuralNetworkBase.cs
@@ -2171,9 +2171,19 @@ public abstract class NeuralNetworkBase<T> : INeuralNetworkModel<T>, IInterpreta
         // ConvTranspose2D layer reports [channels, -1, -1] before first
         // Forward and is compared against OutputSize = channels * H * W
         // (a single flat scalar that can't be element-wise-matched).
-        // -1 is the lazy/deferred sentinel; zero-sized dimensions are
-        // genuinely invalid and should fail validation rather than getting
-        // waved through to fail later at runtime with a less clear error.
+        //
+        // Only -1 sentinels trigger the deferral. Zero-sized dimensions
+        // would ALSO escape the AreShapesCompatible check below — the
+        // ShapesMatchKnownDimensions wildcard rule treats any d <= 0
+        // as matching anything, so a stray d == 0 in either operand
+        // silently passes. That's the existing wildcard convention
+        // across this validator (matches lazy-layer rank-2 [-1, F] vs
+        // resolved rank-3 [B, S, F] etc); a layer that emits d == 0 in
+        // a resolved output shape is a bug a different validator should
+        // catch — not this one's job. Restricting deferral to d < 0
+        // keeps the surface narrow: any future "d > 0 but doesn't
+        // match" path still gets the clear "output shape ... must match
+        // architecture output size" error.
         if (outputShape.Any(d => d < 0))
         {
             error = string.Empty;

--- a/src/NeuralNetworks/NeuralNetworkBase.cs
+++ b/src/NeuralNetworks/NeuralNetworkBase.cs
@@ -2160,6 +2160,26 @@ public abstract class NeuralNetworkBase<T> : INeuralNetworkModel<T>, IInterpreta
 
         int[] outputShape = layerOutputShape!;
 
+        // Partially-deferred shapes — e.g. a transposed-conv generator that
+        // emits [3, -1, -1] until first Forward resolves H/W from runtime
+        // input — can't be compared dimensionally against the architecture's
+        // flat OutputSize. Defer the check; the layer will fail at runtime
+        // with a precise shape error if the resolved output doesn't honour
+        // the contract. This guard was added by PR #1329 and inadvertently
+        // removed by the grafprint PR (c8cac237b) — restoring it closes the
+        // DCGAN cluster-1 false-rejection where the generator's last
+        // ConvTranspose2D layer reports [channels, -1, -1] before first
+        // Forward and is compared against OutputSize = channels * H * W
+        // (a single flat scalar that can't be element-wise-matched).
+        // -1 is the lazy/deferred sentinel; zero-sized dimensions are
+        // genuinely invalid and should fail validation rather than getting
+        // waved through to fail later at runtime with a less clear error.
+        if (outputShape.Any(d => d < 0))
+        {
+            error = string.Empty;
+            return true;
+        }
+
         if (Architecture.OutputSize > 0 && !AreShapesCompatible([Architecture.OutputSize], outputShape))
         {
             error = $"The last layer's output shape [{string.Join(", ", outputShape)}] must match the architecture output size ({Architecture.OutputSize}).";

--- a/src/NeuralNetworks/NeuralNetworkBase.cs
+++ b/src/NeuralNetworks/NeuralNetworkBase.cs
@@ -6451,6 +6451,60 @@ public abstract class NeuralNetworkBase<T> : INeuralNetworkModel<T>, IInterpreta
     }
 
     /// <summary>
+    /// Variant of <see cref="TrainWithCustomLoss"/> that runs backward+optim
+    /// on a loss tensor whose forward pass was already recorded on a
+    /// caller-owned <see cref="GradientTape{T}"/>. Use this when the caller
+    /// needs to share the forward output across multiple training paths so
+    /// the forward only runs once.
+    ///
+    /// <para>Issue #1390 driver: <c>GenerativeAdversarialNetwork.Train</c>
+    /// previously ran the generator forward twice per step — once detached
+    /// (<see cref="Predict"/> + <see cref="NoGradScope{T}"/>) to feed the
+    /// discriminator step, then a second time tape-tracked
+    /// (inside <see cref="TrainWithCustomLoss"/>) for the generator's
+    /// adversarial backward. With this entry point, the GAN's <c>Train</c>
+    /// can open its own gen tape, run the forward once, detach a
+    /// value-snapshot for the discriminator step, and feed the same
+    /// tape-tracked output into the generator loss — eliminating the
+    /// duplicate forward (~4% of step time on the DCGAN MoreData fixture
+    /// per the issue's substep profile).</para>
+    ///
+    /// <para>Contract: the caller MUST keep the tape alive (not dispose it)
+    /// from the time the forward runs until this method returns. The tape
+    /// is NOT disposed here — the caller owns its lifecycle.</para>
+    /// </summary>
+    /// <param name="tape">Open gradient tape on which the forward was recorded.</param>
+    /// <param name="lossTensor">Scalar loss tensor recorded on <paramref name="tape"/>.</param>
+    /// <param name="optimizer">Optimizer to drive; defaults to the base Adam.</param>
+    /// <returns>Scalar loss value (also stored in <see cref="LastLoss"/>).</returns>
+    public T BackwardAndStepOnPrecomputedLoss(
+        GradientTape<T> tape,
+        Tensor<T> lossTensor,
+        IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>>? optimizer = null)
+    {
+        if (tape is null) throw new ArgumentNullException(nameof(tape));
+        if (lossTensor is null) throw new ArgumentNullException(nameof(lossTensor));
+
+        var trainableParams = Training.TapeTrainingStep<T>.CollectParameters(Layers);
+        var opt = optimizer ?? GetOrCreateBaseOptimizer();
+
+        var grads = tape.ComputeGradients(lossTensor, trainableParams);
+        T lossValue = lossTensor.Length > 0 ? lossTensor[0] : NumOps.Zero;
+        LastLoss = lossValue;
+
+        var context = new AiDotNet.Tensors.Engines.Autodiff.TapeStepContext<T>(
+            trainableParams, grads, lossValue);
+
+        opt.Step(context);
+
+        // Mirror the OnBatchEnd advance from TrainWithCustomLoss / TrainWithTape
+        // so a precomputed-loss caller sees identical scheduler behaviour.
+        StepSchedulerIfSupported(opt);
+
+        return lossValue;
+    }
+
+    /// <summary>
     /// Gets or lazily creates the default optimizer for tape-based training.
     /// Used when a network doesn't provide its own optimizer.
     /// </summary>

--- a/src/NeuralNetworks/NeuralNetworkBase.cs
+++ b/src/NeuralNetworks/NeuralNetworkBase.cs
@@ -6477,7 +6477,14 @@ public abstract class NeuralNetworkBase<T> : INeuralNetworkModel<T>, IInterpreta
     /// <param name="lossTensor">Scalar loss tensor recorded on <paramref name="tape"/>.</param>
     /// <param name="optimizer">Optimizer to drive; defaults to the base Adam.</param>
     /// <returns>Scalar loss value (also stored in <see cref="LastLoss"/>).</returns>
-    public T BackwardAndStepOnPrecomputedLoss(
+    /// <remarks>
+    /// Visibility: <c>internal</c>. The codebase contract is "users should only
+    /// interact with <c>AiModelBuilder</c> / <c>AiModelResult</c>" — this helper
+    /// is training plumbing for in-assembly callers (currently
+    /// <see cref="GenerativeAdversarialNetwork{T,TI,TO}.Train"/>) and should not
+    /// appear on the public API surface. (PR #1389 CodeRabbit review.)
+    /// </remarks>
+    internal T BackwardAndStepOnPrecomputedLoss(
         GradientTape<T> tape,
         Tensor<T> lossTensor,
         IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>>? optimizer = null)
@@ -6485,7 +6492,27 @@ public abstract class NeuralNetworkBase<T> : INeuralNetworkModel<T>, IInterpreta
         if (tape is null) throw new ArgumentNullException(nameof(tape));
         if (lossTensor is null) throw new ArgumentNullException(nameof(lossTensor));
 
-        var trainableParams = Training.TapeTrainingStep<T>.CollectParameters(Layers);
+        // PR #1389 CodeRabbit fix: reentrancy guard so concurrent callers don't
+        // interleave optimizer/tape state. Mirrors TrainWithTape's sentinel
+        // discipline; without it, two threads calling this helper on the same
+        // model would race on LastLoss + optimizer-internal state.
+        using var __reentrancyGuard = AcquireTrainSentinel();
+
+        // PR #1389 CodeRabbit fix: include network-level trainable tensors
+        // (raw parameters owned by the model rather than a layer) in the
+        // gradient-and-step set. Without this, models that expose params via
+        // GetExtraTrainableTensors() would silently skip those updates here
+        // while TrainWithTape would still update them — divergent semantics
+        // between the two training entry points.
+        var layerParams = Training.TapeTrainingStep<T>.CollectParameters(Layers);
+        var extraTrainableTensors = new List<Tensor<T>>();
+        foreach (var t in GetExtraTrainableTensors())
+        {
+            if (t is not null && t.Length > 0) extraTrainableTensors.Add(t);
+        }
+        var trainableParams = extraTrainableTensors.Count == 0
+            ? layerParams
+            : layerParams.Concat(extraTrainableTensors).ToList();
         var opt = optimizer ?? GetOrCreateBaseOptimizer();
 
         var grads = tape.ComputeGradients(lossTensor, trainableParams);


### PR DESCRIPTION
Closes #1309

## Summary

Closes PR #1290 CI Cluster 1 (#1309) shape-contract root causes **AND** the two perf/flakiness items previously deferred to follow-ups. All 26 originally-failing tests in `DCGANTests` + `SparseNeuralNetworkTests` now pass.

## Root causes (in this PR)

### 1. `NeuralNetworkBase.IsLastLayerShapeCompatible` — restore the partially-deferred-shape guard

PR #1329 ([commit 969977d](https://github.com/ooples/AiDotNet/commit/969977d55)) added an `outputShape.Any(d => d < 0)` early-return so the validator defers the flat-`OutputSize` check when any output-shape dim is deferred — DCGAN's last transposed-conv emits `[3, -1, -1]` until its first `Forward` resolves H/W. That guard was inadvertently deleted by the grafprint PR ([commit c8cac237b](https://github.com/ooples/AiDotNet/commit/c8cac237b), May 16) one day later. Restoring it unblocks **23 of 25** DCGAN failures at once.

### 2. `DeserializationHelper` conv path — skip pre-resolve when `InputDepth` is deferred

When the saved Conv layer record's `inputShape` carries -1 sentinels (a lazy layer serialized before its first `Forward` — DCGAN's discriminator on a Predict-only pre-clone probe sees only the generator), the pre-existing code coerced all -1 dims to `1` and called `conv.ResolveShapesOnly(...)`. For DCGAN's first conv (kernel=4, padding=1) this fails `OnFirstForward`'s kernel-size check (1 + 2*1 = 3 < 4). Coercing the spatial dim to `Math.Max(1, KernelSize)` fixes that specific check — but locks `InputDepth` at 1, and the real `Forward` with the [3, 64, 64] RGB image then throws `"Expected input depth 1, but got 3"`.

The correct fix is to **skip pre-resolve entirely when `InputDepth` is deferred** — `ConvolutionalLayer.SetParameters` has its own auto-resolve fallback (line ~1598) that derives `InputDepth` from the saved parameter vector's length and uses `KernelSize` as the spatial placeholder. Pre-resolve still runs (with `Math.Max(1, KernelSize)` for any deferred spatial dim) when `InputDepth` is concrete — that's the original PR #1329 contract for the auto-resolve-disambiguation case the comment block calls out.

This unblocks the remaining 2 Clone-path failures (`Clone_ShouldProduceIdenticalOutput`, `MoreData_ShouldNotDegrade` shape contract).

### 3. `GenerativeAdversarialNetwork.Train` — eliminate duplicate generator forward (closes #1390)

The previous code ran the generator forward TWICE per training step:
1. `Generator.Predict(input)` (eval mode, `NoGradScope`) → detached fake images for the combined real+fake discriminator step.
2. `ForwardForTraining(input)` (train mode, on tape) inside `TrainWithCustomLoss` — duplicate of the same forward, just for the gen-adversarial backward.

On the DCGAN MoreData fixture (250 iters, FP64, batch=2, 64×64 RGB) this duplicate forward put the test 10 s over its 120 s budget. After refactor:

- Open a single `GradientTape` at step start.
- Run `ForwardForTraining(input)` ONCE on that tape → `fakeTapeTracked`.
- Take a value-copy detached snapshot (`fakeImages`) for the disc step — fresh `Tensor<T>` with no `GradNode` chain so `disc.Train` (which opens its own nested tape) can not leak gradients back into the generator.
- Walk the discriminator layer-by-layer on the existing gen tape for the adversarial loss.
- Drive the gen optimizer step via the new `NeuralNetworkBase.BackwardAndStepOnPrecomputedLoss` helper (reuses the open tape instead of `TrainWithCustomLoss` opening a fresh one + re-running `ForwardForTraining`).

Behavior note: the disc step now sees train-mode generator output (batch BN stats) instead of eval-mode (running BN stats). This matches PyTorch's standard DCGAN training pattern (`fake = G(z); fake_detached = fake.detach()`) and the existing gen step's own train-mode forward. DCGAN has no Dropout.

### 4. `SparseNeuralNetworkTests.DifferentInputs_AfterTraining_ShouldProduceDifferentOutputs`

Previously flagged as "intermittent mode-collapse" in this PR's earlier description. Verified locally with `SparseLinearLayer`'s deterministic seed (42) and `ModelTestHelpers.CreateSeededRandom(42)` for the test data: 10/10 single-test runs pass, and 21/21 of the full `SparseNeuralNetworkTests` class pass. The historical flakiness was either a transient bug fixed by another landed commit or environment-specific to a CI run that has not recurred. Watching for regression as part of the suite.

## Not in this PR

All originally-deferred items from this PR's earlier revisions are now addressed in-PR.

## Verification

`dotnet test --filter "FullyQualifiedName~DCGANTests|FullyQualifiedName~SparseNeuralNetworkTests" --framework net10.0`:
- `DCGANTests`: **25 / 25** passing (including `MoreData_ShouldNotDegrade` at 1 m 47 s vs 120 s budget — was timing out at > 120 s).
- `SparseNeuralNetworkTests`: **21 / 21** passing.
- `ConditionalGANTests` + `InfoGANTests` (other `GAN.Train` consumers): **50 / 50** passing.

Pre-existing failures elsewhere (`WGANGPTests` "CNN requires 2D or 3D input" test-setup bugs, `CycleGANTurboModelTests` OOM on oversized models, `DeformableConvolutionalLayerTests` known DCN-v2 autograd gaps) — verified independent of this PR via `git stash` + sample re-run on clean master.

## Test plan

- [x] `dotnet build tests/AiDotNet.Tests/AiDotNetTests.csproj --framework net10.0` — 0 errors
- [x] `DCGANTests` 25/25 passing on net10.0 (incl. perf-critical MoreData)
- [x] `SparseNeuralNetworkTests` 21/21 passing on net10.0 (incl. previously-flaky DifferentInputs_AfterTraining)
- [x] `ConditionalGANTests` + `InfoGANTests` 50/50 passing (no GAN.Train regression)
- [x] Verified non-cluster failures (WGANGP, CycleGANTurbo, DeformableConv) are pre-existing on stashed master
- [x] Closes cluster-1 shape-contract root causes from #1309
- [x] Closes #1390 perf timeout

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a public training helper to run backward/optimizer steps from a precomputed loss.

* **Refactor / Performance**
  * Improved GAN training to avoid redundant generator forward passes and reuse precomputed outputs for more efficient updates.

* **Bug Fixes**
  * Fixed convolutional-layer deserialization to reliably interpret legacy/current saved input shapes and preserve deferred unset depths.
  * Relaxed final-layer shape validation to accept partially-deferred output dimensions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ooples/AiDotNet/pull/1389?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->