### PR TITLE
test(diffusion): HeavyTimeout-tag 5 verified compute-bound models

### DIFF
--- a/tests/AiDotNet.Tests/ModelFamilyTests/Diffusion/ARDiffusionModelTests.cs
+++ b/tests/AiDotNet.Tests/ModelFamilyTests/Diffusion/ARDiffusionModelTests.cs
@@ -4,6 +4,10 @@ using AiDotNet.Tests.ModelFamilyTests.Base;
 
 namespace AiDotNet.Tests.ModelFamilyTests.Diffusion;
 
+// Compute-bound foundation-scale autoregressive diffusion: the training probe
+// exceeds the 120s [Fact(Timeout)] in isolation (verified), so it belongs in the
+// HeavyTimeout nightly lane rather than the default PR gate (#1706/#1305).
+[Xunit.Trait("Category", "HeavyTimeout")]
 public class ARDiffusionModelTests : DiffusionModelTestBase<float>
 {
     protected override int[] InputShape => [1, 8, 32, 32];

--- a/tests/AiDotNet.Tests/ModelFamilyTests/Diffusion/MoMaskModelTests.cs
+++ b/tests/AiDotNet.Tests/ModelFamilyTests/Diffusion/MoMaskModelTests.cs
@@ -4,6 +4,10 @@ using AiDotNet.Tests.ModelFamilyTests.Base;
 
 namespace AiDotNet.Tests.ModelFamilyTests.Diffusion;
 
+// Compute-bound foundation-scale motion-generation diffusion: the training probe
+// exceeds the 120s [Fact(Timeout)] in isolation (verified), so it belongs in the
+// HeavyTimeout nightly lane rather than the default PR gate (#1706/#1305).
+[Xunit.Trait("Category", "HeavyTimeout")]
 public class MoMaskModelTests : DiffusionModelTestBase<float>
 {
     protected override int[] InputShape => [1, 4, 32, 32];

--- a/tests/AiDotNet.Tests/ModelFamilyTests/Diffusion/PixArtDeltaLCMModelTests.cs
+++ b/tests/AiDotNet.Tests/ModelFamilyTests/Diffusion/PixArtDeltaLCMModelTests.cs
@@ -4,6 +4,10 @@ using AiDotNet.Tests.ModelFamilyTests.Base;
 
 namespace AiDotNet.Tests.ModelFamilyTests.Diffusion;
 
+// Compute-bound foundation-scale DiT/LCM: the training probe exceeds the 120s
+// [Fact(Timeout)] in isolation (verified), so it belongs in the HeavyTimeout
+// nightly lane rather than the default PR gate (#1706/#1305).
+[Xunit.Trait("Category", "HeavyTimeout")]
 public class PixArtDeltaLCMModelTests : DiffusionModelTestBase<float>
 {
     protected override int[] InputShape => [1, 4, 32, 32];

--- a/tests/AiDotNet.Tests/ModelFamilyTests/Diffusion/PlaygroundV3ModelTests.cs
+++ b/tests/AiDotNet.Tests/ModelFamilyTests/Diffusion/PlaygroundV3ModelTests.cs
@@ -4,6 +4,10 @@ using AiDotNet.Tests.ModelFamilyTests.Base;
 
 namespace AiDotNet.Tests.ModelFamilyTests.Diffusion;
 
+// Compute-bound foundation-scale model: the training probe exceeds the 120s
+// [Fact(Timeout)] in isolation (verified), so it belongs in the HeavyTimeout
+// nightly lane rather than the default PR gate (#1706/#1305).
+[Xunit.Trait("Category", "HeavyTimeout")]
 public class PlaygroundV3ModelTests : DiffusionModelTestBase<float>
 {
     protected override int[] InputShape => [1, 16, 32, 32];

--- a/tests/AiDotNet.Tests/ModelFamilyTests/Diffusion/SiDDiTModelTests.cs
+++ b/tests/AiDotNet.Tests/ModelFamilyTests/Diffusion/SiDDiTModelTests.cs
@@ -4,6 +4,10 @@ using AiDotNet.Tests.ModelFamilyTests.Base;
 
 namespace AiDotNet.Tests.ModelFamilyTests.Diffusion;
 
+// Compute-bound foundation-scale DiT: the training probe exceeds the 120s
+// [Fact(Timeout)] in isolation (verified), so it belongs in the HeavyTimeout
+// nightly lane rather than the default PR gate (#1706/#1305).
+[Xunit.Trait("Category", "HeavyTimeout")]
 public class SiDDiTModelTests : DiffusionModelTestBase<float>
 {
     protected override int[] InputShape => [1, 4, 32, 32];


### PR DESCRIPTION
## What
Tags 5 diffusion model test classes `[Trait("Category","HeavyTimeout")]` so the default PR shard gate (which filters `&Category!=HeavyTimeout`) skips them and the nightly HeavyTimeout lane runs them instead — unblocking the diffusion shards from these models' 120s training timeouts.

**Tagged (verified compute-bound — exceed the 120s `[Fact(Timeout)]` training probe IN ISOLATION, one model per process):**
`PixArtDeltaLCM`, `PlaygroundV3`, `ARDiffusion`, `MoMask`, `SiDDiT`

## Discipline: what was deliberately NOT tagged
Several models that timed out in the *parallel* family run **pass solo in ~10–15s** — they're not compute-bound, they were starved/OOM'd by the concurrent run. Tagging them would wrongly hide passing tests, so they're left alone:
`DreamFusion, InstructVid2Vid, CogVideo, VideoCrafter2, FateZero, FlowVid`

Their parallel-only failure is the **AiDotNet.Tensors #714** foundation-memory bug (WeightRegistry streaming-pool accumulation → ~18 GB OOM-hang), not a per-model cost — fixing #714 is what greens *those*.

## Verification
- Builds clean (net10.0).
- Exclusion confirmed: `FullyQualifiedName~PixArtDeltaLCMModelTests&Category!=HeavyTimeout` → **0 tests matched** after tagging.
- Each tagged model's 120s timeout reproduced in isolation; each non-tagged model's pass reproduced in isolation.

## Scope
First pass over the compute-bound diffusion models surfaced so far. Exhaustive enumeration of *every* heavy diffusion model is itself blocked by #714 (the full family can't complete a parallel run to enumerate them), so further tags will follow as CI surfaces them. Part of the #1706 / #1305 shard-greening effort.

🤖 Generated with [Claude Code](https://claude.com/claude-code)