### PR TITLE
chore: audit(2026-05) phase 2a — consolidate remaining AiModelBuilder concern slices (3/4/9/10/12)

### DIFF
--- a/src/AiModelBuilder.cs
+++ b/src/AiModelBuilder.cs
@@ -156,6 +156,29 @@ public partial class AiModelBuilder<T, TInput, TOutput> : IAiModelBuilder<T, TIn
     private readonly AiDotNet.Configuration.IAiModelTrainingCore<T, TInput, TOutput> _trainingCore
         = new AiDotNet.Configuration.AiModelTrainingCore<T, TInput, TOutput>();
 
+    // audit-2026-05 phase 2a slice 3 — cross-validation concern.
+    private readonly AiDotNet.Configuration.IAiModelCrossValidation<T, TInput, TOutput> _crossValidation
+        = new AiDotNet.Configuration.AiModelCrossValidation<T, TInput, TOutput>();
+
+    // audit-2026-05 phase 2a slice 4 — compliance concern (bias, fairness, interpretability,
+    // adversarial robustness, safety filtering).
+    private readonly AiDotNet.Configuration.IAiModelCompliance<T, TInput, TOutput> _compliance
+        = new AiDotNet.Configuration.AiModelCompliance<T, TInput, TOutput>();
+
+    // audit-2026-05 phase 2a slice 12 — license / enterprise-gate concern. Holds both the user-
+    // supplied AiDotNetLicenseKey and the cached LicenseValidator; ConfigureLicenseKey resets
+    // the validator any time the key changes.
+    private AiDotNet.Configuration.IAiModelLicensing? _licensing;
+
+    // audit-2026-05 phase 2a slice 9 — storage / artifact-management concern.
+    private readonly AiDotNet.Configuration.IAiModelStorage<T, TInput, TOutput> _storage
+        = new AiDotNet.Configuration.AiModelStorage<T, TInput, TOutput>();
+
+    // audit-2026-05 phase 2a slice 10 — observability concern (benchmarking, profiling,
+    // telemetry, GPU diagnostics).
+    private readonly AiDotNet.Configuration.IAiModelObservability _observability
+        = new AiDotNet.Configuration.AiModelObservability();
+
     private PreprocessingPipeline<T, TInput, TInput>? _preprocessingPipeline;
     private PostprocessingPipeline<T, TOutput, TOutput>? _postprocessingPipeline;
 
@@ -506,7 +529,8 @@ public partial class AiModelBuilder<T, TInput, TOutput> : IAiModelBuilder<T, TIn
             throw new ArgumentException("Config file path cannot be null or empty.", nameof(configFilePath));
         }
 
-        _licenseKey = licenseKey;
+        _licensing = new AiDotNet.Configuration.AiModelLicensing(licenseKey);
+        _licenseKey = _licensing.LicenseKey;
 
         var fullPath = Path.GetFullPath(configFilePath);
         if (!File.Exists(fullPath))
@@ -529,7 +553,8 @@ public partial class AiModelBuilder<T, TInput, TOutput> : IAiModelBuilder<T, TIn
     /// </remarks>
     public AiModelBuilder(AiDotNetLicenseKey? licenseKey = null)
     {
-        _licenseKey = licenseKey;
+        _licensing = new AiDotNet.Configuration.AiModelLicensing(licenseKey);
+        _licenseKey = _licensing.LicenseKey;
     }
 
     /// <summary>
@@ -803,9 +828,9 @@ public partial class AiModelBuilder<T, TInput, TOutput> : IAiModelBuilder<T, TIn
     /// <inheritdoc />
     public IAiModelBuilder<T, TInput, TOutput> ConfigureLicenseKey(AiDotNetLicenseKey licenseKey)
     {
-        Guard.NotNull(licenseKey);
-        _licenseKey = licenseKey;
-        _licenseValidator = null; // Reset cached validator when key changes
+        _licensing!.ConfigureLicenseKey(licenseKey);
+        _licenseKey = _licensing.LicenseKey;
+        _licenseValidator = _licensing.Validator;
         return this;
     }
 
@@ -5137,7 +5162,8 @@ public partial class AiModelBuilder<T, TInput, TOutput> : IAiModelBuilder<T, TIn
     /// </remarks>
     public IAiModelBuilder<T, TInput, TOutput> ConfigureBiasDetector(IBiasDetector<T> detector)
     {
-        _biasDetector = detector;
+        _compliance.ConfigureBiasDetector(detector);
+        _biasDetector = _compliance.BiasDetector;
         return this;
     }
 
@@ -5154,7 +5180,8 @@ public partial class AiModelBuilder<T, TInput, TOutput> : IAiModelBuilder<T, TIn
     /// </remarks>
     public IAiModelBuilder<T, TInput, TOutput> ConfigureFairnessEvaluator(IFairnessEvaluator<T> evaluator)
     {
-        _fairnessEvaluator = evaluator;
+        _compliance.ConfigureFairnessEvaluator(evaluator);
+        _fairnessEvaluator = _compliance.FairnessEvaluator;
         return this;
     }
 
@@ -5198,7 +5225,8 @@ public partial class AiModelBuilder<T, TInput, TOutput> : IAiModelBuilder<T, TIn
     /// </remarks>
     public IAiModelBuilder<T, TInput, TOutput> ConfigureInterpretability(InterpretabilityOptions? options = null)
     {
-        _interpretabilityOptions = options ?? new InterpretabilityOptions();
+        _compliance.ConfigureInterpretability(options);
+        _interpretabilityOptions = _compliance.InterpretabilityOptions;
         return this;
     }
 
@@ -5255,7 +5283,8 @@ public partial class AiModelBuilder<T, TInput, TOutput> : IAiModelBuilder<T, TIn
     public IAiModelBuilder<T, TInput, TOutput> ConfigureAdversarialRobustness(
         AdversarialRobustnessConfiguration<T, TInput, TOutput>? configuration = null)
     {
-        _adversarialRobustnessConfiguration = configuration ?? new AdversarialRobustnessConfiguration<T, TInput, TOutput>();
+        _compliance.ConfigureAdversarialRobustness(configuration);
+        _adversarialRobustnessConfiguration = _compliance.AdversarialRobustnessConfiguration;
         return this;
     }
 
@@ -5575,7 +5604,8 @@ public partial class AiModelBuilder<T, TInput, TOutput> : IAiModelBuilder<T, TIn
     /// </remarks>
     public IAiModelBuilder<T, TInput, TOutput> ConfigureCrossValidation(ICrossValidator<T, TInput, TOutput> crossValidator)
     {
-        _crossValidator = crossValidator;
+        _crossValidation.ConfigureCrossValidation(crossValidator);
+        _crossValidator = _crossValidation.CrossValidator;
         return this;
     }
 
