### PR TITLE
fix(tests+graph): correct 15 NN deep-math tests to actual layer contracts; align LinkPredictionModel adjacency fallback

### DIFF
--- a/src/NeuralNetworks/Tasks/Graph/LinkPredictionModel.cs
+++ b/src/NeuralNetworks/Tasks/Graph/LinkPredictionModel.cs
@@ -89,6 +89,12 @@ public class LinkPredictionModel<T> : NeuralNetworkBase<T>
     private readonly IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>> _optimizer;
     private readonly LinkPredictionDecoder _decoderType;
     private Tensor<T>? _cachedAdjacencyMatrix;
+    // Tracks whether _cachedAdjacencyMatrix came from EnsureDefaultAdjacencyForInput
+    // (auto-inferred identity) vs an explicit SetAdjacencyMatrix call. Explicit
+    // matrices are sticky — caller knows the graph; auto-inferred ones must be
+    // regenerated whenever the input node count changes (same contract as
+    // GraphClassificationModel / NodeClassificationModel).
+    private bool _usesFallbackAdjacency;
     private Tensor<T>? _nodeEmbeddings;
 
     /// <summary>
@@ -228,6 +234,7 @@ public class LinkPredictionModel<T> : NeuralNetworkBase<T>
     public void SetAdjacencyMatrix(Tensor<T> adjacencyMatrix)
     {
         _cachedAdjacencyMatrix = adjacencyMatrix;
+        _usesFallbackAdjacency = false;
 
         foreach (var layer in Layers)
         {
@@ -236,6 +243,35 @@ public class LinkPredictionModel<T> : NeuralNetworkBase<T>
                 graphLayer.SetAdjacencyMatrix(adjacencyMatrix);
             }
         }
+    }
+
+    /// <summary>
+    /// Default-of-last-resort adjacency: when no explicit matrix was set, fall back to the
+    /// IDENTITY graph so scaffold invariants stay well-defined — per Kipf &amp; Welling 2017 §2,
+    /// with <c>A = I</c> the GCN encoder degenerates to a per-node dense transform. Production
+    /// callers SHOULD still call <see cref="SetAdjacencyMatrix"/> with the real graph structure.
+    /// Brings this model in line with the documented contract its siblings
+    /// (GraphClassificationModel / NodeClassificationModel) already implement.
+    /// </summary>
+    private void EnsureDefaultAdjacencyForInput(Tensor<T> input)
+    {
+        if (input.Rank < 1) return; // can't infer; let Forward throw with a clear shape error
+        int numNodes = input.Shape[0];
+
+        // Explicit matrices (from SetAdjacencyMatrix) are sticky. Auto-inferred ones must be
+        // regenerated when the input node count changes — otherwise the first inferred identity
+        // becomes stuck model state for a later differently-sized graph.
+        if (_cachedAdjacencyMatrix is not null
+            && (!_usesFallbackAdjacency || _cachedAdjacencyMatrix.Shape[0] == numNodes))
+        {
+            return;
+        }
+
+        var identity = new Tensor<T>(new[] { numNodes, numNodes });
+        for (int i = 0; i < numNodes; i++)
+            identity[i, i] = NumOps.One;
+        SetAdjacencyMatrix(identity);
+        _usesFallbackAdjacency = true;
     }
 
     /// <summary>
