### PR TITLE
fix(gnn): make NodeClassificationModel actually train (TrainOnTask threw; Train was a no-op)

### DIFF
--- a/src/NeuralNetworks/Tasks/Graph/NodeClassificationModel.cs
+++ b/src/NeuralNetworks/Tasks/Graph/NodeClassificationModel.cs
@@ -244,6 +244,54 @@ public class NodeClassificationModel<T> : NeuralNetworkBase<T>
     }
 
     /// <summary>
+    /// Tape-recorded training forward pass. Wires the graph structure into every
+    /// graph-convolutional layer BEFORE the base forward runs, so the autodiff
+    /// tape records the message-passing path and gradients can flow back to the
+    /// layer weights. Without this the default base forward could run against a
+    /// stale/absent adjacency and sever the gradient path.
+    /// </summary>
+    public override Tensor<T> ForwardForTraining(Tensor<T> input)
+    {
+        EnsureDefaultAdjacencyForInput(input);
+        return base.ForwardForTraining(input);
+    }
+
+    /// <summary>
+    /// Runs one gradient-descent training step over the full node-feature batch
+    /// using this model's own optimizer through the GradientTape path.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This override is required because the base <see cref="NeuralNetworkBase{T}.Train"/>
+    /// default did not update this model's graph-convolutional layer parameters:
+    /// it resolved a fresh base optimizer rather than the model's configured
+    /// optimizer and did not wire the adjacency for the training forward, so
+    /// every step was a no-op (loss flat, weights unchanged). Mirroring
+    /// <c>GraphNeuralNetwork</c>, we wire the graph and drive the update with the
+    /// model's optimizer via <see cref="NeuralNetworkBase{T}.TrainWithTape"/>.
+    /// </para>
+    /// <para>
+    /// For semi-supervised node classification, pass an <paramref name="expectedOutput"/>
+    /// whose rows are one-hot for the labeled training nodes and all-zeros for the
+    /// unlabeled nodes: the log-softmax cross-entropy loss multiplies the target in,
+    /// so all-zero rows contribute zero gradient and only the labeled nodes drive
+    /// learning while every node still participates in message passing.
+    /// </para>
+    /// </remarks>
+    public override void Train(Tensor<T> input, Tensor<T> expectedOutput)
+    {
+        if (!IsTrainingMode)
+        {
+            SetTrainingMode(true);
+        }
+
+        EnsureDefaultAdjacencyForInput(input);
+        TrainWithTape(input, expectedOutput, _optimizer);
+
+        SetTrainingMode(false);
+    }
+
+    /// <summary>
     /// Updates the parameters of all layers in the network.
     /// </summary>
     /// <param name="parameters">A vector containing all parameters for the network.</param>
@@ -294,6 +342,18 @@ public class NodeClassificationModel<T> : NeuralNetworkBase<T>
 
         SetAdjacencyMatrix(task.Graph.AdjacencyMatrix);
 
+        // Semi-supervised masking. Keep the one-hot rows for the labeled TRAINING
+        // nodes and zero out every other row. The log-softmax cross-entropy loss
+        // multiplies the target in, so all-zero rows contribute exactly zero
+        // gradient — only the labeled nodes drive learning, while ALL nodes
+        // (including unlabeled val/test nodes) still participate in message
+        // passing during the forward pass.
+        int numNodes = task.Graph.NodeFeatures.Shape[0];
+        var maskedLabels = new Tensor<T>([numNodes, task.NumClasses]);
+        foreach (int n in task.TrainIndices)
+            for (int c = 0; c < task.NumClasses; c++)
+                maskedLabels[n, c] = task.Labels[n, c];
+
         var history = new Dictionary<string, List<double>>
         {
             ["train_loss"] = new List<double>(),
@@ -301,45 +361,26 @@ public class NodeClassificationModel<T> : NeuralNetworkBase<T>
             ["val_accuracy"] = new List<double>()
         };
 
