### PR TITLE
chore: audit(2026-05) phase 2a slice 12: extract licensing concern

### DIFF
--- a/src/AiModelBuilder.cs
+++ b/src/AiModelBuilder.cs
@@ -165,6 +165,11 @@ public partial class AiModelBuilder<T, TInput, TOutput> : IAiModelBuilder<T, TIn
     private readonly AiDotNet.Configuration.IAiModelCompliance<T, TInput, TOutput> _compliance
         = new AiDotNet.Configuration.AiModelCompliance<T, TInput, TOutput>();
 
+    // audit-2026-05 phase 2a slice 12 — license / enterprise-gate concern. Holds both the user-
+    // supplied AiDotNetLicenseKey and the cached LicenseValidator; ConfigureLicenseKey resets
+    // the validator any time the key changes.
+    private AiDotNet.Configuration.IAiModelLicensing? _licensing;
+
     private PreprocessingPipeline<T, TInput, TInput>? _preprocessingPipeline;
     private PostprocessingPipeline<T, TOutput, TOutput>? _postprocessingPipeline;
 
@@ -515,7 +520,8 @@ public partial class AiModelBuilder<T, TInput, TOutput> : IAiModelBuilder<T, TIn
             throw new ArgumentException("Config file path cannot be null or empty.", nameof(configFilePath));
         }
 
-        _licenseKey = licenseKey;
+        _licensing = new AiDotNet.Configuration.AiModelLicensing(licenseKey);
+        _licenseKey = _licensing.LicenseKey;
 
         var fullPath = Path.GetFullPath(configFilePath);
         if (!File.Exists(fullPath))
@@ -538,7 +544,8 @@ public partial class AiModelBuilder<T, TInput, TOutput> : IAiModelBuilder<T, TIn
     /// </remarks>
     public AiModelBuilder(AiDotNetLicenseKey? licenseKey = null)
     {
-        _licenseKey = licenseKey;
+        _licensing = new AiDotNet.Configuration.AiModelLicensing(licenseKey);
+        _licenseKey = _licensing.LicenseKey;
     }
 
     /// <summary>
@@ -812,9 +819,9 @@ public partial class AiModelBuilder<T, TInput, TOutput> : IAiModelBuilder<T, TIn
     /// <inheritdoc />
     public IAiModelBuilder<T, TInput, TOutput> ConfigureLicenseKey(AiDotNetLicenseKey licenseKey)
     {
-        Guard.NotNull(licenseKey);
-        _licenseKey = licenseKey;
-        _licenseValidator = null; // Reset cached validator when key changes
+        _licensing!.ConfigureLicenseKey(licenseKey);
+        _licenseKey = _licensing.LicenseKey;
+        _licenseValidator = _licensing.Validator;
         return this;
     }
 

--- a/src/Configuration/AiModelLicensing.cs
+++ b/src/Configuration/AiModelLicensing.cs
@@ -1,0 +1,32 @@
+using AiDotNet.Helpers;
+using AiDotNet.Models;
+
+namespace AiDotNet.Configuration;
+
+/// <summary>
+/// Default implementation of <see cref="IAiModelLicensing"/>. Audit-2026-05 phase-2a slice 12.
+/// Mirrors the pre-refactor inline storage in <c>AiModelBuilder</c>: setting a new license key
+/// always nulls the cached validator so the next BuildAsync re-resolves against the fresh key.
+/// </summary>
+internal class AiModelLicensing : IAiModelLicensing
+{
+    /// <summary>Sets the license key from the constructor. The component starts with this value but the caller may override via <see cref="ConfigureLicenseKey"/>.</summary>
+    public AiModelLicensing(AiDotNetLicenseKey? initialLicenseKey = null)
+    {
+        LicenseKey = initialLicenseKey;
+    }
+
+    /// <inheritdoc/>
+    public AiDotNetLicenseKey? LicenseKey { get; private set; }
+
+    /// <inheritdoc/>
+    public LicenseValidator? Validator { get; set; }
+
+    /// <inheritdoc/>
+    public void ConfigureLicenseKey(AiDotNetLicenseKey licenseKey)
+    {
+        Guard.NotNull(licenseKey);
+        LicenseKey = licenseKey;
+        Validator = null; // reset cached validator — next BuildAsync re-resolves against the new key
+    }
+}

