### PR TITLE
fix(fitness): R² calculators declared lower-is-better — optimizers kept the WORST iterate

### DIFF
--- a/src/FitnessCalculators/AdjustedRSquaredFitnessCalculator.cs
+++ b/src/FitnessCalculators/AdjustedRSquaredFitnessCalculator.cs
@@ -41,12 +41,13 @@ public class AdjustedRSquaredFitnessCalculator<T, TInput, TOutput> : FitnessCalc
     /// - Validation: A separate set of data used to tune the model (default and recommended)
     /// - Test: A completely separate set of data used for final evaluation
     /// 
-    /// We set "isHigherScoreBetter" to false because in AiDotNet, fitness scores are used for
-    /// optimization where lower values are considered better. This is just an internal convention -
-    /// you should still interpret Adjusted R-Squared in the normal way (higher is better).
+    /// Adjusted R² is a HIGHER-IS-BETTER metric, so "isHigherScoreBetter" is true. (It was
+    /// previously declared false on the claim of an internal lower-is-better convention — no such
+    /// negation existed: GetFitnessScore returns the raw Adjusted R², so optimizers comparing via
+    /// IsBetterFitness kept the WORST iterate ever evaluated.)
     /// </para>
     /// </remarks>
-    public AdjustedRSquaredFitnessCalculator(DataSetType dataSetType = DataSetType.Validation) : base(isHigherScoreBetter: false, dataSetType)
+    public AdjustedRSquaredFitnessCalculator(DataSetType dataSetType = DataSetType.Validation) : base(isHigherScoreBetter: true, dataSetType)
     {
     }
 

--- a/src/FitnessCalculators/RSquaredFitnessCalculator.cs
+++ b/src/FitnessCalculators/RSquaredFitnessCalculator.cs
@@ -62,10 +62,10 @@ public class RSquaredFitnessCalculator<T, TInput, TOutput> : FitnessCalculatorBa
     ///   * Validation: A separate set of data used to tune the model (recommended)
     ///   * Test: A completely separate set of data used for final evaluation
     /// 
-    /// Note: We set "isHigherScoreBetter" to "false" in the base constructor, which might seem 
-    /// counterintuitive since higher R² values are actually better. This is because some optimization 
-    /// algorithms in the library are designed to minimize values. The calculator handles this internally 
-    /// so that optimization works correctly while still interpreting R² in the standard way (higher is better).
+    /// R² is a HIGHER-IS-BETTER metric, so "isHigherScoreBetter" is true. (It was previously
+    /// declared false on the claim that "the calculator handles this internally" — it did not:
+    /// GetFitnessScore returns the raw R², so every optimizer comparing via IsBetterFitness kept
+    /// the WORST iterate ever evaluated, typically the untrained baseline model.)
     /// 
     /// When to use this calculator:
     /// - When you want to know how much of the variation in your data your model explains
@@ -74,7 +74,7 @@ public class RSquaredFitnessCalculator<T, TInput, TOutput> : FitnessCalculatorBa
     /// - For regression problems (predicting continuous values)
     /// </para>
     /// </remarks>
-    public RSquaredFitnessCalculator(DataSetType dataSetType = DataSetType.Validation) : base(isHigherScoreBetter: false, dataSetType)
+    public RSquaredFitnessCalculator(DataSetType dataSetType = DataSetType.Validation) : base(isHigherScoreBetter: true, dataSetType)
     {
     }
 
@@ -97,9 +97,8 @@ public class RSquaredFitnessCalculator<T, TInput, TOutput> : FitnessCalculatorBa
     /// 
     /// This method simply retrieves the pre-calculated R² value from the dataset's prediction statistics.
     /// 
-    /// Note: While higher R² values are better, some optimization algorithms in the library are designed
-    /// to minimize values. The calculator handles this internally so that optimization works correctly
-    /// while still interpreting R² in the standard way (higher is better).
+    /// Higher R² is better and the calculator declares exactly that — no internal negation exists
+    /// or is needed.
     /// </para>
     /// </remarks>
     protected override T GetFitnessScore(DataSetStats<T, TInput, TOutput> dataSet)

--- a/tests/AiDotNet.Tests/IntegrationTests/FitnessCalculators/FitnessCalculatorsIntegrationTests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/FitnessCalculators/FitnessCalculatorsIntegrationTests.cs
@@ -100,20 +100,19 @@ public class FitnessCalculatorsIntegrationTests
     }
 
     [Fact(Timeout = 120000)]
