### PR TITLE
feat(finance): Black-Scholes pricer+Greeks+IV, Kelly sizing, StandardScaler NaN fix

### DIFF
--- a/src/DecompositionMethods/MatrixDecomposition/CholeskyDecomposition.cs
+++ b/src/DecompositionMethods/MatrixDecomposition/CholeskyDecomposition.cs
@@ -279,15 +279,23 @@ public class CholeskyDecomposition<T> : MatrixDecompositionBase<T>
         int n = matrix.Rows;
         var L = new Matrix<T>(n, n);
 
+        // Reused offset-0 scratch buffers for the inner dot products. Copying each L[*, 0..j) slice
+        // to a fresh buffer start reproduces the array-element-0 alignment of the original's
+        // per-element vectors, so NumOps.Dot is bit-identical across frameworks. (A raw mid-row
+        // span starts at offset j*n / i*n, which shifts net10.0 SIMD alignment and changes rounding
+        // enough to fail near-singular KernelRidge/GP tests.) One pair of buffers per decomposition
+        // instead of O(n^2) sub-vector allocations — this is what removes the tens-of-GB churn.
+        var segI = new T[n];
+        var segJ = new T[n];
+
         for (int j = 0; j < n; j++)
         {
-            // VECTORIZED: compute diagonal element using dot product
+            // Diagonal: A[j,j] - Σ_{k<j} L[j,k]².
             T sum = NumOps.Zero;
             if (j > 0)
             {
-                var rowJ = L.GetRow(j);
-                var rowJSegment = new Vector<T>(rowJ.Take(j));
-                sum = rowJSegment.DotProduct(rowJSegment);
+                L.GetRowReadOnlySpan(j).Slice(0, j).CopyTo(segJ);
+                sum = NumOps.Dot(segJ.AsSpan(0, j), segJ.AsSpan(0, j));
             }
 
             T diagonalValue = NumOps.Subtract(matrix[j, j], sum);
@@ -297,27 +305,17 @@ public class CholeskyDecomposition<T> : MatrixDecompositionBase<T>
             }
             L[j, j] = NumOps.Sqrt(diagonalValue);
 
-            // VECTORIZED: compute off-diagonal elements using dot product
-            if (j > 0)
+            // Off-diagonal: (A[i,j] - Σ_{k<j} L[i,k]·L[j,k]) / L[j,j]. segJ already holds L[j, 0..j).
+            for (int i = j + 1; i < n; i++)
             {
-                var rowJ = L.GetRow(j);
-                var rowJSegment = new Vector<T>(rowJ.Take(j));
+                T offSum = NumOps.Zero;
+                if (j > 0)
+                {
+                    L.GetRowReadOnlySpan(i).Slice(0, j).CopyTo(segI);
+                    offSum = NumOps.Dot(segI.AsSpan(0, j), segJ.AsSpan(0, j));
+                }
 
-                for (int i = j + 1; i < n; i++)
-                {
-                    var rowI = L.GetRow(i);
-                    var rowISegment = new Vector<T>(rowI.Take(j));
-                    sum = rowISegment.DotProduct(rowJSegment);
-                    L[i, j] = NumOps.Divide(NumOps.Subtract(matrix[i, j], sum), L[j, j]);
-                }
-            }
-            else
-            {
-                // First column: no dot product needed
-                for (int i = j + 1; i < n; i++)
-                {
-                    L[i, j] = NumOps.Divide(matrix[i, j], L[j, j]);
-                }
+                L[i, j] = NumOps.Divide(NumOps.Subtract(matrix[i, j], offSum), L[j, j]);
             }
         }
 

--- a/src/Finance/Base/PortfolioOptimizerBase.cs
+++ b/src/Finance/Base/PortfolioOptimizerBase.cs
@@ -42,6 +42,15 @@ public abstract class PortfolioOptimizerBase<T> : FinancialModelBase<T>, IPortfo
     public int NumAssets => _numAssets;
 
     /// <summary>
+    /// Closed-form analytic mean-variance optimizer available as a training-free baseline / warm start
+    /// alongside the learned weights. Defaults to <see cref="AiDotNet.Finance.Portfolio.MarkowitzOptimizer{T}"/>;
+    /// assign a custom <see cref="IMeanVarianceOptimizer{T}"/> (shrinkage covariance, constrained QP, …)
+    /// to change the analytic solver.
+    /// </summary>
+    public IMeanVarianceOptimizer<T> AnalyticOptimizer { get; set; }
+        = AiDotNet.Finance.Portfolio.MarkowitzOptimizer<T>.Default;
+
+    /// <summary>
     /// Initializes a new instance of the PortfolioOptimizerBase class for training.
     /// </summary>
     /// <param name="architecture">The neural network architecture.</param>

--- a/src/Finance/Base/RiskModelBase.cs
+++ b/src/Finance/Base/RiskModelBase.cs
@@ -61,6 +61,30 @@ public abstract class RiskModelBase<T> : FinancialModelBase<T>, IRiskModel<T>
     public int TimeHorizon => _timeHorizon;
 
     /// <summary>
+    /// The risk-adjusted-performance calculator used by <see cref="ComputeRiskRatios"/>. Defaults to the
+    /// closed-form <see cref="AiDotNet.Finance.Risk.RiskRatios{T}"/>; assign a custom
+    /// <see cref="AiDotNet.Finance.Interfaces.IRiskRatioCalculator{T}"/> to change the Sharpe/Sortino/
+    /// Calmar conventions (annualization, downside threshold, …) without subclassing.
+    /// </summary>
+    public AiDotNet.Finance.Interfaces.IRiskRatioCalculator<T> RiskRatioCalculator { get; set; }
+        = AiDotNet.Finance.Risk.RiskRatios<T>.Default;
+
+    /// <summary>
+    /// Scores a realized periodic return series with the configured <see cref="RiskRatioCalculator"/>,
+    /// returning the annualized Sharpe, Sortino, and Calmar ratios.
+    /// </summary>
+    /// <remarks><b>For Beginners:</b> Given a list of period-by-period returns, this reports three
+    /// "reward per unit of risk" scores; higher is better. The default uses the standard formulas, but
+    /// you can plug in your own <see cref="AiDotNet.Finance.Interfaces.IRiskRatioCalculator{T}"/>.</remarks>
+    public (T Sharpe, T Sortino, T Calmar) ComputeRiskRatios(
+        System.Collections.Generic.IReadOnlyList<T> returns,
+        double riskFreePerPeriod = 0.0,
+        int periodsPerYear = 252)
+        => (RiskRatioCalculator.Sharpe(returns, riskFreePerPeriod, periodsPerYear),
+            RiskRatioCalculator.Sortino(returns, riskFreePerPeriod, periodsPerYear),
+            RiskRatioCalculator.Calmar(returns, periodsPerYear));
+
+    /// <summary>
     /// Initializes a new instance of the RiskModelBase class for training.
     /// </summary>
     /// <param name="architecture">The neural network architecture.</param>

--- a/src/Finance/Interfaces/IMeanVarianceOptimizer.cs
+++ b/src/Finance/Interfaces/IMeanVarianceOptimizer.cs
@@ -1,0 +1,31 @@
+using AiDotNet.Tensors.LinearAlgebra;
+
+namespace AiDotNet.Finance.Interfaces;
+
+/// <summary>
+/// A closed-form mean-variance portfolio optimizer: the analytic (training-free) weight solutions.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This is a customization point, not a trainable model — unlike <see cref="IPortfolioOptimizer{T}"/>
+/// (the neural, data-fit family), this exposes the classic closed-form Markowitz solutions a portfolio
+/// model can use directly as a baseline or warm start. Consumers default to
+/// <see cref="AiDotNet.Finance.Portfolio.MarkowitzOptimizer{T}"/> but can substitute their own analytic
+/// solver (shrinkage covariance, constrained QP, …).
+/// </para>
+/// <para><b>For Beginners:</b> "Mean-variance" optimization divides money across assets by trading off
+/// expected return against risk. These are the textbook closed-form answers; the default implementation
+/// is the standard Markowitz solver.</para>
+/// </remarks>
+/// <typeparam name="T">Numeric type (float/double).</typeparam>
+public interface IMeanVarianceOptimizer<T>
+{
+    /// <summary>Global minimum-variance fully-invested weights (expected returns ignored).</summary>
+    Vector<T> MinimumVariance(Matrix<T> covariance);
+
+    /// <summary>Tangency (maximum-Sharpe) fully-invested weights for the given risk-free rate.</summary>
+    Vector<T> Tangency(Vector<T> expectedReturns, Matrix<T> covariance, T riskFreeRate);
+
+    /// <summary>Minimum-variance fully-invested weights achieving a target expected return.</summary>
+    Vector<T> TargetReturn(Vector<T> expectedReturns, Matrix<T> covariance, T targetReturn);
+}

--- a/src/Finance/Interfaces/IOptionPricer.cs
+++ b/src/Finance/Interfaces/IOptionPricer.cs
@@ -1,0 +1,43 @@
+namespace AiDotNet.Finance.Interfaces;
+
+/// <summary>
+/// A European-option pricing engine: fair value, first-order Greeks, and implied volatility.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This is a customization point, not a trainable model. Models that need to price options or
+/// hedge option exposure (e.g. an options-focused RL trading agent, a covered-call portfolio model)
+/// depend on this interface and default to the closed-form <see cref="AiDotNet.Finance.Options.BlackScholes{T}"/>
+/// implementation, but callers can substitute their own pricer (binomial tree, Heston, a learned
+/// surface, …) without changing the consuming model.
+/// </para>
+/// <para><b>For Beginners:</b> An "option pricer" answers "what is this option worth, and how does that
+/// value move when the market moves?" The default is the Black-Scholes formula; swap in your own if you
+/// need a different model.</para>
+/// </remarks>
+/// <typeparam name="T">Numeric type (float/double).</typeparam>
+public interface IOptionPricer<T>
+{
+    /// <summary>Fair value of a European call (<paramref name="isCall"/> = true) or put.</summary>
+    T Price(T spot, T strike, T timeToExpiry, T riskFreeRate, T volatility, bool isCall);
+
+    /// <summary>Delta — sensitivity of price to the underlying spot.</summary>
+    T Delta(T spot, T strike, T timeToExpiry, T riskFreeRate, T volatility, bool isCall);
+
+    /// <summary>Gamma — sensitivity of delta to the underlying spot (same for calls and puts).</summary>
+    T Gamma(T spot, T strike, T timeToExpiry, T riskFreeRate, T volatility);
+
+    /// <summary>Vega — sensitivity of price to volatility (same for calls and puts).</summary>
+    T Vega(T spot, T strike, T timeToExpiry, T riskFreeRate, T volatility);
+
+    /// <summary>Theta — sensitivity of price to the passage of time.</summary>
+    T Theta(T spot, T strike, T timeToExpiry, T riskFreeRate, T volatility, bool isCall);
+
+    /// <summary>Rho — sensitivity of price to the risk-free rate.</summary>
+    T Rho(T spot, T strike, T timeToExpiry, T riskFreeRate, T volatility, bool isCall);
+
+    /// <summary>The implied volatility that reproduces <paramref name="marketPrice"/> under this pricer.</summary>
+    T ImpliedVolatility(
+        T marketPrice, T spot, T strike, T timeToExpiry, T riskFreeRate, bool isCall,
+        int maxIterations = 100, double tolerance = 1e-8);
+}

--- a/src/Finance/Interfaces/IPositionSizer.cs
+++ b/src/Finance/Interfaces/IPositionSizer.cs
@@ -1,0 +1,32 @@
+using System.Collections.Generic;
+
+namespace AiDotNet.Finance.Interfaces;
+
+/// <summary>
+/// A bet/position-sizing rule: given an edge, returns the fraction of capital to allocate.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This is a customization point, not a trainable model. Trading agents and portfolio models depend on
+/// this interface to decide <i>how much</i> to commit to a signal and default to the
+/// <see cref="AiDotNet.Finance.Portfolio.KellyCriterion{T}"/> implementation, but callers can substitute
+/// a fixed-fraction, volatility-target, or risk-budget sizer without changing the consuming model.
+/// </para>
+/// <para><b>For Beginners:</b> A "position sizer" answers "how big should this bet be?" The default is the
+/// Kelly criterion (the growth-optimal fraction); swap in your own rule if you prefer.</para>
+/// </remarks>
+/// <typeparam name="T">Numeric type (float/double).</typeparam>
+public interface IPositionSizer<T>
+{
+    /// <summary>Sizing fraction from a discrete win probability and win/loss payoff ratio.</summary>
+    T Discrete(T winProbability, T winLossRatio);
+
+    /// <summary>Sizing fraction from the (Gaussian) mean and variance of returns.</summary>
+    T Continuous(T expectedReturn, T variance);
+
+    /// <summary>Scales a base sizing fraction (e.g. half-Kelly) by <paramref name="fraction"/>.</summary>
+    T Fractional(T baseFraction, double fraction);
+
+    /// <summary>Sizing fraction estimated from a realized return series.</summary>
+    T FromReturns(IEnumerable<T> returns, double fraction = 1.0);
+}

--- a/src/Finance/Interfaces/IRiskRatioCalculator.cs
+++ b/src/Finance/Interfaces/IRiskRatioCalculator.cs
@@ -1,0 +1,29 @@
+using System.Collections.Generic;
+
+namespace AiDotNet.Finance.Interfaces;
+
+/// <summary>
+/// Computes risk-adjusted performance ratios (Sharpe, Sortino, Calmar) from a periodic return series.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This is a customization point, not a trainable model. Risk models, backtests, and trading agents
+/// depend on this interface to score a strategy's risk-adjusted return and default to the
+/// <see cref="AiDotNet.Finance.Risk.RiskRatios{T}"/> implementation, but callers can substitute their
+/// own conventions (e.g. a different annualization, a downside threshold other than zero).
+/// </para>
+/// <para><b>For Beginners:</b> These ratios all divide "how much you earned" by "how much risk you took";
+/// higher is better. The default implementation uses the standard textbook formulas.</para>
+/// </remarks>
+/// <typeparam name="T">Numeric type (float/double).</typeparam>
+public interface IRiskRatioCalculator<T>
+{
+    /// <summary>Annualized Sharpe ratio (mean excess return / total volatility).</summary>
+    T Sharpe(IReadOnlyList<T> returns, double riskFreePerPeriod = 0.0, int periodsPerYear = 252);
+
+    /// <summary>Annualized Sortino ratio (mean excess return / downside deviation).</summary>
+    T Sortino(IReadOnlyList<T> returns, double riskFreePerPeriod = 0.0, int periodsPerYear = 252);
+
+    /// <summary>Calmar ratio (annualized return / maximum drawdown).</summary>
+    T Calmar(IReadOnlyList<T> returns, int periodsPerYear = 252);
+}

--- a/src/Finance/NLP/FinBERT.cs
+++ b/src/Finance/NLP/FinBERT.cs
@@ -876,14 +876,47 @@ public class FinBERT<T> : FinancialNLPModelBase<T>
             inputData[i] = (long)NumOps.ToDouble(input.Data.Span[i]);
         }
 
+        var tensorShape = new[] { 1, _maxSequenceLength };
         var inputTensor = new OnnxTensors.DenseTensor<long>(
             inputData,
-            new[] { 1, _maxSequenceLength });
+            tensorShape);
 
         var inputs = new List<NamedOnnxValue>
         {
             NamedOnnxValue.CreateFromTensor("input_ids", inputTensor)
         };
+
+        // Standard exported BERT ONNX graphs (e.g. ProsusAI/finbert via optimum)
+        // require attention_mask and token_type_ids in addition to input_ids.
+        // Only add the inputs the loaded session actually declares so that
+        // models exported without them continue to work unchanged.
+        var declaredInputs = OnnxSession.InputMetadata;
+
+        if (declaredInputs.ContainsKey("attention_mask"))
+        {
+            // attention_mask: 1 for real (non-pad) token positions, 0 for padding.
+            long padTokenId = _vocabulary.TryGetValue("[PAD]", out int padId) ? padId : 0L;
+            var attentionData = new long[inputData.Length];
+            for (int i = 0; i < inputData.Length; i++)
+            {
+                attentionData[i] = inputData[i] == padTokenId ? 0L : 1L;
+            }
+
+            var attentionTensor = new OnnxTensors.DenseTensor<long>(
+                attentionData,
+                tensorShape);
+            inputs.Add(NamedOnnxValue.CreateFromTensor("attention_mask", attentionTensor));
+        }
+
+        if (declaredInputs.ContainsKey("token_type_ids"))
+        {
+            // token_type_ids: all 0s for single-sentence classification.
+            var tokenTypeData = new long[inputData.Length];
+            var tokenTypeTensor = new OnnxTensors.DenseTensor<long>(
+                tokenTypeData,
+                tensorShape);
+            inputs.Add(NamedOnnxValue.CreateFromTensor("token_type_ids", tokenTypeTensor));
+        }
 
         using var results = OnnxSession.Run(inputs);
         var outputTensor = results.First().AsTensor<float>();

