### PR TITLE
fix(init): seed non-lazy weight init (He/Xavier) from the layer RandomSeed

### DIFF
--- a/src/Initialization/EagerInitializationStrategy.cs
+++ b/src/Initialization/EagerInitializationStrategy.cs
@@ -31,6 +31,10 @@ public class EagerInitializationStrategy<T> : InitializationStrategyBase<T>
     public EagerInitializationStrategy(Random? rng) : base(rng) { }
 
     /// <inheritdoc />
+    public override IInitializationStrategy<T> WithSeededRandom(Random rng)
+        => new EagerInitializationStrategy<T>(rng);
+
+    /// <inheritdoc />
     public override bool IsLazy => false;
 
     /// <inheritdoc />

--- a/src/Initialization/HeInitializationStrategy.cs
+++ b/src/Initialization/HeInitializationStrategy.cs
@@ -42,6 +42,10 @@ public class HeInitializationStrategy<T> : InitializationStrategyBase<T>
     }
 
     /// <inheritdoc />
+    public override IInitializationStrategy<T> WithSeededRandom(Random rng)
+        => new HeInitializationStrategy<T>(rng, _useNormal);
+
+    /// <inheritdoc />
     public override bool IsLazy => false;
 
     /// <inheritdoc />

--- a/src/Initialization/InitializationStrategyBase.cs
+++ b/src/Initialization/InitializationStrategyBase.cs
@@ -52,6 +52,17 @@ public abstract class InitializationStrategyBase<T> : IInitializationStrategy<T>
         Random = rng ?? RandomHelper.ThreadSafeRandom;
     }
 
+    /// <summary>
+    /// Returns an instance of this strategy that samples from the supplied
+    /// (typically seeded) <see cref="Random"/>, preserving the strategy's
+    /// distribution. Used by <c>LayerBase.InitializeLayerWeights</c> to make a
+    /// non-lazy strategy (e.g. He) reproducible when the layer has a pinned
+    /// <c>RandomSeed</c>. The base returns <c>this</c> (no re-seed support);
+    /// strategies whose constructor accepts a <see cref="Random"/> override this
+    /// to return a fresh seeded copy.
+    /// </summary>
+    public virtual IInitializationStrategy<T> WithSeededRandom(Random rng) => this;
+
     /// <inheritdoc />
     public abstract bool IsLazy { get; }
 

