### PR TITLE
feat(agentic): Phase 1 — typed durable graph runtime (epic #1544)

### DIFF
--- a/src/Agentic/Graph/Checkpointing/GraphCheckpoint.cs
+++ b/src/Agentic/Graph/Checkpointing/GraphCheckpoint.cs
@@ -1,0 +1,62 @@
+namespace AiDotNet.Agentic.Graph.Checkpointing;
+
+/// <summary>
+/// An immutable snapshot of a graph run at a point in time: which node runs next and the state as of
+/// that point. Saved after each step so a run can be resumed, inspected, or replayed.
+/// </summary>
+/// <typeparam name="TState">The graph's state type.</typeparam>
+/// <remarks>
+/// <para>
+/// A checkpoint records the <see cref="NextNode"/> (where execution will continue) plus the
+/// <see cref="State"/> at that boundary, tagged with a <see cref="ThreadId"/> (the run/conversation) and a
+/// monotonically increasing <see cref="Step"/>. The sequence of checkpoints for a thread is its history —
+/// the basis for durable resume and time-travel.
+/// </para>
+/// <para><b>For Beginners:</b> Like a save-game. It remembers exactly where the graph was about to go
+/// next and what the data looked like, so you can stop and pick up later (or rewind to an earlier save).
+/// </para>
+/// </remarks>
+public sealed class GraphCheckpoint<TState>
+{
+    /// <summary>
+    /// Initializes a new checkpoint.
+    /// </summary>
+    /// <param name="threadId">The run/thread this checkpoint belongs to.</param>
+    /// <param name="checkpointId">A unique id for this checkpoint within the thread.</param>
+    /// <param name="step">The zero-based step index (monotonically increasing within a thread).</param>
+    /// <param name="nextNode">The node that will execute next (or <see cref="GraphSpecialNodes.End"/> when complete).</param>
+    /// <param name="state">The state at this boundary.</param>
+    /// <exception cref="ArgumentNullException">Thrown when a required string is <c>null</c>.</exception>
+    /// <exception cref="ArgumentException">Thrown when a required string is empty/whitespace.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="step"/> is negative.</exception>
+    public GraphCheckpoint(string threadId, string checkpointId, int step, string nextNode, TState state)
+    {
+        Guard.NotNullOrWhiteSpace(threadId);
+        Guard.NotNullOrWhiteSpace(checkpointId);
+        Guard.NotNullOrWhiteSpace(nextNode);
+        Guard.NonNegative(step);
+        ThreadId = threadId;
+        CheckpointId = checkpointId;
+        Step = step;
+        NextNode = nextNode;
+        State = state;
+    }
+
+    /// <summary>Gets the run/thread this checkpoint belongs to.</summary>
+    public string ThreadId { get; }
+
+    /// <summary>Gets the unique id of this checkpoint within the thread.</summary>
+    public string CheckpointId { get; }
+
+    /// <summary>Gets the zero-based, monotonically increasing step index.</summary>
+    public int Step { get; }
+
+    /// <summary>Gets the node that will execute next (or <see cref="GraphSpecialNodes.End"/> when the run is complete).</summary>
+    public string NextNode { get; }
+
+    /// <summary>Gets the state captured at this boundary.</summary>
+    public TState State { get; }
+
+    /// <summary>Gets a value indicating whether this checkpoint represents a completed run.</summary>
+    public bool IsComplete => NextNode == GraphSpecialNodes.End;
+}

--- a/src/Agentic/Graph/Checkpointing/IGraphCheckpointer.cs
+++ b/src/Agentic/Graph/Checkpointing/IGraphCheckpointer.cs
@@ -37,10 +37,17 @@ public interface IGraphCheckpointer<TState>
     Task<GraphCheckpoint<TState>?> GetAsync(string threadId, string checkpointId, CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Gets the full checkpoint history for a thread, ordered by step ascending.
+    /// Gets the full <see cref="GraphCheckpoint{TState}"/> history for <paramref name="threadId"/> in
+    /// append (chronological) order — i.e. the order checkpoints were saved, by a persistent monotonic
+    /// sequence (e.g. the SQLite backend orders by <c>Seq ASC</c>), NOT by logical step number.
     /// </summary>
+    /// <remarks>
+    /// Replay/time-travel relies on this chronological ordering: logical step values can repeat or branch
+    /// (loops, re-runs from an earlier checkpoint), so ordering by step would diverge across backends.
+    /// Implementations MUST return checkpoints oldest-first by save order.
+    /// </remarks>
     /// <param name="threadId">The run/thread id.</param>
     /// <param name="cancellationToken">Token used to cancel the operation.</param>
-    /// <returns>The ordered history (possibly empty).</returns>
+    /// <returns>The chronologically-ordered history (possibly empty).</returns>
     Task<IReadOnlyList<GraphCheckpoint<TState>>> GetHistoryAsync(string threadId, CancellationToken cancellationToken = default);
 }

--- a/src/Agentic/Graph/Checkpointing/IGraphCheckpointer.cs
+++ b/src/Agentic/Graph/Checkpointing/IGraphCheckpointer.cs
@@ -1,0 +1,46 @@
+namespace AiDotNet.Agentic.Graph.Checkpointing;
+
+/// <summary>
+/// Persists and retrieves <see cref="GraphCheckpoint{TState}"/>s, enabling durable resume and time-travel
+/// for graph runs. Implementations back onto memory, SQLite, Postgres, Redis, etc.
+/// </summary>
+/// <typeparam name="TState">The graph's state type.</typeparam>
+/// <remarks>
+/// <para><b>For Beginners:</b> The save-game store. The graph asks it to save a checkpoint after each
+/// step, to fetch the latest checkpoint when resuming, and to list the full history when rewinding.
+/// </para>
+/// </remarks>
+public interface IGraphCheckpointer<TState>
+{
+    /// <summary>
+    /// Saves (appends) a checkpoint.
+    /// </summary>
+    /// <param name="checkpoint">The checkpoint to persist.</param>
+    /// <param name="cancellationToken">Token used to cancel the operation.</param>
+    Task SaveAsync(GraphCheckpoint<TState> checkpoint, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets the most recent checkpoint for a thread, or <c>null</c> if the thread has none.
+    /// </summary>
+    /// <param name="threadId">The run/thread id.</param>
+    /// <param name="cancellationToken">Token used to cancel the operation.</param>
+    /// <returns>The latest checkpoint, or <c>null</c>.</returns>
+    Task<GraphCheckpoint<TState>?> GetLatestAsync(string threadId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets a specific checkpoint by id (used for time-travel / replay from a past point).
+    /// </summary>
+    /// <param name="threadId">The run/thread id.</param>
+    /// <param name="checkpointId">The checkpoint id.</param>
+    /// <param name="cancellationToken">Token used to cancel the operation.</param>
+    /// <returns>The checkpoint, or <c>null</c> if not found.</returns>
+    Task<GraphCheckpoint<TState>?> GetAsync(string threadId, string checkpointId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets the full checkpoint history for a thread, ordered by step ascending.
+    /// </summary>
+    /// <param name="threadId">The run/thread id.</param>
+    /// <param name="cancellationToken">Token used to cancel the operation.</param>
+    /// <returns>The ordered history (possibly empty).</returns>
+    Task<IReadOnlyList<GraphCheckpoint<TState>>> GetHistoryAsync(string threadId, CancellationToken cancellationToken = default);
+}

--- a/src/Agentic/Graph/Checkpointing/InMemoryGraphCheckpointer.cs
+++ b/src/Agentic/Graph/Checkpointing/InMemoryGraphCheckpointer.cs
@@ -63,13 +63,10 @@ public sealed class InMemoryGraphCheckpointer<TState> : IGraphCheckpointer<TStat
         {
             if (_byThread.TryGetValue(threadId, out var list))
             {
-                foreach (var cp in list)
-                {
-                    if (cp.CheckpointId == checkpointId)
-                    {
-                        return Task.FromResult<GraphCheckpoint<TState>?>(cp);
-                    }
-                }
+                // Return the NEWEST checkpoint with this id (history is append-ordered), matching the durable
+                // backends which order by descending sequence — so re-saving an id resolves to the latest.
+                var match = list.LastOrDefault(cp => cp.CheckpointId == checkpointId);
+                return Task.FromResult<GraphCheckpoint<TState>?>(match);
             }
         }
 

--- a/src/Agentic/Graph/Checkpointing/InMemoryGraphCheckpointer.cs
+++ b/src/Agentic/Graph/Checkpointing/InMemoryGraphCheckpointer.cs
@@ -1,0 +1,91 @@
+namespace AiDotNet.Agentic.Graph.Checkpointing;
+
+/// <summary>
+/// An in-memory <see cref="IGraphCheckpointer{TState}"/> that keeps each thread's checkpoint history in a
+/// dictionary. Suitable for tests, single-process runs, and as the default when no durable store is wired.
+/// </summary>
+/// <typeparam name="TState">The graph's state type.</typeparam>
+/// <remarks>
+/// <para>
+/// Thread-safe via a per-instance lock. Because it stores the state object by reference, callers that use
+/// a mutable reference type for <typeparamref name="TState"/> should treat the state as immutable per step
+/// (return a new/copied instance from nodes) to get true snapshots; durable checkpointers serialize and so
+/// snapshot inherently.
+/// </para>
+/// <para><b>For Beginners:</b> Keeps your save-games in memory. Great for tests and short-lived runs; for
+/// durability across process restarts, use a database-backed checkpointer (coming in later slices).
+/// </para>
+/// </remarks>
+public sealed class InMemoryGraphCheckpointer<TState> : IGraphCheckpointer<TState>
+{
+    private readonly object _gate = new();
+    private readonly Dictionary<string, List<GraphCheckpoint<TState>>> _byThread = new(StringComparer.Ordinal);
+
+    /// <inheritdoc/>
+    public Task SaveAsync(GraphCheckpoint<TState> checkpoint, CancellationToken cancellationToken = default)
+    {
+        Guard.NotNull(checkpoint);
+        lock (_gate)
+        {
+            if (!_byThread.TryGetValue(checkpoint.ThreadId, out var list))
+            {
+                list = new List<GraphCheckpoint<TState>>();
+                _byThread[checkpoint.ThreadId] = list;
+            }
+
+            list.Add(checkpoint);
+        }
+
+        return Task.CompletedTask;
+    }
+
+    /// <inheritdoc/>
+    public Task<GraphCheckpoint<TState>?> GetLatestAsync(string threadId, CancellationToken cancellationToken = default)
+    {
+        Guard.NotNull(threadId);
+        lock (_gate)
+        {
+            if (_byThread.TryGetValue(threadId, out var list) && list.Count > 0)
+            {
+                return Task.FromResult<GraphCheckpoint<TState>?>(list[list.Count - 1]);
+            }
+        }
+
+        return Task.FromResult<GraphCheckpoint<TState>?>(null);
+    }
+
+    /// <inheritdoc/>
+    public Task<GraphCheckpoint<TState>?> GetAsync(string threadId, string checkpointId, CancellationToken cancellationToken = default)
+    {
+        Guard.NotNull(threadId);
+        Guard.NotNull(checkpointId);
+        lock (_gate)
+        {
+            if (_byThread.TryGetValue(threadId, out var list))
+            {
+                foreach (var cp in list)
+                {
+                    if (cp.CheckpointId == checkpointId)
+                    {
+                        return Task.FromResult<GraphCheckpoint<TState>?>(cp);
+                    }
+                }
+            }
+        }
+
+        return Task.FromResult<GraphCheckpoint<TState>?>(null);
+    }
+
+    /// <inheritdoc/>
+    public Task<IReadOnlyList<GraphCheckpoint<TState>>> GetHistoryAsync(string threadId, CancellationToken cancellationToken = default)
+    {
+        Guard.NotNull(threadId);
+        lock (_gate)
+        {
+            IReadOnlyList<GraphCheckpoint<TState>> history = _byThread.TryGetValue(threadId, out var list)
+                ? list.ToList()
+                : new List<GraphCheckpoint<TState>>();
+            return Task.FromResult(history);
+        }
+    }
+}

--- a/src/Agentic/Graph/Checkpointing/JsonFileGraphCheckpointer.cs
+++ b/src/Agentic/Graph/Checkpointing/JsonFileGraphCheckpointer.cs
@@ -1,0 +1,138 @@
+using System.IO;
+using Newtonsoft.Json;
+
+namespace AiDotNet.Agentic.Graph.Checkpointing;
+
+/// <summary>
+/// A durable <see cref="IGraphCheckpointer{TState}"/> that persists all threads' checkpoints to a single
+/// JSON file, so runs survive process restarts. Zero extra dependencies (uses Newtonsoft.Json).
+/// </summary>
+/// <typeparam name="TState">The graph's state type (must be JSON-serializable).</typeparam>
+/// <remarks>
+/// <para>
+/// Simple and self-contained: every save reads, mutates, and rewrites the file under an in-process lock,
+/// so it is correct for single-process durability but not tuned for high-throughput or multi-process
+/// concurrent writers. For those, use a database-backed checkpointer (e.g., SQLite in
+/// <c>AiDotNet.Storage.Sqlite</c>).
+/// </para>
+/// <para><b>For Beginners:</b> Saves your graph's progress to a file on disk, so if the app restarts you
+/// can resume right where it left off.
+/// </para>
+/// </remarks>
+public sealed class JsonFileGraphCheckpointer<TState> : IGraphCheckpointer<TState>
+{
+    private readonly object _gate = new();
+    private readonly string _path;
+
+    /// <summary>
+    /// Initializes the checkpointer, creating the containing directory if needed.
+    /// </summary>
+    /// <param name="filePath">The JSON file used to persist checkpoints.</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="filePath"/> is <c>null</c>.</exception>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="filePath"/> is empty/whitespace.</exception>
+    public JsonFileGraphCheckpointer(string filePath)
+    {
+        Guard.NotNullOrWhiteSpace(filePath);
+        _path = filePath;
+        var dir = Path.GetDirectoryName(filePath);
+        if (!string.IsNullOrEmpty(dir) && !Directory.Exists(dir))
+        {
+            Directory.CreateDirectory(dir);
+        }
+    }
+
+    /// <inheritdoc/>
+    public Task SaveAsync(GraphCheckpoint<TState> checkpoint, CancellationToken cancellationToken = default)
+    {
+        Guard.NotNull(checkpoint);
+        lock (_gate)
+        {
+            var data = Load();
+            if (!data.TryGetValue(checkpoint.ThreadId, out var list))
+            {
+                list = new List<GraphCheckpoint<TState>>();
+                data[checkpoint.ThreadId] = list;
+            }
+
+            list.Add(checkpoint);
+            Persist(data);
+        }
+
+        return Task.CompletedTask;
+    }
+
+    /// <inheritdoc/>
+    public Task<GraphCheckpoint<TState>?> GetLatestAsync(string threadId, CancellationToken cancellationToken = default)
+    {
+        Guard.NotNull(threadId);
+        lock (_gate)
+        {
+            var data = Load();
+            if (data.TryGetValue(threadId, out var list) && list.Count > 0)
+            {
+                return Task.FromResult<GraphCheckpoint<TState>?>(list[list.Count - 1]);
+            }
+        }
+
+        return Task.FromResult<GraphCheckpoint<TState>?>(null);
+    }
+
+    /// <inheritdoc/>
+    public Task<GraphCheckpoint<TState>?> GetAsync(string threadId, string checkpointId, CancellationToken cancellationToken = default)
+    {
+        Guard.NotNull(threadId);
+        Guard.NotNull(checkpointId);
+        lock (_gate)
+        {
+            var data = Load();
+            if (data.TryGetValue(threadId, out var list))
+            {
+                foreach (var cp in list)
+                {
+                    if (cp.CheckpointId == checkpointId)
+                    {
+                        return Task.FromResult<GraphCheckpoint<TState>?>(cp);
+                    }
+                }
+            }
+        }
+
+        return Task.FromResult<GraphCheckpoint<TState>?>(null);
+    }
+
+    /// <inheritdoc/>
+    public Task<IReadOnlyList<GraphCheckpoint<TState>>> GetHistoryAsync(string threadId, CancellationToken cancellationToken = default)
+    {
+        Guard.NotNull(threadId);
+        lock (_gate)
+        {
+            var data = Load();
+            IReadOnlyList<GraphCheckpoint<TState>> history = data.TryGetValue(threadId, out var list)
+                ? list.ToList()
+                : new List<GraphCheckpoint<TState>>();
+            return Task.FromResult(history);
+        }
+    }
+
+    private Dictionary<string, List<GraphCheckpoint<TState>>> Load()
+    {
+        if (!File.Exists(_path))
+        {
+            return new Dictionary<string, List<GraphCheckpoint<TState>>>(StringComparer.Ordinal);
+        }
+
+        var json = File.ReadAllText(_path);
+        if (string.IsNullOrWhiteSpace(json))
+        {
+            return new Dictionary<string, List<GraphCheckpoint<TState>>>(StringComparer.Ordinal);
+        }
+
+        var data = JsonConvert.DeserializeObject<Dictionary<string, List<GraphCheckpoint<TState>>>>(json);
+        return data ?? new Dictionary<string, List<GraphCheckpoint<TState>>>(StringComparer.Ordinal);
+    }
+
+    private void Persist(Dictionary<string, List<GraphCheckpoint<TState>>> data)
+    {
+        File.WriteAllText(_path, JsonConvert.SerializeObject(data, Formatting.None));
+    }
+}

--- a/src/Agentic/Graph/Checkpointing/JsonFileGraphCheckpointer.cs
+++ b/src/Agentic/Graph/Checkpointing/JsonFileGraphCheckpointer.cs
@@ -127,12 +127,70 @@ public sealed class JsonFileGraphCheckpointer<TState> : IGraphCheckpointer<TStat
             return new Dictionary<string, List<GraphCheckpoint<TState>>>(StringComparer.Ordinal);
         }
 
-        var data = JsonConvert.DeserializeObject<Dictionary<string, List<GraphCheckpoint<TState>>>>(json);
-        return data ?? new Dictionary<string, List<GraphCheckpoint<TState>>>(StringComparer.Ordinal);
+        try
+        {
+            var data = JsonConvert.DeserializeObject<Dictionary<string, List<GraphCheckpoint<TState>>>>(json);
+            return data ?? new Dictionary<string, List<GraphCheckpoint<TState>>>(StringComparer.Ordinal);
+        }
+        catch (JsonException ex)
+        {
+            // Surface corruption explicitly rather than silently returning empty — silently dropping the
+            // history would let the next Save overwrite (and permanently lose) recoverable checkpoint data.
+            throw new InvalidOperationException(
+                $"The checkpoint file at '{_path}' is corrupt and could not be parsed. " +
+                "Move or delete it to start a fresh checkpoint store.", ex);
+        }
     }
 
     private void Persist(Dictionary<string, List<GraphCheckpoint<TState>>> data)
     {
-        File.WriteAllText(_path, JsonConvert.SerializeObject(data, Formatting.None));
+        var json = JsonConvert.SerializeObject(data, Formatting.None);
+
+        // Atomic write: serialize to a temp file in the same directory, flush it to disk, then atomically
+        // replace the target. A crash mid-write therefore leaves the previous (valid) file intact rather than
+        // a half-written, unparseable one.
+        var directory = Path.GetDirectoryName(_path);
+        var tempPath = Path.Combine(
+            string.IsNullOrEmpty(directory) ? "." : directory,
+            $".{Path.GetFileName(_path)}.{Guid.NewGuid():N}.tmp");
+
+        try
+        {
+            using (var stream = new FileStream(tempPath, FileMode.Create, FileAccess.Write, FileShare.None))
+            using (var writer = new StreamWriter(stream))
+            {
+                writer.Write(json);
+                writer.Flush();
+                stream.Flush(flushToDisk: true);
+            }
+
+#if NET5_0_OR_GREATER
+            File.Move(tempPath, _path, overwrite: true);
+#else
+            if (File.Exists(_path))
+            {
+                // File.Replace is atomic when the destination exists; it also clears the temp file.
+                File.Replace(tempPath, _path, destinationBackupFileName: null);
+            }
+            else
+            {
+                File.Move(tempPath, _path);
+            }
+#endif
+        }
+        finally
+        {
+            if (File.Exists(tempPath))
+            {
+                try
+                {
+                    File.Delete(tempPath);
+                }
+                catch (IOException)
+                {
+                    // Best-effort cleanup of the temp file; a leftover .tmp is harmless.
+                }
+            }
+        }
     }
 }

--- a/src/Agentic/Graph/CompiledStateGraph.cs
+++ b/src/Agentic/Graph/CompiledStateGraph.cs
@@ -25,17 +25,20 @@ public sealed class CompiledStateGraph<TState>
     private readonly IReadOnlyDictionary<string, Func<TState, CancellationToken, Task<TState>>> _nodes;
     private readonly IReadOnlyDictionary<string, string> _edges;
     private readonly IReadOnlyDictionary<string, Func<TState, string>> _conditionalEdges;
+    private readonly HashSet<string> _interruptBefore;
     private readonly string _entryPoint;
 
     internal CompiledStateGraph(
         IReadOnlyDictionary<string, Func<TState, CancellationToken, Task<TState>>> nodes,
         IReadOnlyDictionary<string, string> edges,
         IReadOnlyDictionary<string, Func<TState, string>> conditionalEdges,
+        HashSet<string> interruptBefore,
         string entryPoint)
     {
         _nodes = nodes;
         _edges = edges;
         _conditionalEdges = conditionalEdges;
+        _interruptBefore = interruptBefore;
         _entryPoint = entryPoint;
     }
 
@@ -47,11 +50,16 @@ public sealed class CompiledStateGraph<TState>
     /// <param name="cancellationToken">Token used to cancel the run.</param>
     /// <returns>The final state when flow reaches the end node.</returns>
     /// <exception cref="GraphRecursionException">Thrown when the step budget is exceeded.</exception>
-    public Task<TState> InvokeAsync(
+    public async Task<TState> InvokeAsync(
         TState initialState,
         GraphRunOptions? options = null,
         CancellationToken cancellationToken = default)
-        => RunCoreAsync(initialState, _entryPoint, startStep: 0, ResolveMaxSteps(options), checkpointer: null, threadId: null, cancellationToken);
+    {
+        var result = await RunCoreAsync(
+            initialState, _entryPoint, startStep: 0, ResolveMaxSteps(options),
+            checkpointer: null, threadId: null, honorInterrupts: false, honorFirstInterrupt: false, cancellationToken).ConfigureAwait(false);
+        return result.State;
+    }
 
     /// <summary>
     /// Runs the graph with durable checkpointing under a thread id, resuming automatically from the latest
@@ -100,7 +108,10 @@ public sealed class CompiledStateGraph<TState>
             return state; // thread already complete
         }
 
-        return await RunCoreAsync(state, startNode, startStep, maxSteps, checkpointer, threadId, cancellationToken).ConfigureAwait(false);
+        var result = await RunCoreAsync(
+            state, startNode, startStep, maxSteps, checkpointer, threadId,
+            honorInterrupts: false, honorFirstInterrupt: false, cancellationToken).ConfigureAwait(false);
+        return result.State;
     }
 
     /// <summary>
