### PR TITLE
fix(synthetic): train FinDiff denoiser via the tape (ε-prediction MSE)

### DIFF
--- a/src/NeuralNetworks/SyntheticData/FinDiffGenerator.cs
+++ b/src/NeuralNetworks/SyntheticData/FinDiffGenerator.cs
@@ -238,15 +238,23 @@ public class FinDiffGenerator<T> : NeuralNetworkBase<T>, ISyntheticTabularGenera
     /// <inheritdoc />
     public override void Train(Tensor<T> input, Tensor<T> expectedOutput)
     {
-        Tensor<T> prediction = Predict(input);
-        LastLoss = _lossFunction.CalculateLoss(prediction.ToVector(), expectedOutput.ToVector());
-        Tensor<T> error = prediction.Subtract(expectedOutput);
-        UpdateNetworkParameters();
-    }
-
-    private void UpdateNetworkParameters()
-    {
-        _optimizer.UpdateParameters(Layers);
+        // ε-prediction diffusion training: the denoiser (all in Layers) maps the
+        // noisy input + timestep embedding to a noise prediction; the default
+        // regression loss (MSE) between that and the sampled target noise IS the
+        // DDPM/FinDiff training objective (Ho et al. 2020; Sattarov et al. 2023).
+        // TrainWithTape runs the forward on the autodiff tape and backpropagates
+        // through the denoiser before the optimizer step. The previous body called
+        // _optimizer.UpdateParameters(Layers) with no backward, so it threw
+        // "Backward pass must be called before updating parameters".
+        SetTrainingMode(true);
+        try
+        {
+            TrainWithTape(input, expectedOutput, _optimizer);
+        }
+        finally
+        {
+            SetTrainingMode(false);
+        }
     }
 
     /// <inheritdoc />


### PR DESCRIPTION
## Summary

FinDiff's `Train` override ran `Predict` then `_optimizer.UpdateParameters(Layers)` **with no backward**, throwing *"Backward pass must be called before updating parameters"* — so neither `Fit` (whose `TrainBatch` calls `Train` per row) nor the generated ModelFamily training tests ever updated a parameter.

## Fix

The denoiser is entirely in `Layers` and `TrainBatch` already builds the noisy `xt + timestep embedding` input and the sampled target noise, so the correct, paper-faithful fix is to route `Train` through `TrainWithTape`: the sequential denoiser forward produces a noise prediction and the default regression (MSE) loss against the target noise **is** the DDPM/FinDiff ε-prediction objective (Ho et al. 2020; Sattarov et al. 2023). The tape backpropagates through the denoiser before the optimizer step.

## Verification
- FinDiff ModelFamily + `FitAndGenerate` tests: **22/22 pass** (was 12 failing).
- Single-file change (`FinDiffGenerator.cs`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)