### PR TITLE
fix(#1668): enable diffusion denoise-loop inference arena via no_grad-style scope

### DIFF
--- a/samples/clustering/CustomerSegmentation/Program.cs
+++ b/samples/clustering/CustomerSegmentation/Program.cs
@@ -98,9 +98,9 @@ Console.WriteLine("\n=== Clustering Quality Metrics (result.Evaluation) ===\n");
 var clusteringMetrics = result.Evaluation.ClusteringMetrics;
 if (clusteringMetrics is not null)
 {
-    Console.WriteLine($"  Silhouette:         {clusteringMetrics.SilhouetteScore,8:F4}  {InterpretMetric("Silhouette Score", clusteringMetrics.SilhouetteScore)}");
-    Console.WriteLine($"  Davies-Bouldin:     {clusteringMetrics.DaviesBouldinIndex,8:F4}  {InterpretMetric("Davies-Bouldin Index", clusteringMetrics.DaviesBouldinIndex)}");
-    Console.WriteLine($"  Calinski-Harabasz:  {clusteringMetrics.CalinskiHarabaszIndex,8:F4}  {InterpretMetric("Calinski-Harabasz Index", clusteringMetrics.CalinskiHarabaszIndex)}");
+    Console.WriteLine($"  Silhouette:         {clusteringMetrics.Silhouette,8:F4}  {InterpretMetric("Silhouette Score", clusteringMetrics.Silhouette)}");
+    Console.WriteLine($"  Davies-Bouldin:     {clusteringMetrics.DaviesBouldin,8:F4}  {InterpretMetric("Davies-Bouldin Index", clusteringMetrics.DaviesBouldin)}");
+    Console.WriteLine($"  Calinski-Harabasz:  {clusteringMetrics.CalinskiHarabasz,8:F4}  {InterpretMetric("Calinski-Harabasz Index", clusteringMetrics.CalinskiHarabasz)}");
 }
 
 // For a deeper per-cluster breakdown, the standalone ClusteringEvaluator is still available.

--- a/src/Diffusion/Attention/DiffusionAttention.cs
+++ b/src/Diffusion/Attention/DiffusionAttention.cs
@@ -198,7 +198,10 @@ public class DiffusionAttention<T> : LayerBase<T>
     /// </remarks>
     public override Tensor<T> Forward(Tensor<T> input)
     {
-        _lastInput = input;
+        // Retain the backward-activation cache only when an eager manual Backward
+        // will read it; skip in inference/under tape so the denoise-loop arena can
+        // recycle scratch without aliasing a stale reference (issue #1668).
+        _lastInput = ShouldCacheForBackward ? input : null;
 
         // Determine if input is image format [B, C, H, W] or sequence format [B, S, D]
         bool isImageFormat = input.Shape.Length == 4;
@@ -450,8 +453,10 @@ public class DiffusionCrossAttention<T> : LayerBase<T>
     /// <returns>Output tensor of the same shape as input.</returns>
     public Tensor<T> ForwardWithContext(Tensor<T> input, Tensor<T>? context)
     {
-        _lastInput = input;
-        _lastContext = context;
+        // See Forward: keep backward-activation caches only when a manual Backward reads them.
+        bool cacheBwd = ShouldCacheForBackward;
+        _lastInput = cacheBwd ? input : null;
+        _lastContext = cacheBwd ? context : null;
 
         bool isImageFormat = input.Shape.Length == 4;
         int batchSize, sequenceLength, channels;

--- a/src/Diffusion/Attention/FactorizedSpatioTemporalAttention.cs
+++ b/src/Diffusion/Attention/FactorizedSpatioTemporalAttention.cs
@@ -94,7 +94,9 @@ public class FactorizedSpatioTemporalAttention<T> : LayerBase<T>
     /// </summary>
     public override Tensor<T> Forward(Tensor<T> input)
     {
-        _lastInput = input;
+        // #1668: skip the backward-activation cache in inference so the denoise-loop
+        // arena can recycle scratch without aliasing a stale reference.
+        _lastInput = ShouldCacheForBackward ? input : null;
 
         // Spatial attention with residual
         var spatialNormed = _spatialNorm.Forward(input);

--- a/src/Diffusion/Attention/Full3DAttention.cs
+++ b/src/Diffusion/Attention/Full3DAttention.cs
@@ -104,7 +104,8 @@ public class Full3DAttention<T> : LayerBase<T>
     /// </summary>
     public override Tensor<T> Forward(Tensor<T> input)
     {
-        _lastInput = input;
+        // #1668: skip the backward-activation cache in inference (denoise-loop arena safety).
+        _lastInput = ShouldCacheForBackward ? input : null;
         return _fullAttention.Forward(input);
     }
 

--- a/src/Diffusion/Attention/MotionModule.cs
+++ b/src/Diffusion/Attention/MotionModule.cs
@@ -123,7 +123,8 @@ public class MotionModule<T> : LayerBase<T>
     /// </summary>
     public override Tensor<T> Forward(Tensor<T> input)
     {
-        _lastInput = input;
+        // #1668: skip the backward-activation cache in inference (denoise-loop arena safety).
+        _lastInput = ShouldCacheForBackward ? input : null;
 
         // Temporal attention with residual
         var normed1 = _norm1.Forward(input);

--- a/src/Diffusion/Attention/STDiTBlock.cs
+++ b/src/Diffusion/Attention/STDiTBlock.cs
@@ -152,22 +152,41 @@ public class STDiTBlock<T> : LayerBase<T>
     /// </summary>
     public override Tensor<T> Forward(Tensor<T> input)
     {
-        _lastInput = input;
+        // The residual-stream checkpoints below double as forward locals (each stage
+        // feeds the next), so compute them into locals and only mirror them into the
+        // backward-cache fields when an eager manual Backward will read them. In
+        // inference/under tape the fields are left null so the denoise-loop arena can
+        // recycle scratch without aliasing a stale reference (issue #1668).
+        bool cacheBwd = ShouldCacheForBackward;
+        _lastInput = cacheBwd ? input : null;
 
         // 1. Spatial self-attention with residual
-        _afterSpatial = AddTensors(input, _spatialAttention.Forward(_spatialNorm.Forward(input)));
+        var afterSpatial = AddTensors(input, _spatialAttention.Forward(_spatialNorm.Forward(input)));
 
         // 2. Temporal self-attention with residual
-        _afterTemporal = AddTensors(_afterSpatial, _temporalAttention.Forward(_temporalNorm.Forward(_afterSpatial)));
+        var afterTemporal = AddTensors(afterSpatial, _temporalAttention.Forward(_temporalNorm.Forward(afterSpatial)));
 
         // 3. Cross-attention with residual
-        _afterCross = AddTensors(_afterTemporal, _crossAttention.Forward(_crossNorm.Forward(_afterTemporal)));
+        var afterCross = AddTensors(afterTemporal, _crossAttention.Forward(_crossNorm.Forward(afterTemporal)));
+
+        if (cacheBwd)
+        {
+            _afterSpatial = afterSpatial;
+            _afterTemporal = afterTemporal;
+            _afterCross = afterCross;
+        }
+        else
+        {
+            _afterSpatial = null;
+            _afterTemporal = null;
+            _afterCross = null;
+        }
 
         // 4. Feed-forward network with residual
-        var ffnInput = _ffnNorm.Forward(_afterCross);
+        var ffnInput = _ffnNorm.Forward(afterCross);
         var ffnHidden = _ffnIn.Forward(ffnInput);
         var ffnOutput = _ffnOut.Forward(ffnHidden);
-        return AddTensors(_afterCross, ffnOutput);
+        return AddTensors(afterCross, ffnOutput);
     }
 
     /// <inheritdoc />

--- a/src/Diffusion/Attention/TemporalConvolution.cs
+++ b/src/Diffusion/Attention/TemporalConvolution.cs
@@ -100,7 +100,8 @@ public class TemporalConvolution<T> : LayerBase<T>
     /// </summary>
     public override Tensor<T> Forward(Tensor<T> input)
     {
-        _lastInput = input;
+        // #1668: skip the backward-activation cache in inference (denoise-loop arena safety).
+        _lastInput = ShouldCacheForBackward ? input : null;
 
         var normed = _norm.Forward(input);
         var convOut = _conv.Forward(normed);

--- a/src/Diffusion/Attention/TemporalSelfAttention.cs
+++ b/src/Diffusion/Attention/TemporalSelfAttention.cs
@@ -104,7 +104,8 @@ public class TemporalSelfAttention<T> : LayerBase<T>
     /// <returns>Output tensor with temporal information mixed, same shape as input.</returns>
     public override Tensor<T> Forward(Tensor<T> input)
     {
-        _lastInput = input;
+        // #1668: skip the backward-activation cache in inference (denoise-loop arena safety).
+        _lastInput = ShouldCacheForBackward ? input : null;
         return _temporalAttention.Forward(input);
     }
 

--- a/src/Diffusion/DiffusionModelBase.cs
+++ b/src/Diffusion/DiffusionModelBase.cs
@@ -12,6 +12,7 @@ using AiDotNet.LossFunctions;
 using AiDotNet.Models;
 using AiDotNet.Models.Options;
 using AiDotNet.NeuralNetworks;
+using AiDotNet.NeuralNetworks.Layers;
 using AiDotNet.Diffusion.Schedulers;
 using AiDotNet.Tensors.Helpers;
 
@@ -673,15 +674,21 @@ public abstract class DiffusionModelBase<T> : IDiffusionModel<T>, IConfigurableM
         // is [ThreadStatic] and `await ...ConfigureAwait(false)` can resume on another thread,
         // which would desynchronise the arena scope — an async-aware arena is a separate change.)
         //
-        // Gated by DiffusionDenoiseEnabled (default OFF), NOT the default-on Predict-funnel flag:
-        // unlike the single-shot Predict funnel, the multi-step denoise loop is NOT arena-safe.
-        // Diffusion forward layers hold cross-forward cached tensors (e.g. DiffusionResBlock's
-        // pre-allocated GroupNorm output buffer; attention reshape scratch) first allocated inside
-        // this arena scope; the per-step Reset() recycles that memory, so a later step's allocation
-        // aliases a still-referenced cached buffer and corrupts its shape — observed as a downsample
-        // conv output emerging with a stale [B, H*W, C] attention layout, surfacing as "Input has N
-        // channels but layer expects M" (and a native host crash when it corrupts the shared pool).
-        // Re-enable only after the layer caches are made arena-safe. See issue #1668.
+        // Arena safety (issue #1668): the multi-step denoise loop was previously NOT
+        // arena-safe because diffusion forward layers retained per-forward backward-
+        // activation caches (`_lastInput`, pre-SiLU buffers, attention reshape scratch).
+        // Those fields held references into arena scratch; the per-step arena.Reset()
+        // recycled that scratch, so a later step's allocation aliased a still-referenced
+        // cached buffer and corrupted its shape/data (a downsample conv output emerging
+        // with a stale [B, H*W, C] attention layout → "Input has N channels but layer
+        // expects M", and a native crash when it corrupted the shared pool).
+        //
+        // The fix is the InferenceMode scope below: it is the torch.inference_mode()
+        // analog, and every layer's ShouldCacheForBackward guard is false inside it, so
+        // no backward-activation cache is populated during the denoise loop. With nothing
+        // referencing scratch across a Reset, the per-step recycle is safe. The carried
+        // latent (`sample`) is separately detached to a GC buffer each step (below).
+        using var _inferenceScope = InferenceMode.Enter();
         using var arena = (InferenceArenaSettings.Enabled && InferenceArenaSettings.DiffusionDenoiseEnabled)
             ? TensorArena.Create()
             : null;

--- a/src/Diffusion/DiffusionModelBase.cs
+++ b/src/Diffusion/DiffusionModelBase.cs
@@ -489,6 +489,11 @@ public abstract class DiffusionModelBase<T> : IDiffusionModel<T>, IConfigurableM
         ValidateGenerateInputs(shape, numInferenceSteps, out long totalElements);
 
         using var _ = new NoGradScope<T>();
+        // Also enter an InferenceMode scope so layers skip their backward-activation caches
+        // on the async path too (no backward runs here). Unlike TensorArena (ThreadStatic,
+        // not wrapped here because await can resume on another thread), InferenceMode is
+        // AsyncLocal and flows across await/continuations, so this is safe for async (#1668).
+        using var _inferenceScope = InferenceMode.Enter();
 
         Vector<T> sample = ResolveInitialSample(shape, numInferenceSteps, seed, initialSample, totalElements);
 

--- a/src/Diffusion/NoisePredictors/DiffusionResBlock.cs
+++ b/src/Diffusion/NoisePredictors/DiffusionResBlock.cs
@@ -258,12 +258,17 @@ public class DiffusionResBlock<T> : LayerBase<T>
     public override Tensor<T> Forward(Tensor<T> input)
     {
         _originalInputShape = input._shape;
-        _lastInput = input;
+        // Only retain the per-layer backward-activation caches when an eager manual
+        // Backward will read them. In inference (and under the tape / graph capture)
+        // these references are dead weight and, inside the denoise-loop arena, would
+        // alias scratch recycled by the per-step Reset (issue #1668).
+        bool cacheBwd = ShouldCacheForBackward;
+        _lastInput = cacheBwd ? input : null;
         _lastForwardUsedTime = false;
 
         // First block: GroupNorm → SiLU → Conv3x3
         var h = _norm1.Forward(input);
-        _preSiLU1 = h;
+        _preSiLU1 = cacheBwd ? h : null;
         h = ApplySiLU(h);
         h = _conv1.Forward(h);
 
@@ -272,7 +277,7 @@ public class DiffusionResBlock<T> : LayerBase<T>
 
         // Second block: GroupNorm → SiLU → Conv3x3
         h = _norm2.Forward(h);
-        _preSiLU2 = h;
+        _preSiLU2 = cacheBwd ? h : null;
         h = ApplySiLU(h);
         h = _conv2.Forward(h);
 
@@ -290,7 +295,11 @@ public class DiffusionResBlock<T> : LayerBase<T>
     public Tensor<T> Forward(Tensor<T> input, Tensor<T> timeEmbed)
     {
         _originalInputShape = input._shape;
-        _lastInput = input;
+        // See Forward(input): keep the backward-activation caches only when an eager
+        // manual Backward will read them, so inference (denoise-loop arena) holds no
+        // recycled-scratch reference across the per-step Reset (issue #1668).
+        bool cacheBwd = ShouldCacheForBackward;
+        _lastInput = cacheBwd ? input : null;
         _lastForwardUsedTime = true;
 
         // Eval-mode (no tape) can use the in-place Engine variants for the
@@ -351,7 +360,7 @@ public class DiffusionResBlock<T> : LayerBase<T>
             // Tape-active path: keep the allocating Forward chain so
             // backward can recover the pre-SiLU tensor.
             h = _norm1.Forward(input);
-            _preSiLU1 = h;
+            _preSiLU1 = cacheBwd ? h : null;
             h = ApplySiLU(h);
             h = _conv1.Forward(h);
         }
@@ -424,7 +433,7 @@ public class DiffusionResBlock<T> : LayerBase<T>
         else
         {
             h = _norm2.Forward(h);
-            _preSiLU2 = h;
+            _preSiLU2 = cacheBwd ? h : null;
             h = ApplySiLU(h);
             h = _conv2.Forward(h);
         }

--- a/src/NeuralNetworks/InferenceArenaSettings.cs
+++ b/src/NeuralNetworks/InferenceArenaSettings.cs
@@ -36,25 +36,26 @@ public static class InferenceArenaSettings
 
     /// <summary>
     /// Whether the multi-step diffusion denoise loop (<c>DiffusionModelBase.Generate</c>) opens a
-    /// per-step <c>TensorArena</c>. Default <c>OFF</c> — distinct from the single-shot
-    /// <see cref="Enabled"/> Predict funnel, which is bit-identical and safe.
+    /// per-step <c>TensorArena</c> (recycling each step's noise-predictor + scheduler intermediates
+    /// instead of GC-churning them). Default <c>ON</c>; set
+    /// <c>AIDOTNET_INFERENCE_ARENA_DIFFUSION=0</c> to disable (escape hatch).
     /// </summary>
     /// <remarks>
-    /// The denoise loop is NOT arena-safe: diffusion forward layers hold <em>cross-forward</em>
-    /// cached tensors (e.g. <c>DiffusionResBlock</c>'s pre-allocated GroupNorm output buffer, and
-    /// attention reshape scratch) that are first allocated <em>inside</em> the arena scope. The
-    /// per-step <c>arena.Reset()</c> then recycles that memory, so a later step's allocation aliases
-    /// a still-referenced cached buffer and corrupts its shape/data — observed as a downsample conv
-    /// output emerging with a stale <c>[B, H*W, C]</c> attention layout, surfacing downstream as
-    /// "Input has N channels but layer expects M" (and, when it corrupts the shared pool, a native
-    /// host crash). Single-step <c>Predict</c> never hits this because there is no second step to
-    /// recycle into. Re-enable ONLY after the diffusion layer caches are made arena-safe
-    /// (GC-allocated, or pinned across <c>Reset()</c>). Opt in with
-    /// <c>AIDOTNET_INFERENCE_ARENA_DIFFUSION=1</c>.
+    /// This was OFF historically (issue #1668): the per-step <c>arena.Reset()</c> recycled scratch
+    /// that diffusion forward layers still referenced via per-forward backward-activation caches
+    /// (<c>_lastInput</c>, conv <c>_preAllocatedOutput</c>, ...), so a later step's allocation
+    /// aliased a still-referenced buffer and corrupted it. The arena cannot auto-detect this (its
+    /// pool strong-refs every buffer it hands out), so the fix is layer-side: the denoise loop runs
+    /// inside an <c>InferenceMode</c> scope (the <c>torch.inference_mode()</c> analog) under which
+    /// every layer's <c>ShouldCacheForBackward</c> guard is false, so no backward-activation cache is
+    /// populated — nothing references scratch across a <c>Reset</c> — and the convolution output
+    /// buffer is re-rented per forward instead of being reused across the recycle boundary. Verified
+    /// bit-identical (arena on vs off) on DDPM <c>Generate</c>; the diffusion model-family and
+    /// <c>DiffusionGenerateArenaIntegrationTests</c> exercise the arena across model types in CI.
     /// </remarks>
     public static bool DiffusionDenoiseEnabled { get; set; } =
-        string.Equals(
+        !string.Equals(
             Environment.GetEnvironmentVariable("AIDOTNET_INFERENCE_ARENA_DIFFUSION"),
-            "1",
+            "0",
             StringComparison.Ordinal);
 }

--- a/src/NeuralNetworks/Layers/ActivationLayer.cs
+++ b/src/NeuralNetworks/Layers/ActivationLayer.cs
@@ -223,7 +223,7 @@ public class ActivationLayer<T> : LayerBase<T>
     public override Tensor<T> Forward(Tensor<T> input)
     {
         EnsureInitializedFromInput(input);
-        _lastInput = input;
+        _lastInput = ShouldCacheForBackward ? input : null; // #1668: skip in inference (arena safety)
         return _useVectorActivation ? ApplyVectorActivation(input) : ApplyScalarActivation(input);
     }
 

--- a/src/NeuralNetworks/Layers/AdaptiveAveragePoolingLayer.cs
+++ b/src/NeuralNetworks/Layers/AdaptiveAveragePoolingLayer.cs
@@ -140,7 +140,7 @@ public class AdaptiveAveragePoolingLayer<T> : LayerBase<T>
             throw new ArgumentException("Input must have at least 3 dimensions (channels, height, width).");
 
         EnsureInitializedFromInput(input);
-        _lastInput = input;
+        _lastInput = ShouldCacheForBackward ? input : null; // #1668: skip in inference (arena safety)
         _lastInputShape = input._shape;
 
         // Handle any rank >= 3: last 3 dims are [C, H, W], earlier dims are batch-like

--- a/src/NeuralNetworks/Layers/AttentionLayer.cs
+++ b/src/NeuralNetworks/Layers/AttentionLayer.cs
@@ -532,9 +532,11 @@ public partial class AttentionLayer<T> : LayerBase<T>, IAuxiliaryLossLayer<T>
             input3D = Engine.Reshape(input, [flatBatch, input.Shape[rank - 2], input.Shape[rank - 1]]);
         }
 
-        _lastInput = ShouldCacheForBackward ? input : null; // #1668: skip in inference (arena safety)
-        _lastQueryInput = input3D;
-        _lastKeyInput = input3D;
+        // #1668: gate every backward-only cache (forward uses locals); skip in inference.
+        bool cacheBwd = ShouldCacheForBackward;
+        _lastInput = cacheBwd ? input : null;
+        _lastQueryInput = cacheBwd ? input3D : null;
+        _lastKeyInput = cacheBwd ? input3D : null;
         _lastWasCrossAttention = false;
         _lastUsedMask = false;
         _lastMask = null;
@@ -580,7 +582,7 @@ public partial class AttentionLayer<T> : LayerBase<T>, IAuxiliaryLossLayer<T>
                 out var attentionWeights4D);
 
             // Reshape attention weights back to 3D for caching: [B, 1, S, S] -> [B, S, S]
-            _lastAttentionWeights = Engine.Reshape(attentionWeights4D, [batchSize, seqLen, seqLen]);
+            _lastAttentionWeights = cacheBwd ? Engine.Reshape(attentionWeights4D, [batchSize, seqLen, seqLen]) : null;
 
             // Reshape output back to 3D: [B, 1, S, A] -> [B, S, A]
             attentionOutput = Engine.Reshape(output4D, [batchSize, seqLen, _attentionSize]);
@@ -604,21 +606,23 @@ public partial class AttentionLayer<T> : LayerBase<T>, IAuxiliaryLossLayer<T>
             T scaleValue = NumericalStabilityHelper.SafeDiv(NumOps.One, NumOps.Sqrt(NumOps.FromDouble(_attentionSize)));
             attentionScores = Engine.TensorMultiplyScalar(attentionScores, scaleValue);
 
-            // 4. Apply activation (custom, not softmax)
-            _lastAttentionWeights = ApplyActivation(attentionScores);
+            // 4. Apply activation (custom, not softmax). Use a local for the forward (it's
+            // read by the weights@V matmul below); cache to the field only for backward (#1668).
+            var attnWeights = ApplyActivation(attentionScores);
+            _lastAttentionWeights = cacheBwd ? attnWeights : null;
 
             // 5. Output: Weights @ V (per-batch)
             attentionOutput = TensorAllocator.Rent<T>([batchSize, seqLen, _attentionSize]);
             for (int b = 0; b < batchSize; b++)
             {
-                var wB = _lastAttentionWeights.GetSliceAlongDimension(b, 0);
+                var wB = attnWeights.GetSliceAlongDimension(b, 0);
                 var vB = V.GetSliceAlongDimension(b, 0);
                 var outB = Engine.TensorMatMul(wB, vB);
                 for (int i = 0; i < outB.Length; i++)
                     attentionOutput.SetFlat(b * seqLen * _attentionSize + i, outB.GetFlat(i));
             }
         }
-        _lastAttentionOutput = attentionOutput; // Cache for backward pass
+        _lastAttentionOutput = cacheBwd ? attentionOutput : null; // #1668: cache for backward only
 
         // 6. Output Projection: Apply Wo to project from attentionSize back to inputSize
         // Flatten for matmul: [B*S, A] @ [A, inputSize] -> [B*S, inputSize]
@@ -733,8 +737,9 @@ public partial class AttentionLayer<T> : LayerBase<T>, IAuxiliaryLossLayer<T>
         // Output projection: [B*S, AttentionSize] @ [AttentionSize, InputSize] -> [B*S, InputSize]
         var outputFlat = gpuEngine.FusedLinearGpu(attnFlat, Engine.TensorTranspose(_Wo), null, FusedActivationType.None);
 
-        // Cache GPU tensors for backward pass during training
-        if (IsTrainingMode)
+        // Cache GPU tensors for backward pass only when an eager Backward will read them
+        // (#1668: ShouldCacheForBackward is false under tape / inference scope / eval).
+        if (ShouldCacheForBackward)
         {
             // Cache the 3D input (don't dispose)
             _gpuInput = input3D;
@@ -941,8 +946,10 @@ public partial class AttentionLayer<T> : LayerBase<T>, IAuxiliaryLossLayer<T>
         // [..., _inputSize] fails with _inputSize == -1).
         EnsureInitializedFromInput(input);
 
-        _lastInput = input;
-        _lastMask = mask;
+        // #1668: gate every backward-only cache; forward uses the local mask/input3D.
+        bool cacheBwd = ShouldCacheForBackward;
+        _lastInput = cacheBwd ? input : null;
+        _lastMask = cacheBwd ? mask : null;
 
         // Handle 2D [Batch, InputSize] or 3D [Batch, Seq, InputSize] input
         _inputWas2D = input.Shape.Length == 2;
@@ -950,9 +957,9 @@ public partial class AttentionLayer<T> : LayerBase<T>, IAuxiliaryLossLayer<T>
             ? Engine.Reshape(input, [input.Shape[0], 1, _inputSize])
             : input;
 
-        _lastQueryInput = input3D;
-        _lastKeyInput = input3D;
-        _lastValueInput = input3D;
+        _lastQueryInput = cacheBwd ? input3D : null;
+        _lastKeyInput = cacheBwd ? input3D : null;
+        _lastValueInput = cacheBwd ? input3D : null;
 
         int batchSize = input3D.Shape[0];
         int seqLen = input3D.Shape[1];
@@ -982,12 +989,13 @@ public partial class AttentionLayer<T> : LayerBase<T>, IAuxiliaryLossLayer<T>
         // 4. Mask
         attentionScores = Engine.TensorAdd(attentionScores, mask);
 
-        // 5. Softmax
-        _lastAttentionWeights = ApplyActivation(attentionScores);
+        // 5. Softmax (cache to the field for backward only; forward uses the local)
+        var attnWeights = ApplyActivation(attentionScores);
+        _lastAttentionWeights = cacheBwd ? attnWeights : null;
 
         // 6. Output: Weights @ V
-        var attentionOutput = Engine.BatchMatMul(_lastAttentionWeights, V);
-        _lastAttentionOutput = attentionOutput; // Cache for backward pass
+        var attentionOutput = Engine.BatchMatMul(attnWeights, V);
+        _lastAttentionOutput = cacheBwd ? attentionOutput : null; // #1668: cache for backward only
 
         // 7. Output Projection: Apply Wo to project from attentionSize back to inputSize
         var attnFlat = Engine.Reshape(attentionOutput, [batchSize * seqLen, _attentionSize]);

--- a/src/NeuralNetworks/Layers/AttentionLayer.cs
+++ b/src/NeuralNetworks/Layers/AttentionLayer.cs
@@ -532,7 +532,7 @@ public partial class AttentionLayer<T> : LayerBase<T>, IAuxiliaryLossLayer<T>
             input3D = Engine.Reshape(input, [flatBatch, input.Shape[rank - 2], input.Shape[rank - 1]]);
         }
 
-        _lastInput = input;
+        _lastInput = ShouldCacheForBackward ? input : null; // #1668: skip in inference (arena safety)
         _lastQueryInput = input3D;
         _lastKeyInput = input3D;
         _lastWasCrossAttention = false;

--- a/src/NeuralNetworks/Layers/AveragePoolingLayer.cs
+++ b/src/NeuralNetworks/Layers/AveragePoolingLayer.cs
@@ -281,7 +281,7 @@ public class AveragePoolingLayer<T> : LayerBase<T>
             throw new ArgumentException($"AveragePooling layer requires at least 3D tensor [C, H, W]. Got rank {input.Shape.Length}.");
 
         // Store input for autodiff backward pass
-        _lastInput = input;
+        _lastInput = ShouldCacheForBackward ? input : null; // #1668: skip in inference (arena safety)
         _originalInputShape = input._shape;
         int rank = input.Shape.Length;
 

--- a/src/NeuralNetworks/Layers/BasicBlock.cs
+++ b/src/NeuralNetworks/Layers/BasicBlock.cs
@@ -280,7 +280,7 @@ public class BasicBlock<T> : LayerBase<T>
         // OnFirstForward observes input.Shape.
         if (!IsShapeResolved) OnFirstForward(input);
 
-        _lastInput = input;
+        _lastInput = ShouldCacheForBackward ? input : null; // #1668: skip in inference (arena safety)
 
         // Main branch: conv1 -> bn1 -> relu -> conv2 -> bn2
         _lastConv1Output = _conv1.Forward(input);

--- a/src/NeuralNetworks/Layers/BidirectionalLayer.cs
+++ b/src/NeuralNetworks/Layers/BidirectionalLayer.cs
@@ -293,7 +293,7 @@ public class BidirectionalLayer<T> : LayerBase<T>
     /// </remarks>
     public override Tensor<T> Forward(Tensor<T> input)
     {
-        _lastInput = input;
+        _lastInput = ShouldCacheForBackward ? input : null; // #1668: skip in inference (arena safety)
 
         // Forward pass
         var forwardInput = input;

--- a/src/NeuralNetworks/Layers/BottleneckBlock.cs
+++ b/src/NeuralNetworks/Layers/BottleneckBlock.cs
@@ -321,7 +321,7 @@ public class BottleneckBlock<T> : LayerBase<T>
         // identity-branch decision below.
         if (!IsShapeResolved) OnFirstForward(input);
 
-        _lastInput = input;
+        _lastInput = ShouldCacheForBackward ? input : null; // #1668: skip in inference (arena safety)
 
         // Main branch: conv1 -> bn1 -> relu -> conv2 -> bn2 -> relu -> conv3 -> bn3
         _lastConv1Output = _conv1.Forward(input);

--- a/src/NeuralNetworks/Layers/ConditionalRandomFieldLayer.cs
+++ b/src/NeuralNetworks/Layers/ConditionalRandomFieldLayer.cs
@@ -330,7 +330,7 @@ public partial class ConditionalRandomFieldLayer<T> : LayerBase<T>
             // If we run Forward on GPU, we should cache tensors if we want GPU backward.
             // But Backward logic is complex (Forward-Backward algo).
             // For now, cache CPU tensor to support existing Backward.
-            _lastInput = input;
+            _lastInput = ShouldCacheForBackward ? input : null; // #1668: skip in inference (arena safety)
             _lastOutput = new Tensor<T>(new Vector<T>(outputData.Select(x => NumOps.FromFloat(x)).ToArray()), [batchSize, seqLen, numClasses]);
         }
 

--- a/src/NeuralNetworks/Layers/ConditionalRandomFieldLayer.cs
+++ b/src/NeuralNetworks/Layers/ConditionalRandomFieldLayer.cs
@@ -710,7 +710,7 @@ public partial class ConditionalRandomFieldLayer<T> : LayerBase<T>
             input3D = Engine.Reshape(input, [1, 1, input.Shape[0]]);
         }
 
-        _lastInput = input3D;
+        _lastInput = ShouldCacheForBackward ? input3D : null; // #1668: skip in inference (arena safety)
 
         // The actual sequence length of THIS input. Used for all Viterbi buffers and
         // loops below so the layer handles variable-length sequences (see note above).

--- a/src/NeuralNetworks/Layers/Conv3DLayer.cs
+++ b/src/NeuralNetworks/Layers/Conv3DLayer.cs
@@ -497,7 +497,7 @@ public partial class Conv3DLayer<T> : LayerBase<T>
     public override Tensor<T> Forward(Tensor<T> input)
     {
         EnsureInitializedFromInput(input);
-        _lastInput = input;
+        _lastInput = ShouldCacheForBackward ? input : null; // #1668: skip in inference (arena safety)
         _originalInputShape = input._shape;
 
         Tensor<T> batchedInput;

--- a/src/NeuralNetworks/Layers/Conv3DLayer.cs
+++ b/src/NeuralNetworks/Layers/Conv3DLayer.cs
@@ -497,7 +497,8 @@ public partial class Conv3DLayer<T> : LayerBase<T>
     public override Tensor<T> Forward(Tensor<T> input)
     {
         EnsureInitializedFromInput(input);
-        _lastInput = ShouldCacheForBackward ? input : null; // #1668: skip in inference (arena safety)
+        bool cacheBwd = ShouldCacheForBackward; // #1668: gate all backward caches (arena safety)
+        _lastInput = cacheBwd ? input : null;
         _originalInputShape = input._shape;
 
         Tensor<T> batchedInput;
@@ -581,8 +582,8 @@ public partial class Conv3DLayer<T> : LayerBase<T>
                 fusedActivation);
 
             // Store for backward pass (activated output is also pre-activation for supported activations)
-            _lastPreActivation = activated;
-            _lastOutput = activated;
+            _lastPreActivation = cacheBwd ? activated : null;
+            _lastOutput = cacheBwd ? activated : null;
         }
         else
         {
@@ -595,10 +596,10 @@ public partial class Conv3DLayer<T> : LayerBase<T>
                 [1, 1, 1]);
 
             var withBias = AddBiases(convOutput);
-            _lastPreActivation = withBias;
+            _lastPreActivation = cacheBwd ? withBias : null;
 
             activated = ApplyActivation(withBias);
-            _lastOutput = activated;
+            _lastOutput = cacheBwd ? activated : null;
         }
 
         // Restore original tensor rank
@@ -818,7 +819,7 @@ public partial class Conv3DLayer<T> : LayerBase<T>
         // Broadcast bias [OC] → [1, OC, 1, 1, 1] over the spatial dims.
         var biasReshape = Engine.Reshape(_biases, new[] { 1, OC, 1, 1, 1 });
         var withBias = Engine.TensorBroadcastAdd(yNCDHW, biasReshape);
-        _lastPreActivation = withBias;
+        _lastPreActivation = ShouldCacheForBackward ? withBias : null; // #1668: skip in inference (arena safety)
 
         // Activation. ApplyActivation routes through the tape-tracked
         // Engine activation operators when the layer's IActivationFunction
@@ -827,7 +828,7 @@ public partial class Conv3DLayer<T> : LayerBase<T>
         // in. For non-fused activations (custom IVectorActivationFunction)
         // it still tape-tracks via the per-element scalar dispatch.
         var activated = ApplyActivation(withBias);
-        _lastOutput = activated;
+        _lastOutput = ShouldCacheForBackward ? activated : null; // #1668: skip in inference (arena safety)
         return activated;
     }
 

--- a/src/NeuralNetworks/Layers/ConvolutionalLayer.cs
+++ b/src/NeuralNetworks/Layers/ConvolutionalLayer.cs
@@ -1168,14 +1168,17 @@ public partial class ConvolutionalLayer<T> : LayerBase<T>
         int batchSize_conv = input4D.Shape[0];
         int[] expectedShape = [batchSize_conv, OutputDepth, outputHeight, outputWidth];
 
-        // Cross-forward output-buffer reuse is unsafe inside the denoise-loop arena:
-        // _preAllocatedOutput is arena scratch, and reusing the same slot across the
-        // per-step Reset() would alias whatever the next step Rents into that slot
-        // (#1668). When an InferenceMode arena owns buffer reuse, Rent a fresh output
-        // each forward (the arena pools+recycles it in cursor order, so this stays
-        // zero-allocation after warmup). Outside an arena, keep the manual reuse.
+        // Cross-forward output-buffer reuse is unsafe only when a TensorArena is actually
+        // active: _preAllocatedOutput is arena scratch, and reusing the same slot across the
+        // per-step Reset() would alias whatever the next step Rents into that slot (#1668).
+        // Key this off TensorArena.Current (not InferenceMode) so the escape hatch
+        // (AIDOTNET_INFERENCE_ARENA_DIFFUSION=0, which leaves InferenceMode on but disables
+        // the arena) keeps the manual zero-allocation reuse — otherwise we'd rent a fresh
+        // buffer every forward with no arena to pool it. With the arena on, re-renting per
+        // forward stays zero-allocation after warmup (the arena recycles in cursor order).
+        bool arenaActive = AiDotNet.Tensors.Helpers.TensorArena.Current is not null;
         if (_preAllocatedOutput is null ||
-            InferenceMode.IsActive ||
+            arenaActive ||
             _preAllocatedOutput.Shape[0] != batchSize_conv ||
             _preAllocatedOutput.Shape[2] != outputHeight ||
             _preAllocatedOutput.Shape[3] != outputWidth)

--- a/src/NeuralNetworks/Layers/ConvolutionalLayer.cs
+++ b/src/NeuralNetworks/Layers/ConvolutionalLayer.cs
@@ -1138,19 +1138,22 @@ public partial class ConvolutionalLayer<T> : LayerBase<T>
         // (Conv1a output at VGG paper-scale is 25.7 MB at fp64) and inflate
         // peak retained memory across the L-layer chain. Skip the assignment
         // in tape mode; use the local input4D directly for the conv ops.
-        bool tapeActive = AiDotNet.Tensors.Engines.Autodiff.GradientTape<T>.Current is not null
-            && !AiDotNet.Tensors.Engines.Autodiff.NoGradScope<T>.IsSuppressed;
-        if (!tapeActive)
+        // Retain the backward-activation caches (_lastInput / _lastOutput) only when an
+        // eager manual Backward will read them. The old `!tapeActive` test still cached
+        // during inference (no tape), pinning the activation set and — inside the
+        // denoise-loop arena — aliasing scratch recycled by the per-step Reset (#1668).
+        // ShouldCacheForBackward is additionally false in eval mode and inside an
+        // InferenceMode scope.
+        bool cacheBwd = ShouldCacheForBackward;
+        if (cacheBwd)
         {
             _lastInput = input4D;
         }
         else
         {
-            // Clear the cache when tape is active so prior non-tape steps
-            // can't keep an old activation rooted alongside the tape's
-            // intermediates. Empty-shape sentinel matches the ctor's
-            // initial state and lets ParameterCount / Serialize logic that
-            // reads _lastInput.Shape continue to work without an NRE.
+            // Empty-shape sentinel matches the ctor's initial state and lets
+            // ParameterCount / Serialize logic that reads _lastInput.Shape continue
+            // to work without an NRE.
             _lastInput = new Tensor<T>([0, 0, 0, 0]);
         }
 
@@ -1165,7 +1168,14 @@ public partial class ConvolutionalLayer<T> : LayerBase<T>
         int batchSize_conv = input4D.Shape[0];
         int[] expectedShape = [batchSize_conv, OutputDepth, outputHeight, outputWidth];
 
+        // Cross-forward output-buffer reuse is unsafe inside the denoise-loop arena:
+        // _preAllocatedOutput is arena scratch, and reusing the same slot across the
+        // per-step Reset() would alias whatever the next step Rents into that slot
+        // (#1668). When an InferenceMode arena owns buffer reuse, Rent a fresh output
+        // each forward (the arena pools+recycles it in cursor order, so this stays
+        // zero-allocation after warmup). Outside an arena, keep the manual reuse.
         if (_preAllocatedOutput is null ||
+            InferenceMode.IsActive ||
             _preAllocatedOutput.Shape[0] != batchSize_conv ||
             _preAllocatedOutput.Shape[2] != outputHeight ||
             _preAllocatedOutput.Shape[3] != outputWidth)
@@ -1272,7 +1282,7 @@ public partial class ConvolutionalLayer<T> : LayerBase<T>
         // for the entire inference branch). When the tape IS active, clear
         // the cache so a prior non-tape step's output can't keep its tensor
         // rooted in parallel with the tape's intermediates.
-        if (!tapeActive)
+        if (cacheBwd)
         {
             _lastOutput = result;
         }

--- a/src/NeuralNetworks/Layers/CroppingLayer.cs
+++ b/src/NeuralNetworks/Layers/CroppingLayer.cs
@@ -438,7 +438,7 @@ public class CroppingLayer<T> : LayerBase<T>
             input4D = Engine.Reshape(input, new[] { flatBatch, input.Shape[rank - 3], input.Shape[rank - 2], input.Shape[rank - 1] });
         }
 
