### PR TITLE
fix(ci): repair model invariant failures

### DIFF
--- a/src/ActivationFunctions/MishActivation.cs
+++ b/src/ActivationFunctions/MishActivation.cs
@@ -99,7 +99,12 @@ public class MishActivation<T> : ActivationFunctionBase<T>, Fused.IFusedActivati
     /// Applies Mish to a tensor via the engine so the gradient tape records the op.
     /// Overrides the scalar element-by-element default which bypasses the tape.
     /// </summary>
-    public override Tensor<T> Activate(Tensor<T> input) => Engine.Mish(input);
+    public override Tensor<T> Activate(Tensor<T> input)
+    {
+        var softplus = Engine.Softplus(input);
+        var tanh = Engine.Tanh(softplus);
+        return Engine.TensorMultiply(input, tanh);
+    }
 
     /// <summary>
     /// Calculates the derivative (gradient) of the Mish function for a single input value.

--- a/src/AiDotNet.Generators/TestScaffoldGenerator.cs
+++ b/src/AiDotNet.Generators/TestScaffoldGenerator.cs
@@ -1812,6 +1812,23 @@ public class TestScaffoldGenerator : IIncrementalGenerator
                     "vocabSize: 16, modelDimension: 32, numLayers: 2, stateDimension: 8, " +
                     "attentionInterval: 2, maxSeqLength: 8)";
             }
+            else if (IsValleCodecLMModel(model.ClassName) && model.TypeParameterCount == 1)
+            {
+                // VALL-E-family models are neural codec language models: token
+                // IDs -> transformer text/codec LM -> codec logits. Use a
+                // smoke-scale config that preserves that paper contract without
+                // constructing the production 1024-wide, 12-layer stack for every
+                // generated invariant test.
+                string optionsType = GetValleCodecLMOptionsType(model.ClassName);
+                constructorExpr = $"new {typeName}<double>(new AiDotNet.NeuralNetworks.NeuralNetworkArchitecture<double>(" +
+                    "inputType: AiDotNet.Enums.InputType.OneDimensional, " +
+                    "taskType: AiDotNet.Enums.NeuralNetworkTaskType.TextGeneration, " +
+                    "inputSize: 4, outputSize: 16), " +
+                    $"new {optionsType} {{ SampleRate = 24000, NumCodebooks = 1, CodebookSize = 16, " +
+                    "CodecFrameRate = 75, TextEncoderDim = 32, LLMDim = 32, NumEncoderLayers = 1, " +
+                    "NumLLMLayers = 1, NumHeads = 4, VocabSize = 64, MaxTextLength = 8, " +
+                    "DropoutRate = 0.0, LearningRate = 1e-3, WeightDecay = 0.0 })";
+            }
             else if (model.HasParameterlessConstructor)
             {
                 // Zero-arg constructor: simple instantiation
@@ -2575,8 +2592,45 @@ public class TestScaffoldGenerator : IIncrementalGenerator
                 // garbage → NaN / no learning). Output is the codec logits
                 // [seq, NumCodebooks*CodebookSize].
                 int codecDim = CodecLMOutputDim(model.ClassName);
+                int tokenVocab = CodecLMInputVocabSize(model.ClassName);
                 sb.AppendLine("    protected override int[] InputShape => new[] { 4 };");
                 sb.AppendLine($"    protected override int[] OutputShape => new[] {{ 4, {codecDim} }};");
+                sb.AppendLine();
+                sb.AppendLine("    protected override AiDotNet.Tensors.LinearAlgebra.Tensor<double> CreateRandomTensor(int[] shape, System.Random rng)");
+                sb.AppendLine("    {");
+                sb.AppendLine("        var tensor = new AiDotNet.Tensors.LinearAlgebra.Tensor<double>(shape);");
+                sb.AppendLine("        bool isInputShape = shape.Length == InputShape.Length;");
+                sb.AppendLine("        for (int d = 0; d < shape.Length && isInputShape; d++)");
+                sb.AppendLine("            isInputShape &= shape[d] == InputShape[d];");
+                sb.AppendLine("        if (isInputShape)");
+                sb.AppendLine("        {");
+                sb.AppendLine("            for (int i = 0; i < tensor.Length; i++)");
+                sb.AppendLine($"                tensor[i] = rng.Next(0, {tokenVocab});");
+                sb.AppendLine("            return tensor;");
+                sb.AppendLine("        }");
+                sb.AppendLine("        for (int i = 0; i < tensor.Length; i++)");
+                sb.AppendLine("            tensor[i] = rng.NextDouble();");
+                sb.AppendLine("        return tensor;");
+                sb.AppendLine("    }");
+                sb.AppendLine();
+                sb.AppendLine("    protected override AiDotNet.Tensors.LinearAlgebra.Tensor<double> CreateConstantTensor(int[] shape, double value)");
+                sb.AppendLine("    {");
+                sb.AppendLine("        var tensor = new AiDotNet.Tensors.LinearAlgebra.Tensor<double>(shape);");
+                sb.AppendLine("        bool isInputShape = shape.Length == InputShape.Length;");
+                sb.AppendLine("        for (int d = 0; d < shape.Length && isInputShape; d++)");
+                sb.AppendLine("            isInputShape &= shape[d] == InputShape[d];");
+                sb.AppendLine("        if (isInputShape)");
+                sb.AppendLine("        {");
+                sb.AppendLine("            int offset = value < 0.5 ? 1 : 17;");
+                sb.AppendLine("            for (int i = 0; i < tensor.Length; i++)");
+                sb.AppendLine($"                tensor[i] = (i + offset) % {tokenVocab};");
+                sb.AppendLine("            return tensor;");
+                sb.AppendLine("        }");
+                sb.AppendLine("        for (int i = 0; i < tensor.Length; i++)");
+                sb.AppendLine("            tensor[i] = value;");
+                sb.AppendLine("        return tensor;");
+                sb.AppendLine("    }");
+                sb.AppendLine();
                 sb.AppendLine("    protected override int MoreDataShortIterations => 3;");
                 sb.AppendLine("    protected override int MoreDataLongIterations => 10;");
                 // Deep embedding-first AR codec LM: pin a deterministic init so the
@@ -5081,7 +5135,7 @@ public class TestScaffoldGenerator : IIncrementalGenerator
     {
         int tickIdx = className.IndexOf('`');
         if (tickIdx > 0) className = className.Substring(0, tickIdx);
-        return className is "GPTSoVITS";
+        return className is "GPTSoVITS" || IsValleCodecLMModel(className);
     }
 
     /// <summary>
@@ -5094,8 +5148,39 @@ public class TestScaffoldGenerator : IIncrementalGenerator
         if (tickIdx > 0) className = className.Substring(0, tickIdx);
         return className switch
         {
+            "VALLE" => 16,
+            "VALLEX" => 16,
+            "VALLE2" => 16,
+            "VALLEXClone" => 16,
             "GPTSoVITS" => 1024,
             _ => 1024,
+        };
+    }
+
+    private static int CodecLMInputVocabSize(string className)
+    {
+        int tickIdx = className.IndexOf('`');
+        if (tickIdx > 0) className = className.Substring(0, tickIdx);
+        return IsValleCodecLMModel(className) ? 64 : 256;
+    }
+
+    private static bool IsValleCodecLMModel(string className)
+    {
+        int tickIdx = className.IndexOf('`');
+        if (tickIdx > 0) className = className.Substring(0, tickIdx);
+        return className is "VALLE" or "VALLEX" or "VALLE2" or "VALLEXClone";
+    }
+
+    private static string GetValleCodecLMOptionsType(string className)
+    {
+        int tickIdx = className.IndexOf('`');
+        if (tickIdx > 0) className = className.Substring(0, tickIdx);
+        return className switch
+        {
+            "VALLEXClone" => "AiDotNet.TextToSpeech.VoiceCloning.VALLEXCloneOptions",
+            "VALLE2" => "AiDotNet.TextToSpeech.CodecBased.VALLE2Options",
+            "VALLEX" => "AiDotNet.TextToSpeech.CodecBased.VALLEXOptions",
+            _ => "AiDotNet.TextToSpeech.CodecBased.VALLEOptions",
         };
     }
 

