### PR TITLE
fix(licensing): building a model must not require a persistence license

### DIFF
--- a/src/ComputerVision/Segmentation/Diffusion/DiffCutSegmentation.cs
+++ b/src/ComputerVision/Segmentation/Diffusion/DiffCutSegmentation.cs
@@ -309,7 +309,7 @@ public class DiffCutSegmentation<T> : NeuralNetworkBase<T>, ISemanticSegmentatio
     public override ModelMetadata<T> GetModelMetadata() => new()
     {
         AdditionalInfo = new Dictionary<string, object> { { "ModelName", "DiffCutSegmentation" }, { "InputHeight", _height }, { "InputWidth", _width }, { "NumClasses", _numClasses }, { "UseNativeMode", _useNativeMode }, { "NumLayers", Layers.Count } },
-        ModelData = this.Serialize()
+        ModelData = SerializeForMetadata()
     };
 
     /// <summary>

--- a/src/ComputerVision/Segmentation/Diffusion/MedSegDiffV2Segmentation.cs
+++ b/src/ComputerVision/Segmentation/Diffusion/MedSegDiffV2Segmentation.cs
@@ -311,7 +311,7 @@ public class MedSegDiffV2Segmentation<T> : NeuralNetworkBase<T>, IMedicalSegment
     public override ModelMetadata<T> GetModelMetadata() => new()
     {
         AdditionalInfo = new Dictionary<string, object> { { "ModelName", "MedSegDiffV2Segmentation" }, { "InputHeight", _height }, { "InputWidth", _width }, { "NumClasses", _numClasses }, { "UseNativeMode", _useNativeMode }, { "NumLayers", Layers.Count } },
-        ModelData = this.Serialize()
+        ModelData = SerializeForMetadata()
     };
 
     /// <summary>

--- a/src/ComputerVision/Segmentation/Diffusion/ODISESegmentation.cs
+++ b/src/ComputerVision/Segmentation/Diffusion/ODISESegmentation.cs
@@ -309,7 +309,7 @@ public class ODISESegmentation<T> : NeuralNetworkBase<T>, IPanopticSegmentation<
     public override ModelMetadata<T> GetModelMetadata() => new()
     {
         AdditionalInfo = new Dictionary<string, object> { { "ModelName", "ODISESegmentation" }, { "SegmentationType", "Panoptic" }, { "InputHeight", _height }, { "InputWidth", _width }, { "NumClasses", _numClasses }, { "UseNativeMode", _useNativeMode }, { "NumLayers", Layers.Count } },
-        ModelData = this.Serialize()
+        ModelData = SerializeForMetadata()
     };
 
     /// <summary>

--- a/src/ComputerVision/Segmentation/Efficient/EdgeSAM.cs
+++ b/src/ComputerVision/Segmentation/Efficient/EdgeSAM.cs
@@ -284,7 +284,7 @@ public class EdgeSAM<T> : NeuralNetworkBase<T>, IPromptableSegmentation<T>
     public override ModelMetadata<T> GetModelMetadata() => new()
     {
         AdditionalInfo = new Dictionary<string, object> { { "ModelName", "EdgeSAM" }, { "InputHeight", _height }, { "InputWidth", _width }, { "NumClasses", _numClasses }, { "UseNativeMode", _useNativeMode }, { "NumLayers", Layers.Count } },
-        ModelData = this.Serialize()
+        ModelData = SerializeForMetadata()
     };
 
     /// <summary>

--- a/src/ComputerVision/Segmentation/Efficient/EfficientSAM.cs
+++ b/src/ComputerVision/Segmentation/Efficient/EfficientSAM.cs
@@ -289,7 +289,7 @@ public class EfficientSAM<T> : NeuralNetworkBase<T>, IPromptableSegmentation<T>
     public override ModelMetadata<T> GetModelMetadata() => new()
     {
         AdditionalInfo = new Dictionary<string, object> { { "ModelName", "EfficientSAM" }, { "InputHeight", _height }, { "InputWidth", _width }, { "NumClasses", _numClasses }, { "UseNativeMode", _useNativeMode }, { "NumLayers", Layers.Count } },
-        ModelData = this.Serialize()
+        ModelData = SerializeForMetadata()
     };
 
     /// <summary>

--- a/src/ComputerVision/Segmentation/Efficient/FastSAM.cs
+++ b/src/ComputerVision/Segmentation/Efficient/FastSAM.cs
@@ -298,7 +298,7 @@ public class FastSAM<T> : NeuralNetworkBase<T>, IPromptableSegmentation<T>
     public override ModelMetadata<T> GetModelMetadata() => new()
     {
         AdditionalInfo = new Dictionary<string, object> { { "ModelName", "FastSAM" }, { "InputHeight", _height }, { "InputWidth", _width }, { "NumClasses", _numClasses }, { "UseNativeMode", _useNativeMode }, { "NumLayers", Layers.Count } },
-        ModelData = this.Serialize()
+        ModelData = SerializeForMetadata()
     };
 
     /// <summary>

--- a/src/ComputerVision/Segmentation/Efficient/MobileSAM.cs
+++ b/src/ComputerVision/Segmentation/Efficient/MobileSAM.cs
@@ -281,7 +281,7 @@ public class MobileSAM<T> : NeuralNetworkBase<T>, IPromptableSegmentation<T>
     public override ModelMetadata<T> GetModelMetadata() => new()
     {
         AdditionalInfo = new Dictionary<string, object> { { "ModelName", "MobileSAM" }, { "InputHeight", _height }, { "InputWidth", _width }, { "NumClasses", _numClasses }, { "UseNativeMode", _useNativeMode }, { "NumLayers", Layers.Count } },
-        ModelData = this.Serialize()
+        ModelData = SerializeForMetadata()
     };
 
     /// <summary>

--- a/src/ComputerVision/Segmentation/Efficient/PIDNet.cs
+++ b/src/ComputerVision/Segmentation/Efficient/PIDNet.cs
@@ -318,7 +318,7 @@ public class PIDNet<T> : NeuralNetworkBase<T>, ISemanticSegmentation<T>
     public override ModelMetadata<T> GetModelMetadata() => new()
     {
         AdditionalInfo = new Dictionary<string, object> { { "ModelName", "PIDNet" }, { "InputHeight", _height }, { "InputWidth", _width }, { "NumClasses", _numClasses }, { "ModelSize", _modelSize.ToString() }, { "UseNativeMode", _useNativeMode }, { "NumLayers", Layers.Count } },
-        ModelData = this.Serialize()
+        ModelData = SerializeForMetadata()
     };
 
     /// <summary>

--- a/src/ComputerVision/Segmentation/Efficient/RepViTSAM.cs
+++ b/src/ComputerVision/Segmentation/Efficient/RepViTSAM.cs
@@ -281,7 +281,7 @@ public class RepViTSAM<T> : NeuralNetworkBase<T>, IPromptableSegmentation<T>
     public override ModelMetadata<T> GetModelMetadata() => new()
     {
         AdditionalInfo = new Dictionary<string, object> { { "ModelName", "RepViTSAM" }, { "InputHeight", _height }, { "InputWidth", _width }, { "NumClasses", _numClasses }, { "UseNativeMode", _useNativeMode }, { "NumLayers", Layers.Count } },
-        ModelData = this.Serialize()
+        ModelData = SerializeForMetadata()
     };
 
     /// <summary>

--- a/src/ComputerVision/Segmentation/Efficient/SlimSAM.cs
+++ b/src/ComputerVision/Segmentation/Efficient/SlimSAM.cs
@@ -291,7 +291,7 @@ public class SlimSAM<T> : NeuralNetworkBase<T>, IPromptableSegmentation<T>
     public override ModelMetadata<T> GetModelMetadata() => new()
     {
         AdditionalInfo = new Dictionary<string, object> { { "ModelName", "SlimSAM" }, { "InputHeight", _height }, { "InputWidth", _width }, { "NumClasses", _numClasses }, { "UseNativeMode", _useNativeMode }, { "NumLayers", Layers.Count } },
-        ModelData = this.Serialize()
+        ModelData = SerializeForMetadata()
     };
 
     /// <summary>

--- a/src/ComputerVision/Segmentation/Foundation/EoMT.cs
+++ b/src/ComputerVision/Segmentation/Foundation/EoMT.cs
@@ -421,7 +421,7 @@ public class EoMT<T> : NeuralNetworkBase<T>, IPanopticSegmentation<T>
                 { "EmbedDim", _embedDim }, { "DecoderDim", _decoderDim },
                 { "UseNativeMode", _useNativeMode }, { "NumLayers", Layers.Count }
             },
-            ModelData = this.Serialize()
+            ModelData = SerializeForMetadata()
         };
     }
 

--- a/src/ComputerVision/Segmentation/Foundation/Mask2Former.cs
+++ b/src/ComputerVision/Segmentation/Foundation/Mask2Former.cs
@@ -452,7 +452,7 @@ public class Mask2Former<T> : NeuralNetworkBase<T>, IPanopticSegmentation<T>
                 { "ModelSize", _modelSize.ToString() }, { "DecoderDim", _decoderDim },
                 { "DropRate", _dropRate }, { "UseNativeMode", _useNativeMode }, { "NumLayers", Layers.Count }
             },
-            ModelData = this.Serialize()
+            ModelData = SerializeForMetadata()
         };
     }
 

--- a/src/ComputerVision/Segmentation/Foundation/MaskDINO.cs
+++ b/src/ComputerVision/Segmentation/Foundation/MaskDINO.cs
@@ -421,7 +421,7 @@ public class MaskDINO<T> : NeuralNetworkBase<T>, IPanopticSegmentation<T>
                 { "DecoderDim", _decoderDim }, { "UseNativeMode", _useNativeMode },
                 { "NumLayers", Layers.Count }
             },
-            ModelData = this.Serialize()
+            ModelData = SerializeForMetadata()
         };
     }
 

--- a/src/ComputerVision/Segmentation/Foundation/OMGSeg.cs
+++ b/src/ComputerVision/Segmentation/Foundation/OMGSeg.cs
@@ -418,7 +418,7 @@ public class OMGSeg<T> : NeuralNetworkBase<T>, IPanopticSegmentation<T>
                 { "DecoderDim", _decoderDim }, { "UseNativeMode", _useNativeMode },
                 { "NumLayers", Layers.Count }
             },
-            ModelData = this.Serialize()
+            ModelData = SerializeForMetadata()
         };
     }
 

--- a/src/ComputerVision/Segmentation/Foundation/OneFormer.cs
+++ b/src/ComputerVision/Segmentation/Foundation/OneFormer.cs
@@ -413,7 +413,7 @@ public class OneFormer<T> : NeuralNetworkBase<T>, IPanopticSegmentation<T>
                 { "ModelSize", _modelSize.ToString() }, { "DecoderDim", _decoderDim },
                 { "DropRate", _dropRate }, { "UseNativeMode", _useNativeMode }, { "NumLayers", Layers.Count }
             },
-            ModelData = this.Serialize()
+            ModelData = SerializeForMetadata()
         };
     }
 

--- a/src/ComputerVision/Segmentation/Foundation/QueryMeldNet.cs
+++ b/src/ComputerVision/Segmentation/Foundation/QueryMeldNet.cs
@@ -407,7 +407,7 @@ public class QueryMeldNet<T> : NeuralNetworkBase<T>, IPanopticSegmentation<T>
                 { "DecoderDim", _decoderDim }, { "UseNativeMode", _useNativeMode },
                 { "NumLayers", Layers.Count }
             },
-            ModelData = this.Serialize()
+            ModelData = SerializeForMetadata()
         };
     }
 

--- a/src/ComputerVision/Segmentation/Foundation/SAM.cs
+++ b/src/ComputerVision/Segmentation/Foundation/SAM.cs
@@ -382,7 +382,7 @@ public class SAM<T> : NeuralNetworkBase<T>, IPromptableSegmentation<T>
             { "NumLayers", Layers.Count },
             { "EncoderLayerEnd", _encoderLayerEnd }
         },
-        ModelData = this.Serialize()
+        ModelData = SerializeForMetadata()
     };
 
     /// <summary>

--- a/src/ComputerVision/Segmentation/Foundation/SAM21.cs
+++ b/src/ComputerVision/Segmentation/Foundation/SAM21.cs
@@ -395,7 +395,7 @@ public class SAM21<T> : NeuralNetworkBase<T>, IPromptableSegmentation<T>
             { "NumLayers", Layers.Count },
             { "EncoderLayerEnd", _encoderLayerEnd }
         },
-        ModelData = this.Serialize()
+        ModelData = SerializeForMetadata()
     };
 
     /// <summary>

--- a/src/ComputerVision/Segmentation/Foundation/SAMHQ.cs
+++ b/src/ComputerVision/Segmentation/Foundation/SAMHQ.cs
@@ -429,7 +429,7 @@ public class SAMHQ<T> : NeuralNetworkBase<T>, IPromptableSegmentation<T>
                 { "ModelSize", _modelSize.ToString() }, { "DecoderDim", _decoderDim },
                 { "UseNativeMode", _useNativeMode }, { "NumLayers", Layers.Count }
             },
-            ModelData = this.Serialize()
+            ModelData = SerializeForMetadata()
         };
     }
 

--- a/src/ComputerVision/Segmentation/Foundation/U2Seg.cs
+++ b/src/ComputerVision/Segmentation/Foundation/U2Seg.cs
@@ -381,7 +381,7 @@ public class U2Seg<T> : NeuralNetworkBase<T>, IPanopticSegmentation<T>
                 { "DecoderDim", _decoderDim }, { "UseNativeMode", _useNativeMode },
                 { "NumLayers", Layers.Count }
             },
-            ModelData = this.Serialize()
+            ModelData = SerializeForMetadata()
         };
     }
 

--- a/src/ComputerVision/Segmentation/Foundation/UNINEXT.cs
+++ b/src/ComputerVision/Segmentation/Foundation/UNINEXT.cs
@@ -409,7 +409,7 @@ public class UNINEXT<T> : NeuralNetworkBase<T>, IPanopticSegmentation<T>
                 { "DecoderDim", _decoderDim }, { "UseNativeMode", _useNativeMode },
                 { "NumLayers", Layers.Count }
             },
-            ModelData = this.Serialize()
+            ModelData = SerializeForMetadata()
         };
     }
 

--- a/src/ComputerVision/Segmentation/Foundation/XDecoder.cs
+++ b/src/ComputerVision/Segmentation/Foundation/XDecoder.cs
@@ -435,7 +435,7 @@ public class XDecoder<T> : NeuralNetworkBase<T>, IPanopticSegmentation<T>
                 { "DecoderDim", _decoderDim }, { "UseNativeMode", _useNativeMode },
                 { "NumLayers", Layers.Count }
             },
-            ModelData = this.Serialize()
+            ModelData = SerializeForMetadata()
         };
     }
 

--- a/src/ComputerVision/Segmentation/InstanceSegmentation/YOLO11Seg.cs
+++ b/src/ComputerVision/Segmentation/InstanceSegmentation/YOLO11Seg.cs
@@ -296,7 +296,7 @@ public class YOLO11Seg<T> : NeuralNetworkBase<T>, IInstanceSegmentation<T>
     public override ModelMetadata<T> GetModelMetadata() => new()
     {
         AdditionalInfo = new Dictionary<string, object> { { "ModelName", "YOLO11Seg" }, { "InputHeight", _height }, { "InputWidth", _width }, { "NumClasses", _numClasses }, { "ModelSize", _modelSize.ToString() }, { "UseNativeMode", _useNativeMode }, { "NumLayers", Layers.Count } },
-        ModelData = this.Serialize()
+        ModelData = SerializeForMetadata()
     };
 
     /// <summary>

--- a/src/ComputerVision/Segmentation/InstanceSegmentation/YOLO26Seg.cs
+++ b/src/ComputerVision/Segmentation/InstanceSegmentation/YOLO26Seg.cs
@@ -317,7 +317,7 @@ public class YOLO26Seg<T> : NeuralNetworkBase<T>, IInstanceSegmentation<T>
     public override ModelMetadata<T> GetModelMetadata() => new()
     {
         AdditionalInfo = new Dictionary<string, object> { { "ModelName", "YOLO26Seg" }, { "InputHeight", _height }, { "InputWidth", _width }, { "NumClasses", _numClasses }, { "ModelSize", _modelSize.ToString() }, { "UseNativeMode", _useNativeMode }, { "NumLayers", Layers.Count } },
-        ModelData = this.Serialize()
+        ModelData = SerializeForMetadata()
     };
 
     /// <summary>

--- a/src/ComputerVision/Segmentation/InstanceSegmentation/YOLOv12Seg.cs
+++ b/src/ComputerVision/Segmentation/InstanceSegmentation/YOLOv12Seg.cs
@@ -348,7 +348,7 @@ public class YOLOv12Seg<T> : NeuralNetworkBase<T>, IInstanceSegmentation<T>
     public override ModelMetadata<T> GetModelMetadata() => new()
     {
         AdditionalInfo = new Dictionary<string, object> { { "ModelName", "YOLOv12Seg" }, { "InputHeight", _height }, { "InputWidth", _width }, { "NumClasses", _numClasses }, { "ModelSize", _modelSize.ToString() }, { "UseNativeMode", _useNativeMode }, { "NumLayers", Layers.Count } },
-        ModelData = this.Serialize()
+        ModelData = SerializeForMetadata()
     };
 
     /// <summary>

