### PR TITLE
fix: compiled fused-training — standard-Adam default, OCP dispatch, MlpForward wiring, loud fallback

### DIFF
--- a/AiDotNet.sln
+++ b/AiDotNet.sln
@@ -33,6 +33,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AiDotNet.Benchmarks", "benc
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AiDotNet.Storage.Elasticsearch", "src\AiDotNet.Storage.Elasticsearch\AiDotNet.Storage.Elasticsearch.csproj", "{BBC4C51F-3BFD-419C-9B59-ADD7AB006095}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AiDotNet.PyTorchParity", "benchmarks\AiDotNet.PyTorchParity\AiDotNet.PyTorchParity.csproj", "{B1427BFB-8A17-4735-8EC5-E594A612AB81}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -175,6 +177,18 @@ Global
 		{BBC4C51F-3BFD-419C-9B59-ADD7AB006095}.Release|x64.Build.0 = Release|Any CPU
 		{BBC4C51F-3BFD-419C-9B59-ADD7AB006095}.Release|x86.ActiveCfg = Release|Any CPU
 		{BBC4C51F-3BFD-419C-9B59-ADD7AB006095}.Release|x86.Build.0 = Release|Any CPU
+		{B1427BFB-8A17-4735-8EC5-E594A612AB81}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B1427BFB-8A17-4735-8EC5-E594A612AB81}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B1427BFB-8A17-4735-8EC5-E594A612AB81}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{B1427BFB-8A17-4735-8EC5-E594A612AB81}.Debug|x64.Build.0 = Debug|Any CPU
+		{B1427BFB-8A17-4735-8EC5-E594A612AB81}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{B1427BFB-8A17-4735-8EC5-E594A612AB81}.Debug|x86.Build.0 = Debug|Any CPU
+		{B1427BFB-8A17-4735-8EC5-E594A612AB81}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B1427BFB-8A17-4735-8EC5-E594A612AB81}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B1427BFB-8A17-4735-8EC5-E594A612AB81}.Release|x64.ActiveCfg = Release|Any CPU
+		{B1427BFB-8A17-4735-8EC5-E594A612AB81}.Release|x64.Build.0 = Release|Any CPU
+		{B1427BFB-8A17-4735-8EC5-E594A612AB81}.Release|x86.ActiveCfg = Release|Any CPU
+		{B1427BFB-8A17-4735-8EC5-E594A612AB81}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -185,6 +199,7 @@ Global
 		{035B7687-2236-4D7F-97C5-8BA20567DD37} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
 		{C1E3CF04-768E-46AE-A6EB-C9F9334365E6} = {66320409-64EC-F7C5-3DEF-65E7510DAAD1}
 		{BBC4C51F-3BFD-419C-9B59-ADD7AB006095} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
+		{B1427BFB-8A17-4735-8EC5-E594A612AB81} = {66320409-64EC-F7C5-3DEF-65E7510DAAD1}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {99F5DE1C-2F44-4B2D-B8B3-DEFFC86D2F16}

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -56,11 +56,21 @@
          fused=True, which takes lr as a per-step scalar); Noam was the only
          missing schedule shape. Closes AiDotNet#1470 (Transformer per-call
          training stalled because the Noam LR stayed frozen at warmup-step-1
-         on the fused path). All AiDotNet.Native packages coreleased in lockstep. -->
-    <PackageVersion Include="AiDotNet.Tensors" Version="0.88.0" />
-    <PackageVersion Include="AiDotNet.Native.OneDNN" Version="0.88.0" />
-    <PackageVersion Include="AiDotNet.Native.OpenBLAS" Version="0.88.0" />
-    <PackageVersion Include="AiDotNet.Native.CLBlast" Version="0.88.0" />
+         on the fused path). All AiDotNet.Native packages coreleased in lockstep.
+
+         Bumped 0.88.0 -> 0.90.2 to pick up the merged compiled-inference work
+         (AiDotNet.Tensors#513 — CompiledMlp self-tuning kernel selection, CNN conv
+         im2col fast path, MlpForward small-batch native-BLAS routing, public
+         CpuInferenceConfig.PinBlasThreadsForLatency) so the AIsEval inference
+         benchmark exercises those wins end-to-end. 0.90.2 also carries Tensors#520
+         (ISparseEngine.SpMM<T> made unconstrained again — #379 had leaked a
+         `where T : unmanaged` into the public API, breaking unconstrained-T
+         consumers like SparseLinearLayer<T>; 0.90.0/0.90.1 do NOT build against
+         AiDotNet, 0.90.2 is the first 0.90.x that does). -->
+    <PackageVersion Include="AiDotNet.Tensors" Version="0.90.2" />
+    <PackageVersion Include="AiDotNet.Native.OneDNN" Version="0.90.2" />
+    <PackageVersion Include="AiDotNet.Native.OpenBLAS" Version="0.90.2" />
+    <PackageVersion Include="AiDotNet.Native.CLBlast" Version="0.90.2" />
     <!-- Microsoft / .NET -->
     <PackageVersion Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageVersion Include="Microsoft.Data.Sqlite" Version="10.0.8" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -45,11 +45,22 @@
          the result in a copying Vector<T>/Matrix<T> ctor, orphaning the
          materializer so fresh-Vector ops returned all-zeros on the GPU backend
          (corrupted GAMLSS and any model trained via AiModelBuilder's
-         auto-detected GPU path). 0.86.6 materializes those immediately. -->
-    <PackageVersion Include="AiDotNet.Tensors" Version="0.86.6" />
-    <PackageVersion Include="AiDotNet.Native.OneDNN" Version="0.86.6" />
-    <PackageVersion Include="AiDotNet.Native.OpenBLAS" Version="0.86.6" />
-    <PackageVersion Include="AiDotNet.Native.CLBlast" Version="0.86.6" />
+         auto-detected GPU path). 0.86.6 materializes those immediately.
+
+         Bumped 0.86.6 -> 0.88.0 for the Noam fused LR schedule (Tensors #504):
+         LrSchedule.Noam(modelDim, warmup, factor) lets the default Transformer
+         recipe (Adam beta2=0.98 + Noam warmup) run on the fused-compiled
+         training path with a correct per-step LR ramp instead of falling back
+         to the slower eager tape. The fused plan already evaluates
+         LrSchedule.GetLr(step) every optimizer step (same model as PyTorch
+         fused=True, which takes lr as a per-step scalar); Noam was the only
+         missing schedule shape. Closes AiDotNet#1470 (Transformer per-call
+         training stalled because the Noam LR stayed frozen at warmup-step-1
+         on the fused path). All AiDotNet.Native packages coreleased in lockstep. -->
+    <PackageVersion Include="AiDotNet.Tensors" Version="0.88.0" />
+    <PackageVersion Include="AiDotNet.Native.OneDNN" Version="0.88.0" />
+    <PackageVersion Include="AiDotNet.Native.OpenBLAS" Version="0.88.0" />
+    <PackageVersion Include="AiDotNet.Native.CLBlast" Version="0.88.0" />
     <!-- Microsoft / .NET -->
     <PackageVersion Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageVersion Include="Microsoft.Data.Sqlite" Version="10.0.8" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -66,11 +66,18 @@
          (ISparseEngine.SpMM<T> made unconstrained again — #379 had leaked a
          `where T : unmanaged` into the public API, breaking unconstrained-T
          consumers like SparseLinearLayer<T>; 0.90.0/0.90.1 do NOT build against
-         AiDotNet, 0.90.2 is the first 0.90.x that does). -->
-    <PackageVersion Include="AiDotNet.Tensors" Version="0.90.2" />
-    <PackageVersion Include="AiDotNet.Native.OneDNN" Version="0.90.2" />
-    <PackageVersion Include="AiDotNet.Native.OpenBLAS" Version="0.90.2" />
-    <PackageVersion Include="AiDotNet.Native.CLBlast" Version="0.90.2" />
+         AiDotNet, 0.90.2 is the first 0.90.x that does).
+
+         Bumped 0.90.2 -> 0.90.3 for two any-rank / fast-path fixes that unblock the
+         CNN + unbatched inference wiring: Tensors#521 (FusedLinear accepts rank-1 [K]
+         input — promotes to [1,K] and squeezes back, so unbatched FeedForward Predict
+         no longer throws "TensorMatMul requires rank >= 2") and Tensors#522 (the
+         int-overload Conv2DInto routes through the im2col-GEMM fast path instead of
+         the ~15x-slower SIMD-direct cascade). -->
+    <PackageVersion Include="AiDotNet.Tensors" Version="0.90.3" />
+    <PackageVersion Include="AiDotNet.Native.OneDNN" Version="0.90.3" />
+    <PackageVersion Include="AiDotNet.Native.OpenBLAS" Version="0.90.3" />
+    <PackageVersion Include="AiDotNet.Native.CLBlast" Version="0.90.3" />
     <!-- Microsoft / .NET -->
     <PackageVersion Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageVersion Include="Microsoft.Data.Sqlite" Version="10.0.8" />

--- a/benchmarks/AiDotNet.PyTorchParity/.gitignore
+++ b/benchmarks/AiDotNet.PyTorchParity/.gitignore
@@ -1,0 +1,6 @@
+# Machine-specific benchmark outputs — never commit timing JSON.
+results/
+# Python side
+pytorch/__pycache__/
+pytorch/.venv/
+*.pyc

--- a/benchmarks/AiDotNet.PyTorchParity/AiDotNet.PyTorchParity.csproj
+++ b/benchmarks/AiDotNet.PyTorchParity/AiDotNet.PyTorchParity.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <LangVersion>preview</LangVersion>
+    <!-- This is a manual benchmark harness, not a unit-test project. Exclude
+         it from coverage and keep it out of the default `dotnet test` run. -->
+    <IsTestProject>false</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!-- LOCAL project reference (NOT a NuGet package). This is the whole point
+         of mirroring AIsEval in-repo: the harness links the working-tree
+         AiDotNet source, so it measures the CURRENT branch's behaviour — e.g.
+         the PR #1469 fused-training gate + FeedForwardNeuralNetwork.Predict ->
+         MlpForward wiring — without waiting for a NuGet publish. AIsEval, by
+         contrast, can only benchmark a released package. -->
+    <ProjectReference Include="..\..\src\AiDotNet.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/benchmarks/AiDotNet.PyTorchParity/GpuDisableBootstrap.cs
+++ b/benchmarks/AiDotNet.PyTorchParity/GpuDisableBootstrap.cs
@@ -1,0 +1,33 @@
+using System;
+using System.Runtime.CompilerServices;
+
+namespace AiDotNet.PyTorchParity;
+
+/// <summary>
+/// Disables AiDotNet.Tensors' GPU auto-detection for this CPU-vs-PyTorch-CPU parity
+/// harness, the right way: from a module initializer on THIS (entry) assembly, which
+/// the runtime runs at startup — before <c>Main</c> and before the Tensors assembly is
+/// first touched (the <c>ResetToCpu()</c> call in Program.cs). Tensors ships a
+/// <c>[ModuleInitializer]</c> (GpuAutoDetectModuleInit) that, at Tensors-assembly load,
+/// auto-detects a GPU/OpenCL device and compiles ~600 OpenCL kernels. Even though
+/// Program.cs immediately calls <c>ResetToCpu()</c>, that's too late — the kernels are
+/// already compiled and the OpenCL/GPU polling threads are spun up, and they then
+/// compete for CPU cores and inflate the very inference numbers this harness measures
+/// (clean-CPU CNN inference measured ~271 µs in a GPU-free process vs ~635 µs here).
+///
+/// <para>Tensors' auto-detect honors the <c>AIDOTNET_DISABLE_GPU</c> env var, checked at
+/// its module-init time. Setting it here — from the entry assembly's initializer, which
+/// runs before Tensors is loaded and touches no Tensors type itself — guarantees the env
+/// var is in place before that check, so GPU auto-detect (and the OpenCL kernel compile)
+/// is skipped entirely. Idempotent and respects an existing value, so a caller can still
+/// set it before process start.</para>
+/// </summary>
+internal static class GpuDisableBootstrap
+{
+    [ModuleInitializer]
+    internal static void DisableGpuForCpuParity()
+    {
+        if (string.IsNullOrEmpty(Environment.GetEnvironmentVariable("AIDOTNET_DISABLE_GPU")))
+            Environment.SetEnvironmentVariable("AIDOTNET_DISABLE_GPU", "1");
+    }
+}

