### PR TITLE
fix(diffusion): wire predictors into weight streaming

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -154,10 +154,10 @@
          gated on: Dense -> LayerNorm -> GELU -> Dense now routes its between-matmul ops through the
          FP16-native path instead of the eager FP32 fallback. 0.96.0 supersedes master's 0.95.2;
          Native packages coreleased in lockstep at 0.96.0. -->
-    <PackageVersion Include="AiDotNet.Tensors" Version="0.96.1" />
-    <PackageVersion Include="AiDotNet.Native.OneDNN" Version="0.96.1" />
-    <PackageVersion Include="AiDotNet.Native.OpenBLAS" Version="0.96.1" />
-    <PackageVersion Include="AiDotNet.Native.CLBlast" Version="0.96.1" />
+    <PackageVersion Include="AiDotNet.Tensors" Version="0.97.2" />
+    <PackageVersion Include="AiDotNet.Native.OneDNN" Version="0.97.2" />
+    <PackageVersion Include="AiDotNet.Native.OpenBLAS" Version="0.97.2" />
+    <PackageVersion Include="AiDotNet.Native.CLBlast" Version="0.97.2" />
     <!-- Microsoft / .NET -->
     <PackageVersion Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageVersion Include="Microsoft.Data.Sqlite" Version="10.0.9" />

--- a/src/Diffusion/NoisePredictors/AsymmDiTPredictor.cs
+++ b/src/Diffusion/NoisePredictors/AsymmDiTPredictor.cs
@@ -128,9 +128,10 @@ public class AsymmDiTPredictor<T> : NoisePredictorBase<T>
     /// <inheritdoc />
     public override Tensor<T> PredictNoise(Tensor<T> noisySample, int timestep, Tensor<T>? conditioning = null)
     {
+        using var streaming = BeginWeightStreamingForward();
         var x = _patchEmbed.Forward(noisySample);
         foreach (var block in _blocks) x = block.Forward(x);
-        return _finalLayer.Forward(x);
+        return streaming.Complete(_finalLayer.Forward(x));
     }
 
     /// <inheritdoc />

--- a/src/Diffusion/NoisePredictors/DiTNoisePredictor.cs
+++ b/src/Diffusion/NoisePredictors/DiTNoisePredictor.cs
@@ -487,33 +487,23 @@ public class DiTNoisePredictor<T> : NoisePredictorBase<T>
     public override Tensor<T> PredictNoise(Tensor<T> noisySample, int timestep, Tensor<T>? conditioning = null)
     {
         EnsureLayersInitialized();
-        // Engage transparent weight streaming for foundation-scale predictors
-        // BEFORE the forward resolves lazy weights, so they allocate through the
-        // disk-backed pool. No-op below threshold or when the registry is busy.
-        MaybeEngageWeightStreaming();
+        using var streaming = BeginWeightStreamingForward();
         _lastInput = noisySample;
 
         // Get timestep embedding
         var timeEmbed = GetTimestepEmbedding(timestep);
         timeEmbed = ProjectTimeEmbedding(timeEmbed);
 
-        var result = Forward(noisySample, timeEmbed, conditioning);
-        // Drop the now-resolved weights to the pool; from the next forward on the
-        // denoising loop runs against a bounded resident set (auto-rehydrate +
-        // owner-drop). No-op unless streaming engaged above.
-        RegisterResolvedStreamingWeights();
-        return result;
+        return streaming.Complete(Forward(noisySample, timeEmbed, conditioning));
     }
 
     /// <inheritdoc />
     public override Tensor<T> PredictNoiseWithEmbedding(Tensor<T> noisySample, Tensor<T> timeEmbedding, Tensor<T>? conditioning = null)
     {
         EnsureLayersInitialized();
-        MaybeEngageWeightStreaming();
+        using var streaming = BeginWeightStreamingForward();
         _lastInput = noisySample;
-        var result = Forward(noisySample, timeEmbedding, conditioning);
-        RegisterResolvedStreamingWeights();
-        return result;
+        return streaming.Complete(Forward(noisySample, timeEmbedding, conditioning));
     }
 
     /// <summary>

