### PR TITLE
perf(inference): freeze-time BatchNorm folding (Conv/Dense → BN) — Phase 6

### DIFF
--- a/src/Configuration/InferenceOptimizationConfig.cs
+++ b/src/Configuration/InferenceOptimizationConfig.cs
@@ -547,6 +547,28 @@ public class InferenceOptimizationConfig
         }
     }
 
+    /// <summary>
+    /// Gets or sets whether freeze-time layer fusion (BatchNorm folding) is applied
+    /// when optimizing a model for inference. Default: <c>true</c>.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// At inference a <c>BatchNormalization</c> layer is a fixed per-channel affine
+    /// transform: <c>y = γ·(x − μ)/√(σ² + ε) + β</c>. When it directly follows a
+    /// linear op with identity activation (the canonical Conv→BN→activation block in
+    /// ResNet/VGG/EfficientNet), it can be folded into that op's weights and bias with
+    /// no change in output: <c>W' = W·s</c>, <c>b' = (b − μ)·s + β</c> where
+    /// <c>s = γ/√(σ² + ε)</c>. The BatchNorm layer is then removed, eliminating a full
+    /// per-element pass and an intermediate tensor per such block.
+    /// </para>
+    /// <para><b>For Beginners:</b> This makes a trained CNN faster at prediction time
+    /// by absorbing the (now-constant) batch-norm math into the convolution itself.
+    /// It's lossless — the predictions are identical (to floating-point rounding) — so
+    /// it's enabled by default. It only triggers on models built for it (a convolution
+    /// with no activation, immediately followed by batch-norm).</para>
+    /// </remarks>
+    public bool EnableLayerFusion { get; set; } = true;
+
     #endregion
 }
 

--- a/src/Inference/InferenceOptimizer.cs
+++ b/src/Inference/InferenceOptimizer.cs
@@ -104,10 +104,13 @@ internal class InferenceOptimizer<T>
 
         _config.Validate();
 
-        // Clone only when we might rewrite layers; otherwise keep original reference.
+        // Clone only when we might mutate layers; otherwise keep original reference.
+        // Layer fusion (BatchNorm folding) rewrites conv weights in place and drops
+        // the BN layer, so it also requires a clone to avoid mutating the user's model.
         bool mayRewriteAttention = _config.EnableFlashAttention || _config.EnableKVCache || _config.EnableWeightOnlyQuantization;
+        bool mayFoldLayers = _config.EnableLayerFusion && HasFoldableBatchNorm(model);
         var workingModel = model;
-        if (cloneModel && mayRewriteAttention && HasOptimizableAttentionLayers(model))
+        if (cloneModel && ((mayRewriteAttention && HasOptimizableAttentionLayers(model)) || mayFoldLayers))
         {
             try
             {
@@ -130,12 +133,47 @@ internal class InferenceOptimizer<T>
 
         ResolveLazyLayers(workingModel);
 
-        bool anyApplied = ApplyAttentionOptimizations(workingModel);
+        bool anyApplied = ApplyLayerFusion(workingModel);
+        anyApplied |= ApplyAttentionOptimizations(workingModel);
         InferenceDiagnostics.RecordDecision("InferenceOptimizer", "AttentionRewrites", enabled: anyApplied, reason: anyApplied ? "Applied" : "NoApplicableLayersOrDisabled");
         anyApplied |= ApplyWeightOnlyQuantization(workingModel);
         anyApplied |= Initialize(workingModel);
 
         return (workingModel, anyApplied);
+    }
+
+    /// <summary>
+    /// Freeze-time layer fusion: folds BatchNorm into a preceding identity-activation
+    /// linear op (Conv→BN). Lossless at inference; eliminates the BN layer. Runs
+    /// before attention rewrites / quantization so the folded weights flow into them.
+    /// </summary>
+    private bool ApplyLayerFusion(NeuralNetworkBase<T> model)
+    {
+        if (!_config.EnableLayerFusion)
+        {
+            InferenceDiagnostics.RecordDecision("InferenceOptimizer", "LayerFusion", enabled: false, reason: "DisabledByConfig");
+            return false;
+        }
+
+        int folded = model.FoldBatchNormForInference();
+        InferenceDiagnostics.RecordDecision("InferenceOptimizer", "LayerFusion",
+            enabled: folded > 0, reason: folded > 0 ? $"FoldedBatchNorm({folded})" : "NoFoldableBatchNorm");
+        return folded > 0;
+    }
+
+    /// <summary>True if the model has a BatchNorm layer directly after an
+    /// identity-activation convolution — the pattern <see cref="ApplyLayerFusion"/>
+    /// can fold. Used to decide whether a clone is needed before mutating.</summary>
+    private static bool HasFoldableBatchNorm(NeuralNetworkBase<T> model)
+    {
+        var layers = model.Layers;
+        for (int i = 1; i < layers.Count; i++)
+        {
+            if (layers[i] is BatchNormalizationLayer<T>
+                && (layers[i - 1] is ConvolutionalLayer<T> || layers[i - 1] is DenseLayer<T>))
+                return true;
+        }
+        return false;
     }
 
     /// <summary>

--- a/src/NeuralNetworks/NeuralNetworkBase.cs
+++ b/src/NeuralNetworks/NeuralNetworkBase.cs
@@ -11,6 +11,7 @@ using AiDotNet.MixedPrecision;
 // repo asked for in ooples/AiDotNet.Tensors#276). Alias the local one to a
 // distinct name so the two coexist without ambiguity at every reference.
 using LocalMixedPrecisionConfig = AiDotNet.MixedPrecision.MixedPrecisionConfig;
+using AiDotNet.ActivationFunctions;
 using AiDotNet.NeuralNetworks.Layers;
 using AiDotNet.Optimizers;
 using AiDotNet.Tensors.Engines;
@@ -2011,6 +2012,150 @@ public abstract class NeuralNetworkBase<T> : INeuralNetworkModel<T>, IInterpreta
             InvalidateParameterCountCache();
         }
         return removed;