--- a/src/CausalInference/XLearner.cs
+++ b/src/CausalInference/XLearner.cs
@@ -333,6 +333,7 @@ public class XLearner<T> : CausalModelBase<T>
     public override Vector<T> EstimateTreatmentEffect(Matrix<T> features)
     {
         EnsureFitted();
+        features = NormalizeFeatureInput(features, nameof(features));
 
         int n = features.Rows;
         var effects = new Vector<T>(n);
@@ -369,6 +370,7 @@ public class XLearner<T> : CausalModelBase<T>
     public override Vector<T> PredictTreated(Matrix<T> features)
     {
         EnsureFitted();
+        features = NormalizeFeatureInput(features, nameof(features));
 
         var result = new Vector<T>(features.Rows);
         for (int i = 0; i < features.Rows; i++)
@@ -387,6 +389,7 @@ public class XLearner<T> : CausalModelBase<T>
     public override Vector<T> PredictControl(Matrix<T> features)
     {
         EnsureFitted();
+        features = NormalizeFeatureInput(features, nameof(features));
 
         var result = new Vector<T>(features.Rows);
         for (int i = 0; i < features.Rows; i++)
@@ -405,6 +408,26 @@ public class XLearner<T> : CausalModelBase<T>
     public override Vector<T> Predict(Matrix<T> input)
     {
         return EstimateTreatmentEffect(input);
+    }
+
+    private Matrix<T> NormalizeFeatureInput(Matrix<T> input, string paramName)
+    {
+        if (input.Columns == NumFeatures)
+            return input;
+
+        if (input.Columns == NumFeatures + 1)
+        {
+            var features = new Matrix<T>(input.Rows, NumFeatures);
+            for (int i = 0; i < input.Rows; i++)
+                for (int j = 0; j < NumFeatures; j++)
+                    features[i, j] = input[i, j + 1];
+            return features;
+        }
+
+        throw new ArgumentException(
+            $"Input must have {NumFeatures} covariate columns, or {NumFeatures + 1} " +
+            $"columns where the first is the treatment indicator. Got {input.Columns}.",
+            paramName);
     }
 
     /// <inheritdoc />
@@ -451,6 +474,7 @@ public class XLearner<T> : CausalModelBase<T>
     /// <inheritdoc />
     protected override Vector<T> EstimatePropensityScoresCore(Matrix<T> x)
     {
+        x = NormalizeFeatureInput(x, nameof(x));
         var result = new Vector<T>(x.Rows);
         for (int i = 0; i < x.Rows; i++)
         {
@@ -536,6 +560,64 @@ public class XLearner<T> : CausalModelBase<T>
     protected override IFullModel<T, Matrix<T>, Vector<T>> CreateNewInstance()
     {
         return new XLearner<T>(MaxIterations, LearningRate, Lambda);
+    }
+
+    /// <inheritdoc />
+    protected override Dictionary<string, object> GetAdditionalModelData()
+    {
+        var data = base.GetAdditionalModelData();
+        data["BiasControl"] = NumOps.ToDouble(_biasControl);
+        data["BiasTreated"] = NumOps.ToDouble(_biasTreated);
+        data["BiasTau0"] = NumOps.ToDouble(_biasTau0);
+        data["BiasTau1"] = NumOps.ToDouble(_biasTau1);
+        data["BiasPropensity"] = NumOps.ToDouble(_biasPropensity);
+        data["WeightsControl"] = ToDoubleArray(_weightsControl);
+        data["WeightsTreated"] = ToDoubleArray(_weightsTreated);
+        data["WeightsTau0"] = ToDoubleArray(_weightsTau0);
+        data["WeightsTau1"] = ToDoubleArray(_weightsTau1);
+        data["WeightsPropensity"] = ToDoubleArray(_weightsPropensity);
+        return data;
+    }
+
+    /// <inheritdoc />
+    protected override void LoadAdditionalModelData(Newtonsoft.Json.Linq.JObject modelDataObj)
+    {
+        base.LoadAdditionalModelData(modelDataObj);
+        if (modelDataObj["BiasControl"] is not null)
+            _biasControl = NumOps.FromDouble(modelDataObj["BiasControl"]!.ToObject<double>());
+        if (modelDataObj["BiasTreated"] is not null)
+            _biasTreated = NumOps.FromDouble(modelDataObj["BiasTreated"]!.ToObject<double>());
+        if (modelDataObj["BiasTau0"] is not null)
+            _biasTau0 = NumOps.FromDouble(modelDataObj["BiasTau0"]!.ToObject<double>());
+        if (modelDataObj["BiasTau1"] is not null)
+            _biasTau1 = NumOps.FromDouble(modelDataObj["BiasTau1"]!.ToObject<double>());
+        if (modelDataObj["BiasPropensity"] is not null)
+            _biasPropensity = NumOps.FromDouble(modelDataObj["BiasPropensity"]!.ToObject<double>());
+
+        _weightsControl = FromJsonArray(modelDataObj["WeightsControl"]);
+        _weightsTreated = FromJsonArray(modelDataObj["WeightsTreated"]);
+        _weightsTau0 = FromJsonArray(modelDataObj["WeightsTau0"]);
+        _weightsTau1 = FromJsonArray(modelDataObj["WeightsTau1"]);
+        _weightsPropensity = FromJsonArray(modelDataObj["WeightsPropensity"]);
+    }
+
+    private double[] ToDoubleArray(Vector<T> vector)
+    {
+        var values = new double[vector.Length];
+        for (int i = 0; i < vector.Length; i++)
+            values[i] = NumOps.ToDouble(vector[i]);
+        return values;
+    }
+
+    private Vector<T> FromJsonArray(Newtonsoft.Json.Linq.JToken? token)
+    {
+        if (token is not Newtonsoft.Json.Linq.JArray array)
+            return new Vector<T>(0);
+
+        var vector = new Vector<T>(array.Count);
+        for (int i = 0; i < array.Count; i++)
+            vector[i] = NumOps.FromDouble(array[i].ToObject<double>());
+        return vector;
     }
 
     /// <inheritdoc />

--- a/src/Diffusion/ImageEditing/ImagicModel.cs
+++ b/src/Diffusion/ImageEditing/ImagicModel.cs
@@ -317,28 +317,16 @@ public class ImagicModel<T> : LatentDiffusionModelBase<T>
     /// <inheritdoc />
     public override IDiffusionModel<T> Clone()
     {
-        var clonedUnet = new UNetNoisePredictor<T>(
-            inputChannels: LATENT_CHANNELS,
-            outputChannels: LATENT_CHANNELS,
-            baseChannels: 320,
-            channelMultipliers: [1, 2, 4, 4],
-            numResBlocks: 2,
-            attentionResolutions: [4, 2, 1],
-            contextDim: CROSS_ATTENTION_DIM);
-        clonedUnet.SetParameters(_unet.GetParameters());
-
-        var clonedVae = new StandardVAE<T>(
-            inputChannels: 3,
-            latentChannels: LATENT_CHANNELS,
-            baseChannels: 128,
-            channelMultipliers: [1, 2, 4, 4],
-            numResBlocksPerLevel: 2,
-            latentScaleFactor: 0.18215);
-        clonedVae.SetParameters(_vae.GetParameters());
+        var clonedOptions = GetOptions() is DiffusionModelOptions<T> options
+            ? new DiffusionModelOptions<T>(options)
+            : null;
 
         return new ImagicModel<T>(
-            unet: clonedUnet,
-            vae: clonedVae,
+            architecture: Architecture,
+            options: clonedOptions,
+            scheduler: new DDIMScheduler<T>(Scheduler.Config),
+            unet: (UNetNoisePredictor<T>)_unet.Clone(),
+            vae: (StandardVAE<T>)_vae.Clone(),
             conditioner: _conditioner);
     }
 

--- a/src/Diffusion/Video/VideoCrafter2Model.cs
+++ b/src/Diffusion/Video/VideoCrafter2Model.cs
@@ -70,7 +70,7 @@ public class VideoCrafter2Model<T> : VideoDiffusionModelBase<T>
     public override bool SupportsImageToVideo => true;
     public override bool SupportsTextToVideo => true;
     public override bool SupportsVideoToVideo => false;
-    public override long ParameterCount => _predictor.ParameterCount + _temporalVAE.GetParameters().Length;
+    public override long ParameterCount => _predictor.ParameterCount + _temporalVAE.ParameterCount;
 
     /// <summary>
     /// Initializes a new instance of VideoCrafter2Model with full customization support.
@@ -162,20 +162,15 @@ public class VideoCrafter2Model<T> : VideoDiffusionModelBase<T>
 
     public override IDiffusionModel<T> Clone()
     {
-        var clonedPredictor = new VideoUNetPredictor<T>(
-            inputChannels: LATENT_CHANNELS,
-            baseChannels: 320,
-            channelMultipliers: new[] { 1, 2, 4, 4 },
-            numResBlocks: 2,
-            numHeads: 8,
-            contextDim: CONTEXT_DIM);
-        clonedPredictor.SetParameters(_predictor.GetParameters());
+        var clonedOptions = GetOptions() is DiffusionModelOptions<T> options
+            ? new DiffusionModelOptions<T>(options)
+            : null;
 
         return new VideoCrafter2Model<T>(
             architecture: Architecture,
-            options: Options as DiffusionModelOptions<T>,
-            scheduler: Scheduler,
-            predictor: clonedPredictor,
+            options: clonedOptions,
+            scheduler: new DDIMScheduler<T>(Scheduler.Config),
+            predictor: (VideoUNetPredictor<T>)_predictor.Clone(),
             temporalVAE: (TemporalVAE<T>)_temporalVAE.Clone(),
             conditioner: _conditioner,
             defaultNumFrames: DefaultNumFrames,

--- a/src/Diffusion/Video/VideoCrafterModel.cs
+++ b/src/Diffusion/Video/VideoCrafterModel.cs
@@ -234,7 +234,11 @@ public class VideoCrafterModel<T> : VideoDiffusionModelBase<T>
             // the output, not full-quality generation — 4 steps is more
             // than enough to surface that signal and keeps Predict within
             // the 120s budget.
-            options ?? new DiffusionModelOptions<T> { DefaultInferenceSteps = 4 },
+            options ?? new DiffusionModelOptions<T>
+            {
+                DefaultInferenceSteps = 4,
+                LearningRate = 0.0001
+            },
             scheduler ?? new DDIMScheduler<T>(SchedulerConfig<T>.CreateStableDiffusion()),
             defaultNumFrames,
             defaultFPS,

--- a/src/Helpers/LayerHelper.cs
+++ b/src/Helpers/LayerHelper.cs
@@ -3090,22 +3090,17 @@ public static class LayerHelper<T>
         // Input layer
         yield return new InputLayer<T>(inputSize);
 
-        // Controller (Feed-forward network) — input is [features + memoryVectorSize]
-        // because ProcessController concatenates input with read results
+        // Controller (feed-forward network). NeuralTuringMachine.ForwardTape
+        // concatenates the external input with the previous read vector before
+        // running this stack; the controller's output is then partitioned into
+        // read/write interface parameters per Graves et al. 2014.
         int controllerInputSize = inputSize + memoryVectorSize;
         yield return new DenseLayer<T>(controllerSize, new TanhActivation<T>() as IActivationFunction<T>);
 
-        // Read heads - typically use content-based addressing with cosine similarity
-        yield return new MemoryReadLayer<T>(memoryVectorSize, memoryVectorSize,
-            new SigmoidActivation<T>() as IActivationFunction<T>);
-
-        // Write heads - typically use gated mechanism with sigmoid for gates
-        yield return new MemoryWriteLayer<T>(
-            memoryVectorSize,
-            new TanhActivation<T>() as IActivationFunction<T>
-        );
-
-        // Output layer - linear projection before final task-specific activation
+        // Output layer. ForwardTape concatenates controller output with the
+        // freshly read memory vector before this projection. The read/write
+        // heads are not standalone feed-forward layers here; they are the
+        // differentiable addressing operations implemented by ForwardTape.
         yield return new DenseLayer<T>(outputSize,
             new IdentityActivation<T>() as IActivationFunction<T>);
 
@@ -32545,9 +32540,14 @@ public static class LayerHelper<T>
         int llmFfnDim = llmDim * 4;
 
         // === Character/Byte Embedding (E2 TTS Eskimez et al. 2024 §3.1) ===
-        // Input is character/byte token IDs [seq], embedded to [seq, textEncoderDim]
-        // before the text encoder's FFT blocks consume them.
-        yield return new EmbeddingLayer<T>(vocabSize, textEncoderDim);
+        // Input is discrete text/acoustic token IDs [seq], embedded to
+        // [seq, textEncoderDim] before the transformer stack consumes them.
+        var tokenEmbedding = new EmbeddingLayer<T>(vocabSize, textEncoderDim)
+        {
+            InputMode = EmbeddingInputMode.Indices,
+            ScaleBySqrtDimension = true
+        };
+        yield return tokenEmbedding;
 
         // === Text Encoder ===
         // Canonical Pre-LN residual Transformer blocks (Vaswani 2017 §3.1). The prior

--- a/src/NeuralNetworks/EchoStateNetwork.cs
+++ b/src/NeuralNetworks/EchoStateNetwork.cs
@@ -621,9 +621,6 @@ public class EchoStateNetwork<T> : NeuralNetworkBase<T>
         _reservoirBias = new Vector<T>(_reservoirSize);
         _outputBias = new Vector<T>(_outputSize);
         _currentState = new Vector<T>(_reservoirSize); // Start with zero state
-        _leakingRate = NumOps.FromDouble(1.0); // Default to no leaking
-        _regularization = NumOps.FromDouble(1e-4); // Default regularization
-        _warmupPeriod = 10; // Default warmup period
 
         // Initialize input weights and reservoir bias
         for (int i = 0; i < _inputSize; i++)
@@ -1316,19 +1313,19 @@ public class EchoStateNetwork<T> : NeuralNetworkBase<T>
         _collectedStates.Add(_currentState.Clone());
         _collectedTargets.Add(targetVector.Clone());
 
-        // Compute loss for diagnostics (the user-visible LastLoss). Done
-        // BEFORE the ridge solve so it reflects the readout this Train
-        // call started with — matches the conventional "loss before
-        // parameter update" semantics other Train(...) impls use.
-        Vector<T> prediction = ComputeOutput();
-        LastLoss = _lossFunction.CalculateLoss(prediction, targetVector);
-
         // Resolve the readout from all collected samples so far. This is
         // the same closed-form solve <see cref="FinalizeTraining"/> runs
         // at the end; we just don't clear the collection so further
         // Train() calls keep accumulating samples and re-solving against
         // the growing dataset.
         SolveReadoutRidgeRegression();
+
+        // Report the post-solve training loss. ESN Train() is a closed-form
+        // readout solve rather than a gradient step, so callers expect the
+        // public loss to describe the fitted readout after this sample has
+        // joined the regression set.
+        Vector<T> prediction = ComputeOutput();
+        LastLoss = _lossFunction.CalculateLoss(prediction, targetVector);
     }
 
     /// <summary>
@@ -1343,7 +1340,8 @@ public class EchoStateNetwork<T> : NeuralNetworkBase<T>
         int numSamples = _collectedStates.Count;
         if (numSamples == 0) return;
 
-        Matrix<T> X = new Matrix<T>(numSamples, _reservoirSize);
+        int readoutFeatureCount = _reservoirSize + 1; // reservoir state plus bias feature
+        Matrix<T> X = new Matrix<T>(numSamples, readoutFeatureCount);
         Matrix<T> Y = new Matrix<T>(numSamples, _outputSize);
         for (int i = 0; i < numSamples; i++)
         {
@@ -1351,6 +1349,7 @@ public class EchoStateNetwork<T> : NeuralNetworkBase<T>
             {
                 X[i, j] = _collectedStates[i][j];
             }
+            X[i, _reservoirSize] = NumOps.One;
             for (int j = 0; j < _outputSize; j++)
             {
                 Y[i, j] = _collectedTargets[i][j];
@@ -1366,14 +1365,12 @@ public class EchoStateNetwork<T> : NeuralNetworkBase<T>
         // X X^T + λI instead of the (reservoirSize × reservoirSize)
         // matrix X^T X + λI. For ESN training the Gram matrix is
         // positive definite as long as λ > 0 — even when the reservoir
-        // states are nearly collinear (which feedback drives toward over
-        // long sequences and which made the primal form numerically
-        // explode and produce NaN weights, tripping
-        // MoreData_ShouldNotDegrade). The dual form's conditioning
-        // depends on sample count, not reservoir dimensionality, so it
-        // stays well-conditioned for the iterative-Train-on-same-pair
-        // case that the LossStrictlyDecreasesOnMemorizationTask
-        // invariant exercises.
+        // X includes the constant bias feature, which is the standard ESN
+        // readout design-matrix form: the bias is trained by the same ridge
+        // solve as the reservoir-to-output weights instead of being patched
+        // on afterward by a different objective. The dual form's
+        // conditioning depends on sample count, not reservoir dimensionality,
+        // so it stays well-conditioned for iterative sequence training.
         Matrix<T> XXt = X.Multiply(X.Transpose());
         Matrix<T> regularized = XXt.Clone();
         for (int i = 0; i < numSamples; i++)
@@ -1382,13 +1379,13 @@ public class EchoStateNetwork<T> : NeuralNetworkBase<T>
         }
         Matrix<T> inverse = ComputeInverse(regularized);
         Matrix<T> innerY = inverse.Multiply(Y);  // (numSamples × outputSize)
-        Matrix<T> weights = X.Transpose().Multiply(innerY);  // (reservoirSize × outputSize)
+        Matrix<T> weights = X.Transpose().Multiply(innerY);  // ((reservoirSize + bias) × outputSize)
 
         // Safety net — even SVD can produce NaN/Inf on completely
         // degenerate inputs (all-zero reservoir, etc.). Keep the
         // previous readout in that case rather than poisoning the
         // model. Belt-and-suspenders alongside the per-σ skip above.
-        for (int i = 0; i < _reservoirSize; i++)
+        for (int i = 0; i < readoutFeatureCount; i++)
         {
             for (int j = 0; j < _outputSize; j++)
             {
@@ -1410,26 +1407,7 @@ public class EchoStateNetwork<T> : NeuralNetworkBase<T>
 
         for (int j = 0; j < _outputSize; j++)
         {
-            T targetSum = NumOps.Zero;
-            for (int i = 0; i < numSamples; i++)
-            {
-                targetSum = NumOps.Add(targetSum, Y[i, j]);
-            }
-            T targetMean = NumOps.Divide(targetSum, NumOps.FromDouble(numSamples));
-
-            T outputSum = NumOps.Zero;
-            for (int i = 0; i < numSamples; i++)
-            {
-                T output = NumOps.Zero;
-                for (int k = 0; k < _reservoirSize; k++)
-                {
-                    output = NumOps.Add(output, NumOps.Multiply(_outputWeights[k, j], X[i, k]));
-                }
-                outputSum = NumOps.Add(outputSum, output);
-            }
-            T outputMean = NumOps.Divide(outputSum, NumOps.FromDouble(numSamples));
-
-            _outputBias[j] = NumOps.Subtract(targetMean, outputMean);
+            _outputBias[j] = weights[_reservoirSize, j];
         }
     }
 
@@ -1474,41 +1452,6 @@ public class EchoStateNetwork<T> : NeuralNetworkBase<T>
         // overwrite the stable readout with the numerically weaker path
         // this PR was introduced to remove.
         SolveReadoutRidgeRegression();
-
-        // Compute bias terms (mean of target - mean of prediction).
-        // Rebuild X / Y once for the bias-only computation since
-        // SolveReadoutRidgeRegression doesn't expose them.
-        int numSamples = _collectedStates.Count;
-        Matrix<T> X = new Matrix<T>(numSamples, _reservoirSize);
-        Matrix<T> Y = new Matrix<T>(numSamples, _outputSize);
-        for (int i = 0; i < numSamples; i++)
-        {
-            for (int j = 0; j < _reservoirSize; j++) X[i, j] = _collectedStates[i][j];
-            for (int j = 0; j < _outputSize; j++) Y[i, j] = _collectedTargets[i][j];
-        }
-        for (int j = 0; j < _outputSize; j++)
-        {
-            T targetSum = NumOps.Zero;
-            for (int i = 0; i < numSamples; i++)
-            {
-                targetSum = NumOps.Add(targetSum, Y[i, j]);
-            }
-            T targetMean = NumOps.Divide(targetSum, NumOps.FromDouble(numSamples));
-
-            T outputSum = NumOps.Zero;
-            for (int i = 0; i < numSamples; i++)
-            {
-                T output = NumOps.Zero;
-                for (int k = 0; k < _reservoirSize; k++)
-                {
-                    output = NumOps.Add(output, NumOps.Multiply(_outputWeights[k, j], X[i, k]));
-                }
-                outputSum = NumOps.Add(outputSum, output);
-            }
-            T outputMean = NumOps.Divide(outputSum, NumOps.FromDouble(numSamples));
-
-            _outputBias[j] = NumOps.Subtract(targetMean, outputMean);
-        }
 
         // Reset training state
         _isTraining = false;

--- a/src/NeuralNetworks/GraphNeuralNetwork.cs
+++ b/src/NeuralNetworks/GraphNeuralNetwork.cs
@@ -1,6 +1,7 @@
 #pragma warning disable CS0649, CS0414, CS0169
 using AiDotNet.Attributes;
 using AiDotNet.Enums;
+using AiDotNet.Models.Options;
 using AiDotNet.NeuralNetworks.Layers;
 using AiDotNet.NeuralNetworks.Options;
 using AiDotNet.Optimizers;
@@ -300,7 +301,7 @@ public class GraphNeuralNetwork<T> : NeuralNetworkBase<T>, IAuxiliaryLossLayer<T
         GraphNeuralNetworkOptions? options = null) :
         base(architecture, lossFunction ?? NeuralNetworkHelper<T>.GetDefaultLossFunction(architecture.TaskType))
     {
-        _optimizer = optimizer ?? new AdamOptimizer<T, Tensor<T>, Tensor<T>>(this);
+        _optimizer = optimizer ?? CreateDefaultOptimizer(this);
         _options = options ?? new GraphNeuralNetworkOptions();
         Options = _options;
         AuxiliaryLossWeight = NumOps.FromDouble(0.05);
@@ -347,7 +348,7 @@ public class GraphNeuralNetwork<T> : NeuralNetworkBase<T>, IAuxiliaryLossLayer<T
         GraphNeuralNetworkOptions? options = null) :
         base(architecture, lossFunction ?? NeuralNetworkHelper<T>.GetDefaultLossFunction(architecture.TaskType))
     {
-        _optimizer = optimizer ?? new AdamOptimizer<T, Tensor<T>, Tensor<T>>(this);
+        _optimizer = optimizer ?? CreateDefaultOptimizer(this);
         _options = options ?? new GraphNeuralNetworkOptions();
         Options = _options;
         AuxiliaryLossWeight = NumOps.FromDouble(0.05);
@@ -359,6 +360,16 @@ public class GraphNeuralNetwork<T> : NeuralNetworkBase<T>, IAuxiliaryLossLayer<T
         _finalActivationLayerScalarActivation = finalActivationLayerActivation;
 
         InitializeLayers();
+    }
+
+    private static AdamOptimizer<T, Tensor<T>, Tensor<T>> CreateDefaultOptimizer(GraphNeuralNetwork<T> model)
+    {
+        return new AdamOptimizer<T, Tensor<T>, Tensor<T>>(
+            model,
+            new AdamOptimizerOptions<T, Tensor<T>, Tensor<T>>
+            {
+                InitialLearningRate = DefaultTrainLearningRate
+            });
     }
 
     /// <summary>
@@ -780,15 +791,13 @@ public class GraphNeuralNetwork<T> : NeuralNetworkBase<T>, IAuxiliaryLossLayer<T
                 nameof(numNodes));
         }
 
-        // Create fully-connected adjacency with symmetric normalization per Kipf & Welling 2017.
-        // Â = D^(-1/2) · (A + I) · D^(-1/2) where D is the degree matrix of A + I.
-        // For a fully-connected graph with self-loops, every node has degree = numNodes,
-        // so D^(-1/2) = 1/sqrt(numNodes) * I, giving Â[i,j] = 1/numNodes.
+        // No explicit graph was supplied, so use the neutral Kipf-Welling case:
+        // A has no off-diagonal edges, A + I is identity, and symmetric
+        // normalization leaves identity unchanged. Real graph structure should
+        // still be provided through PredictGraph when available.
         var adj = new Tensor<T>([numNodes, numNodes]);
-        T normalizedWeight = NumOps.FromDouble(1.0 / numNodes);
         for (int i = 0; i < numNodes; i++)
-            for (int j = 0; j < numNodes; j++)
-                adj[i, j] = normalizedWeight;
+            adj[i, i] = NumOps.One;
 
         _autoAdjacencyMatrix = adj;
         return adj;
@@ -843,6 +852,23 @@ public class GraphNeuralNetwork<T> : NeuralNetworkBase<T>, IAuxiliaryLossLayer<T
         TrainWithTape(input, expectedOutput, _optimizer);
 
         SetTrainingMode(false);
+    }
+
+    public override Tensor<T> ForwardForTraining(Tensor<T> input)
+    {
+        if (input.Rank == 1)
+            input = Engine.Reshape(input, [1, input.Shape[0]]);
+
+        int numNodes = input.Shape[0];
+        var adjacencyMatrix = EnsureAdjacencyMatrix(numNodes);
+
+        foreach (var layer in Layers)
+        {
+            if (layer is IGraphConvolutionLayer<T> graphLayer)
+                graphLayer.SetAdjacencyMatrix(adjacencyMatrix);
+        }
+
+        return base.ForwardForTraining(input);
     }
 
 

--- a/src/NeuralNetworks/Layers/GraphConvolutionalLayer.cs
+++ b/src/NeuralNetworks/Layers/GraphConvolutionalLayer.cs
@@ -1107,7 +1107,7 @@ public partial class GraphConvolutionalLayer<T> : LayerBase<T>, IAuxiliaryLossLa
         int outputFeatures = bias.Length;
 
         // Reshape bias from [outputFeatures] to [1, 1, outputFeatures]
-        var biasReshaped = bias.Reshape([1, 1, outputFeatures]);
+        var biasReshaped = Engine.Reshape(bias, [1, 1, outputFeatures]);
 
         // Tile across batch and node dimensions: [batchSize, numNodes, outputFeatures]
         var broadcast = Engine.TensorTile(biasReshaped, [batchSize, numNodes, 1]);
@@ -1122,11 +1122,11 @@ public partial class GraphConvolutionalLayer<T> : LayerBase<T>, IAuxiliaryLossLa
     private Tensor<T> BatchedMatMul3Dx2D(Tensor<T> input3D, Tensor<T> weights2D, int batch, int rows, int cols, int outputCols)
     {
         // Flatten batch dimension: [batch, rows, cols] -> [batch * rows, cols]
-        var flattened = input3D.Reshape([batch * rows, cols]);
+        var flattened = Engine.Reshape(input3D, [batch * rows, cols]);
         // Standard 2D matmul: [batch * rows, cols] @ [cols, output_cols] -> [batch * rows, output_cols]
         var result = Engine.TensorMatMul(flattened, weights2D);
         // Unflatten: [batch * rows, output_cols] -> [batch, rows, output_cols]
-        return result.Reshape([batch, rows, outputCols]);
+        return Engine.Reshape(result, [batch, rows, outputCols]);
     }
 
     private Tensor<T>? _weightsVelocity;

--- a/src/NeuralNetworks/Options/SiameseNetworkOptions.cs
+++ b/src/NeuralNetworks/Options/SiameseNetworkOptions.cs
@@ -7,4 +7,8 @@ namespace AiDotNet.NeuralNetworks.Options;
 /// </summary>
 public class SiameseNetworkOptions : NeuralNetworkOptions
 {
+    /// <summary>
+    /// Size of the shared-tower embedding compared by the Siamese similarity head.
+    /// </summary>
+    public int EmbeddingSize { get; set; } = 64;
 }

--- a/src/NeuralNetworks/SiameseNetwork.cs
+++ b/src/NeuralNetworks/SiameseNetwork.cs
@@ -160,14 +160,20 @@ public class SiameseNetwork<T> : NeuralNetworkBase<T>, IAuxiliaryLossLayer<T>
         SiameseNetworkOptions? options = null) :
         base(architecture, lossFunction ?? NeuralNetworkHelper<T>.GetDefaultLossFunction(architecture.TaskType))
     {
-        _optimizer = optimizer ?? new AdamOptimizer<T, Tensor<T>, Tensor<T>>(this);
         _options = options ?? new SiameseNetworkOptions();
         Options = _options;
-        // Use CNN for 2D/3D input (images), FFNN for 1D input (features)
+        if (_options.EmbeddingSize <= 0)
+            throw new ArgumentOutOfRangeException(nameof(options), "Siamese embedding size must be positive.");
+
+        var embeddingArchitecture = CreateEmbeddingArchitecture(architecture, _options.EmbeddingSize);
+
+        // Use CNN for 2D/3D input (images), FFNN for 1D input (features).
+        // The shared tower is an embedding function, not the final binary
+        // classifier. The parent Siamese model owns the sigmoid similarity
+        // head below, matching the Koch et al. one-shot Siamese design.
         _subnetwork = architecture.InputType == Enums.InputType.OneDimensional
-            ? (NeuralNetworkBase<T>)new FeedForwardNeuralNetwork<T>(architecture)
-            : new ConvolutionalNeuralNetwork<T>(architecture);
-        int embeddingSize = architecture.GetOutputShape()[0];
+            ? (NeuralNetworkBase<T>)new FeedForwardNeuralNetwork<T>(embeddingArchitecture)
+            : new ConvolutionalNeuralNetwork<T>(embeddingArchitecture);
         _outputLayer = new DenseLayer<T>(1, new SigmoidActivation<T>() as IActivationFunction<T>);
 
         // Initialize NumOps-based fields
@@ -190,6 +196,31 @@ public class SiameseNetwork<T> : NeuralNetworkBase<T>, IAuxiliaryLossLayer<T>
         // Has to run AFTER _subnetwork and _outputLayer are assigned
         // because InitializeLayers reads them.
         InitializeLayers();
+        _optimizer = optimizer ?? new AdamOptimizer<T, Tensor<T>, Tensor<T>>(this);
+    }
+
+    private static NeuralNetworkArchitecture<T> CreateEmbeddingArchitecture(
+        NeuralNetworkArchitecture<T> architecture,
+        int embeddingSize)
+    {
+        if (architecture.Layers.Count > 0)
+            return architecture;
+
+        var embeddingArchitecture = new NeuralNetworkArchitecture<T>(
+            inputType: architecture.InputType,
+            taskType: Enums.NeuralNetworkTaskType.Regression,
+            complexity: architecture.Complexity,
+            inputSize: architecture.InputSize,
+            inputHeight: architecture.InputHeight,
+            inputWidth: architecture.InputWidth,
+            inputDepth: architecture.InputDepth,
+            outputSize: embeddingSize,
+            shouldReturnFullSequence: architecture.ShouldReturnFullSequence,
+            imageEmbeddingDim: architecture.ImageEmbeddingDim,
+            textEmbeddingDim: architecture.TextEmbeddingDim,
+            inputFrames: architecture.InputFrames);
+        embeddingArchitecture.RandomSeed = architecture.RandomSeed;
+        return embeddingArchitecture;
     }
 
     /// <summary>
@@ -640,8 +671,8 @@ public class SiameseNetwork<T> : NeuralNetworkBase<T>, IAuxiliaryLossLayer<T>
     {
         // Deserialize the subnetwork
         _subnetwork = Architecture.InputType == Enums.InputType.OneDimensional
-            ? (NeuralNetworkBase<T>)new FeedForwardNeuralNetwork<T>(Architecture)
-            : new ConvolutionalNeuralNetwork<T>(Architecture);
+            ? (NeuralNetworkBase<T>)new FeedForwardNeuralNetwork<T>(CreateEmbeddingArchitecture(Architecture, _options.EmbeddingSize))
+            : new ConvolutionalNeuralNetwork<T>(CreateEmbeddingArchitecture(Architecture, _options.EmbeddingSize));
         var subNetworkCount = reader.ReadInt32();
         _subnetwork.Deserialize(reader.ReadBytes(subNetworkCount));
 
@@ -655,7 +686,6 @@ public class SiameseNetwork<T> : NeuralNetworkBase<T>, IAuxiliaryLossLayer<T>
         }
 
         // Initialize the output layer with the correct dimensions
-        int embeddingSize = Architecture.GetOutputShape()[0];
         _outputLayer = new DenseLayer<T>(1, new SigmoidActivation<T>() as IActivationFunction<T>);
         _outputLayer.SetParameters(outputLayerParams);
 
@@ -696,7 +726,7 @@ public class SiameseNetwork<T> : NeuralNetworkBase<T>, IAuxiliaryLossLayer<T>
         {
             AdditionalInfo = new Dictionary<string, object>
             {
-                { "EmbeddingSize", Architecture.GetOutputShape()[0] },
+                { "EmbeddingSize", _options.EmbeddingSize },
                 { "SubnetworkType", _subnetwork.GetType().Name },
                 { "TotalParameters", GetParameterCount() },
                 { "InputShape", string.Join(",", Architecture.GetInputShape()) }

--- a/src/TextToSpeech/CodecBased/VALLE.cs
+++ b/src/TextToSpeech/CodecBased/VALLE.cs
@@ -93,7 +93,7 @@ public class VALLE<T> : TtsModelBase<T>, ICodecTts<T>
     {
         _options = options ?? new VALLEOptions();
         _useNativeMode = true;
-        _optimizer = optimizer ?? new AdamWOptimizer<T, Tensor<T>, Tensor<T>>(this);
+        _optimizer = optimizer ?? CreateDefaultOptimizer();
         base.SampleRate = _options.SampleRate;
         base.MelChannels = _options.MelChannels;
         base.HopSize = _options.HopSize;
@@ -211,8 +211,9 @@ public class VALLE<T> : TtsModelBase<T>, ICodecTts<T>
     {
         int len = Math.Min(text.Length, _options.MaxTextLength);
         var t = new Tensor<T>([len]);
+        int vocabSize = Math.Max(1, _options.VocabSize);
         for (int i = 0; i < len; i++)
-            t[i] = NumOps.FromDouble(text[i] / 128.0);
+            t[i] = NumOps.FromDouble(text[i] % vocabSize);
         return t;
     }
 
@@ -230,7 +231,8 @@ public class VALLE<T> : TtsModelBase<T>, ICodecTts<T>
                 _options.TextEncoderDim, _options.LLMDim,
                 _options.NumCodebooks * _options.CodebookSize,
                 _options.NumEncoderLayers, _options.NumLLMLayers,
-                _options.NumHeads, _options.DropoutRate));
+                _options.NumHeads, _options.DropoutRate,
+                _options.VocabSize));
         ComputeEncoderDecoderBoundary();
     }
 
@@ -260,7 +262,7 @@ public class VALLE<T> : TtsModelBase<T>, ICodecTts<T>
         SetTrainingMode(true);
         try
         {
-            TrainWithTape(input, expected);
+            TrainWithTape(input, expected, _optimizer);
         }
         finally
         {
@@ -289,7 +291,26 @@ public class VALLE<T> : TtsModelBase<T>, ICodecTts<T>
         {
             Name = _useNativeMode ? "VALL-E-Native" : "VALL-E-ONNX",
             Description = "VALL-E: Neural Codec Language Model TTS (Wang et al., 2023)",
-            FeatureCount = _options.LLMDim
+            FeatureCount = _options.LLMDim,
+            AdditionalInfo = new Dictionary<string, object>
+            {
+                ["Architecture"] = "VALL-E",
+                ["Mode"] = _useNativeMode ? "Native" : "ONNX",
+                ["SampleRate"] = _options.SampleRate,
+                ["MelChannels"] = _options.MelChannels,
+                ["HopSize"] = _options.HopSize,
+                ["CodecFrameRate"] = _options.CodecFrameRate,
+                ["NumCodebooks"] = _options.NumCodebooks,
+                ["CodebookSize"] = _options.CodebookSize,
+                ["TextEncoderDim"] = _options.TextEncoderDim,
+                ["LLMDim"] = _options.LLMDim,
+                ["NumEncoderLayers"] = _options.NumEncoderLayers,
+                ["NumLLMLayers"] = _options.NumLLMLayers,
+                ["NumHeads"] = _options.NumHeads,
+                ["MaxTextLength"] = _options.MaxTextLength,
+                ["LayerCount"] = Layers.Count
+            },
+            ModelData = SerializeForMetadata()
         };
     }
 
@@ -346,6 +367,14 @@ public class VALLE<T> : TtsModelBase<T>, ICodecTts<T>
         if (_disposed)
             throw new ObjectDisposedException(GetType().FullName ?? nameof(VALLE<T>));
     }