--- a/src/Diffusion/NoisePredictors/EMMDiTPredictor.cs
+++ b/src/Diffusion/NoisePredictors/EMMDiTPredictor.cs
@@ -175,6 +175,8 @@ public class EMMDiTPredictor<T> : NoisePredictorBase<T>
                 $"EMMDiTPredictor requires spatial dims divisible by patchSize ({patchSize}); got {height}×{width}.",
                 nameof(noisySample));
 
+        using var streaming = BeginWeightStreamingForward();
+
         int patchDim = _inputChannels * patchSize * patchSize;
         int hPatches = height / patchSize;
         int wPatches = width / patchSize;
@@ -239,7 +241,7 @@ public class EMMDiTPredictor<T> : NoisePredictorBase<T>
 
         if (wasUnbatched)
             output = output.Reshape(new[] { channels, height, width });
-        return output;
+        return streaming.Complete(output);
     }
 
     /// <inheritdoc />

--- a/src/Diffusion/NoisePredictors/FlagDiTPredictor.cs
+++ b/src/Diffusion/NoisePredictors/FlagDiTPredictor.cs
@@ -133,9 +133,10 @@ public class FlagDiTPredictor<T> : NoisePredictorBase<T>
     /// <inheritdoc />
     public override Tensor<T> PredictNoise(Tensor<T> noisySample, int timestep, Tensor<T>? conditioning = null)
     {
+        using var streaming = BeginWeightStreamingForward();
         var x = _patchEmbed.Forward(noisySample);
         foreach (var block in _blocks) x = block.Forward(x);
-        return _finalLayer.Forward(x);
+        return streaming.Complete(_finalLayer.Forward(x));
     }
 
     /// <inheritdoc />

--- a/src/Diffusion/NoisePredictors/FluxDoubleStreamPredictor.cs
+++ b/src/Diffusion/NoisePredictors/FluxDoubleStreamPredictor.cs
@@ -186,6 +186,8 @@ public class FluxDoubleStreamPredictor<T> : NoisePredictorBase<T>
                 $"FluxDoubleStreamPredictor requires spatial dims divisible by patchSize ({PatchSize}); got {height}×{width}.",
                 nameof(noisySample));
 
+        using var streaming = BeginWeightStreamingForward();
+
         // Patchify: [B, C, H, W] → [B, numTokens, patchDim].
         var tokens = Patchify(input4d, PatchSize);
 
@@ -202,7 +204,7 @@ public class FluxDoubleStreamPredictor<T> : NoisePredictorBase<T>
 
         if (wasUnbatched)
             output = output.Reshape(new[] { channels, height, width });
-        return output;
+        return streaming.Complete(output);
     }
 
     /// <summary>

--- a/src/Diffusion/NoisePredictors/MMDiTNoisePredictor.cs
+++ b/src/Diffusion/NoisePredictors/MMDiTNoisePredictor.cs
@@ -431,15 +431,17 @@ public class MMDiTNoisePredictor<T> : NoisePredictorBase<T>
     /// <inheritdoc />
     public override Tensor<T> PredictNoise(Tensor<T> noisySample, int timestep, Tensor<T>? conditioning = null)
     {
+        using var streaming = BeginWeightStreamingForward();
         var timeEmbed = GetTimestepEmbedding(timestep);
         timeEmbed = ProjectTimeEmbedding(timeEmbed);
-        return Forward(noisySample, timeEmbed, conditioning);
+        return streaming.Complete(Forward(noisySample, timeEmbed, conditioning));
     }
 
     /// <inheritdoc />
     public override Tensor<T> PredictNoiseWithEmbedding(Tensor<T> noisySample, Tensor<T> timeEmbedding, Tensor<T>? conditioning = null)
     {
-        return Forward(noisySample, timeEmbedding, conditioning);
+        using var streaming = BeginWeightStreamingForward();
+        return streaming.Complete(Forward(noisySample, timeEmbedding, conditioning));
     }
 
     private Tensor<T> ProjectTimeEmbedding(Tensor<T> timeEmbed)

