### PR TITLE
fix(nn): close 16 pre-existing NN unit-test failures across SSM, embedding, masking, ports, and contracts

### DIFF
--- a/src/AiDotNet.Generators/TestScaffoldGenerator.cs
+++ b/src/AiDotNet.Generators/TestScaffoldGenerator.cs
@@ -3304,6 +3304,17 @@ public class TestScaffoldGenerator : IIncrementalGenerator
         if (layer.NormalizesInput)
             sb.AppendLine("    protected override bool ExpectsDifferentOutputForDifferentInputs => false;");
 
+        // Mirror EmitLayerTestClass — masking layers that legitimately emit
+        // ±Infinity (ALiBi, causal masks) need the finite-output invariant
+        // off on the dual-input scaffold too. The previous version only
+        // wired the override on the single-input emitter, so any
+        // ±Infinity-emitting layer that ended up with two inputs (e.g. a
+        // mask layer fed feature + position) silently re-enabled the
+        // IsInfinity check and the auto-generated test asserted contrary
+        // to the layer's documented contract.
+        if (layer.ProducesNonFiniteOutput)
+            sb.AppendLine("    protected override bool ExpectsFiniteOutput => false;");
+
         sb.AppendLine("}");
 
         var hintName = GeneratorHelpers.StripGenericSuffix(layer.FullyQualifiedName).Replace(".", "_") + "Tests.g.cs";
@@ -3345,6 +3356,13 @@ public class TestScaffoldGenerator : IIncrementalGenerator
             sb.AppendLine($"    protected override int[] InputShape => new[] {{ {layer.TestInputShape} }};");
         if (!layer.IsTrainable)
             sb.AppendLine("    protected override bool ExpectsTrainableParameters => false;");
+
+        // Mirror EmitLayerTestClass — masking layers that legitimately
+        // emit ±Infinity (ALiBi, causal masks) need the finite-output
+        // invariant off on the multi-input scaffold too. See the
+        // EmitDualInputLayerTestClass note above for the full rationale.
+        if (layer.ProducesNonFiniteOutput)
+            sb.AppendLine("    protected override bool ExpectsFiniteOutput => false;");
 
         sb.AppendLine("}");
 
@@ -3402,6 +3420,13 @@ public class TestScaffoldGenerator : IIncrementalGenerator
             sb.AppendLine($"    protected override int[] InputShape => new[] {{ {layer.TestInputShape} }};");
         if (!layer.IsTrainable)
             sb.AppendLine("    protected override bool ExpectsTrainableParameters => false;");
+
+        // Mirror EmitLayerTestClass — masking layers that legitimately
+        // emit ±Infinity (ALiBi, causal masks) need the finite-output
+        // invariant off on the graph-layer scaffold too. See the
+        // EmitDualInputLayerTestClass note above for the full rationale.
+        if (layer.ProducesNonFiniteOutput)
+            sb.AppendLine("    protected override bool ExpectsFiniteOutput => false;");
 
         sb.AppendLine("}");
 

--- a/src/AiDotNet.Generators/TestScaffoldGenerator.cs
+++ b/src/AiDotNet.Generators/TestScaffoldGenerator.cs
@@ -3050,6 +3050,7 @@ public class TestScaffoldGenerator : IIncrementalGenerator
     {
         bool isTrainable = true, hasTrainingMode = false, changesShape = false, isStateful = false;
         bool supportsBackprop = true, normalizesInput = false, usesSurrogateGradient = false;
+        bool producesNonFiniteOutput = false;
         int apiShape = LayerApiShapeSingleTensor;
         string testInputShape = "";
         string testConstructorArgs = "";
@@ -3098,6 +3099,9 @@ public class TestScaffoldGenerator : IIncrementalGenerator
                     case "UsesSurrogateGradient":
                         usesSurrogateGradient = (bool)(named.Value.Value ?? false);
                         break;
+                    case "ProducesNonFiniteOutput":
+                        producesNonFiniteOutput = (bool)(named.Value.Value ?? false);
+                        break;
                 }
             }
         }
@@ -3120,7 +3124,8 @@ public class TestScaffoldGenerator : IIncrementalGenerator
             TestConstructorArgs = testConstructorArgs,
             TestSetupCode = testSetupCode,
             NormalizesInput = normalizesInput,
-            UsesSurrogateGradient = usesSurrogateGradient
+            UsesSurrogateGradient = usesSurrogateGradient,
+            ProducesNonFiniteOutput = producesNonFiniteOutput
         };
     }
 
@@ -3234,6 +3239,13 @@ public class TestScaffoldGenerator : IIncrementalGenerator
         // Override ExpectsDifferentOutputForConstantInputs for normalizing layers
         if (layer.NormalizesInput)
             sb.AppendLine("    protected override bool ExpectsDifferentOutputForConstantInputs => false;");
+
+        // Override ExpectsFiniteOutput for masking layers that legitimately emit ±Infinity
+        // (ALiBi, causal masks, etc.) so the Forward_ShouldProduceFiniteOutput invariant
+        // skips the IsInfinity check. Per Gu & Dao 2023 + Press et al. 2022, -∞ at masked
+        // positions is the standard signal for the downstream softmax to assign exact zero.
+        if (layer.ProducesNonFiniteOutput)
+            sb.AppendLine("    protected override bool ExpectsFiniteOutput => false;");
 
         sb.AppendLine("}");
 
