### PR TITLE
fix(training): scope streaming training to a per-step arena — fixes #1624 OOM

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -154,7 +154,7 @@
          gated on: Dense -> LayerNorm -> GELU -> Dense now routes its between-matmul ops through the
          FP16-native path instead of the eager FP32 fallback. 0.96.0 supersedes master's 0.95.2;
          Native packages coreleased in lockstep at 0.96.0. -->
-    <PackageVersion Include="AiDotNet.Tensors" Version="0.98.0" />
+    <PackageVersion Include="AiDotNet.Tensors" Version="0.101.0" />
     <PackageVersion Include="AiDotNet.Native.OneDNN" Version="0.98.0" />
     <PackageVersion Include="AiDotNet.Native.OpenBLAS" Version="0.98.0" />
     <PackageVersion Include="AiDotNet.Native.CLBlast" Version="0.98.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -154,10 +154,10 @@
          gated on: Dense -> LayerNorm -> GELU -> Dense now routes its between-matmul ops through the
          FP16-native path instead of the eager FP32 fallback. 0.96.0 supersedes master's 0.95.2;
          Native packages coreleased in lockstep at 0.96.0. -->
-    <PackageVersion Include="AiDotNet.Tensors" Version="0.96.1" />
-    <PackageVersion Include="AiDotNet.Native.OneDNN" Version="0.96.1" />
-    <PackageVersion Include="AiDotNet.Native.OpenBLAS" Version="0.96.1" />
-    <PackageVersion Include="AiDotNet.Native.CLBlast" Version="0.96.1" />
+    <PackageVersion Include="AiDotNet.Tensors" Version="0.98.0" />
+    <PackageVersion Include="AiDotNet.Native.OneDNN" Version="0.98.0" />
+    <PackageVersion Include="AiDotNet.Native.OpenBLAS" Version="0.98.0" />
+    <PackageVersion Include="AiDotNet.Native.CLBlast" Version="0.98.0" />
     <!-- Microsoft / .NET -->
     <PackageVersion Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageVersion Include="Microsoft.Data.Sqlite" Version="10.0.9" />

--- a/src/Diffusion/Control/ControlNetPlusPlusFluxModel.cs
+++ b/src/Diffusion/Control/ControlNetPlusPlusFluxModel.cs
@@ -137,7 +137,10 @@ public class ControlNetPlusPlusFluxModel<T> : LatentDiffusionModelBase<T>
     {
         var clone = new ControlNetPlusPlusFluxModel<T>(
             controlType: _controlType, conditioner: _conditioner, rewardWeight: _rewardWeight, seed: RandomGenerator.Next());
-        clone.SetParameters(GetParameters());
+        // #1624: O(1)-until-write copy-on-write parameter share (avoids the full-model flatten copy that
+        // OOMs the 16 GB runner). Falls back to the flat copy if the structure doesn't match 1:1.
+        if (!clone.TryShareParametersFrom(this))
+            clone.SetParameters(GetParameters());
         return clone;
     }
 

--- a/src/Diffusion/DiffusionModelBase.cs
+++ b/src/Diffusion/DiffusionModelBase.cs
@@ -1110,70 +1110,10 @@ public abstract class DiffusionModelBase<T> : IDiffusionModel<T>, IConfigurableM
     /// </summary>
     protected bool TryShareParametersFrom(DiffusionModelBase<T> source)
     {
-        if (source is null) return false;
-        var srcLayers = CollectTrainableLayers(source);
-        var dstLayers = CollectTrainableLayers(this);
-        if (srcLayers.Count == 0 || srcLayers.Count != dstLayers.Count) return false;
-
-        // Verify the full structure matches before mutating anything.
-        for (int i = 0; i < srcLayers.Count; i++)
-            if (srcLayers[i].GetTrainableParameters().Count != dstLayers[i].GetTrainableParameters().Count)
-                return false;
-
-        for (int i = 0; i < srcLayers.Count; i++)
-        {
-            var sp = srcLayers[i].GetTrainableParameters();
-            if (sp.Count == 0) continue;
-            var shared = new Tensor<T>[sp.Count];
-            for (int p = 0; p < sp.Count; p++)
-                shared[p] = (Tensor<T>)sp[p].CloneShared();
-            dstLayers[i].SetTrainableParameters(shared);
-        }
-
+        if (!AiDotNet.Helpers.CopyOnWriteCloneHelper.TryShareTrainableParameters<T>(source, this))
+            return false;
         InvalidateTrainableParametersCache();
         return true;
-    }
-
-    /// <summary>Reflection walk collecting every <see cref="Interfaces.ITrainableLayer{T}"/> reachable from
-    /// <paramref name="root"/>, in the same deterministic order as <see cref="CollectLayerParameters"/>.</summary>
-    private static List<Interfaces.ITrainableLayer<T>> CollectTrainableLayers(object root)
-    {
-        var layers = new List<Interfaces.ITrainableLayer<T>>();
-        CollectTrainableLayersInto(root, layers,
-            new HashSet<object>(AiDotNet.Helpers.TensorReferenceComparer<object>.Instance));
-        return layers;
-    }
-
-    private static void CollectTrainableLayersInto(object? obj, List<Interfaces.ITrainableLayer<T>> layers, HashSet<object> visited)
-    {
-        if (obj is null || !visited.Add(obj)) return;
-        if (obj is Interfaces.ITrainableLayer<T> trainable) layers.Add(trainable);
-
-        var type = obj.GetType();
-        if (type.IsPrimitive || type == typeof(string) || type.IsEnum) return;
-
-        foreach (var field in type.GetFields(
-            System.Reflection.BindingFlags.Instance |
-            System.Reflection.BindingFlags.NonPublic |
-            System.Reflection.BindingFlags.Public))
-        {
-            if (field.FieldType.IsPrimitive || field.FieldType.IsEnum ||
-                field.FieldType == typeof(string) || field.FieldType == typeof(Tensor<T>))
-                continue;
-
-            var val = field.GetValue(obj);
-            if (val is null) continue;
-
-            if (val is System.Collections.IEnumerable enumerable && val is not string)
-            {
-                foreach (var item in enumerable)
-                    CollectTrainableLayersInto(item, layers, visited);
-            }
-            else
-            {
-                CollectTrainableLayersInto(val, layers, visited);
-            }
-        }
     }
 
     /// <summary>

--- a/src/Diffusion/DiffusionModelBase.cs
+++ b/src/Diffusion/DiffusionModelBase.cs
@@ -1092,6 +1092,91 @@ public abstract class DiffusionModelBase<T> : IDiffusionModel<T>, IConfigurableM
     }
 
     /// <summary>
+    /// COW clone lever (#1624): shares each trainable weight tensor's STORAGE with <paramref name="source"/>
+    /// via the Tensors copy-on-write <c>Tensor&lt;T&gt;.CloneShared()</c> (O(1)-until-write), instead of the
+    /// flat <c>GetParameters()</c> → <c>SetParameters()</c> round-trip that materializes the entire model a
+    /// second time (and a giant intermediate flat vector) — the source of the large-diffusion-model Clone
+    /// OOM on the 16 GB runner. The first in-place write to either side privatizes that tensor, so the clone
+    /// is observationally identical to the flat-copy clone. Fidelity is equivalent to the existing path
+    /// because both transfer exactly the model's trainable tensors (diffusion models carry no non-trainable
+    /// running statistics / serialization extras) — this just shares them rather than copying.
+    ///
+    /// <para>Walks <paramref name="source"/> and <c>this</c> in parallel via reflection (identical type ⇒
+    /// identical field order ⇒ matching layer order, the same assumption <see cref="CollectTrainableParameters"/>
+    /// already relies on) and re-binds each destination layer's parameters through
+    /// <see cref="Interfaces.ITrainableLayer{T}.SetTrainableParameters"/>. Returns <c>false</c> if the
+    /// trainable-layer structure does not match 1:1 (the caller then falls back to the flat copy), and never
+    /// leaves a half-shared clone — structure is fully verified before any sharing.</para>
+    /// </summary>
+    protected bool TryShareParametersFrom(DiffusionModelBase<T> source)
+    {
+        if (source is null) return false;
+        var srcLayers = CollectTrainableLayers(source);
+        var dstLayers = CollectTrainableLayers(this);
+        if (srcLayers.Count == 0 || srcLayers.Count != dstLayers.Count) return false;
+
+        // Verify the full structure matches before mutating anything.
+        for (int i = 0; i < srcLayers.Count; i++)
+            if (srcLayers[i].GetTrainableParameters().Count != dstLayers[i].GetTrainableParameters().Count)
+                return false;
+
+        for (int i = 0; i < srcLayers.Count; i++)
+        {
+            var sp = srcLayers[i].GetTrainableParameters();
+            if (sp.Count == 0) continue;
+            var shared = new Tensor<T>[sp.Count];
+            for (int p = 0; p < sp.Count; p++)
+                shared[p] = (Tensor<T>)sp[p].CloneShared();
+            dstLayers[i].SetTrainableParameters(shared);
+        }
+
+        InvalidateTrainableParametersCache();
+        return true;
+    }
+
+    /// <summary>Reflection walk collecting every <see cref="Interfaces.ITrainableLayer{T}"/> reachable from
+    /// <paramref name="root"/>, in the same deterministic order as <see cref="CollectLayerParameters"/>.</summary>
+    private static List<Interfaces.ITrainableLayer<T>> CollectTrainableLayers(object root)
+    {
+        var layers = new List<Interfaces.ITrainableLayer<T>>();
+        CollectTrainableLayersInto(root, layers,
+            new HashSet<object>(AiDotNet.Helpers.TensorReferenceComparer<object>.Instance));
+        return layers;
+    }
+
+    private static void CollectTrainableLayersInto(object? obj, List<Interfaces.ITrainableLayer<T>> layers, HashSet<object> visited)
+    {
+        if (obj is null || !visited.Add(obj)) return;
+        if (obj is Interfaces.ITrainableLayer<T> trainable) layers.Add(trainable);
+
+        var type = obj.GetType();
+        if (type.IsPrimitive || type == typeof(string) || type.IsEnum) return;
+
+        foreach (var field in type.GetFields(
+            System.Reflection.BindingFlags.Instance |
+            System.Reflection.BindingFlags.NonPublic |
+            System.Reflection.BindingFlags.Public))
+        {
+            if (field.FieldType.IsPrimitive || field.FieldType.IsEnum ||
+                field.FieldType == typeof(string) || field.FieldType == typeof(Tensor<T>))
+                continue;
+
+            var val = field.GetValue(obj);
+            if (val is null) continue;
+
+            if (val is System.Collections.IEnumerable enumerable && val is not string)
+            {
+                foreach (var item in enumerable)
+                    CollectTrainableLayersInto(item, layers, visited);
+            }
+            else
+            {
+                CollectTrainableLayersInto(val, layers, visited);
+            }
+        }
+    }
+
+    /// <summary>
     /// Flattens gradient tensors into a single vector matching GetParameters() layout.
     /// </summary>
     private Vector<T> FlattenGradients(Tensor<T>[] paramTensors, Dictionary<Tensor<T>, Tensor<T>> grads)

