### PR TITLE
fix(#1468): AiModelBuilder.BuildAsync on CNN/multi-dim-input NN models

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -73,10 +73,29 @@
          input — promotes to [1,K] and squeezes back, so unbatched FeedForward Predict
          no longer throws "TensorMatMul requires rank >= 2") and Tensors#522 (the
          int-overload Conv2DInto routes through the im2col-GEMM fast path instead of
-         the ~15x-slower SIMD-direct cascade). -->
-    <PackageVersion Include="AiDotNet.Tensors" Version="0.90.3" />
-    <PackageVersion Include="AiDotNet.Native.OneDNN" Version="0.90.3" />
-    <PackageVersion Include="AiDotNet.Native.OpenBLAS" Version="0.90.3" />
+         the ~15x-slower SIMD-direct cascade).
+
+         Bumped 0.90.3 -> 0.91.0 to pick up the GPU robustness fixes that unblock the
+         prebuilt-CNN/RNN facade path (#1468): Tensors#526 — (1) materialize-before-free
+         in DirectGpuTensorEngine.InvalidateActivationCacheEntry so a deferred GPU
+         download is no longer freed out from under a pending materializer (the #226-class
+         race that crashed AiModelBuilder.BuildAsync on CNN training with
+         "Failed to read OpenCL buffer: -5"), and (2) a GPU auto-detect correctness probe
+         so a present-but-broken backend falls back to CPU instead of being adopted.
+         AiDotNet.Native packages coreleased in lockstep at 0.91.0.
+
+         Bumped 0.91.0 -> 0.91.1 for the GPU MaxPool2D backward fix that actually
+         unblocks prebuilt-CNN training through the facade (#1468): Tensors#527 —
+         (1) pooling indices were uploaded as float[] but every backend's
+         maxpool2d_backward kernel reads them as int* (float bits reinterpreted as
+         ints → out-of-bounds scatter), and (2) the CUDA backend launched the 9-arg
+         kernel with only 8 args (garbage outWidth). Together these caused a hard CUDA
+         access violation / OpenCL "-5" one step into CNN backprop. Verified: the CNN
+         BuildAsync facade test trains + predicts on a real GPU with 0.91.1.
+         AiDotNet.Native packages coreleased in lockstep at 0.91.1. -->
+    <PackageVersion Include="AiDotNet.Tensors" Version="0.91.1" />
+    <PackageVersion Include="AiDotNet.Native.OneDNN" Version="0.91.1" />
+    <PackageVersion Include="AiDotNet.Native.OpenBLAS" Version="0.91.1" />
     <PackageVersion Include="AiDotNet.Native.CLBlast" Version="0.90.3" />
     <!-- Microsoft / .NET -->
     <PackageVersion Include="Microsoft.CSharp" Version="4.7.0" />

--- a/src/NeuralNetworks/Autoencoder.cs
+++ b/src/NeuralNetworks/Autoencoder.cs
@@ -323,6 +323,44 @@ public class Autoencoder<T> : NeuralNetworkBase<T>, IAuxiliaryLossLayer<T>
     /// This helps ensure your autoencoder is structured correctly before you start training it.
     /// </para>
     /// </remarks>
+    /// <summary>
+    /// Compares two layer shapes for the autoencoder structural checks, treating an
+    /// unresolved dimension (a negative value such as -1) on either side as a wildcard.
+    /// </summary>
+    /// <remarks>
+    /// Lazily-constructed layers report unresolved dimensions as -1 until the first
+    /// forward pass resolves them — e.g. <see cref="Layers.DenseLayer{T}"/>'s input shape
+    /// is <c>[-1]</c> when built via the output-size-only constructor. The previous
+    /// <c>SequenceEqual</c> checks compared those -1 sentinels against resolved dimensions
+    /// and threw at construction, so a perfectly valid DenseLayer-based symmetric
+    /// autoencoder could not be built before training (#1468). Resolved dimensions are
+    /// still compared exactly, and any genuine shape mismatch surfaces at the first
+    /// forward pass.
+    /// </remarks>
+    private static bool ShapesCompatibleIgnoringUnresolved(int[] a, int[] b)
+    {
+        if (a.Length != b.Length)
+        {
+            return false;
+        }
+
+        for (int i = 0; i < a.Length; i++)
+        {
+            // A negative dimension means "not yet resolved" — treat as a wildcard.
+            if (a[i] < 0 || b[i] < 0)
+            {
+                continue;
+            }
+
+            if (a[i] != b[i])
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
     protected override void ValidateCustomLayers(List<ILayer<T>> layers)
     {
         base.ValidateCustomLayers(layers);
@@ -333,7 +371,7 @@ public class Autoencoder<T> : NeuralNetworkBase<T>, IAuxiliaryLossLayer<T>
         }
 
         // Check if input and output layers have the same size
-        if (!Enumerable.SequenceEqual(layers[0].GetInputShape(), layers[layers.Count - 1].GetOutputShape()))
+        if (!ShapesCompatibleIgnoringUnresolved(layers[0].GetInputShape(), layers[layers.Count - 1].GetOutputShape()))
         {
             throw new ArgumentException("Input and output layer sizes must be the same for an autoencoder.");
         }
@@ -341,7 +379,7 @@ public class Autoencoder<T> : NeuralNetworkBase<T>, IAuxiliaryLossLayer<T>
         // Ensure the architecture is symmetric
         for (int i = 0; i < layers.Count / 2; i++)
         {
-            if (!Enumerable.SequenceEqual(layers[i].GetOutputShape(), layers[layers.Count - 1 - i].GetInputShape()))
+            if (!ShapesCompatibleIgnoringUnresolved(layers[i].GetOutputShape(), layers[layers.Count - 1 - i].GetInputShape()))
             {
                 throw new ArgumentException($"Layer sizes must be symmetric. Mismatch at position {i} and {layers.Count - i - 1}");
             }

--- a/src/NeuralNetworks/Layers/ReshapeLayer.cs
+++ b/src/NeuralNetworks/Layers/ReshapeLayer.cs
@@ -146,17 +146,24 @@ public class ReshapeLayer<T> : LayerBase<T>
     protected override void OnFirstForward(Tensor<T> input)
     {
         var shape = input.Shape.ToArray();
+        // shape[0] is the batch dimension; the reshape applies PER-SAMPLE and the layer's
+        // shapes exclude batch (see the class remarks). The previous code multiplied the
+        // whole input shape — including batch — and compared it to the per-sample output,
+        // so a batched input like [2, 8, 4] (per-sample 32) was rejected against output
+        // [32] because 2*8*4 = 64 != 32. Count per-sample elements (dims 1..) instead.
         int inElems = 1;
-        for (int i = 0; i < shape.Length; i++) inElems *= shape[i];
+        for (int i = 1; i < shape.Length; i++) inElems *= shape[i];
         int outElems = 1;
         for (int i = 0; i < _outputShape.Length; i++) outElems *= _outputShape[i];
         if (inElems != outElems)
             throw new ArgumentException(
-                $"ReshapeLayer input element count ({inElems}) does not match output element count ({outElems}).",
+                $"ReshapeLayer per-sample input element count ({inElems}) does not match output element count ({outElems}).",
                 nameof(input));
 
-        _inputShape = shape;
-        ResolveShapes(shape, _outputShape);
+        var perSample = new int[shape.Length - 1];
+        Array.Copy(shape, 1, perSample, 0, perSample.Length);
+        _inputShape = perSample;
+        ResolveShapes(perSample, _outputShape);
     }
 
     /// <summary>

--- a/src/NeuralNetworks/Layers/ResidualLayer.cs
+++ b/src/NeuralNetworks/Layers/ResidualLayer.cs
@@ -315,7 +315,34 @@ public class ResidualLayer<T> : LayerBase<T>
     /// </remarks>
     private void ValidateInnerLayer()
     {
-        if (_innerLayer != null && !Enumerable.SequenceEqual(_innerLayer.GetInputShape(), _innerLayer.GetOutputShape()))
+        if (_innerLayer == null)
+        {
+            return;
+        }
+
+        // Lazily-constructed inner layers report unresolved dimensions as -1 (e.g.
+        // DenseLayer's input shape is [-1] until the first forward resolves it). Treat
+        // -1 on either side as a wildcard so a valid residual block isn't rejected at
+        // construction time; resolved dimensions are still compared exactly and a genuine
+        // shape mismatch surfaces at the forward-pass add (#1468 — shared lazy-shape
+        // validation fix, mirrors Autoencoder.ShapesCompatibleIgnoringUnresolved).
+        var inShape = _innerLayer.GetInputShape();
+        var outShape = _innerLayer.GetOutputShape();
+        bool incompatible = inShape.Length != outShape.Length;
+        for (int i = 0; !incompatible && i < inShape.Length; i++)
+        {
+            if (inShape[i] < 0 || outShape[i] < 0)
+            {
+                continue;
+            }
+
+            if (inShape[i] != outShape[i])
+            {
+                incompatible = true;
+            }
+        }
+
+        if (incompatible)
         {
             throw new ArgumentException("Inner layer must have the same input and output shape for residual connections.");
         }

--- a/src/NeuralNetworks/Layers/SplitLayer.cs
+++ b/src/NeuralNetworks/Layers/SplitLayer.cs
@@ -144,8 +144,18 @@ public class SplitLayer<T> : LayerBase<T>
     protected override void OnFirstForward(Tensor<T> input)
     {
         var shape = input.Shape.ToArray();
-        var output = CalculateOutputShape(shape, _numSplits);
-        ResolveShapes(shape, output);
+        // The leading dimension is the batch; the split applies to the per-sample feature
+        // vector (the last dimension), matching Forward which reshapes to
+        // [flatBatch, lastDim] before splitting. The previous code checked shape[0] (the
+        // BATCH size) for divisibility — e.g. input [2, 32] split into 4 threw because
+        // 2 % 4 != 0 — and returned a 1-D output shape inconsistent with Forward's
+        // [batch, numSplits, splitSize] result. Strip the batch dim and split the feature
+        // dimension instead.
+        int featureSize = shape[shape.Length - 1];
+
+        // Per-sample shapes exclude the batch dimension: input is the feature vector,
+        // output adds the split axis → [numSplits, featureSize / numSplits].
+        ResolveShapes(new[] { featureSize }, CalculateOutputShape(shape, _numSplits));
     }
 
     /// <summary>
@@ -172,12 +182,14 @@ public class SplitLayer<T> : LayerBase<T>
     /// </remarks>
     private static int[] CalculateOutputShape(int[] inputShape, int numSplits)
     {
-        if (inputShape[0] % numSplits != 0)
+        // Splits the per-sample feature vector (the last dimension) into numSplits groups.
+        int featureSize = inputShape[inputShape.Length - 1];
+        if (featureSize % numSplits != 0)
         {
             throw new ArgumentException("Input size must be divisible by the number of splits");
         }
 
-        return [inputShape[0] / numSplits];
+        return [numSplits, featureSize / numSplits];
     }
 
     /// <summary>

--- a/src/NeuralNetworks/NeuralNetworkBase.cs
+++ b/src/NeuralNetworks/NeuralNetworkBase.cs
@@ -2111,6 +2111,13 @@ public abstract class NeuralNetworkBase<T> : INeuralNetworkModel<T>, IInterpreta
                 kSpan[baseIdx + j] = NumOps.Multiply(kSpan[baseIdx + j], scale);
             bSpan[oc] = NumOps.Add(NumOps.Multiply(NumOps.Subtract(bSpan[oc], mSpan[oc]), scale), beSpan[oc]);
         }
+
+        // In-place span mutation bypasses the engine's persistent-tensor cache (packed /
+        // GPU-resident kernel + bias buffers). Invalidate it so a cached forward path
+        // re-reads the folded values instead of the stale pre-fold weights — same fix as
+        // the Dense fold below; mirrors SetWeights / SetParameters.
+        Engine.InvalidatePersistentTensor(kernels);
+        Engine.InvalidatePersistentTensor(biases);
         return true;
     }
 
@@ -2155,6 +2162,17 @@ public abstract class NeuralNetworkBase<T> : INeuralNetworkModel<T>, IInterpreta
             }
             bSpan[oc] = NumOps.Add(NumOps.Multiply(NumOps.Subtract(bSpan[oc], mSpan[oc]), scale), beSpan[oc]);
         }
+
+        // The in-place span mutations above bypass the engine's persistent-tensor cache
+        // (the packed / GPU-resident weight + bias buffers keyed by these arrays). Every
+        // other weight-mutation path — SetWeights, SetParameters — invalidates that cache;
+        // the fold must too. Otherwise a forward path that serves weights from the cache
+        // (native-BLAS pre-pack / GPU buffer) reuses the STALE pre-fold weights, so the
+        // BatchNorm fold silently has no effect and the optimized model's output diverges
+        // sharply from the reference (observed as a ~0.18 Dense→BN folded-output divergence
+        // on the Linux native-BLAS CI path; the managed path happened to re-read the arrays).
+        Engine.InvalidatePersistentTensor(weights);
+        Engine.InvalidatePersistentTensor(biases);
         return true;
     }
 

--- a/src/NeuralNetworks/NeuralNetworkBase.cs
+++ b/src/NeuralNetworks/NeuralNetworkBase.cs
@@ -7987,7 +7987,15 @@ public abstract class NeuralNetworkBase<T> : INeuralNetworkModel<T>, IInterpreta
         // Sequence models with EmbeddingLayer don't support feature selection.
         // Their input shape is [1] (single token ID), not a feature vector.
         // Fixes #1113.
-        if (Layers.Count > 0 && Layers[0] is Layers.EmbeddingLayer<T>)
+        //
+        // Models with a non-flat (multi-dimensional) first-layer input shape — CNN
+        // (depth×H×W), RNN/GRU/LSTM (seqLen×features), Vision Transformer, etc. — are the
+        // same case generalized: "select a subset of input features" is a tabular concept
+        // that doesn't apply to spatial/sequence input, and the optimizer feeds flat indices
+        // (0..flatSize) that exceed the first layer's input-shape axis 0. Treat as a no-op
+        // rather than validating those indices against GetInputShape()[0]. Fixes #1468.
+        if (Layers.Count > 0
+            && (Layers[0] is Layers.EmbeddingLayer<T> || Layers[0].GetInputShape() is { Length: > 1 }))
         {
             // Clear any stale feature mask so IsFeatureUsed() doesn't
             // answer from a previous dense-feature configuration.

--- a/src/Optimizers/OptimizerBase.cs
+++ b/src/Optimizers/OptimizerBase.cs
@@ -1290,14 +1290,21 @@ public abstract class OptimizerBase<T, TInput, TOutput> : IOptimizer<T, TInput, 
     /// </remarks>
     protected void UpdateBestSolution(OptimizationStepData<T, TInput, TOutput> currentStepData, ref OptimizationStepData<T, TInput, TOutput> bestStepData)
     {
-        // If bestStepData has never been set by a real evaluation (empty SelectedFeatures
-        // and default fitness), always accept the first real result. This prevents a bug
-        // where the default FitnessScore of 0 is considered "better" than real evaluations
-        // by fitness calculators that treat lower scores as better.
-        bool bestIsUninitialized = bestStepData.SelectedFeatures.Count == 0
-            && NumOps.Equals(bestStepData.FitnessScore, NumOps.Zero);
-
-        if (bestIsUninitialized)
+        // If bestStepData has never been set by a real evaluation, always accept the
+        // first real result. This prevents a bug where the default FitnessScore of 0 is
+        // considered "better" than real evaluations by fitness calculators that treat
+        // lower scores as better.
+        //
+        // The uninitialized signal is "no solution recorded yet" (Solution is null until
+        // the first accept below sets it). It must NOT key off SelectedFeatures.Count == 0:
+        // multi-dimensional-input models (CNN/RNN/etc.) legitimately produce an empty
+        // SelectedFeatures list (feature subsetting doesn't apply — #1468), so a Count==0
+        // sentinel would treat every such step as uninitialized and overwrite a real best
+        // without a fitness comparison whenever the score is 0.
+        // Captured as a local and tested inline (not via an intermediate bool) so the
+        // compiler narrows it to non-null past this guard for the bestResult build below.
+        var bestSolution = bestStepData.Solution;
+        if (bestSolution is null)
         {
             bestStepData.Solution = currentStepData.Solution;
             bestStepData.FitnessScore = currentStepData.FitnessScore;
@@ -1320,7 +1327,7 @@ public abstract class OptimizerBase<T, TInput, TOutput> : IOptimizer<T, TInput, 
 
         var bestResult = new ModelResult<T, TInput, TOutput>
         {
-            Solution = bestStepData.Solution,
+            Solution = bestSolution,
             Fitness = bestStepData.FitnessScore,
             FitDetectionResult = bestStepData.FitDetectionResult,
             EvaluationData = bestStepData.EvaluationData,

--- a/src/Optimizers/OptimizerBase.cs
+++ b/src/Optimizers/OptimizerBase.cs
@@ -350,6 +350,25 @@ public abstract class OptimizerBase<T, TInput, TOutput> : IOptimizer<T, TInput, 
     }
 
     /// <summary>
+    /// Determines whether <paramref name="model"/> takes a non-flat (multi-dimensional)
+    /// input — i.e. a neural network whose first layer's input shape has rank &gt; 1
+    /// (CNN depth×height×width, RNN/GRU/LSTM sequence-length×features, Vision Transformer,
+    /// ResNet, etc.). For such models "feature selection" (selecting a subset of input
+    /// columns) is meaningless: the optimizer derives feature indices from the flattened
+    /// per-sample size, but these models index features against the first axis of their
+    /// input shape, and subsetting a spatial/sequence tensor by flat column index would
+    /// break the shape contract. Used by <see cref="PrepareAndEvaluateSolutionCore"/> and
+    /// <see cref="ApplyFeatureSelection"/> to skip feature selection/subsetting entirely,
+    /// generalizing the embedding-only <see cref="IsEmbeddingBasedModel"/> handling. Fixes #1468.
+    /// </summary>
+    protected static bool HasNonFlatNeuralInput(IFullModel<T, TInput, TOutput> model)
+    {
+        return model is NeuralNetworks.NeuralNetworkBase<T> nn
+            && nn.Layers.Count > 0
+            && nn.Layers[0].GetInputShape() is { Length: > 1 };
+    }
+
+    /// <summary>
     /// Applies the selected features to a model.
     /// </summary>
     /// <param name="model">The model to apply feature selection to.</param>
@@ -362,7 +381,11 @@ public abstract class OptimizerBase<T, TInput, TOutput> : IOptimizer<T, TInput, 
         if (selectedFeatures == null || selectedFeatures.Count == 0)
             throw new ArgumentException("At least one feature must be selected.", nameof(selectedFeatures));
 
-        if (IsEmbeddingBasedModel(model))
+        // Embedding-based and multi-dimensional-input models (CNN/RNN/ViT/etc.) don't
+        // support feature subsetting — their "feature index" doesn't map to a flat column.
+        // Skip applying selection so SetActiveFeatureIndices isn't fed flat indices that
+        // exceed the first layer's input-shape axis (#1113 / #1468).
+        if (IsEmbeddingBasedModel(model) || HasNonFlatNeuralInput(model))
             return;
 
         // Apply features if model supports it
@@ -522,11 +545,18 @@ public abstract class OptimizerBase<T, TInput, TOutput> : IOptimizer<T, TInput, 
         // features — their "feature dimension" is the sequence length, and selecting a
         // random subset of token positions breaks the shape contract between input and
         // target. Fixes #1113 / #1121 — affects ALL optimizers via OptimizerBase.
+        //
+        // Multi-dimensional-input models (CNN/RNN/GRU/LSTM/ViT/ResNet/etc.) are the same
+        // case generalized: their input is a spatial/sequence tensor, not a flat feature
+        // vector, so column-subset feature selection doesn't apply. They use all features
+        // and skip data subsetting entirely (Step 4 below). Fixes #1468.
         int totalFeatures = InputHelper<T, TInput>.GetInputSize(inputData.XTrain);
+        bool hasNonFlatInput = HasNonFlatNeuralInput(solution);
         List<int> selectedFeaturesIndices;
 
         if (!InterfaceGuard.Parameterizable(solution).SupportsParameterInitialization
-            || IsEmbeddingBasedModel(solution))
+            || IsEmbeddingBasedModel(solution)
+            || hasNonFlatInput)
         {
             selectedFeaturesIndices = Enumerable.Range(0, totalFeatures).ToList();
         }
@@ -548,16 +578,33 @@ public abstract class OptimizerBase<T, TInput, TOutput> : IOptimizer<T, TInput, 
             return cachedStepData;
         }
 
-        // Step 4: Apply feature selection to input data
-        var selectedFeatures = ModelHelper<T, TInput, TOutput>.GetColumnVectors(
-            inputData.XTrain, [.. selectedFeaturesIndices]);
+        // Step 4: Apply feature selection to input data.
+        // Multi-dimensional-input models train on the FULL input: flat column indices don't
+        // map to a spatial/sequence tensor's feature axis (GetColumnVectors/SelectFeatures
+        // index axis 1, but totalFeatures is the flattened per-sample size), so subsetting
+        // would throw or corrupt the shape. The indices stay the flat identity range, which
+        // AiModelResult treats as a no-op at predict time. Fixes #1468.
+        List<Vector<T>> selectedFeatures;
+        TInput XTrainSubset, XValSubset, XTestSubset;
+        if (hasNonFlatInput)
+        {
+            selectedFeatures = new List<Vector<T>>();
+            XTrainSubset = inputData.XTrain;
+            XValSubset = inputData.XValidation;
+            XTestSubset = inputData.XTest;
+        }
+        else
+        {
+            selectedFeatures = ModelHelper<T, TInput, TOutput>.GetColumnVectors(
+                inputData.XTrain, [.. selectedFeaturesIndices]);
 
-        var XTrainSubset = OptimizerHelper<T, TInput, TOutput>.SelectFeatures(
-            inputData.XTrain, selectedFeaturesIndices);
-        var XValSubset = OptimizerHelper<T, TInput, TOutput>.SelectFeatures(
-            inputData.XValidation, selectedFeaturesIndices);
-        var XTestSubset = OptimizerHelper<T, TInput, TOutput>.SelectFeatures(
-            inputData.XTest, selectedFeaturesIndices);
+            XTrainSubset = OptimizerHelper<T, TInput, TOutput>.SelectFeatures(
+                inputData.XTrain, selectedFeaturesIndices);
+            XValSubset = OptimizerHelper<T, TInput, TOutput>.SelectFeatures(
+                inputData.XValidation, selectedFeaturesIndices);
+            XTestSubset = OptimizerHelper<T, TInput, TOutput>.SelectFeatures(
+                inputData.XTest, selectedFeaturesIndices);
+        }
 
         // Step 5: Create input data with selected features
         var subsetInputData = new OptimizationInputData<T, TInput, TOutput>

--- a/tests/AiDotNet.Tests/IntegrationTests/NeuralNetworks/AdvancedLayersIntegrationTests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/NeuralNetworks/AdvancedLayersIntegrationTests.cs
@@ -811,6 +811,8 @@ public class AdvancedLayersIntegrationTests
     [Fact(Timeout = 120000)]
     public async Task GatedLinearUnitLayer_ParameterCount_IsPositive()
     {
+        await Task.Yield(); // activate [Fact(Timeout=...)] enforcement for this async test
+
         // Arrange
         var layer = new GatedLinearUnitLayer<float>(32, (IActivationFunction<float>?)null);
 
@@ -1572,6 +1574,8 @@ public class AdvancedLayersIntegrationTests
     [Fact(Timeout = 120000)]
     public async Task LSTMLayer_ParameterCount_IsPositive()
     {
+        await Task.Yield(); // activate [Fact(Timeout=...)] enforcement for this async test
+
         // Arrange
         int inputSize = 16;
         int hiddenSize = 32;

--- a/tests/AiDotNet.Tests/IntegrationTests/NeuralNetworks/AdvancedLayersIntegrationTests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/NeuralNetworks/AdvancedLayersIntegrationTests.cs
@@ -814,6 +814,12 @@ public class AdvancedLayersIntegrationTests
         // Arrange
         var layer = new GatedLinearUnitLayer<float>(32, (IActivationFunction<float>?)null);
 
+        // GLU sizes its [output x input] linear + gate weight matrices lazily from the
+        // input dimension on the first forward — the constructor only fixes the output
+        // dimension (32). Run one forward over a 64-feature input so the weights are
+        // allocated before we count them (otherwise only the two biases exist → 64).
+        _ = layer.Forward(Tensor<float>.CreateRandom([2, 64]));
+
         // Act
         int paramCount = (int)layer.ParameterCount;
 
@@ -1572,6 +1578,11 @@ public class AdvancedLayersIntegrationTests
         int sequenceLength = 5;
         int[] inputShape = [sequenceLength, inputSize];
         var layer = new LSTMLayer<float>( hiddenSize, (IActivationFunction<float>?)null);
+
+        // LSTM sizes its input-to-hidden gate weights lazily from the input dimension on
+        // the first forward — the constructor only fixes the hidden size. Resolve via one
+        // forward over a [batch, seqLen, inputSize] sequence before counting parameters.
+        _ = layer.Forward(Tensor<float>.CreateRandom([2, sequenceLength, inputSize]));
 
         // Act
         int paramCount = (int)layer.ParameterCount;

--- a/tests/AiDotNet.Tests/IntegrationTests/NeuralNetworks/FacadeMultiDimInputBuildAsyncTests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/NeuralNetworks/FacadeMultiDimInputBuildAsyncTests.cs
@@ -113,7 +113,7 @@ public class FacadeMultiDimInputBuildAsyncTests
     [Fact(Timeout = 60000)]
     public async Task SetActiveFeatureIndices_MultiDimInputModel_DoesNotThrow()
     {
-        await Task.CompletedTask;
+        await Task.Yield();
 
         const int side = 8, channels = 3, classes = 3;
         var cnn = BuildCnn(side, channels, classes);
@@ -138,7 +138,7 @@ public class FacadeMultiDimInputBuildAsyncTests
     [Fact(Timeout = 120000)]
     public async Task Autoencoder_CustomSymmetricLayers_ConstructsAndPredicts()
     {
-        await Task.CompletedTask;
+        await Task.Yield();
 
         // A symmetric autoencoder built from DenseLayers: 64 -> 32 -> 8 -> 32 -> 64.
         // DenseLayer(int outputSize) lazy-initializes its input shape to [-1] (resolved on
@@ -179,7 +179,7 @@ public class FacadeMultiDimInputBuildAsyncTests
     [Fact(Timeout = 60000)]
     public async Task ResidualLayer_WrappingLazyInnerLayer_ConstructsWithoutThrowing()
     {
-        await Task.CompletedTask;
+        await Task.Yield();
 
         // A residual block wrapping a DenseLayer whose input shape is lazily [-1] (resolved
         // on first forward) must not throw at construction. The validation compared the

--- a/tests/AiDotNet.Tests/IntegrationTests/NeuralNetworks/FacadeMultiDimInputBuildAsyncTests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/NeuralNetworks/FacadeMultiDimInputBuildAsyncTests.cs
@@ -1,0 +1,135 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using AiDotNet;
+using AiDotNet.ActivationFunctions;
+using AiDotNet.Data.Loaders;
+using AiDotNet.Enums;
+using AiDotNet.Interfaces;
+using AiDotNet.LossFunctions;
+using AiDotNet.Models.Options;
+using AiDotNet.NeuralNetworks;
+using AiDotNet.NeuralNetworks.Layers;
+using AiDotNet.Optimizers;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tests.IntegrationTests.NeuralNetworks;
+
+/// <summary>
+/// Regression tests for issue #1468: <c>AiModelBuilder.BuildAsync</c> threw
+/// <see cref="ArgumentOutOfRangeException"/> ("Feature index N exceeds the input dimension D")
+/// for any prebuilt neural network whose first layer has a non-flat input shape
+/// (CNN, GRU/LSTM, Vision Transformer, etc.).
+///
+/// Root cause: the optimizer's feature-selection pass derives feature indices from the
+/// flattened per-sample input size (e.g. 3·8·8 = 192 for a 3-channel 8×8 image), but a
+/// multi-dimensional NN validates/handles "features" against the FIRST axis of its first
+/// layer's input shape (depth=3 for a CNN, sequence-length for an RNN). The counts diverge,
+/// so an index ≥ that axis throws — and even the "use all features" path then breaks the
+/// spatial/sequence tensor in <c>GetColumnVectors</c>/<c>SelectFeatures</c> (which index axis 1).
+///
+/// "Feature selection" (selecting a subset of input columns) is a tabular concept that does
+/// not apply to spatial/sequence input, so for these models the builder must train on the
+/// full input and skip feature subsetting entirely (generalizing the embedding-only #1113 fix).
+/// </summary>
+public class FacadeMultiDimInputBuildAsyncTests
+{
+    private static (Tensor<double> x, Tensor<double> y) GenerateImages(
+        int samples, int side, int channels, int classes, int seed)
+    {
+        var rng = new Random(seed);
+        var x = new Tensor<double>(new[] { samples, channels, side, side });
+        var y = new Tensor<double>(new[] { samples, classes });
+        for (int n = 0; n < samples; n++)
+        {
+            for (int c = 0; c < channels; c++)
+                for (int h = 0; h < side; h++)
+                    for (int w = 0; w < side; w++)
+                        x[n, c, h, w] = rng.NextDouble();
+
+            int label = rng.Next(classes);
+            for (int k = 0; k < classes; k++)
+                y[n, k] = k == label ? 1.0 : 0.0;
+        }
+        return (x, y);
+    }
+
+    private static ConvolutionalNeuralNetwork<double> BuildCnn(int side, int channels, int classes)
+    {
+        var layers = new List<ILayer<double>>
+        {
+            new ConvolutionalLayer<double>(outputDepth: 8, kernelSize: 3, stride: 1, padding: 1,
+                activationFunction: new ReLUActivation<double>()),
+            new MaxPoolingLayer<double>(poolSize: 2, stride: 2),
+            new FlattenLayer<double>(),
+            new DenseLayer<double>(outputSize: classes, activationFunction: new SoftmaxActivation<double>()),
+        };
+        var architecture = new NeuralNetworkArchitecture<double>(
+            inputType: InputType.ThreeDimensional,
+            taskType: NeuralNetworkTaskType.MultiClassClassification,
+            complexity: NetworkComplexity.Simple,
+            inputHeight: side, inputWidth: side, inputDepth: channels,
+            outputSize: classes, layers: layers);
+        return new ConvolutionalNeuralNetwork<double>(architecture);
+    }
+
+    [Fact(Timeout = 180000)]
+    public async Task BuildAsync_PrebuiltCnn_MultiDimInput_DoesNotThrow_AndPredicts()
+    {
+        const int side = 8, channels = 3, classes = 3, samples = 60;
+        var (trainX, trainY) = GenerateImages(samples, side, channels, classes, seed: 1468);
+
+        var cnn = BuildCnn(side, channels, classes);
+        var adam = new AdamOptimizer<double, Tensor<double>, Tensor<double>>(
+            null,
+            new AdamOptimizerOptions<double, Tensor<double>, Tensor<double>>
+            {
+                InitialLearningRate = 0.01,
+                MaxIterations = 5
+            });
+
+        // Before the #1468 fix this threw ArgumentOutOfRangeException:
+        // "Feature index 3 exceeds the input dimension 3."
+        var result = await new AiModelBuilder<double, Tensor<double>, Tensor<double>>()
+            .ConfigureModel(cnn)
+            .ConfigureOptimizer(adam)
+            .ConfigureLossFunction(new CategoricalCrossEntropyLoss<double>())
+            .ConfigureDataLoader(
+                new InMemoryDataLoader<double, Tensor<double>, Tensor<double>>(trainX, trainY))
+            .BuildAsync();
+
+        Assert.NotNull(result);
+        Assert.NotNull(result.Model);
+
+        // The facade must also predict on new multi-dim input without throwing.
+        var (testX, _) = GenerateImages(4, side, channels, classes, seed: 9999);
+        var predictions = result.Predict(testX);
+        Assert.NotNull(predictions);
+        Assert.Equal(4, predictions.Shape[0]);
+        Assert.Equal(classes, predictions.Shape[predictions.Shape.Length - 1]);
+    }
+
+    [Fact(Timeout = 60000)]
+    public async Task SetActiveFeatureIndices_MultiDimInputModel_DoesNotThrow()
+    {
+        await Task.CompletedTask;
+
+        const int side = 8, channels = 3, classes = 3;
+        var cnn = BuildCnn(side, channels, classes);
+
+        // Resolve the lazy conv input shape ([-1,-1,-1] → [3,8,8]) via one forward pass,
+        // so GetInputShape()[0] == 3 and the pre-fix validation would fire.
+        var (oneImage, _) = GenerateImages(1, side, channels, classes, seed: 7);
+        _ = cnn.Predict(oneImage);
+
+        // The optimizer selects flat feature indices (0..191 for a 3×8×8 image). On a
+        // multi-dim model these must be treated as a no-op, NOT validated against axis 0 (=3).
+        var flatIndices = new List<int>();
+        for (int i = 0; i < channels * side * side; i++)
+            flatIndices.Add(i);
+
+        var ex = Record.Exception(() => cnn.SetActiveFeatureIndices(flatIndices));
+        Assert.Null(ex);
+    }
+}

--- a/tests/AiDotNet.Tests/IntegrationTests/NeuralNetworks/FacadeMultiDimInputBuildAsyncTests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/NeuralNetworks/FacadeMultiDimInputBuildAsyncTests.cs
@@ -132,4 +132,63 @@ public class FacadeMultiDimInputBuildAsyncTests
         var ex = Record.Exception(() => cnn.SetActiveFeatureIndices(flatIndices));
         Assert.Null(ex);
     }
+
+    // ---- Autoencoder custom-layer shape validation (#1468 second affected model) ----
+
+    [Fact(Timeout = 120000)]
+    public async Task Autoencoder_CustomSymmetricLayers_ConstructsAndPredicts()
+    {
+        await Task.CompletedTask;
+
+        // A symmetric autoencoder built from DenseLayers: 64 -> 32 -> 8 -> 32 -> 64.
+        // DenseLayer(int outputSize) lazy-initializes its input shape to [-1] (resolved on
+        // first forward), so the construction-time symmetry/equality checks compared [-1]
+        // against resolved dims and threw "Input and output layer sizes must be the same"
+        // before training — blocking the autoencoder family through the facade (#1468).
+        const int inputDim = 64, hidden = 32, encoding = 8;
+        var layers = new List<ILayer<double>>
+        {
+            new DenseLayer<double>(hidden, activationFunction: new ReLUActivation<double>()),
+            new DenseLayer<double>(encoding, activationFunction: new ReLUActivation<double>()),
+            new DenseLayer<double>(hidden, activationFunction: new ReLUActivation<double>()),
+            new DenseLayer<double>(inputDim, activationFunction: new ReLUActivation<double>()),
+        };
+        var architecture = new NeuralNetworkArchitecture<double>(
+            inputType: InputType.OneDimensional,
+            taskType: NeuralNetworkTaskType.Regression,
+            complexity: NetworkComplexity.Simple,
+            inputSize: inputDim,
+            outputSize: inputDim,
+            layers: layers);
+
+        // Construction runs ValidateCustomLayers — this is where #1468 threw.
+        var autoencoder = new Autoencoder<double>(architecture);
+        Assert.NotNull(autoencoder);
+
+        // And it must reconstruct (forward pass resolves the lazy shapes).
+        var inputData = new double[inputDim];
+        var rng = new Random(1468);
+        for (int i = 0; i < inputDim; i++) inputData[i] = rng.NextDouble();
+        var input = new Tensor<double>(inputData, new[] { inputDim });
+
+        var output = autoencoder.Predict(input);
+        Assert.NotNull(output);
+        Assert.Equal(inputDim, output.Length);
+    }
+
+    [Fact(Timeout = 60000)]
+    public async Task ResidualLayer_WrappingLazyInnerLayer_ConstructsWithoutThrowing()
+    {
+        await Task.CompletedTask;
+
+        // A residual block wrapping a DenseLayer whose input shape is lazily [-1] (resolved
+        // on first forward) must not throw at construction. The validation compared the
+        // inner layer's [-1] input against its resolved output and threw "Inner layer must
+        // have the same input and output shape for residual connections." — the same
+        // lazy-shape validation class as the autoencoder bug (#1468).
+        var inner = new DenseLayer<double>(16, activationFunction: new ReLUActivation<double>());
+
+        var ex = Record.Exception(() => new ResidualLayer<double>(inner));
+        Assert.Null(ex);
+    }
 }


### PR DESCRIPTION
Closes #1468

## Summary

`AiModelBuilder<T, Tensor<T>, Tensor<T>>.BuildAsync()` threw `ArgumentOutOfRangeException` ("Feature index N exceeds the input dimension D") for **any prebuilt NN whose first layer has a non-flat input shape** (CNN, GRU/LSTM, Vision Transformer, ResNet, …), breaking the facade pattern for every CV/sequence model. This PR fixes that **and** the related prebuilt-layer shape/validation bugs surfaced in the same family (including the Autoencoder issue called out in #1468).

## 1. Feature-index bug (the headline issue)

The optimizer's feature-selection pass derives indices from the **flattened** per-sample input size, but a multi-dimensional NN handles "features" against the **first axis** of its first layer's input shape — the counts diverge, so any index ≥ that axis throws (and the "use all features" path then breaks the tensor in `GetColumnVectors`/`SelectFeatures`).

- **`OptimizerBase`** — new `HasNonFlatNeuralInput` detector; multi-dim models use all features and **skip the data-subsetting block** (flat indices don't map to a spatial/sequence tensor's feature axis). `SelectedFeatureIndices` stays the flat identity range → predict-time no-op. Generalizes the embedding-only #1113 fix.
- **`NeuralNetworkBase.SetActiveFeatureIndices`** — defensively no-ops for a multi-dimensional first layer (rank > 1).

## 2. Lazy-shape validation (Autoencoder + ResidualLayer)

`DenseLayer`'s input shape is lazily `[-1]` until the first forward, so structural checks using `SequenceEqual` failed at construction:
- **`Autoencoder.ValidateCustomLayers`** — a valid symmetric DenseLayer autoencoder threw "Input and output layer sizes must be the same". Now treats an unresolved `-1` dim as a wildcard (`ShapesCompatibleIgnoringUnresolved`); resolved dims still compared exactly. *(The Autoencoder validation issue explicitly listed in #1468.)*
- **`ResidualLayer.ValidateInnerLayer`** — a residual block wrapping a lazy `DenseLayer` threw "Inner layer must have the same input and output shape". Same wildcard treatment.

## 3. Batch-dimension handling in layer shape resolution

- **`SplitLayer.OnFirstForward`** — checked `shape[0]` (the **batch** size) for divisibility and returned a 1-D shape, so input `[2,32]` split into 4 threw `2 % 4`. Now splits the per-sample feature (last) dimension → `[numSplits, featureSize/numSplits]`, matching `Forward`.
- **`ReshapeLayer.OnFirstForward`** — multiplied the whole input shape (incl. batch) vs the per-sample output, so `[2,8,4] → [32]` threw on `64 != 32`. Now counts per-sample elements and resolves the per-sample input shape.

## 4. Lazy parameter-count tests (GLU / LSTM)

`GatedLinearUnitLayer` / `LSTMLayer` are correctly lazy (constructors fix only the output/hidden size; input-dependent weights size on first forward). Their `ParameterCount` tests asserted a resolved count **without** resolving — now they run one forward to allocate the weights before counting (GLU `== 4160`, LSTM `> 0`).

## GPU dependency bump (0.91.0 → 0.91.1)

Once the feature-index fix let CNN training reach the GPU backward pass, it surfaced a crash in `AiDotNet.Tensors`' GPU MaxPool2D backward (CUDA `0xC0000005` / OpenCL `-5`): pooling indices uploaded as `float[]` but kernels read `int*`, and the CUDA kernel launched 8 args for a 9-param kernel. Fixed in **[AiDotNet.Tensors#527](https://github.com/ooples/AiDotNet.Tensors/pull/527)** (shipped in `0.91.1`); this PR bumps the pin (lockstep Native packages too) to consume it.

## Verification

- **`FacadeMultiDimInputBuildAsyncTests`** (4 tests): the issue's CNN `BuildAsync` repro (train + predict, **passes on a real CUDA GPU** against the published `0.91.1`), the `SetActiveFeatureIndices` no-op guard, the custom-layer **Autoencoder** construct+predict, and the **ResidualLayer** lazy-inner guard.
- **`AdvancedLayersIntegrationTests`**: the six Split/Reshape/GLU/LSTM failures fixed; **full suite green (211/211)**.
- Regression slice (`AiModelBuilderPredictIntegrationTests` + `RLTrainingIntegrationTests`, 17 tests): green — flat-input models unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented feature-selection from rejecting indices for multi-dimensional/sequence inputs; optimizer now skips feature-subsetting for non-flat neural inputs and fixes best-solution detection.
  * Invalidation of persistent tensor caches after in-place layer folding to avoid stale buffers.
  * Improved shape validation to tolerate unresolved (lazy) dimensions across autoencoders, reshape/split, and residual layers.

* **Tests**
  * Added regression/integration tests for multi-dimensional inputs and lazy-shaped layers; updated GLU/LSTM parameter-count tests.

* **Chores**
  * Bumped core AiDotNet packages to v0.91.1.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->