### PR TITLE
feat(tools): DiffusionTraceProbe --unet parallel-efficiency probe (#642)

### DIFF
--- a/tools/DiffusionTraceProbe/Program.cs
+++ b/tools/DiffusionTraceProbe/Program.cs
@@ -31,15 +31,19 @@ internal static class Program
             return 2;
         }
 
+        // Pin the CPU engine + disable GPU so the profile reflects the CPU path the
+        // CI shard runs (AIDOTNET_DISABLE_GPU=1 is also set by the test harness).
+        AiDotNetEngine.Current = new CpuEngine();
+
+        // P0 (#642): isolate the SD-UNet forward and time it at a chosen degree of
+        // parallelism so the 1-vs-N speedup curve = parallel efficiency = utilization.
+        if (args[0] == "--unet") return RunUNetParallelProbe(args);
+
         string modelName = args[0];
         int trainIters = ArgInt(args, "--train-iters", 5);
         bool doPredict = ArgInt(args, "--predict", 1) != 0;
         bool correctness = args.Contains("--correctness");
         bool allocIsolate = args.Contains("--alloc-isolate");
-
-        // Pin the CPU engine + disable GPU so the profile reflects the CPU path the
-        // CI shard runs (AIDOTNET_DISABLE_GPU=1 is also set by the test harness).
-        AiDotNetEngine.Current = new CpuEngine();
 
         var model = Construct(modelName);
         if (model is null) return 1;
@@ -263,6 +267,62 @@ internal static class Program
         {
             if (model is IDisposable d) d.Dispose();
         }
+    }
+
+    /// <summary>
+    /// P0 #642: build a runnable SD-UNet noise predictor and time a single PredictNoise
+    /// forward at a chosen MaxDegreeOfParallelism. Sweeping maxdop=1..N gives the speedup
+    /// curve; speedup/N = parallel efficiency = effective core utilization for this op mix.
+    /// Eager by default (--compile 0) so we measure per-op parallelism without the
+    /// compiled-plan decision confound; this is also the path Train() uses.
+    /// </summary>
+    private static int RunUNetParallelProbe(string[] args)
+    {
+        int baseCh = ArgInt(args, "--base", 128);
+        int maxdop = ArgInt(args, "--maxdop", Environment.ProcessorCount);
+        int reps = ArgInt(args, "--reps", 3);
+        int height = ArgInt(args, "--height", 64);
+        bool attn = ArgInt(args, "--attn", 1) != 0;
+        bool compile = ArgInt(args, "--compile", 0) != 0;
+
+        AiDotNet.Tensors.Helpers.CpuParallelSettings.MaxDegreeOfParallelism = maxdop;
+        AiDotNet.Tensors.Engines.Optimization.TensorCodecOptions.Current.EnableCompilation = compile;
+
+        var predictor = new AiDotNet.Diffusion.NoisePredictors.UNetNoisePredictor<float>(
+            inputChannels: 4, outputChannels: 4, baseChannels: baseCh,
+            channelMultipliers: new[] { 1, 2, 4, 4 }, numResBlocks: 2,
+            attentionResolutions: attn ? new[] { 4, 2, 1 } : Array.Empty<int>(),
+            contextDim: 768, numHeads: 8, inputHeight: height, seed: 42);
+
+        var rng = new Random(42);
+        var input = RandomTensor(new[] { 1, 4, height, height }, rng);
+        var cond = attn ? RandomTensor(new[] { 1, 77, 768 }, rng) : null;
+        const int t = 500;
+
+        // Warm-up: lazy weight allocation + (if enabled) first-forward trace/compile.
+        // Excluded from timing so steady-state per-op cost is what we measure.
+        var sww = Stopwatch.StartNew();
+        _ = predictor.PredictNoise(input, t, cond);
+        sww.Stop();
+
+        var times = new double[reps];
+        for (int i = 0; i < reps; i++)
+        {
+            var sw = Stopwatch.StartNew();
+            _ = predictor.PredictNoise(input, t, cond);
+            sw.Stop();
+            times[i] = sw.Elapsed.TotalMilliseconds;
+        }
+        Array.Sort(times);
+        double median = times[reps / 2];
+        long pc = -1;
+        try { pc = predictor.ParameterCount; } catch { }
+        Console.WriteLine(
+            $"UNET base={baseCh} attn={attn} h={height} compile={compile} " +
+            $"maxdop={maxdop} procs={Environment.ProcessorCount} params={pc} " +
+            $"warmup_ms={sww.Elapsed.TotalMilliseconds:F0} median_ms={median:F1} min_ms={times[0]:F1}");
+        if (predictor is IDisposable d) d.Dispose();
+        return 0;
     }
 
     private static object? Construct(string modelName)

--- a/tools/DiffusionTraceProbe/Program.cs
+++ b/tools/DiffusionTraceProbe/Program.cs
@@ -285,6 +285,15 @@ internal static class Program
         bool attn = ArgInt(args, "--attn", 1) != 0;
         bool compile = ArgInt(args, "--compile", 0) != 0;
 