--- a/src/Finance/Options/BlackScholes.cs
+++ b/src/Finance/Options/BlackScholes.cs
@@ -1,0 +1,235 @@
+using System;
+using AiDotNet.Helpers;
+using AiDotNet.Interfaces;
+
+namespace AiDotNet.Finance.Options;
+
+/// <summary>
+/// Closed-form Black-Scholes-Merton European option pricing, the full first-order Greeks
+/// (delta, gamma, vega, theta, rho) and implied-volatility solve.
+/// </summary>
+/// <remarks>
+/// <para>
+/// AiDotNet ships <see cref="AiDotNet.PhysicsInformed.PDEs.BlackScholesEquation{T}"/> — the PDE
+/// <i>residual</i> for a PINN solver — but no analytic pricer. This is the cheap, exact closed form for
+/// European options: pricing + Greeks in O(1) with no training, which is what trading/sizing/hedging
+/// actually needs. Feed a GARCH / forecast volatility in as <c>volatility</c>.
+/// </para>
+/// <para><b>For Beginners:</b> The Black-Scholes formula gives the fair price of a European call or put
+/// option from five inputs: the current price (spot), the strike, time to expiry (in years), the
+/// risk-free interest rate, and the volatility. The "Greeks" are its sensitivities — delta (price vs.
+/// spot), gamma (delta vs. spot), vega (price vs. volatility), theta (price vs. time), rho (price vs.
+/// rate) — which traders use to size positions and hedge risk.</para>
+/// </remarks>
+/// <typeparam name="T">Numeric type (float/double).</typeparam>
+public static class BlackScholes<T>
+{
+    private static readonly INumericOperations<T> NumOps = MathHelper.GetNumericOperations<T>();
+
+    /// <summary>Black-Scholes price of a European call (<paramref name="isCall"/> = true) or put.</summary>
+    /// <param name="spot">Current underlying price S.</param>
+    /// <param name="strike">Strike price K.</param>
+    /// <param name="timeToExpiry">Time to expiry T in years.</param>
+    /// <param name="riskFreeRate">Continuously-compounded risk-free rate r.</param>
+    /// <param name="volatility">Annualized volatility σ.</param>
+    /// <param name="isCall">True for a call, false for a put.</param>
+    public static T Price(T spot, T strike, T timeToExpiry, T riskFreeRate, T volatility, bool isCall)
+    {
+        // At/after expiry, or with degenerate vol/time, value collapses to the discounted intrinsic.
+        if (!NumOps.GreaterThan(timeToExpiry, NumOps.Zero) || !NumOps.GreaterThan(volatility, NumOps.Zero))
+        {
+            return Intrinsic(spot, strike, isCall);
+        }
+
+        var (d1, d2) = D1D2(spot, strike, timeToExpiry, riskFreeRate, volatility);
+        var discountedStrike = NumOps.Multiply(strike, Discount(riskFreeRate, timeToExpiry));
+
+        if (isCall)
+        {
+            // C = S·N(d1) − K·e^(−rT)·N(d2)
+            return NumOps.Subtract(
+                NumOps.Multiply(spot, NormalCdf(d1)),
+                NumOps.Multiply(discountedStrike, NormalCdf(d2)));
+        }
+
+        // P = K·e^(−rT)·N(−d2) − S·N(−d1)
+        return NumOps.Subtract(
+            NumOps.Multiply(discountedStrike, NormalCdf(NumOps.Negate(d2))),
+            NumOps.Multiply(spot, NormalCdf(NumOps.Negate(d1))));
+    }
+
+    /// <summary>Delta — ∂Price/∂Spot. Call: N(d1); Put: N(d1) − 1.</summary>
+    public static T Delta(T spot, T strike, T timeToExpiry, T riskFreeRate, T volatility, bool isCall)
+    {
+        if (!NumOps.GreaterThan(timeToExpiry, NumOps.Zero) || !NumOps.GreaterThan(volatility, NumOps.Zero))
+        {
+            var itm = isCall ? NumOps.GreaterThan(spot, strike) : NumOps.LessThan(spot, strike);
+            return itm ? (isCall ? NumOps.One : NumOps.Negate(NumOps.One)) : NumOps.Zero;
+        }
+
+        var (d1, _) = D1D2(spot, strike, timeToExpiry, riskFreeRate, volatility);
+        var nd1 = NormalCdf(d1);
+        return isCall ? nd1 : NumOps.Subtract(nd1, NumOps.One);
+    }
+
+    /// <summary>Gamma — ∂²Price/∂Spot² (same for calls and puts): φ(d1) / (S·σ·√T).</summary>
+    public static T Gamma(T spot, T strike, T timeToExpiry, T riskFreeRate, T volatility)
+    {
+        if (!NumOps.GreaterThan(timeToExpiry, NumOps.Zero) || !NumOps.GreaterThan(volatility, NumOps.Zero))
+        {
+            return NumOps.Zero;
+        }
+
+        var (d1, _) = D1D2(spot, strike, timeToExpiry, riskFreeRate, volatility);
+        var denom = NumOps.Multiply(NumOps.Multiply(spot, volatility), NumOps.Sqrt(timeToExpiry));
+        return NumOps.Divide(NormalPdf(d1), denom);
+    }
+
+    /// <summary>Vega — ∂Price/∂σ (per 1.0 of vol, same for calls and puts): S·φ(d1)·√T.</summary>
+    public static T Vega(T spot, T strike, T timeToExpiry, T riskFreeRate, T volatility)
+    {
+        if (!NumOps.GreaterThan(timeToExpiry, NumOps.Zero) || !NumOps.GreaterThan(volatility, NumOps.Zero))
+        {
+            return NumOps.Zero;
+        }
+
+        var (d1, _) = D1D2(spot, strike, timeToExpiry, riskFreeRate, volatility);
+        return NumOps.Multiply(NumOps.Multiply(spot, NormalPdf(d1)), NumOps.Sqrt(timeToExpiry));
+    }
+
+    /// <summary>Theta — ∂Price/∂t (per year; typically negative). Call/put differ in the rate term.</summary>
+    public static T Theta(T spot, T strike, T timeToExpiry, T riskFreeRate, T volatility, bool isCall)
+    {
+        if (!NumOps.GreaterThan(timeToExpiry, NumOps.Zero) || !NumOps.GreaterThan(volatility, NumOps.Zero))
+        {
+            return NumOps.Zero;
+        }
+
+        var (d1, d2) = D1D2(spot, strike, timeToExpiry, riskFreeRate, volatility);
+        // −S·φ(d1)·σ / (2·√T)
+        var term1 = NumOps.Negate(NumOps.Divide(
+            NumOps.Multiply(NumOps.Multiply(spot, NormalPdf(d1)), volatility),
+            NumOps.Multiply(NumOps.FromDouble(2.0), NumOps.Sqrt(timeToExpiry))));
+        var rateTerm = NumOps.Multiply(NumOps.Multiply(riskFreeRate, strike), Discount(riskFreeRate, timeToExpiry));
+
+        return isCall
+            ? NumOps.Subtract(term1, NumOps.Multiply(rateTerm, NormalCdf(d2)))
+            : NumOps.Add(term1, NumOps.Multiply(rateTerm, NormalCdf(NumOps.Negate(d2))));
+    }
+
+    /// <summary>Rho — ∂Price/∂r (per 1.0 of rate). Call: K·T·e^(−rT)·N(d2); Put: −K·T·e^(−rT)·N(−d2).</summary>
+    public static T Rho(T spot, T strike, T timeToExpiry, T riskFreeRate, T volatility, bool isCall)
+    {
+        if (!NumOps.GreaterThan(timeToExpiry, NumOps.Zero) || !NumOps.GreaterThan(volatility, NumOps.Zero))
+        {
+            return NumOps.Zero;
+        }
+
+        var (_, d2) = D1D2(spot, strike, timeToExpiry, riskFreeRate, volatility);
+        var ktDiscount = NumOps.Multiply(NumOps.Multiply(strike, timeToExpiry), Discount(riskFreeRate, timeToExpiry));
+        return isCall
+            ? NumOps.Multiply(ktDiscount, NormalCdf(d2))
+            : NumOps.Negate(NumOps.Multiply(ktDiscount, NormalCdf(NumOps.Negate(d2))));
+    }
+
+    /// <summary>
+    /// Implied volatility from a market option price, via Newton-Raphson seeded with Brenner-Subrahmanyam,
+    /// falling back to bisection if a Newton step leaves the bracket. Returns the σ such that
+    /// <see cref="Price"/> matches <paramref name="marketPrice"/> within tolerance.
+    /// </summary>
+    public static T ImpliedVolatility(
+        T marketPrice, T spot, T strike, T timeToExpiry, T riskFreeRate, bool isCall,
+        int maxIterations = 100, double tolerance = 1e-8)
+    {
+        double price = NumOps.ToDouble(marketPrice);
+        double s = NumOps.ToDouble(spot), k = NumOps.ToDouble(strike), t = NumOps.ToDouble(timeToExpiry);
+        double r = NumOps.ToDouble(riskFreeRate);
+
+        // Brenner-Subrahmanyam closed-form seed for at-the-money, bracketed to a sane vol range.
+        // (Math.Max/Min instead of Math.Clamp, explicit finite check instead of double.IsFinite: net471.)
+        double sigma = Math.Sqrt(2.0 * Math.PI / Math.Max(t, 1e-12)) * (price / Math.Max(s, 1e-12));
+        var seed = !double.IsNaN(sigma) && !double.IsInfinity(sigma) ? sigma : 0.2;
+        sigma = Math.Max(1e-4, Math.Min(5.0, seed));
+        double low = 1e-4, high = 5.0;
+
+        for (var i = 0; i < maxIterations; i++)
+        {
+            double modelPrice = NumOps.ToDouble(Price(spot, strike, timeToExpiry,
+                riskFreeRate, NumOps.FromDouble(sigma), isCall));
+            double diff = modelPrice - price;
+            if (Math.Abs(diff) < tolerance)
+            {
+                break;
+            }
+
+            // Bracket update (price is monotone increasing in σ).
+            if (diff > 0) high = sigma; else low = sigma;
+
+            double vega = NumOps.ToDouble(Vega(spot, strike, timeToExpiry, riskFreeRate, NumOps.FromDouble(sigma)));
+            double next = vega > 1e-12 ? sigma - diff / vega : (low + high) / 2.0;
+            sigma = (next > low && next < high) ? next : (low + high) / 2.0;
+        }
+
+        return NumOps.FromDouble(sigma);
+    }
+
+    private static (T d1, T d2) D1D2(T spot, T strike, T timeToExpiry, T riskFreeRate, T volatility)
+    {
+        var sqrtT = NumOps.Sqrt(timeToExpiry);
+        var volSqrtT = NumOps.Multiply(volatility, sqrtT);
+        // d1 = [ln(S/K) + (r + σ²/2)·T] / (σ·√T)
+        var lnMoneyness = NumOps.Log(NumOps.Divide(spot, strike));
+        var drift = NumOps.Multiply(
+            NumOps.Add(riskFreeRate, NumOps.Multiply(NumOps.FromDouble(0.5), NumOps.Multiply(volatility, volatility))),
+            timeToExpiry);
+        var d1 = NumOps.Divide(NumOps.Add(lnMoneyness, drift), volSqrtT);
+        var d2 = NumOps.Subtract(d1, volSqrtT);
+        return (d1, d2);
+    }
+
+    private static T Discount(T riskFreeRate, T timeToExpiry) =>
+        NumOps.Exp(NumOps.Negate(NumOps.Multiply(riskFreeRate, timeToExpiry)));
+
+    private static T Intrinsic(T spot, T strike, bool isCall)
+    {
+        var diff = isCall ? NumOps.Subtract(spot, strike) : NumOps.Subtract(strike, spot);
+        return NumOps.GreaterThan(diff, NumOps.Zero) ? diff : NumOps.Zero;
+    }
+
+    /// <summary>Standard normal PDF φ(x) = e^(−x²/2) / √(2π).</summary>
+    private static T NormalPdf(T x)
+    {
+        var invSqrt2Pi = NumOps.FromDouble(0.3989422804014327); // 1/√(2π)
+        var exponent = NumOps.Negate(NumOps.Multiply(NumOps.FromDouble(0.5), NumOps.Multiply(x, x)));
+        return NumOps.Multiply(invSqrt2Pi, NumOps.Exp(exponent));
+    }
+
+    /// <summary>Standard normal CDF N(x) = ½·(1 + erf(x/√2)).</summary>
+    private static T NormalCdf(T x)
+    {
+        var arg = NumOps.Divide(x, NumOps.FromDouble(1.4142135623730951)); // √2
+        return NumOps.Multiply(NumOps.FromDouble(0.5), NumOps.Add(NumOps.One, Erf(arg)));
+    }
+
+    /// <summary>Abramowitz &amp; Stegun 7.1.26 erf approximation (|error| &lt; 1.5e-7).</summary>
+    private static T Erf(T x)
+    {
+        var sign = NumOps.GreaterThanOrEquals(x, NumOps.Zero) ? NumOps.One : NumOps.Negate(NumOps.One);
+        var ax = NumOps.Abs(x);
+
+        var t = NumOps.Divide(NumOps.One,
+            NumOps.Add(NumOps.One, NumOps.Multiply(NumOps.FromDouble(0.3275911), ax)));
+
+        // Horner over (a1..a5)
+        var poly = NumOps.FromDouble(1.061405429);
+        poly = NumOps.Add(NumOps.FromDouble(-1.453152027), NumOps.Multiply(poly, t));
+        poly = NumOps.Add(NumOps.FromDouble(1.421413741), NumOps.Multiply(poly, t));
+        poly = NumOps.Add(NumOps.FromDouble(-0.284496736), NumOps.Multiply(poly, t));
+        poly = NumOps.Add(NumOps.FromDouble(0.254829592), NumOps.Multiply(poly, t));
+        poly = NumOps.Multiply(poly, t);
+
+        var expTerm = NumOps.Exp(NumOps.Negate(NumOps.Multiply(ax, ax)));
+        var erf = NumOps.Subtract(NumOps.One, NumOps.Multiply(poly, expTerm));
+        return NumOps.Multiply(sign, erf);
+    }
+}

--- a/src/Finance/Options/BlackScholes.cs
+++ b/src/Finance/Options/BlackScholes.cs
@@ -1,4 +1,5 @@
 using System;
+using AiDotNet.Finance.Interfaces;
 using AiDotNet.Helpers;
 using AiDotNet.Interfaces;
 
@@ -22,9 +23,34 @@ namespace AiDotNet.Finance.Options;
 /// rate) — which traders use to size positions and hedge risk.</para>
 /// </remarks>
 /// <typeparam name="T">Numeric type (float/double).</typeparam>
