### PR TITLE
fix(scaffold): add Gemma3 + DeepSeekVL/InternVL family to patch-vision list

### DIFF
--- a/src/AiDotNet.Generators/TestScaffoldGenerator.cs
+++ b/src/AiDotNet.Generators/TestScaffoldGenerator.cs
@@ -1239,6 +1239,16 @@ public class TestScaffoldGenerator : IIncrementalGenerator
         "Cambrian", "Dragonfly", "Eagle", "Mantis", "Maya", "MiniCPM",
         "Molmo", "Monkey", "Moondream", "NVLM", "Ovis", "VILA",
         "PathVLM", "RadFM", "QVQ", "SkyworkR1V", "GeoChat", "RSGPT", "SkyEyeGPT",
+        // InstructionTuned VLMs that also resolve a 14-patch SigLIP / ViT-L
+        // encoder via ComputeVisualPatchSize (Gemma3: 896/sqrt(4096)=14,
+        // DeepSeekVL/2: ViT-L/14, InternVL family: ViT-L/14, Llama32Vision:
+        // ViT-L/14, Phi3Vision/Phi4Multimodal: CLIP ViT-L/14). PatchEmbedding
+        // throws "Image H/W (128/128) must be divisible by patchSize (14)"
+        // when the scaffold's default 128 isn't divisible by 14 — surfaced
+        // in PR #1408 Generated Layers shard run 26254401589 as 23 Gemma3
+        // tests all failing at the same Forward boundary.
+        "Gemma", "DeepSeekVL", "InternVL", "Llama32Vision",
+        "Phi3Vision", "Phi4Multimodal",
     };
 
     /// <summary>
@@ -4350,6 +4360,12 @@ public class TestScaffoldGenerator : IIncrementalGenerator
         {
             "BiomedCLIP" => true,
             "DFNCLIP" => true,
+            // Gemma3 (Google 2025): VisionDim=1152, DecoderDim=3584, 27 vision
+            // layers, 36 decoder layers, ImageSize=896 SigLIP-SO. Default Adam
+            // step OOMs the test runner before even completing the warm-up
+            // Predict — surfaced in PR #1408 Generated Layers shard as 23
+            // Gemma3 tests all failing.
+            "Gemma3" => true,
             _ => false,
         };
     }

--- a/src/VisionLanguage/InstructionTuned/Gemma3.cs
+++ b/src/VisionLanguage/InstructionTuned/Gemma3.cs
@@ -6,6 +6,7 @@ using AiDotNet.Models.Options;
 using AiDotNet.NeuralNetworks;
 using AiDotNet.Onnx;
 using AiDotNet.Optimizers;
+using AiDotNet.Tensors.Engines.DirectGpu;
 using AiDotNet.Tokenization;
 using AiDotNet.Tokenization.Interfaces;
 using AiDotNet.VisionLanguage.Interfaces;
@@ -137,6 +138,24 @@ public class Gemma3<T> : VisionLanguageModelBase<T>, IInstructionTunedVLM<T>
             ComputeEncoderDecoderBoundary();
         }
         ValidateEncoderDecoderBoundary(_encoderLayerEnd);
+
+        // NOTE: Gemma3 is paper-scale by default (VisionDim=1152, 27 vision
+        // layers, DecoderDim=3584, 36 decoder layers — Google's 4B/12B/27B
+        // SigLIP-SO family). The auto-detect streaming gate in
+        // NeuralNetworkBase reads ParameterCount, which returns 0 PRE-first-
+        // forward for lazy DenseLayers; the first warm-up Predict
+        // materializes the full lazy weight matrix on the GC heap and OOMs
+        // the runner before auto-detect gets a chance to engage.
+        //
+        // Calling ConfigureWeightLifetime(new GpuOffloadOptions()) here to
+        // pre-engage streaming was the natural fix but surfaces a downstream
+        // engine bug: when PredictEagerStreaming later calls
+        // RegisterLayerTrainableTensorsWithWeightRegistry on a lazy layer's
+        // freshly-materialized weights, DropStorageForStreaming throws
+        // "storage refcount is 2" — some view/rebind operation in
+        // PatchEmbeddingLayer's OnFirstForward leaves the weight tensor's
+        // storage shared. Deferring streaming pre-engagement until the
+        // engine-side refcount issue is fixed.
     }
 
     // Gemma-3 (Google 2025): 896 / sqrt(4096) = 14 — SigLIP 14x14 patches.


### PR DESCRIPTION
## Summary

**Part 1 — Patch-divisibility scaffold fix (lands):** Adds the missing patch-14 VL families to `TestScaffoldGenerator.s_patchVisionFamilies` so the auto-scaffold emits a 112-spatial (lcm of 14, 16) input shape that's divisible by their `PatchEmbeddingLayer`'s `patchSize=14`. Pre-fix the generic 128-spatial default hard-rejected at the first layer with `Image H/W (128/128) must be divisible by patchSize (14)`. Unblocks the patch-divisibility failure mode for Gemma3 + DeepSeekVL + InternVL + Llama32Vision + Phi3Vision + Phi4Multimodal. Also marks Gemma3 as paper-scale for iteration-count reductions.

**Part 2 — Streaming engagement investigation (documented, blocker upstream):** The user explicitly asked me to wire streaming for Gemma3's OOM. I traced the path: `LayerBase.UseStreamingAllocator` flag → `AllocateLazyWeight` routes through `WeightRegistry.AllocateStreaming` → `PredictEagerStreaming` engages on first forward. The natural fix was calling `ConfigureWeightLifetime(new GpuOffloadOptions())` in `Gemma3.InitializeLayers` after layer-list population. Prototyped locally and confirmed it engages — the lazy `DenseLayer.EnsureInitialized` routes through the streaming pool and skips the GC heap OOM entirely.

But the streaming path then surfaces a deeper engine-level bug:

```
System.InvalidOperationException : Streaming drop requires sole storage ownership;
storage refcount is 2. Register the weight via WeightRegistry before any
RebindStorageFrom / view operation that shares its storage.
  at TensorBase.DropStorageForStreaming
  at WeightRegistry.RegisterWeight
  at PredictEagerStreaming:3775 (RegisterLayerTrainableTensorsWithWeightRegistry)
  at Gemma3.Train
```

A view / init op in `PatchEmbeddingLayer.OnFirstForward` (Xavier init, `RegisterTrainableParameter`, or `ResolveShapes`) leaves the weight tensor's storage with refcount=2 by the time `PredictEagerStreaming`'s post-forward re-registration runs. `DropStorageForStreaming` refuses to silently drop in that state.

This is an engine-side issue separate from this PR's scope. The investigation is captured in the commit message of the second commit on this branch so the next pass has the reproduction and stack ready.

## Test plan

- [x] Local: generator + test project rebuild clean on both TFMs.
- [x] `Gemma3Tests.Architecture_ShouldBeNonNull` passes (was failing pre-fix at the PatchEmbedding boundary).
- [ ] CI: Generated Layers shard regression count drops on the next run for the patch-divisibility failures (does NOT unblock Gemma3 tests that go through `Predict` / `Train` — those need the streaming-engine fix).

## Follow-up tracking

- Engine: investigate the `refcount=2` in `DropStorageForStreaming` against `PatchEmbeddingLayer`'s lazy-weight init path.
- Once unblocked: re-introduce the `ConfigureWeightLifetime` call in `Gemma3.InitializeLayers` so the 23-test Gemma3 cascade fully resolves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved GPU handling for Gemma3 model initialization to address downstream engine issues.

* **New Features**
  * Extended support for additional instruction-tuned vision-language model configurations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ooples/AiDotNet/pull/1420?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->