### PR TITLE
fix(vercel): stop deploying on every PR — robust ignoreCommand change detection

### DIFF
--- a/scripts/vercel-ignore-api.sh
+++ b/scripts/vercel-ignore-api.sh
@@ -2,36 +2,61 @@
 # Vercel ignoreCommand for the aidotnet-playground-api project.
 #
 # Exit codes (per Vercel):
-#   0 = ignore the build (skip)
-#   1 = proceed with the build
+#   0 = ignore the build (skip)   1 = proceed with the build
 #
-# Policy:
-# - master / main pushes always build (production deploys).
-# - On preview deploys with a prior build SHA available, build only when
-#   files under api/ or vercel.json itself changed. This avoids spinning
-#   up a Vercel build for PRs that touch only website/, src/, etc.
-# - Without a previous SHA (first deploy of a branch), default to build
-#   so we don't silently skip.
+# Goal: build ONLY when files under api/ (or vercel.json) actually changed — for
+# both production (master/main) and preview (PR) deployments. The playground API
+# does not depend on website/, src/, tests/, .github/, etc., so it must not
+# redeploy for those — that churn is what exhausts the Vercel deploy quota.
 #
-# Lives in scripts/ rather than inlined in vercel.json because Vercel
-# enforces a 256-character cap on ignoreCommand strings.
+# Why the previous version still rebuilt constantly (the rate-limit bug):
+#   1. master/main pushes did `exit 1` UNCONDITIONALLY, so every merge to master
+#      (every src/tests/docs commit) redeployed the API even though api/ was
+#      untouched.
+#   2. Preview deploys keyed off VERCEL_GIT_PREVIOUS_SHA and did `exit 1` (build)
+#      whenever it was empty — which it is on the FIRST deploy of every PR branch.
+#   3. `git diff PREV CURR` returns 128 (fatal: bad object) when PREV is missing
+#      from Vercel's shallow clone; the old `if/else` treated that error the same
+#      as exit-1 "has changes", so a missing PREV also fell through to build.
+#
+# Fix: pick a RELIABLE base to diff against, then only build on a real api/ diff.
+# Treat "cannot determine a base" (never "diff errored") as the sole build-anyway
+# fallback, so we never silently skip a genuine api change.
 
 set -u
 
-if [ "${VERCEL_GIT_COMMIT_REF:-}" = master ] || [ "${VERCEL_GIT_COMMIT_REF:-}" = main ]; then
-  exit 1
-fi
-
-PREV="${VERCEL_GIT_PREVIOUS_SHA:-}"
 CURR="${VERCEL_GIT_COMMIT_SHA:-HEAD}"
+REF="${VERCEL_GIT_COMMIT_REF:-}"
+PREV="${VERCEL_GIT_PREVIOUS_SHA:-}"
 
-if [ -z "$PREV" ]; then
-  exit 1
-fi
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || echo .)"
+cd "$REPO_ROOT" || exit 1
 
-REPO_ROOT="$(git rev-parse --show-toplevel)"
-if git -C "$REPO_ROOT" diff --quiet "$PREV" "$CURR" -- 'api/' 'vercel.json'; then
-  exit 0
+# Resolve a base commit to diff CURR against:
+#   1) the previous successful deployment SHA, if it is present in this clone;
+#   2) production branch: the parent commit (master advances one commit at a time);
+#   3) preview branch: the merge-base with the production branch (the PR's fork
+#      point), fetched shallowly — captures the PR's WHOLE diff, so a PR that never
+#      touches api/ is skipped even on its first push.
+BASE=""
+if [ -n "$PREV" ] && git cat-file -e "${PREV}^{commit}" 2>/dev/null; then
+  BASE="$PREV"
+elif [ "$REF" = "master" ] || [ "$REF" = "main" ]; then
+  BASE="$(git rev-parse "${CURR}^" 2>/dev/null || true)"
 else
