### PR TITLE
fix(models): DCGAN training stability + UnifiedMultimodal streaming collision (#1737, #1738)

### DIFF
--- a/src/NeuralNetworks/DCGAN.cs
+++ b/src/NeuralNetworks/DCGAN.cs
@@ -169,6 +169,30 @@ public class DCGAN<T> : GenerativeAdversarialNetwork<T>
         _imageWidth = imageWidth;
         _generatorFeatureMaps = generatorFeatureMaps;
         _discriminatorFeatureMaps = discriminatorFeatureMaps;
+
+        // DCGAN paper Adam (Radford et al. 2016 §4: lr=2e-4, β1=0.5) on the optimizer the
+        // networks ACTUALLY train through — NeuralNetworkBase.GetOrCreateBaseOptimizer,
+        // which otherwise hands back the generic Adam(1e-3, β1=0.9). The generic rate plus
+        // β1=0.9's heavy momentum destabilizes the adversarial game (the GAN-level
+        // _generator/_discriminatorOptimizer fields are NOT on this train path, so they
+        // can't carry the paper hyperparameters; the network base optimizer is the one).
+        ((NeuralNetworkBase<T>)Generator).SetBaseTrainOptimizer(
+            new AiDotNet.Optimizers.AdamOptimizer<T, Tensor<T>, Tensor<T>>(Generator,
+                new AiDotNet.Models.Options.AdamOptimizerOptions<T, Tensor<T>, Tensor<T>>
+                { InitialLearningRate = 0.0002, Beta1 = 0.5, UseAMSGrad = false }));
+        ((NeuralNetworkBase<T>)Discriminator).SetBaseTrainOptimizer(
+            new AiDotNet.Optimizers.AdamOptimizer<T, Tensor<T>, Tensor<T>>(Discriminator,
+                new AiDotNet.Models.Options.AdamOptimizerOptions<T, Tensor<T>, Tensor<T>>
+                { InitialLearningRate = 0.0002, Beta1 = 0.5, UseAMSGrad = false }));
+
+        // Gradient penalty on the discriminator (Gulrajani et al. 2017; advocated for
+        // standard, non-Wasserstein GANs by Mescheder et al. 2018, "Which Training Methods
+        // for GANs do actually Converge?"). It enforces an approximately 1-Lipschitz
+        // discriminator, bounding its logits so it cannot run away and drive the
+        // generator's non-saturating loss −log σ(D(G(z))) to explode (the observed
+        // step1≈2 → step100≈700+ blow-up on the single-pair memorization task). Reuses the
+        // existing tape-tracked penalty path in GenerativeAdversarialNetwork.Train.
+        EnableGradientPenalty();
     }
 
     /// <summary>

--- a/src/NeuralNetworks/NeuralNetworkBase.cs
+++ b/src/NeuralNetworks/NeuralNetworkBase.cs
@@ -5655,15 +5655,31 @@ public abstract class NeuralNetworkBase<T> : INeuralNetworkModel<T>, IInterpreta
         // unified). The enable itself is latched in Predict (guaranteed inference mode
         // there, so it is correct regardless of whether this finalize ran from a
         // training- or inference-mode call) keyed on _streamingEngagedByAutoDetect.
-        ConfigureWeightLifetime(options);
-        // Declare the default (inference) execution mode so the zero-copy mmap
-        // fast path is eligible immediately — a freshly-built model is in
-        // inference mode until Train() flips it via SetTrainingMode(true), which
-        // forwards the training state here and correctly disables zero-copy
-        // (training writes weights; the mmap alias is read-only).
-        SetStreamingExecutionTrainingIfSupported(IsTrainingMode);
-        _streamingEngagedByAutoDetect = true;
-        _streamingAutoDetectFinalized = true;
+        //
+        // Claim the process-global, single-tenant streaming registry ATOMICALLY. The early
+        // RegisteredEntryCount==0 guard above is only a fast path; on its own it is TOCTOU — two
+        // foundation-scale models constructing concurrently could both observe an empty registry and
+        // then both reach ConfigureWeightLifetime, the second of which throws ("existing streaming
+        // pool has N registered entries") or clobbers the first model's pool. Re-check the count
+        // under a process-wide gate immediately around the configure+finalize so exactly one model
+        // claims streaming; a racer that lost cleanly DECLINES (runs in-memory) instead of throwing.
+        lock (WeightStreamingAutoDetectGate.Sync)
+        {
+            if (WeightRegistry.GetStreamingReport().RegisteredEntryCount > 0)
+            {
+                _streamingAutoDetectFinalized = true;
+                return;
+            }
+            ConfigureWeightLifetime(options);
+            // Declare the default (inference) execution mode so the zero-copy mmap
+            // fast path is eligible immediately — a freshly-built model is in
+            // inference mode until Train() flips it via SetTrainingMode(true), which
+            // forwards the training state here and correctly disables zero-copy
+            // (training writes weights; the mmap alias is read-only).
+            SetStreamingExecutionTrainingIfSupported(IsTrainingMode);
+            _streamingEngagedByAutoDetect = true;
+            _streamingAutoDetectFinalized = true;
+        }
     }
 
     /// <summary>
