### PR TITLE
feat(agentic): Phase 3 — local in-process inference (epic #1544)

### DIFF
--- a/src/Agentic/Models/Local/AllowedTokenSetConstraint.cs
+++ b/src/Agentic/Models/Local/AllowedTokenSetConstraint.cs
@@ -1,0 +1,34 @@
+namespace AiDotNet.Agentic.Models.Local;
+
+/// <summary>
+/// A constraint that always restricts generation to a fixed set of token ids, regardless of context — for
+/// example, "only emit digit tokens" or "only emit tokens from this closed label vocabulary".
+/// </summary>
+/// <remarks>
+/// <para><b>For Beginners:</b> The simplest gate: a permanent allow-list. Whatever has been generated, only
+/// these tokens are ever permitted next. Handy when the whole answer must come from a small known set.
+/// </para>
+/// </remarks>
+public sealed class AllowedTokenSetConstraint : ITokenConstraint
+{
+    private readonly HashSet<int> _allowed;
+
+    /// <summary>
+    /// Initializes a new constraint permitting only the given token ids.
+    /// </summary>
+    /// <param name="allowedTokenIds">The permitted token ids. Must be non-null and non-empty.</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="allowedTokenIds"/> is <c>null</c>.</exception>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="allowedTokenIds"/> is empty.</exception>
+    public AllowedTokenSetConstraint(IEnumerable<int> allowedTokenIds)
+    {
+        Guard.NotNull(allowedTokenIds);
+        _allowed = new HashSet<int>(allowedTokenIds);
+        if (_allowed.Count == 0)
+        {
+            throw new ArgumentException("At least one allowed token id is required.", nameof(allowedTokenIds));
+        }
+    }
+
+    /// <inheritdoc/>
+    public IReadOnlyCollection<int>? AllowedNextTokens(IReadOnlyList<int> generatedTokenIds) => _allowed;
+}

--- a/src/Agentic/Models/Local/ChatMlPromptTemplate.cs
+++ b/src/Agentic/Models/Local/ChatMlPromptTemplate.cs
@@ -1,0 +1,52 @@
+using System.Text;
+using AiDotNet.Agentic.Models;
+
+// Disambiguate from the legacy AiDotNet.PromptEngineering.Templates.ChatMessage (global using).
+using ChatMessage = AiDotNet.Agentic.Models.ChatMessage;
+
+namespace AiDotNet.Agentic.Models.Local;
+
+/// <summary>
+/// A ChatML-style <see cref="IChatPromptTemplate"/> that renders each message as
+/// <c>&lt;|role|&gt;\n{text}\n</c> and ends with an open <c>&lt;|assistant|&gt;</c> turn for the model to
+/// complete. This is a widely-used, model-agnostic default.
+/// </summary>
+/// <remarks>
+/// <para><b>For Beginners:</b> This writes the conversation like a script: each line is tagged with who is
+/// speaking (<c>&lt;|user|&gt;</c>, <c>&lt;|assistant|&gt;</c>, ...), and the script stops right where the
+/// assistant is about to speak — so the model fills in the assistant's reply.
+/// </para>
+/// </remarks>
+public sealed class ChatMlPromptTemplate : IChatPromptTemplate
+{
+    /// <inheritdoc/>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="messages"/> is <c>null</c>.</exception>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="messages"/> is empty.</exception>
+    public string Render(IReadOnlyList<ChatMessage> messages)
+    {
+        Guard.NotNull(messages);
+        if (messages.Count == 0)
+        {
+            throw new ArgumentException("The conversation must contain at least one message.", nameof(messages));
+        }
+
+        var builder = new StringBuilder();
+        foreach (var message in messages)
+        {
+            builder.Append("<|").Append(RoleTag(message.Role)).Append("|>\n");
+            builder.Append(message.Text).Append('\n');
+        }
+
+        builder.Append("<|assistant|>\n");
+        return builder.ToString();
+    }
+
+    private static string RoleTag(ChatRole role) => role switch
+    {
+        ChatRole.System => "system",
+        ChatRole.User => "user",
+        ChatRole.Assistant => "assistant",
+        ChatRole.Tool => "tool",
+        _ => "user"
+    };
+}

--- a/src/Agentic/Models/Local/FiniteStateTokenConstraint.cs
+++ b/src/Agentic/Models/Local/FiniteStateTokenConstraint.cs
@@ -1,0 +1,61 @@
+namespace AiDotNet.Agentic.Models.Local;
+
+/// <summary>
+/// A constraint defined by a finite-state grammar over token ids: the set of allowed next tokens depends on
+/// the most recently generated token (the current state). This expresses exact sequences, branching choices,
+/// and loops — the general mechanism a JSON-schema or regular grammar compiles down to.
+/// </summary>
+/// <remarks>
+/// <para>
+/// State is the last generated token. Before any token is generated, the <c>start</c> set applies. From a
+/// state with no outgoing transitions, the empty set is returned, which tells the engine to stop — so a
+/// chain of single-token transitions forces an exact output, and terminal states end generation cleanly.
+/// </para>
+/// <para><b>For Beginners:</b> Picture a flowchart where each box says "from here, you may only go to these
+/// tokens next". Generation walks the flowchart; it can never step off it. Give each box exactly one exit and
+/// you force a precise output; give it several and you allow choices. Boxes with no exit end the answer.
+/// </para>
+/// </remarks>
+public sealed class FiniteStateTokenConstraint : ITokenConstraint
+{
+    private readonly IReadOnlyCollection<int> _start;
+    private readonly IReadOnlyDictionary<int, IReadOnlyCollection<int>> _transitions;
+
+    /// <summary>
+    /// Initializes a new finite-state constraint.
+    /// </summary>
+    /// <param name="start">The tokens allowed as the very first generated token. Must be non-empty.</param>
+    /// <param name="transitions">
+    /// A map from a just-generated token id to the tokens allowed after it. A token absent from the map (or
+    /// mapped to an empty set) is a terminal state at which generation stops.
+    /// </param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="start"/> or <paramref name="transitions"/> is <c>null</c>.</exception>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="start"/> is empty.</exception>
+    public FiniteStateTokenConstraint(
+        IEnumerable<int> start,
+        IReadOnlyDictionary<int, IReadOnlyCollection<int>> transitions)
+    {
+        Guard.NotNull(start);
+        Guard.NotNull(transitions);
+        _start = new List<int>(start);
+        if (_start.Count == 0)
+        {
+            throw new ArgumentException("At least one start token id is required.", nameof(start));
+        }
+
+        _transitions = transitions;
+    }
+
+    /// <inheritdoc/>
+    public IReadOnlyCollection<int>? AllowedNextTokens(IReadOnlyList<int> generatedTokenIds)
+    {
+        Guard.NotNull(generatedTokenIds);
+        if (generatedTokenIds.Count == 0)
+        {
+            return _start;
+        }
+
+        var lastToken = generatedTokenIds[generatedTokenIds.Count - 1];
+        return _transitions.TryGetValue(lastToken, out var allowed) ? allowed : Array.Empty<int>();
+    }
+}

--- a/src/Agentic/Models/Local/ICausalLanguageModel.cs
+++ b/src/Agentic/Models/Local/ICausalLanguageModel.cs
@@ -1,0 +1,38 @@
+using AiDotNet.LinearAlgebra;
+
+namespace AiDotNet.Agentic.Models.Local;
+
+/// <summary>
+/// The minimal contract an in-process language model exposes to the local generation engine: given the
+/// tokens seen so far, produce the logits for the next token. This is the seam between AiDotNet's own
+/// Transformer (or any other model) and <see cref="LocalEngineChatClient{T}"/>.
+/// </summary>
+/// <typeparam name="T">The tensor element type (e.g., <see cref="float"/> or <see cref="double"/>).</typeparam>
+/// <remarks>
+/// <para>
+/// Keeping the contract this small means the generation loop, sampling, and chat templating are written
+/// once and tested independently of any particular model, and the real network is wired in behind this
+/// interface. An implementation is free to maintain an internal KV-cache keyed on the growing context so
+/// repeated calls stay efficient; callers only ever ask for "the next-token logits given this context".
+/// </para>
+/// <para><b>For Beginners:</b> A language model, at its heart, answers one question over and over: "given
+/// everything so far, how likely is each possible next word-piece?" Those likelihoods (before turning them
+/// into probabilities) are called <em>logits</em>. This interface is exactly that one question, so the rest
+/// of the engine can focus on <em>choosing</em> the next token and stitching the words back together.
+/// </para>
+/// </remarks>
+public interface ICausalLanguageModel<T>
+{
+    /// <summary>
+    /// Gets the size of the model's vocabulary (the length of the logits vector returned by
+    /// <see cref="NextTokenLogits"/>).
+    /// </summary>
+    int VocabularySize { get; }
+
+    /// <summary>
+    /// Computes the next-token logits for the given context.
+    /// </summary>
+    /// <param name="tokenIds">The token ids of the context so far (prompt plus any tokens already generated). Must be non-empty.</param>
+    /// <returns>A vector of length <see cref="VocabularySize"/> giving the unnormalized score for each candidate next token.</returns>
+    Vector<T> NextTokenLogits(IReadOnlyList<int> tokenIds);
+}

--- a/src/Agentic/Models/Local/IChatPromptTemplate.cs
+++ b/src/Agentic/Models/Local/IChatPromptTemplate.cs
@@ -1,0 +1,27 @@
+using AiDotNet.Agentic.Models;
+
+// Disambiguate from the legacy AiDotNet.PromptEngineering.Templates.ChatMessage (global using).
+using ChatMessage = AiDotNet.Agentic.Models.ChatMessage;
+
+namespace AiDotNet.Agentic.Models.Local;
+
+/// <summary>
+/// Renders a chat conversation (a list of <see cref="ChatMessage"/>) into the single prompt string a local
+/// language model is fed. Different model families expect different role markers, so this is pluggable.
+/// </summary>
+/// <remarks>
+/// <para><b>For Beginners:</b> Cloud chat APIs accept a list of messages directly, but a raw local model
+/// just continues one block of text. This converts the conversation into that block, tagging who said what
+/// (system/user/assistant) in the format the model was trained on, and ends with the assistant's turn so the
+/// model knows it should reply next.
+/// </para>
+/// </remarks>
+public interface IChatPromptTemplate
+{
+    /// <summary>
+    /// Renders the conversation into a prompt string.
+    /// </summary>
+    /// <param name="messages">The conversation so far. Must be non-empty.</param>
+    /// <returns>The prompt text to encode and feed to the model.</returns>
+    string Render(IReadOnlyList<ChatMessage> messages);
+}

--- a/src/Agentic/Models/Local/IGenerationTokenizer.cs
+++ b/src/Agentic/Models/Local/IGenerationTokenizer.cs
@@ -1,0 +1,39 @@
+namespace AiDotNet.Agentic.Models.Local;
+
+/// <summary>
+/// The minimal tokenizer contract the local generation engine needs: turn text into token ids, turn token
+/// ids back into text, and know which token marks end-of-sequence.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This is intentionally narrower than the full <see cref="AiDotNet.Tokenization.Interfaces.ITokenizer"/> so
+/// the engine stays decoupled and trivially testable. <see cref="TokenizerGenerationAdapter"/> bridges a
+/// real repo tokenizer to this seam.
+/// </para>
+/// <para><b>For Beginners:</b> Models don't read text directly — they read numbers (token ids). This turns
+/// your prompt into those numbers, turns the model's numbers back into readable text, and tells the engine
+/// the special "stop here" token so it knows when the model is done.
+/// </para>
+/// </remarks>
+public interface IGenerationTokenizer
+{
+    /// <summary>
+    /// Gets the id of the end-of-sequence token. Generation stops when the model produces it. A negative
+    /// value means "no EOS token" (generation then stops only at the token limit).
+    /// </summary>
+    int EosTokenId { get; }
+
+    /// <summary>
+    /// Encodes text into token ids.
+    /// </summary>
+    /// <param name="text">The text to encode.</param>
+    /// <returns>The token ids.</returns>
+    IReadOnlyList<int> Encode(string text);
+
+    /// <summary>
+    /// Decodes token ids back into text.
+    /// </summary>
+    /// <param name="tokenIds">The token ids to decode.</param>
+    /// <returns>The decoded text.</returns>
+    string Decode(IReadOnlyList<int> tokenIds);
+}

--- a/src/Agentic/Models/Local/IIncrementalCausalLanguageModel.cs
+++ b/src/Agentic/Models/Local/IIncrementalCausalLanguageModel.cs
@@ -1,0 +1,46 @@
+using AiDotNet.LinearAlgebra;
+
+namespace AiDotNet.Agentic.Models.Local;
+
+/// <summary>
+/// An <see cref="ICausalLanguageModel{T}"/> that supports incremental (KV-cached) decoding: it processes the
+/// prompt once, caches the per-position state, and then advances one token at a time without recomputing the
+/// whole sequence. This is the fast path for autoregressive generation.
+/// </summary>
+/// <typeparam name="T">The tensor element type.</typeparam>
+/// <remarks>
+/// <para>
+/// The base <see cref="ICausalLanguageModel{T}.NextTokenLogits"/> re-feeds the full context each step, which
+/// is correct but O(n²) over a generation. A model that maintains a key/value cache implements this interface
+/// so <see cref="LocalEngineChatClient{T}"/> can drive it incrementally: <see cref="StartSequence"/> primes
+/// the cache with the prompt and returns the first next-token logits, then each <see cref="AppendToken"/>
+/// feeds a single new token and returns the following logits. <see cref="ResetCache"/> clears state between
+/// independent generations.
+/// </para>
+/// <para><b>For Beginners:</b> Without caching, predicting each new word re-reads the entire conversation —
+/// slower and slower as it grows. With caching, the model remembers the work it already did and only looks at
+/// the one new word each time. This interface is how a model advertises "I can do the fast, remember-as-you-go
+/// version"; the engine uses it automatically when available and falls back to the simple way otherwise.
+/// </para>
+/// </remarks>
+public interface IIncrementalCausalLanguageModel<T> : ICausalLanguageModel<T>
+{
+    /// <summary>
+    /// Clears any cached decoding state, so the next <see cref="StartSequence"/> begins fresh.
+    /// </summary>
+    void ResetCache();
+
+    /// <summary>
+    /// Processes the prompt, populating the cache, and returns the logits for the first generated token.
+    /// </summary>
+    /// <param name="promptTokenIds">The prompt token ids. Must be non-empty.</param>
+    /// <returns>The next-token logits following the prompt (length = <see cref="ICausalLanguageModel{T}.VocabularySize"/>).</returns>
+    Vector<T> StartSequence(IReadOnlyList<int> promptTokenIds);
+
+    /// <summary>
+    /// Appends a single token to the cached context and returns the logits for the token after it.
+    /// </summary>
+    /// <param name="tokenId">The token id to append (typically the one just generated).</param>
+    /// <returns>The next-token logits (length = <see cref="ICausalLanguageModel{T}.VocabularySize"/>).</returns>
+    Vector<T> AppendToken(int tokenId);
+}

--- a/src/Agentic/Models/Local/ITokenConstraint.cs
+++ b/src/Agentic/Models/Local/ITokenConstraint.cs
@@ -1,0 +1,33 @@
+namespace AiDotNet.Agentic.Models.Local;
+
+/// <summary>
+/// Restricts which tokens the local engine may generate next, enabling <em>constrained decoding</em>: the
+/// model can only emit tokens the constraint permits, so the output is guaranteed to satisfy a structure
+/// (a fixed vocabulary, a grammar, a JSON shape) rather than merely being asked to in the prompt.
+/// </summary>
+/// <remarks>
+/// <para>
+/// At each step the engine calls <see cref="AllowedNextTokens"/> with the tokens generated so far. Returning
+/// <c>null</c> means "no restriction this step"; returning a set restricts sampling to exactly those token
+/// ids; returning an empty set tells the engine to stop (nothing valid can follow). This is the foundation
+/// for local structured output and tool-calling — capabilities cloud models approximate with prompting but
+/// cannot guarantee, and which a local engine can enforce at the logits because it controls decoding.
+/// </para>
+/// <para><b>For Beginners:</b> Normally a model can pick any next word-piece. A constraint is a gate that
+/// only lets through the choices that keep the answer valid — for example, only digits when you want a
+/// number, or only tokens that continue well-formed JSON. Because the gate is applied while generating, the
+/// result is always valid by construction, not just "usually" valid.
+/// </para>
+/// </remarks>
+public interface ITokenConstraint
+{
+    /// <summary>
+    /// Returns the token ids permitted as the next token given what has been generated so far.
+    /// </summary>
+    /// <param name="generatedTokenIds">The tokens generated since the prompt (excludes the prompt itself).</param>
+    /// <returns>
+    /// <c>null</c> for no restriction; a non-empty set to restrict sampling to those ids; an empty set to
+    /// signal that generation should stop (no valid continuation exists).
+    /// </returns>
+    IReadOnlyCollection<int>? AllowedNextTokens(IReadOnlyList<int> generatedTokenIds);
+}

--- a/src/Agentic/Models/Local/LocalEngineChatClient.cs
+++ b/src/Agentic/Models/Local/LocalEngineChatClient.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using System.Runtime.CompilerServices;
 using AiDotNet.Agentic.Models;
 
@@ -74,10 +75,12 @@ public sealed class LocalEngineChatClient<T> : IChatClient<T>
         var sampler = new TokenSampler<T>(sampling.Seed);
         var maxTokens = ResolveMaxTokens(options);
 
+        var stopSequences = ResolveStopSequences(options);
         var generated = new List<int>();
-        var finishReason = RunGeneration(promptIds, maxTokens, sampler, sampling, generated, cancellationToken);
+        var finishReason = RunGeneration(promptIds, maxTokens, sampler, sampling, stopSequences, generated, cancellationToken);
 
         var text = generated.Count > 0 ? _tokenizer.Decode(generated) : string.Empty;
+        text = TrimAtStopSequence(text, stopSequences);
         var usage = new ChatUsage(promptIds.Count, generated.Count);
         var response = new ChatResponse(ChatMessage.Assistant(text), finishReason, usage, ModelId);
         return Task.FromResult(response);
@@ -98,6 +101,7 @@ public sealed class LocalEngineChatClient<T> : IChatClient<T>
 
         yield return new ChatResponseUpdate(role: ChatRole.Assistant);
 
+        var stopSequences = ResolveStopSequences(options);
         var context = new List<int>(promptIds);
         var generated = new List<int>();
         var previousText = string.Empty;
@@ -107,23 +111,28 @@ public sealed class LocalEngineChatClient<T> : IChatClient<T>
         {
             cancellationToken.ThrowIfCancellationRequested();
 
-            var logits = _model.NextTokenLogits(context);
-            var next = sampler.Sample(logits, sampling);
-            if (next == _tokenizer.EosTokenId)
+            var next = NextToken(context, generated, sampler, sampling);
+            if (next is null || next.Value == _tokenizer.EosTokenId)
             {
                 finishReason = ChatFinishReason.Stop;
                 break;
             }
 
-            generated.Add(next);
-            context.Add(next);
+            generated.Add(next.Value);
+            context.Add(next.Value);
 
-            var fullText = _tokenizer.Decode(generated);
+            var fullText = TrimAtStopSequence(_tokenizer.Decode(generated), stopSequences);
             if (fullText.Length > previousText.Length)
             {
                 var delta = fullText.Substring(previousText.Length);
                 previousText = fullText;
                 yield return ChatResponseUpdate.ForText(delta);
+            }
+
+            if (stopSequences is not null && ContainsStopSequence(_tokenizer.Decode(generated), stopSequences))
+            {
+                finishReason = ChatFinishReason.Stop;
+                break;
             }
         }
 
@@ -135,6 +144,7 @@ public sealed class LocalEngineChatClient<T> : IChatClient<T>
         int maxTokens,
         TokenSampler<T> sampler,
         LocalSamplingOptions sampling,
+        IReadOnlyList<string>? stopSequences,
         List<int> generated,
         CancellationToken cancellationToken)
     {
@@ -143,18 +153,90 @@ public sealed class LocalEngineChatClient<T> : IChatClient<T>
         {
             cancellationToken.ThrowIfCancellationRequested();
 
-            var logits = _model.NextTokenLogits(context);
-            var next = sampler.Sample(logits, sampling);
-            if (next == _tokenizer.EosTokenId)
+            var next = NextToken(context, generated, sampler, sampling);
+            if (next is null || next.Value == _tokenizer.EosTokenId)
             {
+                // null = the constraint reached a terminal state; either way generation is complete.
                 return ChatFinishReason.Stop;
             }
 
-            generated.Add(next);
-            context.Add(next);
+            generated.Add(next.Value);
+            context.Add(next.Value);
+
+            if (stopSequences is not null && ContainsStopSequence(_tokenizer.Decode(generated), stopSequences))
+            {
+                return ChatFinishReason.Stop;
+            }
         }
 
         return ChatFinishReason.Length;
+    }
+
+    // Computes the next token id honoring the configured constraint, or null when the constraint signals a
+    // terminal state (no valid continuation exists).
+    private int? NextToken(
+        List<int> context,
+        List<int> generated,
+        TokenSampler<T> sampler,
+        LocalSamplingOptions sampling)
+    {
+        IReadOnlyCollection<int>? allowed = null;
+        if (_options.Constraint is { } constraint)
+        {
+            allowed = constraint.AllowedNextTokens(generated);
+            if (allowed is not null && allowed.Count == 0)
+            {
+                return null;
+            }
+        }
+
+        var logits = _model.NextTokenLogits(context);
+        return sampler.Sample(logits, sampling, allowed);
+    }
+
+    private static IReadOnlyList<string>? ResolveStopSequences(ChatOptions? options)
+    {
+        var stops = options?.StopSequences;
+        if (stops is null || stops.Count == 0)
+        {
+            return null;
+        }
+
+        var filtered = stops.Where(s => s is not null && s.Length > 0).ToList();
+        return filtered.Count > 0 ? filtered : null;
+    }
+
+    private static bool ContainsStopSequence(string text, IReadOnlyList<string> stopSequences)
+    {
+        foreach (var stop in stopSequences)
+        {
+            if (text.IndexOf(stop, StringComparison.Ordinal) >= 0)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static string TrimAtStopSequence(string text, IReadOnlyList<string>? stopSequences)
+    {
+        if (stopSequences is null)
+        {
+            return text;
+        }
+
+        var earliest = -1;
+        foreach (var stop in stopSequences)
+        {
+            var index = text.IndexOf(stop, StringComparison.Ordinal);
+            if (index >= 0 && (earliest < 0 || index < earliest))
+            {
+                earliest = index;
+            }
+        }
+
+        return earliest >= 0 ? text.Substring(0, earliest) : text;
     }
 
     private List<int> BuildPromptIds(IReadOnlyList<ChatMessage> messages)

--- a/src/Agentic/Models/Local/LocalEngineChatClient.cs
+++ b/src/Agentic/Models/Local/LocalEngineChatClient.cs
@@ -71,13 +71,23 @@ public sealed class LocalEngineChatClient<T> : IChatClient<T>
         CancellationToken cancellationToken = default)
     {
         var promptIds = BuildPromptIds(messages);
-        var sampling = ResolveSampling(options);
-        var sampler = new TokenSampler<T>(sampling.Seed);
         var maxTokens = ResolveMaxTokens(options);
-
         var stopSequences = ResolveStopSequences(options);
-        var generated = new List<int>();
-        var finishReason = RunGeneration(promptIds, maxTokens, sampler, sampling, stopSequences, generated, cancellationToken);
+
+        List<int> generated;
+        ChatFinishReason finishReason;
+        var beamWidth = _options.BeamWidth is { } width && width > 1 ? width : 1;
+        if (beamWidth > 1)
+        {
+            (generated, finishReason) = RunBeamSearch(promptIds, maxTokens, beamWidth, stopSequences, cancellationToken);
+        }
+        else
+        {
+            var sampling = ResolveSampling(options);
+            var sampler = new TokenSampler<T>(sampling.Seed);
+            generated = new List<int>();
+            finishReason = RunGeneration(promptIds, maxTokens, sampler, sampling, stopSequences, generated, cancellationToken);
+        }
 
         var text = generated.Count > 0 ? _tokenizer.Decode(generated) : string.Empty;
         text = TrimAtStopSequence(text, stopSequences);
@@ -192,6 +202,152 @@ public sealed class LocalEngineChatClient<T> : IChatClient<T>
 
         var logits = _model.NextTokenLogits(context);
         return sampler.Sample(logits, sampling, allowed);
+    }
+
+    // Beam search: explore `beamWidth` hypotheses in parallel, expanding each by its top tokens (honoring
+    // the constraint), and keep the highest-scoring (length-normalized log-probability) beams. Returns the
+    // best completion. Deterministic.
+    private (List<int> Tokens, ChatFinishReason Finish) RunBeamSearch(
+        IReadOnlyList<int> promptIds,
+        int maxTokens,
+        int beamWidth,
+        IReadOnlyList<string>? stopSequences,
+        CancellationToken cancellationToken)
+    {
+        var beams = new List<Beam> { new(new List<int>(), 0.0, finished: false) };
+
+        for (var step = 0; step < maxTokens; step++)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            if (beams.All(b => b.Finished))
+            {
+                break;
+            }
+
+            var expanded = new List<Beam>();
+            foreach (var beam in beams)
+            {
+                if (beam.Finished)
+                {
+                    expanded.Add(beam);
+                    continue;
+                }
+
+                IReadOnlyCollection<int>? allowed = null;
+                if (_options.Constraint is { } constraint)
+                {
+                    allowed = constraint.AllowedNextTokens(beam.Tokens);
+                    if (allowed is not null && allowed.Count == 0)
+                    {
+                        expanded.Add(new Beam(beam.Tokens, beam.LogProbability, finished: true));
+                        continue;
+                    }
+                }
+
+                var context = new List<int>(promptIds.Count + beam.Tokens.Count);
+                context.AddRange(promptIds);
+                context.AddRange(beam.Tokens);
+
+                var logProbabilities = LogSoftmax(_model.NextTokenLogits(context), allowed);
+                foreach (var (tokenId, logProbability) in TopTokens(logProbabilities, beamWidth))
+                {
+                    var finished = tokenId == _tokenizer.EosTokenId;
+                    var tokens = new List<int>(beam.Tokens);
+                    if (!finished)
+                    {
+                        tokens.Add(tokenId);
+                    }
+
+                    if (!finished && stopSequences is not null && ContainsStopSequence(_tokenizer.Decode(tokens), stopSequences))
+                    {
+                        finished = true;
+                    }
+
+                    expanded.Add(new Beam(tokens, beam.LogProbability + logProbability, finished));
+                }
+            }
+
+            beams = expanded
+                .OrderByDescending(NormalizedScore)
+                .Take(beamWidth)
+                .ToList();
+        }
+
+        var best = beams.OrderByDescending(NormalizedScore).First();
+        return (best.Tokens, best.Finished ? ChatFinishReason.Stop : ChatFinishReason.Length);
+    }
+
+    private static double NormalizedScore(Beam beam) => beam.LogProbability / Math.Max(1, beam.Tokens.Count);
+
+    private static double[] LogSoftmax(Vector<T> logits, IReadOnlyCollection<int>? allowed)
+    {
+        var count = logits.Length;
+        bool[]? allowedMask = null;
+        if (allowed is not null)
+        {
+            allowedMask = new bool[count];
+            foreach (var id in allowed)
+            {
+                if (id >= 0 && id < count)
+                {
+                    allowedMask[id] = true;
+                }
+            }
+        }
+
+        var scores = new double[count];
+        var max = double.NegativeInfinity;
+        for (var i = 0; i < count; i++)
+        {
+            var value = allowedMask is null || allowedMask[i] ? Convert.ToDouble(logits[i]) : double.NegativeInfinity;
+            scores[i] = value;
+            if (value > max)
+            {
+                max = value;
+            }
+        }
+
+        var sumExp = 0.0;
+        for (var i = 0; i < count; i++)
+        {
+            if (!double.IsNegativeInfinity(scores[i]))
+            {
+                sumExp += Math.Exp(scores[i] - max);
+            }
+        }
+
+        var logSumExp = max + Math.Log(sumExp);
+        for (var i = 0; i < count; i++)
+        {
+            scores[i] = double.IsNegativeInfinity(scores[i]) ? double.NegativeInfinity : scores[i] - logSumExp;
+        }
+
+        return scores;
+    }
+
+    private static IEnumerable<(int TokenId, double LogProbability)> TopTokens(double[] logProbabilities, int k)
+    {
+        return Enumerable.Range(0, logProbabilities.Length)
+            .Where(i => !double.IsNegativeInfinity(logProbabilities[i]))
+            .OrderByDescending(i => logProbabilities[i])
+            .Take(k)
+            .Select(i => (i, logProbabilities[i]));
+    }
+
+    private sealed class Beam
+    {
+        public Beam(List<int> tokens, double logProbability, bool finished)
+        {
+            Tokens = tokens;
+            LogProbability = logProbability;
+            Finished = finished;
+        }
+
+        public List<int> Tokens { get; }
+
+        public double LogProbability { get; }
+
+        public bool Finished { get; }
     }
 
     private static IReadOnlyList<string>? ResolveStopSequences(ChatOptions? options)

