### PR TITLE
fix(#1462): green the PR #1455 CI shards — diffusion loss, CASTLE/CCM, Siamese clone

### DIFF
--- a/src/CausalDiscovery/DeepLearning/CASTLEAlgorithm.cs
+++ b/src/CausalDiscovery/DeepLearning/CASTLEAlgorithm.cs
@@ -9,28 +9,29 @@ namespace AiDotNet.CausalDiscovery.DeepLearning;
 /// </summary>
 /// <remarks>
 /// <para>
-/// CASTLE trains a neural network to predict each variable from the others, using a shared
-/// mask layer M that represents the adjacency matrix. For each target variable j, the
-/// input is masked by column j of M, then passed through shared hidden layers. The mask
-/// M is learned jointly with the network weights via L1 regularization and NOTEARS
-/// acyclicity constraint on M.
+/// CASTLE trains one neural sub-network f_j per variable to reconstruct x_j from the
+/// other variables. The causal adjacency is read directly from each sub-network's
+/// first-layer weights — A[i,j] = ‖Wh_j[i,:]‖, the influence of variable i on the
+/// reconstruction of variable j — rather than from a separate gate. Sparsity is imposed
+/// by a group-lasso penalty on those input-weight rows, and acyclicity by the NOTEARS
+/// constraint h(A) = tr(exp(A∘A)) − d = 0, enforced with an augmented Lagrangian.
 /// </para>
 /// <para>
 /// <b>Algorithm:</b>
 /// <list type="number">
-/// <item>Initialize mask M (d x d) with sigmoid logits and shared MLP weights</item>
-/// <item>For target j: input = X * diag(sigmoid(M[:,j])), excluding j</item>
-/// <item>Pass masked input through shared hidden layers (sigmoid activation)</item>
-/// <item>Compute MSE loss between prediction and X[:,j]</item>
-/// <item>Add L1 penalty on M and NOTEARS h(sigmoid(M)) = 0</item>
-/// <item>Update M and MLP weights via gradient descent</item>
-/// <item>Threshold final sigmoid(M) to get adjacency</item>
+/// <item>Standardize the data; initialize one MLP f_j per target (self-input held at 0)</item>
+/// <item>Forward: H = σ(X·Wh_j), pred = H·Wo_j; reconstruction MSE against x_j</item>
+/// <item>After a reconstruction-first warmup, add group-L1 on the Wh_j rows and the
+/// augmented-Lagrangian acyclicity gradient on A_sq[i,j] = ‖Wh_j[i,:]‖²</item>
+/// <item>Update all weights with Adam; dual-ascend α and escalate ρ to drive h→0</item>
+/// <item>Read adjacency from the final weight-row norms, normalize, and threshold</item>
 /// </list>
 /// </para>
 /// <para>
-/// <b>For Beginners:</b> CASTLE uses a neural network with a special "mask" that learns
-/// which inputs matter for predicting each variable. The mask ends up representing the
-/// causal graph — connections that help prediction stay, others are removed.
+/// <b>For Beginners:</b> CASTLE trains a little predictor for each variable that guesses
+/// it from the others. How strongly each other variable feeds into that predictor tells
+/// us how likely it is a cause. A sparsity penalty drops weak links and an acyclicity
+/// rule keeps the result a valid causal graph (no loops).
 /// </para>
 /// <para>
 /// Reference: Kyono et al. (2020), "CASTLE: Regularization via Auxiliary Causal Graph Discovery", NeurIPS.
@@ -63,138 +64,241 @@ public class CASTLEAlgorithm<T> : DeepCausalBase<T>
         int h = HiddenUnits;
         if (n < 3 || d < 2) return new Matrix<T>(d, d);
 
+        // ---- Standardize columns to zero mean / unit variance (NOTEARS, Zheng
+        // et al. 2018; CASTLE, Kyono et al. 2020, both preprocess this way).
+        // Vectorized via Engine: tile the per-column mean/inv-std into [n,d] with a
+        // ones[n,1] @ row[1,d] matmul (no broadcasting assumptions), then subtract /
+        // scale element-wise. Without standardization the method is data-scale
+        // dependent (DiscoverStructure_IsInvariantToDataScaling fails) and variables
+        // far down a causal chain have tiny variance, so their parent-mask gradients
+        // never separate from the 0.5 init. ----
+        var X = new Tensor<T>(new[] { n, d }, data);
+        var onesN1 = new Tensor<T>(new[] { n, 1 });
+        for (int s = 0; s < n; s++) onesN1[s, 0] = NumOps.One;
+        var meanRow = Engine.ReduceMean(X, new[] { 0 }, true);                  // [1,d]
+        var centered = Engine.TensorSubtract(X, Engine.TensorMatMul(onesN1, meanRow));
+        var varRow = Engine.ReduceMean(Engine.TensorMultiply(centered, centered), new[] { 0 }, true); // [1,d]
+        var invStdRow = new Tensor<T>(new[] { 1, d });
+        for (int j = 0; j < d; j++)
+        {
+            T v = varRow[0, j];
+            invStdRow[0, j] = NumOps.GreaterThan(v, NumOps.FromDouble(1e-12))
+                ? NumOps.Divide(NumOps.One, NumOps.Sqrt(v)) : NumOps.Zero;
+        }
+        var Xs = Engine.TensorMultiply(centered, Engine.TensorMatMul(onesN1, invStdRow)); // [n,d]
+
         var rng = Tensors.Helpers.RandomHelper.CreateSeededRandom(42);
         T initScale = NumOps.FromDouble(Math.Sqrt(2.0 / d));
 
-        // Mask logits M[i,j]: sigmoid(M[i,j]) = probability of edge i→j
-        var M = new Matrix<T>(d, d);
-
-        // Shared MLP: W_h (d x h), W_o (h x 1)
-        var Wh = new Matrix<T>(d, h);
-        var Wo = new Matrix<T>(h, 1);
-        for (int i = 0; i < d; i++)
-            for (int k = 0; k < h; k++)
-                Wh[i, k] = NumOps.Multiply(initScale, NumOps.FromDouble(rng.NextDouble() - 0.5));
-        for (int k = 0; k < h; k++)
-            Wo[k, 0] = NumOps.Multiply(initScale, NumOps.FromDouble(rng.NextDouble() - 0.5));
-
-        T lr = NumOps.FromDouble(LearningRate);
-        T lambda1 = NumOps.FromDouble(0.1);
-        T rho = NumOps.One;
-
-        for (int epoch = 0; epoch < MaxEpochs; epoch++)
+        // ---- Per-variable sub-networks (CASTLE, Kyono et al. 2020 / NOTEARS-MLP,
+        // Zheng et al. 2020). Each target variable j has its OWN MLP f_j that
+        // reconstructs x_j from the OTHER variables. The causal adjacency is NOT a
+        // separate learned gate — it is read directly from the first-layer weights:
+        // A[i,j] = ‖Wh_j[i,:]‖. A separate sigmoid-mask gate (the earlier design) has
+        // a fatal chicken-and-egg failure: the MLPs start random, so routing real
+        // inputs through untrained weights HURTS reconstruction versus predicting the
+        // standardized mean (0), so the gate gradient drives every edge to zero before
+        // any network can learn to use its true parents (RecoversTrueEdges found 0/3,
+        // all probabilities 0.000). Reading structure straight from the weight norms
+        // removes the gate, so training simply grows the weights for genuine parents.
+        // x_j is excluded from its own predictor by holding Wh_j[j,:] = 0 (no self-
+        // edge / trivial identity map). ----
+        var Wh = new Tensor<T>[d];
+        var Wo = new Tensor<T>[d];
+        // Adam first/second-moment state, one pair per network.
+        var mWh = new Tensor<T>[d];
+        var vWh = new Tensor<T>[d];
+        var mWo = new Tensor<T>[d];
+        var vWo = new Tensor<T>[d];
+        for (int j = 0; j < d; j++)
         {
-            var gM = new Matrix<T>(d, d);
-            var gWh = new Matrix<T>(d, h);
-            var gWo = new Matrix<T>(h, 1);
-            T invN = NumOps.FromDouble(1.0 / n);
-
-            // Compute mask probabilities
-            var mask = new Matrix<T>(d, d);
-            for (int i = 0; i < d; i++)
-                for (int j = 0; j < d; j++)
-                {
-                    if (i == j) { mask[i, j] = NumOps.Zero; continue; }
-                    double sv = NumOps.ToDouble(M[i, j]);
-                    mask[i, j] = NumOps.FromDouble(sv > 20 ? 1.0 : sv < -20 ? 0.0 : 1.0 / (1.0 + Math.Exp(-sv)));
-                }
-
-            // Pre-allocate reusable vectors outside the sample/target loops
-            var xMasked = new Vector<T>(d);
-            var hidden = new Vector<T>(h);
-            var whCol = new Vector<T>(d);
-            var woCol = new Vector<T>(h);
-
-            for (int s = 0; s < n; s++)
-            {
-                for (int j = 0; j < d; j++)
-                {
-                    // Masked input: x_masked[i] = x[i] * mask[i,j]
-                    for (int i = 0; i < d; i++)
-                        xMasked[i] = NumOps.Multiply(data[s, i], mask[i, j]);
-
-                    for (int k = 0; k < h; k++)
-                    {
-                        for (int i = 0; i < d; i++) whCol[i] = Wh[i, k];
-                        double sv = NumOps.ToDouble(Engine.DotProduct(xMasked, whCol));
-                        hidden[k] = NumOps.FromDouble(sv > 20 ? 1.0 : sv < -20 ? 0.0 : 1.0 / (1.0 + Math.Exp(-sv)));
-                    }
-
-                    for (int k = 0; k < h; k++) woCol[k] = Wo[k, 0];
-                    T pred = Engine.DotProduct(hidden, woCol);
-
-                    T residual = NumOps.Multiply(NumOps.Subtract(pred, data[s, j]), invN);
-
-                    // Backprop through shared MLP
-                    for (int k = 0; k < h; k++)
-                    {
-                        gWo[k, 0] = NumOps.Add(gWo[k, 0], NumOps.Multiply(residual, hidden[k]));
-
-                        T sigD = NumOps.Multiply(hidden[k], NumOps.Subtract(NumOps.One, hidden[k]));
-                        T dH = NumOps.Multiply(residual, NumOps.Multiply(Wo[k, 0], sigD));
-
-                        for (int i = 0; i < d; i++)
-                        {
-                            T maskedInput = NumOps.Multiply(data[s, i], mask[i, j]);
-                            gWh[i, k] = NumOps.Add(gWh[i, k], NumOps.Multiply(dH, maskedInput));
-
-                            // Gradient w.r.t. mask
-                            T dMask = NumOps.Multiply(dH, NumOps.Multiply(Wh[i, k], data[s, i]));
-                            T maskSigD = NumOps.Multiply(mask[i, j], NumOps.Subtract(NumOps.One, mask[i, j]));
-                            gM[i, j] = NumOps.Add(gM[i, j], NumOps.Multiply(dMask, maskSigD));
-                        }
-                    }
-                }
-            }
-
-            // NOTEARS acyclicity: h(mask) = tr(exp(mask∘mask)) - d
-            var maskSq = new Matrix<T>(d, d);
-            for (int i = 0; i < d; i++)
-                for (int j = 0; j < d; j++)
-                    maskSq[i, j] = NumOps.Multiply(mask[i, j], mask[i, j]);
-            var expMaskSq = MatrixExponentialTaylor(maskSq, d);
-
-            // L1 and acyclicity gradients on mask
-            for (int i = 0; i < d; i++)
-                for (int j = 0; j < d; j++)
-                {
-                    if (i == j) continue;
-                    // L1 on mask
-                    T l1Grad = NumOps.Multiply(lambda1,
-                        NumOps.FromDouble(Math.Sign(NumOps.ToDouble(mask[i, j]))));
-                    // Acyclicity gradient: d/dM[i,j] tr(exp(M∘M)) = [exp(M∘M)^T ∘ 2M][i,j]
-                    T acycGrad = NumOps.Multiply(rho,
-                        NumOps.Multiply(expMaskSq[j, i], NumOps.Multiply(NumOps.FromDouble(2), mask[i, j])));
-                    T mSigD = NumOps.Multiply(mask[i, j], NumOps.Subtract(NumOps.One, mask[i, j]));
-                    gM[i, j] = NumOps.Add(gM[i, j],
-                        NumOps.Multiply(NumOps.Add(l1Grad, acycGrad), mSigD));
-                }
-
-            // Apply gradients
-            for (int i = 0; i < d; i++)
-                for (int j = 0; j < d; j++)
-                    if (i != j)
-                        M[i, j] = NumOps.Subtract(M[i, j], NumOps.Multiply(lr, gM[i, j]));
-
+            Wh[j] = new Tensor<T>(new[] { d, h });
+            Wo[j] = new Tensor<T>(new[] { h, 1 });
+            mWh[j] = new Tensor<T>(new[] { d, h });
+            vWh[j] = new Tensor<T>(new[] { d, h });
+            mWo[j] = new Tensor<T>(new[] { h, 1 });
+            vWo[j] = new Tensor<T>(new[] { h, 1 });
             for (int i = 0; i < d; i++)
                 for (int k = 0; k < h; k++)
-                    Wh[i, k] = NumOps.Subtract(Wh[i, k], NumOps.Multiply(lr, gWh[i, k]));
+                    Wh[j][i, k] = i == j ? NumOps.Zero
+                        : NumOps.Multiply(initScale, NumOps.FromDouble(rng.NextDouble() - 0.5));
             for (int k = 0; k < h; k++)
-                Wo[k, 0] = NumOps.Subtract(Wo[k, 0], NumOps.Multiply(lr, gWo[k, 0]));
-
-            rho = NumOps.Multiply(rho, NumOps.FromDouble(1.05));
+                Wo[j][k, 0] = NumOps.Multiply(initScale, NumOps.FromDouble(rng.NextDouble() - 0.5));
         }
 
-        // Compute final mask and threshold
-        var cov = ComputeCovarianceMatrix(data);
-        var learnedP = new double[d, d];
-        for (int i = 0; i < d; i++)
+        // Optimization budget. The augmented-Lagrangian solve needs enough full-batch
+        // steps for each f_j to fit and for the constraint to bind; the tiny default
+        // MaxEpochs (100) is a floor, not a ceiling — full-batch steps on this small
+        // problem are microseconds, so we run a robust number of them (the paper uses
+        // Adam over many epochs). Reconstruction-first warmup (no L1 / acyclicity)
+        // lets the true-parent weights grow before sparsity + the DAG constraint prune.
+        int steps = Math.Max(MaxEpochs, 2000);
+        int warmupSteps = steps / 4;
+        int dualEvery = Math.Max(1, (steps - warmupSteps) / 40);
+
+        // Adam hyperparameters (CASTLE optimizes with Adam).
+        double lrA = Math.Max(LearningRate, 0.01);
+        T beta1 = NumOps.FromDouble(0.9);
+        T beta2 = NumOps.FromDouble(0.999);
+        T oneMinusB1 = NumOps.FromDouble(0.1);
+        T oneMinusB2 = NumOps.FromDouble(0.001);
+        T adamEps = NumOps.FromDouble(1e-8);
+        T lambda1 = NumOps.FromDouble(0.02);   // group-lasso sparsity weight
+        T groupEps = NumOps.FromDouble(1e-8);
+        T gradScale = NumOps.FromDouble(2.0 / n);   // d/dpred of mean-squared error
+
+        // Augmented-Lagrangian state for the acyclicity constraint h(A)=0 (NOTEARS):
+        // the gradient of α·h + (ρ/2)·h² is (α + ρ·h)·∇h. Dual ascent on α plus
+        // penalty escalation on ρ drives h→0 (a true DAG) and, with the group-L1 term,
+        // prunes indirect / cyclic edges (e.g. X0→X2 in the chain X0→X1→X2).
+        T alpha = NumOps.Zero;
+        T rho = NumOps.One;
+        T hPrev = NumOps.FromDouble(double.PositiveInfinity);
+
+        for (int step = 0; step < steps; step++)
+        {
+            bool constrain = step >= warmupSteps;
+
+            // 1) Reconstruction forward/backward for every f_j (all O(n) work is
+            //    vectorized via Engine matmuls). Gradients are accumulated and applied
+            //    only after the cross-network acyclicity term is added below.
+            var gWh = new Tensor<T>[d];
+            var gWo = new Tensor<T>[d];
             for (int j = 0; j < d; j++)
             {
-                if (i == j) continue;
-                double sv = NumOps.ToDouble(M[i, j]);
-                learnedP[i, j] = sv > 20 ? 1.0 : sv < -20 ? 0.0 : 1.0 / (1.0 + Math.Exp(-sv));
+                var hPre = Engine.TensorMatMul(Xs, Wh[j]);        // [n,h]
+                var H = Engine.Sigmoid(hPre);                     // [n,h]
+                var pred = Engine.TensorMatMul(H, Wo[j]);         // [n,1]
+
+                var targetCol = new Tensor<T>(new[] { n, 1 });
+                for (int s = 0; s < n; s++) targetCol[s, 0] = Xs[s, j];
+                // resid = (2/n)·(pred − x_j)
+                var resid = Engine.TensorMultiplyScalar(Engine.TensorSubtract(pred, targetCol), gradScale); // [n,1]
+
+                gWo[j] = Engine.TensorMatMul(Engine.TensorTranspose(H), resid);             // [h,1]
+                var dPred = Engine.TensorMatMul(resid, Engine.TensorTranspose(Wo[j]));      // [n,h]
+                var oneMinusH = Engine.TensorAddScalar(
+                    Engine.TensorMultiplyScalar(H, NumOps.FromDouble(-1.0)), NumOps.One);
+                var dH = Engine.TensorMultiply(Engine.TensorMultiply(dPred, H), oneMinusH); // [n,h]
+                gWh[j] = Engine.TensorMatMul(Engine.TensorTranspose(Xs), dH);               // [d,h]
             }
+
+            // 2) Once past warmup, add the group-L1 sparsity and augmented-Lagrangian
+            //    acyclicity gradients to the first-layer weights. The adjacency used by
+            //    the constraint is A_sq[i,j] = ‖Wh_j[i,:]‖² (the squared influence of
+            //    variable i on network j); h(A_sq) = tr(exp(A_sq)) − d, and
+            //    ∂h/∂A_sq[i,j] = exp(A_sq)^T[i,j] = exp(A_sq)[j,i]. Chaining
+            //    ∂A_sq[i,j]/∂Wh_j[i,k] = 2·Wh_j[i,k] gives the per-weight acyclicity
+            //    gradient (α+ρh)·exp(A_sq)[j,i]·2·Wh_j[i,k].
+            if (constrain)
+            {
+                var Asq = new Matrix<T>(d, d);
+                for (int j = 0; j < d; j++)
+                    for (int i = 0; i < d; i++)
+                    {
+                        if (i == j) continue;
+                        T s2 = NumOps.Zero;
+                        for (int k = 0; k < h; k++)
+                            s2 = NumOps.Add(s2, NumOps.Multiply(Wh[j][i, k], Wh[j][i, k]));
+                        Asq[i, j] = s2;
+                    }
+                var expAsq = MatrixExponentialTaylor(Asq, d);
+                T hVal = NumOps.Zero;
+                for (int i = 0; i < d; i++) hVal = NumOps.Add(hVal, expAsq[i, i]);
+                hVal = NumOps.Subtract(hVal, NumOps.FromDouble(d));
+                T alRhoH = NumOps.Add(alpha, NumOps.Multiply(rho, hVal));   // α + ρ·h
+                T twoAlRhoH = NumOps.Multiply(NumOps.FromDouble(2.0), alRhoH);
+
+                for (int j = 0; j < d; j++)
+                    for (int i = 0; i < d; i++)
+                    {
+                        if (i == j) continue;
+                        // Row norm ‖Wh_j[i,:]‖ for the group-lasso subgradient.
+                        T rowNorm = NumOps.Sqrt(NumOps.Add(Asq[i, j], groupEps));
+                        T l1Coef = NumOps.Divide(lambda1, rowNorm);                       // λ1 / ‖·‖
+                        T acycCoef = NumOps.Multiply(twoAlRhoH, expAsq[j, i]);            // 2(α+ρh)·exp[j,i]
+                        T coef = NumOps.Add(l1Coef, acycCoef);
+                        for (int k = 0; k < h; k++)
+                            gWh[j][i, k] = NumOps.Add(gWh[j][i, k], NumOps.Multiply(coef, Wh[j][i, k]));
+                    }
+
+                // Dual ascent on the constraint (periodically — once the inner solve
+                // has had dualEvery steps to reduce the loss at the current α,ρ).
+                if ((step - warmupSteps) % dualEvery == dualEvery - 1)
+                {
+                    alpha = NumOps.Add(alpha, NumOps.Multiply(rho, hVal));
+                    double hAbs = Math.Abs(NumOps.ToDouble(hVal));
+                    if (hAbs > 0.25 * Math.Abs(NumOps.ToDouble(hPrev)))
+                        rho = NumOps.Multiply(rho, NumOps.FromDouble(10.0));
+                    hPrev = hVal;
+                }
+            }
+
+            // 3) Adam update for every network's weights. Bias-correction factors for
+            //    this step (t = step+1). The self-row Wh_j[j,:] is held at zero.
+            int t = step + 1;
+            T bc1 = NumOps.FromDouble(1.0 - Math.Pow(0.9, t));
+            T bc2 = NumOps.FromDouble(1.0 - Math.Pow(0.999, t));
+            T lrAt = NumOps.FromDouble(lrA);
+            for (int j = 0; j < d; j++)
+            {
+                for (int i = 0; i < d; i++)
+                {
+                    if (i == j) continue;   // self-row stays zero
+                    for (int k = 0; k < h; k++)
+                    {
+                        T g = gWh[j][i, k];
+                        T m = NumOps.Add(NumOps.Multiply(beta1, mWh[j][i, k]), NumOps.Multiply(oneMinusB1, g));
+                        T v = NumOps.Add(NumOps.Multiply(beta2, vWh[j][i, k]), NumOps.Multiply(oneMinusB2, NumOps.Multiply(g, g)));
+                        mWh[j][i, k] = m;
+                        vWh[j][i, k] = v;
+                        T mhat = NumOps.Divide(m, bc1);
+                        T vhat = NumOps.Divide(v, bc2);
+                        T stepVal = NumOps.Divide(NumOps.Multiply(lrAt, mhat),
+                            NumOps.Add(NumOps.Sqrt(vhat), adamEps));
+                        Wh[j][i, k] = NumOps.Subtract(Wh[j][i, k], stepVal);
+                    }
+                }
+                for (int k = 0; k < h; k++)
+                {
+                    T g = gWo[j][k, 0];
+                    T m = NumOps.Add(NumOps.Multiply(beta1, mWo[j][k, 0]), NumOps.Multiply(oneMinusB1, g));
+                    T v = NumOps.Add(NumOps.Multiply(beta2, vWo[j][k, 0]), NumOps.Multiply(oneMinusB2, NumOps.Multiply(g, g)));
+                    mWo[j][k, 0] = m;
+                    vWo[j][k, 0] = v;
+                    T mhat = NumOps.Divide(m, bc1);
+                    T vhat = NumOps.Divide(v, bc2);
+                    T stepVal = NumOps.Divide(NumOps.Multiply(lrAt, mhat),
+                        NumOps.Add(NumOps.Sqrt(vhat), adamEps));
+                    Wo[j][k, 0] = NumOps.Subtract(Wo[j][k, 0], stepVal);
+                }
+            }
+        }
+
+        // Adjacency = first-layer weight-row norms A[i,j] = ‖Wh_j[i,:]‖, normalized to
+        // [0,1] so BuildFinalAdjacency's 0.3 gate applies. Direction is resolved there
+        // by A[i,j] vs A[j,i]; edge magnitude comes from the covariance ratio.
+        var cov = ComputeCovarianceMatrix(Xs.ToMatrix());
+        var learnedP = new double[d, d];
+        double maxA = 0.0;
+        for (int j = 0; j < d; j++)
+            for (int i = 0; i < d; i++)
+            {
+                if (i == j) continue;
+                double s2 = 0.0;
+                for (int k = 0; k < h; k++)
+                {
+                    double w = NumOps.ToDouble(Wh[j][i, k]);
+                    s2 += w * w;
+                }
+                double a = Math.Sqrt(s2);
+                learnedP[i, j] = a;
+                if (a > maxA) maxA = a;
+            }
+        if (maxA > 1e-12)
+            for (int i = 0; i < d; i++)
+                for (int j = 0; j < d; j++)
+                    learnedP[i, j] /= maxA;
 
         return BuildFinalAdjacency(learnedP, cov, d);
     }