@@ -599,11 +635,7 @@ public class LinkPredictionModel<T> : NeuralNetworkBase<T>
     /// <returns>The node embeddings tensor.</returns>
     public override Tensor<T> Predict(Tensor<T> input)
     {
-        if (_cachedAdjacencyMatrix is null)
-        {
-            throw new InvalidOperationException(
-                "Adjacency matrix must be set using SetAdjacencyMatrix before calling Predict.");
-        }
+        EnsureDefaultAdjacencyForInput(input);
 
         foreach (var layer in Layers)
         {
@@ -620,11 +652,7 @@ public class LinkPredictionModel<T> : NeuralNetworkBase<T>
     /// <param name="expectedOutput">The expected output (edge scores).</param>
     public override void Train(Tensor<T> input, Tensor<T> expectedOutput)
     {
-        if (_cachedAdjacencyMatrix is null)
-        {
-            throw new InvalidOperationException(
-                "Adjacency matrix must be set using SetAdjacencyMatrix before calling Train.");
-        }
+        EnsureDefaultAdjacencyForInput(input);
 
         foreach (var layer in Layers)
         {

--- a/tests/AiDotNet.Tests/IntegrationTests/NeuralNetworks/GraphLayersIntegrationTests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/NeuralNetworks/GraphLayersIntegrationTests.cs
@@ -246,17 +246,37 @@ public class GraphLayersIntegrationTests
     }
 
     [Fact(Timeout = 120000)]
-    public async Task GraphConvolutionalLayer_WithoutAdjacencyMatrix_ThrowsException()
+    public async Task GraphConvolutionalLayer_WithoutAdjacencyMatrix_DefaultsToIdentity()
     {
-        // Arrange
+        // The layer's DOCUMENTED contract (EnsureDenseAdjacencyForInput) is a default-of-last-resort
+        // IDENTITY adjacency when none is set: per Kipf & Welling 2017 §2, with A = I the GCN layer
+        // degenerates to a per-node dense transform — well-defined for scaffold invariant checks.
+        // Production callers should still SetAdjacencyMatrix with the real graph. This test pins
+        // that the fallback IS exactly A = I by comparing against an explicit identity.
         int inputFeatures = 8;
         int outputFeatures = 16;
+        int numNodes = 5;
 
-        var layer = new GraphConvolutionalLayer<float>(inputFeatures, outputFeatures, (IActivationFunction<float>?)null);
-        var nodeFeatures = CreateNodeFeatures(5, inputFeatures);
+        var implicitLayer = new GraphConvolutionalLayer<float>(inputFeatures, outputFeatures, (IActivationFunction<float>?)null);
+        var nodeFeatures = CreateNodeFeatures(numNodes, inputFeatures);
+        var implicitOut = implicitLayer.Forward(nodeFeatures);
 
-        // Act & Assert
-        Assert.Throws<InvalidOperationException>(() => layer.Forward(nodeFeatures));
+        var explicitLayer = new GraphConvolutionalLayer<float>(inputFeatures, outputFeatures, (IActivationFunction<float>?)null);
+        explicitLayer.SetParameters(implicitLayer.GetParameters()); // identical weights
+        var identity = new Tensor<float>(new[] { numNodes, numNodes });
+        for (int i = 0; i < numNodes; i++)
+        {
+            identity[i, i] = 1.0f;
+        }
+
+        explicitLayer.SetAdjacencyMatrix(identity);
+        var explicitOut = explicitLayer.Forward(nodeFeatures);
+
+        Assert.Equal(implicitOut.Shape.ToArray(), explicitOut.Shape.ToArray());
+        for (int i = 0; i < implicitOut.Length; i++)
+        {
+            Assert.Equal(explicitOut[i], implicitOut[i], 5);
+        }
     }
 
     [Fact(Timeout = 120000)]

--- a/tests/AiDotNet.Tests/IntegrationTests/NeuralNetworks/MissingModelsIntegrationTests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/NeuralNetworks/MissingModelsIntegrationTests.cs
@@ -238,7 +238,8 @@ public class MissingModelsIntegrationTests
             Assert.True(output.Length > 0, $"{name} model produced empty output under the identity fallback");
             for (int i = 0; i < output.Length; i++)
             {
-                Assert.True(float.IsFinite(output[i]), $"{name} model produced non-finite output under the identity fallback");
+                // float.IsFinite is net10-only; use the net471-compatible equivalent (same semantics).
+                Assert.True(!float.IsNaN(output[i]) && !float.IsInfinity(output[i]), $"{name} model produced non-finite output under the identity fallback");
             }
         }
     }

--- a/tests/AiDotNet.Tests/IntegrationTests/NeuralNetworks/MissingModelsIntegrationTests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/NeuralNetworks/MissingModelsIntegrationTests.cs
@@ -204,8 +204,14 @@ public class MissingModelsIntegrationTests
     }
 
     [Fact(Timeout = 120000)]
