### PR TITLE
test(gpu): regression guard for FeedForwardNeuralNetwork identity-head GPU inference (#1422)

### DIFF
--- a/tests/AiDotNet.Tests/IntegrationTests/NeuralNetworks/FeedForwardGpuZeroPredictIssue1422Tests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/NeuralNetworks/FeedForwardGpuZeroPredictIssue1422Tests.cs
@@ -1,0 +1,107 @@
+// Copyright (c) AiDotNet. All rights reserved.
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using AiDotNet.ActivationFunctions;
+using AiDotNet.Enums;
+using AiDotNet.Interfaces;
+using AiDotNet.NeuralNetworks;
+using AiDotNet.NeuralNetworks.Layers;
+using AiDotNet.LinearAlgebra;
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.Engines.DirectGpu;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace AiDotNet.Tests.IntegrationTests.NeuralNetworks;
+
+/// <summary>
+/// #1422: a <see cref="FeedForwardNeuralNetwork{T}"/> with an IDENTITY output head trained on
+/// <c>y = 3x + 1.5</c> converged (loss ~0.1) but every GPU inference call returned all zeros — the
+/// same linear/None output-head class as #1629. This trains the exact repro on real GPU hardware and
+/// asserts inference is non-zero and tracks the target. Skips when no GPU backend is available.
+/// </summary>
+public class FeedForwardGpuZeroPredictIssue1422Tests
+{
+    private readonly ITestOutputHelper _output;
+    public FeedForwardGpuZeroPredictIssue1422Tests(ITestOutputHelper output) => _output = output;
+
+    [Fact(Timeout = 240000)]
+    public async Task IdentityHead_GpuInference_IsNonZero_AfterTraining()
+    {
+        await Task.Yield();
+        DirectGpuTensorEngine? gpu = null;
+        try { gpu = new DirectGpuTensorEngine(); } catch { /* no backend */ }
+        if (gpu is null || !gpu.SupportsGpu)
+        {
+            _output.WriteLine("No GPU backend available — skipping #1422 GPU repro.");
+            return;
+        }
+
+        var previous = AiDotNetEngine.Current;
+        try
+        {
+            AiDotNetEngine.Current = gpu;
+
+            // y = 3x + 1.5 — 40 samples
+            var featureData = new double[40, 1];
+            var labelData = new double[40, 1];
+            for (int i = 0; i < 40; i++)
+            {
+                featureData[i, 0] = i * 0.25;
+                labelData[i, 0] = 3.0 * featureData[i, 0] + 1.5;
+            }
+            var featureTensor = Tensor<double>.FromMatrix(new Matrix<double>(featureData));
+            var labelTensor = Tensor<double>.FromMatrix(new Matrix<double>(labelData));
+
+            var layers = new List<ILayer<double>>
+            {
+                new DenseLayer<double>(outputSize: 8, activationFunction: new ReLUActivation<double>()),
+                new DenseLayer<double>(outputSize: 8, activationFunction: new ReLUActivation<double>()),
+                new DenseLayer<double>(outputSize: 1, activationFunction: new IdentityActivation<double>()),
+            };
+            var arch = new NeuralNetworkArchitecture<double>(
+                inputType: InputType.OneDimensional,
+                taskType: NeuralNetworkTaskType.Regression,
+                complexity: NetworkComplexity.Simple,
+                inputSize: 1,
+                layers: layers);
+            var nn = new FeedForwardNeuralNetwork<double>(arch);
+
+            double firstLoss = double.NaN, lastLoss = double.NaN;
+            for (int e = 0; e < 300; e++)
+            {
+                nn.Train(featureTensor, labelTensor);
+                double loss = Convert.ToDouble(nn.GetLastLoss());
+                if (e == 0) firstLoss = loss;
+                lastLoss = loss;
+            }
+            _output.WriteLine($"loss {firstLoss:F3} -> {lastLoss:F4}");
+            Assert.True(lastLoss < firstLoss * 0.5, $"model did not train (loss {firstLoss} -> {lastLoss})");
+
+            // Inference — the bug returned literal 0 for every input.
+            var testData = new double[3, 1] { { 2.0 }, { 5.0 }, { 8.0 } };
+            double[] expected = { 7.5, 16.5, 25.5 };
+            var testTensor = Tensor<double>.FromMatrix(new Matrix<double>(testData));
+
+            foreach (var pred in new[] { nn.Forward(testTensor), nn.Predict(testTensor) })
+            {
+                var flat = pred.ToArray();
+                bool allZero = true;
+                for (int i = 0; i < flat.Length; i++) { if (flat[i] != 0.0) { allZero = false; break; } }
+                Assert.False(allZero, "GPU inference returned all zeros after training (#1422).");
+                for (int i = 0; i < expected.Length; i++)
+                {
+                    double rel = Math.Abs(flat[i] - expected[i]) / Math.Abs(expected[i]);
+                    Assert.True(rel < 0.15, $"pred[{i}]={flat[i]:F3} vs expected {expected[i]} (rel {rel:F3}) — a converged y=3x+1.5 head must track the line.");
+                }
+            }
+        }
+        finally
+        {
+            AiDotNetEngine.Current = previous;
+            gpu.Dispose();
+        }
+    }
+}

--- a/tests/AiDotNet.Tests/IntegrationTests/NeuralNetworks/FeedForwardGpuZeroPredictIssue1422Tests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/NeuralNetworks/FeedForwardGpuZeroPredictIssue1422Tests.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using AiDotNet.ActivationFunctions;
+using AiDotNet.Data.Loaders;
 using AiDotNet.Enums;
 using AiDotNet.Interfaces;
 using AiDotNet.NeuralNetworks;
@@ -24,6 +25,8 @@ namespace AiDotNet.Tests.IntegrationTests.NeuralNetworks;
 /// </summary>
 public class FeedForwardGpuZeroPredictIssue1422Tests
 {
+    private const int ReproSeed = 1422;
+
     private readonly ITestOutputHelper _output;
     public FeedForwardGpuZeroPredictIssue1422Tests(ITestOutputHelper output) => _output = output;
 
@@ -32,7 +35,15 @@ public class FeedForwardGpuZeroPredictIssue1422Tests
     {
         await Task.Yield();
         DirectGpuTensorEngine? gpu = null;
-        try { gpu = new DirectGpuTensorEngine(); } catch { /* no backend */ }
+        try
+        {
+            gpu = new DirectGpuTensorEngine();
+        }
+        catch (Exception ex)
+        {
+            _output.WriteLine($"GPU engine init failed; skipping #1422 GPU repro. {ex}");
+        }
+
         if (gpu is null || !gpu.SupportsGpu)
         {
             _output.WriteLine("No GPU backend available — skipping #1422 GPU repro.");
@@ -57,16 +68,28 @@ public class FeedForwardGpuZeroPredictIssue1422Tests
 
             var layers = new List<ILayer<double>>
             {
-                new DenseLayer<double>(outputSize: 8, activationFunction: new ReLUActivation<double>()),
-                new DenseLayer<double>(outputSize: 8, activationFunction: new ReLUActivation<double>()),
-                new DenseLayer<double>(outputSize: 1, activationFunction: new IdentityActivation<double>()),
+                new DenseLayer<double>(outputSize: 8, activationFunction: new ReLUActivation<double>())
+                {
+                    RandomSeed = ReproSeed + 1,
+                },
+                new DenseLayer<double>(outputSize: 8, activationFunction: new ReLUActivation<double>())
+                {
+                    RandomSeed = ReproSeed + 2,
+                },
+                new DenseLayer<double>(outputSize: 1, activationFunction: new IdentityActivation<double>())
+                {
+                    RandomSeed = ReproSeed + 3,
+                },
             };
             var arch = new NeuralNetworkArchitecture<double>(
                 inputType: InputType.OneDimensional,
                 taskType: NeuralNetworkTaskType.Regression,
                 complexity: NetworkComplexity.Simple,
                 inputSize: 1,
-                layers: layers);
+                layers: layers)
+            {
+                RandomSeed = ReproSeed,
+            };
             var nn = new FeedForwardNeuralNetwork<double>(arch);
 
             double firstLoss = double.NaN, lastLoss = double.NaN;
@@ -87,21 +110,41 @@ public class FeedForwardGpuZeroPredictIssue1422Tests
 
             foreach (var pred in new[] { nn.Forward(testTensor), nn.Predict(testTensor) })
             {
-                var flat = pred.ToArray();
-                bool allZero = true;
-                for (int i = 0; i < flat.Length; i++) { if (flat[i] != 0.0) { allZero = false; break; } }
-                Assert.False(allZero, "GPU inference returned all zeros after training (#1422).");
-                for (int i = 0; i < expected.Length; i++)
-                {
-                    double rel = Math.Abs(flat[i] - expected[i]) / Math.Abs(expected[i]);
-                    Assert.True(rel < 0.15, $"pred[{i}]={flat[i]:F3} vs expected {expected[i]} (rel {rel:F3}) — a converged y=3x+1.5 head must track the line.");
-                }
+                AssertNonZeroAndTracksLine(pred, expected, "direct GPU inference");
             }
+
+            var facadeResult = await new AiModelBuilder<double, Tensor<double>, Tensor<double>>()
+                .ConfigureDataLoader(DataLoaders.FromTensors(featureTensor, labelTensor))
+                .ConfigureModel(nn)
+                .ConfigureGpuAcceleration()
+                .BuildAsync();
+            AssertNonZeroAndTracksLine(facadeResult.Predict(testTensor), expected, "AiModelBuilder result.Predict");
         }
         finally
         {
             AiDotNetEngine.Current = previous;
             gpu.Dispose();
+        }
+    }
+
+    private static void AssertNonZeroAndTracksLine(Tensor<double> prediction, double[] expected, string path)
+    {
+        var flat = prediction.ToArray();
+        bool allZero = true;
+        for (int i = 0; i < flat.Length; i++)
+        {
+            if (flat[i] != 0.0)
+            {
+                allZero = false;
+                break;
+            }
+        }
+
+        Assert.False(allZero, $"{path} returned all zeros after training (#1422).");
+        for (int i = 0; i < expected.Length; i++)
+        {
+            double rel = Math.Abs(flat[i] - expected[i]) / Math.Abs(expected[i]);
+            Assert.True(rel < 0.15, $"{path} pred[{i}]={flat[i]:F3} vs expected {expected[i]} (rel {rel:F3}) — a converged y=3x+1.5 head must track the line.");
         }
     }
 }