--- a/src/CausalDiscovery/TimeSeries/CCMAlgorithm.cs
+++ b/src/CausalDiscovery/TimeSeries/CCMAlgorithm.cs
@@ -101,15 +101,21 @@ public class CCMAlgorithm<T> : TimeSeriesCausalBase<T>
                     for (int e = 0; e < embDim; e++)
                         embeddings[t, e] = data[t + (embDim - 1) * tau - e * tau, j];
 
-                // Cross-map at full and half library to test convergence
+                // CCM convergence (Sugihara et al. 2012, Science): an edge is accepted
+                // only when cross-map skill ρ INCREASES as the library grows from a
+                // small size toward the full series and plateaus at a high value. The
+                // signature must be measured from a SMALL fixed library (minLib) to the
+                // full library — not half-vs-full, where both endpoints scale with n and
+                // already sit on ρ's plateau, so the measured gain vanishes for large n.
+                // (The previous code measured validN/2-vs-validN and papered over the
+                // resulting collapse by also accepting any ρ > 0.95; on correlated data
+                // that made nearly every pair an edge once n grew, so false positives
+                // increased with more data — the opposite of CCM's convergence promise.)
+                double rhoSmall = ComputeCrossMapCorrelation(data, embeddings, i, minLib, embDim);
                 double rhoFull = ComputeCrossMapCorrelation(data, embeddings, i, validN, embDim);
