### PR TITLE
ci: split slow serial Integration C shard into ComputerVision + Core

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -546,10 +546,25 @@ jobs:
             project: tests/AiDotNet.Tests/AiDotNetTests.csproj
             framework: net10.0
             filter: 'Category!=GPU&Category!=Stress&(FullyQualifiedName~AiDotNet.Tests.IntegrationTests.A|FullyQualifiedName~AiDotNet.Tests.IntegrationTests.B)'
-          - name: Integration C
+          # Integration C was the largest Integration shard (~2300 cases across
+          # 12 C* namespaces) and the only one forced fully serial — its
+          # ComputerVision namespace instantiates paper-scale segmentation
+          # models that OOM the 16 GB runner under parallel collections. Run
+          # serially it never finished before the concurrency-group cancel
+          # superseded the master run, so it was perpetually red. Split into the
+          # heavy ComputerVision namespace (kept serial) and a Core complement
+          # (everything else, which is algorithm/config/causal tests with small
+          # models — safe to run parallel and fast). The complement filter keeps
+          # the two gap-free + non-overlapping (their union == the old C filter)
+          # and future-proof: any new C* namespace lands in Core automatically.
+          - name: Integration C - ComputerVision
             project: tests/AiDotNet.Tests/AiDotNetTests.csproj
             framework: net10.0
-            filter: 'Category!=GPU&Category!=Stress&FullyQualifiedName~AiDotNet.Tests.IntegrationTests.C'
+            filter: 'Category!=GPU&Category!=Stress&FullyQualifiedName~AiDotNet.Tests.IntegrationTests.ComputerVision'
+          - name: Integration C - Core
+            project: tests/AiDotNet.Tests/AiDotNetTests.csproj
+            framework: net10.0
+            filter: 'Category!=GPU&Category!=Stress&FullyQualifiedName~AiDotNet.Tests.IntegrationTests.C&FullyQualifiedName!~AiDotNet.Tests.IntegrationTests.ComputerVision'
           - name: Integration D
             project: tests/AiDotNet.Tests/AiDotNetTests.csproj
             framework: net10.0
@@ -743,7 +758,7 @@ jobs:
             # Finance, ComputerVision, NeuralNetworks, Diffusion, Video, MetaLearning,
             # etc.) — serialize like the ModelFamily shards to stay under the runner
             # memory envelope. The light integration letter-shards run parallel.
-            'Integration C',
+            'Integration C - ComputerVision',
             'Integration D',
             'Integration E-G',
             'Integration M',


### PR DESCRIPTION
## Why Integration C is red on CI

The `Tests (net10.0) - Integration C` shard is red because of **concurrency-cancellation, not test failures.** It's the largest Integration shard (~2300 cases across 12 `C*` namespaces) and the **only one forced fully serial** — its `ComputerVision` namespace instantiates paper-scale segmentation models that OOM the 16 GB runner under parallel collections, so it's in `$heavyShards`. Run serially it never finishes before `cancel-in-progress: true` supersedes the master run. Every recent run's C job ends in `##[error]The runner has received a shutdown signal` / `operation was canceled` after a *passing* test — the CI logs show **0 test failures**; it simply never completes. Meanwhile every other Integration shard finishes in time.

## The split

Replace `Integration C` with two shards:

- **`Integration C - ComputerVision`** — kept serial (in `$heavyShards`); the paper-scale segmentation models.
- **`Integration C - Core`** — the complement (`~IntegrationTests.C & !~IntegrationTests.ComputerVision`), run **parallel** (removed from `$heavyShards`): algorithm/config/causal tests with small models, which are fast and memory-safe in parallel.

The complement filter keeps the two **gap-free, non-overlapping** (their union is exactly the old `C` filter) and **future-proof** — any new `C*` namespace automatically lands in Core. This lets the ~1650-test Core sub-shard go green reliably and finish quickly, and lets ComputerVision *finish* instead of being perpetually cancelled.

## Scope / relationship to the OOM epic

This is the **structural** half of fixing Integration C and is independent of the test-side memory work in #1689. Once ComputerVision actually finishes, it surfaces pre-existing **foundation-scale training OOMs** (large segmentation models' `*_MultiStepTrain_DoesNotThrow`) that CI never reached before. Those are tracked in **#1688** and follow the **#1684** playbook / **#1622** tracker; verified root cause for the dominant case is the **conv-backward im2col transient activation peak** (the models are <1 MB params — not a weights/optimizer issue), whose real fix is im2col tiling in `CpuEngine.Conv2DBackward` (Tensors-side, in progress). This PR does not attempt that — it makes the shard finish and greens Core.

Refs #1684 #1622 #1688

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Split one integration test shard into two smaller shards to improve test distribution and coverage.
  * Adjusted test serialization so the computer vision integration tests run in their own shard.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->