--- a/src/ComputerVision/Segmentation/InstanceSegmentation/YOLOv8Seg.cs
+++ b/src/ComputerVision/Segmentation/InstanceSegmentation/YOLOv8Seg.cs
@@ -349,7 +349,7 @@ public class YOLOv8Seg<T> : NeuralNetworkBase<T>, IInstanceSegmentation<T>
             { "UseNativeMode", _useNativeMode },
             { "NumLayers", Layers.Count }
         },
-        ModelData = this.Serialize()
+        ModelData = SerializeForMetadata()
     };
 
     /// <summary>

--- a/src/ComputerVision/Segmentation/InstanceSegmentation/YOLOv9Seg.cs
+++ b/src/ComputerVision/Segmentation/InstanceSegmentation/YOLOv9Seg.cs
@@ -311,7 +311,7 @@ public class YOLOv9Seg<T> : NeuralNetworkBase<T>, IInstanceSegmentation<T>
     public override ModelMetadata<T> GetModelMetadata() => new()
     {
         AdditionalInfo = new Dictionary<string, object> { { "ModelName", "YOLOv9Seg" }, { "InputHeight", _height }, { "InputWidth", _width }, { "NumClasses", _numClasses }, { "ModelSize", _modelSize.ToString() }, { "UseNativeMode", _useNativeMode }, { "NumLayers", Layers.Count } },
-        ModelData = this.Serialize()
+        ModelData = SerializeForMetadata()
     };
 
     /// <summary>

--- a/src/ComputerVision/Segmentation/Interactive/SEEM.cs
+++ b/src/ComputerVision/Segmentation/Interactive/SEEM.cs
@@ -320,7 +320,7 @@ public class SEEM<T> : NeuralNetworkBase<T>, IPromptableSegmentation<T>
     public override ModelMetadata<T> GetModelMetadata() => new()
     {
         AdditionalInfo = new Dictionary<string, object> { { "ModelName", "SEEM" }, { "InputHeight", _height }, { "InputWidth", _width }, { "NumClasses", _numClasses }, { "ModelSize", _modelSize.ToString() }, { "UseNativeMode", _useNativeMode }, { "NumLayers", Layers.Count } },
-        ModelData = this.Serialize()
+        ModelData = SerializeForMetadata()
     };
 
     /// <summary>

--- a/src/ComputerVision/Segmentation/Interactive/SegGPT.cs
+++ b/src/ComputerVision/Segmentation/Interactive/SegGPT.cs
@@ -291,7 +291,7 @@ public class SegGPT<T> : NeuralNetworkBase<T>, IPromptableSegmentation<T>
     public override ModelMetadata<T> GetModelMetadata() => new()
     {
         AdditionalInfo = new Dictionary<string, object> { { "ModelName", "SegGPT" }, { "InputHeight", _height }, { "InputWidth", _width }, { "NumClasses", _numClasses }, { "ModelSize", _modelSize.ToString() }, { "UseNativeMode", _useNativeMode }, { "NumLayers", Layers.Count } },
-        ModelData = this.Serialize()
+        ModelData = SerializeForMetadata()
     };
 
     /// <summary>

--- a/src/ComputerVision/Segmentation/Mamba/VMamba.cs
+++ b/src/ComputerVision/Segmentation/Mamba/VMamba.cs
@@ -296,7 +296,7 @@ public class VMamba<T> : NeuralNetworkBase<T>, ISemanticSegmentation<T>
     public override ModelMetadata<T> GetModelMetadata() => new()
     {
         AdditionalInfo = new Dictionary<string, object> { { "ModelName", "VMamba" }, { "InputHeight", _height }, { "InputWidth", _width }, { "NumClasses", _numClasses }, { "ModelSize", _modelSize.ToString() }, { "UseNativeMode", _useNativeMode }, { "NumLayers", Layers.Count } },
-        ModelData = this.Serialize()
+        ModelData = SerializeForMetadata()
     };
 
     /// <summary>

--- a/src/ComputerVision/Segmentation/Mamba/ViMUNet.cs
+++ b/src/ComputerVision/Segmentation/Mamba/ViMUNet.cs
@@ -312,7 +312,7 @@ public class ViMUNet<T> : NeuralNetworkBase<T>, ISemanticSegmentation<T>
     public override ModelMetadata<T> GetModelMetadata() => new()
     {
         AdditionalInfo = new Dictionary<string, object> { { "ModelName", "ViMUNet" }, { "InputHeight", _height }, { "InputWidth", _width }, { "NumClasses", _numClasses }, { "UseNativeMode", _useNativeMode }, { "NumLayers", Layers.Count } },
-        ModelData = this.Serialize()
+        ModelData = SerializeForMetadata()
     };
 
     /// <summary>

--- a/src/ComputerVision/Segmentation/Mamba/VisionMamba.cs
+++ b/src/ComputerVision/Segmentation/Mamba/VisionMamba.cs
@@ -297,7 +297,7 @@ public class VisionMamba<T> : NeuralNetworkBase<T>, ISemanticSegmentation<T>
     public override ModelMetadata<T> GetModelMetadata() => new()
     {
         AdditionalInfo = new Dictionary<string, object> { { "ModelName", "VisionMamba" }, { "InputHeight", _height }, { "InputWidth", _width }, { "NumClasses", _numClasses }, { "ModelSize", _modelSize.ToString() }, { "UseNativeMode", _useNativeMode }, { "NumLayers", Layers.Count } },
-        ModelData = this.Serialize()
+        ModelData = SerializeForMetadata()
     };
 
     /// <summary>

--- a/src/ComputerVision/Segmentation/Medical/BiomedParse.cs
+++ b/src/ComputerVision/Segmentation/Medical/BiomedParse.cs
@@ -340,7 +340,7 @@ public class BiomedParse<T> : NeuralNetworkBase<T>, IMedicalSegmentation<T>
     public override ModelMetadata<T> GetModelMetadata() => new()
     {
         AdditionalInfo = new Dictionary<string, object> { { "ModelName", "BiomedParse" }, { "InputHeight", _height }, { "InputWidth", _width }, { "NumClasses", _numClasses }, { "UseNativeMode", _useNativeMode }, { "NumLayers", Layers.Count } },
-        ModelData = this.Serialize()
+        ModelData = SerializeForMetadata()
     };
 
     /// <summary>

--- a/src/ComputerVision/Segmentation/Medical/MedNeXt.cs
+++ b/src/ComputerVision/Segmentation/Medical/MedNeXt.cs
@@ -294,7 +294,7 @@ public class MedNeXt<T> : NeuralNetworkBase<T>, IMedicalSegmentation<T>
     public override ModelMetadata<T> GetModelMetadata() => new()
     {
         AdditionalInfo = new Dictionary<string, object> { { "ModelName", "MedNeXt" }, { "InputHeight", _height }, { "InputWidth", _width }, { "NumClasses", _numClasses }, { "ModelSize", _modelSize.ToString() }, { "UseNativeMode", _useNativeMode }, { "NumLayers", Layers.Count } },
-        ModelData = this.Serialize()
+        ModelData = SerializeForMetadata()
     };
 
     /// <summary>

--- a/src/ComputerVision/Segmentation/Medical/MedSAM.cs
+++ b/src/ComputerVision/Segmentation/Medical/MedSAM.cs
@@ -296,7 +296,7 @@ public class MedSAM<T> : NeuralNetworkBase<T>, IMedicalSegmentation<T>
     public override ModelMetadata<T> GetModelMetadata() => new()
     {
         AdditionalInfo = new Dictionary<string, object> { { "ModelName", "MedSAM" }, { "InputHeight", _height }, { "InputWidth", _width }, { "NumClasses", _numClasses }, { "ModelSize", _modelSize.ToString() }, { "UseNativeMode", _useNativeMode }, { "NumLayers", Layers.Count } },
-        ModelData = this.Serialize()
+        ModelData = SerializeForMetadata()
     };
 
     /// <summary>

--- a/src/ComputerVision/Segmentation/Medical/MedSAM2.cs
+++ b/src/ComputerVision/Segmentation/Medical/MedSAM2.cs
@@ -293,7 +293,7 @@ public class MedSAM2<T> : NeuralNetworkBase<T>, IMedicalSegmentation<T>
     public override ModelMetadata<T> GetModelMetadata() => new()
     {
         AdditionalInfo = new Dictionary<string, object> { { "ModelName", "MedSAM2" }, { "InputHeight", _height }, { "InputWidth", _width }, { "NumClasses", _numClasses }, { "ModelSize", _modelSize.ToString() }, { "UseNativeMode", _useNativeMode }, { "NumLayers", Layers.Count } },
-        ModelData = this.Serialize()
+        ModelData = SerializeForMetadata()
     };
 
     /// <summary>

--- a/src/ComputerVision/Segmentation/Medical/MedSegDiffV2.cs
+++ b/src/ComputerVision/Segmentation/Medical/MedSegDiffV2.cs
@@ -285,7 +285,7 @@ public class MedSegDiffV2<T> : NeuralNetworkBase<T>, IMedicalSegmentation<T>
     public override ModelMetadata<T> GetModelMetadata() => new()
     {
         AdditionalInfo = new Dictionary<string, object> { { "ModelName", "MedSegDiffV2" }, { "InputHeight", _height }, { "InputWidth", _width }, { "NumClasses", _numClasses }, { "UseNativeMode", _useNativeMode }, { "NumLayers", Layers.Count } },
-        ModelData = this.Serialize()
+        ModelData = SerializeForMetadata()
     };
 
     /// <summary>

--- a/src/ComputerVision/Segmentation/Medical/NnUNet.cs
+++ b/src/ComputerVision/Segmentation/Medical/NnUNet.cs
@@ -300,7 +300,7 @@ public class NnUNet<T> : NeuralNetworkBase<T>, IMedicalSegmentation<T>
     public override ModelMetadata<T> GetModelMetadata() => new()
     {
         AdditionalInfo = new Dictionary<string, object> { { "ModelName", "NnUNet" }, { "InputHeight", _height }, { "InputWidth", _width }, { "NumClasses", _numClasses }, { "ModelSize", _modelSize.ToString() }, { "UseNativeMode", _useNativeMode }, { "NumLayers", Layers.Count } },
-        ModelData = this.Serialize()
+        ModelData = SerializeForMetadata()
     };
 
     /// <summary>

--- a/src/ComputerVision/Segmentation/Medical/SegMamba.cs
+++ b/src/ComputerVision/Segmentation/Medical/SegMamba.cs
@@ -512,7 +512,7 @@ public class SegMamba<T> : NeuralNetworkBase<T>, IMedicalSegmentation<T>
     public override ModelMetadata<T> GetModelMetadata() => new()
     {
         AdditionalInfo = new Dictionary<string, object> { { "ModelName", "SegMamba" }, { "InChannels", _inChannels }, { "NumClasses", _numClasses }, { "UseNativeMode", _useNativeMode }, { "NumLayers", Layers.Count } },
-        ModelData = this.Serialize()
+        ModelData = SerializeForMetadata()
     };
 
     protected override void SerializeNetworkSpecificData(BinaryWriter writer)

--- a/src/ComputerVision/Segmentation/Medical/SwinUNETR.cs
+++ b/src/ComputerVision/Segmentation/Medical/SwinUNETR.cs
@@ -337,7 +337,7 @@ public class SwinUNETR<T> : NeuralNetworkBase<T>, IMedicalSegmentation<T>
     public override ModelMetadata<T> GetModelMetadata() => new()
     {
         AdditionalInfo = new Dictionary<string, object> { { "ModelName", "SwinUNETR" }, { "InputHeight", _height }, { "InputWidth", _width }, { "NumClasses", _numClasses }, { "ModelSize", _modelSize.ToString() }, { "UseNativeMode", _useNativeMode }, { "NumLayers", Layers.Count } },
-        ModelData = this.Serialize()
+        ModelData = SerializeForMetadata()
     };
 
     /// <summary>

--- a/src/ComputerVision/Segmentation/Medical/TransUNet.cs
+++ b/src/ComputerVision/Segmentation/Medical/TransUNet.cs
@@ -315,7 +315,7 @@ public class TransUNet<T> : NeuralNetworkBase<T>, IMedicalSegmentation<T>
     public override ModelMetadata<T> GetModelMetadata() => new()
     {
         AdditionalInfo = new Dictionary<string, object> { { "ModelName", "TransUNet" }, { "InputHeight", _height }, { "InputWidth", _width }, { "NumClasses", _numClasses }, { "ModelSize", _modelSize.ToString() }, { "UseNativeMode", _useNativeMode }, { "NumLayers", Layers.Count } },
-        ModelData = this.Serialize()
+        ModelData = SerializeForMetadata()
     };
 
     /// <summary>

--- a/src/ComputerVision/Segmentation/Medical/UMamba.cs
+++ b/src/ComputerVision/Segmentation/Medical/UMamba.cs
@@ -286,7 +286,7 @@ public class UMamba<T> : NeuralNetworkBase<T>, IMedicalSegmentation<T>
     public override ModelMetadata<T> GetModelMetadata() => new()
     {
         AdditionalInfo = new Dictionary<string, object> { { "ModelName", "UMamba" }, { "InputHeight", _height }, { "InputWidth", _width }, { "NumClasses", _numClasses }, { "UseNativeMode", _useNativeMode }, { "NumLayers", Layers.Count } },
-        ModelData = this.Serialize()
+        ModelData = SerializeForMetadata()
     };
 
     /// <summary>

--- a/src/ComputerVision/Segmentation/Medical/UniverSeg.cs
+++ b/src/ComputerVision/Segmentation/Medical/UniverSeg.cs
@@ -285,7 +285,7 @@ public class UniverSeg<T> : NeuralNetworkBase<T>, IMedicalSegmentation<T>
     public override ModelMetadata<T> GetModelMetadata() => new()
     {
         AdditionalInfo = new Dictionary<string, object> { { "ModelName", "UniverSeg" }, { "InputHeight", _height }, { "InputWidth", _width }, { "NumClasses", _numClasses }, { "UseNativeMode", _useNativeMode }, { "NumLayers", Layers.Count } },
-        ModelData = this.Serialize()
+        ModelData = SerializeForMetadata()
     };
 
     /// <summary>

--- a/src/ComputerVision/Segmentation/OpenVocabulary/CATSeg.cs
+++ b/src/ComputerVision/Segmentation/OpenVocabulary/CATSeg.cs
@@ -290,7 +290,7 @@ public class CATSeg<T> : NeuralNetworkBase<T>, IOpenVocabSegmentation<T>
     public override ModelMetadata<T> GetModelMetadata() => new()
     {
         AdditionalInfo = new Dictionary<string, object> { { "ModelName", "CATSeg" }, { "InputHeight", _height }, { "InputWidth", _width }, { "NumClasses", _numClasses }, { "UseNativeMode", _useNativeMode }, { "NumLayers", Layers.Count } },
-        ModelData = this.Serialize()
+        ModelData = SerializeForMetadata()
     };
 
     /// <summary>

--- a/src/ComputerVision/Segmentation/OpenVocabulary/GroundedSAM2.cs
+++ b/src/ComputerVision/Segmentation/OpenVocabulary/GroundedSAM2.cs
@@ -288,7 +288,7 @@ public class GroundedSAM2<T> : NeuralNetworkBase<T>, IOpenVocabSegmentation<T>
     public override ModelMetadata<T> GetModelMetadata() => new()
     {
         AdditionalInfo = new Dictionary<string, object> { { "ModelName", "GroundedSAM2" }, { "InputHeight", _height }, { "InputWidth", _width }, { "NumClasses", _numClasses }, { "UseNativeMode", _useNativeMode }, { "NumLayers", Layers.Count } },
-        ModelData = this.Serialize()
+        ModelData = SerializeForMetadata()
     };
 
     /// <summary>

--- a/src/ComputerVision/Segmentation/OpenVocabulary/MaskAdapter.cs
+++ b/src/ComputerVision/Segmentation/OpenVocabulary/MaskAdapter.cs
@@ -289,7 +289,7 @@ public class MaskAdapter<T> : NeuralNetworkBase<T>, IOpenVocabSegmentation<T>
     public override ModelMetadata<T> GetModelMetadata() => new()
     {
         AdditionalInfo = new Dictionary<string, object> { { "ModelName", "MaskAdapter" }, { "InputHeight", _height }, { "InputWidth", _width }, { "NumClasses", _numClasses }, { "UseNativeMode", _useNativeMode }, { "NumLayers", Layers.Count } },
-        ModelData = this.Serialize()
+        ModelData = SerializeForMetadata()
     };
 
     /// <summary>

