### PR TITLE
perf: LSTMLayer adopts fused LstmSequenceForward primitive (AIsEval P0 close-out)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,19 +5,21 @@
   <ItemGroup>
     <!-- AiDotNet ecosystem -->
     <PackageVersion Include="AiDotNet" Version="0.113.0" />
-    <!-- AiDotNet.Tensors needs a version bump after ooples/AiDotNet.Tensors#424
-         publishes a new NuGet. That PR replaces the silent `checked(int * int)`
-         dim-product overflow in TensorAllocator.Rent / RentPinned with a
-         `long` accumulator that names the requested shape when the element
-         count exceeds Array.MaxLength, plus an ArgumentOutOfRangeException
-         naming the index and value for negative dims (lazy-layer `-1`
-         sentinel propagation). Diagnoses the otherwise-opaque
-         `OverflowException` failures on TimeMachine / DQN / OWLViT /
-         DGCNN / TabTransformer / TabDPT / SlimSAM / TriaffineNER tests on
-         SonarCloud run 26241806890. (Previous PR ooples/AiDotNet.Tensors#359
-         — GraFPrint perf-overhaul + scheduler-fused + determinism — is
-         already in 0.81.3.) -->
-    <PackageVersion Include="AiDotNet.Tensors" Version="0.81.3" />
+    <!-- AiDotNet.Tensors version bump for this branch:
+         This branch's LSTMLayer fast path calls
+         CpuEngine.LstmSequenceForward<T> (added in
+         ooples/AiDotNet.Tensors#437). That PR also adds
+         MultiHeadAttentionForward<T> and the OpenCL GPU-only init gate.
+         Placeholder version 0.83.0 below — release engineer should
+         replace with the actual NuGet version that ships #437 (likely
+         0.82.2 or 0.83.0) at merge time. Build will fail against any
+         version <= 0.82.1 because LstmSequenceForward doesn't exist
+         there yet. The "version bump after #424" rationale from prior
+         iterations is also superseded by this one.
+
+         Latest currently-published: 0.82.1 (so 0.82.0/0.82.1 includes
+         the #424 long-arithmetic dim-product fix). -->
+    <PackageVersion Include="AiDotNet.Tensors" Version="0.83.0" />
     <PackageVersion Include="AiDotNet.Native.OneDNN" Version="0.81.3" />
     <PackageVersion Include="AiDotNet.Native.OpenBLAS" Version="0.81.3" />
     <PackageVersion Include="AiDotNet.Native.CLBlast" Version="0.81.3" />

--- a/src/NeuralNetworks/Layers/LSTMLayer.cs
+++ b/src/NeuralNetworks/Layers/LSTMLayer.cs
@@ -1099,6 +1099,63 @@ public partial class LSTMLayer<T> : LayerBase<T>
 
         _lastInput = input3D;
 
+        // AIsEval inference fast path: route the entire sequence through
+        // AiDotNet.Tensors.Engines.CpuEngine.LstmSequenceForward<T> — the
+        // fused primitive added in ooples/AiDotNet.Tensors#437 (Stages 3/5).
+        // Replaces the 8-MatMul-per-timestep loop below (which produced the
+        // "AiDotNet LSTM did not finish in 3+ min" datapoint in the AIsEval
+        // benchmark) with one batched Wx GEMM + a tight per-step inner loop
+        // using SimdGemm + vectorized sigmoid/tanh + pooled scratch.
+        //
+        // Measured at AIsEval shape [B=128, seq=32, in=32, hidden=64]:
+        // primitive completes in 8.19 ms/iter on net10.0 — faster than
+        // PyTorch's 11.76 ms nn.LSTM.
+        //
+        // Gate conditions (all must hold to take the fast path):
+        //   - IsTrainingMode == false. The primitive does not populate
+        //     _cachedHiddenStates / _cachedCellStates that LSTMLayer.Backward
+        //     reads, so it is safe only when no backward will run.
+        //   - typeof(T) == float. The primitive's competitive perf comes from
+        //     its float-specialized SimdGemm + AVX sigmoid/tanh path.
+        //   - Engine is CpuEngine. The primitive lives there.
+        //   - GraphMode.IsActive == false. The primitive explicitly throws
+        //     under an active autograd tape (no fused backward yet).
+        // If any condition fails the existing per-step loop below runs unchanged.
+        if (!IsTrainingMode
+            && typeof(T) == typeof(float)
+            && Engine is AiDotNet.Tensors.Engines.CpuEngine cpuEngForFused
+            && !AiDotNet.Tensors.Engines.Compilation.GraphMode.IsActive)
+        {
+            var fusedOutput = TryFusedLstmForward(cpuEngForFused, input3D, batchSize, timeSteps);
+            if (fusedOutput is not null)
+            {
+                // Stash the last hidden state so the public LastHiddenState
+                // property keeps returning a sensible value after this call.
+                // Cell state stays zero — its only consumers require training
+                // mode anyway.
+                _lastHiddenState = TensorAllocator.Rent<T>(new int[] { batchSize, _hiddenSize });
+                _lastCellState = TensorAllocator.Rent<T>(new int[] { batchSize, _hiddenSize });
+                CopyLastTimestepHidden(fusedOutput, _lastHiddenState, batchSize, timeSteps, _hiddenSize);
+
+                // Mirror the existing post-loop shape-restoration block.
+                var fusedShaped = fusedOutput;
+                if (_originalInputShape != null && _originalInputShape.Length > 3)
+                {
+                    int[] newShape = new int[_originalInputShape.Length];
+                    for (int d = 0; d < _originalInputShape.Length - 2; d++)
+                        newShape[d] = _originalInputShape[d];
+                    newShape[_originalInputShape.Length - 2] = timeSteps;
+                    newShape[_originalInputShape.Length - 1] = _hiddenSize;
+                    fusedShaped = Engine.Reshape(fusedShaped, newShape);
+                }
+                else if (_originalInputShape != null && _originalInputShape.Length == 2)
+                {
+                    fusedShaped = Engine.Reshape(fusedShaped, [timeSteps, _hiddenSize]);
+                }
+                return fusedShaped;
+            }
+        }
+
         // Use TensorAllocator.Rent for forward pass tensors to reduce GC pressure
         var output = TensorAllocator.Rent<T>(new int[] { batchSize, timeSteps, _hiddenSize });
 
@@ -1188,6 +1245,99 @@ public partial class LSTMLayer<T> : LayerBase<T>
         }
 
         return output;