-        var lr = NumOps.FromDouble(learningRate);
-
         for (int epoch = 0; epoch < epochs; epoch++)
         {
-            // Set all layers to training mode
-            foreach (var layer in Layers)
-            {
-                layer.SetTrainingMode(true);
-            }
+            // One gradient-descent step over all nodes via the GradientTape
+            // autodiff path and the model's own optimizer. (learningRate is
+            // retained for API compatibility; the configured optimizer governs
+            // the actual step size.)
+            Train(task.Graph.NodeFeatures, maskedLabels);
 
-            // Forward pass on all nodes
+            // Record metrics from a clean inference-mode forward pass.
+            SetTrainingMode(false);
             var logits = Forward(task.Graph.NodeFeatures);
-
-            // Compute loss and accuracy on training nodes
             var (loss, trainAcc) = ComputeLossAndAccuracy(logits, task.Labels, task.TrainIndices, task.NumClasses);
-
-            // Validation accuracy
             double valAcc = EvaluateAccuracy(logits, task.Labels, task.ValIndices, task.NumClasses);
 
             history["train_loss"].Add(loss);
             history["train_accuracy"].Add(trainAcc);
             history["val_accuracy"].Add(valAcc);
-
-            // Compute gradient and backward pass
-            var gradient = ComputeGradient(logits, task.Labels, task.TrainIndices, task.NumClasses);
-
-            // Update parameters
-            foreach (var layer in Layers)
-            {
-                layer.UpdateParameters(lr);
-            }
         }
 
-        // Set layers back to inference mode
-        foreach (var layer in Layers)
-        {
-            layer.SetTrainingMode(false);
-        }
-
+        SetTrainingMode(false);
         return history;
     }
 
@@ -385,14 +426,31 @@ public class NodeClassificationModel<T> : NeuralNetworkBase<T>
             }
         }
 
-        // Vectorized cross-entropy loss: -sum(labels * log(clamp(logits, epsilon, 1)))
-        T epsilon = NumOps.FromDouble(1e-10);
-        T one = NumOps.One;
-        var clampedLogits = Engine.TensorClamp(subsetLogits, epsilon, one);
-        var logLogits = Engine.TensorLog(clampedLogits);
-        var labelLogProduct = Engine.TensorMultiply(subsetLabels, logLogits);
-        T negSumLoss = Engine.TensorSum(labelLogProduct);
-        double totalLoss = -NumOps.ToDouble(negSumLoss);
+        // Cross-entropy on the raw logits via numerically-stable log-softmax:
+        //   CE = -Σ labels · logSoftmax(logits),  logSoftmax = z - max - log Σ exp(z - max).
+        // The final GCN layer emits RAW logits (no softmax activation), so the metric
+        // must apply the softmax itself — matching the CrossEntropyWithLogitsLoss used
+        // for the actual training gradient. (The previous version treated the logits as
+        // if they were already probabilities, which made this reported loss meaningless.)
+        double totalLoss = 0.0;
+        for (int i = 0; i < indices.Length; i++)
+        {
+            double max = NumOps.ToDouble(subsetLogits[i, 0]);
+            for (int c = 1; c < numClasses; c++)
+                max = Math.Max(max, NumOps.ToDouble(subsetLogits[i, c]));
+
+            double sumExp = 0.0;
+            for (int c = 0; c < numClasses; c++)
+                sumExp += Math.Exp(NumOps.ToDouble(subsetLogits[i, c]) - max);
+            double logSumExp = Math.Log(sumExp) + max;
+
+            for (int c = 0; c < numClasses; c++)
+            {
+                double yc = NumOps.ToDouble(subsetLabels[i, c]);
+                if (yc != 0.0)
+                    totalLoss += -yc * (NumOps.ToDouble(subsetLogits[i, c]) - logSumExp);
+            }
+        }
         double avgLoss = totalLoss / indices.Length;
 
         // Compute accuracy: compare argmax of logits vs argmax of labels
@@ -470,47 +528,6 @@ public class NodeClassificationModel<T> : NeuralNetworkBase<T>
                 return c;
         }
         return 0;
-    }
-
-    private Tensor<T> ComputeGradient(Tensor<T> logits, Tensor<T> labels, int[] trainIndices, int numClasses)
-    {
-        // Initialize gradient tensor (zeros)
-        var gradient = new Tensor<T>(logits._shape);
-        Engine.TensorFill(gradient, NumOps.Zero);
-
-        if (trainIndices.Length == 0)
-        {
-            return gradient;
-        }
-
-        // Gather logits and labels for the subset of training nodes
-        var subsetLogits = new Tensor<T>([trainIndices.Length, numClasses]);
-        var subsetLabels = new Tensor<T>([trainIndices.Length, numClasses]);
-        for (int i = 0; i < trainIndices.Length; i++)
-        {
-            int nodeIdx = trainIndices[i];
-            for (int c = 0; c < numClasses; c++)
-            {
-                subsetLogits[i, c] = logits[nodeIdx, c];
-                subsetLabels[i, c] = labels[nodeIdx, c];
-            }
-        }
-
-        // Vectorized gradient computation: (logits - labels) / n
-        var diff = Engine.TensorSubtract<T>(subsetLogits, subsetLabels);
-        var scaledDiff = Engine.TensorDivideScalar(diff, NumOps.FromDouble(trainIndices.Length));
-
-        // Scatter gradients back to the full gradient tensor
-        for (int i = 0; i < trainIndices.Length; i++)
-        {
-            int nodeIdx = trainIndices[i];
-            for (int c = 0; c < numClasses; c++)
-            {
-                gradient[nodeIdx, c] = scaledDiff[i, c];
-            }
-        }
-
-        return gradient;
     }
 
     /// <summary>
