### PR TITLE
fix(vae): temporalvae decode built decoder temporal layers in the wrong channel order

### DIFF
--- a/src/Diffusion/VAE/TemporalVAE.cs
+++ b/src/Diffusion/VAE/TemporalVAE.cs
@@ -301,8 +301,15 @@ public class TemporalVAE<T> : VAEModelBase<T>
             _decoderSpatialLayers.Add(allDecoderLayers[i]);
         }
 
-        // Temporal decoder layers (parallel processing path)
-        for (int level = _channelMultipliers.Length - 1; level >= 0; level--)
+        // Temporal decoder layers (parallel processing path).
+        // These run as one monolithic block (see ApplyTemporalLayers) on the post-quant output
+        // BEFORE the spatial decoder, so the LAST temporal block must emit `lastChannels`
+        // (_baseChannels * _channelMultipliers[^1]) to feed the spatial decoder's first residual
+        // block. Building low→high (ascending level) makes the block chain end at lastChannels —
+        // mirroring the encoder's temporal path. Building it high→low (descending) made the chain
+        // end at _baseChannels, so the spatial decoder's GroupNorm rejected the input with a
+        // "channels != expected" mismatch for any numTemporalLayers >= 1 (a hard decode crash).
+        for (int level = 0; level < _channelMultipliers.Length; level++)
         {
             var outChannels = _baseChannels * _channelMultipliers[level];
             for (int t = 0; t < _numTemporalLayers; t++)

--- a/tests/AiDotNet.Tests/UnitTests/Diffusion/TemporalVAEDecodeChannelTests.cs
+++ b/tests/AiDotNet.Tests/UnitTests/Diffusion/TemporalVAEDecodeChannelTests.cs
@@ -1,0 +1,68 @@
+using System;
+using System.Threading.Tasks;
+using AiDotNet.Diffusion.VAE;
+using AiDotNet.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tests.UnitTests.Diffusion;
+
+/// <summary>
+/// Regression tests for the TemporalVAE video decode path. The decoder temporal blocks were built
+/// high→low channels and applied as one monolithic block BEFORE the spatial decoder, so they ended at
+/// <c>baseChannels</c> instead of <c>lastChannels</c> — the spatial decoder's first GroupNorm then rejected
+/// the input with "Input has N channels but layer expects M channels" for ANY config with temporal layers
+/// (<c>numTemporalLayers &gt;= 1</c>), a hard crash on every <see cref="TemporalVAE{T}.Decode"/> call.
+/// (Surfaced while investigating DIAMOND #1764; the model's own latent-space Predict never decodes, so the
+/// broken decode path was untested.)
+/// </summary>
+public class TemporalVAEDecodeChannelTests
+{
+    private static TemporalVAE<float> MakeVae(int numTemporalLayers) => new TemporalVAE<float>(
+        inputChannels: 3, latentChannels: 16, baseChannels: 32,
+        channelMultipliers: new[] { 1, 2, 4, 4 }, numTemporalLayers: numTemporalLayers,
+        temporalKernelSize: 3, causalMode: true, latentScaleFactor: 0.13025);
+
+    private static Tensor<float> MakeVideo(int seed)
+    {
+        var rng = new Random(seed);
+        // 8x spatial downsample (2^3) → latent spatial 4 (survives without collapsing to 1x1).
+        var video = new Tensor<float>(new[] { 1, 3, 4, 32, 32 });
+        for (int i = 0; i < video.Length; i++) video[i] = (float)(rng.NextDouble() * 2 - 1);
+        return video;
+    }
+
+    [Theory]
+    [InlineData(1)]
+    [InlineData(2)]
+    [InlineData(3)]
+    public async Task Decode_WithTemporalLayers_RoundTripsToVideoShape(int numTemporalLayers)
+    {
+        await Task.Yield();
+        var vae = MakeVae(numTemporalLayers);
+        var video = MakeVideo(1764);
+
+        var latent = vae.Encode(video, sampleMode: false);
+        // This threw "Input has 32 channels but layer expects 128 channels." before the fix.
+        var decoded = vae.Decode(latent);
+
+        // Decoder must reconstruct the full [batch, channels, frames, H, W] video shape.
+        Assert.Equal(video.Shape.Length, decoded.Shape.Length);
+        for (int d = 0; d < video.Shape.Length; d++)
+            Assert.Equal(video.Shape[d], decoded.Shape[d]);
+    }
+
+    [Fact]
+    public async Task Decode_IsDeterministic_AcrossRepeatedCalls()
+    {
+        await Task.Yield();
+        var vae = MakeVae(numTemporalLayers: 3);
+        var latent = vae.Encode(MakeVideo(7), sampleMode: false);
+
+        var a = vae.Decode(latent);
+        var b = vae.Decode(latent);
+
+        Assert.Equal(a.Length, b.Length);
+        for (int i = 0; i < a.Length; i++)
+            Assert.Equal(a[i], b[i]);
+    }
+}


### PR DESCRIPTION
Closes #1783.

## Problem
`TemporalVAE<T>.Decode` crashed on **every** call whenever the VAE had temporal layers (`numTemporalLayers >= 1`) with default-style multipliers (e.g. `[1, 2, 4, 4]`):

```
System.ArgumentException : Input has 32 channels but layer expects 128 channels.
   at GroupNormalizationLayer.Forward → VAEResBlock.Forward → TemporalVAE.DecodeVideo
```

## Root cause
The decoder temporal blocks were built **high→low** channels (descending level) and applied as one monolithic block on the post-quant output **before** the spatial decoder. That made the temporal chain end at `baseChannels` (32) instead of `lastChannels` (`baseChannels * channelMultipliers[^1]` = 128), so the spatial decoder’s first residual block’s GroupNorm rejected the input. The **encoder** temporal path is built low→high and correctly ends at `lastChannels`.

The path went untested because the video diffusion models built on `TemporalVAE` run **latent-space** `Predict` (the denoise loop returns the latent; the VAE decode is never invoked).

## Fix
One-line construction change: build the decoder temporal layers **low→high** (ascending level), mirroring the encoder, so the monolithic temporal chain ends at `lastChannels` and feeds the spatial decoder correctly. `CreateTemporalBlock` returns a `Conv3DLayer` with a fixed output-channel count and lazily-inferred input, so the first block cleanly maps the 16-channel latent up to the next width.

## Tests
- New `TemporalVAEDecodeChannelTests`: encode→decode **round-trips to the video shape** across `numTemporalLayers` 1/2/3 (each threw before the fix), plus a decode **determinism** check.
- Both target frameworks build (`net10.0` + `net471`).
- Existing video-model family tests unaffected: StableVideoDiffusion 13/13, Lumiere/Show1 26/26.

## Context
Found while investigating #1764 (DIAMOND clone divergence). This decode bug is **separate** from #1764’s reported symptom, which is on the predictor/denoise path at foundation scale — see the findings comment on #1764.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved temporal video decoding so decoder layers are built in the correct order, preventing channel mismatches during reconstruction.
  * Fixed decoding behavior for configurations with temporal layers to better preserve the expected video tensor shape.

* **Tests**
  * Added regression coverage for temporal VAE decoding.
  * Verified decoded outputs match the original video shape and remain consistent across repeated decode calls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->