### PR TITLE
fix(graph): graph task models require adjacency (strict PyTorch-Geometric contract)

### DIFF
--- a/src/AiDotNet.Generators/TestScaffoldGenerator.cs
+++ b/src/AiDotNet.Generators/TestScaffoldGenerator.cs
@@ -1940,6 +1940,14 @@ public class TestScaffoldGenerator : IIncrementalGenerator
             factoryBody = $"        => {constructorExpr};";
         }
 
+        if (family == TestFamily.GraphNN)
+        {
+            // Graph models require explicit structure (strict PyTorch-Geometric contract); the scaffold
+            // opts them into implicit self-loops-only adjacency, the test equivalent of supplying an
+            // edge_index. Keeps the generic invariants runnable without a silent model-level default.
+            factoryBody = $"        => WireSyntheticGraph({constructorExpr});";
+        }
+
         var baseClassName = GetBaseClassName(family);
         var factoryMethodName = GetFactoryMethodName(family);
         var returnTypeCode = GetReturnTypeCode(family);

--- a/src/NeuralNetworks/Layers/GraphConvolutionalLayer.cs
+++ b/src/NeuralNetworks/Layers/GraphConvolutionalLayer.cs
@@ -203,7 +203,7 @@ public partial class GraphConvolutionalLayer<T> : LayerBase<T>, IAuxiliaryLossLa
     // token stream with no data-flow edges) opt in. DeserializationHelper
     // reconstructs cloned/round-tripped graph layers with this enabled so a
     // model whose adjacency is only set at runtime survives serialization.
-    private readonly bool _implicitIdentityWhenUnset;
+    private bool _implicitIdentityWhenUnset;
 
     /// <summary>
     /// Stores the gradients for the weights calculated during the backward pass.
@@ -522,6 +522,17 @@ public partial class GraphConvolutionalLayer<T> : LayerBase<T>, IAuxiliaryLossLa
     /// In a molecule, it would show which atoms are bonded to each other.
     /// </para>
     /// </remarks>
+    /// <summary>
+    /// Post-construction equivalent of the <c>implicitIdentityWhenUnset</c> ctor flag: enables the
+    /// self-loops-only (identity) tolerance for callers that constructed the layer strictly but later
+    /// need the scaffold / clone / deserialize tolerance. The default remains strict (throw on a
+    /// missing graph); this is an explicit opt-in, never a silent default.
+    /// </summary>
+    public void EnableImplicitIdentityAdjacency()
+    {
+        _implicitIdentityWhenUnset = true;
+    }
+
     public void SetAdjacencyMatrix(Tensor<T> adjacencyMatrix)
     {
         // Check if we need to re-extract edges (new matrix or first time)

--- a/src/NeuralNetworks/Tasks/Graph/GraphClassificationModel.cs
+++ b/src/NeuralNetworks/Tasks/Graph/GraphClassificationModel.cs
@@ -97,6 +97,10 @@ public class GraphClassificationModel<T> : NeuralNetworkBase<T>
     private readonly IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>> _optimizer;
     private readonly GraphPooling _poolingType;
     private Tensor<T>? _cachedAdjacencyMatrix;
+    // Opt-in (EnableImplicitIdentityAdjacency): mirrors the GraphConvolutionalLayer
+    // implicitIdentityWhenUnset ctor flag at the model level. Default is strict (throw on a
+    // missing graph); when enabled, Predict/Train build an identity sized to the input.
+    private bool _implicitIdentityWhenUnset;
     // Tracks whether _cachedAdjacencyMatrix came from EnsureDefaultAdjacencyForInput
     // (auto-inferred identity) vs an explicit SetAdjacencyMatrix call. Explicit
     // matrices are sticky — caller knows the graph; auto-inferred ones must be
@@ -631,6 +635,25 @@ public class GraphClassificationModel<T> : NeuralNetworkBase<T>
 
         return Forward(input);
     }
