### PR TITLE
fix(neuralnetworks): floor default hidden-layer widths — tiny tabular nets were dead at init

### DIFF
--- a/src/Helpers/LayerHelper.cs
+++ b/src/Helpers/LayerHelper.cs
@@ -3129,29 +3129,36 @@ public static class LayerHelper<T>
         // Determine hidden layer sizes based on network complexity
         List<int> hiddenLayerSizes = new List<int>();
 
+        // Floor every hidden width at MinHiddenWidth: for low-dimensional tabular inputs the
+        // unfloored formulas produce width-1/2 hidden layers, which are DEGENERATE — with a width-2
+        // ReLU hidden layer the init has a large probability of every path being dead over the whole
+        // input range (e.g. both second-layer weights negative), at which point no weight receives a
+        // gradient and only the output bias trains: the network is permanently a constant function.
+        const int MinHiddenWidth = 8;
+
         switch (architecture.Complexity)
         {
             case NetworkComplexity.Simple:
                 // One hidden layer with size between input and output
-                hiddenLayerSizes.Add((inputSize + outputSize) / 2);
+                hiddenLayerSizes.Add(Math.Max(MinHiddenWidth, (inputSize + outputSize) / 2));
                 break;
 
             case NetworkComplexity.Medium:
                 // Two hidden layers
-                hiddenLayerSizes.Add(inputSize * 2);
-                hiddenLayerSizes.Add(inputSize);
+                hiddenLayerSizes.Add(Math.Max(MinHiddenWidth, inputSize * 2));
+                hiddenLayerSizes.Add(Math.Max(MinHiddenWidth, inputSize));
                 break;
 
             case NetworkComplexity.Deep:
                 // Three hidden layers
-                hiddenLayerSizes.Add(inputSize * 2);
-                hiddenLayerSizes.Add(inputSize * 2);
-                hiddenLayerSizes.Add(inputSize);
+                hiddenLayerSizes.Add(Math.Max(MinHiddenWidth, inputSize * 2));
+                hiddenLayerSizes.Add(Math.Max(MinHiddenWidth, inputSize * 2));
+                hiddenLayerSizes.Add(Math.Max(MinHiddenWidth, inputSize));
                 break;
 
             default:
                 // Default to one hidden layer
-                hiddenLayerSizes.Add(inputSize);
+                hiddenLayerSizes.Add(Math.Max(MinHiddenWidth, inputSize));
                 break;
         }
 