@@ -11421,5 +11437,18 @@ public abstract class NeuralNetworkBase<T> : INeuralNetworkModel<T>, IInterpreta
 
     #endregion
 
+}
+
+/// <summary>
+/// Process-wide gate that serializes the weight-streaming auto-detect claim on the single-tenant,
+/// process-global <c>WeightRegistry</c>. NON-generic on purpose: a static field inside the generic
+/// <see cref="NeuralNetworkBase{T}"/> gets a SEPARATE instance per closed type
+/// (<c>&lt;float&gt;</c> vs <c>&lt;double&gt;</c>), which would let two models of different element
+/// types both win the "registry is empty" race and both configure the shared pool. Every model
+/// type locks on this single object so exactly one auto-detect claim configures streaming at a time.
+/// </summary>
+internal static class WeightStreamingAutoDetectGate
+{
+    internal static readonly object Sync = new();
 }
 

--- a/src/NeuralNetworks/NeuralNetworkBase.cs
+++ b/src/NeuralNetworks/NeuralNetworkBase.cs
@@ -5581,6 +5581,22 @@ public abstract class NeuralNetworkBase<T> : INeuralNetworkModel<T>, IInterpreta
             return;
         }
 
+        // Don't clobber a WeightRegistry another model instance is already using. The
+        // streaming pool is process-global and single-tenant: WeightRegistry.Configure
+        // throws ("existing streaming pool has N registered entries") if it already holds
+        // another model's registered weights. That happens whenever two foundation-scale
+        // models are live at once in one process — most commonly a model AND its Clone()
+        // (e.g. MoreData_ShouldNotDegrade trains an original and a clone; UnifiedMultimodal
+        // hit exactly this). Streaming is a memory optimization, not a correctness
+        // requirement, so the second model gracefully DECLINES it and runs in-memory
+        // instead of throwing. Mirrors the identical guard in NoisePredictorBase.
+        // Sequential tests start from a clean registry via ResetWeightStreamingForTests (#1722).
+        if (WeightRegistry.GetStreamingReport().RegisteredEntryCount > 0)
+        {
+            _streamingAutoDetectFinalized = true;
+            return;
+        }
+
         // Above threshold: enable streaming with conservative defaults.
         // The locked design (#1222 weight-streaming v1) calls for LZ4
         // compression on the disk-backing store and a prefetch window of

--- a/tests/AiDotNet.Tests/ModelFamilyTests/NeuralNetworks/UnifiedMultimodalNetworkTests.cs
+++ b/tests/AiDotNet.Tests/ModelFamilyTests/NeuralNetworks/UnifiedMultimodalNetworkTests.cs
@@ -5,6 +5,18 @@ using AiDotNet.Tests.ModelFamilyTests.Base;
 
 namespace AiDotNet.Tests.ModelFamilyTests.NeuralNetworks;
 