+    /// <summary>
+    /// Enables implicit self-loops-only (identity) tolerance for this model and its graph layers —
+    /// the model-level analogue of GraphConvolutionalLayer's implicitIdentityWhenUnset ctor flag.
+    /// Default is strict (Predict/Train throw on a missing graph); this is an explicit opt-in for
+    /// scaffold / clone / deserialize paths, propagated to the GCN layers so direct-layer paths
+    /// (e.g. GetNamedLayerActivations) tolerate too.
+    /// </summary>
+    public void EnableImplicitIdentityAdjacency()
+    {
+        _implicitIdentityWhenUnset = true;
+        foreach (var layer in Layers)
+        {
+            if (layer is NeuralNetworks.Layers.GraphConvolutionalLayer<T> gcn)
+            {
+                gcn.EnableImplicitIdentityAdjacency();
+            }
+        }
+    }
+
 
     /// <summary>
     /// Auto-creates an identity adjacency matrix when none has been set,
@@ -647,6 +670,17 @@ public class GraphClassificationModel<T> : NeuralNetworkBase<T>
     /// </summary>
     private void EnsureDefaultAdjacencyForInput(Tensor<T> input)
     {
+        if (_cachedAdjacencyMatrix is null && !_implicitIdentityWhenUnset)
+        {
+            // PyTorch-Geometric contract: the graph is REQUIRED — call SetAdjacencyMatrix() with
+            // the real structure before Predict/Train. Implicit-identity tolerance is opt-in
+            // (EnableImplicitIdentityAdjacency / the layer's implicitIdentityWhenUnset), never a
+            // silent default that would let a GCN ignore all graph structure unnoticed.
+            throw new InvalidOperationException(
+                "Adjacency matrix must be set before Predict/Train: call SetAdjacencyMatrix() with " +
+                "the graph structure. Graph neural networks have no meaningful default graph.");
+        }
+
         if (input.Rank < 1) return; // can't infer; let Forward throw with a clear shape error
         int numNodes = input.Shape[0];
 
@@ -765,13 +799,25 @@ public class GraphClassificationModel<T> : NeuralNetworkBase<T>
     /// </summary>
     protected override IFullModel<T, Tensor<T>, Tensor<T>> CreateNewInstance()
     {
-        return new GraphClassificationModel<T>(
+        var clone = new GraphClassificationModel<T>(
             architecture: Architecture,
             hiddenDim: HiddenDim,
             embeddingDim: EmbeddingDim,
             numGnnLayers: NumGnnLayers,
             dropoutRate: DropoutRate,
             poolingType: _poolingType);
+        // Graph STATE is model state in this stateful-adjacency design, so a clone of a configured
+        // model must stay usable: carry the implicit-identity opt-in and any explicit adjacency.
+        if (_implicitIdentityWhenUnset)
+        {
+            clone.EnableImplicitIdentityAdjacency();
+        }
+        else if (_cachedAdjacencyMatrix is not null)
+        {
+            clone.SetAdjacencyMatrix(_cachedAdjacencyMatrix);
+        }
+
+        return clone;
     }
 
     #endregion

--- a/src/NeuralNetworks/Tasks/Graph/LinkPredictionModel.cs
+++ b/src/NeuralNetworks/Tasks/Graph/LinkPredictionModel.cs
@@ -89,6 +89,10 @@ public class LinkPredictionModel<T> : NeuralNetworkBase<T>
     private readonly IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>> _optimizer;
     private readonly LinkPredictionDecoder _decoderType;
     private Tensor<T>? _cachedAdjacencyMatrix;
+    // Opt-in (EnableImplicitIdentityAdjacency): mirrors the GraphConvolutionalLayer
+    // implicitIdentityWhenUnset ctor flag at the model level. Default is strict (throw on a
+    // missing graph); when enabled, Predict/Train build an identity sized to the input.
+    private bool _implicitIdentityWhenUnset;
     // Tracks whether _cachedAdjacencyMatrix came from EnsureDefaultAdjacencyForInput
     // (auto-inferred identity) vs an explicit SetAdjacencyMatrix call. Explicit
     // matrices are sticky — caller knows the graph; auto-inferred ones must be
@@ -244,6 +248,25 @@ public class LinkPredictionModel<T> : NeuralNetworkBase<T>
             }
         }
     }
