### PR TITLE
fix(#1400): swap CrossEntropyLoss → CrossEntropyWithLogitsLoss across 141 files

### DIFF
--- a/src/AiDotNet.Generators/TestScaffoldGenerator.cs
+++ b/src/AiDotNet.Generators/TestScaffoldGenerator.cs
@@ -1937,6 +1937,34 @@ public class TestScaffoldGenerator : IIncrementalGenerator
             sb.AppendLine("    protected override int[] OutputShape => new[] { 4 };");
         }
         else if (isVisionModel &&
+                 (model.ClassName.StartsWith("LayoutLM", System.StringComparison.Ordinal)
+                  || model.ClassName.StartsWith("LayoutXLM", System.StringComparison.Ordinal)
+                  || model.ClassName.StartsWith("LiLT", System.StringComparison.Ordinal)
+                  || model.ClassName.StartsWith("DocFormer", System.StringComparison.Ordinal)
+                  || model.ClassName.StartsWith("DocBank", System.StringComparison.Ordinal)
+                  || model.ClassName.StartsWith("DocGCN", System.StringComparison.Ordinal)
+                  || model.ClassName.StartsWith("PICK", System.StringComparison.Ordinal)
+                  || model.ClassName.StartsWith("TRIE", System.StringComparison.Ordinal)
+                  || model.ClassName.StartsWith("DocOwl", System.StringComparison.Ordinal)
+                  || model.ClassName.StartsWith("UDOP", System.StringComparison.Ordinal)
+                  || model.ClassName.StartsWith("InfographicVQA", System.StringComparison.Ordinal)))
+        {
+            // LayoutLM-family document models (Xu et al. 2020 KDD "LayoutLM",
+            // Xu et al. 2021 ACL "LayoutXLM", Wang et al. 2022 ACL "LiLT",
+            // Appalaraju et al. 2021 ICCV "DocFormer", etc.) carry the Vision
+            // domain tag because they understand 2D layout, but their actual
+            // model input is TOKEN IDs (rank-1 sequence of int32-shaped doubles),
+            // not raw RGB pixels. Feeding a [3, 128, 128] image tensor causes
+            // the first EmbeddingLayer to treat every float as a token ID:
+            // 49 152 lookups × 768 embedding dim × 12 transformer layers ×
+            // 30 Train iters times out every test that runs Forward. Emit
+            // a short token-ID sequence so the model's intended code path
+            // (token embedding → 2D position embeddings → BERT-style stack)
+            // runs at sensible cost.
+            sb.AppendLine("    protected override int[] InputShape => new[] { 16 };");
+            sb.AppendLine("    protected override int[] OutputShape => new[] { 4 };");
+        }
+        else if (isVisionModel &&
                  (model.ClassName.StartsWith("UNITER", System.StringComparison.Ordinal)
                   || model.ClassName.StartsWith("VisualBERT", System.StringComparison.Ordinal)
                   || model.ClassName.StartsWith("Oscar", System.StringComparison.Ordinal)

--- a/src/Audio/AudioGen/AudioGenModel.cs
+++ b/src/Audio/AudioGen/AudioGenModel.cs
@@ -353,7 +353,7 @@ public class AudioGenModel<T> : AudioNeuralNetworkBase<T>, IAudioGenerator<T>
         IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>>? optimizer = null,
         ILossFunction<T>? lossFunction = null,
         AudioGenOptions? options = null)
-        : base(architecture, lossFunction ?? new CrossEntropyLoss<T>(), 1.0)
+        : base(architecture, lossFunction ?? new CrossEntropyWithLogitsLoss<T>(), 1.0)
     {
         _options = options ?? new AudioGenOptions();
         Options = _options;
@@ -436,7 +436,7 @@ public class AudioGenModel<T> : AudioNeuralNetworkBase<T>, IAudioGenerator<T>
             _tokenizer = tokenizer;
 
             _optimizer = optimizer;
-            _lossFunction = lossFunction ?? new CrossEntropyLoss<T>();
+            _lossFunction = lossFunction ?? new CrossEntropyWithLogitsLoss<T>();
 
             _random = seed.HasValue
                 ? RandomHelper.CreateSeededRandom(seed.Value)
@@ -512,7 +512,7 @@ public class AudioGenModel<T> : AudioNeuralNetworkBase<T>, IAudioGenerator<T>
         IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>>? optimizer = null,
         ILossFunction<T>? lossFunction = null,
         AudioGenOptions? options = null)
-        : base(architecture, lossFunction ?? new CrossEntropyLoss<T>(), 1.0)
+        : base(architecture, lossFunction ?? new CrossEntropyWithLogitsLoss<T>(), 1.0)
     {
         _options = options ?? new AudioGenOptions();
         Options = _options;
@@ -569,7 +569,7 @@ public class AudioGenModel<T> : AudioNeuralNetworkBase<T>, IAudioGenerator<T>
         // Use T5-style tokenizer as default for AudioGen text encoder
         _tokenizer = tokenizer ?? Tokenization.LanguageModelTokenizerFactory.CreateForBackbone(LanguageModelBackbone.FlanT5);
         _optimizer = optimizer ?? new AdamWOptimizer<T, Tensor<T>, Tensor<T>>(this);
-        _lossFunction = lossFunction ?? new CrossEntropyLoss<T>();
+        _lossFunction = lossFunction ?? new CrossEntropyWithLogitsLoss<T>();
 
         _random = seed.HasValue
             ? RandomHelper.CreateSeededRandom(seed.Value)

--- a/src/Audio/Emotion/SpeechEmotionRecognizer.cs
+++ b/src/Audio/Emotion/SpeechEmotionRecognizer.cs
@@ -358,7 +358,7 @@ public class SpeechEmotionRecognizer<T> : AudioClassifierBase<T>, IEmotionRecogn
         }
         else
         {
-            LossFunction = new CrossEntropyLoss<T>();
+            LossFunction = new CrossEntropyWithLogitsLoss<T>();
         }
 
         // Create mel spectrogram extractor

--- a/src/Audio/LanguageIdentification/ECAPATDNNLanguageIdentifier.cs
+++ b/src/Audio/LanguageIdentification/ECAPATDNNLanguageIdentifier.cs
@@ -123,7 +123,7 @@ public class ECAPATDNNLanguageIdentifier<T> : AudioNeuralNetworkBase<T>, ILangua
         NeuralNetworkArchitecture<T> architecture,
         string modelPath,
         ECAPATDNNOptions? options = null)
-        : base(architecture, new CrossEntropyLoss<T>())
+        : base(architecture, new CrossEntropyWithLogitsLoss<T>())
     {
         if (string.IsNullOrWhiteSpace(modelPath))
             throw new ArgumentException("Model path cannot be null or empty.", nameof(modelPath));
@@ -138,7 +138,7 @@ public class ECAPATDNNLanguageIdentifier<T> : AudioNeuralNetworkBase<T>, ILangua
         SampleRate = _options.SampleRate;
         NumMels = _options.NumMels;
 
-        _lossFunction = new CrossEntropyLoss<T>();
+        _lossFunction = new CrossEntropyWithLogitsLoss<T>();
 
         // Initialize MFCC extractor
         _mfccExtractor = new MfccExtractor<T>(new MfccOptions
@@ -173,7 +173,7 @@ public class ECAPATDNNLanguageIdentifier<T> : AudioNeuralNetworkBase<T>, ILangua
         ECAPATDNNOptions? options = null,
         IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>>? optimizer = null,
         ILossFunction<T>? lossFunction = null)
-        : base(architecture, lossFunction ?? new CrossEntropyLoss<T>())
+        : base(architecture, lossFunction ?? new CrossEntropyWithLogitsLoss<T>())
     {
         if (supportedLanguages is null)
             throw new ArgumentNullException(nameof(supportedLanguages));
@@ -187,7 +187,7 @@ public class ECAPATDNNLanguageIdentifier<T> : AudioNeuralNetworkBase<T>, ILangua
         SampleRate = _options.SampleRate;
         NumMels = _options.NumMels;
 
-        _lossFunction = lossFunction ?? new CrossEntropyLoss<T>();
+        _lossFunction = lossFunction ?? new CrossEntropyWithLogitsLoss<T>();
         _optimizer = optimizer ?? new AdamWOptimizer<T, Tensor<T>, Tensor<T>>(this);
 
         // Initialize MFCC extractor

--- a/src/Audio/LanguageIdentification/VoxLingua107Identifier.cs
+++ b/src/Audio/LanguageIdentification/VoxLingua107Identifier.cs
@@ -154,7 +154,7 @@ public class VoxLingua107Identifier<T> : AudioNeuralNetworkBase<T>, ILanguageIde
         NeuralNetworkArchitecture<T> architecture,
         string modelPath,
         VoxLingua107Options? options = null)
-        : base(architecture, new CrossEntropyLoss<T>())
+        : base(architecture, new CrossEntropyWithLogitsLoss<T>())
     {
         if (string.IsNullOrWhiteSpace(modelPath))
             throw new ArgumentException("Model path cannot be null or empty.", nameof(modelPath));
@@ -169,7 +169,7 @@ public class VoxLingua107Identifier<T> : AudioNeuralNetworkBase<T>, ILanguageIde
         SampleRate = _options.SampleRate;
         NumMels = _options.NumMels;
 
-        _lossFunction = new CrossEntropyLoss<T>();
+        _lossFunction = new CrossEntropyWithLogitsLoss<T>();
 
         // Initialize MFCC extractor
         _mfccExtractor = new MfccExtractor<T>(new MfccOptions
@@ -202,7 +202,7 @@ public class VoxLingua107Identifier<T> : AudioNeuralNetworkBase<T>, ILanguageIde
         VoxLingua107Options? options = null,
         IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>>? optimizer = null,
         ILossFunction<T>? lossFunction = null)
-        : base(architecture, lossFunction ?? new CrossEntropyLoss<T>())
+        : base(architecture, lossFunction ?? new CrossEntropyWithLogitsLoss<T>())
     {
         _numOps = MathHelper.GetNumericOperations<T>();
         _options = options ?? new VoxLingua107Options();
@@ -211,7 +211,7 @@ public class VoxLingua107Identifier<T> : AudioNeuralNetworkBase<T>, ILanguageIde
         SampleRate = _options.SampleRate;
         NumMels = _options.NumMels;
 
-        _lossFunction = lossFunction ?? new CrossEntropyLoss<T>();
+        _lossFunction = lossFunction ?? new CrossEntropyWithLogitsLoss<T>();
         _optimizer = optimizer ?? new AdamWOptimizer<T, Tensor<T>, Tensor<T>>(this);
 
         // Initialize MFCC extractor

--- a/src/Audio/LanguageIdentification/Wav2Vec2LanguageIdentifier.cs
+++ b/src/Audio/LanguageIdentification/Wav2Vec2LanguageIdentifier.cs
@@ -115,7 +115,7 @@ public class Wav2Vec2LanguageIdentifier<T> : AudioNeuralNetworkBase<T>, ILanguag
         NeuralNetworkArchitecture<T> architecture,
         string modelPath,
         Wav2Vec2LidOptions? options = null)
-        : base(architecture, new CrossEntropyLoss<T>())
+        : base(architecture, new CrossEntropyWithLogitsLoss<T>())
     {
         if (string.IsNullOrWhiteSpace(modelPath))
             throw new ArgumentException("Model path cannot be null or empty.", nameof(modelPath));
@@ -129,7 +129,7 @@ public class Wav2Vec2LanguageIdentifier<T> : AudioNeuralNetworkBase<T>, ILanguag
 
         SampleRate = _options.SampleRate;
 
-        _lossFunction = new CrossEntropyLoss<T>();
+        _lossFunction = new CrossEntropyWithLogitsLoss<T>();
 
         // Initialize language mappings
         (_languageIdToCode, _languageCodeToId, _languageCodeToName) = InitializeLanguageMappings();
@@ -153,7 +153,7 @@ public class Wav2Vec2LanguageIdentifier<T> : AudioNeuralNetworkBase<T>, ILanguag
         Wav2Vec2LidOptions? options = null,
         IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>>? optimizer = null,
         ILossFunction<T>? lossFunction = null)
-        : base(architecture, lossFunction ?? new CrossEntropyLoss<T>())
+        : base(architecture, lossFunction ?? new CrossEntropyWithLogitsLoss<T>())
     {
         if (supportedLanguages is null)
             throw new ArgumentNullException(nameof(supportedLanguages));
@@ -166,7 +166,7 @@ public class Wav2Vec2LanguageIdentifier<T> : AudioNeuralNetworkBase<T>, ILanguag
 
         SampleRate = _options.SampleRate;
 
-        _lossFunction = lossFunction ?? new CrossEntropyLoss<T>();
+        _lossFunction = lossFunction ?? new CrossEntropyWithLogitsLoss<T>();
         _optimizer = optimizer ?? new AdamWOptimizer<T, Tensor<T>, Tensor<T>>(this);
 
         // Initialize language mappings

--- a/src/Audio/MusicGen/MusicGenModel.cs
+++ b/src/Audio/MusicGen/MusicGenModel.cs
@@ -165,7 +165,7 @@ public class MusicGenModel<T> : AudioNeuralNetworkBase<T>, IAudioGenerator<T>
         MusicGenOptions? options = null,
         IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>>? optimizer = null,
         ILossFunction<T>? lossFunction = null)
-        : base(architecture, lossFunction ?? new CrossEntropyLoss<T>(), 1.0)
+        : base(architecture, lossFunction ?? new CrossEntropyWithLogitsLoss<T>(), 1.0)
     {
         // Validate paths
         if (string.IsNullOrWhiteSpace(textEncoderPath))
@@ -217,7 +217,7 @@ public class MusicGenModel<T> : AudioNeuralNetworkBase<T>, IAudioGenerator<T>
         }
 
         _optimizer = optimizer;
-        _lossFunction = lossFunction ?? new CrossEntropyLoss<T>();
+        _lossFunction = lossFunction ?? new CrossEntropyWithLogitsLoss<T>();
         _random = _options.Seed.HasValue
             ? RandomHelper.CreateSeededRandom(_options.Seed.Value)
             : RandomHelper.CreateSecureRandom();
@@ -250,7 +250,7 @@ public class MusicGenModel<T> : AudioNeuralNetworkBase<T>, IAudioGenerator<T>
         ITokenizer? tokenizer = null,
         IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>>? optimizer = null,
         ILossFunction<T>? lossFunction = null)
-        : base(architecture, lossFunction ?? new CrossEntropyLoss<T>(), 1.0)
+        : base(architecture, lossFunction ?? new CrossEntropyWithLogitsLoss<T>(), 1.0)
     {
         _options = options ?? new MusicGenOptions();
         Options = _options;
@@ -262,7 +262,7 @@ public class MusicGenModel<T> : AudioNeuralNetworkBase<T>, IAudioGenerator<T>
         // Use T5-compatible tokenizer as default
         _tokenizer = tokenizer ?? Tokenization.LanguageModelTokenizerFactory.CreateForBackbone(LanguageModelBackbone.FlanT5);
         _optimizer = optimizer ?? new AdamWOptimizer<T, Tensor<T>, Tensor<T>>(this);
-        _lossFunction = lossFunction ?? new CrossEntropyLoss<T>();
+        _lossFunction = lossFunction ?? new CrossEntropyWithLogitsLoss<T>();
         _random = _options.Seed.HasValue
             ? RandomHelper.CreateSeededRandom(_options.Seed.Value)
             : RandomHelper.CreateSecureRandom();

--- a/src/Audio/SpeechRecognition/Wav2Vec2Model.cs
+++ b/src/Audio/SpeechRecognition/Wav2Vec2Model.cs
@@ -282,8 +282,13 @@ public class Wav2Vec2Model<T> : AudioNeuralNetworkBase<T>, ISpeechRecognizer<T>
         // Initialize supported languages
         SupportedLanguages = new[] { language ?? "en" };
 
-        // Default loss function (cross-entropy is standard for ASR)
-        _lossFunction = new CrossEntropyWithLogitsLoss<T>();
+        // Wav2Vec2 + CTC is the standard ASR training stack (Baevski et al.
+        // 2020 §3.2): CTC handles the variable-length output-vs-input
+        // alignment that plain cross-entropy cannot. CE-with-logits would
+        // be silently wrong here — it forces a fixed-length 1:1 alignment
+        // and the loss is computed per-frame, which is not the ASR
+        // objective. PR #1404 review (CodeRabbit).
+        _lossFunction = new CTCLoss<T>(numClasses: _vocabSize, blankIndex: 0);
 
         InitializeLayers();
     }
@@ -367,9 +372,11 @@ public class Wav2Vec2Model<T> : AudioNeuralNetworkBase<T>, ISpeechRecognizer<T>
         // Initialize supported languages
         SupportedLanguages = new[] { language ?? "en" };
 
-        // Initialize training components
+        // Initialize training components — CTC for ASR (see ONNX ctor for
+        // rationale). Wav2Vec2's variable-length frame-vs-character alignment
+        // can't be expressed by plain cross-entropy.
         _optimizer = optimizer ?? new AdamOptimizer<T, Tensor<T>, Tensor<T>>(this);
-        _lossFunction = lossFunction ?? new CrossEntropyWithLogitsLoss<T>();
+        _lossFunction = lossFunction ?? new CTCLoss<T>(numClasses: _vocabSize, blankIndex: 0);
 
         InitializeNativeLayers();
     }

--- a/src/Audio/SpeechRecognition/Wav2Vec2Model.cs
+++ b/src/Audio/SpeechRecognition/Wav2Vec2Model.cs
@@ -283,7 +283,7 @@ public class Wav2Vec2Model<T> : AudioNeuralNetworkBase<T>, ISpeechRecognizer<T>
         SupportedLanguages = new[] { language ?? "en" };
 
         // Default loss function (cross-entropy is standard for ASR)
-        _lossFunction = new CrossEntropyLoss<T>();
+        _lossFunction = new CrossEntropyWithLogitsLoss<T>();
 
         InitializeLayers();
     }
@@ -369,7 +369,7 @@ public class Wav2Vec2Model<T> : AudioNeuralNetworkBase<T>, ISpeechRecognizer<T>
 
         // Initialize training components
         _optimizer = optimizer ?? new AdamOptimizer<T, Tensor<T>, Tensor<T>>(this);
-        _lossFunction = lossFunction ?? new CrossEntropyLoss<T>();
+        _lossFunction = lossFunction ?? new CrossEntropyWithLogitsLoss<T>();
 
         InitializeNativeLayers();
     }

--- a/src/Audio/SpeechRecognition/Wav2Vec2Model.cs
+++ b/src/Audio/SpeechRecognition/Wav2Vec2Model.cs
@@ -375,7 +375,15 @@ public class Wav2Vec2Model<T> : AudioNeuralNetworkBase<T>, ISpeechRecognizer<T>
         // Initialize training components — CTC for ASR (see ONNX ctor for
         // rationale). Wav2Vec2's variable-length frame-vs-character alignment
         // can't be expressed by plain cross-entropy.
-        _optimizer = optimizer ?? new AdamOptimizer<T, Tensor<T>, Tensor<T>>(this);
+        // Paper-faithful LR per Baevski et al. 2020 NeurIPS §3.3 ("wav2vec 2.0"):
+        // Adam with peak LR=5e-4 for pretraining, 5e-5 for ASR fine-tuning.
+        // Framework default (LR=1e-3) is too aggressive for this BERT-base scale
+        // model at random init and causes Training_ShouldReduceLoss to diverge.
+        // Use the 5e-5 fine-tuning default since the test runs from random init
+        // and supervised CTC; pretraining-scale 5e-4 also works.
+        _optimizer = optimizer ?? new AdamOptimizer<T, Tensor<T>, Tensor<T>>(
+            this,
+            new Models.Options.AdamOptimizerOptions<T, Tensor<T>, Tensor<T>> { InitialLearningRate = 5e-5 });
         _lossFunction = lossFunction ?? new CTCLoss<T>(numClasses: _vocabSize, blankIndex: 0);
 
         InitializeNativeLayers();
@@ -626,7 +634,14 @@ public class Wav2Vec2Model<T> : AudioNeuralNetworkBase<T>, ISpeechRecognizer<T>
         SetTrainingMode(true);
         try
         {
-            TrainWithTape(input, expectedOutput);
+            // Pass the model's own non-AMSGrad AdamOptimizer explicitly.
+            // The optimizer-null branch would otherwise fall back to
+            // GetOrCreateBaseOptimizer (which builds an AMSGrad Adam),
+            // and the fused-Adam fast path bails out on AMSGrad — leaving
+            // every step on the BERT-base-scale wav2vec2 encoder running
+            // through the eager tape executor at multi-second cost per
+            // iteration.
+            TrainWithTape(input, expectedOutput, _optimizer as IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>>);
         }
         finally
         {

--- a/src/Audio/SpeechRecognition/Wav2Vec2Model.cs
+++ b/src/Audio/SpeechRecognition/Wav2Vec2Model.cs
@@ -641,7 +641,16 @@ public class Wav2Vec2Model<T> : AudioNeuralNetworkBase<T>, ISpeechRecognizer<T>
             // every step on the BERT-base-scale wav2vec2 encoder running
             // through the eager tape executor at multi-second cost per
             // iteration.
-            TrainWithTape(input, expectedOutput, _optimizer as IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>>);
+            //
+            // The cast goes through `as ... ?? throw` rather than plain
+            // `as` so a user passing a non-gradient optimizer fails loudly
+            // instead of silently dropping into the default-optimizer
+            // fallback (would mask intent and produce mysteriously-different
+            // training trajectories). PR #1404 review (CodeRabbit).
+            var gradientOptimizer = _optimizer as IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>>
+                ?? throw new InvalidOperationException(
+                    "Wav2Vec2Model training requires an optimizer implementing IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>>.");
+            TrainWithTape(input, expectedOutput, gradientOptimizer);
         }
         finally
         {

--- a/src/Audio/Whisper/WhisperModel.cs
+++ b/src/Audio/Whisper/WhisperModel.cs
@@ -363,7 +363,7 @@ public class WhisperModel<T> : AudioNeuralNetworkBase<T>, ISpeechRecognizer<T>
         SupportedLanguages = GetSupportedLanguages();
 
         // Default loss function (cross-entropy is standard for sequence-to-sequence ASR)
-        _lossFunction = new CrossEntropyLoss<T>();
+        _lossFunction = new CrossEntropyWithLogitsLoss<T>();
 
         InitializeLayers();
     }
@@ -470,7 +470,7 @@ public class WhisperModel<T> : AudioNeuralNetworkBase<T>, ISpeechRecognizer<T>
 
         // Initialize training components
         _optimizer = optimizer ?? new AdamWOptimizer<T, Tensor<T>, Tensor<T>>(this);
-        _lossFunction = lossFunction ?? new CrossEntropyLoss<T>();
+        _lossFunction = lossFunction ?? new CrossEntropyWithLogitsLoss<T>();
 
         InitializeLayers();
     }

--- a/src/Classification/Boosting/DARTClassifier.cs
+++ b/src/Classification/Boosting/DARTClassifier.cs
@@ -104,7 +104,7 @@ public class DARTClassifier<T> : EnsembleClassifierBase<T>
     /// <param name="regularization">Optional regularization.</param>
     public DARTClassifier(DARTClassifierOptions<T>? options = null,
         IRegularization<T, Matrix<T>, Vector<T>>? regularization = null)
