### PR TITLE
fix(rl): implement real training for DDPG, TD3, MADDPG, Dreamer, World Models, MuZero

### DIFF
--- a/src/ReinforcementLearning/Agents/DDPGAgent.cs
+++ b/src/ReinforcementLearning/Agents/DDPGAgent.cs
@@ -227,10 +227,56 @@ public class DDPGAgent<T> : DeepReinforcementLearningAgentBase<T>
         }
 
         var batch = _replayBuffer.Sample(_options.BatchSize);
+        int n = batch.Count;
+        if (n == 0) return NumOps.Zero;
 
-        // Update critic and actor with tape-based training
-        T criticLoss = NumOps.Zero;
-        T actorLoss = NumOps.Zero;
+        int stateDim = _options.StateSize;
+        int actionDim = _options.ActionSize;
+        int saDim = stateDim + actionDim;
+        T gamma = _options.DiscountFactor;
+
+        // --- Critic update (Lillicrap et al. 2015) ---
+        // y = r + gamma*(1-done)*Q'(s', mu'(s')); regress the critic toward y.
+        var saInputs = new Tensor<T>([n, saDim]);
+        var yTargets = new Tensor<T>([n, 1]);
+        for (int i = 0; i < n; i++)
+        {
+            var exp = batch[i];
+            var nextA = _actorTargetNetwork.Predict(Tensor<T>.FromVector(exp.NextState)).ToVector();
+            var nextSA = Tensor<T>.FromVector(ConcatenateStateAction(exp.NextState, nextA));
+            T qNext = _criticTargetNetwork.Predict(nextSA).ToVector()[0];
+
+            T y = exp.Reward;
+            if (!exp.Done) y = NumOps.Add(y, NumOps.Multiply(gamma, qNext));
+
+            var saVec = ConcatenateStateAction(exp.State, exp.Action);
+            for (int j = 0; j < saDim; j++) saInputs[i, j] = saVec[j];
+            yTargets[i, 0] = y;
+        }
+        _criticNetwork.Train(saInputs, yTargets);
+        T criticLoss = _criticNetwork.GetLastLoss();
+
+        // --- Actor update via the deterministic policy gradient ---
+        // ∇θ J = E[∇a Q(s,a)|a=mu(s) · ∇θ mu(s)]. ComputeDDPGPolicyGradient returns −∇a Q (a loss
+        // gradient for gradient ASCENT on Q); the Q-ascending action target is therefore
+        // a − step·(−∇a Q) = a + step·∇a Q. Training the actor toward it realises the chain rule
+        // ∇θ mu through the network's MSE Train.
+        var actorInputs = new Tensor<T>([n, stateDim]);
+        var actorTargets = new Tensor<T>([n, actionDim]);
+        T stepSize = NumOps.FromDouble(0.05);
+        for (int i = 0; i < n; i++)
+        {
+            var s = batch[i].State;
+            var a = _actorNetwork.Predict(Tensor<T>.FromVector(s)).ToVector();
+            var negGrad = ComputeDDPGPolicyGradient(s, a);
+            for (int j = 0; j < stateDim; j++) actorInputs[i, j] = s[j];
+            for (int k = 0; k < actionDim; k++)
+                actorTargets[i, k] = MathHelper.Clamp<T>(
+                    NumOps.Subtract(a[k], NumOps.Multiply(stepSize, negGrad[k])),
+                    NumOps.FromDouble(-1.0), NumOps.FromDouble(1.0));
+        }
+        _actorNetwork.Train(actorInputs, actorTargets);
+        T actorLoss = _actorNetwork.GetLastLoss();
 
         // Soft update target networks
         SoftUpdateTargets();

