### PR TITLE
docs(serving): startup CPU-inference BLAS thread-pin recommendation

### DIFF
--- a/src/AiDotNet.Serving/Services/ModelStartupService.cs
+++ b/src/AiDotNet.Serving/Services/ModelStartupService.cs
@@ -70,6 +70,8 @@ public class ModelStartupService : IHostedService
     /// <param name="cancellationToken">Cancellation token.</param>
     public async Task StartAsync(CancellationToken cancellationToken)
     {
+        LogCpuInferenceThreadRecommendation();
+
         if (_options.StartupModels == null || _options.StartupModels.Count == 0)
         {
             _logger.LogInformation("No startup models configured");
@@ -109,6 +111,39 @@ public class ModelStartupService : IHostedService
         {
             _logger.LogWarning("{Failed} startup model(s) failed to load. Check configuration and file paths.",
                 failedCount);
+        }
+    }
+
+    /// <summary>
+    /// Logs the one-time CPU-inference thread-pin recommendation. All-core BLAS
+    /// saturates large batch/training GEMMs but oversubscribes the small-batch,
+    /// wide-but-short GEMMs typical of latency-sensitive serving — measured ~1.3×
+    /// faster on the wide layers at <c>ProcessorCount/2</c> threads. The pin must be
+    /// applied ONCE at process start (changing the BLAS thread count later rebuilds
+    /// the thread pool), so it's an operator/deployment action, not something this
+    /// service flips at runtime. We surface the recommendation and report whether a
+    /// thread cap is already in effect via the standard env vars.
+    /// </summary>
+    private void LogCpuInferenceThreadRecommendation()
+    {
+        string? omp = Environment.GetEnvironmentVariable("OMP_NUM_THREADS");
+        string? openblas = Environment.GetEnvironmentVariable("OPENBLAS_NUM_THREADS");
+        int recommended = Math.Max(1, Environment.ProcessorCount / 2);
+
+        if (!string.IsNullOrWhiteSpace(omp) || !string.IsNullOrWhiteSpace(openblas))
+        {
+            _logger.LogInformation(
+                "CPU inference: native BLAS thread cap detected (OMP_NUM_THREADS={Omp}, OPENBLAS_NUM_THREADS={OpenBlas}) on a {Cores}-core host.",
+                omp ?? "unset", openblas ?? "unset", Environment.ProcessorCount);
+        }
+        else
+        {
+            _logger.LogInformation(
+                "CPU inference latency tip: BLAS threads are uncapped on this {Cores}-core host. For low-latency " +
+                "small-batch serving, pin them to ~{Recommended} (≈cores/2) before launch — e.g. set OMP_NUM_THREADS={Recommended} " +
+                "(and OPENBLAS_NUM_THREADS={Recommended}) — or call AiDotNet.Tensors.CpuInferenceConfig.PinBlasThreadsForLatency() " +
+                "once at startup. Measured ~1.3× faster on wide inference GEMMs; all-core oversubscribes small-batch work.",
+                Environment.ProcessorCount, recommended, recommended, recommended);
         }
     }
 


### PR DESCRIPTION
## Startup thread-pin recommendation (Phase 7F follow-through)

The Phase-7F GEMM autotune probe found native BLAS at **`ProcessorCount/2` threads beats all-core by ~1.3×** on the small-batch, wide-but-short GEMMs typical of latency-sensitive inference (e.g. a classifier head's 784→512 layer). All-core saturates large batch/training GEMMs but **oversubscribes** small-batch work.

Crucially, the win is only realizable by **pinning the count once at process start** — changing the BLAS thread count at runtime rebuilds the thread pool (~700 µs), so per-call tuning backfires. That makes it an operator/deployment action, not a per-request toggle.

**This PR** has `ModelStartupService` log the recommendation once at host start:
- If a cap is already set (`OMP_NUM_THREADS` / `OPENBLAS_NUM_THREADS`), it reports it.
- Otherwise it nudges the operator to pin to ~cores/2 before launch (env var), or call `AiDotNet.Tensors.CpuInferenceConfig.PinBlasThreadsForLatency()` once at startup (the public knob added in AiDotNet.Tensors), with the measured rationale.

Informational only — it does **not** mutate global thread state itself, avoiding both the per-call pool rebuild and surprising other in-process OpenMP work.

Companion: the actionable `CpuInferenceConfig.PinBlasThreadsForLatency()` API lands in AiDotNet.Tensors PR #513; once released and bumped here, the serving host can call it directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Application startup now logs CPU inference BLAS thread recommendations. The service checks for existing thread configurations and suggests optimal thread allocation to improve CPU inference performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->