--- a/src/Diffusion/NoisePredictors/MMDiTXNoisePredictor.cs
+++ b/src/Diffusion/NoisePredictors/MMDiTXNoisePredictor.cs
@@ -192,6 +192,8 @@ public class MMDiTXNoisePredictor<T> : NoisePredictorBase<T>
                 $"MMDiTXNoisePredictor requires spatial dims divisible by patchSize ({_patchSize}); got {height}×{width}.",
                 nameof(noisySample));
 
+        using var streaming = BeginWeightStreamingForward();
+
         int patchDim = _inputChannels * _patchSize * _patchSize;
         int hPatches = height / _patchSize;
         int wPatches = width / _patchSize;
@@ -211,7 +213,7 @@ public class MMDiTXNoisePredictor<T> : NoisePredictorBase<T>
 
         if (wasUnbatched)
             output = output.Reshape(new[] { channels, height, width });
-        return output;
+        return streaming.Complete(output);
     }
 
     /// <summary>

--- a/src/Diffusion/NoisePredictors/NoisePredictorBase.cs
+++ b/src/Diffusion/NoisePredictors/NoisePredictorBase.cs
@@ -369,6 +369,10 @@ public abstract class NoisePredictorBase<T> : INoisePredictor<T>, IModelShape, I
     // then can't both reconfigure the process-global WeightRegistry.
     private int _streamingEngaged;
 
+    // 0 = no successful weight registration yet, 1 = resolved lazy weights have
+    // been registered with the streaming pool at least once.
+    private int _streamingWeightsRegistered;
+
     /// <summary>
     /// Parameter-count threshold above which <see cref="MaybeEngageWeightStreaming"/>
     /// engages disk-backed weight streaming for the denoising forward loop. 500 M
@@ -442,6 +446,17 @@ public abstract class NoisePredictorBase<T> : INoisePredictor<T>, IModelShape, I
     }
 
     /// <summary>
+    /// Starts a predictor forward that may need transparent weight streaming.
+    /// The returned scope registers resolved lazy weights on successful completion
+    /// and releases any in-flight streaming reservations if the first forward fails.
+    /// </summary>
+    protected WeightStreamingForwardScope BeginWeightStreamingForward()
+    {
+        MaybeEngageWeightStreaming();
+        return new WeightStreamingForwardScope(this);
+    }
+
+    /// <summary>
     /// Registers this predictor's now-resolved weights with the streaming pool,
     /// dropping their resident in-memory copies to disk-backed storage. No-op
     /// unless <see cref="MaybeEngageWeightStreaming"/> engaged. Called after the
@@ -462,6 +477,71 @@ public abstract class NoisePredictorBase<T> : INoisePredictor<T>, IModelShape, I
                 if (tensor is null || tensor.Length == 0 || tensor.StreamingPoolHandle >= 0) continue;
                 tensor.Lifetime = WeightLifetime.Streaming;
                 WeightRegistry.RegisterWeight(tensor);