--- a/src/NeuralNetworks/Layers/LayerBase.cs
+++ b/src/NeuralNetworks/Layers/LayerBase.cs
@@ -4150,50 +4150,53 @@ public abstract class LayerBase<T> : ILayer<T>, ITrainableLayer<T>, IDisposable
     /// </summary>
     protected void InitializeLayerWeights(Tensor<T> tensor, int fanIn, int fanOut)
     {
-        // Skip a LAZY strategy: its InitializeWeights is a generic, NON-seeded
-        // Xavier fill that ignores this layer's RandomSeed (the lazy strategy only
-        // advertises the deferral contract — it expects the layer's own seeded init
-        // to run). Falling through to the RandomSeed-derived path below keeps init
-        // reproducible / order-independent.
-        if (InitializationStrategy is not null && !InitializationStrategy.IsLazy)
-        {
-            InitializationStrategy.InitializeWeights(tensor, fanIn, fanOut);
-            return;
-        }
-
-        // Closes #1383: when this layer has a RandomSeed pinned (set by
-        // LayerHelper from architecture.RandomSeed), build a FRESH seeded
-        // strategy per call rather than the process-shared
-        // DefaultStrategy singleton. The singleton wraps
-        // RandomHelper.ThreadSafeRandom whose per-thread Random state
-        // advances cumulatively across consecutive trainings — so two
-        // back-to-back trainings at the same architecture seed produce
-        // different initial weights without this branch.
+        // Closes #1383, #1539: when this layer has a RandomSeed pinned (set by
+        // LayerHelper from architecture.RandomSeed), drive initialization from a
+        // FRESH seeded RNG so init is reproducible / order-independent. This
+        // takes precedence over the configured strategy's own (process-shared)
+        // RNG even when the strategy is NON-LAZY — e.g. the He init that
+        // Conv1DLayer/ConvolutionalLayer use samples from
+        // RandomHelper.ThreadSafeRandom, whose per-thread state advances
+        // cumulatively across consecutive model constructions. Two back-to-back
+        // trainings at the same architecture seed must produce identical
+        // initial weights (flaky training invariants like
+        // MoreData_ShouldNotDegrade for conv-based models otherwise break).
+        // The lazy contract still works here because the WithSeededRandom /
+        // EagerInitializationStrategy branch below handles both lazy and
+        // non-lazy strategies uniformly when RandomSeed is set.
         if (RandomSeed.HasValue)
         {
-            // Mix the tensor shape (fanIn, fanOut) into the derivation
-            // alongside the layer's RandomSeed and the per-call counter.
-            // This defends the seeded path against the case where two
-            // different layer instances share the same RandomSeed value
-            // (uncommon — LayerHelper.CreateDefaultTransformerLayers
-            // assigns each layer a unique seed via seedRng.Next() — but
-            // possible if a consumer manually sets RandomSeed). Without
-            // shape-mixing, two layers at the same RandomSeed + same
-            // _initWeightsCallCounter index initializing weight tensors
-            // of the same fanIn × fanOut would land on bit-identical
-            // weights, breaking the symmetry the network architecture
-            // relies on. Different-shape tensors already differ via
-            // (fanIn, fanOut); same-shape tensors at the same call
-            // index across distinct layer instances now also differ
-            // via the counter, which is per-instance.
+            // Mix the tensor shape (fanIn, fanOut) into the derivation alongside
+            // the layer's RandomSeed and a per-instance call counter so two
+            // distinct layers (or two weight tensors in one layer) that share a
+            // RandomSeed value + shape don't land on bit-identical weights and
+            // break the symmetry the architecture relies on.
             int derived = unchecked((int)(
                 ((uint)RandomSeed.Value * 2654435761u)
                 ^ ((uint)fanIn * 40503u)
                 ^ ((uint)fanOut * 2654435789u)
                 ^ (uint)System.Threading.Interlocked.Increment(ref _initWeightsCallCounter)));
-            var seeded = new Initialization.EagerInitializationStrategy<T>(
-                AiDotNet.Tensors.Helpers.RandomHelper.CreateSeededRandom(derived));
+            var rng = AiDotNet.Tensors.Helpers.RandomHelper.CreateSeededRandom(derived);
+
+            // Preserve the configured distribution (He for conv layers, Xavier
+            // for dense, etc.) but drive it from the seeded RNG. A non-lazy
+            // strategy that supports re-seeding returns a seeded copy via
+            // WithSeededRandom; a lazy/null strategy defers to the seeded Xavier
+            // EagerInitializationStrategy (the lazy contract expects this path).
+            IInitializationStrategy<T> seeded =
+                (InitializationStrategy is Initialization.InitializationStrategyBase<T> sb
+                    && !InitializationStrategy.IsLazy)
+                    ? sb.WithSeededRandom(rng)
+                    : new Initialization.EagerInitializationStrategy<T>(rng);
             seeded.InitializeWeights(tensor, fanIn, fanOut);
+            return;
+        }
+
+        // No pinned seed: use the configured non-lazy strategy as-is (its own
+        // distribution + RNG), else the process default.
+        if (InitializationStrategy is not null && !InitializationStrategy.IsLazy)
+        {
+            InitializationStrategy.InitializeWeights(tensor, fanIn, fanOut);
             return;
         }
 

--- a/tests/AiDotNet.Tests/IntegrationTests/NeuralNetworks/InitializationDeterminismTests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/NeuralNetworks/InitializationDeterminismTests.cs
@@ -57,6 +57,41 @@ public class InitializationDeterminismTests
             Assert.Equal(first[i], second[i], 12);
     }
 
