### PR TITLE
test(ci): serialize ModelFamily TimeSeries/Activation/Loss shard (#1706)

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -743,6 +743,14 @@ jobs:
             'ModelFamily - NeuralNetworks O-R',
             'ModelFamily - NeuralNetworks S',
             'ModelFamily - NeuralNetworks T-Z',
+            # TimeSeries/Activation/Loss: the double-precision Transformer/CNN forecasters
+            # (Autoformer, Chronos, DeepANT, LSTM-VAE, ...) each fit the 60 s [Fact] budget in
+            # isolation (~15 s) but TIME OUT under the shard's default 4-way collection parallelism —
+            # their managed-engine forward parallelizes over all cores, so N classes in flight
+            # oversubscribe the runner's 4 cores and stall well past 60 s. Serialize so each runs
+            # uncontended with the whole machine (the contention is CPU, not paper-scale heaviness, so
+            # these stay in the default gate rather than HeavyTimeout). #1706/#1305.
+            'ModelFamily - TimeSeries/Activation/Loss',
             'ModelFamily - Code/Forecast/Segment/Survival',
             'Unit - 03a Diffusion Core/Schedulers/Encoding',
             'Unit - 03b Diffusion Models Control/DDPM/Preprocessor',


### PR DESCRIPTION
## Summary

Greens the **ModelFamily TimeSeries/Activation/Loss** shard for #1706 with a one-line CI change.

The double-precision Transformer/CNN forecasters in this shard — **Autoformer, ChronosFoundationModel, DeepANT, LSTM-VAE** — each fit the 60 s `[Fact]` timeout comfortably **in isolation** (~11–15 s locally), but **time out** in the full shard.

**Root cause: CPU oversubscription, not paper-scale heaviness.** Their managed-engine forward parallelizes over all cores; with the shard's default 4-way collection parallelism, several heavy classes run at once on the 4-core runner (N classes × N managed threads ≫ cores), so each forward stalls well past 60 s. The failing set even *shifts with scheduling* — a per-class serialization experiment only unmasked LSTM-VAE next — confirming the contention is shard-wide, not class-local.

**Fix:** add `'ModelFamily - TimeSeries/Activation/Loss'` to the existing `$heavyShards` list, so CI rewrites the built `xunit.runner.json` to `parallelizeTestCollections=false` / `maxParallelThreads=1`. This is the **same proven mechanism** the Diffusion / Generated-Layers / NeuralNetworks / Code-Forecast-Segment-Survival model-family shards already use. Each forward then runs uncontended with the whole machine and finishes in seconds.

Because the configs are deliberately tiny (this is contention, not inherent slowness), these tests **stay in the default gate** — this is *not* a HeavyTimeout deferral.

## Verification (local)

Mimicked the CI rewrite (`maxParallelThreads=1`, `parallelizeTestCollections=false`) on the build output, then ran the exact shard filter:

```
Passed!  -  Failed: 0, Passed: 731, Skipped: 0, Total: 731, Duration: 6 m 25 s
```

0 failures, 0 timeouts — well under the 45-min shard budget. (Confirmed the same 4 tests also pass individually in isolation at ~11–15 s each.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved build/test stability by treating one additional heavy test group as serialized, reducing resource pressure during CI runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->