### PR TITLE
fix(fp16): light up the fused FP16 LayerNorm/GELU path on 0.96.0 (StepAdam float args) + e2e test (#558)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -139,10 +139,10 @@
          cause of the #1221 transformer production-scale convergence failure. 0.92.5 is
          the first release carrying that fix. AiDotNet.Native packages coreleased in
          lockstep at 0.92.5. -->
-    <PackageVersion Include="AiDotNet.Tensors" Version="0.95.2" />
-    <PackageVersion Include="AiDotNet.Native.OneDNN" Version="0.94.2" />
-    <PackageVersion Include="AiDotNet.Native.OpenBLAS" Version="0.94.2" />
-    <PackageVersion Include="AiDotNet.Native.CLBlast" Version="0.94.2" />
+    <PackageVersion Include="AiDotNet.Tensors" Version="0.96.0" />
+    <PackageVersion Include="AiDotNet.Native.OneDNN" Version="0.96.0" />
+    <PackageVersion Include="AiDotNet.Native.OpenBLAS" Version="0.96.0" />
+    <PackageVersion Include="AiDotNet.Native.CLBlast" Version="0.96.0" />
     <!-- Microsoft / .NET -->
     <PackageVersion Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageVersion Include="Microsoft.Data.Sqlite" Version="10.0.8" />

--- a/src/Training/MixedPrecisionReflection.cs
+++ b/src/Training/MixedPrecisionReflection.cs
@@ -223,10 +223,21 @@ internal static class MixedPrecisionReflection
         if (gradScaler is null) throw new ArgumentNullException(nameof(gradScaler));
         MethodInfo? stepAdam = _stepAdamMethod;
         if (stepAdam is null) throw new InvalidOperationException("Mixed-precision API not available.");
-        object? result = stepAdam.Invoke(plan, new object[]
+
+        // The hyperparameters were `double` in the original mixed-precision API but are `float` in the
+        // public StepAdam published from Tensors 0.96.0 (PR #606). Invoke() does not implicitly narrow
+        // double->float, so coerce each numeric argument to the RESOLVED method's parameter type —
+        // version-tolerant across both signatures (otherwise reflection throws "Object of type
+        // 'System.Double' cannot be converted to type 'System.Single'" and the entire Adam FP16 path
+        // silently falls back to the eager tape).
+        var args = new object[] { parameters, learningRate, beta1, beta2, eps, weightDecay, gradScaler };
+        var ps = stepAdam.GetParameters();
+        for (int i = 0; i < args.Length && i < ps.Length; i++)
         {
-            parameters, learningRate, beta1, beta2, eps, weightDecay, gradScaler
-        });
+            if (args[i] is double d && ps[i].ParameterType == typeof(float))
+                args[i] = (float)d;
+        }
+        object? result = stepAdam.Invoke(plan, args);
         return ExtractLoss(result);
     }
 

--- a/tests/AiDotNet.Tests/IntegrationTests/NeuralNetworks/FusedOptimizerIntegrationTests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/NeuralNetworks/FusedOptimizerIntegrationTests.cs
@@ -172,15 +172,14 @@ public class FusedOptimizerIntegrationTests
     /// resident-memory win depends on — LayerNorm + GELU (Tensors #558). A transformer block separates
     /// matmuls with LayerNorm/GELU, so those ops (not just the GEMM the matmul-only tests cover) must
     /// keep their activations Half. Dense → LayerNorm → GELU → Dense, Adam, <c>AIDOTNET_FP16_ACTIVATIONS=1</c>.
-    /// <para>Asserts the contract that holds REGARDLESS of which path engages: enabling FP16 activations on
-    /// a LayerNorm/GELU model trains correctly (finite loss every step, loss descends). Tensors 0.96.0
-    /// (PR #606) ships the FP16-native LayerNorm/GELU ops, but compiling a full LayerNorm/GELU model into
-    /// the fused mixed-precision plan still falls back to the eager FP32 tape here — so this currently
-    /// exercises the eager path and stays green; it lights up the fused path automatically once the
-    /// plan-compilation follow-up lands, without ever silently breaking training in the meantime.</para>
+    /// <para>On Tensors 0.96.0 (PR #606) the FP16-native LayerNorm/GELU ops keep the activation chain Half,
+    /// so this Adam-trained Dense → LayerNorm → GELU → Dense model routes through the fused FP16 plan. The
+    /// test asserts both that the fused path actually engaged (<c>GetFusedStepCount() &gt; 0</c>) and that
+    /// FP16 activations through LayerNorm + GELU train the FP32 master weights (finite loss every step,
+    /// loss descends) — the end-to-end resident-memory win Tensors #558 / #606 targets.</para>
     /// </summary>
     [Fact(Timeout = 120000)]
