### PR TITLE
fix(#1395): surface caught exception in CompiledTapeTrainingStep fallback

### DIFF
--- a/src/NeuralNetworks/NeuralNetworkBase.cs
+++ b/src/NeuralNetworks/NeuralNetworkBase.cs
@@ -6232,20 +6232,39 @@ public abstract class NeuralNetworkBase<T> : INeuralNetworkModel<T>, IInterpreta
             //     plan (strict single-plan policy refused to configure it)
             //   - mutated optimizer hyperparameters between steps
             //     (attached LR scheduler, changed betas, etc.)
+            //   - a kernel-level exception caught and swallowed
+            //     (CompiledTrainingPlan.Step / ConfigureOptimizer threw)
             // Resolution: call ResetState() or InvalidateParameterCountCache()
             // to fully reset training state, then retrain with stable
             // shapes + fixed hyperparameters. Or disable compilation via
             // AllowNondeterminism / Configure(JitCompilationConfig.Disabled)
             // so training runs entirely on the eager path from the start.
+            //
+            // AiDotNet#1395: quote the swallowed exception (if any) inline so
+            // failing tests don't have to chase Trace output to learn the
+            // root cause (Parameter N non-contiguous CPU layout, shape mismatch
+            // in a backward kernel, NaN guard trip, etc.). The inner exception
+            // is also attached for catch (InvalidOperationException ex) callers
+            // that introspect ex.InnerException.
+            var fallbackEx = Training.CompiledTapeTrainingStep<T>.GetLastFallbackException();
+            var rootCauseSuffix = fallbackEx is not null
+                ? $" Root-cause exception (caught in CompiledTapeTrainingStep): " +
+                  $"{fallbackEx.GetType().FullName}: {fallbackEx.Message}"
+                : " (No exception was caught — fused path returned false from one of the explicit " +
+                  "refuse paths: plan reference changed, optimizer hyperparameters drifted, " +
+                  "TensorCodecOptions.EnableCompilation=false, or numeric/optimizer type unsupported.)";
             throw new InvalidOperationException(
                 "Fused compiled training has already run successfully, but the current step cannot " +
                 "engage the fused path. The plan-embedded Adam/AdamW/SGD state cannot be transferred " +
                 "to the eager optimizer, so falling back silently would produce a trajectory that " +
                 "diverges from the previous fused steps. Common causes: variable input/target shape " +
-                "(new compiled plan), LR scheduler or adaptive-rate changes, attached AMSGrad. " +
+                "(new compiled plan), LR scheduler or adaptive-rate changes, attached AMSGrad, or a " +
+                "kernel-level exception in plan.Step/ConfigureOptimizer that was caught and swallowed. " +
                 "Resolution: keep shapes and optimizer hyperparameters stable across steps, OR call " +
                 "ResetState() / InvalidateParameterCountCache() to explicitly reset training state, " +
-                "OR disable compilation (AiModelBuilder.ConfigureJitCompilation(JitCompilationConfig.Disabled)).");
+                "OR disable compilation (AiModelBuilder.ConfigureJitCompilation(JitCompilationConfig.Disabled))." +
+                rootCauseSuffix,
+                innerException: fallbackEx);
         }
         else
         {

--- a/src/Training/CompiledTapeTrainingStep.cs
+++ b/src/Training/CompiledTapeTrainingStep.cs
@@ -102,6 +102,30 @@ public static class CompiledTapeTrainingStep<T>
     /// <summary>Resets the fused-step counter on the calling thread to zero.</summary>
     public static void ResetFusedStepCount() { _fusedStepCount = 0; }
 
+    /// <summary>
+    /// AiDotNet#1395: when <see cref="TryStepWithFusedOptimizer"/> falls back via
+    /// the catch path, the underlying exception is stored here so the caller
+    /// (NeuralNetworkBase) can surface it in the "fused has committed but step N
+    /// can't engage" InvalidOperationException. Previously the catch's exception
+    /// was logged to Trace only — users debugging from a failing test never saw
+    /// the actual root cause (e.g. "Parameter N non-contiguous CPU layout" from
+    /// <see cref="Tensors.Engines.Compilation.CompiledTrainingPlan{T}.ConfigureOptimizer"/>,
+    /// a shape mismatch from a backward kernel, a NaN guard trip). Now the
+    /// caller can quote the original exception's type + message + stack so the
+    /// error is self-diagnosing.
+    /// </summary>
+    [ThreadStatic]
+    private static System.Exception? _lastFallbackException;
+
+    /// <summary>
+    /// AiDotNet#1395: read the last exception that caused
+    /// <see cref="TryStepWithFusedOptimizer"/> to fall back, or <c>null</c> if
+    /// the most recent fallback was due to one of the explicit return-false
+    /// paths (plan switch, config drift, EnableCompilation=false, etc.) rather
+    /// than a swallowed exception.
+    /// </summary>
+    public static System.Exception? GetLastFallbackException() => _lastFallbackException;
+
     // Reflection-cached lookup of ICompiledTrainingPlan<T>.SetMaxGradNorm(double).
     // Populated lazily on first call per process and reused on every subsequent
     // step. Returns null when the underlying Tensors assembly pre-dates the
@@ -282,6 +306,11 @@ public static class CompiledTapeTrainingStep<T>
         AiDotNet.Tensors.Engines.Compilation.LrSchedule? lrSchedule = null)
     {
         lossValue = MathHelper.GetNumericOperations<T>().Zero;
+        // AiDotNet#1395: clear the previous-call's exception buffer so the
+        // caller's GetLastFallbackException reflects only the outcome of THIS
+        // call. (Cleared on entry, not on success, so a successful step doesn't
+        // leak a stale exception from earlier.)
+        _lastFallbackException = null;
 
         if (!TensorCodecOptions.Current.EnableCompilation) return false;
         // Fused optimizer kernels support float and double on the Tensors
@@ -505,6 +534,13 @@ public static class CompiledTapeTrainingStep<T>
             // a fused-path regression from logs requires reproducing the
             // failure locally. Clear the single-slot config state so any
             // next attempt reconfigures fresh.
+            //
+            // AiDotNet#1395: also stash the exception so the caller's
+            // "fused has committed but step cannot engage" InvalidOperationException
+            // can quote the underlying cause (Parameter N non-contiguous CPU
+            // layout, shape mismatch, NaN guard, etc.). Trace alone wasn't
+            // enough — failing tests don't surface Trace output by default.
+            _lastFallbackException = ex;
             System.Diagnostics.Trace.TraceWarning(
                 $"CompiledTapeTrainingStep.TryStepWithFusedOptimizer failed, falling back to eager: " +
                 $"{ex}");


### PR DESCRIPTION
**Closes:** #1395 (debuggability half — quotes the swallowed exception inline)
**Paired with:** AiDotNet.Tensors#fix/1395-cache-key-determinism (root-cause fix on the Tensors side)

## TL;DR

When `CompiledTapeTrainingStep.TryStepWithFusedOptimizer` catches an exception and falls back, the caller `NeuralNetworkBase` now surfaces that exception inline in the "fused has committed but current step cannot engage" `InvalidOperationException`, plus attaches it as `innerException`. Previously the catch logged to `Trace` only — failing tests gave an opaque generic error and required local repro just to learn the root cause.

## What changes

### `CompiledTapeTrainingStep<T>`

- New `[ThreadStatic]` field `_lastFallbackException`.
- Cleared on entry to every `TryStepWithFusedOptimizer` call so the field reflects only the most recent call's outcome.
- Set in the catch path alongside the existing `Trace.TraceWarning`.
- Exposed via `public static System.Exception? GetLastFallbackException()`.

### `NeuralNetworkBase.TryTrainWithFusedOptimizer`

When `ran=false` and `_fusedTrainingCommitted=true`, the throw at line 6240 now:
1. Reads `CompiledTapeTrainingStep<T>.GetLastFallbackException()`.
2. If non-null, appends `" Root-cause exception (caught in CompiledTapeTrainingStep): {type}: {message}"` to the message AND passes the exception as `innerException` to the new `InvalidOperationException`.
3. If null, appends a note that the fused path returned false from one of the explicit refuse paths (plan switch, config drift, `EnableCompilation=false`, unsupported numeric/optimizer type) — not from a swallowed exception.

## Three exception types this now surfaces inline

Observed during AiDotNet#1395 investigation under parallel test load. Each was silently swallowed before this fix:

- `InvalidOperationException "Parameter N has a layout that does not expose a live CPU backing array"` — from `CompiledTrainingPlan.ConfigureOptimizerDouble`.
- `ArgumentException "gradOutput shape [...] must be [...]"` — backward-kernel shape mismatch.
- `InvalidOperationException "Lazy tensor produced NaN at index 0"` — `DifferentiableNeuralComputer` numerical guard.

Tests that fail with the fused-committed throw now get the actual root-cause text immediately.

## Pairing with Tensors fix

The Tensors-side PR removes the cache-key drift that caused #1395's throw in the first place. This PR ensures that **if a different root cause re-emerges in the future**, the failure is self-diagnosing — so we never have to instrument and trace again to understand a #1395-class regression.

## Build

Clean on net10.0 + net471.
