### PR TITLE
chore: audit(2026-05) phase 2a slice 10: extract observability concern

### DIFF
--- a/src/AiModelBuilder.cs
+++ b/src/AiModelBuilder.cs
@@ -174,6 +174,11 @@ public partial class AiModelBuilder<T, TInput, TOutput> : IAiModelBuilder<T, TIn
     private readonly AiDotNet.Configuration.IAiModelStorage<T, TInput, TOutput> _storage
         = new AiDotNet.Configuration.AiModelStorage<T, TInput, TOutput>();
 
+    // audit-2026-05 phase 2a slice 10 — observability concern (benchmarking, profiling,
+    // telemetry, GPU diagnostics).
+    private readonly AiDotNet.Configuration.IAiModelObservability _observability
+        = new AiDotNet.Configuration.AiModelObservability();
+
     private PreprocessingPipeline<T, TInput, TInput>? _preprocessingPipeline;
     private PostprocessingPipeline<T, TOutput, TOutput>? _postprocessingPipeline;
 
@@ -6251,7 +6256,8 @@ public partial class AiModelBuilder<T, TInput, TOutput> : IAiModelBuilder<T, TIn
 
     public IAiModelBuilder<T, TInput, TOutput> ConfigureTelemetry(TelemetryConfig? config = null)
     {
-        _telemetryConfig = config;
+        _observability.ConfigureTelemetry(config);
+        _telemetryConfig = _observability.TelemetryConfig;
         return this;
     }
 
@@ -6504,23 +6510,7 @@ public partial class AiModelBuilder<T, TInput, TOutput> : IAiModelBuilder<T, TIn
     public IAiModelBuilder<T, TInput, TOutput> ConfigureGpuDiagnostics(
         AiDotNet.Configuration.GpuDiagnosticsOptions? options = null)
     {
-        if (options is null) return this;
-
-        // Level wins over Verbose when both set — Level is the richer API.
-        if (options.Level is AiDotNet.Configuration.GpuDiagnosticLevel level)
-        {
-            AiDotNet.Configuration.GpuDiagnosticsConfig.Level = level;
-        }
-        else if (options.Verbose is bool verbose)
-        {
-            AiDotNet.Configuration.GpuDiagnosticsConfig.Verbose = verbose;
-        }
-
-        if (options.Sink is AiDotNet.Configuration.GpuDiagnosticSink sink)
-        {
-            AiDotNet.Configuration.GpuDiagnosticsConfig.Sink = sink;
-        }
-
+        _observability.ConfigureGpuDiagnostics(options);
         return this;
     }
 
@@ -6538,7 +6528,8 @@ public partial class AiModelBuilder<T, TInput, TOutput> : IAiModelBuilder<T, TIn
     /// </remarks>
     public IAiModelBuilder<T, TInput, TOutput> ConfigureBenchmarking(BenchmarkingOptions? options = null)
     {
-        _benchmarkingOptions = options ?? new BenchmarkingOptions();
+        _observability.ConfigureBenchmarking(options);
+        _benchmarkingOptions = _observability.BenchmarkingOptions;
         return this;
     }
 
@@ -6571,7 +6562,8 @@ public partial class AiModelBuilder<T, TInput, TOutput> : IAiModelBuilder<T, TIn
     /// </remarks>
     public IAiModelBuilder<T, TInput, TOutput> ConfigureProfiling(ProfilingConfig? config = null)
     {
-        _profilingConfig = config ?? new ProfilingConfig { Enabled = true };
+        _observability.ConfigureProfiling(config);
+        _profilingConfig = _observability.ProfilingConfig;
         return this;
     }
 

--- a/src/Configuration/AiModelObservability.cs
+++ b/src/Configuration/AiModelObservability.cs
@@ -1,0 +1,42 @@
+using AiDotNet.Deployment.Configuration;
+
+namespace AiDotNet.Configuration;
+
+/// <summary>Default implementation of <see cref="IAiModelObservability"/>. Audit-2026-05 phase-2a slice 10.</summary>
+public class AiModelObservability : IAiModelObservability
+{
+    public BenchmarkingOptions? BenchmarkingOptions { get; private set; }
+    public ProfilingConfig? ProfilingConfig { get; private set; }
+    public TelemetryConfig? TelemetryConfig { get; private set; }
+
+    public void ConfigureBenchmarking(BenchmarkingOptions? options)
+        => BenchmarkingOptions = options ?? new BenchmarkingOptions();
+
+    public void ConfigureProfiling(ProfilingConfig? config)
+        => ProfilingConfig = config ?? new ProfilingConfig { Enabled = true };
+
+    public void ConfigureTelemetry(TelemetryConfig? config) => TelemetryConfig = config;
+
+    public void ConfigureGpuDiagnostics(GpuDiagnosticsOptions? options)
+    {
+        // Mirrors the pre-refactor inline behavior verbatim: mutate the process-wide static
+        // GpuDiagnosticsConfig — no per-instance storage. Slices 2-12 generally avoid statics,
+        // but ConfigureGpuDiagnostics is a deliberate exception: GPU diagnostic level is a
+        // process-global setting, not a per-build configuration.
+        if (options is null) return;
+
+        if (options.Level is GpuDiagnosticLevel level)
+        {
+            GpuDiagnosticsConfig.Level = level;
+        }
+        else if (options.Verbose is bool verbose)
+        {
+            GpuDiagnosticsConfig.Verbose = verbose;
+        }
+
+        if (options.Sink is GpuDiagnosticSink sink)
+        {
+            GpuDiagnosticsConfig.Sink = sink;
+        }
+    }
+}

