### PR TITLE
test(synthetic): make TableGAN ClassificationTargets test async so [Timeout] is honoured

### DIFF
--- a/tests/AiDotNet.Tests/IntegrationTests/SyntheticData/SyntheticTabularGeneratorIntegrationTests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/SyntheticData/SyntheticTabularGeneratorIntegrationTests.cs
@@ -306,8 +306,13 @@ public class SyntheticTabularGeneratorIntegrationTests
     }
 
     [Fact(Timeout = 120000)]
-    public void TableGANGenerator_ClassificationTargets_UseTransformedLabelSlice()
+    public async Task TableGANGenerator_ClassificationTargets_UseTransformedLabelSlice()
     {
+        // xUnit only honours [Fact(Timeout=...)] on async tests; yield once so
+        // this (otherwise synchronous) test is a valid awaitable and actually runs
+        // instead of erroring with "Tests marked with Timeout are only supported
+        // for async tests".
+        await Task.Yield();
         var (data, columns) = CreateTestData();
         var arch = CreateArchitecture(TotalCols, TotalCols);
         var options = new TableGANOptions<double>


### PR DESCRIPTION
## Summary

`TableGANGenerator_ClassificationTargets_UseTransformedLabelSlice` carried `[Fact(Timeout = 120000)]` on a synchronous `void` method, which xUnit rejects at collection time with *"Tests marked with Timeout are only supported for async tests"* — so the test **never actually ran** (it surfaced as a baseline-red error).

Convert it to `async Task` with an `await Task.Yield()` (matching the sibling `*_FitAndGenerate_*` tests) so the timeout attribute is valid and the test executes. The asserted behaviour (`BuildClassificationTargetTensor` maps the label one-hot onto the transformed label slice) **passes** once it runs — no production code change needed.

## Verification
- `TableGANGenerator_ClassificationTargets_UseTransformedLabelSlice`: 1/1 pass (was erroring at collection).

🤖 Generated with [Claude Code](https://claude.com/claude-code)