### PR TITLE
docs: build: ship XML documentation in NuGet packages (fix missing IntelliSense)

### DIFF
--- a/src/CausalInference/SLearner.cs
+++ b/src/CausalInference/SLearner.cs
@@ -243,7 +243,7 @@ public class SLearner<T> : CausalModelBase<T>
     /// <see cref="CausalModelBase{T}.Train(Matrix{T}, Vector{T})"/> splits the
     /// input matrix into <c>features</c> (columns 1..end) and <c>treatment</c>
     /// (column 0) before fitting on the joint <c>[features ∥ treatment] → outcome</c>
-    /// regression. The standard <see cref="IFullModel{T,Matrix{T},Vector{T}}.Predict"/>
+    /// regression. The standard <see cref="IFullModel{T, TInput, TOutput}.Predict"/>
     /// contract returns predicted outcomes (so <c>R²</c> / residual / coefficient-sign
     /// invariants from <c>RegressionModelTestBase</c> are well-defined): walk each row,
     /// read its treatment from column 0, evaluate <c>bias + Σ_j w_j · feature_j +

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,0 +1,34 @@
+<Project>
+
+  <!--
+    Emit XML documentation files for every project under src/.
+
+    Without this, `dotnet pack` produces packages that contain only the .dll and
+    no AiDotNet.xml, so IntelliSense in Visual Studio / Rider shows NO doc tooltips
+    for any public member — even though the source is richly commented. Enabling
+    GenerateDocumentationFile makes the build emit <Assembly>.xml, which the .NET
+    SDK pack target then includes in the package lib/ folder alongside the .dll.
+
+    The XML-doc warning family is suppressed so that turning doc generation on does
+    not convert documentation-quality warnings into build breaks under
+    TreatWarningsAsErrors (set in AiDotNet.csproj):
+      CS1591 — missing XML comment for a publicly visible member
+      CS1570/CS1587/CS1592 — malformed XML in a doc comment
+      CS1571/CS1572/CS1573 — duplicate / unmatched / missing param tags
+      CS1574/CS1580/CS1581/CS1584/CS1589/CS1590 — unresolved or malformed cref/include
+      CS0419 — ambiguous cref (overload set); CS1723 — cref to a type parameter
+      CS1710/CS1711/CS1712 — duplicate / unmatched / missing typeparam tags
+      CS1734/CS1735 — paramref / typeparamref naming a non-existent (type)parameter
+    The compiler still emits <Assembly>.xml for every well-formed comment (the vast
+    majority); this change is purely about SHIPPING the docs we already have so they
+    surface in IntelliSense. Raising coverage and cleaning up the doc comments these
+    codes flag is a separate follow-up — tracked, not blocking. (A small number of
+    genuinely malformed crefs that produced non-suppressible parse errors, CS1658,
+    were fixed in source in this same change.)
+  -->
+  <PropertyGroup>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>$(NoWarn);CS1591;CS1570;CS1571;CS1572;CS1573;CS1574;CS1580;CS1581;CS1584;CS1587;CS1589;CS1590;CS1592;CS0419;CS1710;CS1711;CS1712;CS1723;CS1734;CS1735</NoWarn>
+  </PropertyGroup>
+
+</Project>

--- a/src/Finance/Forecasting/Foundation/Chronos.cs
+++ b/src/Finance/Forecasting/Foundation/Chronos.cs
@@ -70,7 +70,7 @@ namespace AiDotNet.Finance.Forecasting.Foundation;
 /// </para>
 /// <para>
 /// <b>Thread Safety:</b> This class is NOT thread-safe. Concurrent calls to
-/// <see cref="Forecast(Tensor{T}, double[]?)"/> or <see cref="Train(Tensor{T}, Tensor{T})"/>
+/// <see cref="Forecast(Tensor{T}, double[])"/> or <see cref="Train(Tensor{T}, Tensor{T})"/>
 /// will result in undefined behavior due to shared tokenization state.
 /// Create separate instances for concurrent usage scenarios.
 /// </para>


### PR DESCRIPTION
## Problem

The published `AiDotNet` NuGet package ships **only `AiDotNet.dll` — no `AiDotNet.xml`**. Visual Studio / Rider read that XML file to show IntelliSense doc tooltips, so today hovering over any public member (`AiModelBuilder.ConfigureModel`, `BuildAsync`, etc.) shows **nothing**, even though the source is richly documented.

Confirmed against `aidotnet 0.224.1` from nuget.org: `lib/net10.0/` and `lib/net471/` contain the DLL with no XML.

## Root cause

`GenerateDocumentationFile` was never enabled, so the build never emits the XML doc file, so `pack` has nothing to include.

## Fix

- Add **`src/Directory.Build.props`** enabling `GenerateDocumentationFile` for every project under `src/`. The .NET SDK pack target automatically bundles `<Assembly>.xml` into the package `lib/` folders.
- Because `AiDotNet.csproj` sets `TreatWarningsAsErrors`, enabling doc generation would otherwise turn documentation-quality warnings into build breaks. The XML-doc warning family is suppressed via `NoWarn` so doc generation can never break the build:
  - `CS1591` missing comment · `CS1570/1587/1592` malformed XML · `CS1571/1572/1573` param tags · `CS1574/1580/1581/1584/1589/1590` cref/include · `CS0419` ambiguous cref · `CS1710/1711/1712` typeparam · `CS1734/1735` paramref/typeparamref
- Two crefs produced **non-suppressible** parse errors (`CS1658`) and are fixed in source:
  - `Chronos.cs` — drop nullable annotation from a cref (`double[]?` → `double[]`)
  - `SLearner.cs` — cref the open generic by its declared type-parameter names (`IFullModel{T, TInput, TOutput}`) instead of nested constructed generics

## Verification

- `src/AiDotNet` builds clean on **net10.0 + net471**.
- `AiDotNet.xml` (~51 MB) generated for both TFMs.
- A packed `.nupkg` contains `lib/net10.0/AiDotNet.xml` and `lib/net471/AiDotNet.xml` alongside the DLLs.

## Follow-up (not blocking)

The suppressed warnings flag genuinely malformed/missing doc comments. Those can be cleaned up incrementally; this PR is purely about shipping the docs that already exist so they surface in IntelliSense.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced internal documentation references and consistency across the codebase.

* **Chores**
  * Improved build configuration to generate comprehensive documentation files and streamline the build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->