+// UnifiedMultimodalNetwork is foundation-scale (768-dim embeddings, 12 transformer layers
+// plus text/image/audio/video encoders + cross-modal attention + decoders — over the 500M
+// streaming threshold). Its multi-iteration training invariants (MoreData_ShouldNotDegrade
+// trains 50 + 200 steps across an original AND a clone) are CORRECT but inherently exceed
+// the 120s default per-test gate under single-threaded determinism BLAS — verified a genuine
+// timeout (the test runs the full 120s, no hang/exception), not a regression. Per the #1706
+// strategy these are tagged HeavyTimeout: excluded from the default PR gate (Category!=HeavyTimeout)
+// and run full-fidelity in the nightly heavy lane (deferred, not skipped; graduates back once
+// the foundation forward is fast enough). The separate WeightRegistry single-tenant collision
+// this model also hit (original + clone both auto-streaming) is fixed at the source in
+// NeuralNetworkBase.TryAutoEnableWeightStreaming (decline streaming when the pool is occupied). #1738.
+[Xunit.Trait("Category", "HeavyTimeout")]
 public class UnifiedMultimodalNetworkTests : NeuralNetworkModelTestBase<float>
 {
     // Default: inputSize=768 (embedding dim), outputSize=100


### PR DESCRIPTION
## Summary
Fixes the two genuinely-live model bugs from the #1623 sweep (the other 30/32 listed models already pass on master — see the triage comment on #1623). Both turned out to be infrastructure-level; fixed paper-faithfully with existing infra, no tweak-to-pass.

## #1737 — DCGAN generator-loss explosion
`DCGANTests.LossStrictlyDecreasesOnMemorizationTask` exploded ~300× (discriminator runaway). Two real causes, both fixed in the DCGAN ctor:
- **Wrong training optimizer.** The Generator/Discriminator *networks* train via `NeuralNetworkBase.GetOrCreateBaseOptimizer`, which defaulted to the generic `Adam(lr=1e-3, β1=0.9)` — not the DCGAN paper `Adam(2e-4, β1=0.5)` (Radford et al. 2016). The GAN-level optimizer fields aren't on this path. Now configured via `SetBaseTrainOptimizer` on each network.
- **Discriminator logit runaway.** Enabled the existing discriminator **gradient penalty** (Gulrajani et al. 2017; advocated for standard non-Wasserstein GANs by Mescheder et al. 2018) to enforce an approximately 1-Lipschitz discriminator, bounding its logits.

✅ **DCGAN 25/25** (was 24/25).

## #1738 — UnifiedMultimodal weight-streaming collision
`MoreData_ShouldNotDegrade` threw `WeightRegistry.Configure: existing streaming pool has 22 registered entries`: it trains an original **and** its clone, and both foundation-scale instances auto-enabled streaming against the single-tenant, process-global `WeightRegistry`.
- **Source fix:** `NeuralNetworkBase.TryAutoEnableWeightStreaming` now declines streaming (graceful in-memory fallback) when the pool is already occupied — mirroring the identical guard already in `NoisePredictorBase`. Streaming is a memory optimization, not a correctness requirement, so the second model runs in-memory instead of throwing. Single-model streaming behavior is unchanged (the guard only fires when the registry is already occupied, which previously threw).
- **HeavyTimeout:** with the collision gone, the model's training is genuine foundation-scale compute (768-dim, 12 transformer layers + 4 modality encoders) — verified a real 120s timeout, not a hang — so its test class is tagged `HeavyTimeout` per the #1706 strategy (excluded from the default PR gate, run in the nightly heavy lane; deferred, not skipped).

## Verification (net10.0, `AIDOTNET_DISABLE_GPU=1`, serialized)
- `DCGANTests` — 25/25 ✅ (incl. the previously-failing `LossStrictlyDecreasesOnMemorizationTask`).
- `UnifiedMultimodalNetworkTests` — excluded from the default gate (`Category!=HeavyTimeout` matches 0); registry collision no longer thrown.
- Regression batch (InfoGAN/GraphIsomorphism/NEAT/TinyBERTNER/AudioLDM/MemoryNetwork/HTMNetwork) — 27/27 ✅ (registry guard is benign for non-occupied single-model paths).
- Build: 0 errors.

Closes #1737
Closes #1738
Refs #1623


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved GAN training stability by using consistent optimizer settings and enabling gradient penalty during setup.
  * Prevented weight-streaming conflicts when multiple model instances are active at the same time, reducing runtime errors.

* **Tests**
  * Marked a long-running multimodal network test suite for heavier timeout handling so it runs in the appropriate nightly lane.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->