### PR TITLE
fix(diffusion): disable unsafe inference arena in the denoise loop (#1668)

### DIFF
--- a/src/Diffusion/DiffusionModelBase.cs
+++ b/src/Diffusion/DiffusionModelBase.cs
@@ -669,11 +669,22 @@ public abstract class DiffusionModelBase<T> : IDiffusionModel<T>, IConfigurableM
         // latent (`sample`) is the one value that must survive each Reset, so it is
         // detached to a GC-owned buffer below. The pre-allocated `sampleTensor` /
         // `noisePredVec` are created above (outside the arena) and are therefore GC.
-        // Gated by the same default-on flag as the Predict funnel; null = no arena.
         // (The async GenerateAsyncCore path is intentionally NOT wrapped: TensorArena.Current
         // is [ThreadStatic] and `await ...ConfigureAwait(false)` can resume on another thread,
         // which would desynchronise the arena scope — an async-aware arena is a separate change.)
-        using var arena = InferenceArenaSettings.Enabled ? TensorArena.Create() : null;
+        //
+        // Gated by DiffusionDenoiseEnabled (default OFF), NOT the default-on Predict-funnel flag:
+        // unlike the single-shot Predict funnel, the multi-step denoise loop is NOT arena-safe.
+        // Diffusion forward layers hold cross-forward cached tensors (e.g. DiffusionResBlock's
+        // pre-allocated GroupNorm output buffer; attention reshape scratch) first allocated inside
+        // this arena scope; the per-step Reset() recycles that memory, so a later step's allocation
+        // aliases a still-referenced cached buffer and corrupts its shape — observed as a downsample
+        // conv output emerging with a stale [B, H*W, C] attention layout, surfacing as "Input has N
+        // channels but layer expects M" (and a native host crash when it corrupts the shared pool).
+        // Re-enable only after the layer caches are made arena-safe. See issue #1668.
+        using var arena = (InferenceArenaSettings.Enabled && InferenceArenaSettings.DiffusionDenoiseEnabled)
+            ? TensorArena.Create()
+            : null;
 
         // Iterative denoising loop
         foreach (var timestep in _scheduler.Timesteps)

--- a/src/NeuralNetworks/InferenceArenaSettings.cs
+++ b/src/NeuralNetworks/InferenceArenaSettings.cs
@@ -33,4 +33,28 @@ public static class InferenceArenaSettings
             Environment.GetEnvironmentVariable("AIDOTNET_INFERENCE_ARENA"),
             "0",
             StringComparison.Ordinal);
+
+    /// <summary>
+    /// Whether the multi-step diffusion denoise loop (<c>DiffusionModelBase.Generate</c>) opens a
+    /// per-step <c>TensorArena</c>. Default <c>OFF</c> — distinct from the single-shot
+    /// <see cref="Enabled"/> Predict funnel, which is bit-identical and safe.
+    /// </summary>
+    /// <remarks>
+    /// The denoise loop is NOT arena-safe: diffusion forward layers hold <em>cross-forward</em>
+    /// cached tensors (e.g. <c>DiffusionResBlock</c>'s pre-allocated GroupNorm output buffer, and
+    /// attention reshape scratch) that are first allocated <em>inside</em> the arena scope. The
+    /// per-step <c>arena.Reset()</c> then recycles that memory, so a later step's allocation aliases
+    /// a still-referenced cached buffer and corrupts its shape/data — observed as a downsample conv
+    /// output emerging with a stale <c>[B, H*W, C]</c> attention layout, surfacing downstream as
+    /// "Input has N channels but layer expects M" (and, when it corrupts the shared pool, a native
+    /// host crash). Single-step <c>Predict</c> never hits this because there is no second step to
+    /// recycle into. Re-enable ONLY after the diffusion layer caches are made arena-safe
+    /// (GC-allocated, or pinned across <c>Reset()</c>). Opt in with
+    /// <c>AIDOTNET_INFERENCE_ARENA_DIFFUSION=1</c>.
+    /// </remarks>
+    public static bool DiffusionDenoiseEnabled { get; set; } =
+        string.Equals(
+            Environment.GetEnvironmentVariable("AIDOTNET_INFERENCE_ARENA_DIFFUSION"),
+            "1",
+            StringComparison.Ordinal);
 }


### PR DESCRIPTION
Closes #1668 (the biggest CI-shard lever from epic #1673).

## Problem
The inference forward-caching arena (`#1661`, `InferenceArenaSettings.Enabled`, default-ON) wraps `DiffusionModelBase.Generate`'s multi-step denoise loop with a per-step `Reset()`. The loop detaches the carried latent, but **diffusion forward layers hold cross-forward cached tensors** (e.g. `DiffusionResBlock`'s pre-allocated GroupNorm output buffer; attention reshape scratch) first allocated *inside* the arena scope. `Reset()` recycles that memory, so a later step's allocation **aliases a still-referenced cached buffer** and corrupts its shape — a downsample conv output emerged as a stale `[B, H*W, C]` attention layout (`[1,16,128]` not `[1,128,4,4]`), surfacing as `Input has N channels but layer expects M`, and escalating to a **native host crash** (shard abort) when it corrupted `ArrayPool.Shared`.

This was the dominant cause of the failing **diffusion `ModelFamily` + `Unit 03b/03d`** shards on master (clean run `28023414937`). Single-shot `NeuralNetworkBase.Predict` is unaffected — no second step to recycle into.

## Fix
Gate the denoise-loop arena behind a new `InferenceArenaSettings.DiffusionDenoiseEnabled` (**default OFF**; opt in via `AIDOTNET_INFERENCE_ARENA_DIFFUSION=1`). The default-on Predict-funnel arena (bit-identical, safe — ResNet/CNN unaffected) is **untouched**. Correctness over the per-step recycling perf win; the flag lets us re-enable once diffusion layer caches are made arena-safe (follow-up in #1668).

## Verification (local, master + Tensors 0.102.12, **default env** so the NN arena stays ON)
- `DDPMModelTests` 38/38, `SyncDreamerModelTests` pass (were failing with the `1 channel` corruption).
- `ControlNetXSModelTests` / `StableSRModelTests` / `SUPIRModelTests` / `StableDiffusion3ModelTests` **52/52** (were the caught failures in Diffusion A-C / Stable / Step-Sync).
- CI on this PR is the completed-run confirmation across the full diffusion family.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new configuration option to control tensor arena memory optimization for diffusion model inference. Disabled by default; can be enabled via the `AIDOTNET_INFERENCE_ARENA_DIFFUSION` environment variable for advanced performance tuning.

* **Refactor**
  * Improved memory arena conditional logic in diffusion model inference to provide more granular control over when optimization features are applied.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->