### PR TITLE
chore(deps): bump AiDotNet.Tensors 0.92.1 -> 0.92.5 (closes #1221)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -130,11 +130,19 @@
          Cholesky/Gram zero-alloc copy-buffer dot here could accumulate into stale
          data). 0.92.1 also carries #574 (FP16 ComputeGradients) and #564 (memory-bounded
          gradient-streaming core, merged to master via #1543). AiDotNet.Native packages
-         coreleased in lockstep at 0.92.1. -->
-    <PackageVersion Include="AiDotNet.Tensors" Version="0.92.1" />
-    <PackageVersion Include="AiDotNet.Native.OneDNN" Version="0.92.1" />
-    <PackageVersion Include="AiDotNet.Native.OpenBLAS" Version="0.92.1" />
-    <PackageVersion Include="AiDotNet.Native.CLBlast" Version="0.92.1" />
+         coreleased in lockstep at 0.92.1.
+
+         Bumped 0.92.1 -> 0.92.5 for Tensors #583 (validate the prepacked-B GEMM cache
+         against in-place weight mutation): the SgemmWithCachedB inference path reused a
+         stale pre-packed B panel when a layer's weights were mutated in place without a
+         MarkWeightDirty, so FusedLinear inference returned pre-update results — the root
+         cause of the #1221 transformer production-scale convergence failure. 0.92.5 is
+         the first release carrying that fix. AiDotNet.Native packages coreleased in
+         lockstep at 0.92.5. -->
+    <PackageVersion Include="AiDotNet.Tensors" Version="0.92.5" />
+    <PackageVersion Include="AiDotNet.Native.OneDNN" Version="0.92.5" />
+    <PackageVersion Include="AiDotNet.Native.OpenBLAS" Version="0.92.5" />
+    <PackageVersion Include="AiDotNet.Native.CLBlast" Version="0.92.5" />
     <!-- Microsoft / .NET -->
     <PackageVersion Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageVersion Include="Microsoft.Data.Sqlite" Version="10.0.8" />


### PR DESCRIPTION
Bumps `AiDotNet.Tensors` (and the lockstep `AiDotNet.Native.OneDNN/OpenBLAS/CLBlast`) from **0.92.1 → 0.92.5**.

## Why

0.92.5 is the first release carrying **Tensors #583** — *validate the prepacked-B GEMM cache against in-place weight mutation*. The `SgemmWithCachedB` inference path reused a stale pre-packed B panel when a layer's weights were mutated in place without a `MarkWeightDirty`, so `FusedLinear` inference returned pre-update results. That was the **root cause of #1221** (transformer production-scale convergence failure).

## Verification

- `dotnet restore` clean against 0.92.5 (no NU1102); all four lockstep packages confirmed published at 0.92.5.
- Build clean (net10.0, Release).
- **`Issue1221` suite: 11/11 pass** (`TransformerProductionScaleConvergenceIssue1221Tests` + `TransformerProductionScaleHarnessIssue1221Tests`).

Closes #1221.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package dependencies to latest compatible versions for improved stability and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->