+    }
+
+    /// <summary>
+    /// Freeze-time BatchNorm folding (compiled-inference, Phase 6). Folds every
+    /// <see cref="BatchNormalizationLayer{T}"/> that directly follows a linear op
+    /// with identity activation (a <see cref="ConvolutionalLayer{T}"/> here) into
+    /// that op's weights and bias, then removes the BatchNorm layer. At inference a
+    /// BatchNorm is the fixed per-channel affine
+    /// <c>y = γ·(x − μ)/√(σ² + ε) + β</c>; for the preceding linear
+    /// <c>z = W·x + b</c> the composition <c>BN(z)</c> equals
+    /// <c>W'·x + b'</c> with per-output-channel <c>s = γ/√(σ² + ε)</c>,
+    /// <c>W' = W·s</c>, <c>b' = (b − μ)·s + β</c> — so folding is lossless (to
+    /// floating-point rounding) and eliminates a full per-element pass plus an
+    /// intermediate tensor per block.
+    ///
+    /// <para><b>Safety:</b> only folds when the preceding layer's activation is the
+    /// identity (no activation, or <see cref="IdentityActivation{T}"/>) — BatchNorm
+    /// must sit directly on the linear output, before any nonlinearity, or the fold
+    /// is invalid. Channel counts must match. Anything else is left untouched.</para>
+    /// </summary>
+    /// <returns>The number of BatchNorm layers folded (0 if none applicable).</returns>
+    internal int FoldBatchNormForInference()
+    {
+        int folded = 0;
+        // Walk back-to-front so removing a BN doesn't shift the indices of layers
+        // we still have to examine.
+        for (int i = _layers.Count - 1; i >= 1; i--)
+        {
+            if (_layers[i] is not BatchNormalizationLayer<T> bn)
+                continue;
+            var prev = _layers[i - 1];
+            if (!IsIdentityActivation(prev))
+                continue;
+            bool didFold = prev switch
+            {
+                ConvolutionalLayer<T> conv => TryFoldBatchNormIntoConv(conv, bn),
+                DenseLayer<T> dense => TryFoldBatchNormIntoDense(dense, bn),
+                _ => false,
+            };
+            if (didFold)
+            {
+                RemoveLayerFromCollection(bn);
+                folded++;
+            }
+        }
+        return folded;
+    }
+
+    /// <summary>A layer's activation is the identity iff it applies no activation
+    /// or an <see cref="IdentityActivation{T}"/> (folding across a real nonlinearity
+    /// would be incorrect).</summary>
+    private static bool IsIdentityActivation(ILayer<T> layer)
+    {
+        if (layer is not LayerBase<T> lb)
+            return false;
+        bool scalarOk = lb.ScalarActivation is null || lb.ScalarActivation is IdentityActivation<T>;
+        bool vectorOk = lb.VectorActivation is null;
+        return scalarOk && vectorOk;
+    }
+
+    /// <summary>
+    /// Folds <paramref name="bn"/>'s inference affine into <paramref name="conv"/>'s
+    /// kernels/biases in place. Kernel layout is <c>[outChannels, inChannels, kH, kW]</c>;
+    /// the BatchNorm operates per output channel. Returns false (folding nothing) when
+    /// the channel counts don't line up.
+    /// </summary>
+    private bool TryFoldBatchNormIntoConv(ConvolutionalLayer<T> conv, BatchNormalizationLayer<T> bn)
+    {
+        var kernels = conv.GetFilters();   // live [outC, inC, kH, kW]
+        var biases = conv.GetBiases();     // live [outC]
+        int outC = kernels.Shape[0];
+        if (biases.Length != outC) return false;
+
+        var gamma = bn.GetGamma();
+        var beta = bn.GetBeta();
+        var mean = bn.GetRunningMean();
+        var variance = bn.GetRunningVariance();
+        if (gamma.Length != outC || beta.Length != outC || mean.Length != outC || variance.Length != outC)
+            return false;
+
+        T eps = bn.GetEpsilon();
+        int perChannel = kernels.Length / outC;   // inC * kH * kW
+        var kSpan = kernels.Data.Span;
+        var bSpan = biases.Data.Span;
+        var gSpan = gamma.Data.Span;
+        var beSpan = beta.Data.Span;
+        var mSpan = mean.Data.Span;
+        var vSpan = variance.Data.Span;
+
+        for (int oc = 0; oc < outC; oc++)
+        {
+            // s = γ / sqrt(var + ε);  W'[oc] = W[oc]·s;  b'[oc] = (b[oc] − μ)·s + β
+            T denom = NumOps.Sqrt(NumOps.Add(vSpan[oc], eps));
+            T scale = NumOps.Divide(gSpan[oc], denom);
+            int baseIdx = oc * perChannel;
+            for (int j = 0; j < perChannel; j++)
+                kSpan[baseIdx + j] = NumOps.Multiply(kSpan[baseIdx + j], scale);
+            bSpan[oc] = NumOps.Add(NumOps.Multiply(NumOps.Subtract(bSpan[oc], mSpan[oc]), scale), beSpan[oc]);
+        }
+        return true;
+    }
+
+    /// <summary>
+    /// Folds <paramref name="bn"/>'s inference affine into <paramref name="dense"/>'s
+    /// weights/biases in place. Weight layout is <c>[inputSize, outputSize]</c> and the
+    /// BatchNorm operates per output feature, so the scale for output <c>oc</c> multiplies
+    /// column <c>oc</c> of the weight matrix (stride <c>outputSize</c>). Returns false when
+    /// the feature counts don't line up.
+    /// </summary>
+    private bool TryFoldBatchNormIntoDense(DenseLayer<T> dense, BatchNormalizationLayer<T> bn)
+    {
+        var weights = dense.GetWeights();   // live [inputSize, outputSize]
+        var biases = dense.GetBiases();     // live [outputSize]
+        if (weights.Rank != 2) return false;
+        int inSize = weights.Shape[0];
+        int outSize = weights.Shape[1];
+        if (biases.Length != outSize) return false;
+
+        var gamma = bn.GetGamma();
+        var beta = bn.GetBeta();
+        var mean = bn.GetRunningMean();
+        var variance = bn.GetRunningVariance();
+        if (gamma.Length != outSize || beta.Length != outSize || mean.Length != outSize || variance.Length != outSize)
+            return false;
+
+        T eps = bn.GetEpsilon();
+        var wSpan = weights.Data.Span;
+        var bSpan = biases.Data.Span;
+        var gSpan = gamma.Data.Span;
+        var beSpan = beta.Data.Span;
+        var mSpan = mean.Data.Span;
+        var vSpan = variance.Data.Span;
+
+        for (int oc = 0; oc < outSize; oc++)
+        {
+            T scale = NumOps.Divide(gSpan[oc], NumOps.Sqrt(NumOps.Add(vSpan[oc], eps)));
+            for (int i = 0; i < inSize; i++)
+            {
+                int idx = i * outSize + oc;   // row-major [inputSize, outputSize]
+                wSpan[idx] = NumOps.Multiply(wSpan[idx], scale);
+            }
+            bSpan[oc] = NumOps.Add(NumOps.Multiply(NumOps.Subtract(bSpan[oc], mSpan[oc]), scale), beSpan[oc]);
+        }
+        return true;
     }
 
     /// <summary>