+            }
+        }
+
+        System.Threading.Volatile.Write(ref _streamingWeightsRegistered, 1);
+    }
+
+    private void ReleaseStreamingWeights(bool includeRegistered)
+    {
+        if (System.Threading.Volatile.Read(ref _streamingEngaged) == 0) return;
+
+        foreach (var layer in ReflectInstanceLayers(this))
+        {
+            if (layer is not LayerBase<T> lb) continue;
+            foreach (var tensor in lb.GetTrainableParameters())
+            {
+                if (tensor is null || tensor.Lifetime != WeightLifetime.Streaming) continue;
+                if (!includeRegistered && tensor.StreamingPoolHandle >= 0) continue;
+
+                try
+                {
+                    WeightRegistry.UnregisterWeight(tensor);
+                }
+                catch (Exception ex)
+                {
+                    System.Diagnostics.Trace.TraceWarning(
+                        $"NoisePredictorBase: failed to release streaming weight " +
+                        $"from {layer.GetType().Name}: {ex.GetType().Name}: {ex.Message}");
+                }
+            }
+        }
+
+        if (includeRegistered)
+        {
+            System.Threading.Volatile.Write(ref _streamingWeightsRegistered, 0);
+        }
+    }
+
+    /// <summary>
+    /// Per-forward streaming guard used by concrete predictors. Call
+    /// <see cref="Complete"/> with the final output immediately before returning.
+    /// </summary>
+    protected sealed class WeightStreamingForwardScope : IDisposable
+    {
+        private readonly NoisePredictorBase<T> _owner;
+        private bool _completed;
+
+        internal WeightStreamingForwardScope(NoisePredictorBase<T> owner)
+        {
+            _owner = owner;
+        }
+
+        public Tensor<T> Complete(Tensor<T> result)
+        {
+            _owner.RegisterResolvedStreamingWeights();
+            _completed = true;
+            return result;
+        }
+
+        public void Dispose()
+        {
+            if (!_completed)
+            {
+                var firstForwardDidNotRegister =
+                    System.Threading.Volatile.Read(ref _owner._streamingWeightsRegistered) == 0;
+                _owner.ReleaseStreamingWeights(includeRegistered: firstForwardDidNotRegister);
             }
         }
     }
@@ -1195,6 +1275,8 @@ public abstract class NoisePredictorBase<T> : INoisePredictor<T>, IModelShape, I
     {
         if (_disposed || !disposing) return;
         _disposed = true;
+
+        ReleaseStreamingWeights(includeRegistered: true);
 
         _compileHost.Dispose();
 

--- a/src/Diffusion/NoisePredictors/SiTPredictor.cs
+++ b/src/Diffusion/NoisePredictors/SiTPredictor.cs
@@ -172,6 +172,8 @@ public class SiTPredictor<T> : NoisePredictorBase<T>
         int hp = h / patchSize;
         int wp = w / patchSize;
 
+        using var streaming = BeginWeightStreamingForward();
+
         // Patchify: [B, C, H, W] → [B, hp, patchSize, wp, patchSize, C] via
         // permute, then flatten to [B, hp*wp, C*patchSize*patchSize].
         var permuted = Engine.TensorPermute(noisySample, new[] { 0, 2, 3, 1 }).Contiguous();
@@ -187,7 +189,7 @@ public class SiTPredictor<T> : NoisePredictorBase<T>
         var outPatched = Engine.Reshape(outTokens, new[] { b, hp, wp, patchSize, patchSize, c });
         var outOrdered = Engine.TensorPermute(outPatched, new[] { 0, 1, 3, 2, 4, 5 }).Contiguous();
         var outBhwc = Engine.Reshape(outOrdered, new[] { b, h, w, c });
-        return Engine.TensorPermute(outBhwc, new[] { 0, 3, 1, 2 }).Contiguous();
+        return streaming.Complete(Engine.TensorPermute(outBhwc, new[] { 0, 3, 1, 2 }).Contiguous());
     }
 
     /// <inheritdoc />

--- a/src/Diffusion/NoisePredictors/UNetNoisePredictor.cs
+++ b/src/Diffusion/NoisePredictors/UNetNoisePredictor.cs
@@ -490,6 +490,7 @@ public class UNetNoisePredictor<T> : NoisePredictorBase<T>
     public override Tensor<T> PredictNoise(Tensor<T> noisySample, int timestep, Tensor<T>? conditioning = null)
     {
         EnsureLayersInitialized();
+        using var streaming = BeginWeightStreamingForward();
         _preserveMaterializedParameters = true;
         _lastInput = noisySample;
 
@@ -503,7 +504,7 @@ public class UNetNoisePredictor<T> : NoisePredictorBase<T>
         var output = PredictCompiledForward(noisySample, timeEmbed, conditioning);
 
         _lastOutput = output;
-        return output;
+        return streaming.Complete(output);
     }
 
     /// <summary>
