### PR TITLE
fix(clone): stop COW layer-walk recursing through pointer fields (#1669)

### DIFF
--- a/src/Helpers/CopyOnWriteCloneHelper.cs
+++ b/src/Helpers/CopyOnWriteCloneHelper.cs
@@ -102,7 +102,16 @@ internal static class CopyOnWriteCloneHelper
             // Absolute backstop: a pathologically deep/cyclic object graph that the visited-set could
             // not bound. Returning an empty list makes TryShareTrainableParameters fall back to the
             // eager flat copy (always correct, just not COW-shared) instead of risking a host stack
-            // overflow. With the leaf-skips below this is unreachable for every real model graph.
+            // overflow. With the leaf-skips below this is unreachable for every real model graph — so a
+            // trip is a genuine regression signal (a new self-regenerating field type), NOT a routine
+            // event. Surface it via Trace (observable in Release; the codebase's existing diagnostic
+            // idiom) rather than swallowing it silently, otherwise the COW-disabling fallback would
+            // quietly reintroduce the large-Clone() OOM pressure (#1624) with zero observability.
+            System.Diagnostics.Trace.TraceWarning(
+                $"CopyOnWriteCloneHelper: trainable-layer walk for '{root.GetType().FullName}' exceeded " +
+                $"MaxWalkDepth ({MaxWalkDepth}) and fell back to the eager Clone copy. This is expected to " +
+                "be unreachable — investigate a newly-introduced self-regenerating field type in the model " +
+                "object graph (the #1669 failure class).");
             layers.Clear();
         }
         return layers;
@@ -110,11 +119,12 @@ internal static class CopyOnWriteCloneHelper
 
     /// <summary>
     /// Hard ceiling on the reflective walk's recursion depth. Real model object graphs nest only a few
-    /// dozen levels; this guard exists purely so a previously-unseen self-regenerating field type can
-    /// never stack-overflow the test host (the failure mode behind #1669). It is set far above any
-    /// legitimate depth so it never trips for a real model.
+    /// dozen levels, so this is a conservative ~5–10× margin above any legitimate depth: it never trips
+    /// for a real model, yet caps frames well short of a host stack overflow. The guard exists purely as
+    /// a fail-safe so a previously-unseen self-regenerating field type can never stack-overflow the test
+    /// host (the failure mode behind #1669) before the pointer/leaf skips below intercept it.
     /// </summary>
-    private const int MaxWalkDepth = 1024;
+    private const int MaxWalkDepth = 256;
 
     private sealed class CollectDepthExceededException : System.Exception { }
 

--- a/src/Helpers/CopyOnWriteCloneHelper.cs
+++ b/src/Helpers/CopyOnWriteCloneHelper.cs
@@ -93,13 +93,35 @@ internal static class CopyOnWriteCloneHelper
         var layers = new List<ITrainableLayer<T>>();
         // CollectInto walks arbitrary instance fields, so it is necessarily typed `object?` internally;
         // the public entry point constrains the root to a model so callers can't pass an unrelated graph.
-        CollectInto(root, layers, new HashSet<object>(TensorReferenceComparer<object>.Instance));
+        try
+        {
+            CollectInto(root, layers, new HashSet<object>(TensorReferenceComparer<object>.Instance), 0);
+        }
+        catch (CollectDepthExceededException)
+        {
+            // Absolute backstop: a pathologically deep/cyclic object graph that the visited-set could
+            // not bound. Returning an empty list makes TryShareTrainableParameters fall back to the
+            // eager flat copy (always correct, just not COW-shared) instead of risking a host stack
+            // overflow. With the leaf-skips below this is unreachable for every real model graph.
+            layers.Clear();
+        }
         return layers;
     }
 
-    private static void CollectInto<T>(object? obj, List<ITrainableLayer<T>> layers, HashSet<object> visited)
+    /// <summary>
+    /// Hard ceiling on the reflective walk's recursion depth. Real model object graphs nest only a few
+    /// dozen levels; this guard exists purely so a previously-unseen self-regenerating field type can
+    /// never stack-overflow the test host (the failure mode behind #1669). It is set far above any
+    /// legitimate depth so it never trips for a real model.
+    /// </summary>
+    private const int MaxWalkDepth = 1024;
+
+    private sealed class CollectDepthExceededException : System.Exception { }
+
+    private static void CollectInto<T>(object? obj, List<ITrainableLayer<T>> layers, HashSet<object> visited, int depth)
     {
         if (obj is null || !visited.Add(obj)) return;
+        if (depth > MaxWalkDepth) throw new CollectDepthExceededException();
         if (obj is ITrainableLayer<T> trainable) layers.Add(trainable);
 
         var type = obj.GetType();
@@ -114,17 +136,34 @@ internal static class CopyOnWriteCloneHelper
                 field.FieldType == typeof(string) || field.FieldType == typeof(Tensor<T>))
                 continue;
 
