### PR TITLE
fix(diffusion): preserve fp16-resident weights across clone/param round-trip (#1764)

### DIFF
--- a/src/Diffusion/NoisePredictors/DiTNoisePredictor.cs
+++ b/src/Diffusion/NoisePredictors/DiTNoisePredictor.cs
@@ -116,6 +116,16 @@ public class DiTNoisePredictor<T> : NoisePredictorBase<T>
     private const long LowPrecisionResidentThresholdParams = 1_000_000_000L;
 
     /// <summary>
+    /// Test-only override for <see cref="LowPrecisionResidentThresholdParams"/>, letting a unit test
+    /// exercise the fp16-resident eval path (and its clone/parameter round-trip, #1764) at small scale
+    /// without allocating a real &gt;1B-parameter model. Instance-scoped so it never leaks across tests or
+    /// threads. Null in production, where the ~1B default applies.
+    /// </summary>
+    internal long? ResidentThresholdOverrideForTests { get; set; }
+
+    private long EffectiveResidentThreshold => ResidentThresholdOverrideForTests ?? LowPrecisionResidentThresholdParams;
+
+    /// <summary>
     /// Number of attention heads.
     /// </summary>
     private readonly int _numHeads;
@@ -542,7 +552,7 @@ public class DiTNoisePredictor<T> : NoisePredictorBase<T>
     {
         bool tapeActive = AiDotNet.Tensors.Engines.Autodiff.GradientTape<T>.Current is not null
             && !AiDotNet.Tensors.Engines.Autodiff.NoGradScope<T>.IsSuppressed;
-        return !tapeActive && ParameterCount > LowPrecisionResidentThresholdParams;
+        return !tapeActive && ParameterCount > EffectiveResidentThreshold;
     }
 
     public override Tensor<T> PredictNoise(Tensor<T> noisySample, int timestep, Tensor<T>? conditioning = null)
@@ -683,7 +693,7 @@ public class DiTNoisePredictor<T> : NoisePredictorBase<T>
         // Gated OFF while a tape is active (training needs the fp32 master for backward).
         bool tapeActive = AiDotNet.Tensors.Engines.Autodiff.GradientTape<T>.Current is not null
             && !AiDotNet.Tensors.Engines.Autodiff.NoGradScope<T>.IsSuppressed;
-        if (!tapeActive && ParameterCount > LowPrecisionResidentThresholdParams)
+        if (!tapeActive && ParameterCount > EffectiveResidentThreshold)
         {
             foreach (var b in _blocks) b.EnableLowPrecisionResident();
         }
@@ -1436,6 +1446,12 @@ public class DiTNoisePredictor<T> : NoisePredictorBase<T>
             contextDim: _contextDim,
             mlpRatio: _mlpRatio,
             latentSpatialSize: _latentSpatialSize);
+
+        // Carry the test-only resident-threshold override so the clone's probe forward takes the same
+        // (fp16-resident vs fp32) path as the source — otherwise a small test clone would materialize fp32
+        // while the source is resident, masking the resident clone round-trip under test (#1764). Null in
+        // production, so this is a no-op there.
+        clone.ResidentThresholdOverrideForTests = ResidentThresholdOverrideForTests;
 
         ProbeMaterializeAndCopyInto(clone);
         return clone;

--- a/src/NeuralNetworks/Layers/DenseLayer.cs
+++ b/src/NeuralNetworks/Layers/DenseLayer.cs
@@ -1459,9 +1459,15 @@ public partial class DenseLayer<T> : LayerBase<T>, IAuxiliaryLossLayer<T>
         if (!IsShapeResolved) return new Vector<T>(0);
 
         EnsureInitialized();