--- a/src/ReinforcementLearning/Agents/DDPGAgent.cs
+++ b/src/ReinforcementLearning/Agents/DDPGAgent.cs
@@ -242,6 +242,16 @@ public class DDPGAgent<T> : DeepReinforcementLearningAgentBase<T>
         for (int i = 0; i < n; i++)
         {
             var exp = batch[i];
+            // Validate replay-sample shapes before any tensor write: StoreExperience() is a public
+            // input boundary, so a malformed transition would otherwise corrupt the critic inputs
+            // (saInputs) or throw deep inside the target-network forwards. Reject it with a clear message.
+            if (exp.State.Length != stateDim || exp.NextState.Length != stateDim || exp.Action.Length != actionDim)
+            {
+                throw new InvalidOperationException(
+                    $"DDPG replay experience has wrong dimensions; expected State={stateDim}, " +
+                    $"NextState={stateDim}, Action={actionDim} but got State={exp.State.Length}, " +
+                    $"NextState={exp.NextState.Length}, Action={exp.Action.Length}.");
+            }
             var nextA = _actorTargetNetwork.Predict(Tensor<T>.FromVector(exp.NextState)).ToVector();
             var nextSA = Tensor<T>.FromVector(ConcatenateStateAction(exp.NextState, nextA));
             T qNext = _criticTargetNetwork.Predict(nextSA).ToVector()[0];
@@ -263,7 +273,12 @@ public class DDPGAgent<T> : DeepReinforcementLearningAgentBase<T>
         // ∇θ mu through the network's MSE Train.
         var actorInputs = new Tensor<T>([n, stateDim]);
         var actorTargets = new Tensor<T>([n, actionDim]);
-        T stepSize = NumOps.FromDouble(0.05);
+        // DPG action-space ascent step for building the actor's regression target (Lillicrap et al.
+        // 2015). Named constant rather than a magic literal; deliberately distinct from the actor
+        // NETWORK's optimizer learning rate (_options.ActorLearningRate, already wired into
+        // _actorNetwork) — they play different roles and must not be conflated.
+        const double actorPolicyGradientStep = 0.05;
+        T stepSize = NumOps.FromDouble(actorPolicyGradientStep);
         for (int i = 0; i < n; i++)
         {
             var s = batch[i].State;

--- a/src/ReinforcementLearning/Agents/DreamerAgent.cs
+++ b/src/ReinforcementLearning/Agents/DreamerAgent.cs
@@ -206,6 +206,16 @@ public class DreamerAgent<T> : DeepReinforcementLearningAgentBase<T>
 
     public override void StoreExperience(Vector<T> observation, Vector<T> action, T reward, Vector<T> nextObservation, bool done)
     {
+        // Validate transition shapes at this public ingestion boundary so a malformed experience
+        // can't enter the replay buffer and later cause indexing / network-shape failures deep in
+        // Train() (building dynIn/repIn/rewIn/contIn).
+        if (observation.Length != _options.ObservationSize)
+            throw new ArgumentException($"Observation length must be {_options.ObservationSize}, got {observation.Length}.", nameof(observation));
+        if (nextObservation.Length != _options.ObservationSize)
+            throw new ArgumentException($"Next observation length must be {_options.ObservationSize}, got {nextObservation.Length}.", nameof(nextObservation));
+        if (action.Length != _options.ActionSize)
+            throw new ArgumentException($"Action length must be {_options.ActionSize}, got {action.Length}.", nameof(action));
+
         _replayBuffer.Add(new Experience<T, Vector<T>, Vector<T>>(observation, action, reward, nextObservation, done));
     }
 
@@ -273,9 +283,14 @@ public class DreamerAgent<T> : DeepReinforcementLearningAgentBase<T>
         var valTgt = new Tensor<T>([n, 1]);
         var actIn = new Tensor<T>([n, latentSize]);
         var actTgt = new Tensor<T>([n, actionDim]);
-        T step = NumOps.FromDouble(0.05);
-        T eps = NumOps.FromDouble(1e-3);
-        T twoEps = NumOps.FromDouble(2e-3);
+        // Named constants for the behaviour-learning hyperparameters (no magic literals). `step` is
+        // the deterministic-policy-gradient ascent step on the imagined value; `eps`/`twoEps` are the
+        // central finite-difference interval used to estimate ∇a q(z,a).
+        const double behaviorUpdateStep = 0.05;
+        const double finiteDifferenceEpsilon = 1e-3;
+        T step = NumOps.FromDouble(behaviorUpdateStep);
+        T eps = NumOps.FromDouble(finiteDifferenceEpsilon);
+        T twoEps = NumOps.FromDouble(2 * finiteDifferenceEpsilon);
         for (int i = 0; i < n; i++)
         {
             var z = latents[i];

--- a/src/ReinforcementLearning/Agents/DreamerAgent.cs
+++ b/src/ReinforcementLearning/Agents/DreamerAgent.cs
@@ -217,10 +217,95 @@ public class DreamerAgent<T> : DeepReinforcementLearningAgentBase<T>
         }
 
         var batch = _replayBuffer.Sample(_options.BatchSize);
+        int n = batch.Count;
+        if (n == 0) return NumOps.Zero;
 
-        // Tape-based training handles gradient computation
-        T worldModelLoss = NumOps.Zero;
-        T policyLoss = NumOps.Zero;
+        int obsSize = _options.ObservationSize;
+        int latentSize = _options.LatentSize;
+        int actionDim = _options.ActionSize;
+        T gamma = _options.DiscountFactor is not null ? _options.DiscountFactor : NumOps.FromDouble(0.99);
+
+        // ===== World-model learning (Hafner et al. 2020) =====
+        // Encode each observation to a latent, and train the predictive heads:
+        //   dynamics(z_t, a_t) -> z_{t+1};  reward(z_t) -> r_t;  continue(z_t) -> 1-done;
+        // and keep the encoder consistent with the dynamics (representation(o_{t+1}) -> z_pred).
+        var dynIn = new Tensor<T>([n, latentSize + actionDim]);
+        var dynTgt = new Tensor<T>([n, latentSize]);
+        var repIn = new Tensor<T>([n, obsSize]);
+        var repTgt = new Tensor<T>([n, latentSize]);
+        var rewIn = new Tensor<T>([n, latentSize]);
+        var rewTgt = new Tensor<T>([n, 1]);
+        var contIn = new Tensor<T>([n, latentSize]);
+        var contTgt = new Tensor<T>([n, 1]);
+        var latents = new Vector<T>[n];
+
+        for (int i = 0; i < n; i++)
+        {
+            var exp = batch[i];
+            var z = _representationNetwork.Predict(Tensor<T>.FromVector(exp.State)).ToVector();
+            var zNext = _representationNetwork.Predict(Tensor<T>.FromVector(exp.NextState)).ToVector();
+            var dynInput = ConcatenateVectors(z, exp.Action);
+            var zPred = _dynamicsNetwork.Predict(Tensor<T>.FromVector(dynInput)).ToVector();
+            latents[i] = z;
+
+            for (int j = 0; j < latentSize + actionDim; j++) dynIn[i, j] = dynInput[j];
+            for (int j = 0; j < latentSize; j++) dynTgt[i, j] = zNext[j];       // dynamics -> next latent
+            for (int j = 0; j < obsSize; j++) repIn[i, j] = exp.NextState[j];
+            for (int j = 0; j < latentSize; j++) repTgt[i, j] = zPred[j];        // encoder <-> dynamics consistency
+            for (int j = 0; j < latentSize; j++) rewIn[i, j] = z[j];
+            rewTgt[i, 0] = exp.Reward;                                           // reward(z) -> r
+            for (int j = 0; j < latentSize; j++) contIn[i, j] = z[j];
+            contTgt[i, 0] = exp.Done ? NumOps.Zero : NumOps.One;                 // continue(z) -> 1-done
+        }
+        _dynamicsNetwork.Train(dynIn, dynTgt);
+        _representationNetwork.Train(repIn, repTgt);
+        _rewardNetwork.Train(rewIn, rewTgt);
+        _continueNetwork.Train(contIn, contTgt);
+        T worldModelLoss = NumOps.Add(
+            NumOps.Add(_dynamicsNetwork.GetLastLoss(), _representationNetwork.GetLastLoss()),
+            NumOps.Add(_rewardNetwork.GetLastLoss(), _continueNetwork.GetLastLoss()));
+
+        // ===== Behaviour learning in imagination =====
+        // Value regresses toward the imagined discounted return; the actor is improved toward the
+        // action that increases the one-step imagined value q(z,a) = gamma * V(dynamics(z,a)) via the
+        // deterministic policy gradient (finite-difference ∇a q).
+        var valIn = new Tensor<T>([n, latentSize]);
+        var valTgt = new Tensor<T>([n, 1]);
+        var actIn = new Tensor<T>([n, latentSize]);
+        var actTgt = new Tensor<T>([n, actionDim]);
+        T step = NumOps.FromDouble(0.05);
+        T eps = NumOps.FromDouble(1e-3);
+        T twoEps = NumOps.FromDouble(2e-3);
+        for (int i = 0; i < n; i++)
+        {
+            var z = latents[i];
+            T imaginedReturn = ImagineTrajectory(z);
+            for (int j = 0; j < latentSize; j++) valIn[i, j] = z[j];
+            valTgt[i, 0] = imaginedReturn;
+
+            var a = _actorNetwork.Predict(Tensor<T>.FromVector(z)).ToVector();
+            var grad = new Vector<T>(actionDim);
+            for (int k = 0; k < actionDim; k++)
+            {
+                var aPlus = a.Clone();
+                var aMinus = a.Clone();
+                aPlus[k] = NumOps.Add(a[k], eps);
+                aMinus[k] = NumOps.Subtract(a[k], eps);
+                var zPlus = _dynamicsNetwork.Predict(Tensor<T>.FromVector(ConcatenateVectors(z, aPlus))).ToVector();
+                var zMinus = _dynamicsNetwork.Predict(Tensor<T>.FromVector(ConcatenateVectors(z, aMinus))).ToVector();
+                T vPlus = _valueNetwork.Predict(Tensor<T>.FromVector(zPlus)).ToVector()[0];
+                T vMinus = _valueNetwork.Predict(Tensor<T>.FromVector(zMinus)).ToVector()[0];
+                grad[k] = NumOps.Divide(NumOps.Multiply(gamma, NumOps.Subtract(vPlus, vMinus)), twoEps);
+            }
+            for (int j = 0; j < latentSize; j++) actIn[i, j] = z[j];
+            for (int k = 0; k < actionDim; k++)
+                actTgt[i, k] = MathHelper.Clamp<T>(
+                    NumOps.Add(a[k], NumOps.Multiply(step, grad[k])),
+                    NumOps.FromDouble(-1.0), NumOps.FromDouble(1.0));
+        }
+        _valueNetwork.Train(valIn, valTgt);
+        _actorNetwork.Train(actIn, actTgt);
+        T policyLoss = NumOps.Add(_valueNetwork.GetLastLoss(), _actorNetwork.GetLastLoss());
 
         _updateCount++;
 

--- a/src/ReinforcementLearning/Agents/MADDPGAgent.cs
+++ b/src/ReinforcementLearning/Agents/MADDPGAgent.cs
@@ -80,6 +80,12 @@ public class MADDPGAgent<T> : DeepReinforcementLearningAgentBase<T>
     private UniformReplayBuffer<T, Vector<T>, Vector<T>> _replayBuffer;
     private int _stepCount;
 
+    // Actor-update hyperparameters (named rather than magic literals). ActorGradientStepSize is the
+    // deterministic-policy-gradient ascent step; ActorFiniteDifferenceEpsilon is the central
+    // finite-difference interval used to estimate ∇_{a_i} Q_i (Lowe et al. 2017).
+    private const double ActorGradientStepSize = 0.05;
+    private const double ActorFiniteDifferenceEpsilon = 1e-3;
+
     // Track per-agent rewards for competitive/mixed-motive scenarios
     // Maps experience index to array of per-agent rewards
     private Dictionary<int, List<T>> _perAgentRewards;
@@ -292,6 +298,15 @@ public class MADDPGAgent<T> : DeepReinforcementLearningAgentBase<T>
 
     public override void StoreExperience(Vector<T> state, Vector<T> action, T reward, Vector<T> nextState, bool done)
     {
+        // Clear any per-agent reward override left at this buffer position by an earlier joint
+        // transition. _perAgentRewards is keyed only by replay index, so without this a scalar
+        // transition that reuses a circular-buffer slot would inherit the previous occupant's STALE
+        // per-agent rewards in Train(). Index computed exactly as StoreMultiAgentExperience does.
+        int bufferIndex = _replayBuffer.Count < _replayBuffer.Capacity
+            ? _replayBuffer.Count
+            : _stepCount % _replayBuffer.Capacity;
+        _perAgentRewards.Remove(bufferIndex);
+
         _replayBuffer.Add(new Experience<T, Vector<T>, Vector<T>>(state, action, reward, nextState, done));
         _stepCount++;
     }
@@ -313,12 +328,29 @@ public class MADDPGAgent<T> : DeepReinforcementLearningAgentBase<T>
         T gamma = DiscountFactor;
 
         // MADDPG trains on JOINT transitions stored by StoreMultiAgentExperience: the state is the
-        // concatenation of every agent's observation and the action of every agent's action. If the
-        // buffer holds non-joint transitions (e.g. a single-agent state vector passed through the
-        // generic StoreExperience), skip training rather than reading out of bounds.
-        if (n == 0 || batch[0].State.Length < numAgents * sd || batch[0].Action.Length < numAgents * ad)
+        // concatenation of every agent's observation and the action of every agent's action. Validate
+        // EVERY sampled item (not just batch[0]) and fail loudly on a non-joint transition (e.g. a
+        // single-agent vector passed through the generic StoreExperience) rather than silently
+        // no-op'ing or indexing out of bounds deep in the per-agent loops below.
+        int expectedJointState = numAgents * sd;
+        int expectedJointAction = numAgents * ad;
+        if (n == 0)
         {
             return NumOps.Zero;
+        }
+        for (int i = 0; i < n; i++)
+        {
+            var item = batch[i];
+            if (item.State.Length != expectedJointState ||
+                item.NextState.Length != expectedJointState ||
+                item.Action.Length != expectedJointAction)
+            {
+                throw new InvalidOperationException(
+                    $"{nameof(MADDPGAgent<T>)}.{nameof(Train)} requires joint transitions stored via " +
+                    $"{nameof(StoreMultiAgentExperience)}. Batch item {i} has state/action/next-state " +
+                    $"lengths {item.State.Length}/{item.Action.Length}/{item.NextState.Length}; expected " +
+                    $"{expectedJointState}/{expectedJointAction}/{expectedJointState}.");
+            }
         }
 
         T totalLoss = NumOps.Zero;
@@ -344,7 +376,19 @@ public class MADDPGAgent<T> : DeepReinforcementLearningAgentBase<T>
                 T qNext = _targetCriticNetworks[agentId].Predict(Tensor<T>.FromVector(targetCriticInput)).ToVector()[0];
 
                 T rI = exp.Reward;
-                if (_perAgentRewards.TryGetValue(indices[i], out var pr) && agentId < pr.Count) rI = pr[agentId];
+                if (_perAgentRewards.TryGetValue(indices[i], out var pr))
+                {
+                    // A per-agent reward override must cover EVERY agent; a partial list would
+                    // silently fall back to the averaged scalar reward for the later agents and
+                    // train their critics on inconsistent targets. Reject it loudly instead.
+                    if (pr.Count != numAgents)
+                    {
+                        throw new InvalidOperationException(
+                            $"Per-agent reward override for replay index {indices[i]} contains {pr.Count} " +
+                            $"rewards; expected {numAgents}.");
+                    }
+                    rI = pr[agentId];
+                }
                 T y = rI;
                 if (!exp.Done) y = NumOps.Add(y, NumOps.Multiply(gamma, qNext));
 
@@ -360,9 +404,9 @@ public class MADDPGAgent<T> : DeepReinforcementLearningAgentBase<T>
             // agents' actions fixed), then train actor_i toward the improved action. ---
             var actorInputs = new Tensor<T>([n, sd]);
             var actorTargets = new Tensor<T>([n, ad]);
-            T step = NumOps.FromDouble(0.05);
-            T eps = NumOps.FromDouble(1e-3);
-            T twoEps = NumOps.FromDouble(2e-3);
+            T step = NumOps.FromDouble(ActorGradientStepSize);
+            T eps = NumOps.FromDouble(ActorFiniteDifferenceEpsilon);
+            T twoEps = NumOps.FromDouble(2.0 * ActorFiniteDifferenceEpsilon);
             for (int i = 0; i < n; i++)
             {
                 var exp = batch[i];

--- a/src/ReinforcementLearning/Agents/MADDPGAgent.cs
+++ b/src/ReinforcementLearning/Agents/MADDPGAgent.cs
@@ -305,13 +305,95 @@ public class MADDPGAgent<T> : DeepReinforcementLearningAgentBase<T>
 
         // Sample batch with indices to retrieve per-agent rewards
         var (batch, indices) = _replayBuffer.SampleWithIndices(_options.BatchSize);
+        int n = batch.Count;
+        int numAgents = _options.NumAgents;
+        int sd = _options.StateSize;
+        int ad = _options.ActionSize;
+        int criticIn = (sd + ad) * numAgents;
+        T gamma = DiscountFactor;
+
+        // MADDPG trains on JOINT transitions stored by StoreMultiAgentExperience: the state is the
+        // concatenation of every agent's observation and the action of every agent's action. If the
+        // buffer holds non-joint transitions (e.g. a single-agent state vector passed through the
+        // generic StoreExperience), skip training rather than reading out of bounds.
+        if (n == 0 || batch[0].State.Length < numAgents * sd || batch[0].Action.Length < numAgents * ad)
+        {
+            return NumOps.Zero;
+        }
+
         T totalLoss = NumOps.Zero;
 
-        // Update each agent's critic and actor with tape-based training
-        for (int agentId = 0; agentId < _options.NumAgents; agentId++)
+        // Per-agent centralized-critic + decentralized-actor update (Lowe et al. 2017).
+        for (int agentId = 0; agentId < numAgents; agentId++)
         {
-            T criticLoss = NumOps.Zero;
-            T actorLoss = NumOps.Zero;
+            // --- Centralized critic update: y = r_i + gamma*(1-done)*Q'_i(x', a'_1..a'_N),
+            // a'_j = mu'_j(o'_j). Regress critic_i toward y on the stored (x, a_1..a_N). ---
+            var criticInputs = new Tensor<T>([n, criticIn]);
+            var yTargets = new Tensor<T>([n, 1]);
+            for (int i = 0; i < n; i++)
+            {
+                var exp = batch[i];
+                var jointNextAction = new Vector<T>(numAgents * ad);
+                for (int j = 0; j < numAgents; j++)
+                {
+                    var nextObsJ = SliceVector(exp.NextState, j * sd, sd);
+                    var aJ = _targetActorNetworks[j].Predict(Tensor<T>.FromVector(nextObsJ)).ToVector();
+                    for (int k = 0; k < ad; k++) jointNextAction[j * ad + k] = aJ[k];
+                }
+                var targetCriticInput = ConcatTwo(exp.NextState, jointNextAction);
+                T qNext = _targetCriticNetworks[agentId].Predict(Tensor<T>.FromVector(targetCriticInput)).ToVector()[0];
+
+                T rI = exp.Reward;
+                if (_perAgentRewards.TryGetValue(indices[i], out var pr) && agentId < pr.Count) rI = pr[agentId];
+                T y = rI;
+                if (!exp.Done) y = NumOps.Add(y, NumOps.Multiply(gamma, qNext));
+
+                var criticInput = ConcatTwo(exp.State, exp.Action);
+                for (int c = 0; c < criticIn; c++) criticInputs[i, c] = criticInput[c];
+                yTargets[i, 0] = y;
+            }
+            _criticNetworks[agentId].Train(criticInputs, yTargets);
+            T criticLoss = _criticNetworks[agentId].GetLastLoss();
+
+            // --- Decentralized actor update via the deterministic policy gradient: improve a_i in
+            // the direction ∇_{a_i} Q_i (estimated by central finite differences, holding the other
+            // agents' actions fixed), then train actor_i toward the improved action. ---
+            var actorInputs = new Tensor<T>([n, sd]);
+            var actorTargets = new Tensor<T>([n, ad]);
+            T step = NumOps.FromDouble(0.05);
+            T eps = NumOps.FromDouble(1e-3);
+            T twoEps = NumOps.FromDouble(2e-3);
+            for (int i = 0; i < n; i++)
+            {
+                var exp = batch[i];
+                var ownObs = SliceVector(exp.State, agentId * sd, sd);
+                var aI = _actorNetworks[agentId].Predict(Tensor<T>.FromVector(ownObs)).ToVector();
+
+                // Joint action with agent i's slot replaced by the current actor output.
+                var jointAction = exp.Action.Clone();
+                for (int k = 0; k < ad; k++) jointAction[agentId * ad + k] = aI[k];
+
+                var grad = new Vector<T>(ad);
+                for (int k = 0; k < ad; k++)
+                {
+                    var jaPlus = jointAction.Clone();
+                    var jaMinus = jointAction.Clone();
+                    jaPlus[agentId * ad + k] = NumOps.Add(jaPlus[agentId * ad + k], eps);
+                    jaMinus[agentId * ad + k] = NumOps.Subtract(jaMinus[agentId * ad + k], eps);
+                    T qPlus = _criticNetworks[agentId].Predict(Tensor<T>.FromVector(ConcatTwo(exp.State, jaPlus))).ToVector()[0];
+                    T qMinus = _criticNetworks[agentId].Predict(Tensor<T>.FromVector(ConcatTwo(exp.State, jaMinus))).ToVector()[0];
+                    grad[k] = NumOps.Divide(NumOps.Subtract(qPlus, qMinus), twoEps);
+                }
+
+                for (int j = 0; j < sd; j++) actorInputs[i, j] = ownObs[j];
+                for (int k = 0; k < ad; k++)
+                    actorTargets[i, k] = MathHelper.Clamp<T>(
+                        NumOps.Add(aI[k], NumOps.Multiply(step, grad[k])),
+                        NumOps.FromDouble(-1.0), NumOps.FromDouble(1.0));
+            }
+            _actorNetworks[agentId].Train(actorInputs, actorTargets);
+            T actorLoss = _actorNetworks[agentId].GetLastLoss();
+
             totalLoss = NumOps.Add(totalLoss, NumOps.Add(criticLoss, actorLoss));
 
             // Soft update target networks
@@ -320,6 +402,21 @@ public class MADDPGAgent<T> : DeepReinforcementLearningAgentBase<T>
         }
 
         return NumOps.Divide(totalLoss, NumOps.FromDouble(_options.NumAgents * 2));
+    }
+
+    private static Vector<T> SliceVector(Vector<T> v, int start, int length)
+    {
+        var result = new Vector<T>(length);
+        for (int i = 0; i < length; i++) result[i] = v[start + i];
+        return result;
+    }
+
+    private static Vector<T> ConcatTwo(Vector<T> a, Vector<T> b)
+    {
+        var result = new Vector<T>(a.Length + b.Length);
+        for (int i = 0; i < a.Length; i++) result[i] = a[i];
+        for (int i = 0; i < b.Length; i++) result[a.Length + i] = b[i];
+        return result;
     }
 
     private void SoftUpdateTargetNetwork(INeuralNetwork<T> source, INeuralNetwork<T> target)

--- a/src/ReinforcementLearning/Agents/MuZeroAgent.cs
+++ b/src/ReinforcementLearning/Agents/MuZeroAgent.cs
@@ -391,6 +391,16 @@ public class MuZeroAgent<T> : DeepReinforcementLearningAgentBase<T>
 
     public override void StoreExperience(Vector<T> observation, Vector<T> action, T reward, Vector<T> nextObservation, bool done)
     {
+        // Validate transition shapes at this public ingestion boundary so a malformed experience
+        // can't reach Train() (which indexes observations/actions per _options) and crash or build
+        // wrong policy/value targets.
+        if (observation.Length != _options.ObservationSize)
+            throw new ArgumentException($"Observation length must be {_options.ObservationSize}, got {observation.Length}.", nameof(observation));
+        if (nextObservation.Length != _options.ObservationSize)
+            throw new ArgumentException($"Next observation length must be {_options.ObservationSize}, got {nextObservation.Length}.", nameof(nextObservation));
+        if (action.Length != _options.ActionSize)
+            throw new ArgumentException($"Action length must be {_options.ActionSize}, got {action.Length}.", nameof(action));
+
         _replayBuffer.Add(new Experience<T, Vector<T>, Vector<T>>(observation, action, reward, nextObservation, done));
     }
 
@@ -420,6 +430,17 @@ public class MuZeroAgent<T> : DeepReinforcementLearningAgentBase<T>
         int latent = _options.LatentStateSize;
         int actionDim = _options.ActionSize;
         T gamma = DiscountFactor;
+        // This training path builds ONE-STEP recurrent targets. Honoring UnrollSteps > 1 requires
+        // sequence replay and per-unroll-step targets (Schrittwieser et al. 2020); rather than
+        // silently ignoring the configured value, fail fast so a user cannot believe they are
+        // training a multi-step unroll when they are not.
+        if (_options.UnrollSteps != 1)
+        {
+            throw new InvalidOperationException(
+                $"MuZeroAgent.Train currently builds one-step targets, but UnrollSteps is " +
+                $"{_options.UnrollSteps}. Implement sequence replay / unrolled targets before " +
+                "configuring UnrollSteps > 1.");
+        }
 
         // MuZero joint training (Schrittwieser et al. 2020): the representation, dynamics and
         // prediction networks are trained together. Earlier this method computed losses and built

--- a/src/ReinforcementLearning/Agents/MuZeroAgent.cs
+++ b/src/ReinforcementLearning/Agents/MuZeroAgent.cs
@@ -414,97 +414,65 @@ public class MuZeroAgent<T> : DeepReinforcementLearningAgentBase<T>
         // degrades gracefully to single-step updates when it isn't.
         int effectiveBatchSize = Math.Min(_replayBuffer.Count, _options.BatchSize);
         var batch = _replayBuffer.Sample(effectiveBatchSize);
-        T totalLoss = NumOps.Zero;
-        int lossCount = 0;
+        int n = batch.Count;
+        if (n == 0) return NumOps.Zero;
 
-        foreach (var experience in batch)
+        int latent = _options.LatentStateSize;
+        int actionDim = _options.ActionSize;
+        T gamma = DiscountFactor;
+
+        // MuZero joint training (Schrittwieser et al. 2020): the representation, dynamics and
+        // prediction networks are trained together. Earlier this method computed losses and built
+        // gradient tensors but never applied them, so the networks stayed frozen. Build the targets
+        // and apply real gradient steps through the tape-based Train(input, target).
+        var repIn = new Tensor<T>([n, _options.ObservationSize]);
+        var repTgt = new Tensor<T>([n, latent]);
+        var dynIn = new Tensor<T>([n, latent + actionDim]);
+        var dynTgt = new Tensor<T>([n, latent + 1]);
+        var predIn = new Tensor<T>([n, latent]);
+        var predTgt = new Tensor<T>([n, actionDim + 1]);
+
+        for (int i = 0; i < n; i++)
         {
-            // Step 1: Representation Network - encode initial observation to hidden state
-            var stateTensor = Tensor<T>.FromVector(experience.State);
-            var representationOutputTensor = _representationNetwork.Predict(stateTensor);
-            var hiddenState = representationOutputTensor.ToVector();
+            var exp = batch[i];
+            var hidden = _representationNetwork.Predict(Tensor<T>.FromVector(exp.State)).ToVector();
+            var nextHidden = _representationNetwork.Predict(Tensor<T>.FromVector(exp.NextState)).ToVector();
 
-            // Step 2: Prediction Network at initial state - predict policy and value
-            var predictionTensor = Tensor<T>.FromVector(hiddenState);
-            var predictionOutputTensor = _predictionNetwork.Predict(predictionTensor);
-            var prediction = predictionOutputTensor.ToVector();
-            var predictedValue = ExtractValue(prediction);
+            // Dynamics prediction g(h, a) -> (h', r); used for the encoder-consistency target.
+            var dynInput = ConcatenateVectors(hidden, exp.Action);
+            var dynOut = _dynamicsNetwork.Predict(Tensor<T>.FromVector(dynInput)).ToVector();
 
-            // Compute value loss for initial state
-            var valueTarget = experience.Done ? experience.Reward :
-                NumOps.Add(experience.Reward, NumOps.Multiply(DiscountFactor, predictedValue));
+            // Value target bootstraps off the prediction head at the next latent.
+            var nextPred = _predictionNetwork.Predict(Tensor<T>.FromVector(nextHidden)).ToVector();
+            T nextValue = ExtractValue(nextPred);
+            T valueTarget = exp.Done ? exp.Reward : NumOps.Add(exp.Reward, NumOps.Multiply(gamma, nextValue));
 
-            var valueDiff = NumOps.Subtract(valueTarget, predictedValue);
-            var valueLoss = NumOps.Multiply(valueDiff, valueDiff);
-            totalLoss = NumOps.Add(totalLoss, valueLoss);
-            lossCount++;
+            // Prediction head: policy toward the (MCTS-selected) action one-hot, value toward bootstrap.
+            for (int j = 0; j < latent; j++) predIn[i, j] = hidden[j];
+            for (int k = 0; k < actionDim; k++) predTgt[i, k] = k < exp.Action.Length ? exp.Action[k] : NumOps.Zero;
+            predTgt[i, actionDim] = valueTarget;
 
-            // Backpropagate prediction loss through prediction network
-            var predictionGradient = new Vector<T>(_options.ActionSize + 1);
-            predictionGradient[_options.ActionSize] = NumOps.Multiply(NumOps.FromDouble(2.0), valueDiff);
-            var predictionGradTensor = Tensor<T>.FromVector(predictionGradient);
+            // Dynamics: next latent = representation(o'), reward = r.
+            for (int j = 0; j < latent + actionDim; j++) dynIn[i, j] = dynInput[j];
+            for (int j = 0; j < latent; j++) dynTgt[i, j] = nextHidden[j];
+            dynTgt[i, latent] = exp.Reward;
 
-            // Step 3: Unroll dynamics for K steps
-            for (int k = 0; k < _options.UnrollSteps; k++)
-            {
-                // Dynamics Network: predict next hidden state and reward
-                var actionVec = experience.Action;
-                var dynamicsInput = ConcatenateVectors(hiddenState, actionVec);
-                var dynamicsInputTensor = Tensor<T>.FromVector(dynamicsInput);
-                var dynamicsOutputTensor = _dynamicsNetwork.Predict(dynamicsInputTensor);
-                var dynamicsOutput = dynamicsOutputTensor.ToVector();
-
-                // Extract predicted reward and next hidden state
-                var predictedReward = dynamicsOutput[_options.LatentStateSize];
-                var nextHiddenState = new Vector<T>(_options.LatentStateSize);
-                for (int i = 0; i < _options.LatentStateSize; i++)
-                {
-                    nextHiddenState[i] = dynamicsOutput[i];
-                }
-
-                // Compute reward loss
-                var rewardDiff = NumOps.Subtract(experience.Reward, predictedReward);
-                var rewardLoss = NumOps.Multiply(rewardDiff, rewardDiff);
-                totalLoss = NumOps.Add(totalLoss, rewardLoss);
-                lossCount++;
-
-                // Backpropagate reward loss through dynamics network
-                var dynamicsGradient = new Vector<T>(_options.LatentStateSize + 1);
-                dynamicsGradient[_options.LatentStateSize] = NumOps.Multiply(NumOps.FromDouble(2.0), rewardDiff);
-                var dynamicsGradTensor = Tensor<T>.FromVector(dynamicsGradient);
-
-                // Prediction Network at next state
-                var nextPredictionTensor = Tensor<T>.FromVector(nextHiddenState);
-                var nextPredictionOutputTensor = _predictionNetwork.Predict(nextPredictionTensor);
-                var nextPrediction = nextPredictionOutputTensor.ToVector();
-                var nextPredictedValue = ExtractValue(nextPrediction);
-
-                // Compute value loss for next state
-                var nextValueTarget = experience.Done ? NumOps.Zero : nextPredictedValue;
-                var nextValueDiff = NumOps.Subtract(nextValueTarget, nextPredictedValue);
-                var nextValueLoss = NumOps.Multiply(nextValueDiff, nextValueDiff);
-                totalLoss = NumOps.Add(totalLoss, nextValueLoss);
-                lossCount++;
-
-                // Backpropagate next state value loss through prediction network
-                var nextPredictionGradient = new Vector<T>(_options.ActionSize + 1);
-                nextPredictionGradient[_options.ActionSize] = NumOps.Multiply(NumOps.FromDouble(2.0), nextValueDiff);
-                var nextPredictionGradTensor = Tensor<T>.FromVector(nextPredictionGradient);
-
-                // Move to next state
-                hiddenState = nextHiddenState;
-            }
-
-            // Step 4: Backpropagate through representation network
-            // The representation gradient comes from the prediction network loss
-            var representationGradient = new Vector<T>(_options.LatentStateSize);
-            representationGradient[0] = NumOps.Multiply(NumOps.FromDouble(2.0), valueDiff);
-            var representationGradTensor = Tensor<T>.FromVector(representationGradient);
+            // Encoder/dynamics consistency: representation(o') toward the dynamics-predicted next latent.
+            for (int j = 0; j < _options.ObservationSize; j++) repIn[i, j] = exp.NextState[j];
+            for (int j = 0; j < latent; j++) repTgt[i, j] = dynOut[j];
         }
+
+        _predictionNetwork.Train(predIn, predTgt);
+        _dynamicsNetwork.Train(dynIn, dynTgt);
+        _representationNetwork.Train(repIn, repTgt);
+
+        T totalLoss = NumOps.Add(
+            NumOps.Add(_predictionNetwork.GetLastLoss(), _dynamicsNetwork.GetLastLoss()),
+            _representationNetwork.GetLastLoss());
 
         _updateCount++;
 
-        return lossCount > 0 ? NumOps.Divide(totalLoss, NumOps.FromDouble(lossCount)) : NumOps.Zero;
+        return totalLoss;
     }
 
 

--- a/src/ReinforcementLearning/Agents/TD3Agent.cs
+++ b/src/ReinforcementLearning/Agents/TD3Agent.cs
@@ -220,21 +220,102 @@ public class TD3Agent<T> : DeepReinforcementLearningAgentBase<T>
         }
 
         var batch = _replayBuffer.Sample(_options.BatchSize);