-  exit 1
+  git fetch --no-tags --depth=200 origin master 2>/dev/null \
+    || git fetch --no-tags --depth=200 origin main 2>/dev/null || true
+  BASE="$(git merge-base FETCH_HEAD "$CURR" 2>/dev/null || true)"
 fi
+
+# Could not establish a base (truly unknowable history) -> build to be safe.
+[ -z "$BASE" ] && exit 1
+
+# `git diff --quiet` exits 0 (no diff) or 1 (diff). Map explicitly so a >1 error
+# can never masquerade as "has changes".
+git diff --quiet "$BASE" "$CURR" -- 'api/' 'vercel.json'
+case "$?" in
+  0) exit 0 ;;  # no api/ or vercel.json change -> skip the build
+  1) exit 1 ;;  # api/ or vercel.json changed   -> build
+  *) exit 1 ;;  # diff itself failed            -> build (fail safe)
+esac

--- a/website/scripts/vercel-ignore.sh
+++ b/website/scripts/vercel-ignore.sh
@@ -2,49 +2,59 @@
 # Vercel ignoreCommand for the aidotnet_website project.
 #
 # Exit codes (per Vercel):
-#   0 = ignore the build (skip)
-#   1 = proceed with the build
+#   0 = ignore the build (skip)   1 = proceed with the build
 #
-# Policy:
-# - master / main pushes build only when website/ changed (production
-#   deploys still throttle to actual website diffs — see "Why" below).
-# - On preview deploys with a prior build SHA, only build when files
-#   under website/ changed. The path is rooted to the repo top so the
-#   filter works regardless of which cwd Vercel hands us — the previous
-#   'git diff -- .' form was cwd-dependent and silently expanded to the
-#   whole repo on rootDirectory misconfigurations, which is the root
-#   cause of "every commit triggers a deploy" rate-limit exhaustion.
-# - Without a previous SHA (first deploy of a branch / shallow clone)
-#   we still build — better to deploy unnecessarily once on a fresh
-#   branch than to skip the very first preview silently.
+# Goal: build ONLY when files under website/ actually changed — for both
+# production (master/main) and preview (PR) deployments — so unrelated src/,
+# tests/, .github/ churn doesn't burn the Vercel deployment quota.
 #
-# Why master also filters now:
-# - We were burning the Vercel deployment quota on every src/, tests/,
-#   .github/ commit because master pushes unconditionally triggered a
-#   full website build. The website itself doesn't depend on any of
-#   those paths, so there's no production-correctness reason to
-#   rebuild it for them.
+# Why the previous version still rebuilt on every PR (the rate-limit bug):
+#   1. It keyed off VERCEL_GIT_PREVIOUS_SHA and did `exit 1` (build) whenever it
+#      was empty. That env var is EMPTY on the first deployment of every PR
+#      branch, so every freshly-opened PR rebuilt unconditionally.
+#   2. `git diff PREV CURR` returns 128 (fatal: bad object) when PREV is not in
+#      Vercel's shallow clone. `if git diff ...; then exit 0; else exit 1; fi`
+#      conflates that 128 ERROR with exit-1 "has changes", so a missing PREV
+#      silently fell through to build as well.
 #
-# Lives in scripts/ rather than inlined in vercel.json because Vercel
-# enforces a 256-character cap on ignoreCommand strings.
+# Fix: pick a RELIABLE base to diff against, then only build on a real website/
+# diff. Treat "cannot determine a base" (never "diff errored") as the sole
+# build-anyway fallback, so we never silently skip a genuine website change.
 
 set -u
 
-PREV="${VERCEL_GIT_PREVIOUS_SHA:-}"
 CURR="${VERCEL_GIT_COMMIT_SHA:-HEAD}"
+REF="${VERCEL_GIT_COMMIT_REF:-}"
+PREV="${VERCEL_GIT_PREVIOUS_SHA:-}"
 
-if [ -z "$PREV" ]; then
-  exit 1
-fi
-
-# Resolve repo top so the path filter is cwd-independent. Vercel has
-# historically run ignoreCommand from either the repo root or the
-# project's rootDirectory; pinning to the top-level rev makes the
-# diff scope deterministic across both.
 REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || echo .)"