-    public async Task Fp16Activations_LayerNormGeluBlock_TrainsCorrectly_ViaWhicheverPathEngages()
+    public async Task Fp16Activations_LayerNormGeluBlock_EngagesFusedFp16Path_AndTrains()
     {
         await Task.CompletedTask;
 
@@ -211,12 +210,16 @@ public class FusedOptimizerIntegrationTests
                     $"FP16 LayerNorm/GELU path produced non-finite loss at step {step}");
             }
 
-            // FP16 activations through LayerNorm + GELU must train the FP32 master weights — whether the
-            // fused FP16 plan engaged or the eager FP32 tape fallback ran. As of Tensors 0.96.0 the
-            // FP16-native LayerNorm/GELU *ops* exist (Tensors PR #606), but compiling a full LayerNorm/GELU
-            // *model* into the fused mixed-precision plan still falls back to eager here (verified via
-            // GetFusedStepCount() == 0) — lighting up that path is tracked follow-up work in the
-            // mixed-precision plan's graph compilation. Either way, enabling the flag must not break training.
+            // The fused FP16 plan must have actually engaged. On 0.96.0 (Tensors PR #606) both the matmul
+            // and the LayerNorm/GELU activations stay Half, so this Adam-trained model routes through the
+            // fused FP16 ComputeGradients/StepAdam path rather than the eager FP32 fallback. (Engagement
+            // required the MixedPrecisionReflection.StepAdam float-arg fix in this PR: 0.96.0 made StepAdam
+            // public with float hyperparams, and the reflection bridge was still passing doubles — which
+            // threw on invoke and silently dropped every Adam FP16 step to eager.)
+            Assert.True(CompiledTapeTrainingStep<float>.GetFusedStepCount() > 0,
+                "FP16 fused path never engaged for the LayerNorm/GELU model — silent eager fallback.");
+
+            // FP16 activations through LayerNorm + GELU must still train the FP32 master weights.
             Assert.True(losses[losses.Count - 1] < losses[0],
                 $"FP16 LayerNorm/GELU training did not descend: first {losses[0]}, last {losses[losses.Count - 1]}");
         }

--- a/tests/AiDotNet.Tests/IntegrationTests/NeuralNetworks/FusedOptimizerIntegrationTests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/NeuralNetworks/FusedOptimizerIntegrationTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
+using AiDotNet.ActivationFunctions;
 using AiDotNet.Enums;
 using AiDotNet.Helpers;
 using AiDotNet.Interfaces;