+        int n = batch.Count;
+        if (n == 0) return _numOps.Zero;
 
-        // Update critics and policy with tape-based training
-        T criticLoss = _numOps.Zero;
+        int stateDim = _options.StateSize;
+        int actionDim = _options.ActionSize;
+        int saDim = stateDim + actionDim;
+        T gamma = DiscountFactor;
 
-        // Delayed policy update
+        // --- Critic update (Fujimoto et al. 2018) ---
+        // Target action with policy smoothing: a' = clip(mu'(s') + clip(N(0,sigma), -c, c), -1, 1).
+        // Clipped double-Q target: y = r + gamma*(1-done)*min(Q'1(s',a'), Q'2(s',a')). Regress both
+        // critics toward y.
+        var saInputs = new Tensor<T>([n, saDim]);
+        var yTargets = new Tensor<T>([n, 1]);
+        for (int i = 0; i < n; i++)
+        {
+            var exp = batch[i];
+            var nextA = _targetActorNetwork.Predict(Tensor<T>.FromVector(exp.NextState)).ToVector();
+            for (int k = 0; k < actionDim; k++)
+            {
+                T noise = MathHelper.GetNormalRandom<T>(_numOps.Zero, _numOps.FromDouble(_options.TargetPolicyNoise));
+                noise = MathHelper.Clamp<T>(noise,
+                    _numOps.FromDouble(-_options.TargetNoiseClip), _numOps.FromDouble(_options.TargetNoiseClip));
+                nextA[k] = MathHelper.Clamp<T>(_numOps.Add(nextA[k], noise),
+                    _numOps.FromDouble(-1), _numOps.FromDouble(1));
+            }
+            var nextSA = Tensor<T>.FromVector(ConcatenateStateAction(exp.NextState, nextA));
+            T q1n = _targetCritic1Network.Predict(nextSA).ToVector()[0];
+            T q2n = _targetCritic2Network.Predict(nextSA).ToVector()[0];
+            T minN = _numOps.LessThan(q1n, q2n) ? q1n : q2n;
+
+            T y = exp.Reward;
+            if (!exp.Done) y = _numOps.Add(y, _numOps.Multiply(gamma, minN));
+
+            var saVec = ConcatenateStateAction(exp.State, exp.Action);
+            for (int j = 0; j < saDim; j++) saInputs[i, j] = saVec[j];
+            yTargets[i, 0] = y;
+        }
+        _critic1Network.Train(saInputs, yTargets);
+        _critic2Network.Train(saInputs, yTargets);
+        T criticLoss = _numOps.Divide(
+            _numOps.Add(_critic1Network.GetLastLoss(), _critic2Network.GetLastLoss()), _numOps.FromDouble(2));
+
+        // --- Delayed actor update via the deterministic policy gradient ---
+        // The DPG is ∇θ J = E[∇a Q1(s,a)|a=mu(s) · ∇θ mu(s)]. We obtain ∇a Q1 by central finite
+        // differences (the critic exposes no analytic input gradient) and realise the chain rule
+        // through the network's MSE Train: regressing the actor toward the Q-ascending target
+        // a + step·∇a Q1 makes its parameters move along ∇θ mu in the gradient-ascent direction.
         if (_updateCount % _options.PolicyUpdateFrequency == 0)
         {
+            var actorInputs = new Tensor<T>([n, stateDim]);
+            var actorTargets = new Tensor<T>([n, actionDim]);
+            T step = _numOps.FromDouble(0.05);
+            for (int i = 0; i < n; i++)
+            {
+                var s = batch[i].State;
+                var a = _actorNetwork.Predict(Tensor<T>.FromVector(s)).ToVector();
+                var g = FiniteDiffActionGradient(_critic1Network, s, a);
+                for (int j = 0; j < stateDim; j++) actorInputs[i, j] = s[j];
+                for (int k = 0; k < actionDim; k++)
+                    actorTargets[i, k] = MathHelper.Clamp<T>(
+                        _numOps.Add(a[k], _numOps.Multiply(step, g[k])),
+                        _numOps.FromDouble(-1), _numOps.FromDouble(1));
+            }
+            _actorNetwork.Train(actorInputs, actorTargets);
 
-            // Update target networks with soft updates
+            // Update target networks with soft updates (delayed, with the policy)
             SoftUpdateTargetNetworks();
         }
 
         _updateCount++;
 
         return criticLoss;
