### PR TITLE
test(cv): HeavyTimeout-tag the 70-model seg-training class; document CV shard OOM is #714

### DIFF
--- a/tests/AiDotNet.Tests/IntegrationTests/ComputerVision/SegmentationTrainingRobustnessTests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/ComputerVision/SegmentationTrainingRobustnessTests.cs
@@ -27,14 +27,12 @@ namespace AiDotNet.Tests.IntegrationTests.ComputerVision;
 /// backward pass gradient flow, and training with unbatched inputs.
 /// </summary>
 // #1754/#1706: this class constructs and TRAINS 70 foundation-scale SAM/ViT/Swin-family segmentation
-// models one per test. As the class docstring below notes, committed memory accumulates across the
-// class's tests (InferenceWeightCache + un-compacted LOH + the process-global WeightRegistry streaming
-// pool, AiDotNet.Tensors #714) until the runner OOMs mid-shard and dies with a shutdown signal — so the
-// whole "Integration C - ComputerVision" shard never completes and is perpetually red. This is genuine
-// foundation-scale TRAINING cost, not a per-test bug, so route the class to the HeavyTimeout nightly
-// lane: the default PR gate filters `&Category!=HeavyTimeout` and completes on the fast forward/shape
-// robustness CV tests, while these run nightly. Durable fix is Tensors #714 (weak-refs / pressure-evict).
-[Xunit.Trait("Category", "HeavyTimeout")]
+// models (one per test); committed memory accumulates across the class until the runner OOMs and the
+// "Integration C - ComputerVision" shard dies with a shutdown signal. Genuine foundation-scale training
+// cost, not a per-test bug (retention sources detailed in the class docstring below), so route the class
+// to the HeavyTimeout nightly lane; the default PR gate excludes HeavyTimeout and completes on the fast
+// forward/shape CV tests. Durable fix: AiDotNet.Tensors #714 (weak-refs / pressure-evict).
+[Trait("Category", "HeavyTimeout")]
 public class SegmentationTrainingRobustnessTests : IDisposable
 {
     // These tests construct and TRAIN heavy SAM/ViT-family segmentation models one per test. Two

--- a/tests/AiDotNet.Tests/IntegrationTests/ComputerVision/SegmentationTrainingRobustnessTests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/ComputerVision/SegmentationTrainingRobustnessTests.cs
@@ -26,6 +26,15 @@ namespace AiDotNet.Tests.IntegrationTests.ComputerVision;
 /// Tests training robustness: multi-step training, predict-after-train consistency,
 /// backward pass gradient flow, and training with unbatched inputs.
 /// </summary>
+// #1754/#1706: this class constructs and TRAINS 70 foundation-scale SAM/ViT/Swin-family segmentation
+// models one per test. As the class docstring below notes, committed memory accumulates across the
+// class's tests (InferenceWeightCache + un-compacted LOH + the process-global WeightRegistry streaming
+// pool, AiDotNet.Tensors #714) until the runner OOMs mid-shard and dies with a shutdown signal — so the
+// whole "Integration C - ComputerVision" shard never completes and is perpetually red. This is genuine
+// foundation-scale TRAINING cost, not a per-test bug, so route the class to the HeavyTimeout nightly
+// lane: the default PR gate filters `&Category!=HeavyTimeout` and completes on the fast forward/shape
+// robustness CV tests, while these run nightly. Durable fix is Tensors #714 (weak-refs / pressure-evict).
+[Xunit.Trait("Category", "HeavyTimeout")]
 public class SegmentationTrainingRobustnessTests : IDisposable
 {
     // These tests construct and TRAIN heavy SAM/ViT-family segmentation models one per test. Two


### PR DESCRIPTION
Part of #1754 / #1706. Sheds the dominant OOM load from the `Integration C - ComputerVision` shard and precisely characterizes the remaining root cause.

## What
Tags `SegmentationTrainingRobustnessTests` `[Trait("Category","HeavyTimeout")]` — it trains **70** foundation-scale SAM/ViT/Swin seg models one-per-test (**151 train calls**, by far the heaviest single contributor). The default PR gate (`&Category!=HeavyTimeout`) now sheds it; it runs in the nightly lane.

## Honest finding: this alone does NOT green the shard
Verified locally: with the 70-model class excluded, the remaining CV shard **still OOM-hangs (~20 GB)**. The other ~10 CV classes each have only 1–4 train calls, yet foundation seg models are instantiated (forward **and** train) throughout, and **every instantiation registers weights in the process-global `WeightRegistry` which is never released** (AiDotNet.Tensors **#714**). That accumulation is pervasive — tagging every foundation-model CV class would gut the gate's CV coverage.

## Path to fully green
- **Durable:** AiDotNet.Tensors #714 (WeightRegistry weak-refs / pressure-evict).
- **Interim alternative:** a shard-wide `WeightRegistry.Reset()` in each CV integration test's teardown (distinct from #1742's ModelFamily-gate reset). Can add if preferred over waiting on #714.

This commit is the correct, high-value first step (dominant load → nightly) without over-tagging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)