@@ -6205,25 +6235,29 @@ public partial class AiModelBuilder<T, TInput, TOutput> : IAiModelBuilder<T, TIn
 
     public IAiModelBuilder<T, TInput, TOutput> ConfigureCaching(CacheConfig? config = null)
     {
-        _cacheConfig = config;
+        _storage.ConfigureCaching(config);
+        _cacheConfig = _storage.CacheConfig;
         return this;
     }
 
     public IAiModelBuilder<T, TInput, TOutput> ConfigureVersioning(VersioningConfig? config = null)
     {
-        _versioningConfig = config;
+        _storage.ConfigureVersioning(config);
+        _versioningConfig = _storage.VersioningConfig;
         return this;
     }
 
     public IAiModelBuilder<T, TInput, TOutput> ConfigureABTesting(ABTestingConfig? config = null)
     {
-        _abTestingConfig = config;
+        _storage.ConfigureABTesting(config);
+        _abTestingConfig = _storage.ABTestingConfig;
         return this;
     }
 
     public IAiModelBuilder<T, TInput, TOutput> ConfigureTelemetry(TelemetryConfig? config = null)
     {
-        _telemetryConfig = config;
+        _observability.ConfigureTelemetry(config);
+        _telemetryConfig = _observability.TelemetryConfig;
         return this;
     }
 
@@ -6476,23 +6510,7 @@ public partial class AiModelBuilder<T, TInput, TOutput> : IAiModelBuilder<T, TIn
     public IAiModelBuilder<T, TInput, TOutput> ConfigureGpuDiagnostics(
         AiDotNet.Configuration.GpuDiagnosticsOptions? options = null)
     {
-        if (options is null) return this;
-
-        // Level wins over Verbose when both set — Level is the richer API.
-        if (options.Level is AiDotNet.Configuration.GpuDiagnosticLevel level)
-        {
-            AiDotNet.Configuration.GpuDiagnosticsConfig.Level = level;
-        }
-        else if (options.Verbose is bool verbose)
-        {
-            AiDotNet.Configuration.GpuDiagnosticsConfig.Verbose = verbose;
-        }
-
-        if (options.Sink is AiDotNet.Configuration.GpuDiagnosticSink sink)
-        {
-            AiDotNet.Configuration.GpuDiagnosticsConfig.Sink = sink;
-        }
-
+        _observability.ConfigureGpuDiagnostics(options);
         return this;
     }
 
@@ -6510,7 +6528,8 @@ public partial class AiModelBuilder<T, TInput, TOutput> : IAiModelBuilder<T, TIn
     /// </remarks>
     public IAiModelBuilder<T, TInput, TOutput> ConfigureBenchmarking(BenchmarkingOptions? options = null)
     {
-        _benchmarkingOptions = options ?? new BenchmarkingOptions();
+        _observability.ConfigureBenchmarking(options);
+        _benchmarkingOptions = _observability.BenchmarkingOptions;
         return this;
     }
 
@@ -6543,7 +6562,8 @@ public partial class AiModelBuilder<T, TInput, TOutput> : IAiModelBuilder<T, TIn
     /// </remarks>
     public IAiModelBuilder<T, TInput, TOutput> ConfigureProfiling(ProfilingConfig? config = null)
     {
-        _profilingConfig = config ?? new ProfilingConfig { Enabled = true };
+        _observability.ConfigureProfiling(config);
+        _profilingConfig = _observability.ProfilingConfig;
         return this;
     }
 
@@ -6577,8 +6597,8 @@ public partial class AiModelBuilder<T, TInput, TOutput> : IAiModelBuilder<T, TIn
     /// </remarks>
     public IAiModelBuilder<T, TInput, TOutput> ConfigureSafety(Action<AiDotNet.Safety.SafetyConfig>? configure = null)
     {
-        _safetyPipelineConfig = new AiDotNet.Safety.SafetyConfig();
-        configure?.Invoke(_safetyPipelineConfig);
+        _compliance.ConfigureSafety(configure);
+        _safetyPipelineConfig = _compliance.SafetyPipelineConfig;
         return this;
     }
 
@@ -6612,7 +6632,8 @@ public partial class AiModelBuilder<T, TInput, TOutput> : IAiModelBuilder<T, TIn
     /// </remarks>
     public IAiModelBuilder<T, TInput, TOutput> ConfigureExperimentTracker(IExperimentTracker<T> tracker)
     {
-        _experimentTracker = tracker;
+        _storage.ConfigureExperimentTracker(tracker);
+        _experimentTracker = _storage.ExperimentTracker;
         return this;
     }
 
@@ -6713,7 +6734,8 @@ public partial class AiModelBuilder<T, TInput, TOutput> : IAiModelBuilder<T, TIn
     /// </remarks>
     public IAiModelBuilder<T, TInput, TOutput> ConfigureModelRegistry(IModelRegistry<T, TInput, TOutput> registry)
     {
-        _modelRegistry = registry;
+        _storage.ConfigureModelRegistry(registry);
+        _modelRegistry = _storage.ModelRegistry;
         return this;
     }
 
@@ -6728,7 +6750,8 @@ public partial class AiModelBuilder<T, TInput, TOutput> : IAiModelBuilder<T, TIn
     /// </remarks>
     public IAiModelBuilder<T, TInput, TOutput> ConfigureDataVersionControl(IDataVersionControl<T> dataVersionControl)
     {
-        _dataVersionControl = dataVersionControl;
+        _storage.ConfigureDataVersionControl(dataVersionControl);
+        _dataVersionControl = _storage.DataVersionControl;
         return this;
     }
 

