### PR TITLE
perf(#1458): fast-path single-call Vector SafetyFilter input/output paths

### DIFF
--- a/src/Models/Results/AiModelResult.cs
+++ b/src/Models/Results/AiModelResult.cs
@@ -1932,19 +1932,34 @@ public partial class AiModelResult<T, TInput, TOutput> : IFullModel<T, TInput, T
         var dataForPrediction = newData;
         if (SafetyFilter != null && newData is Vector<T> vectorInput && typeof(TInput) == typeof(Vector<T>))
         {
-            var validation = SafetyFilter.ValidateInput(vectorInput);
-            if (!validation.IsValid)
+            // Fast path for the default numeric SafetyFilter — single-call analog of the
+            // ValidateAndSanitizeMatrix fast path (#1447 / #1458). SafetyFilter<T>.ValidateInput
+            // builds a ConvertToText string over every element THREE times (directly + inside
+            // DetectJailbreak + IdentifyHarmfulContent) then runs English-phrase jailbreak/
+            // harmful-content regexes that can never match numeric stringifications. The only
+            // verdicts that apply to a numeric input vector are input-length and finiteness;
+            // when the vector is within MaxInputLength and all-finite, ValidateInput returns
+            // IsValid with no sanitization (the default filter never sets SanitizedInput), so
+            // the per-call text scan is pure cost. Skip it for clean data; any violation falls
+            // through to the full ValidateInput so the exact diagnostic/throw is preserved.
+            // Custom ISafetyFilter implementations always take the per-call path below.
+            if (!(SafetyFilter is SafetyFilter<T> defaultInputFilter
+                  && IsCleanForDefaultVectorInputFilter(vectorInput, defaultInputFilter)))
             {
-                var issues = validation.Issues.Count > 0
-                    ? string.Join("; ", validation.Issues.Select(i => $"{i.Type}:{i.Severity}"))
-                    : "Unknown safety validation failure.";
-                throw new InvalidOperationException($"Safety validation failed: {issues}");
-            }
+                var validation = SafetyFilter.ValidateInput(vectorInput);
+                if (!validation.IsValid)
+                {
+                    var issues = validation.Issues.Count > 0
+                        ? string.Join("; ", validation.Issues.Select(i => $"{i.Type}:{i.Severity}"))
+                        : "Unknown safety validation failure.";
+                    throw new InvalidOperationException($"Safety validation failed: {issues}");
+                }
 
-            if (validation.SanitizedInput != null)
-            {
-                var sanitized = validation.SanitizedInput;
-                dataForPrediction = Unsafe.As<Vector<T>, TInput>(ref sanitized);
+                if (validation.SanitizedInput != null)
+                {
+                    var sanitized = validation.SanitizedInput;
+                    dataForPrediction = Unsafe.As<Vector<T>, TInput>(ref sanitized);
+                }
             }
         }
         else if (SafetyFilter != null && newData is Matrix<T> matrixInput && typeof(TInput) == typeof(Matrix<T>))
@@ -2026,11 +2041,22 @@ public partial class AiModelResult<T, TInput, TOutput> : IFullModel<T, TInput, T
 
         if (SafetyFilter != null && denormalized is Vector<T> vectorOutput && typeof(TOutput) == typeof(Vector<T>))
         {
-            var filtered = SafetyFilter.FilterOutput(vectorOutput);
-            if (filtered.WasModified || !filtered.IsSafe)
+            // Fast path for the default numeric SafetyFilter — single-call analog of the
+            // FilterMatrixOutput fast path (#1447 / #1458). SafetyFilter<T>.FilterOutput's
+            // only check is IdentifyHarmfulContent, which stringifies the vector
+            // (ConvertToText) and regex-matches English harmful-content phrases —
+            // meaningless on a numeric prediction vector, so it never modifies numeric
+            // output (a match would have been a spurious false-positive block). Skip the
+            // ConvertToText + regex for the default filter and return the output unchanged.
+            // Custom ISafetyFilter implementations keep the per-call path.
+            if (SafetyFilter is not SafetyFilter<T>)
             {
-                var filteredOutput = filtered.FilteredOutput;
-                return Unsafe.As<Vector<T>, TOutput>(ref filteredOutput);
+                var filtered = SafetyFilter.FilterOutput(vectorOutput);
+                if (filtered.WasModified || !filtered.IsSafe)
+                {
+                    var filteredOutput = filtered.FilteredOutput;
+                    return Unsafe.As<Vector<T>, TOutput>(ref filteredOutput);
+                }
             }
         }
         else if (SafetyFilter != null && denormalized is Matrix<T> matrixOutput && typeof(TOutput) == typeof(Matrix<T>))
@@ -2162,6 +2188,42 @@ public partial class AiModelResult<T, TInput, TOutput> : IFullModel<T, TInput, T
         }
 
         return Helpers.OptimizerHelper<T, TInput, TOutput>.SelectFeatures(input, featureIndices);
