### PR TITLE
feat(diffusion): multi-input compiled denoising for DiT/UNet (completes #1620)

### DIFF
--- a/src/Diffusion/NoisePredictors/DiTNoisePredictor.cs
+++ b/src/Diffusion/NoisePredictors/DiTNoisePredictor.cs
@@ -490,11 +490,21 @@ public class DiTNoisePredictor<T> : NoisePredictorBase<T>
         using var streaming = BeginWeightStreamingForward();
         _lastInput = noisySample;
 
-        // Get timestep embedding
+        // Get timestep embedding (cheap MLP; computed eagerly each step so the per-step
+        // timestep stays a LIVE input the compiled plan re-binds rather than bakes).
         var timeEmbed = GetTimestepEmbedding(timestep);
         timeEmbed = ProjectTimeEmbedding(timeEmbed);
 
-        return streaming.Complete(Forward(noisySample, timeEmbed, conditioning));
+        // Compile the (expensive) DiT forward ONCE and replay it across the denoising loop,
+        // re-binding every per-step leaf — noisy sample, timestep embedding, optional
+        // conditioning — so a changing timestep is never baked (#1620 / AiDotNet.Tensors#616).
+        // Conditioning is declared as an input only when present, so an unconditional model
+        // never declares a leaf its forward doesn't read (which would fail closed to eager).
+        var inputs = conditioning is not null
+            ? new[] { noisySample, timeEmbed, conditioning }
+            : new[] { noisySample, timeEmbed };
+        return streaming.Complete(
+            PredictCompiledMulti(inputs, () => Forward(noisySample, timeEmbed, conditioning)));
     }
 
     /// <inheritdoc />
@@ -503,18 +513,18 @@ public class DiTNoisePredictor<T> : NoisePredictorBase<T>
         EnsureLayersInitialized();
         using var streaming = BeginWeightStreamingForward();
         _lastInput = noisySample;
-        // NOTE: the per-step forward is run eagerly here, NOT through PredictCompiled.
-        // The compile host re-binds only the single noisy-sample input slot and bakes
-        // every other traced leaf as a constant — including the per-step timestep
-        // embedding. Routing the denoising loop through it would reuse step 0's
-        // timeEmbedding for every step (silent denoising corruption, since compilation
-        // defaults on). Re-enable compiled replay once the compile layer supports
-        // multiple mutable inputs (re-binding timeEmbedding + conditioning each step).
-        //
-        // streaming.Complete(...) calls RegisterResolvedStreamingWeights() internally
-        // and returns the result — equivalent to the prior explicit two-line form,
-        // matching the PredictNoise path above.
-        return streaming.Complete(Forward(noisySample, timeEmbedding, conditioning));
+        // Multi-input compiled replay: every per-step leaf — noisy sample, timestep embedding,
+        // optional conditioning — is re-bound each step, so a changing timestep embedding is
+        // never baked as a constant. The single-input PredictCompiled marks only the noisy
+        // sample as mutable and bakes the rest, which would replay step 0's embedding for the
+        // whole denoising loop (silent corruption — #1620). The multi-input compile
+        // (AiDotNet.Tensors#616) compiles the expensive forward once while keeping all per-step
+        // inputs live; the verify-then-trust gate keeps the output numerically identical to eager.
+        var inputs = conditioning is not null
+            ? new[] { noisySample, timeEmbedding, conditioning }
+            : new[] { noisySample, timeEmbedding };
+        return streaming.Complete(
+            PredictCompiledMulti(inputs, () => Forward(noisySample, timeEmbedding, conditioning)));
     }
 
     /// <summary>

--- a/src/Diffusion/NoisePredictors/NoisePredictorBase.cs
+++ b/src/Diffusion/NoisePredictors/NoisePredictorBase.cs
@@ -262,6 +262,42 @@ public abstract class NoisePredictorBase<T> : INoisePredictor<T>, IModelShape, I
     }
 
     /// <summary>
