### PR TITLE
fix(release): wire AIDOTNET_LICENSE_KEY secret into smoke-test gate env

### DIFF
--- a/.github/workflows/automated-release.yml
+++ b/.github/workflows/automated-release.yml
@@ -306,6 +306,16 @@ jobs:
       # adopted the Category=Smoke convention.
       - name: Smoke tests (release gate)
         if: steps.version.outputs.should_release == 'true'
+        env:
+          # ProgramSynthesisCoverageSmokeTests (CodeT5, GraphCodeBERT)
+          # invoke GetModelMetadata which serializes the model via
+          # ModelPersistenceGuard.EnforceBeforeSerialize. Without a
+          # license key in the environment, the guard throws
+          # LicenseRequiredException and the release-gate fails — the
+          # symptom that blocked every release since the smoke gate was
+          # added. The secret holds the project's CI license; pipe it
+          # through here so LicenseKeyResolver.Resolve finds it.
+          AIDOTNET_LICENSE_KEY: ${{ secrets.AIDOTNET_LICENSE_KEY }}
         run: |
           dotnet test tests/AiDotNet.Tests/AiDotNetTests.csproj \
             --no-build -c Release --framework net10.0 \


### PR DESCRIPTION
## Urgent — automated release pipeline blocked

The "Automated Release Pipeline" workflow has failed on **every commit to master** for the last 4+ days, blocking all NuGet publishes and GitHub releases.

## Root cause

The smoke-test gate (line 307 of `automated-release.yml`) runs the test suite filtered by \`Category=Smoke|FullyQualifiedName~SmokeTests\`. Two of those tests:
- \`ProgramSynthesisCoverageSmokeTests.CodeT5_GetModelMetadata_ProducesTransformerMetadata\`
- \`ProgramSynthesisCoverageSmokeTests.GraphCodeBERT_GetModelMetadata_IncludesUseDataFlow\`

call \`GetModelMetadata\` → \`CreateTransformerModelMetadata\` → \`Serialize\` → \`ModelPersistenceGuard.EnforceBeforeSerialize\` → \`EnforceCore\`. With no license key visible to the runner, \`LicenseKeyResolver.Resolve\` returns null, \`EnforceCore\` falls through to trial enforcement, and \`LicenseRequiredException\` is thrown:

\`\`\`
AiDotNet.Exceptions.LicenseRequiredException : The configured license key is invalid or has been revoked.
   at AiDotNet.Helpers.ModelPersistenceGuard.EnforceCore() in src/Helpers/ModelPersistenceGuard.cs:line 290
   at AiDotNet.NeuralNetworks.NeuralNetworkBase\`1.Serialize() in src/NeuralNetworks/NeuralNetworkBase.cs:line 7081
   at AiDotNet.ProgramSynthesis.Engines.CodeModelBase\`1.CreateTransformerModelMetadata(...) in src/ProgramSynthesis/Engines/CodeModelBase.cs:line 121
\`\`\`

Two tests fail → smoke gate fails → Pack/Publish jobs are skipped → no release.

The repo already has the \`AIDOTNET_LICENSE_KEY\` secret configured. The workflow just never piped it through to the step that needs it.

## Fix

Add the standard \`env:\` block on the smoke step to inject the secret into the runner environment. \`LicenseKeyResolver\` (at \`src/Helpers/LicenseKeyResolver.cs:22\`) reads \`AIDOTNET_LICENSE_KEY\` from env as one of its three resolution sources; with the secret piped through, \`EnforceCore\` line 258 finds the key, \`ValidateLicenseKey\` returns \`Active\`, and the guard returns normally without throwing.

## What this is NOT

- NOT a license validity issue (the secret is valid)
- NOT a smoke-test design issue (the tests are legitimate; they exercise a real Serialize code path)
- NOT a \`ModelPersistenceGuard\` design issue (the guard correctly enforces persistence licensing)
- NOT a CodeModelBase design issue (Serialize is the right call for populating ModelData)

It's pure workflow plumbing — the secret wasn't passed through.

## Scope

Only \`.github/workflows/automated-release.yml\`, only the smoke-test step. The Build/Restore steps in the same job don't fire the persistence guard (it only triggers on Serialize/Deserialize/Save/Load, not on \`dotnet build\`). Other workflows (sonarcloud.yml's test shards) may need the same wiring if their filter happens to include \`ProgramSynthesisCoverageSmokeTests\` — out of scope for this urgent fix, separate audit-and-wire pass to follow if needed.

## Verification path

Once merged, the next push to master that produces a release will run the gate with \`AIDOTNET_LICENSE_KEY\` in env. \`EnforceCore\` will hit the \`Active\` branch (line 266-270) and return; the 2 failing tests will pass; Pack and Publish will run.

## Test plan

- [ ] CI runs on this PR
- [ ] After merge: next master push completes the release pipeline end-to-end
- [ ] Confirm NuGet publish + GitHub Release artifact created

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated release workflow to properly configure license requirements during smoke testing, improving release process reliability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ooples/AiDotNet/pull/1414?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->