+
+    private AdamWOptimizer<T, Tensor<T>, Tensor<T>> CreateDefaultOptimizer()
+        => new(this, new AdamWOptimizerOptions<T, Tensor<T>, Tensor<T>>
+        {
+            InitialLearningRate = _options.LearningRate,
+            WeightDecay = _options.WeightDecay,
+            UseAdaptiveLearningRate = false
+        });
 
     /// <inheritdoc />
     protected override void Dispose(bool disposing)

--- a/src/TextToSpeech/CodecBased/VALLE2.cs
+++ b/src/TextToSpeech/CodecBased/VALLE2.cs
@@ -39,7 +39,7 @@ public class VALLE2<T> : TtsModelBase<T>, ICodecTts<T>
     private readonly VALLE2Options _options; public override ModelOptions GetOptions() => _options;
     private readonly IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>>? _optimizer; private bool _useNativeMode; private bool _disposed;
     public VALLE2(NeuralNetworkArchitecture<T> architecture, string modelPath, VALLE2Options? options = null) : base(architecture) { _options = options ?? new VALLE2Options(); _useNativeMode = false; base.SampleRate = _options.SampleRate; base.MelChannels = _options.MelChannels; base.HopSize = _options.HopSize; base.HiddenDim = _options.LLMDim; if (string.IsNullOrWhiteSpace(modelPath)) throw new ArgumentException("Model path required.", nameof(modelPath)); if (!File.Exists(modelPath)) throw new FileNotFoundException($"ONNX model not found: {modelPath}", modelPath); _options.ModelPath = modelPath; OnnxModel = new OnnxModel<T>(modelPath, _options.OnnxOptions); InitializeLayers(); }
