### PR TITLE
perf(#1478): route Transformer self-attention inference to fused MHA kernel (P0)

### DIFF
--- a/src/NeuralNetworks/Layers/MultiHeadAttentionLayer.cs
+++ b/src/NeuralNetworks/Layers/MultiHeadAttentionLayer.cs
@@ -966,6 +966,102 @@ public partial class MultiHeadAttentionLayer<T> : LayerBase<T>, IAuxiliaryLossLa
     private int[] _originalKeyShape = [];
     private int[] _originalValueShape = [];
 
+    /// <summary>
+    /// Attempts the single fused multi-head-attention inference kernel
+    /// (<c>IEngine.MultiHeadAttentionForward</c>) for a pure self-attention block.
+    /// Returns false (and the caller uses the decomposed <see cref="ForwardInternal"/>
+    /// walk) whenever the block isn't representable by the fused kernel.
+    /// </summary>
+    /// <remarks>
+    /// Eligibility — all required:
+    /// <list type="bullet">
+    /// <item><description>Inference mode (the fused kernel is forward-only; gating on
+    /// <see cref="LayerBase{T}.IsTrainingMode"/> also avoids a per-train-step throw/catch).</description></item>
+    /// <item><description>Self-attention: Q, K, V are the same tensor reference (the kernel
+    /// projects one input for all three).</description></item>
+    /// <item><description>No RoPE / ALiBi / causal masking (the kernel applies no positional bias;
+    /// the non-ALiBi decomposed path already passes <c>mask: null</c>, so a fused call with
+    /// <c>mask: null</c> is behaviour-equivalent for self-attention).</description></item>
+    /// <item><description>Weights materialized (lazy-init networks start at <c>[0,0]</c>).</description></item>
+    /// </list>
+    /// The fused kernel omits the output-projection bias and the layer activation, so the
+    /// fused output adds <c>_outputBias</c> (broadcast) and runs <see cref="LayerBase{T}.ApplyActivation(Tensor{T})"/>,
+    /// matching the decomposed path's <c>FusedLinear(context, _outputWeights, _outputBias, None)</c> +
+    /// <c>ApplyActivation</c> tail. The output is restored to the caller's rank.
+    /// </remarks>
+    private bool TryFusedAttentionInference(Tensor<T> query, Tensor<T> key, Tensor<T> value, out Tensor<T> output)
+    {
+        output = Tensor<T>.Empty();
+
+        if (IsTrainingMode) return false;
+        if (_ropeLayer != null || _alibiLayer != null || UseCausalMask) return false;
+        if (!ReferenceEquals(query, key) || !ReferenceEquals(key, value)) return false;
+
+        // Weights must be materialized (lazy-init Q/K/V start at [0,0]).
+        if (_queryWeights.Rank != 2 || _queryWeights.Shape[0] == 0 || _queryWeights.Shape[1] == 0)
+            return false;
+
+        int rank = query.Rank;
+        if (rank < 1) return false;
+        int dModel = query.Shape[^1];
+        // dModel mismatch is a real error the decomposed path reports with full context.
+        if (dModel != _embeddingDimension) return false;
+        // numHeads must divide dModel (always true by construction, but the kernel asserts it).
+        if (_headCount <= 0 || dModel % _headCount != 0) return false;
+
+        int[] originalShape = query._shape;
+        int seqLen;
+        int batch = 1;
+        if (rank == 1)
+        {
+            seqLen = 1;
+        }
+        else
+        {
+            seqLen = query.Shape[^2];
+            for (int i = 0; i < rank - 2; i++) batch *= query.Shape[i];
+        }
+
+        // The kernel requires a contiguous rank-3 [batch, seq, dModel] input.
+        Tensor<T> input3D = Engine.Reshape(query, [batch, seqLen, dModel]);
+
+        try
+        {
+            var fused = Engine.MultiHeadAttentionForward(
+                input3D, _queryWeights, _keyWeights, _valueWeights, _outputWeights, _headCount, mask: null);
+
+            // Output-projection bias + layer activation (the fused kernel applies neither).
+            Engine.TensorBroadcastAddInPlace(fused, _outputBias);
+            var activated = ApplyActivation(fused);
+
+            // Restore the caller's rank: [dModel] for 1D, [seq, dModel] for 2D,
+            // [origBatch..., seq, dModel] otherwise.
+            if (rank == 1)
+            {
+                output = Engine.Reshape(activated, [dModel]);
+            }
+            else if (rank == 2)
+            {
+                output = Engine.Reshape(activated, [seqLen, dModel]);
+            }
+            else
+            {
+                int[] outShape = new int[rank];
+                for (int i = 0; i < rank - 2; i++) outShape[i] = originalShape[i];
+                outShape[^2] = seqLen;
+                outShape[^1] = dModel;
+                output = Engine.Reshape(activated, outShape);
+            }
+            return true;
+        }
+        catch (InvalidOperationException)
+        {
+            // Forward-only kernel hit an active GradientTape; use the decomposed path.
+            output = Tensor<T>.Empty();
+            return false;
+        }
+    }
+
     private Tensor<T> ForwardInternal(Tensor<T> query, Tensor<T> key, Tensor<T> value)
     {
         // If the layer was constructed with a lazy init strategy, the Q/K/V/O
@@ -975,6 +1071,16 @@ public partial class MultiHeadAttentionLayer<T> : LayerBase<T>, IAuxiliaryLossLa
         // happens (the ROPE/ALiBi fields this layer owns).
         EnsureWeightsAllocated();
         EnsureInitialized();
+
+        // Fused inference fast path: pure self-attention with no positional bias
+        // collapses Q/K/V projection + multi-head SDPA + output projection into ONE
+        // engine call (5+ engine dispatches / 6 transpose materializations -> 1),
+        // the path the AIsEval Transformer-inference benchmark needs (the bs128
+        // 50x scaling cliff is the decomposed per-op walk, not SDPA itself).
+        // Inference-only (the forward kernel throws under a GradientTape); falls
+        // back to the decomposed walk for anything it can't represent.
+        if (TryFusedAttentionInference(query, key, value, out var fusedResult))
+            return fusedResult;
 
         // Industry standard: Support any-rank tensors (like PyTorch's MultiheadAttention)
         // Last two dimensions are [sequence, embedding_dim]

--- a/tests/AiDotNet.Tests/UnitTests/NeuralNetworks/MultiHeadAttentionFusedInferenceTests.cs
+++ b/tests/AiDotNet.Tests/UnitTests/NeuralNetworks/MultiHeadAttentionFusedInferenceTests.cs
@@ -1,0 +1,160 @@
+using System;
+using AiDotNet.ActivationFunctions;
+using AiDotNet.Enums;
+using AiDotNet.Interfaces;
+using AiDotNet.NeuralNetworks;
+using AiDotNet.NeuralNetworks.Layers;
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tests.UnitTests.NeuralNetworks;
+
+/// <summary>
+/// Parity + correctness guards for the fused multi-head-attention inference path
+/// (<see cref="MultiHeadAttentionLayer{T}"/> → <c>IEngine.MultiHeadAttentionForward</c>),
+/// the P0 win of issue #1478. The fused single-call kernel must be numerically
+/// identical to the decomposed Q/K/V + SDPA + output-projection walk it replaces,
+/// across the AIsEval attention shape and from bs1 to bs128 (the batch range where
+/// the decomposed path's 50× scaling cliff showed up).
+/// </summary>
+public class MultiHeadAttentionFusedInferenceTests
+{
+    private const int HeadCount = 4;
+    private const int HeadDim = 16;          // dModel = 64, the AIsEval encoder shape
+    private const int DModel = HeadCount * HeadDim;
+    private const int SeqLen = 32;
+
+    private static Tensor<float> RandomInput(int batch, int seq, int dModel, int seed)
+    {
+        var rng = new Random(seed);
+        var data = new float[batch * seq * dModel];
+        for (int i = 0; i < data.Length; i++)
+            data[i] = (float)(rng.NextDouble() * 2.0 - 1.0);
+        return new Tensor<float>(data, new[] { batch, seq, dModel });
+    }
+
+    /// <summary>
+    /// The fused inference path (eval mode) must equal the decomposed path (train
+    /// mode forces <c>TryFusedAttentionInference</c> to bail) on the SAME materialized
+    /// weights, for representative batch sizes including bs128.
+    /// </summary>
+    [Theory]
+    [InlineData(1)]
+    [InlineData(8)]
+    [InlineData(32)]
+    [InlineData(128)]
+    public void FusedInference_MatchesDecomposed_SelfAttention(int batch)
+    {
+        AiDotNetEngine.ResetToCpu();
+
+        var layer = new MultiHeadAttentionLayer<float>(
+            HeadCount, HeadDim, (IActivationFunction<float>)new IdentityActivation<float>());
+
+        var input = RandomInput(batch, SeqLen, DModel, seed: 1478 + batch);
+
+        // Eval mode → fused single-call kernel. First call also materializes the
+        // lazy Q/K/V/O weights; subsequent calls reuse them.
+        layer.SetTrainingMode(false);
+        var fused = layer.Forward(input);
+
+        // Train mode → decomposed walk (IsTrainingMode gate bails out of the fused
+        // path) on the SAME weights. No GradientTape is active, so this is the pure
+        // forward math of the path the fused kernel replaces.
+        layer.SetTrainingMode(true);
+        var decomposed = layer.Forward(input);
+
+        Assert.Equal(decomposed.Shape, fused.Shape);
+        Assert.Equal(new[] { batch, SeqLen, DModel }, fused.Shape);
+
+        var f = fused.GetDataArray();
+        var d = decomposed.GetDataArray();
+        Assert.Equal(d.Length, f.Length);
+        float maxAbsDiff = 0f;
+        for (int i = 0; i < f.Length; i++)
+        {
+            Assert.True(float.IsFinite(f[i]), $"fused output element {i} is not finite");
+            maxAbsDiff = Math.Max(maxAbsDiff, Math.Abs(f[i] - d[i]));
+        }
+        // Float GEMM + softmax reassociation between the two kernels; 1e-3 is tight.
+        Assert.True(maxAbsDiff < 1e-3f, $"fused vs decomposed max|diff| = {maxAbsDiff} at bs{batch}");
+    }
+
+    /// <summary>
+    /// 2D [seq, dModel] (unbatched) input must also round-trip through the fused path
+    /// and match the decomposed path, with the caller's rank preserved.
+    /// </summary>
+    [Fact]
+    public void FusedInference_Preserves2DRank_AndMatchesDecomposed()
+    {
+        AiDotNetEngine.ResetToCpu();
+
+        var layer = new MultiHeadAttentionLayer<float>(
+            HeadCount, HeadDim, (IActivationFunction<float>)new IdentityActivation<float>());
+
+        var rng = new Random(20260602);
+        var data = new float[SeqLen * DModel];
+        for (int i = 0; i < data.Length; i++) data[i] = (float)(rng.NextDouble() * 2.0 - 1.0);
+        var input = new Tensor<float>(data, new[] { SeqLen, DModel });
+
+        layer.SetTrainingMode(false);
+        var fused = layer.Forward(input);
+        layer.SetTrainingMode(true);
+        var decomposed = layer.Forward(input);
+
+        Assert.Equal(new[] { SeqLen, DModel }, fused.Shape);
+        var f = fused.GetDataArray();
+        var d = decomposed.GetDataArray();
+        float maxAbsDiff = 0f;
+        for (int i = 0; i < f.Length; i++)
+            maxAbsDiff = Math.Max(maxAbsDiff, Math.Abs(f[i] - d[i]));
+        Assert.True(maxAbsDiff < 1e-3f, $"2D fused vs decomposed max|diff| = {maxAbsDiff}");
+    }
+
+    /// <summary>
+    /// End-to-end: the AIsEval-shaped production Transformer's <c>Predict</c> (which
+    /// now routes its encoder self-attention through the fused kernel) returns the
+    /// right shape, finite values, and is deterministic across calls at bs1 and bs128.
+    /// </summary>
+    [Theory]
+    [InlineData(1)]
+    [InlineData(128)]
+    public void Transformer_Predict_FusedAttention_ShapeAndDeterminism(int batch)
+    {
+        AiDotNetEngine.ResetToCpu();
+
+        var arch = new TransformerArchitecture<float>(
+            inputType: InputType.OneDimensional,
+            taskType: NeuralNetworkTaskType.MultiClassClassification,
+            numEncoderLayers: 2,
+            numDecoderLayers: 0,
+            numHeads: HeadCount,
+            modelDimension: DModel,
+            feedForwardDimension: 128,
+            inputSize: 32,
+            outputSize: 10,
+            dropoutRate: 0.0,
+            maxSequenceLength: SeqLen,
+            vocabularySize: 0,
+            usePositionalEncoding: true,
+            sequencePooling: SequencePoolingMode.MeanPool);
+        var model = new Transformer<float>(arch);
+
+        var rng = new Random(99);
+        var data = new float[batch * SeqLen * 32];
+        for (int i = 0; i < data.Length; i++) data[i] = (float)(rng.NextDouble() * 2.0 - 1.0);
+        var input = new Tensor<float>(data, new[] { batch, SeqLen, 32 });
+
+        var first = model.Predict(input);
+        var second = model.Predict(input);
+
+        Assert.Equal(new[] { batch, 10 }, first.Shape);
+        var a = first.GetDataArray();
+        var b = second.GetDataArray();
+        for (int i = 0; i < a.Length; i++)
+        {
+            Assert.True(float.IsFinite(a[i]), $"prediction element {i} is not finite");
+            Assert.Equal(a[i], b[i]);   // deterministic
+        }
+    }
+}


### PR DESCRIPTION
Companion to ooples/AiDotNet.Tensors#540 (and the merged #538). The AIsEval compiled-mode benchmark surfaced three compiled-inference defects; the Tensors-side fixes live in #540, and this PR carries the AiDotNet-side regression tests, the residency valve, and the validation pin.

## Regression tests (CompiledInferenceParityTests)
- **CNN compiled replay == eager** at the traced shape AND at bs=8/128 for a plan traced at bs=1 (BatchDynamic). Was relErr=1.0 garbage before AiDotNet.Tensors#540 (untraced `MaxPool2DWithIndices` left the captured graph disconnected with a scrambled topo order).
- **MLP compiled replay == eager** at bs 1/8/32/128.
- **Replay ≤ 3× eager** at MLP [128,784]. Was 10–19× (the FusedLinear specialization re-packed B every replay).

## ReleaseCompiledPlans() (CompiledPlanMemoryTests)
Compiled plans pre-allocate per-step buffers (tens of MB for conv plans); with many plans warm, residency degraded even non-compiled models in the same process. The new `NeuralNetworkBase.ReleaseCompiledPlans()` valve makes release real:
- `CompiledModelHost.Invalidate` now also drops the hot-path plan reference + preloaded disk plans (both pinned buffers post-dispose).
- Per-layer activation caches (`_lastInput` etc.) hold the same buffers — the valve resets layer state (inference-safe).
- Test contract: warming the CNN plan at bs=64 costs >5 MB; release returns >65% (measured 17.3 → 4.3 MB) and the model still predicts correctly via transparent re-compile.

## Verification
- 9/9 new tests green against Tensors 0.91.46-localfix.
- Compiled-area sweep (45 tests): 42 pass; the 3 `Issue1296LargeXTrainBatching` failures reproduce identically at the pre-change baseline commit (clean-worktree verified) — pre-existing.
- **Draft** until AiDotNet.Tensors#540 merges and releases, then the `-localfix` pin flips to the released version so CI can restore.

🤖 Generated with [Claude Code](https://claude.com/claude-code)