### PR TITLE
fix(finance): defer tsmixer lazy-shape resolution to first forward (#1712)

### DIFF
--- a/src/Finance/Forecasting/Transformers/TSMixer.cs
+++ b/src/Finance/Forecasting/Transformers/TSMixer.cs
@@ -392,6 +392,21 @@ public class TSMixer<T> : ForecastingModelBase<T>
     }
 
     /// <summary>
+    /// Opts out of the base linear lazy-shape pre-resolution (#1712). The base
+    /// <c>ResolveLazyLayerShapes</c> walks <see cref="NeuralNetworkBase{T}.Layers"/> in order with no
+    /// transpose, but <see cref="Forward"/> applies per-block time-mixing TRANSPOSES
+    /// (<c>Engine.TensorPermute [0,2,1]</c> around the time-mixing Dense layers). The linear walk
+    /// therefore runs the time-mixing <c>Dense(sequenceLength)</c> WITHOUT the transpose, so its output
+    /// last dim becomes the sequence length, and the following feature-mixing lazy
+    /// <c>LayerNormalizationLayer</c> binds its gamma to that value instead of the hidden dimension the
+    /// real forward feeds it — "Gamma shape (8) does not match the last 1 dimensions of input shape
+    /// (1, 8, 24)". Returning null skips the walk and lets every layer resolve on the first real Forward,
+    /// which models the transposes correctly (the Dense layers auto-adapt; the LayerNorms bind to the
+    /// hidden dim). TSMixer is small, so deferring per-layer ParameterCount to the first forward is fine.
+    /// </summary>
+    protected override int[]? TryGetArchitectureInputShape() => null;
+
+    /// <summary>
     /// Extracts references to specific layers for the TSMixer architecture.
     /// </summary>
     /// <remarks>


### PR DESCRIPTION
## Summary

Fixes the 4 real `TSMixer` failures in the Finance **Integration E-G** shard (CI run 28293394520, exit 1 — genuine assertions, not timeout/OOM):

- `FinanceCategoryIntegrationTests.ForecastingTransformers_{Double,Float}_CanForecastWithQuantiles`
- `FinanceModelsIntegrationTests.FinanceModels_{Double,Float}_Native_Predict_Train_Serialize`

All four threw the same exception on the **first `Predict`**:
```
System.ArgumentException : Gamma shape (8) does not match the last 1 dimensions of input shape (1, 8, 24)
```

## Root cause

`NeuralNetworkBase.ResolveLazyLayerShapes` pre-resolves lazy layers (so `ParameterCount` is right before the first forward) by walking `Layers` **linearly**, advancing the shape layer-by-layer.

But `TSMixer.Forward` is **not** a linear layer application — each block's time-mixing half transposes around its Dense layers (`Engine.TensorPermute(current, [0, 2, 1])`). The linear walk has no transpose, so it runs the time-mixing `Dense(sequenceLength)` on the **untransposed** tensor and its output last dim becomes the sequence length (8). The next feature-mixing **lazy `LayerNormalizationLayer`** then binds its gamma to 8 — but the real (transposed) forward feeds that LayerNorm the hidden dim (24).

`DenseLayer` auto-adapts its input width on forward (`EnsureWeightShapeForInput`), so the mis-resolved Dense layers silently survive; `LayerNormalizationLayer` does not adapt, so it throws.

(Config from the test factory: SequenceLength=8, NumFeatures=8, HiddenDimension=24, NumBlocks=1 → input `[1, 8, 8]`, post-projection `[1, 8, 24]`.)

## Fix

`TSMixer` overrides `TryGetArchitectureInputShape()` to return `null` — the documented escape hatch that skips the linear pre-resolution and lets every layer bind on the **first real Forward**, which models the transposes correctly (Dense adapts; the LayerNorms bind to the hidden dim). One method, no behavioral change to the forward math. TSMixer is small, so deferring per-layer `ParameterCount` to the first forward is fine.

## Validation

- Finance integration tests (`FinanceModelsIntegrationTests` + `ForecastingTransformers`): **414/414 green** on net10.0 (was 410/414 — the 4 TSMixer failures fixed), `AIDOTNET_DISABLE_GPU=1`.
- `src/AiDotNet.csproj` builds clean on **net471 and net10**.

Closes #1712.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an initialization issue that could cause shape mismatches when setting up forecasting models.
  * Improved model startup so parameter shapes are resolved more reliably during the first run.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->