--- a/tests/AiDotNet.Tests/UnitTests/Inference/ConvBatchNormFoldTests.cs
+++ b/tests/AiDotNet.Tests/UnitTests/Inference/ConvBatchNormFoldTests.cs
@@ -1,0 +1,229 @@
+using System;
+using AiDotNet.ActivationFunctions;
+using AiDotNet.Configuration;
+using AiDotNet.Enums;
+using AiDotNet.Inference;
+using AiDotNet.Interfaces;
+using AiDotNet.NeuralNetworks;
+using AiDotNet.NeuralNetworks.Layers;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tests.UnitTests.Inference;
+
+/// <summary>
+/// Phase 6 (freeze-time super-folding): verifies that
+/// <c>InferenceOptimizer</c> folds a <c>Conv2D(identity)→BatchNorm</c> block into
+/// the convolution's weights/bias and removes the BatchNorm layer, with the
+/// inference output unchanged (lossless to floating-point rounding). Folding is
+/// the canonical ResNet/VGG inference optimization: at inference BatchNorm is a
+/// fixed per-channel affine, so <c>BN(Conv(x)) = Conv'(x)</c> for adjusted
+/// weights/bias.
+/// </summary>
+public class ConvBatchNormFoldTests
+{
+    private static ConvolutionalNeuralNetwork<float> BuildConvBnModel()
+    {
+        // Conv2D(2→8, 3×3, pad 1, IDENTITY activation) → BatchNorm(8) → Flatten → Dense(4).
+        // The conv must have identity activation for the fold to be valid (BN sits
+        // directly on the linear conv output, before any nonlinearity).
+        var layers = new System.Collections.Generic.List<ILayer<float>>
+        {
+            new ConvolutionalLayer<float>(outputDepth: 8, kernelSize: 3, stride: 1, padding: 1,
+                                          activationFunction: new IdentityActivation<float>()),
+            new BatchNormalizationLayer<float>(),
+            new FlattenLayer<float>(),
+            new DenseLayer<float>(4, activationFunction: (IActivationFunction<float>?)null),
+        };
+        var arch = new NeuralNetworkArchitecture<float>(
+            inputType: InputType.ThreeDimensional,
+            taskType: NeuralNetworkTaskType.MultiClassClassification,
+            inputHeight: 6, inputWidth: 6, inputDepth: 2,
+            outputSize: 4,
+            layers: layers);
+        return new ConvolutionalNeuralNetwork<float>(arch);
+    }
+
+    private static Tensor<float> RandomInput(Random rng, int batch = 1)
+    {
+        var data = new float[batch * 2 * 6 * 6];
+        for (int i = 0; i < data.Length; i++) data[i] = (float)(rng.NextDouble() * 2.0 - 1.0);
+        return new Tensor<float>(data, new[] { batch, 2, 6, 6 });
+    }
+
+    // Accumulate non-trivial BatchNorm running mean/variance by pushing a few
+    // random batches through the layer stack in training mode (BN updates its
+    // running stats via momentum on each training forward). No reflection, no
+    // full Train() stack — just the public Layer.Forward path.
+    private static void WarmBatchNormStats(ConvolutionalNeuralNetwork<float> model, Random rng)
+    {
+        model.SetTrainingMode(true);
+        for (int step = 0; step < 8; step++)
+        {
+            Tensor<float> t = RandomInput(rng, batch: 4);
+            foreach (var layer in model.Layers)
+                t = layer.Forward(t);
+        }
+        model.SetTrainingMode(false);
+    }
+
+    [Fact]
+    public void FoldBatchNorm_RemovesLayer_AndPreservesOutput()
+    {
+        var rng = new Random(20260530);
+        var model = BuildConvBnModel();
+
+        // Give gamma/beta non-trivial values (default gamma=1, beta=0 would make BN
+        // a pure normalization — set them so the fold exercises the affine too).
+        var bn = (BatchNormalizationLayer<float>)model.Layers[1];
+        var p = bn.GetParameters();
+        for (int i = 0; i < p.Length; i++) p[i] = (float)(rng.NextDouble() * 1.5 + 0.25); // gamma then beta, all > 0
+        bn.SetParameters(p);
+
+        WarmBatchNormStats(model, rng);
+
+        // Reference output BEFORE folding (inference mode → BN uses running stats).
+        var x = RandomInput(rng);
+        var reference = model.Predict(x).ToArray();
+        Assert.Contains(model.Layers, l => l is BatchNormalizationLayer<float>);
+
+        // Fold via the inference optimizer (no clone — mutate this instance).
+        var config = new InferenceOptimizationConfig
+        {
+            EnableLayerFusion = true,
+            EnableKVCache = false,
+            EnableFlashAttention = false,
+            EnableSpeculativeDecoding = false,
+            EnableWeightOnlyQuantization = false,
+        };
+        var optimizer = new InferenceOptimizer<float>(config);
+        var (optimized, anyApplied) = optimizer.OptimizeForInference(model, cloneModel: false);
+
+        Assert.True(anyApplied, "Expected layer fusion to apply (Conv→BN present).");
+        Assert.DoesNotContain(optimized.Layers, l => l is BatchNormalizationLayer<float>);
+
+        // Folded output must match the pre-fold reference (lossless).
+        var folded = optimized.Predict(x).ToArray();
+        Assert.Equal(reference.Length, folded.Length);
+        double maxDiff = 0;
+        for (int i = 0; i < reference.Length; i++)
+            maxDiff = Math.Max(maxDiff, Math.Abs(reference[i] - folded[i]));
+        Assert.True(maxDiff <= 1e-4, $"Folded output diverged from reference by {maxDiff:E3}");
+    }
+
+    [Fact]
+    public void FoldBatchNorm_Disabled_LeavesModelUnchanged()
+    {
+        var model = BuildConvBnModel();
+        int bnBefore = model.Layers.FindAll(l => l is BatchNormalizationLayer<float>).Count;
+
+        var config = new InferenceOptimizationConfig
+        {
+            EnableLayerFusion = false,
+            EnableKVCache = false,
+            EnableFlashAttention = false,
+            EnableSpeculativeDecoding = false,
+            EnableWeightOnlyQuantization = false,
+        };
+        var optimizer = new InferenceOptimizer<float>(config);
+        var (optimized, _) = optimizer.OptimizeForInference(model, cloneModel: false);
+
+        int bnAfter = optimized.Layers.FindAll(l => l is BatchNormalizationLayer<float>).Count;
+        Assert.Equal(bnBefore, bnAfter);   // fusion off → BN retained
+        Assert.True(bnAfter > 0);
+    }
+
+    [Fact]
+    public void FoldBatchNorm_IntoDense_PreservesOutput()
+    {
+        var rng = new Random(20260601);
+        // Dense(16→8, IDENTITY) → BatchNorm → Dense(4). BN folds into the first Dense.
+        var layers = new System.Collections.Generic.List<ILayer<float>>
+        {
+            new DenseLayer<float>(8, activationFunction: new IdentityActivation<float>()),
+            new BatchNormalizationLayer<float>(),
+            new DenseLayer<float>(4, activationFunction: (IActivationFunction<float>?)null),
+        };
+        var arch = new NeuralNetworkArchitecture<float>(
+            inputType: InputType.OneDimensional,
+            taskType: NeuralNetworkTaskType.MultiClassClassification,
+            inputSize: 16,
+            outputSize: 4,
+            layers: layers);
+        var model = new FeedForwardNeuralNetwork<float>(arch);
+
+        var bn = (BatchNormalizationLayer<float>)model.Layers[1];
+        var p = bn.GetParameters();
+        for (int i = 0; i < p.Length; i++) p[i] = (float)(rng.NextDouble() * 1.5 + 0.25);
+        bn.SetParameters(p);
+
+        // Warm BN running stats with a few training-mode forwards.
+        model.SetTrainingMode(true);
+        for (int step = 0; step < 8; step++)
+        {
+            var dd = new float[4 * 16];
+            for (int i = 0; i < dd.Length; i++) dd[i] = (float)(rng.NextDouble() * 2.0 - 1.0);
+            Tensor<float> t = new Tensor<float>(dd, new[] { 4, 16 });
+            foreach (var layer in model.Layers) t = layer.Forward(t);
+        }
+        model.SetTrainingMode(false);
+
+        var xd = new float[16];
+        for (int i = 0; i < xd.Length; i++) xd[i] = (float)(rng.NextDouble() * 2.0 - 1.0);
+        var x = new Tensor<float>(xd, new[] { 1, 16 });
+        var reference = model.Predict(x).ToArray();
+
+        var config = new InferenceOptimizationConfig
+        {
+            EnableLayerFusion = true,
+            EnableKVCache = false,
+            EnableFlashAttention = false,
+            EnableSpeculativeDecoding = false,
+            EnableWeightOnlyQuantization = false,
+        };
+        var (optimized, anyApplied) = new InferenceOptimizer<float>(config).OptimizeForInference(model, cloneModel: false);
+
+        Assert.True(anyApplied);
+        Assert.DoesNotContain(optimized.Layers, l => l is BatchNormalizationLayer<float>);
+        var folded = optimized.Predict(x).ToArray();
+        double maxDiff = 0;
+        for (int i = 0; i < reference.Length; i++) maxDiff = Math.Max(maxDiff, Math.Abs(reference[i] - folded[i]));
+        Assert.True(maxDiff <= 1e-4, $"Dense→BN folded output diverged by {maxDiff:E3}");
+    }
+
+    [Fact]
+    public void FoldBatchNorm_SkipsWhenConvHasNonIdentityActivation()
+    {
+        // Conv with ReLU activation followed by BN: folding would be INVALID
+        // (a nonlinearity sits between the linear op and BN), so it must be skipped.
+        var layers = new System.Collections.Generic.List<ILayer<float>>
+        {
+            new ConvolutionalLayer<float>(outputDepth: 8, kernelSize: 3, stride: 1, padding: 1,
+                                          activationFunction: new ReLUActivation<float>()),
+            new BatchNormalizationLayer<float>(),
+            new FlattenLayer<float>(),
+            new DenseLayer<float>(4, activationFunction: (IActivationFunction<float>?)null),
+        };
+        var arch = new NeuralNetworkArchitecture<float>(
+            inputType: InputType.ThreeDimensional,
+            taskType: NeuralNetworkTaskType.MultiClassClassification,
+            inputHeight: 6, inputWidth: 6, inputDepth: 2,
+            outputSize: 4,
+            layers: layers);
+        var model = new ConvolutionalNeuralNetwork<float>(arch);
+
+        var config = new InferenceOptimizationConfig
+        {
+            EnableLayerFusion = true,
+            EnableKVCache = false,
+            EnableFlashAttention = false,
+            EnableSpeculativeDecoding = false,
+            EnableWeightOnlyQuantization = false,
+        };
+        var optimizer = new InferenceOptimizer<float>(config);
+        var (optimized, _) = optimizer.OptimizeForInference(model, cloneModel: false);
+
+        // ReLU between conv and BN → fold must NOT fire; BN stays.
+        Assert.Contains(optimized.Layers, l => l is BatchNormalizationLayer<float>);
+    }
+}


