### PR TITLE
fix(inference): flush identity-keyed CPU weight caches after BatchNorm folding

### DIFF
--- a/src/NeuralNetworks/NeuralNetworkBase.cs
+++ b/src/NeuralNetworks/NeuralNetworkBase.cs
@@ -2057,6 +2057,25 @@ public abstract class NeuralNetworkBase<T> : INeuralNetworkModel<T>, IInterpreta
                 folded++;
             }
         }
+
+        if (folded > 0)
+        {
+            // The folds above mutate the weight/bias arrays IN PLACE, which leaves
+            // the engine's identity-keyed inference weight caches stale — chiefly
+            // SimdGemm.SgemmWithCachedB's pre-packed B panels, which are keyed by
+            // the weight ARRAY OBJECT and never re-read its contents
+            // (InferenceWeightCache's documented contract: "callers that mutate
+            // weights in place must call InvalidateAll afterwards"). The per-tensor
+            // Engine.InvalidatePersistentTensor calls inside the fold helpers cover
+            // the GPU-resident persistent buffers but are a NO-OP on CpuEngine, so
+            // the CPU packed-GEMM path kept serving the PRE-fold weights while the
+            // BatchNorm layer was already removed — observed as a deterministic
+            // ~0.17 Dense→BN folded-output divergence on AVX2-only hosts (CI),
+            // invisible on AVX-512 hosts where SgemmWithCachedB bypasses the pack
+            // cache entirely (the `Avx512Sgemm.CanUse` gate).
+            InvalidateWeightCachesAfterSuccessfulWeightUpdate();
+        }
+
         return folded;
     }
 
@@ -2112,10 +2131,12 @@ public abstract class NeuralNetworkBase<T> : INeuralNetworkModel<T>, IInterpreta
             bSpan[oc] = NumOps.Add(NumOps.Multiply(NumOps.Subtract(bSpan[oc], mSpan[oc]), scale), beSpan[oc]);
         }
 
-        // In-place span mutation bypasses the engine's persistent-tensor cache (packed /
-        // GPU-resident kernel + bias buffers). Invalidate it so a cached forward path
-        // re-reads the folded values instead of the stale pre-fold weights — same fix as
-        // the Dense fold below; mirrors SetWeights / SetParameters.
+        // Per-tensor invalidation of the GPU-resident persistent buffers keyed by
+        // these arrays. NO-OP on CpuEngine — the CPU-side identity-keyed caches
+        // (pre-packed GEMM panels, transposed conv kernels) are flushed by the
+        // InvalidateWeightCachesAfterSuccessfulWeightUpdate() call in
+        // FoldBatchNormForInference after all folds complete (see the Dense fold
+        // below for the full staleness story).
         Engine.InvalidatePersistentTensor(kernels);
         Engine.InvalidatePersistentTensor(biases);
         return true;
@@ -2163,14 +2184,14 @@ public abstract class NeuralNetworkBase<T> : INeuralNetworkModel<T>, IInterpreta
             bSpan[oc] = NumOps.Add(NumOps.Multiply(NumOps.Subtract(bSpan[oc], mSpan[oc]), scale), beSpan[oc]);
         }
 
-        // The in-place span mutations above bypass the engine's persistent-tensor cache
-        // (the packed / GPU-resident weight + bias buffers keyed by these arrays). Every
-        // other weight-mutation path — SetWeights, SetParameters — invalidates that cache;
-        // the fold must too. Otherwise a forward path that serves weights from the cache
-        // (native-BLAS pre-pack / GPU buffer) reuses the STALE pre-fold weights, so the
-        // BatchNorm fold silently has no effect and the optimized model's output diverges
-        // sharply from the reference (observed as a ~0.18 Dense→BN folded-output divergence
-        // on the Linux native-BLAS CI path; the managed path happened to re-read the arrays).
+        // Per-tensor invalidation of the GPU-resident persistent buffers keyed by
+        // these arrays. NOTE: this is a NO-OP on CpuEngine — the CPU-side
+        // identity-keyed caches (SgemmWithCachedB pre-packed panels, int8 packs,
+        // transposed conv kernels) are flushed by the single
+        // InvalidateWeightCachesAfterSuccessfulWeightUpdate() call in
+        // FoldBatchNormForInference after all folds complete. Relying on this call
+        // alone left the CPU pack cache stale (the ~0.17 Dense→BN divergence on
+        // AVX2-only CI hosts).
         Engine.InvalidatePersistentTensor(weights);
         Engine.InvalidatePersistentTensor(biases);
         return true;


### PR DESCRIPTION
## Summary

Fixes the CI-only failure `ConvBatchNormFoldTests.FoldBatchNorm_IntoDense_PreservesOutput` ("Dense→BN folded output diverged by 1.741E-001") in shard **05 Helpers/Inference/Interpretability** — a real stale-weight-cache bug in BatchNorm folding, not flake.

## Root cause

`FoldBatchNormForInference` mutates the Dense/Conv weight + bias arrays **in place**. The engine's CPU inference fast paths cache derived forms of weight arrays **keyed by the array's object identity** and never re-read its contents — chiefly `SimdGemm.SgemmWithCachedB`'s pre-packed B panels, which every float 2D matmul routes through (`TensorMatMulFloatInto`). `InferenceWeightCache`'s documented contract: *"callers that mutate weights in place must call InvalidateAll afterwards."*

The fold only called `Engine.InvalidatePersistentTensor`, which covers GPU-resident persistent buffers but is a **no-op on CpuEngine** (the in-code comment claiming it fixed this exact divergence was wrong — the prior fix never reached the CPU caches). Sequence on CI:

1. Reference `Predict` primes the pack cache for the weight array (m=1 fails every direct-kernel gate, so it lands in `GetOrBuildPrePackedB`).
2. The fold rescales the weights in place — same array identity, no epoch bump.
3. The optimized `Predict` hits the stale pack → computes with **pre-fold** weights while the BatchNorm layer is already removed → ~0.17 divergence (the BN affine's whole effect).

**Why CI-only:** `SgemmWithCachedB` bypasses the pack cache entirely on AVX-512-capable hosts (`Avx512Sgemm.CanUse` gate) and JIT-eligible shapes — so the bug is invisible on AVX-512 dev machines and AVX-512 runner pools, and deterministic on AVX2-only runners. That's also why it has flickered across CI runs (heterogeneous runner pool) — it failed identically on today's runs of both this morning's `fix/gpu-weight-cache-staleness-training` build and PR #1493's build, before any of today's changes.

## Fix

`FoldBatchNormForInference` now calls `InvalidateWeightCachesAfterSuccessfulWeightUpdate()` — the same flush every other in-place weight-mutation path (`SetParameters`, optimizer steps) uses: GPU `InvalidateAllWeightCaches` + `InferenceWeightCache.InvalidateAll` — once after any fold. The per-tensor `InvalidatePersistentTensor` calls stay for the GPU persistent buffers; their comments now say what they actually do.

## Verification

- `ConvBatchNormFoldTests` 4/4 locally (including with `DOTNET_EnableAVX512F=0`).
- Full shard 05 filter (`UnitTests.Helpers|UnitTests.Inference|UnitTests.Interpretability`, 387 tests) green locally.
- The conclusive check is this PR's own shard-05 job on an AVX2 CI runner — the exact environment where the divergence reproduces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
