### PR TITLE
perf(#1349): route Int8WeightOnlyMatMul through SgemmWithInt8RowScaledCachedB

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,20 +5,33 @@
   <ItemGroup>
     <!-- AiDotNet ecosystem -->
     <PackageVersion Include="AiDotNet" Version="0.113.0" />
-    <!-- AiDotNet.Tensors 0.84.1 — carries the blocker fixes for the previously-
-         draft framework PRs that depended on Tensors changes:
-           * #427 SgemmWithInt8RowScaledCachedB — per-row-scaled INT8 weight-only
-             GEMM (AiDotNet#1349 / PR #1417).
-           * #437 CpuEngine.LstmSequenceForward — fused recurrent forward
-             (AIsEval LSTM / PR #1457).
-           * #454 BroadcastElementwise SIMD perf (AiDotNet#1307 / PR #1448).
-         Plus the 0.81.4–0.82.5 fixes already in flight (GraphMode gradient
-         recording #367, FP64 SD UNet cliffs #410, fused-compiled VGG #416,
-         clCreateCommandQueue serialisation #418, TensorAllocator long-arith #424). -->
-    <PackageVersion Include="AiDotNet.Tensors" Version="0.84.1" />
-    <PackageVersion Include="AiDotNet.Native.OneDNN" Version="0.81.9" />
-    <PackageVersion Include="AiDotNet.Native.OpenBLAS" Version="0.82.5" />
-    <PackageVersion Include="AiDotNet.Native.CLBlast" Version="0.81.9" />
+    <!-- AiDotNet.Tensors 0.86.1 — bumped from 0.84.1 to unblock this PR (#1417).
+         The dep that gated this PR's INT8 wiring shipped: Tensors PR #427
+         (SgemmWithInt8RowScaledCachedB — per-row-scaled INT8 weight-only GEMM)
+         was merged 2026-05-22 and is published from 0.85.x onward; 0.86.1 is the
+         latest stable, so Int8WeightOnlyMatMul.cs's new single-call body now
+         compiles against the real Tensors API surface instead of a localverify.
+
+         Full v0.84.1 -> v0.86.1 delta picks up:
+           * Tensors #427 — SgemmWithInt8RowScaledCachedB (THIS PR's gating dep).
+           * Tensors #437 — CpuEngine.LstmSequenceForward (AIsEval LSTM / PR #1457).
+           * Tensors #454 — BroadcastElementwise SIMD perf (#1307 / PR #1448).
+           * Tensors #472 — Float32Precision opt-in for FusedAttention<double>.
+           * Tensors #485 — output-only SDPA (6.9x less alloc, 2.7x mean latency).
+           * Tensors #487 — GetSliceAlongDimension tape-backward.
+           * Tensors #488 — fused QKV + transpose-fused SDPA
+             (MHA 5.31 -> 2.26 ms; beats torch ~2.74 ms).
+           * Tensors #474 — small-batch native-BLAS thread cap inside MlpForward.
+           * Tensors #462 — hybrid hardware-aware GEMM strategy (seed + learned).
+           * TensorArena.CreatePersistent / Activate — zero-GC training arena.
+         Plus the 0.81.4–0.82.5 baseline (GraphMode gradient recording #367,
+         FP64 SD UNet cliffs #410, fused-compiled VGG #416, clCreateCommandQueue
+         serialisation #418, TensorAllocator long-arith #424).
+         All AiDotNet.Native packages coreleased to 0.86.1 in lockstep. -->
+    <PackageVersion Include="AiDotNet.Tensors" Version="0.86.1" />
+    <PackageVersion Include="AiDotNet.Native.OneDNN" Version="0.86.1" />
+    <PackageVersion Include="AiDotNet.Native.OpenBLAS" Version="0.86.1" />
+    <PackageVersion Include="AiDotNet.Native.CLBlast" Version="0.86.1" />
     <!-- Microsoft / .NET -->
     <PackageVersion Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageVersion Include="Microsoft.Data.Sqlite" Version="10.0.8" />

--- a/src/Inference/Quantization/Int8WeightOnlyMatMul.cs
+++ b/src/Inference/Quantization/Int8WeightOnlyMatMul.cs
@@ -4,24 +4,31 @@ using AiDotNet.Tensors.Engines.Simd;
 namespace AiDotNet.Inference.Quantization;
 
 /// <summary>
-/// Per-output-row INT8 weight-only matmul accelerated via the AiDotNet.Tensors
-/// SIMD GEMM. Replaces the scalar dequant-on-fly inner loop used by
-/// <see cref="QuantizedDenseLayer"/> and <see cref="QuantizedAttentionLayer"/>.
-///
-/// <para>The shape contract matches both consumers' existing layout:
+/// Per-output-row INT8 weight-only matmul. The shape contract:
 ///   C[m, n] = bias[n] + A[m, k] · dequant(B_int8[n, k], rowScales[n])
 /// where dequant(B[r, c], rowScales[r]) = B[r, c] * rowScales[r]. B is stored
 /// row-major as [n, k] (one int8 row per output column, the same convention
 /// <see cref="Int8WeightOnlyQuantization.QuantizePerRow(Tensor{float})"/>
-/// produces).</para>
+/// produces).
 ///
-/// <para>Implementation strategy: tile the output dimension so that each
-/// dequant-tile of B fits in L2 (≤192 KB by default), call the
-/// AVX2-vectorized <see cref="Int8Quantizer.DequantizeInt8ToFloat32"/> per row
-/// using that row's scale, then dispatch the FP32 tile through the public
-/// <see cref="SimdGemm.Sgemm"/> kernel (transposed B). This composes existing
-/// engine-level SIMD primitives — no System.Numerics, no scalar inner loop.
-/// Weights stay int8 in DRAM; only the active tile is materialized in FP32.</para>
+/// <para>Implementation: routes through
+/// <see cref="SimdGemm.SgemmWithInt8RowScaledCachedB"/> — a tiled GEMM that
+/// keeps weights in INT8 all the way through the macro-kernel and folds the
+/// per-row scales into the per-tile dequant. The pre-packed cache is keyed
+/// on the <c>sbyte[]</c> reference and survives across <c>Predict</c> calls,
+/// so the per-call cost reduces to PackA (activations only) + macro-kernel
+/// dispatch. INT8 weights stay 4× smaller than FP32 in DRAM, finally
+/// realizing the bandwidth saving that motivated the quantization in the
+/// first place. Closes AiDotNet#1349 once the Tensors NuGet ships with
+/// <see cref="SimdGemm.SgemmWithInt8RowScaledCachedB"/> (Tensors PR #427 /
+/// issue ooples/AiDotNet.Tensors#401).</para>
+///
+/// <para>Pre-#1349-fix path was: per-call ArrayPool rent + AVX2 dequant per
+/// tile into FP32 scratch + standard FP32 Sgemm + bias-scatter. That
+/// defeated the INT8 memory-bandwidth advantage because the FP32 scratch
+/// was the size of the active weight tile (and grew with batch). The new
+/// path never materializes the full FP32 weights — dequant is L1-resident
+/// inside the macro-kernel.</para>
 /// </summary>
 internal static class Int8WeightOnlyMatMul
 {
@@ -123,130 +130,34 @@ internal static class Int8WeightOnlyMatMul
                 "that fall-through must now either guard the call themselves or pre-fill the " +
                 "output span with the bias values before invocation (review #1363 C8QXn).");
 
-        int outputTile = ChooseTileSize(outputSize, inputSize);
+        // Single tiled INT8 GEMM call — weights stay int8 inside the cache
+        // and the macro-kernel's per-tile dequant, never materializing the
+        // full FP32 weight matrix. ChooseTileSize / per-call ArrayPool /
+        // outer dequant-then-Sgemm pattern were the source of the ~20×
+        // wall-clock gap reported in #1349; the new kernel collapses all
+        // of that to one call.
+        SimdGemm.SgemmWithInt8RowScaledCachedB(
+            a: input,
+            bInt8: weightsInt8,
+            rowScales: new ReadOnlySpan<float>(rowScales, 0, outputSize),
+            c: output.Slice(0, rows * outputSize),
+            m: rows,
+            k: inputSize,
+            n: outputSize);
 
-        // Allocate using long-typed sizes so overflow against int.MaxValue
-        // surfaces explicitly (e.g. outputTile=3000 × inputSize=4096 +
-        // future scale-up to 1M-row batches would silently wrap to a
-        // negative int and pass to Rent — review #1363 C6XFg). At the
-        // canary shapes covered by tests these products stay well under
-        // 2 GiB / 4 bytes per float, but the bound check matters once
-        // wider FFN / longer sequences land.
-        //
-        // Both products are guaranteed > 0 here (rows >= 1 by the
-        // outputSize/rows==0 early-return; inputSize > 0 by the
-        // inputSize==0 throw above; outputTile > 0 by ChooseTileSize's
-        // ≥ 1 contract). So this check is purely an overflow ceiling,
-        // not a positivity check (review #1363 C8QY_).
-        long dequantScratchLen = (long)outputTile * inputSize;
-        long tileOutputLen = (long)rows * outputTile;
-        if (dequantScratchLen > int.MaxValue || tileOutputLen > int.MaxValue)
-            throw new InvalidOperationException(
-                $"Tiled INT8 matmul exceeded int.MaxValue per-tile buffer (" +
-                $"dequantScratch={dequantScratchLen} from outputTile={outputTile}*inputSize={inputSize}; " +
-                $"tileOutput={tileOutputLen} from rows={rows}*outputTile={outputTile}). " +
-                "outputTile is chosen internally by ChooseTileSize; the caller-actionable knob is to " +
-                "split the call into smaller row batches (rows-by-rows external loop) before invoking " +
-                "MultiplyAddBias, OR to reduce inputSize / outputSize at the layer-shape level " +
-                "(review #1363 C8QXT).");
-
-        var pool = ArrayPool<float>.Shared;
-        // Both rents inside the try block so that if the SECOND rent
-        // throws (rare: pool exhaustion / OOM), the first buffer is
-        // still returned to the pool by the finally (review #1363
-        // C6XF6 — prior code rented before try and leaked dequantScratch
-        // on a tileOutput rent throw).
-        float[]? dequantScratch = null;
-        float[]? tileOutput = null;
-        try
+        // Bias-add. The new kernel writes C without bias; fold biases in
+        // via the same SimdKernels.VectorAdd primitive used before — one
+        // call per output row, AVX2-accelerated when available, scalar
+        // epilogue for the unaligned tail.
+        if (biases != null)
         {
-            dequantScratch = pool.Rent((int)dequantScratchLen);
-            tileOutput = pool.Rent((int)tileOutputLen);
-            for (int oBase = 0; oBase < outputSize; oBase += outputTile)
+            for (int r = 0; r < rows; r++)
             {
-                int tileN = Math.Min(outputTile, outputSize - oBase);
-                int dequantLen = tileN * inputSize;
-                int tileOutLen = rows * tileN;
-
-                // Dequantize tileN consecutive rows of int8 weights with per-row
-                // scale into the scratch buffer. Each call uses AVX2 internally
-                // when supported (see Int8Quantizer.DequantizeInt8ToFloat32) and
-                // fully writes its destination row from the int8 source, so the
-                // ArrayPool-returned uninitialized scratch is safe even though
-                // ArrayPool<T>.Shared.Rent does not zero on rent.
-                for (int oo = 0; oo < tileN; oo++)
-                {
-                    int o = oBase + oo;
-                    int srcStart = o * inputSize;
-                    int dstStart = oo * inputSize;
-                    Int8Quantizer.DequantizeInt8ToFloat32(
-                        new ReadOnlySpan<sbyte>(weightsInt8, srcStart, inputSize),
-                        dequantScratch.AsSpan(dstStart, inputSize),
-                        rowScales[o]);
-                }
-
-                // C_tile [rows, tileN] = A [rows, inputSize] @ B_tile^T (Sgemm
-                // overload with transB=true). Explicit tileSpan.Clear() is
-                // belt-and-braces against a future SimdGemm.Sgemm refactor
-                // that drops its implicit clear of c (review #1363 C6XGz
-                // shortened from the 8-line line-number reference).
-                var tileSpan = tileOutput.AsSpan(0, tileOutLen);
-                tileSpan.Clear();
-                SimdGemm.Sgemm(
-                    a: input,
-                    lda: inputSize,
-                    transA: false,
-                    b: new ReadOnlySpan<float>(dequantScratch, 0, dequantLen),
-                    ldb: inputSize,
-                    transB: true,
-                    c: tileSpan,
-                    m: rows,
-                    k: inputSize,
-                    n: tileN);
-
-                // Scatter tile into the strided output [rows, outputSize],
-                // adding the bias for this output-column block via
-                // AiDotNet.Tensors' SimdKernels.VectorAdd — the same
-                // accelerated SIMD primitive SimdGemm uses. Per the
-                // project-level rule, AiDotNet.Tensors is the in-tree
-                // SIMD library (full PyTorch parity); System.Numerics is
-                // banned. VectorAdd is one call per output row.
-                //
-                // tileN alignment: INTERIOR tiles (where oBase + outputTile
-                // < outputSize) are exactly outputTile elements wide,
-                // which ChooseTileSize sizes as a multiple of 16 for the
-                // AVX2 best-case path. The TAIL tile (last iteration when
-                // outputSize % outputTile != 0) is the remainder
-                // outputSize - oBase, which may not be a multiple of 16 —
-                // VectorAdd's scalar epilogue handles the unaligned tail
-                // correctly, just without the best-case throughput
-                // (review #1363 C8QW7 — earlier comment claimed all
-                // tiles are 16-aligned which was only true for interior
-                // tiles).
-                for (int r = 0; r < rows; r++)
-                {
-                    int srcRow = r * tileN;
-                    int dstRow = r * outputSize + oBase;
-                    var srcSpan = tileOutput.AsSpan(srcRow, tileN);
-                    var dstSpan = output.Slice(dstRow, tileN);
-                    if (biases != null)
-                    {
-                        var biasSpan = new ReadOnlySpan<float>(biases, oBase, tileN);
-                        AiDotNet.Tensors.Engines.Simd.SimdKernels.VectorAdd(srcSpan, biasSpan, dstSpan);
-                    }
-                    else
-                    {
-                        srcSpan.CopyTo(dstSpan);
-                    }
-                }
+                int dstRow = r * outputSize;
+                var rowSpan = output.Slice(dstRow, outputSize);
+                AiDotNet.Tensors.Engines.Simd.SimdKernels.VectorAdd(
+                    rowSpan, new ReadOnlySpan<float>(biases, 0, outputSize), rowSpan);
             }
-        }
-        finally
-        {
-            // Null-conditional Return so a mid-rent throw (only the FIRST
-            // rent succeeded) still returns what we have without an NRE.
-            if (dequantScratch is not null) pool.Return(dequantScratch);
-            if (tileOutput is not null) pool.Return(tileOutput);
         }
     }
 }

--- a/src/Inference/Quantization/Int8WeightOnlyMatMul.cs
+++ b/src/Inference/Quantization/Int8WeightOnlyMatMul.cs
@@ -130,12 +130,15 @@ internal static class Int8WeightOnlyMatMul
                 "that fall-through must now either guard the call themselves or pre-fill the " +
                 "output span with the bias values before invocation (review #1363 C8QXn).");
 
-        // Single tiled INT8 GEMM call — weights stay int8 inside the cache
-        // and the macro-kernel's per-tile dequant, never materializing the
-        // full FP32 weight matrix. ChooseTileSize / per-call ArrayPool /
-        // outer dequant-then-Sgemm pattern were the source of the ~20×
-        // wall-clock gap reported in #1349; the new kernel collapses all
-        // of that to one call.
+#if !NETFRAMEWORK
+        // net10.0 fast path: single tiled INT8 GEMM call — weights stay int8
+        // inside the cache and the macro-kernel's per-tile dequant, never
+        // materializing the full FP32 weight matrix. ChooseTileSize / per-call
+        // ArrayPool / outer dequant-then-Sgemm pattern (the #if NETFRAMEWORK
+        // branch below) were the source of the ~20× wall-clock gap reported in
+        // #1349; this kernel collapses all of that to one call.
+        // SgemmWithInt8RowScaledCachedB (Tensors #427) ships only in the net10.0
+        // Tensors build, so net471 keeps the proven dequant+Sgemm path below.
         SimdGemm.SgemmWithInt8RowScaledCachedB(
             a: input,
             bInt8: weightsInt8,
@@ -159,5 +162,84 @@ internal static class Int8WeightOnlyMatMul
                     rowSpan, new ReadOnlySpan<float>(biases, 0, outputSize), rowSpan);
             }
         }
+#else
+        // net471 fallback: SgemmWithInt8RowScaledCachedB is not present in the
+        // net471 Tensors build, so use the original per-tile dequant-into-FP32-
+        // scratch + SimdGemm.Sgemm path (functionally identical, just without the
+        // INT8-resident macro-kernel's DRAM-bandwidth win). Verified equivalent by
+        // Int8WeightOnlyMatMulTests.MultiplyAddBias_MatchesScalarReference.
+        int outputTile = ChooseTileSize(outputSize, inputSize);
+
+        long dequantScratchLen = (long)outputTile * inputSize;
+        long tileOutputLen = (long)rows * outputTile;
+        if (dequantScratchLen > int.MaxValue || tileOutputLen > int.MaxValue)
+            throw new InvalidOperationException(
+                $"Tiled INT8 matmul exceeded int.MaxValue per-tile buffer (" +
+                $"dequantScratch={dequantScratchLen} from outputTile={outputTile}*inputSize={inputSize}; " +
+                $"tileOutput={tileOutputLen} from rows={rows}*outputTile={outputTile}). " +
+                "Split the call into smaller row batches, OR reduce inputSize / outputSize.");
+
+        var pool = ArrayPool<float>.Shared;
+        float[]? dequantScratch = null;
+        float[]? tileOutput = null;
+        try
+        {
+            dequantScratch = pool.Rent((int)dequantScratchLen);
+            tileOutput = pool.Rent((int)tileOutputLen);
+            for (int oBase = 0; oBase < outputSize; oBase += outputTile)
+            {
+                int tileN = Math.Min(outputTile, outputSize - oBase);
+                int dequantLen = tileN * inputSize;
+                int tileOutLen = rows * tileN;
+
+                for (int oo = 0; oo < tileN; oo++)
+                {
+                    int o = oBase + oo;
+                    int srcStart = o * inputSize;
+                    int dstStart = oo * inputSize;
+                    Int8Quantizer.DequantizeInt8ToFloat32(
+                        new ReadOnlySpan<sbyte>(weightsInt8, srcStart, inputSize),
+                        dequantScratch.AsSpan(dstStart, inputSize),
+                        rowScales[o]);
+                }
+
+                var tileSpan = tileOutput.AsSpan(0, tileOutLen);
+                tileSpan.Clear();
+                SimdGemm.Sgemm(
+                    a: input,
+                    lda: inputSize,
+                    transA: false,
+                    b: new ReadOnlySpan<float>(dequantScratch, 0, dequantLen),
+                    ldb: inputSize,
+                    transB: true,
+                    c: tileSpan,
+                    m: rows,
+                    k: inputSize,
+                    n: tileN);
+
+                for (int r = 0; r < rows; r++)
+                {
+                    int srcRow = r * tileN;
+                    int dstRow = r * outputSize + oBase;
+                    var srcSpan = tileOutput.AsSpan(srcRow, tileN);
+                    var dstSpan = output.Slice(dstRow, tileN);
+                    if (biases != null)
+                    {
+                        var biasSpan = new ReadOnlySpan<float>(biases, oBase, tileN);
+                        AiDotNet.Tensors.Engines.Simd.SimdKernels.VectorAdd(srcSpan, biasSpan, dstSpan);
+                    }
+                    else
+                    {
+                        srcSpan.CopyTo(dstSpan);
+                    }
+                }
+            }
+        }
+        finally
+        {
+            if (dequantScratch is not null) pool.Return(dequantScratch);
+            if (tileOutput is not null) pool.Return(tileOutput);
+        }
+#endif
     }
 }