+    private static double[] BuildAndInitConv1DHe(int seed, int inputChannels, int outputChannels, int kernelSize)
+    {
+        // Conv1DLayer defaults to the He strategy, which is NON-LAZY — the exact
+        // case that bypassed the RandomSeed-derived path (InitializeLayerWeights
+        // early-returned for any non-lazy strategy, letting He sample from the
+        // process-shared ThreadSafeRandom). Use the lazy-input-channel constructor
+        // so initialization runs at first Forward, AFTER RandomSeed is assigned.
+        var layer = new Conv1DLayer<double>(outputChannels: outputChannels, kernelSize: kernelSize)
+        {
+            RandomSeed = seed,
+        };
+        layer.Forward(new Tensor<double>(new[] { 1, inputChannels, 8 }));
+        var p = layer.GetParameters();
+        var arr = new double[p.Length];
+        for (int i = 0; i < p.Length; i++) arr[i] = p[i];
+        return arr;
+    }
+
+    [Fact]
+    public void Conv1DLayer_HeStrategy_WithRandomSeed_InitIsDeterministic_DespiteSharedRngDrain()
+    {
+        double[] first = BuildAndInitConv1DHe(seed: 4242, inputChannels: 8, outputChannels: 16, kernelSize: 3);
+
+        // Advance the shared RNG to simulate prior in-process work. Before the fix
+        // this changed He's draws and the conv weights diverged; after it the
+        // seeded He path is independent of the shared RNG.
+        for (int i = 0; i < 5000; i++) RandomHelper.ThreadSafeRandom.Next();
+
+        double[] second = BuildAndInitConv1DHe(seed: 4242, inputChannels: 8, outputChannels: 16, kernelSize: 3);
+
+        Assert.Equal(first.Length, second.Length);
+        for (int i = 0; i < first.Length; i++)
+            Assert.Equal(first[i], second[i], 12);
+    }
+
     [Fact]
     public void NeuralNetwork_SeededArchitecture_InitIsDeterministic_DespiteSharedRngDrain()
     {


### PR DESCRIPTION
## What

Makes **non-lazy** weight-initialization strategies (He, Xavier) honor the layer's pinned `RandomSeed`, so conv-based models initialize deterministically and independently of process order.

## Why

`LayerBase.InitializeLayerWeights` early-returned for any non-lazy `InitializationStrategy`, calling its `InitializeWeights` directly. Those strategies sample from the process-shared `RandomHelper.ThreadSafeRandom`, whose state advances cumulatively across model constructions. So **every conv-based layer** (`Conv1DLayer`, `ConvolutionalLayer` — both default to the non-lazy He strategy) got **order-dependent** weight init even when the architecture pinned a `RandomSeed`: the same seed produced different weights depending on how many models were built earlier in the process.

That made init-sensitive training invariants (e.g. `MoreData_ShouldNotDegrade`) pass in isolation but flake in-class for conv-based model families.

The sibling determinism fix (#1523) already handles **lazy** strategies (they fall through to the seeded path). This completes the story for the non-lazy strategies.

## How

- `InitializationStrategyBase.WithSeededRandom(Random)` — new virtual (returns `this`), overridden by `HeInitializationStrategy` and `EagerInitializationStrategy` (Xavier) to return a fresh copy bound to the supplied seeded RNG.
- `InitializeLayerWeights` now, when `RandomSeed` is pinned, drives the **configured** strategy from a derived seeded RNG (preserving its distribution — He stays He) instead of early-returning into the strategy's shared RNG. No behavior change when no seed is pinned (production default).
- Regression test: `Conv1DLayer_HeStrategy_WithRandomSeed_InitIsDeterministic_DespiteSharedRngDrain`.

## Notes

- **Stacked on #1523** (`fix/init-seed-determinism`), which provides the `RandomSeed`-from-architecture mechanism this relies on — base is set to that branch; retarget to `master` once #1523 merges.
- Split out of the vocoder PR #1527 to keep that PR's blast radius to the TTS family: this changes init for **all** conv models, so it gets its own PR for CNN regression visibility.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Initialization strategies now support seeded random number generation, enabling reproducible and deterministic weight initialization across different neural network layer types.

* **Tests**
  * Extended test coverage to verify that weight initialization remains deterministic when seeded random generation is combined with different initialization strategies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->