@@ -156,6 +157,66 @@ public class FusedOptimizerIntegrationTests
             // FP16-computed grads applied by RMSprop's own master update must still train.
             Assert.True(losses[losses.Count - 1] < losses[0],
                 $"FP16 RMSprop training did not descend: first {losses[0]}, last {losses[losses.Count - 1]}");
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("AIDOTNET_FP16_ACTIVATIONS", originalEnv);
+            TensorCodecOptions.SetCurrent(originalOptions);
+            CompiledTapeTrainingStep<float>.Invalidate();
+        }
+    }
+
+    /// <summary>
+    /// End-to-end behavioral contract for FP16-activation training through the high-level
+    /// <see cref="NeuralNetworkBase{T}"/> path on a model that uses the between-matmul ops the
+    /// resident-memory win depends on — LayerNorm + GELU (Tensors #558). A transformer block separates
+    /// matmuls with LayerNorm/GELU, so those ops (not just the GEMM the matmul-only tests cover) must
+    /// keep their activations Half. Dense → LayerNorm → GELU → Dense, Adam, <c>AIDOTNET_FP16_ACTIVATIONS=1</c>.
+    /// <para>Asserts the contract that holds REGARDLESS of which path engages: enabling FP16 activations on
+    /// a LayerNorm/GELU model trains correctly (finite loss every step, loss descends). On a Tensors build
+    /// whose mixed-precision plan can compile LayerNorm/GELU in the FP16 path (Tensors #558 — adds the
+    /// FP16-native LayerNorm/GELU emit), this runs through the fused FP16 plan; on an older build it falls
+    /// back to the eager FP32 tape and still trains. This is the integration harness that lights up the
+    /// FP16-fused LayerNorm/GELU path the moment Tensors #558 publishes — without ever silently breaking
+    /// training in the meantime.</para>
+    /// </summary>
+    [Fact(Timeout = 120000)]
+    public async Task Fp16Activations_LayerNormGeluBlock_TrainsCorrectly_ViaWhicheverPathEngages()
+    {
+        await Task.CompletedTask;
+
+        var network = BuildLayerNormGeluNet();
+        var input = CreateRandomTensor(new[] { 16, 4 }, seed: 42);
+        var target = CreateRandomTensor(new[] { 16, 2 }, seed: 43);
+
+        // Warmup forward so layer weight tensors are materialized before training.
+        network.Predict(CreateRandomTensor(new[] { 1, 4 }, seed: 99));
+
+        var optimizer = BuildAdam(network, learningRate: 0.01);
+        var originalOptions = TensorCodecOptions.Current;
+        string? originalEnv = Environment.GetEnvironmentVariable("AIDOTNET_FP16_ACTIVATIONS");
+        try
+        {
+            Environment.SetEnvironmentVariable("AIDOTNET_FP16_ACTIVATIONS", "1");
+            TensorCodecOptions.SetCurrent(new TensorCodecOptions { EnableCompilation = true });
+            CompiledTapeTrainingStep<float>.Invalidate();
+            CompiledTapeTrainingStep<float>.ResetFusedStepCount();
+
+            var losses = new List<float>();
+            for (int step = 0; step < 15; step++)
+            {
+                network.TrainPublic(input, target, optimizer);
+                float loss = network.LastLossPublic;
+                losses.Add(loss);
+                Assert.False(float.IsNaN(loss) || float.IsInfinity(loss),
+                    $"FP16 LayerNorm/GELU path produced non-finite loss at step {step}");
+            }
+
+            // FP16 activations through LayerNorm + GELU must train the FP32 master weights — whether the
+            // fused FP16 plan engaged (Tensors #558+ compiles LayerNorm/GELU in the FP16 path) or the eager
+            // FP32 tape fallback ran (older Tensors). Either way, enabling the flag must not break training.
+            Assert.True(losses[losses.Count - 1] < losses[0],
+                $"FP16 LayerNorm/GELU training did not descend: first {losses[0]}, last {losses[losses.Count - 1]}");
         }
         finally
         {
@@ -427,6 +488,29 @@ public class FusedOptimizerIntegrationTests
 
         var network = new FusedTrainingTestNetwork(architecture);
         network.AddLayer(new DenseLayer<float>(8));
+        network.AddLayer(new DenseLayer<float>(2));
+        return network;
+    }
+
+    /// <summary>
+    /// A transformer-style block exercising the FP16-NATIVE between-matmul ops (#558): a Dense projection,
+    /// a LayerNorm, a GELU activation, then a Dense output. This is the op mix the resident-memory win
+    /// depends on (matmuls separated by LayerNorm/GELU), as opposed to <see cref="BuildMlp"/>'s matmul-only
+    /// stack.
+    /// </summary>
+    private static FusedTrainingTestNetwork BuildLayerNormGeluNet()
+    {
+        var architecture = new NeuralNetworkArchitecture<float>(
+            inputType: InputType.OneDimensional,
+            taskType: NeuralNetworkTaskType.Regression,
+            complexity: NetworkComplexity.Simple,
+            inputSize: 4,
+            outputSize: 2);
+
+        var network = new FusedTrainingTestNetwork(architecture);
+        network.AddLayer(new DenseLayer<float>(8));
+        network.AddLayer(new LayerNormalizationLayer<float>(8));
+        network.AddLayer(new ActivationLayer<float>((IActivationFunction<float>)new GELUActivation<float>()));
         network.AddLayer(new DenseLayer<float>(2));
         return network;
     }

--- a/tests/AiDotNet.Tests/IntegrationTests/NeuralNetworks/FusedOptimizerIntegrationTests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/NeuralNetworks/FusedOptimizerIntegrationTests.cs
@@ -173,12 +173,11 @@ public class FusedOptimizerIntegrationTests
     /// matmuls with LayerNorm/GELU, so those ops (not just the GEMM the matmul-only tests cover) must
     /// keep their activations Half. Dense → LayerNorm → GELU → Dense, Adam, <c>AIDOTNET_FP16_ACTIVATIONS=1</c>.
     /// <para>Asserts the contract that holds REGARDLESS of which path engages: enabling FP16 activations on
-    /// a LayerNorm/GELU model trains correctly (finite loss every step, loss descends). On a Tensors build
-    /// whose mixed-precision plan can compile LayerNorm/GELU in the FP16 path (Tensors #558 — adds the
-    /// FP16-native LayerNorm/GELU emit), this runs through the fused FP16 plan; on an older build it falls
-    /// back to the eager FP32 tape and still trains. This is the integration harness that lights up the
-    /// FP16-fused LayerNorm/GELU path the moment Tensors #558 publishes — without ever silently breaking
-    /// training in the meantime.</para>
+    /// a LayerNorm/GELU model trains correctly (finite loss every step, loss descends). Tensors 0.96.0
+    /// (PR #606) ships the FP16-native LayerNorm/GELU ops, but compiling a full LayerNorm/GELU model into
+    /// the fused mixed-precision plan still falls back to the eager FP32 tape here — so this currently
+    /// exercises the eager path and stays green; it lights up the fused path automatically once the
+    /// plan-compilation follow-up lands, without ever silently breaking training in the meantime.</para>
     /// </summary>
     [Fact(Timeout = 120000)]
     public async Task Fp16Activations_LayerNormGeluBlock_TrainsCorrectly_ViaWhicheverPathEngages()
@@ -213,8 +212,11 @@ public class FusedOptimizerIntegrationTests
             }
 
             // FP16 activations through LayerNorm + GELU must train the FP32 master weights — whether the