-        _lastInput = input4D;
+        _lastInput = ShouldCacheForBackward ? input4D : null; // #1668: skip in inference (arena safety)
 
         // Convert from NHWC [batch, height, width, channels] to NCHW [batch, channels, height, width]
         var inputNCHW = Engine.TensorPermute(input4D, [0, 3, 1, 2]);

--- a/src/NeuralNetworks/Layers/CroppingLayer.cs
+++ b/src/NeuralNetworks/Layers/CroppingLayer.cs
@@ -211,7 +211,7 @@ public class CroppingLayer<T> : LayerBase<T>
 
         if (IsTrainingMode)
         {
-            _lastInput = input;
+            _lastInput = ShouldCacheForBackward ? input : null; // #1668: skip in inference (arena safety)
             _gpuCachedInputShape = (int[])inputShape.Clone();
         }
 

--- a/src/NeuralNetworks/Layers/DecoderLayer.cs
+++ b/src/NeuralNetworks/Layers/DecoderLayer.cs
@@ -519,7 +519,7 @@ public class DecoderLayer<T> : LayerBase<T>
     private Tensor<T> ForwardInternal(Tensor<T> input, Tensor<T> encoderOutput, Tensor<T>? attentionMask = null)
     {
         _lastInput = ShouldCacheForBackward ? input : null; // #1668: skip in inference (arena safety)
-        _lastEncoderOutput = encoderOutput;
+        _lastEncoderOutput = ShouldCacheForBackward ? encoderOutput : null;
 
         // Get dimensions from input and encoder output
         int batchSize = input.Shape[0];

--- a/src/NeuralNetworks/Layers/DecoderLayer.cs
+++ b/src/NeuralNetworks/Layers/DecoderLayer.cs
@@ -518,7 +518,7 @@ public class DecoderLayer<T> : LayerBase<T>
     /// </remarks>
     private Tensor<T> ForwardInternal(Tensor<T> input, Tensor<T> encoderOutput, Tensor<T>? attentionMask = null)
     {
-        _lastInput = input;
+        _lastInput = ShouldCacheForBackward ? input : null; // #1668: skip in inference (arena safety)
         _lastEncoderOutput = encoderOutput;
 
         // Get dimensions from input and encoder output

--- a/src/NeuralNetworks/Layers/DeconvolutionalLayer.cs
+++ b/src/NeuralNetworks/Layers/DeconvolutionalLayer.cs
@@ -508,7 +508,7 @@ public partial class DeconvolutionalLayer<T> : LayerBase<T>
         if (IsInferringShapes) return ShapeInferenceOutput(input);
 
         EnsureInitializedFromInput(input);
-        _lastInput = input;
+        _lastInput = ShouldCacheForBackward ? input : null; // #1668: skip in inference (arena safety)
 
         // Get the fused activation type for optimal GPU/CPU performance
         var fusedActivation = GetFusedActivationType();

--- a/src/NeuralNetworks/Layers/DeformableConvolutionalLayer.cs
+++ b/src/NeuralNetworks/Layers/DeformableConvolutionalLayer.cs
@@ -292,7 +292,7 @@ public partial class DeformableConvolutionalLayer<T> : LayerBase<T>
         // and allocate weights on the first Forward.
         if (!IsShapeResolved) OnFirstForward(input);
 
-        _lastInput = input;
+        _lastInput = ShouldCacheForBackward ? input : null; // #1668: skip in inference (arena safety)
 
         // Ensure 4D input [batch, channels, height, width]
         var input4D = EnsureBatchDimension(input);

--- a/src/NeuralNetworks/Layers/DenseBlockLayer.cs
+++ b/src/NeuralNetworks/Layers/DenseBlockLayer.cs
@@ -162,7 +162,7 @@ internal partial class DenseBlockLayer<T> : LayerBase<T>, ILayerSerializationExt
         // run with their (possibly stale-from-init) weights.
         if (!IsShapeResolved) OnFirstForward(input);
 
-        _lastInput = input;
+        _lastInput = ShouldCacheForBackward ? input : null; // #1668: skip in inference (arena safety)
 
         // BN/Conv expect [N, C, H, W] format. Add batch dim if 3D [C, H, W].
         var x = input.Shape.Length == 3 ? Engine.Reshape(input, [1, input.Shape[0], input.Shape[1], input.Shape[2]]) : input;

--- a/src/NeuralNetworks/Layers/DenseLayer.cs
+++ b/src/NeuralNetworks/Layers/DenseLayer.cs
@@ -955,7 +955,13 @@ public partial class DenseLayer<T> : LayerBase<T>, IAuxiliaryLossLayer<T>
         // pin into _lastOutput.
         bool tapeActive = AiDotNet.Tensors.Engines.Autodiff.GradientTape<T>.Current is not null
             && !AiDotNet.Tensors.Engines.Autodiff.NoGradScope<T>.IsSuppressed;
-        _lastInput = tapeActive ? null : input;
+        // Retain the manual-backward activation caches only when an eager Backward will
+        // read them. The old `!tapeActive` test still cached during inference (no tape),
+        // which pinned the activation set and — inside the denoise-loop arena — aliased
+        // scratch recycled by the per-step Reset (issue #1668). ShouldCacheForBackward is
+        // additionally false in eval mode and inside an InferenceMode scope.
+        bool cacheBwd = ShouldCacheForBackward;
+        _lastInput = cacheBwd ? input : null;
         _originalInputShape = input._shape;
 
         // Industry standard: Support any-rank input tensors [..., inputSize]
@@ -1022,14 +1028,7 @@ public partial class DenseLayer<T> : LayerBase<T>, IAuxiliaryLossLayer<T>
             // FusedLinear entry per forward pass (calling FusedLinear twice corrupts tape
             // entries via RemoveLastNTapeEntries).
             var preActivation = Engine.FusedLinear(flattenedInput, _weights, _biases, FusedActivationType.None);
-            if (!tapeActive)
-            {
-                _lastOutput = preActivation;
-            }
-            else
-            {
-                _lastOutput = null;
-            }
+            _lastOutput = cacheBwd ? preActivation : null;
             result = ApplyActivation(preActivation);
         }
 

--- a/src/NeuralNetworks/Layers/DenseLayer.cs
+++ b/src/NeuralNetworks/Layers/DenseLayer.cs
@@ -953,13 +953,11 @@ public partial class DenseLayer<T> : LayerBase<T>, IAuxiliaryLossLayer<T>
         // 4096-wide intermediate `preActivation` is the larger cost — 16
         // KB at fp32 / 32 KB at fp64, and that's the value we'd otherwise
         // pin into _lastOutput.
-        bool tapeActive = AiDotNet.Tensors.Engines.Autodiff.GradientTape<T>.Current is not null
-            && !AiDotNet.Tensors.Engines.Autodiff.NoGradScope<T>.IsSuppressed;
         // Retain the manual-backward activation caches only when an eager Backward will
-        // read them. The old `!tapeActive` test still cached during inference (no tape),
-        // which pinned the activation set and — inside the denoise-loop arena — aliased
-        // scratch recycled by the per-step Reset (issue #1668). ShouldCacheForBackward is
-        // additionally false in eval mode and inside an InferenceMode scope.
+        // read them. A plain "no tape" test still cached during inference, which pinned the
+        // activation set and — inside the denoise-loop arena — aliased scratch recycled by
+        // the per-step Reset (issue #1668). ShouldCacheForBackward is additionally false in
+        // eval mode and inside an InferenceMode scope.
         bool cacheBwd = ShouldCacheForBackward;
         _lastInput = cacheBwd ? input : null;
         _originalInputShape = input._shape;

--- a/src/NeuralNetworks/Layers/DiffusionConvLayer.cs
+++ b/src/NeuralNetworks/Layers/DiffusionConvLayer.cs
@@ -537,7 +537,7 @@ public partial class DiffusionConvLayer<T> : LayerBase<T>
                 "Eigenbasis or Laplacian must be set via SetEigenbasis or SetLaplacian before calling Forward.");
         }
 
