### PR TITLE
chore(deps): bump AiDotNet.Tensors to 0.102.3 (consume #658 forward-GEMM saturation)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -157,12 +157,17 @@
     <!-- 0.96.3: carried the FP16 non-Adam fused-optimizer fix —
          FusedOptimizerIntegrationTests.Fp16Activations_NonAdamFusedOptimizer_DescendsLoss
          (FP16 RMSprop) was a training no-op (bit-identical first/last loss) on 0.96.1; fixed there. -->
-    <!-- 0.97.2: latest published (from master); supersedes 0.96.3.
+    <!-- 0.97.2: published (from master); supersedes 0.96.3.
          Native packages coreleased in lockstep at 0.97.2. -->
-    <PackageVersion Include="AiDotNet.Tensors" Version="0.97.2" />
-    <PackageVersion Include="AiDotNet.Native.OneDNN" Version="0.97.2" />
-    <PackageVersion Include="AiDotNet.Native.OpenBLAS" Version="0.97.2" />
-    <PackageVersion Include="AiDotNet.Native.CLBlast" Version="0.97.2" />
+    <!-- 0.102.3: latest published; carries #658 — forward-GEMM core saturation
+         default-on (s_forwardPackBothBlocking + s_singleRegion, opt-out
+         AIDOTNET_GEMM_FORWARD_PACKBOTH=0 / AIDOTNET_GEMM_SINGLE_REGION=0; ~1.3-2x on
+         transformer/training GEMM shapes) + net471 PackAOnly non-4x4 tail bugfix.
+         Native packages coreleased in lockstep at 0.102.3. -->
+    <PackageVersion Include="AiDotNet.Tensors" Version="0.102.3" />
+    <PackageVersion Include="AiDotNet.Native.OneDNN" Version="0.102.3" />
+    <PackageVersion Include="AiDotNet.Native.OpenBLAS" Version="0.102.3" />
+    <PackageVersion Include="AiDotNet.Native.CLBlast" Version="0.102.3" />
     <!-- Microsoft / .NET -->
     <PackageVersion Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageVersion Include="Microsoft.Data.Sqlite" Version="10.0.9" />


### PR DESCRIPTION
## Summary
Bumps `AiDotNet.Tensors` + the native packages (OneDNN / OpenBLAS / CLBlast) from 0.97.2 → **0.102.3** so AiDotNet consumes the merged Tensors [#658](https://github.com/ooples/AiDotNet.Tensors/pull/658):

- **Forward-GEMM core saturation, now default-on** (`s_forwardPackBothBlocking` + `s_singleRegion`; opt-out `AIDOTNET_GEMM_FORWARD_PACKBOTH=0` / `AIDOTNET_GEMM_SINGLE_REGION=0`). On the forward/training GEMM path (`BatchMatMul → BlasManaged.Gemm → PackBothStrategy`) this measured ~1.3–2.0× across a 10-shape min-of-many A/B with no regression (FFN-up 1.78×, FFN-down 1.97×, squares/QKV/batched 1.3–1.7×, LM-head neutral) — i.e. training/inference GEMMs now fan across the cores instead of capping at ~8/32.
- **net471 PackAOnly non-4×4 scalar-tail bugfix** (correctness on no-AVX2 hosts).

Native packages coreleased in lockstep at 0.102.3.

## Validation
- Test project builds clean against 0.102.3 (0 errors; the 0.97→0.102 jump has no breaking API changes for AiDotNet).
- `FusedOptimizerParityTests` 9/9 green against 0.102.3 (includes the AMSGrad fused-path test from #1653, confirming the fused optimizer path still works with the new package).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated core library dependencies to newer versions for enhanced performance and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->