### PR TITLE
fix(attention): resolve lazy shape state before classifying multi-input Forward

### DIFF
--- a/src/NeuralNetworks/Layers/AttentionLayer.cs
+++ b/src/NeuralNetworks/Layers/AttentionLayer.cs
@@ -839,6 +839,14 @@ public partial class AttentionLayer<T> : LayerBase<T>, IAuxiliaryLossLayer<T>
                 throw new ArgumentNullException($"inputs[{i}]", $"Input tensor at index {i} cannot be null.");
         }
 
+        // Resolve lazy shape state from the PRIMARY input before classifying the second input:
+        // the mask-vs-cross-attention heuristic and the masked/cross paths read _inputSize, which
+        // is the -1 sentinel until OnFirstForward fires. The single-input Forward resolves it, but
+        // this entry point never did — so valid cross-attention K/V was rejected as "ambiguous
+        // shape" (last dim compared against -1) and the masked path crashed reshaping to [.., -1].
+        // EnsureInitializedFromInput is idempotent (guarded by IsShapeResolved).
+        EnsureInitializedFromInput(inputs[0]);
+
         // Case 1: Standard self-attention with a single input
         if (inputs.Length == 1)
         {


### PR DESCRIPTION
## Bug

`AttentionLayer.Forward(params Tensor<T>[])` classifies the second tensor as **mask vs cross-attention K/V** by comparing its last dimension against `_inputSize` — but this entry point never initializes the layer, so `_inputSize` is still the lazy `-1` sentinel at the check (only the single-input `Forward` calls `EnsureInitializedFromInput`).

Consequences:
- Valid cross-attention K/V `[B, S, inputSize]` is rejected: *"Second input tensor has ambiguous shape 2x12x64. Expected either a mask … or cross-attention K/V [batch, seqLen, **-1**]"* (note the -1 in the actual error).
- The masked path crashes reshaping the input to `[B*S, -1]`: *"Cannot reshape tensor with 384 elements to shape [12, -1]"*.

## Fix

Call `EnsureInitializedFromInput(inputs[0])` once after null validation, before classification — idempotent (guarded by `IsShapeResolved`), and covers the 2-input and 3-input cases in one place.

## Verification

Both pre-existing failures (`AttentionLayer_CrossAttention_ProducesValidOutput`, `AttentionLayer_MaskedAttention_ProducesValidOutput`) now pass; full attention suite 32/32. Part of the pre-existing-failure cleanup catalogued in #1584.

🤖 Generated with [Claude Code](https://claude.com/claude-code)