-    public async Task RSquaredFitnessCalculator_IsHigherScoreBetter_ReturnsFalse()
+    public async Task RSquaredFitnessCalculator_IsHigherScoreBetter_ReturnsTrue()
     {
-        // Note: R² fitness calculator uses isHigherScoreBetter=false for optimization compatibility
+        // R² is higher-is-better; the calculator returns the raw R² with no internal negation.
         var calculator = new RSquaredFitnessCalculator<double, Matrix<double>, Vector<double>>();
-        Assert.False(calculator.IsHigherScoreBetter);
+        Assert.True(calculator.IsHigherScoreBetter);
     }
 
     [Fact(Timeout = 120000)]
-    public async Task RSquaredFitnessCalculator_IsBetterFitness_LowerIsBetter()
+    public async Task RSquaredFitnessCalculator_IsBetterFitness_HigherIsBetter()
     {
-        // Note: For optimization consistency, all fitness calculators use lower-is-better comparison
         var calculator = new RSquaredFitnessCalculator<double, Matrix<double>, Vector<double>>();
-        Assert.True(calculator.IsBetterFitness(0.1, 0.5));
-        Assert.False(calculator.IsBetterFitness(0.5, 0.1));
+        Assert.False(calculator.IsBetterFitness(0.1, 0.5));
+        Assert.True(calculator.IsBetterFitness(0.5, 0.1));
     }
 
     #endregion
@@ -128,20 +127,19 @@ public class FitnessCalculatorsIntegrationTests
     }
 
     [Fact(Timeout = 120000)]
-    public async Task AdjustedRSquaredFitnessCalculator_IsHigherScoreBetter_ReturnsFalse()
+    public async Task AdjustedRSquaredFitnessCalculator_IsHigherScoreBetter_ReturnsTrue()
     {
-        // Note: Adjusted R² fitness calculator uses isHigherScoreBetter=false for optimization compatibility
+        // Adjusted R² is higher-is-better; no internal negation exists.
         var calculator = new AdjustedRSquaredFitnessCalculator<double, Matrix<double>, Vector<double>>();
-        Assert.False(calculator.IsHigherScoreBetter);
+        Assert.True(calculator.IsHigherScoreBetter);
     }
 
     [Fact(Timeout = 120000)]
-    public async Task AdjustedRSquaredFitnessCalculator_IsBetterFitness_LowerIsBetter()
+    public async Task AdjustedRSquaredFitnessCalculator_IsBetterFitness_HigherIsBetter()
     {
-        // Note: For optimization consistency, all fitness calculators use lower-is-better comparison
         var calculator = new AdjustedRSquaredFitnessCalculator<double, Matrix<double>, Vector<double>>();
-        Assert.True(calculator.IsBetterFitness(0.1, 0.5));
-        Assert.False(calculator.IsBetterFitness(0.5, 0.1));
+        Assert.False(calculator.IsBetterFitness(0.1, 0.5));
+        Assert.True(calculator.IsBetterFitness(0.5, 0.1));
     }
 
     #endregion

--- a/tests/AiDotNet.Tests/IntegrationTests/Optimizers/FitnessDirectionRegressionTests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/Optimizers/FitnessDirectionRegressionTests.cs
@@ -51,8 +51,10 @@ public class FitnessDirectionRegressionTests
     public async Task Facade_optimizer_returns_an_improved_iterate_not_the_baseline()
     {
         // y = 0.5x on pre-scaled inputs: trivially learnable. Under the inverted comparator the
-        // build returns the UNTRAINED baseline (random slope, ~50% chance anti-correlated); with
-        // the fix the returned model must track the target's increasing relationship.
+        // build returns the UNTRAINED baseline; with the fix it must return a model that beats the
+        // captured pre-training baseline on MSE. (Asserting on prediction-shape was brittle across
+        // architectures — tiny ReLU nets can converge to lopsided fits that are still vastly better
+        // than the baseline. MSE-vs-baseline is the exact invariant the bug violated.)
         const int n = 100;
         var x = new double[n];
         var y = new double[n];
@@ -62,13 +64,25 @@ public class FitnessDirectionRegressionTests
             y[i] = 0.5 * x[i];
         }
 