+            // Skip unmanaged pointer fields (void*, byte*, T*, ...). Reflecting a pointer field via
+            // FieldInfo.GetValue boxes it into a FRESH System.Reflection.Pointer object on EVERY call,
+            // and that wrapper's own `_ptr` field is itself a pointer — so following it spirals into
+            // unbounded recursion (a brand-new Pointer per level, never deduped by the visited set),
+            // stack-overflowing the host. A pointer can never reference an ITrainableLayer, so it is
+            // always a leaf. This was the single shared cycle behind #1669's NN/Generated shard host
+            // crashes: any model whose graph transitively reached a native pointer (e.g. the
+            // foundation-scale weight-streaming / mmap path) hit it.
+            if (field.FieldType.IsPointer)
+                continue;
+
             var val = field.GetValue(obj);
             if (val is null) continue;
+
+            // Defensive companion to the IsPointer field-skip above: a pointer can also surface through
+            // an object-/interface-typed field, where the declared FieldType is not IsPointer but the
+            // runtime value is a System.Reflection.Pointer. Treat it as a leaf too so the same
+            // wrap-per-call spiral cannot recur via that path.
+            if (val is System.Reflection.Pointer) continue;
 
             if (val is IEnumerable enumerable && val is not string)
             {
                 foreach (var item in enumerable)
-                    CollectInto(item, layers, visited);
+                    CollectInto(item, layers, visited, depth + 1);
             }
             else
             {
-                CollectInto(val, layers, visited);
+                CollectInto(val, layers, visited, depth + 1);
             }
         }
     }


### PR DESCRIPTION
## Summary

Fixes #1669 — the **StackOverflow host crash** that aborted the NN/Generated model-family CI shards (`ModelFamily - NeuralNetworks A-L / O-R / S / T-Z` and `Generated Layers A-M`). Stack overflow is uncatchable, so it killed the whole test host with no `[FAIL]` recorded.

## Root cause

The reflective trainable-layer collector in `CopyOnWriteCloneHelper.CollectInto` (the COW `Clone()` lever, #1624/#1633) walks **every instance field of every reachable object**. When it reaches an **unmanaged pointer field** (`void*`, `byte*`, `T*`), `FieldInfo.GetValue` boxes it into a **fresh `System.Reflection.Pointer` object on every call**, and that wrapper's own `_ptr` field is *itself* a pointer — so following it spirals into unbounded recursion (a brand-new `Pointer` per level, never deduped by the visited set):

```
CopyOnWriteCloneHelper.CollectInto → CollectInto → CollectInto → …   (Pointer._ptr : Pointer, forever)
```

This was the single shared recursion behind every crashing shard: any model whose object graph transitively reaches a native pointer (the foundation-scale weight-streaming / mmap path on SmolVLM, SGPT, SPLADE, SimCSE, …) hit it; name-ranges with no such model (M-N) were spared — exactly the observed crash pattern.

## Fix (root cause, minimal — `src/Helpers/CopyOnWriteCloneHelper.cs`)

- **Skip unmanaged pointer fields** (`field.FieldType.IsPointer`) *before* `GetValue`, so the `System.Reflection.Pointer` wrapper is never created. A pointer can never reference an `ITrainableLayer`, so it is always a leaf.
- **Defensively** treat a runtime `System.Reflection.Pointer` value as a leaf too (covers a pointer surfaced through an `object`/interface-typed field).
- **Fail-safe depth backstop** (1024, far above any real model graph): on the now-unreachable event of another self-regenerating field type, bail to an empty result so `TryShareTrainableParameters` falls back to the eager flat copy (always correct) instead of ever stack-overflowing the host again.

The COW share path is unchanged for every real model (no model holds a layer behind a pointer), so collection results — and clone fidelity — are identical.

## Validation

- **`NeuralNetworks S` shard** (definitively crashed the host before): now **runs to completion** (22m, **0 crash / abort / stack-overflow markers**). 202 passed, 12 failures — **all pure test timeouts** (9×120s, 3×180s) on foundation-scale models (SmolVLM/SPLADE/SimCSE/SGPT). **Zero** assertion/clone-drift/NaN failures. These pre-existing foundation-scale-model perf timeouts are the "remaining genuine per-model failures tracked separately" the issue scopes out.
- **COW clone correctness**: dedicated `CopyOnWriteCloneTests` green; `Clone_ShouldProduceIdenticalOutput` passed for SGPT / SpikingNeuralNetwork / etc. in the shard.
- Builds **net10.0 + net471**.

## Acceptance

✅ The crashing shards no longer stack-overflow; they run to completion. Remaining per-model timeouts are tracked separately (foundation-scale model speed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes
* Prevented stack overflows/infinite recursion during cloning by adding a maximum traversal depth; when exceeded, traversal safely aborts and falls back to the eager copy approach.
* Hardened reflection-based traversal to better handle pointer-like values by skipping pointer-typed fields and treating pointer wrapper values as leaf nodes.
* Added diagnostic logging when traversal depth limits are hit.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->