### PR TITLE
fix(vlm): Q-Former VLMs missing PatchEmbeddingLayer (InstructBLIP+3)

### DIFF
--- a/src/AiDotNet.Generators/TestScaffoldGenerator.cs
+++ b/src/AiDotNet.Generators/TestScaffoldGenerator.cs
@@ -1269,6 +1269,17 @@ public class TestScaffoldGenerator : IIncrementalGenerator
         // tests all failing at the same Forward boundary.
         "Gemma", "DeepSeekVL", "InternVL", "Llama32Vision",
         "Phi3Vision", "Phi4Multimodal",
+        // Q-Former-family generative VLMs (InstructBLIP Dai et al. NeurIPS
+        // 2023 §3.1, MiniGPT4 Zhu et al. 2023 §3.1, MiniGPTv2 Chen et al.
+        // 2023 §3.1, BLIP-3 / XGen-MM Salesforce 2024 §3.1) all wrap a frozen
+        // EVA-ViT-G or CLIP ViT-L/14 vision encoder. CreateDefaultQFormer-
+        // GenerativeLayers now prepends PatchEmbeddingLayer(patchSize=14,
+        // visionDim=1408 default), so the scaffold's spatial size must be
+        // divisible by 14 — same root cause as the LLaVA / Gemma3 entries
+        // above. The bug surfaced in PR #1501 Generated Layers shard run
+        // 27040737008 as 6 InstructBLIPTests all throwing "Image H/W
+        // (128/128) must be divisible by patchSize (14)".
+        "InstructBLIP", "MiniGPT4", "MiniGPTv2", "BLIP3",
     };
 
     /// <summary>
@@ -4473,6 +4484,18 @@ public class TestScaffoldGenerator : IIncrementalGenerator
             // Predict — surfaced in PR #1408 Generated Layers shard as 23
             // Gemma3 tests all failing.
             "Gemma3" => true,
+            // Q-Former-family VLMs (InstructBLIP Dai et al. NeurIPS 2023,
+            // MiniGPT4 Zhu et al. 2023, MiniGPTv2 Chen et al. 2023, BLIP-3
+            // Salesforce 2024) all wrap EVA-ViT-G (VisionDim=1408, 39 vision
+            // layers) + Q-Former (QFormerDim=768, 12 qformer layers) + LLM
+            // decoder (DecoderDim=4096, 32 decoder layers) per their paper
+            // defaults. A single Predict forward iterates all 39 vision
+            // layers at dim 1408 — Training_* invariants at the default
+            // 30/50/200 iters overflow the xUnit 120 s timeout.
+            "InstructBLIP" => true,
+            "MiniGPT4" => true,
+            "MiniGPTv2" => true,
+            "BLIP3" => true,
             _ => false,
         };
     }

--- a/src/Helpers/LayerHelper.cs
+++ b/src/Helpers/LayerHelper.cs
@@ -23210,10 +23210,40 @@ public static class LayerHelper<T>
     }
 
     /// <summary>
-    /// Creates default layers for Q-Former-based generative VLMs (InstructBLIP, BLIP-3).
+    /// Creates default layers for Q-Former-based generative VLMs (InstructBLIP, BLIP-3, MiniGPT-4, MiniGPT-v2).
     /// Architecture: ViT vision encoder -> Q-Former (cross-attention queries) -> text decoder.
     /// </summary>
+    /// <param name="visionDim">Vision encoder embedding dimension (default 1408 — EVA-ViT-G per Dai et al. 2023 §3.1).</param>
+    /// <param name="qFormerDim">Q-Former hidden dimension (default 768 — BLIP-2 §3.1 base config).</param>
+    /// <param name="decoderDim">LLM decoder hidden dimension (default 4096 — Vicuna-7B / OPT-2.7B class).</param>
+    /// <param name="numVisionLayers">Number of vision encoder transformer blocks (default 12 — ViT-B; ViT-G uses 39).</param>
+    /// <param name="numQFormerLayers">Number of Q-Former transformer blocks (default 12 — BLIP-2 §3.1).</param>
+    /// <param name="numDecoderLayers">Number of text decoder transformer blocks.</param>
     /// <param name="numQueryTokens">Number of learnable query tokens (managed externally as learnable tensors in the model class, not as a layer).</param>