+        // Fail fast on a non-positive rep count before allocating buffers / constructing the predictor:
+        // --reps 0 would index an empty times[] (IndexOutOfRange), and a negative value throws on the
+        // `new double[reps]` allocation — neither gives the user an actionable message.
+        if (reps <= 0)
+        {
+            Console.Error.WriteLine($"--reps must be a positive integer (got {reps}).");
+            return 1;
+        }
+
         AiDotNet.Tensors.Helpers.CpuParallelSettings.MaxDegreeOfParallelism = maxdop;
         AiDotNet.Tensors.Engines.Optimization.TensorCodecOptions.Current.EnableCompilation = compile;
 
@@ -294,35 +303,44 @@ internal static class Program
             attentionResolutions: attn ? new[] { 4, 2, 1 } : Array.Empty<int>(),
             contextDim: 768, numHeads: 8, inputHeight: height, seed: 42);
 
-        var rng = new Random(42);
-        var input = RandomTensor(new[] { 1, 4, height, height }, rng);
-        var cond = attn ? RandomTensor(new[] { 1, 77, 768 }, rng) : null;
-        const int t = 500;
-
-        // Warm-up: lazy weight allocation + (if enabled) first-forward trace/compile.
-        // Excluded from timing so steady-state per-op cost is what we measure.
-        var sww = Stopwatch.StartNew();
-        _ = predictor.PredictNoise(input, t, cond);
-        sww.Stop();
-
-        var times = new double[reps];
-        for (int i = 0; i < reps; i++)
+        // Dispose the predictor on every exit path: if PredictNoise / ParameterCount / output
+        // formatting throws, the model and its backing buffers would otherwise leak for the rest
+        // of the process.
+        try
         {
-            var sw = Stopwatch.StartNew();
+            var rng = new Random(42);
+            var input = RandomTensor(new[] { 1, 4, height, height }, rng);
+            var cond = attn ? RandomTensor(new[] { 1, 77, 768 }, rng) : null;
+            const int t = 500;
+
+            // Warm-up: lazy weight allocation + (if enabled) first-forward trace/compile.
+            // Excluded from timing so steady-state per-op cost is what we measure.
+            var sww = Stopwatch.StartNew();
             _ = predictor.PredictNoise(input, t, cond);
-            sw.Stop();
-            times[i] = sw.Elapsed.TotalMilliseconds;
+            sww.Stop();
+
+            var times = new double[reps];
+            for (int i = 0; i < reps; i++)
+            {
+                var sw = Stopwatch.StartNew();
+                _ = predictor.PredictNoise(input, t, cond);
+                sw.Stop();
+                times[i] = sw.Elapsed.TotalMilliseconds;
+            }
+            Array.Sort(times);
+            double median = times[reps / 2];
+            long pc = -1;
+            try { pc = predictor.ParameterCount; } catch { }
+            Console.WriteLine(
+                $"UNET base={baseCh} attn={attn} h={height} compile={compile} " +
+                $"maxdop={maxdop} procs={Environment.ProcessorCount} params={pc} " +
+                $"warmup_ms={sww.Elapsed.TotalMilliseconds:F0} median_ms={median:F1} min_ms={times[0]:F1}");
+            return 0;
         }
-        Array.Sort(times);
-        double median = times[reps / 2];
-        long pc = -1;
-        try { pc = predictor.ParameterCount; } catch { }
-        Console.WriteLine(
-            $"UNET base={baseCh} attn={attn} h={height} compile={compile} " +
-            $"maxdop={maxdop} procs={Environment.ProcessorCount} params={pc} " +
-            $"warmup_ms={sww.Elapsed.TotalMilliseconds:F0} median_ms={median:F1} min_ms={times[0]:F1}");
-        if (predictor is IDisposable d) d.Dispose();
-        return 0;
+        finally
+        {
+            if (predictor is IDisposable d) d.Dispose();
+        }
     }
 
     private static object? Construct(string modelName)


### PR DESCRIPTION
Adds a `--unet` mode to `DiffusionTraceProbe` that builds a runnable SD-UNet noise predictor and times a single `PredictNoise` forward at a chosen `MaxDegreeOfParallelism`. Sweeping `--maxdop 1..N` gives the speedup curve; speedup/N = parallel efficiency = effective core utilization for the diffusion op mix. Eager by default (`--compile 0`) so it measures per-op parallelism without the compiled-plan confound — the same path `Train()` uses. Knobs: `--base / --maxdop / --reps / --height / --attn / --compile`.

Preserves work that was sitting uncommitted in the `fix/ci-shard-model-fidelity` worktree (PR #1647, merged), rebased onto master. The relocated arg-parsing was reconciled with master's later-added `--correctness` / `--alloc-isolate` flags. The tool builds clean (0 errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an early command-line mode for running a specialized UNet performance probe.
  * The probe measures prediction latency over repeated runs and reports summary timing results, with optional model size details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->