### PR TITLE
ci: cancel orphaned pr runs server-side via concurrency-group eviction

### DIFF
--- a/.github/workflows/cancel-on-pr-close.yml
+++ b/.github/workflows/cancel-on-pr-close.yml
@@ -20,6 +20,57 @@ permissions:
   actions: write
 
 jobs:
+  # ── Server-side eviction (the runner-proof path) ──────────────────────────
+  # GitHub evaluates a job's `concurrency` group AT QUEUE TIME, the moment the
+  # run is created — BEFORE any runner is assigned. Entering a heavy workflow's
+  # group with cancel-in-progress: true therefore cancels its in-flight run
+  # immediately and server-side, even while this job itself sits queued.
+  #
+  # This is the fix for the saturation deadlock: the API-sweep job below needs
+  # a runner, and when the pool is saturated by the very runs it must cancel,
+  # it queues BEHIND them and fires ~45 minutes too late. The eviction jobs'
+  # side effect needs no runner at all; their bodies are no-ops.
+  #
+  # Group keys must mirror the heavy workflows' own `concurrency.group`
+  # expressions exactly, evaluated in this (pull_request: closed) context:
+  #   - sonarcloud.yml:  build-${{ github.event.pull_request.number || github.ref }}
+  #   - ci-website.yml:  ci-website-${{ github.head_ref }}
+  #   - codacy.yml:      codacy-${{ github.ref }}  (refs/pull/N/merge on PR events)
+  evict-build-group:
+    name: Evict Build & SonarCloud concurrency group
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    concurrency:
+      group: build-${{ github.event.pull_request.number }}
+      cancel-in-progress: true
+    steps:
+      - run: echo "Evicted concurrency group build-${{ github.event.pull_request.number }} (cancellation happened server-side at queue time)."
+
+  evict-ci-website-group:
+    name: Evict ci-website concurrency group
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    concurrency:
+      group: ci-website-${{ github.event.pull_request.head.ref }}
+      cancel-in-progress: true
+    steps:
+      - run: echo "Evicted concurrency group ci-website-${{ github.event.pull_request.head.ref }}."
+
+  evict-codacy-group:
+    name: Evict codacy concurrency group
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    concurrency:
+      group: codacy-${{ github.ref }}
+      cancel-in-progress: true
+    steps:
+      - run: echo "Evicted concurrency group codacy-${{ github.ref }}."
+
+  # ── API sweep (defense-in-depth) ──────────────────────────────────────────
+  # Catches workflows whose group keys can't be reproduced here (group strings
+  # embedding ${{ github.workflow }} evaluate to THIS workflow's name in this
+  # context) plus queued-but-not-started runs. May fire late under saturation —
+  # the eviction jobs above already killed the long runs by then.
   cancel:
     name: Cancel orphaned PR runs
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Problem

When a PR is merged or closed, `cancel-on-pr-close.yml` cancels the PR's in-flight runs via the Actions API — but that cancel job needs a runner. When the runner pool is saturated by the very runs it is supposed to cancel, the cancel job **queues behind them** and fires ~45 minutes too late. The orphaned Build & SonarCloud run keeps burning a slot the whole time, compounding the saturation across every open PR — this was holding up CI across the board.

## Fix: server-side cancellation that needs no runner

GitHub evaluates a job's `concurrency` group **at queue time**, the moment the run is created — before any runner is assigned. This PR adds three no-op "eviction" jobs that enter the heavy PR workflows' exact concurrency groups with `cancel-in-progress: true`:

| Eviction job | Group entered | Heavy workflow |
|---|---|---|
| `evict-build-group` | `build-<PR#>` | Build & SonarCloud (16 jobs, ~45 min) |
| `evict-ci-website-group` | `ci-website-<head-ref>` | ci-website |
| `evict-codacy-group` | `codacy-refs/pull/N/merge` | codacy |

The in-flight runs are cancelled **immediately and server-side on PR close, regardless of runner availability** — the eviction jobs' own bodies are no-ops and it doesn't matter when (or whether) they ever execute.

The existing API sweep job is kept as defense-in-depth: it catches queued runs and workflows whose group keys embed their own workflow name (not reproducible from this workflow's context). It may still fire late under saturation, but by then the eviction jobs have already killed the long runs.

## Why it takes effect for all open PRs immediately

`pull_request` events execute the workflow definition from the PR's **merge ref** (head merged into base), so as soon as this lands on master, every open PR's close event runs this updated workflow.

## Verification

- YAML validated; all three group expressions cross-checked character-for-character against `sonarcloud.yml`, `ci-website.yml`, and `codacy.yml`, evaluated in the `pull_request: closed` context (`pull_request.number` is set; `head_ref` is set; `github.ref` is `refs/pull/N/merge` for both the original run and the close event).

🤖 Generated with [Claude Code](https://claude.com/claude-code)