### PR TITLE
fix(diffusion): SASTD 4-ch latent + perf: kill per-forward streaming reflection walk (#1646)

### DIFF
--- a/src/Diffusion/NoisePredictors/NoisePredictorBase.cs
+++ b/src/Diffusion/NoisePredictors/NoisePredictorBase.cs
@@ -237,6 +237,9 @@ public abstract class NoisePredictorBase<T> : INoisePredictor<T>, IModelShape, I
             // of T, not layers, and walking them adds noise for no benefit.
             if (ns.StartsWith("AiDotNet.Tensors", StringComparison.Ordinal)) return false;
             if (t.Name == "Vector`1" || t.Name == "Matrix`1" || t.Name == "Tensor`1") return false;
+            // Only walk types within known AiDotNet namespaces — caller-injected objects
+            // (custom ILossFunction implementations, etc.) are not walked.
+            if (!ns.StartsWith("AiDotNet", StringComparison.Ordinal)) return false;
             return true;
         });
 

--- a/src/Diffusion/NoisePredictors/NoisePredictorBase.cs
+++ b/src/Diffusion/NoisePredictors/NoisePredictorBase.cs
@@ -129,21 +129,17 @@ public abstract class NoisePredictorBase<T> : INoisePredictor<T>, IModelShape, I
         if (!visited.Add(root)) yield break;
         stack.Push(root);
 
