### PR TITLE
fix(neuralnetworks): align rank-1 regression targets ([B] vs [B,1]) at every training entry point

### DIFF
--- a/src/NeuralNetworks/NeuralNetworkBase.cs
+++ b/src/NeuralNetworks/NeuralNetworkBase.cs
@@ -3363,15 +3363,7 @@ public abstract class NeuralNetworkBase<T> : INeuralNetworkModel<T>, IInterpreta
                 var prediction = ForwardForTraining(xChunk);
 
                 // Align target to prediction shape — same policy as TrainWithTape.
-                var alignedTarget = yChunk;
-                if (prediction.Rank > yChunk.Rank && prediction.Shape[0] == 1 && prediction.Length == yChunk.Length)
-                {
-                    alignedTarget = Engine.Reshape(yChunk, prediction._shape);
-                }
-                else if (yChunk.Rank > prediction.Rank && yChunk.Shape[0] == 1 && yChunk.Length == prediction.Length)
-                {
-                    alignedTarget = Engine.Reshape(yChunk, prediction._shape);
-                }
+                var alignedTarget = AlignTargetToOutputShape(prediction, yChunk);
 
                 var lossTensor = loss.ComputeTapeLoss(prediction, alignedTarget);
                 T chunkLoss = lossTensor.Length > 0 ? lossTensor[0] : NumOps.Zero;
@@ -6269,14 +6261,7 @@ public abstract class NeuralNetworkBase<T> : INeuralNetworkModel<T>, IInterpreta
             // GradientFlow_ShouldBeNonZeroAndFinite). Reshaping `expected` instead
             // keeps `output` tape-connected end-to-end. Use the internal _shape field
             // (zero-alloc) rather than Shape.ToArray().
-            if (output.Rank > expected.Rank && output.Shape[0] == 1 && output.Length == expected.Length)
-            {
-                expected = Engine.Reshape(expected, output._shape);
-            }
-            else if (expected.Rank > output.Rank && expected.Shape[0] == 1 && expected.Length == output.Length)
-            {
-                expected = Engine.Reshape(expected, output._shape);
-            }
+            expected = AlignTargetToOutputShape(output, expected);
 
             var lossTensor = loss.ComputeTapeLoss(output, expected);
 
@@ -8645,6 +8630,50 @@ public abstract class NeuralNetworkBase<T> : INeuralNetworkModel<T>, IInterpreta
     /// stated policy that training and inference remain fully available. Explicit saves
     /// (<c>SaveModel</c>/<c>Serialize</c>) still enforce the license as before.
     /// </summary>
+    /// <summary>
+    /// Aligns a training target's shape to the network output before the loss computation.
+    /// Reshapes the TARGET (a leaf tensor not on the tape) rather than the output (which IS on the
+    /// tape — see the gradient-chain note in TrainWithTape). Handles, in order:
+    /// (1) leading singleton batch dims (legacy policy: [1, ...] vs [...]), and
+    /// (2) rank-off-by-one trailing singletons — the industry-standard rank-1 regression target
+    ///     ([B] vs output [B, 1], or [B, S] vs [B, S, 1], and the symmetric [B, 1] target vs [B]
+    ///     output). Without this, regression losses crash in TensorSubtract on the most common
+    ///     target shape every other ML stack accepts (sklearn y=(n,), PyTorch broadcasting).
+    /// Only fires when element counts match and the extra dimension is exactly 1, so integer
+    /// class-index targets against [B, C&gt;1] logits are never touched (the loss one-hots those).
+    /// </summary>
+    private Tensor<T> AlignTargetToOutputShape(Tensor<T> output, Tensor<T> expected)
+    {
+        if (output.Rank == expected.Rank || output.Length != expected.Length)
+        {
+            return expected;
+        }
+
+        // Legacy leading-singleton policy.
+        if (output.Rank > expected.Rank && output.Shape[0] == 1)
+        {
+            return Engine.Reshape(expected, output._shape);
+        }
+
+        if (expected.Rank > output.Rank && expected.Shape[0] == 1)
+        {
+            return Engine.Reshape(expected, output._shape);
+        }
+
+        // Rank-off-by-one trailing singleton: [B] target vs [B,1] output (or [B,1] vs [B]).
+        if (output.Rank == expected.Rank + 1 && output.Shape[output.Rank - 1] == 1)
+        {
+            return Engine.Reshape(expected, output._shape);
+        }
+
+        if (expected.Rank == output.Rank + 1 && expected.Shape[expected.Rank - 1] == 1)
+        {
+            return Engine.Reshape(expected, output._shape);
+        }
+
+        return expected;
+    }
+
     protected byte[] SerializeForMetadata()
     {
         try
@@ -9437,9 +9466,16 @@ public abstract class NeuralNetworkBase<T> : INeuralNetworkModel<T>, IInterpreta
                 "layer implementing ITrainableLayer<T> with registered parameters.");
         }
 
