### PR TITLE
fix(website): unblock production deploy — anchor .vercelignore patterns (aidotnet.dev → 200)

### DIFF
--- a/.vercelignore
+++ b/.vercelignore
@@ -1,18 +1,29 @@
-src/
-tests/
-tools/
-samples/
-testconsole/
-AiDotNetBenchmarkTests/
-PhaseATestRunner/
-.worktrees/
+# Leading-slash patterns are gitignore-anchored to this file's directory
+# (the repo root) so they only match the top-level C# project directories
+# WITHOUT also matching the Astro Vercel project at /website/. Unanchored
+# patterns like `src/` would also match `website/src/` (gitignore-style
+# matching is depth-agnostic by default), removing the Astro pages before
+# `npm run build` ever sees them — that's the bug that produced 0-page
+# production deploys and aidotnet.dev → 404 until this was anchored.
+/src/
+/tests/
+/tools/
+/samples/
+/testconsole/
+/AiDotNetBenchmarkTests/
+/PhaseATestRunner/
+/.worktrees/
+/bin/
+/obj/
+/.github/
+/docs/
+# Build outputs anywhere in the tree (these patterns intentionally match
+# at any depth — keep them unanchored).
 *.dll
 *.exe
 *.pdb
 *.nupkg
-bin/
-obj/
-.github/
-docs/
+# Website-tree exclusions: explicit because these live under /website/
+# and aren't caught by the anchored patterns above.
 website/node_modules/
 website/.astro/

--- a/.vercelignore
+++ b/.vercelignore
@@ -24,6 +24,8 @@
 *.pdb
 *.nupkg
 # Website-tree exclusions: explicit because these live under /website/
-# and aren't caught by the anchored patterns above.
-website/node_modules/
-website/.astro/
+# and aren't caught by the anchored patterns above. Leading slash keeps
+# them anchored too — without it, a hypothetical `tools/website/node_modules/`
+# or any other nested `website/` directory would also match.
+/website/node_modules/
+/website/.astro/

--- a/website/.vercelignore
+++ b/website/.vercelignore
@@ -1,4 +1,3 @@
 node_modules/
-src/
 .astro/
 supabase/


### PR DESCRIPTION
## Summary

**aidotnet.dev is down (404)** because every production deploy builds **0 pages**.

### Root cause

\`.vercelignore\` uses gitignore semantics where unanchored patterns like \`src/\` match a directory of that name **at any depth**. The repo-root \`src/\` rule (intended to exclude the C# project) silently also matched **\`website/src/\`**, deleting the Astro source tree before \`npm run build\` ever saw it. Same problem for \`tests/\` and \`docs/\`.

### Evidence

**Production deploy log (4 h old)** — \`vercel inspect --logs\` on the live alias:
\`\`\`
Cloning github.com/ooples/AiDotNet (Branch: master, Commit: 8603fbe)
Removed 8616 ignored files defined in .vercelignore
  /src/ActivationFunctions/ActivationFunctionBase.cs
  ...
Restored build cache from previous deployment (5uNQHmBYeJpWCrq6zq9rinPpkXv2)
Running "npm run build"
> astro build
[build] 0 page(s) built in 1.42s   ← empty deployment
Deployment completed
\`\`\`

**Local \`npm run build\`** produces **81 pages**, confirming this is a deploy-only regression.

**Gitignore semantics** (reproduced with \`git check-ignore\`):

```
$ echo 'src/' > .gitignore
$ git check-ignore -v website/src/pages/index.astro
.gitignore:1:src/  website/src/pages/index.astro    ← matches (bug)

$ echo '/src/' > .gitignore
$ git check-ignore -v website/src/pages/index.astro
(no match, exit 1)                                  ← correct (fix)
```

### Fix

- **\`.vercelignore\` (root)** — anchor every directory pattern with a leading \`/\` so it matches only top-level C# project dirs (\`src\`, \`tests\`, \`tools\`, \`samples\`, \`testconsole\`, \`AiDotNetBenchmarkTests\`, \`PhaseATestRunner\`, \`.worktrees\`, \`bin\`, \`obj\`, \`.github\`, \`docs\`). File globs (\`*.dll\`, \`*.exe\`, \`*.pdb\`, \`*.nupkg\`) stay unanchored — build outputs should still be excluded at any depth.
- **\`website/.vercelignore\`** — drop \`src/\` (same root cause; nothing in the website-local ignore should have excluded its own source tree).

Also adds an inline comment explaining the gotcha so the next person editing these files doesn't recreate the bug.

## Test plan

- [x] Local \`git check-ignore\` verification of anchored vs unanchored patterns.
- [x] Local \`npm run build\` succeeds → 81 pages.
- [ ] Once merged: master push triggers Vercel production deploy; build log should show >0 pages and aidotnet.dev should return 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved deployment ignore rules to avoid unintentionally excluding nested project files and ensure only intended top-level folders are ignored.
  * Explicitly excluded common build outputs (binaries, debug symbols, packages) from deployments to reduce artifact size.
  * Added targeted ignore entries for the web subtree (node modules and framework build dirs) to streamline web deployments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->