### PR TITLE
feat(facade): ConfigureTargetScaling — complete the orphaned target-pipeline plumbing

### DIFF
--- a/src/AiModelBuilder.BuildPipeline.cs
+++ b/src/AiModelBuilder.BuildPipeline.cs
@@ -169,6 +169,29 @@ public partial class AiModelBuilder<T, TInput, TOutput>
                     pipelineFitted = true;
                 }
 
+                // TARGET scaling (ConfigureTargetScaling) on the streaming path: fit once on the first
+                // batch's targets (mirroring the feature pipeline's first-batch fit above), then transform
+                // every batch's targets so the model trains in scaled space. Predict inverse-transforms via
+                // PreprocessingInfo.InverseTransformPredictions.
+                TOutput[] processedOutputs = outputs;
+                if (_targetPipeline is not null)
+                {
+                    if (!_targetPipeline.IsFitted && outputs.Length > 0)
+                    {
+                        _targetPipeline.Fit(outputs[0] is Tensor<T> && outputs.Length > 1
+                            && TryStackTensorBatch(outputs.Cast<Tensor<T>>().ToArray(), out var batchedY)
+                            && batchedY is TOutput typedY
+                                ? typedY
+                                : outputs[0]);
+                    }
+
+                    processedOutputs = new TOutput[outputs.Length];
+                    for (int i = 0; i < outputs.Length; i++)
+                    {
+                        processedOutputs[i] = _targetPipeline.Transform(outputs[i]);
+                    }
+                }
+
                 // Apply preprocessing to each sample BEFORE stacking so the
                 // batched tensor reflects the transformed features. Same
                 // pipeline-output handling as the previous code.
@@ -200,7 +223,7 @@ public partial class AiModelBuilder<T, TInput, TOutput>
                 // bounced subclassed tensor types into the per-sample slow path
                 // for no good reason.
                 if (processedInputs.Length > 0 && processedInputs[0] is Tensor<T>
-                    && outputs.Length > 0 && outputs[0] is Tensor<T>
+                    && processedOutputs.Length > 0 && processedOutputs[0] is Tensor<T>
                     && _model is INeuralNetwork<T> nn)
                 {
                     // BUILDER-OPTIMIZER PLUMBING (closes review-comment #1265.f03A
@@ -246,7 +269,7 @@ public partial class AiModelBuilder<T, TInput, TOutput>
                     // preserves correctness for default loaders while
                     // letting padded loaders enjoy the batched fast path.
                     var inputArray = processedInputs.Cast<Tensor<T>>().ToArray();
-                    var outputArray = outputs.Cast<Tensor<T>>().ToArray();
+                    var outputArray = processedOutputs.Cast<Tensor<T>>().ToArray();
                     if (TryStackTensorBatch(inputArray, out var batchedInput) &&
                         TryStackTensorBatch(outputArray, out var batchedTarget))
                     {
@@ -285,7 +308,7 @@ public partial class AiModelBuilder<T, TInput, TOutput>
                     // forward" concept; each sample is an independent update.
                     for (int i = 0; i < processedInputs.Length; i++)
                     {
-                        var gradients = InterfaceGuard.GradientComputable(_model).ComputeGradients(processedInputs[i], outputs[i], lossFunction);
+                        var gradients = InterfaceGuard.GradientComputable(_model).ComputeGradients(processedInputs[i], processedOutputs[i], lossFunction);
                         // Pass the optimizer's CURRENT learning rate (which
                         // reflects scheduler / decay / step-counter state) instead
                         // of the constant InitialLearningRate. The previous code
@@ -311,7 +334,7 @@ public partial class AiModelBuilder<T, TInput, TOutput>
 
                         var prediction = _model.Predict(processedInputs[i]);
                         var predictionVector = ConversionsHelper.ConvertToVector<T, TOutput>(prediction);
-                        var targetVector = ConversionsHelper.ConvertToVector<T, TOutput>(outputs[i]);
+                        var targetVector = ConversionsHelper.ConvertToVector<T, TOutput>(processedOutputs[i]);
                         var loss = lossFunction.CalculateLoss(predictionVector, targetVector);
                         epochLoss = numOps.Add(epochLoss, loss);
                         epochBatches++;
@@ -374,8 +397,12 @@ public partial class AiModelBuilder<T, TInput, TOutput>
         var options = new AiModelResultOptions<T, TInput, TOutput>
         {
             OptimizationResult = optimizationResult,
-            PreprocessingInfo = _preprocessingPipeline is not null && pipelineFitted
-                ? new PreprocessingInfo<T, TInput, TOutput>(_preprocessingPipeline)
+            PreprocessingInfo = (_preprocessingPipeline is not null && pipelineFitted) || _targetPipeline is not null
+                ? new PreprocessingInfo<T, TInput, TOutput>
+                {
+                    Pipeline = _preprocessingPipeline is not null && pipelineFitted ? _preprocessingPipeline : null,
+                    TargetPipeline = _targetPipeline,
+                }
                 : null,
             PostprocessingPipeline = _postprocessingPipeline,
             Tokenizer = _tokenizer,
@@ -1163,7 +1190,7 @@ public partial class AiModelBuilder<T, TInput, TOutput>
 
                 preprocessingInfo = new PreprocessingInfo<T, TInput, TOutput>(
                     _preprocessingPipeline,
-                    targetPipeline: null
+                    targetPipeline: _targetPipeline
                 );
             }
             else
@@ -1228,6 +1255,18 @@ public partial class AiModelBuilder<T, TInput, TOutput>
                 }
             }
 
+            // TARGET scaling (ConfigureTargetScaling): fit on TRAINING targets only, transform val/test
+            // into the same scaled space so in-build metrics compare like-with-like. Predict inverse-
+            // transforms outputs back to original units via PreprocessingInfo.InverseTransformPredictions.
+            if (_targetPipeline is not null)
+            {
+                yTrain = _targetPipeline.FitTransform(yTrain);
+#pragma warning disable CS8604 // yVal / yTest are assigned by DataSplitter.Split above
+                yVal = _targetPipeline.Transform(yVal);
+                yTest = _targetPipeline.Transform(yTest);
+#pragma warning restore CS8604
+            }
+
             if (_preprocessingPipeline is not null)
             {
                 // FitTransform on training data only — learns statistics from training set
@@ -1241,7 +1280,7 @@ public partial class AiModelBuilder<T, TInput, TOutput>
 
                 preprocessingInfo = new PreprocessingInfo<T, TInput, TOutput>(
                     _preprocessingPipeline,
-                    targetPipeline: null
+                    targetPipeline: _targetPipeline
                 );
 
                 preprocessedX = XTrain; // For downstream references
@@ -1252,6 +1291,11 @@ public partial class AiModelBuilder<T, TInput, TOutput>
                 // No preprocessing pipeline configured - pass through, but keep any training-only data preparation
                 preprocessedX = XTrain;
                 preprocessedY = yTrain;
+                if (_targetPipeline is not null)
+                {
+                    // Target-only scaling still needs a carrier so Predict can inverse-transform.
+                    preprocessingInfo = new PreprocessingInfo<T, TInput, TOutput> { TargetPipeline = _targetPipeline };
+                }
             }
         }
 

