### PR TITLE
feat(metrics): language-model perplexity + top-k accuracy metrics

### DIFF
--- a/src/Metrics/LanguageModelMetrics.cs
+++ b/src/Metrics/LanguageModelMetrics.cs
@@ -1,0 +1,145 @@
+using AiDotNet.Helpers;
+using AiDotNet.LinearAlgebra;
+
+namespace AiDotNet.Metrics;
+
+/// <summary>
+/// Static helpers for evaluating language-model / classification predictions over a vocabulary:
+/// <b>perplexity</b> (how surprised the model is by the true tokens) and <b>top-k accuracy</b>
+/// (how often the true token is among the model's k most likely guesses).
+/// </summary>
+/// <typeparam name="T">The numeric type used for calculations (e.g., float, double).</typeparam>
+/// <remarks>
+/// <para><b>For Beginners:</b> A language model outputs, for each position, a score for every word
+/// in its vocabulary. Two standard ways to grade those outputs:</para>
+/// <list type="bullet">
+///   <item><b>Perplexity</b> — think of it as "on average, how many words was the model torn
+///   between?". A perfect model that always puts all its confidence on the right word has
+///   perplexity 1. A model that is uniformly unsure across a 50,000-word vocabulary has
+///   perplexity 50,000. Lower is better. It is exactly <c>exp(mean cross-entropy)</c>.</item>
+///   <item><b>Top-k accuracy</b> — the fraction of positions where the true word is in the model's
+///   top k guesses. Top-1 is ordinary accuracy; top-5 is more forgiving. Higher is better.</item>
+/// </list>
+/// <para>These live next to the other <c>AiDotNet.Metrics</c> helpers and are the standard signals
+/// for gating a language-model training run (e.g. "abort if perplexity stops falling").</para>
+/// </remarks>
+public static class LanguageModelMetrics<T>
+{
+    private static readonly INumericOperations<T> NumOps = MathHelper.GetNumericOperations<T>();
+
+    /// <summary>
+    /// Computes perplexity = <c>exp(mean negative-log-likelihood)</c> of the true tokens under the
+    /// model's predicted distributions.
+    /// </summary>
+    /// <param name="predictions">A [N, V] tensor: for each of N positions, a score over V vocabulary
+    /// entries. Interpreted as raw logits when <paramref name="fromLogits"/> is true (a numerically
+    /// stable softmax is applied), or as already-normalized probabilities otherwise.</param>
+    /// <param name="targets">The N true vocabulary indices (one per row).</param>
+    /// <param name="fromLogits">True (default) if <paramref name="predictions"/> are raw logits;
+    /// false if they are probabilities that already sum to 1 per row.</param>
+    /// <returns>The perplexity as a <typeparamref name="T"/> (≥ 1; lower is better).</returns>
+    /// <exception cref="ArgumentNullException">A required argument is null.</exception>
+    /// <exception cref="ArgumentException">Shapes are inconsistent or empty.</exception>
+    public static T Perplexity(Tensor<T> predictions, int[] targets, bool fromLogits = true)
+        => NumOps.FromDouble(Math.Exp(MeanCrossEntropyDouble(predictions, targets, fromLogits)));
+
+    /// <summary>
+    /// Computes the mean cross-entropy (average negative log-likelihood, in nats) of the true tokens.
+    /// Perplexity is <c>exp</c> of this value; it is exposed separately because a training monitor
+    /// typically streams the loss (cross-entropy) and reports perplexity alongside it.
+    /// </summary>
+    /// <inheritdoc cref="Perplexity(Tensor{T}, int[], bool)"/>
+    public static T CrossEntropy(Tensor<T> predictions, int[] targets, bool fromLogits = true)
+        => NumOps.FromDouble(MeanCrossEntropyDouble(predictions, targets, fromLogits));
+
+    /// <summary>
+    /// Computes top-k accuracy: the fraction of positions whose true token is among the model's k
+    /// highest-scoring vocabulary entries. <paramref name="k"/> = 1 is ordinary top-1 accuracy.
+    /// </summary>
+    /// <param name="predictions">A [N, V] tensor of per-position scores over the vocabulary. Only the
+    /// ordering matters, so logits and probabilities give the same result.</param>
+    /// <param name="targets">The N true vocabulary indices (one per row).</param>
+    /// <param name="k">How many top guesses to consider (1 ≤ k ≤ V).</param>
+    /// <returns>The fraction in [0, 1] as a <typeparamref name="T"/> (higher is better).</returns>
+    public static T TopKAccuracy(Tensor<T> predictions, int[] targets, int k)
+    {
+        if (predictions is null) throw new ArgumentNullException(nameof(predictions));
+        if (targets is null) throw new ArgumentNullException(nameof(targets));
+        var (n, v) = ValidateShape(predictions, targets);
+        if (k < 1 || k > v)
+            throw new ArgumentException($"k must be in [1, {v}] (the vocabulary size), was {k}.", nameof(k));
+
+        int hits = 0;
+        for (int i = 0; i < n; i++)
+        {
+            int target = targets[i];
+            if (target < 0 || target >= v)
+                throw new ArgumentException($"target[{i}]={target} is outside the vocabulary [0, {v}).", nameof(targets));
+
+            // The true token is in the top k iff strictly fewer than k other tokens outscore it.
+            double targetScore = Convert.ToDouble(NumOps.ToDouble(predictions[i, target]));
+            int strictlyGreater = 0;
+            for (int j = 0; j < v; j++)
+            {
+                if (j == target) continue;
+                if (Convert.ToDouble(NumOps.ToDouble(predictions[i, j])) > targetScore && ++strictlyGreater >= k)
+                    break;
+            }
+            if (strictlyGreater < k) hits++;
+        }
+        return NumOps.FromDouble((double)hits / n);
+    }
+
+    // ---- shared numerics ----
+
+    private static double MeanCrossEntropyDouble(Tensor<T> predictions, int[] targets, bool fromLogits)
+    {
+        if (predictions is null) throw new ArgumentNullException(nameof(predictions));
+        if (targets is null) throw new ArgumentNullException(nameof(targets));
+        var (n, v) = ValidateShape(predictions, targets);
+
+        double sumNll = 0.0;
+        for (int i = 0; i < n; i++)
+        {
+            int target = targets[i];
+            if (target < 0 || target >= v)
+                throw new ArgumentException($"target[{i}]={target} is outside the vocabulary [0, {v}).", nameof(targets));
+
+            if (fromLogits)
+            {
+                // Numerically stable log-softmax: nll = logSumExp(row) - row[target].
+                double max = double.NegativeInfinity;
+                for (int j = 0; j < v; j++)
+                {
+                    double z = Convert.ToDouble(NumOps.ToDouble(predictions[i, j]));
+                    if (z > max) max = z;
+                }
+                double sumExp = 0.0;
+                for (int j = 0; j < v; j++)
+                    sumExp += Math.Exp(Convert.ToDouble(NumOps.ToDouble(predictions[i, j])) - max);
+                double logSumExp = max + Math.Log(sumExp);
+                sumNll += logSumExp - Convert.ToDouble(NumOps.ToDouble(predictions[i, target]));
+            }
+            else
+            {
+                double p = Convert.ToDouble(NumOps.ToDouble(predictions[i, target]));
+                // Guard against log(0) for a zero-probability true token.
+                sumNll += -Math.Log(Math.Max(p, 1e-12));
+            }
+        }
+        return sumNll / n;
+    }
+
+    private static (int n, int v) ValidateShape(Tensor<T> predictions, int[] targets)
+    {
+        if (predictions.Rank != 2)
+            throw new ArgumentException($"predictions must be a 2-D [N, V] tensor, had rank {predictions.Rank}.", nameof(predictions));
+        int n = predictions.Shape[0];
+        int v = predictions.Shape[1];
+        if (n == 0 || v == 0)
+            throw new ArgumentException("predictions must be non-empty in both dimensions.", nameof(predictions));
+        if (targets.Length != n)
+            throw new ArgumentException($"targets length {targets.Length} must equal the number of rows {n}.", nameof(targets));
+        return (n, v);
+    }
+}