--- a/src/Diffusion/FastGeneration/Flux2SchnellModel.cs
+++ b/src/Diffusion/FastGeneration/Flux2SchnellModel.cs
@@ -149,7 +149,10 @@ public class Flux2SchnellModel<T> : LatentDiffusionModelBase<T>
     public override IDiffusionModel<T> Clone()
     {
         var clone = new Flux2SchnellModel<T>(conditioner: _conditioner, seed: RandomGenerator.Next());
-        clone.SetParameters(GetParameters());
+        // #1624: O(1)-until-write copy-on-write parameter share (avoids the full-model flatten copy that
+        // OOMs the 16 GB runner). Falls back to the flat copy if the structure doesn't match 1:1.
+        if (!clone.TryShareParametersFrom(this))
+            clone.SetParameters(GetParameters());
         return clone;
     }
 

--- a/src/Diffusion/Video/CogVideoModel.cs
+++ b/src/Diffusion/Video/CogVideoModel.cs
@@ -288,15 +288,17 @@ public class CogVideoModel<T> : VideoDiffusionModelBase<T>
     /// <inheritdoc />
     public override IDiffusionModel<T> Clone()
     {
-        var baseChannels = _variant == "5B" ? 384 : 320;
-
-                        return new CogVideoModel<T>(
-            videoUnet: (VideoUNetPredictor<T>)_videoUnet.Clone(),
-            temporalVae: (TemporalVAE<T>)_temporalVae.Clone(),
+        // #1624: build with fresh (cheap) sub-models and share weight-tensor STORAGE copy-on-write
+        // (O(1)-until-write), instead of cloning each sub-model's full weight set. Falls back to the flat
+        // copy if the structure doesn't match 1:1 (e.g. a sub-model whose lazy layers aren't resolved).
+        var clone = new CogVideoModel<T>(
             conditioner: _conditioner,
             variant: _variant,
             defaultNumFrames: DefaultNumFrames,
             defaultFPS: DefaultFPS);
+        if (!AiDotNet.Helpers.CopyOnWriteCloneHelper.TryShareTrainableParameters<T>(this, clone))
+            clone.SetParameters(GetParameters());
+        return clone;
     }
 
     #endregion

--- a/src/Helpers/CopyOnWriteCloneHelper.cs
+++ b/src/Helpers/CopyOnWriteCloneHelper.cs
@@ -1,0 +1,99 @@
+using System.Collections;
+using System.Collections.Generic;
+using System.Reflection;
+using AiDotNet.Interfaces;
+using AiDotNet.LinearAlgebra;
+
+namespace AiDotNet.Helpers;
+
+/// <summary>
+/// Copy-on-write clone lever (#1624): shares a model's trainable weight tensors with its clone via the
+/// Tensors O(1)-until-write <see cref="Tensor{T}.CloneShared"/> (issue #624), instead of the
+/// <c>SetParameters(GetParameters())</c> flatten round-trip that materializes the whole weight set a
+/// second time (plus a giant intermediate flat vector) — the source of large-model <c>Clone()</c> OOMs
+/// on the 16 GB CI runner.
+/// </summary>
+/// <remarks>
+/// <para>Universal across base classes: any <c>Clone()</c> that builds a fresh same-typed instance can
+/// replace <c>clone.SetParameters(GetParameters())</c> with
+/// <c>if (!CopyOnWriteCloneHelper.TryShareTrainableParameters&lt;T&gt;(this, clone)) clone.SetParameters(GetParameters());</c>.
+/// The first in-place write to either side privatizes that tensor, so the clone is observationally
+/// identical to the flat-copy clone. Fidelity is equivalent to the flat copy because both transfer
+/// exactly the model's trainable tensors.</para>
+/// </remarks>
+public static class CopyOnWriteCloneHelper
+{
+    /// <summary>
+    /// Re-binds every trainable parameter of <paramref name="dest"/> to a copy-on-write share of the
+    /// corresponding parameter of <paramref name="source"/>. Walks both object graphs in parallel by
+    /// reflection (identical runtime type ⇒ identical field order ⇒ matching layer order). Returns
+    /// <c>false</c> — leaving <paramref name="dest"/> untouched — if the trainable-layer structure does
+    /// not line up 1:1 (e.g. a freshly-constructed clone whose lazy layers aren't resolved yet), so the
+    /// caller can fall back to the eager flat copy.
+    /// </summary>
+    public static bool TryShareTrainableParameters<T>(object? source, object? dest)
+    {
+        if (source is null || dest is null || ReferenceEquals(source, dest)) return false;
+        if (source.GetType() != dest.GetType()) return false;
+
+        var srcLayers = CollectTrainableLayers<T>(source);
+        var dstLayers = CollectTrainableLayers<T>(dest);
+        if (srcLayers.Count == 0 || srcLayers.Count != dstLayers.Count) return false;
+
+        // Verify the full structure matches BEFORE mutating anything, so we never leave a half-shared clone.
+        for (int i = 0; i < srcLayers.Count; i++)
+            if (srcLayers[i].GetTrainableParameters().Count != dstLayers[i].GetTrainableParameters().Count)
+                return false;
+
+        for (int i = 0; i < srcLayers.Count; i++)
+        {
+            var sp = srcLayers[i].GetTrainableParameters();
+            if (sp.Count == 0) continue;
+            var shared = new Tensor<T>[sp.Count];
+            for (int p = 0; p < sp.Count; p++)
+                shared[p] = (Tensor<T>)sp[p].CloneShared();
+            dstLayers[i].SetTrainableParameters(shared);
+        }
+
+        return true;
+    }
+
+    private static List<ITrainableLayer<T>> CollectTrainableLayers<T>(object root)
+    {
+        var layers = new List<ITrainableLayer<T>>();
+        CollectInto(root, layers, new HashSet<object>(TensorReferenceComparer<object>.Instance));
+        return layers;
+    }
+
+    private static void CollectInto<T>(object? obj, List<ITrainableLayer<T>> layers, HashSet<object> visited)
+    {
+        if (obj is null || !visited.Add(obj)) return;
+        if (obj is ITrainableLayer<T> trainable) layers.Add(trainable);
+
+        var type = obj.GetType();
+        if (type.IsPrimitive || type == typeof(string) || type.IsEnum) return;
+
+        foreach (var field in type.GetFields(
+            BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public))
+        {
+            // Tensor fields are leaves (their owning layer already exposed them via
+            // GetTrainableParameters); skip primitives/strings/enums that can't hold a layer.
+            if (field.FieldType.IsPrimitive || field.FieldType.IsEnum ||
+                field.FieldType == typeof(string) || field.FieldType == typeof(Tensor<T>))
+                continue;
+
+            var val = field.GetValue(obj);
+            if (val is null) continue;
+
+            if (val is IEnumerable enumerable && val is not string)
+            {
+                foreach (var item in enumerable)
+                    CollectInto(item, layers, visited);
+            }
+            else
+            {
+                CollectInto(val, layers, visited);
+            }
+        }
+    }
+}

--- a/src/Helpers/CopyOnWriteCloneHelper.cs
+++ b/src/Helpers/CopyOnWriteCloneHelper.cs
@@ -31,7 +31,9 @@ public static class CopyOnWriteCloneHelper
     /// not line up 1:1 (e.g. a freshly-constructed clone whose lazy layers aren't resolved yet), so the
     /// caller can fall back to the eager flat copy.
     /// </summary>
-    public static bool TryShareTrainableParameters<T>(object? source, object? dest)
+    public static bool TryShareTrainableParameters<T>(
+        IFullModel<T, Tensor<T>, Tensor<T>>? source,
+        IFullModel<T, Tensor<T>, Tensor<T>>? dest)
     {
         if (source is null || dest is null || ReferenceEquals(source, dest)) return false;
         if (source.GetType() != dest.GetType()) return false;
@@ -58,9 +60,18 @@ public static class CopyOnWriteCloneHelper
         return true;
     }
 
-    private static List<ITrainableLayer<T>> CollectTrainableLayers<T>(object root)
+    /// <summary>
+    /// Collects every <see cref="ITrainableLayer{T}"/> reachable from <paramref name="root"/> by reflection,
+    /// in a deterministic order. Captures layers held both in a base <c>_layers</c> list AND in dedicated
+    /// fields (e.g. a tabular transformer's feature tokenizer / encoder stack / final layer-norm), which a
+    /// <c>_layers</c>-only walk misses. Two instances of the same runtime type yield matching order, so the
+    /// result pairs 1:1 between a model and its fresh clone.
+    /// </summary>
+    public static List<ITrainableLayer<T>> CollectTrainableLayers<T>(IFullModel<T, Tensor<T>, Tensor<T>> root)
     {
         var layers = new List<ITrainableLayer<T>>();
+        // CollectInto walks arbitrary instance fields, so it is necessarily typed `object?` internally;
+        // the public entry point is constrained to a model so callers can't pass an unrelated graph.
         CollectInto(root, layers, new HashSet<object>(TensorReferenceComparer<object>.Instance));
         return layers;
     }

--- a/src/MixedPrecision/Float8Types.cs
+++ b/src/MixedPrecision/Float8Types.cs
@@ -66,6 +66,30 @@ internal static class BitConverterHelper
         return Int32BitsToSingle(unchecked((int)truncated));
     }
 
