### PR TITLE
chore: build(deps): bump aidotnet.tensors + native packages to 0.102.9

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -192,10 +192,10 @@
          AIDOTNET_GEMM_SINGLE_REGION=0; ~1.3-2x on transformer/training GEMM shapes) + the net471
          PackAOnly non-4x4 scalar-tail bugfix. 0.102.3 is a linear superset of 0.102.2, so the #632 /
          Phase C deps above are retained. -->
-    <PackageVersion Include="AiDotNet.Tensors" Version="0.102.3" />
-    <PackageVersion Include="AiDotNet.Native.OneDNN" Version="0.102.3" />
-    <PackageVersion Include="AiDotNet.Native.OpenBLAS" Version="0.102.3" />
-    <PackageVersion Include="AiDotNet.Native.CLBlast" Version="0.102.3" />
+    <PackageVersion Include="AiDotNet.Tensors" Version="0.102.9" />
+    <PackageVersion Include="AiDotNet.Native.OneDNN" Version="0.102.9" />
+    <PackageVersion Include="AiDotNet.Native.OpenBLAS" Version="0.102.9" />
+    <PackageVersion Include="AiDotNet.Native.CLBlast" Version="0.102.9" />
     <!-- Microsoft / .NET -->
     <PackageVersion Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageVersion Include="Microsoft.Data.Sqlite" Version="10.0.9" />


### PR DESCRIPTION
Bumps **AiDotNet.Tensors** and the lockstep native packages (Native.OneDNN / Native.OpenBLAS / Native.CLBlast) **0.102.3 → 0.102.9**.

## Why
0.102.9 carries **Tensors PR #668** — `fix(gpu): track WAW/WAR buffer hazards in the deferred execution graph`. That fixes the GPU deferred-execution-graph producing **~100%-wrong output** for the UNet encoder→decoder **skip-connection / concat** pattern (root-caused on a GTX 1660 Ti), i.e. the upstream bug **ooples/AiDotNet.Tensors#670** that blocks **#1650** (opt-in GPU deferred-graph denoising). It also picks up the intervening 0.102.4–0.102.8 fixes.

## Double-check (this box, net10.0)
- `src/AiDotNet.csproj` (main library) — restore + build **clean** against 0.102.9.
- `tests/AiDotNet.Tests` — build **clean** against 0.102.9.
- No breaking API changes from 0.102.3 (no NU/CS errors).

## Follow-up (separate, needs CUDA)
This unblocks **#1650**: once it rebases onto this bump, its CUDA-gated `DiffusionGpuExecutionGraphCudaTests` (`TensorsDeferredGraphFixed`) can be flipped to `true` and re-run on a CUDA box to confirm the deferred denoise now equals the eager forward, before #1650 leaves draft. The GPU-correctness flip is **not** verifiable on this non-CUDA box.

🤖 Generated with [Claude Code](https://claude.com/claude-code)