--- a/src/Agentic/Models/Local/LocalEngineChatClient.cs
+++ b/src/Agentic/Models/Local/LocalEngineChatClient.cs
@@ -1,0 +1,195 @@
+using System.Runtime.CompilerServices;
+using AiDotNet.Agentic.Models;
+
+// Disambiguate from the legacy AiDotNet.PromptEngineering.Templates.ChatMessage (global using).
+using ChatMessage = AiDotNet.Agentic.Models.ChatMessage;
+
+namespace AiDotNet.Agentic.Models.Local;
+
+/// <summary>
+/// An <see cref="IChatClient{T}"/> that runs entirely in-process over an <see cref="ICausalLanguageModel{T}"/>
+/// — no network, no API key, no external service. It renders the conversation to a prompt, encodes it,
+/// autoregressively samples tokens until the end-of-sequence token or a length limit, and decodes the
+/// result. This is the flagship "local-first" capability: the same agent code that drives OpenAI or
+/// Anthropic drives AiDotNet's own model.
+/// </summary>
+/// <typeparam name="T">The tensor element type shared with the model.</typeparam>
+/// <remarks>
+/// <para>
+/// Because it implements <see cref="IChatClient{T}"/>, the local engine is a drop-in for every higher layer
+/// (agents, supervisor/swarm, memory). Both non-streaming and streaming generation are supported; streaming
+/// decodes incrementally and yields the new text on each step. Native tool-calling and structured-output
+/// constraints are not applied by this slice (they require constrained decoding, a follow-up) — supplied
+/// tools are ignored and the engine produces plain text.
+/// </para>
+/// <para><b>For Beginners:</b> This is your own chatbot brain running on your machine. You hand it the
+/// conversation; it writes the reply one word-piece at a time until it decides it's done or hits the length
+/// cap. Everything else in this library that talks to a "chat model" can talk to this one instead — so you
+/// can build agents with no cloud dependency at all.
+/// </para>
+/// </remarks>
+public sealed class LocalEngineChatClient<T> : IChatClient<T>
+{
+    private readonly ICausalLanguageModel<T> _model;
+    private readonly IGenerationTokenizer _tokenizer;
+    private readonly IChatPromptTemplate _template;
+    private readonly LocalEngineOptions _options;
+
+    /// <summary>
+    /// Initializes a new local engine.
+    /// </summary>
+    /// <param name="model">The in-process language model that produces next-token logits.</param>
+    /// <param name="tokenizer">The tokenizer used to encode prompts and decode generated tokens.</param>
+    /// <param name="template">The chat prompt template. <c>null</c> uses <see cref="ChatMlPromptTemplate"/>.</param>
+    /// <param name="options">Engine settings. <c>null</c> uses defaults.</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="model"/> or <paramref name="tokenizer"/> is <c>null</c>.</exception>
+    public LocalEngineChatClient(
+        ICausalLanguageModel<T> model,
+        IGenerationTokenizer tokenizer,
+        IChatPromptTemplate? template = null,
+        LocalEngineOptions? options = null)
+    {
+        Guard.NotNull(model);
+        Guard.NotNull(tokenizer);
+        _model = model;
+        _tokenizer = tokenizer;
+        _template = template ?? new ChatMlPromptTemplate();
+        _options = options ?? new LocalEngineOptions();
+    }
+
+    /// <inheritdoc/>
+    public string ModelId =>
+        _options.ModelId is { } id && id.Trim().Length > 0 ? id : "local";
+
+    /// <inheritdoc/>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="messages"/> is <c>null</c>.</exception>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="messages"/> is empty.</exception>
+    public Task<ChatResponse> GetResponseAsync(
+        IReadOnlyList<ChatMessage> messages,
+        ChatOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        var promptIds = BuildPromptIds(messages);
+        var sampling = ResolveSampling(options);
+        var sampler = new TokenSampler<T>(sampling.Seed);
+        var maxTokens = ResolveMaxTokens(options);
+
+        var generated = new List<int>();
+        var finishReason = RunGeneration(promptIds, maxTokens, sampler, sampling, generated, cancellationToken);
+
+        var text = generated.Count > 0 ? _tokenizer.Decode(generated) : string.Empty;
+        var usage = new ChatUsage(promptIds.Count, generated.Count);
+        var response = new ChatResponse(ChatMessage.Assistant(text), finishReason, usage, ModelId);
+        return Task.FromResult(response);
+    }
+
+    /// <inheritdoc/>
+    public async IAsyncEnumerable<ChatResponseUpdate> GetStreamingResponseAsync(
+        IReadOnlyList<ChatMessage> messages,
+        ChatOptions? options = null,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        await Task.CompletedTask.ConfigureAwait(false);
+
+        var promptIds = BuildPromptIds(messages);
+        var sampling = ResolveSampling(options);
+        var sampler = new TokenSampler<T>(sampling.Seed);
+        var maxTokens = ResolveMaxTokens(options);
+
+        yield return new ChatResponseUpdate(role: ChatRole.Assistant);
+
+        var context = new List<int>(promptIds);
+        var generated = new List<int>();
+        var previousText = string.Empty;
+        var finishReason = ChatFinishReason.Length;
+
+        for (var step = 0; step < maxTokens; step++)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var logits = _model.NextTokenLogits(context);
+            var next = sampler.Sample(logits, sampling);
+            if (next == _tokenizer.EosTokenId)
+            {
+                finishReason = ChatFinishReason.Stop;
+                break;
+            }
+
+            generated.Add(next);
+            context.Add(next);
+
+            var fullText = _tokenizer.Decode(generated);
+            if (fullText.Length > previousText.Length)
+            {
+                var delta = fullText.Substring(previousText.Length);
+                previousText = fullText;
+                yield return ChatResponseUpdate.ForText(delta);
+            }
+        }
+
+        yield return ChatResponseUpdate.ForFinish(finishReason, new ChatUsage(promptIds.Count, generated.Count));
+    }
+
+    private ChatFinishReason RunGeneration(
+        IReadOnlyList<int> promptIds,
+        int maxTokens,
+        TokenSampler<T> sampler,
+        LocalSamplingOptions sampling,
+        List<int> generated,
+        CancellationToken cancellationToken)
+    {
+        var context = new List<int>(promptIds);
+        for (var step = 0; step < maxTokens; step++)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var logits = _model.NextTokenLogits(context);
+            var next = sampler.Sample(logits, sampling);
+            if (next == _tokenizer.EosTokenId)
+            {
+                return ChatFinishReason.Stop;
+            }
+
+            generated.Add(next);
+            context.Add(next);
+        }
+
+        return ChatFinishReason.Length;
+    }
+
+    private List<int> BuildPromptIds(IReadOnlyList<ChatMessage> messages)
+    {
+        Guard.NotNull(messages);
+        if (messages.Count == 0)
+        {
+            throw new ArgumentException("The conversation must contain at least one message.", nameof(messages));
+        }
+
+        var prompt = _template.Render(messages);
+        return new List<int>(_tokenizer.Encode(prompt));
+    }
+
+    private int ResolveMaxTokens(ChatOptions? options)
+    {
+        if (options?.MaxOutputTokens is { } requested && requested > 0)
+        {
+            return requested;
+        }
+
+        return _options.MaxOutputTokens is { } configured && configured > 0
+            ? configured
+            : LocalEngineOptions.DefaultMaxOutputTokens;
+    }
+
+    private LocalSamplingOptions ResolveSampling(ChatOptions? options)
+    {
+        var defaults = _options.Sampling ?? new LocalSamplingOptions();
+        return new LocalSamplingOptions
+        {
+            Temperature = options?.Temperature ?? defaults.Temperature,
+            TopK = options?.TopK ?? defaults.TopK,
+            TopP = options?.TopP ?? defaults.TopP,
+            Seed = options?.Seed ?? defaults.Seed,
+        };
+    }
+}

