### PR TITLE
fix(#1311 cluster-3): snap VLM vision-encoder head count to divide visionDim cleanly

### DIFF
--- a/src/Helpers/LayerHelper.cs
+++ b/src/Helpers/LayerHelper.cs
@@ -29,6 +29,73 @@ public static class LayerHelper<T>
     }
 
     /// <summary>
+    /// Picks a head-count + head-dim pair for a MultiHeadAttention layer such
+    /// that <c>heads × headDim == embedDim</c> exactly. The requested head
+    /// count is honoured when it divides <paramref name="embedDim"/> cleanly;
+    /// otherwise it's reduced to the largest divisor of
+    /// <paramref name="embedDim"/> that is ≤ <paramref name="requestedHeads"/>
+    /// (and ≤ <paramref name="maxHeads"/>, default 16, which preserves the
+    /// existing VLM cap most call sites use). Used to fix
+    /// <c>cluster-3 #1311</c> SmolVLM-style failures where, e.g.,
+    /// <c>visionDim=384 / numHeads=9 = 42</c> (integer division) and
+    /// <c>9 × 42 = 378 ≠ 384</c> — the MHA's QKV weight matrices end up sized
+    /// <c>[378, 378]</c> while the input it sees is <c>[..., 384]</c>, and
+    /// <c>MultiHeadAttentionLayer.ForwardInternal</c> throws
+    /// <c>"Input embedding dimension (384) does not match weight dimension (378)"</c>
+    /// the moment the test forwards the patch-embedded tokens.
+    ///
+    /// <para>
+    /// Snapping heads downward (vs upward / padding the embed dim) keeps every
+    /// other shape in the chain unchanged — FFN, LayerNorm, downstream
+    /// DenseLayer outputs all keep their <paramref name="embedDim"/>-wide
+    /// view. The trade-off is the attention pattern uses slightly fewer
+    /// heads than the upstream model card; that's strictly more local than
+    /// reshaping the entire residual stream. Paper-faithful head counts can
+    /// be re-introduced once the per-subsystem head-count knob exists on the
+    /// options class (NumVisionHeads vs NumDecoderHeads), filed separately.
+    /// </para>
+    /// </summary>
+    private static (int heads, int headDim) ChooseDivisibleHeadConfig(
+        int embedDim, int requestedHeads, int maxHeads = 16)
+    {
+        if (embedDim <= 0)
+            throw new ArgumentOutOfRangeException(nameof(embedDim), embedDim, "embedDim must be positive.");
+        if (requestedHeads <= 0)
+            throw new ArgumentOutOfRangeException(nameof(requestedHeads), requestedHeads, "requestedHeads must be positive.");
+        if (maxHeads <= 0)
+            throw new ArgumentOutOfRangeException(nameof(maxHeads), maxHeads, "maxHeads must be positive.");
+
+        int heads = System.Math.Min(requestedHeads, maxHeads);
+        while (heads > 1 && embedDim % heads != 0) heads--;
+        // Last-ditch fallback: a 1-head attention always divides. Useful for
+        // pathological embed dims (primes > maxHeads or arbitrary user-set
+        // values) so the test doesn't crash before its assertion runs.
+        return (heads, embedDim / heads);
+    }
+
+    /// <summary>
+    /// Builds the vision-encoder <see cref="NeuralNetworks.Layers.MultiHeadAttentionLayer{T}"/>
+    /// for a VLM factory, with head count adjusted to divide
+    /// <paramref name="visionDim"/> exactly. See
+    /// <see cref="ChooseDivisibleHeadConfig"/> for the snap-to-divisor
+    /// rationale; this method is the call-site shim that replaces the
+    /// inline <c>new MultiHeadAttentionLayer&lt;T&gt;(numHeads &gt; 16 ? 16 : numHeads,
+    /// (visionDim) / (numHeads &gt; 16 ? 16 : numHeads))</c> pattern in 10+ VLM factories.
+    /// </summary>
+    private static NeuralNetworks.Layers.MultiHeadAttentionLayer<T> CreateVisionMha(
+        int visionDim,
+        int numHeads,
+        Initialization.IInitializationStrategy<T>? initializationStrategy = null)
+    {
+        var (heads, headDim) = ChooseDivisibleHeadConfig(visionDim, numHeads);
+        return new NeuralNetworks.Layers.MultiHeadAttentionLayer<T>(
+            heads,
+            headDim,
+            activationFunction: null,
+            initializationStrategy: initializationStrategy);
+    }
+
+    /// <summary>
     /// Creates the default layer configuration for a Deep Portfolio Management model.
     /// </summary>
     /// <param name="architecture">The neural network architecture configuration.</param>
