### PR TITLE
fix(#1675): green Integration T-Z shard — reproducible init + opt-in LSUV

### DIFF
--- a/src/NeuralNetworks/NeuralNetworkBase.cs
+++ b/src/NeuralNetworks/NeuralNetworkBase.cs
@@ -5796,6 +5796,105 @@ public abstract class NeuralNetworkBase<T> : INeuralNetworkModel<T>, IInterpreta
     /// rather than calling Train one example at a time — see TrainBatched().
     /// </para>
     /// </remarks>
+    // LSUV (Layer-Sequential Unit-Variance) data-dependent init state. Opt-in: enable per
+    // process with AIDOTNET_LSUV_INIT=1. Default-off so it can't change the init trajectory of
+    // the many models whose He/Xavier init is already well-conditioned; turn it on to harden
+    // training of init-sensitive models (it normalizes each layer's output variance to ~1 on the
+    // first batch, removing poorly-conditioned random draws).
+    private bool _lsuvInitDone;
+
+    /// <summary>
+    /// Enables LSUV data-dependent init (see <see cref="ApplyLsuvInitOnce"/>). Opt-in: default-off,
+    /// seeded from the <c>AIDOTNET_LSUV_INIT=1</c> environment variable. Settable so init-sensitive
+    /// training can turn it on programmatically (and so tests can exercise it deterministically).
+    /// </summary>
+    internal static bool LsuvInitEnabled { get; set; } =
+        System.Environment.GetEnvironmentVariable("AIDOTNET_LSUV_INIT") == "1";
+
+    /// <summary>
+    /// Layer-Sequential Unit-Variance init (Mishkin &amp; Matas 2015, "All you need is a good init").
+    /// On the first training step, walks the layer chain in forward order and rescales each
+    /// trainable layer's weights so its output variance over this batch is ~1. Standard
+    /// activation-matched init (He/Xavier) fixes the EXPECTED variance but not its draw-to-draw
+    /// VARIANCE: for small / low-fan-in nets a poorly-conditioned random draw leaves the net
+    /// nearly input-insensitive (collapsed output spread), so a fraction of random inits fail to
+    /// converge in a bounded step budget (the order-dependent-init flakiness). Calibrating to unit
+    /// per-layer output variance removes that tail. Self-limiting: a healthy layer already sits at
+    /// ~unit variance so its scale factor is ~1 and it is left untouched (the &lt;5% guard below),
+    /// so well-conditioned models are unaffected. Opt out via <c>AIDOTNET_LSUV_INIT=0</c>.
+    /// </summary>
+    private void ApplyLsuvInitOnce(Tensor<T> input)
+    {
+        if (_lsuvInitDone || !LsuvInitEnabled) return;
+        _lsuvInitDone = true;
+        if (Layers is null || Layers.Count == 0) return;
+
+        bool wasTraining = IsTrainingMode;
+        SetTrainingMode(false); // calibration forward must not consume dropout/noise RNG
+        try
+        {
+            var current = input;
+            const int maxIters = 4;
+            foreach (var layer in Layers)
+            {
+                if (layer is null) continue;
+                // First forward also materializes lazy weights so GetParameters is non-empty.
+                Tensor<T> outp = layer.Forward(current);
+                if (layer is LayerBase<T> lb)
+                {
+                    var ps = lb.GetParameters();
+                    if (ps is not null && ps.Length > 0)
+                    {
+                        for (int it = 0; it < maxIters; it++)
+                        {
+                            double v = TensorVariance(outp);
+                            if (v <= 1e-12 || double.IsNaN(v) || double.IsInfinity(v)) break;
+                            double scale = Math.Sqrt(1.0 / v);
+                            if (Math.Abs(scale - 1.0) < 0.05) break;        // already ~unit → leave healthy inits untouched
+                            if (scale > 5.0) scale = 5.0; else if (scale < 0.2) scale = 0.2; // bound per-iter correction
+                            var scaleT = NumOps.FromDouble(scale);
+                            var arr = new T[ps.Length];
+                            for (int i = 0; i < ps.Length; i++) arr[i] = NumOps.Multiply(ps[i], scaleT);
+                            ps = new Vector<T>(arr);
+                            lb.SetParameters(ps);
+                            outp = layer.Forward(current);
+                        }
+                    }
+                }
+                current = outp;
+            }
+        }
+        catch
+        {
+            // Best-effort: a layer that can't be forwarded/rescaled here (exotic topology,
+            // non-finite probe) keeps its standard init and training proceeds normally.
+        }
+        finally
+        {
+            SetTrainingMode(wasTraining);
+        }
+    }
+
+    /// <summary>
+    /// Test seam: runs the one-shot LSUV calibration directly (no surrounding training step) so the
+    /// rescaling can be asserted in isolation. Honors <see cref="LsuvInitEnabled"/> exactly as the
+    /// training path does, so a test must enable the flag for this to do anything.
+    /// </summary>
+    internal void ApplyLsuvInitForTest(Tensor<T> calibrationInput) => ApplyLsuvInitOnce(calibrationInput);
+
+    private static double TensorVariance(Tensor<T> t)
+    {
+        var sp = t.Data.Span;
+        int n = sp.Length;
+        if (n == 0) return 0.0;
+        double s = 0.0;
+        for (int i = 0; i < n; i++) s += Convert.ToDouble(sp[i]);
+        double mean = s / n;
+        double s2 = 0.0;
+        for (int i = 0; i < n; i++) { double d = Convert.ToDouble(sp[i]) - mean; s2 += d * d; }
+        return s2 / n;
+    }
+
     public virtual void Train(Tensor<T> input, Tensor<T> expectedOutput)
     {
         // Fresh step: no parameter has been mutated yet, so an OOM during the forward/backward
@@ -5847,6 +5946,16 @@ public abstract class NeuralNetworkBase<T> : INeuralNetworkModel<T>, IInterpreta
         // <c>[C,H,W]</c> / <c>[seq,F]</c> / <c>[F]</c> or batched
         // <c>[B,C,H,W]</c> / <c>[B,seq,F]</c> / <c>[B,F]</c> — both work.
         (input, expectedOutput) = NormalizeBatchDim(input, expectedOutput);
+
+        // Data-dependent LSUV init (Mishkin & Matas 2015): on the FIRST training step, rescale
+        // each trainable layer's weights so its output has ~unit variance across this batch. This
+        // hardens against the order-dependent-init flakiness where a poorly-conditioned random
+        // draw leaves the net nearly input-insensitive (low output spread) so ~1-in-4 random
+        // inits fail to converge in a bounded step budget. Self-limiting: a well-conditioned
+        // layer already has ~unit variance, so its scale factor is ~1 (≈ no-op) — only the
+        // poorly-scaled draws are corrected, bounding the behavioural change for healthy models.
+        // Opt out with AIDOTNET_LSUV_INIT=0.
+        ApplyLsuvInitOnce(input);
 
         // G8 (#1624) — gradient micro-batch accumulation. For a large model with a batch big enough to
         // make activations a memory problem, process the batch in small chunks (forward+backward per

--- a/tests/AiDotNet.Tests/IntegrationTests/LsuvInitTests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/LsuvInitTests.cs
@@ -1,0 +1,129 @@
+using System;
+using System.IO;
+using AiDotNet.Interfaces;
+using AiDotNet.LinearAlgebra;
+using AiDotNet.LossFunctions;
+using AiDotNet.Models;
+using AiDotNet.NeuralNetworks;
+using AiDotNet.NeuralNetworks.Layers;
+using AiDotNet.Tensors;
+using Xunit;
+
+namespace AiDotNet.Tests.IntegrationTests;
+
+/// <summary>
+/// Exercises the opt-in LSUV (Layer-Sequential Unit-Variance) data-dependent init
+/// (Mishkin &amp; Matas 2015) wired into <see cref="NeuralNetworkBase{T}"/>. LSUV runs once on the
+/// first training step: it forwards a calibration batch and rescales each trainable layer's weights
+/// so the layer's output variance is ~1, which removes the poorly-conditioned-random-draw tail that
+/// leaves a small net nearly input-insensitive. These tests prove (a) it actually normalizes a
+/// deliberately badly-scaled net back toward unit output variance, and (b) it is strictly opt-in —
+/// with the flag off (the default) it never touches the weights, so it can't change the training
+/// trajectory of the many models whose standard He/Xavier init is already well-conditioned.
+/// </summary>
+public sealed class LsuvInitTests : IDisposable
+{
+    public void Dispose() => NeuralNetworkBase<float>.LsuvInitEnabled = false;
+
+    /// <summary>Two bare Dense layers — enough for the per-layer calibration walk to compound.</summary>
+    private sealed class TwoLayerNet : NeuralNetworkBase<float>
+    {
+        public TwoLayerNet()
+            : base(lossFunction: new MeanSquaredErrorLoss<float>(), maxGradNorm: 1.0)
+        {
+            Layers.Add(new DenseLayer<float>(outputSize: 12));
+            Layers.Add(new DenseLayer<float>(outputSize: 4));
+        }
+
+        protected override void InitializeLayers() { /* layers added in ctor */ }
+
+        // Route UpdateParameters through the base layer-walking SetParameters so the test's
+        // weight-inflation actually takes effect on the layers.
+        public override void UpdateParameters(Vector<float> parameters) => SetParameters(parameters);
+
+        public override ModelMetadata<float> GetModelMetadata() => new() { Name = "TwoLayerNet" };
+
+        protected override void SerializeNetworkSpecificData(BinaryWriter writer) { }
+        protected override void DeserializeNetworkSpecificData(BinaryReader reader) { }
+
+        protected override IFullModel<float, Tensor<float>, Tensor<float>> CreateNewInstance()
+            => new TwoLayerNet();
+    }
+
+    private static Tensor<float> CalibrationBatch()
+    {
+        // 16 rows × 8 features so the output spread (variance) is well-defined.
+        const int rows = 16, features = 8;
+        var input = new Tensor<float>([rows, features]);
+        for (int r = 0; r < rows; r++)
+            for (int c = 0; c < features; c++)
+                input[r, c] = (float)Math.Sin((r + 1) * 0.37 + c * 0.91); // deterministic, varied
+        return input;
+    }
+
+    private static double OutputVariance(Tensor<float> t)
+    {
+        int n = t.Length;
+        double mean = 0.0;
+        for (int i = 0; i < n; i++) mean += t[i];
+        mean /= n;
+        double s2 = 0.0;
+        for (int i = 0; i < n; i++) { double d = t[i] - mean; s2 += d * d; }
+        return s2 / n;
+    }
+
+    private static void ScaleAllWeights(TwoLayerNet net, float factor)
+    {
+        var p = net.GetParameters();
+        var scaled = new float[p.Length];
+        for (int i = 0; i < p.Length; i++) scaled[i] = p[i] * factor;
+        net.UpdateParameters(new Vector<float>(scaled));
+    }
+
+    [Fact]
+    public void Lsuv_NormalizesBadlyScaledNet_BackTowardUnitOutputVariance()
+    {
+        var net = new TwoLayerNet();
+        var input = CalibrationBatch();
+
+        // Materialize the lazy Dense weights, then deliberately blow the weights up ×50 so the
+        // output variance explodes far past unit scale — the pathological condition LSUV exists to fix.
+        _ = net.Predict(input);
+        ScaleAllWeights(net, 50f);
+
+        double preVar = OutputVariance(net.Predict(input));
+        Assert.True(preVar > 100.0,
+            $"Test setup failed: inflating weights ×50 should explode output variance, but preVar={preVar}.");
+
+        // Run LSUV once (the same calibration the first training step performs).
+        NeuralNetworkBase<float>.LsuvInitEnabled = true;
+        net.ApplyLsuvInitForTest(input);
+
+        double postVar = OutputVariance(net.Predict(input));
+
+        // LSUV calibrates each layer's output variance to ~1, so the final output variance lands in
+        // an O(1) band — a massive reduction from the inflated value.
+        Assert.True(postVar < preVar * 0.05,
+            $"LSUV should have collapsed the inflated output variance (pre={preVar}, post={postVar}).");
+        Assert.InRange(postVar, 0.05, 20.0);
+    }
+
+    [Fact]
+    public void Lsuv_Disabled_IsNoOp_LeavesBadScaleUntouched()
+    {
+        var net = new TwoLayerNet();
+        var input = CalibrationBatch();
+
+        _ = net.Predict(input);
+        ScaleAllWeights(net, 50f);
+        double preVar = OutputVariance(net.Predict(input));
+
+        // Flag OFF (the default). The calibration must NOT run — proving the feature is strictly
+        // opt-in and can't silently alter any model's init.
+        NeuralNetworkBase<float>.LsuvInitEnabled = false;
+        net.ApplyLsuvInitForTest(input);
+
+        double postVar = OutputVariance(net.Predict(input));
+        Assert.Equal(preVar, postVar, 3); // unchanged to 3 decimal places
+    }
+}

--- a/tests/AiDotNet.Tests/IntegrationTests/TrainingGroupsFacadeTests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/TrainingGroupsFacadeTests.cs
@@ -26,6 +26,10 @@ public sealed class TrainingGroupsFacadeTests
     private const int N = 100;          // total rows fed to the loader
     private const int TrainRows = 70;   // facade's internal split: 0.7 train
 
+    // Reproducible init seed — see BuildNet for why this is set on the architecture (not a
+    // [ThreadStatic] ambient seed).
+    private const int InitSeed = 1675;
+
     private static (Tensor<double> X, Tensor<double> Y) BuildLinearData()
     {
         // y = 2x + 1 — trivially learnable, but ONLY if the grouped slices keep each row paired
@@ -44,12 +48,26 @@ public sealed class TrainingGroupsFacadeTests
             new Tensor<double>(new[] { N }, new Vector<double>(y)));
     }
 
-    private static NeuralNetwork<double> BuildNet() => new(new NeuralNetworkArchitecture<double>(
-        inputType: InputType.OneDimensional,
-        taskType: NeuralNetworkTaskType.Regression,
-        complexity: NetworkComplexity.Simple,
-        inputSize: 1,
-        outputSize: 1));
+    private static NeuralNetwork<double> BuildNet()
+    {
+        // Pin per-layer weight init so the "grouped loop genuinely trains" convergence assertions are
+        // reproducible. The net is otherwise built from a non-reproducible, order-dependent init
+        // (RandomHelper.ThreadSafeRandom, advanced by sibling tests on the same worker thread); a
+        // poorly-conditioned draw fails to converge in the optimizer's bounded iteration budget, so the
+        // test flaked under parallel scheduling (#1675). The seed lives on the architecture object
+        // (not a [ThreadStatic] ambient seed) because the facade builds the net via an async pipeline
+        // whose continuation may run on a different thread — the architecture carries the seed across it.
+        var architecture = new NeuralNetworkArchitecture<double>(
+            inputType: InputType.OneDimensional,
+            taskType: NeuralNetworkTaskType.Regression,
+            complexity: NetworkComplexity.Simple,
+            inputSize: 1,
+            outputSize: 1)
+        {
+            RandomSeed = InitSeed,
+        };
+        return new NeuralNetwork<double>(architecture);
+    }
 
     private static IReadOnlyList<IReadOnlyList<int>> PartitionTrainingRows(int groupSize)
     {

--- a/tests/AiDotNet.Tests/IntegrationTests/WeightStreaming/WeightStreamingEndToEndTests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/WeightStreaming/WeightStreamingEndToEndTests.cs
@@ -50,7 +50,7 @@ public sealed class WeightStreamingSingletonCollection : ICollectionFixture<Weig
 /// in PaLMEProfilerTest because it needs ~2 TB of disk.
 /// </summary>
 [Collection("WeightStreaming-Singleton")]
-public sealed class WeightStreamingEndToEndTests
+public sealed class WeightStreamingEndToEndTests : IDisposable
 {
     private readonly WeightStreamingResetFixture _fixture;
 
@@ -63,7 +63,22 @@ public sealed class WeightStreamingEndToEndTests
         // constructor runs per test, so resetting here is the right
         // place. The Dispose half handles teardown after the last test.
         NeuralNetworkBase<float>.ResetWeightStreamingForTests();
+
+        // Pin per-layer weight init so the streaming forward/train assertions are
+        // reproducible. These tests assert on a SmallStreamableNetwork's (untrained)
+        // input-sensitivity and (trained) convergence — both depend on the weight init,
+        // which otherwise comes from the process-shared RandomHelper.ThreadSafeRandom whose
+        // per-thread state depends on how many sibling tests ran first. A poorly-conditioned
+        // draw (low input-sensitivity) made Streaming_PredictEager / Streaming_TrainingStep
+        // flake under parallel scheduling (#1675). Reproducible init is standard for
+        // convergence/forward assertions — the same AmbientFallbackSeed mechanism the
+        // ModelFamily harness uses. Cleared in Dispose so it can't leak to other collections
+        // on a reused worker thread.
+        AiDotNet.NeuralNetworks.Layers.LayerInitializationSeedScope.AmbientFallbackSeed = 1675;
     }
+
+    public void Dispose() =>
+        AiDotNet.NeuralNetworks.Layers.LayerInitializationSeedScope.AmbientFallbackSeed = null;
 
     /// <summary>
     /// Minimal subclass so the test can drive ConfigureWeightLifetime


### PR DESCRIPTION
## Summary

Greens the **Integration T-Z** CI shard, which flaked on ~25% of runs on two
convergence / input-sensitivity assertions: `WeightStreamingEndToEndTests` and
`TrainingGroupsFacadeTests`.

**Root cause** — weight init is non-reproducible and order-dependent. It draws
from `RandomHelper.ThreadSafeRandom` (a `ThreadLocal<Random>` whose per-thread
state advances cumulatively), so a model's init depends on how many sibling
tests drew RNG first on that worker thread. A poorly-conditioned draw leaves a
tiny net nearly input-insensitive and unable to converge in the bounded step
budget, so the assertions failed only under certain parallel schedules. The init
itself is already best-practice (He-for-ReLU); the flake is inherent random-init
variance, which only deterministic init removes (tests were **not** weakened).

## Fixes (reproducible init for the two flaky test classes)

- **`WeightStreamingEndToEndTests`** — pin per-layer init via
  `LayerInitializationSeedScope.AmbientFallbackSeed` (the net builds
  *synchronously* on the test thread, so the `[ThreadStatic]` ambient seed
  applies); cleared in `Dispose`.
- **`TrainingGroupsFacadeTests`** — pin via the **architecture's `RandomSeed`**
  instead. The facade builds the net through an *async* pipeline whose
  continuation can run on a different thread, where a `[ThreadStatic]` ambient
  seed would not be visible; the seed on the architecture object carries across
  the hop. Verified deterministic **and** converging across repeated runs.

## Feature — opt-in LSUV data-dependent init

LSUV (Layer-Sequential Unit-Variance, Mishkin & Matas 2015) in
`NeuralNetworkBase`: on the first training step it forwards the batch and
rescales each trainable layer's weights so its output variance is ~1, removing
the poorly-conditioned-random-draw tail that causes the flakiness above for
init-sensitive models.

- **Strictly opt-in**: default-off, enabled via `AIDOTNET_LSUV_INIT=1` or the
  settable `LsuvInitEnabled` flag — cannot change the init trajectory of the many
  models whose standard init is already well-conditioned.
- **Self-limiting** (a layer already at ~unit variance is left untouched) and
  **best-effort** (exotic topologies fall back to standard init).
- Covered by `LsuvInitTests` (normalizes a ×50-inflated net back to ~unit
  variance; verified no-op when disabled).

## Verification

- Full **T-Z shard: 1551/1551 passing across 3 consecutive runs** (was ~25% flaky),
  `AIDOTNET_DISABLE_GPU=1`, net10.0.
- TrainingGroups + WeightStreaming: **10/10 across 5 runs** (deterministic).
- LSUV feature tests: 2/2.
- `dotnet build` green; no null-forgiving operators introduced.

Stacked on #1675 (now merged), so this diff is only the T-Z commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)