-    public VALLE2(NeuralNetworkArchitecture<T> architecture, VALLE2Options? options = null, IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>>? optimizer = null) : base(architecture) { _options = options ?? new VALLE2Options(); _useNativeMode = true; _optimizer = optimizer ?? new AdamWOptimizer<T, Tensor<T>, Tensor<T>>(this); base.SampleRate = _options.SampleRate; base.MelChannels = _options.MelChannels; base.HopSize = _options.HopSize; base.HiddenDim = _options.LLMDim; InitializeLayers(); }
+    public VALLE2(NeuralNetworkArchitecture<T> architecture, VALLE2Options? options = null, IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>>? optimizer = null) : base(architecture) { _options = options ?? new VALLE2Options(); _useNativeMode = true; _optimizer = optimizer ?? CreateDefaultOptimizer(); base.SampleRate = _options.SampleRate; base.MelChannels = _options.MelChannels; base.HopSize = _options.HopSize; base.HiddenDim = _options.LLMDim; InitializeLayers(); }
     int ITtsModel<T>.SampleRate => _options.SampleRate; public int MaxTextLength => _options.MaxTextLength; public int NumCodebooks => _options.NumCodebooks; public int CodebookSize => _options.CodebookSize; public int CodecFrameRate => _options.CodecFrameRate;
     /// <summary>
     /// Synthesizes speech from text.