--- a/src/ComputerVision/Segmentation/OpenVocabulary/OpenVocabSAM.cs
+++ b/src/ComputerVision/Segmentation/OpenVocabulary/OpenVocabSAM.cs
@@ -291,7 +291,7 @@ public class OpenVocabSAM<T> : NeuralNetworkBase<T>, IOpenVocabSegmentation<T>
     public override ModelMetadata<T> GetModelMetadata() => new()
     {
         AdditionalInfo = new Dictionary<string, object> { { "ModelName", "OpenVocabSAM" }, { "InputHeight", _height }, { "InputWidth", _width }, { "NumClasses", _numClasses }, { "UseNativeMode", _useNativeMode }, { "NumLayers", Layers.Count } },
-        ModelData = this.Serialize()
+        ModelData = SerializeForMetadata()
     };
 
     /// <summary>

--- a/src/ComputerVision/Segmentation/OpenVocabulary/SAN.cs
+++ b/src/ComputerVision/Segmentation/OpenVocabulary/SAN.cs
@@ -285,7 +285,7 @@ public class SAN<T> : NeuralNetworkBase<T>, IOpenVocabSegmentation<T>
     public override ModelMetadata<T> GetModelMetadata() => new()
     {
         AdditionalInfo = new Dictionary<string, object> { { "ModelName", "SAN" }, { "InputHeight", _height }, { "InputWidth", _width }, { "NumClasses", _numClasses }, { "UseNativeMode", _useNativeMode }, { "NumLayers", Layers.Count } },
-        ModelData = this.Serialize()
+        ModelData = SerializeForMetadata()
     };
 
     /// <summary>

--- a/src/ComputerVision/Segmentation/OpenVocabulary/SED.cs
+++ b/src/ComputerVision/Segmentation/OpenVocabulary/SED.cs
@@ -285,7 +285,7 @@ public class SED<T> : NeuralNetworkBase<T>, IOpenVocabSegmentation<T>
     public override ModelMetadata<T> GetModelMetadata() => new()
     {
         AdditionalInfo = new Dictionary<string, object> { { "ModelName", "SED" }, { "InputHeight", _height }, { "InputWidth", _width }, { "NumClasses", _numClasses }, { "UseNativeMode", _useNativeMode }, { "NumLayers", Layers.Count } },
-        ModelData = this.Serialize()
+        ModelData = SerializeForMetadata()
     };
 
     /// <summary>

--- a/src/ComputerVision/Segmentation/Panoptic/CUPS.cs
+++ b/src/ComputerVision/Segmentation/Panoptic/CUPS.cs
@@ -284,7 +284,7 @@ public class CUPS<T> : NeuralNetworkBase<T>, IPanopticSegmentation<T>
     public override ModelMetadata<T> GetModelMetadata() => new()
     {
         AdditionalInfo = new Dictionary<string, object> { { "ModelName", "CUPS" }, { "InputHeight", _height }, { "InputWidth", _width }, { "NumClasses", _numClasses }, { "UseNativeMode", _useNativeMode }, { "NumLayers", Layers.Count } },
-        ModelData = this.Serialize()
+        ModelData = SerializeForMetadata()
     };
 
     /// <summary>

--- a/src/ComputerVision/Segmentation/Panoptic/KMaXDeepLab.cs
+++ b/src/ComputerVision/Segmentation/Panoptic/KMaXDeepLab.cs
@@ -295,7 +295,7 @@ public class KMaXDeepLab<T> : NeuralNetworkBase<T>, IPanopticSegmentation<T>
     public override ModelMetadata<T> GetModelMetadata() => new()
     {
         AdditionalInfo = new Dictionary<string, object> { { "ModelName", "KMaXDeepLab" }, { "InputHeight", _height }, { "InputWidth", _width }, { "NumClasses", _numClasses }, { "ModelSize", _modelSize.ToString() }, { "UseNativeMode", _useNativeMode }, { "NumLayers", Layers.Count } },
-        ModelData = this.Serialize()
+        ModelData = SerializeForMetadata()
     };
 
     /// <summary>

--- a/src/ComputerVision/Segmentation/Panoptic/ODISE.cs
+++ b/src/ComputerVision/Segmentation/Panoptic/ODISE.cs
@@ -310,7 +310,7 @@ public class ODISE<T> : NeuralNetworkBase<T>, IPanopticSegmentation<T>
     public override ModelMetadata<T> GetModelMetadata() => new()
     {
         AdditionalInfo = new Dictionary<string, object> { { "ModelName", "ODISE" }, { "InputHeight", _height }, { "InputWidth", _width }, { "NumClasses", _numClasses }, { "ModelSize", _modelSize.ToString() }, { "UseNativeMode", _useNativeMode }, { "NumLayers", Layers.Count } },
-        ModelData = this.Serialize()
+        ModelData = SerializeForMetadata()
     };
 
     /// <summary>

--- a/src/ComputerVision/Segmentation/PointCloud/Concerto.cs
+++ b/src/ComputerVision/Segmentation/PointCloud/Concerto.cs
@@ -290,7 +290,7 @@ public class Concerto<T> : NeuralNetworkBase<T>, ISemanticSegmentation<T>
     public override ModelMetadata<T> GetModelMetadata() => new()
     {
         AdditionalInfo = new Dictionary<string, object> { { "ModelName", "Concerto" }, { "InputHeight", _height }, { "InputWidth", _width }, { "NumClasses", _numClasses }, { "ModelSize", _modelSize.ToString() }, { "UseNativeMode", _useNativeMode }, { "NumLayers", Layers.Count } },
-        ModelData = this.Serialize()
+        ModelData = SerializeForMetadata()
     };
 
     /// <summary>

--- a/src/ComputerVision/Segmentation/PointCloud/PointTransformerV3.cs
+++ b/src/ComputerVision/Segmentation/PointCloud/PointTransformerV3.cs
@@ -289,7 +289,7 @@ public class PointTransformerV3<T> : NeuralNetworkBase<T>, ISemanticSegmentation
     public override ModelMetadata<T> GetModelMetadata() => new()
     {
         AdditionalInfo = new Dictionary<string, object> { { "ModelName", "PointTransformerV3" }, { "InputHeight", _height }, { "InputWidth", _width }, { "NumClasses", _numClasses }, { "ModelSize", _modelSize.ToString() }, { "UseNativeMode", _useNativeMode }, { "NumLayers", Layers.Count } },
-        ModelData = this.Serialize()
+        ModelData = SerializeForMetadata()
     };
 
     /// <summary>

--- a/src/ComputerVision/Segmentation/PointCloud/Sonata.cs
+++ b/src/ComputerVision/Segmentation/PointCloud/Sonata.cs
@@ -289,7 +289,7 @@ public class Sonata<T> : NeuralNetworkBase<T>, ISemanticSegmentation<T>
     public override ModelMetadata<T> GetModelMetadata() => new()
     {
         AdditionalInfo = new Dictionary<string, object> { { "ModelName", "Sonata" }, { "InputHeight", _height }, { "InputWidth", _width }, { "NumClasses", _numClasses }, { "ModelSize", _modelSize.ToString() }, { "UseNativeMode", _useNativeMode }, { "NumLayers", Layers.Count } },
-        ModelData = this.Serialize()
+        ModelData = SerializeForMetadata()
     };
 
     /// <summary>

--- a/src/ComputerVision/Segmentation/Referring/GLaMM.cs
+++ b/src/ComputerVision/Segmentation/Referring/GLaMM.cs
@@ -290,7 +290,7 @@ public class GLaMM<T> : NeuralNetworkBase<T>, IReferringSegmentation<T>
     public override ModelMetadata<T> GetModelMetadata() => new()
     {
         AdditionalInfo = new Dictionary<string, object> { { "ModelName", "GLaMM" }, { "InputHeight", _height }, { "InputWidth", _width }, { "NumClasses", _numClasses }, { "UseNativeMode", _useNativeMode }, { "NumLayers", Layers.Count } },
-        ModelData = this.Serialize()
+        ModelData = SerializeForMetadata()
     };
 
     /// <summary>

--- a/src/ComputerVision/Segmentation/Referring/LISA.cs
+++ b/src/ComputerVision/Segmentation/Referring/LISA.cs
@@ -286,7 +286,7 @@ public class LISA<T> : NeuralNetworkBase<T>, IReferringSegmentation<T>
     public override ModelMetadata<T> GetModelMetadata() => new()
     {
         AdditionalInfo = new Dictionary<string, object> { { "ModelName", "LISA" }, { "InputHeight", _height }, { "InputWidth", _width }, { "NumClasses", _numClasses }, { "UseNativeMode", _useNativeMode }, { "NumLayers", Layers.Count } },
-        ModelData = this.Serialize()
+        ModelData = SerializeForMetadata()
     };
 
     /// <summary>

--- a/src/ComputerVision/Segmentation/Referring/OMGLLaVA.cs
+++ b/src/ComputerVision/Segmentation/Referring/OMGLLaVA.cs
@@ -288,7 +288,7 @@ public class OMGLLaVA<T> : NeuralNetworkBase<T>, IReferringSegmentation<T>
     public override ModelMetadata<T> GetModelMetadata() => new()
     {
         AdditionalInfo = new Dictionary<string, object> { { "ModelName", "OMGLLaVA" }, { "InputHeight", _height }, { "InputWidth", _width }, { "NumClasses", _numClasses }, { "UseNativeMode", _useNativeMode }, { "NumLayers", Layers.Count } },
-        ModelData = this.Serialize()
+        ModelData = SerializeForMetadata()
     };
 
     /// <summary>

--- a/src/ComputerVision/Segmentation/Referring/PixelLM.cs
+++ b/src/ComputerVision/Segmentation/Referring/PixelLM.cs
@@ -285,7 +285,7 @@ public class PixelLM<T> : NeuralNetworkBase<T>, IReferringSegmentation<T>
     public override ModelMetadata<T> GetModelMetadata() => new()
     {
         AdditionalInfo = new Dictionary<string, object> { { "ModelName", "PixelLM" }, { "InputHeight", _height }, { "InputWidth", _width }, { "NumClasses", _numClasses }, { "UseNativeMode", _useNativeMode }, { "NumLayers", Layers.Count } },
-        ModelData = this.Serialize()
+        ModelData = SerializeForMetadata()
     };
 
     /// <summary>

--- a/src/ComputerVision/Segmentation/Referring/VideoLISA.cs
+++ b/src/ComputerVision/Segmentation/Referring/VideoLISA.cs
@@ -288,7 +288,7 @@ public class VideoLISA<T> : NeuralNetworkBase<T>, IReferringSegmentation<T>
     public override ModelMetadata<T> GetModelMetadata() => new()
     {
         AdditionalInfo = new Dictionary<string, object> { { "ModelName", "VideoLISA" }, { "InputHeight", _height }, { "InputWidth", _width }, { "NumClasses", _numClasses }, { "UseNativeMode", _useNativeMode }, { "NumLayers", Layers.Count } },
-        ModelData = this.Serialize()
+        ModelData = SerializeForMetadata()
     };
 
     /// <summary>

--- a/src/ComputerVision/Segmentation/Semantic/DiffCut.cs
+++ b/src/ComputerVision/Segmentation/Semantic/DiffCut.cs
@@ -381,7 +381,7 @@ public class DiffCut<T> : NeuralNetworkBase<T>, ISemanticSegmentation<T>
                 { "NumClasses", _numClasses }, { "DecoderDim", _decoderDim }, { "DropRate", _dropRate },
                 { "UseNativeMode", _useNativeMode }, { "NumLayers", Layers.Count }
             },
-            ModelData = this.Serialize()
+            ModelData = SerializeForMetadata()
         };
     }
 

--- a/src/ComputerVision/Segmentation/Semantic/DiffSeg.cs
+++ b/src/ComputerVision/Segmentation/Semantic/DiffSeg.cs
@@ -377,7 +377,7 @@ public class DiffSeg<T> : NeuralNetworkBase<T>, ISemanticSegmentation<T>
                 { "NumClasses", _numClasses }, { "DecoderDim", _decoderDim }, { "DropRate", _dropRate },
                 { "UseNativeMode", _useNativeMode }, { "NumLayers", Layers.Count }
             },
-            ModelData = this.Serialize()
+            ModelData = SerializeForMetadata()
         };
     }
 

--- a/src/ComputerVision/Segmentation/Semantic/InternImage.cs
+++ b/src/ComputerVision/Segmentation/Semantic/InternImage.cs
@@ -449,7 +449,7 @@ public class InternImage<T> : NeuralNetworkBase<T>, ISemanticSegmentation<T>
                 { "DecoderDim", _decoderDim }, { "DropRate", _dropRate },
                 { "UseNativeMode", _useNativeMode }, { "NumLayers", Layers.Count }
             },
-            ModelData = this.Serialize()
+            ModelData = SerializeForMetadata()
         };
     }
 

--- a/src/ComputerVision/Segmentation/Semantic/SegFormer.cs
+++ b/src/ComputerVision/Segmentation/Semantic/SegFormer.cs
@@ -668,7 +668,7 @@ public class SegFormer<T> : NeuralNetworkBase<T>, ISemanticSegmentation<T>
         return new ModelMetadata<T>
         {
             AdditionalInfo = additionalInfo,
-            ModelData = this.Serialize()
+            ModelData = SerializeForMetadata()
         };
     }
 

--- a/src/ComputerVision/Segmentation/Semantic/SegNeXt.cs
+++ b/src/ComputerVision/Segmentation/Semantic/SegNeXt.cs
@@ -631,7 +631,7 @@ public class SegNeXt<T> : NeuralNetworkBase<T>, ISemanticSegmentation<T>
         return new ModelMetadata<T>
         {
             AdditionalInfo = additionalInfo,
-            ModelData = this.Serialize()
+            ModelData = SerializeForMetadata()
         };
     }
 

--- a/src/ComputerVision/Segmentation/Semantic/ViTAdapter.cs
+++ b/src/ComputerVision/Segmentation/Semantic/ViTAdapter.cs
@@ -411,7 +411,7 @@ public class ViTAdapter<T> : NeuralNetworkBase<T>, ISemanticSegmentation<T>
                 { "EmbedDim", _embedDim }, { "DecoderDim", _decoderDim }, { "DropRate", _dropRate },
                 { "UseNativeMode", _useNativeMode }, { "NumLayers", Layers.Count }
             },
-            ModelData = this.Serialize()
+            ModelData = SerializeForMetadata()
         };
     }
 

--- a/src/ComputerVision/Segmentation/Semantic/ViTCoMer.cs
+++ b/src/ComputerVision/Segmentation/Semantic/ViTCoMer.cs
@@ -405,7 +405,7 @@ public class ViTCoMer<T> : NeuralNetworkBase<T>, ISemanticSegmentation<T>
                 { "EmbedDim", _embedDim }, { "DecoderDim", _decoderDim }, { "DropRate", _dropRate },
                 { "UseNativeMode", _useNativeMode }, { "NumLayers", Layers.Count }
             },
-            ModelData = this.Serialize()
+            ModelData = SerializeForMetadata()
         };
     }
 

--- a/src/ComputerVision/Segmentation/Video/DEVA.cs
+++ b/src/ComputerVision/Segmentation/Video/DEVA.cs
@@ -297,7 +297,7 @@ public class DEVA<T> : NeuralNetworkBase<T>, IVideoSegmentation<T>
     public override ModelMetadata<T> GetModelMetadata() => new()
     {
         AdditionalInfo = new Dictionary<string, object> { { "ModelName", "DEVA" }, { "InputHeight", _height }, { "InputWidth", _width }, { "NumClasses", _numClasses }, { "ModelSize", _modelSize.ToString() }, { "UseNativeMode", _useNativeMode }, { "NumLayers", Layers.Count } },
-        ModelData = this.Serialize()
+        ModelData = SerializeForMetadata()
     };
 
     /// <summary>

--- a/src/ComputerVision/Segmentation/Video/EfficientTAM.cs
+++ b/src/ComputerVision/Segmentation/Video/EfficientTAM.cs
@@ -293,7 +293,7 @@ public class EfficientTAM<T> : NeuralNetworkBase<T>, IVideoSegmentation<T>
     public override ModelMetadata<T> GetModelMetadata() => new()
     {
         AdditionalInfo = new Dictionary<string, object> { { "ModelName", "EfficientTAM" }, { "InputHeight", _height }, { "InputWidth", _width }, { "NumClasses", _numClasses }, { "ModelSize", _modelSize.ToString() }, { "UseNativeMode", _useNativeMode }, { "NumLayers", Layers.Count } },
-        ModelData = this.Serialize()
+        ModelData = SerializeForMetadata()
     };
 
     /// <summary>

--- a/src/ComputerVision/Segmentation/Video/UniVS.cs
+++ b/src/ComputerVision/Segmentation/Video/UniVS.cs
@@ -293,7 +293,7 @@ public class UniVS<T> : NeuralNetworkBase<T>, IVideoSegmentation<T>
     public override ModelMetadata<T> GetModelMetadata() => new()
     {
         AdditionalInfo = new Dictionary<string, object> { { "ModelName", "UniVS" }, { "InputHeight", _height }, { "InputWidth", _width }, { "NumClasses", _numClasses }, { "ModelSize", _modelSize.ToString() }, { "UseNativeMode", _useNativeMode }, { "NumLayers", Layers.Count } },
-        ModelData = this.Serialize()
+        ModelData = SerializeForMetadata()
     };
 
     /// <summary>