--- a/src/Metrics/LanguageModelMetrics.cs
+++ b/src/Metrics/LanguageModelMetrics.cs
@@ -49,6 +49,10 @@ public static class LanguageModelMetrics<T>
     /// typically streams the loss (cross-entropy) and reports perplexity alongside it.
     /// </summary>
     /// <inheritdoc cref="Perplexity(Tensor{T}, int[], bool)"/>
+    /// <returns>
+    /// The mean cross-entropy (negative log-likelihood) in nats, &gt;= 0; lower is better. (Perplexity is
+    /// <c>exp</c> of this, so it is &gt;= 1 — this method overrides the inherited perplexity return text.)
+    /// </returns>
     public static T CrossEntropy(Tensor<T> predictions, int[] targets, bool fromLogits = true)
         => NumOps.FromDouble(MeanCrossEntropyDouble(predictions, targets, fromLogits));
 
@@ -77,12 +81,12 @@ public static class LanguageModelMetrics<T>
                 throw new ArgumentException($"target[{i}]={target} is outside the vocabulary [0, {v}).", nameof(targets));
 
             // The true token is in the top k iff strictly fewer than k other tokens outscore it.
-            double targetScore = Convert.ToDouble(NumOps.ToDouble(predictions[i, target]));
+            double targetScore = NumOps.ToDouble(predictions[i, target]);
             int strictlyGreater = 0;
             for (int j = 0; j < v; j++)
             {
                 if (j == target) continue;
-                if (Convert.ToDouble(NumOps.ToDouble(predictions[i, j])) > targetScore && ++strictlyGreater >= k)
+                if (NumOps.ToDouble(predictions[i, j]) > targetScore && ++strictlyGreater >= k)
                     break;
             }
             if (strictlyGreater < k) hits++;