@@ -55,15 +55,44 @@ public class VALLE2<T> : TtsModelBase<T>, ICodecTts<T>
     }
     public Tensor<T> EncodeToTokens(Tensor<T> audio) { ThrowIfDisposed(); if (IsOnnxMode && OnnxModel is not null) return OnnxModel.Run(audio); return Predict(audio); }
     public Tensor<T> DecodeFromTokens(Tensor<T> tokens) { ThrowIfDisposed(); if (IsOnnxMode && OnnxModel is not null) return OnnxModel.Run(tokens); return Predict(tokens); }
-    protected override Tensor<T> PreprocessText(string text) { int len = Math.Min(text.Length, _options.MaxTextLength); var t = new Tensor<T>([len]); for (int i = 0; i < len; i++) t[i] = NumOps.FromDouble(text[i] / 128.0); return t; } protected override Tensor<T> PostprocessAudio(Tensor<T> output) => output;
-    protected override void InitializeLayers() { if (!_useNativeMode) return; if (Architecture.Layers is not null && Architecture.Layers.Count > 0) Layers.AddRange(Architecture.Layers); else Layers.AddRange(LayerHelper<T>.CreateDefaultCodecLMLayers(_options.TextEncoderDim, _options.LLMDim, _options.NumCodebooks * _options.CodebookSize, _options.NumEncoderLayers, _options.NumLLMLayers, _options.NumHeads, _options.DropoutRate)); }
+    protected override Tensor<T> PreprocessText(string text) { int len = Math.Min(text.Length, _options.MaxTextLength); var t = new Tensor<T>([len]); int vocabSize = Math.Max(1, _options.VocabSize); for (int i = 0; i < len; i++) t[i] = NumOps.FromDouble(text[i] % vocabSize); return t; } protected override Tensor<T> PostprocessAudio(Tensor<T> output) => output;
+    protected override void InitializeLayers() { if (!_useNativeMode) return; if (Architecture.Layers is not null && Architecture.Layers.Count > 0) Layers.AddRange(Architecture.Layers); else Layers.AddRange(LayerHelper<T>.CreateDefaultCodecLMLayers(_options.TextEncoderDim, _options.LLMDim, _options.NumCodebooks * _options.CodebookSize, _options.NumEncoderLayers, _options.NumLLMLayers, _options.NumHeads, _options.DropoutRate, _options.VocabSize)); }
     public override Tensor<T> Predict(Tensor<T> input) { ThrowIfDisposed(); if (IsOnnxMode && OnnxModel is not null) return OnnxModel.Run(input); SetTrainingMode(false); var c = input; foreach (var l in Layers) c = l.Forward(c); return c; }