--- a/src/NeuralNetworks/ACGAN.cs
+++ b/src/NeuralNetworks/ACGAN.cs
@@ -728,7 +728,7 @@ public class ACGAN<T> : NeuralNetworkBase<T>
                 { "DiscriminatorParameters", Discriminator.GetParameterCount() },
                 { "NumClasses", _numClasses }
             },
-            ModelData = this.Serialize()
+            ModelData = SerializeForMetadata()
         };
     }
 

--- a/src/NeuralNetworks/AttentionNetwork.cs
+++ b/src/NeuralNetworks/AttentionNetwork.cs
@@ -381,7 +381,7 @@ public class AttentionNetwork<T> : NeuralNetworkBase<T>, IAuxiliaryLossLayer<T>
                 { "InputShape", new[] { _sequenceLength, _embeddingSize } },
                 { "OutputShape", Layers[Layers.Count - 1].GetOutputShape() }
             },
-            ModelData = this.Serialize()
+            ModelData = SerializeForMetadata()
         };
     }
 

--- a/src/NeuralNetworks/Blip2NeuralNetwork.cs
+++ b/src/NeuralNetworks/Blip2NeuralNetwork.cs
@@ -2401,7 +2401,7 @@ public class Blip2NeuralNetwork<T> : NeuralNetworkBase<T>, IBlip2Model<T>
                 { "TaskType", Architecture.TaskType.ToString() },
                 { "LayerCount", Layers.Count }
             },
-            ModelData = this.Serialize()
+            ModelData = SerializeForMetadata()
         };
     }
 

--- a/src/NeuralNetworks/BlipNeuralNetwork.cs
+++ b/src/NeuralNetworks/BlipNeuralNetwork.cs
@@ -1873,7 +1873,7 @@ public class BlipNeuralNetwork<T> : NeuralNetworkBase<T>, IBlipModel<T>
                 { "ParameterCount", ParameterCount },
                 { "UseNativeMode", _useNativeMode }
             },
-            ModelData = this.Serialize()
+            ModelData = SerializeForMetadata()
         };
     }
 

--- a/src/NeuralNetworks/CapsuleNetwork.cs
+++ b/src/NeuralNetworks/CapsuleNetwork.cs
@@ -476,7 +476,7 @@ public class CapsuleNetwork<T> : NeuralNetworkBase<T>, IAuxiliaryLossLayer<T>
                 { "LayerCount", Layers.Count },
                 { "LayerTypes", Layers.Select(l => l.GetType().Name).ToArray() }
             },
-            ModelData = this.Serialize()
+            ModelData = SerializeForMetadata()
         };
     }
 

--- a/src/NeuralNetworks/ConditionalGAN.cs
+++ b/src/NeuralNetworks/ConditionalGAN.cs
@@ -852,7 +852,7 @@ public class ConditionalGAN<T> : GenerativeAdversarialNetwork<T>
                 { "DiscriminatorParameters", Discriminator.GetParameterCount() },
                 { "NumConditionClasses", _numConditionClasses }
             },
-            ModelData = this.Serialize()
+            ModelData = SerializeForMetadata()
         };
     }
 

--- a/src/NeuralNetworks/ConvolutionalNeuralNetwork.cs
+++ b/src/NeuralNetworks/ConvolutionalNeuralNetwork.cs
@@ -572,7 +572,7 @@ public class ConvolutionalNeuralNetwork<T> : NeuralNetworkBase<T>
                 { "LayerCount", Layers.Count },
                 { "LayerTypes", Layers.Select(l => l.GetType().Name).ToArray() }
             },
-            ModelData = this.Serialize()
+            ModelData = SerializeForMetadata()
         };
     }
 

--- a/src/NeuralNetworks/CycleGAN.cs
+++ b/src/NeuralNetworks/CycleGAN.cs
@@ -821,7 +821,7 @@ public class CycleGAN<T> : NeuralNetworkBase<T>
                 { "CycleConsistencyLambda", NumOps.ToDouble(_cycleConsistencyLambda) },
                 { "IdentityLambda", NumOps.ToDouble(_identityLambda) }
             },
-            ModelData = this.Serialize()
+            ModelData = SerializeForMetadata()
         };
     }
 

--- a/src/NeuralNetworks/DeepBeliefNetwork.cs
+++ b/src/NeuralNetworks/DeepBeliefNetwork.cs
@@ -707,7 +707,7 @@ public class DeepBeliefNetwork<T> : NeuralNetworkBase<T>
                 { "LearningRate", Convert.ToDouble(_learningRate) },
                 { "BatchSize", _batchSize }
             },
-            ModelData = this.Serialize()
+            ModelData = SerializeForMetadata()
         };
     }
 

--- a/src/NeuralNetworks/DeepBoltzmannMachine.cs
+++ b/src/NeuralNetworks/DeepBoltzmannMachine.cs
@@ -994,7 +994,7 @@ public class DeepBoltzmannMachine<T> : NeuralNetworkBase<T>
                 { "Epochs", _epochs },
                 { "LearningRate", Convert.ToDouble(_learningRate) }
             },
-            ModelData = this.Serialize()
+            ModelData = SerializeForMetadata()
         };
     }
 

--- a/src/NeuralNetworks/DeepQNetwork.cs
+++ b/src/NeuralNetworks/DeepQNetwork.cs
@@ -753,7 +753,7 @@ public class DeepQNetwork<T> : NeuralNetworkBase<T>
                 { "ExplorationRate", Convert.ToDouble(_epsilon) },
                 { "ReplayBufferSize", _replayBuffer.Count }
             },
-            ModelData = this.Serialize()
+            ModelData = SerializeForMetadata()
         };
     }
 

--- a/src/NeuralNetworks/DenseNetNetwork.cs
+++ b/src/NeuralNetworks/DenseNetNetwork.cs
@@ -347,7 +347,7 @@ public class DenseNetNetwork<T> : NeuralNetworkBase<T>
                 { "LayerCount", Layers.Count },
                 { "ParameterCount", GetParameterCount() }
             },
-            ModelData = this.Serialize()
+            ModelData = SerializeForMetadata()
         };
     }
 

--- a/src/NeuralNetworks/DifferentiableNeuralComputer.cs
+++ b/src/NeuralNetworks/DifferentiableNeuralComputer.cs
@@ -1928,7 +1928,7 @@ public class DifferentiableNeuralComputer<T> : NeuralNetworkBase<T>, IAuxiliaryL
                 { "LayerCount", Layers.Count },
                 { "ParameterCount", ParameterCount }
             },
-            ModelData = this.Serialize()
+            ModelData = SerializeForMetadata()
         };
     }
 

--- a/src/NeuralNetworks/EagleLanguageModel.cs
+++ b/src/NeuralNetworks/EagleLanguageModel.cs
@@ -150,7 +150,7 @@ public class EagleLanguageModel<T> : NeuralNetworkBase<T>
                 { "MaxSeqLength", _maxSeqLength },
                 { "LayerCount", Layers.Count }
             },
-            ModelData = this.Serialize()
+            ModelData = SerializeForMetadata()
         };
     }
 

--- a/src/NeuralNetworks/EchoStateNetwork.cs
+++ b/src/NeuralNetworks/EchoStateNetwork.cs
@@ -1646,7 +1646,7 @@ public class EchoStateNetwork<T> : NeuralNetworkBase<T>
                 { "Regularization", Convert.ToDouble(_regularization) },
                 { "WarmupPeriod", _warmupPeriod }
             },
-            ModelData = this.Serialize()
+            ModelData = SerializeForMetadata()
         };
     }
 

--- a/src/NeuralNetworks/EfficientNetNetwork.cs
+++ b/src/NeuralNetworks/EfficientNetNetwork.cs
@@ -406,7 +406,7 @@ public class EfficientNetNetwork<T> : NeuralNetworkBase<T>
                 { "LayerCount", Layers.Count },
                 { "ParameterCount", GetParameterCount() }
             },
-            ModelData = this.Serialize()
+            ModelData = SerializeForMetadata()
         };
     }
 

--- a/src/NeuralNetworks/ExtremeLearningMachine.cs
+++ b/src/NeuralNetworks/ExtremeLearningMachine.cs
@@ -370,7 +370,7 @@ public class ExtremeLearningMachine<T> : NeuralNetworkBase<T>
                 { "LayerCount", Layers.Count },
                 { "ParameterCount", GetParameterCount() }
             },
-            ModelData = this.Serialize()
+            ModelData = SerializeForMetadata()
         };
     }
 

--- a/src/NeuralNetworks/FalconMambaLanguageModel.cs
+++ b/src/NeuralNetworks/FalconMambaLanguageModel.cs
@@ -152,7 +152,7 @@ public class FalconMambaLanguageModel<T> : NeuralNetworkBase<T>
                 { "MaxSeqLength", _maxSeqLength },
                 { "LayerCount", Layers.Count }
             },
-            ModelData = this.Serialize()
+            ModelData = SerializeForMetadata()
         };
     }
 

--- a/src/NeuralNetworks/FeedForwardNeuralNetwork.cs
+++ b/src/NeuralNetworks/FeedForwardNeuralNetwork.cs
@@ -521,7 +521,7 @@ public class FeedForwardNeuralNetwork<T> : NeuralNetworkBase<T>
                 { "TaskType", Architecture.TaskType.ToString() },
                 { "ParameterCount", GetParameterCount() }
             },
-            ModelData = this.Serialize()
+            ModelData = SerializeForMetadata()
         };
     }
 

--- a/src/NeuralNetworks/FinchLanguageModel.cs
+++ b/src/NeuralNetworks/FinchLanguageModel.cs
@@ -151,7 +151,7 @@ public class FinchLanguageModel<T> : NeuralNetworkBase<T>
                 { "MaxSeqLength", _maxSeqLength },
                 { "LayerCount", Layers.Count }
             },
-            ModelData = this.Serialize()
+            ModelData = SerializeForMetadata()
         };
     }
 

--- a/src/NeuralNetworks/FlamingoNeuralNetwork.cs
+++ b/src/NeuralNetworks/FlamingoNeuralNetwork.cs
@@ -1153,7 +1153,7 @@ public class FlamingoNeuralNetwork<T> : NeuralNetworkBase<T>, IFlamingoModel<T>
                 { "ParameterCount", ParameterCount },
                 { "TaskType", Architecture.TaskType.ToString() }
             },
-            ModelData = this.Serialize()
+            ModelData = SerializeForMetadata()
         };
     }
 

--- a/src/NeuralNetworks/GLALanguageModel.cs
+++ b/src/NeuralNetworks/GLALanguageModel.cs
@@ -145,7 +145,7 @@ public class GLALanguageModel<T> : NeuralNetworkBase<T>
                 { "MaxSeqLength", _maxSeqLength },
                 { "LayerCount", Layers.Count }
             },
-            ModelData = this.Serialize()
+            ModelData = SerializeForMetadata()
         };
     }
 

--- a/src/NeuralNetworks/GRUNeuralNetwork.cs
+++ b/src/NeuralNetworks/GRUNeuralNetwork.cs
@@ -368,7 +368,7 @@ public class GRUNeuralNetwork<T> : NeuralNetworkBase<T>
                 { "InputSize", Architecture.InputSize },
                 { "OutputSize", Architecture.OutputSize },
             },
-            ModelData = this.Serialize()
+            ModelData = SerializeForMetadata()
         };
     }
 

--- a/src/NeuralNetworks/GatedDeltaNetLanguageModel.cs
+++ b/src/NeuralNetworks/GatedDeltaNetLanguageModel.cs
@@ -145,7 +145,7 @@ public class GatedDeltaNetLanguageModel<T> : NeuralNetworkBase<T>
                 { "MaxSeqLength", _maxSeqLength },
                 { "LayerCount", Layers.Count }
             },
-            ModelData = this.Serialize()
+            ModelData = SerializeForMetadata()
         };
     }
 

--- a/src/NeuralNetworks/GenerativeAdversarialNetwork.cs
+++ b/src/NeuralNetworks/GenerativeAdversarialNetwork.cs
@@ -1714,7 +1714,7 @@ public class GenerativeAdversarialNetwork<T> : NeuralNetworkBase<T>, IAuxiliaryL
                 { "DiscriminatorArchitecture", Discriminator.GetModelMetadata() },
                 { "OptimizationType", "Adam" }
             },
-            ModelData = this.Serialize()
+            ModelData = SerializeForMetadata()
         };
     }
 

--- a/src/NeuralNetworks/GraphNeuralNetwork.cs
+++ b/src/NeuralNetworks/GraphNeuralNetwork.cs
@@ -910,7 +910,7 @@ public class GraphNeuralNetwork<T> : NeuralNetworkBase<T>, IAuxiliaryLossLayer<T
                 { "ParameterCount", GetParameterCount() },
                 { "ActivationTypes", string.Join(", ", GetActivationTypes()) }
             },
-            ModelData = this.Serialize()
+            ModelData = SerializeForMetadata()
         };
     }
 

--- a/src/NeuralNetworks/GriffinLanguageModel.cs
+++ b/src/NeuralNetworks/GriffinLanguageModel.cs
@@ -141,7 +141,7 @@ public class GriffinLanguageModel<T> : NeuralNetworkBase<T>
                 { "MaxSeqLength", _maxSeqLength },
                 { "LayerCount", Layers.Count }
             },
-            ModelData = this.Serialize()
+            ModelData = SerializeForMetadata()
         };
     }
 

--- a/src/NeuralNetworks/HTMNetwork.cs
+++ b/src/NeuralNetworks/HTMNetwork.cs
@@ -705,7 +705,7 @@ public class HTMNetwork<T> : NeuralNetworkBase<T>
                 { "LayerCount", Layers.Count },
                 { "TotalParameters", GetParameterCount() }
             },
-            ModelData = this.Serialize()
+            ModelData = SerializeForMetadata()
         };
     }
 

--- a/src/NeuralNetworks/HawkLanguageModel.cs
+++ b/src/NeuralNetworks/HawkLanguageModel.cs
@@ -161,7 +161,7 @@ public class HawkLanguageModel<T> : NeuralNetworkBase<T>
                 { "MaxSeqLength", _maxSeqLength },
                 { "LayerCount", Layers.Count }
             },
-            ModelData = this.Serialize()
+            ModelData = SerializeForMetadata()
         };
     }
 

--- a/src/NeuralNetworks/HopfieldNetwork.cs
+++ b/src/NeuralNetworks/HopfieldNetwork.cs
@@ -625,7 +625,7 @@ public class HopfieldNetwork<T> : NeuralNetworkBase<T>
                 { "Size", _size },
                 { "WeightMatrixShape", $"{_weights.Rows}x{_weights.Columns}" }
             },
-            ModelData = this.Serialize()
+            ModelData = SerializeForMetadata()
         };
     }
 

--- a/src/NeuralNetworks/HyperbolicNeuralNetwork.cs
+++ b/src/NeuralNetworks/HyperbolicNeuralNetwork.cs
@@ -277,7 +277,7 @@ public class HyperbolicNeuralNetwork<T> : NeuralNetworkBase<T>
                 { "TaskType", Architecture.TaskType.ToString() },
                 { "ParameterCount", GetParameterCount() }
             },
-            ModelData = this.Serialize()
+            ModelData = SerializeForMetadata()
         };
     }
 

--- a/src/NeuralNetworks/ImageBindNeuralNetwork.cs
+++ b/src/NeuralNetworks/ImageBindNeuralNetwork.cs
@@ -1710,7 +1710,7 @@ public class ImageBindNeuralNetwork<T> : NeuralNetworkBase<T>, IImageBindModel<T
                 { "SupportedModalities", _supportedModalities.Select(m => m.ToString()).ToList() },
                 { "UseNativeMode", _useNativeMode }
             },
-            ModelData = this.Serialize()
+            ModelData = SerializeForMetadata()
         };
     }
 

--- a/src/NeuralNetworks/InfoGAN.cs
+++ b/src/NeuralNetworks/InfoGAN.cs
@@ -930,7 +930,7 @@ public class InfoGAN<T> : NeuralNetworkBase<T>
                 { "LatentCodeSize", _latentCodeSize },
                 { "MutualInfoCoefficient", NumOps.ToDouble(_mutualInfoCoefficient) }
             },
-            ModelData = this.Serialize()
+            ModelData = SerializeForMetadata()
         };
     }
 

--- a/src/NeuralNetworks/JambaLanguageModel.cs
+++ b/src/NeuralNetworks/JambaLanguageModel.cs
@@ -150,7 +150,7 @@ public class JambaLanguageModel<T> : NeuralNetworkBase<T>
                 { "MaxSeqLength", _maxSeqLength },
                 { "LayerCount", Layers.Count }
             },
-            ModelData = this.Serialize()
+            ModelData = SerializeForMetadata()
         };
     }
 

--- a/src/NeuralNetworks/LLaVANeuralNetwork.cs
+++ b/src/NeuralNetworks/LLaVANeuralNetwork.cs
@@ -1345,7 +1345,7 @@ public class LLaVANeuralNetwork<T> : NeuralNetworkBase<T>, ILLaVAModel<T>
                 { "VocabularySize", _vocabularySize },
                 { "UseNativeMode", _useNativeMode }
             },