+    /// Multi-input compiled replay for a forward that reads SEVERAL per-call-varying leaves —
+    /// the diffusion per-step <see cref="Forward"/> reads the noisy sample, the per-step timestep
+    /// embedding, and optional conditioning. The single-input <see cref="PredictCompiled"/> bakes
+    /// every leaf but the first as a constant, so it would replay step 0's timestep embedding for
+    /// the whole denoising loop (silent corruption); this overload marks EVERY tensor in
+    /// <paramref name="inputs"/> as a mutable slot the compiled plan re-binds each step
+    /// (AiDotNet.Tensors#616), compiling the expensive forward once while keeping the per-step
+    /// inputs live. The verify-then-trust gate still adopts the compiled plan for a shape only
+    /// after it matches eager, so output stays numerically identical to eager.
+    /// </summary>
+    /// <param name="inputs">The per-step mutable input leaves, in a stable order. Each must be a
+    /// tensor the forward reads directly; otherwise compile fails closed and this falls back to eager.</param>
+    /// <param name="eagerFallback">The eager forward pass (traced, replayed, verified, or fallback).</param>
+    protected Tensor<T> PredictCompiledMulti(Tensor<T>[] inputs, Func<Tensor<T>> eagerFallback)
+    {
+        // Direct compile host when the verify gate is opted out.
+        if (s_autoCompileDisabled)
+            return _compileHost.Predict(inputs, _layerStructureVersion, eagerFallback);
+
+        return _inferenceGate.Run(
+            inputs,
+            _layerStructureVersion,
+            eager: eagerFallback,
+            compiled: () => _compileHost.Predict(inputs, _layerStructureVersion, eagerFallback),
+            onDecision: (enabled, reason) => AiDotNet.Helpers.InferenceDiagnostics.RecordDecision(
+                area: "NoisePredictorBase", feature: "AutoCompiledMultiInputInference", enabled: enabled, reason: reason));
+    }
+
+    /// <summary>
+    /// Count of successful multi-input compiled-plan executions on this predictor's compile
+    /// host (the per-step denoising path). Test/diagnostic hook: a test can assert this grew
+    /// to confirm the compiled plan actually ran rather than silently falling back to eager.
+    /// </summary>
+    internal long CompiledMultiInputReplays => _compileHost.MultiInputReplays;
+
+    /// <summary>
     /// Async overload of <see cref="PredictCompiled"/> — routes through
     /// <see cref="CompiledModelHost{T}.PredictAsync"/> so the compiled plan's
     /// <c>ExecuteAsync</c> path is taken. CPU engines complete synchronously

--- a/src/Diffusion/NoisePredictors/UNetNoisePredictor.cs
+++ b/src/Diffusion/NoisePredictors/UNetNoisePredictor.cs
@@ -484,15 +484,6 @@ public class UNetNoisePredictor<T> : NoisePredictorBase<T>
     }
 
 