-    public override void Train(Tensor<T> input, Tensor<T> expected) { if (IsOnnxMode) throw new NotSupportedException("Training not supported in ONNX mode."); SetTrainingMode(true); try { TrainWithTape(input, expected); } finally { SetTrainingMode(false); } }
+    public override void Train(Tensor<T> input, Tensor<T> expected) { if (IsOnnxMode) throw new NotSupportedException("Training not supported in ONNX mode."); SetTrainingMode(true); try { TrainWithTape(input, expected, _optimizer); } finally { SetTrainingMode(false); } }
     public override void UpdateParameters(Vector<T> parameters) { if (!_useNativeMode) throw new NotSupportedException("Cannot update parameters in ONNX mode."); int idx = 0; foreach (var l in Layers) { int c = (int)l.ParameterCount; l.UpdateParameters(parameters.Slice(idx, c)); idx += c; } }
-    public override ModelMetadata<T> GetModelMetadata() { return new ModelMetadata<T> { Name = _useNativeMode ? "VALLE2-Native" : "VALLE2-ONNX", Description = "VALLE2 TTS", FeatureCount = _options.LLMDim }; }
+    public override ModelMetadata<T> GetModelMetadata()
+    {
+        return new ModelMetadata<T>
+        {
+            Name = _useNativeMode ? "VALLE2-Native" : "VALLE2-ONNX",
+            Description = "VALL-E 2: Neural Codec Language Model TTS (Chen et al., 2024)",
+            FeatureCount = _options.LLMDim,
+            AdditionalInfo = new Dictionary<string, object>
+            {
+                ["Architecture"] = "VALL-E 2",
+                ["Mode"] = _useNativeMode ? "Native" : "ONNX",
+                ["SampleRate"] = _options.SampleRate,
+                ["MelChannels"] = _options.MelChannels,
+                ["HopSize"] = _options.HopSize,
+                ["CodecFrameRate"] = _options.CodecFrameRate,
+                ["NumCodebooks"] = _options.NumCodebooks,
+                ["CodebookSize"] = _options.CodebookSize,
+                ["TextEncoderDim"] = _options.TextEncoderDim,
+                ["LLMDim"] = _options.LLMDim,
+                ["NumEncoderLayers"] = _options.NumEncoderLayers,
+                ["NumLLMLayers"] = _options.NumLLMLayers,
+                ["NumHeads"] = _options.NumHeads,
+                ["MaxTextLength"] = _options.MaxTextLength,
+                ["LayerCount"] = Layers.Count
+            },
+            ModelData = SerializeForMetadata()
+        };
+    }
     protected override void SerializeNetworkSpecificData(BinaryWriter writer) { writer.Write(_useNativeMode); writer.Write(_options.ModelPath ?? string.Empty); writer.Write(_options.SampleRate); writer.Write(_options.CodebookSize); writer.Write(_options.DropoutRate); writer.Write(_options.LLMDim); writer.Write(_options.NumCodebooks); writer.Write(_options.NumEncoderLayers); writer.Write(_options.NumHeads); writer.Write(_options.NumLLMLayers); writer.Write(_options.TextEncoderDim); }
     protected override void DeserializeNetworkSpecificData(BinaryReader reader) { _useNativeMode = reader.ReadBoolean(); string mp = reader.ReadString(); if (!string.IsNullOrEmpty(mp)) _options.ModelPath = mp; _options.SampleRate = reader.ReadInt32();  _options.CodebookSize = reader.ReadInt32(); _options.DropoutRate = reader.ReadDouble(); _options.LLMDim = reader.ReadInt32(); _options.NumCodebooks = reader.ReadInt32(); _options.NumEncoderLayers = reader.ReadInt32(); _options.NumHeads = reader.ReadInt32(); _options.NumLLMLayers = reader.ReadInt32(); _options.TextEncoderDim = reader.ReadInt32();  base.SampleRate = _options.SampleRate; base.MelChannels = _options.MelChannels; base.HopSize = _options.HopSize; base.HiddenDim = _options.LLMDim; if (!_useNativeMode && _options.ModelPath is {} p && !string.IsNullOrEmpty(p)) OnnxModel = new OnnxModel<T>(p, _options.OnnxOptions); }
     protected override IFullModel<T, Tensor<T>, Tensor<T>> CreateNewInstance() { if (!_useNativeMode && _options.ModelPath is {} mp && !string.IsNullOrEmpty(mp)) return new VALLE2<T>(Architecture, mp, _options); return new VALLE2<T>(Architecture, _options); }
+    private AdamWOptimizer<T, Tensor<T>, Tensor<T>> CreateDefaultOptimizer()
+        => new(this, new AdamWOptimizerOptions<T, Tensor<T>, Tensor<T>> { InitialLearningRate = _options.LearningRate, WeightDecay = _options.WeightDecay, UseAdaptiveLearningRate = false });
     private void ThrowIfDisposed() { if (_disposed) throw new ObjectDisposedException(GetType().FullName ?? nameof(VALLE2<T>)); }
     protected override void Dispose(bool disposing) { if (_disposed) return; _disposed = true; base.Dispose(disposing); }
 }

