### PR TITLE
chore(deps): bump yamldotnet, stripe.net, coverlet to latest majors

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -247,12 +247,12 @@
     <!-- Pin Snappier to non-vulnerable 1.3.1 (1.3.0 has GHSA-pggp-6c3x-2xmx, transitive via Parquet.Net / Pipelines.Sockets.Unofficial) -->
     <PackageVersion Include="Snappier" Version="1.3.1" />
     <PackageVersion Include="Xunit.SkippableFact" Version="1.5.61" />
-    <PackageVersion Include="YamlDotNet" Version="16.3.0" />
+    <PackageVersion Include="YamlDotNet" Version="18.1.0" />
     <!-- Infrastructure -->
     <PackageVersion Include="Elastic.Clients.Elasticsearch" Version="9.4.2" />
     <PackageVersion Include="Pinecone.Client" Version="4.0.2" />
     <PackageVersion Include="StackExchange.Redis" Version="2.13.17" />
-    <PackageVersion Include="Stripe.net" Version="50.4.1" />
+    <PackageVersion Include="Stripe.net" Version="52.1.0" />
     <PackageVersion Include="Swashbuckle.AspNetCore" Version="10.2.3" />
     <!-- Code analysis (default version; source generators may override) -->
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="3.11.0" />
@@ -277,7 +277,7 @@
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2" />
-    <PackageVersion Include="coverlet.collector" Version="8.0.1" />
+    <PackageVersion Include="coverlet.collector" Version="10.0.1" />
     <PackageVersion Include="BenchmarkDotNet" Version="0.15.8" />
     <PackageVersion Include="Moq" Version="4.20.72" />
   </ItemGroup>


### PR DESCRIPTION
## Summary

Picks up the **net471-compatible major-version bumps** that were deferred from #1700 (which only took the in-major / net471-safe updates). Each crossed a major boundary, so they were held back for a build verification pass — done here.

| Package | From | To | Used by |
|---|---|---|---|
| YamlDotNet | 16.3.0 | 18.1.0 | `YamlConfigLoader` + YAML config source generator |
| Stripe.net | 50.4.1 | 52.1.0 | `AiDotNet.Serving` licensing / webhooks |
| coverlet.collector | 8.0.1 | 10.0.1 | test coverage collector (build/test tooling) |

All three **compile clean on both target frameworks (net471 + net10)** across the full solution. No source changes were required — the APIs we use (`DeserializerBuilder`/`CamelCaseNamingConvention`, `StripeConfiguration`/webhook construction, coverlet's MSBuild integration) are unchanged across these majors.

## Validation

- Full `dotnet build AiDotNet.sln -c Release` succeeds on net471 **and** net10.
- coverlet is test-time only (zero runtime/library impact). YamlDotNet and Stripe.net compile clean including the generated `YamlTypeRegistry`; our usage surface is API-stable across the bump, so the two-TFM build is the gate (no unit tests exercise these libraries directly).

## Held back: Azure.Search.Documents 12

`Azure.Search.Documents` is intentionally **kept at 11.7.0**. On net471, v12 pulls `System.IdentityModel.Metadata` (WIF) into the transitive closure, which makes the YAML config source generator emit an unconstrained-generic registry entry for `LocalizedEntryCollection<T>` and fail the net471 build with **CS0314**. Unblocking it needs either:

1. the net471 target dropped, or
2. the YAML source generator scoped to skip WIF metadata types.

Tracked as a separate follow-up rather than forced in here.

The remaining deferred majors (Parquet.Net 6, xunit.runner.visualstudio 3, SixLabors.ImageSharp 4, Microsoft.ML 5) all **drop net471 support** (NU1202) and likewise require the net471-drop decision first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