--- a/src/Configuration/AiModelCompliance.cs
+++ b/src/Configuration/AiModelCompliance.cs
@@ -1,0 +1,50 @@
+using System;
+using AiDotNet.Models.Options;
+using AiDotNet.Safety;
+
+namespace AiDotNet.Configuration;
+
+/// <summary>
+/// Default implementation of <see cref="IAiModelCompliance{T,TInput,TOutput}"/>. Audit-2026-05
+/// phase-2a slice 4. Mirrors pre-refactor inline logic verbatim, including the
+/// <c>?? new SomethingConfig()</c> fallback patterns for the null-arg overloads.
+/// </summary>
+public class AiModelCompliance<T, TInput, TOutput> : IAiModelCompliance<T, TInput, TOutput>
+{
+    /// <inheritdoc/>
+    public IBiasDetector<T>? BiasDetector { get; private set; }
+
+    /// <inheritdoc/>
+    public IFairnessEvaluator<T>? FairnessEvaluator { get; private set; }
+
+    /// <inheritdoc/>
+    public InterpretabilityOptions? InterpretabilityOptions { get; private set; }
+
+    /// <inheritdoc/>
+    public AdversarialRobustnessConfiguration<T, TInput, TOutput>? AdversarialRobustnessConfiguration { get; private set; }
+
+    /// <inheritdoc/>
+    public SafetyConfig? SafetyPipelineConfig { get; private set; }
+
+    /// <inheritdoc/>
+    public void ConfigureBiasDetector(IBiasDetector<T> detector) => BiasDetector = detector;
+
+    /// <inheritdoc/>
+    public void ConfigureFairnessEvaluator(IFairnessEvaluator<T> evaluator) => FairnessEvaluator = evaluator;
+
+    /// <inheritdoc/>
+    public void ConfigureInterpretability(InterpretabilityOptions? options)
+        => InterpretabilityOptions = options ?? new InterpretabilityOptions();
+
+    /// <inheritdoc/>
+    public void ConfigureAdversarialRobustness(AdversarialRobustnessConfiguration<T, TInput, TOutput>? configuration)
+        => AdversarialRobustnessConfiguration = configuration ?? new AdversarialRobustnessConfiguration<T, TInput, TOutput>();
+
+    /// <inheritdoc/>
+    public void ConfigureSafety(Action<SafetyConfig>? configure)
+    {
+        var config = new SafetyConfig();
+        configure?.Invoke(config);
+        SafetyPipelineConfig = config;
+    }
+}

--- a/src/Configuration/AiModelCompliance.cs
+++ b/src/Configuration/AiModelCompliance.cs
@@ -9,7 +9,7 @@ namespace AiDotNet.Configuration;
 /// phase-2a slice 4. Mirrors pre-refactor inline logic verbatim, including the
 /// <c>?? new SomethingConfig()</c> fallback patterns for the null-arg overloads.
 /// </summary>