+    /// <summary>
+    /// Packs a float into a 2-byte BF16 (the upper 16 bits of the float32 with
+    /// round-to-nearest-even on the dropped low 16 bits). Unlike FP16, BF16 keeps
+    /// the full float32 exponent, so no scale factor is needed — the dynamic range
+    /// is preserved and only mantissa precision is reduced. NaN is preserved as a
+    /// quiet NaN; ±Inf passes through. Used for half-footprint optimizer moment state.
+    /// </summary>
+    public static ushort FloatToBf16Bits(float value)
+    {
+        uint bits = unchecked((uint)SingleToInt32Bits(value));
+        if (float.IsNaN(value))
+            return (ushort)((bits >> 16) | 0x0040u); // force a mantissa bit so it stays NaN
+        // Round to nearest even: add 0x7FFF + (lsb of the surviving mantissa) then truncate.
+        uint lsb = (bits >> 16) & 1u;
+        bits += 0x7FFFu + lsb;
+        return (ushort)(bits >> 16);
+    }
+
+    /// <summary>Expands a 2-byte BF16 back to a float (BF16 occupies the high 16 bits).</summary>
+    public static float Bf16BitsToFloat(ushort bf16)
+    {
+        return Int32BitsToSingle(unchecked((int)((uint)bf16 << 16)));
+    }
+
     [StructLayout(LayoutKind.Explicit)]
     private struct SingleInt32Union
     {

--- a/src/Models/Options/Adam8BitOptimizerOptions.cs
+++ b/src/Models/Options/Adam8BitOptimizerOptions.cs
@@ -130,4 +130,25 @@ public class Adam8BitOptimizerOptions<T, TInput, TOutput> : AdamOptimizerOptions
     /// </para>
     /// </remarks>
     public bool CompressBothMoments { get; set; } = true;
+
+    /// <summary>
+    /// Stores the optimizer moment state (m and v) as BFloat16 (2 bytes/element) instead of the
+    /// default 8-bit block-quantized representation (1 byte/element). Default: false.
+    /// </summary>
+    /// <value>True to store moments as BFloat16; false (default) to use 8-bit block quantization.</value>
+    /// <remarks>
+    /// <para>
+    /// BFloat16 keeps the full float32 exponent (only the mantissa is shortened), so it preserves
+    /// dynamic range without per-block scale factors and changes Adam's convergence far less than the
+    /// 8-bit block quantization does — at the cost of using twice the storage (still half of fp32).
+    /// This is the gentle, proactive rung of the optimizer-memory ladder: fp32 (4B) → BF16 (2B) →
+    /// 8-bit (1B). When true, this overrides <see cref="BlockSize"/>/<see cref="CompressBothMoments"/>
+    /// and the block-quant path for the tape (NN) training step.
+    /// </para>
+    /// <para><b>For Beginners:</b> This halves the memory the optimizer needs to remember each weight's
+    /// momentum and variance, with almost no effect on how well the model learns — a safer way to fit a
+    /// big model in memory than the more aggressive 8-bit mode.
+    /// </para>
+    /// </remarks>
+    public bool UseBFloat16MomentStorage { get; set; } = false;
 }

--- a/src/NeuralNetworks/NeuralNetworkBase.cs
+++ b/src/NeuralNetworks/NeuralNetworkBase.cs
@@ -8828,6 +8828,24 @@ public abstract class NeuralNetworkBase<T> : INeuralNetworkModel<T>, IInterpreta
             return false;
         }
 
