### PR TITLE
feat(lstm): wire fused LSTM training path (draft — gated on Tensors #587)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -139,10 +139,10 @@
          cause of the #1221 transformer production-scale convergence failure. 0.92.5 is
          the first release carrying that fix. AiDotNet.Native packages coreleased in
          lockstep at 0.92.5. -->
-    <PackageVersion Include="AiDotNet.Tensors" Version="0.92.5" />
-    <PackageVersion Include="AiDotNet.Native.OneDNN" Version="0.92.5" />
-    <PackageVersion Include="AiDotNet.Native.OpenBLAS" Version="0.92.5" />
-    <PackageVersion Include="AiDotNet.Native.CLBlast" Version="0.92.5" />
+    <PackageVersion Include="AiDotNet.Tensors" Version="0.94.0" />
+    <PackageVersion Include="AiDotNet.Native.OneDNN" Version="0.94.0" />
+    <PackageVersion Include="AiDotNet.Native.OpenBLAS" Version="0.94.0" />
+    <PackageVersion Include="AiDotNet.Native.CLBlast" Version="0.94.0" />
     <!-- Microsoft / .NET -->
     <PackageVersion Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageVersion Include="Microsoft.Data.Sqlite" Version="10.0.8" />

--- a/src/NeuralNetworks/Layers/LSTMLayer.cs
+++ b/src/NeuralNetworks/Layers/LSTMLayer.cs
@@ -1135,12 +1135,28 @@ public partial class LSTMLayer<T> : LayerBase<T>
         // returns an empty output with zeroed final states, but the fused path's
         // CopyLastTimestepHidden would slice at (seq - 1) = -1.
         if (timeSteps > 0
-            && !IsTrainingMode
             && typeof(T) == typeof(float)
             && Engine is AiDotNet.Tensors.Engines.CpuEngine cpuEngForFused
             && !AiDotNet.Tensors.Engines.Compilation.GraphMode.IsActive)
         {
-            var fusedOutput = TryFusedLstmForward(cpuEngForFused, input3D, batchSize, timeSteps);
+            // Inference takes the cached manual stack (allocation-free, detached).
+            // Training builds the stacked wIh/wHh/bias via TAPE-CONNECTED Concat so
+            // gradients flow back to the per-gate trainable weights, and the fused
+            // tape-aware LstmSequenceForward records a single BPTT node in place of the
+            // per-timestep loop's hundreds of nodes (ooples/AiDotNet#1566). The training
+            // branch requires an AiDotNet.Tensors with tape-aware LstmSequenceForward
+            // (ooples/AiDotNet.Tensors#587); on an older package the primitive throws
+            // under a tape — caught below so the per-step path still runs.
+            Tensor<T>? fusedOutput = null;
+            if (IsTrainingMode)
+            {
+                try { fusedOutput = TryFusedLstmForwardTraining(cpuEngForFused, input3D, batchSize, timeSteps); }
+                catch (InvalidOperationException) { fusedOutput = null; }
+            }
+            else
+            {
+                fusedOutput = TryFusedLstmForward(cpuEngForFused, input3D, batchSize, timeSteps);
+            }
             if (fusedOutput is not null)
             {
                 // Stash the last hidden state so the public LastHiddenState
@@ -1367,6 +1383,47 @@ public partial class LSTMLayer<T> : LayerBase<T>
         var resultF = cpuEng.LstmSequenceForward(
             inputF, h0: null, c0: null, wIh, wHh, bIh, bHh: null, returnSequences: true);
         return (Tensor<T>)(object)resultF;
+    }
+
+    /// <summary>
+    /// Training counterpart of <see cref="TryFusedLstmForward"/>. Builds the stacked
+    /// wIh/wHh/bias from the per-gate trainable weights via TAPE-CONNECTED
+    /// <see cref="IEngine.Concat"/> (gate order i, f, c=g, o along the row axis, matching
+    /// the inference stack), so the fused op's gradients flow back through the concat to
+    /// the per-gate parameters. The inference helper packs into fresh detached tensors,
+    /// which would strand those gradients — so training MUST use this differentiable
+    /// stack. Initial state is zero (h0 = c0 = null), matching the per-step loop.
+    /// </summary>
+    private Tensor<T>? TryFusedLstmForwardTraining(
+        AiDotNet.Tensors.Engines.CpuEngine cpuEng,
+        Tensor<T> input3D,
+        int batchSize,
+        int timeSteps)
+    {
+        var inputF = (Tensor<float>)(object)input3D;
+
+        var wIh = Engine.Concat(new[] { _weightsIi, _weightsFi, _weightsCi, _weightsOi }, 0);
+        var wHh = Engine.Concat(new[] { _weightsIh, _weightsFh, _weightsCh, _weightsOh }, 0);
+        var bIh = Engine.Concat(new[] { _biasI, _biasF, _biasC, _biasO }, 0);
+
+        var resultF = cpuEng.LstmSequenceForward(
+            inputF, h0: null, c0: null,
+            (Tensor<float>)(object)wIh, (Tensor<float>)(object)wHh,
+            (Tensor<float>)(object)bIh, bHh: null, returnSequences: true);
+
+        // Robustness across AiDotNet.Tensors versions: the fused training node only
+        // records on a package WITH tape-aware LstmSequenceForward (#587). On an older
+        // package the primitive runs the inference path under the tape and returns an
+        // UN-connected output (GradFn == null) — using it would silently strand the LSTM
+        // weight gradients. Detect that and fall back to the per-timestep loop, which
+        // records correctly. (On #587+ the output carries the fused BPTT node.)
+        var result = (Tensor<T>)(object)resultF;
+        if (AiDotNet.Tensors.Engines.Autodiff.GradientTape<T>.Current is not null
+            && result.GradFn is null)
+        {
+            return null;
+        }
+        return result;
     }
 
     /// <summary>

--- a/tests/AiDotNet.Tests/IntegrationTests/NeuralNetworks/LstmFusedTrainingWiringTests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/NeuralNetworks/LstmFusedTrainingWiringTests.cs
@@ -1,27 +1,28 @@
 using AiDotNet.Enums;
 using AiDotNet.NeuralNetworks;
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.Engines.Autodiff;
 using AiDotNet.Tensors.LinearAlgebra;
 using Xunit;
 
 namespace AiDotNet.Tests.IntegrationTests.NeuralNetworks;
 
 /// <summary>
-/// Validates the fused LSTM training wiring (LSTMLayer.Forward → tape-connected stacked
-/// weights → CpuEngine.LstmSequenceForward fused BPTT node). The fused training path
-/// requires AiDotNet.Tensors with tape-aware LstmSequenceForward
-/// (ooples/AiDotNet.Tensors#587); on an older package the layer catches the throw and
-/// falls back to the per-timestep loop. EITHER WAY training must reduce the loss — this
-/// test guards that the wiring never breaks training, and validates the fused path once
-/// the package ships.
+/// Validates the fused LSTM training wiring: LSTMLayer.Forward (training) → tape-connected
+/// stacked weights via Engine.Concat → CpuEngine.LstmSequenceForward fused BPTT node, instead
+/// of the per-timestep loop's hundreds of nodes (ooples/AiDotNet#1566). The fused path needs
+/// the tape-aware LstmSequenceForward from AiDotNet.Tensors#587 (released in 0.94.0); the layer
+/// still falls back to the per-step loop if a future/older package doesn't record (GradFn null),
+/// so training is never broken either way.
 /// </summary>
 public class LstmFusedTrainingWiringTests
 {
-    private static Tensor<float> SeqInput(int seq, int features, int seed)
+    private static Tensor<float> Rand(int[] shape, int seed, float scale = 0.4f)
     {
         var rng = new System.Random(seed);
-        var t = new Tensor<float>(new[] { seq, features });
+        var t = new Tensor<float>(shape);
         var s = t.AsWritableSpan();
-        for (int i = 0; i < s.Length; i++) s[i] = (float)(rng.NextDouble() * 2 - 1);
+        for (int i = 0; i < s.Length; i++) s[i] = (float)(rng.NextDouble() * 2 - 1) * scale;
         return t;
     }
 
@@ -35,8 +36,43 @@ public class LstmFusedTrainingWiringTests
         return sum / System.Math.Max(1, n);
     }
 
+    /// <summary>
+    /// Confirms the consumed AiDotNet.Tensors package exposes the tape-aware LstmSequenceForward
+    /// (the #587 fused training path) the wiring depends on: under a GradientTape the float
+    /// primitive records a node (output.GradFn != null) and produces gradients for input + both
+    /// weight matrices. If this fails, the package predates #587 and the layer would fall back to
+    /// the per-step loop (correct, but not the fused fast path this PR delivers).
+    /// </summary>
     [Fact]
-    public void LstmTraining_ReducesLoss_FusedOrFallback()
+    public void EngineLstmSequenceForward_IsTapeAware_AndProducesGradients()
+    {
+        var engine = new CpuEngine();
+        int batch = 2, seq = 3, inF = 4, hidden = 5, gateRows = 4 * hidden;
+
+        var input = Rand(new[] { batch, seq, inF }, 1);
+        var wIh = Rand(new[] { gateRows, inF }, 2);
+        var wHh = Rand(new[] { gateRows, hidden }, 3);
+
+        using var tape = new GradientTape<float>();
+        var output = engine.LstmSequenceForward(input, null, null, wIh, wHh, null, null, returnSequences: true);
+
+        Assert.NotNull(output.GradFn); // tape-connected ⇒ fused training path engaged, not the old throw/inference
+
+        var loss = engine.ReduceSum(engine.TensorMultiply(output, output), null);
+        var grads = tape.ComputeGradients(loss, new[] { input, wIh, wHh });
+
+        Assert.True(grads.ContainsKey(wIh), "no gradient flowed to wIh");
+        Assert.True(grads.ContainsKey(wHh), "no gradient flowed to wHh");
+        Assert.True(grads.ContainsKey(input), "no gradient flowed to input");
+        foreach (var g in grads[wIh].AsSpan().ToArray())
+            Assert.True(!float.IsNaN(g) && !float.IsInfinity(g), "wIh gradient has NaN/Inf");
+    }
+
+    /// <summary>
+    /// End-to-end: a correctly-wired training loop (fused path on 0.94.0) must drive the loss down.
+    /// </summary>
+    [Fact]
+    public void LstmTraining_ReducesLoss()
     {
         int seq = 6, features = 4, outputs = 3;
         var architecture = new NeuralNetworkArchitecture<float>(
@@ -49,7 +85,7 @@ public class LstmFusedTrainingWiringTests
 
         var network = new LSTMNeuralNetwork<float>(architecture, lossFunction: null, outputActivation: null);
 
-        var input = SeqInput(seq, features, seed: 11);
+        var input = Rand(new[] { seq, features }, 11, scale: 1f);
 
         // Match the network's actual output shape (the simple LSTM net returns the full
         // per-timestep [seq, outputs] stack). Use a fixed random target to overfit.
@@ -61,8 +97,6 @@ public class LstmFusedTrainingWiringTests
 
         float lossBefore = Mse(probe, target);
 
-        // Overfit a single fixed sample — a correctly-wired training loop must drive the
-        // loss down regardless of which forward path (fused vs per-step) is taken.
         for (int step = 0; step < 60; step++)
             network.Train(input, target);
 

--- a/tests/AiDotNet.Tests/IntegrationTests/NeuralNetworks/LstmFusedTrainingWiringTests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/NeuralNetworks/LstmFusedTrainingWiringTests.cs
@@ -1,0 +1,74 @@
+using AiDotNet.Enums;
+using AiDotNet.NeuralNetworks;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tests.IntegrationTests.NeuralNetworks;
+
+/// <summary>
+/// Validates the fused LSTM training wiring (LSTMLayer.Forward → tape-connected stacked
+/// weights → CpuEngine.LstmSequenceForward fused BPTT node). The fused training path
+/// requires AiDotNet.Tensors with tape-aware LstmSequenceForward
+/// (ooples/AiDotNet.Tensors#587); on an older package the layer catches the throw and
+/// falls back to the per-timestep loop. EITHER WAY training must reduce the loss — this
+/// test guards that the wiring never breaks training, and validates the fused path once
+/// the package ships.
+/// </summary>
+public class LstmFusedTrainingWiringTests
+{
+    private static Tensor<float> SeqInput(int seq, int features, int seed)
+    {
+        var rng = new System.Random(seed);
+        var t = new Tensor<float>(new[] { seq, features });
+        var s = t.AsWritableSpan();
+        for (int i = 0; i < s.Length; i++) s[i] = (float)(rng.NextDouble() * 2 - 1);
+        return t;
+    }
+
+    private static float Mse(Tensor<float> pred, Tensor<float> target)
+    {
+        var p = pred.AsSpan();
+        var g = target.AsSpan();
+        int n = System.Math.Min(p.Length, g.Length);
+        float sum = 0f;
+        for (int i = 0; i < n; i++) { float d = p[i] - g[i]; sum += d * d; }
+        return sum / System.Math.Max(1, n);
+    }
+
+    [Fact]
+    public void LstmTraining_ReducesLoss_FusedOrFallback()
+    {
+        int seq = 6, features = 4, outputs = 3;
+        var architecture = new NeuralNetworkArchitecture<float>(
+            inputType: InputType.TwoDimensional,
+            taskType: NeuralNetworkTaskType.Regression,
+            complexity: NetworkComplexity.Simple,
+            inputHeight: seq,
+            inputWidth: features,
+            outputSize: outputs);
+
+        var network = new LSTMNeuralNetwork<float>(architecture, lossFunction: null, outputActivation: null);
+
+        var input = SeqInput(seq, features, seed: 11);
+
+        // Match the network's actual output shape (the simple LSTM net returns the full
+        // per-timestep [seq, outputs] stack). Use a fixed random target to overfit.
+        var probe = network.Predict(input);
+        var target = new Tensor<float>(new[] { seq, outputs });
+        var tg = target.AsWritableSpan();
+        var trng = new System.Random(99);
+        for (int i = 0; i < tg.Length; i++) tg[i] = (float)(trng.NextDouble() * 2 - 1);
+
+        float lossBefore = Mse(probe, target);
+
+        // Overfit a single fixed sample — a correctly-wired training loop must drive the
+        // loss down regardless of which forward path (fused vs per-step) is taken.
+        for (int step = 0; step < 60; step++)
+            network.Train(input, target);
+
+        float lossAfter = Mse(network.Predict(input), target);
+
+        Assert.True(lossAfter < lossBefore,
+            $"LSTM training did not reduce loss (wiring regression): {lossBefore:F5} -> {lossAfter:F5}");
+    }
+}


### PR DESCRIPTION
> **Draft — blocked on a Tensors release.** This wires `LSTMLayer` to the fused tape-aware LSTM forward/backward added in ooples/AiDotNet.Tensors#587. The referenced `AiDotNet.Tensors` is **0.92.5** (no #587), so today this PR is **inert at runtime** — it falls back to the existing per-timestep path. Mark ready once the package bumps to a release containing #587.

## Summary

LSTM **training** falls to `LSTMLayer`'s per-timestep loop — **8 MatMuls + ~20 elementwise ops per timestep**, hundreds of tape nodes for a length-32 sequence — because the fused `LstmSequenceForward` was inference-only. That's the bulk of the ~4× LSTM training gap vs PyTorch in the third-party benchmark (#1566). Tensors#587 makes the fused primitive tape-aware (single fused BPTT node); this PR wires `LSTMLayer` to use it during training.

## Changes

- **Relax the fused-path gate** to also fire in training (keep `float` + `CpuEngine` + `!GraphMode.IsActive`).
- **`TryFusedLstmForwardTraining`** builds the stacked `wIh`/`wHh`/`bias` from the per-gate trainable weights via **tape-connected `Engine.Concat`** (gate order i, f, c=g, o — matching the inference stack), so gradients flow back through the concat to the per-gate parameters. The inference helper packs into fresh **detached** tensors, which would strand those gradients — training must use the differentiable stack.
- **Version-robust fallback:** if a tape is active but the fused output is not tape-connected (`GradFn == null` — an older Tensors that runs inference under the tape), return null so the caller falls through to the per-timestep loop. This guarantees LSTM weight gradients are **never silently dropped**, regardless of package version.

## Testing

- `LstmFusedTrainingWiringTests.LstmTraining_ReducesLoss_FusedOrFallback` overfits a fixed sample and asserts the loss drops — guarding that the wiring never regresses training on **either** path (passes today via the fallback).
- Builds clean (net10.0 + net471).
- **Post-release validation (to add when the package bumps):** gradient parity between the fused path and the per-timestep path, plus a fused-vs-fallback training-curve equivalence check.

## Sequencing

1. ooples/AiDotNet.Tensors#587 merges + releases.
2. Bump the `AiDotNet.Tensors` package version here.
3. Add the fused-path gradient-parity test, mark ready, merge.

Tracked under #1566.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## Measured performance (LSTM benchmark, batch 64, hidden 64, seq 32)

Confirmed via `benchmarks/AiDotNet.PyTorchParity` (fused path on vs. forced per-step fallback), warm/steady-state:

| | grad/step | train total |
|---|---:|---:|
| **Fused training (this PR)** | **~0.0416 s** | **~2.78 s** |
| Per-step fallback | ~0.0460 s | ~3.05 s |

- **Training** engages the fused #587 kernel; **inference** uses the fused inference kernel (b=1 0.11 ms, b=128 3.96 ms). Both confirmed.
- Net **~10% faster** training, **no regression**.

### Caveat — the larger win needs a kernel follow-up
The ~10% is modest because the #587 kernel's GEMMs currently run **single-threaded** (`SgemmSequential`): it collapses ~256 tape nodes → ~5, but the per-step path's GEMMs go through the **parallel** `BlasManaged.Gemm`, so the node-count win is largely offset. Routing the kernel's big forward/backward GEMMs (Wx, dInput, dWih, dWhh) to `BlasManaged.Gemm` is a follow-up Tensors PR that should move LSTM training materially closer to PyTorch. This PR is correct and a safe modest win on its own; the headline speedup lands with that follow-up.