@@ -3417,6 +3429,7 @@ public class TestScaffoldGenerator : IIncrementalGenerator
         public string TestSetupCode { get; set; } = "";
         public bool NormalizesInput { get; set; }
         public bool UsesSurrogateGradient { get; set; }
+        public bool ProducesNonFiniteOutput { get; set; }
     }
 
     /// <summary>

--- a/src/Attributes/LayerAttributes.cs
+++ b/src/Attributes/LayerAttributes.cs
@@ -75,6 +75,17 @@ public sealed class LayerPropertyAttribute : Attribute
     /// The generator emits these as integer literal arguments: new LayerType&lt;double&gt;(4, 8).
     /// </summary>
     public string TestConstructorArgs { get; set; } = "";
+
+    /// <summary>
+    /// Whether the layer legitimately produces ±Infinity values in its Forward output,
+    /// by design rather than by numerical instability. Set true for attention masking
+    /// layers (ALiBi, causal masks) that emit -Infinity at future positions so the
+    /// downstream softmax assigns exactly zero weight to those positions. The test
+    /// scaffold generator translates this to an override of <c>ExpectsFiniteOutput</c>
+    /// on the generated layer test so the Forward_ShouldProduceFiniteOutput invariant
+    /// skips checking IsInfinity for these layers. Default: false.
+    /// </summary>
+    public bool ProducesNonFiniteOutput { get; set; }
 }
 
 /// <summary>

--- a/src/Diffusion/NoisePredictors/DiffusionResBlock.cs
+++ b/src/Diffusion/NoisePredictors/DiffusionResBlock.cs
@@ -181,13 +181,32 @@ public class DiffusionResBlock<T> : LayerBase<T>
     }
 
     /// <summary>
-    /// Declares named input ports. When <c>timeEmbedDim &gt; 0</c> this block
-    /// accepts a second <c>time_embed</c> input alongside the feature-map
-    /// <c>input</c>. The two inputs are SEMANTICALLY distinct (feature map vs
-    /// conditioning vector) so they get descriptive names rather than the
-    /// generic <c>input_0</c>/<c>input_1</c> used by symmetric n-ary layers
-    /// like AddLayer/ConcatenateLayer.
+    /// Declares named input ports. When <c>timeEmbedDim &gt; 0</c> this
+    /// block accepts a second <c>time_embed</c> input alongside the
+    /// feature-map <c>input</c>.
     /// </summary>
+    /// <remarks>
+    /// <para><b>Port naming convention across the codebase.</b> Two
+    /// conventions coexist:</para>
+    /// <list type="bullet">
+    /// <item><description><b>Semantic names</b> (this block:
+    /// <c>"input"</c>, <c>"time_embed"</c>) — used when inputs are
+    /// SEMANTICALLY distinct (feature map vs conditioning vector vs
+    /// attention mask, etc.). The name carries meaning that the caller
+    /// needs to wire correctly.</description></item>
+    /// <item><description><b>Indexed names</b> (<c>"input_0"</c>,
+    /// <c>"input_1"</c>, …) — used by symmetric n-ary layers like
+    /// <see cref="AiDotNet.NeuralNetworks.Layers.AddLayer{T}"/>,
+    /// <see cref="AiDotNet.NeuralNetworks.Layers.ConcatenateLayer{T}"/>,
+    /// <see cref="AiDotNet.NeuralNetworks.Layers.MultiplyLayer{T}"/>,
+    /// where the inputs are interchangeable.</description></item>
+    /// </list>
+    /// <para>Callers can discover the port names at runtime by reading
+    /// <c>layer.InputPorts</c> — each entry has a <c>Name</c> string
+    /// and a <c>Shape</c>. Pass tensors to
+    /// <see cref="Forward(IReadOnlyDictionary{string, Tensor{T}})"/>
+    /// keyed by those same names.</para>
+    /// </remarks>
     private IReadOnlyList<AiDotNet.NeuralNetworks.Layers.LayerPort>? _inputPortsCache;
     public override IReadOnlyList<AiDotNet.NeuralNetworks.Layers.LayerPort> InputPorts =>
         _inputPortsCache ??= _timeEmbedDim > 0

--- a/src/Diffusion/NoisePredictors/DiffusionResBlock.cs
+++ b/src/Diffusion/NoisePredictors/DiffusionResBlock.cs
@@ -148,6 +148,73 @@ public class DiffusionResBlock<T> : LayerBase<T>
                 activationFunction: new IdentityActivation<T>(),
                 initializationStrategy: InitializationStrategies<T>.Lazy);
         }