@@ -111,18 +115,18 @@ public static class LanguageModelMetrics<T>
                 double max = double.NegativeInfinity;
                 for (int j = 0; j < v; j++)
                 {
-                    double z = Convert.ToDouble(NumOps.ToDouble(predictions[i, j]));
+                    double z = NumOps.ToDouble(predictions[i, j]);
                     if (z > max) max = z;
                 }
                 double sumExp = 0.0;
                 for (int j = 0; j < v; j++)
-                    sumExp += Math.Exp(Convert.ToDouble(NumOps.ToDouble(predictions[i, j])) - max);
+                    sumExp += Math.Exp(NumOps.ToDouble(predictions[i, j]) - max);
                 double logSumExp = max + Math.Log(sumExp);
-                sumNll += logSumExp - Convert.ToDouble(NumOps.ToDouble(predictions[i, target]));
+                sumNll += logSumExp - NumOps.ToDouble(predictions[i, target]);
             }
             else
             {
-                double p = Convert.ToDouble(NumOps.ToDouble(predictions[i, target]));
+                double p = NumOps.ToDouble(predictions[i, target]);
                 // Guard against log(0) for a zero-probability true token.
                 sumNll += -Math.Log(Math.Max(p, 1e-12));
             }

--- a/tests/AiDotNet.Tests/IntegrationTests/Metrics/LanguageModelMetricsTests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/Metrics/LanguageModelMetricsTests.cs
@@ -1,0 +1,108 @@
+using System;
+using AiDotNet.Metrics;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tests.IntegrationTests.Metrics;
+
+/// <summary>
+/// Unit tests for <see cref="LanguageModelMetrics{T}"/> — perplexity, cross-entropy, and top-k
+/// accuracy over a vocabulary. Values are checked against hand-computed references.
+/// </summary>
+public class LanguageModelMetricsTests
+{
+    private static Tensor<double> Logits(double[,] rows)
+    {
+        int n = rows.GetLength(0), v = rows.GetLength(1);
+        var t = new Tensor<double>(new[] { n, v });
+        for (int i = 0; i < n; i++)
+            for (int j = 0; j < v; j++)
+                t[i, j] = rows[i, j];
+        return t;
+    }
+
+    [Fact]
+    public void Perplexity_UniformOverV_EqualsV()
+    {
+        // Uniform logits over a 4-word vocab => the model is "torn between 4" => perplexity == 4.
+        var logits = Logits(new double[,] { { 0, 0, 0, 0 }, { 0, 0, 0, 0 } });
+        double ppl = LanguageModelMetrics<double>.Perplexity(logits, new[] { 0, 3 });
+        Assert.Equal(4.0, ppl, 6);
+    }
+
+    [Fact]
+    public void Perplexity_ConfidentCorrect_ApproachesOne()
+    {
+        // A very peaked logit on the true token => near-zero surprise => perplexity ~ 1.
+        var logits = Logits(new double[,] { { 20, 0, 0, 0 }, { 0, 0, 0, 20 } });
+        double ppl = LanguageModelMetrics<double>.Perplexity(logits, new[] { 0, 3 });
+        Assert.True(ppl < 1.01, $"expected perplexity ~1, got {ppl}");
+        Assert.True(ppl >= 1.0 - 1e-9, $"perplexity must be >= 1, got {ppl}");
+    }
+
+    [Fact]
+    public void Perplexity_ConfidentWrong_IsLarge()
+    {
+        // All confidence on the WRONG token => very high surprise => large perplexity.
+        var logits = Logits(new double[,] { { 20, 0, 0, 0 } });
+        double ppl = LanguageModelMetrics<double>.Perplexity(logits, new[] { 1 });
+        Assert.True(ppl > 100.0, $"expected large perplexity for a confident wrong prediction, got {ppl}");
+    }
+
+    [Fact]
+    public void CrossEntropy_MatchesLogOfPerplexity()
+    {
+        var logits = Logits(new double[,] { { 2.0, 1.0, 0.5, -1.0 }, { -0.5, 0.3, 1.7, 0.0 } });
+        var targets = new[] { 0, 2 };
+        double ce = LanguageModelMetrics<double>.CrossEntropy(logits, targets);
+        double ppl = LanguageModelMetrics<double>.Perplexity(logits, targets);
+        Assert.Equal(Math.Exp(ce), ppl, 6);
+    }
+
+    [Fact]
+    public void Perplexity_FromProbabilities_Works()
+    {
+        // Rows already sum to 1; true-token probs are 0.5 and 0.25 => CE = mean(-ln p).
+        var probs = Logits(new double[,] { { 0.5, 0.3, 0.2 }, { 0.25, 0.25, 0.5 } });
+        double ppl = LanguageModelMetrics<double>.Perplexity(probs, new[] { 0, 1 }, fromLogits: false);
+        double expected = Math.Exp((-Math.Log(0.5) - Math.Log(0.25)) / 2.0);
+        Assert.Equal(expected, ppl, 6);
+    }
+
+    [Fact]
+    public void TopKAccuracy_Top1_IsArgmaxAccuracy()
+    {
+        // Row 0 argmax=0 (target 0 => hit); row 1 argmax=1 but target 2 => miss. 1/2 = 0.5.
+        var scores = Logits(new double[,] { { 3, 1, 0 }, { 0, 5, 2 } });
+        double acc = LanguageModelMetrics<double>.TopKAccuracy(scores, new[] { 0, 2 }, k: 1);
+        Assert.Equal(0.5, acc, 6);
+    }
+
+    [Fact]
+    public void TopKAccuracy_Top2_IsMoreForgiving()
+    {
+        // Row 1: scores {0,5,2} => top-2 = {1,2}; target 2 is now a hit. Both rows hit => 1.0.
+        var scores = Logits(new double[,] { { 3, 1, 0 }, { 0, 5, 2 } });
+        double acc = LanguageModelMetrics<double>.TopKAccuracy(scores, new[] { 0, 2 }, k: 2);
+        Assert.Equal(1.0, acc, 6);
+    }
+
+    [Fact]
+    public void TopKAccuracy_HandlesTiesWithoutFalseHit()
+    {
+        // Tie between indices 0 and 1 (both 5); target is 2 (score 0). With k=1 the true token is
+        // NOT in the single top slot regardless of tie-breaking => miss.
+        var scores = Logits(new double[,] { { 5, 5, 0 } });
+        double acc = LanguageModelMetrics<double>.TopKAccuracy(scores, new[] { 2 }, k: 1);
+        Assert.Equal(0.0, acc, 6);
+    }
+
+    [Fact]
+    public void InvalidArguments_Throw()
+    {
+        var logits = Logits(new double[,] { { 1, 2, 3 } });
+        Assert.Throws<ArgumentException>(() => LanguageModelMetrics<double>.TopKAccuracy(logits, new[] { 0 }, k: 4));
+        Assert.Throws<ArgumentException>(() => LanguageModelMetrics<double>.Perplexity(logits, new[] { 0, 1 })); // length mismatch
+        Assert.Throws<ArgumentException>(() => LanguageModelMetrics<double>.Perplexity(logits, new[] { 9 }));    // target OOB
+    }
+}

