### PR TITLE
docs: [codex] Lazily initialize pixel-to-sequence document models

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -139,7 +139,7 @@
          cause of the #1221 transformer production-scale convergence failure. 0.92.5 is
          the first release carrying that fix. AiDotNet.Native packages coreleased in
          lockstep at 0.92.5. -->
-    <PackageVersion Include="AiDotNet.Tensors" Version="0.94.2" />
+    <PackageVersion Include="AiDotNet.Tensors" Version="0.95.2" />
     <PackageVersion Include="AiDotNet.Native.OneDNN" Version="0.94.2" />
     <PackageVersion Include="AiDotNet.Native.OpenBLAS" Version="0.94.2" />
     <PackageVersion Include="AiDotNet.Native.CLBlast" Version="0.94.2" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -139,10 +139,19 @@
          cause of the #1221 transformer production-scale convergence failure. 0.92.5 is
          the first release carrying that fix. AiDotNet.Native packages coreleased in
          lockstep at 0.92.5. -->
+    <!-- 0.95.2: transparent weight streaming (Tensors #602 + #603 — EnsureMaterialized AND the
+         .Memory/.Data accessor auto-rehydrate a paged-out streaming weight on access; required by
+         the DiT transparent-streaming engagement here, DiTWeightStreamingTests) PLUS the full
+         weight-streaming PERF stack (Tensors #604): clean/dirty eviction (stops re-writing
+         read-only weights every eviction), default compression (bf16 inference / lossless training
+         via StreamingStoreDtype.Auto), RAM-aware budget, Belady-optimal paging, and int8 weight-only
+         quantized inference. So a foundation-scale model fits a bounded resident set with no
+         per-layer orchestration. 0.95.2 supersedes both master's 0.94.2 and this PR's earlier 0.95.1
+         pin. Native packages coreleased in lockstep at 0.95.2. -->
     <PackageVersion Include="AiDotNet.Tensors" Version="0.95.2" />
-    <PackageVersion Include="AiDotNet.Native.OneDNN" Version="0.94.2" />
-    <PackageVersion Include="AiDotNet.Native.OpenBLAS" Version="0.94.2" />
-    <PackageVersion Include="AiDotNet.Native.CLBlast" Version="0.94.2" />
+    <PackageVersion Include="AiDotNet.Native.OneDNN" Version="0.95.2" />
+    <PackageVersion Include="AiDotNet.Native.OpenBLAS" Version="0.95.2" />
+    <PackageVersion Include="AiDotNet.Native.CLBlast" Version="0.95.2" />
     <!-- Microsoft / .NET -->
     <PackageVersion Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageVersion Include="Microsoft.Data.Sqlite" Version="10.0.8" />

--- a/src/AiDotNet.Generators/TestScaffoldGenerator.cs
+++ b/src/AiDotNet.Generators/TestScaffoldGenerator.cs
@@ -137,6 +137,18 @@ public class TestScaffoldGenerator : IIncrementalGenerator
         // ModelFamilyTests/NeuralNetworks/{HelixTests,GPT4PointTests}.
         "Helix", "GPT4Point",
 
+        // OmniGen2 (VisionLanguage.Unified): paper-faithful unified understanding +
+        // generation VLM (VisionDim=1024, DecoderDim=4096, 24 vision + 32 decoder layers,
+        // 32 heads, Phi-3 backbone) — a multi-billion-parameter model. At paper scale it
+        // trips disk-backed weight streaming (so a forward no longer OOMs) but a single
+        // backward+AdamW step still cannot complete inside the 120s CI budget on CPU. The
+        // manual OmniGen2Tests in ModelFamilyTests/NeuralNetworks runs the same dual-path
+        // architecture at reduced <float> scale (Janus precedent), exercising every code path
+        // in seconds. NB: matches the VisionLanguage class named exactly "OmniGen2" — the
+        // separate diffusion model AiDotNet.Diffusion.ImageEditing.OmniGen2Model is unaffected
+        // (exact-name match) and has its own manual DiffusionModelTestBase scaffold.
+        "OmniGen2",
+
         // Donut (Kim et al. 2022, VisionLanguage.Document): paper-scale Swin+BART defaults
         // (VisionDim=1024, DecoderDim=1024, 12+4 layers, NumHeads=16, ImageSize=2560) make
         // a single AdamW train step ~9s on CPU, so the training-invariant counts overflow
@@ -1812,13 +1824,20 @@ public class TestScaffoldGenerator : IIncrementalGenerator
                     "vocabSize: 16, modelDimension: 32, numLayers: 2, stateDimension: 8, " +
                     "attentionInterval: 2, maxSeqLength: 8)";
             }
-            else if (IsValleCodecLMModel(model.ClassName) && model.TypeParameterCount == 1)
+            else if (IsValleCodecLMModel(model.ClassName) && model.TypeParameterCount == 1
+                     && model.FullyQualifiedName.StartsWith("AiDotNet.TextToSpeech.", System.StringComparison.Ordinal))
             {
                 // VALL-E-family models are neural codec language models: token
                 // IDs -> transformer text/codec LM -> codec logits. Use a
                 // smoke-scale config that preserves that paper contract without
                 // constructing the production 1024-wide, 12-layer stack for every
-                // generated invariant test.
+                // generated invariant test. The namespace gate is REQUIRED: the
+                // codec-LM VALL-E family lives under AiDotNet.TextToSpeech.* and uses
+                // TextToSpeech VALLE*Options, but a distinct AiDotNet.Audio.Generation.VALLE
+                // (different VALLEOptions type + an arch-only native ctor) shares the simple
+                // name "VALLE" — without this gate it would be emitted with the wrong
+                // TextToSpeech.CodecBased.VALLEOptions and fail to compile. The Audio one
+                // falls through to the arch-only constructor path below.
                 string optionsType = GetValleCodecLMOptionsType(model.ClassName);
                 constructorExpr = $"new {typeName}<double>(new AiDotNet.NeuralNetworks.NeuralNetworkArchitecture<double>(" +
                     "inputType: AiDotNet.Enums.InputType.OneDimensional, " +

--- a/src/Diffusion/Audio/JEN1Model.cs
+++ b/src/Diffusion/Audio/JEN1Model.cs
@@ -266,19 +266,11 @@ public class JEN1Model<T> : AudioDiffusionModelBase<T>
     /// <inheritdoc />
     public override IDiffusionModel<T> Clone()
     {
-        var clonedUnet = new UNetNoisePredictor<T>(
-            inputChannels: JEN1_LATENT_CHANNELS, outputChannels: JEN1_LATENT_CHANNELS,
-            baseChannels: 256, channelMultipliers: [1, 2, 4, 4],
-            numResBlocks: 2, attentionResolutions: [4, 2, 1],
-            contextDim: JEN1_CROSS_ATTENTION_DIM);
-        clonedUnet.SetParameters(_unet.GetParameters());
-
-        var clonedVae = new AudioVAE<T>(
-            melChannels: 128, latentChannels: JEN1_LATENT_CHANNELS,
-            baseChannels: 64, numResBlocks: 2);
-        clonedVae.SetParameters(_audioVae.GetParameters());
+        var clonedUnet = (UNetNoisePredictor<T>)_unet.Clone();
+        var clonedVae = (AudioVAE<T>)_audioVae.Clone();
 
         return new JEN1Model<T>(
+            architecture: Architecture,
             unet: clonedUnet,
             audioVae: clonedVae,
             conditioner: _conditioner);

--- a/src/Diffusion/Audio/MusicGenModel.cs
+++ b/src/Diffusion/Audio/MusicGenModel.cs
@@ -1023,15 +1023,19 @@ public class MusicGenModel<T> : AudioDiffusionModelBase<T>
     /// <inheritdoc />
     public override IDiffusionModel<T> Clone()
     {
-        return new MusicGenModel<T>(
-            options: null,
-            scheduler: null,
-            unet: null,
-            musicVAE: null,
+        var clone = new MusicGenModel<T>(
+            architecture: Architecture,
+            unet: (UNetNoisePredictor<T>)_unet.Clone(),
+            musicVAE: (AudioVAE<T>)_musicVAE.Clone(),
             textConditioner: _textConditioner,
             modelSize: _modelSize,
             sampleRate: SampleRate,
             defaultDurationSeconds: DefaultDurationSeconds);
+
+        clone._melodyEncoder.SetParameters(_melodyEncoder.GetParameters());
+        clone._rhythmEncoder.SetParameters(_rhythmEncoder.GetParameters());
+
+        return clone;
     }
 
     #endregion

--- a/src/Diffusion/Control/ControlNetModel.cs
+++ b/src/Diffusion/Control/ControlNetModel.cs
@@ -830,17 +830,28 @@ public class ControlNetEncoder<T>
     {
         int spatialSize = _imageSize;
 
+        // These convs use the lazy-default ctor (input depth resolved on first
+        // forward). Resolve each one's SHAPE ONLY at construction — sets InputDepth
+        // (so ParameterCount is exact and matches GetParameters().Length, and so the
+        // ZeroInitializeConv sizing below is correct) without allocating the kernel.
+        // Channels follow the Encode() data flow: inProj sees the control image
+        // (inputChannels), zeroProj sees inProj's output (baseChannels), each
+        // downBlock sees the previous block's output (prevChannels), and each zero
+        // conv sees its downBlock's output (channels).
+
         // Input projection: 3×3 conv, inputChannels → baseChannels, same padding
         int padding = 1; // 3×3 kernel with padding=1 preserves spatial size
         var inProj = new ConvolutionalLayer<T>(
             _baseChannels, kernelSize: 3, stride: 1, padding: padding,
             activationFunction: new SiLUActivation<T>());
+        inProj.ResolveShapesOnly([1, _inputChannels, spatialSize, spatialSize]);
         _downBlocks.Add(inProj);
 
         // Zero convolution for input: 1×1 conv initialized to zero (per paper)
         var zeroProj = new ConvolutionalLayer<T>(
             _baseChannels, kernelSize: 1, stride: 1, padding: 0,
             activationFunction: (IActivationFunction<T>?)null);
+        zeroProj.ResolveShapesOnly([1, _baseChannels, spatialSize, spatialSize]);
         ZeroInitializeConv(zeroProj);
         _zeroConvs.Add(zeroProj);
 
@@ -855,6 +866,7 @@ public class ControlNetEncoder<T>
             var downBlock = new ConvolutionalLayer<T>(
                 channels, kernelSize: 3, stride: 2, padding: 1,
                 activationFunction: new SiLUActivation<T>());
+            downBlock.ResolveShapesOnly([1, prevChannels, spatialSize, spatialSize]);
             _downBlocks.Add(downBlock);
 
             spatialSize = outSpatial;
@@ -863,6 +875,7 @@ public class ControlNetEncoder<T>
             var zc = new ConvolutionalLayer<T>(
                 channels, kernelSize: 1, stride: 1, padding: 0,
                 activationFunction: (IActivationFunction<T>?)null);
+            zc.ResolveShapesOnly([1, channels, spatialSize, spatialSize]);
             ZeroInitializeConv(zc);
             _zeroConvs.Add(zc);
 
@@ -918,23 +931,13 @@ public class ControlNetEncoder<T>
     /// </summary>
     public Vector<T> GetParameters()
     {
-        var allParams = new List<T>();
-
-        foreach (var block in _downBlocks)
-        {
-            var p = block.GetParameters();
-            for (int i = 0; i < p.Length; i++)
-                allParams.Add(p[i]);
-        }
-
-        foreach (var zc in _zeroConvs)
-        {
-            var p = zc.GetParameters();
-            for (int i = 0; i < p.Length; i++)
-                allParams.Add(p[i]);
-        }
-
-        return new Vector<T>(allParams.ToArray());
+        // Single-allocation concat — avoids the List<T> + per-element Add + ToArray
+        // triple-copy. Vector<T>.Concatenate pre-sizes one result and vectorized-
+        // copies each conv's params in once.
+        var parts = new List<Vector<T>>(_downBlocks.Count + _zeroConvs.Count);
+        foreach (var block in _downBlocks) parts.Add(block.GetParameters());
+        foreach (var zc in _zeroConvs) parts.Add(zc.GetParameters());
+        return Vector<T>.Concatenate(parts.ToArray());
     }
 
     /// <summary>

--- a/src/Diffusion/Control/ControlNetPlusPlusModel.cs
+++ b/src/Diffusion/Control/ControlNetPlusPlusModel.cs
@@ -140,12 +140,14 @@ public class ControlNetPlusPlusModel<T> : LatentDiffusionModelBase<T>
     /// <inheritdoc />
     public override Vector<T> GetParameters()
     {
-        var allParams = new List<T>();
-        var baseParams = _baseUNet.GetParameters();
-        for (int i = 0; i < baseParams.Length; i++) allParams.Add(baseParams[i]);
-        var ctrlParams = _controlEncoder.GetParameters();
-        for (int i = 0; i < ctrlParams.Length; i++) allParams.Add(ctrlParams[i]);
-        return new Vector<T>(allParams.ToArray());
+        // Single-allocation concat. The previous List<T> + per-element Add +
+        // ToArray triple-copied the parameter vector (~3x the model's size) and
+        // OOM'd the CI runner when materialising a paper-scale (580M-param) model.
+        // Vector<T>.Concatenate pre-sizes one result and vectorized-copies each
+        // sub-network's parameters in exactly once.
+        return Vector<T>.Concatenate(
+            _baseUNet.GetParameters(),
+            _controlEncoder.GetParameters());
     }
 
     /// <inheritdoc />

--- a/src/Diffusion/FastGeneration/AuraFlowModel.cs
+++ b/src/Diffusion/FastGeneration/AuraFlowModel.cs
@@ -195,17 +195,15 @@ public class AuraFlowModel<T> : LatentDiffusionModelBase<T>
     /// <inheritdoc />
     public override IDiffusionModel<T> Clone()
     {
-        var cd = new DiTNoisePredictor<T>(
-            inputChannels: LATENT_CHANNELS, hiddenSize: 1536,
-            numLayers: 24, numHeads: 24, patchSize: 2,
-            contextDim: CROSS_ATTENTION_DIM);
-        cd.SetParameters(_dit.GetParameters());
-        var cv = new StandardVAE<T>(
-            inputChannels: 3, latentChannels: LATENT_CHANNELS,
-            baseChannels: 128, channelMultipliers: [1, 2, 4, 4],
-            numResBlocksPerLevel: 2, latentScaleFactor: 0.13025);
-        cv.SetParameters(_vae.GetParameters());
-        return new AuraFlowModel<T>(dit: cd, vae: cv, conditioner: _conditioner);
+        // Delegate to the predictor's and VAE's own Clone(), which reconstruct from their
+        // actual config fields (NOT hardcoded foundation-scale constants) and preserve
+        // materialized weights — so a caller-injected variant of any scale round-trips
+        // correctly. Rebuilding at fixed 1536/24 here would size a clone that cannot accept
+        // an injected tiny (or otherwise non-default) predictor's parameter vector.
+        return new AuraFlowModel<T>(
+            dit: (DiTNoisePredictor<T>)_dit.Clone(),
+            vae: (StandardVAE<T>)_vae.Clone(),
+            conditioner: _conditioner);
     }
 
     #endregion

--- a/src/Diffusion/ImageEditing/OmniGen2Model.cs
+++ b/src/Diffusion/ImageEditing/OmniGen2Model.cs
@@ -136,9 +136,15 @@ public class OmniGen2Model<T> : LatentDiffusionModelBase<T>
     /// <inheritdoc />
     public override IDiffusionModel<T> Clone()
     {
-        var clone = new OmniGen2Model<T>(conditioner: _conditioner, seed: RandomGenerator.Next());
-        clone.SetParameters(GetParameters());
-        return clone;
+        // Delegate to the predictor's and VAE's own Clone(), which reconstruct from their
+        // actual config fields and preserve materialized weights. The previous form rebuilt a
+        // DEFAULT-scale model (SiTPredictor 1152/28) and SetParameters(GetParameters()) onto it,
+        // which both ignored a caller-injected variant and threw on the resulting parameter-count
+        // mismatch for any non-default predictor.
+        return new OmniGen2Model<T>(
+            predictor: (SiTPredictor<T>)_predictor.Clone(),
+            vae: (StandardVAE<T>)_vae.Clone(),
+            conditioner: _conditioner);
     }
 
     /// <inheritdoc />

--- a/src/Diffusion/NoisePredictors/DiTNoisePredictor.cs
+++ b/src/Diffusion/NoisePredictors/DiTNoisePredictor.cs
@@ -182,6 +182,20 @@ public class DiTNoisePredictor<T> : NoisePredictorBase<T>
     private readonly object _initLock = new();
 
     /// <summary>
+    /// Whether this predictor's lazy weight tensors have been materialized yet
+    /// (i.e. a forward pass, <see cref="GetParameters"/>, or
+    /// <see cref="SetParameters"/> has run). While <c>false</c> the predictor
+    /// holds no resident weights — its parameters are fully determined by its
+    /// construction config — so a clone can be produced by re-running the same
+    /// construction rather than copying a flat parameter vector. That matters
+    /// for foundation-scale configs (e.g. WanVideo-14B ≈ 15 B params) where the
+    /// flat <see cref="Vector{T}"/> copy path is both int.MaxValue-bounded and
+    /// far larger than host RAM. Callers that need a true deep copy of resolved
+    /// weights use <see cref="CopyParametersFrom"/> instead.
+    /// </summary>
+    public bool AreLayersInitialized => _layersInitialized;
+
+    /// <summary>
     /// Position embeddings (learnable).
     /// </summary>
     private Tensor<T>? _posEmbed;
@@ -473,21 +487,33 @@ public class DiTNoisePredictor<T> : NoisePredictorBase<T>
     public override Tensor<T> PredictNoise(Tensor<T> noisySample, int timestep, Tensor<T>? conditioning = null)
     {
         EnsureLayersInitialized();
+        // Engage transparent weight streaming for foundation-scale predictors
+        // BEFORE the forward resolves lazy weights, so they allocate through the
+        // disk-backed pool. No-op below threshold or when the registry is busy.
+        MaybeEngageWeightStreaming();
         _lastInput = noisySample;
 
         // Get timestep embedding
         var timeEmbed = GetTimestepEmbedding(timestep);
         timeEmbed = ProjectTimeEmbedding(timeEmbed);
 
-        return Forward(noisySample, timeEmbed, conditioning);
+        var result = Forward(noisySample, timeEmbed, conditioning);
+        // Drop the now-resolved weights to the pool; from the next forward on the
+        // denoising loop runs against a bounded resident set (auto-rehydrate +
+        // owner-drop). No-op unless streaming engaged above.
+        RegisterResolvedStreamingWeights();
+        return result;
     }
 
     /// <inheritdoc />
     public override Tensor<T> PredictNoiseWithEmbedding(Tensor<T> noisySample, Tensor<T> timeEmbedding, Tensor<T>? conditioning = null)
     {
         EnsureLayersInitialized();
+        MaybeEngageWeightStreaming();
         _lastInput = noisySample;
-        return Forward(noisySample, timeEmbedding, conditioning);
+        var result = Forward(noisySample, timeEmbedding, conditioning);
+        RegisterResolvedStreamingWeights();
+        return result;
     }
 
     /// <summary>
@@ -1266,11 +1292,78 @@ public class DiTNoisePredictor<T> : NoisePredictorBase<T>
             mlpRatio: _mlpRatio,
             latentSpatialSize: _latentSpatialSize);
 
-        // Preserve trained/materialized weights without forcing a foundation-scale
-        // default constructor to allocate and copy billions of random parameters.
+        // Preserve trained/materialized weights without forcing a foundation-scale default
+        // constructor to allocate and copy billions of random parameters (HasMaterializedParameters
+        // gates the copy to a source that genuinely has allocated weights).
+        //
+        // The DiT's projection layers are LazyDense — they only ALLOCATE their weight tensors on
+        // the first forward, not in EnsureLayersInitialized. A fresh clone therefore has the layer
+        // STRUCTURE but unallocated weights, so CopyParametersFrom alone has nothing to copy INTO;
+        // the clone would re-initialize those tensors with a fresh RNG on its first real forward
+        // and diverge from the source (observed: ~50k fewer materialized params, divergent Predict).
+        // Run one throwaway forward at the canonical input shape to materialize EVERY weight tensor
+        // on the clone first (weight dims are fixed by config, so the probe's spatial size is
+        // irrelevant), then copy the source's trained values. The probe must materialize exactly the
+        // paths the source has materialized so CopyParametersFrom finds a target for every source
+        // weight. A null-conditioned probe only touches the unconditional path, so if the source was
+        // used WITH conditioning its class-embedding (_labelEmbed) and/or cross-attention K/V/Out
+        // projections are materialized — leaving the clone's equivalents lazy would let them re-init
+        // with fresh RNG on the first conditioned forward and diverge from the source.
+        // BuildProbeConditioning returns representative conditioning whenever a conditioned path is
+        // materialized on the source (and null otherwise, keeping those layers lazy on both).
         if (HasMaterializedParameters())
+        {
+            var probe = new Tensor<T>(new[] { 1, _inputChannels, _latentSpatialSize, _latentSpatialSize });
+            clone.PredictNoise(probe, timestep: 0, conditioning: BuildProbeConditioning());
             clone.CopyParametersFrom(this);
+            // The probe forward traced a compiled plan over the clone's random init; drop it so
+            // the next real forward re-traces against the copied weights.
+            clone.InvalidateCompiledPlans();
+        }
+        // else: source has no materialized weights — nothing to copy. The clone shares the same
+        // config and initializes lazily on first use; calling GetParameters() here would allocate
+        // the full (foundation-scale) parameter vector for nothing.
         return clone;
+    }
+
+    /// <summary>
+    /// Builds a representative conditioning tensor for the <see cref="Clone"/> probe forward,
+    /// matching whichever conditioned path the source has materialized so that path is allocated on
+    /// the clone before <see cref="CopyParametersFrom"/> runs. Returns <c>null</c> when no conditioned
+    /// path is materialized — the source's conditioned layers are lazy, so the clone's stay lazy too.
+    /// </summary>
+    private Tensor<T>? BuildProbeConditioning()
+    {
+        // Class-conditional DiT: a one-hot [1, numClasses] label materializes _labelEmbed.
+        if (_numClasses > 0 && _labelEmbed is { IsInitialized: true })
+        {
+            return new Tensor<T>(new[] { 1, _numClasses });
+        }
+
+        // Text/cross-attention DiT: a [1, 1, contextDim] context tensor materializes the per-block
+        // cross-attention K/V/Out projections.
+        if (_contextDim > 0 && HasMaterializedCrossAttention())
+        {
+            return new Tensor<T>(new[] { 1, 1, _contextDim });
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// True when any transformer block's cross-attention key projection has materialized its weights,
+    /// i.e. the source ran at least one conditioned (text/context) forward.
+    /// </summary>
+    private bool HasMaterializedCrossAttention()
+    {
+        foreach (var block in _blocks)
+        {
+            if (block.CrossAttnK is { IsInitialized: true })
+            {
+                return true;
+            }
+        }
+        return false;
     }
 
     /// <inheritdoc />

--- a/src/Diffusion/NoisePredictors/DiffusionResBlock.cs
+++ b/src/Diffusion/NoisePredictors/DiffusionResBlock.cs
@@ -159,24 +159,18 @@ public class DiffusionResBlock<T> : LayerBase<T>
         // `block2.SetParameters(block1.GetParameters()) ⇒ block2(x) == block1(x)`
         // determinism contract relied on by tests and checkpoint reload.
         //
-        // Materialize via per-sublayer ResolveFromShape — ALLOCATION ONLY, no
-        // conv compute. The previous implementation ran a full probe Forward
-        // through the block at the paper spatial size; profiling
-        // (dotnet-trace, DallE2ModelTests.Predict_ShouldBeDeterministic) showed
-        // 100% of the 120s test timeout inside this ctor chain — the fused
-        // im2col conv GEMM ran a real [1, C, S, S] convolution for every res
-        // block in the U-Net, so paper-scale models (DallE2, SDXLInpainting)
-        // spent minutes CONSTRUCTING and timed out before Predict ever ran.
-        // ResolveFromShape runs each layer's lazy-init hook only (shape
-        // resolution + weight allocation + RNG init) — the determinism
-        // contract needs the weights to exist, not a convolution result.
-        _conv1.ResolveFromShape([1, inChannels, spatialSize, spatialSize]);
-        if (timeEmbedDim > 0)
-        {
-            _timeMlp.ResolveFromShape([1, timeEmbedDim]);
-        }
-        _conv2.ResolveFromShape([1, outChannels, spatialSize, spatialSize]);
-        _skipConv?.ResolveFromShape([1, inChannels, spatialSize, spatialSize]);
+        // Sublayers are left FULLY LAZY here — no shape resolution and no weight
+        // allocation in the ctor. At paper scale eager allocation was the dominant
+        // construction cost (a single SD U-Net is ~860M params, ~7 GB at double) and
+        // OOM'd the 16 GB CI runner on construction alone (Unit-03b). The owning
+        // UNetNoisePredictor resolves every sublayer's TRUE shape via its shape-only
+        // forward (ResolveShapesViaForward) before any ParameterCount / GetParameters
+        // read — the single source of truth that matches the real forward exactly —
+        // and weights materialise on demand at that GetParameters or the first real
+        // Forward. The SetParameters(GetParameters()) determinism contract is
+        // unaffected: GetParameters resolves shapes then materialises, and
+        // SetParameters overwrites the values.
+        _ = inChannels; _ = outChannels; _ = spatialSize; _ = timeEmbedDim;
     }
 
     /// <summary>

--- a/src/Diffusion/NoisePredictors/MMDiTNoisePredictor.cs
+++ b/src/Diffusion/NoisePredictors/MMDiTNoisePredictor.cs
@@ -1146,8 +1146,73 @@ public class MMDiTNoisePredictor<T> : NoisePredictorBase<T>
             contextDim: _contextDim,
             mlpRatio: _mlpRatio);
 
-        clone.SetParameters(GetParameters());
+        // The LazyDense weights resolve+allocate through the FORWARD path
+        // (EnsureInitializedFromInput) — a different entry than the SetParameters/GetParameters
+        // path (EnsureInitialized). Copying parameters into a clone whose layers were never
+        // forwarded leaves its first real forward to re-resolve and RNG-initialize along the
+        // forward path, discarding the copied values and diverging from the source. Run one
+        // throwaway forward to materialize the clone through the same path the source used,
+        // THEN copy the source's weights so they persist. Gated on the source having been
+        // forwarded (a never-forwarded foundation-scale model has nothing materialized to copy
+        // and must not pay a full forward here).
+        if (_patchEmbed.IsInitialized)
+        {
+            int probeSpatial = _patchSize * 2;
+            var probe = new Tensor<T>(new[] { 1, _inputChannels, probeSpatial, probeSpatial });
+            // A null-conditioned probe only materializes the unconditional (image-stream) path.
+            // When the source ran conditioned forwards its context projection (_contextProj) and
+            // text-stream block layers are materialized, so probe the clone WITH a representative
+            // text-conditioning tensor — otherwise those layers stay lazy on the clone and re-init
+            // with fresh RNG on the first conditioned forward, diverging from the source.
+            Tensor<T>? probeConditioning = _contextProj.IsInitialized
+                ? new Tensor<T>(new[] { 1, 1, _contextDim })
+                : null;
+            clone.PredictNoise(probe, timestep: 0, conditioning: probeConditioning);
+            // Layer-by-layer copy: each layer's GetParameters/SetParameters works on its own small
+            // vector, so cloning never materializes one contiguous foundation-scale parameter vector
+            // (the flat List<T> -> ToArray() path in GetParameters that OOMs at SD3/FLUX scale).
+            clone.CopyParametersFrom(this);
+            // The probe forward traced a compiled plan over the clone's random init; drop it so
+            // the next real forward re-traces against the copied weights.
+            clone.InvalidateCompiledPlans();
+        }
         return clone;
+    }
+
+    /// <summary>
+    /// Copies trained weights from <paramref name="source"/> into this predictor layer by layer,
+    /// without ever materializing a single contiguous parameter vector. Both predictors enumerate
+    /// their layers via the same <see cref="EnumerateLayers"/> order, so each source layer is paired
+    /// with its target and copied through that layer's own (small) <c>GetParameters</c>/
+    /// <c>SetParameters</c>. This is the foundation-scale-safe path that <see cref="Clone"/> uses
+    /// instead of <c>SetParameters(GetParameters())</c>, whose flat allocation OOMs at SD3/FLUX scale.
+    /// </summary>
+    private void CopyParametersFrom(MMDiTNoisePredictor<T> source)
+    {
+        Guard.NotNull(source);
+
+        using var src = source.EnumerateLayers().GetEnumerator();
+        using var dst = EnumerateLayers().GetEnumerator();
+
+        while (src.MoveNext())
+        {
+            if (!dst.MoveNext())
+            {
+                throw new InvalidOperationException(
+                    "Clone has fewer layers than the source MMDiT predictor; architectures differ.");
+            }
+
+            // Per-layer copy. A lazy source layer reports an empty vector and the corresponding
+            // SetParameters is a no-op, which is correct: the clone's matching layer was probed to
+            // the same materialization state, so both stay lazy together.
+            dst.Current.SetParameters(src.Current.GetParameters());
+        }
+
+        if (dst.MoveNext())
+        {
+            throw new InvalidOperationException(
+                "Clone has more layers than the source MMDiT predictor; architectures differ.");
+        }
     }
 
     /// <inheritdoc />

--- a/src/Diffusion/NoisePredictors/NoisePredictorBase.cs
+++ b/src/Diffusion/NoisePredictors/NoisePredictorBase.cs
@@ -7,6 +7,7 @@ using AiDotNet.Interfaces;
 using AiDotNet.LossFunctions;
 using AiDotNet.NeuralNetworks.Layers;
 using AiDotNet.Tensors.Engines.Autodiff;
+using AiDotNet.Tensors.LinearAlgebra;
 using AiDotNet.Models;
 using AiDotNet.Models.Options;
 
@@ -360,6 +361,136 @@ public abstract class NoisePredictorBase<T> : INoisePredictor<T>, IModelShape, I
             shapeMode: AiDotNet.NeuralNetworks.SymbolicShapeMode.BatchDynamic,
             modelIdentity: GetType().FullName ?? GetType().Name);
     }
+
+    #region Transparent Weight Streaming (Tensors #602 / issue #430)
+
+    // 0 = not engaged, 1 = engaged. Int (not bool) so the engage transition can be claimed
+    // atomically via Interlocked.CompareExchange — concurrent callers on the same instance
+    // then can't both reconfigure the process-global WeightRegistry.
+    private int _streamingEngaged;
+
+    /// <summary>
+    /// Parameter-count threshold above which <see cref="MaybeEngageWeightStreaming"/>
+    /// engages disk-backed weight streaming for the denoising forward loop. 500 M
+    /// is the same memory-pressure inflection point <c>NeuralNetworkBase</c> uses.
+    /// </summary>
+    private const long DefaultStreamingThresholdParams = 500_000_000L;
+
+    /// <summary>
+    /// Test/diagnostic override for <see cref="DefaultStreamingThresholdParams"/> so
+    /// controlled-scale tests can exercise the streaming path without a
+    /// foundation-scale model. <c>null</c> ⇒ use the default. Process-global.
+    /// </summary>
+    internal static long? StreamingThresholdOverride { get; set; }
+
+    /// <summary>
+    /// Test/diagnostic override for the streaming pool's resident-byte cap so a
+    /// small model can be forced to page (the auto-cap is sized for foundation
+    /// models). <c>null</c> ⇒ use <see cref="ComputeResidentCapBytes"/>.
+    /// </summary>
+    internal static long? StreamingResidentCapOverride { get; set; }
+
+    /// <summary>
+    /// Engages transparent weight streaming for this predictor when it is large
+    /// enough to pressure host RAM. Idempotent — runs at most once per instance.
+    /// <para>
+    /// When engaged it configures the process-wide <see cref="WeightRegistry"/> for
+    /// transparent auto-eviction and flags every owned layer to allocate its lazy
+    /// weights through the disk-backed streaming pool. Combined with
+    /// <see cref="RegisterResolvedStreamingWeights"/> (called after the first
+    /// forward resolves weights), the multi-step denoising loop then keeps only a
+    /// bounded resident set: each weight auto-rehydrates on access and the
+    /// symmetric owner-drop evicts cold ones.
+    /// </para>
+    /// <para>
+    /// <b>Safety guard.</b> The registry is process-global and
+    /// <see cref="WeightRegistry.Configure"/> throws on a pool that already has
+    /// live handles. So this only engages when the registry is empty — if another
+    /// model currently owns a streaming session, this predictor runs resident
+    /// rather than clobbering it. The common single-model inference path sees an
+    /// empty registry.
+    /// </para>
+    /// </summary>
+    protected void MaybeEngageWeightStreaming()
+    {
+        if (System.Threading.Volatile.Read(ref _streamingEngaged) != 0) return;
+
+        long threshold = StreamingThresholdOverride ?? DefaultStreamingThresholdParams;
+        if (ParameterCount <= threshold) return;
+
+        // Don't reconfigure (or clobber) a registry another model is using.
+        if (WeightRegistry.GetStreamingReport().RegisteredEntryCount > 0) return;
+
+        // Atomically claim engagement: if a concurrent call on this same instance already
+        // won the race, that thread owns the WeightRegistry.Configure below and this one
+        // returns (runs resident) rather than reconfiguring the process-global registry.
+        if (System.Threading.Interlocked.CompareExchange(ref _streamingEngaged, 1, 0) != 0) return;
+
+        WeightRegistry.Configure(new GpuOffloadOptions
+        {
+            StreamingPoolMaxResidentBytes = StreamingResidentCapOverride ?? ComputeResidentCapBytes(),
+            TransparentAutoEviction = true,
+        });
+
+        // ReflectInstanceLayers (not EnumerateLayers) so the engagement works for
+        // ANY predictor without requiring an EnumerateLayers override — it walks
+        // owned layer fields recursively, including those inside the DiT block list.
+        foreach (var layer in ReflectInstanceLayers(this))
+        {
+            if (layer is LayerBase<T> lb) lb.UseStreamingAllocator = true;
+        }
+    }
+
+    /// <summary>
+    /// Registers this predictor's now-resolved weights with the streaming pool,
+    /// dropping their resident in-memory copies to disk-backed storage. No-op
+    /// unless <see cref="MaybeEngageWeightStreaming"/> engaged. Called after the
+    /// first forward resolves the lazy weights, so from the second forward on the
+    /// transparent auto-rehydrate + owner-drop keep the resident set bounded.
+    /// </summary>
+    protected void RegisterResolvedStreamingWeights()
+    {
+        if (System.Threading.Volatile.Read(ref _streamingEngaged) == 0) return;
+
+        foreach (var layer in ReflectInstanceLayers(this))
+        {
+            if (layer is not LayerBase<T> lb) continue;
+            foreach (var tensor in lb.GetTrainableParameters())
+            {
+                // Skip placeholders (lazy weights not yet resolved) and tensors
+                // already registered (idempotent across forwards).
+                if (tensor is null || tensor.Length == 0 || tensor.StreamingPoolHandle >= 0) continue;
+                tensor.Lifetime = WeightLifetime.Streaming;
+                WeightRegistry.RegisterWeight(tensor);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Resident-byte cap for the streaming pool: half the host's available managed
+    /// memory, clamped to [512 MiB, 8 GiB]. Big enough for several layers' working
+    /// set (so a single op never needs more than the cap), small enough to leave
+    /// headroom for activations and runtime on a 16 GB host.
+    /// </summary>
+    private static long ComputeResidentCapBytes()
+    {
+        long cap;
+#if NET5_0_OR_GREATER
+        long avail = 0;
+        try { avail = GC.GetGCMemoryInfo().TotalAvailableMemoryBytes; } catch { /* fall through */ }
+        cap = avail > 0 ? avail / 2 : 4L * 1024 * 1024 * 1024;
+#else
+        // GCMemoryInfo isn't available on net471; use a conservative fixed cap.
+        cap = 4L * 1024 * 1024 * 1024;
+#endif
+        const long min = 512L * 1024 * 1024;
+        const long max = 8L * 1024 * 1024 * 1024;
+        if (cap < min) cap = min;
+        if (cap > max) cap = max;
+        return cap;
+    }
+
+    #endregion
 
     #region Lazy Layer Factories
 

--- a/src/Diffusion/NoisePredictors/UNetNoisePredictor.cs
+++ b/src/Diffusion/NoisePredictors/UNetNoisePredictor.cs
@@ -306,6 +306,9 @@ public class UNetNoisePredictor<T> : NoisePredictorBase<T>
         _timeEmbedMlp1 = (DenseLayer<T>)baseLayers[1];
         _timeEmbedMlp2 = (DenseLayer<T>)baseLayers[2];
 
+        // input/output convs are left fully lazy; the predictor's shape-only forward
+        // (ResolveShapesViaForward) resolves their true InputDepth from the topology.
+
         // Output conv from decoder layers
         var decoderBaseLayers = LayerHelper<T>.CreateUNetNoisePredictorDecoderLayers(
             _outputChannels, _baseChannels, _channelMultipliers, _numResBlocks).ToList();
@@ -990,6 +993,8 @@ public class UNetNoisePredictor<T> : NoisePredictorBase<T>
     private ILayer<T> CreateDownsample(int channels, int spatialSize)
     {
         // LazyConv2D: kernel tensor stays unallocated until first Forward() call.
+        // Fully lazy: the predictor's ResolveShapesViaForward resolves this conv's
+        // true InputDepth through the forward topology (no construction-time estimate).
         return LazyConv2D(
             inputDepth: channels,
             inputHeight: spatialSize,
@@ -1003,7 +1008,8 @@ public class UNetNoisePredictor<T> : NoisePredictorBase<T>
 
     private ILayer<T> CreateUpsample(int channels, int spatialSize)
     {
-        // spatialSize here is the current (smaller) spatial size before upsampling
+        // spatialSize here is the current (smaller) spatial size before upsampling.
+        // Fully lazy: shape resolved by the predictor's shape-only forward.
         return new DeconvolutionalLayer<T>(
             outputDepth: channels,
             kernelSize: 4,
@@ -1018,6 +1024,14 @@ public class UNetNoisePredictor<T> : NoisePredictorBase<T>
 
     private int CalculateParameterCount()
     {
+        // Resolve every lazy layer's TRUE shape via a shape-only forward (single source
+        // of truth) — NO weight materialisation, so this stays cheap on a foundation-scale
+        // U-Net (the Unit-03b construction OOM was the old materialising dummy forward).
+        // Using the forward topology (not a per-construction estimate) guarantees this
+        // count equals GetParameters().Length and the real forward's resolution, including
+        // decoder skip concatenation.
+        ResolveShapesViaForward();
+
         // Walk the same layers GetParameters walks and sum their actual ParameterCount.
         // Must match GetParameters().Length exactly — the previous "approximate" formula
         // diverged from the real count and broke contract tests asserting equality.
@@ -1049,6 +1063,12 @@ public class UNetNoisePredictor<T> : NoisePredictorBase<T>
     /// <inheritdoc />
     public override Vector<T> GetParameters()
     {
+        // Resolve all layer shapes via the shape-only forward (single source of truth,
+        // no materialisation) so the returned vector's length matches ParameterCount
+        // exactly. Each layer.GetParameters() below then materialises just that layer's
+        // weights on demand.
+        ResolveShapesViaForward();
+
         // Collect all sublayer parameter vectors first (each layer allocates its own)
         var layerParams = new List<Vector<T>>();
         int totalCount = 0;
@@ -1165,7 +1185,12 @@ public class UNetNoisePredictor<T> : NoisePredictorBase<T>
     /// <inheritdoc />
     public override void SetParameters(Vector<T> parameters)
     {
+        // Resolve lazy layer shapes first so each layer's slice is sized to its
+        // real ParameterCount; otherwise lazy layers size to 0 and the incoming
+        // values are silently dropped (the SetParameters/GetParameters round-trip bug).
+        TriggerLazyShapeResolution();
         _preserveMaterializedParameters = true;
+
         var index = 0;
 
         SetLayerParameters(_inputConv, parameters, ref index);
@@ -1303,13 +1328,73 @@ public class UNetNoisePredictor<T> : NoisePredictorBase<T>
     /// manually (instead of delegating to <see cref="Clone"/>) can
     /// force lazy shape resolution on both sides too.
     /// </summary>
+    private bool _lazyShapesResolved;
+
     internal void TriggerLazyShapeResolution()
     {
-        var dummy = new Tensor<T>(new[] { 1, _inputChannels, _inputHeight, _inputHeight });
+        // Idempotent: a single dummy forward resolves every lazy layer's weight
+        // shapes; shapes never change afterwards (SetParameters overwrites values,
+        // not shapes), so cache it. The guard is set BEFORE the forward so any
+        // re-entrant parameter access during resolution short-circuits instead of
+        // recursing. Without this, GetParameters / SetParameters / ParameterCount
+        // disagreed before the first real forward — the lazy layers reported their
+        // architectural ParameterCount but an empty GetParameters() vector — which
+        // broke the parameter round-trip, count-equality, Clone, and SaveState
+        // contracts (the whole DDPM parameter-management test cluster).
+        if (_lazyShapesResolved) return;
+        _lazyShapesResolved = true;
+
+        // Resolve at the SMALLEST valid spatial size, not the model's native
+        // _inputHeight. Weight shapes are channel-based (conv kernels
+        // [outC,inC,kH,kW], dense [in,out], attention [embed,embed]) and are
+        // INDEPENDENT of spatial H/W — but the forward compute (conv/attention)
+        // scales with H×W. On a foundation-scale UNet a native-resolution
+        // resolve forward costs minutes purely to allocate weights; resolving at
+        // the minimum spatial extent that still survives every downsampling
+        // stage (2^stages, doubled so the bottleneck stays >= 2) allocates the
+        // identical weight tensors with trivial compute. Cap at _inputHeight so
+        // models whose native size is already small aren't enlarged.
+        int numDownsamples = System.Math.Max(0, _channelMultipliers.Length - 1);
+        int safeSpatial = System.Math.Max(2, (1 << numDownsamples) * 2);
+        int resolveSpatial = System.Math.Min(_inputHeight, safeSpatial);
+        if (resolveSpatial < 1) resolveSpatial = _inputHeight;
+
+        var dummy = new Tensor<T>(new[] { 1, _inputChannels, resolveSpatial, resolveSpatial });
         Tensor<T>? dummyCtx = _contextDim > 0
             ? new Tensor<T>(new[] { 1, 1, _contextDim })
             : null;
         _ = PredictNoise(dummy, timestep: 0, conditioning: dummyCtx);
+    }
+
+    private bool _shapesResolvedViaForward;
+
+    /// <summary>
+    /// Single-source-of-truth shape resolution: runs the real forward topology under
+    /// <see cref="LayerBase{T}.RunShapeInference"/> so every lazy layer resolves its TRUE
+    /// shape exactly as the forward would — including decoder skip concatenation — WITHOUT
+    /// allocating any weights. This makes <c>ParameterCount</c>, <see cref="GetParameters"/>,
+    /// <see cref="SetParameters"/>, and the real forward all agree, which a per-construction
+    /// shape estimate cannot guarantee (the estimate diverged from the forward's actual
+    /// decoder concat). Unlike <see cref="TriggerLazyShapeResolution"/> this materialises
+    /// nothing, so it is safe to call from metadata accessors on a foundation-scale model.
+    /// Idempotent; the guard is set before the forward so re-entrant accessor calls during
+    /// resolution short-circuit instead of recursing.
+    /// </summary>
+    internal void ResolveShapesViaForward()
+    {
+        if (_shapesResolvedViaForward) return;
+        _shapesResolvedViaForward = true;
+
+        int numDownsamples = System.Math.Max(0, _channelMultipliers.Length - 1);
+        int safeSpatial = System.Math.Max(2, (1 << numDownsamples) * 2);
+        int resolveSpatial = System.Math.Min(_inputHeight, safeSpatial);
+        if (resolveSpatial < 1) resolveSpatial = _inputHeight;
+
+        var dummy = new Tensor<T>(new[] { 1, _inputChannels, resolveSpatial, resolveSpatial });
+        Tensor<T>? dummyCtx = _contextDim > 0
+            ? new Tensor<T>(new[] { 1, 1, _contextDim })
+            : null;
+        LayerBase<T>.RunShapeInference(() => { _ = PredictNoise(dummy, timestep: 0, conditioning: dummyCtx); });
     }
 
     /// <inheritdoc />

--- a/src/Diffusion/TextToImage/Flux1Model.cs
+++ b/src/Diffusion/TextToImage/Flux1Model.cs
@@ -353,28 +353,14 @@ public class Flux1Model<T> : LatentDiffusionModelBase<T>
     /// <inheritdoc />
     public override IDiffusionModel<T> Clone()
     {
-        var clonedMmdit = new MMDiTNoisePredictor<T>(
-            inputChannels: FLUX_LATENT_CHANNELS,
-            hiddenSize: FLUX_HIDDEN_SIZE,
-            numJointLayers: FLUX_JOINT_LAYERS,
-            numSingleLayers: FLUX_SINGLE_LAYERS,
-            numHeads: FLUX_NUM_HEADS,
-            patchSize: 2,
-            contextDim: FLUX_CONTEXT_DIM);
-        clonedMmdit.SetParameters(_mmdit.GetParameters());
-
-        var clonedVae = new StandardVAE<T>(
-            inputChannels: 3,
-            latentChannels: FLUX_LATENT_CHANNELS,
-            baseChannels: 128,
-            channelMultipliers: [1, 2, 4, 4],
-            numResBlocksPerLevel: 2,
-            latentScaleFactor: 1.5305);
-        clonedVae.SetParameters(_vae.GetParameters());
-
+        // Delegate to the predictor's and VAE's own Clone(), which reconstruct from their
+        // actual config fields (NOT hardcoded foundation-scale constants) and preserve
+        // materialized weights — so a caller-injected variant of any scale round-trips
+        // correctly. Rebuilding at fixed FLUX_HIDDEN_SIZE here would size a clone that cannot
+        // accept an injected tiny (or otherwise non-default) predictor's parameter vector.
         return new Flux1Model<T>(
-            mmdit: clonedMmdit,
-            vae: clonedVae,
+            mmdit: (MMDiTNoisePredictor<T>)_mmdit.Clone(),
+            vae: (StandardVAE<T>)_vae.Clone(),
             conditioner: _conditioner,
             variant: _variant);
     }

--- a/src/Diffusion/TextToImage/HunyuanDiTModel.cs
+++ b/src/Diffusion/TextToImage/HunyuanDiTModel.cs
@@ -253,20 +253,15 @@ public class HunyuanDiTModel<T> : LatentDiffusionModelBase<T>
     public override IDiffusionModel<T> Clone()
     {
         EnsureInitialized();
-        var clonedDit = new DiTNoisePredictor<T>(
-            inputChannels: LATENT_CHANNELS, hiddenSize: 1408,
-            numLayers: 40, numHeads: 16, patchSize: 2,
-            contextDim: CROSS_ATTENTION_DIM);
-        clonedDit.SetParameters(_dit.GetParameters());
-
-        var clonedVae = new StandardVAE<T>(
-            inputChannels: 3, latentChannels: LATENT_CHANNELS,
-            baseChannels: 128, channelMultipliers: [1, 2, 4, 4],
-            numResBlocksPerLevel: 2, latentScaleFactor: 0.13025);
-        clonedVae.SetParameters(_vae.GetParameters());
-
+        // Delegate to the predictor's and VAE's own Clone(), which reconstruct from their
+        // actual config fields (NOT hardcoded foundation-scale constants) and preserve
+        // materialized weights — so a caller-injected variant of any scale round-trips
+        // correctly. Rebuilding at fixed 1408/40 here would size a clone that cannot accept
+        // an injected tiny (or otherwise non-default) predictor's parameter vector.
         return new HunyuanDiTModel<T>(
-            dit: clonedDit, vae: clonedVae, conditioner: _conditioner);
+            dit: (DiTNoisePredictor<T>)_dit.Clone(),
+            vae: (StandardVAE<T>)_vae.Clone(),
+            conditioner: _conditioner);
     }
 
     #endregion

--- a/src/Diffusion/TextToImage/OmniGenModel.cs
+++ b/src/Diffusion/TextToImage/OmniGenModel.cs
@@ -328,27 +328,14 @@ public class OmniGenModel<T> : LatentDiffusionModelBase<T>
     /// <inheritdoc />
     public override IDiffusionModel<T> Clone()
     {
-        var clonedDit = new DiTNoisePredictor<T>(
-            inputChannels: LATENT_CHANNELS,
-            hiddenSize: 2048,
-            numLayers: 32,
-            numHeads: 16,
-            patchSize: 2,
-            contextDim: CROSS_ATTENTION_DIM);
-        clonedDit.SetParameters(_dit.GetParameters());
-
-        var clonedVae = new StandardVAE<T>(
-            inputChannels: 3,
-            latentChannels: LATENT_CHANNELS,
-            baseChannels: 128,
-            channelMultipliers: [1, 2, 4, 4],
-            numResBlocksPerLevel: 2,
-            latentScaleFactor: 0.18215);
-        clonedVae.SetParameters(_vae.GetParameters());
-
+        // Delegate to the predictor's and VAE's own Clone(), which reconstruct from their
+        // actual config fields (NOT hardcoded foundation-scale constants) and preserve
+        // materialized weights — so a caller-injected variant of any scale round-trips
+        // correctly. Rebuilding at fixed 2048/32 here would size a clone that cannot accept
+        // an injected tiny (or otherwise non-default) predictor's parameter vector.
         return new OmniGenModel<T>(
-            dit: clonedDit,
-            vae: clonedVae,
+            dit: (DiTNoisePredictor<T>)_dit.Clone(),
+            vae: (StandardVAE<T>)_vae.Clone(),
             conditioner: _conditioner);
     }
 

--- a/src/Diffusion/TextToImage/PixArtSigmaModel.cs
+++ b/src/Diffusion/TextToImage/PixArtSigmaModel.cs
@@ -247,20 +247,16 @@ public class PixArtSigmaModel<T> : LatentDiffusionModelBase<T>
     /// <inheritdoc />
     public override IDiffusionModel<T> Clone()
     {
-        var clonedDit = new DiTNoisePredictor<T>(
-            inputChannels: LATENT_CHANNELS, hiddenSize: 1152,
-            numLayers: 28, numHeads: 16, patchSize: 2,
-            contextDim: CROSS_ATTENTION_DIM);
-        clonedDit.SetParameters(_dit.GetParameters());
-
-        var clonedVae = new StandardVAE<T>(
-            inputChannels: 3, latentChannels: LATENT_CHANNELS,
-            baseChannels: 128, channelMultipliers: [1, 2, 4, 4],
-            numResBlocksPerLevel: 2, latentScaleFactor: 0.13025);
-        clonedVae.SetParameters(_vae.GetParameters());
-
+        // Lazy-preserving clone: delegate to the predictor's and VAE's own Clone(), which
+        // reconstruct from their actual config fields and copy only materialized weights.
+        // The previous flatten -> SetParameters(GetParameters()) round-trip materialised the
+        // entire foundation-scale DiT + VAE (model + clone + flat parameter vector) at once
+        // and OOM'd the runner. Delegating also lets a caller-injected non-default-scale
+        // predictor/VAE round-trip correctly instead of being rebuilt at fixed constants.
         return new PixArtSigmaModel<T>(
-            dit: clonedDit, vae: clonedVae, conditioner: _conditioner);
+            dit: (DiTNoisePredictor<T>)_dit.Clone(),
+            vae: (StandardVAE<T>)_vae.Clone(),
+            conditioner: _conditioner);
     }
 
     #endregion

--- a/src/Diffusion/ThreeD/LGMModel.cs
+++ b/src/Diffusion/ThreeD/LGMModel.cs
@@ -327,19 +327,15 @@ public class LGMModel<T> : ThreeDDiffusionModelBase<T>
     /// <inheritdoc />
     public override IDiffusionModel<T> Clone()
     {
-        var clonedUnet = new UNetNoisePredictor<T>(
-            inputChannels: INPUT_CHANNELS, outputChannels: OUTPUT_CHANNELS,
-            baseChannels: BASE_CHANNELS, channelMultipliers: new[] { 1, 2, 4, 8 },
-            numResBlocks: 2, attentionResolutions: new[] { 8, 4 },
-            contextDim: CROSS_ATTENTION_DIM);
-        clonedUnet.SetParameters(_unet.GetParameters());
+        var clonedUnet = (UNetNoisePredictor<T>)_unet.Clone();
+        var clonedVae = (StandardVAE<T>)_vae.Clone();
 
         return new LGMModel<T>(
+            architecture: Architecture,
             unet: clonedUnet,
-            vae: new StandardVAE<T>(inputChannels: 3, latentChannels: LATENT_CHANNELS,
-                baseChannels: 128, channelMultipliers: new[] { 1, 2, 4, 4 },
-                numResBlocksPerLevel: 2, latentScaleFactor: 0.18215),
-            conditioner: _conditioner, defaultPointCount: DefaultPointCount);
+            vae: clonedVae,
+            conditioner: _conditioner,
+            defaultPointCount: DefaultPointCount);
     }
 
     #endregion

--- a/src/Diffusion/ThreeD/MeshyModel.cs
+++ b/src/Diffusion/ThreeD/MeshyModel.cs
@@ -241,17 +241,15 @@ public class MeshyModel<T> : ThreeDDiffusionModelBase<T>
     /// <inheritdoc />
     public override IDiffusionModel<T> Clone()
     {
-        var clonedUnet = new UNetNoisePredictor<T>(
-            inputChannels: LATENT_CHANNELS, outputChannels: LATENT_CHANNELS,
-            baseChannels: BASE_CHANNELS, channelMultipliers: new[] { 1, 2, 4 },
-            numResBlocks: 2, attentionResolutions: new[] { 4, 2 },
-            contextDim: CROSS_ATTENTION_DIM);
-        clonedUnet.SetParameters(_unet.GetParameters());
-        return new MeshyModel<T>(unet: clonedUnet,
-            vae: new StandardVAE<T>(inputChannels: 3, latentChannels: LATENT_CHANNELS,
-                baseChannels: 128, channelMultipliers: new[] { 1, 2, 4, 4 },
-                numResBlocksPerLevel: 2, latentScaleFactor: 0.18215),
-            conditioner: _conditioner, defaultPointCount: DefaultPointCount);
+        var clonedUnet = (UNetNoisePredictor<T>)_unet.Clone();
+        var clonedVae = (StandardVAE<T>)_vae.Clone();
+
+        return new MeshyModel<T>(
+            architecture: Architecture,
+            unet: clonedUnet,
+            vae: clonedVae,
+            conditioner: _conditioner,
+            defaultPointCount: DefaultPointCount);
     }
 
     #endregion

--- a/src/Diffusion/VAE/StandardVAE.cs
+++ b/src/Diffusion/VAE/StandardVAE.cs
@@ -511,6 +511,11 @@ public class StandardVAE<T> : VAEModelBase<T>
 
     private int CalculateParameterCount()
     {
+        // Resolve lazy layer shapes so the count matches GetParameters().Length even
+        // pre-forward (lazy layers otherwise report their architectural count here
+        // but an empty GetParameters() vector — the count-equality failure source).
+        TriggerLazyShapeResolution();
+
         // Walk the same layers GetParameters walks and sum their actual ParameterCount.
         // Must match GetParameters().Length exactly — earlier "approximate" formulas
         // diverged from the real per-layer count and broke contract tests asserting
@@ -535,40 +540,23 @@ public class StandardVAE<T> : VAEModelBase<T>
     /// <inheritdoc />
     public override Vector<T> GetParameters()
     {
+        // Resolve lazy layer shapes so the vector matches ParameterCount even
+        // before the first real forward (lazy layers otherwise contribute 0).
         TriggerLazyShapeResolution();
 
-        var parameters = new List<T>();
-
-        AddLayerParameters(parameters, _inputConv);
-
-        foreach (var layer in _encoderLayers)
+        // Single-allocation concat over the same layers GetParameterChunks walks.
+        // The previous List<T> + per-element Add + ToArray triple-copied the whole
+        // parameter vector (~3x), OOM'ing the runner when a paper-scale VAE is
+        // materialised (e.g. during a foundation model's Clone). Vector<T>.Concatenate
+        // pre-sizes one result and vectorized-copies each layer's params in once.
+        var parts = new List<Vector<T>>();
+        foreach (var layer in EnumerateAllLayers())
         {
-            AddLayerParameters(parameters, layer);
+            if (layer == null) continue;
+            parts.Add(layer.GetParameters());
         }
 
-        AddLayerParameters(parameters, _meanConv);
-        AddLayerParameters(parameters, _logVarConv);
-        AddLayerParameters(parameters, _quantConv);
-        AddLayerParameters(parameters, _postQuantConv);
-
-        foreach (var layer in _decoderLayers)
-        {
-            AddLayerParameters(parameters, layer);
-        }
-
-        AddLayerParameters(parameters, _outputConv);
-
-        return new Vector<T>(parameters.ToArray());
-    }
-
-    private void AddLayerParameters(List<T> parameters, ILayer<T>? layer)
-    {
-        if (layer == null) return;
-        var layerParams = layer.GetParameters();
-        for (int i = 0; i < layerParams.Length; i++)
-        {
-            parameters.Add(layerParams[i]);
-        }
+        return Vector<T>.Concatenate(parts.ToArray());
     }
 
     /// <inheritdoc />
@@ -622,6 +610,9 @@ public class StandardVAE<T> : VAEModelBase<T>
     /// <inheritdoc />
     public override void SetParameters(Vector<T> parameters)
     {
+        // Resolve lazy layer shapes first so each layer's slice is sized to its
+        // real parameter count; otherwise lazy layers size to 0 and incoming
+        // values are silently dropped (the round-trip bug).
         _preserveMaterializedParameters = true;
         TriggerLazyShapeResolution();
 
@@ -754,8 +745,21 @@ public class StandardVAE<T> : VAEModelBase<T>
     /// invariant), so any size works as long as the conv stack doesn't
     /// underflow.
     /// </remarks>
+    private bool _lazyShapesResolved;
+
     internal void TriggerLazyShapeResolution()
     {
+        // Idempotent: one tiny encode+decode resolves every lazy layer's weight
+        // shapes (channel-based, so a minimal spatial extent suffices); shapes
+        // never change afterwards. Guard set before the forward to block
+        // re-entrant parameter access during resolution. Without this, the VAE's
+        // GetParameters / SetParameters / ParameterCount disagreed pre-forward
+        // (lazy layers reported architectural ParameterCount but an empty
+        // GetParameters() vector), which propagated to every latent diffusion
+        // model's ParameterCount == GetParameters().Length contract (SD1.5, SDXL,
+        // TripoSR, …) since those sum _unet + _vae.
+        if (_lazyShapesResolved) return;
+        _lazyShapesResolved = true;
         int downsamples = _channelMultipliers.Length - 1;
         int dummySpatial = 1 << Math.Max(downsamples, 1);
         var dummyImage = new Tensor<T>(new[] { 1, _inputChannels, dummySpatial, dummySpatial });

--- a/src/Diffusion/Video/WanVideoModel.cs
+++ b/src/Diffusion/Video/WanVideoModel.cs
@@ -439,6 +439,10 @@ public class WanVideoModel<T> : VideoDiffusionModelBase<T>
     /// <inheritdoc />
     public override IDiffusionModel<T> Clone()
     {
+        // _dit.Clone() reconstructs from the predictor's own config fields and (with the
+        // lazy-layer-materializing DiTNoisePredictor.Clone) preserves its weights — so it is
+        // correct for both a caller-injected predictor and the default variant build, with no
+        // need to re-derive the variant config or round-trip a flat foundation-scale vector.
         return new WanVideoModel<T>(
             dit: (DiTNoisePredictor<T>)_dit.Clone(),
             temporalVAE: (TemporalVAE<T>)_temporalVAE.Clone(),

--- a/src/Document/PixelToSequence/Dessurt.cs
+++ b/src/Document/PixelToSequence/Dessurt.cs
@@ -77,6 +77,7 @@ public class Dessurt<T> : DocumentNeuralNetworkBase<T>, IDocumentQA<T>
     // Native mode layers
     private readonly List<ILayer<T>> _encoderLayersList = [];
     private readonly List<ILayer<T>> _decoderLayersList = [];
+    private bool _nativeLayersInitialized;
 
     // Learnable embeddings
     private Tensor<T>? _encoderPositionEmbeddings;
@@ -196,8 +197,12 @@ public class Dessurt<T> : DocumentNeuralNetworkBase<T>, IDocumentQA<T>
         ImageSize = imageSize;
         MaxSequenceLength = maxSequenceLength;
 
-        InitializeLayers();
-        InitializeEmbeddings();
+        // Native layers/embeddings are materialized on first use to avoid
+        // constructor-time allocation for metadata and construction probes.
+        if (Architecture.Layers is { Count: > 0 })
+        {
+            EnsureNativeInitialized();
+        }
     }
 
     #endregion
@@ -245,6 +250,19 @@ public class Dessurt<T> : DocumentNeuralNetworkBase<T>, IDocumentQA<T>
         InitializeWithSmallRandomValues(_decoderPositionEmbeddings, random, 0.02);
     }
 
+    private void EnsureNativeInitialized()
+    {
+        if (!_useNativeMode || _nativeLayersInitialized)
+        {
+            return;
+        }
+
+        InitializeLayers();
+        InitializeEmbeddings();
+        _nativeLayersInitialized = true;
+        InvalidateParameterCountCache();
+    }
+
     private void InitializeWithSmallRandomValues(Tensor<T> tensor, Random random, double stdDev)
     {
         for (int i = 0; i < tensor.Data.Length; i++)
@@ -273,7 +291,9 @@ public class Dessurt<T> : DocumentNeuralNetworkBase<T>, IDocumentQA<T>
         var startTime = DateTime.UtcNow;
 
         var preprocessed = PreprocessDocument(documentImage);
-        var output = _useNativeMode ? Forward(preprocessed) : RunOnnxInference(preprocessed);
+        var output = _useNativeMode
+            ? ForwardAfterNativeInitialization(preprocessed)
+            : RunOnnxInference(preprocessed);
 
         // Decode output to text
         var answer = DecodeOutput(output, maxAnswerLength);
@@ -373,7 +393,9 @@ public class Dessurt<T> : DocumentNeuralNetworkBase<T>, IDocumentQA<T>
     {
         ValidateImageShape(documentImage);
         var preprocessed = PreprocessDocument(documentImage);
-        return _useNativeMode ? Forward(preprocessed) : RunOnnxInference(preprocessed);
+        return _useNativeMode
+            ? ForwardAfterNativeInitialization(preprocessed)
+            : RunOnnxInference(preprocessed);
     }
 
     /// <inheritdoc/>
@@ -475,8 +497,15 @@ public class Dessurt<T> : DocumentNeuralNetworkBase<T>, IDocumentQA<T>
                 { "image_size", ImageSize },
                 { "use_native_mode", _useNativeMode }
             },
-            ModelData = SafeSerialize()
+            ModelData = SafeSerializeMaterializedModel()
         };
+    }
+
+    private byte[] SafeSerializeMaterializedModel()
+    {
+        return _useNativeMode && !_nativeLayersInitialized
+            ? Array.Empty<byte>()
+            : SafeSerialize();
     }
 
     /// <inheritdoc/>
@@ -508,13 +537,20 @@ public class Dessurt<T> : DocumentNeuralNetworkBase<T>, IDocumentQA<T>
 
         ImageSize = imageSize;
         MaxSequenceLength = maxSeqLen;
+        _nativeLayersInitialized = Layers.Count > 0;
     }
 
     /// <inheritdoc/>
     protected override IFullModel<T, Tensor<T>, Tensor<T>> CreateNewInstance()
     {
-        return new Dessurt<T>(Architecture, ImageSize, MaxSequenceLength, _encoderDim, _decoderDim,
+        var model = new Dessurt<T>(Architecture, ImageSize, MaxSequenceLength, _encoderDim, _decoderDim,
             _encoderLayers, _decoderLayers, _numHeads, _vocabSize);
+        if (_nativeLayersInitialized)
+        {
+            model.EnsureNativeInitialized();
+        }
+
+        return model;
     }
 
     #endregion
@@ -525,7 +561,15 @@ public class Dessurt<T> : DocumentNeuralNetworkBase<T>, IDocumentQA<T>
     public override Tensor<T> Predict(Tensor<T> input)
     {
         var preprocessed = PreprocessDocument(input);
-        return _useNativeMode ? Forward(preprocessed) : RunOnnxInference(preprocessed);
+        return _useNativeMode
+            ? ForwardAfterNativeInitialization(preprocessed)
+            : RunOnnxInference(preprocessed);
+    }
+
+    private Tensor<T> ForwardAfterNativeInitialization(Tensor<T> input)
+    {
+        EnsureNativeInitialized();
+        return Forward(input);
     }
 
     /// <inheritdoc/>
@@ -534,6 +578,7 @@ public class Dessurt<T> : DocumentNeuralNetworkBase<T>, IDocumentQA<T>
         if (!_useNativeMode)
             throw new NotSupportedException("Training not supported in ONNX mode.");
 
+        EnsureNativeInitialized();
         SetTrainingMode(true);
         TrainWithTape(input, expectedOutput);
 
@@ -547,6 +592,7 @@ public class Dessurt<T> : DocumentNeuralNetworkBase<T>, IDocumentQA<T>
         if (!_useNativeMode)
             throw new NotSupportedException("Parameter updates not supported in ONNX mode.");
 
+        EnsureNativeInitialized();
         var currentParams = GetParameters();
         T lr = NumOps.FromDouble(0.00005);
         
@@ -557,6 +603,7 @@ public class Dessurt<T> : DocumentNeuralNetworkBase<T>, IDocumentQA<T>
     private Vector<T> CollectGradients()
     {
         var grads = new List<T>();
+        EnsureNativeInitialized();
         foreach (var layer in Layers)
             grads.AddRange(layer.GetParameterGradients());
         return new Vector<T>([.. grads]);

--- a/src/Document/PixelToSequence/Donut.cs
+++ b/src/Document/PixelToSequence/Donut.cs
@@ -112,6 +112,7 @@ public class Donut<T> : DocumentNeuralNetworkBase<T>, IOCRModel<T>, IDocumentQA<
 
     // Gradient storage
     private Tensor<T>? _decoderPositionEmbeddingsGradients;
+    private bool _nativeLayersInitialized;
     #pragma warning disable CS0414
     private bool _decoderForwardExecuted;
     #pragma warning restore CS0414
@@ -326,8 +327,12 @@ public class Donut<T> : DocumentNeuralNetworkBase<T>, IOCRModel<T>, IDocumentQA<
         _tokenizer = tokenizer ?? LanguageModelTokenizerFactory.CreateForBackbone(LanguageModelBackbone.OPT);
         _optimizer = optimizer ?? new AdamOptimizer<T, Tensor<T>, Tensor<T>>(this);
 
-        InitializeLayers();
-        InitializeEmbeddings();
+        // Native layers/embeddings are materialized on first use to avoid
+        // constructor-time allocation for metadata and construction probes.
+        if (Architecture.Layers is { Count: > 0 })
+        {
+            EnsureNativeInitialized();
+        }
     }
 
     #endregion
@@ -543,6 +548,19 @@ public class Donut<T> : DocumentNeuralNetworkBase<T>, IOCRModel<T>, IDocumentQA<
 
         // Initialize gradient tensor
         _decoderPositionEmbeddingsGradients = Tensor<T>.CreateDefault([_maxGenerationLength, _decoderHiddenDim], NumOps.Zero);
+    }
+
+    private void EnsureNativeInitialized()
+    {
+        if (!_useNativeMode || _nativeLayersInitialized)
+        {
+            return;
+        }
+
+        InitializeLayers();
+        InitializeEmbeddings();
+        _nativeLayersInitialized = true;
+        InvalidateParameterCountCache();
     }
 
     private void InitializeWithSmallRandomValues(Tensor<T> tensor, Random random, double stdDev)
@@ -901,6 +919,7 @@ public class Donut<T> : DocumentNeuralNetworkBase<T>, IOCRModel<T>, IDocumentQA<
 
         if (_useNativeMode)
         {
+            EnsureNativeInitialized();
             var output = preprocessed;
 
             // Patch embedding
@@ -1162,8 +1181,15 @@ public class Donut<T> : DocumentNeuralNetworkBase<T>, IOCRModel<T>, IDocumentQA<
                 { "use_native_mode", _useNativeMode },
                 { "ocr_free", IsOCRFree }
             },
-            ModelData = SafeSerialize()
+            ModelData = SafeSerializeMaterializedModel()
         };
+    }
+
+    private byte[] SafeSerializeMaterializedModel()
+    {
+        return _useNativeMode && !_nativeLayersInitialized
+            ? Array.Empty<byte>()
+            : SafeSerialize();
     }
 
     /// <inheritdoc/>
@@ -1317,10 +1343,11 @@ public class Donut<T> : DocumentNeuralNetworkBase<T>, IOCRModel<T>, IDocumentQA<
             _decoderPositionEmbeddingsGradients = Tensor<T>.CreateDefault(
                 [_maxGenerationLength, _decoderHiddenDim], NumOps.Zero);
         }
-        else
+        else if (Layers.Count > 0)
         {
             InitializeEmbeddings();
         }
+        _nativeLayersInitialized = _useNativeMode && Layers.Count > 0;
     }
 
     /// <inheritdoc/>
@@ -1359,7 +1386,7 @@ public class Donut<T> : DocumentNeuralNetworkBase<T>, IOCRModel<T>, IDocumentQA<
                 LossFunction);
         }
 
-        return new Donut<T>(
+        var model = new Donut<T>(
             Architecture,
             _tokenizer,
             ImageHeight,
@@ -1377,6 +1404,12 @@ public class Donut<T> : DocumentNeuralNetworkBase<T>, IOCRModel<T>, IDocumentQA<
             _vocabSize,
             _optimizer,
             LossFunction);
+        if (_nativeLayersInitialized)
+        {
+            model.EnsureNativeInitialized();
+        }
+
+        return model;
     }
 
     #endregion
@@ -1390,6 +1423,7 @@ public class Donut<T> : DocumentNeuralNetworkBase<T>, IOCRModel<T>, IDocumentQA<
 
         if (_useNativeMode)
         {
+            EnsureNativeInitialized();
             // Encode image and generate text output
             var encoderOutput = EncodeImage(preprocessed);
             return encoderOutput;
@@ -1408,6 +1442,7 @@ public class Donut<T> : DocumentNeuralNetworkBase<T>, IOCRModel<T>, IDocumentQA<
             throw new NotSupportedException("Training is not supported in ONNX inference mode. Use native mode for training.");
         }
 
+        EnsureNativeInitialized();
         SetTrainingMode(true);
         try
         {
@@ -1427,6 +1462,7 @@ public class Donut<T> : DocumentNeuralNetworkBase<T>, IOCRModel<T>, IDocumentQA<
             throw new NotSupportedException("Parameter updates are not supported in ONNX inference mode.");
         }
 
+        EnsureNativeInitialized();
         int expectedCount = ParameterCountHelper.ToFlatVectorSize(ParameterCount);
         if (gradients.Length != expectedCount)
         {
@@ -1468,6 +1504,7 @@ public class Donut<T> : DocumentNeuralNetworkBase<T>, IOCRModel<T>, IDocumentQA<
     private Vector<T> CollectParameterGradients()
     {
         var gradients = new List<T>();
+        EnsureNativeInitialized();
 
         // Collect gradients from all layers
         foreach (var layer in Layers)

--- a/src/Document/PixelToSequence/MATCHA.cs
+++ b/src/Document/PixelToSequence/MATCHA.cs
@@ -79,6 +79,7 @@ public class MATCHA<T> : DocumentNeuralNetworkBase<T>, IDocumentQA<T>, ITableExt
     // Native mode layers
     private readonly List<ILayer<T>> _encoderLayersList = [];
     private readonly List<ILayer<T>> _decoderLayersList = [];
+    private bool _nativeLayersInitialized;
 
     // Learnable embeddings
     private Tensor<T>? _patchEmbeddings;
@@ -215,8 +216,12 @@ public class MATCHA<T> : DocumentNeuralNetworkBase<T>, IDocumentQA<T>, ITableExt
         ImageSize = imageSize;
         MaxSequenceLength = maxSequenceLength;
 
-        InitializeLayers();
-        InitializeEmbeddings();
+        // Native layers/embeddings are materialized on first use to avoid
+        // constructor-time allocation for metadata and construction probes.
+        if (Architecture.Layers is { Count: > 0 })
+        {
+            EnsureNativeInitialized();
+        }
     }
 
     #endregion
@@ -264,6 +269,19 @@ public class MATCHA<T> : DocumentNeuralNetworkBase<T>, IDocumentQA<T>, ITableExt
         InitializeWithSmallRandomValues(_decoderPositionEmbeddings, random, 0.02);
     }
 
+    private void EnsureNativeInitialized()
+    {
+        if (!_useNativeMode || _nativeLayersInitialized)
+        {
+            return;
+        }
+
+        InitializeLayers();
+        InitializeEmbeddings();
+        _nativeLayersInitialized = true;
+        InvalidateParameterCountCache();
+    }
+
     private void InitializeWithSmallRandomValues(Tensor<T> tensor, Random random, double stdDev)
     {
         for (int i = 0; i < tensor.Data.Length; i++)
@@ -292,7 +310,9 @@ public class MATCHA<T> : DocumentNeuralNetworkBase<T>, IDocumentQA<T>, ITableExt
         var startTime = DateTime.UtcNow;
 
         var preprocessed = PreprocessDocument(documentImage);
-        var output = _useNativeMode ? Forward(preprocessed) : RunOnnxInference(preprocessed);
+        var output = _useNativeMode
+            ? ForwardAfterNativeInitialization(preprocessed)
+            : RunOnnxInference(preprocessed);
 
         var answer = DecodeOutput(output, maxAnswerLength);
 
@@ -381,7 +401,9 @@ public class MATCHA<T> : DocumentNeuralNetworkBase<T>, IDocumentQA<T>, ITableExt
     {
         ValidateImageShape(documentImage);
         var preprocessed = PreprocessDocument(documentImage);
-        var output = _useNativeMode ? Forward(preprocessed) : RunOnnxInference(preprocessed);
+        var output = _useNativeMode
+            ? ForwardAfterNativeInitialization(preprocessed)
+            : RunOnnxInference(preprocessed);
 
         // MATCHA detects chart/table regions
         yield return new TableRegion<T>
@@ -404,7 +426,9 @@ public class MATCHA<T> : DocumentNeuralNetworkBase<T>, IDocumentQA<T>, ITableExt
     {
         ValidateImageShape(tableImage);
         var preprocessed = PreprocessDocument(tableImage);
-        var output = _useNativeMode ? Forward(preprocessed) : RunOnnxInference(preprocessed);
+        var output = _useNativeMode
+            ? ForwardAfterNativeInitialization(preprocessed)
+            : RunOnnxInference(preprocessed);
 
         // MATCHA can derender charts to data tables
         var cells = ExtractChartData(output, 0.5);
@@ -553,7 +577,9 @@ public class MATCHA<T> : DocumentNeuralNetworkBase<T>, IDocumentQA<T>, ITableExt
     {
         ValidateImageShape(documentImage);
         var preprocessed = PreprocessDocument(documentImage);
-        return _useNativeMode ? Forward(preprocessed) : RunOnnxInference(preprocessed);
+        return _useNativeMode
+            ? ForwardAfterNativeInitialization(preprocessed)
+            : RunOnnxInference(preprocessed);
     }
 
     /// <inheritdoc/>
@@ -679,8 +705,15 @@ public class MATCHA<T> : DocumentNeuralNetworkBase<T>, IDocumentQA<T>, ITableExt
                 { "image_size", ImageSize },
                 { "use_native_mode", _useNativeMode }
             },
-            ModelData = SafeSerialize()
+            ModelData = SafeSerializeMaterializedModel()
         };
+    }
+
+    private byte[] SafeSerializeMaterializedModel()
+    {
+        return _useNativeMode && !_nativeLayersInitialized
+            ? Array.Empty<byte>()
+            : SafeSerialize();
     }
 
     /// <inheritdoc/>
@@ -714,13 +747,20 @@ public class MATCHA<T> : DocumentNeuralNetworkBase<T>, IDocumentQA<T>, ITableExt
 
         ImageSize = imageSize;
         MaxSequenceLength = maxSeqLen;
+        _nativeLayersInitialized = Layers.Count > 0;
     }
 
     /// <inheritdoc/>
     protected override IFullModel<T, Tensor<T>, Tensor<T>> CreateNewInstance()
     {
-        return new MATCHA<T>(Architecture, ImageSize, MaxSequenceLength, _encoderDim, _decoderDim,
+        var model = new MATCHA<T>(Architecture, ImageSize, MaxSequenceLength, _encoderDim, _decoderDim,
             _encoderLayers, _decoderLayers, _numHeads, _vocabSize, _maxPatchesPerImage);
+        if (_nativeLayersInitialized)
+        {
+            model.EnsureNativeInitialized();
+        }
+
+        return model;
     }
 
     #endregion
@@ -731,7 +771,15 @@ public class MATCHA<T> : DocumentNeuralNetworkBase<T>, IDocumentQA<T>, ITableExt
     public override Tensor<T> Predict(Tensor<T> input)
     {
         var preprocessed = PreprocessDocument(input);
-        return _useNativeMode ? Forward(preprocessed) : RunOnnxInference(preprocessed);
+        return _useNativeMode
+            ? ForwardAfterNativeInitialization(preprocessed)
+            : RunOnnxInference(preprocessed);
+    }
+
+    private Tensor<T> ForwardAfterNativeInitialization(Tensor<T> input)
+    {
+        EnsureNativeInitialized();
+        return Forward(input);
     }
 
     /// <inheritdoc/>
@@ -740,6 +788,7 @@ public class MATCHA<T> : DocumentNeuralNetworkBase<T>, IDocumentQA<T>, ITableExt
         if (!_useNativeMode)
             throw new NotSupportedException("Training not supported in ONNX mode.");
 
+        EnsureNativeInitialized();
         SetTrainingMode(true);
         TrainWithTape(input, expectedOutput);
 
@@ -753,6 +802,7 @@ public class MATCHA<T> : DocumentNeuralNetworkBase<T>, IDocumentQA<T>, ITableExt
         if (!_useNativeMode)
             throw new NotSupportedException("Parameter updates not supported in ONNX mode.");
 
+        EnsureNativeInitialized();
         var currentParams = GetParameters();
         T lr = NumOps.FromDouble(0.00005);
         
@@ -763,6 +813,7 @@ public class MATCHA<T> : DocumentNeuralNetworkBase<T>, IDocumentQA<T>, ITableExt
     private Vector<T> CollectGradients()
     {
         var grads = new List<T>();
+        EnsureNativeInitialized();
         foreach (var layer in Layers)
             grads.AddRange(layer.GetParameterGradients());
         return new Vector<T>([.. grads]);

--- a/src/Document/PixelToSequence/Nougat.cs
+++ b/src/Document/PixelToSequence/Nougat.cs
@@ -79,6 +79,7 @@ public class Nougat<T> : DocumentNeuralNetworkBase<T>, IDocumentQA<T>
     // Native mode layers
     private readonly List<ILayer<T>> _encoderLayers = [];
     private readonly List<ILayer<T>> _decoderLayers = [];
+    private bool _nativeLayersInitialized;
 
     #endregion
 
@@ -159,7 +160,6 @@ public class Nougat<T> : DocumentNeuralNetworkBase<T>, IDocumentQA<T>
 
         _onnxSession = new InferenceSession(onnxModelPath);
 
-        InitializeLayers();
     }
 
     /// <summary>
@@ -222,7 +222,12 @@ public class Nougat<T> : DocumentNeuralNetworkBase<T>, IDocumentQA<T>
 
         _tokenizer = tokenizer ?? LanguageModelTokenizerFactory.CreateForBackbone(LanguageModelBackbone.OPT);
 
-        InitializeLayers();
+        // Native layers are materialized on first use to avoid constructor-time
+        // allocation for metadata and construction probes.
+        if (Architecture.Layers is { Count: > 0 })
+        {
+            EnsureNativeInitialized();
+        }
     }
 
     #endregion
@@ -261,6 +266,18 @@ public class Nougat<T> : DocumentNeuralNetworkBase<T>, IDocumentQA<T>
         Layers.AddRange(_decoderLayers);
     }
 
+    private void EnsureNativeInitialized()
+    {
+        if (!_useNativeMode || _nativeLayersInitialized)
+        {
+            return;
+        }
+
+        InitializeLayers();
+        _nativeLayersInitialized = true;
+        InvalidateParameterCountCache();
+    }
+
     #endregion
 
     #region IDocumentQA Implementation
@@ -284,7 +301,9 @@ public class Nougat<T> : DocumentNeuralNetworkBase<T>, IDocumentQA<T>
         }
 
         var preprocessed = PreprocessDocument(documentImage);
-        var output = _useNativeMode ? Forward(preprocessed) : RunOnnxInference(preprocessed);
+        var output = _useNativeMode
+            ? ForwardAfterNativeInitialization(preprocessed)
+            : RunOnnxInference(preprocessed);
 
         var (markdown, confidence) = DecodeToMarkdown(output, maxAnswerLength, temperature);
 
@@ -539,7 +558,9 @@ public class Nougat<T> : DocumentNeuralNetworkBase<T>, IDocumentQA<T>
     {
         ValidateImageShape(documentImage);
         var preprocessed = PreprocessDocument(documentImage);
-        return _useNativeMode ? Forward(preprocessed) : RunOnnxInference(preprocessed);
+        return _useNativeMode
+            ? ForwardAfterNativeInitialization(preprocessed)
+            : RunOnnxInference(preprocessed);
     }
 
     /// <inheritdoc/>
@@ -642,8 +663,15 @@ public class Nougat<T> : DocumentNeuralNetworkBase<T>, IDocumentQA<T>
                 { "supports_latex", SupportsLatex },
                 { "use_native_mode", _useNativeMode }
             },
-            ModelData = SafeSerialize()
+            ModelData = SafeSerializeMaterializedModel()
         };
+    }
+
+    private byte[] SafeSerializeMaterializedModel()
+    {
+        return _useNativeMode && !_nativeLayersInitialized
+            ? Array.Empty<byte>()
+            : SafeSerialize();
     }
 
     /// <inheritdoc/>
@@ -683,13 +711,20 @@ public class Nougat<T> : DocumentNeuralNetworkBase<T>, IDocumentQA<T>
 
         ImageSize = imageSize;
         MaxSequenceLength = maxSeqLen;
+        _nativeLayersInitialized = Layers.Count > 0;
     }
 
     /// <inheritdoc/>
     protected override IFullModel<T, Tensor<T>, Tensor<T>> CreateNewInstance()
     {
-        return new Nougat<T>(Architecture, _tokenizer, ImageSize, _patchSize, MaxSequenceLength,
+        var model = new Nougat<T>(Architecture, _tokenizer, ImageSize, _patchSize, MaxSequenceLength,
             _hiddenDim, _numEncoderLayers, _numDecoderLayers, _numHeads, _vocabSize);
+        if (_nativeLayersInitialized)
+        {
+            model.EnsureNativeInitialized();
+        }
+
+        return model;
     }
 
     #endregion
@@ -700,7 +735,15 @@ public class Nougat<T> : DocumentNeuralNetworkBase<T>, IDocumentQA<T>
     public override Tensor<T> Predict(Tensor<T> input)
     {
         var preprocessed = PreprocessDocument(input);
-        return _useNativeMode ? Forward(preprocessed) : RunOnnxInference(preprocessed);
+        return _useNativeMode
+            ? ForwardAfterNativeInitialization(preprocessed)
+            : RunOnnxInference(preprocessed);
+    }
+
+    private Tensor<T> ForwardAfterNativeInitialization(Tensor<T> input)
+    {
+        EnsureNativeInitialized();
+        return Forward(input);
     }
 
     /// <inheritdoc/>
@@ -709,6 +752,7 @@ public class Nougat<T> : DocumentNeuralNetworkBase<T>, IDocumentQA<T>
         if (!_useNativeMode)
             throw new NotSupportedException("Training not supported in ONNX mode.");
 
+        EnsureNativeInitialized();
         SetTrainingMode(true);
         TrainWithTape(input, expectedOutput);
 
@@ -722,6 +766,7 @@ public class Nougat<T> : DocumentNeuralNetworkBase<T>, IDocumentQA<T>
         if (!_useNativeMode)
             throw new NotSupportedException("Parameter updates not supported in ONNX mode.");
 
+        EnsureNativeInitialized();
         var currentParams = GetParameters();
         T lr = NumOps.FromDouble(0.0001);
         
@@ -732,6 +777,7 @@ public class Nougat<T> : DocumentNeuralNetworkBase<T>, IDocumentQA<T>
     private Vector<T> CollectGradients()
     {
         var grads = new List<T>();
+        EnsureNativeInitialized();
         foreach (var layer in Layers)
             grads.AddRange(layer.GetParameterGradients());
         return new Vector<T>([.. grads]);

--- a/src/Document/PixelToSequence/Pix2Struct.cs
+++ b/src/Document/PixelToSequence/Pix2Struct.cs
@@ -77,6 +77,7 @@ public class Pix2Struct<T> : DocumentNeuralNetworkBase<T>, IDocumentQA<T>
     // Native mode layers
     private readonly List<ILayer<T>> _encoderLayers = [];
     private readonly List<ILayer<T>> _decoderLayers = [];
+    private bool _nativeLayersInitialized;
 
     #endregion
 
@@ -155,7 +156,6 @@ public class Pix2Struct<T> : DocumentNeuralNetworkBase<T>, IDocumentQA<T>
 
         _onnxSession = new InferenceSession(onnxModelPath);
 
-        InitializeLayers();
     }
 
     /// <summary>
@@ -220,7 +220,12 @@ public class Pix2Struct<T> : DocumentNeuralNetworkBase<T>, IDocumentQA<T>
 
         _tokenizer = tokenizer ?? LanguageModelTokenizerFactory.CreateForBackbone(LanguageModelBackbone.OPT);
 
-        InitializeLayers();
+        // Native layers are materialized on first use to avoid constructor-time
+        // allocation for metadata and construction probes.
+        if (Architecture.Layers is { Count: > 0 })
+        {
+            EnsureNativeInitialized();
+        }
     }
 
     #endregion
@@ -259,6 +264,18 @@ public class Pix2Struct<T> : DocumentNeuralNetworkBase<T>, IDocumentQA<T>
         Layers.AddRange(_decoderLayers);
     }
 
+    private void EnsureNativeInitialized()
+    {
+        if (!_useNativeMode || _nativeLayersInitialized)
+        {
+            return;
+        }
+
+        InitializeLayers();
+        _nativeLayersInitialized = true;
+        InvalidateParameterCountCache();
+    }
+
     #endregion
 
     #region IDocumentQA Implementation
@@ -276,7 +293,9 @@ public class Pix2Struct<T> : DocumentNeuralNetworkBase<T>, IDocumentQA<T>
         var startTime = DateTime.UtcNow;
 
         var preprocessed = PreprocessDocument(documentImage);
-        var output = _useNativeMode ? Forward(preprocessed) : RunOnnxInference(preprocessed);
+        var output = _useNativeMode
+            ? ForwardAfterNativeInitialization(preprocessed)
+            : RunOnnxInference(preprocessed);
 
         // Decode output to text
         var answer = DecodeOutput(output, maxAnswerLength, temperature);
@@ -379,7 +398,9 @@ public class Pix2Struct<T> : DocumentNeuralNetworkBase<T>, IDocumentQA<T>
     {
         ValidateImageShape(documentImage);
         var preprocessed = PreprocessDocument(documentImage);
-        return _useNativeMode ? Forward(preprocessed) : RunOnnxInference(preprocessed);
+        return _useNativeMode
+            ? ForwardAfterNativeInitialization(preprocessed)
+            : RunOnnxInference(preprocessed);
     }
 
     /// <inheritdoc/>
@@ -480,8 +501,15 @@ public class Pix2Struct<T> : DocumentNeuralNetworkBase<T>, IDocumentQA<T>
                 { "vocab_size", _vocabSize },
                 { "use_native_mode", _useNativeMode }
             },
-            ModelData = SafeSerialize()
+            ModelData = SafeSerializeMaterializedModel()
         };
+    }
+
+    private byte[] SafeSerializeMaterializedModel()
+    {
+        return _useNativeMode && !_nativeLayersInitialized
+            ? Array.Empty<byte>()
+            : SafeSerialize();
     }
 
     /// <inheritdoc/>
@@ -515,13 +543,20 @@ public class Pix2Struct<T> : DocumentNeuralNetworkBase<T>, IDocumentQA<T>
 
         ImageSize = imageSize;
         MaxSequenceLength = maxSeqLen;
+        _nativeLayersInitialized = Layers.Count > 0;
     }
 
     /// <inheritdoc/>
     protected override IFullModel<T, Tensor<T>, Tensor<T>> CreateNewInstance()
     {
-        return new Pix2Struct<T>(Architecture, _tokenizer, ImageSize, _patchSize, _maxPatches,
+        var model = new Pix2Struct<T>(Architecture, _tokenizer, ImageSize, _patchSize, _maxPatches,
             MaxSequenceLength, _hiddenDim, _numEncoderLayers, _numDecoderLayers, _numHeads, _vocabSize);
+        if (_nativeLayersInitialized)
+        {
+            model.EnsureNativeInitialized();
+        }
+
+        return model;
     }
 
     #endregion
@@ -532,7 +567,15 @@ public class Pix2Struct<T> : DocumentNeuralNetworkBase<T>, IDocumentQA<T>
     public override Tensor<T> Predict(Tensor<T> input)
     {
         var preprocessed = PreprocessDocument(input);
-        return _useNativeMode ? Forward(preprocessed) : RunOnnxInference(preprocessed);
+        return _useNativeMode
+            ? ForwardAfterNativeInitialization(preprocessed)
+            : RunOnnxInference(preprocessed);
+    }
+
+    private Tensor<T> ForwardAfterNativeInitialization(Tensor<T> input)
+    {
+        EnsureNativeInitialized();
+        return Forward(input);
     }
 
     /// <inheritdoc/>
@@ -541,6 +584,7 @@ public class Pix2Struct<T> : DocumentNeuralNetworkBase<T>, IDocumentQA<T>
         if (!_useNativeMode)
             throw new NotSupportedException("Training not supported in ONNX mode.");
 
+        EnsureNativeInitialized();
         SetTrainingMode(true);
         TrainWithTape(input, expectedOutput);
 
@@ -554,6 +598,7 @@ public class Pix2Struct<T> : DocumentNeuralNetworkBase<T>, IDocumentQA<T>
         if (!_useNativeMode)
             throw new NotSupportedException("Parameter updates not supported in ONNX mode.");
 
+        EnsureNativeInitialized();
         var currentParams = GetParameters();
         T lr = NumOps.FromDouble(0.0001);
         
@@ -564,6 +609,7 @@ public class Pix2Struct<T> : DocumentNeuralNetworkBase<T>, IDocumentQA<T>
     private Vector<T> CollectGradients()
     {
         var grads = new List<T>();
+        EnsureNativeInitialized();
         foreach (var layer in Layers)
             grads.AddRange(layer.GetParameterGradients());
         return new Vector<T>([.. grads]);

--- a/src/NeuralNetworks/Layers/ConvolutionalLayer.cs
+++ b/src/NeuralNetworks/Layers/ConvolutionalLayer.cs
@@ -1028,6 +1028,11 @@ public partial class ConvolutionalLayer<T> : LayerBase<T>
     /// </remarks>
     public override Tensor<T> Forward(Tensor<T> input)
     {
+        // Shape-inference mode: resolve dims from the input and return a correctly-shaped
+        // placeholder WITHOUT allocating the kernel or computing. Lets a model resolve all
+        // layer shapes via its real forward topology as the single source of truth.
+        if (IsInferringShapes) return ShapeInferenceOutput(input);
+
         // Resolve deferred shape (PyTorch LazyConv2d-style) and allocate weights on first call.
         EnsureInitializedFromInput(input);
 

--- a/src/NeuralNetworks/Layers/DeconvolutionalLayer.cs
+++ b/src/NeuralNetworks/Layers/DeconvolutionalLayer.cs
@@ -303,7 +303,19 @@ public partial class DeconvolutionalLayer<T> : LayerBase<T>
     /// - It will improve its upsampling abilities as it processes more data
     /// </para>
     /// </remarks>
-    public override long ParameterCount => _kernels.Length + _biases.Length;
+    public override long ParameterCount => _kernels.Length > 0
+        ? _kernels.Length + _biases.Length
+        // Deferred-shape mode: weights aren't materialised yet (e.g. resolved via
+        // ResolveShapesOnly so a parent can read ParameterCount without allocating
+        // the kernel). Once the shape is resolved InputDepth is known, so report the
+        // exact count from dims — kernel layout is [InputDepth, OutputDepth,
+        // KernelSize, KernelSize] plus an OutputDepth-length bias. This equals the
+        // materialised _kernels.Length + _biases.Length, so ParameterCount stays
+        // consistent with GetParameters().Length. Returns 0 only while InputDepth is
+        // still the unresolved -1 sentinel.
+        : InputDepth > 0
+            ? (long)InputDepth * OutputDepth * KernelSize * KernelSize + OutputDepth
+            : 0;
     public override bool SupportsTraining => true;
 
     /// <summary>
@@ -492,6 +504,9 @@ public partial class DeconvolutionalLayer<T> : LayerBase<T>
     /// </remarks>
     public override Tensor<T> Forward(Tensor<T> input)
     {
+        // Shape-inference mode: resolve dims + return a placeholder, no kernel allocation.
+        if (IsInferringShapes) return ShapeInferenceOutput(input);
+
         EnsureInitializedFromInput(input);
         _lastInput = input;
 

--- a/src/NeuralNetworks/Layers/DenseLayer.cs
+++ b/src/NeuralNetworks/Layers/DenseLayer.cs
@@ -860,8 +860,29 @@ public partial class DenseLayer<T> : LayerBase<T>, IAuxiliaryLossLayer<T>
     /// This is where the actual "thinking" happens in the neural network.
     /// </para>
     /// </remarks>
+    /// <summary>
+    /// Dense maps only the last axis (to the output size) and preserves all leading
+    /// batch/sequence dims, so the shape-inference placeholder is the input shape with
+    /// its last dimension replaced by the output size.
+    /// </summary>
+    protected override Tensor<T> ShapeInferenceOutput(Tensor<T> input)
+    {
+        if (!IsShapeResolved)
+        {
+            OnFirstForward(input);
+        }
+        int rank = input.Shape.Length;
+        var shape = new int[rank];
+        for (int i = 0; i < rank; i++) shape[i] = input.Shape[i];
+        shape[rank - 1] = OutputShape[OutputShape.Length - 1];
+        return new Tensor<T>(shape);
+    }
+
     public override Tensor<T> Forward(Tensor<T> input)
     {
+        // Shape-inference mode: resolve dims + return a placeholder, no weight allocation.
+        if (IsInferringShapes) return ShapeInferenceOutput(input);
+
         // Lazy layers must run shape resolution (OnFirstForward) BEFORE
         // EnsureInitialized — calling EnsureInitialized() directly on a
         // lazily-constructed DenseLayer reads InputShape[0]/OutputShape[0]

--- a/src/NeuralNetworks/Layers/LayerBase.cs
+++ b/src/NeuralNetworks/Layers/LayerBase.cs
@@ -642,6 +642,73 @@ public abstract class LayerBase<T> : ILayer<T>, ITrainableLayer<T>, IDisposable
         EnsureInitialized();
     }
 
+    // ── Shape-inference mode (single source of truth for lazy shape resolution) ─────
+    // When active, a leaf layer's Forward resolves its shape from the input (OnFirstForward)
+    // and returns a correctly-shaped, zero-filled placeholder WITHOUT materialising weights
+    // or running compute. A model can then run its real forward topology in this mode to
+    // resolve every layer's true shape exactly as the forward would (including skip
+    // concatenation, reshapes, etc.) — making ParameterCount / GetParameters / SetParameters
+    // / forward all agree, with no weight allocation. ThreadStatic: the resolution forward is
+    // synchronous and single-threaded, and normal forwards must never see it set.
+    [ThreadStatic]
+    private static bool _shapeInferenceActive;
+
+    /// <summary>
+    /// Whether the current thread is running a shape-only resolution forward. Leaf-layer
+    /// <c>Forward</c> overrides check this and return <see cref="ShapeInferenceOutput"/>
+    /// instead of materialising weights and computing. Off during all real forwards.
+    /// </summary>
+    internal static bool IsInferringShapes
+    {
+        get => _shapeInferenceActive;
+        set => _shapeInferenceActive = value;
+    }
+
+    /// <summary>
+    /// Resolves this layer's shape from <paramref name="input"/> (without allocating weights)
+    /// and returns a zero-filled tensor of the resulting forward output shape
+    /// (<c>[batch, ...OutputShape]</c>). Leaf layers call this at the top of <c>Forward</c>
+    /// when <see cref="IsInferringShapes"/> is set, so shapes propagate through the real
+    /// forward topology with no materialisation.
+    /// </summary>
+    protected virtual Tensor<T> ShapeInferenceOutput(Tensor<T> input)
+    {
+        if (!IsShapeResolved)
+        {
+            OnFirstForward(input);
+        }
+
+        // Default: forward output is [batch, ...OutputShape] — correct for layers like
+        // Conv/Deconv whose OutputShape carries the full per-sample output dims. Layers
+        // with a different shape contract (e.g. a rank-agnostic Dense that maps only the
+        // last axis) override this.
+        int batch = input.Shape.Length > 0 ? input.Shape[0] : 1;
+        int[] outShape = OutputShape;
+        var full = new int[outShape.Length + 1];
+        full[0] = batch;
+        System.Array.Copy(outShape, 0, full, 1, outShape.Length);
+        return new Tensor<T>(full);
+    }
+
+    /// <summary>
+    /// Runs <paramref name="resolve"/> with shape-inference mode active, guaranteeing the flag
+    /// is cleared afterward even on exception. Models call this around a dummy forward to
+    /// resolve all layer shapes as the single source of truth.
+    /// </summary>
+    internal static void RunShapeInference(Action resolve)
+    {
+        bool prior = _shapeInferenceActive;
+        _shapeInferenceActive = true;
+        try
+        {
+            resolve();
+        }
+        finally
+        {
+            _shapeInferenceActive = prior;
+        }
+    }
+
     /// <summary>
     /// Eagerly resolves a lazy layer's shape (and allocates its weights) from a known
     /// input shape, without running an actual forward pass. Parent wrappers that already

--- a/src/NeuralNetworks/Layers/PatchEmbeddingLayer.cs
+++ b/src/NeuralNetworks/Layers/PatchEmbeddingLayer.cs
@@ -457,6 +457,15 @@ public partial class PatchEmbeddingLayer<T> : LayerBase<T>
         // Reshape back to 3D: [B, N, embedDim]
         var projected = Engine.Reshape(projectedFlat, new[] { batchSize, _numPatches, _embeddingDim });
 
+        // When weight streaming is engaged the bias's resident storage is paged out after
+        // registration. Engine.TensorMatMul above rehydrates _projectionWeights transparently
+        // on access, but Engine.Reshape views the storage directly and does NOT trip the
+        // transparent-streaming rehydrate gate — so reshaping a paged-out bias would view empty
+        // storage and throw ("View exceeds storage bounds ... storage [0, -1]"). Touch .Data
+        // first: the 0.95.x rehydrate gate fires on .Data/.Memory access and brings the bias
+        // resident. Cheap (a property read) for the non-streaming common case.
+        _ = _projectionBias.Data;
+
         // Add bias (broadcast) — reshape bias fresh each call to keep the tape
         // GradFn chain alive (a cached reshape primed during inference would
         // disconnect _projectionBias from the backward walk).

--- a/src/NeuralNetworks/NeuralNetworkBase.cs
+++ b/src/NeuralNetworks/NeuralNetworkBase.cs
@@ -4153,6 +4153,42 @@ public abstract class NeuralNetworkBase<T> : INeuralNetworkModel<T>, IInterpreta
         }
     }
 
+    private bool _streamingScheduleSet;
+
+    /// <summary>
+    /// Feeds the streaming pool this network's per-step weight-access SCHEDULE —
+    /// forward layer order then backward (training) — so it pages with Belady-optimal
+    /// eviction (evict the weight whose next use is furthest) instead of LRU. For the
+    /// cyclic forward→backward pattern LRU is near-pessimal (it evicts the weight
+    /// about to be reused); Belady is provably minimal-fault. No-op unless weight
+    /// streaming is engaged; runs once after the first forward, when every weight's
+    /// StreamingPoolHandle is assigned.
+    /// </summary>
+    private void RefreshStreamingSchedule()
+    {
+        if (_streamingScheduleSet) return;
+        var pool = WeightRegistry.StreamingPool;
+        if (pool is null) return;
+
+        var order = new System.Collections.Generic.List<long>();
+        for (int i = 0; i < Layers.Count; i++) CollectStreamingHandles(Layers[i], order);          // forward 0..N
+        // Backward reuses the same weights in reverse — include it so Belady knows the
+        // late layers are needed again right after the forward turn (training path).
+        if (IsTrainingMode)
+            for (int i = Layers.Count - 1; i >= 0; i--) CollectStreamingHandles(Layers[i], order);
+        if (order.Count == 0) return; // nothing streamed (all weights resident) — keep LRU
+
+        pool.SetAccessSchedule(order.ToArray());
+        _streamingScheduleSet = true;
+    }
+
+    private static void CollectStreamingHandles(ILayer<T> layer, System.Collections.Generic.List<long> order)
+    {
+        if (layer is not LayerBase<T> lb) return;
+        foreach (var t in lb.GetTrainableParameters())
+            if (t is not null && t.StreamingPoolHandle >= 0) order.Add(t.StreamingPoolHandle);
+    }
+
     /// <summary>
     /// Hook into <c>WeightRegistry.PrefetchAsyncMany</c> for the given
     /// layer's trainable tensors. No-op for layers without weights
@@ -4319,6 +4355,15 @@ public abstract class NeuralNetworkBase<T> : INeuralNetworkModel<T>, IInterpreta
         ResolveLazyLayerShapes();
         TryAutoEnableWeightStreaming();
 
+        // Tell the weight-streaming pool which execution mode we're in so its
+        // StreamingStoreDtype.Auto policy is safe: store paged-out weights as bf16
+        // (2x I/O) during INFERENCE — where a read-only weight is quantized once and
+        // never accumulates error — but at full fp32/fp64 precision during TRAINING,
+        // so the pool's canonical copy (the master weight) isn't silently truncated
+        // to bf16 and small optimizer updates aren't lost. No-op unless streaming is
+        // engaged and the dtype is Auto.
+        WeightRegistry.SetStreamingExecutionTraining(isTraining);
+
         if (SupportsTraining)
         {
             IsTrainingMode = isTraining;
@@ -4333,6 +4378,12 @@ public abstract class NeuralNetworkBase<T> : INeuralNetworkModel<T>, IInterpreta
                 _layers[i].SetTrainingMode(isTraining);
             }
         }
+
+        // If weight streaming is engaged, hand the pool the fwd/bwd access schedule
+        // so it pages Belady-optimally. No-op until the first forward has assigned
+        // every weight's StreamingPoolHandle (then it sets the schedule once), and a
+        // no-op when streaming isn't engaged.
+        RefreshStreamingSchedule();
     }
 
     /// <summary>

--- a/src/NeuralNetworks/SyntheticData/CTGANDataSampler.cs
+++ b/src/NeuralNetworks/SyntheticData/CTGANDataSampler.cs
@@ -111,9 +111,85 @@ public class CTGANDataSampler<T>
                 }
             }
 
-            _discreteColumnInfos.Add(new DiscreteColumnInfo(numCats, rowsByCategory));
+            // Log-frequency category-sampling distribution (Xu 2019 §4.3). The
+            // paper samples the conditioned category from the LOGARITHM of its
+            // frequency, not uniformly — this is the actual imbalance-handling
+            // mechanism of training-by-sampling (it lifts rare categories without
+            // fully flattening to uniform, which would over-represent noise). The
+            // official CTGAN uses log(count + 1) normalized.
+            var logFreqProb = new double[numCats];
+            double probSum = 0;
+            for (int c = 0; c < numCats; c++)
+            {
+                logFreqProb[c] = Math.Log(rowsByCategory[c].Count + 1.0);
+                probSum += logFreqProb[c];
+            }
+            if (probSum > 1e-12)
+                for (int c = 0; c < numCats; c++) logFreqProb[c] /= probSum;
+            else
+                for (int c = 0; c < numCats; c++) logFreqProb[c] = 1.0 / numCats;
+
+            _discreteColumnInfos.Add(new DiscreteColumnInfo(numCats, rowsByCategory, logFreqProb));
             _condVectorWidth += numCats;
         }
+    }
+
+    /// <summary>
+    /// Full training-by-sampling draw (Xu 2019 §4.3) exposing everything the
+    /// generator's conditional cross-entropy loss needs: the one-hot conditional
+    /// vector, a MASK that is 1 only over the selected column's category block,
+    /// the selected discrete-column and category indices, and a real row index
+    /// whose value in that column equals the selected category.
+    /// </summary>
+    public (Vector<T> CondVector, Vector<T> Mask, int DiscreteColIndex, int CategoryIndex, int RowIndex) SampleCondVecWithMask()
+    {
+        var condVector = new Vector<T>(_condVectorWidth);
+        var mask = new Vector<T>(_condVectorWidth);
+
+        if (_discreteColumnInfos.Count == 0)
+        {
+            int randomRow = _totalRows > 0 ? _random.Next(_totalRows) : 0;
+            return (condVector, mask, -1, -1, randomRow);
+        }
+
+        int colIdx = _random.Next(_discreteColumnInfos.Count);
+        var colInfo = _discreteColumnInfos[colIdx];
+        int catIdx = SampleCategoryByLogFreq(colInfo);
+
+        int condOffset = 0;
+        for (int c = 0; c < colIdx; c++) condOffset += _discreteColumnInfos[c].NumCategories;
+
+        condVector[condOffset + catIdx] = NumOps.One;
+        for (int c = 0; c < colInfo.NumCategories; c++) mask[condOffset + c] = NumOps.One;
+
+        var rows = colInfo.RowsByCategory[catIdx];
+        int rowIdx = rows.Count > 0 ? rows[_random.Next(rows.Count)] : (_totalRows > 0 ? _random.Next(_totalRows) : 0);
+
+        return (condVector, mask, colIdx, catIdx, rowIdx);
+    }
+
+    /// <summary>
+    /// Samples a category index from a discrete column's log-frequency
+    /// distribution (Xu 2019 §4.3), falling back to a populated category if the
+    /// draw lands on an empty one.
+    /// </summary>
+    private int SampleCategoryByLogFreq(DiscreteColumnInfo colInfo)
+    {
+        double u = _random.NextDouble();
+        double acc = 0;
+        int catIdx = colInfo.NumCategories - 1;
+        for (int c = 0; c < colInfo.NumCategories; c++)
+        {
+            acc += colInfo.CategoryProb[c];
+            if (u <= acc) { catIdx = c; break; }
+        }
+        // Guard: if the chosen category has no real rows, resample to a populated one.
+        int guard = 0;
+        while (colInfo.RowsByCategory[catIdx].Count == 0 && colInfo.NumCategories > 1 && guard++ < 64)
+        {
+            catIdx = _random.Next(colInfo.NumCategories);
+        }
+        return catIdx;
     }
 
     /// <summary>
@@ -144,18 +220,12 @@ public class CTGANDataSampler<T>
             return (condVector, randomRow);
         }
 
-        // Step 1: Pick a random discrete column
+        // Step 1: Pick a random discrete column (uniform over columns, per paper)
         int colIdx = _random.Next(_discreteColumnInfos.Count);
         var colInfo = _discreteColumnInfos[colIdx];
 
-        // Step 2: Pick a random category from that column
-        int catIdx = _random.Next(colInfo.NumCategories);
-
-        // If no rows have this category, pick a random one that does
-        while (colInfo.RowsByCategory[catIdx].Count == 0 && colInfo.NumCategories > 1)
-        {
-            catIdx = _random.Next(colInfo.NumCategories);
-        }
+        // Step 2: Pick a category by LOG-FREQUENCY (Xu 2019 §4.3), not uniformly.
+        int catIdx = SampleCategoryByLogFreq(colInfo);
 
         // Step 3: Set the conditional vector
         int condOffset = 0;
@@ -233,10 +303,14 @@ public class CTGANDataSampler<T>
         public int NumCategories { get; }
         public List<int>[] RowsByCategory { get; }
 
-        public DiscreteColumnInfo(int numCategories, List<int>[] rowsByCategory)
+        /// <summary>Log-frequency sampling distribution over categories (Xu 2019 §4.3).</summary>
+        public double[] CategoryProb { get; }
+
+        public DiscreteColumnInfo(int numCategories, List<int>[] rowsByCategory, double[] categoryProb)
         {
             NumCategories = numCategories;
             RowsByCategory = rowsByCategory;
+            CategoryProb = categoryProb;
         }
     }
 

--- a/src/NeuralNetworks/SyntheticData/CTGANGenerator.cs
+++ b/src/NeuralNetworks/SyntheticData/CTGANGenerator.cs
@@ -80,7 +80,16 @@ namespace AiDotNet.NeuralNetworks.SyntheticData;
 public class CTGANGenerator<T> : NeuralNetworkBase<T>, ISyntheticTabularGenerator<T>
 {
     private readonly CTGANOptions<T> _options;
-    private IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>> _optimizer;
+    // SEPARATE optimizers for generator and discriminator. They MUST be distinct
+    // instances: AdamOptimizer keeps a single flat (_m,_v) moment buffer sized to
+    // the parameter count and resets the timestep whenever that count changes, so
+    // sharing one optimizer across the generator and discriminator (different
+    // param counts) wiped the moments every alternating Step and pinned bias
+    // correction at t=1 — the root cause of CTGAN diverging worse with more
+    // epochs. The golden GAN base (GenerativeAdversarialNetwork<T>) likewise keeps
+    // separate optimizers.
+    private IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>> _generatorOptimizer;
+    private IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>> _discriminatorOptimizer;
     private ILossFunction<T> _lossFunction;
 
     // Synthetic tabular data infrastructure
@@ -91,6 +100,13 @@ public class CTGANGenerator<T> : NeuralNetworkBase<T>, ISyntheticTabularGenerato
     private int _condWidth;
     private int _packedInputDim;
     private Random _random;
+
+    // Generated-output offsets of each categorical column's softmax block, in
+    // categorical-column order — the SAME order the conditional vector lays out its
+    // category blocks. Used to align the generator's output categorical
+    // distributions with the conditional one-hot so the §4.3 conditional
+    // cross-entropy loss can be computed. (offset, width) per categorical column.
+    private readonly List<(int Offset, int Width)> _catOutputBlocks = new();
 
     // Generator batch normalization layers (auxiliary, always created to match Layers)
     private readonly List<BatchNormalizationLayer<T>> _genBNLayers = new();
@@ -181,7 +197,22 @@ public class CTGANGenerator<T> : NeuralNetworkBase<T>, ISyntheticTabularGenerato
     {
         _options = options ?? new CTGANOptions<T>();
         _lossFunction = lossFunction ?? NeuralNetworkHelper<T>.GetDefaultLossFunction(architecture.TaskType);
-        _optimizer = optimizer ?? new AdamOptimizer<T, Tensor<T>, Tensor<T>>(this);
+
+        // WGAN-GP Adam configuration (Gulrajani et al. 2017 / Xu et al. 2019):
+        // β1=0.5, β2=0.9, no adaptive-LR mutation (the GP already regularizes the
+        // critic). Two independent instances so generator and discriminator
+        // moment estimates never cross-contaminate.
+        AdamOptimizer<T, Tensor<T>, Tensor<T>> MakeAdam() =>
+            new(this, new Models.Options.AdamOptimizerOptions<T, Tensor<T>, Tensor<T>>
+            {
+                InitialLearningRate = _options.LearningRate,
+                Beta1 = 0.5,
+                Beta2 = 0.9,
+                UseAdaptiveLearningRate = false,
+                UseAMSGrad = false,
+            });
+        _generatorOptimizer = optimizer ?? MakeAdam();
+        _discriminatorOptimizer = MakeAdam();
 
         int? seed = _options.Seed;
         _random = seed.HasValue
@@ -300,7 +331,7 @@ public class CTGANGenerator<T> : NeuralNetworkBase<T>, ISyntheticTabularGenerato
 
     private void UpdateNetworkParameters()
     {
-        _optimizer.UpdateParameters(Layers);
+        _generatorOptimizer.UpdateParameters(Layers);
     }
 
     /// <inheritdoc />
@@ -348,6 +379,7 @@ public class CTGANGenerator<T> : NeuralNetworkBase<T>, ISyntheticTabularGenerato
         _transformer = new TabularDataTransformer<T>(_options.VGMModes, _random);
         _transformer.Fit(data, _columns);
         _dataWidth = _transformer.TransformedWidth;
+        BuildCategoricalOutputBlocks();
 
         // Step 2: Fit the data sampler
         _sampler = new CTGANDataSampler<T>(_random);
@@ -403,6 +435,7 @@ public class CTGANGenerator<T> : NeuralNetworkBase<T>, ISyntheticTabularGenerato
             _transformer = new TabularDataTransformer<T>(_options.VGMModes, _random);
             _transformer.Fit(data, _columns);
             _dataWidth = _transformer.TransformedWidth;
+            BuildCategoricalOutputBlocks();
 
             _sampler = new CTGANDataSampler<T>(_random);
             _sampler.Fit(data, _columns);
@@ -618,7 +651,7 @@ public class CTGANGenerator<T> : NeuralNetworkBase<T>, ISyntheticTabularGenerato
             discParams, grads, lossValue,
             realPacked, realPacked, ComputeForward, RecomputeLoss,
             parameterBuffer: null);
-        _optimizer.Step(context);
+        _discriminatorOptimizer.Step(context);
     }
 
     /// <summary>
@@ -629,6 +662,67 @@ public class CTGANGenerator<T> : NeuralNetworkBase<T>, ISyntheticTabularGenerato
     /// frozen forward, so generator parameters get gradients via the critic
     /// but the critic itself does not update on this step.
     /// </summary>
+    /// <summary>
+    /// Records the generated-output offset + width of each categorical column's
+    /// softmax block, in categorical-column order (the order the conditional vector
+    /// uses), so <see cref="ConditionalCrossEntropy"/> can align them.
+    /// </summary>
+    private void BuildCategoricalOutputBlocks()
+    {
+        _catOutputBlocks.Clear();
+        if (_transformer is null) return;
+        for (int col = 0; col < _columns.Count; col++)
+        {
+            var info = _transformer.GetTransformInfo(col);
+            if (!info.IsContinuous)
+                _catOutputBlocks.Add((info.StartOffset, info.Width));
+        }
+    }
+
+    /// <summary>
+    /// Samples a batch of conditional vectors together with their masks (Xu 2019
+    /// §4.3). Returns ([N, condWidth] one-hot conditions, [N, condWidth] masks that
+    /// are 1 over the selected column's block). Both are tape constants.
+    /// </summary>
+    private (Tensor<T> Cond, Tensor<T> Mask) SampleCondMaskBatch(int batchSize)
+    {
+        var cond = new Tensor<T>([batchSize, _condWidth]);
+        var mask = new Tensor<T>([batchSize, _condWidth]);
+        if (_sampler is null || _condWidth == 0) return (cond, mask);
+        for (int b = 0; b < batchSize; b++)
+        {
+            var (cv, mv, _, _, _) = _sampler.SampleCondVecWithMask();
+            for (int j = 0; j < _condWidth; j++) { cond[b, j] = cv[j]; mask[b, j] = mv[j]; }
+        }
+        return (cond, mask);
+    }
+
+    /// <summary>
+    /// Conditional generator loss term (Xu 2019 §4.3): cross-entropy between the
+    /// conditional one-hot and the generator's output distribution for the
+    /// conditioned discrete column, masked to that column. With a one-hot condition
+    /// inside the masked block this reduces to -log p(selected category), averaged
+    /// over the batch — the term that forces the generator to actually honour the
+    /// conditional vector instead of ignoring it.
+    /// </summary>
+    private Tensor<T> ConditionalCrossEntropy(Tensor<T> fakeActivated, Tensor<T> condBatch, Tensor<T> maskBatch)
+    {
+        int batch = fakeActivated.Shape[0];
+        // Gather the generator's categorical softmax blocks in categorical-column
+        // order → [batch, condWidth], aligning with the conditional-vector layout.
+        var blocks = new List<Tensor<T>>(_catOutputBlocks.Count);
+        foreach (var (offset, width) in _catOutputBlocks)
+            blocks.Add(Engine.TensorSlice(fakeActivated, [0, offset], [batch, width]));
+        var alignedGen = blocks.Count == 1 ? blocks[0] : Engine.TensorConcatenate(blocks.ToArray(), axis: 1);
+
+        // CE = -mean_b sum_j mask*cond*log(alignedGen + eps).
+        var logp = Engine.TensorLog(Engine.TensorAddScalar(alignedGen, NumOps.FromDouble(1e-8)));
+        var masked = Engine.TensorMultiply(Engine.TensorMultiply(maskBatch, condBatch), logp);
+        var perRow = Engine.ReduceSum(masked, [1], keepDims: false);     // [batch]
+        var meanCe = Engine.ReduceMean(perRow, [0], keepDims: false);     // scalar
+        return Engine.TensorNegate(meanCe);
+    }
+
     private void TrainGeneratorStepBatched(Matrix<T> transformedData, int numPacks)
     {
         if (_sampler is null) return;
@@ -645,9 +739,10 @@ public class CTGANGenerator<T> : NeuralNetworkBase<T>, ISyntheticTabularGenerato
         int singleDim = _dataWidth + _condWidth;
         int genInputDim = _options.EmbeddingDimension + _condWidth;
 
-        // Build the conditional generator input batch [numPacks * pacSize, genInputDim].
+        // Build the conditional generator input batch [numPacks * pacSize, genInputDim],
+        // capturing the mask so the conditional cross-entropy term can be computed.
         var noiseBatch = GenerateNoiseBatchTensor(numPacks * pacSize);
-        var condBatch = SampleConditionalBatchTensor(numPacks * pacSize);
+        var (condBatch, maskBatch) = SampleCondMaskBatch(numPacks * pacSize);
         var genInput = Engine.TensorConcatenate([noiseBatch, condBatch], axis: 1);
 
         // Forward through generator → produces [numPacks * pacSize, dataWidth].
@@ -662,8 +757,13 @@ public class CTGANGenerator<T> : NeuralNetworkBase<T>, ISyntheticTabularGenerato
         var fakeScores = DiscriminatorForwardBatched(fakePacked, isTraining: false);
         var allAxes = Enumerable.Range(0, fakeScores.Shape.Length).ToArray();
         var avgFake = Engine.ReduceMean(fakeScores, allAxes, keepDims: false);
-        // Generator minimizes -E[D(G(z, c))].
+        // Generator loss = -E[D(G(z, c))] + conditional cross-entropy (Xu 2019 §4.3).
         var lossTensor = Engine.TensorNegate(avgFake);
+        if (_condWidth > 0 && _catOutputBlocks.Count > 0)
+        {
+            var ce = ConditionalCrossEntropy(fakeActivated, condBatch, maskBatch);
+            lossTensor = Engine.TensorAdd(lossTensor, ce);
+        }
 
         var grads = tape.ComputeGradients(lossTensor, genParams);
         T lossValue = lossTensor.Length > 0 ? lossTensor[0] : NumOps.Zero;
@@ -682,7 +782,7 @@ public class CTGANGenerator<T> : NeuralNetworkBase<T>, ISyntheticTabularGenerato
             genParams, grads, lossValue,
             genInput, genInput, ComputeForward, RecomputeLoss,
             parameterBuffer: null);
-        _optimizer.Step(context);
+        _generatorOptimizer.Step(context);
     }
 
     /// <summary>
@@ -1246,7 +1346,7 @@ public class CTGANGenerator<T> : NeuralNetworkBase<T>, ISyntheticTabularGenerato
         return new CTGANGenerator<T>(
             Architecture,
             _options,
-            _optimizer,
+            _generatorOptimizer,
             _lossFunction);
     }
 

--- a/src/NeuralNetworks/SyntheticData/CausalGANGenerator.cs
+++ b/src/NeuralNetworks/SyntheticData/CausalGANGenerator.cs
@@ -97,7 +97,9 @@ namespace AiDotNet.NeuralNetworks.SyntheticData;
 public class CausalGANGenerator<T> : NeuralNetworkBase<T>, ISyntheticTabularGenerator<T>
 {
     private readonly CausalGANOptions<T> _options;
-    private IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>> _optimizer;
+    // Separate G/D optimizers (see CTGANGenerator for the divergence rationale).
+    private IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>> _generatorOptimizer;
+    private IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>> _discriminatorOptimizer;
     private ILossFunction<T> _lossFunction;
 
     // Synthetic tabular data infrastructure
@@ -171,7 +173,17 @@ public class CausalGANGenerator<T> : NeuralNetworkBase<T>, ISyntheticTabularGene
     {
         _options = options ?? new CausalGANOptions<T>();
         _lossFunction = lossFunction ?? NeuralNetworkHelper<T>.GetDefaultLossFunction(architecture.TaskType);
-        _optimizer = optimizer ?? new AdamOptimizer<T, Tensor<T>, Tensor<T>>(this);
+        AdamOptimizer<T, Tensor<T>, Tensor<T>> MakeAdam() =>
+            new(this, new Models.Options.AdamOptimizerOptions<T, Tensor<T>, Tensor<T>>
+            {
+                InitialLearningRate = _options.LearningRate,
+                Beta1 = 0.5,
+                Beta2 = 0.9,
+                UseAdaptiveLearningRate = false,
+                UseAMSGrad = false,
+            });
+        _generatorOptimizer = optimizer ?? MakeAdam();
+        _discriminatorOptimizer = MakeAdam();
         _random = _options.Seed.HasValue
             ? RandomHelper.CreateSeededRandom(_options.Seed.Value)
             : RandomHelper.CreateSecureRandom();
@@ -626,7 +638,7 @@ public class CausalGANGenerator<T> : NeuralNetworkBase<T>, ISyntheticTabularGene
             discParams, grads, lossValue,
             realBatch, realBatch, ComputeForward, RecomputeLoss,
             parameterBuffer: null);
-        _optimizer.Step(context);
+        _discriminatorOptimizer.Step(context);
     }
 
     /// <summary>
@@ -668,7 +680,7 @@ public class CausalGANGenerator<T> : NeuralNetworkBase<T>, ISyntheticTabularGene
             genParams, grads, lossValue,
             noiseBatch, noiseBatch, ComputeForward, RecomputeLoss,
             parameterBuffer: null);
-        _optimizer.Step(context);
+        _generatorOptimizer.Step(context);
     }
 
     private (Tensor<T> realBatch, Tensor<T> fakeBatch) BuildRealAndFakeBatches(
@@ -1260,7 +1272,7 @@ public class CausalGANGenerator<T> : NeuralNetworkBase<T>, ISyntheticTabularGene
         return new CausalGANGenerator<T>(
             Architecture,
             _options,
-            _optimizer,
+            _generatorOptimizer,
             _lossFunction);
     }
 

--- a/src/NeuralNetworks/SyntheticData/CopulaGANGenerator.cs
+++ b/src/NeuralNetworks/SyntheticData/CopulaGANGenerator.cs
@@ -82,7 +82,13 @@ namespace AiDotNet.NeuralNetworks.SyntheticData;
 public class CopulaGANGenerator<T> : NeuralNetworkBase<T>, ISyntheticTabularGenerator<T>
 {
     private readonly CopulaGANOptions<T> _options;
-    private IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>> _optimizer;
+    // Separate generator/discriminator optimizers — see CTGANGenerator for the
+    // full rationale: AdamOptimizer keeps one flat (_m,_v) moment buffer sized to
+    // the parameter count and resets the timestep when that count changes, so a
+    // single optimizer shared across G and D (different param counts) wiped the
+    // moments every alternating Step and diverged worse with more epochs.
+    private IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>> _generatorOptimizer;
+    private IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>> _discriminatorOptimizer;
     private ILossFunction<T> _lossFunction;
 
     // Synthetic tabular data infrastructure
@@ -187,7 +193,17 @@ public class CopulaGANGenerator<T> : NeuralNetworkBase<T>, ISyntheticTabularGene
     {
         _options = options ?? new CopulaGANOptions<T>();
         _lossFunction = lossFunction ?? NeuralNetworkHelper<T>.GetDefaultLossFunction(architecture.TaskType);
-        _optimizer = optimizer ?? new AdamOptimizer<T, Tensor<T>, Tensor<T>>(this);
+        AdamOptimizer<T, Tensor<T>, Tensor<T>> MakeAdam() =>
+            new(this, new Models.Options.AdamOptimizerOptions<T, Tensor<T>, Tensor<T>>
+            {
+                InitialLearningRate = _options.LearningRate,
+                Beta1 = 0.5,
+                Beta2 = 0.9,
+                UseAdaptiveLearningRate = false,
+                UseAMSGrad = false,
+            });
+        _generatorOptimizer = optimizer ?? MakeAdam();
+        _discriminatorOptimizer = MakeAdam();
         _random = _options.Seed.HasValue
             ? RandomHelper.CreateSeededRandom(_options.Seed.Value)
             : RandomHelper.CreateSecureRandom();
@@ -688,7 +704,7 @@ public class CopulaGANGenerator<T> : NeuralNetworkBase<T>, ISyntheticTabularGene
             discParams, grads, lossValue,
             realPacked, realPacked, ComputeForward, RecomputeLoss,
             parameterBuffer: null);
-        _optimizer.Step(context);
+        _discriminatorOptimizer.Step(context);
     }
 
     /// <summary>
@@ -738,7 +754,7 @@ public class CopulaGANGenerator<T> : NeuralNetworkBase<T>, ISyntheticTabularGene
             genParams, grads, lossValue,
             genInput, genInput, ComputeForward, RecomputeLoss,
             parameterBuffer: null);
-        _optimizer.Step(context);
+        _generatorOptimizer.Step(context);
     }
 
     private (Tensor<T> realPacked, Tensor<T> fakePacked) BuildPackedRealAndFakeBatches(
@@ -1421,7 +1437,7 @@ public class CopulaGANGenerator<T> : NeuralNetworkBase<T>, ISyntheticTabularGene
         return new CopulaGANGenerator<T>(
             Architecture,
             _options,
-            _optimizer,
+            _generatorOptimizer,
             _lossFunction);
     }
 

--- a/src/NeuralNetworks/SyntheticData/CopulaSynthGenerator.cs
+++ b/src/NeuralNetworks/SyntheticData/CopulaSynthGenerator.cs
@@ -50,8 +50,18 @@ public class CopulaSynthGenerator<T> : SyntheticTabularGeneratorBase<T>
 {
     private readonly CopulaSynthOptions<T> _options;
 
-    // Marginal parameters per feature
+    // Marginal parameters per feature: sorted observed values, used as the
+    // empirical quantile grid. For the probability-integral transform to be
+    // rank-preserving (and therefore correlation-preserving), the forward CDF
+    // and the inverse CDF MUST share one plotting-position grid — see
+    // EmpiricalCDF / InverseEmpiricalCDF.
     private double[][] _sortedValues = Array.Empty<double[]>();
+
+    // Per-feature column type, captured at fit time. Categorical and Discrete
+    // columns must NOT be linearly interpolated on the inverse transform —
+    // doing so leaks float noise into integer/categorical columns (the Copula
+    // failure mode). Continuous columns interpolate normally.
+    private ColumnDataType[] _columnTypes = Array.Empty<ColumnDataType>();
 
     // Gaussian copula: correlation matrix (Cholesky-decomposed for sampling)
     private double[,]? _choleskyCorr;
@@ -72,6 +82,16 @@ public class CopulaSynthGenerator<T> : SyntheticTabularGeneratorBase<T>
     {
         _numFeatures = data.Columns;
         int n = data.Rows;
+
+        // Capture per-column type so the inverse transform can snap categorical
+        // and discrete columns to valid values instead of interpolating between
+        // them. `columns` was previously accepted and ignored — that omission is
+        // exactly why float noise leaked into categorical columns.
+        _columnTypes = new ColumnDataType[_numFeatures];
+        for (int j = 0; j < _numFeatures; j++)
+        {
+            _columnTypes[j] = j < columns.Count ? columns[j].DataType : ColumnDataType.Continuous;
+        }
 
         // Step 1: Store sorted values per feature for empirical CDF/quantile
         _sortedValues = new double[_numFeatures][];
@@ -144,40 +164,89 @@ public class CopulaSynthGenerator<T> : SyntheticTabularGeneratorBase<T>
     }
 
     /// <summary>
-    /// Computes the empirical CDF value for a given feature and value.
-    /// P(X &lt;= x) approximated by the proportion of sorted values &lt;= x.
+    /// Forward empirical CDF for the probability-integral transform. The i-th
+    /// order statistic (0-based) is mapped to the Hazen plotting position
+    /// <c>(i + 0.5) / n</c>. This is the inverse of <see cref="InverseEmpiricalCDF"/>
+    /// on the SAME grid — the two MUST agree, or the round-trip
+    /// value→u→normal→…→normal→u→value stops being rank-preserving and the fitted
+    /// correlation bleeds off (the 0.82–0.93 degradation). Hazen positions sit
+    /// strictly inside (0, 1), so no boundary clamping is needed and the tails
+    /// are not squashed.
     /// </summary>
     private double EmpiricalCDF(int featureIndex, double value)
     {
         var sorted = _sortedValues[featureIndex];
         int n = sorted.Length;
         if (n == 0) return 0.5;
+        if (n == 1) return 0.5;
 
-        // Binary search for the position
-        int idx = Array.BinarySearch(sorted, value);
-        if (idx < 0) idx = ~idx;
-        else idx++; // Include the found element
-
-        return (double)idx / n;
+        // Rank = number of values strictly less than `value`, plus half the ties
+        // (mid-rank), so equal values map to a single shared plotting position and
+        // the transform stays monotone. Implemented via the two bisection bounds.
+        int lower = LowerBound(sorted, value); // first index >= value
+        int upper = UpperBound(sorted, value); // first index > value
+        double rank = (lower + upper) / 2.0;    // mid-rank of the tie block
+        return (rank + 0.5) / n;
     }
 
     /// <summary>
-    /// Inverse empirical CDF (quantile function): given probability u, returns value.
-    /// Uses linear interpolation between sorted values.
+    /// Inverse empirical CDF (quantile function) on the Hazen grid that
+    /// <see cref="EmpiricalCDF"/> uses: plotting position <c>(i + 0.5)/n</c> maps
+    /// back to <c>sorted[i]</c>. For Continuous columns we interpolate linearly
+    /// between adjacent order statistics; for Categorical and Discrete columns we
+    /// snap to the nearest order statistic (no interpolation) so the output is
+    /// always a value that actually occurred — fixing the float-into-categorical
+    /// leak (e.g. Education ∈ {0,1,2,3} can never come back as 1.7).
     /// </summary>
     private double InverseEmpiricalCDF(int featureIndex, double u)
     {
         var sorted = _sortedValues[featureIndex];
         int n = sorted.Length;
         if (n == 0) return 0;
+        if (n == 1) return sorted[0];
 
-        double idx = u * (n - 1);
-        int lo = (int)Math.Floor(idx);
-        int hi = Math.Min(lo + 1, n - 1);
-        lo = Math.Max(lo, 0);
+        bool snap = _columnTypes.Length > featureIndex
+            && _columnTypes[featureIndex] != ColumnDataType.Continuous;
 
-        double frac = idx - lo;
+        // Position on the Hazen grid: u = (pos + 0.5)/n  ⇒  pos = u*n - 0.5.
+        double pos = u * n - 0.5;
+        if (pos <= 0) return sorted[0];
+        if (pos >= n - 1) return sorted[n - 1];
+
+        int lo = (int)Math.Floor(pos);
+        int hi = lo + 1;
+        double frac = pos - lo;
+
+        if (snap)
+        {
+            // Discrete / categorical: pick the nearer order statistic. Never blend.
+            return frac < 0.5 ? sorted[lo] : sorted[hi];
+        }
         return sorted[lo] * (1 - frac) + sorted[hi] * frac;
+    }
+
+    /// <summary>First index i with sorted[i] &gt;= value (lower bound).</summary>
+    private static int LowerBound(double[] sorted, double value)
+    {
+        int lo = 0, hi = sorted.Length;
+        while (lo < hi)
+        {
+            int mid = lo + ((hi - lo) >> 1);
+            if (sorted[mid] < value) lo = mid + 1; else hi = mid;
+        }
+        return lo;
+    }
+
+    /// <summary>First index i with sorted[i] &gt; value (upper bound).</summary>
+    private static int UpperBound(double[] sorted, double value)
+    {
+        int lo = 0, hi = sorted.Length;
+        while (lo < hi)
+        {
+            int mid = lo + ((hi - lo) >> 1);
+            if (sorted[mid] <= value) lo = mid + 1; else hi = mid;
+        }
+        return lo;
     }
 
     /// <summary>

--- a/src/NeuralNetworks/SyntheticData/DPCTGANGenerator.cs
+++ b/src/NeuralNetworks/SyntheticData/DPCTGANGenerator.cs
@@ -90,7 +90,9 @@ namespace AiDotNet.NeuralNetworks.SyntheticData;
 public class DPCTGANGenerator<T> : NeuralNetworkBase<T>, ISyntheticTabularGenerator<T>
 {
     private readonly DPCTGANOptions<T> _options;
-    private IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>> _optimizer;
+    // Separate G/D optimizers (see CTGANGenerator for the divergence rationale).
+    private IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>> _generatorOptimizer;
+    private IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>> _discriminatorOptimizer;
     private ILossFunction<T> _lossFunction;
 
     // Synthetic tabular data infrastructure
@@ -192,7 +194,17 @@ public class DPCTGANGenerator<T> : NeuralNetworkBase<T>, ISyntheticTabularGenera
     {
         _options = options ?? new DPCTGANOptions<T>();
         _lossFunction = lossFunction ?? NeuralNetworkHelper<T>.GetDefaultLossFunction(architecture.TaskType);
-        _optimizer = optimizer ?? new AdamOptimizer<T, Tensor<T>, Tensor<T>>(this);
+        AdamOptimizer<T, Tensor<T>, Tensor<T>> MakeAdam() =>
+            new(this, new Models.Options.AdamOptimizerOptions<T, Tensor<T>, Tensor<T>>
+            {
+                InitialLearningRate = _options.LearningRate,
+                Beta1 = 0.5,
+                Beta2 = 0.9,
+                UseAdaptiveLearningRate = false,
+                UseAMSGrad = false,
+            });
+        _generatorOptimizer = optimizer ?? MakeAdam();
+        _discriminatorOptimizer = MakeAdam();
         _random = _options.Seed.HasValue
             ? RandomHelper.CreateSeededRandom(_options.Seed.Value)
             : RandomHelper.CreateSecureRandom();
@@ -302,7 +314,7 @@ public class DPCTGANGenerator<T> : NeuralNetworkBase<T>, ISyntheticTabularGenera
 
     private void UpdateNetworkParameters()
     {
-        _optimizer.UpdateParameters(Layers);
+        _generatorOptimizer.UpdateParameters(Layers);
     }
 
     /// <inheritdoc />
@@ -671,7 +683,7 @@ public class DPCTGANGenerator<T> : NeuralNetworkBase<T>, ISyntheticTabularGenera
             discParams, noisedGrads, lossValue,
             realPacked, realPacked, ComputeForward, RecomputeLoss,
             parameterBuffer: null);
-        _optimizer.Step(context);
+        _discriminatorOptimizer.Step(context);
     }
 
     /// <summary>
@@ -722,7 +734,7 @@ public class DPCTGANGenerator<T> : NeuralNetworkBase<T>, ISyntheticTabularGenera
             genParams, grads, lossValue,
             genInput, genInput, ComputeForward, RecomputeLoss,
             parameterBuffer: null);
-        _optimizer.Step(context);
+        _generatorOptimizer.Step(context);
     }
 
     /// <summary>
@@ -1335,7 +1347,7 @@ public class DPCTGANGenerator<T> : NeuralNetworkBase<T>, ISyntheticTabularGenera
         return new DPCTGANGenerator<T>(
             Architecture,
             _options,
-            _optimizer,
+            _generatorOptimizer,
             _lossFunction);
     }
 

--- a/src/NeuralNetworks/SyntheticData/MedSynthGenerator.cs
+++ b/src/NeuralNetworks/SyntheticData/MedSynthGenerator.cs
@@ -72,7 +72,13 @@ namespace AiDotNet.NeuralNetworks.SyntheticData;
 public class MedSynthGenerator<T> : NeuralNetworkBase<T>, ISyntheticTabularGenerator<T>
 {
     private readonly MedSynthOptions<T> _options;
-    private IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>> _optimizer;
+    // One dedicated optimizer per sub-network (discriminator / generator / VAE).
+    // See CTGANGenerator: a single shared AdamOptimizer corrupts its flat moment
+    // buffer across networks of different parameter counts. MedSynth trains three
+    // distinct param sets, so it needs three independent optimizers.
+    private IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>> _generatorOptimizer;
+    private IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>> _discriminatorOptimizer;
+    private IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>> _vaeOptimizer;
     private ILossFunction<T> _lossFunction;
     private Random _random;
 
@@ -152,7 +158,18 @@ public class MedSynthGenerator<T> : NeuralNetworkBase<T>, ISyntheticTabularGener
     {
         _options = options ?? new MedSynthOptions<T>();
         _lossFunction = lossFunction ?? NeuralNetworkHelper<T>.GetDefaultLossFunction(architecture.TaskType);
-        _optimizer = optimizer ?? new AdamOptimizer<T, Tensor<T>, Tensor<T>>(this);
+        AdamOptimizer<T, Tensor<T>, Tensor<T>> MakeAdam() =>
+            new(this, new Models.Options.AdamOptimizerOptions<T, Tensor<T>, Tensor<T>>
+            {
+                InitialLearningRate = _options.LearningRate,
+                Beta1 = 0.5,
+                Beta2 = 0.9,
+                UseAdaptiveLearningRate = false,
+                UseAMSGrad = false,
+            });
+        _generatorOptimizer = optimizer ?? MakeAdam();
+        _discriminatorOptimizer = MakeAdam();
+        _vaeOptimizer = MakeAdam();
         _random = _options.Seed.HasValue
             ? RandomHelper.CreateSeededRandom(_options.Seed.Value)
             : RandomHelper.CreateSecureRandom();
@@ -424,7 +441,7 @@ public class MedSynthGenerator<T> : NeuralNetworkBase<T>, ISyntheticTabularGener
         SetTrainingMode(true);
         try
         {
-            TrainWithTape(input, expectedOutput, _optimizer);
+            TrainWithTape(input, expectedOutput, _vaeOptimizer);
         }
         finally
         {
@@ -576,7 +593,7 @@ public class MedSynthGenerator<T> : NeuralNetworkBase<T>, ISyntheticTabularGener
             discParams, grads, lossValue,
             realBatch, realBatch, ComputeForward, RecomputeLoss,
             parameterBuffer: null);
-        _optimizer.Step(context);
+        _discriminatorOptimizer.Step(context);
     }
 
     /// <summary>
@@ -703,7 +720,7 @@ public class MedSynthGenerator<T> : NeuralNetworkBase<T>, ISyntheticTabularGener
             discParams, noisedAvgGrads, avgLoss,
             stackedReal, stackedReal, ComputeForward, RecomputeLoss,
             parameterBuffer: null);
-        _optimizer.Step(context);
+        _discriminatorOptimizer.Step(context);
     }
 
     /// <summary>
@@ -749,7 +766,7 @@ public class MedSynthGenerator<T> : NeuralNetworkBase<T>, ISyntheticTabularGener
             genParams, grads, lossValue,
             noiseBatch, noiseBatch, ComputeForward, RecomputeLoss,
             parameterBuffer: null);
-        _optimizer.Step(context);
+        _generatorOptimizer.Step(context);
     }
 
     /// <summary>
@@ -963,7 +980,7 @@ public class MedSynthGenerator<T> : NeuralNetworkBase<T>, ISyntheticTabularGener
             vaeParams, grads, lossValue,
             realBatch, realBatch, ComputeForward, RecomputeLoss,
             parameterBuffer: null);
-        _optimizer.Step(context);
+        _vaeOptimizer.Step(context);
     }
 
     /// <summary>

--- a/src/NeuralNetworks/SyntheticData/MisGANGenerator.cs
+++ b/src/NeuralNetworks/SyntheticData/MisGANGenerator.cs
@@ -104,7 +104,15 @@ namespace AiDotNet.NeuralNetworks.SyntheticData;
 public class MisGANGenerator<T> : NeuralNetworkBase<T>, ISyntheticTabularGenerator<T>
 {
     private readonly MisGANOptions<T> _options;
-    private IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>> _optimizer;
+    // One dedicated optimizer per sub-network (Li et al. 2019 MisGAN trains four:
+    // data discriminator, mask discriminator, data generator, mask generator).
+    // See CTGANGenerator for why one shared AdamOptimizer corrupts moments across
+    // networks of different parameter counts. TapeStepOver takes the optimizer so
+    // each network keeps its own moment state.
+    private IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>> _dataGenOptimizer;
+    private IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>> _maskGenOptimizer;
+    private IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>> _dataDiscOptimizer;
+    private IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>> _maskDiscOptimizer;
     private ILossFunction<T> _lossFunction;
 
     // Synthetic tabular data infrastructure
@@ -186,7 +194,19 @@ public class MisGANGenerator<T> : NeuralNetworkBase<T>, ISyntheticTabularGenerat
     {
         _options = options ?? new MisGANOptions<T>();
         _lossFunction = lossFunction ?? NeuralNetworkHelper<T>.GetDefaultLossFunction(architecture.TaskType);
-        _optimizer = optimizer ?? new AdamOptimizer<T, Tensor<T>, Tensor<T>>(this);
+        AdamOptimizer<T, Tensor<T>, Tensor<T>> MakeAdam() =>
+            new(this, new Models.Options.AdamOptimizerOptions<T, Tensor<T>, Tensor<T>>
+            {
+                InitialLearningRate = _options.LearningRate,
+                Beta1 = 0.5,
+                Beta2 = 0.9,
+                UseAdaptiveLearningRate = false,
+                UseAMSGrad = false,
+            });
+        _dataGenOptimizer = optimizer ?? MakeAdam();
+        _maskGenOptimizer = MakeAdam();
+        _dataDiscOptimizer = MakeAdam();
+        _maskDiscOptimizer = MakeAdam();
         _random = _options.Seed.HasValue
             ? RandomHelper.CreateSeededRandom(_options.Seed.Value)
             : RandomHelper.CreateSecureRandom();
@@ -565,7 +585,7 @@ public class MisGANGenerator<T> : NeuralNetworkBase<T>, ISyntheticTabularGenerat
             var fakeMask = MaskGeneratorForward(maskNoise);
             var fakeScore = DataDiscriminatorForward(ElementwiseMultiplyTensor(fakeRow, fakeMask), isTraining: true);
             var loss = Engine.TensorSubtract(ReduceToScalar(fakeScore), ReduceToScalar(realScore));
-            TapeStepOver(tape, loss, criticLayers);
+            TapeStepOver(tape, loss, criticLayers, _dataDiscOptimizer);
             ClipWeights(criticLayers);
         }
     }
@@ -583,7 +603,7 @@ public class MisGANGenerator<T> : NeuralNetworkBase<T>, ISyntheticTabularGenerat
             var fakeMask = MaskGeneratorForward(noise);
             var fakeScore = MaskDiscriminatorForward(fakeMask, isTraining: true);
             var loss = Engine.TensorSubtract(ReduceToScalar(fakeScore), ReduceToScalar(realScore));
-            TapeStepOver(tape, loss, criticLayers);
+            TapeStepOver(tape, loss, criticLayers, _maskDiscOptimizer);
             ClipWeights(criticLayers);
         }
     }
@@ -602,7 +622,7 @@ public class MisGANGenerator<T> : NeuralNetworkBase<T>, ISyntheticTabularGenerat
             var fakeMask = MaskGeneratorForward(maskNoise);
             var fakeScore = DataDiscriminatorForward(ElementwiseMultiplyTensor(fakeRow, fakeMask), isTraining: true);
             var loss = Engine.TensorNegate(ReduceToScalar(fakeScore));
-            TapeStepOver(tape, loss, BuildDataGenLayerList());
+            TapeStepOver(tape, loss, BuildDataGenLayerList(), _dataGenOptimizer);
         }
     }
 
@@ -616,7 +636,7 @@ public class MisGANGenerator<T> : NeuralNetworkBase<T>, ISyntheticTabularGenerat
             var fakeMask = MaskGeneratorForward(noise);
             var fakeScore = MaskDiscriminatorForward(fakeMask, isTraining: true);
             var loss = Engine.TensorNegate(ReduceToScalar(fakeScore));
-            TapeStepOver(tape, loss, BuildMaskGenLayerList());
+            TapeStepOver(tape, loss, BuildMaskGenLayerList(), _maskGenOptimizer);
         }
     }
 
@@ -625,7 +645,8 @@ public class MisGANGenerator<T> : NeuralNetworkBase<T>, ISyntheticTabularGenerat
     #region Tape Step Helpers
 
     /// <summary>Runs one optimizer step over the given sub-network's parameters from a tape-tracked loss.</summary>
-    private void TapeStepOver(GradientTape<T> tape, Tensor<T> loss, IReadOnlyList<ILayer<T>> layers)
+    private void TapeStepOver(GradientTape<T> tape, Tensor<T> loss, IReadOnlyList<ILayer<T>> layers,
+        IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>> optimizer)
     {
         var trainable = Training.TapeTrainingStep<T>.CollectParameters(layers);
         if (trainable.Count == 0) return;
@@ -633,7 +654,7 @@ public class MisGANGenerator<T> : NeuralNetworkBase<T>, ISyntheticTabularGenerat
         T lossValue = loss.Length > 0 ? loss[0] : NumOps.Zero;
         LastLoss = lossValue;
         var ctx = new AiDotNet.Tensors.Engines.Autodiff.TapeStepContext<T>(trainable, grads, lossValue);
-        _optimizer.Step(ctx);
+        optimizer.Step(ctx);
     }
 
     private Tensor<T> ReduceToScalar(Tensor<T> t)
@@ -717,7 +738,7 @@ public class MisGANGenerator<T> : NeuralNetworkBase<T>, ISyntheticTabularGenerat
             Tensor<T> loss = LossFunction is LossFunctions.LossFunctionBase<T> tapeLoss
                 ? tapeLoss.ComputeTapeLoss(flatOut, target)
                 : ReduceToScalar(Engine.TensorSquare(Engine.TensorSubtract(flatOut, target)));
-            TapeStepOver(tape, loss, BuildDataGenLayerList());
+            TapeStepOver(tape, loss, BuildDataGenLayerList(), _dataGenOptimizer);
         }
         finally
         {

--- a/src/NeuralNetworks/SyntheticData/OCTGANGenerator.cs
+++ b/src/NeuralNetworks/SyntheticData/OCTGANGenerator.cs
@@ -80,7 +80,11 @@ namespace AiDotNet.NeuralNetworks.SyntheticData;
 public class OCTGANGenerator<T> : NeuralNetworkBase<T>, ISyntheticTabularGenerator<T>
 {
     private readonly OCTGANOptions<T> _options;
-    private IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>> _optimizer;
+    // Separate G/D optimizers (see CTGANGenerator for the divergence rationale).
+    // Both training steps route through TapeStepOver, which now takes the optimizer
+    // so the generator and discriminator never share Adam moment state.
+    private IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>> _generatorOptimizer;
+    private IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>> _discriminatorOptimizer;
     private ILossFunction<T> _lossFunction;
 
     // Synthetic tabular data infrastructure
@@ -142,7 +146,17 @@ public class OCTGANGenerator<T> : NeuralNetworkBase<T>, ISyntheticTabularGenerat
     {
         _options = options ?? new OCTGANOptions<T>();
         _lossFunction = lossFunction ?? NeuralNetworkHelper<T>.GetDefaultLossFunction(architecture.TaskType);
-        _optimizer = optimizer ?? new AdamOptimizer<T, Tensor<T>, Tensor<T>>(this);
+        AdamOptimizer<T, Tensor<T>, Tensor<T>> MakeAdam() =>
+            new(this, new Models.Options.AdamOptimizerOptions<T, Tensor<T>, Tensor<T>>
+            {
+                InitialLearningRate = _options.LearningRate,
+                Beta1 = 0.5,
+                Beta2 = 0.9,
+                UseAdaptiveLearningRate = false,
+                UseAMSGrad = false,
+            });
+        _generatorOptimizer = optimizer ?? MakeAdam();
+        _discriminatorOptimizer = MakeAdam();
         _random = _options.Seed.HasValue
             ? RandomHelper.CreateSeededRandom(_options.Seed.Value)
             : RandomHelper.CreateSecureRandom();
@@ -524,7 +538,7 @@ public class OCTGANGenerator<T> : NeuralNetworkBase<T>, ISyntheticTabularGenerat
             var fakeRow = GeneratorForward(noise);
             var fakeEmb = DiscriminatorForward(fakeRow, isTraining: true);
             var loss = Engine.TensorSubtract(SvddDistSq(realEmb), SvddDistSq(fakeEmb));
-            TapeStepOver(tape, loss, BuildDiscriminatorLayerList());
+            TapeStepOver(tape, loss, BuildDiscriminatorLayerList(), _discriminatorOptimizer);
         }
         ClipWeights(BuildDiscriminatorLayerList());
     }
@@ -539,7 +553,7 @@ public class OCTGANGenerator<T> : NeuralNetworkBase<T>, ISyntheticTabularGenerat
             var fakeRow = GeneratorForward(noise);
             var fakeEmb = DiscriminatorForward(fakeRow, isTraining: false);
             var loss = SvddDistSq(fakeEmb);
-            TapeStepOver(tape, loss, BuildGeneratorLayerList());
+            TapeStepOver(tape, loss, BuildGeneratorLayerList(), _generatorOptimizer);
         }
     }
 
@@ -745,7 +759,7 @@ public class OCTGANGenerator<T> : NeuralNetworkBase<T>, ISyntheticTabularGenerat
             var flatOut = output.Rank == 1 ? output : Engine.Reshape(output, new[] { output.Length });
             var target = expectedOutput.Rank == 1 ? expectedOutput : Engine.Reshape(expectedOutput, new[] { expectedOutput.Length });
             var loss = ReduceToScalar(Engine.TensorSquare(Engine.TensorSubtract(flatOut, target)));
-            TapeStepOver(tape, loss, BuildGeneratorLayerList());
+            TapeStepOver(tape, loss, BuildGeneratorLayerList(), _generatorOptimizer);
         }
         finally { SetTrainingMode(false); }
     }
@@ -817,7 +831,7 @@ public class OCTGANGenerator<T> : NeuralNetworkBase<T>, ISyntheticTabularGenerat
     /// <inheritdoc />
     protected override IFullModel<T, Tensor<T>, Tensor<T>> CreateNewInstance()
     {
-        return new OCTGANGenerator<T>(Architecture, _options, _optimizer, _lossFunction);
+        return new OCTGANGenerator<T>(Architecture, _options, _generatorOptimizer, _lossFunction);
     }
 
     #endregion
@@ -825,7 +839,8 @@ public class OCTGANGenerator<T> : NeuralNetworkBase<T>, ISyntheticTabularGenerat
 
     #region Tape Step Helpers
 
-    private void TapeStepOver(GradientTape<T> tape, Tensor<T> loss, IReadOnlyList<ILayer<T>> layers)
+    private void TapeStepOver(GradientTape<T> tape, Tensor<T> loss, IReadOnlyList<ILayer<T>> layers,
+        IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>> optimizer)
     {
         var trainable = Training.TapeTrainingStep<T>.CollectParameters(layers);
         if (trainable.Count == 0) return;
@@ -833,7 +848,7 @@ public class OCTGANGenerator<T> : NeuralNetworkBase<T>, ISyntheticTabularGenerat
         T lossValue = loss.Length > 0 ? loss[0] : NumOps.Zero;
         LastLoss = lossValue;
         var ctx = new AiDotNet.Tensors.Engines.Autodiff.TapeStepContext<T>(trainable, grads, lossValue);
-        _optimizer.Step(ctx);
+        optimizer.Step(ctx);
     }
 
     private Tensor<T> ReduceToScalar(Tensor<T> t)

--- a/src/NeuralNetworks/SyntheticData/PATEGANGenerator.cs
+++ b/src/NeuralNetworks/SyntheticData/PATEGANGenerator.cs
@@ -90,7 +90,14 @@ namespace AiDotNet.NeuralNetworks.SyntheticData;
 public class PATEGANGenerator<T> : NeuralNetworkBase<T>, ISyntheticTabularGenerator<T>
 {
     private readonly PATEGANOptions<T> _options;
-    private IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>> _optimizer;
+    // One dedicated optimizer per sub-network (Jordon et al. 2019 PATE-GAN trains
+    // NumTeachers teacher discriminators + one student + one generator). See
+    // CTGANGenerator: a single shared AdamOptimizer corrupts its flat moment buffer
+    // across networks of different parameter counts. Each teacher is its own
+    // network, so it gets its own optimizer in the array.
+    private IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>> _generatorOptimizer;
+    private IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>> _studentOptimizer;
+    private IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>>[] _teacherOptimizers = System.Array.Empty<IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>>>();
     private ILossFunction<T> _lossFunction;
 
     // Synthetic tabular data infrastructure
@@ -163,7 +170,19 @@ public class PATEGANGenerator<T> : NeuralNetworkBase<T>, ISyntheticTabularGenera
     {
         _options = options ?? new PATEGANOptions<T>();
         _lossFunction = lossFunction ?? NeuralNetworkHelper<T>.GetDefaultLossFunction(architecture.TaskType);
-        _optimizer = optimizer ?? new AdamOptimizer<T, Tensor<T>, Tensor<T>>(this);
+        AdamOptimizer<T, Tensor<T>, Tensor<T>> MakeAdam() =>
+            new(this, new Models.Options.AdamOptimizerOptions<T, Tensor<T>, Tensor<T>>
+            {
+                InitialLearningRate = _options.LearningRate,
+                Beta1 = 0.5,
+                Beta2 = 0.9,
+                UseAdaptiveLearningRate = false,
+                UseAMSGrad = false,
+            });
+        _generatorOptimizer = optimizer ?? MakeAdam();
+        _studentOptimizer = MakeAdam();
+        _teacherOptimizers = new IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>>[Math.Max(1, _options.NumTeachers)];
+        for (int t = 0; t < _teacherOptimizers.Length; t++) _teacherOptimizers[t] = MakeAdam();
         _random = _options.Seed.HasValue
             ? RandomHelper.CreateSeededRandom(_options.Seed.Value)
             : RandomHelper.CreateSecureRandom();
@@ -547,7 +566,7 @@ public class PATEGANGenerator<T> : NeuralNetworkBase<T>, ISyntheticTabularGenera
                 var fakeData = GeneratorForward(noise);
                 var fakeScore = TeacherForward(teacherIdx, fakeData);
                 var loss = Engine.TensorAdd(BceLoss(realScore, 1.0), BceLoss(fakeScore, 0.0));
-                TapeStepOver(tape, loss, BuildTeacherLayerList(teacherIdx));
+                TapeStepOver(tape, loss, BuildTeacherLayerList(teacherIdx), _teacherOptimizers[teacherIdx % _teacherOptimizers.Length]);
             }
         }
     }
@@ -568,7 +587,7 @@ public class PATEGANGenerator<T> : NeuralNetworkBase<T>, ISyntheticTabularGenera
             var fakeScore = StudentForward(VectorToTensor(fakeVector), isTraining: true);
             var realScore = StudentForward(VectorToTensor(realSample), isTraining: true);
             var loss = Engine.TensorAdd(BceLoss(fakeScore, fakeLabel), BceLoss(realScore, realLabel));
-            TapeStepOver(tape, loss, BuildStudentLayerList());
+            TapeStepOver(tape, loss, BuildStudentLayerList(), _studentOptimizer);
         }
     }
 
@@ -581,7 +600,7 @@ public class PATEGANGenerator<T> : NeuralNetworkBase<T>, ISyntheticTabularGenera
             var fakeData = GeneratorForward(noise);
             var studentScore = StudentForward(fakeData, isTraining: true);
             var loss = BceLoss(studentScore, 1.0);
-            TapeStepOver(tape, loss, BuildGeneratorLayerList());
+            TapeStepOver(tape, loss, BuildGeneratorLayerList(), _generatorOptimizer);
         }
     }
 
@@ -632,7 +651,8 @@ public class PATEGANGenerator<T> : NeuralNetworkBase<T>, ISyntheticTabularGenera
 
     #region Tape Step Helpers
 
-    private void TapeStepOver(GradientTape<T> tape, Tensor<T> loss, IReadOnlyList<ILayer<T>> layers)
+    private void TapeStepOver(GradientTape<T> tape, Tensor<T> loss, IReadOnlyList<ILayer<T>> layers,
+        IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>> optimizer)
     {
         var trainable = Training.TapeTrainingStep<T>.CollectParameters(layers);
         if (trainable.Count == 0) return;
@@ -640,7 +660,7 @@ public class PATEGANGenerator<T> : NeuralNetworkBase<T>, ISyntheticTabularGenera
         T lossValue = loss.Length > 0 ? loss[0] : NumOps.Zero;
         LastLoss = lossValue;
         var ctx = new AiDotNet.Tensors.Engines.Autodiff.TapeStepContext<T>(trainable, grads, lossValue);
-        _optimizer.Step(ctx);
+        optimizer.Step(ctx);
     }
 
     private Tensor<T> ReduceToScalar(Tensor<T> t)
@@ -901,7 +921,7 @@ public class PATEGANGenerator<T> : NeuralNetworkBase<T>, ISyntheticTabularGenera
             var flatOut = output.Rank == 1 ? output : Engine.Reshape(output, new[] { output.Length });
             var target = expectedOutput.Rank == 1 ? expectedOutput : Engine.Reshape(expectedOutput, new[] { expectedOutput.Length });
             var loss = ReduceToScalar(Engine.TensorSquare(Engine.TensorSubtract(flatOut, target)));
-            TapeStepOver(tape, loss, BuildGeneratorLayerList());
+            TapeStepOver(tape, loss, BuildGeneratorLayerList(), _generatorOptimizer);
         }
         finally
         {
@@ -974,7 +994,7 @@ public class PATEGANGenerator<T> : NeuralNetworkBase<T>, ISyntheticTabularGenera
     /// <inheritdoc />
     protected override IFullModel<T, Tensor<T>, Tensor<T>> CreateNewInstance()
     {
-        return new PATEGANGenerator<T>(Architecture, _options, _optimizer, _lossFunction);
+        return new PATEGANGenerator<T>(Architecture, _options, _generatorOptimizer, _lossFunction);
     }
 
     #endregion

--- a/src/NeuralNetworks/SyntheticData/TableGANGenerator.cs
+++ b/src/NeuralNetworks/SyntheticData/TableGANGenerator.cs
@@ -78,7 +78,9 @@ namespace AiDotNet.NeuralNetworks.SyntheticData;
 public class TableGANGenerator<T> : NeuralNetworkBase<T>, ISyntheticTabularGenerator<T>
 {
     private readonly TableGANOptions<T> _options;
-    private IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>> _optimizer;
+    // Separate G/D optimizers (see CTGANGenerator for the divergence rationale).
+    private IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>> _generatorOptimizer;
+    private IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>> _discriminatorOptimizer;
     private ILossFunction<T> _lossFunction;
 
     // Synthetic tabular data infrastructure
@@ -146,7 +148,17 @@ public class TableGANGenerator<T> : NeuralNetworkBase<T>, ISyntheticTabularGener
     {
         _options = options ?? new TableGANOptions<T>();
         _lossFunction = lossFunction ?? NeuralNetworkHelper<T>.GetDefaultLossFunction(architecture.TaskType);
-        _optimizer = optimizer ?? new AdamOptimizer<T, Tensor<T>, Tensor<T>>(this);
+        AdamOptimizer<T, Tensor<T>, Tensor<T>> MakeAdam() =>
+            new(this, new Models.Options.AdamOptimizerOptions<T, Tensor<T>, Tensor<T>>
+            {
+                InitialLearningRate = _options.LearningRate,
+                Beta1 = 0.5,
+                Beta2 = 0.9,
+                UseAdaptiveLearningRate = false,
+                UseAMSGrad = false,
+            });
+        _generatorOptimizer = optimizer ?? MakeAdam();
+        _discriminatorOptimizer = MakeAdam();
         _random = _options.Seed.HasValue
             ? RandomHelper.CreateSeededRandom(_options.Seed.Value)
             : RandomHelper.CreateSecureRandom();
@@ -467,7 +479,7 @@ public class TableGANGenerator<T> : NeuralNetworkBase<T>, ISyntheticTabularGener
             discParams, grads, lossValue,
             realBatch, realBatch, ComputeForward, RecomputeLoss,
             parameterBuffer: null);
-        _optimizer.Step(context);
+        _discriminatorOptimizer.Step(context);
     }
 
     /// <summary>
@@ -557,7 +569,7 @@ public class TableGANGenerator<T> : NeuralNetworkBase<T>, ISyntheticTabularGener
             genParams, grads, lossValue,
             noiseBatch, noiseBatch, ComputeForward, RecomputeLoss,
             parameterBuffer: null);
-        _optimizer.Step(context);
+        _generatorOptimizer.Step(context);
     }
 
     private Tensor<T> ComputeGeneratorLoss(Tensor<T> fakeActivated, Tensor<T> realBatch)

--- a/src/NeuralNetworks/SyntheticData/TabularDataTransformer.cs
+++ b/src/NeuralNetworks/SyntheticData/TabularDataTransformer.cs
@@ -362,139 +362,156 @@ public class TabularDataTransformer<T>
             values[i] = NumOps.ToDouble(data[i, colIndex]);
         }
 
-        // Fit Gaussian mixture using simplified EM algorithm
+        // Variational Bayesian Gaussian Mixture (Bishop PRML §10.2) — this is the
+        // "V" in VGM. The CTGAN paper (Xu et al. 2019 §4.2) and the official
+        // implementation fit a *Bayesian* GMM whose Dirichlet weight-concentration
+        // prior drives unused components' weights toward zero, so the number of
+        // active modes is discovered from the data rather than fixed. Plain EM
+        // (the previous code) keeps all K components alive and relies on a post-hoc
+        // 0.01 threshold, which mis-estimates mode structure on real multimodal
+        // columns. Here we run mean-field VB with a symmetric Dirichlet prior on the
+        // weights and a Normal-Gamma conjugate prior on each component's
+        // (mean, precision), then keep the components whose posterior weight is
+        // non-negligible.
         int k = Math.Min(_vgmModes, Math.Max(1, n / 5));
-        var means = new double[k];
-        var stds = new double[k];
-        var weights = new double[k];
 
-        // Initialize: spread modes evenly across the data range
         Array.Sort(values);
         double valMin = values[0];
         double valMax = values[n - 1];
         double range = valMax - valMin;
         if (range < 1e-10) range = 1.0;
 
+        double dataMean = 0;
+        for (int i = 0; i < n; i++) dataMean += values[i];
+        dataMean /= n;
+        double dataVar = 0;
+        for (int i = 0; i < n; i++) { double d = values[i] - dataMean; dataVar += d * d; }
+        dataVar = Math.Max(dataVar / Math.Max(1, n), 1e-6);
+
+        // Prior hyperparameters. A small Dirichlet concentration (alpha0 << 1) gives
+        // the sparse, automatic-pruning behaviour of a Dirichlet-process mixture —
+        // the regime the official CTGAN BayesianGaussianMixture runs in.
+        double alpha0 = 1e-3;                 // symmetric Dirichlet weight prior
+        double beta0 = 1.0;                   // mean prior strength
+        double m0 = dataMean;                 // mean prior location
+        double a0 = 1.0;                      // Gamma (precision) prior shape
+        double b0 = dataVar;                  // Gamma (precision) prior rate
+
+        // Posterior parameters, initialized by spreading component means across the
+        // data range (k-means-style seeding) with broad precision.
+        var alpha = new double[k];
+        var betap = new double[k];
+        var mp = new double[k];
+        var ap = new double[k];
+        var bp = new double[k];
         for (int m = 0; m < k; m++)
         {
-            means[m] = valMin + range * (m + 0.5) / k;
-            stds[m] = range / k;
-            weights[m] = 1.0 / k;
+            alpha[m] = alpha0 + (double)n / k;
+            betap[m] = beta0 + (double)n / k;
+            mp[m] = valMin + range * (m + 0.5) / k;
+            ap[m] = a0 + 0.5 * n / k;
+            bp[m] = b0 + 0.5 * dataVar * n / k;
         }
 
-        // EM iterations
-        int maxIter = 25;
-        var responsibilities = new double[n, k];
-
+        var r = new double[n, k];
+        const int maxIter = 100;
         for (int iter = 0; iter < maxIter; iter++)
         {
-            // E-step: compute responsibilities
+            // --- Variational E-step: responsibilities from expected log-likelihoods.
+            double alphaSum = 0;
+            for (int m = 0; m < k; m++) alphaSum += alpha[m];
+            double psiAlphaSum = Digamma(alphaSum);
+
             for (int i = 0; i < n; i++)
             {
-                double totalResp = 0;
+                double maxLog = double.NegativeInfinity;
                 for (int m = 0; m < k; m++)
                 {
-                    double diff = values[i] - means[m];
-                    double s = Math.Max(stds[m], 1e-10);
-                    double logProb = -0.5 * (diff * diff) / (s * s) - Math.Log(s) + Math.Log(Math.Max(weights[m], 1e-10));
-                    responsibilities[i, m] = Math.Exp(logProb);
-                    totalResp += responsibilities[i, m];
+                    double eLnPi = Digamma(alpha[m]) - psiAlphaSum;           // E[ln π_k]
+                    double eLnTau = Digamma(ap[m]) - Math.Log(bp[m]);          // E[ln τ_k]
+                    double eTau = ap[m] / bp[m];                              // E[τ_k]
+                    double diff = values[i] - mp[m];
+                    // E[τ_k (x-μ_k)^2] = 1/β_k + E[τ_k](x-m_k)^2
+                    double eTauSq = 1.0 / betap[m] + eTau * diff * diff;
+                    double logRho = eLnPi + 0.5 * eLnTau - 0.5 * eTauSq - 0.5 * Math.Log(2 * Math.PI);
+                    r[i, m] = logRho;
+                    if (logRho > maxLog) maxLog = logRho;
                 }
-
-                if (totalResp > 1e-10)
-                {
-                    for (int m = 0; m < k; m++)
-                    {
-                        responsibilities[i, m] /= totalResp;
-                    }
-                }
-                else
-                {
-                    // Assign to nearest mode
-                    int nearest = 0;
-                    double minDist = double.MaxValue;
-                    for (int m = 0; m < k; m++)
-                    {
-                        double dist = Math.Abs(values[i] - means[m]);
-                        if (dist < minDist)
-                        {
-                            minDist = dist;
-                            nearest = m;
-                        }
-                    }
-                    responsibilities[i, nearest] = 1.0;
-                }
+                // log-sum-exp normalize
+                double sum = 0;
+                for (int m = 0; m < k; m++) { r[i, m] = Math.Exp(r[i, m] - maxLog); sum += r[i, m]; }
+                if (sum <= 1e-300) { for (int m = 0; m < k; m++) r[i, m] = 1.0 / k; }
+                else { for (int m = 0; m < k; m++) r[i, m] /= sum; }
             }
 
-            // M-step: update parameters
+            // --- Variational M-step: update posteriors from sufficient statistics.
             for (int m = 0; m < k; m++)
             {
-                double sumResp = 0;
-                double sumVal = 0;
+                double Nk = 0, xbar = 0;
+                for (int i = 0; i < n; i++) { Nk += r[i, m]; xbar += r[i, m] * values[i]; }
+                if (Nk > 1e-12) xbar /= Nk;
+                double sk = 0;
+                for (int i = 0; i < n; i++) { double d = values[i] - xbar; sk += r[i, m] * d * d; }
+                if (Nk > 1e-12) sk /= Nk;
 
-                for (int i = 0; i < n; i++)
-                {
-                    sumResp += responsibilities[i, m];
-                    sumVal += responsibilities[i, m] * values[i];
-                }
-
-                if (sumResp > 1e-10)
-                {
-                    means[m] = sumVal / sumResp;
-
-                    double sumSqDiff = 0;
-                    for (int i = 0; i < n; i++)
-                    {
-                        double diff = values[i] - means[m];
-                        sumSqDiff += responsibilities[i, m] * diff * diff;
-                    }
-
-                    stds[m] = Math.Sqrt(sumSqDiff / sumResp);
-                    if (stds[m] < 1e-10) stds[m] = 1e-10;
-                    weights[m] = sumResp / n;
-                }
-                else
-                {
-                    weights[m] = 0;
-                }
-            }
-
-            // Normalize weights
-            double totalWeight = 0;
-            for (int m = 0; m < k; m++) totalWeight += weights[m];
-            if (totalWeight > 1e-10)
-            {
-                for (int m = 0; m < k; m++) weights[m] /= totalWeight;
+                alpha[m] = alpha0 + Nk;
+                betap[m] = beta0 + Nk;
+                mp[m] = (beta0 * m0 + Nk * xbar) / betap[m];
+                ap[m] = a0 + 0.5 * Nk;
+                bp[m] = b0 + 0.5 * (Nk * sk + beta0 * Nk * (xbar - m0) * (xbar - m0) / betap[m]);
+                if (bp[m] < 1e-10) bp[m] = 1e-10;
             }
         }
 
-        // Keep only active modes (weight > threshold)
-        double threshold = 0.01;
-        var activeModes = new List<int>();
+        // Posterior point estimates. Component weight = E[π_k] = α_k / Σα; mode is
+        // kept when its effective count clears a small floor (the Dirichlet prior has
+        // already shrunk genuinely-empty components to ≈ alpha0/Σα).
+        double totalAlpha = 0;
+        for (int m = 0; m < k; m++) totalAlpha += alpha[m];
+
+        var activeMeans = new List<double>();
+        var activeStds = new List<double>();
+        var activeWeights = new List<double>();
         for (int m = 0; m < k; m++)
         {
-            if (weights[m] > threshold) activeModes.Add(m);
+            double w = alpha[m] / totalAlpha;
+            double effectiveCount = alpha[m] - alpha0;     // ≈ N_k assigned to this mode
+            if (effectiveCount < 1.0 || w < 1e-3) continue; // pruned by the variational prior
+            activeMeans.Add(mp[m]);
+            activeStds.Add(Math.Sqrt(Math.Max(bp[m] / ap[m], 1e-10))); // E[1/τ] ≈ b_k/a_k
+            activeWeights.Add(w);
         }
 
-        if (activeModes.Count == 0)
+        if (activeWeights.Count == 0)
         {
-            activeModes.Add(0); // Keep at least one mode
+            // Degenerate column (e.g. constant): one mode at the data mean.
+            activeMeans.Add(dataMean);
+            activeStds.Add(Math.Sqrt(dataVar));
+            activeWeights.Add(1.0);
         }
 
-        // Build compact arrays of active modes
-        var activeMeans = new double[activeModes.Count];
-        var activeStds = new double[activeModes.Count];
-        var activeWeights = new double[activeModes.Count];
+        // Renormalize the kept weights so they sum to 1.
+        double wsum = 0;
+        for (int i = 0; i < activeWeights.Count; i++) wsum += activeWeights[i];
+        for (int i = 0; i < activeWeights.Count; i++) activeWeights[i] /= wsum;
 
-        for (int i = 0; i < activeModes.Count; i++)
-        {
-            int m = activeModes[i];
-            activeMeans[i] = means[m];
-            activeStds[i] = stds[m];
-            activeWeights[i] = weights[m];
-        }
+        return new VGMColumnInfo(activeMeans.ToArray(), activeStds.ToArray(), activeWeights.ToArray());
+    }
 
-        return new VGMColumnInfo(activeMeans, activeStds, activeWeights);
+    /// <summary>
+    /// Digamma function ψ(x) = d/dx ln Γ(x), used by the variational GMM E-step.
+    /// Uses the asymptotic series with a recurrence to push the argument above 6.
+    /// </summary>
+    private static double Digamma(double x)
+    {
+        double result = 0;
+        while (x < 6.0) { result -= 1.0 / x; x += 1.0; }
+        double inv = 1.0 / x;
+        double inv2 = inv * inv;
+        // ln(x) - 1/(2x) - series in 1/x^2 (Bernoulli)
+        result += Math.Log(x) - 0.5 * inv
+                  - inv2 * (1.0 / 12.0 - inv2 * (1.0 / 120.0 - inv2 * (1.0 / 252.0)));
+        return result;
     }
 
     private static CategoricalColumnInfo FitCategoricalColumn(ColumnMetadata meta)
@@ -518,35 +535,59 @@ public class TabularDataTransformer<T>
         var info = _continuousColumnInfos[transform.Index];
         double value = NumOps.ToDouble(data[row, col]);
 
-        // Find the most likely mode for this value
-        int bestMode = 0;
-        double bestProb = double.MinValue;
+        // Mode assignment by SAMPLING from the posterior responsibilities, per
+        // Xu et al. 2019 §4.2 and the official CTGAN DataTransformer
+        // (np.random.choice with p = predict_proba). Argmax (the previous code)
+        // collapses every value onto its single most-likely mode, erasing the
+        // multimodal structure the one-hot β is meant to expose to the generator.
+        int selMode = SampleMode(info, value);
 
-        for (int m = 0; m < info.NumActiveModes; m++)
-        {
-            double diff = value - info.Means[m];
-            double s = info.Stds[m];
-            double logProb = -0.5 * (diff * diff) / (s * s) - Math.Log(s) + Math.Log(info.Weights[m]);
-            if (logProb > bestProb)
-            {
-                bestProb = logProb;
-                bestMode = m;
-            }
-        }
-
-        // Normalize value relative to selected mode: (value - mean) / (4 * std)
-        // Clipped to [-1, 1] as in CTGAN paper
-        double normalized = (value - info.Means[bestMode]) / (4.0 * info.Stds[bestMode]);
+        // Normalize value relative to selected mode: (value - mean) / (4 * std),
+        // clipped to (-1, 1) as in the paper (4σ covers ~99.99% of a Gaussian).
+        double normalized = (value - info.Means[selMode]) / (4.0 * info.Stds[selMode]);
         normalized = Math.Max(-0.99, Math.Min(0.99, normalized));
 
         int offset = transform.StartOffset;
         result[row, offset] = NumOps.FromDouble(normalized);
 
-        // One-hot mode indicator
+        // One-hot mode indicator (β).
         for (int m = 0; m < info.NumActiveModes; m++)
         {
-            result[row, offset + 1 + m] = m == bestMode ? NumOps.One : NumOps.Zero;
+            result[row, offset + 1 + m] = m == selMode ? NumOps.One : NumOps.Zero;
         }
+    }
+
+    /// <summary>
+    /// Samples a mode index for <paramref name="value"/> proportional to the
+    /// component responsibilities ρ_m ∝ w_m · N(value; μ_m, σ_m), matching the
+    /// paper's probabilistic mode assignment. Uses the transformer's seeded RNG.
+    /// </summary>
+    private int SampleMode(VGMColumnInfo info, double value)
+    {
+        int k = info.NumActiveModes;
+        if (k == 1) return 0;
+
+        Span<double> probs = k <= 64 ? stackalloc double[k] : new double[k];
+        double maxLog = double.NegativeInfinity;
+        for (int m = 0; m < k; m++)
+        {
+            double diff = value - info.Means[m];
+            double s = Math.Max(info.Stds[m], 1e-10);
+            double logp = -0.5 * (diff * diff) / (s * s) - Math.Log(s) + Math.Log(Math.Max(info.Weights[m], 1e-12));
+            probs[m] = logp;
+            if (logp > maxLog) maxLog = logp;
+        }
+        double sum = 0;
+        for (int m = 0; m < k; m++) { probs[m] = Math.Exp(probs[m] - maxLog); sum += probs[m]; }
+
+        double u = _random.NextDouble() * sum;
+        double acc = 0;
+        for (int m = 0; m < k; m++)
+        {
+            acc += probs[m];
+            if (u <= acc) return m;
+        }
+        return k - 1;
     }
 
     private void TransformCategoricalValue(Matrix<T> data, int row, int col,

--- a/src/NeuralNetworks/SyntheticData/TimeGANGenerator.cs
+++ b/src/NeuralNetworks/SyntheticData/TimeGANGenerator.cs
@@ -86,7 +86,14 @@ namespace AiDotNet.NeuralNetworks.SyntheticData;
 public class TimeGANGenerator<T> : NeuralNetworkBase<T>, ISyntheticTabularGenerator<T>
 {
     private readonly TimeGANOptions<T> _options;
-    private IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>> _optimizer;
+    // One dedicated optimizer per training phase (Yoon et al. 2019 uses separate
+    // solvers: embedder, supervisor, generator, discriminator). See CTGANGenerator
+    // for why a single shared AdamOptimizer corrupts its flat moment buffer across
+    // networks of different parameter counts and diverges.
+    private IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>> _embedderOptimizer;
+    private IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>> _supervisorOptimizer;
+    private IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>> _generatorOptimizer;
+    private IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>> _discriminatorOptimizer;
     private ILossFunction<T> _lossFunction;
 
     // Synthetic tabular data infrastructure
@@ -162,7 +169,19 @@ public class TimeGANGenerator<T> : NeuralNetworkBase<T>, ISyntheticTabularGenera
     {
         _options = options ?? new TimeGANOptions<T>();
         _lossFunction = lossFunction ?? NeuralNetworkHelper<T>.GetDefaultLossFunction(architecture.TaskType);
-        _optimizer = optimizer ?? new AdamOptimizer<T, Tensor<T>, Tensor<T>>(this);
+        AdamOptimizer<T, Tensor<T>, Tensor<T>> MakeAdam() =>
+            new(this, new Models.Options.AdamOptimizerOptions<T, Tensor<T>, Tensor<T>>
+            {
+                InitialLearningRate = _options.LearningRate,
+                Beta1 = 0.5,
+                Beta2 = 0.9,
+                UseAdaptiveLearningRate = false,
+                UseAMSGrad = false,
+            });
+        _generatorOptimizer = optimizer ?? MakeAdam();
+        _discriminatorOptimizer = MakeAdam();
+        _embedderOptimizer = MakeAdam();
+        _supervisorOptimizer = MakeAdam();
         _random = _options.Seed.HasValue
             ? RandomHelper.CreateSeededRandom(_options.Seed.Value)
             : RandomHelper.CreateSecureRandom();
@@ -601,7 +620,7 @@ public class TimeGANGenerator<T> : NeuralNetworkBase<T>, ISyntheticTabularGenera
             paramsList, grads, lossValue,
             xBatch, xBatch, ComputeForward, RecomputeLoss,
             parameterBuffer: null);
-        _optimizer.Step(context);
+        _embedderOptimizer.Step(context);
     }
 
     /// <summary>
@@ -644,7 +663,7 @@ public class TimeGANGenerator<T> : NeuralNetworkBase<T>, ISyntheticTabularGenera
             paramsList, grads, lossValue,
             ht, htNext, ComputeForward, RecomputeLoss,
             parameterBuffer: null);
-        _optimizer.Step(context);
+        _supervisorOptimizer.Step(context);
     }
 
     /// <summary>
@@ -706,7 +725,7 @@ public class TimeGANGenerator<T> : NeuralNetworkBase<T>, ISyntheticTabularGenera
             paramsList, grads, lossValue,
             realEmb, realEmb, ComputeForward, RecomputeLoss,
             parameterBuffer: null);
-        _optimizer.Step(context);
+        _discriminatorOptimizer.Step(context);
     }
 
     /// <summary>
@@ -806,7 +825,7 @@ public class TimeGANGenerator<T> : NeuralNetworkBase<T>, ISyntheticTabularGenera
             paramsList, grads, lossValue,
             noise, noise, ComputeForward, RecomputeLoss,
             parameterBuffer: null);
-        _optimizer.Step(context);
+        _generatorOptimizer.Step(context);
     }
 
     /// <summary>

--- a/src/NeuralNetworks/Tabular/FTTransformerClassifier.cs
+++ b/src/NeuralNetworks/Tabular/FTTransformerClassifier.cs
@@ -267,21 +267,64 @@ public class FTTransformerClassifier<T> : FTTransformerBase<T>
         T learningRate,
         Matrix<int>? categoricalIndices = null)
     {
-        // Forward pass
-        var probabilities = PredictProbabilities(numericalFeatures, categoricalIndices);
+        // Collect every trainable tensor as a LIVE field instance — tokenizer
+        // (custom), then backbone encoder layers + final LayerNorm + the
+        // classification head (via the tape param collector). ComputeGradients
+        // maps gradients back to exactly these instances, and we apply SGD to
+        // them in place so the model actually updates.
+        var trainable = new System.Collections.Generic.List<Tensor<T>>(Tokenizer.GetTrainableTensors());
+        var layers = new System.Collections.Generic.List<AiDotNet.Interfaces.ILayer<T>>();
+        foreach (var encoderLayer in EncoderLayers) layers.Add(encoderLayer);
+        layers.Add(FinalLayerNorm);
+        layers.Add(_classificationHead);
+        trainable.AddRange(AiDotNet.Training.TapeTrainingStep<T>.CollectParameters(layers));
 
-        // Compute loss
-        var loss = ComputeCrossEntropyLoss(probabilities, targets);
+        // Reverse-mode AD over the whole network: the forward (tokenizer +
+        // transformer + head) and the cross-entropy below are Engine ops, so a
+        // forward under the tape records them and ComputeGradients fills in the
+        // gradient for every leaf tensor we collected. (Previously TrainStep had
+        // only a "// Backward pass" comment, so UpdateParameters threw "Backward
+        // pass must be called before updating parameters" — training never ran.)
+        using var tape = new AiDotNet.Tensors.Engines.Autodiff.GradientTape<T>();
+        var logits = Forward(numericalFeatures, categoricalIndices);
+        var lossTensor = SoftmaxCrossEntropyLoss(logits, targets);
+        var grads = tape.ComputeGradients(lossTensor, trainable.ToArray());
 
-        // Backward pass
+        // SGD: param -= lr * grad, written back into the live tensor in place.
+        foreach (var t in trainable)
+        {
+            if (t is null || !grads.TryGetValue(t, out var g) || g is null) continue;
+            var updated = Engine.TensorSubtract(t, Engine.TensorMultiplyScalar(g, learningRate));
+            int n = t.Length;
+            for (int i = 0; i < n; i++) t[i] = updated[i];
+        }
 
-        // Update parameters
-        UpdateParameters(learningRate);
-
-        // Reset for next iteration
+        T lossValue = lossTensor.Length > 0 ? lossTensor[0] : NumOps.Zero;
         ResetState();
+        return lossValue;
+    }
 
-        return loss;
+    /// <summary>
+    /// Tape-tracked softmax cross-entropy on logits [B, C] against integer targets.
+    /// CE = −mean_b Σ_c onehot[b,c]·log(softmax(logits)[b,c]). Built from Engine
+    /// tensor ops (recorded by the active <c>GradientTape</c>) with a CONSTANT
+    /// one-hot target (no gradient), so reverse-mode AD differentiates it cleanly.
+    /// </summary>
+    private Tensor<T> SoftmaxCrossEntropyLoss(Tensor<T> logits, int[] targets)
+    {
+        int batch = logits.Shape[0];
+        int numClasses = logits.Shape[1];
+
+        var onehot = new Tensor<T>([batch, numClasses]);
+        for (int b = 0; b < batch; b++)
+            onehot[b * numClasses + targets[b]] = NumOps.One;
+
+        // Numerically-stable log-softmax (avoids the log(0) risk of softmax→log).
+        var logProbs = Engine.TensorLogSoftmax(logits, axis: -1);
+        var weighted = Engine.TensorMultiply(logProbs, onehot);
+        var perRow = Engine.ReduceSum(weighted, new[] { 1 }, keepDims: false);
+        var meanVal = Engine.ReduceMean(perRow, new[] { 0 }, keepDims: false);
+        return Engine.TensorMultiplyScalar(meanVal, NumOps.FromDouble(-1.0));
     }
 
     /// <summary>
@@ -405,7 +448,13 @@ public class FTTransformerClassifier<T> : FTTransformerBase<T>
     /// </summary>
     public override void SetParameters(Vector<T> parameters)
     {
-        int baseCount = (int)(base.ParameterCount - _classificationHead.ParameterCount);
+        // GetParameters concatenates [base.GetParameters() (= base.ParameterCount)][head].
+        // base.ParameterCount is the explicit-base call (backbone only, WITHOUT the head),
+        // so the base slice is exactly base.ParameterCount. The previous
+        // `base.ParameterCount - head.ParameterCount` under-counted the base by the head
+        // size, leaving the head to read trailing base params — corrupting both halves
+        // (the save/load round-trip then failed).
+        int baseCount = checked((int)base.ParameterCount);
         var baseParams = new Vector<T>(baseCount);
         for (int i = 0; i < baseCount; i++)
         {

--- a/src/NeuralNetworks/Tabular/FTTransformerRegression.cs
+++ b/src/NeuralNetworks/Tabular/FTTransformerRegression.cs
@@ -406,7 +406,12 @@ public class FTTransformerRegression<T> : FTTransformerBase<T>
     /// </summary>
     public override void SetParameters(Vector<T> parameters)
     {
-        int baseCount = (int)(base.ParameterCount - _regressionHead.ParameterCount);
+        // GetParameters concatenates [base.GetParameters() (= base.ParameterCount)][head].
+        // base.ParameterCount (explicit-base call) is the backbone only, WITHOUT the head,
+        // so the base slice is exactly that. The previous
+        // `base.ParameterCount - head.ParameterCount` under-counted the base by the head
+        // size and corrupted the round-trip.
+        int baseCount = checked((int)base.ParameterCount);
         var baseParams = new Vector<T>(baseCount);
         for (int i = 0; i < baseCount; i++)
         {

--- a/src/NeuralNetworks/Tabular/FeatureTokenizer.cs
+++ b/src/NeuralNetworks/Tabular/FeatureTokenizer.cs
@@ -322,6 +322,24 @@ public class FeatureTokenizer<T>
     }
 
     /// <summary>
+    /// Returns the tokenizer's trainable weight TENSORS (the live field instances,
+    /// not a flat copy) so a caller can register them with a <c>GradientTape</c> and
+    /// apply gradients in place. Order matches <see cref="GetParameters"/>:
+    /// numerical weights, numerical bias (if present), CLS token, then each
+    /// categorical embedding. Used by the FT-Transformer tape-based training step —
+    /// the tokenizer keeps its own manual gradient fields for the legacy path, but
+    /// tape training updates these tensors directly.
+    /// </summary>
+    internal IReadOnlyList<Tensor<T>> GetTrainableTensors()
+    {
+        var tensors = new List<Tensor<T>> { _numericalWeights };
+        if (_numericalBias is not null) tensors.Add(_numericalBias);
+        tensors.Add(_clsToken);
+        tensors.AddRange(_categoricalEmbeddings);
+        return tensors;
+    }
+
+    /// <summary>
     /// Sets the trainable parameters from a vector.
     /// </summary>
     public void SetParameters(Vector<T> parameters)

--- a/src/Preprocessing/DataPreparation/DataSplitter.cs
+++ b/src/Preprocessing/DataPreparation/DataSplitter.cs
@@ -69,6 +69,78 @@ public static class DataSplitter
             "Supported: (Matrix<T>, Vector<T>) or (Tensor<T>, Tensor<T>).");
     }
 
+    /// <summary>
+    /// Computes train/validation/test partition sizes that always sum to
+    /// <paramref name="totalSamples"/> and never leave a requested partition empty
+    /// when the data can afford it.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>For Beginners:</b> The split ratios are fractions, so multiplying them by a
+    /// small row count and rounding down (<c>floor</c>) can accidentally produce a
+    /// partition with zero rows — for example one row at 70/15/15 rounds to
+    /// "0 train, 0 validation, 1 test", and any fewer than seven rows leaves the
+    /// validation set empty. An empty <i>training</i> set is the worst case: the model
+    /// never trains and its layers stay at their random initial values. This method
+    /// guarantees a usable split by giving training priority and then handing each
+    /// other requested partition at least one row once there are enough rows to go
+    /// around, reclaiming those rows from the largest partition so the totals still
+    /// add up. For datasets large enough that <c>floor</c> already fills every
+    /// partition, the result is identical to the plain ratio split.
+    /// </para>
+    /// </remarks>
+    private static (int trainSize, int validationSize, int testSize) ComputeSplitSizes(
+        int totalSamples, double trainRatio, double validationRatio)
+    {
+        if (totalSamples <= 0)
+        {
+            return (0, 0, 0);
+        }
+
+        bool wantValidation = validationRatio > 0.0;
+        bool wantTest = (1.0 - trainRatio - validationRatio) > 0.0;
+        int wantedPartitions = 1 + (wantValidation ? 1 : 0) + (wantTest ? 1 : 0);
+
+        // Fewer rows than requested partitions (1 or 2 rows): training takes
+        // priority — a model cannot learn from an empty set — then test, then
+        // validation gets whatever (if anything) is left.
+        if (totalSamples < wantedPartitions)
+        {
+            int tinyTrain = 1;
+            int tinyTest = (wantTest && totalSamples >= 2) ? 1 : 0;
+            return (tinyTrain, totalSamples - tinyTrain - tinyTest, tinyTest);
+        }
+
+        int trainSize = (int)(totalSamples * trainRatio);
+        int validationSize = (int)(totalSamples * validationRatio);
+        int testSize = totalSamples - trainSize - validationSize;
+
+        // Integer floor() can still starve a single partition to zero even when the
+        // data could afford it. Promote each starved-but-requested partition to one
+        // row, reclaiming it from the larger of the other two so the totals still sum
+        // to totalSamples and the dominant (training) share is preferred on ties.
+        if (trainSize < 1)
+        {
+            if (validationSize >= testSize) { validationSize--; }
+            else { testSize--; }
+            trainSize++;
+        }
+        if (wantValidation && validationSize < 1)
+        {
+            if (trainSize > testSize) { trainSize--; }
+            else { testSize--; }
+            validationSize++;
+        }
+        if (wantTest && testSize < 1)
+        {
+            if (trainSize > validationSize) { trainSize--; }
+            else { validationSize--; }
+            testSize++;
+        }
+
+        return (trainSize, validationSize, testSize);
+    }
+
     private static (Matrix<T> XTrain, Vector<T> yTrain, Matrix<T> XVal, Vector<T> yVal, Matrix<T> XTest, Vector<T> yTest)
         SplitMatrix<T>(
             Matrix<T> X,
@@ -79,9 +151,7 @@ public static class DataSplitter
             int randomSeed)
     {
         int totalSamples = X.Rows;
-        int trainSize = (int)(totalSamples * trainRatio);
-        int validationSize = (int)(totalSamples * validationRatio);
-        int testSize = totalSamples - trainSize - validationSize;
+        var (trainSize, validationSize, testSize) = ComputeSplitSizes(totalSamples, trainRatio, validationRatio);
 
         var indices = Enumerable.Range(0, totalSamples).ToList();
         if (shuffle)
@@ -132,9 +202,7 @@ public static class DataSplitter
             int randomSeed)
     {
         int totalSamples = X.Shape[0];
-        int trainSize = (int)(totalSamples * trainRatio);
-        int validationSize = (int)(totalSamples * validationRatio);
-        int testSize = totalSamples - trainSize - validationSize;
+        var (trainSize, validationSize, testSize) = ComputeSplitSizes(totalSamples, trainRatio, validationRatio);
 
         var indices = Enumerable.Range(0, totalSamples).ToList();
         if (shuffle)

--- a/src/TimeSeries/AnomalyDetection/DeepANT.cs
+++ b/src/TimeSeries/AnomalyDetection/DeepANT.cs
@@ -320,19 +320,13 @@ public class DeepANT<T> : TimeSeriesModelBase<T>
     public override Vector<T> Predict(Matrix<T> input)
     {
         int n = input.Rows;
-        int trainN = _trainingSeries.Length;
         var predictions = new Vector<T>(n);
 
+        // Predict every row from its own input window (see DeepARModel.Predict: the prior
+        // i < _trainingSeries.Length shortcut returned memorized training values for OOS rows).
         for (int i = 0; i < n; i++)
         {
-            if (i < trainN && trainN > 0)
-            {
-                predictions[i] = _trainingSeries[i];
-            }
-            else
-            {
-                predictions[i] = PredictSingle(input.GetRow(i));
-            }
+            predictions[i] = PredictSingle(input.GetRow(i));
         }
 
         return predictions;

--- a/src/TimeSeries/AnomalyDetection/LSTMVAE.cs
+++ b/src/TimeSeries/AnomalyDetection/LSTMVAE.cs
@@ -186,15 +186,13 @@ public class LSTMVAE<T> : TimeSeriesModelBase<T>
     public override Vector<T> Predict(Matrix<T> input)
     {
         int n = input.Rows;
-        int trainN = _trainingSeries.Length;
         var predictions = new Vector<T>(n);
 
+        // Reconstruct every row from its own input window (see DeepARModel.Predict: the prior
+        // i < _trainingSeries.Length shortcut returned memorized training values for OOS rows).
         for (int i = 0; i < n; i++)
         {
-            if (i < trainN && trainN > 0)
-                predictions[i] = _trainingSeries[i];
-            else
-                predictions[i] = PredictSingle(input.GetRow(i));
+            predictions[i] = PredictSingle(input.GetRow(i));
         }
 
         return predictions;

--- a/src/TimeSeries/AutoformerModel.cs
+++ b/src/TimeSeries/AutoformerModel.cs
@@ -1021,19 +1021,13 @@ public class AutoformerModel<T> : TimeSeriesModelBase<T>
     public override Vector<T> Predict(Matrix<T> input)
     {
         int n = input.Rows;
-        int trainN = _trainingSeries.Length;
         var predictions = new Vector<T>(n);
 
+        // Forecast every row from its own lookback window (see DeepARModel.Predict: the prior
+        // i < _trainingSeries.Length shortcut returned memorized training values for OOS rows).
         for (int i = 0; i < n; i++)
         {
-            if (i < trainN && trainN > 0)
-            {
-                predictions[i] = _trainingSeries[i];
-            }
-            else
-            {
-                predictions[i] = PredictSingle(input.GetRow(i));
-            }
+            predictions[i] = PredictSingle(input.GetRow(i));
         }
 
         return predictions;

--- a/src/TimeSeries/ChronosFoundationModel.cs
+++ b/src/TimeSeries/ChronosFoundationModel.cs
@@ -640,14 +640,12 @@ public class ChronosFoundationModel<T> : TimeSeriesModelBase<T>
     public override Vector<T> Predict(Matrix<T> input)
     {
         int n = input.Rows;
-        int trainN = _trainingSeries.Length;
         var predictions = new Vector<T>(n);
+        // Forecast every row from its own lookback window (see DeepARModel.Predict: the prior
+        // i < _trainingSeries.Length shortcut returned memorized training values for OOS rows).
         for (int i = 0; i < n; i++)
         {
-            if (i < trainN && trainN > 0)
-                predictions[i] = _trainingSeries[i];
-            else
-                predictions[i] = PredictSingle(input.GetRow(i));
+            predictions[i] = PredictSingle(input.GetRow(i));
         }
         return predictions;
     }

--- a/src/TimeSeries/DeepARModel.cs
+++ b/src/TimeSeries/DeepARModel.cs
@@ -402,15 +402,16 @@ public class DeepARModel<T> : TimeSeriesModelBase<T>
     public override Vector<T> Predict(Matrix<T> input)
     {
         int n = input.Rows;
-        int trainN = _trainingSeries.Length;
         var predictions = new Vector<T>(n);
 
+        // Each input row is an independent lookback window — forecast it from its own content. (Previously
+        // rows with index i < _trainingSeries.Length returned the memorized training value _trainingSeries[i]
+        // instead of a forecast, conflating the test-matrix row index with a training-series position. That
+        // made out-of-sample Predict() return training data — and any two models whose OOS window fit inside
+        // the training length returned byte-identical "predictions".)
         for (int i = 0; i < n; i++)
         {
-            if (i < trainN && trainN > 0)
-                predictions[i] = _trainingSeries[i];
-            else
-                predictions[i] = PredictSingle(input.GetRow(i));
+            predictions[i] = PredictSingle(input.GetRow(i));
         }
 
         return predictions;

--- a/src/TimeSeries/InformerModel.cs
+++ b/src/TimeSeries/InformerModel.cs
@@ -332,14 +332,12 @@ public class InformerModel<T> : TimeSeriesModelBase<T>
     public override Vector<T> Predict(Matrix<T> input)
     {
         int n = input.Rows;
-        int trainN = _trainingSeries.Length;
         var predictions = new Vector<T>(n);
+        // Forecast every row from its own lookback window (see DeepARModel.Predict: the prior
+        // i < _trainingSeries.Length shortcut returned memorized training values for OOS rows).
         for (int i = 0; i < n; i++)
         {
-            if (i < trainN && trainN > 0)
-                predictions[i] = _trainingSeries[i];
-            else
-                predictions[i] = PredictSingle(input.GetRow(i));
+            predictions[i] = PredictSingle(input.GetRow(i));
         }
         return predictions;
     }

--- a/src/TimeSeries/NHiTSModel.cs
+++ b/src/TimeSeries/NHiTSModel.cs
@@ -186,14 +186,12 @@ public class NHiTSModel<T> : TimeSeriesModelBase<T>
     public override Vector<T> Predict(Matrix<T> input)
     {
         int n = input.Rows;
-        int trainN = _trainingSeries.Length;
         var predictions = new Vector<T>(n);
+        // Forecast every row from its own lookback window (see DeepARModel.Predict: the prior
+        // i < _trainingSeries.Length shortcut returned memorized training values for OOS rows).
         for (int i = 0; i < n; i++)
         {
-            if (i < trainN && trainN > 0)
-                predictions[i] = _trainingSeries[i];
-            else
-                predictions[i] = PredictSingle(input.GetRow(i));
+            predictions[i] = PredictSingle(input.GetRow(i));
         }
         return predictions;
     }

--- a/src/Training/CompiledTapeTrainingStep.cs
+++ b/src/Training/CompiledTapeTrainingStep.cs
@@ -579,6 +579,22 @@ public static class CompiledTapeTrainingStep<T>
             var parameters = _cachedParameters ??= CollectDeduplicatedParameters(layers);
             if (firstCollectThisLifecycle) RememberLayerSet(layers);
 
+            // GPU-RESIDENCY (campaign M1): on the DirectGpu engine, make the parameters GPU-resident ONCE so
+            // CompiledTrainingPlan.ConfigureOptimizerFloat takes its GPU Adam branch (param.TryGetGpuBuffer()
+            // != null) — Adam/m/v run on-device and the forward reads weights from the resident buffer instead
+            // of re-uploading per op (the ~10%-util host ping-pong). .Gpu() mutates in place and no-ops when no
+            // GPU engine is available. Gated to float + Adam/AdamW/SGD (the only GPU-supported optimizer
+            // kernels; others would NotSupported on the GPU branch). Opt out with AIDOTNET_GPU_RESIDENT_PARAMS=0.
+            if (firstCollectThisLifecycle && typeof(T) == typeof(float)
+                && (optimizerType == AiDotNet.Tensors.Engines.Compilation.OptimizerType.Adam
+                    || optimizerType == AiDotNet.Tensors.Engines.Compilation.OptimizerType.AdamW
+                    || optimizerType == AiDotNet.Tensors.Engines.Compilation.OptimizerType.SGD)
+                && Environment.GetEnvironmentVariable("AIDOTNET_GPU_RESIDENT_PARAMS") != "0"
+                && AiDotNet.Tensors.Engines.AiDotNetEngine.Current is AiDotNet.Tensors.Engines.DirectGpuTensorEngine)
+            {
+                foreach (var p in parameters) p.Gpu();
+            }
+
             foreach (var layer in layers)
                 layer.ZeroGrad();
 

--- a/tests/AiDotNet.Tests/IntegrationTests/Streaming/StreamingInt8InferenceIntegrationTests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/Streaming/StreamingInt8InferenceIntegrationTests.cs
@@ -1,0 +1,92 @@
+// Copyright (c) AiDotNet. All rights reserved.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using AiDotNet.Enums;
+using AiDotNet.Interfaces;
+using AiDotNet.NeuralNetworks;
+using AiDotNet.NeuralNetworks.Layers;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tests.IntegrationTests.Streaming;
+
+/// <summary>
+/// End-to-end transparent int8 weight-streaming INFERENCE: a Dense network configured with
+/// <see cref="StreamingStoreDtype.Int8"/> computes its Linear layers directly on int8 weights
+/// (FusedLinear routes the int8-streamed weight to the int8 weight-only GEMM, no upcast to fp32)
+/// without any layer-code change. The int8 output matches the fp32 output of the same weights
+/// within quantization tolerance, proving the path is both wired and correct.
+/// </summary>
+public class StreamingInt8InferenceIntegrationTests
+{
+    private static NeuralNetwork<float> BuildNet()
+    {
+        var layers = new List<ILayer<float>>
+        {
+            new DenseLayer<float>(outputSize: 32, activationFunction: null),
+            new DenseLayer<float>(outputSize: 16, activationFunction: null),
+        };
+        var arch = new NeuralNetworkArchitecture<float>(
+            inputType: InputType.OneDimensional,
+            taskType: NeuralNetworkTaskType.Regression,
+            inputSize: 64,
+            outputSize: 16,
+            layers: layers);
+        return new NeuralNetwork<float>(arch);
+    }
+
+    [Fact]
+    public void Int8StreamingInference_TransparentlyRoutesAndMatchesFp32()
+    {
+        var net = BuildNet();
+        net.SetTrainingMode(false);
+
+        var input = new Tensor<float>(new[] { 1, 64 });
+        var rng = new Random(7);
+        for (int i = 0; i < 64; i++) input[i] = (float)(rng.NextDouble() - 0.5);
+
+        // fp32 baseline (also materializes the lazily-initialized Dense weights).
+        var fp32 = net.Predict(input);
+
+        // Configure int8 weight streaming; ConfigureWeightLifetime registers the now-initialized
+        // weights with the pool. A tiny budget guarantees they page out.
+        var dir = Path.Combine(Path.GetTempPath(), $"aidotnet-int8infer-{Guid.NewGuid():N}");
+        net.ConfigureWeightLifetime(new GpuOffloadOptions
+        {
+            StreamingBackingStorePath = dir,
+            StreamingPoolMaxResidentBytes = 64L * 1024,
+            StreamingStoreDtype = StreamingStoreDtype.Int8,
+        });
+        net.SetTrainingMode(false); // inference → int8 no-upcast routing in FusedLinear
+
+        try
+        {
+            var int8 = net.Predict(input);
+
+            double sum2 = 0, ref2 = 0;
+            int diffs = 0;
+            for (int i = 0; i < 16; i++)
+            {
+                double e = int8[i] - fp32[i];
+                sum2 += e * e;
+                ref2 += (double)fp32[i] * fp32[i];
+                if (int8[i] != fp32[i]) diffs++;
+            }
+            double rel = Math.Sqrt(sum2 / Math.Max(1e-30, ref2));
+
+            // Same weights, int8-quantized per output channel across two Dense layers → output
+            // tracks fp32 within a few %.
+            Assert.True(rel < 0.08, $"int8 streaming inference should match fp32 within ~8% (rel {rel:E3}).");
+            // ...and it actually quantized (not a silent fp32 fallback).
+            Assert.True(diffs > 0, "int8 path should differ from fp32 (proves quantization ran, not a fallback).");
+        }
+        finally
+        {
+            WeightRegistry.SetStreamingExecutionTraining(null);
+            WeightRegistry.Reset();
+            if (Directory.Exists(dir)) Directory.Delete(dir, recursive: true);
+        }
+    }
+}

--- a/tests/AiDotNet.Tests/IntegrationTests/SyntheticData/CopulaSynthPaperFidelityTests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/SyntheticData/CopulaSynthPaperFidelityTests.cs
@@ -1,0 +1,156 @@
+using System;
+using System.Collections.Generic;
+using AiDotNet.Enums;
+using AiDotNet.LinearAlgebra;
+using AiDotNet.Models.Options;
+using AiDotNet.NeuralNetworks.SyntheticData;
+using Xunit;
+
+namespace AiDotNet.Tests.IntegrationTests.SyntheticData;
+
+/// <summary>
+/// Paper-fidelity guards for <see cref="CopulaSynthGenerator{T}"/> (Patki et al.
+/// 2016, "The Synthetic Data Vault" — Gaussian Copula). These pin the two defects
+/// the Synthetic POC review measured on AiDotNet 0.213.3:
+///   1. correlation preservation degraded to 0.82–0.93 (planted ~0.95), because the
+///      forward empirical CDF and the inverse quantile used inconsistent grids, so
+///      the probability-integral transform was not rank-preserving;
+///   2. float noise leaked into categorical columns, because the column metadata
+///      never reached the inverse transform and categorical values were linearly
+///      interpolated.
+/// Both are now fixed; these tests fail loudly if either regresses.
+/// </summary>
+public class CopulaSynthPaperFidelityTests
+{
+    private const int Seed = 42;
+
+    /// <summary>
+    /// A Gaussian copula MUST preserve the linear correlation structure of the
+    /// data. We plant a strong correlation (~0.95) between two continuous columns,
+    /// fit, generate 4× the rows, and require the synthetic correlation to land
+    /// within 0.05 of the real one. The pre-fix code landed 0.06–0.17 LOW here
+    /// (0.82–0.93 vs ~0.99); 0.05 cleanly separates "preserved" from "degraded".
+    /// </summary>
+    [Fact]
+    public void Copula_PreservesPlantedCorrelation_WithinTolerance()
+    {
+        const int rows = 400;
+        var rng = new Random(Seed);
+
+        // Two continuous columns with a planted linear relationship:
+        //   x ~ N(0,1);  y = rho*x + sqrt(1-rho^2)*noise  → Corr(x,y) ≈ rho.
+        const double rho = 0.95;
+        var data = new Matrix<double>(rows, 2);
+        for (int i = 0; i < rows; i++)
+        {
+            double x = SampleNormal(rng);
+            double e = SampleNormal(rng);
+            data[i, 0] = 10.0 + 3.0 * x;                       // shift/scale: copula must be scale-invariant
+            data[i, 1] = 100.0 + 5.0 * (rho * x + Math.Sqrt(1 - rho * rho) * e);
+        }
+
+        var columns = new List<ColumnMetadata>
+        {
+            new("X", ColumnDataType.Continuous, columnIndex: 0),
+            new("Y", ColumnDataType.Continuous, columnIndex: 1),
+        };
+
+        double realCorr = Pearson(data, 0, 1, rows);
+
+        var gen = new CopulaSynthGenerator<double>(new CopulaSynthOptions<double> { Seed = Seed });
+        gen.Fit(data, columns, epochs: 1);
+        var synth = gen.Generate(rows * 4);
+
+        double synthCorr = Pearson(synth, 0, 1, synth.Rows);
+
+        Assert.True(Math.Abs(realCorr - synthCorr) < 0.05,
+            $"Copula correlation not preserved: real={realCorr:F4}, synthetic={synthCorr:F4}, " +
+            $"|gap|={Math.Abs(realCorr - synthCorr):F4} exceeds 0.05 (Gaussian-copula fidelity regressed).");
+    }
+
+    /// <summary>
+    /// Categorical columns must come back as values that actually occurred — never
+    /// an interpolated float. We declare a 4-level categorical column encoded as
+    /// {0,1,2,3} and require every generated value to be exactly one of those.
+    /// </summary>
+    [Fact]
+    public void Copula_CategoricalColumn_NeverLeaksFloatNoise()
+    {
+        const int rows = 300;
+        var rng = new Random(Seed);
+        var data = new Matrix<double>(rows, 2);
+        var valid = new HashSet<double> { 0, 1, 2, 3 };
+        for (int i = 0; i < rows; i++)
+        {
+            data[i, 0] = 50.0 + 10.0 * SampleNormal(rng); // continuous
+            data[i, 1] = rng.Next(4);                      // categorical {0,1,2,3}
+        }
+
+        var columns = new List<ColumnMetadata>
+        {
+            new("Income", ColumnDataType.Continuous, columnIndex: 0),
+            new("Education", ColumnDataType.Categorical, new[] { "HS", "BA", "MA", "PhD" }, columnIndex: 1),
+        };
+
+        var gen = new CopulaSynthGenerator<double>(new CopulaSynthOptions<double> { Seed = Seed });
+        gen.Fit(data, columns, epochs: 1);
+        var synth = gen.Generate(500);
+
+        for (int i = 0; i < synth.Rows; i++)
+        {
+            double v = synth[i, 1];
+            Assert.True(valid.Contains(v),
+                $"Categorical column leaked a non-category value at row {i}: {v} (expected one of 0,1,2,3).");
+        }
+    }
+
+    /// <summary>
+    /// Discrete (integer) columns must also stay integral — the same snap rule
+    /// applies to <see cref="ColumnDataType.Discrete"/>, not just Categorical.
+    /// </summary>
+    [Fact]
+    public void Copula_DiscreteColumn_StaysIntegral()
+    {
+        const int rows = 200;
+        var rng = new Random(Seed);
+        var data = new Matrix<double>(rows, 1);
+        for (int i = 0; i < rows; i++) data[i, 0] = rng.Next(0, 11); // counts 0..10
+
+        var columns = new List<ColumnMetadata>
+        {
+            new("Count", ColumnDataType.Discrete, columnIndex: 0),
+        };
+
+        var gen = new CopulaSynthGenerator<double>(new CopulaSynthOptions<double> { Seed = Seed });
+        gen.Fit(data, columns, epochs: 1);
+        var synth = gen.Generate(300);
+
+        for (int i = 0; i < synth.Rows; i++)
+        {
+            double v = synth[i, 0];
+            Assert.True(Math.Abs(v - Math.Round(v)) < 1e-9,
+                $"Discrete column produced a non-integer value at row {i}: {v}.");
+        }
+    }
+
+    private static double Pearson(Matrix<double> m, int a, int b, int n)
+    {
+        double ma = 0, mb = 0;
+        for (int i = 0; i < n; i++) { ma += m[i, a]; mb += m[i, b]; }
+        ma /= n; mb /= n;
+        double cov = 0, va = 0, vb = 0;
+        for (int i = 0; i < n; i++)
+        {
+            double da = m[i, a] - ma, db = m[i, b] - mb;
+            cov += da * db; va += da * da; vb += db * db;
+        }
+        return cov / (Math.Sqrt(va) * Math.Sqrt(vb));
+    }
+
+    private static double SampleNormal(Random rng)
+    {
+        double u1 = 1.0 - rng.NextDouble();
+        double u2 = 1.0 - rng.NextDouble();
+        return Math.Sqrt(-2.0 * Math.Log(u1)) * Math.Cos(2.0 * Math.PI * u2);
+    }
+}

--- a/tests/AiDotNet.Tests/IntegrationTests/SyntheticData/CtganSamplerPaperFidelityTests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/SyntheticData/CtganSamplerPaperFidelityTests.cs
@@ -1,0 +1,77 @@
+using System;
+using System.Collections.Generic;
+using AiDotNet.Enums;
+using AiDotNet.LinearAlgebra;
+using AiDotNet.NeuralNetworks.SyntheticData;
+using Xunit;
+
+namespace AiDotNet.Tests.IntegrationTests.SyntheticData;
+
+/// <summary>
+/// Paper-fidelity guards for <see cref="CTGANDataSampler{T}"/>'s training-by-sampling
+/// (Xu et al. 2019 §4.3). Pins: (1) the conditioned category is drawn from the
+/// LOG-frequency distribution — not uniformly (the previous behaviour) and not
+/// proportionally — so rare categories are lifted but frequent ones still dominate;
+/// (2) the emitted mask is exactly the one selected column's category block; (3) the
+/// conditional vector is one-hot inside that block.
+/// </summary>
+public class CtganSamplerPaperFidelityTests
+{
+    private const int Seed = 7;
+
+    [Fact]
+    public void Sampler_LogFrequencyCategorySampling_AndMaskShape()
+    {
+        // One categorical column with a heavily imbalanced 3-category distribution:
+        // cat0 = 800 rows, cat1 = 150, cat2 = 50.
+        int[] counts = { 800, 150, 50 };
+        int rows = counts[0] + counts[1] + counts[2];
+        var data = new Matrix<double>(rows, 1);
+        int r = 0;
+        for (int c = 0; c < 3; c++)
+            for (int j = 0; j < counts[c]; j++) data[r++, 0] = c;
+
+        var columns = new List<ColumnMetadata>
+        {
+            new("Cat", ColumnDataType.Categorical, new[] { "A", "B", "C" }, columnIndex: 0),
+        };
+
+        var sampler = new CTGANDataSampler<double>(new Random(Seed));
+        sampler.Fit(data, columns);
+
+        var drawn = new int[3];
+        const int draws = 30000;
+        for (int i = 0; i < draws; i++)
+        {
+            var (cond, mask, colIdx, catIdx, rowIdx) = sampler.SampleCondVecWithMask();
+
+            Assert.Equal(0, colIdx);                       // only one discrete column
+            Assert.InRange(catIdx, 0, 2);
+            // Mask covers the whole 3-category block; cond is one-hot within it.
+            int ones = 0, condOnes = 0;
+            for (int k = 0; k < cond.Length; k++)
+            {
+                if (Math.Abs(mask[k] - 1.0) < 1e-9) ones++;
+                if (Math.Abs(cond[k] - 1.0) < 1e-9) condOnes++;
+            }
+            Assert.Equal(3, ones);                          // exactly the selected column's block
+            Assert.Equal(1, condOnes);                      // one-hot condition
+            Assert.Equal(1.0, cond[catIdx], 9);             // the set bit matches the reported category
+            // The sampled real row must actually have the conditioned category.
+            Assert.Equal(catIdx, (int)Math.Round(data[rowIdx, 0]));
+            drawn[catIdx]++;
+        }
+
+        // Log-frequency ordering: P(cat0) > P(cat1) > P(cat2), but the ratio is far
+        // gentler than the raw 800:150:50 frequency (that is the whole point of
+        // log-frequency vs proportional sampling). Expected ~ log(801):log(151):log(51)
+        // = 6.69 : 5.02 : 3.93  →  0.43 : 0.32 : 0.25.
+        double p0 = (double)drawn[0] / draws, p1 = (double)drawn[1] / draws, p2 = (double)drawn[2] / draws;
+        Assert.True(p0 > p1 && p1 > p2, $"log-freq ordering violated: {p0:F3},{p1:F3},{p2:F3}");
+        // Not proportional: cat2 would be ~5% under proportional sampling; log-freq
+        // must lift it well above that.
+        Assert.True(p2 > 0.15, $"rare category under-sampled ({p2:F3}); not log-frequency.");
+        // Not uniform: cat0 must stay clearly above 1/3.
+        Assert.True(p0 > 0.38, $"frequent category not favored ({p0:F3}); looks uniform.");
+    }
+}

--- a/tests/AiDotNet.Tests/IntegrationTests/SyntheticData/VgmTransformerPaperFidelityTests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/SyntheticData/VgmTransformerPaperFidelityTests.cs
@@ -1,0 +1,87 @@
+using System;
+using System.Collections.Generic;
+using AiDotNet.Enums;
+using AiDotNet.LinearAlgebra;
+using AiDotNet.NeuralNetworks.SyntheticData;
+using Xunit;
+
+namespace AiDotNet.Tests.IntegrationTests.SyntheticData;
+
+/// <summary>
+/// Paper-fidelity guards for <see cref="TabularDataTransformer{T}"/>'s variational
+/// Gaussian-mixture mode-specific normalization (Xu et al. 2019 §4.2 — the "VGM" the
+/// whole tabular-GAN family shares). Pins the two behaviours the previous plain-EM +
+/// argmax implementation got wrong:
+///   1. the variational Dirichlet prior must DISCOVER the number of modes (a clean
+///      2-component mixture must recover ~2 active modes near the true means, not the
+///      configured maximum);
+///   2. forward transform must SAMPLE the mode from the responsibilities, and the
+///      forward→inverse round-trip must reconstruct continuous values closely.
+/// </summary>
+public class VgmTransformerPaperFidelityTests
+{
+    private const int Seed = 1234;
+
+    /// <summary>
+    /// A column drawn from a well-separated 2-component mixture
+    /// (N(-5, 0.4) and N(+5, 0.4)) must be fit with ~2 active modes whose means sit
+    /// near ±5, even though up to 10 modes are allowed. This is the variational
+    /// auto-pruning the "V" in VGM provides; plain EM kept all 10 alive.
+    /// </summary>
+    [Fact]
+    public void Vgm_RecoversTwoModeMixture_StructureAndMeans()
+    {
+        const int perMode = 300;
+        var rng = new Random(Seed);
+        var data = new Matrix<double>(perMode * 2, 1);
+        for (int i = 0; i < perMode; i++)
+            data[i, 0] = -5.0 + 0.4 * SampleNormal(rng);
+        for (int i = 0; i < perMode; i++)
+            data[perMode + i, 0] = 5.0 + 0.4 * SampleNormal(rng);
+
+        var columns = new List<ColumnMetadata> { new("X", ColumnDataType.Continuous, columnIndex: 0) };
+
+        var t = new TabularDataTransformer<double>(vgmModes: 10, random: new Random(Seed));
+        t.Fit(data, columns);
+
+        // transformedWidth = 1 (normalized) + numActiveModes. Recover the mode count.
+        var info = t.GetTransformInfo(0);
+        int activeModes = info.Width - 1;
+
+        Assert.True(activeModes >= 2 && activeModes <= 3,
+            $"VGM should recover ~2 modes from a clean 2-component mixture, got {activeModes} " +
+            "(variational pruning regressed — plain EM would keep all 10).");
+
+        // Forward then inverse should reconstruct each value within a few tenths
+        // (mode-relative normalization is near-lossless for in-distribution data).
+        var transformed = t.Transform(data);
+        var recon = t.InverseTransform(transformed);
+        double maxErr = 0;
+        for (int i = 0; i < data.Rows; i++)
+            maxErr = Math.Max(maxErr, Math.Abs(recon[i, 0] - data[i, 0]));
+        Assert.True(maxErr < 1.0,
+            $"VGM forward→inverse round-trip error {maxErr:F3} too large (mode normalization broken).");
+
+        // Reconstructed values must cluster near ±5 (the two real modes), never in
+        // the empty gap around 0 — proof the mode structure survived the round-trip.
+        int nearLow = 0, nearHigh = 0, inGap = 0;
+        for (int i = 0; i < recon.Rows; i++)
+        {
+            double v = recon[i, 0];
+            if (Math.Abs(v - (-5.0)) < 2.0) nearLow++;
+            else if (Math.Abs(v - 5.0) < 2.0) nearHigh++;
+            else if (Math.Abs(v) < 2.0) inGap++;
+        }
+        Assert.True(nearLow > perMode / 2 && nearHigh > perMode / 2,
+            $"Reconstructed values did not cluster at both modes (low={nearLow}, high={nearHigh}).");
+        Assert.True(inGap < data.Rows / 20,
+            $"Too many reconstructions ({inGap}) landed in the empty gap around 0 — mode collapse.");
+    }
+
+    private static double SampleNormal(Random rng)
+    {
+        double u1 = 1.0 - rng.NextDouble();
+        double u2 = 1.0 - rng.NextDouble();
+        return Math.Sqrt(-2.0 * Math.Log(u1)) * Math.Cos(2.0 * Math.PI * u2);
+    }
+}

--- a/tests/AiDotNet.Tests/ModelFamilyTests/Base/DiffusionModelTestBase.cs
+++ b/tests/AiDotNet.Tests/ModelFamilyTests/Base/DiffusionModelTestBase.cs
@@ -443,43 +443,39 @@ public abstract class DiffusionModelTestBase<TNum> : IAsyncLifetime
     {
         await Task.Yield();
         using var _arena = TensorArena.Create();
-        var rng = ModelTestHelpers.CreateSeededRandom();
         using var model = CreateModel();
-        var baseInput = CreateRandomTensor(InputShape, rng);
 
-        // Predict at different "noise levels" by scaling input
-        // Low noise (near-original), medium noise, high noise
-        double[] scales = new double[] { 0.1, 0.5, 1.0, 2.0 };
-        double[] outputMagnitudes = new double[scales.Length];
+        // The noise schedule is the SCHEDULER's signal-retention curve: the cumulative product
+        // of alphas (the fraction of the original signal retained at timestep t) must not
+        // increase as t grows, because every step only adds noise. Equivalently the noise
+        // fraction 1 - alpha_cumprod is monotonically non-decreasing. That is the actual
+        // "noise schedule is monotonic" invariant this test is named for, and it holds for
+        // every correctly-configured scheduler (DDPM/cosine/linear/flow-matching).
+        //
+        // (The previous proxy scaled the model's INPUT and checked the OUTPUT magnitude. That
+        // is architecturally invalid for input-normalizing noise predictors such as DiT — its
+        // LayerNorm removes the input scale, so the denoised sample's magnitude is independent
+        // of the input scale by design. Every DiT-based diffusion model failed the old proxy
+        // for that reason, not because of a real bug.)
+        var scheduler = model.Scheduler;
+        int n = scheduler.TrainTimesteps;
+        if (n < 2) return;
 
-        for (int s = 0; s < scales.Length; s++)
-        {
-            var noisyInput = new Tensor<TNum>(InputShape);
-            for (int i = 0; i < baseInput.Length; i++)
-                noisyInput[i] = _numOps.FromDouble(ToDouble(baseInput[i]) * scales[s]);
-
-            var output = model.Predict(noisyInput);
-
-            double magnitude = 0;
-            for (int i = 0; i < output.Length; i++)
-            {
-                double v = ToDouble(output[i]);
-                magnitude += v * v;
-            }
-            outputMagnitudes[s] = Math.Sqrt(magnitude / Math.Max(1, output.Length));
-        }
-
-        // Check monotonicity: allow at most 1 violation out of 3 transitions
+        double prevSignal = ToDouble(scheduler.GetAlphaCumulativeProduct(0));
         int violations = 0;
-        for (int i = 1; i < outputMagnitudes.Length; i++)
+        double worst = 0;
+        for (int t = 1; t < n; t++)
         {
-            if (outputMagnitudes[i] < outputMagnitudes[i - 1] - 1e-10)
-                violations++;
+            double signal = ToDouble(scheduler.GetAlphaCumulativeProduct(t));
+            double increase = signal - prevSignal;
+            if (increase > 1e-9) { violations++; worst = Math.Max(worst, increase); }
+            prevSignal = signal;
         }
 
-        Assert.True(violations <= 1,
-            $"Noise schedule not monotonic: magnitudes = [{string.Join(", ", outputMagnitudes.Select(m => m.ToString("F4")))}]. " +
-            $"Found {violations} violations (max allowed: 1).");
+        Assert.True(violations == 0,
+            $"Noise schedule not monotonic: alpha-cumulative-product (signal retention) increased " +
+            $"with timestep at {violations} step(s) (worst +{worst:E3}); it must be non-increasing " +
+            "as noise accumulates.");
     }
 
     // =====================================================

--- a/tests/AiDotNet.Tests/ModelFamilyTests/Diffusion/AuraFlowModelTests.cs
+++ b/tests/AiDotNet.Tests/ModelFamilyTests/Diffusion/AuraFlowModelTests.cs
@@ -1,5 +1,7 @@
 using AiDotNet.Interfaces;
 using AiDotNet.Diffusion.FastGeneration;
+using AiDotNet.Diffusion.NoisePredictors;
+using AiDotNet.Diffusion.VAE;
 using AiDotNet.Tests.ModelFamilyTests.Base;
 
 namespace AiDotNet.Tests.ModelFamilyTests.Diffusion;
@@ -9,6 +11,20 @@ public class AuraFlowModelTests : DiffusionModelTestBase
     protected override int[] InputShape => [1, 4, 32, 32];
     protected override int[] OutputShape => [1, 4, 32, 32];
 
+    // AuraFlow defaults to a foundation-scale DiT (hidden 1536, 24 layers, ~680M params): it
+    // trips disk-backed weight streaming and cannot complete a single forward within the 120s
+    // test budget. Inject a tiny DiT + VAE so these model-family invariants run against a REAL
+    // instance of the same architecture at a runnable scale — latentChannels (4) and contextDim
+    // (4096) stay paper-correct; only the hidden width / depth / VAE base channels are shrunk,
+    // keeping the model well below the streaming threshold.
     protected override IDiffusionModel<double> CreateModel()
-        => new AuraFlowModel<double>(seed: 42);
+        => new AuraFlowModel<double>(
+            dit: new DiTNoisePredictor<double>(
+                inputChannels: 4, hiddenSize: 64, numLayers: 2, numHeads: 2,
+                patchSize: 2, contextDim: 4096, seed: 42),
+            vae: new StandardVAE<double>(
+                inputChannels: 3, latentChannels: 4, baseChannels: 16,
+                channelMultipliers: new[] { 1, 2 }, numResBlocksPerLevel: 1,
+                latentScaleFactor: 0.13025, seed: 42),
+            seed: 42);
 }

--- a/tests/AiDotNet.Tests/ModelFamilyTests/Diffusion/Flux1ModelTests.cs
+++ b/tests/AiDotNet.Tests/ModelFamilyTests/Diffusion/Flux1ModelTests.cs
@@ -1,5 +1,7 @@
 using AiDotNet.Interfaces;
 using AiDotNet.Diffusion.TextToImage;
+using AiDotNet.Diffusion.NoisePredictors;
+using AiDotNet.Diffusion.VAE;
 using AiDotNet.Tests.ModelFamilyTests.Base;
 
 namespace AiDotNet.Tests.ModelFamilyTests.Diffusion;
@@ -9,6 +11,20 @@ public class Flux1ModelTests : DiffusionModelTestBase
     protected override int[] InputShape => [1, 16, 32, 32];
     protected override int[] OutputShape => [1, 16, 32, 32];
 
+    // FLUX.1 defaults to a 12B-scale hybrid MMDiT (hidden 3072, 19 joint + 38 single layers):
+    // it trips disk-backed weight streaming and cannot complete a single forward within the
+    // 120s test budget. Inject a tiny MMDiT + VAE so these model-family invariants run against
+    // a REAL instance of the same architecture at a runnable scale — latentChannels (16) and
+    // contextDim (4096) stay paper-correct; only the hidden width / depth / VAE base channels
+    // are shrunk, keeping the model well below the streaming threshold.
     protected override IDiffusionModel<double> CreateModel()
-        => new Flux1Model<double>(seed: 42);
+        => new Flux1Model<double>(
+            mmdit: new MMDiTNoisePredictor<double>(
+                inputChannels: 16, hiddenSize: 64, numJointLayers: 2, numSingleLayers: 2,
+                numHeads: 2, patchSize: 2, contextDim: 4096, seed: 42),
+            vae: new StandardVAE<double>(
+                inputChannels: 3, latentChannels: 16, baseChannels: 16,
+                channelMultipliers: new[] { 1, 2 }, numResBlocksPerLevel: 1,
+                latentScaleFactor: 1.5305, seed: 42),
+            seed: 42);
 }

--- a/tests/AiDotNet.Tests/ModelFamilyTests/Diffusion/HunyuanDiTModelTests.cs
+++ b/tests/AiDotNet.Tests/ModelFamilyTests/Diffusion/HunyuanDiTModelTests.cs
@@ -1,5 +1,7 @@
 using AiDotNet.Interfaces;
 using AiDotNet.Diffusion.TextToImage;
+using AiDotNet.Diffusion.NoisePredictors;
+using AiDotNet.Diffusion.VAE;
 using AiDotNet.Tests.ModelFamilyTests.Base;
 
 namespace AiDotNet.Tests.ModelFamilyTests.Diffusion;
@@ -9,6 +11,20 @@ public class HunyuanDiTModelTests : DiffusionModelTestBase
     protected override int[] InputShape => [1, 4, 32, 32];
     protected override int[] OutputShape => [1, 4, 32, 32];
 
+    // Hunyuan-DiT defaults to a foundation-scale DiT (hidden 1408, 40 layers): it trips
+    // disk-backed weight streaming and cannot complete a single forward within the 120s test
+    // budget. Inject a tiny DiT + VAE so these model-family invariants run against a REAL
+    // instance of the same architecture at a runnable scale — latentChannels (4) and contextDim
+    // (2048) stay paper-correct; only the hidden width / depth / VAE base channels are shrunk,
+    // keeping the model well below the streaming threshold.
     protected override IDiffusionModel<double> CreateModel()
-        => new HunyuanDiTModel<double>(seed: 42);
+        => new HunyuanDiTModel<double>(
+            dit: new DiTNoisePredictor<double>(
+                inputChannels: 4, hiddenSize: 64, numLayers: 2, numHeads: 2,
+                patchSize: 2, contextDim: 2048, seed: 42),
+            vae: new StandardVAE<double>(
+                inputChannels: 3, latentChannels: 4, baseChannels: 16,
+                channelMultipliers: new[] { 1, 2 }, numResBlocksPerLevel: 1,
+                latentScaleFactor: 0.13025, seed: 42),
+            seed: 42);
 }

--- a/tests/AiDotNet.Tests/ModelFamilyTests/Diffusion/OmniGen2ModelTests.cs
+++ b/tests/AiDotNet.Tests/ModelFamilyTests/Diffusion/OmniGen2ModelTests.cs
@@ -1,5 +1,7 @@
 using AiDotNet.Interfaces;
 using AiDotNet.Diffusion.ImageEditing;
+using AiDotNet.Diffusion.NoisePredictors;
+using AiDotNet.Diffusion.VAE;
 using AiDotNet.Tests.ModelFamilyTests.Base;
 
 namespace AiDotNet.Tests.ModelFamilyTests.Diffusion;
@@ -9,6 +11,19 @@ public class OmniGen2ModelTests : DiffusionModelTestBase
     protected override int[] InputShape => [1, 16, 32, 32];
     protected override int[] OutputShape => [1, 16, 32, 32];
 
+    // OmniGen-2 defaults to a foundation-scale SiT predictor (hidden 3072, 32 layers, Phi-3
+    // backbone): it trips disk-backed weight streaming and cannot complete a single forward
+    // within the 120s test budget. Inject a tiny SiT + VAE so these model-family invariants run
+    // against a REAL instance of the same architecture at a runnable scale — latentChannels (16)
+    // stays paper-correct; only the hidden width / depth / VAE base channels are shrunk, keeping
+    // the model well below the streaming threshold.
     protected override IDiffusionModel<double> CreateModel()
-        => new OmniGen2Model<double>(seed: 42);
+        => new OmniGen2Model<double>(
+            predictor: new SiTPredictor<double>(
+                inputChannels: 16, hiddenSize: 64, numLayers: 2, numHeads: 2, seed: 42),
+            vae: new StandardVAE<double>(
+                inputChannels: 3, latentChannels: 16, baseChannels: 16,
+                channelMultipliers: new[] { 1, 2 }, numResBlocksPerLevel: 1,
+                latentScaleFactor: 1.5305, seed: 42),
+            seed: 42);
 }

--- a/tests/AiDotNet.Tests/ModelFamilyTests/Diffusion/OmniGenModelTests.cs
+++ b/tests/AiDotNet.Tests/ModelFamilyTests/Diffusion/OmniGenModelTests.cs
@@ -1,5 +1,7 @@
 using AiDotNet.Interfaces;
 using AiDotNet.Diffusion.TextToImage;
+using AiDotNet.Diffusion.NoisePredictors;
+using AiDotNet.Diffusion.VAE;
 using AiDotNet.Tests.ModelFamilyTests.Base;
 
 namespace AiDotNet.Tests.ModelFamilyTests.Diffusion;
@@ -9,6 +11,20 @@ public class OmniGenModelTests : DiffusionModelTestBase
     protected override int[] InputShape => [1, 4, 32, 32];
     protected override int[] OutputShape => [1, 4, 32, 32];
 
+    // OmniGen defaults to a foundation-scale DiT (hidden 2048, 32 layers): it trips disk-backed
+    // weight streaming and cannot complete a single forward within the 120s test budget. Inject
+    // a tiny DiT + VAE so these model-family invariants run against a REAL instance of the same
+    // architecture at a runnable scale — latentChannels (4) and contextDim (2048) stay
+    // paper-correct; only the hidden width / depth / VAE base channels are shrunk, keeping the
+    // model well below the streaming threshold.
     protected override IDiffusionModel<double> CreateModel()
-        => new OmniGenModel<double>(seed: 42);
+        => new OmniGenModel<double>(
+            dit: new DiTNoisePredictor<double>(
+                inputChannels: 4, hiddenSize: 64, numLayers: 2, numHeads: 2,
+                patchSize: 2, contextDim: 2048, seed: 42),
+            vae: new StandardVAE<double>(
+                inputChannels: 3, latentChannels: 4, baseChannels: 16,
+                channelMultipliers: new[] { 1, 2 }, numResBlocksPerLevel: 1,
+                latentScaleFactor: 0.18215, seed: 42),
+            seed: 42);
 }

--- a/tests/AiDotNet.Tests/ModelFamilyTests/Diffusion/WanVideoModelTests.cs
+++ b/tests/AiDotNet.Tests/ModelFamilyTests/Diffusion/WanVideoModelTests.cs
@@ -1,5 +1,7 @@
 using AiDotNet.Interfaces;
 using AiDotNet.Diffusion.Video;
+using AiDotNet.Diffusion.NoisePredictors;
+using AiDotNet.Diffusion.VAE;
 using AiDotNet.Tests.ModelFamilyTests.Base;
 
 namespace AiDotNet.Tests.ModelFamilyTests.Diffusion;
@@ -9,6 +11,21 @@ public class WanVideoModelTests : DiffusionModelTestBase
     protected override int[] InputShape => [1, 16, 32, 32];
     protected override int[] OutputShape => [1, 16, 32, 32];
 
+    // WanVideoModel defaults to the paper 14B variant (3072 hidden, 40 layers): a foundation-
+    // scale model whose lazy weights trip disk-backed weight streaming and cannot complete a
+    // single forward within the 120s test budget (and leak streaming reservations across
+    // tests). Inject a tiny DiT + TemporalVAE so these model-family invariants run against a
+    // REAL instance of the same architecture at a runnable scale — latentChannels (16) and
+    // contextDim (4096) stay paper-correct; only the hidden width / depth / VAE base channels
+    // are shrunk, keeping the model well below the streaming threshold.
     protected override IDiffusionModel<double> CreateModel()
-        => new WanVideoModel<double>(seed: 42);
+        => new WanVideoModel<double>(
+            dit: new DiTNoisePredictor<double>(
+                inputChannels: 16, hiddenSize: 64, numLayers: 2, numHeads: 2,
+                patchSize: 2, contextDim: 4096, seed: 42),
+            temporalVAE: new TemporalVAE<double>(
+                inputChannels: 3, latentChannels: 16, baseChannels: 16,
+                channelMultipliers: new[] { 1, 2 }, numTemporalLayers: 1,
+                temporalKernelSize: 3, causalMode: true, latentScaleFactor: 0.13025, seed: 42),
+            seed: 42);
 }

--- a/tests/AiDotNet.Tests/ModelFamilyTests/NeuralNetworks/BiLSTMCRFTests.cs
+++ b/tests/AiDotNet.Tests/ModelFamilyTests/NeuralNetworks/BiLSTMCRFTests.cs
@@ -1,0 +1,214 @@
+using AiDotNet.Enums;
+using AiDotNet.Interfaces;
+using AiDotNet.NER.Options;
+using AiDotNet.NER.SequenceLabeling;
+using AiDotNet.NeuralNetworks;
+using AiDotNet.Tensors;
+using AiDotNet.Tensors.Helpers;
+using AiDotNet.Tensors.LinearAlgebra;
+using AiDotNet.Tests.ModelFamilyTests.Base;
+using System;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace AiDotNet.Tests.ModelFamilyTests.NeuralNetworks;
+
+/// <summary>
+/// Manual scaffold for the BiLSTM-CRF sequence-labeling model (Lample et al. 2016,
+/// "Neural Architectures for Named Entity Recognition"). Suppresses the auto-generated
+/// stub so we can add the paper-fidelity invariant the POC reported as broken in
+/// AiDotNet 0.213.3: <b>training diverges</b>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The inherited family invariants below reproduce exactly what the auto-generated
+/// SequenceLabelingNER scaffold emits (InputShape <c>[8,100]</c>, a
+/// <see cref="CreateRandomTargetTensor"/> that probes the model's own label count, and a
+/// widened <see cref="TrainingLossReductionTolerance"/> because the CRF objective is
+/// <c>−log P(gold_path)</c>, not the argmax-MSE those generic tests measure). Keeping them
+/// here means suppressing the stub costs no coverage.
+/// </para>
+/// <para>
+/// On top of that, <see cref="Training_DoesNotDiverge_AndDrivesCrfNllDown"/> and
+/// <see cref="Parameters_StayFinite_AfterTraining"/> are the divergence regression. Two
+/// correctness fixes underpin them: (1) the CRF negative-log-likelihood is computed by a
+/// tape-tracked forward algorithm so gradients flow into the transition / start / end
+/// scores, and (2) the default optimizer is the paper's clipped SGD with the
+/// <c>lr_t = lr_0 / (1 + 0.05 t)</c> decay (Lample §4) rather than an adaptive optimizer
+/// whose steps oscillate on the CRF objective. They run on a small, self-contained,
+/// linearly-separable task so the assertions are fast and deterministic.
+/// </para>
+/// </remarks>
+public class BiLSTMCRFTests : SequenceLabelingNERTestBase
+{
+    // ---- Family-invariant configuration (mirrors the auto-generated stub) ----
+
+    // LSTM-CRF family defaults to EmbeddingDimension = 100.
+    protected override int[] InputShape => [8, 100];
+
+    // The CRF NLL objective (−log P(gold_path)) is correlated with but not equal to the
+    // argmax-MSE the generic Training_ShouldReduceLoss measures; combined with 0.5 dropout
+    // and SGD warm-up on a random-target one-sample probe, per-step MSE can transiently
+    // rise. 5.0 is well above stochastic noise yet far below catastrophic divergence
+    // (which spirals to 1e3+ within steps). Matches the scaffold's emitted value.
+    protected override double TrainingLossReductionTolerance => 5.0;
+
+    /// <summary>
+    /// Sequence-labeling CRF models consume INTEGER label indices, not arbitrary floats.
+    /// The base default yields random doubles in [0,1) which the CRF NLL path rounds to a
+    /// degenerate two-class target. Probe the model's actual <c>NumLabels</c> and emit
+    /// legal integer indices in <c>[0, NumLabels)</c> — a test-data adaptation to the
+    /// family's output type, not an assertion weakening. Mirrors the auto-generated stub.
+    /// </summary>
+    protected override Tensor<double> CreateRandomTargetTensor(int[] shape, Random rng)
+    {
+        using var probe = CreateNetwork();
+        if (probe is not AiDotNet.NER.Interfaces.INERModel<double> ner)
+        {
+            string actualType = probe?.GetType().FullName ?? "null";
+            throw new InvalidOperationException(
+                $"SequenceLabelingNER scaffold expected an INERModel<double>, got {actualType}.");
+        }
+        int numLabels = ner.NumLabels;
+        if (numLabels <= 0)
+            throw new InvalidOperationException(
+                $"INERModel<double>.NumLabels returned {numLabels}; expected a positive label count.");
+        var tensor = new Tensor<double>(shape);
+        for (int i = 0; i < tensor.Length; i++)
+            tensor[i] = rng.Next(0, numLabels);
+        return tensor;
+    }
+
+    protected override INeuralNetworkModel<double> CreateNetwork() =>
+        new BiLSTMCRF<double>(
+            new NeuralNetworkArchitecture<double>(
+                inputType: InputType.OneDimensional,
+                taskType: NeuralNetworkTaskType.Regression,
+                inputSize: 100,
+                outputSize: 9));
+
+    // ---- Divergence regression (the POC-reported defect) ----
+
+    private const int Embed = 16;
+    private const int Hidden = 16;
+    private const int RegressionLabels = 4;
+    private const int SeqLen = 8;   // == MaxSequenceLength so no pad/truncate noise
+
+    private static BiLSTMCRF<double> CreateSmallModel() =>
+        new BiLSTMCRF<double>(
+            new NeuralNetworkArchitecture<double>(
+                inputType: InputType.OneDimensional,
+                taskType: NeuralNetworkTaskType.Regression,
+                inputSize: Embed,
+                outputSize: RegressionLabels),
+            new BiLSTMCRFOptions
+            {
+                EmbeddingDimension = Embed,
+                HiddenDimension = Hidden,
+                NumLSTMLayers = 1,
+                NumLabels = RegressionLabels,
+                MaxSequenceLength = SeqLen,
+                UseCRF = true,
+                LabelNames = new[] { "O", "B-PER", "I-PER", "B-LOC" },
+            });
+
+    /// <summary>
+    /// Builds one linearly-separable training example: each token's gold label is encoded
+    /// in its embedding (a one-hot block of width <c>Embed / RegressionLabels</c> plus
+    /// small deterministic jitter), so a correctly-wired BiLSTM-CRF can drive the NLL down.
+    /// The jitter is seeded per (sentence, token) so the dataset is identical across runs.
+    /// </summary>
+    private static (Tensor<double> input, Tensor<double> labels) MakeExample(int sentence)
+    {
+        int block = Embed / RegressionLabels;
+        var input = new Tensor<double>([SeqLen, Embed]);
+        var labels = new Tensor<double>([SeqLen]);
+        for (int t = 0; t < SeqLen; t++)
+        {
+            int label = (t + sentence) % RegressionLabels;
+            labels[t] = label;
+            for (int e = 0; e < Embed; e++)
+            {
+                bool hot = e >= label * block && e < (label + 1) * block;
+                double jitter = 0.05 * (((t * 7 + e * 13 + sentence * 17) % 5) - 2);
+                input[t, e] = (hot ? 1.0 : 0.0) + jitter;
+            }
+        }
+        return (input, labels);
+    }
+
+    /// <summary>
+    /// THE divergence regression: train the BiLSTM-CRF on a small separable dataset and
+    /// assert the CRF NLL stays finite every epoch, is always ≥ 0 (NLL = logZ − goldScore,
+    /// and logZ ≥ goldScore by construction), and ends well below where it started — i.e.
+    /// the model learns instead of diverging. A divergent run shows up here as NaN/Inf loss
+    /// or a final loss that has grown rather than shrunk.
+    /// </summary>
+    [Fact(Timeout = 180000)]
+    public async Task Training_DoesNotDiverge_AndDrivesCrfNllDown()
+    {
+        await Task.Yield();
+        using var _arena = TensorArena.Create();
+        using var model = CreateSmallModel();
+
+        var examples = new (Tensor<double> input, Tensor<double> labels)[3];
+        for (int s = 0; s < examples.Length; s++)
+            examples[s] = MakeExample(s);
+
+        const int epochs = 40;
+        double firstLoss = double.NaN;
+        double lastLoss = double.NaN;
+
+        for (int epoch = 0; epoch < epochs; epoch++)
+        {
+            double epochLoss = 0.0;
+            foreach (var (input, labels) in examples)
+            {
+                model.Train(input, labels);
+                double loss = Convert.ToDouble(model.GetLastLoss());
+
+                Assert.False(double.IsNaN(loss),
+                    $"CRF NLL is NaN at epoch {epoch} — training diverged.");
+                Assert.False(double.IsInfinity(loss),
+                    $"CRF NLL is Infinity at epoch {epoch} — training diverged.");
+                // NLL = logZ − goldScore ≥ 0; a negative value means the forward
+                // log-partition is below the gold-path score, which is impossible.
+                Assert.True(loss >= -1e-6,
+                    $"CRF NLL = {loss:E3} is negative at epoch {epoch} — logZ/goldScore inconsistent.");
+
+                epochLoss += loss;
+            }
+            epochLoss /= examples.Length;
+
+            if (epoch == 0) firstLoss = epochLoss;
+            lastLoss = epochLoss;
+        }
+
+        Assert.True(lastLoss < firstLoss,
+            $"CRF NLL did not decrease over {epochs} epochs (first={firstLoss:F4}, " +
+            $"last={lastLoss:F4}). BiLSTM-CRF training is not converging.");
+    }
+
+    /// <summary>
+    /// Parameters must stay finite after a full training run. Divergence in the original
+    /// 0.213.3 report manifested as the weights blowing up; this guards that directly.
+    /// </summary>
+    [Fact(Timeout = 180000)]
+    public async Task Parameters_StayFinite_AfterTraining()
+    {
+        await Task.Yield();
+        using var _arena = TensorArena.Create();
+        using var model = CreateSmallModel();
+
+        var (input, labels) = MakeExample(0);
+        for (int i = 0; i < 30; i++)
+            model.Train(input, labels);
+
+        var p = model.GetParameters();
+        for (int i = 0; i < p.Length; i++)
+        {
+            Assert.False(double.IsNaN(p[i]), $"Parameter[{i}] is NaN after training — diverged.");
+            Assert.False(double.IsInfinity(p[i]), $"Parameter[{i}] is Infinity after training — diverged.");
+        }
+    }
+}

--- a/tests/AiDotNet.Tests/ModelFamilyTests/NeuralNetworks/CTGANGeneratorTests.cs
+++ b/tests/AiDotNet.Tests/ModelFamilyTests/NeuralNetworks/CTGANGeneratorTests.cs
@@ -1,0 +1,146 @@
+using System;
+using System.Collections.Generic;
+using AiDotNet.Enums;
+using AiDotNet.Models.Options;
+using AiDotNet.NeuralNetworks;
+using AiDotNet.NeuralNetworks.SyntheticData;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tests.ModelFamilyTests.NeuralNetworks;
+
+/// <summary>
+/// Manual test scaffold for <see cref="CTGANGenerator{T}"/> (Xu et al. 2019,
+/// "Modeling Tabular Data using Conditional GAN"). Follows the
+/// <see cref="TableGANGeneratorTests"/> pattern: CTGAN's real training runs
+/// through <see cref="CTGANGenerator{T}.Fit"/> against a tabular matrix + column
+/// metadata, not the <c>Train(Tensor, Tensor)</c> surface the auto-generated
+/// <c>TestScaffoldGenerator</c> invariants exercise. Being named
+/// <c>CTGANGeneratorTests</c> suppresses that auto-generated stub and lets this
+/// scaffold cover the model's real surface — construction, Predict, the
+/// Fit + Generate path — plus the paper-faithfulness invariants that pin the
+/// Synthetic POC's findings (divergence on small data, worse with more epochs).
+/// </summary>
+public class CTGANGeneratorTests
+{
+    private const int Seed = 1729;
+
+    private static CTGANGenerator<double> CreateGenerator(CTGANOptions<double>? options = null)
+    {
+        options ??= new CTGANOptions<double>
+        {
+            Seed = Seed,
+            EmbeddingDimension = 32,
+            GeneratorDimensions = new[] { 64, 64 },
+            DiscriminatorDimensions = new[] { 64, 64 },
+            BatchSize = 50,
+            PacSize = 5,
+            VGMModes = 10,
+            DiscriminatorSteps = 1,
+            LearningRate = 1e-3,
+        };
+        var arch = new NeuralNetworkArchitecture<double>(
+            inputType: InputType.OneDimensional,
+            taskType: NeuralNetworkTaskType.Generative,
+            inputSize: 2,
+            outputSize: 2);
+        return new CTGANGenerator<double>(arch, options);
+    }
+
+    /// <summary>
+    /// Bimodal dataset: a strongly separated continuous column (N(-5,0.5) ∪
+    /// N(5,0.5)) + a binary categorical column correlated with the mode — the
+    /// multimodal-tabular case CTGAN's VGM + conditional machinery exists for.
+    /// </summary>
+    private static (Matrix<double> data, ColumnMetadata[] columns) BuildBimodalDataset(int perMode = 150)
+    {
+        int rows = perMode * 2;
+        var rng = new Random(Seed);
+        var data = new Matrix<double>(rows, 2);
+        for (int i = 0; i < perMode; i++) { data[i, 0] = -5.0 + 0.5 * SampleNormal(rng); data[i, 1] = 0; }
+        for (int i = 0; i < perMode; i++) { data[perMode + i, 0] = 5.0 + 0.5 * SampleNormal(rng); data[perMode + i, 1] = 1; }
+        var columns = new[]
+        {
+            new ColumnMetadata("X", ColumnDataType.Continuous, columnIndex: 0),
+            new ColumnMetadata("C", ColumnDataType.Categorical, new[] { "lo", "hi" }, columnIndex: 1),
+        };
+        return (data, columns);
+    }
+
+    [Fact]
+    public void Constructor_DefaultOptions_DoesNotThrow()
+    {
+        using var gen = CreateGenerator();
+        Assert.NotNull(gen);
+        Assert.False(gen.IsFitted);
+    }
+
+    [Fact]
+    public void Generate_AfterFit_ProducesFiniteSyntheticRows()
+    {
+        var (data, columns) = BuildBimodalDataset(perMode: 40);
+        using var gen = CreateGenerator();
+        gen.Fit(data, columns, epochs: 5);
+
+        var synthetic = gen.Generate(numSamples: 16);
+
+        Assert.Equal(16, synthetic.Rows);
+        Assert.Equal(columns.Length, synthetic.Columns);
+        for (int r = 0; r < synthetic.Rows; r++)
+            for (int c = 0; c < synthetic.Columns; c++)
+                Assert.False(double.IsNaN(synthetic[r, c]) || double.IsInfinity(synthetic[r, c]),
+                    $"Synthetic[{r},{c}] not finite: {synthetic[r, c]}");
+    }
+
+    /// <summary>
+    /// PAPER INVARIANT (the POC's headline finding): CTGAN must train stably and
+    /// recover the bimodal distribution. The pre-fix code shared one AdamOptimizer
+    /// across generator and discriminator, whose flat moment buffer reallocated and
+    /// reset the timestep on every alternating step (different param counts) — so it
+    /// diverged worse with more epochs. This trains 60 epochs (well past the old
+    /// blow-up point) and asserts non-divergence, no mode collapse, and bimodality.
+    /// </summary>
+    [Fact]
+    public void Ctgan_TrainsStably_AndRecoversBimodalDistribution()
+    {
+        var (data, columns) = BuildBimodalDataset(perMode: 150);
+        using var gen = CreateGenerator();
+
+        gen.Fit(data, columns, epochs: 60);
+        var synth = gen.Generate(400);
+
+        double mean = 0;
+        for (int i = 0; i < synth.Rows; i++)
+        {
+            double x = synth[i, 0];
+            Assert.False(double.IsNaN(x) || double.IsInfinity(x), $"row {i}: non-finite value {x} (CTGAN diverged).");
+            Assert.InRange(x, -24, 24); // generous; catches explosion
+            mean += x;
+        }
+        mean /= synth.Rows;
+
+        double var0 = 0;
+        for (int i = 0; i < synth.Rows; i++) { double d = synth[i, 0] - mean; var0 += d * d; }
+        double std = Math.Sqrt(var0 / synth.Rows);
+        Assert.True(std > 1.5, $"generated std {std:F2} too small — mode collapse (real std ≈ 5).");
+
+        int low = 0, high = 0;
+        for (int i = 0; i < synth.Rows; i++)
+        {
+            if (synth[i, 0] < -1.5) low++;
+            else if (synth[i, 0] > 1.5) high++;
+        }
+        Assert.True(low > synth.Rows / 10, $"too few low-mode samples ({low}) — a mode was ignored.");
+        Assert.True(high > synth.Rows / 10, $"too few high-mode samples ({high}) — a mode was ignored.");
+
+        for (int i = 0; i < synth.Rows; i++)
+            Assert.InRange((int)Math.Round(synth[i, 1]), 0, 1);
+    }
+
+    private static double SampleNormal(Random rng)
+    {
+        double u1 = 1.0 - rng.NextDouble();
+        double u2 = 1.0 - rng.NextDouble();
+        return Math.Sqrt(-2.0 * Math.Log(u1)) * Math.Cos(2.0 * Math.PI * u2);
+    }
+}

--- a/tests/AiDotNet.Tests/ModelFamilyTests/NeuralNetworks/OmniGen2Tests.cs
+++ b/tests/AiDotNet.Tests/ModelFamilyTests/NeuralNetworks/OmniGen2Tests.cs
@@ -1,0 +1,71 @@
+using AiDotNet.Enums;
+using AiDotNet.Interfaces;
+using AiDotNet.NeuralNetworks;
+using AiDotNet.Tests.ModelFamilyTests.Base;
+using AiDotNet.VisionLanguage.Unified;
+
+namespace AiDotNet.Tests.ModelFamilyTests.NeuralNetworks;
+
+/// <summary>
+/// Manual test scaffold for OmniGen2 (VisionLanguage.Unified) — the unified
+/// understanding + generation VLM with a Phi-3 decoder backbone. The auto-generator
+/// is told to skip OmniGen2 (<c>ExcludedClassNames</c>) so this hand-written scaffold
+/// is authoritative.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Why a reduced-scale config:</b> OmniGen2's paper defaults (VisionDim=1024,
+/// DecoderDim=4096, 24 vision + 32 decoder layers, 32 heads, ImageSize=512,
+/// VocabSize=32000) make it a multi-billion-parameter model. At that scale it trips
+/// disk-backed weight streaming (so a forward no longer OOMs), but a single
+/// backward+AdamW step still cannot complete within the 120s CI budget on CPU — the
+/// cost is dominated by the parameter COUNT (image size / iteration count don't change
+/// it), exactly the Janus-Pro / Helix situation.
+/// </para>
+/// <para>
+/// These model-family invariants validate the <i>architecture's code paths</i>
+/// (dual-path vision encoder + decoder wiring, patch embedding, attention/FFN, backprop,
+/// optimizer step) — not paper-scale numerical behaviour. A smaller config exercises
+/// every one of those paths in seconds while keeping the architecture's SHAPE faithful.
+/// The dims below are scaled down ~8x (DecoderDim 4096→512, layers 32→4, etc.); the
+/// model wiring is unchanged. Dropout is disabled so the memorization-based invariants
+/// (strictly-decreasing loss, params-change) see clean monotonic convergence — those
+/// tests validate the optimization path, not regularization.
+/// </para>
+/// </remarks>
+public class OmniGen2Tests : VisionLanguageTestBase<float>
+{
+    // Reduced input: (64/16)^2 visual tokens through the patch embedder.
+    // VisionLanguageModelBase's contract is [batch, channels=3, height, width].
+    protected override int[] InputShape => [1, 3, 64, 64];
+
+    protected override INeuralNetworkModel<float> CreateNetwork()
+    {
+        // Architecture image dims must match the options' ImageSize so the vision
+        // encoder's patch embedder sees the expected spatial extent.
+        var architecture = new NeuralNetworkArchitecture<float>(
+            inputType: InputType.ThreeDimensional,
+            taskType: NeuralNetworkTaskType.ImageClassification,
+            inputHeight: 64,
+            inputWidth: 64,
+            inputDepth: 3,
+            outputSize: 512);
+
+        // Reduced-scale config (see <remarks>): same dual-path architecture shape as the
+        // multi-billion-parameter paper model, ~8x smaller dims so all invariants fit the
+        // CI budget. NumHeads (8) divides both VisionDim (256) and DecoderDim (512).
+        var options = new OmniGen2Options
+        {
+            ImageSize = 64,
+            VisionDim = 256,
+            DecoderDim = 512,
+            NumVisionLayers = 4,
+            NumDecoderLayers = 4,
+            NumHeads = 8,
+            VocabSize = 1000,
+            NumVisualTokens = 256,
+            DropoutRate = 0.0,
+        };
+        return new OmniGen2<float>(architecture, options);
+    }
+}

--- a/tests/AiDotNet.Tests/UnitTests/Diffusion/Models/ControlModelContractTests.cs
+++ b/tests/AiDotNet.Tests/UnitTests/Diffusion/Models/ControlModelContractTests.cs
@@ -15,7 +15,7 @@ public class ControlModelContractTests : DiffusionUnitTestBase
     [Fact(Timeout = 120000)]
     public async Task PerturbedAttentionGuidance_DefaultConstructor_CreatesValid()
     {
-        var guidance = new PerturbedAttentionGuidance<double>();
+        var guidance = new PerturbedAttentionGuidance<float>();
 
         Assert.NotNull(guidance);
     }
@@ -23,7 +23,7 @@ public class ControlModelContractTests : DiffusionUnitTestBase
     [Fact(Timeout = 120000)]
     public async Task SelfAttentionGuidance_DefaultConstructor_CreatesValid()
     {
-        var guidance = new SelfAttentionGuidance<double>();
+        var guidance = new SelfAttentionGuidance<float>();
 
         Assert.NotNull(guidance);
     }
@@ -31,7 +31,7 @@ public class ControlModelContractTests : DiffusionUnitTestBase
     [Fact(Timeout = 120000)]
     public async Task DynamicCFGScheduler_DefaultConstructor_CreatesValid()
     {
-        var scheduler = new DynamicCFGScheduler<double>();
+        var scheduler = new DynamicCFGScheduler<float>();
 
         Assert.NotNull(scheduler);
     }
@@ -39,7 +39,7 @@ public class ControlModelContractTests : DiffusionUnitTestBase
     [Fact(Timeout = 120000)]
     public async Task RescaledCFG_DefaultConstructor_CreatesValid()
     {
-        var cfg = new RescaledCFG<double>();
+        var cfg = new RescaledCFG<float>();
 
         Assert.NotNull(cfg);
     }
@@ -47,7 +47,7 @@ public class ControlModelContractTests : DiffusionUnitTestBase
     [Fact(Timeout = 120000)]
     public async Task AdaptiveProjectedGuidance_DefaultConstructor_CreatesValid()
     {
-        var guidance = new AdaptiveProjectedGuidance<double>();
+        var guidance = new AdaptiveProjectedGuidance<float>();
 
         Assert.NotNull(guidance);
     }
@@ -59,7 +59,7 @@ public class ControlModelContractTests : DiffusionUnitTestBase
     [Fact(Timeout = 120000)]
     public async Task ControlNetPlusPlusModel_DefaultConstructor_CreatesValidModel()
     {
-        var model = new ControlNetPlusPlusModel<double>();
+        var model = new ControlNetPlusPlusModel<float>();
 
         Assert.NotNull(model);
         Assert.NotNull(model.NoisePredictor);
@@ -71,7 +71,7 @@ public class ControlModelContractTests : DiffusionUnitTestBase
     [Fact(Timeout = 120000)]
     public async Task ControlNetFluxModel_DefaultConstructor_CreatesValidModel()
     {
-        var model = new ControlNetFluxModel<double>();
+        var model = new ControlNetFluxModel<float>();
 
         Assert.NotNull(model);
         Assert.NotNull(model.NoisePredictor);
@@ -82,7 +82,7 @@ public class ControlModelContractTests : DiffusionUnitTestBase
     [Fact(Timeout = 120000)]
     public async Task ControlNetSD3Model_DefaultConstructor_CreatesValidModel()
     {
-        var model = new ControlNetSD3Model<double>();
+        var model = new ControlNetSD3Model<float>();
 
         Assert.NotNull(model);
         Assert.NotNull(model.NoisePredictor);
@@ -93,7 +93,7 @@ public class ControlModelContractTests : DiffusionUnitTestBase
     [Fact(Timeout = 120000)]
     public async Task ControlNetUnionProModel_DefaultConstructor_CreatesValidModel()
     {
-        var model = new ControlNetUnionProModel<double>();
+        var model = new ControlNetUnionProModel<float>();
 
         Assert.NotNull(model);
         Assert.NotNull(model.NoisePredictor);
@@ -104,7 +104,7 @@ public class ControlModelContractTests : DiffusionUnitTestBase
     [Fact(Timeout = 120000)]
     public async Task IPAdapterPlusModel_DefaultConstructor_CreatesValidModel()
     {
-        var model = new IPAdapterPlusModel<double>();
+        var model = new IPAdapterPlusModel<float>();
 
         Assert.NotNull(model);
         Assert.NotNull(model.NoisePredictor);
@@ -115,7 +115,7 @@ public class ControlModelContractTests : DiffusionUnitTestBase
     [Fact(Timeout = 120000)]
     public async Task IPAdapterFaceIDPlusModel_DefaultConstructor_CreatesValidModel()
     {
-        var model = new IPAdapterFaceIDPlusModel<double>();
+        var model = new IPAdapterFaceIDPlusModel<float>();
 
         Assert.NotNull(model);
         Assert.NotNull(model.NoisePredictor);
@@ -126,7 +126,7 @@ public class ControlModelContractTests : DiffusionUnitTestBase
     [Fact(Timeout = 120000)]
     public async Task ControlNetLiteModel_DefaultConstructor_CreatesValidModel()
     {
-        var model = new ControlNetLiteModel<double>();
+        var model = new ControlNetLiteModel<float>();
 
         Assert.NotNull(model);
         Assert.NotNull(model.NoisePredictor);
@@ -137,7 +137,7 @@ public class ControlModelContractTests : DiffusionUnitTestBase
     [Fact(Timeout = 120000)]
     public async Task ControlNetQRModel_DefaultConstructor_CreatesValidModel()
     {
-        var model = new ControlNetQRModel<double>();
+        var model = new ControlNetQRModel<float>();
 
         Assert.NotNull(model);
         Assert.NotNull(model.NoisePredictor);
@@ -148,7 +148,7 @@ public class ControlModelContractTests : DiffusionUnitTestBase
     [Fact(Timeout = 120000)]
     public async Task ReferenceOnlyModel_DefaultConstructor_CreatesValidModel()
     {
-        var model = new ReferenceOnlyModel<double>();
+        var model = new ReferenceOnlyModel<float>();
 
         Assert.NotNull(model);
         Assert.NotNull(model.NoisePredictor);
@@ -159,7 +159,7 @@ public class ControlModelContractTests : DiffusionUnitTestBase
     [Fact(Timeout = 120000)]
     public async Task StyleAlignedModel_DefaultConstructor_CreatesValidModel()
     {
-        var model = new StyleAlignedModel<double>();
+        var model = new StyleAlignedModel<float>();
 
         Assert.NotNull(model);
         Assert.NotNull(model.NoisePredictor);
@@ -170,7 +170,7 @@ public class ControlModelContractTests : DiffusionUnitTestBase
     [Fact(Timeout = 120000)]
     public async Task ControlNetTileModel_DefaultConstructor_CreatesValidModel()
     {
-        var model = new ControlNetTileModel<double>();
+        var model = new ControlNetTileModel<float>();
 
         Assert.NotNull(model);
         Assert.NotNull(model.NoisePredictor);
@@ -181,7 +181,7 @@ public class ControlModelContractTests : DiffusionUnitTestBase
     [Fact(Timeout = 120000)]
     public async Task ControlNetInpaintingModel_DefaultConstructor_CreatesValidModel()
     {
-        var model = new ControlNetInpaintingModel<double>();
+        var model = new ControlNetInpaintingModel<float>();
 
         Assert.NotNull(model);
         Assert.NotNull(model.NoisePredictor);
@@ -192,7 +192,7 @@ public class ControlModelContractTests : DiffusionUnitTestBase
     [Fact(Timeout = 120000)]
     public async Task ControlNeXtModel_DefaultConstructor_CreatesValidModel()
     {
-        var model = new ControlNeXtModel<double>();
+        var model = new ControlNeXtModel<float>();
 
         Assert.NotNull(model);
         Assert.NotNull(model.NoisePredictor);
@@ -203,7 +203,7 @@ public class ControlModelContractTests : DiffusionUnitTestBase
     [Fact(Timeout = 120000)]
     public async Task ControlARModel_DefaultConstructor_CreatesValidModel()
     {
-        var model = new ControlARModel<double>();
+        var model = new ControlARModel<float>();
 
         Assert.NotNull(model);
         Assert.NotNull(model.NoisePredictor);
@@ -214,7 +214,7 @@ public class ControlModelContractTests : DiffusionUnitTestBase
     [Fact(Timeout = 120000)]
     public async Task ControlNetPlusPlusFluxModel_DefaultConstructor_CreatesValidModel()
     {
-        var model = new ControlNetPlusPlusFluxModel<double>();
+        var model = new ControlNetPlusPlusFluxModel<float>();
 
         Assert.NotNull(model);
         Assert.NotNull(model.NoisePredictor);
@@ -229,7 +229,7 @@ public class ControlModelContractTests : DiffusionUnitTestBase
     [Fact(Timeout = 120000)]
     public async Task ControlNetPlusPlusModel_Clone_CreatesIndependentCopy()
     {
-        var model = new ControlNetPlusPlusModel<double>();
+        var model = new ControlNetPlusPlusModel<float>();
         var clone = model.Clone();
 
         Assert.NotNull(clone);
@@ -240,7 +240,7 @@ public class ControlModelContractTests : DiffusionUnitTestBase
     [Fact(Timeout = 120000)]
     public async Task ControlNetFluxModel_Clone_CreatesIndependentCopy()
     {
-        var model = new ControlNetFluxModel<double>();
+        var model = new ControlNetFluxModel<float>();
         var clone = model.Clone();
 
         Assert.NotNull(clone);
@@ -255,7 +255,7 @@ public class ControlModelContractTests : DiffusionUnitTestBase
     [Fact(Timeout = 120000)]
     public async Task IPAdapterModel_DefaultConstructor_CreatesValidModel()
     {
-        var model = new IPAdapterModel<double>();
+        var model = new IPAdapterModel<float>();
 
         Assert.NotNull(model);
         Assert.NotNull(model.NoisePredictor);

--- a/tests/AiDotNet.Tests/UnitTests/Diffusion/Models/DiTWeightStreamingTests.cs
+++ b/tests/AiDotNet.Tests/UnitTests/Diffusion/Models/DiTWeightStreamingTests.cs
@@ -1,0 +1,186 @@
+using System;
+using AiDotNet.Diffusion.NoisePredictors;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tests.UnitTests.Diffusion.Models;
+
+/// <summary>
+/// Controlled-scale validation of transparent weight streaming for DiT noise
+/// predictors (Tensors #602 / #603, issue #430). Foundation-scale DiT models
+/// (Sora / Flux2 / WanVideo) can't be forwarded on a 16 GB host, so these tests
+/// engage the exact same code path on a tiny DiT via the test-only threshold +
+/// resident-cap overrides, and assert the two guarantees that matter:
+///
+///   1. Faithful paging — the CORE streaming contract: forward-1 (weights
+///      resident) and forward-2 (weights registered, dropped to the disk-backed
+///      pool, and auto-rehydrated on access) must be BIT-IDENTICAL. That is the
+///      "transparent" guarantee — a model computes the same result it would with
+///      all weights resident, just within a bounded memory budget.
+///   2. Bounded residency — after the weights are registered, a forward keeps
+///      the pool's resident set under the cap (EvictionCount &gt; 0,
+///      ResidentBytes ≤ cap); the symmetric owner-drop frees the tensors'
+///      resident copies.
+///
+/// <para>The streaming forward reaches each weight through <c>Tensor.Memory</c>
+/// (SelfAttention etc.), which only auto-rehydrates a paged-out weight on the
+/// Tensors build that carries the #603 <c>.Memory</c> gate. These tests probe
+/// for that gate at runtime and <see cref="Skip"/> cleanly on an older Tensors
+/// (e.g. 0.95.0) — they run and pass once the consuming project bumps to the
+/// #603 release. This is a cross-repo version gate, not a masked failure.</para>
+///
+/// <para>The tests mutate the process-wide <see cref="WeightRegistry"/> and the
+/// static engagement overrides, so each resets all global state in a finally
+/// block. Tests in one class are one xUnit collection (run sequentially), and no
+/// other diffusion test forwards a DiT model, so the global override window
+/// doesn't race a neighbour.</para>
+/// </summary>
+public class DiTWeightStreamingTests
+{
+    private const int InputChannels = 4;
+    private const int HiddenSize = 64;
+    private const int NumLayers = 4;
+    private const int NumHeads = 4;
+    private const int PatchSize = 2;
+    private const int ContextDim = 32;
+    private const int LatentSpatial = 8;
+    private const int Seed = 42;
+
+    // Cap above the largest single weight (~128 KiB here, so AllocateStreaming
+    // never goes over-budget on one tensor) but below the model's total
+    // (~525 KiB), so the pool pages cold weights out ACROSS the forward. The
+    // production floor is 512 MiB (>> any single weight); this mirrors that
+    // relationship at the tiny test scale.
+    private const long ResidentCap = 256 * 1024;
+
+    private static DiTNoisePredictor<double> NewPredictor() => new(
+        inputChannels: InputChannels,
+        hiddenSize: HiddenSize,
+        numLayers: NumLayers,
+        numHeads: NumHeads,
+        patchSize: PatchSize,
+        contextDim: ContextDim,
+        latentSpatialSize: LatentSpatial,
+        seed: Seed);
+
+    private static Tensor<double> NewInput() =>
+        new(new[] { 1, InputChannels, LatentSpatial, LatentSpatial });
+
+    /// <summary>
+    /// True when the referenced Tensors build auto-rehydrates a paged-out
+    /// streaming weight read through <c>Tensor.Memory</c> (PR #603). Detected by
+    /// running a tiny streamed forward — SelfAttention reaches weights via
+    /// <c>.Memory</c>, which on a pre-#603 build slices empty dropped storage and
+    /// throws <see cref="ArgumentOutOfRangeException"/>.
+    /// </summary>
+    private static bool MemoryGatePresent()
+    {
+        WeightRegistry.Reset();
+        NoisePredictorBase<double>.StreamingThresholdOverride = 1;
+        NoisePredictorBase<double>.StreamingResidentCapOverride = ResidentCap;
+        try
+        {
+            var p = NewPredictor();
+            _ = p.PredictNoise(NewInput(), timestep: 250); // engage + register + drop
+            _ = p.PredictNoise(NewInput(), timestep: 250); // rehydrate via .Memory
+            return true;
+        }
+        catch (ArgumentOutOfRangeException)
+        {
+            return false;
+        }
+        finally
+        {
+            NoisePredictorBase<double>.StreamingThresholdOverride = null;
+            NoisePredictorBase<double>.StreamingResidentCapOverride = null;
+            WeightRegistry.Reset();
+        }
+    }
+
+    [SkippableFact]
+    public void Streaming_FaithfulPaging_AndBoundedResidentSet()
+    {
+        Skip.IfNot(MemoryGatePresent(),
+            "Requires the Tensors .Memory auto-rehydrate gate (PR #603); the referenced " +
+            "build lacks it. Bump AiDotNet.Tensors to the #603 release to run this test.");
+
+        try
+        {
+            WeightRegistry.Reset();
+            // threshold 1 forces engage on the tiny model; the cap forces the
+            // pool to page weights out across the forward.
+            NoisePredictorBase<double>.StreamingThresholdOverride = 1;
+            NoisePredictorBase<double>.StreamingResidentCapOverride = ResidentCap;
+
+            var streamed = NewPredictor();
+
+            // First forward: engages streaming, resolves + registers weights.
+            var out1 = streamed.PredictNoise(NewInput(), timestep: 250);
+            var report1 = WeightRegistry.GetStreamingReport();
+            Assert.True(report1.RegisteredEntryCount > 0,
+                "Streaming should have engaged and registered the predictor's weights.");
+
+            // Second forward: runs against the bounded, paged-out resident set.
+            var out2 = streamed.PredictNoise(NewInput(), timestep: 250);
+            var report2 = WeightRegistry.GetStreamingReport();
+
+            // Bounded residency: the pool paged cold weights to disk under the
+            // cap and never held more than the cap resident.
+            Assert.True(report2.EvictionCount > 0,
+                "The cap (below the model's total weight bytes) must force at least one eviction.");
+            Assert.True(report2.ResidentBytes <= ResidentCap,
+                $"Resident bytes ({report2.ResidentBytes}) must stay within the {ResidentCap}-byte cap.");
+
+            var firstOut = out1.ToArray();
+            var streamedOut = out2.ToArray();
+            Assert.True(firstOut.Length > 0);
+            Assert.Equal(firstOut.Length, streamedOut.Length);
+
+            // Output must be finite and non-trivial — an all-zero or NaN/Inf
+            // forward would make the faithfulness check meaningless.
+            bool anyNonZero = false;
+            foreach (var v in streamedOut)
+            {
+                Assert.True(!double.IsNaN(v) && !double.IsInfinity(v), "Streamed output must be finite.");
+                if (Math.Abs(v) > 1e-12) anyNonZero = true;
+            }
+            Assert.True(anyNonZero, "Streamed forward produced an all-zero output (weights never resolved).");
+
+            // THE core streaming guarantee: paging weights to disk and back must
+            // not change the result. forward-1 (resident) vs forward-2 (paged out
+            // then auto-rehydrated on access) must be BIT-IDENTICAL.
+            for (int i = 0; i < firstOut.Length; i++)
+                Assert.True(Math.Abs(firstOut[i] - streamedOut[i]) < 1e-12,
+                    $"Rehydrated forward-2[{i}]={streamedOut[i]} diverged from resident forward-1 {firstOut[i]} — disk paging is not faithful.");
+        }
+        finally
+        {
+            NoisePredictorBase<double>.StreamingThresholdOverride = null;
+            NoisePredictorBase<double>.StreamingResidentCapOverride = null;
+            WeightRegistry.Reset();
+        }
+    }
+
+    [Fact]
+    public void Streaming_NotEngaged_BelowThreshold()
+    {
+        // With no override, a tiny predictor is far below the 500M default and
+        // must NOT engage streaming — leaving the registry untouched. (No
+        // .Memory-gate dependency: nothing pages out, so this always runs.)
+        WeightRegistry.Reset();
+        NoisePredictorBase<double>.StreamingThresholdOverride = null;
+        NoisePredictorBase<double>.StreamingResidentCapOverride = null;
+        try
+        {
+            var predictor = NewPredictor();
+            _ = predictor.PredictNoise(NewInput(), timestep: 100);
+
+            var report = WeightRegistry.GetStreamingReport();
+            Assert.Equal(0, report.RegisteredEntryCount);
+        }
+        finally
+        {
+            WeightRegistry.Reset();
+        }
+    }
+}

--- a/tests/AiDotNet.Tests/UnitTests/Diffusion/Models/DiffusionModelContractTests.cs
+++ b/tests/AiDotNet.Tests/UnitTests/Diffusion/Models/DiffusionModelContractTests.cs
@@ -26,7 +26,7 @@ public class DiffusionModelContractTests : DiffusionUnitTestBase
     [Fact(Timeout = 120000)]
     public async Task StableDiffusion15Model_DefaultConstructor_CreatesValidModel()
     {
-        var model = new StableDiffusion15Model<double>();
+        var model = new StableDiffusion15Model<float>();
 
         Assert.NotNull(model);
         Assert.NotNull(model.NoisePredictor);
@@ -38,7 +38,7 @@ public class DiffusionModelContractTests : DiffusionUnitTestBase
     [Fact(Timeout = 120000)]
     public async Task StableDiffusion2Model_DefaultConstructor_CreatesValidModel()
     {
-        var model = new StableDiffusion2Model<double>();
+        var model = new StableDiffusion2Model<float>();
 
         Assert.NotNull(model);
         Assert.NotNull(model.NoisePredictor);
@@ -49,7 +49,7 @@ public class DiffusionModelContractTests : DiffusionUnitTestBase
     [Fact(Timeout = 120000)]
     public async Task StableDiffusion3Model_DefaultConstructor_CreatesValidModel()
     {
-        var model = new StableDiffusion3Model<double>();
+        var model = new StableDiffusion3Model<float>();
 
         Assert.NotNull(model);
         Assert.NotNull(model.NoisePredictor);
@@ -60,7 +60,7 @@ public class DiffusionModelContractTests : DiffusionUnitTestBase
     [Fact(Timeout = 120000)]
     public async Task Flux1Model_DefaultConstructor_CreatesValidModel()
     {
-        var model = new Flux1Model<double>();
+        var model = new Flux1Model<float>();
 
         Assert.NotNull(model);
         Assert.NotNull(model.NoisePredictor);
@@ -71,7 +71,7 @@ public class DiffusionModelContractTests : DiffusionUnitTestBase
     [Fact(Timeout = 120000)]
     public async Task DallE2Model_DefaultConstructor_CreatesValidModel()
     {
-        var model = new DallE2Model<double>();
+        var model = new DallE2Model<float>();
 
         Assert.NotNull(model);
         Assert.NotNull(model.NoisePredictor);
@@ -81,7 +81,7 @@ public class DiffusionModelContractTests : DiffusionUnitTestBase
     [Fact(Timeout = 120000)]
     public async Task KandinskyModel_DefaultConstructor_CreatesValidModel()
     {
-        var model = new KandinskyModel<double>();
+        var model = new KandinskyModel<float>();
 
         Assert.NotNull(model);
         Assert.NotNull(model.NoisePredictor);
@@ -91,7 +91,7 @@ public class DiffusionModelContractTests : DiffusionUnitTestBase
     [Fact(Timeout = 120000)]
     public async Task ImagenModel_DefaultConstructor_CreatesValidModel()
     {
-        var model = new ImagenModel<double>();
+        var model = new ImagenModel<float>();
 
         Assert.NotNull(model);
         Assert.NotNull(model.NoisePredictor);
@@ -101,7 +101,7 @@ public class DiffusionModelContractTests : DiffusionUnitTestBase
     [Fact(Timeout = 120000)]
     public async Task DeepFloydIFModel_DefaultConstructor_CreatesValidModel()
     {
-        var model = new DeepFloydIFModel<double>();
+        var model = new DeepFloydIFModel<float>();
 
         Assert.NotNull(model);
         Assert.NotNull(model.NoisePredictor);
@@ -115,7 +115,7 @@ public class DiffusionModelContractTests : DiffusionUnitTestBase
     [Fact(Timeout = 120000)]
     public async Task SDXLModel_DefaultConstructor_CreatesValidModel()
     {
-        var model = new SDXLModel<double>();
+        var model = new SDXLModel<float>();
 
         Assert.NotNull(model);
         Assert.NotNull(model.NoisePredictor);
@@ -125,7 +125,7 @@ public class DiffusionModelContractTests : DiffusionUnitTestBase
     [Fact(Timeout = 120000)]
     public async Task DallE3Model_DefaultConstructor_CreatesValidModel()
     {
-        var model = new DallE3Model<double>();
+        var model = new DallE3Model<float>();
 
         Assert.NotNull(model);
         Assert.NotNull(model.NoisePredictor);
@@ -135,7 +135,7 @@ public class DiffusionModelContractTests : DiffusionUnitTestBase
     [Fact(Timeout = 120000)]
     public async Task DreamFusionModel_DefaultConstructor_CreatesValidModel()
     {
-        var model = new DreamFusionModel<double>();
+        var model = new DreamFusionModel<float>();
 
         Assert.NotNull(model);
         Assert.NotNull(model.NoisePredictor);
@@ -145,7 +145,7 @@ public class DiffusionModelContractTests : DiffusionUnitTestBase
     [Fact(Timeout = 120000)]
     public async Task ControlNetModel_DefaultConstructor_CreatesValidModel()
     {
-        var model = new ControlNetModel<double>();
+        var model = new ControlNetModel<float>();
 
         Assert.NotNull(model);
         Assert.NotNull(model.NoisePredictor);
@@ -160,7 +160,7 @@ public class DiffusionModelContractTests : DiffusionUnitTestBase
     public async Task StableDiffusion15Model_HasLazyParameterContract()
     {
         await Task.Yield();
-        var model = new StableDiffusion15Model<double>();
+        var model = new StableDiffusion15Model<float>();
 
         Assert.True(model.ParameterCount > 0, "Parameters should not be empty");
 
@@ -181,7 +181,7 @@ public class DiffusionModelContractTests : DiffusionUnitTestBase
     public async Task StableDiffusion15Model_ParameterCount_RemainsValidAcrossChunkEnumeration()
     {
         await Task.Yield();
-        var model = new StableDiffusion15Model<double>();
+        var model = new StableDiffusion15Model<float>();
         var before = model.ParameterCount;
 
         int inspectedChunks = 0;
@@ -199,7 +199,7 @@ public class DiffusionModelContractTests : DiffusionUnitTestBase
     public async Task StableDiffusion15Model_Clone_PreservesLazyParameterCount()
     {
         await Task.Yield();
-        var model = new StableDiffusion15Model<double>();
+        var model = new StableDiffusion15Model<float>();
         var clone = model.Clone();
 
         Assert.Equal(model.ParameterCount, clone.ParameterCount);
@@ -242,12 +242,12 @@ public class DiffusionModelContractTests : DiffusionUnitTestBase
             Assert.Equal(parameters[i], cloneParameters[i]);
         }
 
-        var modifiedCloneParameters = new Vector<double>(cloneParameters.Length);
+        var modifiedCloneParameters = new Vector<float>(cloneParameters.Length);
         for (int i = 0; i < cloneParameters.Length; i++)
         {
             modifiedCloneParameters[i] = cloneParameters[i];
         }
-        modifiedCloneParameters[0] += 1.0;
+        modifiedCloneParameters[0] += 1.0f;
 
         clone.SetParameters(modifiedCloneParameters);
 
@@ -259,7 +259,7 @@ public class DiffusionModelContractTests : DiffusionUnitTestBase
     public async Task DiTNoisePredictor_MaterializedSmallModel_ChunksMatchParameterCount()
     {
         await Task.Yield();
-        var predictor = new DiTNoisePredictor<double>(
+        var predictor = new DiTNoisePredictor<float>(
             inputChannels: 4,
             hiddenSize: 16,
             numLayers: 1,
@@ -269,8 +269,8 @@ public class DiffusionModelContractTests : DiffusionUnitTestBase
             mlpRatio: 2.0,
             latentSpatialSize: 4);
 
-        var noisySample = new Tensor<double>([1, 4, 4, 4]);
-        var conditioning = new Tensor<double>([1, 1, 8]);
+        var noisySample = new Tensor<float>([1, 4, 4, 4]);
+        var conditioning = new Tensor<float>([1, 1, 8]);
 
         _ = predictor.PredictNoise(noisySample, timestep: 0, conditioning);
 
@@ -282,9 +282,9 @@ public class DiffusionModelContractTests : DiffusionUnitTestBase
 
     #endregion
 
-    private static StableDiffusion15Model<double> CreateTinyStableDiffusion15Model()
+    private static StableDiffusion15Model<float> CreateTinyStableDiffusion15Model()
     {
-        var unet = new UNetNoisePredictor<double>(
+        var unet = new UNetNoisePredictor<float>(
             inputChannels: 4,
             outputChannels: 4,
             baseChannels: 8,
@@ -295,14 +295,14 @@ public class DiffusionModelContractTests : DiffusionUnitTestBase
             numHeads: 1,
             inputHeight: 8);
 
-        var vae = new StandardVAE<double>(
+        var vae = new StandardVAE<float>(
             inputChannels: 3,
             latentChannels: 4,
             baseChannels: 8,
             channelMultipliers: [1],
             numResBlocksPerLevel: 1);
 
-        return new StableDiffusion15Model<double>(
+        return new StableDiffusion15Model<float>(
             unet: unet,
             vae: vae);
     }
@@ -312,7 +312,7 @@ public class DiffusionModelContractTests : DiffusionUnitTestBase
     [Fact(Timeout = 120000)]
     public async Task StableDiffusion15Model_Clone_CreatesIndependentCopy()
     {
-        var model = new StableDiffusion15Model<double>();
+        var model = new StableDiffusion15Model<float>();
         var clone = model.Clone();
 
         Assert.NotNull(clone);
@@ -323,7 +323,7 @@ public class DiffusionModelContractTests : DiffusionUnitTestBase
     [Fact(Timeout = 120000)]
     public async Task StableDiffusion15Model_GetModelMetadata_ReturnsValidMetadata()
     {
-        var model = new StableDiffusion15Model<double>();
+        var model = new StableDiffusion15Model<float>();
 
         var metadata = model.GetModelMetadata();
 
@@ -338,7 +338,7 @@ public class DiffusionModelContractTests : DiffusionUnitTestBase
     [Fact(Timeout = 120000)]
     public async Task CogVideoModel_DefaultConstructor_CreatesValidModel()
     {
-        var model = new CogVideoModel<double>();
+        var model = new CogVideoModel<float>();
 
         Assert.NotNull(model);
         Assert.NotNull(model.NoisePredictor);
@@ -348,7 +348,7 @@ public class DiffusionModelContractTests : DiffusionUnitTestBase
     [Fact(Timeout = 120000)]
     public async Task Magic3DModel_DefaultConstructor_CreatesValidModel()
     {
-        var model = new Magic3DModel<double>();
+        var model = new Magic3DModel<float>();
 
         Assert.NotNull(model);
         Assert.NotNull(model.NoisePredictor);
@@ -358,7 +358,7 @@ public class DiffusionModelContractTests : DiffusionUnitTestBase
     [Fact(Timeout = 120000)]
     public async Task JEN1Model_DefaultConstructor_CreatesValidModel()
     {
-        var model = new JEN1Model<double>();
+        var model = new JEN1Model<float>();
 
         Assert.NotNull(model);
         Assert.NotNull(model.NoisePredictor);
@@ -368,7 +368,7 @@ public class DiffusionModelContractTests : DiffusionUnitTestBase
     [Fact(Timeout = 120000)]
     public async Task StableCascadeModel_DefaultConstructor_CreatesValidModel()
     {
-        var model = new StableCascadeModel<double>();
+        var model = new StableCascadeModel<float>();
 
         Assert.NotNull(model);
         Assert.NotNull(model.NoisePredictor);
@@ -378,7 +378,7 @@ public class DiffusionModelContractTests : DiffusionUnitTestBase
     [Fact(Timeout = 120000)]
     public async Task T2IAdapterModel_DefaultConstructor_CreatesValidModel()
     {
-        var model = new T2IAdapterModel<double>();
+        var model = new T2IAdapterModel<float>();
 
         Assert.NotNull(model);
         Assert.NotNull(model.NoisePredictor);
@@ -388,7 +388,7 @@ public class DiffusionModelContractTests : DiffusionUnitTestBase
     [Fact(Timeout = 120000)]
     public async Task SDTurboModel_DefaultConstructor_CreatesValidModel()
     {
-        var model = new SDTurboModel<double>();
+        var model = new SDTurboModel<float>();
 
         Assert.NotNull(model);
         Assert.NotNull(model.NoisePredictor);
@@ -398,7 +398,7 @@ public class DiffusionModelContractTests : DiffusionUnitTestBase
     [Fact(Timeout = 120000)]
     public async Task LatentConsistencyModel_DefaultConstructor_CreatesValidModel()
     {
-        var model = new LatentConsistencyModel<double>();
+        var model = new LatentConsistencyModel<float>();
 
         Assert.NotNull(model);
         Assert.NotNull(model.NoisePredictor);
@@ -408,7 +408,7 @@ public class DiffusionModelContractTests : DiffusionUnitTestBase
     [Fact(Timeout = 120000)]
     public async Task PlaygroundV25Model_DefaultConstructor_CreatesValidModel()
     {
-        var model = new PlaygroundV25Model<double>();
+        var model = new PlaygroundV25Model<float>();
 
         Assert.NotNull(model);
         Assert.NotNull(model.NoisePredictor);
@@ -422,7 +422,7 @@ public class DiffusionModelContractTests : DiffusionUnitTestBase
     [Fact(Timeout = 120000)]
     public async Task PixArtSigmaModel_DefaultConstructor_CreatesValidModel()
     {
-        var model = new PixArtSigmaModel<double>();
+        var model = new PixArtSigmaModel<float>();
 
         Assert.NotNull(model);
         Assert.NotNull(model.NoisePredictor);
@@ -433,7 +433,7 @@ public class DiffusionModelContractTests : DiffusionUnitTestBase
     [Fact(Timeout = 120000)]
     public async Task PixArtDeltaModel_DefaultConstructor_CreatesValidModel()
     {
-        var model = new PixArtDeltaModel<double>();
+        var model = new PixArtDeltaModel<float>();
 
         Assert.NotNull(model);
         Assert.NotNull(model.NoisePredictor);
@@ -444,7 +444,7 @@ public class DiffusionModelContractTests : DiffusionUnitTestBase
     [Fact(Timeout = 120000)]
     public async Task Imagen2Model_DefaultConstructor_CreatesValidModel()
     {
-        var model = new Imagen2Model<double>();
+        var model = new Imagen2Model<float>();
 
         Assert.NotNull(model);
         Assert.NotNull(model.NoisePredictor);
@@ -455,7 +455,7 @@ public class DiffusionModelContractTests : DiffusionUnitTestBase
     [Fact(Timeout = 120000)]
     public async Task RAPHAELModel_DefaultConstructor_CreatesValidModel()
     {
-        var model = new RAPHAELModel<double>();
+        var model = new RAPHAELModel<float>();
 
         Assert.NotNull(model);
         Assert.NotNull(model.NoisePredictor);
@@ -466,7 +466,7 @@ public class DiffusionModelContractTests : DiffusionUnitTestBase
     [Fact(Timeout = 120000)]
     public async Task EDiffIModel_DefaultConstructor_CreatesValidModel()
     {
-        var model = new EDiffIModel<double>();
+        var model = new EDiffIModel<float>();
 
         Assert.NotNull(model);
         Assert.NotNull(model.NoisePredictor);
@@ -477,7 +477,7 @@ public class DiffusionModelContractTests : DiffusionUnitTestBase
     [Fact(Timeout = 120000)]
     public async Task HunyuanDiTModel_DefaultConstructor_CreatesValidModel()
     {
-        var model = new HunyuanDiTModel<double>();
+        var model = new HunyuanDiTModel<float>();
 
         Assert.NotNull(model);
         Assert.NotNull(model.NoisePredictor);
@@ -488,7 +488,7 @@ public class DiffusionModelContractTests : DiffusionUnitTestBase
     [Fact(Timeout = 120000)]
     public async Task KolorsModel_DefaultConstructor_CreatesValidModel()
     {
-        var model = new KolorsModel<double>();
+        var model = new KolorsModel<float>();
 
         Assert.NotNull(model);
         Assert.NotNull(model.NoisePredictor);
@@ -499,7 +499,7 @@ public class DiffusionModelContractTests : DiffusionUnitTestBase
     [Fact(Timeout = 120000)]
     public async Task AuraFlowModel_DefaultConstructor_CreatesValidModel()
     {
-        var model = new AuraFlowModel<double>();
+        var model = new AuraFlowModel<float>();
 
         Assert.NotNull(model);
         Assert.NotNull(model.NoisePredictor);
@@ -510,7 +510,7 @@ public class DiffusionModelContractTests : DiffusionUnitTestBase
     [Fact(Timeout = 120000)]
     public async Task LuminaT2XModel_DefaultConstructor_CreatesValidModel()
     {
-        var model = new AiDotNet.Diffusion.TextToImage.LuminaT2XModel<double>();
+        var model = new AiDotNet.Diffusion.TextToImage.LuminaT2XModel<float>();
 
         Assert.NotNull(model);
         Assert.NotNull(model.NoisePredictor);
@@ -521,7 +521,7 @@ public class DiffusionModelContractTests : DiffusionUnitTestBase
     [Fact(Timeout = 120000)]
     public async Task OmniGenModel_DefaultConstructor_CreatesValidModel()
     {
-        var model = new OmniGenModel<double>();
+        var model = new OmniGenModel<float>();
 
         Assert.NotNull(model);
         Assert.NotNull(model.NoisePredictor);
@@ -536,7 +536,7 @@ public class DiffusionModelContractTests : DiffusionUnitTestBase
     [Fact(Timeout = 120000)]
     public async Task ControlNetXSModel_DefaultConstructor_CreatesValidModel()
     {
-        var model = new ControlNetXSModel<double>();
+        var model = new ControlNetXSModel<float>();
 
         Assert.NotNull(model);
         Assert.NotNull(model.NoisePredictor);
@@ -547,7 +547,7 @@ public class DiffusionModelContractTests : DiffusionUnitTestBase
     [Fact(Timeout = 120000)]
     public async Task InstantIDModel_DefaultConstructor_CreatesValidModel()
     {
-        var model = new InstantIDModel<double>();
+        var model = new InstantIDModel<float>();
 
         Assert.NotNull(model);
         Assert.NotNull(model.NoisePredictor);
@@ -558,7 +558,7 @@ public class DiffusionModelContractTests : DiffusionUnitTestBase
     [Fact(Timeout = 120000)]
     public async Task PhotoMakerModel_DefaultConstructor_CreatesValidModel()
     {
-        var model = new PhotoMakerModel<double>();
+        var model = new PhotoMakerModel<float>();
 
         Assert.NotNull(model);
         Assert.NotNull(model.NoisePredictor);
@@ -569,7 +569,7 @@ public class DiffusionModelContractTests : DiffusionUnitTestBase
     [Fact(Timeout = 120000)]
     public async Task IPAdapterFaceIDModel_DefaultConstructor_CreatesValidModel()
     {
-        var model = new IPAdapterFaceIDModel<double>();
+        var model = new IPAdapterFaceIDModel<float>();
 
         Assert.NotNull(model);
         Assert.NotNull(model.NoisePredictor);
@@ -580,7 +580,7 @@ public class DiffusionModelContractTests : DiffusionUnitTestBase
     [Fact(Timeout = 120000)]
     public async Task ControlNetUnionModel_DefaultConstructor_CreatesValidModel()
     {
-        var model = new ControlNetUnionModel<double>();
+        var model = new ControlNetUnionModel<float>();
 
         Assert.NotNull(model);
         Assert.NotNull(model.NoisePredictor);
@@ -591,7 +591,7 @@ public class DiffusionModelContractTests : DiffusionUnitTestBase
     [Fact(Timeout = 120000)]
     public async Task UniControlNetModel_DefaultConstructor_CreatesValidModel()
     {
-        var model = new UniControlNetModel<double>();
+        var model = new UniControlNetModel<float>();
 
         Assert.NotNull(model);
         Assert.NotNull(model.NoisePredictor);
@@ -606,7 +606,7 @@ public class DiffusionModelContractTests : DiffusionUnitTestBase
     [Fact(Timeout = 120000)]
     public async Task InstructPix2PixModel_DefaultConstructor_CreatesValidModel()
     {
-        var model = new InstructPix2PixModel<double>();
+        var model = new InstructPix2PixModel<float>();
 
         Assert.NotNull(model);
         Assert.NotNull(model.NoisePredictor);
@@ -617,7 +617,7 @@ public class DiffusionModelContractTests : DiffusionUnitTestBase
     [Fact(Timeout = 120000)]
     public async Task PromptToPromptModel_DefaultConstructor_CreatesValidModel()
     {
-        var model = new PromptToPromptModel<double>();
+        var model = new PromptToPromptModel<float>();
 
         Assert.NotNull(model);
         Assert.NotNull(model.NoisePredictor);
@@ -628,7 +628,7 @@ public class DiffusionModelContractTests : DiffusionUnitTestBase
     [Fact(Timeout = 120000)]
     public async Task NullTextInversionModel_DefaultConstructor_CreatesValidModel()
     {
-        var model = new NullTextInversionModel<double>();
+        var model = new NullTextInversionModel<float>();
 
         Assert.NotNull(model);
         Assert.NotNull(model.NoisePredictor);
@@ -639,7 +639,7 @@ public class DiffusionModelContractTests : DiffusionUnitTestBase
     [Fact(Timeout = 120000)]
     public async Task DiffEditModel_DefaultConstructor_CreatesValidModel()
     {
-        var model = new DiffEditModel<double>();
+        var model = new DiffEditModel<float>();
 
         Assert.NotNull(model);
         Assert.NotNull(model.NoisePredictor);
@@ -650,7 +650,7 @@ public class DiffusionModelContractTests : DiffusionUnitTestBase
     [Fact(Timeout = 120000)]
     public async Task LEDITSPPModel_DefaultConstructor_CreatesValidModel()
     {
-        var model = new LEDITSPPModel<double>();
+        var model = new LEDITSPPModel<float>();
 
         Assert.NotNull(model);
         Assert.NotNull(model.NoisePredictor);
@@ -661,7 +661,7 @@ public class DiffusionModelContractTests : DiffusionUnitTestBase
     [Fact(Timeout = 120000)]
     public async Task MagicBrushModel_DefaultConstructor_CreatesValidModel()
     {
-        var model = new MagicBrushModel<double>();
+        var model = new MagicBrushModel<float>();
 
         Assert.NotNull(model);
         Assert.NotNull(model.NoisePredictor);
@@ -672,7 +672,7 @@ public class DiffusionModelContractTests : DiffusionUnitTestBase
     [Fact(Timeout = 120000)]
     public async Task ImagicModel_DefaultConstructor_CreatesValidModel()
     {
-        var model = new ImagicModel<double>();
+        var model = new ImagicModel<float>();
 
         Assert.NotNull(model);
         Assert.NotNull(model.NoisePredictor);
@@ -683,7 +683,7 @@ public class DiffusionModelContractTests : DiffusionUnitTestBase
     [Fact(Timeout = 120000)]
     public async Task SDEditModel_DefaultConstructor_CreatesValidModel()
     {
-        var model = new SDEditModel<double>();
+        var model = new SDEditModel<float>();
 
         Assert.NotNull(model);
         Assert.NotNull(model.NoisePredictor);
@@ -694,7 +694,7 @@ public class DiffusionModelContractTests : DiffusionUnitTestBase
     [Fact(Timeout = 120000)]
     public async Task PaintByExampleModel_DefaultConstructor_CreatesValidModel()
     {
-        var model = new PaintByExampleModel<double>();
+        var model = new PaintByExampleModel<float>();
 
         Assert.NotNull(model);
         Assert.NotNull(model.NoisePredictor);
@@ -705,7 +705,7 @@ public class DiffusionModelContractTests : DiffusionUnitTestBase
     [Fact(Timeout = 120000)]
     public async Task BlendedDiffusionModel_DefaultConstructor_CreatesValidModel()
     {
-        var model = new BlendedDiffusionModel<double>();
+        var model = new BlendedDiffusionModel<float>();
 
         Assert.NotNull(model);
         Assert.NotNull(model.NoisePredictor);
@@ -720,7 +720,7 @@ public class DiffusionModelContractTests : DiffusionUnitTestBase
     [Fact(Timeout = 120000)]
     public async Task SDUpscalerModel_DefaultConstructor_CreatesValidModel()
     {
-        var model = new SDUpscalerModel<double>();
+        var model = new SDUpscalerModel<float>();
 
         Assert.NotNull(model);
         Assert.NotNull(model.NoisePredictor);
@@ -731,7 +731,7 @@ public class DiffusionModelContractTests : DiffusionUnitTestBase
     [Fact(Timeout = 120000)]
     public async Task RealESRGANModel_DefaultConstructor_CreatesValidModel()
     {
-        var model = new RealESRGANModel<double>();
+        var model = new RealESRGANModel<float>();
 
         Assert.NotNull(model);
         Assert.NotNull(model.NoisePredictor);
@@ -742,7 +742,7 @@ public class DiffusionModelContractTests : DiffusionUnitTestBase
     [Fact(Timeout = 120000)]
     public async Task StableSRModel_DefaultConstructor_CreatesValidModel()
     {
-        var model = new StableSRModel<double>();
+        var model = new StableSRModel<float>();
 
         Assert.NotNull(model);
         Assert.NotNull(model.NoisePredictor);
@@ -753,7 +753,7 @@ public class DiffusionModelContractTests : DiffusionUnitTestBase
     [Fact(Timeout = 120000)]
     public async Task DiffBIRModel_DefaultConstructor_CreatesValidModel()
     {
-        var model = new DiffBIRModel<double>();
+        var model = new DiffBIRModel<float>();
 
         Assert.NotNull(model);
         Assert.NotNull(model.NoisePredictor);
@@ -764,7 +764,7 @@ public class DiffusionModelContractTests : DiffusionUnitTestBase
     [Fact(Timeout = 120000)]
     public async Task SUPIRModel_DefaultConstructor_CreatesValidModel()
     {
-        var model = new SUPIRModel<double>();
+        var model = new SUPIRModel<float>();
 
         Assert.NotNull(model);
         Assert.NotNull(model.NoisePredictor);
@@ -775,7 +775,7 @@ public class DiffusionModelContractTests : DiffusionUnitTestBase
     [Fact(Timeout = 120000)]
     public async Task UpscaleAVideoModel_DefaultConstructor_CreatesValidModel()
     {
-        var model = new UpscaleAVideoModel<double>();
+        var model = new UpscaleAVideoModel<float>();
 
         Assert.NotNull(model);
         Assert.NotNull(model.NoisePredictor);
@@ -790,7 +790,7 @@ public class DiffusionModelContractTests : DiffusionUnitTestBase
     [Fact(Timeout = 120000)]
     public async Task SoraModel_DefaultConstructor_CreatesValidModel()
     {
-        var model = new SoraModel<double>();
+        var model = new SoraModel<float>();
 
         Assert.NotNull(model);
         Assert.NotNull(model.NoisePredictor);
@@ -802,7 +802,7 @@ public class DiffusionModelContractTests : DiffusionUnitTestBase
     [Fact(Timeout = 120000)]
     public async Task ModelScopeT2VModel_DefaultConstructor_CreatesValidModel()
     {
-        var model = new ModelScopeT2VModel<double>();
+        var model = new ModelScopeT2VModel<float>();
 
         Assert.NotNull(model);
         Assert.NotNull(model.NoisePredictor);
@@ -813,7 +813,7 @@ public class DiffusionModelContractTests : DiffusionUnitTestBase
     [Fact(Timeout = 120000)]
     public async Task LatteModel_DefaultConstructor_CreatesValidModel()
     {
-        var model = new LatteModel<double>();
+        var model = new LatteModel<float>();
 
         Assert.NotNull(model);
         Assert.NotNull(model.NoisePredictor);
@@ -824,7 +824,7 @@ public class DiffusionModelContractTests : DiffusionUnitTestBase
     [Fact(Timeout = 120000)]
     public async Task OpenSoraModel_DefaultConstructor_CreatesValidModel()
     {
-        var model = new OpenSoraModel<double>();
+        var model = new OpenSoraModel<float>();
 
         Assert.NotNull(model);
         Assert.NotNull(model.NoisePredictor);
@@ -835,7 +835,7 @@ public class DiffusionModelContractTests : DiffusionUnitTestBase
     [Fact(Timeout = 120000)]
     public async Task RunwayGenModel_DefaultConstructor_CreatesValidModel()
     {
-        var model = new RunwayGenModel<double>();
+        var model = new RunwayGenModel<float>();
 
         Assert.NotNull(model);
         Assert.NotNull(model.NoisePredictor);
@@ -847,7 +847,7 @@ public class DiffusionModelContractTests : DiffusionUnitTestBase
     [Fact(Timeout = 120000)]
     public async Task MakeAVideoModel_DefaultConstructor_CreatesValidModel()
     {
-        var model = new MakeAVideoModel<double>();
+        var model = new MakeAVideoModel<float>();
 
         Assert.NotNull(model);
         Assert.NotNull(model.NoisePredictor);
@@ -858,7 +858,7 @@ public class DiffusionModelContractTests : DiffusionUnitTestBase
     [Fact(Timeout = 120000)]
     public async Task KlingModel_DefaultConstructor_CreatesValidModel()
     {
-        var model = new KlingModel<double>();
+        var model = new KlingModel<float>();
 
         Assert.NotNull(model);
         Assert.NotNull(model.NoisePredictor);
@@ -870,7 +870,7 @@ public class DiffusionModelContractTests : DiffusionUnitTestBase
     [Fact(Timeout = 120000)]
     public async Task VeoModel_DefaultConstructor_CreatesValidModel()
     {
-        var model = new VeoModel<double>();
+        var model = new VeoModel<float>();
 
         Assert.NotNull(model);
         Assert.NotNull(model.NoisePredictor);
@@ -882,7 +882,7 @@ public class DiffusionModelContractTests : DiffusionUnitTestBase
     [Fact(Timeout = 120000)]
     public async Task Mochi1Model_DefaultConstructor_CreatesValidModel()
     {
-        var model = new Mochi1Model<double>();
+        var model = new Mochi1Model<float>();
 
         Assert.NotNull(model);
         Assert.NotNull(model.NoisePredictor);
@@ -894,7 +894,7 @@ public class DiffusionModelContractTests : DiffusionUnitTestBase
     [Fact(Timeout = 120000)]
     public async Task HunyuanVideoModel_DefaultConstructor_CreatesValidModel()
     {
-        var model = new HunyuanVideoModel<double>();
+        var model = new HunyuanVideoModel<float>();
 
         Assert.NotNull(model);
         Assert.NotNull(model.NoisePredictor);
@@ -906,7 +906,7 @@ public class DiffusionModelContractTests : DiffusionUnitTestBase
     [Fact(Timeout = 120000)]
     public async Task LTXVideoModel_DefaultConstructor_CreatesValidModel()
     {
-        var model = new LTXVideoModel<double>();
+        var model = new LTXVideoModel<float>();
 
         Assert.NotNull(model);
         Assert.NotNull(model.NoisePredictor);
@@ -918,7 +918,7 @@ public class DiffusionModelContractTests : DiffusionUnitTestBase
     [Fact(Timeout = 120000)]
     public async Task WanVideoModel_DefaultConstructor_CreatesValidModel()
     {
-        var model = new WanVideoModel<double>();
+        var model = new WanVideoModel<float>();
 
         Assert.NotNull(model);
         Assert.NotNull(model.NoisePredictor);
@@ -932,7 +932,7 @@ public class DiffusionModelContractTests : DiffusionUnitTestBase
     [Fact(Timeout = 120000)]
     public async Task WanVideoModel_Create1_3B_CreatesLightweightVariant()
     {
-        var model = WanVideoModel<double>.Create1_3B();
+        var model = WanVideoModel<float>.Create1_3B();
 
         Assert.NotNull(model);
         Assert.Equal("1.3B", model.Variant);
@@ -941,7 +941,7 @@ public class DiffusionModelContractTests : DiffusionUnitTestBase
     [Fact(Timeout = 120000)]
     public async Task WanVideoModel_Create5B_CreatesMediumVariant()
     {
-        var model = WanVideoModel<double>.Create5B();
+        var model = WanVideoModel<float>.Create5B();
 
         Assert.NotNull(model);
         Assert.Equal("5B", model.Variant);
@@ -954,7 +954,7 @@ public class DiffusionModelContractTests : DiffusionUnitTestBase
     [Fact(Timeout = 120000)]
     public async Task SyncDreamerModel_DefaultConstructor_CreatesValidModel()
     {
-        var model = new SyncDreamerModel<double>();
+        var model = new SyncDreamerModel<float>();
 
         Assert.NotNull(model);
         Assert.NotNull(model.NoisePredictor);
@@ -965,7 +965,7 @@ public class DiffusionModelContractTests : DiffusionUnitTestBase
     [Fact(Timeout = 120000)]
     public async Task Wonder3DModel_DefaultConstructor_CreatesValidModel()
     {
-        var model = new Wonder3DModel<double>();
+        var model = new Wonder3DModel<float>();
 
         Assert.NotNull(model);
         Assert.NotNull(model.NoisePredictor);
@@ -976,7 +976,7 @@ public class DiffusionModelContractTests : DiffusionUnitTestBase
     [Fact(Timeout = 120000)]
     public async Task One2345Model_DefaultConstructor_CreatesValidModel()
     {
-        var model = new One2345Model<double>();
+        var model = new One2345Model<float>();
 
         Assert.NotNull(model);
         Assert.NotNull(model.NoisePredictor);
@@ -987,7 +987,7 @@ public class DiffusionModelContractTests : DiffusionUnitTestBase
     [Fact(Timeout = 120000)]
     public async Task Instant3DModel_DefaultConstructor_CreatesValidModel()
     {
-        var model = new Instant3DModel<double>();
+        var model = new Instant3DModel<float>();
 
         Assert.NotNull(model);
         Assert.NotNull(model.NoisePredictor);
@@ -998,7 +998,7 @@ public class DiffusionModelContractTests : DiffusionUnitTestBase
     [Fact(Timeout = 120000)]
     public async Task DreamGaussianModel_DefaultConstructor_CreatesValidModel()
     {
-        var model = new DreamGaussianModel<double>();
+        var model = new DreamGaussianModel<float>();
 
         Assert.NotNull(model);
         Assert.NotNull(model.NoisePredictor);
@@ -1009,7 +1009,7 @@ public class DiffusionModelContractTests : DiffusionUnitTestBase
     [Fact(Timeout = 120000)]
     public async Task LGMModel_DefaultConstructor_CreatesValidModel()
     {
-        var model = new LGMModel<double>();
+        var model = new LGMModel<float>();
 
         Assert.NotNull(model);
         Assert.NotNull(model.NoisePredictor);
@@ -1020,7 +1020,7 @@ public class DiffusionModelContractTests : DiffusionUnitTestBase
     [Fact(Timeout = 120000)]
     public async Task TripoSRModel_DefaultConstructor_CreatesValidModel()
     {
-        var model = new TripoSRModel<double>();
+        var model = new TripoSRModel<float>();
 
         Assert.NotNull(model);
         Assert.NotNull(model.NoisePredictor);
@@ -1031,7 +1031,7 @@ public class DiffusionModelContractTests : DiffusionUnitTestBase
     [Fact(Timeout = 120000)]
     public async Task MeshyModel_DefaultConstructor_CreatesValidModel()
     {
-        var model = new MeshyModel<double>();
+        var model = new MeshyModel<float>();
 
         Assert.NotNull(model);
         Assert.NotNull(model.NoisePredictor);
@@ -1046,7 +1046,7 @@ public class DiffusionModelContractTests : DiffusionUnitTestBase
     [Fact(Timeout = 120000)]
     public async Task StableAudioModel_DefaultConstructor_CreatesValidModel()
     {
-        var model = new StableAudioModel<double>();
+        var model = new StableAudioModel<float>();
 
         Assert.NotNull(model);
         Assert.NotNull(model.NoisePredictor);
@@ -1059,7 +1059,7 @@ public class DiffusionModelContractTests : DiffusionUnitTestBase
     [Fact(Timeout = 120000)]
     public async Task BarkModel_DefaultConstructor_CreatesValidModel()
     {
-        var model = new BarkModel<double>();
+        var model = new BarkModel<float>();
 
         Assert.NotNull(model);
         Assert.NotNull(model.NoisePredictor);
@@ -1072,7 +1072,7 @@ public class DiffusionModelContractTests : DiffusionUnitTestBase
     [Fact(Timeout = 120000)]
     public async Task VoiceCraftModel_DefaultConstructor_CreatesValidModel()
     {
-        var model = new VoiceCraftModel<double>();
+        var model = new VoiceCraftModel<float>();
 
         Assert.NotNull(model);
         Assert.NotNull(model.NoisePredictor);
@@ -1085,7 +1085,7 @@ public class DiffusionModelContractTests : DiffusionUnitTestBase
     [Fact(Timeout = 120000)]
     public async Task SoundStormModel_DefaultConstructor_CreatesValidModel()
     {
-        var model = new SoundStormModel<double>();
+        var model = new SoundStormModel<float>();
 
         Assert.NotNull(model);
         Assert.NotNull(model.NoisePredictor);
@@ -1097,7 +1097,7 @@ public class DiffusionModelContractTests : DiffusionUnitTestBase
     [Fact(Timeout = 120000)]
     public async Task UdioModel_DefaultConstructor_CreatesValidModel()
     {
-        var model = new UdioModel<double>();
+        var model = new UdioModel<float>();
 
         Assert.NotNull(model);
         Assert.NotNull(model.NoisePredictor);
@@ -1114,18 +1114,21 @@ public class DiffusionModelContractTests : DiffusionUnitTestBase
     [Fact(Timeout = 120000)]
     public async Task WanVideoModel_Clone_CreatesIndependentCopy()
     {
-        var model = new WanVideoModel<double>();
+        var model = new WanVideoModel<float>();
         var clone = model.Clone();
 
         Assert.NotNull(clone);
         Assert.NotSame(model, clone);
+        // ParameterCount is long: WanVideo-14B reports ~15.2 B params, far past
+        // int.MaxValue, so the comparison must stay in long arithmetic (a prior
+        // (int) cast overflowed and made the assertion meaningless at this scale).
         Assert.Equal(model.ParameterCount, clone.ParameterCount);
     }
 
     [Fact(Timeout = 120000)]
     public async Task BarkModel_Clone_CreatesIndependentCopy()
     {
-        var model = new BarkModel<double>();
+        var model = new BarkModel<float>();
         var clone = model.Clone();
 
         Assert.NotNull(clone);
@@ -1136,7 +1139,7 @@ public class DiffusionModelContractTests : DiffusionUnitTestBase
     [Fact(Timeout = 120000)]
     public async Task SDUpscalerModel_Clone_CreatesIndependentCopy()
     {
-        var model = new SDUpscalerModel<double>();
+        var model = new SDUpscalerModel<float>();
         var clone = model.Clone();
 
         Assert.NotNull(clone);
@@ -1147,7 +1150,7 @@ public class DiffusionModelContractTests : DiffusionUnitTestBase
     [Fact(Timeout = 120000)]
     public async Task PixArtSigmaModel_Clone_CreatesIndependentCopy()
     {
-        var model = new PixArtSigmaModel<double>();
+        var model = new PixArtSigmaModel<float>();
         var clone = model.Clone();
 
         Assert.NotNull(clone);
@@ -1162,7 +1165,7 @@ public class DiffusionModelContractTests : DiffusionUnitTestBase
     [Fact(Timeout = 120000)]
     public async Task WanVideoModel_GetModelMetadata_ReturnsValidMetadata()
     {
-        var model = new WanVideoModel<double>();
+        var model = new WanVideoModel<float>();
 
         var metadata = model.GetModelMetadata();
 
@@ -1173,7 +1176,7 @@ public class DiffusionModelContractTests : DiffusionUnitTestBase
     [Fact(Timeout = 120000)]
     public async Task BarkModel_GetModelMetadata_ReturnsValidMetadata()
     {
-        var model = new BarkModel<double>();
+        var model = new BarkModel<float>();
 
         var metadata = model.GetModelMetadata();
 
@@ -1184,7 +1187,7 @@ public class DiffusionModelContractTests : DiffusionUnitTestBase
     [Fact(Timeout = 120000)]
     public async Task SoraModel_GetModelMetadata_ReturnsValidMetadata()
     {
-        var model = new SoraModel<double>();
+        var model = new SoraModel<float>();
 
         var metadata = model.GetModelMetadata();
 
@@ -1195,7 +1198,7 @@ public class DiffusionModelContractTests : DiffusionUnitTestBase
     [Fact(Timeout = 120000)]
     public async Task StableAudioModel_GetModelMetadata_ReturnsValidMetadata()
     {
-        var model = new StableAudioModel<double>();
+        var model = new StableAudioModel<float>();
 
         var metadata = model.GetModelMetadata();
 
@@ -1210,7 +1213,7 @@ public class DiffusionModelContractTests : DiffusionUnitTestBase
     [Fact(Timeout = 120000)]
     public async Task InstructPix2PixModel_GetParameters_ReturnsNonEmptyVector()
     {
-        var model = new InstructPix2PixModel<double>();
+        var model = new InstructPix2PixModel<float>();
 
         var parameters = model.GetParameters();
 
@@ -1237,16 +1240,16 @@ public class DiffusionModelContractTests : DiffusionUnitTestBase
     public async Task SoraModel_HasPaperFaithfulComponents()
     {
         await Task.Yield();
-        var model = new SoraModel<double>();
+        var model = new SoraModel<float>();
 
         // Sora's noise predictor is a DiT (Diffusion Transformer); the VAE
         // is the 3D-causal TemporalVAE for spatiotemporal video compression.
         // Both are required to produce the paper's quality / latent layout.
         Assert.NotNull(model.NoisePredictor);
-        Assert.IsType<AiDotNet.Diffusion.NoisePredictors.DiTNoisePredictor<double>>(model.NoisePredictor);
+        Assert.IsType<AiDotNet.Diffusion.NoisePredictors.DiTNoisePredictor<float>>(model.NoisePredictor);
 
         Assert.NotNull(model.VAE);
-        Assert.IsType<AiDotNet.Diffusion.VAE.TemporalVAE<double>>(model.VAE);
+        Assert.IsType<AiDotNet.Diffusion.VAE.TemporalVAE<float>>(model.VAE);
 
         // #1237: ParameterCount is now long. Sora's paper config (DiT-XL/2
         // with HiddenDim 3072 x 48 layers) reports ~5.4 B parameters in the
@@ -1275,7 +1278,7 @@ public class DiffusionModelContractTests : DiffusionUnitTestBase
     public async Task UdioModel_HasPaperScaleLazyParameterContract()
     {
         await Task.Yield();
-        var model = new UdioModel<double>();
+        var model = new UdioModel<float>();
 
         Assert.True(model.ParameterCount > int.MaxValue,
             "Udio's paper-scale DiT backbone should report a foundation-scale parameter count.");
@@ -1298,7 +1301,7 @@ public class DiffusionModelContractTests : DiffusionUnitTestBase
     [Fact(Timeout = 120000)]
     public async Task TripoSRModel_ParameterCount_MatchesGetParametersLength()
     {
-        var model = new TripoSRModel<double>();
+        var model = new TripoSRModel<float>();
 
         var parameters = model.GetParameters();
 
@@ -1312,7 +1315,7 @@ public class DiffusionModelContractTests : DiffusionUnitTestBase
     [Fact(Timeout = 120000)]
     public async Task PixArtModel_DefaultConstructor_CreatesValidModel()
     {
-        var model = new PixArtModel<double>();
+        var model = new PixArtModel<float>();
 
         Assert.NotNull(model);
         Assert.NotNull(model.NoisePredictor);
@@ -1324,7 +1327,7 @@ public class DiffusionModelContractTests : DiffusionUnitTestBase
     [Fact(Timeout = 120000)]
     public async Task DiffWaveModel_DefaultConstructor_CreatesValidModel()
     {
-        var model = new DiffWaveModel<double>();
+        var model = new DiffWaveModel<float>();
 
         Assert.NotNull(model);
         Assert.True(model.ParameterCount > 0);
@@ -1333,7 +1336,7 @@ public class DiffusionModelContractTests : DiffusionUnitTestBase
     [Fact(Timeout = 120000)]
     public async Task RiffusionModel_DefaultConstructor_CreatesValidModel()
     {
-        var model = new RiffusionModel<double>();
+        var model = new RiffusionModel<float>();
 
         Assert.NotNull(model);
         Assert.NotNull(model.NoisePredictor);
@@ -1344,7 +1347,7 @@ public class DiffusionModelContractTests : DiffusionUnitTestBase
     [Fact(Timeout = 120000)]
     public async Task Zero123Model_DefaultConstructor_CreatesValidModel()
     {
-        var model = new Zero123Model<double>();
+        var model = new Zero123Model<float>();
 
         Assert.NotNull(model);
         Assert.NotNull(model.NoisePredictor);

--- a/tests/AiDotNet.Tests/UnitTests/NeuralNetworks/FTTransformerClassifierTests.cs
+++ b/tests/AiDotNet.Tests/UnitTests/NeuralNetworks/FTTransformerClassifierTests.cs
@@ -1,0 +1,129 @@
+using System;
+using AiDotNet.Models.Options;
+using AiDotNet.NeuralNetworks.Tabular;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tests.UnitTests.NeuralNetworks;
+
+/// <summary>
+/// Paper-fidelity invariant for FT-Transformer (Gorishniy et al. 2021,
+/// "Revisiting Deep Learning Models for Tabular Data"). Pins the POC-reported
+/// save/load (GetParameters/SetParameters) round-trip defect.
+/// </summary>
+/// <remarks>
+/// The round-trip is exercised via a forward pass (to resolve the lazy layer
+/// shapes) rather than training — the classifier's backward/train path is a
+/// separate, still-open item, so coupling this invariant to it would mask the
+/// serialization fix this test targets.
+/// </remarks>
+public class FTTransformerClassifierTests
+{
+    private const int NumNumerical = 4;
+    private const int NumClasses = 3;
+
+    // Small, dropout-free config so the forward is deterministic (round-trip
+    // prediction-equality is only meaningful when the forward is reproducible).
+    private static FTTransformerOptions<double> Opts() => new()
+    {
+        EmbeddingDimension = 16,
+        NumHeads = 2,
+        NumLayers = 1,
+        FeedForwardMultiplier = 2,
+        DropoutRate = 0.0,
+        AttentionDropoutRate = 0.0,
+        ResidualDropoutRate = 0.0,
+    };
+
+    private static FTTransformerClassifier<double> NewModel() =>
+        new(NumNumerical, NumClasses, Opts());
+
+    private static Tensor<double> MakeInput(int n, int seed)
+    {
+        var rng = new Random(seed);
+        var x = new Tensor<double>([n, NumNumerical]);
+        for (int i = 0; i < n; i++)
+            for (int f = 0; f < NumNumerical; f++)
+                x[i, f] = rng.NextDouble();
+        return x;
+    }
+
+    // Linearly-separable dataset: class = i % NumClasses, with the class encoded in
+    // the features (feature[cls] = 1, others 0) + tiny deterministic jitter.
+    private static (Tensor<double> x, int[] y) MakeSeparable(int n, int seed)
+    {
+        var rng = new Random(seed);
+        var x = new Tensor<double>([n, NumNumerical]);
+        var y = new int[n];
+        for (int i = 0; i < n; i++)
+        {
+            int cls = i % NumClasses;
+            y[i] = cls;
+            for (int f = 0; f < NumNumerical; f++)
+                x[i, f] = (f == cls ? 1.0 : 0.0) + 0.01 * (rng.NextDouble() - 0.5);
+        }
+        return (x, y);
+    }
+
+    [Fact]
+    public void SaveLoad_RoundTrip_PreservesParametersAndPredictions()
+    {
+        var original = NewModel();
+        var x = MakeInput(6, seed: 1);
+
+        // Forward once to resolve lazy layer shapes, then snapshot the params.
+        var pOrig = original.PredictProbabilities(x).ToArray();
+        var saved = original.GetParameters();
+        Assert.True(saved.Length > 0);
+        Assert.Equal(original.ParameterCount, saved.Length);
+
+        // "Load" into a fresh model: resolve its shapes (forward), then set the
+        // saved params. A mis-sliced SetParameters (base/head boundary off by the
+        // head size) corrupts both halves and the round-trip below diverges.
+        var loaded = NewModel();
+        _ = loaded.PredictProbabilities(x);
+        loaded.SetParameters(saved);
+
+        var reread = loaded.GetParameters();
+        Assert.Equal(saved.Length, reread.Length);
+        for (int i = 0; i < saved.Length; i++)
+            Assert.True(Math.Abs(saved[i] - reread[i]) < 1e-12,
+                $"Round-trip parameter[{i}]={reread[i]} != saved {saved[i]} — SetParameters mis-sliced.");
+
+        // The loaded model must now predict identically to the original — the
+        // whole point of save/load.
+        var pLoaded = loaded.PredictProbabilities(x).ToArray();
+        Assert.Equal(pOrig.Length, pLoaded.Length);
+        for (int i = 0; i < pOrig.Length; i++)
+            Assert.True(Math.Abs(pOrig[i] - pLoaded[i]) < 1e-9,
+                $"Loaded model probability[{i}]={pLoaded[i]} != original {pOrig[i]} — save/load not faithful.");
+    }
+
+    [Fact]
+    public void Train_ReducesCrossEntropy_OnSeparableData_AndStaysFinite()
+    {
+        // The classifier train path: TrainStep runs a tape-tracked forward +
+        // softmax cross-entropy, backprops to every weight (tokenizer + transformer
+        // + head), and applies SGD. On a separable task the loss must drop and stay
+        // finite. (Previously TrainStep had no backward and threw on UpdateParameters.)
+        var model = NewModel();
+        var (x, y) = MakeSeparable(9, seed: 2);
+
+        double firstLoss = Convert.ToDouble(model.TrainStep(x, y, learningRate: 0.05));
+        double lastLoss = firstLoss;
+        for (int step = 0; step < 60; step++)
+        {
+            lastLoss = Convert.ToDouble(model.TrainStep(x, y, learningRate: 0.05));
+            Assert.False(double.IsNaN(lastLoss), $"Loss NaN at step {step} — training diverged.");
+            Assert.False(double.IsInfinity(lastLoss), $"Loss Inf at step {step} — training diverged.");
+        }
+
+        Assert.True(lastLoss < firstLoss,
+            $"Cross-entropy did not decrease (first={firstLoss:F4}, last={lastLoss:F4}) — classifier train path broken.");
+
+        var p = model.GetParameters();
+        for (int i = 0; i < p.Length; i++)
+            Assert.False(double.IsNaN(p[i]) || double.IsInfinity(p[i]),
+                $"Parameter[{i}] non-finite after training.");
+    }
+}

--- a/tests/AiDotNet.Tests/UnitTests/Preprocessing/DataSplitterTinyDatasetTests.cs
+++ b/tests/AiDotNet.Tests/UnitTests/Preprocessing/DataSplitterTinyDatasetTests.cs
@@ -1,0 +1,111 @@
+using AiDotNet.Preprocessing.DataPreparation;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tests.UnitTests.Preprocessing;
+
+/// <summary>
+/// Pins the tiny-dataset breakage in <see cref="DataSplitter"/> that surfaced
+/// through <c>AiModelBuilder.BuildAsync</c>: integer <c>floor()</c> of the 0.7 /
+/// 0.15 ratios starves a partition to zero rows on small inputs. For n=1 the
+/// TRAINING set comes out empty (model never trains, lazy layers stay unseeded);
+/// for any n &lt; 7 the validation set is empty. The split must always produce a
+/// usable training set, a partition total that sums back to n, and must never
+/// throw — regardless of how few rows the caller supplies.
+/// </summary>
+public class DataSplitterTinyDatasetTests
+{
+    private const int NumFeatures = 3;
+
+    private static (Matrix<double> x, Vector<double> y) MakeMatrix(int n)
+    {
+        var x = new Matrix<double>(n, NumFeatures);
+        var y = new Vector<double>(n);
+        for (int i = 0; i < n; i++)
+        {
+            for (int f = 0; f < NumFeatures; f++)
+                x[i, f] = i * NumFeatures + f;
+            y[i] = i;
+        }
+        return (x, y);
+    }
+
+    private static (Tensor<double> x, Tensor<double> y) MakeTensor(int n)
+    {
+        var x = new Tensor<double>([n, NumFeatures]);
+        var y = new Tensor<double>([n, 1]);
+        for (int i = 0; i < n; i++)
+        {
+            for (int f = 0; f < NumFeatures; f++)
+                x[i, f] = i * NumFeatures + f;
+            y[i, 0] = i;
+        }
+        return (x, y);
+    }
+
+    [Theory]
+    [InlineData(1)]
+    [InlineData(2)]
+    [InlineData(3)]
+    [InlineData(4)]
+    [InlineData(5)]
+    [InlineData(6)]
+    [InlineData(7)]
+    [InlineData(10)]
+    public void Split_Matrix_TinyDataset_KeepsTrainNonEmpty_AndSumsToN(int n)
+    {
+        var (x, y) = MakeMatrix(n);
+
+        var (xTrain, yTrain, xVal, yVal, xTest, yTest) =
+            DataSplitter.Split<double, Matrix<double>, Vector<double>>(x, y);
+
+        Assert.True(xTrain.Rows >= 1, $"n={n}: training set is empty — model cannot train.");
+        Assert.Equal(xTrain.Rows, yTrain.Length);
+        Assert.Equal(xVal.Rows, yVal.Length);
+        Assert.Equal(xTest.Rows, yTest.Length);
+        Assert.True(xVal.Rows >= 0 && xTest.Rows >= 0);
+        Assert.Equal(n, xTrain.Rows + xVal.Rows + xTest.Rows);
+    }
+
+    [Theory]
+    [InlineData(1)]
+    [InlineData(2)]
+    [InlineData(3)]
+    [InlineData(4)]
+    [InlineData(5)]
+    [InlineData(6)]
+    [InlineData(7)]
+    [InlineData(10)]
+    public void Split_Tensor_TinyDataset_KeepsTrainNonEmpty_AndSumsToN(int n)
+    {
+        var (x, y) = MakeTensor(n);
+
+        var (xTrain, yTrain, xVal, yVal, xTest, yTest) =
+            DataSplitter.Split<double, Tensor<double>, Tensor<double>>(x, y);
+
+        Assert.True(xTrain.Shape[0] >= 1, $"n={n}: training set is empty — model cannot train.");
+        Assert.Equal(xTrain.Shape[0], yTrain.Shape[0]);
+        Assert.Equal(xVal.Shape[0], yVal.Shape[0]);
+        Assert.Equal(xTest.Shape[0], yTest.Shape[0]);
+        Assert.Equal(n, xTrain.Shape[0] + xVal.Shape[0] + xTest.Shape[0]);
+    }
+
+    // With enough rows to afford one each, every partition must be non-empty so
+    // validation-based model selection and the held-out test metric are real.
+    [Theory]
+    [InlineData(3)]
+    [InlineData(8)]
+    [InlineData(20)]
+    public void Split_Matrix_AffordableDataset_FillsEveryPartition(int n)
+    {
+        var (x, y) = MakeMatrix(n);
+
+        var (xTrain, _, xVal, _, xTest, _) =
+            DataSplitter.Split<double, Matrix<double>, Vector<double>>(x, y);
+
+        Assert.True(xTrain.Rows >= 1, $"n={n}: empty training set.");
+        Assert.True(xVal.Rows >= 1, $"n={n}: empty validation set — model selection has nothing to score.");
+        Assert.True(xTest.Rows >= 1, $"n={n}: empty test set — no held-out evaluation.");
+        Assert.Equal(n, xTrain.Rows + xVal.Rows + xTest.Rows);
+    }
+}


### PR DESCRIPTION
## Summary

This layers onto PR #1599 and keeps the scope to the Integration C/D timeout work.

- Lazily materializes native layer graphs and large embeddings for Donut, Nougat, Pix2Struct, Dessurt, and MATCHA.
- Keeps metadata for unmaterialized native models on the lightweight config path instead of serializing/flattening paper-scale weights.
- Preserves eager validation/materialization when callers provide explicit custom layers.
- Preserves lazy-aware clone behavior: unmaterialized models clone lazily, materialized models initialize the clone before parameter copy.

## Root Cause

The Integration D logs showed cancellation while running pixel-to-sequence document models. Those constructors and metadata paths eagerly built large native transformer layer stacks and, for several models, large embedding tensors even for construction, metadata, and `RequiresOCR` smoke probes. That compounds memory/time across the serialized heavy shard.

## Validation

- `dotnet test tests\AiDotNet.Tests\AiDotNetTests.csproj --framework net10.0 --no-restore --filter "FullyQualifiedName~PixelToSequenceDocumentTests" -v minimal` -> 16/16 passed in 47s
- `dotnet test tests\AiDotNet.Tests\AiDotNetTests.csproj --framework net10.0 --no-build --filter "FullyQualifiedName~LayoutAwareDocumentTests" -v minimal` -> 23/23 passed in 42s
- `dotnet test tests\AiDotNet.Tests\AiDotNetTests.csproj --framework net10.0 --no-build --filter "FullyQualifiedName~SegmentationModelSizeVariationTests" -v minimal` -> 96/96 passed in 2m02s
- `dotnet test tests\AiDotNet.Tests\AiDotNetTests.csproj --framework net10.0 --no-build --filter "FullyQualifiedName~DiffusionExtendedIntegrationTests" -v minimal` -> 79/79 passed in 4m14s

A full local `Integration D` shard run was attempted but stopped after running well past the prior CI cancellation point without producing failures or a summary; the targeted PR #1599 and hot document model tests above completed successfully.