-    public async Task GraphModels_RequireAdjacencyMatrix()
+    public async Task GraphModels_PredictWithoutAdjacency_UsesDocumentedIdentityFallback()
     {
+        // The graph models' DOCUMENTED contract (EnsureDefaultAdjacencyForInput) is a
+        // default-of-last-resort identity adjacency on Predict/Train when none was set —
+        // per Kipf & Welling 2017 §2 an A = I graph degenerates the GCN to per-node dense
+        // transforms, keeping scaffold invariants well-defined. Production callers should
+        // still call SetAdjacencyMatrix with the real graph. This pins that Predict succeeds
+        // and produces finite output instead of throwing.
         int numNodes = 3;
         int inputFeatures = 2;
         int numClasses = 2;
@@ -222,9 +228,19 @@ public class MissingModelsIntegrationTests
         var nodeModel = new NodeClassificationModel<float>(architecture);
         var nodeFeatures = CreateRandomTensor(new[] { numNodes, inputFeatures });
 
-        Assert.Throws<InvalidOperationException>(() => graphModel.Predict(nodeFeatures));
-        Assert.Throws<InvalidOperationException>(() => linkModel.Predict(nodeFeatures));
-        Assert.Throws<InvalidOperationException>(() => nodeModel.Predict(nodeFeatures));
+        foreach (var (name, output) in new[]
+        {
+            ("graph", graphModel.Predict(nodeFeatures)),
+            ("link", linkModel.Predict(nodeFeatures)),
+            ("node", nodeModel.Predict(nodeFeatures)),
+        })
+        {
+            Assert.True(output.Length > 0, $"{name} model produced empty output under the identity fallback");
+            for (int i = 0; i < output.Length; i++)
+            {
+                Assert.True(float.IsFinite(output[i]), $"{name} model produced non-finite output under the identity fallback");
+            }
+        }
     }
 
     [Fact(Timeout = 120000)]

--- a/tests/AiDotNet.Tests/IntegrationTests/NeuralNetworks/NeuralNetworkLayersDeepMathIntegrationTests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/NeuralNetworks/NeuralNetworkLayersDeepMathIntegrationTests.cs
@@ -398,8 +398,11 @@ public class NeuralNetworkLayersDeepMathIntegrationTests
     [Fact(Timeout = 120000)]
     public async Task FullyConnectedLayer_ParameterCount()
     {
-        // FC layer with inputSize=3, outputSize=2 should have 3*2 + 2 = 8 parameters
+        // FC layer resolving inputSize=3 with outputSize=2 has 3*2 + 2 = 8 parameters. The ctor
+        // takes only outputSize (input size resolves LAZILY on first Forward, like Keras build()),
+        // so the count is only meaningful after shape resolution.
         var layer = new FullyConnectedLayer<double>(2, (IActivationFunction<double>?)null);
+        layer.Forward(new Tensor<double>(new[] { 1, 3 }, new Vector<double>(new double[] { 1.0, 2.0, 3.0 })));
         Assert.Equal(8, (int)layer.ParameterCount);
     }
 