@@ -137,25 +148,100 @@ public sealed class CompiledStateGraph<TState>
             return checkpoint.State;
         }
 
-        return await RunCoreAsync(
-            checkpoint.State, checkpoint.NextNode, checkpoint.Step, ResolveMaxSteps(options), checkpointer, threadId, cancellationToken).ConfigureAwait(false);
+        var result = await RunCoreAsync(
+            checkpoint.State, checkpoint.NextNode, checkpoint.Step, ResolveMaxSteps(options), checkpointer, threadId,
+            honorInterrupts: false, honorFirstInterrupt: false, cancellationToken).ConfigureAwait(false);
+        return result.State;
     }
 
-    private async Task<TState> RunCoreAsync(
+    /// <summary>
+    /// Runs the graph with human-in-the-loop interrupts under a thread id. On the first call it runs from
+    /// the entry node and pauses just before the first interrupt node (returning an interrupted result);
+    /// calling it again on the same thread resumes past that pause and runs until the next interrupt or
+    /// completion. Optionally applies the human's edit to the state when resuming.
+    /// </summary>
+    /// <param name="initialState">The starting state (used only when the thread has no prior checkpoint).</param>
+    /// <param name="checkpointer">The checkpoint store.</param>
+    /// <param name="threadId">The run/thread id.</param>
+    /// <param name="applyOnResume">When resuming, an optional transform applied to the saved state (the human's input). Ignored on a fresh run.</param>
+    /// <param name="options">Run options (step budget). <c>null</c> uses defaults.</param>
+    /// <param name="cancellationToken">Token used to cancel the run.</param>
+    /// <returns>A <see cref="GraphRunResult{TState}"/> indicating completion or an interrupt point.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="checkpointer"/> or <paramref name="threadId"/> is <c>null</c>.</exception>
+    public async Task<GraphRunResult<TState>> RunAsync(
+        TState initialState,
+        IGraphCheckpointer<TState> checkpointer,
+        string threadId,
+        Func<TState, TState>? applyOnResume = null,
+        GraphRunOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        Guard.NotNull(checkpointer);
+        Guard.NotNullOrWhiteSpace(threadId);
+        var maxSteps = ResolveMaxSteps(options);
+
+        var latest = await checkpointer.GetLatestAsync(threadId, cancellationToken).ConfigureAwait(false);
+        string startNode;
+        TState state;
+        int startStep;
+        bool honorFirstInterrupt;
+        if (latest is not null)
+        {
+            // Resuming: the caller chose to continue, so do not re-pause at the node we stopped before.
+            startNode = latest.NextNode;
+            state = applyOnResume is not null ? applyOnResume(latest.State) : latest.State;
+            startStep = latest.Step;
+            honorFirstInterrupt = false;
+        }
+        else
+        {
+            startNode = _entryPoint;
+            state = initialState;
+            startStep = 0;
+            honorFirstInterrupt = true;
+            await checkpointer.SaveAsync(
+                new GraphCheckpoint<TState>(threadId, $"{threadId}-0", 0, _entryPoint, initialState), cancellationToken).ConfigureAwait(false);
+        }
+
+        if (startNode == GraphSpecialNodes.End)
+        {
+            return GraphRunResult<TState>.Complete(state);
+        }
+
+        return await RunCoreAsync(
+            state, startNode, startStep, maxSteps, checkpointer, threadId,
+            honorInterrupts: true, honorFirstInterrupt: honorFirstInterrupt, cancellationToken).ConfigureAwait(false);
+    }
+
+    private async Task<GraphRunResult<TState>> RunCoreAsync(
         TState state,
         string startNode,
         int startStep,
         int maxSteps,
         IGraphCheckpointer<TState>? checkpointer,
         string? threadId,
+        bool honorInterrupts,
+        bool honorFirstInterrupt,
         CancellationToken cancellationToken)
     {
         var current = startNode;
         var step = startStep;
+        var firstNode = true;
 
         while (current != GraphSpecialNodes.End)
         {
             cancellationToken.ThrowIfCancellationRequested();
+
+            var considerInterrupt = honorInterrupts && (honorFirstInterrupt || !firstNode);
+            if (considerInterrupt && _interruptBefore.Contains(current))
+            {
+                // Pause before this node. The latest checkpoint already records NextNode == current,
+                // so a subsequent resume picks up here.
+                return GraphRunResult<TState>.Interrupted(state, current);
+            }
+
+            firstNode = false;
+
             if (++step > maxSteps)
             {
                 throw new GraphRecursionException(maxSteps);
@@ -171,7 +257,7 @@ public sealed class CompiledStateGraph<TState>
             }
         }
 
-        return state;
+        return GraphRunResult<TState>.Complete(state);
     }
 
     /// <summary>

--- a/src/Agentic/Graph/CompiledStateGraph.cs
+++ b/src/Agentic/Graph/CompiledStateGraph.cs
@@ -1,4 +1,5 @@
 using System.Runtime.CompilerServices;
+using AiDotNet.Agentic.Graph.Checkpointing;
 
 namespace AiDotNet.Agentic.Graph;
 
@@ -46,26 +47,128 @@ public sealed class CompiledStateGraph<TState>
     /// <param name="cancellationToken">Token used to cancel the run.</param>
     /// <returns>The final state when flow reaches the end node.</returns>
     /// <exception cref="GraphRecursionException">Thrown when the step budget is exceeded.</exception>
-    public async Task<TState> InvokeAsync(
+    public Task<TState> InvokeAsync(
         TState initialState,
         GraphRunOptions? options = null,
         CancellationToken cancellationToken = default)
+        => RunCoreAsync(initialState, _entryPoint, startStep: 0, ResolveMaxSteps(options), checkpointer: null, threadId: null, cancellationToken);
+
+    /// <summary>
+    /// Runs the graph with durable checkpointing under a thread id, resuming automatically from the latest
+    /// saved checkpoint if one exists for that thread (otherwise starting fresh from <paramref name="initialState"/>).
+    /// </summary>
+    /// <param name="initialState">The starting state (used only when the thread has no prior checkpoint).</param>
+    /// <param name="checkpointer">The checkpoint store.</param>
+    /// <param name="threadId">The run/thread id under which checkpoints are saved and resumed.</param>
+    /// <param name="options">Run options (step budget). <c>null</c> uses defaults. The budget is cumulative across resumes.</param>
+    /// <param name="cancellationToken">Token used to cancel the run.</param>
+    /// <returns>The final state.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="checkpointer"/> or <paramref name="threadId"/> is <c>null</c>.</exception>
+    /// <exception cref="GraphRecursionException">Thrown when the step budget is exceeded.</exception>
+    public async Task<TState> InvokeAsync(
+        TState initialState,
+        IGraphCheckpointer<TState> checkpointer,
+        string threadId,
+        GraphRunOptions? options = null,
+        CancellationToken cancellationToken = default)
     {
+        Guard.NotNull(checkpointer);
+        Guard.NotNullOrWhiteSpace(threadId);
         var maxSteps = ResolveMaxSteps(options);
-        var state = initialState;
-        var current = _entryPoint;
-        var steps = 0;
+
+        var latest = await checkpointer.GetLatestAsync(threadId, cancellationToken).ConfigureAwait(false);
+        string startNode;
+        TState state;
+        int startStep;
+        if (latest is not null)
+        {
+            startNode = latest.NextNode;
+            state = latest.State;
+            startStep = latest.Step;
+        }
+        else
+        {
+            startNode = _entryPoint;
+            state = initialState;
+            startStep = 0;
+            await checkpointer.SaveAsync(
+                new GraphCheckpoint<TState>(threadId, $"{threadId}-0", 0, _entryPoint, initialState), cancellationToken).ConfigureAwait(false);
+        }
+
+        if (startNode == GraphSpecialNodes.End)
+        {
+            return state; // thread already complete
+        }
+
+        return await RunCoreAsync(state, startNode, startStep, maxSteps, checkpointer, threadId, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Resumes (replays) a thread from a specific past checkpoint — the basis for time-travel — continuing
+    /// execution from that checkpoint's next node and state, and saving new checkpoints as it goes.
+    /// </summary>
+    /// <param name="checkpointer">The checkpoint store.</param>
+    /// <param name="threadId">The run/thread id.</param>
+    /// <param name="checkpointId">The id of the checkpoint to resume from.</param>
+    /// <param name="options">Run options (step budget). <c>null</c> uses defaults.</param>
+    /// <param name="cancellationToken">Token used to cancel the run.</param>
+    /// <returns>The final state.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="checkpointer"/>, <paramref name="threadId"/>, or <paramref name="checkpointId"/> is <c>null</c>.</exception>
+    /// <exception cref="InvalidOperationException">Thrown when the checkpoint does not exist.</exception>
+    public async Task<TState> ResumeFromAsync(
+        IGraphCheckpointer<TState> checkpointer,
+        string threadId,
+        string checkpointId,
+        GraphRunOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        Guard.NotNull(checkpointer);
+        Guard.NotNullOrWhiteSpace(threadId);
+        Guard.NotNullOrWhiteSpace(checkpointId);
+
+        var checkpoint = await checkpointer.GetAsync(threadId, checkpointId, cancellationToken).ConfigureAwait(false);
+        if (checkpoint is null)
+        {
+            throw new InvalidOperationException($"Checkpoint '{checkpointId}' was not found for thread '{threadId}'.");
+        }
+
+        if (checkpoint.NextNode == GraphSpecialNodes.End)
+        {
+            return checkpoint.State;
+        }
+
+        return await RunCoreAsync(
+            checkpoint.State, checkpoint.NextNode, checkpoint.Step, ResolveMaxSteps(options), checkpointer, threadId, cancellationToken).ConfigureAwait(false);
+    }
+
+    private async Task<TState> RunCoreAsync(
+        TState state,
+        string startNode,
+        int startStep,
+        int maxSteps,
+        IGraphCheckpointer<TState>? checkpointer,
+        string? threadId,
+        CancellationToken cancellationToken)
+    {
+        var current = startNode;
+        var step = startStep;
 
         while (current != GraphSpecialNodes.End)
         {
             cancellationToken.ThrowIfCancellationRequested();
-            if (++steps > maxSteps)
+            if (++step > maxSteps)
             {
                 throw new GraphRecursionException(maxSteps);
             }
 
             state = await _nodes[current](state, cancellationToken).ConfigureAwait(false);
             current = NextNode(current, state);
+
+            if (checkpointer is not null && threadId is not null)
+            {
+                await checkpointer.SaveAsync(
+                    new GraphCheckpoint<TState>(threadId, $"{threadId}-{step}", step, current, state), cancellationToken).ConfigureAwait(false);
+            }
         }
 
         return state;

--- a/src/Agentic/Graph/CompiledStateGraph.cs
+++ b/src/Agentic/Graph/CompiledStateGraph.cs
@@ -293,6 +293,63 @@ public sealed class CompiledStateGraph<TState>
         }
     }
 
+    /// <summary>
+    /// Deterministically replays a recorded run from its checkpoint history WITHOUT executing any nodes,
+    /// yielding the same (node, state) sequence the original run produced.
+    /// </summary>
+    /// <param name="checkpointer">The checkpoint store holding the recorded run.</param>
+    /// <param name="threadId">The recorded run/thread id.</param>
+    /// <param name="cancellationToken">Token used to cancel the replay.</param>
+    /// <returns>The recorded per-node updates, in order.</returns>
+    /// <remarks>
+    /// <para><b>For Beginners:</b> Re-watch a past run exactly as it happened, reading from the saved
+    /// checkpoints instead of re-running the (possibly slow or non-deterministic) nodes. Great for
+    /// debugging and audit.
+    /// </para>
+    /// </remarks>
+    public async IAsyncEnumerable<GraphStepUpdate<TState>> ReplayAsync(
+        IGraphCheckpointer<TState> checkpointer,
+        string threadId,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        Guard.NotNull(checkpointer);
+        Guard.NotNullOrWhiteSpace(threadId);
+
+        var history = await checkpointer.GetHistoryAsync(threadId, cancellationToken).ConfigureAwait(false);
+        for (var k = 1; k < history.Count; k++)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            // The node that ran to produce history[k] is the one recorded as "next" by history[k-1].
+            var executedNode = history[k - 1].NextNode;
+            yield return new GraphStepUpdate<TState>(executedNode, history[k].State);
+        }
+    }
+
+    /// <summary>
+    /// Returns the final recorded state for a thread (read from checkpoints, no execution).
+    /// </summary>
+    /// <param name="checkpointer">The checkpoint store.</param>
+    /// <param name="threadId">The run/thread id.</param>
+    /// <param name="cancellationToken">Token used to cancel the operation.</param>
+    /// <returns>The latest recorded state.</returns>
+    /// <exception cref="InvalidOperationException">Thrown when the thread has no checkpoints.</exception>
+    public async Task<TState> GetRecordedStateAsync(
+        IGraphCheckpointer<TState> checkpointer,
+        string threadId,
+        CancellationToken cancellationToken = default)
+    {
+        Guard.NotNull(checkpointer);
+        Guard.NotNullOrWhiteSpace(threadId);
+
+        var latest = await checkpointer.GetLatestAsync(threadId, cancellationToken).ConfigureAwait(false);
+        if (latest is null)
+        {
+            throw new InvalidOperationException($"No checkpoints found for thread '{threadId}'.");
+        }
+
+        return latest.State;
+    }
+
     private static int ResolveMaxSteps(GraphRunOptions? options)
     {
         var max = options?.MaxSteps ?? new GraphRunOptions().MaxSteps;

--- a/src/Agentic/Graph/CompiledStateGraph.cs
+++ b/src/Agentic/Graph/CompiledStateGraph.cs
@@ -1,0 +1,135 @@
+using System.Runtime.CompilerServices;
+
+namespace AiDotNet.Agentic.Graph;
+
+/// <summary>
+/// An executable, validated state graph produced by <see cref="StateGraph{TState}.Compile"/>. Runs nodes
+/// according to the graph's edges, threading the state from one node to the next until it reaches the end.
+/// </summary>
+/// <typeparam name="TState">The graph's state type (threaded through every node).</typeparam>
+/// <remarks>
+/// <para>
+/// Execution starts at the entry node. After a node runs, the next node is chosen by: its conditional
+/// router (if any), else its fixed edge, else the run ends. Cycles are allowed and bounded by
+/// <see cref="GraphRunOptions.MaxSteps"/>. Use <see cref="InvokeAsync"/> for the final state or
+/// <see cref="StreamAsync"/> to observe each step.
+/// </para>
+/// <para><b>For Beginners:</b> This is the "compiled program" form of your graph. You give it a starting
+/// state and it walks the nodes you wired up, handing each node the latest state, until it reaches the
+/// end — then returns the final state.
+/// </para>
+/// </remarks>
+public sealed class CompiledStateGraph<TState>
+{
+    private readonly IReadOnlyDictionary<string, Func<TState, CancellationToken, Task<TState>>> _nodes;
+    private readonly IReadOnlyDictionary<string, string> _edges;
+    private readonly IReadOnlyDictionary<string, Func<TState, string>> _conditionalEdges;
+    private readonly string _entryPoint;
+
+    internal CompiledStateGraph(
+        IReadOnlyDictionary<string, Func<TState, CancellationToken, Task<TState>>> nodes,
+        IReadOnlyDictionary<string, string> edges,
+        IReadOnlyDictionary<string, Func<TState, string>> conditionalEdges,
+        string entryPoint)
+    {
+        _nodes = nodes;
+        _edges = edges;
+        _conditionalEdges = conditionalEdges;
+        _entryPoint = entryPoint;
+    }
+
+    /// <summary>
+    /// Runs the graph from the supplied initial state and returns the final state.
+    /// </summary>
+    /// <param name="initialState">The starting state.</param>
+    /// <param name="options">Run options (step budget). <c>null</c> uses defaults.</param>
+    /// <param name="cancellationToken">Token used to cancel the run.</param>
+    /// <returns>The final state when flow reaches the end node.</returns>
+    /// <exception cref="GraphRecursionException">Thrown when the step budget is exceeded.</exception>
+    public async Task<TState> InvokeAsync(
+        TState initialState,
+        GraphRunOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        var maxSteps = ResolveMaxSteps(options);
+        var state = initialState;
+        var current = _entryPoint;
+        var steps = 0;
+
+        while (current != GraphSpecialNodes.End)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            if (++steps > maxSteps)
+            {
+                throw new GraphRecursionException(maxSteps);
+            }
+
+            state = await _nodes[current](state, cancellationToken).ConfigureAwait(false);
+            current = NextNode(current, state);
+        }
+
+        return state;
+    }
+
+    /// <summary>
+    /// Runs the graph and yields an update after each node executes, ending when flow reaches the end node.
+    /// </summary>
+    /// <param name="initialState">The starting state.</param>
+    /// <param name="options">Run options (step budget). <c>null</c> uses defaults.</param>
+    /// <param name="cancellationToken">Token used to cancel the run.</param>
+    /// <returns>A stream of <see cref="GraphStepUpdate{TState}"/>; the final update carries the final state.</returns>
+    /// <exception cref="GraphRecursionException">Thrown when the step budget is exceeded.</exception>
+    public async IAsyncEnumerable<GraphStepUpdate<TState>> StreamAsync(
+        TState initialState,
+        GraphRunOptions? options = null,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        var maxSteps = ResolveMaxSteps(options);
+        var state = initialState;
+        var current = _entryPoint;
+        var steps = 0;
+
+        while (current != GraphSpecialNodes.End)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            if (++steps > maxSteps)
+            {
+                throw new GraphRecursionException(maxSteps);
+            }
+
+            var executed = current;
+            state = await _nodes[current](state, cancellationToken).ConfigureAwait(false);
+            yield return new GraphStepUpdate<TState>(executed, state);
+            current = NextNode(current, state);
+        }
+    }
+
+    private static int ResolveMaxSteps(GraphRunOptions? options)
+    {
+        var max = options?.MaxSteps ?? new GraphRunOptions().MaxSteps;
+        return max > 0 ? max : new GraphRunOptions().MaxSteps;
+    }
+
+    private string NextNode(string current, TState state)
+    {
+        if (_conditionalEdges.TryGetValue(current, out var router))
+        {
+            var next = router(state);
+            if (string.IsNullOrEmpty(next))
+            {
+                throw new InvalidOperationException(
+                    $"The conditional router for node '{current}' returned a null or empty target.");
+            }
+
+            if (next != GraphSpecialNodes.End && !_nodes.ContainsKey(next))
+            {
+                throw new InvalidOperationException(
+                    $"The conditional router for node '{current}' returned unknown target '{next}'.");
+            }
+
+            return next;
+        }
+
+        return _edges.TryGetValue(current, out var target) ? target : GraphSpecialNodes.End;
+    }
+}

--- a/src/Agentic/Graph/GraphRecursionException.cs
+++ b/src/Agentic/Graph/GraphRecursionException.cs
@@ -1,0 +1,30 @@
+namespace AiDotNet.Agentic.Graph;
+
+/// <summary>
+/// Thrown when a graph run exceeds its configured maximum number of steps, which usually indicates a
+/// cycle that never reaches the end node.
+/// </summary>
+/// <remarks>
+/// <para><b>For Beginners:</b> Graphs can loop (a node can route back to an earlier node). To stop an
+/// accidental infinite loop, every run has a step budget. If the graph keeps going past that budget,
+/// this exception is raised so you can fix the routing or raise the limit deliberately.
+/// </para>
+/// </remarks>
+public sealed class GraphRecursionException : Exception
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="GraphRecursionException"/> class.
+    /// </summary>
+    /// <param name="maxSteps">The step budget that was exceeded.</param>
+    public GraphRecursionException(int maxSteps)
+        : base($"Graph exceeded its maximum of {maxSteps} steps without reaching the end node. " +
+               "This usually means a cycle never terminates; check your conditional edges or raise GraphRunOptions.MaxSteps.")
+    {
+        MaxSteps = maxSteps;
+    }
+
+    /// <summary>
+    /// Gets the step budget that was exceeded.
+    /// </summary>
+    public int MaxSteps { get; }
+}