--- a/src/Agentic/Models/Local/LocalEngineChatClient.cs
+++ b/src/Agentic/Models/Local/LocalEngineChatClient.cs
@@ -86,7 +86,9 @@ public sealed class LocalEngineChatClient<T> : IChatClient<T>
             var sampling = ResolveSampling(options);
             var sampler = new TokenSampler<T>(sampling.Seed);
             generated = new List<int>();
-            finishReason = RunGeneration(promptIds, maxTokens, sampler, sampling, stopSequences, generated, cancellationToken);
+            finishReason = _model is IIncrementalCausalLanguageModel<T> incremental
+                ? RunGenerationIncremental(incremental, promptIds, maxTokens, sampler, sampling, stopSequences, generated, cancellationToken)
+                : RunGeneration(promptIds, maxTokens, sampler, sampling, stopSequences, generated, cancellationToken);
         }
 
         var text = generated.Count > 0 ? _tokenizer.Decode(generated) : string.Empty;
@@ -182,11 +184,51 @@ public sealed class LocalEngineChatClient<T> : IChatClient<T>
         return ChatFinishReason.Length;
     }
 
-    // Computes the next token id honoring the configured constraint, or null when the constraint signals a
-    // terminal state (no valid continuation exists).
-    private int? NextToken(
-        List<int> context,
+    // Incremental (KV-cached) generation: prime with the prompt, then advance one token at a time.
+    private ChatFinishReason RunGenerationIncremental(
+        IIncrementalCausalLanguageModel<T> model,
+        IReadOnlyList<int> promptIds,
+        int maxTokens,
+        TokenSampler<T> sampler,
+        LocalSamplingOptions sampling,
+        IReadOnlyList<string>? stopSequences,
         List<int> generated,
+        CancellationToken cancellationToken)
+    {
+        model.ResetCache();
+        var logits = model.StartSequence(promptIds);
+
+        for (var step = 0; step < maxTokens; step++)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var next = PickToken(generated, logits, sampler, sampling);
+            if (next is null || next.Value == _tokenizer.EosTokenId)
+            {
+                return ChatFinishReason.Stop;
+            }
+
+            generated.Add(next.Value);
+
+            if (stopSequences is not null && ContainsStopSequence(_tokenizer.Decode(generated), stopSequences))
+            {
+                return ChatFinishReason.Stop;
+            }
+
+            if (step < maxTokens - 1)
+            {
+                logits = model.AppendToken(next.Value);
+            }
+        }
+
+        return ChatFinishReason.Length;
+    }
+
+    // Computes the next token id from precomputed logits, honoring the configured constraint, or null when
+    // the constraint signals a terminal state (no valid continuation exists).
+    private int? PickToken(
+        List<int> generated,
+        Vector<T> logits,
         TokenSampler<T> sampler,
         LocalSamplingOptions sampling)
     {
@@ -200,9 +242,16 @@ public sealed class LocalEngineChatClient<T> : IChatClient<T>
             }
         }
 
