### PR TITLE
perf: [codex] add streaming first-order optimizer variants

### DIFF
--- a/docs/reference/optimizers.md
+++ b/docs/reference/optimizers.md
@@ -117,6 +117,16 @@ When `NeuralNetworkBase.StreamingTrainingEnabled` is enabled, the streaming trai
 
 Each state buffer stores one byte per parameter plus one double scale per block, instead of one full-precision numeric value per parameter. With the default 2048-parameter block size, one-buffer optimizers use about 1 byte per parameter plus scale metadata, two-buffer Adam-style optimizers use about 2 bytes per parameter plus metadata, and AMSGrad uses about 3 bytes per parameter plus metadata. Compared with full `double` moment state, this is roughly an 8x reduction for the moment buffers; compared with full `float` moment state, it is roughly a 4x reduction.
 
+#### Second-order streaming: L-BFGS
+
+The first-order variants update each parameter in place as its gradient is produced. L-BFGS is a **second-order** method — its search direction depends on the whole gradient plus a curvature history — so it can't update per-parameter-as-gradient-arrives. `StreamingLBFGS<T>` instead buffers the per-parameter gradients into flat vectors as they stream in, then performs the two-loop recursion and parameter update once the full gradient is available.
+
+| Configured optimizer | Streaming variant | Quantized state |
+|:---------------------|:------------------|:----------------|
+| `LBFGSOptimizer` | `StreamingLBFGS<T>` | `MemorySize` (s, y) history vectors, 8-bit block-quantized |
+
+The dominant memory cost of L-BFGS is its `(s, y)` curvature history — `MemorySize` vector pairs of length *n*, i.e. O(*m·n*). `StreamingLBFGS` stores that history 8-bit block-quantized (~8x smaller than `double`) and dequantizes it **one vector at a time** during the two-loop recursion, so the transient working set stays O(*n*) rather than O(*m·n*). Full BFGS / Newton are intentionally not provided as streaming variants: their O(*n²*) dense Hessian (approximation) does not fit memory-bounded large-model training at all.
+
 ---
 
 ## Second-Order Optimizers

