### PR TITLE
fix: bump aidotnet.tensors to 0.103.1 — fix ModelFamily-NeuralNetworks streaming crash

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -192,10 +192,13 @@
          AIDOTNET_GEMM_SINGLE_REGION=0; ~1.3-2x on transformer/training GEMM shapes) + the net471
          PackAOnly non-4x4 scalar-tail bugfix. 0.102.3 is a linear superset of 0.102.2, so the #632 /
          Phase C deps above are retained. -->
-    <!-- 0.102.17 is the published AiDotNet.Tensors release that ships the diffusion CUDA-graph capture +
-         all-backend FP16 conv + FP16-activation work (AiDotNet.Tensors #671, merged + released) on top of the
-         net8.0 target (#680). Ships lib/net8.0 + net10.0 + net471. This is what #1650's diffusion path requires. -->
-    <PackageVersion Include="AiDotNet.Tensors" Version="0.102.17" />
+    <!-- 0.103.1 ships the weight-streaming ReleaseToPool soft-defer fix (AiDotNet.Tensors #692): the
+         strict storage drop threw "sole storage ownership; refcount 2" during MaterializeScope.Dispose,
+         the ROOT CAUSE of the foundation-scale ModelFamily-NeuralNetworks shard failures (Phi3Vision et al.
+         fail with that AggregateException on a 16 GB runner). Also carries the 0.102.18+/0.103.0 conv perf
+         (implicit-GEMM #690, dcnv3 #691) + the prior diffusion CUDA-graph + FP16 work (#671/#680).
+         Ships lib/net8.0 + net10.0 + net471. -->
+    <PackageVersion Include="AiDotNet.Tensors" Version="0.103.1" />
     <PackageVersion Include="AiDotNet.Native.OneDNN" Version="0.102.9" />
     <PackageVersion Include="AiDotNet.Native.OpenBLAS" Version="0.102.9" />
     <PackageVersion Include="AiDotNet.Native.CLBlast" Version="0.102.9" />


### PR DESCRIPTION
## What

Bumps `AiDotNet.Tensors` `0.102.17` -> `0.103.1`.

## Why

`0.103.1` ships AiDotNet.Tensors **#692**, the root-cause fix for the
**ModelFamily – NeuralNetworks** CI shard failures.

Those shards are not failing on the models — the models are correct (they pass
with weight-streaming off). They fail because of a weight-streaming bug:
`WeightRegistry.ReleaseToPool` used the strict storage drop, which throws
`"sole storage ownership; refcount 2"` when a forward-time peer (COW clone /
compiled-plan rebind / int-quant alias) shares a materialized streaming weight's
storage. `MaterializeScope.Dispose` aggregates that into the `AggregateException`
that breaks every paper-scale VLM forward on the 16 GB runner. The near-master O-R
shard fails on **Phi3Vision x10**, every one with that exact exception.

#692 mirrors the established #430 soft-defer fix (defer the drop instead of
throwing). Validated upstream: 56/56 streaming tests + the exact consumer repro.

## Note

A separate streaming **perf** timeout (paper-scale single-forward churn on the
16 GB runner) is tracked independently; this PR lands the correctness fix that
removes the crash/AggregateException class.

🤖 Generated with [Claude Code](https://claude.com/claude-code)