+    }
+
+    /// <summary>
+    /// Central finite-difference estimate of ∇a Q(s, a) — the action-gradient at the heart of the
+    /// deterministic policy gradient (Silver et al. 2014; Lillicrap et al. 2015). Used because the
+    /// critic network does not expose an analytic gradient w.r.t. its input.
+    /// </summary>
+    private Vector<T> FiniteDiffActionGradient(INeuralNetwork<T> critic, Vector<T> state, Vector<T> action)
+    {
+        var grad = new Vector<T>(action.Length);
+        T eps = _numOps.FromDouble(1e-3);
+        T twoEps = _numOps.FromDouble(2e-3);
+        for (int i = 0; i < action.Length; i++)
+        {
+            var aPlus = action.Clone();
+            var aMinus = action.Clone();
+            aPlus[i] = _numOps.Add(action[i], eps);
+            aMinus[i] = _numOps.Subtract(action[i], eps);
+            T qPlus = critic.Predict(Tensor<T>.FromVector(ConcatenateStateAction(state, aPlus))).ToVector()[0];
+            T qMinus = critic.Predict(Tensor<T>.FromVector(ConcatenateStateAction(state, aMinus))).ToVector()[0];
+            grad[i] = _numOps.Divide(_numOps.Subtract(qPlus, qMinus), twoEps);
+        }
+        return grad;
     }
 
     private void SoftUpdateTargetNetworks()

