### PR TITLE
fix(nn): engage weight streaming pre-first-forward for foundation VLMs

### DIFF
--- a/src/NeuralNetworks/Layers/LayerBase.cs
+++ b/src/NeuralNetworks/Layers/LayerBase.cs
@@ -638,8 +638,51 @@ public abstract class LayerBase<T> : ILayer<T>, ITrainableLayer<T>, IDisposable
         if (!IsShapeResolved)
         {
             OnFirstForward(input);
+            RegisterStreamingWeightsWithPool();
         }
         EnsureInitialized();
+    }
+
+    /// <summary>
+    /// Registers this layer's just-materialized streaming weight tensors with
+    /// the process-wide <see cref="WeightRegistry"/> so they become evictable
+    /// LRU entries the moment they exist — not in a batched post-forward sweep.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Lazy layers in a foundation-scale model allocate their weights through
+    /// <see cref="AllocateLazyWeight"/> → <c>WeightRegistry.AllocateStreaming</c>
+    /// during the FIRST forward. That call only <em>reserves</em> pool budget; it
+    /// does not register the tensor, so the weight is resident-on-heap but absent
+    /// from the pool's eviction LRU. Without this hook, every layer's weight
+    /// accumulates on the GC heap as the forward walks the stack — the pool has
+    /// nothing registered to evict — and a multi-GB model OOMs mid-forward on a
+    /// memory-bounded runner even though weight streaming is "enabled". The
+    /// previous registration path only ran AFTER the full forward (and is bypassed
+    /// entirely by models with a custom <c>Predict</c>), i.e. far too late.
+    /// </para>
+    /// <para>
+    /// Registering here adds the freshly-initialized weight to the LRU and drops
+    /// its resident copy to the backing store; this layer's own immediately-
+    /// following matmul transparently rehydrates it, and the next layer's
+    /// allocation evicts it again once the resident budget is crossed — keeping
+    /// the resident set bounded across the whole forward. No-op unless streaming
+    /// was enabled for this layer (<see cref="UseStreamingAllocator"/>);
+    /// idempotent via the already-registered handle gate.
+    /// </para>
+    /// </remarks>
+    private void RegisterStreamingWeightsWithPool()
+    {
+        if (!UseStreamingAllocator) return;
+        foreach (var tensor in GetTrainableParameters())
+        {
+            if (tensor is null || tensor.Length == 0) continue;
+            // Only streaming-allocated tensors carry Lifetime.Streaming; skip
+            // anything already registered (handle assigned) to stay idempotent.
+            if (tensor.Lifetime != WeightLifetime.Streaming) continue;
+            if (tensor.StreamingPoolHandle >= 0) continue;
+            WeightRegistry.RegisterWeight(tensor);
+        }
     }
 
     // ── Shape-inference mode (single source of truth for lazy shape resolution) ─────

--- a/src/NeuralNetworks/NeuralNetworkBase.cs
+++ b/src/NeuralNetworks/NeuralNetworkBase.cs
@@ -4237,8 +4237,21 @@ public abstract class NeuralNetworkBase<T> : INeuralNetworkModel<T>, IInterpreta
         _streamingPoolSetAccessScheduleMethod?.Invoke(pool, new object[] { order });
     }
 