+        var net = new NeuralNetwork<double>(new NeuralNetworkArchitecture<double>(
+            inputType: InputType.OneDimensional,
+            taskType: NeuralNetworkTaskType.Regression,
+            complexity: NetworkComplexity.Simple,
+            inputSize: 1,
+            outputSize: 1));
+
+        var probes = new[] { -1.5, -0.75, 0.0, 0.75, 1.5 };
+        var targets = probes.Select(p => 0.5 * p).ToArray();
+
+        double Mse(Func<double, double> f) =>
+            probes.Select((p, i) => Math.Pow(f(p) - targets[i], 2)).Average();
+
+        // Capture the untrained baseline's error BEFORE training mutates the instance.
+        double baselineMse = Mse(p => net.Predict(
+            new Tensor<double>(new[] { 1, 1 }, new Vector<double>(new[] { p })))[0]);
+
         var result = await new AiModelBuilder<double, Tensor<double>, Tensor<double>>()
-            .ConfigureModel(new NeuralNetwork<double>(new NeuralNetworkArchitecture<double>(
-                inputType: InputType.OneDimensional,
-                taskType: NeuralNetworkTaskType.Regression,
-                complexity: NetworkComplexity.Simple,
-                inputSize: 1,
-                outputSize: 1)))
+            .ConfigureModel(net)
             .ConfigureDataLoader(DataLoaders.FromTensors(
                 new Tensor<double>(new[] { n, 1 }, new Vector<double>(x)),
                 new Tensor<double>(new[] { n, 1 }, new Vector<double>(y))))
@@ -77,26 +91,14 @@ public class FitnessDirectionRegressionTests
                 options: new AdamOptimizerOptions<double, Tensor<double>, Tensor<double>> { MaxIterations = 250 }))
             .BuildAsync();
 
-        var probes = new[] { -1.5, -0.75, 0.0, 0.75, 1.5 };
-        var preds = probes
-            .Select(p => result.Predict(new Tensor<double>(new[] { 1, 1 }, new Vector<double>(new[] { p })))[0])
-            .ToArray();
+        double resultMse = Mse(p => result.Predict(
+            new Tensor<double>(new[] { 1, 1 }, new Vector<double>(new[] { p })))[0]);
 
-        int rising = 0;
-        for (int i = 1; i < preds.Length; i++)
-        {
-            if (preds[i] > preds[i - 1])
-            {
-                rising++;
-            }
-        }
-
-        // The inverted comparator returns the baseline (random sign — frequently DECREASING).
-        // A correctly-selected trained model must be increasing overall and non-trivial. (rising >= 2,
-        // not 4: tiny ReLU nets legitimately saturate flat on part of the range while still fitting
-        // the other side — the bug signature is a DECREASING/flat-everywhere baseline.)
-        Assert.True(rising >= 2 && preds[4] > preds[0] && preds[4] - preds[0] > 0.2,
-            "Optimizer returned a non-improved (baseline-like) model — best-solution selection direction regressed. " +
-            $"preds=[{string.Join(", ", preds.Select(v => v.ToString("F3")))}]");
+        // The inverted comparator freezes the baseline in as "best" → resultMse == baselineMse.
+        // A correct selection returns an iterate with materially lower error (or the baseline was
+        // already essentially perfect, which a random init never is on this target).
+        Assert.True(resultMse < (baselineMse * 0.8) || resultMse < 0.02,
+            $"Optimizer did not return an improved iterate: baselineMse={baselineMse:F4}, resultMse={resultMse:F4} " +
+            "— best-solution selection direction regressed (kept the pre-training baseline).");
     }
 }