-        _lastInput = input;
+        _lastInput = ShouldCacheForBackward ? input : null; // #1668: skip in inference (arena safety)
 
         bool hasBatch = input.Rank == 3;
         int numVertices = hasBatch ? input.Shape[1] : input.Shape[0];

--- a/src/NeuralNetworks/Layers/DropoutLayer.cs
+++ b/src/NeuralNetworks/Layers/DropoutLayer.cs
@@ -285,7 +285,7 @@ public class DropoutLayer<T> : LayerBase<T>
     /// </remarks>
     public override Tensor<T> Forward(Tensor<T> input)
     {
-        _lastInput = input;
+        _lastInput = ShouldCacheForBackward ? input : null; // #1668: skip in inference (arena safety)
 
         if (!IsTrainingMode)
             return input;

--- a/src/NeuralNetworks/Layers/EmbeddingLayer.cs
+++ b/src/NeuralNetworks/Layers/EmbeddingLayer.cs
@@ -591,7 +591,7 @@ public partial class EmbeddingLayer<T> : LayerBase<T>, IAuxiliaryLossLayer<T>, I
         // allocation up front.
         EnsureEmbeddingInitialized();
 
-        _lastInput = input;
+        _lastInput = ShouldCacheForBackward ? input : null; // #1668: skip in inference (arena safety)
         _originalInputShape = input._shape;
 
         int embeddingDim = _embeddingTensor.Shape[1];

--- a/src/NeuralNetworks/Layers/FlattenLayer.cs
+++ b/src/NeuralNetworks/Layers/FlattenLayer.cs
@@ -228,7 +228,7 @@ public class FlattenLayer<T> : LayerBase<T>
     public override Tensor<T> Forward(Tensor<T> input)
     {
         EnsureInitializedFromInput(input);
-        _lastInput = input;
+        _lastInput = ShouldCacheForBackward ? input : null; // #1668: skip in inference (arena safety)
 
         // Handle truly unbatched 1D input
         if (input.Rank == 1)

--- a/src/NeuralNetworks/Layers/FullyConnectedLayer.cs
+++ b/src/NeuralNetworks/Layers/FullyConnectedLayer.cs
@@ -439,7 +439,7 @@ public partial class FullyConnectedLayer<T> : LayerBase<T>
             input = Engine.Reshape(input, new[] { 1, input.Length });
         }
 
-        _lastInput = input;
+        _lastInput = ShouldCacheForBackward ? input : null; // #1668: skip in inference (arena safety)
 
         // Compute output = input * weights^T + biases using Engine operations
         // input: [batchSize, inputSize]

--- a/src/NeuralNetworks/Layers/GatedLinearUnitLayer.cs
+++ b/src/NeuralNetworks/Layers/GatedLinearUnitLayer.cs
@@ -546,11 +546,14 @@ public partial class GatedLinearUnitLayer<T> : LayerBase<T>
         var gateOutput = input.MatrixMultiply(gateWeightsT);
         gateOutput = Engine.TensorBroadcastAdd(gateOutput, _gateBias); // Broadcasting
 
-        _lastLinearOutput = linearOutput;
-        _lastGateOutput = ApplyActivation(gateOutput);
+        // #1668: cache the linear/gate activations for backward only; forward uses locals.
+        var linOut = linearOutput;
+        var gateOut = ApplyActivation(gateOutput);
+        _lastLinearOutput = ShouldCacheForBackward ? linOut : null;
+        _lastGateOutput = ShouldCacheForBackward ? gateOut : null;
 
         // GLU output: output = linear * gate
-        var output = Engine.TensorMultiply(_lastLinearOutput, _lastGateOutput);
+        var output = Engine.TensorMultiply(linOut, gateOut);
 
         return output;
     }
@@ -592,8 +595,9 @@ public partial class GatedLinearUnitLayer<T> : LayerBase<T>
         // Element-wise multiply on GPU
         backend.Multiply(linearOutput.Buffer, gateOutput.Buffer, outputBuffer, size);
 
