### PR TITLE
fix: EmbeddingLayer Optional trainable param (#1331) + FitDetector rank-discordant leniency (#1322)

### DIFF
--- a/src/AiDotNet.Generators/TrainableParameterGenerator.cs
+++ b/src/AiDotNet.Generators/TrainableParameterGenerator.cs
@@ -331,8 +331,29 @@ public class TrainableParameterGenerator : IIncrementalGenerator
                 // re-registered) only while it is currently a materialized tensor
                 // (Length > 0) — mirroring GetTrainableParameters exactly, so the
                 // get/set round-trip stays consistent. The predicate is evaluated on
-                // the *current* field state before assignment, which matches the
-                // state GetTrainableParameters saw when the caller built the list.
+                // the *current* field state, which matches the state
+                // GetTrainableParameters saw when the caller built the list.
+                //
+                // Validate the count up front — BEFORE any state mutation — so a
+                // rejected call leaves the layer untouched rather than partially
+                // updated (a short list would otherwise throw mid-assignment from
+                // parameters[__i], a long list only after every field + registration
+                // had already been mutated). The expected count is the number of
+                // currently-present trainable tensors, computed with the same
+                // predicates the assignment loop uses (field tensors are not mutated
+                // between here and the loop, so the values are stable).
+                sb.AppendLine("        if (parameters is null)");
+                sb.AppendLine("            throw new System.ArgumentNullException(nameof(parameters));");
+                sb.AppendLine("        int __expected = 0;");
+                foreach (var pf in paramFields)
+                {
+                    if (pf.Optional)
+                        sb.AppendLine($"        if ({pf.Name}.Length > 0) __expected++;");
+                    else
+                        sb.AppendLine("        __expected++;");
+                }
+                sb.AppendLine("        if (parameters.Count != __expected)");
+                sb.AppendLine("            throw new System.ArgumentException($\"Expected {__expected} parameters (currently-present trainable tensors), got {parameters.Count}.\", nameof(parameters));");
                 sb.AppendLine("        int __i = 0;");
                 sb.AppendLine("        ClearRegisteredParameters();");
                 foreach (var pf in paramFields)
@@ -353,8 +374,6 @@ public class TrainableParameterGenerator : IIncrementalGenerator
                         sb.AppendLine("        __i++;");
                     }
                 }
-                sb.AppendLine("        if (__i != parameters.Count)");
-                sb.AppendLine("            throw new System.ArgumentException($\"Expected {__i} parameters (currently-present trainable tensors), got {parameters.Count}.\", nameof(parameters));");
             }
             else
             {

--- a/src/AiDotNet.Generators/TrainableParameterGenerator.cs
+++ b/src/AiDotNet.Generators/TrainableParameterGenerator.cs
@@ -90,6 +90,7 @@ public class TrainableParameterGenerator : IIncrementalGenerator
                 {
                     var role = "PersistentTensorRole.Weights";
                     var order = 0;
+                    var optional = false;
 
                     foreach (var namedArg in attr.NamedArguments)
                     {
@@ -97,11 +98,13 @@ public class TrainableParameterGenerator : IIncrementalGenerator
                             role = $"PersistentTensorRole.{(PersistentTensorRoleEnum)roleVal}";
                         else if (namedArg.Key == "Order" && namedArg.Value.Value is int orderVal)
                             order = orderVal;
+                        else if (namedArg.Key == "Optional" && namedArg.Value.Value is bool optVal)
+                            optional = optVal;
                     }
 
                     paramFields.Add(new ParameterFieldInfo(
                         field.Name, role, order, DeclIndex: 0,
-                        TypeName: field.Type.ToDisplayString()));
+                        TypeName: field.Type.ToDisplayString(), Optional: optional));
                 }
 
                 // Check for gradient fields (convention: {name}Gradient)
