### PR TITLE
fix(autoencoder): chain-resolve default layers so EncodedSize is real at construction

### DIFF
--- a/src/Helpers/LayerHelper.cs
+++ b/src/Helpers/LayerHelper.cs
@@ -1354,6 +1354,7 @@ public static class LayerHelper<T>
     {
         var inputShape = architecture.GetInputShape();
         int inputSize = inputShape.Length > 0 ? inputShape.Aggregate(1, (a, b) => a * b) : architecture.CalculatedInputSize;
+        int rootInputSize = inputSize;
         int[] layerSizes = architecture.GetLayerSizes();
 
         // If no layers specified, create a default symmetric autoencoder architecture
@@ -1369,20 +1370,27 @@ public static class LayerHelper<T>
 
         int middleIndex = layerSizes.Length / 2;
 
+        // Build the layer chain into a list, then chain-resolve from the architecture's known
+        // input size before yielding — same eager contract as CreateDefaultNeuralNetworkLayers.
+        // Lazy DenseLayers have unresolved input shapes until resolution, so without this the
+        // Autoencoder's EncodedSize (read from the middle layer's input shape at construction)
+        // was permanently 0 and ParameterCount was 0 until the first Forward.
+        var layers = new List<ILayer<T>>();
+
         // Encoder layers
         for (int i = 0; i < middleIndex; i++)
         {
             int outputSize = layerSizes[i + 1];
-            yield return new DenseLayer<T>(outputSize, new ReLUActivation<T>() as IActivationFunction<T>);
+            layers.Add(new DenseLayer<T>(outputSize, new ReLUActivation<T>() as IActivationFunction<T>));
 
             if (i < middleIndex - 1)
             {
-                yield return new ActivationLayer<T>(new ReLUActivation<T>() as IActivationFunction<T>);
+                layers.Add(new ActivationLayer<T>(new ReLUActivation<T>() as IActivationFunction<T>));
             }
             else
             {
                 // Use linear activation for the encoded layer
-                yield return new ActivationLayer<T>(new IdentityActivation<T>() as IActivationFunction<T>);
+                layers.Add(new ActivationLayer<T>(new IdentityActivation<T>() as IActivationFunction<T>));
             }
 
             inputSize = outputSize;
@@ -1392,20 +1400,23 @@ public static class LayerHelper<T>
         for (int i = middleIndex; i < layerSizes.Length - 1; i++)
         {
             int outputSize = layerSizes[i + 1];
-            yield return new DenseLayer<T>(outputSize, new ReLUActivation<T>() as IActivationFunction<T>);
+            layers.Add(new DenseLayer<T>(outputSize, new ReLUActivation<T>() as IActivationFunction<T>));
 
             if (i < layerSizes.Length - 2)
             {
-                yield return new ActivationLayer<T>(new ReLUActivation<T>() as IActivationFunction<T>);
+                layers.Add(new ActivationLayer<T>(new ReLUActivation<T>() as IActivationFunction<T>));
             }
             else
             {
                 // Use sigmoid activation for the output layer to constrain values between 0 and 1
-                yield return new ActivationLayer<T>(new SigmoidActivation<T>() as IActivationFunction<T>);
+                layers.Add(new ActivationLayer<T>(new SigmoidActivation<T>() as IActivationFunction<T>));
             }
 
             inputSize = outputSize;
         }
+
+        ChainResolveLazyLayers(layers, new[] { rootInputSize });
+        foreach (var layer in layers) yield return layer;
     }
 
     /// <summary>


### PR DESCRIPTION
## Bug

`Autoencoder.InitializeLayers` computes `EncodedSize` from the middle layer's input shape at construction:

```csharp
EncodedSize = Layers[Layers.Count / 2].GetInputShape()[0];
```

…but `CreateDefaultAutoEncoderLayers` yields **lazy** `DenseLayer`s whose input shapes are unresolved until the first Forward. `EncodedSize` therefore read an unresolved shape and was **permanently 0** (it's set once and never recomputed), and `ParameterCount` was 0 on a freshly constructed model.

## Fix

Build the default layer list and `ChainResolveLazyLayers` from the architecture's known input size before yielding — the exact eager contract the sibling `CreateDefaultNeuralNetworkLayers` factory already delivers.

## Verification

Pre-existing failure `Autoencoder_EncodedSize_IsPositive` now passes (a 128-input default autoencoder reports its real bottleneck width 32 = inputSize/4, satisfying both `> 0` and `< inputSize` compression assertions). Autoencoder suite: 62/62.

Note: `SpiralNet_GetParameterCount_ReturnsPositiveValue` has the same symptom but a deeper cause — `SpiralConvLayer.ResolveShapes` declares a rank-2 output even for rank-3 input, so eager chain resolution diverges from real-forward state for downstream rank-sensitive layers (BatchNorm's channel-axis rule). That needs its own fix and PR; attempting the simple chain-resolve there regressed `DifferentInputs_ShouldProduceDifferentOutputs`, which is exactly the divergence. Part of the pre-existing-failure cleanup catalogued in #1584.

🤖 Generated with [Claude Code](https://claude.com/claude-code)