--- a/src/AiModelBuilder.Configure.cs
+++ b/src/AiModelBuilder.Configure.cs
@@ -281,6 +281,31 @@ public partial class AiModelBuilder<T, TInput, TOutput>
     /// It's like having someone adjust the knobs on a radio to get the clearest signal.
     /// The optimizer tries different settings and keeps the ones that work best.
     /// </remarks>
+    /// <summary>
+    /// Configures TARGET (label) scaling for regression: the targets are scaled (default: z-score via
+    /// <see cref="AiDotNet.Preprocessing.TargetStandardScaler{T,TOutput}"/>) before training — fit on the
+    /// TRAINING split only — and <c>Predict</c> automatically inverse-transforms model outputs back to the
+    /// ORIGINAL target units. Pass a custom pipeline to control the transformation.
+    /// </summary>
+    /// <remarks>
+    /// <b>For Beginners:</b> If your target is, say, a price in the hundreds while your features are
+    /// scaled to ~1, gradient training struggles. This scales the target down for training and scales
+    /// predictions back up for you — no manual inverse-transform needed. Regression only: never scale
+    /// class labels.
+    /// </remarks>
+    public IAiModelBuilder<T, TInput, TOutput> ConfigureTargetScaling(
+        AiDotNet.Preprocessing.PreprocessingPipeline<T, TOutput, TOutput>? pipeline = null)
+    {
+        if (pipeline is null)
+        {
+            pipeline = new AiDotNet.Preprocessing.PreprocessingPipeline<T, TOutput, TOutput>();
+            pipeline.Add(new AiDotNet.Preprocessing.TargetStandardScaler<T, TOutput>());
+        }
+
+        _targetPipeline = pipeline;
+        return this;
+    }
+
     public IAiModelBuilder<T, TInput, TOutput> ConfigureOptimizer(IOptimizer<T, TInput, TOutput> optimizationAlgorithm)
     {
         _trainingCore.ConfigureOptimizer(optimizationAlgorithm);

--- a/src/AiModelBuilder.cs
+++ b/src/AiModelBuilder.cs
@@ -176,6 +176,7 @@ public partial class AiModelBuilder<T, TInput, TOutput> : IAiModelBuilder<T, TIn
         = new AiDotNet.Configuration.AiModelObservability();
 
     private PreprocessingPipeline<T, TInput, TInput>? _preprocessingPipeline;
+    private PreprocessingPipeline<T, TOutput, TOutput>? _targetPipeline;
     private PostprocessingPipeline<T, TOutput, TOutput>? _postprocessingPipeline;
 
     /// <summary>

--- a/src/Interfaces/IAiModelBuilder.cs
+++ b/src/Interfaces/IAiModelBuilder.cs
@@ -128,6 +128,15 @@ public interface IAiModelBuilder<T, TInput, TOutput>
     IAiModelBuilder<T, TInput, TOutput> ConfigurePostprocessing(IDataTransformer<T, TOutput, TOutput> transformer);
 
     /// <summary>
+    /// Configures TARGET (label) scaling for regression: targets are scaled before training (fit on the
+    /// TRAINING split only; default z-score via <c>TargetStandardScaler</c>) and <c>Predict</c>
+    /// automatically inverse-transforms outputs back to the ORIGINAL target units. Regression only —
+    /// never scale class labels.
+    /// </summary>
+    IAiModelBuilder<T, TInput, TOutput> ConfigureTargetScaling(
+        AiDotNet.Preprocessing.PreprocessingPipeline<T, TOutput, TOutput>? pipeline = null);
+
+    /// <summary>
     /// Configures the output postprocessing pipeline for the model using a fluent builder.
     /// </summary>
     /// <remarks>

--- a/src/Preprocessing/TargetScalingInfo.cs
+++ b/src/Preprocessing/TargetScalingInfo.cs
@@ -1,0 +1,148 @@
+using AiDotNet.Interfaces;
+using AiDotNet.Preprocessing.Scalers;
+using AiDotNet.Tensors.LinearAlgebra;
+
+namespace AiDotNet.Preprocessing;
+
+/// <summary>
+/// Standard (z-score) scaling for regression TARGETS — the <see cref="IDataTransformer{T,TInput,TOutput}"/>
+/// that <c>AiModelBuilder.ConfigureTargetScaling()</c> installs into the (previously always-null)
+/// <see cref="PreprocessingInfo{T,TInput,TOutput}.TargetPipeline"/>.
+/// </summary>
+/// <remarks>
+/// <para><b>Why:</b> the facade has always scaled FEATURES (<c>ConfigurePreprocessing</c>) but never the
+/// target — raw targets on wide scales (prices, dollar P&amp;L) make gradient training diverge, so every
+/// consumer hand-rolled a target scaler plus the inverse transform on the way out. The carrier
+/// (<c>PreprocessingInfo.TargetPipeline</c> + <c>InverseTransformPredictions</c>) existed but nothing ever
+/// populated or invoked it; this transformer + the builder/predict wiring completes the feature.</para>
+/// <para><b>Shapes:</b> targets are adapted to a column matrix for the underlying
+/// <see cref="StandardScaler{T}"/> — <c>Vector&lt;T&gt;</c> ↔ <c>Matrix[n,1]</c>; <c>Tensor&lt;T&gt;</c>
+/// rank-1 ↔ <c>Matrix[n,1]</c>; <c>Tensor&lt;T&gt;</c> rank-2 <c>[n,k]</c> ↔ <c>Matrix[n,k]</c> (each
+/// output column scaled independently). Other output types are rejected at construction.</para>
+/// </remarks>
+public sealed class TargetStandardScaler<T, TOutput> : IDataTransformer<T, TOutput, TOutput>
+{
+    private readonly StandardScaler<T> _scaler;
+
+    public TargetStandardScaler(StandardScaler<T>? scaler = null)
+    {
+        _scaler = scaler ?? new StandardScaler<T>();
+        if (typeof(TOutput) != typeof(Vector<T>) && typeof(TOutput) != typeof(Tensor<T>))
+        {
+            throw new NotSupportedException(
+                $"Target scaling supports Vector<T> and Tensor<T> outputs; got {typeof(TOutput).Name}. " +
+                "Classification/label outputs must not be scaled — configure target scaling for regression only.");
+        }
+    }
+
+    /// <inheritdoc/>
+    public bool IsFitted { get; private set; }
+
+    /// <inheritdoc/>
+    public bool SupportsInverseTransform => true;
+
+    /// <inheritdoc/>
+    public int[]? ColumnIndices => null; // target scaling always applies to every output column
+
+    /// <inheritdoc/>
+    public string[] GetFeatureNamesOut(string[]? inputFeatures = null)
+        => inputFeatures ?? []; // scaling does not rename target columns
+
+    /// <inheritdoc/>
+    public void Fit(TOutput data)
+    {
+        _scaler.Fit(ToMatrix(data));
+        IsFitted = true;
+    }
+
+    /// <inheritdoc/>
+    public TOutput Transform(TOutput data)
+        => FromMatrix(_scaler.Transform(ToMatrix(data)), data);
+
+    /// <inheritdoc/>
+    public TOutput FitTransform(TOutput data)
+    {
+        var scaled = _scaler.FitTransform(ToMatrix(data));
+        IsFitted = true;
+        return FromMatrix(scaled, data);
+    }
+
+    /// <inheritdoc/>
+    public TOutput InverseTransform(TOutput data)
+        => FromMatrix(_scaler.InverseTransform(ToMatrix(data)), data);
+
+    private static Matrix<T> ToMatrix(TOutput y)
+    {
+        switch (y)
+        {
+            case Vector<T> v:
+            {
+                var m = new Matrix<T>(v.Length, 1);
+                for (int i = 0; i < v.Length; i++)
+                {
+                    m[i, 0] = v[i];
+                }
+
+                return m;
+            }
+
+            case Tensor<T> t when t.Rank == 1:
+            {
+                var m = new Matrix<T>(t.Shape[0], 1);
+                var span = t.Data.Span;
+                for (int i = 0; i < t.Shape[0]; i++)
+                {
+                    m[i, 0] = span[i];
+                }
+
+                return m;
+            }
+
+            case Tensor<T> t when t.Rank == 2:
+            {
+                var m = new Matrix<T>(t.Shape[0], t.Shape[1]);
+                var span = t.Data.Span;
+                for (int i = 0; i < t.Shape[0]; i++)
+                {
+                    for (int j = 0; j < t.Shape[1]; j++)
+                    {
+                        m[i, j] = span[(i * t.Shape[1]) + j];
+                    }
+                }
+
+                return m;
+            }
+
+            default:
+                throw new NotSupportedException(
+                    $"Target scaling cannot adapt output of type {y?.GetType().Name ?? "null"} (rank > 2 tensors unsupported).");
+        }
+    }
+
+    private static TOutput FromMatrix(Matrix<T> m, TOutput shapeLike)
+    {
+        if (shapeLike is Vector<T>)
+        {
+            var v = new Vector<T>(m.Rows);
+            for (int i = 0; i < m.Rows; i++)
+            {
+                v[i] = m[i, 0];
+            }
+
+            return (TOutput)(object)v;
+        }
+
+        var rank1 = shapeLike is Tensor<T> t && t.Rank == 1;
+        var data = new T[m.Rows * m.Columns];
+        for (int i = 0; i < m.Rows; i++)
+        {
+            for (int j = 0; j < m.Columns; j++)
+            {
+                data[(i * m.Columns) + j] = m[i, j];
+            }
+        }
+
+        var tensorShape = rank1 ? new[] { m.Rows } : new[] { m.Rows, m.Columns };
+        return (TOutput)(object)new Tensor<T>(tensorShape, new Vector<T>(data));
+    }
+}

--- a/tests/AiDotNet.Tests/IntegrationTests/Preprocessing/TargetScalingFacadeTests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/Preprocessing/TargetScalingFacadeTests.cs
@@ -1,0 +1,73 @@
+using AiDotNet.Data.Loaders;
+using AiDotNet.Preprocessing;
+using AiDotNet.Preprocessing.Scalers;
+using AiDotNet.Regression;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tests.IntegrationTests.Preprocessing;
+
+/// <summary>
+/// ConfigureTargetScaling end-to-end: the facade fits the target scaler on the TRAINING split, trains in
+/// scaled space, and Predict returns values in the ORIGINAL target units (via the previously-orphaned
+/// PreprocessingInfo.TargetPipeline / InverseTransformPredictions plumbing — now populated and exercised).
+/// </summary>
+public class TargetScalingFacadeTests
+{
+    [Fact]
+    public async Task Predictions_come_back_in_original_target_units()
+    {
+        // y = 1000·x1 + 5000 — a target whose scale (thousands) is far from the unit-scaled features.
+        const int n = 120;
+        var x = new Matrix<double>(n, 1);
+        var y = new Vector<double>(n);
+        for (int i = 0; i < n; i++)
+        {
+            double xi = i / (double)n;
+            x[i, 0] = xi;
+            y[i] = (1000.0 * xi) + 5000.0;
+        }
+
+        var result = await new AiModelBuilder<double, Matrix<double>, Vector<double>>()
+            .ConfigureModel(new MultipleRegression<double>())
+            .ConfigureDataLoader(new InMemoryDataLoader<double, Matrix<double>, Vector<double>>(x, y))
+            .ConfigurePreprocessing(new StandardScaler<double>())
+            .ConfigureTargetScaling()
+            .BuildAsync();
+
+        Assert.True(result.PreprocessingInfo is not null, "PreprocessingInfo missing on the result");
+        Assert.True(result.PreprocessingInfo!.IsTargetFitted,
+            $"Target pipeline not fitted/carried: TargetPipeline={(result.PreprocessingInfo.TargetPipeline is null ? "null" : "set-unfitted")}");
+
+        var probe = new Matrix<double>(2, 1);
+        probe[0, 0] = 0.25; // expect ≈ 5250
+        probe[1, 0] = 0.75; // expect ≈ 5750
+        var pred = result.Predict(probe);
+
+        // If the inverse transform were missing, predictions would sit near 0 (z-score space, |v| < ~3).
+        Assert.True(Math.Abs(pred[0] - 5250.0) < 150.0, $"pred[0]={pred[0]} — expected ≈5250 in ORIGINAL units");
+        Assert.True(Math.Abs(pred[1] - 5750.0) < 150.0, $"pred[1]={pred[1]} — expected ≈5750 in ORIGINAL units");
+    }
+
+    [Fact]
+    public void TargetStandardScaler_round_trips_vectors_and_tensors()
+    {
+        var v = new Vector<double>(new[] { 10.0, 20.0, 30.0, 40.0 });
+        var sv = new TargetStandardScaler<double, Vector<double>>();
+        var scaled = sv.FitTransform(v);
+        Assert.True(Math.Abs(scaled.Average()) < 1e-9, "scaled mean should be ~0");
+        var back = sv.InverseTransform(scaled);
+        for (int i = 0; i < v.Length; i++)
+        {
+            Assert.Equal(v[i], back[i], 6);
+        }
+
+        var t = new Tensor<double>(new[] { 4, 1 }, new Vector<double>(new[] { 10.0, 20.0, 30.0, 40.0 }));
+        var st = new TargetStandardScaler<double, Tensor<double>>();
+        var backT = st.InverseTransform(st.FitTransform(t));
+        for (int i = 0; i < 4; i++)
+        {
+            Assert.Equal(t.Data.Span[i], backT.Data.Span[i], 6);
+        }
+    }
+}


### PR DESCRIPTION
## The gap
`PreprocessingInfo.TargetPipeline` + `InverseTransformPredictions` existed, and both `Predict` paths already invoked the inverse when `IsTargetFitted` — but **nothing ever populated them**: the build pipeline hardcoded `targetPipeline: null` and no builder API existed. Every consumer hand-rolled target scalers + inverse transforms around facade regressions with wide-scale targets (prices, P&L).

## The fix (completes the half-built feature)
- `TargetStandardScaler<T,TOutput>` (`IDataTransformer<T,TOutput,TOutput>`): z-score target scaling with Vector/Tensor shape adapters; regression-only by construction.
- `ConfigureTargetScaling(pipeline = null)` on the builder + interface.
- Supervised path: fit on TRAIN only, transform val/test (consistent in-build metrics); supervised + federated `PreprocessingInfo` constructions now carry the pipeline.
- Streaming-loader path: first-batch fit (mirrors the feature pipeline), per-batch target transform, carried in the result.
- `Predict` returns original units through the pre-existing inverse hooks.

## Tests
End-to-end facade regression (thousand-scale target → predictions in original units, carrier + inverse asserted) and Vector/Tensor scaler round-trips. Neighboring facade tests (NnDoubleInputDim, UQ facade, multi-dim input) all green — 22/22.

🤖 Generated with [Claude Code](https://claude.com/claude-code)