--- a/tests/AiDotNet.Tests/IntegrationTests/NeuralNetworks/NormalizationLayersDeepMathIntegrationTests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/NeuralNetworks/NormalizationLayersDeepMathIntegrationTests.cs
@@ -21,8 +21,9 @@ public class NormalizationLayersDeepMathIntegrationTests
     [Fact(Timeout = 120000)]
     public async Task BatchNorm_Init_GammaIsOnes()
     {
-        // gamma initialized to 1.0 for each feature
-        var bn = new BatchNormalizationLayer<double>();
+        // gamma initialized to 1.0 for each feature. The parameterless ctor is LAZY (shape resolves
+        // on first Forward), so init-state assertions need the eager numFeatures ctor.
+        var bn = new BatchNormalizationLayer<double>(numFeatures: 3);
         var gamma = bn.GetGamma();
         Assert.Equal(3, gamma.Length);
         for (int i = 0; i < 3; i++)
@@ -32,8 +33,8 @@ public class NormalizationLayersDeepMathIntegrationTests
     [Fact(Timeout = 120000)]
     public async Task BatchNorm_Init_BetaIsZeros()
     {
-        // beta initialized to 0.0 for each feature
-        var bn = new BatchNormalizationLayer<double>();
+        // beta initialized to 0.0 for each feature (eager ctor — see GammaIsOnes note).
+        var bn = new BatchNormalizationLayer<double>(numFeatures: 3);
         var beta = bn.GetBeta();
         Assert.Equal(3, beta.Length);
         for (int i = 0; i < 3; i++)
@@ -43,7 +44,7 @@ public class NormalizationLayersDeepMathIntegrationTests
     [Fact(Timeout = 120000)]
     public async Task BatchNorm_Init_RunningMeanIsZeros()
     {
-        var bn = new BatchNormalizationLayer<double>();
+        var bn = new BatchNormalizationLayer<double>(numFeatures: 3);
         var runningMean = bn.GetRunningMean();
         Assert.Equal(3, runningMean.Length);
         for (int i = 0; i < 3; i++)
@@ -53,7 +54,7 @@ public class NormalizationLayersDeepMathIntegrationTests
     [Fact(Timeout = 120000)]
     public async Task BatchNorm_Init_RunningVarianceIsOnes()
     {
-        var bn = new BatchNormalizationLayer<double>();
+        var bn = new BatchNormalizationLayer<double>(numFeatures: 3);
         var runningVar = bn.GetRunningVariance();
         Assert.Equal(3, runningVar.Length);
         for (int i = 0; i < 3; i++)
@@ -84,7 +85,7 @@ public class NormalizationLayersDeepMathIntegrationTests
     public async Task BatchNorm_ParameterCount_IsTwiceFeatureSize()
     {
         // ParameterCount = gamma.Length + beta.Length = 2 * numFeatures
-        var bn = new BatchNormalizationLayer<double>();
+        var bn = new BatchNormalizationLayer<double>(numFeatures: 5);
         Assert.Equal(10, (int)bn.ParameterCount);
     }
 
@@ -245,7 +246,7 @@ public class NormalizationLayersDeepMathIntegrationTests
     [Fact(Timeout = 120000)]
     public async Task BatchNorm_ZeroInitGamma_SetsGammaToZero()
     {
-        var bn = new BatchNormalizationLayer<double>();
+        var bn = new BatchNormalizationLayer<double>(numFeatures: 3);
         bn.ZeroInitGamma();
 
         var gamma = bn.GetGamma();
@@ -354,8 +355,9 @@ public class NormalizationLayersDeepMathIntegrationTests
     public async Task BatchNorm_CustomEpsilon_AffectsScale()
     {
         // With large epsilon, scale = gamma / sqrt(runningVar + eps)
-        // eps=1.0: scale = 1 / sqrt(1 + 1) = 1/sqrt(2)
-        var bn = new BatchNormalizationLayer<double>();
+        // eps=1.0: scale = 1 / sqrt(1 + 1) = 1/sqrt(2). The test math assumes eps=1.0, so it
+        // must actually be passed (the default is 1e-5).
+        var bn = new BatchNormalizationLayer<double>(numFeatures: 1, epsilon: 1.0);
         bn.SetTrainingMode(false);
 
         var input = new Tensor<double>(new[] { 1, 1 }, new Vector<double>(new double[] { 4.0 }));
@@ -780,8 +782,9 @@ public class NormalizationLayersDeepMathIntegrationTests
     [Fact(Timeout = 120000)]
     public async Task BatchNorm_CustomMomentum_RunningStats()
     {
-        // momentum=0.5: runningMean = 0.5*old + 0.5*batch
-        var bn = new BatchNormalizationLayer<double>();
+        // momentum=0.5: runningMean = momentum*old + (1-momentum)*batch = 0.5*0 + 0.5*6 = 3.
+        // The test math assumes momentum=0.5, so it must actually be passed (the default is 0.9).
+        var bn = new BatchNormalizationLayer<double>(numFeatures: 1, momentum: 0.5);
         bn.SetTrainingMode(true);
 
         // batchMean = (4 + 8) / 2 = 6

--- a/tests/AiDotNet.Tests/IntegrationTests/NeuralNetworks/RecurrentAndUtilityLayersDeepMathIntegrationTests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/NeuralNetworks/RecurrentAndUtilityLayersDeepMathIntegrationTests.cs
@@ -114,9 +114,13 @@ public class RecurrentAndUtilityLayersDeepMathIntegrationTests
     // ========================================================================
 
     [Fact(Timeout = 120000)]
-    public async Task GRU_HiddenStateCarriesOver_SecondCallDiffersFromFirst()
+    public async Task GRU_StatelessForward_SecondCallMatchesFirst()
     {
         await Task.Yield(); // make the body truly async so [Fact(Timeout)] is enforced (xUnit v2)
+        // The library implements STANDARD non-streaming RNN semantics: every Forward starts from
+        // a zero initial hidden state (GRULayer documents this explicitly — it guarantees
+        // repeated-Predict determinism and Clone-after-training parity). The previous version of
+        // this test asserted the OPPOSITE (stateful carry-over), a contract the layer never had.
         var gru = new GRULayer<double>( hiddenSize: 3,
             activation: (IActivationFunction<double>?)null);
 
@@ -129,13 +133,10 @@ public class RecurrentAndUtilityLayersDeepMathIntegrationTests
 
         var output2 = gru.Forward(input);
 
-        bool differs = false;
         for (int i = 0; i < 3; i++)
         {
-            if (Math.Abs(output2[i] - o1vals[i]) > 1e-10)
-                differs = true;
+            Assert.Equal(o1vals[i], output2[i], 10);
         }
-        Assert.True(differs, "Second GRU forward with same input should differ due to hidden state");
     }
 
     [Fact(Timeout = 120000)]

--- a/tests/AiDotNet.Tests/IntegrationTests/NeuralNetworks/SpecializedBlocksIntegrationTests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/NeuralNetworks/SpecializedBlocksIntegrationTests.cs
@@ -99,20 +99,22 @@ public class SpecializedBlocksIntegrationTests
     [Fact(Timeout = 120000)]
     public async Task BottleneckBlock_ForwardPass_ProducesValidOutput()
     {
-        // Arrange - Bottleneck uses 1x1 -> 3x3 -> 1x1 pattern with expansion
+        // Arrange - Bottleneck uses 1x1 -> 3x3 -> 1x1 pattern with expansion. The ctor is
+        // (baseChannels, stride): input channels resolve lazily on first Forward, and output
+        // channels = baseChannels * Expansion(4). Passing (in, out) here set stride=64.
         int inChannels = 64;
-        int outChannels = 64;
+        int baseChannels = 64;
         int height = 8;
         int width = 8;
-        var block = new BottleneckBlock<float>(inChannels, outChannels);
+        var block = new BottleneckBlock<float>(baseChannels);
         var input = CreateRandomTensor<float>([2, inChannels, height, width]);
 
         // Act
         var output = block.Forward(input);
 
-        // Assert - output channels = outChannels * expansion (4)
+        // Assert - output channels = baseChannels * expansion (4)
         Assert.Equal(2, output.Shape[0]); // batch
-        Assert.Equal(outChannels * 4, output.Shape[1]); // channels * expansion
+        Assert.Equal(baseChannels * 4, output.Shape[1]); // channels * expansion
         Assert.Equal(height, output.Shape[2]);
         Assert.Equal(width, output.Shape[3]);
         Assert.False(ContainsNaN(output));
@@ -165,19 +167,20 @@ public class SpecializedBlocksIntegrationTests
     [Fact(Timeout = 120000)]
     public async Task BottleneckBlock_ExpansionFactor_CorrectlyApplied()
     {
-        // Arrange - default expansion is 4
+        // Arrange - default expansion is 4. Ctor is (baseChannels, stride) — input channels
+        // resolve lazily on first Forward; passing (in, out) here set stride=32.
         int inChannels = 64;
-        int outChannels = 32;
+        int baseChannels = 32;
         int height = 8;
         int width = 8;
-        var block = new BottleneckBlock<float>(inChannels, outChannels);
+        var block = new BottleneckBlock<float>(baseChannels);
         var input = CreateRandomTensor<float>([1, inChannels, height, width]);
 
         // Act
         var output = block.Forward(input);
 
-        // Assert - output channels should be outChannels * 4
-        Assert.Equal(outChannels * 4, output.Shape[1]); // 32 * 4 = 128
+        // Assert - output channels should be baseChannels * 4
+        Assert.Equal(baseChannels * 4, output.Shape[1]); // 32 * 4 = 128
     }
 
     #endregion
@@ -327,6 +330,11 @@ public class SpecializedBlocksIntegrationTests
         int height = 8;
         int width = 8;
         var block = new DenseBlock<float>(numLayers, growthRate);
+
+        // Input channels resolve LAZILY on first Forward (OutputChannels is the documented -1
+        // sentinel until then) — drive one forward so the property has its inputs.
+        Assert.Equal(-1, block.OutputChannels);
+        block.Forward(CreateRandomTensor<float>([1, inputChannels, height, width]));
 
         // Assert - verify property calculation
         Assert.Equal(inputChannels + numLayers * growthRate, block.OutputChannels);


### PR DESCRIPTION
## What

Fifteen pre-existing integration-test failures on master pinned contracts the library never had — tests written against assumed ctor defaults and eager-init behavior. Each was verified against the library source before deciding test-vs-library fault:

| Cluster | Tests | Actual contract | Fix |
|---|---|---|---|
| BatchNorm | 8 | Parameterless ctor is **lazy** (resolves on first Forward); the eager `numFeatures` ctor initializes γ=1, β=0, μ=0, σ²=1 correctly | Use the eager ctor with the feature count / epsilon / momentum the tests' own math assumes (the "custom eps/momentum" tests assumed 1.0/0.5 but passed neither) |
| FullyConnectedLayer | 1 | Ctor takes `outputSize` only; input size resolves lazily (Keras `build()` style) | Forward once, then assert 3·2+2=8 |
| BottleneckBlock | 2 | Ctor is `(baseChannels, stride)` — the tests passed `(inChannels, outChannels)`, silently setting **stride=32/64** | Correct ctor usage; out = baseChannels·4 |
| DenseBlock | 1 | `OutputChannels` is a documented −1 sentinel until first Forward | Assert sentinel pre-forward + calculation post-forward |
| GRU | 1 | Documented **stateless** per-Forward semantics (zero initial hidden state → repeated-Predict determinism) | Rewritten to pin stateless determinism (was asserting the opposite) |
| GraphConvolutionalLayer | 1 | Documented default-of-last-resort **identity** adjacency (Kipf & Welling 2017 §2: A=I ⇒ per-node dense) | Rewritten to prove the fallback ≡ explicit A=I |
| Graph task models | 1 | Same documented identity-fallback on Predict | Rewritten to pin it for all three models |

## One library fix (required by the family contract)

`LinkPredictionModel.Predict/Train` still **threw** on missing adjacency while its siblings (`GraphClassificationModel`, `NodeClassificationModel`) implement the documented `EnsureDefaultAdjacencyForInput` identity fallback with explicit-vs-inferred stickiness. Brought in line with the family contract (same helper, same stickiness semantics, same doc text).

## Verification

Targeted slice: **128/128** (was 15 failures). These 15 are part of the 26 pre-existing failures catalogued while validating #1583; the remaining 11 are genuine library bugs being fixed in separate PRs (attention lazy-init ordering, BatchNorm rank-3 inference scale, ConditionalGAN shape, eager default-factory resolution, transformer training trio).

🤖 Generated with [Claude Code](https://claude.com/claude-code)