-        var logits = _model.NextTokenLogits(context);
         return sampler.Sample(logits, sampling, allowed);
     }
+
+    // Computes the next token id by re-feeding the full context (fallback when the model has no KV-cache).
+    private int? NextToken(
+        List<int> context,
+        List<int> generated,
+        TokenSampler<T> sampler,
+        LocalSamplingOptions sampling) =>
+        PickToken(generated, _model.NextTokenLogits(context), sampler, sampling);
 
     // Beam search: explore `beamWidth` hypotheses in parallel, expanding each by its top tokens (honoring
     // the constraint), and keep the highest-scoring (length-normalized log-probability) beams. Returns the

--- a/src/Agentic/Models/Local/LocalEngineOptions.cs
+++ b/src/Agentic/Models/Local/LocalEngineOptions.cs
@@ -40,4 +40,13 @@ public sealed class LocalEngineOptions
     /// vocabulary) at the logits rather than relying on prompting.
     /// </summary>
     public ITokenConstraint? Constraint { get; set; }
+
+    /// <summary>
+    /// Gets or sets the beam width for beam-search decoding. <c>null</c> or a value &lt;= 1 uses ordinary
+    /// token-by-token sampling/greedy decoding. A value &gt; 1 explores that many hypotheses in parallel and
+    /// returns the highest-scoring (length-normalized) completion — deterministic, and typically higher
+    /// quality than greedy for short structured outputs. Beam search applies to non-streaming
+    /// <see cref="LocalEngineChatClient{T}.GetResponseAsync"/>; streaming always decodes token-by-token.
+    /// </summary>
+    public int? BeamWidth { get; set; }
 }

--- a/src/Agentic/Models/Local/LocalEngineOptions.cs
+++ b/src/Agentic/Models/Local/LocalEngineOptions.cs
@@ -33,4 +33,11 @@ public sealed class LocalEngineOptions
     /// <see cref="ChatOptions"/> values (temperature, top-k, top-p, seed) override the matching fields.
     /// </summary>
     public LocalSamplingOptions? Sampling { get; set; }
+
+    /// <summary>
+    /// Gets or sets a token constraint applied during generation (constrained decoding). <c>null</c> means
+    /// unconstrained generation. Use this to guarantee structured output (a grammar, JSON shape, or a closed
+    /// vocabulary) at the logits rather than relying on prompting.
+    /// </summary>
+    public ITokenConstraint? Constraint { get; set; }
 }

--- a/src/Agentic/Models/Local/LocalEngineOptions.cs
+++ b/src/Agentic/Models/Local/LocalEngineOptions.cs
@@ -1,0 +1,36 @@
+namespace AiDotNet.Agentic.Models.Local;
+
+/// <summary>
+/// Settings for <see cref="LocalEngineChatClient{T}"/>: the reported model id, the default generation length,
+/// and the default sampling behavior (overridable per request via <see cref="ChatOptions"/>).
+/// </summary>
+/// <remarks>
+/// <para><b>For Beginners:</b> These are the local model's defaults. The most useful is
+/// <see cref="MaxOutputTokens"/> (how long a reply may get before the engine stops). Leave
+/// <see cref="Sampling"/> unset for safe, near-greedy behavior, or set it to make replies more creative.
+/// </para>
+/// </remarks>
+public sealed class LocalEngineOptions
+{
+    /// <summary>The default maximum number of tokens generated per reply when none is specified.</summary>
+    public const int DefaultMaxOutputTokens = 256;
+
+    /// <summary>
+    /// Gets or sets the model id reported by <see cref="LocalEngineChatClient{T}.ModelId"/>. <c>null</c> or
+    /// empty falls back to <c>"local"</c>.
+    /// </summary>
+    public string? ModelId { get; set; }
+
+    /// <summary>
+    /// Gets or sets the default maximum number of tokens to generate per reply. <c>null</c> or a non-positive
+    /// value uses <see cref="DefaultMaxOutputTokens"/>. A request's <see cref="ChatOptions.MaxOutputTokens"/>
+    /// overrides this.
+    /// </summary>
+    public int? MaxOutputTokens { get; set; }
+
+    /// <summary>
+    /// Gets or sets the default sampling settings. <c>null</c> uses near-greedy defaults. Per-request
+    /// <see cref="ChatOptions"/> values (temperature, top-k, top-p, seed) override the matching fields.
+    /// </summary>
+    public LocalSamplingOptions? Sampling { get; set; }
+}

--- a/src/Agentic/Models/Local/LocalSamplingOptions.cs
+++ b/src/Agentic/Models/Local/LocalSamplingOptions.cs
@@ -1,0 +1,46 @@
+namespace AiDotNet.Agentic.Models.Local;
+
+/// <summary>
+/// Controls how the next token is chosen from the model's logits: temperature, top-k, top-p (nucleus), and
+/// an optional seed for reproducibility.
+/// </summary>
+/// <remarks>
+/// <para>
+/// All values are nullable with sensible behavior when unset. A temperature of <c>0</c> (or less) selects
+/// greedy decoding (always the highest-scoring token); higher temperatures increase randomness. Top-k and
+/// top-p restrict sampling to the most likely tokens. These mirror the knobs exposed on
+/// <see cref="ChatOptions"/>, which override these per request.
+/// </para>
+/// <para><b>For Beginners:</b> After the model says how likely each next word-piece is, these settings decide
+/// how to pick one. Low temperature = safe and repetitive; higher = more creative. Top-k ("only consider the
+/// best k options") and top-p ("only consider the most likely options that together cover p% of the
+/// probability") keep the choice from wandering into unlikely tokens.
+/// </para>
+/// </remarks>
+public sealed class LocalSamplingOptions
+{
+    /// <summary>
+    /// Gets or sets the sampling temperature. <c>null</c> uses <c>1.0</c>; <c>0</c> or less selects greedy
+    /// (deterministic argmax) decoding.
+    /// </summary>
+    public double? Temperature { get; set; }
+
+    /// <summary>
+    /// Gets or sets the number of highest-probability tokens to consider. <c>null</c> or a non-positive
+    /// value disables the top-k restriction.
+    /// </summary>
+    public int? TopK { get; set; }
+
+    /// <summary>
+    /// Gets or sets the nucleus-sampling probability mass (0–1): only the most likely tokens whose
+    /// cumulative probability reaches this value are considered. <c>null</c> or a value outside (0,1)
+    /// disables the top-p restriction.
+    /// </summary>
+    public double? TopP { get; set; }
+
+    /// <summary>
+    /// Gets or sets the random seed for reproducible sampling. <c>null</c> uses a non-deterministic seed.
+    /// Ignored under greedy decoding (which is already deterministic).
+    /// </summary>
+    public int? Seed { get; set; }
+}

--- a/src/Agentic/Models/Local/NeuralNetworkCausalLanguageModel.cs
+++ b/src/Agentic/Models/Local/NeuralNetworkCausalLanguageModel.cs
@@ -19,6 +19,12 @@ namespace AiDotNet.Agentic.Models.Local;
 /// and calls <see cref="NeuralNetworkBase{T}.ResetState"/> before each pass so recurrent models (Mamba/GLA)
 /// start fresh — correct, if not yet optimal. A KV-cached fast path is a planned follow-up.
 /// </para>
+/// <para>
+/// <b>Quantization</b> composes through this adapter rather than being re-implemented here: quantize the
+/// network with the repository's <c>ModelCompression</c> stack first, then wrap the quantized
+/// <see cref="NeuralNetworkBase{T}"/> — the adapter accepts any such network unchanged, so a smaller/faster
+/// model needs no engine-side code.
+/// </para>
 /// <para><b>For Beginners:</b> This is the bridge that lets the local chat engine talk to a real AiDotNet
 /// network. It turns the running list of tokens into the exact tensor shape the network expects, asks the
 /// network for its prediction, and hands back the scores for the next token — which the engine then samples

--- a/src/Agentic/Models/Local/NeuralNetworkCausalLanguageModel.cs
+++ b/src/Agentic/Models/Local/NeuralNetworkCausalLanguageModel.cs
@@ -1,0 +1,126 @@
+using AiDotNet.LinearAlgebra;
+using AiDotNet.NeuralNetworks;
+using AiDotNet.Tensors;
+
+namespace AiDotNet.Agentic.Models.Local;
+
+/// <summary>
+/// Adapts a trained AiDotNet <see cref="NeuralNetworkBase{T}"/> language model (e.g.,
+/// <c>MambaLanguageModel</c>, <c>GLALanguageModel</c>, or a Transformer LM head) to the
+/// <see cref="ICausalLanguageModel{T}"/> seam, so <see cref="LocalEngineChatClient{T}"/> can run real,
+/// fully in-process generation over the library's own networks.
+/// </summary>
+/// <typeparam name="T">The tensor element type of the network (e.g., <see cref="float"/> or <see cref="double"/>).</typeparam>
+/// <remarks>
+/// <para>
+/// AiDotNet's language models accept a one-hot input tensor of shape <c>[1, sequence, vocab]</c> and return
+/// logits of the same leading shape. This adapter encodes the context as that one-hot tensor, runs a forward
+/// pass, and returns the final position's logits. It re-feeds the full context each step (no KV-cache yet)
+/// and calls <see cref="NeuralNetworkBase{T}.ResetState"/> before each pass so recurrent models (Mamba/GLA)
+/// start fresh — correct, if not yet optimal. A KV-cached fast path is a planned follow-up.
+/// </para>
+/// <para><b>For Beginners:</b> This is the bridge that lets the local chat engine talk to a real AiDotNet
+/// network. It turns the running list of tokens into the exact tensor shape the network expects, asks the
+/// network for its prediction, and hands back the scores for the next token — which the engine then samples
+/// from. The result: a chatbot powered entirely by an in-house model, no external service.
+/// </para>
+/// </remarks>
+public sealed class NeuralNetworkCausalLanguageModel<T> : ICausalLanguageModel<T>
+{
+    private static readonly T One = (T)Convert.ChangeType(1.0, typeof(T));
+
+    private readonly NeuralNetworkBase<T> _network;
+    private readonly int _maxContextTokens;
+
+    /// <summary>
+    /// Initializes a new adapter over a network language model.
+    /// </summary>
+    /// <param name="network">The trained network whose <c>Predict</c> maps one-hot tokens to vocab logits.</param>
+    /// <param name="vocabularySize">The model's vocabulary size (the width of the one-hot input and logits).</param>
+    /// <param name="maxContextTokens">
+    /// The maximum number of most-recent tokens to feed the network (typically its max sequence length).
+    /// <c>null</c> or non-positive feeds the entire context.
+    /// </param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="network"/> is <c>null</c>.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="vocabularySize"/> is not positive.</exception>
+    public NeuralNetworkCausalLanguageModel(NeuralNetworkBase<T> network, int vocabularySize, int? maxContextTokens = null)
+    {
+        Guard.NotNull(network);
+        Guard.Positive(vocabularySize);
+        _network = network;
+        VocabularySize = vocabularySize;
+        _maxContextTokens = maxContextTokens is { } configured && configured > 0 ? configured : int.MaxValue;
+    }
+
+    /// <inheritdoc/>
+    public int VocabularySize { get; }
+
+    /// <inheritdoc/>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="tokenIds"/> is <c>null</c>.</exception>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="tokenIds"/> is empty.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when a token id is outside the vocabulary.</exception>
+    public Vector<T> NextTokenLogits(IReadOnlyList<int> tokenIds)
+    {
+        Guard.NotNull(tokenIds);
+        if (tokenIds.Count == 0)
+        {
+            throw new ArgumentException("The context must contain at least one token.", nameof(tokenIds));
+        }
+
+        var start = _maxContextTokens == int.MaxValue ? 0 : Math.Max(0, tokenIds.Count - _maxContextTokens);
+        var sequenceLength = tokenIds.Count - start;
+
+        var input = new Tensor<T>(new[] { 1, sequenceLength, VocabularySize });
+        for (var position = 0; position < sequenceLength; position++)
+        {
+            var id = tokenIds[start + position];
+            if (id < 0 || id >= VocabularySize)
+            {
+                throw new ArgumentOutOfRangeException(
+                    nameof(tokenIds), id, $"Token id is outside the vocabulary [0, {VocabularySize}).");
+            }
+
+            input[new[] { 0, position, id }] = One;
+        }
+
+        _network.ResetState();
+        var output = _network.Predict(input);
+        return ExtractLastPositionLogits(output);
+    }
+
+    private Vector<T> ExtractLastPositionLogits(Tensor<T> output)
+    {
+        var shape = output.Shape.ToArray();
+        var vocab = shape[shape.Length - 1];
+        if (vocab != VocabularySize)
+        {
+            throw new InvalidOperationException(
+                $"Model produced logits of width {vocab}, but vocabulary size is {VocabularySize}.");
+        }
+
+        var logits = new T[vocab];
+        if (shape.Length == 3)
+        {
+            var lastPosition = shape[1] - 1;
+            for (var v = 0; v < vocab; v++)
+            {
+                logits[v] = output[new[] { 0, lastPosition, v }];
+            }
+        }
+        else if (shape.Length == 2)
+        {
+            var lastPosition = shape[0] - 1;
+            for (var v = 0; v < vocab; v++)
+            {
+                logits[v] = output[new[] { lastPosition, v }];
+            }
+        }
+        else
+        {
+            throw new InvalidOperationException(
+                $"Expected logits of rank 2 or 3, but the model returned rank {shape.Length}.");
+        }
+
+        return new Vector<T>(logits);
+    }
+}

