### PR TITLE
perf(optimizers): wire amsgrad to the fused compiled training path (#653)

### DIFF
--- a/src/Optimizers/AMSGradOptimizer.cs
+++ b/src/Optimizers/AMSGradOptimizer.cs
@@ -24,7 +24,7 @@ namespace AiDotNet.Optimizers;
 /// </remarks>
 [ComponentType(ComponentType.Optimizer)]
 [PipelineStage(PipelineStage.Training)]
-public class AMSGradOptimizer<T, TInput, TOutput> : GradientBasedOptimizerBase<T, TInput, TOutput>
+public class AMSGradOptimizer<T, TInput, TOutput> : GradientBasedOptimizerBase<T, TInput, TOutput>, Fused.IFusedOptimizerSpec
 {
     /// <summary>
     /// The options specific to the AMSGrad optimizer.
@@ -73,6 +73,31 @@ public class AMSGradOptimizer<T, TInput, TOutput> : GradientBasedOptimizerBase<T
         _options = options ?? new AMSGradOptimizerOptions<T, TInput, TOutput>();
 
         InitializeAdaptiveParameters();
+    }
+
+    /// <summary>
+    /// Describes this AMSGrad optimizer for the compiled fused-training kernel.
+    /// AMSGrad is Adam with a running maximum of the second moment, which the
+    /// Tensors fused kernel implements directly as
+    /// <see cref="Tensors.Engines.Compilation.OptimizerType.AMSGrad"/> (the same
+    /// variant <see cref="AdamOptimizer{T, TInput, TOutput}"/> selects when its
+    /// <c>UseAMSGrad</c> flag is set). Wiring it here lets a standalone
+    /// AMSGradOptimizer engage the compiled forward/backward fast path instead of
+    /// falling back to the eager autograd tape every step (the multi-× perf cliff).
+    /// Falls back (returns false) when an adaptive learning rate or an
+    /// unsupported LR scheduler is configured, exactly like the Adam/AdaMax specs.
+    /// </summary>
+    bool Fused.IFusedOptimizerSpec.TryGetFusedOptimizerConfig(out Fused.FusedOptimizerConfig config)
+    {
+        config = default;
+        if (_options.UseAdaptiveLearningRate) return false;
+        if (!TryGetFusedLrSchedule(out var schedule)) return false;
+        config = new Fused.FusedOptimizerConfig(
+            Tensors.Engines.Compilation.OptimizerType.AMSGrad,
+            (float)GetCurrentLearningRate(),
+            (float)_options.Beta1, (float)_options.Beta2, (float)_options.Epsilon,
+            0f, schedule);
+        return true;
     }
 
     /// <summary>

--- a/tests/AiDotNet.Tests/IntegrationTests/Optimizers/FusedOptimizerParityTests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/Optimizers/FusedOptimizerParityTests.cs
@@ -220,4 +220,14 @@ public class FusedOptimizerParityTests
                 null, new LAMBOptimizerOptions<float, Tensor<float>, Tensor<float>> { InitialLearningRate = 1e-2 }));
         AssertOptimizerParity("LAMB", fusedSteps, diff, trainDelta, adamDiff);
     }
+
+    [Fact]
+    public void AMSGrad_FusedMatchesEager_NoWorseThanAdam()
+    {
+        var (adamDiff, _, _) = Divergence(Adam);
+        var (diff, fusedSteps, trainDelta) = Divergence(() =>
+            new AMSGradOptimizer<float, Tensor<float>, Tensor<float>>(
+                null, new AMSGradOptimizerOptions<float, Tensor<float>, Tensor<float>> { InitialLearningRate = 1e-2 }));
+        AssertOptimizerParity("AMSGrad", fusedSteps, diff, trainDelta, adamDiff);
+    }
 }


### PR DESCRIPTION
## Summary
#653 core-saturation, training-perf lever: widen fused-optimizer coverage so AMSGrad no longer falls off the fused compiled training path into the eager tape fallback.

`AMSGradOptimizer<T>` now implements `IFusedOptimizerSpec` and maps to the Tensors `OptimizerType.AMSGrad` fused kernel via `TryMapToFusedOptimizerConfig`, so `TrainWithTape` keeps AMSGrad on the fused fast path (which eliminates the bulk of the tape-walk backward cost) instead of dropping to the eager fallback cliff. The map is guarded: it declines (returns false) when `UseAdaptiveLearningRate` is set or the LR schedule isn't fused-representable, so those paths still run eager — correctness preserved.

## Tests
`FusedOptimizerParityTests.AMSGrad_FusedMatchesEager_NoWorseThanAdam` — runs the fused (compiled) vs eager training step for 40 steps and asserts:
- the fused path actually engages (`fusedSteps > 0`),
- training makes progress (`trainDelta > 1e-6`),
- fused-vs-eager parameter divergence stays within the Adam-parity bound.

Green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * AMSGrad optimizer now supports fused-training compilation mode for optimized performance.

* **Tests**
  * Added integration test to verify training parity between fused and eager execution modes for AMSGrad.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->