@@ -133,8 +136,12 @@ public class TrainableParameterGenerator : IIncrementalGenerator
                 {
                     // Build attribute-discovered roles map for enrichment
                     var attrRoles = new Dictionary<string, string>();
+                    var attrOptional = new Dictionary<string, bool>();
                     foreach (var pf in paramFields)
+                    {
                         attrRoles[pf.Name] = pf.Role;
+                        attrOptional[pf.Name] = pf.Optional;
+                    }
 
                     // Replace paramFields with registration-ordered list
                     paramFields.Clear();
@@ -154,9 +161,11 @@ public class TrainableParameterGenerator : IIncrementalGenerator
                             // Prefer attribute role if available (more specific)
                             var finalRole = attrRoles.TryGetValue(fieldName, out var attrRole)
                                 ? attrRole : role;
+                            var finalOptional = attrOptional.TryGetValue(fieldName, out var optFlag)
+                                && optFlag;
                             paramFields.Add(new ParameterFieldInfo(
                                 matchingField.Name, finalRole, paramFields.Count, DeclIndex: 0,
-                                TypeName: matchingField.Type.ToDisplayString()));
+                                TypeName: matchingField.Type.ToDisplayString(), Optional: finalOptional));
                         }
                     }
                 }
@@ -229,6 +238,7 @@ public class TrainableParameterGenerator : IIncrementalGenerator
         sb.AppendLine("{");
 
         // GetTrainableParameters
+        bool hasOptional = paramFields.Any(p => p.Optional);
         if (paramFields.Count > 0)
         {
             sb.AppendLine("    /// <summary>");
@@ -246,6 +256,14 @@ public class TrainableParameterGenerator : IIncrementalGenerator
             sb.AppendLine("    /// case we return the (still-empty) placeholder tensors — those");
             sb.AppendLine("    /// layers will materialize their real weights on their first Forward()");
             sb.AppendLine("    /// and a subsequent CollectTrainableParameters pass will pick them up.");
+            if (hasOptional)
+            {
+                sb.AppendLine("    /// Optional parameters (lazily-materialized, conditionally-used fields)");
+                sb.AppendLine("    /// are omitted while they remain empty [0,0] placeholders so they are");
+                sb.AppendLine("    /// not exposed as trainable params that can never receive a gradient");
+                sb.AppendLine("    /// update; they re-appear once materialized. SetTrainableParameters is");
+                sb.AppendLine("    /// emitted symmetrically (consumes a slot only for currently-present fields).");
+            }
             sb.AppendLine("    /// </remarks>");
             sb.AppendLine($"    public override System.Collections.Generic.IReadOnlyList<Tensor<{GetTypeParamName(classSymbol)}>> GetTrainableParameters()");
             sb.AppendLine("    {");
@@ -254,7 +272,22 @@ public class TrainableParameterGenerator : IIncrementalGenerator
                 sb.AppendLine("        EnsureSubLayersRegistered();");
             }
             sb.AppendLine("        if (IsShapeResolved) EnsureInitialized();");
-            sb.AppendLine($"        return new Tensor<{GetTypeParamName(classSymbol)}>[] {{ {string.Join(", ", paramFields.Select(f => f.Name))} }};");
+            if (hasOptional)
+            {
+                sb.AppendLine($"        var __params = new System.Collections.Generic.List<Tensor<{GetTypeParamName(classSymbol)}>>({paramFields.Count});");
+                foreach (var f in paramFields)
+                {
+                    if (f.Optional)
+                        sb.AppendLine($"        if ({f.Name}.Length > 0) __params.Add({f.Name});");
+                    else
+                        sb.AppendLine($"        __params.Add({f.Name});");
+                }
+                sb.AppendLine("        return __params;");
+            }
+            else
+            {
+                sb.AppendLine($"        return new Tensor<{GetTypeParamName(classSymbol)}>[] {{ {string.Join(", ", paramFields.Select(f => f.Name))} }};");
+            }
             sb.AppendLine("    }");
             sb.AppendLine();
 