### PR DESCRIPTION
## Phase 6 — freeze-time super-folding (compiled-inference plan)

Folds inference-time **BatchNorm into a preceding identity-activation linear op** and removes the BN layer — the canonical ResNet/VGG/EfficientNet inference optimization, extended to Dense→BN.

### What
At inference BatchNorm is a fixed per-channel affine `y = γ·(x−μ)/√(σ²+ε) + β`. Directly after a linear `z = W·x + b` (identity activation), `BN(z) = W'·x + b'` with `s = γ/√(σ²+ε)`, `W' = W·s`, `b' = (b−μ)·s + β`. Lossless; eliminates a per-element pass + an intermediate tensor per block.

- `NeuralNetworkBase.FoldBatchNormForInference()` — folds `Conv2D→BN` (per output channel) and `Dense→BN` (per output feature) in place, then removes the BN layer. Guards: only folds across **identity/no activation**, and on matching channel counts.
- `InferenceOptimizer.OptimizeForInference` gains an `ApplyLayerFusion` step (before attention rewrites / quantization), gated by `InferenceOptimizationConfig.EnableLayerFusion` (default **true** — lossless). Clone-before-mutate now also triggers for foldable Conv/Dense→BN.

### Verification
`ConvBatchNormFoldTests` (4 cases, all green):
- Conv→BN and Dense→BN fold reproduce the pre-fold output within `1e-4` (non-trivial γ/β + running μ/σ² warmed by training-mode forwards), BN removed.
- Fusion-off retains BN; `Conv(ReLU)→BN` is correctly left unfolded.
- All 30 existing `InferenceOptimizer` tests pass. net10.0 + net471 build clean.

Note: triggers only on models built for it (linear op with no activation immediately followed by BatchNorm) — targets BN-heavy backbones (ResNet/EfficientNet/CSPDarknet); the parity-benchmark MLP/CNN have no BN.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added layer fusion optimization for inference models, reducing model complexity while preserving accuracy. Users can enable or disable this optimization via a new configuration setting (enabled by default).

* **Tests**
  * Added comprehensive test coverage for layer fusion optimization across different model architectures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->