### PR TITLE
fix(neural-networks): lazy-init race in TrainWithTape — warmup before CollectParameters

### DIFF
--- a/src/NeuralNetworks/NeuralNetworkBase.cs
+++ b/src/NeuralNetworks/NeuralNetworkBase.cs
@@ -5666,6 +5666,49 @@ public abstract class NeuralNetworkBase<T> : INeuralNetworkModel<T>, IInterpreta
         // AdamW, SGD, etc.) all iterate `context.Parameters` directly
         // and never read `context.ParamBuffer`, so passing null is safe
         // for the model layer's optimizer path.
+        // Lazy-init warmup: materialise weight tensors for any layer whose
+        // shape isn't resolved yet, BEFORE we collect parameters or set up
+        // the ParameterBuffer. Without this, the subsequent
+        // `CollectParameters` call captures `Tensor<T>.Empty()` placeholder
+        // refs from layers built with single-arg ctors (FeedForwardLayer,
+        // DenseLayer, EmbeddingLayer, MultiHeadAttentionLayer, etc. when
+        // input dim is deferred to first forward). The tape's backward pass
+        // then writes gradients keyed by the post-Forward real-tensor refs;
+        // the filter loop that intersects `allGrads` against `trainableParams`
+        // finds zero matches; the optimizer step iterates an empty grad dict
+        // and the first Train() call becomes a complete no-op. Test scaffolds
+        // (LossStrictlyDecreasesOnMemorizationTask,
+        // Training_ShouldChangeParameters) then capture the placeholder-
+        // forward baseline as "step 1" and report flat-loss / no-param-change
+        // failures across every model with at least one lazy layer.
+        //
+        // Industry-standard PyTorch contract (nn.LazyLinear / nn.LazyConv*):
+        // the user runs a dummy forward to materialise lazy params BEFORE
+        // constructing the optimizer. AiDotNet attaches the optimizer at
+        // model construction time, so the framework does the warmup itself.
+        //
+        // EVAL mode (not training) so Dropout/BatchNorm don't consume the
+        // per-forward RNG counter or advance running statistics — same
+        // contract the fused path's pre-init forward already follows at
+        // `CompiledTapeTrainingStep.cs` lines 514-534. Caught exceptions are
+        // best-effort: a model whose forward fails in eval mode still falls
+        // through to the real training step below, which will surface the
+        // failure with the proper diagnostic.
+        if (AnyLayerNeedsShapeResolution())
+        {
+            bool wasTraining = IsTrainingMode;
+            if (wasTraining) SetTrainingMode(false);
+            try { ForwardForTraining(input); }
+            catch
+            {
+                // Swallow: warmup is best-effort. If the model genuinely
+                // can't forward in eval mode, the real Train forward below
+                // will hit the same path under training mode and surface
+                // the failure with the actionable stack trace there.
+            }
+            finally { if (wasTraining) SetTrainingMode(true); }
+        }
+
         ParameterBuffer<T>? paramBuffer;
         // Fast-path: a previous training step on the SAME layer structure
         // already concluded "skip buffer" — re-applying that decision is
@@ -6536,6 +6579,40 @@ public abstract class NeuralNetworkBase<T> : INeuralNetworkModel<T>, IInterpreta
     /// at PerStep still gives per-step detail for those who want it.
     /// </summary>
     private bool _loggedFusedFallback;