+cd "$REPO_ROOT" || exit 1
 
-if git -C "$REPO_ROOT" diff --quiet "$PREV" "$CURR" -- 'website/'; then
-  exit 0
+# Resolve a base commit to diff CURR against:
+#   1) the previous successful deployment SHA, if it is present in this clone;
+#   2) production branch: the parent commit (master advances one commit at a time);
+#   3) preview branch: the merge-base with the production branch (the PR's fork
+#      point), fetched shallowly — this captures the PR's WHOLE diff, so a PR that
+#      never touches website/ is skipped even on its first push.
+BASE=""
+if [ -n "$PREV" ] && git cat-file -e "${PREV}^{commit}" 2>/dev/null; then
+  BASE="$PREV"
+elif [ "$REF" = "master" ] || [ "$REF" = "main" ]; then
+  BASE="$(git rev-parse "${CURR}^" 2>/dev/null || true)"
 else
-  exit 1
+  git fetch --no-tags --depth=200 origin master 2>/dev/null \
+    || git fetch --no-tags --depth=200 origin main 2>/dev/null || true
+  BASE="$(git merge-base FETCH_HEAD "$CURR" 2>/dev/null || true)"
 fi
+
+# Could not establish a base (truly unknowable history) -> build to be safe.
+[ -z "$BASE" ] && exit 1
+
+# `git diff --quiet` exits 0 (no diff) or 1 (diff). Map explicitly so a >1 error
+# can never masquerade as "has changes".
+git diff --quiet "$BASE" "$CURR" -- 'website/'
+case "$?" in
+  0) exit 0 ;;  # no website/ change -> skip the build
+  1) exit 1 ;;  # website/ changed   -> build
+  *) exit 1 ;;  # diff itself failed -> build (fail safe)
+esac


### PR DESCRIPTION
## Problem
Every PR shows a failing **Vercel – aidotnet_website** / **Vercel – aidotnet-playground-api** check with a `build-rate-limit` error. The earlier "only deploy on website changes" fix didn't take because the deployments come from the **Vercel Git integration (App)**, which runs `vercel.json`'s `ignoreCommand` on *every* push — GitHub Actions path filters (e.g. `deploy-website.yml`) do **not** gate it. The ignore scripts were building far too often and exhausting the daily deploy quota.

## Root cause (in the ignore scripts)
1. They keyed off `VERCEL_GIT_PREVIOUS_SHA` and did `exit 1` (build) whenever it was empty — and it's **empty on the first deploy of every PR branch**, so every freshly-opened PR rebuilt unconditionally.
2. `git diff PREV CURR` returns **128 (bad object)** when `PREV` isn't in Vercel's shallow clone; the old `if/else` treated that *error* the same as exit-1 "has changes", so a missing `PREV` also fell through to build.
3. The **API** script additionally did `master → exit 1` **unconditionally**, so every merge to master redeployed the playground API even when `api/` was untouched (every `src/`, `tests/`, `.github/` merge).

## Fix
Resolve a **reliable base** to diff against, then build only on a *real* path diff:
- previous-SHA if it's actually present in the clone, else
- production branch → the parent commit, else
- preview branch → **merge-base with master** (the PR's fork point, fetched shallowly) — this captures the PR's whole diff, so a PR that never touches `website/` (resp. `api/` + `vercel.json`) is skipped **even on its first push**.

`git diff` errors map to *build* (fail-safe), never to "has changes". "Cannot determine a base" is the sole build-anyway fallback, so a genuine change is never silently skipped.

## Verified locally
- website-touching commit → build (exit 1)
- same commit under the `api/` filter → skip (exit 0)
- PR preview with no `website/` diff vs master → **skip (exit 0)** — previously this built

## Note (not in this repo)
For the website project, ensure its Vercel **Root Directory = `website/`** so `website/vercel.json`'s `ignoreCommand` is the one that runs. If it's the repo root, Vercel reads the root (API) `vercel.json` for the website project and this script never executes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)