### PR TITLE
perf(#653): reuse one TensorArena across grad-accum chunks (eliminate ~117 MB/fwd)

### DIFF
--- a/src/NeuralNetworks/NeuralNetworkBase.cs
+++ b/src/NeuralNetworks/NeuralNetworkBase.cs
@@ -3370,8 +3370,17 @@ public abstract class NeuralNetworkBase<T> : INeuralNetworkModel<T>, IInterpreta
             T accumLoss = NumOps.Zero;
             int totalSamples = 0;
 
+            // #653: ONE arena for the whole batch; arena.Reset() at the top of each chunk
+            // recycles the previous chunk's forward/backward intermediates instead of
+            // re-allocating them (measured ~970x fewer allocations + eliminated GC-pause tail
+            // on the attnblock probe — the PyTorch-caching-allocator equivalent). Safe because
+            // the accumulated gradients (accumGrads) are RentPinned below, so they survive
+            // Reset, while only the recyclable per-chunk scratch is rewound.
+            using var arena = TensorArena.Create();
+
             for (int chunkIdx = 0; chunkIdx < nChunks; chunkIdx++)
             {
+                arena.Reset(); // recycle the prior chunk's scratch before allocating this chunk's
                 int start = chunkIdx * batchSize;
                 int end = Math.Min(start + batchSize, n);
                 int chunkSamples = end - start;
@@ -3379,7 +3388,6 @@ public abstract class NeuralNetworkBase<T> : INeuralNetworkModel<T>, IInterpreta
                 var xChunk = SliceAlongAxis0(input, start, end);
                 var yChunk = SliceAlongAxis0(target, start, end);
 
-                using var arena = TensorArena.Create();
                 using var tape = new GradientTape<T>();
                 var prediction = ForwardForTraining(xChunk);
 
@@ -3416,11 +3424,13 @@ public abstract class NeuralNetworkBase<T> : INeuralNetworkModel<T>, IInterpreta
                     }
                     else
                     {
-                        // Clone-and-scale so the gradient survives tape
-                        // disposal at the arena-using scope end AND is
-                        // pre-weighted by its chunk's sample count.
-                        var cloned = Engine.TensorMultiplyScalar(grad, chunkSamplesT);
-                        accumGrads[param] = cloned;
+                        // #653: PINNED accumulator survives arena.Reset() across chunks (per-chunk
+                        // scratch is rewound; this is not). COPY the chunk's pre-weighted gradient
+                        // values in so we never retain a reference to recyclable scratch.
+                        var scaled = Engine.TensorMultiplyScalar(grad, chunkSamplesT);
+                        var acc = AiDotNet.Tensors.Helpers.TensorAllocator.RentPinned<T>(grad._shape);
+                        scaled.AsSpan().CopyTo(acc.AsWritableSpan());
+                        accumGrads[param] = acc;
                     }
                 }
             }


### PR DESCRIPTION
## Summary
`TrainWithGradientAccumulation` created a fresh `TensorArena` **inside** the per-chunk loop with no cross-chunk `Reset()` — so it got **zero array reuse** and re-allocated every forward/backward intermediate each chunk. This hoists **one** arena over the whole batch and `Reset()`s per chunk, so the prior chunk's scratch is recycled — the PyTorch-caching-allocator behavior `TensorArena` already implements but wasn't getting.

## Correctness (use-after-free-safe)
The cross-chunk accumulators (`accumGrads`) are now allocated via `TensorAllocator.RentPinned` (the arena's **pinned** list survives `Reset()`), and each chunk's pre-weighted gradient is **copied** in — so nothing recyclable is retained across `Reset()`; only per-chunk scratch is rewound.

- **21/21** grad-accumulation batching tests pass (`Issue1296LargeXTrainBatchingTests` — asserts batching-equivalence/loss).
- **79/79** mixed-precision integration tests pass.

## Measured (mechanism, ConvParallelProbe attnblock S=256 D=768 H=12 blocks=6)
| | alloc MB/fwd | median ms | max ms (GC tail) |
|---|---|---|---|
| arena reused OFF | 117.196 | 644.6 | 2380 |
| arena reused ON | **0.121** | 626.5 | **638** |

**~970× fewer allocations + GC-pause tail eliminated.** This is the dominant CPU overhead vs PyTorch (its caching allocator reuses storage with ≈zero malloc/op); the autotrace-closure overhead audited in the sibling Tensors PR was ~0.006% of this by comparison.

🤖 Generated with [Claude Code](https://claude.com/claude-code)