### PR TITLE
fix(PTV3): swap CrossEntropyLoss → CrossEntropyWithLogitsLoss (closes one #1314 test)

### DIFF
--- a/src/ComputerVision/Segmentation/PointCloud/PointTransformerV3.cs
+++ b/src/ComputerVision/Segmentation/PointCloud/PointTransformerV3.cs
@@ -109,7 +109,7 @@ public class PointTransformerV3<T> : NeuralNetworkBase<T>, ISemanticSegmentation
         ILossFunction<T>? lossFunction = null, int numClasses = 40,
         PointTransformerV3ModelSize modelSize = PointTransformerV3ModelSize.Base, double dropRate = 0.1,
         PointTransformerV3Options? options = null)
-        : base(architecture, lossFunction ?? new CrossEntropyLoss<T>())
+        : base(architecture, lossFunction ?? new CrossEntropyWithLogitsLoss<T>())
     {
         _options = options ?? new PointTransformerV3Options(); Options = _options;
         _height = architecture.InputHeight > 0 ? architecture.InputHeight : 1;
@@ -141,7 +141,7 @@ public class PointTransformerV3<T> : NeuralNetworkBase<T>, ISemanticSegmentation
     public PointTransformerV3(NeuralNetworkArchitecture<T> architecture, string onnxModelPath,
         int numClasses = 40, PointTransformerV3ModelSize modelSize = PointTransformerV3ModelSize.Base,
         PointTransformerV3Options? options = null)
-        : base(architecture, new CrossEntropyLoss<T>())
+        : base(architecture, new CrossEntropyWithLogitsLoss<T>())
     {
         _options = options ?? new PointTransformerV3Options(); Options = _options;
         if (string.IsNullOrWhiteSpace(onnxModelPath))


### PR DESCRIPTION
## Summary

- PointTransformerV3 emits raw conv logits via identity-activated decoder but defaulted to `CrossEntropyLoss<T>` (probability-input loss). The `-actual/predicted` derivative term hit `ClampProbability`'s epsilon floor and produced gradient spikes that exceed `MaxGradNorm=1.0` clipping in the deep encoder cascade.
- Loss diverged **1.26 → 16575 over 30 iterations** before this fix (13000× explosion).
- Swapped both ctors (native-mode and ONNX-mode) to `CrossEntropyWithLogitsLoss<T>` — the PyTorch-equivalent fused LogSoftmax+NLL loss that's numerically stable on raw logits.

## Test plan

- [x] `dotnet build src/AiDotNet.csproj --no-restore` — clean (0 errors)
- [x] `dotnet test --filter "PointTransformerV3Tests.Training_ShouldReduceLoss"` — PASS (was FAIL with 13000× loss explosion)
- [x] Full `PointTransformerV3Tests` suite: **20/21 pass** (only `MoreData_ShouldNotDegrade` still fails, already tracked in #1395 as the per-iter loss-degradation pattern, unrelated to this fix)
- [ ] CI on the full suite

## Scope note

The same default-loss bug affects ~15 other segmentation models in `src/ComputerVision/Segmentation/` (Sonata, SwinUNETR, ODISE, VMamba, KMaXDeepLab, EfficientTAM, YOLOv9Seg, …). They are **NOT in the #1314 cluster-6 scope** and would risk regressing tests outside this issue's coverage. Tracking those separately rather than expanding scope here.

Closes one of the 20 listed cluster-6 tests in #1314.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved loss function computation in the point cloud segmentation model for enhanced training accuracy.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ooples/AiDotNet/pull/1399?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->