@@ -265,37 +298,25 @@ public class TrainableParameterGenerator : IIncrementalGenerator
             sb.AppendLine("    /// </summary>");
             sb.AppendLine($"    public override void SetTrainableParameters(System.Collections.Generic.IReadOnlyList<Tensor<{GetTypeParamName(classSymbol)}>> parameters)");
             sb.AppendLine("    {");
-            sb.AppendLine($"        if (parameters.Count != {paramFields.Count})");
-            sb.AppendLine($"            throw new System.ArgumentException($\"Expected {paramFields.Count} parameters, got {{parameters.Count}}.\");");
-            for (int i = 0; i < paramFields.Count; i++)
+            // Local helper: emit the assignment of a field from a parameters[idx]
+            // slot, with the sparse-leaf downcast when the field's concrete type
+            // is a Tensor<T> subclass. indexExpr may be a literal index (fixed path)
+            // or a post-increment cursor (optional path).
+            void EmitFieldAssign(ParameterFieldInfo pf, string indexExpr, string idxLabel)
             {
-                var pf = paramFields[i];
-                // For Tensor<T> fields the assignment is direct; for
-                // subclass fields (SparseTensor<T> etc.) we need an
-                // explicit downcast since the API exposes Tensor<T>.
-                // The cast will throw InvalidCastException if the buffer
-                // hands back a tensor whose runtime type doesn't match
-                // the registered field type — which is the right failure
-                // mode (the buffer should preserve the concrete type for
-                // sparse-aware leaves).
                 bool needsCast = pf.TypeName is not null
                     && !(pf.TypeName.StartsWith(TensorTypeName + "<") || pf.TypeName == TensorTypeName);
                 if (needsCast)
                 {
-                    // Generated form (split across two lines for readability):
-                    //   _weights = (parameters[0] ?? throw new ArgumentNullException(...)) as global::SparseTensor<T>
-                    //              ?? throw new ArgumentException("Parameter at index 0 ... is not a SparseTensor<T>", ...);
-                    // Note: the runtime-type message is a plain string (no
-                    // $-interpolation) so we don't have to escape quotes
-                    // inside an interpolation hole.
-                    sb.AppendLine($"        {pf.Name} = (parameters[{i}] ?? throw new System.ArgumentNullException(nameof(parameters), \"Parameter at index {i} is null.\")) as global::{pf.TypeName}");
-                    sb.AppendLine($"            ?? throw new System.ArgumentException(\"Parameter at index {i} is not a {pf.TypeName}. Tape-buffer must preserve sparse leaf types.\", nameof(parameters));");
+                    sb.AppendLine($"        {pf.Name} = (parameters[{indexExpr}] ?? throw new System.ArgumentNullException(nameof(parameters), \"Parameter at index {idxLabel} is null.\")) as global::{pf.TypeName}");
+                    sb.AppendLine($"            ?? throw new System.ArgumentException(\"Parameter at index {idxLabel} is not a {pf.TypeName}. Tape-buffer must preserve sparse leaf types.\", nameof(parameters));");
                 }
                 else
                 {
-                    sb.AppendLine($"        {pf.Name} = parameters[{i}] ?? throw new System.ArgumentNullException(nameof(parameters), \"Parameter at index {i} is null.\");");
+                    sb.AppendLine($"        {pf.Name} = parameters[{indexExpr}] ?? throw new System.ArgumentNullException(nameof(parameters), \"Parameter at index {idxLabel} is null.\");");
                 }
             }
+
             // Re-sync _registeredTensors with the newly assigned field values.
             // We cannot call base.SetTrainableParameters because _registeredTensors
             // may have a different count than paramFields when multiple parameters
@@ -304,15 +325,55 @@ public class TrainableParameterGenerator : IIncrementalGenerator
             // re-register each field so the runtime list matches the generator's
             // field count exactly. The role is read from the [TrainableParameter]
             // attribute at compile time — no hardcoded mapping needed.