+
+        // Eagerly materialize all sublayer lazy weights so they participate
+        // in GetParameters / SetParameters. With pure-lazy init, two freshly-
+        // constructed blocks have all sublayer `_weights` as [0,0] placeholders;
+        // GetParameters on block1 returns a vector that excludes those zero-shape
+        // weights, SetParameters on block2 leaves them at [0,0], then both
+        // blocks lazy-init at first Forward with INDEPENDENT random weights
+        // and produce divergent outputs — breaking the
+        // `block2.SetParameters(block1.GetParameters()) ⇒ block2(x) == block1(x)`
+        // determinism contract relied on by tests and checkpoint reload.
+        //
+        // We trigger materialization by running one probe forward through the
+        // whole block (with NoGradScope so the tape stays clean), then reset
+        // per-step state. Memory cost: one [1, C, S, S] tensor's worth of
+        // intermediate activations per block at construction time, returned
+        // to the pool by ResetState. Cheap relative to one training step.
+        {
+            using var _ = new AiDotNet.Tensors.Engines.Autodiff.NoGradScope<T>();
+            var probeInput = new Tensor<T>([1, inChannels, spatialSize, spatialSize]);
+            if (timeEmbedDim > 0)
+            {
+                var probeTime = new Tensor<T>([1, timeEmbedDim]);
+                Forward(probeInput, probeTime);
+            }
+            else
+            {
+                Forward(probeInput);
+            }
+            ResetState();
+        }
+    }
+
+    /// <summary>
+    /// Declares named input ports. When <c>timeEmbedDim &gt; 0</c> this block
+    /// accepts a second <c>time_embed</c> input alongside the feature-map
+    /// <c>input</c>. The two inputs are SEMANTICALLY distinct (feature map vs
+    /// conditioning vector) so they get descriptive names rather than the
+    /// generic <c>input_0</c>/<c>input_1</c> used by symmetric n-ary layers
+    /// like AddLayer/ConcatenateLayer.
+    /// </summary>
+    private IReadOnlyList<AiDotNet.NeuralNetworks.Layers.LayerPort>? _inputPortsCache;
+    public override IReadOnlyList<AiDotNet.NeuralNetworks.Layers.LayerPort> InputPorts =>
+        _inputPortsCache ??= _timeEmbedDim > 0
+            ?
+            [
+                new AiDotNet.NeuralNetworks.Layers.LayerPort("input", GetInputShape()),
+                new AiDotNet.NeuralNetworks.Layers.LayerPort("time_embed", new[] { _timeEmbedDim })
+            ]
+            :
+            [
+                new AiDotNet.NeuralNetworks.Layers.LayerPort("input", GetInputShape())
+            ];
+
+    /// <summary>
+    /// Named multi-input forward pass. Routes the dict-keyed inputs to the
+    /// existing positional <c>Forward(input, timeEmbed)</c> implementation.
+    /// </summary>
+    public override Tensor<T> Forward(IReadOnlyDictionary<string, Tensor<T>> inputs)
+    {
+        if (inputs is null) throw new ArgumentNullException(nameof(inputs));
+        if (!inputs.TryGetValue("input", out var input) || input is null)
+            throw new ArgumentException("DiffusionResBlock requires an 'input' tensor.", nameof(inputs));
+        if (_timeEmbedDim > 0 && inputs.TryGetValue("time_embed", out var timeEmbed) && timeEmbed is not null)
+        {
+            return Forward(input, timeEmbed);
+        }
+        return Forward(input);
     }
 
     /// <summary>

--- a/src/NeuralNetworks/Layers/ALiBiPositionalBiasLayer.cs
+++ b/src/NeuralNetworks/Layers/ALiBiPositionalBiasLayer.cs
@@ -37,7 +37,7 @@ namespace AiDotNet.NeuralNetworks.Layers;
 /// <typeparam name="T">The numeric type used for calculations, typically float or double.</typeparam>
 [LayerCategory(LayerCategory.Positional)]
 [LayerTask(LayerTask.PositionalEncoding)]
-[LayerProperty(IsTrainable = false, TestInputShape = "2, 4, 4", TestConstructorArgs = "2, 4")]
+[LayerProperty(IsTrainable = false, TestInputShape = "2, 4, 4", TestConstructorArgs = "2, 4", ProducesNonFiniteOutput = true)]
 internal partial class ALiBiPositionalBiasLayer<T> : LayerBase<T>
 {
     private readonly int _numHeads;
@@ -127,7 +127,18 @@ internal partial class ALiBiPositionalBiasLayer<T> : LayerBase<T>
         }
 
         var bias = new Tensor<T>([_numHeads, queryLen, keyLen]);
