### PR TITLE
fix(streaming): wire weight-streaming auto-detect to all Predict paths

### DIFF
--- a/src/NeuralNetworks/NeuralNetworkBase.cs
+++ b/src/NeuralNetworks/NeuralNetworkBase.cs
@@ -4307,6 +4307,17 @@ public abstract class NeuralNetworkBase<T> : INeuralNetworkModel<T>, IInterpreta
     /// </remarks>
     public virtual void SetTrainingMode(bool isTraining)
     {
+        // Auto-detect weight streaming on first model touch. Every Predict
+        // override (~933 of them across the codebase) calls SetTrainingMode
+        // before iterating layers; the base-class Predict's auto-detect
+        // hooks (lines 3080, 3170) never fire because the subclass
+        // overrides bypass them. Wiring detection here covers all forward-
+        // path callers in one place. Both calls are idempotent (gated by
+        // _layerShapesResolved / _streamingAutoDetectFinalized) so the
+        // hot path is one branch + early-return after the first call.
+        ResolveLazyLayerShapes();
+        TryAutoEnableWeightStreaming();
+
         if (SupportsTraining)
         {
             IsTrainingMode = isTraining;
@@ -4660,15 +4671,27 @@ public abstract class NeuralNetworkBase<T> : INeuralNetworkModel<T>, IInterpreta
 
     /// <summary>
     /// Default parameter-count threshold above which weight streaming is
-    /// auto-enabled. 10 billion parameters ≈ 40 GB at fp32 / 20 GB at fp16
-    /// — the point at which consumer GPUs (24 GB max) and most workstation
-    /// systems (32–64 GB RAM) start hitting memory pressure. Models below
-    /// this train eagerly with no streaming overhead. Override per-process
-    /// via the <c>AIDOTNET_STREAMING_THRESHOLD_PARAMS</c> environment
-    /// variable, or per-instance via <see cref="DisableAutoStreaming"/> /
-    /// the explicit <see cref="ConfigureWeightLifetime"/> call.
+    /// auto-enabled. 500 million parameters covers the memory-pressure
+    /// inflection point across precisions and host environments:
+    /// <list type="bullet">
+    /// <item>fp64 (default for ModelFamily tests): 4 GB of weights — CI
+    /// runners with 7 GB total RAM need this headroom for activations
+    /// + optimizer state + runtime, otherwise paper-scale VLMs (EVA-ViT-G
+    /// in InstructBLIP/MiniGPT4/BLIP3 ≈ 1 B params, Gemma3 vision ≈ 1.2 B)
+    /// OOM at first DenseLayer allocation.</item>
+    /// <item>fp32: 2 GB of weights — consumer GPUs (8–24 GB) keep ample
+    /// headroom for activations.</item>
+    /// <item>fp16: 1 GB of weights — workstation systems unaffected.</item>
+    /// </list>
+    /// Was 10 B (fp32-only sizing); raised the floor for paper-scale fp64
+    /// model tests that OOM'd before the threshold check ever fired.
+    /// Models below this train eagerly with no streaming overhead. Override
+    /// per-process via the <c>AIDOTNET_STREAMING_THRESHOLD_PARAMS</c>
+    /// environment variable, or per-instance via
+    /// <see cref="DisableAutoStreaming"/> / the explicit
+    /// <see cref="ConfigureWeightLifetime"/> call.
     /// </summary>
-    private const long DefaultStreamingThresholdParams = 10_000_000_000L;
+    private const long DefaultStreamingThresholdParams = 500_000_000L;
 
     /// <summary>
     /// Public-readable view of the auto-detect threshold for telemetry


### PR DESCRIPTION
## Summary

Two-part fix making the existing weight-streaming infrastructure (#1222 / #183) actually engage for paper-scale models in tests:

### 1. Lower default threshold 10 B → 500 M params

The 10 B threshold (\`"≈ 40 GB at fp32 / 20 GB at fp16"\`) only ever fires for LLaMA-70B-class models. Real-world paper-scale models all fall under it:

| Model | Params (fp64 bytes) | 10 B threshold? |
|---|---|---|
| InstructBLIP (EVA-ViT-G + Q-Former + LLM) | ~1.5 B (12 GB) | NO |
| Gemma3 (SigLIP-SO + 27 layers) | 1.2 B (10 GB) | NO |
| MiniGPT-4 / MiniGPTv2 / BLIP-3 | ~1.5 B each | NO |
| DFNCLIP (ViT-H/14) | 631 M (5 GB) | NO |
| BiomedCLIP (ViT-B/16) | 85 M (700 MB) | NO |

CI runners have ~7 GB total RAM. **500 M params gives 4 GB of fp64 weights**, leaving ≈ 3 GB for activations + optimizer state + runtime. fp32 / fp16 numbers shrink proportionally so no consumer-GPU user is impacted.

### 2. Wire auto-detect into \`SetTrainingMode\`

Of the 5 existing call sites for \`TryAutoEnableWeightStreaming\`, **none fire for the 933 Predict overrides** in this codebase — they bypass \`NeuralNetworkBase.Predict\` by iterating \`Layers\` directly. \`SetTrainingMode\` is called by every Predict override before the forward loop, so wiring detection there covers the entire forward-path surface with one change. Both \`ResolveLazyLayerShapes\` and \`TryAutoEnableWeightStreaming\` are already idempotent (\`_layerShapesResolved\` / \`_streamingAutoDetectFinalized\`), so the hot path after the first call is one branch + early-return.

## Verification

**InstructBLIPTests.Predict_ShouldBeDeterministic** (local, net10.0):

| State | Outcome |
|---|---|
| Before (master) | \`OutOfMemoryException\` at \`DenseLayer.AllocateLazyWeight\` (1 m 41 s timeout) |
| After (this PR + #1518) | **PASS in 1 m 49 s** — streaming pool routes the 39-vision-layer paper-scale ViT-G allocation, no OOM. |

The shape-mismatch fix in #1518 is a prerequisite (lets the test get past MHA before hitting the FFN allocation); this PR is the prerequisite for the test to actually pass once it reaches the FFN.

## Dependencies

- Stacks on #1519 (Tensors 0.91.12 bump — unblocks master build).

## Test plan

- [ ] CI green on this branch.
- [ ] After merging #1519 + #1518 + this: 6/6 \`InstructBLIPTests\` pass on the Generated Layers shard.
- [ ] No regression on the \`AutoDetectWeightStreamingTests\` unit suite (those tests pin their own threshold via \`SetThresholdForTest\`, so the default change doesn't affect them).
- [ ] No regression on the 933 existing Predict overrides — \`SetTrainingMode\` is the common call site they all hit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced training initialization with automatic weight streaming optimization for improved memory efficiency on large models.
  * Reduced the default parameter threshold for automatic weight streaming from 10 billion to 500 million parameters, enabling more models to benefit from streaming features by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->