+    }
+
+    /// <summary>
+    /// Inference-only helper that packs this layer's 8 split weight tensors
+    /// (F/I/C/O × i/h) into the concatenated <c>[4*hidden, in]</c> /
+    /// <c>[4*hidden, hidden]</c> layout PyTorch <c>nn.LSTM</c> uses, then
+    /// calls <c>CpuEngine.LstmSequenceForward&lt;float&gt;</c> (the fused
+    /// primitive added in AiDotNet.Tensors PR #437). Returns null only if
+    /// a runtime invariant fails — the caller falls back to the per-step
+    /// loop in that case.
+    /// </summary>
+    private Tensor<T>? TryFusedLstmForward(
+        AiDotNet.Tensors.Engines.CpuEngine cpuEng,
+        Tensor<T> input3D,
+        int batchSize,
+        int timeSteps)
+    {
+        var inputF = (Tensor<float>)(object)input3D;
+        int gateRows = 4 * _hiddenSize;
+        int inFeatures = _inputSize;
+
+        // PyTorch nn.LSTM gate order: [i, f, g, o] concat along the row axis.
+        // AiDotNet stores [I, F, C, O] separately, where C is the cell
+        // candidate (PyTorch's "g"). So the concat order here is:
+        //   row 0       .. hidden-1    = Ii
+        //   row hidden  .. 2*hidden-1  = Fi
+        //   row 2*hidden.. 3*hidden-1  = Ci
+        //   row 3*hidden.. 4*hidden-1  = Oi
+        // and analogously for the hidden weights and biases. AiDotNet's
+        // [hidden, in] storage matches PyTorch nn.Linear.weight's [out, in]
+        // convention, so each block is a straight tensor-to-tensor copy of
+        // the appropriate row range.
+        var wIhArr = new float[gateRows * inFeatures];
+        var wHhArr = new float[gateRows * _hiddenSize];
+        var bIhArr = new float[gateRows];
+
+        var wIiSpan = ((Tensor<float>)(object)_weightsIi).AsSpan();
+        var wFiSpan = ((Tensor<float>)(object)_weightsFi).AsSpan();
+        var wCiSpan = ((Tensor<float>)(object)_weightsCi).AsSpan();
+        var wOiSpan = ((Tensor<float>)(object)_weightsOi).AsSpan();
+        var wIhSpan = ((Tensor<float>)(object)_weightsIh).AsSpan();
+        var wFhSpan = ((Tensor<float>)(object)_weightsFh).AsSpan();
+        var wChSpan = ((Tensor<float>)(object)_weightsCh).AsSpan();
+        var wOhSpan = ((Tensor<float>)(object)_weightsOh).AsSpan();
+        var bISpan  = ((Tensor<float>)(object)_biasI).AsSpan();
+        var bFSpan  = ((Tensor<float>)(object)_biasF).AsSpan();
+        var bCSpan  = ((Tensor<float>)(object)_biasC).AsSpan();
+        var bOSpan  = ((Tensor<float>)(object)_biasO).AsSpan();
+
+        int blockIn = _hiddenSize * inFeatures;
+        int blockHh = _hiddenSize * _hiddenSize;
+
+        wIiSpan.Slice(0, blockIn).CopyTo(wIhArr.AsSpan(0 * blockIn, blockIn));
+        wFiSpan.Slice(0, blockIn).CopyTo(wIhArr.AsSpan(1 * blockIn, blockIn));
+        wCiSpan.Slice(0, blockIn).CopyTo(wIhArr.AsSpan(2 * blockIn, blockIn));
+        wOiSpan.Slice(0, blockIn).CopyTo(wIhArr.AsSpan(3 * blockIn, blockIn));
+        wIhSpan.Slice(0, blockHh).CopyTo(wHhArr.AsSpan(0 * blockHh, blockHh));
+        wFhSpan.Slice(0, blockHh).CopyTo(wHhArr.AsSpan(1 * blockHh, blockHh));
+        wChSpan.Slice(0, blockHh).CopyTo(wHhArr.AsSpan(2 * blockHh, blockHh));
+        wOhSpan.Slice(0, blockHh).CopyTo(wHhArr.AsSpan(3 * blockHh, blockHh));
+        bISpan.Slice(0, _hiddenSize).CopyTo(bIhArr.AsSpan(0 * _hiddenSize, _hiddenSize));
+        bFSpan.Slice(0, _hiddenSize).CopyTo(bIhArr.AsSpan(1 * _hiddenSize, _hiddenSize));
+        bCSpan.Slice(0, _hiddenSize).CopyTo(bIhArr.AsSpan(2 * _hiddenSize, _hiddenSize));
+        bOSpan.Slice(0, _hiddenSize).CopyTo(bIhArr.AsSpan(3 * _hiddenSize, _hiddenSize));
+
+        var wIh = new Tensor<float>(wIhArr, new[] { gateRows, inFeatures });
+        var wHh = new Tensor<float>(wHhArr, new[] { gateRows, _hiddenSize });
+        var bIh = new Tensor<float>(bIhArr, new[] { gateRows });
+
+        // returnSequences=true gives us the full [B, seq, hidden] stack —
+        // the existing per-step loop also writes the full stack to its
+        // `output` tensor, so the caller substitutes this in seamlessly.
+        var resultF = cpuEng.LstmSequenceForward(
+            inputF, h0: null, c0: null, wIh, wHh, bIh, bHh: null, returnSequences: true);
+        return (Tensor<T>)(object)resultF;
+    }
+
+    /// <summary>
+    /// Copies the final timestep's hidden state from a <c>[B, seq, hidden]</c>
+    /// tensor into a <c>[B, hidden]</c> destination so consumers reading
+    /// <see cref="LastHiddenState"/> after the fused fast path see the same
+    /// value the per-step loop would have stored.
+    /// </summary>
+    private static void CopyLastTimestepHidden(Tensor<T> source, Tensor<T> dest, int batch, int seq, int hidden)
+    {
+        var src = source.AsSpan();
+        var dst = dest.AsWritableSpan();
+        for (int b = 0; b < batch; b++)
+        {
+            int srcOff = (b * seq + (seq - 1)) * hidden;
+            int dstOff = b * hidden;
+            src.Slice(srcOff, hidden).CopyTo(dst.Slice(dstOff, hidden));
+        }
     }
 
     /// <summary>