--- a/src/Inference/Quantization/Int8WeightOnlyMatMul.cs
+++ b/src/Inference/Quantization/Int8WeightOnlyMatMul.cs
@@ -158,7 +158,7 @@ internal static class Int8WeightOnlyMatMul
             {
                 int dstRow = r * outputSize;
                 var rowSpan = output.Slice(dstRow, outputSize);
-                AiDotNet.Tensors.Engines.Simd.SimdKernels.VectorAdd(
+                SimdKernels.VectorAdd(
                     rowSpan, new ReadOnlySpan<float>(biases, 0, outputSize), rowSpan);
             }
         }


### PR DESCRIPTION
> ⚠️ **DRAFT** — depends on [`ooples/AiDotNet.Tensors#427`](https://github.com/ooples/AiDotNet.Tensors/pull/427) publishing a new NuGet. Will not compile until then. Held as draft to track the dependency.

## Summary

Closes #1349 once the Tensors NuGet bump lands.

Replaces the current `Int8WeightOnlyMatMul.MultiplyAddBias` body — per-call `ArrayPool.Rent`, per-tile AVX2 dequant into FP32 scratch, standard FP32 `SimdGemm.Sgemm`, SIMD bias-scatter — with a single call to the new `SimdGemm.SgemmWithInt8RowScaledCachedB` kernel + a one-row `SimdKernels.VectorAdd` bias pass:

```csharp
SimdGemm.SgemmWithInt8RowScaledCachedB(
    a: input, bInt8: weightsInt8, rowScales: rowScales,
    c: output, m: rows, k: inputSize, n: outputSize);
if (biases != null) { /* per-row VectorAdd */ }
```

The new kernel keeps weights in INT8 all the way through the macro-kernel and folds per-row scales into the per-tile dequant. The 4× DRAM-bandwidth advantage of INT8 weights is finally realized at inference instead of being destroyed by materializing the full FP32 weight matrix in scratch.

## Behavior parity

- Same matmul contract: `C[r, o] = bias[o] + A[r, i] · (B_int8[o, i] * rowScales[o])`
- Same `[n, k]` weight layout (matches `Int8WeightOnlyQuantization.QuantizePerRow` output)
- Same SNR envelope — the new kernel's tile pipeline is the same one the prior path drove via `Sgemm` after pre-dequanting

## Diff shape

Net **−89 lines** (177 → 56 in `Int8WeightOnlyMatMul.cs`). The deleted code was the per-call dequant + ArrayPool + tile-scatter loop. `ChooseTileSize` stays defined for now — existing unit tests reference it as a static heuristic; cleanup is a separate follow-up once this PR is buildable.

## Expected perf delta

Per the Tensors#401 downstream estimate:
- 16×64 transformer canary INT8/FP32 ratio: **~20× → ~3-5×**
- BERT-class shapes: full **4× DRAM saving** on weight loads

## Merge sequence

1. **Land Tensors#427** ([per-row-scaled INT8 GEMM kernel + tests](https://github.com/ooples/AiDotNet.Tensors/pull/427))
2. **Publish new `AiDotNet.Tensors` NuGet**
3. **Bump `Directory.Packages.props`** (literal edit — the comment block already documents which PR triggers the bump)
4. **Mark this PR ready for review** — CI then passes, perf assertions in `Int8InferenceModelIntegrationTests.FromTrained_PredictWallClockGapVsFP32_DocumentsCurrentState` can tighten

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Faster INT8 weight-only matrix multiplication for improved inference throughput on supported platforms.

* **Code Improvements**
  * Reduced implementation redundancy and simplified buffer handling for more reliable execution and a streamlined fallback path on legacy runtimes.

* **Chores**
  * Updated project comments documenting the dependency bump context and INT8 wiring notes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ooples/AiDotNet/pull/1417?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->