-                double rhoHalf = ComputeCrossMapCorrelation(data, embeddings, i, validN / 2, embDim);
 
-                double convergence = rhoFull - rhoHalf;
-                // Accept edge if: convergence is positive (standard CCM) OR
-                // rhoFull is very high (near-perfect prediction, common for deterministic data)
-                const double highCorrelationThreshold = 0.95;
-                if ((convergence > _convergenceThreshold || rhoFull > highCorrelationThreshold) && rhoFull > _correlationThreshold)
+                double convergence = rhoFull - rhoSmall;
+                if (convergence > _convergenceThreshold && rhoFull > _correlationThreshold)
                     result[i, j] = NumOps.FromDouble(rhoFull);
             }
 

--- a/src/Diffusion/DiffusionModelBase.cs
+++ b/src/Diffusion/DiffusionModelBase.cs
@@ -603,7 +603,19 @@ public abstract class DiffusionModelBase<T> : IDiffusionModel<T>, IConfigurableM
         var noiseTensor = new Tensor<T>(predicted._shape, noiseVector);
         var diff = Engine.TensorSubtract(predicted, noiseTensor);
         var sq = Engine.TensorMultiply(diff, diff);
-        var loss = Engine.ReduceSum(sq, null);
+        // DDPM training objective (Ho et al. 2020, the simplified loss L_simple =
+        // E[||ε − ε_θ||²]) is the MEAN squared error between predicted and true
+        // noise — matching the reference implementations (HuggingFace diffusers
+        // trains with F.mse_loss, which uses mean reduction). A SUM here scales
+        // the gradient by the element count (e.g. 1024× for a [1,4,16,16] latent),
+        // which destabilised the plain-SGD update: Imagen2's
+        // Training_ShouldReducePredictionError saw the error RISE (0.317 → 0.321)
+        // over 10 steps because each step overshot. Mean keeps the gradient scale
+        // invariant to latent size, so the same LearningRate is stable regardless
+        // of resolution. d(mean)/dparam = (1/N)·d(sum)/dparam, so this is exactly
+        // the mean-MSE gradient.
+        var loss = Engine.TensorMultiplyScalar(
+            Engine.ReduceSum(sq, null), NumOps.FromDouble(1.0 / sq.Length));
 
         // Backward pass via graph-based autodiff.
         var grads = tape.ComputeGradients(loss, paramTensors);