-    /// <summary>
-    /// Per-instance compile cache for the UNet forward pass. Lazy-allocated
-    /// on first <see cref="PredictNoise"/> call when
-    /// <see cref="AiDotNet.Tensors.Engines.Optimization.TensorCodecOptions.EnableCompilation"/>
-    /// is on. Keyed by noisy-sample input shape — different shapes compile
-    /// different plans. Dropped when <see cref="ResetState"/> runs.
-    /// </summary>
-    private AiDotNet.Tensors.Engines.Compilation.CompiledModelCache<T>? _compiledInferenceCache;
-
     /// <inheritdoc />
     public override Tensor<T> PredictNoise(Tensor<T> noisySample, int timestep, Tensor<T>? conditioning = null)
     {
@@ -542,19 +533,15 @@ public class UNetNoisePredictor<T> : NoisePredictorBase<T>
             var timeEmbed = GetTimestepEmbedding(sampleTimestep);
             timeEmbed = ProjectTimeEmbedding(timeEmbed);
 
-            var cache = _compiledInferenceCache ??= new AiDotNet.Tensors.Engines.Compilation.CompiledModelCache<T>();
-            // Key includes conditioning presence so null-vs-present paths
-            // don't share plans (different traced graphs).
-            var key = BuildCompileKey(sampleNoisy, conditioning);
-            var plan = cache.GetOrCompileInference(
-                key,
-                () => ForwardUNet(sampleNoisy, timeEmbed, conditioning));
-            // Execute once to validate the plan replays correctly and warm
-            // workspace buffers. Dispose the output to avoid leaking the
-            // pooled tensor allocation from the warm-up.
-            var warmupOutput = plan.Execute();
-            if (warmupOutput is IDisposable disposableOutput)
-                disposableOutput.Dispose();
+            // Warm the SAME multi-input compiled path PredictNoise replays: one gated
+            // forward at the representative shapes traces + compiles the plan and records
+            // the verify-then-trust verdict, so the first real inference skips the trace
+            // cost. Conditioning is declared as an input only when present, matching the
+            // production call's leaf set (#1620 / AiDotNet.Tensors#616 multi-input compile).
+            var inputs = conditioning is not null
+                ? new[] { sampleNoisy, timeEmbed, conditioning }
+                : new[] { sampleNoisy, timeEmbed };
+            _ = PredictCompiledMulti(inputs, () => ForwardUNet(sampleNoisy, timeEmbed, conditioning));
             return true;
         }
         catch (Exception ex) when (
@@ -576,41 +563,18 @@ public class UNetNoisePredictor<T> : NoisePredictorBase<T>
     /// </summary>
     private Tensor<T> PredictCompiledForward(Tensor<T> noisySample, Tensor<T> timeEmbed, Tensor<T>? conditioning)
     {
-        // CORRECTNESS: run eagerly. The compiled-plan cache keys on the noisy-sample
-        // shape only and the plan re-binds at most a single mutable input slot, baking
-        // every other traced leaf — including the per-step timeEmbed — as a constant.
-        // Because the denoising loop calls this at a constant shape with a changing
-        // timestep, the cached plan would replay step 0's output for every step (and
-        // compilation defaults ON). The compiled replay returns only after the compile
-        // layer supports multiple mutable inputs so timeEmbed + conditioning are
-        // re-bound each step; until then eager execution is the only correct path.
-        return ForwardUNet(noisySample, timeEmbed, conditioning);
-    }
-
-    /// <summary>
-    /// Builds a composite cache key that includes BOTH the noisy-sample
-    /// shape AND the conditioning shape (or a sentinel for null). This
-    /// prevents a plan traced with conditioning=null from being replayed
-    /// with a conditioning tensor (different graph) or vice versa.
-    /// </summary>
-    private static int[] BuildCompileKey(Tensor<T> noisySample, Tensor<T>? conditioning)
-    {
-        var inputShape = noisySample._shape;
-        if (conditioning is null)
-        {
-            // Append a single -1 sentinel so "no conditioning" has a
-            // distinct key from any real conditioning shape.
-            var key = new int[inputShape.Length + 1];
-            Array.Copy(inputShape, key, inputShape.Length);
-            key[^1] = -1;
-            return key;
-        }
-        var condShape = conditioning._shape;
-        var compositeKey = new int[inputShape.Length + 1 + condShape.Length];
-        Array.Copy(inputShape, 0, compositeKey, 0, inputShape.Length);
-        compositeKey[inputShape.Length] = -1; // separator
-        Array.Copy(condShape, 0, compositeKey, inputShape.Length + 1, condShape.Length);
-        return compositeKey;
+        // Multi-input compiled replay: mark the noisy sample, the per-step timestep
+        // embedding, and optional conditioning as mutable input slots the plan re-binds
+        // every step (AiDotNet.Tensors#616), so the changing timestep is never baked as a
+        // constant. The single-input path re-bound only the noisy sample and baked the rest,
+        // which replayed step 0's timeEmbed for the whole denoising loop (silent corruption —
+        // #1620). The expensive ForwardUNet is compiled once; the verify-then-trust gate
+        // adopts the plan for a shape only after it matches eager, so output is numerically
+        // identical to eager (rejected shapes stay eager).
+        var inputs = conditioning is not null
+            ? new[] { noisySample, timeEmbed, conditioning }
+            : new[] { noisySample, timeEmbed };
+        return PredictCompiledMulti(inputs, () => ForwardUNet(noisySample, timeEmbed, conditioning));
     }
 
     /// <inheritdoc />

--- a/src/NeuralNetworks/CompiledModelHost.cs
+++ b/src/NeuralNetworks/CompiledModelHost.cs
@@ -132,12 +132,20 @@ internal sealed class CompiledModelHost<T> : IDisposable
     /// </summary>
     private long _hotPathHits;
     private long _slowPathCalls;
+    private long _multiInputReplays;
 
     /// <summary>Hot-path replay count since this host was created. Diagnostic-only.</summary>
     public long HotPathHits => System.Threading.Interlocked.Read(ref _hotPathHits);
 
     /// <summary>Slow-path call count since this host was created. Diagnostic-only.</summary>
     public long SlowPathCalls => System.Threading.Interlocked.Read(ref _slowPathCalls);
+
+    /// <summary>
+    /// Count of successful multi-input compiled-plan executions (the diffusion per-step
+    /// denoising path) since this host was created. Diagnostic/test-only — lets a test
+    /// confirm the compiled plan actually ran rather than silently falling back to eager.
+    /// </summary>
+    public long MultiInputReplays => System.Threading.Interlocked.Read(ref _multiInputReplays);
 
     public CompiledModelHost(
         SymbolicShapeMode shapeMode = SymbolicShapeMode.BatchDynamic,
@@ -493,6 +501,157 @@ internal sealed class CompiledModelHost<T> : IDisposable
             // "last-out" check is atomic with the dispose action.
             DrainPendingDisposals();
         }
+    }
+
+    /// <summary>
+    /// Multi-input variant of <see cref="Predict(Tensor{T}, int, Func{Tensor{T}})"/>: every
+    /// tensor in <paramref name="inputs"/> is marked as a mutable input slot the compiled
+    /// plan re-binds on each replay (AiDotNet.Tensors#616). The canonical use is a diffusion
+    /// denoiser whose per-step forward reads BOTH the noisy sample AND a per-step timestep
+    /// embedding (plus optional conditioning): the single-input path bakes step 0's embedding
+    /// as a constant and replays it for every step, so those predictors route through this
+    /// overload to keep the per-step inputs live while still compiling the (expensive) forward
+    /// exactly once.
+    /// </summary>
+    /// <param name="inputs">
+    /// The mutable input leaves, in a stable order. Each must be a tensor the forward reads
+    /// directly; multi-input compile fails closed (throws) if a declared input is not a traced
+    /// leaf, and this method then falls back to eager — so a caller can never silently get a
+    /// baked input.
+    /// </param>
+    /// <param name="structureVersion">Layer-structure version; a change swaps in a fresh cache.</param>
+    /// <param name="eagerForward">The eager forward to trace once, and to fall back to.</param>
+    public Tensor<T> Predict(
+        Tensor<T>[] inputs,
+        int structureVersion,
+        Func<Tensor<T>> eagerForward)
+    {
+        if (eagerForward is null)
+            throw new ArgumentNullException(nameof(eagerForward));
+        if (inputs is null || inputs.Length == 0)
+            throw new ArgumentException("At least one input is required.", nameof(inputs));
+
+        // EAGER-ONLY ratchet: a (combined-shape, version) that previously failed to compile
+        // goes straight to eager, skipping the ~14 ms trace+throw retry. Keyed on the combined
+        // key over ALL inputs so a different secondary-input shape re-attempts compilation.
+        bool keyOk = TryComputeMultiShapeKey(inputs, out long shapeKey);
+        var eagerSnap = System.Threading.Volatile.Read(ref _eagerOnlyShapeKeys);
+        if (keyOk && eagerSnap is not null && eagerSnap.Contains((shapeKey, structureVersion)))
+            return eagerForward();
+
+        // Acquire the cache under the lock with the SAME version-swap + active-call accounting
+        // as the single-input path, then compile/replay OUTSIDE the lock. Unlike the single-
+        // input path there is no separate host-level hot-plan short-circuit: a foundation-scale
+        // denoiser's per-step forward dominates the cache dictionary lookup, and the cache's own
+        // lock-free hit path (GetOrCompileInference re-binds every input via SetInputs on a hit)
+        // already provides steady-state replay.
+        CompiledModelCache<T>? cache;
+        bool fallToEager;
+        lock (_sync)
+        {
+            fallToEager = _disposed || _disposeRequested
+                || !TensorCodecOptions.Current.EnableCompilation;
+
+            if (!fallToEager)
+            {
+                if (_cache is not null && structureVersion != _lastCompiledVersion)
+                {
+                    (_pendingDisposeCaches ??= new List<CompiledModelCache<T>>()).Add(_cache);
+                    _cache = new CompiledModelCache<T>();
+                    _lastCompiledVersion = structureVersion;
+                    _hotPlan = null;
+                    _eagerOnlyShapeKeys = null;
+                }
+                cache = _cache ??= new CompiledModelCache<T>();
+                _activeCalls++;
+            }
+            else
+            {
+                cache = null;
+            }
+        }
+
+        if (fallToEager || cache is null)
+            return eagerForward();
+
+        try
+        {
+            try
+            {
+                // Traces once (cache miss) or re-binds every input into the cached plan (cache
+                // hit) — either way the plan reflects THIS call's input data, so Execute()
+                // replays the current step. A changing timestep embedding is re-bound, never
+                // baked, which is the whole point of the multi-input path.
+                var plan = cache.GetOrCompileInference(inputs, () => eagerForward());
+                _lastCompiledVersion = structureVersion;
+                var result = plan.Execute();
+                System.Threading.Interlocked.Increment(ref _multiInputReplays);
+                return result;
+            }
+            catch (Exception ex) when (
+                // Same narrow fallback as the single-input path: tolerate compile/replay bugs,
+                // let truly-unrecoverable CLR failures propagate.
+                ex is not OutOfMemoryException &&
+                ex is not AccessViolationException &&
+                ex is not StackOverflowException &&
+                ex is not BadImageFormatException &&
+                ex is not InvalidProgramException &&
+                ex is not System.Threading.ThreadAbortException &&
+                ex is not AppDomainUnloadedException &&
+                ex is not CannotUnloadAppDomainException)
+            {
+                lock (_sync)
+                {
+                    _cache?.Invalidate();
+                    _lastCompiledVersion = -1;
+                }
+                System.Diagnostics.Trace.TraceWarning(
+                    "CompiledModelHost (multi-input) falling back to eager after compile/replay " +
+                    $"failure: {ex}");
+                if (keyOk)
+                {
+                    lock (_sync)
+                    {
+                        var current = _eagerOnlyShapeKeys;
+                        var next = current is null
+                            ? new HashSet<(long, int)>()
+                            : new HashSet<(long, int)>(current);
+                        next.Add((shapeKey, structureVersion));
+                        System.Threading.Volatile.Write(ref _eagerOnlyShapeKeys, next);
+                    }
+                }
+                return eagerForward();
+            }
+        }
+        finally
+        {
+            DrainPendingDisposals();
+        }
+    }
+
+    /// <summary>
+    /// Combined shape key over multiple inputs — folds each input's single-shape key
+    /// (see <see cref="TryComputeShapeKey"/>) into one value so distinct secondary-input
+    /// shapes never collide. Returns <c>false</c> (un-keyable) if any input's shape is
+    /// un-keyable (rank &gt; 4 or a dim &gt; 65535).
+    /// </summary>
+    private static bool TryComputeMultiShapeKey(Tensor<T>[] inputs, out long key)
+    {
+        key = 0;
+        unchecked
+        {
+            for (int i = 0; i < inputs.Length; i++)
+            {
+                if (!TryComputeShapeKey(inputs[i]._shape, out long k))
+                {
+                    key = 0;
+                    return false;
+                }
+                // Order-sensitive fold so [a,b] and [b,a] differ.
+                key = (key * 1000003L) ^ (k + unchecked((long)0x9E3779B97F4A7C15) * (i + 1));
+            }
+        }
+        return true;
     }
 
     /// <summary>

