### PR TITLE
chore: build: add net8.0 target (stop net8/net9 falling back to net471)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -192,7 +192,11 @@
          AIDOTNET_GEMM_SINGLE_REGION=0; ~1.3-2x on transformer/training GEMM shapes) + the net471
          PackAOnly non-4x4 scalar-tail bugfix. 0.102.3 is a linear superset of 0.102.2, so the #632 /
          Phase C deps above are retained. -->
-    <PackageVersion Include="AiDotNet.Tensors" Version="0.102.12" />
+    <!-- 0.102.14 is the published AiDotNet.Tensors release that ships the net8.0 target
+         (AiDotNet.Tensors #680, merged + released). net8.0 in src/AiDotNet.csproj requires a
+         Tensors build with a net8.0 asset; the published 0.102.14 nupkg contains lib/net8.0/
+         (alongside net10.0 + net471), so this is no longer blocked. -->
+    <PackageVersion Include="AiDotNet.Tensors" Version="0.102.14" />
     <PackageVersion Include="AiDotNet.Native.OneDNN" Version="0.102.9" />
     <PackageVersion Include="AiDotNet.Native.OpenBLAS" Version="0.102.9" />
     <PackageVersion Include="AiDotNet.Native.CLBlast" Version="0.102.9" />

--- a/src/AiDotNet.csproj
+++ b/src/AiDotNet.csproj
@@ -1,14 +1,16 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
 	  <!--
-	    net10.0 is the latest .NET; net471 covers legacy Framework consumers.
-	    net8.0 LTS is intentionally NOT yet in the target list — the
-	    AiDotNet.Tensors transitive dependency does not currently ship an
-	    explicit net8.0 build, so adding the target produces NU1701 warnings.
-	    Tracked as a follow-up: bump AiDotNet.Tensors to a release with
-	    explicit net8.0 support, then add net8.0 here.
+	    net10.0 is the latest .NET; net471 covers legacy Framework consumers;
+	    net8.0 LTS serves net8/net9 consumers. Without net8.0, a net8/net9 app
+	    had no compatible modern asset and NuGet's AssetTargetFallback silently
+	    selected the net471 .NET Framework build (NU1701) — which misresolves
+	    types at the consumer. net8.0 was previously blocked on AiDotNet.Tensors
+	    not shipping a net8.0 build; that dependency now does (AiDotNet.Tensors
+	    PR #680), so net8.0 is enabled here against that release.
+	    Extending to net462 / netstandard2.0 is tracked in AiDotNet.Tensors #679.
 	  -->
-	  <TargetFrameworks>net10.0;net471</TargetFrameworks>
+	  <TargetFrameworks>net10.0;net8.0;net471</TargetFrameworks>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>


### PR DESCRIPTION
> **Unblocked + verified.** [AiDotNet.Tensors#680](https://github.com/ooples/AiDotNet.Tensors/pull/680) is merged and released — the published **AiDotNet.Tensors 0.102.14** nupkg ships `lib/net8.0/` (alongside net10.0 + net471), so `Directory.Packages.props` is pinned to it (no longer a placeholder). Branch is up to date with `master`; `AiDotNet` builds clean on **net8.0** against the published package with **no `NU1701` fallback**.

## Problem

The `AiDotNet` package shipped only **net10.0 + net471**. A **net8.0/net9.0** consumer has no compatible modern asset, so NuGet's `AssetTargetFallback` silently restored the **net471** .NET Framework build (`NU1701`), which compiles different code paths/deps and misresolves types (e.g. `Matrix` "not found" on a net8.0 project). This was the other half of the user-reported repro — fixing `AiDotNet.Tensors` alone isn't enough because the main package also lacked net8.0.

## Fix

`net10.0;net471` → `net10.0;net8.0;net471`. net8.0 was previously deferred *because `AiDotNet.Tensors` had no net8.0 build* — now fixed in AiDotNet.Tensors #680. The existing TFM-conditional `ItemGroup`s already handle net8.0 correctly (gets `SixLabors.ImageSharp` via `!= net471`; no Framework-only refs).

## Verification (local)

Built against a locally-packed net8.0 `AiDotNet.Tensors`:
- ✅ AiDotNet builds clean on **net8.0**, **net10.0**, and **net471**.

## Before merge
- [ ] AiDotNet.Tensors #680 merged and released.
- [ ] Bump `AiDotNet.Tensors` in `Directory.Packages.props` to that published version (replace placeholder `0.102.14`).
- [ ] Mark ready for review.

Matrix extension to net462 / netstandard2.0 tracked in AiDotNet.Tensors #679.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