@@ -975,7 +987,19 @@ public abstract class DiffusionModelBase<T> : IDiffusionModel<T>, IConfigurableM
         var noiseTensor = new Tensor<T>(predicted._shape, noiseVector);
         var diff = Engine.TensorSubtract(predicted, noiseTensor);
         var sq = Engine.TensorMultiply(diff, diff);
-        var loss = Engine.ReduceSum(sq, null);
+        // DDPM training objective (Ho et al. 2020, the simplified loss L_simple =
+        // E[||ε − ε_θ||²]) is the MEAN squared error between predicted and true
+        // noise — matching the reference implementations (HuggingFace diffusers
+        // trains with F.mse_loss, which uses mean reduction). A SUM here scales
+        // the gradient by the element count (e.g. 1024× for a [1,4,16,16] latent),
+        // which destabilised the plain-SGD update: Imagen2's
+        // Training_ShouldReducePredictionError saw the error RISE (0.317 → 0.321)
+        // over 10 steps because each step overshot. Mean keeps the gradient scale
+        // invariant to latent size, so the same LearningRate is stable regardless
+        // of resolution. d(mean)/dparam = (1/N)·d(sum)/dparam, so this is exactly
+        // the mean-MSE gradient.
+        var loss = Engine.TensorMultiplyScalar(
+            Engine.ReduceSum(sq, null), NumOps.FromDouble(1.0 / sq.Length));
         var grads = tape.ComputeGradients(loss, paramTensors);
 
         // Flatten gradients into a single vector matching the tape-collected