--- a/src/Agentic/Models/Local/TokenSampler.cs
+++ b/src/Agentic/Models/Local/TokenSampler.cs
@@ -35,20 +35,30 @@ public sealed class TokenSampler<T>
     }
 
     /// <summary>
-    /// Chooses the next token id from the supplied logits.
+    /// Chooses the next token id from the supplied logits, optionally restricted to an allowed set
+    /// (constrained decoding).
     /// </summary>
     /// <param name="logits">The next-token logits (length = vocabulary size). Must be non-empty.</param>
     /// <param name="options">The sampling settings. <c>null</c> uses defaults (temperature 1.0, no filters).</param>
+    /// <param name="allowedTokenIds">
+    /// When non-null, sampling is restricted to these token ids (others are excluded). Must be non-empty when
+    /// provided. <c>null</c> means all tokens are eligible.
+    /// </param>
     /// <returns>The chosen token id (an index into <paramref name="logits"/>).</returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="logits"/> is <c>null</c>.</exception>
-    /// <exception cref="ArgumentException">Thrown when <paramref name="logits"/> is empty.</exception>
-    public int Sample(Vector<T> logits, LocalSamplingOptions? options = null)
+    /// <exception cref="ArgumentException">Thrown when <paramref name="logits"/> or <paramref name="allowedTokenIds"/> is empty.</exception>
+    public int Sample(Vector<T> logits, LocalSamplingOptions? options = null, IReadOnlyCollection<int>? allowedTokenIds = null)
     {
         Guard.NotNull(logits);
         var count = logits.Length;
         if (count == 0)
         {
             throw new ArgumentException("Logits must be non-empty.", nameof(logits));
+        }
+
+        if (allowedTokenIds is not null && allowedTokenIds.Count == 0)
+        {
+            throw new ArgumentException("The allowed token set must be non-empty when provided.", nameof(allowedTokenIds));
         }
 
         var settings = options ?? new LocalSamplingOptions();
@@ -59,10 +69,12 @@ public sealed class TokenSampler<T>
             scores[i] = Convert.ToDouble(logits[i]);
         }
 
+        var allowed = BuildAllowedMask(count, allowedTokenIds);
+
         var temperature = settings.Temperature ?? 1.0;
         if (temperature <= 0)
         {
-            return ArgMax(scores);
+            return ArgMax(scores, allowed);
         }
 
         for (var i = 0; i < count; i++)
@@ -94,11 +106,15 @@ public sealed class TokenSampler<T>
             probabilities[i] /= sum;
         }
 
-        // Candidate token ids, ordered by descending probability (so top-k / top-p slice from the front).
+        // Candidate token ids (allowed only), ordered by descending probability so top-k / top-p slice
+        // from the front.
         var candidates = new List<int>(count);
         for (var i = 0; i < count; i++)
         {
-            candidates.Add(i);
+            if (allowed is null || allowed[i])
+            {
+                candidates.Add(i);
+            }
         }
 
         candidates.Sort((a, b) => probabilities[b].CompareTo(probabilities[a]));
@@ -145,19 +161,44 @@ public sealed class TokenSampler<T>
         return candidates[candidates.Count - 1];
     }
 
-    private static int ArgMax(double[] scores)
+    private static bool[]? BuildAllowedMask(int count, IReadOnlyCollection<int>? allowedTokenIds)
     {
-        var bestIndex = 0;
-        var best = scores[0];
-        for (var i = 1; i < scores.Length; i++)
+        if (allowedTokenIds is null)
         {
-            if (scores[i] > best)
+            return null;
+        }
+
+        var mask = new bool[count];
+        foreach (var id in allowedTokenIds)
+        {
+            if (id >= 0 && id < count)
+            {
+                mask[id] = true;
+            }
+        }
+
+        return mask;
+    }
+
+    private static int ArgMax(double[] scores, bool[]? allowed)
+    {
+        var bestIndex = -1;
+        var best = double.NegativeInfinity;
+        for (var i = 0; i < scores.Length; i++)
+        {
+            if (allowed is not null && !allowed[i])
+            {
+                continue;
+            }
+
+            if (bestIndex < 0 || scores[i] > best)
             {
                 best = scores[i];
                 bestIndex = i;
             }
         }
 
-        return bestIndex;
+        // If the allowed set referenced only out-of-range ids, fall back to the global argmax.
+        return bestIndex >= 0 ? bestIndex : 0;
     }
 }

--- a/src/Agentic/Models/Local/TokenSampler.cs
+++ b/src/Agentic/Models/Local/TokenSampler.cs
@@ -1,0 +1,163 @@
+using AiDotNet.LinearAlgebra;
+
+namespace AiDotNet.Agentic.Models.Local;
+
+/// <summary>
+/// Selects the next token id from a logits vector according to <see cref="LocalSamplingOptions"/>:
+/// greedy (argmax) when temperature is zero, otherwise temperature-scaled softmax sampling restricted by
+/// optional top-k and top-p filters.
+/// </summary>
+/// <typeparam name="T">The logits element type.</typeparam>
+/// <remarks>
+/// <para>
+/// The sampler owns a single <see cref="Random"/> (seeded from <see cref="LocalSamplingOptions.Seed"/> when
+/// provided), so a fixed seed yields a reproducible token stream. Logits are read through
+/// <see cref="Convert.ToDouble(object)"/>, so the same code path serves <see cref="float"/> and
+/// <see cref="double"/> models.
+/// </para>
+/// <para><b>For Beginners:</b> This is the "dice roll" step. With temperature 0 it isn't a roll at all — it
+/// just takes the single most likely token. Otherwise it turns the scores into probabilities, optionally
+/// throws away the unlikely options (top-k / top-p), and then picks one at random in proportion to how
+/// likely each is.
+/// </para>
+/// </remarks>
+public sealed class TokenSampler<T>
+{
+    private readonly Random _random;
+
+    /// <summary>
+    /// Initializes a new sampler.
+    /// </summary>
+    /// <param name="seed">Optional RNG seed for reproducibility. <c>null</c> uses a non-deterministic seed.</param>
+    public TokenSampler(int? seed = null)
+    {
+        _random = seed is { } value ? new Random(value) : new Random();
+    }
+
+    /// <summary>
+    /// Chooses the next token id from the supplied logits.
+    /// </summary>
+    /// <param name="logits">The next-token logits (length = vocabulary size). Must be non-empty.</param>
+    /// <param name="options">The sampling settings. <c>null</c> uses defaults (temperature 1.0, no filters).</param>
+    /// <returns>The chosen token id (an index into <paramref name="logits"/>).</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="logits"/> is <c>null</c>.</exception>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="logits"/> is empty.</exception>
+    public int Sample(Vector<T> logits, LocalSamplingOptions? options = null)
+    {
+        Guard.NotNull(logits);
+        var count = logits.Length;
+        if (count == 0)
+        {
+            throw new ArgumentException("Logits must be non-empty.", nameof(logits));
+        }
+
+        var settings = options ?? new LocalSamplingOptions();
+
+        var scores = new double[count];
+        for (var i = 0; i < count; i++)
+        {
+            scores[i] = Convert.ToDouble(logits[i]);
+        }
+
+        var temperature = settings.Temperature ?? 1.0;
+        if (temperature <= 0)
+        {
+            return ArgMax(scores);
+        }
+
+        for (var i = 0; i < count; i++)
+        {
+            scores[i] /= temperature;
+        }
+
+        // Numerically stable softmax.
+        var max = double.NegativeInfinity;
+        for (var i = 0; i < count; i++)
+        {
+            if (scores[i] > max)
+            {
+                max = scores[i];
+            }
+        }
+
+        var probabilities = new double[count];
+        var sum = 0.0;
+        for (var i = 0; i < count; i++)
+        {
+            var p = Math.Exp(scores[i] - max);
+            probabilities[i] = p;
+            sum += p;
+        }
+
+        for (var i = 0; i < count; i++)
+        {
+            probabilities[i] /= sum;
+        }
+
+        // Candidate token ids, ordered by descending probability (so top-k / top-p slice from the front).
+        var candidates = new List<int>(count);
+        for (var i = 0; i < count; i++)
+        {
+            candidates.Add(i);
+        }
+
+        candidates.Sort((a, b) => probabilities[b].CompareTo(probabilities[a]));
+
+        if (settings.TopK is { } topK && topK > 0 && topK < candidates.Count)
+        {
+            candidates = candidates.GetRange(0, topK);
+        }
+
+        if (settings.TopP is { } topP && topP > 0 && topP < 1)
+        {
+            var kept = new List<int>(candidates.Count);
+            var cumulative = 0.0;
+            foreach (var id in candidates)
+            {
+                kept.Add(id);
+                cumulative += probabilities[id];
+                if (cumulative >= topP)
+                {
+                    break;
+                }
+            }
+
+            candidates = kept;
+        }
+
+        var total = 0.0;
+        foreach (var id in candidates)
+        {
+            total += probabilities[id];
+        }
+
+        var threshold = _random.NextDouble() * total;
+        var accumulated = 0.0;
+        foreach (var id in candidates)
+        {
+            accumulated += probabilities[id];
+            if (threshold <= accumulated)
+            {
+                return id;
+            }
+        }
+
+        return candidates[candidates.Count - 1];
+    }
+
+    private static int ArgMax(double[] scores)
+    {
+        var bestIndex = 0;
+        var best = scores[0];
+        for (var i = 1; i < scores.Length; i++)
+        {
+            if (scores[i] > best)
+            {
+                best = scores[i];
+                bestIndex = i;
+            }
+        }
+
+        return bestIndex;
+    }
+}

--- a/src/Agentic/Models/Local/TokenizerGenerationAdapter.cs
+++ b/src/Agentic/Models/Local/TokenizerGenerationAdapter.cs
@@ -1,0 +1,57 @@
+using AiDotNet.Tokenization.Interfaces;
+
+namespace AiDotNet.Agentic.Models.Local;
+
+/// <summary>
+/// Bridges a full repo <see cref="ITokenizer"/> to the engine's minimal <see cref="IGenerationTokenizer"/>
+/// seam, so any AiDotNet tokenizer can drive <see cref="LocalEngineChatClient{T}"/>.
+/// </summary>
+/// <remarks>
+/// <para><b>For Beginners:</b> The library's tokenizers do a lot more than generation needs. This adapter
+/// exposes just the three things the generation loop uses (encode, decode, end-of-sequence id), so you can
+/// plug a real tokenizer into the local engine without it depending on the larger tokenizer surface.
+/// </para>
+/// </remarks>
+public sealed class TokenizerGenerationAdapter : IGenerationTokenizer
+{
+    private readonly ITokenizer _tokenizer;
+
+    /// <summary>
+    /// Initializes a new adapter over the given tokenizer. The EOS id is resolved from the tokenizer's
+    /// <see cref="AiDotNet.Tokenization.Models.SpecialTokens"/>.
+    /// </summary>
+    /// <param name="tokenizer">The tokenizer to wrap.</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="tokenizer"/> is <c>null</c>.</exception>
+    public TokenizerGenerationAdapter(ITokenizer tokenizer)
+    {
+        Guard.NotNull(tokenizer);
+        _tokenizer = tokenizer;
+
+        var eosToken = tokenizer.SpecialTokens.EosToken;
+        if (eosToken is null || eosToken.Trim().Length == 0)
+        {
+            EosTokenId = -1;
+            return;
+        }
+
+        var ids = tokenizer.ConvertTokensToIds(new List<string> { eosToken });
+        EosTokenId = ids.Count > 0 ? ids[0] : -1;
+    }
+
+    /// <inheritdoc/>
+    public int EosTokenId { get; }
+
+    /// <inheritdoc/>
+    public IReadOnlyList<int> Encode(string text)
+    {
+        Guard.NotNull(text);
+        return _tokenizer.Encode(text).TokenIds;
+    }
+
+    /// <inheritdoc/>
+    public string Decode(IReadOnlyList<int> tokenIds)
+    {
+        Guard.NotNull(tokenIds);
+        return _tokenizer.Decode(new List<int>(tokenIds), skipSpecialTokens: true);
+    }
+}