@@ -607,43 +624,6 @@ public class NodeClassificationModel<T> : NeuralNetworkBase<T>
             identity[i, i] = NumOps.One;
         SetAdjacencyMatrix(identity);
         _usesFallbackAdjacency = true;
-    }
-
-    /// <summary>
-    /// Trains the network on a single batch of data.
-    /// </summary>
-    /// <param name="input">The input node features.</param>
-    /// <param name="expectedOutput">The expected output (labels).</param>
-    public override void Train(Tensor<T> input, Tensor<T> expectedOutput)
-    {
-        EnsureDefaultAdjacencyForInput(input);
-
-        foreach (var layer in Layers)
-        {
-            layer.SetTrainingMode(true);
-        }
-
-        var predictions = Forward(input);
-
-        var flattenedPredictions = predictions.ToVector();
-        var flattenedExpected = expectedOutput.ToVector();
-
-        LastLoss = _lossFunction.CalculateLoss(flattenedPredictions, flattenedExpected);
-
-        var outputGradients = _lossFunction.CalculateDerivative(flattenedPredictions, flattenedExpected);
-        var gradOutput = Tensor<T>.FromVector(outputGradients);
-
-        if (gradOutput.Shape.Length == 1 && predictions.Shape.Length > 1)
-        {
-            gradOutput = gradOutput.Reshape(predictions._shape);
-        }
-
-
-        Vector<T> parameterGradients = GetParameterGradients();
-        Vector<T> currentParameters = GetParameters();
-        Vector<T> updatedParameters = _optimizer.UpdateParameters(currentParameters, parameterGradients);
-
-        UpdateParameters(updatedParameters);
     }
 
     /// <summary>

--- a/tests/AiDotNet.Tests/IntegrationTests/NeuralNetworks/MissingModelsIntegrationTests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/NeuralNetworks/MissingModelsIntegrationTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using AiDotNet.Data.Structures;
 using AiDotNet.Diffusion;
 using AiDotNet.Enums;
 using AiDotNet.NeuralNetworks;
@@ -201,6 +202,90 @@ public class MissingModelsIntegrationTests
         var output = model.Predict(nodeFeatures);
 
         Assert.Equal(new[] { numNodes, numClasses }, output.Shape.ToArray());