--- a/src/Agentic/Graph/GraphRunOptions.cs
+++ b/src/Agentic/Graph/GraphRunOptions.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace AiDotNet.Agentic.Graph;
 
 /// <summary>
@@ -11,9 +13,25 @@ namespace AiDotNet.Agentic.Graph;
 /// </remarks>
 public sealed class GraphRunOptions
 {
+    private int _maxSteps = 25;
+
     /// <summary>
     /// Gets or sets the maximum number of node executions allowed in a single run before a
     /// <see cref="GraphRecursionException"/> is thrown. Default: 25. Must be positive.
     /// </summary>
-    public int MaxSteps { get; set; } = 25;
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when set to a value &lt;= 0.</exception>
+    public int MaxSteps
+    {
+        get => _maxSteps;
+        set
+        {
+            if (value <= 0)
+            {
+                throw new ArgumentOutOfRangeException(
+                    nameof(value), value, "MaxSteps must be positive (a run needs at least one step).");
+            }
+
+            _maxSteps = value;
+        }
+    }
 }

--- a/src/Agentic/Graph/GraphRunOptions.cs
+++ b/src/Agentic/Graph/GraphRunOptions.cs
@@ -1,0 +1,19 @@
+namespace AiDotNet.Agentic.Graph;
+
+/// <summary>
+/// Per-run settings for executing a <see cref="CompiledStateGraph{TState}"/>.
+/// </summary>
+/// <remarks>
+/// <para><b>For Beginners:</b> Knobs for a single graph run. The most important one is
+/// <see cref="MaxSteps"/>, which caps how many node executions a run may take before giving up — a
+/// safety net against cycles that never end.
+/// </para>
+/// </remarks>
+public sealed class GraphRunOptions
+{
+    /// <summary>
+    /// Gets or sets the maximum number of node executions allowed in a single run before a
+    /// <see cref="GraphRecursionException"/> is thrown. Default: 25. Must be positive.
+    /// </summary>
+    public int MaxSteps { get; set; } = 25;
+}