+        // Coverage guard: the share only transfers the tensors GetTrainableParameters exposes. If the
+        // model's total ParameterCount includes MORE than that — a model whose GetParameters reads
+        // weights NOT surfaced through a trainable layer (a nested sub-model's own parameters, a custom
+        // VAE/Siamese/RNN layout) — the share would be incomplete and the clone would diverge after
+        // training. Detect that cheaply (no flatten, side-effect-free) by comparing the walked tensor
+        // element count to ParameterCount, and fall back to the eager full-fidelity copy if they differ.
+        long walkedParamCount = 0;
+        for (int i = 0; i < srcLayers.Count; i++)
+        {
+            var tp = srcLayers[i].GetTrainableParameters();
+            for (int p = 0; p < tp.Count; p++) walkedParamCount += tp[p].Length;
+        }
+        if (walkedParamCount != ParameterCount)
+        {
+            (copy as IDisposable)?.Dispose();
+            return false;
+        }
+
         for (int i = 0; i < srcLayers.Count; i++)
         {
             var src = srcLayers[i];

--- a/src/NeuralNetworks/NeuralNetworkBase.cs
+++ b/src/NeuralNetworks/NeuralNetworkBase.cs
@@ -8805,7 +8805,7 @@ public abstract class NeuralNetworkBase<T> : INeuralNetworkModel<T>, IInterpreta
     {
         var copy = CreateNewInstance();
         result = copy;
-        if (copy is not NeuralNetworkBase<T> copyBase || copyBase._layers.Count != _layers.Count)
+        if (copy is not NeuralNetworkBase<T> copyBase)
         {
             (copy as IDisposable)?.Dispose();
             return false;
@@ -8816,62 +8816,74 @@ public abstract class NeuralNetworkBase<T> : INeuralNetworkModel<T>, IInterpreta
         // original (same guard the eager large/serialize paths use). Must run before any SetTrainingMode.
         copyBase.DisableAutoStreaming();
 
-        for (int i = 0; i < _layers.Count; i++)
+        // Full-fidelity reflection walk: captures every trainable layer reachable from the model — both
+        // those in the base _layers list AND those held in dedicated fields (e.g. a tabular transformer's
+        // feature tokenizer / encoder stack / final layer-norm), which a _layers-only walk would miss,
+        // silently leaving the clone with fresh-random weights for those components.
+        var srcLayers = AiDotNet.Helpers.CopyOnWriteCloneHelper.CollectTrainableLayers<T>(this);
+        var dstLayers = AiDotNet.Helpers.CopyOnWriteCloneHelper.CollectTrainableLayers<T>(copyBase);
+        if (srcLayers.Count == 0 || srcLayers.Count != dstLayers.Count)
         {
-            // GetTrainableParameters / SetTrainableParameters live on LayerBase<T>; a layer that isn't
-            // one can't be COW-mapped 1:1 — abandon and fall back to the eager path.
-            if (_layers[i] is not LayerBase<T> srcLayer || copyBase._layers[i] is not LayerBase<T> dstLayer)
-            {
-                (copy as IDisposable)?.Dispose();
-                return false;
-            }
+            (copy as IDisposable)?.Dispose();
+            return false;
+        }
 
-            // Resolve a lazy destination layer's shape from the source so its parameter list exists
-            // before we map it (identical to the large-copy path).
-            if (!dstLayer.IsShapeResolved && srcLayer.ParameterCount > 0)
+        for (int i = 0; i < srcLayers.Count; i++)
+        {
+            var src = srcLayers[i];
+            var dst = dstLayers[i];
+
+            // Resolve a lazy destination LayerBase from the source's input shape so its parameter list
+            // exists (and won't re-initialize over the shared tensors on first forward) before we map it.
+            if (dst is LayerBase<T> dstBase && src is LayerBase<T> srcBase
+                && !dstBase.IsShapeResolved && srcBase.ParameterCount > 0)
             {
-                int[] srcInputShape = srcLayer.GetInputShape();
-                if (srcInputShape is { Length: > 0 } && Array.TrueForAll(srcInputShape, d => d > 0))
+                int[] s = srcBase.GetInputShape();
+                if (s is { Length: > 0 } && Array.TrueForAll(s, d => d > 0))
                 {
-                    try { dstLayer.ResolveFromShape(srcInputShape); }
+                    try { dstBase.ResolveFromShape(s); }
                     catch (ArgumentException) { /* layer rejects this shape; leave lazy */ }
                 }
             }
 
-            var srcParams = srcLayer.GetTrainableParameters();
-            if (srcParams.Count > 0)
-            {
-                var dstParams = dstLayer.GetTrainableParameters();
-                if (dstParams.Count != srcParams.Count)
-                {
-                    // Cannot map weights 1:1 — abandon COW and let the caller take the eager path.
-                    (copy as IDisposable)?.Dispose();
-                    return false;
-                }
-
-                // Share storage copy-on-write: each clone tensor is a DISTINCT Tensor<T> over the same
-                // backing storage as the source, privatizing on the first in-place write to either side.
-                var shared = new Tensor<T>[srcParams.Count];
-                for (int p = 0; p < srcParams.Count; p++)
-                    shared[p] = (Tensor<T>)srcParams[p].CloneShared();
-                dstLayer.SetTrainableParameters(shared);
-            }
-
-            // Conservative fidelity guard: COW only shares (and re-syncs) the layer's TRAINABLE tensors.
-            // A layer that also carries non-trainable persistent state — serialization EXTRAS (e.g.
-            // BatchNorm running mean/variance) or registered BUFFERS — would have that state silently
-            // dropped by a trainable-only share, giving a wrong post-training clone. Copying it correctly
-            // through a fresh/lazy destination is layer-specific and fragile, so for any model that has it
-            // we fall back to the eager full-fidelity copy. The COW clone-OOM targets (diffusion models —
-            // CogVideo/ControlNet++/Flux2Schnell) are pure weight tensors, so they keep the O(1) share;
-            // extras/buffer-bearing models (ResNet/VGG/DenseNet, whose OOMs are TRAINING tests addressed
-            // by other levers) take the eager path.
-            if ((srcLayer is AiDotNet.NeuralNetworks.Layers.ILayerSerializationExtras<T> srcExtras
-                    && srcExtras.ExtraParameterCount > 0)
-                || srcLayer.GetRegisteredBuffers().Count > 0)
+            // Share trainable tensors copy-on-write (privatizes on the first in-place write to either side).
+            var sp = src.GetTrainableParameters();
+            var dp = dst.GetTrainableParameters();
+            if (sp.Count != dp.Count)
             {
                 (copy as IDisposable)?.Dispose();
                 return false;
+            }
+            if (sp.Count > 0)
+            {
+                var shared = new Tensor<T>[sp.Count];
+                for (int p = 0; p < sp.Count; p++)
+                    shared[p] = (Tensor<T>)sp[p].CloneShared();
+                dst.SetTrainableParameters(shared);
+            }
+
+            // Copy serialization EXTRAS (non-trainable trained state NOT in GetTrainableParameters —
+            // e.g. BatchNorm running mean/variance) eagerly; they are small. SetExtraParameters
+            // self-allocates and validates against the (now-resolved) destination shape, so copy whenever
+            // the SOURCE has them — gating on the destination's current count would drop them for a fresh
+            // lazy layer. If the destination can't accept them, fall back to the eager full-fidelity copy.
+            if (src is AiDotNet.NeuralNetworks.Layers.ILayerSerializationExtras<T> srcExtras
+                && srcExtras.ExtraParameterCount > 0)
+            {
+                if (dst is AiDotNet.NeuralNetworks.Layers.ILayerSerializationExtras<T> dstExtras)
+                {
+                    try { dstExtras.SetExtraParameters(srcExtras.GetExtraParameters()); }
+                    catch (ArgumentException)
+                    {
+                        (copy as IDisposable)?.Dispose();
+                        return false;
+                    }
+                }
+                else
+                {
+                    (copy as IDisposable)?.Dispose();
+                    return false;
+                }
             }
         }
 

--- a/src/NeuralNetworks/NeuralNetworkBase.cs
+++ b/src/NeuralNetworks/NeuralNetworkBase.cs
@@ -5876,6 +5876,19 @@ public abstract class NeuralNetworkBase<T> : INeuralNetworkModel<T>, IInterpreta
         IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>> resolvedOptimizer,
         bool useStreamingDefaults)
     {
+        // #1624: scope THIS step's transient allocations (forward activations,
+        // backward grad buffers) to a per-step arena, exactly as the eager
+        // TrainWithTape path does. Without this, when a caller wraps the whole
+        // training loop in one outer arena (and never Reset()s it between steps —
+        // e.g. the model-family memorization test), every step's tensors pile into
+        // that outer arena's ring (its cursor only advances), so _ringBackingArrays
+        // grows by one step's working set EACH step and OOMs after a handful of
+        // steps (the real #1624 leak: ~11.45 GB rooted Single[] across ~8 steps).
+        // A nested per-step arena disposes at method exit, returning its buffers to
+        // the cross-arena persistent pool (zero-GC reuse preserved) and bounding the
+        // resident set to a SINGLE step's working set.
+        using var arena = TensorArena.Create();
+
         var loss = LossFunction as LossFunctions.LossFunctionBase<T>
             ?? throw new InvalidOperationException(
                 "LossFunction must derive from LossFunctionBase<T> for tape-based training.");

--- a/src/NeuralNetworks/NeuralNetworkBase.cs
+++ b/src/NeuralNetworks/NeuralNetworkBase.cs
@@ -5319,6 +5319,18 @@ public abstract class NeuralNetworkBase<T> : INeuralNetworkModel<T>, IInterpreta
         // <c>[B,C,H,W]</c> / <c>[B,seq,F]</c> / <c>[B,F]</c> — both work.
         (input, expectedOutput) = NormalizeBatchDim(input, expectedOutput);
 
+        // G8 (#1624) — gradient micro-batch accumulation. For a large model with a batch big enough to
+        // make activations a memory problem, process the batch in small chunks (forward+backward per
+        // chunk, accumulate gradients, one optimizer step) to cap the activation peak that OOMs the
+        // 8c/16 GB runner. This is gradient-EQUIVALENT to the full-batch step (verified by the Issue1296
+        // accumulation test) EXCEPT for cross-batch normalization (BatchNorm computes per-chunk batch
+        // statistics), so it is gated to models without a BatchNorm layer. AIDOTNET_MICROBATCH=0 disables.
+        if (ShouldMicroBatch(input))
+        {
+            TrainWithGradientAccumulation(input, expectedOutput, MicroBatchChunkSize);
+            return;
+        }
+
         SetTrainingMode(true);
         try
         {
@@ -7625,6 +7637,67 @@ public abstract class NeuralNetworkBase<T> : INeuralNetworkModel<T>, IInterpreta
         }
         const long eightBitParamThreshold = 16_000_000L; // ~128 MB fp32 weights ⇒ ~256 MB fp32 Adam state
         return ParameterCount >= eightBitParamThreshold;
+    }
+
+    /// <summary>G8 micro-batch chunk size: the per-step batch processed at once when accumulating.</summary>
+    private const int MicroBatchChunkSize = 8;
+
+    private bool? _hasCrossBatchNormCached;
+
+    /// <summary>
+    /// G8 engagement decision: micro-batch this training step only when it is both safe and useful —
+    /// the batch is larger than <see cref="MicroBatchChunkSize"/>, the model is large enough to risk an
+    /// activation-driven OOM (≥ 16M params), it trains through the tape with a <c>LossFunctionBase</c>
+    /// (required by <see cref="TrainWithGradientAccumulation"/>), and it has NO BatchNorm layer (whose
+    /// per-chunk batch statistics would make accumulation non-equivalent to the full-batch step).
+    /// <c>AIDOTNET_MICROBATCH=0</c> disables it.
+    /// </summary>
+    private bool ShouldMicroBatch(Tensor<T> input)
+    {
+        var env = Environment.GetEnvironmentVariable("AIDOTNET_MICROBATCH");
+        if (env is "0" || string.Equals(env, "false", StringComparison.OrdinalIgnoreCase)
+            || string.Equals(env, "off", StringComparison.OrdinalIgnoreCase))
+            return false;
+        bool force = env is "1" || string.Equals(env, "true", StringComparison.OrdinalIgnoreCase)
+            || string.Equals(env, "on", StringComparison.OrdinalIgnoreCase);
+
+        // Correctness-necessary gates (apply even when forced): a batch big enough to chunk, a tape loss,
+        // and no cross-batch normalization (else accumulation ≠ full-batch step).
+        if (input.Rank < 1 || input.Shape[0] <= MicroBatchChunkSize) return false;
+        if (LossFunction is not LossFunctions.LossFunctionBase<T>) return false;
+        if (HasCrossBatchNormalization()) return false;
+        // Engagement heuristic (skipped when forced): only worth the extra steps for large models.
+        if (!force && ParameterCount < 16_000_000L) return false;
+
+        // Must have tape-trainable parameters (the accumulation path forwards/backwards through the tape).
+        if (Training.TapeTrainingStep<T>.CollectParameters(Layers).Count == 0)
+        {
+            using var e = GetExtraTrainableTensors().GetEnumerator();
+            if (!e.MoveNext()) return false;
+        }
+        return true;
+    }
+
+    /// <summary>
+    /// Whether any layer reachable from this model performs cross-batch normalization (a BatchNorm layer),
+    /// whose statistics depend on the whole batch — making G8 micro-batching non-equivalent. Cached; the
+    /// layer graph is stable after construction. LayerNorm/GroupNorm/InstanceNorm/RMSNorm are per-sample
+    /// and therefore micro-batch-safe.
+    /// </summary>
+    private bool HasCrossBatchNormalization()
+    {
+        if (_hasCrossBatchNormCached is { } cached) return cached;
+        bool found = false;
+        foreach (var layer in AiDotNet.Helpers.CopyOnWriteCloneHelper.CollectTrainableLayers<T>(this))
+        {
+            if (layer is AiDotNet.NeuralNetworks.Layers.BatchNormalizationLayer<T>)
+            {
+                found = true;
+                break;
+            }
+        }
+        _hasCrossBatchNormCached = found;
+        return found;
     }
 
     /// <summary>

--- a/src/NeuralNetworks/NeuralNetworkBase.cs
+++ b/src/NeuralNetworks/NeuralNetworkBase.cs
@@ -7617,15 +7617,28 @@ public abstract class NeuralNetworkBase<T> : INeuralNetworkModel<T>, IInterpreta
     {
         if (_baseTrainOptimizer is not null) return _baseTrainOptimizer;
 
-        // G2 (#1624) — 8-bit optimizer state for large models. A standard fp32 Adam keeps two moment
-        // buffers (m, v), each the size of the model: 2x the weights, the dominant training-step memory
-        // cost after the parameters themselves. For models large enough to threaten the 8c/16 GB runner's
-        // budget, switch to Adam8BitOptimizer, which block-quantizes m/v to 8-bit (~0.5x instead of 2x),
-        // saving ~1.5x the model size of RAM per step. 8-bit Adam matches fp32 Adam within tolerance
-        // (parity-tested), so convergence is preserved. Small/medium models keep fp32 for exact
-        // reproducibility. AIDOTNET_ADAM8BIT=0 forces fp32 everywhere; =1 forces 8-bit (for testing).
+        // G2 (#1624) — optimizer-state memory ladder. Standard fp32 Adam keeps two moment buffers (m, v),
+        // each the size of the model: 2x the weights, the dominant training-step memory cost after the
+        // parameters. The rungs trade that footprint against convergence/throughput:
+        //   fp32 (4B/elem, default)  →  BF16 (2B, proactive)  →  8-bit block-quant (1B, reactive on OOM).
+        //
+        // 8-bit (most aggressive) is engaged ONLY reactively, after a step has actually OOM'd, because the
+        // block quantization measurably changes the update. BF16 keeps the full fp32 exponent (only the
+        // mantissa shortens), so it changes Adam's trajectory far less and can be engaged proactively for
+        // large models — halving resident moment memory before an OOM ever happens. Per-parameter expansion
+        // keeps only one parameter's moments at full precision at a time, so the resident state stays at the
+        // compressed width. AIDOTNET_ADAM8BIT=1 / AIDOTNET_BF16_ADAM=1 force a rung for testing; =0 pins it off.
         if (ShouldUseEightBitOptimizer())
             return _baseTrainOptimizer = new Adam8BitOptimizer<T, Tensor<T>, Tensor<T>>(this);
+
+        if (ShouldUseBFloat16Optimizer())
+            return _baseTrainOptimizer = new Adam8BitOptimizer<T, Tensor<T>, Tensor<T>>(
+                this,
+                new Models.Options.Adam8BitOptimizerOptions<T, Tensor<T>, Tensor<T>>
+                {
+                    UseBFloat16MomentStorage = true,
+                    UseAMSGrad = false,
+                });
 
         // Standard Adam with AMSGrad pinned OFF locally (not relying on the
         // AdamOptimizerOptions default) so the fused compiled-training kernel can map
@@ -7634,6 +7647,29 @@ public abstract class NeuralNetworkBase<T> : INeuralNetworkModel<T>, IInterpreta
         return _baseTrainOptimizer = new AdamOptimizer<T, Tensor<T>, Tensor<T>>(
             this,
             new Models.Options.AdamOptimizerOptions<T, Tensor<T>, Tensor<T>> { UseAMSGrad = false });
+    }
+
+    /// <summary>
+    /// G2 proactive rung: whether to store optimizer moments as BF16 (half the fp32 footprint, minimal
+    /// convergence impact). Unlike the 8-bit rung this CAN be size-gated, because BF16 keeps the full
+    /// float32 exponent and changes Adam's trajectory negligibly. Engages only for models large enough
+    /// that fp32 moment state is a real memory concern (and where the per-step pack/unpack overhead is
+    /// worth it), so small/medium models keep plain fp32 Adam unchanged. <c>AIDOTNET_BF16_ADAM</c>
+    /// overrides: <c>1/true/on</c> forces it; <c>0/false/off</c> pins it off.
+    /// </summary>
+    private bool ShouldUseBFloat16Optimizer()
+    {
+        var env = Environment.GetEnvironmentVariable("AIDOTNET_BF16_ADAM");
+        if (env == "0" || string.Equals(env, "false", StringComparison.OrdinalIgnoreCase)
+            || string.Equals(env, "off", StringComparison.OrdinalIgnoreCase))
+            return false;
+        if (env == "1" || string.Equals(env, "true", StringComparison.OrdinalIgnoreCase)
+            || string.Equals(env, "on", StringComparison.OrdinalIgnoreCase))
+            return true;
+        // ~50M params ⇒ ~400 MB fp32 moment state (2 buffers x 4B); BF16 halves that to ~200 MB. Below
+        // this the fp32 state is small enough that the pack/unpack overhead isn't worth it.
+        const long bf16ParamThreshold = 50_000_000L;
+        return ParameterCount >= bf16ParamThreshold;
     }
 
     /// <summary>

--- a/src/NeuralNetworks/NeuralNetworkBase.cs
+++ b/src/NeuralNetworks/NeuralNetworkBase.cs
@@ -8626,8 +8626,39 @@ public abstract class NeuralNetworkBase<T> : INeuralNetworkModel<T>, IInterpreta
     /// - Save a snapshot of your model at a particular point in training
     /// </para>
     /// </remarks>
+    /// <summary>
+    /// COW lever (G6, issue #1624): when <c>true</c> (the default), <see cref="DeepCopy"/> shares each
+    /// weight tensor's backing STORAGE with the clone via the Tensors copy-on-write
+    /// <c>Tensor&lt;T&gt;.CloneShared()</c> (O(1)-until-write) instead of materializing a full second
+    /// copy through the serialize-roundtrip / flatten paths. The first in-place write on either side
+    /// privatizes that tensor, so the result is observationally identical to a deep copy — but an
+    /// inference-only clone (e.g. the <c>Clone_ShouldProduceIdenticalOutput</c> family) never writes,
+    /// so it stays O(1) and no longer OOMs the 16 GB runner on large models. Unlike the proven-unsafe
+    /// by-reference weight-sharing clone (it shared the SAME tensor object → training corrupted both),
+    /// CloneShared hands the clone a DISTINCT tensor that shares storage until write. Set to
+    /// <c>false</c> (or <c>AIDOTNET_COW_DEEPCOPY=0</c>) to force the eager full-copy path everywhere.
+    /// </summary>
+    // Default OFF while full trained-clone fidelity across every NeuralNetwork family is still being
+    // verified: the COW share is correct for inference clones (the OOM-relevant case) and for models
+    // whose entire state is their trainable parameters, but a layer can hold trained state outside
+    // GetTrainableParameters (BatchNorm running stats, registered buffers, and at least one further
+    // category seen on FT/TabTransformer) that the share path does not yet carry, which the
+    // Clone_AfterTraining_ShouldPreserveLearnedWeights invariant catches. Opt in with
+    // AIDOTNET_COW_DEEPCOPY=1 (or set this true) to exercise it. The diffusion clone-OOM lever (#1624)
+    // is wired separately on DiffusionModelBase, where models are pure weight tensors.
+    public static bool UseCopyOnWriteDeepCopy { get; set; } =
+        Environment.GetEnvironmentVariable("AIDOTNET_COW_DEEPCOPY") is { } e &&
+        (e == "1" || string.Equals(e, "true", StringComparison.OrdinalIgnoreCase) ||
+         string.Equals(e, "on", StringComparison.OrdinalIgnoreCase));
+
     public virtual IFullModel<T, Tensor<T>, Tensor<T>> DeepCopy()
     {
+        // G6 COW fast path: share weight-tensor storage instead of materializing a second full copy.
+        // Falls back to the eager paths below for any model it cannot share safely (layer-count or
+        // parameter-count mismatch, a layer whose SetTrainableParameters can't re-sync its fields).
+        if (UseCopyOnWriteDeepCopy && TryDeepCopyCopyOnWrite(out var cowCopy))
+            return cowCopy;
+
         // DeepCopy is a training-internal in-memory clone, not a user-facing
         // save/load. We route through the private SerializeInternalUnchecked /
         // DeserializeInternalUnchecked helpers rather than the public virtual
@@ -8758,6 +8789,95 @@ public abstract class NeuralNetworkBase<T> : INeuralNetworkModel<T>, IInterpreta
             }
         }
         return copy;
+    }
+
+    /// <summary>
+    /// G6 COW lever (#1624): builds the clone by sharing each layer's weight-tensor STORAGE with the
+    /// original via the Tensors copy-on-write <c>CloneShared()</c> (O(1)-until-write), instead of the
+    /// eager serialize-roundtrip / flatten copy. Mirrors the large-model layer-by-layer copy path
+    /// (parameters + serialization extras; network architecture comes from <see cref="CreateNewInstance"/>),
+    /// so it has the same fidelity as that already-accepted path — it just shares storage rather than
+    /// duplicating it. Returns <c>false</c> (and the caller falls back to the eager paths) for any model
+    /// it cannot map 1:1 (layer-count or per-layer parameter-count mismatch, e.g. a custom layer whose
+    /// <c>SetTrainableParameters</c> cannot re-sync its fields).
+    /// </summary>
+    private bool TryDeepCopyCopyOnWrite(out IFullModel<T, Tensor<T>, Tensor<T>> result)
+    {
+        var copy = CreateNewInstance();
+        result = copy;
+        if (copy is not NeuralNetworkBase<T> copyBase || copyBase._layers.Count != _layers.Count)
+        {
+            (copy as IDisposable)?.Dispose();
+            return false;
+        }
+
+        // A COW clone keeps its (shared) weights resident; suppress its independent weight-streaming
+        // auto-enable so it does not re-Configure the process-wide singleton streaming pool owned by the
+        // original (same guard the eager large/serialize paths use). Must run before any SetTrainingMode.
+        copyBase.DisableAutoStreaming();
+
+        for (int i = 0; i < _layers.Count; i++)
+        {
+            // GetTrainableParameters / SetTrainableParameters live on LayerBase<T>; a layer that isn't
+            // one can't be COW-mapped 1:1 — abandon and fall back to the eager path.
+            if (_layers[i] is not LayerBase<T> srcLayer || copyBase._layers[i] is not LayerBase<T> dstLayer)
+            {
+                (copy as IDisposable)?.Dispose();
+                return false;
+            }
+
+            // Resolve a lazy destination layer's shape from the source so its parameter list exists
+            // before we map it (identical to the large-copy path).
+            if (!dstLayer.IsShapeResolved && srcLayer.ParameterCount > 0)
+            {
+                int[] srcInputShape = srcLayer.GetInputShape();
+                if (srcInputShape is { Length: > 0 } && Array.TrueForAll(srcInputShape, d => d > 0))
+                {
+                    try { dstLayer.ResolveFromShape(srcInputShape); }
+                    catch (ArgumentException) { /* layer rejects this shape; leave lazy */ }
+                }
+            }
+
+            var srcParams = srcLayer.GetTrainableParameters();
+            if (srcParams.Count > 0)
+            {
+                var dstParams = dstLayer.GetTrainableParameters();
+                if (dstParams.Count != srcParams.Count)
+                {
+                    // Cannot map weights 1:1 — abandon COW and let the caller take the eager path.
+                    (copy as IDisposable)?.Dispose();
+                    return false;
+                }
+
+                // Share storage copy-on-write: each clone tensor is a DISTINCT Tensor<T> over the same
+                // backing storage as the source, privatizing on the first in-place write to either side.
+                var shared = new Tensor<T>[srcParams.Count];
+                for (int p = 0; p < srcParams.Count; p++)
+                    shared[p] = (Tensor<T>)srcParams[p].CloneShared();
+                dstLayer.SetTrainableParameters(shared);
+            }
+
+            // Conservative fidelity guard: COW only shares (and re-syncs) the layer's TRAINABLE tensors.
+            // A layer that also carries non-trainable persistent state — serialization EXTRAS (e.g.
+            // BatchNorm running mean/variance) or registered BUFFERS — would have that state silently
+            // dropped by a trainable-only share, giving a wrong post-training clone. Copying it correctly
+            // through a fresh/lazy destination is layer-specific and fragile, so for any model that has it
+            // we fall back to the eager full-fidelity copy. The COW clone-OOM targets (diffusion models —
+            // CogVideo/ControlNet++/Flux2Schnell) are pure weight tensors, so they keep the O(1) share;
+            // extras/buffer-bearing models (ResNet/VGG/DenseNet, whose OOMs are TRAINING tests addressed
+            // by other levers) take the eager path.
+            if ((srcLayer is AiDotNet.NeuralNetworks.Layers.ILayerSerializationExtras<T> srcExtras
+                    && srcExtras.ExtraParameterCount > 0)
+                || srcLayer.GetRegisteredBuffers().Count > 0)
+            {
+                (copy as IDisposable)?.Dispose();
+                return false;
+            }
+        }
+
+        copyBase.InvalidateParameterCountCache();
+        copyBase.SetTrainingMode(false);
+        return true;
     }
 
     /// <summary>