@@ -624,6 +625,7 @@ public class UNetNoisePredictor<T> : NoisePredictorBase<T>
     public override Tensor<T> PredictNoiseWithEmbedding(Tensor<T> noisySample, Tensor<T> timeEmbedding, Tensor<T>? conditioning = null)
     {
         EnsureLayersInitialized();
+        using var streaming = BeginWeightStreamingForward();
         _preserveMaterializedParameters = true;
         _lastInput = noisySample;
 
@@ -635,7 +637,7 @@ public class UNetNoisePredictor<T> : NoisePredictorBase<T>
         SaveForwardState(skips, timeEmbed);
 
         _lastOutput = output;
-        return output;
+        return streaming.Complete(output);
     }
 
     /// <summary>

--- a/src/Diffusion/NoisePredictors/UViTNoisePredictor.cs
+++ b/src/Diffusion/NoisePredictors/UViTNoisePredictor.cs
@@ -226,17 +226,19 @@ public class UViTNoisePredictor<T> : NoisePredictorBase<T>
     /// <inheritdoc />
     public override Tensor<T> PredictNoise(Tensor<T> noisySample, int timestep, Tensor<T>? conditioning = null)
     {
+        using var streaming = BeginWeightStreamingForward();
         _lastInput = noisySample;
         var timeEmbed = GetTimestepEmbedding(timestep);
         timeEmbed = ProjectTimeEmbedding(timeEmbed);
-        return Forward(noisySample, timeEmbed, conditioning);
+        return streaming.Complete(Forward(noisySample, timeEmbed, conditioning));
     }
 
     /// <inheritdoc />
     public override Tensor<T> PredictNoiseWithEmbedding(Tensor<T> noisySample, Tensor<T> timeEmbedding, Tensor<T>? conditioning = null)
     {
+        using var streaming = BeginWeightStreamingForward();
         _lastInput = noisySample;
-        return Forward(noisySample, timeEmbedding, conditioning);
+        return streaming.Complete(Forward(noisySample, timeEmbedding, conditioning));
     }
 
     private Tensor<T> ProjectTimeEmbedding(Tensor<T> timeEmbed)

--- a/src/Diffusion/NoisePredictors/VideoUNetPredictor.cs
+++ b/src/Diffusion/NoisePredictors/VideoUNetPredictor.cs
@@ -456,6 +456,7 @@ public class VideoUNetPredictor<T> : NoisePredictorBase<T>
     /// <inheritdoc />
     public override Tensor<T> PredictNoise(Tensor<T> noisySample, int timestep, Tensor<T>? conditioning = null)
     {
+        using var streaming = BeginWeightStreamingForward();
         _lastInput = noisySample;
 
         // Compute timestep embedding
@@ -463,16 +464,17 @@ public class VideoUNetPredictor<T> : NoisePredictorBase<T>
         timeEmbed = ProjectTimeEmbedding(timeEmbed);
 
         // Forward pass
-        return ForwardVideoUNet(noisySample, timeEmbed, conditioning, imageCondition: null);
+        return streaming.Complete(ForwardVideoUNet(noisySample, timeEmbed, conditioning, imageCondition: null));
     }
 
     /// <inheritdoc />
     public override Tensor<T> PredictNoiseWithEmbedding(Tensor<T> noisySample, Tensor<T> timeEmbedding, Tensor<T>? conditioning = null)
     {
+        using var streaming = BeginWeightStreamingForward();
         _lastInput = noisySample;
 
         var timeEmbed = ProjectTimeEmbedding(timeEmbedding);
-        return ForwardVideoUNet(noisySample, timeEmbed, conditioning, imageCondition: null);
+        return streaming.Complete(ForwardVideoUNet(noisySample, timeEmbed, conditioning, imageCondition: null));
     }
 
     /// <summary>