-        // Cache state for backward pass only during training
-        if (IsTrainingMode)
+        // Cache state for backward pass only when an eager Backward will read it (#1668:
+        // ShouldCacheForBackward is false under tape / inference scope / eval).
+        if (ShouldCacheForBackward)
         {
             // Cache GPU tensors for GPU-resident backward pass
             _gpuInput = input;

--- a/src/NeuralNetworks/Layers/GatedLinearUnitLayer.cs
+++ b/src/NeuralNetworks/Layers/GatedLinearUnitLayer.cs
@@ -534,7 +534,7 @@ public partial class GatedLinearUnitLayer<T> : LayerBase<T>
     public override Tensor<T> Forward(Tensor<T> input)
     {
         EnsureInitializedFromInput(input);
-        _lastInput = input;
+        _lastInput = ShouldCacheForBackward ? input : null; // #1668: skip in inference (arena safety)
 
         // Linear path: linear = input @ weights^T + bias
         var linearWeightsT = Engine.TensorPermute(_linearWeights, [1, 0]);

--- a/src/NeuralNetworks/Layers/GaussianNoiseLayer.cs
+++ b/src/NeuralNetworks/Layers/GaussianNoiseLayer.cs
@@ -256,7 +256,7 @@ public class GaussianNoiseLayer<T> : LayerBase<T>
     public override Tensor<T> Forward(Tensor<T> input)
     {
         EnsureInitializedFromInput(input);
-        _lastInput = input;
+        _lastInput = ShouldCacheForBackward ? input : null; // #1668: skip in inference (arena safety)
         if (IsTrainingMode)
         {
             _lastNoise = GenerateNoise(input._shape);

--- a/src/NeuralNetworks/Layers/GaussianNoiseLayer.cs
+++ b/src/NeuralNetworks/Layers/GaussianNoiseLayer.cs
@@ -163,7 +163,7 @@ public class GaussianNoiseLayer<T> : LayerBase<T>
 
             var result = gpuEngine.AddGpu(input, noise);
 
-            _lastInput = input;
+            _lastInput = ShouldCacheForBackward ? input : null; // #1668: skip in inference (arena safety)
             _lastNoise = noise;
 
             noise.Dispose();

--- a/src/NeuralNetworks/Layers/GlobalPoolingLayer.cs
+++ b/src/NeuralNetworks/Layers/GlobalPoolingLayer.cs
@@ -383,7 +383,7 @@ public class GlobalPoolingLayer<T> : LayerBase<T>
     public override Tensor<T> Forward(Tensor<T> input)
     {
         EnsureInitializedFromInput(input);
-        _lastInput = input;
+        _lastInput = ShouldCacheForBackward ? input : null; // #1668: skip in inference (arena safety)
 
         // Industry-standard: dynamically determine axes based on input rank
         // For any rank, reduce all dimensions except first (batch) and last (features/channels)

--- a/src/NeuralNetworks/Layers/GraphAttentionLayer.cs
+++ b/src/NeuralNetworks/Layers/GraphAttentionLayer.cs
@@ -424,6 +424,11 @@ public partial class GraphAttentionLayer<T> : LayerBase<T>, IGraphConvolutionLay
         }
 
         // Dense aggregation path (original implementation)
+        // #1668: these per-head buffers double as forward working scratch (written + read
+        // back below) AND manual-backward caches. They're released after their last forward
+        // use when no eager Backward will read them (see below), so an arena loop holds no
+        // reference across a Reset.
+        bool cacheBwd = ShouldCacheForBackward;
         // Step 1: Transform input for each head using Engine operations
         // transformed[b,h,n,f] = sum_i(input[b,n,i] * weights[h,i,f])
         _lastTransformed = TensorAllocator.Rent<T>([batchSize, _numHeads, numNodes, _outputFeatures]);
@@ -504,6 +509,16 @@ public partial class GraphAttentionLayer<T> : LayerBase<T>, IGraphConvolutionLay
         // Step 5: Average across heads and add bias using Engine operations
         // Sum over head dimension (axis 1): [batchSize, numHeads, numNodes, outputFeatures] -> [batchSize, numNodes, outputFeatures]
         var sumOverHeads = Engine.ReduceSum(_lastHeadOutputs, [1], keepDims: false);
+
+        // #1668: last forward use of the per-head working buffers is above. When no eager
+        // Backward will read them, drop the references so the arena can recycle them safely.
+        if (!cacheBwd)
+        {
+            _lastTransformed = null;
+            _lastPreSoftmaxScores = null;
+            _lastAttentionCoefficients = null;
+            _lastHeadOutputs = null;
+        }
 
         // Divide by number of heads using scalar divide
         T numHeadsT = NumOps.FromDouble(_numHeads);

--- a/src/NeuralNetworks/Layers/GraphAttentionLayer.cs
+++ b/src/NeuralNetworks/Layers/GraphAttentionLayer.cs
@@ -347,7 +347,12 @@ public partial class GraphAttentionLayer<T> : LayerBase<T>, IGraphConvolutionLay
             processInput = Engine.Reshape(input, [flatBatch, input.Shape[rank - 2], input.Shape[rank - 1]]);
         }
 
-        _lastInput = processInput;
+        // #1668: compute the backward-cache decision once up front so every backward-only cache
+        // in both the sparse and dense paths (and _lastInput here) is gated/cleared consistently.
+        // Clearing (not just skipping) is required: a prior step's arena-owned tensor must not
+        // survive into the next denoise-loop Reset().
+        bool cacheBwd = ShouldCacheForBackward;
+        _lastInput = cacheBwd ? processInput : null;
 
         Tensor<T> output;
         Tensor<T> activatedOutput;
@@ -397,13 +402,14 @@ public partial class GraphAttentionLayer<T> : LayerBase<T>, IGraphConvolutionLay
             activatedOutput = ApplyActivation(output);
 
             // Reshape output to match original input rank
+            Tensor<T> sparseReshaped;
             if (rank == 1)
             {
-                _lastOutput = Engine.Reshape(activatedOutput, [_outputFeatures]);
+                sparseReshaped = Engine.Reshape(activatedOutput, [_outputFeatures]);
             }
             else if (rank == 2)
             {
-                _lastOutput = Engine.Reshape(activatedOutput, [numNodes, _outputFeatures]);
+                sparseReshaped = Engine.Reshape(activatedOutput, [numNodes, _outputFeatures]);
             }
             else
             {
@@ -417,18 +423,20 @@ public partial class GraphAttentionLayer<T> : LayerBase<T>, IGraphConvolutionLay
                     outputShape[d] = originalShape[d];
                 outputShape[rank - 2] = numNodes;
                 outputShape[rank - 1] = _outputFeatures;
-                _lastOutput = Engine.Reshape(activatedOutput, outputShape);
+                sparseReshaped = Engine.Reshape(activatedOutput, outputShape);
             }
 
-            return _lastOutput;
+            // #1668: _lastOutput is a backward-only cache; clear it in inference so the
+            // arena-owned reshaped output is not retained across the next Reset().
+            _lastOutput = cacheBwd ? sparseReshaped : null;
+            return sparseReshaped;
         }
 
         // Dense aggregation path (original implementation)
         // #1668: these per-head buffers double as forward working scratch (written + read
         // back below) AND manual-backward caches. They're released after their last forward
         // use when no eager Backward will read them (see below), so an arena loop holds no
-        // reference across a Reset.
-        bool cacheBwd = ShouldCacheForBackward;
+        // reference across a Reset. (cacheBwd is computed once at the top of Forward.)
         // Step 1: Transform input for each head using Engine operations
         // transformed[b,h,n,f] = sum_i(input[b,n,i] * weights[h,i,f])
         _lastTransformed = TensorAllocator.Rent<T>([batchSize, _numHeads, numNodes, _outputFeatures]);
@@ -531,15 +539,16 @@ public partial class GraphAttentionLayer<T> : LayerBase<T>, IGraphConvolutionLay
         activatedOutput = ApplyActivation(output);
 
         // Reshape output to match original input rank
+        Tensor<T> denseReshaped;
         if (rank == 1)
         {
             // Original was [inputFeatures], output should be [outputFeatures]
-            _lastOutput = Engine.Reshape(activatedOutput, [_outputFeatures]);
+            denseReshaped = Engine.Reshape(activatedOutput, [_outputFeatures]);
         }
         else if (rank == 2)
         {
             // Original was [numNodes, inputFeatures], output should be [numNodes, outputFeatures]
-            _lastOutput = Engine.Reshape(activatedOutput, [numNodes, _outputFeatures]);
+            denseReshaped = Engine.Reshape(activatedOutput, [numNodes, _outputFeatures]);
         }
         else
         {
@@ -554,10 +563,13 @@ public partial class GraphAttentionLayer<T> : LayerBase<T>, IGraphConvolutionLay
                 outputShape[d] = originalShape[d];
             outputShape[rank - 2] = numNodes;
             outputShape[rank - 1] = _outputFeatures;
-            _lastOutput = Engine.Reshape(activatedOutput, outputShape);
+            denseReshaped = Engine.Reshape(activatedOutput, outputShape);
         }
 
-        return _lastOutput;
+        // #1668: _lastOutput is a backward-only cache; clear it in inference so the
+        // arena-owned reshaped output is not retained across the next Reset().
+        _lastOutput = cacheBwd ? denseReshaped : null;
+        return denseReshaped;
     }
 
     private Tensor<T> ExtractHeadWeight(int h)

--- a/src/NeuralNetworks/Layers/GraphTransformerLayer.cs
+++ b/src/NeuralNetworks/Layers/GraphTransformerLayer.cs
@@ -539,10 +539,16 @@ public partial class GraphTransformerLayer<T> : LayerBase<T>, IGraphConvolutionL
 
         var result = ApplyActivation(output);
 
-        // Only store for backward pass when an eager Backward will read it (#1668).
+        // Only store for backward pass when an eager Backward will read it (#1668). Clear any
+        // prior cached output otherwise, so an arena-owned tensor from a previous step is not
+        // retained across the next denoise-loop Reset().
         if (cacheBwd)
         {
             _lastOutput = result;
+        }
+        else
+        {
+            _lastOutput = null;
         }
 
         // Restore original shape for any-rank tensor support

--- a/src/NeuralNetworks/Layers/GraphTransformerLayer.cs
+++ b/src/NeuralNetworks/Layers/GraphTransformerLayer.cs
@@ -498,7 +498,8 @@ public partial class GraphTransformerLayer<T> : LayerBase<T>, IGraphConvolutionL
             processInput = Engine.Reshape(input, [1, 1, input.Shape[0]]);
         }
 
-        _lastInput = processInput;
+        bool cacheBwd = ShouldCacheForBackward; // #1668: gate backward-only caches (arena safety)
+        _lastInput = cacheBwd ? processInput : null;
         int numNodes = processInput.Shape[1];
 
         // Multi-head attention block with residual connection
@@ -527,19 +528,19 @@ public partial class GraphTransformerLayer<T> : LayerBase<T>, IGraphConvolutionL
         }
 
         var normed1 = Engine.TensorAdd(attended, residualInput);
-        _lastNormed1 = normed1;
+        _lastNormed1 = cacheBwd ? normed1 : null;
 
         // Feed-forward network with residual
         var ffnOutput = FeedForwardNetwork(normed1, batchSize, numNodes);
-        _lastFFNOutput = ffnOutput;
+        _lastFFNOutput = cacheBwd ? ffnOutput : null;
 
         // Final residual and layer norm
         var output = Engine.TensorAdd(normed1, ffnOutput);
 
         var result = ApplyActivation(output);
 
-        // Only store for backward pass during training - skip during inference
-        if (IsTrainingMode)
+        // Only store for backward pass when an eager Backward will read it (#1668).
+        if (cacheBwd)
         {
             _lastOutput = result;
         }
@@ -934,14 +935,16 @@ public partial class GraphTransformerLayer<T> : LayerBase<T>, IGraphConvolutionL
 
     private Tensor<T> MultiHeadAttention(Tensor<T> input, int batchSize, int numNodes)
     {
-        // Rent attention tensors — all fully overwritten in forward pass
+        // Rent attention tensors. headOutputs is forward scratch (consumed below); the _last*
+        // fields are manual-backward caches only (the forward uses per-head locals), so rent +
+        // populate them only when an eager Backward will read them (#1668) — leaving nothing for
+        // an arena Reset to alias in inference.
+        bool cacheBwd = ShouldCacheForBackward;
         var headOutputs = TensorAllocator.Rent<T>([batchSize, _numHeads, numNodes, _headDim]);
-        _lastAttentionWeights = TensorAllocator.Rent<T>([batchSize, _numHeads, numNodes, numNodes]);
-
-        // Q, K, V are fully overwritten per head — safe to rent
-        _lastQueries = TensorAllocator.Rent<T>([batchSize, _numHeads, numNodes, _headDim]);
-        _lastKeys = TensorAllocator.Rent<T>([batchSize, _numHeads, numNodes, _headDim]);
-        _lastValues = TensorAllocator.Rent<T>([batchSize, _numHeads, numNodes, _headDim]);
+        _lastAttentionWeights = cacheBwd ? TensorAllocator.Rent<T>([batchSize, _numHeads, numNodes, numNodes]) : null;
+        _lastQueries = cacheBwd ? TensorAllocator.Rent<T>([batchSize, _numHeads, numNodes, _headDim]) : null;
+        _lastKeys = cacheBwd ? TensorAllocator.Rent<T>([batchSize, _numHeads, numNodes, _headDim]) : null;
+        _lastValues = cacheBwd ? TensorAllocator.Rent<T>([batchSize, _numHeads, numNodes, _headDim]) : null;
 
         // Attention scale factor: 1/sqrt(d_k). Compute as a scalar Multiply factor
         // so we can use Engine.TensorMultiplyScalar instead of per-element Divide.
@@ -1009,19 +1012,26 @@ public partial class GraphTransformerLayer<T> : LayerBase<T>, IGraphConvolutionL
             // there's no dest-slice-write Engine op — but this is bounded to
             // O(B·N·D) per head, vs the O(B·N²·D) attention compute that just
             // collapsed to two Engine ops above.
-            ScatterHeadSlice(_lastQueries, queries, h, batchSize, numNodes, _headDim);
-            ScatterHeadSlice(_lastKeys, keys, h, batchSize, numNodes, _headDim);
-            ScatterHeadSlice(_lastValues, values, h, batchSize, numNodes, _headDim);
             ScatterHeadSlice(headOutputs, headOut, h, batchSize, numNodes, _headDim);
 
-            // Attention weights are [B, N, N] not [B, N, D]; separate scatter.
-            for (int b = 0; b < batchSize; b++)
-                for (int i = 0; i < numNodes; i++)
-                    for (int j = 0; j < numNodes; j++)
-                        _lastAttentionWeights[b, h, i, j] = attnWeights[b, i, j];
+            // #1668: Q/K/V/attn-weight scatters populate backward-only caches; skip them when
+            // no eager Backward will read them. The combined null-check both expresses that
+            // (the fields are null in inference) and narrows them to non-null for the compiler.
+            if (_lastQueries != null && _lastKeys != null && _lastValues != null && _lastAttentionWeights != null)
+            {
+                ScatterHeadSlice(_lastQueries, queries, h, batchSize, numNodes, _headDim);
+                ScatterHeadSlice(_lastKeys, keys, h, batchSize, numNodes, _headDim);
+                ScatterHeadSlice(_lastValues, values, h, batchSize, numNodes, _headDim);
+
+                // Attention weights are [B, N, N] not [B, N, D]; separate scatter.
+                for (int b = 0; b < batchSize; b++)
+                    for (int i = 0; i < numNodes; i++)
+                        for (int j = 0; j < numNodes; j++)
+                            _lastAttentionWeights[b, h, i, j] = attnWeights[b, i, j];
+            }
         }
 
-        _lastHeadOutputs = headOutputs;
+        _lastHeadOutputs = cacheBwd ? headOutputs : null;
 
         // Concatenate heads: [batch, numNodes, numHeads * headDim]
         var concatenated = TensorAllocator.Rent<T>([batchSize, numNodes, _numHeads * _headDim]);
@@ -1040,7 +1050,7 @@ public partial class GraphTransformerLayer<T> : LayerBase<T>, IGraphConvolutionL
             }
         }
 
-        _lastConcatenated = concatenated;
+        _lastConcatenated = cacheBwd ? concatenated : null;
 
         // Project concatenated output: [batch, numNodes, numHeads*headDim] @ [numHeads*headDim, outputFeatures]
         var output = BatchedMatMul3Dx2D(concatenated, _outputWeights, batchSize, numNodes, _numHeads * _headDim, _outputFeatures);
@@ -1049,7 +1059,7 @@ public partial class GraphTransformerLayer<T> : LayerBase<T>, IGraphConvolutionL
         var biasBroadcast = BroadcastBias(_outputBias, batchSize, numNodes);
         output = Engine.TensorAdd(output, biasBroadcast);
 
-        _lastAttnOutput = output;
+        _lastAttnOutput = cacheBwd ? output : null;
         return output;
     }
 
@@ -1099,6 +1109,7 @@ public partial class GraphTransformerLayer<T> : LayerBase<T>, IGraphConvolutionL
 
     private Tensor<T> FeedForwardNetwork(Tensor<T> input, int batchSize, int numNodes)
     {
+        bool cacheBwd = ShouldCacheForBackward; // #1668: gate the backward-only FFN-hidden cache
         // First layer: [batch, numNodes, outputFeatures] @ [outputFeatures, ffnHiddenDim]
         var hidden = BatchedMatMul3Dx2D(input, _ffnWeights1, batchSize, numNodes, _outputFeatures, _ffnHiddenDim);
 
@@ -1108,7 +1119,7 @@ public partial class GraphTransformerLayer<T> : LayerBase<T>, IGraphConvolutionL
 
         // Apply FFN activation (configurable: GELU by default, but user can choose any activation)
         hidden = ApplyFFNActivation(hidden);
-        _lastFFNHidden = hidden;
+        _lastFFNHidden = cacheBwd ? hidden : null;
 
         // Second layer: [batch, numNodes, ffnHiddenDim] @ [ffnHiddenDim, outputFeatures]
         var output = BatchedMatMul3Dx2D(hidden, _ffnWeights2, batchSize, numNodes, _ffnHiddenDim, _outputFeatures);

--- a/src/NeuralNetworks/Layers/GroupNormalizationLayer.cs
+++ b/src/NeuralNetworks/Layers/GroupNormalizationLayer.cs
@@ -146,7 +146,11 @@ public partial class GroupNormalizationLayer<T> : LayerBase<T>
 
     public override Tensor<T> Forward(Tensor<T> input)
     {
-        _lastInput = input;
+        // Retain backward-activation caches (_lastInput / _lastMean / _lastVariance)
+        // only when an eager manual Backward will read them; skip in inference/under
+        // tape so the denoise-loop arena can recycle scratch without aliasing (#1668).
+        bool cacheBwd = ShouldCacheForBackward;
+        _lastInput = cacheBwd ? input : null;
         _originalInputShape = input._shape;
 
         var shape = input._shape;
@@ -210,8 +214,8 @@ public partial class GroupNormalizationLayer<T> : LayerBase<T>
             out var mean,
             out var variance);
 
-        _lastMean = mean;
-        _lastVariance = variance;
+        _lastMean = cacheBwd ? mean : null;
+        _lastVariance = cacheBwd ? variance : null;
 
         // Restore original tensor rank — via Engine so tape records the restore.
         if (_originalInputShape.Length > 4)
@@ -329,8 +333,10 @@ public partial class GroupNormalizationLayer<T> : LayerBase<T>
             spatialSize,
             (float)NumOps.ToDouble(_epsilon));
 
-        // Cache statistics for backward pass during training
-        if (IsTrainingMode)
+        // Cache statistics for backward pass during training. Skip inside an
+        // InferenceMode scope: no backward runs, and retaining these would pin
+        // (and, in the denoise-loop arena, alias) per-step buffers (#1668).
+        if (IsTrainingMode && !InferenceMode.IsActive)
         {
             // Cache GPU tensor for GPU-resident training
             _gpuLastInput = input;

--- a/src/NeuralNetworks/Layers/GroupedQueryAttentionLayer.cs
+++ b/src/NeuralNetworks/Layers/GroupedQueryAttentionLayer.cs
@@ -341,7 +341,7 @@ internal partial class GroupedQueryAttentionLayer<T> : LayerBase<T>
             ? Engine.Reshape(input, new[] { 1, seqLen, embDim })
             : Engine.Reshape(input, new[] { batchSize, seqLen, embDim });
 
-        _lastInput = input3D;
+        _lastInput = ShouldCacheForBackward ? input3D : null; // #1668: skip in inference (arena safety)
 
         // Project Q, K, V
         var input2D = Engine.Reshape(input3D, new[] { batchSize * seqLen, embDim });

--- a/src/NeuralNetworks/Layers/GroupedQueryAttentionLayer.cs
+++ b/src/NeuralNetworks/Layers/GroupedQueryAttentionLayer.cs
@@ -341,7 +341,8 @@ internal partial class GroupedQueryAttentionLayer<T> : LayerBase<T>
             ? Engine.Reshape(input, new[] { 1, seqLen, embDim })
             : Engine.Reshape(input, new[] { batchSize, seqLen, embDim });
 
-        _lastInput = ShouldCacheForBackward ? input3D : null; // #1668: skip in inference (arena safety)
+        bool cacheBwd = ShouldCacheForBackward; // #1668: gate all backward caches (arena safety)
+        _lastInput = cacheBwd ? input3D : null;
 
         // Project Q, K, V
         var input2D = Engine.Reshape(input3D, new[] { batchSize * seqLen, embDim });
@@ -368,23 +369,23 @@ internal partial class GroupedQueryAttentionLayer<T> : LayerBase<T>
             (queries, keys) = _ropeLayer.ApplyRoPE(queries, keys, startPosition: 0);
         }
 
-        _lastProjectedQueries = queries;
-        _lastProjectedKeys = keys;
-        _lastProjectedValues = values;
+        _lastProjectedQueries = cacheBwd ? queries : null;
+        _lastProjectedKeys = cacheBwd ? keys : null;
+        _lastProjectedValues = cacheBwd ? values : null;
 
         // Expand K/V heads to match Q heads via repeat
         var expandedKeys = ExpandKVHeads(keys, batchSize, seqLen);
         var expandedValues = ExpandKVHeads(values, batchSize, seqLen);
 
-        _lastExpandedKeys = expandedKeys;
-        _lastExpandedValues = expandedValues;
+        _lastExpandedKeys = cacheBwd ? expandedKeys : null;
+        _lastExpandedValues = cacheBwd ? expandedValues : null;
 
         // Compute attention with weights caching: [batch, numHeads, seqQ, seqKV]
         var (context, attentionWeights) = _alibiLayer != null
             ? ComputeALiBiAttention(queries, expandedKeys, expandedValues, seqLen, batchSize)
             : ComputeStandardAttentionWithWeights(queries, expandedKeys, expandedValues);
 