-            ModelData = this.Serialize()
+            ModelData = SerializeForMetadata()
         };
     }
 

--- a/src/NeuralNetworks/LSTMNeuralNetwork.cs
+++ b/src/NeuralNetworks/LSTMNeuralNetwork.cs
@@ -1841,7 +1841,7 @@ public class LSTMNeuralNetwork<T> : NeuralNetworkBase<T>
                 { "InputSize", Architecture.InputSize },
                 { "OutputSize", Architecture.OutputSize }
             },
-            ModelData = this.Serialize()
+            ModelData = SerializeForMetadata()
         };
     }
 

--- a/src/NeuralNetworks/Mamba2LanguageModel.cs
+++ b/src/NeuralNetworks/Mamba2LanguageModel.cs
@@ -151,7 +151,7 @@ public class Mamba2LanguageModel<T> : NeuralNetworkBase<T>
                 { "MaxSeqLength", _maxSeqLength },
                 { "LayerCount", Layers.Count }
             },
-            ModelData = this.Serialize()
+            ModelData = SerializeForMetadata()
         };
     }
 

--- a/src/NeuralNetworks/MambaLanguageModel.cs
+++ b/src/NeuralNetworks/MambaLanguageModel.cs
@@ -158,7 +158,7 @@ public class MambaLanguageModel<T> : NeuralNetworkBase<T>
                 { "MaxSeqLength", _maxSeqLength },
                 { "LayerCount", Layers.Count }
             },
-            ModelData = this.Serialize()
+            ModelData = SerializeForMetadata()
         };
     }
 

--- a/src/NeuralNetworks/MeshCNN.cs
+++ b/src/NeuralNetworks/MeshCNN.cs
@@ -494,7 +494,7 @@ public class MeshCNN<T> : NeuralNetworkBase<T>
                 { "DropoutRate", _options.DropoutRate },
                 { "LayerCount", Layers.Count }
             },
-            ModelData = this.Serialize()
+            ModelData = SerializeForMetadata()
         };
     }
 

--- a/src/NeuralNetworks/MixtureOfExpertsNeuralNetwork.cs
+++ b/src/NeuralNetworks/MixtureOfExpertsNeuralNetwork.cs
@@ -462,7 +462,7 @@ public class MixtureOfExpertsNeuralNetwork<T> : NeuralNetworkBase<T>
                 { "TaskType", Architecture.TaskType.ToString() },
                 { "ParameterCount", GetParameterCount() }
             },
-            ModelData = this.Serialize()
+            ModelData = SerializeForMetadata()
         };
     }
 

--- a/src/NeuralNetworks/MobileNetV2Network.cs
+++ b/src/NeuralNetworks/MobileNetV2Network.cs
@@ -360,7 +360,7 @@ public class MobileNetV2Network<T> : NeuralNetworkBase<T>
                 { "LayerCount", Layers.Count },
                 { "ParameterCount", GetParameterCount() }
             },
-            ModelData = this.Serialize()
+            ModelData = SerializeForMetadata()
         };
     }
 

--- a/src/NeuralNetworks/MobileNetV3Network.cs
+++ b/src/NeuralNetworks/MobileNetV3Network.cs
@@ -282,7 +282,7 @@ public class MobileNetV3Network<T> : NeuralNetworkBase<T>
                 { "LayerCount", Layers.Count },
                 { "ParameterCount", GetParameterCount() }
             },
-            ModelData = this.Serialize()
+            ModelData = SerializeForMetadata()
         };
     }
 

--- a/src/NeuralNetworks/NEAT.cs
+++ b/src/NeuralNetworks/NEAT.cs
@@ -1544,7 +1544,7 @@ public class NEAT<T> : NeuralNetworkBase<T>
                 { "BestGenomeConnections", bestGenome.Connections.Count },
                 { "BestGenomeEnabledConnections", bestGenome.Connections.Count(c => c.IsEnabled) }
             },
-            ModelData = this.Serialize()
+            ModelData = SerializeForMetadata()
         };
     }
 

--- a/src/NeuralNetworks/NeuralNetwork.cs
+++ b/src/NeuralNetworks/NeuralNetwork.cs
@@ -387,7 +387,7 @@ public class NeuralNetwork<T> : NeuralNetworkBase<T>
                 { "HiddenLayerSizes", Architecture.GetHiddenLayerSizes() },
                 { "TaskType", Architecture.TaskType.ToString() }
             },
-            ModelData = this.Serialize()
+            ModelData = SerializeForMetadata()
         };
     }
 

--- a/src/NeuralNetworks/NeuralNetworkBase.cs
+++ b/src/NeuralNetworks/NeuralNetworkBase.cs
@@ -8636,6 +8636,27 @@ public abstract class NeuralNetworkBase<T> : INeuralNetworkModel<T>, IInterpreta
     /// - Implementing feature selection techniques
     /// </para>
     /// </remarks>
+    /// <summary>
+    /// Serializes the model for embedding in <c>ModelMetadata.ModelData</c>, degrading to an EMPTY payload
+    /// when model persistence is not licensed. GetModelMetadata() is a descriptive/inspection call invoked
+    /// by <c>AiModelResult</c>'s constructor on every facade build — before this guard, the embedded
+    /// <c>this.Serialize()</c> made BUILDING any neural model through the facade throw
+    /// <see cref="AiDotNet.Exceptions.LicenseRequiredException"/> without a license, contradicting the
+    /// stated policy that training and inference remain fully available. Explicit saves
+    /// (<c>SaveModel</c>/<c>Serialize</c>) still enforce the license as before.
+    /// </summary>
+    protected byte[] SerializeForMetadata()
+    {
+        try
+        {
+            return this.Serialize();
+        }
+        catch (AiDotNet.Exceptions.LicenseRequiredException)
+        {
+            return [];
+        }
+    }
+
     public virtual void SetActiveFeatureIndices(IEnumerable<int> featureIndices)
     {
         if (featureIndices == null)

--- a/src/NeuralNetworks/NeuralTuringMachine.cs
+++ b/src/NeuralNetworks/NeuralTuringMachine.cs
@@ -2121,7 +2121,7 @@ public class NeuralTuringMachine<T> : NeuralNetworkBase<T>, IAuxiliaryLossLayer<
                 { "TotalParameters", ParameterCount },
                 { "LayerCount", Layers.Count }
             },
-            ModelData = this.Serialize()
+            ModelData = SerializeForMetadata()
         };
     }
 

--- a/src/NeuralNetworks/OccupancyNeuralNetwork.cs
+++ b/src/NeuralNetworks/OccupancyNeuralNetwork.cs
@@ -601,7 +601,7 @@ public class OccupancyNeuralNetwork<T> : NeuralNetworkBase<T>
                 { "TotalParameters", ParameterCount },
                 { "HiddenLayerSizes", Architecture.GetHiddenLayerSizes() }
             },
-            ModelData = this.Serialize()
+            ModelData = SerializeForMetadata()
         };
     }
 

--- a/src/NeuralNetworks/OctonionNeuralNetwork.cs
+++ b/src/NeuralNetworks/OctonionNeuralNetwork.cs
@@ -263,7 +263,7 @@ public class OctonionNeuralNetwork<T> : NeuralNetworkBase<T>
                 { "TaskType", Architecture.TaskType.ToString() },
                 { "ParameterCount", GetParameterCount() }
             },
-            ModelData = this.Serialize()
+            ModelData = SerializeForMetadata()
         };
     }
 

--- a/src/NeuralNetworks/Pix2Pix.cs
+++ b/src/NeuralNetworks/Pix2Pix.cs
@@ -700,7 +700,7 @@ public class Pix2Pix<T> : NeuralNetworkBase<T>
                 { "DiscriminatorParameters", Discriminator.GetParameterCount() },
                 { "L1Lambda", NumOps.ToDouble(_l1Lambda) }
             },
-            ModelData = this.Serialize()
+            ModelData = SerializeForMetadata()
         };
     }
 

--- a/src/NeuralNetworks/QuantumNeuralNetwork.cs
+++ b/src/NeuralNetworks/QuantumNeuralNetwork.cs
@@ -330,7 +330,7 @@ public class QuantumNeuralNetwork<T> : NeuralNetworkBase<T>
                 { "LayerTypes", Layers.Select(l => l.GetType().Name).ToArray() },
                 { "NumberOfQubits", _numQubits }
             },
-            ModelData = this.Serialize()
+            ModelData = SerializeForMetadata()
         };
     }
 

--- a/src/NeuralNetworks/RWKV4LanguageModel.cs
+++ b/src/NeuralNetworks/RWKV4LanguageModel.cs
@@ -210,7 +210,7 @@ public class RWKV4LanguageModel<T> : NeuralNetworkBase<T>
                 { "TotalParameters", ParameterCount },
                 { "LayerCount", Layers.Count }
             },
-            ModelData = this.Serialize()
+            ModelData = SerializeForMetadata()
         };
     }
 

--- a/src/NeuralNetworks/RWKV7LanguageModel.cs
+++ b/src/NeuralNetworks/RWKV7LanguageModel.cs
@@ -161,7 +161,7 @@ public class RWKV7LanguageModel<T> : NeuralNetworkBase<T>
                 { "MaxSeqLength", _maxSeqLength },
                 { "LayerCount", Layers.Count }
             },
-            ModelData = this.Serialize()
+            ModelData = SerializeForMetadata()
         };
     }
 

--- a/src/NeuralNetworks/RadialBasisFunctionNetwork.cs
+++ b/src/NeuralNetworks/RadialBasisFunctionNetwork.cs
@@ -468,7 +468,7 @@ public class RadialBasisFunctionNetwork<T> : NeuralNetworkBase<T>
                 { "OutputSize", _outputSize },
                 { "RadialBasisFunction", _radialBasisFunction.GetType().Name }
             },
-            ModelData = this.Serialize()
+            ModelData = SerializeForMetadata()
         };
 
         return metadata;

--- a/src/NeuralNetworks/RecurrentGemmaLanguageModel.cs
+++ b/src/NeuralNetworks/RecurrentGemmaLanguageModel.cs
@@ -140,7 +140,7 @@ public class RecurrentGemmaLanguageModel<T> : NeuralNetworkBase<T>
                 { "MaxSeqLength", _maxSeqLength },
                 { "LayerCount", Layers.Count }
             },
-            ModelData = this.Serialize()
+            ModelData = SerializeForMetadata()
         };
     }
 

--- a/src/NeuralNetworks/RecurrentNeuralNetwork.cs
+++ b/src/NeuralNetworks/RecurrentNeuralNetwork.cs
@@ -374,7 +374,7 @@ public class RecurrentNeuralNetwork<T> : NeuralNetworkBase<T>
                 { "InputShape", Architecture.GetInputShape() },
                 { "OutputShape", Architecture.GetOutputShape() },
             },
-            ModelData = this.Serialize()
+            ModelData = SerializeForMetadata()
         };
 
         return metadata;

--- a/src/NeuralNetworks/ResNetNetwork.cs
+++ b/src/NeuralNetworks/ResNetNetwork.cs
@@ -586,7 +586,7 @@ public class ResNetNetwork<T> : NeuralNetworkBase<T>
                 { "NumWeightLayers", _configuration.NumWeightLayers },
                 { "ZeroInitResidual", _configuration.ZeroInitResidual }
             },
-            ModelData = this.Serialize()
+            ModelData = SerializeForMetadata()
         };
     }
 

--- a/src/NeuralNetworks/ResidualNeuralNetwork.cs
+++ b/src/NeuralNetworks/ResidualNeuralNetwork.cs
@@ -742,7 +742,7 @@ finally
                 { "InputSize", Architecture.CalculatedInputSize },
                 { "OutputSize", Architecture.CalculateOutputSize() }
             },
-            ModelData = this.Serialize()
+            ModelData = SerializeForMetadata()
         };
     }
 

--- a/src/NeuralNetworks/RestrictedBoltzmannMachine.cs
+++ b/src/NeuralNetworks/RestrictedBoltzmannMachine.cs
@@ -1233,7 +1233,7 @@ public class RestrictedBoltzmannMachine<T> : NeuralNetworkBase<T>
                 { "LearningRate", Convert.ToDouble(_learningRate) },
                 { "CDSteps", _cdSteps }
             },
-            ModelData = this.Serialize()
+            ModelData = SerializeForMetadata()
         };
     }
 

--- a/src/NeuralNetworks/SambaLanguageModel.cs
+++ b/src/NeuralNetworks/SambaLanguageModel.cs
@@ -150,7 +150,7 @@ public class SambaLanguageModel<T> : NeuralNetworkBase<T>
                 { "MaxSeqLength", _maxSeqLength },
                 { "LayerCount", Layers.Count }
             },
-            ModelData = this.Serialize()
+            ModelData = SerializeForMetadata()
         };
     }
 

--- a/src/NeuralNetworks/SelfOrganizingMap.cs
+++ b/src/NeuralNetworks/SelfOrganizingMap.cs
@@ -777,7 +777,7 @@ public class SelfOrganizingMap<T> : NeuralNetworkBase<T>
                 { "TotalEpochs", _totalEpochs },
                 { "CurrentEpoch", _currentEpoch }
             },
-            ModelData = this.Serialize()
+            ModelData = SerializeForMetadata()
         };
     }
 

--- a/src/NeuralNetworks/SiameseNetwork.cs
+++ b/src/NeuralNetworks/SiameseNetwork.cs
@@ -701,7 +701,7 @@ public class SiameseNetwork<T> : NeuralNetworkBase<T>, IAuxiliaryLossLayer<T>
                 { "TotalParameters", GetParameterCount() },
                 { "InputShape", string.Join(",", Architecture.GetInputShape()) }
             },
-            ModelData = this.Serialize()
+            ModelData = SerializeForMetadata()
         };
 
         return metadata;

--- a/src/NeuralNetworks/SparseNeuralNetwork.cs
+++ b/src/NeuralNetworks/SparseNeuralNetwork.cs
@@ -440,7 +440,7 @@ public class SparseNeuralNetwork<T> : NeuralNetworkBase<T>
                 { "TaskType", Architecture.TaskType.ToString() },
                 { "ParameterCount", GetParameterCount() }
             },
-            ModelData = this.Serialize()
+            ModelData = SerializeForMetadata()
         };
     }
 

--- a/src/NeuralNetworks/SpikingNeuralNetwork.cs
+++ b/src/NeuralNetworks/SpikingNeuralNetwork.cs
@@ -1187,7 +1187,7 @@ public class SpikingNeuralNetwork<T> : NeuralNetworkBase<T>
                 { "OutputSize", Architecture.OutputSize },
                 { "HiddenLayerSizes", Architecture.GetHiddenLayerSizes() }
             },
-            ModelData = this.Serialize()
+            ModelData = SerializeForMetadata()
         };
     }
 

--- a/src/NeuralNetworks/SpiralNet.cs
+++ b/src/NeuralNetworks/SpiralNet.cs
@@ -564,7 +564,7 @@ public class SpiralNet<T> : NeuralNetworkBase<T>
                 { "DropoutRate", _options.DropoutRate },
                 { "LayerCount", Layers.Count }
             },
-            ModelData = this.Serialize()
+            ModelData = SerializeForMetadata()
         };
     }
 

--- a/src/NeuralNetworks/StyleGAN.cs
+++ b/src/NeuralNetworks/StyleGAN.cs
@@ -860,7 +860,7 @@ public class StyleGAN<T> : NeuralNetworkBase<T>
                 { "IntermediateLatentSize", _intermediateLatentSize },
                 { "StyleMixingEnabled", _enableStyleMixing }
             },
-            ModelData = this.Serialize()
+            ModelData = SerializeForMetadata()
         };
     }
 

--- a/src/NeuralNetworks/SyntheticData/AutoDiffTabGenerator.cs
+++ b/src/NeuralNetworks/SyntheticData/AutoDiffTabGenerator.cs
@@ -824,7 +824,7 @@ public class AutoDiffTabGenerator<T> : NeuralNetworkBase<T>, ISyntheticTabularGe
                 { "DenoiserLayerCount", Layers.Count },
                 { "DenoiserLayerTypes", Layers.Select(l => l.GetType().Name).ToArray() }
             },
-            ModelData = this.Serialize()
+            ModelData = SerializeForMetadata()
         };
     }
 

--- a/src/NeuralNetworks/SyntheticData/CTABGANPlusGenerator.cs
+++ b/src/NeuralNetworks/SyntheticData/CTABGANPlusGenerator.cs
@@ -961,7 +961,7 @@ public class CTABGANPlusGenerator<T> : NeuralNetworkBase<T>, ISyntheticTabularGe
                 { "GeneratorLayerCount", Layers.Count },
                 { "GeneratorLayerTypes", Layers.Select(l => l.GetType().Name).ToArray() }
             },
-            ModelData = this.Serialize()
+            ModelData = SerializeForMetadata()
         };
     }
 