--- a/benchmarks/AiDotNet.PyTorchParity/Program.cs
+++ b/benchmarks/AiDotNet.PyTorchParity/Program.cs
@@ -452,7 +452,10 @@ internal sealed class AiDotNetCnnModel : AiDotNetBenchmarkModel
     protected override int OutputClasses => 10;
     protected override NeuralNetworkBase<float> BuildNetwork()
     {
-        // Conv2d(1,16,3,pad=1)+ReLU+MaxPool(2)+Conv2d(16,32,3,pad=1)+ReLU+MaxPool(2)+Flatten+Linear(10).
+        // Mirror the PyTorch CNN exactly (benchmark.py): Conv2d(1,16,3,pad=1)+ReLU+MaxPool(2) +
+        // Conv2d(16,32,3,pad=1)+ReLU+AdaptiveAvgPool2d((4,4)) + Flatten + Linear(32*4*4=512, 10).
+        // (Previously the second stage used MaxPool(2) → 32×7×7=1568-wide head, a different workload
+        // and head size than PyTorch's 512-wide head, making the parity numbers non-comparable.)
         var layers = new List<ILayer<float>>
         {
             new ConvolutionalLayer<float>(outputDepth: 16, kernelSize: 3, stride: 1, padding: 1,
@@ -460,7 +463,7 @@ internal sealed class AiDotNetCnnModel : AiDotNetBenchmarkModel
             new MaxPoolingLayer<float>(poolSize: 2, stride: 2),
             new ConvolutionalLayer<float>(outputDepth: 32, kernelSize: 3, stride: 1, padding: 1,
                                           activationFunction: new ReLUActivation<float>()),
-            new MaxPoolingLayer<float>(poolSize: 2, stride: 2),
+            new AdaptiveAveragePoolingLayer<float>(outputHeight: 4, outputWidth: 4),
             new FlattenLayer<float>(),
             new DenseLayer<float>(10, activationFunction: (IActivationFunction<float>?)null),
         };

--- a/benchmarks/AiDotNet.PyTorchParity/Program.cs
+++ b/benchmarks/AiDotNet.PyTorchParity/Program.cs
@@ -1,0 +1,606 @@
+// AiDotNet ⇄ PyTorch parity benchmark harness.
+//
+// A self-contained, in-repo twin of the AIsEval aidotnet-benchmarks project
+// (https://github.com/ooples/AIsEval). It builds the SAME four reference
+// models — MLP / CNN / LSTM / Transformer — with paper-matched layer shapes,
+// runs the SAME training + multi-batch inference measurement loop, and emits
+// the SAME JSON schema as the PyTorch side (pytorch/benchmark.py), so the two
+// reports drop straight into the same comparison.
+//
+// Why this lives in the AiDotNet repo (vs only in AIsEval): it references the
+// working-tree AiDotNet *source* (ProjectReference, not a NuGet package), so it
+// measures the CURRENT branch. That makes it the validation harness for changes
+// like PR #1469 (default-Adam fused-training gate) and the
+// FeedForwardNeuralNetwork.Predict -> IEngine.MlpForward fused-inference wiring,
+// which a released-package benchmark cannot see until a publish.
+//
+// Usage:
+//   dotnet run -c Release --project benchmarks/AiDotNet.PyTorchParity -- \
+//       --models mlp,cnn,lstm,transformer,mlp-fused --output results/aidotnet.json
+// Then run the PyTorch side (see pytorch/README in this folder) and compare.
+
+using AiDotNet.ActivationFunctions;
+using AiDotNet.Enums;
+using AiDotNet.Interfaces;
+using AiDotNet.NeuralNetworks;
+using AiDotNet.NeuralNetworks.Layers;
+using AiDotNet.Tensors.LinearAlgebra;
+using System.Diagnostics;
+using System.Text.Json;
+
+// Fair comparison vs PyTorch-CPU: force the native CPU engine.
+//
+// AiDotNet.Tensors ships a [ModuleInitializer] (GpuAutoDetectModuleInit) that
+// auto-detects a GPU/OpenCL device at assembly load and switches the global
+// engine to DirectGpu/OpenCL. On an integrated-GPU rig that path is SLOWER than
+// the native OneDNN/OpenBLAS CPU path for these small-to-medium workloads, and
+// is not the path the Tensors micro-benchmarks beat PyTorch-CPU on. ResetToCpu()
+// pins the CPU engine so this harness compares CPU-vs-CPU. (AIDOTNET_DISABLE_GPU=1
+// is the documented before-startup opt-out; this in-code reset also covers the
+// published-DLL path where launchSettings env vars don't apply.)
+AiDotNet.Tensors.Engines.AiDotNetEngine.ResetToCpu();
+Console.WriteLine($"[bench] engine pinned to CPU: {AiDotNet.Tensors.Engines.AiDotNetEngine.Current.GetType().Name}");
+
+// Opt-in (AIDOTNET_FUSED_DIAG=1): surface whether the compiled fused-optimizer
+// training path actually runs (Hit) or silently falls back to the eager tape
+// (and why). This is the exact instrument that found the "compiled training does
+// nothing" bug fixed by PR #1469: EnableCompilation defaults to true and the
+// fused step is ATTEMPTED every step, but if TryMapToFusedOptimizerConfig rejects
+// the model's optimizer, every step silently falls back to the eager tape. The
+// fallback is invisible at the default Silent diagnostic level — only PerStep
+// surfaces the FusedOptimizerPathEvent. With the fix, Hit=True should appear.
+var fusedDiag = Environment.GetEnvironmentVariable("AIDOTNET_FUSED_DIAG") == "1";
+if (fusedDiag)
+{
+    AiDotNet.Configuration.TrainingDiagnosticsConfig.Level =
+        AiDotNet.Configuration.TrainingDiagnosticLevel.PerStep;
+    AiDotNet.Training.CompiledTapeTrainingStep<float>.ResetFusedStepCount();
+    var fusedSeen = new HashSet<string>();
+    AiDotNet.Configuration.TrainingDiagnosticsConfig.Sink = evt =>
+    {
+        if (evt is AiDotNet.Configuration.FusedOptimizerPathEvent f)
+        {
+            var key = $"{f.Hit}:{f.Reason}";
+            if (fusedSeen.Add(key))
+                Console.WriteLine($"[bench] FUSED-PATH event: Hit={f.Hit} Reason={f.Reason ?? "(none)"}");
+        }
+    };
+}
+
+var benchOptions = BenchmarkOptions.Parse(args);
+var report = new BenchmarkRunner(benchOptions).Run();
+var outputPath = Path.GetFullPath(benchOptions.OutputPath);
+Directory.CreateDirectory(Path.GetDirectoryName(outputPath)!);
+File.WriteAllText(outputPath, JsonSerializer.Serialize(report, JsonOptions.Default));
+Console.WriteLine($"Benchmark report written to {outputPath}");
+
+if (fusedDiag)
+{
+    // Answer "did compiled fused training actually run, and if not, why?" from a
+    // single run. A step count of 0 with a captured fallback exception is the
+    // signature of the "compiled does nothing" failure mode: the FIRST fused
+    // step fell back (silently, reason often null when the Tensors plan refuses
+    // the model), which sticky-disables the path for the rest of the session.
+    var fusedSteps = AiDotNet.Training.CompiledTapeTrainingStep<float>.GetFusedStepCount();
+    var lastFallback = AiDotNet.Training.CompiledTapeTrainingStep<float>.GetLastFallbackException();
+    Console.WriteLine($"[bench] fused training steps that engaged: {fusedSteps}");
+    Console.WriteLine(lastFallback is null
+        ? "[bench] last fused-fallback exception: (none captured)"
+        : $"[bench] last fused-fallback exception: {lastFallback.GetType().FullName}: {lastFallback.Message}");
+}
+
+internal sealed record BenchmarkOptions(
+    string[] Models,
+    int Epochs,
+    int TrainBatches,
+    int BatchSize,
+    int InferenceIterations,
+    int WarmupIterations,
+    int Seed,
+    string OutputPath)
+{
+    public static BenchmarkOptions Parse(string[] args)
+    {
+        // Convert --key value command-line pairs into a simple lookup table so
+        // individual options can fall back to sensible defaults when omitted.
+        var map = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        for (var i = 0; i < args.Length - 1; i += 2)
+        {
+            if (args[i].StartsWith("--", StringComparison.Ordinal)) map[args[i][2..]] = args[i + 1];
+        }
+
+        static int Int(Dictionary<string, string> map, string key, int fallback) =>
+            map.TryGetValue(key, out var value) && int.TryParse(value, out var parsed) ? parsed : fallback;
+
+        var models = map.GetValueOrDefault("models", "mlp,cnn,lstm,transformer")
+            .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+
+        return new BenchmarkOptions(
+            models,
+            Int(map, "epochs", 3),
+            Int(map, "train-batches", 20),
+            Int(map, "batch-size", 64),
+            Int(map, "inference-iterations", 100),
+            Int(map, "warmup-iterations", 10),
+            Int(map, "seed", 1234),
+            map.GetValueOrDefault("output", "results/aidotnet.json"));
+    }
+}
+
+internal sealed class BenchmarkRunner(BenchmarkOptions options)
+{
+    private static readonly int[] InferenceBatchSizes = [1, 8, 32, 128];
+
+    public BenchmarkReport Run()
+    {
+        // Create each requested model, measure its training and inference
+        // phases, and collect those measurements into one framework-level report.
+        var factory = new AiDotNetTensorBackend(options.Seed);
+        var results = new List<ModelReport>();
+        foreach (var modelName in options.Models)
+        {
+            var modelStart = Stopwatch.StartNew();
+            Console.WriteLine($"[bench] {modelName}: building network…");
+            var model = factory.Create(modelName);
+            Console.WriteLine($"[bench] {modelName}: training ({options.Epochs}e × {options.TrainBatches}b × {options.BatchSize}bs, {model.ParameterCount} params)…");
+            var training = BenchmarkTraining(model);
+            Console.WriteLine($"[bench] {modelName}: training done in {training.TotalSeconds:F2}s; running inference…");
+            var inference = BenchmarkInference(model);
+            modelStart.Stop();
+            Console.WriteLine($"[bench] {modelName}: complete in {modelStart.Elapsed.TotalSeconds:F2}s");
+            results.Add(new ModelReport(modelName, "AiDotNetNeuralNetwork", model.ParameterCount, training, inference));
+        }
+
+        return new BenchmarkReport(
+            "AiDotNet",
+            Environment.Version.ToString(),
+            AiDotNetProbe.Describe(),
+            results);
+    }
+
+    private TrainingReport BenchmarkTraining(IBenchmarkModel model)
+    {
+        // Track per-epoch duration plus the synthetic data-loading and gradient
+        // phases, while a background monitor samples process resources.
+        var epochSeconds = new List<double>();
+        var gradientSeconds = new List<double>();
+        var dataSeconds = new List<double>();
+        var total = Stopwatch.StartNew();
+        using var monitor = ResourceMonitor.Start();
+
+        for (var epoch = 0; epoch < options.Epochs; epoch++)
+        {
+            var epochTimer = Stopwatch.StartNew();
+            for (var batch = 0; batch < options.TrainBatches; batch++)
+            {
+                var dataTimer = Stopwatch.StartNew();
+                model.LoadSyntheticBatch(options.BatchSize);
+                dataTimer.Stop();
+                dataSeconds.Add(dataTimer.Elapsed.TotalSeconds);
+
+                model.Forward();
+                var gradientTimer = Stopwatch.StartNew();
+                model.Backward();
+                gradientTimer.Stop();
+                gradientSeconds.Add(gradientTimer.Elapsed.TotalSeconds);
+                model.Step();
+            }
+            epochTimer.Stop();
+            epochSeconds.Add(epochTimer.Elapsed.TotalSeconds);
+        }
+
+        total.Stop();
+        return new TrainingReport(
+            epochSeconds.Select(Round6).ToArray(),
+            Round6(total.Elapsed.TotalSeconds),
+            Round6(gradientSeconds.Count == 0 ? 0 : gradientSeconds.Average()),
+            Round6(dataSeconds.Count == 0 ? 0 : dataSeconds.Average()),
+            monitor.Summary());
+    }
+
+    private List<InferenceReport> BenchmarkInference(IBenchmarkModel model)
+    {
+        // Measure inference at multiple batch sizes so the report captures both
+        // latency and throughput behavior under different request shapes.
+        var reports = new List<InferenceReport>();
+        var process = Process.GetCurrentProcess();
+        foreach (var batchSize in InferenceBatchSizes)
+        {
+            model.LoadSyntheticBatch(batchSize);
+
+            // Warmup iterations prime JIT compilation and tensor internals before
+            // steady-state measurements are recorded.
+            var warmup = new List<double>();
+            for (var i = 0; i < options.WarmupIterations; i++)
+            {
+                var timer = Stopwatch.StartNew();
+                model.Forward();
+                timer.Stop();
+                warmup.Add(timer.Elapsed.TotalSeconds);
+            }
+
+            // RSS via Process.WorkingSet64 mirrors the PyTorch side's
+            // psutil rss (whole-process resident set incl. native allocs),
+            // so both report the same kind of memory number.
+            process.Refresh();
+            var peakBefore = process.WorkingSet64 / 1024d / 1024d;
+            var steady = new List<double>();
+            var peak = peakBefore;
+
+            for (var i = 0; i < options.InferenceIterations; i++)
+            {
+                var timer = Stopwatch.StartNew();
+                model.Forward();
+                timer.Stop();
+                steady.Add(timer.Elapsed.TotalSeconds);
+                process.Refresh();
+                peak = Math.Max(peak, process.WorkingSet64 / 1024d / 1024d);
+            }
+            var totalSteady = steady.Sum();
+            // p95 latency (symmetric with the PyTorch side): robust to the
+            // rig-contention noise that swings the mean. The Tensors perf gate is
+            // p95(ours) < median(PyTorch).
+            var steadySorted = steady.OrderBy(x => x).ToList();
+            int p95Idx = Math.Min(steadySorted.Count - 1, (int)Math.Round(0.95 * (steadySorted.Count - 1)));
+            reports.Add(new InferenceReport(
+                batchSize,
+                Round6(warmup.Average()),
+                Math.Round(steady.Average() * 1000d, 3),
+                Math.Round(steadySorted[p95Idx] * 1000d, 3),
+                Math.Round(options.InferenceIterations * batchSize / totalSteady, 3),
+                Math.Round(peak, 3)));
+        }
+        return reports;
+    }
+
+    private static double Round6(double value) => Math.Round(value, 6);
+}
+
+internal interface IBenchmarkModel
+{
+    long ParameterCount { get; }
+    void LoadSyntheticBatch(int batchSize);
+    void Forward();
+    void Backward();
+    void Step();
+}
+
+internal sealed class AiDotNetTensorBackend(int seed)
+{
+    // Each model constructs the real AiDotNet neural-network class with
+    // paper-matched layer shapes so the comparison is real-Conv2D vs
+    // real-Conv2D, real-LSTM vs real-LSTM, etc. — not "PyTorch real model vs
+    // AiDotNet MLP". The shapes mirror pytorch/benchmark.py exactly.
+    public IBenchmarkModel Create(string model) => model.ToLowerInvariant() switch
+    {
+        // PyTorch: nn.Sequential(Linear(784,512), ReLU, Linear(512,128), ReLU, Linear(128,10)).
+        "mlp" => new AiDotNetMlpModel(seed),
+        // PyTorch: Conv2d(1,16,3,pad=1)+ReLU+MaxPool(2)+Conv2d(16,32,3,pad=1)+ReLU+AdaptiveAvgPool((4,4))+Linear(512,10).
+        "cnn" => new AiDotNetCnnModel(seed),
+        // PyTorch: nn.LSTM(input=32, hidden=64) + Linear(64, 10). Input [B, 32, 32].
+        "lstm" => new AiDotNetLstmModel(seed),
+        // PyTorch: Linear(32,64) + 2× TransformerEncoderLayer(d_model=64,nhead=4,dim_ff=128) + mean(seq) + Linear(64,10).
+        "transformer" => new AiDotNetTransformerModel(seed),
+        // Fused-primitive INFERENCE path: same 784->512->128->10 ReLU MLP, but
+        // routed explicitly through the IEngine.MlpForward fused kernel. With
+        // PR #1469's FeedForwardNeuralNetwork.Predict wiring, the plain "mlp"
+        // model should now ALSO hit this kernel through Predict() — compare the
+        // two rows to confirm the high-level path no longer leaves perf on the table.
+        "mlp-fused" => new AiDotNetMlpFusedModel(seed),
+        _ => throw new ArgumentException($"Unknown model '{model}'.")
+    };
+}
+
+/// <summary>
+/// Base for the benchmark models. Centralises the IBenchmarkModel contract so
+/// each subclass only declares its architecture + input shape. Training runs
+/// through AiDotNet's real <c>NeuralNetworkBase.Train</c> (forward + GradientTape
+/// backward + optimizer step under the covers); inference runs through real
+/// <c>NeuralNetworkBase.Predict</c>.
+/// </summary>
+internal abstract class AiDotNetBenchmarkModel : IBenchmarkModel
+{
+    protected readonly Random Random;
+    protected readonly NeuralNetworkBase<float> Network;
+    protected Tensor<float> Input = Tensor<float>.Empty();
+    protected Tensor<float> Label = Tensor<float>.Empty();
+
+    protected AiDotNetBenchmarkModel(int seed)
+    {
+        Random = new Random(seed);
+        Network = BuildNetwork();
+        ParameterCount = Network.GetParameters().Length;
+    }
+
+    public long ParameterCount { get; }
+
+    protected abstract NeuralNetworkBase<float> BuildNetwork();
+    protected abstract int[] InputShapePerSample { get; }   // shape WITHOUT batch dim
+    protected abstract int OutputClasses { get; }
+
+    public void LoadSyntheticBatch(int batchSize)
+    {
+        var perSample = InputShapePerSample;
+        var sampleSize = perSample.Aggregate(1, (a, b) => a * b);
+        var fullShape = new[] { batchSize }.Concat(perSample).ToArray();
+        var inputs = new float[batchSize * sampleSize];
+        for (var i = 0; i < inputs.Length; i++) inputs[i] = (float)Random.NextDouble();
+        Input = new Tensor<float>(inputs, fullShape);
+
+        var labels = new float[batchSize * OutputClasses];
+        for (var b = 0; b < batchSize; b++)
+        {
+            var cls = Random.Next(OutputClasses);
+            labels[b * OutputClasses + cls] = 1f;
+        }
+        Label = new Tensor<float>(labels, [batchSize, OutputClasses]);
+    }
+
+    public void Forward()
+    {
+        // Real inference: walks the layer stack, runs activations + ops.
+        var _ = Network.Predict(Input);
+    }
+
+    public void Backward()
+    {
+        // PyTorch runs `loss = criterion(model(x), y); loss.backward()` then
+        // optimizer.step(). AiDotNet's Train(input, expected) is the equivalent:
+        // forward + GradientTape backward + optimizer step in one call (and, with
+        // PR #1469's gate, the compiled fused step when the optimizer maps). For
+        // the per-batch wall-time measurement Backward does the full train step
+        // and Step is a no-op — gradientSeconds therefore captures backward+step.
+        Network.Train(Input, Label);
+    }
+
+    public void Step()
+    {
+        // Real optimizer step happened inside Backward()'s Train call.
+    }
+}
+
+internal sealed class AiDotNetMlpModel : AiDotNetBenchmarkModel
+{
+    public AiDotNetMlpModel(int seed) : base(seed) { }
+    protected override int[] InputShapePerSample => new[] { 784 };
+    protected override int OutputClasses => 10;
+    protected override NeuralNetworkBase<float> BuildNetwork()
+    {
+        // Linear(784,512)+ReLU+Linear(512,128)+ReLU+Linear(128,10).
+        var layers = new List<ILayer<float>>
+        {
+            new DenseLayer<float>(512, (IActivationFunction<float>)new ReLUActivation<float>()),
+            new DenseLayer<float>(128, (IActivationFunction<float>)new ReLUActivation<float>()),
+            new DenseLayer<float>(10, activationFunction: (IActivationFunction<float>?)null),
+        };
+        var arch = new NeuralNetworkArchitecture<float>(
+            inputType: InputType.OneDimensional,
+            taskType: NeuralNetworkTaskType.MultiClassClassification,
+            inputSize: 784,
+            outputSize: 10,
+            layers: layers);
+        return new FeedForwardNeuralNetwork<float>(arch);
+    }
+}
+
+/// <summary>
+/// Fused-primitive MLP: identical 784→512→128→10 ReLU shape as
+/// <see cref="AiDotNetMlpModel"/>, but inference routes explicitly through
+/// <c>IEngine.MlpForward</c> — the fused, thread-capped multi-layer kernel.
+/// Forward-only (MlpForward throws under a GradientTape), so training is a no-op;
+/// training perf for this shape is measured by the plain "mlp" model.
+/// </summary>
+internal sealed class AiDotNetMlpFusedModel : IBenchmarkModel
+{
+    private static readonly int[] LayerSizes = [784, 512, 128, 10];
+    private readonly Tensor<float>[] _weights;
+    private readonly Tensor<float>?[] _biases;
+    private Tensor<float> _input = Tensor<float>.Empty();
+
+    public AiDotNetMlpFusedModel(int seed)
+    {
+        var rng = new Random(seed);
+        _weights = new Tensor<float>[LayerSizes.Length - 1];
+        _biases = new Tensor<float>?[LayerSizes.Length - 1];
+        for (var i = 0; i < _weights.Length; i++)
+        {
+            int inF = LayerSizes[i], outF = LayerSizes[i + 1];
+            var scale = (float)Math.Sqrt(2.0 / inF);
+            var w = new float[inF * outF];
+            for (var k = 0; k < w.Length; k++) w[k] = (float)(rng.NextDouble() - 0.5) * 2f * scale;
+            _weights[i] = new Tensor<float>(w, [inF, outF]);
+            var b = new float[outF];
+            for (var k = 0; k < b.Length; k++) b[k] = (float)(rng.NextDouble() - 0.5) * 0.01f;
+            _biases[i] = new Tensor<float>(b, [outF]);
+        }
+        ParameterCount = _weights.Sum(w => (long)w.Length) + _biases.Sum(b => (long)(b?.Length ?? 0));
+    }
+
+    public long ParameterCount { get; }
+
+    public void LoadSyntheticBatch(int batchSize)
+    {
+        var data = new float[batchSize * 784];
+        var rng = new Random(1234);
+        for (var i = 0; i < data.Length; i++) data[i] = (float)rng.NextDouble();
+        _input = new Tensor<float>(data, [batchSize, 784]);
+    }
+
+    public void Forward()
+    {
+        // activation(x @ Wᵢ + bᵢ) for every layer in one fused call.
+        var _ = AiDotNet.Tensors.Engines.AiDotNetEngine.Current.MlpForward(
+            _input, _weights, _biases,
+            AiDotNet.Tensors.Engines.FusedActivationType.ReLU,
+            AiDotNet.Tensors.Engines.FusedActivationType.None);
+    }
+
+    public void Backward() { }
+    public void Step() { }
+}
+
+internal sealed class AiDotNetCnnModel : AiDotNetBenchmarkModel
+{
+    public AiDotNetCnnModel(int seed) : base(seed) { }
+    protected override int[] InputShapePerSample => new[] { 1, 28, 28 };
+    protected override int OutputClasses => 10;
+    protected override NeuralNetworkBase<float> BuildNetwork()
+    {
+        // Conv2d(1,16,3,pad=1)+ReLU+MaxPool(2)+Conv2d(16,32,3,pad=1)+ReLU+MaxPool(2)+Flatten+Linear(10).
+        var layers = new List<ILayer<float>>
+        {
+            new ConvolutionalLayer<float>(outputDepth: 16, kernelSize: 3, stride: 1, padding: 1,
+                                          activationFunction: new ReLUActivation<float>()),
+            new MaxPoolingLayer<float>(poolSize: 2, stride: 2),
+            new ConvolutionalLayer<float>(outputDepth: 32, kernelSize: 3, stride: 1, padding: 1,
+                                          activationFunction: new ReLUActivation<float>()),
+            new MaxPoolingLayer<float>(poolSize: 2, stride: 2),
+            new FlattenLayer<float>(),
+            new DenseLayer<float>(10, activationFunction: (IActivationFunction<float>?)null),
+        };
+        var arch = new NeuralNetworkArchitecture<float>(
+            inputType: InputType.ThreeDimensional,
+            taskType: NeuralNetworkTaskType.MultiClassClassification,
+            inputHeight: 28, inputWidth: 28, inputDepth: 1,
+            outputSize: 10,
+            layers: layers);
+        return new ConvolutionalNeuralNetwork<float>(arch);
+    }
+}
+
+internal sealed class AiDotNetLstmModel : AiDotNetBenchmarkModel
+{
+    public AiDotNetLstmModel(int seed) : base(seed) { }
+    protected override int[] InputShapePerSample => new[] { 32, 32 };
+    protected override int OutputClasses => 10;
+    protected override NeuralNetworkBase<float> BuildNetwork()
+    {
+        // LSTM(input=32, hidden=64) + last-timestep slice + Linear(64, 10).
+        var layers = new List<ILayer<float>>
+        {
+            new LSTMLayer<float>(hiddenSize: 64),
+            new SequenceTokenSliceLayer<float>(SequenceTokenSliceLayer<float>.Position.Last),
+            new DenseLayer<float>(10, activationFunction: (IActivationFunction<float>?)null),
+        };
+        var arch = new NeuralNetworkArchitecture<float>(
+            inputType: InputType.OneDimensional,
+            taskType: NeuralNetworkTaskType.MultiClassClassification,
+            inputSize: 32,
+            outputSize: 10,
+            layers: layers);
+        return new LSTMNeuralNetwork<float>(arch, outputActivation: (IActivationFunction<float>?)null);
+    }
+}
+
+internal sealed class AiDotNetTransformerModel : AiDotNetBenchmarkModel
+{
+    public AiDotNetTransformerModel(int seed) : base(seed) { }
+    protected override int[] InputShapePerSample => new[] { 32, 32 };
+    protected override int OutputClasses => 10;
+    protected override NeuralNetworkBase<float> BuildNetwork()
+    {
+        // Linear(32,64) + 2× TransformerEncoderLayer(d_model=64,nhead=4,dim_ff=128)
+        // + mean(seq) + Linear(64,10), via AiDotNet's production Transformer<float>.
+        var arch = new TransformerArchitecture<float>(
+            inputType: InputType.OneDimensional,
+            taskType: NeuralNetworkTaskType.MultiClassClassification,
+            numEncoderLayers: 2,
+            numDecoderLayers: 0,
+            numHeads: 4,
+            modelDimension: 64,
+            feedForwardDimension: 128,
+            inputSize: 32,
+            outputSize: 10,
+            dropoutRate: 0.0,
+            maxSequenceLength: 32,
+            vocabularySize: 0,
+            usePositionalEncoding: true,
+            sequencePooling: SequencePoolingMode.MeanPool);
+        return new Transformer<float>(arch);
+    }
+}
+
+internal sealed class ResourceMonitor : IDisposable
+{
+    private readonly Process _process = Process.GetCurrentProcess();
+    private readonly CancellationTokenSource _cts = new();
+    private readonly List<double> _rssMb = [];
+    private readonly Task _task;
+
+    private ResourceMonitor()
+    {
+        _task = Task.Run(async () =>
+        {
+            while (!_cts.IsCancellationRequested)
+            {
+                _process.Refresh();
+                _rssMb.Add(_process.WorkingSet64 / 1024d / 1024d);
+                await Task.Delay(100, _cts.Token).ContinueWith(_ => { });
+            }
+        });
+    }
+
+    public static ResourceMonitor Start() => new();
+
+    public ResourceReport Summary() => new(Math.Round(_rssMb.Count == 0 ? 0 : _rssMb.Max(), 3), NvidiaSmi.TryRead());
+
+    public void Dispose()
+    {
+        _cts.Cancel();
+        _task.Wait(TimeSpan.FromSeconds(2));
+        _cts.Dispose();
+    }
+}
+
+internal static class NvidiaSmi
+{
+    public static string? TryRead()
+    {
+        try
+        {
+            using var process = Process.Start(new ProcessStartInfo
+            {
+                FileName = "nvidia-smi",
+                ArgumentList = { "--query-gpu=utilization.gpu,memory.used", "--format=csv,noheader,nounits" },
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+            });
+            if (process is null || !process.WaitForExit(1000) || process.ExitCode != 0) return null;
+            return process.StandardOutput.ReadLine();
+        }
+        catch
+        {
+            return null;
+        }
+    }
+}
+
+internal static class AiDotNetProbe
+{
+    public static object Describe()
+    {
+        // Report the loaded AiDotNet assembly metadata so the report identifies
+        // which build ran (working-tree source vs a package).
+        var assembly = typeof(NeuralNetworkBase<float>).Assembly;
+        var location = string.Empty;
+        try { location = assembly.Location; } catch { /* single-file: no location */ }
+        return new
+        {
+            loaded = true,
+            name = assembly.GetName().Name,
+            version = assembly.GetName().Version?.ToString(),
+            location,
+        };
+    }
+}
+
+internal sealed record BenchmarkReport(string Framework, string DotNetRuntime, object AiDotNet, List<ModelReport> Results);
+internal sealed record ModelReport(string Model, string Backend, long Parameters, TrainingReport Training, List<InferenceReport> Inference);
+internal sealed record TrainingReport(double[] EpochSeconds, double TotalSeconds, double GradientSecondsAvg, double DataLoadingSecondsAvg, ResourceReport Resources);
+internal sealed record ResourceReport(double ManagedRssMbPeak, string? NvidiaSmiSample);
+internal sealed record InferenceReport(int BatchSize, double WarmupSecondsAvg, double SteadyStateLatencyMsAvg, double SteadyStateLatencyMsP95, double ThroughputSamplesPerSecond, double MemoryMbPeak);
+
+internal static class JsonOptions
+{
+    public static readonly JsonSerializerOptions Default = new() { WriteIndented = true };
+}

--- a/benchmarks/AiDotNet.PyTorchParity/Program.cs
+++ b/benchmarks/AiDotNet.PyTorchParity/Program.cs
@@ -224,18 +224,24 @@ internal sealed class BenchmarkRunner(BenchmarkOptions options)
             // so both report the same kind of memory number.
             process.Refresh();
             var peakBefore = process.WorkingSet64 / 1024d / 1024d;
-            var steady = new List<double>();
-            var peak = peakBefore;
+            var steady = new List<double>(options.InferenceIterations);
 
+            // Steady-state latency: a TIGHT loop timing only model.Forward(). Do NOT
+            // sample process memory inside this loop — Process.Refresh()/WorkingSet64 is
+            // a per-call syscall that also allocates, and its GC churn fires during a
+            // later timed Forward, inflating the mean and especially p95 (it made the
+            // CNN read ~740 µs / p95 1.1 ms vs a clean ~270 µs steady state). RSS is a
+            // whole-process resident-set figure that barely moves per inference, so
+            // sampling it once after the loop is sufficient for the report.
             for (var i = 0; i < options.InferenceIterations; i++)
             {
                 var timer = Stopwatch.StartNew();
                 model.Forward();
                 timer.Stop();
                 steady.Add(timer.Elapsed.TotalSeconds);
-                process.Refresh();
-                peak = Math.Max(peak, process.WorkingSet64 / 1024d / 1024d);
             }
+            process.Refresh();
+            var peak = Math.Max(peakBefore, process.WorkingSet64 / 1024d / 1024d);
             var totalSteady = steady.Sum();
             // p95 latency (symmetric with the PyTorch side): robust to the
             // rig-contention noise that swings the mean. The Tensors perf gate is

--- a/benchmarks/AiDotNet.PyTorchParity/README.md
+++ b/benchmarks/AiDotNet.PyTorchParity/README.md
@@ -1,0 +1,90 @@
+# AiDotNet ⇄ PyTorch parity benchmark
+
+An in-repo twin of the [AIsEval](https://github.com/ooples/AIsEval)
+`aidotnet-benchmarks` harness, with one decisive difference: this project
+references the AiDotNet **source** (`<ProjectReference Include="..\..\src\AiDotNet.csproj" />`),
+not a published NuGet package. So it measures the **current working tree** —
+the exact thing you want when validating a perf change before it ships.
+
+That makes it the validation harness for changes a released-package benchmark
+can't yet see, e.g.:
+
+- **PR #1469** — the default-Adam fused-training gate (set `AIDOTNET_FUSED_DIAG=1`
+  to print whether the compiled fused step actually engages: `Hit=True`).
+- **`FeedForwardNeuralNetwork.Predict` → `IEngine.MlpForward`** fused-inference
+  wiring — compare the `mlp` row (high-level `Predict`) against the `mlp-fused`
+  row (direct kernel call). With the wiring in place they should converge.
+
+Both sides build the same four reference models with matching layer shapes
+(MLP / CNN / LSTM / Transformer), run the same training + multi-batch-inference
+loop, and emit the same JSON schema. `pytorch/compare.py` lines the two reports
+up row-by-row.
+
+## 1. Run the AiDotNet side
+
+```bash
+# From the repo root. Release is mandatory for meaningful numbers.
+# Match the thread count to the PyTorch side for a fair head-to-head.
+set AIDOTNET_BLAS_THREADS=8          # PowerShell: $env:AIDOTNET_BLAS_THREADS=8
+set AIDOTNET_FUSED_DIAG=1            # optional: print fused-path Hit/Miss
+
+dotnet run -c Release --project benchmarks/AiDotNet.PyTorchParity -- \
+    --models mlp,cnn,lstm,transformer,mlp-fused \
+    --epochs 3 --train-batches 20 --batch-size 64 \
+    --inference-iterations 100 --warmup-iterations 10 \
+    --output benchmarks/AiDotNet.PyTorchParity/results/aidotnet.json
+```
+
+The harness pins the CPU engine via `AiDotNetEngine.ResetToCpu()` so the
+comparison is CPU-vs-CPU (the integrated-GPU/OpenCL auto-detect path is slower
+for these small/medium workloads and is not what the Tensors micro-benchmarks
+beat PyTorch on).
+
+## 2. Run the PyTorch side
+
+```bash
+cd benchmarks/AiDotNet.PyTorchParity/pytorch
+pip install -r requirements.txt
+python benchmark.py --models mlp,cnn,lstm,transformer --device cpu \
+    --threads 8 --output ../results/pytorch.json
+```
+
+PyTorch runs **eager** here (no `torch.compile`) on purpose: the AiDotNet side
+runs its own compiled/fused path, and pitting it against a separately compiled
+PyTorch compares two compilation stacks rather than the kernels. Pin both sides
+to the same thread count (`--threads` ↔ `AIDOTNET_BLAS_THREADS`).
+
+## 3. Compare
+
+```bash
+cd benchmarks/AiDotNet.PyTorchParity/pytorch
+python compare.py ../results/aidotnet.json ../results/pytorch.json
+```
+
+Prints a per-model / per-batch table with the latency ratio and verdict. The
+gate (from AIsEval `Reporting/findings.md`) is **p95(AiDotNet) < mean(PyTorch)**:
+our worst-of-95% steady-state latency still beats their average.
+
+## CLI options (both sides)
+
+| flag | default | meaning |
+|------|---------|---------|
+| `--models` | `mlp,cnn,lstm,transformer` | comma-separated subset; C# side also accepts `mlp-fused` |
+| `--epochs` | `3` | training epochs |
+| `--train-batches` | `20` | batches per epoch |
+| `--batch-size` | `64` | training batch size |
+| `--inference-iterations` | `100` | steady-state inference iterations per batch size |
+| `--warmup-iterations` | `10` | warmup iterations before measuring |
+| `--seed` | `1234` | RNG seed |
+| `--output` | `results/{aidotnet,pytorch}.json` | report path |
+| `--threads` (PyTorch) | `0` (all cores) | pin CPU threads; match `AIDOTNET_BLAS_THREADS` |
+
+Inference is measured at batch sizes **1, 8, 32, 128** on both sides.
+
+## Notes
+
+- `results/` is git-ignored (machine-specific timings don't belong in version control).
+- `mlp-fused` is an AiDotNet-only primitive variant (direct `MlpForward`); the
+  PyTorch side maps it to the same `MLP` so a shared `--models` list won't error.
+- This project is excluded from `dotnet test` (`IsTestProject=false`); it's a
+  manual harness you run on demand.

--- a/benchmarks/AiDotNet.PyTorchParity/pytorch/benchmark.py
+++ b/benchmarks/AiDotNet.PyTorchParity/pytorch/benchmark.py
@@ -1,0 +1,345 @@
+"""PyTorch side of the AiDotNet ⇄ PyTorch parity benchmark.
+
+Twin of the C# harness (../Program.cs): same four reference models
+(MLP / CNN / LSTM / Transformer) with matching layer shapes, the same
+training + multi-batch inference measurement loop, and the same JSON schema,
+so the two reports compare directly via compare.py.
+
+IMPORTANT (fair comparison): PyTorch here runs EAGER (no torch.compile). The
+AiDotNet side runs its own compiled/fused path; pitting it against a separately
+torch.compile'd PyTorch would compare two different compilation stacks rather
+than the kernels. Pin both sides to the same CPU thread count:
+    python benchmark.py --threads 8 ...
+    dotnet run ... (set AIDOTNET_BLAS_THREADS=8)
+
+Usage:
+    pip install -r requirements.txt
+    python benchmark.py --models mlp,cnn,lstm,transformer --device cpu \
+        --threads 8 --output ../results/pytorch.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import platform
+import random
+import statistics
+import subprocess
+import threading
+import time
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+import psutil
+import torch
+from torch import nn
+
+BATCH_SIZES = [1, 8, 32, 128]
+
+
+@dataclass
+class ResourceSummary:
+    cpu_percent_avg: float
+    rss_mb_peak: float
+    gpu_util_percent_avg: float | None
+    gpu_mem_mb_peak: float | None
+
+
+@dataclass
+class TrainingResult:
+    epoch_seconds: list[float]
+    total_seconds: float
+    gradient_seconds_avg: float
+    data_loading_seconds_avg: float
+    resources: ResourceSummary
+
+
+@dataclass
+class InferenceBatchResult:
+    batch_size: int
+    warmup_seconds_avg: float
+    steady_state_latency_ms_avg: float
+    steady_state_latency_ms_p95: float
+    throughput_samples_per_second: float
+    memory_mb_peak: float
+
+
+@dataclass
+class ModelResult:
+    model: str
+    device: str
+    parameters: int
+    training: TrainingResult
+    inference: list[InferenceBatchResult]
+
+
+class ResourceMonitor:
+    def __init__(self, sample_seconds: float = 0.1) -> None:
+        self.sample_seconds = sample_seconds
+        self.process = psutil.Process(os.getpid())
+        self.cpu: list[float] = []
+        self.rss_mb: list[float] = []
+        self.gpu_util: list[float] = []
+        self.gpu_mem: list[float] = []
+        self._stop = threading.Event()
+        self._thread = threading.Thread(target=self._sample, daemon=True)
+
+    def __enter__(self) -> "ResourceMonitor":
+        self.process.cpu_percent(interval=None)
+        self._thread.start()
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        self._stop.set()
+        self._thread.join(timeout=2)
+
+    def _sample(self) -> None:
+        while not self._stop.is_set():
+            self.cpu.append(self.process.cpu_percent(interval=None))
+            self.rss_mb.append(self.process.memory_info().rss / 1024 / 1024)
+            gpu = query_nvidia_smi()
+            if gpu is not None:
+                util, mem = gpu
+                self.gpu_util.append(util)
+                self.gpu_mem.append(mem)
+            time.sleep(self.sample_seconds)
+
+    def summary(self) -> ResourceSummary:
+        return ResourceSummary(
+            cpu_percent_avg=round(statistics.fmean(self.cpu), 3) if self.cpu else 0.0,
+            rss_mb_peak=round(max(self.rss_mb), 3) if self.rss_mb else 0.0,
+            gpu_util_percent_avg=round(statistics.fmean(self.gpu_util), 3) if self.gpu_util else None,
+            gpu_mem_mb_peak=round(max(self.gpu_mem), 3) if self.gpu_mem else None,
+        )
+
+
+def query_nvidia_smi() -> tuple[float, float] | None:
+    try:
+        output = subprocess.check_output(
+            [
+                "nvidia-smi",
+                "--query-gpu=utilization.gpu,memory.used",
+                "--format=csv,noheader,nounits",
+            ],
+            text=True,
+            timeout=1,
+            stderr=subprocess.DEVNULL,
+        )
+    except (FileNotFoundError, subprocess.SubprocessError):
+        return None
+    first = output.strip().splitlines()[0]
+    util, mem = [float(part.strip()) for part in first.split(",")]
+    return util, mem
+
+
+class MLP(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.net = nn.Sequential(nn.Linear(784, 512), nn.ReLU(), nn.Linear(512, 128), nn.ReLU(), nn.Linear(128, 10))
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.net(x.view(x.shape[0], -1))
+
+
+class SmallCNN(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.features = nn.Sequential(
+            nn.Conv2d(1, 16, 3, padding=1), nn.ReLU(), nn.MaxPool2d(2),
+            nn.Conv2d(16, 32, 3, padding=1), nn.ReLU(), nn.AdaptiveAvgPool2d((4, 4)),
+        )
+        self.head = nn.Linear(32 * 4 * 4, 10)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.head(self.features(x).flatten(1))
+
+
+class LSTMClassifier(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.lstm = nn.LSTM(input_size=32, hidden_size=64, batch_first=True)
+        self.head = nn.Linear(64, 10)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        out, _ = self.lstm(x)
+        return self.head(out[:, -1, :])
+
+
+class TransformerClassifier(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        layer = nn.TransformerEncoderLayer(d_model=64, nhead=4, dim_feedforward=128, batch_first=True)
+        self.proj = nn.Linear(32, 64)
+        self.encoder = nn.TransformerEncoder(layer, num_layers=2)
+        self.head = nn.Linear(64, 10)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        encoded = self.encoder(self.proj(x))
+        return self.head(encoded.mean(dim=1))
+
+
+def make_model(name: str) -> tuple[nn.Module, tuple[int, ...]]:
+    if name == "mlp":
+        return MLP(), (1, 28, 28)
+    if name == "cnn":
+        return SmallCNN(), (1, 28, 28)
+    if name == "lstm":
+        return LSTMClassifier(), (32, 32)
+    if name == "transformer":
+        return TransformerClassifier(), (32, 32)
+    # "mlp-fused" is an AiDotNet-only primitive variant; map it to the same MLP
+    # so a --models list shared with the C# side does not error out here.
+    if name == "mlp-fused":
+        return MLP(), (1, 28, 28)
+    raise ValueError(f"Unknown model: {name}")
+
+
+def synchronize(device: torch.device) -> None:
+    if device.type == "cuda":
+        torch.cuda.synchronize(device)
+
+
+def synthetic_batch(batch_size: int, shape: tuple[int, ...], device: torch.device) -> tuple[torch.Tensor, torch.Tensor]:
+    x = torch.randn((batch_size, *shape), device=device)
+    y = torch.randint(0, 10, (batch_size,), device=device)
+    return x, y
+
+
+def benchmark_training(model: nn.Module, shape: tuple[int, ...], device: torch.device, epochs: int, batches: int, batch_size: int) -> TrainingResult:
+    criterion = nn.CrossEntropyLoss()
+    optimizer = torch.optim.AdamW(model.parameters(), lr=1e-3)
+    epoch_seconds: list[float] = []
+    gradient_seconds: list[float] = []
+    data_seconds: list[float] = []
+
+    start_total = time.perf_counter()
+    with ResourceMonitor() as monitor:
+        for _ in range(epochs):
+            start_epoch = time.perf_counter()
+            for _ in range(batches):
+                start_data = time.perf_counter()
+                x, y = synthetic_batch(batch_size, shape, device)
+                synchronize(device)
+                data_seconds.append(time.perf_counter() - start_data)
+
+                optimizer.zero_grad(set_to_none=True)
+                logits = model(x)
+                loss = criterion(logits, y)
+                synchronize(device)
+                start_grad = time.perf_counter()
+                loss.backward()
+                synchronize(device)
+                gradient_seconds.append(time.perf_counter() - start_grad)
+                optimizer.step()
+            synchronize(device)
+            epoch_seconds.append(time.perf_counter() - start_epoch)
+    total = time.perf_counter() - start_total
+    return TrainingResult(
+        epoch_seconds=[round(value, 6) for value in epoch_seconds],
+        total_seconds=round(total, 6),
+        gradient_seconds_avg=round(statistics.fmean(gradient_seconds), 6),
+        data_loading_seconds_avg=round(statistics.fmean(data_seconds), 6),
+        resources=monitor.summary(),
+    )
+
+
+@torch.inference_mode()
+def benchmark_inference(model: nn.Module, shape: tuple[int, ...], device: torch.device, iterations: int, warmup: int) -> list[InferenceBatchResult]:
+    results: list[InferenceBatchResult] = []
+    for batch_size in BATCH_SIZES:
+        x, _ = synthetic_batch(batch_size, shape, device)
+        warmup_times: list[float] = []
+        for _ in range(warmup):
+            start = time.perf_counter()
+            model(x)
+            synchronize(device)
+            warmup_times.append(time.perf_counter() - start)
+
+        if device.type == "cuda":
+            torch.cuda.reset_peak_memory_stats(device)
+        process = psutil.Process(os.getpid())
+        rss_peak = process.memory_info().rss / 1024 / 1024
+        steady: list[float] = []
+        for _ in range(iterations):
+            start = time.perf_counter()
+            model(x)
+            synchronize(device)
+            elapsed = time.perf_counter() - start
+            steady.append(elapsed)
+            rss_peak = max(rss_peak, process.memory_info().rss / 1024 / 1024)
+        total = sum(steady)
+        cuda_peak = torch.cuda.max_memory_allocated(device) / 1024 / 1024 if device.type == "cuda" else 0.0
+        # p95 latency: robust to rig-contention noise that swings the mean.
+        steady_sorted = sorted(steady)
+        p95_idx = min(len(steady_sorted) - 1, int(round(0.95 * (len(steady_sorted) - 1))))
+        results.append(InferenceBatchResult(
+            batch_size=batch_size,
+            warmup_seconds_avg=round(statistics.fmean(warmup_times), 6),
+            steady_state_latency_ms_avg=round(statistics.fmean(steady) * 1000, 3),
+            steady_state_latency_ms_p95=round(steady_sorted[p95_idx] * 1000, 3),
+            throughput_samples_per_second=round((iterations * batch_size) / total, 3),
+            memory_mb_peak=round(max(rss_peak, cuda_peak), 3),
+        ))
+    return results
+
+
+def run(args: argparse.Namespace) -> dict[str, object]:
+    seed = args.seed
+    random.seed(seed)
+    torch.manual_seed(seed)
+    # Pin CPU threads for a fair head-to-head — match the AiDotNet side's
+    # AIDOTNET_BLAS_THREADS so the numbers reflect the kernels, not the scheduler.
+    if args.threads and args.threads > 0:
+        torch.set_num_threads(args.threads)
+    if args.device == "auto":
+        device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    else:
+        device = torch.device(args.device)
+
+    model_results: list[ModelResult] = []
+    for name in [item.strip() for item in args.models.split(",") if item.strip()]:
+        model, shape = make_model(name)
+        model.to(device)
+        parameters = sum(parameter.numel() for parameter in model.parameters())
+        training = benchmark_training(model, shape, device, args.epochs, args.train_batches, args.batch_size)
+        model.eval()
+        inference = benchmark_inference(model, shape, device, args.inference_iterations, args.warmup_iterations)
+        model_results.append(ModelResult(name, str(device), parameters, training, inference))
+
+    return {
+        "framework": "PyTorch",
+        "python": platform.python_version(),
+        "torch": torch.__version__,
+        "device": str(device),
+        "torch_num_threads": torch.get_num_threads(),
+        "cuda_available": torch.cuda.is_available(),
+        "results": [asdict(result) for result in model_results],
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Benchmark PyTorch MLP/CNN/LSTM/Transformer workloads (eager).")
+    parser.add_argument("--models", default="mlp,cnn,lstm,transformer")
+    parser.add_argument("--device", default="auto", choices=["auto", "cpu", "cuda"])
+    parser.add_argument("--epochs", type=int, default=3)
+    parser.add_argument("--train-batches", type=int, default=20)
+    parser.add_argument("--batch-size", type=int, default=64)
+    parser.add_argument("--inference-iterations", type=int, default=100)
+    parser.add_argument("--warmup-iterations", type=int, default=10)
+    parser.add_argument("--seed", type=int, default=1234)
+    parser.add_argument("--threads", type=int, default=0,
+                        help="Pin CPU thread count (0 = PyTorch default = all cores). "
+                             "Match the AiDotNet side's AIDOTNET_BLAS_THREADS for a fair comparison.")
+    parser.add_argument("--output", type=Path, default=Path("../results/pytorch.json"))
+    args = parser.parse_args()
+
+    report = run(args)
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(report, indent=2), encoding="utf-8")
+    print(json.dumps(report, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/AiDotNet.PyTorchParity/pytorch/benchmark.py
+++ b/benchmarks/AiDotNet.PyTorchParity/pytorch/benchmark.py
@@ -303,6 +303,10 @@ def run(args: argparse.Namespace) -> dict[str, object]:
         model, shape = make_model(name)
         model.to(device)
         parameters = sum(parameter.numel() for parameter in model.parameters())
+        if args.compile:
+            # torch.compile (TorchInductor) — the "PyTorch compiled" comparison.
+            # Counts params BEFORE compile (the wrapper hides .parameters()).
+            model = torch.compile(model)
         training = benchmark_training(model, shape, device, args.epochs, args.train_batches, args.batch_size)
         model.eval()
         inference = benchmark_inference(model, shape, device, args.inference_iterations, args.warmup_iterations)
@@ -332,6 +336,8 @@ def main() -> None:
     parser.add_argument("--threads", type=int, default=0,
                         help="Pin CPU thread count (0 = PyTorch default = all cores). "
                              "Match the AiDotNet side's AIDOTNET_BLAS_THREADS for a fair comparison.")
+    parser.add_argument("--compile", action="store_true",
+                        help="Wrap each model in torch.compile (TorchInductor) — the 'PyTorch compiled' head-to-head.")
     parser.add_argument("--output", type=Path, default=Path("../results/pytorch.json"))
     args = parser.parse_args()
 

--- a/benchmarks/AiDotNet.PyTorchParity/pytorch/benchmark.py
+++ b/benchmarks/AiDotNet.PyTorchParity/pytorch/benchmark.py
@@ -86,7 +86,7 @@ class ResourceMonitor:
         self._stop = threading.Event()
         self._thread = threading.Thread(target=self._sample, daemon=True)
 
-    def __enter__(self) -> "ResourceMonitor":
+    def __enter__(self) -> ResourceMonitor:
         self.process.cpu_percent(interval=None)
         self._thread.start()
         return self
@@ -273,7 +273,7 @@ def benchmark_inference(model: nn.Module, shape: tuple[int, ...], device: torch.
         cuda_peak = torch.cuda.max_memory_allocated(device) / 1024 / 1024 if device.type == "cuda" else 0.0
         # p95 latency: robust to rig-contention noise that swings the mean.
         steady_sorted = sorted(steady)
-        p95_idx = min(len(steady_sorted) - 1, int(round(0.95 * (len(steady_sorted) - 1))))
+        p95_idx = min(len(steady_sorted) - 1, round(0.95 * (len(steady_sorted) - 1)))
         results.append(InferenceBatchResult(
             batch_size=batch_size,
             warmup_seconds_avg=round(statistics.fmean(warmup_times), 6),

--- a/benchmarks/AiDotNet.PyTorchParity/pytorch/compare.py
+++ b/benchmarks/AiDotNet.PyTorchParity/pytorch/compare.py
@@ -1,0 +1,98 @@
+"""Compare an AiDotNet report against a PyTorch report.
+
+The two harnesses emit the same schema with different key casing (C# records
+serialize PascalCase; the Python dataclasses serialize snake_case). This script
+normalizes both, then prints a per-model / per-batch-size inference table with
+the latency ratio and a verdict.
+
+Gate (from AIsEval Reporting/findings.md): a build "wins" a row when
+    p95(AiDotNet) < mean(PyTorch)
+i.e. our worst-of-95% steady-state latency still beats their average — a
+deliberately conservative bar that is robust to rig-contention noise.
+
+Usage:
+    python compare.py ../results/aidotnet.json ../results/pytorch.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+
+def _get(d: dict, *names: str, default=None):
+    """Fetch the first present key from a set of casing variants."""
+    for n in names:
+        if n in d:
+            return d[n]
+    return default
+
+
+def _norm_inference(row: dict) -> dict:
+    return {
+        "batch_size": _get(row, "batch_size", "BatchSize"),
+        "avg_ms": _get(row, "steady_state_latency_ms_avg", "SteadyStateLatencyMsAvg"),
+        "p95_ms": _get(row, "steady_state_latency_ms_p95", "SteadyStateLatencyMsP95"),
+        "throughput": _get(row, "throughput_samples_per_second", "ThroughputSamplesPerSecond"),
+        "mem_mb": _get(row, "memory_mb_peak", "MemoryMbPeak"),
+    }
+
+
+def _index(report: dict) -> dict[str, dict[int, dict]]:
+    """model -> batch_size -> normalized inference row."""
+    out: dict[str, dict[int, dict]] = {}
+    for model in _get(report, "results", "Results", default=[]):
+        name = _get(model, "model", "Model")
+        rows = {}
+        for r in _get(model, "inference", "Inference", default=[]):
+            n = _norm_inference(r)
+            rows[n["batch_size"]] = n
+        out[name] = rows
+    return out
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Compare AiDotNet vs PyTorch benchmark JSON reports.")
+    parser.add_argument("aidotnet", type=Path, help="Path to the AiDotNet report JSON.")
+    parser.add_argument("pytorch", type=Path, help="Path to the PyTorch report JSON.")
+    args = parser.parse_args()
+
+    ai = json.loads(args.aidotnet.read_text(encoding="utf-8"))
+    pt = json.loads(args.pytorch.read_text(encoding="utf-8"))
+
+    ai_idx = _index(ai)
+    pt_idx = _index(pt)
+
+    print(f"AiDotNet: {_get(ai, 'framework', 'Framework')}  runtime={_get(ai, 'dotnetRuntime', 'DotNetRuntime')}")
+    print(f"PyTorch:  {pt.get('framework')} {pt.get('torch')}  threads={pt.get('torch_num_threads')}  device={pt.get('device')}")
+    print()
+    header = f"{'model':<13}{'bs':>5}{'AiDotNet p95':>14}{'PyTorch avg':>14}{'ratio':>9}  verdict"
+    print(header)
+    print("-" * len(header))
+
+    wins = 0
+    total = 0
+    for model in sorted(set(ai_idx) | set(pt_idx)):
+        for bs in sorted(set(ai_idx.get(model, {})) | set(pt_idx.get(model, {}))):
+            a = ai_idx.get(model, {}).get(bs)
+            p = pt_idx.get(model, {}).get(bs)
+            if not a or not p:
+                continue
+            ai_p95 = a["p95_ms"]
+            pt_avg = p["avg_ms"]
+            if ai_p95 is None or pt_avg in (None, 0):
+                continue
+            ratio = ai_p95 / pt_avg
+            win = ai_p95 < pt_avg
+            wins += int(win)
+            total += 1
+            verdict = "WIN " if win else "lose"
+            print(f"{model:<13}{bs:>5}{ai_p95:>14.3f}{pt_avg:>14.3f}{ratio:>8.2f}x  {verdict}")
+
+    print("-" * len(header))
+    print(f"AiDotNet wins {wins}/{total} rows (p95(AiDotNet) < mean(PyTorch)).")
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/AiDotNet.PyTorchParity/pytorch/compare.py
+++ b/benchmarks/AiDotNet.PyTorchParity/pytorch/compare.py
@@ -21,7 +21,7 @@ import json
 from pathlib import Path
 
 
-def _get(d: dict, *names: str, default=None):
+def _get(d: dict, *names: str, default=None) -> object:
     """Fetch the first present key from a set of casing variants."""
     for n in names:
         if n in d:

--- a/benchmarks/AiDotNet.PyTorchParity/pytorch/requirements.txt
+++ b/benchmarks/AiDotNet.PyTorchParity/pytorch/requirements.txt
@@ -1,0 +1,4 @@
+# PyTorch side of the parity benchmark. CPU wheels are sufficient for the
+# CPU-vs-CPU comparison; install a CUDA build if you want --device cuda.
+torch>=2.2
+psutil>=5.9

--- a/benchmarks/AiDotNet.PyTorchParity/pytorch/requirements.txt
+++ b/benchmarks/AiDotNet.PyTorchParity/pytorch/requirements.txt
@@ -1,4 +1,4 @@
 # PyTorch side of the parity benchmark. CPU wheels are sufficient for the
 # CPU-vs-CPU comparison; install a CUDA build if you want --device cuda.
-torch>=2.2
+torch>=2.5.0
 psutil>=5.9

--- a/src/ActivationFunctions/BentIdentityActivation.cs
+++ b/src/ActivationFunctions/BentIdentityActivation.cs
@@ -27,8 +27,15 @@ namespace AiDotNet.ActivationFunctions;
 [ActivationCategory(ActivationCategory.General)]
 [ActivationTask(ActivationTask.HiddenLayer)]
 [ActivationProperty(IsMonotonic = true, ZeroPreserving = true, IsBounded = false, Cost = ComputeCost.Medium)]
-public class BentIdentityActivation<T> : ActivationFunctionBase<T>
+public class BentIdentityActivation<T> : ActivationFunctionBase<T>, Fused.IFusedActivation
 {
+    /// <inheritdoc/>
+    bool Fused.IFusedActivation.TryGetFusedActivation(out AiDotNet.Tensors.Engines.FusedActivationType type)
+    {
+        type = AiDotNet.Tensors.Engines.FusedActivationType.BentIdentity;
+        return true;
+    }
+
     /// <summary>
     /// Indicates that this activation function supports operations on individual scalar values.
     /// </summary>

--- a/src/ActivationFunctions/ELUActivation.cs
+++ b/src/ActivationFunctions/ELUActivation.cs
@@ -26,6 +26,15 @@ namespace AiDotNet.ActivationFunctions;
 [ActivationCategory(ActivationCategory.General)]
 [ActivationTask(ActivationTask.HiddenLayer)]
 [ActivationProperty(IsMonotonic = true, ZeroPreserving = true, IsBounded = false, Cost = ComputeCost.Medium)]
+// NOTE: ELU intentionally does NOT implement IFusedActivation. The shipped
+// Tensors FusedLinear/MlpForward path resolves pointwise activations through
+// CpuFusedOperations._floatActivations/_doubleActivations, which currently
+// register only None/ReLU/GELU/Sigmoid/Tanh/LeakyReLU/Swish — ELU has no
+// kernel there (it exists only in the unrelated BlasManaged ActivationEpilogue
+// path). Claiming a fused ELU kernel would make MlpForward throw. Wiring it is
+// tracked by AiDotNet.Tensors #499 (add ELU to the FusedLinear tables); once a
+// Tensors release ships the kernel, re-add IFusedActivation here (guarding
+// alpha==1 since the kernel hardcodes that).
 public class ELUActivation<T> : ActivationFunctionBase<T>
 {
     /// <summary>

--- a/src/ActivationFunctions/Fused/IFusedActivation.cs
+++ b/src/ActivationFunctions/Fused/IFusedActivation.cs
@@ -1,0 +1,23 @@
+using AiDotNet.Tensors.Engines;
+
+namespace AiDotNet.ActivationFunctions.Fused;
+
+/// <summary>
+/// Implemented by scalar activation functions that have an exact fused-kernel
+/// equivalent (<see cref="FusedActivationType"/>), so fused inference paths such
+/// as <c>IEngine.MlpForward</c> can ask the activation what kernel it maps to
+/// instead of switching on its type.
+/// </summary>
+/// <remarks>
+/// Open/closed-compliant for the same reason as
+/// <see cref="Optimizers.Fused.IFusedOptimizerSpec"/>: only activations whose
+/// fused kernel is numerically identical to the scalar form implement this, so
+/// there is no central activation→enum switch to maintain and an unrecognized
+/// activation simply keeps the generic per-layer path. A null activation (linear
+/// layer) is treated as <see cref="FusedActivationType.None"/> by callers.
+/// </remarks>
+public interface IFusedActivation
+{
+    /// <summary>The fused-kernel activation type equivalent to this activation.</summary>
+    FusedActivationType FusedActivationType { get; }
+}

--- a/src/ActivationFunctions/Fused/IFusedActivation.cs
+++ b/src/ActivationFunctions/Fused/IFusedActivation.cs
@@ -9,15 +9,27 @@ namespace AiDotNet.ActivationFunctions.Fused;
 /// instead of switching on its type.
 /// </summary>
 /// <remarks>
+/// <para>
 /// Open/closed-compliant for the same reason as
 /// <see cref="Optimizers.Fused.IFusedOptimizerSpec"/>: only activations whose
 /// fused kernel is numerically identical to the scalar form implement this, so
 /// there is no central activation→enum switch to maintain and an unrecognized
 /// activation simply keeps the generic per-layer path. A null activation (linear
 /// layer) is treated as <see cref="FusedActivationType.None"/> by callers.
+/// </para>
+/// <para>
+/// <see cref="TryGetFusedActivation"/> returns <c>false</c> when THIS instance
+/// can't be reproduced by the fused kernel — e.g. a parametric activation whose
+/// parameter (LeakyReLU slope, ELU alpha) differs from the value the kernel
+/// hardcodes — so a custom-parameter instance correctly falls back rather than
+/// silently getting the kernel's default parameter.
+/// </para>
 /// </remarks>
 public interface IFusedActivation
 {
-    /// <summary>The fused-kernel activation type equivalent to this activation.</summary>
-    FusedActivationType FusedActivationType { get; }
+    /// <summary>
+    /// Reports the fused-kernel activation type equivalent to this activation, or
+    /// returns <c>false</c> if this instance can't be reproduced by the kernel.
+    /// </summary>
+    bool TryGetFusedActivation(out FusedActivationType type);
 }

--- a/src/ActivationFunctions/GELUActivation.cs
+++ b/src/ActivationFunctions/GELUActivation.cs
@@ -32,12 +32,16 @@ namespace AiDotNet.ActivationFunctions;
 [ActivationTask(ActivationTask.HiddenLayer)]
 [ActivationTask(ActivationTask.TransformerFFN)]
 [ActivationProperty(IsMonotonic = false, ZeroPreserving = true, IsBounded = false, Cost = ComputeCost.High)]
-public class GELUActivation<T> : ActivationFunctionBase<T>
+public class GELUActivation<T> : ActivationFunctionBase<T>, Fused.IFusedActivation
 {
-    // Intentionally NOT IFusedActivation: GELU has tanh-approx vs exact-erf
-    // variants, and the fused kernel's GELU must be numerically identical to this
-    // class's formula before it can be mapped. Left on the generic path until that
-    // equivalence is verified, so fused routing never changes GELU outputs.
+    /// <inheritdoc/>
+    // This class uses the tanh approximation of GELU, identical to the fused
+    // ActivationEpilogue GELU kernel (0.5·x·(1+tanh(√(2/π)·(x+0.044715·x³)))).
+    public bool TryGetFusedActivation(out AiDotNet.Tensors.Engines.FusedActivationType type)
+    {
+        type = AiDotNet.Tensors.Engines.FusedActivationType.GELU;
+        return true;
+    }
 
     /// <summary>
     /// Indicates that this activation function supports operations on individual scalar values.

--- a/src/ActivationFunctions/GELUActivation.cs
+++ b/src/ActivationFunctions/GELUActivation.cs
@@ -34,6 +34,11 @@ namespace AiDotNet.ActivationFunctions;
 [ActivationProperty(IsMonotonic = false, ZeroPreserving = true, IsBounded = false, Cost = ComputeCost.High)]
 public class GELUActivation<T> : ActivationFunctionBase<T>
 {
+    // Intentionally NOT IFusedActivation: GELU has tanh-approx vs exact-erf
+    // variants, and the fused kernel's GELU must be numerically identical to this
+    // class's formula before it can be mapped. Left on the generic path until that
+    // equivalence is verified, so fused routing never changes GELU outputs.
+
     /// <summary>
     /// Indicates that this activation function supports operations on individual scalar values.
     /// </summary>

--- a/src/ActivationFunctions/GELUActivation.cs
+++ b/src/ActivationFunctions/GELUActivation.cs
@@ -37,7 +37,7 @@ public class GELUActivation<T> : ActivationFunctionBase<T>, Fused.IFusedActivati
     /// <inheritdoc/>
     // This class uses the tanh approximation of GELU, identical to the fused
     // ActivationEpilogue GELU kernel (0.5·x·(1+tanh(√(2/π)·(x+0.044715·x³)))).
-    public bool TryGetFusedActivation(out AiDotNet.Tensors.Engines.FusedActivationType type)
+    bool Fused.IFusedActivation.TryGetFusedActivation(out AiDotNet.Tensors.Engines.FusedActivationType type)
     {
         type = AiDotNet.Tensors.Engines.FusedActivationType.GELU;
         return true;

--- a/src/ActivationFunctions/GaussianActivation.cs
+++ b/src/ActivationFunctions/GaussianActivation.cs
@@ -31,8 +31,15 @@ namespace AiDotNet.ActivationFunctions;
 [ActivationCategory(ActivationCategory.General)]
 [ActivationTask(ActivationTask.HiddenLayer)]
 [ActivationProperty(IsMonotonic = false, ZeroPreserving = false, IsBounded = true, Cost = ComputeCost.Medium)]
-public class GaussianActivation<T> : ActivationFunctionBase<T>
+public class GaussianActivation<T> : ActivationFunctionBase<T>, Fused.IFusedActivation
 {
+    /// <inheritdoc/>
+    bool Fused.IFusedActivation.TryGetFusedActivation(out AiDotNet.Tensors.Engines.FusedActivationType type)
+    {
+        type = AiDotNet.Tensors.Engines.FusedActivationType.Gaussian;
+        return true;
+    }
+
     /// <summary>
     /// Indicates that this activation function supports operations on individual scalar values.
     /// </summary>

--- a/src/ActivationFunctions/HardSwishActivation.cs
+++ b/src/ActivationFunctions/HardSwishActivation.cs
@@ -33,8 +33,15 @@ namespace AiDotNet.ActivationFunctions;
 [ActivationCategory(ActivationCategory.General)]
 [ActivationTask(ActivationTask.HiddenLayer)]
 [ActivationProperty(IsMonotonic = false, ZeroPreserving = true, IsBounded = false, IsDifferentiable = false, Cost = ComputeCost.Low)]
-public class HardSwishActivation<T> : ActivationFunctionBase<T>
+public class HardSwishActivation<T> : ActivationFunctionBase<T>, Fused.IFusedActivation
 {
+    /// <inheritdoc/>
+    bool Fused.IFusedActivation.TryGetFusedActivation(out AiDotNet.Tensors.Engines.FusedActivationType type)
+    {
+        type = AiDotNet.Tensors.Engines.FusedActivationType.HardSwish;
+        return true;
+    }
+
     private readonly T _three;
     private readonly T _six;
     private readonly T _negThree;

--- a/src/ActivationFunctions/IdentityActivation.cs
+++ b/src/ActivationFunctions/IdentityActivation.cs
@@ -33,8 +33,11 @@ namespace AiDotNet.ActivationFunctions;
 public class IdentityActivation<T> : ActivationFunctionBase<T>, Fused.IFusedActivation
 {
     /// <inheritdoc/>
-    public AiDotNet.Tensors.Engines.FusedActivationType FusedActivationType
-        => AiDotNet.Tensors.Engines.FusedActivationType.None;
+    public bool TryGetFusedActivation(out AiDotNet.Tensors.Engines.FusedActivationType type)
+    {
+        type = AiDotNet.Tensors.Engines.FusedActivationType.None;
+        return true;
+    }
 
     /// <summary>
     /// Applies the Identity activation function to a single value.

--- a/src/ActivationFunctions/IdentityActivation.cs
+++ b/src/ActivationFunctions/IdentityActivation.cs
@@ -30,8 +30,12 @@ namespace AiDotNet.ActivationFunctions;
 [ActivationTask(ActivationTask.HiddenLayer)]
 [ActivationTask(ActivationTask.OutputLayer)]
 [ActivationProperty(IsMonotonic = true, ZeroPreserving = true, IsBounded = false, Cost = ComputeCost.Low)]
-public class IdentityActivation<T> : ActivationFunctionBase<T>
+public class IdentityActivation<T> : ActivationFunctionBase<T>, Fused.IFusedActivation
 {
+    /// <inheritdoc/>
+    public AiDotNet.Tensors.Engines.FusedActivationType FusedActivationType
+        => AiDotNet.Tensors.Engines.FusedActivationType.None;
+
     /// <summary>
     /// Applies the Identity activation function to a single value.
     /// </summary>

--- a/src/ActivationFunctions/IdentityActivation.cs
+++ b/src/ActivationFunctions/IdentityActivation.cs
@@ -33,7 +33,7 @@ namespace AiDotNet.ActivationFunctions;
 public class IdentityActivation<T> : ActivationFunctionBase<T>, Fused.IFusedActivation
 {
     /// <inheritdoc/>
-    public bool TryGetFusedActivation(out AiDotNet.Tensors.Engines.FusedActivationType type)
+    bool Fused.IFusedActivation.TryGetFusedActivation(out AiDotNet.Tensors.Engines.FusedActivationType type)
     {
         type = AiDotNet.Tensors.Engines.FusedActivationType.None;
         return true;

--- a/src/ActivationFunctions/LeakyReLUActivation.cs
+++ b/src/ActivationFunctions/LeakyReLUActivation.cs
@@ -29,8 +29,20 @@ namespace AiDotNet.ActivationFunctions;
 [ActivationCategory(ActivationCategory.General)]
 [ActivationTask(ActivationTask.HiddenLayer)]
 [ActivationProperty(IsMonotonic = true, ZeroPreserving = true, IsBounded = false, IsDifferentiable = true, Cost = ComputeCost.Low)]
-public class LeakyReLUActivation<T> : ActivationFunctionBase<T>
+public class LeakyReLUActivation<T> : ActivationFunctionBase<T>, Fused.IFusedActivation
 {
+    /// <inheritdoc/>
+    // The fused LeakyReLU kernel hardcodes slope=0.01; only fuse when this
+    // instance's alpha matches, else fall back so the result stays exact.
+    // Tolerance is float-grade (1e-6), not 1e-12: when T is float the default
+    // 0.01 round-trips through ToDouble as 0.009999999776, which differs from
+    // the literal 0.01 by ~2.2e-10 — a 1e-12 guard would reject the *default*.
+    public bool TryGetFusedActivation(out AiDotNet.Tensors.Engines.FusedActivationType type)
+    {
+        type = AiDotNet.Tensors.Engines.FusedActivationType.LeakyReLU;
+        return Math.Abs(NumOps.ToDouble(_alpha) - 0.01) < 1e-6;
+    }
+
     /// <summary>
     /// The slope coefficient for negative input values.
     /// </summary>

--- a/src/ActivationFunctions/LeakyReLUActivation.cs
+++ b/src/ActivationFunctions/LeakyReLUActivation.cs
@@ -37,7 +37,7 @@ public class LeakyReLUActivation<T> : ActivationFunctionBase<T>, Fused.IFusedAct
     // Tolerance is float-grade (1e-6), not 1e-12: when T is float the default
     // 0.01 round-trips through ToDouble as 0.009999999776, which differs from
     // the literal 0.01 by ~2.2e-10 — a 1e-12 guard would reject the *default*.
-    public bool TryGetFusedActivation(out AiDotNet.Tensors.Engines.FusedActivationType type)
+    bool Fused.IFusedActivation.TryGetFusedActivation(out AiDotNet.Tensors.Engines.FusedActivationType type)
     {
         type = AiDotNet.Tensors.Engines.FusedActivationType.LeakyReLU;
         return Math.Abs(NumOps.ToDouble(_alpha) - 0.01) < 1e-6;

--- a/src/ActivationFunctions/LiSHTActivation.cs
+++ b/src/ActivationFunctions/LiSHTActivation.cs
@@ -31,8 +31,15 @@ namespace AiDotNet.ActivationFunctions;
 [ActivationCategory(ActivationCategory.General)]
 [ActivationTask(ActivationTask.HiddenLayer)]
 [ActivationProperty(IsMonotonic = false, ZeroPreserving = true, IsBounded = false, Cost = ComputeCost.Medium)]
-public class LiSHTActivation<T> : ActivationFunctionBase<T>
+public class LiSHTActivation<T> : ActivationFunctionBase<T>, Fused.IFusedActivation
 {
+    /// <inheritdoc/>
+    bool Fused.IFusedActivation.TryGetFusedActivation(out AiDotNet.Tensors.Engines.FusedActivationType type)
+    {
+        type = AiDotNet.Tensors.Engines.FusedActivationType.LiSHT;
+        return true;
+    }
+
     /// <summary>
     /// Determines if the activation function supports operations on individual scalar values.
     /// </summary>

--- a/src/ActivationFunctions/MishActivation.cs
+++ b/src/ActivationFunctions/MishActivation.cs
@@ -29,6 +29,14 @@ namespace AiDotNet.ActivationFunctions;
 [ActivationCategory(ActivationCategory.General)]
 [ActivationTask(ActivationTask.HiddenLayer)]
 [ActivationProperty(IsMonotonic = false, ZeroPreserving = true, IsBounded = false, Cost = ComputeCost.High)]
+// NOTE: Mish intentionally does NOT implement IFusedActivation. The shipped
+// Tensors FusedLinear/MlpForward path resolves pointwise activations through
+// CpuFusedOperations._floatActivations/_doubleActivations, which currently
+// register only None/ReLU/GELU/Sigmoid/Tanh/LeakyReLU/Swish — Mish has no
+// kernel there (it exists only in the unrelated BlasManaged ActivationEpilogue
+// path). Claiming a fused Mish kernel would make MlpForward throw. Wiring it
+// is tracked by AiDotNet.Tensors #499 (add Mish to the FusedLinear tables);
+// once a Tensors release ships the kernel, re-add IFusedActivation here.
 public class MishActivation<T> : ActivationFunctionBase<T>
 {
     /// <summary>

--- a/src/ActivationFunctions/MishActivation.cs
+++ b/src/ActivationFunctions/MishActivation.cs
@@ -29,14 +29,10 @@ namespace AiDotNet.ActivationFunctions;
 [ActivationCategory(ActivationCategory.General)]
 [ActivationTask(ActivationTask.HiddenLayer)]
 [ActivationProperty(IsMonotonic = false, ZeroPreserving = true, IsBounded = false, Cost = ComputeCost.High)]
-// NOTE: Mish intentionally does NOT implement IFusedActivation. The shipped
-// Tensors FusedLinear/MlpForward path resolves pointwise activations through
-// CpuFusedOperations._floatActivations/_doubleActivations, which currently
-// register only None/ReLU/GELU/Sigmoid/Tanh/LeakyReLU/Swish — Mish has no
-// kernel there (it exists only in the unrelated BlasManaged ActivationEpilogue
-// path). Claiming a fused Mish kernel would make MlpForward throw. Wiring it
-// is tracked by AiDotNet.Tensors #499 (add Mish to the FusedLinear tables);
-// once a Tensors release ships the kernel, re-add IFusedActivation here.
+// Mish implements IFusedActivation: the FusedLinear/MlpForward path now registers a
+// FusedActivationType.Mish kernel (AiDotNet.Tensors #499, shipped 0.90.0+), so routing Mish
+// through the fused inference path matches its scalar Activate (verified by
+// FusedInferenceParityTests.FusedActivationKernel_MatchesScalarActivation).
 public class MishActivation<T> : ActivationFunctionBase<T>, Fused.IFusedActivation
 {
     /// <inheritdoc/>

--- a/src/ActivationFunctions/MishActivation.cs
+++ b/src/ActivationFunctions/MishActivation.cs
@@ -37,8 +37,15 @@ namespace AiDotNet.ActivationFunctions;
 // path). Claiming a fused Mish kernel would make MlpForward throw. Wiring it
 // is tracked by AiDotNet.Tensors #499 (add Mish to the FusedLinear tables);
 // once a Tensors release ships the kernel, re-add IFusedActivation here.
-public class MishActivation<T> : ActivationFunctionBase<T>
+public class MishActivation<T> : ActivationFunctionBase<T>, Fused.IFusedActivation
 {
+    /// <inheritdoc/>
+    bool Fused.IFusedActivation.TryGetFusedActivation(out AiDotNet.Tensors.Engines.FusedActivationType type)
+    {
+        type = AiDotNet.Tensors.Engines.FusedActivationType.Mish;
+        return true;
+    }
+
     /// <summary>
     /// Determines if the activation function supports operations on individual scalar values.
     /// </summary>

--- a/src/ActivationFunctions/ReLU6Activation.cs
+++ b/src/ActivationFunctions/ReLU6Activation.cs
@@ -30,8 +30,15 @@ namespace AiDotNet.ActivationFunctions;
 [ActivationCategory(ActivationCategory.General)]
 [ActivationTask(ActivationTask.HiddenLayer)]
 [ActivationProperty(IsMonotonic = true, ZeroPreserving = true, IsBounded = true, BoundLower = 0.0, BoundUpper = 6.0, IsDifferentiable = false, Cost = ComputeCost.Low)]
-public class ReLU6Activation<T> : ActivationFunctionBase<T>
+public class ReLU6Activation<T> : ActivationFunctionBase<T>, Fused.IFusedActivation
 {
+    /// <inheritdoc/>
+    bool Fused.IFusedActivation.TryGetFusedActivation(out AiDotNet.Tensors.Engines.FusedActivationType type)
+    {
+        type = AiDotNet.Tensors.Engines.FusedActivationType.ReLU6;
+        return true;
+    }
+
     private readonly T _six;
 
     /// <summary>

--- a/src/ActivationFunctions/ReLUActivation.cs
+++ b/src/ActivationFunctions/ReLUActivation.cs
@@ -27,7 +27,7 @@ namespace AiDotNet.ActivationFunctions;
 public class ReLUActivation<T> : ActivationFunctionBase<T>, Fused.IFusedActivation
 {
     /// <inheritdoc/>
-    public bool TryGetFusedActivation(out AiDotNet.Tensors.Engines.FusedActivationType type)
+    bool Fused.IFusedActivation.TryGetFusedActivation(out AiDotNet.Tensors.Engines.FusedActivationType type)
     {
         type = AiDotNet.Tensors.Engines.FusedActivationType.ReLU;
         return true;

--- a/src/ActivationFunctions/ReLUActivation.cs
+++ b/src/ActivationFunctions/ReLUActivation.cs
@@ -24,8 +24,12 @@ namespace AiDotNet.ActivationFunctions;
 [ActivationCategory(ActivationCategory.General)]
 [ActivationTask(ActivationTask.HiddenLayer)]
 [ActivationProperty(IsMonotonic = true, ZeroPreserving = true, IsBounded = false, IsDifferentiable = false, Cost = ComputeCost.Low)]
-public class ReLUActivation<T> : ActivationFunctionBase<T>
+public class ReLUActivation<T> : ActivationFunctionBase<T>, Fused.IFusedActivation
 {
+    /// <inheritdoc/>
+    public AiDotNet.Tensors.Engines.FusedActivationType FusedActivationType
+        => AiDotNet.Tensors.Engines.FusedActivationType.ReLU;
+
     /// <summary>
     /// Indicates whether this activation function supports scalar operations.
     /// </summary>

--- a/src/ActivationFunctions/ReLUActivation.cs
+++ b/src/ActivationFunctions/ReLUActivation.cs
@@ -27,8 +27,11 @@ namespace AiDotNet.ActivationFunctions;
 public class ReLUActivation<T> : ActivationFunctionBase<T>, Fused.IFusedActivation
 {
     /// <inheritdoc/>
-    public AiDotNet.Tensors.Engines.FusedActivationType FusedActivationType
-        => AiDotNet.Tensors.Engines.FusedActivationType.ReLU;
+    public bool TryGetFusedActivation(out AiDotNet.Tensors.Engines.FusedActivationType type)
+    {
+        type = AiDotNet.Tensors.Engines.FusedActivationType.ReLU;
+        return true;
+    }
 
     /// <summary>
     /// Indicates whether this activation function supports scalar operations.

--- a/src/ActivationFunctions/SELUActivation.cs
+++ b/src/ActivationFunctions/SELUActivation.cs
@@ -27,8 +27,15 @@ namespace AiDotNet.ActivationFunctions;
 [ActivationCategory(ActivationCategory.General)]
 [ActivationTask(ActivationTask.HiddenLayer)]
 [ActivationProperty(IsMonotonic = true, ZeroPreserving = true, IsBounded = false, Cost = ComputeCost.Medium)]
-public class SELUActivation<T> : ActivationFunctionBase<T>
+public class SELUActivation<T> : ActivationFunctionBase<T>, Fused.IFusedActivation
 {
+    /// <inheritdoc/>
+    bool Fused.IFusedActivation.TryGetFusedActivation(out AiDotNet.Tensors.Engines.FusedActivationType type)
+    {
+        type = AiDotNet.Tensors.Engines.FusedActivationType.SELU;
+        return true;
+    }
+
     /// <summary>
     /// The scaling factor for the SELU function.
     /// </summary>

--- a/src/ActivationFunctions/SQRBFActivation.cs
+++ b/src/ActivationFunctions/SQRBFActivation.cs
@@ -31,8 +31,15 @@ namespace AiDotNet.ActivationFunctions;
 [ActivationCategory(ActivationCategory.General)]
 [ActivationTask(ActivationTask.HiddenLayer)]
 [ActivationProperty(IsMonotonic = false, ZeroPreserving = false, IsBounded = true, Cost = ComputeCost.Low)]
-public class SQRBFActivation<T> : ActivationFunctionBase<T>
+public class SQRBFActivation<T> : ActivationFunctionBase<T>, Fused.IFusedActivation
 {
+    /// <inheritdoc/>
+    bool Fused.IFusedActivation.TryGetFusedActivation(out AiDotNet.Tensors.Engines.FusedActivationType type)
+    {
+        type = AiDotNet.Tensors.Engines.FusedActivationType.SQRBF;
+        return true;
+    }
+
     /// <summary>
     /// The width parameter that controls the shape of the Gaussian bell curve.
     /// </summary>

--- a/src/ActivationFunctions/SiLUActivation.cs
+++ b/src/ActivationFunctions/SiLUActivation.cs
@@ -28,8 +28,16 @@ namespace AiDotNet.ActivationFunctions;
 [ActivationTask(ActivationTask.HiddenLayer)]
 [ActivationTask(ActivationTask.TransformerFFN)]
 [ActivationProperty(IsMonotonic = false, ZeroPreserving = true, IsBounded = false, Cost = ComputeCost.High)]
-public class SiLUActivation<T> : ActivationFunctionBase<T>
+public class SiLUActivation<T> : ActivationFunctionBase<T>, Fused.IFusedActivation
 {
+    /// <inheritdoc/>
+    // SiLU is f(x) = x·sigmoid(x) — the same function as the fused Swish kernel.
+    public bool TryGetFusedActivation(out AiDotNet.Tensors.Engines.FusedActivationType type)
+    {
+        type = AiDotNet.Tensors.Engines.FusedActivationType.Swish;
+        return true;
+    }
+
     /// <summary>
     /// Indicates whether this activation function supports scalar operations.
     /// </summary>

--- a/src/ActivationFunctions/SiLUActivation.cs
+++ b/src/ActivationFunctions/SiLUActivation.cs
@@ -32,7 +32,7 @@ public class SiLUActivation<T> : ActivationFunctionBase<T>, Fused.IFusedActivati
 {
     /// <inheritdoc/>
     // SiLU is f(x) = x·sigmoid(x) — the same function as the fused Swish kernel.
-    public bool TryGetFusedActivation(out AiDotNet.Tensors.Engines.FusedActivationType type)
+    bool Fused.IFusedActivation.TryGetFusedActivation(out AiDotNet.Tensors.Engines.FusedActivationType type)
     {
         type = AiDotNet.Tensors.Engines.FusedActivationType.Swish;
         return true;

--- a/src/ActivationFunctions/SigmoidActivation.cs
+++ b/src/ActivationFunctions/SigmoidActivation.cs
@@ -36,8 +36,11 @@ namespace AiDotNet.ActivationFunctions;
 public class SigmoidActivation<T> : ActivationFunctionBase<T>, IOutputDerivative<T>, Fused.IFusedActivation
 {
     /// <inheritdoc/>
-    public AiDotNet.Tensors.Engines.FusedActivationType FusedActivationType
-        => AiDotNet.Tensors.Engines.FusedActivationType.Sigmoid;
+    public bool TryGetFusedActivation(out AiDotNet.Tensors.Engines.FusedActivationType type)
+    {
+        type = AiDotNet.Tensors.Engines.FusedActivationType.Sigmoid;
+        return true;
+    }
 
     /// <summary>
     /// Indicates whether this activation function supports scalar operations.

--- a/src/ActivationFunctions/SigmoidActivation.cs
+++ b/src/ActivationFunctions/SigmoidActivation.cs
@@ -33,8 +33,12 @@ namespace AiDotNet.ActivationFunctions;
 [ActivationTask(ActivationTask.RecurrentGating)]
 [ActivationTask(ActivationTask.OutputLayer)]
 [ActivationProperty(IsMonotonic = true, ZeroPreserving = false, IsBounded = true, Cost = ComputeCost.Medium)]
-public class SigmoidActivation<T> : ActivationFunctionBase<T>, IOutputDerivative<T>
+public class SigmoidActivation<T> : ActivationFunctionBase<T>, IOutputDerivative<T>, Fused.IFusedActivation
 {
+    /// <inheritdoc/>
+    public AiDotNet.Tensors.Engines.FusedActivationType FusedActivationType
+        => AiDotNet.Tensors.Engines.FusedActivationType.Sigmoid;
+
     /// <summary>
     /// Indicates whether this activation function supports scalar operations.
     /// </summary>

--- a/src/ActivationFunctions/SigmoidActivation.cs
+++ b/src/ActivationFunctions/SigmoidActivation.cs
@@ -36,7 +36,7 @@ namespace AiDotNet.ActivationFunctions;
 public class SigmoidActivation<T> : ActivationFunctionBase<T>, IOutputDerivative<T>, Fused.IFusedActivation
 {
     /// <inheritdoc/>
-    public bool TryGetFusedActivation(out AiDotNet.Tensors.Engines.FusedActivationType type)
+    bool Fused.IFusedActivation.TryGetFusedActivation(out AiDotNet.Tensors.Engines.FusedActivationType type)
     {
         type = AiDotNet.Tensors.Engines.FusedActivationType.Sigmoid;
         return true;

--- a/src/ActivationFunctions/SignActivation.cs
+++ b/src/ActivationFunctions/SignActivation.cs
@@ -24,8 +24,15 @@ namespace AiDotNet.ActivationFunctions;
 [ActivationCategory(ActivationCategory.General)]
 [ActivationTask(ActivationTask.HiddenLayer)]
 [ActivationProperty(IsMonotonic = true, ZeroPreserving = true, IsBounded = true, IsDifferentiable = false, Cost = ComputeCost.Low)]
-public class SignActivation<T> : ActivationFunctionBase<T>
+public class SignActivation<T> : ActivationFunctionBase<T>, Fused.IFusedActivation
 {
+    /// <inheritdoc/>
+    bool Fused.IFusedActivation.TryGetFusedActivation(out AiDotNet.Tensors.Engines.FusedActivationType type)
+    {
+        type = AiDotNet.Tensors.Engines.FusedActivationType.Sign;
+        return true;
+    }
+
     /// <summary>
     /// Indicates whether this activation function supports scalar operations.
     /// </summary>

--- a/src/ActivationFunctions/SoftPlusActivation.cs
+++ b/src/ActivationFunctions/SoftPlusActivation.cs
@@ -29,8 +29,15 @@ namespace AiDotNet.ActivationFunctions;
 [ActivationCategory(ActivationCategory.General)]
 [ActivationTask(ActivationTask.HiddenLayer)]
 [ActivationProperty(IsMonotonic = true, ZeroPreserving = false, IsBounded = false, Cost = ComputeCost.Medium)]
-public class SoftPlusActivation<T> : ActivationFunctionBase<T>
+public class SoftPlusActivation<T> : ActivationFunctionBase<T>, Fused.IFusedActivation
 {
+    /// <inheritdoc/>
+    bool Fused.IFusedActivation.TryGetFusedActivation(out AiDotNet.Tensors.Engines.FusedActivationType type)
+    {
+        type = AiDotNet.Tensors.Engines.FusedActivationType.Softplus;
+        return true;
+    }
+
     /// <summary>
     /// Indicates whether this activation function supports scalar operations.
     /// </summary>

--- a/src/ActivationFunctions/SoftSignActivation.cs
+++ b/src/ActivationFunctions/SoftSignActivation.cs
@@ -31,8 +31,15 @@ namespace AiDotNet.ActivationFunctions;
 [ActivationCategory(ActivationCategory.General)]
 [ActivationTask(ActivationTask.HiddenLayer)]
 [ActivationProperty(IsMonotonic = true, ZeroPreserving = true, IsBounded = true, Cost = ComputeCost.Low)]
-public class SoftSignActivation<T> : ActivationFunctionBase<T>
+public class SoftSignActivation<T> : ActivationFunctionBase<T>, Fused.IFusedActivation
 {
+    /// <inheritdoc/>
+    bool Fused.IFusedActivation.TryGetFusedActivation(out AiDotNet.Tensors.Engines.FusedActivationType type)
+    {
+        type = AiDotNet.Tensors.Engines.FusedActivationType.SoftSign;
+        return true;
+    }
+
     /// <summary>
     /// Indicates whether this activation function supports scalar operations.
     /// </summary>

--- a/src/ActivationFunctions/SwishActivation.cs
+++ b/src/ActivationFunctions/SwishActivation.cs
@@ -28,8 +28,16 @@ namespace AiDotNet.ActivationFunctions;
 [ActivationTask(ActivationTask.HiddenLayer)]
 [ActivationTask(ActivationTask.TransformerFFN)]
 [ActivationProperty(IsMonotonic = false, ZeroPreserving = true, IsBounded = false, Cost = ComputeCost.High)]
-public class SwishActivation<T> : ActivationFunctionBase<T>
+public class SwishActivation<T> : ActivationFunctionBase<T>, Fused.IFusedActivation
 {
+    /// <inheritdoc/>
+    // f(x) = x·sigmoid(x), identical to the fused Swish epilogue kernel.
+    public bool TryGetFusedActivation(out AiDotNet.Tensors.Engines.FusedActivationType type)
+    {
+        type = AiDotNet.Tensors.Engines.FusedActivationType.Swish;
+        return true;
+    }
+
     /// <inheritdoc/>
     public override bool SupportsJitCompilation => true;
 

--- a/src/ActivationFunctions/SwishActivation.cs
+++ b/src/ActivationFunctions/SwishActivation.cs
@@ -32,7 +32,7 @@ public class SwishActivation<T> : ActivationFunctionBase<T>, Fused.IFusedActivat
 {
     /// <inheritdoc/>
     // f(x) = x·sigmoid(x), identical to the fused Swish epilogue kernel.
-    public bool TryGetFusedActivation(out AiDotNet.Tensors.Engines.FusedActivationType type)
+    bool Fused.IFusedActivation.TryGetFusedActivation(out AiDotNet.Tensors.Engines.FusedActivationType type)
     {
         type = AiDotNet.Tensors.Engines.FusedActivationType.Swish;
         return true;

--- a/src/ActivationFunctions/TanhActivation.cs
+++ b/src/ActivationFunctions/TanhActivation.cs
@@ -44,8 +44,11 @@ namespace AiDotNet.ActivationFunctions;
 public class TanhActivation<T> : ActivationFunctionBase<T>, IOutputDerivative<T>, Fused.IFusedActivation
 {
     /// <inheritdoc/>
-    public AiDotNet.Tensors.Engines.FusedActivationType FusedActivationType
-        => AiDotNet.Tensors.Engines.FusedActivationType.Tanh;
+    public bool TryGetFusedActivation(out AiDotNet.Tensors.Engines.FusedActivationType type)
+    {
+        type = AiDotNet.Tensors.Engines.FusedActivationType.Tanh;
+        return true;
+    }
 
     /// <summary>
     /// Indicates that this activation function supports operations on individual scalar values.

--- a/src/ActivationFunctions/TanhActivation.cs
+++ b/src/ActivationFunctions/TanhActivation.cs
@@ -41,8 +41,12 @@ namespace AiDotNet.ActivationFunctions;
 [ActivationTask(ActivationTask.RecurrentGating)]
 [ActivationTask(ActivationTask.GenerativeOutput)]
 [ActivationProperty(IsMonotonic = true, ZeroPreserving = true, IsBounded = true, Cost = ComputeCost.Medium)]
-public class TanhActivation<T> : ActivationFunctionBase<T>, IOutputDerivative<T>
+public class TanhActivation<T> : ActivationFunctionBase<T>, IOutputDerivative<T>, Fused.IFusedActivation
 {
+    /// <inheritdoc/>
+    public AiDotNet.Tensors.Engines.FusedActivationType FusedActivationType
+        => AiDotNet.Tensors.Engines.FusedActivationType.Tanh;
+
     /// <summary>
     /// Indicates that this activation function supports operations on individual scalar values.
     /// </summary>

--- a/src/ActivationFunctions/TanhActivation.cs
+++ b/src/ActivationFunctions/TanhActivation.cs
@@ -44,7 +44,7 @@ namespace AiDotNet.ActivationFunctions;
 public class TanhActivation<T> : ActivationFunctionBase<T>, IOutputDerivative<T>, Fused.IFusedActivation
 {
     /// <inheritdoc/>
-    public bool TryGetFusedActivation(out AiDotNet.Tensors.Engines.FusedActivationType type)
+    bool Fused.IFusedActivation.TryGetFusedActivation(out AiDotNet.Tensors.Engines.FusedActivationType type)
     {
         type = AiDotNet.Tensors.Engines.FusedActivationType.Tanh;
         return true;

--- a/src/LearningRateSchedulers/CyclicLRScheduler.cs
+++ b/src/LearningRateSchedulers/CyclicLRScheduler.cs
@@ -105,6 +105,13 @@ public class CyclicLRScheduler : LearningRateSchedulerBase
     /// </summary>
     public int CycleCount => _cycleCount;
 
+    /// <summary>
+    /// Cyclic mode (Triangular / Triangular2 / ExponentialRange). Exposed so the
+    /// fused-training path can map the symmetric-triangular case to
+    /// <c>LrSchedule.Cyclic</c> and fall back to eager for the others.
+    /// </summary>
+    public CyclicMode Mode => _mode;
+
     /// <inheritdoc/>
     protected override double ComputeLearningRate(int step)
     {

--- a/src/LearningRateSchedulers/NoamSchedule.cs
+++ b/src/LearningRateSchedulers/NoamSchedule.cs
@@ -117,6 +117,14 @@ public class NoamSchedule : LearningRateSchedulerBase
     /// <summary>Model dimension this schedule was configured for.</summary>
     public int ModelDimension => _modelDimension;
 
+    /// <summary>
+    /// Multiplicative scale on the schedule (1.0 = paper-faithful). Exposed so
+    /// the fused-training path can reconstruct an equivalent
+    /// <c>AiDotNet.Tensors.Engines.Compilation.LrSchedule.Noam(...)</c> and run
+    /// Adam+Noam on the fused fast path with an identical per-step LR ramp.
+    /// </summary>
+    public double Factor => _factor;
+
     /// <inheritdoc />
     /// <remarks>
     /// <c>step</c> here is the library's "batches completed so far" counter

--- a/src/NeuralNetworks/ConvolutionalNeuralNetwork.cs
+++ b/src/NeuralNetworks/ConvolutionalNeuralNetwork.cs
@@ -248,6 +248,133 @@ public class ConvolutionalNeuralNetwork<T> : NeuralNetworkBase<T>
     protected override Tensor<T> PredictEager(Tensor<T> input) => Forward(input);
 
     /// <summary>
+    /// Fused conv-stem inference fast path: a canonical CNN classifier
+    /// — <c>[Conv(→ReLU) | MaxPool]+ → Flatten → Dense(+)</c> — replayed by calling
+    /// the engine kernels directly (FusedConv2D fusing bias+activation; index-free
+    /// MaxPool2D; cached-B FusedLinear), skipping the per-layer
+    /// <see cref="LayerBase{T}.Forward"/> wrappers. Two measured wins at bs1 on the
+    /// parity CNN: (1) the layer path pools via <c>MaxPool2DWithIndices</c> — it
+    /// allocates a 5-D backward-index array even at inference (~213 µs vs ~26 µs for
+    /// the index-free pool); this path never asks for indices. (2) it drops the
+    /// per-layer shape-resolution / <c>_lastInput</c>-caching / Tensor-view churn.
+    /// Falls back to <see cref="NeuralNetworkBase{T}.Predict"/> for anything it can't
+    /// represent (non-float, active tape, lazy/unmaterialized weights, a conv
+    /// activation other than identity/ReLU, or a layer sequence outside the pattern).
+    /// </summary>
+    public override Tensor<T> Predict(Tensor<T> input)
+    {
+        if (typeof(T) == typeof(float) && TryFusedConvStemPredict(input, out var fused))
+            return fused;
+        return base.Predict(input);
+    }
+
+    private bool TryFusedConvStemPredict(Tensor<T> input, out Tensor<T> output)
+    {
+        output = Tensor<T>.Empty();
+        if (input is null) return false;
+
+        // Inference-only: the fused kernels bypass the gradient tape.
+        if (Tensors.Engines.Autodiff.GradientTape<T>.Current is not null
+            && !Tensors.Engines.Autodiff.NoGradScope<T>.IsSuppressed)
+            return false;
+
+        var layers = Layers;
+        if (layers is null || layers.Count == 0) return false;
+
+        // Pattern: a [Conv | MaxPool]+ prefix (at least one Conv), then exactly one
+        // FlattenLayer, then a Dense+ tail — nothing else.
+        int idx = 0;
+        bool sawConv = false;
+        while (idx < layers.Count &&
+               (layers[idx] is Layers.ConvolutionalLayer<T> || layers[idx] is Layers.MaxPoolingLayer<T>))
+        {
+            if (layers[idx] is Layers.ConvolutionalLayer<T>) sawConv = true;
+            idx++;
+        }
+        if (!sawConv) return false;
+        if (idx >= layers.Count || layers[idx] is not Layers.FlattenLayer<T>) return false;
+        int flattenIdx = idx;
+        idx++;
+        int denseStart = idx;
+        while (idx < layers.Count && layers[idx] is Layers.DenseLayer<T>) idx++;
+        if (idx != layers.Count || denseStart == layers.Count) return false;
+
+        // Canonicalize input to 4D [B, C, H, W]; remember if we added the batch axis.
+        bool addedBatch = false;
+        Tensor<T> t;
+        if (input.Rank == 4) t = input;
+        else if (input.Rank == 3) { t = Engine.Reshape(input, new[] { 1, input.Shape[0], input.Shape[1], input.Shape[2] }); addedBatch = true; }
+        else return false;
+        if (!t.IsContiguous) return false;
+        int batch = t.Shape[0];
+
+        try
+        {
+            // Conv / pool prefix.
+            for (int li = 0; li < flattenIdx; li++)
+            {
+                if (layers[li] is Layers.ConvolutionalLayer<T> conv)
+                {
+                    if (conv.VectorActivation is not null) return false;
+                    // FusedConv2D's in-place epilogue fast path covers identity + ReLU.
+                    var act = Tensors.Engines.FusedActivationType.None;
+                    if (conv.ScalarActivation is not null)
+                    {
+                        if (conv.ScalarActivation is ActivationFunctions.Fused.IFusedActivation cf
+                            && cf.TryGetFusedActivation(out var cft)
+                            && (cft == Tensors.Engines.FusedActivationType.None || cft == Tensors.Engines.FusedActivationType.ReLU))
+                            act = cft;
+                        else
+                            return false;
+                    }
+                    var kernels = conv.GetFilters();
+                    if (kernels.Rank != 4 || kernels.Shape[0] == 0) return false;   // lazy → bail
+                    t = Engine.FusedConv2D(t, kernels, conv.GetBiases(),
+                        conv.Stride, conv.Stride, conv.Padding, conv.Padding, 1, 1, act);
+                }
+                else
+                {
+                    var pool = (Layers.MaxPoolingLayer<T>)layers[li];
+                    t = Engine.MaxPool2D(t, pool.PoolSize, pool.Stride);   // index-free (inference)
+                }
+            }
+
+            // Flatten [B, C, H, W] → [B, C·H·W].
+            int flat = 1;
+            for (int d = 1; d < t.Rank; d++) flat *= t.Shape[d];
+            t = Engine.Reshape(t, new[] { batch, flat });
+
+            // Dense tail.
+            for (int li = denseStart; li < layers.Count; li++)
+            {
+                var dense = (Layers.DenseLayer<T>)layers[li];
+                if (dense.VectorActivation is not null) return false;
+                var act = Tensors.Engines.FusedActivationType.None;
+                if (dense.ScalarActivation is not null)
+                {
+                    if (dense.ScalarActivation is ActivationFunctions.Fused.IFusedActivation df
+                        && df.TryGetFusedActivation(out var dft))
+                        act = dft;
+                    else
+                        return false;
+                }
+                var w = dense.GetWeights();
+                if (w.Rank != 2 || w.Shape[0] == 0 || w.Shape[1] == 0) return false;   // lazy → bail
+                t = Engine.FusedLinear(t, w, dense.GetBiases(), act);
+            }
+
+            output = addedBatch ? Engine.Reshape(t, new[] { t.Shape[1] }) : t;
+            return true;
+        }
+        catch (InvalidOperationException)
+        {
+            // A kernel declined (e.g. an unexpected active-tape state) — fall back.
+            output = Tensor<T>.Empty();
+            return false;
+        }
+    }
+
+    /// <summary>
     /// Trains the convolutional neural network using the provided input and expected output.
     /// </summary>
     /// <param name="input">The input tensor for training.</param>

--- a/src/NeuralNetworks/ConvolutionalNeuralNetwork.cs
+++ b/src/NeuralNetworks/ConvolutionalNeuralNetwork.cs
@@ -268,6 +268,16 @@ public class ConvolutionalNeuralNetwork<T> : NeuralNetworkBase<T>
         return base.Predict(input);
     }
 
+    // Cached scratch feature-map buffers for the conv/pool prefix (one per layer).
+    // Reused across Predict calls so the stem allocates none of the intermediate
+    // tensors per inference — a profiler showed the parity CNN allocated ~100 KB
+    // PER Predict (the Conv2D/MaxPool result tensors), driving 27 gen1 GCs / 2000
+    // calls and inflating p95. The buffers depend only on batch + layer geometry
+    // (weights are read fresh each call), so they're rebuilt only when the batch
+    // size changes; weight updates need no invalidation.
+    private Tensor<T>[]? _convStemBuf;
+    private int _convStemBatch = -1;
+
     private bool TryFusedConvStemPredict(Tensor<T> input, out Tensor<T> output)
     {
         output = Tensor<T>.Empty();
@@ -308,36 +318,88 @@ public class ConvolutionalNeuralNetwork<T> : NeuralNetworkBase<T>
         if (!t.IsContiguous) return false;
         int batch = t.Shape[0];
 
+        // The zero-alloc path uses CpuEngine's into-variant conv/pool kernels (not on
+        // IEngine); fall back for any other engine (e.g. GPU).
+        if (Engine is not AiDotNet.Tensors.Engines.CpuEngine cpu) return false;
+
         try
         {
-            // Conv / pool prefix.
+            // Validate conv activations + materialized weights up front (so we can bail
+            // cleanly before touching the buffer cache).
             for (int li = 0; li < flattenIdx; li++)
             {
                 if (layers[li] is Layers.ConvolutionalLayer<T> conv)
                 {
                     if (conv.VectorActivation is not null) return false;
-                    // FusedConv2D's in-place epilogue fast path covers identity + ReLU.
-                    var act = Tensors.Engines.FusedActivationType.None;
-                    if (conv.ScalarActivation is not null)
+                    if (conv.ScalarActivation is not null
+                        && !(conv.ScalarActivation is ActivationFunctions.Fused.IFusedActivation cf
+                             && cf.TryGetFusedActivation(out var cft)
+                             && (cft == Tensors.Engines.FusedActivationType.None || cft == Tensors.Engines.FusedActivationType.ReLU)))
+                        return false;   // conv epilogue fast path covers identity + ReLU only
+                    var k = conv.GetFilters();
+                    if (k.Rank != 4 || k.Shape[0] == 0) return false;   // lazy → bail
+                }
+            }
+
+            // (Re)build the per-layer scratch buffers when the batch geometry changes.
+            // Shapes are fully determined by batch + layer config; weights are read
+            // fresh per call, so no weight-based invalidation is needed.
+            if (_convStemBuf is null || _convStemBuf.Length != flattenIdx || _convStemBatch != batch)
+            {
+                _convStemBuf = new Tensor<T>[flattenIdx];
+                int curC = t.Shape[1], curH = t.Shape[2], curW = t.Shape[3];
+                for (int li = 0; li < flattenIdx; li++)
+                {
+                    int[] sh;
+                    if (layers[li] is Layers.ConvolutionalLayer<T> conv)
                     {
-                        if (conv.ScalarActivation is ActivationFunctions.Fused.IFusedActivation cf
-                            && cf.TryGetFusedActivation(out var cft)
-                            && (cft == Tensors.Engines.FusedActivationType.None || cft == Tensors.Engines.FusedActivationType.ReLU))
-                            act = cft;
-                        else
-                            return false;
+                        var k = conv.GetFilters();
+                        int outC = k.Shape[0], kh = k.Shape[2], kw = k.Shape[3];
+                        int oh = (curH + 2 * conv.Padding - kh) / conv.Stride + 1;
+                        int ow = (curW + 2 * conv.Padding - kw) / conv.Stride + 1;
+                        if (oh <= 0 || ow <= 0) return false;
+                        sh = new[] { batch, outC, oh, ow }; curC = outC; curH = oh; curW = ow;
                     }
-                    var kernels = conv.GetFilters();
-                    if (kernels.Rank != 4 || kernels.Shape[0] == 0) return false;   // lazy → bail
-                    t = Engine.FusedConv2D(t, kernels, conv.GetBiases(),
-                        conv.Stride, conv.Stride, conv.Padding, conv.Padding, 1, 1, act);
+                    else
+                    {
+                        var pool = (Layers.MaxPoolingLayer<T>)layers[li];
+                        int oh = (curH - pool.PoolSize) / pool.Stride + 1;
+                        int ow = (curW - pool.PoolSize) / pool.Stride + 1;
+                        if (oh <= 0 || ow <= 0) return false;
+                        sh = new[] { batch, curC, oh, ow }; curH = oh; curW = ow;
+                    }
+                    _convStemBuf[li] = new Tensor<T>(sh);
+                }
+                _convStemBatch = batch;
+            }
+
+            // Conv / pool prefix — into the reused buffers (zero per-call allocation;
+            // conv = Conv2DInto + in-place SIMD bias/ReLU epilogue, pool = index-free
+            // MaxPool2DInto).
+            var cur = t;
+            for (int li = 0; li < flattenIdx; li++)
+            {
+                var buf = _convStemBuf[li];
+                if (layers[li] is Layers.ConvolutionalLayer<T> conv)
+                {
+                    var act = Tensors.Engines.FusedActivationType.None;
+                    if (conv.ScalarActivation is ActivationFunctions.Fused.IFusedActivation cf2
+                        && cf2.TryGetFusedActivation(out var cft2))
+                        act = cft2;
+                    cpu.Conv2DInto(buf, cur, conv.GetFilters(),
+                        new[] { conv.Stride, conv.Stride }, new[] { conv.Padding, conv.Padding }, new[] { 1, 1 });
+                    AiDotNet.Tensors.Helpers.CpuFusedOperations.ApplyBiasActivationNCHWInPlace(
+                        (float[])(object)buf.GetDataArray(), (float[])(object)conv.GetBiases().GetDataArray(),
+                        buf.Shape[0], buf.Shape[1], buf.Shape[2], buf.Shape[3], act);
                 }
                 else
                 {
                     var pool = (Layers.MaxPoolingLayer<T>)layers[li];
-                    t = Engine.MaxPool2D(t, pool.PoolSize, pool.Stride);   // index-free (inference)
+                    cpu.MaxPool2DInto(buf, cur, pool.PoolSize, pool.Stride);
                 }
+                cur = buf;
             }
+            t = cur;
 
             // Flatten [B, C, H, W] → [B, C·H·W].
             int flat = 1;

--- a/src/NeuralNetworks/FeedForwardNeuralNetwork.cs
+++ b/src/NeuralNetworks/FeedForwardNeuralNetwork.cs
@@ -233,10 +233,11 @@ public class FeedForwardNeuralNetwork<T> : NeuralNetworkBase<T>
             Tensors.Engines.FusedActivationType act;
             if (dense.ScalarActivation is null)
                 act = Tensors.Engines.FusedActivationType.None;
-            else if (dense.ScalarActivation is ActivationFunctions.Fused.IFusedActivation fused)
-                act = fused.FusedActivationType;
+            else if (dense.ScalarActivation is ActivationFunctions.Fused.IFusedActivation fused
+                     && fused.TryGetFusedActivation(out var ft))
+                act = ft;
             else
-                return false; // activation has no exact fused equivalent
+                return false; // activation has no exact fused equivalent (or custom param)
 
             if (i == layers.Count - 1)
             {
@@ -254,7 +255,14 @@ public class FeedForwardNeuralNetwork<T> : NeuralNetworkBase<T>
                 return false;
             }
 
-            weights.Add(dense.GetWeights());
+            // DenseLayer initializes its weights lazily on first Forward. On a
+            // fresh network's very first inference the weights are still the [0,0]
+            // sentinel, which MlpForward would reject. Bail to the generic Forward
+            // (which runs the lazy shape resolution); subsequent inferences, with
+            // weights materialized, take the fused path.
+            var w = dense.GetWeights();
+            if (w.Rank != 2 || w.Shape[0] == 0 || w.Shape[1] == 0) return false;
+            weights.Add(w);
             biases.Add(dense.GetBiases());
         }
 

--- a/src/NeuralNetworks/FeedForwardNeuralNetwork.cs
+++ b/src/NeuralNetworks/FeedForwardNeuralNetwork.cs
@@ -185,11 +185,92 @@ public class FeedForwardNeuralNetwork<T> : NeuralNetworkBase<T>
 
         ValidateInputShape(input, "prediction");
 
+        // Fused fast path: a pure stack of dense layers with fused-eligible scalar
+        // activations runs as ONE IEngine.MlpForward call instead of a per-layer
+        // tape/dispatch walk — the kernel the AiDotNet.Tensors MLP micro-benchmarks
+        // beat PyTorch-CPU on. Falls back to the generic Forward for any layer the
+        // kernel can't represent (non-dense, vector activation, unmapped activation,
+        // mixed hidden activations) or if the kernel declines (e.g. active tape).
+        if (TryFusedDensePredict(input, out var fused))
+        {
+            IsTrainingMode = true;
+            return fused;
+        }
+
         var predictions = Forward(input);
 
         IsTrainingMode = true;
 
         return predictions;
+    }
+
+    /// <summary>
+    /// Attempts the fused multi-layer-perceptron inference kernel for a pure
+    /// dense+activation stack. Returns false (and the caller uses the generic
+    /// per-layer <see cref="Forward"/>) whenever the stack isn't representable by
+    /// <c>IEngine.MlpForward</c>. Activation→kernel mapping is open/closed: each
+    /// activation that has an exact fused equivalent implements
+    /// <see cref="ActivationFunctions.Fused.IFusedActivation"/>; there is no switch.
+    /// </summary>
+    private bool TryFusedDensePredict(Tensor<T> input, out Tensor<T> output)
+    {
+        output = Tensor<T>.Empty();
+        var layers = Layers;
+        if (layers is null || layers.Count == 0) return false;
+
+        var weights = new List<Tensor<T>>(layers.Count);
+        var biases = new List<Tensor<T>?>(layers.Count);
+        var hiddenActivation = Tensors.Engines.FusedActivationType.None;
+        bool hiddenActivationSet = false;
+        var outputActivation = Tensors.Engines.FusedActivationType.None;
+
+        for (int i = 0; i < layers.Count; i++)
+        {
+            if (layers[i] is not Layers.DenseLayer<T> dense) return false;
+            // Vector activations aren't covered by the scalar fused kernels.
+            if (dense.VectorActivation is not null) return false;
+
+            Tensors.Engines.FusedActivationType act;
+            if (dense.ScalarActivation is null)
+                act = Tensors.Engines.FusedActivationType.None;
+            else if (dense.ScalarActivation is ActivationFunctions.Fused.IFusedActivation fused)
+                act = fused.FusedActivationType;
+            else
+                return false; // activation has no exact fused equivalent
+
+            if (i == layers.Count - 1)
+            {
+                outputActivation = act;
+            }
+            else if (!hiddenActivationSet)
+            {
+                hiddenActivation = act;
+                hiddenActivationSet = true;
+            }
+            else if (hiddenActivation != act)
+            {
+                // MlpForward applies a single hidden activation to every non-final
+                // layer; a stack with mixed hidden activations can't use it.
+                return false;
+            }
+
+            weights.Add(dense.GetWeights());
+            biases.Add(dense.GetBiases());
+        }
+
+        try
+        {
+            output = AiDotNet.Tensors.Engines.AiDotNetEngine.Current.MlpForward(
+                input, weights, biases, hiddenActivation, outputActivation);
+            return true;
+        }
+        catch (InvalidOperationException)
+        {
+            // MlpForward is forward-only and throws under an active GradientTape;
+            // fall back to the generic path rather than failing the prediction.
+            output = Tensor<T>.Empty();
+            return false;
+        }
     }
 
     /// <summary>

--- a/src/NeuralNetworks/FeedForwardNeuralNetwork.cs
+++ b/src/NeuralNetworks/FeedForwardNeuralNetwork.cs
@@ -365,7 +365,10 @@ public class FeedForwardNeuralNetwork<T> : NeuralNetworkBase<T>
         if (inFeatures != plan.InputFeatures) return false;
 
         var inputArr = (float[])(object)input.GetDataArray();
-        var outArr = new float[(long)batch * plan.OutputFeatures];
+        // Array lengths are int in C#; compute the output element count in a checked int so an
+        // oversized batch×features product throws OverflowException rather than silently wrapping
+        // (the prior (long) length forced an int-narrowing conversion at the array creation site).
+        var outArr = new float[checked(batch * plan.OutputFeatures)];
         plan.Run(inputArr, batch, outArr);
 
         var resultShape = input.Rank == 2 ? new[] { batch, plan.OutputFeatures } : new[] { plan.OutputFeatures };

--- a/src/NeuralNetworks/FeedForwardNeuralNetwork.cs
+++ b/src/NeuralNetworks/FeedForwardNeuralNetwork.cs
@@ -268,6 +268,18 @@ public class FeedForwardNeuralNetwork<T> : NeuralNetworkBase<T>
 
         try
         {
+            // Flagship compiled-inference tier (float only): replay a cached, self-tuned
+            // CompiledMlp plan (array-based, near-zero per-call allocation, per-layer
+            // managed-vs-native kernel selection) instead of the Tensor-based MlpForward.
+            // At the kernel level CompiledMlp.Run beats torch.compile (~0.11 ms vs
+            // ~0.22 ms at bs1 on the AIsEval MLP); MlpForward's per-call Tensor/dispatch
+            // overhead is what loses. Falls through to MlpForward when ineligible.
+            if (typeof(T) == typeof(float)
+                && TryCompiledMlpPredict(input, weights, biases, hiddenActivation, outputActivation, out output))
+            {
+                return true;
+            }
+
             output = AiDotNet.Tensors.Engines.AiDotNetEngine.Current.MlpForward(
                 input, weights, biases, hiddenActivation, outputActivation);
             return true;
@@ -279,6 +291,86 @@ public class FeedForwardNeuralNetwork<T> : NeuralNetworkBase<T>
             output = Tensor<T>.Empty();
             return false;
         }
+    }
+
+    // ── Compiled-inference plan cache (float pure-dense fast path) ────────────
+    private AiDotNet.Tensors.Engines.Compilation.CompiledMlp? _compiledMlpPlan;
+    private float[][]? _compiledMlpWeightRefs;   // backing arrays the plan was built from
+    private int _compiledMlpMaxBatch;
+
+    /// <summary>
+    /// Runs the pure-dense float stack through the cached <c>CompiledMlp</c> plan.
+    /// Returns false when the input shape isn't a contiguous rank-1/2 batch the plan
+    /// can replay (caller then uses <c>MlpForward</c>). The plan is (re)built when it's
+    /// absent, the batch exceeds the buffers it was sized for, or any layer's weight
+    /// backing array was reallocated — the same frozen-weights-during-inference contract
+    /// as the MlpForward path (which likewise relies on SgemmWithCachedB's
+    /// identity-keyed pack), plus a reallocation guard the cached plan requires.
+    /// </summary>
+    private bool TryCompiledMlpPredict(
+        Tensor<T> input,
+        List<Tensor<T>> weights,
+        List<Tensor<T>?> biases,
+        Tensors.Engines.FusedActivationType hiddenActivation,
+        Tensors.Engines.FusedActivationType outputActivation,
+        out Tensor<T> output)
+    {
+        output = Tensor<T>.Empty();
+
+        // Only contiguous rank-1 ([features]) or rank-2 ([batch, features]) inputs map
+        // to the plan's [batch, features] array contract.
+        if (!input.IsContiguous || input.Rank < 1 || input.Rank > 2) return false;
+        int batch = input.Rank == 2 ? input.Shape[0] : 1;
+        int inFeatures = input.Shape[input.Rank - 1];
+        if (batch < 1) return false;
+
+        int layerCount = weights.Count;
+        var wRefs = new float[layerCount][];
+        for (int i = 0; i < layerCount; i++)
+            wRefs[i] = (float[])(object)weights[i].GetDataArray();
+        if (wRefs[0].Length < (long)inFeatures * weights[0].Shape[1]) return false;
+
+        bool rebuild = _compiledMlpPlan is null
+            || batch > _compiledMlpMaxBatch
+            || _compiledMlpWeightRefs is null
+            || _compiledMlpWeightRefs.Length != layerCount;
+        if (!rebuild)
+        {
+            for (int i = 0; i < layerCount; i++)
+                if (!ReferenceEquals(_compiledMlpWeightRefs![i], wRefs[i])) { rebuild = true; break; }
+        }
+
+        if (rebuild)
+        {
+            var inF = new int[layerCount];
+            var outF = new int[layerCount];
+            var bArrs = new float[]?[layerCount];
+            for (int i = 0; i < layerCount; i++)
+            {
+                inF[i] = weights[i].Shape[0];
+                outF[i] = weights[i].Shape[1];
+                var b = biases[i];
+                bArrs[i] = b is null ? null : (float[])(object)b.GetDataArray();
+            }
+            // Size buffers for at least this batch; grow (never shrink) so cycling
+            // batch sizes doesn't thrash. maxBatch caps the ping-pong scratch.
+            int maxBatch = Math.Max(batch, _compiledMlpMaxBatch);
+            _compiledMlpPlan = Tensors.Engines.Compilation.CompiledMlp.Create(
+                wRefs, bArrs, inF, outF, hiddenActivation, outputActivation, maxBatch);
+            _compiledMlpWeightRefs = wRefs;
+            _compiledMlpMaxBatch = maxBatch;
+        }
+
+        var plan = _compiledMlpPlan!;
+        if (inFeatures != plan.InputFeatures) return false;
+
+        var inputArr = (float[])(object)input.GetDataArray();
+        var outArr = new float[(long)batch * plan.OutputFeatures];
+        plan.Run(inputArr, batch, outArr);
+
+        var resultShape = input.Rank == 2 ? new[] { batch, plan.OutputFeatures } : new[] { plan.OutputFeatures };
+        output = (Tensor<T>)(object)new Tensor<float>(outArr, resultShape);
+        return true;
     }
 
     /// <summary>

--- a/src/NeuralNetworks/NeuralNetworkBase.cs
+++ b/src/NeuralNetworks/NeuralNetworkBase.cs
@@ -5319,6 +5319,28 @@ public abstract class NeuralNetworkBase<T> : INeuralNetworkModel<T>, IInterpreta
             && TryTrainWithFusedOptimizer(input, expected, resolvedOptimizer))
             return;
 
+        // Loud one-time fallback warning. The fused path above is the fast path;
+        // when it doesn't engage we drop to the eager tape every step — a large,
+        // previously-SILENT perf cliff. Surface it once per model so "compiled
+        // training does nothing" is never invisible again. Skipped when mixed
+        // precision is active (that path is an intentional, documented fallback,
+        // not a misconfiguration). Suppressible via AIDOTNET_QUIET.
+        if (!_loggedFusedFallback && _mixedPrecisionContext is null)
+        {
+            _loggedFusedFallback = true;
+            if (string.IsNullOrEmpty(Environment.GetEnvironmentVariable("AIDOTNET_QUIET")))
+            {
+                var reason = _pendingFusedMissReason ?? "(unspecified gate)";
+                System.Diagnostics.Trace.TraceWarning(
+                    $"[AiDotNet] Compiled fused-training fast path is OFF for {GetType().Name} — " +
+                    $"every Train() step falls back to the eager autograd tape (reason: {reason}). " +
+                    "Training is substantially slower than the compiled path. To re-enable it, use a " +
+                    "fused-compatible optimizer (plain Adam/AdamW/SGD, no adaptive-rate/AMSGrad, float/double) " +
+                    "and keep TensorCodecOptions.EnableCompilation = true. Set TrainingDiagnosticsConfig.Level " +
+                    "= PerStep for per-step path detail, or AIDOTNET_QUIET to silence this warning.");
+            }
+        }
+
         // The parameter walk here exists only to size the buffer on first Train()
         // call. On every subsequent call the buffer is already the right size, and
         // GetOrCreateParameterBuffer short-circuits to return it. Skipping the
@@ -6193,6 +6215,24 @@ public abstract class NeuralNetworkBase<T> : INeuralNetworkModel<T>, IInterpreta
     /// call so a prior step's bail-out can't leak into this one.
     /// </summary>
     private string? _pendingFusedMissReason;
+
+    /// <summary>
+    /// One-shot guard for the loud fused-fallback warning emitted by
+    /// <see cref="TrainWithTape"/>. The compiled fused-training fast path
+    /// silently falls back to the eager autograd tape when its gates aren't
+    /// met (incompatible optimizer config, non-float/double type, mixed
+    /// precision, tracing failure). That fallback is a multi-× perf cliff
+    /// with — until now — zero signal at the default diagnostic level: a user
+    /// could "enable compilation" and unknowingly train on the slow path
+    /// forever (the AIsEval benchmark hit exactly this — the default Adam was
+    /// rejected by <see cref="TryMapToFusedOptimizerConfig"/> and every step
+    /// fell back, invisibly). We surface it ONCE per model instance via
+    /// <see cref="System.Diagnostics.Trace"/> (suppressible with
+    /// <c>AIDOTNET_QUIET</c>); the flag keeps the hot training loop quiet
+    /// after the first warning. <see cref="Configuration.TrainingDiagnosticsConfig"/>
+    /// at PerStep still gives per-step detail for those who want it.
+    /// </summary>
+    private bool _loggedFusedFallback;
 
     /// <summary>
     /// Attempts the fused-compiled training path — forward + backward + fused

--- a/src/NeuralNetworks/NeuralNetworkBase.cs
+++ b/src/NeuralNetworks/NeuralNetworkBase.cs
@@ -5325,7 +5325,12 @@ public abstract class NeuralNetworkBase<T> : INeuralNetworkModel<T>, IInterpreta
         // training does nothing" is never invisible again. Skipped when mixed
         // precision is active (that path is an intentional, documented fallback,
         // not a misconfiguration). Suppressible via AIDOTNET_QUIET.
-        if (!_loggedFusedFallback && _mixedPrecisionContext is null)
+        // Don't warn when compilation is intentionally disabled — that's an explicit
+        // opt-out (TensorCodecOptions.EnableCompilation = false), not an unexpected
+        // fallback, so the "training is slower" warning would be noisy and misleading.
+        if (!_loggedFusedFallback
+            && _mixedPrecisionContext is null
+            && AiDotNet.Tensors.Engines.Optimization.TensorCodecOptions.Current.EnableCompilation)
         {
             _loggedFusedFallback = true;
             if (string.IsNullOrEmpty(Environment.GetEnvironmentVariable("AIDOTNET_QUIET")))
@@ -6665,11 +6670,13 @@ public abstract class NeuralNetworkBase<T> : INeuralNetworkModel<T>, IInterpreta
     /// </remarks>
     protected virtual IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>> GetOrCreateBaseOptimizer()
     {
-        // Standard Adam (UseAMSGrad stays at its false default) so the fused
-        // compiled-training kernel can map this optimizer and engage.
+        // Standard Adam with AMSGrad pinned OFF locally (not relying on the
+        // AdamOptimizerOptions default) so the fused compiled-training kernel can map
+        // this optimizer and engage — if that external default ever flips, the fused
+        // fast path must not silently regress.
         return _baseTrainOptimizer ??= new AdamOptimizer<T, Tensor<T>, Tensor<T>>(
             this,
-            new Models.Options.AdamOptimizerOptions<T, Tensor<T>, Tensor<T>>());
+            new Models.Options.AdamOptimizerOptions<T, Tensor<T>, Tensor<T>> { UseAMSGrad = false });
     }
 
     /// <summary>

--- a/src/NeuralNetworks/NeuralNetworkBase.cs
+++ b/src/NeuralNetworks/NeuralNetworkBase.cs
@@ -6471,6 +6471,14 @@ public abstract class NeuralNetworkBase<T> : INeuralNetworkModel<T>, IInterpreta
         out float weightDecay,
         out AiDotNet.Tensors.Engines.Compilation.LrSchedule? lrSchedule)
     {
+        // Open/closed-compliant dispatch: the optimizer self-describes its fused
+        // config (incl. selecting the AMSGrad kernel variant when it opts in, and
+        // converting any attached LR scheduler) via IFusedOptimizerSpec. Replaces
+        // the old type-switch that had to be edited for every new optimizer and
+        // silently rejected AMSGrad. Only optimizers that actually have a fused
+        // SIMD kernel implement the interface, so there is no central whitelist to
+        // maintain — an optimizer without a kernel simply isn't an
+        // IFusedOptimizerSpec and uses the eager tape.
         optimizerType = default;
         learningRate = 0f;
         beta1 = 0f;
@@ -6479,85 +6487,18 @@ public abstract class NeuralNetworkBase<T> : INeuralNetworkModel<T>, IInterpreta
         weightDecay = 0f;
         lrSchedule = null;
 
-        // When an LR scheduler is attached, try to convert it to a fused-side
-        // LrSchedule. The fused kernel evaluates the schedule per Step() — no
-        // performance penalty vs constant-LR — so paper-faithful training
-        // recipes (cosine annealing, OneCycle, linear-warmup-cosine, etc.)
-        // get full compile-mode perf. Only unknown / unsupported scheduler
-        // types fall back to eager.
-        if (optimizer is Optimizers.GradientBasedOptimizerBase<T, Tensor<T>, Tensor<T>> gradBase
-            && gradBase.LearningRateScheduler is not null)
-        {
-            switch (gradBase.LearningRateScheduler)
-            {
-                case AiDotNet.LearningRateSchedulers.CosineAnnealingLRScheduler cosine:
-                    lrSchedule = AiDotNet.Tensors.Engines.Compilation.LrSchedule.Cosine(
-                        cosine.BaseLearningRate, cosine.TMax, cosine.EtaMin);
-                    break;
-                case AiDotNet.LearningRateSchedulers.ExponentialLRScheduler expo:
-                    lrSchedule = AiDotNet.Tensors.Engines.Compilation.LrSchedule.Exponential(
-                        expo.BaseLearningRate, expo.Gamma);
-                    break;
-                case AiDotNet.LearningRateSchedulers.ConstantLRScheduler:
-                    // Constant scheduler = effectively no schedule; let the
-                    // GetCurrentLearningRate path below handle the rate.
-                    break;
-                default:
-                    // Unknown scheduler type — fall back to eager so the
-                    // configured schedule isn't silently ignored.
-                    return false;
-            }
-        }
+        if (optimizer is not Optimizers.Fused.IFusedOptimizerSpec spec
+            || !spec.TryGetFusedOptimizerConfig(out var cfg))
+            return false;
 
-        switch (optimizer)
-        {
-            case Optimizers.AdamOptimizer<T, Tensor<T>, Tensor<T>> adam:
-            {
-                if (adam.GetOptions() is not Models.Options.AdamOptimizerOptions<T, Tensor<T>, Tensor<T>> opts)
-                    return false;
-                if (opts.UseAdaptiveLearningRate) return false;
-                // Fused Adam kernel doesn't implement AMSGrad's max-of-second-
-                // moment update rule. Fall back to the eager Adam step which
-                // does (see AdamOptimizer.Step). Mirrors the AdamW + AMSGrad
-                // bail-out a few cases below.
-                if (opts.UseAMSGrad) return false;
-                optimizerType = AiDotNet.Tensors.Engines.Compilation.OptimizerType.Adam;
-                learningRate = (float)adam.GetCurrentLearningRate();
-                beta1 = (float)opts.Beta1;
-                beta2 = (float)opts.Beta2;
-                epsilon = (float)opts.Epsilon;
-                weightDecay = 0f;
-                return true;
-            }
-            case Optimizers.AdamWOptimizer<T, Tensor<T>, Tensor<T>> adamW:
-            {
-                if (adamW.GetOptions() is not Models.Options.AdamWOptimizerOptions<T, Tensor<T>, Tensor<T>> opts)
-                    return false;
-                if (opts.UseAdaptiveLearningRate) return false;
-                // Fused AdamW kernel does not implement AMSGrad's max-of-second-moment
-                // update rule. If the user enabled it, fall back to eager so the
-                // configured update rule isn't silently swapped for standard AdamW.
-                if (adamW.UseAMSGrad) return false;
-                optimizerType = AiDotNet.Tensors.Engines.Compilation.OptimizerType.AdamW;
-                learningRate = (float)adamW.GetCurrentLearningRate();
-                beta1 = (float)opts.Beta1;
-                beta2 = (float)opts.Beta2;
-                epsilon = (float)opts.Epsilon;
-                weightDecay = (float)opts.WeightDecay;
-                return true;
-            }
-            case Optimizers.StochasticGradientDescentOptimizer<T, Tensor<T>, Tensor<T>> sgd:
-            {
-                if (sgd.GetOptions() is not Models.Options.StochasticGradientDescentOptimizerOptions<T, Tensor<T>, Tensor<T>> opts)
-                    return false;
-                if (opts.UseAdaptiveLearningRate) return false;
-                optimizerType = AiDotNet.Tensors.Engines.Compilation.OptimizerType.SGD;
-                learningRate = (float)sgd.GetCurrentLearningRate();
-                return true;
-            }
-            default:
-                return false;
-        }
+        optimizerType = cfg.Type;
+        learningRate = cfg.LearningRate;
+        beta1 = cfg.Beta1;
+        beta2 = cfg.Beta2;
+        epsilon = cfg.Epsilon;
+        weightDecay = cfg.WeightDecay;
+        lrSchedule = cfg.Schedule;
+        return true;
     }
 
     /// <summary>
@@ -6702,24 +6643,33 @@ public abstract class NeuralNetworkBase<T> : INeuralNetworkModel<T>, IInterpreta
     /// Used when a network doesn't provide its own optimizer.
     /// </summary>
     /// <remarks>
-    /// Default is AMSGrad-mode Adam (Reddi, Kale, Kumar 2018). Standard
-    /// Adam's bias-corrected m̂ / √v̂ ratio doesn't decay fast enough after
-    /// gradient convergence on some models, so AMSGrad's running v̂_max
-    /// (which guarantees the denominator can only grow) bounds post-
-    /// convergence drift to negligible levels on the base-optimizer path.
-    /// Scope: improves stability for models that go through this
-    /// <c>GetOrCreateBaseOptimizer</c> path. <c>Training_ShouldChangeParameters</c>
-    /// was addressed separately by the ESN parameter-chunk work, and
-    /// <c>MoreData_ShouldNotDegrade</c> failures remain unresolved in other
-    /// areas tracked under #1332. Note that the fused-Adam fast path falls
-    /// back to eager training because the fused kernel does not implement
-    /// AMSGrad's max-second-moment update.
+    /// Default is <b>standard Adam</b> (Kingma &amp; Ba 2015) — matching the
+    /// industry default in PyTorch (<c>torch.optim.Adam(amsgrad=False)</c>),
+    /// TensorFlow/Keras, and Optax. AMSGrad is a niche opt-in variant, not a
+    /// default anywhere; callers who want it set <c>UseAMSGrad = true</c> on a
+    /// supplied optimizer.
+    /// <para>
+    /// History: #1350 flipped this default to AMSGrad to suppress
+    /// post-convergence drift on a couple of recurrent models'
+    /// <c>MoreData_ShouldNotDegrade</c> invariant. That was the wrong lever — it
+    /// only partially helped those models (GRU still drifted past tolerance
+    /// even with AMSGrad; DBM was unchanged), yet it <b>silently disabled the
+    /// compiled fused-training fast path for EVERY model</b> (the fused Adam
+    /// kernel implements standard Adam, correctly omitting the non-standard
+    /// AMSGrad max-second-moment rule), so all models fell back to the slow
+    /// eager tape. The proper drift fix is LR-decay scheduling past convergence
+    /// (as #1350 itself noted), applied per-model — not a non-standard global
+    /// optimizer default. Reverting to standard Adam restores both the industry
+    /// default and the fused fast path.
+    /// </para>
     /// </remarks>
     protected virtual IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>> GetOrCreateBaseOptimizer()
     {
+        // Standard Adam (UseAMSGrad stays at its false default) so the fused
+        // compiled-training kernel can map this optimizer and engage.
         return _baseTrainOptimizer ??= new AdamOptimizer<T, Tensor<T>, Tensor<T>>(
             this,
-            new Models.Options.AdamOptimizerOptions<T, Tensor<T>, Tensor<T>> { UseAMSGrad = true });
+            new Models.Options.AdamOptimizerOptions<T, Tensor<T>, Tensor<T>>());
     }
 
     /// <summary>

--- a/src/Optimizers/AdaDeltaOptimizer.cs
+++ b/src/Optimizers/AdaDeltaOptimizer.cs
@@ -31,8 +31,27 @@ namespace AiDotNet.Optimizers;
 /// <typeparam name="T">The numeric type used for calculations, typically float or double.</typeparam>
 [ComponentType(ComponentType.Optimizer)]
 [PipelineStage(PipelineStage.Training)]
-public class AdaDeltaOptimizer<T, TInput, TOutput> : GradientBasedOptimizerBase<T, TInput, TOutput>
+public class AdaDeltaOptimizer<T, TInput, TOutput> : GradientBasedOptimizerBase<T, TInput, TOutput>, Fused.IFusedOptimizerSpec
 {
+    /// <summary>
+    /// Describes this AdaDelta instance for the fused kernel (Tensors
+    /// <c>OptimizerType.AdaDelta</c> = <c>AdaDeltaUpdateSimd(lr, rho, eps)</c>):
+    /// Rho → Beta2 slot, Epsilon → eps; the two accumulators live in the plan.
+    /// The adaptive rho schedule only fires under UseAdaptiveLearningRate, which
+    /// is declined here (→ eager). Parity-gated.
+    /// </summary>
+    bool Fused.IFusedOptimizerSpec.TryGetFusedOptimizerConfig(out Fused.FusedOptimizerConfig config)
+    {
+        config = default;
+        if (_options.UseAdaptiveLearningRate) return false;
+        if (!TryGetFusedLrSchedule(out var schedule)) return false;
+        config = new Fused.FusedOptimizerConfig(
+            Tensors.Engines.Compilation.OptimizerType.AdaDelta,
+            (float)GetCurrentLearningRate(),
+            0f, (float)_options.Rho, (float)_options.Epsilon, 0f, schedule);
+        return true;
+    }
+
     /// <summary>
     /// The configuration options specific to the AdaDelta optimizer.
     /// </summary>

--- a/src/Optimizers/AdaMaxOptimizer.cs
+++ b/src/Optimizers/AdaMaxOptimizer.cs
@@ -30,8 +30,28 @@ namespace AiDotNet.Optimizers;
 /// </remarks>
 [ComponentType(ComponentType.Optimizer)]
 [PipelineStage(PipelineStage.Training)]
-public class AdaMaxOptimizer<T, TInput, TOutput> : GradientBasedOptimizerBase<T, TInput, TOutput>
+public class AdaMaxOptimizer<T, TInput, TOutput> : GradientBasedOptimizerBase<T, TInput, TOutput>, Fused.IFusedOptimizerSpec
 {
+    /// <summary>
+    /// Describes this AdaMax instance for the fused-compiled training kernel
+    /// (Tensors <c>OptimizerType.AdaMax</c>). AdaMax has no decoupled weight
+    /// decay, so WeightDecay is 0. Declines (falls back to eager) when an
+    /// adaptive LR or an unmappable scheduler is configured. Verified
+    /// fused-vs-eager parity in FusedOptimizerParityTests.
+    /// </summary>
+    bool Fused.IFusedOptimizerSpec.TryGetFusedOptimizerConfig(out Fused.FusedOptimizerConfig config)
+    {
+        config = default;
+        if (_options.UseAdaptiveLearningRate) return false;
+        if (!TryGetFusedLrSchedule(out var schedule)) return false;
+        config = new Fused.FusedOptimizerConfig(
+            Tensors.Engines.Compilation.OptimizerType.AdaMax,
+            (float)GetCurrentLearningRate(),
+            (float)_options.Beta1, (float)_options.Beta2, (float)_options.Epsilon,
+            0f, schedule);
+        return true;
+    }
+
     /// <summary>
     /// The configuration options specific to the AdaMax optimizer.
     /// </summary>

--- a/src/Optimizers/AdagradOptimizer.cs
+++ b/src/Optimizers/AdagradOptimizer.cs
@@ -30,8 +30,27 @@ namespace AiDotNet.Optimizers;
 /// </remarks>
 [ComponentType(ComponentType.Optimizer)]
 [PipelineStage(PipelineStage.Training)]
-public class AdagradOptimizer<T, TInput, TOutput> : GradientBasedOptimizerBase<T, TInput, TOutput>
+public class AdagradOptimizer<T, TInput, TOutput> : GradientBasedOptimizerBase<T, TInput, TOutput>, Fused.IFusedOptimizerSpec
 {
+    /// <summary>
+    /// Describes this Adagrad instance for the fused kernel (Tensors
+    /// <c>OptimizerType.Adagrad</c> = <c>AdagradUpdateSimd(lr, eps)</c>):
+    /// Epsilon → eps; the running squared-gradient accumulator lives in the plan.
+    /// The adaptive LR-increase/decrease factors only fire under
+    /// UseAdaptiveLearningRate, which is declined here (→ eager). Parity-gated.
+    /// </summary>
+    bool Fused.IFusedOptimizerSpec.TryGetFusedOptimizerConfig(out Fused.FusedOptimizerConfig config)
+    {
+        config = default;
+        if (_options.UseAdaptiveLearningRate) return false;
+        if (!TryGetFusedLrSchedule(out var schedule)) return false;
+        config = new Fused.FusedOptimizerConfig(
+            Tensors.Engines.Compilation.OptimizerType.Adagrad,
+            (float)GetCurrentLearningRate(),
+            0f, 0f, (float)_options.Epsilon, 0f, schedule);
+        return true;
+    }
+
     /// <summary>
     /// The configuration options specific to the Adagrad optimizer.
     /// </summary>

--- a/src/Optimizers/AdamOptimizer.cs
+++ b/src/Optimizers/AdamOptimizer.cs
@@ -24,7 +24,7 @@ namespace AiDotNet.Optimizers;
 /// </remarks>
 [ComponentType(ComponentType.Optimizer)]
 [PipelineStage(PipelineStage.Training)]
-public class AdamOptimizer<T, TInput, TOutput> : GradientBasedOptimizerBase<T, TInput, TOutput>
+public class AdamOptimizer<T, TInput, TOutput> : GradientBasedOptimizerBase<T, TInput, TOutput>, Fused.IFusedOptimizerSpec
 {
     /// <summary>
     /// The options specific to the Adam optimizer.
@@ -121,6 +121,26 @@ public class AdamOptimizer<T, TInput, TOutput> : GradientBasedOptimizerBase<T, T
         // which syncs CurrentLearningRate with the scheduler. We don't set it here.
         _currentBeta1 = NumOps.FromDouble(_options.Beta1);
         _currentBeta2 = NumOps.FromDouble(_options.Beta2);
+    }
+
+    /// <inheritdoc/>
+    public bool TryGetFusedOptimizerConfig(out Fused.FusedOptimizerConfig config)
+    {
+        config = default;
+        // Adaptive LR mutates the rate between steps; the fused kernel bakes a
+        // constant rate, so it can't reproduce that — fall back to eager.
+        if (_options.UseAdaptiveLearningRate) return false;
+        if (!TryGetFusedLrSchedule(out var schedule)) return false;
+        // AMSGrad opt-in selects the AMSGrad kernel variant (max-second-moment),
+        // which keeps the fast path instead of falling back.
+        config = new Fused.FusedOptimizerConfig(
+            _options.UseAMSGrad
+                ? Tensors.Engines.Compilation.OptimizerType.AMSGrad
+                : Tensors.Engines.Compilation.OptimizerType.Adam,
+            (float)GetCurrentLearningRate(),
+            (float)_options.Beta1, (float)_options.Beta2, (float)_options.Epsilon,
+            0f, schedule);
+        return true;
     }
 
     /// <summary>

--- a/src/Optimizers/AdamOptimizer.cs
+++ b/src/Optimizers/AdamOptimizer.cs
@@ -124,7 +124,7 @@ public class AdamOptimizer<T, TInput, TOutput> : GradientBasedOptimizerBase<T, T
     }
 
     /// <inheritdoc/>
-    public bool TryGetFusedOptimizerConfig(out Fused.FusedOptimizerConfig config)
+    bool Fused.IFusedOptimizerSpec.TryGetFusedOptimizerConfig(out Fused.FusedOptimizerConfig config)
     {
         config = default;
         // Adaptive LR mutates the rate between steps; the fused kernel bakes a

--- a/src/Optimizers/AdamWOptimizer.cs
+++ b/src/Optimizers/AdamWOptimizer.cs
@@ -46,7 +46,7 @@ namespace AiDotNet.Optimizers;
 /// </example>
 [ComponentType(ComponentType.Optimizer)]
 [PipelineStage(PipelineStage.Training)]
-public class AdamWOptimizer<T, TInput, TOutput> : GradientBasedOptimizerBase<T, TInput, TOutput>
+public class AdamWOptimizer<T, TInput, TOutput> : GradientBasedOptimizerBase<T, TInput, TOutput>, Fused.IFusedOptimizerSpec
 {
     /// <summary>
     /// The options specific to the AdamW optimizer.
@@ -142,6 +142,24 @@ public class AdamWOptimizer<T, TInput, TOutput> : GradientBasedOptimizerBase<T, 
     /// Gets whether AMSGrad variant is enabled.
     /// </summary>
     public bool UseAMSGrad => _options.UseAMSGrad;
+
+    /// <inheritdoc/>
+    public bool TryGetFusedOptimizerConfig(out Fused.FusedOptimizerConfig config)
+    {
+        config = default;
+        if (_options.UseAdaptiveLearningRate) return false;
+        if (!TryGetFusedLrSchedule(out var schedule)) return false;
+        // AdamW + AMSGrad uses the same max-second-moment kernel; decoupled weight
+        // decay is carried in WeightDecay and applied by the AdamW update path.
+        config = new Fused.FusedOptimizerConfig(
+            _options.UseAMSGrad
+                ? Tensors.Engines.Compilation.OptimizerType.AMSGrad
+                : Tensors.Engines.Compilation.OptimizerType.AdamW,
+            (float)GetCurrentLearningRate(),
+            (float)_options.Beta1, (float)_options.Beta2, (float)_options.Epsilon,
+            (float)_options.WeightDecay, schedule);
+        return true;
+    }
 
     /// <summary>
     /// Performs the optimization process using the AdamW algorithm.

--- a/src/Optimizers/AdamWOptimizer.cs
+++ b/src/Optimizers/AdamWOptimizer.cs
@@ -144,7 +144,7 @@ public class AdamWOptimizer<T, TInput, TOutput> : GradientBasedOptimizerBase<T, 
     public bool UseAMSGrad => _options.UseAMSGrad;
 
     /// <inheritdoc/>
-    public bool TryGetFusedOptimizerConfig(out Fused.FusedOptimizerConfig config)
+    bool Fused.IFusedOptimizerSpec.TryGetFusedOptimizerConfig(out Fused.FusedOptimizerConfig config)
     {
         config = default;
         if (_options.UseAdaptiveLearningRate) return false;

--- a/src/Optimizers/Fused/IFusedOptimizerSpec.cs
+++ b/src/Optimizers/Fused/IFusedOptimizerSpec.cs
@@ -1,0 +1,58 @@
+using OptimizerType = AiDotNet.Tensors.Engines.Compilation.OptimizerType;
+using LrSchedule = AiDotNet.Tensors.Engines.Compilation.LrSchedule;
+
+namespace AiDotNet.Optimizers.Fused;
+
+/// <summary>
+/// Describes how an optimizer maps onto the compiled fused-optimizer kernel:
+/// which <see cref="OptimizerType"/> to run plus the baked hyperparameters and
+/// optional fused LR schedule.
+/// </summary>
+/// <param name="Type">The fused kernel variant to dispatch (Adam, AdamW, AMSGrad, SGD).</param>
+/// <param name="LearningRate">Current learning rate, baked into the plan.</param>
+/// <param name="Beta1">Adam/AdamW first-moment decay (0 for SGD).</param>
+/// <param name="Beta2">Adam/AdamW second-moment decay (0 for SGD).</param>
+/// <param name="Epsilon">Denominator epsilon (0 for SGD).</param>
+/// <param name="WeightDecay">Decoupled weight decay (AdamW); 0 otherwise.</param>
+/// <param name="Schedule">Optional fused-side LR schedule, or null for constant LR.</param>
+public readonly record struct FusedOptimizerConfig(
+    OptimizerType Type,
+    float LearningRate,
+    float Beta1,
+    float Beta2,
+    float Epsilon,
+    float WeightDecay,
+    LrSchedule? Schedule);
+
+/// <summary>
+/// Implemented by optimizers that have a compiled fused-kernel equivalent, so the
+/// fused-training dispatcher can ask the optimizer to describe itself instead of
+/// switching on its concrete type.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Open/closed-compliant by construction: having a fused SIMD kernel
+/// (<c>FusedOptimizer.{SGD,Adam,AdamW,AMSGrad}UpdateSimd</c>) is intrinsic to an
+/// optimizer, so the optimizer declares it. Only the optimizers that actually have
+/// a kernel implement this interface — there is no central catalog and no
+/// <c>OptimizerType is (… or … or …)</c> whitelist to keep in sync. An optimizer
+/// without a fused kernel simply doesn't implement it and uses the eager tape;
+/// adding a kernel later means implementing this interface, with no change to the
+/// dispatcher. This is also why only a handful of the ~20 optimizers are
+/// fuse-able: the rest have no SIMD kernel.
+/// </para>
+/// <para>
+/// <see cref="TryGetFusedOptimizerConfig"/> returns <c>false</c> when THIS
+/// instance is configured in a way the fused kernel can't reproduce (adaptive
+/// learning rate, an unsupported LR-scheduler type, etc.), so a fuse-able
+/// optimizer family can still fall back per-instance.
+/// </para>
+/// </remarks>
+public interface IFusedOptimizerSpec
+{
+    /// <summary>
+    /// Describes this optimizer for the fused kernel, or returns <c>false</c> to
+    /// fall back to the eager tape.
+    /// </summary>
+    bool TryGetFusedOptimizerConfig(out FusedOptimizerConfig config);
+}

--- a/src/Optimizers/Fused/IFusedOptimizerSpec.cs
+++ b/src/Optimizers/Fused/IFusedOptimizerSpec.cs
@@ -15,7 +15,7 @@ namespace AiDotNet.Optimizers.Fused;
 /// <param name="Epsilon">Denominator epsilon (0 for SGD).</param>
 /// <param name="WeightDecay">Decoupled weight decay (AdamW); 0 otherwise.</param>
 /// <param name="Schedule">Optional fused-side LR schedule, or null for constant LR.</param>
-public readonly record struct FusedOptimizerConfig(
+internal readonly record struct FusedOptimizerConfig(
     OptimizerType Type,
     float LearningRate,
     float Beta1,
@@ -48,7 +48,7 @@ public readonly record struct FusedOptimizerConfig(
 /// optimizer family can still fall back per-instance.
 /// </para>
 /// </remarks>
-public interface IFusedOptimizerSpec
+internal interface IFusedOptimizerSpec
 {
     /// <summary>
     /// Describes this optimizer for the fused kernel, or returns <c>false</c> to

--- a/src/Optimizers/GradientBasedOptimizerBase.cs
+++ b/src/Optimizers/GradientBasedOptimizerBase.cs
@@ -300,6 +300,15 @@ public abstract class GradientBasedOptimizerBase<T, TInput, TOutput> : Optimizer
                 schedule = Tensors.Engines.Compilation.LrSchedule.Exponential(
                     expo.BaseLearningRate, expo.Gamma);
                 return true;
+            case LearningRateSchedulers.NoamSchedule noam:
+                // Vaswani-2017 warmup + inverse-sqrt. The fused kernel evaluates
+                // GetLr(step) per optimizer step, so the Noam ramp runs on the
+                // fused fast path with the SAME per-step LR sequence as the eager
+                // NoamSchedule (both use t = step, 1-based) — no eager fallback,
+                // no constant-rate freeze (AiDotNet#1470).
+                schedule = Tensors.Engines.Compilation.LrSchedule.Noam(
+                    noam.ModelDimension, noam.WarmupSteps, noam.Factor);
+                return true;
             default:
                 return false;
         }

--- a/src/Optimizers/GradientBasedOptimizerBase.cs
+++ b/src/Optimizers/GradientBasedOptimizerBase.cs
@@ -293,8 +293,14 @@ public abstract class GradientBasedOptimizerBase<T, TInput, TOutput> : Optimizer
             case LearningRateSchedulers.ConstantLRScheduler:
                 return true;
             case LearningRateSchedulers.CosineAnnealingLRScheduler cosine:
+                // Denominator reconciliation: eager CosineAnnealing uses
+                // cos(π·(N-1)/tMax) on batch N, but the fused CosineLr uses
+                // cos(π·(s-1)/(totalSteps-1)). Passing totalSteps = tMax+1 makes
+                // (s-1)/(totalSteps-1) = (N-1)/tMax, so the fused per-step
+                // sequence is bit-identical to eager (previously off by ~4e-6/
+                // step from passing tMax directly).
                 schedule = Tensors.Engines.Compilation.LrSchedule.Cosine(
-                    cosine.BaseLearningRate, cosine.TMax, cosine.EtaMin);
+                    cosine.BaseLearningRate, cosine.TMax + 1, cosine.EtaMin);
                 return true;
             case LearningRateSchedulers.ExponentialLRScheduler expo:
                 schedule = Tensors.Engines.Compilation.LrSchedule.Exponential(
@@ -308,6 +314,21 @@ public abstract class GradientBasedOptimizerBase<T, TInput, TOutput> : Optimizer
                 // no constant-rate freeze (AiDotNet#1470).
                 schedule = Tensors.Engines.Compilation.LrSchedule.Noam(
                     noam.ModelDimension, noam.WarmupSteps, noam.Factor);
+                return true;
+            case LearningRateSchedulers.StepLRScheduler stepLr:
+                // lr0 · gamma^decayCount. The Tensors StepLr's max(0, step-1)/stepSize
+                // exactly matches the eager (N-1)/stepSize decay count on batch N.
+                schedule = Tensors.Engines.Compilation.LrSchedule.Step(
+                    stepLr.BaseLearningRate, stepLr.StepSize, stepLr.Gamma);
+                return true;
+            case LearningRateSchedulers.CyclicLRScheduler cyclic
+                    when cyclic.Mode == LearningRateSchedulers.CyclicLRScheduler.CyclicMode.Triangular
+                         && cyclic.StepSizeUp == cyclic.StepSizeDown:
+                // Fused Cyclic is symmetric-triangular only (single stepSize).
+                // Triangular2 / ExponentialRange / asymmetric up≠down have no
+                // fused equivalent → fall through to eager.
+                schedule = Tensors.Engines.Compilation.LrSchedule.Cyclic(
+                    cyclic.BaseLearningRate, cyclic.MaxLearningRate, cyclic.StepSizeUp);
                 return true;
             default:
                 return false;

--- a/src/Optimizers/GradientBasedOptimizerBase.cs
+++ b/src/Optimizers/GradientBasedOptimizerBase.cs
@@ -270,6 +270,42 @@ public abstract class GradientBasedOptimizerBase<T, TInput, TOutput> : Optimizer
     public ILearningRateScheduler? LearningRateScheduler => _learningRateScheduler;
 
     /// <summary>
+    /// Resolves this optimizer's attached LR scheduler (if any) into a fused-side
+    /// <see cref="Tensors.Engines.Compilation.LrSchedule"/> for
+    /// <see cref="Fused.IFusedOptimizerSpec"/> implementations. Shared so the
+    /// per-optimizer specs don't each repeat the mapping.
+    /// <para>
+    /// Returns <c>false</c> only for an UNKNOWN scheduler type (so a configured
+    /// schedule is never silently dropped — the caller falls back to eager). A
+    /// null scheduler or a constant scheduler yields <c>true</c> with
+    /// <paramref name="schedule"/> = null (constant LR; the spec's
+    /// <c>GetCurrentLearningRate</c> supplies the rate). The supported set mirrors
+    /// the fused kernel's implemented schedule shapes; new shapes are added here
+    /// alongside their kernel support.
+    /// </para>
+    /// </summary>
+    protected bool TryGetFusedLrSchedule(out Tensors.Engines.Compilation.LrSchedule? schedule)
+    {
+        schedule = null;
+        switch (_learningRateScheduler)
+        {
+            case null:
+            case LearningRateSchedulers.ConstantLRScheduler:
+                return true;
+            case LearningRateSchedulers.CosineAnnealingLRScheduler cosine:
+                schedule = Tensors.Engines.Compilation.LrSchedule.Cosine(
+                    cosine.BaseLearningRate, cosine.TMax, cosine.EtaMin);
+                return true;
+            case LearningRateSchedulers.ExponentialLRScheduler expo:
+                schedule = Tensors.Engines.Compilation.LrSchedule.Exponential(
+                    expo.BaseLearningRate, expo.Gamma);
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    /// <summary>
     /// Gets the current scheduler step mode.
     /// </summary>
     public SchedulerStepMode SchedulerStepMode => _schedulerStepMode;

--- a/src/Optimizers/LAMBOptimizer.cs
+++ b/src/Optimizers/LAMBOptimizer.cs
@@ -59,8 +59,29 @@ namespace AiDotNet.Optimizers;
 /// </example>
 [ComponentType(ComponentType.Optimizer)]
 [PipelineStage(PipelineStage.Training)]
-public class LAMBOptimizer<T, TInput, TOutput> : GradientBasedOptimizerBase<T, TInput, TOutput>
+public class LAMBOptimizer<T, TInput, TOutput> : GradientBasedOptimizerBase<T, TInput, TOutput>, Fused.IFusedOptimizerSpec
 {
+    /// <summary>
+    /// Describes this LAMB instance for the fused kernel (Tensors
+    /// <c>OptimizerType.LAMB</c> = <c>LAMBUpdateSimd(lr, b1, b2, eps, wd)</c>):
+    /// Beta1/Beta2 → β1/β2, Epsilon → eps, WeightDecay → wd. Declines (eager) on
+    /// adaptive LR or an unmappable scheduler. Parity-gated — if AiDotNet's
+    /// trust-ratio clamp (MaxTrustRatio) differs from the kernel's the parity
+    /// test fails and this stays unwired.
+    /// </summary>
+    bool Fused.IFusedOptimizerSpec.TryGetFusedOptimizerConfig(out Fused.FusedOptimizerConfig config)
+    {
+        config = default;
+        if (_options.UseAdaptiveLearningRate) return false;
+        if (!TryGetFusedLrSchedule(out var schedule)) return false;
+        config = new Fused.FusedOptimizerConfig(
+            Tensors.Engines.Compilation.OptimizerType.LAMB,
+            (float)GetCurrentLearningRate(),
+            (float)_options.Beta1, (float)_options.Beta2, (float)_options.Epsilon,
+            (float)_options.WeightDecay, schedule);
+        return true;
+    }
+
     /// <summary>
     /// The options specific to the LAMB optimizer.
     /// </summary>

--- a/src/Optimizers/LionOptimizer.cs
+++ b/src/Optimizers/LionOptimizer.cs
@@ -33,8 +33,26 @@ namespace AiDotNet.Optimizers;
 /// </remarks>
 [ComponentType(ComponentType.Optimizer)]
 [PipelineStage(PipelineStage.Training)]
-public class LionOptimizer<T, TInput, TOutput> : GradientBasedOptimizerBase<T, TInput, TOutput>
+public class LionOptimizer<T, TInput, TOutput> : GradientBasedOptimizerBase<T, TInput, TOutput>, Fused.IFusedOptimizerSpec
 {
+    /// <summary>
+    /// Describes this Lion instance for the fused kernel (Tensors
+    /// <c>OptimizerType.Lion</c> = <c>LionUpdateSimd(lr, b1, b2, wd)</c>):
+    /// Beta1/Beta2 → β1/β2, WeightDecay → wd. No epsilon term. Declines (eager)
+    /// on adaptive LR or an unmappable scheduler. Parity-gated.
+    /// </summary>
+    bool Fused.IFusedOptimizerSpec.TryGetFusedOptimizerConfig(out Fused.FusedOptimizerConfig config)
+    {
+        config = default;
+        if (_options.UseAdaptiveLearningRate) return false;
+        if (!TryGetFusedLrSchedule(out var schedule)) return false;
+        config = new Fused.FusedOptimizerConfig(
+            Tensors.Engines.Compilation.OptimizerType.Lion,
+            (float)GetCurrentLearningRate(),
+            (float)_options.Beta1, (float)_options.Beta2, 0f, (float)_options.WeightDecay, schedule);
+        return true;
+    }
+
     /// <summary>
     /// The options specific to the Lion optimizer.
     /// </summary>

--- a/src/Optimizers/NadamOptimizer.cs
+++ b/src/Optimizers/NadamOptimizer.cs
@@ -25,8 +25,28 @@ namespace AiDotNet.Optimizers;
 /// <typeparam name="T">The numeric type used for calculations, typically float or double.</typeparam>
 [ComponentType(ComponentType.Optimizer)]
 [PipelineStage(PipelineStage.Training)]
-public class NadamOptimizer<T, TInput, TOutput> : GradientBasedOptimizerBase<T, TInput, TOutput>
+public class NadamOptimizer<T, TInput, TOutput> : GradientBasedOptimizerBase<T, TInput, TOutput>, Fused.IFusedOptimizerSpec
 {
+    /// <summary>
+    /// Describes this Nadam instance for the fused-compiled training kernel
+    /// (Tensors <c>OptimizerType.Nadam</c> — Nesterov-accelerated Adam). No
+    /// decoupled weight decay, so WeightDecay is 0. Declines (falls back to
+    /// eager) when an adaptive LR or an unmappable scheduler is configured.
+    /// Verified fused-vs-eager parity in FusedOptimizerParityTests.
+    /// </summary>
+    bool Fused.IFusedOptimizerSpec.TryGetFusedOptimizerConfig(out Fused.FusedOptimizerConfig config)
+    {
+        config = default;
+        if (_options.UseAdaptiveLearningRate) return false;
+        if (!TryGetFusedLrSchedule(out var schedule)) return false;
+        config = new Fused.FusedOptimizerConfig(
+            Tensors.Engines.Compilation.OptimizerType.Nadam,
+            (float)GetCurrentLearningRate(),
+            (float)_options.Beta1, (float)_options.Beta2, (float)_options.Epsilon,
+            0f, schedule);
+        return true;
+    }
+
     /// <summary>
     /// The options specific to the Nadam optimizer.
     /// </summary>

--- a/src/Optimizers/RootMeanSquarePropagationOptimizer.cs
+++ b/src/Optimizers/RootMeanSquarePropagationOptimizer.cs
@@ -38,8 +38,26 @@ namespace AiDotNet.Optimizers;
 /// </remarks>
 [ComponentType(ComponentType.Optimizer)]
 [PipelineStage(PipelineStage.Training)]
-public class RootMeanSquarePropagationOptimizer<T, TInput, TOutput> : GradientBasedOptimizerBase<T, TInput, TOutput>
+public class RootMeanSquarePropagationOptimizer<T, TInput, TOutput> : GradientBasedOptimizerBase<T, TInput, TOutput>, Fused.IFusedOptimizerSpec
 {
+    /// <summary>
+    /// Describes this RMSprop instance for the fused kernel (Tensors
+    /// <c>OptimizerType.RMSprop</c> = <c>RMSpropUpdateSimd(lr, decay, eps)</c>):
+    /// Decay → Beta2 slot, Epsilon → eps. No momentum/weight-decay term. Declines
+    /// (eager) on adaptive LR or an unmappable scheduler. Parity-gated.
+    /// </summary>
+    bool Fused.IFusedOptimizerSpec.TryGetFusedOptimizerConfig(out Fused.FusedOptimizerConfig config)
+    {
+        config = default;
+        if (_options.UseAdaptiveLearningRate) return false;
+        if (!TryGetFusedLrSchedule(out var schedule)) return false;
+        config = new Fused.FusedOptimizerConfig(
+            Tensors.Engines.Compilation.OptimizerType.RMSprop,
+            (float)GetCurrentLearningRate(),
+            0f, (float)_options.Decay, (float)_options.Epsilon, 0f, schedule);
+        return true;
+    }
+
     /// <summary>
     /// Moving average of squared gradients for each parameter.
     /// </summary>

--- a/src/Optimizers/StochasticGradientDescentOptimizer.cs
+++ b/src/Optimizers/StochasticGradientDescentOptimizer.cs
@@ -30,7 +30,7 @@ namespace AiDotNet.Optimizers;
 /// </remarks>
 [ComponentType(ComponentType.Optimizer)]
 [PipelineStage(PipelineStage.Training)]
-public class StochasticGradientDescentOptimizer<T, TInput, TOutput> : GradientBasedOptimizerBase<T, TInput, TOutput>
+public class StochasticGradientDescentOptimizer<T, TInput, TOutput> : GradientBasedOptimizerBase<T, TInput, TOutput>, Fused.IFusedOptimizerSpec
 {
     private StochasticGradientDescentOptimizerOptions<T, TInput, TOutput> _options;
 
@@ -65,6 +65,19 @@ public class StochasticGradientDescentOptimizer<T, TInput, TOutput> : GradientBa
         : base(model, options ?? new())
     {
         _options = options ?? new();
+    }
+
+    /// <inheritdoc/>
+    public bool TryGetFusedOptimizerConfig(out Fused.FusedOptimizerConfig config)
+    {
+        config = default;
+        if (_options.UseAdaptiveLearningRate) return false;
+        if (!TryGetFusedLrSchedule(out var schedule)) return false;
+        config = new Fused.FusedOptimizerConfig(
+            Tensors.Engines.Compilation.OptimizerType.SGD,
+            (float)GetCurrentLearningRate(),
+            0f, 0f, 0f, 0f, schedule);
+        return true;
     }
 
     /// <summary>

--- a/src/Optimizers/StochasticGradientDescentOptimizer.cs
+++ b/src/Optimizers/StochasticGradientDescentOptimizer.cs
@@ -68,7 +68,7 @@ public class StochasticGradientDescentOptimizer<T, TInput, TOutput> : GradientBa
     }
 
     /// <inheritdoc/>
-    public bool TryGetFusedOptimizerConfig(out Fused.FusedOptimizerConfig config)
+    bool Fused.IFusedOptimizerSpec.TryGetFusedOptimizerConfig(out Fused.FusedOptimizerConfig config)
     {
         config = default;
         if (_options.UseAdaptiveLearningRate) return false;

--- a/src/Training/CompiledTapeTrainingStep.cs
+++ b/src/Training/CompiledTapeTrainingStep.cs
@@ -125,7 +125,7 @@ public static class CompiledTapeTrainingStep<T>
     /// which would turn a one-time capability gap into per-step exception + log churn.
     /// </summary>
     [ThreadStatic]
-    private static bool _amsgradFusedUnavailable;
+    private static System.Collections.Generic.HashSet<AiDotNet.Tensors.Engines.Compilation.OptimizerType>? _fusedUnavailableTypes;
 
     /// <summary>Gets the count of successful fused-step executions on the calling thread.</summary>
     public static long GetFusedStepCount() => _fusedStepCount;
@@ -404,26 +404,40 @@ public static class CompiledTapeTrainingStep<T>
         // overloads + CompiledTrainingPlan.ConfigureOptimizerDouble). Other
         // numeric types still fall through to the eager autograd path.
         if (typeof(T) != typeof(float) && typeof(T) != typeof(double)) return false;
-        // SGD, Adam, AdamW, and AMSGrad are wired through ConfigureOptimizer.
-        // AMSGrad reuses the Adam/AdamW second-moment state plus the vMax buffer
-        // (FusedOptimizer.AMSGradUpdateSimd); the Tensors-side plan selects the
-        // AMSGrad kernel and allocates vMax when ConfigureOptimizer sees the
-        // AMSGrad type. If the linked Tensors build predates that wiring, the
-        // plan reports the type unsupported and TryStepWithFusedOptimizer's
-        // catch falls back to the eager tape (with the one-time warning) — never
-        // a wrong update.
+        // Allowlist of optimizer kernels wired through ConfigureOptimizer in the
+        // linked AiDotNet.Tensors build (0.88.0: ConfigureOptimizerFloat handles
+        // all of these on CPU). Only OptimizerTypes an IFusedOptimizerSpec
+        // actually emits are reachable here; the allowlist is the belt-and-braces
+        // guard so a spec that names a type the linked Tensors build can't run
+        // falls back loudly (via the catch below + the per-type latch) rather
+        // than throwing per step — never a wrong update.
         if (optimizerType is not (AiDotNet.Tensors.Engines.Compilation.OptimizerType.SGD
+            or AiDotNet.Tensors.Engines.Compilation.OptimizerType.SGDMomentum
             or AiDotNet.Tensors.Engines.Compilation.OptimizerType.Adam
             or AiDotNet.Tensors.Engines.Compilation.OptimizerType.AdamW
-            or AiDotNet.Tensors.Engines.Compilation.OptimizerType.AMSGrad))
+            or AiDotNet.Tensors.Engines.Compilation.OptimizerType.AMSGrad
+            or AiDotNet.Tensors.Engines.Compilation.OptimizerType.Nadam
+            or AiDotNet.Tensors.Engines.Compilation.OptimizerType.RAdam
+            or AiDotNet.Tensors.Engines.Compilation.OptimizerType.AdaMax
+            or AiDotNet.Tensors.Engines.Compilation.OptimizerType.AdaDelta
+            or AiDotNet.Tensors.Engines.Compilation.OptimizerType.Adagrad
+            or AiDotNet.Tensors.Engines.Compilation.OptimizerType.RMSprop
+            or AiDotNet.Tensors.Engines.Compilation.OptimizerType.Lion
+            or AiDotNet.Tensors.Engines.Compilation.OptimizerType.LARS
+            or AiDotNet.Tensors.Engines.Compilation.OptimizerType.LAMB
+            or AiDotNet.Tensors.Engines.Compilation.OptimizerType.FTRL
+            or AiDotNet.Tensors.Engines.Compilation.OptimizerType.ASGD
+            or AiDotNet.Tensors.Engines.Compilation.OptimizerType.Rprop
+            or AiDotNet.Tensors.Engines.Compilation.OptimizerType.HypergradientSGD
+            or AiDotNet.Tensors.Engines.Compilation.OptimizerType.ScheduleFreeSGD
+            or AiDotNet.Tensors.Engines.Compilation.OptimizerType.DAdaptationSGD))
             return false;
 
-        // If a prior AMSGrad fused step already proved this thread's Tensors build
-        // can't run the AMSGrad kernel, don't retry the fused path — go straight to
+        // If a prior fused step already proved this thread's Tensors build can't
+        // run THIS optimizer kernel, don't retry the fused path — go straight to
         // the eager tape. Otherwise every step would reconfigure, throw, catch and
         // warn, turning a one-time capability gap into per-step exception/log churn.
-        if (optimizerType == AiDotNet.Tensors.Engines.Compilation.OptimizerType.AMSGrad
-            && _amsgradFusedUnavailable)
+        if (_fusedUnavailableTypes is not null && _fusedUnavailableTypes.Contains(optimizerType))
             return false;
 
         try
@@ -658,10 +672,12 @@ public static class CompiledTapeTrainingStep<T>
             System.Diagnostics.Trace.TraceWarning(
                 $"CompiledTapeTrainingStep.TryStepWithFusedOptimizer failed, falling back to eager: " +
                 $"{ex}");
-            // Latch AMSGrad-unsupported so we don't reconfigure/throw/warn every step
-            // for a capability gap that won't change within this process.
-            if (optimizerType == AiDotNet.Tensors.Engines.Compilation.OptimizerType.AMSGrad)
-                _amsgradFusedUnavailable = true;
+            // Latch THIS optimizer type as fused-unsupported on this thread so we
+            // don't reconfigure/throw/warn every step for a capability gap that
+            // won't change within this process (e.g. the linked Tensors build
+            // lacks the kernel). Generalized from the original AMSGrad-only latch.
+            (_fusedUnavailableTypes ??= new System.Collections.Generic.HashSet<AiDotNet.Tensors.Engines.Compilation.OptimizerType>())
+                .Add(optimizerType);
             _configuredPlan = null;
             _configuredOptimizerConfig = null;
             return false;

--- a/src/Training/CompiledTapeTrainingStep.cs
+++ b/src/Training/CompiledTapeTrainingStep.cs
@@ -117,6 +117,16 @@ public static class CompiledTapeTrainingStep<T>
     [ThreadStatic]
     private static long _fusedStepCount;
 
+    /// <summary>
+    /// Set once on the calling thread when an AMSGrad fused step fails because the
+    /// linked Tensors build can't run the AMSGrad kernel. Subsequent AMSGrad steps
+    /// then skip the fused attempt outright (returning false straight to the eager
+    /// tape) instead of reconfiguring → throwing → catching → warning every step,
+    /// which would turn a one-time capability gap into per-step exception + log churn.
+    /// </summary>
+    [ThreadStatic]
+    private static bool _amsgradFusedUnavailable;
+
     /// <summary>Gets the count of successful fused-step executions on the calling thread.</summary>
     public static long GetFusedStepCount() => _fusedStepCount;
 
@@ -408,6 +418,14 @@ public static class CompiledTapeTrainingStep<T>
             or AiDotNet.Tensors.Engines.Compilation.OptimizerType.AMSGrad))
             return false;
 
+        // If a prior AMSGrad fused step already proved this thread's Tensors build
+        // can't run the AMSGrad kernel, don't retry the fused path — go straight to
+        // the eager tape. Otherwise every step would reconfigure, throw, catch and
+        // warn, turning a one-time capability gap into per-step exception/log churn.
+        if (optimizerType == AiDotNet.Tensors.Engines.Compilation.OptimizerType.AMSGrad
+            && _amsgradFusedUnavailable)
+            return false;
+
         try
         {
             // AiDotNet#1406: drop the cached compiled plan + parameter array
@@ -640,6 +658,10 @@ public static class CompiledTapeTrainingStep<T>
             System.Diagnostics.Trace.TraceWarning(
                 $"CompiledTapeTrainingStep.TryStepWithFusedOptimizer failed, falling back to eager: " +
                 $"{ex}");
+            // Latch AMSGrad-unsupported so we don't reconfigure/throw/warn every step
+            // for a capability gap that won't change within this process.
+            if (optimizerType == AiDotNet.Tensors.Engines.Compilation.OptimizerType.AMSGrad)
+                _amsgradFusedUnavailable = true;
             _configuredPlan = null;
             _configuredOptimizerConfig = null;
             return false;

--- a/src/Training/CompiledTapeTrainingStep.cs
+++ b/src/Training/CompiledTapeTrainingStep.cs
@@ -394,10 +394,18 @@ public static class CompiledTapeTrainingStep<T>
         // overloads + CompiledTrainingPlan.ConfigureOptimizerDouble). Other
         // numeric types still fall through to the eager autograd path.
         if (typeof(T) != typeof(float) && typeof(T) != typeof(double)) return false;
-        // Only SGD, Adam, AdamW are wired through ConfigureOptimizer.
+        // SGD, Adam, AdamW, and AMSGrad are wired through ConfigureOptimizer.
+        // AMSGrad reuses the Adam/AdamW second-moment state plus the vMax buffer
+        // (FusedOptimizer.AMSGradUpdateSimd); the Tensors-side plan selects the
+        // AMSGrad kernel and allocates vMax when ConfigureOptimizer sees the
+        // AMSGrad type. If the linked Tensors build predates that wiring, the
+        // plan reports the type unsupported and TryStepWithFusedOptimizer's
+        // catch falls back to the eager tape (with the one-time warning) — never
+        // a wrong update.
         if (optimizerType is not (AiDotNet.Tensors.Engines.Compilation.OptimizerType.SGD
             or AiDotNet.Tensors.Engines.Compilation.OptimizerType.Adam
-            or AiDotNet.Tensors.Engines.Compilation.OptimizerType.AdamW))
+            or AiDotNet.Tensors.Engines.Compilation.OptimizerType.AdamW
+            or AiDotNet.Tensors.Engines.Compilation.OptimizerType.AMSGrad))
             return false;
 
         try

--- a/src/Training/CompiledTapeTrainingStep.cs
+++ b/src/Training/CompiledTapeTrainingStep.cs
@@ -339,6 +339,11 @@ public static class CompiledTapeTrainingStep<T>
         // assertion about "fused ran at least N times" should reflect the
         // new lifecycle.
         _fusedStepCount = 0;
+        // AiDotNet#1469 review: a fresh lifecycle must be able to re-enable fused execution. The
+        // unavailable-type latch records capability gaps seen during the PREVIOUS lifecycle; clear
+        // it here so a re-traced plan (e.g. a different model on this thread) retries the fused path
+        // instead of inheriting a stale "disabled" verdict.
+        _fusedUnavailableTypes?.Clear();
     }
 
     /// <summary>
@@ -672,12 +677,19 @@ public static class CompiledTapeTrainingStep<T>
             System.Diagnostics.Trace.TraceWarning(
                 $"CompiledTapeTrainingStep.TryStepWithFusedOptimizer failed, falling back to eager: " +
                 $"{ex}");
-            // Latch THIS optimizer type as fused-unsupported on this thread so we
-            // don't reconfigure/throw/warn every step for a capability gap that
-            // won't change within this process (e.g. the linked Tensors build
-            // lacks the kernel). Generalized from the original AMSGrad-only latch.
-            (_fusedUnavailableTypes ??= new System.Collections.Generic.HashSet<AiDotNet.Tensors.Engines.Compilation.OptimizerType>())
-                .Add(optimizerType);
+            // Latch THIS optimizer type as fused-unsupported on this thread ONLY for capability-gap
+            // exceptions — a missing kernel/method/type/native-entry won't change within this
+            // process, so latching avoids reconfigure/throw/warn churn every step. Transient runtime
+            // failures (shape mismatch, NaN guard, a one-off non-contiguous CPU layout) must fall
+            // back THIS step but NOT permanently disable fused for the type on this thread, since a
+            // later unrelated model could engage it fine (AiDotNet#1469 review). Generalized from the
+            // original AMSGrad-only latch.
+            if (ex is NotSupportedException or MissingMethodException or TypeLoadException
+                or EntryPointNotFoundException or DllNotFoundException)
+            {
+                (_fusedUnavailableTypes ??= new System.Collections.Generic.HashSet<AiDotNet.Tensors.Engines.Compilation.OptimizerType>())
+                    .Add(optimizerType);
+            }
             _configuredPlan = null;
             _configuredOptimizerConfig = null;
             return false;

--- a/tests/AiDotNet.Tests/IntegrationTests/NeuralNetworks/FusedOptimizerIntegrationTests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/NeuralNetworks/FusedOptimizerIntegrationTests.cs
@@ -96,6 +96,57 @@ public class FusedOptimizerIntegrationTests
     }
 
     /// <summary>
+    /// Regression guard for the "compiled does nothing" bug (PR #1469): training
+    /// with NO explicitly-supplied optimizer must still engage the fused compiled
+    /// path. When the caller passes <c>optimizer: null</c>, <c>TrainWithTape</c>
+    /// resolves the DEFAULT via <c>GetOrCreateBaseOptimizer()</c>. That default
+    /// previously constructed Adam with <c>UseAMSGrad = true</c>, which
+    /// <c>TryMapToFusedOptimizerConfig</c> rejected — silently demoting EVERY
+    /// default-configured model to the eager tape so "compiled training" never
+    /// actually ran. The default must be a fused-mappable optimizer; this test
+    /// fails loudly if a non-mappable default is ever reintroduced.
+    /// </summary>
+    [Fact(Timeout = 120000)]
+    public async Task DefaultOptimizer_EngagesFusedPath_NotSilentEagerFallback()
+    {
+        await Task.CompletedTask;
+
+        var network = BuildMlp();
+        var input = CreateRandomTensor(new[] { 16, 4 }, seed: 42);
+        var target = CreateRandomTensor(new[] { 16, 2 }, seed: 43);
+
+        // Warmup forward so layer weight tensors are materialized.
+        network.Predict(CreateRandomTensor(new[] { 1, 4 }, seed: 99));
+
+        var originalOptions = TensorCodecOptions.Current;
+        try
+        {
+            TensorCodecOptions.SetCurrent(new TensorCodecOptions { EnableCompilation = true });
+            CompiledTapeTrainingStep<float>.Invalidate();
+            CompiledTapeTrainingStep<float>.ResetFusedStepCount();
+
+            // network.Train(...) calls TrainWithTape(input, target) with the
+            // optimizer defaulted to null → the GetOrCreateBaseOptimizer() path.
+            for (int step = 0; step < 10; step++)
+            {
+                network.Train(input, target);
+                Assert.False(float.IsNaN(network.LastLossPublic),
+                    $"default-optimizer fused step {step} produced NaN loss");
+            }
+
+            Assert.True(CompiledTapeTrainingStep<float>.GetFusedStepCount() > 0,
+                "Default optimizer never engaged the fused path — the 'compiled does " +
+                "nothing' regression is back: GetOrCreateBaseOptimizer() returned an " +
+                "optimizer that TryMapToFusedOptimizerConfig rejects.");
+        }
+        finally
+        {
+            TensorCodecOptions.SetCurrent(originalOptions);
+            CompiledTapeTrainingStep<float>.Invalidate();
+        }
+    }
+
+    /// <summary>
     /// The eager tape fallback path (<see cref="TensorCodecOptions.EnableCompilation"/>=false)
     /// must actually update parameters — this is the reference path that must always work,
     /// independent of whether the fused path engages.

--- a/tests/AiDotNet.Tests/IntegrationTests/NeuralNetworks/TransformerNoamPerCallLRIssue1470Tests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/NeuralNetworks/TransformerNoamPerCallLRIssue1470Tests.cs
@@ -1,0 +1,213 @@
+using System.Reflection;
+using AiDotNet.Enums;
+using AiDotNet.LearningRateSchedulers;
+using AiDotNet.LossFunctions;
+using AiDotNet.Models.Options;
+using AiDotNet.NeuralNetworks;
+using AiDotNet.Optimizers;
+using AiDotNet.Optimizers.Fused;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace AiDotNetTests.IntegrationTests.NeuralNetworks;
+
+/// <summary>
+/// Regression suite for AiDotNet#1470 — a from-scratch Transformer trained via
+/// the per-call minibatch pattern (<c>MaxIterations=1</c> + an external epoch
+/// loop calling <c>model.Train(xBatch, yBatch)</c> repeatedly) stalled: the
+/// default Noam learning-rate schedule stayed frozen at its warmup-step-1 value
+/// (~1e-7) across thousands of <c>Train</c> calls instead of ramping, so loss
+/// barely left the uniform floor (PPL ≈ V).
+///
+/// <para>
+/// <b>Root cause (#1470):</b> the per-call <c>TrainWithTape</c> path must
+/// (a) reuse the SAME optimizer instance across <c>Train</c> calls so the
+/// scheduler's step counter accumulates, and (b) advance that scheduler once
+/// per batch (<see cref="SchedulerStepMode.StepPerBatch"/>) via
+/// <c>OnBatchEnd</c> → <c>StepScheduler</c>, with the consolidated
+/// <c>Step(TapeStepContext)</c> reading the scheduler's refreshed
+/// <c>CurrentLearningRate</c>. The Noam schedule must also stay on the eager
+/// path — the compiled fused-training kernel bakes a constant rate and cannot
+/// reproduce a per-step-mutating schedule, so an Adam+Noam optimizer must fall
+/// back to eager rather than freeze the LR.
+/// </para>
+///
+/// <para>
+/// <b>Test design:</b> the deterministic guard reads the model's actual base
+/// training optimizer (the same instance <c>Train</c> resolves through
+/// <c>GetOrCreateBaseOptimizer</c>) and asserts, after N per-call <c>Train</c>
+/// invocations, that the scheduler advanced exactly N steps (state accumulated
+/// across calls, NOT reset per call) and that the Noam LR ramped well above its
+/// warmup-step-1 value. This directly locks the #1470 root cause without
+/// depending on stochastic loss convergence.
+/// </para>
+/// </summary>
+public class TransformerNoamPerCallLRIssue1470Tests
+{
+    private readonly ITestOutputHelper _output;
+
+    public TransformerNoamPerCallLRIssue1470Tests(ITestOutputHelper output)
+    {
+        _output = output;
+    }
+
+    /// <summary>
+    /// The exact #1470 fix, tested at its seam: an Adam optimizer carrying a
+    /// per-step-mutating schedule (Noam, <see cref="SchedulerStepMode.StepPerBatch"/>)
+    /// must NOT map to a fused-optimizer config — the compiled fused-training
+    /// kernel bakes a CONSTANT learning rate, so committing an Adam+Noam model
+    /// to it freezes the LR at its warmup-step-1 value (the #1470 symptom).
+    /// <see cref="AdamOptimizer{T,TInput,TOutput}.TryGetFusedOptimizerConfig"/>
+    /// must return <c>false</c> for an unmapped schedule so the model falls back
+    /// to the eager scheduler-stepping path that actually ramps the LR.
+    ///
+    /// <para>Positive controls: a no-scheduler Adam (constant LR) and the
+    /// fused-mappable Cosine/Exponential schedules must still return <c>true</c>,
+    /// so the fix doesn't over-broadly disable the fast path.</para>
+    /// </summary>
+    [Fact]
+    public void AdamWithNoamSchedule_DoesNotMapToConstantRateFusedConfig()
+    {
+        int d = 16, warmup = 8;
+
+        // Adam + Noam (StepPerBatch) — the default Transformer recipe. The
+        // schedule mutates the LR every batch, which the constant-rate fused
+        // kernel can't reproduce ⇒ must decline the fused path.
+        var noamAdam = new AdamOptimizer<float, Tensor<float>, Tensor<float>>(
+            null,
+            new AdamOptimizerOptions<float, Tensor<float>, Tensor<float>>
+            {
+                InitialLearningRate = 1e-3,
+                LearningRateScheduler = new NoamSchedule(modelDimension: d, warmupSteps: warmup),
+                SchedulerStepMode = SchedulerStepMode.StepPerBatch,
+            });
+        // TryGetFusedOptimizerConfig is an explicit IFusedOptimizerSpec impl
+        // (internal; reachable here via InternalsVisibleTo "AiDotNetTests").
+        Assert.False(((IFusedOptimizerSpec)noamAdam).TryGetFusedOptimizerConfig(out _),
+            "Adam+Noam must decline the fused path (constant-rate kernel would freeze the warmup ramp — #1470). " +
+            "If this returns true, the Noam LR will be baked at its warmup-step-1 value and never ramp.");
+
+        // Positive control 1: constant LR (no scheduler) is safe for the fused kernel.
+        var plainAdam = new AdamOptimizer<float, Tensor<float>, Tensor<float>>(
+            null,
+            new AdamOptimizerOptions<float, Tensor<float>, Tensor<float>> { InitialLearningRate = 1e-3 });
+        Assert.True(((IFusedOptimizerSpec)plainAdam).TryGetFusedOptimizerConfig(out _),
+            "A constant-LR Adam (no scheduler) should still use the fused fast path.");
+    }
+
+    /// <summary>
+    /// A default-optimizer (Adam + Noam, <see cref="SchedulerStepMode.StepPerBatch"/>)
+    /// Transformer trained via repeated per-call <c>Train</c> must ramp its
+    /// Noam learning rate across calls. Pre-#1470 the LR was frozen at the
+    /// warmup-step-1 value because per-call training didn't accumulate
+    /// scheduler step state (and/or the model was captured by the constant-rate
+    /// fused kernel). This is the end-to-end smoke complement to the gating
+    /// unit test above.
+    /// </summary>
+    [Fact]
+    public void Transformer_PerCallTrain_DefaultNoam_RampsLearningRateAcrossCalls()
+    {
+        const int vocab = 8;
+        const int seqLen = 4;
+        const int modelDim = 16;
+        const int ffDim = 32;
+        const int warmup = 8;   // small warmup so the ramp is observable in a few batches
+
+        // NO explicit optimizer → exercises CreateDefaultVaswaniOptimizer
+        // (Adam + NoamSchedule, StepPerBatch), the exact default the #1470
+        // repro used (`new Transformer(arch, loss)`).
+        var arch = new TransformerArchitecture<float>(
+            inputType: InputType.TwoDimensional,
+            taskType: NeuralNetworkTaskType.MultiClassClassification,
+            numEncoderLayers: 1,
+            numDecoderLayers: 0,
+            numHeads: 2,
+            modelDimension: modelDim,
+            feedForwardDimension: ffDim,
+            inputSize: seqLen,
+            outputSize: vocab,
+            maxSequenceLength: seqLen,
+            vocabularySize: vocab,
+            warmupSteps: warmup);
+
+        var model = new Transformer<float>(
+            arch,
+            lossFunction: new CategoricalCrossEntropyLoss<float>());
+        model.SetTrainingMode(true);
+
+        var optimizer = GetBaseTrainOptimizer(model);
+        Assert.NotNull(optimizer);
+
+        var scheduler = optimizer!.LearningRateScheduler;
+        Assert.NotNull(scheduler); // default Transformer optimizer carries a Noam schedule
+
+        double lrBefore = optimizer.GetCurrentLearningRate();
+        int stepBefore = scheduler!.CurrentStep;
+
+        // Per-call minibatch loop (MaxIterations=1 by virtue of one Train call
+        // == one batch). Run through the full warmup so the Noam LR climbs to
+        // its peak; pre-fix it stayed pinned at the step-1 value.
+        const int batches = warmup;
+        for (int i = 0; i < batches; i++)
+        {
+            var input = BuildAllKInput(i % vocab, seqLen);
+            var target = BuildOneHotTarget((i + 3) % vocab, vocab);
+            model.Train(input, target);
+        }
+
+        double lrAfter = optimizer.GetCurrentLearningRate();
+        int stepAfter = scheduler.CurrentStep;
+
+        _output.WriteLine(
+            $"step {stepBefore}->{stepAfter} (expected {batches}); " +
+            $"lr {lrBefore:E4}->{lrAfter:E4} (ratio {lrAfter / System.Math.Max(lrBefore, 1e-12):F2}x)");
+
+        // (a) Scheduler step state must ACCUMULATE across per-call Train — one
+        // StepPerBatch advance per Train call. Pre-#1470 this stayed at 0/1
+        // because the per-call path didn't persist/advance the scheduler.
+        Assert.Equal(stepBefore + batches, stepAfter);
+
+        // (b) Noam ramps linearly up to t=warmup, so the LR at the end of warmup
+        // must be materially larger than the warmup-step-1 value. A frozen LR
+        // (the #1470 symptom) would leave lrAfter ≈ lrBefore.
+        Assert.True(lrAfter > lrBefore * 1.5,
+            $"Noam LR must ramp across per-call Train invocations (StepPerBatch); " +
+            $"observed lrBefore={lrBefore:E4}, lrAfter={lrAfter:E4}. A near-constant LR is " +
+            "the #1470 symptom — per-call training is not advancing the scheduler, or the " +
+            "Adam+Noam optimizer was captured by the constant-rate fused-training kernel " +
+            "instead of falling back to the eager scheduler-stepping path.");
+    }
+
+    /// <summary>
+    /// Reads the model's base training optimizer — the same instance
+    /// <c>Train</c> resolves through <c>GetOrCreateBaseOptimizer</c> — so the
+    /// test inspects the real scheduler state, not a detached copy. The field
+    /// is private on <c>NeuralNetworkBase</c>; walk the hierarchy to find it.
+    /// </summary>
+    private static GradientBasedOptimizerBase<float, Tensor<float>, Tensor<float>>? GetBaseTrainOptimizer(
+        Transformer<float> model)
+    {
+        for (var t = (System.Type?)model.GetType(); t != null; t = t.BaseType)
+        {
+            var field = t.GetField("_baseTrainOptimizer",
+                BindingFlags.Instance | BindingFlags.NonPublic);
+            if (field == null) continue;
+            return field.GetValue(model) as GradientBasedOptimizerBase<float, Tensor<float>, Tensor<float>>;
+        }
+        return null;
+    }
+
+    private static Tensor<float> BuildAllKInput(int k, int seqLen)
+    {
+        var t = new Tensor<float>(new[] { 1, seqLen });
+        for (int s = 0; s < seqLen; s++) t[0, s] = k;
+        return t;
+    }
+
+    private static Tensor<float> BuildOneHotTarget(int classIndex, int vocab)
+    {
+        var t = new Tensor<float>(new[] { 1, vocab });
+        t[0, classIndex] = 1f;
+        return t;
+    }
+}

--- a/tests/AiDotNet.Tests/IntegrationTests/NeuralNetworks/TransformerNoamPerCallLRIssue1470Tests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/NeuralNetworks/TransformerNoamPerCallLRIssue1470Tests.cs
@@ -1,4 +1,5 @@
-using System.Reflection;
+using System;
+using System.Threading.Tasks;
 using AiDotNet.Enums;
 using AiDotNet.LearningRateSchedulers;
 using AiDotNet.LossFunctions;
@@ -6,40 +7,37 @@ using AiDotNet.Models.Options;
 using AiDotNet.NeuralNetworks;
 using AiDotNet.Optimizers;
 using AiDotNet.Optimizers.Fused;
+using AiDotNet.Training;
 using Xunit;
 using Xunit.Abstractions;
 
 namespace AiDotNetTests.IntegrationTests.NeuralNetworks;
 
 /// <summary>
-/// Regression suite for AiDotNet#1470 — a from-scratch Transformer trained via
-/// the per-call minibatch pattern (<c>MaxIterations=1</c> + an external epoch
-/// loop calling <c>model.Train(xBatch, yBatch)</c> repeatedly) stalled: the
-/// default Noam learning-rate schedule stayed frozen at its warmup-step-1 value
-/// (~1e-7) across thousands of <c>Train</c> calls instead of ramping, so loss
-/// barely left the uniform floor (PPL ≈ V).
+/// Regression + integration suite for AiDotNet#1470 — a from-scratch Transformer
+/// trained via the per-call minibatch pattern (<c>MaxIterations=1</c> + an
+/// external epoch loop calling <c>model.Train(xBatch, yBatch)</c> repeatedly)
+/// stalled: the default Noam learning-rate schedule stayed frozen at its
+/// warmup-step-1 value (~1e-7) instead of ramping, so loss never left the
+/// uniform floor (PPL ≈ V).
 ///
 /// <para>
-/// <b>Root cause (#1470):</b> the per-call <c>TrainWithTape</c> path must
-/// (a) reuse the SAME optimizer instance across <c>Train</c> calls so the
-/// scheduler's step counter accumulates, and (b) advance that scheduler once
-/// per batch (<see cref="SchedulerStepMode.StepPerBatch"/>) via
-/// <c>OnBatchEnd</c> → <c>StepScheduler</c>, with the consolidated
-/// <c>Step(TapeStepContext)</c> reading the scheduler's refreshed
-/// <c>CurrentLearningRate</c>. The Noam schedule must also stay on the eager
-/// path — the compiled fused-training kernel bakes a constant rate and cannot
-/// reproduce a per-step-mutating schedule, so an Adam+Noam optimizer must fall
-/// back to eager rather than freeze the LR.
+/// <b>Root cause:</b> the compiled fused-training kernel takes <c>lr</c> as a
+/// per-step scalar (it evaluates <c>LrSchedule.GetLr(step)</c> every optimizer
+/// step — the same model as PyTorch <c>fused=True</c>). The fused path
+/// supported Cosine/Exponential/OneCycle/LinearWarmupCosine but NOT Noam, so an
+/// Adam+Noam Transformer either fell back to the slower eager tape or (pre-gate)
+/// was committed to a constant-rate fused config that froze the warmup ramp.
 /// </para>
 ///
 /// <para>
-/// <b>Test design:</b> the deterministic guard reads the model's actual base
-/// training optimizer (the same instance <c>Train</c> resolves through
-/// <c>GetOrCreateBaseOptimizer</c>) and asserts, after N per-call <c>Train</c>
-/// invocations, that the scheduler advanced exactly N steps (state accumulated
-/// across calls, NOT reset per call) and that the Noam LR ramped well above its
-/// warmup-step-1 value. This directly locks the #1470 root cause without
-/// depending on stochastic loss convergence.
+/// <b>Fix:</b> AiDotNet.Tensors 0.88.0 (PR #504) adds
+/// <c>LrSchedule.Noam(modelDim, warmup, factor)</c>, and
+/// <c>GradientBasedOptimizerBase.TryGetFusedLrSchedule</c> now maps
+/// <see cref="NoamSchedule"/> to it. So Adam+Noam runs on the fused fast path
+/// with a correct, per-step warmup ramp — bit-identical to the eager schedule
+/// (both use <c>t = step</c>, 1-based) — instead of being forced to eager or
+/// frozen.
 /// </para>
 /// </summary>
 public class TransformerNoamPerCallLRIssue1470Tests
@@ -52,76 +50,120 @@ public class TransformerNoamPerCallLRIssue1470Tests
     }
 
     /// <summary>
-    /// The exact #1470 fix, tested at its seam: an Adam optimizer carrying a
-    /// per-step-mutating schedule (Noam, <see cref="SchedulerStepMode.StepPerBatch"/>)
-    /// must NOT map to a fused-optimizer config — the compiled fused-training
-    /// kernel bakes a CONSTANT learning rate, so committing an Adam+Noam model
-    /// to it freezes the LR at its warmup-step-1 value (the #1470 symptom).
-    /// <see cref="AdamOptimizer{T,TInput,TOutput}.TryGetFusedOptimizerConfig"/>
-    /// must return <c>false</c> for an unmapped schedule so the model falls back
-    /// to the eager scheduler-stepping path that actually ramps the LR.
-    ///
-    /// <para>Positive controls: a no-scheduler Adam (constant LR) and the
-    /// fused-mappable Cosine/Exponential schedules must still return <c>true</c>,
-    /// so the fix doesn't over-broadly disable the fast path.</para>
+    /// The fix seam: an Adam optimizer carrying a Noam schedule must now MAP to
+    /// a fused-optimizer config (no eager fallback), and the mapped schedule
+    /// must ramp — warmup-end LR far above the warmup-step-1 LR. Pre-fix this
+    /// either returned false (forced eager) or carried a constant rate (#1470
+    /// freeze). Positive control: a no-scheduler Adam maps with a null (constant)
+    /// schedule and still takes the fused path.
     /// </summary>
     [Fact]
-    public void AdamWithNoamSchedule_DoesNotMapToConstantRateFusedConfig()
+    public void AdamWithNoamSchedule_MapsToFusedConfig_WithRampingSchedule()
     {
-        int d = 16, warmup = 8;
+        const int d = 512, warmup = 4000;
 
-        // Adam + Noam (StepPerBatch) — the default Transformer recipe. The
-        // schedule mutates the LR every batch, which the constant-rate fused
-        // kernel can't reproduce ⇒ must decline the fused path.
         var noamAdam = new AdamOptimizer<float, Tensor<float>, Tensor<float>>(
             null,
             new AdamOptimizerOptions<float, Tensor<float>, Tensor<float>>
             {
                 InitialLearningRate = 1e-3,
+                Beta2 = 0.98,
+                Epsilon = 1e-9,
                 LearningRateScheduler = new NoamSchedule(modelDimension: d, warmupSteps: warmup),
                 SchedulerStepMode = SchedulerStepMode.StepPerBatch,
             });
-        // TryGetFusedOptimizerConfig is an explicit IFusedOptimizerSpec impl
-        // (internal; reachable here via InternalsVisibleTo "AiDotNetTests").
-        Assert.False(((IFusedOptimizerSpec)noamAdam).TryGetFusedOptimizerConfig(out _),
-            "Adam+Noam must decline the fused path (constant-rate kernel would freeze the warmup ramp — #1470). " +
-            "If this returns true, the Noam LR will be baked at its warmup-step-1 value and never ramp.");
 
-        // Positive control 1: constant LR (no scheduler) is safe for the fused kernel.
+        // TryGetFusedOptimizerConfig is an explicit IFusedOptimizerSpec impl
+        // (internal; reachable via InternalsVisibleTo "AiDotNetTests").
+        Assert.True(((IFusedOptimizerSpec)noamAdam).TryGetFusedOptimizerConfig(out var cfg),
+            "Adam+Noam must now MAP to a fused-optimizer config — the fused kernel evaluates " +
+            "the schedule per step, so there's no reason to force the slower eager path (#1470).");
+
+        var schedule = cfg.Schedule;
+        Assert.NotNull(schedule); // Noam is a real per-step schedule, not constant
+
+        // The schedule must ramp during warmup: lr(warmup) is the peak, far above
+        // lr(1). A constant/frozen schedule (the #1470 symptom) would make these equal.
+        double lrStart = schedule!.GetLr(1);
+        double lrPeak = schedule.GetLr(warmup);
+        _output.WriteLine($"fused Noam schedule: GetLr(1)={lrStart:E4}, GetLr({warmup})={lrPeak:E4}, ratio={lrPeak / lrStart:F1}x");
+        Assert.True(lrPeak > lrStart * 10,
+            $"Fused Noam schedule must ramp during warmup (peak {lrPeak:E4} ≫ start {lrStart:E4}); " +
+            "an unramped schedule is the #1470 freeze.");
+
+        // Matches the paper formula (and therefore the eager NoamSchedule, which
+        // uses the same t = step convention) at the warmup peak.
+        double expectedPeak = Math.Pow(d, -0.5) * Math.Pow(warmup, -0.5);
+        Assert.Equal(expectedPeak, lrPeak, 9);
+
+        // Positive control: constant-LR Adam still uses the fused path (null schedule).
         var plainAdam = new AdamOptimizer<float, Tensor<float>, Tensor<float>>(
             null,
             new AdamOptimizerOptions<float, Tensor<float>, Tensor<float>> { InitialLearningRate = 1e-3 });
-        Assert.True(((IFusedOptimizerSpec)plainAdam).TryGetFusedOptimizerConfig(out _),
+        Assert.True(((IFusedOptimizerSpec)plainAdam).TryGetFusedOptimizerConfig(out var plainCfg),
             "A constant-LR Adam (no scheduler) should still use the fused fast path.");
+        Assert.Null(plainCfg.Schedule); // constant rate → no per-step schedule
     }
 
     /// <summary>
-    /// A default-optimizer (Adam + Noam, <see cref="SchedulerStepMode.StepPerBatch"/>)
-    /// Transformer trained via repeated per-call <c>Train</c> must ramp its
-    /// Noam learning rate across calls. Pre-#1470 the LR was frozen at the
-    /// warmup-step-1 value because per-call training didn't accumulate
-    /// scheduler step state (and/or the model was captured by the constant-rate
-    /// fused kernel). This is the end-to-end smoke complement to the gating
-    /// unit test above.
+    /// The fused Noam schedule must produce the SAME per-step LR sequence as the
+    /// eager <see cref="NoamSchedule"/> — otherwise the fused fast path would
+    /// train differently from the eager reference. Both map <c>t = step</c>
+    /// (1-based) to <c>lr(t=N)</c> on batch N.
     /// </summary>
     [Fact]
-    public void Transformer_PerCallTrain_DefaultNoam_RampsLearningRateAcrossCalls()
+    public void FusedNoamSchedule_MatchesEagerNoamSchedule_StepForStep()
     {
+        const int d = 256, warmup = 100;
+        var eager = new NoamSchedule(modelDimension: d, warmupSteps: warmup);
+
+        var adam = new AdamOptimizer<float, Tensor<float>, Tensor<float>>(
+            null,
+            new AdamOptimizerOptions<float, Tensor<float>, Tensor<float>>
+            {
+                LearningRateScheduler = new NoamSchedule(modelDimension: d, warmupSteps: warmup),
+                SchedulerStepMode = SchedulerStepMode.StepPerBatch,
+            });
+        Assert.True(((IFusedOptimizerSpec)adam).TryGetFusedOptimizerConfig(out var cfg));
+        var fused = cfg.Schedule!;
+
+        // Eager batch N uses lr(t=N): the ctor sets lr(t=1) for batch 1, and each
+        // OnBatchEnd Step() advances to the next. Replay that sequence and compare
+        // to the fused schedule's GetLr(N).
+        double eagerLr = eager.CurrentLearningRate;     // batch 1 (t=1), set in ctor
+        for (int n = 1; n <= 3 * warmup; n++)
+        {
+            Assert.Equal(eagerLr, fused.GetLr(n), 9);
+            eagerLr = eager.Step();                     // advance to batch n+1's lr
+        }
+    }
+
+    /// <summary>
+    /// End-to-end: a default-optimizer (Adam + Noam) Transformer trained via the
+    /// per-call minibatch pattern must (1) actually ENGAGE the fused-compiled
+    /// training path — proving Noam no longer forces the slow eager fallback —
+    /// and (2) break through the uniform-softmax floor (loss &lt; ln(V)),
+    /// proving the Noam LR ramped instead of freezing (#1470).
+    /// </summary>
+    [Fact]
+    public async Task Transformer_PerCallTrain_DefaultNoam_EngagesFusedPath_AndConverges()
+    {
+        await Task.Yield();
         const int vocab = 8;
         const int seqLen = 4;
-        const int modelDim = 16;
-        const int ffDim = 32;
-        const int warmup = 8;   // small warmup so the ramp is observable in a few batches
+        const int totalEpochs = 400;
+        const int modelDim = 32;
+        const int ffDim = 64;
+        const int warmup = 64;   // small so the ramp clears warmup within the budget
 
-        // NO explicit optimizer → exercises CreateDefaultVaswaniOptimizer
-        // (Adam + NoamSchedule, StepPerBatch), the exact default the #1470
-        // repro used (`new Transformer(arch, loss)`).
+        // No explicit optimizer → CreateDefaultVaswaniOptimizer (Adam + Noam,
+        // StepPerBatch) — the exact default the #1470 repro used.
         var arch = new TransformerArchitecture<float>(
             inputType: InputType.TwoDimensional,
             taskType: NeuralNetworkTaskType.MultiClassClassification,
-            numEncoderLayers: 1,
+            numEncoderLayers: 2,
             numDecoderLayers: 0,
-            numHeads: 2,
+            numHeads: 4,
             modelDimension: modelDim,
             feedForwardDimension: ffDim,
             inputSize: seqLen,
@@ -135,66 +177,60 @@ public class TransformerNoamPerCallLRIssue1470Tests
             lossFunction: new CategoricalCrossEntropyLoss<float>());
         model.SetTrainingMode(true);
 
-        var optimizer = GetBaseTrainOptimizer(model);
-        Assert.NotNull(optimizer);
+        CompiledTapeTrainingStep<float>.ResetFusedStepCount();
 
-        var scheduler = optimizer!.LearningRateScheduler;
-        Assert.NotNull(scheduler); // default Transformer optimizer carries a Noam schedule
-
-        double lrBefore = optimizer.GetCurrentLearningRate();
-        int stepBefore = scheduler!.CurrentStep;
-
-        // Per-call minibatch loop (MaxIterations=1 by virtue of one Train call
-        // == one batch). Run through the full warmup so the Noam LR climbs to
-        // its peak; pre-fix it stayed pinned at the step-1 value.
-        const int batches = warmup;
-        for (int i = 0; i < batches; i++)
+        for (int epoch = 0; epoch < totalEpochs; epoch++)
         {
-            var input = BuildAllKInput(i % vocab, seqLen);
-            var target = BuildOneHotTarget((i + 3) % vocab, vocab);
-            model.Train(input, target);
+            for (int k = 0; k < vocab; k++)
+            {
+                var input = BuildAllKInput(k, seqLen);
+                var target = BuildOneHotTarget((k + 3) % vocab, vocab);
+                model.Train(input, target);
+            }
         }
 
-        double lrAfter = optimizer.GetCurrentLearningRate();
-        int stepAfter = scheduler.CurrentStep;
+        long fusedSteps = CompiledTapeTrainingStep<float>.GetFusedStepCount();
+        model.SetTrainingMode(false);
 
-        _output.WriteLine(
-            $"step {stepBefore}->{stepAfter} (expected {batches}); " +
-            $"lr {lrBefore:E4}->{lrAfter:E4} (ratio {lrAfter / System.Math.Max(lrBefore, 1e-12):F2}x)");
+        // (1) The fused-compiled path must have actually run. Pre-fix, Adam+Noam
+        // was declined by TryGetFusedLrSchedule and every step fell back to the
+        // eager tape (fusedSteps == 0). The fix maps Noam → LrSchedule.Noam so
+        // the fast path engages.
+        _output.WriteLine($"fused steps engaged: {fusedSteps} / {totalEpochs * vocab}");
+        Assert.True(fusedSteps > 0,
+            "Adam+Noam Transformer must engage the fused-compiled training path now that " +
+            "LrSchedule.Noam exists — fusedSteps==0 means it's still forced onto the eager tape (#1470).");
 
-        // (a) Scheduler step state must ACCUMULATE across per-call Train — one
-        // StepPerBatch advance per Train call. Pre-#1470 this stayed at 0/1
-        // because the per-call path didn't persist/advance the scheduler.
-        Assert.Equal(stepBefore + batches, stepAfter);
-
-        // (b) Noam ramps linearly up to t=warmup, so the LR at the end of warmup
-        // must be materially larger than the warmup-step-1 value. A frozen LR
-        // (the #1470 symptom) would leave lrAfter ≈ lrBefore.
-        Assert.True(lrAfter > lrBefore * 1.5,
-            $"Noam LR must ramp across per-call Train invocations (StepPerBatch); " +
-            $"observed lrBefore={lrBefore:E4}, lrAfter={lrAfter:E4}. A near-constant LR is " +
-            "the #1470 symptom — per-call training is not advancing the scheduler, or the " +
-            "Adam+Noam optimizer was captured by the constant-rate fused-training kernel " +
-            "instead of falling back to the eager scheduler-stepping path.");
-    }
-
-    /// <summary>
-    /// Reads the model's base training optimizer — the same instance
-    /// <c>Train</c> resolves through <c>GetOrCreateBaseOptimizer</c> — so the
-    /// test inspects the real scheduler state, not a detached copy. The field
-    /// is private on <c>NeuralNetworkBase</c>; walk the hierarchy to find it.
-    /// </summary>
-    private static GradientBasedOptimizerBase<float, Tensor<float>, Tensor<float>>? GetBaseTrainOptimizer(
-        Transformer<float> model)
-    {
-        for (var t = (System.Type?)model.GetType(); t != null; t = t.BaseType)
+        // (2) Convergence below the uniform floor proves the Noam LR ramped on
+        // the fused path. Pre-fix the LR was frozen at warmup-step-1 and loss
+        // stayed at exactly ln(V) (PPL = V).
+        double totalNll = 0;
+        int correct = 0;
+        for (int k = 0; k < vocab; k++)
         {
-            var field = t.GetField("_baseTrainOptimizer",
-                BindingFlags.Instance | BindingFlags.NonPublic);
-            if (field == null) continue;
-            return field.GetValue(model) as GradientBasedOptimizerBase<float, Tensor<float>, Tensor<float>>;
+            var input = BuildAllKInput(k, seqLen);
+            var pred = model.Predict(input);
+            int expectedNext = (k + 3) % vocab;
+            float pTarget = pred.Length == vocab ? pred[expectedNext] : pred[0, expectedNext];
+            totalNll += -Math.Log(Math.Max((double)pTarget, 1e-9));
+
+            int argmax = 0;
+            float maxVal = float.MinValue;
+            for (int v = 0; v < vocab; v++)
+            {
+                float val = pred.Length == vocab ? pred[v] : pred[0, v];
+                if (val > maxVal) { maxVal = val; argmax = v; }
+            }
+            if (argmax == expectedNext) correct++;
         }
-        return null;
+        double avgNll = totalNll / vocab;
+        double lnV = Math.Log(vocab);
+        _output.WriteLine($"avgNll={avgNll:F3}  ln(V)={lnV:F3}  PPL={Math.Exp(avgNll):F2}  top-1={correct}/{vocab}");
+
+        Assert.True(avgNll < lnV * 0.95,
+            $"Default-Noam Transformer should train below ln(V)*0.95={lnV * 0.95:F3} on a deterministic " +
+            $"byte-LM task; observed avgNll={avgNll:F3}. A value at/near ln(V) means the Noam LR is frozen " +
+            "at warmup-step-1 — the #1470 regression.");
     }
 
     private static Tensor<float> BuildAllKInput(int k, int seqLen)

--- a/tests/AiDotNet.Tests/IntegrationTests/Optimizers/FusedActivationParityTests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/Optimizers/FusedActivationParityTests.cs
@@ -1,0 +1,85 @@
+using System;
+using System.Collections.Generic;
+using AiDotNet.ActivationFunctions;
+using AiDotNet.Tensors.Engines;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace AiDotNetTests.IntegrationTests.Optimizers;
+
+/// <summary>
+/// Numerical-parity gate for activations wired onto the fused inference path
+/// (#1447). An activation is only safe to map to a Tensors
+/// <see cref="FusedActivationType"/> if the fused kernel produces the same
+/// values as AiDotNet's eager scalar activation — otherwise <c>MlpForward</c>
+/// would silently compute a different function than the per-layer path.
+///
+/// <para><b>Methodology:</b> isolate the activation by running it through
+/// <c>IEngine.FusedLinear(x, I, null, type)</c> with an identity weight matrix
+/// (so the linear part is a no-op and only the fused activation kernel applies),
+/// and compare element-wise against the eager <c>activation.Activate(x)</c> over
+/// a range of inputs spanning negatives, zero and positives. Only activations
+/// that match here get <c>IFusedActivation</c> wired; this test is the gate.</para>
+/// </summary>
+public class FusedActivationParityTests
+{
+    private const double Tol = 1e-4;
+    private readonly ITestOutputHelper _output;
+    public FusedActivationParityTests(ITestOutputHelper output) => _output = output;
+
+    public static IEnumerable<object[]> NonParametricActivations()
+    {
+        yield return new object[] { "Sigmoid", new SigmoidActivation<float>(), FusedActivationType.Sigmoid };
+        yield return new object[] { "Tanh", new TanhActivation<float>(), FusedActivationType.Tanh };
+        yield return new object[] { "Mish", new MishActivation<float>(), FusedActivationType.Mish };
+        yield return new object[] { "SELU", new SELUActivation<float>(), FusedActivationType.SELU };
+        yield return new object[] { "Softplus", new SoftPlusActivation<float>(), FusedActivationType.Softplus };
+        yield return new object[] { "SoftSign", new SoftSignActivation<float>(), FusedActivationType.SoftSign };
+        yield return new object[] { "Sign", new SignActivation<float>(), FusedActivationType.Sign };
+        yield return new object[] { "BentIdentity", new BentIdentityActivation<float>(), FusedActivationType.BentIdentity };
+        yield return new object[] { "Gaussian", new GaussianActivation<float>(), FusedActivationType.Gaussian };
+        yield return new object[] { "LiSHT", new LiSHTActivation<float>(), FusedActivationType.LiSHT };
+        yield return new object[] { "SQRBF", new SQRBFActivation<float>(), FusedActivationType.SQRBF };
+        yield return new object[] { "ReLU6", new ReLU6Activation<float>(), FusedActivationType.ReLU6 };
+        yield return new object[] { "HardSwish", new HardSwishActivation<float>(), FusedActivationType.HardSwish };
+        // HardSigmoid intentionally NOT wired: AiDotNet's HardSigmoidActivation
+        // uses slope 0.2 (clamp(0.2x+0.5,0,1)) while the fused kernel uses the
+        // PyTorch form (x/6+0.5) — the parity gate measured a 0.333 divergence,
+        // so it stays on the eager path. Reconcile the formula before wiring.
+    }
+
+    [Theory]
+    [MemberData(nameof(NonParametricActivations))]
+    public void FusedActivation_MatchesEagerActivate(string name, ActivationFunctionBase<float> activation, FusedActivationType type)
+    {
+        var engine = new CpuEngine();
+        const int n = 5, d = 9;
+
+        // Inputs spanning negative / zero / positive (and a couple of larger
+        // magnitudes) so saturating regions are exercised.
+        var x = new Tensor<float>(new[] { n, d });
+        var samples = new float[] { -4f, -2f, -1f, -0.3f, 0f, 0.3f, 1f, 2f, 4f };
+        for (int i = 0; i < n; i++)
+            for (int j = 0; j < d; j++)
+                x[i, j] = samples[j] + i * 0.05f;
+
+        // Identity weights → FusedLinear computes activation(x · I) = activation(x).
+        var id = new Tensor<float>(new[] { d, d });
+        for (int j = 0; j < d; j++) id[j, j] = 1f;
+
+        var fused = engine.FusedLinear(x, id, null, type);
+        var eager = activation.Activate(x);
+
+        Assert.Equal(eager.Length, fused.Length);
+        double maxAbs = 0;
+        var ef = eager.ToArray();
+        var ff = fused.ToArray();
+        for (int i = 0; i < ff.Length; i++)
+            maxAbs = Math.Max(maxAbs, Math.Abs((double)ff[i] - (double)ef[i]));
+
+        _output.WriteLine($"{name}: maxAbsDiff(fused vs eager) = {maxAbs:E3}");
+        Assert.True(maxAbs <= Tol,
+            $"{name}: fused FusedActivationType.{type} diverges from eager {name}Activation by {maxAbs:E3} (> {Tol:E1}). " +
+            "Do NOT wire IFusedActivation for this activation until the kernel and eager form agree.");
+    }
+}

--- a/tests/AiDotNet.Tests/IntegrationTests/Optimizers/FusedLrScheduleMappingTests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/Optimizers/FusedLrScheduleMappingTests.cs
@@ -1,0 +1,133 @@
+using AiDotNet.Enums;
+using AiDotNet.LearningRateSchedulers;
+using AiDotNet.Models.Options;
+using AiDotNet.Optimizers;
+using AiDotNet.Optimizers.Fused;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace AiDotNetTests.IntegrationTests.Optimizers;
+
+/// <summary>
+/// Parity guards for <c>GradientBasedOptimizerBase.TryGetFusedLrSchedule</c> —
+/// the seam that lets an LR scheduler run on the fused-compiled training path.
+/// The fused plan evaluates <c>LrSchedule.GetLr(step)</c> once per optimizer
+/// step (the same model as PyTorch <c>fused=True</c>), so each mapped AiDotNet
+/// scheduler MUST produce a per-step LR sequence bit-identical to its eager
+/// counterpart — otherwise the fused fast path would train differently from the
+/// eager reference. These tests construct an Adam carrying each scheduler, pull
+/// the mapped fused <c>LrSchedule</c> out of the optimizer's fused config, and
+/// assert step-for-step equality against the eager scheduler.
+/// </summary>
+public class FusedLrScheduleMappingTests
+{
+    private const double Tol = 1e-9;
+    private readonly ITestOutputHelper _output;
+    public FusedLrScheduleMappingTests(ITestOutputHelper output) => _output = output;
+
+    private static AiDotNet.Tensors.Engines.Compilation.LrSchedule? MapToFused(ILearningRateScheduler scheduler)
+    {
+        var adam = new AdamOptimizer<float, Tensor<float>, Tensor<float>>(
+            null,
+            new AdamOptimizerOptions<float, Tensor<float>, Tensor<float>>
+            {
+                LearningRateScheduler = scheduler,
+                SchedulerStepMode = SchedulerStepMode.StepPerBatch,
+            });
+        Assert.True(((IFusedOptimizerSpec)adam).TryGetFusedOptimizerConfig(out var cfg),
+            $"{scheduler.GetType().Name} should map to a fused-optimizer config.");
+        return cfg.Schedule;
+    }
+
+    /// <summary>
+    /// Replays the eager scheduler's per-batch LR sequence (ctor value for batch
+    /// 1, then one Step() per subsequent batch) and asserts it equals the fused
+    /// schedule's GetLr(N) for every batch N in [1, steps].
+    /// </summary>
+    private void AssertStepForStepParity(
+        ILearningRateScheduler eager,
+        AiDotNet.Tensors.Engines.Compilation.LrSchedule fused,
+        int steps,
+        string label)
+    {
+        double eagerLr = eager.CurrentLearningRate;   // batch 1 (set in ctor)
+        for (int n = 1; n <= steps; n++)
+        {
+            double fusedLr = fused.GetLr(n);
+            Assert.True(System.Math.Abs(eagerLr - fusedLr) <= Tol,
+                $"{label}: batch {n} eager={eagerLr:E6} vs fused={fusedLr:E6} (Δ={System.Math.Abs(eagerLr - fusedLr):E3})");
+            eagerLr = eager.Step();                    // advance to batch n+1
+        }
+        _output.WriteLine($"{label}: step-for-step parity over {steps} batches ✓");
+    }
+
+    [Fact]
+    public void StepLR_MapsToFusedStep_StepForStepParity()
+    {
+        var fused = MapToFused(new StepLRScheduler(baseLearningRate: 0.1, stepSize: 7, gamma: 0.5));
+        Assert.NotNull(fused);
+        AssertStepForStepParity(
+            new StepLRScheduler(baseLearningRate: 0.1, stepSize: 7, gamma: 0.5),
+            fused!, steps: 50, label: "StepLR");
+    }
+
+    [Fact]
+    public void CyclicLR_TriangularSymmetric_MapsToFusedCyclic_StepForStepParity()
+    {
+        var fused = MapToFused(new CyclicLRScheduler(
+            baseLearningRate: 0.001, maxLearningRate: 0.1, stepSizeUp: 10, stepSizeDown: 10,
+            mode: CyclicLRScheduler.CyclicMode.Triangular));
+        Assert.NotNull(fused);
+        AssertStepForStepParity(
+            new CyclicLRScheduler(
+                baseLearningRate: 0.001, maxLearningRate: 0.1, stepSizeUp: 10, stepSizeDown: 10,
+                mode: CyclicLRScheduler.CyclicMode.Triangular),
+            fused!, steps: 60, label: "CyclicLR(Triangular)");
+    }
+
+    [Fact]
+    public void CyclicLR_NonCanonical_FallsBackToEager_NotFused()
+    {
+        // Triangular2 has no fused shape (per-cycle amplitude decay) → must NOT map.
+        var t2 = new AdamOptimizer<float, Tensor<float>, Tensor<float>>(
+            null,
+            new AdamOptimizerOptions<float, Tensor<float>, Tensor<float>>
+            {
+                LearningRateScheduler = new CyclicLRScheduler(
+                    baseLearningRate: 0.001, maxLearningRate: 0.1, stepSizeUp: 10, stepSizeDown: 10,
+                    mode: CyclicLRScheduler.CyclicMode.Triangular2),
+                SchedulerStepMode = SchedulerStepMode.StepPerBatch,
+            });
+        Assert.False(((IFusedOptimizerSpec)t2).TryGetFusedOptimizerConfig(out _),
+            "Triangular2 cyclic has no fused equivalent and must fall back to the eager path.");
+
+        // Asymmetric up≠down also has no fused shape.
+        var asym = new AdamOptimizer<float, Tensor<float>, Tensor<float>>(
+            null,
+            new AdamOptimizerOptions<float, Tensor<float>, Tensor<float>>
+            {
+                LearningRateScheduler = new CyclicLRScheduler(
+                    baseLearningRate: 0.001, maxLearningRate: 0.1, stepSizeUp: 5, stepSizeDown: 15,
+                    mode: CyclicLRScheduler.CyclicMode.Triangular),
+                SchedulerStepMode = SchedulerStepMode.StepPerBatch,
+            });
+        Assert.False(((IFusedOptimizerSpec)asym).TryGetFusedOptimizerConfig(out _),
+            "Asymmetric cyclic (up≠down) has no fused equivalent and must fall back to eager.");
+    }
+
+    [Fact]
+    public void ExistingMappings_CosineAndExponential_RemainStepForStepCorrect()
+    {
+        var cosFused = MapToFused(new CosineAnnealingLRScheduler(baseLearningRate: 0.1, tMax: 50));
+        Assert.NotNull(cosFused);
+        AssertStepForStepParity(
+            new CosineAnnealingLRScheduler(baseLearningRate: 0.1, tMax: 50),
+            cosFused!, steps: 50, label: "CosineAnnealing");
+
+        var expFused = MapToFused(new ExponentialLRScheduler(baseLearningRate: 0.1, gamma: 0.95));
+        Assert.NotNull(expFused);
+        AssertStepForStepParity(
+            new ExponentialLRScheduler(baseLearningRate: 0.1, gamma: 0.95),
+            expFused!, steps: 40, label: "Exponential");
+    }
+}

--- a/tests/AiDotNet.Tests/IntegrationTests/Optimizers/FusedOptimizerParityTests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/Optimizers/FusedOptimizerParityTests.cs
@@ -62,13 +62,14 @@ public class FusedOptimizerParityTests
     /// <see cref="Steps"/> steps and returns the max abs parameter divergence
     /// plus the number of fused steps that actually engaged.
     /// </summary>
-    private (double maxAbsDiff, long fusedSteps) Divergence(
+    private (double maxAbsDiff, long fusedSteps, double trainDelta) Divergence(
         Func<IGradientBasedOptimizer<float, Tensor<float>, Tensor<float>>> optFactory)
     {
         var fused = new FeedForwardNeuralNetwork<float>(MakeArch(), optFactory(), new MeanSquaredErrorLoss<float>());
         var eager = new FeedForwardNeuralNetwork<float>(MakeArch(), optFactory(), new MeanSquaredErrorLoss<float>());
         // Identical initial weights: copy the fused model's init into the eager one.
-        eager.UpdateParameters(fused.GetParameters());
+        var init = fused.GetParameters();
+        eager.UpdateParameters(init);
         fused.SetTrainingMode(true);
         eager.SetTrainingMode(true);
         var (x, y) = MakeData();
@@ -98,10 +99,13 @@ public class FusedOptimizerParityTests
         var pf = fused.GetParameters();
         var pe = eager.GetParameters();
         Assert.Equal(pf.Length, pe.Length);
-        double maxAbs = 0;
+        double maxAbs = 0, trainDelta = 0;
         for (int i = 0; i < pf.Length; i++)
+        {
             maxAbs = Math.Max(maxAbs, Math.Abs((double)pf[i] - (double)pe[i]));
-        return (maxAbs, fusedSteps);
+            trainDelta = Math.Max(trainDelta, Math.Abs((double)pf[i] - (double)init[i]));
+        }
+        return (maxAbs, fusedSteps, trainDelta);
     }
 
     private static AdamOptimizer<float, Tensor<float>, Tensor<float>> Adam() =>
@@ -110,7 +114,7 @@ public class FusedOptimizerParityTests
     [Fact]
     public void Adam_Control_FusedMatchesEager()
     {
-        var (diff, fusedSteps) = Divergence(Adam);
+        var (diff, fusedSteps, trainDelta) = Divergence(Adam);
         _output.WriteLine($"Adam control: fusedSteps={fusedSteps}, maxAbsDiff={diff:E3}");
         Assert.True(fusedSteps > 0, "Adam must engage the fused path (control is meaningless otherwise).");
         Assert.True(diff < 1e-3, $"Adam fused-vs-eager divergence {diff:E3} unexpectedly large — forward/backward float-order issue?");
@@ -119,8 +123,8 @@ public class FusedOptimizerParityTests
     [Fact]
     public void AdaMax_FusedMatchesEager_NoWorseThanAdam()
     {
-        var (adamDiff, _) = Divergence(Adam);
-        var (diff, fusedSteps) = Divergence(() =>
+        var (adamDiff, _, _) = Divergence(Adam);
+        var (diff, fusedSteps, trainDelta) = Divergence(() =>
             new AdaMaxOptimizer<float, Tensor<float>, Tensor<float>>(
                 null, new AdaMaxOptimizerOptions<float, Tensor<float>, Tensor<float>> { InitialLearningRate = 1e-2 }));
         _output.WriteLine($"AdaMax: fusedSteps={fusedSteps}, maxAbsDiff={diff:E3} (Adam control {adamDiff:E3})");
@@ -134,8 +138,8 @@ public class FusedOptimizerParityTests
     [Fact]
     public void Nadam_FusedMatchesEager_NoWorseThanAdam()
     {
-        var (adamDiff, _) = Divergence(Adam);
-        var (diff, fusedSteps) = Divergence(() =>
+        var (adamDiff, _, _) = Divergence(Adam);
+        var (diff, fusedSteps, trainDelta) = Divergence(() =>
             new NadamOptimizer<float, Tensor<float>, Tensor<float>>(
                 null, new NadamOptimizerOptions<float, Tensor<float>, Tensor<float>> { InitialLearningRate = 1e-2 }));
         _output.WriteLine($"Nadam: fusedSteps={fusedSteps}, maxAbsDiff={diff:E3} (Adam control {adamDiff:E3})");
@@ -144,5 +148,70 @@ public class FusedOptimizerParityTests
         Assert.True(diff <= Math.Max(adamDiff * 10.0, 1e-4),
             $"Nadam fused-vs-eager divergence {diff:E3} ≫ Adam control {adamDiff:E3} — the fused Nadam kernel does " +
             "not match AiDotNet's eager Nadam update. Do NOT wire this mapping until reconciled.");
+    }
+
+    private void AssertOptimizerParity(
+        string name, long fusedSteps, double diff, double trainDelta, double adamDiff)
+    {
+        _output.WriteLine($"{name}: fusedSteps={fusedSteps}, maxAbsDiff={diff:E3}, trainDelta={trainDelta:E3} (Adam control {adamDiff:E3})");
+        Assert.True(fusedSteps > 0,
+            $"{name} must engage the fused path — fusedSteps==0 means the mapping didn't take (allowlist/spec).");
+        // Non-vacuous guard: training must actually move the parameters, else a
+        // 0 divergence is meaningless (two un-trained models trivially match).
+        Assert.True(trainDelta > 1e-6,
+            $"{name}: training did not change parameters (trainDelta={trainDelta:E3}); the parity comparison is vacuous.");
+        Assert.True(diff <= Math.Max(adamDiff * 10.0, 1e-4),
+            $"{name} fused-vs-eager divergence {diff:E3} ≫ Adam control {adamDiff:E3} — the fused kernel does not " +
+            $"match AiDotNet's eager {name} update. Do NOT wire this mapping until reconciled.");
+    }
+
+    [Fact]
+    public void RMSprop_FusedMatchesEager_NoWorseThanAdam()
+    {
+        var (adamDiff, _, _) = Divergence(Adam);
+        var (diff, fusedSteps, trainDelta) = Divergence(() =>
+            new RootMeanSquarePropagationOptimizer<float, Tensor<float>, Tensor<float>>(
+                null, new RootMeanSquarePropagationOptimizerOptions<float, Tensor<float>, Tensor<float>> { InitialLearningRate = 1e-2 }));
+        AssertOptimizerParity("RMSprop", fusedSteps, diff, trainDelta, adamDiff);
+    }
+
+    [Fact]
+    public void Adagrad_FusedMatchesEager_NoWorseThanAdam()
+    {
+        var (adamDiff, _, _) = Divergence(Adam);
+        var (diff, fusedSteps, trainDelta) = Divergence(() =>
+            new AdagradOptimizer<float, Tensor<float>, Tensor<float>>(
+                null, new AdagradOptimizerOptions<float, Tensor<float>, Tensor<float>> { InitialLearningRate = 1e-2 }));
+        AssertOptimizerParity("Adagrad", fusedSteps, diff, trainDelta, adamDiff);
+    }
+
+    [Fact]
+    public void Lion_FusedMatchesEager_NoWorseThanAdam()
+    {
+        var (adamDiff, _, _) = Divergence(Adam);
+        var (diff, fusedSteps, trainDelta) = Divergence(() =>
+            new LionOptimizer<float, Tensor<float>, Tensor<float>>(
+                null, new LionOptimizerOptions<float, Tensor<float>, Tensor<float>> { InitialLearningRate = 1e-2 }));
+        AssertOptimizerParity("Lion", fusedSteps, diff, trainDelta, adamDiff);
+    }
+
+    [Fact]
+    public void AdaDelta_FusedMatchesEager_NoWorseThanAdam()
+    {
+        var (adamDiff, _, _) = Divergence(Adam);
+        var (diff, fusedSteps, trainDelta) = Divergence(() =>
+            new AdaDeltaOptimizer<float, Tensor<float>, Tensor<float>>(
+                null, new AdaDeltaOptimizerOptions<float, Tensor<float>, Tensor<float>> { InitialLearningRate = 1e-2 }));
+        AssertOptimizerParity("AdaDelta", fusedSteps, diff, trainDelta, adamDiff);
+    }
+
+    [Fact]
+    public void LAMB_FusedMatchesEager_NoWorseThanAdam()
+    {
+        var (adamDiff, _, _) = Divergence(Adam);
+        var (diff, fusedSteps, trainDelta) = Divergence(() =>
+            new LAMBOptimizer<float, Tensor<float>, Tensor<float>>(
+                null, new LAMBOptimizerOptions<float, Tensor<float>, Tensor<float>> { InitialLearningRate = 1e-2 }));
+        AssertOptimizerParity("LAMB", fusedSteps, diff, trainDelta, adamDiff);
     }
 }

--- a/tests/AiDotNet.Tests/IntegrationTests/Optimizers/FusedOptimizerParityTests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/Optimizers/FusedOptimizerParityTests.cs
@@ -1,0 +1,148 @@
+using System;
+using AiDotNet.Enums;
+using AiDotNet.Interfaces;
+using AiDotNet.LossFunctions;
+using AiDotNet.Models.Options;
+using AiDotNet.NeuralNetworks;
+using AiDotNet.Optimizers;
+using AiDotNet.Training;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace AiDotNetTests.IntegrationTests.Optimizers;
+
+/// <summary>
+/// Fused-vs-eager numerical-parity gate for the optimizers wired onto the
+/// fused-compiled training path (#1447). An optimizer is only safe to map to a
+/// Tensors fused kernel if training a model on the fused path produces the same
+/// parameters as the eager tape — otherwise users silently get different results
+/// depending on whether compilation engaged.
+///
+/// <para><b>Methodology:</b> train two identically-initialised MLPs on the same
+/// data — one with <c>TensorCodecOptions.EnableCompilation = true</c> (fused),
+/// one <c>= false</c> (eager) — and compare final parameters. Fused and eager
+/// differ slightly even for a known-correct optimizer because the fused plan
+/// orders float ops differently from the eager tape; <b>Adam is the control</b>
+/// (already wired and known-correct), so each newly-wired optimizer must diverge
+/// no more than Adam does. A wrong kernel mapping diverges by orders of
+/// magnitude more. Each test also asserts the fused path actually engaged
+/// (<c>GetFusedStepCount &gt; 0</c>) so the comparison isn't vacuously
+/// eager-vs-eager.</para>
+/// </summary>
+[Collection("FusedTrainingSerial")]
+public class FusedOptimizerParityTests
+{
+    private const int Steps = 40;
+    private readonly ITestOutputHelper _output;
+    public FusedOptimizerParityTests(ITestOutputHelper output) => _output = output;
+
+    private static NeuralNetworkArchitecture<float> MakeArch() =>
+        new NeuralNetworkArchitecture<float>(
+            inputType: InputType.OneDimensional,
+            taskType: NeuralNetworkTaskType.Regression,
+            complexity: NetworkComplexity.Simple,
+            inputSize: 8,
+            outputSize: 3);
+
+    private static (Tensor<float> x, Tensor<float> y) MakeData()
+    {
+        var x = new Tensor<float>(new[] { 4, 8 });
+        var y = new Tensor<float>(new[] { 4, 3 });
+        // Deterministic synthetic batch (fixed values, no RNG).
+        for (int b = 0; b < 4; b++)
+        {
+            for (int f = 0; f < 8; f++) x[b, f] = (float)(((b * 8 + f) % 7) - 3) * 0.1f;
+            for (int o = 0; o < 3; o++) y[b, o] = (float)(((b * 3 + o) % 5) - 2) * 0.2f;
+        }
+        return (x, y);
+    }
+
+    /// <summary>
+    /// Trains a fused model and an identically-initialised eager model for
+    /// <see cref="Steps"/> steps and returns the max abs parameter divergence
+    /// plus the number of fused steps that actually engaged.
+    /// </summary>
+    private (double maxAbsDiff, long fusedSteps) Divergence(
+        Func<IGradientBasedOptimizer<float, Tensor<float>, Tensor<float>>> optFactory)
+    {
+        var fused = new FeedForwardNeuralNetwork<float>(MakeArch(), optFactory(), new MeanSquaredErrorLoss<float>());
+        var eager = new FeedForwardNeuralNetwork<float>(MakeArch(), optFactory(), new MeanSquaredErrorLoss<float>());
+        // Identical initial weights: copy the fused model's init into the eager one.
+        eager.UpdateParameters(fused.GetParameters());
+        fused.SetTrainingMode(true);
+        eager.SetTrainingMode(true);
+        var (x, y) = MakeData();
+
+        bool saved = AiDotNet.Tensors.Engines.Optimization.TensorCodecOptions.Current.EnableCompilation;
+        long fusedSteps;
+        try
+        {
+            // Fused run.
+            AiDotNet.Tensors.Engines.Optimization.TensorCodecOptions.Current.EnableCompilation = true;
+            CompiledTapeTrainingStep<float>.Invalidate();
+            CompiledTapeTrainingStep<float>.ResetFusedStepCount();
+            for (int i = 0; i < Steps; i++) fused.Train(x, y);
+            fusedSteps = CompiledTapeTrainingStep<float>.GetFusedStepCount();
+
+            // Eager run (compilation disabled → pure tape path).
+            AiDotNet.Tensors.Engines.Optimization.TensorCodecOptions.Current.EnableCompilation = false;
+            CompiledTapeTrainingStep<float>.Invalidate();
+            for (int i = 0; i < Steps; i++) eager.Train(x, y);
+        }
+        finally
+        {
+            AiDotNet.Tensors.Engines.Optimization.TensorCodecOptions.Current.EnableCompilation = saved;
+            CompiledTapeTrainingStep<float>.Invalidate();
+        }
+
+        var pf = fused.GetParameters();
+        var pe = eager.GetParameters();
+        Assert.Equal(pf.Length, pe.Length);
+        double maxAbs = 0;
+        for (int i = 0; i < pf.Length; i++)
+            maxAbs = Math.Max(maxAbs, Math.Abs((double)pf[i] - (double)pe[i]));
+        return (maxAbs, fusedSteps);
+    }
+
+    private static AdamOptimizer<float, Tensor<float>, Tensor<float>> Adam() =>
+        new(null, new AdamOptimizerOptions<float, Tensor<float>, Tensor<float>> { InitialLearningRate = 1e-2 });
+
+    [Fact]
+    public void Adam_Control_FusedMatchesEager()
+    {
+        var (diff, fusedSteps) = Divergence(Adam);
+        _output.WriteLine($"Adam control: fusedSteps={fusedSteps}, maxAbsDiff={diff:E3}");
+        Assert.True(fusedSteps > 0, "Adam must engage the fused path (control is meaningless otherwise).");
+        Assert.True(diff < 1e-3, $"Adam fused-vs-eager divergence {diff:E3} unexpectedly large — forward/backward float-order issue?");
+    }
+
+    [Fact]
+    public void AdaMax_FusedMatchesEager_NoWorseThanAdam()
+    {
+        var (adamDiff, _) = Divergence(Adam);
+        var (diff, fusedSteps) = Divergence(() =>
+            new AdaMaxOptimizer<float, Tensor<float>, Tensor<float>>(
+                null, new AdaMaxOptimizerOptions<float, Tensor<float>, Tensor<float>> { InitialLearningRate = 1e-2 }));
+        _output.WriteLine($"AdaMax: fusedSteps={fusedSteps}, maxAbsDiff={diff:E3} (Adam control {adamDiff:E3})");
+        Assert.True(fusedSteps > 0,
+            "AdaMax must engage the fused path (OptimizerType.AdaMax) — fusedSteps==0 means the mapping didn't take.");
+        Assert.True(diff <= Math.Max(adamDiff * 10.0, 1e-4),
+            $"AdaMax fused-vs-eager divergence {diff:E3} ≫ Adam control {adamDiff:E3} — the fused AdaMax kernel does " +
+            "not match AiDotNet's eager AdaMax update. Do NOT wire this mapping until reconciled.");
+    }
+
+    [Fact]
+    public void Nadam_FusedMatchesEager_NoWorseThanAdam()
+    {
+        var (adamDiff, _) = Divergence(Adam);
+        var (diff, fusedSteps) = Divergence(() =>
+            new NadamOptimizer<float, Tensor<float>, Tensor<float>>(
+                null, new NadamOptimizerOptions<float, Tensor<float>, Tensor<float>> { InitialLearningRate = 1e-2 }));
+        _output.WriteLine($"Nadam: fusedSteps={fusedSteps}, maxAbsDiff={diff:E3} (Adam control {adamDiff:E3})");
+        Assert.True(fusedSteps > 0,
+            "Nadam must engage the fused path (OptimizerType.Nadam) — fusedSteps==0 means the mapping didn't take.");
+        Assert.True(diff <= Math.Max(adamDiff * 10.0, 1e-4),
+            $"Nadam fused-vs-eager divergence {diff:E3} ≫ Adam control {adamDiff:E3} — the fused Nadam kernel does " +
+            "not match AiDotNet's eager Nadam update. Do NOT wire this mapping until reconciled.");
+    }
+}

--- a/tests/AiDotNet.Tests/IntegrationTests/Optimizers/FusedOptimizerParityTests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/Optimizers/FusedOptimizerParityTests.cs
@@ -117,6 +117,8 @@ public class FusedOptimizerParityTests
         var (diff, fusedSteps, trainDelta) = Divergence(Adam);
         _output.WriteLine($"Adam control: fusedSteps={fusedSteps}, maxAbsDiff={diff:E3}");
         Assert.True(fusedSteps > 0, "Adam must engage the fused path (control is meaningless otherwise).");
+        Assert.True(trainDelta > 1e-6,
+            $"Adam control: training did not move parameters (trainDelta={trainDelta:E3}); the fused-vs-eager parity comparison is vacuous.");
         Assert.True(diff < 1e-3, $"Adam fused-vs-eager divergence {diff:E3} unexpectedly large — forward/backward float-order issue?");
     }
 
@@ -130,6 +132,8 @@ public class FusedOptimizerParityTests
         _output.WriteLine($"AdaMax: fusedSteps={fusedSteps}, maxAbsDiff={diff:E3} (Adam control {adamDiff:E3})");
         Assert.True(fusedSteps > 0,
             "AdaMax must engage the fused path (OptimizerType.AdaMax) — fusedSteps==0 means the mapping didn't take.");
+        Assert.True(trainDelta > 1e-6,
+            $"AdaMax: training did not move parameters (trainDelta={trainDelta:E3}); the fused-vs-eager parity comparison is vacuous.");
         Assert.True(diff <= Math.Max(adamDiff * 10.0, 1e-4),
             $"AdaMax fused-vs-eager divergence {diff:E3} ≫ Adam control {adamDiff:E3} — the fused AdaMax kernel does " +
             "not match AiDotNet's eager AdaMax update. Do NOT wire this mapping until reconciled.");
@@ -145,6 +149,8 @@ public class FusedOptimizerParityTests
         _output.WriteLine($"Nadam: fusedSteps={fusedSteps}, maxAbsDiff={diff:E3} (Adam control {adamDiff:E3})");
         Assert.True(fusedSteps > 0,
             "Nadam must engage the fused path (OptimizerType.Nadam) — fusedSteps==0 means the mapping didn't take.");
+        Assert.True(trainDelta > 1e-6,
+            $"Nadam: training did not move parameters (trainDelta={trainDelta:E3}); the fused-vs-eager parity comparison is vacuous.");
         Assert.True(diff <= Math.Max(adamDiff * 10.0, 1e-4),
             $"Nadam fused-vs-eager divergence {diff:E3} ≫ Adam control {adamDiff:E3} — the fused Nadam kernel does " +
             "not match AiDotNet's eager Nadam update. Do NOT wire this mapping until reconciled.");

--- a/tests/AiDotNet.Tests/UnitTests/NeuralNetworks/CnnInferenceAllocProfile.cs
+++ b/tests/AiDotNet.Tests/UnitTests/NeuralNetworks/CnnInferenceAllocProfile.cs
@@ -71,11 +71,22 @@ public class CnnInferenceAllocProfile
         const int reps = 2000;
         GC.Collect(); GC.WaitForPendingFinalizers(); GC.Collect();
         int g0 = GC.CollectionCount(0), g1 = GC.CollectionCount(1), g2 = GC.CollectionCount(2);
+        // GetAllocatedBytesForCurrentThread is net5+; on net471 fall back to
+        // GetTotalMemory (less precise but always available) so this profiler
+        // compiles on every target framework.
+#if NET5_0_OR_GREATER
         long allocBefore = GC.GetAllocatedBytesForCurrentThread();
+#else
+        long allocBefore = GC.GetTotalMemory(forceFullCollection: false);
+#endif
         var sw = System.Diagnostics.Stopwatch.StartNew();
         for (int i = 0; i < reps; i++) { var _ = predict(); }
         sw.Stop();
+#if NET5_0_OR_GREATER
         long allocAfter = GC.GetAllocatedBytesForCurrentThread();
+#else
+        long allocAfter = GC.GetTotalMemory(forceFullCollection: false);
+#endif
         int d0 = GC.CollectionCount(0) - g0, d1 = GC.CollectionCount(1) - g1, d2 = GC.CollectionCount(2) - g2;
 
         double usPer = sw.Elapsed.TotalMilliseconds * 1000.0 / reps;

--- a/tests/AiDotNet.Tests/UnitTests/NeuralNetworks/CnnInferenceAllocProfile.cs
+++ b/tests/AiDotNet.Tests/UnitTests/NeuralNetworks/CnnInferenceAllocProfile.cs
@@ -1,0 +1,93 @@
+using System;
+using AiDotNet.ActivationFunctions;
+using AiDotNet.Enums;
+using AiDotNet.Interfaces;
+using AiDotNet.NeuralNetworks;
+using AiDotNet.NeuralNetworks.Layers;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace AiDotNet.Tests.UnitTests.NeuralNetworks;
+
+/// <summary>
+/// Allocation + GC-churn profile of CNN (and MLP) inference Predict — exact bytes
+/// allocated per call (GC.GetAllocatedBytesForCurrentThread) and Gen0/1/2 collection
+/// counts over a run. Env-gated (AIDOTNET_RUN_JIT_PERF=1). This is the
+/// allocation/GC half of the profiling; the CPU call tree comes from dotnet-trace.
+/// </summary>
+public class CnnInferenceAllocProfile
+{
+    private readonly ITestOutputHelper _output;
+    public CnnInferenceAllocProfile(ITestOutputHelper output) => _output = output;
+
+    [Fact]
+    public void Profile_CnnAndMlp_AllocAndGc()
+    {
+        if (Environment.GetEnvironmentVariable("AIDOTNET_RUN_JIT_PERF") != "1") return;
+
+        ProfileCnn();
+        ProfileMlp();
+    }
+
+    private void ProfileCnn()
+    {
+        var layers = new System.Collections.Generic.List<ILayer<float>>
+        {
+            new ConvolutionalLayer<float>(16, 3, 1, 1, activationFunction: new ReLUActivation<float>()),
+            new MaxPoolingLayer<float>(2, 2),
+            new ConvolutionalLayer<float>(32, 3, 1, 1, activationFunction: new ReLUActivation<float>()),
+            new MaxPoolingLayer<float>(2, 2),
+            new FlattenLayer<float>(),
+            new DenseLayer<float>(10, activationFunction: (IActivationFunction<float>?)null),
+        };
+        var arch = new NeuralNetworkArchitecture<float>(InputType.ThreeDimensional,
+            NeuralNetworkTaskType.MultiClassClassification, inputHeight: 28, inputWidth: 28, inputDepth: 1,
+            outputSize: 10, layers: layers);
+        var model = new ConvolutionalNeuralNetwork<float>(arch);
+        var x = Rand(new[] { 1, 1, 28, 28 }, 1);
+        Run("CNN", () => model.Predict(x));
+    }
+
+    private void ProfileMlp()
+    {
+        var layers = new System.Collections.Generic.List<ILayer<float>>
+        {
+            new DenseLayer<float>(512, activationFunction: new ReLUActivation<float>()),
+            new DenseLayer<float>(128, activationFunction: new ReLUActivation<float>()),
+            new DenseLayer<float>(10, activationFunction: (IActivationFunction<float>?)null),
+        };
+        var arch = new NeuralNetworkArchitecture<float>(InputType.OneDimensional,
+            NeuralNetworkTaskType.MultiClassClassification, inputSize: 784, outputSize: 10, layers: layers);
+        var model = new FeedForwardNeuralNetwork<float>(arch);
+        var x = Rand(new[] { 1, 784 }, 1);
+        Run("MLP", () => model.Predict(x));
+    }
+
+    private void Run(string name, Func<Tensor<float>> predict)
+    {
+        for (int i = 0; i < 50; i++) { var _ = predict(); }   // warm (materialize weights, JIT, prepack)
+
+        const int reps = 2000;
+        GC.Collect(); GC.WaitForPendingFinalizers(); GC.Collect();
+        int g0 = GC.CollectionCount(0), g1 = GC.CollectionCount(1), g2 = GC.CollectionCount(2);
+        long allocBefore = GC.GetAllocatedBytesForCurrentThread();
+        var sw = System.Diagnostics.Stopwatch.StartNew();
+        for (int i = 0; i < reps; i++) { var _ = predict(); }
+        sw.Stop();
+        long allocAfter = GC.GetAllocatedBytesForCurrentThread();
+        int d0 = GC.CollectionCount(0) - g0, d1 = GC.CollectionCount(1) - g1, d2 = GC.CollectionCount(2) - g2;
+
+        double usPer = sw.Elapsed.TotalMilliseconds * 1000.0 / reps;
+        long bytesPer = (allocAfter - allocBefore) / reps;
+        _output.WriteLine($"[{name}] {usPer:F1} us/Predict   {bytesPer:N0} bytes/Predict   " +
+            $"GC over {reps} calls: gen0={d0} gen1={d1} gen2={d2}   total alloc {(allocAfter - allocBefore) / 1024.0 / 1024.0:F1} MB");
+    }
+
+    private static Tensor<float> Rand(int[] shape, int seed)
+    {
+        var rng = new Random(seed); var t = new Tensor<float>(shape); var s = t.AsWritableSpan();
+        for (int i = 0; i < s.Length; i++) s[i] = (float)(rng.NextDouble() - 0.5);
+        return t;
+    }
+}

--- a/tests/AiDotNet.Tests/UnitTests/NeuralNetworks/CnnStemOpBreakdownBench.cs
+++ b/tests/AiDotNet.Tests/UnitTests/NeuralNetworks/CnnStemOpBreakdownBench.cs
@@ -1,0 +1,153 @@
+using System;
+using System.Collections.Generic;
+using AiDotNet.ActivationFunctions;
+using AiDotNet.Enums;
+using AiDotNet.Interfaces;
+using AiDotNet.NeuralNetworks;
+using AiDotNet.NeuralNetworks.Layers;
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.Helpers;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace AiDotNet.Tests.UnitTests.NeuralNetworks;
+
+/// <summary>
+/// Per-op breakdown of the zero-alloc CNN inference stem (option C: find the
+/// non-conv headroom). Times each step the parity CNN's <c>TryFusedConvStemPredict</c>
+/// runs — both Conv2DInto kernels, both bias/ReLU epilogues, both MaxPool2DInto, the
+/// flatten Reshape, and the dense FusedLinear — individually, vs the whole Predict, at
+/// bs1 and bs128. Reveals where the time goes once the conv kernel is fixed.
+/// Env-gated (AIDOTNET_RUN_JIT_PERF=1). Uses the exact parity shapes
+/// (1×28×28 → Conv16 → Pool → Conv32 → Pool → Flatten → Dense10).
+/// </summary>
+public class CnnStemOpBreakdownBench
+{
+    private readonly ITestOutputHelper _output;
+    public CnnStemOpBreakdownBench(ITestOutputHelper output) => _output = output;
+
+    [Fact]
+    public void Breakdown_CnnStem_PerOp()
+    {
+        if (Environment.GetEnvironmentVariable("AIDOTNET_RUN_JIT_PERF") != "1") return;
+        Run(batch: 1);
+        Run(batch: 128);
+    }
+
+    private void Run(int batch)
+    {
+        var conv1 = new ConvolutionalLayer<float>(16, 3, 1, 1, activationFunction: new ReLUActivation<float>());
+        var pool1 = new MaxPoolingLayer<float>(2, 2);
+        var conv2 = new ConvolutionalLayer<float>(32, 3, 1, 1, activationFunction: new ReLUActivation<float>());
+        var pool2 = new MaxPoolingLayer<float>(2, 2);
+        var flatten = new FlattenLayer<float>();
+        var dense = new DenseLayer<float>(10, activationFunction: (IActivationFunction<float>?)null);
+        var layers = new List<ILayer<float>> { conv1, pool1, conv2, pool2, flatten, dense };
+        var arch = new NeuralNetworkArchitecture<float>(InputType.ThreeDimensional,
+            NeuralNetworkTaskType.MultiClassClassification, inputHeight: 28, inputWidth: 28, inputDepth: 1,
+            outputSize: 10, layers: layers);
+        var model = new ConvolutionalNeuralNetwork<float>(arch);
+
+        var x = Rand(new[] { batch, 1, 28, 28 }, 1);
+        for (int i = 0; i < 50; i++) { var _ = model.Predict(x); }   // warm: materialize weights, prepack, JIT
+
+        var cpu = new CpuEngine();
+        // Scratch buffers (exactly the stem's geometry).
+        var b1 = new Tensor<float>(new[] { batch, 16, 28, 28 });   // conv1 out
+        var b2 = new Tensor<float>(new[] { batch, 16, 14, 14 });   // pool1 out
+        var b3 = new Tensor<float>(new[] { batch, 32, 14, 14 });   // conv2 out
+        var b4 = new Tensor<float>(new[] { batch, 32, 7, 7 });     // pool2 out
+        var k1 = conv1.GetFilters(); var bias1 = (float[])(object)conv1.GetBiases().GetDataArray();
+        var k2 = conv2.GetFilters(); var bias2 = (float[])(object)conv2.GetBiases().GetDataArray();
+        var w = dense.GetWeights(); var db = dense.GetBiases();
+        var b1d = (float[])(object)b1.GetDataArray();
+        var b3d = (float[])(object)b3.GetDataArray();
+        var stride = new[] { 1, 1 }; var pad = new[] { 1, 1 }; var dil = new[] { 1, 1 };
+        var flat = new Tensor<float>(new[] { batch, 32 * 7 * 7 });
+
+        double tConv1 = B(() => cpu.Conv2DInto(b1, x, k1, stride, pad, dil));
+        double tAct1 = B(() => CpuFusedOperations.ApplyBiasActivationNCHWInPlace(b1d, bias1, batch, 16, 28, 28, FusedActivationType.ReLU));
+        double tPool1 = B(() => cpu.MaxPool2DInto(b2, b1, 2, 2));
+        // Isolate kernel vs engine-wrapper: raw inline 2x2 maxpool over the same arrays.
+        var b2d = (float[])(object)b2.GetDataArray();
+        int poolC = 16, inH = 28, inW = 28, outHp = 14, outWp = 14;
+        double tPool1Raw = B(() =>
+        {
+            for (int bc = 0; bc < batch * poolC; bc++)
+            {
+                int inBase = bc * inH * inW, outBase = bc * outHp * outWp;
+                for (int oh = 0; oh < outHp; oh++)
+                {
+                    int r0 = inBase + oh * 2 * inW, r1 = r0 + inW, dst = outBase + oh * outWp;
+                    for (int ow = 0; ow < outWp; ow++)
+                    {
+                        int iw = ow * 2;
+                        float m = b1d[r0 + iw];
+                        float v = b1d[r0 + iw + 1]; if (v > m) m = v;
+                        v = b1d[r1 + iw]; if (v > m) m = v;
+                        v = b1d[r1 + iw + 1]; if (v > m) m = v;
+                        b2d[dst + ow] = m;
+                    }
+                }
+            }
+        });
+        _output.WriteLine($"  [pool1 raw-inline {tPool1Raw*1000:F2}us  engine {tPool1*1000:F2}us  b1.IsContiguous={b1.IsContiguous}]");
+        double tConv2 = B(() => cpu.Conv2DInto(b3, b2, k2, stride, pad, dil));
+        double tAct2 = B(() => CpuFusedOperations.ApplyBiasActivationNCHWInPlace(b3d, bias2, batch, 32, 14, 14, FusedActivationType.ReLU));
+        double tPool2 = B(() => cpu.MaxPool2DInto(b4, b3, 2, 2));
+        double tFlat = B(() => { var r = cpu.Reshape(b4, new[] { batch, 32 * 7 * 7 }); });
+        double tDense = B(() => { var r = cpu.FusedLinear(flat, w, db, FusedActivationType.None); });
+
+        // Manual full chain in ONE timed region — disambiguates real per-call
+        // orchestration overhead from the sum-of-per-op-minimums artifact.
+        double tChain = B(() =>
+        {
+            cpu.Conv2DInto(b1, x, k1, stride, pad, dil);
+            CpuFusedOperations.ApplyBiasActivationNCHWInPlace(b1d, bias1, batch, 16, 28, 28, FusedActivationType.ReLU);
+            cpu.MaxPool2DInto(b2, b1, 2, 2);
+            cpu.Conv2DInto(b3, b2, k2, stride, pad, dil);
+            CpuFusedOperations.ApplyBiasActivationNCHWInPlace(b3d, bias2, batch, 32, 14, 14, FusedActivationType.ReLU);
+            cpu.MaxPool2DInto(b4, b3, 2, 2);
+            var fl = cpu.Reshape(b4, new[] { batch, 32 * 7 * 7 });
+            var r = cpu.FusedLinear(fl, w, db, FusedActivationType.None);
+        });
+        double tPredict = B(() => { var _ = model.Predict(x); });
+
+        double sum = tConv1 + tAct1 + tPool1 + tConv2 + tAct2 + tPool2 + tFlat + tDense;
+        _output.WriteLine($"  [MaxDOP={AiDotNet.Tensors.Helpers.CpuParallelSettings.MaxDegreeOfParallelism}]");
+        _output.WriteLine($"=== CNN stem breakdown, batch={batch} (us, best-of) ===");
+        _output.WriteLine($"  conv1  Conv2DInto   {tConv1*1000,8:F2}");
+        _output.WriteLine($"  conv1  bias+ReLU    {tAct1*1000,8:F2}");
+        _output.WriteLine($"  pool1  MaxPool2DInto{tPool1*1000,8:F2}");
+        _output.WriteLine($"  conv2  Conv2DInto   {tConv2*1000,8:F2}");
+        _output.WriteLine($"  conv2  bias+ReLU    {tAct2*1000,8:F2}");
+        _output.WriteLine($"  pool2  MaxPool2DInto{tPool2*1000,8:F2}");
+        _output.WriteLine($"  flat   Reshape      {tFlat*1000,8:F2}");
+        _output.WriteLine($"  dense  FusedLinear  {tDense*1000,8:F2}");
+        _output.WriteLine($"  ---- sum of ops      {sum*1000,8:F2}  (sum-of-minimums; lower bound)");
+        _output.WriteLine($"  ==== manual chain    {tChain*1000,8:F2}  (real op cost, one region)");
+        _output.WriteLine($"  ==== full Predict    {tPredict*1000,8:F2}  (Predict overhead vs chain = {(tPredict-tChain)*1000:F2})");
+    }
+
+    private static double B(Action f)
+    {
+        for (int i = 0; i < 30; i++) f();
+        double best = double.MaxValue;
+        for (int r = 0; r < 400; r++)
+        {
+            var sw = System.Diagnostics.Stopwatch.StartNew();
+            f();
+            sw.Stop();
+            best = Math.Min(best, sw.Elapsed.TotalMilliseconds);
+        }
+        return best;
+    }
+
+    private static Tensor<float> Rand(int[] shape, int seed)
+    {
+        var rng = new Random(seed); var t = new Tensor<float>(shape); var s = t.AsWritableSpan();
+        for (int i = 0; i < s.Length; i++) s[i] = (float)(rng.NextDouble() - 0.5);
+        return t;
+    }
+}

--- a/tests/AiDotNet.Tests/UnitTests/NeuralNetworks/ConvNetFusedStemPredictTests.cs
+++ b/tests/AiDotNet.Tests/UnitTests/NeuralNetworks/ConvNetFusedStemPredictTests.cs
@@ -1,0 +1,65 @@
+using System;
+using AiDotNet.ActivationFunctions;
+using AiDotNet.Enums;
+using AiDotNet.Interfaces;
+using AiDotNet.NeuralNetworks;
+using AiDotNet.NeuralNetworks.Layers;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tests.UnitTests.NeuralNetworks;
+
+/// <summary>
+/// Correctness guard for the fused conv-stem Predict fast path
+/// (ConvolutionalNeuralNetwork.TryFusedConvStemPredict). On a fresh network the
+/// first Predict runs the generic per-layer Forward (conv weights still lazy, so the
+/// fused stem declines); later Predicts run the fused stem. Both must agree to
+/// floating-point rounding — the fast path changes speed, not results.
+/// </summary>
+public class ConvNetFusedStemPredictTests
+{
+    private static ConvolutionalNeuralNetwork<float> BuildCnn()
+    {
+        var layers = new System.Collections.Generic.List<ILayer<float>>
+        {
+            new ConvolutionalLayer<float>(outputDepth: 8, kernelSize: 3, stride: 1, padding: 1,
+                                          activationFunction: new ReLUActivation<float>()),
+            new MaxPoolingLayer<float>(poolSize: 2, stride: 2),
+            new ConvolutionalLayer<float>(outputDepth: 16, kernelSize: 3, stride: 1, padding: 1,
+                                          activationFunction: new ReLUActivation<float>()),
+            new MaxPoolingLayer<float>(poolSize: 2, stride: 2),
+            new FlattenLayer<float>(),
+            new DenseLayer<float>(4, activationFunction: (IActivationFunction<float>?)null),
+        };
+        var arch = new NeuralNetworkArchitecture<float>(
+            inputType: InputType.ThreeDimensional,
+            taskType: NeuralNetworkTaskType.MultiClassClassification,
+            inputHeight: 16, inputWidth: 16, inputDepth: 1,
+            outputSize: 4,
+            layers: layers);
+        return new ConvolutionalNeuralNetwork<float>(arch);
+    }
+
+    [Theory]
+    [InlineData(1)]
+    [InlineData(4)]
+    public void Predict_FusedConvStem_MatchesGenericForward(int batch)
+    {
+        var model = BuildCnn();
+        var rng = new Random(7);
+        var data = new float[batch * 1 * 16 * 16];
+        for (int i = 0; i < data.Length; i++) data[i] = (float)(rng.NextDouble() * 2 - 1);
+        var input = new Tensor<float>(data, new[] { batch, 1, 16, 16 });
+
+        var generic = model.Predict(input).ToArray();    // first call: lazy weights → generic Forward
+        var fused = model.Predict(input).ToArray();       // weights materialized → fused conv-stem
+
+        Assert.Equal(generic.Length, fused.Length);
+        double maxDiff = 0;
+        for (int i = 0; i < generic.Length; i++) maxDiff = Math.Max(maxDiff, Math.Abs(generic[i] - fused[i]));
+        Assert.True(maxDiff <= 1e-4, $"Fused conv-stem Predict diverged from generic Forward by {maxDiff:E3}");
+
+        var fused2 = model.Predict(input).ToArray();      // determinism across fused calls
+        for (int i = 0; i < fused.Length; i++) Assert.Equal(fused[i], fused2[i]);
+    }
+}

--- a/tests/AiDotNet.Tests/UnitTests/NeuralNetworks/FeedForwardCompiledMlpPredictTests.cs
+++ b/tests/AiDotNet.Tests/UnitTests/NeuralNetworks/FeedForwardCompiledMlpPredictTests.cs
@@ -1,0 +1,67 @@
+using System;
+using AiDotNet.ActivationFunctions;
+using AiDotNet.Enums;
+using AiDotNet.Interfaces;
+using AiDotNet.NeuralNetworks;
+using AiDotNet.NeuralNetworks.Layers;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tests.UnitTests.NeuralNetworks;
+
+/// <summary>
+/// Correctness guard for the float Predict → CompiledMlp fast path
+/// (FeedForwardNeuralNetwork.TryFusedDensePredict). The first Predict on a fresh
+/// network runs the generic per-layer Forward (weights are still lazy, so the fused
+/// path declines); subsequent Predicts run the CompiledMlp plan. Both must produce
+/// the same output to floating-point rounding — i.e. wiring CompiledMlp into Predict
+/// does not change results, only speed.
+/// </summary>
+public class FeedForwardCompiledMlpPredictTests
+{
+    private static FeedForwardNeuralNetwork<float> BuildMlp(int inSize, int h, int outSize)
+    {
+        var layers = new System.Collections.Generic.List<ILayer<float>>
+        {
+            new DenseLayer<float>(h, activationFunction: new ReLUActivation<float>()),
+            new DenseLayer<float>(outSize, activationFunction: (IActivationFunction<float>?)null),
+        };
+        var arch = new NeuralNetworkArchitecture<float>(
+            inputType: InputType.OneDimensional,
+            taskType: NeuralNetworkTaskType.Regression,
+            inputSize: inSize,
+            outputSize: outSize,
+            layers: layers);
+        return new FeedForwardNeuralNetwork<float>(arch);
+    }
+
+    [Theory]
+    [InlineData(1)]
+    [InlineData(8)]
+    [InlineData(32)]
+    public void Predict_CompiledMlpPath_MatchesGenericForward(int batch)
+    {
+        const int inSize = 6, h = 5, outSize = 3;
+        var model = BuildMlp(inSize, h, outSize);
+
+        var rng = new Random(123);
+        var inData = new float[batch * inSize];
+        for (int i = 0; i < inData.Length; i++) inData[i] = (float)(rng.NextDouble() * 2 - 1);
+        var input = new Tensor<float>(inData, new[] { batch, inSize });
+
+        // First call: weights are lazy → fused path declines → generic per-layer Forward.
+        var generic = model.Predict(input).ToArray();
+        // Second call: weights materialized → CompiledMlp fast path engages.
+        var compiled = model.Predict(input).ToArray();
+
+        Assert.Equal(generic.Length, compiled.Length);
+        double maxDiff = 0;
+        for (int i = 0; i < generic.Length; i++) maxDiff = Math.Max(maxDiff, Math.Abs(generic[i] - compiled[i]));
+        Assert.True(maxDiff <= 1e-4, $"CompiledMlp Predict diverged from generic Forward by {maxDiff:E3}");
+
+        // Determinism: a third call (also CompiledMlp) must equal the second exactly.
+        var compiled2 = model.Predict(input).ToArray();
+        for (int i = 0; i < compiled.Length; i++)
+            Assert.Equal(compiled[i], compiled2[i]);
+    }
+}

--- a/tests/AiDotNet.Tests/UnitTests/NeuralNetworks/FusedInferenceParityTests.cs
+++ b/tests/AiDotNet.Tests/UnitTests/NeuralNetworks/FusedInferenceParityTests.cs
@@ -1,0 +1,152 @@
+using System;
+using System.Collections.Generic;
+using AiDotNet.ActivationFunctions;
+using AiDotNet.Enums;
+using AiDotNet.Interfaces;
+using AiDotNet.NeuralNetworks;
+using AiDotNet.NeuralNetworks.Layers;
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tests.UnitTests.NeuralNetworks;
+
+/// <summary>
+/// Parity tests for the fused inference path. The fused activation kernel routed
+/// through IEngine.MlpForward must be numerically identical to the scalar
+/// activation it claims to implement (the IFusedActivation contract), and the
+/// FeedForwardNeuralNetwork.Predict fast path must not change inference results
+/// or crash on a freshly-constructed (lazily-initialized) network.
+/// </summary>
+public class FusedInferenceParityTests
+{
+    public static IEnumerable<object[]> FusedActivations() => new List<object[]>
+    {
+        new object[] { "ReLU", new ReLUActivation<float>() },
+        new object[] { "Sigmoid", new SigmoidActivation<float>() },
+        new object[] { "Tanh", new TanhActivation<float>() },
+        new object[] { "Identity", new IdentityActivation<float>() },
+        new object[] { "GELU", new GELUActivation<float>() },
+        new object[] { "Swish", new SwishActivation<float>() },
+        new object[] { "SiLU", new SiLUActivation<float>() },
+        new object[] { "LeakyReLU", new LeakyReLUActivation<float>() },
+        // Mish and ELU are intentionally excluded: the shipped Tensors
+        // FusedLinear/MlpForward path has no kernel for them (see
+        // MishAndElu_ReportNoFusedKernel below). Tracked by Tensors #499.
+    };
+
+    /// <summary>
+    /// The fused kernel for each activation's declared FusedActivationType must
+    /// equal applying that activation's own scalar Activate() to the same linear
+    /// pre-activation. Both sides share the identical x·W (computed via MlpForward
+    /// with no activation), so this isolates the activation formula.
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(FusedActivations))]
+    public void FusedActivationKernel_MatchesScalarActivation(string name, IActivationFunction<float> activation)
+    {
+        AiDotNetEngine.ResetToCpu();
+        var engine = AiDotNetEngine.Current;
+
+        Assert.True(((AiDotNet.ActivationFunctions.Fused.IFusedActivation)activation)
+            .TryGetFusedActivation(out var fusedType), $"{name} must declare a fused activation type");
+
+        const int batch = 4, inF = 16, outF = 8;
+        var rng = new Random(20260529);
+        var wData = new float[inF * outF];
+        for (int i = 0; i < wData.Length; i++) wData[i] = (float)(rng.NextDouble() * 2.0 - 1.0);
+        var w = new Tensor<float>(wData, new[] { inF, outF });
+        var xData = new float[batch * inF];
+        for (int i = 0; i < xData.Length; i++) xData[i] = (float)(rng.NextDouble() * 4.0 - 2.0);
+        var x = new Tensor<float>(xData, new[] { batch, inF });
+
+        var weights = new List<Tensor<float>> { w };
+        var noBias = new List<Tensor<float>?> { null };
+
+        // Same linear pre-activation for both sides.
+        var rawLinear = engine.MlpForward(x, weights, noBias,
+            FusedActivationType.None, FusedActivationType.None);
+        var eager = activation.Activate(rawLinear);                 // scalar activation
+        var fused = engine.MlpForward(x, weights, noBias,
+            FusedActivationType.None, fusedType);                   // fused-kernel activation
+
+        Assert.Equal(eager.Length, fused.Length);
+        for (int i = 0; i < eager.Length; i++)
+        {
+            double e = Convert.ToDouble(eager[i]);
+            double f = Convert.ToDouble(fused[i]);
+            Assert.True(Math.Abs(e - f) < 1e-4,
+                $"{name}: fused kernel {f} != scalar Activate {e} at index {i}");
+        }
+    }
+
+    /// <summary>
+    /// A parametric activation whose parameter differs from the fused kernel's
+    /// hardcoded value must report NO fused equivalent, so it stays on the exact
+    /// generic path rather than silently getting the kernel's default parameter.
+    /// </summary>
+    [Fact]
+    public void CustomParamLeakyReLU_DoesNotClaimFusedKernel()
+    {
+        var custom = new LeakyReLUActivation<float>(alpha: 0.25); // kernel hardcodes 0.01
+        Assert.False(((AiDotNet.ActivationFunctions.Fused.IFusedActivation)custom)
+            .TryGetFusedActivation(out _), "custom-slope LeakyReLU must not claim a fused kernel");
+
+        var standard = new LeakyReLUActivation<float>(); // default 0.01 == kernel
+        Assert.True(((AiDotNet.ActivationFunctions.Fused.IFusedActivation)standard)
+            .TryGetFusedActivation(out var t) && t == FusedActivationType.LeakyReLU);
+    }
+
+    /// <summary>
+    /// Mish and ELU must NOT advertise a fused kernel: the shipped Tensors
+    /// FusedLinear/MlpForward activation tables register only
+    /// None/ReLU/GELU/Sigmoid/Tanh/LeakyReLU/Swish, so routing Mish/ELU through
+    /// the fused path would throw. They stay on the exact generic path until the
+    /// kernels are added (Tensors #499). This test locks that contract so the
+    /// activations aren't silently re-wired before the kernel exists.
+    /// </summary>
+    [Fact]
+    public void MishAndElu_ReportNoFusedKernel()
+    {
+        Assert.False(new MishActivation<float>() is AiDotNet.ActivationFunctions.Fused.IFusedActivation,
+            "Mish must not claim a fused kernel — the FusedLinear path has none (Tensors #499)");
+        Assert.False(new ELUActivation<float>() is AiDotNet.ActivationFunctions.Fused.IFusedActivation,
+            "ELU must not claim a fused kernel — the FusedLinear path has none (Tensors #499)");
+    }
+
+    /// <summary>
+    /// Predict on a freshly-constructed (lazily-initialized) network must not
+    /// throw — the fused fast path bails to the generic Forward when weights
+    /// aren't materialized yet, then engages on subsequent calls. Both calls must
+    /// produce the same result.
+    /// </summary>
+    [Fact]
+    public void Predict_FreshLazyNetwork_DoesNotThrow_AndIsStable()
+    {
+        AiDotNetEngine.ResetToCpu();
+        const int inF = 16, batch = 4;
+        var arch = new NeuralNetworkArchitecture<float>(
+            inputType: InputType.OneDimensional,
+            taskType: NeuralNetworkTaskType.Regression,
+            inputSize: inF, outputSize: 4,
+            layers: new List<ILayer<float>>
+            {
+                new DenseLayer<float>(8, (IActivationFunction<float>)new ReLUActivation<float>()),
+                new DenseLayer<float>(4, (IActivationFunction<float>?)null),
+            });
+        var net = new FeedForwardNeuralNetwork<float>(arch);
+
+        var rng = new Random(7);
+        var data = new float[batch * inF];
+        for (int i = 0; i < data.Length; i++) data[i] = (float)(rng.NextDouble() * 2.0 - 1.0);
+        var input = new Tensor<float>(data, new[] { batch, inF });
+
+        var first = net.Predict(input);   // lazy weights ⇒ fused path bails to Forward
+        var second = net.Predict(input);  // weights now materialized ⇒ fused path engages
+
+        Assert.Equal(first.Length, second.Length);
+        for (int i = 0; i < first.Length; i++)
+            Assert.True(Math.Abs(Convert.ToDouble(first[i]) - Convert.ToDouble(second[i])) < 1e-4,
+                $"fused vs fallback mismatch at {i}: {first[i]} vs {second[i]}");
+    }
+}

--- a/tests/AiDotNet.Tests/UnitTests/NeuralNetworks/FusedInferenceParityTests.cs
+++ b/tests/AiDotNet.Tests/UnitTests/NeuralNetworks/FusedInferenceParityTests.cs
@@ -30,9 +30,10 @@ public class FusedInferenceParityTests
         new object[] { "Swish", new SwishActivation<float>() },
         new object[] { "SiLU", new SiLUActivation<float>() },
         new object[] { "LeakyReLU", new LeakyReLUActivation<float>() },
-        // Mish and ELU are intentionally excluded: the shipped Tensors
-        // FusedLinear/MlpForward path has no kernel for them (see
-        // MishAndElu_ReportNoFusedKernel below). Tracked by Tensors #499.
+        new object[] { "Mish", new MishActivation<float>() },
+        // ELU is intentionally excluded: the FusedLinear/MlpForward path still has
+        // no ELU kernel (see Elu_ReportsNoFusedKernel below). Mish's kernel shipped
+        // in Tensors #499 (0.90.0+), so it is now parity-checked above.
     };
 
     /// <summary>
@@ -98,20 +99,21 @@ public class FusedInferenceParityTests
     }
 
     /// <summary>
-    /// Mish and ELU must NOT advertise a fused kernel: the shipped Tensors
-    /// FusedLinear/MlpForward activation tables register only
-    /// None/ReLU/GELU/Sigmoid/Tanh/LeakyReLU/Swish, so routing Mish/ELU through
-    /// the fused path would throw. They stay on the exact generic path until the
-    /// kernels are added (Tensors #499). This test locks that contract so the
-    /// activations aren't silently re-wired before the kernel exists.
+    /// ELU must NOT advertise a fused kernel: the FusedLinear/MlpForward activation tables have no
+    /// ELU kernel, so routing it through the fused path would throw. It stays on the exact generic
+    /// path until a kernel is added. (Mish's kernel shipped in Tensors #499 / 0.90.0+, so Mish now
+    /// DOES advertise a fused kernel and is parity-checked in
+    /// <see cref="FusedActivationKernel_MatchesScalarActivation"/>.) This locks the contract so ELU
+    /// isn't silently re-wired before its kernel exists.
     /// </summary>
     [Fact]
-    public void MishAndElu_ReportNoFusedKernel()
+    public void Elu_ReportsNoFusedKernel()
     {
-        Assert.False(new MishActivation<float>() is AiDotNet.ActivationFunctions.Fused.IFusedActivation,
-            "Mish must not claim a fused kernel — the FusedLinear path has none (Tensors #499)");
         Assert.False(new ELUActivation<float>() is AiDotNet.ActivationFunctions.Fused.IFusedActivation,
-            "ELU must not claim a fused kernel — the FusedLinear path has none (Tensors #499)");
+            "ELU must not claim a fused kernel — the FusedLinear path has none");
+        // Mish, by contrast, now legitimately advertises a fused kernel (Tensors #499).
+        Assert.True(new MishActivation<float>() is AiDotNet.ActivationFunctions.Fused.IFusedActivation,
+            "Mish should claim a fused kernel — the FusedLinear Mish kernel shipped in Tensors #499 (0.90.0+)");
     }
 
     /// <summary>


### PR DESCRIPTION
**Closes #1447** (wire AIsEval fused primitives into NN layers + builder — framework side of AiDotNet.Tensors#436)
**Closes #1470** (Transformer per-call training stalls — Noam LR frozen on the fused path)

Wires AiDotNet's NN training/inference onto AiDotNet.Tensors' fused-compiled kernels (the compile-once / replay-many path the Tensors micro-benchmarks beat PyTorch-CPU on), via open/closed self-describing interfaces — no central enum whitelist to keep in sync. Found by profiling the AIsEval PyTorch-vs-AiDotNet benchmark, where every `Train()` step silently fell back to the eager tape.

## 1. Default-optimizer gate (root cause of "compiled does nothing")
`GetOrCreateBaseOptimizer` defaulted `UseAMSGrad = true` (a non-standard band-aid from #1350); the fused mapper rejected AMSGrad, so **every** default-optimizer model fell back to the eager tape — silently. Reverted to **standard Adam** (matches PyTorch/TF/Optax, all default `amsgrad=False`).

## 2. Open/closed fused dispatch (replaces type-switch + enum whitelist)
- **`IFusedOptimizerSpec`** — optimizers self-describe their `FusedOptimizerConfig`; no central catalog.
- **`IFusedActivation`** — activations self-declare their `FusedActivationType`.
- **`TryGetFusedLrSchedule`** — LR schedulers map to the per-step fused `LrSchedule` (the fused kernel evaluates `GetLr(step)` every optimizer step, exactly like PyTorch `fused=True`).

## 3. #1470 — Adam+Noam on the fused fast path (true adaptive-LR fix)
Bumped AiDotNet.Tensors 0.86.6 → **0.88.0** for `LrSchedule.Noam` (Tensors #504). `TryGetFusedLrSchedule` now maps `NoamSchedule → LrSchedule.Noam(d, warmup, factor)` (replacing an eager-fallback workaround). The default Transformer recipe (Adam β₂=0.98 + Noam) now trains on the fused path with a correct per-step warmup ramp, bit-identical to the eager schedule. Verified: a default-Noam Transformer per-call `Train` engages the fused path 3200/3200 steps and converges (PPL 5.06, top-1 7/8) instead of freezing at the uniform floor.

## 4. Proper wiring — `Predict` → `MlpForward`
`FeedForwardNeuralNetwork.Predict` runs a pure dense+fused-activation stack as one `IEngine.MlpForward` call instead of the per-layer tape walk, via the activation interface. Falls back to generic `Forward` for anything unrepresentable.

## 5. Loud fallback (observability)
The fused path silently fell back at the default diagnostic level. Now emits a one-time warning per model naming the reason (suppressible via `AIDOTNET_QUIET`).

## Coverage being completed on this branch
AiDotNet.Tensors 0.88.0 exposes **37 fused activations, 22 fused optimizers, 8 fused LR-schedule shapes**. This PR expands AiDotNet's mappings toward full coverage, each gated by a numerical-parity test (fused result == eager result within tolerance) so no optimizer/activation is wired to a kernel whose math differs:
- **Schedulers:** Constant, Cosine, Exponential, Noam, + Step / Cyclic / OneCycle / LinearWarmupCosine.
- **Optimizers:** Adam, AdamW, SGD(+momentum), + the remaining fused kernels whose AiDotNet update math matches (AMSGrad, AdaMax, Nadam, RAdam, Adagrad, RMSprop, AdaDelta, Lion, …).
- **Activations:** ReLU/Sigmoid/Tanh/Identity, + the remaining exact-equivalent fused shapes (GELU, LeakyReLU, ELU, Softplus, Mish, Swish, HardSwish/HardSigmoid/HardTanh, ReLU6, SoftSign, CELU, …).
- **Benchmarks:** AIsEval PyTorch-parity harness re-run to confirm the compiled training plan beats PyTorch compiled (`torch.compile`) on the target shapes.

Builds clean on net10.0 + net471.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Broad fused activation support and a fused MLP inference fast path.
  * Fused/compiled optimizer training paths added for many optimizers (Adam variants, SGD, RMSProp, Adagrad, AdaDelta, AdaMax, LAMB, Lion, Nadam).

* **Improvements**
  * Learning-rate schedules integrated with compiled training; improved fused-path diagnostics and fallback behavior.
  * Default Adam tuned for fused-kernel alignment.

* **Documentation**
  * Added PyTorch parity benchmark suite.

* **Tests**
  * New parity and integration tests validating fused inference and fused training.

* **Dependencies**
  * Updated native libraries to v0.90.2.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## ✅ Coverage completed + verified (parity-gated)

All wirings gated by a numerical-parity test; anything that diverged was left on eager and documented.

**LR schedulers** → `LrSchedule`: Constant, Cosine (fixed a pre-existing off-by-one), Exponential, Noam, **Step, Cyclic(triangular)**. Step-for-step parity. (OneCycle deferred — AiDotNet uses linear warmup vs the kernel's cosine.)

**Optimizers** → fused kernels (fused-vs-eager training parity, Adam as control, all maxAbsDiff=0): SGD, Adam, AdamW, AMSGrad, **AdaMax, Nadam, RMSprop, Adagrad, Lion, AdaDelta, LAMB**. Expanded the stale 4-type allowlist → 20 and generalized the per-type fallback latch. (LARS/FTRL need params the config can't carry; RAdam/ASGD/Rprop have no AiDotNet class.)

**Activations** → `FusedActivationType` (parity ≤5e-7 via identity-weight FusedLinear): added **Mish, SELU, Softplus, SoftSign, Sign, BentIdentity, Gaussian, LiSHT, SQRBF, ReLU6, HardSwish** (on top of ReLU/Sigmoid/Tanh/Identity/GELU/LeakyReLU/SiLU/Swish). The gate caught **HardSigmoid** (0.2 slope vs kernel's x/6) — left on eager. Parametric (ELU/CELU/HardTanh/…) and RReLU/softmax-family deferred (documented).

## Benchmark — vs `torch.compile` (TorchInductor), MLP CPU, steady-state

| | AiDotNet fused | torch.compile | verdict |
|---|---|---|---|
| **Training** (compiled training plan) | **~0.014 s/epoch** | ~0.084 s/epoch | **AiDotNet ~6× faster** ✅ |
| Inference (Predict latency, bs32) | p95 1.27 ms | mean 0.32 ms | torch.compile ~4× faster |

The **compiled training plan beats `torch.compile`** (~6×, and ~15× over AiDotNet eager). Inference-latency vs TorchInductor is an honest remaining gap. Harness: `benchmarks/AiDotNet.PyTorchParity` (now with `--compile`).
