### PR TITLE
perf(optimizer): raw-array Adam8Bit BF16 quant/dequant (PerfView NN-shard hot path)

### DIFF
--- a/src/Optimizers/Adam8BitOptimizer.cs
+++ b/src/Optimizers/Adam8BitOptimizer.cs
@@ -420,8 +420,8 @@ public class Adam8BitOptimizer<T, TInput, TOutput> : GradientBasedOptimizerBase<
 
         // BF16 moment storage (UseBFloat16MomentStorage == true): 2 bytes/element, no per-block
         // scales. Mutually exclusive with the byte-quantized fields above — only one set is allocated.
-        public Vector<ushort>? MBf16;
-        public Vector<ushort>? VBf16;
+        public ushort[]? MBf16;
+        public ushort[]? VBf16;
 
         // GPU-resident 8-bit state (AIDOTNET_GPU_ADAM=1, CUDA): int8 m/v + per-block
         // double scales kept on the device across steps so the adam8bit_update kernel
@@ -710,8 +710,8 @@ public class Adam8BitOptimizer<T, TInput, TOutput> : GradientBasedOptimizerBase<
             {
                 Length = paramLength,
                 NumBlocks = 0,
-                MBf16 = new Vector<ushort>(paramLength),
-                VBf16 = new Vector<ushort>(paramLength),
+                MBf16 = new ushort[paramLength],
+                VBf16 = new ushort[paramLength],
             };
         }
 
@@ -894,14 +894,23 @@ public class Adam8BitOptimizer<T, TInput, TOutput> : GradientBasedOptimizerBase<
     /// Expands a BF16 (2 bytes/element) moment buffer into a freshly-allocated full-precision tensor of
     /// the given shape. Transient — consumed within a single Step iteration and released to the arena.
     /// </summary>
-    private Tensor<T> Bf16ToTensor(Vector<ushort> bf16, int[] paramShape)
+    private Tensor<T> Bf16ToTensor(ushort[] bf16, int[] paramShape)
     {
         var result = new Tensor<T>(paramShape);
         int length = result.Length;
-        CpuParallelSettings.ParallelForOrSerial(0, length, (long)length, i =>
+        // Raw-array dequant (no Tensor/Vector indexer, no NumOps dispatch on the float fast path).
+        // Profiled as ~half the NN-training managed hot path (ViT) before this; the typeof(T) branch
+        // folds at JIT. BF16→float is a pure widening, no scale.
+        var dst = result.GetCpuData();
+        if (typeof(T) == typeof(float))
         {
-            result[i] = NumOps.FromDouble(BitConverterHelper.Bf16BitsToFloat(bf16[i]));
-        });
+            var f = (float[])(object)dst;
+            CpuParallelSettings.ParallelForOrSerial(0, length, (long)length, i => f[i] = BitConverterHelper.Bf16BitsToFloat(bf16[i]));
+        }
+        else
+        {
+            CpuParallelSettings.ParallelForOrSerial(0, length, (long)length, i => dst[i] = NumOps.FromDouble(BitConverterHelper.Bf16BitsToFloat(bf16[i])));
+        }
         return result;
     }
 
@@ -909,13 +918,20 @@ public class Adam8BitOptimizer<T, TInput, TOutput> : GradientBasedOptimizerBase<
     /// Packs a full-precision tensor's values back into a pre-allocated BF16 (2 bytes/element) buffer
     /// with round-to-nearest-even. BF16 keeps the float32 exponent, so no scale factor is needed.
     /// </summary>
-    private void TensorToBf16(Tensor<T> values, Vector<ushort> bf16)
+    private void TensorToBf16(Tensor<T> values, ushort[] bf16)
     {
         int length = values.Length;
-        CpuParallelSettings.ParallelForOrSerial(0, length, (long)length, i =>
+        // Raw-array quant (no Tensor/Vector indexer, no NumOps dispatch on the float fast path).
+        var src = values.GetCpuData();
+        if (typeof(T) == typeof(float))
         {
-            bf16[i] = BitConverterHelper.FloatToBf16Bits((float)NumOps.ToDouble(values[i]));
-        });
+            var f = (float[])(object)src;
+            CpuParallelSettings.ParallelForOrSerial(0, length, (long)length, i => bf16[i] = BitConverterHelper.FloatToBf16Bits(f[i]));
+        }
+        else
+        {
+            CpuParallelSettings.ParallelForOrSerial(0, length, (long)length, i => bf16[i] = BitConverterHelper.FloatToBf16Bits((float)NumOps.ToDouble(src[i])));
+        }
     }
 
     /// <summary>

