### PR TITLE
test(ci): green 2 OOM-cancelled diffusion shards (SA-SD + 03b Control) via HeavyTimeout

### DIFF
--- a/tests/AiDotNet.Tests/ModelFamilyTests/Diffusion/SANAModelTests.cs
+++ b/tests/AiDotNet.Tests/ModelFamilyTests/Diffusion/SANAModelTests.cs
@@ -4,6 +4,12 @@ using AiDotNet.Tests.ModelFamilyTests.Base;
 
 namespace AiDotNet.Tests.ModelFamilyTests.Diffusion;
 
+// HeavyTimeout (#1706): instantiated at full default (paper) scale — a single model's construct +
+// forward/train probe peak exceeds the 16 GB PR runner, which SIGTERM-cancelled the SA-SD shard.
+// Runs in the nightly HeavyTimeout lane; the default gate filters Category!=HeavyTimeout. Drop once
+// it fits the per-test budget (e.g. via a tiny same-architecture injection like SDXLTurbo).
+[Xunit.Collection("FoundationScaleSerial")]
+[Xunit.Trait("Category", "HeavyTimeout")]
 public class SANAModelTests : DiffusionModelTestBase<float>
 {
     protected override int[] InputShape => [1, 32, 64, 64];

--- a/tests/AiDotNet.Tests/ModelFamilyTests/Diffusion/SANAModelTests.cs
+++ b/tests/AiDotNet.Tests/ModelFamilyTests/Diffusion/SANAModelTests.cs
@@ -4,11 +4,9 @@ using AiDotNet.Tests.ModelFamilyTests.Base;
 
 namespace AiDotNet.Tests.ModelFamilyTests.Diffusion;
 
-// HeavyTimeout (#1706): instantiated at full default (paper) scale — a single model's construct +
-// forward/train probe peak exceeds the 16 GB PR runner, which SIGTERM-cancelled the SA-SD shard.
-// Runs in the nightly HeavyTimeout lane; the default gate filters Category!=HeavyTimeout. Drop once
-// it fits the per-test budget (e.g. via a tiny same-architecture injection like SDXLTurbo).
 [Xunit.Collection("FoundationScaleSerial")]
+// HeavyTimeout: foundation-scale diffusion (video / paper-scale); correct but a single
+// forward x N-step Generate exceeds the 120 s per-test gate. Runs in the nightly lane.
 [Xunit.Trait("Category", "HeavyTimeout")]
 public class SANAModelTests : DiffusionModelTestBase<float>
 {

--- a/tests/AiDotNet.Tests/ModelFamilyTests/Diffusion/SANASprintModelTests.cs
+++ b/tests/AiDotNet.Tests/ModelFamilyTests/Diffusion/SANASprintModelTests.cs
@@ -4,6 +4,12 @@ using AiDotNet.Tests.ModelFamilyTests.Base;
 
 namespace AiDotNet.Tests.ModelFamilyTests.Diffusion;
 
+// HeavyTimeout (#1706): instantiated at full default (paper) scale — a single model's construct +
+// forward/train probe peak exceeds the 16 GB PR runner, which SIGTERM-cancelled the SA-SD shard.
+// Runs in the nightly HeavyTimeout lane; the default gate filters Category!=HeavyTimeout. Drop once
+// it fits the per-test budget (e.g. via a tiny same-architecture injection like SDXLTurbo).
+[Xunit.Collection("FoundationScaleSerial")]
+[Xunit.Trait("Category", "HeavyTimeout")]
 public class SANASprintModelTests : DiffusionModelTestBase<float>
 {
     protected override int[] InputShape => [1, 32, 32, 32];

--- a/tests/AiDotNet.Tests/ModelFamilyTests/Diffusion/SASTDModelTests.cs
+++ b/tests/AiDotNet.Tests/ModelFamilyTests/Diffusion/SASTDModelTests.cs
@@ -5,6 +5,9 @@ using AiDotNet.Tests.ModelFamilyTests.Base;
 namespace AiDotNet.Tests.ModelFamilyTests.Diffusion;
 
 [Xunit.Collection("FoundationScaleSerial")] // dedicated cores (#1622 L4)
+// HeavyTimeout (#1706): full default (paper) scale — single-model peak exceeds the 16 GB PR runner,
+// which SIGTERM-cancelled the SA-SD shard. Runs in the nightly lane (gate filters Category!=HeavyTimeout).
+[Xunit.Trait("Category", "HeavyTimeout")]
 public class SASTDModelTests : DiffusionModelTestBase<float>
 {
     // SD-based latent diffusion: 4 channels, 64x64 latent (512x512 images / 8x VAE)

--- a/tests/AiDotNet.Tests/ModelFamilyTests/Diffusion/SCottModelTests.cs
+++ b/tests/AiDotNet.Tests/ModelFamilyTests/Diffusion/SCottModelTests.cs
@@ -5,6 +5,9 @@ using AiDotNet.Tests.ModelFamilyTests.Base;
 namespace AiDotNet.Tests.ModelFamilyTests.Diffusion;
 
 [Xunit.Collection("FoundationScaleSerial")] // dedicated cores (#1622 L4)
+// HeavyTimeout (#1706): full default (paper) scale — single-model peak exceeds the 16 GB PR runner,
+// which SIGTERM-cancelled the SA-SD shard. Runs in the nightly lane (gate filters Category!=HeavyTimeout).
+[Xunit.Trait("Category", "HeavyTimeout")]
 public class SCottModelTests : DiffusionModelTestBase<float>
 {
     // SD-based latent diffusion: 4 channels, 64x64 latent (512x512 images / 8x VAE)

--- a/tests/AiDotNet.Tests/ModelFamilyTests/Diffusion/SD3FlashModelTests.cs
+++ b/tests/AiDotNet.Tests/ModelFamilyTests/Diffusion/SD3FlashModelTests.cs
@@ -4,6 +4,11 @@ using AiDotNet.Tests.ModelFamilyTests.Base;
 
 namespace AiDotNet.Tests.ModelFamilyTests.Diffusion;
 
+// HeavyTimeout (#1706): SD3 MMDiT instantiated at full default (paper) scale — a single model's peak
+// exceeds the 16 GB PR runner, which SIGTERM-cancelled the SA-SD shard. Runs in the nightly
+// HeavyTimeout lane; the default gate filters Category!=HeavyTimeout. Drop once it fits the budget.
+[Xunit.Collection("FoundationScaleSerial")]
+[Xunit.Trait("Category", "HeavyTimeout")]
 public class SD3FlashModelTests : DiffusionModelTestBase<float>
 {
     protected override int[] InputShape => [1, 16, 64, 64];

--- a/tests/AiDotNet.Tests/ModelFamilyTests/Diffusion/SD3InpaintingModelTests.cs
+++ b/tests/AiDotNet.Tests/ModelFamilyTests/Diffusion/SD3InpaintingModelTests.cs
@@ -4,6 +4,11 @@ using AiDotNet.Tests.ModelFamilyTests.Base;
 
 namespace AiDotNet.Tests.ModelFamilyTests.Diffusion;
 
+// HeavyTimeout (#1706): SD3 MMDiT instantiated at full default (paper) scale — a single model's peak
+// exceeds the 16 GB PR runner, which SIGTERM-cancelled the SA-SD shard. Runs in the nightly
+// HeavyTimeout lane; the default gate filters Category!=HeavyTimeout. Drop once it fits the budget.
+[Xunit.Collection("FoundationScaleSerial")]
+[Xunit.Trait("Category", "HeavyTimeout")]
 public class SD3InpaintingModelTests : DiffusionModelTestBase<float>
 {
     protected override int[] InputShape => [1, 16, 64, 64];

--- a/tests/AiDotNet.Tests/ModelFamilyTests/Diffusion/SD3TurboModelTests.cs
+++ b/tests/AiDotNet.Tests/ModelFamilyTests/Diffusion/SD3TurboModelTests.cs
@@ -4,6 +4,11 @@ using AiDotNet.Tests.ModelFamilyTests.Base;
 
 namespace AiDotNet.Tests.ModelFamilyTests.Diffusion;
 
+// HeavyTimeout (#1706): SD3 MMDiT instantiated at full default (paper) scale — a single model's peak
+// exceeds the 16 GB PR runner, which SIGTERM-cancelled the SA-SD shard. Runs in the nightly
+// HeavyTimeout lane; the default gate filters Category!=HeavyTimeout. Drop once it fits the budget.
+[Xunit.Collection("FoundationScaleSerial")]
+[Xunit.Trait("Category", "HeavyTimeout")]
 public class SD3TurboModelTests : DiffusionModelTestBase<float>
 {
     protected override int[] InputShape => [1, 16, 64, 64];

--- a/tests/AiDotNet.Tests/ModelFamilyTests/Diffusion/SDXLLightningModelTests.cs
+++ b/tests/AiDotNet.Tests/ModelFamilyTests/Diffusion/SDXLLightningModelTests.cs
@@ -5,6 +5,9 @@ using AiDotNet.Tests.ModelFamilyTests.Base;
 namespace AiDotNet.Tests.ModelFamilyTests.Diffusion;
 
 [Xunit.Collection("FoundationScaleSerial")] // dedicated cores (#1622 L4)
+// HeavyTimeout (#1706): SDXL UNet at full default (paper) scale — single-model peak exceeds the 16 GB
+// PR runner, which SIGTERM-cancelled the SA-SD shard. Runs in the nightly lane (gate filters Category!=HeavyTimeout).
+[Xunit.Trait("Category", "HeavyTimeout")]
 public class SDXLLightningModelTests : DiffusionModelTestBase<float>
 {
     // SD-based latent diffusion: 4 channels, 64x64 latent (512x512 images / 8x VAE)

--- a/tests/AiDotNet.Tests/UnitTests/Diffusion/Models/ControlModelContractTests.cs
+++ b/tests/AiDotNet.Tests/UnitTests/Diffusion/Models/ControlModelContractTests.cs
@@ -69,6 +69,9 @@ public class ControlModelContractTests : DiffusionUnitTestBase
     }
 
     [Fact(Timeout = 120000)]
+    // HeavyTimeout (#1706): Flux backbone (~12B params ~= 48 GB fp32) — constructing it alone exceeds
+    // the 16 GB PR runner, which SIGTERM-cancelled the 03b shard. Runs in the nightly HeavyTimeout lane.
+    [Trait("Category", "HeavyTimeout")]
     public async Task ControlNetFluxModel_DefaultConstructor_CreatesValidModel()
     {
         var model = new ControlNetFluxModel<float>();
@@ -80,6 +83,9 @@ public class ControlModelContractTests : DiffusionUnitTestBase
     }
 
     [Fact(Timeout = 120000)]
+    // HeavyTimeout (#1706): SD3 MMDiT backbone (billions of params) — constructing it alone exceeds the
+    // 16 GB PR runner, which SIGTERM-cancelled the 03b shard. Runs in the nightly HeavyTimeout lane.
+    [Trait("Category", "HeavyTimeout")]
     public async Task ControlNetSD3Model_DefaultConstructor_CreatesValidModel()
     {
         var model = new ControlNetSD3Model<float>();
@@ -212,6 +218,9 @@ public class ControlModelContractTests : DiffusionUnitTestBase
     }
 
     [Fact(Timeout = 120000)]
+    // HeavyTimeout (#1706): Flux backbone (~12B params ~= 48 GB fp32) — constructing it alone exceeds
+    // the 16 GB PR runner, which SIGTERM-cancelled the 03b shard. Runs in the nightly HeavyTimeout lane.
+    [Trait("Category", "HeavyTimeout")]
     public async Task ControlNetPlusPlusFluxModel_DefaultConstructor_CreatesValidModel()
     {
         var model = new ControlNetPlusPlusFluxModel<float>();
@@ -238,6 +247,9 @@ public class ControlModelContractTests : DiffusionUnitTestBase
     }
 
     [Fact(Timeout = 120000)]
+    // HeavyTimeout (#1706): Clone constructs a second ~12B-param Flux model — exceeds the 16 GB PR
+    // runner, which SIGTERM-cancelled the 03b shard. Runs in the nightly HeavyTimeout lane.
+    [Trait("Category", "HeavyTimeout")]
     public async Task ControlNetFluxModel_Clone_CreatesIndependentCopy()
     {
         var model = new ControlNetFluxModel<float>();


### PR DESCRIPTION
## Summary

Two `Build & SonarCloud` test shards fail on **master** — both **SIGTERM-cancelled** (exit 143, *\"The runner has received a shutdown signal\"* / *\"The operation was canceled\"*) on the 16 GB github-hosted runner, **not** by any assertion failure. This is the known *\"Cancelled-runner shards (Diffusion)\"* foundation-scale OOM pattern (the workflow's own step comments call it out), the same class of failure fixed in #1744 / #1749 / #1706.

The `DiffusionModelTestBase` already disposes each model (`using var model`) and forces a GC + LOH reclaim between tests, so this is a **single-model peak** exceeding 16 GB, not a cross-test leak.

### 1. `ModelFamily - Diffusion SA-SD`
8 model classes instantiate at **full default (paper) scale** via default constructors — SD3-MMDiT / SDXL-UNet backbones, billions of params:
`SANA`, `SANASprint`, `SASTD`, `SCott`, `SD3Flash`, `SD3Inpainting`, `SD3Turbo`, `SDXLLightning`.
Tagged `[Category=HeavyTimeout]` (+ `FoundationScaleSerial`), matching the already-tagged `SDXLTurbo`/`SDXLInpainting` siblings in the same shard. The default gate filters `Category!=HeavyTimeout`; these run fully in the nightly lane. The smaller base-64 injected models (`SDEdit`/`SDTurbo`/`SDUpscaler`/`SDXL`) stay on the PR gate.

### 2. `Unit - 03b Diffusion Models Control/DDPM/Preprocessor`
`ControlModelContractTests` constructs each model and asserts `ParameterCount > 0`. The **Flux (~12B ≈ 48 GB fp32)** and **SD3** backbones can't fit 16 GB even to construct. Per-method `[Category=HeavyTimeout]` on the 4 Flux/SD3 methods (`ControlNetFluxModel` ctor + Clone, `ControlNetSD3Model`, `ControlNetPlusPlusFluxModel`). The SD-scale ControlNets and the lightweight guidance tests stay on the PR gate.

## Validation
- Build verified locally (net10.0, test project compiles).
- Attribute-only change using the exact `[Xunit.Trait]`/`[Xunit.Collection]`/`[Trait]` mechanism the gate already filters on for existing HeavyTimeout models — no code/behavior change; the models still run in the nightly HeavyTimeout lane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)