+        // Align rank-off-by-one regression targets ([B] vs [B,1]) BEFORE the loss: classification
+        // index targets are handled inside the loss (EnsureTargetMatchesPredicted one-hots them),
+        // but regression losses subtract tensors directly and crash on the industry-standard
+        // rank-1 target shape. AlignTargetToOutputShape only fires on a trailing singleton, so
+        // class-index targets against [B, C>1] logits are untouched.
+        target = AlignTargetToOutputShape(prediction, target);
+
         // Compute loss via the user's configured loss function.
-        // Shape matching (integer → one-hot, singleton reshape) is handled
-        // inside each loss function's ComputeTapeLoss via EnsureTargetMatchesPredicted.
+        // Integer-class → one-hot matching is handled inside each loss function's
+        // ComputeTapeLoss via EnsureTargetMatchesPredicted.
         var resolved = lossFunction ?? LossFunction;
         Tensor<T> lossTensor;
         if (resolved is LossFunctions.LossFunctionBase<T> tapeLoss)

--- a/tests/AiDotNet.Tests/IntegrationTests/NeuralNetworks/RankOneTargetAlignmentTests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/NeuralNetworks/RankOneTargetAlignmentTests.cs
@@ -1,0 +1,104 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using AiDotNet.Data.Loaders;
+using AiDotNet.Enums;
+using AiDotNet.Models;
+using AiDotNet.Models.Options;
+using AiDotNet.NeuralNetworks;
+using AiDotNet.Optimizers;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tests.IntegrationTests.NeuralNetworks;
+
+/// <summary>
+/// Regression guard: rank-1 regression targets ([B] against a [B,1] network output) are the
+/// industry-standard target shape (sklearn's y is (n,); PyTorch broadcasts [B] vs [B,1]) but
+/// crashed AiDotNet's training paths with "Tensor shapes must match. Got [B, 1] and [B]" —
+/// regression losses subtract tensors directly, the only in-loss shape handling
+/// (EnsureTargetMatchesPredicted) is a CLASSIFICATION one-hot encoder, and the network-level
+/// alignment policy only covered leading singleton batch dims. AlignTargetToOutputShape now
+/// aligns rank-off-by-one trailing singletons at every training entry point (Train/TrainWithTape,
+/// the chunked path, and ComputeGradients used by the facade optimizer loop).
+/// </summary>
+public class RankOneTargetAlignmentTests
+{
+    private static NeuralNetwork<double> BuildNet() => new(new NeuralNetworkArchitecture<double>(
+        inputType: InputType.OneDimensional,
+        taskType: NeuralNetworkTaskType.Regression,
+        complexity: NetworkComplexity.Simple,
+        inputSize: 1,
+        outputSize: 1));
+
+    private static (Tensor<double> X, Tensor<double> YRank1) LinearData(int n)
+    {
+        var x = new double[n];
+        var y = new double[n];
+        for (int i = 0; i < n; i++)
+        {
+            x[i] = (i - (n / 2)) / (double)n * 2.0;
+            y[i] = 0.5 * x[i];
+        }
+
+        return (
+            new Tensor<double>(new[] { n, 1 }, new Vector<double>(x)),
+            new Tensor<double>(new[] { n }, new Vector<double>(y)));
+    }
+
+    [Fact]
+    public void Direct_Train_accepts_rank1_targets()
+    {
+        var (x, y) = LinearData(40);
+        var net = BuildNet();
+
+        // Crashed before the fix: MeanSquaredErrorLoss.ComputeTapeLoss → TensorSubtract([40,1],[40]).
+        var ex = Record.Exception(() => net.Train(x, y));
+        Assert.Null(ex);
+    }
+
+    [Fact]
+    public async Task Facade_optimizer_path_accepts_rank1_targets_and_trains()
+    {
+        // The facade's Adam loop goes through ComputeGradients, which had NO regression target
+        // alignment at all (its comment wrongly delegated "singleton reshape" to the loss).
+        const int n = 100;
+        var (x, y) = LinearData(n);
+
+        var net = BuildNet();
+        var baseline = Probe(net, 1.0) - Probe(net, -1.0);
+
+        var result = await new AiModelBuilder<double, Tensor<double>, Tensor<double>>()
+            .ConfigureModel(net)
+            .ConfigureDataLoader(DataLoaders.FromTensors(x, y))
+            .ConfigureOptimizer(new AdamOptimizer<double, Tensor<double>, Tensor<double>>(
+                model: null,
+                options: new AdamOptimizerOptions<double, Tensor<double>, Tensor<double>> { MaxIterations = 100 }))
+            .BuildAsync();
+
+        // Beyond not crashing: training must have actually consumed the rank-1 targets — the
+        // returned model's probe MSE must beat a do-nothing zero predictor or show real slope.
+        var preds = new[] { -1.0, -0.5, 0.0, 0.5, 1.0 }
+            .Select(p => result.Predict(new Tensor<double>(new[] { 1, 1 }, new Vector<double>(new[] { p })))[0])
+            .ToArray();
+        Assert.True(preds.All(double.IsFinite), "non-finite predictions after rank-1 target training");
+        Assert.True(preds.Max() - preds.Min() > 1e-6 || Math.Abs(baseline) < 1e-9,
+            "model unchanged by training on rank-1 targets");
+    }
+
+    [Fact]
+    public void Symmetric_case_rank2_target_against_rank1_style_output_does_not_crash()
+    {
+        // [B,1] targets are the documented batch convention and must keep working.
+        var (x, _) = LinearData(40);
+        var y2 = new Tensor<double>(new[] { 40, 1 }, new Vector<double>(
+            Enumerable.Range(0, 40).Select(i => 0.5 * ((i - 20) / 40.0 * 2.0)).ToArray()));
+
+        var net = BuildNet();
+        var ex = Record.Exception(() => net.Train(x, y2));
+        Assert.Null(ex);
+    }
+
+    private static double Probe(NeuralNetwork<double> net, double v) =>
+        net.Predict(new Tensor<double>(new[] { 1, 1 }, new Vector<double>(new[] { v })))[0];
+}