-        _lastAttentionWeights = attentionWeights;
+        _lastAttentionWeights = cacheBwd ? attentionWeights : null;
 
         // Reshape back: [batch, numHeads, seq, headDim] -> [batch, seq, embDim]
         var contextPermuted = Engine.TensorPermute(context, new[] { 0, 2, 1, 3 });
@@ -393,9 +394,9 @@ internal partial class GroupedQueryAttentionLayer<T> : LayerBase<T>
             new[] { batchSize * seqLen, _numHeads * _headDimension });
 
         // Cache pre-projection context for output weights gradient
-        _lastAttentionContext = Engine.Reshape(
-            contextTransposed,
-            new[] { batchSize, seqLen, _numHeads * _headDimension });
+        _lastAttentionContext = cacheBwd
+            ? Engine.Reshape(contextTransposed, new[] { batchSize, seqLen, _numHeads * _headDimension })
+            : null;
 
         // Output projection
         var output = Engine.TensorMatMul(contextTransposed, _outputWeights);
@@ -408,7 +409,7 @@ internal partial class GroupedQueryAttentionLayer<T> : LayerBase<T>
         var outputWithBias = Engine.TensorBroadcastAdd(output3D, biasBroadcast);
         var result = ApplyActivation(outputWithBias);
 
-        _lastOutput = result;
+        _lastOutput = cacheBwd ? result : null;
 
         // Reshape back to original rank — via Engine for tape recording.
         if (rank == 2)

--- a/src/NeuralNetworks/Layers/HighwayLayer.cs
+++ b/src/NeuralNetworks/Layers/HighwayLayer.cs
@@ -520,21 +520,24 @@ public partial class HighwayLayer<T> : LayerBase<T>, IAuxiliaryLossLayer<T>
     /// </remarks>
     public override Tensor<T> Forward(Tensor<T> input)
     {
-        _lastInput = ShouldCacheForBackward ? input : null; // #1668: skip in inference (arena safety)
+        // #1668: gate every backward-only cache (not just _lastInput) so an InferenceMode
+        // arena loop holds no recycled-scratch references. Forward uses locals throughout.
+        bool cacheBwd = ShouldCacheForBackward;
+        _lastInput = cacheBwd ? input : null;
 
         // Transform path: transform = activation(input @ weights + bias)
         var transformLinear = Engine.TensorMatMul(input, _transformWeights);
         var transformWithBias = Engine.TensorBroadcastAdd(transformLinear, _transformBias);
-        _lastTransformPreActivation = transformWithBias; // Store pre-activation for backward pass
+        _lastTransformPreActivation = cacheBwd ? transformWithBias : null; // Store pre-activation for backward pass
         var transformOutput = ApplyActivation(transformWithBias, _transformActivation, _vectorTransformActivation);
-        _lastTransformOutput = transformOutput;
+        _lastTransformOutput = cacheBwd ? transformOutput : null;
 
         // Gate path: gate = sigmoid(input @ weights + bias)
         var gateLinear = Engine.TensorMatMul(input, _gateWeights);
         var gateWithBias = Engine.TensorBroadcastAdd(gateLinear, _gateBias);
-        _lastGatePreActivation = gateWithBias; // Store pre-activation for backward pass
+        _lastGatePreActivation = cacheBwd ? gateWithBias : null; // Store pre-activation for backward pass
         var gateOutput = ApplyActivation(gateWithBias, _gateActivation, _vectorGateActivation);
-        _lastGateOutput = gateOutput;
+        _lastGateOutput = cacheBwd ? gateOutput : null;
 
         // Highway output: output = gate * transform + (1 - gate) * input
         // Rewritten as: output = gate * (transform - input) + input
@@ -542,7 +545,7 @@ public partial class HighwayLayer<T> : LayerBase<T>, IAuxiliaryLossLayer<T>
         var gatedDiff = Engine.TensorMultiply(gateOutput, transformMinusInput);
         var output = Engine.TensorAdd(gatedDiff, input);
 
-        _lastOutput = output;
+        _lastOutput = cacheBwd ? output : null;
         return output;
     }
 

--- a/src/NeuralNetworks/Layers/HighwayLayer.cs
+++ b/src/NeuralNetworks/Layers/HighwayLayer.cs
@@ -520,7 +520,7 @@ public partial class HighwayLayer<T> : LayerBase<T>, IAuxiliaryLossLayer<T>
     /// </remarks>
     public override Tensor<T> Forward(Tensor<T> input)
     {
-        _lastInput = input;
+        _lastInput = ShouldCacheForBackward ? input : null; // #1668: skip in inference (arena safety)
 
         // Transform path: transform = activation(input @ weights + bias)
         var transformLinear = Engine.TensorMatMul(input, _transformWeights);

--- a/src/NeuralNetworks/Layers/InferenceMode.cs
+++ b/src/NeuralNetworks/Layers/InferenceMode.cs
@@ -1,0 +1,81 @@
+using System;
+using System.Threading;
+
+namespace AiDotNet.NeuralNetworks.Layers;
+
+/// <summary>
+/// Ambient "no backward pass will run on this flow" scope — the analog of
+/// PyTorch's <c>torch.inference_mode()</c> / <c>torch.no_grad()</c>. While a scope
+/// is active, layers skip populating their manual-backward activation caches
+/// (the per-layer <c>_lastInput</c> / pre-activation fields that an eager
+/// <c>Backward()</c> reads).
+/// </summary>
+/// <remarks>
+/// <para>
+/// Two reasons to skip those caches during inference:
+/// </para>
+/// <list type="number">
+///   <item><description><b>Memory.</b> No backward will read them, so storing one
+///   tensor reference per layer per forward is pure waste — it pins the whole
+///   forward activation set alive for the duration of a prediction.</description></item>
+///   <item><description><b>Correctness under the inference caching allocator.</b>
+///   The multi-forward inference path (e.g. a diffusion denoise loop) runs inside a
+///   <c>TensorArena</c> and calls <c>Reset()</c> between forwards to recycle that
+///   step's scratch. A layer field that still references a recycled scratch buffer
+///   would alias whatever the next step's allocation hands out of the same slot,
+///   corrupting its contents/shape. Not caching means nothing survives the
+///   <c>Reset()</c>, so the recycle is safe (issue #1668).</description></item>
+/// </list>
+/// <para><b>For Beginners:</b> When a model trains, every layer must remember the
+/// inputs it saw so it can later compute how to improve (the "backward pass").
+/// When the model is only making predictions there is no backward pass, so
+/// remembering those inputs just wastes memory. This scope is a way to tell every
+/// layer at once: "we're only predicting right now — don't bother remembering."</para>
+/// <para>
+/// Backed by <see cref="AsyncLocal{T}"/> so entering inference on one async flow
+/// (say, a prediction request) never disables caching for a training loop running
+/// in parallel on another thread. Scopes nest correctly: an inner scope restores
+/// the enclosing scope's state on dispose rather than unconditionally clearing it.
+/// </para>
+/// </remarks>
+internal static class InferenceMode
+{
+    private static readonly AsyncLocal<bool> _active = new();
+
+    /// <summary>
+    /// True when the current async flow is inside an <see cref="Enter"/> scope, i.e.
+    /// no backward pass will run and manual-backward activation caches can be skipped.
+    /// </summary>
+    internal static bool IsActive => _active.Value;
+
+    /// <summary>
+    /// Enters an inference scope. Dispose the returned token (idiomatically with a
+    /// <c>using</c> statement) to restore the previous state. Nesting is supported.
+    /// </summary>
+    /// <returns>A token whose disposal restores the prior inference-scope state.</returns>
+    internal static IDisposable Enter()
+    {
+        bool previous = _active.Value;
+        _active.Value = true;
+        return new Scope(previous);
+    }
+
+    private sealed class Scope : IDisposable
+    {
+        private readonly bool _previous;
+        private bool _disposed;
+
+        internal Scope(bool previous) => _previous = previous;
+
+        public void Dispose()
+        {
+            if (_disposed)
+            {
+                return;
+            }
+
+            _disposed = true;
+            _active.Value = _previous;
+        }
+    }
+}

--- a/src/NeuralNetworks/Layers/InvertedResidualBlock.cs
+++ b/src/NeuralNetworks/Layers/InvertedResidualBlock.cs
@@ -420,7 +420,7 @@ public class InvertedResidualBlock<T> : LayerBase<T>, ILayerSerializationExtras<
         var projectConv = _projectConv ?? throw new InvalidOperationException("OnFirstForward did not allocate _projectConv.");
         var projectBn = _projectBn ?? throw new InvalidOperationException("OnFirstForward did not allocate _projectBn.");
 
-        _lastInput = input;
+        _lastInput = ShouldCacheForBackward ? input : null; // #1668: skip in inference (arena safety)
         Tensor<T> x = input;
 
         // Expansion phase (if expansion > 1)

--- a/src/NeuralNetworks/Layers/InvertedResidualBlock.cs
+++ b/src/NeuralNetworks/Layers/InvertedResidualBlock.cs
@@ -420,23 +420,34 @@ public class InvertedResidualBlock<T> : LayerBase<T>, ILayerSerializationExtras<
         var projectConv = _projectConv ?? throw new InvalidOperationException("OnFirstForward did not allocate _projectConv.");
         var projectBn = _projectBn ?? throw new InvalidOperationException("OnFirstForward did not allocate _projectBn.");
 
-        _lastInput = ShouldCacheForBackward ? input : null; // #1668: skip in inference (arena safety)
+        // #1668: every per-stage activation below is read by the NEXT stage (chained),
+        // so compute into locals and mirror to the backward-cache fields only when an
+        // eager Backward will read them. In an InferenceMode arena loop the fields stay
+        // null, so nothing references recycled scratch across the per-step Reset.
+        bool cacheBwd = ShouldCacheForBackward;
+        _lastInput = cacheBwd ? input : null;
         Tensor<T> x = input;
 
         // Expansion phase (if expansion > 1)
         if (_hasExpansion && _expandConv is not null && _expandBn is not null)
         {
-            _lastExpandOut = _expandConv.Forward(x);
-            _lastExpandBnOut = _expandBn.Forward(_lastExpandOut);
-            _lastExpandActOut = ApplyBlockActivation(_lastExpandBnOut);
-            x = _lastExpandActOut;
+            var expandOut = _expandConv.Forward(x);
+            _lastExpandOut = cacheBwd ? expandOut : null;
+            var expandBnOut = _expandBn.Forward(expandOut);
+            _lastExpandBnOut = cacheBwd ? expandBnOut : null;
+            var expandActOut = ApplyBlockActivation(expandBnOut);
+            _lastExpandActOut = cacheBwd ? expandActOut : null;
+            x = expandActOut;
         }
 
         // Depthwise convolution phase
-        _lastDwOut = dwConv.Forward(x);
-        _lastDwBnOut = dwBn.Forward(_lastDwOut);
-        _lastDwActOut = ApplyBlockActivation(_lastDwBnOut);
-        x = _lastDwActOut;
+        var dwOut = dwConv.Forward(x);
+        _lastDwOut = cacheBwd ? dwOut : null;
+        var dwBnOut = dwBn.Forward(dwOut);
+        _lastDwBnOut = cacheBwd ? dwBnOut : null;
+        var dwActOut = ApplyBlockActivation(dwBnOut);
+        _lastDwActOut = cacheBwd ? dwActOut : null;
+        x = dwActOut;
 
         // Squeeze-and-Excitation phase (optional)
         // Note: SE layer expects NHWC format, but our tensors are in NCHW format
@@ -446,21 +457,24 @@ public class InvertedResidualBlock<T> : LayerBase<T>, ILayerSerializationExtras<
             var seInput = TransposeNCHWToNHWC(x);
             var seOutput = _se.Forward(seInput);
             // Transpose NHWC [B, H, W, C] -> NCHW [B, C, H, W]
-            _lastSeOut = TransposeNHWCToNCHW(seOutput);
-            x = _lastSeOut;
+            var seOut = TransposeNHWCToNCHW(seOutput);
+            _lastSeOut = cacheBwd ? seOut : null;
+            x = seOut;
         }
 
         // Projection phase (LINEAR - no activation)
-        _lastProjectOut = projectConv.Forward(x);
-        _lastProjectBnOut = projectBn.Forward(_lastProjectOut);
+        var projectOut = projectConv.Forward(x);
+        _lastProjectOut = cacheBwd ? projectOut : null;
+        var projectBnOut = projectBn.Forward(projectOut);
+        _lastProjectBnOut = cacheBwd ? projectBnOut : null;
 
         // Residual connection (only if dimensions match)
         if (_useResidual)
         {
-            return AddTensors(_lastProjectBnOut, input);
+            return AddTensors(projectBnOut, input);
         }
 
-        return _lastProjectBnOut;
+        return projectBnOut;
     }
 
     /// <summary>

--- a/src/NeuralNetworks/Layers/LSTMLayer.cs
+++ b/src/NeuralNetworks/Layers/LSTMLayer.cs
@@ -1116,7 +1116,11 @@ public partial class LSTMLayer<T> : LayerBase<T>
             input3D = Engine.Reshape(input, [flatBatch, timeSteps, _inputSize]);
         }
 
-        _lastInput = input3D;
+        // #1668: _lastInput is a manual-backward cache; gate it (and the per-timestep BPTT
+        // caches below) on ShouldCacheForBackward so inference/tape/eval keeps no arena-backed
+        // activation alive across a TensorArena.Reset().
+        bool cacheBwd = ShouldCacheForBackward;
+        _lastInput = cacheBwd ? input3D : null;
 
         // AIsEval inference fast path: route the entire sequence through
         // AiDotNet.Tensors.Engines.CpuEngine.LstmSequenceForward<T> — the
@@ -1203,9 +1207,8 @@ public partial class LSTMLayer<T> : LayerBase<T>
         var hiddenStatesList = new System.Collections.Generic.List<Tensor<T>>(timeSteps);
 
         // #1668: the per-timestep BPTT caches are read only by the manual Backward; skip
-        // renting+populating them when no eager Backward will run (inference / tape / eval),
+        // renting+populating them when no eager Backward will run (cacheBwd computed above),
         // so an arena loop holds no per-step references across a Reset.
-        bool cacheBwd = ShouldCacheForBackward;
         _cachedHiddenStates = cacheBwd ? TensorAllocator.Rent<T>(new int[] { batchSize, timeSteps, _hiddenSize }) : null;
         _cachedCellStates = cacheBwd ? TensorAllocator.Rent<T>(new int[] { batchSize, timeSteps, _hiddenSize }) : null;
 

--- a/src/NeuralNetworks/Layers/LSTMLayer.cs
+++ b/src/NeuralNetworks/Layers/LSTMLayer.cs
@@ -1202,8 +1202,12 @@ public partial class LSTMLayer<T> : LayerBase<T>
         // non-CpuEngine, or an active autograd tape).
         var hiddenStatesList = new System.Collections.Generic.List<Tensor<T>>(timeSteps);
 
-        _cachedHiddenStates = TensorAllocator.Rent<T>(new int[] { batchSize, timeSteps, _hiddenSize });
-        _cachedCellStates = TensorAllocator.Rent<T>(new int[] { batchSize, timeSteps, _hiddenSize });
+        // #1668: the per-timestep BPTT caches are read only by the manual Backward; skip
+        // renting+populating them when no eager Backward will run (inference / tape / eval),
+        // so an arena loop holds no per-step references across a Reset.
+        bool cacheBwd = ShouldCacheForBackward;
+        _cachedHiddenStates = cacheBwd ? TensorAllocator.Rent<T>(new int[] { batchSize, timeSteps, _hiddenSize }) : null;
+        _cachedCellStates = cacheBwd ? TensorAllocator.Rent<T>(new int[] { batchSize, timeSteps, _hiddenSize }) : null;
 
         var currentH = TensorAllocator.Rent<T>(new int[] { batchSize, _hiddenSize });
         var currentC = TensorAllocator.Rent<T>(new int[] { batchSize, _hiddenSize });
@@ -1278,8 +1282,8 @@ public partial class LSTMLayer<T> : LayerBase<T>
             // Collect the hidden state for the tape-connected output concat below.
             hiddenStatesList.Add(Engine.Reshape(currentH, new[] { batchSize, 1, _hiddenSize }));
             // Caches for the manual backward path (not on the tape).
-            _cachedHiddenStates.SetSlice(1, t, currentH);
-            _cachedCellStates.SetSlice(1, t, currentC);
+            _cachedHiddenStates?.SetSlice(1, t, currentH);
+            _cachedCellStates?.SetSlice(1, t, currentC);
         }
 
         // Assemble the [batch, timeSteps, hiddenSize] output on the tape so gradients

--- a/src/NeuralNetworks/Layers/LambdaLayer.cs
+++ b/src/NeuralNetworks/Layers/LambdaLayer.cs
@@ -282,7 +282,7 @@ public class LambdaLayer<T> : LayerBase<T>
 
         output = ApplyActivation(output);
 
-        _lastOutput = output;
+        _lastOutput = ShouldCacheForBackward ? output : null; // #1668: skip in inference (arena safety)
         return output;
     }
 

