### PR TITLE
test(lora): align LoRAValidationTests with the resolved-shape adapter contract

### DIFF
--- a/tests/AiDotNet.Tests/UnitTests/LoRA/LoRAValidationTests.cs
+++ b/tests/AiDotNet.Tests/UnitTests/LoRA/LoRAValidationTests.cs
@@ -153,6 +153,12 @@ public class LoRAValidationTests
         // Arrange
         var config = new DefaultLoRAConfiguration<double>(rank: 4, alpha: 4, freezeBaseLayer: true);
         var baseLayer = new DenseLayer<double>(5);
+        // ApplyLoRA wraps shape-RESOLVED layers only: lazy layers are skipped by
+        // design (AiDotNet#1345 guard; AiModelBuilder runs a warmup forward to
+        // resolve them before the LoRA pass, and review #1368 rejected sizing
+        // adapters from heuristic dims as silent fabrication). Materialize the
+        // dense's input dim the way the production pipeline would.
+        baseLayer.ResolveFromShape(new[] { 10 });
 
         // Act
         var adaptedLayer = config.ApplyLoRA(baseLayer);
@@ -162,12 +168,33 @@ public class LoRAValidationTests
     }
 
     [Fact(Timeout = 60000)]
+    public async Task DefaultLoRAConfiguration_LazyUnresolvedLayer_ReturnsUnchanged()
+    {
+        // Pins the lazy-shape design decision: a shape-UNRESOLVED layer must pass
+        // through ApplyLoRA untouched rather than be wrapped from fabricated dims
+        // (#1345 guard + review #1368). The production pipeline resolves shapes
+        // via the warmup forward / TryDeclareShape oracle before wrapping.
+        // Arrange
+        var config = new DefaultLoRAConfiguration<double>(rank: 4, alpha: 4, freezeBaseLayer: true);
+        var lazyLayer = new DenseLayer<double>(5); // input dim unknown until first forward
+
+        // Act
+        var result = config.ApplyLoRA(lazyLayer);
+
+        // Assert - same instance, not wrapped
+        Assert.Same(lazyLayer, result);
+    }
+
+    [Fact(Timeout = 60000)]
     public async Task DefaultLoRAConfiguration_DoRAAdapter_CreatesSuccessfully()
     {
         // Arrange - DoRA has matching constructor signature (ILayer<T>, int, double, bool)
-        var doraAdapter = new DoRAAdapter<double>(new DenseLayer<double>(5), rank: 4, alpha: 4, freezeBaseLayer: true);
+        var prototypeBase = new DenseLayer<double>(5);
+        prototypeBase.ResolveFromShape(new[] { 10 });
+        var doraAdapter = new DoRAAdapter<double>(prototypeBase, rank: 4, alpha: 4, freezeBaseLayer: true);
         var config = new DefaultLoRAConfiguration<double>(rank: 4, alpha: 4, freezeBaseLayer: true, loraAdapter: doraAdapter);
         var baseLayer = new DenseLayer<double>(5);
+        baseLayer.ResolveFromShape(new[] { 10 });
 
         // Act
         var adaptedLayer = config.ApplyLoRA(baseLayer);
@@ -180,9 +207,12 @@ public class LoRAValidationTests
     public async Task DefaultLoRAConfiguration_AdaLoRAAdapter_CreatesSuccessfully()
     {
         // Arrange - AdaLoRA has compatible constructor (4th param is bool, rest have defaults)
-        var adaloraAdapter = new AdaLoRAAdapter<double>(new DenseLayer<double>(5), maxRank: 4);
+        var prototypeBase = new DenseLayer<double>(5);
+        prototypeBase.ResolveFromShape(new[] { 10 });
+        var adaloraAdapter = new AdaLoRAAdapter<double>(prototypeBase, maxRank: 4);
         var config = new DefaultLoRAConfiguration<double>(rank: 4, alpha: 4, freezeBaseLayer: true, loraAdapter: adaloraAdapter);
         var baseLayer = new DenseLayer<double>(5);
+        baseLayer.ResolveFromShape(new[] { 10 });
 
         // Act
         var adaptedLayer = config.ApplyLoRA(baseLayer);
@@ -197,9 +227,12 @@ public class LoRAValidationTests
         // QLoRA has incompatible constructor signature (4th param is QuantizationType, not bool)
         // This should throw a helpful error message
         // Arrange
-        var qloraAdapter = new QLoRAAdapter<double>(new DenseLayer<double>(5), rank: 4);
+        var prototypeBase = new DenseLayer<double>(5);
+        prototypeBase.ResolveFromShape(new[] { 10 });
+        var qloraAdapter = new QLoRAAdapter<double>(prototypeBase, rank: 4);
         var config = new DefaultLoRAConfiguration<double>(rank: 4, alpha: 4, freezeBaseLayer: true, loraAdapter: qloraAdapter);
         var baseLayer = new DenseLayer<double>(5);
+        baseLayer.ResolveFromShape(new[] { 10 });
 
         // Act & Assert
         var ex = Assert.Throws<InvalidOperationException>(() => config.ApplyLoRA(baseLayer));
@@ -253,6 +286,7 @@ public class LoRAValidationTests
         int outputSize = 10;
         int rank = 4;
         var baseLayer = new DenseLayer<double>(outputSize);
+        baseLayer.ResolveFromShape(new[] { inputSize }); // materialize [5 -> 10] weights so merge has a real base
         var adapter = new StandardLoRAAdapter<double>(baseLayer, rank: rank, alpha: rank, freezeBaseLayer: true);
 
         // Act & Assert - should not throw
@@ -269,6 +303,7 @@ public class LoRAValidationTests
         int outputSize = 10;
         int rank = 4;
         var baseLayer = new DenseLayer<double>(outputSize);
+        baseLayer.ResolveFromShape(new[] { inputSize }); // materialize [5 -> 10] weights so merge has a real base
         var adapter = new DoRAAdapter<double>(baseLayer, rank: rank, alpha: rank, freezeBaseLayer: true);
 
         // Act & Assert - should not throw
@@ -285,6 +320,7 @@ public class LoRAValidationTests
         int outputSize = 10;
         int rank = 4;
         var baseLayer = new DenseLayer<double>(outputSize);
+        baseLayer.ResolveFromShape(new[] { inputSize }); // materialize [5 -> 10] weights so QLoRA can quantize a real base
         var adapter = new QLoRAAdapter<double>(baseLayer, rank: rank, alpha: rank, freezeBaseLayer: true);
 
         // Act & Assert - should not throw
@@ -307,6 +343,11 @@ public class LoRAValidationTests
         try
         {
             var baseLayer = new DenseLayer<double>(outputSize);
+            // Materialize [5 -> 10] weights: VeRA validates its shared matrices
+            // against the base layer's REAL input dim, so an unresolved base would
+            // be sized from the outSize*2 heuristic (20) and reject the shared A
+            // initialized for inputSize=5 above.
+            baseLayer.ResolveFromShape(new[] { inputSize });
             var adapter = new VeRAAdapter<double>(baseLayer, rank: rank, alpha: rank, freezeBaseLayer: true);
 
             // Act & Assert - should not throw
@@ -335,6 +376,7 @@ public class LoRAValidationTests
         int rank = 4;
         int batchSize = 2;
         var baseLayer = new DenseLayer<double>(outputSize);
+        baseLayer.ResolveFromShape(new[] { inputSize }); // the [2, 5] input below must match the adapter's real input dim
         var adapter = new DoRAAdapter<double>(baseLayer, rank: rank, alpha: rank, freezeBaseLayer: true);
 
         // Create input tensor [batchSize, inputSize]


### PR DESCRIPTION
## Summary

Closes the 9 master-red `LoRAValidationTests` failures by settling the lazy-shape design question and aligning the tests with the resolved-shape adapter contract. **Test-only change — no production code is touched.**

## The design question

Should `ApplyLoRA` (and direct adapter construction) wrap a layer whose input shape is still unresolved?

**Decision: no — and that was already decided, in three pieces:**
- The #1345 guard makes `ApplyLoRA` return lazy layers unchanged (wrapping at zero/unknown shape crashes adapter construction).
- Review #1368 rejected sizing adapters from the `outSize*2` heuristic as "silent fabrication" — it survives only for `ParameterCount`-readiness on unresolved bases, never as real adapter dims.
- The production pipeline (`AiModelBuilder`) resolves shapes before the LoRA pass (warmup forward + `TryDeclareShape` oracle, #1370).

The 9 failing tests predate the lazy-`DenseLayer` refactor: each declares `int inputSize = 5;` **and then never uses it**, constructing `new DenseLayer<double>(outputSize)` (lazy). The unresolved base made:
- adapters fall back to the `outSize*2` heuristic → DoRA `Forward` rejected the `[batch, 5]` test input ("Flat index is out of range"), VeRA rejected its shared matrices ("required 20×4" vs the 5×4 the test initialized);
- `MergeToOriginalLayer` index past the unmaterialized base's empty parameter vector (`ArgumentOutOfRangeException`);
- the `DefaultLoRAConfiguration` Create/Throw tests see the guard's pass-through instead of the expected adapter type.

## Changes

- Materialize each test's base layer to its **declared** `inputSize` via the public `ResolveFromShape` API (what the production warmup achieves) — restoring the tests' original intent. The `outputSize > inputSize` merge/forward indexing coverage now genuinely exercises real weight matrices.
- New regression test `DefaultLoRAConfiguration_LazyUnresolvedLayer_ReturnsUnchanged` pins the design decision: a shape-unresolved layer passes through `ApplyLoRA` untouched.

## Verification

- `LoRAValidationTests` 23/23 (was 14/23 on master).
- Combined `LoRAValidationTests` + `Bucket10_LoRA` + `ConvBatchNormFoldTests` run: 28/28.
- No production code changed; the merge/forward "matrix indexing fix" checks pass against real matrices, confirming those production paths are correct.

Related: PR #1493 independently widens the `ApplyLoRA` guard to the `TryDeclareShape` oracle so ctor-determined layers (MultiHeadAttention) are admitted; that change and this one are compatible — lazy `DenseLayer` is skipped under both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
