### PR TITLE
fix(#1713): IPW Predict crash + Meissonic Train param-walk hang (timeouts that were hangs, not heavy)

### DIFF
--- a/src/CausalInference/CausalModelBase.cs
+++ b/src/CausalInference/CausalModelBase.cs
@@ -477,6 +477,43 @@ public abstract class CausalModelBase<T> : ICausalModel<T>, IModelShape
     }
 
     /// <summary>
+    /// Reconciles a Predict-time feature matrix with the [treatment | covariates] layout that
+    /// <see cref="Train(Matrix{T}, Vector{T})"/> consumes. Models fit through Train drop column 0
+    /// (the treatment indicator) before learning, so a later Predict handed the same matrix must
+    /// drop it too — otherwise the covariate count no longer matches the fitted parameters (the
+    /// #1713 InverseProbabilityWeighting coefficient-overrun). If <paramref name="input"/> already
+    /// has <see cref="NumFeatures"/> columns it is returned unchanged, so the covariate-only API
+    /// surface (e.g. EstimatePropensityScores called directly) keeps working.
+    /// </summary>
+    protected Matrix<T> ExtractCovariates(Matrix<T> input)
+    {
+        if (input.Columns == NumFeatures)
+        {
+            return input;
+        }
+
+        if (input.Columns == NumFeatures + 1)
+        {
+            int n = input.Rows;
+            var covariates = new Matrix<T>(n, NumFeatures);
+            for (int i = 0; i < n; i++)
+            {
+                for (int j = 0; j < NumFeatures; j++)
+                {
+                    covariates[i, j] = input[i, j + 1];
+                }
+            }
+            return covariates;
+        }
+
+        throw new ArgumentException(
+            $"Predict input has {input.Columns} columns but the model was fit with {NumFeatures} " +
+            $"covariates; expected {NumFeatures} (covariates only) or {NumFeatures + 1} " +
+            $"([treatment | covariates], matching Train).",
+            nameof(input));
+    }
+
+    /// <summary>
     /// Standard prediction - returns predicted outcomes.
     /// </summary>
     public abstract Vector<T> Predict(Matrix<T> input);

--- a/src/CausalInference/InverseProbabilityWeighting.cs
+++ b/src/CausalInference/InverseProbabilityWeighting.cs
@@ -673,7 +673,12 @@ public class InverseProbabilityWeighting<T> : CausalModelBase<T>
     /// </summary>
     public override Vector<T> Predict(Matrix<T> input)
     {
-        return EstimatePropensityScores(input);
+        // #1713: Train(X, Y) drops column 0 (the treatment indicator) before fitting the
+        // propensity model, so this IFullModel Predict path must reconcile the same
+        // [treatment | covariates] layout — otherwise the extra column overruns the fitted
+        // coefficient vector. ExtractCovariates passes covariate-only input through unchanged
+        // for callers that already supply just the covariates.
+        return EstimatePropensityScores(ExtractCovariates(input));
     }
 
     #region IFullModel Implementation

--- a/src/Diffusion/DiffusionModelBase.cs
+++ b/src/Diffusion/DiffusionModelBase.cs
@@ -1527,6 +1527,15 @@ public abstract class DiffusionModelBase<T> : IDiffusionModel<T>, IConfigurableM
             }
         }
 
+        // #1713: a Tensor<T> is a DATA LEAF — its scalar values are model parameters (already
+        // collected via the owning ITrainableLayer above), never a container of further layers.
+        // Descending into its backing storage and recursing element-by-element is the Meissonic
+        // hang: a 304M-parameter model walked one boxed scalar at a time (each added to the
+        // visited set). Stop at the tensor boundary. Tensor<T> fields are already skipped below,
+        // but tensors reached via Tensor<T>[] / List<Tensor<T>> / object-typed fields are not, so
+        // this guard is what actually closes the walk.
+        if (obj is Tensor<T>) return;
+
         // Recurse into every reference-type instance field so nested composites
         // (e.g., DiffusionModel -> UNetNoisePredictor -> List<Layer>) are fully
         // walked even when the intermediate types don't implement ITrainableLayer.