--- a/src/Agentic/Graph/GraphRunResult.cs
+++ b/src/Agentic/Graph/GraphRunResult.cs
@@ -1,0 +1,55 @@
+namespace AiDotNet.Agentic.Graph;
+
+/// <summary>
+/// The outcome of a human-in-the-loop graph run: either the run completed, or it paused before an
+/// interrupt node awaiting input. Carries the state either way.
+/// </summary>
+/// <typeparam name="TState">The graph's state type.</typeparam>
+/// <remarks>
+/// <para>
+/// When a graph has interrupt points (see <see cref="StateGraph{TState}.AddInterruptBefore"/>), a run
+/// stops just before such a node and returns an interrupted result with <see cref="InterruptedBefore"/>
+/// set to that node. Call the run again on the same thread to resume past the pause (optionally editing
+/// the state with the human's input first).
+/// </para>
+/// <para><b>For Beginners:</b> Tells you whether the graph finished or stopped to ask a human. If it
+/// stopped, <see cref="InterruptedBefore"/> says which step it's waiting to run, and <see cref="State"/>
+/// is the data so far so you can review/edit it before continuing.
+/// </para>
+/// </remarks>
+public sealed class GraphRunResult<TState>
+{
+    private GraphRunResult(bool isComplete, TState state, string? interruptedBefore)
+    {
+        IsComplete = isComplete;
+        State = state;
+        InterruptedBefore = interruptedBefore;
+    }
+
+    /// <summary>Gets a value indicating whether the run reached the end node.</summary>
+    public bool IsComplete { get; }
+
+    /// <summary>Gets a value indicating whether the run paused at an interrupt point.</summary>
+    public bool IsInterrupted => InterruptedBefore is not null;
+
+    /// <summary>Gets the state (final when complete, or as of the pause when interrupted).</summary>
+    public TState State { get; }
+
+    /// <summary>Gets the node the run paused before, or <c>null</c> when the run completed.</summary>
+    public string? InterruptedBefore { get; }
+
+    /// <summary>Creates a completed result.</summary>
+    /// <param name="state">The final state.</param>
+    /// <returns>A completed <see cref="GraphRunResult{TState}"/>.</returns>
+    public static GraphRunResult<TState> Complete(TState state) => new(true, state, null);
+
+    /// <summary>Creates an interrupted result.</summary>
+    /// <param name="state">The state as of the pause.</param>
+    /// <param name="node">The node the run paused before.</param>
+    /// <returns>An interrupted <see cref="GraphRunResult{TState}"/>.</returns>
+    public static GraphRunResult<TState> Interrupted(TState state, string node)
+    {
+        Guard.NotNullOrWhiteSpace(node);
+        return new GraphRunResult<TState>(false, state, node);
+    }
+}

--- a/src/Agentic/Graph/GraphSpecialNodes.cs
+++ b/src/Agentic/Graph/GraphSpecialNodes.cs
@@ -1,0 +1,18 @@
+namespace AiDotNet.Agentic.Graph;
+
+/// <summary>
+/// Reserved node names recognized by the graph runtime.
+/// </summary>
+/// <remarks>
+/// <para><b>For Beginners:</b> A graph finishes when flow reaches the special <see cref="End"/> node.
+/// You route to it with <c>AddEdge("lastNode", GraphSpecialNodes.End)</c> (or return it from a
+/// conditional router) to say "we're done".
+/// </para>
+/// </remarks>
+public static class GraphSpecialNodes
+{
+    /// <summary>
+    /// The terminal node name. When flow reaches this node, the run completes and returns the current state.
+    /// </summary>
+    public const string End = "__end__";
+}

--- a/src/Agentic/Graph/GraphStepUpdate.cs
+++ b/src/Agentic/Graph/GraphStepUpdate.cs
@@ -1,0 +1,38 @@
+namespace AiDotNet.Agentic.Graph;
+
+/// <summary>
+/// A streamed update emitted after a single node finishes executing during a graph run: the node's name
+/// and the graph state as it stands after that node.
+/// </summary>
+/// <typeparam name="TState">The graph's state type.</typeparam>
+/// <remarks>
+/// <para><b>For Beginners:</b> When you stream a graph run, you receive one of these each time a step
+/// completes — letting you watch the state evolve node by node (for progress UIs, logging, or
+/// debugging). The last update's <see cref="State"/> is the final result.
+/// </para>
+/// </remarks>
+public sealed class GraphStepUpdate<TState>
+{
+    /// <summary>
+    /// Initializes a new step update.
+    /// </summary>
+    /// <param name="nodeName">The name of the node that just executed.</param>
+    /// <param name="state">The graph state after the node executed.</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="nodeName"/> is <c>null</c>.</exception>
+    public GraphStepUpdate(string nodeName, TState state)
+    {
+        Guard.NotNull(nodeName);
+        NodeName = nodeName;
+        State = state;
+    }
+
+    /// <summary>
+    /// Gets the name of the node that just executed.
+    /// </summary>
+    public string NodeName { get; }
+
+    /// <summary>
+    /// Gets the graph state after the node executed.
+    /// </summary>
+    public TState State { get; }
+}