### PR DESCRIPTION
## Summary
#1422 reported a `FeedForwardNeuralNetwork<double>` with an **Identity output head** that trained fine on `y = 3x + 1.5` (loss ~223 → ~0.1) but returned **all-zero GPU inference** for every input — the same linear/`None` output-head class as #1629, rooted in `AiDotNet.Tensors`' `FusedLinearGpu` `None` branch.

## Verified fixed in the current package
Reproduced and re-verified on **real GPU hardware (AMD RX 5500 XT / OpenCL)** against the referenced **AiDotNet.Tensors 0.106.1**: training converges *and* both `Forward` and `Predict` return non-zero output that tracks the target (~7.5, ~16.5, ~25.5). Filed against an older package; fixed as of the current one — no consumer code change needed.

## What this PR adds
A GPU regression test (`FeedForwardGpuZeroPredictIssue1422Tests`) that trains the exact repro FFNN and asserts inference is (1) non-zero and (2) tracks `y = 3x + 1.5`, so the fix can't silently regress. **Skips** when no GPU backend is available (CI runners without a device); confirmed **passing on this AMD/OpenCL box**.

Closes #1422

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added a new GPU integration test covering neural network training and inference behavior.
  * Verifies predictions are not all zeros after training and stay close to expected values.
  * Includes safeguards to skip the test when GPU support is unavailable and restores the previous engine state afterward.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->