### PR TITLE
fix(batchnorm): inference broadcast must mirror the channel-axis rule for unbatched rank-3 input

### DIFF
--- a/src/NeuralNetworks/Layers/BatchNormalizationLayer.cs
+++ b/src/NeuralNetworks/Layers/BatchNormalizationLayer.cs
@@ -737,15 +737,18 @@ public partial class BatchNormalizationLayer<T> : LayerBase<T>, ILayerSerializat
     {
         // Engine-accelerated batch normalization inference:
         // output = input * scale_broadcast + shift_broadcast
-        // Reshape scale/shift to [1, C, 1, 1, ...] for broadcasting across batch and spatial dims.
+        // The channel axis MUST mirror OnFirstForward's resolution rule (Ioffe & Szegedy 2015 §3):
+        //   rank 1 [F] / rank 3 [C, H, W] (unbatched image) — channels in axis 0
+        //   rank 2 [B, F] / rank >= 4 [B, C, H, W, ...]     — channels in axis 1
+        // Hardcoding axis 1 here broke unbatched rank-3 inputs: scale reshaped to [1, C, 1]
+        // against input [C, H, W] — "Tensors with shapes [64, 32, 32] and [1, 64, 1] cannot
+        // be broadcast" (surfaced by DenseNetNetwork.Predict on a [3, 32, 32] image).
         int rank = input.Shape.Length;
+        int channelAxis = rank == 1 || rank == 3 ? 0 : 1;
 
-        // Build broadcast shape: [1, C, 1, 1, ...]
         var broadcastShape = new int[rank];
-        broadcastShape[0] = 1;           // batch
-        broadcastShape[1] = scale.Length; // channels
-        for (int d = 2; d < rank; d++)
-            broadcastShape[d] = 1;       // spatial
+        for (int d = 0; d < rank; d++)
+            broadcastShape[d] = d == channelAxis ? scale.Length : 1;
 
         var scaleReshaped = Engine.Reshape(scale, broadcastShape);
         var shiftReshaped = Engine.Reshape(shift, broadcastShape);


### PR DESCRIPTION
## Bug

`BatchNormalizationLayer.ApplyInferenceAnyRank` hardcodes the channel axis to 1 (`[1, C, 1, …]` broadcast shape) — but the layer's own shape resolution (`OnFirstForward`, per Ioffe & Szegedy 2015 §3) treats **rank-3 input as an unbatched channels-first image `[C, H, W]`** with the channel axis at 0. Inference on rank-3 input reshapes scale/shift to `[1, C, 1]` against `[C, H, W]`:

```
Tensors with shapes [64, 32, 32] and [1, 64, 1] cannot be broadcast
```

Surfaced by `DenseNetNetwork_Predict_ProducesOutput` (predicting on a `[3, 32, 32]` image). `OnFirstForward`'s comment records the identical bug class on the resolution side ("scale [1, H, 1, 1] cannot be broadcast against [B, C, H, W]") — this is the inference-path twin that never got the fix.

## Fix

Channel axis 0 for rank 1/3, axis 1 for rank 2/≥4 — exactly the documented resolution rule, in one place.

## Verification

`DenseNetNetwork_Predict_ProducesOutput` passes; normalization suite green apart from the 8 test-contract failures already fixed in #1584 (this branch is based on master). Part of the pre-existing-failure cleanup catalogued in #1584.

🤖 Generated with [Claude Code](https://claude.com/claude-code)