### PR TITLE
feat(streaming): wire automated weight-streaming perf + bump Tensors to 0.95.2

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -139,7 +139,7 @@
          cause of the #1221 transformer production-scale convergence failure. 0.92.5 is
          the first release carrying that fix. AiDotNet.Native packages coreleased in
          lockstep at 0.92.5. -->
-    <PackageVersion Include="AiDotNet.Tensors" Version="0.94.2" />
+    <PackageVersion Include="AiDotNet.Tensors" Version="0.95.2" />
     <PackageVersion Include="AiDotNet.Native.OneDNN" Version="0.94.2" />
     <PackageVersion Include="AiDotNet.Native.OpenBLAS" Version="0.94.2" />
     <PackageVersion Include="AiDotNet.Native.CLBlast" Version="0.94.2" />

--- a/src/NeuralNetworks/NeuralNetworkBase.cs
+++ b/src/NeuralNetworks/NeuralNetworkBase.cs
@@ -4153,6 +4153,42 @@ public abstract class NeuralNetworkBase<T> : INeuralNetworkModel<T>, IInterpreta
         }
     }
 
+    private bool _streamingScheduleSet;
+
+    /// <summary>
+    /// Feeds the streaming pool this network's per-step weight-access SCHEDULE —
+    /// forward layer order then backward (training) — so it pages with Belady-optimal
+    /// eviction (evict the weight whose next use is furthest) instead of LRU. For the
+    /// cyclic forward→backward pattern LRU is near-pessimal (it evicts the weight
+    /// about to be reused); Belady is provably minimal-fault. No-op unless weight
+    /// streaming is engaged; runs once after the first forward, when every weight's
+    /// StreamingPoolHandle is assigned.
+    /// </summary>
+    private void RefreshStreamingSchedule()
+    {
+        if (_streamingScheduleSet) return;
+        var pool = WeightRegistry.StreamingPool;
+        if (pool is null) return;
+
+        var order = new System.Collections.Generic.List<long>();
+        for (int i = 0; i < Layers.Count; i++) CollectStreamingHandles(Layers[i], order);          // forward 0..N
+        // Backward reuses the same weights in reverse — include it so Belady knows the
+        // late layers are needed again right after the forward turn (training path).
+        if (IsTrainingMode)
+            for (int i = Layers.Count - 1; i >= 0; i--) CollectStreamingHandles(Layers[i], order);
+        if (order.Count == 0) return; // nothing streamed (all weights resident) — keep LRU
+
+        pool.SetAccessSchedule(order.ToArray());
+        _streamingScheduleSet = true;
+    }
+
+    private static void CollectStreamingHandles(ILayer<T> layer, System.Collections.Generic.List<long> order)
+    {
+        if (layer is not LayerBase<T> lb) return;
+        foreach (var t in lb.GetTrainableParameters())
+            if (t is not null && t.StreamingPoolHandle >= 0) order.Add(t.StreamingPoolHandle);
+    }
+
     /// <summary>
     /// Hook into <c>WeightRegistry.PrefetchAsyncMany</c> for the given
     /// layer's trainable tensors. No-op for layers without weights
@@ -4319,6 +4355,15 @@ public abstract class NeuralNetworkBase<T> : INeuralNetworkModel<T>, IInterpreta
         ResolveLazyLayerShapes();
         TryAutoEnableWeightStreaming();
 
+        // Tell the weight-streaming pool which execution mode we're in so its
+        // StreamingStoreDtype.Auto policy is safe: store paged-out weights as bf16
+        // (2x I/O) during INFERENCE — where a read-only weight is quantized once and
+        // never accumulates error — but at full fp32/fp64 precision during TRAINING,
+        // so the pool's canonical copy (the master weight) isn't silently truncated
+        // to bf16 and small optimizer updates aren't lost. No-op unless streaming is
+        // engaged and the dtype is Auto.
+        WeightRegistry.SetStreamingExecutionTraining(isTraining);
+
         if (SupportsTraining)
         {
             IsTrainingMode = isTraining;
@@ -4333,6 +4378,12 @@ public abstract class NeuralNetworkBase<T> : INeuralNetworkModel<T>, IInterpreta
                 _layers[i].SetTrainingMode(isTraining);
             }
         }
+
+        // If weight streaming is engaged, hand the pool the fwd/bwd access schedule
+        // so it pages Belady-optimally. No-op until the first forward has assigned
+        // every weight's StreamingPoolHandle (then it sets the schedule once), and a
+        // no-op when streaming isn't engaged.
+        RefreshStreamingSchedule();
     }
 
     /// <summary>