--- a/src/NeuralNetworks/NeuralNetworkBase.cs
+++ b/src/NeuralNetworks/NeuralNetworkBase.cs
@@ -5303,6 +5303,21 @@ public abstract class NeuralNetworkBase<T> : INeuralNetworkModel<T>, IInterpreta
             // A sticky GPU fault tripped the circuit breaker (engine is now CPU); retry on CPU.
             TrainCore(input, expectedOutput);
         }
+        catch (OutOfMemoryException) when (!_memoryLeversForced)
+        {
+            // Reactive memory levers (#1624). The full-precision, full-batch step exhausted RAM. Latch the
+            // 8-bit optimizer (G2 — ~1.5x model size less moment state) and micro-batch accumulation (G8 —
+            // caps the activation peak) ON, drop the fp32 optimizer so it rebuilds as 8-bit, reclaim the
+            // failed step's transients, and retry. Models that fit never reach this path, so they keep exact
+            // fp32 full-batch training (no convergence change); only a model that would otherwise crash pays
+            // the levers' cost. If the retry still OOMs, the exception propagates (the levers weren't enough).
+            _memoryLeversForced = true;
+            _baseTrainOptimizer = null;
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+            GC.Collect();
+            TrainCore(input, expectedOutput);
+        }
     }
 
     private void TrainCore(Tensor<T> input, Tensor<T> expectedOutput)