--- a/src/NeuralNetworks/SyntheticData/CTGANGenerator.cs
+++ b/src/NeuralNetworks/SyntheticData/CTGANGenerator.cs
@@ -1214,7 +1214,7 @@ public class CTGANGenerator<T> : NeuralNetworkBase<T>, ISyntheticTabularGenerato
                 { "GeneratorLayerCount", Layers.Count },
                 { "GeneratorLayerTypes", Layers.Select(l => l.GetType().Name).ToArray() }
             },
-            ModelData = this.Serialize()
+            ModelData = SerializeForMetadata()
         };
     }
 

--- a/src/NeuralNetworks/SyntheticData/CausalGANGenerator.cs
+++ b/src/NeuralNetworks/SyntheticData/CausalGANGenerator.cs
@@ -1226,7 +1226,7 @@ public class CausalGANGenerator<T> : NeuralNetworkBase<T>, ISyntheticTabularGene
                 { "GeneratorLayerCount", Layers.Count },
                 { "GeneratorLayerTypes", Layers.Select(l => l.GetType().Name).ToArray() }
             },
-            ModelData = this.Serialize()
+            ModelData = SerializeForMetadata()
         };
     }
 

--- a/src/NeuralNetworks/SyntheticData/CopulaGANGenerator.cs
+++ b/src/NeuralNetworks/SyntheticData/CopulaGANGenerator.cs
@@ -1382,7 +1382,7 @@ public class CopulaGANGenerator<T> : NeuralNetworkBase<T>, ISyntheticTabularGene
                 { "GeneratorLayerCount", Layers.Count },
                 { "GeneratorLayerTypes", Layers.Select(l => l.GetType().Name).ToArray() }
             },
-            ModelData = this.Serialize()
+            ModelData = SerializeForMetadata()
         };
     }
 

--- a/src/NeuralNetworks/SyntheticData/DPCTGANGenerator.cs
+++ b/src/NeuralNetworks/SyntheticData/DPCTGANGenerator.cs
@@ -1292,7 +1292,7 @@ public class DPCTGANGenerator<T> : NeuralNetworkBase<T>, ISyntheticTabularGenera
                 { "GeneratorLayerCount", Layers.Count },
                 { "GeneratorLayerTypes", Layers.Select(l => l.GetType().Name).ToArray() }
             },
-            ModelData = this.Serialize()
+            ModelData = SerializeForMetadata()
         };
     }
 

--- a/src/NeuralNetworks/SyntheticData/FinDiffGenerator.cs
+++ b/src/NeuralNetworks/SyntheticData/FinDiffGenerator.cs
@@ -596,7 +596,7 @@ public class FinDiffGenerator<T> : NeuralNetworkBase<T>, ISyntheticTabularGenera
                 { "LayerCount", Layers.Count },
                 { "LayerTypes", Layers.Select(l => l.GetType().Name).ToArray() }
             },
-            ModelData = this.Serialize()
+            ModelData = SerializeForMetadata()
         };
     }
 

--- a/src/NeuralNetworks/SyntheticData/TVAEGenerator.cs
+++ b/src/NeuralNetworks/SyntheticData/TVAEGenerator.cs
@@ -775,7 +775,7 @@ public class TVAEGenerator<T> : NeuralNetworkBase<T>, ISyntheticTabularGenerator
                 { "DecoderLayerCount", _decoderLayers.Count },
                 { "EncoderLayerTypes", Layers.Select(l => l.GetType().Name).ToArray() }
             },
-            ModelData = this.Serialize()
+            ModelData = SerializeForMetadata()
         };
     }
 

--- a/src/NeuralNetworks/SyntheticData/TabDDPMGenerator.cs
+++ b/src/NeuralNetworks/SyntheticData/TabDDPMGenerator.cs
@@ -964,7 +964,7 @@ public class TabDDPMGenerator<T> : NeuralNetworkBase<T>, ISyntheticTabularGenera
                 { "DenoiserLayerCount", Layers.Count },
                 { "DenoiserLayerTypes", Layers.Select(l => l.GetType().Name).ToArray() }
             },
-            ModelData = this.Serialize()
+            ModelData = SerializeForMetadata()
         };
     }
 

--- a/src/NeuralNetworks/SyntheticData/TabFlowGenerator.cs
+++ b/src/NeuralNetworks/SyntheticData/TabFlowGenerator.cs
@@ -716,7 +716,7 @@ public class TabFlowGenerator<T> : NeuralNetworkBase<T>, ISyntheticTabularGenera
                 { "LayerCount", Layers.Count },
                 { "LayerTypes", Layers.Select(l => l.GetType().Name).ToArray() }
             },
-            ModelData = this.Serialize()
+            ModelData = SerializeForMetadata()
         };
     }
 

--- a/src/NeuralNetworks/SyntheticData/TabSynGenerator.cs
+++ b/src/NeuralNetworks/SyntheticData/TabSynGenerator.cs
@@ -978,7 +978,7 @@ public class TabSynGenerator<T> : NeuralNetworkBase<T>, ISyntheticTabularGenerat
                 { "EncoderLayerCount", Layers.Count },
                 { "EncoderLayerTypes", Layers.Select(l => l.GetType().Name).ToArray() }
             },
-            ModelData = this.Serialize()
+            ModelData = SerializeForMetadata()
         };
     }
 

--- a/src/NeuralNetworks/Tabular/AutoIntNetwork.cs
+++ b/src/NeuralNetworks/Tabular/AutoIntNetwork.cs
@@ -228,7 +228,7 @@ public class AutoIntNetwork<T> : NeuralNetworkBase<T>
                 { "LayerCount", Layers.Count },
                 { "LayerTypes", Layers.Select(l => l.GetType().Name).ToArray() }
             },
-            ModelData = this.Serialize()
+            ModelData = SerializeForMetadata()
         };
     }
 

--- a/src/NeuralNetworks/Tabular/FTTransformerNetwork.cs
+++ b/src/NeuralNetworks/Tabular/FTTransformerNetwork.cs
@@ -249,7 +249,7 @@ public class FTTransformerNetwork<T> : NeuralNetworkBase<T>
                 { "LayerCount", Layers.Count },
                 { "LayerTypes", Layers.Select(l => l.GetType().Name).ToArray() }
             },
-            ModelData = this.Serialize()
+            ModelData = SerializeForMetadata()
         };
     }
 

--- a/src/NeuralNetworks/Tabular/GANDALFNetwork.cs
+++ b/src/NeuralNetworks/Tabular/GANDALFNetwork.cs
@@ -389,7 +389,7 @@ public class GANDALFNetwork<T> : NeuralNetworkBase<T>
                 { "LayerCount", Layers.Count },
                 { "LayerTypes", Layers.Select(l => l.GetType().Name).ToArray() }
             },
-            ModelData = this.Serialize()
+            ModelData = SerializeForMetadata()
         };
     }
 

--- a/src/NeuralNetworks/Tabular/MambularNetwork.cs
+++ b/src/NeuralNetworks/Tabular/MambularNetwork.cs
@@ -222,7 +222,7 @@ public class MambularNetwork<T> : NeuralNetworkBase<T>
                 { "LayerCount", Layers.Count },
                 { "LayerTypes", Layers.Select(l => l.GetType().Name).ToArray() }
             },
-            ModelData = this.Serialize()
+            ModelData = SerializeForMetadata()
         };
     }
 

--- a/src/NeuralNetworks/Tabular/NODENetwork.cs
+++ b/src/NeuralNetworks/Tabular/NODENetwork.cs
@@ -269,7 +269,7 @@ public class NODENetwork<T> : NeuralNetworkBase<T>
                 { "LayerCount", Layers.Count },
                 { "LayerTypes", Layers.Select(l => l.GetType().Name).ToArray() }
             },
-            ModelData = this.Serialize()
+            ModelData = SerializeForMetadata()
         };
     }
 

--- a/src/NeuralNetworks/Tabular/SAINTNetwork.cs
+++ b/src/NeuralNetworks/Tabular/SAINTNetwork.cs
@@ -402,7 +402,7 @@ public class SAINTNetwork<T> : NeuralNetworkBase<T>
                 { "LayerCount", Layers.Count },
                 { "LayerTypes", Layers.Select(l => l.GetType().Name).ToArray() }
             },
-            ModelData = this.Serialize()
+            ModelData = SerializeForMetadata()
         };
     }
 

--- a/src/NeuralNetworks/Tabular/TabDPTNetwork.cs
+++ b/src/NeuralNetworks/Tabular/TabDPTNetwork.cs
@@ -224,7 +224,7 @@ public class TabDPTNetwork<T> : NeuralNetworkBase<T>
                 { "LayerCount", Layers.Count },
                 { "LayerTypes", Layers.Select(l => l.GetType().Name).ToArray() }
             },
-            ModelData = this.Serialize()
+            ModelData = SerializeForMetadata()
         };
     }
 

--- a/src/NeuralNetworks/Tabular/TabMNetwork.cs
+++ b/src/NeuralNetworks/Tabular/TabMNetwork.cs
@@ -209,7 +209,7 @@ public class TabMNetwork<T> : NeuralNetworkBase<T>
                 { "LayerCount", Layers.Count },
                 { "LayerTypes", Layers.Select(l => l.GetType().Name).ToArray() }
             },
-            ModelData = this.Serialize()
+            ModelData = SerializeForMetadata()
         };
     }
 

--- a/src/NeuralNetworks/Tabular/TabNetNetwork.cs
+++ b/src/NeuralNetworks/Tabular/TabNetNetwork.cs
@@ -220,7 +220,7 @@ public class TabNetNetwork<T> : NeuralNetworkBase<T>
                 { "LayerCount", Layers.Count },
                 { "LayerTypes", Layers.Select(l => l.GetType().Name).ToArray() }
             },
-            ModelData = this.Serialize()
+            ModelData = SerializeForMetadata()
         };
     }
 

--- a/src/NeuralNetworks/Tabular/TabPFNNetwork.cs
+++ b/src/NeuralNetworks/Tabular/TabPFNNetwork.cs
@@ -229,7 +229,7 @@ public class TabPFNNetwork<T> : NeuralNetworkBase<T>
                 { "LayerCount", Layers.Count },
                 { "LayerTypes", Layers.Select(l => l.GetType().Name).ToArray() }
             },
-            ModelData = this.Serialize()
+            ModelData = SerializeForMetadata()
         };
     }
 

--- a/src/NeuralNetworks/Tabular/TabRNetwork.cs
+++ b/src/NeuralNetworks/Tabular/TabRNetwork.cs
@@ -233,7 +233,7 @@ public class TabRNetwork<T> : NeuralNetworkBase<T>
                 { "LayerCount", Layers.Count },
                 { "LayerTypes", Layers.Select(l => l.GetType().Name).ToArray() }
             },
-            ModelData = this.Serialize()
+            ModelData = SerializeForMetadata()
         };
     }
 

--- a/src/NeuralNetworks/Tabular/TabTransformerNetwork.cs
+++ b/src/NeuralNetworks/Tabular/TabTransformerNetwork.cs
@@ -419,7 +419,7 @@ public class TabTransformerNetwork<T> : NeuralNetworkBase<T>
                 { "LayerCount", Layers.Count },
                 { "LayerTypes", Layers.Select(l => l.GetType().Name).ToArray() }
             },
-            ModelData = this.Serialize()
+            ModelData = SerializeForMetadata()
         };
     }
 

--- a/src/NeuralNetworks/Transformer.cs
+++ b/src/NeuralNetworks/Transformer.cs
@@ -979,7 +979,7 @@ public class Transformer<T> : NeuralNetworkBase<T>, IAuxiliaryLossLayer<T>
                 { "LossFunction", LossFunction.GetType().Name },
                 { "Optimizer", _optimizer.GetType().Name }
             },
-            ModelData = this.Serialize()
+            ModelData = SerializeForMetadata()
         };
     }
 

--- a/src/NeuralNetworks/UNet3D.cs
+++ b/src/NeuralNetworks/UNet3D.cs
@@ -314,7 +314,7 @@ public class UNet3D<T> : NeuralNetworkBase<T>
                 { "LayerCount", Layers.Count },
                 { "LayerTypes", Layers.Select(l => l.GetType().Name).ToArray() }
             },
-            ModelData = this.Serialize()
+            ModelData = SerializeForMetadata()
         };
     }
 

--- a/src/NeuralNetworks/VGGNetwork.cs
+++ b/src/NeuralNetworks/VGGNetwork.cs
@@ -477,7 +477,7 @@ public class VGGNetwork<T> : NeuralNetworkBase<T>
                 { "NumWeightLayers", _configuration.NumWeightLayers },
                 { "DropoutRate", _configuration.DropoutRate }
             },
-            ModelData = this.Serialize()
+            ModelData = SerializeForMetadata()
         };
     }
 

--- a/src/NeuralNetworks/VariationalAutoencoder.cs
+++ b/src/NeuralNetworks/VariationalAutoencoder.cs
@@ -880,7 +880,7 @@ public class VariationalAutoencoder<T> : NeuralNetworkBase<T>, IAuxiliaryLossLay
                 { "EncoderLayers", Layers.Take(Layers.Count / 2).Select(l => l.GetType().Name).ToArray() },
                 { "DecoderLayers", Layers.Skip(Layers.Count / 2).Select(l => l.GetType().Name).ToArray() }
             },
-            ModelData = this.Serialize()
+            ModelData = SerializeForMetadata()
         };
     }
 

--- a/src/NeuralNetworks/VideoCLIPNeuralNetwork.cs
+++ b/src/NeuralNetworks/VideoCLIPNeuralNetwork.cs
@@ -1796,7 +1796,7 @@ public class VideoCLIPNeuralNetwork<T> : NeuralNetworkBase<T>, IVideoCLIPModel<T
                 { "VocabularySize", _vocabularySize },
                 { "UseNativeMode", _useNativeMode }
             },
-            ModelData = this.Serialize()
+            ModelData = SerializeForMetadata()
         };
     }
 

--- a/src/NeuralNetworks/VisionMambaModel.cs
+++ b/src/NeuralNetworks/VisionMambaModel.cs
@@ -378,7 +378,7 @@ public class VisionMambaModel<T> : NeuralNetworkBase<T>
                 { "NumPatches", _numPatches },
                 { "LayerCount", Layers.Count }
             },
-            ModelData = this.Serialize()
+            ModelData = SerializeForMetadata()
         };
     }
 

--- a/src/NeuralNetworks/VoxelCNN.cs
+++ b/src/NeuralNetworks/VoxelCNN.cs
@@ -361,7 +361,7 @@ public class VoxelCNN<T> : NeuralNetworkBase<T>
                 { "LayerCount", Layers.Count },
                 { "LayerTypes", Layers.Select(l => l.GetType().Name).ToArray() }
             },
-            ModelData = this.Serialize()
+            ModelData = SerializeForMetadata()
         };
     }
 

--- a/src/NeuralNetworks/WGAN.cs
+++ b/src/NeuralNetworks/WGAN.cs
@@ -634,7 +634,7 @@ public class WGAN<T> : NeuralNetworkBase<T>
                 { "WeightClipValue", _weightClipValue },
                 { "CriticIterations", _criticIterations }
             },
-            ModelData = this.Serialize()
+            ModelData = SerializeForMetadata()
         };
     }
 

--- a/src/NeuralNetworks/WGANGP.cs
+++ b/src/NeuralNetworks/WGANGP.cs
@@ -655,7 +655,7 @@ public class WGANGP<T> : NeuralNetworkBase<T>
                 { "GradientPenaltyCoefficient", _gradientPenaltyCoefficient },
                 { "CriticIterations", _criticIterations }
             },
-            ModelData = this.Serialize()
+            ModelData = SerializeForMetadata()
         };
     }
 

--- a/src/NeuralNetworks/XLSTMLanguageModel.cs
+++ b/src/NeuralNetworks/XLSTMLanguageModel.cs
@@ -145,7 +145,7 @@ public class XLSTMLanguageModel<T> : NeuralNetworkBase<T>
                 { "MaxSeqLength", _maxSeqLength },
                 { "LayerCount", Layers.Count }
             },
-            ModelData = this.Serialize()
+            ModelData = SerializeForMetadata()
         };
     }
 

--- a/src/NeuralNetworks/Zamba2LanguageModel.cs
+++ b/src/NeuralNetworks/Zamba2LanguageModel.cs
@@ -154,7 +154,7 @@ public class Zamba2LanguageModel<T> : NeuralNetworkBase<T>
                 { "MaxSeqLength", _maxSeqLength },
                 { "LayerCount", Layers.Count }
             },
-            ModelData = this.Serialize()
+            ModelData = SerializeForMetadata()
         };
     }
 

--- a/src/NeuralNetworks/ZambaLanguageModel.cs
+++ b/src/NeuralNetworks/ZambaLanguageModel.cs
@@ -150,7 +150,7 @@ public class ZambaLanguageModel<T> : NeuralNetworkBase<T>
                 { "MaxSeqLength", _maxSeqLength },
                 { "LayerCount", Layers.Count }
             },
-            ModelData = this.Serialize()
+            ModelData = SerializeForMetadata()
         };
     }
 

--- a/src/PointCloud/Models/DGCNN.cs
+++ b/src/PointCloud/Models/DGCNN.cs
@@ -502,7 +502,7 @@ public class DGCNN<T> : NeuralNetworkBase<T>, IPointCloudModel<T>, IPointCloudCl
                 { "TotalLayers", Layers.Count },
                 { "TaskType", Architecture.TaskType.ToString() }
             },
