### PR TITLE
fix(continual-learning): declare IParameterizable on EWC/SI test mock model

### DIFF
--- a/tests/AiDotNet.Tests/IntegrationTests/ContinualLearning/ContinualLearningDeepMathIntegrationTests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/ContinualLearning/ContinualLearningDeepMathIntegrationTests.cs
@@ -855,7 +855,15 @@ public class ContinualLearningDeepMathIntegrationTests
     /// <summary>
     /// Mock model for continual learning tests.
     /// </summary>
-    private class CLMockModel : IFullModel<double, Tensor<double>, Tensor<double>>
+    // Implements IParameterizable explicitly: the interface-segregation refactor
+    // moved GetParameters/SetParameters/ParameterCount/WithParameters off IFullModel
+    // and onto IParameterizable, and EWC/SI guard-require it via
+    // InterfaceGuard.Parameterizable (EWC's Fisher matrix and SI's importance are
+    // computed OVER the model's parameters). The mock already implements every
+    // IParameterizable member below; it just needs to declare the interface so the
+    // runtime `model is IParameterizable<...>` check succeeds.
+    private class CLMockModel : IFullModel<double, Tensor<double>, Tensor<double>>,
+        IParameterizable<double, Tensor<double>, Tensor<double>>
     {
         private Vector<double> _parameters;
         private List<int> _activeFeatures;


### PR DESCRIPTION
## Summary

Fixes the continual-learning cluster in the **Integration C** shard from the PR #1563 failing-CI list — 14 `ElasticWeightConsolidation` / `SynapticIntelligence` deep-math integration tests (in my hand-off lane from #1562; does not touch any files #1562 owns).

**Root cause (one shared bug):** the interface-segregation refactor moved `GetParameters` / `SetParameters` / `ParameterCount` / `WithParameters` off `IFullModel` onto the separate `IParameterizable` interface. EWC and SI guard-require it via `InterfaceGuard.Parameterizable` — **correctly**, since EWC's Fisher information matrix and SI's per-parameter importance are both computed *over the model's parameters*, so a model with no trainable parameters cannot participate. The `CLMockModel` test fixture still declared only `IFullModel`, so the runtime `model is IParameterizable<...>` check failed:

```
System.InvalidOperationException : CLMockModel does not implement IParameterizable<Double, Tensor, Tensor>.
This operation requires a model with trainable parameters.
   at AiDotNet.ContinualLearning.Strategies.SynapticIntelligence.PrepareForTask(...)
```

**Fix:** declare `IParameterizable<double, Tensor<double>, Tensor<double>>` on `CLMockModel`. The mock **already implements every member** of that interface (`GetParameters`, `SetParameters`, `ParameterCount`, `SupportsParameterInitialization`, `WithParameters`, `SanitizeParameters`) — it just needed to declare it so the cast succeeds.

This is a fixture completing an interface it already implements. **No production code is changed, and no assertion or expected value is weakened** — the production requirement (EWC/SI need `IParameterizable`) is correct and stays.

## Verification

All **36** `ContinualLearningDeepMathIntegrationTests` pass locally (`net10.0`, Release) — the 14 previously-failing EWC/SI tests plus the 22 that already passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)