+
+    /// <summary>
+    /// Returns <c>true</c> if any layer (including nested sub-layers) reports
+    /// <see cref="Layers.LayerBase{T}.IsShapeResolved"/> = <c>false</c>, i.e.,
+    /// hasn't yet seen a forward pass and is still carrying placeholder
+    /// <c>Tensor&lt;T&gt;.Empty()</c> weight refs. Used by
+    /// <see cref="TrainWithTape"/> to gate a one-shot warmup forward that
+    /// materialises lazy weights before <c>CollectParameters</c> captures
+    /// references the gradient tape will later key by. Short-circuits on the
+    /// first unresolved layer; on fully eager networks (most CNNs / fixed-
+    /// dim transformers constructed with all input sizes known) every layer
+    /// is resolved at construction time so this returns <c>false</c> and
+    /// the warmup is skipped — zero overhead for the common case.
+    /// </summary>
+    private bool AnyLayerNeedsShapeResolution()
+    {
+        // Walk top-level Layers; LayerBase exposes GetSubLayers() so we
+        // recurse to catch composite layers (TransformerEncoder,
+        // ResidualBlock, etc.) that wrap their own children.
+        return AnyLayerNeedsShapeResolutionRecursive(Layers);
+    }
+
+    private static bool AnyLayerNeedsShapeResolutionRecursive(IEnumerable<ILayer<T>> layers)
+    {
+        foreach (var layer in layers)
+        {
+            if (layer is Layers.LayerBase<T> baseLayer && !baseLayer.IsShapeResolved)
+                return true;
+            var subs = layer.GetSubLayers();
+            if (subs.Count > 0 && AnyLayerNeedsShapeResolutionRecursive(subs))
+                return true;
+        }
+        return false;
+    }
 
     /// <summary>
     /// Attempts the fused-compiled training path — forward + backward + fused

--- a/src/NeuralNetworks/NeuralNetworkBase.cs
+++ b/src/NeuralNetworks/NeuralNetworkBase.cs
@@ -5694,7 +5694,13 @@ public abstract class NeuralNetworkBase<T> : INeuralNetworkModel<T>, IInterpreta
         // best-effort: a model whose forward fails in eval mode still falls
         // through to the real training step below, which will surface the
         // failure with the proper diagnostic.
