### PR TITLE
fix(deps): bump AiDotNet.Tensors 0.102.9 → 0.102.12 (conv ArrayPool host-crash fix)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -192,7 +192,7 @@
          AIDOTNET_GEMM_SINGLE_REGION=0; ~1.3-2x on transformer/training GEMM shapes) + the net471
          PackAOnly non-4x4 scalar-tail bugfix. 0.102.3 is a linear superset of 0.102.2, so the #632 /
          Phase C deps above are retained. -->
-    <PackageVersion Include="AiDotNet.Tensors" Version="0.102.9" />
+    <PackageVersion Include="AiDotNet.Tensors" Version="0.102.12" />
     <PackageVersion Include="AiDotNet.Native.OneDNN" Version="0.102.9" />
     <PackageVersion Include="AiDotNet.Native.OpenBLAS" Version="0.102.9" />
     <PackageVersion Include="AiDotNet.Native.CLBlast" Version="0.102.9" />


### PR DESCRIPTION
## Why the failing-shard count was *rising*

Over the last several Tensors bumps, CI went from ~17 → ~29 failing shards even as raw GEMM/conv perf improved. The increase was **chunky** — whole shards flipping red together — which is the signature of a **host-process crash**, not a drift of independent test regressions.

Root cause (fixed in **Tensors [#672](https://github.com/ooples/AiDotNet.Tensors/pull/672)**, shipped in **0.102.12**): a native `AccessViolationException` in `ArrayPool<float>.Shared` for `fp32` GEMM shapes too small for the `6×16` SIMD tile. `BlasManaged.Gemm`'s small-M scalar fallback reset the tile to `mr=4` and then re-checked alignment against the *new* `mr=4`, so `m=4` slipped into `PackBothStrategy` — whose fp32 pack + machine-code kernel assume `mr=6` — overran the pooled buffer and **corrupted the shared pool free-list**. The next `Rent` anywhere faulted and took down the **entire test host**, aborting every remaining test in the shard.

The real-world trigger is a **1×1 stride-2 conv** (ResNet/diffusion-UNet downsample, e.g. `inC=512 4×4 → outC=1024`): im2col → `SGEMM m=4, k=512, n=1024`. That's why **every** shard running CNN convs died together:
- `Unit - 08a NN-Classic (ResNet/VGG/DenseNet)`
- all 9 `ModelFamily - Diffusion *` + 6 `Unit - 03b/03c*/03d Diffusion *`
- `ModelFamily - NeuralNetworks *`, `Generated Layers *`
- the CNN-training `Integration` shards

## The fix

This PR just bumps the pin `0.102.9 → 0.102.12` (which also catches master up past `0.102.10/0.102.11`'s GEMM mis-routing fix). No source changes.

## Verification

Tensors #672 is verified end-to-end on an AVX2 box (GTX 1660 Ti):
- New `Conv2DIm2colArrayPoolReproTests` reproduced the crash pre-fix; passes post-fix (full-buffer + naive-reference correctness assertions).
- The real **AiDotNet** `ResNetNetworkTests` (**56/56**) and `ConvolutionalNeuralNetworkTests` (**21/21**) pass through the full model+layer stack with 0.102.12 swapped in — both were host crashes before.
- Tensors CI green (build / avx512 / gemm-bench / CodeRabbit).

CI on this PR is the completed-run confirmation that the previously-crashing shards go green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated a NuGet package dependency to the latest version for improved stability and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->