--- a/src/NeuralNetworks/SiameseNetwork.cs
+++ b/src/NeuralNetworks/SiameseNetwork.cs
@@ -658,6 +658,20 @@ public class SiameseNetwork<T> : NeuralNetworkBase<T>, IAuxiliaryLossLayer<T>
         int embeddingSize = Architecture.GetOutputShape()[0];
         _outputLayer = new DenseLayer<T>(1, new SigmoidActivation<T>() as IActivationFunction<T>);
         _outputLayer.SetParameters(outputLayerParams);
+
+        // Re-wire the base Layers list to the freshly deserialized _subnetwork /
+        // _outputLayer, exactly as the constructor does. The base deserialize
+        // populated Layers from the generic layer stream BEFORE this method ran,
+        // so without this call Layers would reference stale layer objects while
+        // _subnetwork/_outputLayer point to these new ones. Training would then
+        // forward through _subnetwork/_outputLayer (ForwardForTraining) but the
+        // optimizer would read and update the disconnected Layers parameters —
+        // the clone (DeepCopy/Clone routes through this path) trained on a
+        // mismatched parameter set and its loss diverged with more iterations
+        // (MoreData_ShouldNotDegrade: loss rose instead of falling). Re-running
+        // InitializeLayers binds Layers to the live objects so forward and
+        // update share one parameter surface.
+        InitializeLayers();
     }
 
     /// <summary>

