### PR TITLE
fix(#1406): pinn train silently no-op when reusing fused-plan thread cache

### DIFF
--- a/src/Training/CompiledTapeTrainingStep.cs
+++ b/src/Training/CompiledTapeTrainingStep.cs
@@ -35,6 +35,27 @@ public static class CompiledTapeTrainingStep<T>
     private static Tensor<T>[]? _cachedParameters;
 
     /// <summary>
+    /// AiDotNet#1406: identity of the trainable-layer set that produced
+    /// <see cref="_cachedParameters"/> and the cached compiled plan. The
+    /// per-thread cache above keys plans by tensor shape only, so two
+    /// distinct models with the same input/target shapes — created in
+    /// sequence on the same test thread, for example — would otherwise
+    /// share a single compiled plan. The plan's tensor leaves capture the
+    /// FIRST model's parameter refs, and a replay then "trains" model A's
+    /// (potentially garbage-collected) tensors while model B's params sit
+    /// untouched. Surfaced as
+    /// <c>ScientificMLTests.{Hamiltonian,Lagrangian}NeuralNetwork_TrainUpdatesParameters</c>
+    /// failing only when run after
+    /// <c>UniversalDifferentialEquation_TrainUpdatesParameters</c>.
+    /// We track the layer-set identity (element-wise <see cref="object.ReferenceEquals"/>)
+    /// and force <see cref="Invalidate"/> when it diverges from the cached
+    /// one. Per-instance optimizer state is reset as part of Invalidate, so
+    /// the next model gets a clean compile.
+    /// </summary>
+    [ThreadStatic]
+    private static object?[]? _cachedLayerSetIdentities;
+
+    /// <summary>
     /// AiDotNet#1331: persistent input tensor reused across <see cref="TryStepWithFusedOptimizer"/>
     /// calls. The compiled plan captures whatever tensor ref the trace lambda saw — if every call
     /// allocated a fresh <c>Tensor&lt;T&gt;</c> for <c>input</c> (the canonical PyTorch-style
@@ -170,6 +191,17 @@ public static class CompiledTapeTrainingStep<T>
 
         try
         {
+            // AiDotNet#1406: drop the cached compiled plan + parameter array
+            // when the caller has switched to a different layer set. Without
+            // this the next non-matching model on the same thread would
+            // replay the previous model's plan against its own (uninvolved)
+            // tensors — the plan was compiled with the FIRST model's leaf
+            // refs and the optimizer step would update those tensors, not
+            // the caller's.
+            if (InvalidateIfLayerSetChanged(layers))
+            {
+                // Caches cleared; cache field rebound below.
+            }
             var cache = _cache ??= new CompiledModelCache<T>();
 
             // Force layer initialization before collecting parameters.
@@ -183,7 +215,9 @@ public static class CompiledTapeTrainingStep<T>
             // TryStepWithFusedOptimizer. Shared/tied weights would otherwise
             // appear twice in the array — wrong for both eager-SGD here AND
             // wrong for the fused kernel's m/v buffers downstream.
+            bool firstCollectThisLifecycle = _cachedParameters is null;
             var parameters = _cachedParameters ??= CollectDeduplicatedParameters(layers);
+            if (firstCollectThisLifecycle) RememberLayerSet(layers);
 
             // Zero gradients before forward pass
             foreach (var layer in layers)
@@ -236,10 +270,52 @@ public static class CompiledTapeTrainingStep<T>
     /// <summary>
     /// Invalidates the compiled plan cache. Call when model structure changes.
     /// </summary>
+    /// <summary>
+    /// AiDotNet#1406: invalidates the per-thread compiled-plan cache when the
+    /// supplied trainable-layer set is not the same one that produced the
+    /// currently-cached parameters (compared element-wise by reference
+    /// identity). Returns <c>true</c> if an invalidation occurred. Cheap on
+    /// the steady state (single ref-compare per layer when the set matches);
+    /// only allocates on a model switch.
+    /// </summary>
+    private static bool InvalidateIfLayerSetChanged<TLayer>(IReadOnlyList<TLayer> layers) where TLayer : class
+    {
+        var cached = _cachedLayerSetIdentities;
+        if (cached is null) return false;
+
+        if (cached.Length != layers.Count)
+        {
+            Invalidate();
+            return true;
+        }
+        for (int i = 0; i < cached.Length; i++)
+        {
+            if (!ReferenceEquals(cached[i], layers[i]))
+            {
+                Invalidate();
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /// <summary>
+    /// Captures the current trainable-layer set's reference identities so a
+    /// subsequent call can detect a model switch. Called immediately after
+    /// the cache is populated for the first time in a given lifecycle.
+    /// </summary>
+    private static void RememberLayerSet<TLayer>(IReadOnlyList<TLayer> layers) where TLayer : class
+    {
+        var ids = new object?[layers.Count];
+        for (int i = 0; i < layers.Count; i++) ids[i] = layers[i];
+        _cachedLayerSetIdentities = ids;
+    }
+
     public static void Invalidate()
     {
         _cache?.Invalidate();
         _cachedParameters = null;
+        _cachedLayerSetIdentities = null;
         _configuredPlan = null;
         _configuredOptimizerConfig = null;
         // AiDotNet#1331: drop the persistent input/target tensors so the next
@@ -326,6 +402,16 @@ public static class CompiledTapeTrainingStep<T>
 
         try
         {
+            // AiDotNet#1406: drop the cached compiled plan + parameter array
+            // when the caller has switched to a different layer set. The
+            // per-thread cache keys plans by shape only, so two distinct
+            // models with the same (input, target) shapes — chained on the
+            // same test thread, for example — would otherwise replay the
+            // FIRST model's compiled plan against tensors that no longer
+            // exist on the live model. Symptom: post-Train params identical
+            // to pre-Train, even though LastLoss reports a non-zero loss
+            // (the plan ran on the previous model's now-stale tensors).
+            InvalidateIfLayerSetChanged(layers);
             var cache = _cache ??= new CompiledModelCache<T>();
 
             // AiDotNet#1331: ensure the persistent input/target tensors exist
@@ -406,7 +492,9 @@ public static class CompiledTapeTrainingStep<T>
             // weights (same Tensor<T> instance referenced by multiple layers)
             // would otherwise drive the fused kernel's m/v buffers to update
             // the same parameter twice per step, breaking Adam's moment math.
+            bool firstCollectThisLifecycle = _cachedParameters is null;
             var parameters = _cachedParameters ??= CollectDeduplicatedParameters(layers);
+            if (firstCollectThisLifecycle) RememberLayerSet(layers);
 
             foreach (var layer in layers)
                 layer.ZeroGrad();


### PR DESCRIPTION
## Summary

Two ScientificMLTests were failing only when run after a sibling test in the same class:

- `HamiltonianNeuralNetwork_TrainUpdatesParameters` 
- `LagrangianNeuralNetwork_TrainUpdatesParameters`

Each passes in isolation. Symptom: `model.Train(...)` returned in ~4 ms with `LastLoss` non-zero but **post-train parameters bit-identical to pre-train** (`before=[0.3,-0.4,0.2] after=[0.3,-0.4,0.2]`).

## Root cause

`CompiledTapeTrainingStep<T>` keeps a `[ThreadStatic]` cache of compiled plans, plus `_cachedParameters`, `_persistentInput`, `_persistentTarget`, etc. The cache key for both `Step` and `TryStepWithFusedOptimizer` is **just `(input shape, target shape)`** — the trainable-layer set is not part of the key.

In the failing test sequence:

1. `UniversalDifferentialEquation.Train` runs first → compiles a plan + caches a parameter array whose tensor leaves are UDE's model.
2. `HamiltonianNeuralNetwork.Train` then runs with the **same `[1,2] → [1,1]` shapes** → cache hit → the cached plan replays against UDE's (now uninvolved) parameter tensors. The optimizer dutifully updates *those* tensors; Hamiltonian/Lagrangian's actual layer weights never get touched.

The 4 ms execution time was the giveaway: pure compiled-plan replay, no real eager forward + backward + Adam step.

## Fix

Track the trainable-layer set's reference identities alongside the cached parameters. When a subsequent call arrives with a different layer set (element-wise `ReferenceEquals`), force `Invalidate()` so the cache rebuilds against the new model's tensors. Applied at both call sites (`Step` and `TryStepWithFusedOptimizer`). `Invalidate()` also clears the new `_cachedLayerSetIdentities` field so manual invalidation paths reset it too.

Steady-state cost: one reference compare per layer per train step. On a model switch we pay one cache rebuild — exactly the correctness boundary.

## Test plan

- [x] `ScientificMLTests` full class — 7/7 pass on net10.0 Release (was 5/7)
- [x] `FullyQualifiedName~PhysicsInformed|FullyQualifiedName~Training` — 46/46 pass
- [x] Build clean (0 errors, Release/net10.0)
- [x] Individual `HamiltonianNeuralNetwork_TrainUpdatesParameters` and `LagrangianNeuralNetwork_TrainUpdatesParameters` still pass (regression guard for the isolation case)

Closes #1406

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed cache invalidation mechanism to reliably detect layer set changes and automatically recompile using the current model's parameters.
  * Enhanced layer identity tracking to ensure both standard and optimized training modes correctly handle cache invalidation when model structure changes during training sessions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ooples/AiDotNet/pull/1411?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->