--- a/src/TextToSpeech/CodecBased/VALLEX.cs
+++ b/src/TextToSpeech/CodecBased/VALLEX.cs
@@ -94,7 +94,7 @@ public class VALLEX<T> : TtsModelBase<T>, ICodecTts<T>
     {
         _options = options ?? new VALLEXOptions();
         _useNativeMode = true;
-        _optimizer = optimizer ?? new AdamWOptimizer<T, Tensor<T>, Tensor<T>>(this);
+        _optimizer = optimizer ?? CreateDefaultOptimizer();
         base.SampleRate = _options.SampleRate;
         base.MelChannels = _options.MelChannels;
         base.HopSize = _options.HopSize;
@@ -221,8 +221,9 @@ public class VALLEX<T> : TtsModelBase<T>, ICodecTts<T>
     {
         int len = Math.Min(text.Length, _options.MaxTextLength);
         var t = new Tensor<T>([len]);
+        int vocabSize = Math.Max(1, _options.VocabSize);
         for (int i = 0; i < len; i++)
-            t[i] = NumOps.FromDouble(text[i] / 128.0);
+            t[i] = NumOps.FromDouble(text[i] % vocabSize);
         return t;
     }
 
@@ -240,7 +241,8 @@ public class VALLEX<T> : TtsModelBase<T>, ICodecTts<T>
                 _options.TextEncoderDim, _options.LLMDim,
                 _options.NumCodebooks * _options.CodebookSize,
                 _options.NumEncoderLayers, _options.NumLLMLayers,
-                _options.NumHeads, _options.DropoutRate));
+                _options.NumHeads, _options.DropoutRate,
+                _options.VocabSize));
         ComputeEncoderDecoderBoundary();
     }
 
@@ -270,7 +272,7 @@ public class VALLEX<T> : TtsModelBase<T>, ICodecTts<T>
         SetTrainingMode(true);
         try
         {
-            TrainWithTape(input, expected);
+            TrainWithTape(input, expected, _optimizer);
         }
         finally
         {
@@ -299,7 +301,26 @@ public class VALLEX<T> : TtsModelBase<T>, ICodecTts<T>
         {
             Name = _useNativeMode ? "VALLEX-Native" : "VALLEX-ONNX",
             Description = "VALL-E X: Cross-Lingual Zero-Shot TTS (Zhang et al., 2023)",
-            FeatureCount = _options.LLMDim
+            FeatureCount = _options.LLMDim,
+            AdditionalInfo = new Dictionary<string, object>
+            {
+                ["Architecture"] = "VALL-E X",
+                ["Mode"] = _useNativeMode ? "Native" : "ONNX",
+                ["SampleRate"] = _options.SampleRate,
+                ["MelChannels"] = _options.MelChannels,
+                ["HopSize"] = _options.HopSize,
+                ["CodecFrameRate"] = _options.CodecFrameRate,
+                ["NumCodebooks"] = _options.NumCodebooks,
+                ["CodebookSize"] = _options.CodebookSize,
+                ["TextEncoderDim"] = _options.TextEncoderDim,
+                ["LLMDim"] = _options.LLMDim,
+                ["NumEncoderLayers"] = _options.NumEncoderLayers,
+                ["NumLLMLayers"] = _options.NumLLMLayers,
+                ["NumHeads"] = _options.NumHeads,
+                ["MaxTextLength"] = _options.MaxTextLength,
+                ["LayerCount"] = Layers.Count
+            },
+            ModelData = SerializeForMetadata()
         };
     }
 
@@ -356,6 +377,14 @@ public class VALLEX<T> : TtsModelBase<T>, ICodecTts<T>
         if (_disposed)
             throw new ObjectDisposedException(GetType().FullName ?? nameof(VALLEX<T>));
     }
+
+    private AdamWOptimizer<T, Tensor<T>, Tensor<T>> CreateDefaultOptimizer()
+        => new(this, new AdamWOptimizerOptions<T, Tensor<T>, Tensor<T>>
+        {
+            InitialLearningRate = _options.LearningRate,
+            WeightDecay = _options.WeightDecay,
+            UseAdaptiveLearningRate = false
+        });
 
     /// <inheritdoc />
     protected override void Dispose(bool disposing)

--- a/src/TextToSpeech/VoiceCloning/VALLEXClone.cs
+++ b/src/TextToSpeech/VoiceCloning/VALLEXClone.cs
@@ -39,7 +39,7 @@ public class VALLEXClone<T> : TtsModelBase<T>, ICodecTts<T>, IVoiceCloner<T>
     private readonly VALLEXCloneOptions _options; public override ModelOptions GetOptions() => _options;
     private readonly IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>>? _optimizer; private bool _useNativeMode; private bool _disposed;
     public VALLEXClone(NeuralNetworkArchitecture<T> architecture, string modelPath, VALLEXCloneOptions? options = null) : base(architecture) { _options = options ?? new VALLEXCloneOptions(); _useNativeMode = false; base.SampleRate = _options.SampleRate; base.MelChannels = _options.MelChannels; base.HopSize = _options.HopSize; base.HiddenDim = _options.LLMDim; if (string.IsNullOrWhiteSpace(modelPath)) throw new ArgumentException("Model path required.", nameof(modelPath)); if (!File.Exists(modelPath)) throw new FileNotFoundException($"ONNX model not found: {modelPath}", modelPath); _options.ModelPath = modelPath; OnnxModel = new OnnxModel<T>(modelPath, _options.OnnxOptions); InitializeLayers(); }
-    public VALLEXClone(NeuralNetworkArchitecture<T> architecture, VALLEXCloneOptions? options = null, IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>>? optimizer = null) : base(architecture) { _options = options ?? new VALLEXCloneOptions(); _useNativeMode = true; _optimizer = optimizer ?? new AdamWOptimizer<T, Tensor<T>, Tensor<T>>(this); base.SampleRate = _options.SampleRate; base.MelChannels = _options.MelChannels; base.HopSize = _options.HopSize; base.HiddenDim = _options.LLMDim; InitializeLayers(); }
+    public VALLEXClone(NeuralNetworkArchitecture<T> architecture, VALLEXCloneOptions? options = null, IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>>? optimizer = null) : base(architecture) { _options = options ?? new VALLEXCloneOptions(); _useNativeMode = true; _optimizer = optimizer ?? CreateDefaultOptimizer(); base.SampleRate = _options.SampleRate; base.MelChannels = _options.MelChannels; base.HopSize = _options.HopSize; base.HiddenDim = _options.LLMDim; InitializeLayers(); }
     int ITtsModel<T>.SampleRate => _options.SampleRate; public int MaxTextLength => _options.MaxTextLength; public int NumCodebooks => _options.NumCodebooks; public int CodebookSize => _options.CodebookSize; public int CodecFrameRate => _options.CodecFrameRate;
     public double MinReferenceDuration => _options.MinReferenceDurationSec; public int SpeakerEmbeddingDim => _options.SpeakerEmbeddingDim;
     public Tensor<T> Synthesize(string text)
@@ -64,15 +64,46 @@ public class VALLEXClone<T> : TtsModelBase<T>, ICodecTts<T>, IVoiceCloner<T>
     public Tensor<T> ExtractSpeakerEmbedding(Tensor<T> referenceAudio) { int embDim = _options.SpeakerEmbeddingDim; var emb = new Tensor<T>([embDim]); int hopLen = Math.Max(1, _options.HopSize); int numFrames = Math.Max(1, referenceAudio.Length / hopLen); for (int d = 0; d < embDim; d++) { double acc = 0; for (int f = 0; f < numFrames; f++) { int idx = Math.Min(f * hopLen + d % hopLen, referenceAudio.Length - 1); double val = NumOps.ToDouble(referenceAudio[idx]); acc += Math.Tanh(val * Math.Sin((d + 1.0) * (f + 1.0) * 0.001) * 0.5); } emb[d] = NumOps.FromDouble(acc / numFrames); } double norm = 0; for (int d = 0; d < embDim; d++) { double v = NumOps.ToDouble(emb[d]); norm += v * v; } norm = Math.Sqrt(norm); if (norm > 1e-8) for (int d = 0; d < embDim; d++) emb[d] = NumOps.FromDouble(NumOps.ToDouble(emb[d]) / norm); return emb; }
     public Tensor<T> EncodeToTokens(Tensor<T> audio) { int samplesPerFrame = Math.Max(1, SampleRate / _options.CodecFrameRate); int frames = Math.Max(1, audio.Length / samplesPerFrame); var tokens = new Tensor<T>([frames]); for (int f = 0; f < frames; f++) { double sum = 0; int start = f * samplesPerFrame; int count = Math.Min(samplesPerFrame, audio.Length - start); for (int s = 0; s < count; s++) sum += NumOps.ToDouble(audio[start + s]); double avg = sum / Math.Max(1, count); int bin = (int)Math.Round((Math.Tanh(avg) + 1.0) * 0.5 * (_options.CodebookSize - 1)); bin = Math.Max(0, Math.Min(_options.CodebookSize - 1, bin)); tokens[f] = NumOps.FromDouble(bin); } return tokens; }
     public Tensor<T> DecodeFromTokens(Tensor<T> tokens) { int samplesPerFrame = Math.Max(1, SampleRate / _options.CodecFrameRate); int waveLen = tokens.Length * samplesPerFrame; var wave = new Tensor<T>([waveLen]); for (int i = 0; i < waveLen; i++) { int f = Math.Min(i / samplesPerFrame, tokens.Length - 1); double tokenVal = NumOps.ToDouble(tokens[f]); double normalized = tokenVal / Math.Max(1, _options.CodebookSize - 1) * 2.0 - 1.0; double phase = i * 2.0 * Math.PI * 200.0 / SampleRate; wave[i] = NumOps.FromDouble(normalized * Math.Sin(phase) * 0.8); } return wave; }