+        // fp16-resident (#1764): _weights is a transient shared upcast scratch (overwritten every forward,
+        // and shared across same-shape layers), not the authoritative store. Read the resident half master
+        // — GetWeights() upcasts it — so the round-trip returns THIS layer's weights rather than whatever
+        // last occupied the scratch. Otherwise clone/serialize silently copies wrong (or another layer's)
+        // values at foundation scale.
+        var weightsView = _weightsHalf is not null ? GetWeights() : _weights;
         // Bulk copy from contiguous tensor storage — avoids ToArray() double-copy
         return Vector<T>.Concatenate(
-            Vector<T>.FromMemory(_weights.Data),
+            Vector<T>.FromMemory(weightsView.Data),
             Vector<T>.FromMemory(_biases.Data));
     }
 
@@ -1530,6 +1536,26 @@ public partial class DenseLayer<T> : LayerBase<T>, IAuxiliaryLossLayer<T>
         }
 
         EnsureInitialized();
+
+        // fp16-resident path (#1764): when LowPrecisionResident engaged, _weightsHalf is the authoritative
+        // weight store and _weights is a transient, shared upcast scratch that every forward overwrites
+        // from _weightsHalf. Writing the incoming weights into _weights would therefore be silently
+        // discarded on the next forward (the clone/deserialize would keep whatever the resident master
+        // held — e.g. a clone's random probe-init — diverging from the source). Downcast the incoming
+        // weights straight into the resident half master instead. Biases stay full precision.
+        if (_weightsHalf is not null)
+        {
+            int wLenHalf = _weightsHalf.Length;
+            int expectedHalf = wLenHalf + _biases.Length;
+            if (parameters.Length != expectedHalf)
+            {
+                throw new ArgumentException($"Expected {expectedHalf} parameters, but got {parameters.Length}");
+            }
+            NumOps.ToHalfSpan(parameters.AsSpan().Slice(0, wLenHalf), _weightsHalf.AsWritableSpan());
+            parameters.AsSpan().Slice(wLenHalf, _biases.Length).CopyTo(_biases.Data.Span);
+            Engine.InvalidatePersistentTensor(_biases);
+            return;
+        }
 
         int expected = _weights.Length + _biases.Length;
         if (parameters.Length != expected)