+    /// <param name="numHeads">Number of attention heads for vision and decoder self-attention. Snapped down to the nearest divisor of <paramref name="visionDim"/> / <paramref name="decoderDim"/> when not exactly divisible (see <see cref="ChooseDivisibleHeadConfig"/>).</param>
+    /// <param name="numQFormerHeads">Number of attention heads for Q-Former self-attention. Snapped down similarly against <paramref name="qFormerDim"/>.</param>
+    /// <param name="dropoutRate">Dropout probability applied after each transformer sub-block (default 0.1).</param>
+    /// <param name="patchSize">ViT patch size for the leading <see cref="PatchEmbeddingLayer{T}"/> (default 14 — EVA-ViT-G / ViT-L/14).</param>
+    /// <returns>The ordered <see cref="ILayer{T}"/> sequence — patch embedding + ViT encoder + optional vision→Q-Former projection + Q-Former blocks + optional Q-Former→decoder projection + decoder blocks. Callers split this stream into named sub-streams (Layers / _qFormerLayers / _decoderLayers) using the pre-computed layer-count boundaries.</returns>
+    /// <remarks>
+    /// <para>
+    /// <b>For Beginners:</b> This builds the layer chain used by Q-Former-bridge VLMs.
+    /// The first stage is a Vision Transformer (ViT) that turns an image into a
+    /// sequence of visual tokens. The Q-Former then uses a small set of learnable
+    /// "query tokens" that cross-attend to those visual tokens to extract the
+    /// information the language model needs. Finally the text decoder generates
+    /// the output, attending back to the Q-Former's output. Defaults match the
+    /// original BLIP-2 / InstructBLIP paper configurations.
+    /// </para>
+    /// <para>
+    /// Attention head counts use <see cref="ChooseDivisibleHeadConfig"/> so a
+    /// requested head count that doesn't divide the embedding dim cleanly (e.g.
+    /// <c>visionDim=1408 / numHeads=12 = 117.33</c>) is snapped down to the
+    /// nearest divisor instead of silently truncating to <c>12 * 117 = 1404</c>
+    /// and breaking the QKV projection. Same SmolVLM / InternVL root-cause
+    /// pattern as PR #1290 / #1311.
+    /// </para>
+    /// </remarks>
     public static IEnumerable<ILayer<T>> CreateDefaultQFormerGenerativeLayers(
         int visionDim = 1408,
         int qFormerDim = 768,
@@ -23235,6 +23265,18 @@ public static class LayerHelper<T>
         int qfFfnDim = qFormerDim * 4;
         int decoderFfnDim = decoderDim * 4;
 
+        // Snap requested head counts down to divisors of their respective embed
+        // dims ONCE up front. Inline integer division (e.g. visionDim/numHeads)
+        // would produce heads*headDim != embedDim when numHeads doesn't divide
+        // cleanly (1408/12=117, 12*117=1404≠1408 → "Input embedding dimension
+        // (1408) does not match weight dimension (1404)" on first MHA forward).
+        // Single ChooseDivisibleHeadConfig per stream keeps the qformer block
+        // count formulas in the call sites correct (each iteration still emits
+        // the same number of layers regardless of head snapping).
+        var (visionHeads, visionHeadDim) = ChooseDivisibleHeadConfig(visionDim, numHeads);
+        var (qfHeads, qfHeadDim) = ChooseDivisibleHeadConfig(qFormerDim, numQFormerHeads);
+        var (decoderHeads, decoderHeadDim) = ChooseDivisibleHeadConfig(decoderDim, numHeads);
+
         // === Vision Encoder (ViT) ===
         // Dai et al. 2023 (InstructBLIP) §3.1 / Li et al. 2023 (BLIP-2) §3.1 use
         // EVA-ViT-G (patchSize=14, visionDim=1408) as the frozen vision encoder.
@@ -23248,7 +23290,7 @@ public static class LayerHelper<T>
 
         for (int i = 0; i < numVisionLayers; i++)
         {
-            yield return new MultiHeadAttentionLayer<T>(numHeads, (visionDim) / (numHeads));
+            yield return new MultiHeadAttentionLayer<T>(visionHeads, visionHeadDim);
             yield return new LayerNormalizationLayer<T>();
             yield return new DenseLayer<T>(visionFfnDim, geluActivation);
             yield return new DenseLayer<T>(visionDim, identityActivation);
@@ -23266,7 +23308,7 @@ public static class LayerHelper<T>
             yield return new CrossAttentionLayer<T>(qFormerDim, visionDim, numQFormerHeads);
             yield return new LayerNormalizationLayer<T>();
             // Self-attention among query tokens
-            yield return new MultiHeadAttentionLayer<T>(numQFormerHeads, (qFormerDim) / (numQFormerHeads));
+            yield return new MultiHeadAttentionLayer<T>(qfHeads, qfHeadDim);
             yield return new LayerNormalizationLayer<T>();
             // Feed-forward
             yield return new DenseLayer<T>(qfFfnDim, geluActivation);
@@ -23282,7 +23324,7 @@ public static class LayerHelper<T>
         for (int i = 0; i < numDecoderLayers; i++)
         {
             // Causal self-attention
-            var decoderSelfAttn = new MultiHeadAttentionLayer<T>(numHeads, (decoderDim) / (numHeads));
+            var decoderSelfAttn = new MultiHeadAttentionLayer<T>(decoderHeads, decoderHeadDim);
             decoderSelfAttn.UseCausalMask = true;
             yield return decoderSelfAttn;
             yield return new LayerNormalizationLayer<T>();

--- a/src/Helpers/LayerHelper.cs
+++ b/src/Helpers/LayerHelper.cs
@@ -23224,8 +23224,11 @@ public static class LayerHelper<T>
         int numQueryTokens = 32,
         int numHeads = 12,
         int numQFormerHeads = 12,
-        double dropoutRate = 0.1)
+        double dropoutRate = 0.1,
+        int patchSize = 14)
     {
+        ValidatePatchSize(patchSize);
+
         IActivationFunction<T> geluActivation = new GELUActivation<T>();
         IActivationFunction<T> identityActivation = new IdentityActivation<T>();
         int visionFfnDim = visionDim * 4;
@@ -23233,6 +23236,14 @@ public static class LayerHelper<T>
         int decoderFfnDim = decoderDim * 4;
 
         // === Vision Encoder (ViT) ===
+        // Dai et al. 2023 (InstructBLIP) §3.1 / Li et al. 2023 (BLIP-2) §3.1 use
+        // EVA-ViT-G (patchSize=14, visionDim=1408) as the frozen vision encoder.
+        // Without PatchEmbeddingLayer the downstream MultiHeadAttentionLayer
+        // reads the raw image's spatial dim (e.g. 128) as the feature dim and
+        // hard-rejects with "Input embedding dimension (128) does not match
+        // weight dimension (1408)" — same root cause pattern as the SmolVLM /
+        // InternVL fix (PR #1290 / #1311).
+        yield return new PatchEmbeddingLayer<T>(patchSize, visionDim, expectedInputChannels: 3);
         yield return new LayerNormalizationLayer<T>();
 
         for (int i = 0; i < numVisionLayers; i++)

--- a/src/VisionLanguage/Generative/BLIP3.cs
+++ b/src/VisionLanguage/Generative/BLIP3.cs
@@ -175,13 +175,14 @@ public class BLIP3<T> : VisionLanguageModelBase<T>, IGenerativeVisionLanguageMod
         }
 
         // CreateDefaultQFormerGenerativeLayers emits:
-        //   [pre-norm + N×vision-block, optional projection, M×qformer-block, K×decoder-block]
+        //   [patch-embed + pre-norm + N×vision-block, optional projection, M×qformer-block, K×decoder-block]
         //
         // Block sizes (no dropout): vision = 5, qformer = 7, decoder ~ same as transformer = 5.
         // With dropout add 1 per block. Compute boundaries first, then split.
         int blockSize = _options.DropoutRate > 0 ? 6 : 5;
         int qfBlockSize = _options.DropoutRate > 0 ? 8 : 7;
-        int visionLayerEnd = 1 + _options.NumVisionLayers * blockSize;
+        // 2 + ...: PatchEmbeddingLayer + pre-norm, then N×vision-block.
+        int visionLayerEnd = 2 + _options.NumVisionLayers * blockSize;
         int qfProj = _options.VisionDim != _options.QFormerDim ? 1 : 0;
         int qFormerLayerEnd = visionLayerEnd + qfProj + _options.NumQFormerLayers * qfBlockSize;
 

--- a/src/VisionLanguage/Generative/InstructBLIP.cs
+++ b/src/VisionLanguage/Generative/InstructBLIP.cs
@@ -169,7 +169,8 @@ public class InstructBLIP<T> : VisionLanguageModelBase<T>, IGenerativeVisionLang
 
         int blockSize = _options.DropoutRate > 0 ? 6 : 5;
         int qfBlockSize = _options.DropoutRate > 0 ? 8 : 7;
-        int visionLayerEnd = 1 + _options.NumVisionLayers * blockSize;
+        // 2 + ...: PatchEmbeddingLayer + pre-norm, then N×vision-block.
+        int visionLayerEnd = 2 + _options.NumVisionLayers * blockSize;
         int qfProj = _options.VisionDim != _options.QFormerDim ? 1 : 0;
         int qFormerLayerEnd = visionLayerEnd + qfProj + _options.NumQFormerLayers * qfBlockSize;
 

--- a/src/VisionLanguage/InstructionTuned/MiniGPT4.cs
+++ b/src/VisionLanguage/InstructionTuned/MiniGPT4.cs
@@ -189,7 +189,8 @@ public class MiniGPT4<T> : VisionLanguageModelBase<T>, IInstructionTunedVLM<T>
 
         int blockSize = _options.DropoutRate > 0 ? 6 : 5;
         int qfBlockSize = _options.DropoutRate > 0 ? 8 : 7;
-        int visionLayerEnd = 1 + _options.NumVisionLayers * blockSize;
+        // 2 + ...: PatchEmbeddingLayer + pre-norm, then N×vision-block.
+        int visionLayerEnd = 2 + _options.NumVisionLayers * blockSize;
         int qfProj = _options.VisionDim != _options.QFormerDim ? 1 : 0;
         int qFormerLayerEnd = visionLayerEnd + qfProj + _options.NumQFormerLayers * qfBlockSize;
 

--- a/src/VisionLanguage/InstructionTuned/MiniGPTv2.cs
+++ b/src/VisionLanguage/InstructionTuned/MiniGPTv2.cs
@@ -188,7 +188,8 @@ public class MiniGPTv2<T> : VisionLanguageModelBase<T>, IInstructionTunedVLM<T>
 
         int blockSize = _options.DropoutRate > 0 ? 6 : 5;
         int qfBlockSize = _options.DropoutRate > 0 ? 8 : 7;
-        int visionLayerEnd = 1 + _options.NumVisionLayers * blockSize;
+        // 2 + ...: PatchEmbeddingLayer + pre-norm, then N×vision-block.
+        int visionLayerEnd = 2 + _options.NumVisionLayers * blockSize;
         int qfProj = _options.VisionDim != _options.QFormerDim ? 1 : 0;
         int qFormerLayerEnd = visionLayerEnd + qfProj + _options.NumQFormerLayers * qfBlockSize;
 


### PR DESCRIPTION
## Summary

- `LayerHelper.CreateDefaultQFormerGenerativeLayers` started the ViT vision encoder with `LayerNormalizationLayer + MultiHeadAttentionLayer(visionDim=1408)` directly — no `PatchEmbeddingLayer` to convert raw `[B,3,H,W]` pixels into `[B,num_patches,visionDim]` tokens. First MHA hard-rejected with `ArgumentException : Input embedding dimension (128) does not match weight dimension (1408)`.
- Same root-cause pattern as the SmolVLM/InternVL fix (#1290/#1311) and Gemma3 patch-vision fix (#1420).
- Affects 4 models: **InstructBLIP** (Dai et al. NeurIPS 2023), **MiniGPT4** (Zhu et al. 2023), **MiniGPTv2** (Chen et al. 2023), **BLIP-3** (Salesforce 2024) — all wrap a frozen EVA-ViT-G or CLIP ViT-L/14.

## Fix

1. **`LayerHelper.CreateDefaultQFormerGenerativeLayers`**: add `int patchSize = 14` parameter, prepend `PatchEmbeddingLayer<T>(patchSize, visionDim, expectedInputChannels: 3)` before the vision encoder LayerNorm.
2. **`InstructBLIP`/`MiniGPT4`/`MiniGPTv2`/`BLIP3.InitializeLayers`**: update `visionLayerEnd` from `1 + …` to `2 + …` to count the new `PatchEmbedding` in the layer split.
3. **`TestScaffoldGenerator.s_patchVisionFamilies`**: add the 4 class names so scaffold emits `spatial=112` (divisible by 14), not the CNN default 128.
4. **`TestScaffoldGenerator.IsPaperScaleVisionLanguageModel`**: add the 4 models so `Training_*` invariants use the reduced iteration counts (paper defaults — 39 vision layers × dim 1408 × FFN 5632 per block — overflow the 120 s xUnit timeout at 30/50/200 iters).

Surfaced on PR #1501 Generated Layers shard run [27040737008](https://github.com/ooples/AiDotNet/actions/runs/27040737008) as 6 `InstructBLIPTests` all throwing the same shape-mismatch `ArgumentException`.

## Test plan

- [ ] Generated Layers shard `InstructBLIPTests`: 6/6 fails → 0/6 fails (CI verifies — local OOMs on 39-layer VL forward at fp64 default, separate paper-scale concern shared with Gemma3/DFNCLIP).
- [ ] No regression on MiniGPT4/MiniGPTv2/BLIP3 tests (same fix applies).
- [ ] No regression on the 14 other VLM helpers in `LayerHelper.cs` (unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed vision-layer boundary calculations for several generative vision-language models to ensure correct layer partitioning.
  * Added explicit patch-embedding handling and a configurable patch size so vision encoders use the correct input patch layout and head divisibility.

* **Tests**
  * Test scaffolding now recognizes more vision-language models and applies reduced-iteration overrides to avoid per-test timeouts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->