### PR TITLE
fix(physics): HamiltonianNeuralNetwork parameterless ctor input-size mismatch

### DIFF
--- a/src/PhysicsInformed/ScientificML/HamiltonianNeuralNetwork.cs
+++ b/src/PhysicsInformed/ScientificML/HamiltonianNeuralNetwork.cs
@@ -103,7 +103,14 @@ namespace AiDotNet.PhysicsInformed.ScientificML
         : this(new NeuralNetworkArchitecture<T>(
             inputType: Enums.InputType.OneDimensional,
             taskType: Enums.NeuralNetworkTaskType.Regression,
-            inputSize: DefaultStateDim * 2,
+            // The network input IS the full phase-space state vector (q, p), so
+            // its size must equal stateDim — the ctor enforces
+            // CalculatedInputSize == stateDim. The previous `DefaultStateDim * 2`
+            // made the input 4 while stateDim stayed 2, so the parameterless ctor
+            // always threw "input size (4) must match state dimension (2)".
+            // DefaultStateDim = 2 is the canonical 1-DOF Hamiltonian phase space
+            // (one position q + one momentum p).
+            inputSize: DefaultStateDim,
             outputSize: 1),
             stateDim: DefaultStateDim)
     {


### PR DESCRIPTION
## Summary

Fixes the bulk of the **Generated Layers A-M** shard from the PR #1563 failing-CI list — all **21** `HamiltonianNeuralNetworkTests` (in my hand-off lane from #1562; does not touch any files #1562 owns).

**Root cause:** the parameterless constructor built its architecture with `inputSize = DefaultStateDim * 2` (= 4) but passed `stateDim = DefaultStateDim` (= 2). The constructor enforces `CalculatedInputSize == stateDim` — the network input *is* the full phase-space state vector (q, p), which the model splits into q/p halves — so every `new HamiltonianNeuralNetwork<T>()` threw:

```
System.ArgumentException : Hamiltonian network input size (4) must match state dimension (2).
```

The source-generated ModelFamily test scaffold instantiates the model via the parameterless ctor, so this throw failed **all 21** test methods (Architecture / Clone / ForwardPass / Training / Metadata / Parameters / …).

**Fix:** set `inputSize = DefaultStateDim` so the input size matches `stateDim`. `DefaultStateDim = 2` is the canonical 1-DOF Hamiltonian phase space (one position q + one momentum p).

## Verification

All **21** `HamiltonianNeuralNetworkTests` pass locally (`net10.0`, Release).

## Scope

`BSVD` (×3) and `MCSLAlgorithm` (×1) — the remaining failures in the Gen Layers A-M shard — are unrelated and will be addressed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)