-            sb.AppendLine("        ClearRegisteredParameters();");
-            for (int i = 0; i < paramFields.Count; i++)
+            if (hasOptional)
             {
-                // Use AppendTrainableParameter (not RegisterTrainableParameter)
-                // after ClearRegisteredParameters to avoid role-based dedup.
-                // Layers like MultiHeadAttentionLayer have multiple parameters
-                // with the same role (e.g., 4 × Weights) — RegisterTrainableParameter
-                // would collapse them back to 1 via replace-by-role logic.
-                sb.AppendLine($"        AppendTrainableParameter({paramFields[i].Name}, {paramFields[i].Role});");
+                // Count-aware: an optional field consumes a parameter slot (and is
+                // re-registered) only while it is currently a materialized tensor
+                // (Length > 0) — mirroring GetTrainableParameters exactly, so the
+                // get/set round-trip stays consistent. The predicate is evaluated on
+                // the *current* field state before assignment, which matches the
+                // state GetTrainableParameters saw when the caller built the list.
+                sb.AppendLine("        int __i = 0;");
+                sb.AppendLine("        ClearRegisteredParameters();");
+                foreach (var pf in paramFields)
+                {
+                    if (pf.Optional)
+                    {
+                        sb.AppendLine($"        if ({pf.Name}.Length > 0)");
+                        sb.AppendLine("        {");
+                        EmitFieldAssign(pf, "__i", "__i");
+                        sb.AppendLine($"            AppendTrainableParameter({pf.Name}, {pf.Role});");
+                        sb.AppendLine("            __i++;");
+                        sb.AppendLine("        }");
+                    }
+                    else
+                    {
+                        EmitFieldAssign(pf, "__i", "__i");
+                        sb.AppendLine($"        AppendTrainableParameter({pf.Name}, {pf.Role});");
+                        sb.AppendLine("        __i++;");
+                    }
+                }
+                sb.AppendLine("        if (__i != parameters.Count)");
+                sb.AppendLine("            throw new System.ArgumentException($\"Expected {__i} parameters (currently-present trainable tensors), got {parameters.Count}.\", nameof(parameters));");
+            }
+            else
+            {
+                sb.AppendLine($"        if (parameters.Count != {paramFields.Count})");
+                sb.AppendLine($"            throw new System.ArgumentException($\"Expected {paramFields.Count} parameters, got {{parameters.Count}}.\");");
+                for (int i = 0; i < paramFields.Count; i++)
+                {
+                    EmitFieldAssign(paramFields[i], i.ToString(), i.ToString());
+                }
+                sb.AppendLine("        ClearRegisteredParameters();");
+                for (int i = 0; i < paramFields.Count; i++)
+                {
+                    // Use AppendTrainableParameter (not RegisterTrainableParameter)
+                    // after ClearRegisteredParameters to avoid role-based dedup.
+                    // Layers like MultiHeadAttentionLayer have multiple parameters
+                    // with the same role (e.g., 4 × Weights) — RegisterTrainableParameter
+                    // would collapse them back to 1 via replace-by-role logic.
+                    sb.AppendLine($"        AppendTrainableParameter({paramFields[i].Name}, {paramFields[i].Role});");
+                }
             }
             sb.AppendLine("    }");
             sb.AppendLine();
@@ -576,7 +637,7 @@ public class TrainableParameterGenerator : IIncrementalGenerator
     /// (e.g., <c>SparseTensor&lt;T&gt;</c>) the generator emits a downcast
     /// in SetTrainableParameters so the field assignment compiles.
     /// </summary>
-    private record struct ParameterFieldInfo(string Name, string Role, int Order, int DeclIndex = 0, string? TypeName = null);
+    private record struct ParameterFieldInfo(string Name, string Role, int Order, int DeclIndex = 0, string? TypeName = null, bool Optional = false);
     private record struct GradientFieldInfo(string Name, bool IsNullable);
     private record struct SubLayerFieldInfo(string Name, bool IsNullable);
 }

