### PR TITLE
test(ci): tag the named HeavyTimeout heavy-cast models (#1706)

### DIFF
--- a/tests/AiDotNet.Tests/ModelFamilyTests/Diffusion/CosmosModelTests.cs
+++ b/tests/AiDotNet.Tests/ModelFamilyTests/Diffusion/CosmosModelTests.cs
@@ -5,6 +5,9 @@ using AiDotNet.Tests.ModelFamilyTests.Base;
 namespace AiDotNet.Tests.ModelFamilyTests.Diffusion;
 
 [Xunit.Collection("FoundationScaleSerial")] // dedicated cores (#1622 L4)
+// HeavyTimeout (#1706): correct but too slow for the default per-test gate (foundation-scale diffusion,
+// ~100 s/forward x N-step Generate); runs in the nightly lane. Drop this trait once it fits the budget.
+[Xunit.Trait("Category", "HeavyTimeout")]
 public class CosmosModelTests : DiffusionModelTestBase<float>
 {
     protected override int[] InputShape => [1, 16, 32, 32];

--- a/tests/AiDotNet.Tests/ModelFamilyTests/Diffusion/DallE2ModelTests.cs
+++ b/tests/AiDotNet.Tests/ModelFamilyTests/Diffusion/DallE2ModelTests.cs
@@ -24,6 +24,9 @@ namespace AiDotNet.Tests.ModelFamilyTests.Diffusion;
 /// smoke/invariant tests can run a short sampler while quality-sensitive
 /// callers pass a larger step count to <c>Generate</c> / <c>GenerateFromText</c>.
 /// </remarks>
+// HeavyTimeout (#1706): correct but too slow for the default per-test gate (foundation-scale diffusion,
+// ~100 s/forward x N-step Generate); runs in the nightly lane. Drop this trait once it fits the budget.
+[Xunit.Trait("Category", "HeavyTimeout")]
 public class DallE2ModelTests : DiffusionModelTestBase<float>
 {
     protected override int[] InputShape => [1, 3, 16, 16];

--- a/tests/AiDotNet.Tests/ModelFamilyTests/Diffusion/Flux2ModelTests.cs
+++ b/tests/AiDotNet.Tests/ModelFamilyTests/Diffusion/Flux2ModelTests.cs
@@ -4,6 +4,9 @@ using AiDotNet.Tests.ModelFamilyTests.Base;
 
 namespace AiDotNet.Tests.ModelFamilyTests.Diffusion;
 
+// HeavyTimeout (#1706): correct but too slow for the default per-test gate (foundation-scale diffusion,
+// ~100 s/forward x N-step Generate); runs in the nightly lane. Drop this trait once it fits the budget.
+[Xunit.Trait("Category", "HeavyTimeout")]
 public class Flux2ModelTests : DiffusionModelTestBase<float>
 {
     protected override int[] InputShape => [1, 16, 32, 32];

--- a/tests/AiDotNet.Tests/ModelFamilyTests/Diffusion/FluxSchnellModelTests.cs
+++ b/tests/AiDotNet.Tests/ModelFamilyTests/Diffusion/FluxSchnellModelTests.cs
@@ -4,6 +4,9 @@ using AiDotNet.Tests.ModelFamilyTests.Base;
 
 namespace AiDotNet.Tests.ModelFamilyTests.Diffusion;
 
+// HeavyTimeout (#1706): correct but too slow for the default per-test gate (foundation-scale diffusion,
+// ~100 s/forward x N-step Generate); runs in the nightly lane. Drop this trait once it fits the budget.
+[Xunit.Trait("Category", "HeavyTimeout")]
 public class FluxSchnellModelTests : DiffusionModelTestBase<float>
 {
     protected override int[] InputShape => [1, 16, 32, 32];

--- a/tests/AiDotNet.Tests/ModelFamilyTests/Diffusion/HunyuanDiTModelTests.cs
+++ b/tests/AiDotNet.Tests/ModelFamilyTests/Diffusion/HunyuanDiTModelTests.cs
@@ -6,6 +6,9 @@ using AiDotNet.Tests.ModelFamilyTests.Base;
 
 namespace AiDotNet.Tests.ModelFamilyTests.Diffusion;
 
+// HeavyTimeout (#1706): correct but too slow for the default per-test gate (foundation-scale diffusion,
+// ~100 s/forward x N-step Generate); runs in the nightly lane. Drop this trait once it fits the budget.
+[Xunit.Trait("Category", "HeavyTimeout")]
 public class HunyuanDiTModelTests : DiffusionModelTestBase<float>
 {
     protected override int[] InputShape => [1, 4, 32, 32];

--- a/tests/AiDotNet.Tests/ModelFamilyTests/Diffusion/KandinskyModelTests.cs
+++ b/tests/AiDotNet.Tests/ModelFamilyTests/Diffusion/KandinskyModelTests.cs
@@ -10,6 +10,9 @@ namespace AiDotNet.Tests.ModelFamilyTests.Diffusion;
 /// probes at FP64 on the 16 GB CI host.
 /// </summary>
 [Xunit.Collection("FoundationScaleSerial")] // dedicated cores (#1622 L4)
+// HeavyTimeout (#1706): correct but too slow for the default per-test gate (foundation-scale diffusion,
+// ~100 s/forward x N-step Generate); runs in the nightly lane. Drop this trait once it fits the budget.
+[Xunit.Trait("Category", "HeavyTimeout")]
 public class KandinskyModelTests : DiffusionModelTestBase<float>
 {
     protected override int[] InputShape => [1, 4, 64, 64];

--- a/tests/AiDotNet.Tests/ModelFamilyTests/Diffusion/MidJourneyV7ModelTests.cs
+++ b/tests/AiDotNet.Tests/ModelFamilyTests/Diffusion/MidJourneyV7ModelTests.cs
@@ -4,6 +4,9 @@ using AiDotNet.Tests.ModelFamilyTests.Base;
 
 namespace AiDotNet.Tests.ModelFamilyTests.Diffusion;
 
+// HeavyTimeout (#1706): correct but too slow for the default per-test gate (foundation-scale diffusion,
+// ~100 s/forward x N-step Generate); runs in the nightly lane. Drop this trait once it fits the budget.
+[Xunit.Trait("Category", "HeavyTimeout")]
 public class MidJourneyV7ModelTests : DiffusionModelTestBase<float>
 {
     protected override int[] InputShape => [1, 16, 32, 32];

--- a/tests/AiDotNet.Tests/ModelFamilyTests/Diffusion/OpenSora13ModelTests.cs
+++ b/tests/AiDotNet.Tests/ModelFamilyTests/Diffusion/OpenSora13ModelTests.cs
@@ -6,6 +6,9 @@ using AiDotNet.Tests.ModelFamilyTests.Base;
 
 namespace AiDotNet.Tests.ModelFamilyTests.Diffusion;
 
+// HeavyTimeout (#1706): correct but too slow for the default per-test gate (foundation-scale diffusion,
+// ~100 s/forward x N-step Generate); runs in the nightly lane. Drop this trait once it fits the budget.
+[Xunit.Trait("Category", "HeavyTimeout")]
 public class OpenSora13ModelTests : DiffusionModelTestBase<float>
 {
     protected override int[] InputShape => [1, 4, 32, 32];

--- a/tests/AiDotNet.Tests/ModelFamilyTests/Diffusion/SDXLInpaintingModelTests.cs
+++ b/tests/AiDotNet.Tests/ModelFamilyTests/Diffusion/SDXLInpaintingModelTests.cs
@@ -36,6 +36,9 @@ namespace AiDotNet.Tests.ModelFamilyTests.Diffusion;
 /// <c>T = double</c> at configure-time), so this is also the only numeric
 /// type compatible with the documented production training path.
 /// </remarks>
+// HeavyTimeout (#1706): correct but too slow for the default per-test gate (foundation-scale diffusion,
+// ~100 s/forward x N-step Generate); runs in the nightly lane. Drop this trait once it fits the budget.
+[Xunit.Trait("Category", "HeavyTimeout")]
 public class SDXLInpaintingModelTests : DiffusionModelTestBase<float>
 {
     // SDXL inpainting denoises 4-channel latents. The UNet itself receives

--- a/tests/AiDotNet.Tests/ModelFamilyTests/Diffusion/SDXLTurboModelTests.cs
+++ b/tests/AiDotNet.Tests/ModelFamilyTests/Diffusion/SDXLTurboModelTests.cs
@@ -6,6 +6,9 @@ using AiDotNet.Tests.ModelFamilyTests.Base;
 
 namespace AiDotNet.Tests.ModelFamilyTests.Diffusion;
 
+// HeavyTimeout (#1706): correct but too slow for the default per-test gate (foundation-scale diffusion,
+// ~100 s/forward x N-step Generate); runs in the nightly lane. Drop this trait once it fits the budget.
+[Xunit.Trait("Category", "HeavyTimeout")]
 public class SDXLTurboModelTests : DiffusionModelTestBase<float>
 {
     // SD-based latent diffusion: 4 channels, 64x64 latent (512x512 images / 8x VAE)

--- a/tests/AiDotNet.Tests/ModelFamilyTests/Diffusion/SenseFlowModelTests.cs
+++ b/tests/AiDotNet.Tests/ModelFamilyTests/Diffusion/SenseFlowModelTests.cs
@@ -4,6 +4,9 @@ using AiDotNet.Tests.ModelFamilyTests.Base;
 
 namespace AiDotNet.Tests.ModelFamilyTests.Diffusion;
 
+// HeavyTimeout (#1706): correct but too slow for the default per-test gate (foundation-scale diffusion,
+// ~100 s/forward x N-step Generate); runs in the nightly lane. Drop this trait once it fits the budget.
+[Xunit.Trait("Category", "HeavyTimeout")]
 public class SenseFlowModelTests : DiffusionModelTestBase<float>
 {
     protected override int[] InputShape => [1, 16, 32, 32];

--- a/tests/AiDotNet.Tests/ModelFamilyTests/Diffusion/TransfusionModelTests.cs
+++ b/tests/AiDotNet.Tests/ModelFamilyTests/Diffusion/TransfusionModelTests.cs
@@ -4,6 +4,9 @@ using AiDotNet.Tests.ModelFamilyTests.Base;
 
 namespace AiDotNet.Tests.ModelFamilyTests.Diffusion;
 
+// HeavyTimeout (#1706): correct but too slow for the default per-test gate (foundation-scale diffusion,
+// ~100 s/forward x N-step Generate); runs in the nightly lane. Drop this trait once it fits the budget.
+[Xunit.Trait("Category", "HeavyTimeout")]
 public class TransfusionModelTests : DiffusionModelTestBase<float>
 {
     protected override int[] InputShape => [1, 16, 32, 32];

--- a/tests/AiDotNet.Tests/ModelFamilyTests/Diffusion/WanVideoModelTests.cs
+++ b/tests/AiDotNet.Tests/ModelFamilyTests/Diffusion/WanVideoModelTests.cs
@@ -6,6 +6,9 @@ using AiDotNet.Tests.ModelFamilyTests.Base;
 
 namespace AiDotNet.Tests.ModelFamilyTests.Diffusion;
 
+// HeavyTimeout (#1706): correct but too slow for the default per-test gate (foundation-scale diffusion,
+// ~100 s/forward x N-step Generate); runs in the nightly lane. Drop this trait once it fits the budget.
+[Xunit.Trait("Category", "HeavyTimeout")]
 public class WanVideoModelTests : DiffusionModelTestBase<float>
 {
     protected override int[] InputShape => [1, 16, 32, 32];

--- a/tests/AiDotNet.Tests/ModelFamilyTests/NeuralNetworks/VGGNetworkTests.cs
+++ b/tests/AiDotNet.Tests/ModelFamilyTests/NeuralNetworks/VGGNetworkTests.cs
@@ -4,6 +4,9 @@ using AiDotNet.Tests.ModelFamilyTests.Base;
 
 namespace AiDotNet.Tests.ModelFamilyTests.NeuralNetworks;
 
+// HeavyTimeout (#1706): correct but too slow for the default per-test gate (VGG is GEMM-bound,
+// ~7 s/iter); runs in the nightly lane. Drop this trait once it fits the budget.
+[Xunit.Trait("Category", "HeavyTimeout")]
 public class VGGNetworkTests : NeuralNetworkModelTestBase<float>
 {
     // Paper-canonical VGG16-BN on ImageNet input per Simonyan & Zisserman 2014

--- a/tests/AiDotNet.Tests/ModelFamilyTests/NeuralNetworks/VisionTransformerTests.cs
+++ b/tests/AiDotNet.Tests/ModelFamilyTests/NeuralNetworks/VisionTransformerTests.cs
@@ -4,6 +4,9 @@ using AiDotNet.Tests.ModelFamilyTests.Base;
 
 namespace AiDotNet.Tests.ModelFamilyTests.NeuralNetworks;
 
+// HeavyTimeout (#1706): correct but too slow for the default per-test gate (ViT is GEMM-bound,
+// ~44 s/iter); runs in the nightly lane. Drop this trait once it fits the budget.
+[Xunit.Trait("Category", "HeavyTimeout")]
 public class VisionTransformerTests : NeuralNetworkModelTestBase<float>
 {
     // ViT default architecture is [batch, 3, 224, 224] (paper-faithful


### PR DESCRIPTION
## What & why

Issue #1706 tracks models that are **correct but inherently too slow** for the default sharded test gate (`Build & SonarCloud`, per-test / 45-min budget). Per the agreed strategy (mechanism shipped in #1705), these are tagged `[Trait("Category","HeavyTimeout")]`, **excluded** from the default gate (`&Category!=HeavyTimeout`) so PRs go green, and run best-effort in the `Heavy Timeout Models (nightly)` lane. They are **deferred, not skipped** — each class carries an inline comment to drop the trait once it fits the budget.

This PR tags the **named, high-confidence heavy cast** from the issue (15 test classes, **228 tests**):

- **NN (GEMM-bound):** `VisionTransformerTests` (ViT, ~44 s/iter), `VGGNetworkTests` (~7 s/iter).
- **Diffusion (foundation-scale, ~100 s/forward x N-step `Generate`):** `OpenSora13`, `Flux2`, `WanVideo`, `Cosmos`, `HunyuanDiT`, `SDXLTurbo`, `Kandinsky`, `MidJourneyV7`, `SenseFlow`, `Transfusion`, `FluxSchnell`, `DallE2`, `SDXLInpainting`.

## Verification
- `dotnet test --list-tests --filter "Category=HeavyTimeout"` selects exactly **228 tests** across these 15 classes — i.e. the #1705 default-gate filter will now exclude them and the nightly lane will pick them up.
- Test project builds clean (net10.0, Release). Trait added via `[Xunit.Trait(...)]` (no `using` churn), placed alongside any existing `[Xunit.Collection("FoundationScaleSerial")]`.

## Scope (intentionally partial)
Per #1706 the list is preliminary and gets finalized against the first **completed** CI run (still in flight at issue time). This PR tags only the **named** cast — the confident subset from prior profiling. The issue's other confirmed-timeout shards (the remaining `NeuralNetworks O-R` / `S` NN models, ~24 unnamed) need the completed run's per-model verdict before they can be pinned to specific classes, so they are **not** tagged here. This is the first batch toward the issue's Definition of Done, not its closure.

Refs #1706. Mechanism: #1705.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Marked several long-running model and vision test suites as **HeavyTimeout** so they run in the nightly lane instead of the default per-test timeout.
  * Added notes clarifying these tests are valid but exceed the standard execution budget.
  * Updated coverage across multiple diffusion, neural network, and vision test groups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->