--- a/tests/AiDotNet.Tests/IntegrationTests/NeuralNetworks/DefaultArchitectureLearnabilityTests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/NeuralNetworks/DefaultArchitectureLearnabilityTests.cs
@@ -1,0 +1,95 @@
+using System;
+using System.Linq;
+using AiDotNet.Enums;
+using AiDotNet.Models;
+using AiDotNet.NeuralNetworks;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tests.IntegrationTests.NeuralNetworks;
+
+/// <summary>
+/// Regression guard for the degenerate default-architecture bug: for low-dimensional tabular inputs
+/// the unfloored complexity formulas produced width-1/2 hidden layers ((inputSize+outputSize)/2 = 1
+/// for a 1→1 Simple net). With a width-2 ReLU hidden layer the init frequently leaves EVERY path
+/// dead over the whole input range (e.g. both second-layer weights negative), so no weight receives
+/// a gradient and only the output bias trains — the network is permanently a constant function.
+/// Observed concretely: a 1-input Simple/Medium regression net trained on y = 2x + 1 predicted the
+/// identical constant for every probe input, with only the final bias parameter moving.
+/// </summary>
+public class DefaultArchitectureLearnabilityTests
+{
+    private static NeuralNetwork<double> BuildNet(NetworkComplexity complexity) => new(
+        new NeuralNetworkArchitecture<double>(
+            inputType: InputType.OneDimensional,
+            taskType: NeuralNetworkTaskType.Regression,
+            complexity: complexity,
+            inputSize: 1,
+            outputSize: 1));
+
+    [Theory]
+    [InlineData(NetworkComplexity.Simple)]
+    [InlineData(NetworkComplexity.Medium)]
+    public void Default_one_input_regression_net_is_not_a_constant_function(NetworkComplexity complexity)
+    {
+        var net = BuildNet(complexity);
+
+        // Train y = 2x + 1 over x in [-1, 1], mini-batches of 10, 250 epochs — the exact setup that
+        // exposed the dead net (predictions frozen at one constant for every input).
+        const int n = 70;
+        for (int epoch = 0; epoch < 250; epoch++)
+        {
+            for (int start = 0; start < n; start += 10)
+            {
+                int cnt = Math.Min(10, n - start);
+                var bx = new double[cnt];
+                var by = new double[cnt];
+                for (int i = 0; i < cnt; i++)
+                {
+                    double xi = (start + i - 35) / 35.0;
+                    bx[i] = xi;
+                    by[i] = (2.0 * xi) + 1.0;
+                }
+
+                net.Train(
+                    new Tensor<double>(new[] { cnt, 1 }, new Vector<double>(bx)),
+                    new Tensor<double>(new[] { cnt, 1 }, new Vector<double>(by)));
+            }
+        }
+
+        var probes = new[] { -0.8, -0.4, 0.0, 0.4, 0.8 };
+        var preds = probes
+            .Select(p => net.Predict(new Tensor<double>(new[] { 1, 1 }, new Vector<double>(new[] { p })))[0])
+            .ToArray();
+
+        // Statistical invariants, not exact values: the trained function must (1) actually depend on
+        // its input and (2) be predominantly increasing on an increasing target. The dead net fails
+        // both (identical constant at every probe).
+        Assert.True(preds.Max() - preds.Min() > 0.5,
+            $"{complexity}: net is (near-)constant over the input range — hidden layers dead, only the output bias trained. " +
+            $"preds=[{string.Join(", ", preds.Select(v => v.ToString("F3")))}]");
+
+        int rising = 0;
+        for (int i = 1; i < preds.Length; i++)
+        {
+            if (preds[i] > preds[i - 1])
+            {
+                rising++;
+            }
+        }
+
+        Assert.True(rising >= 3,
+            $"{complexity}: predictions not predominantly increasing in x. " +
+            $"preds=[{string.Join(", ", preds.Select(v => v.ToString("F3")))}]");
+    }
+
+    [Fact]
+    public void Default_hidden_layers_have_a_sane_minimum_width()
+    {
+        // A 1→1 Simple net previously had 4 trainable parameters total (width-1 hidden layer).
+        // With the width floor the parameter count must reflect non-degenerate hidden layers.
+        var net = BuildNet(NetworkComplexity.Simple);
+        Assert.True(net.GetParameters().Length >= 25,
+            $"Expected floored hidden width (>=25 params for 1→8→1), got {net.GetParameters().Length} — hidden sizing regressed to degenerate widths.");
+    }
+}


### PR DESCRIPTION
## Bug

`LayerHelper.CreateDefaultNeuralNetworkLayers` sizes hidden layers purely from `inputSize` with no floor:

| Complexity | Formula | 1-input net gets |
|---|---|---|
| Simple | `(inputSize+outputSize)/2` | **width 1** |
| Medium | `[2·inputSize, inputSize]` | **widths 2, 1** |

A width-1/2 ReLU hidden layer is degenerate: the init frequently leaves **every** path dead over the entire input range (e.g. both second-layer weights negative → ReLU output 0 for all x), at which point no weight receives a gradient and only the output bias trains. The network is permanently a constant function.

## Evidence

A 1-input regression net trained on `y = 2x + 1` (70 rows, 60 epochs, mini-batch 10):
- Predictions: `0.210, 0.210, 0.210, 0.210, 0.210` at x = 0.1…0.9 — one constant for every input.
- Parameter dump epoch-over-epoch: **only the final bias moves**; the live first-layer path is frozen because the dead layer-2 ReLU blocks all upstream gradients.
- Identical loss trajectories for Simple AND Medium (both collapse the same way).

After flooring widths at 8: loss 4.75 → 0.99 in 60 epochs, predictions monotonic (`-0.31, 0.50, 2.03` tracking the target).

## Fix

Floor every default hidden width at `MinHiddenWidth = 8` in the complexity switch.

## Tests

`DefaultArchitectureLearnabilityTests`:
- 1-input Simple/Medium nets trained on `y = 2x + 1` must be non-constant (range > 0.5) and predominantly increasing — statistical invariants, robust to training stochasticity. Both fail on master.
- Parameter-count floor guard (Simple 1→1 had 4 params total on master).

Found while building the `ConfigureTrainingGroups` facade e2e test — initially looked like the grouped training loop not training; bisected to bare `net.Train` reproducing the same constant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)