-        const System.Reflection.BindingFlags fieldFlags =
-            System.Reflection.BindingFlags.Instance |
-            System.Reflection.BindingFlags.Public |
-            System.Reflection.BindingFlags.NonPublic;
-
         while (stack.Count > 0)
         {
             var current = stack.Pop();
             var currentType = current.GetType();
             for (var t = currentType; t != null && t != typeof(object); t = t.BaseType)
             {
-                foreach (var field in t.GetFields(fieldFlags | System.Reflection.BindingFlags.DeclaredOnly))
+                // Cached, pre-filtered reference-type declared fields for this type — see
+                // GetDeclaredWalkableFields. Skips the per-field value-type/string probe
+                // (RuntimeType.IsPrimitiveImpl) that dominated the forward (#1646).
+                foreach (var field in GetDeclaredWalkableFields(t))
                 {
-                    if (field.FieldType.IsValueType || field.FieldType == typeof(string)) continue;
-
                     object? value;
                     try { value = field.GetValue(current); }
                     catch (Exception ex)
@@ -189,9 +185,18 @@ public abstract class NoisePredictorBase<T> : INoisePredictor<T>, IModelShape, I
                     }
                     else if (value is System.Collections.IEnumerable enumerable && value is not string)
                     {
+                        // We MUST enumerate the whole sequence: enumerating a streaming-placeholder
+                        // weight tensor (Tensor<T> as IEnumerable<float>) rehydrates it, and the
+                        // forward relies on that side effect (NoisePredictorWeightStreamingTests).
+                        // But value-type elements — the millions of boxed floats in a Tensor<T> /
+                        // float[] / double[] buffer — can never be, or own, a layer, so skip the
+                        // `visited` bookkeeping for them: hashing every boxed element
+                        // (RuntimeHelpers.GetHashCode) was the dominant walk cost (#1646). `continue`
+                        // still advances the enumerator, so rehydration is preserved.
                         foreach (var item in enumerable)
                         {
-                            if (item is null || !visited.Add(item)) continue;
+                            if (item is null || item is ValueType) continue;
+                            if (!visited.Add(item)) continue;
                             if (item is ILayer<T> nestedLayer)
                             {
                                 yield return nestedLayer;
@@ -223,16 +228,47 @@ public abstract class NoisePredictorBase<T> : INoisePredictor<T>, IModelShape, I
     /// bounded; wrappers inside this assembly's namespaces are fair game.
     /// </summary>
     private static bool IsWalkableWrapper(Type type)
-    {
-        if (type.IsPrimitive || type.IsEnum) return false;
-        var ns = type.Namespace ?? string.Empty;
-        if (ns.StartsWith("System", StringComparison.Ordinal)) return false;
-        // Avoid recursing into low-level numeric containers — their fields are arrays
-        // of T, not layers, and walking them adds noise for no benefit.
-        if (ns.StartsWith("AiDotNet.Tensors", StringComparison.Ordinal)) return false;
-        if (type.Name == "Vector`1" || type.Name == "Matrix`1" || type.Name == "Tensor`1") return false;
-        return true;
-    }
+        => s_walkableWrapperCache.GetOrAdd(type, static t =>
+        {
+            if (t.IsPrimitive || t.IsEnum) return false;
+            var ns = t.Namespace ?? string.Empty;
+            if (ns.StartsWith("System", StringComparison.Ordinal)) return false;
+            // Avoid recursing into low-level numeric containers — their fields are arrays
+            // of T, not layers, and walking them adds noise for no benefit.
+            if (ns.StartsWith("AiDotNet.Tensors", StringComparison.Ordinal)) return false;
+            if (t.Name == "Vector`1" || t.Name == "Matrix`1" || t.Name == "Tensor`1") return false;
+            return true;
+        });
+
+    // Per-type reflection-metadata caches. GetFields and "is this a walkable wrapper" are
+    // pure functions of the Type, so resolve each once across every instance and every
+    // forward instead of re-probing runtime type handles on the hot streaming path (#1646).
+    private static readonly System.Collections.Concurrent.ConcurrentDictionary<Type, System.Reflection.FieldInfo[]> s_walkableFieldCache = new();
+    private static readonly System.Collections.Concurrent.ConcurrentDictionary<Type, bool> s_walkableWrapperCache = new();
+
+    /// <summary>
+    /// Reference-type, non-string instance fields declared directly on <paramref name="declaringType"/>.
+    /// Value-type and string fields are filtered out at cache-build time — they can never be,
+    /// or own, an <see cref="ILayer{T}"/> — so the walk never re-checks them. The walk calls
+    /// this once per type in the base chain (the caller iterates <c>BaseType</c>).
+    /// </summary>
+    private static System.Reflection.FieldInfo[] GetDeclaredWalkableFields(Type declaringType)
+        => s_walkableFieldCache.GetOrAdd(declaringType, static t =>
+        {
+            const System.Reflection.BindingFlags flags =
+                System.Reflection.BindingFlags.Instance |
+                System.Reflection.BindingFlags.Public |
+                System.Reflection.BindingFlags.NonPublic |
+                System.Reflection.BindingFlags.DeclaredOnly;
+            var fields = new List<System.Reflection.FieldInfo>();
+            foreach (var f in t.GetFields(flags))
+            {
+                var ft = f.FieldType;
+                if (ft.IsValueType || ft == typeof(string)) continue;
+                fields.Add(f);
+            }
+            return fields.ToArray();
+        });
 
     /// <summary>
     /// Runs <paramref name="eagerFallback"/> under the compile host — traces on
@@ -461,15 +497,35 @@ public abstract class NoisePredictorBase<T> : INoisePredictor<T>, IModelShape, I
         // returns (runs resident) rather than reconfiguring the process-global registry.
         if (System.Threading.Interlocked.CompareExchange(ref _streamingEngaged, 1, 0) != 0) return;
 
-        WeightRegistry.Configure(new GpuOffloadOptions
+        var offloadOptions = new GpuOffloadOptions
         {
             StreamingPoolMaxResidentBytes = StreamingResidentCapOverride ?? ComputeResidentCapBytes(),
             TransparentAutoEviction = true,
-        });
+        };
+        try
+        {
+            WeightRegistry.Configure(offloadOptions);
+        }
+        catch (InvalidOperationException)
+        {
+            // Configure also throws on leftover ReservedBytes — orphaned streaming
+            // reservations from a PRIOR predictor whose first forward reserved weights
+            // (AllocateStreaming) but never reached RegisterResolvedStreamingWeights
+            // (its forward threw, or the model was disposed mid-stream). The registry
+            // is process-global, so those orphans accumulate across models in one
+            // process (a test shard runs many) until every subsequent streaming model
+            // fails to engage here. We already confirmed RegisteredEntryCount == 0
+            // above, so no LIVE model owns the pool — the leftover reservations belong
+            // to a dead model and are safe to forcibly drop. Reset and reconfigure.
+            WeightRegistry.Reset();
+            WeightRegistry.Configure(offloadOptions);
+        }
 
-        // ReflectInstanceLayers (not EnumerateLayers) so the engagement works for
-        // ANY predictor without requiring an EnumerateLayers override — it walks
-        // owned layer fields recursively, including those inside the DiT block list.
+        // Walk owned layer fields recursively (including those inside the DiT block list)
+        // and flag each for the streaming allocator. Iterated LAZILY: each layer is flagged
+        // as the walk yields it, BEFORE the walk descends into that layer — the layer's own
+        // lazy weight allocation (triggered while descending) reads UseStreamingAllocator, so
+        // the flag must be set first. Do NOT materialize this into a list and flag afterwards.
         foreach (var layer in ReflectInstanceLayers(this))
         {
             if (layer is LayerBase<T> lb) lb.UseStreamingAllocator = true;
@@ -497,6 +553,14 @@ public abstract class NoisePredictorBase<T> : INoisePredictor<T>, IModelShape, I
     protected void RegisterResolvedStreamingWeights()
     {
         if (System.Threading.Volatile.Read(ref _streamingEngaged) == 0) return;
+
+        // The first forward runs every layer (a diffusion predictor exercises its whole graph
+        // each denoising step), so it resolves and registers all lazy weights. Skip the full
+        // graph re-walk on forwards 2..N — that per-forward walk was the dominant streaming
+        // cost on foundation models (#1646). Worst case a weight that only resolves on a later
+        // forward stays resident rather than streamed: identical output, slightly more RAM,
+        // never wrong.
+        if (System.Threading.Volatile.Read(ref _streamingWeightsRegistered) == 1) return;
 
         foreach (var layer in ReflectInstanceLayers(this))
         {

--- a/src/Diffusion/NoisePredictors/NoisePredictorBase.cs
+++ b/src/Diffusion/NoisePredictors/NoisePredictorBase.cs
@@ -517,6 +517,9 @@ public abstract class NoisePredictorBase<T> : INoisePredictor<T>, IModelShape, I
             // fails to engage here. We already confirmed RegisteredEntryCount == 0
             // above, so no LIVE model owns the pool — the leftover reservations belong
             // to a dead model and are safe to forcibly drop. Reset and reconfigure.
+            System.Diagnostics.Trace.TraceWarning(
+                "NoisePredictorBase.MaybeEngageWeightStreaming: recovering from orphaned " +
+                "streaming reservations by resetting WeightRegistry and reconfiguring.");
             WeightRegistry.Reset();
             WeightRegistry.Configure(offloadOptions);
         }

--- a/src/Diffusion/StyleTransfer/SASTDModel.cs
+++ b/src/Diffusion/StyleTransfer/SASTDModel.cs
@@ -73,7 +73,14 @@ public class SASTDModel<T> : LatentDiffusionModelBase<T>
     private void InitializeLayers(UNetNoisePredictor<T>? predictor, StandardVAE<T>? vae, int? seed)
     {
         _predictor = predictor ?? new UNetNoisePredictor<T>(
-            architecture: Architecture, inputChannels: 5, outputChannels: LATENT_CHANNELS,
+            // Style Aligned (Hertz et al. 2023) is an inference-time shared-attention
+            // technique over a STANDARD Stable Diffusion U-Net: the noise predictor
+            // consumes the 4-channel latent and emits a 4-channel noise estimate — it
+            // does NOT add an input channel. inputChannels was 5 (a copy-paste from a
+            // latent+mask inpainting predictor), so the UNet's input conv expected 5
+            // channels while the diffusion latent (and every sibling StyleTransfer
+            // model) is 4 → shape mismatch on every forward/output/training test.
+            architecture: Architecture, inputChannels: LATENT_CHANNELS, outputChannels: LATENT_CHANNELS,
             baseChannels: 320, channelMultipliers: new[] { 1, 2, 4, 4 },
             numResBlocks: 2, attentionResolutions: new[] { 4, 2, 1 }, contextDim: 768, seed: seed);
         _vae = vae ?? new StandardVAE<T>(inputChannels: 3, latentChannels: LATENT_CHANNELS,

--- a/tools/DiffusionTraceProbe/DiffusionTraceProbe.csproj
+++ b/tools/DiffusionTraceProbe/DiffusionTraceProbe.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <LangVersion>latest</LangVersion>
+    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
+    <RootNamespace>AiDotNet.Tools.DiffusionTraceProbe</RootNamespace>
+    <AssemblyName>DiffusionTraceProbe</AssemblyName>
+    <ServerGarbageCollection>true</ServerGarbageCollection>
+    <ConcurrentGarbageCollection>true</ConcurrentGarbageCollection>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="Program.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\AiDotNet.csproj" />
+  </ItemGroup>
+</Project>

--- a/tools/DiffusionTraceProbe/Program.cs
+++ b/tools/DiffusionTraceProbe/Program.cs
@@ -42,45 +42,51 @@ internal static class Program
         var model = Construct(modelName);
         if (model is null) return 1;
 
-        var diff = (IDiffusionModel<float>)model;
-        var full = (IFullModel<float, Tensor<float>, Tensor<float>>)model;
-
-        var rng = new Random(42);
-        var input = RandomTensor(new[] { 1, 4, 64, 64 }, rng);
-
-        Console.WriteLine($"=== DiffusionTraceProbe: {modelName} ===");
-        Console.WriteLine($".NET {Environment.Version}  ParameterCount={SafeParamCount(full)}");
-
-        // Phase 1: warm-up noise-prediction probe (the test's errBefore measurement).
-        int probeT = Math.Max(1, diff.Scheduler.TrainTimesteps / 2);
-        var noisy = RandomTensor(new[] { 1, 4, 64, 64 }, rng);
-        var sw = Stopwatch.StartNew();
-        _ = diff.PredictNoise(noisy, probeT);
-        sw.Stop();
-        Console.WriteLine($"[PredictNoise warm-up]      {sw.Elapsed.TotalSeconds,8:F2} s");
-
-        // Phase 2: training loop (forward + backward) — the timeout test runs 5-10 iters.
-        sw.Restart();
-        for (int i = 0; i < trainIters; i++)
+        try
         {
-            full.Train(input, input);
-            Console.WriteLine($"  train iter {i + 1}/{trainIters}   {sw.Elapsed.TotalSeconds,8:F2} s cumulative");
-        }
-        sw.Stop();
-        Console.WriteLine($"[Train x{trainIters}]               {sw.Elapsed.TotalSeconds,8:F2} s total");
+            var diff = (IDiffusionModel<float>)model;
+            var full = (IFullModel<float, Tensor<float>, Tensor<float>>)model;
 
-        // Phase 3: full sampling Predict (DDIM loop x SD-UNet forward) — the heaviest call.
-        if (doPredict)
-        {
-            sw.Restart();
-            var output = full.Predict(input);
+            var rng = new Random(42);
+            var input = RandomTensor(new[] { 1, 4, 64, 64 }, rng);
+
+            Console.WriteLine($"=== DiffusionTraceProbe: {modelName} ===");
+            Console.WriteLine($".NET {Environment.Version}  ParameterCount={SafeParamCount(full)}");
+
+            // Phase 1: warm-up noise-prediction probe (the test's errBefore measurement).
+            int probeT = Math.Max(1, diff.Scheduler.TrainTimesteps / 2);
+            var noisy = RandomTensor(new[] { 1, 4, 64, 64 }, rng);
+            var sw = Stopwatch.StartNew();
+            _ = diff.PredictNoise(noisy, probeT);
             sw.Stop();
-            Console.WriteLine($"[Predict (sampling loop)]   {sw.Elapsed.TotalSeconds,8:F2} s  (out len {output.Length})");
-        }
+            Console.WriteLine($"[PredictNoise warm-up]      {sw.Elapsed.TotalSeconds,8:F2} s");
 
-        Console.WriteLine("=== done ===");
-        if (model is IDisposable d) d.Dispose();
-        return 0;
+            // Phase 2: training loop (forward + backward) — the timeout test runs 5-10 iters.
+            sw.Restart();
+            for (int i = 0; i < trainIters; i++)
+            {
+                full.Train(input, input);
+                Console.WriteLine($"  train iter {i + 1}/{trainIters}   {sw.Elapsed.TotalSeconds,8:F2} s cumulative");
+            }
+            sw.Stop();
+            Console.WriteLine($"[Train x{trainIters}]               {sw.Elapsed.TotalSeconds,8:F2} s total");
+
+            // Phase 3: full sampling Predict (DDIM loop x SD-UNet forward) — the heaviest call.
+            if (doPredict)
+            {
+                sw.Restart();
+                var output = full.Predict(input);
+                sw.Stop();
+                Console.WriteLine($"[Predict (sampling loop)]   {sw.Elapsed.TotalSeconds,8:F2} s  (out len {output.Length})");
+            }
+
+            Console.WriteLine("=== done ===");
+            return 0;
+        }
+        finally
+        {
+            if (model is IDisposable d) d.Dispose();
+        }
     }
 
     private static object? Construct(string modelName)
@@ -105,6 +111,14 @@ internal static class Program
         }
 
         var closed = open.MakeGenericType(typeof(float));
+
+        // Validate that the closed type implements IDiffusionModel<float> before attempting to cast it.
+        var diffusionModelInterface = typeof(IDiffusionModel<float>);
+        if (!diffusionModelInterface.IsAssignableFrom(closed))
+        {
+            Console.Error.WriteLine($"ERROR: {closed.Name} does not implement IDiffusionModel<float>.");
+            return null;
+        }
 
         // Pick the ctor with the most parameters that are ALL optional (matches the
         // (arch?, options?, scheduler?, predictor?, vae?, conditioner?, seed?) shape);

--- a/tools/DiffusionTraceProbe/Program.cs
+++ b/tools/DiffusionTraceProbe/Program.cs
@@ -1,0 +1,165 @@
+using System;
+using System.Diagnostics;
+using System.Linq;
+using System.Reflection;
+using AiDotNet.Interfaces;
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.LinearAlgebra;
+
+namespace AiDotNet.Tools.DiffusionTraceProbe;
+
+/// <summary>
+/// Replays the EXACT workload of the timeout-prone diffusion model-family tests
+/// (<c>Training_ShouldReducePredictionError</c> / <c>ForwardPass_ShouldBeFinite_AfterTraining</c>)
+/// for a single named model, so a sampling profiler (dotnet-trace) attached to
+/// this process produces a clean, single-model hot-path report — without the
+/// xunit/testhost noise and without the 16 GB-runner cross-model contention.
+///
+/// Construction and the [1,4,64,64] latent input mirror DiffusionModelTestBase&lt;float&gt;.
+///
+/// Usage:
+///   DiffusionTraceProbe &lt;ModelName&gt; [--train-iters N] [--predict 0|1]
+///   e.g.  DiffusionTraceProbe KandinskyModel --train-iters 5 --predict 1
+/// </summary>
+internal static class Program
+{
+    private static int Main(string[] args)
+    {
+        if (args.Length < 1)
+        {
+            Console.Error.WriteLine("usage: DiffusionTraceProbe <ModelName> [--train-iters N] [--predict 0|1]");
+            return 2;
+        }
+
+        string modelName = args[0];
+        int trainIters = ArgInt(args, "--train-iters", 5);
+        bool doPredict = ArgInt(args, "--predict", 1) != 0;
+
+        // Pin the CPU engine + disable GPU so the profile reflects the CPU path the
+        // CI shard runs (AIDOTNET_DISABLE_GPU=1 is also set by the test harness).
+        AiDotNetEngine.Current = new CpuEngine();
+
+        var model = Construct(modelName);
+        if (model is null) return 1;
+
+        var diff = (IDiffusionModel<float>)model;
+        var full = (IFullModel<float, Tensor<float>, Tensor<float>>)model;
+
+        var rng = new Random(42);
+        var input = RandomTensor(new[] { 1, 4, 64, 64 }, rng);
+
+        Console.WriteLine($"=== DiffusionTraceProbe: {modelName} ===");
+        Console.WriteLine($".NET {Environment.Version}  ParameterCount={SafeParamCount(full)}");
+
+        // Phase 1: warm-up noise-prediction probe (the test's errBefore measurement).
+        int probeT = Math.Max(1, diff.Scheduler.TrainTimesteps / 2);
+        var noisy = RandomTensor(new[] { 1, 4, 64, 64 }, rng);
+        var sw = Stopwatch.StartNew();
+        _ = diff.PredictNoise(noisy, probeT);
+        sw.Stop();
+        Console.WriteLine($"[PredictNoise warm-up]      {sw.Elapsed.TotalSeconds,8:F2} s");
+
+        // Phase 2: training loop (forward + backward) — the timeout test runs 5-10 iters.
+        sw.Restart();
+        for (int i = 0; i < trainIters; i++)
+        {
+            full.Train(input, input);
+            Console.WriteLine($"  train iter {i + 1}/{trainIters}   {sw.Elapsed.TotalSeconds,8:F2} s cumulative");
+        }
+        sw.Stop();
+        Console.WriteLine($"[Train x{trainIters}]               {sw.Elapsed.TotalSeconds,8:F2} s total");
+
+        // Phase 3: full sampling Predict (DDIM loop x SD-UNet forward) — the heaviest call.
+        if (doPredict)
+        {
+            sw.Restart();
+            var output = full.Predict(input);
+            sw.Stop();
+            Console.WriteLine($"[Predict (sampling loop)]   {sw.Elapsed.TotalSeconds,8:F2} s  (out len {output.Length})");
+        }
+
+        Console.WriteLine("=== done ===");
+        if (model is IDisposable d) d.Dispose();
+        return 0;
+    }
+
+    private static object? Construct(string modelName)
+    {
+        var asm = typeof(AiDotNet.NeuralNetworks.NeuralNetworkBase<>).Assembly;
+        var open = asm.GetTypes().FirstOrDefault(t =>
+            t.IsClass && !t.IsAbstract && t.IsGenericTypeDefinition
+            && t.GetGenericArguments().Length == 1
+            && string.Equals(t.Name, modelName + "`1", StringComparison.Ordinal));
+
+        if (open is null)
+        {
+            // Allow passing the raw CLR name "Foo`1" too.
+            open = asm.GetTypes().FirstOrDefault(t =>
+                t.IsClass && !t.IsAbstract && t.IsGenericTypeDefinition
+                && string.Equals(t.Name, modelName, StringComparison.Ordinal));
+        }
+        if (open is null)
+        {
+            Console.Error.WriteLine($"ERROR: no generic model type named '{modelName}' in {asm.GetName().Name}.");
+            return null;
+        }
+
+        var closed = open.MakeGenericType(typeof(float));
+
+        // Pick the ctor with the most parameters that are ALL optional (matches the
+        // (arch?, options?, scheduler?, predictor?, vae?, conditioner?, seed?) shape);
+        // fill each with its compile-time default, but pin seed=42 like the tests.
+        var ctor = closed.GetConstructors()
+            .Where(c => c.GetParameters().All(p => p.HasDefaultValue))
+            .OrderByDescending(c => c.GetParameters().Length)
+            .FirstOrDefault();
+
+        if (ctor is null)
+        {
+            Console.Error.WriteLine($"ERROR: {closed.Name} has no all-optional ctor to probe.");
+            return null;
+        }
+
+        var pars = ctor.GetParameters();
+        var ctorArgs = new object?[pars.Length];
+        for (int i = 0; i < pars.Length; i++)
+            ctorArgs[i] = string.Equals(pars[i].Name, "seed", StringComparison.OrdinalIgnoreCase)
+                ? 42
+                : pars[i].DefaultValue;
+
+        try
+        {
+            var swCtor = Stopwatch.StartNew();
+            var model = ctor.Invoke(ctorArgs);
+            swCtor.Stop();
+            Console.WriteLine($"[construct]                 {swCtor.Elapsed.TotalSeconds,8:F2} s");
+            return model;
+        }
+        catch (TargetInvocationException tie)
+        {
+            var inner = tie.InnerException ?? tie;
+            Console.Error.WriteLine($"ERROR constructing {closed.Name}: {inner.GetType().Name}: {inner.Message}");
+            return null;
+        }
+    }
+
+    private static long SafeParamCount(IFullModel<float, Tensor<float>, Tensor<float>> model)
+    {
+        try { return ((IDiffusionModel<float>)model).ParameterCount; }
+        catch { return -1; }
+    }
+
+    private static Tensor<float> RandomTensor(int[] shape, Random rng)
+    {
+        var t = new Tensor<float>(shape);
+        for (int i = 0; i < t.Length; i++) t[i] = (float)rng.NextDouble();
+        return t;
+    }
+
+    private static int ArgInt(string[] args, string flag, int fallback)
+    {
+        int idx = Array.IndexOf(args, flag);
+        if (idx >= 0 && idx + 1 < args.Length && int.TryParse(args[idx + 1], out int v)) return v;
+        return fallback;
+    }
+}


### PR DESCRIPTION
## What

Two independent diffusion fixes surfaced while profiling the foundation-scale ModelFamily timeout shards from #1620:

1. **`fix(diffusion)` — SASTD uses a 4-channel SD latent, not 5 (#1620 SA-SD).** Style Aligned (Hertz et al. 2023) is inference-time shared attention over a *standard* SD U-Net. `SASTDModel` built its `UNetNoisePredictor` with `inputChannels: 5` (copy-paste from a latent+mask inpainting predictor) while `LATENT_CHANNELS`, `outputChannels`, the VAE, and all 9 sibling StyleTransfer models use 4 → the input conv expected 5 channels but the latent is 4 → shape mismatch on every forward/output/training test. Also makes `MaybeEngageWeightStreaming` resilient to a prior dead model's orphaned streaming reservations (`Reset` + retry), which was cascading failures across the whole SA-SD shard.

2. **`perf(diffusion)` — eliminate the per-forward weight-streaming reflection walk (#1646).** Profiling a single Kandinsky (1.8B-param U-Net) forward showed **~61%** of the forward thread's CPU in `RuntimeType.IsPrimitiveImpl` + **~17%** in `HashSet.Resize`, all under `NoisePredictorBase.ReflectInstanceLayers` — the transparent-weight-streaming graph walk, not arithmetic. Since streaming became the adaptive default at 500M params (#1610), every foundation diffusion model paid this, on **every** forward.

## #1646 fix detail (4 changes)

| # | Change | Effect |
|---|--------|--------|
| 1 | Cache per-type `GetFields` (reference-type, non-string only) | removes per-field `IsValueType` reflection repeated across the graph |
| 2 | Cache `IsWalkableWrapper` per type | dict lookup vs per-item `IsPrimitive` reflection |
| 3 | Skip `visited.Add` bookkeeping for value-type elements in the `IEnumerable` branch (but **keep advancing the enumerator**) | kills the `GetHashCode` storm from hashing millions of boxed `Tensor<T>` elements |
| 4 | `RegisterResolvedStreamingWeights` early-returns once registered | forwards 2..N of a 30–50 step sampling loop no longer re-walk the graph |

**Load-bearing gotcha (documented in code + #1646):** enumerating a streaming-placeholder weight tensor *rehydrates* it, and the forward relies on that side effect. So change #3 keeps enumerating and only skips the bookkeeping; the tempting "skip the whole collection" optimization **silently breaks streaming** (caught by `NoisePredictorWeightStreamingTests`). Memoizing the layer list is likewise unsafe — `UseStreamingAllocator` must be flagged progressively during the lazy walk.

## Verification

- **Build:** green (net10.0).
- **`NoisePredictorWeightStreamingTests` / `DiTWeightStreaming` / `AutoDetectWeightStreaming` / other `WeightStreaming` suites: 31/31 pass.**
- **Re-profiled** the Kandinsky forward after the fix: `IsPrimitiveImpl` / `HashSet.Resize` / `ReflectInstanceLayers` are gone from the hot path; the main thread now spends its CPU on the real U-Net forward (`CompiledModelCache`/Conv2D). New harness `tools/DiffusionTraceProbe` reproduces this.

## Scope — what this does and does NOT do

This **removes the reflection overhead**; it does **not** by itself green the foundation-diffusion timeout shards. After the fix the forward is still **compute-bound and near-serial** — ~63 BLAS worker threads sit parked while the GEMMs run effectively single-threaded (filed separately as **ooples/AiDotNet.Tensors#642**). A single Kandinsky forward still takes >200s locally, so the 120s `[Fact(Timeout)]` shards need #642 (parallelism) and/or test-scale variants too. CI on this PR is the arbiter for the SA-SD shard.

Related: #1620 (source of failing shards), #1610 (streaming-as-default), #1622 (foundation-timeout tracker), ooples/AiDotNet.Tensors#642 (near-serial GEMM).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes
- Fixed style transfer model initialization to align U-Net input channels with 4-channel diffusion latents.

## Performance
- Improved noise predictor layer discovery using cached reflection to reduce repeated runtime overhead.
- Enhanced weight streaming resilience and prevented redundant streaming registration after initial setup.

## Tooling
- Added **DiffusionTraceProbe**, a console tool to replay and profile a diffusion model CPU hot path with configurable warm-up, training iterations, and optional prediction timing/output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->