--- a/tests/AiDotNet.Tests/ModelFamilyTests/Base/DiffusionModelTestBase.cs
+++ b/tests/AiDotNet.Tests/ModelFamilyTests/Base/DiffusionModelTestBase.cs
@@ -187,8 +187,25 @@ public abstract class DiffusionModelTestBase : IAsyncLifetime
 
     // =====================================================
     // MATHEMATICAL INVARIANT: Training Should Reduce Prediction Error
-    // After training on a fixed (input, target) pair, the predict output
-    // should move closer to the target — verifying gradient flow works.
+    //
+    // Per DDPM (Ho et al. 2020, Algorithm 1), diffusion training minimizes the
+    // MEAN squared error between the true noise ε and the model's predicted noise
+    // ε_θ(√ᾱₜ·x₀ + √(1−ᾱₜ)·ε, t). There is NO supervised "target output" in
+    // diffusion — the data point is the clean sample x₀, noise is added, and the
+    // model predicts that noise. So the valid, paper-faithful "training reduces
+    // error" check is: does the noise-prediction MSE at a FIXED probe (x₀, ε, t)
+    // go down (or at least not up) after training?
+    //
+    // The earlier formulation measured MSE(Generate(x₀), random_target). That is
+    // not a paper quantity and is causally unrelated to the training objective:
+    // `Train` ignores the target argument (it self-samples noise, exactly per the
+    // paper), so Generate(x₀) drifts toward the model's own learned denoising
+    // fixed point — away from an arbitrary random target — for ANY model whose
+    // sampler genuinely depends on its weights. Expressive models (e.g. the
+    // attention-UNet Imagen2 config) therefore "failed" that check while training
+    // perfectly correctly (output bounded, converges to a fixed point). The probe
+    // below measures the actual objective and only fails if training makes
+    // noise-prediction WORSE — a real gradient-sign / divergence bug.
     // =====================================================
 
     [Fact(Timeout = 120000)]
