### PR TITLE
fix(buildkey): stop ObfuscationTests asserting against the test-override cache

### DIFF
--- a/src/Helpers/BuildKeyProvider.cs
+++ b/src/Helpers/BuildKeyProvider.cs
@@ -35,6 +35,26 @@ internal static class BuildKeyProvider
     }
 
     /// <summary>
+    /// TEST-ONLY: reports whether the embedded build-key RESOURCE is present in the assembly,
+    /// bypassing the in-memory cache (which the test ModuleInitializer overrides process-wide).
+    /// Lets dev-build assertions check the actual ship-state of the DLL instead of the runtime
+    /// cache that has been populated for license-validation tests.
+    /// </summary>
+    internal static bool HasEmbeddedResource()
+    {
+        try
+        {
+            var assembly = typeof(BuildKeyProvider).Assembly;
+            using var stream = assembly.GetManifestResourceStream(ResourceName);
+            return stream is { Length: > 0 };
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    /// <summary>
     /// Gets whether this is an official build with an embedded build key.
     /// </summary>
     internal static bool IsOfficialBuild

--- a/tests/AiDotNet.Tests/Helpers/LicenseTestSupport.cs
+++ b/tests/AiDotNet.Tests/Helpers/LicenseTestSupport.cs
@@ -16,9 +16,14 @@ namespace AiDotNet.Tests.Helpers;
 /// </summary>
 internal static class LicenseTestSupport
 {
-    /// <summary>A fixed 40-byte test build key (never a real signing secret).</summary>
+    /// <summary>
+    /// A fixed 32-byte test build key (never a real signing secret). The size matches the
+    /// official build key (HMAC-SHA256 key length) so tests asserting the published
+    /// "0 bytes (dev) or 32 bytes (official)" key-size contract pass under the
+    /// ModuleInitializer's process-wide override.
+    /// </summary>
     internal static readonly byte[] TestBuildKey =
-        Encoding.UTF8.GetBytes("aidotnet-test-build-key-0123456789ABCDEF");
+        Encoding.UTF8.GetBytes("aidotnet-test-build-key-32bytes!");
 
     /// <summary>
     /// Produces a valid signed key <c>aidn.{id}.{sig}</c> where

--- a/tests/AiDotNet.Tests/UnitTests/Serialization/ObfuscationTests.cs
+++ b/tests/AiDotNet.Tests/UnitTests/Serialization/ObfuscationTests.cs
@@ -12,16 +12,25 @@ public class ObfuscationTests
     [Fact(Timeout = 60000)]
     public async Task BuildKeyProvider_ReturnsEmpty_WhenNoEmbeddedResource()
     {
-        // In test/dev builds there is no embedded build key
-        var key = BuildKeyProvider.GetBuildKey();
-        Assert.NotNull(key);
-        Assert.Empty(key);
+        // Assert against the embedded RESOURCE state, not the runtime cache:
+        // the test ModuleInitializer overrides the cache process-wide so offline
+        // license validation can verify against a known test build key, which
+        // means `GetBuildKey()` reflects the override here. The dev-build
+        // contract this test guards is "the shipped DLL has no embedded
+        // build-key resource", which is what HasEmbeddedResource() checks
+        // directly (bypassing the cache).
+        Assert.False(BuildKeyProvider.HasEmbeddedResource());
     }
 
     [Fact(Timeout = 60000)]
     public async Task BuildKeyProvider_IsOfficialBuild_ReturnsFalse_InDevBuild()
     {
-        Assert.False(BuildKeyProvider.IsOfficialBuild);
+        // Same rationale as BuildKeyProvider_ReturnsEmpty_WhenNoEmbeddedResource:
+        // `IsOfficialBuild` reads through the test-overridden cache, so check
+        // the embedded resource directly. An "official build" by definition
+        // ships with the build-key resource embedded — a dev/fork build does
+        // not.
+        Assert.False(BuildKeyProvider.HasEmbeddedResource());
     }
 
     [Fact(Timeout = 60000)]


### PR DESCRIPTION
## Summary

PR #1555 introduced a process-wide `BuildKeyProvider.OverrideForTesting()` call in the test `ModuleInitializer` so serialize-gated paths get a valid license. That populated the in-memory cache with a 40-byte test key, breaking three tests that defend the "dev build has no embedded build-key resource" invariant via the cache-reading public APIs:

- `ObfuscationTests.BuildKeyProvider_ReturnsEmpty_WhenNoEmbeddedResource`
- `ObfuscationTests.BuildKeyProvider_IsOfficialBuild_ReturnsFalse_InDevBuild`
- `Helpers.BuildKeyAndEncryptionTests.BuildKeyProvider_GetBuildKey_ReturnsValidResult`

The first two are why the `Tests (net10.0) - Unit - 13 Remaining` shard turned red on master after PR #1555 merged — they're the only new regression introduced by that PR. The third would have surfaced in a different shard.

## Fix

1. **`src/Helpers/BuildKeyProvider.cs`** — add `HasEmbeddedResource()`: a test-only static that queries `assembly.GetManifestResourceStream(\"AiDotNet.BuildKey\")` directly, bypassing the cache. Lets dev-build assertions check the actual ship-state of the DLL instead of the runtime cache populated for license-validation tests.

2. **`tests/AiDotNet.Tests/UnitTests/Serialization/ObfuscationTests.cs`** — reframe the two failing tests to assert via `HasEmbeddedResource()`. The contract they guard is about the resource, not about the cache that the test ModuleInitializer override has legitimately populated.

3. **`tests/AiDotNet.Tests/Helpers/LicenseTestSupport.cs`** — trim `TestBuildKey` from 40 to 32 bytes. The docstring on `BuildKeyProvider.GetBuildKey()` documents "0 bytes (dev) or 32 bytes (official)" (HMAC-SHA256 key length); the test data drifted. `SignedKey()` recomputes HMAC from `TestBuildKey` at runtime, so trimming the key needs no other fixture updates.

## Test plan

Confirmed locally on net10.0:

```
Passed!  - Failed:     0, Passed:   145, Skipped:     0, Total:   145, Duration: 30 s
```

across `ObfuscationTests`, `BuildKeyAndEncryptionTests`, `LicenseE2ETests`, `LicenseValidatorTests`, `ModelPersistenceGuardTests`, `AiModelBuilderLicensingTests`, `LicenseServerEndpointTests`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)