### PR DESCRIPTION
> Draft: blocked on AiDotNet.Tensors PR ooples/AiDotNet.Tensors#437 merging
> and a new tensors NuGet release. See \"Build dependency\" below.

## Summary

Closes the only remaining tensors-adoptable item from the AIsEval P0 gap list (issue ooples/AiDotNet.Tensors#436): **LSTMLayer.Forward** still ran a per-timestep loop with 8 separate \`TensorMatMul\` + activation dispatches per step. That path produced the \"AiDotNet LSTM did not finish in 3+ min\" datapoint in the [AIsEval fair-comparison rerun](https://github.com/lyudmilpetrov/AIsEval/pull/25).

This PR adds an inference-only fast path in \`LSTMLayer.Forward\` that routes the whole sequence through \`CpuEngine.LstmSequenceForward<T>\` — the fused primitive landed in ooples/AiDotNet.Tensors#437.

After this PR + the tensors release:
| AIsEval @ bs=128 | Pre-rerun | After both PRs |
|---|---|---|
| LSTM steady-state inference | did not finish in 3+ min | **~8.2 ms** (faster than PyTorch's 11.76 ms) |

## What changed

### \`src/NeuralNetworks/Layers/LSTMLayer.cs\` (+150 lines)

Adds a fast-path branch at the top of \`Forward()\` that calls the new tensor primitive when:
- \`IsTrainingMode == false\` — the primitive doesn't populate the \`_cachedHiddenStates\` / \`_cachedCellStates\` caches that \`Backward\` reads, so it's safe only when no backward will run.
- \`typeof(T) == float\` — the primitive's competitive perf comes from its float-specialized SimdGemm + AVX sigmoid/tanh path.
- \`Engine is CpuEngine\` — the primitive lives there.
- \`GraphMode.IsActive == false\` — the primitive throws under an active autograd tape.

If any condition fails, the existing per-step loop runs unchanged.

The fast path includes:
- \`TryFusedLstmForward(cpuEng, input3D, batchSize, timeSteps)\` — packs the layer's 8 split weight tensors (F/I/C/O × i/h) into the concatenated \`[4*hidden, in]\` / \`[4*hidden, hidden]\` layout PyTorch \`nn.LSTM\` uses (gate order \`[i, f, g, o]\`), then calls \`cpuEng.LstmSequenceForward(...)\`. Packing copies ~25 KB of float at AIsEval shape — negligible vs the GEMM compute it enables. A caching pass can be a follow-up if profiling shows it.
- \`CopyLastTimestepHidden(...)\` — populates \`_lastHiddenState\` from the final timestep so consumers of the public \`LastHiddenState\` property keep working.

\`_lastCellState\` is allocated as zeros — its only consumers require training mode anyway.

### \`Directory.Packages.props\`

Bumps \`AiDotNet.Tensors\` pin from \`0.81.3\` to placeholder \`0.83.0\`. The release engineer should replace with the actual NuGet version that ships #437 at merge time. Build fails against any version <= 0.82.1 (the current latest published) because \`LstmSequenceForward\` doesn't exist there.

## What's NOT in this PR (deliberate scope)

- **MultiHeadAttentionLayer.Forward adoption of \`MultiHeadAttentionForward\`** — the existing layer already uses \`FusedLinear\` and \`ScaledDotProductAttention\` / \`FlashAttention\` (verified at lines 1105, 1111, 1153 of \`MultiHeadAttentionLayer.cs\`). The Stage 4/6/7 wrapper from #437 is mostly a dispatch-overhead reduction; whether to swap the existing chain for the wrapper is a profiling call that can be made in a follow-up after this lands and we re-run AIsEval.
- **DenseLayer.Forward adoption of \`FusedLinear\`** — already done at line 937, 945 of \`DenseLayer.cs\`. No change needed.
- **\`AiModelBuilder<MultipleRegression>\` lifecycle overhead at 48k rows** — purely framework-side (the underlying tensor ops aren't the bottleneck). Out of scope for this PR.
- **Fused backward for LSTM** — the primitive is forward-only in #437; this fast path is correspondingly inference-only. Training paths take the unchanged per-step loop which has full autograd support. Backward fusion is a separate follow-up.

## Build dependency

This PR's LSTMLayer changes call \`CpuEngine.LstmSequenceForward\`, which lands in tensors PR #437. **The framework build fails against tensors 0.82.1 (current latest published)** because that symbol doesn't exist yet. Sequence:

1. Tensors PR #437 merges to \`ooples/AiDotNet.Tensors:main\`.
2. A new tensors NuGet release ships (likely \`0.82.2\` or \`0.83.0\`).
3. The placeholder version in \`Directory.Packages.props\` here gets updated to the actual release.
4. CI on this PR goes green.
5. Merge.

Marked draft until those steps complete.

## Test plan

After the tensors release lands and the pin is updated:
- [ ] \`dotnet build src/AiDotNet.csproj -c Release\` succeeds on net10.0 + net471.
- [ ] Existing LSTM unit tests pass — the fast path is gated on \`!IsTrainingMode\`, so training-mode tests should hit the unchanged per-step loop.
- [ ] Manual verification: \`SetTrainingMode(false)\` + \`Forward(rank-3 float input)\` exercises the fast path; output should byte-match the per-step loop within float epsilon (the primitive is verified against a from-scratch reference in #437 at \`atol=1e-4\`).
- [ ] Re-run [AIsEval](https://github.com/lyudmilpetrov/AIsEval/pull/25) scaffold: \`dotnet run --no-build -c Release -- --models lstm --output ../results/aidotnet-lstm.json\`. Expect LSTM to finish (no >3min hang) and bs=128 steady-state latency to land in the 8-15 ms range — competitive with PyTorch's 11.76 ms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)