-            ModelData = this.Serialize()
+            ModelData = SerializeForMetadata()
         };
     }
 

--- a/src/PointCloud/Models/PointNet.cs
+++ b/src/PointCloud/Models/PointNet.cs
@@ -423,7 +423,7 @@ public class PointNet<T> : NeuralNetworkBase<T>, IPointCloudModel<T>, IPointClou
                 { "TotalLayers", Layers.Count },
                 { "TaskType", Architecture.TaskType.ToString() }
             },
-            ModelData = this.Serialize()
+            ModelData = SerializeForMetadata()
         };
     }
 

--- a/src/PointCloud/Models/PointNetPlusPlus.cs
+++ b/src/PointCloud/Models/PointNetPlusPlus.cs
@@ -575,7 +575,7 @@ public class PointNetPlusPlus<T> : NeuralNetworkBase<T>, IPointCloudModel<T>, IP
                 { "TotalLayers", Layers.Count },
                 { "TaskType", Architecture.TaskType.ToString() }
             },
-            ModelData = this.Serialize()
+            ModelData = SerializeForMetadata()
         };
     }
 

--- a/src/TimeSeries/ARIMAModel.cs
+++ b/src/TimeSeries/ARIMAModel.cs
@@ -813,7 +813,7 @@ public class ARIMAModel<T> : TimeSeriesModelBase<T>
                 // Additional settings from options
                 { "LagOrder", _arimaOptions.LagOrder }
             },
-            ModelData = this.Serialize()
+            ModelData = SerializeForMetadata()
         };
 
         return metadata;

--- a/src/TimeSeries/ARIMAXModel.cs
+++ b/src/TimeSeries/ARIMAXModel.cs
@@ -718,7 +718,7 @@ public class ARIMAXModel<T> : TimeSeriesModelBase<T>
                 { "ExogenousVariables", arimaxOptions.ExogenousVariables },
                 { "DecompositionType", arimaxOptions.DecompositionType }
             },
-            ModelData = this.Serialize()
+            ModelData = SerializeForMetadata()
         };
 
         return metadata;

--- a/src/TimeSeries/ARMAModel.cs
+++ b/src/TimeSeries/ARMAModel.cs
@@ -673,7 +673,7 @@ public class ARMAModel<T> : TimeSeriesModelBase<T>
                 { "MaxIterations", armaOptions.MaxIterations },
                 { "Tolerance", armaOptions.Tolerance }
             },
-            ModelData = this.Serialize()
+            ModelData = SerializeForMetadata()
         };
         return metadata;
     }

--- a/src/TimeSeries/ARModel.cs
+++ b/src/TimeSeries/ARModel.cs
@@ -565,7 +565,7 @@ public class ARModel<T> : TimeSeriesModelBase<T>
                 { "MaxIterations", arOptions.MaxIterations },
                 { "Tolerance", arOptions.Tolerance }
             },
-            ModelData = this.Serialize()
+            ModelData = SerializeForMetadata()
         };
         return metadata;
     }

--- a/src/TimeSeries/BayesianStructuralTimeSeriesModel.cs
+++ b/src/TimeSeries/BayesianStructuralTimeSeriesModel.cs
@@ -1390,7 +1390,7 @@ public class BayesianStructuralTimeSeriesModel<T> : TimeSeriesModelBase<T>
                 { "RidgeParameter", bstsOptions.RidgeParameter },
                 { "RegressionDecompositionType", bstsOptions.RegressionDecompositionType.ToString() }
             },
-            ModelData = this.Serialize()
+            ModelData = SerializeForMetadata()
         };
         return metadata;
     }

--- a/src/TimeSeries/DynamicRegressionWithARIMAErrors.cs
+++ b/src/TimeSeries/DynamicRegressionWithARIMAErrors.cs
@@ -1570,7 +1570,7 @@ public class DynamicRegressionWithARIMAErrors<T> : TimeSeriesModelBase<T>
                 { "DecompositionType", options.DecompositionType },
                 { "Regularization", options.Regularization?.GetType().Name ?? "None" }
             },
-            ModelData = this.Serialize()
+            ModelData = SerializeForMetadata()
         };
 
         return metadata;

--- a/src/TimeSeries/ExponentialSmoothingModel.cs
+++ b/src/TimeSeries/ExponentialSmoothingModel.cs
@@ -873,7 +873,7 @@ public class ExponentialSmoothingModel<T> : TimeSeriesModelBase<T>
                 { "UseSeasonal", EsOptions.UseSeasonal },
                 { "SeasonalPeriod", EsOptions.SeasonalPeriod }
             },
-            ModelData = this.Serialize()
+            ModelData = SerializeForMetadata()
         };
 
         return metadata;

--- a/src/TimeSeries/GARCHModel.cs
+++ b/src/TimeSeries/GARCHModel.cs
@@ -1048,7 +1048,7 @@ public class GARCHModel<T> : TimeSeriesModelBase<T>
                 { "GARCHOrder", _garchOptions.GARCHOrder },
                 { "UseMeanModel", _meanModel != null },
             },
-            ModelData = this.Serialize()
+            ModelData = SerializeForMetadata()
         };
         return metadata;
     }

--- a/src/TimeSeries/InterventionAnalysisModel.cs
+++ b/src/TimeSeries/InterventionAnalysisModel.cs
@@ -841,7 +841,7 @@ public class InterventionAnalysisModel<T> : TimeSeriesModelBase<T>
                 { "MAOrder", _iaOptions.MAOrder },
                 { "InterventionCount", _iaOptions.Interventions.Count },
             },
-            ModelData = this.Serialize()
+            ModelData = SerializeForMetadata()
         };
 
         return metadata;

--- a/src/TimeSeries/MAModel.cs
+++ b/src/TimeSeries/MAModel.cs
@@ -1128,7 +1128,7 @@ public class MAModel<T> : TimeSeriesModelBase<T>
                 // Add specific coefficient values for inspection
                 { "MACoefficients", _maCoefficients.Select(c => Convert.ToDouble(c)).ToArray() }
             },
-            ModelData = this.Serialize()
+            ModelData = SerializeForMetadata()
         };
 
         return metadata;

--- a/src/TimeSeries/NeuralNetworkARIMAModel.cs
+++ b/src/TimeSeries/NeuralNetworkARIMAModel.cs
@@ -945,7 +945,7 @@ public class NeuralNetworkARIMAModel<T> : TimeSeriesModelBase<T>
                 { "AR Parameters", _arParameters },
                 { "MA Parameters", _maParameters }
             },
-            ModelData = this.Serialize()
+            ModelData = SerializeForMetadata()
         };
 
         return metaData;

--- a/src/TimeSeries/ProphetModel.cs
+++ b/src/TimeSeries/ProphetModel.cs
@@ -1264,7 +1264,7 @@ public class ProphetModel<T, TInput, TOutput> : TimeSeriesModelBase<T>
         metadata.AdditionalInfo["StateSize"] = GetStateSize();
 
         // Include serialized model data
-        metadata.ModelData = this.Serialize();
+        metadata.ModelData = SerializeForMetadata();
 
         return metadata;
     }

--- a/src/TimeSeries/SARIMAModel.cs
+++ b/src/TimeSeries/SARIMAModel.cs
@@ -986,7 +986,7 @@ public class SARIMAModel<T> : TimeSeriesModelBase<T>
                 { "MaxIterations", _sarimaOptions.MaxIterations },
                 { "Tolerance", _sarimaOptions.Tolerance }
             },
-            ModelData = this.Serialize()
+            ModelData = SerializeForMetadata()
         };
 
         return metadata;

--- a/src/TimeSeries/STLDecomposition.cs
+++ b/src/TimeSeries/STLDecomposition.cs
@@ -1060,7 +1060,7 @@ public class STLDecomposition<T> : TimeSeriesModelBase<T>
                 { "SeasonalStrength", Convert.ToDouble(CalculateSeasonalStrength()) },
                 { "TrendStrength", Convert.ToDouble(CalculateTrendStrength()) }
             },
-            ModelData = this.Serialize()
+            ModelData = SerializeForMetadata()
         };
 
         return metadata;

--- a/src/TimeSeries/SpectralAnalysisModel.cs
+++ b/src/TimeSeries/SpectralAnalysisModel.cs
@@ -651,7 +651,7 @@ public class SpectralAnalysisModel<T> : TimeSeriesModelBase<T>
         }
 
         // Add the serialized model data
-        metadata.ModelData = this.Serialize();
+        metadata.ModelData = SerializeForMetadata();
 
         return metadata;
     }

--- a/src/TimeSeries/StateSpaceModel.cs
+++ b/src/TimeSeries/StateSpaceModel.cs
@@ -779,7 +779,7 @@ public class StateSpaceModel<T> : TimeSeriesModelBase<T>
                 { "ProcessNoiseDimensions", $"{_processNoise.Rows}x{_processNoise.Columns}" },
                 { "ObservationNoiseDimensions", $"{_observationNoise.Rows}x{_observationNoise.Columns}" }
             },
-            ModelData = this.Serialize()
+            ModelData = SerializeForMetadata()
         };
 
         return metadata;

--- a/src/TimeSeries/TBATSModel.cs
+++ b/src/TimeSeries/TBATSModel.cs
@@ -1270,7 +1270,7 @@ public class TBATSModel<T> : TimeSeriesModelBase<T>
                 { "LastLevel", _level.Length > 0 ? Convert.ToDouble(_level[_level.Length - 1]) : 0 },
                 { "LastTrend", _trend.Length > 0 ? Convert.ToDouble(_trend[_trend.Length - 1]) : 0 }
             },
-            ModelData = this.Serialize()
+            ModelData = SerializeForMetadata()
         };
 
         return metadata;

--- a/src/TimeSeries/TimeSeriesModelBase.cs
+++ b/src/TimeSeries/TimeSeriesModelBase.cs
@@ -721,6 +721,23 @@ public abstract class TimeSeriesModelBase<T> : ITimeSeriesModel<T>, IConfigurabl
     /// which can save significant time for complex models trained on large datasets.
     /// </para>
     /// </remarks>
+    /// <summary>
+    /// Serializes the model for embedding in <c>ModelMetadata.ModelData</c>, degrading to an EMPTY payload
+    /// when persistence is not licensed — GetModelMetadata() is a descriptive call (invoked by the facade
+    /// result constructor on every build) and must not require a license; explicit saves still enforce it.
+    /// </summary>
+    protected byte[] SerializeForMetadata()
+    {
+        try
+        {
+            return this.Serialize();
+        }
+        catch (AiDotNet.Exceptions.LicenseRequiredException)
+        {
+            return [];
+        }
+    }
+
     public virtual byte[] Serialize()
     {
         ModelPersistenceGuard.EnforceBeforeSerialize();

--- a/src/TimeSeries/TransferFunctionModel.cs
+++ b/src/TimeSeries/TransferFunctionModel.cs
@@ -717,7 +717,7 @@ public class TransferFunctionModel<T> : TimeSeriesModelBase<T>
                 { "ResidualsMean", _residuals.Length > 0 ? Convert.ToDouble(_residuals.Mean()) : 0.0 },
                 { "ResidualsStdDev", _residuals.Length > 0 ? Convert.ToDouble(_residuals.StandardDeviation()) : 0.0 }
             },
-            ModelData = this.Serialize()
+            ModelData = SerializeForMetadata()
         };
 
         return metadata;

--- a/src/TimeSeries/UnobservedComponentsModel.cs
+++ b/src/TimeSeries/UnobservedComponentsModel.cs
@@ -1849,7 +1849,7 @@ public class UnobservedComponentsModel<T, TInput, TOutput> : TimeSeriesModelBase
                 { "SeasonalAmplitude", _seasonal.Length > 0 ? Convert.ToDouble(NumOps.Subtract(_seasonal.Max(), _seasonal.Min())) : 0.0 },
                 { "IrregularStdDev", _irregular.Length > 0 ? Convert.ToDouble(_irregular.StandardDeviation()) : 0.0 }
             },
-            ModelData = this.Serialize()
+            ModelData = SerializeForMetadata()
         };
 
         return metadata;

--- a/src/TimeSeries/VectorAutoRegressionModel.cs
+++ b/src/TimeSeries/VectorAutoRegressionModel.cs
@@ -1272,7 +1272,7 @@ public class VectorAutoRegressionModel<T> : TimeSeriesModelBase<T>
                 { "NumberOfObservations", _residuals.Rows + _varOptions.Lag },
                 { "NumberOfParameters", _varOptions.OutputDimension * (_varOptions.OutputDimension * _varOptions.Lag + 1) }
             },
-            ModelData = this.Serialize()
+            ModelData = SerializeForMetadata()
         };
 
         // Add residual statistics if available

--- a/src/Video/ActionRecognition/VideoMAE.cs
+++ b/src/Video/ActionRecognition/VideoMAE.cs
@@ -855,7 +855,7 @@ public class VideoMAE<T> : NeuralNetworkBase<T>
         return new ModelMetadata<T>
         {
             AdditionalInfo = additionalInfo,
-            ModelData = this.Serialize()
+            ModelData = SerializeForMetadata()
         };
     }
 

--- a/src/Video/Denoising/BSVD.cs
+++ b/src/Video/Denoising/BSVD.cs
@@ -229,7 +229,7 @@ public class BSVD<T> : VideoDenoisingBase<T>
                 { "BufferDim", _options.BufferDim },
                 { "NumLevels", _options.NumLevels }
             },
-            ModelData = this.Serialize()
+            ModelData = SerializeForMetadata()
         };
     }
 

--- a/src/Video/Denoising/FloRNN.cs
+++ b/src/Video/Denoising/FloRNN.cs
@@ -170,7 +170,7 @@ public class FloRNN<T> : VideoDenoisingBase<T>
                 { "HiddenDim", _options.HiddenDim },
                 { "NumFlowScales", _options.NumFlowScales }
             },
-            ModelData = this.Serialize()
+            ModelData = SerializeForMetadata()
         };
     }
 

--- a/src/Video/Denoising/LiteDVDNet.cs
+++ b/src/Video/Denoising/LiteDVDNet.cs
@@ -173,7 +173,7 @@ public class LiteDVDNet<T> : VideoDenoisingBase<T>
                 { "TemporalWindowSize", _options.TemporalWindowSize },
                 { "ExpansionFactor", _options.ExpansionFactor }
             },
-            ModelData = this.Serialize()
+            ModelData = SerializeForMetadata()
         };
     }
 

--- a/src/Video/Denoising/ShiftNet.cs
+++ b/src/Video/Denoising/ShiftNet.cs
@@ -174,7 +174,7 @@ public class ShiftNet<T> : VideoDenoisingBase<T>
                 { "NumShifts", _options.NumShifts },
                 { "ShiftRadius", _options.ShiftRadius }
             },
-            ModelData = this.Serialize()
+            ModelData = SerializeForMetadata()
         };
     }
 

--- a/src/Video/Denoising/UDVD.cs
+++ b/src/Video/Denoising/UDVD.cs
@@ -180,7 +180,7 @@ public class UDVD<T> : VideoDenoisingBase<T>
                 { "NumResBlocks", _options.NumResBlocks },
                 { "TemporalBufferSize", _options.TemporalBufferSize }
             },
-            ModelData = this.Serialize()
+            ModelData = SerializeForMetadata()
         };
     }
 

--- a/src/Video/Depth/DepthAnythingV2.cs
+++ b/src/Video/Depth/DepthAnythingV2.cs
@@ -645,7 +645,7 @@ public class DepthAnythingV2<T> : NeuralNetworkBase<T>
         return new ModelMetadata<T>
         {
             AdditionalInfo = additionalInfo,
-            ModelData = this.Serialize()
+            ModelData = SerializeForMetadata()
         };
     }
 

--- a/src/Video/FrameInterpolation/FILM.cs
+++ b/src/Video/FrameInterpolation/FILM.cs
@@ -1184,7 +1184,7 @@ public class FILM<T> : FrameInterpolationBase<T>
                 { "InputWidth", _width },
                 { "NumScales", _numScales }
             },
-            ModelData = this.Serialize()
+            ModelData = SerializeForMetadata()
         };
     }
 

--- a/src/Video/FrameInterpolation/RIFE.cs
+++ b/src/Video/FrameInterpolation/RIFE.cs
@@ -961,7 +961,7 @@ public class RIFE<T> : FrameInterpolationBase<T>
         return new ModelMetadata<T>
         {
             AdditionalInfo = additionalInfo,
-            ModelData = this.Serialize()
+            ModelData = SerializeForMetadata()
         };
     }
 

--- a/src/Video/FrameInterpolation/ToonCrafter.cs
+++ b/src/Video/FrameInterpolation/ToonCrafter.cs
@@ -201,7 +201,7 @@ public class ToonCrafter<T> : FrameInterpolationBase<T>
                 { "GuidanceScale", _options.GuidanceScale },
                 { "Complexity", _options.NumDiffusionSteps * _options.NumResBlocks }
             },
-            ModelData = this.Serialize()
+            ModelData = SerializeForMetadata()
         };
     }
 

