### PR TITLE
feat(nn): recover GPU training faults on the eager CPU path instead of aborting

### DIFF
--- a/src/NeuralNetworks/NeuralNetwork.cs
+++ b/src/NeuralNetworks/NeuralNetwork.cs
@@ -244,6 +244,19 @@ public class NeuralNetwork<T> : NeuralNetworkBase<T>
     /// </remarks>
     public override Tensor<T> Predict(Tensor<T> input)
     {
+        try
+        {
+            return PredictCore(input);
+        }
+        catch (Exception ex) when (IsGpuTransientFailure(ex))
+        {
+            // A sticky GPU fault tripped the circuit breaker (engine is now CPU); retry on CPU.
+            return PredictCore(input);
+        }
+    }
+
+    private Tensor<T> PredictCore(Tensor<T> input)
+    {
         // GPU-resident optimization: use TryForwardGpuOptimized for speedup
         if (TryForwardGpuOptimized(input, out var gpuResult))
             return gpuResult;

--- a/src/NeuralNetworks/NeuralNetworkBase.cs
+++ b/src/NeuralNetworks/NeuralNetworkBase.cs
@@ -5023,6 +5023,19 @@ public abstract class NeuralNetworkBase<T> : INeuralNetworkModel<T>, IInterpreta
     /// </remarks>
     public virtual void Train(Tensor<T> input, Tensor<T> expectedOutput)
     {
+        try
+        {
+            TrainCore(input, expectedOutput);
+        }
+        catch (Exception ex) when (IsGpuTransientFailure(ex))
+        {
+            // A sticky GPU fault tripped the circuit breaker (engine is now CPU); retry on CPU.
+            TrainCore(input, expectedOutput);
+        }
+    }
+
+    private void TrainCore(Tensor<T> input, Tensor<T> expectedOutput)
+    {
         // Universal batch-dim auto-promotion. When the caller passes an
         // unbatched single sample (matching the architecture's declared rank
         // exactly), prepend a unit batch dim so downstream Conv/BN/Dense
@@ -6592,6 +6605,21 @@ public abstract class NeuralNetworkBase<T> : INeuralNetworkModel<T>, IInterpreta
             // is also attached for catch (InvalidOperationException ex) callers
             // that introspect ex.InnerException.
             var fallbackEx = Training.CompiledTapeTrainingStep<T>.GetLastFallbackException();
+
+            // Transient GPU/CUDA fault in the committed fused plan (e.g. CUDA error 700 from the
+            // activation-cache deferred-materializer race, or a device fault): the compiled plan
+            // can't continue on the GPU. Rather than abort the whole training run, reset the
+            // fused/compiled state and fall back to the eager path — the optimizer moments reset
+            // (a one-time trajectory perturbation), which is far better than crashing. Non-GPU
+            // causes (shape drift, hyperparameter changes) still surface loudly below.
+            if (IsGpuTransientFailure(fallbackEx))
+            {
+                _fusedTrainingDisabled = true;
+                _fusedTrainingCommitted = false;
+                InvalidateParameterCountCache();
+                return false;
+            }
+
             var rootCauseSuffix = fallbackEx is not null
                 ? $" Root-cause exception (caught in CompiledTapeTrainingStep): " +
                   $"{fallbackEx.GetType().FullName}: {fallbackEx.Message}"
@@ -6619,6 +6647,32 @@ public abstract class NeuralNetworkBase<T> : INeuralNetworkModel<T>, IInterpreta
             _fusedTrainingDisabled = true;
         }
         return ran;
+    }
+
+    /// <summary>
+    /// True if the exception chain indicates a transient GPU/CUDA fault (device error, failed
+    /// host/device copy, or the activation-cache deferred-materializer race) — as opposed to a
+    /// logical cause (shape drift, hyperparameter change). Used to decide whether a committed
+    /// fused step can reset-and-recover on the eager path instead of aborting.
+    /// </summary>
+    protected static bool IsGpuTransientFailure(Exception? exception)
+    {
+        for (var e = exception; e is not null; e = e.InnerException)
+        {
+            var message = e.Message;
+            if (message.Contains("CUDA error", StringComparison.OrdinalIgnoreCase)
+                || message.Contains("cuMem", StringComparison.Ordinal)
+                || message.Contains("cuStream", StringComparison.Ordinal)
+                || message.Contains("cuLaunch", StringComparison.Ordinal)
+                || message.Contains("OpenCL", StringComparison.OrdinalIgnoreCase)
+                || message.Contains("released before materialization", StringComparison.OrdinalIgnoreCase)
+                || message.Contains("buffer was released", StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /// <summary>


### PR DESCRIPTION
## Problem
On a real GPU box, a committed fused-optimizer training step can fault with a transient CUDA error (device fault, or the activation-cache deferred-materializer race / illegal-address 700). The previous behavior threw `Fused compiled training has already run successfully, but the current step cannot engage the fused path` — deliberately refusing to fall back silently to avoid optimizer-state divergence. For a **hardware/context fault** that means crashing the whole training run.

## Fix
- `NeuralNetworkBase.IsGpuTransientFailure` classifies transient GPU/CUDA faults (vs. logical causes like shape drift).
- On a committed fused step that hits such a fault, reset the fused/compiled state and fall back to eager instead of throwing.
- `Train`/`Predict` (and `NeuralNetwork.Predict`) retry the step on CPU after a transient GPU fault — by then the Tensors-side circuit breaker (ooples/AiDotNet.Tensors#565) has switched the engine to CPU.

Together a GPU fault **self-heals to CPU** and training continues, instead of cascading CUDA 700 across the process.

## Verification
Applied onto `master`; `AiDotNet` builds in Release. End-to-end: a consumer app whose full CPU test suite (78 tests) previously failed with cascading CUDA 700 is now green.

Depends on ooples/AiDotNet.Tensors#565.

🤖 Generated with [Claude Code](https://claude.com/claude-code)