+    /// <summary>
+    /// Enables implicit self-loops-only (identity) tolerance for this model and its graph layers —
+    /// the model-level analogue of GraphConvolutionalLayer's implicitIdentityWhenUnset ctor flag.
+    /// Default is strict (Predict/Train throw on a missing graph); this is an explicit opt-in for
+    /// scaffold / clone / deserialize paths, propagated to the GCN layers so direct-layer paths
+    /// (e.g. GetNamedLayerActivations) tolerate too.
+    /// </summary>
+    public void EnableImplicitIdentityAdjacency()
+    {
+        _implicitIdentityWhenUnset = true;
+        foreach (var layer in Layers)
+        {
+            if (layer is NeuralNetworks.Layers.GraphConvolutionalLayer<T> gcn)
+            {
+                gcn.EnableImplicitIdentityAdjacency();
+            }
+        }
+    }
+
 
     /// <summary>
     /// Default-of-last-resort adjacency: when no explicit matrix was set, fall back to the
@@ -255,6 +278,17 @@ public class LinkPredictionModel<T> : NeuralNetworkBase<T>
     /// </summary>
     private void EnsureDefaultAdjacencyForInput(Tensor<T> input)
     {
+        if (_cachedAdjacencyMatrix is null && !_implicitIdentityWhenUnset)
+        {
+            // PyTorch-Geometric contract: the graph is REQUIRED — call SetAdjacencyMatrix() with
+            // the real structure before Predict/Train. Implicit-identity tolerance is opt-in
+            // (EnableImplicitIdentityAdjacency / the layer's implicitIdentityWhenUnset), never a
+            // silent default that would let a GCN ignore all graph structure unnoticed.
+            throw new InvalidOperationException(
+                "Adjacency matrix must be set before Predict/Train: call SetAdjacencyMatrix() with " +
+                "the graph structure. Graph neural networks have no meaningful default graph.");
+        }
+
         if (input.Rank < 1) return; // can't infer; let Forward throw with a clear shape error
         int numNodes = input.Shape[0];
 
@@ -739,13 +773,25 @@ public class LinkPredictionModel<T> : NeuralNetworkBase<T>
     /// </summary>
     protected override IFullModel<T, Tensor<T>, Tensor<T>> CreateNewInstance()
     {
-        return new LinkPredictionModel<T>(
+        var clone = new LinkPredictionModel<T>(
             architecture: Architecture,
             hiddenDim: HiddenDim,
             embeddingDim: EmbeddingDim,
             numLayers: NumLayers,
             dropoutRate: DropoutRate,
             decoderType: _decoderType);
+        // Graph STATE is model state in this stateful-adjacency design, so a clone of a configured
+        // model must stay usable: carry the implicit-identity opt-in and any explicit adjacency.
+        if (_implicitIdentityWhenUnset)
+        {
+            clone.EnableImplicitIdentityAdjacency();
+        }
+        else if (_cachedAdjacencyMatrix is not null)
+        {
+            clone.SetAdjacencyMatrix(_cachedAdjacencyMatrix);
+        }
+
+        return clone;
     }
 
     #endregion

--- a/src/NeuralNetworks/Tasks/Graph/NodeClassificationModel.cs
+++ b/src/NeuralNetworks/Tasks/Graph/NodeClassificationModel.cs
@@ -87,6 +87,10 @@ public class NodeClassificationModel<T> : NeuralNetworkBase<T>
     private readonly ILossFunction<T> _lossFunction;
     private readonly IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>> _optimizer;
     private Tensor<T>? _cachedAdjacencyMatrix;
+    // Opt-in (EnableImplicitIdentityAdjacency): mirrors the GraphConvolutionalLayer
+    // implicitIdentityWhenUnset ctor flag at the model level. Default is strict (throw on a
+    // missing graph); when enabled, Predict/Train build an identity sized to the input.
+    private bool _implicitIdentityWhenUnset;
     // Tracks whether _cachedAdjacencyMatrix came from EnsureDefaultAdjacencyForInput
     // (auto-inferred identity) vs an explicit SetAdjacencyMatrix call. Explicit
     // matrices are sticky — caller knows the graph; auto-inferred ones must be
@@ -544,6 +548,25 @@ public class NodeClassificationModel<T> : NeuralNetworkBase<T>
 
         return Forward(input);
     }
+    /// <summary>
+    /// Enables implicit self-loops-only (identity) tolerance for this model and its graph layers —
+    /// the model-level analogue of GraphConvolutionalLayer's implicitIdentityWhenUnset ctor flag.
+    /// Default is strict (Predict/Train throw on a missing graph); this is an explicit opt-in for
+    /// scaffold / clone / deserialize paths, propagated to the GCN layers so direct-layer paths
+    /// (e.g. GetNamedLayerActivations) tolerate too.
+    /// </summary>
+    public void EnableImplicitIdentityAdjacency()
+    {
+        _implicitIdentityWhenUnset = true;
+        foreach (var layer in Layers)
+        {
+            if (layer is NeuralNetworks.Layers.GraphConvolutionalLayer<T> gcn)
+            {
+                gcn.EnableImplicitIdentityAdjacency();
+            }
+        }
+    }
+
 
     /// <summary>
     /// Auto-creates an identity adjacency matrix when none has been set —
@@ -555,6 +578,17 @@ public class NodeClassificationModel<T> : NeuralNetworkBase<T>
     /// </summary>
     private void EnsureDefaultAdjacencyForInput(Tensor<T> input)
     {
+        if (_cachedAdjacencyMatrix is null && !_implicitIdentityWhenUnset)
+        {
+            // PyTorch-Geometric contract: the graph is REQUIRED — call SetAdjacencyMatrix() with
+            // the real structure before Predict/Train. Implicit-identity tolerance is opt-in
+            // (EnableImplicitIdentityAdjacency / the layer's implicitIdentityWhenUnset), never a
+            // silent default that would let a GCN ignore all graph structure unnoticed.
+            throw new InvalidOperationException(
+                "Adjacency matrix must be set before Predict/Train: call SetAdjacencyMatrix() with " +
+                "the graph structure. Graph neural networks have no meaningful default graph.");
+        }
+
         if (input.Rank < 1) return;
         int numNodes = input.Shape[0];
 
@@ -666,11 +700,23 @@ public class NodeClassificationModel<T> : NeuralNetworkBase<T>
     /// </summary>
     protected override IFullModel<T, Tensor<T>, Tensor<T>> CreateNewInstance()
     {
-        return new NodeClassificationModel<T>(
+        var clone = new NodeClassificationModel<T>(
             architecture: Architecture,
             hiddenDim: HiddenDim,
             numLayers: NumLayers,
             dropoutRate: DropoutRate);
+        // Graph STATE is model state in this stateful-adjacency design, so a clone of a configured
+        // model must stay usable: carry the implicit-identity opt-in and any explicit adjacency.
+        if (_implicitIdentityWhenUnset)
+        {
+            clone.EnableImplicitIdentityAdjacency();
+        }
+        else if (_cachedAdjacencyMatrix is not null)
+        {
+            clone.SetAdjacencyMatrix(_cachedAdjacencyMatrix);
+        }
+
+        return clone;
     }
 
     #endregion

--- a/tests/AiDotNet.Tests/IntegrationTests/NeuralNetworks/GraphLayersIntegrationTests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/NeuralNetworks/GraphLayersIntegrationTests.cs
@@ -246,37 +246,18 @@ public class GraphLayersIntegrationTests
     }
 
     [Fact(Timeout = 120000)]
-    public async Task GraphConvolutionalLayer_WithoutAdjacencyMatrix_DefaultsToIdentity()
+    public async Task GraphConvolutionalLayer_WithoutAdjacencyMatrix_ThrowsException()
     {
-        // The layer's DOCUMENTED contract (EnsureDenseAdjacencyForInput) is a default-of-last-resort
-        // IDENTITY adjacency when none is set: per Kipf & Welling 2017 §2, with A = I the GCN layer
-        // degenerates to a per-node dense transform — well-defined for scaffold invariant checks.
-        // Production callers should still SetAdjacencyMatrix with the real graph. This test pins
-        // that the fallback IS exactly A = I by comparing against an explicit identity.
+        await Task.Yield();
+        // Strict PyTorch-Geometric contract: a GCN layer constructed without the implicit-identity
+        // opt-in REQUIRES a graph — Forward throws when none was set (Kipf & Welling 2017 §2). The
+        // opt-in path (implicitIdentityWhenUnset / EnableImplicitIdentityAdjacency) is tested separately.
         int inputFeatures = 8;
         int outputFeatures = 16;
-        int numNodes = 5;
+        var layer = new GraphConvolutionalLayer<float>(inputFeatures, outputFeatures, (IActivationFunction<float>?)null);
+        var nodeFeatures = CreateNodeFeatures(5, inputFeatures);
 
-        var implicitLayer = new GraphConvolutionalLayer<float>(inputFeatures, outputFeatures, (IActivationFunction<float>?)null);
-        var nodeFeatures = CreateNodeFeatures(numNodes, inputFeatures);
-        var implicitOut = implicitLayer.Forward(nodeFeatures);
-
-        var explicitLayer = new GraphConvolutionalLayer<float>(inputFeatures, outputFeatures, (IActivationFunction<float>?)null);
-        explicitLayer.SetParameters(implicitLayer.GetParameters()); // identical weights
-        var identity = new Tensor<float>(new[] { numNodes, numNodes });
-        for (int i = 0; i < numNodes; i++)
-        {
-            identity[i, i] = 1.0f;
-        }
-
-        explicitLayer.SetAdjacencyMatrix(identity);
-        var explicitOut = explicitLayer.Forward(nodeFeatures);
-
-        Assert.Equal(implicitOut.Shape.ToArray(), explicitOut.Shape.ToArray());
-        for (int i = 0; i < implicitOut.Length; i++)
-        {
-            Assert.Equal(explicitOut[i], implicitOut[i], 5);
-        }
+        Assert.Throws<InvalidOperationException>(() => layer.Forward(nodeFeatures));
     }
 
     [Fact(Timeout = 120000)]

--- a/tests/AiDotNet.Tests/IntegrationTests/NeuralNetworks/MissingModelsIntegrationTests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/NeuralNetworks/MissingModelsIntegrationTests.cs
@@ -204,14 +204,11 @@ public class MissingModelsIntegrationTests
     }
 
     [Fact(Timeout = 120000)]
-    public async Task GraphModels_PredictWithoutAdjacency_UsesDocumentedIdentityFallback()
+    public async Task GraphModels_RequireAdjacencyMatrix()
     {
-        // The graph models' DOCUMENTED contract (EnsureDefaultAdjacencyForInput) is a
-        // default-of-last-resort identity adjacency on Predict/Train when none was set —
-        // per Kipf & Welling 2017 §2 an A = I graph degenerates the GCN to per-node dense
-        // transforms, keeping scaffold invariants well-defined. Production callers should
-        // still call SetAdjacencyMatrix with the real graph. This pins that Predict succeeds
-        // and produces finite output instead of throwing.
+        await Task.Yield();
+        // Strict PyTorch-Geometric contract: graph task models REQUIRE the graph structure — Predict
+        // throws when no adjacency was set and the implicit-identity tolerance was not opted into.
         int numNodes = 3;
         int inputFeatures = 2;
         int numClasses = 2;
@@ -228,20 +225,9 @@ public class MissingModelsIntegrationTests
         var nodeModel = new NodeClassificationModel<float>(architecture);
         var nodeFeatures = CreateRandomTensor(new[] { numNodes, inputFeatures });
 
-        foreach (var (name, output) in new[]
-        {
-            ("graph", graphModel.Predict(nodeFeatures)),
-            ("link", linkModel.Predict(nodeFeatures)),
-            ("node", nodeModel.Predict(nodeFeatures)),
-        })
-        {
-            Assert.True(output.Length > 0, $"{name} model produced empty output under the identity fallback");
-            for (int i = 0; i < output.Length; i++)
-            {
-                // float.IsFinite is net10-only; use the net471-compatible equivalent (same semantics).
-                Assert.True(!float.IsNaN(output[i]) && !float.IsInfinity(output[i]), $"{name} model produced non-finite output under the identity fallback");
-            }
-        }
+        Assert.Throws<InvalidOperationException>(() => graphModel.Predict(nodeFeatures));
+        Assert.Throws<InvalidOperationException>(() => linkModel.Predict(nodeFeatures));
+        Assert.Throws<InvalidOperationException>(() => nodeModel.Predict(nodeFeatures));
     }
 
     [Fact(Timeout = 120000)]

--- a/tests/AiDotNet.Tests/ModelFamilyTests/Base/GraphNNModelTestBase.cs
+++ b/tests/AiDotNet.Tests/ModelFamilyTests/Base/GraphNNModelTestBase.cs
@@ -13,6 +13,18 @@ namespace AiDotNet.Tests.ModelFamilyTests.Base;
 /// </summary>
 public abstract class GraphNNModelTestBase : NeuralNetworkModelTestBase
 {
+    /// <summary>Opts a graph model into implicit self-loops-only adjacency (the model-level analogue
+    /// of GraphConvolutionalLayer's implicitIdentityWhenUnset flag), so the generic invariant tests
+    /// run under the strict graph contract — the scaffold equivalent of a PyG test supplying an
+    /// edge_index. No-op for models without the method. Matches the numerics of the previous
+    /// model-level default, so this moves no model-family tests.</summary>
+    protected TModel WireSyntheticGraph<TModel>(TModel model)
+    {
+        typeof(TModel).GetMethod("EnableImplicitIdentityAdjacency", System.Type.EmptyTypes)
+            ?.Invoke(model, null);
+        return model;
+    }
+
     // =====================================================
     // GRAPH INVARIANT: Self-Loops Should Not Cause Numerical Issues
     // A diagonal-heavy adjacency matrix (self-loops) is common in graph


### PR DESCRIPTION
## Bug

`GraphConvolutionalLayer` already enforces the strict contract (throws on a missing graph; `implicitIdentityWhenUnset` ctor flag opts into an identity). But the graph **task models** (`GraphClassificationModel`, `NodeClassificationModel`, `LinkPredictionModel`) still **silently auto-defaulted** to an identity adjacency via `EnsureDefaultAdjacencyForInput` — so `model.Predict` on an unset graph quietly ran a GCN that ignores all graph structure, with no signal to the caller.

PyTorch-Geometric requires the graph at every forward (`GCNConv.forward(x, edge_index)`); this aligns the models with the layer's existing strict behavior.

## Change

- **Models throw** an actionable `InvalidOperationException` from `Predict`/`Train` when no adjacency is set, gated on a new `_implicitIdentityWhenUnset` flag (default strict).
- **`EnableImplicitIdentityAdjacency()`** — the post-construction opt-in (model-level analogue of the layer's ctor flag), propagated to the GCN layers so direct-layer paths (`GetNamedLayerActivations`) tolerate too.
- **Layer**: the existing `implicitIdentityWhenUnset` field is now settable via `EnableImplicitIdentityAdjacency()` (purely additive — the ctor flag is unchanged), so a strictly-constructed layer can be opted in post-hoc.
- **Clone** (`CreateNewInstance`) carries the graph state (opt-in flag or explicit adjacency) so a clone of a configured model stays usable — graph is model state in this design.
- **Integration tests** restored to assert the throw (`GraphConvolutionalLayer_WithoutAdjacencyMatrix_ThrowsException`, `GraphModels_RequireAdjacencyMatrix`) — they had been asserting the fallback.
- **Test scaffold**: `GraphNNModelTestBase.WireSyntheticGraph` opts graph models into the identity tolerance (the test equivalent of supplying an `edge_index`), so the generic model-family invariants still run under the strict contract.

## Verification

- Integration contract tests: green (36/36 in the graph-layer + missing-models slice).
- Model-family scaffold: `GraphClassification`/`Node`/`LinkPrediction` unchanged at 3/19/22 failures, identical to master — those are separate pre-existing per-model bugs (NodeClassification InputShape mismatch, LinkPrediction layer input-dim, GraphClassification training trio) tracked for their own PRs. **Zero regression** from this contract change.

GraphCodeBERT is unaffected (its GCN is already built with `implicitIdentityWhenUnset: true` by `CodeTransformerLayerFactory`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)