--- a/src/Optimizers/Adam8BitOptimizer.cs
+++ b/src/Optimizers/Adam8BitOptimizer.cs
@@ -1,6 +1,8 @@
 using AiDotNet.Helpers;
 using System.Buffers;
 using System.Collections.Concurrent;
+using System.Runtime.CompilerServices;
+using SimdVector = System.Numerics.Vector;
 using AiDotNet.Tensors.Engines.Autodiff;
 using AiDotNet.Tensors.Helpers;
 using Newtonsoft.Json;
@@ -559,16 +561,21 @@ public class Adam8BitOptimizer<T, TInput, TOutput> : GradientBasedOptimizerBase<
             // at 2 bytes/element while the math runs at full precision.
             if (_options.UseBFloat16MomentStorage)
             {
-                Tensor<T> mB = Bf16ToTensor(state.MBf16!, param._shape);
-                Tensor<T> vB = Bf16ToTensor(state.VBf16!, param._shape);
+                // AllocateTapeState always allocates both BF16 buffers when UseBFloat16MomentStorage is
+                // set, so they are non-null on this path; capture into locals (no null-forgiving operator).
+                ushort[] mBf16 = state.MBf16 ?? throw new InvalidOperationException("BF16 moment buffer M was not allocated.");
+                ushort[] vBf16 = state.VBf16 ?? throw new InvalidOperationException("BF16 moment buffer V was not allocated.");
+
+                Tensor<T> mB = Bf16ToTensor(mBf16, param._shape);
+                Tensor<T> vB = Bf16ToTensor(vBf16, param._shape);
 
                 var newMB = Engine.TensorAdd(Engine.TensorMultiplyScalar(mB, beta1),
                                              Engine.TensorMultiplyScalar(grad, oneMinusBeta1));
                 var newVB = Engine.TensorAdd(Engine.TensorMultiplyScalar(vB, beta2),
                                              Engine.TensorMultiplyScalar(Engine.TensorMultiply(grad, grad), oneMinusBeta2));
 
-                TensorToBf16(newMB, state.MBf16!);
-                TensorToBf16(newVB, state.VBf16!);
+                TensorToBf16(newMB, mBf16);
+                TensorToBf16(newVB, vBf16);
 
                 var mHatB = Engine.TensorDivideScalar(newMB, biasCorrection1);
                 var vHatB = Engine.TensorDivideScalar(newVB, biasCorrection2);
@@ -905,7 +912,19 @@ public class Adam8BitOptimizer<T, TInput, TOutput> : GradientBasedOptimizerBase<
         if (typeof(T) == typeof(float))
         {
             var f = (float[])(object)dst;
-            CpuParallelSettings.ParallelForOrSerial(0, length, (long)length, i => f[i] = BitConverterHelper.Bf16BitsToFloat(bf16[i]));
+            // Chunked range loop (not per-element delegate) so the inner loop is tight and can run a
+            // SIMD bulk widen on NET7+. Bit-identical to BitConverterHelper.Bf16BitsToFloat (the scalar
+            // tail uses it directly, and the SIMD body reproduces the same high-16-bits placement).
+            CpuParallelSettings.ParallelForChunks(length, Bf16BulkChunkGrain, (chunkStart, chunkCount) =>
+            {
+                int i = chunkStart;
+                int chunkEnd = chunkStart + chunkCount;
+#if NET7_0_OR_GREATER
+                i = ConvertBf16ToFloatSimd(bf16, f, chunkStart, chunkCount);
+#endif
+                for (; i < chunkEnd; i++)
+                    f[i] = BitConverterHelper.Bf16BitsToFloat(bf16[i]);
+            });
         }
         else
         {
@@ -926,13 +945,109 @@ public class Adam8BitOptimizer<T, TInput, TOutput> : GradientBasedOptimizerBase<
         if (typeof(T) == typeof(float))
         {
             var f = (float[])(object)src;
-            CpuParallelSettings.ParallelForOrSerial(0, length, (long)length, i => bf16[i] = BitConverterHelper.FloatToBf16Bits(f[i]));
+            // Chunked range loop + SIMD bulk round-to-nearest-even on NET7+. Bit-identical to
+            // BitConverterHelper.FloatToBf16Bits (the scalar tail calls it; the SIMD body reproduces
+            // the same RNE add + NaN-preserving path lane-for-lane).
+            CpuParallelSettings.ParallelForChunks(length, Bf16BulkChunkGrain, (chunkStart, chunkCount) =>
+            {
+                int i = chunkStart;
+                int chunkEnd = chunkStart + chunkCount;
+#if NET7_0_OR_GREATER
+                i = ConvertFloatToBf16Simd(f, bf16, chunkStart, chunkCount);
+#endif
+                for (; i < chunkEnd; i++)
+                    bf16[i] = BitConverterHelper.FloatToBf16Bits(f[i]);
+            });
         }
         else
         {
             CpuParallelSettings.ParallelForOrSerial(0, length, (long)length, i => bf16[i] = BitConverterHelper.FloatToBf16Bits((float)NumOps.ToDouble(src[i])));
         }
     }
+
+    /// <summary>
+    /// Minimum elements per parallel chunk for the BF16 bulk conversions. Below this the work runs
+    /// serially (single chunk); above it the work is split across cores, and within each chunk the
+    /// inner loop runs a SIMD bulk convert (NET7+) followed by a scalar tail.
+    /// </summary>
+    private const int Bf16BulkChunkGrain = 8192;
+
+#if NET7_0_OR_GREATER
+    /// <summary>
+    /// SIMD bulk float→BF16 with round-to-nearest-even, bit-identical to
+    /// <see cref="BitConverterHelper.FloatToBf16Bits(float)"/>. Processes whole <see cref="Vector{T}"/>
+    /// blocks in <paramref name="src"/>[<paramref name="start"/>, start+count); returns the first index
+    /// not covered (the caller finishes the &lt; one-vector tail with the scalar helper).
+    /// </summary>
+    private static int ConvertFloatToBf16Simd(float[] src, ushort[] dst, int start, int count)
+    {
+        int laneU = System.Numerics.Vector<uint>.Count;        // == Vector<float>.Count
+        int stride = System.Numerics.Vector<ushort>.Count;     // == 2 * laneU ushorts produced per iteration
+        var c7fff = new System.Numerics.Vector<uint>(0x7FFFu);
+        var cInf = new System.Numerics.Vector<uint>(0x7F800000u);
+        var cAbs = new System.Numerics.Vector<uint>(0x7FFFFFFFu);
+        var cNan = new System.Numerics.Vector<uint>(0x0040u);
+        var cOne = new System.Numerics.Vector<uint>(1u);
+        int i = start;
+        int end = start + count;
+        for (; i + stride <= end; i += stride)
+        {
+            System.Numerics.Vector<uint> lo = FloatLaneToBf16(new System.Numerics.Vector<float>(src, i), c7fff, cInf, cAbs, cNan, cOne);
+            System.Numerics.Vector<uint> hi = FloatLaneToBf16(new System.Numerics.Vector<float>(src, i + laneU), c7fff, cInf, cAbs, cNan, cOne);
+            SimdVector.Narrow(lo, hi).CopyTo(dst, i);
+        }
+        return i;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static System.Numerics.Vector<uint> FloatLaneToBf16(System.Numerics.Vector<float> value,
+        System.Numerics.Vector<uint> c7fff, System.Numerics.Vector<uint> cInf,
+        System.Numerics.Vector<uint> cAbs, System.Numerics.Vector<uint> cNan, System.Numerics.Vector<uint> cOne)
+    {
+        System.Numerics.Vector<uint> bits = SimdVector.AsVectorUInt32(value);
+        System.Numerics.Vector<uint> high = SimdVector.ShiftRightLogical(bits, 16);
+        System.Numerics.Vector<uint> isNan = SimdVector.GreaterThan(bits & cAbs, cInf);   // (bits & 0x7FFFFFFF) > 0x7F800000
+        System.Numerics.Vector<uint> nanResult = high | cNan;                              // (bits>>16) | 0x40
+        System.Numerics.Vector<uint> lsb = high & cOne;                                    // (bits>>16) & 1
+        System.Numerics.Vector<uint> rounded = SimdVector.ShiftRightLogical(bits + c7fff + lsb, 16);
+        // Narrow takes the low 16 bits, matching the scalar (ushort) truncation.
+        return SimdVector.ConditionalSelect(isNan, nanResult, rounded);
+    }
+
+    /// <summary>
+    /// SIMD bulk BF16→float (pure widening, bit-identical to
+    /// <see cref="BitConverterHelper.Bf16BitsToFloat(ushort)"/>). Returns the first index not covered.
+    /// </summary>
+    private static int ConvertBf16ToFloatSimd(ushort[] src, float[] dst, int start, int count)
+    {
+        int laneU = System.Numerics.Vector<uint>.Count;
+        int stride = System.Numerics.Vector<ushort>.Count;
+        int i = start;
+        int end = start + count;
+        for (; i + stride <= end; i += stride)
+        {
+            SimdVector.Widen(new System.Numerics.Vector<ushort>(src, i), out System.Numerics.Vector<uint> lo, out System.Numerics.Vector<uint> hi);
+            SimdVector.AsVectorSingle(SimdVector.ShiftLeft(lo, 16)).CopyTo(dst, i);
+            SimdVector.AsVectorSingle(SimdVector.ShiftLeft(hi, 16)).CopyTo(dst, i + laneU);
+        }
+        return i;
+    }
+
+    /// <summary>
+    /// Test-only hook: runs the exact production float→BF16→float path (SIMD block + scalar tail) over
+    /// whole arrays so a unit test can assert bit-identity against the scalar
+    /// <see cref="BitConverterHelper"/> reference. Not part of the optimizer's runtime behavior.
+    /// </summary>
+    internal static void Bf16RoundTripForTest(float[] src, ushort[] bf16, float[] back)
+    {
+        int i = ConvertFloatToBf16Simd(src, bf16, 0, src.Length);
+        for (; i < src.Length; i++)
+            bf16[i] = BitConverterHelper.FloatToBf16Bits(src[i]);
+        int j = ConvertBf16ToFloatSimd(bf16, back, 0, bf16.Length);
+        for (; j < bf16.Length; j++)
+            back[j] = BitConverterHelper.Bf16BitsToFloat(bf16[j]);
+    }
+#endif
 
     /// <summary>
     /// Updates the adaptive parameters of the optimizer based on the current and previous optimization steps.

--- a/tests/AiDotNet.Tests/IntegrationTests/Optimizers/Adam8BitBf16SimdParityTests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/Optimizers/Adam8BitBf16SimdParityTests.cs
@@ -1,0 +1,90 @@
+#if NET7_0_OR_GREATER
+using System;
+using AiDotNet.MixedPrecision;
+using AiDotNet.Optimizers;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tests.IntegrationTests.Optimizers;
+
+/// <summary>
+/// Proves the SIMD bulk BF16 quantize/dequantize path in <see cref="Adam8BitOptimizer{T, TInput, TOutput}"/>
+/// is bit-identical to the scalar <see cref="BitConverterHelper.FloatToBf16Bits(float)"/> /
+/// <see cref="BitConverterHelper.Bf16BitsToFloat(ushort)"/> reference, over normals, zeros, subnormals,
+/// infinities, NaN, round-to-nearest-even carry cases, and arrays whose length is not a multiple of the
+/// hardware vector width (so the scalar tail is exercised too). The SIMD path is a NET7+ perf optimization
+/// on the Adam8Bit BF16 moment-storage step; this test is the correctness gate for it.
+/// </summary>
+public class Adam8BitBf16SimdParityTests
+{
+    private static void AssertParity(float[] src)
+    {
+        var bf16 = new ushort[src.Length];
+        var back = new float[src.Length];
+
+        // Production path (SIMD block + scalar tail).
+        Adam8BitOptimizer<float, Matrix<float>, Vector<float>>.Bf16RoundTripForTest(src, bf16, back);
+
+        for (int i = 0; i < src.Length; i++)
+        {
+            // Quantize must match the scalar reference exactly (raw 16-bit pattern).
+            ushort expectedBits = BitConverterHelper.FloatToBf16Bits(src[i]);
+            Assert.True(expectedBits == bf16[i],
+                $"float→bf16 mismatch at {i} for {src[i]} (0x{BitConverter.SingleToUInt32Bits(src[i]):X8}): " +
+                $"expected 0x{expectedBits:X4}, got 0x{bf16[i]:X4}");
+
+            // Dequantize must match the scalar reference exactly (compare bit patterns so NaN == NaN).
+            float expectedBack = BitConverterHelper.Bf16BitsToFloat(expectedBits);
+            uint expBackBits = BitConverter.SingleToUInt32Bits(expectedBack);
+            uint actBackBits = BitConverter.SingleToUInt32Bits(back[i]);
+            Assert.True(expBackBits == actBackBits,
+                $"bf16→float mismatch at {i}: expected 0x{expBackBits:X8}, got 0x{actBackBits:X8}");
+        }
+    }
+
+    [Fact]
+    public void Bf16Simd_MatchesScalar_OnEdgeCases()
+    {
+        var edge = new float[]
+        {
+            0f, -0f, 1f, -1f, 2f, -2f, 0.5f, -0.5f,
+            float.Epsilon, -float.Epsilon,                 // smallest subnormal
+            1.17549435e-38f, -1.17549435e-38f,             // ~smallest normal
+            float.MaxValue, float.MinValue,
+            float.PositiveInfinity, float.NegativeInfinity,
+            float.NaN, -float.NaN,
+            BitConverter.UInt32BitsToSingle(0x7FC00001u),  // a specific quiet NaN payload
+            BitConverter.UInt32BitsToSingle(0x7F800001u),  // a signaling NaN
+            BitConverter.UInt32BitsToSingle(0x0000FFFFu),  // low-mantissa subnormal -> rounds toward 0
+            BitConverter.UInt32BitsToSingle(0x3F7FFFFFu),  // just below 1.0, forces RNE carry
+            BitConverter.UInt32BitsToSingle(0x3F7F8000u),  // exact bf16 boundary (lsb 0, no round)
+            BitConverter.UInt32BitsToSingle(0x3F7F8001u),  // round-up case
+            3.14159265f, -2.71828182f, 1e30f, -1e-30f,
+        };
+        AssertParity(edge);
+    }
+
+    [Theory]
+    // Lengths spanning < one vector, exactly one+ vector, and non-multiples (forces the scalar tail).
+    [InlineData(1, 11)]
+    [InlineData(7, 22)]
+    [InlineData(16, 33)]
+    [InlineData(31, 44)]
+    [InlineData(257, 55)]
+    [InlineData(8193, 66)]   // > Bf16BulkChunkGrain, multiple parallel chunks
+    [InlineData(20001, 77)]
+    public void Bf16Simd_MatchesScalar_OnRandomArrays(int length, int seed)
+    {
+        var rng = new Random(seed);
+        var src = new float[length];
+        for (int i = 0; i < length; i++)
+        {
+            // Wide dynamic range, mixed sign, including some exact halves to hit RNE.
+            double mag = Math.Pow(10, rng.NextDouble() * 60 - 30);
+            float v = (float)(mag * (rng.Next(2) == 0 ? 1 : -1));
+            src[i] = rng.Next(20) == 0 ? 0f : v;
+        }
+        AssertParity(src);
+    }
+}
+#endif


### PR DESCRIPTION
## Summary
PerfView `/ThreadTime` profiling of the **NN ModelFamily train shard** (winning-formula pass). The timeout-ers are the large-input vision models — **ViT [1,3,224,224] ≈ 44.3 s/iter** (30-iter `Training_ShouldReduceLoss` ≈ 22 min) and VGG (7.2 s/iter). On ViT, the dominant **managed** hot path (~18% of leaf CPU) is **not GEMM** (native, GEMM-bound like diffusion/InternImage conv) but the **Adam8Bit optimizer's BF16 moment quantize/dequantize**:

`TensorToBf16` / `Bf16ToTensor` ran per element through the `Tensor` indexer (`values[i]`/`result[i]`), the `Vector<ushort>` indexer (`bf16[i]`), and `INumericOperations<T>.ToDouble`/`FromDouble` dispatch — the exact per-element-indexer + virtual-dispatch anti-pattern, on **every Adam8Bit-trained model's** step.

## Fix
Two layers, both **numerically identical** (bit-exact round-to-nearest-even BF16):

1. **Raw-array access** — read/write the live backing arrays via `Tensor.GetCpuData()`, and change the BF16 moment state from `Vector<ushort>` to `ushort[]` (writable raw access), with a `typeof(T)==float` fast path (folds at JIT, no dispatch) + generic `NumOps` fallback. Removes the per-element `Tensor`/`Vector` indexer + `NumOps.ToDouble`/`FromDouble` dispatch — the bulk of the profiled ~18%.

2. **SIMD bulk convert (NET7+)** — the inner float↔BF16 loop now runs a `System.Numerics.Vector<T>` bulk convert (`ConvertFloatToBf16Simd` / `ConvertBf16ToFloatSimd`) followed by a scalar tail, instead of calling the scalar `FloatToBf16Bits` per element. The vectorized RNE (`FloatLaneToBf16`) reproduces the scalar rounding add + NaN-preserving path lane-for-lane, so the 16-bit output pattern is identical. Removes the remaining scalar bit-twiddle cost. *(This is the optimization previously listed as a follow-up — now folded into the PR, commit `3926ea748`.)*

Both benefit **every Adam8Bit-trained model** (~10–18% of the training step). ViT itself stays GEMM-bound (still slow); moderate models gain proportionally more.

## Verification
- **30/30** `Adam8Bit` tests green on net10.0 — including a dedicated SIMD↔scalar **bit-exactness** gate (`Adam8BitBf16SimdParityTests`): NaN / signaling-NaN / subnormal / infinity / RNE-carry / exact-bf16-boundary edge cases, plus random wide-dynamic-range arrays at lengths that exercise the `< one vector` scalar tail and the `> chunk-grain` multi-chunk parallel path.
- `src/AiDotNet.csproj` builds clean (net10.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