--- a/tests/AiDotNet.Tests/IntegrationTests/Optimizers/FitnessDirectionRegressionTests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/Optimizers/FitnessDirectionRegressionTests.cs
@@ -1,0 +1,102 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using AiDotNet.Data.Loaders;
+using AiDotNet.Enums;
+using AiDotNet.FitnessCalculators;
+using AiDotNet.Models;
+using AiDotNet.Models.Options;
+using AiDotNet.NeuralNetworks;
+using AiDotNet.Optimizers;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tests.IntegrationTests.Optimizers;
+
+/// <summary>
+/// Regression guard for the inverted default-fitness-direction bug: RSquaredFitnessCalculator (the
+/// DEFAULT calculator on OptimizationAlgorithmOptions) declared isHigherScoreBetter: false while
+/// GetFitnessScore returns the RAW R² with no internal negation (despite docs claiming "the
+/// calculator handles this internally"). IsBetterFitness therefore preferred LOWER R², so every
+/// optimizer's UpdateBestSolution kept the WORST iterate ever evaluated — typically the untrained
+/// pre-training baseline from PrepareAndEvaluateSolution. Observed: a facade NN trained 250 epochs
+/// on a perfectly-correlated y = 0.58x returned a model ANTI-correlated with the target (the random
+/// init happened to slope negative; per-epoch fitness improved monotonically -4.38 → -4.00 while
+/// the returned BestSolution stayed frozen at the baseline).
+/// </summary>
+public class FitnessDirectionRegressionTests
+{
+    [Fact]
+    public void RSquared_calculators_prefer_higher_scores()
+    {
+        var r2 = new RSquaredFitnessCalculator<double, Matrix<double>, Vector<double>>();
+        Assert.True(r2.IsHigherScoreBetter, "R² is a higher-is-better metric");
+        Assert.True(r2.IsBetterFitness(0.9, 0.1), "R² 0.9 must beat 0.1");
+        Assert.False(r2.IsBetterFitness(-4.0, 0.5), "negative R² must not beat positive");
+
+        var adj = new AdjustedRSquaredFitnessCalculator<double, Matrix<double>, Vector<double>>();
+        Assert.True(adj.IsHigherScoreBetter, "Adjusted R² is a higher-is-better metric");
+        Assert.True(adj.IsBetterFitness(0.9, 0.1));
+    }
+
+    [Fact]
+    public void Error_calculators_still_prefer_lower_scores()
+    {
+        var mse = new MeanSquaredErrorFitnessCalculator<double, Matrix<double>, Vector<double>>();
+        Assert.False(mse.IsHigherScoreBetter);
+        Assert.True(mse.IsBetterFitness(0.1, 0.9), "MSE 0.1 must beat 0.9");
+    }
+
+    [Fact]
+    public async Task Facade_optimizer_returns_an_improved_iterate_not_the_baseline()
+    {
+        // y = 0.5x on pre-scaled inputs: trivially learnable. Under the inverted comparator the
+        // build returns the UNTRAINED baseline (random slope, ~50% chance anti-correlated); with
+        // the fix the returned model must track the target's increasing relationship.
+        const int n = 100;
+        var x = new double[n];
+        var y = new double[n];
+        for (int i = 0; i < n; i++)
+        {
+            x[i] = (i - 50) / 29.0;
+            y[i] = 0.5 * x[i];
+        }
+
+        var result = await new AiModelBuilder<double, Tensor<double>, Tensor<double>>()
+            .ConfigureModel(new NeuralNetwork<double>(new NeuralNetworkArchitecture<double>(
+                inputType: InputType.OneDimensional,
+                taskType: NeuralNetworkTaskType.Regression,
+                complexity: NetworkComplexity.Simple,
+                inputSize: 1,
+                outputSize: 1)))
+            .ConfigureDataLoader(DataLoaders.FromTensors(
+                new Tensor<double>(new[] { n, 1 }, new Vector<double>(x)),
+                new Tensor<double>(new[] { n, 1 }, new Vector<double>(y))))
+            .ConfigureOptimizer(new AdamOptimizer<double, Tensor<double>, Tensor<double>>(
+                model: null,
+                options: new AdamOptimizerOptions<double, Tensor<double>, Tensor<double>> { MaxIterations = 250 }))
+            .BuildAsync();
+
+        var probes = new[] { -1.5, -0.75, 0.0, 0.75, 1.5 };
+        var preds = probes
+            .Select(p => result.Predict(new Tensor<double>(new[] { 1, 1 }, new Vector<double>(new[] { p })))[0])
+            .ToArray();
+
+        int rising = 0;
+        for (int i = 1; i < preds.Length; i++)
+        {
+            if (preds[i] > preds[i - 1])
+            {
+                rising++;
+            }
+        }
+
+        // The inverted comparator returns the baseline (random sign — frequently DECREASING).
+        // A correctly-selected trained model must be increasing overall and non-trivial. (rising >= 2,
+        // not 4: tiny ReLU nets legitimately saturate flat on part of the range while still fitting
+        // the other side — the bug signature is a DECREASING/flat-everywhere baseline.)
+        Assert.True(rising >= 2 && preds[4] > preds[0] && preds[4] - preds[0] > 0.2,
+            "Optimizer returned a non-improved (baseline-like) model — best-solution selection direction regressed. " +
+            $"preds=[{string.Join(", ", preds.Select(v => v.ToString("F3")))}]");
+    }
+}

--- a/tests/AiDotNet.Tests/UnitTests/FitnessCalculators/RSquaredFitnessCalculatorTests.cs
+++ b/tests/AiDotNet.Tests/UnitTests/FitnessCalculators/RSquaredFitnessCalculatorTests.cs
@@ -131,36 +131,33 @@ public class RSquaredFitnessCalculatorTests
     }
 
     [Fact(Timeout = 60000)]