--- a/docs/reference/optimizers.md
+++ b/docs/reference/optimizers.md
@@ -102,6 +102,21 @@ var optimizer = new LionOptimizer<float>(
     weightDecay: 0.0f);
 ```
 
+### Memory-Bounded Streaming Optimizers
+
+When `NeuralNetworkBase.StreamingTrainingEnabled` is enabled, the streaming training path now resolves configured first-order optimizers to optimizer-in-backward variants with 8-bit block-quantized state. This keeps gradients and moment buffers bounded while preserving the configured optimizer family and learning-rate scheduler handoff.
+
+| Configured optimizer | Streaming variant | Quantized state |
+|:---------------------|:------------------|:----------------|
+| Gradient descent, SGD, mini-batch GD, proximal GD | `StreamingSgd8Bit<T>` | none |
+| Momentum, Nesterov | `StreamingMomentum8Bit<T>`, `StreamingNesterov8Bit<T>` | 1 signed buffer |
+| RMSprop, Adagrad | `StreamingRmsProp8Bit<T>`, `StreamingAdagrad8Bit<T>` | 1 unsigned buffer |
+| AdaDelta, FTRL | `StreamingAdaDelta8Bit<T>`, `StreamingFtrl8Bit<T>` | 2 unsigned buffers |
+| Adam, AdamW, Nadam, AdaMax, Lion, LAMB, LARS | matching `Streaming*8Bit<T>` variant | 1-2 buffers |
+| AMSGrad or Adam with `UseAMSGrad = true` | `StreamingAMSGrad8Bit<T>` | 3 buffers |
+
+Each state buffer stores one byte per parameter plus one double scale per block, instead of one full-precision numeric value per parameter. With the default 2048-parameter block size, one-buffer optimizers use about 1 byte per parameter plus scale metadata, two-buffer Adam-style optimizers use about 2 bytes per parameter plus metadata, and AMSGrad uses about 3 bytes per parameter plus metadata. Compared with full `double` moment state, this is roughly an 8x reduction for the moment buffers; compared with full `float` moment state, it is roughly a 4x reduction.
+
 ---
 
 ## Second-Order Optimizers

--- a/docs/reference/optimizers.md
+++ b/docs/reference/optimizers.md
@@ -117,6 +117,8 @@ When `NeuralNetworkBase.StreamingTrainingEnabled` is enabled, the streaming trai
 
 Each state buffer stores one byte per parameter plus one double scale per block, instead of one full-precision numeric value per parameter. With the default 2048-parameter block size, one-buffer optimizers use about 1 byte per parameter plus scale metadata, two-buffer Adam-style optimizers use about 2 bytes per parameter plus metadata, and AMSGrad uses about 3 bytes per parameter plus metadata. Compared with full `double` moment state, this is roughly an 8x reduction for the moment buffers; compared with full `float` moment state, it is roughly a 4x reduction.
 
+Within a single parameter, the per-block update (dequantize moments → apply the rule → requantize) runs in parallel across blocks: each block owns a disjoint parameter/gradient/state slice, so each worker gets its own requantization scratch and the blocks update concurrently with no shared mutable state. The parallel path is gated on parameter size (small parameters such as biases and norm scales stay on the serial path, where thread-dispatch overhead would not pay off) and is deterministic — block `b`'s output depends only on its own slice, so results are identical regardless of how blocks are scheduled.
+
 #### Second-order streaming: L-BFGS
 
 The first-order variants update each parameter in place as its gradient is produced. L-BFGS is a **second-order** method — its search direction depends on the whole gradient plus a curvature history — so it can't update per-parameter-as-gradient-arrives. `StreamingLBFGS<T>` instead buffers the per-parameter gradients into flat vectors as they stream in, then performs the two-loop recursion and parameter update once the full gradient is available.

--- a/src/NeuralNetworks/NeuralNetworkBase.cs
+++ b/src/NeuralNetworks/NeuralNetworkBase.cs
@@ -22,6 +22,7 @@ using AiDotNet.Tensors.LinearAlgebra;
 using AiDotNet.Tensors.Engines.Gpu;
 using AiDotNet.Tensors.Helpers;
 using AiDotNet.Validation;
+using System.Reflection;
 using System.Threading;
 
 namespace AiDotNet.NeuralNetworks;
@@ -4178,8 +4179,42 @@ public abstract class NeuralNetworkBase<T> : INeuralNetworkModel<T>, IInterpreta
             for (int i = Layers.Count - 1; i >= 0; i--) CollectStreamingHandles(Layers[i], order);
         if (order.Count == 0) return; // nothing streamed (all weights resident) — keep LRU
 
-        pool.SetAccessSchedule(order.ToArray());
+        TrySetStreamingAccessSchedule(pool, order.ToArray());
         _streamingScheduleSet = true;
+    }
+
+    private static MethodInfo? _streamingPoolSetAccessScheduleMethod;
+    private static bool _streamingPoolSetAccessScheduleLookupDone;
+
+    private static void TrySetStreamingAccessSchedule(object pool, long[] order)
+    {
+        // Optional hook: present in some AiDotNet.Tensors versions, absent in others.
+        // Keep the Belady schedule when available without binding this assembly to it.
+        if (!_streamingPoolSetAccessScheduleLookupDone)
+        {
+            _streamingPoolSetAccessScheduleMethod = pool.GetType().GetMethod(
+                "SetAccessSchedule",
+                BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic,
+                binder: null,
+                types: new[] { typeof(long[]) },
+                modifiers: null);
+            _streamingPoolSetAccessScheduleLookupDone = true;
+        }
+
+        _streamingPoolSetAccessScheduleMethod?.Invoke(pool, new object[] { order });
+    }
+
+    private static readonly MethodInfo? StreamingExecutionTrainingMethod =
+        typeof(WeightRegistry).GetMethod(
+            "SetStreamingExecutionTraining",
+            BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic,
+            binder: null,
+            types: new[] { typeof(bool) },
+            modifiers: null);
+
+    private static void SetStreamingExecutionTrainingIfSupported(bool isTraining)
+    {
+        StreamingExecutionTrainingMethod?.Invoke(null, new object[] { isTraining });
     }
 
     private static void CollectStreamingHandles(ILayer<T> layer, System.Collections.Generic.List<long> order)
@@ -4362,7 +4397,7 @@ public abstract class NeuralNetworkBase<T> : INeuralNetworkModel<T>, IInterpreta
         // so the pool's canonical copy (the master weight) isn't silently truncated
         // to bf16 and small optimizer updates aren't lost. No-op unless streaming is
         // engaged and the dtype is Auto.
-        WeightRegistry.SetStreamingExecutionTraining(isTraining);
+        SetStreamingExecutionTrainingIfSupported(isTraining);
 
         if (SupportsTraining)
         {
@@ -5666,17 +5701,20 @@ public abstract class NeuralNetworkBase<T> : INeuralNetworkModel<T>, IInterpreta
     /// </summary>
     public StreamingTrainingMode StreamingTraining { get; set; } = StreamingTrainingMode.Auto;
 
-    /// <summary>Learning rate used by the streaming 8-bit Adam epilogue. Defaults
+    /// <summary>Learning rate used by the default streaming 8-bit Adam epilogue. Defaults
     /// to 1e-4 — the conservative rate large-transformer/foundation-model
-    /// training uses, which stays stable under 8-bit moment quantization.</summary>
+    /// training uses, which stays stable under 8-bit moment quantization. When
+    /// callers configure a gradient optimizer explicitly, the streaming resolver
+    /// uses that optimizer's current learning rate instead.</summary>
     public double StreamingTrainingLearningRate { get; set; } = 1e-4;
 
-    /// <summary>Decoupled (AdamW) weight decay used by the streaming epilogue. 0 = plain Adam.</summary>
+    /// <summary>Decoupled weight decay used by the default streaming Adam epilogue. 0 = plain Adam.</summary>
     public double StreamingTrainingWeightDecay { get; set; } = 0.0;
 
-    // Per-parameter 8-bit Adam state for the streaming path; persists across
-    // Train calls so the moments accumulate over a multi-step run.
-    private Training.StreamingAdam8Bit<T>? _streamingOptimizerState;
+    // Per-parameter 8-bit optimizer state for the streaming path; persists
+    // across Train calls so the moments accumulate over a multi-step run.
+    private Training.IStreamingOptimizer<T>? _streamingOptimizerState;
+    private string? _streamingOptimizerKey;
 
     /// <summary>
     /// Autotuner: decides whether this Train step should take the memory-bounded
@@ -5730,18 +5768,49 @@ public abstract class NeuralNetworkBase<T> : INeuralNetworkModel<T>, IInterpreta
         }
     }
 
+    private Training.IStreamingOptimizer<T> GetOrCreateStreamingOptimizer(
+        IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>> resolvedOptimizer,
+        bool useStreamingDefaults)
+    {
+        string key = Training.StreamingOptimizerResolver<T>.BuildKey(
+            resolvedOptimizer,
+            useStreamingDefaults,
+            StreamingTrainingWeightDecay);
+
+        if (_streamingOptimizerState is null || _streamingOptimizerKey != key)
+        {
+            _streamingOptimizerState = Training.StreamingOptimizerResolver<T>.Create(
+                resolvedOptimizer,
+                useStreamingDefaults,
+                StreamingTrainingLearningRate,
+                StreamingTrainingWeightDecay);
+            _streamingOptimizerKey = key;
+        }
+
+        Training.StreamingOptimizerResolver<T>.RefreshLearningRate(
+            _streamingOptimizerState,
+            resolvedOptimizer,
+            useStreamingDefaults,
+            StreamingTrainingLearningRate);
+
+        return _streamingOptimizerState;
+    }
+
     /// <summary>
     /// Memory-bounded streaming training step: optimizer-in-backward with 8-bit
-    /// Adam state and topological-min gradient release. Each parameter's gradient
-    /// is applied (via <see cref="Training.StreamingAdam8Bit{T}"/>) and freed the
-    /// instant it is computed, so the full gradient set is never resident — which
-    /// is what lets a model whose gradients exceed RAM still take a real Adam
-    /// step. Used automatically by <see cref="TrainWithTape(Tensor{T}, Tensor{T}, IGradientBasedOptimizer{T, Tensor{T}, Tensor{T}}?)"/>
-    /// when the autotuner engages it. The model's configured optimizer is not
-    /// used on this path (its full-precision moment state is exactly what does
-    /// not fit); the 8-bit streaming epilogue stands in for it.
+    /// quantized optimizer state and topological-min gradient release. Each
+    /// parameter's gradient is applied (via <see cref="Training.IStreamingOptimizer{T}"/>)
+    /// and freed the instant it is computed, so the full gradient set is never
+    /// resident. Used automatically by <see cref="TrainWithTape(Tensor{T}, Tensor{T}, IGradientBasedOptimizer{T, Tensor{T}, Tensor{T}}?)"/>
+    /// when the autotuner engages it. The streaming resolver mirrors the user's
+    /// configured first-order optimizer while replacing its full-precision state
+    /// tensors with per-parameter 8-bit block-quantized state.
     /// </summary>
-    protected void TrainWithTapeStreaming(Tensor<T> input, Tensor<T> expected)
+    protected void TrainWithTapeStreaming(
+        Tensor<T> input,
+        Tensor<T> expected,
+        IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>> resolvedOptimizer,
+        bool useStreamingDefaults)
     {
         var loss = LossFunction as LossFunctions.LossFunctionBase<T>
             ?? throw new InvalidOperationException(
@@ -5782,11 +5851,10 @@ public abstract class NeuralNetworkBase<T> : INeuralNetworkModel<T>, IInterpreta
         foreach (var t in GetExtraTrainableTensors())
             if (t is not null && t.Length > 0) sources.Add(t);
 
-        _streamingOptimizerState ??= new Training.StreamingAdam8Bit<T>(
-            learningRate: StreamingTrainingLearningRate,
-            beta1: 0.9, beta2: 0.999, epsilon: 1e-8,
-            weightDecay: StreamingTrainingWeightDecay);
-        _streamingOptimizerState.BeginStep();
+        var streamingOptimizer = GetOrCreateStreamingOptimizer(
+            resolvedOptimizer,
+            useStreamingDefaults);
+        streamingOptimizer.BeginStep();
 
         if (!clip)
         {
@@ -5803,7 +5871,7 @@ public abstract class NeuralNetworkBase<T> : INeuralNetworkModel<T>, IInterpreta
                 (source, grad) =>
                 {
                     if (grad is null || grad.Length == 0) return;
-                    _streamingOptimizerState.Apply(source, grad);
+                    streamingOptimizer.Apply(source, grad);
                 });
         }
         else
@@ -5853,7 +5921,7 @@ public abstract class NeuralNetworkBase<T> : INeuralNetworkModel<T>, IInterpreta
                         for (int i = 0; i < len; i++)
                             span[i] = NumOps.Multiply(span[i], scale);
                     }
-                    _streamingOptimizerState.Apply(source, grad);
+                    streamingOptimizer.Apply(source, grad);
                 });
         }
 
@@ -5864,6 +5932,7 @@ public abstract class NeuralNetworkBase<T> : INeuralNetworkModel<T>, IInterpreta
         // and subsequent forwards would silently produce stale predictions. Other
         // update paths (TrainWithTape, batch eager) call this at the same point.
         InvalidateWeightCachesAfterSuccessfulWeightUpdate();
+        StepSchedulerIfSupported(resolvedOptimizer);
     }
 
     protected void TrainWithTape(Tensor<T> input, Tensor<T> expected,
@@ -5876,20 +5945,23 @@ public abstract class NeuralNetworkBase<T> : INeuralNetworkModel<T>, IInterpreta
         // exit. See AcquireTrainSentinel for the contract.
         using var __reentrancyGuard = AcquireTrainSentinel();
 
+        var configuredOptimizer = optimizer ?? _baseTrainOptimizer;
+        bool useStreamingDefaults = configuredOptimizer is null;
+        var resolvedOptimizer = configuredOptimizer ?? GetOrCreateBaseOptimizer();
+
         // Memory-bounded streaming training path (optimizer-in-backward). The
         // autotuner engages it only when the model's estimated full-precision
-        // training footprint (weights + grads + Adam moments) would not
+        // training footprint (weights + grads + optimizer moments) would not
         // comfortably fit in available memory — so for the overwhelming
         // majority of models that already fit, this is a no-op and the classic
         // path below runs unchanged (zero overhead, bit-identical results).
         // StreamingTraining = ForceOn/ForceOff overrides the autotuner.
         if (ShouldUseStreamingTraining())
         {
-            TrainWithTapeStreaming(input, expected);
+            TrainWithTapeStreaming(input, expected, resolvedOptimizer, useStreamingDefaults);
             return;
         }
 
-        var resolvedOptimizer = optimizer ?? GetOrCreateBaseOptimizer();
         // Reset the pending fused-miss reason so this call's emission
         // window starts clean. The fused-path try sets it via
         // EmitFusedMissAndFallback when it bails out; the post-commit
@@ -5916,7 +5988,7 @@ public abstract class NeuralNetworkBase<T> : INeuralNetworkModel<T>, IInterpreta
         // eager tape path so the MP wiring below (cast weights to low precision,
         // scale loss, unscale gradients, overflow detection) actually runs.
         if (_mixedPrecisionContext is null
-            && TryTrainWithFusedOptimizer(input, expected, resolvedOptimizer))
+            && TryTrainWithFusedOptimizer(input, expected, resolvedOptimizer, useStreamingDefaults))
             return;
 
         // Loud one-time fallback warning. The fused path above is the fast path;
@@ -7007,7 +7079,8 @@ public abstract class NeuralNetworkBase<T> : INeuralNetworkModel<T>, IInterpreta
     private bool TryTrainWithFusedOptimizer(
         Tensor<T> input,
         Tensor<T> expected,
-        IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>> resolvedOptimizer)
+        IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>> resolvedOptimizer,
+        bool useStreamingDefaults)
     {
         // Callers can still force the eager path via
         // <c>TensorCodecOptions.EnableCompilation = false</c> (handled
@@ -7179,9 +7252,9 @@ public abstract class NeuralNetworkBase<T> : INeuralNetworkModel<T>, IInterpreta
             // moments resident. This is precisely what the memory-bounded streaming
             // training path exists for — degrade to it rather than aborting the run.
             // TrainWithTapeStreaming drives optimizer-in-backward with topological-min
-            // gradient release (tape.ComputeGradientsStreaming) and an 8-bit Adam
-            // (StreamingAdam8Bit) that maintains its OWN moment state, so the
-            // "the compiled plan's Adam moments can't be transferred" obstruction
+            // gradient release (tape.ComputeGradientsStreaming) and an 8-bit
+            // streaming optimizer that maintains its OWN moment state, so the
+            // "the compiled plan's moments can't be transferred" obstruction
             // that forces the throw below does NOT apply here — streaming simply
             // continues training under its own optimizer. Pin StreamingTraining =
             // ForceOn so every subsequent step in this run also takes the streaming
@@ -7195,7 +7268,7 @@ public abstract class NeuralNetworkBase<T> : INeuralNetworkModel<T>, IInterpreta
                 _fusedTrainingCommitted = false;
                 StreamingTraining = StreamingTrainingMode.ForceOn;
                 InvalidateParameterCountCache();
-                TrainWithTapeStreaming(input, expected);
+                TrainWithTapeStreaming(input, expected, resolvedOptimizer, useStreamingDefaults);
                 return true; // step handled via the streaming path
             }
 

--- a/src/NeuralNetworks/NeuralNetworkBase.cs
+++ b/src/NeuralNetworks/NeuralNetworkBase.cs
@@ -5925,6 +5925,12 @@ public abstract class NeuralNetworkBase<T> : INeuralNetworkModel<T>, IInterpreta
                 });
         }
 
+        // Post-step hook: first-order optimizers already updated each parameter in place during
+        // Apply (no-op here); a full-gradient optimizer like streaming L-BFGS buffered the
+        // per-parameter gradients above and performs its global two-loop update + parameter
+        // write-back now that the whole gradient is available.
+        streamingOptimizer.EndStep();
+
         // GPU weight-cache coherence after the in-place parameter mutation. The
         // 8-bit StreamingAdam state already updated source tensors in place; without
         // invalidation here, the cached derived weights (CPU SIMD-packed copies,

--- a/src/Training/StreamingAdam8Bit.cs
+++ b/src/Training/StreamingAdam8Bit.cs
@@ -16,6 +16,14 @@ internal interface IStreamingOptimizer<T>
 {
     void BeginStep();
     void Apply(Tensor<T> param, Tensor<T> grad);
+
+    /// <summary>
+    /// Called once after every parameter's gradient has been handed to <see cref="Apply"/> for
+    /// the current step. First-order optimizers update in place during <see cref="Apply"/> and
+    /// no-op here; full-gradient (second-order) optimizers like streaming L-BFGS buffer the
+    /// per-parameter gradients and perform their global update here.
+    /// </summary>
+    void EndStep();
 }
 
 internal interface IStreamingOptimizerLearningRate
@@ -47,12 +55,14 @@ internal abstract class BlockQuantizedStreamingOptimizer<T> : IStreamingOptimize
             {
                 Quantized[m] = new byte[length];
                 Scales[m] = new double[numBlocks];
+                // net471 has no Array.Fill — initialize with loops. Signed moments quantize 0 as
+                // byte 128 (the zero point); unsigned default to 0. All block scales start at 1.0.
                 if (signedMoments[m])
                 {
-                    Array.Fill(Quantized[m], (byte)128);
+                    for (int i = 0; i < length; i++) Quantized[m][i] = 128;
                 }
 
-                Array.Fill(Scales[m], 1.0);
+                for (int i = 0; i < numBlocks; i++) Scales[m][i] = 1.0;
             }
         }
     }
@@ -110,6 +120,11 @@ internal abstract class BlockQuantizedStreamingOptimizer<T> : IStreamingOptimize
     }
 
     protected virtual void OnBeginStep()
+    {
+    }
+
+    // First-order optimizers update in place during Apply, so the post-step hook is a no-op.
+    public virtual void EndStep()
     {
     }
 
@@ -807,6 +822,9 @@ internal static class StreamingOptimizerResolver<T>
                 return new StreamingLars8Bit<T>(lr, ReadDouble(options, "Momentum", 0.9), ReadDouble(options, "WeightDecay", 1e-4), ReadDouble(options, "TrustCoefficient", 0.001), ReadDouble(options, "Epsilon", 1e-8), ReadBool(options, "UseNesterov", false));
             case FTRLOptimizer<T, Tensor<T>, Tensor<T>>:
                 return new StreamingFtrl8Bit<T>(ReadDouble(options, "Alpha", lr), ReadDouble(options, "Beta", 1.0), ReadDouble(options, "Lambda1", 1.0), ReadDouble(options, "Lambda2", 1.0));
+            case LBFGSOptimizer<T, Tensor<T>, Tensor<T>>:
+                // Second-order: memory-bounded streaming L-BFGS (8-bit-quantized (s,y) history).
+                return new StreamingLBFGS<T>(lr, (int)ReadDouble(options, "MemorySize", 10.0));
             case AdaDeltaOptimizer<T, Tensor<T>, Tensor<T>>:
                 return new StreamingAdaDelta8Bit<T>(lr, ReadDouble(options, "Rho", 0.95), ReadDouble(options, "Epsilon", 1e-6));
             case AdagradOptimizer<T, Tensor<T>, Tensor<T>>:

--- a/src/Training/StreamingAdam8Bit.cs
+++ b/src/Training/StreamingAdam8Bit.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Collections.Generic;
-using System.Reflection;
 using AiDotNet.Helpers;
+using AiDotNet.Models.Options;
 using AiDotNet.Optimizers;
 using AiDotNet.Tensors.Helpers;
 using AiDotNet.Tensors.Interfaces;
@@ -213,77 +213,142 @@ internal abstract class BlockQuantizedStreamingOptimizer<T> : IStreamingOptimize
         return update;
     }
 
+    // Only parallelize the block loop when there is enough work to amortize thread
+    // dispatch. Small parameters (biases, norms) stay on the serial, zero-dispatch path.
+    private const int ParallelApplyMinLength = 1 << 15;
+
     private void ApplyBlocks(Tensor<T> param, Tensor<T> grad, QuantizedState state, int length)
     {
         int momentCount = _signedMoments.Length;
-        var previous = _previousMomentValues.AsSpan(0, momentCount);
-        var next = _nextMomentValues.AsSpan(0, momentCount);
 
-        for (int b = 0; b < state.NumBlocks; b++)
+        // Each block updates a DISJOINT parameter/gradient/quantized-state slice, so the
+        // block loop is embarrassingly parallel. The only per-block shared state on the
+        // serial path is the moment scratch — give each worker its own copy and the loop
+        // parallelizes cleanly. The per-element parameter write goes through the tensor
+        // indexer, whose only cross-thread mutation is an Interlocked version bump; writes
+        // land at disjoint indices, so no extra synchronization (or O(n) staging buffer,
+        // which would defeat the memory-bounded design) is needed.
+        if (length < ParallelApplyMinLength || state.NumBlocks < 2 || Environment.ProcessorCount < 2)
         {
-            int start = b * BlockSize;
-            int end = Math.Min(start + BlockSize, length);
-            Array.Clear(_momentMax, 0, _momentMax.Length);
-
-            for (int i = start; i < end; i++)
+            for (int b = 0; b < state.NumBlocks; b++)
             {
-                int local = i - start;
-                for (int m = 0; m < momentCount; m++)
-                {
-                    double value = Dequantize(state, m, i);
-                    _previousMomentValues[m] = value;
-                    _nextMomentValues[m] = value;
-                }
+                ApplyOneBlock(b, param, grad, state, length, momentCount,
+                    _previousMomentValues, _nextMomentValues, _momentScratch, _momentMax);
+            }
+            return;
+        }
 
-                double gradientValue = ToDouble(grad[i]);
-                if (!double.IsNaN(gradientValue) && !double.IsInfinity(gradientValue))
-                {
-                    double parameterValue = ToDouble(param[i]);
-                    double nextParameter = UpdateElement(parameterValue, gradientValue, previous, next, i);
-                    if (!double.IsNaN(nextParameter) && !double.IsInfinity(nextParameter))
-                    {
-                        param[i] = FromDouble(nextParameter);
-                    }
-                }
+        // Force any lazy-graph realization / streaming-weight rehydration ONCE on this
+        // thread, so the parallel workers only ever touch already-materialized storage
+        // (the indexer fast path is then a pure disjoint array read/write).
+        _ = _ops.ToDouble(param[0]);
+        _ = _ops.ToDouble(grad[0]);
 
-                for (int m = 0; m < momentCount; m++)
+        System.Threading.Tasks.Parallel.For(
+            0,
+            state.NumBlocks,
+            () => new BlockScratch(momentCount, BlockSize),
+            (b, _, scratch) =>
+            {
+                ApplyOneBlock(b, param, grad, state, length, momentCount,
+                    scratch.Previous, scratch.Next, scratch.MomentScratch, scratch.MomentMax);
+                return scratch;
+            },
+            _ => { });
+    }
+
+    private void ApplyOneBlock(
+        int b, Tensor<T> param, Tensor<T> grad, QuantizedState state, int length, int momentCount,
+        double[] previous, double[] next, double[][] momentScratch, double[] momentMax)
+    {
+        int start = b * BlockSize;
+        int end = Math.Min(start + BlockSize, length);
+        for (int m = 0; m < momentCount; m++) momentMax[m] = 0.0;
+
+        var previousSpan = previous.AsSpan(0, momentCount);
+        var nextSpan = next.AsSpan(0, momentCount);
+
+        for (int i = start; i < end; i++)
+        {
+            int local = i - start;
+            for (int m = 0; m < momentCount; m++)
+            {
+                double value = Dequantize(state, m, i);
+                previous[m] = value;
+                next[m] = value;
+            }
+
+            double gradientValue = ToDouble(grad[i]);
+            if (!double.IsNaN(gradientValue) && !double.IsInfinity(gradientValue))
+            {
+                double parameterValue = ToDouble(param[i]);
+                double nextParameter = UpdateElement(parameterValue, gradientValue, previousSpan, nextSpan, i);
+                if (!double.IsNaN(nextParameter) && !double.IsInfinity(nextParameter))
                 {
-                    double value = _nextMomentValues[m];
-                    _momentScratch[m][local] = value;
-                    double magnitude = _signedMoments[m] ? Math.Abs(value) : Math.Max(0.0, value);
-                    if (magnitude > _momentMax[m]) _momentMax[m] = magnitude;
+                    param[i] = FromDouble(nextParameter);
                 }
             }
 
             for (int m = 0; m < momentCount; m++)
             {
-                double divisor = _signedMoments[m] ? 127.0 : 255.0;
-                double scale = _momentMax[m] / divisor;
-                if (scale < 1e-10 || double.IsNaN(scale) || double.IsInfinity(scale))
-                    scale = 1e-10;
-                state.Scales[m][b] = scale;
+                double value = next[m];
+                momentScratch[m][local] = value;
+                double magnitude = _signedMoments[m] ? Math.Abs(value) : Math.Max(0.0, value);
+                if (magnitude > momentMax[m]) momentMax[m] = magnitude;
+            }
+        }
 
-                double invScale = 1.0 / scale;
-                for (int i = start; i < end; i++)
+        for (int m = 0; m < momentCount; m++)
+        {
+            double divisor = _signedMoments[m] ? 127.0 : 255.0;
+            double scale = momentMax[m] / divisor;
+            if (scale < 1e-10 || double.IsNaN(scale) || double.IsInfinity(scale))
+                scale = 1e-10;
+            state.Scales[m][b] = scale;
+
+            double invScale = 1.0 / scale;
+            for (int i = start; i < end; i++)
+            {
+                int local = i - start;
+                double value = momentScratch[m][local];
+                if (_signedMoments[m])
                 {
-                    int local = i - start;
-                    double value = _momentScratch[m][local];
-                    if (_signedMoments[m])
-                    {
-                        int q = (int)Math.Round(value * invScale);
-                        if (q < -127) q = -127;
-                        else if (q > 127) q = 127;
-                        state.Quantized[m][i] = (byte)(q + 128);
-                    }
-                    else
-                    {
-                        int q = (int)Math.Round(Math.Max(0.0, value) * invScale);
-                        if (q < 0) q = 0;
-                        else if (q > 255) q = 255;
-                        state.Quantized[m][i] = (byte)q;
-                    }
+                    int q = (int)Math.Round(value * invScale);
+                    if (q < -127) q = -127;
+                    else if (q > 127) q = 127;
+                    state.Quantized[m][i] = (byte)(q + 128);
+                }
+                else
+                {
+                    int q = (int)Math.Round(Math.Max(0.0, value) * invScale);
+                    if (q < 0) q = 0;
+                    else if (q > 255) q = 255;
+                    state.Quantized[m][i] = (byte)q;
                 }
             }
+        }
+    }
+
+    /// <summary>
+    /// Per-worker moment scratch for the parallel block loop. Each parallel worker owns one
+    /// instance (allocated once per worker via <c>Parallel.For</c> localInit, reused across the
+    /// blocks that worker handles), so no two threads share the requantization scratch.
+    /// </summary>
+    private sealed class BlockScratch
+    {
+        public readonly double[] Previous;
+        public readonly double[] Next;
+        public readonly double[][] MomentScratch;
+        public readonly double[] MomentMax;
+
+        public BlockScratch(int momentCount, int blockSize)
+        {
+            Previous = new double[momentCount];
+            Next = new double[momentCount];
+            MomentMax = new double[momentCount];
+            MomentScratch = new double[momentCount][];
+            for (int m = 0; m < momentCount; m++)
+                MomentScratch[m] = new double[blockSize];
         }
     }
 }
@@ -762,26 +827,16 @@ internal static class StreamingOptimizerResolver<T>
         bool useStreamingDefaults,
         double streamingWeightDecay)
     {
-        string type = useStreamingDefaults ? "DefaultAdam" : optimizer.GetType().FullName ?? optimizer.GetType().Name;
-        object? options = GetOptionsObject(optimizer);
+        if (useStreamingDefaults)
+            return "DefaultAdam|" + streamingWeightDecay;
+
+        StreamingConfig c = Resolve(optimizer, streamingWeightDecay);
         return string.Join("|",
-            type,
-            ReadDouble(options, "Beta1", 0.9),
-            ReadDouble(options, "Beta2", 0.999),
-            ReadDouble(options, "Epsilon", 1e-8),
-            ReadDouble(options, "Decay", 0.9),
-            ReadDouble(options, "Rho", 0.95),
-            ReadDouble(options, "InitialMomentum", ReadDouble(options, "Momentum", 0.9)),
-            ReadDouble(options, "WeightDecay", streamingWeightDecay),
-            ReadDouble(options, "TrustCoefficient", 0.001),
-            ReadDouble(options, "Alpha", 0.005),
-            ReadDouble(options, "Lambda1", 1.0),
-            ReadDouble(options, "Lambda2", 1.0),
-            ReadBool(options, "UseAMSGrad", false),
-            ReadBool(options, "UseNesterov", false),
-            ReadBool(options, "ClipTrustRatio", true),
-            ReadDouble(options, "MaxTrustRatio", 10.0),
-            ReadBool(options, "UseBiasCorrection", true));
+            optimizer.GetType().FullName ?? optimizer.GetType().Name,
+            c.Kind,
+            c.Beta1, c.Beta2, c.Epsilon, c.Decay, c.Rho, c.Momentum, c.WeightDecay,
+            c.TrustCoefficient, c.FtrlAlpha, c.FtrlBeta, c.Lambda1, c.Lambda2, c.MaxTrustRatio,
+            c.UseAMSGrad, c.UseNesterov, c.ClipTrustRatio, c.UseBiasCorrection, c.MemorySize);
     }
 
     public static IStreamingOptimizer<T> Create(
@@ -790,7 +845,6 @@ internal static class StreamingOptimizerResolver<T>
         double fallbackLearningRate,
         double fallbackWeightDecay)
     {
-        object? options = GetOptionsObject(optimizer);
         double lr = useStreamingDefaults ? fallbackLearningRate : ResolveLearningRate(optimizer, fallbackLearningRate);
 
         if (useStreamingDefaults)
@@ -798,50 +852,210 @@ internal static class StreamingOptimizerResolver<T>
             return new StreamingAdam8Bit<T>(lr, weightDecay: fallbackWeightDecay);
         }
 
+        StreamingConfig c = Resolve(optimizer, fallbackWeightDecay);
+        switch (c.Kind)
+        {
+            case StreamingKind.AdamW:
+                return new StreamingAdamW8Bit<T>(lr, c.Beta1, c.Beta2, c.Epsilon, c.WeightDecay);
+            case StreamingKind.AmsGrad:
+                return new StreamingAMSGrad8Bit<T>(lr, c.Beta1, c.Beta2, c.Epsilon, c.WeightDecay);
+            case StreamingKind.Nadam:
+                return new StreamingNadam8Bit<T>(lr, c.Beta1, c.Beta2, c.Epsilon);
+            case StreamingKind.AdaMax:
+                return new StreamingAdaMax8Bit<T>(lr, c.Beta1, c.Beta2, c.Epsilon);
+            case StreamingKind.Lion:
+                return new StreamingLion8Bit<T>(lr, c.Beta1, c.Beta2, c.WeightDecay);
+            case StreamingKind.Lamb:
+                return new StreamingLamb8Bit<T>(lr, c.Beta1, c.Beta2, c.Epsilon, c.WeightDecay, c.ClipTrustRatio, c.MaxTrustRatio, c.UseBiasCorrection);
+            case StreamingKind.Lars:
+                return new StreamingLars8Bit<T>(lr, c.Momentum, c.WeightDecay, c.TrustCoefficient, c.Epsilon, c.UseNesterov);
+            case StreamingKind.Ftrl:
+                return new StreamingFtrl8Bit<T>(c.FtrlAlpha, c.FtrlBeta, c.Lambda1, c.Lambda2);
+            case StreamingKind.Lbfgs:
+                // Second-order: memory-bounded streaming L-BFGS (8-bit-quantized (s,y) history).
+                return new StreamingLBFGS<T>(lr, c.MemorySize);
+            case StreamingKind.AdaDelta:
+                return new StreamingAdaDelta8Bit<T>(lr, c.Rho, c.Epsilon);
+            case StreamingKind.Adagrad:
+                return new StreamingAdagrad8Bit<T>(lr, c.Epsilon);
+            case StreamingKind.RmsProp:
+                return new StreamingRmsProp8Bit<T>(lr, c.Decay, c.Epsilon);
+            case StreamingKind.Momentum:
+                return new StreamingMomentum8Bit<T>(lr, c.Momentum);
+            case StreamingKind.Nesterov:
+                return new StreamingNesterov8Bit<T>(lr, c.Momentum);
+            case StreamingKind.Sgd:
+                return new StreamingSgd8Bit<T>(lr);
+            case StreamingKind.Adam:
+            default:
+                return new StreamingAdam8Bit<T>(lr, c.Beta1, c.Beta2, c.Epsilon, c.WeightDecay);
+        }
+    }
+
+    /// <summary>
+    /// The streaming variant family a configured optimizer maps to.
+    /// </summary>
+    private enum StreamingKind
+    {
+        Sgd, Momentum, Nesterov, RmsProp, Adagrad, AdaDelta,
+        Adam, AdamW, AmsGrad, Nadam, AdaMax, Lion, Lamb, Lars, Ftrl, Lbfgs
+    }
+
+    /// <summary>
+    /// Strongly-typed snapshot of the hyperparameters needed to build (and cache-key) a streaming
+    /// optimizer. Populated once by <see cref="Resolve"/> from each optimizer's typed options, so
+    /// the construction path and the cache key never disagree and never depend on reflection.
+    /// </summary>
+    private struct StreamingConfig
+    {
+        public StreamingKind Kind;
+        public double Beta1;
+        public double Beta2;
+        public double Epsilon;
+        public double Decay;
+        public double Rho;
+        public double Momentum;
+        public double WeightDecay;
+        public double TrustCoefficient;
+        public double FtrlAlpha;
+        public double FtrlBeta;
+        public double Lambda1;
+        public double Lambda2;
+        public double MaxTrustRatio;
+        public bool UseAMSGrad;
+        public bool UseNesterov;
+        public bool ClipTrustRatio;
+        public bool UseBiasCorrection;
+        public int MemorySize;
+    }
+
+    /// <summary>
+    /// Maps a configured optimizer + its strongly-typed options to a <see cref="StreamingConfig"/>.
+    /// Reads each option via the optimizer's public <c>GetOptions()</c> downcast to its concrete
+    /// options type — compile-time-checked property access, no reflection. A renamed option becomes
+    /// a build error here rather than a silently-defaulted hyperparameter.
+    /// </summary>
+    private static StreamingConfig Resolve(
+        IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>> optimizer,
+        double defaultWeightDecay)
+    {
         switch (optimizer)
         {
-            case AdamWOptimizer<T, Tensor<T>, Tensor<T>>:
-                if (ReadBool(options, "UseAMSGrad", false))
-                    return new StreamingAMSGrad8Bit<T>(lr, ReadDouble(options, "Beta1", 0.9), ReadDouble(options, "Beta2", 0.999), ReadDouble(options, "Epsilon", 1e-8), ReadDouble(options, "WeightDecay", 0.01));
-                return new StreamingAdamW8Bit<T>(lr, ReadDouble(options, "Beta1", 0.9), ReadDouble(options, "Beta2", 0.999), ReadDouble(options, "Epsilon", 1e-8), ReadDouble(options, "WeightDecay", 0.01));
-            case AdamOptimizer<T, Tensor<T>, Tensor<T>>:
-                if (ReadBool(options, "UseAMSGrad", false))
-                    return new StreamingAMSGrad8Bit<T>(lr, ReadDouble(options, "Beta1", 0.9), ReadDouble(options, "Beta2", 0.999), ReadDouble(options, "Epsilon", 1e-8), fallbackWeightDecay);
-                return new StreamingAdam8Bit<T>(lr, ReadDouble(options, "Beta1", 0.9), ReadDouble(options, "Beta2", 0.999), ReadDouble(options, "Epsilon", 1e-8), fallbackWeightDecay);
-            case AMSGradOptimizer<T, Tensor<T>, Tensor<T>>:
-                return new StreamingAMSGrad8Bit<T>(lr, ReadDouble(options, "Beta1", 0.9), ReadDouble(options, "Beta2", 0.999), ReadDouble(options, "Epsilon", 1e-8), 0.0);
-            case NadamOptimizer<T, Tensor<T>, Tensor<T>>:
-                return new StreamingNadam8Bit<T>(lr, ReadDouble(options, "Beta1", 0.9), ReadDouble(options, "Beta2", 0.999), ReadDouble(options, "Epsilon", 1e-8));
-            case AdaMaxOptimizer<T, Tensor<T>, Tensor<T>>:
-                return new StreamingAdaMax8Bit<T>(lr, ReadDouble(options, "Beta1", 0.9), ReadDouble(options, "Beta2", 0.999), ReadDouble(options, "Epsilon", 1e-8));
-            case LionOptimizer<T, Tensor<T>, Tensor<T>>:
-                return new StreamingLion8Bit<T>(lr, ReadDouble(options, "Beta1", 0.9), ReadDouble(options, "Beta2", 0.99), ReadDouble(options, "WeightDecay", 0.0));
-            case LAMBOptimizer<T, Tensor<T>, Tensor<T>>:
-                return new StreamingLamb8Bit<T>(lr, ReadDouble(options, "Beta1", 0.9), ReadDouble(options, "Beta2", 0.999), ReadDouble(options, "Epsilon", 1e-6), ReadDouble(options, "WeightDecay", 0.01), ReadBool(options, "ClipTrustRatio", true), ReadDouble(options, "MaxTrustRatio", 10.0), ReadBool(options, "UseBiasCorrection", true));
-            case LARSOptimizer<T, Tensor<T>, Tensor<T>>:
-                return new StreamingLars8Bit<T>(lr, ReadDouble(options, "Momentum", 0.9), ReadDouble(options, "WeightDecay", 1e-4), ReadDouble(options, "TrustCoefficient", 0.001), ReadDouble(options, "Epsilon", 1e-8), ReadBool(options, "UseNesterov", false));
-            case FTRLOptimizer<T, Tensor<T>, Tensor<T>>:
-                return new StreamingFtrl8Bit<T>(ReadDouble(options, "Alpha", lr), ReadDouble(options, "Beta", 1.0), ReadDouble(options, "Lambda1", 1.0), ReadDouble(options, "Lambda2", 1.0));
-            case LBFGSOptimizer<T, Tensor<T>, Tensor<T>>:
-                // Second-order: memory-bounded streaming L-BFGS (8-bit-quantized (s,y) history).
-                return new StreamingLBFGS<T>(lr, (int)ReadDouble(options, "MemorySize", 10.0));
-            case AdaDeltaOptimizer<T, Tensor<T>, Tensor<T>>:
-                return new StreamingAdaDelta8Bit<T>(lr, ReadDouble(options, "Rho", 0.95), ReadDouble(options, "Epsilon", 1e-6));
-            case AdagradOptimizer<T, Tensor<T>, Tensor<T>>:
-                return new StreamingAdagrad8Bit<T>(lr, ReadDouble(options, "Epsilon", 1e-8));
-            case RootMeanSquarePropagationOptimizer<T, Tensor<T>, Tensor<T>>:
-                return new StreamingRmsProp8Bit<T>(lr, ReadDouble(options, "Decay", 0.9), ReadDouble(options, "Epsilon", 1e-8));
-            case MomentumOptimizer<T, Tensor<T>, Tensor<T>>:
-                return new StreamingMomentum8Bit<T>(lr, ReadDouble(options, "InitialMomentum", 0.9));
-            case NesterovAcceleratedGradientOptimizer<T, Tensor<T>, Tensor<T>>:
-                return new StreamingNesterov8Bit<T>(lr, ReadDouble(options, "InitialMomentum", 0.9));
+            case AdamWOptimizer<T, Tensor<T>, Tensor<T>> o:
+            {
+                var opt = (AdamWOptimizerOptions<T, Tensor<T>, Tensor<T>>)o.GetOptions();
+                return new StreamingConfig
+                {
+                    Kind = opt.UseAMSGrad ? StreamingKind.AmsGrad : StreamingKind.AdamW,
+                    Beta1 = opt.Beta1, Beta2 = opt.Beta2, Epsilon = opt.Epsilon,
+                    WeightDecay = opt.WeightDecay, UseAMSGrad = opt.UseAMSGrad,
+                };
+            }
+            case AdamOptimizer<T, Tensor<T>, Tensor<T>> o:
+            {
+                var opt = (AdamOptimizerOptions<T, Tensor<T>, Tensor<T>>)o.GetOptions();
+                return new StreamingConfig
+                {
+                    Kind = opt.UseAMSGrad ? StreamingKind.AmsGrad : StreamingKind.Adam,
+                    Beta1 = opt.Beta1, Beta2 = opt.Beta2, Epsilon = opt.Epsilon,
+                    WeightDecay = defaultWeightDecay, UseAMSGrad = opt.UseAMSGrad,
+                };
+            }
+            case AMSGradOptimizer<T, Tensor<T>, Tensor<T>> o:
+            {
+                var opt = (AMSGradOptimizerOptions<T, Tensor<T>, Tensor<T>>)o.GetOptions();
+                return new StreamingConfig
+                {
+                    Kind = StreamingKind.AmsGrad,
+                    Beta1 = opt.Beta1, Beta2 = opt.Beta2, Epsilon = opt.Epsilon,
+                    WeightDecay = 0.0, UseAMSGrad = true,
+                };
+            }
+            case NadamOptimizer<T, Tensor<T>, Tensor<T>> o:
+            {
+                var opt = (NadamOptimizerOptions<T, Tensor<T>, Tensor<T>>)o.GetOptions();
+                return new StreamingConfig { Kind = StreamingKind.Nadam, Beta1 = opt.Beta1, Beta2 = opt.Beta2, Epsilon = opt.Epsilon };
+            }
+            case AdaMaxOptimizer<T, Tensor<T>, Tensor<T>> o:
+            {
+                var opt = (AdaMaxOptimizerOptions<T, Tensor<T>, Tensor<T>>)o.GetOptions();
+                return new StreamingConfig { Kind = StreamingKind.AdaMax, Beta1 = opt.Beta1, Beta2 = opt.Beta2, Epsilon = opt.Epsilon };
+            }
+            case LionOptimizer<T, Tensor<T>, Tensor<T>> o:
+            {
+                var opt = (LionOptimizerOptions<T, Tensor<T>, Tensor<T>>)o.GetOptions();
+                return new StreamingConfig { Kind = StreamingKind.Lion, Beta1 = opt.Beta1, Beta2 = opt.Beta2, WeightDecay = opt.WeightDecay };
+            }
+            case LAMBOptimizer<T, Tensor<T>, Tensor<T>> o:
+            {
+                var opt = (LAMBOptimizerOptions<T, Tensor<T>, Tensor<T>>)o.GetOptions();
+                return new StreamingConfig
+                {
+                    Kind = StreamingKind.Lamb,
+                    Beta1 = opt.Beta1, Beta2 = opt.Beta2, Epsilon = opt.Epsilon, WeightDecay = opt.WeightDecay,
+                    ClipTrustRatio = opt.ClipTrustRatio, MaxTrustRatio = opt.MaxTrustRatio, UseBiasCorrection = opt.UseBiasCorrection,
+                };
+            }
+            case LARSOptimizer<T, Tensor<T>, Tensor<T>> o:
+            {
+                var opt = (LARSOptimizerOptions<T, Tensor<T>, Tensor<T>>)o.GetOptions();
+                return new StreamingConfig
+                {
+                    Kind = StreamingKind.Lars,
+                    Momentum = opt.Momentum, WeightDecay = opt.WeightDecay, TrustCoefficient = opt.TrustCoefficient,
+                    Epsilon = opt.Epsilon, UseNesterov = opt.UseNesterov,
+                };
+            }
+            case FTRLOptimizer<T, Tensor<T>, Tensor<T>> o:
+            {
+                var opt = (FTRLOptimizerOptions<T, Tensor<T>, Tensor<T>>)o.GetOptions();
+                return new StreamingConfig
+                {
+                    Kind = StreamingKind.Ftrl,
+                    FtrlAlpha = opt.Alpha, FtrlBeta = opt.Beta, Lambda1 = opt.Lambda1, Lambda2 = opt.Lambda2,
+                };
+            }
+            case LBFGSOptimizer<T, Tensor<T>, Tensor<T>> o:
+            {
+                var opt = (LBFGSOptimizerOptions<T, Tensor<T>, Tensor<T>>)o.GetOptions();
+                return new StreamingConfig { Kind = StreamingKind.Lbfgs, MemorySize = opt.MemorySize };
+            }
+            case AdaDeltaOptimizer<T, Tensor<T>, Tensor<T>> o:
+            {
+                var opt = (AdaDeltaOptimizerOptions<T, Tensor<T>, Tensor<T>>)o.GetOptions();
+                return new StreamingConfig { Kind = StreamingKind.AdaDelta, Rho = opt.Rho, Epsilon = opt.Epsilon };
+            }
+            case AdagradOptimizer<T, Tensor<T>, Tensor<T>> o:
+            {
+                var opt = (AdagradOptimizerOptions<T, Tensor<T>, Tensor<T>>)o.GetOptions();
+                return new StreamingConfig { Kind = StreamingKind.Adagrad, Epsilon = opt.Epsilon };
+            }
+            case RootMeanSquarePropagationOptimizer<T, Tensor<T>, Tensor<T>> o:
+            {
+                var opt = (RootMeanSquarePropagationOptimizerOptions<T, Tensor<T>, Tensor<T>>)o.GetOptions();
+                return new StreamingConfig { Kind = StreamingKind.RmsProp, Decay = opt.Decay, Epsilon = opt.Epsilon };
+            }
+            case MomentumOptimizer<T, Tensor<T>, Tensor<T>> o:
+            {
+                var opt = (MomentumOptimizerOptions<T, Tensor<T>, Tensor<T>>)o.GetOptions();
+                return new StreamingConfig { Kind = StreamingKind.Momentum, Momentum = opt.InitialMomentum };
+            }
+            case NesterovAcceleratedGradientOptimizer<T, Tensor<T>, Tensor<T>> o:
+            {
+                var opt = (NesterovAcceleratedGradientOptimizerOptions<T, Tensor<T>, Tensor<T>>)o.GetOptions();
+                return new StreamingConfig { Kind = StreamingKind.Nesterov, Momentum = opt.InitialMomentum };
+            }
             case GradientDescentOptimizer<T, Tensor<T>, Tensor<T>>:
             case StochasticGradientDescentOptimizer<T, Tensor<T>, Tensor<T>>:
             case MiniBatchGradientDescentOptimizer<T, Tensor<T>, Tensor<T>>:
             case ProximalGradientDescentOptimizer<T, Tensor<T>, Tensor<T>>:
-                return new StreamingSgd8Bit<T>(lr);
+                return new StreamingConfig { Kind = StreamingKind.Sgd };
             default:
-                return new StreamingAdam8Bit<T>(fallbackLearningRate, weightDecay: fallbackWeightDecay);
+                return new StreamingConfig
+                {
+                    Kind = StreamingKind.Adam,
+                    Beta1 = 0.9, Beta2 = 0.999, Epsilon = 1e-8, WeightDecay = defaultWeightDecay,
+                };
         }
     }
 
@@ -869,52 +1083,5 @@ internal static class StreamingOptimizerResolver<T>
         }
 
         return fallbackLearningRate;
-    }
-
-    private static object? GetOptionsObject(object optimizer)
-    {
-        Type? type = optimizer.GetType();
-        while (type is not null)
-        {
-            foreach (var field in type.GetFields(BindingFlags.Instance | BindingFlags.NonPublic))
-            {
-                if (!field.Name.Contains("options", StringComparison.OrdinalIgnoreCase))
-                    continue;
-                object? value = field.GetValue(optimizer);
-                if (value is not null)
-                    return value;
-            }
-
-            type = type.BaseType;
-        }
-
-        return null;
-    }
-
-    private static double ReadDouble(object? options, string propertyName, double fallback)
-    {
-        object? value = ReadProperty(options, propertyName);
-        if (value is null) return fallback;
-        try
-        {
-            return Convert.ToDouble(value);
-        }
-        catch
-        {
-            return fallback;
-        }
-    }
-
-    private static bool ReadBool(object? options, string propertyName, bool fallback)
-    {
-        object? value = ReadProperty(options, propertyName);
-        return value is bool b ? b : fallback;
-    }
-
-    private static object? ReadProperty(object? options, string propertyName)
-    {
-        if (options is null) return null;
-        var property = options.GetType().GetProperty(propertyName, BindingFlags.Instance | BindingFlags.Public);
-        return property?.GetValue(options);
     }
 }

--- a/src/Training/StreamingAdam8Bit.cs
+++ b/src/Training/StreamingAdam8Bit.cs
@@ -221,44 +221,52 @@ internal abstract class BlockQuantizedStreamingOptimizer<T> : IStreamingOptimize
     {
         int momentCount = _signedMoments.Length;
 
-        // Each block updates a DISJOINT parameter/gradient/quantized-state slice, so the
-        // block loop is embarrassingly parallel. The only per-block shared state on the
-        // serial path is the moment scratch — give each worker its own copy and the loop
-        // parallelizes cleanly. The per-element parameter write goes through the tensor
-        // indexer, whose only cross-thread mutation is an Interlocked version bump; writes
-        // land at disjoint indices, so no extra synchronization (or O(n) staging buffer,
-        // which would defeat the memory-bounded design) is needed.
+        // Force any lazy-graph realization / streaming-weight rehydration ONCE on this thread,
+        // then try to grab the LIVE contiguous backing arrays. For trainable weights and their
+        // gradients (simple, contiguous, CPU-resident storage) this lets us update the parameter
+        // array IN PLACE with raw indexing — no per-element tensor-indexer overhead (each
+        // GetFlat/SetFlat re-checks materialization, bounds, and does an Interlocked version
+        // bump) — and bump the version exactly ONCE at the end. Views / GPU-resident / lazy
+        // tensors return null here and fall back to the per-element indexer. Either way each
+        // block updates a DISJOINT parameter/gradient/state slice, so the loop parallelizes
+        // with per-worker scratch and stays deterministic (no O(n) staging buffer, so the
+        // memory-bounded design is preserved).
+        _ = _ops.ToDouble(param[0]);
+        _ = _ops.ToDouble(grad[0]);
+        T[]? paramArr = param.GetLiveBackingArrayOrNull();
+        T[]? gradArr = grad.GetLiveBackingArrayOrNull();
+
         if (length < ParallelApplyMinLength || state.NumBlocks < 2 || Environment.ProcessorCount < 2)
         {
             for (int b = 0; b < state.NumBlocks; b++)
             {
-                ApplyOneBlock(b, param, grad, state, length, momentCount,
+                ApplyOneBlock(b, param, grad, paramArr, gradArr, state, length, momentCount,
                     _previousMomentValues, _nextMomentValues, _momentScratch, _momentMax);
             }
-            return;
+        }
+        else
+        {
+            System.Threading.Tasks.Parallel.For(
+                0,
+                state.NumBlocks,
+                () => new BlockScratch(momentCount, BlockSize),
+                (b, _, scratch) =>
+                {
+                    ApplyOneBlock(b, param, grad, paramArr, gradArr, state, length, momentCount,
+                        scratch.Previous, scratch.Next, scratch.MomentScratch, scratch.MomentMax);
+                    return scratch;
+                },
+                _ => { });
         }
 
-        // Force any lazy-graph realization / streaming-weight rehydration ONCE on this
-        // thread, so the parallel workers only ever touch already-materialized storage
-        // (the indexer fast path is then a pure disjoint array read/write).
-        _ = _ops.ToDouble(param[0]);
-        _ = _ops.ToDouble(grad[0]);
-
-        System.Threading.Tasks.Parallel.For(
-            0,
-            state.NumBlocks,
-            () => new BlockScratch(momentCount, BlockSize),
-            (b, _, scratch) =>
-            {
-                ApplyOneBlock(b, param, grad, state, length, momentCount,
-                    scratch.Previous, scratch.Next, scratch.MomentScratch, scratch.MomentMax);
-                return scratch;
-            },
-            _ => { });
+        // The raw-array write path bypasses the indexer's per-element version bump, so bump
+        // once here to invalidate any cached GPU buffer for the now-mutated parameter.
+        if (paramArr is not null) param.IncrementVersion();
     }
 
     private void ApplyOneBlock(
-        int b, Tensor<T> param, Tensor<T> grad, QuantizedState state, int length, int momentCount,
+        int b, Tensor<T> param, Tensor<T> grad, T[]? paramArr, T[]? gradArr,
+        QuantizedState state, int length, int momentCount,
         double[] previous, double[] next, double[][] momentScratch, double[] momentMax)
     {
         int start = b * BlockSize;
@@ -278,14 +286,15 @@ internal abstract class BlockQuantizedStreamingOptimizer<T> : IStreamingOptimize
                 next[m] = value;
             }
 
-            double gradientValue = ToDouble(grad[i]);
+            double gradientValue = gradArr is not null ? ToDouble(gradArr[i]) : ToDouble(grad[i]);
             if (!double.IsNaN(gradientValue) && !double.IsInfinity(gradientValue))
             {
-                double parameterValue = ToDouble(param[i]);
+                double parameterValue = paramArr is not null ? ToDouble(paramArr[i]) : ToDouble(param[i]);
                 double nextParameter = UpdateElement(parameterValue, gradientValue, previousSpan, nextSpan, i);
                 if (!double.IsNaN(nextParameter) && !double.IsInfinity(nextParameter))
                 {
-                    param[i] = FromDouble(nextParameter);
+                    if (paramArr is not null) paramArr[i] = FromDouble(nextParameter);
+                    else param[i] = FromDouble(nextParameter);
                 }
             }
 

--- a/src/Training/StreamingAdam8Bit.cs
+++ b/src/Training/StreamingAdam8Bit.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Generic;
+using System.Reflection;
 using AiDotNet.Helpers;
+using AiDotNet.Optimizers;
 using AiDotNet.Tensors.Helpers;
 using AiDotNet.Tensors.Interfaces;
 using AiDotNet.Tensors.LinearAlgebra;
@@ -8,74 +10,390 @@ using AiDotNet.Tensors.LinearAlgebra;
 namespace AiDotNet.Training;
 
 /// <summary>
-/// Per-parameter 8-bit Adam(W) optimizer state for the memory-bounded streaming
-/// training path. Each parameter's first/second moments are stored block-wise
-/// quantized to 8 bits — roughly 16× smaller than fp64 moments — so a model
-/// whose full-precision Adam state would not fit in RAM can still take a real,
-/// Adam-faithful optimizer step. Each parameter's state is created lazily and
-/// updated + applied IN PLACE inside the gradient-streaming callback, right
-/// after that parameter's gradient is produced and before it is freed
-/// (optimizer-in-backward).
+/// Optimizer-in-backward contract for the memory-bounded streaming training path.
 /// </summary>
-/// <remarks>
-/// <para>
-/// This mirrors the block-wise quantization scheme of
-/// <see cref="AiDotNet.Optimizers.Adam8BitOptimizer{T, TInput, TOutput}"/>
-/// (8-bit signed first moment, 8-bit unsigned second moment, one scale per
-/// block) but is scoped to a single parameter tensor so it can run incrementally
-/// during the streaming backward rather than over one flat model-wide vector.
-/// All arithmetic is performed in <see cref="double"/> and converted at the
-/// tensor boundary, matching the rest of the framework's numeric pattern.
-/// </para>
-/// <para>
-/// State persists across <c>Train</c> calls (keyed by parameter-tensor
-/// reference) so the moments accumulate correctly over a multi-step training
-/// run; <see cref="BeginStep"/> advances the shared timestep used for Adam bias
-/// correction once per backward pass.
-/// </para>
-/// </remarks>
-internal sealed class StreamingAdam8Bit<T>
+internal interface IStreamingOptimizer<T>
 {
-    private sealed class MomentState
-    {
-        public readonly byte[] MQuant;     // signed first moment, 128 == 0
-        public readonly byte[] VQuant;     // unsigned second moment
-        public readonly double[] MScale;   // per block
-        public readonly double[] VScale;   // per block
+    void BeginStep();
+    void Apply(Tensor<T> param, Tensor<T> grad);
+}
 
-        public MomentState(int length, int numBlocks)
+internal interface IStreamingOptimizerLearningRate
+{
+    void SetLearningRate(double learningRate);
+}
+
+/// <summary>
+/// Shared per-parameter block-quantized state machinery for streaming optimizers.
+/// Concrete optimizers only provide the per-element update rule and moment layout.
+/// </summary>
+internal abstract class BlockQuantizedStreamingOptimizer<T> : IStreamingOptimizer<T>, IStreamingOptimizerLearningRate
+{
+    protected sealed class QuantizedState
+    {
+        public readonly byte[][] Quantized;
+        public readonly double[][] Scales;
+        public readonly int Length;
+        public readonly int NumBlocks;
+
+        public QuantizedState(int momentCount, int length, int numBlocks, IReadOnlyList<bool> signedMoments)
         {
-            MQuant = new byte[length];
-            VQuant = new byte[length];
-            MScale = new double[numBlocks];
-            VScale = new double[numBlocks];
-            // 128 maps to 0 for the signed first moment; scales start at 1.0
-            // so the zero-initialized state dequantizes to exactly zero.
-            for (int i = 0; i < length; i++) MQuant[i] = 128;
-            for (int b = 0; b < numBlocks; b++) { MScale[b] = 1.0; VScale[b] = 1.0; }
+            Length = length;
+            NumBlocks = numBlocks;
+            Quantized = new byte[momentCount][];
+            Scales = new double[momentCount][];
+
+            for (int m = 0; m < momentCount; m++)
+            {
+                Quantized[m] = new byte[length];
+                Scales[m] = new double[numBlocks];
+                if (signedMoments[m])
+                {
+                    Array.Fill(Quantized[m], (byte)128);
+                }
+
+                Array.Fill(Scales[m], 1.0);
+            }
         }
     }
 
-    private readonly Dictionary<Tensor<T>, MomentState> _state =
+    private readonly Dictionary<Tensor<T>, QuantizedState> _state =
         new(TensorReferenceComparer<Tensor<T>>.Instance);
     private readonly INumericOperations<T> _ops = MathHelper.GetNumericOperations<T>();
+    private readonly bool[] _signedMoments;
+    private readonly double[] _previousMomentValues;
+    private readonly double[] _nextMomentValues;
+    private readonly double[][] _momentScratch;
+    private readonly double[] _momentMax;
+    private readonly string _optimizerName;
 
-    private readonly int _blockSize;
-    private readonly double _lr;
+    protected readonly int BlockSize;
+    protected readonly double MaxUpdateRatio;
+    protected int Step { get; private set; }
+    protected double LearningRate { get; private set; }
+
+    protected BlockQuantizedStreamingOptimizer(
+        string optimizerName,
+        double learningRate,
+        bool[] signedMoments,
+        int blockSize = 2048,
+        double maxUpdateRatio = 5.0)
+    {
+        _optimizerName = optimizerName;
+        LearningRate = learningRate;
+        _signedMoments = signedMoments;
+        BlockSize = Math.Max(1, blockSize);
+        MaxUpdateRatio = maxUpdateRatio > 0 ? maxUpdateRatio : 5.0;
+
+        _previousMomentValues = new double[signedMoments.Length];
+        _nextMomentValues = new double[signedMoments.Length];
+        _momentScratch = new double[signedMoments.Length][];
+        _momentMax = new double[signedMoments.Length];
+        for (int i = 0; i < signedMoments.Length; i++)
+        {
+            _momentScratch[i] = new double[BlockSize];
+        }
+    }
+
+    public void SetLearningRate(double learningRate)
+    {
+        if (learningRate > 0.0 && !double.IsNaN(learningRate) && !double.IsInfinity(learningRate))
+        {
+            LearningRate = learningRate;
+        }
+    }
+
+    public void BeginStep()
+    {
+        Step++;
+        OnBeginStep();
+    }
+
+    protected virtual void OnBeginStep()
+    {
+    }
+
+    public virtual void Apply(Tensor<T> param, Tensor<T> grad)
+    {
+        if (param is null) throw new ArgumentNullException(nameof(param));
+        if (grad is null) throw new ArgumentNullException(nameof(grad));
+
+        int length = param.Length;
+        if (length == 0)
+        {
+            throw new ArgumentException(
+                $"{_optimizerName}.Apply: param is empty (length == 0); a zero-length parameter should never be registered as a training source.",
+                nameof(param));
+        }
+
+        if (grad.Length != length)
+        {
+            throw new ArgumentException(
+                $"{_optimizerName}.Apply: gradient length {grad.Length} does not match param length {length}.",
+                nameof(grad));
+        }
+
+        int numBlocks = (length + BlockSize - 1) / BlockSize;
+        if (!_state.TryGetValue(param, out var state) || state.Length != length)
+        {
+            state = new QuantizedState(_signedMoments.Length, length, numBlocks, _signedMoments);
+            _state[param] = state;
+        }
+
+        PrepareParameter(param, grad, state, length);
+        ApplyBlocks(param, grad, state, length);
+    }
+
+    protected virtual void PrepareParameter(Tensor<T> param, Tensor<T> grad, QuantizedState state, int length)
+    {
+    }
+
+    protected abstract double UpdateElement(
+        double parameter,
+        double gradient,
+        ReadOnlySpan<double> moments,
+        Span<double> nextMoments,
+        int index);
+
+    protected double ToDouble(T value) => _ops.ToDouble(value);
+
+    protected T FromDouble(double value) => _ops.FromDouble(value);
+
+    protected double Dequantize(QuantizedState state, int moment, int index)
+    {
+        int block = index / BlockSize;
+        double scale = state.Scales[moment][block];
+        byte q = state.Quantized[moment][index];
+        return _signedMoments[moment] ? (q - 128) * scale : q * scale;
+    }
+
+    protected double L2Norm(Tensor<T> tensor)
+    {
+        double sum = 0.0;
+        for (int i = 0; i < tensor.Length; i++)
+        {
+            double v = ToDouble(tensor[i]);
+            if (double.IsNaN(v) || double.IsInfinity(v)) continue;
+            sum += v * v;
+        }
+
+        return Math.Sqrt(sum);
+    }
+
+    protected double ApplyDecoupledWeightDecay(double parameter, double weightDecay)
+    {
+        return weightDecay == 0.0 ? parameter : parameter - LearningRate * weightDecay * parameter;
+    }
+
+    protected double ClampUpdate(double update)
+    {
+        double maxStep = LearningRate * MaxUpdateRatio;
+        if (maxStep <= 0.0 || double.IsNaN(maxStep) || double.IsInfinity(maxStep))
+            return update;
+
+        if (double.IsNaN(update) || double.IsInfinity(update))
+            return update > 0 ? maxStep : -maxStep;
+        if (update > maxStep) return maxStep;
+        if (update < -maxStep) return -maxStep;
+        return update;
+    }
+
+    private void ApplyBlocks(Tensor<T> param, Tensor<T> grad, QuantizedState state, int length)
+    {
+        int momentCount = _signedMoments.Length;
+        var previous = _previousMomentValues.AsSpan(0, momentCount);
+        var next = _nextMomentValues.AsSpan(0, momentCount);
+
+        for (int b = 0; b < state.NumBlocks; b++)
+        {
+            int start = b * BlockSize;
+            int end = Math.Min(start + BlockSize, length);
+            Array.Clear(_momentMax, 0, _momentMax.Length);
+
+            for (int i = start; i < end; i++)
+            {
+                int local = i - start;
+                for (int m = 0; m < momentCount; m++)
+                {
+                    double value = Dequantize(state, m, i);
+                    _previousMomentValues[m] = value;
+                    _nextMomentValues[m] = value;
+                }
+
+                double gradientValue = ToDouble(grad[i]);
+                if (!double.IsNaN(gradientValue) && !double.IsInfinity(gradientValue))
+                {
+                    double parameterValue = ToDouble(param[i]);
+                    double nextParameter = UpdateElement(parameterValue, gradientValue, previous, next, i);
+                    if (!double.IsNaN(nextParameter) && !double.IsInfinity(nextParameter))
+                    {
+                        param[i] = FromDouble(nextParameter);
+                    }
+                }
+
+                for (int m = 0; m < momentCount; m++)
+                {
+                    double value = _nextMomentValues[m];
+                    _momentScratch[m][local] = value;
+                    double magnitude = _signedMoments[m] ? Math.Abs(value) : Math.Max(0.0, value);
+                    if (magnitude > _momentMax[m]) _momentMax[m] = magnitude;
+                }
+            }
+
+            for (int m = 0; m < momentCount; m++)
+            {
+                double divisor = _signedMoments[m] ? 127.0 : 255.0;
+                double scale = _momentMax[m] / divisor;
+                if (scale < 1e-10 || double.IsNaN(scale) || double.IsInfinity(scale))
+                    scale = 1e-10;
+                state.Scales[m][b] = scale;
+
+                double invScale = 1.0 / scale;
+                for (int i = start; i < end; i++)
+                {
+                    int local = i - start;
+                    double value = _momentScratch[m][local];
+                    if (_signedMoments[m])
+                    {
+                        int q = (int)Math.Round(value * invScale);
+                        if (q < -127) q = -127;
+                        else if (q > 127) q = 127;
+                        state.Quantized[m][i] = (byte)(q + 128);
+                    }
+                    else
+                    {
+                        int q = (int)Math.Round(Math.Max(0.0, value) * invScale);
+                        if (q < 0) q = 0;
+                        else if (q > 255) q = 255;
+                        state.Quantized[m][i] = (byte)q;
+                    }
+                }
+            }
+        }
+    }
+}
+
+internal sealed class StreamingSgd8Bit<T> : BlockQuantizedStreamingOptimizer<T>
+{
+    public StreamingSgd8Bit(double learningRate)
+        : base(nameof(StreamingSgd8Bit<T>), learningRate, Array.Empty<bool>())
+    {
+    }
+
+    protected override double UpdateElement(double parameter, double gradient, ReadOnlySpan<double> moments, Span<double> nextMoments, int index)
+        => parameter - ClampUpdate(LearningRate * gradient);
+}
+
+internal sealed class StreamingMomentum8Bit<T> : BlockQuantizedStreamingOptimizer<T>
+{
+    private readonly double _momentum;
+
+    public StreamingMomentum8Bit(double learningRate, double momentum)
+        : base(nameof(StreamingMomentum8Bit<T>), learningRate, new[] { true })
+    {
+        _momentum = momentum;
+    }
+
+    protected override double UpdateElement(double parameter, double gradient, ReadOnlySpan<double> moments, Span<double> nextMoments, int index)
+    {
+        double velocity = _momentum * moments[0] + LearningRate * gradient;
+        nextMoments[0] = velocity;
+        return parameter - ClampUpdate(velocity);
+    }
+}
+
+internal sealed class StreamingNesterov8Bit<T> : BlockQuantizedStreamingOptimizer<T>
+{
+    private readonly double _momentum;
+
+    public StreamingNesterov8Bit(double learningRate, double momentum)
+        : base(nameof(StreamingNesterov8Bit<T>), learningRate, new[] { true })
+    {
+        _momentum = momentum;
+    }
+
+    protected override double UpdateElement(double parameter, double gradient, ReadOnlySpan<double> moments, Span<double> nextMoments, int index)
+    {
+        double velocity = _momentum * moments[0] + LearningRate * gradient;
+        double nesterovUpdate = _momentum * velocity + LearningRate * gradient;
+        nextMoments[0] = velocity;
+        return parameter - ClampUpdate(nesterovUpdate);
+    }
+}
+
+internal sealed class StreamingRmsProp8Bit<T> : BlockQuantizedStreamingOptimizer<T>
+{
+    private readonly double _decay;
+    private readonly double _epsilon;
+
+    public StreamingRmsProp8Bit(double learningRate, double decay, double epsilon)
+        : base(nameof(StreamingRmsProp8Bit<T>), learningRate, new[] { false })
+    {
+        _decay = decay;
+        _epsilon = epsilon;
+    }
+
+    protected override double UpdateElement(double parameter, double gradient, ReadOnlySpan<double> moments, Span<double> nextMoments, int index)
+    {
+        double sq = _decay * moments[0] + (1.0 - _decay) * gradient * gradient;
+        nextMoments[0] = sq;
+        double update = LearningRate * gradient / (Math.Sqrt(sq) + _epsilon);
+        return parameter - ClampUpdate(update);
+    }
+}
+
+internal sealed class StreamingAdagrad8Bit<T> : BlockQuantizedStreamingOptimizer<T>
+{
+    private readonly double _epsilon;
+
+    public StreamingAdagrad8Bit(double learningRate, double epsilon)
+        : base(nameof(StreamingAdagrad8Bit<T>), learningRate, new[] { false })
+    {
+        _epsilon = epsilon;
+    }
+
+    protected override double UpdateElement(double parameter, double gradient, ReadOnlySpan<double> moments, Span<double> nextMoments, int index)
+    {
+        double acc = moments[0] + gradient * gradient;
+        nextMoments[0] = acc;
+        double update = LearningRate * gradient / (Math.Sqrt(acc) + _epsilon);
+        return parameter - ClampUpdate(update);
+    }
+}
+
+internal sealed class StreamingAdaDelta8Bit<T> : BlockQuantizedStreamingOptimizer<T>
+{
+    private readonly double _rho;
+    private readonly double _epsilon;
+
+    public StreamingAdaDelta8Bit(double learningRate, double rho, double epsilon)
+        : base(nameof(StreamingAdaDelta8Bit<T>), learningRate, new[] { false, false })
+    {
+        _rho = rho;
+        _epsilon = epsilon;
+    }
+
+    protected override double UpdateElement(double parameter, double gradient, ReadOnlySpan<double> moments, Span<double> nextMoments, int index)
+    {
+        double accGrad = _rho * moments[0] + (1.0 - _rho) * gradient * gradient;
+        double delta = Math.Sqrt(moments[1] + _epsilon) / Math.Sqrt(accGrad + _epsilon) * gradient;
+        double accUpdate = _rho * moments[1] + (1.0 - _rho) * delta * delta;
+
+        nextMoments[0] = accGrad;
+        nextMoments[1] = accUpdate;
+        return parameter - ClampUpdate(LearningRate * delta);
+    }
+}
+
+/// <summary>
+/// Per-parameter 8-bit Adam optimizer state for the memory-bounded streaming path.
+/// </summary>
+internal class StreamingAdam8Bit<T> : BlockQuantizedStreamingOptimizer<T>
+{
     private readonly double _beta1;
     private readonly double _beta2;
     private readonly double _epsilon;
     private readonly double _weightDecay;
-    private readonly double _maxUpdateRatio;
-
-    private int _t; // shared Adam timestep (bias correction), advanced per backward pass
-
-    // Reusable one-block-wide scratch for the updated full-precision moments —
-    // the only full-precision optimizer buffers ever resident, and reused across
-    // every block of every parameter so the steady-state epilogue is zero-alloc.
-    // Training is single-threaded per step (reentrancy guard), so sharing is safe.
-    private readonly double[] _mScratch;
-    private readonly double[] _vScratch;
 
     public StreamingAdam8Bit(
         double learningRate,
@@ -85,290 +403,500 @@ internal sealed class StreamingAdam8Bit<T>
         double weightDecay = 0.0,
         int blockSize = 2048,
         double maxUpdateRatio = 5.0)
+        : base(nameof(StreamingAdam8Bit<T>), learningRate, new[] { true, false }, blockSize, maxUpdateRatio)
     {
-        _lr = learningRate;
         _beta1 = beta1;
         _beta2 = beta2;
         _epsilon = epsilon;
         _weightDecay = weightDecay;
-        _blockSize = Math.Max(1, blockSize);
-        _maxUpdateRatio = maxUpdateRatio > 0 ? maxUpdateRatio : 5.0;
-        _mScratch = new double[_blockSize];
-        _vScratch = new double[_blockSize];
     }
 
-    /// <summary>Advances the shared Adam timestep. Call once per backward pass,
-    /// before streaming that pass's parameter gradients.</summary>
-    public void BeginStep() => _t++;
-
-    /// <summary>
-    /// Applies one Adam(W) update to <paramref name="param"/> in place using the
-    /// just-computed <paramref name="grad"/>, maintaining this parameter's 8-bit
-    /// moment state. Safe to call exactly once per parameter per backward pass.
-    /// </summary>
-    public void Apply(Tensor<T> param, Tensor<T> grad)
+    protected override double UpdateElement(double parameter, double gradient, ReadOnlySpan<double> moments, Span<double> nextMoments, int index)
     {
-        // Apply is on the hot training path — a null tensor or length mismatch is a
-        // hard correctness bug in the backward pass (gradient missing for a registered
-        // source, or a shape regression between forward and backward). Silently
-        // dropping the update hides the bug and leaves the parameter forever frozen,
-        // which is worse than failing fast.
-        if (param is null) throw new ArgumentNullException(nameof(param));
-        if (grad is null) throw new ArgumentNullException(nameof(grad));
-        int length = param.Length;
-        if (length == 0)
-            throw new ArgumentException("StreamingAdam8Bit.Apply: param is empty (length == 0); " +
-                "a zero-length parameter should never be registered as a training source.", nameof(param));
-        if (grad.Length != length)
-            throw new ArgumentException(
-                $"StreamingAdam8Bit.Apply: gradient length {grad.Length} does not match param length {length}. " +
-                "This indicates a shape mismatch between the forward pass and the tape backward — " +
-                "fix the source of the size drift rather than letting Apply silently no-op.",
-                nameof(grad));
+        double m = _beta1 * moments[0] + (1.0 - _beta1) * gradient;
+        double v = _beta2 * moments[1] + (1.0 - _beta2) * gradient * gradient;
+        nextMoments[0] = m;
+        nextMoments[1] = v;
 
-        int numBlocks = (length + _blockSize - 1) / _blockSize;
-        if (!_state.TryGetValue(param, out var st))
-        {
-            st = new MomentState(length, numBlocks);
-            _state[param] = st;
-        }
+        double biasCorr1 = 1.0 - Math.Pow(_beta1, Step);
+        double biasCorr2 = 1.0 - Math.Pow(_beta2, Step);
+        if (biasCorr1 <= 0.0) biasCorr1 = 1.0;
+        if (biasCorr2 <= 0.0) biasCorr2 = 1.0;
 
-        double biasCorr1 = 1.0 - Math.Pow(_beta1, _t);
-        double biasCorr2 = 1.0 - Math.Pow(_beta2, _t);
-        if (biasCorr1 <= 0) biasCorr1 = 1.0;
-        if (biasCorr2 <= 0) biasCorr2 = 1.0;
+        parameter = ApplyDecoupledWeightDecay(parameter, _weightDecay);
+        double update = LearningRate * (m / biasCorr1) / (Math.Sqrt(v / biasCorr2) + _epsilon);
+        return parameter - ClampUpdate(update);
+    }
+}
 
-        // Fast path: raw double spans (no per-element Tensor indexer / NumOps
-        // virtual dispatch). This is the dominant cost at foundation scale —
-        // billions of elements — so the spanned path is ~10× the generic one and
-        // the JIT auto-vectorizes the FMA-heavy moment math. Only valid for
-        // non-view, full-storage parameter tensors (layer weights are exactly
-        // that); anything else falls through to the generic path.
-        if (typeof(T) == typeof(double)
-            && (object)param is Tensor<double> pTen
-            && (object)grad is Tensor<double> gTen)
-        {
-            var pSpan = pTen.Data.Span;
-            var gSpan = gTen.Data.Span;
-            if (pSpan.Length >= length && gSpan.Length >= length)
-            {
-                ApplyDouble(pSpan, gSpan, st, numBlocks, length, biasCorr1, biasCorr2);
-                return;
-            }
-        }
-        else if (typeof(T) == typeof(float)
-            && (object)param is Tensor<float> pTenF
-            && (object)grad is Tensor<float> gTenF)
-        {
-            var pSpan = pTenF.Data.Span;
-            var gSpan = gTenF.Data.Span;
-            if (pSpan.Length >= length && gSpan.Length >= length)
-            {
-                ApplyFloat(pSpan, gSpan, st, numBlocks, length, biasCorr1, biasCorr2);
-                return;
-            }
-        }
+internal sealed class StreamingAdamW8Bit<T> : StreamingAdam8Bit<T>
+{
+    public StreamingAdamW8Bit(
+        double learningRate,
+        double beta1,
+        double beta2,
+        double epsilon,
+        double weightDecay)
+        : base(learningRate, beta1, beta2, epsilon, weightDecay)
+    {
+    }
+}
 
-        ApplyGeneric(param, grad, st, numBlocks, length, biasCorr1, biasCorr2);
+internal sealed class StreamingAMSGrad8Bit<T> : BlockQuantizedStreamingOptimizer<T>
+{
+    private readonly double _beta1;
+    private readonly double _beta2;
+    private readonly double _epsilon;
+    private readonly double _weightDecay;
+
+    public StreamingAMSGrad8Bit(double learningRate, double beta1, double beta2, double epsilon, double weightDecay)
+        : base(nameof(StreamingAMSGrad8Bit<T>), learningRate, new[] { true, false, false })
+    {
+        _beta1 = beta1;
+        _beta2 = beta2;
+        _epsilon = epsilon;
+        _weightDecay = weightDecay;
     }
 
-    private void ApplyDouble(
-        Span<double> p, ReadOnlySpan<double> g, MomentState st,
-        int numBlocks, int length, double biasCorr1, double biasCorr2)
+    protected override double UpdateElement(double parameter, double gradient, ReadOnlySpan<double> moments, Span<double> nextMoments, int index)
     {
-        double beta1 = _beta1, beta2 = _beta2, oneMinusB1 = 1.0 - _beta1, oneMinusB2 = 1.0 - _beta2;
-        double lr = _lr, eps = _epsilon, wd = _weightDecay, maxStep = _lr * _maxUpdateRatio;
-        double invBc1 = 1.0 / biasCorr1, invBc2 = 1.0 / biasCorr2;
-        double[] mNew = _mScratch, vNew = _vScratch;
-        byte[] mQ = st.MQuant, vQ = st.VQuant;
+        double m = _beta1 * moments[0] + (1.0 - _beta1) * gradient;
+        double v = _beta2 * moments[1] + (1.0 - _beta2) * gradient * gradient;
+        double vMax = Math.Max(moments[2], v);
+        nextMoments[0] = m;
+        nextMoments[1] = v;
+        nextMoments[2] = vMax;
 
-        for (int b = 0; b < numBlocks; b++)
-        {
-            int start = b * _blockSize;
-            int end = Math.Min(start + _blockSize, length);
-            double mScale = st.MScale[b];
-            double vScale = st.VScale[b];
-            double newMMaxAbs = 0.0, newVMax = 0.0;
+        double biasCorr1 = 1.0 - Math.Pow(_beta1, Step);
+        double biasCorr2 = 1.0 - Math.Pow(_beta2, Step);
+        if (biasCorr1 <= 0.0) biasCorr1 = 1.0;
+        if (biasCorr2 <= 0.0) biasCorr2 = 1.0;
 
-            for (int i = start; i < end; i++)
-            {
-                int li = i - start;
-                double gi = g[i];
-                double mPrev = (mQ[i] - 128) * mScale;   // signed dequant
-                double vPrev = vQ[i] * vScale;            // unsigned dequant
+        parameter = ApplyDecoupledWeightDecay(parameter, _weightDecay);
+        double update = LearningRate * (m / biasCorr1) / (Math.Sqrt(vMax / biasCorr2) + _epsilon);
+        return parameter - ClampUpdate(update);
+    }
+}
 
-                if (double.IsNaN(gi) || double.IsInfinity(gi))
-                {
-                    // Skip non-finite gradient: keep prior moments + weight.
-                    mNew[li] = mPrev; vNew[li] = vPrev;
-                }
-                else
-                {
-                    double m = beta1 * mPrev + oneMinusB1 * gi;
-                    double v = beta2 * vPrev + oneMinusB2 * gi * gi;
-                    double mHat = m * invBc1;
-                    double vHat = v * invBc2;
+internal sealed class StreamingNadam8Bit<T> : BlockQuantizedStreamingOptimizer<T>
+{
+    private readonly double _beta1;
+    private readonly double _beta2;
+    private readonly double _epsilon;
 
-                    double pv = p[i];
-                    if (wd != 0.0) pv -= lr * wd * pv;
-                    double update = lr * mHat / (Math.Sqrt(vHat) + eps);
-                    // Trust bound: 8-bit quantization can round vHat→0, which
-                    // would blow up the step; clamp to a small multiple of lr
-                    // (real Adam steps are ~lr) and catch any residual NaN.
-                    if (!(update >= -maxStep)) update = update > 0 ? maxStep : -maxStep;
-                    else if (update > maxStep) update = maxStep;
-                    p[i] = pv - update;
-                    mNew[li] = m; vNew[li] = v;
-                }
-
-                double am = Math.Abs(mNew[li]);
-                if (am > newMMaxAbs) newMMaxAbs = am;
-                if (vNew[li] > newVMax) newVMax = vNew[li];
-            }
-
-            double newMScale = newMMaxAbs / 127.0; if (newMScale < 1e-10) newMScale = 1e-10;
-            double newVScale = newVMax / 255.0;     if (newVScale < 1e-10) newVScale = 1e-10;
-            st.MScale[b] = newMScale; st.VScale[b] = newVScale;
-            double invM = 1.0 / newMScale, invV = 1.0 / newVScale;
-
-            for (int i = start; i < end; i++)
-            {
-                int li = i - start;
-                int mq = (int)Math.Round(mNew[li] * invM);
-                if (mq < -127) mq = -127; else if (mq > 127) mq = 127;
-                mQ[i] = (byte)(mq + 128);
-                int vq = (int)Math.Round(vNew[li] * invV);
-                if (vq < 0) vq = 0; else if (vq > 255) vq = 255;
-                vQ[i] = (byte)vq;
-            }
-        }
+    public StreamingNadam8Bit(double learningRate, double beta1, double beta2, double epsilon)
+        : base(nameof(StreamingNadam8Bit<T>), learningRate, new[] { true, false })
+    {
+        _beta1 = beta1;
+        _beta2 = beta2;
+        _epsilon = epsilon;
     }
 
-    private void ApplyFloat(
-        Span<float> p, ReadOnlySpan<float> g, MomentState st,
-        int numBlocks, int length, double biasCorr1, double biasCorr2)
+    protected override double UpdateElement(double parameter, double gradient, ReadOnlySpan<double> moments, Span<double> nextMoments, int index)
     {
-        double beta1 = _beta1, beta2 = _beta2, oneMinusB1 = 1.0 - _beta1, oneMinusB2 = 1.0 - _beta2;
-        double lr = _lr, eps = _epsilon, wd = _weightDecay, maxStep = _lr * _maxUpdateRatio;
-        double invBc1 = 1.0 / biasCorr1, invBc2 = 1.0 / biasCorr2;
-        double[] mNew = _mScratch, vNew = _vScratch;
-        byte[] mQ = st.MQuant, vQ = st.VQuant;
+        double m = _beta1 * moments[0] + (1.0 - _beta1) * gradient;
+        double v = _beta2 * moments[1] + (1.0 - _beta2) * gradient * gradient;
+        nextMoments[0] = m;
+        nextMoments[1] = v;
 
-        for (int b = 0; b < numBlocks; b++)
+        double biasCorr1 = 1.0 - Math.Pow(_beta1, Step);
+        double biasCorr2 = 1.0 - Math.Pow(_beta2, Step);
+        if (biasCorr1 <= 0.0) biasCorr1 = 1.0;
+        if (biasCorr2 <= 0.0) biasCorr2 = 1.0;
+
+        double mHat = m / biasCorr1;
+        double vHat = v / biasCorr2;
+        double nesterov = _beta1 * mHat + (1.0 - _beta1) * gradient / biasCorr1;
+        double update = LearningRate * nesterov / (Math.Sqrt(vHat) + _epsilon);
+        return parameter - ClampUpdate(update);
+    }
+}
+
+internal sealed class StreamingAdaMax8Bit<T> : BlockQuantizedStreamingOptimizer<T>
+{
+    private readonly double _beta1;
+    private readonly double _beta2;
+    private readonly double _epsilon;
+
+    public StreamingAdaMax8Bit(double learningRate, double beta1, double beta2, double epsilon)
+        : base(nameof(StreamingAdaMax8Bit<T>), learningRate, new[] { true, false })
+    {
+        _beta1 = beta1;
+        _beta2 = beta2;
+        _epsilon = epsilon;
+    }
+
+    protected override double UpdateElement(double parameter, double gradient, ReadOnlySpan<double> moments, Span<double> nextMoments, int index)
+    {
+        double m = _beta1 * moments[0] + (1.0 - _beta1) * gradient;
+        double u = Math.Max(_beta2 * moments[1], Math.Abs(gradient));
+        nextMoments[0] = m;
+        nextMoments[1] = u;
+
+        double biasCorr1 = 1.0 - Math.Pow(_beta1, Step);
+        if (biasCorr1 <= 0.0) biasCorr1 = 1.0;
+
+        double update = (LearningRate / biasCorr1) * m / (u + _epsilon);
+        return parameter - ClampUpdate(update);
+    }
+}
+
+internal sealed class StreamingLion8Bit<T> : BlockQuantizedStreamingOptimizer<T>
+{
+    private readonly double _beta1;
+    private readonly double _beta2;
+    private readonly double _weightDecay;
+
+    public StreamingLion8Bit(double learningRate, double beta1, double beta2, double weightDecay)
+        : base(nameof(StreamingLion8Bit<T>), learningRate, new[] { true })
+    {
+        _beta1 = beta1;
+        _beta2 = beta2;
+        _weightDecay = weightDecay;
+    }
+
+    protected override double UpdateElement(double parameter, double gradient, ReadOnlySpan<double> moments, Span<double> nextMoments, int index)
+    {
+        double updateDirection = _beta1 * moments[0] + (1.0 - _beta1) * gradient;
+        double momentum = _beta2 * moments[0] + (1.0 - _beta2) * gradient;
+        nextMoments[0] = momentum;
+
+        parameter = ApplyDecoupledWeightDecay(parameter, _weightDecay);
+        double update = LearningRate * Math.Sign(updateDirection);
+        return parameter - ClampUpdate(update);
+    }
+}
+
+internal sealed class StreamingLars8Bit<T> : BlockQuantizedStreamingOptimizer<T>
+{
+    private readonly double _momentum;
+    private readonly double _weightDecay;
+    private readonly double _trustCoefficient;
+    private readonly double _epsilon;
+    private readonly bool _useNesterov;
+    private double _localLearningRate;
+
+    public StreamingLars8Bit(
+        double learningRate,
+        double momentum,
+        double weightDecay,
+        double trustCoefficient,
+        double epsilon,
+        bool useNesterov)
+        : base(nameof(StreamingLars8Bit<T>), learningRate, new[] { true })
+    {
+        _momentum = momentum;
+        _weightDecay = weightDecay;
+        _trustCoefficient = trustCoefficient;
+        _epsilon = epsilon;
+        _useNesterov = useNesterov;
+        _localLearningRate = learningRate;
+    }
+
+    protected override void PrepareParameter(Tensor<T> param, Tensor<T> grad, QuantizedState state, int length)
+    {
+        double paramNorm = L2Norm(param);
+        double gradNorm = L2Norm(grad);
+        if (paramNorm > 0.0 && gradNorm > 0.0)
         {
-            int start = b * _blockSize;
-            int end = Math.Min(start + _blockSize, length);
-            double mScale = st.MScale[b];
-            double vScale = st.VScale[b];
-            double newMMaxAbs = 0.0, newVMax = 0.0;
-
-            for (int i = start; i < end; i++)
-            {
-                int li = i - start;
-                double gi = g[i];
-                double mPrev = (mQ[i] - 128) * mScale;
-                double vPrev = vQ[i] * vScale;
-
-                if (double.IsNaN(gi) || double.IsInfinity(gi))
-                {
-                    mNew[li] = mPrev; vNew[li] = vPrev;
-                }
-                else
-                {
-                    double m = beta1 * mPrev + oneMinusB1 * gi;
-                    double v = beta2 * vPrev + oneMinusB2 * gi * gi;
-                    double mHat = m * invBc1;
-                    double vHat = v * invBc2;
-                    double pv = p[i];
-                    if (wd != 0.0) pv -= lr * wd * pv;
-                    double update = lr * mHat / (Math.Sqrt(vHat) + eps);
-                    if (!(update >= -maxStep)) update = update > 0 ? maxStep : -maxStep;
-                    else if (update > maxStep) update = maxStep;
-                    p[i] = (float)(pv - update);
-                    mNew[li] = m; vNew[li] = v;
-                }
-                double am = Math.Abs(mNew[li]);
-                if (am > newMMaxAbs) newMMaxAbs = am;
-                if (vNew[li] > newVMax) newVMax = vNew[li];
-            }
-
-            double newMScale = newMMaxAbs / 127.0; if (newMScale < 1e-10) newMScale = 1e-10;
-            double newVScale = newVMax / 255.0;     if (newVScale < 1e-10) newVScale = 1e-10;
-            st.MScale[b] = newMScale; st.VScale[b] = newVScale;
-            double invM = 1.0 / newMScale, invV = 1.0 / newVScale;
-
-            for (int i = start; i < end; i++)
-            {
-                int li = i - start;
-                int mq = (int)Math.Round(mNew[li] * invM);
-                if (mq < -127) mq = -127; else if (mq > 127) mq = 127;
-                mQ[i] = (byte)(mq + 128);
-                int vq = (int)Math.Round(vNew[li] * invV);
-                if (vq < 0) vq = 0; else if (vq > 255) vq = 255;
-                vQ[i] = (byte)vq;
-            }
+            double denom = gradNorm + _weightDecay * paramNorm + _epsilon;
+            _localLearningRate = LearningRate * _trustCoefficient * paramNorm / denom;
+        }
+        else
+        {
+            _localLearningRate = LearningRate;
         }
     }
 
-    private void ApplyGeneric(
-        Tensor<T> param, Tensor<T> grad, MomentState st,
-        int numBlocks, int length, double biasCorr1, double biasCorr2)
+    protected override double UpdateElement(double parameter, double gradient, ReadOnlySpan<double> moments, Span<double> nextMoments, int index)
     {
-        double[] mNew = _mScratch, vNew = _vScratch;
-        double maxStep = _lr * _maxUpdateRatio;
+        double gradWithDecay = gradient + _weightDecay * parameter;
+        double scaledGrad = _localLearningRate * gradWithDecay;
+        double velocity = _momentum * moments[0] + scaledGrad;
+        nextMoments[0] = velocity;
 
-        for (int b = 0; b < numBlocks; b++)
+        double update = _useNesterov ? _momentum * velocity + scaledGrad : velocity;
+        return parameter - ClampUpdate(update);
+    }
+}
+
+internal sealed class StreamingLamb8Bit<T> : BlockQuantizedStreamingOptimizer<T>
+{
+    private readonly double _beta1;
+    private readonly double _beta2;
+    private readonly double _epsilon;
+    private readonly double _weightDecay;
+    private readonly bool _clipTrustRatio;
+    private readonly double _maxTrustRatio;
+    private readonly bool _useBiasCorrection;
+    private double _trustRatio = 1.0;
+
+    public StreamingLamb8Bit(
+        double learningRate,
+        double beta1,
+        double beta2,
+        double epsilon,
+        double weightDecay,
+        bool clipTrustRatio,
+        double maxTrustRatio,
+        bool useBiasCorrection)
+        : base(nameof(StreamingLamb8Bit<T>), learningRate, new[] { true, false })
+    {
+        _beta1 = beta1;
+        _beta2 = beta2;
+        _epsilon = epsilon;
+        _weightDecay = weightDecay;
+        _clipTrustRatio = clipTrustRatio;
+        _maxTrustRatio = maxTrustRatio;
+        _useBiasCorrection = useBiasCorrection;
+    }
+
+    protected override void PrepareParameter(Tensor<T> param, Tensor<T> grad, QuantizedState state, int length)
+    {
+        double paramNormSq = 0.0;
+        double updateNormSq = 0.0;
+        double biasCorr1 = _useBiasCorrection ? 1.0 - Math.Pow(_beta1, Step) : 1.0;
+        double biasCorr2 = _useBiasCorrection ? 1.0 - Math.Pow(_beta2, Step) : 1.0;
+        if (biasCorr1 <= 0.0) biasCorr1 = 1.0;
+        if (biasCorr2 <= 0.0) biasCorr2 = 1.0;
+
+        for (int i = 0; i < length; i++)
         {
-            int start = b * _blockSize;
-            int end = Math.Min(start + _blockSize, length);
-            double mScale = st.MScale[b];
-            double vScale = st.VScale[b];
-            double newMMaxAbs = 0.0, newVMax = 0.0;
+            double p = ToDouble(param[i]);
+            double g = ToDouble(grad[i]);
+            if (double.IsNaN(g) || double.IsInfinity(g)) continue;
 
-            for (int i = start; i < end; i++)
-            {
-                int li = i - start;
-                double g = _ops.ToDouble(grad[i]);
-                double mPrev = (st.MQuant[i] - 128) * mScale;
-                double vPrev = st.VQuant[i] * vScale;
-
-                if (double.IsNaN(g) || double.IsInfinity(g))
-                {
-                    mNew[li] = mPrev; vNew[li] = vPrev;
-                }
-                else
-                {
-                    double m = _beta1 * mPrev + (1.0 - _beta1) * g;
-                    double v = _beta2 * vPrev + (1.0 - _beta2) * g * g;
-                    double mHat = m / biasCorr1;
-                    double vHat = v / biasCorr2;
-                    double p = _ops.ToDouble(param[i]);
-                    if (_weightDecay != 0.0) p -= _lr * _weightDecay * p;
-                    double update = _lr * mHat / (Math.Sqrt(vHat) + _epsilon);
-                    if (!(update >= -maxStep)) update = update > 0 ? maxStep : -maxStep;
-                    else if (update > maxStep) update = maxStep;
-                    param[i] = _ops.FromDouble(p - update);
-                    mNew[li] = m; vNew[li] = v;
-                }
-                double am = Math.Abs(mNew[li]);
-                if (am > newMMaxAbs) newMMaxAbs = am;
-                if (vNew[li] > newVMax) newVMax = vNew[li];
-            }
-
-            double newMScale = newMMaxAbs / 127.0; if (newMScale < 1e-10) newMScale = 1e-10;
-            double newVScale = newVMax / 255.0;     if (newVScale < 1e-10) newVScale = 1e-10;
-            st.MScale[b] = newMScale; st.VScale[b] = newVScale;
-
-            for (int i = start; i < end; i++)
-            {
-                int li = i - start;
-                int mq = (int)Math.Round(mNew[li] / newMScale);
-                if (mq < -127) mq = -127; else if (mq > 127) mq = 127;
-                st.MQuant[i] = (byte)(mq + 128);
-                int vq = (int)Math.Round(vNew[li] / newVScale);
-                if (vq < 0) vq = 0; else if (vq > 255) vq = 255;
-                st.VQuant[i] = (byte)vq;
-            }
+            double m = _beta1 * Dequantize(state, 0, i) + (1.0 - _beta1) * g;
+            double v = _beta2 * Dequantize(state, 1, i) + (1.0 - _beta2) * g * g;
+            double update = (m / biasCorr1) / (Math.Sqrt(v / biasCorr2) + _epsilon) + _weightDecay * p;
+            paramNormSq += p * p;
+            updateNormSq += update * update;
         }
+
+        double paramNorm = Math.Sqrt(paramNormSq);
+        double updateNorm = Math.Sqrt(updateNormSq);
+        if (paramNorm > 0.0 && updateNorm > 0.0)
+        {
+            _trustRatio = paramNorm / updateNorm;
+            if (_clipTrustRatio && _trustRatio > _maxTrustRatio)
+                _trustRatio = _maxTrustRatio;
+        }
+        else
+        {
+            _trustRatio = 1.0;
+        }
+    }
+
+    protected override double UpdateElement(double parameter, double gradient, ReadOnlySpan<double> moments, Span<double> nextMoments, int index)
+    {
+        double m = _beta1 * moments[0] + (1.0 - _beta1) * gradient;
+        double v = _beta2 * moments[1] + (1.0 - _beta2) * gradient * gradient;
+        nextMoments[0] = m;
+        nextMoments[1] = v;
+
+        double biasCorr1 = _useBiasCorrection ? 1.0 - Math.Pow(_beta1, Step) : 1.0;
+        double biasCorr2 = _useBiasCorrection ? 1.0 - Math.Pow(_beta2, Step) : 1.0;
+        if (biasCorr1 <= 0.0) biasCorr1 = 1.0;
+        if (biasCorr2 <= 0.0) biasCorr2 = 1.0;
+
+        double update = (m / biasCorr1) / (Math.Sqrt(v / biasCorr2) + _epsilon) + _weightDecay * parameter;
+        return parameter - ClampUpdate(LearningRate * _trustRatio * update);
+    }
+}
+
+internal sealed class StreamingFtrl8Bit<T> : BlockQuantizedStreamingOptimizer<T>
+{
+    private readonly double _alpha;
+    private readonly double _beta;
+    private readonly double _lambda1;
+    private readonly double _lambda2;
+
+    public StreamingFtrl8Bit(double alpha, double beta, double lambda1, double lambda2)
+        : base(nameof(StreamingFtrl8Bit<T>), alpha, new[] { true, false })
+    {
+        _alpha = alpha;
+        _beta = beta;
+        _lambda1 = lambda1;
+        _lambda2 = lambda2;
+    }
+
+    protected override double UpdateElement(double parameter, double gradient, ReadOnlySpan<double> moments, Span<double> nextMoments, int index)
+    {
+        double z = moments[0];
+        double n = moments[1];
+        double nNew = n + gradient * gradient;
+        double sigma = (Math.Sqrt(nNew) - Math.Sqrt(n)) / _alpha;
+        double zNew = z + gradient - sigma * parameter;
+
+        nextMoments[0] = zNew;
+        nextMoments[1] = nNew;
+
+        if (Math.Abs(zNew) <= _lambda1)
+            return 0.0;
+
+        double numerator = -Math.Sign(zNew) * (Math.Abs(zNew) - _lambda1);
+        double denominator = _lambda2 + (Math.Sqrt(nNew) + _beta) / _alpha;
+        return numerator / denominator;
+    }
+}
+
+internal static class StreamingOptimizerResolver<T>
+{
+    public static string BuildKey(
+        IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>> optimizer,
+        bool useStreamingDefaults,
+        double streamingWeightDecay)
+    {
+        string type = useStreamingDefaults ? "DefaultAdam" : optimizer.GetType().FullName ?? optimizer.GetType().Name;
+        object? options = GetOptionsObject(optimizer);
+        return string.Join("|",
+            type,
+            ReadDouble(options, "Beta1", 0.9),
+            ReadDouble(options, "Beta2", 0.999),
+            ReadDouble(options, "Epsilon", 1e-8),
+            ReadDouble(options, "Decay", 0.9),
+            ReadDouble(options, "Rho", 0.95),
+            ReadDouble(options, "InitialMomentum", ReadDouble(options, "Momentum", 0.9)),
+            ReadDouble(options, "WeightDecay", streamingWeightDecay),
+            ReadDouble(options, "TrustCoefficient", 0.001),
+            ReadDouble(options, "Alpha", 0.005),
+            ReadDouble(options, "Lambda1", 1.0),
+            ReadDouble(options, "Lambda2", 1.0),
+            ReadBool(options, "UseAMSGrad", false),
+            ReadBool(options, "UseNesterov", false),
+            ReadBool(options, "ClipTrustRatio", true),
+            ReadDouble(options, "MaxTrustRatio", 10.0),
+            ReadBool(options, "UseBiasCorrection", true));
+    }
+
+    public static IStreamingOptimizer<T> Create(
+        IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>> optimizer,
+        bool useStreamingDefaults,
+        double fallbackLearningRate,
+        double fallbackWeightDecay)
+    {
+        object? options = GetOptionsObject(optimizer);
+        double lr = useStreamingDefaults ? fallbackLearningRate : ResolveLearningRate(optimizer, fallbackLearningRate);
+
+        if (useStreamingDefaults)
+        {
+            return new StreamingAdam8Bit<T>(lr, weightDecay: fallbackWeightDecay);
+        }
+
+        switch (optimizer)
+        {
+            case AdamWOptimizer<T, Tensor<T>, Tensor<T>>:
+                if (ReadBool(options, "UseAMSGrad", false))
+                    return new StreamingAMSGrad8Bit<T>(lr, ReadDouble(options, "Beta1", 0.9), ReadDouble(options, "Beta2", 0.999), ReadDouble(options, "Epsilon", 1e-8), ReadDouble(options, "WeightDecay", 0.01));
+                return new StreamingAdamW8Bit<T>(lr, ReadDouble(options, "Beta1", 0.9), ReadDouble(options, "Beta2", 0.999), ReadDouble(options, "Epsilon", 1e-8), ReadDouble(options, "WeightDecay", 0.01));
+            case AdamOptimizer<T, Tensor<T>, Tensor<T>>:
+                if (ReadBool(options, "UseAMSGrad", false))
+                    return new StreamingAMSGrad8Bit<T>(lr, ReadDouble(options, "Beta1", 0.9), ReadDouble(options, "Beta2", 0.999), ReadDouble(options, "Epsilon", 1e-8), fallbackWeightDecay);
+                return new StreamingAdam8Bit<T>(lr, ReadDouble(options, "Beta1", 0.9), ReadDouble(options, "Beta2", 0.999), ReadDouble(options, "Epsilon", 1e-8), fallbackWeightDecay);
+            case AMSGradOptimizer<T, Tensor<T>, Tensor<T>>:
+                return new StreamingAMSGrad8Bit<T>(lr, ReadDouble(options, "Beta1", 0.9), ReadDouble(options, "Beta2", 0.999), ReadDouble(options, "Epsilon", 1e-8), 0.0);
+            case NadamOptimizer<T, Tensor<T>, Tensor<T>>:
+                return new StreamingNadam8Bit<T>(lr, ReadDouble(options, "Beta1", 0.9), ReadDouble(options, "Beta2", 0.999), ReadDouble(options, "Epsilon", 1e-8));
+            case AdaMaxOptimizer<T, Tensor<T>, Tensor<T>>:
+                return new StreamingAdaMax8Bit<T>(lr, ReadDouble(options, "Beta1", 0.9), ReadDouble(options, "Beta2", 0.999), ReadDouble(options, "Epsilon", 1e-8));
+            case LionOptimizer<T, Tensor<T>, Tensor<T>>:
+                return new StreamingLion8Bit<T>(lr, ReadDouble(options, "Beta1", 0.9), ReadDouble(options, "Beta2", 0.99), ReadDouble(options, "WeightDecay", 0.0));
+            case LAMBOptimizer<T, Tensor<T>, Tensor<T>>:
+                return new StreamingLamb8Bit<T>(lr, ReadDouble(options, "Beta1", 0.9), ReadDouble(options, "Beta2", 0.999), ReadDouble(options, "Epsilon", 1e-6), ReadDouble(options, "WeightDecay", 0.01), ReadBool(options, "ClipTrustRatio", true), ReadDouble(options, "MaxTrustRatio", 10.0), ReadBool(options, "UseBiasCorrection", true));
+            case LARSOptimizer<T, Tensor<T>, Tensor<T>>:
+                return new StreamingLars8Bit<T>(lr, ReadDouble(options, "Momentum", 0.9), ReadDouble(options, "WeightDecay", 1e-4), ReadDouble(options, "TrustCoefficient", 0.001), ReadDouble(options, "Epsilon", 1e-8), ReadBool(options, "UseNesterov", false));
+            case FTRLOptimizer<T, Tensor<T>, Tensor<T>>:
+                return new StreamingFtrl8Bit<T>(ReadDouble(options, "Alpha", lr), ReadDouble(options, "Beta", 1.0), ReadDouble(options, "Lambda1", 1.0), ReadDouble(options, "Lambda2", 1.0));
+            case AdaDeltaOptimizer<T, Tensor<T>, Tensor<T>>:
+                return new StreamingAdaDelta8Bit<T>(lr, ReadDouble(options, "Rho", 0.95), ReadDouble(options, "Epsilon", 1e-6));
+            case AdagradOptimizer<T, Tensor<T>, Tensor<T>>:
+                return new StreamingAdagrad8Bit<T>(lr, ReadDouble(options, "Epsilon", 1e-8));
+            case RootMeanSquarePropagationOptimizer<T, Tensor<T>, Tensor<T>>:
+                return new StreamingRmsProp8Bit<T>(lr, ReadDouble(options, "Decay", 0.9), ReadDouble(options, "Epsilon", 1e-8));
+            case MomentumOptimizer<T, Tensor<T>, Tensor<T>>:
+                return new StreamingMomentum8Bit<T>(lr, ReadDouble(options, "InitialMomentum", 0.9));
+            case NesterovAcceleratedGradientOptimizer<T, Tensor<T>, Tensor<T>>:
+                return new StreamingNesterov8Bit<T>(lr, ReadDouble(options, "InitialMomentum", 0.9));
+            case GradientDescentOptimizer<T, Tensor<T>, Tensor<T>>:
+            case StochasticGradientDescentOptimizer<T, Tensor<T>, Tensor<T>>:
+            case MiniBatchGradientDescentOptimizer<T, Tensor<T>, Tensor<T>>:
+            case ProximalGradientDescentOptimizer<T, Tensor<T>, Tensor<T>>:
+                return new StreamingSgd8Bit<T>(lr);
+            default:
+                return new StreamingAdam8Bit<T>(fallbackLearningRate, weightDecay: fallbackWeightDecay);
+        }
+    }
+
+    public static void RefreshLearningRate(
+        IStreamingOptimizer<T> streamingOptimizer,
+        IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>> optimizer,
+        bool useStreamingDefaults,
+        double fallbackLearningRate)
+    {
+        if (streamingOptimizer is IStreamingOptimizerLearningRate mutable)
+        {
+            mutable.SetLearningRate(useStreamingDefaults
+                ? fallbackLearningRate
+                : ResolveLearningRate(optimizer, fallbackLearningRate));
+        }
+    }
+
+    private static double ResolveLearningRate(
+        IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>> optimizer,
+        double fallbackLearningRate)
+    {
+        if (optimizer is GradientBasedOptimizerBase<T, Tensor<T>, Tensor<T>> gradientBased)
+        {
+            return gradientBased.GetCurrentLearningRate();
+        }
+
+        return fallbackLearningRate;
+    }
+
+    private static object? GetOptionsObject(object optimizer)
+    {
+        Type? type = optimizer.GetType();
+        while (type is not null)
+        {
+            foreach (var field in type.GetFields(BindingFlags.Instance | BindingFlags.NonPublic))
+            {
+                if (!field.Name.Contains("options", StringComparison.OrdinalIgnoreCase))
+                    continue;
+                object? value = field.GetValue(optimizer);
+                if (value is not null)
+                    return value;
+            }
+
+            type = type.BaseType;
+        }
+
+        return null;
+    }
+
+    private static double ReadDouble(object? options, string propertyName, double fallback)
+    {
+        object? value = ReadProperty(options, propertyName);
+        if (value is null) return fallback;
+        try
+        {
+            return Convert.ToDouble(value);
+        }
+        catch
+        {
+            return fallback;
+        }
+    }
+
+    private static bool ReadBool(object? options, string propertyName, bool fallback)
+    {
+        object? value = ReadProperty(options, propertyName);
+        return value is bool b ? b : fallback;
+    }
+
+    private static object? ReadProperty(object? options, string propertyName)
+    {
+        if (options is null) return null;
+        var property = options.GetType().GetProperty(propertyName, BindingFlags.Instance | BindingFlags.Public);
+        return property?.GetValue(options);
     }
 }

--- a/src/Training/StreamingLBFGS.cs
+++ b/src/Training/StreamingLBFGS.cs
@@ -1,0 +1,263 @@
+// Copyright (c) AiDotNet. All rights reserved.
+
+using System;
+using System.Collections.Generic;
+using AiDotNet.Helpers;
+using AiDotNet.Tensors.Interfaces;
+using AiDotNet.Tensors.LinearAlgebra;
+
+namespace AiDotNet.Training;
+
+/// <summary>
+/// Memory-bounded streaming L-BFGS — the second-order entry in the streaming optimizer family.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Unlike the first-order streaming optimizers (which update each parameter in place as its
+/// gradient is produced), L-BFGS computes a search direction from the WHOLE gradient plus a
+/// curvature history, so it can't update per-parameter-as-gradient-arrives. Instead it buffers
+/// the per-parameter gradients/params into flat vectors during <see cref="Apply"/> and performs
+/// the two-loop recursion + parameter update once per step in <see cref="EndStep"/>.
+/// </para>
+/// <para>
+/// <b>The memory win:</b> the (s, y) curvature history — <c>MemorySize</c> vectors of length n
+/// each, O(m·n) — is the dominant memory cost of L-BFGS. Here it's stored 8-bit block-quantized
+/// (one signed int8 per element + one fp64 scale per block), ~8× smaller than fp64. The history
+/// is dequantized ON DEMAND, one vector at a time into a reused O(n) buffer, so the two-loop's
+/// transient memory stays O(n) rather than O(m·n). Full BFGS/Newton (O(n²) / dense Hessian) are
+/// intentionally not provided — they don't fit memory-bounded large-model training.
+/// </para>
+/// </remarks>
+internal sealed class StreamingLBFGS<T> : IStreamingOptimizer<T>, IStreamingOptimizerLearningRate
+{
+    private readonly INumericOperations<T> _ops = MathHelper.GetNumericOperations<T>();
+    private readonly int _memorySize;
+    private readonly int _blockSize;
+    private double _learningRate;
+
+    // Stable per-step layout of the parameter tensors + their slices in the flat buffers.
+    private readonly List<(Tensor<T> Param, int Offset, int Length)> _layout = new();
+    private double[] _gradFlat = Array.Empty<double>();
+    private double[] _paramFlat = Array.Empty<double>();
+    private int _writeOffset;
+
+    // 8-bit block-quantized history (the memory win) + the O(n) previous gradient for y = g - g_prev.
+    private readonly List<QuantVec> _sHist = new();
+    private readonly List<QuantVec> _yHist = new();
+    private double[]? _prevGrad;
+
+    // O(n) reused scratch so the two-loop's dequant stays O(n) transient (not O(m·n)).
+    private double[] _q = Array.Empty<double>();
+    private double[] _tmpS = Array.Empty<double>();
+    private double[] _tmpY = Array.Empty<double>();
+
+    public StreamingLBFGS(double learningRate, int memorySize = 10, int blockSize = 2048)
+    {
+        _learningRate = learningRate;
+        _memorySize = Math.Max(1, memorySize);
+        _blockSize = Math.Max(1, blockSize);
+    }
+
+    public void SetLearningRate(double learningRate)
+    {
+        if (learningRate > 0 && !double.IsNaN(learningRate) && !double.IsInfinity(learningRate))
+            _learningRate = learningRate;
+    }
+
+    public void BeginStep()
+    {
+        _layout.Clear();
+        _writeOffset = 0;
+    }
+
+    public void Apply(Tensor<T> param, Tensor<T> grad)
+    {
+        if (param is null) throw new ArgumentNullException(nameof(param));
+        if (grad is null) throw new ArgumentNullException(nameof(grad));
+        int len = param.Length;
+        if (grad.Length != len)
+            throw new ArgumentException($"StreamingLBFGS.Apply: gradient length {grad.Length} does not match param length {len}.", nameof(grad));
+
+        EnsureFlatCapacity(_writeOffset + len);
+        _layout.Add((param, _writeOffset, len));
+        for (int i = 0; i < len; i++)
+        {
+            _gradFlat[_writeOffset + i] = _ops.ToDouble(grad[i]);
+            _paramFlat[_writeOffset + i] = _ops.ToDouble(param[i]);
+        }
+        _writeOffset += len;
+    }
+
+    public void EndStep()
+    {
+        int n = _writeOffset;
+        if (n == 0) return;
+        EnsureScratch(n);
+
+        // Search direction d = H_k * g (gradient descent on the first step, before any history).
+        var d = TwoLoopDirection(n);
+
+        // s = x_new - x = -lr*d (computed into _tmpS); write x_new = x + s back to the live tensors.
+        for (int i = 0; i < n; i++)
+        {
+            double step = _learningRate * d[i];
+            _tmpS[i] = (double.IsNaN(step) || double.IsInfinity(step)) ? 0.0 : -step;
+        }
+        Scatter(_tmpS);
+
+        // Curvature pair: y = g - g_prev. Only store a positive-curvature (s·y > 0) pair so the
+        // implicit Hessian approximation stays positive-definite (standard L-BFGS skip rule).
+        if (_prevGrad is not null)
+        {
+            for (int i = 0; i < n; i++) _tmpY[i] = _gradFlat[i] - _prevGrad[i];
+            if (Dot(_tmpS, _tmpY, n) > 1e-12)
+                PushHistory(_tmpS, _tmpY, n);
+        }
+
+        if (_prevGrad is null || _prevGrad.Length < n) _prevGrad = new double[n];
+        Array.Copy(_gradFlat, _prevGrad, n);
+    }
+
+    private double[] TwoLoopDirection(int n)
+    {
+        Array.Copy(_gradFlat, _q, n); // q = g
+        int k = _sHist.Count;
+        if (k == 0)
+        {
+            var d0 = new double[n];
+            Array.Copy(_q, d0, n);
+            return d0; // plain gradient descent until curvature is available
+        }
+
+        var alpha = new double[k];
+        var rho = new double[k];
+
+        for (int i = k - 1; i >= 0; i--) // recent → old
+        {
+            Dequantize(_sHist[i], _tmpS, n);
+            Dequantize(_yHist[i], _tmpY, n);
+            double ys = Dot(_tmpY, _tmpS, n);
+            rho[i] = ys != 0.0 ? 1.0 / ys : 0.0;
+            alpha[i] = rho[i] * Dot(_tmpS, _q, n);
+            Axpy(_q, _tmpY, -alpha[i], n); // q -= alpha_i * y_i
+        }
+
+        // H0 = gamma·I, gamma = (s·y)/(y·y) of the most recent pair (Nocedal & Wright).
+        Dequantize(_sHist[k - 1], _tmpS, n);
+        Dequantize(_yHist[k - 1], _tmpY, n);
+        double yy = Dot(_tmpY, _tmpY, n);
+        double gamma = yy > 0.0 ? Dot(_tmpS, _tmpY, n) / yy : 1.0;
+        if (gamma <= 0.0 || double.IsNaN(gamma) || double.IsInfinity(gamma)) gamma = 1.0;
+
+        var r = new double[n];
+        for (int i = 0; i < n; i++) r[i] = gamma * _q[i];
+
+        for (int i = 0; i < k; i++) // old → recent
+        {
+            Dequantize(_sHist[i], _tmpS, n);
+            Dequantize(_yHist[i], _tmpY, n);
+            double beta = rho[i] * Dot(_tmpY, r, n);
+            Axpy(r, _tmpS, alpha[i] - beta, n); // r += (alpha_i - beta) * s_i
+        }
+        return r;
+    }
+
+    private void Scatter(double[] delta)
+    {
+        foreach (var (param, offset, length) in _layout)
+        {
+            for (int i = 0; i < length; i++)
+            {
+                double next = _ops.ToDouble(param[i]) + delta[offset + i];
+                param[i] = _ops.FromDouble(next);
+            }
+        }
+    }
+
+    private void PushHistory(double[] s, double[] y, int n)
+    {
+        _sHist.Add(Quantize(s, n));
+        _yHist.Add(Quantize(y, n));
+        while (_sHist.Count > _memorySize)
+        {
+            _sHist.RemoveAt(0);
+            _yHist.RemoveAt(0);
+        }
+    }
+
+    private sealed class QuantVec
+    {
+        public byte[] Quantized = Array.Empty<byte>();
+        public double[] Scales = Array.Empty<double>();
+    }
+
+    private QuantVec Quantize(double[] v, int n)
+    {
+        int numBlocks = (n + _blockSize - 1) / _blockSize;
+        var q = new byte[n];
+        var scales = new double[numBlocks];
+        for (int b = 0; b < numBlocks; b++)
+        {
+            int start = b * _blockSize, end = Math.Min(start + _blockSize, n);
+            double max = 0.0;
+            for (int i = start; i < end; i++)
+            {
+                double a = Math.Abs(v[i]);
+                if (!double.IsNaN(a) && !double.IsInfinity(a) && a > max) max = a;
+            }
+            double scale = max / 127.0;
+            if (scale < 1e-12 || double.IsNaN(scale) || double.IsInfinity(scale)) scale = 1e-12;
+            scales[b] = scale;
+            double inv = 1.0 / scale;
+            for (int i = start; i < end; i++)
+            {
+                int qi = (int)Math.Round(v[i] * inv);
+                if (qi < -127) qi = -127; else if (qi > 127) qi = 127;
+                q[i] = (byte)(qi + 128);
+            }
+        }
+        return new QuantVec { Quantized = q, Scales = scales };
+    }
+
+    private void Dequantize(QuantVec qv, double[] dst, int n)
+    {
+        for (int b = 0; b * _blockSize < n; b++)
+        {
+            int start = b * _blockSize, end = Math.Min(start + _blockSize, n);
+            double scale = qv.Scales[b];
+            for (int i = start; i < end; i++) dst[i] = (qv.Quantized[i] - 128) * scale;
+        }
+    }
+
+    private static double Dot(double[] a, double[] b, int n)
+    {
+        double s = 0.0;
+        for (int i = 0; i < n; i++) s += a[i] * b[i];
+        return s;
+    }
+
+    private static void Axpy(double[] y, double[] x, double a, int n)
+    {
+        for (int i = 0; i < n; i++) y[i] += a * x[i];
+    }
+
+    private void EnsureFlatCapacity(int needed)
+    {
+        if (_gradFlat.Length < needed)
+        {
+            int cap = Math.Max(needed, _gradFlat.Length == 0 ? needed : _gradFlat.Length * 2);
+            Array.Resize(ref _gradFlat, cap);
+            Array.Resize(ref _paramFlat, cap);
+        }
+    }
+
+    private void EnsureScratch(int n)
+    {
+        if (_q.Length < n)
+        {
+            _q = new double[n];
+            _tmpS = new double[n];
+            _tmpY = new double[n];
+        }
+    }
+}

--- a/tests/AiDotNet.Tests/UnitTests/Training/StreamingOptimizerParityTests.cs
+++ b/tests/AiDotNet.Tests/UnitTests/Training/StreamingOptimizerParityTests.cs
@@ -311,4 +311,80 @@ public class StreamingOptimizerParityTests
         double rel = RelL2(sa, rp);
         Assert.True(rel < 0.10, $"Streaming L-BFGS (8-bit history) drifted from fp64 L-BFGS (relL2 {rel:E3} >= 0.10).");
     }
+
+    private static double[] GradN(int n, int step)
+    {
+        var g = new double[n];
+        uint s = (uint)(step * 2654435761u + 12345u);
+        for (int i = 0; i < n; i++)
+        {
+            s ^= s << 13; s ^= s >> 17; s ^= s << 5;
+            g[i] = ((s & 0xFFFF) / 65535.0 - 0.5) * 0.2;
+        }
+        return g;
+    }
+
+    private static double[] InitParamsN(int n)
+    {
+        var p = new double[n];
+        uint s = 99u;
+        for (int i = 0; i < n; i++) { s ^= s << 13; s ^= s >> 17; s ^= s << 5; p[i] = ((s & 0xFFFF) / 65535.0 - 0.5); }
+        return p;
+    }
+
+    private static double[] RunAdamLarge(int n)
+    {
+        var opt = new StreamingAdam8Bit<double>(Lr);
+        var p = new Tensor<double>(new[] { n });
+        var init = InitParamsN(n);
+        for (int i = 0; i < n; i++) p[i] = init[i];
+        for (int step = 1; step <= Steps; step++)
+        {
+            var g = GradN(n, step);
+            opt.BeginStep();
+            var gt = new Tensor<double>(new[] { n });
+            for (int i = 0; i < n; i++) gt[i] = g[i];
+            opt.Apply(p, gt);
+            opt.EndStep();
+        }
+        var outArr = new double[n];
+        for (int i = 0; i < n; i++) outArr[i] = p[i];
+        return outArr;
+    }
+
+    // The block loop parallelizes over DISJOINT parameter slices, so for a parameter large enough
+    // to take the parallel path (40000 > the 1<<15 threshold) the result must (a) still track the
+    // fp64 Adam reference within the same tolerance as the small serial case — no drift from a race
+    // — and (b) be perfectly reproducible across runs — no nondeterminism from a race.
+    [Fact]
+    public void Adam_LargeTensor_ParallelBlockLoop_TracksFp64AndIsDeterministic()
+    {
+        const int n = 40000;
+
+        // fp64 reference (independent of the streaming optimizer).
+        var refParam = InitParamsN(n);
+        var m = new double[n];
+        var v = new double[n];
+        for (int step = 1; step <= Steps; step++)
+        {
+            var g = GradN(n, step);
+            double c1 = 1 - Math.Pow(0.9, step), c2 = 1 - Math.Pow(0.999, step);
+            for (int i = 0; i < n; i++)
+            {
+                m[i] = 0.9 * m[i] + 0.1 * g[i];
+                v[i] = 0.999 * v[i] + 0.001 * g[i] * g[i];
+                refParam[i] -= Lr * (m[i] / c1) / (Math.Sqrt(v[i] / c2) + 1e-8);
+            }
+        }
+
+        var run1 = RunAdamLarge(n);
+        double rel = RelL2(run1, refParam);
+        Assert.True(rel < 0.05, $"Adam (parallel block loop, n={n}) drifted from fp64 reference (relL2 {rel:E3} >= 0.05).");
+
+        // Determinism: a second identical run must be bit-for-bit identical (a data race in the
+        // parallel loop would surface here as a mismatch).
+        var run2 = RunAdamLarge(n);
+        for (int i = 0; i < n; i++)
+            Assert.Equal(run1[i], run2[i]);
+    }
 }

--- a/tests/AiDotNet.Tests/UnitTests/Training/StreamingOptimizerParityTests.cs
+++ b/tests/AiDotNet.Tests/UnitTests/Training/StreamingOptimizerParityTests.cs
@@ -387,4 +387,49 @@ public class StreamingOptimizerParityTests
         for (int i = 0; i < n; i++)
             Assert.Equal(run1[i], run2[i]);
     }
+
+    // Proves the parallel block loop actually takes the raw LIVE-backing-array branch (the perf
+    // win) rather than silently falling back to the per-element indexer. ApplyBlocks computes
+    // `paramArr = param.GetLiveBackingArrayOrNull()` (after a one-time `param[0]` materialization
+    // touch) and uses raw array writes iff that is non-null. We reproduce that exact call on the
+    // same tensor instances the optimizer receives and assert it is non-null — and that the array
+    // we capture beforehand is the one mutated in place by training.
+    [Fact]
+    public void Adam_LargeTensor_TakesLiveBackingArrayFastPath()
+    {
+        const int n = 40000;
+        var param = new Tensor<double>(new[] { n });
+        var init = InitParamsN(n);
+        for (int i = 0; i < n; i++) param[i] = init[i];
+
+        _ = param[0]; // identical to the optimizer's materialization touch before the fast-path probe
+        var liveProbe = param.GetLiveBackingArrayOrNull();
+        Assert.NotNull(liveProbe); // non-null => ApplyBlocks takes the raw-array branch, not the indexer fallback
+        double[] live = liveProbe ?? throw new InvalidOperationException("param exposed no live backing array");
+
+        // A gradient tensor built the same way must also expose its live array (so gradArr != null).
+        var grad = new Tensor<double>(new[] { n });
+        var g0 = GradN(n, 1);
+        for (int i = 0; i < n; i++) grad[i] = g0[i];
+        _ = grad[0];
+        Assert.NotNull(grad.GetLiveBackingArrayOrNull());
+
+        // End-to-end: train, then confirm the captured live array was mutated in place and still
+        // aliases the tensor's logical values (i.e. the raw writes landed in the real storage).
+        var opt = new StreamingAdam8Bit<double>(Lr);
+        for (int step = 1; step <= Steps; step++)
+        {
+            opt.BeginStep();
+            var g = GradN(n, step);
+            var gt = new Tensor<double>(new[] { n });
+            for (int i = 0; i < n; i++) gt[i] = g[i];
+            opt.Apply(param, gt);
+            opt.EndStep();
+        }
+
+        bool changed = false;
+        for (int i = 0; i < n; i++) if (live[i] != init[i]) { changed = true; break; }
+        Assert.True(changed, "optimizer did not mutate the live backing array in place");
+        for (int i = 0; i < n; i++) Assert.Equal(param[i], live[i]);
+    }
 }

--- a/tests/AiDotNet.Tests/UnitTests/Training/StreamingOptimizerParityTests.cs
+++ b/tests/AiDotNet.Tests/UnitTests/Training/StreamingOptimizerParityTests.cs
@@ -1,0 +1,236 @@
+// Copyright (c) AiDotNet. All rights reserved.
+
+using System;
+using AiDotNet.LinearAlgebra;
+using AiDotNet.Training;
+using Xunit;
+
+namespace AiDotNet.Tests.UnitTests.Training;
+
+/// <summary>
+/// Parity tests for the 8-bit block-quantized streaming optimizers (#1600 acceptance criterion:
+/// "each streaming variant matches its full-precision counterpart within tolerance over N steps").
+/// Each streaming optimizer is run against an INDEPENDENT fp64 reference of the SAME canonical
+/// update rule, on the same fixed gradient sequence; the test asserts the 8-bit parameter
+/// trajectory tracks the fp64 one within a bounded relative error — i.e. the rule is correct AND
+/// the per-block 8-bit moment quantization doesn't drift/diverge over many steps.
+/// </summary>
+public class StreamingOptimizerParityTests
+{
+    private const int N = 512;     // one 2048-block, so per-block scale behaviour is exercised
+    private const int Steps = 60;
+    private const double Lr = 1e-2;
+
+    // Per-element fp64 reference update: (param, grad, state[]) -> newParam, mutating state in place.
+    private delegate double RefUpdate(double param, double grad, double[] state, int step);
+
+    private static double[] Grad(int step)
+    {
+        var g = new double[N];
+        uint s = (uint)(step * 2654435761u + 12345u);
+        for (int i = 0; i < N; i++)
+        {
+            s ^= s << 13; s ^= s >> 17; s ^= s << 5;
+            g[i] = ((s & 0xFFFF) / 65535.0 - 0.5) * 0.2; // ~[-0.1, 0.1]
+        }
+        return g;
+    }
+
+    private static double[] InitParams()
+    {
+        var p = new double[N];
+        uint s = 99u;
+        for (int i = 0; i < N; i++) { s ^= s << 13; s ^= s >> 17; s ^= s << 5; p[i] = ((s & 0xFFFF) / 65535.0 - 0.5); }
+        return p;
+    }
+
+    private static double RelL2(double[] a, double[] b)
+    {
+        double num = 0, den = 0;
+        for (int i = 0; i < a.Length; i++) { double e = a[i] - b[i]; num += e * e; den += b[i] * b[i]; }
+        return Math.Sqrt(num / Math.Max(1e-30, den));
+    }
+
+    private void RunParity(string name, IStreamingOptimizer<double> opt, RefUpdate reference, int momentCount, double tol)
+    {
+        var streamParam = new Tensor<double>(new[] { N });
+        var refParam = InitParams();
+        for (int i = 0; i < N; i++) streamParam[i] = refParam[i];
+        var refState = new double[N * Math.Max(1, momentCount)];
+
+        for (int step = 1; step <= Steps; step++)
+        {
+            var g = Grad(step);
+
+            opt.BeginStep();
+            var gradTensor = new Tensor<double>(new[] { N });
+            for (int i = 0; i < N; i++) gradTensor[i] = g[i];
+            opt.Apply(streamParam, gradTensor);
+
+            for (int i = 0; i < N; i++)
+            {
+                var slot = momentCount == 0 ? Array.Empty<double>() : new double[momentCount];
+                for (int m = 0; m < momentCount; m++) slot[m] = refState[i * momentCount + m];
+                refParam[i] = reference(refParam[i], g[i], slot, step);
+                for (int m = 0; m < momentCount; m++) refState[i * momentCount + m] = slot[m];
+            }
+        }
+
+        var streamArr = new double[N];
+        for (int i = 0; i < N; i++) streamArr[i] = streamParam[i];
+        double rel = RelL2(streamArr, refParam);
+        Assert.True(rel < tol, $"{name}: 8-bit streaming drifted from fp64 reference (relL2 {rel:E3} >= {tol}).");
+    }
+
+    [Fact] public void Sgd_TracksFp64()
+        => RunParity("SGD", new StreamingSgd8Bit<double>(Lr), (p, g, st, t) => p - Lr * g, 0, 1e-9);
+
+    [Fact] public void Momentum_TracksFp64()
+        => RunParity("Momentum", new StreamingMomentum8Bit<double>(Lr, 0.9),
+            (p, g, st, t) => { st[0] = 0.9 * st[0] + Lr * g; return p - st[0]; }, 1, 0.03);
+
+    [Fact] public void Nesterov_TracksFp64()
+        => RunParity("Nesterov", new StreamingNesterov8Bit<double>(Lr, 0.9),
+            (p, g, st, t) => { st[0] = 0.9 * st[0] + Lr * g; return p - (0.9 * st[0] + Lr * g); }, 1, 0.03);
+
+    [Fact] public void RmsProp_TracksFp64()
+        => RunParity("RMSProp", new StreamingRmsProp8Bit<double>(Lr, 0.9, 1e-8),
+            (p, g, st, t) => { st[0] = 0.9 * st[0] + 0.1 * g * g; return p - Lr * g / (Math.Sqrt(st[0]) + 1e-8); }, 1, 0.05);
+
+    [Fact] public void Adagrad_TracksFp64()
+        => RunParity("Adagrad", new StreamingAdagrad8Bit<double>(Lr, 1e-8),
+            (p, g, st, t) => { st[0] += g * g; return p - Lr * g / (Math.Sqrt(st[0]) + 1e-8); }, 1, 0.05);
+
+    [Fact] public void Adam_TracksFp64()
+        => RunParity("Adam", new StreamingAdam8Bit<double>(Lr), (p, g, st, t) =>
+        {
+            st[0] = 0.9 * st[0] + 0.1 * g; st[1] = 0.999 * st[1] + 0.001 * g * g;
+            double c1 = 1 - Math.Pow(0.9, t), c2 = 1 - Math.Pow(0.999, t);
+            return p - Lr * (st[0] / c1) / (Math.Sqrt(st[1] / c2) + 1e-8);
+        }, 2, 0.05);
+
+    [Fact] public void AmsGrad_TracksFp64()
+        => RunParity("AMSGrad", new StreamingAMSGrad8Bit<double>(Lr, 0.9, 0.999, 1e-8, 0.0), (p, g, st, t) =>
+        {
+            st[0] = 0.9 * st[0] + 0.1 * g; st[1] = 0.999 * st[1] + 0.001 * g * g; st[2] = Math.Max(st[2], st[1]);
+            double c1 = 1 - Math.Pow(0.9, t), c2 = 1 - Math.Pow(0.999, t);
+            return p - Lr * (st[0] / c1) / (Math.Sqrt(st[2] / c2) + 1e-8);
+        }, 3, 0.05);
+
+    [Fact] public void Nadam_TracksFp64()
+        => RunParity("Nadam", new StreamingNadam8Bit<double>(Lr, 0.9, 0.999, 1e-8), (p, g, st, t) =>
+        {
+            st[0] = 0.9 * st[0] + 0.1 * g; st[1] = 0.999 * st[1] + 0.001 * g * g;
+            double c1 = 1 - Math.Pow(0.9, t), c2 = 1 - Math.Pow(0.999, t);
+            double mHat = st[0] / c1, vHat = st[1] / c2;
+            double nest = 0.9 * mHat + 0.1 * g / c1;
+            return p - Lr * nest / (Math.Sqrt(vHat) + 1e-8);
+        }, 2, 0.05);
+
+    [Fact] public void AdaMax_TracksFp64()
+        => RunParity("AdaMax", new StreamingAdaMax8Bit<double>(Lr, 0.9, 0.999, 1e-8), (p, g, st, t) =>
+        {
+            st[0] = 0.9 * st[0] + 0.1 * g; st[1] = Math.Max(0.999 * st[1], Math.Abs(g));
+            double c1 = 1 - Math.Pow(0.9, t);
+            return p - (Lr / c1) * st[0] / (st[1] + 1e-8);
+        }, 2, 0.05);
+
+    [Fact] public void AdaDelta_TracksFp64()
+        => RunParity("AdaDelta", new StreamingAdaDelta8Bit<double>(Lr, 0.95, 1e-6), (p, g, st, t) =>
+        {
+            double accG = 0.95 * st[0] + 0.05 * g * g;
+            double delta = Math.Sqrt(st[1] + 1e-6) / Math.Sqrt(accG + 1e-6) * g;
+            st[1] = 0.95 * st[1] + 0.05 * delta * delta;
+            st[0] = accG;
+            return p - Lr * delta;
+        }, 2, 0.06);
+
+    [Fact] public void AdamW_TracksFp64()
+        => RunParity("AdamW", new StreamingAdamW8Bit<double>(Lr, 0.9, 0.999, 1e-8, 0.01), (p, g, st, t) =>
+        {
+            st[0] = 0.9 * st[0] + 0.1 * g; st[1] = 0.999 * st[1] + 0.001 * g * g;
+            double c1 = 1 - Math.Pow(0.9, t), c2 = 1 - Math.Pow(0.999, t);
+            p -= Lr * 0.01 * p; // decoupled weight decay
+            return p - Lr * (st[0] / c1) / (Math.Sqrt(st[1] / c2) + 1e-8);
+        }, 2, 0.05);
+
+    // Lion's update is lr*sign(interp(m,g)); the 8-bit momentum only flips the SIGN near zero, so
+    // a looser bound (a few sign disagreements over 60 steps) is expected and still meaningful.
+    [Fact] public void Lion_TracksFp64()
+        => RunParity("Lion", new StreamingLion8Bit<double>(Lr, 0.9, 0.99, 0.0), (p, g, st, t) =>
+        {
+            double dir = 0.9 * st[0] + 0.1 * g;
+            st[0] = 0.99 * st[0] + 0.01 * g;
+            return p - Lr * Math.Sign(dir);
+        }, 1, 0.12);
+
+    // FTRL replaces the parameter from its (z, n) accumulators (closed form), so it's per-element.
+    // lambda1 is the L1 strength; use a small value so the soft-threshold actually fires.
+    [Fact] public void Ftrl_TracksFp64()
+        => RunParity("FTRL", new StreamingFtrl8Bit<double>(Lr, 1.0, 1e-3, 1e-3), (p, g, st, t) =>
+        {
+            double nNew = st[1] + g * g;
+            double sigma = (Math.Sqrt(nNew) - Math.Sqrt(st[1])) / Lr;
+            double zNew = st[0] + g - sigma * p;
+            st[0] = zNew; st[1] = nNew;
+            if (Math.Abs(zNew) <= 1e-3) return 0.0;
+            double num = -Math.Sign(zNew) * (Math.Abs(zNew) - 1e-3);
+            double den = 1e-3 + (Math.Sqrt(nNew) + 1.0) / Lr;
+            return num / den;
+        }, 2, 0.06);
+
+    // LARS/LAMB need the per-PARAMETER norm (a full-param pre-pass), so they get a dedicated driver.
+    [Fact] public void Lars_TracksFp64()
+    {
+        const double momentum = 0.9, wd = 1e-4, trust = 0.001, eps = 1e-8;
+        var opt = new StreamingLars8Bit<double>(Lr, momentum, wd, trust, eps, false);
+        var sp = new Tensor<double>(new[] { N }); var rp = InitParams(); var vel = new double[N];
+        for (int i = 0; i < N; i++) sp[i] = rp[i];
+        for (int step = 1; step <= Steps; step++)
+        {
+            var g = Grad(step);
+            opt.BeginStep(); var gt = new Tensor<double>(new[] { N }); for (int i = 0; i < N; i++) gt[i] = g[i];
+            opt.Apply(sp, gt);
+            double pn = 0, gn = 0; for (int i = 0; i < N; i++) { pn += rp[i] * rp[i]; gn += g[i] * g[i]; }
+            pn = Math.Sqrt(pn); gn = Math.Sqrt(gn);
+            double localLr = (pn > 0 && gn > 0) ? Lr * trust * pn / (gn + wd * pn + eps) : Lr;
+            for (int i = 0; i < N; i++) { vel[i] = momentum * vel[i] + localLr * (g[i] + wd * rp[i]); rp[i] -= vel[i]; }
+        }
+        var sa = new double[N]; for (int i = 0; i < N; i++) sa[i] = sp[i];
+        double rel = RelL2(sa, rp);
+        Assert.True(rel < 0.05, $"LARS: 8-bit drifted from fp64 (relL2 {rel:E3}).");
+    }
+
+    [Fact] public void Lamb_TracksFp64()
+    {
+        const double b1 = 0.9, b2 = 0.999, eps = 1e-6, wd = 0.01, maxTrust = 10.0;
+        var opt = new StreamingLamb8Bit<double>(Lr, b1, b2, eps, wd, true, maxTrust, true);
+        var sp = new Tensor<double>(new[] { N }); var rp = InitParams(); var m = new double[N]; var v = new double[N];
+        for (int i = 0; i < N; i++) sp[i] = rp[i];
+        for (int step = 1; step <= Steps; step++)
+        {
+            var g = Grad(step);
+            opt.BeginStep(); var gt = new Tensor<double>(new[] { N }); for (int i = 0; i < N; i++) gt[i] = g[i];
+            opt.Apply(sp, gt);
+            double c1 = 1 - Math.Pow(b1, step), c2 = 1 - Math.Pow(b2, step);
+            double pn = 0, un = 0;
+            for (int i = 0; i < N; i++)
+            {
+                double mm = b1 * m[i] + (1 - b1) * g[i], vv = b2 * v[i] + (1 - b2) * g[i] * g[i];
+                double u = (mm / c1) / (Math.Sqrt(vv / c2) + eps) + wd * rp[i];
+                pn += rp[i] * rp[i]; un += u * u;
+            }
+            pn = Math.Sqrt(pn); un = Math.Sqrt(un);
+            double tr = (pn > 0 && un > 0) ? Math.Min(pn / un, maxTrust) : 1.0;
+            for (int i = 0; i < N; i++)
+            {
+                m[i] = b1 * m[i] + (1 - b1) * g[i]; v[i] = b2 * v[i] + (1 - b2) * g[i] * g[i];
+                double u = (m[i] / c1) / (Math.Sqrt(v[i] / c2) + eps) + wd * rp[i];
+                rp[i] -= Lr * tr * u;
+            }
+        }
+        var sa = new double[N]; for (int i = 0; i < N; i++) sa[i] = sp[i];
+        double rel = RelL2(sa, rp);
+        Assert.True(rel < 0.05, $"LAMB: 8-bit drifted from fp64 (relL2 {rel:E3}).");
+    }
+}

--- a/tests/AiDotNet.Tests/UnitTests/Training/StreamingOptimizerParityTests.cs
+++ b/tests/AiDotNet.Tests/UnitTests/Training/StreamingOptimizerParityTests.cs
@@ -233,4 +233,82 @@ public class StreamingOptimizerParityTests
         double rel = RelL2(sa, rp);
         Assert.True(rel < 0.05, $"LAMB: 8-bit drifted from fp64 (relL2 {rel:E3}).");
     }
+
+    private static double Dot(double[] a, double[] b) { double s = 0; for (int i = 0; i < a.Length; i++) s += a[i] * b[i]; return s; }
+
+    // fp64 reference two-loop recursion (full-precision (s,y) history) — identical algorithm to
+    // StreamingLBFGS.TwoLoopDirection but without the 8-bit history quantization.
+    private static double[] RefLbfgsDirection(double[] g, System.Collections.Generic.List<double[]> sH, System.Collections.Generic.List<double[]> yH)
+    {
+        int n = g.Length, k = sH.Count;
+        var q = (double[])g.Clone();
+        if (k == 0) return q;
+        var alpha = new double[k]; var rho = new double[k];
+        for (int i = k - 1; i >= 0; i--)
+        {
+            double ys = Dot(yH[i], sH[i]); rho[i] = ys != 0 ? 1.0 / ys : 0.0;
+            alpha[i] = rho[i] * Dot(sH[i], q);
+            for (int j = 0; j < n; j++) q[j] -= alpha[i] * yH[i][j];
+        }
+        double yy = Dot(yH[k - 1], yH[k - 1]);
+        double gamma = yy > 0 ? Dot(sH[k - 1], yH[k - 1]) / yy : 1.0;
+        if (gamma <= 0 || double.IsNaN(gamma) || double.IsInfinity(gamma)) gamma = 1.0;
+        var r = new double[n]; for (int j = 0; j < n; j++) r[j] = gamma * q[j];
+        for (int i = 0; i < k; i++)
+        {
+            double beta = rho[i] * Dot(yH[i], r);
+            for (int j = 0; j < n; j++) r[j] += (alpha[i] - beta) * sH[i][j];
+        }
+        return r;
+    }
+
+    // Streaming L-BFGS (second-order) with an 8-bit-quantized (s,y) history must track an fp64
+    // L-BFGS (full-precision history) running the SAME two-loop + fixed step. The only divergence
+    // source is the 8-bit history quantization; the test asserts it stays bounded over many steps.
+    [Fact]
+    public void LBFGS_8bitHistory_TracksFp64()
+    {
+        const int memSize = 10;
+        var opt = new StreamingLBFGS<double>(Lr, memSize);
+        var sp = new Tensor<double>(new[] { N });
+        var rp = InitParams();
+        for (int i = 0; i < N; i++) sp[i] = rp[i];
+
+        var sH = new System.Collections.Generic.List<double[]>();
+        var yH = new System.Collections.Generic.List<double[]>();
+        double[]? prevGrad = null;
+
+        for (int step = 1; step <= Steps; step++)
+        {
+            var g = Grad(step);
+
+            opt.BeginStep();
+            var gt = new Tensor<double>(new[] { N });
+            for (int i = 0; i < N; i++) gt[i] = g[i];
+            opt.Apply(sp, gt);
+            opt.EndStep();
+
+            // fp64 reference: same two-loop, full-precision history.
+            var d = RefLbfgsDirection(g, sH, yH);
+            var xNew = new double[N];
+            var s = new double[N];
+            for (int i = 0; i < N; i++) { xNew[i] = rp[i] - Lr * d[i]; s[i] = xNew[i] - rp[i]; }
+            if (prevGrad is not null)
+            {
+                var y = new double[N];
+                for (int i = 0; i < N; i++) y[i] = g[i] - prevGrad[i];
+                if (Dot(s, y) > 1e-12)
+                {
+                    sH.Add(s); yH.Add(y);
+                    if (sH.Count > memSize) { sH.RemoveAt(0); yH.RemoveAt(0); }
+                }
+            }
+            rp = xNew;
+            prevGrad = (double[])g.Clone();
+        }
+
+        var sa = new double[N]; for (int i = 0; i < N; i++) sa[i] = sp[i];
+        double rel = RelL2(sa, rp);
+        Assert.True(rel < 0.10, $"Streaming L-BFGS (8-bit history) drifted from fp64 L-BFGS (relL2 {rel:E3} >= 0.10).");
+    }
 }

--- a/tests/AiDotNet.Tests/UnitTests/Training/StreamingOptimizerResolverTests.cs
+++ b/tests/AiDotNet.Tests/UnitTests/Training/StreamingOptimizerResolverTests.cs
@@ -1,0 +1,130 @@
+using System;
+using System.Collections.Generic;
+using AiDotNet.Interfaces;
+using AiDotNet.Models.Options;
+using AiDotNet.Optimizers;
+using AiDotNet.Training;
+using Xunit;
+
+namespace AiDotNet.Tests.UnitTests.Training;
+
+public sealed class StreamingOptimizerResolverTests
+{
+    public static IEnumerable<object[]> OptimizerMappings()
+    {
+        yield return Case("Adam", typeof(StreamingAdam8Bit<float>));
+        yield return Case("AdamAmsGrad", typeof(StreamingAMSGrad8Bit<float>));
+        yield return Case("AdamW", typeof(StreamingAdamW8Bit<float>));
+        yield return Case("AMSGrad", typeof(StreamingAMSGrad8Bit<float>));
+        yield return Case("Nadam", typeof(StreamingNadam8Bit<float>));
+        yield return Case("AdaMax", typeof(StreamingAdaMax8Bit<float>));
+        yield return Case("Lion", typeof(StreamingLion8Bit<float>));
+        yield return Case("LAMB", typeof(StreamingLamb8Bit<float>));
+        yield return Case("LARS", typeof(StreamingLars8Bit<float>));
+        yield return Case("FTRL", typeof(StreamingFtrl8Bit<float>));
+        yield return Case("AdaDelta", typeof(StreamingAdaDelta8Bit<float>));
+        yield return Case("Adagrad", typeof(StreamingAdagrad8Bit<float>));
+        yield return Case("RMSProp", typeof(StreamingRmsProp8Bit<float>));
+        yield return Case("Momentum", typeof(StreamingMomentum8Bit<float>));
+        yield return Case("Nesterov", typeof(StreamingNesterov8Bit<float>));
+        yield return Case("GradientDescent", typeof(StreamingSgd8Bit<float>));
+        yield return Case("SGD", typeof(StreamingSgd8Bit<float>));
+        yield return Case("MiniBatchGD", typeof(StreamingSgd8Bit<float>));
+        yield return Case("ProximalGD", typeof(StreamingSgd8Bit<float>));
+    }
+
+    [Theory]
+    [MemberData(nameof(OptimizerMappings))]
+    public void Resolver_MapsFirstOrderOptimizers_ToStreamingVariants(
+        string optimizerName,
+        Type expectedStreamingType)
+    {
+        var optimizer = CreateOptimizer(optimizerName);
+        var streaming = StreamingOptimizerResolver<float>.Create(
+            optimizer,
+            useStreamingDefaults: false,
+            fallbackLearningRate: 0.01,
+            fallbackWeightDecay: 0.0);
+
+        Assert.Equal(expectedStreamingType, streaming.GetType());
+    }
+
+    [Theory]
+    [MemberData(nameof(OptimizerMappings))]
+    public void ResolvedStreamingOptimizer_AppliesFiniteInPlaceUpdate(
+        string optimizerName,
+        Type _)
+    {
+        var optimizer = CreateOptimizer(optimizerName);
+        var streaming = StreamingOptimizerResolver<float>.Create(
+            optimizer,
+            useStreamingDefaults: false,
+            fallbackLearningRate: 0.01,
+            fallbackWeightDecay: 0.0);
+
+        var param = new Tensor<float>(new[] { 6 });
+        var grad = new Tensor<float>(new[] { 6 });
+        for (int i = 0; i < param.Length; i++)
+        {
+            param[i] = 0.25f + i * 0.1f;
+            grad[i] = (i % 2 == 0 ? 0.2f : -0.15f) + i * 0.01f;
+        }
+
+        var before = new float[param.Length];
+        for (int i = 0; i < param.Length; i++)
+            before[i] = param[i];
+
+        streaming.BeginStep();
+        streaming.Apply(param, grad);
+
+        bool changed = false;
+        for (int i = 0; i < param.Length; i++)
+        {
+            Assert.False(float.IsNaN(param[i]));
+            Assert.False(float.IsInfinity(param[i]));
+            changed |= Math.Abs(param[i] - before[i]) > 1e-8f;
+        }
+
+        Assert.True(changed, $"{streaming.GetType().Name} did not update any parameter.");
+    }
+
+    private static IGradientBasedOptimizer<float, Tensor<float>, Tensor<float>> CreateOptimizer(string optimizerName)
+        => optimizerName switch
+        {
+            "Adam" => new AdamOptimizer<float, Tensor<float>, Tensor<float>>(null!, new AdamOptimizerOptions<float, Tensor<float>, Tensor<float>>
+            {
+                InitialLearningRate = 0.01,
+                UseAMSGrad = false
+            }),
+            "AdamAmsGrad" => new AdamOptimizer<float, Tensor<float>, Tensor<float>>(null!, new AdamOptimizerOptions<float, Tensor<float>, Tensor<float>>
+            {
+                InitialLearningRate = 0.01,
+                UseAMSGrad = true
+            }),
+            "AdamW" => new AdamWOptimizer<float, Tensor<float>, Tensor<float>>(null!, new AdamWOptimizerOptions<float, Tensor<float>, Tensor<float>>
+            {
+                InitialLearningRate = 0.01,
+                WeightDecay = 0.01
+            }),
+            "AMSGrad" => new AMSGradOptimizer<float, Tensor<float>, Tensor<float>>(null!, new() { InitialLearningRate = 0.01 }),
+            "Nadam" => new NadamOptimizer<float, Tensor<float>, Tensor<float>>(null!, new() { InitialLearningRate = 0.01 }),
+            "AdaMax" => new AdaMaxOptimizer<float, Tensor<float>, Tensor<float>>(null!, new() { InitialLearningRate = 0.01 }),
+            "Lion" => new LionOptimizer<float, Tensor<float>, Tensor<float>>(null!, new() { InitialLearningRate = 0.01 }),
+            "LAMB" => new LAMBOptimizer<float, Tensor<float>, Tensor<float>>(null!, new() { InitialLearningRate = 0.01 }),
+            "LARS" => new LARSOptimizer<float, Tensor<float>, Tensor<float>>(null!, new() { InitialLearningRate = 0.01 }),
+            "FTRL" => new FTRLOptimizer<float, Tensor<float>, Tensor<float>>(null!, new() { Alpha = 0.01, Lambda1 = 0.0 }),
+            "AdaDelta" => new AdaDeltaOptimizer<float, Tensor<float>, Tensor<float>>(null!, new() { InitialLearningRate = 0.01 }),
+            "Adagrad" => new AdagradOptimizer<float, Tensor<float>, Tensor<float>>(null!, new() { InitialLearningRate = 0.01 }),
+            "RMSProp" => new RootMeanSquarePropagationOptimizer<float, Tensor<float>, Tensor<float>>(null!, new() { InitialLearningRate = 0.01 }),
+            "Momentum" => new MomentumOptimizer<float, Tensor<float>, Tensor<float>>(null!, new() { InitialLearningRate = 0.01 }),
+            "Nesterov" => new NesterovAcceleratedGradientOptimizer<float, Tensor<float>, Tensor<float>>(null!, new() { InitialLearningRate = 0.01 }),
+            "GradientDescent" => new GradientDescentOptimizer<float, Tensor<float>, Tensor<float>>(null!, new() { InitialLearningRate = 0.01 }),
+            "SGD" => new StochasticGradientDescentOptimizer<float, Tensor<float>, Tensor<float>>(null!, new() { InitialLearningRate = 0.01 }),
+            "MiniBatchGD" => new MiniBatchGradientDescentOptimizer<float, Tensor<float>, Tensor<float>>(null!, new() { InitialLearningRate = 0.01 }),
+            "ProximalGD" => new ProximalGradientDescentOptimizer<float, Tensor<float>, Tensor<float>>(null!, new() { InitialLearningRate = 0.01 }),
+            _ => throw new ArgumentOutOfRangeException(nameof(optimizerName), optimizerName, "Unknown optimizer mapping.")
+        };
+
+    private static object[] Case(string optimizerName, Type expectedStreamingType)
+        => new object[] { optimizerName, expectedStreamingType };
+}


### PR DESCRIPTION
## Summary
- Generalize the streaming optimizer path behind a shared 8-bit block-quantized optimizer framework.
- Add streaming variants and resolver mappings for first-order optimizers including SGD/GD, Momentum/Nesterov, RMSProp, Adagrad/AdaDelta, Adam/AdamW/AMSGrad/Nadam/AdaMax, Lion, LARS/LAMB, and FTRL.
- Keep streaming training aligned with configured optimizer hyperparameters and scheduler learning-rate updates; document expected state-memory reductions.
- Add resolver tests covering optimizer-to-streaming mappings and finite in-place updates.

Fixes #1600.

## Validation
- `dotnet build src\AiDotNet.csproj -f net10.0 --no-restore` (passes with existing analyzer warnings on current master)
- `dotnet test tests\AiDotNet.Tests\AiDotNetTests.csproj -f net10.0 --no-build --filter FullyQualifiedName~StreamingOptimizerResolverTests --verbosity quiet` (38 passed)