--- a/src/Agentic/Graph/StateGraph.cs
+++ b/src/Agentic/Graph/StateGraph.cs
@@ -129,6 +129,46 @@ public sealed class StateGraph<TState>
     }
 
     /// <summary>
+    /// Adds a node that runs an entire compiled graph as a single step (a subgraph), threading the same
+    /// state in and out. Enables composition: build small graphs and embed them in larger ones.
+    /// </summary>
+    /// <param name="name">The node name for the subgraph.</param>
+    /// <param name="subgraph">The compiled graph to run when this node executes.</param>
+    /// <returns>This builder, for chaining.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="subgraph"/> is <c>null</c>.</exception>
+    public StateGraph<TState> AddSubgraph(string name, CompiledStateGraph<TState> subgraph)
+    {
+        Guard.NotNull(subgraph);
+        return AddNode(name, (state, ct) => subgraph.InvokeAsync(state, null, ct));
+    }
+
+    /// <summary>
+    /// Adds reward-gated routing after a node: a scoring function rates the state, and flow goes to
+    /// <paramref name="ifMeetsThreshold"/> when the score is at least <paramref name="threshold"/>, else to
+    /// <paramref name="ifBelowThreshold"/>. A differentiator for verifier/critic-driven control flow.
+    /// </summary>
+    /// <param name="from">The source node name.</param>
+    /// <param name="reward">Scores the current state (e.g., a critic/reward model).</param>
+    /// <param name="threshold">The minimum score required to take the "meets" branch.</param>
+    /// <param name="ifMeetsThreshold">The next node when <c>reward(state) &gt;= threshold</c> (may be <see cref="End"/>).</param>
+    /// <param name="ifBelowThreshold">The next node otherwise (may be <see cref="End"/>).</param>
+    /// <returns>This builder, for chaining.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="reward"/> is <c>null</c>.</exception>
+    /// <exception cref="ArgumentException">Thrown when a node name is empty/whitespace.</exception>
+    public StateGraph<TState> AddRewardGatedEdges(
+        string from,
+        Func<TState, double> reward,
+        double threshold,
+        string ifMeetsThreshold,
+        string ifBelowThreshold)
+    {
+        Guard.NotNull(reward);
+        Guard.NotNullOrWhiteSpace(ifMeetsThreshold);
+        Guard.NotNullOrWhiteSpace(ifBelowThreshold);
+        return AddConditionalEdges(from, state => reward(state) >= threshold ? ifMeetsThreshold : ifBelowThreshold);
+    }
+
+    /// <summary>
     /// Marks a node as a human-in-the-loop interrupt point: a run pauses just before this node so a human
     /// can review (and optionally edit) the state, then resume.
     /// </summary>

--- a/src/Agentic/Graph/StateGraph.cs
+++ b/src/Agentic/Graph/StateGraph.cs
@@ -1,0 +1,195 @@
+namespace AiDotNet.Agentic.Graph;
+
+/// <summary>
+/// A builder for a typed state graph: register nodes (state transformers), wire them with fixed or
+/// conditional edges (cycles allowed), set an entry point, then <see cref="Compile"/> into an executable
+/// <see cref="CompiledStateGraph{TState}"/>.
+/// </summary>
+/// <typeparam name="TState">
+/// The state type threaded through the graph. Each node receives the current state and returns the next
+/// state (it may mutate and return the same instance, or return a new one).
+/// </typeparam>
+/// <remarks>
+/// <para>
+/// This is the AiDotNet counterpart to LangGraph's <c>StateGraph</c>, but fully typed: there are no
+/// stringly-typed state dictionaries — <typeparamref name="TState"/> is your own type, checked by the
+/// compiler. Routing is explicit: a node has at most one fixed edge or one conditional router; reaching
+/// <see cref="End"/> finishes the run.
+/// </para>
+/// <para><b>For Beginners:</b> Think of building a flowchart. <see cref="AddNode"/> adds a box that does
+/// some work on your data; <see cref="AddEdge"/> draws an arrow to the next box; <see cref="AddConditionalEdges"/>
+/// draws arrows that depend on the data; <see cref="SetEntryPoint"/> marks where to start. Arrows can
+/// loop back to create cycles. <see cref="Compile"/> turns the flowchart into something you can run.
+/// </para>
+/// <para><b>Example:</b>
+/// <code>
+/// var graph = new StateGraph&lt;MyState&gt;()
+///     .AddNode("plan", (s, ct) =&gt; Task.FromResult(s.WithPlan()))
+///     .AddNode("act", (s, ct) =&gt; Task.FromResult(s.Act()))
+///     .AddConditionalEdges("act", s =&gt; s.IsDone ? StateGraph&lt;MyState&gt;.End : "act")
+///     .AddEdge("plan", "act")
+///     .SetEntryPoint("plan")
+///     .Compile();
+/// var result = await graph.InvokeAsync(new MyState());
+/// </code>
+/// </para>
+/// </remarks>
+public sealed class StateGraph<TState>
+{
+    /// <summary>
+    /// The terminal node name; route here to finish the run. Alias of <see cref="GraphSpecialNodes.End"/>.
+    /// </summary>
+    public const string End = GraphSpecialNodes.End;
+
+    private readonly Dictionary<string, Func<TState, CancellationToken, Task<TState>>> _nodes = new(StringComparer.Ordinal);
+    private readonly Dictionary<string, string> _edges = new(StringComparer.Ordinal);
+    private readonly Dictionary<string, Func<TState, string>> _conditionalEdges = new(StringComparer.Ordinal);
+    private string? _entryPoint;
+
+    /// <summary>
+    /// Adds an asynchronous node that transforms the state.
+    /// </summary>
+    /// <param name="name">The unique node name (cannot be empty or the reserved end name).</param>
+    /// <param name="node">The node body: receives the current state and returns the next state.</param>
+    /// <returns>This builder, for chaining.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="name"/> or <paramref name="node"/> is <c>null</c>.</exception>
+    /// <exception cref="ArgumentException">Thrown when the name is empty/whitespace, reserved, or already used.</exception>
+    public StateGraph<TState> AddNode(string name, Func<TState, CancellationToken, Task<TState>> node)
+    {
+        Guard.NotNullOrWhiteSpace(name);
+        Guard.NotNull(node);
+        if (name == End)
+        {
+            throw new ArgumentException($"'{End}' is a reserved node name.", nameof(name));
+        }
+
+        if (_nodes.ContainsKey(name))
+        {
+            throw new ArgumentException($"A node named '{name}' has already been added.", nameof(name));
+        }
+
+        _nodes[name] = node;
+        return this;
+    }
+
+    /// <summary>
+    /// Adds a synchronous node that transforms the state.
+    /// </summary>
+    /// <param name="name">The unique node name.</param>
+    /// <param name="node">The node body: receives the current state and returns the next state.</param>
+    /// <returns>This builder, for chaining.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="name"/> or <paramref name="node"/> is <c>null</c>.</exception>
+    public StateGraph<TState> AddNode(string name, Func<TState, TState> node)
+    {
+        Guard.NotNull(node);
+        return AddNode(name, (state, _) => Task.FromResult(node(state)));
+    }
+
+    /// <summary>
+    /// Adds a fixed edge: after <paramref name="from"/> runs, flow always moves to <paramref name="to"/>.
+    /// </summary>
+    /// <param name="from">The source node name.</param>
+    /// <param name="to">The destination node name, or <see cref="End"/>.</param>
+    /// <returns>This builder, for chaining.</returns>
+    /// <exception cref="ArgumentException">Thrown when names are empty or <paramref name="from"/> already has a fixed edge.</exception>
+    public StateGraph<TState> AddEdge(string from, string to)
+    {
+        Guard.NotNullOrWhiteSpace(from);
+        Guard.NotNullOrWhiteSpace(to);
+        if (_edges.ContainsKey(from))
+        {
+            throw new ArgumentException($"Node '{from}' already has a fixed edge.", nameof(from));
+        }
+
+        _edges[from] = to;
+        return this;
+    }
+
+    /// <summary>
+    /// Adds conditional edges: after <paramref name="from"/> runs, the router inspects the state and
+    /// returns the next node name (or <see cref="End"/>).
+    /// </summary>
+    /// <param name="from">The source node name.</param>
+    /// <param name="router">Selects the next node from the current state.</param>
+    /// <returns>This builder, for chaining.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="router"/> is <c>null</c>.</exception>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="from"/> is empty or already has conditional edges.</exception>
+    public StateGraph<TState> AddConditionalEdges(string from, Func<TState, string> router)
+    {
+        Guard.NotNullOrWhiteSpace(from);
+        Guard.NotNull(router);
+        if (_conditionalEdges.ContainsKey(from))
+        {
+            throw new ArgumentException($"Node '{from}' already has conditional edges.", nameof(from));
+        }
+
+        _conditionalEdges[from] = router;
+        return this;
+    }
+
+    /// <summary>
+    /// Sets the node where execution begins.
+    /// </summary>
+    /// <param name="name">The entry node name.</param>
+    /// <returns>This builder, for chaining.</returns>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="name"/> is empty/whitespace.</exception>
+    public StateGraph<TState> SetEntryPoint(string name)
+    {
+        Guard.NotNullOrWhiteSpace(name);
+        _entryPoint = name;
+        return this;
+    }
+
+    /// <summary>
+    /// Validates the graph and produces an executable <see cref="CompiledStateGraph{TState}"/>.
+    /// </summary>
+    /// <returns>The compiled graph.</returns>
+    /// <exception cref="InvalidOperationException">Thrown when the graph is invalid (no/unknown entry point, edges to unknown nodes, or a node with both a fixed edge and conditional edges).</exception>
+    public CompiledStateGraph<TState> Compile()
+    {
+        var entry = _entryPoint;
+        if (entry is null || entry.Length == 0)
+        {
+            throw new InvalidOperationException("No entry point set. Call SetEntryPoint(...) before Compile().");
+        }
+
+        if (!_nodes.ContainsKey(entry))
+        {
+            throw new InvalidOperationException($"Entry point '{entry}' is not a registered node.");
+        }
+
+        foreach (var edge in _edges)
+        {
+            if (!_nodes.ContainsKey(edge.Key))
+            {
+                throw new InvalidOperationException($"Edge source '{edge.Key}' is not a registered node.");
+            }
+
+            if (edge.Value != End && !_nodes.ContainsKey(edge.Value))
+            {
+                throw new InvalidOperationException($"Edge target '{edge.Value}' (from '{edge.Key}') is not a registered node or End.");
+            }
+        }
+
+        foreach (var conditional in _conditionalEdges)
+        {
+            if (!_nodes.ContainsKey(conditional.Key))
+            {
+                throw new InvalidOperationException($"Conditional-edge source '{conditional.Key}' is not a registered node.");
+            }
+
+            if (_edges.ContainsKey(conditional.Key))
+            {
+                throw new InvalidOperationException(
+                    $"Node '{conditional.Key}' has both a fixed edge and conditional edges; use one or the other.");
+            }
+        }
+
+        // Snapshot so post-compile builder mutations don't affect the compiled graph.
+        return new CompiledStateGraph<TState>(
+            new Dictionary<string, Func<TState, CancellationToken, Task<TState>>>(_nodes, StringComparer.Ordinal),
+            new Dictionary<string, string>(_edges, StringComparer.Ordinal),
+            new Dictionary<string, Func<TState, string>>(_conditionalEdges, StringComparer.Ordinal),
+            entry);
+    }
+}

--- a/src/Agentic/Graph/StateGraph.cs
+++ b/src/Agentic/Graph/StateGraph.cs
@@ -44,6 +44,7 @@ public sealed class StateGraph<TState>
     private readonly Dictionary<string, Func<TState, CancellationToken, Task<TState>>> _nodes = new(StringComparer.Ordinal);
     private readonly Dictionary<string, string> _edges = new(StringComparer.Ordinal);
     private readonly Dictionary<string, Func<TState, string>> _conditionalEdges = new(StringComparer.Ordinal);
+    private readonly HashSet<string> _interruptBefore = new(StringComparer.Ordinal);
     private string? _entryPoint;
 
     /// <summary>
@@ -128,6 +129,24 @@ public sealed class StateGraph<TState>
     }
 
     /// <summary>
