### PR TITLE
fix(cgan): actionable latentDim guard in Predict; correct the noise-size test

### DIFF
--- a/src/NeuralNetworks/ConditionalGAN.cs
+++ b/src/NeuralNetworks/ConditionalGAN.cs
@@ -272,6 +272,18 @@ public class ConditionalGAN<T> : GenerativeAdversarialNetwork<T>
         }
 
         int batchSize = noise.Shape[0];
+        int latentDim = Generator.Architecture.InputSize - _numConditionClasses;
+        if (latentDim > 0 && noise.Shape[1] != latentDim)
+        {
+            throw new ArgumentException(
+                $"ConditionalGAN.Predict expects NOISE of latentDim = generator inputSize - numConditionClasses " +
+                $"= {Generator.Architecture.InputSize} - {_numConditionClasses} = {latentDim} features; got {noise.Shape[1]}. " +
+                "Condition features are appended internally (the generator architecture's inputSize is the FULL " +
+                "noise+condition width — see the parameterless ctor's 110 = 100 noise + 10 classes convention). " +
+                "To control the class, use GenerateConditional.",
+                nameof(input));
+        }
+
         var conditions = CreateOneHotCondition(batchSize, 0);
 
         var generatorInput = ConcatenateTensors(noise, conditions);

--- a/tests/AiDotNet.Tests/IntegrationTests/NeuralNetworks/AdvancedNeuralNetworkModelsIntegrationTests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/NeuralNetworks/AdvancedNeuralNetworkModelsIntegrationTests.cs
@@ -1786,7 +1786,10 @@ public class AdvancedNeuralNetworkModelsIntegrationTests
             numConditionClasses: 10,
             InputType.OneDimensional);
 
-        var noiseInput = CreateRandomTensor([32]);
+        // The generator architecture's inputSize (32) is the FULL noise+condition width — Predict
+        // takes the NOISE only (latentDim = 32 - 10 = 22) and appends the one-hot condition
+        // internally (same convention as the parameterless ctor's 110 = 100 noise + 10 classes).
+        var noiseInput = CreateRandomTensor([22]);
 
         // Act
         var output = cgan.Predict(noiseInput);


### PR DESCRIPTION
## Bug

`ConditionalGAN.Predict` documents that it takes **noise only** (latentDim features) and appends the one-hot condition internally — the generator architecture's `inputSize` is the FULL noise+condition width (the parameterless ctor's convention: 110 = 100 noise + 10 classes). Feeding `inputSize`-wide noise produces a cryptic shape error five frames deep:

```
TensorShapeMismatchException: Expected shape [32], but got [42]   (inside FeedForwardNeuralNetwork.Predict)
```

The failing test `ConditionalGAN_Predict_ProducesOutput` did exactly this (32-wide noise into a 32-input generator with 10 condition classes).

## Fix

- **Library**: `Predict` validates the noise width up front and throws an actionable `ArgumentException` spelling out `latentDim = generator inputSize − numConditionClasses = 32 − 10 = 22` and pointing at `GenerateConditional` for class control. No more buried five-frame shape mismatch.
- **Test**: feed latentDim-wide noise (22) per the documented convention.

## Verification

ConditionalGAN suite: 30/30 (was 1 pre-existing failure). Part of the cleanup catalogued in #1584.

🤖 Generated with [Claude Code](https://claude.com/claude-code)