--- a/src/Video/FrameInterpolation/UPRNet.cs
+++ b/src/Video/FrameInterpolation/UPRNet.cs
@@ -565,7 +565,7 @@ public class UPRNet<T> : FrameInterpolationBase<T>
                 { "LSTMHiddenDim", _options.LSTMHiddenDim },
                 { "Complexity", _options.NumPyramidLevels * _options.NumRecurrentIters }
             },
-            ModelData = this.Serialize()
+            ModelData = SerializeForMetadata()
         };
     }
 

--- a/src/Video/FrameInterpolation/VFIMamba.cs
+++ b/src/Video/FrameInterpolation/VFIMamba.cs
@@ -201,7 +201,7 @@ public class VFIMamba<T> : FrameInterpolationBase<T>
                 { "NumStages", _options.NumStages },
                 { "Complexity", _options.NumMambaBlocks * _options.NumStages }
             },
-            ModelData = this.Serialize()
+            ModelData = SerializeForMetadata()
         };
     }
 

--- a/src/Video/FrameInterpolation/VFIT.cs
+++ b/src/Video/FrameInterpolation/VFIT.cs
@@ -194,7 +194,7 @@ public class VFIT<T> : FrameInterpolationBase<T>
                 { "NumHeads", _options.NumHeads },
                 { "Complexity", _options.NumTemporalLayers * _options.NumSpatialLayers }
             },
-            ModelData = this.Serialize()
+            ModelData = SerializeForMetadata()
         };
     }
 

--- a/src/Video/FrameInterpolation/VFIformer.cs
+++ b/src/Video/FrameInterpolation/VFIformer.cs
@@ -198,7 +198,7 @@ public class VFIformer<T> : FrameInterpolationBase<T>
                 { "NumDeformablePoints", _options.NumDeformablePoints },
                 { "Complexity", _options.NumEncoderLayers * _options.NumDecoderLayers }
             },
-            ModelData = this.Serialize()
+            ModelData = SerializeForMetadata()
         };
     }
 

--- a/src/Video/FrameInterpolation/XVFI.cs
+++ b/src/Video/FrameInterpolation/XVFI.cs
@@ -201,7 +201,7 @@ public class XVFI<T> : FrameInterpolationBase<T>
                 { "UseComplementaryFlow", _options.UseComplementaryFlow },
                 { "Complexity", _options.NumPyramidLevels * _options.NumResBlocks }
             },
-            ModelData = this.Serialize()
+            ModelData = SerializeForMetadata()
         };
     }
 

--- a/src/Video/Generation/OpenSora.cs
+++ b/src/Video/Generation/OpenSora.cs
@@ -1190,7 +1190,7 @@ public class OpenSora<T> : NeuralNetworkBase<T>
             { "NumLayers", _numLayers },
             { "GuidanceScale", _guidanceScale }
         },
-        ModelData = this.Serialize()
+        ModelData = SerializeForMetadata()
     };
 
     protected override void SerializeNetworkSpecificData(BinaryWriter writer)

--- a/src/Video/Generation/StableVideoDiffusion.cs
+++ b/src/Video/Generation/StableVideoDiffusion.cs
@@ -1213,7 +1213,7 @@ public class StableVideoDiffusion<T> : NeuralNetworkBase<T>
         return new ModelMetadata<T>
         {
             AdditionalInfo = additionalInfo,
-            ModelData = this.Serialize()
+            ModelData = SerializeForMetadata()
         };
     }
 

--- a/src/Video/Inpainting/AVID.cs
+++ b/src/Video/Inpainting/AVID.cs
@@ -179,7 +179,7 @@ public class AVID<T> : VideoInpaintingBase<T>
                 { "NumResBlocks", _options.NumResBlocks },
                 { "NumHeads", _options.NumHeads }
             },
-            ModelData = this.Serialize()
+            ModelData = SerializeForMetadata()
         };
     }
 

--- a/src/Video/Inpainting/E2FGVI.cs
+++ b/src/Video/Inpainting/E2FGVI.cs
@@ -810,7 +810,7 @@ public class E2FGVI<T> : VideoInpaintingBase<T>
             { "InputHeight", _height },
             { "InputWidth", _width }
         },
-        ModelData = this.Serialize()
+        ModelData = SerializeForMetadata()
     };
 
     protected override void SerializeNetworkSpecificData(BinaryWriter writer)

--- a/src/Video/Inpainting/FlowLens.cs
+++ b/src/Video/Inpainting/FlowLens.cs
@@ -179,7 +179,7 @@ public class FlowLens<T> : VideoInpaintingBase<T>
                 { "NumLevels", _options.NumLevels },
                 { "NumResBlocks", _options.NumResBlocks }
             },
-            ModelData = this.Serialize()
+            ModelData = SerializeForMetadata()
         };
     }
 

--- a/src/Video/Inpainting/FuseFormer.cs
+++ b/src/Video/Inpainting/FuseFormer.cs
@@ -180,7 +180,7 @@ public class FuseFormer<T> : VideoInpaintingBase<T>
                 { "NumHeads", _options.NumHeads },
                 { "PatchSize", _options.PatchSize }
             },
-            ModelData = this.Serialize()
+            ModelData = SerializeForMetadata()
         };
     }
 

--- a/src/Video/Inpainting/ProPainter.cs
+++ b/src/Video/Inpainting/ProPainter.cs
@@ -905,7 +905,7 @@ public class ProPainter<T> : VideoInpaintingBase<T>
         return new ModelMetadata<T>
         {
             AdditionalInfo = additionalInfo,
-            ModelData = this.Serialize()
+            ModelData = SerializeForMetadata()
         };
     }
 

--- a/src/Video/Inpainting/STTN.cs
+++ b/src/Video/Inpainting/STTN.cs
@@ -180,7 +180,7 @@ public class STTN<T> : VideoInpaintingBase<T>
                 { "NumHeads", _options.NumHeads },
                 { "NumScales", _options.NumScales }
             },
-            ModelData = this.Serialize()
+            ModelData = SerializeForMetadata()
         };
     }
 

--- a/src/Video/Motion/DKM.cs
+++ b/src/Video/Motion/DKM.cs
@@ -232,7 +232,7 @@ public class DKM<T> : OpticalFlowBase<T>
                 { "NumFeatures", _numFeatures },
                 { "NumLayers", _numLayers }
             },
-            ModelData = this.Serialize()
+            ModelData = SerializeForMetadata()
         };
     }
 

--- a/src/Video/Motion/DPFlow.cs
+++ b/src/Video/Motion/DPFlow.cs
@@ -244,7 +244,7 @@ public class DPFlow<T> : OpticalFlowBase<T>
                 { "NumFeatures", _numFeatures },
                 { "NumLayers", _numLayers }
             },
-            ModelData = this.Serialize()
+            ModelData = SerializeForMetadata()
         };
     }
 

--- a/src/Video/Motion/FlowDiffuser.cs
+++ b/src/Video/Motion/FlowDiffuser.cs
@@ -232,7 +232,7 @@ public class FlowDiffuser<T> : OpticalFlowBase<T>
                 { "NumFeatures", _numFeatures },
                 { "NumLayers", _numLayers }
             },
-            ModelData = this.Serialize()
+            ModelData = SerializeForMetadata()
         };
     }
 

--- a/src/Video/Motion/FlowFormerPlusPlus.cs
+++ b/src/Video/Motion/FlowFormerPlusPlus.cs
@@ -243,7 +243,7 @@ public class FlowFormerPlusPlus<T> : OpticalFlowBase<T>
                 { "NumFeatures", _numFeatures },
                 { "NumLayers", _numLayers }
             },
-            ModelData = this.Serialize()
+            ModelData = SerializeForMetadata()
         };
     }
 

--- a/src/Video/Motion/GMFlow.cs
+++ b/src/Video/Motion/GMFlow.cs
@@ -674,7 +674,7 @@ public class GMFlow<T> : OpticalFlowBase<T>
             { "InputWidth", _width },
             { "NumTransformerLayers", _numTransformerLayers }
         },
-        ModelData = this.Serialize()
+        ModelData = SerializeForMetadata()
     };
 
     protected override void SerializeNetworkSpecificData(BinaryWriter writer)

--- a/src/Video/Motion/MemFlow.cs
+++ b/src/Video/Motion/MemFlow.cs
@@ -242,7 +242,7 @@ public class MemFlow<T> : OpticalFlowBase<T>
                 { "NumFeatures", _numFeatures },
                 { "NumLayers", _numLayers }
             },
-            ModelData = this.Serialize()
+            ModelData = SerializeForMetadata()
         };
     }
 

--- a/src/Video/Motion/NeuFlowV2.cs
+++ b/src/Video/Motion/NeuFlowV2.cs
@@ -234,7 +234,7 @@ public class NeuFlowV2<T> : OpticalFlowBase<T>
                 { "NumFeatures", _numFeatures },
                 { "NumLayers", _numLayers }
             },
-            ModelData = this.Serialize()
+            ModelData = SerializeForMetadata()
         };
     }
 

--- a/src/Video/Motion/RAFT.cs
+++ b/src/Video/Motion/RAFT.cs
@@ -717,7 +717,7 @@ public class RAFT<T> : OpticalFlowBase<T>
         return new ModelMetadata<T>
         {
             AdditionalInfo = additionalInfo,
-            ModelData = this.Serialize()
+            ModelData = SerializeForMetadata()
         };
     }
 

--- a/src/Video/Motion/RAPIDFlow.cs
+++ b/src/Video/Motion/RAPIDFlow.cs
@@ -455,7 +455,7 @@ public class RAPIDFlow<T> : OpticalFlowBase<T>
                 { "Level3Channels", Level3Channels },
                 { "NumRefinementIterations", _numRefinementIterations }
             },
-            ModelData = this.Serialize()
+            ModelData = SerializeForMetadata()
         };
     }
 

--- a/src/Video/Motion/RPKNet.cs
+++ b/src/Video/Motion/RPKNet.cs
@@ -234,7 +234,7 @@ public class RPKNet<T> : OpticalFlowBase<T>
                 { "NumFeatures", _numFeatures },
                 { "NumLayers", _numLayers }
             },
-            ModelData = this.Serialize()
+            ModelData = SerializeForMetadata()
         };
     }
 

--- a/src/Video/Motion/RoMa.cs
+++ b/src/Video/Motion/RoMa.cs
@@ -232,7 +232,7 @@ public class RoMa<T> : OpticalFlowBase<T>
                 { "NumFeatures", _numFeatures },
                 { "NumLayers", _numLayers }
             },
-            ModelData = this.Serialize()
+            ModelData = SerializeForMetadata()
         };
     }
 

--- a/src/Video/Motion/SEARAFT.cs
+++ b/src/Video/Motion/SEARAFT.cs
@@ -232,7 +232,7 @@ public class SEARAFT<T> : OpticalFlowBase<T>
                 { "NumFeatures", _numFeatures },
                 { "NumLayers", _numLayers }
             },
-            ModelData = this.Serialize()
+            ModelData = SerializeForMetadata()
         };
     }
 

--- a/src/Video/Motion/SKFlow.cs
+++ b/src/Video/Motion/SKFlow.cs
@@ -232,7 +232,7 @@ public class SKFlow<T> : OpticalFlowBase<T>
                 { "NumFeatures", _numFeatures },
                 { "NumLayers", _numLayers }
             },
-            ModelData = this.Serialize()
+            ModelData = SerializeForMetadata()
         };
     }
 

--- a/src/Video/Motion/UFM.cs
+++ b/src/Video/Motion/UFM.cs
@@ -247,7 +247,7 @@ public class UFM<T> : OpticalFlowBase<T>
                 { "NumFeatures", _numFeatures },
                 { "NumLayers", _numLayers }
             },
-            ModelData = this.Serialize()
+            ModelData = SerializeForMetadata()
         };
     }
 

--- a/src/Video/Motion/UniMatch.cs
+++ b/src/Video/Motion/UniMatch.cs
@@ -233,7 +233,7 @@ public class UniMatch<T> : OpticalFlowBase<T>
                 { "NumFeatures", _numFeatures },
                 { "NumLayers", _numLayers }
             },
-            ModelData = this.Serialize()
+            ModelData = SerializeForMetadata()
         };
     }
 

--- a/src/Video/Motion/VideoFlow.cs
+++ b/src/Video/Motion/VideoFlow.cs
@@ -235,7 +235,7 @@ public class VideoFlow<T> : OpticalFlowBase<T>
                 { "NumFeatures", _numFeatures },
                 { "NumLayers", _numLayers }
             },
-            ModelData = this.Serialize()
+            ModelData = SerializeForMetadata()
         };
     }
 

--- a/src/Video/Segmentation/SAM2.cs
+++ b/src/Video/Segmentation/SAM2.cs
@@ -1116,7 +1116,7 @@ public class SAM2<T> : NeuralNetworkBase<T>
         return new ModelMetadata<T>
         {
             AdditionalInfo = additionalInfo,
-            ModelData = this.Serialize()
+            ModelData = SerializeForMetadata()
         };
     }
 

--- a/src/Video/Stabilization/DUT.cs
+++ b/src/Video/Stabilization/DUT.cs
@@ -168,7 +168,7 @@ public class DUT<T> : VideoStabilizationBase<T>
                 { "NumResBlocks", _options.NumResBlocks },
                 { "TemporalWindowSize", _options.TemporalWindowSize }
             },
-            ModelData = this.Serialize()
+            ModelData = SerializeForMetadata()
         };
     }
 

--- a/src/Video/Stabilization/FuSta.cs
+++ b/src/Video/Stabilization/FuSta.cs
@@ -172,7 +172,7 @@ public class FuSta<T> : VideoStabilizationBase<T>
                 { "NumResBlocks", _options.NumResBlocks },
                 { "NumHeads", _options.NumHeads }
             },
-            ModelData = this.Serialize()
+            ModelData = SerializeForMetadata()
         };
     }
 

--- a/src/Video/Stabilization/GaVS.cs
+++ b/src/Video/Stabilization/GaVS.cs
@@ -170,7 +170,7 @@ public class GaVS<T> : VideoStabilizationBase<T>
                 { "GazeHiddenDim", _options.GazeHiddenDim },
                 { "SmoothingWindow", _options.SmoothingWindow }
             },
-            ModelData = this.Serialize()
+            ModelData = SerializeForMetadata()
         };
     }
 

--- a/src/Video/Stabilization/PWStableNet.cs
+++ b/src/Video/Stabilization/PWStableNet.cs
@@ -168,7 +168,7 @@ public class PWStableNet<T> : VideoStabilizationBase<T>
                 { "GridSize", _options.GridSize },
                 { "NumResBlocks", _options.NumResBlocks }
             },
-            ModelData = this.Serialize()
+            ModelData = SerializeForMetadata()
         };
     }
 

--- a/src/Video/Stabilization/StabStitch.cs
+++ b/src/Video/Stabilization/StabStitch.cs
@@ -168,7 +168,7 @@ public class StabStitch<T> : VideoStabilizationBase<T>
                 { "MeshGridRows", _options.MeshGridRows },
                 { "MeshGridCols", _options.MeshGridCols }
             },
-            ModelData = this.Serialize()
+            ModelData = SerializeForMetadata()
         };
     }
 

--- a/src/Video/Stabilization/ThreeDMF.cs
+++ b/src/Video/Stabilization/ThreeDMF.cs
@@ -168,7 +168,7 @@ public class ThreeDMF<T> : VideoStabilizationBase<T>
                 { "NumMotionIters", _options.NumMotionIters },
                 { "NumResBlocks", _options.NumResBlocks }
             },
-            ModelData = this.Serialize()
+            ModelData = SerializeForMetadata()
         };
     }
 

--- a/src/Video/Understanding/VideoCLIP.cs
+++ b/src/Video/Understanding/VideoCLIP.cs
@@ -1158,7 +1158,7 @@ public class VideoCLIP<T> : NeuralNetworkBase<T>
         return new ModelMetadata<T>
         {
             AdditionalInfo = additionalInfo,
-            ModelData = this.Serialize()
+            ModelData = SerializeForMetadata()
         };
     }
 


### PR DESCRIPTION
## Bug
`AiModelResult`'s constructor calls `GetModelMetadata()`, which embedded `ModelData = this.Serialize()` in 259 model classes — and `Serialize()` enforces the persistence license. Net effect: **building any neural or time-series model through the AiModelBuilder facade throws `LicenseRequiredException` without a license**, contradicting the library's own message that "training and inference remain fully available without a license." The in-repo facade tests only pass because the test fixture injects a build key; downstream consumers (e.g. nuget 0.208.118) hit this immediately.

## Fix
`SerializeForMetadata()` on `NeuralNetworkBase` + `TimeSeriesModelBase`: embeds the payload when licensed, degrades to an empty payload when not (metadata stays descriptive either way). Explicit `SaveModel()`/`Serialize()` enforcement is unchanged. All 259 sites switched mechanically.

Found while adopting 0.208.118 in a downstream app: every facade NN build failed at `AiModelResult..ctor → GetModelMetadata → Serialize → ModelPersistenceGuard.EnforceBeforeSerialize`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)