### PR TITLE
ci: run build/sonar/codacy on ready_for_review (draft-gated workflows)

### DIFF
--- a/.github/workflows/codacy.yml
+++ b/.github/workflows/codacy.yml
@@ -11,6 +11,9 @@ on:
       - '**.csproj'
       - '.github/workflows/codacy.yml'
   pull_request:
+    # Include ready_for_review (default types omit it): the codacy job is gated on
+    # draft != true, so a draft→ready transition must re-trigger it.
+    types: [opened, synchronize, reopened, ready_for_review]
     branches: [ master, main ]
     paths:
       - '**.cs'

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -9,7 +9,10 @@ on:
       - master
       - main
   pull_request:
-    types: [opened, synchronize, reopened]
+    # ready_for_review is REQUIRED: the build/test/sonar jobs below are gated on
+    # `github.event.pull_request.draft != true`, so without this event type a draft→ready
+    # transition never re-triggers them and the PR is left with no Build/Tests run.
+    types: [opened, synchronize, reopened, ready_for_review]
   workflow_dispatch:
     inputs:
       pr_number:


### PR DESCRIPTION
## Problem
Marking a PR **draft → ready** doesn't run Build/Tests/SonarCloud/Codacy. Observed on #1650 after it was marked ready — Build/Tests/CodeQL/SonarCloud/Codacy all show **"skipping"** with no way to get a green Build.

## Root cause
`sonarcloud.yml` (Build + Tests + SonarCloud) and `codacy.yml` gate their jobs on `github.event.pull_request.draft != true`, but their `pull_request` triggers only listen for `[opened, synchronize, reopened]` — **not `ready_for_review`**. So:
- While the PR is a draft, the workflows trigger (opened/synchronize) but every job **skips** (draft gate).
- When the PR is marked ready (a `ready_for_review` event), the workflows **don't re-trigger** — that event type isn't listed.

Result: a draft→ready PR has no Build/Tests run until an *unrelated* `synchronize` (a new push) happens to fire.

## Fix
Add `ready_for_review` to both workflows' `pull_request.types`:
- `sonarcloud.yml`: `[opened, synchronize, reopened]` → `+ ready_for_review`.
- `codacy.yml`: had no explicit `types` (default set also omits `ready_for_review`) → add explicit `types: [opened, synchronize, reopened, ready_for_review]`.

Both YAMLs validated (parse OK). No job logic changed — only when the workflows fire.

## Note
`pull_request` workflows run from the **base branch** version, so this only takes effect for PRs once it's merged to master. To get CI on **#1650 right now** (before this merges), push any commit to it (a `synchronize`) or reopen it (`reopened`) — both are already in the trigger list and now that it's not a draft, the jobs will run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)