--- a/tests/AiDotNet.Tests/IntegrationTests/NeuralNetworks/RankOneTargetAlignmentTests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/NeuralNetworks/RankOneTargetAlignmentTests.cs
@@ -81,7 +81,8 @@ public class RankOneTargetAlignmentTests
         var preds = new[] { -1.0, -0.5, 0.0, 0.5, 1.0 }
             .Select(p => result.Predict(new Tensor<double>(new[] { 1, 1 }, new Vector<double>(new[] { p })))[0])
             .ToArray();
-        Assert.True(preds.All(double.IsFinite), "non-finite predictions after rank-1 target training");
+        // double.IsFinite is net10-only; use the net471-compatible equivalent (same semantics).
+        Assert.True(preds.All(p => !double.IsNaN(p) && !double.IsInfinity(p)), "non-finite predictions after rank-1 target training");
         Assert.True(preds.Max() - preds.Min() > 1e-6 || Math.Abs(baseline) < 1e-9,
             "model unchanged by training on rank-1 targets");
     }


### PR DESCRIPTION
## Bug

Rank-1 regression targets — the industry-standard shape (sklearn's `y` is `(n,)`; PyTorch broadcasts `[B]` vs `[B,1]`) — crash every AiDotNet training path:

```
System.ArgumentException : Tensor shapes must match. Got [32, 1] and [32].
   at CpuEngine.TensorSubtract
   at MeanSquaredErrorLoss.ComputeTapeLoss
```

Three compounding gaps:
1. Regression losses (`MSE`, etc.) subtract tensors directly with no shape handling.
2. The only in-loss shape machinery, `EnsureTargetMatchesPredicted`, is a **classification one-hot encoder** — wrong tool for regression, and MSE doesn't even call it.
3. The network-level alignment policy (TrainWithTape + chunked path) only covers **leading** singleton batch dims; `ComputeGradients` (the facade optimizer's entry) has **no** alignment at all, with a comment delegating "singleton reshape" to the losses — which never implemented it.

## Fix

`AlignTargetToOutputShape` — one helper consolidating the legacy leading-singleton policy plus rank-off-by-one **trailing** singletons (`[B]` vs `[B,1]`, `[B,S]` vs `[B,S,1]`, and the symmetric case), applied at all three training entry sites. It reshapes the **target leaf**, not the tape-connected output (preserving the existing gradient-chain rationale), and only fires when element counts match and the extra dim is exactly 1 — integer class-index targets against `[B, C>1]` logits are untouched.

## Tests

`RankOneTargetAlignmentTests` (3): direct `Train` and the facade Adam path with rank-1 targets — **both crash on master** (verified via negative control); the `[B,1]` convention case stays green.

Broad NN+loss integration slice (1431 tests): **zero new failures** vs the master baseline run under identical conditions. The 26 failures in that slice are pre-existing on master and are being addressed separately. (One pre-existing flake, `Issue1227_TransformerTrain_NoLeakAtReporterConfig_L4`, passes with this fix.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)