-public class AiModelCompliance<T, TInput, TOutput> : IAiModelCompliance<T, TInput, TOutput>
+internal class AiModelCompliance<T, TInput, TOutput> : IAiModelCompliance<T, TInput, TOutput>
 {
     /// <inheritdoc/>
     public IBiasDetector<T>? BiasDetector { get; private set; }

--- a/src/Configuration/AiModelCrossValidation.cs
+++ b/src/Configuration/AiModelCrossValidation.cs
@@ -1,0 +1,15 @@
+namespace AiDotNet.Configuration;
+
+/// <summary>
+/// Default implementation of <see cref="IAiModelCrossValidation{T,TInput,TOutput}"/>.
+/// Audit-2026-05 phase-2a slice 3.
+/// </summary>
+public class AiModelCrossValidation<T, TInput, TOutput> : IAiModelCrossValidation<T, TInput, TOutput>
+{
+    /// <inheritdoc/>
+    public ICrossValidator<T, TInput, TOutput>? CrossValidator { get; private set; }
+
+    /// <inheritdoc/>
+    public void ConfigureCrossValidation(ICrossValidator<T, TInput, TOutput> crossValidator)
+        => CrossValidator = crossValidator;
+}

--- a/src/Configuration/AiModelCrossValidation.cs
+++ b/src/Configuration/AiModelCrossValidation.cs
@@ -4,7 +4,7 @@ namespace AiDotNet.Configuration;
 /// Default implementation of <see cref="IAiModelCrossValidation{T,TInput,TOutput}"/>.
 /// Audit-2026-05 phase-2a slice 3.
 /// </summary>
-public class AiModelCrossValidation<T, TInput, TOutput> : IAiModelCrossValidation<T, TInput, TOutput>
+internal class AiModelCrossValidation<T, TInput, TOutput> : IAiModelCrossValidation<T, TInput, TOutput>
 {
     /// <inheritdoc/>
     public ICrossValidator<T, TInput, TOutput>? CrossValidator { get; private set; }

--- a/src/Configuration/AiModelLicensing.cs
+++ b/src/Configuration/AiModelLicensing.cs
@@ -1,0 +1,32 @@
+using AiDotNet.Helpers;
+using AiDotNet.Models;
+
+namespace AiDotNet.Configuration;
+
+/// <summary>
+/// Default implementation of <see cref="IAiModelLicensing"/>. Audit-2026-05 phase-2a slice 12.
+/// Mirrors the pre-refactor inline storage in <c>AiModelBuilder</c>: setting a new license key
+/// always nulls the cached validator so the next BuildAsync re-resolves against the fresh key.
+/// </summary>
+internal class AiModelLicensing : IAiModelLicensing
+{
+    /// <summary>Sets the license key from the constructor. The component starts with this value but the caller may override via <see cref="ConfigureLicenseKey"/>.</summary>
+    public AiModelLicensing(AiDotNetLicenseKey? initialLicenseKey = null)
+    {
+        LicenseKey = initialLicenseKey;
+    }
+
+    /// <inheritdoc/>
+    public AiDotNetLicenseKey? LicenseKey { get; private set; }
+
+    /// <inheritdoc/>
+    public LicenseValidator? Validator { get; set; }
+
+    /// <inheritdoc/>
+    public void ConfigureLicenseKey(AiDotNetLicenseKey licenseKey)
+    {
+        Guard.NotNull(licenseKey);
+        LicenseKey = licenseKey;
+        Validator = null; // reset cached validator — next BuildAsync re-resolves against the new key
+    }
+}

--- a/src/Configuration/AiModelObservability.cs
+++ b/src/Configuration/AiModelObservability.cs
@@ -3,7 +3,7 @@ using AiDotNet.Deployment.Configuration;
 namespace AiDotNet.Configuration;
 
 /// <summary>Default implementation of <see cref="IAiModelObservability"/>. Audit-2026-05 phase-2a slice 10.</summary>
-public class AiModelObservability : IAiModelObservability
+internal class AiModelObservability : IAiModelObservability
 {
     public BenchmarkingOptions? BenchmarkingOptions { get; private set; }
     public ProfilingConfig? ProfilingConfig { get; private set; }

--- a/src/Configuration/AiModelObservability.cs
+++ b/src/Configuration/AiModelObservability.cs
@@ -1,0 +1,42 @@
+using AiDotNet.Deployment.Configuration;
+
+namespace AiDotNet.Configuration;
+
+/// <summary>Default implementation of <see cref="IAiModelObservability"/>. Audit-2026-05 phase-2a slice 10.</summary>
+public class AiModelObservability : IAiModelObservability
+{
+    public BenchmarkingOptions? BenchmarkingOptions { get; private set; }
+    public ProfilingConfig? ProfilingConfig { get; private set; }
+    public TelemetryConfig? TelemetryConfig { get; private set; }
+
+    public void ConfigureBenchmarking(BenchmarkingOptions? options)
+        => BenchmarkingOptions = options ?? new BenchmarkingOptions();
+
+    public void ConfigureProfiling(ProfilingConfig? config)
+        => ProfilingConfig = config ?? new ProfilingConfig { Enabled = true };
+
+    public void ConfigureTelemetry(TelemetryConfig? config) => TelemetryConfig = config;
+
+    public void ConfigureGpuDiagnostics(GpuDiagnosticsOptions? options)
+    {
+        // Mirrors the pre-refactor inline behavior verbatim: mutate the process-wide static
+        // GpuDiagnosticsConfig — no per-instance storage. Slices 2-12 generally avoid statics,
+        // but ConfigureGpuDiagnostics is a deliberate exception: GPU diagnostic level is a
+        // process-global setting, not a per-build configuration.
+        if (options is null) return;
+
+        if (options.Level is GpuDiagnosticLevel level)
+        {
+            GpuDiagnosticsConfig.Level = level;
+        }
+        else if (options.Verbose is bool verbose)
+        {
+            GpuDiagnosticsConfig.Verbose = verbose;
+        }
+
+        if (options.Sink is GpuDiagnosticSink sink)
+        {
+            GpuDiagnosticsConfig.Sink = sink;
+        }
+    }
+}

--- a/src/Configuration/AiModelStorage.cs
+++ b/src/Configuration/AiModelStorage.cs
@@ -3,7 +3,7 @@ using AiDotNet.Deployment.Configuration;
 namespace AiDotNet.Configuration;
 
 /// <summary>Default implementation of <see cref="IAiModelStorage{T,TInput,TOutput}"/>. Audit-2026-05 phase-2a slice 9.</summary>
-public class AiModelStorage<T, TInput, TOutput> : IAiModelStorage<T, TInput, TOutput>
+internal class AiModelStorage<T, TInput, TOutput> : IAiModelStorage<T, TInput, TOutput>
 {
     public CacheConfig? CacheConfig { get; private set; }
     public VersioningConfig? VersioningConfig { get; private set; }

--- a/src/Configuration/AiModelStorage.cs
+++ b/src/Configuration/AiModelStorage.cs
@@ -1,0 +1,21 @@
+using AiDotNet.Deployment.Configuration;
+
+namespace AiDotNet.Configuration;
+
+/// <summary>Default implementation of <see cref="IAiModelStorage{T,TInput,TOutput}"/>. Audit-2026-05 phase-2a slice 9.</summary>
+public class AiModelStorage<T, TInput, TOutput> : IAiModelStorage<T, TInput, TOutput>
+{
+    public CacheConfig? CacheConfig { get; private set; }
+    public VersioningConfig? VersioningConfig { get; private set; }
+    public ABTestingConfig? ABTestingConfig { get; private set; }
+    public IExperimentTracker<T>? ExperimentTracker { get; private set; }
+    public IModelRegistry<T, TInput, TOutput>? ModelRegistry { get; private set; }
+    public IDataVersionControl<T>? DataVersionControl { get; private set; }
+
+    public void ConfigureCaching(CacheConfig? config) => CacheConfig = config;
+    public void ConfigureVersioning(VersioningConfig? config) => VersioningConfig = config;
+    public void ConfigureABTesting(ABTestingConfig? config) => ABTestingConfig = config;
+    public void ConfigureExperimentTracker(IExperimentTracker<T> tracker) => ExperimentTracker = tracker;
+    public void ConfigureModelRegistry(IModelRegistry<T, TInput, TOutput> registry) => ModelRegistry = registry;
+    public void ConfigureDataVersionControl(IDataVersionControl<T> dataVersionControl) => DataVersionControl = dataVersionControl;
+}

--- a/src/Configuration/IAiModelCompliance.cs
+++ b/src/Configuration/IAiModelCompliance.cs
@@ -13,7 +13,7 @@ namespace AiDotNet.Configuration;
 /// <typeparam name="T">Element numeric type.</typeparam>
 /// <typeparam name="TInput">Model input tensor type.</typeparam>
 /// <typeparam name="TOutput">Model output tensor type.</typeparam>
-public interface IAiModelCompliance<T, TInput, TOutput>
+internal interface IAiModelCompliance<T, TInput, TOutput>
 {
     /// <summary>The configured bias detector, or <c>null</c> if not configured.</summary>
     IBiasDetector<T>? BiasDetector { get; }

--- a/src/Configuration/IAiModelCompliance.cs
+++ b/src/Configuration/IAiModelCompliance.cs
@@ -1,0 +1,47 @@
+using System;
+using AiDotNet.Models.Options;
+using AiDotNet.Safety;
+
+namespace AiDotNet.Configuration;
+
+/// <summary>
+/// Component that owns the compliance / ethical-AI configuration for an AI model build:
+/// bias detection, fairness evaluation, interpretability / explainability, adversarial-robustness
+/// hardening, and safety filtering. Extracted from <c>AiModelBuilder</c> as slice 4 of the
+/// audit-2026-05 phase-2a DI refactor.
+/// </summary>
+/// <typeparam name="T">Element numeric type.</typeparam>
+/// <typeparam name="TInput">Model input tensor type.</typeparam>
+/// <typeparam name="TOutput">Model output tensor type.</typeparam>
+public interface IAiModelCompliance<T, TInput, TOutput>
+{
+    /// <summary>The configured bias detector, or <c>null</c> if not configured.</summary>
+    IBiasDetector<T>? BiasDetector { get; }
+
+    /// <summary>The configured fairness evaluator, or <c>null</c> if not configured.</summary>
+    IFairnessEvaluator<T>? FairnessEvaluator { get; }
+
+    /// <summary>The configured interpretability options, or <c>null</c> if not configured.</summary>
+    InterpretabilityOptions? InterpretabilityOptions { get; }
+
+    /// <summary>The configured adversarial-robustness configuration, or <c>null</c> if not configured.</summary>
+    AdversarialRobustnessConfiguration<T, TInput, TOutput>? AdversarialRobustnessConfiguration { get; }
+
+    /// <summary>The configured safety-filter pipeline, or <c>null</c> if not configured.</summary>
+    SafetyConfig? SafetyPipelineConfig { get; }
+
+    /// <summary>Sets the bias detector.</summary>
+    void ConfigureBiasDetector(IBiasDetector<T> detector);
+
+    /// <summary>Sets the fairness evaluator.</summary>
+    void ConfigureFairnessEvaluator(IFairnessEvaluator<T> evaluator);
+
+    /// <summary>Sets the interpretability options. <c>null</c> applies defaults.</summary>
+    void ConfigureInterpretability(InterpretabilityOptions? options);
+
+    /// <summary>Sets the adversarial-robustness configuration. <c>null</c> applies defaults.</summary>
+    void ConfigureAdversarialRobustness(AdversarialRobustnessConfiguration<T, TInput, TOutput>? configuration);
+
+    /// <summary>Sets the safety pipeline. <c>null</c> action applies an empty config.</summary>
+    void ConfigureSafety(Action<SafetyConfig>? configure);
+}

--- a/src/Configuration/IAiModelCrossValidation.cs
+++ b/src/Configuration/IAiModelCrossValidation.cs
@@ -7,7 +7,7 @@ namespace AiDotNet.Configuration;
 /// <typeparam name="T">Element numeric type.</typeparam>
 /// <typeparam name="TInput">Model input tensor type.</typeparam>
 /// <typeparam name="TOutput">Model output tensor type.</typeparam>
-public interface IAiModelCrossValidation<T, TInput, TOutput>
+internal interface IAiModelCrossValidation<T, TInput, TOutput>
 {
     /// <summary>The configured cross-validator, or <c>null</c> if not configured.</summary>
     ICrossValidator<T, TInput, TOutput>? CrossValidator { get; }

--- a/src/Configuration/IAiModelCrossValidation.cs
+++ b/src/Configuration/IAiModelCrossValidation.cs
@@ -1,0 +1,17 @@
+namespace AiDotNet.Configuration;
+
+/// <summary>
+/// Component that owns the cross-validation configuration for an AI model build. Extracted from
+/// <c>AiModelBuilder</c> as slice 3 of the audit-2026-05 phase-2a DI refactor.
+/// </summary>
+/// <typeparam name="T">Element numeric type.</typeparam>
+/// <typeparam name="TInput">Model input tensor type.</typeparam>
+/// <typeparam name="TOutput">Model output tensor type.</typeparam>
+public interface IAiModelCrossValidation<T, TInput, TOutput>
+{
+    /// <summary>The configured cross-validator, or <c>null</c> if not configured.</summary>
+    ICrossValidator<T, TInput, TOutput>? CrossValidator { get; }
+
+    /// <summary>Sets the cross-validation strategy.</summary>
+    void ConfigureCrossValidation(ICrossValidator<T, TInput, TOutput> crossValidator);
+}

--- a/src/Configuration/IAiModelLicensing.cs
+++ b/src/Configuration/IAiModelLicensing.cs
@@ -1,0 +1,23 @@
+using AiDotNet.Helpers;
+using AiDotNet.Models;
+
+namespace AiDotNet.Configuration;
+
+/// <summary>
+/// Component that owns the enterprise-license configuration for an AI model build. Extracted
+/// from <c>AiModelBuilder</c> as slice 12 of the audit-2026-05 phase-2a DI refactor. Holds both
+/// the user-supplied key and the cached <see cref="LicenseValidator"/> derived from it; the
+/// component invalidates the validator any time the key changes so callers never see a stale
+/// validation result.
+/// </summary>
+internal interface IAiModelLicensing
+{
+    /// <summary>The configured license key (from constructor or <see cref="ConfigureLicenseKey"/>), or <c>null</c> if not supplied.</summary>
+    AiDotNetLicenseKey? LicenseKey { get; }
+
+    /// <summary>Cached license validator. <c>null</c> until BuildAsync resolves it; the component clears this slot any time the key changes.</summary>
+    LicenseValidator? Validator { get; set; }
+
+    /// <summary>Sets the license key and clears the cached validator (subsequent BuildAsync calls re-resolve).</summary>
+    void ConfigureLicenseKey(AiDotNetLicenseKey licenseKey);
+}

--- a/src/Configuration/IAiModelObservability.cs
+++ b/src/Configuration/IAiModelObservability.cs
@@ -1,0 +1,25 @@
+using AiDotNet.Deployment.Configuration;
+
+namespace AiDotNet.Configuration;
+
+/// <summary>
+/// Component that owns the observability configuration for an AI model build: benchmarking,
+/// profiling, telemetry, and GPU diagnostics. Audit-2026-05 phase-2a slice 10.
+/// </summary>
+public interface IAiModelObservability
+{
+    BenchmarkingOptions? BenchmarkingOptions { get; }
+    ProfilingConfig? ProfilingConfig { get; }
+    TelemetryConfig? TelemetryConfig { get; }
+
+    void ConfigureBenchmarking(BenchmarkingOptions? options);
+    void ConfigureProfiling(ProfilingConfig? config);
+    void ConfigureTelemetry(TelemetryConfig? config);
+
+    /// <summary>
+    /// Configures GPU diagnostics. Mutates the process-wide static
+    /// <see cref="GpuDiagnosticsConfig"/> directly per the pre-refactor semantics; no per-instance
+    /// state stored in this component.
+    /// </summary>
+    void ConfigureGpuDiagnostics(GpuDiagnosticsOptions? options);
+}

--- a/src/Configuration/IAiModelObservability.cs
+++ b/src/Configuration/IAiModelObservability.cs
@@ -6,7 +6,7 @@ namespace AiDotNet.Configuration;
 /// Component that owns the observability configuration for an AI model build: benchmarking,
 /// profiling, telemetry, and GPU diagnostics. Audit-2026-05 phase-2a slice 10.
 /// </summary>
-public interface IAiModelObservability
+internal interface IAiModelObservability
 {
     BenchmarkingOptions? BenchmarkingOptions { get; }
     ProfilingConfig? ProfilingConfig { get; }

--- a/src/Configuration/IAiModelStorage.cs
+++ b/src/Configuration/IAiModelStorage.cs
@@ -8,7 +8,7 @@ namespace AiDotNet.Configuration;
 /// control. Extracted from <c>AiModelBuilder</c> as slice 9 of the audit-2026-05 phase-2a DI
 /// refactor.
 /// </summary>
-public interface IAiModelStorage<T, TInput, TOutput>
+internal interface IAiModelStorage<T, TInput, TOutput>
 {
     CacheConfig? CacheConfig { get; }
     VersioningConfig? VersioningConfig { get; }

--- a/src/Configuration/IAiModelStorage.cs
+++ b/src/Configuration/IAiModelStorage.cs
@@ -1,0 +1,26 @@
+using AiDotNet.Deployment.Configuration;
+
+namespace AiDotNet.Configuration;
+
+/// <summary>
+/// Component that owns the storage / artifact-management configuration for an AI model build:
+/// caching, versioning, A/B testing, experiment tracking, model registry, and data version
+/// control. Extracted from <c>AiModelBuilder</c> as slice 9 of the audit-2026-05 phase-2a DI
+/// refactor.
+/// </summary>
+public interface IAiModelStorage<T, TInput, TOutput>
+{
+    CacheConfig? CacheConfig { get; }
+    VersioningConfig? VersioningConfig { get; }
+    ABTestingConfig? ABTestingConfig { get; }
+    IExperimentTracker<T>? ExperimentTracker { get; }
+    IModelRegistry<T, TInput, TOutput>? ModelRegistry { get; }
+    IDataVersionControl<T>? DataVersionControl { get; }
+
+    void ConfigureCaching(CacheConfig? config);
+    void ConfigureVersioning(VersioningConfig? config);
+    void ConfigureABTesting(ABTestingConfig? config);
+    void ConfigureExperimentTracker(IExperimentTracker<T> tracker);
+    void ConfigureModelRegistry(IModelRegistry<T, TInput, TOutput> registry);
+    void ConfigureDataVersionControl(IDataVersionControl<T> dataVersionControl);
+}

--- a/tests/AiDotNet.Tests/UnitTests/Configuration/AiModelComplianceTests.cs
+++ b/tests/AiDotNet.Tests/UnitTests/Configuration/AiModelComplianceTests.cs
@@ -1,0 +1,115 @@
+using System.Threading.Tasks;
+using AiDotNet.Configuration;
+using AiDotNet.Interfaces;
+using AiDotNet.Models.Options;
+using AiDotNet.Safety;
+using AiDotNet.Tensors.LinearAlgebra;
+using Moq;
+using Xunit;
+
+namespace AiDotNet.Tests.UnitTests.Configuration;
+
+/// <summary>Audit-2026-05 phase-2a slice 4 — compliance component isolation tests.</summary>
+public class AiModelComplianceTests
+{
+    [Fact(Timeout = 30000)]
+    public async Task InitialState_AllSlotsAreNull()
+    {
+        await Task.Yield();
+        var c = new AiModelCompliance<double, Matrix<double>, Vector<double>>();
+        Assert.Null(c.BiasDetector);
+        Assert.Null(c.FairnessEvaluator);
+        Assert.Null(c.InterpretabilityOptions);
+        Assert.Null(c.AdversarialRobustnessConfiguration);
+        Assert.Null(c.SafetyPipelineConfig);
+    }
+
+    [Fact(Timeout = 30000)]
+    public async Task ConfigureBiasDetector_Stores()
+    {
+        await Task.Yield();
+        var c = new AiModelCompliance<double, Matrix<double>, Vector<double>>();
+        var detector = Mock.Of<IBiasDetector<double>>();
+        c.ConfigureBiasDetector(detector);
+        Assert.Same(detector, c.BiasDetector);
+    }
+
+    [Fact(Timeout = 30000)]
+    public async Task ConfigureFairnessEvaluator_Stores()
+    {
+        await Task.Yield();
+        var c = new AiModelCompliance<double, Matrix<double>, Vector<double>>();
+        var evaluator = Mock.Of<IFairnessEvaluator<double>>();
+        c.ConfigureFairnessEvaluator(evaluator);
+        Assert.Same(evaluator, c.FairnessEvaluator);
+    }
+
+    [Fact(Timeout = 30000)]
+    public async Task ConfigureInterpretability_NullAppliesDefault()
+    {
+        await Task.Yield();
+        var c = new AiModelCompliance<double, Matrix<double>, Vector<double>>();
+        c.ConfigureInterpretability(null);
+        Assert.NotNull(c.InterpretabilityOptions);
+    }
+
+    [Fact(Timeout = 30000)]
+    public async Task ConfigureInterpretability_ExplicitOptions_Stored()
+    {
+        await Task.Yield();
+        var c = new AiModelCompliance<double, Matrix<double>, Vector<double>>();
+        var opts = new InterpretabilityOptions();
+        c.ConfigureInterpretability(opts);
+        Assert.Same(opts, c.InterpretabilityOptions);
+    }
+
+    [Fact(Timeout = 30000)]
+    public async Task ConfigureAdversarialRobustness_NullAppliesDefault()
+    {
+        await Task.Yield();
+        var c = new AiModelCompliance<double, Matrix<double>, Vector<double>>();
+        c.ConfigureAdversarialRobustness(null);
+        Assert.NotNull(c.AdversarialRobustnessConfiguration);
+    }
+
+    [Fact(Timeout = 30000)]
+    public async Task ConfigureAdversarialRobustness_Explicit_Stored()
+    {
+        await Task.Yield();
+        var c = new AiModelCompliance<double, Matrix<double>, Vector<double>>();
+        var cfg = new AdversarialRobustnessConfiguration<double, Matrix<double>, Vector<double>>();
+        c.ConfigureAdversarialRobustness(cfg);
+        Assert.Same(cfg, c.AdversarialRobustnessConfiguration);
+    }
+
+    [Fact(Timeout = 30000)]
+    public async Task ConfigureSafety_NullActionLeavesEmptyConfig()
+    {
+        await Task.Yield();
+        var c = new AiModelCompliance<double, Matrix<double>, Vector<double>>();
+        c.ConfigureSafety(null);
+        Assert.NotNull(c.SafetyPipelineConfig);
+    }
+
+    [Fact(Timeout = 30000)]
+    public async Task ConfigureSafety_ActionInvokedOnNewConfig()
+    {
+        await Task.Yield();
+        var c = new AiModelCompliance<double, Matrix<double>, Vector<double>>();
+        SafetyConfig? captured = null;
+        c.ConfigureSafety(sc => captured = sc);
+        Assert.NotNull(captured);
+        Assert.Same(c.SafetyPipelineConfig, captured);
+    }
+
+    [Fact(Timeout = 30000)]
+    public async Task Interface_IsImplemented()
+    {
+        await Task.Yield();
+        IAiModelCompliance<double, Matrix<double>, Vector<double>> c
+            = new AiModelCompliance<double, Matrix<double>, Vector<double>>();
+        var detector = Mock.Of<IBiasDetector<double>>();
+        c.ConfigureBiasDetector(detector);
+        Assert.Same(detector, c.BiasDetector);
+    }
+}

--- a/tests/AiDotNet.Tests/UnitTests/Configuration/AiModelCrossValidationTests.cs
+++ b/tests/AiDotNet.Tests/UnitTests/Configuration/AiModelCrossValidationTests.cs
@@ -1,0 +1,43 @@
+using System.Threading.Tasks;
+using AiDotNet.Configuration;
+using AiDotNet.Interfaces;
+using AiDotNet.Tensors.LinearAlgebra;
+using Moq;
+using Xunit;
+
+namespace AiDotNet.Tests.UnitTests.Configuration;
+
+/// <summary>Audit-2026-05 phase-2a slice 3 — cross-validation component isolation tests.</summary>
+public class AiModelCrossValidationTests
+{
+    [Fact(Timeout = 30000)]
+    public async Task InitialState_IsNull()
+    {
+        await Task.Yield();
+        var cv = new AiModelCrossValidation<double, Matrix<double>, Vector<double>>();
+        Assert.Null(cv.CrossValidator);
+    }
+
+    [Fact(Timeout = 30000)]
+    public async Task Configure_Stores()
+    {
+        await Task.Yield();
+        var cv = new AiModelCrossValidation<double, Matrix<double>, Vector<double>>();
+        var validator = Mock.Of<ICrossValidator<double, Matrix<double>, Vector<double>>>();
+
+        cv.ConfigureCrossValidation(validator);
+
+        Assert.Same(validator, cv.CrossValidator);
+    }
+
+    [Fact(Timeout = 30000)]
+    public async Task Interface_IsImplemented()
+    {
+        await Task.Yield();
+        IAiModelCrossValidation<double, Matrix<double>, Vector<double>> cv
+            = new AiModelCrossValidation<double, Matrix<double>, Vector<double>>();
+        var validator = Mock.Of<ICrossValidator<double, Matrix<double>, Vector<double>>>();
+        cv.ConfigureCrossValidation(validator);
+        Assert.Same(validator, cv.CrossValidator);
+    }
+}

--- a/tests/AiDotNet.Tests/UnitTests/Configuration/AiModelLicensingTests.cs
+++ b/tests/AiDotNet.Tests/UnitTests/Configuration/AiModelLicensingTests.cs
@@ -1,0 +1,61 @@
+using System;
+using System.Threading.Tasks;
+using AiDotNet.Configuration;
+using AiDotNet.Models;
+using Xunit;
+
+namespace AiDotNet.Tests.UnitTests.Configuration;
+
+/// <summary>Audit-2026-05 phase-2a slice 12 — licensing component isolation tests.</summary>
+public class AiModelLicensingTests
+{
+    [Fact(Timeout = 30000)]
+    public async Task NullKey_Stored()
+    {
+        await Task.Yield();
+        var l = new AiModelLicensing();
+        Assert.Null(l.LicenseKey);
+        Assert.Null(l.Validator);
+    }
+
+    [Fact(Timeout = 30000)]
+    public async Task InitialKey_StoredFromCtor()
+    {
+        await Task.Yield();
+        var key = new AiDotNetLicenseKey("test-key-12345");
+        var l = new AiModelLicensing(key);
+        Assert.Same(key, l.LicenseKey);
+    }
+
+    [Fact(Timeout = 30000)]
+    public async Task ConfigureLicenseKey_Replaces()
+    {
+        await Task.Yield();
+        var key1 = new AiDotNetLicenseKey("k1");
+        var key2 = new AiDotNetLicenseKey("k2");
+        var l = new AiModelLicensing(key1);
+        l.ConfigureLicenseKey(key2);
+        Assert.Same(key2, l.LicenseKey);
+    }
+
+    [Fact(Timeout = 30000)]
+    public async Task ConfigureLicenseKey_NullArg_Throws()
+    {
+        await Task.Yield();
+        var l = new AiModelLicensing();
+        Assert.Throws<ArgumentNullException>(() => l.ConfigureLicenseKey(null!));
+    }
+
+    [Fact(Timeout = 30000)]
+    public async Task ConfigureLicenseKey_ResetsCachedValidator()
+    {
+        await Task.Yield();
+        var l = new AiModelLicensing(new AiDotNetLicenseKey("initial"));
+        // Simulate BuildAsync caching a validator after the initial key was set.
+        // We can't construct a real LicenseValidator from tests (it's internal with non-trivial
+        // dependencies), but Validator is settable so we can directly assert the contract.
+        l.Validator = null; // No-op; just demonstrates the slot exists.
+        l.ConfigureLicenseKey(new AiDotNetLicenseKey("rotated"));
+        Assert.Null(l.Validator);
+    }
+}

--- a/tests/AiDotNet.Tests/UnitTests/Configuration/AiModelObservabilityTests.cs
+++ b/tests/AiDotNet.Tests/UnitTests/Configuration/AiModelObservabilityTests.cs
@@ -1,0 +1,93 @@
+using System.Threading.Tasks;
+using AiDotNet.Configuration;
+using AiDotNet.Deployment.Configuration;
+using Xunit;
+
+namespace AiDotNet.Tests.UnitTests.Configuration;
+
+/// <summary>Audit-2026-05 phase-2a slice 10 — observability component isolation tests.</summary>
+public class AiModelObservabilityTests
+{
+    [Fact(Timeout = 30000)]
+    public async Task InitialState_AllSlotsAreNull()
+    {
+        await Task.Yield();
+        var o = new AiModelObservability();
+        Assert.Null(o.BenchmarkingOptions);
+        Assert.Null(o.ProfilingConfig);
+        Assert.Null(o.TelemetryConfig);
+    }
+
+    [Fact(Timeout = 30000)]
+    public async Task ConfigureBenchmarking_NullAppliesDefault()
+    {
+        await Task.Yield();
+        var o = new AiModelObservability();
+        o.ConfigureBenchmarking(null);
+        Assert.NotNull(o.BenchmarkingOptions);
+    }
+
+    [Fact(Timeout = 30000)]
+    public async Task ConfigureBenchmarking_ExplicitStored()
+    {
+        await Task.Yield();
+        var o = new AiModelObservability();
+        var opts = new BenchmarkingOptions();
+        o.ConfigureBenchmarking(opts);
+        Assert.Same(opts, o.BenchmarkingOptions);
+    }
+
+    [Fact(Timeout = 30000)]
+    public async Task ConfigureProfiling_NullAppliesEnabledDefault()
+    {
+        await Task.Yield();
+        var o = new AiModelObservability();
+        o.ConfigureProfiling(null);
+        Assert.NotNull(o.ProfilingConfig);
+        Assert.True(o.ProfilingConfig!.Enabled);
+    }
+
+    [Fact(Timeout = 30000)]
+    public async Task ConfigureTelemetry_NullIsValid()
+    {
+        await Task.Yield();
+        var o = new AiModelObservability();
+        o.ConfigureTelemetry(null);
+        Assert.Null(o.TelemetryConfig);
+    }
+
+    [Fact(Timeout = 30000)]
+    public async Task ConfigureTelemetry_ExplicitStored()
+    {
+        await Task.Yield();
+        var o = new AiModelObservability();
+        var cfg = new TelemetryConfig();
+        o.ConfigureTelemetry(cfg);
+        Assert.Same(cfg, o.TelemetryConfig);
+    }
+
+    [Fact(Timeout = 30000)]
+    public async Task ConfigureGpuDiagnostics_Null_NoOps()
+    {
+        await Task.Yield();
+        var o = new AiModelObservability();
+        o.ConfigureGpuDiagnostics(null); // should not throw
+    }
+
+    [Fact(Timeout = 30000)]
+    public async Task ConfigureGpuDiagnostics_LevelMutatesStatic()
+    {
+        await Task.Yield();
+        var o = new AiModelObservability();
+        var originalLevel = GpuDiagnosticsConfig.Level;
+        try
+        {
+            o.ConfigureGpuDiagnostics(new GpuDiagnosticsOptions { Level = GpuDiagnosticLevel.Verbose });
+            Assert.Equal(GpuDiagnosticLevel.Verbose, GpuDiagnosticsConfig.Level);
+        }
+        finally
+        {
+            GpuDiagnosticsConfig.Level = originalLevel; // restore process state
+        }
+    }
+}

--- a/tests/AiDotNet.Tests/UnitTests/Configuration/AiModelStorageTests.cs
+++ b/tests/AiDotNet.Tests/UnitTests/Configuration/AiModelStorageTests.cs
@@ -1,0 +1,95 @@
+using System.Threading.Tasks;
+using AiDotNet.Configuration;
+using AiDotNet.Deployment.Configuration;
+using AiDotNet.Interfaces;
+using AiDotNet.Tensors.LinearAlgebra;
+using Moq;
+using Xunit;
+
+namespace AiDotNet.Tests.UnitTests.Configuration;
+
+/// <summary>Audit-2026-05 phase-2a slice 9 — storage component isolation tests.</summary>
+public class AiModelStorageTests
+{
+    [Fact(Timeout = 30000)]
+    public async Task InitialState_AllSlotsAreNull()
+    {
+        await Task.Yield();
+        var s = new AiModelStorage<double, Matrix<double>, Vector<double>>();
+        Assert.Null(s.CacheConfig);
+        Assert.Null(s.VersioningConfig);
+        Assert.Null(s.ABTestingConfig);
+        Assert.Null(s.ExperimentTracker);
+        Assert.Null(s.ModelRegistry);
+        Assert.Null(s.DataVersionControl);
+    }
+
+    [Fact(Timeout = 30000)]
+    public async Task ConfigureCaching_NullIsValid()
+    {
+        await Task.Yield();
+        var s = new AiModelStorage<double, Matrix<double>, Vector<double>>();
+        s.ConfigureCaching(null);
+        Assert.Null(s.CacheConfig);
+    }
+
+    [Fact(Timeout = 30000)]
+    public async Task ConfigureCaching_ExplicitStored()
+    {
+        await Task.Yield();
+        var s = new AiModelStorage<double, Matrix<double>, Vector<double>>();
+        var cfg = new CacheConfig();
+        s.ConfigureCaching(cfg);
+        Assert.Same(cfg, s.CacheConfig);
+    }
+
+    [Fact(Timeout = 30000)]
+    public async Task ConfigureVersioning_ExplicitStored()
+    {
+        await Task.Yield();
+        var s = new AiModelStorage<double, Matrix<double>, Vector<double>>();
+        var cfg = new VersioningConfig();
+        s.ConfigureVersioning(cfg);
+        Assert.Same(cfg, s.VersioningConfig);
+    }
+
+    [Fact(Timeout = 30000)]
+    public async Task ConfigureABTesting_ExplicitStored()
+    {
+        await Task.Yield();
+        var s = new AiModelStorage<double, Matrix<double>, Vector<double>>();
+        var cfg = new ABTestingConfig();
+        s.ConfigureABTesting(cfg);
+        Assert.Same(cfg, s.ABTestingConfig);
+    }
+
+    [Fact(Timeout = 30000)]
+    public async Task ConfigureExperimentTracker_Stores()
+    {
+        await Task.Yield();
+        var s = new AiModelStorage<double, Matrix<double>, Vector<double>>();
+        var tracker = Mock.Of<IExperimentTracker<double>>();
+        s.ConfigureExperimentTracker(tracker);
+        Assert.Same(tracker, s.ExperimentTracker);
+    }
+
+    [Fact(Timeout = 30000)]
+    public async Task ConfigureModelRegistry_Stores()
+    {
+        await Task.Yield();
+        var s = new AiModelStorage<double, Matrix<double>, Vector<double>>();
+        var registry = Mock.Of<IModelRegistry<double, Matrix<double>, Vector<double>>>();
+        s.ConfigureModelRegistry(registry);
+        Assert.Same(registry, s.ModelRegistry);
+    }
+
+    [Fact(Timeout = 30000)]
+    public async Task ConfigureDataVersionControl_Stores()
+    {
+        await Task.Yield();
+        var s = new AiModelStorage<double, Matrix<double>, Vector<double>>();
+        var dvc = Mock.Of<IDataVersionControl<double>>();
+        s.ConfigureDataVersionControl(dvc);
+        Assert.Same(dvc, s.DataVersionControl);
+    }
+}


### PR DESCRIPTION
## Summary

Consolidates the **remaining Phase 2a `AiModelBuilder` concern slices** onto latest `master` in a single PR. Slices 1 (data-pipeline, #1432) and 2 (training-core, #1433) already landed; this brings in the rest — **slices 3, 4, 9, 10, 12**.

### Why a new branch instead of the original stack
The remaining slices were authored as a stack of sibling-based PRs (#1434 cross-validation, #1435 compliance, #1436 license, #1437 storage, #1438 observability). The stack tangled because the PR bases were never re-pointed to `master` — some showed "merged" but had actually merged into their *sibling* branches, so their work never reached `master`. Rather than untangle the mis-merged stack, this re-applies the full remaining delta cleanly onto current `master`. The content is taken from the fully-resolved tip of the original stack (`slice10-observability`), which already contained all seven slices.

### What lands (each extracts a concern out of the `AiModelBuilder` god class into a separately-testable component behind an interface)
| Slice | Interface | Configure methods |
|------|-----------|-------------------|
| 3 | `IAiModelCrossValidation` | ConfigureCrossValidation |
| 4 | `IAiModelCompliance` | BiasDetector, FairnessEvaluator, Interpretability, AdversarialRobustness, Safety |
| 12 | `IAiModelLicensing` (internal) | ConfigureLicenseKey |
| 9 | `IAiModelStorage` | Caching, Versioning, ABTesting, ExperimentTracker, ModelRegistry, DataVersionControl |
| 10 | `IAiModelObservability` | Benchmarking, Profiling, Telemetry, GpuDiagnostics |

### Hard invariant (same as the whole campaign)
Every public `AiModelBuilder` API surface stays identical in signature and observable behaviour. Legacy private fields remain as synced caches that `BuildAsync` and partial-class siblings read. Pre-existing side effects preserved verbatim (license-validator cache reset on key change; `GpuDiagnostics` process-wide static). Only internal composition changes.

### Verification
- [x] `src` builds clean on **net10.0** (0 errors)
- [x] `src` builds clean on **net471** (0 errors)
- [x] **72 / 72** `UnitTests.Configuration` tests pass

### Supersedes
#1434, #1435, #1436, #1437, #1438 — these can be closed once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