--- a/src/Configuration/IAiModelLicensing.cs
+++ b/src/Configuration/IAiModelLicensing.cs
@@ -1,0 +1,23 @@
+using AiDotNet.Helpers;
+using AiDotNet.Models;
+
+namespace AiDotNet.Configuration;
+
+/// <summary>
+/// Component that owns the enterprise-license configuration for an AI model build. Extracted
+/// from <c>AiModelBuilder</c> as slice 12 of the audit-2026-05 phase-2a DI refactor. Holds both
+/// the user-supplied key and the cached <see cref="LicenseValidator"/> derived from it; the
+/// component invalidates the validator any time the key changes so callers never see a stale
+/// validation result.
+/// </summary>
+internal interface IAiModelLicensing
+{
+    /// <summary>The configured license key (from constructor or <see cref="ConfigureLicenseKey"/>), or <c>null</c> if not supplied.</summary>
+    AiDotNetLicenseKey? LicenseKey { get; }
+
+    /// <summary>Cached license validator. <c>null</c> until BuildAsync resolves it; the component clears this slot any time the key changes.</summary>
+    LicenseValidator? Validator { get; set; }
+
+    /// <summary>Sets the license key and clears the cached validator (subsequent BuildAsync calls re-resolve).</summary>
+    void ConfigureLicenseKey(AiDotNetLicenseKey licenseKey);
+}

--- a/tests/AiDotNet.Tests/UnitTests/Configuration/AiModelLicensingTests.cs
+++ b/tests/AiDotNet.Tests/UnitTests/Configuration/AiModelLicensingTests.cs
@@ -1,0 +1,61 @@
+using System;
+using System.Threading.Tasks;
+using AiDotNet.Configuration;
+using AiDotNet.Models;
+using Xunit;
+
+namespace AiDotNet.Tests.UnitTests.Configuration;
+
+/// <summary>Audit-2026-05 phase-2a slice 12 — licensing component isolation tests.</summary>
+public class AiModelLicensingTests
+{
+    [Fact(Timeout = 30000)]
+    public async Task NullKey_Stored()
+    {
+        await Task.Yield();
+        var l = new AiModelLicensing();
+        Assert.Null(l.LicenseKey);
+        Assert.Null(l.Validator);
+    }
+
+    [Fact(Timeout = 30000)]
+    public async Task InitialKey_StoredFromCtor()
+    {
+        await Task.Yield();
+        var key = new AiDotNetLicenseKey("test-key-12345");
+        var l = new AiModelLicensing(key);
+        Assert.Same(key, l.LicenseKey);
+    }
+
+    [Fact(Timeout = 30000)]
+    public async Task ConfigureLicenseKey_Replaces()
+    {
+        await Task.Yield();
+        var key1 = new AiDotNetLicenseKey("k1");
+        var key2 = new AiDotNetLicenseKey("k2");
+        var l = new AiModelLicensing(key1);
+        l.ConfigureLicenseKey(key2);
+        Assert.Same(key2, l.LicenseKey);
+    }
+
+    [Fact(Timeout = 30000)]
+    public async Task ConfigureLicenseKey_NullArg_Throws()
+    {
+        await Task.Yield();
+        var l = new AiModelLicensing();
+        Assert.Throws<ArgumentNullException>(() => l.ConfigureLicenseKey(null!));
+    }
+
+    [Fact(Timeout = 30000)]
+    public async Task ConfigureLicenseKey_ResetsCachedValidator()
+    {
+        await Task.Yield();
+        var l = new AiModelLicensing(new AiDotNetLicenseKey("initial"));
+        // Simulate BuildAsync caching a validator after the initial key was set.
+        // We can't construct a real LicenseValidator from tests (it's internal with non-trivial
+        // dependencies), but Validator is settable so we can directly assert the contract.
+        l.Validator = null; // No-op; just demonstrates the slot exists.
+        l.ConfigureLicenseKey(new AiDotNetLicenseKey("rotated"));
+        Assert.Null(l.Validator);
+    }
+}


### PR DESCRIPTION
Stacked on #1435. Extracts ConfigureLicenseKey into `internal IAiModelLicensing` (internal because LicenseValidator is internal). Both ctors initialise the component with their optional licenseKey; ConfigureLicenseKey resets the cached validator on key change (preserves pre-refactor side-effect verbatim). 5/5 tests pass, both TFMs clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)