--- a/tests/AiDotNet.Tests/UnitTests/Agentic/Local/BeamSearchTests.cs
+++ b/tests/AiDotNet.Tests/UnitTests/Agentic/Local/BeamSearchTests.cs
@@ -1,0 +1,142 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using AiDotNet.Agentic.Models;
+using AiDotNet.Agentic.Models.Local;
+using AiDotNet.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNetTests.UnitTests.Agentic.Local
+{
+    public class BeamSearchTests
+    {
+        // Vocabulary: 0=EOS, 1=A, 2=B, 3=C. The model's next-token logits depend on the last token, set up
+        // so that the locally-best first token (A) leads to a worse overall sequence than B -> C.
+        private static TransitionModel BuildModel() => new(
+            vocabularySize: 4,
+            transitions: new Dictionary<int, double[]>
+            {
+                [0] = new[] { 0.1, 2.0, 1.9, 0.1 }, // start (prompt's last token): A slightly beats B
+                [1] = new[] { 2.0, 0.1, 0.1, 0.1 }, // after A: EOS (A is a short, lower-total path)
+                [2] = new[] { 0.1, 0.1, 0.1, 5.0 }, // after B: C is almost certain
+                [3] = new[] { 5.0, 0.1, 0.1, 0.1 }, // after C: EOS
+            });
+
+        private static MapTokenizer BuildTokenizer() =>
+            new(eos: 0, ("A", 1), ("B", 2), ("C", 3));
+
+        [Fact(Timeout = 60000)]
+        public async Task Greedy_TakesLocallyBestToken()
+        {
+            var engine = new LocalEngineChatClient<double>(BuildModel(), BuildTokenizer(), options: new LocalEngineOptions
+            {
+                Sampling = new LocalSamplingOptions { Temperature = 0.0 }, // greedy, beam width 1
+            });
+
+            var response = await engine.GetResponseAsync(new[] { ChatMessage.User("go") });
+
+            Assert.Equal("A", response.Text);
+        }
+
+        [Fact(Timeout = 60000)]
+        public async Task BeamSearch_FindsHigherProbabilitySequence()
+        {
+            var engine = new LocalEngineChatClient<double>(BuildModel(), BuildTokenizer(), options: new LocalEngineOptions
+            {
+                BeamWidth = 2,
+            });
+
+            var response = await engine.GetResponseAsync(new[] { ChatMessage.User("go") });
+
+            // Beam search explores B as well as A and discovers the globally better B -> C completion.
+            Assert.Equal("BC", response.Text);
+            Assert.Equal(ChatFinishReason.Stop, response.FinishReason);
+        }
+
+        [Fact(Timeout = 60000)]
+        public async Task BeamSearch_RespectsConstraint()
+        {
+            // Force the grammar A -> B -> (terminal) even though the model would prefer other paths.
+            var constraint = new FiniteStateTokenConstraint(
+                start: new[] { 1 },
+                transitions: new Dictionary<int, IReadOnlyCollection<int>>
+                {
+                    [1] = new[] { 2 },
+                    [2] = Array.Empty<int>(),
+                });
+
+            var engine = new LocalEngineChatClient<double>(BuildModel(), BuildTokenizer(), options: new LocalEngineOptions
+            {
+                BeamWidth = 3,
+                Constraint = constraint,
+            });
+
+            var response = await engine.GetResponseAsync(new[] { ChatMessage.User("go") });
+
+            Assert.Equal("AB", response.Text);
+            Assert.Equal(ChatFinishReason.Stop, response.FinishReason);
+        }
+
+        // ---- Test doubles ----
+
+        private sealed class TransitionModel : ICausalLanguageModel<double>
+        {
+            private readonly Dictionary<int, double[]> _transitions;
+            private readonly double[] _default;
+
+            public TransitionModel(int vocabularySize, Dictionary<int, double[]> transitions)
+            {
+                VocabularySize = vocabularySize;
+                _transitions = transitions;
+                _default = new double[vocabularySize];
+                _default[0] = 5.0; // unknown state -> prefer EOS
+            }
+
+            public int VocabularySize { get; }
+
+            public Vector<double> NextTokenLogits(IReadOnlyList<int> tokenIds)
+            {
+                var last = tokenIds[tokenIds.Count - 1];
+                var logits = _transitions.TryGetValue(last, out var row) ? row : _default;
+                return new Vector<double>((double[])logits.Clone());
+            }
+        }
+
+        private sealed class MapTokenizer : IGenerationTokenizer
+        {
+            private readonly Dictionary<string, int> _wordToId = new(StringComparer.Ordinal);
+            private readonly Dictionary<int, string> _idToWord = new();
+
+            public MapTokenizer(int eos, params (string Word, int Id)[] entries)
+            {
+                EosTokenId = eos;
+                _idToWord[eos] = string.Empty;
+                foreach (var (word, id) in entries)
+                {
+                    _wordToId[word] = id;
+                    _idToWord[id] = word;
+                }
+            }
+
+            public int EosTokenId { get; }
+
+            public IReadOnlyList<int> Encode(string text)
+            {
+                var ids = text
+                    .Split(new[] { ' ', '\n', '\r', '\t' }, StringSplitOptions.RemoveEmptyEntries)
+                    .Select(w => _wordToId.TryGetValue(w, out var id) ? id : EosTokenId)
+                    .ToList();
+                if (ids.Count == 0)
+                {
+                    ids.Add(EosTokenId);
+                }
+
+                return ids;
+            }
+
+            public string Decode(IReadOnlyList<int> tokenIds) =>
+                string.Concat(tokenIds.Select(id => _idToWord.TryGetValue(id, out var w) ? w : string.Empty));
+        }
+    }
+}

--- a/tests/AiDotNet.Tests/UnitTests/Agentic/Local/ConstrainedDecodingTests.cs
+++ b/tests/AiDotNet.Tests/UnitTests/Agentic/Local/ConstrainedDecodingTests.cs
@@ -1,0 +1,218 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using AiDotNet.Agentic.Models;
+using AiDotNet.Agentic.Models.Local;
+using AiDotNet.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNetTests.UnitTests.Agentic.Local
+{
+    public class ConstrainedDecodingTests
+    {
+        // ---- TokenSampler with an allowed set ----
+
+        [Fact(Timeout = 60000)]
+        public async Task Sampler_Greedy_RespectsAllowedSet()
+        {
+            var sampler = new TokenSampler<double>();
+            // Index 3 has the highest logit, but it is excluded by the allowed set.
+            var logits = new Vector<double>(new[] { 0.1, 0.5, 0.2, 0.9 });
+
+            var id = sampler.Sample(logits, new LocalSamplingOptions { Temperature = 0.0 }, new[] { 0, 1, 2 });
+
+            Assert.Equal(1, id); // best among {0,1,2}
+            await Task.CompletedTask;
+        }
+
+        [Fact(Timeout = 60000)]
+        public async Task Sampler_Sampling_NeverEmitsDisallowedToken()
+        {
+            var sampler = new TokenSampler<double>(seed: 5);
+            var logits = new Vector<double>(new[] { 5.0, 0.1, 5.0, 0.1 });
+            var allowed = new[] { 1, 3 };
+
+            for (var i = 0; i < 40; i++)
+            {
+                var id = sampler.Sample(logits, new LocalSamplingOptions { Temperature = 1.0 }, allowed);
+                Assert.Contains(id, allowed);
+            }
+
+            await Task.CompletedTask;
+        }
+
+        // ---- FiniteStateTokenConstraint forces structure ----
+
+        [Fact(Timeout = 60000)]
+        public async Task FiniteStateConstraint_ForcesExactSequence_RegardlessOfModel()
+        {
+            var tokenizer = new MapTokenizer(
+                eos: 0,
+                ("{", 1), ("\"ok\"", 2), ("}", 3), ("garbage", 4));
+
+            // A model that, left unconstrained, always wants token 4 ("garbage").
+            var model = new BiasedModel(tokenizer.VocabularySize, preferredToken: 4);
+
+            // Grammar: start -> 1 ; 1 -> 2 ; 2 -> 3 ; 3 -> terminal (stop).
+            var constraint = new FiniteStateTokenConstraint(
+                start: new[] { 1 },
+                transitions: new Dictionary<int, IReadOnlyCollection<int>>
+                {
+                    [1] = new[] { 2 },
+                    [2] = new[] { 3 },
+                    [3] = Array.Empty<int>(),
+                });
+
+            var engine = new LocalEngineChatClient<double>(model, tokenizer, options: new LocalEngineOptions
+            {
+                Sampling = new LocalSamplingOptions { Temperature = 0.0 },
+                Constraint = constraint,
+            });
+
+            var response = await engine.GetResponseAsync(new[] { ChatMessage.User("emit json") });
+
+            // Despite the model preferring "garbage", the constraint forced the exact grammar output.
+            Assert.Equal("{\"ok\"}", response.Text);
+            Assert.Equal(ChatFinishReason.Stop, response.FinishReason);
+        }
+
+        [Fact(Timeout = 60000)]
+        public async Task AllowedTokenSetConstraint_RestrictsWholeOutput()
+        {
+            var tokenizer = new MapTokenizer(eos: 0, ("a", 1), ("b", 2), ("c", 3));
+            var model = new BiasedModel(tokenizer.VocabularySize, preferredToken: 3); // wants "c"
+            var constraint = new AllowedTokenSetConstraint(new[] { 1, 2 }); // only a or b allowed
+
+            var engine = new LocalEngineChatClient<double>(model, tokenizer, options: new LocalEngineOptions
+            {
+                Sampling = new LocalSamplingOptions { Temperature = 0.0 },
+                Constraint = constraint,
+                MaxOutputTokens = 4,
+            });
+
+            var response = await engine.GetResponseAsync(new[] { ChatMessage.User("x") });
+
+            Assert.DoesNotContain("c", response.Text);
+            Assert.True(response.Text.Replace(" ", "").Length > 0);
+        }
+
+        // ---- Stop sequences ----
+
+        [Fact(Timeout = 60000)]
+        public async Task StopSequence_HaltsGeneration_AndTrimsOutput()
+        {
+            var tokenizer = new MapTokenizer(eos: 0, ("hello", 1), ("STOP", 2), ("world", 3));
+            // Model emits: hello, STOP, world, ... (never EOS on its own within the budget).
+            var model = new ScriptedModel(tokenizer.VocabularySize, new[] { 1, 2, 3, 3, 3 });
+
+            var engine = new LocalEngineChatClient<double>(model, tokenizer, options: new LocalEngineOptions
+            {
+                Sampling = new LocalSamplingOptions { Temperature = 0.0 },
+            });
+
+            var response = await engine.GetResponseAsync(
+                new[] { ChatMessage.User("go") },
+                new ChatOptions { StopSequences = new[] { "STOP" }, MaxOutputTokens = 10 });
+
+            // Output is trimmed at the stop sequence and generation halts.
+            Assert.Equal("hello", response.Text);
+            Assert.Equal(ChatFinishReason.Stop, response.FinishReason);
+        }
+
+        // ---- Test doubles ----
+
+        // Always biases toward one preferred token (one-hot logits), ignoring context.
+        private sealed class BiasedModel : ICausalLanguageModel<double>
+        {
+            private readonly int _preferred;
+
+            public BiasedModel(int vocabularySize, int preferredToken)
+            {
+                VocabularySize = vocabularySize;
+                _preferred = preferredToken;
+            }
+
+            public int VocabularySize { get; }
+
+            public Vector<double> NextTokenLogits(IReadOnlyList<int> tokenIds)
+            {
+                var logits = new double[VocabularySize];
+                for (var i = 0; i < VocabularySize; i++)
+                {
+                    logits[i] = i == _preferred ? 10.0 : 0.0;
+                }
+
+                return new Vector<double>(logits);
+            }
+        }
+
+        // Emits a fixed sequence (one-hot), then EOS.
+        private sealed class ScriptedModel : ICausalLanguageModel<double>
+        {
+            private readonly int[] _sequence;
+            private int _index;
+
+            public ScriptedModel(int vocabularySize, int[] sequence)
+            {
+                VocabularySize = vocabularySize;
+                _sequence = sequence;
+            }
+
+            public int VocabularySize { get; }
+
+            public Vector<double> NextTokenLogits(IReadOnlyList<int> tokenIds)
+            {
+                var id = _index < _sequence.Length ? _sequence[_index] : 0;
+                _index++;
+                var logits = new double[VocabularySize];
+                logits[id] = 1.0;
+                return new Vector<double>(logits);
+            }
+        }
+
+        // Tokenizer over an explicit (text, id) map; id 0 reserved for EOS.
+        private sealed class MapTokenizer : IGenerationTokenizer
+        {
+            private readonly Dictionary<string, int> _wordToId = new(StringComparer.Ordinal);
+            private readonly Dictionary<int, string> _idToWord = new();
+
+            public MapTokenizer(int eos, params (string Word, int Id)[] entries)
+            {
+                EosTokenId = eos;
+                _idToWord[eos] = string.Empty;
+                var max = eos;
+                foreach (var (word, id) in entries)
+                {
+                    _wordToId[word] = id;
+                    _idToWord[id] = word;
+                    max = Math.Max(max, id);
+                }
+
+                VocabularySize = max + 1;
+            }
+
+            public int VocabularySize { get; }
+
+            public int EosTokenId { get; }
+
+            public IReadOnlyList<int> Encode(string text)
+            {
+                var ids = text
+                    .Split(new[] { ' ', '\n', '\r', '\t' }, StringSplitOptions.RemoveEmptyEntries)
+                    .Select(w => _wordToId.TryGetValue(w, out var id) ? id : EosTokenId)
+                    .ToList();
+                if (ids.Count == 0)
+                {
+                    ids.Add(EosTokenId == 0 && _wordToId.Count > 0 ? _wordToId.Values.First() : 0);
+                }
+
+                return ids;
+            }
+
+            // Concatenate token texts directly (no separators) so grammar output like {"ok"} is exact.
+            public string Decode(IReadOnlyList<int> tokenIds) =>
+                string.Concat(tokenIds.Select(id => _idToWord.TryGetValue(id, out var w) ? w : string.Empty));
+        }
+    }
+}