+    // WeightRegistry.SetStreamingExecutionTraining takes a Nullable<bool>
+    // (true=training, false=inference, null=unknown), so the reflected lookup
+    // must request typeof(bool?) — a typeof(bool) probe finds no overload and
+    // silently returns null, which left the execution-mode hint permanently
+    // "unknown" and disabled both bf16-Auto store selection AND the zero-copy
+    // mmap inference fast path for every model. Fall back to a name-only lookup
+    // so an older package that still declared the bool overload keeps working.
     private static readonly MethodInfo? StreamingExecutionTrainingMethod =
         typeof(WeightRegistry).GetMethod(
+            "SetStreamingExecutionTraining",
+            BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic,
+            binder: null,
+            types: new[] { typeof(bool?) },
+            modifiers: null)
+        ?? typeof(WeightRegistry).GetMethod(
             "SetStreamingExecutionTraining",
             BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic,
             binder: null,
@@ -4247,7 +4260,7 @@ public abstract class NeuralNetworkBase<T> : INeuralNetworkModel<T>, IInterpreta
 
     private static void SetStreamingExecutionTrainingIfSupported(bool isTraining)
     {
-        StreamingExecutionTrainingMethod?.Invoke(null, new object[] { isTraining });
+        StreamingExecutionTrainingMethod?.Invoke(null, new object?[] { isTraining });
     }
 
     private static void CollectStreamingHandles(ILayer<T> layer, System.Collections.Generic.List<long> order)
@@ -5107,7 +5120,26 @@ public abstract class NeuralNetworkBase<T> : INeuralNetworkModel<T>, IInterpreta
 
         long threshold = _streamingThresholdOverride ?? s_streamingThresholdParams;
 
-        if (paramCount < threshold)
+        // Lazy models (Transformer/VLM decoders built from FullyConnected /
+        // MultiHeadAttention layers that resolve their input dim on first
+        // forward) report ParameterCount == 0 here because no weight tensor
+        // has materialized yet. Relying on the post-first-forward retry is
+        // too late: that first forward is exactly what allocates the entire
+        // (multi-GB) weight set on the GC heap and OOMs on a memory-bounded
+        // runner BEFORE the retry can engage streaming. So when the
+        // materialized count is below threshold, fall back to the model's
+        // structural estimate (computed from its architecture/options, no
+        // materialization required) so streaming turns on in the ctor and
+        // the lazy weights stream as they materialize. See
+        // EstimateStructuralParameterCount.
+        long effectiveCount = paramCount;
+        if (effectiveCount < threshold)
+        {
+            long structural = SafeEstimateStructuralParameterCount();
+            if (structural > effectiveCount) effectiveCount = structural;
+        }
+
+        if (effectiveCount < threshold)
         {
             // Below threshold. For lazy models (Transformer, etc.),
             // ParameterCount may legitimately report 0 here because
@@ -5130,8 +5162,46 @@ public abstract class NeuralNetworkBase<T> : INeuralNetworkModel<T>, IInterpreta
         // parameterless ctor so any future field additions inherit the
         // Tensors-side default rather than getting frozen at the value we
         // pinned today.
-        var options = new GpuOffloadOptions();
+        var options = new GpuOffloadOptions
+        {
+            // Auto-detect only fires for foundation-scale models (paramCount or
+            // structural estimate over the threshold), and the model-family /
+            // inference paths drive a single forward at a time. Transparent
+            // auto-eviction lets a layer's first-forward Materialize drop cold
+            // weights once the resident budget is crossed, so the full weight
+            // set never has to be simultaneously resident — without it, a lazy
+            // foundation model materializes every layer on the GC heap during
+            // the first forward and OOMs a memory-bounded runner even though
+            // streaming was "enabled". Safe here because auto-detect targets
+            // single-threaded foundation-scale inference (see
+            // GpuOffloadOptions.TransparentAutoEviction remarks); the streaming
+            // training path manages its own residency explicitly.
+            TransparentAutoEviction = true,
+        };
+        // Cap the resident budget conservatively. The Tensors default
+        // (0.7 × available, ceiling 16 GB) is tuned for "model is a fraction of
+        // RAM"; for a foundation model whose weights approach the machine's
+        // total RAM (e.g. a ~15 GB float model on a 16 GB runner) a 0.7 budget
+        // leaves no room for activations, the rehydrated active weight, GEMM
+        // scratch, and the framework, so the forward still OOMs even with
+        // streaming. Holding the resident weight set to ~0.4 × available leaves
+        // generous headroom for everything else while keeping enough weights
+        // hot to avoid thrashing. Only lowers the budget — never raises it
+        // above the Tensors default — so large-RAM hosts are unaffected.
+        long availableForBudget = ResolveAvailableMemoryForStreaming();
+        if (availableForBudget > 0)
+        {
+            long conservative = Math.Max(1L * 1024 * 1024 * 1024, (long)(availableForBudget * 0.25));
+            if (conservative < options.StreamingPoolMaxResidentBytes)
+                options.StreamingPoolMaxResidentBytes = conservative;
+        }
         ConfigureWeightLifetime(options);
+        // Declare the default (inference) execution mode so the zero-copy mmap
+        // fast path is eligible immediately — a freshly-built model is in
+        // inference mode until Train() flips it via SetTrainingMode(true), which
+        // forwards the training state here and correctly disables zero-copy
+        // (training writes weights; the mmap alias is read-only).
+        SetStreamingExecutionTrainingIfSupported(IsTrainingMode);
         _streamingEngagedByAutoDetect = true;
         _streamingAutoDetectFinalized = true;
     }
@@ -5144,6 +5214,78 @@ public abstract class NeuralNetworkBase<T> : INeuralNetworkModel<T>, IInterpreta
     /// </summary>
     protected virtual IEnumerable<LayerBase<T>?> GetExtraTrainableLayers()
         => System.Linq.Enumerable.Empty<LayerBase<T>?>();
+
+    /// <summary>
+    /// Structural estimate of this model's trainable parameter count, computed
+    /// from its architecture/options WITHOUT materializing any lazy weight
+    /// tensors. Returns 0 by default (meaning "no estimate available — rely on
+    /// the materialized <see cref="ParameterCount"/>").
+    /// </summary>
+    /// <remarks>
+    /// Foundation-scale models built from lazy layers (large Transformer/VLM
+    /// decoders) report <see cref="ParameterCount"/> == 0 until the first
+    /// forward materializes their weights. That is too late for the weight-
+    /// streaming auto-detector: the first forward is what allocates the full
+    /// multi-GB weight set on the GC heap and OOMs a memory-bounded runner.
+    /// Overriding this lets <see cref="TryAutoEnableWeightStreaming"/> engage
+    /// streaming in the constructor so those weights stream as they
+    /// materialize. The estimate only needs to be accurate enough to land on
+    /// the correct side of the streaming threshold — a coarse lower bound from
+    /// the dominant layers (decoder depth × hidden² , etc.) is sufficient.
+    /// </remarks>
+    protected virtual long EstimateStructuralParameterCount() => 0L;
+
+    /// <summary>
+    /// Best-effort query of the memory ceiling the process can actually use —
+    /// the GC heap hard limit when one is configured (containers / constrained
+    /// CI runners), else physical RAM. Used to size the weight-streaming
+    /// resident budget conservatively. Returns 0 when unavailable so the caller
+    /// keeps the streaming pool's own default.
+    /// </summary>
+    private static long ResolveAvailableMemoryForStreaming()
+    {
+#if NET5_0_OR_GREATER
+        try
+        {
+            long avail = GC.GetGCMemoryInfo().TotalAvailableMemoryBytes;
+            return avail > 0 ? avail : 0L;
+        }
+        catch
+        {
+            return 0L;
+        }
+#else
+        // net471: no portable available-memory query — let the streaming pool
+        // keep its own default budget.
+        return 0L;
+#endif
+    }
+
+    /// <summary>
+    /// Calls <see cref="EstimateStructuralParameterCount"/> defensively: the
+    /// override runs during construction (before subclass fields may be fully
+    /// set) and must never break auto-detect, so any failure degrades to 0
+    /// ("no estimate").
+    /// </summary>
+    private long SafeEstimateStructuralParameterCount()
+    {
+        try
+        {
+            long est = EstimateStructuralParameterCount();
+            return est > 0 ? est : 0L;
+        }
+        catch (Exception ex) when (
+            ex is InvalidOperationException ||
+            ex is NullReferenceException ||
+            ex is OverflowException ||
+            ex is ArithmeticException)
+        {
+            System.Diagnostics.Debug.WriteLine(
+                $"[NeuralNetworkBase] EstimateStructuralParameterCount threw " +
+                $"{ex.GetType().Name}: {ex.Message}; treating as no estimate.");
+            return 0L;
+        }
+    }
 
     /// <summary>
     /// Override-point for subclasses that own raw trainable

--- a/src/VisionLanguage/InstructionTuned/Phi3Vision.cs
+++ b/src/VisionLanguage/InstructionTuned/Phi3Vision.cs
@@ -64,8 +64,8 @@ public class Phi3Vision<T> : VisionLanguageModelBase<T>, IInstructionTunedVLM<T>
     private readonly ITokenizer? _tokenizer; private bool _useNativeMode; private bool _disposed;
     private int _encoderLayerEnd;
 
-    public Phi3Vision(NeuralNetworkArchitecture<T> architecture, string modelPath, Phi3VisionOptions? options = null) : base(architecture) { _options = options ?? new Phi3VisionOptions(); _useNativeMode = false; base.ImageSize = _options.ImageSize; base.ImageChannels = 3; base.EmbeddingDim = _options.DecoderDim; if (string.IsNullOrWhiteSpace(modelPath)) throw new ArgumentException("Model path cannot be null or empty.", nameof(modelPath)); if (!File.Exists(modelPath)) throw new FileNotFoundException($"ONNX model not found: {modelPath}", modelPath); _options.ModelPath = modelPath; OnnxModel = new OnnxModel<T>(modelPath, _options.OnnxOptions); _tokenizer = ClipTokenizerFactory.CreateSimple(vocabSize: _options.VocabSize); InitializeLayers(); }
-    public Phi3Vision(NeuralNetworkArchitecture<T> architecture, Phi3VisionOptions? options = null, IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>>? optimizer = null) : base(architecture) { _options = options ?? new Phi3VisionOptions(); _options.ValidateVisualSizing(); _useNativeMode = true; _optimizer = optimizer ?? new AdamWOptimizer<T, Tensor<T>, Tensor<T>>(this); base.ImageSize = _options.ImageSize; base.ImageChannels = 3; base.EmbeddingDim = _options.DecoderDim; _tokenizer = ClipTokenizerFactory.CreateSimple(vocabSize: _options.VocabSize); InitializeLayers(); }
+    public Phi3Vision(NeuralNetworkArchitecture<T> architecture, string modelPath, Phi3VisionOptions? options = null) : base(architecture) { _options = options ?? new Phi3VisionOptions(); _useNativeMode = false; base.ImageSize = _options.ImageSize; base.ImageChannels = 3; base.EmbeddingDim = _options.DecoderDim; if (string.IsNullOrWhiteSpace(modelPath)) throw new ArgumentException("Model path cannot be null or empty.", nameof(modelPath)); if (!File.Exists(modelPath)) throw new FileNotFoundException($"ONNX model not found: {modelPath}", modelPath); _options.ModelPath = modelPath; OnnxModel = new OnnxModel<T>(modelPath, _options.OnnxOptions); _tokenizer = ClipTokenizerFactory.CreateSimple(vocabSize: _options.VocabSize); InitializeLayers(); TryAutoEnableWeightStreaming(); }
+    public Phi3Vision(NeuralNetworkArchitecture<T> architecture, Phi3VisionOptions? options = null, IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>>? optimizer = null) : base(architecture) { _options = options ?? new Phi3VisionOptions(); _options.ValidateVisualSizing(); _useNativeMode = true; _optimizer = optimizer ?? new AdamWOptimizer<T, Tensor<T>, Tensor<T>>(this); base.ImageSize = _options.ImageSize; base.ImageChannels = 3; base.EmbeddingDim = _options.DecoderDim; _tokenizer = ClipTokenizerFactory.CreateSimple(vocabSize: _options.VocabSize); InitializeLayers(); TryAutoEnableWeightStreaming(); }
 
     public int EmbeddingDimension => _options.DecoderDim; int IVisualEncoder<T>.ImageSize => _options.ImageSize; int IVisualEncoder<T>.ImageChannels => 3; public int MaxGenerationLength => _options.MaxGenerationLength; public int DecoderEmbeddingDim => _options.DecoderDim; public string LanguageModelName => _options.LanguageModelName;
 
@@ -146,11 +146,31 @@ public class Phi3Vision<T> : VisionLanguageModelBase<T>, IInstructionTunedVLM<T>
     private void ComputeEncoderDecoderBoundary() { _encoderLayerEnd = ComputeVisionLanguageBoundary(leadingLayerCount: 2, visionLayerCount: _options.NumVisionLayers, visionBlockLayerCount: TransformerBlockLayerCount(_options.DropoutRate), trailingLayerCount: 6); }
     private Tensor<T> TokenizeText(string text) { if (_tokenizer is null) throw new InvalidOperationException("Tokenizer not initialized."); var encoding = _tokenizer.Encode(text); int seqLen = Math.Min(encoding.TokenIds.Count, _options.MaxSequenceLength); var tokens = new Tensor<T>([seqLen]); for (int i = 0; i < seqLen; i++) tokens[i] = NumOps.FromDouble(encoding.TokenIds[i]); return tokens; }
 
-    public override Tensor<T> Predict(Tensor<T> input) { ThrowIfDisposed(); if (IsOnnxMode && OnnxModel is not null) return OnnxModel.Run(input); var c = input; foreach (var l in Layers) c = l.Forward(c); return c; }
-    public override void Train(Tensor<T> input, Tensor<T> expected) { if (IsOnnxMode) throw new NotSupportedException("Training is not supported in ONNX mode."); SetTrainingMode(true); TrainWithTape(input, expected); SetTrainingMode(false); }
+    public override Tensor<T> Predict(Tensor<T> input) { ThrowIfDisposed(); if (IsOnnxMode && OnnxModel is not null) return OnnxModel.Run(input); TryAutoEnableWeightStreaming(); var c = input; foreach (var l in Layers) c = l.Forward(c); return c; }
+    public override void Train(Tensor<T> input, Tensor<T> expected) { if (IsOnnxMode) throw new NotSupportedException("Training is not supported in ONNX mode."); TryAutoEnableWeightStreaming(); SetTrainingMode(true); TrainWithTape(input, expected); SetTrainingMode(false); }
     public override void UpdateParameters(Vector<T> parameters) { if (!_useNativeMode) throw new NotSupportedException("Cannot update parameters in ONNX mode."); int idx = 0; foreach (var l in Layers) { int c = (int)l.ParameterCount; l.UpdateParameters(parameters.Slice(idx, c)); idx += c; } }
     protected override Tensor<T> PreprocessImage(Tensor<T> image) => NormalizeImage(image, _options.ImageMean, _options.ImageStd);
     protected override Tensor<T> PostprocessOutput(Tensor<T> output) => output;
+
+    // Phi-3-Vision's decoder/vision blocks are lazy FullyConnected/attention
+    // layers that report ParameterCount == 0 until the first forward, so weight
+    // streaming would otherwise engage too late (after the first forward has
+    // already materialized ~15 GB on the GC heap and OOM'd a 16 GB runner). A
+    // coarse structural estimate (≈12·d² per transformer block for QKVO + FFN,
+    // plus the token embedding) lets the auto-detector turn streaming on in the
+    // constructor so those weights stream as they materialize.
+    protected override long EstimateStructuralParameterCount()
+    {
+        // ONNX mode keeps weights in the external runtime; the AiDotNet layer
+        // list is empty, so there is nothing for weight streaming to manage.
+        if (!_useNativeMode) return 0L;
+        long visionDim = _options.VisionDim;
+        long decoderDim = _options.DecoderDim;
+        long vision = (long)_options.NumVisionLayers * 12L * visionDim * visionDim;
+        long decoder = (long)_options.NumDecoderLayers * 12L * decoderDim * decoderDim;
+        long embeddings = (long)_options.VocabSize * decoderDim;
+        return vision + decoder + embeddings;
+    }
     public override ModelMetadata<T> GetModelMetadata() { var m = new ModelMetadata<T> { Name = _useNativeMode ? "Phi-3-Vision-Native" : "Phi-3-Vision-ONNX", Description = "Phi-3-Vision: A Highly Capable Language Model Locally on Your Phone (Abdin et al., 2024)", FeatureCount = _options.DecoderDim, Complexity = _options.NumVisionLayers + _options.NumDecoderLayers }; m.AdditionalInfo["Architecture"] = "Phi-3-Vision"; m.AdditionalInfo["InstructionType"] = _options.InstructionArchitectureType.ToString(); m.AdditionalInfo["LanguageModel"] = _options.LanguageModelName; return m; }
     protected override void SerializeNetworkSpecificData(BinaryWriter writer) { writer.Write(_useNativeMode); writer.Write(_options.ModelPath ?? string.Empty); writer.Write(_options.ImageSize); writer.Write(_options.VisionDim); writer.Write(_options.DecoderDim); writer.Write(_options.ProjectionDim); writer.Write(_options.NumVisionLayers); writer.Write(_options.NumDecoderLayers); writer.Write(_options.NumHeads); }
     protected override void DeserializeNetworkSpecificData(BinaryReader reader) { _useNativeMode = reader.ReadBoolean(); string mp = reader.ReadString(); if (!string.IsNullOrEmpty(mp)) _options.ModelPath = mp; _options.ImageSize = reader.ReadInt32(); _options.VisionDim = reader.ReadInt32(); _options.DecoderDim = reader.ReadInt32(); _options.ProjectionDim = reader.ReadInt32(); _options.NumVisionLayers = reader.ReadInt32(); _options.NumDecoderLayers = reader.ReadInt32(); _options.NumHeads = reader.ReadInt32(); if (!_useNativeMode && _options.ModelPath is { } p && !string.IsNullOrEmpty(p)) OnnxModel = new OnnxModel<T>(p, _options.OnnxOptions); }

--- a/src/VisionLanguage/Proprietary/GrokVision.cs
+++ b/src/VisionLanguage/Proprietary/GrokVision.cs
@@ -62,8 +62,8 @@ public class GrokVision<T> : VisionLanguageModelBase<T>, IProprietaryVLM<T>
     private readonly ITokenizer? _tokenizer; private bool _useNativeMode; private bool _disposed;
     private int _encoderLayerEnd;
 
-    public GrokVision(NeuralNetworkArchitecture<T> architecture, string modelPath, GrokVisionOptions? options = null) : base(architecture) { _options = options ?? new GrokVisionOptions(); _useNativeMode = false; base.ImageSize = _options.ImageSize; base.ImageChannels = 3; base.EmbeddingDim = _options.DecoderDim; if (string.IsNullOrWhiteSpace(modelPath)) throw new ArgumentException("Model path cannot be null or empty.", nameof(modelPath)); if (!File.Exists(modelPath)) throw new FileNotFoundException($"ONNX model not found: {modelPath}", modelPath); _options.ModelPath = modelPath; OnnxModel = new OnnxModel<T>(modelPath, _options.OnnxOptions); _tokenizer = ClipTokenizerFactory.CreateSimple(vocabSize: _options.VocabSize); InitializeLayers(); }
-    public GrokVision(NeuralNetworkArchitecture<T> architecture, GrokVisionOptions? options = null, IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>>? optimizer = null) : base(architecture) { _options = options ?? new GrokVisionOptions(); _useNativeMode = true; _optimizer = optimizer ?? new AdamWOptimizer<T, Tensor<T>, Tensor<T>>(this); base.ImageSize = _options.ImageSize; base.ImageChannels = 3; base.EmbeddingDim = _options.DecoderDim; _tokenizer = ClipTokenizerFactory.CreateSimple(vocabSize: _options.VocabSize); InitializeLayers(); }
+    public GrokVision(NeuralNetworkArchitecture<T> architecture, string modelPath, GrokVisionOptions? options = null) : base(architecture) { _options = options ?? new GrokVisionOptions(); _useNativeMode = false; base.ImageSize = _options.ImageSize; base.ImageChannels = 3; base.EmbeddingDim = _options.DecoderDim; if (string.IsNullOrWhiteSpace(modelPath)) throw new ArgumentException("Model path cannot be null or empty.", nameof(modelPath)); if (!File.Exists(modelPath)) throw new FileNotFoundException($"ONNX model not found: {modelPath}", modelPath); _options.ModelPath = modelPath; OnnxModel = new OnnxModel<T>(modelPath, _options.OnnxOptions); _tokenizer = ClipTokenizerFactory.CreateSimple(vocabSize: _options.VocabSize); InitializeLayers(); TryAutoEnableWeightStreaming(); }
+    public GrokVision(NeuralNetworkArchitecture<T> architecture, GrokVisionOptions? options = null, IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>>? optimizer = null) : base(architecture) { _options = options ?? new GrokVisionOptions(); _useNativeMode = true; _optimizer = optimizer ?? new AdamWOptimizer<T, Tensor<T>, Tensor<T>>(this); base.ImageSize = _options.ImageSize; base.ImageChannels = 3; base.EmbeddingDim = _options.DecoderDim; _tokenizer = ClipTokenizerFactory.CreateSimple(vocabSize: _options.VocabSize); InitializeLayers(); TryAutoEnableWeightStreaming(); }
 
     public int EmbeddingDimension => _options.DecoderDim; int IVisualEncoder<T>.ImageSize => _options.ImageSize; int IVisualEncoder<T>.ImageChannels => 3; public int MaxGenerationLength => _options.MaxGenerationLength; public int DecoderEmbeddingDim => _options.DecoderDim; public string LanguageModelName => _options.LanguageModelName; public string Provider => _options.Provider;
     public Tensor<T> EncodeImage(Tensor<T> image) { ThrowIfDisposed(); var p = PreprocessImage(image); if (IsOnnxMode && OnnxModel is not null) return L2Normalize(OnnxModel.Run(p)); var c = p; for (int i = 0; i < _encoderLayerEnd; i++) c = Layers[i].Forward(c); return L2Normalize(c); }
@@ -117,6 +117,23 @@ public class GrokVision<T> : VisionLanguageModelBase<T>, IProprietaryVLM<T>
     public override void UpdateParameters(Vector<T> parameters) { if (!_useNativeMode) throw new NotSupportedException("Cannot update parameters in ONNX mode."); int idx = 0; foreach (var l in Layers) { int c = (int)l.ParameterCount; l.UpdateParameters(parameters.Slice(idx, c)); idx += c; } }
     protected override Tensor<T> PreprocessImage(Tensor<T> image) => NormalizeImage(image, _options.ImageMean, _options.ImageStd);
     protected override Tensor<T> PostprocessOutput(Tensor<T> output) => output;
+
+    // Lazy decoder/vision blocks report ParameterCount == 0 until the first
+    // forward, so weight streaming would engage too late and OOM a constrained
+    // runner; a coarse structural estimate (~12·d² per transformer block plus
+    // the token embedding) lets the auto-detector turn streaming on in the
+    // constructor. ONNX mode keeps weights in the external runtime → no estimate.
+    protected override long EstimateStructuralParameterCount()
+    {
+        if (!_useNativeMode) return 0L;
+        long visionDim = _options.VisionDim;
+        long decoderDim = _options.DecoderDim;
+        long vision = (long)_options.NumVisionLayers * 12L * visionDim * visionDim;
+        long decoder = (long)_options.NumDecoderLayers * 12L * decoderDim * decoderDim;
+        long embeddings = (long)_options.VocabSize * decoderDim;
+        return vision + decoder + embeddings;
+    }
+
     public override ModelMetadata<T> GetModelMetadata() {
         var m = new ModelMetadata<T> { Name = _useNativeMode ? "Grok-Vision-Native" : "Grok-Vision-ONNX", Description = "Grok Vision: reference implementation of xAI's real-time multimodal model.", FeatureCount = _options.DecoderDim, Complexity = _options.NumVisionLayers + _options.NumDecoderLayers };
         m.AdditionalInfo["Architecture"] = "Grok-Vision";

--- a/src/VisionLanguage/Unified/Transfusion.cs
+++ b/src/VisionLanguage/Unified/Transfusion.cs
@@ -64,8 +64,8 @@ public class Transfusion<T> : VisionLanguageModelBase<T>, IUnifiedVisionModel<T>
     private readonly ITokenizer? _tokenizer; private bool _useNativeMode; private bool _disposed;
     private int _encoderLayerEnd;
 
-    public Transfusion(NeuralNetworkArchitecture<T> architecture, string modelPath, TransfusionOptions? options = null) : base(architecture) { _options = options ?? new TransfusionOptions(); _useNativeMode = false; base.ImageSize = _options.ImageSize; base.ImageChannels = 3; base.EmbeddingDim = _options.DecoderDim; if (string.IsNullOrWhiteSpace(modelPath)) throw new ArgumentException("Model path cannot be null or empty.", nameof(modelPath)); if (!File.Exists(modelPath)) throw new FileNotFoundException($"ONNX model not found: {modelPath}", modelPath); _options.ModelPath = modelPath; OnnxModel = new OnnxModel<T>(modelPath, _options.OnnxOptions); _tokenizer = ClipTokenizerFactory.CreateSimple(vocabSize: _options.VocabSize); InitializeLayers(); }
-    public Transfusion(NeuralNetworkArchitecture<T> architecture, TransfusionOptions? options = null, IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>>? optimizer = null) : base(architecture) { _options = options ?? new TransfusionOptions(); _useNativeMode = true; _optimizer = optimizer ?? new AdamWOptimizer<T, Tensor<T>, Tensor<T>>(this); base.ImageSize = _options.ImageSize; base.ImageChannels = 3; base.EmbeddingDim = _options.DecoderDim; _tokenizer = ClipTokenizerFactory.CreateSimple(vocabSize: _options.VocabSize); InitializeLayers(); }
+    public Transfusion(NeuralNetworkArchitecture<T> architecture, string modelPath, TransfusionOptions? options = null) : base(architecture) { _options = options ?? new TransfusionOptions(); _useNativeMode = false; base.ImageSize = _options.ImageSize; base.ImageChannels = 3; base.EmbeddingDim = _options.DecoderDim; if (string.IsNullOrWhiteSpace(modelPath)) throw new ArgumentException("Model path cannot be null or empty.", nameof(modelPath)); if (!File.Exists(modelPath)) throw new FileNotFoundException($"ONNX model not found: {modelPath}", modelPath); _options.ModelPath = modelPath; OnnxModel = new OnnxModel<T>(modelPath, _options.OnnxOptions); _tokenizer = ClipTokenizerFactory.CreateSimple(vocabSize: _options.VocabSize); InitializeLayers(); TryAutoEnableWeightStreaming(); }
+    public Transfusion(NeuralNetworkArchitecture<T> architecture, TransfusionOptions? options = null, IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>>? optimizer = null) : base(architecture) { _options = options ?? new TransfusionOptions(); _useNativeMode = true; _optimizer = optimizer ?? new AdamWOptimizer<T, Tensor<T>, Tensor<T>>(this); base.ImageSize = _options.ImageSize; base.ImageChannels = 3; base.EmbeddingDim = _options.DecoderDim; _tokenizer = ClipTokenizerFactory.CreateSimple(vocabSize: _options.VocabSize); InitializeLayers(); TryAutoEnableWeightStreaming(); }
 
     public int EmbeddingDimension => _options.DecoderDim; int IVisualEncoder<T>.ImageSize => _options.ImageSize; int IVisualEncoder<T>.ImageChannels => 3; public int MaxGenerationLength => _options.MaxGenerationLength; public int DecoderEmbeddingDim => _options.DecoderDim; public bool SupportsGeneration => _options.SupportsGeneration;
     public Tensor<T> EncodeImage(Tensor<T> image) { ThrowIfDisposed(); var p = PreprocessImage(image); if (IsOnnxMode && OnnxModel is not null) return L2Normalize(OnnxModel.Run(p)); var c = p; for (int i = 0; i < _encoderLayerEnd; i++) c = Layers[i].Forward(c); return L2Normalize(c); }
@@ -239,6 +239,23 @@ public class Transfusion<T> : VisionLanguageModelBase<T>, IUnifiedVisionModel<T>
     public override void UpdateParameters(Vector<T> parameters) { if (!_useNativeMode) throw new NotSupportedException("Cannot update parameters in ONNX mode."); int idx = 0; foreach (var l in Layers) { int c = (int)l.ParameterCount; l.UpdateParameters(parameters.Slice(idx, c)); idx += c; } }
     protected override Tensor<T> PreprocessImage(Tensor<T> image) => NormalizeImage(image, _options.ImageMean, _options.ImageStd);
     protected override Tensor<T> PostprocessOutput(Tensor<T> output) => output;
+
+    // Lazy decoder/vision blocks report ParameterCount == 0 until the first
+    // forward, so weight streaming would engage too late and OOM a constrained
+    // runner; a coarse structural estimate (~12·d² per transformer block plus
+    // the token embedding) lets the auto-detector turn streaming on in the
+    // constructor. ONNX mode keeps weights in the external runtime → no estimate.
+    protected override long EstimateStructuralParameterCount()
+    {
+        if (!_useNativeMode) return 0L;
+        long visionDim = _options.VisionDim;
+        long decoderDim = _options.DecoderDim;
+        long vision = (long)_options.NumVisionLayers * 12L * visionDim * visionDim;
+        long decoder = (long)_options.NumDecoderLayers * 12L * decoderDim * decoderDim;
+        long embeddings = (long)_options.VocabSize * decoderDim;
+        return vision + decoder + embeddings;
+    }
+
     public override ModelMetadata<T> GetModelMetadata() {
         var m = new ModelMetadata<T> { Name = _useNativeMode ? "Transfusion-Native" : "Transfusion-ONNX", Description = "Transfusion: combined autoregressive and diffusion loss in single transformer.", FeatureCount = _options.DecoderDim, Complexity = _options.NumVisionLayers + _options.NumDecoderLayers };
         m.AdditionalInfo["Architecture"] = "Transfusion";


### PR DESCRIPTION
## Problem
Foundation-scale VLMs (`Phi3Vision`, `GrokVision`, `Transfusion`) OOM on a memory-bounded **16 GB / 8-core** CI runner. A ~15 GB float model materializes its entire weight set on the GC heap during the **first forward**, exceeding RAM.

Weight streaming (the infra that pages weights to a backing store to bound resident memory) never engaged for these models:
1. They override `Predict`/`InitializeLayers` and bypass every `TryAutoEnableWeightStreaming` hook, and a lazy model reports `ParameterCount == 0` at construction — so auto-detect can't see the size until the first forward, which is exactly what OOMs.
2. Even when configured, lazy weights were `AllocateStreaming`-reserved but never `RegisterWeight`'d into the pool's eviction LRU until a *post-forward* sweep the custom `Predict` skips — so nothing was evictable mid-forward.

## Fix
- **`NeuralNetworkBase`**: `EstimateStructuralParameterCount()` virtual so lazy foundation models trip the streaming auto-detector from the constructor; `TransparentAutoEviction` + a conservative `0.25×available` resident budget (the `0.7×` default leaves no headroom for activations when weights ≈ RAM); declare inference execution mode on engage. **Bug fix:** the `SetStreamingExecutionTraining` reflection probed `typeof(bool)` but the method takes `bool?` → the execution-mode hint was *never* applied for any model, silently disabling bf16-Auto store selection and the zero-copy mmap path project-wide.
- **`LayerBase.EnsureInitializedFromInput`**: register each lazy streaming weight with the pool immediately after it materializes, so it becomes an evictable LRU entry mid-forward and the resident set stays bounded across the stack.
- **`Phi3Vision` / `GrokVision` / `Transfusion`**: structural param estimate + engage streaming at the end of the native constructor.

## Verification
On an 8-core/16 GB repro (`DOTNET_GCHeapHardLimit=0x400000000` + `DOTNET_PROCESSOR_COUNT=8`): a Phi3Vision forward went from `OutOfMemoryException` → **completes**.

## Notes / follow-ups
- A companion **AiDotNet.Tensors** `WeightRegistry.AllocateStreaming` drain-on-alloc change makes the streamed forward materially faster (~138 s → ~106 s in repro). It is a *speed* optimization (this PR alone removes the OOM); tracked as a separate Tensors PR + package bump.
- **Multi-forward wall-clock** (Clone / Predict-determinism / ScaledInput = 2 forwards) at this scale on 8 cores / 16 GB is at the irreducible weight-I/O+compute limit for the 120 s budget and is **deferred** by decision; bf16 and zero-copy were measured as non-helping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)