--- a/tests/AiDotNet.Tests/IntegrationTests/Metrics/LanguageModelMetricsTests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/Metrics/LanguageModelMetricsTests.cs
@@ -104,5 +104,10 @@ public class LanguageModelMetricsTests
         Assert.Throws<ArgumentException>(() => LanguageModelMetrics<double>.TopKAccuracy(logits, new[] { 0 }, k: 4));
         Assert.Throws<ArgumentException>(() => LanguageModelMetrics<double>.Perplexity(logits, new[] { 0, 1 })); // length mismatch
         Assert.Throws<ArgumentException>(() => LanguageModelMetrics<double>.Perplexity(logits, new[] { 9 }));    // target OOB
+
+        // Null-argument paths (all three public methods guard predictions/targets).
+        Assert.Throws<ArgumentNullException>(() => LanguageModelMetrics<double>.Perplexity(null!, new[] { 0 }));
+        Assert.Throws<ArgumentNullException>(() => LanguageModelMetrics<double>.CrossEntropy(null!, new[] { 0 }));
+        Assert.Throws<ArgumentNullException>(() => LanguageModelMetrics<double>.TopKAccuracy(logits, null!, k: 1));
     }
 }


### PR DESCRIPTION
## Summary

`AiDotNet.Metrics` had no language-model evaluation metrics — only a data-quality `PerplexityFilter` and `RankingMetrics`. This adds the two standard signals for grading LM / vocabulary-classification predictions and for gating a training run.

