### PR TITLE
chore(deps): update nuget packages to latest net471-compatible versions

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -198,10 +198,10 @@
          fail with that AggregateException on a 16 GB runner). Also carries the 0.102.18+/0.103.0 conv perf
          (implicit-GEMM #690, dcnv3 #691) + the prior diffusion CUDA-graph + FP16 work (#671/#680).
          Ships lib/net8.0 + net10.0 + net471. -->
-    <PackageVersion Include="AiDotNet.Tensors" Version="0.103.1" />
-    <PackageVersion Include="AiDotNet.Native.OneDNN" Version="0.102.9" />
-    <PackageVersion Include="AiDotNet.Native.OpenBLAS" Version="0.102.9" />
-    <PackageVersion Include="AiDotNet.Native.CLBlast" Version="0.102.9" />
+    <PackageVersion Include="AiDotNet.Tensors" Version="0.104.5" />
+    <PackageVersion Include="AiDotNet.Native.OneDNN" Version="0.104.5" />
+    <PackageVersion Include="AiDotNet.Native.OpenBLAS" Version="0.104.5" />
+    <PackageVersion Include="AiDotNet.Native.CLBlast" Version="0.104.5" />
     <!-- Microsoft / .NET -->
     <PackageVersion Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageVersion Include="Microsoft.Data.Sqlite" Version="10.0.9" />
@@ -214,23 +214,23 @@
     <PackageVersion Include="System.Text.RegularExpressions" Version="4.3.1" />
     <PackageVersion Include="System.ValueTuple" Version="4.6.2" />
     <!-- ASP.NET Core -->
-    <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.9" />
     <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.0-preview.1.25120.3" />
     <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="10.0.0-preview.1.25120.3" />
-    <PackageVersion Include="Microsoft.AspNetCore.DataProtection.EntityFrameworkCore" Version="10.0.7" />
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.AspNetCore.DataProtection.EntityFrameworkCore" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.9" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.9" />
     <PackageVersion Include="System.IdentityModel.Tokens.Jwt" Version="8.19.1" />
     <!-- Entity Framework Core -->
-    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="10.0.7" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.7" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.7" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.7" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.7" />
-    <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.1" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.9" />
+    <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.2" />
     <PackageVersion Include="Npgsql" Version="10.0.1" />
     <PackageVersion Include="Pomelo.EntityFrameworkCore.MySql" Version="9.0.0" />
-    <PackageVersion Include="MySqlConnector" Version="2.6.0" />
+    <PackageVersion Include="MySqlConnector" Version="2.6.1" />
     <!-- Azure -->
     <PackageVersion Include="Azure.Search.Documents" Version="11.7.0" />
     <PackageVersion Include="Microsoft.ApplicationInsights.WorkerService" Version="2.23.0" />
@@ -253,7 +253,7 @@
     <PackageVersion Include="Pinecone.Client" Version="4.0.2" />
     <PackageVersion Include="StackExchange.Redis" Version="2.13.17" />
     <PackageVersion Include="Stripe.net" Version="50.4.1" />
-    <PackageVersion Include="Swashbuckle.AspNetCore" Version="10.2.2" />
+    <PackageVersion Include="Swashbuckle.AspNetCore" Version="10.2.3" />
     <!-- Code analysis (default version; source generators may override) -->
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="3.11.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="5.3.0" />
@@ -274,7 +274,7 @@
     <PackageVersion Include="TorchSharp" Version="0.107.0" />
     <PackageVersion Include="TorchSharp-cuda-windows" Version="0.107.0" />
     <!-- Testing -->
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2" />
     <PackageVersion Include="coverlet.collector" Version="8.0.1" />


### PR DESCRIPTION
## Summary

Updates centrally-managed NuGet package versions (`Directory.Packages.props`) to their latest **net471-compatible** releases. The full solution builds clean (`AiDotNet.sln`, Release).

## Updated (16 packages)

| package(s) | from → to |
|---|---|
| **AiDotNet ecosystem** (Tensors + Native OneDNN/OpenBLAS/CLBlast, coreleased) | 0.103.1 / 0.102.9 → **0.104.5** |
| ASP.NET Core / EF Core (JwtBearer, DataProtection.EFCore, Mvc.NewtonsoftJson, EntityFrameworkCore + Design/Relational/Sqlite/SqlServer) | 10.0.7 → **10.0.9** |
| Npgsql.EntityFrameworkCore.PostgreSQL | 10.0.1 → **10.0.2** |
| MySqlConnector | 2.6.0 → **2.6.1** |
| Swashbuckle.AspNetCore | 10.2.2 → **10.2.3** |
| Microsoft.NET.Test.Sdk | 18.6.0 → **18.7.0** |

## Deferred to separate PRs

The repo multi-targets **net471**, so several latest majors can't land here:

- **Drop net471 support (NU1202):** Parquet.Net 5.5.0→6.0.3, xunit.runner.visualstudio 2.8.2→3.1.5, SixLabors.ImageSharp 3.1.12→4.0.0, Microsoft.ML 3.0.1→5.0.0 — these require dropping net471 first.
- **Major API migration (need own PR + testing):** Azure.Search.Documents 11→12, YamlDotNet 16→18, Stripe.net 50→52, coverlet.collector 8→10.
- **Microsoft.CodeAnalysis.\*** left at its existing pin.

I verified the broken set by building: applying all 26 updates failed restore on the net471-incompatible majors, so they were reverted; the 16 above build clean across the whole solution.

## Validation

Full `AiDotNet.sln` builds in Release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