--- a/src/Attributes/TrainableParameterAttribute.cs
+++ b/src/Attributes/TrainableParameterAttribute.cs
@@ -57,4 +57,29 @@ public sealed class TrainableParameterAttribute : Attribute
     /// Defaults to 0 (declaration order).
     /// </summary>
     public int Order { get; set; }
+
+    /// <summary>
+    /// Gets or sets whether this parameter is <i>optional</i>: a conditionally-used,
+    /// lazily-materialized field that stays a zero-length <c>[0,0]</c> placeholder
+    /// until (and unless) the layer actually needs it. Defaults to <c>false</c>.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// When <c>false</c> (the default) the field is always reported by
+    /// <c>GetTrainableParameters()</c>, even while it is an empty placeholder — the
+    /// historical fixed-count behavior every layer relies on.
+    /// </para>
+    /// <para>
+    /// When <c>true</c> the generator omits the field from <c>GetTrainableParameters()</c>
+    /// while it is still an empty placeholder (<c>Length == 0</c>) and re-includes it once
+    /// the layer materializes it. <c>SetTrainableParameters</c> is emitted symmetrically
+    /// (count-aware, consuming a slot only for currently-present fields), so the get/set
+    /// round-trip stays consistent. This prevents an unused placeholder from being exposed
+    /// as a trainable parameter that can never receive a gradient update — e.g. the
+    /// continuous-input projection weights of <c>EmbeddingLayer</c> in token-id mode (#1331).
+    /// Use it only for genuinely optional, last-in-order parameters that the layer may never
+    /// materialize; required parameters must stay non-optional so they appear even pre-init.
+    /// </para>
+    /// </remarks>
+    public bool Optional { get; set; }
 }

