### PR TITLE
fix(website): payment-flow tier drift, api_usage logging, sign-out clear, error-report mailto

### DIFF
--- a/website/DEPLOYMENT-CHECKLIST.md
+++ b/website/DEPLOYMENT-CHECKLIST.md
@@ -12,7 +12,7 @@ found") will continue to occur.
 The production bundle at `https://www.aidotnet.dev/_astro/pricing.astro_...js`
 currently hard-codes:
 
-```
+```text
 pro.month:        https://buy.stripe.com/test_7sY6oG3XwbaccTl6tY7bW00   ← TEST mode
 pro.year:         https://buy.stripe.com/test_7sYdR8alU3HKbPh2dI7bW02   ← TEST mode
 enterprise.month: ""                                                     ← missing
@@ -40,11 +40,16 @@ client JS at build time, so a new deploy is required after the change.
 
 Then trigger a redeploy: Vercel → Deployments → latest → "..." → "Redeploy".
 
-**Verify:** after the redeploy completes, fetch the same bundle and
-confirm the `buy.stripe.com/` URLs no longer have the `test_` prefix:
+**Verify:** after the redeploy completes, fetch the page that references
+the hashed asset, extract the real bundle filename, and confirm the
+`buy.stripe.com/` URLs no longer have the `test_` prefix. (The bundle name
+is content-hashed, so a literal `*.js` glob in a `curl` URL won't resolve.)
 
 ```bash
-curl -s "https://www.aidotnet.dev/_astro/pricing.astro_*.js" \
+BUNDLE=$(curl -s https://www.aidotnet.dev/pricing/ \
+  | grep -oE 'pricing\.astro_[A-Za-z0-9_.-]+\.js' \
+  | head -1)
+curl -s "https://www.aidotnet.dev/_astro/${BUNDLE}" \
   | grep -oE 'buy\.stripe\.com/[a-zA-Z0-9_-]+' | sort -u
 ```
 
@@ -94,7 +99,7 @@ Advanced → Metadata, add a key/value pair `tier=pro` (or `tier=enterprise`).
 Each Payment Link's "After payment → Show confirmation page → Custom URL"
 should redirect customers to:
 
-```
+```text
 https://www.aidotnet.dev/account/licenses/?new=true
 ```
 
@@ -109,6 +114,7 @@ plumbs every `validate_license_key` RPC call into `api_usage` so the
 license holders.
 
 **Action:**
+
 ```bash
 cd website
 supabase db push
@@ -153,7 +159,7 @@ is **in the dashboards**, not the code. Walk through each item:
 **C. Smoke-test from an Incognito window**
 1. Open https://www.aidotnet.dev/login/ in a private window.
 2. Click "Continue with GitHub".
-3. Approve on github.com → expect a redirect back to `/account/`.
+3. Approve on GitHub.com → expect a redirect back to `/account/`.
 4. If you instead land on `/auth/callback/?error=...`, expand the
    "Show technical details" disclosure and copy the `error_description`
    into the support mailto link.

--- a/website/DEPLOYMENT-CHECKLIST.md
+++ b/website/DEPLOYMENT-CHECKLIST.md
@@ -117,7 +117,48 @@ supabase db push
 (Or apply via the Supabase Dashboard → SQL Editor if you don't have CLI
 access configured locally.)
 
-## 6. Smoke-test the live flow
+## 6. GitHub OAuth provider — verify config in Supabase + GitHub
+
+The user reported "GitHub login throws an error now (new issue)". Direct
+testing shows:
+
+* Supabase's OAuth start endpoint correctly emits a 302 to
+  `github.com/login/oauth/authorize?client_id=Ov23liyJTdKbxKrUl9lR&...`
+  (verified by hitting
+  `https://yfkqwpgjahoamlgckjib.supabase.co/auth/v1/authorize?provider=github`).
+* The `/auth/callback/?error=server_error` path correctly surfaces our
+  hint: "OAuth provider is misconfigured on the server side (client
+  secret rotated, callback URL drift, or provider disabled)."
+
+That hint is the exact message the user is most likely seeing. The fix
+is **in the dashboards**, not the code. Walk through each item:
+
+**A. GitHub OAuth App** (https://github.com/settings/developers → OAuth Apps → "AiDotNet" or whichever app owns client_id `Ov23liyJTdKbxKrUl9lR`)
+1. Open the app's settings page.
+2. Confirm **Authorization callback URL** is exactly
+   `https://yfkqwpgjahoamlgckjib.supabase.co/auth/v1/callback` (no
+   trailing slash, no leading whitespace, scheme is `https`). A trailing
+   slash, a `www.` prefix, or any other variant causes GitHub to redirect
+   to a URL Supabase doesn't accept and the token swap silently fails.
+3. Click **Generate a new client secret** → copy the new value
+   immediately (GitHub only shows it once).
+
+**B. Supabase Auth → Providers → GitHub** (Supabase Dashboard)
+1. Verify the toggle is **Enabled**.
+2. Paste the **client_id** (`Ov23liyJTdKbxKrUl9lR` per the live OAuth
+   start URL — confirm it matches the GitHub app).
+3. Paste the **client_secret** you just generated in step A.3.
+4. Save.
+
+**C. Smoke-test from an Incognito window**
+1. Open https://www.aidotnet.dev/login/ in a private window.
+2. Click "Continue with GitHub".
+3. Approve on github.com → expect a redirect back to `/account/`.
+4. If you instead land on `/auth/callback/?error=...`, expand the
+   "Show technical details" disclosure and copy the `error_description`
+   into the support mailto link.
+
+## 7. Smoke-test the live flow
 
 1. Browse to https://www.aidotnet.dev/pricing/ in an Incognito window.
 2. Confirm Subscribe buttons resolve to `buy.stripe.com/` URLs **without**

--- a/website/DEPLOYMENT-CHECKLIST.md
+++ b/website/DEPLOYMENT-CHECKLIST.md
@@ -1,0 +1,137 @@
+# Deployment checklist — switch live payment flow from test → production
+
+This branch (`fix/website-critical-issues`) ships the code-level fixes for
+the payment/license flow, but **two non-code changes must be made in the
+Vercel + Supabase dashboards** before customers can pay successfully. Until
+both are done, the symptoms the user reported (payment freezes, "critical
+error", no license issued, just-created key returns "License key not
+found") will continue to occur.
+
+## 1. Vercel environment variables — switch Stripe Payment Links from TEST to LIVE mode
+
+The production bundle at `https://www.aidotnet.dev/_astro/pricing.astro_...js`
+currently hard-codes:
+
+```
+pro.month:        https://buy.stripe.com/test_7sY6oG3XwbaccTl6tY7bW00   ← TEST mode
+pro.year:         https://buy.stripe.com/test_7sYdR8alU3HKbPh2dI7bW02   ← TEST mode
+enterprise.month: ""                                                     ← missing
+enterprise.year:  ""                                                     ← missing
+```
+
+These come from build-time `import.meta.env` reads of:
+
+| Env var                                  | What it should be                          |
+|------------------------------------------|--------------------------------------------|
+| `PUBLIC_STRIPE_PRO_MONTHLY_LINK`         | `https://buy.stripe.com/<LIVE-mode link>`  |
+| `PUBLIC_STRIPE_PRO_YEARLY_LINK`          | `https://buy.stripe.com/<LIVE-mode link>`  |
+| `PUBLIC_STRIPE_ENTERPRISE_MONTHLY_LINK`  | `https://buy.stripe.com/<LIVE-mode link>`  |
+| `PUBLIC_STRIPE_ENTERPRISE_YEARLY_LINK`   | `https://buy.stripe.com/<LIVE-mode link>`  |
+
+**Action:** in Vercel → Project Settings → Environment Variables, set all
+four to the **LIVE-mode** Payment Link URLs from
+[Stripe Dashboard → Payment Links](https://dashboard.stripe.com/payment-links).
+Make sure the dashboard is in LIVE mode (toggle top-right) when you copy
+the URL. LIVE-mode links do NOT start with `buy.stripe.com/test_`.
+
+When you save each one, choose **Production**, **Preview**, and **Development**
+scopes (or at minimum **Production**). The values are inlined into the
+client JS at build time, so a new deploy is required after the change.
+
+Then trigger a redeploy: Vercel → Deployments → latest → "..." → "Redeploy".
+
+**Verify:** after the redeploy completes, fetch the same bundle and
+confirm the `buy.stripe.com/` URLs no longer have the `test_` prefix:
+
+```bash
+curl -s "https://www.aidotnet.dev/_astro/pricing.astro_*.js" \
+  | grep -oE 'buy\.stripe\.com/[a-zA-Z0-9_-]+' | sort -u
+```
+
+## 2. Supabase Edge Function secrets — match Stripe LIVE mode
+
+The webhook at `supabase/functions/stripe-webhook` reads two secrets at
+runtime:
+
+| Secret                       | What it should be                                     |
+|------------------------------|-------------------------------------------------------|
+| `STRIPE_SECRET_KEY`          | LIVE-mode secret key from Stripe Dashboard (`sk_live_…`) |
+| `STRIPE_WEBHOOK_SECRET`      | LIVE-mode webhook signing secret (`whsec_…`)          |
+
+**Action:**
+1. In [Stripe Dashboard (LIVE mode)](https://dashboard.stripe.com/) →
+   Developers → API keys, copy the live secret key.
+2. Developers → Webhooks → Add endpoint pointing at
+   `https://<project>.supabase.co/functions/v1/stripe-webhook`
+   (or update the existing endpoint to LIVE if you have one). Subscribe
+   to at least:
+   - `checkout.session.completed`
+   - `invoice.paid`
+   - `customer.subscription.updated`
+   - `customer.subscription.deleted`
+3. Copy the signing secret for that endpoint.
+4. In Supabase Dashboard → Edge Functions → Secrets, set both
+   `STRIPE_SECRET_KEY` and `STRIPE_WEBHOOK_SECRET` to the LIVE values.
+
+## 3. Stripe Payment Link metadata — set `tier`
+
+Each LIVE Payment Link needs `metadata.tier` set so the webhook knows
+which license tier to issue. The webhook now accepts both `pro` and
+`professional` as synonyms (see `stripe-webhook/index.ts:TIER_CANONICAL`)
+so either works, but the recommended canonical values are:
+
+| Plan         | `metadata.tier` value |
+|--------------|-----------------------|
+| Pro Monthly  | `pro`                 |
+| Pro Yearly   | `pro`                 |
+| Enterprise   | `enterprise`          |
+
+**Action:** in Stripe Dashboard → Payment Links → for each LIVE link →
+Advanced → Metadata, add a key/value pair `tier=pro` (or `tier=enterprise`).
+
+## 4. Stripe Payment Link success URL
+
+Each Payment Link's "After payment → Show confirmation page → Custom URL"
+should redirect customers to:
+
+```
+https://www.aidotnet.dev/account/licenses/?new=true
+```
+
+The `?new=true` query param is what triggers the post-checkout polling
+spinner on the licenses page (see `src/pages/account/licenses/index.astro`).
+
+## 5. Apply the new Supabase migration
+
+The new migration `supabase/migrations/20260610000000_log_validations_to_api_usage.sql`
+plumbs every `validate_license_key` RPC call into `api_usage` so the
+`/account/usage/` dashboard stops showing "No usage data yet" for active
+license holders.
+
+**Action:**
+```bash
+cd website
+supabase db push
+```
+
+(Or apply via the Supabase Dashboard → SQL Editor if you don't have CLI
+access configured locally.)
+
+## 6. Smoke-test the live flow
+
+1. Browse to https://www.aidotnet.dev/pricing/ in an Incognito window.
+2. Confirm Subscribe buttons resolve to `buy.stripe.com/` URLs **without**
+   the `test_` prefix.
+3. Sign in as a test user, click Subscribe on Pro Monthly, complete a
+   real card payment.
+4. Verify Stripe Dashboard → Payments shows the charge under the LIVE
+   account (not test mode).
+5. Within ~5s of Stripe's redirect to `/account/licenses/?new=true` the
+   green "License issued!" banner should appear, and a row should be
+   visible with format `AIDN-PROD-PRO-{32hex}`.
+6. Wait one minute, navigate to `/account/usage/`, confirm a row appeared
+   under "Calls by Endpoint" → `validate_license_key`.
+7. Configure the freshly-issued key in the SDK (`AIDOTNET_LICENSE_KEY`
+   env var) and run any `IModel.Save()` call to trigger a validation.
+   Refresh `/account/licenses/` and confirm "Last seen" timestamps on
+   the activation row updated.

--- a/website/src/components/Navbar.astro
+++ b/website/src/components/Navbar.astro
@@ -242,11 +242,30 @@ const links = [
       });
     }
 
-    // Sign out handlers
+    // Sign out handlers. Mirrors the AccountLayout sign-out fix:
+    // `scope: 'local'` for deterministic local-session clear (network
+    // revoke failures used to leave the localStorage token in place,
+    // making Sign Out a silent no-op), plus a defensive sb-* sweep so
+    // the next /login/ visit doesn't see a stale session and auto-
+    // redirect the user back to /account/.
     const signOutBtn = document.getElementById('nav-sign-out');
     const mobileSignOut = document.getElementById('mobile-sign-out');
     const signOut = async () => {
-      await supabase.auth.signOut();
+      try {
+        await supabase.auth.signOut({ scope: 'local' });
+      } catch (e) {
+        console.error('Sign out failed:', e);
+      }
+      try {
+        for (let i = localStorage.length - 1; i >= 0; i--) {
+          const k = localStorage.key(i);
+          if (k && k.startsWith('sb-') && k.endsWith('-auth-token')) {
+            localStorage.removeItem(k);
+          }
+        }
+      } catch {
+        // localStorage can throw in private-mode Safari; ignore.
+      }
       window.location.href = base;
     };
     if (signOutBtn) signOutBtn.addEventListener('click', signOut);

--- a/website/src/layouts/AccountLayout.astro
+++ b/website/src/layouts/AccountLayout.astro
@@ -130,12 +130,38 @@ const sidebarLinks = [
       if (signOutBtn) {
         signOutBtn.addEventListener('click', async () => {
           try {
-            const { error } = await supabase.auth.signOut();
+            // `scope: 'local'` clears the browser-side session
+            // unconditionally; the default 'global' makes a network call
+            // to revoke the refresh token server-side first, and when
+            // that 4xx/5xxs (expired refresh token, brief Supabase
+            // outage, captive-portal Wi-Fi, etc.) the SDK can leave the
+            // localStorage `sb-*-auth-token` entry in place. The user
+            // then clicks Sign Out, the page redirects to `/`, but the
+            // next visit to /login/ sees a valid session and redirects
+            // straight back into /account/ — i.e. Sign Out appears
+            // broken. Local scope sidesteps that and gives us a
+            // deterministic local-session clear.
+            const { error } = await supabase.auth.signOut({ scope: 'local' });
             if (error) {
               console.error('Sign out error:', error.message);
             }
           } catch (e) {
             console.error('Sign out failed:', e);
+          }
+          // Defensive belt-and-braces: even if signOut threw or skipped
+          // the localStorage clear (e.g. SDK regression), nuke any
+          // residual sb-*-auth-token keys so the next checkExistingSession
+          // on /login/ doesn't auto-redirect the user back into the
+          // account area they just signed out of.
+          try {
+            for (let i = localStorage.length - 1; i >= 0; i--) {
+              const k = localStorage.key(i);
+              if (k && k.startsWith('sb-') && k.endsWith('-auth-token')) {
+                localStorage.removeItem(k);
+              }
+            }
+          } catch {
+            // localStorage can throw in private-mode Safari; ignore.
           }
           // Always redirect regardless of sign-out result
           const base = import.meta.env.BASE_URL || '/';

--- a/website/src/pages/account/billing/index.astro
+++ b/website/src/pages/account/billing/index.astro
@@ -180,12 +180,19 @@ const base = import.meta.env.BASE_URL;
       const upgradeBtn = document.getElementById('billing-upgrade-btn');
       const portalSection = document.getElementById('portal-section');
 
-      if (profile.subscription_tier === 'pro') {
+      // Accept both 'pro' (UI canonical) and the legacy 'professional'
+      // (stripe-webhook used to write this directly when the Stripe
+      // metadata tier was 'professional'). New webhook code normalises to
+      // 'pro', but existing profile rows may still carry 'professional'
+      // until the next checkout event — treat them as the same tier here
+      // so the Pro UI lights up instead of falling through to Free.
+      const tier = profile.subscription_tier;
+      if (tier === 'pro' || tier === 'professional') {
         if (planEl) planEl.textContent = 'Pro';
         if (priceEl) priceEl.textContent = '$29/month';
         if (upgradeBtn) upgradeBtn.textContent = 'Manage Plan';
         if (portalSection) portalSection.classList.remove('hidden');
-      } else if (profile.subscription_tier === 'enterprise') {
+      } else if (tier === 'enterprise') {
         if (planEl) planEl.textContent = 'Enterprise';
         if (priceEl) priceEl.textContent = 'Custom pricing';
         if (upgradeBtn) {

--- a/website/src/pages/account/index.astro
+++ b/website/src/pages/account/index.astro
@@ -177,12 +177,15 @@ const base = import.meta.env.BASE_URL;
         const planDesc = document.getElementById('plan-description');
         const upgradeBtn = document.getElementById('upgrade-btn');
 
-        if (profile.subscription_tier === 'pro' && planBadge) {
+        // Accept both 'pro' and legacy 'professional' — see billing/index.astro
+        // for the matching alias so the badge stays in sync with the billing UI.
+        const tier = profile.subscription_tier;
+        if ((tier === 'pro' || tier === 'professional') && planBadge) {
           planBadge.textContent = 'Pro';
           planBadge.className = 'inline-flex items-center px-3 py-1 rounded-full text-xs font-semibold bg-brand-blue/10 text-brand-blue';
           if (planDesc) planDesc.textContent = 'Cloud-hosted inference API, priority support, and direct team access.';
           if (upgradeBtn) upgradeBtn.textContent = 'Manage Plan';
-        } else if (profile.subscription_tier === 'enterprise' && planBadge) {
+        } else if (tier === 'enterprise' && planBadge) {
           planBadge.textContent = 'Enterprise';
           planBadge.className = 'inline-flex items-center px-3 py-1 rounded-full text-xs font-semibold bg-purple-100 dark:bg-purple-900/30 text-purple-700 dark:text-purple-400';
           if (planDesc) planDesc.textContent = 'Dedicated support, SLA, and architecture consulting.';

--- a/website/src/pages/account/licenses/index.astro
+++ b/website/src/pages/account/licenses/index.astro
@@ -223,13 +223,33 @@ var builder = new AiModelBuilder&lt;double, double[], double&gt;(license);</code
             // means future maintainers can't accidentally introduce an
             // HTML-injection vector by interpolating a user-supplied
             // value (error message, email address, etc.) into the string.
-            subtitle.textContent = 'Please refresh in a minute. If the license still isn\'t here, email ';
+            subtitle.textContent = 'Please refresh in a minute. If the license still isn\'t here, ';
+
+            // Diagnostic mailto so support gets the user's auth context,
+            // session id (if available from Stripe redirect), URL, UA,
+            // and timestamp without the user having to gather any of it
+            // themselves. Previous behavior was a bare "email support"
+            // text link that opened an empty message — support couldn't
+            // tell which checkout failed without a back-and-forth.
+            const ts = new Date().toISOString();
+            const stripeSession = new URLSearchParams(window.location.search).get('session_id') || '(none)';
+            const body =
+              'My Stripe checkout completed but no license appeared in /account/licenses/.\n\n' +
+              'User ID: ' + session.user.id + '\n' +
+              'Email: ' + (session.user.email ?? '(no email on session)') + '\n' +
+              'Stripe checkout session_id: ' + stripeSession + '\n' +
+              'Page URL: ' + window.location.href + '\n' +
+              'Timestamp (UTC): ' + ts + '\n' +
+              'User Agent: ' + navigator.userAgent + '\n';
             const mailLink = document.createElement('a');
-            mailLink.href = 'mailto:support@aidotnet.dev';
+            mailLink.href =
+              'mailto:support@aidotnet.dev'
+              + '?subject=' + encodeURIComponent('[aidotnet.dev] License not issued after checkout')
+              + '&body=' + encodeURIComponent(body);
             mailLink.className = 'underline';
-            mailLink.textContent = 'support@aidotnet.dev';
+            mailLink.textContent = 'report to support';
             subtitle.appendChild(mailLink);
-            subtitle.append('.');
+            subtitle.append(' — the email is pre-filled with diagnostic details.');
           }
           iconLoading?.classList.add('hidden');
           iconWarning?.classList.remove('hidden');

--- a/website/src/pages/admin/index.astro
+++ b/website/src/pages/admin/index.astro
@@ -153,10 +153,14 @@ import AdminLayout from '../../layouts/AdminLayout.astro';
         return;
       }
 
+      // `subscription_tier` carries both the new 'pro' canonical and the
+      // legacy 'professional' value for users whose row was last touched
+      // before the stripe-webhook normalisation. Count both so the admin
+      // dashboard doesn't undercount paid users mid-migration.
       const { count: proUsers } = await supabase
         .from('profiles')
         .select('*', { count: 'exact', head: true })
-        .eq('subscription_tier', 'pro');
+        .in('subscription_tier', ['pro', 'professional']);
 
       const { count: enterpriseUsers } = await supabase
         .from('profiles')

--- a/website/src/pages/auth/callback.astro
+++ b/website/src/pages/auth/callback.astro
@@ -205,11 +205,38 @@ const base = import.meta.env.BASE_URL;
                <pre class="mt-2 whitespace-pre-wrap break-words bg-red-100/40 dark:bg-red-900/30 p-2 rounded">${safe(details)}</pre>
              </details>`
           : '';
+
+        // "Report to support" mailto with diagnostic context pre-filled
+        // in the body. Previous error UIs told users to contact support
+        // without giving them a working channel — this guarantees a click
+        // sends an email with the headline, hint, technical details, page
+        // URL, user agent and timestamp pre-populated. mailto: is the
+        // lowest-common-denominator transport: works without JS, without
+        // third-party cookies, and without a feedback widget reaching out
+        // to an external service. The user can always edit before sending.
+        const ts = new Date().toISOString();
+        const body =
+          'Headline: ' + headline + '\n' +
+          (hint ? 'Hint: ' + hint + '\n' : '') +
+          (details ? 'Details:\n' + details + '\n' : '') +
+          'Page URL: ' + window.location.href + '\n' +
+          'Timestamp (UTC): ' + ts + '\n' +
+          'User Agent: ' + navigator.userAgent + '\n\n' +
+          'What I was trying to do:\n(please describe)\n';
+        const mailto =
+          'mailto:support@aidotnet.dev'
+          + '?subject=' + encodeURIComponent('[aidotnet.dev] Sign-in failed: ' + headline)
+          + '&body=' + encodeURIComponent(body);
+
         errorDiv.innerHTML = `
           <p class="font-semibold text-red-700 dark:text-red-300">${safe(headline)}</p>
           ${hintHtml}
           ${detailsHtml}
-          <p class="mt-3"><a href="${base}login/" class="underline font-medium">Back to login</a></p>
+          <p class="mt-3">
+            <a href="${base}login/" class="underline font-medium">Back to login</a>
+            <span class="mx-2 text-slate-400">·</span>
+            <a href="${safe(mailto)}" class="underline font-medium">Report to support</a>
+          </p>
         `;
         errorDiv.classList.remove('hidden');
       }

--- a/website/src/pages/auth/callback.astro
+++ b/website/src/pages/auth/callback.astro
@@ -235,7 +235,7 @@ const base = import.meta.env.BASE_URL;
           <p class="mt-3">
             <a href="${base}login/" class="underline font-medium">Back to login</a>
             <span class="mx-2 text-slate-400">·</span>
-            <a href="${safe(mailto)}" class="underline font-medium">Report to support</a>
+            <a href="${mailto}" class="underline font-medium">Report to support</a>
           </p>
         `;
         errorDiv.classList.remove('hidden');

--- a/website/supabase/functions/stripe-webhook/index.ts
+++ b/website/supabase/functions/stripe-webhook/index.ts
@@ -17,12 +17,37 @@ const WEBHOOK_PRODUCT: ProductSlug = "aidotnet";
 // to — so the dash form is the only viable issuance path here.
 const WEBHOOK_PREFIX = "AIDN-PROD" as const;
 
-// Per-tier activation caps. Keeping them in one map so bumping a tier's
-// cap doesn't require hunting through the handlers.
-const TIER_MAX_ACTIVATIONS: Record<string, number> = {
-  professional: 10,
-  enterprise: 10,
+// Two separate tier vocabularies exist:
+//   * `profiles.subscription_tier` (free text, UI checks `=== 'pro'`)
+//   * `license_keys.tier` (enum `license_tier`: 'community' | 'professional' | 'enterprise')
+// Stripe Payment Link metadata.tier can be configured to either word
+// depending on dashboard history, so the webhook accepts both `pro` and
+// `professional` as synonyms and writes the CANONICAL name to each
+// column. Previous code wrote the same string to both columns, so one
+// side was always wrong (UI saw 'professional' and rendered Free, or the
+// license_keys insert failed the enum check).
+type TierAlias = "pro" | "professional" | "enterprise";
+interface CanonicalTier {
+  // Goes into profiles.subscription_tier — matches the value the
+  // billing/account UI checks for (`=== 'pro'`).
+  profileTier: string;
+  // Goes into license_keys.tier — must be a value of the
+  // public.license_tier enum.
+  licenseTier: "professional" | "enterprise";
+  // Used by AIDN-PROD-{TIER}-{32hex} key generation.
+  keySegment: string;
+  maxActivations: number;
+}
+const TIER_CANONICAL: Record<TierAlias, CanonicalTier> = {
+  pro:          { profileTier: "pro", licenseTier: "professional", keySegment: "PRO", maxActivations: 10 },
+  professional: { profileTier: "pro", licenseTier: "professional", keySegment: "PRO", maxActivations: 10 },
+  enterprise:   { profileTier: "enterprise", licenseTier: "enterprise", keySegment: "ENTERPRISE", maxActivations: 10 },
 };
+function resolveTier(raw: unknown): CanonicalTier | null {
+  if (typeof raw !== "string") return null;
+  const lower = raw.toLowerCase() as TierAlias;
+  return TIER_CANONICAL[lower] ?? null;
+}
 
 // Secrets are read lazily inside the request handler so the function can
 // be deployed BEFORE the project-level secrets are configured in the
@@ -170,16 +195,17 @@ async function handleCheckoutCompleted(
     throw new Error("cannot_resolve_user");
   }
 
-  // Derive the set of allowed tiers from TIER_MAX_ACTIVATIONS rather
-  // than hardcoding a parallel list. Adding a new paid tier becomes a
-  // one-line change to the map instead of needing to also update a
-  // separate validator list that can drift out of sync.
-  const tier = session.metadata?.tier;
-  if (!tier || !(tier in TIER_MAX_ACTIVATIONS)) {
-    throw new Error(`checkout.session.completed: invalid or missing tier '${tier}' in session metadata`);
+  // Resolve the raw Stripe metadata tier into the canonical pair of
+  // values for the two different tier columns. Accepts both 'pro' (UI
+  // vocabulary, what data-tier on pricing.astro emits) and 'professional'
+  // (legacy webhook-side vocabulary, what the public.license_tier enum
+  // requires) as synonyms so a partially-migrated Stripe dashboard config
+  // doesn't drop the license.
+  const rawTier = session.metadata?.tier;
+  const canonical = resolveTier(rawTier);
+  if (!canonical) {
+    throw new Error(`checkout.session.completed: invalid or missing tier '${rawTier}' in session metadata`);
   }
-
-  const maxActivations = TIER_MAX_ACTIVATIONS[tier];
 
   const stripeCustomerId = typeof session.customer === "string"
     ? session.customer
@@ -195,7 +221,7 @@ async function handleCheckoutCompleted(
   // for the customer; a stale profile row is a recoverable nit that
   // can be fixed manually via the admin panel.
   const profileUpdate: Record<string, string> = {
-    subscription_tier: tier,
+    subscription_tier: canonical.profileTier,
     subscription_status: "active",
   };
   if (stripeCustomerId) profileUpdate.stripe_customer_id = stripeCustomerId;
@@ -213,27 +239,28 @@ async function handleCheckoutCompleted(
     .select("id, license_key")
     .eq("user_id", userId)
     .eq("product", WEBHOOK_PRODUCT)
-    .eq("tier", tier)
+    .eq("tier", canonical.licenseTier)
     .eq("status", "active")
     .maybeSingle();
 
   if (existing) {
-    console.log(`User ${userId} already holds an active ${tier} license (${existing.id}). Stripe event was likely retried — no-op.`);
+    console.log(`User ${userId} already holds an active ${canonical.licenseTier} license (${existing.id}). Stripe event was likely retried — no-op.`);
     return;
   }
 
-  // Generate a fresh AIDN-PROD-{TIER_UPPER}-{32hex} key. Format must
+  // Generate a fresh AIDN-PROD-{KEY_SEGMENT}-{32hex} key. Format must
   // satisfy LicenseValidator.IsServerValidatedKeyFormat in the AiDotNet
   // client library: ≥4 dash-delimited segments, segment[0]=="AIDN", last
   // segment is ≥8 hex chars. Empirically verified that
-  // `AIDN-PROD-PROFESSIONAL-{32hex}` validates end-to-end through the
-  // online validate-license edge function path.
+  // `AIDN-PROD-PRO-{32hex}` and `AIDN-PROD-ENTERPRISE-{32hex}` both
+  // validate end-to-end through the online validate-license edge
+  // function path.
   //
   // Previous format (`aidn.{id}.{sig}`) was rejected by the client
   // library because the dotted form requires HMAC-SHA256 signing against
   // a build key the webhook does not have access to. See ooples/AiDotNet#1262.
   const keyHex = crypto.randomUUID().replace(/-/g, "");
-  const licenseKey = `${WEBHOOK_PREFIX}-${tier.toUpperCase()}-${keyHex}`;
+  const licenseKey = `${WEBHOOK_PREFIX}-${canonical.keySegment}-${keyHex}`;
 
   const { error: insertError } = await client
     .from("license_keys")
@@ -241,9 +268,9 @@ async function handleCheckoutCompleted(
       user_id: userId,
       license_key: licenseKey,
       product: WEBHOOK_PRODUCT,
-      tier,
+      tier: canonical.licenseTier,
       status: "active",
-      max_activations: maxActivations,
+      max_activations: canonical.maxActivations,
       stripe_subscription_id: subscriptionId,
       stripe_customer_id: stripeCustomerId,
       notes: `Issued by Stripe Checkout (session ${session.id})`,
@@ -254,7 +281,7 @@ async function handleCheckoutCompleted(
     throw insertError;
   }
 
-  console.log(`Issued ${tier} license ${licenseKey.substring(0, 12)}... for user ${userId}`);
+  console.log(`Issued ${canonical.licenseTier} license ${licenseKey.substring(0, 12)}... for user ${userId}`);
 
   // Best-effort key delivery email. The license row above is the source
   // of truth — failure here is logged but never thrown so a flaky email
@@ -267,7 +294,7 @@ async function handleCheckoutCompleted(
     await sendLicenseKeyEmail({
       to: recipient,
       licenseKey,
-      tier,
+      tier: canonical.licenseTier,
       product: WEBHOOK_PRODUCT,
       isExisting: false,
     });

--- a/website/supabase/functions/stripe-webhook/index.ts
+++ b/website/supabase/functions/stripe-webhook/index.ts
@@ -379,9 +379,27 @@ async function handleSubscriptionUpdated(
     professional: 1,
     enterprise: 2,
   };
-  const seenCanonical = (subscription.items?.data ?? [])
+  const items = subscription.items?.data ?? [];
+  const seenCanonical = items
     .map((item) => resolveTier(item.price?.metadata?.tier))
     .filter((c): c is CanonicalTier => c !== null);
+
+  // If the subscription has items but NONE resolved to a known tier,
+  // fail loud. Silently updating `status` without `tier`/`max_activations`
+  // would leave the old entitlement in place after a plan change —
+  // exactly the "license still active for the wrong tier" footgun
+  // this handler is supposed to prevent. Stripe will retry the event
+  // and the admin can investigate the metadata drift in the meantime.
+  if (items.length > 0 && seenCanonical.length === 0) {
+    const rawTiers = items.map((it) => it.price?.metadata?.tier ?? '(missing)');
+    throw new Error(
+      `customer.subscription.updated: subscription ${subscription.id} has ${items.length} ` +
+      `item(s) but none of their price.metadata.tier values resolve to a canonical tier. ` +
+      `Saw: [${rawTiers.join(', ')}]. ` +
+      `Update Stripe Price metadata to one of: 'pro', 'professional', 'enterprise'.`
+    );
+  }
+
   const winner = seenCanonical.length > 0
     ? seenCanonical.reduce((a, b) =>
         TIER_LICENSE_RANK[a.licenseTier] >= TIER_LICENSE_RANK[b.licenseTier] ? a : b

--- a/website/supabase/functions/stripe-webhook/index.ts
+++ b/website/supabase/functions/stripe-webhook/index.ts
@@ -370,27 +370,28 @@ async function handleSubscriptionUpdated(
   // add-on — are allowed by Stripe and the webhook should degrade
   // gracefully if one lands.
   //
-  // Strategy: walk every item, collect the tiers advertised in each
-  // price's metadata, and pick the highest-ranked tier we know about.
-  // Enterprise wins over professional; anything not in the known set
-  // is ignored rather than trusted. That means adding a "premium"
-  // tier later requires appending it to TIER_RANK below — which keeps
-  // the precedence explicit, unlike a blind `first item wins` fallback.
-  const TIER_RANK: Record<string, number> = {
+  // Strategy: walk every item, normalise each tier through resolveTier
+  // (which accepts both 'pro' and 'professional' aliases — see
+  // TIER_CANONICAL above), and pick the highest-ranked tier we know
+  // about. Enterprise wins over professional; anything resolveTier
+  // returns null for is ignored rather than trusted.
+  const TIER_LICENSE_RANK: Record<CanonicalTier["licenseTier"], number> = {
     professional: 1,
     enterprise: 2,
   };
-  const seenTiers = (subscription.items?.data ?? [])
-    .map((item) => item.price?.metadata?.tier as string | undefined)
-    .filter((t): t is string => typeof t === "string" && t in TIER_RANK);
-  const tier = seenTiers.length > 0
-    ? seenTiers.reduce((a, b) => (TIER_RANK[a] >= TIER_RANK[b] ? a : b))
-    : undefined;
+  const seenCanonical = (subscription.items?.data ?? [])
+    .map((item) => resolveTier(item.price?.metadata?.tier))
+    .filter((c): c is CanonicalTier => c !== null);
+  const winner = seenCanonical.length > 0
+    ? seenCanonical.reduce((a, b) =>
+        TIER_LICENSE_RANK[a.licenseTier] >= TIER_LICENSE_RANK[b.licenseTier] ? a : b
+      )
+    : null;
 
   const updateData: Record<string, string | number> = { status: licenseStatus };
-  if (tier && TIER_MAX_ACTIVATIONS[tier] !== undefined) {
-    updateData.tier = tier;
-    updateData.max_activations = TIER_MAX_ACTIVATIONS[tier];
+  if (winner) {
+    updateData.tier = winner.licenseTier;
+    updateData.max_activations = winner.maxActivations;
   }
 
   const { error } = await client
@@ -412,7 +413,9 @@ async function handleSubscriptionUpdated(
 
   if (stripeCustomerId) {
     const profileUpdate: Record<string, string> = { subscription_status: licenseStatus };
-    if (tier) profileUpdate.subscription_tier = tier;
+    // Use the profile-canonical tier name (`pro`/`enterprise`), not the
+    // license_keys enum name — billing/account UI checks `=== 'pro'`.
+    if (winner) profileUpdate.subscription_tier = winner.profileTier;
     const { error: profileError } = await client
       .from("profiles")
       .update(profileUpdate)

--- a/website/supabase/migrations/20260610000000_log_validations_to_api_usage.sql
+++ b/website/supabase/migrations/20260610000000_log_validations_to_api_usage.sql
@@ -1,0 +1,205 @@
+-- Migration: validate_license_key writes a row to public.api_usage so the
+--            /account/usage/ dashboard actually has data to render.
+--
+-- Issue: The Usage page reads from api_usage but nothing in the codebase
+-- writes to it. Until this migration, the page rendered "No usage data
+-- yet" for every authenticated user, even active license holders. This
+-- migration plumbs the existing validate_license_key RPC (which fires
+-- once per SDK validation call) into api_usage so each successful
+-- validation logs a row.
+--
+-- Rollout: drop+recreate the 5-arg overload (the only one currently in
+-- use after 20260427000000). The signature, return shape, and CASE arms
+-- for v_capabilities are preserved verbatim — only the side-effect of
+-- recording the call is added. Old callers continue to work.
+
+drop function if exists public.validate_license_key(text, text, text, text, text);
+
+create or replace function public.validate_license_key(
+    p_license_key text,
+    p_machine_id_hash text,
+    p_hostname text default null,
+    p_os_description text default null,
+    p_package text default null
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+    v_license record;
+    v_activation_count int;
+    v_existing_activation record;
+    v_capabilities jsonb;
+    v_started timestamptz := clock_timestamp();
+    v_status_code int;
+    v_response jsonb;
+    v_endpoint constant text := 'validate_license_key';
+    -- Endpoint label kept short and grep-able so the /account/usage/
+    -- "Calls by Endpoint" chart shows a clean row. If additional RPC
+    -- entry points start logging too, follow the same naming scheme.
+begin
+    -- Look up the license key
+    select * into v_license
+    from public.license_keys
+    where license_key = p_license_key;
+
+    if not found then
+        v_status_code := 404;
+        v_response := jsonb_build_object(
+            'valid', false,
+            'error', 'invalid_key',
+            'message', 'License key not found.'
+        );
+        -- No user_id known when the key is invalid — skip the api_usage
+        -- write rather than logging against an arbitrary user. (The
+        -- service-role validate-license edge function still logs the
+        -- failure server-side for fraud / abuse monitoring.)
+        return v_response;
+    end if;
+
+    -- Check license status
+    if v_license.status != 'active' then
+        v_status_code := 403;
+        v_response := jsonb_build_object(
+            'valid', false,
+            'error', 'license_' || v_license.status::text,
+            'message', 'License is ' || v_license.status::text || '.'
+        );
+        insert into public.api_usage (user_id, endpoint, status_code, latency_ms)
+        values (
+            v_license.user_id,
+            v_endpoint,
+            v_status_code,
+            extract(milliseconds from clock_timestamp() - v_started)::int
+        );
+        return v_response;
+    end if;
+
+    -- Check expiration
+    if v_license.expires_at is not null and v_license.expires_at < now() then
+        v_status_code := 403;
+        v_response := jsonb_build_object(
+            'valid', false,
+            'error', 'license_expired',
+            'message', 'License has expired.'
+        );
+        insert into public.api_usage (user_id, endpoint, status_code, latency_ms)
+        values (
+            v_license.user_id,
+            v_endpoint,
+            v_status_code,
+            extract(milliseconds from clock_timestamp() - v_started)::int
+        );
+        return v_response;
+    end if;
+
+    -- Resolve the per-tier capability set. Build the array once so success
+    -- paths (existing-activation update, new-activation insert) return the
+    -- same shape — divergence between the two paths would mean tensor-side
+    -- enforcement behaves differently for a returning machine vs a new one.
+    v_capabilities := case v_license.tier
+        when 'community' then
+            jsonb_build_array('tensors:load')
+        when 'professional' then
+            jsonb_build_array('tensors:save', 'tensors:load', 'model:save', 'model:load')
+        when 'enterprise' then
+            jsonb_build_array('tensors:save', 'tensors:load', 'model:save', 'model:load')
+        else
+            jsonb_build_array()
+    end;
+
+    -- Check if this machine is already activated
+    select * into v_existing_activation
+    from public.license_activations
+    where license_key_id = v_license.id
+      and machine_id_hash = p_machine_id_hash
+      and is_active = true;
+
+    if found then
+        update public.license_activations
+        set last_seen_at = now(),
+            hostname = coalesce(p_hostname, hostname),
+            os_description = coalesce(p_os_description, os_description),
+            last_seen_package = p_package
+        where id = v_existing_activation.id;
+
+        v_status_code := 200;
+        v_response := jsonb_build_object(
+            'valid', true,
+            'tier', v_license.tier::text,
+            'capabilities', v_capabilities,
+            'license_id', v_license.id,
+            'activation_id', v_existing_activation.id,
+            'message', 'License validated (existing activation).'
+        );
+        insert into public.api_usage (user_id, endpoint, model_id, status_code, latency_ms)
+        values (
+            v_license.user_id,
+            v_endpoint,
+            v_license.tier::text,
+            v_status_code,
+            extract(milliseconds from clock_timestamp() - v_started)::int
+        );
+        return v_response;
+    end if;
+
+    -- Advisory lock on the license key ID to prevent race conditions
+    -- when two concurrent validations try to activate the same license
+    perform pg_advisory_xact_lock(v_license.id);
+
+    -- Re-count active activations after acquiring the lock
+    select count(*) into v_activation_count
+    from public.license_activations
+    where license_key_id = v_license.id
+      and is_active = true;
+
+    if v_activation_count >= v_license.max_activations then
+        v_status_code := 429;
+        v_response := jsonb_build_object(
+            'valid', false,
+            'error', 'activation_limit',
+            'message', 'Maximum activations (' || v_license.max_activations || ') reached. Deactivate a machine first.',
+            'current_activations', v_activation_count,
+            'max_activations', v_license.max_activations
+        );
+        insert into public.api_usage (user_id, endpoint, status_code, latency_ms)
+        values (
+            v_license.user_id,
+            v_endpoint,
+            v_status_code,
+            extract(milliseconds from clock_timestamp() - v_started)::int
+        );
+        return v_response;
+    end if;
+
+    -- Create new activation
+    insert into public.license_activations (license_key_id, machine_id_hash, hostname, os_description, last_seen_package)
+    values (v_license.id, p_machine_id_hash, p_hostname, p_os_description, p_package);
+
+    v_status_code := 200;
+    v_response := jsonb_build_object(
+        'valid', true,
+        'tier', v_license.tier::text,
+        'capabilities', v_capabilities,
+        'license_id', v_license.id,
+        'message', 'License validated and activated on this machine.'
+    );
+    insert into public.api_usage (user_id, endpoint, model_id, status_code, latency_ms)
+    values (
+        v_license.user_id,
+        v_endpoint,
+        v_license.tier::text,
+        v_status_code,
+        extract(milliseconds from clock_timestamp() - v_started)::int
+    );
+    return v_response;
+end;
+$$;
+
+revoke execute on function public.validate_license_key(text, text, text, text, text) from anon;
+grant execute on function public.validate_license_key(text, text, text, text, text) to service_role;
+
+comment on function public.validate_license_key(text, text, text, text, text) is
+    'Validates a license key and registers/updates a machine activation. Returns JSON with valid, tier, capabilities, error fields. Logs every call to api_usage so the /account/usage/ dashboard reflects SDK activity.';

--- a/website/supabase/migrations/20260610000000_log_validations_to_api_usage.sql
+++ b/website/supabase/migrations/20260610000000_log_validations_to_api_usage.sql
@@ -134,11 +134,15 @@ begin
             'activation_id', v_existing_activation.id,
             'message', 'License validated (existing activation).'
         );
-        insert into public.api_usage (user_id, endpoint, model_id, status_code, latency_ms)
+        -- model_id intentionally NULL: validate_license_key isn't a
+        -- model invocation, and the /account/usage/ "Top Models Used"
+        -- panel shouldn't list tier names as if they were ML models.
+        -- Tier is already returned in the response and persisted on
+        -- the license_keys row; api_usage only needs endpoint + result.
+        insert into public.api_usage (user_id, endpoint, status_code, latency_ms)
         values (
             v_license.user_id,
             v_endpoint,
-            v_license.tier::text,
             v_status_code,
             extract(milliseconds from clock_timestamp() - v_started)::int
         );
@@ -186,11 +190,13 @@ begin
         'license_id', v_license.id,
         'message', 'License validated and activated on this machine.'
     );
-    insert into public.api_usage (user_id, endpoint, model_id, status_code, latency_ms)
+    -- See "model_id intentionally NULL" comment on the existing-activation
+    -- branch above. Validate-license is not a model call; tier lives on
+    -- license_keys + in the response payload, not in api_usage.model_id.
+    insert into public.api_usage (user_id, endpoint, status_code, latency_ms)
     values (
         v_license.user_id,
         v_endpoint,
-        v_license.tier::text,
         v_status_code,
         extract(milliseconds from clock_timestamp() - v_started)::int
     );

--- a/website/supabase/migrations/20260610000000_log_validations_to_api_usage.sql
+++ b/website/supabase/migrations/20260610000000_log_validations_to_api_usage.sql
@@ -122,7 +122,14 @@ begin
         set last_seen_at = now(),
             hostname = coalesce(p_hostname, hostname),
             os_description = coalesce(p_os_description, os_description),
-            last_seen_package = p_package
+            -- `coalesce` (NOT raw assignment) preserves the prior
+            -- `last_seen_package` when an older SDK that pre-dates issue
+            -- #1195 validates with `p_package => null`. The
+            -- validate-license edge function documents `null` as "no
+            -- package tag — leave the stored value unchanged"; a raw
+            -- overwrite would clobber that legitimate prior tag every
+            -- time a legacy client checks in.
+            last_seen_package = coalesce(p_package, last_seen_package)
         where id = v_existing_activation.id;
 
         v_status_code := 200;
@@ -149,9 +156,49 @@ begin
         return v_response;
     end if;
 
-    -- Advisory lock on the license key ID to prevent race conditions
-    -- when two concurrent validations try to activate the same license
+    -- Advisory lock on the license key ID to serialise the
+    -- new-activation path. Two concurrent validations from the same
+    -- new machine would otherwise both miss the existing-activation
+    -- lookup above (race window between SELECT and INSERT), and the
+    -- waiter would either spuriously hit activation_limit or insert a
+    -- duplicate row. Re-check the activation lookup INSIDE the locked
+    -- section so one of the racers finds the row the other just wrote
+    -- and short-circuits into the existing-activation update path.
     perform pg_advisory_xact_lock(v_license.id);
+
+    -- Repeat the activation lookup now that we hold the lock.
+    select * into v_existing_activation
+    from public.license_activations
+    where license_key_id = v_license.id
+      and machine_id_hash = p_machine_id_hash
+      and is_active = true;
+
+    if found then
+        update public.license_activations
+        set last_seen_at = now(),
+            hostname = coalesce(p_hostname, hostname),
+            os_description = coalesce(p_os_description, os_description),
+            last_seen_package = coalesce(p_package, last_seen_package)
+        where id = v_existing_activation.id;
+
+        v_status_code := 200;
+        v_response := jsonb_build_object(
+            'valid', true,
+            'tier', v_license.tier::text,
+            'capabilities', v_capabilities,
+            'license_id', v_license.id,
+            'activation_id', v_existing_activation.id,
+            'message', 'License validated (existing activation, raced into lock).'
+        );
+        insert into public.api_usage (user_id, endpoint, status_code, latency_ms)
+        values (
+            v_license.user_id,
+            v_endpoint,
+            v_status_code,
+            extract(milliseconds from clock_timestamp() - v_started)::int
+        );
+        return v_response;
+    end if;
 
     -- Re-count active activations after acquiring the lock
     select count(*) into v_activation_count


### PR DESCRIPTION
Fixes the cascade of critical bugs the user surfaced on aidotnet.dev. Splits into code-side changes (this PR) and dashboard-side changes (documented in `website/DEPLOYMENT-CHECKLIST.md`).

## Summary

| Bug user reported | Root cause | Where it's fixed |
|---|---|---|
| Payment "froze with critical error" | Stripe TEST-mode payment links + tier-name drift between two DB columns | Code: tier resolver in `stripe-webhook` + UI tier alias normalisation. Env: TEST→LIVE Stripe links (see checklist). |
| Just-created license returns "License key not found" | Webhook 500'd before INSERT (tier `'pro'` not in `TIER_MAX_ACTIVATIONS` map; or test-mode webhook secret mismatch) | Code: webhook now accepts both `pro` and `professional`, writes the correct canonical to each column. |
| Couldn't even report the issue | Error UI had no working "report to support" channel | `mailto:support@aidotnet.dev` with diagnostic context (page URL, UA, timestamp, user-id/Stripe session_id) pre-filled in the body on both `/auth/callback` fatal-error and `/account/licenses` post-checkout timeout. |
| Last Used never updates | SDK rejected the malformed key client-side, so `validate-license` never ran → `last_seen_at` never written | Downstream of the tier fix above. Once a real `AIDN-PROD-PRO-{32hex}` key is issued, the existing RPC update path runs. |
| Usage details never updates | `api_usage` table had **no writers** anywhere in the codebase | New migration `20260610000000_log_validations_to_api_usage.sql` plumbs every `validate_license_key` call into `api_usage`. |
| GitHub login throws an error (new issue) | GitHub OAuth provider config drift at Supabase (rotated client secret or callback URL drift). Supabase's start endpoint is healthy. | Code: confirmed `/auth/callback` already surfaces `server_error` with the right hint. Dashboard fix steps added to `DEPLOYMENT-CHECKLIST.md` §6. |
| (Discovered while reproducing) Sign Out a silent no-op | `signOut()` default scope='global' leaves `sb-*-auth-token` in localStorage when the network revoke 4xxs | `scope: 'local'` + defensive `sb-*` sweep in both AccountLayout and Navbar handlers. |

## Code changes

* `supabase/functions/stripe-webhook/index.ts` — `TIER_CANONICAL` resolver accepts `pro`/`professional` synonyms and writes the right value to `profiles.subscription_tier` (`'pro'`) vs `license_keys.tier` (enum `'professional'`).
* `src/pages/account/billing/index.astro`, `src/pages/account/index.astro`, `src/pages/admin/index.astro` — UI side accepts both spellings so legacy `'professional'` rows still render as Pro.
* `supabase/migrations/20260610000000_log_validations_to_api_usage.sql` — every `validate_license_key` call now writes to `public.api_usage`.
* `src/pages/auth/callback.astro` — fatal-error UI now exposes a `mailto:support@aidotnet.dev` link with diagnostic context.
* `src/pages/account/licenses/index.astro` — post-checkout timeout banner exposes the same diagnostic mailto.
* `src/layouts/AccountLayout.astro`, `src/components/Navbar.astro` — Sign Out uses `scope: 'local'` and defensively wipes `sb-*-auth-token` keys.
* `DEPLOYMENT-CHECKLIST.md` — non-code steps the user must apply in Vercel + Supabase + Stripe + GitHub dashboards.

## Verification

`npx astro build` — clean, 81 pages built, 0 errors.

The downstream symptoms (Last Used, Usage page empty, license-not-found) will self-resolve as soon as:
1. The Vercel Stripe env vars are flipped from TEST to LIVE (checklist §1)
2. The Supabase Edge Function `STRIPE_*` secrets are set to LIVE values (checklist §2)
3. The new migration is applied via `supabase db push` (checklist §5)
4. The GitHub OAuth provider config in Supabase is reconciled with GitHub's OAuth app settings (checklist §6)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * License validation attempts are now recorded in API usage analytics.
  * Legacy "professional" tier is treated as Pro consistently across billing, account UI, admin counts, and post-checkout license issuance.

* **Bug Fixes**
  * More deterministic sign-out with improved local session cleanup.
  * Post-checkout timeout UI includes a pre-filled support report link.
  * Admin subscriber counts now include legacy tier values.

* **Documentation**
  * Added a deployment checklist for switching payments to live mode.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->