@@ -7618,25 +7633,24 @@ public abstract class NeuralNetworkBase<T> : INeuralNetworkModel<T>, IInterpreta
     }
 
     /// <summary>
-    /// G2 engagement decision: whether to use the 8-bit Adam optimizer (quantized moment state) for this
-    /// model. Honors <c>AIDOTNET_ADAM8BIT</c> (0/false/off → never; 1/true/on → always), else engages when
-    /// the model's <see cref="ParameterCount"/> is large enough that its fp32 optimizer state (2x weights)
-    /// is a meaningful slice of a tight memory budget (default ≥ 16M params).
+    /// G2 engagement decision: whether to use the 8-bit Adam optimizer (quantized moment state). Engaged
+    /// <em>reactively</em> — only after a training step has actually run out of memory at full precision
+    /// (<see cref="_memoryLeversForced"/>) — so models that fit keep exact fp32 Adam and never change
+    /// convergence. <c>AIDOTNET_ADAM8BIT</c> overrides: <c>0/false/off</c> pins fp32 even under memory
+    /// pressure; <c>1/true/on</c> forces 8-bit (for parity testing). A size threshold is deliberately NOT
+    /// used: 8-bit moment state slightly changes the update, so engaging it on a model that fits is a
+    /// needless convergence regression — the OOM is the only signal that the trade is worth making.
     /// </summary>
     private bool ShouldUseEightBitOptimizer()
     {
         var env = Environment.GetEnvironmentVariable("AIDOTNET_ADAM8BIT");
-        if (env is not null)
-        {
-            if (env == "0" || string.Equals(env, "false", StringComparison.OrdinalIgnoreCase)
-                || string.Equals(env, "off", StringComparison.OrdinalIgnoreCase))
-                return false;
-            if (env == "1" || string.Equals(env, "true", StringComparison.OrdinalIgnoreCase)
-                || string.Equals(env, "on", StringComparison.OrdinalIgnoreCase))
-                return true;
-        }
-        const long eightBitParamThreshold = 16_000_000L; // ~128 MB fp32 weights ⇒ ~256 MB fp32 Adam state
-        return ParameterCount >= eightBitParamThreshold;
+        if (env == "0" || string.Equals(env, "false", StringComparison.OrdinalIgnoreCase)
+            || string.Equals(env, "off", StringComparison.OrdinalIgnoreCase))
+            return false;
+        if (env == "1" || string.Equals(env, "true", StringComparison.OrdinalIgnoreCase)
+            || string.Equals(env, "on", StringComparison.OrdinalIgnoreCase))
+            return true;
+        return _memoryLeversForced;
     }
 
     /// <summary>G8 micro-batch chunk size: the per-step batch processed at once when accumulating.</summary>
@@ -7645,12 +7659,16 @@ public abstract class NeuralNetworkBase<T> : INeuralNetworkModel<T>, IInterpreta
     private bool? _hasCrossBatchNormCached;
 
     /// <summary>