--- a/src/FitDetectors/CalibratedProbabilityFitDetector.cs
+++ b/src/FitDetectors/CalibratedProbabilityFitDetector.cs
@@ -270,49 +270,32 @@ public class CalibratedProbabilityFitDetector<T, TInput, TOutput> : FitDetectorB
         }
         else if (predicted.Length != actual.Length)
         {
-            // Truly incompatible shapes — neither length divides the other —
-            // are a pipeline bug, not a research quirk. Surface them as a clear
-            // InvalidOperationException so the developer can fix the upstream
-            // shape mismatch instead of silently shipping empty calibration.
-            // The #1322 lenient-warn-and-empty fallback below remains for
-            // rank-discordant cases where ONE side is a multiple of the other
-            // (per-sample vs stacked-batch).
-            bool oneSideMultipleOfOther =
-                (actual.Length > 0 && predicted.Length % actual.Length == 0)
-                || (predicted.Length > 0 && actual.Length % predicted.Length == 0);
-            if (!oneSideMultipleOfOther)
-            {
-                throw new InvalidOperationException(
-                    "CalibratedProbabilityFitDetector: predicted length (" + predicted.Length + ") and "
-                    + "actual length (" + actual.Length + ") have incompatible shapes — neither divides "
-                    + "the other, so binning cannot align them. Check that the model's Predict output "
-                    + "and the labels share a consistent batch axis.");
-            }
-
-            // Non-multiclass mismatch (e.g. rank-discordant tensors, or
-            // model emits per-sample output while batch labels are stacked
-            // — the inverse of the multiclass case above). Two scenarios
-            // we surface gracefully here so the optimizer's per-iteration
-            // loop doesn't unconditionally throw:
+            // Any mismatch that reaches here cannot be reconciled into the
+            // binary-calibration path: the divisible multiclass case (predicted =
+            // actual × numClasses) was already reduced above, and equal lengths
+            // take the calibration path below. What remains is one of:
             //
             //   1. actual.Length is an integer multiple of predicted.Length
             //      (the inverse-multiclass case from #1322 — model returns
             //      one sample's output but labels carry the full batch).
-            //      Calibration is genuinely undefined here: we have one
-            //      prediction and many ground-truth values, so binning
-            //      cannot align them. Return EMPTY calibration vectors so
-            //      DetermineFitType / CalculateConfidenceLevel see a
-            //      no-data signal rather than a thrown exception.
-            //   2. Anything else (rank-discordant tensors, off-by-one
-            //      shape drift). Same handling — empty calibration —
-            //      with a Trace warning so the developer can find the
-            //      shape-contract issue without losing the training run.
+            //   2. Rank-discordant / off-by-one shape drift where neither
+            //      length divides the other (e.g. predicted [10], actual [13]).
             //
-            // The earlier always-throw behaviour blocked legitimate
-            // research / custom-architecture training under the default
-            // FitDetector setting (#1322). Industry-standard pattern:
-            // lenient default + diagnostic trace + the strict gate only
-            // applies when shape can be reconciled. Closes #1322.
+            // Calibration is genuinely undefined in every one of these cases —
+            // binning cannot align a predicted vector to a differently-sized
+            // label vector regardless of whether the ratio happens to be
+            // integral. Return EMPTY calibration vectors (a no-data signal that
+            // DetermineFitType / CalculateConfidenceLevel route to the explicit
+            // "cannot evaluate" verdict: MaxCalibrationError → Overfit, zero
+            // confidence) plus a Trace warning so the developer can find the
+            // shape-contract issue, rather than throwing.
+            //
+            // The earlier behaviour threw on the rank-discordant sub-case, which
+            // blocked legitimate research / custom-architecture training under
+            // the default FitDetector setting and made the lenient handling
+            // inconsistent with the divisible case. Industry-standard pattern:
+            // lenient default + diagnostic trace, never an unconditional throw
+            // inside the optimizer's per-iteration loop. Closes #1322.
             System.Diagnostics.Trace.WriteLine(
                 $"CalibratedProbabilityFitDetector: predicted length ({predicted.Length}) and actual "
                 + $"length ({actual.Length}) cannot be reconciled. Calibration metrics will be empty "

--- a/src/NeuralNetworks/Layers/EmbeddingLayer.cs
+++ b/src/NeuralNetworks/Layers/EmbeddingLayer.cs
@@ -112,11 +112,14 @@ public partial class EmbeddingLayer<T> : LayerBase<T>, IAuxiliaryLossLayer<T>, I
     /// is materialized on demand — the same pattern <see cref="_embeddingTensor"/>
     /// uses, and the direct analog of PyTorch's <c>nn.LazyLinear</c>
     /// UninitializedParameter (which materializes on first forward and then appears
-    /// in <c>parameters()</c>). Keeping it non-null gives a fixed trainable-parameter
-    /// count so the generated GetTrainableParameters/SetTrainableParameters stay
-    /// consistent; in token-index mode it simply remains the empty placeholder.
+    /// in <c>parameters()</c>). It is marked <c>Optional</c> so the generated
+    /// GetTrainableParameters/SetTrainableParameters omit it while it is still the
+    /// empty placeholder (token-index mode never materializes it) and re-include it
+    /// once continuous-input Forward sizes it. Exposing the empty placeholder as a
+    /// trainable parameter previously made it a permanently "stuck" param that could
+    /// never receive a gradient update on the fused training path (#1331).
     /// </summary>
-    [TrainableParameter(Role = PersistentTensorRole.Weights)]
+    [TrainableParameter(Role = PersistentTensorRole.Weights, Optional = true)]
     private Tensor<T> _projectionWeights;
 
     private Tensor<T>? _projectionWeightsGradient;
@@ -373,10 +376,17 @@ public partial class EmbeddingLayer<T> : LayerBase<T>, IAuxiliaryLossLayer<T>, I
             _embeddingTensor = AllocateLazyWeight([_vocabularySize, _embeddingDimension]);
             InitializeParameters();
             RegisterTrainableParameter(_embeddingTensor, PersistentTensorRole.Embeddings);
-            // Register the (placeholder) projection weights too so the generated
-            // GetTrainableParameters exposes both; re-registered after the lazy
-            // continuous sizing in Forward keeps the runtime list in sync.
-            RegisterTrainableParameter(_projectionWeights, PersistentTensorRole.Weights);
+            // The projection weights are a continuous-input-mode feature: they stay a
+            // [0,0] placeholder for token-id (discrete) embedding and are only
+            // materialized + registered when Forward sees continuous input (see the
+            // RegisterTrainableParameter calls after the TensorAllocator.Rent below).
+            // The field is [TrainableParameter(Optional = true)], so the generated
+            // GetTrainableParameters/SetTrainableParameters already skip it while empty
+            // (#1331). Keep _registeredTensors in sync with that view by only registering
+            // it here once it actually holds weights; otherwise it would surface as a
+            // permanently "stuck" trainable param on the fused training path.
+            if (_projectionWeights.Length > 0)
+                RegisterTrainableParameter(_projectionWeights, PersistentTensorRole.Weights);
             _embeddingInitialized = true;
         }
     }