--- a/tests/AiDotNet.Tests/UnitTests/Agentic/Local/IncrementalDecodingTests.cs
+++ b/tests/AiDotNet.Tests/UnitTests/Agentic/Local/IncrementalDecodingTests.cs
@@ -1,0 +1,159 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using AiDotNet.Agentic.Models;
+using AiDotNet.Agentic.Models.Local;
+using AiDotNet.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNetTests.UnitTests.Agentic.Local
+{
+    public class IncrementalDecodingTests
+    {
+        // Deterministic next-token rule keyed on the last token: 0(EOS)->1, 1->2, 2->3, 3->0(EOS).
+        private static readonly Dictionary<int, int> Transition = new()
+        {
+            [0] = 1,
+            [1] = 2,
+            [2] = 3,
+            [3] = 0,
+        };
+
+        private const int Vocab = 4;
+
+        private static MapTokenizer BuildTokenizer() => new(eos: 0, ("A", 1), ("B", 2), ("C", 3));
+
+        private static double[] LogitsFor(int lastToken)
+        {
+            var next = Transition.TryGetValue(lastToken, out var n) ? n : 0;
+            var logits = new double[Vocab];
+            logits[next] = 10.0;
+            return logits;
+        }
+
+        [Fact(Timeout = 60000)]
+        public async Task Engine_UsesIncrementalPath_FeedingOneTokenAtATime()
+        {
+            var model = new IncrementalProbe();
+            var engine = new LocalEngineChatClient<double>(model, BuildTokenizer(), options: new LocalEngineOptions
+            {
+                Sampling = new LocalSamplingOptions { Temperature = 0.0 },
+            });
+
+            var response = await engine.GetResponseAsync(new[] { ChatMessage.User("go") });
+
+            Assert.Equal("ABC", response.Text);
+            Assert.Equal(ChatFinishReason.Stop, response.FinishReason);
+
+            // The engine took the incremental fast path: reset once, primed once with the prompt, then fed
+            // each generated token singly via AppendToken.
+            Assert.Equal(1, model.ResetCalls);
+            Assert.Equal(1, model.StartCalls);
+            Assert.Equal(new[] { 1, 2, 3 }, model.AppendedTokens);
+        }
+
+        [Fact(Timeout = 60000)]
+        public async Task IncrementalAndFullRefeed_ProduceIdenticalOutput()
+        {
+            var tokenizer = BuildTokenizer();
+            var sampling = new LocalSamplingOptions { Temperature = 0.0 };
+
+            var incremental = new LocalEngineChatClient<double>(new IncrementalProbe(), tokenizer,
+                options: new LocalEngineOptions { Sampling = sampling });
+            var fullRefeed = new LocalEngineChatClient<double>(new FullRefeedModel(), tokenizer,
+                options: new LocalEngineOptions { Sampling = sampling });
+
+            var a = await incremental.GetResponseAsync(new[] { ChatMessage.User("go") });
+            var b = await fullRefeed.GetResponseAsync(new[] { ChatMessage.User("go") });
+
+            Assert.Equal(b.Text, a.Text);
+            Assert.Equal("ABC", a.Text);
+        }
+
+        // ---- Test doubles ----
+
+        // A KV-cached model: tracks how the engine drives it and advances state by the last token only.
+        private sealed class IncrementalProbe : IIncrementalCausalLanguageModel<double>
+        {
+            private int _lastToken;
+
+            public int VocabularySize => Vocab;
+
+            public int ResetCalls { get; private set; }
+
+            public int StartCalls { get; private set; }
+
+            public List<int> AppendedTokens { get; } = new();
+
+            public void ResetCache()
+            {
+                ResetCalls++;
+                _lastToken = 0;
+            }
+
+            public Vector<double> StartSequence(IReadOnlyList<int> promptTokenIds)
+            {
+                StartCalls++;
+                _lastToken = promptTokenIds[promptTokenIds.Count - 1];
+                return new Vector<double>(LogitsFor(_lastToken));
+            }
+
+            public Vector<double> AppendToken(int tokenId)
+            {
+                AppendedTokens.Add(tokenId);
+                _lastToken = tokenId;
+                return new Vector<double>(LogitsFor(_lastToken));
+            }
+
+            // Full-refeed fallback (unused when the engine takes the incremental path).
+            public Vector<double> NextTokenLogits(IReadOnlyList<int> tokenIds) =>
+                new(LogitsFor(tokenIds[tokenIds.Count - 1]));
+        }
+
+        // Same next-token rule, but no KV-cache: forces the engine's full-context path.
+        private sealed class FullRefeedModel : ICausalLanguageModel<double>
+        {
+            public int VocabularySize => Vocab;
+
+            public Vector<double> NextTokenLogits(IReadOnlyList<int> tokenIds) =>
+                new(LogitsFor(tokenIds[tokenIds.Count - 1]));
+        }
+
+        private sealed class MapTokenizer : IGenerationTokenizer
+        {
+            private readonly Dictionary<string, int> _wordToId = new(StringComparer.Ordinal);
+            private readonly Dictionary<int, string> _idToWord = new();
+
+            public MapTokenizer(int eos, params (string Word, int Id)[] entries)
+            {
+                EosTokenId = eos;
+                _idToWord[eos] = string.Empty;
+                foreach (var (word, id) in entries)
+                {
+                    _wordToId[word] = id;
+                    _idToWord[id] = word;
+                }
+            }
+
+            public int EosTokenId { get; }
+
+            public IReadOnlyList<int> Encode(string text)
+            {
+                var ids = text
+                    .Split(new[] { ' ', '\n', '\r', '\t' }, StringSplitOptions.RemoveEmptyEntries)
+                    .Select(w => _wordToId.TryGetValue(w, out var id) ? id : EosTokenId)
+                    .ToList();
+                if (ids.Count == 0)
+                {
+                    ids.Add(EosTokenId);
+                }
+
+                return ids;
+            }
+
+            public string Decode(IReadOnlyList<int> tokenIds) =>
+                string.Concat(tokenIds.Select(id => _idToWord.TryGetValue(id, out var w) ? w : string.Empty));
+        }
+    }
+}