+    /// Marks a node as a human-in-the-loop interrupt point: a run pauses just before this node so a human
+    /// can review (and optionally edit) the state, then resume.
+    /// </summary>
+    /// <param name="name">The node to pause before.</param>
+    /// <returns>This builder, for chaining.</returns>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="name"/> is empty/whitespace.</exception>
+    /// <remarks>
+    /// Interrupts are honored by <see cref="CompiledStateGraph{TState}.RunAsync(TState, AiDotNet.Agentic.Graph.Checkpointing.IGraphCheckpointer{TState}, string, GraphRunOptions, System.Threading.CancellationToken)"/>;
+    /// the plain <c>InvokeAsync</c> overloads run straight through without pausing.
+    /// </remarks>
+    public StateGraph<TState> AddInterruptBefore(string name)
+    {
+        Guard.NotNullOrWhiteSpace(name);
+        _interruptBefore.Add(name);
+        return this;
+    }
+
+    /// <summary>
     /// Sets the node where execution begins.
     /// </summary>
     /// <param name="name">The entry node name.</param>
@@ -185,11 +204,20 @@ public sealed class StateGraph<TState>
             }
         }
 
+        foreach (var node in _interruptBefore)
+        {
+            if (!_nodes.ContainsKey(node))
+            {
+                throw new InvalidOperationException($"Interrupt node '{node}' is not a registered node.");
+            }
+        }
+
         // Snapshot so post-compile builder mutations don't affect the compiled graph.
         return new CompiledStateGraph<TState>(
             new Dictionary<string, Func<TState, CancellationToken, Task<TState>>>(_nodes, StringComparer.Ordinal),
             new Dictionary<string, string>(_edges, StringComparer.Ordinal),
             new Dictionary<string, Func<TState, string>>(_conditionalEdges, StringComparer.Ordinal),
+            new HashSet<string>(_interruptBefore, StringComparer.Ordinal),
             entry);
     }
 }

--- a/src/Agentic/Graph/StateGraph.cs
+++ b/src/Agentic/Graph/StateGraph.cs
@@ -169,6 +169,72 @@ public sealed class StateGraph<TState>
     }
 
     /// <summary>
+    /// Adds a dynamic fan-out (map-reduce) node: it derives a set of items from the current state, runs a
+    /// branch over each item in parallel, then reduces the branch results back into the state. This is the
+    /// typed equivalent of LangGraph's <c>Send</c>/map-reduce.
+    /// </summary>
+    /// <typeparam name="TItem">The per-branch input item type.</typeparam>
+    /// <typeparam name="TResult">The per-branch result type.</typeparam>
+    /// <param name="name">The node name.</param>
+    /// <param name="map">Derives the items to fan out over from the current state.</param>
+    /// <param name="branch">The work run for each item (in parallel).</param>
+    /// <param name="reduce">Merges the ordered branch results back into the state.</param>
+    /// <param name="maxDegreeOfParallelism">Optional cap on concurrent branches; <c>null</c> runs all at once.</param>
+    /// <returns>This builder, for chaining.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="map"/>, <paramref name="branch"/>, or <paramref name="reduce"/> is <c>null</c>.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="maxDegreeOfParallelism"/> is less than 1.</exception>
+    public StateGraph<TState> AddFanOutNode<TItem, TResult>(
+        string name,
+        Func<TState, IEnumerable<TItem>> map,
+        Func<TItem, CancellationToken, Task<TResult>> branch,
+        Func<TState, IReadOnlyList<TResult>, TState> reduce,
+        int? maxDegreeOfParallelism = null)
+    {
+        Guard.NotNull(map);
+        Guard.NotNull(branch);
+        Guard.NotNull(reduce);
+        if (maxDegreeOfParallelism is { } dop && dop < 1)
+        {
+            throw new ArgumentOutOfRangeException(nameof(maxDegreeOfParallelism), "Max degree of parallelism must be at least 1.");
+        }
+
+        return AddNode(name, async (state, ct) =>
+        {
+            var items = (map(state) ?? Enumerable.Empty<TItem>()).ToList();
+            IReadOnlyList<TResult> results = await RunBranchesAsync(items, branch, maxDegreeOfParallelism, ct).ConfigureAwait(false);
+            return reduce(state, results);
+        });
+    }
+
+    private static async Task<TResult[]> RunBranchesAsync<TItem, TResult>(
+        IReadOnlyList<TItem> items,
+        Func<TItem, CancellationToken, Task<TResult>> branch,
+        int? maxDegreeOfParallelism,
+        CancellationToken cancellationToken)
+    {
+        if (maxDegreeOfParallelism is not { } dop)
+        {
+            return await Task.WhenAll(items.Select(item => branch(item, cancellationToken))).ConfigureAwait(false);
+        }
+
+        using var throttle = new SemaphoreSlim(dop);
+        async Task<TResult> RunThrottled(TItem item)
+        {
+            await throttle.WaitAsync(cancellationToken).ConfigureAwait(false);
+            try
+            {
+                return await branch(item, cancellationToken).ConfigureAwait(false);
+            }
+            finally
+            {
+                throttle.Release();
+            }
+        }
+
+        return await Task.WhenAll(items.Select(RunThrottled)).ConfigureAwait(false);
+    }
+
+    /// <summary>
     /// Marks a node as a human-in-the-loop interrupt point: a run pauses just before this node so a human
     /// can review (and optionally edit) the state, then resume.
     /// </summary>

