### PR TITLE
fix(generators): exclude non-public types from the YamlTypeRegistry

### DIFF
--- a/src/AiDotNet.Generators/YamlConfigSourceGenerator.cs
+++ b/src/AiDotNet.Generators/YamlConfigSourceGenerator.cs
@@ -1212,9 +1212,12 @@ internal static class YamlParamsHelper
                     c.IsImplicitlyDeclared &&
                     c.DeclaredAccessibility == Accessibility.Public);
 
-                // Skip nested types that aren't publicly accessible.
-                if (symbol.ContainingType is not null &&
-                    symbol.DeclaredAccessibility != Accessibility.Public)
+                // Skip types that aren't publicly accessible from generated code. This must check the
+                // FULL containment chain, not just nested types: top-level INTERNAL types in referenced
+                // assemblies (e.g. FormattedLogValues : IReadOnlyList<...> in Microsoft.Extensions.Logging)
+                // match broad BCL interfaces like IReadOnlyList<T> and would be emitted as typeof(...)
+                // references the generated registry cannot compile against (CS0122).
+                if (!IsEffectivelyPublic(symbol))
                 {
                     hasPublicCtor = false;
                     hasImplicitDefaultCtor = false;
@@ -1246,6 +1249,23 @@ internal static class YamlParamsHelper
             {
                 nestedType.Accept(this);
             }
+        }
+
+        /// <summary>
+        /// True when the type and every containing type is declared public — i.e. generated code in
+        /// another assembly can legally reference it via <c>typeof(...)</c>.
+        /// </summary>
+        private static bool IsEffectivelyPublic(INamedTypeSymbol symbol)
+        {
+            for (INamedTypeSymbol? current = symbol; current is not null; current = current.ContainingType)
+            {
+                if (current.DeclaredAccessibility != Accessibility.Public)
+                {
+                    return false;
+                }
+            }
+
+            return true;
         }
 
         /// <summary>

--- a/tests/AiDotNet.Tests/IntegrationTests/Configuration/YamlTypeRegistryAccessibilityTests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/Configuration/YamlTypeRegistryAccessibilityTests.cs
@@ -1,0 +1,60 @@
+using System.Reflection;
+using AiDotNet.Configuration;
+using Xunit;
+
+namespace AiDotNet.Tests.IntegrationTests.Configuration;
+
+/// <summary>
+/// Regression guard for the YamlConfigSourceGenerator accessibility bug: the implementation finder
+/// only rejected NESTED non-public types, so a TOP-LEVEL internal type in any referenced assembly
+/// that implemented a broad interface (e.g. <c>FormattedLogValues : IReadOnlyList&lt;...&gt;</c> in
+/// Microsoft.Extensions.Logging matching an <c>IReadOnlyList&lt;T&gt;</c> Configure parameter) was
+/// emitted into the generated registry as a <c>typeof(...)</c> reference the registry could not
+/// compile against (CS0122). The generator now checks the full containment chain is public; this
+/// test pins the contract on whatever the registry actually emitted.
+/// </summary>
+public class YamlTypeRegistryAccessibilityTests
+{
+    [Fact]
+    public void Every_registered_implementation_type_is_publicly_visible()
+    {
+        var registryType = typeof(YamlModelConfig).Assembly
+            .GetTypes()
+            .FirstOrDefault(t => t.Name.StartsWith("YamlTypeRegistry", StringComparison.Ordinal));
+
+        Assert.True(registryType is not null, "Generated YamlTypeRegistry type not found in the AiDotNet assembly.");
+
+        // Walk every static field/property of the registry that holds Type values (the per-section
+        // name → implementation maps) and assert each registered Type is visible to external code.
+        var offenders = new List<string>();
+        foreach (var field in registryType!.GetFields(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static))
+        {
+            object? value;
+            try
+            {
+                value = field.GetValue(null);
+            }
+            catch (Exception)
+            {
+                continue; // a throwing initializer would itself fail other registry tests
+            }
+
+            if (value is not System.Collections.IDictionary dict)
+            {
+                continue;
+            }
+
+            foreach (var entryValue in dict.Values)
+            {
+                if (entryValue is Type implType && !implType.IsVisible)
+                {
+                    offenders.Add($"{field.Name}: {implType.FullName}");
+                }
+            }
+        }
+
+        Assert.True(offenders.Count == 0,
+            "Generated YamlTypeRegistry references non-public types (generator accessibility filter regressed): " +
+            string.Join("; ", offenders));
+    }
+}


### PR DESCRIPTION
## Bug

The YamlConfigSourceGenerator's `ImplementationFinder` accessibility guard only rejected **nested** non-public types:

```csharp
if (symbol.ContainingType is not null && symbol.DeclaredAccessibility != Accessibility.Public)
```

A **top-level internal** type in any referenced assembly that implements a broad interface sails through and gets emitted into `YamlTypeRegistry.g.cs` as a `typeof(...)` reference that the generated code cannot legally compile against.

## Repro

Add any `Configure*` method whose first parameter is `IReadOnlyList<T>` (or any other broad BCL interface). The generator sweeps every internal `IReadOnlyList` implementation across all references into the registry — `FormattedLogValues` (Microsoft.Extensions.Logging), `ChangeTrackingList<T>`, `EmptyReadOnlyList<T>`, `JPropertyKeyedCollection` (Newtonsoft), compiler-synthesized `z__ReadOnlyArray` / `z__ReadOnlySingleElementList` — and the build fails with a wall of CS0122 + parse errors in generated code.

## Fix

`IsEffectivelyPublic`: require the type **and its full containment chain** to be declared public before registration.

## Test

`YamlTypeRegistryAccessibilityTests` reflects over the generated registry's section maps at runtime and asserts every registered `Type.IsVisible` — pinning the contract against regression regardless of which interface parameters Configure methods grow in the future.

Found while implementing `ConfigureTrainingGroups(IReadOnlyList<IReadOnlyList<int>>)` (follow-up PR depends on this fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)