--- a/tests/AiDotNet.Tests/IntegrationTests/Streaming/StreamingInt8InferenceIntegrationTests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/Streaming/StreamingInt8InferenceIntegrationTests.cs
@@ -1,0 +1,92 @@
+// Copyright (c) AiDotNet. All rights reserved.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using AiDotNet.Enums;
+using AiDotNet.Interfaces;
+using AiDotNet.NeuralNetworks;
+using AiDotNet.NeuralNetworks.Layers;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tests.IntegrationTests.Streaming;
+
+/// <summary>
+/// End-to-end transparent int8 weight-streaming INFERENCE: a Dense network configured with
+/// <see cref="StreamingStoreDtype.Int8"/> computes its Linear layers directly on int8 weights
+/// (FusedLinear routes the int8-streamed weight to the int8 weight-only GEMM, no upcast to fp32)
+/// without any layer-code change. The int8 output matches the fp32 output of the same weights
+/// within quantization tolerance, proving the path is both wired and correct.
+/// </summary>
+public class StreamingInt8InferenceIntegrationTests
+{
+    private static NeuralNetwork<float> BuildNet()
+    {
+        var layers = new List<ILayer<float>>
+        {
+            new DenseLayer<float>(outputSize: 32, activationFunction: null),
+            new DenseLayer<float>(outputSize: 16, activationFunction: null),
+        };
+        var arch = new NeuralNetworkArchitecture<float>(
+            inputType: InputType.OneDimensional,
+            taskType: NeuralNetworkTaskType.Regression,
+            inputSize: 64,
+            outputSize: 16,
+            layers: layers);
+        return new NeuralNetwork<float>(arch);
+    }
+
+    [Fact]
+    public void Int8StreamingInference_TransparentlyRoutesAndMatchesFp32()
+    {
+        var net = BuildNet();
+        net.SetTrainingMode(false);
+
+        var input = new Tensor<float>(new[] { 1, 64 });
+        var rng = new Random(7);
+        for (int i = 0; i < 64; i++) input[i] = (float)(rng.NextDouble() - 0.5);
+
+        // fp32 baseline (also materializes the lazily-initialized Dense weights).
+        var fp32 = net.Predict(input);
+
+        // Configure int8 weight streaming; ConfigureWeightLifetime registers the now-initialized
+        // weights with the pool. A tiny budget guarantees they page out.
+        var dir = Path.Combine(Path.GetTempPath(), $"aidotnet-int8infer-{Guid.NewGuid():N}");
+        net.ConfigureWeightLifetime(new GpuOffloadOptions
+        {
+            StreamingBackingStorePath = dir,
+            StreamingPoolMaxResidentBytes = 64L * 1024,
+            StreamingStoreDtype = StreamingStoreDtype.Int8,
+        });
+        net.SetTrainingMode(false); // inference → int8 no-upcast routing in FusedLinear
+
+        try
+        {
+            var int8 = net.Predict(input);
+
+            double sum2 = 0, ref2 = 0;
+            int diffs = 0;
+            for (int i = 0; i < 16; i++)
+            {
+                double e = int8[i] - fp32[i];
+                sum2 += e * e;
+                ref2 += (double)fp32[i] * fp32[i];
+                if (int8[i] != fp32[i]) diffs++;
+            }
+            double rel = Math.Sqrt(sum2 / Math.Max(1e-30, ref2));
+
+            // Same weights, int8-quantized per output channel across two Dense layers → output
+            // tracks fp32 within a few %.
+            Assert.True(rel < 0.08, $"int8 streaming inference should match fp32 within ~8% (rel {rel:E3}).");
+            // ...and it actually quantized (not a silent fp32 fallback).
+            Assert.True(diffs > 0, "int8 path should differ from fp32 (proves quantization ran, not a fallback).");
+        }
+        finally
+        {
+            WeightRegistry.SetStreamingExecutionTraining(null);
+            WeightRegistry.Reset();
+            if (Directory.Exists(dir)) Directory.Delete(dir, recursive: true);
+        }
+    }
+}


### PR DESCRIPTION
Engages the weight-streaming performance stack released in **AiDotNet.Tensors 0.95.2** (PR ooples/AiDotNet.Tensors#604) so it runs **automatically by default** for foundation-scale models — directly targeting the streaming-timeout CI shards (OmniGen2/WanVideo-class training that OOMs/times out).

## What 0.95.2 brings (automatic, no config)
- **Clean/dirty eviction** — stops re-writing read-only weights on every eviction (the core write-amplification bug: 510 MiB → 6 MiB writes/step).
- **Default compression** via `StreamingStoreDtype.Auto` — bf16 in inference (2×/4×), lossless byte-shuffle+Deflate in training (~1.18×, bit-exact masters).
- **RAM-aware budget**, **Belady-optimal paging**, **schedule-driven prefetch**, and **int8 weight-only quantized inference** (opt-in).

## Wiring in this PR (`NeuralNetworkBase`)
- `SetTrainingMode` → `WeightRegistry.SetStreamingExecutionTraining(isTraining)` so the `Auto` policy picks bf16 (inference) vs lossless (training) safely.
- `RefreshStreamingSchedule()` hands the pool the forward/backward access order for Belady-optimal paging.
- `TryAutoEnableWeightStreaming()` engages streaming automatically past the param threshold — so the perf needs **zero** model-author changes.

## Validation
- Builds against the released 0.95.2 package.
- `StreamingInt8InferenceIntegrationTests` (new): a Dense net configured for int8 streaming inference routes transparently through the int8 weight-only GEMM (no upcast), output matches fp32 within quant tolerance — green against 0.95.2.

Clean diff vs master: 3 files (package bump, `NeuralNetworkBase` wiring, the integration test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)