@@ -1561,8 +1570,15 @@ public abstract class DiffusionModelBase<T> : IDiffusionModel<T>, IConfigurableM
 
                 if (val is System.Collections.IEnumerable enumerable && val is not string)
                 {
-                    foreach (var item in enumerable)
-                        CollectLayerParameters(item, allParams, visited);
+                    // #1713: only descend into collections whose ELEMENTS could be layers/composites.
+                    // Skip value-type element collections (a layer's float[] weight buffer, a Tensor's
+                    // backing array, List<int> shapes, etc.) — iterating their scalar elements is
+                    // pathological on a foundation-scale model and never yields a layer.
+                    if (!EnumerableElementsAreValueTypes(val.GetType()))
+                    {
+                        foreach (var item in enumerable)
+                            CollectLayerParameters(item, allParams, visited);
+                    }
                 }
                 else
                 {
@@ -1570,6 +1586,34 @@ public abstract class DiffusionModelBase<T> : IDiffusionModel<T>, IConfigurableM
                 }
             }
         }
+    }
+
+    /// <summary>
+    /// #1713: true when <paramref name="enumerableType"/> is a collection of value-type elements
+    /// (e.g. <c>float[]</c>, <c>List&lt;int&gt;</c>, a tensor's scalar backing array). Such collections
+    /// hold data, not layers, so the trainable-parameter walk must not recurse element-by-element into
+    /// them — on a foundation-scale model that is millions of boxed scalars (the Meissonic Train hang).
+    /// A non-generic or reference-element enumerable returns false so genuine layer collections
+    /// (List&lt;ILayer&gt;, ITrainableLayer[]) are still walked.
+    /// </summary>
+    private static bool EnumerableElementsAreValueTypes(Type enumerableType)
+    {
+        if (enumerableType.IsArray)
+        {
+            var elem = enumerableType.GetElementType();
+            return elem is not null && elem.IsValueType;
+        }
+
+        foreach (var iface in enumerableType.GetInterfaces())
+        {
+            if (iface.IsGenericType &&
+                iface.GetGenericTypeDefinition() == typeof(System.Collections.Generic.IEnumerable<>))
+            {
+                return iface.GetGenericArguments()[0].IsValueType;
+            }
+        }
+
+        return false;
     }
 
     /// <summary>


### PR DESCRIPTION
Fixes the two #1713 CI timeouts that are hangs/crashes, not legitimately-heavy work (umbrella #1706; **not** tagged HeavyTimeout). Both root causes were found by **isolated reproduction**, not by shrinking tests.

## InverseProbabilityWeighting — dimension-mismatch crash
`CausalModelBase.Train(X, Y)` follows the `[treatment | covariates]` convention and drops column 0 before fitting the propensity model → `NumFeatures` covariates → `NumFeatures+1` coefficients. But `IPW.Predict` forwarded the **full** `[treatment | covariates]` matrix straight to `EstimatePropensityScores`, so `PredictPropensityWithCoefficients` indexed `coefficients[j+1]` one past the end → `ArgumentOutOfRangeException`. The unhandled exception (after `await Task.Yield()`) took down the async test host, surfacing as a shard timeout.

Diagnostic match: the 4 failing `CausalModelTestBase` tests all call `Predict`; the 2 that pass (`Metadata`, `Parameters`) don't.

**Fix:** new `CausalModelBase.ExtractCovariates` — drops column 0 when handed the Train-format `NumFeatures+1` matrix, and passes a `NumFeatures`-wide covariate matrix through unchanged so the `EstimatePropensityScores` API the integration tests call directly is untouched. `IPW.Predict` routes through it.

## Meissonic — runaway parameter-collection walk
The issue called `Metadata_ShouldExist` trivial, but it calls **`model.Train(input, target)`** first. `DiffusionModelBase.CollectLayerParameters` reflection-walks the model graph and only skipped fields typed *exactly* `Tensor<T>`. Tensors reached via `Tensor<T>[]` / `List<Tensor<T>>` / `object` fields were descended into, and their scalar backing arrays iterated **element-by-element** — millions of boxed scalars on the 304M-parameter E-MMDiT model, each added to the visited set. `Train` hung in `CollectTrainableParameters` (confirmed by two `dotnet-stack` samples 3s apart, both deep in `CollectLayerParameters`).

**Fix:** treat `Tensor<T>` as a data leaf (never descend into it — its values are already collected via the owning `ITrainableLayer.GetTrainableParameters`), and skip enumerables whose elements are value types (scalar buffers). Parameter **discovery is unchanged** — only data traversal is pruned.

## Verification (CPU, `AIDOTNET_DISABLE_GPU=1`)
- `InverseProbabilityWeighting` + `MeissonicModelTests.Metadata_ShouldExist` → **7 passed / 0 failed in 11s**.
- Meissonic `Train` now **7.2s** (was hanging >200s).
- Builds clean on **net10.0 and net471**.

Closes #1713.

🤖 Generated with [Claude Code](https://claude.com/claude-code)