### PR TITLE
fix(meshcnn): fail fast on empty-mesh (0-edge) input with a clear message

### DIFF
--- a/src/NeuralNetworks/MeshCNN.cs
+++ b/src/NeuralNetworks/MeshCNN.cs
@@ -327,6 +327,13 @@ public class MeshCNN<T> : NeuralNetworkBase<T>
                 "Edge adjacency must be set via SetEdgeAdjacency before calling Forward.");
         }
 
+        // Guard the empty-mesh case up front: MeshCNN data is [numEdges, channels], and an
+        // edge count of 0 produces a degenerate [1, 0, channels] tensor at the GlobalPooling
+        // reshape that fails downstream with an opaque pooling error. Fail fast with a clear
+        // message instead.
+        if (input.Rank >= 1 && input.Shape[0] == 0)
+            throw new ArgumentException("Cannot pool over empty edge dimension (0 edges).", nameof(input));
+
         PropagateAdjacencyToLayers();
 
         Tensor<T> output = input;

--- a/tests/AiDotNet.Tests/IntegrationTests/NeuralNetworks/AdvancedNeuralNetworkModelsIntegrationTests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/NeuralNetworks/AdvancedNeuralNetworkModelsIntegrationTests.cs
@@ -4066,6 +4066,24 @@ public class AdvancedNeuralNetworkModelsIntegrationTests
         Assert.True(output.Length > 0, "MeshCNN output should have elements");
     }
 
+    [Fact]
+    public void MeshCNN_Predict_EmptyEdges_ThrowsClearError()
+    {
+        // Arrange - valid adjacency, but an empty-mesh (0-edge) input. Without the
+        // guard the [0, features] input reshapes to a degenerate [1, 0, channels]
+        // tensor that fails downstream in pooling with an opaque error.
+        int maxAdjacent = 4;
+        var meshCnn = new MeshCNN<float>(numClasses: 4, inputFeatures: 5);
+        var edgeAdjacency = new int[4, maxAdjacent];
+        meshCnn.SetEdgeAdjacency(edgeAdjacency);
+
+        var emptyInput = CreateRandomTensor([0, 5]);
+
+        // Act + Assert - fails fast with a clear, actionable message.
+        var ex = Assert.Throws<ArgumentException>(() => meshCnn.Predict(emptyInput));
+        Assert.Contains("0 edges", ex.Message);
+    }
+
     [Fact(Timeout = 120000)]
     public async Task MeshCNN_GetParameterCount_ReturnsPositiveValue()
     {


### PR DESCRIPTION
## Summary

A MeshCNN forward pass on a 0-edge input (`[0, features]`) reshapes to a degenerate `[1, 0, channels]` tensor at the `GlobalPoolingLayer` step and fails downstream with an opaque pooling error. This guards the empty-mesh case at the start of the shared forward walker (`WalkLayersWithMeshReshape`) and throws a clear, actionable `ArgumentException` ("Cannot pool over empty edge dimension (0 edges).") instead.

Rescued from an abandoned worktree during cleanup; the companion training-state-restore fix from that branch was already independently merged to master, so this is the one remaining novel piece.

## Test
Adds `MeshCNN_Predict_EmptyEdges_ThrowsClearError` — passes. Builds clean on net471 + net10.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * MeshCNN now detects empty edge dimensions early and provides a clear, descriptive error message instead of encountering unclear failures in downstream operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->