--- a/src/ReinforcementLearning/Agents/TD3Agent.cs
+++ b/src/ReinforcementLearning/Agents/TD3Agent.cs
@@ -63,6 +63,13 @@ public class TD3Agent<T> : DeepReinforcementLearningAgentBase<T>
 {
     private TD3Options<T> _options;
 
+    // Actor-update hyperparameters (named rather than magic literals). ActorPolicyGradientStep is the
+    // deterministic-policy-gradient ascent step on the action; FiniteDifferenceEpsilon is the central
+    // finite-difference interval used to estimate ∇a Q1 (the critic exposes no analytic input
+    // gradient). Distinct from the actor NETWORK optimizer's learning rate.
+    private const double ActorPolicyGradientStep = 0.05;
+    private const double FiniteDifferenceEpsilon = 1e-3;
+
     /// <inheritdoc/>
     public override ModelOptions GetOptions() => _options;
     private readonly INumericOperations<T> _numOps;
@@ -237,6 +244,16 @@ public class TD3Agent<T> : DeepReinforcementLearningAgentBase<T>
         for (int i = 0; i < n; i++)
         {
             var exp = batch[i];
+            // Validate replay-sample shapes before any tensor write/index: a malformed transition
+            // (wrong State/Action/NextState length) would otherwise crash tensor construction or
+            // train the twin critics on corrupted inputs.
+            if (exp.State.Length != stateDim || exp.NextState.Length != stateDim || exp.Action.Length != actionDim)
+            {
+                throw new InvalidOperationException(
+                    $"TD3 replay experience has wrong dimensions; expected State={stateDim}, " +
+                    $"NextState={stateDim}, Action={actionDim} but got State={exp.State.Length}, " +
+                    $"NextState={exp.NextState.Length}, Action={exp.Action.Length}.");
+            }
             var nextA = _targetActorNetwork.Predict(Tensor<T>.FromVector(exp.NextState)).ToVector();
             for (int k = 0; k < actionDim; k++)
             {
@@ -272,7 +289,7 @@ public class TD3Agent<T> : DeepReinforcementLearningAgentBase<T>
         {
             var actorInputs = new Tensor<T>([n, stateDim]);
             var actorTargets = new Tensor<T>([n, actionDim]);
-            T step = _numOps.FromDouble(0.05);
+            T step = _numOps.FromDouble(ActorPolicyGradientStep);
             for (int i = 0; i < n; i++)
             {
                 var s = batch[i].State;
@@ -303,8 +320,8 @@ public class TD3Agent<T> : DeepReinforcementLearningAgentBase<T>
     private Vector<T> FiniteDiffActionGradient(INeuralNetwork<T> critic, Vector<T> state, Vector<T> action)
     {
         var grad = new Vector<T>(action.Length);
-        T eps = _numOps.FromDouble(1e-3);
-        T twoEps = _numOps.FromDouble(2e-3);
+        T eps = _numOps.FromDouble(FiniteDifferenceEpsilon);
+        T twoEps = _numOps.FromDouble(2.0 * FiniteDifferenceEpsilon);
         for (int i = 0; i < action.Length; i++)
         {
             var aPlus = action.Clone();

--- a/src/ReinforcementLearning/Agents/WorldModelsAgent.cs
+++ b/src/ReinforcementLearning/Agents/WorldModelsAgent.cs
@@ -288,6 +288,16 @@ public class WorldModelsAgent<T> : DeepReinforcementLearningAgentBase<T>
 
     public override void StoreExperience(Vector<T> observation, Vector<T> action, T reward, Vector<T> nextObservation, bool done)
     {
+        // Validate transition shapes at this public input boundary so a malformed experience can't
+        // enter the replay buffer and later overflow rnnInput / encIn / decIn during Train().
+        int obsSize = _options.ObservationWidth * _options.ObservationHeight * _options.ObservationChannels;
+        if (observation.Length != obsSize)
+            throw new ArgumentException($"Observation length must be {obsSize}, got {observation.Length}.", nameof(observation));
+        if (nextObservation.Length != obsSize)
+            throw new ArgumentException($"Next observation length must be {obsSize}, got {nextObservation.Length}.", nameof(nextObservation));
+        if (action.Length != _options.ActionSize)
+            throw new ArgumentException($"Action length must be {_options.ActionSize}, got {action.Length}.", nameof(action));
+
         // Store using Experience<T, TState, TAction> which expects Vector<T>
         var experience = new Experience<T, Vector<T>, Vector<T>>(observation, action, reward, nextObservation, done);
         _replayBuffer.Add(experience);
@@ -375,29 +385,56 @@ public class WorldModelsAgent<T> : DeepReinforcementLearningAgentBase<T>
 
     private T TrainController()
     {
-        // Simplified Evolution Strategy for controller training
-        // Note: Full World Models uses CMA-ES; this is a basic (1+1)-ES approximation
+        // (1+1)-ES controller improvement (full World Models uses CMA-ES). The candidate objective
+        // MUST depend on the candidate weights — the previous version scored every candidate from the
+        // same replay rewards (independent of perturbedWeights), so the search never moved the
+        // controller and merely added a reward as "loss". Here each candidate is scored by
+        // REWARD-WEIGHTED behavior agreement: a controller that reproduces the actions taken on
+        // HIGH-reward transitions scores higher. This is a legitimate offline policy-improvement
+        // signal (advantage/reward-weighted behavior) and genuinely depends on the candidate policy.
 
         const int numCandidates = 5;
         const double perturbationScale = 0.01;
 
         var batch = _replayBuffer.Sample(Math.Min(10, _replayBuffer.Count));
+        if (batch.Count == 0) return NumOps.Zero;
 
-        // Evaluate current controller
-        T currentReward = NumOps.Zero;
-        foreach (var experience in batch)
+        // Pre-encode each batch state to its latent code once (the controller maps
+        // latent ⊕ zero-hidden -> action, mirroring Act()).
+        var zeroHidden = new Vector<T>(_options.RNNHiddenSize);
+        var controllerInputs = new Vector<T>[batch.Count];
+        for (int b = 0; b < batch.Count; b++)
         {
-            currentReward = NumOps.Add(currentReward, experience.Reward);
+            var z = ExtractMean(_vaeEncoder.Predict(Tensor<T>.FromVector(batch[b].State)).ToVector());
+            controllerInputs[b] = ConcatenateVectors(z, zeroHidden);
         }
-        currentReward = NumOps.Divide(currentReward, NumOps.FromDouble(batch.Count));
 
-        // Try random perturbations and keep the best one
+        // Score(weights) = mean over the batch of -reward · ||controller(z) - storedAction||²
+        // (higher = better: low action error on high-reward transitions). Depends on `weights`.
+        T ScoreCandidate(Matrix<T> weights)
+        {
+            T total = NumOps.Zero;
+            for (int b = 0; b < batch.Count; b++)
+            {
+                var input = controllerInputs[b];
+                T err = NumOps.Zero;
+                for (int i = 0; i < _options.ActionSize; i++)
+                {
+                    var col = new Vector<T>(input.Length);
+                    for (int j = 0; j < input.Length; j++) col[j] = weights[j, i];
+                    T act = MathHelper.Tanh<T>(Engine.DotProduct(input, col));
+                    T d = NumOps.Subtract(act, batch[b].Action[i]);
+                    err = NumOps.Add(err, NumOps.Multiply(d, d));
+                }
+                total = NumOps.Subtract(total, NumOps.Multiply(batch[b].Reward, err));
+            }
+            return NumOps.Divide(total, NumOps.FromDouble(batch.Count));
+        }
+
+        T bestScore = ScoreCandidate(_controllerWeights);
         Matrix<T>? bestWeights = null;
-        T bestReward = currentReward;
-
         for (int candidate = 0; candidate < numCandidates; candidate++)
         {
-            // Create perturbed weights
             var perturbedWeights = new Matrix<T>(_controllerWeights.Rows, _controllerWeights.Columns);
             for (int i = 0; i < _controllerWeights.Rows; i++)
             {
@@ -408,29 +445,35 @@ public class WorldModelsAgent<T> : DeepReinforcementLearningAgentBase<T>
                 }
             }
 
-            // Evaluate perturbed controller (simplified: use same batch)
-            T perturbedReward = NumOps.Zero;
-            foreach (var experience in batch)
+            T candidateScore = ScoreCandidate(perturbedWeights);
+            if (NumOps.GreaterThan(candidateScore, bestScore))
             {
-                perturbedReward = NumOps.Add(perturbedReward, experience.Reward);
-            }
-            perturbedReward = NumOps.Divide(perturbedReward, NumOps.FromDouble(batch.Count));
-
-            // Keep if better
-            if (NumOps.GreaterThan(perturbedReward, bestReward))
-            {
-                bestReward = perturbedReward;
+                bestScore = candidateScore;
                 bestWeights = perturbedWeights;
             }
         }
 
-        // Update controller weights if we found a better candidate
-        if (bestWeights is not null && !object.ReferenceEquals(bestWeights, null))
+        if (bestWeights is not null)
         {
             _controllerWeights = bestWeights;
         }
 
-        return bestReward;
+        // Return a clean, non-negative behavior LOSS for the chosen controller (mean unweighted
+        // action MSE over the batch) for the totalLoss aggregation — lower is better.
+        T lossTotal = NumOps.Zero;
+        for (int b = 0; b < batch.Count; b++)
+        {
+            var input = controllerInputs[b];
+            for (int i = 0; i < _options.ActionSize; i++)
+            {
+                var col = new Vector<T>(input.Length);
+                for (int j = 0; j < input.Length; j++) col[j] = _controllerWeights[j, i];
+                T act = MathHelper.Tanh<T>(Engine.DotProduct(input, col));
+                T d = NumOps.Subtract(act, batch[b].Action[i]);
+                lossTotal = NumOps.Add(lossTotal, NumOps.Multiply(d, d));
+            }
+        }
+        return NumOps.Divide(lossTotal, NumOps.FromDouble(batch.Count));
     }
 
     private Vector<T> ExtractMean(Vector<T> encoderOutput)
@@ -681,17 +724,16 @@ public class WorldModelsAgent<T> : DeepReinforcementLearningAgentBase<T>
 
     public override IFullModel<T, Vector<T>, Vector<T>> Clone()
     {
-        // The fresh constructor reproduces the VAE/RNN networks EXACTLY: their
-        // lazy weights initialize from the deterministic per-layer seeds, and
-        // Train() never updates them (only the controller is trained, via the
-        // evolution strategy). So the only state we must copy is the trained
-        // controller weights plus the rollout/bookkeeping fields.
-        //
-        // A serialization round-trip would instead REBUILD the networks' layers
-        // from the serialized graph, dropping the RandomSeed pins — the clone
-        // would then re-initialize to different weights and produce a different
-        // policy (Clone_ShouldProduceSamePolicy).
+        // The fresh constructor reproduces the VAE/RNN network ARCHITECTURE exactly (deterministic
+        // per-layer seeds), but Train() now UPDATES those networks' weights (the VAE encoder/decoder
+        // and the MDN-RNN are trained, not just the controller). So we must copy the learned network
+        // parameters onto the clone — otherwise it would keep the seed-initial weights and produce a
+        // different world model / policy than the trained original (Clone_ShouldProduceSamePolicy).
+        // GetParameters/SetParameters round-trip the network weights in-place WITHOUT rebuilding the
+        // layer graph, so the RandomSeed pins (and thus tensor shapes) are preserved — unlike a full
+        // serialization round-trip. The trained controller weights are copied separately below.
         var clone = new WorldModelsAgent<T>(_options);
+        clone.SetParameters(GetParameters());
 
         var controllerCopy = new Matrix<T>(_controllerWeights.Rows, _controllerWeights.Columns);
         for (int i = 0; i < _controllerWeights.Rows; i++)

--- a/src/ReinforcementLearning/Agents/WorldModelsAgent.cs
+++ b/src/ReinforcementLearning/Agents/WorldModelsAgent.cs
@@ -306,12 +306,65 @@ public class WorldModelsAgent<T> : DeepReinforcementLearningAgentBase<T>
             return NumOps.Zero;
         }
 
-        // Tape-based training handles gradient computation
+        var batch = _replayBuffer.Sample(_options.BatchSize);
+        int n = batch.Count;
         T vaeLoss = NumOps.Zero;
         T rnnLoss = NumOps.Zero;
+
+        if (n > 0)
+        {
+            int obsSize = _options.ObservationWidth * _options.ObservationHeight * _options.ObservationChannels;
+            int latentSize = _options.LatentSize;
+            int actionDim = _options.ActionSize;
+            int hiddenSize = _options.RNNHiddenSize;
+            int rnnInSize = latentSize + actionDim + hiddenSize;
+            int rnnOutSize = latentSize + hiddenSize;
+
+            var decIn = new Tensor<T>([n, latentSize]);
+            var decTgt = new Tensor<T>([n, obsSize]);
+            var rnnIn = new Tensor<T>([n, rnnInSize]);
+            var rnnTgt = new Tensor<T>([n, rnnOutSize]);
+            var encIn = new Tensor<T>([n, obsSize]);
+            var encTgt = new Tensor<T>([n, latentSize * 2]);
+            var zeroHidden = new Vector<T>(hiddenSize);
+
+            for (int i = 0; i < n; i++)
+            {
+                var exp = batch[i];
+                var mean = ExtractMean(_vaeEncoder.Predict(Tensor<T>.FromVector(exp.State)).ToVector());
+                var encNextOut = _vaeEncoder.Predict(Tensor<T>.FromVector(exp.NextState)).ToVector();
+                var meanNext = ExtractMean(encNextOut);
+
+                // MDN-RNN next-latent prediction: predict z_{t+1} from (z_t, a_t, h).
+                var rnnInput = ConcatenateVectors(ConcatenateVectors(mean, exp.Action), zeroHidden);
+                var rnnOut = _rnnNetwork.Predict(Tensor<T>.FromVector(rnnInput)).ToVector();
+
+                // VAE decoder reconstruction: D(z_t) -> o_t.
+                for (int j = 0; j < latentSize; j++) decIn[i, j] = mean[j];
+                for (int j = 0; j < obsSize && j < exp.State.Length; j++) decTgt[i, j] = exp.State[j];
+
+                // RNN target = its own output with the LATENT half steered toward z_{t+1}.
+                for (int j = 0; j < rnnInSize; j++) rnnIn[i, j] = rnnInput[j];
+                for (int j = 0; j < rnnOutSize; j++) rnnTgt[i, j] = rnnOut[j];
+                for (int j = 0; j < latentSize; j++) rnnTgt[i, j] = meanNext[j];
+
+                // Encoder consistency: steer E(o_{t+1}) mean toward the RNN's predicted next latent
+                // (keep its log-variance) so encoder and dynamics agree on the latent space.
+                for (int j = 0; j < obsSize && j < exp.NextState.Length; j++) encIn[i, j] = exp.NextState[j];
+                for (int j = 0; j < latentSize; j++) encTgt[i, j] = rnnOut[j];
+                for (int j = 0; j < latentSize; j++) encTgt[i, latentSize + j] = encNextOut[latentSize + j];
+            }
+
+            _vaeDecoder.Train(decIn, decTgt);
+            _vaeEncoder.Train(encIn, encTgt);
+            _rnnNetwork.Train(rnnIn, rnnTgt);
+            vaeLoss = NumOps.Add(_vaeDecoder.GetLastLoss(), _vaeEncoder.GetLastLoss());
+            rnnLoss = _rnnNetwork.GetLastLoss();
+        }
+
         T totalLoss = NumOps.Add(vaeLoss, rnnLoss);
 
-        // Train Controller (evolution strategy - simplified to gradient-based)
+        // Train Controller (evolution strategy - (1+1)-ES; full World Models uses CMA-ES)
         T controllerLoss = TrainController();
         totalLoss = NumOps.Add(totalLoss, controllerLoss);
 

--- a/tests/AiDotNet.Tests/UnitTests/ReinforcementLearning/ContinuousControlTrainingTests.cs
+++ b/tests/AiDotNet.Tests/UnitTests/ReinforcementLearning/ContinuousControlTrainingTests.cs
@@ -1,0 +1,97 @@
+using System;
+using System.Threading.Tasks;
+using AiDotNet.LinearAlgebra;
+using AiDotNet.Models.Options;
+using AiDotNet.ReinforcementLearning.Agents.DDPG;
+using AiDotNet.ReinforcementLearning.Agents.TD3;
+using AiDotNet.Tensors.Helpers;
+using Xunit;
+
+namespace AiDotNet.Tests.UnitTests.ReinforcementLearning;
+
+/// <summary>
+/// Regression tests for issue #1727: the deterministic actor-critic agents (DDPG, TD3) shipped a
+/// stubbed <c>Train()</c> that hardcoded its losses to zero and never updated the actor or critic
+/// networks — the agents did not learn. These tests fill a small replay buffer, run a few training
+/// steps, and assert the agent's parameters actually change and stay finite.
+/// </summary>
+public class ContinuousControlTrainingTests
+{
+    private const int StateDim = 4;
+    private const int ActionDim = 2;
+    private const int BatchSize = 16;
+
+    private static void FillBuffer(Action<Vector<double>, Vector<double>, double, Vector<double>, bool> store, int count)
+    {
+        var rng = RandomHelper.CreateSeededRandom(11);
+        for (int i = 0; i < count; i++)
+        {
+            var s = new Vector<double>(StateDim);
+            var ns = new Vector<double>(StateDim);
+            for (int j = 0; j < StateDim; j++)
+            {
+                s[j] = rng.NextDouble() * 2.0 - 1.0;
+                ns[j] = rng.NextDouble() * 2.0 - 1.0;
+            }
+            var a = new Vector<double>(ActionDim);
+            for (int k = 0; k < ActionDim; k++) a[k] = rng.NextDouble() * 2.0 - 1.0;
+            double reward = a[0] > 0.0 ? 1.0 : -1.0;
+            store(s, a, reward, ns, false);
+        }
+    }
+
+    private static bool ParametersChangedAndFinite(Vector<double> before, Vector<double> after)
+    {
+        Assert.Equal(before.Length, after.Length);
+        bool anyChanged = false;
+        for (int i = 0; i < after.Length; i++)
+        {
+            Assert.False(double.IsNaN(after[i]), $"Parameter {i} became NaN after training.");
+            Assert.False(double.IsInfinity(after[i]), $"Parameter {i} became infinite after training.");
+            if (Math.Abs(before[i] - after[i]) > 1e-9) anyChanged = true;
+        }
+        return anyChanged;
+    }
+
+    [Fact(Timeout = 60000)]
+    public async Task DDPG_Train_UpdatesParameters()
+    {
+        await Task.Yield();
+        var agent = new DDPGAgent<double>(new DDPGOptions<double>
+        {
+            StateSize = StateDim,
+            ActionSize = ActionDim,
+            BatchSize = BatchSize,
+            WarmupSteps = 0,
+        });
+        FillBuffer(agent.StoreExperience, BatchSize * 2);
+
+        var before = agent.GetParameters();
+        for (int step = 0; step < 10; step++) agent.Train();
+        var after = agent.GetParameters();
+
+        Assert.True(ParametersChangedAndFinite(before, after),
+            "DDPGAgent parameters did not change after training — Train() is not applying a gradient step.");
+    }
+
+    [Fact(Timeout = 60000)]
+    public async Task TD3_Train_UpdatesParameters()
+    {
+        await Task.Yield();
+        var agent = new TD3Agent<double>(new TD3Options<double>
+        {
+            StateSize = StateDim,
+            ActionSize = ActionDim,
+            BatchSize = BatchSize,
+            WarmupSteps = 0,
+        });
+        FillBuffer(agent.StoreExperience, BatchSize * 2);
+
+        var before = agent.GetParameters();
+        for (int step = 0; step < 10; step++) agent.Train();
+        var after = agent.GetParameters();
+
+        Assert.True(ParametersChangedAndFinite(before, after),
+            "TD3Agent parameters did not change after training — Train() is not applying a gradient step.");
+    }
+}

--- a/tests/AiDotNet.Tests/UnitTests/ReinforcementLearning/ModelBasedAndMultiAgentTrainingTests.cs
+++ b/tests/AiDotNet.Tests/UnitTests/ReinforcementLearning/ModelBasedAndMultiAgentTrainingTests.cs
@@ -1,0 +1,138 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using AiDotNet.LinearAlgebra;
+using AiDotNet.Models.Options;
+using AiDotNet.ReinforcementLearning.Agents.Dreamer;
+using AiDotNet.ReinforcementLearning.Agents.MADDPG;
+using AiDotNet.ReinforcementLearning.Agents.WorldModels;
+using AiDotNet.Tensors.Helpers;
+using Xunit;
+
+namespace AiDotNet.Tests.UnitTests.ReinforcementLearning;
+
+/// <summary>
+/// Regression tests for issue #1727: MADDPG, Dreamer, and World Models shipped a stubbed
+/// <c>Train()</c> whose losses were hardcoded to zero so their networks were never updated.
+/// These tests fill each agent's buffer with the kind of transition it expects, run a few
+/// training steps, and assert the agent's parameters actually change and stay finite.
+/// </summary>
+public class ModelBasedAndMultiAgentTrainingTests
+{
+    private static Vector<double> Rand(Random rng, int dim)
+    {
+        var v = new Vector<double>(dim);
+        for (int i = 0; i < dim; i++) v[i] = rng.NextDouble() * 2.0 - 1.0;
+        return v;
+    }
+
+    private static bool ParametersChangedAndFinite(Vector<double> before, Vector<double> after)
+    {
+        Assert.Equal(before.Length, after.Length);
+        bool anyChanged = false;
+        for (int i = 0; i < after.Length; i++)
+        {
+            Assert.False(double.IsNaN(after[i]), $"Parameter {i} became NaN after training.");
+            Assert.False(double.IsInfinity(after[i]), $"Parameter {i} became infinite after training.");
+            if (Math.Abs(before[i] - after[i]) > 1e-9) anyChanged = true;
+        }
+        return anyChanged;
+    }
+
+    [Fact(Timeout = 60000)]
+    public async Task MADDPG_Train_UpdatesParameters()
+    {
+        await Task.Yield();
+        const int numAgents = 2, stateDim = 4, actionDim = 2, batch = 8;
+        var agent = new MADDPGAgent<double>(new MADDPGOptions<double>
+        {
+            NumAgents = numAgents,
+            StateSize = stateDim,
+            ActionSize = actionDim,
+            BatchSize = batch,
+            WarmupSteps = 0,
+        });
+        var rng = RandomHelper.CreateSeededRandom(3);
+        for (int t = 0; t < batch * 2; t++)
+        {
+            var states = new List<Vector<double>>();
+            var actions = new List<Vector<double>>();
+            var rewards = new List<double>();
+            var nextStates = new List<Vector<double>>();
+            for (int a = 0; a < numAgents; a++)
+            {
+                var act = Rand(rng, actionDim);
+                states.Add(Rand(rng, stateDim));
+                actions.Add(act);
+                rewards.Add(act[0] > 0 ? 1.0 : -1.0);
+                nextStates.Add(Rand(rng, stateDim));
+            }
+            agent.StoreMultiAgentExperience(states, actions, rewards, nextStates, false);
+        }
+
+        var before = agent.GetParameters();
+        for (int step = 0; step < 10; step++) agent.Train();
+        var after = agent.GetParameters();
+
+        Assert.True(ParametersChangedAndFinite(before, after),
+            "MADDPGAgent parameters did not change after training — Train() is not applying a gradient step.");
+    }
+
+    [Fact(Timeout = 60000)]
+    public async Task Dreamer_Train_UpdatesParameters()
+    {
+        await Task.Yield();
+        const int obs = 4, actionDim = 2, batch = 8;
+        var agent = new DreamerAgent<double>(new DreamerOptions<double>
+        {
+            ObservationSize = obs,
+            ActionSize = actionDim,
+            LatentSize = 16,
+            ImaginationHorizon = 3,
+            BatchSize = batch,
+        });
+        var rng = RandomHelper.CreateSeededRandom(5);
+        for (int t = 0; t < batch * 2; t++)
+        {
+            var a = Rand(rng, actionDim);
+            agent.StoreExperience(Rand(rng, obs), a, a[0] > 0 ? 1.0 : -1.0, Rand(rng, obs), false);
+        }
+
+        var before = agent.GetParameters();
+        for (int step = 0; step < 5; step++) agent.Train();
+        var after = agent.GetParameters();
+
+        Assert.True(ParametersChangedAndFinite(before, after),
+            "DreamerAgent parameters did not change after training — Train() is not applying a gradient step.");
+    }
+
+    [Fact(Timeout = 60000)]
+    public async Task WorldModels_Train_UpdatesParameters()
+    {
+        await Task.Yield();
+        const int obs = 4, actionDim = 2, batch = 8;
+        var agent = new WorldModelsAgent<double>(new WorldModelsOptions<double>
+        {
+            ObservationWidth = obs,
+            ObservationHeight = 1,
+            ObservationChannels = 1,
+            ActionSize = actionDim,
+            LatentSize = 8,
+            RNNHiddenSize = 8,
+            BatchSize = batch,
+        });
+        var rng = RandomHelper.CreateSeededRandom(9);
+        for (int t = 0; t < batch * 2; t++)
+        {
+            var a = Rand(rng, actionDim);
+            agent.StoreExperience(Rand(rng, obs), a, a[0] > 0 ? 1.0 : -1.0, Rand(rng, obs), false);
+        }
+
+        var before = agent.GetParameters();
+        for (int step = 0; step < 5; step++) agent.Train();
+        var after = agent.GetParameters();
+
+        Assert.True(ParametersChangedAndFinite(before, after),
+            "WorldModelsAgent parameters did not change after training — Train() is not applying a gradient step.");
+    }
+}

--- a/tests/AiDotNet.Tests/UnitTests/ReinforcementLearning/ModelBasedAndMultiAgentTrainingTests.cs
+++ b/tests/AiDotNet.Tests/UnitTests/ReinforcementLearning/ModelBasedAndMultiAgentTrainingTests.cs
@@ -5,6 +5,7 @@ using AiDotNet.LinearAlgebra;
 using AiDotNet.Models.Options;
 using AiDotNet.ReinforcementLearning.Agents.Dreamer;
 using AiDotNet.ReinforcementLearning.Agents.MADDPG;
+using AiDotNet.ReinforcementLearning.Agents.MuZero;
 using AiDotNet.ReinforcementLearning.Agents.WorldModels;
 using AiDotNet.Tensors.Helpers;
 using Xunit;
@@ -134,5 +135,33 @@ public class ModelBasedAndMultiAgentTrainingTests
 
         Assert.True(ParametersChangedAndFinite(before, after),
             "WorldModelsAgent parameters did not change after training — Train() is not applying a gradient step.");
+    }
+
+    [Fact(Timeout = 60000)]
+    public async Task MuZero_Train_UpdatesParameters()
+    {
+        await Task.Yield();
+        const int obs = 4, actionDim = 2, batch = 8;
+        var agent = new MuZeroAgent<double>(new MuZeroOptions<double>
+        {
+            ObservationSize = obs,
+            ActionSize = actionDim,
+            LatentStateSize = 16,
+            BatchSize = batch,
+        });
+        var rng = RandomHelper.CreateSeededRandom(13);
+        for (int t = 0; t < batch * 2; t++)
+        {
+            var a = new Vector<double>(actionDim);
+            a[rng.Next(actionDim)] = 1.0; // one-hot action
+            agent.StoreExperience(Rand(rng, obs), a, rng.NextDouble(), Rand(rng, obs), false);
+        }
+
+        var before = agent.GetParameters();
+        for (int step = 0; step < 5; step++) agent.Train();
+        var after = agent.GetParameters();
+
+        Assert.True(ParametersChangedAndFinite(before, after),
+            "MuZeroAgent parameters did not change after training — Train() builds gradients but never applies them.");
     }
 }

--- a/tests/AiDotNet.Tests/UnitTests/ReinforcementLearning/ModelBasedAndMultiAgentTrainingTests.cs
+++ b/tests/AiDotNet.Tests/UnitTests/ReinforcementLearning/ModelBasedAndMultiAgentTrainingTests.cs
@@ -13,7 +13,7 @@ using Xunit;
 namespace AiDotNet.Tests.UnitTests.ReinforcementLearning;
 
 /// <summary>
-/// Regression tests for issue #1727: MADDPG, Dreamer, and World Models shipped a stubbed
+/// Regression tests for issue #1727: MADDPG, Dreamer, World Models, and MuZero shipped a stubbed
 /// <c>Train()</c> whose losses were hardcoded to zero so their networks were never updated.
 /// These tests fill each agent's buffer with the kind of transition it expects, run a few
 /// training steps, and assert the agent's parameters actually change and stay finite.


### PR DESCRIPTION
## What

Implements the actual training step for five RL agents whose `Train()` was a **no-op stub** (losses hardcoded to zero, networks never updated — the agents did not learn).

### Deterministic actor-critic
- **DDPGAgent** (Lillicrap et al. 2015) — critic Bellman regression; actor via the deterministic policy gradient (the existing finite-difference `∇a Q` helper, finally wired in).
- **TD3Agent** (Fujimoto et al. 2018) — clipped double-Q target with target-policy smoothing, delayed finite-diff DPG actor update.
- **MADDPGAgent** (Lowe et al. 2017) — per-agent **centralized** critic Bellman over the joint observation + all agents' actions (next actions from the target actors) and a **decentralized** finite-diff DPG actor (holding the other agents' actions fixed). Guards against non-joint input so the single-agent path can't crash.

The deterministic policy gradient `∇a Q` is estimated by central finite differences (the critic exposes no analytic input gradient) and realised through the network's MSE `Train` toward the Q-ascending action target `a + step·∇a Q` — the chain rule `∇θ μ` falls out of training the actor toward that target.

### Model-based
- **DreamerAgent** (Hafner et al. 2020) — world-model learning (dynamics → next latent, reward, continue, encoder/dynamics consistency) + imagination behaviour learning (value toward the imagined return; actor by finite-diff DPG on the one-step imagined value).
- **WorldModelsAgent** (Ha & Schmidhuber 2018) — VAE decoder reconstruction + encoder/dynamics consistency + MDN-RNN next-latent prediction. (The controller (1+1)-ES was already implemented.)

> `SACAgent` was checked and is **already correctly implemented** (real `TrainWithCustomLoss` SAC actor + soft TD targets) — left untouched.

## Why

The offline slice of this stubbed-`Train()` cluster (CQL, IQL) was fixed in #1724; this PR finishes the actor-critic / model-based slice. Triage: #1726.

## Tests

- `tests/.../ReinforcementLearning/ContinuousControlTrainingTests.cs` — DDPG, TD3.
- `tests/.../ReinforcementLearning/ModelBasedAndMultiAgentTrainingTests.cs` — MADDPG, Dreamer, World Models.

Each fills the agent's buffer with the transitions it expects, runs a few training steps, and asserts the parameters change and stay finite. **5/5 passing.** `src` builds clean on net10.0 and net471.

Closes #1727

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Reinforcement learning training now performs real parameter updates for several agents, including DDPG, TD3, MADDPG, Dreamer, World Models, and MuZero.
  * Continuous-control and model-based agents now use more complete batch training behavior, improving learning from replayed experience.

* **Tests**
  * Added regression tests to verify these agents update parameters during training.
  * Tests also check that trained values remain finite and do not become `NaN` or `Infinity`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->