### PR TITLE
fix(samples): use correct clustering metric property names in customersegmentation

### DIFF
--- a/samples/clustering/CustomerSegmentation/Program.cs
+++ b/samples/clustering/CustomerSegmentation/Program.cs
@@ -98,9 +98,9 @@ Console.WriteLine("\n=== Clustering Quality Metrics (result.Evaluation) ===\n");
 var clusteringMetrics = result.Evaluation.ClusteringMetrics;
 if (clusteringMetrics is not null)
 {
-    Console.WriteLine($"  Silhouette:         {clusteringMetrics.SilhouetteScore,8:F4}  {InterpretMetric("Silhouette Score", clusteringMetrics.SilhouetteScore)}");
-    Console.WriteLine($"  Davies-Bouldin:     {clusteringMetrics.DaviesBouldinIndex,8:F4}  {InterpretMetric("Davies-Bouldin Index", clusteringMetrics.DaviesBouldinIndex)}");
-    Console.WriteLine($"  Calinski-Harabasz:  {clusteringMetrics.CalinskiHarabaszIndex,8:F4}  {InterpretMetric("Calinski-Harabasz Index", clusteringMetrics.CalinskiHarabaszIndex)}");
+    Console.WriteLine($"  Silhouette:         {clusteringMetrics.Silhouette,8:F4}  {InterpretMetric("Silhouette Score", clusteringMetrics.Silhouette)}");
+    Console.WriteLine($"  Davies-Bouldin:     {clusteringMetrics.DaviesBouldin,8:F4}  {InterpretMetric("Davies-Bouldin Index", clusteringMetrics.DaviesBouldin)}");
+    Console.WriteLine($"  Calinski-Harabasz:  {clusteringMetrics.CalinskiHarabasz,8:F4}  {InterpretMetric("Calinski-Harabasz Index", clusteringMetrics.CalinskiHarabasz)}");
 }
 
 // For a deeper per-cluster breakdown, the standalone ClusteringEvaluator is still available.


### PR DESCRIPTION
## Summary

The `CustomerSegmentation` clustering sample read three properties off `ClusteringScores` that do not exist:

| Sample used | Actual property |
|---|---|
| `SilhouetteScore` | `Silhouette` |
| `DaviesBouldinIndex` | `DaviesBouldin` |
| `CalinskiHarabaszIndex` | `CalinskiHarabasz` |

This produced `CS1061` and broke the **Samples (build + run)** CI check on `master` after #1685 enabled the samples harness.

## Validation

- Built the full `samples/Samples.slnx`: `CustomerSegmentation` was the **only** failing sample; the other 35 build clean.
- After the rename, `CustomerSegmentation.csproj` builds clean — so this greens the check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