--- a/src/NeuralNetworks/Layers/SelfAttentionLayer.cs
+++ b/src/NeuralNetworks/Layers/SelfAttentionLayer.cs
@@ -1101,10 +1101,19 @@ public partial class SelfAttentionLayer<T> : LayerBase<T>, IAuxiliaryLossLayer<T
     {
         // Force lazy tensors to materialize before copying their data.
         EnsureInitialized();
-        // Calculate total number of parameters using tensor shape
-        int qRows = _queryWeights.Shape[0], qCols = _queryWeights.Shape[1];
-        int kRows = _keyWeights.Shape[0], kCols = _keyWeights.Shape[1];
-        int vRows = _valueWeights.Shape[0], vCols = _valueWeights.Shape[1];
+
+        // fp16-resident (#1764): on the separate-projection resident path the fp32 _queryWeights/_keyWeights/
+        // _valueWeights are freed to [0,0] and the fp16 half masters are authoritative. Reading _queryWeights
+        // directly would return a zero-length (or stale) vector, so clone/serialize silently drops the
+        // attention weights. Read the effective full-precision weights (half master upcast when resident,
+        // fp32 tensor otherwise — the latter also covers the fused-QKV path, where the projections stay fp32).
+        Tensor<T> qEff = _queryWeightsHalf is not null ? _queryWeightsHalf.Cast<T>() : _queryWeights;
+        Tensor<T> kEff = _keyWeightsHalf is not null ? _keyWeightsHalf.Cast<T>() : _keyWeights;
+        Tensor<T> vEff = _valueWeightsHalf is not null ? _valueWeightsHalf.Cast<T>() : _valueWeights;
+
+        int qRows = qEff.Shape[0], qCols = qEff.Shape[1];
+        int kRows = kEff.Shape[0], kCols = kEff.Shape[1];
+        int vRows = vEff.Shape[0], vCols = vEff.Shape[1];
         int biasLen = _outputBias.Shape[0];
 
         int totalParams = qRows * qCols + kRows * kCols + vRows * vCols + biasLen;
@@ -1117,7 +1126,7 @@ public partial class SelfAttentionLayer<T> : LayerBase<T>, IAuxiliaryLossLayer<T
         {
             for (int j = 0; j < qCols; j++)
             {
-                parameters[index++] = _queryWeights[i, j];
+                parameters[index++] = qEff[i, j];
             }
         }
 
@@ -1126,7 +1135,7 @@ public partial class SelfAttentionLayer<T> : LayerBase<T>, IAuxiliaryLossLayer<T
         {
             for (int j = 0; j < kCols; j++)
             {
-                parameters[index++] = _keyWeights[i, j];
+                parameters[index++] = kEff[i, j];
             }
         }
 
@@ -1135,7 +1144,7 @@ public partial class SelfAttentionLayer<T> : LayerBase<T>, IAuxiliaryLossLayer<T
         {
             for (int j = 0; j < vCols; j++)
             {
-                parameters[index++] = _valueWeights[i, j];
+                parameters[index++] = vEff[i, j];
             }
         }
 
@@ -1182,53 +1191,47 @@ public partial class SelfAttentionLayer<T> : LayerBase<T>, IAuxiliaryLossLayer<T
         // Force lazy tensors to materialize so the shape reads below report the
         // real dimensions rather than 0.
         EnsureInitialized();
-        // Calculate total number of parameters using tensor shape
-        int qRows = _queryWeights.Shape[0], qCols = _queryWeights.Shape[1];
-        int kRows = _keyWeights.Shape[0], kCols = _keyWeights.Shape[1];
-        int vRows = _valueWeights.Shape[0], vCols = _valueWeights.Shape[1];
+
+        // fp16-resident (#1764): on the separate-projection resident path the fp32 _queryWeights/_keyWeights/
+        // _valueWeights are freed to [0,0] and the fp16 half masters are authoritative — writing into the
+        // fp32 tensors would be silently discarded on the next forward (which re-upcasts the STALE half),
+        // so a clone/deserialize keeps the resident master's old (e.g. random probe-init) values. Downcast
+        // straight into the half master when resident; write the fp32 tensor otherwise (which also covers
+        // the fused-QKV path, where the projections stay fp32). Dimensions come from whichever is live.
+        bool qResident = _queryWeightsHalf is not null;
+        bool kResident = _keyWeightsHalf is not null;
+        bool vResident = _valueWeightsHalf is not null;
+
+        int qRows, qCols, kRows, kCols, vRows, vCols;
+        (qRows, qCols) = qResident ? (_queryWeightsHalf!.Shape[0], _queryWeightsHalf!.Shape[1]) : (_queryWeights.Shape[0], _queryWeights.Shape[1]);
+        (kRows, kCols) = kResident ? (_keyWeightsHalf!.Shape[0], _keyWeightsHalf!.Shape[1]) : (_keyWeights.Shape[0], _keyWeights.Shape[1]);
+        (vRows, vCols) = vResident ? (_valueWeightsHalf!.Shape[0], _valueWeightsHalf!.Shape[1]) : (_valueWeights.Shape[0], _valueWeights.Shape[1]);
         int biasLen = _outputBias.Shape[0];
 
-        int totalParams = qRows * qCols + kRows * kCols + vRows * vCols + biasLen;
+        int qLen = qRows * qCols, kLen = kRows * kCols, vLen = vRows * vCols;
+        int totalParams = qLen + kLen + vLen + biasLen;
 
         if (parameters.Length != totalParams)
         {
             throw new ArgumentException($"Expected {totalParams} parameters, but got {parameters.Length}");
         }
 
-        int index = 0;
+        var span = parameters.AsSpan();
+        if (qResident) NumOps.ToHalfSpan(span.Slice(0, qLen), _queryWeightsHalf!.AsWritableSpan());
+        else span.Slice(0, qLen).CopyTo(_queryWeights.Data.Span);
 
-        // Set query weights
-        for (int i = 0; i < qRows; i++)
-        {
-            for (int j = 0; j < qCols; j++)
-            {
-                _queryWeights[i, j] = parameters[index++];
-            }
-        }
+        if (kResident) NumOps.ToHalfSpan(span.Slice(qLen, kLen), _keyWeightsHalf!.AsWritableSpan());
+        else span.Slice(qLen, kLen).CopyTo(_keyWeights.Data.Span);
 
-        // Set key weights
-        for (int i = 0; i < kRows; i++)
-        {
-            for (int j = 0; j < kCols; j++)
-            {
-                _keyWeights[i, j] = parameters[index++];
-            }
-        }
+        if (vResident) NumOps.ToHalfSpan(span.Slice(qLen + kLen, vLen), _valueWeightsHalf!.AsWritableSpan());
+        else span.Slice(qLen + kLen, vLen).CopyTo(_valueWeights.Data.Span);
 
-        // Set value weights
-        for (int i = 0; i < vRows; i++)
-        {
-            for (int j = 0; j < vCols; j++)
-            {
-                _valueWeights[i, j] = parameters[index++];
-            }
-        }
+        span.Slice(qLen + kLen + vLen, biasLen).CopyTo(_outputBias.Data.Span);
 
-        // Set output bias
-        for (int i = 0; i < biasLen; i++)
-        {
-            _outputBias[i] = parameters[index++];
-        }
+        // The cached fused-QKV weight was built from the OLD projection weights; force a rebuild so the
+        // fused path (when enabled) reflects the new values instead of a stale concatenation.
+        _fusedQkvBuilt = false;
+        _fusedQkvWeightsHalf = null;
 
         // Notify GPU that tensor data has changed
         Engine.InvalidatePersistentTensor(_queryWeights);

--- a/tests/AiDotNet.Tests/UnitTests/Diffusion/DiTNoisePredictorResidentCloneTests.cs
+++ b/tests/AiDotNet.Tests/UnitTests/Diffusion/DiTNoisePredictorResidentCloneTests.cs
@@ -52,8 +52,10 @@ public class DiTNoisePredictorResidentCloneTests
         double maxAbs = 0;
         for (int i = 0; i < o1.Length; i++)
         {
-            Assert.True(double.IsFinite((double)o1[i]), $"source output[{i}] not finite");
-            maxAbs = Math.Max(maxAbs, Math.Abs((double)o1[i]));
+            // net471 has no double.IsFinite; !IsNaN && !IsInfinity is the equivalent (both exist since .NET 2.0).
+            double v = (double)o1[i];
+            Assert.True(!double.IsNaN(v) && !double.IsInfinity(v), $"source output[{i}] not finite");
+            maxAbs = Math.Max(maxAbs, Math.Abs(v));
         }
         Assert.True(maxAbs > 1e-6, "source output is all ~zero — test would be vacuous");
 

--- a/tests/AiDotNet.Tests/UnitTests/Diffusion/DiTNoisePredictorResidentCloneTests.cs
+++ b/tests/AiDotNet.Tests/UnitTests/Diffusion/DiTNoisePredictorResidentCloneTests.cs
@@ -1,0 +1,89 @@
+using System;
+using AiDotNet.Diffusion.NoisePredictors;
+using AiDotNet.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tests.UnitTests.Diffusion;
+
+/// <summary>
+/// Regression tests for issue #1764: cloning a foundation-scale DiT after an fp16-resident eval forward
+/// used to diverge (~8% on DIAMOND) because the resident fp16 weight master was not part of the
+/// parameter round-trip — the probe forward downcast the clone's random init to the resident master, and
+/// the subsequent CopyParametersFrom wrote the (transient) fp32 scratch while the stale random master was
+/// what the next forward actually consumed. These tests force the resident path at small scale via the
+/// internal <see cref="DiTNoisePredictor{T}.ResidentThresholdOverrideForTests"/> hook so the fix is guarded
+/// without allocating a real &gt;1B-parameter model (which OOMs the CI runner and only runs nightly).
+/// </summary>
+public class DiTNoisePredictorResidentCloneTests
+{
+    private static DiTNoisePredictor<float> CreateResidentPredictor(int seed)
+    {
+        var p = new DiTNoisePredictor<float>(
+            inputChannels: 16, hiddenSize: 32, numLayers: 2, numHeads: 2,
+            patchSize: 2, contextDim: 64, latentSpatialSize: 8, seed: seed);
+        // Any nonzero param count exceeds this, so the model takes the fp16-resident eval path.
+        p.ResidentThresholdOverrideForTests = 1_000L;
+        return p;
+    }
+
+    private static Tensor<float> Rand(int[] shape, int seed)
+    {
+        var t = new Tensor<float>(shape);
+        var d = t.GetCpuData();
+        var rng = new Random(seed);
+        for (int i = 0; i < d.Length; i++) d[i] = (float)(rng.NextDouble() * 2 - 1);
+        return t;
+    }
+
+    [Fact]
+    public void Clone_UnderFp16Resident_ReproducesSourceOutput()
+    {
+        var source = CreateResidentPredictor(seed: 123);
+        var input = Rand(new[] { 1, 16, 8, 8 }, seed: 7);
+        var conditioning = Rand(new[] { 1, 1, 64 }, seed: 9); // exercise the resident cross-attention path too
+
+        var o1 = source.PredictNoise(input, timestep: 0, conditioning: conditioning);
+        var clone = (DiTNoisePredictor<float>)source.Clone();
+        var o2 = clone.PredictNoise(input, timestep: 0, conditioning: conditioning);
+
+        Assert.Equal(o1.Length, o2.Length);
+
+        // The source output must be a real (finite, non-degenerate) signal, else "equal" would be trivial.
+        double maxAbs = 0;
+        for (int i = 0; i < o1.Length; i++)
+        {
+            Assert.True(double.IsFinite((double)o1[i]), $"source output[{i}] not finite");
+            maxAbs = Math.Max(maxAbs, Math.Abs((double)o1[i]));
+        }
+        Assert.True(maxAbs > 1e-6, "source output is all ~zero — test would be vacuous");
+
+        // Source and clone both run fp16-resident with identical masters → bit-identical output.
+        for (int i = 0; i < o1.Length; i++)
+            Assert.True(Math.Abs((double)o1[i] - (double)o2[i]) < 1e-6,
+                $"clone output[{i}]={o2[i]} diverged from source {o1[i]} (fp16-resident clone drift, #1764)");
+    }
+
+    [Fact]
+    public void GetSetParameters_UnderFp16Resident_RoundTrips()
+    {
+        var predictor = CreateResidentPredictor(seed: 321);
+        var input = Rand(new[] { 1, 16, 8, 8 }, seed: 11);
+        var conditioning = Rand(new[] { 1, 1, 64 }, seed: 13);
+
+        // Force materialization + fp16-resident downcast.
+        _ = predictor.PredictNoise(input, timestep: 0, conditioning: conditioning);
+
+        // GetParameters must return the full parameter set (resident layers read their half masters, not the
+        // freed [0,0] fp32 placeholders / shared upcast scratch) — the count must match ParameterCount.
+        var flat = predictor.GetParameters();
+        Assert.Equal(predictor.ParameterCount, flat.Length);
+
+        // Round-trip: setting the same parameters back and re-running must reproduce the output exactly.
+        var before = predictor.PredictNoise(input, timestep: 0, conditioning: conditioning);
+        predictor.SetParameters(flat);
+        var after = predictor.PredictNoise(input, timestep: 0, conditioning: conditioning);
+        for (int i = 0; i < before.Length; i++)
+            Assert.True(Math.Abs((double)before[i] - (double)after[i]) < 1e-6,
+                $"resident GetParameters→SetParameters round-trip changed output at [{i}] (#1764)");
+    }
+}

--- a/tests/AiDotNet.Tests/UnitTests/Diffusion/DiTNoisePredictorResidentCloneTests.cs
+++ b/tests/AiDotNet.Tests/UnitTests/Diffusion/DiTNoisePredictorResidentCloneTests.cs
@@ -30,7 +30,7 @@ public class DiTNoisePredictorResidentCloneTests
     {
         var t = new Tensor<float>(shape);
         var d = t.GetCpuData();
-        var rng = new Random(seed);
+        var rng = RandomHelper.CreateSeededRandom(seed);
         for (int i = 0; i < d.Length; i++) d[i] = (float)(rng.NextDouble() * 2 - 1);
         return t;
     }


### PR DESCRIPTION
## Summary

Fixes the `DIAMONDModelTests.Clone_ShouldProduceIdenticalOutput` ~8% divergence — a genuine clone-fidelity bug, not float noise.

## Root cause

The divergence only appears once a DiT predictor crosses the ~1B-param **fp16-resident eval threshold** (`LowPrecisionResidentThresholdParams`), which is why it never reproduced at small scale. In that mode `DenseLayer`/`SelfAttentionLayer` downcast their fp32 weights into an fp16 **master** (`_weightsHalf` / `_queryWeightsHalf`…) and free the fp32 copy — it becomes a `[0,0]` placeholder or a *shared, per-forward-overwritten* upcast scratch. The half master is authoritative.

But the parameter round-trip ignored the master:
- **`GetParameters`** read the freed/scratch fp32 tensor → returned stale or short data (the predictor-level walk even threw `GetParameters wrote N vs ParameterCount M` for `SelfAttentionLayer`'s `[0,0]` projections).
- **`SetParameters`** wrote the fp32 tensor, never the master.

So in `Clone()` → `ProbeMaterializeAndCopyInto`: the clone's probe forward downcast the clone's **random init** into the master, then `CopyParametersFrom` wrote the fp32 scratch, and the next real forward re-upcast the **stale random master** — the clone silently ran on random weights.

## Fix

Make the fp16-resident half master part of the parameter round-trip:
- **`DenseLayer`**: `GetParameters` reads via the resident master when resident; `SetParameters` downcasts incoming weights straight into the master.
- **`SelfAttentionLayer`**: `GetParameters`/`SetParameters` read/write Q/K/V via the resident half masters when present (separate-projection path; the fused path keeps fp32 projections and is unaffected), and invalidate the cached fused-QKV weight on any `SetParameters` so it can't serve a stale concatenation.

## Testing

Added `DiTNoisePredictorResidentCloneTests`, which force the resident path at small scale via a new **internal** `ResidentThresholdOverrideForTests` hook — so the fix is guarded without a real >1B-param model (which OOMs the 16 GB CI runner and only runs in the nightly HeavyTimeout lane). Both tests (clone output equality; `GetParameters`↔`SetParameters` round-trip) **fail before this change and pass after**.

Regression: **93** existing param-streaming / attention / weight-streaming tests still pass (`PredictorParameterStreamingTests`, `AttentionLayersIntegrationTests`, `CoreLayersIntegrationTests`, `DiTWeightStreamingTests`, `NoisePredictorWeightStreamingTests`).

> Note: this also fixes the same resident round-trip for `GetParameters`/`SetParameters` generally (serialize/save-load at foundation scale), not just `Clone()`.

Closes #1764

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved model cloning and parameter save/load behavior for certain low-precision evaluation paths.
  * Fixed issues where restored or cloned models could produce incorrect outputs after round-tripping parameters.
* **Tests**
  * Added regression coverage for cloning and parameter round-trips in low-precision resident evaluation mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->