### PR DESCRIPTION
Fixes two independent master baseline-red tests in the EmbeddingLayer / FitDetector area. Both are surgical, opt-in, and leave all other layers/detectors unchanged.

## #1331 — empty placeholder exposed as a "stuck" trainable param

`Transformer_ByteLM_FusedPath_AllParamsMustMove` trains one step on the fused-compiled path and asserts every trainable parameter moves (`L2(Δ) > 1e-9`). It reported `3 moved, 1 stuck` — the stuck param was `EmbeddingLayer._projectionWeights`, a continuous-input-mode feature that stays a `[0,0]` placeholder in token-id mode. The `TrainableParameterGenerator` exposed it unconditionally, so an empty tensor that can never receive a gradient was counted as a trainable parameter.

**Fix:** add an opt-in `Optional` flag to `[TrainableParameter]`.
- When set, the generator emits a list-based `GetTrainableParameters` that omits the field while it is an empty placeholder (`Length == 0`) and re-includes it once materialized.
- `SetTrainableParameters` is emitted symmetrically (count-aware: consumes a parameter slot only for currently-present fields), so the get/set round-trip stays consistent.
- The `ParameterBuffer` view-swap flow already tolerates a varying trainable-param count (`NeuralNetworkBase.RestoreOriginalParameters` treats a count change as a structural change), so this is safe.
- Non-optional params keep the fixed-count fast path → **no other layer's generated code changes.**

`EmbeddingLayer._projectionWeights` is marked `Optional = true`; its `_registeredTensors` registration is guarded so the runtime list stays in sync.

After: `3 moved, 0 stuck`.

## #1322 — FitDetector threw on rank-discordant shapes

`CalibratedProbabilityFitDetector` threw `InvalidOperationException` when predicted/actual lengths could not be reconciled and neither divided the other (e.g. predicted `[10]`, actual `[13]`), violating the #1322 contract that the detector must never throw inside the optimizer's per-iteration loop. The divisible-mismatch case already returned empty calibration leniently; this aligns the rank-discordant case with it — Trace warning + empty calibration, routing to the explicit "cannot evaluate" verdict (`MaxCalibrationError → Overfit`, zero confidence). The matched-shape calibration path is unchanged.

## Verification

`108/108` pass locally on the master base across the `EmbeddingLayer`, `ParameterBuffer`, `Transformer_ByteLM_FusedPath_AllParamsMustMove`, and `EmbeddingLayerValidatorIssues1321_1322_1323` suites (net10.0, Release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added optional trainable parameter support, allowing fields to be conditionally included in parameter lists based on materialization state

* **Improvements**
  * Enhanced probability calibration detection to gracefully handle incompatible tensor shapes with diagnostic messaging instead of throwing errors
  * Optimized embedding layer parameter registration to only include projection weights when materialized

<!-- end of auto-generated comment: release notes by coderabbit.ai -->