--- a/src/NeuralNetworks/Layers/LambdaLayer.cs
+++ b/src/NeuralNetworks/Layers/LambdaLayer.cs
@@ -277,7 +277,7 @@ public class LambdaLayer<T> : LayerBase<T>
     /// </remarks>
     public override Tensor<T> Forward(Tensor<T> input)
     {
-        _lastInput = input;
+        _lastInput = ShouldCacheForBackward ? input : null; // #1668: skip in inference (arena safety)
         var output = _forwardFunction(input);
 
         output = ApplyActivation(output);

--- a/src/NeuralNetworks/Layers/LayerBase.cs
+++ b/src/NeuralNetworks/Layers/LayerBase.cs
@@ -1020,12 +1020,34 @@ public abstract class LayerBase<T> : ILayer<T>, ITrainableLayer<T>, IDisposable
     /// True when the layer should populate its manual-backward activation caches:
     /// only when NO <see cref="GradientTape{T}"/> is recording (the tape-less
     /// manual-autodiff path may read them) or when <see cref="KeepActivationCacheUnderTape"/>
-    /// forces it. Under a recording tape the caches are never read — the tape
-    /// backward walks the tape, not the layers — so skipping them frees the
-    /// redundant activation reference.
+    /// forces it, AND we are not inside an <see cref="InferenceMode"/> scope. Under a
+    /// recording tape the caches are never read — the tape backward walks the tape,
+    /// not the layers — and during inference no backward runs at all, so skipping
+    /// them frees the redundant activation reference (and, in a multi-forward arena
+    /// loop, prevents aliasing recycled scratch — issue #1668).
     /// </summary>
     protected static bool ShouldCacheActivationsForManualBackward
-        => GradientTape<T>.Current is null || KeepActivationCacheUnderTape;
+        => !InferenceMode.IsActive
+        && (GradientTape<T>.Current is null || KeepActivationCacheUnderTape);
+
+    /// <summary>
+    /// True when this layer should populate its per-layer manual-backward activation
+    /// caches (the bespoke <c>_lastInput</c> / pre-activation fields a layer's own
+    /// eager <see cref="Backward(Tensor{T})"/> reads). This is the canonical guard
+    /// every such cache write should be gated on:
+    /// <code>if (ShouldCacheForBackward) _lastInput = input;</code>
+    /// It is false whenever no eager manual backward will read the caches —
+    /// during graph capture (<see cref="IsCapturing"/>), under a recording
+    /// <see cref="GradientTape{T}"/> (unless <see cref="KeepActivationCacheUnderTape"/>),
+    /// in eval mode (<see cref="IsTrainingMode"/> is false), or inside an
+    /// <see cref="InferenceMode"/> scope — so the redundant reference is dropped and the
+    /// inference caching allocator can safely recycle the buffer (issue #1668).
+    /// </summary>
+    protected bool ShouldCacheForBackward
+        => IsTrainingMode
+        && !IsCapturing
+        && !InferenceMode.IsActive
+        && (GradientTape<T>.Current is null || KeepActivationCacheUnderTape);
 
     /// <summary>
     /// Initializes a new instance of the <see cref="LayerBase{T}"/> class with the specified input and output shapes.
@@ -2335,13 +2357,16 @@ public abstract class LayerBase<T> : ILayer<T>, ITrainableLayer<T>, IDisposable
         //     isn't sufficient.
         //
         // Only push when we know the eager backward will drain it: training
-        // mode ON, not capturing, no tape recording. The tape path already
-        // preserves the pre-activation reference through its recorded GradFn
-        // closures; the capture path encodes it into the graph node — both
-        // cases make the cache redundant.
+        // mode ON, not capturing, not inside an inference scope, no tape recording.
+        // The tape path already preserves the pre-activation reference through its
+        // recorded GradFn closures; the capture path encodes it into the graph node;
+        // an InferenceMode scope guarantees no backward at all — all three make the
+        // cache redundant (and leaving it set would alias arena scratch across a
+        // denoise-loop Reset — issue #1668).
         bool eagerBackwardWillRun =
             IsTrainingMode
             && !IsCapturing
+            && !InferenceMode.IsActive
             && GradientTape<T>.Current is null;
         if (eagerBackwardWillRun)
         {

--- a/src/NeuralNetworks/Layers/LayerNormalizationLayer.cs
+++ b/src/NeuralNetworks/Layers/LayerNormalizationLayer.cs
@@ -379,9 +379,11 @@ public partial class LayerNormalizationLayer<T> : LayerBase<T>
         var (output, saveMean, saveInvVar) = gpuEngine.LayerNormGpu(
             input, _gamma, _beta, epsilonDouble);
 
-        // Cache state for backward pass only during training
+        // Cache state for backward pass only during training. Also skip inside an
+        // InferenceMode scope (no backward runs; retaining these would pin / alias
+        // per-step buffers under the denoise-loop arena — #1668).
         // Skip this expensive download during inference (50% overhead reduction)
-        if (IsTrainingMode)
+        if (IsTrainingMode && !InferenceMode.IsActive)
         {
             _gpuLastInput = input;
             _gpuSaveMean = saveMean;

--- a/src/NeuralNetworks/Layers/LogVarianceLayer.cs
+++ b/src/NeuralNetworks/Layers/LogVarianceLayer.cs
@@ -241,7 +241,7 @@ public class LogVarianceLayer<T> : LayerBase<T>
     public override Tensor<T> Forward(Tensor<T> input)
     {
         EnsureInitializedFromInput(input);
-        _lastInput = input;
+        _lastInput = ShouldCacheForBackward ? input : null; // #1668: skip in inference (arena safety)
 
         // Use Engine operations for GPU/CPU acceleration
         _meanValues = Engine.ReduceMean(input, [Axis], keepDims: true);

--- a/src/NeuralNetworks/Layers/MaskingLayer.cs
+++ b/src/NeuralNetworks/Layers/MaskingLayer.cs
@@ -204,8 +204,9 @@ public class MaskingLayer<T> : LayerBase<T>
     {
         EnsureInitializedFromInput(input);
         _lastInput = ShouldCacheForBackward ? input : null; // #1668: skip in inference (arena safety)
-        _lastMask = CreateMask(input);
-        return ApplyMask(input, _lastMask);
+        var mask = CreateMask(input);
+        _lastMask = ShouldCacheForBackward ? mask : null; // #1668: cache the mask only for backward
+        return ApplyMask(input, mask);
     }
 
     /// <summary>

--- a/src/NeuralNetworks/Layers/MaskingLayer.cs
+++ b/src/NeuralNetworks/Layers/MaskingLayer.cs
@@ -203,7 +203,7 @@ public class MaskingLayer<T> : LayerBase<T>
     public override Tensor<T> Forward(Tensor<T> input)
     {
         EnsureInitializedFromInput(input);
-        _lastInput = input;
+        _lastInput = ShouldCacheForBackward ? input : null; // #1668: skip in inference (arena safety)
         _lastMask = CreateMask(input);
         return ApplyMask(input, _lastMask);
     }

--- a/src/NeuralNetworks/Layers/MaxPool3DLayer.cs
+++ b/src/NeuralNetworks/Layers/MaxPool3DLayer.cs
@@ -187,7 +187,7 @@ public class MaxPool3DLayer<T> : LayerBase<T>
     public override Tensor<T> Forward(Tensor<T> input)
     {
         EnsureInitializedFromInput(input);
-        _lastInput = input;
+        _lastInput = ShouldCacheForBackward ? input : null; // #1668: skip in inference (arena safety)
         _originalInputShape = input._shape;
         int rank = input.Rank;
 
@@ -294,7 +294,7 @@ public class MaxPool3DLayer<T> : LayerBase<T>
         var output = gpuEngine.MaxPool3DGpu<T>(input5D, poolSizeArr, strideArr, out _gpuIndicesBuffer);
 
         // Store _lastInput for backward pass
-        _lastInput = input;
+        _lastInput = ShouldCacheForBackward ? input : null; // #1668: skip in inference (arena safety)
 
         // Restore original tensor rank
         if (_originalInputShape.Length > 5)

--- a/src/NeuralNetworks/Layers/MaxPoolingLayer.cs
+++ b/src/NeuralNetworks/Layers/MaxPoolingLayer.cs
@@ -293,7 +293,7 @@ public class MaxPoolingLayer<T> : LayerBase<T>
         if (input.Shape.Length < 3)
             throw new ArgumentException($"MaxPooling layer requires at least 3D tensor [C, H, W]. Got rank {input.Shape.Length}.");
 
-        _lastInput = input;
+        _lastInput = ShouldCacheForBackward ? input : null; // #1668: skip in inference (arena safety)
         _originalInputShape = input._shape;
         int rank = input.Shape.Length;
 

--- a/src/NeuralNetworks/Layers/MeanLayer.cs
+++ b/src/NeuralNetworks/Layers/MeanLayer.cs
@@ -237,7 +237,7 @@ public class MeanLayer<T> : LayerBase<T>
     public override Tensor<T> Forward(Tensor<T> input)
     {
         EnsureInitializedFromInput(input);
-        _lastInput = input;
+        _lastInput = ShouldCacheForBackward ? input : null; // #1668: skip in inference (arena safety)
 
         // Use Engine operation for GPU/CPU acceleration
         _lastOutput = Engine.ReduceMean(input, [Axis], keepDims: false);

--- a/src/NeuralNetworks/Layers/MemoryReadLayer.cs
+++ b/src/NeuralNetworks/Layers/MemoryReadLayer.cs
@@ -463,7 +463,7 @@ public partial class MemoryReadLayer<T> : LayerBase<T>, IAuxiliaryLossLayer<T>
         // initial [0, 0] sentinel — matmul then throws on incompatible dims.
         EnsureInitializedFromInput(input);
 
-        _lastInput = input;
+        _lastInput = ShouldCacheForBackward ? input : null; // #1668: skip in inference (arena safety)
         _lastMemory = memory;
 
         // Use Engine operations for matrix multiplications

--- a/src/NeuralNetworks/Layers/MemoryWriteLayer.cs
+++ b/src/NeuralNetworks/Layers/MemoryWriteLayer.cs
@@ -494,7 +494,7 @@ public partial class MemoryWriteLayer<T> : LayerBase<T>, IAuxiliaryLossLayer<T>
         // but only when the layer has run at least once. Force init here.
         EnsureInitializedFromInput(input);
 
-        _lastInput = input;
+        _lastInput = ShouldCacheForBackward ? input : null; // #1668: skip in inference (arena safety)
         _lastMemory = memory;
 
         // Dynamic input dimension adaptation

--- a/src/NeuralNetworks/Layers/MeshEdgeConvLayer.cs
+++ b/src/NeuralNetworks/Layers/MeshEdgeConvLayer.cs
@@ -306,7 +306,7 @@ public partial class MeshEdgeConvLayer<T> : LayerBase<T>
                 "Edge adjacency must be set via SetEdgeAdjacency before calling Forward.");
         }
 
-        _lastInput = input;
+        _lastInput = ShouldCacheForBackward ? input : null; // #1668: skip in inference (arena safety)
 
         int numEdges = input.Shape[0];
         int aggregatedFeatures = InputChannels * (1 + NumNeighbors);

--- a/src/NeuralNetworks/Layers/MeshPoolLayer.cs
+++ b/src/NeuralNetworks/Layers/MeshPoolLayer.cs
@@ -237,7 +237,7 @@ public partial class MeshPoolLayer<T> : LayerBase<T>
                 "Edge adjacency must be set via SetEdgeAdjacency before calling Forward.");
         }
 
-        _lastInput = input;
+        _lastInput = ShouldCacheForBackward ? input : null; // #1668: skip in inference (arena safety)
 
         int numEdges = input.Shape[0];
         int numToKeep = Math.Min(TargetEdges, numEdges);

--- a/src/NeuralNetworks/Layers/MixtureOfExpertsLayer.cs
+++ b/src/NeuralNetworks/Layers/MixtureOfExpertsLayer.cs
@@ -656,7 +656,7 @@ public partial class MixtureOfExpertsLayer<T> : LayerBase<T>, IAuxiliaryLossLaye
         }
 
         // Cache input for backward pass
-        _lastInput = input2D;
+        _lastInput = ShouldCacheForBackward ? input2D : null; // #1668: skip in inference (arena safety)
 
         // Step 1: Compute routing scores
         var routingLogits = _router.Forward(input2D);
@@ -2037,7 +2037,7 @@ public partial class MixtureOfExpertsLayer<T> : LayerBase<T>, IAuxiliaryLossLaye
         }
 
         // Cache for backward pass (only in training mode - download to CPU)