--- a/src/AiDotNet.Storage.Sqlite/SqliteGraphCheckpointer.cs
+++ b/src/AiDotNet.Storage.Sqlite/SqliteGraphCheckpointer.cs
@@ -1,0 +1,167 @@
+using System.Collections.Generic;
+using System.Data.Common;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Data.Sqlite;
+using Newtonsoft.Json;
+
+namespace AiDotNet.Agentic.Graph.Checkpointing;
+
+/// <summary>
+/// A SQLite-backed <see cref="IGraphCheckpointer{TState}"/> that persists graph checkpoints in a database
+/// table, giving durable resume and time-travel across process restarts and machines. Ships in the opt-in
+/// <c>AiDotNet.Storage.Sqlite</c> package so the core stays free of the SQLite dependency.
+/// </summary>
+/// <typeparam name="TState">The graph's state type (serialized to JSON for storage).</typeparam>
+/// <remarks>
+/// <para><b>For Beginners:</b> Saves your graph's progress into a SQLite database file. Point it at a
+/// connection string and runs survive restarts — resume or rewind by thread id.
+/// </para>
+/// </remarks>
+public sealed class SqliteGraphCheckpointer<TState> : IGraphCheckpointer<TState>
+{
+    private readonly string _connectionString;
+
+    /// <summary>
+    /// Initializes the checkpointer with a SQLite connection string (e.g. <c>Data Source=graph.db</c>).
+    /// </summary>
+    /// <param name="connectionString">The SQLite connection string.</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="connectionString"/> is <c>null</c>.</exception>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="connectionString"/> is empty/whitespace.</exception>
+    public SqliteGraphCheckpointer(string connectionString)
+    {
+        if (string.IsNullOrWhiteSpace(connectionString))
+        {
+            throw new ArgumentException("Connection string cannot be empty.", nameof(connectionString));
+        }
+
+        _connectionString = connectionString;
+    }
+
+    /// <inheritdoc/>
+    public async Task SaveAsync(GraphCheckpoint<TState> checkpoint, CancellationToken cancellationToken = default)
+    {
+        if (checkpoint is null)
+        {
+            throw new ArgumentNullException(nameof(checkpoint));
+        }
+
+        using var connection = await OpenAsync(cancellationToken).ConfigureAwait(false);
+        using var command = connection.CreateCommand();
+        command.CommandText =
+            "INSERT INTO GraphCheckpoints (ThreadId, CheckpointId, Step, NextNode, StateJson) " +
+            "VALUES ($threadId, $checkpointId, $step, $nextNode, $stateJson);";
+        command.Parameters.AddWithValue("$threadId", checkpoint.ThreadId);
+        command.Parameters.AddWithValue("$checkpointId", checkpoint.CheckpointId);
+        command.Parameters.AddWithValue("$step", checkpoint.Step);
+        command.Parameters.AddWithValue("$nextNode", checkpoint.NextNode);
+        command.Parameters.AddWithValue("$stateJson", JsonConvert.SerializeObject(checkpoint.State));
+        await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc/>
+    public async Task<GraphCheckpoint<TState>?> GetLatestAsync(string threadId, CancellationToken cancellationToken = default)
+    {
+        if (threadId is null)
+        {
+            throw new ArgumentNullException(nameof(threadId));
+        }
+
+        using var connection = await OpenAsync(cancellationToken).ConfigureAwait(false);
+        using var command = connection.CreateCommand();
+        command.CommandText =
+            "SELECT CheckpointId, Step, NextNode, StateJson FROM GraphCheckpoints " +
+            "WHERE ThreadId = $threadId ORDER BY Seq DESC LIMIT 1;";
+        command.Parameters.AddWithValue("$threadId", threadId);
+        using var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+        if (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+        {
+            return ReadRow(threadId, reader);
+        }
+
+        return null;
+    }
+
+    /// <inheritdoc/>
+    public async Task<GraphCheckpoint<TState>?> GetAsync(string threadId, string checkpointId, CancellationToken cancellationToken = default)
+    {
+        if (threadId is null)
+        {
+            throw new ArgumentNullException(nameof(threadId));
+        }
+
+        if (checkpointId is null)
+        {
+            throw new ArgumentNullException(nameof(checkpointId));
+        }
+
+        using var connection = await OpenAsync(cancellationToken).ConfigureAwait(false);
+        using var command = connection.CreateCommand();
+        command.CommandText =
+            "SELECT CheckpointId, Step, NextNode, StateJson FROM GraphCheckpoints " +
+            "WHERE ThreadId = $threadId AND CheckpointId = $checkpointId ORDER BY Seq DESC LIMIT 1;";
+        command.Parameters.AddWithValue("$threadId", threadId);
+        command.Parameters.AddWithValue("$checkpointId", checkpointId);
+        using var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+        if (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+        {
+            return ReadRow(threadId, reader);
+        }
+
+        return null;
+    }
+
+    /// <inheritdoc/>
+    public async Task<IReadOnlyList<GraphCheckpoint<TState>>> GetHistoryAsync(string threadId, CancellationToken cancellationToken = default)
+    {
+        if (threadId is null)
+        {
+            throw new ArgumentNullException(nameof(threadId));
+        }
+
+        var history = new List<GraphCheckpoint<TState>>();
+        using var connection = await OpenAsync(cancellationToken).ConfigureAwait(false);
+        using var command = connection.CreateCommand();
+        command.CommandText =
+            "SELECT CheckpointId, Step, NextNode, StateJson FROM GraphCheckpoints " +
+            "WHERE ThreadId = $threadId ORDER BY Seq ASC;";
+        command.Parameters.AddWithValue("$threadId", threadId);
+        using var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+        while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+        {
+            history.Add(ReadRow(threadId, reader));
+        }
+
+        return history;
+    }
+
+    private static GraphCheckpoint<TState> ReadRow(string threadId, DbDataReader reader)
+    {
+        var checkpointId = reader.GetString(0);
+        var step = reader.GetInt32(1);
+        var nextNode = reader.GetString(2);
+        var stateJson = reader.GetString(3);
+        var state = JsonConvert.DeserializeObject<TState>(stateJson);
+        return new GraphCheckpoint<TState>(threadId, checkpointId, step, nextNode, state);
+    }
+
+    private async Task<SqliteConnection> OpenAsync(CancellationToken cancellationToken)
+    {
+        var connection = new SqliteConnection(_connectionString);
+        await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+
+        using var command = connection.CreateCommand();
+        command.CommandText =
+            "CREATE TABLE IF NOT EXISTS GraphCheckpoints (" +
+            "Seq INTEGER PRIMARY KEY AUTOINCREMENT, " +
+            "ThreadId TEXT NOT NULL, " +
+            "CheckpointId TEXT NOT NULL, " +
+            "Step INTEGER NOT NULL, " +
+            "NextNode TEXT NOT NULL, " +
+            "StateJson TEXT NOT NULL);" +
+            "CREATE INDEX IF NOT EXISTS IX_GraphCheckpoints_Thread ON GraphCheckpoints (ThreadId, Seq);";
+        await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+
+        return connection;
+    }
+}

--- a/src/AiDotNet.Storage.Sqlite/SqliteGraphCheckpointer.cs
+++ b/src/AiDotNet.Storage.Sqlite/SqliteGraphCheckpointer.cs
@@ -142,6 +142,13 @@ public sealed class SqliteGraphCheckpointer<TState> : IGraphCheckpointer<TState>
         var nextNode = reader.GetString(2);
         var stateJson = reader.GetString(3);
         var state = JsonConvert.DeserializeObject<TState>(stateJson);
+        if (state is null)
+        {
+            throw new InvalidOperationException(
+                $"Checkpoint '{checkpointId}' for thread '{threadId}' has a null or unparseable state payload " +
+                "and cannot be reconstructed.");
+        }
+
         return new GraphCheckpoint<TState>(threadId, checkpointId, step, nextNode, state);
     }
 

--- a/tests/AiDotNet.Tests/UnitTests/Agentic/Graph/GraphCheckpointingTests.cs
+++ b/tests/AiDotNet.Tests/UnitTests/Agentic/Graph/GraphCheckpointingTests.cs
@@ -1,0 +1,86 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using AiDotNet.Agentic.Graph;
+using AiDotNet.Agentic.Graph.Checkpointing;
+using Xunit;
+
+namespace AiDotNetTests.UnitTests.Agentic.Graph
+{
+    public class GraphCheckpointingTests
+    {
+        // a: +1, b: +10, a -> b -> End
+        private static CompiledStateGraph<int> BuildGraph() =>
+            new StateGraph<int>()
+                .AddNode("a", s => s + 1)
+                .AddNode("b", s => s + 10)
+                .AddEdge("a", "b")
+                .AddEdge("b", StateGraph<int>.End)
+                .SetEntryPoint("a")
+                .Compile();
+
+        [Fact(Timeout = 60000)]
+        public async Task CheckpointedRun_Completes_AndRecordsHistory()
+        {
+            var graph = BuildGraph();
+            var cp = new InMemoryGraphCheckpointer<int>();
+
+            var result = await graph.InvokeAsync(0, cp, "t1");
+            Assert.Equal(11, result);
+
+            var history = await cp.GetHistoryAsync("t1");
+            // step0(next=a,0), step1(next=b,1), step2(next=End,11)
+            Assert.Equal(3, history.Count);
+            Assert.Equal(new[] { 0, 1, 2 }, history.Select(h => h.Step));
+            Assert.Equal(StateGraph<int>.End, history[2].NextNode);
+            Assert.True(history[2].IsComplete);
+            Assert.Equal(11, history[2].State);
+        }
+
+        [Fact(Timeout = 60000)]
+        public async Task Resume_PicksUpFromLatestCheckpoint_SkippingEarlierNodes()
+        {
+            var graph = BuildGraph();
+            var cp = new InMemoryGraphCheckpointer<int>();
+
+            // Simulate that node 'a' already ran (produced 100, next is 'b').
+            await cp.SaveAsync(new GraphCheckpoint<int>("t2", "t2-1", 1, "b", 100));
+
+            var result = await graph.InvokeAsync(initialState: 0, cp, "t2");
+            // Resumes at 'b' with state 100 -> 110; 'a' is NOT re-run (would have given 11).
+            Assert.Equal(110, result);
+        }
+
+        [Fact(Timeout = 60000)]
+        public async Task ReinvokingCompletedThread_ReturnsFinalState_WithoutRerunning()
+        {
+            var graph = BuildGraph();
+            var cp = new InMemoryGraphCheckpointer<int>();
+
+            await graph.InvokeAsync(0, cp, "t3"); // completes at 11
+            var again = await graph.InvokeAsync(999, cp, "t3"); // initialState ignored; thread is complete
+            Assert.Equal(11, again);
+        }
+
+        [Fact(Timeout = 60000)]
+        public async Task TimeTravel_ResumeFromEarlierCheckpoint_Replays()
+        {
+            var graph = BuildGraph();
+            var cp = new InMemoryGraphCheckpointer<int>();
+            await graph.InvokeAsync(0, cp, "t4"); // history: t4-0(a,0), t4-1(b,1), t4-2(End,11)
+
+            // Rewind to the checkpoint after 'a' (next='b', state=1) and replay forward.
+            var result = await graph.ResumeFromAsync(cp, "t4", "t4-1");
+            Assert.Equal(11, result);
+        }
+
+        [Fact(Timeout = 60000)]
+        public async Task ResumeFrom_UnknownCheckpoint_Throws()
+        {
+            var graph = BuildGraph();
+            var cp = new InMemoryGraphCheckpointer<int>();
+            await Assert.ThrowsAsync<InvalidOperationException>(
+                () => graph.ResumeFromAsync(cp, "t5", "does-not-exist"));
+        }
+    }
+}

--- a/tests/AiDotNet.Tests/UnitTests/Agentic/Graph/GraphCompositionTests.cs
+++ b/tests/AiDotNet.Tests/UnitTests/Agentic/Graph/GraphCompositionTests.cs
@@ -1,0 +1,68 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using AiDotNet.Agentic.Graph;
+using AiDotNet.Agentic.Graph.Checkpointing;
+using Xunit;
+
+namespace AiDotNetTests.UnitTests.Agentic.Graph
+{
+    public class GraphCompositionTests
+    {
+        [Fact(Timeout = 60000)]
+        public async Task Subgraph_RunsAsSingleStep()
+        {
+            var inner = new StateGraph<int>()
+                .AddNode("plus1", s => s + 1)
+                .AddEdge("plus1", StateGraph<int>.End)
+                .SetEntryPoint("plus1")
+                .Compile();
+
+            var outer = new StateGraph<int>()
+                .AddNode("pre", s => s * 2)
+                .AddSubgraph("sub", inner)
+                .AddEdge("pre", "sub")
+                .AddEdge("sub", StateGraph<int>.End)
+                .SetEntryPoint("pre")
+                .Compile();
+
+            Assert.Equal(7, await outer.InvokeAsync(3)); // (3*2) then +1
+        }
+
+        [Fact(Timeout = 60000)]
+        public async Task RewardGatedEdges_LoopUntilThresholdMet()
+        {
+            var graph = new StateGraph<int>()
+                .AddNode("work", s => s + 1)
+                .AddRewardGatedEdges("work", reward: s => s, threshold: 3, ifMeetsThreshold: StateGraph<int>.End, ifBelowThreshold: "work")
+                .SetEntryPoint("work")
+                .Compile();
+
+            Assert.Equal(3, await graph.InvokeAsync(0)); // loops work until score >= 3
+        }
+
+        [Fact(Timeout = 60000)]
+        public async Task Replay_ReproducesRecordedTrajectory_WithoutExecuting()
+        {
+            var graph = new StateGraph<int>()
+                .AddNode("a", s => s + 1)
+                .AddNode("b", s => s + 10)
+                .AddEdge("a", "b")
+                .AddEdge("b", StateGraph<int>.End)
+                .SetEntryPoint("a")
+                .Compile();
+            var cp = new InMemoryGraphCheckpointer<int>();
+            await graph.InvokeAsync(0, cp, "r1");
+
+            var replay = new List<GraphStepUpdate<int>>();
+            await foreach (var u in graph.ReplayAsync(cp, "r1"))
+            {
+                replay.Add(u);
+            }
+
+            Assert.Equal(new[] { "a", "b" }, replay.Select(u => u.NodeName));
+            Assert.Equal(new[] { 1, 11 }, replay.Select(u => u.State));
+            Assert.Equal(11, await graph.GetRecordedStateAsync(cp, "r1"));
+        }
+    }
+}

--- a/tests/AiDotNet.Tests/UnitTests/Agentic/Graph/GraphDurableCheckpointerTests.cs
+++ b/tests/AiDotNet.Tests/UnitTests/Agentic/Graph/GraphDurableCheckpointerTests.cs
@@ -1,0 +1,94 @@
+using System.IO;
+using System.Threading.Tasks;
+using AiDotNet.Agentic.Graph;
+using AiDotNet.Agentic.Graph.Checkpointing;
+using Xunit;
+
+namespace AiDotNetTests.UnitTests.Agentic.Graph
+{
+    public class GraphDurableCheckpointerTests
+    {
+        // a: +1, b: +10, a -> b -> End
+        private static CompiledStateGraph<int> BuildGraph() =>
+            new StateGraph<int>()
+                .AddNode("a", s => s + 1)
+                .AddNode("b", s => s + 10)
+                .AddEdge("a", "b")
+                .AddEdge("b", StateGraph<int>.End)
+                .SetEntryPoint("a")
+                .Compile();
+
+        // Runs a checkpointed graph via 'writer', then verifies a *fresh* checkpointer instance over the
+        // same backing store can read the history and resume — proving durability across instances/restarts.
+        private static async Task AssertDurableAsync(IGraphCheckpointer<int> writer, IGraphCheckpointer<int> freshReader)
+        {
+            var graph = BuildGraph();
+
+            var result = await graph.InvokeAsync(0, writer, "d1");
+            Assert.Equal(11, result);
+
+            var history = await freshReader.GetHistoryAsync("d1");
+            Assert.Equal(3, history.Count);
+            Assert.True(history[history.Count - 1].IsComplete);
+            Assert.Equal(11, history[history.Count - 1].State);
+
+            // Resuming a completed thread through the fresh instance returns the persisted final state.
+            Assert.Equal(11, await graph.InvokeAsync(999, freshReader, "d1"));
+        }
+
+        [Fact(Timeout = 60000)]
+        public async Task JsonFileCheckpointer_PersistsAcrossInstances()
+        {
+            var path = Path.GetTempFileName();
+            try
+            {
+                await AssertDurableAsync(
+                    new JsonFileGraphCheckpointer<int>(path),
+                    new JsonFileGraphCheckpointer<int>(path));
+            }
+            finally
+            {
+                TryDelete(path);
+            }
+        }
+
+#if NET5_0_OR_GREATER
+        // SqliteGraphCheckpointer works on both target frameworks, but the native SQLite library
+        // (e_sqlite3) is not deployed to the .NET Framework (net471) shadow-copy test host in this
+        // environment — a pre-existing, repo-wide condition that also affects SqliteSqlSyntaxValidatorTests.
+        // The cross-TFM durability contract is covered by the JSON-file test above; this adds SQLite coverage
+        // on the framework where the native dependency is available.
+        [Fact(Timeout = 60000)]
+        public async Task SqliteCheckpointer_PersistsAcrossInstances()
+        {
+            var path = Path.GetTempFileName();
+            var connectionString = $"Data Source={path};Pooling=False";
+            try
+            {
+                await AssertDurableAsync(
+                    new SqliteGraphCheckpointer<int>(connectionString),
+                    new SqliteGraphCheckpointer<int>(connectionString));
+            }
+            finally
+            {
+                TryDelete(path);
+            }
+        }
+#endif
+
+        private static void TryDelete(string path)
+        {
+            try
+            {
+                if (File.Exists(path))
+                {
+                    File.Delete(path);
+                }
+            }
+            catch (IOException)
+            {
+                // Best-effort cleanup; the OS reclaims temp files eventually.
+            }
+        }
+    }
+}

--- a/tests/AiDotNet.Tests/UnitTests/Agentic/Graph/GraphFanOutTests.cs
+++ b/tests/AiDotNet.Tests/UnitTests/Agentic/Graph/GraphFanOutTests.cs
@@ -1,0 +1,63 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using AiDotNet.Agentic.Graph;
+using Xunit;
+
+namespace AiDotNetTests.UnitTests.Agentic.Graph
+{
+    public class GraphFanOutTests
+    {
+        // Fan out over 1..N, square each branch in parallel, reduce by summing into the state.
+        private static CompiledStateGraph<int> BuildSquareSumGraph(int? maxParallelism = null) =>
+            new StateGraph<int>()
+                .AddFanOutNode<int, int>(
+                    "squareSum",
+                    map: s => Enumerable.Range(1, s),
+                    branch: async (i, ct) => { await Task.Yield(); return i * i; },
+                    reduce: (s, results) => results.Sum(),
+                    maxDegreeOfParallelism: maxParallelism)
+                .AddEdge("squareSum", StateGraph<int>.End)
+                .SetEntryPoint("squareSum")
+                .Compile();
+
+        [Fact(Timeout = 60000)]
+        public async Task FanOut_MapsBranchesAndReduces()
+        {
+            var graph = BuildSquareSumGraph();
+            Assert.Equal(14, await graph.InvokeAsync(3)); // 1 + 4 + 9
+        }
+
+        [Fact(Timeout = 60000)]
+        public async Task FanOut_RespectsParallelismCap_StillCorrect()
+        {
+            var graph = BuildSquareSumGraph(maxParallelism: 2);
+            Assert.Equal(30, await graph.InvokeAsync(4)); // 1 + 4 + 9 + 16
+        }
+
+        [Fact(Timeout = 60000)]
+        public async Task FanOut_EmptyItemSet_ReducesOverNothing()
+        {
+            var graph = BuildSquareSumGraph();
+            Assert.Equal(0, await graph.InvokeAsync(0)); // no items -> Sum() == 0
+        }
+
+        [Fact(Timeout = 60000)]
+        public async Task FanOut_ComposesWithOtherNodes()
+        {
+            var graph = new StateGraph<int>()
+                .AddNode("seed", s => s + 2) // 1 -> 3
+                .AddFanOutNode<int, int>(
+                    "squareSum",
+                    map: s => Enumerable.Range(1, s),
+                    branch: (i, ct) => Task.FromResult(i * i),
+                    reduce: (s, results) => results.Sum())
+                .AddEdge("seed", "squareSum")
+                .AddEdge("squareSum", StateGraph<int>.End)
+                .SetEntryPoint("seed")
+                .Compile();
+
+            Assert.Equal(14, await graph.InvokeAsync(1)); // seed: 1->3, then 1+4+9
+        }
+    }
+}

--- a/tests/AiDotNet.Tests/UnitTests/Agentic/Graph/GraphInterruptTests.cs
+++ b/tests/AiDotNet.Tests/UnitTests/Agentic/Graph/GraphInterruptTests.cs
@@ -1,0 +1,81 @@
+using System.Threading.Tasks;
+using AiDotNet.Agentic.Graph;
+using AiDotNet.Agentic.Graph.Checkpointing;
+using Xunit;
+
+namespace AiDotNetTests.UnitTests.Agentic.Graph
+{
+    public class GraphInterruptTests
+    {
+        // draft: +1, approve: *10, draft -> approve -> End, pause before "approve".
+        private static CompiledStateGraph<int> BuildApprovalGraph() =>
+            new StateGraph<int>()
+                .AddNode("draft", s => s + 1)
+                .AddNode("approve", s => s * 10)
+                .AddEdge("draft", "approve")
+                .AddEdge("approve", StateGraph<int>.End)
+                .AddInterruptBefore("approve")
+                .SetEntryPoint("draft")
+                .Compile();
+
+        [Fact(Timeout = 60000)]
+        public async Task RunAsync_PausesBeforeInterruptNode_ThenResumesToCompletion()
+        {
+            var graph = BuildApprovalGraph();
+            var cp = new InMemoryGraphCheckpointer<int>();
+
+            var first = await graph.RunAsync(1, cp, "t1");
+            Assert.True(first.IsInterrupted);
+            Assert.Equal("approve", first.InterruptedBefore);
+            Assert.Equal(2, first.State); // draft ran (1 -> 2); approve did not
+
+            var second = await graph.RunAsync(0, cp, "t1"); // initialState ignored on resume
+            Assert.True(second.IsComplete);
+            Assert.Equal(20, second.State); // approve ran (2 -> 20)
+        }
+
+        [Fact(Timeout = 60000)]
+        public async Task RunAsync_AppliesHumanEdit_OnResume()
+        {
+            var graph = BuildApprovalGraph();
+            var cp = new InMemoryGraphCheckpointer<int>();
+
+            var first = await graph.RunAsync(1, cp, "t2");
+            Assert.True(first.IsInterrupted);
+
+            // Human edits the state (adds 100) before approving.
+            var second = await graph.RunAsync(0, cp, "t2", applyOnResume: s => s + 100);
+            Assert.True(second.IsComplete);
+            Assert.Equal(1020, second.State); // (2 + 100) * 10
+        }
+
+        [Fact(Timeout = 60000)]
+        public async Task RunAsync_CanInterruptBeforeEntryNode()
+        {
+            var graph = new StateGraph<int>()
+                .AddNode("start", s => s + 1)
+                .AddEdge("start", StateGraph<int>.End)
+                .AddInterruptBefore("start")
+                .SetEntryPoint("start")
+                .Compile();
+            var cp = new InMemoryGraphCheckpointer<int>();
+
+            var first = await graph.RunAsync(5, cp, "t3");
+            Assert.True(first.IsInterrupted);
+            Assert.Equal("start", first.InterruptedBefore);
+            Assert.Equal(5, first.State); // nothing ran yet
+
+            var second = await graph.RunAsync(0, cp, "t3");
+            Assert.True(second.IsComplete);
+            Assert.Equal(6, second.State);
+        }
+
+        [Fact(Timeout = 60000)]
+        public async Task InvokeAsync_RunsStraightThrough_IgnoringInterrupts()
+        {
+            var graph = BuildApprovalGraph();
+            var result = await graph.InvokeAsync(1); // plain run, no checkpointer
+            Assert.Equal(20, result); // (1 + 1) * 10 — did not pause
+        }
+    }
+}

--- a/tests/AiDotNet.Tests/UnitTests/Agentic/Graph/StateGraphTests.cs
+++ b/tests/AiDotNet.Tests/UnitTests/Agentic/Graph/StateGraphTests.cs
@@ -87,7 +87,7 @@ namespace AiDotNetTests.UnitTests.Agentic.Graph
         }
 
         [Fact(Timeout = 60000)]
-        public async Task Compile_Validates_EntryPointEdgesAndExclusiveRouting()
+        public Task Compile_Validates_EntryPointEdgesAndExclusiveRouting()
         {
             // No entry point.
             Assert.Throws<InvalidOperationException>(() =>
@@ -106,16 +106,16 @@ namespace AiDotNetTests.UnitTests.Agentic.Graph
                     .SetEntryPoint("a")
                     .Compile());
 
-            await Task.CompletedTask;
+            return Task.CompletedTask;
         }
 
         [Fact(Timeout = 60000)]
-        public async Task AddNode_RejectsDuplicateAndReservedNames()
+        public Task AddNode_RejectsDuplicateAndReservedNames()
         {
             var graph = new StateGraph<int>().AddNode("a", s => s);
             Assert.Throws<ArgumentException>(() => graph.AddNode("a", s => s));            // duplicate
             Assert.Throws<ArgumentException>(() => new StateGraph<int>().AddNode(StateGraph<int>.End, s => s)); // reserved
-            await Task.CompletedTask;
+            return Task.CompletedTask;
         }
     }
 }