## API — `LanguageModelMetrics<T>`

- **`Perplexity(Tensor<T> predictions, int[] targets, bool fromLogits = true)`** — `exp(mean cross-entropy)`; applies a numerically stable log-softmax when given logits, or treats rows as probabilities when `fromLogits: false`.
- **`CrossEntropy(...)`** — mean negative log-likelihood (nats), exposed separately so a monitor can stream the loss and report perplexity alongside it.
- **`TopKAccuracy(Tensor<T> predictions, int[] targets, int k)`** — fraction of positions whose true token is in the model's top-k, via a tie-safe "strictly-greater `< k`" count (no false hit on ties).

## Tests

`LanguageModelMetricsTests` — 9 tests vs hand-computed references: uniform logits ⇒ perplexity == V; confident-correct ⇒ ~1; confident-wrong ⇒ large; `CrossEntropy == ln(Perplexity)`; probabilities path; top-1 == argmax accuracy; top-2 more forgiving; tie handling; argument validation. All green (net10.0).

## Notes

- Pure `AiDotNet.Metrics` addition; no changes to existing code. Independent of #1790.
- Motivated by eval-during-training gates (abort a run that trains but stops improving perplexity / top-k).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added language-model evaluation metrics for perplexity, cross-entropy, and top-k accuracy.
  * Metrics now work with either raw scores or probabilities.

* **Bug Fixes**
  * Improved numerical stability for score handling.
  * Added validation for invalid inputs, including mismatched sizes, out-of-range targets, and invalid top-k values.

* **Tests**
  * Added coverage for perplexity, cross-entropy consistency, top-k behavior, tie handling, and error cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->