+    }
+
+    [Fact(Timeout = 120000)]
+    public async Task NodeClassificationModel_TrainOnTask_LearnsSeparableGraph()
+    {
+        // Regression test for the GNN training bugs (fix/gnn-node-classification-training):
+        //   1. TrainOnTask threw ("Backward pass must be called before updating parameters")
+        //      because it called layer.UpdateParameters without an autodiff backward pass.
+        //   2. Train(input, expected) was a no-op — it read stale (zero) parameter gradients,
+        //      so weights never changed and loss stayed flat.
+        // Both now route through the GradientTape path, so a GCN must actually learn a
+        // linearly/graph-separable node-classification problem.
+        await Task.Yield();
+
+        const int n = 60, F = 4, C = 2;
+        var rng = new Random(3);
+        var features = new Tensor<double>(new[] { n, F });
+        var labels = new Tensor<double>(new[] { n, C });
+        var adjacency = new Tensor<double>(new[] { n, n });
+        var yTrue = new int[n];
+
+        // Two communities (first/second half). Features clearly encode the class;
+        // edges only connect within a community.
+        var nbr = new List<int>[n];
+        for (int i = 0; i < n; i++) nbr[i] = new List<int>();
+        for (int i = 0; i < n; i++)
+        {
+            int comm = i < n / 2 ? 0 : 1;
+            yTrue[i] = comm;
+            labels[i, comm] = 1.0;
+            for (int f = 0; f < F; f++)
+                features[i, f] = rng.NextDouble() * 0.2 + (f == comm ? 1.0 : 0.0);
+        }
+        for (int i = 0; i < n; i++)
+            for (int j = i + 1; j < n; j++)
+                if ((i < n / 2) == (j < n / 2) && rng.NextDouble() < 0.3)
+                {
+                    nbr[i].Add(j);
+                    nbr[j].Add(i);
+                }
+
+        // Symmetric-normalized adjacency with self-loops (Kipf & Welling renormalization).
+        var deg = new double[n];
+        for (int i = 0; i < n; i++) deg[i] = nbr[i].Count + 1.0;
+        for (int i = 0; i < n; i++)
+        {
+            adjacency[i, i] = 1.0 / deg[i];
+            foreach (int j in nbr[i])
+                adjacency[i, j] = 1.0 / (Math.Sqrt(deg[i]) * Math.Sqrt(deg[j]));
+        }
+
+        var architecture = new NeuralNetworkArchitecture<double>(
+            inputType: InputType.OneDimensional,
+            taskType: NeuralNetworkTaskType.MultiClassClassification,
+            inputSize: F,
+            outputSize: C);
+        var model = new NodeClassificationModel<double>(
+            architecture, hiddenDim: 16, numLayers: 2, dropoutRate: 0.0, maxGradNorm: 0.0);
+
+        var allNodes = Enumerable.Range(0, n).ToArray();
+        var task = new NodeClassificationTask<double>
+        {
+            Graph = new GraphData<double> { NodeFeatures = features, AdjacencyMatrix = adjacency, NodeLabels = labels },
+            Labels = labels,
+            NumClasses = C,
+            TrainIndices = allNodes,
+            ValIndices = allNodes,
+            TestIndices = allNodes,
+        };
+
+        // Must NOT throw (bug #1) and must actually learn (bug #2).
+        var history = model.TrainOnTask(task, epochs: 150, learningRate: 0.02);
+
+        double firstLoss = history["train_loss"][0];
+        double lastLoss = history["train_loss"][^1];
+        double finalAcc = history["train_accuracy"][^1];
+
+        Assert.True(lastLoss < firstLoss,
+            $"Training should reduce loss (first={firstLoss:F4}, last={lastLoss:F4}) — a flat loss means the no-op bug regressed.");
+        Assert.True(finalAcc >= 0.9,
+            $"GCN should learn the separable graph (final train accuracy {finalAcc:P0} < 90%).");
+
+        double testAcc = model.EvaluateOnTask(task);
+        Assert.True(testAcc >= 0.9, $"EvaluateOnTask accuracy {testAcc:P0} < 90%.");
     }
 
     [Fact(Timeout = 120000)]


### PR DESCRIPTION
## Problem

`NodeClassificationModel<T>` could not train — both of its training entry points were dead code left over from before the library moved from per-layer `Backward()` to `GradientTape` autodiff:

- **`Train(input, expected)` was a silent no-op.** It ran an eager forward, then read `GetParameterGradients()` — which is never populated without a backward pass — and applied those (zero) gradients. Loss stayed flat and weights never changed.
- **`TrainOnTask()` threw.** It computed an output gradient then called `layer.UpdateParameters(lr)` with no backward pass, so `GraphConvolutionalLayer` threw `"Backward pass must be called before updating parameters."`

Reproduced on a synthetic graph: params changed by exactly `0` and loss was identical every epoch, while the sibling `GraphNeuralNetwork<T>` (which overrides `Train`/`ForwardForTraining` to drive the tape) trained fine.

## Fix

Route `NodeClassificationModel` through the same `GradientTape` path the rest of the library uses, mirroring `GraphNeuralNetwork`:

- `Train(input, expected)` → wire the adjacency onto the graph layers, then `TrainWithTape(input, expected, _optimizer)`.
- `ForwardForTraining(input)` → ensure the adjacency is set on the GCN layers before the tape-recorded forward, so gradients flow through message passing.
- `TrainOnTask()` → rewritten to step the tape each epoch with **semi-supervised label masking** (one-hot rows for labeled training nodes, all-zeros elsewhere). The log-softmax cross-entropy multiplies the target in, so unlabeled rows contribute zero gradient while every node still participates in message passing.
- Removed the now-dead `ComputeGradient` helper.
- Fixed the reported `train_loss` metric in `ComputeLossAndAccuracy` to use numerically-stable log-softmax cross-entropy on the raw logits (it previously treated logits as probabilities, making the reported loss meaningless).

## Verification

- New regression test `NodeClassificationModel_TrainOnTask_LearnsSeparableGraph`: trains a 2-layer GCN on a separable 2-community graph and asserts loss decreases and accuracy reaches ≥90%. Before the fix this test would throw; after, it converges to 100% train accuracy.
- Existing graph tests green: `MissingModelsIntegrationTests` (9/9), `GraphLayersIntegrationTests` + `GraphNeuralNetworkTests` (59/59), on both `net10.0` and `net471`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