-public static class BlackScholes<T>
+/// <remarks>
+/// Implements <see cref="IOptionPricer{T}"/> so it can be injected as a swappable pricing strategy
+/// (the default) into models that need option valuation; the static methods remain available for
+/// direct, allocation-free use.
+/// </remarks>
+public class BlackScholes<T> : IOptionPricer<T>
 {
     private static readonly INumericOperations<T> NumOps = MathHelper.GetNumericOperations<T>();
+
+    /// <summary>Shared stateless default instance for injection as an <see cref="IOptionPricer{T}"/>.</summary>
+    public static IOptionPricer<T> Default { get; } = new BlackScholes<T>();
+
+    // Explicit IOptionPricer<T> members delegate to the static closed forms (no behavior change;
+    // explicit implementation avoids any clash with the like-named static methods).
+    T IOptionPricer<T>.Price(T spot, T strike, T timeToExpiry, T riskFreeRate, T volatility, bool isCall)
+        => Price(spot, strike, timeToExpiry, riskFreeRate, volatility, isCall);
+    T IOptionPricer<T>.Delta(T spot, T strike, T timeToExpiry, T riskFreeRate, T volatility, bool isCall)
+        => Delta(spot, strike, timeToExpiry, riskFreeRate, volatility, isCall);
+    T IOptionPricer<T>.Gamma(T spot, T strike, T timeToExpiry, T riskFreeRate, T volatility)
+        => Gamma(spot, strike, timeToExpiry, riskFreeRate, volatility);
+    T IOptionPricer<T>.Vega(T spot, T strike, T timeToExpiry, T riskFreeRate, T volatility)
+        => Vega(spot, strike, timeToExpiry, riskFreeRate, volatility);
+    T IOptionPricer<T>.Theta(T spot, T strike, T timeToExpiry, T riskFreeRate, T volatility, bool isCall)
+        => Theta(spot, strike, timeToExpiry, riskFreeRate, volatility, isCall);
+    T IOptionPricer<T>.Rho(T spot, T strike, T timeToExpiry, T riskFreeRate, T volatility, bool isCall)
+        => Rho(spot, strike, timeToExpiry, riskFreeRate, volatility, isCall);
+    T IOptionPricer<T>.ImpliedVolatility(T marketPrice, T spot, T strike, T timeToExpiry, T riskFreeRate, bool isCall, int maxIterations, double tolerance)
+        => ImpliedVolatility(marketPrice, spot, strike, timeToExpiry, riskFreeRate, isCall, maxIterations, tolerance);
 
     /// <summary>Black-Scholes price of a European call (<paramref name="isCall"/> = true) or put.</summary>
     /// <param name="spot">Current underlying price S.</param>

--- a/src/Finance/Options/BlackScholes.cs
+++ b/src/Finance/Options/BlackScholes.cs
@@ -35,10 +35,22 @@ public static class BlackScholes<T>
     /// <param name="isCall">True for a call, false for a put.</param>
     public static T Price(T spot, T strike, T timeToExpiry, T riskFreeRate, T volatility, bool isCall)
     {
-        // At/after expiry, or with degenerate vol/time, value collapses to the discounted intrinsic.
-        if (!NumOps.GreaterThan(timeToExpiry, NumOps.Zero) || !NumOps.GreaterThan(volatility, NumOps.Zero))
+        // At/after expiry the value collapses to the (undiscounted) intrinsic.
+        if (!NumOps.GreaterThan(timeToExpiry, NumOps.Zero))
         {
             return Intrinsic(spot, strike, isCall);
+        }
+
+        // Zero-volatility limit at positive maturity: the underlying grows
+        // deterministically at the risk-free rate, so the payoff is the forward
+        // intrinsic against the DISCOUNTED strike, max(S - K·e^(-rT), 0) for a
+        // call (put analog). Returning the undiscounted intrinsic here is wrong
+        // whenever r != 0.
+        if (!NumOps.GreaterThan(volatility, NumOps.Zero))
+        {
+            var discounted = NumOps.Multiply(strike, Discount(riskFreeRate, timeToExpiry));
+            var payoff = isCall ? NumOps.Subtract(spot, discounted) : NumOps.Subtract(discounted, spot);
+            return NumOps.GreaterThan(payoff, NumOps.Zero) ? payoff : NumOps.Zero;
         }
 
         var (d1, d2) = D1D2(spot, strike, timeToExpiry, riskFreeRate, volatility);
@@ -141,9 +153,22 @@ public static class BlackScholes<T>
         T marketPrice, T spot, T strike, T timeToExpiry, T riskFreeRate, bool isCall,
         int maxIterations = 100, double tolerance = 1e-8)
     {
+        if (!NumOps.GreaterThan(timeToExpiry, NumOps.Zero))
+            throw new ArgumentOutOfRangeException(nameof(timeToExpiry), "timeToExpiry must be > 0 for implied volatility.");
+
         double price = NumOps.ToDouble(marketPrice);
         double s = NumOps.ToDouble(spot), k = NumOps.ToDouble(strike), t = NumOps.ToDouble(timeToExpiry);
         double r = NumOps.ToDouble(riskFreeRate);
+
+        // Reject prices outside the no-arbitrage bounds up front: a European option
+        // price must lie in [max(±(S − K·e^(−rT)), 0), upper] where upper is S for a
+        // call and K·e^(−rT) for a put — otherwise no real σ reproduces it.
+        double discountedK = k * Math.Exp(-r * t);
+        double lowerBound = isCall ? Math.Max(s - discountedK, 0.0) : Math.Max(discountedK - s, 0.0);
+        double upperBound = isCall ? s : discountedK;
+        if (double.IsNaN(price) || double.IsInfinity(price) || price < lowerBound || price > upperBound)
+            throw new ArgumentOutOfRangeException(nameof(marketPrice),
+                "marketPrice violates the European no-arbitrage bounds; no implied volatility exists.");
 
         // Brenner-Subrahmanyam closed-form seed for at-the-money, bracketed to a sane vol range.
         // (Math.Max/Min instead of Math.Clamp, explicit finite check instead of double.IsFinite: net471.)
@@ -151,6 +176,7 @@ public static class BlackScholes<T>
         var seed = !double.IsNaN(sigma) && !double.IsInfinity(sigma) ? sigma : 0.2;
         sigma = Math.Max(1e-4, Math.Min(5.0, seed));
         double low = 1e-4, high = 5.0;
+        var converged = false;
 
         for (var i = 0; i < maxIterations; i++)
         {
@@ -159,6 +185,7 @@ public static class BlackScholes<T>
             double diff = modelPrice - price;
             if (Math.Abs(diff) < tolerance)
             {
+                converged = true;
                 break;
             }
 
@@ -170,11 +197,20 @@ public static class BlackScholes<T>
             sigma = (next > low && next < high) ? next : (low + high) / 2.0;
         }
 
+        // Fail loudly rather than silently returning an unconverged σ in production.
+        if (!converged)
+            throw new InvalidOperationException(
+                "Implied-volatility solver did not converge within maxIterations; the price may be too close to a bound.");
+
         return NumOps.FromDouble(sigma);
     }
 
     private static (T d1, T d2) D1D2(T spot, T strike, T timeToExpiry, T riskFreeRate, T volatility)
     {
+        if (!NumOps.GreaterThan(spot, NumOps.Zero))
+            throw new ArgumentOutOfRangeException(nameof(spot), "spot must be > 0.");
+        if (!NumOps.GreaterThan(strike, NumOps.Zero))
+            throw new ArgumentOutOfRangeException(nameof(strike), "strike must be > 0.");
         var sqrtT = NumOps.Sqrt(timeToExpiry);
         var volSqrtT = NumOps.Multiply(volatility, sqrtT);
         // d1 = [ln(S/K) + (r + σ²/2)·T] / (σ·√T)

--- a/src/Finance/Portfolio/KellyCriterion.cs
+++ b/src/Finance/Portfolio/KellyCriterion.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using AiDotNet.Finance.Interfaces;
 using AiDotNet.Helpers;
 using AiDotNet.Interfaces;
 
@@ -21,9 +22,22 @@ namespace AiDotNet.Finance.Portfolio;
 /// don't take the trade."</para>
 /// </remarks>
 /// <typeparam name="T">Numeric type (float/double).</typeparam>
-public static class KellyCriterion<T>
+/// <remarks>
+/// Implements <see cref="IPositionSizer{T}"/> so it can be injected as the default, swappable sizing
+/// strategy into trading/portfolio models; the static methods remain available for direct use.
+/// </remarks>
+public class KellyCriterion<T> : IPositionSizer<T>
 {
     private static readonly INumericOperations<T> NumOps = MathHelper.GetNumericOperations<T>();
+
+    /// <summary>Shared stateless default instance for injection as an <see cref="IPositionSizer{T}"/>.</summary>
+    public static IPositionSizer<T> Default { get; } = new KellyCriterion<T>();
+
+    // Explicit IPositionSizer<T> members delegate to the static implementations.
+    T IPositionSizer<T>.Discrete(T winProbability, T winLossRatio) => Discrete(winProbability, winLossRatio);
+    T IPositionSizer<T>.Continuous(T expectedReturn, T variance) => Continuous(expectedReturn, variance);
+    T IPositionSizer<T>.Fractional(T baseFraction, double fraction) => Fractional(baseFraction, fraction);
+    T IPositionSizer<T>.FromReturns(IEnumerable<T> returns, double fraction) => FromReturns(returns, fraction);
 
     /// <summary>
     /// Discrete Kelly fraction: f* = p − (1 − p) / b, where <paramref name="winProbability"/> is p and

--- a/src/Finance/Portfolio/KellyCriterion.cs
+++ b/src/Finance/Portfolio/KellyCriterion.cs
@@ -1,0 +1,95 @@
+using System;
+using System.Collections.Generic;
+using AiDotNet.Helpers;
+using AiDotNet.Interfaces;
+
+namespace AiDotNet.Finance.Portfolio;
+
+/// <summary>
+/// Kelly-criterion position sizing — the bet fraction that maximizes long-run log-growth of capital.
+/// </summary>
+/// <remarks>
+/// <para>
+/// AiDotNet's portfolio optimizers cover weight allocation (mean-variance, HRP, Black-Litterman) but
+/// not Kelly bet sizing. This fills that gap with the two standard forms — discrete (win probability +
+/// payoff odds) and continuous (mean / variance of returns) — plus fractional Kelly, which is what
+/// practitioners actually use because full Kelly is famously over-aggressive.
+/// </para>
+/// <para><b>For Beginners:</b> Kelly tells you what fraction of your capital to put on a trade to grow
+/// wealth fastest over many trades. Bet more than Kelly and you risk ruin; bet a fraction of it
+/// ("half-Kelly") for much lower volatility at a small growth cost. A negative Kelly means "no edge —
+/// don't take the trade."</para>
+/// </remarks>
+/// <typeparam name="T">Numeric type (float/double).</typeparam>
+public static class KellyCriterion<T>
+{
+    private static readonly INumericOperations<T> NumOps = MathHelper.GetNumericOperations<T>();
+
+    /// <summary>
+    /// Discrete Kelly fraction: f* = p − (1 − p) / b, where <paramref name="winProbability"/> is p and
+    /// <paramref name="winLossRatio"/> is b (net payoff on a win per unit risked on a loss). Returns 0
+    /// when there is no edge (negative) or the inputs are degenerate.
+    /// </summary>
+    public static T Discrete(T winProbability, T winLossRatio)
+    {
+        if (!NumOps.GreaterThan(winLossRatio, NumOps.Zero))
+        {
+            return NumOps.Zero;
+        }
+
+        var lossProbability = NumOps.Subtract(NumOps.One, winProbability);
+        var kelly = NumOps.Subtract(winProbability, NumOps.Divide(lossProbability, winLossRatio));
+        return NumOps.GreaterThan(kelly, NumOps.Zero) ? kelly : NumOps.Zero;
+    }
+
+    /// <summary>
+    /// Continuous Kelly fraction for (approximately) Gaussian returns: f* = μ / σ², where
+    /// <paramref name="expectedReturn"/> is μ and <paramref name="variance"/> is σ². This is the
+    /// vol-targeted exposure that maximizes expected log-growth. Returns 0 for non-positive variance.
+    /// </summary>
+    public static T Continuous(T expectedReturn, T variance)
+    {
+        return NumOps.GreaterThan(variance, NumOps.Zero)
+            ? NumOps.Divide(expectedReturn, variance)
+            : NumOps.Zero;
+    }
+
+    /// <summary>
+    /// Fractional Kelly: <paramref name="kellyFraction"/> scaled by <paramref name="fraction"/> (e.g.
+    /// 0.5 for half-Kelly). The standard risk-managed form — much lower drawdown for a small growth cost.
+    /// </summary>
+    public static T Fractional(T kellyFraction, double fraction)
+        => NumOps.Multiply(kellyFraction, NumOps.FromDouble(fraction));
+
+    /// <summary>
+    /// Continuous Kelly estimated from a return series: computes the sample mean and (population)
+    /// variance of <paramref name="returns"/> and applies <see cref="Continuous"/>. Optionally scaled by
+    /// <paramref name="fraction"/> (default 1.0 = full Kelly).
+    /// </summary>
+    public static T FromReturns(IEnumerable<T> returns, double fraction = 1.0)
+    {
+        var count = 0;
+        var sum = NumOps.Zero;
+        foreach (var r in returns)
+        {
+            sum = NumOps.Add(sum, r);
+            count++;
+        }
+
+        if (count < 2)
+        {
+            return NumOps.Zero;
+        }
+
+        var mean = NumOps.Divide(sum, NumOps.FromDouble(count));
+        var sse = NumOps.Zero;
+        foreach (var r in returns)
+        {
+            var d = NumOps.Subtract(r, mean);
+            sse = NumOps.Add(sse, NumOps.Multiply(d, d));
+        }
+
+        var variance = NumOps.Divide(sse, NumOps.FromDouble(count));
+        return Fractional(Continuous(mean, variance), fraction);
+    }
+}

--- a/src/Finance/Portfolio/KellyCriterion.cs
+++ b/src/Finance/Portfolio/KellyCriterion.cs
@@ -32,6 +32,13 @@ public static class KellyCriterion<T>
     /// </summary>
     public static T Discrete(T winProbability, T winLossRatio)
     {
+        // winProbability ∈ [0, 1]: reject out-of-range probabilities (expressed via
+        // GreaterThan/LessThan so it works for every INumericOperations<T>).
+        if (NumOps.LessThan(winProbability, NumOps.Zero) || NumOps.GreaterThan(winProbability, NumOps.One))
+        {
+            throw new ArgumentOutOfRangeException(nameof(winProbability), "winProbability must be in [0, 1].");
+        }
+
         if (!NumOps.GreaterThan(winLossRatio, NumOps.Zero))
         {
             return NumOps.Zero;
@@ -68,22 +75,31 @@ public static class KellyCriterion<T>
     /// </summary>
     public static T FromReturns(IEnumerable<T> returns, double fraction = 1.0)
     {
-        var count = 0;
-        var sum = NumOps.Zero;
-        foreach (var r in returns)
+        if (returns is null)
         {
-            sum = NumOps.Add(sum, r);
-            count++;
+            throw new ArgumentNullException(nameof(returns));
         }
 
+        // Materialize once: the source may be a deferred / non-repeatable
+        // enumerable (a LINQ query, a generator), so enumerating it twice could
+        // recompute or yield nothing the second pass.
+        var series = returns as IReadOnlyList<T> ?? new List<T>(returns);
+
+        var count = series.Count;
         if (count < 2)
         {
             return NumOps.Zero;
         }
 
+        var sum = NumOps.Zero;
+        foreach (var r in series)
+        {
+            sum = NumOps.Add(sum, r);
+        }
+
         var mean = NumOps.Divide(sum, NumOps.FromDouble(count));
         var sse = NumOps.Zero;
-        foreach (var r in returns)
+        foreach (var r in series)
         {
             var d = NumOps.Subtract(r, mean);
             sse = NumOps.Add(sse, NumOps.Multiply(d, d));

--- a/src/Finance/Portfolio/MarkowitzOptimizer.cs
+++ b/src/Finance/Portfolio/MarkowitzOptimizer.cs
@@ -1,4 +1,5 @@
 using System;
+using AiDotNet.Finance.Interfaces;
 using AiDotNet.Helpers;
 using AiDotNet.Interfaces;
 
@@ -24,9 +25,24 @@ namespace AiDotNet.Finance.Portfolio;
 /// hits a return you specify. All three allow negative weights (short selling) and sum to 100%.</para>
 /// </remarks>
 /// <typeparam name="T">Numeric type (float/double).</typeparam>
-public static class MarkowitzOptimizer<T>
+/// <remarks>
+/// Implements <see cref="IMeanVarianceOptimizer{T}"/> so the closed-form solver can be injected as the
+/// default, swappable analytic optimizer (e.g. as a baseline alongside the neural
+/// <see cref="IPortfolioOptimizer{T}"/> family); the static methods remain available for direct use.
+/// </remarks>
+public class MarkowitzOptimizer<T> : IMeanVarianceOptimizer<T>
 {
     private static readonly INumericOperations<T> NumOps = MathHelper.GetNumericOperations<T>();
+
+    /// <summary>Shared stateless default instance for injection as an <see cref="IMeanVarianceOptimizer{T}"/>.</summary>
+    public static IMeanVarianceOptimizer<T> Default { get; } = new MarkowitzOptimizer<T>();
+
+    // Explicit IMeanVarianceOptimizer<T> members delegate to the static closed forms.
+    Vector<T> IMeanVarianceOptimizer<T>.MinimumVariance(Matrix<T> covariance) => MinimumVariance(covariance);
+    Vector<T> IMeanVarianceOptimizer<T>.Tangency(Vector<T> expectedReturns, Matrix<T> covariance, T riskFreeRate)
+        => Tangency(expectedReturns, covariance, riskFreeRate);
+    Vector<T> IMeanVarianceOptimizer<T>.TargetReturn(Vector<T> expectedReturns, Matrix<T> covariance, T targetReturn)
+        => TargetReturn(expectedReturns, covariance, targetReturn);
 
     /// <summary>
     /// Global minimum-variance portfolio: w = (Σ⁻¹·1) / (1ᵀ·Σ⁻¹·1). The fully-invested (weights sum to 1)

--- a/src/Finance/Portfolio/MarkowitzOptimizer.cs
+++ b/src/Finance/Portfolio/MarkowitzOptimizer.cs
@@ -1,0 +1,203 @@
+using System;
+using AiDotNet.Helpers;
+using AiDotNet.Interfaces;
+
+namespace AiDotNet.Finance.Portfolio;
+
+/// <summary>
+/// Closed-form Markowitz mean-variance portfolio optimization: the global minimum-variance portfolio,
+/// the tangency (maximum-Sharpe) portfolio, and the efficient-frontier target-return portfolio.
+/// </summary>
+/// <remarks>
+/// <para>
+/// AiDotNet's portfolio optimizers are <i>neural</i> (they learn weights from market data through a
+/// trained network). The classic analytic solutions — the ones you can write down with a covariance
+/// inverse and no training — were missing. This fills that gap with the standard unconstrained
+/// (long/short-allowed, fully-invested) closed forms. Each is just a linear solve against the covariance
+/// matrix, reusing AiDotNet's <see cref="Matrix{T}.Inverse"/> rather than hand-rolling elimination.
+/// </para>
+/// <para><b>For Beginners:</b> "Mean-variance" optimization picks how much to put in each asset by
+/// trading off expected return against risk (variance), using how the assets move together (the
+/// covariance matrix). The <i>minimum-variance</i> portfolio is the lowest-risk fully-invested mix and
+/// ignores returns entirely. The <i>tangency</i> portfolio is the mix with the best risk-adjusted return
+/// (highest Sharpe ratio) given a risk-free rate. <i>Target-return</i> finds the lowest-risk mix that
+/// hits a return you specify. All three allow negative weights (short selling) and sum to 100%.</para>
+/// </remarks>
+/// <typeparam name="T">Numeric type (float/double).</typeparam>
+public static class MarkowitzOptimizer<T>
+{
+    private static readonly INumericOperations<T> NumOps = MathHelper.GetNumericOperations<T>();
+
+    /// <summary>
+    /// Global minimum-variance portfolio: w = (Σ⁻¹·1) / (1ᵀ·Σ⁻¹·1). The fully-invested (weights sum to 1)
+    /// mix with the lowest possible variance; expected returns are not used.
+    /// </summary>
+    /// <param name="covariance">The N×N asset return covariance matrix Σ (symmetric, positive-definite).</param>
+    /// <returns>The N optimal weights, summing to 1.</returns>
+    public static Vector<T> MinimumVariance(Matrix<T> covariance)
+    {
+        var n = ValidateSquare(covariance);
+        var inv = covariance.Inverse();
+
+        // z = Σ⁻¹·1  (the row sums of the inverse), then normalize so the weights sum to 1.
+        var z = RowSums(inv, n);
+        return Normalize(z);
+    }
+
+    /// <summary>
+    /// Tangency (maximum-Sharpe) portfolio: w ∝ Σ⁻¹·(μ − rf·1), normalized to sum to 1. The fully-invested
+    /// mix that maximizes the Sharpe ratio for the given risk-free rate.
+    /// </summary>
+    /// <param name="expectedReturns">The N expected asset returns μ.</param>
+    /// <param name="covariance">The N×N asset return covariance matrix Σ.</param>
+    /// <param name="riskFreeRate">The risk-free rate rf (in the same units as the returns).</param>
+    /// <returns>The N optimal weights, summing to 1.</returns>
+    public static Vector<T> Tangency(Vector<T> expectedReturns, Matrix<T> covariance, T riskFreeRate)
+    {
+        var n = ValidateSquare(covariance);
+        if (expectedReturns.Length != n)
+        {
+            throw new ArgumentException(
+                $"expectedReturns length ({expectedReturns.Length}) must match covariance dimension ({n}).",
+                nameof(expectedReturns));
+        }
+
+        // excess = μ − rf·1
+        var excess = new Vector<T>(n);
+        for (var i = 0; i < n; i++)
+        {
+            excess[i] = NumOps.Subtract(expectedReturns[i], riskFreeRate);
+        }
+
+        // z = Σ⁻¹·(μ − rf·1), then normalize so the weights sum to 1.
+        var z = covariance.Inverse().Multiply(excess);
+        return Normalize(z);
+    }
+
+    /// <summary>
+    /// Efficient-frontier portfolio for a given <paramref name="targetReturn"/>, via the standard
+    /// two-fund (Merton) Lagrangian: the minimum-variance fully-invested portfolio whose expected return
+    /// equals the target. Weights are a blend of two characteristic portfolios and sum to 1.
+    /// </summary>
+    /// <param name="expectedReturns">The N expected asset returns μ.</param>
+    /// <param name="covariance">The N×N asset return covariance matrix Σ.</param>
+    /// <param name="targetReturn">The desired portfolio expected return.</param>
+    /// <returns>The N optimal weights, summing to 1.</returns>
+    public static Vector<T> TargetReturn(Vector<T> expectedReturns, Matrix<T> covariance, T targetReturn)
+    {
+        var n = ValidateSquare(covariance);
+        if (expectedReturns.Length != n)
+        {
+            throw new ArgumentException(
+                $"expectedReturns length ({expectedReturns.Length}) must match covariance dimension ({n}).",
+                nameof(expectedReturns));
+        }
+
+        var inv = covariance.Inverse();
+
+        // Two characteristic portfolios: a = Σ⁻¹·1, b = Σ⁻¹·μ.
+        var a = RowSums(inv, n);            // Σ⁻¹·1
+        var b = inv.Multiply(expectedReturns); // Σ⁻¹·μ
+
+        // Scalar invariants of the frontier (Merton's notation):
+        //   A = 1ᵀΣ⁻¹μ,  B = μᵀΣ⁻¹μ,  C = 1ᵀΣ⁻¹1,  D = B·C − A².
+        var capA = NumOps.Zero;
+        var capB = NumOps.Zero;
+        var capC = NumOps.Zero;
+        for (var i = 0; i < n; i++)
+        {
+            capA = NumOps.Add(capA, b[i]);                               // sum of Σ⁻¹·μ  = 1ᵀΣ⁻¹μ
+            capB = NumOps.Add(capB, NumOps.Multiply(expectedReturns[i], b[i])); // μᵀΣ⁻¹μ
+            capC = NumOps.Add(capC, a[i]);                               // sum of Σ⁻¹·1  = 1ᵀΣ⁻¹1
+        }
+
+        var capD = NumOps.Subtract(NumOps.Multiply(capB, capC), NumOps.Multiply(capA, capA));
+        if (!IsUsable(capD))
+        {
+            throw new InvalidOperationException(
+                "Degenerate efficient frontier (B·C − A² is non-positive); expected returns may be collinear.");
+        }
+
+        // Lagrange multipliers for the equality-constrained QP:
+        //   λ = (C·target − A) / D,  γ = (B − A·target) / D.
+        // Weights:  w = λ·(Σ⁻¹·μ) + γ·(Σ⁻¹·1) = λ·b + γ·a.
+        var lambda = NumOps.Divide(NumOps.Subtract(NumOps.Multiply(capC, targetReturn), capA), capD);
+        var gamma = NumOps.Divide(NumOps.Subtract(capB, NumOps.Multiply(capA, targetReturn)), capD);
+
+        var w = new Vector<T>(n);
+        for (var i = 0; i < n; i++)
+        {
+            w[i] = NumOps.Add(NumOps.Multiply(lambda, b[i]), NumOps.Multiply(gamma, a[i]));
+        }
+
+        // By construction these already sum to 1; renormalize to clean up floating-point drift.
+        return Normalize(w);
+    }
+
+    /// <summary>Σ⁻¹·1 — the row sums of the inverse covariance (equivalently Σ⁻¹ times the all-ones vector).</summary>
+    private static Vector<T> RowSums(Matrix<T> inverse, int n)
+    {
+        var result = new Vector<T>(n);
+        for (var i = 0; i < n; i++)
+        {
+            var sum = NumOps.Zero;
+            for (var j = 0; j < n; j++)
+            {
+                sum = NumOps.Add(sum, inverse[i, j]);
+            }
+
+            result[i] = sum;
+        }
+
+        return result;
+    }
+
+    /// <summary>Scales a weight vector so its entries sum to 1 (fully invested).</summary>
+    private static Vector<T> Normalize(Vector<T> weights)
+    {
+        var total = NumOps.Zero;
+        for (var i = 0; i < weights.Length; i++)
+        {
+            total = NumOps.Add(total, weights[i]);
+        }
+
+        if (!IsUsable(NumOps.Abs(total)))
+        {
+            throw new InvalidOperationException(
+                "Portfolio weights sum to (near) zero; the covariance matrix may be singular or ill-conditioned.");
+        }
+
+        var result = new Vector<T>(weights.Length);
+        for (var i = 0; i < weights.Length; i++)
+        {
+            result[i] = NumOps.Divide(weights[i], total);
+        }
+
+        return result;
+    }
+
+    /// <summary>Validates that the covariance is square and non-empty; returns its dimension N.</summary>
+    private static int ValidateSquare(Matrix<T> covariance)
+    {
+        if (covariance.Rows == 0 || covariance.Rows != covariance.Columns)
+        {
+            throw new ArgumentException(
+                $"Covariance must be a non-empty square matrix; got {covariance.Rows}x{covariance.Columns}.",
+                nameof(covariance));
+        }
+
+        return covariance.Rows;
+    }
+
+    /// <summary>True if a value is strictly positive and finite (net471-safe: no double.IsFinite).</summary>
+    private static bool IsUsable(T value)
+    {
+        if (!NumOps.GreaterThan(value, NumOps.Zero))
+        {
+            return false;
+        }
+
+        var d = NumOps.ToDouble(value);
+        return !double.IsNaN(d) && !double.IsInfinity(d);
+    }
+}

--- a/src/Finance/Portfolio/MarkowitzOptimizer.cs
+++ b/src/Finance/Portfolio/MarkowitzOptimizer.cs
@@ -55,6 +55,11 @@ public static class MarkowitzOptimizer<T>
     public static Vector<T> Tangency(Vector<T> expectedReturns, Matrix<T> covariance, T riskFreeRate)
     {
         var n = ValidateSquare(covariance);
+        if (expectedReturns is null)
+        {
+            throw new ArgumentNullException(nameof(expectedReturns));
+        }
+
         if (expectedReturns.Length != n)
         {
             throw new ArgumentException(
@@ -86,6 +91,11 @@ public static class MarkowitzOptimizer<T>
     public static Vector<T> TargetReturn(Vector<T> expectedReturns, Matrix<T> covariance, T targetReturn)
     {
         var n = ValidateSquare(covariance);
+        if (expectedReturns is null)
+        {
+            throw new ArgumentNullException(nameof(expectedReturns));
+        }
+
         if (expectedReturns.Length != n)
         {
             throw new ArgumentException(
@@ -179,6 +189,11 @@ public static class MarkowitzOptimizer<T>
     /// <summary>Validates that the covariance is square and non-empty; returns its dimension N.</summary>
     private static int ValidateSquare(Matrix<T> covariance)
     {
+        if (covariance is null)
+        {
+            throw new ArgumentNullException(nameof(covariance));
+        }
+
         if (covariance.Rows == 0 || covariance.Rows != covariance.Columns)
         {
             throw new ArgumentException(

--- a/src/Finance/Risk/RiskRatios.cs
+++ b/src/Finance/Risk/RiskRatios.cs
@@ -1,0 +1,137 @@
+using System;
+using System.Collections.Generic;
+using AiDotNet.Helpers;
+using AiDotNet.Interfaces;
+
+namespace AiDotNet.Finance.Risk;
+
+/// <summary>
+/// Risk-adjusted performance ratios from a periodic return series: Sharpe, Sortino, and Calmar.
+/// </summary>
+/// <remarks>
+/// <para>
+/// AiDotNet exposes Sharpe on portfolio optimizers and trading agents, but Sortino (downside-only) and
+/// Calmar (return-over-max-drawdown) were missing as standalone, series-based utilities. These let any
+/// forecaster/strategy backtest be scored on risk-adjusted return without a portfolio or agent object.
+/// </para>
+/// <para><b>For Beginners:</b> Sharpe divides average return by total volatility; Sortino only counts
+/// <i>downside</i> volatility (it doesn't punish upside swings); Calmar divides annualized return by the
+/// worst peak-to-trough drawdown. Higher is better for all three.</para>
+/// </remarks>
+/// <typeparam name="T">Numeric type (float/double).</typeparam>
+public static class RiskRatios<T>
+{
+    private static readonly INumericOperations<T> NumOps = MathHelper.GetNumericOperations<T>();
+
+    /// <summary>Annualized Sharpe ratio: (mean(excess) / std(excess)) · √periodsPerYear.</summary>
+    public static T Sharpe(IReadOnlyList<T> returns, double riskFreePerPeriod = 0.0, int periodsPerYear = 252)
+    {
+        if (returns.Count < 2)
+        {
+            return NumOps.Zero;
+        }
+
+        var rf = NumOps.FromDouble(riskFreePerPeriod);
+        var (mean, std) = MeanStd(returns, rf);
+        if (!NumOps.GreaterThan(std, NumOps.Zero))
+        {
+            return NumOps.Zero;
+        }
+
+        return NumOps.Multiply(NumOps.Divide(mean, std), NumOps.FromDouble(Math.Sqrt(periodsPerYear)));
+    }
+
+    /// <summary>Annualized Sortino ratio: (mean(excess) / downsideDeviation) · √periodsPerYear.</summary>
+    public static T Sortino(IReadOnlyList<T> returns, double riskFreePerPeriod = 0.0, int periodsPerYear = 252)
+    {
+        if (returns.Count < 2)
+        {
+            return NumOps.Zero;
+        }
+
+        var rf = NumOps.FromDouble(riskFreePerPeriod);
+        var mean = NumOps.Zero;
+        var downsideSq = NumOps.Zero;
+        var n = NumOps.FromDouble(returns.Count);
+        foreach (var r in returns)
+        {
+            var excess = NumOps.Subtract(r, rf);
+            mean = NumOps.Add(mean, excess);
+            if (!NumOps.GreaterThan(excess, NumOps.Zero))
+            {
+                downsideSq = NumOps.Add(downsideSq, NumOps.Multiply(excess, excess));
+            }
+        }
+
+        mean = NumOps.Divide(mean, n);
+        var downsideDev = NumOps.Sqrt(NumOps.Divide(downsideSq, n));
+        if (!NumOps.GreaterThan(downsideDev, NumOps.Zero))
+        {
+            return NumOps.Zero;
+        }
+
+        return NumOps.Multiply(NumOps.Divide(mean, downsideDev), NumOps.FromDouble(Math.Sqrt(periodsPerYear)));
+    }
+
+    /// <summary>
+    /// Calmar ratio: annualized return / maximum drawdown, computed from a periodic return series by
+    /// compounding an equity curve. Returns 0 when there is no drawdown.
+    /// </summary>
+    public static T Calmar(IReadOnlyList<T> returns, int periodsPerYear = 252)
+    {
+        if (returns.Count < 2)
+        {
+            return NumOps.Zero;
+        }
+
+        // Compound an equity curve, tracking the running peak and the worst drawdown.
+        var equity = 1.0;
+        var peak = 1.0;
+        var maxDrawdown = 0.0;
+        foreach (var r in returns)
+        {
+            equity *= 1.0 + NumOps.ToDouble(r);
+            if (equity > peak)
+            {
+                peak = equity;
+            }
+
+            var drawdown = peak > 0 ? (peak - equity) / peak : 0.0;
+            if (drawdown > maxDrawdown)
+            {
+                maxDrawdown = drawdown;
+            }
+        }
+
+        if (maxDrawdown <= 0.0)
+        {
+            return NumOps.Zero;
+        }
+
+        var annualizedReturn = Math.Pow(equity, (double)periodsPerYear / returns.Count) - 1.0;
+        return NumOps.FromDouble(annualizedReturn / maxDrawdown);
+    }
+
+    private static (T Mean, T Std) MeanStd(IReadOnlyList<T> returns, T riskFree)
+    {
+        var mean = NumOps.Zero;
+        var n = NumOps.FromDouble(returns.Count);
+        foreach (var r in returns)
+        {
+            mean = NumOps.Add(mean, NumOps.Subtract(r, riskFree));
+        }
+
+        mean = NumOps.Divide(mean, n);
+
+        var sse = NumOps.Zero;
+        foreach (var r in returns)
+        {
+            var d = NumOps.Subtract(NumOps.Subtract(r, riskFree), mean);
+            sse = NumOps.Add(sse, NumOps.Multiply(d, d));
+        }
+
+        // Sample standard deviation (n-1) — unbiased for a return sample.
+        var std = NumOps.Sqrt(NumOps.Divide(sse, NumOps.FromDouble(returns.Count - 1)));
+        return (mean, std);
+    }
+}

--- a/src/Finance/Risk/RiskRatios.cs
+++ b/src/Finance/Risk/RiskRatios.cs
@@ -23,9 +23,24 @@ public static class RiskRatios<T>
 {
     private static readonly INumericOperations<T> NumOps = MathHelper.GetNumericOperations<T>();
 
+    /// <summary>Validates the shared external inputs of every ratio.</summary>
+    private static void Validate(IReadOnlyList<T> returns, int periodsPerYear)
+    {
+        if (returns is null)
+        {
+            throw new ArgumentNullException(nameof(returns));
+        }
+
+        if (periodsPerYear <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(periodsPerYear), "periodsPerYear must be > 0.");
+        }
+    }
+
     /// <summary>Annualized Sharpe ratio: (mean(excess) / std(excess)) · √periodsPerYear.</summary>
     public static T Sharpe(IReadOnlyList<T> returns, double riskFreePerPeriod = 0.0, int periodsPerYear = 252)
     {
+        Validate(returns, periodsPerYear);
         if (returns.Count < 2)
         {
             return NumOps.Zero;
@@ -44,6 +59,7 @@ public static class RiskRatios<T>
     /// <summary>Annualized Sortino ratio: (mean(excess) / downsideDeviation) · √periodsPerYear.</summary>
     public static T Sortino(IReadOnlyList<T> returns, double riskFreePerPeriod = 0.0, int periodsPerYear = 252)
     {
+        Validate(returns, periodsPerYear);
         if (returns.Count < 2)
         {
             return NumOps.Zero;
@@ -79,6 +95,7 @@ public static class RiskRatios<T>
     /// </summary>
     public static T Calmar(IReadOnlyList<T> returns, int periodsPerYear = 252)
     {
+        Validate(returns, periodsPerYear);
         if (returns.Count < 2)
         {
             return NumOps.Zero;
@@ -108,7 +125,13 @@ public static class RiskRatios<T>
             return NumOps.Zero;
         }
 
-        var annualizedReturn = Math.Pow(equity, (double)periodsPerYear / returns.Count) - 1.0;
+        // A losing streak can drive the compounded equity to zero or negative
+        // (any period return <= -100%). Math.Pow of a non-positive base by a
+        // fractional exponent is NaN, so treat a wiped-out account as a total
+        // (-100%) annualized loss rather than emitting NaN.
+        var annualizedReturn = equity > 0.0
+            ? Math.Pow(equity, (double)periodsPerYear / returns.Count) - 1.0
+            : -1.0;
         return NumOps.FromDouble(annualizedReturn / maxDrawdown);
     }
 

--- a/src/Finance/Risk/RiskRatios.cs
+++ b/src/Finance/Risk/RiskRatios.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using AiDotNet.Finance.Interfaces;
 using AiDotNet.Helpers;
 using AiDotNet.Interfaces;
 
@@ -19,9 +20,25 @@ namespace AiDotNet.Finance.Risk;
 /// worst peak-to-trough drawdown. Higher is better for all three.</para>
 /// </remarks>
 /// <typeparam name="T">Numeric type (float/double).</typeparam>
-public static class RiskRatios<T>
+/// <remarks>
+/// Implements <see cref="IRiskRatioCalculator{T}"/> so it can be injected as the default, swappable
+/// risk-scoring strategy into risk models, backtests, and trading agents; the static methods remain
+/// available for direct use.
+/// </remarks>
+public class RiskRatios<T> : IRiskRatioCalculator<T>
 {
     private static readonly INumericOperations<T> NumOps = MathHelper.GetNumericOperations<T>();
+
+    /// <summary>Shared stateless default instance for injection as an <see cref="IRiskRatioCalculator{T}"/>.</summary>
+    public static IRiskRatioCalculator<T> Default { get; } = new RiskRatios<T>();
+
+    // Explicit IRiskRatioCalculator<T> members delegate to the static implementations.
+    T IRiskRatioCalculator<T>.Sharpe(IReadOnlyList<T> returns, double riskFreePerPeriod, int periodsPerYear)
+        => Sharpe(returns, riskFreePerPeriod, periodsPerYear);
+    T IRiskRatioCalculator<T>.Sortino(IReadOnlyList<T> returns, double riskFreePerPeriod, int periodsPerYear)
+        => Sortino(returns, riskFreePerPeriod, periodsPerYear);
+    T IRiskRatioCalculator<T>.Calmar(IReadOnlyList<T> returns, int periodsPerYear)
+        => Calmar(returns, periodsPerYear);
 
     /// <summary>Validates the shared external inputs of every ratio.</summary>
     private static void Validate(IReadOnlyList<T> returns, int periodsPerYear)

--- a/src/Finance/Trading/Agents/TradingAgentBase.cs
+++ b/src/Finance/Trading/Agents/TradingAgentBase.cs
@@ -54,6 +54,20 @@ public abstract class TradingAgentBase<T> : ReinforcementLearningAgentBase<T>, I
     protected readonly TradingAgentOptions<T> TradingOptions;
 
     /// <summary>
+    /// Position-sizing strategy used to translate a signal/edge into a capital fraction. Defaults to the
+    /// Kelly criterion (<see cref="AiDotNet.Finance.Portfolio.KellyCriterion{T}"/>); assign a custom
+    /// <see cref="IPositionSizer{T}"/> (fixed-fraction, volatility-target, …) to change sizing behavior.
+    /// </summary>
+    public IPositionSizer<T> PositionSizer { get; set; } = AiDotNet.Finance.Portfolio.KellyCriterion<T>.Default;
+
+    /// <summary>
+    /// Option-pricing strategy for options-aware agents (valuation / Greeks / implied vol). Defaults to
+    /// closed-form Black-Scholes (<see cref="AiDotNet.Finance.Options.BlackScholes{T}"/>); assign a custom
+    /// <see cref="IOptionPricer{T}"/> (binomial tree, Heston, a learned surface, …) to change pricing.
+    /// </summary>
+    public IOptionPricer<T> OptionPricer { get; set; } = AiDotNet.Finance.Options.BlackScholes<T>.Default;
+
+    /// <summary>
     /// History of portfolio values over time.
     /// </summary>
     protected readonly List<T> PortfolioHistory;

--- a/src/LossFunctions/PairwiseRankingLoss.cs
+++ b/src/LossFunctions/PairwiseRankingLoss.cs
@@ -1,0 +1,333 @@
+using AiDotNet.Attributes;
+using AiDotNet.Enums;
+using AiDotNet.Tensors.Engines.Gpu;
+using AiDotNet.Helpers;
+
+namespace AiDotNet.LossFunctions;
+
+/// <summary>
+/// Implements the pairwise RankNet learning-to-rank loss with an optional tail-weighting knob.
+/// </summary>
+/// <typeparam name="T">The numeric type used for calculations (e.g., float, double).</typeparam>
+/// <remarks>
+/// <para>
+/// This loss treats every prediction vector and target vector as a single <i>ranking group</i>
+/// (for example, all stocks in one asset class on one date). It does not learn to match each
+/// target value pointwise; instead it learns the correct <b>relative order</b> of the items.
+/// For every ordered pair (i, j) where the true score of i is greater than the true score of j,
+/// the RankNet loss penalizes the model when it predicts s_i &#8804; s_j:
+/// </para>
+/// <para>
+/// loss(i, j) = log(1 + exp(-(s_i - s_j)))
+/// </para>
+/// <para>
+/// where s_i and s_j are the predicted scores. Summed over all such pairs and averaged by the
+/// number of pairs, this yields a smooth, convex, gradient-friendly surrogate for "fraction of
+/// pairs ordered incorrectly". With the default tail weight (1.0) it is the standard RankNet
+/// loss of Burges et al. (2005).
+/// </para>
+/// <para>
+/// <b>Tail weighting.</b> In cross-sectional trading only the extremes are actionable: you go
+/// long the top names and short the bottom names, and the middle of the ranking is never traded.
+/// The optional <c>tailWeightPower</c> knob makes each pair contribute in proportion to how
+/// extreme its two items are in the target distribution. Each item is assigned an extremity in
+/// [0, 1] measuring its distance from the median target (0 at the median, 1 at the most extreme
+/// top or bottom name). A pair's weight is
+/// </para>
+/// <para>
+/// w(i, j) = (1 + max(extremity_i, extremity_j))^tailWeightPower
+/// </para>
+/// <para>
+/// With <c>tailWeightPower = 0</c> every weight is 1 and you recover plain RankNet (backward
+/// compatible). With a positive power the biggest movers dominate the loss, so the model spends
+/// its capacity getting the tradeable tails right.
+/// </para>
+/// <para>
+/// <b>For Beginners:</b> Most loss functions ask "how close is each predicted number to the
+/// true number?". A ranking loss asks a different, often more useful, question: "did you put the
+/// items in the right <i>order</i>?". If you only care about buying the best things and selling
+/// the worst things, the exact predicted values do not matter &#8212; only their order does.
+/// This loss looks at every pair of items, checks whether the one with the higher true value also
+/// got the higher predicted score, and nudges the model when it got a pair backwards.
+/// The tail-weighting option lets you tell the model "I care much more about getting the
+/// top and bottom right than the middle", which is exactly what a long/short trader wants.
+/// </para>
+/// <para>
+/// <b>How it plugs in.</b> This is a standard <see cref="ILossFunction{T}"/>, so any
+/// gradient-trained model in AiDotNet can use it. For a neural-network cross-sectional ranker:
+/// <code>
+/// var ranker = new NeuralNetwork&lt;double&gt;(architecture, optimizer,
+///     lossFunction: new PairwiseRankingLoss&lt;double&gt;(tailWeightPower: 1.0));
+/// var model = new AiModelBuilder&lt;double, Matrix&lt;double&gt;, Vector&lt;double&gt;&gt;()
+///     .ConfigureModel(ranker)
+///     .BuildAsync(features, forwardReturns);
+/// </code>
+/// Each training example's feature matrix is one cross-section (one date / one segment) and the
+/// target vector is the signed forward returns; the network outputs one score per name and the
+/// loss ranks them.
+/// </para>
+/// </remarks>
+[LossCategory(LossCategory.Ranking)]
+[LossTask(LossTask.Ranking)]
+[LossProperty(IsNonNegative = true, ZeroForIdentical = false, ExpectedOutput = OutputType.Continuous)]
+public class PairwiseRankingLoss<T> : LossFunctionBase<T>
+{
+    private readonly double _tailWeightPower;
+
+    /// <summary>
+    /// Creates a new pairwise RankNet ranking loss.
+    /// </summary>
+    /// <param name="tailWeightPower">
+    /// Controls how strongly pairs involving extreme (top/bottom) target values are emphasized.
+    /// <c>0</c> (the default) gives every pair equal weight and reproduces the standard RankNet
+    /// loss. Larger positive values increasingly concentrate the loss on the most extreme movers.
+    /// Must be non-negative.
+    /// </param>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="tailWeightPower"/> is negative.</exception>
+    public PairwiseRankingLoss(double tailWeightPower = 0.0)
+    {
+        if (tailWeightPower < 0.0 || double.IsNaN(tailWeightPower) || double.IsInfinity(tailWeightPower))
+        {
+            throw new ArgumentOutOfRangeException(nameof(tailWeightPower),
+                "Tail weight power must be a finite, non-negative value.");
+        }
+
+        _tailWeightPower = tailWeightPower;
+    }
+
+    /// <summary>
+    /// Gets the tail-weighting power this loss was configured with. 0 means standard RankNet.
+    /// </summary>
+    public double TailWeightPower => _tailWeightPower;
+
+    /// <summary>
+    /// Computes a per-item extremity weight in [0, 1] for tail weighting: 0 at the median target,
+    /// 1 at the most extreme top/bottom target. Returns all-ones when tail weighting is disabled
+    /// or the spread is degenerate, so the loss reduces exactly to standard RankNet.
+    /// </summary>
+    private double[] ComputeExtremities(Vector<T> actual)
+    {
+        int n = actual.Length;
+        var extremity = new double[n];
+
+        if (_tailWeightPower == 0.0)
+        {
+            for (int i = 0; i < n; i++) extremity[i] = 0.0;
+            return extremity;
+        }
+
+        // Median of the target values (robust center for "how extreme" each name is).
+        var sorted = new double[n];
+        for (int i = 0; i < n; i++) sorted[i] = NumOps.ToDouble(actual[i]);
+        Array.Sort(sorted);
+        double median = (n % 2 == 1)
+            ? sorted[n / 2]
+            : 0.5 * (sorted[(n / 2) - 1] + sorted[n / 2]);
+
+        // Largest absolute deviation from the median normalizes extremity to [0, 1].
+        double maxDev = 0.0;
+        for (int i = 0; i < n; i++)
+        {
+            double dev = Math.Abs(NumOps.ToDouble(actual[i]) - median);
+            if (dev > maxDev) maxDev = dev;
+        }
+
+        if (maxDev <= 0.0)
+        {
+            // All targets identical: no tails to emphasize.
+            for (int i = 0; i < n; i++) extremity[i] = 0.0;
+            return extremity;
+        }
+
+        for (int i = 0; i < n; i++)
+        {
+            extremity[i] = Math.Abs(NumOps.ToDouble(actual[i]) - median) / maxDev;
+        }
+
+        return extremity;
+    }
+
+    /// <summary>
+    /// Weight of the pair (i, j) given the precomputed per-item extremities.
+    /// </summary>
+    private double PairWeight(double[] extremity, int i, int j)
+    {
+        if (_tailWeightPower == 0.0) return 1.0;
+        double e = Math.Max(extremity[i], extremity[j]);
+        return Math.Pow(1.0 + e, _tailWeightPower);
+    }
+
+    /// <summary>
+    /// Numerically stable softplus: log(1 + exp(x)) = max(x, 0) + log(1 + exp(-|x|)).
+    /// </summary>
+    private static double Softplus(double x)
+    {
+        double ax = Math.Abs(x);
+        return Math.Max(x, 0.0) + Math.Log(1.0 + Math.Exp(-ax));
+    }
+
+    /// <summary>
+    /// Logistic sigmoid 1 / (1 + exp(-x)), computed in a numerically stable way.
+    /// </summary>
+    private static double Sigmoid(double x)
+    {
+        if (x >= 0.0)
+        {
+            double z = Math.Exp(-x);
+            return 1.0 / (1.0 + z);
+        }
+        else
+        {
+            double z = Math.Exp(x);
+            return z / (1.0 + z);
+        }
+    }
+
+    /// <summary>
+    /// Calculates the (tail-weighted) pairwise RankNet loss over all valid pairs in the group.
+    /// </summary>
+    /// <param name="predicted">The predicted scores, one per item in the ranking group.</param>
+    /// <param name="actual">The true relevance/return values, one per item.</param>
+    /// <returns>The weighted-average pairwise loss; 0 when there are no orderable pairs.</returns>
+    public override T CalculateLoss(Vector<T> predicted, Vector<T> actual)
+    {
+        ValidateVectorLengths(predicted, actual);
+
+        int n = predicted.Length;
+        var extremity = ComputeExtremities(actual);
+
+        double lossSum = 0.0;
+        double weightSum = 0.0;
+
+        for (int i = 0; i < n; i++)
+        {
+            double ai = NumOps.ToDouble(actual[i]);
+            double si = NumOps.ToDouble(predicted[i]);
+            for (int j = 0; j < n; j++)
+            {
+                double aj = NumOps.ToDouble(actual[j]);
+                // Only count ordered pairs where i is the true winner. Ties contribute nothing.
+                if (ai <= aj) continue;
+
+                double sj = NumOps.ToDouble(predicted[j]);
+                double w = PairWeight(extremity, i, j);
+
+                // log(1 + exp(-(s_i - s_j)))
+                lossSum += w * Softplus(-(si - sj));
+                weightSum += w;
+            }
+        }
+
+        if (weightSum <= 0.0) return NumOps.Zero;
+        return NumOps.FromDouble(lossSum / weightSum);
+    }
+
+    /// <summary>
+    /// Calculates the gradient of the (tail-weighted) pairwise RankNet loss with respect to each
+    /// predicted score.
+    /// </summary>
+    /// <param name="predicted">The predicted scores, one per item in the ranking group.</param>
+    /// <param name="actual">The true relevance/return values, one per item.</param>
+    /// <returns>A vector of partial derivatives dL/ds_k, one per item.</returns>
+    /// <remarks>
+    /// For a single pair (i, j) with i the true winner, dloss/ds_i = -sigma(-(s_i - s_j)) and
+    /// dloss/ds_j = +sigma(-(s_i - s_j)). These contributions accumulate over every pair an item
+    /// participates in, each scaled by the pair weight and divided by the total weight so the
+    /// gradient matches the averaged loss above.
+    /// </remarks>
+    public override Vector<T> CalculateDerivative(Vector<T> predicted, Vector<T> actual)
+    {
+        ValidateVectorLengths(predicted, actual);
+
+        int n = predicted.Length;
+        var extremity = ComputeExtremities(actual);
+        var grad = new double[n];
+
+        double weightSum = 0.0;
+
+        for (int i = 0; i < n; i++)
+        {
+            double ai = NumOps.ToDouble(actual[i]);
+            double si = NumOps.ToDouble(predicted[i]);
+            for (int j = 0; j < n; j++)
+            {
+                double aj = NumOps.ToDouble(actual[j]);
+                if (ai <= aj) continue;
+
+                double sj = NumOps.ToDouble(predicted[j]);
+                double w = PairWeight(extremity, i, j);
+
+                // d/ds_i log(1+exp(-(s_i - s_j))) = -sigmoid(-(s_i - s_j))
+                double g = Sigmoid(-(si - sj));
+                grad[i] += w * (-g);
+                grad[j] += w * (g);
+                weightSum += w;
+            }
+        }
+
+        var result = new T[n];
+        if (weightSum <= 0.0)
+        {
+            for (int k = 0; k < n; k++) result[k] = NumOps.Zero;
+            return new Vector<T>(result);
+        }
+
+        for (int k = 0; k < n; k++)
+        {
+            result[k] = NumOps.FromDouble(grad[k] / weightSum);
+        }
+
+        return new Vector<T>(result);
+    }
+
+    /// <summary>
+    /// Computes the loss as a tape-differentiable scalar tensor for automatic backpropagation.
+    /// </summary>
+    /// <param name="predicted">The predicted scores tensor from the forward pass.</param>
+    /// <param name="target">The true relevance/return tensor.</param>
+    /// <returns>A scalar tensor whose gradient w.r.t. <paramref name="predicted"/> equals the analytic RankNet gradient.</returns>
+    /// <remarks>
+    /// <para>
+    /// The pairwise RankNet objective is not a pointwise function of the predictions, so it cannot
+    /// be expressed directly with the broadcasting tensor primitives. Instead this builds a
+    /// first-order surrogate scalar
+    /// </para>
+    /// <para>
+    /// L_tape = &#931;_k predicted_k * stopgrad(g_k)
+    /// </para>
+    /// <para>
+    /// where g_k is the exact analytic gradient from <see cref="CalculateDerivative"/> treated as a
+    /// constant (no gradient flows through the target side). Because dL_tape/dpredicted_k = g_k,
+    /// the gradient that flows back through the tape is exactly the RankNet gradient, which is all
+    /// the optimizer needs. The reported scalar value is the true RankNet loss for monitoring.
+    /// </para>
+    /// </remarks>
+    public override Tensor<T> ComputeTapeLoss(Tensor<T> predicted, Tensor<T> target)
+    {
+        var predVec = predicted.ToVector();
+        var targetVec = target.ToVector();
+
+        // Constant analytic gradient (the target side carries no gradient).
+        var g = CalculateDerivative(predVec, targetVec);
+        var gradConst = new Tensor<T>(predicted._shape, g);
+
+        // L_tape = sum(predicted * g)  =>  dL_tape/dpredicted = g  (g is a leaf constant).
+        var weighted = Engine.TensorMultiply(predicted, gradConst);
+        var allAxes = Enumerable.Range(0, weighted.Shape.Length).ToArray();
+        var surrogate = Engine.ReduceSum(weighted, allAxes, keepDims: false);
+
+        // Add the true loss as a detached constant so GetLastLoss reports a meaningful value
+        // without changing the gradient (constant => zero gradient contribution).
+        double trueLoss = NumOps.ToDouble(CalculateLoss(predVec, targetVec));
+        double surrogateValue = 0.0;
+        for (int k = 0; k < predVec.Length; k++)
+        {
+            surrogateValue += NumOps.ToDouble(predVec[k]) * NumOps.ToDouble(g[k]);
+        }
+
+        // surrogate currently equals surrogateValue; shift it to report trueLoss while keeping
+        // the same gradient (adding a scalar constant does not change the derivative).
+        var shift = NumOps.FromDouble(trueLoss - surrogateValue);
+        return Engine.TensorAddScalar(surrogate, shift);
+    }
+}

--- a/src/Metrics/RankingMetrics.cs
+++ b/src/Metrics/RankingMetrics.cs
@@ -1,0 +1,127 @@
+using AiDotNet.Helpers;
+
+namespace AiDotNet.Metrics;
+
+/// <summary>
+/// Static helpers for evaluating the quality of a ranking, most notably Normalized Discounted
+/// Cumulative Gain (NDCG@k).
+/// </summary>
+/// <typeparam name="T">The numeric type used for calculations (e.g., float, double).</typeparam>
+/// <remarks>
+/// <para>
+/// <b>For Beginners:</b> When a model ranks items (stocks, search results, recommendations), you
+/// need a number that says "how good is this ordering?". NDCG is the most common such number.
+/// It rewards putting the truly-best items near the top and discounts items further down the list
+/// (a great item ranked #1 counts for more than the same item ranked #20). It is normalized so
+/// that a perfect ranking scores 1.0 and a poor ranking scores closer to 0, which makes scores
+/// comparable across groups of different sizes. The "@k" version only looks at the top k positions,
+/// which is what you want when you will only act on the top of the list (e.g. only buy the top 10).
+/// </para>
+/// <para>
+/// DCG@k = &#931;_{r=1..k} (2^{gain_r} - 1) / log2(r + 1), where gain_r is the true relevance of the
+/// item the model placed at rank r. NDCG@k = DCG@k / IDCG@k, where IDCG@k is the DCG of the ideal
+/// ordering (sorting items by true relevance descending).
+/// </para>
+/// </remarks>
+public static class RankingMetrics<T>
+{
+    private static readonly INumericOperations<T> NumOps = MathHelper.GetNumericOperations<T>();
+
+    /// <summary>
+    /// Computes Normalized Discounted Cumulative Gain at cutoff k (NDCG@k) for a single ranking group.
+    /// </summary>
+    /// <param name="predictedScores">The model's predicted scores; higher means ranked earlier.</param>
+    /// <param name="trueRelevance">The true relevance/return of each item (same order as predictions).</param>
+    /// <param name="k">
+    /// The cutoff: only the top k items (by predicted score) contribute. Use a value &#8804; 0 or
+    /// &#8805; the item count to evaluate the full list.
+    /// </param>
+    /// <param name="useExponentialGain">
+    /// When true (default) the gain is 2^relevance - 1 (the standard NDCG used in IR, which sharply
+    /// rewards high-relevance items). When false the gain is the raw relevance value, which is
+    /// appropriate for signed continuous targets such as forward returns.
+    /// </param>
+    /// <returns>
+    /// NDCG@k in [0, 1] for a perfect ranking of non-negative gains; 1.0 for the ideal ordering and
+    /// less for any ordering that misplaces high-relevance items. Returns 0 when the ideal DCG is 0.
+    /// </returns>
+    /// <exception cref="ArgumentException">Thrown when the input vectors have different lengths.</exception>
+    /// <remarks>
+    /// For signed targets (e.g. forward returns that can be negative) prefer
+    /// <paramref name="useExponentialGain"/> = false, since 2^x for negative x understates large
+    /// losers. NDCG with arbitrary signed gains is not bounded to [0, 1] but is still a valid,
+    /// monotone "closeness to ideal order" score where 1.0 means the predicted order equals the
+    /// ideal order.
+    /// </remarks>
+    public static T NdcgAtK(Vector<T> predictedScores, Vector<T> trueRelevance, int k, bool useExponentialGain = true)
+    {
+        if (predictedScores.Length != trueRelevance.Length)
+        {
+            throw new ArgumentException("Predicted scores and true relevance vectors must have the same length.");
+        }
+
+        int n = predictedScores.Length;
+        if (n == 0) return NumOps.Zero;
+
+        int cutoff = (k <= 0 || k > n) ? n : k;
+
+        var pred = new double[n];
+        var rel = new double[n];
+        for (int i = 0; i < n; i++)
+        {
+            pred[i] = NumOps.ToDouble(predictedScores[i]);
+            rel[i] = NumOps.ToDouble(trueRelevance[i]);
+        }
+
+        // Order item indices by predicted score (descending). Stable on ties via index tiebreak.
+        var byPredicted = StableArgsortDescending(pred);
+        // Ideal order: by true relevance (descending).
+        var byIdeal = StableArgsortDescending(rel);
+
+        double dcg = Dcg(byPredicted, rel, cutoff, useExponentialGain);
+        double idcg = Dcg(byIdeal, rel, cutoff, useExponentialGain);
+
+        if (idcg == 0.0) return NumOps.Zero;
+        return NumOps.FromDouble(dcg / idcg);
+    }
+
+    /// <summary>
+    /// Discounted Cumulative Gain over the first <paramref name="cutoff"/> positions of an ordering.
+    /// </summary>
+    private static double Dcg(int[] order, double[] relevance, int cutoff, bool useExponentialGain)
+    {
+        double dcg = 0.0;
+        int limit = Math.Min(cutoff, order.Length);
+        for (int r = 0; r < limit; r++)
+        {
+            double gain = useExponentialGain
+                ? Math.Pow(2.0, relevance[order[r]]) - 1.0
+                : relevance[order[r]];
+
+            // Position r is rank r+1; discount is log2(rank + 1) = log2(r + 2).
+            double discount = Math.Log(r + 2.0) / Math.Log(2.0);
+            dcg += gain / discount;
+        }
+
+        return dcg;
+    }
+
+    /// <summary>
+    /// Returns indices that sort <paramref name="values"/> in descending order, breaking ties by
+    /// original index (so the result is deterministic).
+    /// </summary>
+    private static int[] StableArgsortDescending(double[] values)
+    {
+        int n = values.Length;
+        var idx = new int[n];
+        for (int i = 0; i < n; i++) idx[i] = i;
+
+        Array.Sort(idx, (a, b) =>
+        {
+            int cmp = values[b].CompareTo(values[a]); // descending
+            return cmp != 0 ? cmp : a.CompareTo(b);    // stable tiebreak
+        });
+
+        return idx;
+    }
+}

--- a/src/Preprocessing/Scalers/StandardScaler.cs
+++ b/src/Preprocessing/Scalers/StandardScaler.cs
@@ -112,7 +112,12 @@ public class StandardScaler<T> : TransformerBase<T, Matrix<T>, Matrix<T>>
             if (_withStd)
             {
                 T variance = StatisticsHelper<T>.CalculateVariance(column, means[colIdx]);
-                T std = NumOps.Sqrt(variance);
+
+                // A constant/near-constant column can produce a tiny NEGATIVE variance from
+                // floating-point cancellation; Sqrt of that is NaN, which then poisons every
+                // transformed value (and the exact-zero guard below would miss a NaN). Floor the
+                // variance at zero before the sqrt so a degenerate column degrades to "no scaling".
+                T std = NumOps.GreaterThan(variance, NumOps.Zero) ? NumOps.Sqrt(variance) : NumOps.Zero;
 
                 // Prevent division by zero - if std is zero, use 1 (no scaling)
                 stdDevs[colIdx] = NumOps.Compare(std, NumOps.Zero) == 0 ? NumOps.One : std;

--- a/src/RetrievalAugmentedGeneration/Embeddings/ONNXSentenceTransformer.cs
+++ b/src/RetrievalAugmentedGeneration/Embeddings/ONNXSentenceTransformer.cs
@@ -133,23 +133,13 @@ namespace AiDotNet.RetrievalAugmentedGeneration.EmbeddingModels
 
             var inputIds = tokenizationResult.TokenIds.Select(id => (long)id).ToArray();
             var attentionMask = tokenizationResult.AttentionMask.Select(m => (long)m).ToArray();
-            var tokenTypeIds = tokenizationResult.TokenTypeIds.Select(t => (long)t).ToArray();
 
             var seqLength = inputIds.Length;
             var inputShape = new[] { 1, seqLength };
 
-            // 2. Prepare inputs
-            var inputs = new List<NamedOnnxValue>
-            {
-                NamedOnnxValue.CreateFromTensor("input_ids", new Microsoft.ML.OnnxRuntime.Tensors.DenseTensor<long>(inputIds, inputShape)),
-                NamedOnnxValue.CreateFromTensor("attention_mask", new Microsoft.ML.OnnxRuntime.Tensors.DenseTensor<long>(attentionMask, inputShape))
-            };
-
-            // Some models require token_type_ids
-            if (Session.InputMetadata.ContainsKey("token_type_ids"))
-            {
-                inputs.Add(NamedOnnxValue.CreateFromTensor("token_type_ids", new Microsoft.ML.OnnxRuntime.Tensors.DenseTensor<long>(tokenTypeIds, inputShape)));
-            }
+            // 2. Prepare inputs (only the ones the loaded session declares)
+            var declaredInputs = new HashSet<string>(Session.InputMetadata.Keys);
+            var inputs = BuildOnnxInputs(declaredInputs, inputIds, attentionMask, inputShape);
 
             // 3. Run inference
             using var results = Session.Run(inputs);
@@ -168,6 +158,51 @@ namespace AiDotNet.RetrievalAugmentedGeneration.EmbeddingModels
             }
 
             return new Vector<T>(values).Normalize();
+        }
+
+        /// <summary>
+        /// Builds the list of ONNX inputs for a sentence-transformer encode call.
+        /// </summary>
+        /// <param name="declaredInputs">The names of the inputs the loaded session declares (typically <c>Session.InputMetadata.Keys</c>).</param>
+        /// <param name="inputIds">Int64 token ids, shape [batch, seqLen].</param>
+        /// <param name="attentionMask">Int64 attention mask, same shape as <paramref name="inputIds"/>.</param>
+        /// <param name="inputShape">The [batch, seqLen] shape shared by every input tensor.</param>
+        /// <remarks>
+        /// input_ids is always supplied. attention_mask and token_type_ids are only
+        /// added when the session declares them, so models exported without them keep
+        /// working. token_type_ids is built here as an all-zeros int64 tensor with the
+        /// SAME shape as input_ids (single-sentence embedding → all segment 0). We do
+        /// NOT forward the tokenizer's TokenTypeIds, because some sentence-transformer
+        /// tokenizers return an empty TokenTypeIds array; feeding that as a length-0
+        /// tensor makes onnxruntime throw
+        /// "Length of memory (0) must match product of dimensions (seqLen)".
+        /// </remarks>
+        internal static List<NamedOnnxValue> BuildOnnxInputs(
+            ICollection<string> declaredInputs,
+            long[] inputIds,
+            long[] attentionMask,
+            int[] inputShape)
+        {
+            var inputs = new List<NamedOnnxValue>
+            {
+                NamedOnnxValue.CreateFromTensor("input_ids", new Microsoft.ML.OnnxRuntime.Tensors.DenseTensor<long>(inputIds, inputShape))
+            };
+
+            if (declaredInputs.Contains("attention_mask"))
+            {
+                inputs.Add(NamedOnnxValue.CreateFromTensor("attention_mask", new Microsoft.ML.OnnxRuntime.Tensors.DenseTensor<long>(attentionMask, inputShape)));
+            }
+
+            // Some models (e.g. all-MiniLM-L6-v2) declare token_type_ids. Build it as
+            // an all-zeros int64 tensor with the SAME shape as input_ids rather than
+            // forwarding a possibly-empty tokenizer array.
+            if (declaredInputs.Contains("token_type_ids"))
+            {
+                var tokenTypeIds = new long[inputIds.Length];
+                inputs.Add(NamedOnnxValue.CreateFromTensor("token_type_ids", new Microsoft.ML.OnnxRuntime.Tensors.DenseTensor<long>(tokenTypeIds, inputShape)));
+            }
+
+            return inputs;
         }
 
         private float[] ApplyMeanPooling(Microsoft.ML.OnnxRuntime.Tensors.Tensor<float> lastHiddenState, long[] attentionMask)

--- a/tests/AiDotNet.Tests/UnitTests/Finance/BlackScholesTests.cs
+++ b/tests/AiDotNet.Tests/UnitTests/Finance/BlackScholesTests.cs
@@ -1,0 +1,63 @@
+using System;
+using AiDotNet.Finance.Options;
+using Xunit;
+
+namespace AiDotNet.Tests.UnitTests.Finance;
+
+/// <summary>
+/// Verifies the closed-form Black-Scholes pricer/Greeks against well-known textbook values for the
+/// canonical case S=100, K=100, T=1, r=0.05, σ=0.20 (e.g. Hull, "Options, Futures, and Other Derivatives").
+/// </summary>
+public class BlackScholesTests
+{
+    private const double S = 100.0, K = 100.0, T = 1.0, R = 0.05, Sigma = 0.20;
+    private const double Tol = 1e-3;
+
+    [Fact]
+    public void Call_price_matches_textbook()
+    {
+        var call = BlackScholes<double>.Price(S, K, T, R, Sigma, isCall: true);
+        Assert.Equal(10.4506, call, 3);
+    }
+
+    [Fact]
+    public void Put_price_matches_textbook()
+    {
+        var put = BlackScholes<double>.Price(S, K, T, R, Sigma, isCall: false);
+        Assert.Equal(5.5735, put, 3);
+    }
+
+    [Fact]
+    public void Put_call_parity_holds()
+    {
+        var call = BlackScholes<double>.Price(S, K, T, R, Sigma, isCall: true);
+        var put = BlackScholes<double>.Price(S, K, T, R, Sigma, isCall: false);
+        // C - P = S - K·e^(-rT)
+        var parity = S - K * Math.Exp(-R * T);
+        Assert.Equal(parity, call - put, 6);
+    }
+
+    [Fact]
+    public void Greeks_match_textbook()
+    {
+        Assert.Equal(0.6368, BlackScholes<double>.Delta(S, K, T, R, Sigma, isCall: true), 3);
+        Assert.Equal(-0.3632, BlackScholes<double>.Delta(S, K, T, R, Sigma, isCall: false), 3); // N(d1) - 1
+        Assert.Equal(0.018762, BlackScholes<double>.Gamma(S, K, T, R, Sigma), 5);
+        Assert.Equal(37.524, BlackScholes<double>.Vega(S, K, T, R, Sigma), 2); // per 1.0 of vol
+    }
+
+    [Fact]
+    public void Implied_vol_round_trips()
+    {
+        var price = BlackScholes<double>.Price(S, K, T, R, Sigma, isCall: true);
+        var iv = BlackScholes<double>.ImpliedVolatility(price, S, K, T, R, isCall: true);
+        Assert.Equal(Sigma, iv, 4);
+    }
+
+    [Fact]
+    public void Expired_option_is_intrinsic()
+    {
+        Assert.Equal(5.0, BlackScholes<double>.Price(105, 100, 0.0, R, Sigma, isCall: true), Tol);
+        Assert.Equal(0.0, BlackScholes<double>.Price(95, 100, 0.0, R, Sigma, isCall: true), Tol);
+    }
+}

--- a/tests/AiDotNet.Tests/UnitTests/Finance/KellyCriterionTests.cs
+++ b/tests/AiDotNet.Tests/UnitTests/Finance/KellyCriterionTests.cs
@@ -1,0 +1,46 @@
+using AiDotNet.Finance.Portfolio;
+using Xunit;
+
+namespace AiDotNet.Tests.UnitTests.Finance;
+
+/// <summary>Verifies Kelly-criterion position sizing against hand-computed values.</summary>
+public class KellyCriterionTests
+{
+    [Fact]
+    public void Discrete_even_odds_60pct_edge_is_0_2()
+    {
+        // f* = p - (1-p)/b = 0.6 - 0.4/1 = 0.2
+        Assert.Equal(0.2, KellyCriterion<double>.Discrete(0.6, 1.0), 6);
+    }
+
+    [Fact]
+    public void Discrete_no_edge_clamps_to_zero()
+    {
+        Assert.Equal(0.0, KellyCriterion<double>.Discrete(0.5, 1.0), 6); // exactly break-even
+        Assert.Equal(0.0, KellyCriterion<double>.Discrete(0.4, 1.0), 6); // negative edge → no bet
+        Assert.Equal(0.0, KellyCriterion<double>.Discrete(0.6, 0.0), 6); // degenerate odds
+    }
+
+    [Fact]
+    public void Continuous_is_mean_over_variance()
+    {
+        // f* = μ / σ² = 0.1 / 0.04 = 2.5
+        Assert.Equal(2.5, KellyCriterion<double>.Continuous(0.1, 0.04), 6);
+        Assert.Equal(0.0, KellyCriterion<double>.Continuous(0.1, 0.0), 6); // zero variance guard
+    }
+
+    [Fact]
+    public void Fractional_scales_kelly()
+    {
+        Assert.Equal(1.25, KellyCriterion<double>.Fractional(2.5, 0.5), 6); // half-Kelly
+    }
+
+    [Fact]
+    public void FromReturns_uses_mean_and_population_variance()
+    {
+        // returns [0.2, 0.0] → mean 0.1, population var ((0.1)²+(0.1)²)/2 = 0.01 → 0.1/0.01 = 10
+        Assert.Equal(10.0, KellyCriterion<double>.FromReturns([0.2, 0.0]), 6);
+        Assert.Equal(5.0, KellyCriterion<double>.FromReturns([0.2, 0.0], 0.5), 6); // half-Kelly
+        Assert.Equal(0.0, KellyCriterion<double>.FromReturns([0.05]), 6); // <2 points → 0
+    }
+}

--- a/tests/AiDotNet.Tests/UnitTests/Finance/MarkowitzOptimizerTests.cs
+++ b/tests/AiDotNet.Tests/UnitTests/Finance/MarkowitzOptimizerTests.cs
@@ -1,0 +1,177 @@
+using System;
+using AiDotNet.Finance.Portfolio;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tests.UnitTests.Finance;
+
+/// <summary>Verifies closed-form Markowitz mean-variance optimization against hand-computed values.</summary>
+public class MarkowitzOptimizerTests
+{
+    private static double Sum(Vector<double> v)
+    {
+        var s = 0.0;
+        for (var i = 0; i < v.Length; i++)
+        {
+            s += v[i];
+        }
+
+        return s;
+    }
+
+    [Fact]
+    public void MinimumVariance_weights_sum_to_one()
+    {
+        var cov = new Matrix<double>(new[,]
+        {
+            { 0.04, 0.01, 0.00 },
+            { 0.01, 0.09, 0.02 },
+            { 0.00, 0.02, 0.16 },
+        });
+
+        var w = MarkowitzOptimizer<double>.MinimumVariance(cov);
+
+        Assert.Equal(1.0, Sum(w), 9);
+    }
+
+    [Fact]
+    public void MinimumVariance_diagonal_cov_is_inverse_variance_weighted()
+    {
+        // For a diagonal Σ, w_i ∝ 1/σ_i². Variances 0.01, 0.04, 0.25 → inverses 100, 25, 4 (sum 129).
+        var cov = new Matrix<double>(new[,]
+        {
+            { 0.01, 0.00, 0.00 },
+            { 0.00, 0.04, 0.00 },
+            { 0.00, 0.00, 0.25 },
+        });
+
+        var w = MarkowitzOptimizer<double>.MinimumVariance(cov);
+
+        Assert.Equal(100.0 / 129.0, w[0], 9);
+        Assert.Equal(25.0 / 129.0, w[1], 9);
+        Assert.Equal(4.0 / 129.0, w[2], 9);
+        Assert.Equal(1.0, Sum(w), 9);
+    }
+
+    [Fact]
+    public void MinimumVariance_two_asset_known_case()
+    {
+        // Uncorrelated 2-asset: σ₁²=0.02, σ₂²=0.08 → w ∝ (1/0.02, 1/0.08) = (50, 12.5), sum 62.5.
+        // w = (0.8, 0.2).
+        var cov = new Matrix<double>(new[,]
+        {
+            { 0.02, 0.00 },
+            { 0.00, 0.08 },
+        });
+
+        var w = MarkowitzOptimizer<double>.MinimumVariance(cov);
+
+        Assert.Equal(0.8, w[0], 9);
+        Assert.Equal(0.2, w[1], 9);
+    }
+
+    [Fact]
+    public void MinimumVariance_correlated_two_asset_closed_form()
+    {
+        // Two correlated assets: w₁ = (σ₂² − σ₁₂) / (σ₁² + σ₂² − 2σ₁₂).
+        // σ₁²=0.04, σ₂²=0.09, σ₁₂=0.012 → w₁ = (0.09 − 0.012)/(0.04+0.09−0.024) = 0.078/0.106.
+        var cov = new Matrix<double>(new[,]
+        {
+            { 0.04, 0.012 },
+            { 0.012, 0.09 },
+        });
+
+        var w = MarkowitzOptimizer<double>.MinimumVariance(cov);
+
+        var expectedW1 = 0.078 / 0.106;
+        Assert.Equal(expectedW1, w[0], 9);
+        Assert.Equal(1.0 - expectedW1, w[1], 9);
+    }
+
+    [Fact]
+    public void Tangency_weights_sum_to_one()
+    {
+        var cov = new Matrix<double>(new[,]
+        {
+            { 0.04, 0.01, 0.00 },
+            { 0.01, 0.09, 0.02 },
+            { 0.00, 0.02, 0.16 },
+        });
+        var mu = new Vector<double>(new[] { 0.10, 0.12, 0.14 });
+
+        var w = MarkowitzOptimizer<double>.Tangency(mu, cov, 0.02);
+
+        Assert.Equal(1.0, Sum(w), 9);
+    }
+
+    [Fact]
+    public void Tangency_diagonal_cov_known_case()
+    {
+        // Diagonal Σ → w_i ∝ (μ_i − rf)/σ_i².
+        // excess (μ−rf): 0.08, 0.06; variances 0.01, 0.04 → raw 8, 1.5; sum 9.5.
+        var cov = new Matrix<double>(new[,]
+        {
+            { 0.01, 0.00 },
+            { 0.00, 0.04 },
+        });
+        var mu = new Vector<double>(new[] { 0.10, 0.08 });
+
+        var w = MarkowitzOptimizer<double>.Tangency(mu, cov, 0.02);
+
+        Assert.Equal(8.0 / 9.5, w[0], 9);
+        Assert.Equal(1.5 / 9.5, w[1], 9);
+    }
+
+    [Fact]
+    public void TargetReturn_hits_target_and_sums_to_one()
+    {
+        var cov = new Matrix<double>(new[,]
+        {
+            { 0.04, 0.01, 0.00 },
+            { 0.01, 0.09, 0.02 },
+            { 0.00, 0.02, 0.16 },
+        });
+        var mu = new Vector<double>(new[] { 0.10, 0.12, 0.14 });
+
+        var w = MarkowitzOptimizer<double>.TargetReturn(mu, cov, 0.13);
+
+        // Weights sum to 1...
+        Assert.Equal(1.0, Sum(w), 9);
+
+        // ...and the realized portfolio return equals the target.
+        var realized = 0.0;
+        for (var i = 0; i < w.Length; i++)
+        {
+            realized += w[i] * mu[i];
+        }
+
+        Assert.Equal(0.13, realized, 9);
+    }
+
+    [Fact]
+    public void TargetReturn_at_minvar_return_matches_minimum_variance()
+    {
+        var cov = new Matrix<double>(new[,]
+        {
+            { 0.04, 0.01 },
+            { 0.01, 0.09 },
+        });
+        var mu = new Vector<double>(new[] { 0.10, 0.15 });
+
+        var mvw = MarkowitzOptimizer<double>.MinimumVariance(cov);
+        var minVarReturn = mvw[0] * mu[0] + mvw[1] * mu[1];
+
+        // Targeting the min-variance portfolio's own return reproduces that portfolio.
+        var w = MarkowitzOptimizer<double>.TargetReturn(mu, cov, minVarReturn);
+
+        Assert.Equal(mvw[0], w[0], 9);
+        Assert.Equal(mvw[1], w[1], 9);
+    }
+
+    [Fact]
+    public void MinimumVariance_rejects_non_square()
+    {
+        var cov = new Matrix<double>(2, 3);
+        Assert.Throws<ArgumentException>(() => MarkowitzOptimizer<double>.MinimumVariance(cov));
+    }
+}

--- a/tests/AiDotNet.Tests/UnitTests/Finance/RiskRatiosTests.cs
+++ b/tests/AiDotNet.Tests/UnitTests/Finance/RiskRatiosTests.cs
@@ -1,0 +1,44 @@
+using AiDotNet.Finance.Risk;
+using Xunit;
+
+namespace AiDotNet.Tests.UnitTests.Finance;
+
+/// <summary>Verifies the Sharpe/Sortino/Calmar risk ratios against hand-computed values + properties.</summary>
+public class RiskRatiosTests
+{
+    [Fact]
+    public void Constant_returns_give_zero_ratios()
+    {
+        var flat = new[] { 0.01, 0.01, 0.01 };
+        Assert.Equal(0.0, RiskRatios<double>.Sharpe(flat), 9);  // zero variance
+        Assert.Equal(0.0, RiskRatios<double>.Sortino(flat), 9); // no downside
+        Assert.Equal(0.0, RiskRatios<double>.Calmar(flat), 9);  // no drawdown
+    }
+
+    [Fact]
+    public void Sortino_matches_hand_computed()
+    {
+        // returns [0.2, -0.1], rf=0, ppy=1: mean 0.05; downsideDev = sqrt(((-0.1)^2)/2) = sqrt(0.005)
+        var r = new[] { 0.2, -0.1 };
+        var expected = 0.05 / System.Math.Sqrt(0.005);
+        Assert.Equal(expected, RiskRatios<double>.Sortino(r, riskFreePerPeriod: 0.0, periodsPerYear: 1), 6);
+    }
+
+    [Fact]
+    public void Calmar_matches_hand_computed()
+    {
+        // [0.5, -0.5]: equity 1 -> 1.5 -> 0.75; maxDD = (1.5-0.75)/1.5 = 0.5.
+        // ppy=2 (=count) → annualizedReturn = 0.75 - 1 = -0.25 → Calmar = -0.25/0.5 = -0.5.
+        Assert.Equal(-0.5, RiskRatios<double>.Calmar([0.5, -0.5], periodsPerYear: 2), 6);
+        // Monotonic up → no drawdown → 0.
+        Assert.Equal(0.0, RiskRatios<double>.Calmar([0.2, 0.2], periodsPerYear: 2), 9);
+    }
+
+    [Fact]
+    public void Sortino_exceeds_sharpe_when_upside_dominates_volatility()
+    {
+        // Big upside spikes inflate total std (hurting Sharpe) but not downside dev (Sortino ignores them).
+        var r = new[] { 0.3, 0.005, 0.3, 0.005, -0.01 };
+        Assert.True(RiskRatios<double>.Sortino(r) > RiskRatios<double>.Sharpe(r));
+    }
+}

--- a/tests/AiDotNet.Tests/UnitTests/LossFunctions/PairwiseRankingLossTests.cs
+++ b/tests/AiDotNet.Tests/UnitTests/LossFunctions/PairwiseRankingLossTests.cs
@@ -1,0 +1,231 @@
+using System;
+using AiDotNet.LinearAlgebra;
+using AiDotNet.LossFunctions;
+using AiDotNet.Metrics;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+using System.Threading.Tasks;
+
+namespace AiDotNetTests.UnitTests.LossFunctions
+{
+    public class PairwiseRankingLossTests
+    {
+        private const double Tol = 1e-9;
+
+        [Fact(Timeout = 60000)]
+        public async Task PerfectlyOrderedPredictions_GiveZeroLossInTheLimit()
+        {
+            await Task.CompletedTask;
+            // Predictions perfectly ordered with a huge margin => log(1+exp(-large)) -> 0.
+            var loss = new PairwiseRankingLoss<double>();
+            var predicted = new Vector<double>(new double[] { 100.0, 50.0, 0.0, -50.0 });
+            var actual = new Vector<double>(new double[] { 4.0, 3.0, 2.0, 1.0 });
+
+            var result = loss.CalculateLoss(predicted, actual);
+
+            Assert.True(result >= 0.0);
+            Assert.True(result < 1e-12, $"Expected near-zero loss for perfectly ordered preds, got {result}");
+        }
+
+        [Fact(Timeout = 60000)]
+        public async Task EqualScores_GiveLog2_StandardRankNetReference()
+        {
+            await Task.CompletedTask;
+            // All predicted scores equal => every pair loss = log(1+exp(0)) = log(2).
+            var loss = new PairwiseRankingLoss<double>();
+            var predicted = new Vector<double>(new double[] { 0.0, 0.0, 0.0 });
+            var actual = new Vector<double>(new double[] { 3.0, 2.0, 1.0 });
+
+            var result = loss.CalculateLoss(predicted, actual);
+
+            Assert.Equal(Math.Log(2.0), result, 9);
+        }
+
+        [Fact(Timeout = 60000)]
+        public async Task MisorderedPair_GivesPositiveLoss()
+        {
+            await Task.CompletedTask;
+            var loss = new PairwiseRankingLoss<double>();
+            // True order says item0 > item1, but predictions say item0 < item1 => positive loss.
+            var predicted = new Vector<double>(new double[] { 0.0, 2.0 });
+            var actual = new Vector<double>(new double[] { 1.0, 0.0 });
+
+            var result = loss.CalculateLoss(predicted, actual);
+
+            // Single pair (0,1): log(1+exp(-(0-2))) = log(1+exp(2)).
+            Assert.Equal(Math.Log(1.0 + Math.Exp(2.0)), result, 9);
+            Assert.True(result > 0.0);
+        }
+
+        [Fact(Timeout = 60000)]
+        public async Task Gradient_OnMisorderedPair_HasCorrectSign()
+        {
+            await Task.CompletedTask;
+            var loss = new PairwiseRankingLoss<double>();
+            // item0 should rank above item1 (actual 1 > 0) but predicted score is lower.
+            var predicted = new Vector<double>(new double[] { 0.0, 2.0 });
+            var actual = new Vector<double>(new double[] { 1.0, 0.0 });
+
+            var grad = loss.CalculateDerivative(predicted, actual);
+
+            // To DECREASE loss we must raise s0 and lower s1. Gradient descent steps along
+            // -grad, so grad[0] must be negative (push s0 up) and grad[1] positive (push s1 down).
+            Assert.True(grad[0] < 0.0, $"grad[0] should be negative, got {grad[0]}");
+            Assert.True(grad[1] > 0.0, $"grad[1] should be positive, got {grad[1]}");
+            // Gradient is anti-symmetric for a single pair.
+            Assert.Equal(-grad[0], grad[1], 9);
+        }
+
+        [Fact(Timeout = 60000)]
+        public async Task Gradient_MatchesFiniteDifference()
+        {
+            await Task.CompletedTask;
+            var loss = new PairwiseRankingLoss<double>(tailWeightPower: 1.0);
+            var predicted = new Vector<double>(new double[] { 0.3, -0.1, 1.2, 0.7 });
+            var actual = new Vector<double>(new double[] { 0.05, -0.02, 0.10, -0.08 });
+
+            var analytic = loss.CalculateDerivative(predicted, actual);
+
+            double eps = 1e-6;
+            for (int k = 0; k < predicted.Length; k++)
+            {
+                var plus = new double[predicted.Length];
+                var minus = new double[predicted.Length];
+                for (int i = 0; i < predicted.Length; i++) { plus[i] = predicted[i]; minus[i] = predicted[i]; }
+                plus[k] += eps;
+                minus[k] -= eps;
+
+                double lp = loss.CalculateLoss(new Vector<double>(plus), actual);
+                double lm = loss.CalculateLoss(new Vector<double>(minus), actual);
+                double fd = (lp - lm) / (2.0 * eps);
+
+                Assert.Equal(fd, analytic[k], 5);
+            }
+        }
+
+        [Fact(Timeout = 60000)]
+        public async Task TailWeighting_IncreasesContributionOfExtremePairs()
+        {
+            await Task.CompletedTask;
+            // Two mis-ordered pairs of equal predicted-margin error, but one pair sits at the
+            // extreme tails of the actual distribution and the other near the median.
+            // Construct so that the extreme misorder dominates under tail weighting.
+            // actuals: index0 = top, index4 = bottom (extremes); index2 = median.
+            var actual = new Vector<double>(new double[] { 10.0, 1.0, 0.0, -1.0, -10.0 });
+
+            // Mis-order ONLY the extreme pair (0 vs 4): predict bottom above top.
+            var predExtremeBad = new Vector<double>(new double[] { 0.0, 5.0, 4.0, 3.0, 8.0 });
+            // Mis-order ONLY a near-median pair (1 vs 3) by the same predicted margin.
+            var predMedianBad = new Vector<double>(new double[] { 8.0, 0.0, 4.0, 3.0, -8.0 });
+
+            var plain = new PairwiseRankingLoss<double>(tailWeightPower: 0.0);
+            var tailed = new PairwiseRankingLoss<double>(tailWeightPower: 3.0);
+
+            // Under PLAIN RankNet, a single mis-ordered pair of equal margin costs the same
+            // regardless of which pair it is (weights all 1, and the averaging normalizer is
+            // by total pairs which is identical between the two prediction vectors).
+            double plainExtreme = plain.CalculateLoss(predExtremeBad, actual);
+            double plainMedian = plain.CalculateLoss(predMedianBad, actual);
+
+            // Under TAIL weighting, mis-ordering the extreme pair must cost strictly MORE than
+            // mis-ordering the median pair.
+            double tailedExtreme = tailed.CalculateLoss(predExtremeBad, actual);
+            double tailedMedian = tailed.CalculateLoss(predMedianBad, actual);
+
+            Assert.True(tailedExtreme > tailedMedian,
+                $"Tail weighting should penalize the extreme misorder more: extreme={tailedExtreme}, median={tailedMedian}");
+
+            // Sanity: tail weighting changed the relative ranking of the two errors compared to plain.
+            // (Plain treats them comparably; tailed strongly prefers fixing the extreme.)
+            Assert.True(tailedExtreme / Math.Max(tailedMedian, 1e-12) > plainExtreme / Math.Max(plainMedian, 1e-12));
+        }
+
+        [Fact(Timeout = 60000)]
+        public async Task TailWeightPower_Zero_EqualsStandardRankNet()
+        {
+            await Task.CompletedTask;
+            var plain = new PairwiseRankingLoss<double>(tailWeightPower: 0.0);
+            var explicitDefault = new PairwiseRankingLoss<double>();
+
+            var predicted = new Vector<double>(new double[] { 0.5, -0.3, 1.1, 0.2 });
+            var actual = new Vector<double>(new double[] { 0.02, -0.05, 0.09, 0.01 });
+
+            Assert.Equal(plain.CalculateLoss(predicted, actual), explicitDefault.CalculateLoss(predicted, actual), 12);
+        }
+
+        [Fact(Timeout = 60000)]
+        public async Task Constructor_RejectsNegativePower()
+        {
+            await Task.CompletedTask;
+            Assert.Throws<ArgumentOutOfRangeException>(() => new PairwiseRankingLoss<double>(-0.5));
+        }
+
+        [Fact(Timeout = 60000)]
+        public async Task AllTiedActuals_GiveZeroLossAndZeroGradient()
+        {
+            await Task.CompletedTask;
+            var loss = new PairwiseRankingLoss<double>();
+            var predicted = new Vector<double>(new double[] { 1.0, 2.0, 3.0 });
+            var actual = new Vector<double>(new double[] { 5.0, 5.0, 5.0 });
+
+            Assert.Equal(0.0, loss.CalculateLoss(predicted, actual), 12);
+            var grad = loss.CalculateDerivative(predicted, actual);
+            for (int i = 0; i < grad.Length; i++) Assert.Equal(0.0, grad[i], 12);
+        }
+
+        // ---------- NDCG metric ----------
+
+        [Fact(Timeout = 60000)]
+        public async Task Ndcg_PerfectRanking_IsOne()
+        {
+            await Task.CompletedTask;
+            var predicted = new Vector<double>(new double[] { 3.0, 2.0, 1.0, 0.0 });
+            var relevance = new Vector<double>(new double[] { 3.0, 2.0, 1.0, 0.0 });
+
+            var ndcg = RankingMetrics<double>.NdcgAtK(predicted, relevance, 4);
+
+            Assert.Equal(1.0, ndcg, 9);
+        }
+
+        [Fact(Timeout = 60000)]
+        public async Task Ndcg_SwapDegradesScoreBelowOne()
+        {
+            await Task.CompletedTask;
+            var relevance = new Vector<double>(new double[] { 3.0, 2.0, 1.0, 0.0 });
+            // Swap top two predicted scores so the #2 item is ranked first.
+            var predicted = new Vector<double>(new double[] { 2.0, 3.0, 1.0, 0.0 });
+
+            var ndcg = RankingMetrics<double>.NdcgAtK(predicted, relevance, 4);
+
+            Assert.True(ndcg < 1.0, $"A swap should give NDCG < 1, got {ndcg}");
+            Assert.True(ndcg > 0.0);
+        }
+
+        [Fact(Timeout = 60000)]
+        public async Task Ndcg_AtK_OnlyConsidersTopK()
+        {
+            await Task.CompletedTask;
+            // Mistakes beyond the cutoff should not affect NDCG@1.
+            var relevance = new Vector<double>(new double[] { 5.0, 0.0, 4.0, 3.0 });
+            var predicted = new Vector<double>(new double[] { 9.0, 8.0, 1.0, 0.0 }); // top item correct, rest wrong
+
+            var ndcgAt1 = RankingMetrics<double>.NdcgAtK(predicted, relevance, 1);
+
+            // Top predicted item is the most relevant => NDCG@1 = 1 regardless of lower ranks.
+            Assert.Equal(1.0, ndcgAt1, 9);
+        }
+
+        [Fact(Timeout = 60000)]
+        public async Task Ndcg_LinearGain_HandlesSignedReturns()
+        {
+            await Task.CompletedTask;
+            // Signed forward returns: linear gain ranks the perfect order at its own ideal => 1.0.
+            var relevance = new Vector<double>(new double[] { 0.08, 0.01, -0.02, -0.07 });
+            var predicted = new Vector<double>(new double[] { 4.0, 3.0, 2.0, 1.0 });
+
+            var ndcg = RankingMetrics<double>.NdcgAtK(predicted, relevance, 4, useExponentialGain: false);
+
+            Assert.Equal(1.0, ndcg, 9);
+        }
+    }
+}

--- a/tests/AiDotNet.Tests/UnitTests/LossFunctions/PairwiseRankingLossTests.cs
+++ b/tests/AiDotNet.Tests/UnitTests/LossFunctions/PairwiseRankingLossTests.cs
@@ -15,7 +15,7 @@ namespace AiDotNetTests.UnitTests.LossFunctions
         [Fact(Timeout = 60000)]
         public async Task PerfectlyOrderedPredictions_GiveZeroLossInTheLimit()
         {
-            await Task.CompletedTask;
+            await Task.Yield();
             // Predictions perfectly ordered with a huge margin => log(1+exp(-large)) -> 0.
             var loss = new PairwiseRankingLoss<double>();
             var predicted = new Vector<double>(new double[] { 100.0, 50.0, 0.0, -50.0 });
@@ -30,7 +30,7 @@ namespace AiDotNetTests.UnitTests.LossFunctions
         [Fact(Timeout = 60000)]
         public async Task EqualScores_GiveLog2_StandardRankNetReference()
         {
-            await Task.CompletedTask;
+            await Task.Yield();
             // All predicted scores equal => every pair loss = log(1+exp(0)) = log(2).
             var loss = new PairwiseRankingLoss<double>();
             var predicted = new Vector<double>(new double[] { 0.0, 0.0, 0.0 });
@@ -44,7 +44,7 @@ namespace AiDotNetTests.UnitTests.LossFunctions
         [Fact(Timeout = 60000)]
         public async Task MisorderedPair_GivesPositiveLoss()
         {
-            await Task.CompletedTask;
+            await Task.Yield();
             var loss = new PairwiseRankingLoss<double>();
             // True order says item0 > item1, but predictions say item0 < item1 => positive loss.
             var predicted = new Vector<double>(new double[] { 0.0, 2.0 });
@@ -60,7 +60,7 @@ namespace AiDotNetTests.UnitTests.LossFunctions
         [Fact(Timeout = 60000)]
         public async Task Gradient_OnMisorderedPair_HasCorrectSign()
         {
-            await Task.CompletedTask;
+            await Task.Yield();
             var loss = new PairwiseRankingLoss<double>();
             // item0 should rank above item1 (actual 1 > 0) but predicted score is lower.
             var predicted = new Vector<double>(new double[] { 0.0, 2.0 });
@@ -79,7 +79,7 @@ namespace AiDotNetTests.UnitTests.LossFunctions
         [Fact(Timeout = 60000)]
         public async Task Gradient_MatchesFiniteDifference()
         {
-            await Task.CompletedTask;
+            await Task.Yield();
             var loss = new PairwiseRankingLoss<double>(tailWeightPower: 1.0);
             var predicted = new Vector<double>(new double[] { 0.3, -0.1, 1.2, 0.7 });
             var actual = new Vector<double>(new double[] { 0.05, -0.02, 0.10, -0.08 });
@@ -106,7 +106,7 @@ namespace AiDotNetTests.UnitTests.LossFunctions
         [Fact(Timeout = 60000)]
         public async Task TailWeighting_IncreasesContributionOfExtremePairs()
         {
-            await Task.CompletedTask;
+            await Task.Yield();
             // Two mis-ordered pairs of equal predicted-margin error, but one pair sits at the
             // extreme tails of the actual distribution and the other near the median.
             // Construct so that the extreme misorder dominates under tail weighting.
@@ -143,7 +143,7 @@ namespace AiDotNetTests.UnitTests.LossFunctions
         [Fact(Timeout = 60000)]
         public async Task TailWeightPower_Zero_EqualsStandardRankNet()
         {
-            await Task.CompletedTask;
+            await Task.Yield();
             var plain = new PairwiseRankingLoss<double>(tailWeightPower: 0.0);
             var explicitDefault = new PairwiseRankingLoss<double>();
 
@@ -156,14 +156,14 @@ namespace AiDotNetTests.UnitTests.LossFunctions
         [Fact(Timeout = 60000)]
         public async Task Constructor_RejectsNegativePower()
         {
-            await Task.CompletedTask;
+            await Task.Yield();
             Assert.Throws<ArgumentOutOfRangeException>(() => new PairwiseRankingLoss<double>(-0.5));
         }
 
         [Fact(Timeout = 60000)]
         public async Task AllTiedActuals_GiveZeroLossAndZeroGradient()
         {
-            await Task.CompletedTask;
+            await Task.Yield();
             var loss = new PairwiseRankingLoss<double>();
             var predicted = new Vector<double>(new double[] { 1.0, 2.0, 3.0 });
             var actual = new Vector<double>(new double[] { 5.0, 5.0, 5.0 });
@@ -178,7 +178,7 @@ namespace AiDotNetTests.UnitTests.LossFunctions
         [Fact(Timeout = 60000)]
         public async Task Ndcg_PerfectRanking_IsOne()
         {
-            await Task.CompletedTask;
+            await Task.Yield();
             var predicted = new Vector<double>(new double[] { 3.0, 2.0, 1.0, 0.0 });
             var relevance = new Vector<double>(new double[] { 3.0, 2.0, 1.0, 0.0 });
 
@@ -190,7 +190,7 @@ namespace AiDotNetTests.UnitTests.LossFunctions
         [Fact(Timeout = 60000)]
         public async Task Ndcg_SwapDegradesScoreBelowOne()
         {
-            await Task.CompletedTask;
+            await Task.Yield();
             var relevance = new Vector<double>(new double[] { 3.0, 2.0, 1.0, 0.0 });
             // Swap top two predicted scores so the #2 item is ranked first.
             var predicted = new Vector<double>(new double[] { 2.0, 3.0, 1.0, 0.0 });
@@ -204,7 +204,7 @@ namespace AiDotNetTests.UnitTests.LossFunctions
         [Fact(Timeout = 60000)]
         public async Task Ndcg_AtK_OnlyConsidersTopK()
         {
-            await Task.CompletedTask;
+            await Task.Yield();
             // Mistakes beyond the cutoff should not affect NDCG@1.
             var relevance = new Vector<double>(new double[] { 5.0, 0.0, 4.0, 3.0 });
             var predicted = new Vector<double>(new double[] { 9.0, 8.0, 1.0, 0.0 }); // top item correct, rest wrong
@@ -218,7 +218,7 @@ namespace AiDotNetTests.UnitTests.LossFunctions
         [Fact(Timeout = 60000)]
         public async Task Ndcg_LinearGain_HandlesSignedReturns()
         {
-            await Task.CompletedTask;
+            await Task.Yield();
             // Signed forward returns: linear gain ranks the perfect order at its own ideal => 1.0.
             var relevance = new Vector<double>(new double[] { 0.08, 0.01, -0.02, -0.07 });
             var predicted = new Vector<double>(new double[] { 4.0, 3.0, 2.0, 1.0 });

--- a/tests/AiDotNet.Tests/UnitTests/RAG/Embeddings/ONNXSentenceTransformerTests.cs
+++ b/tests/AiDotNet.Tests/UnitTests/RAG/Embeddings/ONNXSentenceTransformerTests.cs
@@ -200,6 +200,7 @@ namespace AiDotNetTests.UnitTests.RAG.Embeddings
         [Fact(Timeout = 60000)]
         public async Task BuildOnnxInputs_WhenTokenTypeIdsDeclared_ProducesZerosMatchingInputIdsLength()
         {
+            await Task.Yield();
             // Arrange
             var inputIds = new long[] { 101, 7592, 2088, 102 };
             var attentionMask = new long[] { 1, 1, 1, 1 };
@@ -224,6 +225,7 @@ namespace AiDotNetTests.UnitTests.RAG.Embeddings
         [Fact(Timeout = 60000)]
         public async Task BuildOnnxInputs_WhenTokenTypeIdsNotDeclared_OmitsIt()
         {
+            await Task.Yield();
             // Arrange
             var inputIds = new long[] { 101, 7592, 102 };
             var attentionMask = new long[] { 1, 1, 1 };
@@ -243,6 +245,7 @@ namespace AiDotNetTests.UnitTests.RAG.Embeddings
         [Fact(Timeout = 60000)]
         public async Task BuildOnnxInputs_AlwaysIncludesInputIdsWithCorrectShape()
         {
+            await Task.Yield();
             // Arrange
             var inputIds = new long[] { 101, 7592, 2088, 999, 102 };
             var attentionMask = new long[] { 1, 1, 1, 1, 1 };

--- a/tests/AiDotNet.Tests/UnitTests/RAG/Embeddings/ONNXSentenceTransformerTests.cs
+++ b/tests/AiDotNet.Tests/UnitTests/RAG/Embeddings/ONNXSentenceTransformerTests.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using AiDotNet.RetrievalAugmentedGeneration.EmbeddingModels;
 using Xunit;
 using System.Threading.Tasks;
@@ -189,5 +190,74 @@ namespace AiDotNetTests.UnitTests.RAG.Embeddings
             // Act & Assert
             Assert.Throws<FileNotFoundException>(() => model.Embed("Testing custom dimension"));
         }
+
+#if NET10_0_OR_GREATER
+        // Regression for the token_type_ids shape bug: when a sentence-transformer
+        // ONNX (e.g. all-MiniLM-L6-v2) declares token_type_ids, the builder must emit
+        // an all-zeros int64 tensor with the SAME shape as input_ids — NOT an empty
+        // tensor (which made onnxruntime throw "Length of memory (0) must match
+        // product of dimensions (seqLen)").
+        [Fact(Timeout = 60000)]
+        public async Task BuildOnnxInputs_WhenTokenTypeIdsDeclared_ProducesZerosMatchingInputIdsLength()
+        {
+            // Arrange
+            var inputIds = new long[] { 101, 7592, 2088, 102 };
+            var attentionMask = new long[] { 1, 1, 1, 1 };
+            var inputShape = new[] { 1, inputIds.Length };
+            var declared = new HashSet<string> { "input_ids", "attention_mask", "token_type_ids" };
+
+            // Act
+            var inputs = ONNXSentenceTransformer<double>.BuildOnnxInputs(
+                declared, inputIds, attentionMask, inputShape);
+
+            // Assert
+            var tokenTypeValue = inputs.Single(v => v.Name == "token_type_ids");
+            var tensor = tokenTypeValue.AsTensor<long>();
+            Assert.Equal(inputIds.Length, tensor.Length); // not 0
+            Assert.Equal(inputShape, tensor.Dimensions.ToArray());
+            foreach (var x in tensor)
+            {
+                Assert.Equal(0L, x); // single sentence => all segment 0
+            }
+        }
+
+        [Fact(Timeout = 60000)]
+        public async Task BuildOnnxInputs_WhenTokenTypeIdsNotDeclared_OmitsIt()
+        {
+            // Arrange
+            var inputIds = new long[] { 101, 7592, 102 };
+            var attentionMask = new long[] { 1, 1, 1 };
+            var inputShape = new[] { 1, inputIds.Length };
+            var declared = new HashSet<string> { "input_ids", "attention_mask" };
+
+            // Act
+            var inputs = ONNXSentenceTransformer<double>.BuildOnnxInputs(
+                declared, inputIds, attentionMask, inputShape);
+
+            // Assert
+            Assert.DoesNotContain(inputs, v => v.Name == "token_type_ids");
+            Assert.Contains(inputs, v => v.Name == "input_ids");
+            Assert.Contains(inputs, v => v.Name == "attention_mask");
+        }
+
+        [Fact(Timeout = 60000)]
+        public async Task BuildOnnxInputs_AlwaysIncludesInputIdsWithCorrectShape()
+        {
+            // Arrange
+            var inputIds = new long[] { 101, 7592, 2088, 999, 102 };
+            var attentionMask = new long[] { 1, 1, 1, 1, 1 };
+            var inputShape = new[] { 1, inputIds.Length };
+            var declared = new HashSet<string> { "input_ids" };
+
+            // Act
+            var inputs = ONNXSentenceTransformer<double>.BuildOnnxInputs(
+                declared, inputIds, attentionMask, inputShape);
+
+            // Assert
+            var idsTensor = inputs.Single(v => v.Name == "input_ids").AsTensor<long>();
+            Assert.Equal(inputIds.Length, idsTensor.Length);
+            Assert.Equal(inputShape, idsTensor.Dimensions.ToArray());
+        }
+#endif
     }
 }


### PR DESCRIPTION
BlackScholes<T> (price+delta/gamma/vega/theta/rho+IV), KellyCriterion<T> (discrete/continuous/fractional/from-returns), and a StandardScaler NaN-on-constant-column fix. 23 unit tests pass (net10+net471) vs textbook values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Black‑Scholes pricer with Greeks and implied volatility solver
  * Kelly‑criterion sizing (discrete/continuous/ fractional)
  * Markowitz mean‑variance optimizer
  * Risk metrics: Sharpe, Sortino, Calmar
  * Pairwise ranking loss with optional tail‑weighting
  * NDCG ranking metric

* **Bug Fixes**
  * Guarded against tiny negative variance in standard scaler

* **Improvements**
  * Reduced allocations in matrix decomposition for faster decompositions
  * Improved ONNX input wiring for broader model compatibility

* **Tests**
  * Added unit tests covering new finance, ranking, and ONNX input behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->