+    }
+
+    /// <summary>
+    /// Returns true when the default numeric <see cref="SafetyFilter{T}"/> would pass
+    /// <paramref name="input"/> through unchanged — i.e. input validation is disabled, or
+    /// the vector is within <see cref="SafetyFilterOptions{T}.MaxInputLength"/> and contains
+    /// no NaN/Infinity. In that case <see cref="SafetyFilter{T}.ValidateInput"/> returns a
+    /// valid result with no sanitization, so its per-call text scan can be skipped. Any
+    /// violation returns false so the caller falls through to the full per-call validation
+    /// for the exact diagnostic. Mirrors the matrix fast path in
+    /// <see cref="ValidateAndSanitizeMatrix"/> (#1447 / #1458).
+    /// </summary>
+    private static bool IsCleanForDefaultVectorInputFilter(Vector<T> input, SafetyFilter<T> filter)
+    {
+        var opts = filter.GetOptions();
+        if (!opts.EnableInputValidation)
+        {
+            return true;
+        }
+
+        if (input.Length > opts.MaxInputLength)
+        {
+            return false;
+        }
+
+        var numOps = MathHelper.GetNumericOperations<T>();
+        for (int i = 0; i < input.Length; i++)
+        {
+            double d = numOps.ToDouble(input[i]);
+            if (double.IsNaN(d) || double.IsInfinity(d))
+            {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     private Matrix<T> ValidateAndSanitizeMatrix(Matrix<T> input)

--- a/tests/AiDotNet.Tests/UnitTests/Safety/AiModelResultVectorSafetyFastPathTests.cs
+++ b/tests/AiDotNet.Tests/UnitTests/Safety/AiModelResultVectorSafetyFastPathTests.cs
@@ -1,0 +1,256 @@
+using System;
+using System.IO;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using AiDotNet.Attributes;
+using AiDotNet.Interfaces;
+using AiDotNet.LossFunctions;
+using AiDotNet.Models;
+using AiDotNet.Models.Options;
+using AiDotNet.Models.Results;
+using AiDotNet.Preprocessing;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tests.UnitTests.Safety;
+
+/// <summary>
+/// Guards the single-call Vector input/output SafetyFilter fast paths in
+/// <see cref="AiModelResult{T, TInput, TOutput}.Predict"/> (issue #1458 follow-through
+/// to the #1447 matrix fast paths).
+///
+/// For the default numeric <see cref="AiDotNet.AdversarialRobustness.Safety.SafetyFilter{T}"/>,
+/// the per-call <c>ValidateInput</c>/<c>FilterOutput</c> build a <c>ConvertToText</c>
+/// string over every element (three times in <c>ValidateInput</c>) and run
+/// English-phrase jailbreak/harmful-content regexes that can never match numeric
+/// stringifications. The fast paths skip that meaningless text scan. These tests lock
+/// the two invariants that make skipping safe:
+///   1. For clean/finite numeric data the fast path produces bit-identical output to a
+///      disabled filter (default filter never modifies numeric Vector I/O).
+///   2. Non-finite / over-length input still throws (the input fast path falls through
+///      to the full per-call validation for exact diagnostics).
+/// and that a CUSTOM <see cref="ISafetyFilter{T}"/> is still consulted on both Vector
+/// paths (only the concrete default filter is fast-pathed).
+/// </summary>
+public class AiModelResultVectorSafetyFastPathTests
+{
+    private const int Dim = 6;
+
+    private static AiModelResult<double, Vector<double>, Vector<double>> BuildResult(
+        SafetyFilterConfiguration<double>? safety)
+    {
+        var optimizationResult = new OptimizationResult<double, Vector<double>, Vector<double>>
+        {
+            BestSolution = new EchoVectorModel(Dim)
+        };
+
+        var options = new AiModelResultOptions<double, Vector<double>, Vector<double>>
+        {
+            OptimizationResult = optimizationResult,
+            PreprocessingInfo = new PreprocessingInfo<double, Vector<double>, Vector<double>>(),
+            SafetyFilterConfiguration = safety
+        };
+
+        return new AiModelResult<double, Vector<double>, Vector<double>>(options);
+    }
+
+    private static Vector<double> Finite()
+    {
+        var v = new Vector<double>(Dim);
+        for (int i = 0; i < Dim; i++)
+        {
+            v[i] = (i + 1) * 1.5 - 2.0; // mix of positive/negative non-trivial values
+        }
+        return v;
+    }
+
+    [Fact(Timeout = 60000)]
+    public async Task Predict_VectorOutput_DefaultFilter_BitIdenticalToDisabledFilter()
+    {
+        var input = Finite();
+
+        var withDefault = BuildResult(null); // null config => default SafetyFilter<T> (fast path)
+        var disabled = BuildResult(new SafetyFilterConfiguration<double> { Enabled = false });
+
+        var fast = withDefault.Predict(input);
+        var baseline = disabled.Predict(input);
+
+        Assert.Equal(baseline.Length, fast.Length);
+        for (int i = 0; i < baseline.Length; i++)
+        {
+            // Identical bits: the default numeric filter must not alter the output.
+            Assert.Equal(baseline[i], fast[i]);
+        }
+    }
+
+    [Fact(Timeout = 60000)]
+    public async Task Predict_VectorInput_DefaultFilter_FiniteInput_PassesThroughUnchanged()
+    {
+        var input = Finite();
+
+        var withDefault = BuildResult(null);
+
+        // EchoVectorModel returns a clone of its input, so a clean numeric input must
+        // reach the model untouched and round-trip exactly through the input fast path.
+        var output = withDefault.Predict(input);
+
+        Assert.Equal(input.Length, output.Length);
+        for (int i = 0; i < input.Length; i++)
+        {
+            Assert.Equal(input[i], output[i]);
+        }
+    }
+
+    [Fact(Timeout = 60000)]
+    public async Task Predict_VectorInput_DefaultFilter_NonFiniteInput_StillThrows()
+    {
+        var input = Finite();
+        input[2] = double.NaN; // non-finite => fast path must fall through to full validation
+
+        var withDefault = BuildResult(null);
+
+        Assert.Throws<InvalidOperationException>(() => withDefault.Predict(input));
+    }
+
+    [Fact(Timeout = 60000)]
+    public async Task Predict_VectorOutput_CustomFilter_IsStillApplied()
+    {
+        var input = Finite();
+        var custom = new RecordingSafetyFilter(zeroOutput: true);
+
+        var result = BuildResult(new SafetyFilterConfiguration<double> { Filter = custom });
+
+        var output = result.Predict(input);
+
+        Assert.True(custom.FilterOutputCalls > 0,
+            "Custom ISafetyFilter.FilterOutput must still be invoked on the Vector output path.");
+        for (int i = 0; i < output.Length; i++)
+        {
+            Assert.Equal(0.0, output[i]); // custom filter zeroed the output, proving it ran
+        }
+    }
+
+    [Fact(Timeout = 60000)]
+    public async Task Predict_VectorInput_CustomFilter_IsStillConsulted()
+    {
+        var input = Finite();
+        var custom = new RecordingSafetyFilter(zeroOutput: false);
+
+        var result = BuildResult(new SafetyFilterConfiguration<double> { Filter = custom });
+
+        _ = result.Predict(input);
+
+        Assert.True(custom.ValidateInputCalls > 0,
+            "Custom ISafetyFilter.ValidateInput must still be invoked on the Vector input path.");
+    }
+
+    /// <summary>Minimal Vector-&gt;Vector model that echoes a clone of its input.</summary>
+    [ModelMetadataExempt]
+    private sealed class EchoVectorModel : IFullModel<double, Vector<double>, Vector<double>>
+    {
+        private readonly int _dim;
+        private List<int> _activeFeatures;
+
+        public EchoVectorModel(int dim)
+        {
+            _dim = dim;
+            _activeFeatures = Enumerable.Range(0, dim).ToList();
+        }
+
+        public ILossFunction<double> DefaultLossFunction => new MeanSquaredErrorLoss<double>();
+
+        public Vector<double> Predict(Vector<double> input)
+        {
+            var output = new Vector<double>(input.Length);
+            for (int i = 0; i < input.Length; i++)
+            {
+                output[i] = input[i];
+            }
+            return output;
+        }
+
+        public void Train(Vector<double> input, Vector<double> expectedOutput) { }
+        public ModelMetadata<double> GetModelMetadata() => new ModelMetadata<double>();
+        public byte[] Serialize() => Array.Empty<byte>();
+        public void Deserialize(byte[] data) { }
+        public void SaveModel(string filePath) { }
+        public void LoadModel(string filePath) { }
+        public void SaveState(Stream stream) { }
+        public void LoadState(Stream stream) { }
+        public IFullModel<double, Vector<double>, Vector<double>> Clone() => new EchoVectorModel(_dim);
+        public IFullModel<double, Vector<double>, Vector<double>> DeepCopy() => new EchoVectorModel(_dim);
+        public Vector<double> ComputeGradients(Vector<double> input, Vector<double> target, ILossFunction<double>? lossFunction = null) => new Vector<double>(_dim);
+        public void ApplyGradients(Vector<double> gradients, double learningRate) { }
+        public Vector<double> GetParameters() => new Vector<double>(_dim);
+        public void SetParameters(Vector<double> parameters) { }
+        public IFullModel<double, Vector<double>, Vector<double>> WithParameters(Vector<double> parameters) => new EchoVectorModel(_dim);
+        public long ParameterCount => _dim;
+        public bool SupportsParameterInitialization => true;
+        public IEnumerable<int> GetActiveFeatureIndices() => _activeFeatures;
+        public void SetActiveFeatureIndices(IEnumerable<int> featureIndices) => _activeFeatures = featureIndices.ToList();
+        public bool IsFeatureUsed(int featureIndex) => _activeFeatures.Contains(featureIndex);
+        public Dictionary<string, double> GetFeatureImportance() => Enumerable.Range(0, _dim).ToDictionary(i => $"Feature{i}", i => 1.0 / _dim);
+        public Vector<double> SanitizeParameters(Vector<double> parameters) => parameters;
+        public void Dispose() { }
+    }
+
+    /// <summary>
+    /// Custom <see cref="ISafetyFilter{T}"/> that records invocation counts so a test can
+    /// prove the per-call path is still taken for non-default filters. Optionally zeroes
+    /// the output to make the FilterOutput effect observable end-to-end.
+    /// </summary>
+    private sealed class RecordingSafetyFilter : ISafetyFilter<double>
+    {
+        private readonly bool _zeroOutput;
+        private readonly SafetyFilterOptions<double> _options = new();
+
+        public RecordingSafetyFilter(bool zeroOutput)
+        {
+            _zeroOutput = zeroOutput;
+        }
+
+        public int ValidateInputCalls { get; private set; }
+        public int FilterOutputCalls { get; private set; }
+
+        public SafetyValidationResult<double> ValidateInput(Vector<double> input)
+        {
+            ValidateInputCalls++;
+            return new SafetyValidationResult<double> { IsValid = true, SafetyScore = 1.0 };
+        }
+
+        public SafetyFilterResult<double> FilterOutput(Vector<double> output)
+        {
+            FilterOutputCalls++;
+            if (_zeroOutput)
+            {
+                var zeroed = new Vector<double>(output.Length);
+                return new SafetyFilterResult<double>
+                {
+                    IsSafe = false,
+                    SafetyScore = 0.0,
+                    FilteredOutput = zeroed,
+                    WasModified = true
+                };
+            }
+
+            return new SafetyFilterResult<double>
+            {
+                IsSafe = true,
+                SafetyScore = 1.0,
+                FilteredOutput = output,
+                WasModified = false
+            };
+        }
+
+        public JailbreakDetectionResult<double> DetectJailbreak(Vector<double> input) => new();
+        public HarmfulContentResult<double> IdentifyHarmfulContent(Vector<double> content) => new();
+        public double ComputeSafetyScore(Vector<double> content) => 1.0;
+        public SafetyFilterOptions<double> GetOptions() => _options;
+        public void Reset() { }
+        public byte[] Serialize() => Array.Empty<byte>();
+        public void Deserialize(byte[] data) { }
+        public void SaveModel(string filePath) { }
+        public void LoadModel(string filePath) { }
+    }
+}


### PR DESCRIPTION
Closes #1458

## Summary

Follow-through on #1458. The #1447/#1457 work vectorized the per-**row** `SafetyFilter<T>` scan for **Matrix** I/O (`ValidateAndSanitizeMatrix` / `FilterMatrixOutput`). This PR extends the same behavior-preserving fast path to the **single-call Vector** input/output paths in `AiModelResult.Predict` — the item the #1458 issue explicitly listed under *"Not in scope"* (the `ConvertToText` big-string build on the full vector).

## What was already done vs. this PR

- **Already merged on `master` (PR #1457):** the Matrix-I/O fast paths and a regression guard (`Predict_WithSafetyConfigured_NumericWorks_AndStringSafetyStillFlagsBadStrings`). The core #1458 deliverable is in.
- **This PR:** the remaining Vector single-call paths, completing the issue.

## Change

For the default numeric `SafetyFilter<T>`:

- **Vector input** — `ValidateInput` builds a `ConvertToText` string over every element **three times** (directly + inside `DetectJailbreak` + `IdentifyHarmfulContent`) then runs English-phrase jailbreak/harmful-content regexes that can never match numeric stringifications. The only verdicts that apply to a numeric input vector are input-length and finiteness, so when the vector is within `MaxInputLength` and all-finite the per-call text scan is skipped (new `IsCleanForDefaultVectorInputFilter` helper). Non-finite / over-length input **falls through** to the full `ValidateInput` so the exact diagnostic/throw is preserved.
- **Vector output** — `FilterOutput`'s only check (`IdentifyHarmfulContent` text regex) is meaningless on a numeric prediction vector and never modifies it, so it is skipped and the output returned unchanged.

Custom `ISafetyFilter` implementations keep the per-call path. **Predictions are bit-identical for clean numeric data.**

## Why this is behavior-preserving

The jailbreak/harmful-content patterns are a closed set of English words (`kill`, `ssn`, `password`, `false`, …). Numeric `T` stringification only ever yields digits/`.`/`-`/`+`/`e`/`nan`/`infinity` — none of which are substrings of any pattern — so the text scan can never legitimately fire on numeric Vector I/O. The default filter also never sets `SanitizedInput`, so a clean validation is a no-op.

## Gap analysis (verified nothing else needs the same treatment)

- **All `SafetyFilter` call sites covered.** The only `ValidateInput`/`FilterOutput` call sites in `src` are the 4 in `AiModelResult.cs`: 2 Matrix-row (already fast-pathed via #1457) + the 2 Vector paths fixed here. No other code invokes the filter.
- **Other `Predict*` entry points bypass the numeric filter entirely** (pre-existing, out of scope): `InferenceSession.Predict` (KV-cache session path), `PredictWithUncertainty`, `PredictWithDefense`, `PredictWithTestTimeAugmentation` call the model directly without the `SafetyFilter` — there is nothing to fast-path there.
- **Tensor I/O** isn't routed through the filter (branches gate on `Vector<T>`/`Matrix<T>`) — matches the issue.
- **Edge cases verified behavior-identical:** empty vector, non-finite output, over-length input, `!EnableInputValidation`, `!EnableOutputFiltering`.

## Tests

New `AiModelResultVectorSafetyFastPathTests` locks the invariants the fast path relies on:
- default-filter Vector output is **bit-identical** to a disabled filter
- finite Vector input round-trips unchanged
- non-finite Vector input **still throws** `InvalidOperationException`
- a custom `ISafetyFilter` is **still consulted** on both Vector paths

Verification (local):
- New tests: 5/5 pass (green before *and* after the source change — the optimization is behavior-preserving by construction; the tests fail if implemented incorrectly, e.g. skipping custom filters or the non-finite throw).
- `AiModelBuilderPredictIntegrationTests` + `SafetyFilterTests`: 51/51 pass (includes the merged #1447/#1458 matrix guard).
- `RLTrainingIntegrationTests` (real `Vector<double>`→`Vector<double>` model): 2/2 pass.

## Cross-references
- #1458 (this issue; Matrix fix already merged via #1457)
- #1447 (P2 origin)

🤖 Generated with [Claude Code](https://claude.com/claude-code)