--- a/src/Configuration/IAiModelObservability.cs
+++ b/src/Configuration/IAiModelObservability.cs
@@ -1,0 +1,25 @@
+using AiDotNet.Deployment.Configuration;
+
+namespace AiDotNet.Configuration;
+
+/// <summary>
+/// Component that owns the observability configuration for an AI model build: benchmarking,
+/// profiling, telemetry, and GPU diagnostics. Audit-2026-05 phase-2a slice 10.
+/// </summary>
+public interface IAiModelObservability
+{
+    BenchmarkingOptions? BenchmarkingOptions { get; }
+    ProfilingConfig? ProfilingConfig { get; }
+    TelemetryConfig? TelemetryConfig { get; }
+
+    void ConfigureBenchmarking(BenchmarkingOptions? options);
+    void ConfigureProfiling(ProfilingConfig? config);
+    void ConfigureTelemetry(TelemetryConfig? config);
+
+    /// <summary>
+    /// Configures GPU diagnostics. Mutates the process-wide static
+    /// <see cref="GpuDiagnosticsConfig"/> directly per the pre-refactor semantics; no per-instance
+    /// state stored in this component.
+    /// </summary>
+    void ConfigureGpuDiagnostics(GpuDiagnosticsOptions? options);
+}

--- a/tests/AiDotNet.Tests/UnitTests/Configuration/AiModelObservabilityTests.cs
+++ b/tests/AiDotNet.Tests/UnitTests/Configuration/AiModelObservabilityTests.cs
@@ -1,0 +1,93 @@
+using System.Threading.Tasks;
+using AiDotNet.Configuration;
+using AiDotNet.Deployment.Configuration;
+using Xunit;
+
+namespace AiDotNet.Tests.UnitTests.Configuration;
+
+/// <summary>Audit-2026-05 phase-2a slice 10 — observability component isolation tests.</summary>
+public class AiModelObservabilityTests
+{
+    [Fact(Timeout = 30000)]
+    public async Task InitialState_AllSlotsAreNull()
+    {
+        await Task.Yield();
+        var o = new AiModelObservability();
+        Assert.Null(o.BenchmarkingOptions);
+        Assert.Null(o.ProfilingConfig);
+        Assert.Null(o.TelemetryConfig);
+    }
+
+    [Fact(Timeout = 30000)]
+    public async Task ConfigureBenchmarking_NullAppliesDefault()
+    {
+        await Task.Yield();
+        var o = new AiModelObservability();
+        o.ConfigureBenchmarking(null);
+        Assert.NotNull(o.BenchmarkingOptions);
+    }
+
+    [Fact(Timeout = 30000)]
+    public async Task ConfigureBenchmarking_ExplicitStored()
+    {
+        await Task.Yield();
+        var o = new AiModelObservability();
+        var opts = new BenchmarkingOptions();
+        o.ConfigureBenchmarking(opts);
+        Assert.Same(opts, o.BenchmarkingOptions);
+    }
+
+    [Fact(Timeout = 30000)]
+    public async Task ConfigureProfiling_NullAppliesEnabledDefault()
+    {
+        await Task.Yield();
+        var o = new AiModelObservability();
+        o.ConfigureProfiling(null);
+        Assert.NotNull(o.ProfilingConfig);
+        Assert.True(o.ProfilingConfig!.Enabled);
+    }
+
+    [Fact(Timeout = 30000)]
+    public async Task ConfigureTelemetry_NullIsValid()
+    {
+        await Task.Yield();
+        var o = new AiModelObservability();
+        o.ConfigureTelemetry(null);
+        Assert.Null(o.TelemetryConfig);
+    }
+
+    [Fact(Timeout = 30000)]
+    public async Task ConfigureTelemetry_ExplicitStored()
+    {
+        await Task.Yield();
+        var o = new AiModelObservability();
+        var cfg = new TelemetryConfig();
+        o.ConfigureTelemetry(cfg);
+        Assert.Same(cfg, o.TelemetryConfig);
+    }
+
+    [Fact(Timeout = 30000)]
+    public async Task ConfigureGpuDiagnostics_Null_NoOps()
+    {
+        await Task.Yield();
+        var o = new AiModelObservability();
+        o.ConfigureGpuDiagnostics(null); // should not throw
+    }
+
+    [Fact(Timeout = 30000)]
+    public async Task ConfigureGpuDiagnostics_LevelMutatesStatic()
+    {
+        await Task.Yield();
+        var o = new AiModelObservability();
+        var originalLevel = GpuDiagnosticsConfig.Level;
+        try
+        {
+            o.ConfigureGpuDiagnostics(new GpuDiagnosticsOptions { Level = GpuDiagnosticLevel.Verbose });
+            Assert.Equal(GpuDiagnosticLevel.Verbose, GpuDiagnosticsConfig.Level);
+        }
+        finally
+        {
+            GpuDiagnosticsConfig.Level = originalLevel; // restore process state
+        }
+    }
+}


### PR DESCRIPTION
Stacked on #1437. Extracts 4 observability Configure methods (Benchmarking, Profiling, Telemetry, GpuDiagnostics). GpuDiagnostics still mutates the process-wide static (preserved pre-refactor semantics). 8/8 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)