-        if (AnyLayerNeedsShapeResolution())
+        // Gate on actual weight MATERIALIZATION, not just shape resolution:
+        // ResolveLazyLayerShapes()/ResolveShapesOnly (driven by a pre-train
+        // ParameterCount / GetParameters call) can flip IsShapeResolved to true
+        // WITHOUT allocating the weight tensors, leaving length-0 placeholders
+        // that CollectParameters would still capture. So also warm up whenever
+        // any trainable parameter is still an unallocated placeholder.
+        if (AnyLayerNeedsShapeResolution() || AnyLayerHasUnmaterializedParameters())
         {
             bool wasTraining = IsTrainingMode;
             if (wasTraining) SetTrainingMode(false);
@@ -6609,6 +6615,40 @@ public abstract class NeuralNetworkBase<T> : INeuralNetworkModel<T>, IInterpreta
                 return true;
             var subs = layer.GetSubLayers();
             if (subs.Count > 0 && AnyLayerNeedsShapeResolutionRecursive(subs))
+                return true;
+        }
+        return false;
+    }
+
+    /// <summary>
+    /// True if any (possibly nested) layer still holds an unallocated
+    /// placeholder trainable parameter (a <c>Length == 0</c> tensor). Shape
+    /// resolution alone (<see cref="AnyLayerNeedsShapeResolution"/>) is not
+    /// sufficient to decide whether the lazy-init warmup is needed:
+    /// <c>ResolveShapesOnly</c> can flip <c>IsShapeResolved</c> to true without
+    /// allocating the weight tensors, so a forward is still required to
+    /// materialise them before <c>CollectParameters</c> runs. After a real
+    /// forward materialises the weights this returns false, so it does not
+    /// re-fire the warmup on subsequent training steps.
+    /// </summary>
+    private bool AnyLayerHasUnmaterializedParameters()
+    {
+        return AnyLayerHasUnmaterializedParametersRecursive(Layers);
+    }
+
+    private static bool AnyLayerHasUnmaterializedParametersRecursive(IEnumerable<ILayer<T>> layers)
+    {
+        foreach (var layer in layers)
+        {
+            if (layer is Layers.LayerBase<T> baseLayer)
+            {
+                foreach (var p in baseLayer.GetTrainableParameters())
+                {
+                    if (p is null || p.Length == 0) return true;
+                }
+            }
+            var subs = layer.GetSubLayers();
+            if (subs.Count > 0 && AnyLayerHasUnmaterializedParametersRecursive(subs))
                 return true;
         }
         return false;


### PR DESCRIPTION
## Summary

Every model built with a single-arg constructor that defers weight allocation to first forward (`FeedForwardLayer`, `DenseLayer`, `EmbeddingLayer`, `MultiHeadAttentionLayer`, etc.) **silently wastes its first `Train()` call**. The optimizer iterates an empty gradient dict, parameters don't update, and test scaffolds like `LossStrictlyDecreasesOnMemorizationTask` / `Training_ShouldChangeParameters` capture a placeholder-forward baseline as their \"step 1\" — producing flat-loss / no-param-change failures.

## Root cause

`NeuralNetworkBase.TrainWithTape`:
1. Line 5777: `CollectParameters` runs **BEFORE** the forward at line 5945
2. For lazy layers, this captures `Tensor<T>.Empty()` placeholder refs
3. Line 5945 forward materialises real tensors
4. Tape backward writes gradients keyed by the **real** tensor refs
5. Lines 5996-6000 filter loop intersects `allGrads` against `trainableParams` via `TensorReferenceComparer` identity → **zero matches**
6. `opt.Step` iterates the empty grad dict → no-op

## Fix

Add a one-shot warmup forward in EVAL mode when `AnyLayerNeedsShapeResolution()` is true, BEFORE the parameter-buffer initialization block. After warmup, lazy layers have materialised real tensors and the subsequent `CollectParameters` captures the same refs the tape will use.

**EVAL mode (not training)** so `DropoutLayer` / `BatchNorm` don't consume the per-forward RNG counter or update running statistics. Caught exceptions are best-effort — a model that genuinely can't forward in eval mode falls through to the real training step which surfaces the failure with the actionable stack trace.

**`AnyLayerNeedsShapeResolution`** walks `Layers` + sub-layers checking `LayerBase.IsShapeResolved`. Short-circuits on the first unresolved layer. **Fully-eager networks return false immediately and skip the warmup — zero overhead for the common case.**

## Industry standard / pattern parity

- **PyTorch `nn.LazyLinear` / `nn.LazyConv*` contract**: users run a dummy forward to materialise lazy params BEFORE constructing the optimizer. AiDotNet attaches the optimizer at model construction time, so the framework does the warmup itself — equivalent contract from the user's perspective.
- **Existing fused-path pattern**: `CompiledTapeTrainingStep.cs:514-534` already does exactly this for the fused-compiled path via `forward(_persistentInput)` wrapped in inference mode. This PR brings the eager tape path to parity.

## Verification

- **Warmup engages correctly** (verified via temporary forced-eager + count probe on MOIRAI): call #1's `trainableParams.Count` went 8 (placeholders) → 164 (materialised).
- **94-test cross-section** (MOIRAI + Wav2Vec2Model + AdversarialImageEvaluator + AudioVisualCorrespondenceNetwork): **17 fails before, 17 fails after** — no regressions.
- Build clean on net10.0 + net471.

## What this PR does NOT fix

- MOIRAI's `LossStrictlyDecreasesOnMemorizationTask` — that test fails because of a separate state-corruption bug (forward output collapses from `[1.46, ...]` to `[0, ...]` after the first real Adam step, with all-zero gradients thereafter). That's BUG B from the diagnostic; this PR fixes BUG A only. BUG B is independent and requires per-layer tape-aware instrumentation to pinpoint which layer-internal state is being corrupted between training calls.
- Models that take the fused-compiled fast path (most float/double Adam/AdamW/SGD models since PR #319) already have an equivalent warmup at `CompiledTapeTrainingStep.cs:514`, so this PR has the most impact on models that fall back to the eager tape path (mixed-precision, exotic optimizers, custom configurations).

## Test plan
- [ ] CI green on net10.0 + net471
- [ ] No regression in passing test counts across model-family tests
- [ ] Verify on a clean eager-path model that the first Train call now updates parameters (was previously a no-op for lazy-init models)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved training startup for models with lazily-initialized layers and parameters: training now performs a safe warmup pass to fully materialize shapes and weights before collecting trainable parameters and gradients. This prevents a no-op first step and ensures gradients are computed correctly from the start, even for nested or deferred components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->