### PR TITLE
fix(deps): bump AiDotNet.Tensors 0.91.11 → 0.91.12 (unblock master)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -118,7 +118,7 @@
          Do NOT pin an unpublished version (0.91.14/0.91.16 broke restore with NU1102);
          re-bump once a newer Tensors is actually released. The AiDotNet.Native packages
          stay at 0.91.2 (no native change needed). -->
-    <PackageVersion Include="AiDotNet.Tensors" Version="0.91.11" />
+    <PackageVersion Include="AiDotNet.Tensors" Version="0.91.12" />
     <PackageVersion Include="AiDotNet.Native.OneDNN" Version="0.91.2" />
     <PackageVersion Include="AiDotNet.Native.OpenBLAS" Version="0.91.2" />
     <PackageVersion Include="AiDotNet.Native.CLBlast" Version="0.91.2" />


### PR DESCRIPTION
## Summary

PR #1501 (gpu-resident optimizer, merged 2026-06-07) added GPU-fast-path calls (\`GpuOptimizer.TryRmspropStep\` / \`TrySgdMomentumStep\` / \`TryNadamStep\` / \`TryLionStep\` / \`TryFtrlStep\` / \`TryProximalL1Step\` / \`TryAdagradStep\` / \`TryAmsgradStep\` / \`TryAdadeltaStep\` / \`TryAdamaxStep\` and \`FreeGpuBuffer\`) across 11 Optimizer files, but the Tensors NuGet pinned to **0.91.11** does not ship those symbols. **Master build breaks** with \`CS0117\` across all 11 optimizers — and every PR opened after the merge inherits the broken master state.

\`0.91.12\` (latest published on nuget.org) ships the symbols. **Pure version bump** — no AiDotNet-side code change since PR #1501's call sites already match the new Tensors API surface.

## Test plan

- [x] Local: \`dotnet build src/AiDotNet.csproj -f net10.0\` **fails** CS0117 ×40+ with 0.91.11, **succeeds** with 0.91.12.
- [ ] CI: Build & SonarCloud green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package dependencies to latest compatible versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->