@@ -198,25 +215,37 @@ public abstract class DiffusionModelTestBase : IAsyncLifetime
         using var _arena = TensorArena.Create();
         var rng = ModelTestHelpers.CreateSeededRandom();
         using var model = CreateModel();
-        var input = CreateRandomTensor(InputShape, rng);
-        var target = CreateRandomTensor(OutputShape, rng);
 
-        // Initial error
-        var initialOutput = model.Predict(input);
-        double initialError = ComputeMSE(initialOutput, target);
+        // Treat the random tensor as the clean sample x₀ (the diffusion data point).
+        var x0 = CreateRandomTensor(InputShape, rng);
 
-        // Train
+        // Fixed noise-prediction probe held constant across the before/after
+        // measurement: a single (noise ε, timestep t) so we compare like-for-like.
+        // (Per-step Train uses a random t internally, so raw per-step loss values
+        // are confounded by timestep magnitude; a fixed probe is not.) Mid-range t.
+        int probeT = System.Math.Max(1, model.Scheduler.TrainTimesteps / 2);
+        var probeNoiseVec = new Vector<double>(x0.Length);
+        for (int i = 0; i < probeNoiseVec.Length; i++)
+            probeNoiseVec[i] = rng.NextDouble() * 2.0 - 1.0;
+        var noisyProbe = new Tensor<double>(x0._shape, model.Scheduler.AddNoise(x0.ToVector(), probeNoiseVec, probeT));
+        var probeNoise = new Tensor<double>(x0._shape, probeNoiseVec);
+
+        double errBefore = ComputeMSE(model.PredictNoise(noisyProbe, probeT), probeNoise);
+
+        // Train on x₀ (the diffusion data point). The target argument is unused by
+        // the diffusion training path per the paper; pass x₀ for clarity.
         for (int i = 0; i < TrainingIterations; i++)
-            model.Train(input, target);
+            model.Train(x0, x0);
 
-        // Final error
-        var finalOutput = model.Predict(input);
-        double finalError = ComputeMSE(finalOutput, target);
+        double errAfter = ComputeMSE(model.PredictNoise(noisyProbe, probeT), probeNoise);
 
-        if (!double.IsNaN(initialError) && !double.IsNaN(finalError))
+        if (!double.IsNaN(errBefore) && !double.IsNaN(errAfter))
         {
-            Assert.True(finalError <= initialError + 1e-6,
-                $"Training did not reduce error: initial={initialError:F6}, final={finalError:F6}.");
+            Assert.True(errAfter <= errBefore + 1e-6,
+                $"Training increased the noise-prediction error: before={errBefore:F6}, after={errAfter:F6}. " +
+                "DDPM training (Ho et al. 2020, Alg. 1) minimizes MSE(ε, ε_θ); after training on x₀ the model " +
+                "must predict the noise at a fixed (x₀, ε, t) probe at least as well as before — an increase " +
+                "indicates a gradient-sign error, divergence, or first-step explosion in the training path.");
         }
     }
 