-            // fused FP16 plan engaged (Tensors #558+ compiles LayerNorm/GELU in the FP16 path) or the eager
-            // FP32 tape fallback ran (older Tensors). Either way, enabling the flag must not break training.
+            // fused FP16 plan engaged or the eager FP32 tape fallback ran. As of Tensors 0.96.0 the
+            // FP16-native LayerNorm/GELU *ops* exist (Tensors PR #606), but compiling a full LayerNorm/GELU
+            // *model* into the fused mixed-precision plan still falls back to eager here (verified via
+            // GetFusedStepCount() == 0) — lighting up that path is tracked follow-up work in the
+            // mixed-precision plan's graph compilation. Either way, enabling the flag must not break training.
             Assert.True(losses[losses.Count - 1] < losses[0],
                 $"FP16 LayerNorm/GELU training did not descend: first {losses[0]}, last {losses[losses.Count - 1]}");
         }


### PR DESCRIPTION
Completes the FP16-native LayerNorm/GELU integration that was gated on Tensors PR #606 publishing. #606 merged and shipped as **AiDotNet.Tensors 0.96.0**, so this PR bumps to it — and, crucially, makes the fused FP16 path actually engage end-to-end.

## What it does
1. **Bump** AiDotNet.Tensors + Native to **0.96.0** (the release carrying #606's FP16-native LayerNorm/GELU emit + #555 eviction-safety). Merged master.
2. **Fix the regression the bump exposed.** 0.96.0 published `MixedPrecisionCompiledPlan.StepAdam` as public with **float** hyperparameters, but `MixedPrecisionReflection.StepAdam` still passed **double**. `MethodInfo.Invoke` doesn't implicitly narrow `double`→`float`, so every Adam FP16 step threw `ArgumentException: Object of type 'System.Double' cannot be converted to type 'System.Single'`, was caught, and **silently fell back to the eager FP32 tape** — for *every* Adam model. (The generic RMSprop/Lion `ComputeGradients` path was unaffected, which is what made it look LayerNorm/GELU-specific.) Fixed by coercing each numeric StepAdam arg to the resolved method's parameter type — version-tolerant across both signatures.
3. **Strengthen the e2e test.** `Dense → LayerNorm → GELU → Dense`, Adam, `AIDOTNET_FP16_ACTIVATIONS=1` now asserts the fused path **actually engaged** (`GetFusedStepCount() > 0`) in addition to finite-loss + descent — i.e. the FP16-native LayerNorm/GELU resident-memory path runs end-to-end, not eager fallback. Renamed `…_EngagesFusedFp16Path_AndTrains`.

## How it was found
Bumping to 0.96.0, I added the engagement assertion and it failed; a one-shot diagnostic via `GetLastFallbackException()` surfaced the exact `double`→`float` `ArgumentException` in the StepAdam reflection invoke.

## Verification
All **8 FusedOptimizerIntegrationTests pass** on net10.0 (Adam matmul engagement + the new LayerNorm/GELU engagement + the non-Adam generic path); net10.0 **and** net471 build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)