-        T negInf = NumOps.MinValue;
+        // Use true -Infinity (not MinValue) so the downstream softmax sees
+        // exp(-inf) = 0 EXACTLY on masked positions. NumOps.MinValue is a
+        // large finite value (~-3.4e38 for float) — exp of that underflows
+        // to 0 in normal cases but can leave tiny non-zero attention weight
+        // on masked positions under FP intermediate ordering, and any code
+        // path that ADDS bias values without going through softmax (e.g.
+        // residual-summing masked rows) accumulates a real finite penalty
+        // instead of cleanly masking. FromDouble preserves ±∞ for float /
+        // double specializations; the [LayerProperty(ProducesNonFiniteOutput
+        // = true)] annotation tells the test scaffold generator to skip
+        // the Forward_ShouldProduceFiniteOutput invariant for this layer.
+        T negInf = NumOps.FromDouble(double.NegativeInfinity);
 
         for (int h = 0; h < _numHeads; h++)
         {

--- a/src/NeuralNetworks/Layers/ALiBiPositionalBiasLayer.cs
+++ b/src/NeuralNetworks/Layers/ALiBiPositionalBiasLayer.cs
@@ -105,6 +105,20 @@ internal partial class ALiBiPositionalBiasLayer<T> : LayerBase<T>
     /// <param name="keyLen">Number of key positions.</param>
     /// <param name="useCausalMask">Whether to apply causal masking (future positions get -inf). Default: true.</param>
     /// <returns>Bias tensor of shape [numHeads, queryLen, keyLen].</returns>
+    /// <remarks>
+    /// Masked positions are filled with <see cref="double.NegativeInfinity"/>
+    /// (via <c>NumOps.FromDouble(double.NegativeInfinity)</c>), NOT
+    /// <c>NumOps.MinValue</c>. A literal −∞ guarantees the downstream softmax
+    /// sees <c>exp(−∞) = 0</c> exactly on masked positions; <c>MinValue</c>
+    /// is a large finite value (~−3.4e38 for float) whose exp underflows to
+    /// 0 most of the time but can leak tiny non-zero attention weight under
+    /// FP intermediate ordering, and any code path that ADDS the bias
+    /// without going through softmax (e.g. residual-summing) would
+    /// accumulate a real finite penalty instead of cleanly masking. The
+    /// <c>[LayerProperty(ProducesNonFiniteOutput = true)]</c> annotation
+    /// on this class tells the test scaffold generator to skip the
+    /// <c>Forward_ShouldProduceFiniteOutput</c> invariant.
+    /// </remarks>
     public Tensor<T> ComputeBias(int queryLen, int keyLen, bool useCausalMask = true)
     {
         if (useCausalMask && queryLen > keyLen)
@@ -127,17 +141,9 @@ internal partial class ALiBiPositionalBiasLayer<T> : LayerBase<T>
         }
 
         var bias = new Tensor<T>([_numHeads, queryLen, keyLen]);
-        // Use true -Infinity (not MinValue) so the downstream softmax sees
-        // exp(-inf) = 0 EXACTLY on masked positions. NumOps.MinValue is a
-        // large finite value (~-3.4e38 for float) — exp of that underflows
-        // to 0 in normal cases but can leave tiny non-zero attention weight
-        // on masked positions under FP intermediate ordering, and any code
-        // path that ADDS bias values without going through softmax (e.g.
-        // residual-summing masked rows) accumulates a real finite penalty
-        // instead of cleanly masking. FromDouble preserves ±∞ for float /
-        // double specializations; the [LayerProperty(ProducesNonFiniteOutput
-        // = true)] annotation tells the test scaffold generator to skip
-        // the Forward_ShouldProduceFiniteOutput invariant for this layer.
+        // True −Infinity for masked positions — see ComputeBias remarks
+        // for the full rationale (softmax exactness vs MinValue, the
+        // ProducesNonFiniteOutput annotation contract).
         T negInf = NumOps.FromDouble(double.NegativeInfinity);
 
         for (int h = 0; h < _numHeads; h++)

--- a/src/NeuralNetworks/Layers/EmbeddingLayer.cs
+++ b/src/NeuralNetworks/Layers/EmbeddingLayer.cs
@@ -391,9 +391,23 @@ public partial class EmbeddingLayer<T> : LayerBase<T>, IAuxiliaryLossLayer<T>, I
     /// </summary>
     private void InitializeProjectionWeights(Tensor<T> projectionWeights, int inputFeatures, int embeddingDim)
     {
+        // Projection weights are LAZILY allocated on first Forward — by then
+        // GetParameters() may already have run and returned a parameter vector
+        // that does NOT contain the projection (because it wasn't allocated
+        // yet). A subsequent SetParameters(thatVector) on a sibling layer will
+        // also see no projection slice and leave _projectionWeights = null on
+        // the receiving side, so the receiver's first Forward then allocates
+        // its OWN projection with independent randomness — breaking the
+        // determinism contract `model2.SetParameters(model1.GetParameters());
+        // model2.Predict(x) == model1.Predict(x)` that callers rely on (e.g.
+        // RWKV7/Mamba LM tests). Deriving the default seed from the projection
+        // SHAPE makes the lazy init shape-deterministic across sibling layers
+        // when no explicit RandomSeed is provided, restoring the contract
+        // without forcing eager allocation. Explicit RandomSeed still wins.
+        int defaultSeed = HashCode.Combine(inputFeatures, embeddingDim, _vocabularySize);
         Random random = RandomSeed.HasValue
             ? RandomHelper.CreateSeededRandom(RandomSeed.Value)
-            : RandomHelper.CreateSecureRandom();
+            : RandomHelper.CreateSeededRandom(defaultSeed);
         T scale = NumOps.FromDouble(Math.Sqrt(2.0 / (inputFeatures + embeddingDim)));
         for (int i = 0; i < projectionWeights.Length; i++)
         {
@@ -825,6 +839,19 @@ public partial class EmbeddingLayer<T> : LayerBase<T>, IAuxiliaryLossLayer<T>, I
 
     private bool IsContinuousInput(Tensor<T> input, int vocabularySize)
     {
+        // Shape-based detection: when the last axis equals the vocabulary size,
+        // the input is one-hot / probability distribution / continuous features
+        // along that axis (the standard LM input shape [B, T, V]). Treating
+        // those V values as token indices instead would mis-rank the output
+        // ([B, T, V, D] vs the correct [B, T, D]) and gather V embedding rows
+        // per (B, T) position. PyTorch's nn.Linear vs nn.Embedding split is
+        // shape-driven for the same reason — index inputs are shape [B, T],
+        // continuous inputs are shape [..., features].
+        if (input.Rank >= 2 && input.Shape[input.Rank - 1] == vocabularySize)
+        {
+            return true;
+        }
+
         for (int i = 0; i < input.Length; i++)
         {
             double val = NumOps.ToDouble(input.Data.Span[i]);

--- a/src/NeuralNetworks/Layers/SSM/MambaBlock.cs
+++ b/src/NeuralNetworks/Layers/SSM/MambaBlock.cs
@@ -432,7 +432,17 @@ internal partial class MambaBlock<T> : LayerBase<T>
         var outputWithBias = Engine.TensorBroadcastAdd(outputFlat, outBias2D);
         var output3D = Engine.Reshape(outputWithBias, new[] { batchSize, seqLen, _modelDimension });
 
-        var result = ApplyActivation(output3D);
+        // Residual connection: h = h + Block(h). Standard Mamba block pattern
+        // per Gu & Dao 2023 (state-spaces/mamba reference impl wraps the inner
+        // block in `residual + Block(LN(residual))`). Without it, repeated
+        // block stacks attenuate ~3 orders of magnitude per layer (observed
+        // 0.036 → 1e-38 through 4 blocks in MultiLayerModel_ProducesNonTrivialOutput),
+        // collapsing the LM head's logits to zero and producing a uniform
+        // distribution. input3D and output3D both have shape
+        // [batchSize, seqLen, _modelDimension] so the add is shape-aligned.
+        var residualOutput = Engine.TensorAdd(output3D, input3D);
+
+        var result = ApplyActivation(residualOutput);
         _lastOutput = result;
 
         // Reshape back to original rank

--- a/src/NeuralNetworks/VisionMambaModel.cs
+++ b/src/NeuralNetworks/VisionMambaModel.cs
@@ -242,7 +242,26 @@ public class VisionMambaModel<T> : NeuralNetworkBase<T>
     public override Tensor<T> Predict(Tensor<T> input)
     {
         SetTrainingMode(false);
+        return RunForward(input);
+    }
 
+    /// <summary>
+    /// ForwardForTraining MUST execute the same pipeline as Predict (patch
+    /// embed → positional → scan pattern → Mamba blocks → pool → norm →
+    /// classifier). The base implementation walks <c>Layers</c> directly,
+    /// but VisionMamba's Layers list only contains the MambaBlock stack —
+    /// patch embedding lives in this class's custom forward code. Without
+    /// the override, Train() feeds the raw [B,C,H,W] image straight into
+    /// MambaBlock[0] and crashes on the [16,16] x [32,128] matmul mismatch.
+    /// </summary>
+    public override Tensor<T> ForwardForTraining(Tensor<T> input)
+    {
+        SetTrainingMode(true);
+        return RunForward(input);
+    }
+
+    private Tensor<T> RunForward(Tensor<T> input)
+    {
         int rank = input.Shape.Length;
         int batchSize;
         Tensor<T> input4D;

--- a/tests/AiDotNet.Tests/ModelFamilyTests/Base/LayerTestBase.cs
+++ b/tests/AiDotNet.Tests/ModelFamilyTests/Base/LayerTestBase.cs
@@ -95,6 +95,16 @@ public abstract class LayerTestBase
     protected virtual bool ExpectsDifferentOutputForConstantInputs => true;
 
     /// <summary>
+    /// Whether the layer's Forward output is expected to consist entirely of finite
+    /// values. False for masking layers (ALiBi, causal attention masks) that emit
+    /// ±Infinity at masked positions by design — the downstream softmax converts
+    /// those to exact zero attention weight. The Forward_ShouldProduceFiniteOutput
+    /// invariant skips the IsInfinity check when this is false. The TestScaffold
+    /// generator emits an override of this from <c>[LayerProperty(ProducesNonFiniteOutput = true)]</c>.
+    /// </summary>
+    protected virtual bool ExpectsFiniteOutput => true;
+
+    /// <summary>
     /// Whether this layer supports testing with different activation functions.
     /// Override to true and implement CreateLayerWithActivation() for layers that
     /// accept activation function parameters in their options/constructor.
@@ -310,12 +320,16 @@ public abstract class LayerTestBase
         var output = layer.Forward(input);
 
         Assert.True(output.Length > 0, "Layer output should not be empty.");
+        bool checkFinite = ExpectsFiniteOutput;
         for (int i = 0; i < output.Length; i++)
         {
             Assert.False(double.IsNaN(output[i]),
                 $"Output[{i}] is NaN — numerical instability in Forward.");
-            Assert.False(double.IsInfinity(output[i]),
-                $"Output[{i}] is Infinity — overflow in Forward.");
+            if (checkFinite)
+            {
+                Assert.False(double.IsInfinity(output[i]),
+                    $"Output[{i}] is Infinity — overflow in Forward.");
+            }
         }
     }
 
@@ -571,6 +585,16 @@ public abstract class LayerTestBase
         Assert.Equal(originalOutput.Length, deserializedOutput.Length);
         for (int i = 0; i < originalOutput.Length; i++)
         {
+            // Direct equality check covers ±Infinity (where Math.Abs(inf - inf) = NaN
+            // would make the tolerance check spuriously fail for layers like ALiBi that
+            // legitimately emit -∞ at masked positions). For ordinary finite outputs the
+            // direct comparison still requires bit-exact roundtrip because serialization
+            // is lossless — fall back to the 1e-12 tolerance check only if they aren't
+            // bit-equal so legacy near-equal serialization formats remain accepted.
+            if (originalOutput[i] == deserializedOutput[i])
+            {
+                continue;
+            }
             Assert.True(Math.Abs(originalOutput[i] - deserializedOutput[i]) < 1e-12,
                 $"Output[{i}] differs after serialization roundtrip: " +
                 $"original={originalOutput[i]:G17}, deserialized={deserializedOutput[i]:G17}");

--- a/tests/AiDotNet.Tests/UnitTests/NeuralNetworks/LayerPortTests.cs
+++ b/tests/AiDotNet.Tests/UnitTests/NeuralNetworks/LayerPortTests.cs
@@ -56,8 +56,8 @@ public class LayerPortTests
     {
         var layer = new AddLayer<double>(new int[][] { new[] { 4 }, new[] { 4 } }, (IActivationFunction<double>?)null);
         Assert.Equal(2, layer.InputPorts.Count);
-        Assert.Equal("input_a", layer.InputPorts[0].Name);
-        Assert.Equal("input_b", layer.InputPorts[1].Name);
+        Assert.Equal("input_0", layer.InputPorts[0].Name);
+        Assert.Equal("input_1", layer.InputPorts[1].Name);
     }
 
     [Fact(Timeout = 120000)]
@@ -69,8 +69,8 @@ public class LayerPortTests
 
         var result = layer.Forward(new Dictionary<string, Tensor<double>>
         {
-            ["input_a"] = a,
-            ["input_b"] = b
+            ["input_0"] = a,
+            ["input_1"] = b
         });
 
         Assert.Equal(5.0, result[0], 10);

--- a/tests/AiDotNet.Tests/UnitTests/NeuralNetworks/Layers/RotaryPositionalEncodingLayerTests.cs
+++ b/tests/AiDotNet.Tests/UnitTests/NeuralNetworks/Layers/RotaryPositionalEncodingLayerTests.cs
@@ -16,21 +16,9 @@ public class RotaryPositionalEncodingLayerTests
         var layer = new RotaryPositionalEncodingLayer<float>(128, 64);
 
         Assert.NotNull(layer);
-        // RoPE (Su et al. 2021, RoFormer) is a deterministic rotation
-        // of query/key vectors using precomputed cosine/sine frequency
-        // caches — it has ZERO trainable parameters by construction. The
-        // ILayer.SupportsTraining contract (see Interfaces/ILayer.cs:273-283:
-        // "return false because they don't have parameters that need
-        // training") therefore requires `false` here, matching the
-        // PyTorch industry analog `any(p.requires_grad for p in
-        // module.parameters())` which is False for a parameter-free
-        // module (`any` of empty is False). The combined-usage pattern
-        // `Layers.Where(l => l.SupportsTraining && l.ParameterCount > 0)`
-        // used throughout NeuralNetworkBase confirms the property is
-        // load-bearing only when ParameterCount > 0, which RoPE never is.
-        // The previous `Assert.True` was inconsistent with both the
-        // documented contract and PyTorch semantics; fixed per the global
-        // rule's step 6 (test had a contract error) with justification.
+        // RoPE (Su et al. 2021) is a parameter-free rotation — ILayer
+        // contract says SupportsTraining is false when ParameterCount=0,
+        // matching PyTorch's `any(p.requires_grad …)` on an empty module.
         Assert.False(layer.SupportsTraining);
         Assert.Equal(0L, layer.ParameterCount);
     }

--- a/tests/AiDotNet.Tests/UnitTests/NeuralNetworks/Layers/RotaryPositionalEncodingLayerTests.cs
+++ b/tests/AiDotNet.Tests/UnitTests/NeuralNetworks/Layers/RotaryPositionalEncodingLayerTests.cs
@@ -16,7 +16,23 @@ public class RotaryPositionalEncodingLayerTests
         var layer = new RotaryPositionalEncodingLayer<float>(128, 64);
 
         Assert.NotNull(layer);
-        Assert.True(layer.SupportsTraining);
+        // RoPE (Su et al. 2021, RoFormer) is a deterministic rotation
+        // of query/key vectors using precomputed cosine/sine frequency
+        // caches — it has ZERO trainable parameters by construction. The
+        // ILayer.SupportsTraining contract (see Interfaces/ILayer.cs:273-283:
+        // "return false because they don't have parameters that need
+        // training") therefore requires `false` here, matching the
+        // PyTorch industry analog `any(p.requires_grad for p in
+        // module.parameters())` which is False for a parameter-free
+        // module (`any` of empty is False). The combined-usage pattern
+        // `Layers.Where(l => l.SupportsTraining && l.ParameterCount > 0)`
+        // used throughout NeuralNetworkBase confirms the property is
+        // load-bearing only when ParameterCount > 0, which RoPE never is.
+        // The previous `Assert.True` was inconsistent with both the
+        // documented contract and PyTorch semantics; fixed per the global
+        // rule's step 6 (test had a contract error) with justification.
+        Assert.False(layer.SupportsTraining);
+        Assert.Equal(0L, layer.ParameterCount);
     }
 
     [Theory]

--- a/tests/AiDotNet.Tests/UnitTests/NeuralNetworks/TransformerCustomLayerValidationIssue1317Tests.cs
+++ b/tests/AiDotNet.Tests/UnitTests/NeuralNetworks/TransformerCustomLayerValidationIssue1317Tests.cs
@@ -17,14 +17,10 @@ public class TransformerCustomLayerValidationIssue1317Tests
             new ShapeCompatibleCustomLayer([1, 16], [1, 256])
         };
 
-        // numEncoderLayers and numDecoderLayers must both be 0 when a custom
-        // `layers:` list is provided — the custom list REPLACES the auto-built
-        // encoder/decoder blocks, so passing non-zero counts here would
-        // silently ignore those structural params and produce a model with
-        // no attention/feed-forward path (vacuous 0-trainable-param training).
-        // The #1382 fail-fast throw enforces this. This test asserts the
-        // narrower #1317 claim: a shape-compatible custom layer is accepted
-        // without requiring built-in boundary layer types in the list.
+        // numEncoderLayers / numDecoderLayers must both be 0 when a custom
+        // `layers:` list is provided — the list replaces the auto-built
+        // structure (#1382 fail-fast throw). This test verifies #1317:
+        // shape-compatible custom layers are accepted.
         var architecture = new TransformerArchitecture<float>(
             inputType: InputType.OneDimensional,
             taskType: NeuralNetworkTaskType.SequenceClassification,

--- a/tests/AiDotNet.Tests/UnitTests/NeuralNetworks/TransformerCustomLayerValidationIssue1317Tests.cs
+++ b/tests/AiDotNet.Tests/UnitTests/NeuralNetworks/TransformerCustomLayerValidationIssue1317Tests.cs
@@ -17,10 +17,18 @@ public class TransformerCustomLayerValidationIssue1317Tests
             new ShapeCompatibleCustomLayer([1, 16], [1, 256])
         };
 
+        // numEncoderLayers and numDecoderLayers must both be 0 when a custom
+        // `layers:` list is provided — the custom list REPLACES the auto-built
+        // encoder/decoder blocks, so passing non-zero counts here would
+        // silently ignore those structural params and produce a model with
+        // no attention/feed-forward path (vacuous 0-trainable-param training).
+        // The #1382 fail-fast throw enforces this. This test asserts the
+        // narrower #1317 claim: a shape-compatible custom layer is accepted
+        // without requiring built-in boundary layer types in the list.
         var architecture = new TransformerArchitecture<float>(
             inputType: InputType.OneDimensional,
             taskType: NeuralNetworkTaskType.SequenceClassification,
-            numEncoderLayers: 1,
+            numEncoderLayers: 0,
             numDecoderLayers: 0,
             numHeads: 2,
             modelDimension: 16,


### PR DESCRIPTION
## Summary

Closes **16 of 17** pre-existing unit-test failures in `tests/AiDotNet.Tests/UnitTests/NeuralNetworks/` with zero regressions in the broader NN sweep (final state: 856 passed, 0 failed, 3 pre-existing skipped). Each commit is a self-contained logical change with an explanatory commit body; commit ordering reflects dependency between fixes (later commits' tests pass only because earlier commits' fixes are in place).

### Failure baseline (master, this branch's merge base)
17 failing tests across SSM language models, layer-port infrastructure, attention masking, transformer architecture validation, and positional encoding.

### Commits (7, all in `fix:`/`test:` lowercase per Conventional Commits)

1. **`4d6321622` fix(embeddinglayer)** — shape-aware continuous-input detection + deterministic projection seed
   - `IsContinuousInput` now treats `[B, T, V]` (last axis = vocabularySize) as continuous regardless of values, matching PyTorch's shape-driven `nn.Linear` vs `nn.Embedding` split. One-hot tensors (values strictly in {0,1}) were being mis-routed to the index path and producing rank-`rank+1` output. Lazy projection init now uses a shape-derived default seed (HashCode.Combine of dims) so two layers with identical embedding params produce identical projection weights without explicit RandomSeed.
   - Closes 8 SSM tests: `Mamba/RWKV7 LM Predict_2D/3D/Double + Train_FwdBwd`.

2. **`bd741716e` fix(mambablock)** — add residual connection per standard Mamba design
   - Per Gu & Dao 2023 (arXiv:2312.00752) and the `state-spaces/mamba` reference impl, each block wraps in `h = h + Block(h)`. Without it, repeated blocks attenuate ~3 orders of magnitude per layer (observed input range `[-0.23, 0.23]` decay to `[-1e-38, 1e-38]` through 4 stacked blocks).
   - Closes `MambaLanguageModelTests.MultiLayerModel_ProducesNonTrivialOutput`. All 34 MambaBlock-direct unit tests continue to pass.

3. **`abad6fee4` fix(visionmamba)** — override `ForwardForTraining` to run patch-embed pipeline
   - `Train()` routed through the base `ForwardForTraining` which iterates `Layers` directly. VisionMamba's `Layers` list contains only the MambaBlock stack — patch embedding, positional encoding, and bidirectional scan lived in custom code only inside `Predict()`. Extracted a shared `RunForward(input)` helper; both `Predict` and `ForwardForTraining` delegate to it after their respective `SetTrainingMode` calls.
   - Closes `VisionMambaModelTests.Train_ForwardBackwardUpdate_NoErrors`.

4. **`730a8831f` test(#1317)** — pass `numEncoderLayers=0` alongside custom layers list
   - The #1382 fail-fast throw catches a real footgun: silent param-ignore when `layers:` is provided alongside `numEncoderLayers > 0` produces a 0-trainable-param vacuous-training model. The narrower #1317 claim ("custom shape-compatible layers don't require built-in boundary layer types") is preserved by passing `numEncoderLayers=0 + numDecoderLayers=0` so the auto-build path is fully replaced. Kept the #1382 throw.

5. **`5503f5391` fix(layerports)** — align test naming + DiffusionResBlock named ports + eager-init for determinism
   - **Test alignment:** `AddLayer`/`ConcatenateLayer` use `input_0`/`input_1` numeric naming (matching `IntegrationTests/MultiInputPortTests.cs`); 4 unit tests updated to match.
   - **DiffusionResBlock named ports:** Added `InputPorts` override declaring `"input"` + `"time_embed"` (when `timeEmbedDim > 0`) and a `Forward(IReadOnlyDictionary)` override that routes dict-keyed inputs through the existing positional `Forward(input, timeEmbed)`. Semantically-distinct inputs get descriptive names rather than generic numeric.
   - **Determinism fix:** Eagerly materialize all sublayer lazy weights at DiffusionResBlock construction via a no-grad probe forward. Without this, GetParameters returns a vector that excludes `[0,0]`-placeholder weights and SetParameters on a sibling block leaves them at `[0,0]`, so the receiver's first forward lazy-inits with independent random weights — breaking the `block2.SetParameters(block1.GetParameters()) ⇒ block2(x) == block1(x)` contract.
   - Closes 4 LayerPortTests.

6. **`c2c3c20f9` fix(alibi)** — true `-Infinity` masks + `ProducesNonFiniteOutput` attribute opt-out (4 files)
   - ALiBi (Press et al. 2022) now emits `double.NegativeInfinity` at masked positions instead of `NumOps.MinValue`. Clean approach so the generated `Forward_ShouldProduceFiniteOutput` and `Serialize_Deserialize_ShouldPreserveBehavior` invariants don't false-positive on masking layers:
     - `LayerPropertyAttribute` gains `ProducesNonFiniteOutput` bool field.
     - ALiBi annotated with `[LayerProperty(..., ProducesNonFiniteOutput = true)]`.
     - `LayerTestBase` gains `protected virtual bool ExpectsFiniteOutput => true;` opt-out; `Forward_ShouldProduceFiniteOutput` skips IsInfinity check when false (IsNaN check still runs — NaN is always a bug).
     - `Serialize_Deserialize` short-circuits via bit-exact equality before the Math.Abs tolerance check so ±∞ roundtrips cleanly.
     - `TestScaffoldGenerator` reads the new flag and emits the `ExpectsFiniteOutput => false` override on the generated test class.
   - Closes `ALiBi.ComputeBias_FuturePositionsMasked`. All 33 ALiBi tests (unit + generated) pass.

7. **`bc6cd7912` test(rope)** — assert `SupportsTraining == false` per documented contract + PyTorch semantics
   - Researched and resolved with citations: PyTorch analog `any(p.requires_grad for p in parameters())` is False for parameter-free modules; AiDotNet's `ILayer.SupportsTraining` docs explicitly say "return false because they don't have parameters that need training"; `NeuralNetworkBase` always combines `SupportsTraining && ParameterCount > 0` making the property load-bearing only when ParameterCount > 0 (which RoPE never is). Test asserted True — wrong by both the documented contract and PyTorch semantics. Fixed per the global rule's step 6 (test had a contract error) with full justification.

## Test plan

- [x] `dotnet test --filter "FullyQualifiedName~UnitTests.NeuralNetworks"` on net10.0 — **856 passed, 0 failed, 3 skipped** (baseline: 17 failed)
- [x] All ALiBi tests (33) pass
- [x] All RotaryPositionalEncoding tests (20) pass
- [x] All VisionMamba tests (16) pass
- [x] All Mamba/RWKV7 LM unit tests pass
- [x] All MambaBlock-direct tests (34) pass
- [x] All LayerPort tests (12) pass
- [ ] CI green on push (will need to wait for full integration + multi-TFM run)

The one remaining pre-existing failure type from master (3 skipped tests) is unchanged on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Layers can now declare support for non-finite outputs (e.g., masked attention values, infinity).
  * Added named input-port support for multi-input layer operations.

* **Bug Fixes**
  * Fixed MambaBlock activation to apply to residual-connected output instead of raw output.
  * Fixed positional bias to use true infinity for attention masking.
  * Improved embedding layer continuous-input detection logic.

* **Improvements**
  * Embedding weights now deterministically initialized by default for better reproducibility.
  * Enhanced test framework to properly handle infinite-valued outputs without false failures.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ooples/AiDotNet/pull/1424?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->