--- a/tests/AiDotNet.Tests/ModelFamilyTests/NeuralNetworks/SiameseNetworkTests.cs
+++ b/tests/AiDotNet.Tests/ModelFamilyTests/NeuralNetworks/SiameseNetworkTests.cs
@@ -11,42 +11,6 @@ public class SiameseNetworkTests : NeuralNetworkModelTestBase
     protected override int[] InputShape => [1, 2, 128];
     protected override int[] OutputShape => [1];
 
-    // SiameseNetwork's output head is a sigmoid (similarity score in
-    // [0, 1]); when training against an arbitrary regression target
-    // drawn from [0, 1) the sigmoid output saturates near the activation
-    // midpoint, so the per-call MSE between predict and target is
-    // dominated by the target-distribution noise of whatever seed
-    // CreateRandomTensor used. The default 3× train/test ratio bound
-    // catches train-vs-test divergence on regression-output models, but
-    // saturating-output models legitimately produce MSE ratios well
-    // above 3× across different random target draws (seed 42 train,
-    // seed 99 test). Loosen the bound for Siamese: still catches the
-    // "training explodes error" bug class but doesn't false-fail on the
-    // sigmoid-output flakiness.
-    protected override double TrainingErrorMultiplier => 100.0;
-
-    // Same sigmoid-saturation rationale as TrainingErrorMultiplier:
-    // sigmoid heads on arbitrary regression targets drive each output
-    // toward 0 or 1, where the gradient flattens. After enough
-    // iterations the optimizer steps stop producing meaningful loss
-    // movement and the per-call MSE between predict and a random
-    // target becomes dominated by the saturation regime — a "more
-    // iterations = lower loss" comparison stops being meaningful at
-    // that scale (200 iterations on a 1-sample memorization shifted
-    // the sigmoid output onto a different saturation slope from the
-    // 50-iteration baseline; lossLong=0.57 vs lossShort=0.03 was
-    // the symptom). Cap to a paper-scale 1 / 2 / 4 split — same
-    // override the Forecasting-Foundation / CLIP-family / VGG /
-    // VoxelCNN / NEAT / ConditionalGAN tests use; still catches the
-    // sign-error / first-step-explosion bug class without false-
-    // failing on legitimate sigmoid saturation. The Cluster D
-    // SiameseNetwork.Layers fix has already established that
-    // gradient flow works (the parameter-change invariant passes
-    // on the same model with shared init).
-    protected override int MoreDataShortIterations => 1;
-    protected override int MoreDataLongIterations => 2;
-    protected override double MoreDataTolerance => 0.01;
-
     protected override INeuralNetworkModel<double> CreateNetwork()
         => new SiameseNetwork<double>();
 }


### PR DESCRIPTION
## Summary

Fixes the assertion failures that were turning PR #1455's CI shards red, working from latest `master` with Tensors 0.86.1. Each is a real model/algorithm bug fixed to match its research paper — **no tolerance overrides, no skipped tests, no weakened assertions**.

Relates to #1462. The genuinely paper-scale fp64 compute-bound *timeouts* (full VGG16/ResNet50/SD-UNet) are tracked separately in #1463 — those are Tensors-side and blocked on a Tensors release (pinned at 0.86.1 here).

## Fixes

### 1. Diffusion training loss + convergence test (`9389c3fc1`)
`DiffusionModelBase.Train` minimized a **summed** MSE (inflating the gradient ~1024×). Switched to the mean-MSE objective of DDPM (Ho et al. 2020, Algorithm 1). Redesigned the diffusion convergence test into a paper-faithful noise-prediction probe.

### 2. CASTLE causal discovery (`15bc88ef`)
`RecoversTrueEdges` found 0/3 (empty graph). The implementation used a single shared MLP plus a separate sigmoid mask gate that collapsed to zero (chicken-and-egg: untrained weights hurt reconstruction, so the gate was driven down before any parent could be learned). Reimplemented faithfully to CASTLE (Kyono et al. 2020) / NOTEARS-MLP (Zheng et al. 2020): one sub-network per variable, adjacency read from first-layer weight-row norms (no collapsible gate), group-lasso sparsity, augmented-Lagrangian acyclicity, Adam. Recovers true edges with correct direction; all 14 CASTLE tests pass.

### 3. CCM convergence (`05ef03a9`)
`MoreDataDoesNotDegradeQuality` failed (false positives grew 3→6 with more data). Removed a non-paper "accept if rho>0.95" shortcut and fixed the convergence metric to measure rho from the **minimum library** to the full series (Sugihara et al. 2012) instead of half-vs-full (both endpoints sat on rho's plateau). Scale-invariant; all 14 CCM tests pass.

### 4. SiameseNetwork clone (`5f01606c`)
`MoreData_ShouldNotDegrade` diverged (loss rose with more training). Root cause was `Clone()`/`DeepCopy`: `DeserializeNetworkSpecificData` re-created `_subnetwork`/`_outputLayer` but never re-wired the base `Layers` list to them, so the clone's forward pass and optimizer operated on different parameter surfaces. Added the `InitializeLayers()` re-wire the constructor already performs. A 30-init clone sweep went from 30/30 diverged to 0/30; removed all four tolerance overrides — all 21 Siamese tests pass at defaults.

🤖 Generated with [Claude Code](https://claude.com/claude-code)