--- a/src/NeuralNetworks/VerifiedInferenceGate.cs
+++ b/src/NeuralNetworks/VerifiedInferenceGate.cs
@@ -127,6 +127,83 @@ internal sealed class VerifiedInferenceGate<T>
         return output;
     }
 
+    /// <summary>
+    /// Multi-input variant: verify-then-trust keyed on the COMBINED shape of all
+    /// <paramref name="inputs"/>. Used by diffusion noise predictors whose per-step forward reads
+    /// several per-call-varying leaves (noisy sample + timestep embedding + optional conditioning).
+    /// The first call at a new (combined-shape, version) runs BOTH eager and compiled and adopts
+    /// the compiled plan only if it matches eager numerically; later calls at the same shape replay
+    /// the trusted compiled plan. Unlike the single-input overload there is no identical-input value
+    /// memo — a denoising loop changes its inputs every step, so the memo would never hit; the
+    /// per-shape verdict is the whole benefit (verify once, replay the rest of the loop).
+    /// </summary>
+    /// <param name="inputs">The per-call mutable input leaves, in a stable order.</param>
+    /// <param name="structureVersion">Caller's monotonic layer-graph version.</param>
+    /// <param name="eager">The eager forward (source of truth).</param>
+    /// <param name="compiled">The compiled multi-input forward (candidate).</param>
+    /// <param name="onDecision">Optional callback invoked when a shape's verdict is first decided.</param>
+    public Tensor<T> Run(
+        Tensor<T>[] inputs,
+        int structureVersion,
+        System.Func<Tensor<T>> eager,
+        System.Func<Tensor<T>> compiled,
+        System.Action<bool, string>? onDecision = null)
+    {
+        if (inputs is null || inputs.Length == 0) return eager();
+
+        long shapeKey = ComputeMultiShapeKey(inputs);
+
+        _verdicts.TryGetValue(shapeKey, out var v);
+        bool decided = v.Version == structureVersion && (v.Verdict == VerdictTrusted || v.Verdict == VerdictRejected);
+
+        if (decided && v.Verdict == VerdictTrusted)
+            return compiled();
+        if (decided && v.Verdict == VerdictRejected)
+            return eager();
+
+        System.Threading.Interlocked.Increment(ref _verifyCount);
+        var reference = eager();
+        Tensor<T> candidate;
+        try
+        {
+            candidate = compiled();
+        }
+        catch (System.Exception ex) when (
+            ex is not System.OutOfMemoryException &&
+            ex is not System.StackOverflowException &&
+            ex is not System.AccessViolationException)
+        {
+            _verdicts[shapeKey] = (VerdictRejected, structureVersion);
+            onDecision?.Invoke(false, $"verify-throw:{ex.GetType().Name}");
+            return reference;
+        }
+
+        bool parity = OutputsClose(reference, candidate);
+        _verdicts[shapeKey] = (parity ? VerdictTrusted : VerdictRejected, structureVersion);
+        onDecision?.Invoke(parity, parity ? "compiled-matches-eager" : "compiled-diverged-stay-eager");
+        // The eager reference is the source of truth on the verify call, so a divergent compiled
+        // plan never leaks a wrong value to the caller.
+        return reference;
+    }
+
+    /// <summary>FNV-1a fold of every input's shape (rank-tagged) so distinct secondary shapes don't collide.</summary>
+    private static long ComputeMultiShapeKey(Tensor<T>[] inputs)
+    {
+        long hash = unchecked((long)0xcbf29ce484222325L);
+        for (int t = 0; t < inputs.Length; t++)
+        {
+            var shape = inputs[t]._shape;
+            hash ^= shape.Length;           // rank-tag so [1,4,1] never collides with [1,4]
+            hash *= unchecked((long)0x100000001b3L);
+            for (int i = 0; i < shape.Length; i++)
+            {
+                hash ^= shape[i];
+                hash *= unchecked((long)0x100000001b3L);
+            }
+        }
+        return hash;
+    }
+
     /// <summary>Drops all verdicts and memo entries (e.g. on entering training, where weights change).</summary>
     public void Clear()
     {

--- a/tests/AiDotNet.Tests/IntegrationTests/Jit/DiffusionMultiInputCompiledTests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/Jit/DiffusionMultiInputCompiledTests.cs
@@ -1,0 +1,105 @@
+using System;
+using System.Linq;
+using AiDotNet.Diffusion.NoisePredictors;
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.Engines.Optimization;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tests.IntegrationTests.Jit;
+
+/// <summary>
+/// Multi-input compiled denoising (ooples/AiDotNet#1620 + AiDotNet.Tensors#616). A DiT per-step
+/// forward reads BOTH the noisy sample AND a per-step timestep embedding. The single-input
+/// compile baked step 0's embedding and replayed it for every step (silent corruption), so #1620
+/// reverted to eager. The proper fix routes the forward through the multi-input compiled path so
+/// every per-step input is re-bound. This asserts, on ONE instance (so weights are identical —
+/// the predictor's seed is not reproducible across instances):
+///   1. ENGAGED  — the compiled plan actually executes (not a silent eager fallback);
+///   2. NOT BAKED — holding the noisy sample fixed and varying only the timestep changes the
+///      compiled output;
+///   3. PARITY   — the compiled output matches the eager output at every timestep.
+///
+/// The eager pass (compilation OFF) primes the verify-then-trust verdict to "trusted"
+/// (compiled()==eager() trivially when disabled); the compiled pass (compilation ON) then
+/// replays the REAL compiled plan for the same shape, so eager/compiled are read from the same
+/// weights. Runs NonParallel because it mutates process-global compile options.
+/// </summary>
+[Collection("NonParallelIntegration")]
+public class DiffusionMultiInputCompiledTests : IDisposable
+{
+    private readonly TensorCodecOptions _originalOptions;
+
+    public DiffusionMultiInputCompiledTests()
+    {
+        AiDotNetEngine.ResetToCpu();
+        _originalOptions = TensorCodecOptions.Current;
+    }
+
+    public void Dispose() => TensorCodecOptions.SetCurrent(_originalOptions);
+
+    private static DiTNoisePredictor<float> NewDiT() =>
+        new DiTNoisePredictor<float>(
+            inputChannels: 4, hiddenSize: 64, numLayers: 2, numHeads: 2,
+            patchSize: 2, contextDim: 4096, latentSpatialSize: 32, seed: 42);
+
+    private static Tensor<float> Noisy(int seed)
+    {
+        var data = new float[1 * 4 * 32 * 32];
+        for (int i = 0; i < data.Length; i++)
+            data[i] = (float)(((i * 7 + seed * 13) % 17) - 8) * 0.05f;
+        return new Tensor<float>(data, new[] { 1, 4, 32, 32 });
+    }
+
+    private static float MaxAbsDiff(float[] a, float[] b)
+    {
+        float m = 0f;
+        for (int i = 0; i < a.Length; i++)
+        {
+            float d = Math.Abs(a[i] - b[i]);
+            if (d > m) m = d;
+        }
+        return m;
+    }
+
+    // RELEASE-GATED: the compiled DiT replay only matches eager once AiDotNet.Tensors ships the
+    // BlasBatchPass multi-input reorder fix (Tensors branch fix/blasbatch-multiinput-reorder).
+    // Until the consumer bumps AiDotNet.Tensors to that release, the verify-then-trust gate
+    // correctly REJECTS the (still-divergent) compiled plan and falls back to eager — safe, just
+    // no perf win — so this parity assertion would not hold. Validated locally against a
+    // 0.97.2 + fix package: compiled == eager, timestep not baked, compiled plan executed.
+    // Un-skip when AiDotNet.Tensors is bumped to the fixed release.
+    [Fact(Skip = "Release-gated: needs AiDotNet.Tensors BlasBatch multi-input reorder fix; un-skip on the version bump.")]
+    public void DiT_MultiInputCompiledDenoising_MatchesEager_AndTimestepNotBaked()
+    {
+        var dit = NewDiT();
+        var noisy = Noisy(1);                 // SAME noisy sample for every timestep
+        int[] steps = { 50, 500, 950 };
+
+        // Eager pass (compilation OFF) on this instance — also primes the gate verdict to trusted.
+        TensorCodecOptions.SetCurrent(new TensorCodecOptions { EnableCompilation = false });
+        var eager = steps.Select(t => dit.PredictNoise(noisy, t).ToArray()).ToArray();
+
+        // Compiled pass (compilation ON) on the SAME instance: trusted verdict -> real compiled replay.
+        TensorCodecOptions.SetCurrent(new TensorCodecOptions { EnableCompilation = true });
+        var compiled = steps.Select(t => dit.PredictNoise(noisy, t).ToArray()).ToArray();
+
+        // 1) ENGAGED.
+        Assert.True(dit.CompiledMultiInputReplays > 0,
+            "multi-input compiled plan never executed — the path silently fell back to eager.");
+
+        // 2) NOT BAKED.
+        float bakeDiff = MaxAbsDiff(compiled[0], compiled[2]);
+        Assert.True(bakeDiff > 1e-4f,
+            $"compiled replay baked the timestep: t={steps[0]} and t={steps[2]} gave identical output " +
+            $"(maxAbsDiff={bakeDiff:E3}).");
+
+        // 3) PARITY.
+        for (int i = 0; i < steps.Length; i++)
+        {
+            float diff = MaxAbsDiff(compiled[i], eager[i]);
+            Assert.True(diff < 1e-3f,
+                $"compiled diverged from eager at t={steps[i]}: maxAbsDiff={diff:E3}.");
+        }
+    }
+}


### PR DESCRIPTION
Completes the follow-up deferred by #1620. That PR reverted DiT/UNet per-step denoising to **eager** because the single-input compile re-bound only the noisy sample and **baked the per-step timestep embedding** as a constant, so the cached plan replayed step 0's embedding for the whole denoising loop (silent corruption). This routes the forward through the multi-input compiled path so every per-step input is re-bound.

## Changes
- **`CompiledModelHost.Predict(Tensor<T>[] inputs, …)`** — multi-input compiled replay, mirroring the single-input concurrency / dispose / narrow-fallback contract. The single-input hot path is **untouched** (no regression). Adds a `MultiInputReplays` telemetry counter.
- **`VerifiedInferenceGate.Run(Tensor<T>[] inputs, …)`** — verify-then-trust keyed on the combined input shape: a compiled plan is adopted for a shape only after it matches eager, so output stays numerically identical to eager (divergent plans stay eager).
- **`NoisePredictorBase.PredictCompiledMulti(…)`**.
- **`DiTNoisePredictor`** (`PredictNoise` + `PredictNoiseWithEmbedding`) and **`UNetNoisePredictor`** pass `[noisySample, timeEmbed, conditioning?]` (conditioning only when present). UNet's dead single-input pre-warm cache + key builder removed.

## Safety / correctness
Safe by construction: where the compiled plan diverges from eager, the verify-then-trust gate **rejects it and runs eager** — correct, just not compiled. No corruption, no regression vs. #1620's eager behaviour.

The compiled DiT replay actually **matches eager** (so the gate adopts it → the compiled perf win is delivered) once the paired **AiDotNet.Tensors `BlasBatchPass` reorder fix** ships (ooples/AiDotNet.Tensors#637 — that pass reordered matmuls across buffer lifetimes, latent for single-input). Validated locally end-to-end against a `0.97.2 + fix` package: compiled == eager, timestep not baked, compiled plan executes.

## Release gating
The regression test `DiffusionMultiInputCompiledTests` is **`[Fact(Skip=…)]`** until `AiDotNet.Tensors` is bumped to the release containing #637; un-skip on that version bump. (The multi-input compile API itself is already present since 0.97.0.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)