@@ -23604,7 +23671,7 @@ public static class LayerHelper<T>
 
         for (int i = 0; i < numVisionLayers; i++)
         {
-            yield return new MultiHeadAttentionLayer<T>(numHeads > 16 ? 16 : numHeads, (visionDim) / (numHeads > 16 ? 16 : numHeads));
+            yield return CreateVisionMha(visionDim, numHeads);
             yield return new LayerNormalizationLayer<T>();
             yield return new DenseLayer<T>(visionFfnDim, geluActivation);
             yield return new DenseLayer<T>(visionDim, identityActivation);
@@ -23661,7 +23728,7 @@ public static class LayerHelper<T>
 
         for (int i = 0; i < numVisionLayers; i++)
         {
-            yield return new MultiHeadAttentionLayer<T>(numHeads > 16 ? 16 : numHeads, (visionDim) / (numHeads > 16 ? 16 : numHeads));
+            yield return CreateVisionMha(visionDim, numHeads);
             yield return new LayerNormalizationLayer<T>();
             yield return new DenseLayer<T>(visionFfnDim, geluActivation);
             yield return new DenseLayer<T>(visionDim, identityActivation);
@@ -23723,7 +23790,7 @@ public static class LayerHelper<T>
 
         for (int i = 0; i < numVisionLayers; i++)
         {
-            yield return new MultiHeadAttentionLayer<T>(numHeads > 16 ? 16 : numHeads, (visionDim) / (numHeads > 16 ? 16 : numHeads));
+            yield return CreateVisionMha(visionDim, numHeads);
             yield return new LayerNormalizationLayer<T>();
             yield return new DenseLayer<T>(visionFfnDim, geluActivation);
             yield return new DenseLayer<T>(visionDim, identityActivation);
@@ -23838,7 +23905,7 @@ public static class LayerHelper<T>
 
         for (int i = 0; i < numVisionLayers; i++)
         {
-            yield return new MultiHeadAttentionLayer<T>(numHeads > 16 ? 16 : numHeads, (visionDim) / (numHeads > 16 ? 16 : numHeads));
+            yield return CreateVisionMha(visionDim, numHeads);
             yield return new LayerNormalizationLayer<T>();
             yield return new DenseLayer<T>(visionFfnDim, geluActivation);
             yield return new DenseLayer<T>(visionDim, identityActivation);
@@ -23899,7 +23966,7 @@ public static class LayerHelper<T>
 
         for (int i = 0; i < numVisionLayers; i++)
         {
-            yield return new MultiHeadAttentionLayer<T>(numHeads > 16 ? 16 : numHeads, (visionDim) / (numHeads > 16 ? 16 : numHeads));
+            yield return CreateVisionMha(visionDim, numHeads);
             yield return new LayerNormalizationLayer<T>();
             yield return new DenseLayer<T>(visionFfnDim, geluActivation);
             yield return new DenseLayer<T>(visionDim, identityActivation);
@@ -23994,7 +24061,7 @@ public static class LayerHelper<T>
 
         for (int i = 0; i < numVisionLayers; i++)
         {
-            yield return new MultiHeadAttentionLayer<T>(numHeads > 16 ? 16 : numHeads, (visionDim) / (numHeads > 16 ? 16 : numHeads), initializationStrategy: lazy);
+            yield return CreateVisionMha(visionDim, numHeads, initializationStrategy: lazy);
             yield return new LayerNormalizationLayer<T>();
             yield return new DenseLayer<T>(visionFfnDim, geluActivation, lazy);
             yield return new DenseLayer<T>(visionDim, identityActivation, lazy);
@@ -24058,7 +24125,7 @@ public static class LayerHelper<T>
 
         for (int i = 0; i < numVisionLayers; i++)
         {
-            yield return new MultiHeadAttentionLayer<T>(numHeads > 16 ? 16 : numHeads, (visionDim) / (numHeads > 16 ? 16 : numHeads));
+            yield return CreateVisionMha(visionDim, numHeads);
             yield return new LayerNormalizationLayer<T>();
             yield return new DenseLayer<T>(visionFfnDim, geluActivation);
             yield return new DenseLayer<T>(visionDim, identityActivation);
@@ -24163,7 +24230,7 @@ public static class LayerHelper<T>
 
         for (int i = 0; i < numVisionLayers; i++)
         {
-            yield return new MultiHeadAttentionLayer<T>(numHeads > 16 ? 16 : numHeads, (visionDim) / (numHeads > 16 ? 16 : numHeads));
+            yield return CreateVisionMha(visionDim, numHeads);
             yield return new LayerNormalizationLayer<T>();
             yield return new DenseLayer<T>(visionFfnDim, geluActivation);
             yield return new DenseLayer<T>(visionDim, identityActivation);
@@ -24307,7 +24374,7 @@ public static class LayerHelper<T>
 
         for (int i = 0; i < numEncoderLayers; i++)
         {
-            yield return new MultiHeadAttentionLayer<T>(numHeads > 16 ? 16 : numHeads, (visionDim) / (numHeads > 16 ? 16 : numHeads));
+            yield return CreateVisionMha(visionDim, numHeads);
             yield return new LayerNormalizationLayer<T>();
             yield return new DenseLayer<T>(visionFfnDim, geluActivation);
             yield return new DenseLayer<T>(visionDim, identityActivation);
@@ -24372,7 +24439,7 @@ public static class LayerHelper<T>
 
         for (int i = 0; i < numVisionLayers; i++)
         {
-            yield return new MultiHeadAttentionLayer<T>(numHeads > 16 ? 16 : numHeads, (visionDim) / (numHeads > 16 ? 16 : numHeads));
+            yield return CreateVisionMha(visionDim, numHeads);
             yield return new LayerNormalizationLayer<T>();
             yield return new DenseLayer<T>(visionFfnDim, geluActivation);
             yield return new DenseLayer<T>(visionDim, identityActivation);


### PR DESCRIPTION
## Summary

Closes the shape-contract root cause of [#1311](https://github.com/ooples/AiDotNet/issues/1311) (PR #1290 CI Cluster 3 — VLM/Multimodal cross-attention embedding-dim mismatch). **23 of 23 SmolVLM shape failures eliminated.** The other affected models (EmotiVoice, RainbowDQN) were already fixed by intervening work; Phi3Vision's remaining failures are foundation-scale OOM/timeout (separate class).

## Per-model state on current master (pre-fix in this PR)

| Model | Pass | Fail | Notes |
|---|---:|---:|---|
| EmotiVoiceTests | 26 | 1 | mel→encoder projection fix shipped previously (commit e61329bd8 May 14); remaining 1 = MoreData timeout, perf-gap |
| RainbowDQNAgentTests | 7 | 0 | fully fixed by intervening work |
| SmolVLMTests | 2 | 23 | **ALL 23 share the shape-mismatch error** — fixed by this PR |
| Phi3VisionTests | 2 | 23 | 17 OOM + 6 timeout, foundation-scale (336×336 ViT-Large + 3B-param decoder), NOT the shape contract |

## Root cause (SmolVLM)

SmolVLM defaults: \`VisionDim=384, NumHeads=9\`. At the vision-encoder MHA construction in \`CreateDefaultPixelShuffleProjectorLayers\` (and 9 other VLM factories):

\`\`\`csharp
new MultiHeadAttentionLayer<T>(numHeads > 16 ? 16 : numHeads,
                               (visionDim) / (numHeads > 16 ? 16 : numHeads))
\`\`\`

C# integer division: \`384 / 9 = 42\`. Then \`MultiHeadAttentionLayer._embeddingDimension = 9 * 42 = 378\` (NOT 384). The QKV weight matrices end up sized \`[378, 378]\`, but \`PatchEmbeddingLayer\` upstream emits patch tokens at visionDim=384 — so \`ForwardInternal\` throws at the very first vision MHA call with:

\`\`\`
System.ArgumentException : Input embedding dimension (384) does not match
weight dimension (378). Query shape: [1, 256, 384], Weights shape: [378, 378]
\`\`\`

The 9-heads / 384-vision-dim mismatch is paper-faithful (SmolVLM uses SmolLM's 9-head decoder config) but the vision encoder is SigLIP-Large @ 16 heads × 64 head-dim = 1024 vision-dim — different counts per subsystem. AiDotNet's \`SmolVLMOptions\` collapses both to a single \`NumHeads\` knob, so the factory reuses the decoder's 9 for the vision MHA where it doesn't divide.

## Fix

Add \`ChooseDivisibleHeadConfig(embedDim, requestedHeads, maxHeads = 16)\` helper in \`LayerHelper<T>\` that returns \`(heads, headDim)\` with \`heads * headDim == embedDim\` exactly — finds the largest \`h ≤ min(requestedHeads, maxHeads)\` such that \`embedDim % h == 0\`. For SmolVLM (visionDim=384, numHeads=9): start at 9, 384%9=6≠0, drop to 8, 384%8=0 ✓ → \`(8, 48)\`. MHA gets \`[384, 384]\` weights matching the 384-dim input.

Add \`CreateVisionMha(visionDim, numHeads, initializationStrategy?)\` shim that applies the helper and returns the configured \`MultiHeadAttentionLayer<T>\`. Replace all 10 inline \`new MultiHeadAttentionLayer<T>(numHeads > 16 ? 16 : numHeads, ...)\` call sites across the VLM factories.

Snapping heads downward (vs upward / padding embedDim) keeps every other shape in the chain unchanged — FFN, LayerNorm, downstream Dense all keep their visionDim-wide view. The trade-off is the attention pattern uses slightly fewer heads than the upstream model card; that's strictly more local than reshaping the entire residual stream. Per-subsystem head counts on the options class (\`NumVisionHeads\` vs \`NumDecoderHeads\`) is the paper-faithful long-term fix but is an API-surface change; the minimal no-surface-change fix is to snap downward.

## Affected factories (10 sites all converted)

All \`(visionDim) / (numHeads > 16 ? 16 : numHeads)\` patterns: \`CreateDefaultEncoderDecoderVLMLayers\`, \`CreateDefaultVisualExpertVLMLayers\`, \`CreateDefaultCrossAttentionResamplerVLMLayers\`, \`CreateDefaultPixelShuffleProjectorLayers\` (SmolVLM — direct fix here), \`CreateDefaultVisionAdapterLayers\` (Phi3Vision), \`CreateDefaultTokenReductionVLMLayers\` (DeepSeek-VL), + 4 more.

Defensive fix: applies to any VLM where the configured \`NumHeads\` doesn't divide \`VisionDim\` cleanly — not just SmolVLM's specific 9/384 mismatch.

## Verification

Pre-fix on master:

\`\`\`
$ dotnet test --filter "FullyQualifiedName~SmolVLMTests"
Failed: 23, Passed: 2
   All 23 failures: \"Input embedding dimension (384) does not match weight dimension (378)\"
\`\`\`

Post-fix:

\`\`\`
$ dotnet test --filter "FullyQualifiedName~SmolVLMTests"
Failed: 14, Passed: 11
   Remaining 14: 7 OutOfMemoryException + 6 timeout 120s + 1 timeout 180s
   NO MORE shape mismatch failures.
\`\`\`

This PR closes **23 of 23 SmolVLM shape-contract failures**. Remaining 14 SmolVLM + 23 Phi3Vision failures are foundation-scale resource issues (OOM at ImageNet-scale ViT-Large + multi-billion-param decoders), same class as [#1394](https://github.com/ooples/AiDotNet/issues/1394) (ResNet/VGG ImageNet-scale perf). Different root cause; separate follow-up.

## Test plan

- [x] \`dotnet build src/AiDotNet.csproj --framework net10.0\` — 0 errors
- [x] \`dotnet test --filter SmolVLMTests --framework net10.0\` — 11 pass / 14 fail; **zero shape-mismatch errors** (was 23 shape errors pre-fix)
- [x] Defensive: applied across all 10 VLM vision-encoder MHA construction sites
- [x] Closes #1311 shape-contract root cause; foundation-scale resource residue tracked separately

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved vision and encoder layer construction so attention head configuration is chosen to evenly match model dimensions, yielding more consistent and reliable layer behavior and initialization.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ooples/AiDotNet/pull/1397?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->