-        : base(options ??= new DARTClassifierOptions<T>(), regularization, new CrossEntropyLoss<T>())
+        : base(options ??= new DARTClassifierOptions<T>(), regularization, new CrossEntropyWithLogitsLoss<T>())
     {
         _options = options;
         _trees = [];

--- a/src/Classification/Boosting/ExplainableBoostingClassifier.cs
+++ b/src/Classification/Boosting/ExplainableBoostingClassifier.cs
@@ -141,7 +141,7 @@ public class ExplainableBoostingClassifier<T> : EnsembleClassifierBase<T>
     public ExplainableBoostingClassifier(
         ExplainableBoostingClassifierOptions<T>? options = null,
         IRegularization<T, Matrix<T>, Vector<T>>? regularization = null)
-        : base(options ??= new ExplainableBoostingClassifierOptions<T>(), regularization, new CrossEntropyLoss<T>())
+        : base(options ??= new ExplainableBoostingClassifierOptions<T>(), regularization, new CrossEntropyWithLogitsLoss<T>())
     {
         _options = options;
         _shapeFunctions = [];

--- a/src/Classification/Boosting/NGBoostClassifier.cs
+++ b/src/Classification/Boosting/NGBoostClassifier.cs
@@ -109,7 +109,7 @@ public class NGBoostClassifier<T> : EnsembleClassifierBase<T>
     /// <param name="regularization">Optional regularization strategy.</param>
     public NGBoostClassifier(NGBoostClassifierOptions<T>? options = null,
         IRegularization<T, Matrix<T>, Vector<T>>? regularization = null)
-        : base(options ??= new NGBoostClassifierOptions<T>(), regularization, new CrossEntropyLoss<T>())
+        : base(options ??= new NGBoostClassifierOptions<T>(), regularization, new CrossEntropyWithLogitsLoss<T>())
     {
         _options = options;
         _trees = [];

--- a/src/Classification/Calibration/CalibratedClassifier.cs
+++ b/src/Classification/Calibration/CalibratedClassifier.cs
@@ -118,7 +118,7 @@ public class CalibratedClassifier<T> : ProbabilisticClassifierBase<T>,
         IProbabilisticClassifier<T> baseClassifier,
         CalibratedClassifierOptions<T>? options = null,
         IRegularization<T, Matrix<T>, Vector<T>>? regularization = null)
-        : base(options ??= new CalibratedClassifierOptions<T>(), regularization, new CrossEntropyLoss<T>())
+        : base(options ??= new CalibratedClassifierOptions<T>(), regularization, new CrossEntropyWithLogitsLoss<T>())
     {
         _baseClassifier = baseClassifier;
         _options = options;

--- a/src/Classification/ClassifierBase.cs
+++ b/src/Classification/ClassifierBase.cs
@@ -156,7 +156,7 @@ public abstract class ClassifierBase<T> : IClassifier<T>, IConfigurableModel<T>,
         NumOps = MathHelper.GetNumericOperations<T>();
         Options = options ?? new ClassifierOptions<T>();
         TaskType = Options.TaskType;
-        _defaultLossFunction = lossFunction ?? new CrossEntropyLoss<T>();
+        _defaultLossFunction = lossFunction ?? new CrossEntropyWithLogitsLoss<T>();
     }
 
     /// <summary>

--- a/src/Classification/DiscriminantAnalysis/LinearDiscriminantAnalysis.cs
+++ b/src/Classification/DiscriminantAnalysis/LinearDiscriminantAnalysis.cs
@@ -115,7 +115,7 @@ public class LinearDiscriminantAnalysis<T> : ProbabilisticClassifierBase<T>,
     /// <param name="regularization">Optional regularization strategy.</param>
     public LinearDiscriminantAnalysis(DiscriminantAnalysisOptions<T>? options = null,
         IRegularization<T, Matrix<T>, Vector<T>>? regularization = null)
-        : base(options ?? new DiscriminantAnalysisOptions<T>(), regularization, new CrossEntropyLoss<T>())
+        : base(options ?? new DiscriminantAnalysisOptions<T>(), regularization, new CrossEntropyWithLogitsLoss<T>())
     {
     }
 

--- a/src/Classification/DiscriminantAnalysis/QuadraticDiscriminantAnalysis.cs
+++ b/src/Classification/DiscriminantAnalysis/QuadraticDiscriminantAnalysis.cs
@@ -109,7 +109,7 @@ public class QuadraticDiscriminantAnalysis<T> : ProbabilisticClassifierBase<T>,
     /// <param name="regularization">Optional regularization strategy.</param>
     public QuadraticDiscriminantAnalysis(DiscriminantAnalysisOptions<T>? options = null,
         IRegularization<T, Matrix<T>, Vector<T>>? regularization = null)
-        : base(options ?? new DiscriminantAnalysisOptions<T>(), regularization, new CrossEntropyLoss<T>())
+        : base(options ?? new DiscriminantAnalysisOptions<T>(), regularization, new CrossEntropyWithLogitsLoss<T>())
     {
     }
 

--- a/src/Classification/Ensemble/AdaBoostClassifier.cs
+++ b/src/Classification/Ensemble/AdaBoostClassifier.cs
@@ -87,7 +87,13 @@ public class AdaBoostClassifier<T> : EnsembleClassifierBase<T>
     /// <param name="regularization">Optional regularization strategy.</param>
     public AdaBoostClassifier(AdaBoostClassifierOptions<T>? options = null,
         IRegularization<T, Matrix<T>, Vector<T>>? regularization = null)
-        : base(options ?? new AdaBoostClassifierOptions<T>(), regularization, new CrossEntropyWithLogitsLoss<T>())
+        // PR #1404 review: AdaBoostClassifier outputs probabilities via
+        // PredictProbabilities() (weighted normalized votes). Pass the
+        // probability-input cross-entropy so any future code path that
+        // evaluates DefaultLossFunction against the classifier's outputs
+        // gets the right gradient. AdaBoost's own training doesn't consume
+        // this loss but design-time consistency matters.
+        : base(options ?? new AdaBoostClassifierOptions<T>(), regularization, new CrossEntropyLoss<T>())
     {
     }
 

--- a/src/Classification/Ensemble/AdaBoostClassifier.cs
+++ b/src/Classification/Ensemble/AdaBoostClassifier.cs
@@ -87,7 +87,7 @@ public class AdaBoostClassifier<T> : EnsembleClassifierBase<T>
     /// <param name="regularization">Optional regularization strategy.</param>
     public AdaBoostClassifier(AdaBoostClassifierOptions<T>? options = null,
         IRegularization<T, Matrix<T>, Vector<T>>? regularization = null)
-        : base(options ?? new AdaBoostClassifierOptions<T>(), regularization, new CrossEntropyLoss<T>())
+        : base(options ?? new AdaBoostClassifierOptions<T>(), regularization, new CrossEntropyWithLogitsLoss<T>())
     {
     }
 

--- a/src/Classification/Ensemble/EnsembleClassifierBase.cs
+++ b/src/Classification/Ensemble/EnsembleClassifierBase.cs
@@ -57,7 +57,7 @@ public abstract class EnsembleClassifierBase<T> : ProbabilisticClassifierBase<T>
     protected EnsembleClassifierBase(ClassifierOptions<T>? options = null,
         IRegularization<T, Matrix<T>, Vector<T>>? regularization = null,
         ILossFunction<T>? lossFunction = null)
-        : base(options ?? new ClassifierOptions<T>(), regularization, lossFunction ?? new CrossEntropyLoss<T>())
+        : base(options ?? new ClassifierOptions<T>(), regularization, lossFunction ?? new CrossEntropyWithLogitsLoss<T>())
     {
     }
 

--- a/src/Classification/Ensemble/ExtraTreesClassifier.cs
+++ b/src/Classification/Ensemble/ExtraTreesClassifier.cs
@@ -84,7 +84,7 @@ public class ExtraTreesClassifier<T> : EnsembleClassifierBase<T>, ITreeBasedClas
     /// <param name="regularization">Optional regularization strategy.</param>
     public ExtraTreesClassifier(ExtraTreesClassifierOptions<T>? options = null,
         IRegularization<T, Matrix<T>, Vector<T>>? regularization = null)
-        : base(options ?? new ExtraTreesClassifierOptions<T>(), regularization, new CrossEntropyLoss<T>())
+        : base(options ?? new ExtraTreesClassifierOptions<T>(), regularization, new CrossEntropyWithLogitsLoss<T>())
     {
     }
 

--- a/src/Classification/Ensemble/GradientBoostingClassifier.cs
+++ b/src/Classification/Ensemble/GradientBoostingClassifier.cs
@@ -115,7 +115,7 @@ public class GradientBoostingClassifier<T> : EnsembleClassifierBase<T>, ITreeBas
     /// <param name="regularization">Optional regularization strategy.</param>
     public GradientBoostingClassifier(GradientBoostingClassifierOptions<T>? options = null,
         IRegularization<T, Matrix<T>, Vector<T>>? regularization = null)
-        : base(options ?? new GradientBoostingClassifierOptions<T>(), regularization, new CrossEntropyLoss<T>())
+        : base(options ?? new GradientBoostingClassifierOptions<T>(), regularization, new CrossEntropyWithLogitsLoss<T>())
     {
         _initPrediction = NumOps.Zero;
     }

--- a/src/Classification/Ensemble/RandomForestClassifier.cs
+++ b/src/Classification/Ensemble/RandomForestClassifier.cs
@@ -110,7 +110,7 @@ public class RandomForestClassifier<T> : EnsembleClassifierBase<T>, ITreeBasedCl
     /// <param name="regularization">Optional regularization strategy.</param>
     public RandomForestClassifier(RandomForestClassifierOptions<T>? options = null,
         IRegularization<T, Matrix<T>, Vector<T>>? regularization = null)
-        : base(options ?? new RandomForestClassifierOptions<T>(), regularization, new CrossEntropyLoss<T>())
+        : base(options ?? new RandomForestClassifierOptions<T>(), regularization, new CrossEntropyWithLogitsLoss<T>())
     {
     }
 

--- a/src/Classification/Meta/MetaClassifierBase.cs
+++ b/src/Classification/Meta/MetaClassifierBase.cs
@@ -48,7 +48,7 @@ public abstract class MetaClassifierBase<T> : ProbabilisticClassifierBase<T>,
         MetaClassifierOptions<T>? options = null,
         Func<IClassifier<T>>? estimatorFactory = null,
         IRegularization<T, Matrix<T>, Vector<T>>? regularization = null)
-        : base(options ?? new MetaClassifierOptions<T>(), regularization, new CrossEntropyLoss<T>())
+        : base(options ?? new MetaClassifierOptions<T>(), regularization, new CrossEntropyWithLogitsLoss<T>())
     {
         EstimatorFactory = estimatorFactory;
     }

--- a/src/Classification/NaiveBayes/NaiveBayesBase.cs
+++ b/src/Classification/NaiveBayes/NaiveBayesBase.cs
@@ -54,7 +54,7 @@ public abstract class NaiveBayesBase<T> : ProbabilisticClassifierBase<T>,
     /// <param name="regularization">Optional regularization strategy.</param>
     protected NaiveBayesBase(NaiveBayesOptions<T>? options = null,
         IRegularization<T, Matrix<T>, Vector<T>>? regularization = null)
-        : base(options ?? new NaiveBayesOptions<T>(), regularization, new CrossEntropyLoss<T>())
+        : base(options ?? new NaiveBayesOptions<T>(), regularization, new CrossEntropyWithLogitsLoss<T>())
     {
     }
 

--- a/src/Classification/Neighbors/KNeighborsClassifier.cs
+++ b/src/Classification/Neighbors/KNeighborsClassifier.cs
@@ -75,7 +75,7 @@ public class KNeighborsClassifier<T> : ProbabilisticClassifierBase<T>
     /// <param name="regularization">Optional regularization strategy.</param>
     public KNeighborsClassifier(KNeighborsOptions<T>? options = null,
         IRegularization<T, Matrix<T>, Vector<T>>? regularization = null)
-        : base(options ?? new KNeighborsOptions<T>(), regularization, new CrossEntropyLoss<T>())
+        : base(options ?? new KNeighborsOptions<T>(), regularization, new CrossEntropyWithLogitsLoss<T>())
     {
     }
 

--- a/src/Classification/OrdinalRegression.cs
+++ b/src/Classification/OrdinalRegression.cs
@@ -156,7 +156,7 @@ public class OrdinalRegression<T> : ClassifierBase<T>,
     /// </para>
     /// </remarks>
     public OrdinalRegression(OrdinalRegressionOptions<T>? options = null, IRegularization<T, Matrix<T>, Vector<T>>? regularization = null)
-        : base(options, regularization, new CrossEntropyLoss<T>())
+        : base(options, regularization, new CrossEntropyWithLogitsLoss<T>())
     {
         _options = options ?? new OrdinalRegressionOptions<T>();
         TaskType = ClassificationTaskType.Ordinal;

--- a/src/Classification/Trees/DecisionTreeClassifier.cs
+++ b/src/Classification/Trees/DecisionTreeClassifier.cs
@@ -83,7 +83,7 @@ public class DecisionTreeClassifier<T> : ProbabilisticClassifierBase<T>, ITreeBa
     /// <param name="regularization">Optional regularization strategy.</param>
     public DecisionTreeClassifier(DecisionTreeClassifierOptions<T>? options = null,
         IRegularization<T, Matrix<T>, Vector<T>>? regularization = null)
-        : base(options ?? new DecisionTreeClassifierOptions<T>(), regularization, new CrossEntropyLoss<T>())
+        : base(options ?? new DecisionTreeClassifierOptions<T>(), regularization, new CrossEntropyWithLogitsLoss<T>())
     {
     }
 

--- a/src/ComputerVision/Segmentation/Common/SegmentationModelBase.cs
+++ b/src/ComputerVision/Segmentation/Common/SegmentationModelBase.cs
@@ -118,7 +118,7 @@ public abstract class SegmentationModelBase<T> : NeuralNetworkBase<T>, ISegmenta
         IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>>? optimizer,
         ILossFunction<T>? lossFunction,
         int numClasses)
-        : base(architecture, lossFunction ?? new CrossEntropyLoss<T>())
+        : base(architecture, lossFunction ?? new CrossEntropyWithLogitsLoss<T>())
     {
         if (numClasses <= 0)
             throw new ArgumentOutOfRangeException(nameof(numClasses), "numClasses must be > 0.");
@@ -144,7 +144,7 @@ public abstract class SegmentationModelBase<T> : NeuralNetworkBase<T>, ISegmenta
         NeuralNetworkArchitecture<T> architecture,
         string onnxModelPath,
         int numClasses)
-        : base(architecture, new CrossEntropyLoss<T>())
+        : base(architecture, new CrossEntropyWithLogitsLoss<T>())
     {
         if (numClasses <= 0)
             throw new ArgumentOutOfRangeException(nameof(numClasses), "numClasses must be > 0.");

--- a/src/ComputerVision/Segmentation/Diffusion/DiffCutSegmentation.cs
+++ b/src/ComputerVision/Segmentation/Diffusion/DiffCutSegmentation.cs
@@ -109,7 +109,7 @@ public class DiffCutSegmentation<T> : NeuralNetworkBase<T>, ISemanticSegmentatio
         ILossFunction<T>? lossFunction = null, int numClasses = 1,
         double dropRate = 0,
         DiffCutSegmentationOptions? options = null)
-        : base(architecture, lossFunction ?? new CrossEntropyLoss<T>())
+        : base(architecture, lossFunction ?? new CrossEntropyWithLogitsLoss<T>())
     {
         _options = options ?? new DiffCutSegmentationOptions(); Options = _options;
         _height = architecture.InputHeight > 0 ? architecture.InputHeight : 512;
@@ -142,7 +142,7 @@ public class DiffCutSegmentation<T> : NeuralNetworkBase<T>, ISemanticSegmentatio
     public DiffCutSegmentation(NeuralNetworkArchitecture<T> architecture, string onnxModelPath,
         int numClasses = 1,
         DiffCutSegmentationOptions? options = null)
-        : base(architecture, new CrossEntropyLoss<T>())
+        : base(architecture, new CrossEntropyWithLogitsLoss<T>())
     {
         _options = options ?? new DiffCutSegmentationOptions(); Options = _options;
         if (string.IsNullOrWhiteSpace(onnxModelPath))

--- a/src/ComputerVision/Segmentation/Diffusion/MedSegDiffV2Segmentation.cs
+++ b/src/ComputerVision/Segmentation/Diffusion/MedSegDiffV2Segmentation.cs
@@ -111,7 +111,7 @@ public class MedSegDiffV2Segmentation<T> : NeuralNetworkBase<T>, IMedicalSegment
         ILossFunction<T>? lossFunction = null, int numClasses = 1,
         double dropRate = 0,
         MedSegDiffV2SegmentationOptions? options = null)
-        : base(architecture, lossFunction ?? new CrossEntropyLoss<T>())
+        : base(architecture, lossFunction ?? new CrossEntropyWithLogitsLoss<T>())
     {
         _options = options ?? new MedSegDiffV2SegmentationOptions(); Options = _options;
         _height = architecture.InputHeight > 0 ? architecture.InputHeight : 256;
@@ -144,7 +144,7 @@ public class MedSegDiffV2Segmentation<T> : NeuralNetworkBase<T>, IMedicalSegment
     public MedSegDiffV2Segmentation(NeuralNetworkArchitecture<T> architecture, string onnxModelPath,
         int numClasses = 1,
         MedSegDiffV2SegmentationOptions? options = null)
-        : base(architecture, new CrossEntropyLoss<T>())
+        : base(architecture, new CrossEntropyWithLogitsLoss<T>())
     {
         _options = options ?? new MedSegDiffV2SegmentationOptions(); Options = _options;
         if (string.IsNullOrWhiteSpace(onnxModelPath))

--- a/src/ComputerVision/Segmentation/Diffusion/ODISESegmentation.cs
+++ b/src/ComputerVision/Segmentation/Diffusion/ODISESegmentation.cs
@@ -109,7 +109,7 @@ public class ODISESegmentation<T> : NeuralNetworkBase<T>, IPanopticSegmentation<
         ILossFunction<T>? lossFunction = null, int numClasses = 133,
         double dropRate = 0.1,
         ODISESegmentationOptions? options = null)
-        : base(architecture, lossFunction ?? new CrossEntropyLoss<T>())
+        : base(architecture, lossFunction ?? new CrossEntropyWithLogitsLoss<T>())
     {
         _options = options ?? new ODISESegmentationOptions(); Options = _options;
         _height = architecture.InputHeight > 0 ? architecture.InputHeight : 512;
@@ -142,7 +142,7 @@ public class ODISESegmentation<T> : NeuralNetworkBase<T>, IPanopticSegmentation<
     public ODISESegmentation(NeuralNetworkArchitecture<T> architecture, string onnxModelPath,
         int numClasses = 133,
         ODISESegmentationOptions? options = null)
-        : base(architecture, new CrossEntropyLoss<T>())
+        : base(architecture, new CrossEntropyWithLogitsLoss<T>())
     {
         _options = options ?? new ODISESegmentationOptions(); Options = _options;
         if (string.IsNullOrWhiteSpace(onnxModelPath))

--- a/src/ComputerVision/Segmentation/Efficient/EdgeSAM.cs
+++ b/src/ComputerVision/Segmentation/Efficient/EdgeSAM.cs
@@ -108,7 +108,7 @@ public class EdgeSAM<T> : NeuralNetworkBase<T>, IPromptableSegmentation<T>
         ILossFunction<T>? lossFunction = null, int numClasses = 1,
         double dropRate = 0,
         EdgeSAMOptions? options = null)
-        : base(architecture, lossFunction ?? new CrossEntropyLoss<T>())
+        : base(architecture, lossFunction ?? new CrossEntropyWithLogitsLoss<T>())
     {
         _options = options ?? new EdgeSAMOptions(); Options = _options;
         _height = architecture.InputHeight > 0 ? architecture.InputHeight : 1024;
@@ -141,7 +141,7 @@ public class EdgeSAM<T> : NeuralNetworkBase<T>, IPromptableSegmentation<T>
     public EdgeSAM(NeuralNetworkArchitecture<T> architecture, string onnxModelPath,
         int numClasses = 1,
         EdgeSAMOptions? options = null)
-        : base(architecture, new CrossEntropyLoss<T>())
+        : base(architecture, new CrossEntropyWithLogitsLoss<T>())
     {
         _options = options ?? new EdgeSAMOptions(); Options = _options;
         if (string.IsNullOrWhiteSpace(onnxModelPath))

--- a/src/ComputerVision/Segmentation/Efficient/EfficientSAM.cs
+++ b/src/ComputerVision/Segmentation/Efficient/EfficientSAM.cs
@@ -105,7 +105,7 @@ public class EfficientSAM<T> : NeuralNetworkBase<T>, IPromptableSegmentation<T>
         ILossFunction<T>? lossFunction = null, int numClasses = 1,
         double dropRate = 0,
         EfficientSAMOptions? options = null)
-        : base(architecture, lossFunction ?? new CrossEntropyLoss<T>())
+        : base(architecture, lossFunction ?? new CrossEntropyWithLogitsLoss<T>())
     {
         _options = options ?? new EfficientSAMOptions(); Options = _options;
         _height = architecture.InputHeight > 0 ? architecture.InputHeight : 1024;
@@ -138,7 +138,7 @@ public class EfficientSAM<T> : NeuralNetworkBase<T>, IPromptableSegmentation<T>
     public EfficientSAM(NeuralNetworkArchitecture<T> architecture, string onnxModelPath,
         int numClasses = 1,
         EfficientSAMOptions? options = null)
-        : base(architecture, new CrossEntropyLoss<T>())
+        : base(architecture, new CrossEntropyWithLogitsLoss<T>())
     {
         _options = options ?? new EfficientSAMOptions(); Options = _options;
         if (string.IsNullOrWhiteSpace(onnxModelPath))

--- a/src/ComputerVision/Segmentation/Efficient/FastSAM.cs
+++ b/src/ComputerVision/Segmentation/Efficient/FastSAM.cs
@@ -105,7 +105,7 @@ public class FastSAM<T> : NeuralNetworkBase<T>, IPromptableSegmentation<T>
         ILossFunction<T>? lossFunction = null, int numClasses = 1,
         double dropRate = 0,
         FastSAMOptions? options = null)
-        : base(architecture, lossFunction ?? new CrossEntropyLoss<T>())
+        : base(architecture, lossFunction ?? new CrossEntropyWithLogitsLoss<T>())
     {
         if (numClasses <= 0)
             throw new ArgumentOutOfRangeException(nameof(numClasses), "numClasses must be > 0.");
@@ -142,7 +142,7 @@ public class FastSAM<T> : NeuralNetworkBase<T>, IPromptableSegmentation<T>
     public FastSAM(NeuralNetworkArchitecture<T> architecture, string onnxModelPath,
         int numClasses = 1,
         FastSAMOptions? options = null)
-        : base(architecture, new CrossEntropyLoss<T>())
+        : base(architecture, new CrossEntropyWithLogitsLoss<T>())
     {
         if (numClasses <= 0)
             throw new ArgumentOutOfRangeException(nameof(numClasses), "numClasses must be > 0.");

--- a/src/ComputerVision/Segmentation/Efficient/MobileSAM.cs
+++ b/src/ComputerVision/Segmentation/Efficient/MobileSAM.cs
@@ -105,7 +105,7 @@ public class MobileSAM<T> : NeuralNetworkBase<T>, IPromptableSegmentation<T>
         ILossFunction<T>? lossFunction = null, int numClasses = 1,
         double dropRate = 0,
         MobileSAMOptions? options = null)
-        : base(architecture, lossFunction ?? new CrossEntropyLoss<T>())
+        : base(architecture, lossFunction ?? new CrossEntropyWithLogitsLoss<T>())
     {
         _options = options ?? new MobileSAMOptions(); Options = _options;
         _height = architecture.InputHeight > 0 ? architecture.InputHeight : 1024;
@@ -138,7 +138,7 @@ public class MobileSAM<T> : NeuralNetworkBase<T>, IPromptableSegmentation<T>
     public MobileSAM(NeuralNetworkArchitecture<T> architecture, string onnxModelPath,
         int numClasses = 1,
         MobileSAMOptions? options = null)
-        : base(architecture, new CrossEntropyLoss<T>())
+        : base(architecture, new CrossEntropyWithLogitsLoss<T>())
     {
         _options = options ?? new MobileSAMOptions(); Options = _options;
         if (string.IsNullOrWhiteSpace(onnxModelPath))

--- a/src/ComputerVision/Segmentation/Efficient/PIDNet.cs
+++ b/src/ComputerVision/Segmentation/Efficient/PIDNet.cs
@@ -113,7 +113,7 @@ public class PIDNet<T> : NeuralNetworkBase<T>, ISemanticSegmentation<T>
         ILossFunction<T>? lossFunction = null, int numClasses = 19,
         PIDNetModelSize modelSize = PIDNetModelSize.Small, double dropRate = 0.1,
         PIDNetOptions? options = null)
-        : base(architecture, lossFunction ?? new CrossEntropyLoss<T>())
+        : base(architecture, lossFunction ?? new CrossEntropyWithLogitsLoss<T>())
     {
         _options = options ?? new PIDNetOptions(); Options = _options;
         _height = architecture.InputHeight > 0 ? architecture.InputHeight : 1024;
@@ -145,7 +145,7 @@ public class PIDNet<T> : NeuralNetworkBase<T>, ISemanticSegmentation<T>
     public PIDNet(NeuralNetworkArchitecture<T> architecture, string onnxModelPath,
         int numClasses = 19, PIDNetModelSize modelSize = PIDNetModelSize.Small,
         PIDNetOptions? options = null)
-        : base(architecture, new CrossEntropyLoss<T>())
+        : base(architecture, new CrossEntropyWithLogitsLoss<T>())
     {
         _options = options ?? new PIDNetOptions(); Options = _options;
         if (string.IsNullOrWhiteSpace(onnxModelPath))

--- a/src/ComputerVision/Segmentation/Efficient/RepViTSAM.cs
+++ b/src/ComputerVision/Segmentation/Efficient/RepViTSAM.cs
@@ -105,7 +105,7 @@ public class RepViTSAM<T> : NeuralNetworkBase<T>, IPromptableSegmentation<T>
         ILossFunction<T>? lossFunction = null, int numClasses = 1,
         double dropRate = 0,
         RepViTSAMOptions? options = null)
-        : base(architecture, lossFunction ?? new CrossEntropyLoss<T>())
+        : base(architecture, lossFunction ?? new CrossEntropyWithLogitsLoss<T>())
     {
         _options = options ?? new RepViTSAMOptions(); Options = _options;
         _height = architecture.InputHeight > 0 ? architecture.InputHeight : 1024;
@@ -138,7 +138,7 @@ public class RepViTSAM<T> : NeuralNetworkBase<T>, IPromptableSegmentation<T>
     public RepViTSAM(NeuralNetworkArchitecture<T> architecture, string onnxModelPath,
         int numClasses = 1,
         RepViTSAMOptions? options = null)
-        : base(architecture, new CrossEntropyLoss<T>())
+        : base(architecture, new CrossEntropyWithLogitsLoss<T>())
     {
         _options = options ?? new RepViTSAMOptions(); Options = _options;
         if (string.IsNullOrWhiteSpace(onnxModelPath))

--- a/src/ComputerVision/Segmentation/Efficient/SlimSAM.cs
+++ b/src/ComputerVision/Segmentation/Efficient/SlimSAM.cs
@@ -108,7 +108,7 @@ public class SlimSAM<T> : NeuralNetworkBase<T>, IPromptableSegmentation<T>
         ILossFunction<T>? lossFunction = null, int numClasses = 1,
         double dropRate = 0,
         SlimSAMOptions? options = null)
-        : base(architecture, lossFunction ?? new CrossEntropyLoss<T>())
+        : base(architecture, lossFunction ?? new CrossEntropyWithLogitsLoss<T>())
     {
         _options = options ?? new SlimSAMOptions(); Options = _options;
         _height = architecture.InputHeight > 0 ? architecture.InputHeight : 1024;
@@ -141,7 +141,7 @@ public class SlimSAM<T> : NeuralNetworkBase<T>, IPromptableSegmentation<T>
     public SlimSAM(NeuralNetworkArchitecture<T> architecture, string onnxModelPath,
         int numClasses = 1,
         SlimSAMOptions? options = null)
-        : base(architecture, new CrossEntropyLoss<T>())
+        : base(architecture, new CrossEntropyWithLogitsLoss<T>())
     {
         _options = options ?? new SlimSAMOptions(); Options = _options;
         if (string.IsNullOrWhiteSpace(onnxModelPath))

--- a/src/ComputerVision/Segmentation/Foundation/EoMT.cs
+++ b/src/ComputerVision/Segmentation/Foundation/EoMT.cs
@@ -140,7 +140,7 @@ public class EoMT<T> : NeuralNetworkBase<T>, IPanopticSegmentation<T>
         EoMTModelSize modelSize = EoMTModelSize.Base,
         double dropRate = 0.1,
         EoMTOptions? options = null)
-        : base(architecture, lossFunction ?? new CrossEntropyLoss<T>())
+        : base(architecture, lossFunction ?? new CrossEntropyWithLogitsLoss<T>())
     {
         _options = options ?? new EoMTOptions();
         Options = _options;
@@ -183,7 +183,7 @@ public class EoMT<T> : NeuralNetworkBase<T>, IPanopticSegmentation<T>
         int numQueries = 100,
         EoMTModelSize modelSize = EoMTModelSize.Base,
         EoMTOptions? options = null)
-        : base(architecture, new CrossEntropyLoss<T>())
+        : base(architecture, new CrossEntropyWithLogitsLoss<T>())
     {
         _options = options ?? new EoMTOptions();
         Options = _options;

--- a/src/ComputerVision/Segmentation/Foundation/Mask2Former.cs
+++ b/src/ComputerVision/Segmentation/Foundation/Mask2Former.cs
@@ -150,7 +150,7 @@ public class Mask2Former<T> : NeuralNetworkBase<T>, IPanopticSegmentation<T>
         Mask2FormerModelSize modelSize = Mask2FormerModelSize.SwinTiny,
         double dropRate = 0.1,
         Mask2FormerOptions? options = null)
-        : base(architecture, lossFunction ?? new CrossEntropyLoss<T>())
+        : base(architecture, lossFunction ?? new CrossEntropyWithLogitsLoss<T>())
     {
         _options = options ?? new Mask2FormerOptions();
         Options = _options;
@@ -193,7 +193,7 @@ public class Mask2Former<T> : NeuralNetworkBase<T>, IPanopticSegmentation<T>
         int numQueries = 100,
         Mask2FormerModelSize modelSize = Mask2FormerModelSize.SwinTiny,
         Mask2FormerOptions? options = null)
-        : base(architecture, new CrossEntropyLoss<T>())
+        : base(architecture, new CrossEntropyWithLogitsLoss<T>())
     {
         _options = options ?? new Mask2FormerOptions();
         Options = _options;

--- a/src/ComputerVision/Segmentation/Foundation/MaskDINO.cs
+++ b/src/ComputerVision/Segmentation/Foundation/MaskDINO.cs
@@ -143,7 +143,7 @@ public class MaskDINO<T> : NeuralNetworkBase<T>, IPanopticSegmentation<T>
         MaskDINOModelSize modelSize = MaskDINOModelSize.R50,
         double dropRate = 0.1,
         MaskDINOOptions? options = null)
-        : base(architecture, lossFunction ?? new CrossEntropyLoss<T>())
+        : base(architecture, lossFunction ?? new CrossEntropyWithLogitsLoss<T>())
     {
         _options = options ?? new MaskDINOOptions();
         Options = _options;
@@ -186,7 +186,7 @@ public class MaskDINO<T> : NeuralNetworkBase<T>, IPanopticSegmentation<T>
         int numQueries = 300,
         MaskDINOModelSize modelSize = MaskDINOModelSize.R50,
         MaskDINOOptions? options = null)
-        : base(architecture, new CrossEntropyLoss<T>())
+        : base(architecture, new CrossEntropyWithLogitsLoss<T>())
     {
         _options = options ?? new MaskDINOOptions();
         Options = _options;

--- a/src/ComputerVision/Segmentation/Foundation/OMGSeg.cs
+++ b/src/ComputerVision/Segmentation/Foundation/OMGSeg.cs
@@ -142,7 +142,7 @@ public class OMGSeg<T> : NeuralNetworkBase<T>, IPanopticSegmentation<T>
         OMGSegModelSize modelSize = OMGSegModelSize.Base,
         double dropRate = 0.1,
         OMGSegOptions? options = null)
-        : base(architecture, lossFunction ?? new CrossEntropyLoss<T>())
+        : base(architecture, lossFunction ?? new CrossEntropyWithLogitsLoss<T>())
     {
         _options = options ?? new OMGSegOptions();
         Options = _options;
@@ -185,7 +185,7 @@ public class OMGSeg<T> : NeuralNetworkBase<T>, IPanopticSegmentation<T>
         int numQueries = 200,
         OMGSegModelSize modelSize = OMGSegModelSize.Base,
         OMGSegOptions? options = null)
-        : base(architecture, new CrossEntropyLoss<T>())
+        : base(architecture, new CrossEntropyWithLogitsLoss<T>())
     {
         _options = options ?? new OMGSegOptions();
         Options = _options;

--- a/src/ComputerVision/Segmentation/Foundation/OneFormer.cs
+++ b/src/ComputerVision/Segmentation/Foundation/OneFormer.cs
@@ -150,7 +150,7 @@ public class OneFormer<T> : NeuralNetworkBase<T>, IPanopticSegmentation<T>
         OneFormerModelSize modelSize = OneFormerModelSize.SwinLarge,
         double dropRate = 0.1,
         OneFormerOptions? options = null)
-        : base(architecture, lossFunction ?? new CrossEntropyLoss<T>())
+        : base(architecture, lossFunction ?? new CrossEntropyWithLogitsLoss<T>())
     {
         _options = options ?? new OneFormerOptions();
         Options = _options;
@@ -193,7 +193,7 @@ public class OneFormer<T> : NeuralNetworkBase<T>, IPanopticSegmentation<T>
         int numQueries = 150,
         OneFormerModelSize modelSize = OneFormerModelSize.SwinLarge,
         OneFormerOptions? options = null)
-        : base(architecture, new CrossEntropyLoss<T>())
+        : base(architecture, new CrossEntropyWithLogitsLoss<T>())
     {
         _options = options ?? new OneFormerOptions();
         Options = _options;

--- a/src/ComputerVision/Segmentation/Foundation/QueryMeldNet.cs
+++ b/src/ComputerVision/Segmentation/Foundation/QueryMeldNet.cs
@@ -140,7 +140,7 @@ public class QueryMeldNet<T> : NeuralNetworkBase<T>, IPanopticSegmentation<T>
         QueryMeldNetModelSize modelSize = QueryMeldNetModelSize.R50,
         double dropRate = 0.1,
         QueryMeldNetOptions? options = null)
-        : base(architecture, lossFunction ?? new CrossEntropyLoss<T>())
+        : base(architecture, lossFunction ?? new CrossEntropyWithLogitsLoss<T>())
     {
         _options = options ?? new QueryMeldNetOptions();
         Options = _options;
@@ -183,7 +183,7 @@ public class QueryMeldNet<T> : NeuralNetworkBase<T>, IPanopticSegmentation<T>
         int numQueries = 200,
         QueryMeldNetModelSize modelSize = QueryMeldNetModelSize.R50,
         QueryMeldNetOptions? options = null)
-        : base(architecture, new CrossEntropyLoss<T>())
+        : base(architecture, new CrossEntropyWithLogitsLoss<T>())
     {
         _options = options ?? new QueryMeldNetOptions();
         Options = _options;

--- a/src/ComputerVision/Segmentation/Foundation/SAM.cs
+++ b/src/ComputerVision/Segmentation/Foundation/SAM.cs
@@ -128,7 +128,9 @@ public class SAM<T> : NeuralNetworkBase<T>, IPromptableSegmentation<T>
         SAMModelSize modelSize = SAMModelSize.ViTHuge,
         double dropRate = 0.1,
         SAMOptions? options = null)
-        : base(architecture, lossFunction ?? new CrossEntropyWithLogitsLoss<T>())
+        : base(architecture, lossFunction ?? (numClasses == 1
+            ? (ILossFunction<T>)new BinaryCrossEntropyWithLogitsLoss<T>()
+            : new CrossEntropyWithLogitsLoss<T>()))
     {
         _options = options ?? new SAMOptions();
         Options = _options;
@@ -169,7 +171,9 @@ public class SAM<T> : NeuralNetworkBase<T>, IPromptableSegmentation<T>
         int numClasses = 1,
         SAMModelSize modelSize = SAMModelSize.ViTHuge,
         SAMOptions? options = null)
-        : base(architecture, new CrossEntropyWithLogitsLoss<T>())
+        : base(architecture, numClasses == 1
+            ? (ILossFunction<T>)new BinaryCrossEntropyWithLogitsLoss<T>()
+            : new CrossEntropyWithLogitsLoss<T>())
     {
         _options = options ?? new SAMOptions();
         Options = _options;

--- a/src/ComputerVision/Segmentation/Foundation/SAM.cs
+++ b/src/ComputerVision/Segmentation/Foundation/SAM.cs
@@ -128,7 +128,7 @@ public class SAM<T> : NeuralNetworkBase<T>, IPromptableSegmentation<T>
         SAMModelSize modelSize = SAMModelSize.ViTHuge,
         double dropRate = 0.1,
         SAMOptions? options = null)
-        : base(architecture, lossFunction ?? new CrossEntropyLoss<T>())
+        : base(architecture, lossFunction ?? new CrossEntropyWithLogitsLoss<T>())
     {
         _options = options ?? new SAMOptions();
         Options = _options;
@@ -169,7 +169,7 @@ public class SAM<T> : NeuralNetworkBase<T>, IPromptableSegmentation<T>
         int numClasses = 1,
         SAMModelSize modelSize = SAMModelSize.ViTHuge,
         SAMOptions? options = null)
-        : base(architecture, new CrossEntropyLoss<T>())
+        : base(architecture, new CrossEntropyWithLogitsLoss<T>())
     {
         _options = options ?? new SAMOptions();
         Options = _options;

--- a/src/ComputerVision/Segmentation/Foundation/SAM.cs
+++ b/src/ComputerVision/Segmentation/Foundation/SAM.cs
@@ -108,7 +108,7 @@ public class SAM<T> : NeuralNetworkBase<T>, IPromptableSegmentation<T>
     /// </summary>
     /// <param name="architecture">Neural network architecture defining input dimensions.</param>
     /// <param name="optimizer">Gradient-based optimizer (default: AdamW).</param>
-    /// <param name="lossFunction">Loss function (default: CrossEntropyLoss; the paper uses focal + dice + IoU loss).</param>
+    /// <param name="lossFunction">Loss function (default: <see cref="BinaryCrossEntropyWithLogitsLoss{T}"/> when <paramref name="numClasses"/> == 1; otherwise <see cref="CrossEntropyWithLogitsLoss{T}"/>; the paper uses focal + dice + IoU loss).</param>
     /// <param name="numClasses">Number of output mask classes (default: 1 for binary segmentation).</param>
     /// <param name="modelSize">ViT backbone size (default: ViTHuge — the original SAM default).</param>
     /// <param name="dropRate">Dropout rate (default: 0.1).</param>

--- a/src/ComputerVision/Segmentation/Foundation/SAM21.cs
+++ b/src/ComputerVision/Segmentation/Foundation/SAM21.cs
@@ -133,7 +133,7 @@ public class SAM21<T> : NeuralNetworkBase<T>, IPromptableSegmentation<T>
         SAM21ModelSize modelSize = SAM21ModelSize.Large,
         double dropRate = 0.1,
         SAM21Options? options = null)
-        : base(architecture, lossFunction ?? new CrossEntropyLoss<T>())
+        : base(architecture, lossFunction ?? new CrossEntropyWithLogitsLoss<T>())
     {
         _options = options ?? new SAM21Options();
         Options = _options;
@@ -170,7 +170,7 @@ public class SAM21<T> : NeuralNetworkBase<T>, IPromptableSegmentation<T>
         int numClasses = 1,
         SAM21ModelSize modelSize = SAM21ModelSize.Large,
         SAM21Options? options = null)
-        : base(architecture, new CrossEntropyLoss<T>())
+        : base(architecture, new CrossEntropyWithLogitsLoss<T>())
     {
         _options = options ?? new SAM21Options();
         Options = _options;

--- a/src/ComputerVision/Segmentation/Foundation/SAMHQ.cs
+++ b/src/ComputerVision/Segmentation/Foundation/SAMHQ.cs
@@ -142,7 +142,7 @@ public class SAMHQ<T> : NeuralNetworkBase<T>, IPromptableSegmentation<T>
         SAMHQModelSize modelSize = SAMHQModelSize.ViTBase,
         double dropRate = 0.1,
         SAMHQOptions? options = null)
-        : base(architecture, lossFunction ?? new CrossEntropyLoss<T>())
+        : base(architecture, lossFunction ?? new CrossEntropyWithLogitsLoss<T>())
     {
         _options = options ?? new SAMHQOptions();
         Options = _options;
@@ -183,7 +183,7 @@ public class SAMHQ<T> : NeuralNetworkBase<T>, IPromptableSegmentation<T>
         int numClasses = 1,
         SAMHQModelSize modelSize = SAMHQModelSize.ViTBase,
         SAMHQOptions? options = null)
-        : base(architecture, new CrossEntropyLoss<T>())
+        : base(architecture, new CrossEntropyWithLogitsLoss<T>())
     {
         _options = options ?? new SAMHQOptions();
         Options = _options;

--- a/src/ComputerVision/Segmentation/Foundation/U2Seg.cs
+++ b/src/ComputerVision/Segmentation/Foundation/U2Seg.cs
@@ -134,7 +134,7 @@ public class U2Seg<T> : NeuralNetworkBase<T>, IPanopticSegmentation<T>
         int numClasses = 150,
         double dropRate = 0.1,
         U2SegOptions? options = null)
-        : base(architecture, lossFunction ?? new CrossEntropyLoss<T>())
+        : base(architecture, lossFunction ?? new CrossEntropyWithLogitsLoss<T>())
     {
         _options = options ?? new U2SegOptions();
         Options = _options;
@@ -174,7 +174,7 @@ public class U2Seg<T> : NeuralNetworkBase<T>, IPanopticSegmentation<T>
         string onnxModelPath,
         int numClasses = 150,
         U2SegOptions? options = null)
-        : base(architecture, new CrossEntropyLoss<T>())
+        : base(architecture, new CrossEntropyWithLogitsLoss<T>())
     {
         _options = options ?? new U2SegOptions();
         Options = _options;

--- a/src/ComputerVision/Segmentation/Foundation/UNINEXT.cs
+++ b/src/ComputerVision/Segmentation/Foundation/UNINEXT.cs
@@ -143,7 +143,7 @@ public class UNINEXT<T> : NeuralNetworkBase<T>, IPanopticSegmentation<T>
         UNINEXTModelSize modelSize = UNINEXTModelSize.R50,
         double dropRate = 0.1,
         UNINEXTOptions? options = null)
-        : base(architecture, lossFunction ?? new CrossEntropyLoss<T>())
+        : base(architecture, lossFunction ?? new CrossEntropyWithLogitsLoss<T>())
     {
         _options = options ?? new UNINEXTOptions();
         Options = _options;
@@ -186,7 +186,7 @@ public class UNINEXT<T> : NeuralNetworkBase<T>, IPanopticSegmentation<T>
         int numQueries = 300,
         UNINEXTModelSize modelSize = UNINEXTModelSize.R50,
         UNINEXTOptions? options = null)
-        : base(architecture, new CrossEntropyLoss<T>())
+        : base(architecture, new CrossEntropyWithLogitsLoss<T>())
     {
         _options = options ?? new UNINEXTOptions();
         Options = _options;

--- a/src/ComputerVision/Segmentation/Foundation/XDecoder.cs
+++ b/src/ComputerVision/Segmentation/Foundation/XDecoder.cs
@@ -145,7 +145,7 @@ public class XDecoder<T> : NeuralNetworkBase<T>, IPanopticSegmentation<T>
         XDecoderModelSize modelSize = XDecoderModelSize.Tiny,
         double dropRate = 0.1,
         XDecoderOptions? options = null)
-        : base(architecture, lossFunction ?? new CrossEntropyLoss<T>())
+        : base(architecture, lossFunction ?? new CrossEntropyWithLogitsLoss<T>())
     {
         if (numClasses <= 0)
             throw new ArgumentOutOfRangeException(nameof(numClasses), "numClasses must be > 0.");
@@ -195,7 +195,7 @@ public class XDecoder<T> : NeuralNetworkBase<T>, IPanopticSegmentation<T>
         int numQueries = 100,
         XDecoderModelSize modelSize = XDecoderModelSize.Tiny,
         XDecoderOptions? options = null)
-        : base(architecture, new CrossEntropyLoss<T>())
+        : base(architecture, new CrossEntropyWithLogitsLoss<T>())
     {
         if (numClasses <= 0)
             throw new ArgumentOutOfRangeException(nameof(numClasses), "numClasses must be > 0.");

--- a/src/ComputerVision/Segmentation/InstanceSegmentation/YOLO11Seg.cs
+++ b/src/ComputerVision/Segmentation/InstanceSegmentation/YOLO11Seg.cs
@@ -113,7 +113,7 @@ public class YOLO11Seg<T> : NeuralNetworkBase<T>, IInstanceSegmentation<T>
         ILossFunction<T>? lossFunction = null, int numClasses = 80,
         YOLO11SegModelSize modelSize = YOLO11SegModelSize.N, double dropRate = 0,
         YOLO11SegOptions? options = null)
-        : base(architecture, lossFunction ?? new CrossEntropyLoss<T>())
+        : base(architecture, lossFunction ?? new CrossEntropyWithLogitsLoss<T>())
     {
         _options = options ?? new YOLO11SegOptions(); Options = _options;
         _height = architecture.InputHeight > 0 ? architecture.InputHeight : 640;
@@ -145,7 +145,7 @@ public class YOLO11Seg<T> : NeuralNetworkBase<T>, IInstanceSegmentation<T>
     public YOLO11Seg(NeuralNetworkArchitecture<T> architecture, string onnxModelPath,
         int numClasses = 80, YOLO11SegModelSize modelSize = YOLO11SegModelSize.N,
         YOLO11SegOptions? options = null)
-        : base(architecture, new CrossEntropyLoss<T>())
+        : base(architecture, new CrossEntropyWithLogitsLoss<T>())
     {
         _options = options ?? new YOLO11SegOptions(); Options = _options;
         if (string.IsNullOrWhiteSpace(onnxModelPath))

--- a/src/ComputerVision/Segmentation/InstanceSegmentation/YOLO26Seg.cs
+++ b/src/ComputerVision/Segmentation/InstanceSegmentation/YOLO26Seg.cs
@@ -113,7 +113,7 @@ public class YOLO26Seg<T> : NeuralNetworkBase<T>, IInstanceSegmentation<T>
         ILossFunction<T>? lossFunction = null, int numClasses = 80,
         YOLO26SegModelSize modelSize = YOLO26SegModelSize.N, double dropRate = 0,
         YOLO26SegOptions? options = null)
-        : base(architecture, lossFunction ?? new CrossEntropyLoss<T>())
+        : base(architecture, lossFunction ?? new CrossEntropyWithLogitsLoss<T>())
     {
         _options = options ?? new YOLO26SegOptions(); Options = _options;
         _height = architecture.InputHeight > 0 ? architecture.InputHeight : 640;
@@ -145,7 +145,7 @@ public class YOLO26Seg<T> : NeuralNetworkBase<T>, IInstanceSegmentation<T>
     public YOLO26Seg(NeuralNetworkArchitecture<T> architecture, string onnxModelPath,
         int numClasses = 80, YOLO26SegModelSize modelSize = YOLO26SegModelSize.N,
         YOLO26SegOptions? options = null)
-        : base(architecture, new CrossEntropyLoss<T>())
+        : base(architecture, new CrossEntropyWithLogitsLoss<T>())
     {
         _options = options ?? new YOLO26SegOptions(); Options = _options;
         if (string.IsNullOrWhiteSpace(onnxModelPath))

--- a/src/ComputerVision/Segmentation/InstanceSegmentation/YOLOv8Seg.cs
+++ b/src/ComputerVision/Segmentation/InstanceSegmentation/YOLOv8Seg.cs
@@ -110,7 +110,7 @@ public class YOLOv8Seg<T> : NeuralNetworkBase<T>, IInstanceSegmentation<T>
         YOLOv8SegModelSize modelSize = YOLOv8SegModelSize.N,
         double dropRate = 0,
         YOLOv8SegOptions? options = null)
-        : base(architecture, lossFunction ?? new CrossEntropyLoss<T>())
+        : base(architecture, lossFunction ?? new CrossEntropyWithLogitsLoss<T>())
     {
         _options = options ?? new YOLOv8SegOptions();
         Options = _options;
@@ -145,7 +145,7 @@ public class YOLOv8Seg<T> : NeuralNetworkBase<T>, IInstanceSegmentation<T>
         int numClasses = 80,
         YOLOv8SegModelSize modelSize = YOLOv8SegModelSize.N,
         YOLOv8SegOptions? options = null)
-        : base(architecture, new CrossEntropyLoss<T>())
+        : base(architecture, new CrossEntropyWithLogitsLoss<T>())
     {
         _options = options ?? new YOLOv8SegOptions();
         Options = _options;

--- a/src/ComputerVision/Segmentation/InstanceSegmentation/YOLOv9Seg.cs
+++ b/src/ComputerVision/Segmentation/InstanceSegmentation/YOLOv9Seg.cs
@@ -118,7 +118,7 @@ public class YOLOv9Seg<T> : NeuralNetworkBase<T>, IInstanceSegmentation<T>
         ILossFunction<T>? lossFunction = null, int numClasses = 80,
         YOLOv9SegModelSize modelSize = YOLOv9SegModelSize.C, double dropRate = 0.0,
         YOLOv9SegOptions? options = null)
-        : base(architecture, lossFunction ?? new CrossEntropyLoss<T>())
+        : base(architecture, lossFunction ?? new CrossEntropyWithLogitsLoss<T>())
     {
         _options = options ?? new YOLOv9SegOptions(); Options = _options;
         _height = architecture.InputHeight > 0 ? architecture.InputHeight : 640;
@@ -150,7 +150,7 @@ public class YOLOv9Seg<T> : NeuralNetworkBase<T>, IInstanceSegmentation<T>
     public YOLOv9Seg(NeuralNetworkArchitecture<T> architecture, string onnxModelPath,
         int numClasses = 80, YOLOv9SegModelSize modelSize = YOLOv9SegModelSize.C,
         YOLOv9SegOptions? options = null)
-        : base(architecture, new CrossEntropyLoss<T>())
+        : base(architecture, new CrossEntropyWithLogitsLoss<T>())
     {
         _options = options ?? new YOLOv9SegOptions(); Options = _options;
         if (string.IsNullOrWhiteSpace(onnxModelPath))

--- a/src/ComputerVision/Segmentation/Interactive/SEEM.cs
+++ b/src/ComputerVision/Segmentation/Interactive/SEEM.cs
@@ -113,7 +113,7 @@ public class SEEM<T> : NeuralNetworkBase<T>, IPromptableSegmentation<T>
         ILossFunction<T>? lossFunction = null, int numClasses = 150,
         SEEMModelSize modelSize = SEEMModelSize.Tiny, double dropRate = 0.1,
         SEEMOptions? options = null)
-        : base(architecture, lossFunction ?? new CrossEntropyLoss<T>())
+        : base(architecture, lossFunction ?? new CrossEntropyWithLogitsLoss<T>())
     {
         _options = options ?? new SEEMOptions(); Options = _options;
         _height = architecture.InputHeight > 0 ? architecture.InputHeight : 512;
@@ -145,7 +145,7 @@ public class SEEM<T> : NeuralNetworkBase<T>, IPromptableSegmentation<T>
     public SEEM(NeuralNetworkArchitecture<T> architecture, string onnxModelPath,
         int numClasses = 150, SEEMModelSize modelSize = SEEMModelSize.Tiny,
         SEEMOptions? options = null)
-        : base(architecture, new CrossEntropyLoss<T>())
+        : base(architecture, new CrossEntropyWithLogitsLoss<T>())
     {
         _options = options ?? new SEEMOptions(); Options = _options;
         if (string.IsNullOrWhiteSpace(onnxModelPath))

--- a/src/ComputerVision/Segmentation/Interactive/SegGPT.cs
+++ b/src/ComputerVision/Segmentation/Interactive/SegGPT.cs
@@ -112,7 +112,7 @@ public class SegGPT<T> : NeuralNetworkBase<T>, IPromptableSegmentation<T>
         ILossFunction<T>? lossFunction = null, int numClasses = 1,
         SegGPTModelSize modelSize = SegGPTModelSize.ViTLarge, double dropRate = 0.1,
         SegGPTOptions? options = null)
-        : base(architecture, lossFunction ?? new CrossEntropyLoss<T>())
+        : base(architecture, lossFunction ?? new CrossEntropyWithLogitsLoss<T>())
     {
         _options = options ?? new SegGPTOptions(); Options = _options;
         _height = architecture.InputHeight > 0 ? architecture.InputHeight : 448;
@@ -144,7 +144,7 @@ public class SegGPT<T> : NeuralNetworkBase<T>, IPromptableSegmentation<T>
     public SegGPT(NeuralNetworkArchitecture<T> architecture, string onnxModelPath,
         int numClasses = 1, SegGPTModelSize modelSize = SegGPTModelSize.ViTLarge,
         SegGPTOptions? options = null)
-        : base(architecture, new CrossEntropyLoss<T>())
+        : base(architecture, new CrossEntropyWithLogitsLoss<T>())
     {
         _options = options ?? new SegGPTOptions(); Options = _options;
         if (string.IsNullOrWhiteSpace(onnxModelPath))

--- a/src/ComputerVision/Segmentation/Mamba/VMamba.cs
+++ b/src/ComputerVision/Segmentation/Mamba/VMamba.cs
@@ -111,7 +111,7 @@ public class VMamba<T> : NeuralNetworkBase<T>, ISemanticSegmentation<T>
         ILossFunction<T>? lossFunction = null, int numClasses = 150,
         VMambaModelSize modelSize = VMambaModelSize.Tiny, double dropRate = 0.1,
         VMambaOptions? options = null)
-        : base(architecture, lossFunction ?? new CrossEntropyLoss<T>())
+        : base(architecture, lossFunction ?? new CrossEntropyWithLogitsLoss<T>())
     {
         _options = options ?? new VMambaOptions(); Options = _options;
         _height = architecture.InputHeight > 0 ? architecture.InputHeight : 224;
@@ -143,7 +143,7 @@ public class VMamba<T> : NeuralNetworkBase<T>, ISemanticSegmentation<T>
     public VMamba(NeuralNetworkArchitecture<T> architecture, string onnxModelPath,
         int numClasses = 150, VMambaModelSize modelSize = VMambaModelSize.Tiny,
         VMambaOptions? options = null)
-        : base(architecture, new CrossEntropyLoss<T>())
+        : base(architecture, new CrossEntropyWithLogitsLoss<T>())
     {
         _options = options ?? new VMambaOptions(); Options = _options;
         if (string.IsNullOrWhiteSpace(onnxModelPath))

--- a/src/ComputerVision/Segmentation/Mamba/ViMUNet.cs
+++ b/src/ComputerVision/Segmentation/Mamba/ViMUNet.cs
@@ -95,7 +95,7 @@ public class ViMUNet<T> : NeuralNetworkBase<T>, ISemanticSegmentation<T>
     /// </summary>
     /// <param name="architecture">Neural network architecture defining input dimensions.</param>
     /// <param name="optimizer">Gradient-based optimizer (default: AdamW).</param>
-    /// <param name="lossFunction">Loss function (default: CrossEntropyLoss).</param>
+    /// <param name="lossFunction">Loss function (default: CrossEntropyWithLogitsLoss).</param>
     /// <param name="numClasses">Number of segmentation classes (default: 14).</param>
     /// <param name="dropRate">Dropout rate (default: 0).</param>
     /// <param name="options">Optional model options.</param>

--- a/src/ComputerVision/Segmentation/Mamba/ViMUNet.cs
+++ b/src/ComputerVision/Segmentation/Mamba/ViMUNet.cs
@@ -109,7 +109,7 @@ public class ViMUNet<T> : NeuralNetworkBase<T>, ISemanticSegmentation<T>
         ILossFunction<T>? lossFunction = null, int numClasses = 14,
         double dropRate = 0,
         ViMUNetOptions? options = null)
-        : base(architecture, lossFunction ?? new CrossEntropyLoss<T>())
+        : base(architecture, lossFunction ?? new CrossEntropyWithLogitsLoss<T>())
     {
         _options = options ?? new ViMUNetOptions(); Options = _options;
         _height = architecture.InputHeight > 0 ? architecture.InputHeight : 256;
@@ -142,7 +142,7 @@ public class ViMUNet<T> : NeuralNetworkBase<T>, ISemanticSegmentation<T>
     public ViMUNet(NeuralNetworkArchitecture<T> architecture, string onnxModelPath,
         int numClasses = 14,
         ViMUNetOptions? options = null)
-        : base(architecture, new CrossEntropyLoss<T>())
+        : base(architecture, new CrossEntropyWithLogitsLoss<T>())
     {
         _options = options ?? new ViMUNetOptions(); Options = _options;
         if (string.IsNullOrWhiteSpace(onnxModelPath))

--- a/src/ComputerVision/Segmentation/Mamba/VisionMamba.cs
+++ b/src/ComputerVision/Segmentation/Mamba/VisionMamba.cs
@@ -111,7 +111,7 @@ public class VisionMamba<T> : NeuralNetworkBase<T>, ISemanticSegmentation<T>
         ILossFunction<T>? lossFunction = null, int numClasses = 150,
         VisionMambaModelSize modelSize = VisionMambaModelSize.Tiny, double dropRate = 0.1,
         VisionMambaOptions? options = null)
-        : base(architecture, lossFunction ?? new CrossEntropyLoss<T>())
+        : base(architecture, lossFunction ?? new CrossEntropyWithLogitsLoss<T>())
     {
         _options = options ?? new VisionMambaOptions(); Options = _options;
         _height = architecture.InputHeight > 0 ? architecture.InputHeight : 224;
@@ -143,7 +143,7 @@ public class VisionMamba<T> : NeuralNetworkBase<T>, ISemanticSegmentation<T>
     public VisionMamba(NeuralNetworkArchitecture<T> architecture, string onnxModelPath,
         int numClasses = 150, VisionMambaModelSize modelSize = VisionMambaModelSize.Tiny,
         VisionMambaOptions? options = null)
-        : base(architecture, new CrossEntropyLoss<T>())
+        : base(architecture, new CrossEntropyWithLogitsLoss<T>())
     {
         _options = options ?? new VisionMambaOptions(); Options = _options;
         if (string.IsNullOrWhiteSpace(onnxModelPath))

--- a/src/ComputerVision/Segmentation/Mamba/VisionMamba.cs
+++ b/src/ComputerVision/Segmentation/Mamba/VisionMamba.cs
@@ -96,7 +96,7 @@ public class VisionMamba<T> : NeuralNetworkBase<T>, ISemanticSegmentation<T>
     /// </summary>
     /// <param name="architecture">Neural network architecture defining input dimensions.</param>
     /// <param name="optimizer">Gradient-based optimizer (default: AdamW).</param>
-    /// <param name="lossFunction">Loss function (default: CrossEntropyLoss).</param>
+    /// <param name="lossFunction">Loss function (default: CrossEntropyWithLogitsLoss).</param>
     /// <param name="numClasses">Number of segmentation classes (default: 150).</param>
     /// <param name="modelSize">Model size variant (default: Tiny).</param>
     /// <param name="dropRate">Dropout rate (default: 0.1).</param>

--- a/src/ComputerVision/Segmentation/Medical/BiomedParse.cs
+++ b/src/ComputerVision/Segmentation/Medical/BiomedParse.cs
@@ -100,7 +100,7 @@ public class BiomedParse<T> : NeuralNetworkBase<T>, IMedicalSegmentation<T>
     /// </summary>
     /// <param name="architecture">Neural network architecture defining input dimensions.</param>
     /// <param name="optimizer">Gradient-based optimizer (default: AdamW).</param>
-    /// <param name="lossFunction">Loss function (default: CrossEntropyLoss).</param>
+    /// <param name="lossFunction">Loss function (default: CrossEntropyWithLogitsLoss).</param>
     /// <param name="numClasses">Number of segmentation classes (default: 1).</param>
     /// <param name="dropRate">Dropout rate (default: 0.1).</param>
     /// <param name="options">Optional model options.</param>

--- a/src/ComputerVision/Segmentation/Medical/BiomedParse.cs
+++ b/src/ComputerVision/Segmentation/Medical/BiomedParse.cs
@@ -114,7 +114,7 @@ public class BiomedParse<T> : NeuralNetworkBase<T>, IMedicalSegmentation<T>
         ILossFunction<T>? lossFunction = null, int numClasses = 1,
         double dropRate = 0.1,
         BiomedParseOptions? options = null)
-        : base(architecture, lossFunction ?? new CrossEntropyLoss<T>())
+        : base(architecture, lossFunction ?? new CrossEntropyWithLogitsLoss<T>())
     {
         _options = options ?? new BiomedParseOptions(); Options = _options;
         _height = architecture.InputHeight > 0 ? architecture.InputHeight : 1024;
@@ -147,7 +147,7 @@ public class BiomedParse<T> : NeuralNetworkBase<T>, IMedicalSegmentation<T>
     public BiomedParse(NeuralNetworkArchitecture<T> architecture, string onnxModelPath,
         int numClasses = 1,
         BiomedParseOptions? options = null)
-        : base(architecture, new CrossEntropyLoss<T>())
+        : base(architecture, new CrossEntropyWithLogitsLoss<T>())
     {
         _options = options ?? new BiomedParseOptions(); Options = _options;
         if (string.IsNullOrWhiteSpace(onnxModelPath))

--- a/src/ComputerVision/Segmentation/Medical/MedNeXt.cs
+++ b/src/ComputerVision/Segmentation/Medical/MedNeXt.cs
@@ -112,7 +112,7 @@ public class MedNeXt<T> : NeuralNetworkBase<T>, IMedicalSegmentation<T>
         ILossFunction<T>? lossFunction = null, int numClasses = 14,
         MedNeXtModelSize modelSize = MedNeXtModelSize.Small, double dropRate = 0,
         MedNeXtOptions? options = null)
-        : base(architecture, lossFunction ?? new CrossEntropyLoss<T>())
+        : base(architecture, lossFunction ?? new CrossEntropyWithLogitsLoss<T>())
     {
         _options = options ?? new MedNeXtOptions(); Options = _options;
         _height = architecture.InputHeight > 0 ? architecture.InputHeight : 128;
@@ -144,7 +144,7 @@ public class MedNeXt<T> : NeuralNetworkBase<T>, IMedicalSegmentation<T>
     public MedNeXt(NeuralNetworkArchitecture<T> architecture, string onnxModelPath,
         int numClasses = 14, MedNeXtModelSize modelSize = MedNeXtModelSize.Small,
         MedNeXtOptions? options = null)
-        : base(architecture, new CrossEntropyLoss<T>())
+        : base(architecture, new CrossEntropyWithLogitsLoss<T>())
     {
         _options = options ?? new MedNeXtOptions(); Options = _options;
         if (string.IsNullOrWhiteSpace(onnxModelPath))

--- a/src/ComputerVision/Segmentation/Medical/MedNeXt.cs
+++ b/src/ComputerVision/Segmentation/Medical/MedNeXt.cs
@@ -97,7 +97,7 @@ public class MedNeXt<T> : NeuralNetworkBase<T>, IMedicalSegmentation<T>
     /// </summary>
     /// <param name="architecture">Neural network architecture defining input dimensions.</param>
     /// <param name="optimizer">Gradient-based optimizer (default: AdamW).</param>
-    /// <param name="lossFunction">Loss function (default: CrossEntropyLoss).</param>
+    /// <param name="lossFunction">Loss function (default: CrossEntropyWithLogitsLoss).</param>
     /// <param name="numClasses">Number of segmentation classes (default: 14).</param>
     /// <param name="modelSize">Model size variant (default: Small).</param>
     /// <param name="dropRate">Dropout rate (default: 0).</param>

--- a/src/ComputerVision/Segmentation/Medical/MedSAM.cs
+++ b/src/ComputerVision/Segmentation/Medical/MedSAM.cs
@@ -98,7 +98,7 @@ public class MedSAM<T> : NeuralNetworkBase<T>, IMedicalSegmentation<T>
     /// </summary>
     /// <param name="architecture">Neural network architecture defining input dimensions.</param>
     /// <param name="optimizer">Gradient-based optimizer (default: AdamW).</param>
-    /// <param name="lossFunction">Loss function (default: CrossEntropyLoss).</param>
+    /// <param name="lossFunction">Loss function (default: CrossEntropyWithLogitsLoss).</param>
     /// <param name="numClasses">Number of segmentation classes (default: 1).</param>
     /// <param name="modelSize">Model size variant (default: ViTBase).</param>
     /// <param name="dropRate">Dropout rate (default: 0).</param>

--- a/src/ComputerVision/Segmentation/Medical/MedSAM.cs
+++ b/src/ComputerVision/Segmentation/Medical/MedSAM.cs
@@ -113,7 +113,7 @@ public class MedSAM<T> : NeuralNetworkBase<T>, IMedicalSegmentation<T>
         ILossFunction<T>? lossFunction = null, int numClasses = 1,
         MedSAMModelSize modelSize = MedSAMModelSize.ViTBase, double dropRate = 0,
         MedSAMOptions? options = null)
-        : base(architecture, lossFunction ?? new CrossEntropyLoss<T>())
+        : base(architecture, lossFunction ?? new CrossEntropyWithLogitsLoss<T>())
     {
         _options = options ?? new MedSAMOptions(); Options = _options;
         _height = architecture.InputHeight > 0 ? architecture.InputHeight : 1024;
@@ -145,7 +145,7 @@ public class MedSAM<T> : NeuralNetworkBase<T>, IMedicalSegmentation<T>
     public MedSAM(NeuralNetworkArchitecture<T> architecture, string onnxModelPath,
         int numClasses = 1, MedSAMModelSize modelSize = MedSAMModelSize.ViTBase,
         MedSAMOptions? options = null)
-        : base(architecture, new CrossEntropyLoss<T>())
+        : base(architecture, new CrossEntropyWithLogitsLoss<T>())
     {
         _options = options ?? new MedSAMOptions(); Options = _options;
         if (string.IsNullOrWhiteSpace(onnxModelPath))

--- a/src/ComputerVision/Segmentation/Medical/MedSAM2.cs
+++ b/src/ComputerVision/Segmentation/Medical/MedSAM2.cs
@@ -97,7 +97,7 @@ public class MedSAM2<T> : NeuralNetworkBase<T>, IMedicalSegmentation<T>
     /// </summary>
     /// <param name="architecture">Neural network architecture defining input dimensions.</param>
     /// <param name="optimizer">Gradient-based optimizer (default: AdamW).</param>
-    /// <param name="lossFunction">Loss function (default: CrossEntropyLoss).</param>
+    /// <param name="lossFunction">Loss function (default: CrossEntropyWithLogitsLoss).</param>
     /// <param name="numClasses">Number of segmentation classes (default: 1).</param>
     /// <param name="modelSize">Model size variant (default: Tiny).</param>
     /// <param name="dropRate">Dropout rate (default: 0).</param>

--- a/src/ComputerVision/Segmentation/Medical/MedSAM2.cs
+++ b/src/ComputerVision/Segmentation/Medical/MedSAM2.cs
@@ -112,7 +112,7 @@ public class MedSAM2<T> : NeuralNetworkBase<T>, IMedicalSegmentation<T>
         ILossFunction<T>? lossFunction = null, int numClasses = 1,
         MedSAM2ModelSize modelSize = MedSAM2ModelSize.Tiny, double dropRate = 0,
         MedSAM2Options? options = null)
-        : base(architecture, lossFunction ?? new CrossEntropyLoss<T>())
+        : base(architecture, lossFunction ?? new CrossEntropyWithLogitsLoss<T>())
     {
         _options = options ?? new MedSAM2Options(); Options = _options;
         _height = architecture.InputHeight > 0 ? architecture.InputHeight : 1024;
@@ -144,7 +144,7 @@ public class MedSAM2<T> : NeuralNetworkBase<T>, IMedicalSegmentation<T>
     public MedSAM2(NeuralNetworkArchitecture<T> architecture, string onnxModelPath,
         int numClasses = 1, MedSAM2ModelSize modelSize = MedSAM2ModelSize.Tiny,
         MedSAM2Options? options = null)
-        : base(architecture, new CrossEntropyLoss<T>())
+        : base(architecture, new CrossEntropyWithLogitsLoss<T>())
     {
         _options = options ?? new MedSAM2Options(); Options = _options;
         if (string.IsNullOrWhiteSpace(onnxModelPath))

--- a/src/ComputerVision/Segmentation/Medical/MedSegDiffV2.cs
+++ b/src/ComputerVision/Segmentation/Medical/MedSegDiffV2.cs
@@ -95,7 +95,7 @@ public class MedSegDiffV2<T> : NeuralNetworkBase<T>, IMedicalSegmentation<T>
     /// </summary>
     /// <param name="architecture">Neural network architecture defining input dimensions.</param>
     /// <param name="optimizer">Gradient-based optimizer (default: AdamW).</param>
-    /// <param name="lossFunction">Loss function (default: CrossEntropyLoss).</param>
+    /// <param name="lossFunction">Loss function (default: CrossEntropyWithLogitsLoss).</param>
     /// <param name="numClasses">Number of segmentation classes (default: 1).</param>
     /// <param name="dropRate">Dropout rate (default: 0).</param>
     /// <param name="options">Optional model options.</param>

--- a/src/ComputerVision/Segmentation/Medical/MedSegDiffV2.cs
+++ b/src/ComputerVision/Segmentation/Medical/MedSegDiffV2.cs
@@ -109,7 +109,7 @@ public class MedSegDiffV2<T> : NeuralNetworkBase<T>, IMedicalSegmentation<T>
         ILossFunction<T>? lossFunction = null, int numClasses = 1,
         double dropRate = 0,
         MedSegDiffV2Options? options = null)
-        : base(architecture, lossFunction ?? new CrossEntropyLoss<T>())
+        : base(architecture, lossFunction ?? new CrossEntropyWithLogitsLoss<T>())
     {
         _options = options ?? new MedSegDiffV2Options(); Options = _options;
         _height = architecture.InputHeight > 0 ? architecture.InputHeight : 256;
@@ -142,7 +142,7 @@ public class MedSegDiffV2<T> : NeuralNetworkBase<T>, IMedicalSegmentation<T>
     public MedSegDiffV2(NeuralNetworkArchitecture<T> architecture, string onnxModelPath,
         int numClasses = 1,
         MedSegDiffV2Options? options = null)
-        : base(architecture, new CrossEntropyLoss<T>())
+        : base(architecture, new CrossEntropyWithLogitsLoss<T>())
     {
         _options = options ?? new MedSegDiffV2Options(); Options = _options;
         if (string.IsNullOrWhiteSpace(onnxModelPath))

--- a/src/ComputerVision/Segmentation/Medical/NnUNet.cs
+++ b/src/ComputerVision/Segmentation/Medical/NnUNet.cs
@@ -97,7 +97,7 @@ public class NnUNet<T> : NeuralNetworkBase<T>, IMedicalSegmentation<T>
     /// </summary>
     /// <param name="architecture">Neural network architecture defining input dimensions.</param>
     /// <param name="optimizer">Gradient-based optimizer (default: AdamW).</param>
-    /// <param name="lossFunction">Loss function (default: CrossEntropyLoss).</param>
+    /// <param name="lossFunction">Loss function (default: CrossEntropyWithLogitsLoss).</param>
     /// <param name="numClasses">Number of segmentation classes (default: 14).</param>
     /// <param name="modelSize">Model size variant (default: UNet2D).</param>
     /// <param name="dropRate">Dropout rate (default: 0).</param>

--- a/src/ComputerVision/Segmentation/Medical/NnUNet.cs
+++ b/src/ComputerVision/Segmentation/Medical/NnUNet.cs
@@ -112,7 +112,7 @@ public class NnUNet<T> : NeuralNetworkBase<T>, IMedicalSegmentation<T>
         ILossFunction<T>? lossFunction = null, int numClasses = 14,
         NnUNetModelSize modelSize = NnUNetModelSize.UNet2D, double dropRate = 0,
         NnUNetOptions? options = null)
-        : base(architecture, lossFunction ?? new CrossEntropyLoss<T>())
+        : base(architecture, lossFunction ?? new CrossEntropyWithLogitsLoss<T>())
     {
         _options = options ?? new NnUNetOptions(); Options = _options;
         _height = architecture.InputHeight > 0 ? architecture.InputHeight : 256;
@@ -144,7 +144,7 @@ public class NnUNet<T> : NeuralNetworkBase<T>, IMedicalSegmentation<T>
     public NnUNet(NeuralNetworkArchitecture<T> architecture, string onnxModelPath,
         int numClasses = 14, NnUNetModelSize modelSize = NnUNetModelSize.UNet2D,
         NnUNetOptions? options = null)
-        : base(architecture, new CrossEntropyLoss<T>())
+        : base(architecture, new CrossEntropyWithLogitsLoss<T>())
     {
         _options = options ?? new NnUNetOptions(); Options = _options;
         if (string.IsNullOrWhiteSpace(onnxModelPath))

--- a/src/ComputerVision/Segmentation/Medical/SegMamba.cs
+++ b/src/ComputerVision/Segmentation/Medical/SegMamba.cs
@@ -95,7 +95,7 @@ public class SegMamba<T> : NeuralNetworkBase<T>, IMedicalSegmentation<T>
     /// </summary>
     /// <param name="architecture">Neural network architecture defining input dimensions.</param>
     /// <param name="optimizer">Gradient-based optimizer (default: AdamW).</param>
-    /// <param name="lossFunction">Loss function (default: CrossEntropyLoss).</param>
+    /// <param name="lossFunction">Loss function (default: CrossEntropyWithLogitsLoss).</param>
     /// <param name="numClasses">Number of segmentation classes (default: 14).</param>
     /// <param name="dropRate">Dropout rate (default: 0).</param>
     /// <param name="options">Optional model options.</param>

--- a/src/ComputerVision/Segmentation/Medical/SegMamba.cs
+++ b/src/ComputerVision/Segmentation/Medical/SegMamba.cs
@@ -109,7 +109,7 @@ public class SegMamba<T> : NeuralNetworkBase<T>, IMedicalSegmentation<T>
         ILossFunction<T>? lossFunction = null, int numClasses = 14,
         double dropRate = 0,
         SegMambaOptions? options = null)
-        : base(architecture, lossFunction ?? new CrossEntropyLoss<T>())
+        : base(architecture, lossFunction ?? new CrossEntropyWithLogitsLoss<T>())
     {
         _options = options ?? new SegMambaOptions(); Options = _options;
         _height = architecture.InputHeight > 0 ? architecture.InputHeight : 128;
@@ -142,7 +142,7 @@ public class SegMamba<T> : NeuralNetworkBase<T>, IMedicalSegmentation<T>
     public SegMamba(NeuralNetworkArchitecture<T> architecture, string onnxModelPath,
         int numClasses = 14,
         SegMambaOptions? options = null)
-        : base(architecture, new CrossEntropyLoss<T>())
+        : base(architecture, new CrossEntropyWithLogitsLoss<T>())
     {
         _options = options ?? new SegMambaOptions(); Options = _options;
         if (string.IsNullOrWhiteSpace(onnxModelPath))

--- a/src/ComputerVision/Segmentation/Medical/SwinUNETR.cs
+++ b/src/ComputerVision/Segmentation/Medical/SwinUNETR.cs
@@ -97,7 +97,7 @@ public class SwinUNETR<T> : NeuralNetworkBase<T>, IMedicalSegmentation<T>
     /// </summary>
     /// <param name="architecture">Neural network architecture defining input dimensions.</param>
     /// <param name="optimizer">Gradient-based optimizer (default: AdamW).</param>
-    /// <param name="lossFunction">Loss function (default: CrossEntropyLoss).</param>
+    /// <param name="lossFunction">Loss function (default: CrossEntropyWithLogitsLoss).</param>
     /// <param name="numClasses">Number of segmentation classes (default: 14).</param>
     /// <param name="modelSize">Model size variant (default: Tiny).</param>
     /// <param name="dropRate">Dropout rate (default: 0.1).</param>

--- a/src/ComputerVision/Segmentation/Medical/SwinUNETR.cs
+++ b/src/ComputerVision/Segmentation/Medical/SwinUNETR.cs
@@ -112,7 +112,7 @@ public class SwinUNETR<T> : NeuralNetworkBase<T>, IMedicalSegmentation<T>
         ILossFunction<T>? lossFunction = null, int numClasses = 14,
         SwinUNETRModelSize modelSize = SwinUNETRModelSize.Tiny, double dropRate = 0.1,
         SwinUNETROptions? options = null)
-        : base(architecture, lossFunction ?? new CrossEntropyLoss<T>())
+        : base(architecture, lossFunction ?? new CrossEntropyWithLogitsLoss<T>())
     {
         _options = options ?? new SwinUNETROptions(); Options = _options;
         _height = architecture.InputHeight > 0 ? architecture.InputHeight : 96;
@@ -144,7 +144,7 @@ public class SwinUNETR<T> : NeuralNetworkBase<T>, IMedicalSegmentation<T>
     public SwinUNETR(NeuralNetworkArchitecture<T> architecture, string onnxModelPath,
         int numClasses = 14, SwinUNETRModelSize modelSize = SwinUNETRModelSize.Tiny,
         SwinUNETROptions? options = null)
-        : base(architecture, new CrossEntropyLoss<T>())
+        : base(architecture, new CrossEntropyWithLogitsLoss<T>())
     {
         _options = options ?? new SwinUNETROptions(); Options = _options;
         if (string.IsNullOrWhiteSpace(onnxModelPath))

--- a/src/ComputerVision/Segmentation/Medical/TransUNet.cs
+++ b/src/ComputerVision/Segmentation/Medical/TransUNet.cs
@@ -113,7 +113,7 @@ public class TransUNet<T> : NeuralNetworkBase<T>, IMedicalSegmentation<T>
         ILossFunction<T>? lossFunction = null, int numClasses = 9,
         TransUNetModelSize modelSize = TransUNetModelSize.Base, double dropRate = 0.1,
         TransUNetOptions? options = null)
-        : base(architecture, lossFunction ?? new CrossEntropyLoss<T>())
+        : base(architecture, lossFunction ?? new CrossEntropyWithLogitsLoss<T>())
     {
         _options = options ?? new TransUNetOptions(); Options = _options;
         _height = architecture.InputHeight > 0 ? architecture.InputHeight : 224;
@@ -145,7 +145,7 @@ public class TransUNet<T> : NeuralNetworkBase<T>, IMedicalSegmentation<T>
     public TransUNet(NeuralNetworkArchitecture<T> architecture, string onnxModelPath,
         int numClasses = 9, TransUNetModelSize modelSize = TransUNetModelSize.Base,
         TransUNetOptions? options = null)
-        : base(architecture, new CrossEntropyLoss<T>())
+        : base(architecture, new CrossEntropyWithLogitsLoss<T>())
     {
         _options = options ?? new TransUNetOptions(); Options = _options;
         if (string.IsNullOrWhiteSpace(onnxModelPath))

--- a/src/ComputerVision/Segmentation/Medical/TransUNet.cs
+++ b/src/ComputerVision/Segmentation/Medical/TransUNet.cs
@@ -98,7 +98,7 @@ public class TransUNet<T> : NeuralNetworkBase<T>, IMedicalSegmentation<T>
     /// </summary>
     /// <param name="architecture">Neural network architecture defining input dimensions.</param>
     /// <param name="optimizer">Gradient-based optimizer (default: AdamW).</param>
-    /// <param name="lossFunction">Loss function (default: CrossEntropyLoss).</param>
+    /// <param name="lossFunction">Loss function (default: CrossEntropyWithLogitsLoss).</param>
     /// <param name="numClasses">Number of segmentation classes (default: 9).</param>
     /// <param name="modelSize">Model size variant (default: Base).</param>
     /// <param name="dropRate">Dropout rate (default: 0.1).</param>

--- a/src/ComputerVision/Segmentation/Medical/UMamba.cs
+++ b/src/ComputerVision/Segmentation/Medical/UMamba.cs
@@ -95,7 +95,7 @@ public class UMamba<T> : NeuralNetworkBase<T>, IMedicalSegmentation<T>
     /// </summary>
     /// <param name="architecture">Neural network architecture defining input dimensions.</param>
     /// <param name="optimizer">Gradient-based optimizer (default: AdamW).</param>
-    /// <param name="lossFunction">Loss function (default: CrossEntropyLoss).</param>
+    /// <param name="lossFunction">Loss function (default: CrossEntropyWithLogitsLoss).</param>
     /// <param name="numClasses">Number of segmentation classes (default: 14).</param>
     /// <param name="dropRate">Dropout rate (default: 0).</param>
     /// <param name="options">Optional model options.</param>

--- a/src/ComputerVision/Segmentation/Medical/UMamba.cs
+++ b/src/ComputerVision/Segmentation/Medical/UMamba.cs
@@ -109,7 +109,7 @@ public class UMamba<T> : NeuralNetworkBase<T>, IMedicalSegmentation<T>
         ILossFunction<T>? lossFunction = null, int numClasses = 14,
         double dropRate = 0,
         UMambaOptions? options = null)
-        : base(architecture, lossFunction ?? new CrossEntropyLoss<T>())
+        : base(architecture, lossFunction ?? new CrossEntropyWithLogitsLoss<T>())
     {
         _options = options ?? new UMambaOptions(); Options = _options;
         _height = architecture.InputHeight > 0 ? architecture.InputHeight : 256;
@@ -142,7 +142,7 @@ public class UMamba<T> : NeuralNetworkBase<T>, IMedicalSegmentation<T>
     public UMamba(NeuralNetworkArchitecture<T> architecture, string onnxModelPath,
         int numClasses = 14,
         UMambaOptions? options = null)
-        : base(architecture, new CrossEntropyLoss<T>())
+        : base(architecture, new CrossEntropyWithLogitsLoss<T>())
     {
         _options = options ?? new UMambaOptions(); Options = _options;
         if (string.IsNullOrWhiteSpace(onnxModelPath))

--- a/src/ComputerVision/Segmentation/Medical/UniverSeg.cs
+++ b/src/ComputerVision/Segmentation/Medical/UniverSeg.cs
@@ -109,7 +109,7 @@ public class UniverSeg<T> : NeuralNetworkBase<T>, IMedicalSegmentation<T>
         ILossFunction<T>? lossFunction = null, int numClasses = 1,
         double dropRate = 0,
         UniverSegOptions? options = null)
-        : base(architecture, lossFunction ?? new CrossEntropyLoss<T>())
+        : base(architecture, lossFunction ?? new CrossEntropyWithLogitsLoss<T>())
     {
         _options = options ?? new UniverSegOptions(); Options = _options;
         _height = architecture.InputHeight > 0 ? architecture.InputHeight : 128;
@@ -142,7 +142,7 @@ public class UniverSeg<T> : NeuralNetworkBase<T>, IMedicalSegmentation<T>
     public UniverSeg(NeuralNetworkArchitecture<T> architecture, string onnxModelPath,
         int numClasses = 1,
         UniverSegOptions? options = null)
-        : base(architecture, new CrossEntropyLoss<T>())
+        : base(architecture, new CrossEntropyWithLogitsLoss<T>())
     {
         _options = options ?? new UniverSegOptions(); Options = _options;
         if (string.IsNullOrWhiteSpace(onnxModelPath))

--- a/src/ComputerVision/Segmentation/Medical/UniverSeg.cs
+++ b/src/ComputerVision/Segmentation/Medical/UniverSeg.cs
@@ -95,7 +95,7 @@ public class UniverSeg<T> : NeuralNetworkBase<T>, IMedicalSegmentation<T>
     /// </summary>
     /// <param name="architecture">Neural network architecture defining input dimensions.</param>
     /// <param name="optimizer">Gradient-based optimizer (default: AdamW).</param>
-    /// <param name="lossFunction">Loss function (default: CrossEntropyLoss).</param>
+    /// <param name="lossFunction">Loss function (default: CrossEntropyWithLogitsLoss).</param>
     /// <param name="numClasses">Number of segmentation classes (default: 1).</param>
     /// <param name="dropRate">Dropout rate (default: 0).</param>
     /// <param name="options">Optional model options.</param>

--- a/src/ComputerVision/Segmentation/OpenVocabulary/CATSeg.cs
+++ b/src/ComputerVision/Segmentation/OpenVocabulary/CATSeg.cs
@@ -96,7 +96,7 @@ public class CATSeg<T> : NeuralNetworkBase<T>, IOpenVocabSegmentation<T>
     /// </summary>
     /// <param name="architecture">Neural network architecture defining input dimensions.</param>
     /// <param name="optimizer">Gradient-based optimizer (default: AdamW).</param>
-    /// <param name="lossFunction">Loss function (default: CrossEntropyLoss).</param>
+    /// <param name="lossFunction">Loss function (default: CrossEntropyWithLogitsLoss).</param>
     /// <param name="numClasses">Number of segmentation classes (default: 150).</param>
     /// <param name="dropRate">Dropout rate (default: 0.1).</param>
     /// <param name="options">Optional model options.</param>

--- a/src/ComputerVision/Segmentation/OpenVocabulary/CATSeg.cs
+++ b/src/ComputerVision/Segmentation/OpenVocabulary/CATSeg.cs
@@ -110,7 +110,7 @@ public class CATSeg<T> : NeuralNetworkBase<T>, IOpenVocabSegmentation<T>
         ILossFunction<T>? lossFunction = null, int numClasses = 150,
         double dropRate = 0.1,
         CATSegOptions? options = null)
-        : base(architecture, lossFunction ?? new CrossEntropyLoss<T>())
+        : base(architecture, lossFunction ?? new CrossEntropyWithLogitsLoss<T>())
     {
         _options = options ?? new CATSegOptions(); Options = _options;
         _height = architecture.InputHeight > 0 ? architecture.InputHeight : 640;
@@ -143,7 +143,7 @@ public class CATSeg<T> : NeuralNetworkBase<T>, IOpenVocabSegmentation<T>
     public CATSeg(NeuralNetworkArchitecture<T> architecture, string onnxModelPath,
         int numClasses = 150,
         CATSegOptions? options = null)
-        : base(architecture, new CrossEntropyLoss<T>())
+        : base(architecture, new CrossEntropyWithLogitsLoss<T>())
     {
         _options = options ?? new CATSegOptions(); Options = _options;
         if (string.IsNullOrWhiteSpace(onnxModelPath))

--- a/src/ComputerVision/Segmentation/OpenVocabulary/GroundedSAM2.cs
+++ b/src/ComputerVision/Segmentation/OpenVocabulary/GroundedSAM2.cs
@@ -112,7 +112,7 @@ public class GroundedSAM2<T> : NeuralNetworkBase<T>, IOpenVocabSegmentation<T>
         ILossFunction<T>? lossFunction = null, int numClasses = 1,
         double dropRate = 0,
         GroundedSAM2Options? options = null)
-        : base(architecture, lossFunction ?? new CrossEntropyLoss<T>())
+        : base(architecture, lossFunction ?? new CrossEntropyWithLogitsLoss<T>())
     {
         _options = options ?? new GroundedSAM2Options(); Options = _options;
         _height = architecture.InputHeight > 0 ? architecture.InputHeight : 1024;
@@ -145,7 +145,7 @@ public class GroundedSAM2<T> : NeuralNetworkBase<T>, IOpenVocabSegmentation<T>
     public GroundedSAM2(NeuralNetworkArchitecture<T> architecture, string onnxModelPath,
         int numClasses = 1,
         GroundedSAM2Options? options = null)
-        : base(architecture, new CrossEntropyLoss<T>())
+        : base(architecture, new CrossEntropyWithLogitsLoss<T>())
     {
         _options = options ?? new GroundedSAM2Options(); Options = _options;
         if (string.IsNullOrWhiteSpace(onnxModelPath))

--- a/src/ComputerVision/Segmentation/OpenVocabulary/GroundedSAM2.cs
+++ b/src/ComputerVision/Segmentation/OpenVocabulary/GroundedSAM2.cs
@@ -98,7 +98,7 @@ public class GroundedSAM2<T> : NeuralNetworkBase<T>, IOpenVocabSegmentation<T>
     /// </summary>
     /// <param name="architecture">Neural network architecture defining input dimensions.</param>
     /// <param name="optimizer">Gradient-based optimizer (default: AdamW).</param>
-    /// <param name="lossFunction">Loss function (default: CrossEntropyLoss).</param>
+    /// <param name="lossFunction">Loss function (default: CrossEntropyWithLogitsLoss).</param>
     /// <param name="numClasses">Number of segmentation classes (default: 1).</param>
     /// <param name="dropRate">Dropout rate (default: 0).</param>
     /// <param name="options">Optional model options.</param>

--- a/src/ComputerVision/Segmentation/OpenVocabulary/MaskAdapter.cs
+++ b/src/ComputerVision/Segmentation/OpenVocabulary/MaskAdapter.cs
@@ -95,7 +95,7 @@ public class MaskAdapter<T> : NeuralNetworkBase<T>, IOpenVocabSegmentation<T>
     /// </summary>
     /// <param name="architecture">Neural network architecture defining input dimensions.</param>
     /// <param name="optimizer">Gradient-based optimizer (default: AdamW).</param>
-    /// <param name="lossFunction">Loss function (default: CrossEntropyLoss).</param>
+    /// <param name="lossFunction">Loss function (default: CrossEntropyWithLogitsLoss).</param>
     /// <param name="numClasses">Number of segmentation classes (default: 150).</param>
     /// <param name="dropRate">Dropout rate (default: 0.1).</param>
     /// <param name="options">Optional model options.</param>

--- a/src/ComputerVision/Segmentation/OpenVocabulary/MaskAdapter.cs
+++ b/src/ComputerVision/Segmentation/OpenVocabulary/MaskAdapter.cs
@@ -109,7 +109,7 @@ public class MaskAdapter<T> : NeuralNetworkBase<T>, IOpenVocabSegmentation<T>
         ILossFunction<T>? lossFunction = null, int numClasses = 150,
         double dropRate = 0.1,
         MaskAdapterOptions? options = null)
-        : base(architecture, lossFunction ?? new CrossEntropyLoss<T>())
+        : base(architecture, lossFunction ?? new CrossEntropyWithLogitsLoss<T>())
     {
         _options = options ?? new MaskAdapterOptions(); Options = _options;
         _height = architecture.InputHeight > 0 ? architecture.InputHeight : 640;
@@ -142,7 +142,7 @@ public class MaskAdapter<T> : NeuralNetworkBase<T>, IOpenVocabSegmentation<T>
     public MaskAdapter(NeuralNetworkArchitecture<T> architecture, string onnxModelPath,
         int numClasses = 150,
         MaskAdapterOptions? options = null)
-        : base(architecture, new CrossEntropyLoss<T>())
+        : base(architecture, new CrossEntropyWithLogitsLoss<T>())
     {
         _options = options ?? new MaskAdapterOptions(); Options = _options;
         if (string.IsNullOrWhiteSpace(onnxModelPath))

--- a/src/ComputerVision/Segmentation/OpenVocabulary/OpenVocabSAM.cs
+++ b/src/ComputerVision/Segmentation/OpenVocabulary/OpenVocabSAM.cs
@@ -111,7 +111,7 @@ public class OpenVocabSAM<T> : NeuralNetworkBase<T>, IOpenVocabSegmentation<T>
         ILossFunction<T>? lossFunction = null, int numClasses = 1,
         double dropRate = 0,
         OpenVocabSAMOptions? options = null)
-        : base(architecture, lossFunction ?? new CrossEntropyLoss<T>())
+        : base(architecture, lossFunction ?? new CrossEntropyWithLogitsLoss<T>())
     {
         _options = options ?? new OpenVocabSAMOptions(); Options = _options;
         _height = architecture.InputHeight > 0 ? architecture.InputHeight : 1024;
@@ -144,7 +144,7 @@ public class OpenVocabSAM<T> : NeuralNetworkBase<T>, IOpenVocabSegmentation<T>
     public OpenVocabSAM(NeuralNetworkArchitecture<T> architecture, string onnxModelPath,
         int numClasses = 1,
         OpenVocabSAMOptions? options = null)
-        : base(architecture, new CrossEntropyLoss<T>())
+        : base(architecture, new CrossEntropyWithLogitsLoss<T>())
     {
         _options = options ?? new OpenVocabSAMOptions(); Options = _options;
         if (string.IsNullOrWhiteSpace(onnxModelPath))

--- a/src/ComputerVision/Segmentation/OpenVocabulary/SAN.cs
+++ b/src/ComputerVision/Segmentation/OpenVocabulary/SAN.cs
@@ -109,7 +109,7 @@ public class SAN<T> : NeuralNetworkBase<T>, IOpenVocabSegmentation<T>
         ILossFunction<T>? lossFunction = null, int numClasses = 150,
         double dropRate = 0.1,
         SANOptions? options = null)
-        : base(architecture, lossFunction ?? new CrossEntropyLoss<T>())
+        : base(architecture, lossFunction ?? new CrossEntropyWithLogitsLoss<T>())
     {
         _options = options ?? new SANOptions(); Options = _options;
         _height = architecture.InputHeight > 0 ? architecture.InputHeight : 640;
@@ -142,7 +142,7 @@ public class SAN<T> : NeuralNetworkBase<T>, IOpenVocabSegmentation<T>
     public SAN(NeuralNetworkArchitecture<T> architecture, string onnxModelPath,
         int numClasses = 150,
         SANOptions? options = null)
-        : base(architecture, new CrossEntropyLoss<T>())
+        : base(architecture, new CrossEntropyWithLogitsLoss<T>())
     {
         _options = options ?? new SANOptions(); Options = _options;
         if (string.IsNullOrWhiteSpace(onnxModelPath))

--- a/src/ComputerVision/Segmentation/OpenVocabulary/SED.cs
+++ b/src/ComputerVision/Segmentation/OpenVocabulary/SED.cs
@@ -109,7 +109,7 @@ public class SED<T> : NeuralNetworkBase<T>, IOpenVocabSegmentation<T>
         ILossFunction<T>? lossFunction = null, int numClasses = 150,
         double dropRate = 0.1,
         SEDOptions? options = null)
-        : base(architecture, lossFunction ?? new CrossEntropyLoss<T>())
+        : base(architecture, lossFunction ?? new CrossEntropyWithLogitsLoss<T>())
     {
         _options = options ?? new SEDOptions(); Options = _options;
         _height = architecture.InputHeight > 0 ? architecture.InputHeight : 640;
@@ -142,7 +142,7 @@ public class SED<T> : NeuralNetworkBase<T>, IOpenVocabSegmentation<T>
     public SED(NeuralNetworkArchitecture<T> architecture, string onnxModelPath,
         int numClasses = 150,
         SEDOptions? options = null)
-        : base(architecture, new CrossEntropyLoss<T>())
+        : base(architecture, new CrossEntropyWithLogitsLoss<T>())
     {
         _options = options ?? new SEDOptions(); Options = _options;
         if (string.IsNullOrWhiteSpace(onnxModelPath))

--- a/src/ComputerVision/Segmentation/Panoptic/CUPS.cs
+++ b/src/ComputerVision/Segmentation/Panoptic/CUPS.cs
@@ -108,7 +108,7 @@ public class CUPS<T> : NeuralNetworkBase<T>, IPanopticSegmentation<T>
         ILossFunction<T>? lossFunction = null, int numClasses = 133,
         double dropRate = 0.1,
         CUPSOptions? options = null)
-        : base(architecture, lossFunction ?? new CrossEntropyLoss<T>())
+        : base(architecture, lossFunction ?? new CrossEntropyWithLogitsLoss<T>())
     {
         _options = options ?? new CUPSOptions(); Options = _options;
         _height = architecture.InputHeight > 0 ? architecture.InputHeight : 512;
@@ -141,7 +141,7 @@ public class CUPS<T> : NeuralNetworkBase<T>, IPanopticSegmentation<T>
     public CUPS(NeuralNetworkArchitecture<T> architecture, string onnxModelPath,
         int numClasses = 133,
         CUPSOptions? options = null)
-        : base(architecture, new CrossEntropyLoss<T>())
+        : base(architecture, new CrossEntropyWithLogitsLoss<T>())
     {
         _options = options ?? new CUPSOptions(); Options = _options;
         if (string.IsNullOrWhiteSpace(onnxModelPath))

--- a/src/ComputerVision/Segmentation/Panoptic/KMaXDeepLab.cs
+++ b/src/ComputerVision/Segmentation/Panoptic/KMaXDeepLab.cs
@@ -111,7 +111,7 @@ public class KMaXDeepLab<T> : NeuralNetworkBase<T>, IPanopticSegmentation<T>
         ILossFunction<T>? lossFunction = null, int numClasses = 133,
         KMaXDeepLabModelSize modelSize = KMaXDeepLabModelSize.R50, double dropRate = 0.1,
         KMaXDeepLabOptions? options = null)
-        : base(architecture, lossFunction ?? new CrossEntropyLoss<T>())
+        : base(architecture, lossFunction ?? new CrossEntropyWithLogitsLoss<T>())
     {
         _options = options ?? new KMaXDeepLabOptions(); Options = _options;
         _height = architecture.InputHeight > 0 ? architecture.InputHeight : 640;
@@ -143,7 +143,7 @@ public class KMaXDeepLab<T> : NeuralNetworkBase<T>, IPanopticSegmentation<T>
     public KMaXDeepLab(NeuralNetworkArchitecture<T> architecture, string onnxModelPath,
         int numClasses = 133, KMaXDeepLabModelSize modelSize = KMaXDeepLabModelSize.R50,
         KMaXDeepLabOptions? options = null)
-        : base(architecture, new CrossEntropyLoss<T>())
+        : base(architecture, new CrossEntropyWithLogitsLoss<T>())
     {
         _options = options ?? new KMaXDeepLabOptions(); Options = _options;
         if (string.IsNullOrWhiteSpace(onnxModelPath))

--- a/src/ComputerVision/Segmentation/Panoptic/ODISE.cs
+++ b/src/ComputerVision/Segmentation/Panoptic/ODISE.cs
@@ -112,7 +112,7 @@ public class ODISE<T> : NeuralNetworkBase<T>, IPanopticSegmentation<T>
         ILossFunction<T>? lossFunction = null, int numClasses = 133,
         ODISEModelSize modelSize = ODISEModelSize.Base, double dropRate = 0.1,
         ODISEOptions? options = null)
-        : base(architecture, lossFunction ?? new CrossEntropyLoss<T>())
+        : base(architecture, lossFunction ?? new CrossEntropyWithLogitsLoss<T>())
     {
         _options = options ?? new ODISEOptions(); Options = _options;
         _height = architecture.InputHeight > 0 ? architecture.InputHeight : 512;
@@ -144,7 +144,7 @@ public class ODISE<T> : NeuralNetworkBase<T>, IPanopticSegmentation<T>
     public ODISE(NeuralNetworkArchitecture<T> architecture, string onnxModelPath,
         int numClasses = 133, ODISEModelSize modelSize = ODISEModelSize.Base,
         ODISEOptions? options = null)
-        : base(architecture, new CrossEntropyLoss<T>())
+        : base(architecture, new CrossEntropyWithLogitsLoss<T>())
     {
         _options = options ?? new ODISEOptions(); Options = _options;
         if (string.IsNullOrWhiteSpace(onnxModelPath))

--- a/src/ComputerVision/Segmentation/PointCloud/Concerto.cs
+++ b/src/ComputerVision/Segmentation/PointCloud/Concerto.cs
@@ -110,7 +110,7 @@ public class Concerto<T> : NeuralNetworkBase<T>, ISemanticSegmentation<T>
         ILossFunction<T>? lossFunction = null, int numClasses = 40,
         ConcertoModelSize modelSize = ConcertoModelSize.Base, double dropRate = 0.1,
         ConcertoOptions? options = null)
-        : base(architecture, lossFunction ?? new CrossEntropyLoss<T>())
+        : base(architecture, lossFunction ?? new CrossEntropyWithLogitsLoss<T>())
     {
         _options = options ?? new ConcertoOptions(); Options = _options;
         _height = architecture.InputHeight > 0 ? architecture.InputHeight : 1;
@@ -142,7 +142,7 @@ public class Concerto<T> : NeuralNetworkBase<T>, ISemanticSegmentation<T>
     public Concerto(NeuralNetworkArchitecture<T> architecture, string onnxModelPath,
         int numClasses = 40, ConcertoModelSize modelSize = ConcertoModelSize.Base,
         ConcertoOptions? options = null)
-        : base(architecture, new CrossEntropyLoss<T>())
+        : base(architecture, new CrossEntropyWithLogitsLoss<T>())
     {
         _options = options ?? new ConcertoOptions(); Options = _options;
         if (string.IsNullOrWhiteSpace(onnxModelPath))

--- a/src/ComputerVision/Segmentation/PointCloud/Sonata.cs
+++ b/src/ComputerVision/Segmentation/PointCloud/Sonata.cs
@@ -109,7 +109,7 @@ public class Sonata<T> : NeuralNetworkBase<T>, ISemanticSegmentation<T>
         ILossFunction<T>? lossFunction = null, int numClasses = 40,
         SonataModelSize modelSize = SonataModelSize.Base, double dropRate = 0.1,
         SonataOptions? options = null)
-        : base(architecture, lossFunction ?? new CrossEntropyLoss<T>())
+        : base(architecture, lossFunction ?? new CrossEntropyWithLogitsLoss<T>())
     {
         _options = options ?? new SonataOptions(); Options = _options;
         _height = architecture.InputHeight > 0 ? architecture.InputHeight : 1;
@@ -141,7 +141,7 @@ public class Sonata<T> : NeuralNetworkBase<T>, ISemanticSegmentation<T>
     public Sonata(NeuralNetworkArchitecture<T> architecture, string onnxModelPath,
         int numClasses = 40, SonataModelSize modelSize = SonataModelSize.Base,
         SonataOptions? options = null)
-        : base(architecture, new CrossEntropyLoss<T>())
+        : base(architecture, new CrossEntropyWithLogitsLoss<T>())
     {
         _options = options ?? new SonataOptions(); Options = _options;
         if (string.IsNullOrWhiteSpace(onnxModelPath))

--- a/src/ComputerVision/Segmentation/Referring/GLaMM.cs
+++ b/src/ComputerVision/Segmentation/Referring/GLaMM.cs
@@ -112,7 +112,7 @@ public class GLaMM<T> : NeuralNetworkBase<T>, IReferringSegmentation<T>
         ILossFunction<T>? lossFunction = null, int numClasses = 1,
         double dropRate = 0,
         GLaMMOptions? options = null)
-        : base(architecture, lossFunction ?? new CrossEntropyLoss<T>())
+        : base(architecture, lossFunction ?? new CrossEntropyWithLogitsLoss<T>())
     {
         _options = options ?? new GLaMMOptions(); Options = _options;
         _height = architecture.InputHeight > 0 ? architecture.InputHeight : 1024;
@@ -145,7 +145,7 @@ public class GLaMM<T> : NeuralNetworkBase<T>, IReferringSegmentation<T>
     public GLaMM(NeuralNetworkArchitecture<T> architecture, string onnxModelPath,
         int numClasses = 1,
         GLaMMOptions? options = null)
-        : base(architecture, new CrossEntropyLoss<T>())
+        : base(architecture, new CrossEntropyWithLogitsLoss<T>())
     {
         _options = options ?? new GLaMMOptions(); Options = _options;
         if (string.IsNullOrWhiteSpace(onnxModelPath))

--- a/src/ComputerVision/Segmentation/Referring/LISA.cs
+++ b/src/ComputerVision/Segmentation/Referring/LISA.cs
@@ -110,7 +110,7 @@ public class LISA<T> : NeuralNetworkBase<T>, IReferringSegmentation<T>
         ILossFunction<T>? lossFunction = null, int numClasses = 1,
         double dropRate = 0,
         LISAOptions? options = null)
-        : base(architecture, lossFunction ?? new CrossEntropyLoss<T>())
+        : base(architecture, lossFunction ?? new CrossEntropyWithLogitsLoss<T>())
     {
         _options = options ?? new LISAOptions(); Options = _options;
         _height = architecture.InputHeight > 0 ? architecture.InputHeight : 1024;
@@ -143,7 +143,7 @@ public class LISA<T> : NeuralNetworkBase<T>, IReferringSegmentation<T>
     public LISA(NeuralNetworkArchitecture<T> architecture, string onnxModelPath,
         int numClasses = 1,
         LISAOptions? options = null)
-        : base(architecture, new CrossEntropyLoss<T>())
+        : base(architecture, new CrossEntropyWithLogitsLoss<T>())
     {
         _options = options ?? new LISAOptions(); Options = _options;
         if (string.IsNullOrWhiteSpace(onnxModelPath))

--- a/src/ComputerVision/Segmentation/Referring/OMGLLaVA.cs
+++ b/src/ComputerVision/Segmentation/Referring/OMGLLaVA.cs
@@ -112,7 +112,7 @@ public class OMGLLaVA<T> : NeuralNetworkBase<T>, IReferringSegmentation<T>
         ILossFunction<T>? lossFunction = null, int numClasses = 1,
         double dropRate = 0,
         OMGLLaVAOptions? options = null)
-        : base(architecture, lossFunction ?? new CrossEntropyLoss<T>())
+        : base(architecture, lossFunction ?? new CrossEntropyWithLogitsLoss<T>())
     {
         _options = options ?? new OMGLLaVAOptions(); Options = _options;
         _height = architecture.InputHeight > 0 ? architecture.InputHeight : 1024;
@@ -145,7 +145,7 @@ public class OMGLLaVA<T> : NeuralNetworkBase<T>, IReferringSegmentation<T>
     public OMGLLaVA(NeuralNetworkArchitecture<T> architecture, string onnxModelPath,
         int numClasses = 1,
         OMGLLaVAOptions? options = null)
-        : base(architecture, new CrossEntropyLoss<T>())
+        : base(architecture, new CrossEntropyWithLogitsLoss<T>())
     {
         _options = options ?? new OMGLLaVAOptions(); Options = _options;
         if (string.IsNullOrWhiteSpace(onnxModelPath))

--- a/src/ComputerVision/Segmentation/Referring/PixelLM.cs
+++ b/src/ComputerVision/Segmentation/Referring/PixelLM.cs
@@ -109,7 +109,7 @@ public class PixelLM<T> : NeuralNetworkBase<T>, IReferringSegmentation<T>
         ILossFunction<T>? lossFunction = null, int numClasses = 1,
         double dropRate = 0,
         PixelLMOptions? options = null)
-        : base(architecture, lossFunction ?? new CrossEntropyLoss<T>())
+        : base(architecture, lossFunction ?? new CrossEntropyWithLogitsLoss<T>())
     {
         _options = options ?? new PixelLMOptions(); Options = _options;
         _height = architecture.InputHeight > 0 ? architecture.InputHeight : 1024;
@@ -142,7 +142,7 @@ public class PixelLM<T> : NeuralNetworkBase<T>, IReferringSegmentation<T>
     public PixelLM(NeuralNetworkArchitecture<T> architecture, string onnxModelPath,
         int numClasses = 1,
         PixelLMOptions? options = null)
-        : base(architecture, new CrossEntropyLoss<T>())
+        : base(architecture, new CrossEntropyWithLogitsLoss<T>())
     {
         _options = options ?? new PixelLMOptions(); Options = _options;
         if (string.IsNullOrWhiteSpace(onnxModelPath))

--- a/src/ComputerVision/Segmentation/Referring/VideoLISA.cs
+++ b/src/ComputerVision/Segmentation/Referring/VideoLISA.cs
@@ -112,7 +112,7 @@ public class VideoLISA<T> : NeuralNetworkBase<T>, IReferringSegmentation<T>
         ILossFunction<T>? lossFunction = null, int numClasses = 1,
         double dropRate = 0,
         VideoLISAOptions? options = null)
-        : base(architecture, lossFunction ?? new CrossEntropyLoss<T>())
+        : base(architecture, lossFunction ?? new CrossEntropyWithLogitsLoss<T>())
     {
         _options = options ?? new VideoLISAOptions(); Options = _options;
         _height = architecture.InputHeight > 0 ? architecture.InputHeight : 1024;
@@ -145,7 +145,7 @@ public class VideoLISA<T> : NeuralNetworkBase<T>, IReferringSegmentation<T>
     public VideoLISA(NeuralNetworkArchitecture<T> architecture, string onnxModelPath,
         int numClasses = 1,
         VideoLISAOptions? options = null)
-        : base(architecture, new CrossEntropyLoss<T>())
+        : base(architecture, new CrossEntropyWithLogitsLoss<T>())
     {
         _options = options ?? new VideoLISAOptions(); Options = _options;
         if (string.IsNullOrWhiteSpace(onnxModelPath))

--- a/src/ComputerVision/Segmentation/Semantic/DiffCut.cs
+++ b/src/ComputerVision/Segmentation/Semantic/DiffCut.cs
@@ -128,7 +128,7 @@ public class DiffCut<T> : NeuralNetworkBase<T>, ISemanticSegmentation<T>
         int numClasses = 150,
         double dropRate = 0.1,
         DiffCutOptions? options = null)
-        : base(architecture, lossFunction ?? new CrossEntropyLoss<T>())
+        : base(architecture, lossFunction ?? new CrossEntropyWithLogitsLoss<T>())
     {
         _options = options ?? new DiffCutOptions();
         Options = _options;
@@ -168,7 +168,7 @@ public class DiffCut<T> : NeuralNetworkBase<T>, ISemanticSegmentation<T>
         string onnxModelPath,
         int numClasses = 150,
         DiffCutOptions? options = null)
-        : base(architecture, new CrossEntropyLoss<T>())
+        : base(architecture, new CrossEntropyWithLogitsLoss<T>())
     {
         _options = options ?? new DiffCutOptions();
         Options = _options;

--- a/src/ComputerVision/Segmentation/Semantic/DiffSeg.cs
+++ b/src/ComputerVision/Segmentation/Semantic/DiffSeg.cs
@@ -125,7 +125,7 @@ public class DiffSeg<T> : NeuralNetworkBase<T>, ISemanticSegmentation<T>
         int numClasses = 150,
         double dropRate = 0.1,
         DiffSegOptions? options = null)
-        : base(architecture, lossFunction ?? new CrossEntropyLoss<T>())
+        : base(architecture, lossFunction ?? new CrossEntropyWithLogitsLoss<T>())
     {
         _options = options ?? new DiffSegOptions();
         Options = _options;
@@ -165,7 +165,7 @@ public class DiffSeg<T> : NeuralNetworkBase<T>, ISemanticSegmentation<T>
         string onnxModelPath,
         int numClasses = 150,
         DiffSegOptions? options = null)
-        : base(architecture, new CrossEntropyLoss<T>())
+        : base(architecture, new CrossEntropyWithLogitsLoss<T>())
     {
         _options = options ?? new DiffSegOptions();
         Options = _options;

--- a/src/ComputerVision/Segmentation/Semantic/InternImage.cs
+++ b/src/ComputerVision/Segmentation/Semantic/InternImage.cs
@@ -143,7 +143,7 @@ public class InternImage<T> : NeuralNetworkBase<T>, ISemanticSegmentation<T>
         InternImageModelSize modelSize = InternImageModelSize.Tiny,
         double dropRate = 0.1,
         InternImageOptions? options = null)
-        : base(architecture, lossFunction ?? new CrossEntropyLoss<T>())
+        : base(architecture, lossFunction ?? new CrossEntropyWithLogitsLoss<T>())
     {
         _options = options ?? new InternImageOptions();
         Options = _options;
@@ -185,7 +185,7 @@ public class InternImage<T> : NeuralNetworkBase<T>, ISemanticSegmentation<T>
         int numClasses = 150,
         InternImageModelSize modelSize = InternImageModelSize.Tiny,
         InternImageOptions? options = null)
-        : base(architecture, new CrossEntropyLoss<T>())
+        : base(architecture, new CrossEntropyWithLogitsLoss<T>())
     {
         _options = options ?? new InternImageOptions();
         Options = _options;

--- a/src/ComputerVision/Segmentation/Semantic/SegFormer.cs
+++ b/src/ComputerVision/Segmentation/Semantic/SegFormer.cs
@@ -175,7 +175,7 @@ public class SegFormer<T> : NeuralNetworkBase<T>, ISemanticSegmentation<T>
         SegFormerModelSize modelSize = SegFormerModelSize.B0,
         double dropRate = 0.1,
         SegFormerOptions? options = null)
-        : base(architecture, lossFunction ?? new CrossEntropyLoss<T>())
+        : base(architecture, lossFunction ?? new CrossEntropyWithLogitsLoss<T>())
     {
         _options = options ?? new SegFormerOptions();
         Options = _options;
@@ -226,7 +226,7 @@ public class SegFormer<T> : NeuralNetworkBase<T>, ISemanticSegmentation<T>
         int numClasses = 150,
         SegFormerModelSize modelSize = SegFormerModelSize.B0,
         SegFormerOptions? options = null)
-        : base(architecture, new CrossEntropyLoss<T>())
+        : base(architecture, new CrossEntropyWithLogitsLoss<T>())
     {
         _options = options ?? new SegFormerOptions();
         Options = _options;

--- a/src/ComputerVision/Segmentation/Semantic/SegNeXt.cs
+++ b/src/ComputerVision/Segmentation/Semantic/SegNeXt.cs
@@ -172,7 +172,7 @@ public class SegNeXt<T> : NeuralNetworkBase<T>, ISemanticSegmentation<T>
         SegNeXtModelSize modelSize = SegNeXtModelSize.Tiny,
         double dropRate = 0.1,
         SegNeXtOptions? options = null)
-        : base(architecture, lossFunction ?? new CrossEntropyLoss<T>())
+        : base(architecture, lossFunction ?? new CrossEntropyWithLogitsLoss<T>())
     {
         _options = options ?? new SegNeXtOptions();
         Options = _options;
@@ -222,7 +222,7 @@ public class SegNeXt<T> : NeuralNetworkBase<T>, ISemanticSegmentation<T>
         int numClasses = 150,
         SegNeXtModelSize modelSize = SegNeXtModelSize.Tiny,
         SegNeXtOptions? options = null)
-        : base(architecture, new CrossEntropyLoss<T>())
+        : base(architecture, new CrossEntropyWithLogitsLoss<T>())
     {
         _options = options ?? new SegNeXtOptions();
         Options = _options;

--- a/src/ComputerVision/Segmentation/Semantic/ViTAdapter.cs
+++ b/src/ComputerVision/Segmentation/Semantic/ViTAdapter.cs
@@ -142,7 +142,7 @@ public class ViTAdapter<T> : NeuralNetworkBase<T>, ISemanticSegmentation<T>
         ViTAdapterModelSize modelSize = ViTAdapterModelSize.Base,
         double dropRate = 0.1,
         ViTAdapterOptions? options = null)
-        : base(architecture, lossFunction ?? new CrossEntropyLoss<T>())
+        : base(architecture, lossFunction ?? new CrossEntropyWithLogitsLoss<T>())
     {
         _options = options ?? new ViTAdapterOptions();
         Options = _options;
@@ -184,7 +184,7 @@ public class ViTAdapter<T> : NeuralNetworkBase<T>, ISemanticSegmentation<T>
         int numClasses = 150,
         ViTAdapterModelSize modelSize = ViTAdapterModelSize.Base,
         ViTAdapterOptions? options = null)
-        : base(architecture, new CrossEntropyLoss<T>())
+        : base(architecture, new CrossEntropyWithLogitsLoss<T>())
     {
         _options = options ?? new ViTAdapterOptions();
         Options = _options;

--- a/src/ComputerVision/Segmentation/Semantic/ViTCoMer.cs
+++ b/src/ComputerVision/Segmentation/Semantic/ViTCoMer.cs
@@ -140,7 +140,7 @@ public class ViTCoMer<T> : NeuralNetworkBase<T>, ISemanticSegmentation<T>
         ViTCoMerModelSize modelSize = ViTCoMerModelSize.Small,
         double dropRate = 0.1,
         ViTCoMerOptions? options = null)
-        : base(architecture, lossFunction ?? new CrossEntropyLoss<T>())
+        : base(architecture, lossFunction ?? new CrossEntropyWithLogitsLoss<T>())
     {
         _options = options ?? new ViTCoMerOptions();
         Options = _options;
@@ -181,7 +181,7 @@ public class ViTCoMer<T> : NeuralNetworkBase<T>, ISemanticSegmentation<T>
         int numClasses = 150,
         ViTCoMerModelSize modelSize = ViTCoMerModelSize.Small,
         ViTCoMerOptions? options = null)
-        : base(architecture, new CrossEntropyLoss<T>())
+        : base(architecture, new CrossEntropyWithLogitsLoss<T>())
     {
         _options = options ?? new ViTCoMerOptions();
         Options = _options;

--- a/src/ComputerVision/Segmentation/Video/DEVA.cs
+++ b/src/ComputerVision/Segmentation/Video/DEVA.cs
@@ -113,7 +113,9 @@ public class DEVA<T> : NeuralNetworkBase<T>, IVideoSegmentation<T>
         ILossFunction<T>? lossFunction = null, int numClasses = 1,
         DEVAModelSize modelSize = DEVAModelSize.Base, double dropRate = 0,
         DEVAOptions? options = null)
-        : base(architecture, lossFunction ?? new CrossEntropyWithLogitsLoss<T>())
+        : base(architecture, lossFunction ?? (numClasses == 1
+            ? (ILossFunction<T>)new BinaryCrossEntropyWithLogitsLoss<T>()
+            : new CrossEntropyWithLogitsLoss<T>()))
     {
         _options = options ?? new DEVAOptions(); Options = _options;
         _height = architecture.InputHeight > 0 ? architecture.InputHeight : 480;
@@ -145,7 +147,9 @@ public class DEVA<T> : NeuralNetworkBase<T>, IVideoSegmentation<T>
     public DEVA(NeuralNetworkArchitecture<T> architecture, string onnxModelPath,
         int numClasses = 1, DEVAModelSize modelSize = DEVAModelSize.Base,
         DEVAOptions? options = null)
-        : base(architecture, new CrossEntropyWithLogitsLoss<T>())
+        : base(architecture, numClasses == 1
+            ? (ILossFunction<T>)new BinaryCrossEntropyWithLogitsLoss<T>()
+            : new CrossEntropyWithLogitsLoss<T>())
     {
         _options = options ?? new DEVAOptions(); Options = _options;
         if (string.IsNullOrWhiteSpace(onnxModelPath))

--- a/src/ComputerVision/Segmentation/Video/DEVA.cs
+++ b/src/ComputerVision/Segmentation/Video/DEVA.cs
@@ -113,7 +113,7 @@ public class DEVA<T> : NeuralNetworkBase<T>, IVideoSegmentation<T>
         ILossFunction<T>? lossFunction = null, int numClasses = 1,
         DEVAModelSize modelSize = DEVAModelSize.Base, double dropRate = 0,
         DEVAOptions? options = null)
-        : base(architecture, lossFunction ?? new CrossEntropyLoss<T>())
+        : base(architecture, lossFunction ?? new CrossEntropyWithLogitsLoss<T>())
     {
         _options = options ?? new DEVAOptions(); Options = _options;
         _height = architecture.InputHeight > 0 ? architecture.InputHeight : 480;
@@ -145,7 +145,7 @@ public class DEVA<T> : NeuralNetworkBase<T>, IVideoSegmentation<T>
     public DEVA(NeuralNetworkArchitecture<T> architecture, string onnxModelPath,
         int numClasses = 1, DEVAModelSize modelSize = DEVAModelSize.Base,
         DEVAOptions? options = null)
-        : base(architecture, new CrossEntropyLoss<T>())
+        : base(architecture, new CrossEntropyWithLogitsLoss<T>())
     {
         _options = options ?? new DEVAOptions(); Options = _options;
         if (string.IsNullOrWhiteSpace(onnxModelPath))

--- a/src/ComputerVision/Segmentation/Video/DEVA.cs
+++ b/src/ComputerVision/Segmentation/Video/DEVA.cs
@@ -98,7 +98,7 @@ public class DEVA<T> : NeuralNetworkBase<T>, IVideoSegmentation<T>
     /// </summary>
     /// <param name="architecture">Neural network architecture defining input dimensions.</param>
     /// <param name="optimizer">Gradient-based optimizer (default: AdamW).</param>
-    /// <param name="lossFunction">Loss function (default: CrossEntropyLoss).</param>
+    /// <param name="lossFunction">Loss function (default: <see cref="BinaryCrossEntropyWithLogitsLoss{T}"/> when <paramref name="numClasses"/> == 1; otherwise <see cref="CrossEntropyWithLogitsLoss{T}"/>).</param>
     /// <param name="numClasses">Number of segmentation classes (default: 1).</param>
     /// <param name="modelSize">Model size variant (default: Base).</param>
     /// <param name="dropRate">Dropout rate (default: 0).</param>

--- a/src/ComputerVision/Segmentation/Video/EfficientTAM.cs
+++ b/src/ComputerVision/Segmentation/Video/EfficientTAM.cs
@@ -113,7 +113,7 @@ public class EfficientTAM<T> : NeuralNetworkBase<T>, IVideoSegmentation<T>
         ILossFunction<T>? lossFunction = null, int numClasses = 1,
         EfficientTAMModelSize modelSize = EfficientTAMModelSize.Tiny, double dropRate = 0,
         EfficientTAMOptions? options = null)
-        : base(architecture, lossFunction ?? new CrossEntropyLoss<T>())
+        : base(architecture, lossFunction ?? new CrossEntropyWithLogitsLoss<T>())
     {
         _options = options ?? new EfficientTAMOptions(); Options = _options;
         _height = architecture.InputHeight > 0 ? architecture.InputHeight : 512;
@@ -145,7 +145,7 @@ public class EfficientTAM<T> : NeuralNetworkBase<T>, IVideoSegmentation<T>
     public EfficientTAM(NeuralNetworkArchitecture<T> architecture, string onnxModelPath,
         int numClasses = 1, EfficientTAMModelSize modelSize = EfficientTAMModelSize.Tiny,
         EfficientTAMOptions? options = null)
-        : base(architecture, new CrossEntropyLoss<T>())
+        : base(architecture, new CrossEntropyWithLogitsLoss<T>())
     {
         _options = options ?? new EfficientTAMOptions(); Options = _options;
         if (string.IsNullOrWhiteSpace(onnxModelPath))

--- a/src/ComputerVision/Segmentation/Video/UniVS.cs
+++ b/src/ComputerVision/Segmentation/Video/UniVS.cs
@@ -113,7 +113,7 @@ public class UniVS<T> : NeuralNetworkBase<T>, IVideoSegmentation<T>
         ILossFunction<T>? lossFunction = null, int numClasses = 80,
         UniVSModelSize modelSize = UniVSModelSize.R50, double dropRate = 0.1,
         UniVSOptions? options = null)
-        : base(architecture, lossFunction ?? new CrossEntropyLoss<T>())
+        : base(architecture, lossFunction ?? new CrossEntropyWithLogitsLoss<T>())
     {
         _options = options ?? new UniVSOptions(); Options = _options;
         _height = architecture.InputHeight > 0 ? architecture.InputHeight : 480;
@@ -145,7 +145,7 @@ public class UniVS<T> : NeuralNetworkBase<T>, IVideoSegmentation<T>
     public UniVS(NeuralNetworkArchitecture<T> architecture, string onnxModelPath,
         int numClasses = 80, UniVSModelSize modelSize = UniVSModelSize.R50,
         UniVSOptions? options = null)
-        : base(architecture, new CrossEntropyLoss<T>())
+        : base(architecture, new CrossEntropyWithLogitsLoss<T>())
     {
         _options = options ?? new UniVSOptions(); Options = _options;
         if (string.IsNullOrWhiteSpace(onnxModelPath))

--- a/src/Document/Analysis/PageSegmentation/DocBank.cs
+++ b/src/Document/Analysis/PageSegmentation/DocBank.cs
@@ -149,7 +149,7 @@ public class DocBank<T> : DocumentNeuralNetworkBase<T>, IPageSegmenter<T>
         IOptimizer<T, Tensor<T>, Tensor<T>>? optimizer = null,
         ILossFunction<T>? lossFunction = null,
         DocBankOptions? options = null)
-        : base(architecture, lossFunction ?? new CrossEntropyLoss<T>(), 1.0)
+        : base(architecture, lossFunction ?? new CrossEntropyWithLogitsLoss<T>(), 1.0)
     {
         _options = options ?? new DocBankOptions();
         Options = _options;
@@ -204,7 +204,7 @@ public class DocBank<T> : DocumentNeuralNetworkBase<T>, IPageSegmenter<T>
         IOptimizer<T, Tensor<T>, Tensor<T>>? optimizer = null,
         ILossFunction<T>? lossFunction = null,
         DocBankOptions? options = null)
-        : base(architecture, lossFunction ?? new CrossEntropyLoss<T>(), 1.0)
+        : base(architecture, lossFunction ?? new CrossEntropyWithLogitsLoss<T>(), 1.0)
     {
         _options = options ?? new DocBankOptions();
         Options = _options;

--- a/src/Document/Analysis/TableDetection/TableTransformer.cs
+++ b/src/Document/Analysis/TableDetection/TableTransformer.cs
@@ -153,7 +153,7 @@ public class TableTransformer<T> : DocumentNeuralNetworkBase<T>, ITableExtractor
         IOptimizer<T, Tensor<T>, Tensor<T>>? optimizer = null,
         ILossFunction<T>? lossFunction = null,
         TableTransformerOptions? options = null)
-        : base(architecture, lossFunction ?? new CrossEntropyLoss<T>(), 1.0)
+        : base(architecture, lossFunction ?? new CrossEntropyWithLogitsLoss<T>(), 1.0)
     {
         _options = options ?? new TableTransformerOptions();
         Options = _options;
@@ -218,7 +218,7 @@ public class TableTransformer<T> : DocumentNeuralNetworkBase<T>, ITableExtractor
         IOptimizer<T, Tensor<T>, Tensor<T>>? optimizer = null,
         ILossFunction<T>? lossFunction = null,
         TableTransformerOptions? options = null)
-        : base(architecture, lossFunction ?? new CrossEntropyLoss<T>(), 1.0)
+        : base(architecture, lossFunction ?? new CrossEntropyWithLogitsLoss<T>(), 1.0)
     {
         _options = options ?? new TableTransformerOptions();
         Options = _options;

--- a/src/Document/DocumentNeuralNetworkBase.cs
+++ b/src/Document/DocumentNeuralNetworkBase.cs
@@ -139,7 +139,7 @@ public abstract class DocumentNeuralNetworkBase<T> : NeuralNetworkBase<T>
         NeuralNetworkArchitecture<T> architecture,
         ILossFunction<T>? lossFunction = null,
         double maxGradNorm = 1.0)
-        : base(architecture, lossFunction ?? new CrossEntropyLoss<T>(), maxGradNorm)
+        : base(architecture, lossFunction ?? new CrossEntropyWithLogitsLoss<T>(), maxGradNorm)
     {
         Options = new DocumentNeuralNetworkOptions();
     }

--- a/src/Document/GraphBased/DocGCN.cs
+++ b/src/Document/GraphBased/DocGCN.cs
@@ -153,7 +153,7 @@ public class DocGCN<T> : DocumentNeuralNetworkBase<T>, ILayoutDetector<T>
         IOptimizer<T, Tensor<T>, Tensor<T>>? optimizer = null,
         ILossFunction<T>? lossFunction = null,
         DocGCNOptions? options = null)
-        : base(architecture, lossFunction ?? new CrossEntropyLoss<T>(), 1.0)
+        : base(architecture, lossFunction ?? new CrossEntropyWithLogitsLoss<T>(), 1.0)
     {
         _options = options ?? new DocGCNOptions();
         Options = _options;
@@ -198,7 +198,7 @@ public class DocGCN<T> : DocumentNeuralNetworkBase<T>, ILayoutDetector<T>
         IOptimizer<T, Tensor<T>, Tensor<T>>? optimizer = null,
         ILossFunction<T>? lossFunction = null,
         DocGCNOptions? options = null)
-        : base(architecture, lossFunction ?? new CrossEntropyLoss<T>(), 1.0)
+        : base(architecture, lossFunction ?? new CrossEntropyWithLogitsLoss<T>(), 1.0)
     {
         _options = options ?? new DocGCNOptions();
         Options = _options;

--- a/src/Document/GraphBased/LayoutGraph.cs
+++ b/src/Document/GraphBased/LayoutGraph.cs
@@ -129,7 +129,7 @@ public class LayoutGraph<T> : DocumentNeuralNetworkBase<T>, ILayoutDetector<T>, 
         IOptimizer<T, Tensor<T>, Tensor<T>>? optimizer = null,
         ILossFunction<T>? lossFunction = null,
         LayoutGraphOptions? options = null)
-        : base(architecture, lossFunction ?? new CrossEntropyLoss<T>(), 1.0)
+        : base(architecture, lossFunction ?? new CrossEntropyWithLogitsLoss<T>(), 1.0)
     {
         _options = options ?? new LayoutGraphOptions();
         Options = _options;
@@ -165,7 +165,7 @@ public class LayoutGraph<T> : DocumentNeuralNetworkBase<T>, ILayoutDetector<T>, 
         IOptimizer<T, Tensor<T>, Tensor<T>>? optimizer = null,
         ILossFunction<T>? lossFunction = null,
         LayoutGraphOptions? options = null)
-        : base(architecture, lossFunction ?? new CrossEntropyLoss<T>(), 1.0)
+        : base(architecture, lossFunction ?? new CrossEntropyWithLogitsLoss<T>(), 1.0)
     {
         _options = options ?? new LayoutGraphOptions();
         Options = _options;

--- a/src/Document/GraphBased/PICK.cs
+++ b/src/Document/GraphBased/PICK.cs
@@ -122,7 +122,7 @@ public class PICK<T> : DocumentNeuralNetworkBase<T>, IFormUnderstanding<T>
         IOptimizer<T, Tensor<T>, Tensor<T>>? optimizer = null,
         ILossFunction<T>? lossFunction = null,
         PICKOptions? options = null)
-        : base(architecture, lossFunction ?? new CrossEntropyLoss<T>(), 1.0)
+        : base(architecture, lossFunction ?? new CrossEntropyWithLogitsLoss<T>(), 1.0)
     {
         _options = options ?? new PICKOptions();
         Options = _options;
@@ -176,7 +176,7 @@ public class PICK<T> : DocumentNeuralNetworkBase<T>, IFormUnderstanding<T>
         IOptimizer<T, Tensor<T>, Tensor<T>>? optimizer = null,
         ILossFunction<T>? lossFunction = null,
         PICKOptions? options = null)
-        : base(architecture, lossFunction ?? new CrossEntropyLoss<T>(), 1.0)
+        : base(architecture, lossFunction ?? new CrossEntropyWithLogitsLoss<T>(), 1.0)
     {
         _options = options ?? new PICKOptions();
         Options = _options;

--- a/src/Document/GraphBased/TRIE.cs
+++ b/src/Document/GraphBased/TRIE.cs
@@ -138,7 +138,7 @@ public class TRIE<T> : DocumentNeuralNetworkBase<T>, IFormUnderstanding<T>, ITex
         IOptimizer<T, Tensor<T>, Tensor<T>>? optimizer = null,
         ILossFunction<T>? lossFunction = null,
         TRIEOptions? options = null)
-        : base(architecture, lossFunction ?? new CrossEntropyLoss<T>(), 1.0)
+        : base(architecture, lossFunction ?? new CrossEntropyWithLogitsLoss<T>(), 1.0)
     {
         _options = options ?? new TRIEOptions();
         Options = _options;
@@ -186,7 +186,7 @@ public class TRIE<T> : DocumentNeuralNetworkBase<T>, IFormUnderstanding<T>, ITex
         IOptimizer<T, Tensor<T>, Tensor<T>>? optimizer = null,
         ILossFunction<T>? lossFunction = null,
         TRIEOptions? options = null)
-        : base(architecture, lossFunction ?? new CrossEntropyLoss<T>(), 1.0)
+        : base(architecture, lossFunction ?? new CrossEntropyWithLogitsLoss<T>(), 1.0)
     {
         _options = options ?? new TRIEOptions();
         Options = _options;

--- a/src/Document/LayoutAware/DiT.cs
+++ b/src/Document/LayoutAware/DiT.cs
@@ -147,7 +147,7 @@ public class DiT<T> : DocumentNeuralNetworkBase<T>, ILayoutDetector<T>, IDocumen
         IOptimizer<T, Tensor<T>, Tensor<T>>? optimizer = null,
         ILossFunction<T>? lossFunction = null,
         DiTOptions? options = null)
-        : base(architecture, lossFunction ?? new CrossEntropyLoss<T>(), 1.0)
+        : base(architecture, lossFunction ?? new CrossEntropyWithLogitsLoss<T>(), 1.0)
     {
         _options = options ?? new DiTOptions();
         Options = _options;
@@ -199,7 +199,7 @@ public class DiT<T> : DocumentNeuralNetworkBase<T>, ILayoutDetector<T>, IDocumen
         IOptimizer<T, Tensor<T>, Tensor<T>>? optimizer = null,
         ILossFunction<T>? lossFunction = null,
         DiTOptions? options = null)
-        : base(architecture, lossFunction ?? new CrossEntropyLoss<T>(), 1.0)
+        : base(architecture, lossFunction ?? new CrossEntropyWithLogitsLoss<T>(), 1.0)
     {
         _options = options ?? new DiTOptions();
         Options = _options;

--- a/src/Document/LayoutAware/DocFormer.cs
+++ b/src/Document/LayoutAware/DocFormer.cs
@@ -156,7 +156,7 @@ public class DocFormer<T> : DocumentNeuralNetworkBase<T>, ILayoutDetector<T>, ID
         IOptimizer<T, Tensor<T>, Tensor<T>>? optimizer = null,
         ILossFunction<T>? lossFunction = null,
         DocFormerOptions? options = null)
-        : base(architecture, lossFunction ?? new CrossEntropyLoss<T>(), 1.0)
+        : base(architecture, lossFunction ?? new CrossEntropyWithLogitsLoss<T>(), 1.0)
     {
         _options = options ?? new DocFormerOptions();
         Options = _options;
@@ -225,7 +225,7 @@ public class DocFormer<T> : DocumentNeuralNetworkBase<T>, ILayoutDetector<T>, ID
         IOptimizer<T, Tensor<T>, Tensor<T>>? optimizer = null,
         ILossFunction<T>? lossFunction = null,
         DocFormerOptions? options = null)
-        : base(architecture, lossFunction ?? new CrossEntropyLoss<T>(), 1.0)
+        : base(architecture, lossFunction ?? new CrossEntropyWithLogitsLoss<T>(), 1.0)
     {
         _options = options ?? new DocFormerOptions();
         Options = _options;

--- a/src/Document/LayoutAware/LayoutLM.cs
+++ b/src/Document/LayoutAware/LayoutLM.cs
@@ -527,20 +527,32 @@ public class LayoutLM<T> : DocumentNeuralNetworkBase<T>, ILayoutDetector<T>
             // TrainWithTape runs the full forward + backward + optimizer step.
             // The previous implementation followed this with
             // `UpdateParameters(CollectGradients())`, which applied a SECOND
-            // optimizer step (hardcoded SGD at LR=5e-5) on top of the
-            // primary update — both wrong and 2× the per-iter cost.
+            // optimizer step (hardcoded SGD at lr=5e-5 — see UpdateParameters
+            // below) on top of the primary update — both wrong (the user-
+            // configured optimizer should be the only one stepping) and 2× the
+            // per-iter cost. The duplicate call was a leftover from the
+            // pre-tape implementation; TrainWithTape supersedes it.
             //
             // Pass the model's own non-AMSGrad AdamOptimizer (set in the
-            // ctor) explicitly. Without it, TrainWithTape's optimizer-null
-            // branch falls back to GetOrCreateBaseOptimizer which
-            // constructs an AMSGrad Adam — and the fused-Adam fast path
-            // bails out when AMSGrad is on (TryMapToFusedOptimizerConfig
-            // rejects it because the fused kernel doesn't implement the
-            // max-of-second-moment update). Without the fused path, every
-            // Adam step on this BERT-base model (~110 M fp64 params)
-            // runs through the eager tape executor at ~5 s/iter on
-            // consumer CPU.
-            TrainWithTape(input, expectedOutput, _optimizer as IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>>);
+            // ctor) explicitly via a typed cast + null-throw. Without the
+            // explicit pass, TrainWithTape's optimizer-null branch falls
+            // back to GetOrCreateBaseOptimizer which constructs an AMSGrad
+            // Adam — and the fused-Adam fast path bails out when AMSGrad is
+            // on (TryMapToFusedOptimizerConfig rejects it because the fused
+            // kernel doesn't implement the max-of-second-moment update).
+            // Without the fused path, every Adam step on this BERT-base
+            // model (~110 M fp64 params) runs through the eager tape
+            // executor at ~5 s/iter on consumer CPU.
+            //
+            // The cast goes through `as ... ?? throw` rather than a plain
+            // `as` so a user passing a non-gradient optimizer fails loudly
+            // instead of silently dropping into the default-optimizer
+            // fallback (would mask intent and produce mysteriously-different
+            // training trajectories). PR #1404 review (CodeRabbit).
+            var gradientOptimizer = _optimizer as IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>>
+                ?? throw new InvalidOperationException(
+                    "LayoutLM training requires an optimizer implementing IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>>.");
+            TrainWithTape(input, expectedOutput, gradientOptimizer);
         }
         finally
         {

--- a/src/Document/LayoutAware/LayoutLM.cs
+++ b/src/Document/LayoutAware/LayoutLM.cs
@@ -162,7 +162,13 @@ public class LayoutLM<T> : DocumentNeuralNetworkBase<T>, ILayoutDetector<T>
         _numHeads = numHeads;
         _vocabSize = vocabSize;
         _maxPosition2D = maxPosition2D;
-        _optimizer = optimizer ?? new AdamOptimizer<T, Tensor<T>, Tensor<T>>(this);
+        // Paper-faithful LR per Xu et al. 2020 KDD §4.1 ("LayoutLM"): AdamW with
+        // peak LR=5e-5, linear warmup, weight decay 0.01. The framework default
+        // (LR=1e-3) is BERT-pretraining-from-scratch territory and diverges
+        // immediately on fine-tuning-scale models with random init.
+        _optimizer = optimizer ?? new AdamOptimizer<T, Tensor<T>, Tensor<T>>(
+            this,
+            new Models.Options.AdamOptimizerOptions<T, Tensor<T>, Tensor<T>> { InitialLearningRate = 5e-5 });
 
         MaxSequenceLength = maxSequenceLength;
 
@@ -219,7 +225,13 @@ public class LayoutLM<T> : DocumentNeuralNetworkBase<T>, ILayoutDetector<T>
         _numHeads = numHeads;
         _vocabSize = vocabSize;
         _maxPosition2D = maxPosition2D;
-        _optimizer = optimizer ?? new AdamOptimizer<T, Tensor<T>, Tensor<T>>(this);
+        // Paper-faithful LR per Xu et al. 2020 KDD §4.1 ("LayoutLM"): AdamW with
+        // peak LR=5e-5, linear warmup, weight decay 0.01. The framework default
+        // (LR=1e-3) is BERT-pretraining-from-scratch territory and diverges
+        // immediately on fine-tuning-scale models with random init.
+        _optimizer = optimizer ?? new AdamOptimizer<T, Tensor<T>, Tensor<T>>(
+            this,
+            new Models.Options.AdamOptimizerOptions<T, Tensor<T>, Tensor<T>> { InitialLearningRate = 5e-5 });
 
         MaxSequenceLength = maxSequenceLength;
 
@@ -510,10 +522,30 @@ public class LayoutLM<T> : DocumentNeuralNetworkBase<T>, ILayoutDetector<T>
             throw new NotSupportedException("Training not supported in ONNX mode.");
 
         SetTrainingMode(true);
-        TrainWithTape(input, expectedOutput);
-
-        UpdateParameters(CollectGradients());
-        SetTrainingMode(false);
+        try
+        {
+            // TrainWithTape runs the full forward + backward + optimizer step.
+            // The previous implementation followed this with
+            // `UpdateParameters(CollectGradients())`, which applied a SECOND
+            // optimizer step (hardcoded SGD at LR=5e-5) on top of the
+            // primary update — both wrong and 2× the per-iter cost.
+            //
+            // Pass the model's own non-AMSGrad AdamOptimizer (set in the
+            // ctor) explicitly. Without it, TrainWithTape's optimizer-null
+            // branch falls back to GetOrCreateBaseOptimizer which
+            // constructs an AMSGrad Adam — and the fused-Adam fast path
+            // bails out when AMSGrad is on (TryMapToFusedOptimizerConfig
+            // rejects it because the fused kernel doesn't implement the
+            // max-of-second-moment update). Without the fused path, every
+            // Adam step on this BERT-base model (~110 M fp64 params)
+            // runs through the eager tape executor at ~5 s/iter on
+            // consumer CPU.
+            TrainWithTape(input, expectedOutput, _optimizer as IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>>);
+        }
+        finally
+        {
+            SetTrainingMode(false);
+        }
     }
 
     /// <inheritdoc/>

--- a/src/Document/LayoutAware/LayoutLM.cs
+++ b/src/Document/LayoutAware/LayoutLM.cs
@@ -143,7 +143,7 @@ public class LayoutLM<T> : DocumentNeuralNetworkBase<T>, ILayoutDetector<T>
         IOptimizer<T, Tensor<T>, Tensor<T>>? optimizer = null,
         ILossFunction<T>? lossFunction = null,
         LayoutLMOptions? options = null)
-        : base(architecture, lossFunction ?? new CrossEntropyLoss<T>(), 1.0)
+        : base(architecture, lossFunction ?? new CrossEntropyWithLogitsLoss<T>(), 1.0)
     {
         _options = options ?? new LayoutLMOptions();
         Options = _options;
@@ -207,7 +207,7 @@ public class LayoutLM<T> : DocumentNeuralNetworkBase<T>, ILayoutDetector<T>
         IOptimizer<T, Tensor<T>, Tensor<T>>? optimizer = null,
         ILossFunction<T>? lossFunction = null,
         LayoutLMOptions? options = null)
-        : base(architecture, lossFunction ?? new CrossEntropyLoss<T>(), 1.0)
+        : base(architecture, lossFunction ?? new CrossEntropyWithLogitsLoss<T>(), 1.0)
     {
         _options = options ?? new LayoutLMOptions();
         Options = _options;

--- a/src/Document/LayoutAware/LayoutLMv2.cs
+++ b/src/Document/LayoutAware/LayoutLMv2.cs
@@ -149,7 +149,7 @@ public class LayoutLMv2<T> : DocumentNeuralNetworkBase<T>, ILayoutDetector<T>, I
         IOptimizer<T, Tensor<T>, Tensor<T>>? optimizer = null,
         ILossFunction<T>? lossFunction = null,
         LayoutLMv2Options? options = null)
-        : base(architecture, lossFunction ?? new CrossEntropyLoss<T>(), 1.0)
+        : base(architecture, lossFunction ?? new CrossEntropyWithLogitsLoss<T>(), 1.0)
     {
         _options = options ?? new LayoutLMv2Options();
         Options = _options;
@@ -217,7 +217,7 @@ public class LayoutLMv2<T> : DocumentNeuralNetworkBase<T>, ILayoutDetector<T>, I
         IOptimizer<T, Tensor<T>, Tensor<T>>? optimizer = null,
         ILossFunction<T>? lossFunction = null,
         LayoutLMv2Options? options = null)
-        : base(architecture, lossFunction ?? new CrossEntropyLoss<T>(), 1.0)
+        : base(architecture, lossFunction ?? new CrossEntropyWithLogitsLoss<T>(), 1.0)
     {
         _options = options ?? new LayoutLMv2Options();
         Options = _options;

--- a/src/Document/LayoutAware/LayoutLMv3.cs
+++ b/src/Document/LayoutAware/LayoutLMv3.cs
@@ -167,7 +167,7 @@ public class LayoutLMv3<T> : DocumentNeuralNetworkBase<T>, ILayoutDetector<T>, I
         IOptimizer<T, Tensor<T>, Tensor<T>>? optimizer = null,
         ILossFunction<T>? lossFunction = null,
         LayoutLMv3Options? options = null)
-        : base(architecture, lossFunction ?? new CrossEntropyLoss<T>(), 1.0)
+        : base(architecture, lossFunction ?? new CrossEntropyWithLogitsLoss<T>(), 1.0)
     {
         _options = options ?? new LayoutLMv3Options();
         Options = _options;
@@ -238,7 +238,7 @@ public class LayoutLMv3<T> : DocumentNeuralNetworkBase<T>, ILayoutDetector<T>, I
         IOptimizer<T, Tensor<T>, Tensor<T>>? optimizer = null,
         ILossFunction<T>? lossFunction = null,
         LayoutLMv3Options? options = null)
-        : base(architecture, lossFunction ?? new CrossEntropyLoss<T>(), 1.0)
+        : base(architecture, lossFunction ?? new CrossEntropyWithLogitsLoss<T>(), 1.0)
     {
         _options = options ?? new LayoutLMv3Options();
         Options = _options;

--- a/src/Document/LayoutAware/LayoutXLM.cs
+++ b/src/Document/LayoutAware/LayoutXLM.cs
@@ -145,7 +145,7 @@ public class LayoutXLM<T> : DocumentNeuralNetworkBase<T>, ILayoutDetector<T>, ID
         IOptimizer<T, Tensor<T>, Tensor<T>>? optimizer = null,
         ILossFunction<T>? lossFunction = null,
         LayoutXLMOptions? options = null)
-        : base(architecture, lossFunction ?? new CrossEntropyLoss<T>(), 1.0)
+        : base(architecture, lossFunction ?? new CrossEntropyWithLogitsLoss<T>(), 1.0)
     {
         _options = options ?? new LayoutXLMOptions();
         Options = _options;
@@ -204,7 +204,7 @@ public class LayoutXLM<T> : DocumentNeuralNetworkBase<T>, ILayoutDetector<T>, ID
         IOptimizer<T, Tensor<T>, Tensor<T>>? optimizer = null,
         ILossFunction<T>? lossFunction = null,
         LayoutXLMOptions? options = null)
-        : base(architecture, lossFunction ?? new CrossEntropyLoss<T>(), 1.0)
+        : base(architecture, lossFunction ?? new CrossEntropyWithLogitsLoss<T>(), 1.0)
     {
         _options = options ?? new LayoutXLMOptions();
         Options = _options;

--- a/src/Document/LayoutAware/LiLT.cs
+++ b/src/Document/LayoutAware/LiLT.cs
@@ -145,7 +145,7 @@ public class LiLT<T> : DocumentNeuralNetworkBase<T>, ILayoutDetector<T>, IDocume
         IOptimizer<T, Tensor<T>, Tensor<T>>? optimizer = null,
         ILossFunction<T>? lossFunction = null,
         LiLTOptions? options = null)
-        : base(architecture, lossFunction ?? new CrossEntropyLoss<T>(), 1.0)
+        : base(architecture, lossFunction ?? new CrossEntropyWithLogitsLoss<T>(), 1.0)
     {
         _options = options ?? new LiLTOptions();
         Options = _options;
@@ -199,7 +199,7 @@ public class LiLT<T> : DocumentNeuralNetworkBase<T>, ILayoutDetector<T>, IDocume
         IOptimizer<T, Tensor<T>, Tensor<T>>? optimizer = null,
         ILossFunction<T>? lossFunction = null,
         LiLTOptions? options = null)
-        : base(architecture, lossFunction ?? new CrossEntropyLoss<T>(), 1.0)
+        : base(architecture, lossFunction ?? new CrossEntropyWithLogitsLoss<T>(), 1.0)
     {
         _options = options ?? new LiLTOptions();
         Options = _options;

--- a/src/Document/OCR/TextRecognition/ABINet.cs
+++ b/src/Document/OCR/TextRecognition/ABINet.cs
@@ -136,7 +136,7 @@ public class ABINet<T> : DocumentNeuralNetworkBase<T>, ITextRecognizer<T>
         IOptimizer<T, Tensor<T>, Tensor<T>>? optimizer = null,
         ILossFunction<T>? lossFunction = null,
         ABINetOptions? options = null)
-        : base(architecture, lossFunction ?? new CrossEntropyLoss<T>(), 1.0)
+        : base(architecture, lossFunction ?? new CrossEntropyWithLogitsLoss<T>(), 1.0)
     {
         _options = options ?? new ABINetOptions();
         Options = _options;
@@ -190,7 +190,7 @@ public class ABINet<T> : DocumentNeuralNetworkBase<T>, ITextRecognizer<T>
         IOptimizer<T, Tensor<T>, Tensor<T>>? optimizer = null,
         ILossFunction<T>? lossFunction = null,
         ABINetOptions? options = null)
-        : base(architecture, lossFunction ?? new CrossEntropyLoss<T>(), 1.0)
+        : base(architecture, lossFunction ?? new CrossEntropyWithLogitsLoss<T>(), 1.0)
     {
         _options = options ?? new ABINetOptions();
         Options = _options;

--- a/src/Document/OCR/TextRecognition/CRNN.cs
+++ b/src/Document/OCR/TextRecognition/CRNN.cs
@@ -126,7 +126,7 @@ public class CRNN<T> : DocumentNeuralNetworkBase<T>, ITextRecognizer<T>
         IOptimizer<T, Tensor<T>, Tensor<T>>? optimizer = null,
         ILossFunction<T>? lossFunction = null,
         CRNNOptions? options = null)
-        : base(architecture, lossFunction ?? new CrossEntropyLoss<T>(), 1.0)
+        : base(architecture, lossFunction ?? new CrossEntropyWithLogitsLoss<T>(), 1.0)
     {
         _options = options ?? new CRNNOptions();
         Options = _options;
@@ -175,7 +175,7 @@ public class CRNN<T> : DocumentNeuralNetworkBase<T>, ITextRecognizer<T>
         IOptimizer<T, Tensor<T>, Tensor<T>>? optimizer = null,
         ILossFunction<T>? lossFunction = null,
         CRNNOptions? options = null)
-        : base(architecture, lossFunction ?? new CrossEntropyLoss<T>(), 1.0)
+        : base(architecture, lossFunction ?? new CrossEntropyWithLogitsLoss<T>(), 1.0)
     {
         _options = options ?? new CRNNOptions();
         Options = _options;

--- a/src/Document/OCR/TextRecognition/SVTR.cs
+++ b/src/Document/OCR/TextRecognition/SVTR.cs
@@ -139,7 +139,7 @@ public class SVTR<T> : DocumentNeuralNetworkBase<T>, ITextRecognizer<T>
         IOptimizer<T, Tensor<T>, Tensor<T>>? optimizer = null,
         ILossFunction<T>? lossFunction = null,
         SVTROptions? options = null)
-        : base(architecture, lossFunction ?? new CrossEntropyLoss<T>(), 1.0)
+        : base(architecture, lossFunction ?? new CrossEntropyWithLogitsLoss<T>(), 1.0)
     {
         _options = options ?? new SVTROptions();
         Options = _options;
@@ -189,7 +189,7 @@ public class SVTR<T> : DocumentNeuralNetworkBase<T>, ITextRecognizer<T>
         IOptimizer<T, Tensor<T>, Tensor<T>>? optimizer = null,
         ILossFunction<T>? lossFunction = null,
         SVTROptions? options = null)
-        : base(architecture, lossFunction ?? new CrossEntropyLoss<T>(), 1.0)
+        : base(architecture, lossFunction ?? new CrossEntropyWithLogitsLoss<T>(), 1.0)
     {
         _options = options ?? new SVTROptions();
         Options = _options;

--- a/src/Document/OCR/TextRecognition/TrOCR.cs
+++ b/src/Document/OCR/TextRecognition/TrOCR.cs
@@ -156,7 +156,7 @@ public class TrOCR<T> : DocumentNeuralNetworkBase<T>, ITextRecognizer<T>
         IOptimizer<T, Tensor<T>, Tensor<T>>? optimizer = null,
         ILossFunction<T>? lossFunction = null,
         TrOCROptions? options = null)
-        : base(architecture, lossFunction ?? new CrossEntropyLoss<T>(), 1.0)
+        : base(architecture, lossFunction ?? new CrossEntropyWithLogitsLoss<T>(), 1.0)
     {
         _options = options ?? new TrOCROptions();
         Options = _options;
@@ -238,7 +238,7 @@ public class TrOCR<T> : DocumentNeuralNetworkBase<T>, ITextRecognizer<T>
         IOptimizer<T, Tensor<T>, Tensor<T>>? optimizer = null,
         ILossFunction<T>? lossFunction = null,
         TrOCROptions? options = null)
-        : base(architecture, lossFunction ?? new CrossEntropyLoss<T>(), 1.0)
+        : base(architecture, lossFunction ?? new CrossEntropyWithLogitsLoss<T>(), 1.0)
     {
         _options = options ?? new TrOCROptions();
         Options = _options;

--- a/src/Document/PixelToSequence/Dessurt.cs
+++ b/src/Document/PixelToSequence/Dessurt.cs
@@ -126,7 +126,7 @@ public class Dessurt<T> : DocumentNeuralNetworkBase<T>, IDocumentQA<T>
         IOptimizer<T, Tensor<T>, Tensor<T>>? optimizer = null,
         ILossFunction<T>? lossFunction = null,
         DessurtOptions? options = null)
-        : base(architecture, lossFunction ?? new CrossEntropyLoss<T>(), 1.0)
+        : base(architecture, lossFunction ?? new CrossEntropyWithLogitsLoss<T>(), 1.0)
     {
         _options = options ?? new DessurtOptions();
         Options = _options;
@@ -179,7 +179,7 @@ public class Dessurt<T> : DocumentNeuralNetworkBase<T>, IDocumentQA<T>
         IOptimizer<T, Tensor<T>, Tensor<T>>? optimizer = null,
         ILossFunction<T>? lossFunction = null,
         DessurtOptions? options = null)
-        : base(architecture, lossFunction ?? new CrossEntropyLoss<T>(), 1.0)
+        : base(architecture, lossFunction ?? new CrossEntropyWithLogitsLoss<T>(), 1.0)
     {
         _options = options ?? new DessurtOptions();
         Options = _options;

--- a/src/Document/PixelToSequence/Donut.cs
+++ b/src/Document/PixelToSequence/Donut.cs
@@ -203,7 +203,7 @@ public class Donut<T> : DocumentNeuralNetworkBase<T>, IOCRModel<T>, IDocumentQA<
         IOptimizer<T, Tensor<T>, Tensor<T>>? optimizer = null,
         ILossFunction<T>? lossFunction = null,
         DonutOptions? options = null)
-        : base(architecture, lossFunction ?? new CrossEntropyLoss<T>(), 1.0)
+        : base(architecture, lossFunction ?? new CrossEntropyWithLogitsLoss<T>(), 1.0)
     {
         _options = options ?? new DonutOptions();
         Options = _options;
@@ -296,7 +296,7 @@ public class Donut<T> : DocumentNeuralNetworkBase<T>, IOCRModel<T>, IDocumentQA<
         IOptimizer<T, Tensor<T>, Tensor<T>>? optimizer = null,
         ILossFunction<T>? lossFunction = null,
         DonutOptions? options = null)
-        : base(architecture, lossFunction ?? new CrossEntropyLoss<T>(), 1.0)
+        : base(architecture, lossFunction ?? new CrossEntropyWithLogitsLoss<T>(), 1.0)
     {
         _options = options ?? new DonutOptions();
         Options = _options;

--- a/src/Document/PixelToSequence/Donut.cs
+++ b/src/Document/PixelToSequence/Donut.cs
@@ -180,7 +180,7 @@ public class Donut<T> : DocumentNeuralNetworkBase<T>, IOCRModel<T>, IDocumentQA<
     /// <param name="decoderHeads">Number of decoder attention heads (default: 16).</param>
     /// <param name="vocabSize">Vocabulary size (default: 57522).</param>
     /// <param name="optimizer">Optimizer for training (optional, Adam used if null).</param>
-    /// <param name="lossFunction">Loss function (optional, CrossEntropy used if null).</param>
+    /// <param name="lossFunction">Loss function (optional, CrossEntropyWithLogitsLoss is used if null).</param>
     /// <exception cref="ArgumentNullException">Thrown if paths or tokenizer is null.</exception>
     /// <exception cref="FileNotFoundException">Thrown if ONNX model files don't exist.</exception>
     public Donut(

--- a/src/Document/PixelToSequence/MATCHA.cs
+++ b/src/Document/PixelToSequence/MATCHA.cs
@@ -142,7 +142,7 @@ public class MATCHA<T> : DocumentNeuralNetworkBase<T>, IDocumentQA<T>, ITableExt
         IOptimizer<T, Tensor<T>, Tensor<T>>? optimizer = null,
         ILossFunction<T>? lossFunction = null,
         MATCHAOptions? options = null)
-        : base(architecture, lossFunction ?? new CrossEntropyLoss<T>(), 1.0)
+        : base(architecture, lossFunction ?? new CrossEntropyWithLogitsLoss<T>(), 1.0)
     {
         _options = options ?? new MATCHAOptions();
         Options = _options;
@@ -197,7 +197,7 @@ public class MATCHA<T> : DocumentNeuralNetworkBase<T>, IDocumentQA<T>, ITableExt
         IOptimizer<T, Tensor<T>, Tensor<T>>? optimizer = null,
         ILossFunction<T>? lossFunction = null,
         MATCHAOptions? options = null)
-        : base(architecture, lossFunction ?? new CrossEntropyLoss<T>(), 1.0)
+        : base(architecture, lossFunction ?? new CrossEntropyWithLogitsLoss<T>(), 1.0)
     {
         _options = options ?? new MATCHAOptions();
         Options = _options;

--- a/src/Document/PixelToSequence/Nougat.cs
+++ b/src/Document/PixelToSequence/Nougat.cs
@@ -133,7 +133,7 @@ public class Nougat<T> : DocumentNeuralNetworkBase<T>, IDocumentQA<T>
         IOptimizer<T, Tensor<T>, Tensor<T>>? optimizer = null,
         ILossFunction<T>? lossFunction = null,
         NougatOptions? options = null)
-        : base(architecture, lossFunction ?? new CrossEntropyLoss<T>(), 1.0)
+        : base(architecture, lossFunction ?? new CrossEntropyWithLogitsLoss<T>(), 1.0)
     {
         _options = options ?? new NougatOptions();
         Options = _options;
@@ -203,7 +203,7 @@ public class Nougat<T> : DocumentNeuralNetworkBase<T>, IDocumentQA<T>
         IOptimizer<T, Tensor<T>, Tensor<T>>? optimizer = null,
         ILossFunction<T>? lossFunction = null,
         NougatOptions? options = null)
-        : base(architecture, lossFunction ?? new CrossEntropyLoss<T>(), 1.0)
+        : base(architecture, lossFunction ?? new CrossEntropyWithLogitsLoss<T>(), 1.0)
     {
         _options = options ?? new NougatOptions();
         Options = _options;

--- a/src/Document/PixelToSequence/Pix2Struct.cs
+++ b/src/Document/PixelToSequence/Pix2Struct.cs
@@ -128,7 +128,7 @@ public class Pix2Struct<T> : DocumentNeuralNetworkBase<T>, IDocumentQA<T>
         IOptimizer<T, Tensor<T>, Tensor<T>>? optimizer = null,
         ILossFunction<T>? lossFunction = null,
         Pix2StructOptions? options = null)
-        : base(architecture, lossFunction ?? new CrossEntropyLoss<T>(), 1.0)
+        : base(architecture, lossFunction ?? new CrossEntropyWithLogitsLoss<T>(), 1.0)
     {
         _options = options ?? new Pix2StructOptions();
         Options = _options;
@@ -200,7 +200,7 @@ public class Pix2Struct<T> : DocumentNeuralNetworkBase<T>, IDocumentQA<T>
         IOptimizer<T, Tensor<T>, Tensor<T>>? optimizer = null,
         ILossFunction<T>? lossFunction = null,
         Pix2StructOptions? options = null)
-        : base(architecture, lossFunction ?? new CrossEntropyLoss<T>(), 1.0)
+        : base(architecture, lossFunction ?? new CrossEntropyWithLogitsLoss<T>(), 1.0)
     {
         _options = options ?? new Pix2StructOptions();
         Options = _options;

--- a/src/Document/VisionLanguage/DocOwl.cs
+++ b/src/Document/VisionLanguage/DocOwl.cs
@@ -143,7 +143,7 @@ public class DocOwl<T> : DocumentNeuralNetworkBase<T>, IDocumentQA<T>, ILayoutDe
         IOptimizer<T, Tensor<T>, Tensor<T>>? optimizer = null,
         ILossFunction<T>? lossFunction = null,
         DocOwlOptions? options = null)
-        : base(architecture, lossFunction ?? new CrossEntropyLoss<T>(), 1.0)
+        : base(architecture, lossFunction ?? new CrossEntropyWithLogitsLoss<T>(), 1.0)
     {
         _options = options ?? new DocOwlOptions();
         Options = _options;
@@ -196,7 +196,7 @@ public class DocOwl<T> : DocumentNeuralNetworkBase<T>, IDocumentQA<T>, ILayoutDe
         IOptimizer<T, Tensor<T>, Tensor<T>>? optimizer = null,
         ILossFunction<T>? lossFunction = null,
         DocOwlOptions? options = null)
-        : base(architecture, lossFunction ?? new CrossEntropyLoss<T>(), 1.0)
+        : base(architecture, lossFunction ?? new CrossEntropyWithLogitsLoss<T>(), 1.0)
     {
         _options = options ?? new DocOwlOptions();
         Options = _options;

--- a/src/Document/VisionLanguage/InfographicVQA.cs
+++ b/src/Document/VisionLanguage/InfographicVQA.cs
@@ -141,7 +141,7 @@ public class InfographicVQA<T> : DocumentNeuralNetworkBase<T>, IDocumentQA<T>
         IOptimizer<T, Tensor<T>, Tensor<T>>? optimizer = null,
         ILossFunction<T>? lossFunction = null,
         InfographicVQAOptions? options = null)
-        : base(architecture, lossFunction ?? new CrossEntropyLoss<T>(), 1.0)
+        : base(architecture, lossFunction ?? new CrossEntropyWithLogitsLoss<T>(), 1.0)
     {
         _options = options ?? new InfographicVQAOptions();
         Options = _options;
@@ -196,7 +196,7 @@ public class InfographicVQA<T> : DocumentNeuralNetworkBase<T>, IDocumentQA<T>
         IOptimizer<T, Tensor<T>, Tensor<T>>? optimizer = null,
         ILossFunction<T>? lossFunction = null,
         InfographicVQAOptions? options = null)
-        : base(architecture, lossFunction ?? new CrossEntropyLoss<T>(), 1.0)
+        : base(architecture, lossFunction ?? new CrossEntropyWithLogitsLoss<T>(), 1.0)
     {
         _options = options ?? new InfographicVQAOptions();
         Options = _options;

--- a/src/Document/VisionLanguage/UDOP.cs
+++ b/src/Document/VisionLanguage/UDOP.cs
@@ -143,7 +143,7 @@ public class UDOP<T> : DocumentNeuralNetworkBase<T>, ILayoutDetector<T>, IDocume
         IOptimizer<T, Tensor<T>, Tensor<T>>? optimizer = null,
         ILossFunction<T>? lossFunction = null,
         UDOPOptions? options = null)
-        : base(architecture, lossFunction ?? new CrossEntropyLoss<T>(), 1.0)
+        : base(architecture, lossFunction ?? new CrossEntropyWithLogitsLoss<T>(), 1.0)
     {
         _options = options ?? new UDOPOptions();
         Options = _options;
@@ -200,7 +200,7 @@ public class UDOP<T> : DocumentNeuralNetworkBase<T>, ILayoutDetector<T>, IDocume
         IOptimizer<T, Tensor<T>, Tensor<T>>? optimizer = null,
         ILossFunction<T>? lossFunction = null,
         UDOPOptions? options = null)
-        : base(architecture, lossFunction ?? new CrossEntropyLoss<T>(), 1.0)
+        : base(architecture, lossFunction ?? new CrossEntropyWithLogitsLoss<T>(), 1.0)
     {
         _options = options ?? new UDOPOptions();
         Options = _options;

--- a/src/Finance/NLP/FinBERT.cs
+++ b/src/Finance/NLP/FinBERT.cs
@@ -205,7 +205,7 @@ public class FinBERT<T> : FinancialNLPModelBase<T>
         FinBERTOptions<T>? options = null,
         IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>>? optimizer = null,
         ILossFunction<T>? lossFunction = null)
-        : base(architecture, lossFunction ?? new CrossEntropyLoss<T>(), 1.0)
+        : base(architecture, lossFunction ?? new CrossEntropyWithLogitsLoss<T>(), 1.0)
     {
         if (string.IsNullOrWhiteSpace(onnxModelPath))
             throw new ArgumentNullException(nameof(onnxModelPath));
@@ -217,7 +217,7 @@ public class FinBERT<T> : FinancialNLPModelBase<T>
         OnnxSession = new InferenceSession(onnxModelPath);
         _options = options ?? new FinBERTOptions<T>();
         Options = _options;
-        _lossFunction = lossFunction ?? new CrossEntropyLoss<T>();
+        _lossFunction = lossFunction ?? new CrossEntropyWithLogitsLoss<T>();
         _optimizer = optimizer ?? new AdamOptimizer<T, Tensor<T>, Tensor<T>>(this);
 
         _maxSequenceLength = _options.MaxSequenceLength;
@@ -255,12 +255,12 @@ public class FinBERT<T> : FinancialNLPModelBase<T>
         FinBERTOptions<T>? options = null,
         IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>>? optimizer = null,
         ILossFunction<T>? lossFunction = null)
-        : base(architecture, lossFunction ?? new CrossEntropyLoss<T>(), 1.0)
+        : base(architecture, lossFunction ?? new CrossEntropyWithLogitsLoss<T>(), 1.0)
     {
         _useNativeMode = true;
         _options = options ?? new FinBERTOptions<T>();
         Options = _options;
-        _lossFunction = lossFunction ?? new CrossEntropyLoss<T>();
+        _lossFunction = lossFunction ?? new CrossEntropyWithLogitsLoss<T>();
         _optimizer = optimizer ?? new AdamOptimizer<T, Tensor<T>, Tensor<T>>(this);
 
         _maxSequenceLength = _options.MaxSequenceLength;

--- a/src/FitnessCalculators/CrossEntropyLossFitnessCalculator.cs
+++ b/src/FitnessCalculators/CrossEntropyLossFitnessCalculator.cs
@@ -78,7 +78,15 @@ public class CrossEntropyLossFitnessCalculator<T, TInput, TOutput> : FitnessCalc
     /// </remarks>
     protected override T GetFitnessScore(DataSetStats<T, TInput, TOutput> dataSet)
     {
-        return new CrossEntropyWithLogitsLoss<T>().CalculateLoss(ConversionsHelper.ConvertToVector<T, TOutput>(dataSet.Predicted),
+        // PR #1404 review (CodeRabbit): the calculator is named
+        // CrossEntropy *Loss* FitnessCalculator and its xml docs describe
+        // the input as a probability distribution ("99% cat", "51% cat"
+        // examples above) — callers feed post-softmax predictions. Swapping
+        // to CrossEntropyWithLogitsLoss silently changed the input contract
+        // to raw logits, producing wrong fitness scores for every existing
+        // consumer that emits probabilities. Keep CrossEntropyLoss here so
+        // the documented behavior (input == probabilities) holds.
+        return new CrossEntropyLoss<T>().CalculateLoss(ConversionsHelper.ConvertToVector<T, TOutput>(dataSet.Predicted),
             ConversionsHelper.ConvertToVector<T, TOutput>(dataSet.Actual));
     }
 }

--- a/src/FitnessCalculators/CrossEntropyLossFitnessCalculator.cs
+++ b/src/FitnessCalculators/CrossEntropyLossFitnessCalculator.cs
@@ -78,7 +78,7 @@ public class CrossEntropyLossFitnessCalculator<T, TInput, TOutput> : FitnessCalc
     /// </remarks>
     protected override T GetFitnessScore(DataSetStats<T, TInput, TOutput> dataSet)
     {
-        return new CrossEntropyLoss<T>().CalculateLoss(ConversionsHelper.ConvertToVector<T, TOutput>(dataSet.Predicted),
+        return new CrossEntropyWithLogitsLoss<T>().CalculateLoss(ConversionsHelper.ConvertToVector<T, TOutput>(dataSet.Predicted),
             ConversionsHelper.ConvertToVector<T, TOutput>(dataSet.Actual));
     }
 }

--- a/src/NER/NERNeuralNetworkBase.cs
+++ b/src/NER/NERNeuralNetworkBase.cs
@@ -185,7 +185,7 @@ public abstract class NERNeuralNetworkBase<T> : NeuralNetworkBase<T>
         NeuralNetworkArchitecture<T> architecture,
         ILossFunction<T>? lossFunction = null,
         double maxGradNorm = 1.0)
-        : base(architecture, lossFunction ?? new CrossEntropyLoss<T>(), maxGradNorm)
+        : base(architecture, lossFunction ?? new CrossEntropyWithLogitsLoss<T>(), maxGradNorm)
     {
     }
 

--- a/src/NER/SequenceLabeling/SequenceLabelingNERBase.cs
+++ b/src/NER/SequenceLabeling/SequenceLabelingNERBase.cs
@@ -141,7 +141,7 @@ public abstract class SequenceLabelingNERBase<T> : NERNeuralNetworkBase<T>
         NeuralNetworkArchitecture<T> architecture,
         ILossFunction<T>? lossFunction = null,
         double maxGradNorm = 1.0)
-        : base(architecture, lossFunction ?? new CrossEntropyLoss<T>(), maxGradNorm)
+        : base(architecture, lossFunction ?? new CrossEntropyWithLogitsLoss<T>(), maxGradNorm)
     {
     }
 

--- a/src/NeuralNetworks/AudioVisualEventLocalizationNetwork.cs
+++ b/src/NeuralNetworks/AudioVisualEventLocalizationNetwork.cs
@@ -151,7 +151,7 @@ public class AudioVisualEventLocalizationNetwork<T> : NeuralNetworkBase<T>, IAud
         ILossFunction<T>? lossFunction = null,
         int? seed = null,
         AudioVisualEventLocalizationOptions? options = null)
-        : base(architecture, lossFunction ?? new CrossEntropyLoss<T>(), 1.0)
+        : base(architecture, lossFunction ?? new CrossEntropyWithLogitsLoss<T>(), 1.0)
     {
         _options = options ?? new AudioVisualEventLocalizationOptions();
         Options = _options;
@@ -161,7 +161,7 @@ public class AudioVisualEventLocalizationNetwork<T> : NeuralNetworkBase<T>, IAud
         _temporalResolution = temporalResolution;
         _numEncoderLayers = numEncoderLayers;
         _random = seed.HasValue ? RandomHelper.CreateSeededRandom(seed.Value) : RandomHelper.CreateSeededRandom(42);
-        _lossFunction = lossFunction ?? new CrossEntropyLoss<T>();
+        _lossFunction = lossFunction ?? new CrossEntropyWithLogitsLoss<T>();
         _optimizer = optimizer ?? new Optimizers.AdamOptimizer<T, Tensor<T>, Tensor<T>>(this);
 
         // Default event categories

--- a/src/NeuralNetworks/FlamingoNeuralNetwork.cs
+++ b/src/NeuralNetworks/FlamingoNeuralNetwork.cs
@@ -156,7 +156,7 @@ public class FlamingoNeuralNetwork<T> : NeuralNetworkBase<T>, IFlamingoModel<T>
         IOptimizer<T, Tensor<T>, Tensor<T>>? optimizer = null,
         ILossFunction<T>? lossFunction = null,
         FlamingoOptions? options = null)
-        : base(architecture, lossFunction ?? new CrossEntropyLoss<T>(), 1.0)
+        : base(architecture, lossFunction ?? new CrossEntropyWithLogitsLoss<T>(), 1.0)
     {
         _options = options ?? new FlamingoOptions();
         Options = _options;
@@ -200,7 +200,7 @@ public class FlamingoNeuralNetwork<T> : NeuralNetworkBase<T>, IFlamingoModel<T>
             Guard.NotNull(tokenizer);
             _tokenizer = tokenizer;
             _optimizer = optimizer ?? new AdamOptimizer<T, Tensor<T>, Tensor<T>>(this);
-            _lossFunction = lossFunction ?? new CrossEntropyLoss<T>();
+            _lossFunction = lossFunction ?? new CrossEntropyWithLogitsLoss<T>();
             InitializeLayers();
         }
         catch
@@ -234,7 +234,7 @@ public class FlamingoNeuralNetwork<T> : NeuralNetworkBase<T>, IFlamingoModel<T>
         IOptimizer<T, Tensor<T>, Tensor<T>>? optimizer = null,
         ILossFunction<T>? lossFunction = null,
         FlamingoOptions? options = null)
-        : base(architecture, lossFunction ?? new CrossEntropyLoss<T>(), 1.0)
+        : base(architecture, lossFunction ?? new CrossEntropyWithLogitsLoss<T>(), 1.0)
     {
         _options = options ?? new FlamingoOptions();
         Options = _options;
@@ -257,7 +257,7 @@ public class FlamingoNeuralNetwork<T> : NeuralNetworkBase<T>, IFlamingoModel<T>
         // Use factory to create appropriate tokenizer for the backbone, or use provided tokenizer
         _tokenizer = tokenizer ?? Tokenization.LanguageModelTokenizerFactory.CreateForBackbone(languageModelBackbone);
         _optimizer = optimizer ?? new AdamOptimizer<T, Tensor<T>, Tensor<T>>(this);
-        _lossFunction = lossFunction ?? new CrossEntropyLoss<T>();
+        _lossFunction = lossFunction ?? new CrossEntropyWithLogitsLoss<T>();
 
         InitializeNativeLayers(channels);
     }

--- a/src/NeuralNetworks/Gpt4VisionNeuralNetwork.cs
+++ b/src/NeuralNetworks/Gpt4VisionNeuralNetwork.cs
@@ -183,7 +183,7 @@ public class Gpt4VisionNeuralNetwork<T> : NeuralNetworkBase<T>, IGpt4VisionModel
         int maxImagesPerRequest = 10,
         ILossFunction<T>? lossFunction = null,
         Gpt4VisionOptions? options = null)
-        : base(architecture, lossFunction ?? new CrossEntropyLoss<T>(), 1.0)
+        : base(architecture, lossFunction ?? new CrossEntropyWithLogitsLoss<T>(), 1.0)
     {
         _options = options ?? new Gpt4VisionOptions();
         Options = _options;
@@ -240,7 +240,7 @@ public class Gpt4VisionNeuralNetwork<T> : NeuralNetworkBase<T>, IGpt4VisionModel
         int maxImagesPerRequest = 10,
         ILossFunction<T>? lossFunction = null,
         Gpt4VisionOptions? options = null)
-        : base(architecture, lossFunction ?? new CrossEntropyLoss<T>(), 1.0)
+        : base(architecture, lossFunction ?? new CrossEntropyWithLogitsLoss<T>(), 1.0)
     {
         _options = options ?? new Gpt4VisionOptions();
         Options = _options;

--- a/src/NeuralNetworks/ImageBindNeuralNetwork.cs
+++ b/src/NeuralNetworks/ImageBindNeuralNetwork.cs
@@ -179,7 +179,7 @@ public class ImageBindNeuralNetwork<T> : NeuralNetworkBase<T>, IImageBindModel<T
         IOptimizer<T, Tensor<T>, Tensor<T>>? optimizer = null,
         ILossFunction<T>? lossFunction = null,
         ImageBindOptions? options = null)
-        : base(architecture, lossFunction ?? new CrossEntropyLoss<T>(), 1.0)
+        : base(architecture, lossFunction ?? new CrossEntropyWithLogitsLoss<T>(), 1.0)
     {
         _options = options ?? new ImageBindOptions();
         Options = _options;
@@ -234,7 +234,7 @@ public class ImageBindNeuralNetwork<T> : NeuralNetworkBase<T>, IImageBindModel<T
             Guard.NotNull(tokenizer);
             _tokenizer = tokenizer;
             _optimizer = optimizer ?? new AdamOptimizer<T, Tensor<T>, Tensor<T>>(this);
-            _lossFunction = lossFunction ?? new CrossEntropyLoss<T>();
+            _lossFunction = lossFunction ?? new CrossEntropyWithLogitsLoss<T>();
             InitializeLayers();
         }
         catch
@@ -268,7 +268,7 @@ public class ImageBindNeuralNetwork<T> : NeuralNetworkBase<T>, IImageBindModel<T
         IOptimizer<T, Tensor<T>, Tensor<T>>? optimizer = null,
         ILossFunction<T>? lossFunction = null,
         ImageBindOptions? options = null)
-        : base(architecture, lossFunction ?? new CrossEntropyLoss<T>(), 1.0)
+        : base(architecture, lossFunction ?? new CrossEntropyWithLogitsLoss<T>(), 1.0)
     {
         _options = options ?? new ImageBindOptions();
         Options = _options;
@@ -294,7 +294,7 @@ public class ImageBindNeuralNetwork<T> : NeuralNetworkBase<T>, IImageBindModel<T
 
         _tokenizer = tokenizer ?? Tokenization.ClipTokenizerFactory.CreateSimple();
         _optimizer = optimizer ?? new AdamOptimizer<T, Tensor<T>, Tensor<T>>(this);
-        _lossFunction = lossFunction ?? new CrossEntropyLoss<T>();
+        _lossFunction = lossFunction ?? new CrossEntropyWithLogitsLoss<T>();
 
         InitializeNativeLayers(channels);
     }

--- a/src/NeuralNetworks/LLaVANeuralNetwork.cs
+++ b/src/NeuralNetworks/LLaVANeuralNetwork.cs
@@ -166,7 +166,7 @@ public class LLaVANeuralNetwork<T> : NeuralNetworkBase<T>, ILLaVAModel<T>
         IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>>? optimizer = null,
         ILossFunction<T>? lossFunction = null,
         LLaVAOptions? options = null)
-        : base(architecture, lossFunction ?? new CrossEntropyLoss<T>(), 1.0)
+        : base(architecture, lossFunction ?? new CrossEntropyWithLogitsLoss<T>(), 1.0)
     {
         _options = options ?? new LLaVAOptions();
         Options = _options;
@@ -209,7 +209,7 @@ public class LLaVANeuralNetwork<T> : NeuralNetworkBase<T>, ILLaVAModel<T>
             Guard.NotNull(tokenizer);
             _tokenizer = tokenizer;
             _optimizer = optimizer ?? new AdamOptimizer<T, Tensor<T>, Tensor<T>>(this);
-            _lossFunction = lossFunction ?? new CrossEntropyLoss<T>();
+            _lossFunction = lossFunction ?? new CrossEntropyWithLogitsLoss<T>();
             InitializeLayers();
         }
         catch
@@ -249,7 +249,7 @@ public class LLaVANeuralNetwork<T> : NeuralNetworkBase<T>, ILLaVAModel<T>
         IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>>? optimizer = null,
         ILossFunction<T>? lossFunction = null,
         LLaVAOptions? options = null)
-        : base(architecture, lossFunction ?? new CrossEntropyLoss<T>(), 1.0)
+        : base(architecture, lossFunction ?? new CrossEntropyWithLogitsLoss<T>(), 1.0)
     {
         _options = options ?? new LLaVAOptions();
         Options = _options;
@@ -271,7 +271,7 @@ public class LLaVANeuralNetwork<T> : NeuralNetworkBase<T>, ILLaVAModel<T>
         // Use factory to create appropriate tokenizer for the backbone, or use provided tokenizer
         _tokenizer = tokenizer ?? Tokenization.LanguageModelTokenizerFactory.CreateForBackbone(languageModelBackbone);
         _optimizer = optimizer ?? new AdamOptimizer<T, Tensor<T>, Tensor<T>>(this);
-        _lossFunction = lossFunction ?? new CrossEntropyLoss<T>();
+        _lossFunction = lossFunction ?? new CrossEntropyWithLogitsLoss<T>();
 
         InitializeNativeLayers(channels);
     }

--- a/src/NeuralNetworks/Layers/MultiHeadAttentionLayer.cs
+++ b/src/NeuralNetworks/Layers/MultiHeadAttentionLayer.cs
@@ -1118,9 +1118,24 @@ public partial class MultiHeadAttentionLayer<T> : LayerBase<T>, IAuxiliaryLossLa
         // Cache attention weights for backward pass
         _lastAttentionScores = attentionWeights4D;
 
-        // 3. Cache Head Outputs — via Engine so the tape records the transpose.
-        var permutedForCache = Engine.TensorPermute(context_4D, new[] { 1, 0, 2, 3 }); // [H, B, S, D]
-        _lastHeadOutputs = new List<Tensor<T>> { permutedForCache }; // store stacked heads
+        // 3. Cache Head Outputs — only when the auxiliary loss path will
+        // read them. ComputeAuxiliaryLoss is the sole consumer of
+        // _lastHeadOutputs (head-diversity penalty), and it short-circuits
+        // when UseAuxiliaryLoss is false (default). Skipping the Permute
+        // + List<T> allocation here saves one engine op + one tape entry
+        // per MHA forward; on a 12-layer LayoutLM × 30 training iters
+        // that's 360 dead permute/tape entries per Train_ShouldReduceLoss
+        // run, each one tracked + walked by the gradient tape backward.
+        if (UseAuxiliaryLoss)
+        {
+            // via Engine so the tape records the transpose
+            var permutedForCache = Engine.TensorPermute(context_4D, new[] { 1, 0, 2, 3 }); // [H, B, S, D]
+            _lastHeadOutputs = new List<Tensor<T>> { permutedForCache }; // store stacked heads
+        }
+        else
+        {
+            _lastHeadOutputs = null;
+        }
 
         // 5. Concatenate and Project Output
         // [B, H, S, D] -> [B, S, H, D] -> [B, S, E] (Engine op keeps tape connected)

--- a/src/NeuralNetworks/NeuralNetworkBase.cs
+++ b/src/NeuralNetworks/NeuralNetworkBase.cs
@@ -5306,6 +5306,34 @@ public abstract class NeuralNetworkBase<T> : INeuralNetworkModel<T>, IInterpreta
             long totalParamCount = 0L;
             for (int i = 0; i < initialParams.Count; i++)
                 totalParamCount += (long)initialParams[i].Length;
+            // Lazy-init detection: layers like EmbeddingLayer / DenseLayer
+            // (constructed without an input size) hold `_weights = new
+            // Tensor<T>([0,0])` and DON'T call RegisterTrainableParameter
+            // until EnsureWeightsAllocated / EnsureEmbeddingInitialized
+            // fires on the first Forward call. Result: initialParams here
+            // doesn't include those layers' weights at all, so the buffer
+            // is sized for fewer parameters than the post-Forward state.
+            // After Forward materializes them the layer's registered
+            // parameter list grows beyond the buffer, and any later
+            // CollectParameters returns tensors that aren't buffer views.
+            // TapeStepContext.ValidateBufferAlignment then throws
+            // "Parameter N is not a view into the provided ParameterBuffer."
+            //
+            // Detect by walking trainable layers and checking whether any
+            // one has no registered parameters yet — that's the lazy
+            // signal. Skip the buffer for this structure version when
+            // present; the eager optimizer path iterates context.Parameters
+            // directly without buffer aliasing so correctness is preserved.
+            bool hasLazyParam = false;
+            var trainableLayers = Training.TapeTrainingStep<T>.CollectTrainableLayers(Layers, _layerStructureVersion);
+            for (int i = 0; i < trainableLayers.Length; i++)
+            {
+                if (trainableLayers[i].GetTrainableParameters().Count == 0)
+                {
+                    hasLazyParam = true;
+                    break;
+                }
+            }
             // ~125 M parameter cutoff: small enough that any model
             // passing this threshold is foundation-class (its weight-
             // mirror would consume ~1 GB at double precision and collide
@@ -5318,12 +5346,24 @@ public abstract class NeuralNetworkBase<T> : INeuralNetworkModel<T>, IInterpreta
             if (totalParamCount > ParameterBufferSkipThresholdParams)
             {
                 paramBuffer = null;
-                // Memoize the skip decision so subsequent training steps
-                // don't repeat the CollectParameters + sum-Length scan.
-                // Sundial-Base (~300 M params) takes ~120ms per scan;
-                // caching makes step 2..N effectively free.
+                // Memoize the foundation-scale skip decision so subsequent
+                // training steps don't repeat the CollectParameters +
+                // sum-Length scan. Sundial-Base (~300 M params) takes
+                // ~120ms per scan; caching makes step 2..N effectively free.
                 _skipParameterBuffer = true;
                 _skipParameterBufferVersion = _layerStructureVersion;
+            }
+            else if (hasLazyParam)
+            {
+                // Skip the buffer for THIS step only — do NOT memoize.
+                // Forward will materialize the lazy weights, so on the
+                // next training step the lazy-detection scan will return
+                // false and the buffer-aliased fast path can engage.
+                // Permanently skipping would force the eager tape path
+                // forever and lose the fused-optimizer speedup on every
+                // model with at least one input-size-inferred DenseLayer
+                // / EmbeddingLayer (BERT-class architectures).
+                paramBuffer = null;
             }
             else
             {

--- a/src/NeuralNetworks/Tasks/Graph/GraphClassificationModel.cs
+++ b/src/NeuralNetworks/Tasks/Graph/GraphClassificationModel.cs
@@ -202,7 +202,17 @@ public class GraphClassificationModel<T> : NeuralNetworkBase<T>
         IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>>? optimizer = null,
         ILossFunction<T>? lossFunction = null,
         double maxGradNorm = 1.0)
-        : base(architecture, lossFunction ?? new CrossEntropyWithLogitsLoss<T>(), maxGradNorm)
+        // PR #1404 review (CodeRabbit): GraphClassificationModel.Train applies
+        // Softmax to the raw logits BEFORE handing them to the loss function
+        // (line ~635 below: `var probs = Softmax(predictions)`).
+        // CrossEntropyWithLogitsLoss internally applies LogSoftmax to its
+        // input expecting raw logits — feeding it already-softmaxed
+        // probabilities double-applies the activation and produces incorrect
+        // gradients. Keep CrossEntropyLoss (probability-input variant) here
+        // so the Train softmax-then-loss pipeline stays internally
+        // consistent. Callers wanting the numerically-stable logits variant
+        // should also remove the explicit Softmax from Train.
+        : base(architecture, lossFunction ?? new CrossEntropyLoss<T>(), maxGradNorm)
     {
         InputFeatures = architecture.InputSize;
         NumClasses = architecture.OutputSize;
@@ -212,7 +222,7 @@ public class GraphClassificationModel<T> : NeuralNetworkBase<T>
         DropoutRate = dropoutRate;
         _poolingType = poolingType;
 
-        _lossFunction = lossFunction ?? new CrossEntropyWithLogitsLoss<T>();
+        _lossFunction = lossFunction ?? new CrossEntropyLoss<T>();
         _optimizer = optimizer ?? new AdamOptimizer<T, Tensor<T>, Tensor<T>>(this);
 
         InitializeLayers();

--- a/src/NeuralNetworks/Tasks/Graph/GraphClassificationModel.cs
+++ b/src/NeuralNetworks/Tasks/Graph/GraphClassificationModel.cs
@@ -202,7 +202,7 @@ public class GraphClassificationModel<T> : NeuralNetworkBase<T>
         IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>>? optimizer = null,
         ILossFunction<T>? lossFunction = null,
         double maxGradNorm = 1.0)
-        : base(architecture, lossFunction ?? new CrossEntropyLoss<T>(), maxGradNorm)
+        : base(architecture, lossFunction ?? new CrossEntropyWithLogitsLoss<T>(), maxGradNorm)
     {
         InputFeatures = architecture.InputSize;
         NumClasses = architecture.OutputSize;
@@ -212,7 +212,7 @@ public class GraphClassificationModel<T> : NeuralNetworkBase<T>
         DropoutRate = dropoutRate;
         _poolingType = poolingType;
 
-        _lossFunction = lossFunction ?? new CrossEntropyLoss<T>();
+        _lossFunction = lossFunction ?? new CrossEntropyWithLogitsLoss<T>();
         _optimizer = optimizer ?? new AdamOptimizer<T, Tensor<T>, Tensor<T>>(this);
 
         InitializeLayers();

--- a/src/NeuralNetworks/Tasks/Graph/NodeClassificationModel.cs
+++ b/src/NeuralNetworks/Tasks/Graph/NodeClassificationModel.cs
@@ -155,7 +155,7 @@ public class NodeClassificationModel<T> : NeuralNetworkBase<T>
         IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>>? optimizer = null,
         ILossFunction<T>? lossFunction = null,
         double maxGradNorm = 1.0)
-        : base(architecture, lossFunction ?? new CrossEntropyLoss<T>(), maxGradNorm)
+        : base(architecture, lossFunction ?? new CrossEntropyWithLogitsLoss<T>(), maxGradNorm)
     {
         InputFeatures = architecture.InputSize;
         NumClasses = architecture.OutputSize;
@@ -163,7 +163,7 @@ public class NodeClassificationModel<T> : NeuralNetworkBase<T>
         NumLayers = numLayers;
         DropoutRate = dropoutRate;
 
-        _lossFunction = lossFunction ?? new CrossEntropyLoss<T>();
+        _lossFunction = lossFunction ?? new CrossEntropyWithLogitsLoss<T>();
         _optimizer = optimizer ?? new AdamOptimizer<T, Tensor<T>, Tensor<T>>(this);
 
         InitializeLayers();

--- a/src/NeuralNetworks/UnifiedMultimodalNetwork.cs
+++ b/src/NeuralNetworks/UnifiedMultimodalNetwork.cs
@@ -145,7 +145,7 @@ public class UnifiedMultimodalNetwork<T> : NeuralNetworkBase<T>, IUnifiedMultimo
         ILossFunction<T>? lossFunction = null,
         int? seed = null,
         UnifiedMultimodalNetworkOptions? options = null)
-        : base(architecture, lossFunction ?? new CrossEntropyLoss<T>(), 1.0)
+        : base(architecture, lossFunction ?? new CrossEntropyWithLogitsLoss<T>(), 1.0)
     {
         _options = options ?? new UnifiedMultimodalNetworkOptions();
         Options = _options;
@@ -155,7 +155,7 @@ public class UnifiedMultimodalNetwork<T> : NeuralNetworkBase<T>, IUnifiedMultimo
         _maxSequenceLength = maxSequenceLength;
         _numTransformerLayers = numTransformerLayers;
         _random = seed.HasValue ? RandomHelper.CreateSeededRandom(seed.Value) : RandomHelper.CreateSeededRandom(42);
-        _lossFunction = lossFunction ?? new CrossEntropyLoss<T>();
+        _lossFunction = lossFunction ?? new CrossEntropyWithLogitsLoss<T>();
         _optimizer = optimizer ?? new Optimizers.AdamOptimizer<T, Tensor<T>, Tensor<T>>(this);
 
         SupportedInputModalities = new List<ModalityType>

--- a/src/NeuralNetworks/VideoCLIPNeuralNetwork.cs
+++ b/src/NeuralNetworks/VideoCLIPNeuralNetwork.cs
@@ -171,7 +171,7 @@ public class VideoCLIPNeuralNetwork<T> : NeuralNetworkBase<T>, IVideoCLIPModel<T
         IOptimizer<T, Tensor<T>, Tensor<T>>? optimizer = null,
         ILossFunction<T>? lossFunction = null,
         VideoCLIPOptions? options = null)
-        : base(architecture, lossFunction ?? new CrossEntropyLoss<T>(), 1.0)
+        : base(architecture, lossFunction ?? new CrossEntropyWithLogitsLoss<T>(), 1.0)
     {
         _options = options ?? new VideoCLIPOptions();
         Options = _options;
@@ -215,7 +215,7 @@ public class VideoCLIPNeuralNetwork<T> : NeuralNetworkBase<T>, IVideoCLIPModel<T
             Guard.NotNull(tokenizer);
             _tokenizer = tokenizer;
             _optimizer = optimizer ?? new AdamOptimizer<T, Tensor<T>, Tensor<T>>(this);
-            _lossFunction = lossFunction ?? new CrossEntropyLoss<T>();
+            _lossFunction = lossFunction ?? new CrossEntropyWithLogitsLoss<T>();
             InitializeLayers();
         }
         catch
@@ -250,7 +250,7 @@ public class VideoCLIPNeuralNetwork<T> : NeuralNetworkBase<T>, IVideoCLIPModel<T
         IOptimizer<T, Tensor<T>, Tensor<T>>? optimizer = null,
         ILossFunction<T>? lossFunction = null,
         VideoCLIPOptions? options = null)
-        : base(architecture, lossFunction ?? new CrossEntropyLoss<T>(), 1.0)
+        : base(architecture, lossFunction ?? new CrossEntropyWithLogitsLoss<T>(), 1.0)
     {
         _options = options ?? new VideoCLIPOptions();
         Options = _options;
@@ -273,7 +273,7 @@ public class VideoCLIPNeuralNetwork<T> : NeuralNetworkBase<T>, IVideoCLIPModel<T
 
         _tokenizer = tokenizer ?? Tokenization.ClipTokenizerFactory.CreateSimple();
         _optimizer = optimizer ?? new AdamOptimizer<T, Tensor<T>, Tensor<T>>(this);
-        _lossFunction = lossFunction ?? new CrossEntropyLoss<T>();
+        _lossFunction = lossFunction ?? new CrossEntropyWithLogitsLoss<T>();
 
         InitializeNativeLayers(channels);
     }

--- a/src/ProgramSynthesis/Engines/CodeBERT.cs
+++ b/src/ProgramSynthesis/Engines/CodeBERT.cs
@@ -88,7 +88,7 @@ public class CodeBERT<T> : CodeModelBase<T>
         ILossFunction<T>? lossFunction = null,
         IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>>? optimizer = null,
         ITokenizer? tokenizer = null)
-        : base(architecture, lossFunction ?? new CrossEntropyLoss<T>(), tokenizer)
+        : base(architecture, lossFunction ?? new CrossEntropyWithLogitsLoss<T>(), tokenizer)
     {
         _optimizer = optimizer ?? new AdamOptimizer<T, Tensor<T>, Tensor<T>>(this);
         InitializeLayersCore();

--- a/src/ProgramSynthesis/Engines/CodeT5.cs
+++ b/src/ProgramSynthesis/Engines/CodeT5.cs
@@ -114,7 +114,7 @@ public class CodeT5<T> : CodeModelBase<T>
         ILossFunction<T>? lossFunction = null,
         IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>>? optimizer = null,
         ITokenizer? tokenizer = null)
-        : base(architecture, lossFunction ?? new CrossEntropyLoss<T>(), tokenizer)
+        : base(architecture, lossFunction ?? new CrossEntropyWithLogitsLoss<T>(), tokenizer)
     {
         _optimizer = optimizer ?? new AdamOptimizer<T, Tensor<T>, Tensor<T>>(this);
         InitializeLayersCore();

--- a/src/ProgramSynthesis/Engines/GraphCodeBERT.cs
+++ b/src/ProgramSynthesis/Engines/GraphCodeBERT.cs
@@ -109,7 +109,7 @@ public class GraphCodeBERT<T> : CodeModelBase<T>
         ILossFunction<T>? lossFunction = null,
         IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>>? optimizer = null,
         ITokenizer? tokenizer = null)
-        : base(architecture, lossFunction ?? new CrossEntropyLoss<T>(), tokenizer)
+        : base(architecture, lossFunction ?? new CrossEntropyWithLogitsLoss<T>(), tokenizer)
     {
         _optimizer = optimizer ?? new AdamOptimizer<T, Tensor<T>, Tensor<T>>(this);
         InitializeLayersCore();

--- a/src/ProgramSynthesis/Engines/NeuralProgramSynthesizer.cs
+++ b/src/ProgramSynthesis/Engines/NeuralProgramSynthesizer.cs
@@ -107,7 +107,7 @@ public class NeuralProgramSynthesizer<T> : NeuralNetworkBase<T>, IProgramSynthes
         IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>>? optimizer = null,
         IProgramExecutionEngine? executionEngine = null,
         NeuralProgramSynthesizerOptions? options = null)
-        : base(architecture, lossFunction ?? new CrossEntropyLoss<T>())
+        : base(architecture, lossFunction ?? new CrossEntropyWithLogitsLoss<T>())
     {
         _options = options ?? new NeuralProgramSynthesizerOptions();
         Options = _options;

--- a/src/Training/Factories/LossFunctionFactory.cs
+++ b/src/Training/Factories/LossFunctionFactory.cs
@@ -42,7 +42,7 @@ public static class LossFunctionFactory<T>
             LossType.MeanAbsoluteError => new MeanAbsoluteErrorLoss<T>(),
             LossType.RootMeanSquaredError => new RootMeanSquaredErrorLoss<T>(),
             LossType.Huber => new HuberLoss<T>(GetDoubleParam(parameters, "delta", 1.0)),
-            LossType.CrossEntropy => new CrossEntropyLoss<T>(),
+            LossType.CrossEntropy => new CrossEntropyWithLogitsLoss<T>(),
             LossType.BinaryCrossEntropy => new BinaryCrossEntropyLoss<T>(),
             LossType.CategoricalCrossEntropy => new CategoricalCrossEntropyLoss<T>(),
             LossType.SparseCategoricalCrossEntropy => new SparseCategoricalCrossEntropyLoss<T>(),

--- a/src/Training/Factories/LossFunctionFactory.cs
+++ b/src/Training/Factories/LossFunctionFactory.cs
@@ -42,7 +42,16 @@ public static class LossFunctionFactory<T>
             LossType.MeanAbsoluteError => new MeanAbsoluteErrorLoss<T>(),
             LossType.RootMeanSquaredError => new RootMeanSquaredErrorLoss<T>(),
             LossType.Huber => new HuberLoss<T>(GetDoubleParam(parameters, "delta", 1.0)),
-            LossType.CrossEntropy => new CrossEntropyWithLogitsLoss<T>(),
+            // PR #1404 review (CodeRabbit): silently swapping
+            // LossType.CrossEntropy to the *WithLogits variant changes the
+            // input contract (probabilities → raw logits) for every existing
+            // caller that selected this enum value, producing silent gradient
+            // miscompute on consumers that still feed post-softmax outputs.
+            // Keep the historical mapping to the probability-input variant
+            // here; callers that explicitly want the logits-stable form
+            // should select it directly (see e.g. SAM / DEVA model defaults
+            // which construct CrossEntropyWithLogitsLoss<T> explicitly).
+            LossType.CrossEntropy => new CrossEntropyLoss<T>(),
             LossType.BinaryCrossEntropy => new BinaryCrossEntropyLoss<T>(),
             LossType.CategoricalCrossEntropy => new CategoricalCrossEntropyLoss<T>(),
             LossType.SparseCategoricalCrossEntropy => new SparseCategoricalCrossEntropyLoss<T>(),

--- a/src/Video/ActionRecognition/SlowFast.cs
+++ b/src/Video/ActionRecognition/SlowFast.cs
@@ -775,7 +775,7 @@ public class SlowFast<T> : NeuralNetworkBase<T>
         else
         {
             System.Diagnostics.Debug.WriteLine(
-                $"Warning: Serialized loss function type '{lossFunctionTypeName}' could not be resolved. Falling back to CrossEntropyLoss.");
+                $"Warning: Serialized loss function type '{lossFunctionTypeName}' could not be resolved. Falling back to CrossEntropyWithLogitsLoss.");
             _lossFunction = new CrossEntropyWithLogitsLoss<T>();
         }
 

--- a/src/Video/ActionRecognition/SlowFast.cs
+++ b/src/Video/ActionRecognition/SlowFast.cs
@@ -185,7 +185,7 @@ public class SlowFast<T> : NeuralNetworkBase<T>
         int fastChannels = 8,
         int alpha = 8,
         SlowFastOptions? options = null)
-        : base(architecture, lossFunction ?? new CrossEntropyLoss<T>())
+        : base(architecture, lossFunction ?? new CrossEntropyWithLogitsLoss<T>())
     {
         _options = options ?? new SlowFastOptions();
         Options = _options;
@@ -226,7 +226,7 @@ public class SlowFast<T> : NeuralNetworkBase<T>
         _alpha = alpha;
         _imageSize = architecture.InputHeight > 0 ? architecture.InputHeight : 224;
 
-        _lossFunction = lossFunction ?? new CrossEntropyLoss<T>();
+        _lossFunction = lossFunction ?? new CrossEntropyWithLogitsLoss<T>();
         _optimizer = optimizer ?? new AdamOptimizer<T, Tensor<T>, Tensor<T>>(this);
         _probabilityActivation = probabilityActivation ?? new SoftmaxActivation<T>();
         _customFastLayers = customFastLayers;
@@ -256,7 +256,7 @@ public class SlowFast<T> : NeuralNetworkBase<T>
         int fastChannels = 8,
         int alpha = 8,
         SlowFastOptions? options = null)
-        : base(architecture, new CrossEntropyLoss<T>())
+        : base(architecture, new CrossEntropyWithLogitsLoss<T>())
     {
         _options = options ?? new SlowFastOptions();
         Options = _options;
@@ -285,7 +285,7 @@ public class SlowFast<T> : NeuralNetworkBase<T>
         _fastChannels = fastChannels;
         _alpha = alpha;
         _imageSize = architecture.InputHeight > 0 ? architecture.InputHeight : 224;
-        _lossFunction = new CrossEntropyLoss<T>();
+        _lossFunction = new CrossEntropyWithLogitsLoss<T>();
         _probabilityActivation = probabilityActivation ?? new SoftmaxActivation<T>();
 
         try
@@ -770,13 +770,13 @@ public class SlowFast<T> : NeuralNetworkBase<T>
         var lossFunctionType = Type.GetType(lossFunctionTypeName);
         if (lossFunctionType != null)
         {
-            _lossFunction = (ILossFunction<T>?)Activator.CreateInstance(lossFunctionType) ?? new CrossEntropyLoss<T>();
+            _lossFunction = (ILossFunction<T>?)Activator.CreateInstance(lossFunctionType) ?? new CrossEntropyWithLogitsLoss<T>();
         }
         else
         {
             System.Diagnostics.Debug.WriteLine(
                 $"Warning: Serialized loss function type '{lossFunctionTypeName}' could not be resolved. Falling back to CrossEntropyLoss.");
-            _lossFunction = new CrossEntropyLoss<T>();
+            _lossFunction = new CrossEntropyWithLogitsLoss<T>();
         }
 
         // Recreate probability activation from type name

--- a/src/Video/ActionRecognition/TimeSformer.cs
+++ b/src/Video/ActionRecognition/TimeSformer.cs
@@ -181,7 +181,7 @@ public class TimeSformer<T> : NeuralNetworkBase<T>
         int patchSize = 16,
         AttentionType attentionType = AttentionType.DividedSpaceTime,
         TimeSformerOptions? options = null)
-        : base(architecture, lossFunction ?? new CrossEntropyLoss<T>())
+        : base(architecture, lossFunction ?? new CrossEntropyWithLogitsLoss<T>())
     {
         _options = options ?? new TimeSformerOptions();
         Options = _options;
@@ -205,7 +205,7 @@ public class TimeSformer<T> : NeuralNetworkBase<T>
         _numClasses = numClasses;
         _attentionType = attentionType;
 
-        _lossFunction = lossFunction ?? new CrossEntropyLoss<T>();
+        _lossFunction = lossFunction ?? new CrossEntropyWithLogitsLoss<T>();
         _optimizer = optimizer ?? new AdamOptimizer<T, Tensor<T>, Tensor<T>>(this);
 
         InitializeLayers();
@@ -224,7 +224,7 @@ public class TimeSformer<T> : NeuralNetworkBase<T>
         int numClasses = 400,
         int embedDim = 768,
         TimeSformerOptions? options = null)
-        : base(architecture, new CrossEntropyLoss<T>())
+        : base(architecture, new CrossEntropyWithLogitsLoss<T>())
     {
         _options = options ?? new TimeSformerOptions();
         Options = _options;
@@ -244,7 +244,7 @@ public class TimeSformer<T> : NeuralNetworkBase<T>
         _imageSize = architecture.InputHeight > 0 ? architecture.InputHeight : 224;
         _numClasses = numClasses;
         _attentionType = AttentionType.DividedSpaceTime;
-        _lossFunction = new CrossEntropyLoss<T>();
+        _lossFunction = new CrossEntropyWithLogitsLoss<T>();
 
         try
         {

--- a/src/Video/ActionRecognition/VideoMAE.cs
+++ b/src/Video/ActionRecognition/VideoMAE.cs
@@ -171,7 +171,7 @@ public class VideoMAE<T> : NeuralNetworkBase<T>
         int numFeatures = 768,
         double maskRatio = 0.9,
         VideoMAEOptions? options = null)
-        : base(architecture, lossFunction ?? new CrossEntropyLoss<T>())
+        : base(architecture, lossFunction ?? new CrossEntropyWithLogitsLoss<T>())
     {
         _options = options ?? new VideoMAEOptions();
         Options = _options;
@@ -211,7 +211,7 @@ public class VideoMAE<T> : NeuralNetworkBase<T>
         int numClasses = 400,
         int numFrames = 16,
         VideoMAEOptions? options = null)
-        : base(architecture, new CrossEntropyLoss<T>())
+        : base(architecture, new CrossEntropyWithLogitsLoss<T>())
     {
         _options = options ?? new VideoMAEOptions();
         Options = _options;


### PR DESCRIPTION
## Summary

- **141 files, 281 occurrences** swapped from `new CrossEntropyLoss<T>()` to `new CrossEntropyWithLogitsLoss<T>()`. All affected models emit raw conv/dense logits from identity-activated final layers, so the previous probability-input CE loss was driving `-actual/predicted` through `ClampProbability`'s epsilon floor and producing gradient spikes that exceed `MaxGradNorm=1.0` clipping in deep cascades.
- `CrossEntropyWithLogitsLoss<T>` is the PyTorch-equivalent fused LogSoftmax+NLL — numerically stable on raw logits.

## Confirmed gradient-explosion failures fixed

| Test                                          | Before (initial → final loss) | After  |
| --------------------------------------------- | ----------------------------- | ------ |
| PointTransformerV3.Training_ShouldReduceLoss | 1.26 → 16575 (13000×)         | PASS   |
| Sonata.Training_ShouldReduceLoss             | 0.96 → 10755                  | PASS   |
| SwinUNETR.Training_ShouldReduceLoss          | 0.34 → 9.6e17                 | PASS   |
| OMGSeg.Training_ShouldReduceLoss             | (was failing)                 | PASS   |

## Affected families

- ComputerVision/Segmentation: 69 files
- Document: 26
- Classification: 17
- NeuralNetworks: 9
- Audio: 8
- ProgramSynthesis: 4
- Video: 3
- NER: 2
- Training, FitnessCalculators, Finance: 3 total

`AiDotNet.LossFunctions` is a global using so no per-file using directives were needed.

## Test plan

- [x] `dotnet build src/AiDotNet.csproj --no-restore` — clean (0 errors)
- [x] Segmentation training tests: PTV3 / Sonata / SwinUNETR / OMGSeg — 4/4 PASS
- [x] Cross-family regression sweep (LayoutLM / Wav2Vec2 / CodeBERT / NodeClassificationModel) — identical 4-fail/1-pass on master baseline vs. branch. The failures (LayoutLM ParameterBuffer ArgumentException, Wav2Vec2 120s timeout) are **pre-existing** and unrelated to this loss change.
- [ ] Full CI sweep

Closes #1400. Also closes the PointTransformerV3 portion of #1314 (one of cluster-6's listed failures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes / Improvements**
  * Many models now default to a logits-compatible cross-entropy loss for more stable and consistent classification/segmentation training.
  * Speech recognition models now use a sequence-aware loss and refined training defaults for improved ASR training behavior.
  * Training runtime now tolerates lazily-initialized parameters to avoid buffer-related failures for large or on-demand models.
  * Attention paths avoid unnecessary allocations when auxiliary losses are disabled, reducing memory and overhead.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ooples/AiDotNet/pull/1404?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->