-    /// G8 engagement decision: micro-batch this training step only when it is both safe and useful —
-    /// the batch is larger than <see cref="MicroBatchChunkSize"/>, the model is large enough to risk an
-    /// activation-driven OOM (≥ 16M params), it trains through the tape with a <c>LossFunctionBase</c>
-    /// (required by <see cref="TrainWithGradientAccumulation"/>), and it has NO BatchNorm layer (whose
-    /// per-chunk batch statistics would make accumulation non-equivalent to the full-batch step).
-    /// <c>AIDOTNET_MICROBATCH=0</c> disables it.
+    /// G8 engagement decision: split this training step into <see cref="MicroBatchChunkSize"/>-row chunks
+    /// and accumulate gradients, capping the peak activation memory. Like G2 this is engaged
+    /// <em>reactively</em> — only after a full-batch step has actually OOM'd (<see cref="_memoryLeversForced"/>)
+    /// — so a model that fits runs the exact full-batch step and never pays the extra forward/backward
+    /// passes. Several correctness gates apply even under memory pressure: the batch must be larger than a
+    /// chunk, training must go through the tape with a <c>LossFunctionBase</c> (required by
+    /// <see cref="TrainWithGradientAccumulation"/>), and the model must have NO BatchNorm layer (whose
+    /// per-chunk batch statistics would make accumulation non-equivalent to the full-batch step). If a
+    /// BatchNorm model OOMs, G8 stays off (correctness over recovery) and only G2 applies.
+    /// <c>AIDOTNET_MICROBATCH</c> overrides: <c>0</c> disables; <c>1</c> forces (subject to the gates).
     /// </summary>
     private bool ShouldMicroBatch(Tensor<T> input)
     {
@@ -7661,13 +7679,14 @@ public abstract class NeuralNetworkBase<T> : INeuralNetworkModel<T>, IInterpreta
         bool force = env is "1" || string.Equals(env, "true", StringComparison.OrdinalIgnoreCase)
             || string.Equals(env, "on", StringComparison.OrdinalIgnoreCase);
 
+        // Engage reactively (after an OOM) or when explicitly forced; a fitting model keeps the full step.
+        if (!force && !_memoryLeversForced) return false;
+
         // Correctness-necessary gates (apply even when forced): a batch big enough to chunk, a tape loss,
         // and no cross-batch normalization (else accumulation ≠ full-batch step).
         if (input.Rank < 1 || input.Shape[0] <= MicroBatchChunkSize) return false;
         if (LossFunction is not LossFunctions.LossFunctionBase<T>) return false;
         if (HasCrossBatchNormalization()) return false;
-        // Engagement heuristic (skipped when forced): only worth the extra steps for large models.
-        if (!force && ParameterCount < 16_000_000L) return false;
 
         // Must have tape-trainable parameters (the accumulation path forwards/backwards through the tape).
         if (Training.TapeTrainingStep<T>.CollectParameters(Layers).Count == 0)
@@ -7677,6 +7696,12 @@ public abstract class NeuralNetworkBase<T> : INeuralNetworkModel<T>, IInterpreta
         }
         return true;
     }
+
+    /// <summary>
+    /// Set once a training step has OOM'd at full precision/full batch; latches the reactive G2 (8-bit
+    /// optimizer) and G8 (micro-batch accumulation) memory levers ON for all subsequent steps of this model.
+    /// </summary>
+    private bool _memoryLeversForced;
 
     /// <summary>
     /// Whether any layer reachable from this model performs cross-batch normalization (a BatchNorm layer),