-    public async Task IsHigherScoreBetter_ReturnsFalse()
+    public async Task IsHigherScoreBetter_ReturnsTrue()
     {
         // Arrange
         var calculator = new RSquaredFitnessCalculator<double, Vector<double>, Vector<double>>();
 
         // Act & Assert
-        // The calculator sets IsHigherScoreBetter to false because some optimization algorithms
-        // in the library are designed to minimize values. This allows the optimizer to work
-        // correctly while the calculator still interprets R² in the standard way (higher is better).
-        Assert.False(calculator.IsHigherScoreBetter);
+        // R² is a higher-is-better metric and GetFitnessScore returns the RAW R² (no negation).
+        // The previous false declaration made every optimizer's best-solution selection keep the
+        // WORST iterate (typically the untrained baseline) — see FitnessDirectionRegressionTests.
+        Assert.True(calculator.IsHigherScoreBetter);
     }
 
     [Fact(Timeout = 60000)]
-    public async Task IsBetterFitness_WithLowerScore_ReturnsTrue()
+    public async Task IsBetterFitness_WithLowerScore_ReturnsFalse()
     {
         // Arrange
         var calculator = new RSquaredFitnessCalculator<double, Vector<double>, Vector<double>>();
 
-        // Act
-        // Since IsHigherScoreBetter is false (for optimizer compatibility), IsBetterFitness
-        // considers lower values as "better" internally. This allows minimization-based
-        // optimizers to work correctly with R² without special handling.
+        // Act — a lower R² is a worse fit and must NOT be considered better.
         var result = calculator.IsBetterFitness(0.5, 0.8);
 
         // Assert
-        Assert.True(result);
+        Assert.False(result);
     }
 
     [Fact(Timeout = 60000)]
-    public async Task IsBetterFitness_WithHigherScore_ReturnsFalse()
+    public async Task IsBetterFitness_WithHigherScore_ReturnsTrue()
     {
         // Arrange
         var calculator = new RSquaredFitnessCalculator<double, Vector<double>, Vector<double>>();
@@ -169,7 +166,7 @@ public class RSquaredFitnessCalculatorTests
         var result = calculator.IsBetterFitness(0.9, 0.6);
 
         // Assert
-        Assert.False(result);
+        Assert.True(result);
     }
 
     [Fact(Timeout = 60000)]


### PR DESCRIPTION
## Bug

`RSquaredFitnessCalculator` — the **default** `FitnessCalculator` on `OptimizationAlgorithmOptions` — passes `isHigherScoreBetter: false`, while `GetFitnessScore` returns the **raw R²** with no negation. The XML docs claim "the calculator handles this internally so that optimization works correctly" — no such handling exists anywhere. `AdjustedRSquaredFitnessCalculator` has the same defect.

Consequence: `IsBetterFitness` prefers **lower** R², so `UpdateBestSolution` in every optimizer keeps the **worst iterate ever evaluated** — typically the untrained pre-training baseline from `PrepareAndEvaluateSolution`.

## Evidence

Facade NN + `AdamOptimizer`, 250 epochs, on perfectly correlated data (a spy optimizer verified `corr(X,y)=+1.0000` at the `Optimize` boundary):

- Per-epoch validation fitness improved monotonically: `-4.38 → -4.19 → -4.00 → …` (training descends correctly)
- The returned `BestSolution` stayed frozen at the **baseline** — a random init that happened to slope negative — so `BuildAsync` returned a model **anti-correlated** with its target.

Every facade `BuildAsync` using the default calculator silently returns a near-untrained model. (This also retro-explains downstream reports of facade-trained NNs losing to trivial baselines.)

## Fix

`isHigherScoreBetter: true` for both R² calculators. MAE/MSE/RMSE calculators are already correctly `false`. Docs corrected. The unit/integration tests that had **pinned the inverted behavior** (`IsHigherScoreBetter_ReturnsFalse`, `IsBetterFitness_LowerIsBetter`) are updated to the correct contract.

## Tests

- `FitnessDirectionRegressionTests`: direction contracts for R²/Adjusted-R²/MSE + an e2e guard that a facade Adam build on `y = 0.5x` returns an *improved* (increasing) model, not the baseline. The e2e fails on master.
- Optimizer/fitness slice: 774/776 pass (1 skip; 1 pre-existing `Issue1296LargeXTrainBatchingTests` memory failure reproduced on pristine master, unrelated — will file separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)