--- a/tests/AiDotNet.Tests/UnitTests/Agentic/Local/LocalInferenceTests.cs
+++ b/tests/AiDotNet.Tests/UnitTests/Agentic/Local/LocalInferenceTests.cs
@@ -155,9 +155,14 @@ namespace AiDotNetTests.UnitTests.Agentic.Local
         [Fact(Timeout = 60000)]
         public async Task Engine_IsDropInForAgentExecutor()
         {
-            var tokenizer = new WordTokenizer("done");
+            var tokenizer = new WordTokenizer("done", "later");
             var model = new ScriptedCausalModel(tokenizer.VocabularySize, new[] { 1, 0 });
-            var engine = new LocalEngineChatClient<double>(model, tokenizer);
+            // AgentExecutor does not specify a temperature, so make the engine greedy by default for a
+            // deterministic assertion (otherwise it samples stochastically at the default temperature).
+            var engine = new LocalEngineChatClient<double>(model, tokenizer, options: new LocalEngineOptions
+            {
+                Sampling = new LocalSamplingOptions { Temperature = 0.0 }
+            });
 
             // The local engine drives a standard agent with no code changes.
             var agent = new AgentExecutor<double>(engine);

--- a/tests/AiDotNet.Tests/UnitTests/Agentic/Local/LocalInferenceTests.cs
+++ b/tests/AiDotNet.Tests/UnitTests/Agentic/Local/LocalInferenceTests.cs
@@ -1,0 +1,257 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using AiDotNet.Agentic.Agents;
+using AiDotNet.Agentic.Models;
+using AiDotNet.Agentic.Models.Local;
+using AiDotNet.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNetTests.UnitTests.Agentic.Local
+{
+    public class LocalInferenceTests
+    {
+        // ---- TokenSampler ----
+
+        [Fact(Timeout = 60000)]
+        public async Task Sampler_Greedy_PicksArgMax()
+        {
+            var sampler = new TokenSampler<double>();
+            var logits = new Vector<double>(new[] { 0.1, 0.9, 0.3, 0.2 });
+
+            var id = sampler.Sample(logits, new LocalSamplingOptions { Temperature = 0.0 });
+
+            Assert.Equal(1, id);
+            await Task.CompletedTask;
+        }
+
+        [Fact(Timeout = 60000)]
+        public async Task Sampler_SameSeed_IsReproducible()
+        {
+            var logits = new Vector<double>(new[] { 1.0, 1.0, 1.0, 1.0 });
+            var options = new LocalSamplingOptions { Temperature = 1.0 };
+
+            var a = new TokenSampler<double>(seed: 123);
+            var b = new TokenSampler<double>(seed: 123);
+
+            var seqA = Enumerable.Range(0, 20).Select(_ => a.Sample(logits, options)).ToList();
+            var seqB = Enumerable.Range(0, 20).Select(_ => b.Sample(logits, options)).ToList();
+
+            Assert.Equal(seqA, seqB);
+        }
+
+        [Fact(Timeout = 60000)]
+        public async Task Sampler_TopK1_AlwaysSelectsTopToken()
+        {
+            var sampler = new TokenSampler<double>(seed: 7);
+            var logits = new Vector<double>(new[] { 0.2, 5.0, 0.1 }); // index 1 dominates
+            var options = new LocalSamplingOptions { Temperature = 1.0, TopK = 1 };
+
+            for (var i = 0; i < 25; i++)
+            {
+                Assert.Equal(1, sampler.Sample(logits, options));
+            }
+
+            await Task.CompletedTask;
+        }
+
+        [Fact(Timeout = 60000)]
+        public async Task Sampler_TinyTopP_RestrictsToMostLikely()
+        {
+            var sampler = new TokenSampler<double>(seed: 7);
+            var logits = new Vector<double>(new[] { 0.1, 5.0, 0.2 });
+            // A tiny nucleus keeps only the single most-likely token.
+            var options = new LocalSamplingOptions { Temperature = 1.0, TopP = 0.01 };
+
+            for (var i = 0; i < 25; i++)
+            {
+                Assert.Equal(1, sampler.Sample(logits, options));
+            }
+
+            await Task.CompletedTask;
+        }
+
+        // ---- ChatMlPromptTemplate ----
+
+        [Fact(Timeout = 60000)]
+        public async Task Template_RendersRoles_AndOpensAssistantTurn()
+        {
+            var template = new ChatMlPromptTemplate();
+            var prompt = template.Render(new[]
+            {
+                ChatMessage.System("be brief"),
+                ChatMessage.User("hi"),
+            });
+
+            Assert.Contains("<|system|>\nbe brief\n", prompt);
+            Assert.Contains("<|user|>\nhi\n", prompt);
+            Assert.EndsWith("<|assistant|>\n", prompt);
+            await Task.CompletedTask;
+        }
+
+        // ---- LocalEngineChatClient ----
+
+        [Fact(Timeout = 60000)]
+        public async Task Engine_GreedyGeneration_DecodesExpectedText_AndStopsOnEos()
+        {
+            var tokenizer = new WordTokenizer("hello", "world");
+            // Emit "hello" (1), "world" (2), then EOS (0).
+            var model = new ScriptedCausalModel(tokenizer.VocabularySize, new[] { 1, 2, 0 });
+            var engine = new LocalEngineChatClient<double>(model, tokenizer);
+
+            var response = await engine.GetResponseAsync(new[] { ChatMessage.User("greet") },
+                new ChatOptions { Temperature = 0.0 });
+
+            Assert.Equal("hello world", response.Text);
+            Assert.Equal(ChatFinishReason.Stop, response.FinishReason);
+            Assert.NotNull(response.Usage);
+            Assert.Equal(2, response.Usage.OutputTokens);
+            Assert.Equal("local", response.ModelId);
+        }
+
+        [Fact(Timeout = 60000)]
+        public async Task Engine_HitsTokenLimit_ReportsLength()
+        {
+            var tokenizer = new WordTokenizer("again");
+            // Always emits the non-EOS token "again" (1), never stopping on its own.
+            var model = new ScriptedCausalModel(tokenizer.VocabularySize, new[] { 1 }, repeatLast: true);
+            var engine = new LocalEngineChatClient<double>(model, tokenizer);
+
+            var response = await engine.GetResponseAsync(new[] { ChatMessage.User("go") },
+                new ChatOptions { Temperature = 0.0, MaxOutputTokens = 3 });
+
+            Assert.Equal(ChatFinishReason.Length, response.FinishReason);
+            Assert.Equal(3, response.Usage.OutputTokens);
+        }
+
+        [Fact(Timeout = 60000)]
+        public async Task Engine_Streaming_DeltasReconstructFullText()
+        {
+            var tokenizer = new WordTokenizer("alpha", "beta", "gamma");
+            var model = new ScriptedCausalModel(tokenizer.VocabularySize, new[] { 1, 2, 3, 0 });
+            var engine = new LocalEngineChatClient<double>(model, tokenizer);
+
+            var text = string.Empty;
+            ChatFinishReason? finish = null;
+            await foreach (var update in engine.GetStreamingResponseAsync(new[] { ChatMessage.User("x") },
+                new ChatOptions { Temperature = 0.0 }))
+            {
+                if (update.TextDelta is { } delta)
+                {
+                    text += delta;
+                }
+
+                if (update.FinishReason is { } reason)
+                {
+                    finish = reason;
+                }
+            }
+
+            Assert.Equal("alpha beta gamma", text);
+            Assert.Equal(ChatFinishReason.Stop, finish);
+        }
+
+        [Fact(Timeout = 60000)]
+        public async Task Engine_IsDropInForAgentExecutor()
+        {
+            var tokenizer = new WordTokenizer("done");
+            var model = new ScriptedCausalModel(tokenizer.VocabularySize, new[] { 1, 0 });
+            var engine = new LocalEngineChatClient<double>(model, tokenizer);
+
+            // The local engine drives a standard agent with no code changes.
+            var agent = new AgentExecutor<double>(engine);
+            var result = await agent.RunAsync("anything");
+
+            Assert.True(result.Completed);
+            Assert.Equal("done", result.FinalText);
+        }
+
+        // ---- Deterministic test doubles ----
+
+        // Emits a predetermined token sequence as one-hot logits, ignoring context. When the sequence is
+        // exhausted it emits EOS (id 0), or repeats the last token when repeatLast is set.
+        private sealed class ScriptedCausalModel : ICausalLanguageModel<double>
+        {
+            private readonly int[] _sequence;
+            private readonly bool _repeatLast;
+            private int _index;
+
+            public ScriptedCausalModel(int vocabularySize, int[] sequence, bool repeatLast = false)
+            {
+                VocabularySize = vocabularySize;
+                _sequence = sequence;
+                _repeatLast = repeatLast;
+            }
+
+            public int VocabularySize { get; }
+
+            public Vector<double> NextTokenLogits(IReadOnlyList<int> tokenIds)
+            {
+                int id;
+                if (_index < _sequence.Length)
+                {
+                    id = _sequence[_index];
+                }
+                else
+                {
+                    id = _repeatLast ? _sequence[_sequence.Length - 1] : 0;
+                }
+
+                _index++;
+                var logits = new double[VocabularySize];
+                logits[id] = 1.0;
+                return new Vector<double>(logits);
+            }
+        }
+
+        // Minimal whitespace tokenizer: id 0 is EOS, words get ids 1.. in order. Unknown words map to id 1.
+        private sealed class WordTokenizer : IGenerationTokenizer
+        {
+            private readonly Dictionary<string, int> _wordToId = new(StringComparer.Ordinal);
+            private readonly Dictionary<int, string> _idToWord = new();
+
+            public WordTokenizer(params string[] words)
+            {
+                _idToWord[0] = string.Empty; // EOS decodes to nothing
+                var nextId = 1;
+                foreach (var word in words)
+                {
+                    _wordToId[word] = nextId;
+                    _idToWord[nextId] = word;
+                    nextId++;
+                }
+
+                VocabularySize = nextId;
+            }
+
+            public int VocabularySize { get; }
+
+            public int EosTokenId => 0;
+
+            public IReadOnlyList<int> Encode(string text)
+            {
+                var ids = new List<int>();
+                foreach (var word in text.Split(new[] { ' ', '\n', '\r', '\t' }, StringSplitOptions.RemoveEmptyEntries))
+                {
+                    ids.Add(_wordToId.TryGetValue(word, out var id) ? id : 1);
+                }
+
+                if (ids.Count == 0)
+                {
+                    ids.Add(1);
+                }
+
+                return ids;
+            }
+
+            public string Decode(IReadOnlyList<int> tokenIds)
+            {
+                var words = tokenIds
+                    .Select(id => _idToWord.TryGetValue(id, out var word) ? word : string.Empty)
+                    .Where(w => w.Length > 0);
+                return string.Join(" ", words);
+            }
+        }
+    }
+}

--- a/tests/AiDotNet.Tests/UnitTests/Agentic/Local/RealModelLocalInferenceTests.cs
+++ b/tests/AiDotNet.Tests/UnitTests/Agentic/Local/RealModelLocalInferenceTests.cs
@@ -1,0 +1,177 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using AiDotNet.Agentic.Models;
+using AiDotNet.Agentic.Models.Local;
+using AiDotNet.Enums;
+using AiDotNet.NeuralNetworks;
+using AiDotNet.Tensors.Engines;
+using Xunit;
+
+namespace AiDotNetTests.UnitTests.Agentic.Local
+{
+    /// <summary>
+    /// Marks the real-network inference tests as a non-parallel collection. Running a real neural-network
+    /// forward pass mutates process-wide tensor-engine state (engine selection / LazyTensorScope), which can
+    /// disturb tensor ops in tests running concurrently; isolating this collection avoids that.
+    /// </summary>
+    [CollectionDefinition("RealModelInference", DisableParallelization = true)]
+    public sealed class RealModelInferenceCollection
+    {
+    }
+
+    /// <summary>
+    /// Integration tests that run the local generation engine over a real (tiny, untrained) AiDotNet
+    /// <see cref="MambaLanguageModel{T}"/>. They validate the full in-process pipeline — one-hot encoding,
+    /// forward pass, last-position logit extraction, sampling, autoregressive loop — not output quality.
+    /// All use greedy decoding (temperature 0) for deterministic assertions.
+    /// </summary>
+    [Collection("RealModelInference")]
+    public class RealModelLocalInferenceTests
+    {
+        private const int Vocab = 20;
+        private const int MaxSeq = 16;
+
+        // A real network forward dispatches through AiDotNetEngine.Current, which a module initializer may
+        // auto-set to a GPU engine; some GPU backends return zeros for small shapes. Pin a CPU engine for the
+        // duration of each test (documented mitigation) and restore it afterwards.
+        private static async Task PinCpuAsync(Func<Task> body)
+        {
+            var priorEngine = AiDotNetEngine.Current;
+            AiDotNetEngine.Current = new CpuEngine();
+            try
+            {
+                await body();
+            }
+            finally
+            {
+                AiDotNetEngine.Current = priorEngine;
+            }
+        }
+
+        private static MambaLanguageModel<double> BuildTinyModel()
+        {
+            var architecture = new NeuralNetworkArchitecture<double>(
+                InputType.OneDimensional,
+                NeuralNetworkTaskType.TextGeneration,
+                inputSize: Vocab,
+                outputSize: Vocab);
+
+            return new MambaLanguageModel<double>(
+                architecture,
+                vocabSize: Vocab,
+                modelDimension: 16,
+                numLayers: 1,
+                stateDimension: 4,
+                maxSeqLength: MaxSeq);
+        }
+
+        [Fact(Timeout = 120000)]
+        public async Task Adapter_NextTokenLogits_ReturnsVocabWidthLogits()
+        {
+            await PinCpuAsync(() =>
+            {
+                var lm = new NeuralNetworkCausalLanguageModel<double>(BuildTinyModel(), Vocab, maxContextTokens: MaxSeq);
+
+                var logits = lm.NextTokenLogits(new[] { 1, 2, 3 });
+
+                Assert.Equal(Vocab, logits.Length);
+                for (var i = 0; i < logits.Length; i++)
+                {
+                    Assert.False(double.IsNaN(logits[i]));
+                }
+
+                return Task.CompletedTask;
+            });
+        }
+
+        [Fact(Timeout = 120000)]
+        public async Task Engine_GeneratesEndToEnd_OverRealNetwork()
+        {
+            await PinCpuAsync(async () =>
+            {
+                var lm = new NeuralNetworkCausalLanguageModel<double>(BuildTinyModel(), Vocab, maxContextTokens: MaxSeq);
+                var tokenizer = new BoundedTokenizer(Vocab);
+                var engine = new LocalEngineChatClient<double>(lm, tokenizer);
+
+                var response = await engine.GetResponseAsync(
+                    new[] { ChatMessage.User("hello there") },
+                    new ChatOptions { Temperature = 0.0, MaxOutputTokens = 3 });
+
+                // The untrained model produces arbitrary tokens, but the full pipeline must run cleanly and
+                // honor the token budget.
+                Assert.Equal(ChatFinishReason.Length, response.FinishReason);
+                Assert.NotNull(response.Usage);
+                Assert.Equal(3, response.Usage.OutputTokens);
+                Assert.NotNull(response.Text);
+            });
+        }
+
+        [Fact(Timeout = 120000)]
+        public async Task Engine_StreamingOverRealNetwork_TerminatesWithFinish()
+        {
+            await PinCpuAsync(async () =>
+            {
+                var lm = new NeuralNetworkCausalLanguageModel<double>(BuildTinyModel(), Vocab, maxContextTokens: MaxSeq);
+                var engine = new LocalEngineChatClient<double>(lm, new BoundedTokenizer(Vocab));
+
+                ChatFinishReason? finish = null;
+                var updates = 0;
+                await foreach (var update in engine.GetStreamingResponseAsync(
+                    new[] { ChatMessage.User("hi") },
+                    new ChatOptions { Temperature = 0.0, MaxOutputTokens = 2 }))
+                {
+                    updates++;
+                    if (update.FinishReason is { } reason)
+                    {
+                        finish = reason;
+                    }
+                }
+
+                Assert.True(updates > 0);
+                Assert.Equal(ChatFinishReason.Length, finish);
+            });
+        }
+
+        // A whitespace tokenizer whose ids stay within the model's vocabulary. EOS is disabled (-1) so
+        // greedy generation runs deterministically to the token budget regardless of the untrained model.
+        private sealed class BoundedTokenizer : IGenerationTokenizer
+        {
+            private readonly int _vocab;
+
+            public BoundedTokenizer(int vocab)
+            {
+                _vocab = vocab;
+            }
+
+            public int EosTokenId => -1;
+
+            public IReadOnlyList<int> Encode(string text)
+            {
+                var ids = new List<int>();
+                foreach (var word in text.Split(new[] { ' ', '\n', '\r', '\t' }, StringSplitOptions.RemoveEmptyEntries))
+                {
+                    // Deterministic, bounded id from a stable char-sum (string.GetHashCode is randomized per process).
+                    var sum = 0;
+                    foreach (var ch in word)
+                    {
+                        sum = (sum + ch) & 0x7fffffff;
+                    }
+
+                    ids.Add((sum % (_vocab - 1)) + 1);
+                }
+
+                if (ids.Count == 0)
+                {
+                    ids.Add(1);
+                }
+
+                return ids;
+            }
+
+            public string Decode(IReadOnlyList<int> tokenIds) =>
+                string.Join(" ", tokenIds.Select(id => "t" + id));
+        }
+    }
+}


### PR DESCRIPTION
**Draft — do not review yet.** Epic #1544 (Phase 3). Stacked on Phase 2 (#1551), which is stacked on Phase 0 (#1545). Rebase down the stack as the lower PRs merge.

## Phase 3 goal — the flagship differentiator
Run inference **in-process** over AiDotNet's own model: no Python, no API, no key. An `IChatClient<T>` implementation means the exact same agent code (executor / supervisor / swarm / memory) runs against a local model.

## Landed (slice 1 — the generation core)
- **`ICausalLanguageModel<T>`** — minimal next-token-logits seam the real Transformer plugs into (free to keep an internal KV-cache).
- **`IGenerationTokenizer`** + `TokenizerGenerationAdapter` over the repo's `ITokenizer`.
- **`TokenSampler<T>`** — greedy / temperature / top-k / top-p (nucleus), seedable for reproducibility.
- **`IChatPromptTemplate`** + `ChatMlPromptTemplate`.
- **`LocalEngineChatClient<T>`** — render → encode → autoregressive sample (until EOS / token cap) → decode; non-streaming **and** streaming (incremental deltas); token-count usage.
- **9 tests** (green net10.0 + net471) on a deterministic fake model + tokenizer, including an `AgentExecutor` drop-in.

## Planned next in this PR
- Wire the concrete `Transformer`/LM behind `ICausalLanguageModel<T>` (real logits + KV-cache).
- Constrained decoding (JSON-schema / grammar at the logits) → native local structured output & tool-calling.
- Stop-sequence handling; beam search; quantization hooks.

No null-forgiving operators; enums for closed sets; "For Beginners" docs throughout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)