--- a/tests/AiDotNet.Tests/UnitTests/Agentic/Graph/StateGraphTests.cs
+++ b/tests/AiDotNet.Tests/UnitTests/Agentic/Graph/StateGraphTests.cs
@@ -1,0 +1,121 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using AiDotNet.Agentic.Graph;
+using Xunit;
+
+namespace AiDotNetTests.UnitTests.Agentic.Graph
+{
+    public class StateGraphTests
+    {
+        [Fact(Timeout = 60000)]
+        public async Task Linear_RunsNodesInOrder_AndThreadsState()
+        {
+            var graph = new StateGraph<int>()
+                .AddNode("inc", s => s + 1)
+                .AddNode("double", s => s * 2)
+                .AddEdge("inc", "double")
+                .AddEdge("double", StateGraph<int>.End)
+                .SetEntryPoint("inc")
+                .Compile();
+
+            var result = await graph.InvokeAsync(1);
+            Assert.Equal(4, result); // (1 + 1) * 2
+        }
+
+        [Fact(Timeout = 60000)]
+        public async Task ConditionalEdges_SupportCycles()
+        {
+            var graph = new StateGraph<int>()
+                .AddNode("inc", s => s + 1)
+                .AddConditionalEdges("inc", s => s < 3 ? "inc" : StateGraph<int>.End)
+                .SetEntryPoint("inc")
+                .Compile();
+
+            var result = await graph.InvokeAsync(0);
+            Assert.Equal(3, result); // loops inc until value reaches 3
+        }
+
+        [Fact(Timeout = 60000)]
+        public async Task Stream_EmitsUpdatePerNode_WithFinalState()
+        {
+            var graph = new StateGraph<int>()
+                .AddNode("a", s => s + 1)
+                .AddNode("b", s => s + 10)
+                .AddEdge("a", "b")
+                .AddEdge("b", StateGraph<int>.End)
+                .SetEntryPoint("a")
+                .Compile();
+
+            var updates = new List<GraphStepUpdate<int>>();
+            await foreach (var u in graph.StreamAsync(0))
+            {
+                updates.Add(u);
+            }
+
+            Assert.Equal(new[] { "a", "b" }, updates.Select(u => u.NodeName));
+            Assert.Equal(1, updates[0].State);
+            Assert.Equal(11, updates[1].State);
+        }
+
+        [Fact(Timeout = 60000)]
+        public async Task RecursionLimit_Throws_OnRunawayCycle()
+        {
+            var graph = new StateGraph<int>()
+                .AddNode("loop", s => s + 1)
+                .AddConditionalEdges("loop", _ => "loop") // never terminates
+                .SetEntryPoint("loop")
+                .Compile();
+
+            var ex = await Assert.ThrowsAsync<GraphRecursionException>(
+                () => graph.InvokeAsync(0, new GraphRunOptions { MaxSteps = 5 }));
+            Assert.Equal(5, ex.MaxSteps);
+        }
+
+        [Fact(Timeout = 60000)]
+        public async Task AsyncNode_IsAwaited()
+        {
+            var graph = new StateGraph<int>()
+                .AddNode("delay", async (s, ct) => { await Task.Yield(); return s + 41; })
+                .AddEdge("delay", StateGraph<int>.End)
+                .SetEntryPoint("delay")
+                .Compile();
+
+            Assert.Equal(42, await graph.InvokeAsync(1));
+        }
+
+        [Fact(Timeout = 60000)]
+        public async Task Compile_Validates_EntryPointEdgesAndExclusiveRouting()
+        {
+            // No entry point.
+            Assert.Throws<InvalidOperationException>(() =>
+                new StateGraph<int>().AddNode("a", s => s).Compile());
+
+            // Edge to unknown node.
+            Assert.Throws<InvalidOperationException>(() =>
+                new StateGraph<int>().AddNode("a", s => s).AddEdge("a", "ghost").SetEntryPoint("a").Compile());
+
+            // A node cannot have both a fixed edge and conditional edges.
+            Assert.Throws<InvalidOperationException>(() =>
+                new StateGraph<int>()
+                    .AddNode("a", s => s)
+                    .AddEdge("a", StateGraph<int>.End)
+                    .AddConditionalEdges("a", _ => StateGraph<int>.End)
+                    .SetEntryPoint("a")
+                    .Compile());
+
+            await Task.CompletedTask;
+        }
+
+        [Fact(Timeout = 60000)]
+        public async Task AddNode_RejectsDuplicateAndReservedNames()
+        {
+            var graph = new StateGraph<int>().AddNode("a", s => s);
+            Assert.Throws<ArgumentException>(() => graph.AddNode("a", s => s));            // duplicate
+            Assert.Throws<ArgumentException>(() => new StateGraph<int>().AddNode(StateGraph<int>.End, s => s)); // reserved
+            await Task.CompletedTask;
+        }
+    }
+}


### PR DESCRIPTION
## Phase 1 (graph runtime) — slice 1 of the agentic-orchestration epic

Part of **#1544**. Phase 0 is in #1545; this PR begins **Phase 1**, the typed graph runtime that is the core differentiator vs LangGraph (typed state, compile-time wiring, deterministic execution — durability/HITL to follow).

### What's in this slice (`AiDotNet.Agentic.Graph`)
- **`StateGraph<TState>`** — fluent builder: `AddNode` (sync/async), `AddEdge`, `AddConditionalEdges`, `SetEntryPoint`, `Compile()`. Fully typed state (no stringly-typed state dicts). `Compile()` validates the graph (entry exists; edges resolve to a node or `End`; a node can't have both a fixed edge and conditional edges).
- **`CompiledStateGraph<TState>`** — `InvokeAsync` (returns final state) and `StreamAsync` (yields a `GraphStepUpdate<TState>` after each node). Cycles are allowed and bounded by `GraphRunOptions.MaxSteps` (default 25) → `GraphRecursionException`.
- **`GraphSpecialNodes.End`** sentinel; conditional routers return a node name or `End`.

### Not in this slice (subsequent Phase 1 PRs)
Durable checkpointing (memory/SQLite/Postgres/Redis), resume, time-travel + deterministic record/replay, human-in-the-loop interrupts, channels/reducers + dynamic fan-out (Send/map-reduce), subgraphs, reward-gated edges.

### Verification
- Core builds clean on **net10.0 + net471**.
- `UnitTests/Agentic/Graph/StateGraphTests.cs`: **7/7 pass on net10.0 and net471** (linear, conditional cycle, streaming, recursion-limit, async node, compile validation, duplicate/reserved names).

Conventions: generic `<T>`, `Guard.*`, enums/sentinels (no magic strings), "For Beginners" XML docs, and **no null-forgiving operators**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added graph state checkpointing with support for in-memory, JSON file, and SQLite persistence
  * Added human-in-the-loop execution with interrupt points and state resumption
  * Added streaming execution progress tracking and replay of recorded runs
  * Added fan-out/parallel node execution with configurable concurrency limits
  * Added step budget limits to prevent infinite loops
  * Added time-travel resumption from specific checkpoints

<!-- end of auto-generated comment: release notes by coderabbit.ai -->