-        if (IsTrainingMode)
+        if (IsTrainingMode && !InferenceMode.IsActive) // #1668: skip caches inside an InferenceMode scope
         {
             _lastInput = input;
             _lastRoutingLogits = routingLogitsGpu;

--- a/src/NeuralNetworks/Layers/PReLULayer.cs
+++ b/src/NeuralNetworks/Layers/PReLULayer.cs
@@ -148,8 +148,8 @@ public class PReLULayer<T> : LayerBase<T>
     public override Tensor<T> Forward(Tensor<T> input)
     {
         EnsureInitializedFromInput(input);
-        if (ShouldCacheForBackward) // #1668: also skip inside an InferenceMode scope (arena safety)
-            _lastInput = input;
+        // #1668: also clear a previously-cached activation when caching is off (don't leave it pinned).
+        _lastInput = ShouldCacheForBackward ? input : null;
 
         var positivePart = Engine.ReLU(input);
         var negated = Engine.TensorNegate(input);

--- a/src/NeuralNetworks/Layers/PReLULayer.cs
+++ b/src/NeuralNetworks/Layers/PReLULayer.cs
@@ -148,7 +148,7 @@ public class PReLULayer<T> : LayerBase<T>
     public override Tensor<T> Forward(Tensor<T> input)
     {
         EnsureInitializedFromInput(input);
-        if (IsTrainingMode)
+        if (ShouldCacheForBackward) // #1668: also skip inside an InferenceMode scope (arena safety)
             _lastInput = input;
 
         var positivePart = Engine.ReLU(input);

--- a/src/NeuralNetworks/Layers/PaddingLayer.cs
+++ b/src/NeuralNetworks/Layers/PaddingLayer.cs
@@ -197,7 +197,7 @@ public class PaddingLayer<T> : LayerBase<T>
 
         if (IsTrainingMode)
         {
-            _lastInput = input;
+            _lastInput = ShouldCacheForBackward ? input : null; // #1668: skip in inference (arena safety)
             _gpuCachedInputShape = (int[])input._shape.Clone();
         }
 

--- a/src/NeuralNetworks/Layers/PaddingLayer.cs
+++ b/src/NeuralNetworks/Layers/PaddingLayer.cs
@@ -367,7 +367,7 @@ public class PaddingLayer<T> : LayerBase<T>
     public override Tensor<T> Forward(Tensor<T> input)
     {
         EnsureInitializedFromInput(input);
-        _lastInput = input;
+        _lastInput = ShouldCacheForBackward ? input : null; // #1668: skip in inference (arena safety)
         if (_padding.Length != input.Shape.Length)
             throw new ArgumentException("Padding array length must match input dimensions.");
 

--- a/src/NeuralNetworks/Layers/PixelShuffleLayer.cs
+++ b/src/NeuralNetworks/Layers/PixelShuffleLayer.cs
@@ -269,7 +269,7 @@ public class PixelShuffleLayer<T> : LayerBase<T>
         // For 4D tensors (batch, channels, height, width), use Engine directly
         if (shape.Length == 4)
         {
-            _lastInput = input;
+            _lastInput = ShouldCacheForBackward ? input : null; // #1668: skip in inference (arena safety)
             return Engine.PixelShuffle(input, _upscaleFactor);
         }
 

--- a/src/NeuralNetworks/Layers/PoolingLayer.cs
+++ b/src/NeuralNetworks/Layers/PoolingLayer.cs
@@ -326,7 +326,7 @@ public class PoolingLayer<T> : LayerBase<T>
         // chain-walkers and tests see the resolved input/output shapes.
         if (!IsShapeResolved) OnFirstForward(input);
 
-        _lastInput = input;
+        _lastInput = ShouldCacheForBackward ? input : null; // #1668: skip in inference (arena safety)
         _originalInputShape = input._shape;
 
         // Support any rank >= 3: last 3 dims are [C, H, W], earlier dims are batch-like

--- a/src/NeuralNetworks/Layers/RBFLayer.cs
+++ b/src/NeuralNetworks/Layers/RBFLayer.cs
@@ -187,9 +187,9 @@ public partial class RBFLayer<T> : LayerBase<T>
         // Weights are persistent tensors, handled by engine
         var output = gpuEngine.RbfKernelGpu(input2D, _centers, _widths);
 
-        if (IsTrainingMode)
+        if (ShouldCacheForBackward) // #1668: skip backward caches in inference (arena safety)
         {
-            _lastInput = ShouldCacheForBackward ? input : null; // #1668: skip in inference (arena safety)
+            _lastInput = input;
             _lastOutput = output;
         }
 
@@ -349,7 +349,7 @@ public partial class RBFLayer<T> : LayerBase<T>
             : input;
 
         // Store 2D input for backward pass (RBFKernelBackward requires 2D)
-        _lastInput = processedInput;
+        _lastInput = ShouldCacheForBackward ? processedInput : null; // #1668: skip in inference (arena safety)
 
         // Use Engine.RBFKernel for GPU/CPU acceleration
         // This computes exp(-epsilon * ||x - center||²) for Gaussian RBF
@@ -358,7 +358,7 @@ public partial class RBFLayer<T> : LayerBase<T>
         var output = Engine.RBFKernel(processedInput, _centers, epsilons);
 
         // Store 2D output for backward pass
-        _lastOutput = output;
+        _lastOutput = ShouldCacheForBackward ? output : null; // #1668: skip in inference (arena safety)
 
         // Remove batch dimension if input was unbatched
         return wasUnbatched ? Engine.Reshape(output, [output.Shape[1]]) : output;

--- a/src/NeuralNetworks/Layers/RBFLayer.cs
+++ b/src/NeuralNetworks/Layers/RBFLayer.cs
@@ -189,7 +189,7 @@ public partial class RBFLayer<T> : LayerBase<T>
 
         if (IsTrainingMode)
         {
-            _lastInput = input;
+            _lastInput = ShouldCacheForBackward ? input : null; // #1668: skip in inference (arena safety)
             _lastOutput = output;
         }
 

--- a/src/NeuralNetworks/Layers/RRDBLayer.cs
+++ b/src/NeuralNetworks/Layers/RRDBLayer.cs
@@ -250,7 +250,7 @@ public class RRDBLayer<T> : LayerBase<T>
         x = _rdbBlocks[1].Forward(x);
         x = _rdbBlocks[2].Forward(x);
 
-        _rdb3Output = x;
+        _rdb3Output = ShouldCacheForBackward ? x : null; // #1668: skip in inference (arena safety)
 
         // Global residual: output = RDB3_output * residualScale + input
         return AddResidual(x, input, _residualScale);

--- a/src/NeuralNetworks/Layers/RRDBLayer.cs
+++ b/src/NeuralNetworks/Layers/RRDBLayer.cs
@@ -243,7 +243,7 @@ public class RRDBLayer<T> : LayerBase<T>
     {
         if (!IsShapeResolved) OnFirstForward(input);
 
-        _lastInput = input;
+        _lastInput = ShouldCacheForBackward ? input : null; // #1668: skip in inference (arena safety)
 
         // Pass through 3 Residual Dense Blocks sequentially
         var x = _rdbBlocks[0].Forward(input);

--- a/src/NeuralNetworks/Layers/RRDBNetGenerator.cs
+++ b/src/NeuralNetworks/Layers/RRDBNetGenerator.cs
@@ -370,33 +370,41 @@ public class RRDBNetGenerator<T> : LayerBase<T>
     {
         if (!IsShapeResolved) OnFirstForward(input);
 
-        _lastInput = ShouldCacheForBackward ? input : null; // #1668: skip in inference (arena safety)
+        // #1668: gate every backward-only cache (the per-stage outputs + intermediate
+        // arrays). Forward uses the local `conv1Output`/`x`; the fields/arrays only hold
+        // references for an eager Backward, so in an InferenceMode arena loop nothing
+        // survives the per-step Reset.
+        bool cacheBwd = ShouldCacheForBackward;
+        _lastInput = cacheBwd ? input : null;
 
         // Initial feature extraction
-        _conv1Output = _convFirst.Forward(input);
-        var x = _conv1Output;
+        var conv1Output = _convFirst.Forward(input);
+        _conv1Output = cacheBwd ? conv1Output : null;
+        var x = conv1Output;
 
-        // Deep feature extraction through RRDB blocks
+        // Deep feature extraction through RRDB blocks. The array is always allocated
+        // (cheap — references only) but the per-block tensors are stored only when an
+        // eager Backward will read them (#1668).
         _rrdbOutputs = new Tensor<T>[_rrdbBlocks.Length];
         for (int i = 0; i < _rrdbBlocks.Length; i++)
         {
             x = _rrdbBlocks[i].Forward(x);
-            _rrdbOutputs[i] = x;
+            if (cacheBwd) _rrdbOutputs[i] = x;
         }
 
         // Trunk convolution + global residual
         var trunk = _trunkConv.Forward(x);
-        x = AddTensors(trunk, _conv1Output); // Global residual connection
+        x = AddTensors(trunk, conv1Output); // Global residual connection
 
-        // Upsampling
+        // Upsampling (array always allocated; tensors stored only for backward — #1668)
         _upsampleOutputs = new Tensor<T>[_upsampleConvs.Length * 2]; // Conv output + PixelShuffle output
         for (int i = 0; i < _upsampleConvs.Length; i++)
         {
             x = _upsampleConvs[i].Forward(x);
-            _upsampleOutputs[i * 2] = x;
+            if (cacheBwd) _upsampleOutputs[i * 2] = x;
             x = _pixelShuffleLayers[i].Forward(x);
             x = ApplyLeakyReLU(x);
-            _upsampleOutputs[i * 2 + 1] = x;
+            if (cacheBwd) _upsampleOutputs[i * 2 + 1] = x;
         }
 
         // HR convolution + activation

--- a/src/NeuralNetworks/Layers/RRDBNetGenerator.cs
+++ b/src/NeuralNetworks/Layers/RRDBNetGenerator.cs
@@ -370,7 +370,7 @@ public class RRDBNetGenerator<T> : LayerBase<T>
     {
         if (!IsShapeResolved) OnFirstForward(input);
 
-        _lastInput = input;
+        _lastInput = ShouldCacheForBackward ? input : null; // #1668: skip in inference (arena safety)
 
         // Initial feature extraction
         _conv1Output = _convFirst.Forward(input);

--- a/src/NeuralNetworks/Layers/ReadoutLayer.cs
+++ b/src/NeuralNetworks/Layers/ReadoutLayer.cs
@@ -260,7 +260,7 @@ public partial class ReadoutLayer<T> : LayerBase<T>
     /// </remarks>
     public override Tensor<T> Forward(Tensor<T> input)
     {
-        _lastInput = input;
+        _lastInput = ShouldCacheForBackward ? input : null; // #1668: skip in inference (arena safety)
         _originalInputShape = input._shape;
 
         int inputSize = input.Shape[^1];

--- a/src/NeuralNetworks/Layers/ReshapeLayer.cs
+++ b/src/NeuralNetworks/Layers/ReshapeLayer.cs
@@ -203,7 +203,7 @@ public class ReshapeLayer<T> : LayerBase<T>
     public override Tensor<T> Forward(Tensor<T> input)
     {
         EnsureInitializedFromInput(input);
-        _lastInput = input;
+        _lastInput = ShouldCacheForBackward ? input : null; // #1668: skip in inference (arena safety)
         int batchSize = input.Shape[0];
         int[] targetShape = new int[_outputShape.Length + 1];
         targetShape[0] = batchSize;

--- a/src/NeuralNetworks/Layers/ResidualDenseBlock.cs
+++ b/src/NeuralNetworks/Layers/ResidualDenseBlock.cs
@@ -323,7 +323,7 @@ public class ResidualDenseBlock<T> : LayerBase<T>
     {
         if (!IsShapeResolved) OnFirstForward(input);
 
-        _lastInput = input;
+        _lastInput = ShouldCacheForBackward ? input : null; // #1668: skip in inference (arena safety)
         _convOutputs = new Tensor<T>[5];
         _activationOutputs = new Tensor<T>[4]; // Only first 4 have activation
         _concatInputs = new Tensor<T>[5];

--- a/src/NeuralNetworks/Layers/ResidualLayer.cs
+++ b/src/NeuralNetworks/Layers/ResidualLayer.cs
@@ -188,7 +188,7 @@ public class ResidualLayer<T> : LayerBase<T>
             // Skip this expensive download during inference (50% overhead reduction)
             if (IsTrainingMode)
             {
-                _lastInput = input;
+                _lastInput = ShouldCacheForBackward ? input : null; // #1668: skip in inference (arena safety)
                 _lastInnerOutput = innerOutput;
             }
         }

--- a/src/NeuralNetworks/Layers/ResidualLayer.cs
+++ b/src/NeuralNetworks/Layers/ResidualLayer.cs
@@ -186,9 +186,9 @@ public class ResidualLayer<T> : LayerBase<T>
 
             // Cache state for backward pass only during training
             // Skip this expensive download during inference (50% overhead reduction)
-            if (IsTrainingMode)
+            if (ShouldCacheForBackward) // #1668: skip backward caches in inference (arena safety)
             {
-                _lastInput = ShouldCacheForBackward ? input : null; // #1668: skip in inference (arena safety)
+                _lastInput = input;
                 _lastInnerOutput = innerOutput;
             }
         }
@@ -198,8 +198,8 @@ public class ResidualLayer<T> : LayerBase<T>
             var inputCpu = input;
             var innerOutputCpu = _innerLayer.Forward(inputCpu);
 
-            // Cache state for backward pass only during training
-            if (IsTrainingMode)
+            // Cache state for backward pass only when an eager Backward will read it (#1668).
+            if (ShouldCacheForBackward)
             {
                 _lastInput = inputCpu;
                 _lastInnerOutput = innerOutputCpu;
@@ -219,8 +219,8 @@ public class ResidualLayer<T> : LayerBase<T>
             // No inner layer - input passes through
             result = input;
 
-            // Cache state for backward pass only during training
-            if (IsTrainingMode)
+            // Cache state for backward pass only when an eager Backward will read it (#1668).
+            if (ShouldCacheForBackward)
             {
                 _lastInput = input;
                 _lastInnerOutput = null;
@@ -460,9 +460,12 @@ public class ResidualLayer<T> : LayerBase<T>
     public override Tensor<T> Forward(Tensor<T> input)
     {
         EnsureInitializedFromInput(input);
-        _lastInput = input;
-        _lastInnerOutput = _innerLayer?.Forward(input);
-        var result = _lastInnerOutput == null ? input : Engine.TensorAdd(input, _lastInnerOutput);
+        // #1668: gate backward caches; forward uses the local innerOutput (chained).
+        bool cacheBwd = ShouldCacheForBackward;
+        _lastInput = cacheBwd ? input : null;
+        var innerOutput = _innerLayer?.Forward(input);
+        _lastInnerOutput = cacheBwd ? innerOutput : null;
+        var result = innerOutput == null ? input : Engine.TensorAdd(input, innerOutput);
 
         return ApplyActivation(result);
     }

--- a/src/NeuralNetworks/Layers/SeparableConvolutionalLayer.cs
+++ b/src/NeuralNetworks/Layers/SeparableConvolutionalLayer.cs
@@ -619,7 +619,7 @@ public partial class SeparableConvolutionalLayer<T> : LayerBase<T>
     public override Tensor<T> Forward(Tensor<T> input)
     {
         EnsureInitializedFromInput(input);
-        _lastInput = input;
+        _lastInput = ShouldCacheForBackward ? input : null; // #1668: skip in inference (arena safety)
 
         // Convert input from NHWC [batch, H, W, channels] to NCHW [batch, channels, H, W]
         var inputNCHW = Engine.TensorPermute(input, [0, 3, 1, 2]);

--- a/src/NeuralNetworks/Layers/SparseLinearLayer.cs
+++ b/src/NeuralNetworks/Layers/SparseLinearLayer.cs
@@ -228,7 +228,7 @@ public partial class SparseLinearLayer<T> : LayerBase<T>
     /// <returns>Output tensor with shape [outputFeatures] or [batch, outputFeatures].</returns>
     public override Tensor<T> Forward(Tensor<T> input)
     {
-        _lastInput = input;
+        _lastInput = ShouldCacheForBackward ? input : null; // #1668: skip in inference (arena safety)
         bool wasSingleSample = input.Rank == 1;
 
         int batchSize;

--- a/src/NeuralNetworks/Layers/SpectralNormalizationLayer.cs
+++ b/src/NeuralNetworks/Layers/SpectralNormalizationLayer.cs
@@ -232,7 +232,7 @@ public class SpectralNormalizationLayer<T> : LayerBase<T>
     /// </summary>
     public override Tensor<T> Forward(Tensor<T> input)
     {
-        _lastInput = input;
+        _lastInput = ShouldCacheForBackward ? input : null; // #1668: skip in inference (arena safety)
 
         // Get weights from inner layer
         var parameters = _innerLayer.GetParameters();

--- a/src/NeuralNetworks/Layers/SpikingLayer.cs
+++ b/src/NeuralNetworks/Layers/SpikingLayer.cs
@@ -769,7 +769,7 @@ public partial class SpikingLayer<T> : LayerBase<T>
         int rank = input.Shape.Length;
 
         // Store the input for backward pass
-        _lastInput = input;
+        _lastInput = ShouldCacheForBackward ? input : null; // #1668: skip in inference (arena safety)
 
         // Flatten input to 1D tensor for processing
         // Supports any-rank tensors by computing total element count for last dimension

--- a/src/NeuralNetworks/Layers/SpiralConvLayer.cs
+++ b/src/NeuralNetworks/Layers/SpiralConvLayer.cs
@@ -301,7 +301,7 @@ public partial class SpiralConvLayer<T> : LayerBase<T>
             // Recomputing is safer for now to avoid complexity of downloading.
             // But optimal is caching.
             // For now, just cache output/input.
-            _lastOutput = result;
+            _lastOutput = ShouldCacheForBackward ? result : null; // #1668: skip in inference (arena safety)
         }
 
         return result;
@@ -669,7 +669,8 @@ public partial class SpiralConvLayer<T> : LayerBase<T>
                 "Spiral indices must be set via SetSpiralIndices before calling Forward.");
         }
 
-        _lastInput = input;
+        bool cacheBwd = ShouldCacheForBackward; // #1668: gate all backward caches (arena safety)
+        _lastInput = cacheBwd ? input : null;
 
         bool hasBatch = input.Rank == 3;
         int numVertices = hasBatch ? input.Shape[1] : input.Shape[0];
@@ -694,9 +695,9 @@ public partial class SpiralConvLayer<T> : LayerBase<T>
             output = ProcessSingle(input, numVertices);
         }
 
-        _lastPreActivation = output;
+        _lastPreActivation = cacheBwd ? output : null;
         var activated = ApplyActivation(output);
-        _lastOutput = activated;
+        _lastOutput = cacheBwd ? activated : null;
 
         return activated;
     }

--- a/src/NeuralNetworks/Layers/SpiralConvLayer.cs
+++ b/src/NeuralNetworks/Layers/SpiralConvLayer.cs
@@ -294,7 +294,7 @@ public partial class SpiralConvLayer<T> : LayerBase<T>
 
         if (IsTrainingMode)
         {
-            _lastInput = input;
+            _lastInput = ShouldCacheForBackward ? input : null; // #1668: skip in inference (arena safety)
             // We might need gathered features for backward pass?
             // The CPU Backward uses _gatheredFeatures.
             // We should cache it if possible, or recompute.

--- a/src/NeuralNetworks/Layers/SpiralConvLayer.cs
+++ b/src/NeuralNetworks/Layers/SpiralConvLayer.cs
@@ -688,11 +688,11 @@ public partial class SpiralConvLayer<T> : LayerBase<T>
         if (hasBatch)
         {
             int batchSize = input.Shape[0];
-            output = ProcessBatched(input, batchSize, numVertices);
+            output = ProcessBatched(input, batchSize, numVertices, cacheBwd);
         }
         else
         {
-            output = ProcessSingle(input, numVertices);
+            output = ProcessSingle(input, numVertices, cacheBwd);
         }
 
         _lastPreActivation = cacheBwd ? output : null;
@@ -708,10 +708,11 @@ public partial class SpiralConvLayer<T> : LayerBase<T>
     /// <param name="input">Input tensor [numVertices, InputChannels].</param>
     /// <param name="numVertices">Number of vertices.</param>
     /// <returns>Output tensor [numVertices, OutputChannels].</returns>
-    private Tensor<T> ProcessSingle(Tensor<T> input, int numVertices)
+    private Tensor<T> ProcessSingle(Tensor<T> input, int numVertices, bool cacheBwd)
     {
         var gathered = GatherSpiralFeatures(input, numVertices);
-        _gatheredFeatures = gathered;
+        // #1668: _gatheredFeatures is read only by Backward; release it when no eager Backward runs.
+        _gatheredFeatures = cacheBwd ? gathered : null;
 
         var transposedWeights = Engine.TensorTranspose(_weights);
         var output = Engine.TensorMatMul(gathered, transposedWeights);
@@ -727,7 +728,7 @@ public partial class SpiralConvLayer<T> : LayerBase<T>
     /// <param name="batchSize">Batch size.</param>
     /// <param name="numVertices">Number of vertices per sample.</param>
     /// <returns>Output tensor [batch, numVertices, OutputChannels].</returns>
-    private Tensor<T> ProcessBatched(Tensor<T> input, int batchSize, int numVertices)
+    private Tensor<T> ProcessBatched(Tensor<T> input, int batchSize, int numVertices, bool cacheBwd)
     {
         var outputData = new T[batchSize * numVertices * OutputChannels];
 
@@ -747,9 +748,8 @@ public partial class SpiralConvLayer<T> : LayerBase<T>
             var singleOutput = Engine.TensorMatMul(gathered, transposedWeights);
             singleOutput = AddBiases(singleOutput, numVertices);
 
-            // Apply activation
-            singleOutput = ApplyActivation(singleOutput);
-
+            // Activation is applied exactly once by Forward() after ProcessBatched returns, so the
+            // per-sample output must stay PRE-activation here (matches the ProcessSingle path).
             var singleData = singleOutput.ToArray();
             int offset = b * numVertices * OutputChannels;
             Array.Copy(singleData, 0, outputData, offset, singleData.Length);
@@ -758,9 +758,15 @@ public partial class SpiralConvLayer<T> : LayerBase<T>
         // Combine gathered features for backward pass (sum across batch)
         // For backward pass, we need the gathered features. Store the first batch's for gradient computation.
         // A more complete solution would store all or use a different gradient strategy.
-        if (batchSize > 0 && localGatheredFeatures[0] != null)
+        // #1668: _gatheredFeatures is a backward-only cache; only build+retain it when an eager
+        // Backward will read it, so inference holds no gathered arena scratch across a Reset.
+        if (cacheBwd && batchSize > 0 && localGatheredFeatures[0] != null)
         {
             _gatheredFeatures = CombineGatheredFeatures(localGatheredFeatures, batchSize, numVertices);
+        }
+        else
+        {
+            _gatheredFeatures = null;
         }
 
         return new Tensor<T>(outputData, [batchSize, numVertices, OutputChannels]);

--- a/src/NeuralNetworks/Layers/SqueezeAndExcitationLayer.cs
+++ b/src/NeuralNetworks/Layers/SqueezeAndExcitationLayer.cs
@@ -730,7 +730,7 @@ public partial class SqueezeAndExcitationLayer<T> : LayerBase<T>, IAuxiliaryLoss
             squeezed = Engine.ReduceMean(input, spatialAxes, keepDims: false);
         }
 
-        _lastInput = input;
+        _lastInput = ShouldCacheForBackward ? input : null; // #1668: skip in inference (arena safety)
         _lastSqueezed = squeezed;
 
         // 2. Excitation: FC1 + Activation

--- a/src/NeuralNetworks/Layers/TemporalMemoryLayer.cs
+++ b/src/NeuralNetworks/Layers/TemporalMemoryLayer.cs
@@ -250,7 +250,7 @@ public class TemporalMemoryLayer<T> : LayerBase<T>
     /// </remarks>
     public override Tensor<T> Forward(Tensor<T> input)
     {
-        _lastInput = input;
+        _lastInput = ShouldCacheForBackward ? input : null; // #1668: skip in inference (arena safety)
         // Reshape CellStates from [ColumnCount, CellsPerColumn] to [ColumnCount * CellsPerColumn]
         var flatCellStates = Engine.Reshape(CellStates, [ColumnCount * CellsPerColumn]);
 

--- a/src/NeuralNetworks/Layers/TimeDistributedLayer.cs
+++ b/src/NeuralNetworks/Layers/TimeDistributedLayer.cs
@@ -178,7 +178,7 @@ public class TimeDistributedLayer<T> : LayerBase<T>
 
         if (IsTrainingMode)
         {
-            _lastInput = input;
+            _lastInput = ShouldCacheForBackward ? input : null; // #1668: skip in inference (arena safety)
             _lastOutput = output;
             _originalInputShape = input._shape;
         }

--- a/src/NeuralNetworks/Layers/TimeDistributedLayer.cs
+++ b/src/NeuralNetworks/Layers/TimeDistributedLayer.cs
@@ -176,9 +176,11 @@ public class TimeDistributedLayer<T> : LayerBase<T>
             output = gpuEngine.ActivationGpu(output, fusedOp);
         }
 
-        if (IsTrainingMode)
+        // #1668: gate the backward caches on ShouldCacheForBackward (not IsTrainingMode) so a
+        // tape/inference scope doesn't retain backward-only tensors the arena could recycle.
+        if (ShouldCacheForBackward)
         {
-            _lastInput = ShouldCacheForBackward ? input : null; // #1668: skip in inference (arena safety)
+            _lastInput = input;
             _lastOutput = output;
             _originalInputShape = input._shape;
         }

--- a/src/NeuralNetworks/Layers/TimeEmbeddingLayer.cs
+++ b/src/NeuralNetworks/Layers/TimeEmbeddingLayer.cs
@@ -233,7 +233,7 @@ public partial class TimeEmbeddingLayer<T> : LayerBase<T>
 
         if (IsTrainingMode)
         {
-            _lastInput = input;
+            _lastInput = ShouldCacheForBackward ? input : null; // #1668: skip in inference (arena safety)
             _lastSinusoidalEmbed = embedding;
             _lastHidden = hidden;
 

--- a/src/NeuralNetworks/Layers/TransformerDecoderLayer.cs
+++ b/src/NeuralNetworks/Layers/TransformerDecoderLayer.cs
@@ -796,7 +796,7 @@ public class TransformerDecoderLayer<T> : LayerBase<T>, IAuxiliaryLossLayer<T>
                 nameof(encoderOutput));
         }
 
-        _lastInput = input;
+        _lastInput = ShouldCacheForBackward ? input : null; // #1668: skip in inference (arena safety)
         _lastEncoderOutput = encoderOutput;
 
         _lastSelfAttentionOutput = _selfAttention.Forward(input);

--- a/src/NeuralNetworks/Layers/UNetDiscriminator.cs
+++ b/src/NeuralNetworks/Layers/UNetDiscriminator.cs
@@ -547,15 +547,20 @@ internal partial class UNetConvBlock<T> : LayerBase<T>
     {
         if (!IsShapeResolved) OnFirstForward(input);
 
-        _lastInput = ShouldCacheForBackward ? input : null; // #1668: skip in inference (arena safety)
+        // #1668: chained per-stage outputs → locals; cache to fields only for backward.
+        bool cacheBwd = ShouldCacheForBackward;
+        _lastInput = cacheBwd ? input : null;
 
         // Conv1 + LeakyReLU
-        _conv1RawOutput = _conv1.Forward(input);
-        _conv1Output = ApplyLeakyReLU(_conv1RawOutput);
+        var conv1Raw = _conv1.Forward(input);
+        _conv1RawOutput = cacheBwd ? conv1Raw : null;
+        var conv1Out = ApplyLeakyReLU(conv1Raw);
+        _conv1Output = cacheBwd ? conv1Out : null;
 
         // Conv2 + LeakyReLU
-        _conv2RawOutput = _conv2.Forward(_conv1Output);
-        var output = ApplyLeakyReLU(_conv2RawOutput);
+        var conv2Raw = _conv2.Forward(conv1Out);
+        _conv2RawOutput = cacheBwd ? conv2Raw : null;
+        var output = ApplyLeakyReLU(conv2Raw);
 
         return output;
     }
@@ -719,29 +724,34 @@ internal partial class UNetUpBlock<T> : LayerBase<T>
     {
         if (!IsShapeResolved) OnFirstForward(input);
 
-        _lastInput = ShouldCacheForBackward ? input : null; // #1668: skip in inference (arena safety)
-        _lastSkip = skip;
+        // #1668: gate backward caches; _upsampledInput/_concatenated are read below
+        // (chained), so forward uses locals and the fields cache only for backward.
+        bool cacheBwd = ShouldCacheForBackward;
+        _lastInput = cacheBwd ? input : null;
+        _lastSkip = cacheBwd ? skip : null;
 
         // Upsample
-        _upsampledInput = _upsample.Forward(input);
+        var upsampledInput = _upsample.Forward(input);
+        _upsampledInput = cacheBwd ? upsampledInput : null;
 
         // Concatenate with skip connection
         Tensor<T> x;
         if (skip != null)
         {
-            _concatenated = ConcatenateChannels(_upsampledInput, skip);
-            x = _concatenated;
+            var concatenated = ConcatenateChannels(upsampledInput, skip);
+            _concatenated = cacheBwd ? concatenated : null;
+            x = concatenated;
         }
         else
         {
             _concatenated = null;
-            x = _upsampledInput;
+            x = upsampledInput;
         }
 
         // Conv1 + LeakyReLU
         x = _conv1.Forward(x);
         x = ApplyLeakyReLU(x);
-        _conv1Output = x;
+        _conv1Output = cacheBwd ? x : null;
 
         // Conv2 + LeakyReLU
         x = _conv2.Forward(x);

--- a/src/NeuralNetworks/Layers/UNetDiscriminator.cs
+++ b/src/NeuralNetworks/Layers/UNetDiscriminator.cs
@@ -298,7 +298,7 @@ public class UNetDiscriminator<T> : LayerBase<T>
     {
         if (!IsShapeResolved) OnFirstForward(input);
 
-        _lastInput = input;
+        _lastInput = ShouldCacheForBackward ? input : null; // #1668: skip in inference (arena safety)
 
         // Initial conv + activation
         var x = _convFirst.Forward(input);
@@ -547,7 +547,7 @@ internal partial class UNetConvBlock<T> : LayerBase<T>
     {
         if (!IsShapeResolved) OnFirstForward(input);
 
-        _lastInput = input;
+        _lastInput = ShouldCacheForBackward ? input : null; // #1668: skip in inference (arena safety)
 
         // Conv1 + LeakyReLU
         _conv1RawOutput = _conv1.Forward(input);
@@ -719,7 +719,7 @@ internal partial class UNetUpBlock<T> : LayerBase<T>
     {
         if (!IsShapeResolved) OnFirstForward(input);
 
-        _lastInput = input;
+        _lastInput = ShouldCacheForBackward ? input : null; // #1668: skip in inference (arena safety)
         _lastSkip = skip;
 
         // Upsample

--- a/src/NeuralNetworks/Layers/Upsample3DLayer.cs
+++ b/src/NeuralNetworks/Layers/Upsample3DLayer.cs
@@ -261,7 +261,7 @@ public class Upsample3DLayer<T> : LayerBase<T>
     public override Tensor<T> Forward(Tensor<T> input)
     {
         EnsureInitializedFromInput(input);
-        _lastInput = input;
+        _lastInput = ShouldCacheForBackward ? input : null; // #1668: skip in inference (arena safety)
         _originalInputShape = input._shape;
         int rank = input.Rank;
 
@@ -357,7 +357,7 @@ public class Upsample3DLayer<T> : LayerBase<T>
         _addedBatchDimension = addedBatch;
 
         // Store _lastInput for backward pass
-        _lastInput = input;
+        _lastInput = ShouldCacheForBackward ? input : null; // #1668: skip in inference (arena safety)
 
         var output = gpuEngine.NearestNeighborUpsample3DGpu<T>(input5D, ScaleDepth, ScaleHeight, ScaleWidth);
 

--- a/src/NeuralNetworks/Layers/UpsamplingLayer.cs
+++ b/src/NeuralNetworks/Layers/UpsamplingLayer.cs
@@ -236,7 +236,7 @@ public class UpsamplingLayer<T> : LayerBase<T>
     public override Tensor<T> Forward(Tensor<T> input)
     {
         EnsureInitializedFromInput(input);
-        _lastInput = input;
+        _lastInput = ShouldCacheForBackward ? input : null; // #1668: skip in inference (arena safety)
 
         return Engine.Upsample(input, _scaleFactor, _scaleFactor);
     }

--- a/testconsole/Arena1668Probe.cs
+++ b/testconsole/Arena1668Probe.cs
@@ -1,0 +1,90 @@
+using System;
+using AiDotNet.Diffusion;
+using AiDotNet.NeuralNetworks;
+
+namespace AiDotNetTestConsole;
+
+/// <summary>
+/// Issue #1668 verification probe. The diffusion denoise loop must produce
+/// bit-identical, finite, deterministic output with the inference TensorArena
+/// (and its per-step Reset) ENABLED vs disabled. Before the layer no_grad gating
+/// (InferenceMode scope + ShouldCacheForBackward), arena-on corrupted the output:
+/// recycled scratch aliased layer activation caches (_lastInput, conv
+/// _preAllocatedOutput, ...) that were still referenced across the Reset.
+///
+/// Run: dotnet run --project testconsole -- arena1668-probe
+/// </summary>
+internal static class Arena1668Probe
+{
+    public static void Run()
+    {
+        var shape = new[] { 1, 4, 8, 8 };
+        const int seed = 42, steps = 10;
+
+        var off = Generate(shape, steps, seed, arena: false);
+        var on = Generate(shape, steps, seed, arena: true);
+
+        int nanOff = CountNonFinite(off), nanOn = CountNonFinite(on);
+        float maxDiff = 0f;
+        int firstDiff = -1;
+        for (int i = 0; i < off.Length; i++)
+        {
+            float d = Math.Abs(off[i] - on[i]);
+            if (d > maxDiff) maxDiff = d;
+            if (d != 0f && firstDiff < 0) firstDiff = i;
+        }
+
+        Console.WriteLine($"[#1668] DDPM Generate arena OFF vs ON  shape=[{string.Join(",", shape)}] steps={steps} seed={seed}");
+        Console.WriteLine($"  non-finite:  off={nanOff}  on={nanOn}");
+        Console.WriteLine($"  maxAbsDiff={maxDiff:G9}  firstDiffIdx={firstDiff}  len={off.Length}");
+        bool bitIdentical = maxDiff == 0f && nanOff == 0 && nanOn == 0;
+        Console.WriteLine($"  BIT-IDENTICAL (arena on==off): {(bitIdentical ? "PASS" : "FAIL")}");
+
+        // Replay determinism with the denoise arena ON: two generations from the
+        // same seed on the same instance must be bit-identical (catches arena state
+        // bleeding between generations / a carried buffer aliasing recycled scratch).
+        var replayShape = new[] { 1, 4, 4, 4 };
+        float rmax = float.NaN;
+        try
+        {
+            InferenceArenaSettings.Enabled = true;
+            InferenceArenaSettings.DiffusionDenoiseEnabled = true;
+            var m = new DDPMModel<float>(7);
+            var ta = m.Generate(replayShape, 5, 7);
+            var tb = m.Generate(replayShape, 5, 7);
+            rmax = 0f;
+            for (int i = 0; i < ta.Length; i++) rmax = Math.Max(rmax, Math.Abs(ta[i] - tb[i]));
+        }
+        finally
+        {
+            InferenceArenaSettings.DiffusionDenoiseEnabled = false;
+            InferenceArenaSettings.Enabled = false;
+        }
+        Console.WriteLine($"  REPLAY-DETERMINISTIC (arena on): {(rmax == 0f ? "PASS" : "FAIL")}  maxAbsDiff={rmax:G9}");
+    }
+
+    private static float[] Generate(int[] shape, int steps, int seed, bool arena)
+    {
+        InferenceArenaSettings.Enabled = arena;
+        InferenceArenaSettings.DiffusionDenoiseEnabled = arena;
+        try
+        {
+            var t = new DDPMModel<float>(seed).Generate(shape, steps, seed);
+            var arr = new float[t.Length];
+            for (int i = 0; i < t.Length; i++) arr[i] = t[i];
+            return arr;
+        }
+        finally
+        {
+            InferenceArenaSettings.DiffusionDenoiseEnabled = false;
+            InferenceArenaSettings.Enabled = false;
+        }
+    }
+
+    private static int CountNonFinite(float[] a)
+    {
+        int n = 0;
+        foreach (var x in a) if (float.IsNaN(x) || float.IsInfinity(x)) n++;
+        return n;
+    }
+}

--- a/testconsole/Arena1668Probe.cs
+++ b/testconsole/Arena1668Probe.cs
@@ -60,7 +60,16 @@ internal static class Arena1668Probe
             InferenceArenaSettings.DiffusionDenoiseEnabled = false;
             InferenceArenaSettings.Enabled = false;
         }
-        Console.WriteLine($"  REPLAY-DETERMINISTIC (arena on): {(rmax == 0f ? "PASS" : "FAIL")}  maxAbsDiff={rmax:G9}");
+        bool replayOk = rmax == 0f;
+        Console.WriteLine($"  REPLAY-DETERMINISTIC (arena on): {(replayOk ? "PASS" : "FAIL")}  maxAbsDiff={rmax:G9}");
+
+        // Fail the process on any #1668 regression so this probe is usable as a gate
+        // (otherwise a regression would still exit 0 and look green).
+        if (!bitIdentical || !replayOk)
+        {
+            Console.Error.WriteLine("[#1668] PROBE FAILED: denoise arena is not bit-identical/deterministic.");
+            Environment.Exit(1);
+        }
     }
 
     private static float[] Generate(int[] shape, int steps, int seed, bool arena)

--- a/testconsole/Program.cs
+++ b/testconsole/Program.cs
@@ -41,6 +41,7 @@ class Program
         ["acestep-nan-diag"]    = ACEStepNanDiag.Run,
         ["ace-tail-min-repro"]  = AceTailMinRepro.Run,
         ["tape-matmul-micro"]   = TapeMatMulMicroTest.Run,
+        ["arena1668-probe"]     = Arena1668Probe.Run,
     };
 
     static async Task Main(string[] args)

--- a/tests/AiDotNet.Tests/IntegrationTests/Diffusion/DiffusionGenerateArenaIntegrationTests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/Diffusion/DiffusionGenerateArenaIntegrationTests.cs
@@ -26,10 +26,21 @@ public class DiffusionGenerateArenaIntegrationTests
 {
     private static T WithArena<T>(bool enabled, System.Func<T> body)
     {
-        bool prev = InferenceArenaSettings.Enabled;
+        // The denoise-loop arena requires BOTH Enabled and DiffusionDenoiseEnabled
+        // (the latter was the #1668 opt-in gate). Toggle both so this test actually
+        // exercises the per-step Reset path — otherwise "enabled" only engages the
+        // single-shot Predict-funnel arena, which the denoise loop never uses, and
+        // the test would pass trivially.
+        bool prevEnabled = InferenceArenaSettings.Enabled;
+        bool prevDenoise = InferenceArenaSettings.DiffusionDenoiseEnabled;
         InferenceArenaSettings.Enabled = enabled;
+        InferenceArenaSettings.DiffusionDenoiseEnabled = enabled;
         try { return body(); }
-        finally { InferenceArenaSettings.Enabled = prev; }
+        finally
+        {
+            InferenceArenaSettings.Enabled = prevEnabled;
+            InferenceArenaSettings.DiffusionDenoiseEnabled = prevDenoise;
+        }
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary

Re-enables the diffusion denoise-loop inference `TensorArena` (recycling each step's
noise-predictor + scheduler intermediates instead of GC-churning them) by fixing the
underlying aliasing bug, replacing the lazy "arena-off" workaround. **`DiffusionDenoiseEnabled`
now defaults ON** (escape hatch: `AIDOTNET_INFERENCE_ARENA_DIFFUSION=0`).

Closes #1668.

## Root cause

The denoise loop calls `arena.Reset()` between steps to recycle that step's scratch.
Layers retained references to that scratch across the `Reset` via per-forward
backward-activation caches (`_lastInput`, pre-activation buffers) and a `Rent`'d
convolution output buffer reused across forwards. A later step's allocation then aliased
a still-referenced buffer and corrupted its shape/data. The arena cannot auto-detect this
(its pool strong-refs every buffer it hands out), so the fix is layer-side.

## Fix — the `torch.inference_mode()` analog

- **`InferenceMode`**: an `AsyncLocal` "no backward will run on this flow" scope.
- **`LayerBase.ShouldCacheForBackward`**: the canonical guard
  (`IsTrainingMode && !IsCapturing && !InferenceMode.IsActive && (no tape || KeepActivationCacheUnderTape)`),
  folded into the existing `ShouldCacheActivationsForManualBackward` + eager-backward push so
  layers already gating on that guard (e.g. MultiHeadAttention, LayerNorm) are auto-covered.
- `DiffusionModelBase.Generate` and `GenerateAsyncCore` enter the scope (the latter via
  `AsyncLocal`, which flows across `await`; the arena itself stays unwrapped on the async path).
- **Convolution P2 fix**: `ConvolutionalLayer._preAllocatedOutput` is re-`Rent`ed per forward
  **only when a `TensorArena` is active**, so the arena owns reuse (recycle-safe, still
  zero-allocation after warmup); outside an arena the manual reuse is kept.
- **Backward-cache gating across every layer composed by diffusion noise predictors** plus the
  commonly-shared layers (Conv/Conv3D/Dense/GroupNorm/LayerNorm/Instance/Pooling/Residual/
  Attention/GQA/Highway/GLU/RBF/Dropout/Padding/Cropping/Embedding/... ~60 layers): gate every
  backward-only cache (`_lastInput`, `_lastOutput`, attention weights/Q/K/V, etc.) on
  `ShouldCacheForBackward`, across CPU + GPU + masked/cross paths. Caches that double as forward
  intermediates use locals with conditional field-caching so the forward is unchanged.

## Scope (complete, not deferred)

Every layer that holds a `Rent`'d buffer across a forward — backward-activation cache **or**
working scratch — is now arena-safe, including the graph layers and the LSTM BPTT caches that
an earlier revision had left as-is:
- **GraphTransformerLayer**: the Q/K/V / attention-weight / head-output / concatenated / attn-output
  fields and the block-level input/normed/FFN caches are manual-backward caches only (the forward
  uses per-head locals plus the local `headOutputs`/`concatenated`). Their `Rent` + scatter-populate
  is gated on `ShouldCacheForBackward`; the Q/K/V/attn scatter guard is a combined null-check so the
  compiler narrows the fields to non-null (no null-forgiving). Forward output is byte-for-byte unchanged.
- **GraphAttentionLayer**: the per-head buffers double as in-forward working scratch (written then
  read back this forward), so the `Rent` must stay; instead the references are dropped right after
  their last forward use (the head-sum `ReduceSum`) when no eager Backward will read them.
- **LSTMLayer**: the per-timestep BPTT caches (`_cachedHiddenStates`/`_cachedCellStates`) are gated
  on `ShouldCacheForBackward` (null-conditional `SetSlice` populate).

Two field categories are intentionally left untouched because they are *forward-essential* — read by
the forward itself, not only by Backward, so nulling them would change inference:
- **Recurrent/SSM state** (GRU/LSTM/ConvLSTM `_lastHiddenState`/`_lastCellState`): carried across
  forwards under `stateful=true`. (Distinct from LSTM's per-timestep BPTT caches above, which ARE gated.)
- **VAE reparameterization noise** (`RepParameterizationLayer._lastEpsilon`): consumed in the forward
  output (`mean + stdDev·ε`).
These two are state/noise, not `Rent`'d scratch, so neither poses an arena-aliasing hazard.

## Verification

- `testconsole arena1668-probe`: DDPM `Generate` is bit-identical with the arena on vs off
  (maxAbsDiff=0, zero non-finite) and replay-deterministic — re-confirmed after the default flip.
- `DiffusionGenerateArenaIntegrationTests` (now exercises the denoise arena): 2/2 pass.
- CI runs the diffusion model-family + integration suites with the arena on.
- Graph (GAT + GraphTransformer) and LSTM gating builds clean (0 errors, net10.0 + net471);
  the gated fields are backward-only, so the forward/inference path is unchanged.
- All CodeRabbit review comments addressed and resolved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an inference mode to reduce unwanted runtime caching during generation.
  * Added a new `arena1668-probe` command-line check for diffusion determinism.

* **Bug Fixes**
  * Improved diffusion generation repeatability and multi-step denoise stability in arena-based runs.
  * Reduced inference-time retained state by disabling backward-only caching across many neural network layers.

* **Tests**
  * Updated arena integration tests to ensure diffusion denoise arena settings are exercised.

* **Documentation**
  * Updated the customer segmentation sample output to reflect renamed clustering metric values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->