@@ -494,12 +496,13 @@ public class VideoUNetPredictor<T> : NoisePredictorBase<T>
             throw new InvalidOperationException("This predictor does not support image conditioning.");
         }
 
+        using var streaming = BeginWeightStreamingForward();
         _lastInput = noisySample;
 
         var timeEmbed = GetTimestepEmbedding(timestep);
         timeEmbed = ProjectTimeEmbedding(timeEmbed);
 
-        return ForwardVideoUNet(noisySample, timeEmbed, textConditioning, imageCondition);
+        return streaming.Complete(ForwardVideoUNet(noisySample, timeEmbed, textConditioning, imageCondition));
     }
 
     /// <summary>

--- a/tests/AiDotNet.Tests/UnitTests/Diffusion/Models/DiTWeightStreamingTests.cs
+++ b/tests/AiDotNet.Tests/UnitTests/Diffusion/Models/DiTWeightStreamingTests.cs
@@ -35,6 +35,7 @@ namespace AiDotNet.Tests.UnitTests.Diffusion.Models;
 /// other diffusion test forwards a DiT model, so the global override window
 /// doesn't race a neighbour.</para>
 /// </summary>
+[Collection("WeightStreaming-Singleton")]
 public class DiTWeightStreamingTests
 {
     private const int InputChannels = 4;

--- a/tests/AiDotNet.Tests/UnitTests/Diffusion/Models/NoisePredictorWeightStreamingTests.cs
+++ b/tests/AiDotNet.Tests/UnitTests/Diffusion/Models/NoisePredictorWeightStreamingTests.cs
@@ -1,0 +1,137 @@
+using System;
+using AiDotNet.Diffusion.NoisePredictors;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tests.UnitTests.Diffusion.Models;
+
+/// <summary>
+/// Regression coverage for diffusion predictors that used lazy layer
+/// construction but were not wired into the transparent streaming allocator.
+/// </summary>
+[Collection("WeightStreaming-Singleton")]
+public sealed class NoisePredictorWeightStreamingTests
+{
+    private const long ResidentCap = 16 * 1024 * 1024;
+
+    [Fact]
+    public void UNetPredictNoise_ForcedStreaming_RegistersResolvedWeights()
+    {
+        using var _ = ForceStreamingForTinyModel();
+
+        using var predictor = new UNetNoisePredictor<float>(
+            inputChannels: 4,
+            outputChannels: 4,
+            baseChannels: 8,
+            channelMultipliers: [1],
+            numResBlocks: 1,
+            attentionResolutions: [],
+            contextDim: 16,
+            numHeads: 1,
+            inputHeight: 8,
+            seed: 42);
+
+        var input = new Tensor<float>(new[] { 1, 4, 8, 8 });
+        var output = predictor.PredictNoise(input, timestep: 25);
+
+        Assert.Equal(input.Length, output.Length);
+        AssertStreamingRegistered();
+    }
+
+    [Fact]
+    public void MMDiTPredictNoise_ForcedStreaming_RegistersResolvedWeights()
+    {
+        using var _ = ForceStreamingForTinyModel();
+
+        using var predictor = new MMDiTNoisePredictor<float>(
+            inputChannels: 4,
+            hiddenSize: 32,
+            numJointLayers: 1,
+            numSingleLayers: 0,
+            numHeads: 4,
+            patchSize: 2,
+            contextDim: 16,
+            seed: 42);
+
+        var input = new Tensor<float>(new[] { 1, 4, 8, 8 });
+        var conditioning = new Tensor<float>(new[] { 1, 1, 16 });
+        var output = predictor.PredictNoise(input, timestep: 25, conditioning);
+
+        Assert.Equal(input.Length, output.Length);
+        AssertStreamingRegistered();
+    }
+
+    [Fact]
+    public void UViTPredictNoise_ForcedStreaming_RegistersResolvedWeights()
+    {
+        using var _ = ForceStreamingForTinyModel();
+
+        using var predictor = new UViTNoisePredictor<float>(
+            inputChannels: 4,
+            hiddenSize: 32,
+            numLayers: 2,
+            numHeads: 4,
+            patchSize: 2,
+            contextDim: 0,
+            latentSpatialSize: 8,
+            seed: 42);
+
+        var input = new Tensor<float>(new[] { 1, 4, 8, 8 });
+        var output = predictor.PredictNoise(input, timestep: 25);
+
+        Assert.Equal(input.Length, output.Length);
+        AssertStreamingRegistered();
+    }
+
+    [Fact]
+    public void PredictNoise_Dispose_ReleasesRegisteredStreamingWeights()
+    {
+        using var _ = ForceStreamingForTinyModel();
+
+        var predictor = new UViTNoisePredictor<float>(
+            inputChannels: 4,
+            hiddenSize: 32,
+            numLayers: 2,
+            numHeads: 4,
+            patchSize: 2,
+            contextDim: 0,
+            latentSpatialSize: 8,
+            seed: 42);
+
+        var input = new Tensor<float>(new[] { 1, 4, 8, 8 });
+        var output = predictor.PredictNoise(input, timestep: 25);
+
+        Assert.Equal(input.Length, output.Length);
+        AssertStreamingRegistered();
+
+        predictor.Dispose();
+
+        var report = WeightRegistry.GetStreamingReport();
+        Assert.Equal(0, report.RegisteredEntryCount);
+    }
+
+    private static IDisposable ForceStreamingForTinyModel()
+    {
+        WeightRegistry.Reset();
+        NoisePredictorBase<float>.StreamingThresholdOverride = 1;
+        NoisePredictorBase<float>.StreamingResidentCapOverride = ResidentCap;
+        return new StreamingOverrideScope();
+    }
+
+    private static void AssertStreamingRegistered()
+    {
+        var report = WeightRegistry.GetStreamingReport();
+        Assert.True(report.RegisteredEntryCount > 0,
+            "Forced streaming should register resolved lazy weights after the first forward.");
+    }
+
+    private sealed class StreamingOverrideScope : IDisposable
+    {
+        public void Dispose()
+        {
+            NoisePredictorBase<float>.StreamingThresholdOverride = null;
+            NoisePredictorBase<float>.StreamingResidentCapOverride = null;
+            WeightRegistry.Reset();
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Route diffusion noise predictor forward entrypoints through the existing transparent weight streaming lifecycle.
- Add a scoped streaming guard that registers resolved lazy weights after successful forwards and cleans up abandoned or disposed streaming allocations.
- Add regression coverage for UNet, MMDiT, and UViT forced-streaming forwards plus streaming registry cleanup on predictor dispose.

## Root Cause

The foundation-scale diffusion models already had lazy layer construction and a streaming allocator path, but most concrete `NoisePredictorBase` subclasses did not engage that path before their first lazy forward. As a result, large diffusion predictors could still materialize resident weights during model-family CI instead of moving resolved weights into the bounded streaming pool.

## Notes

PR #1605 is still expected to own the clone and test dtype changes already in flight. This PR intentionally does not duplicate those fixes; it focuses on wiring the model-side streaming path.

## Validation

- `dotnet test tests\AiDotNet.Tests\AiDotNetTests.csproj --framework net10.0 --filter "FullyQualifiedName~NoisePredictorWeightStreamingTests|FullyQualifiedName~DiTWeightStreamingTests"`
- `dotnet test tests\AiDotNet.Tests\AiDotNetTests.csproj --framework net10.0 --configuration Release --no-restore --filter "FullyQualifiedName~AiDotNet.Tests.ModelFamilyTests.Diffusion.MultiDiffusionModelTests&FullyQualifiedName!~Clone_ShouldProduceIdenticalOutput" --logger "console;verbosity=minimal"`
- `git diff --check`

Known local observation: the unfiltered Release MultiDiffusion class still fails `Clone_ShouldProduceIdenticalOutput` on current `master` with `Expected 643774499 parameters, got 10342915`; that matches the #1605 clone-fix scope.