-    protected override Tensor<T> PreprocessText(string text) { int len = Math.Min(text.Length, _options.MaxTextLength); var t = new Tensor<T>([len]); for (int i = 0; i < len; i++) t[i] = NumOps.FromDouble(text[i] / 128.0); return t; } protected override Tensor<T> PostprocessAudio(Tensor<T> output) => output;
-    protected override void InitializeLayers() { if (!_useNativeMode) return; if (Architecture.Layers is not null && Architecture.Layers.Count > 0) Layers.AddRange(Architecture.Layers); else Layers.AddRange(LayerHelper<T>.CreateDefaultCodecLMLayers(_options.TextEncoderDim, _options.LLMDim, _options.NumCodebooks * _options.CodebookSize, _options.NumEncoderLayers, _options.NumLLMLayers, _options.NumHeads, _options.DropoutRate)); }
+    protected override Tensor<T> PreprocessText(string text) { int len = Math.Min(text.Length, _options.MaxTextLength); var t = new Tensor<T>([len]); int vocabSize = Math.Max(1, _options.VocabSize); for (int i = 0; i < len; i++) t[i] = NumOps.FromDouble(text[i] % vocabSize); return t; } protected override Tensor<T> PostprocessAudio(Tensor<T> output) => output;
+    protected override void InitializeLayers() { if (!_useNativeMode) return; if (Architecture.Layers is not null && Architecture.Layers.Count > 0) Layers.AddRange(Architecture.Layers); else Layers.AddRange(LayerHelper<T>.CreateDefaultCodecLMLayers(_options.TextEncoderDim, _options.LLMDim, _options.NumCodebooks * _options.CodebookSize, _options.NumEncoderLayers, _options.NumLLMLayers, _options.NumHeads, _options.DropoutRate, _options.VocabSize)); }
     public override Tensor<T> Predict(Tensor<T> input) { ThrowIfDisposed(); if (IsOnnxMode && OnnxModel is not null) return OnnxModel.Run(input); SetTrainingMode(false); var c = input; foreach (var l in Layers) c = l.Forward(c); return c; }
-    public override void Train(Tensor<T> input, Tensor<T> expected) { if (IsOnnxMode) throw new NotSupportedException("Training not supported in ONNX mode."); SetTrainingMode(true); TrainWithTape(input, expected); SetTrainingMode(false); }
+    public override void Train(Tensor<T> input, Tensor<T> expected) { if (IsOnnxMode) throw new NotSupportedException("Training not supported in ONNX mode."); SetTrainingMode(true); try { TrainWithTape(input, expected, _optimizer); } finally { SetTrainingMode(false); } }
     public override void UpdateParameters(Vector<T> parameters) { if (!_useNativeMode) throw new NotSupportedException("Cannot update parameters in ONNX mode."); int idx = 0; foreach (var l in Layers) { int c = (int)l.ParameterCount; l.UpdateParameters(parameters.Slice(idx, c)); idx += c; } }
-    public override ModelMetadata<T> GetModelMetadata() { return new ModelMetadata<T> { Name = _useNativeMode ? "VALL-E-X-Clone-Native" : "VALL-E-X-Clone-ONNX", Description = "VALL-E X: Cross-Lingual Voice Cloning (Zhang et al., 2023)", FeatureCount = _options.LLMDim }; }
+    public override ModelMetadata<T> GetModelMetadata()
+    {
+        return new ModelMetadata<T>
+        {
+            Name = _useNativeMode ? "VALL-E-X-Clone-Native" : "VALL-E-X-Clone-ONNX",
+            Description = "VALL-E X: Cross-Lingual Voice Cloning (Zhang et al., 2023)",
+            FeatureCount = _options.LLMDim,
+            AdditionalInfo = new Dictionary<string, object>
+            {
+                ["Architecture"] = "VALL-E X Voice Cloning",
+                ["Mode"] = _useNativeMode ? "Native" : "ONNX",
+                ["SampleRate"] = _options.SampleRate,
+                ["MelChannels"] = _options.MelChannels,
+                ["HopSize"] = _options.HopSize,
+                ["CodecFrameRate"] = _options.CodecFrameRate,
+                ["NumCodebooks"] = _options.NumCodebooks,
+                ["CodebookSize"] = _options.CodebookSize,
+                ["TextEncoderDim"] = _options.TextEncoderDim,
+                ["LLMDim"] = _options.LLMDim,
+                ["NumEncoderLayers"] = _options.NumEncoderLayers,
+                ["NumLLMLayers"] = _options.NumLLMLayers,
+                ["NumHeads"] = _options.NumHeads,
+                ["SpeakerEmbeddingDim"] = _options.SpeakerEmbeddingDim,
+                ["MinReferenceDurationSec"] = _options.MinReferenceDurationSec,
+                ["MaxTextLength"] = _options.MaxTextLength,
+                ["LayerCount"] = Layers.Count
+            },
+            ModelData = SerializeForMetadata()
+        };
+    }
     protected override void SerializeNetworkSpecificData(BinaryWriter writer) { writer.Write(_useNativeMode); writer.Write(_options.ModelPath ?? string.Empty); writer.Write(_options.SampleRate); writer.Write(_options.NumCodebooks); writer.Write(_options.LLMDim); writer.Write(_options.SpeakerEmbeddingDim); writer.Write(_options.CodebookSize); writer.Write(_options.DropoutRate); writer.Write(_options.NumEncoderLayers); writer.Write(_options.NumHeads); writer.Write(_options.NumLLMLayers); writer.Write(_options.TextEncoderDim); }
     protected override void DeserializeNetworkSpecificData(BinaryReader reader) { _useNativeMode = reader.ReadBoolean(); string mp = reader.ReadString(); if (!string.IsNullOrEmpty(mp)) _options.ModelPath = mp; _options.SampleRate = reader.ReadInt32(); _options.NumCodebooks = reader.ReadInt32(); _options.LLMDim = reader.ReadInt32(); _options.SpeakerEmbeddingDim = reader.ReadInt32();  _options.CodebookSize = reader.ReadInt32(); _options.DropoutRate = reader.ReadDouble(); _options.NumEncoderLayers = reader.ReadInt32(); _options.NumHeads = reader.ReadInt32(); _options.NumLLMLayers = reader.ReadInt32(); _options.TextEncoderDim = reader.ReadInt32();  base.SampleRate = _options.SampleRate; base.MelChannels = _options.MelChannels; base.HopSize = _options.HopSize; base.HiddenDim = _options.LLMDim; if (!_useNativeMode && _options.ModelPath is { } p && !string.IsNullOrEmpty(p)) OnnxModel = new OnnxModel<T>(p, _options.OnnxOptions); }
     protected override IFullModel<T, Tensor<T>, Tensor<T>> CreateNewInstance() { if (!_useNativeMode && _options.ModelPath is { } mp && !string.IsNullOrEmpty(mp)) return new VALLEXClone<T>(Architecture, mp, _options); return new VALLEXClone<T>(Architecture, _options); }
+    private AdamWOptimizer<T, Tensor<T>, Tensor<T>> CreateDefaultOptimizer()
+        => new(this, new AdamWOptimizerOptions<T, Tensor<T>, Tensor<T>> { InitialLearningRate = _options.LearningRate, WeightDecay = _options.WeightDecay, UseAdaptiveLearningRate = false });
     private void ThrowIfDisposed() { if (_disposed) throw new ObjectDisposedException(GetType().FullName ?? nameof(VALLEXClone<T>)); }
     protected override void Dispose(bool disposing) { if (_disposed) return; _disposed = true; base.Dispose(disposing); }
 }


### PR DESCRIPTION
## Summary

- Repairs model invariant failures found during PR #1562 follow-up triage.
- Keeps fixes focused on model semantics and scaffold/model contract mismatches rather than weakening assertions.
- Includes paper-faithful fixes for graph/ESN/NTM/Siamese/VALL-E-family behavior, plus serialization/metadata bugs surfaced by generated invariants.

## Current CI triage notes

I inspected the user-referenced run `27477014887` / job family and parsed the TRX artifacts for these shards:

- `Other - Playground`
- `ModelFamily - Regression`
- `ModelFamily - Code/Forecast/Segment/Survival`
- `Integration A-B`
- `Integration E-G`
- `Integration N-O`
- `Integration H-L`

That run checked out PR #1592 before PR #1562 landed, so several model failures in those artifacts are stale on current `master`. The current clean branch passes the relevant model clusters locally for `ConditionalGAN`, `GeneralizedAdditiveModel`, `MGTSD`, and Finance model integration. `SwinUNETRTests` also passed locally before rebasing this branch onto `master`.

## Verification

- `dotnet build .\tests\AiDotNet.Tests\AiDotNetTests.csproj -c Debug -f net10.0 --no-restore -v:quiet -clp:ErrorsOnly`
- `dotnet test .\tests\AiDotNet.Tests\AiDotNetTests.csproj --no-build -c Debug -f net10.0 --filter "FullyQualifiedName~ConditionalGAN|FullyQualifiedName~AiDotNet.Tests.ModelFamilyTests.Regression.GeneralizedAdditiveModelTests|FullyQualifiedName~AiDotNet.Tests.ModelFamilyTests.Forecasting.MGTSDTests|FullyQualifiedName~FinanceModelsIntegrationTests" -v:minimal` (466/466 passed)
- Pre-rebase targeted checks also passed: `SwinUNETRTests` (25/25), `MGTSDTests` (21/21), `GeneralizedAdditiveModelTests` (22/22), `ConditionalGAN` (31/31), `FinanceModelsIntegrationTests` (392/392)

## Notes

PR #1562 has already been merged into `master`. This branch is now rebased cleanly onto current `master` and contains one follow-up commit: `3b8d89f49`.