### PR TITLE
fix(lstm): resolve gate-weight width from the real input, not a stale _inputSize

### DIFF
--- a/src/NeuralNetworks/Layers/LSTMLayer.cs
+++ b/src/NeuralNetworks/Layers/LSTMLayer.cs
@@ -1061,6 +1061,15 @@ public partial class LSTMLayer<T> : LayerBase<T>
     /// </remarks>
     public override Tensor<T> Forward(Tensor<T> input)
     {
+        // Until the gate weights are actually allocated (_isInitialized), the real input
+        // width is authoritative. A stale _inputSize — copied by Clone (or a parameter-load
+        // that recorded a width without allocating the matching gate weights) — would
+        // otherwise drive EnsureInitialized, which runs BEFORE OnFirstForward, to allocate
+        // [_hiddenSize, staleWidth] gate weights, and the per-timestep matmul then fails
+        // against the actual input width (ooples/AiDotNet#1589: LSTM-CRF predict path threw
+        // "Matrix dimensions incompatible: [B,realWidth] x [4*hidden,staleWidth]").
+        if (!_isInitialized && input.Shape.Length >= 1)
+            _inputSize = input.Shape[input.Shape.Length - 1];
         // Resolve _inputSize from input.Shape[^1] and allocate weights on first call.
         // Idempotent — gated by _isInitialized.
         EnsureInitializedFromInput(input);
@@ -2431,10 +2440,18 @@ public partial class LSTMLayer<T> : LayerBase<T>
     /// </remarks>
     public override void SetParameters(Vector<T> parameters)
     {
-        if (!_isInitialized || _inputSize <= 0)
+        // The parameter vector's length is authoritative for the gate-weight layout. Re-infer
+        // _inputSize from it whenever the layer hasn't resolved a width yet OR the current
+        // _inputSize disagrees with the vector (e.g. a clone copied a stale width without
+        // allocating the matching gate weights — ooples/AiDotNet#1589: LSTM-CRF Clone tests
+        // threw "Expected 91600 parameters, but got 80400" because the clone's LSTM carried
+        // _inputSize=128 while the source params encode input=100).
+        int expectedForCurrent = _inputSize > 0
+            ? 4 * (_hiddenSize * _inputSize) + 4 * (_hiddenSize * _hiddenSize) + 4 * _hiddenSize
+            : -1;
+        if (!_isInitialized || _inputSize <= 0 || parameters.Length != expectedForCurrent)
         {
-            // Lazy LSTM with no resolved input width — try to recover by inferring
-            // _inputSize from parameters.Length. The flat layout is:
+            // Recover by inferring _inputSize from parameters.Length. The flat layout is:
             //   4 * (hidden*input) + 4 * (hidden*hidden) + 4 * hidden
             // → input = (params - 4*hidden*hidden - 4*hidden) / (4*hidden)
             int hidden4 = 4 * _hiddenSize;
@@ -2445,13 +2462,12 @@ public partial class LSTMLayer<T> : LayerBase<T>
                 if (inferredInput > 0)
                 {
                     _inputSize = inferredInput;
-                    // Allocate weight tensors now (we know hiddenSize and inferredInput),
-                    // but DO NOT call ResolveFromShape with a synthetic shape — that would
-                    // bake a fake rank-2 [1, inferredInput] into InputShape/OutputShape and
-                    // override the real rank-3 [B, T, F] sequence shape on the first
-                    // actual Forward(...). Leaving _isInitialized true (set inside
-                    // EnsureInitialized) but IsShapeResolved false defers shape resolution
-                    // to OnFirstForward, which receives the real input tensor.
+                    // Force EnsureInitialized to (re)allocate the gate weights at the inferred
+                    // width — without clearing the flag it would early-return and leave stale
+                    // [_hiddenSize, oldWidth] weights that the copy loop below then overflows.
+                    // IsShapeResolved stays false so OnFirstForward still binds the real rank-3
+                    // [B, T, F] sequence shape on the first actual Forward(...).
+                    _isInitialized = false;
                     EnsureInitialized();
                 }
                 else

--- a/tests/AiDotNet.Tests/UnitTests/NeuralNetworks/LazyShape/RecurrentTransformerLazyShapeTests.cs
+++ b/tests/AiDotNet.Tests/UnitTests/NeuralNetworks/LazyShape/RecurrentTransformerLazyShapeTests.cs
@@ -168,4 +168,27 @@ public class RecurrentTransformerLazyShapeTests
         var dec = new TransformerDecoderLayer<double>(numHeads: 4, feedForwardDim: 64);
         dec.ClearGradients();
     }
+
+    [Fact]
+    public void LazyLSTM_SetParameters_ReinfersWidth_WhenVectorDisagreesWithStaleInputSize()
+    {
+        // #1589: an LSTM whose _inputSize was resolved to one width (12) but is then handed a
+        // parameter vector encoding a DIFFERENT width (10) — the pattern Clone hits when it
+        // copies a stale width without allocating the matching gate weights — must RE-INFER the
+        // width from the vector instead of throwing "Expected X parameters, but got Y".
+        var src = new LSTMLayer<double>(hiddenSize: 8);
+        src.Forward(new Tensor<double>(new[] { 1, 3, 10 })); // resolves _inputSize = 10
+        var srcParams = src.GetParameters();                 // sized for input width 10
+
+        var target = new LSTMLayer<double>(hiddenSize: 8);
+        target.Forward(new Tensor<double>(new[] { 1, 3, 12 })); // resolves _inputSize = 12 (stale vs srcParams)
+
+        // Must not throw: re-infer width 10 from the 10-width vector and re-allocate gates.
+        target.SetParameters(srcParams);
+
+        // A subsequent forward at the inferred (10) width must succeed end-to-end.
+        var output = target.Forward(new Tensor<double>(new[] { 1, 3, 10 }));
+        Assert.Equal(3, output.Shape.Length);
+        Assert.Equal(8, output.Shape[output.Shape.Length - 1]);
+    }
 }


### PR DESCRIPTION
## Summary

A lazily-constructed `LSTMLayer` can end up carrying a recorded `_inputSize` whose **gate weights were never allocated for it** — the state a `Clone` (or a parameter-load) leaves behind. Because `EnsureInitialized` runs *before* `OnFirstForward`, this drove allocation of `[_hiddenSize, staleWidth]` gate weights, and then:

- the per-timestep matmul threw `Matrix dimensions incompatible: [B, realWidth] x [4*hidden, staleWidth]`, and
- `SetParameters` threw `Expected N parameters, but got M`.

This surfaced across the **LSTM-CRF NER model family** (LSTMCRF / CNNBiLSTMCRF) generated tests — e.g. `[1,100] x [128,100]` and `Expected 91600 parameters, but got 80400`.

## Fix
Treat the actual data as authoritative whenever the layer's gates are **not yet allocated**:

1. **`Forward`** resolves `_inputSize` from the real input width *before* `EnsureInitialized` when `!_isInitialized`.
2. **`SetParameters`** re-infers `_inputSize` from the parameter-vector length whenever it disagrees with the current width, and forces a re-allocation at the inferred width (clearing `_isInitialized` so the gate weights are actually rebuilt rather than left stale).

Both paths are behavior-preserving for a normally-resolved LSTM (the new branches only fire when the gates are unallocated or the vector length disagrees), so other LSTM-based models are unaffected.

## Verification
- **LSTMCRF model tests: 26 → 8 failures** (recovers 18) on master; CNNBiLSTMCRF similarly improved.
- Both **net471 + net10.0** build clean.
- Adds `LazyLSTM_SetParameters_ReinfersWidth_WhenVectorDisagreesWithStaleInputSize` (16/16 lazy-shape tests green).

## Not in scope (separate, pre-existing)
The remaining LSTM-CRF failures are unrelated: a CRF degenerate-collapse assertion on discrete Viterbi output (`DifferentInputs_AfterTraining`), a deeper stacked-LSTM dimension interaction, and pre-existing training-quality failures shared with non-CRF LSTM models (XLSTM, LSTMDetector). Tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)