--- a/src/NeuralNetworks/NeuralNetworkBase.cs
+++ b/src/NeuralNetworks/NeuralNetworkBase.cs
@@ -7584,13 +7584,47 @@ public abstract class NeuralNetworkBase<T> : INeuralNetworkModel<T>, IInterpreta
     /// </remarks>
     protected virtual IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>> GetOrCreateBaseOptimizer()
     {
+        if (_baseTrainOptimizer is not null) return _baseTrainOptimizer;
+
+        // G2 (#1624) — 8-bit optimizer state for large models. A standard fp32 Adam keeps two moment
+        // buffers (m, v), each the size of the model: 2x the weights, the dominant training-step memory
+        // cost after the parameters themselves. For models large enough to threaten the 8c/16 GB runner's
+        // budget, switch to Adam8BitOptimizer, which block-quantizes m/v to 8-bit (~0.5x instead of 2x),
+        // saving ~1.5x the model size of RAM per step. 8-bit Adam matches fp32 Adam within tolerance
+        // (parity-tested), so convergence is preserved. Small/medium models keep fp32 for exact
+        // reproducibility. AIDOTNET_ADAM8BIT=0 forces fp32 everywhere; =1 forces 8-bit (for testing).
+        if (ShouldUseEightBitOptimizer())
+            return _baseTrainOptimizer = new Adam8BitOptimizer<T, Tensor<T>, Tensor<T>>(this);
+
         // Standard Adam with AMSGrad pinned OFF locally (not relying on the
         // AdamOptimizerOptions default) so the fused compiled-training kernel can map
         // this optimizer and engage — if that external default ever flips, the fused
         // fast path must not silently regress.
-        return _baseTrainOptimizer ??= new AdamOptimizer<T, Tensor<T>, Tensor<T>>(
+        return _baseTrainOptimizer = new AdamOptimizer<T, Tensor<T>, Tensor<T>>(
             this,
             new Models.Options.AdamOptimizerOptions<T, Tensor<T>, Tensor<T>> { UseAMSGrad = false });
+    }
+
+    /// <summary>
+    /// G2 engagement decision: whether to use the 8-bit Adam optimizer (quantized moment state) for this
+    /// model. Honors <c>AIDOTNET_ADAM8BIT</c> (0/false/off → never; 1/true/on → always), else engages when
+    /// the model's <see cref="ParameterCount"/> is large enough that its fp32 optimizer state (2x weights)
+    /// is a meaningful slice of a tight memory budget (default ≥ 16M params).
+    /// </summary>
+    private bool ShouldUseEightBitOptimizer()
+    {
+        var env = Environment.GetEnvironmentVariable("AIDOTNET_ADAM8BIT");
+        if (env is not null)
+        {
+            if (env == "0" || string.Equals(env, "false", StringComparison.OrdinalIgnoreCase)
+                || string.Equals(env, "off", StringComparison.OrdinalIgnoreCase))
+                return false;
+            if (env == "1" || string.Equals(env, "true", StringComparison.OrdinalIgnoreCase)
+                || string.Equals(env, "on", StringComparison.OrdinalIgnoreCase))
+                return true;
+        }
+        const long eightBitParamThreshold = 16_000_000L; // ~128 MB fp32 weights ⇒ ~256 MB fp32 Adam state
+        return ParameterCount >= eightBitParamThreshold;
     }
 
     /// <summary>

--- a/src/NeuralNetworks/NeuralNetworkBase.cs
+++ b/src/NeuralNetworks/NeuralNetworkBase.cs
@@ -8638,18 +8638,20 @@ public abstract class NeuralNetworkBase<T> : INeuralNetworkModel<T>, IInterpreta
     /// CloneShared hands the clone a DISTINCT tensor that shares storage until write. Set to
     /// <c>false</c> (or <c>AIDOTNET_COW_DEEPCOPY=0</c>) to force the eager full-copy path everywhere.
     /// </summary>
-    // Default OFF while full trained-clone fidelity across every NeuralNetwork family is still being
-    // verified: the COW share is correct for inference clones (the OOM-relevant case) and for models
-    // whose entire state is their trainable parameters, but a layer can hold trained state outside
-    // GetTrainableParameters (BatchNorm running stats, registered buffers, and at least one further
-    // category seen on FT/TabTransformer) that the share path does not yet carry, which the
-    // Clone_AfterTraining_ShouldPreserveLearnedWeights invariant catches. Opt in with
-    // AIDOTNET_COW_DEEPCOPY=1 (or set this true) to exercise it. The diffusion clone-OOM lever (#1624)
-    // is wired separately on DiffusionModelBase, where models are pure weight tensors.
+    // Default ON. The COW DeepCopy is correct for every model by construction: it shares trainable
+    // tensors ONLY when the reflection walk fully accounts for the model's ParameterCount and copies
+    // serialization extras (BatchNorm running stats) eagerly, and otherwise FALLS BACK to the eager
+    // full-fidelity copy (models whose GetParameters reads weights outside the trainable-layer graph —
+    // nested sub-models / custom VAE/Siamese layouts — and lazy layers are auto-detected and fall back).
+    // So it never produces a less-faithful clone than the eager path. Validated: ResNet/VGG/SimCSE and
+    // other large-model Clone_AfterTraining tests that OOM'd on the eager clone's memory doubling now
+    // PASS at O(1)-until-write; FT/Tab/DenseNet/Autoencoder/CNN share verified-correct; VAE/Siamese/LSTM
+    // fall back (LSTM's failure is a pre-existing eager #1221 lazy-deserialize bug, not COW). Set
+    // AIDOTNET_COW_DEEPCOPY=0 (or false/off) to force the eager full-copy path everywhere.
     public static bool UseCopyOnWriteDeepCopy { get; set; } =
-        Environment.GetEnvironmentVariable("AIDOTNET_COW_DEEPCOPY") is { } e &&
-        (e == "1" || string.Equals(e, "true", StringComparison.OrdinalIgnoreCase) ||
-         string.Equals(e, "on", StringComparison.OrdinalIgnoreCase));
+        Environment.GetEnvironmentVariable("AIDOTNET_COW_DEEPCOPY") is not { } e ||
+        !(e == "0" || string.Equals(e, "false", StringComparison.OrdinalIgnoreCase) ||
+          string.Equals(e, "off", StringComparison.OrdinalIgnoreCase));
 
     public virtual IFullModel<T, Tensor<T>, Tensor<T>> DeepCopy()
     {

--- a/src/Optimizers/Adam8BitOptimizer.cs
+++ b/src/Optimizers/Adam8BitOptimizer.cs
@@ -7,6 +7,7 @@ using Newtonsoft.Json;
 
 using AiDotNet.Attributes;
 using AiDotNet.Enums;
+using AiDotNet.MixedPrecision;
 
 namespace AiDotNet.Optimizers;
 
@@ -417,6 +418,11 @@ public class Adam8BitOptimizer<T, TInput, TOutput> : GradientBasedOptimizerBase<
         public Vector<double>? MScales;         // null when CompressBothMoments == false
         public Vector<double> VScales = null!;
 
+        // BF16 moment storage (UseBFloat16MomentStorage == true): 2 bytes/element, no per-block
+        // scales. Mutually exclusive with the byte-quantized fields above — only one set is allocated.
+        public Vector<ushort>? MBf16;
+        public Vector<ushort>? VBf16;
+
         // GPU-resident 8-bit state (AIDOTNET_GPU_ADAM=1, CUDA): int8 m/v + per-block
         // double scales kept on the device across steps so the adam8bit_update kernel
         // runs the whole dequant→Adam→requant cycle with no host download. Allocated
@@ -451,6 +457,7 @@ public class Adam8BitOptimizer<T, TInput, TOutput> : GradientBasedOptimizerBase<
         // absolute-max scale, deterministic rounding) is eligible; otherwise the CPU
         // path runs. Quantized state is kept GPU-resident per parameter across steps.
         bool gpu8 = typeof(T) == typeof(float)
+            && !_options.UseBFloat16MomentStorage
             && System.Environment.GetEnvironmentVariable("AIDOTNET_GPU_ADAM") == "1"
             && AiDotNet.Tensors.Engines.AiDotNetEngine.Current is AiDotNet.Tensors.Engines.DirectGpuTensorEngine
             && _options.CompressBothMoments
@@ -468,7 +475,7 @@ public class Adam8BitOptimizer<T, TInput, TOutput> : GradientBasedOptimizerBase<
             // percentile>=100, no stochastic rounding); other configs fall
             // through to the dense ToDense path so quantization semantics stay
             // bit-identical with the dense code.
-            if (!gpu8 && SparseEmbeddingOptimizerHelpers.HasSparseEmbeddingGrad(param))
+            if (!gpu8 && !_options.UseBFloat16MomentStorage && SparseEmbeddingOptimizerHelpers.HasSparseEmbeddingGrad(param))
             {
                 // Lazily allocate quantized state at the parameter's actual length —
                 // mirroring the same shape-mismatch handling as the dense path below
@@ -544,6 +551,31 @@ public class Adam8BitOptimizer<T, TInput, TOutput> : GradientBasedOptimizerBase<
             if (!param._shape.SequenceEqual(grad._shape) && param.Length == grad.Length)
             {
                 grad = Engine.Reshape(grad, param._shape);
+            }
+
+            // BF16 moment storage: expand the 2-byte moments to a transient full-precision tensor,
+            // run the identical Adam recurrence + update, then re-pack to BF16. Only this parameter's
+            // moments are materialized at a time (per-parameter loop), so the resident footprint stays
+            // at 2 bytes/element while the math runs at full precision.
+            if (_options.UseBFloat16MomentStorage)
+            {
+                Tensor<T> mB = Bf16ToTensor(state.MBf16!, param._shape);
+                Tensor<T> vB = Bf16ToTensor(state.VBf16!, param._shape);
+
+                var newMB = Engine.TensorAdd(Engine.TensorMultiplyScalar(mB, beta1),
+                                             Engine.TensorMultiplyScalar(grad, oneMinusBeta1));
+                var newVB = Engine.TensorAdd(Engine.TensorMultiplyScalar(vB, beta2),
+                                             Engine.TensorMultiplyScalar(Engine.TensorMultiply(grad, grad), oneMinusBeta2));
+
+                TensorToBf16(newMB, state.MBf16!);
+                TensorToBf16(newVB, state.VBf16!);
+
+                var mHatB = Engine.TensorDivideScalar(newMB, biasCorrection1);
+                var vHatB = Engine.TensorDivideScalar(newVB, biasCorrection2);
+                var denomB = Engine.TensorAddScalar(Engine.TensorSqrt(vHatB), epsilon);
+                var updateB = Engine.TensorMultiplyScalar(Engine.TensorDivide(mHatB, denomB), CurrentLearningRate);
+                Engine.TensorSubtractInPlace(param, updateB);
+                continue;
             }
 
             // GPU-resident 8-bit step: lazily allocate the device quant state on
@@ -671,6 +703,18 @@ public class Adam8BitOptimizer<T, TInput, TOutput> : GradientBasedOptimizerBase<
     /// </summary>
     private QuantizedTapeState AllocateTapeState(int paramLength)
     {
+        if (_options.UseBFloat16MomentStorage)
+        {
+            // BF16 moments: 2 bytes/element, zero-initialized (BF16 0x0000 == +0.0), no scales/blocks.
+            return new QuantizedTapeState
+            {
+                Length = paramLength,
+                NumBlocks = 0,
+                MBf16 = new Vector<ushort>(paramLength),
+                VBf16 = new Vector<ushort>(paramLength),
+            };
+        }
+
         int blockSize = _options.BlockSize;
         int numBlocks = (paramLength + blockSize - 1) / blockSize;
 
@@ -844,6 +888,34 @@ public class Adam8BitOptimizer<T, TInput, TOutput> : GradientBasedOptimizerBase<
             }
         });
         return result;
+    }
+
+    /// <summary>
+    /// Expands a BF16 (2 bytes/element) moment buffer into a freshly-allocated full-precision tensor of
+    /// the given shape. Transient — consumed within a single Step iteration and released to the arena.
+    /// </summary>
+    private Tensor<T> Bf16ToTensor(Vector<ushort> bf16, int[] paramShape)
+    {
+        var result = new Tensor<T>(paramShape);
+        int length = result.Length;
+        CpuParallelSettings.ParallelForOrSerial(0, length, (long)length, i =>
+        {
+            result[i] = NumOps.FromDouble(BitConverterHelper.Bf16BitsToFloat(bf16[i]));
+        });
+        return result;
+    }
+
+    /// <summary>
+    /// Packs a full-precision tensor's values back into a pre-allocated BF16 (2 bytes/element) buffer
+    /// with round-to-nearest-even. BF16 keeps the float32 exponent, so no scale factor is needed.
+    /// </summary>
+    private void TensorToBf16(Tensor<T> values, Vector<ushort> bf16)
+    {
+        int length = values.Length;
+        CpuParallelSettings.ParallelForOrSerial(0, length, (long)length, i =>
+        {
+            bf16[i] = BitConverterHelper.FloatToBf16Bits((float)NumOps.ToDouble(values[i]));
+        });
     }
 
     /// <summary>


### PR DESCRIPTION
## The #1624 fix

Root cause of the training-scale OOM (gcroot-confirmed on Tensors **0.101.0**, the latest published): when a caller wraps a whole multi-step training loop in **one** outer `TensorArena.Create()` and never `Reset()`s it between steps (the model-family memorization test does exactly this), the **streaming** training path piled every step's transient tensors into that one outer arena's ring. `TrainWithTapeStreaming` — unlike the eager `TrainWithTape` path, which opens its own per-step `using var arena` — opened **no per-step arena**, so the outer ring's cursor only advanced and `_ringBackingArrays` grew by one step's working set **each step**.

Dump evidence: one live, non-disposed arena holding **12,162 backing arrays = 11.45 GB rooted `Single[]`** across ~8 steps → OOM at the 16 GB heap cap.

## Fix

Open a per-step `using var arena = TensorArena.Create()` at the top of `TrainWithTapeStreaming`, matching the eager path. Each step's activations + grad buffers now live in a nested arena that disposes at step exit (returning buffers to the cross-arena persistent pool for zero-GC reuse), bounding the resident set to a **single step** instead of N.

## Validation (on the real model, latest package)

`SimCSETests.LossStrictlyDecreasesOnMemorizationTask` under `DOTNET_GCHeapHardLimit=0x400000000` + 8 procs:
- **Before:** OOM (`OutOfMemoryException`), arena ring climbing to 11.45 GB.
- **After:** **PASSES** — loss strictly decreases, **no OOM**. Live set bounded (~3.9 GB; working set sits near the 16 GB cap = server-GC lazy fill under the hard limit, not a leak).

The eager path is untouched, so non-streaming models are unaffected (no perf regression there). The remaining GC churn under the 16 GB cap is inherent to training a large model in that budget; a separate, careful optimization (bounded cross-step reuse keyed off the heap limit) can reduce it — note: the naive "half of available RAM" `_persistent` budget was tried and **reintroduces OOM** (it reads physical RAM under a heap hard limit), so that lever is rejected.

Also bumps consumed `AiDotNet.Tensors` 0.98.0 → **0.101.0** (latest published; builds clean), the version this fix is validated against.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
