### PR TITLE
chore: harden licensing: require a prior online validation before honouring ValidationPending (option B)

### DIFF
--- a/src/Helpers/LicenseValidator.cs
+++ b/src/Helpers/LicenseValidator.cs
@@ -175,6 +175,14 @@ internal sealed class LicenseValidator
                 _cached = result;
             }
 
+            // Record a machine-bound attestation of this SUCCESSFUL online validation so the persistence gate can
+            // safely honour a later ValidationPending (server unreachable) without opening a "block the server →
+            // free forever" bypass. Best-effort; never affects the returned result.
+            if (result.Status == LicenseKeyStatus.Active)
+            {
+                OnlineValidationAttestation.Record(_licenseKey.Key);
+            }
+
             return result;
         }
         catch (Exception ex)
@@ -543,6 +551,11 @@ internal sealed class LicenseValidator
         {
             var result = await ValidateOnlineAsync(cancellationToken).ConfigureAwait(false);
             lock (_cacheLock) { _cached = result; }
+            if (result.Status == LicenseKeyStatus.Active)
+            {
+                OnlineValidationAttestation.Record(_licenseKey.Key);
+            }
+
             return result;
         }
         catch

--- a/src/Helpers/ModelPersistenceGuard.cs
+++ b/src/Helpers/ModelPersistenceGuard.cs
@@ -272,10 +272,24 @@ internal static class ModelPersistenceGuard
             switch (result.Status)
             {
                 case LicenseKeyStatus.Active:
-                case LicenseKeyStatus.ValidationPending:
-                    // Active or pending (within grace period) — allow the operation
+                    // Confirmed valid (online, or offline via a verified HMAC signature) — allow.
                     LicensingTelemetryCollector.Instance.RecordLicensedOperation("persistence");
                     return;
+
+                case LicenseKeyStatus.ValidationPending:
+                    // Server unreachable and not validated in-process. Honour it ONLY when this key has a
+                    // machine-bound attestation of a recent SUCCESSFUL online validation — otherwise blocking the
+                    // license server would grant unbounded unlicensed persistence. A key that has validated online
+                    // (e.g. a community/open-source key) keeps working offline for AttestationValidity.
+                    if (OnlineValidationAttestation.HasValidWithin(
+                            licenseKey, OnlineValidationAttestation.AttestationValidity))
+                    {
+                        LicensingTelemetryCollector.Instance.RecordLicensedOperation("persistence");
+                        return;
+                    }
+
+                    LicensingTelemetryCollector.Instance.RecordLicensingError("validation_pending_no_attestation");
+                    throw new LicenseRequiredException(TrialExpirationReason.LicenseInvalid);
 
                 case LicenseKeyStatus.Expired:
                     LicensingTelemetryCollector.Instance.RecordLicensingError("license_expired");

--- a/src/Helpers/OnlineValidationAttestation.cs
+++ b/src/Helpers/OnlineValidationAttestation.cs
@@ -1,0 +1,202 @@
+using System.Globalization;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace AiDotNet.Helpers;
+
+/// <summary>
+/// Tamper-evident, machine-bound record that a license key has completed at least one SUCCESSFUL ONLINE validation
+/// against the license server.
+/// </summary>
+/// <remarks>
+/// <para><b>Why:</b> the persistence gate honours <c>LicenseKeyStatus.ValidationPending</c> — the status returned
+/// when the license server is unreachable and the key was never validated in this process — by ALLOWING the
+/// operation during an offline grace window. On its own that is a bypass: simply blocking the license server (a
+/// firewall rule, an <c>/etc/hosts</c> entry) yields <c>ValidationPending</c> forever and therefore unbounded
+/// unlicensed persistence. This attestation closes it: <c>ValidationPending</c> is honoured ONLY when the key has a
+/// recorded successful ONLINE validation within <see cref="AttestationValidity"/>. A key that has ever validated
+/// online — e.g. a community/open-source key — keeps working fully offline for <see cref="AttestationValidity"/>
+/// after each success, so genuinely-offline licensed users are not inconvenienced; a never-validated key that can't
+/// reach the server is denied.</para>
+/// <para><b>Protection:</b> the plaintext key is NEVER written — only its SHA-256 hash. The record is HMAC-SHA256
+/// signed with a key derived from the machine fingerprint (same scheme as <see cref="TrialStateManager"/>), so the
+/// file cannot be forged, its timestamp cannot be back-dated, and it cannot be copied to another machine. Signed
+/// (aidn.*) keys are unaffected — they verify offline by HMAC and return <c>Active</c>, never <c>ValidationPending</c>.</para>
+/// </remarks>
+internal static class OnlineValidationAttestation
+{
+    /// <summary>How long a successful online validation lets the key keep operating while the server is
+    /// unreachable. Generous (a licensed user validates online at least monthly) but bounded, so a permanently
+    /// blocked server eventually fails closed.</summary>
+    internal static readonly TimeSpan AttestationValidity = TimeSpan.FromDays(30);
+
+    private static readonly object FileLock = new();
+    private static string? _pathOverrideForTests;
+
+    private static string GetPath() => _pathOverrideForTests ?? Path.Combine(
+        Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".aidotnet", "validation.att");
+
+    /// <summary>TEST-ONLY: redirects the attestation file so tests don't touch the real user profile.</summary>
+    internal static IDisposable OverridePathForTesting(string path)
+    {
+        var previous = _pathOverrideForTests;
+        _pathOverrideForTests = path;
+        return new PathOverrideScope(previous);
+    }
+
+    /// <summary>Records a successful ONLINE validation of <paramref name="licenseKey"/>. Best-effort: an IO failure
+    /// never breaks the validation that just succeeded.</summary>
+    public static void Record(string licenseKey)
+    {
+        if (string.IsNullOrWhiteSpace(licenseKey))
+        {
+            return;
+        }
+
+        try
+        {
+            string data = KeyHash(licenseKey) + "|" +
+                DateTimeOffset.UtcNow.ToUnixTimeSeconds().ToString(CultureInfo.InvariantCulture);
+            string payload = data + "\n" + Sign(data);
+            string path = GetPath();
+            string? dir = Path.GetDirectoryName(path);
+            lock (FileLock)
+            {
+                if (!string.IsNullOrEmpty(dir))
+                {
+                    Directory.CreateDirectory(dir);
+                }
+
+                File.WriteAllText(path, payload);
+            }
+        }
+        catch (Exception ex)
+        {
+            System.Diagnostics.Trace.TraceWarning(
+                "OnlineValidationAttestation: failed to record: " + ex.GetType().Name + ": " + ex.Message);
+        }
+    }
+
+    /// <summary>Returns true when a valid, machine-matched, key-matched attestation exists whose timestamp is within
+    /// <paramref name="window"/> of now (and not implausibly in the future). Fails closed on any error.</summary>
+    public static bool HasValidWithin(string licenseKey, TimeSpan window)
+    {
+        if (string.IsNullOrWhiteSpace(licenseKey))
+        {
+            return false;
+        }
+
+        try
+        {
+            string path = GetPath();
+            string payload;
+            lock (FileLock)
+            {
+                if (!File.Exists(path))
+                {
+                    return false;
+                }
+
+                payload = File.ReadAllText(path);
+            }
+
+            int newline = payload.IndexOf('\n');
+            if (newline <= 0)
+            {
+                return false;
+            }
+
+            string data = payload[..newline];
+            string signature = payload[(newline + 1)..].Trim();
+
+            // Tamper / wrong-machine check: the HMAC is keyed to this machine, so a copied or edited file fails here.
+            if (!ConstantTimeEquals(Sign(data), signature))
+            {
+                return false;
+            }
+
+            string[] parts = data.Split('|');
+            if (parts.Length != 2)
+            {
+                return false;
+            }
+
+            // The attestation must belong to THIS license key.
+            if (!ConstantTimeEquals(parts[0], KeyHash(licenseKey)))
+            {
+                return false;
+            }
+
+            if (!long.TryParse(parts[1], NumberStyles.Integer, CultureInfo.InvariantCulture, out long unix))
+            {
+                return false;
+            }
+
+            DateTimeOffset when = DateTimeOffset.FromUnixTimeSeconds(unix);
+            DateTimeOffset now = DateTimeOffset.UtcNow;
+
+            // A timestamp in the future means the clock was rolled back (or the record forged) — reject.
+            if (when > now.AddMinutes(5))
+            {
+                return false;
+            }
+
+            return when + window > now;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    /// <summary>SHA-256 hash of the key (domain-separated) so the plaintext key never touches disk.</summary>
+    private static string KeyHash(string key)
+    {
+        byte[] bytes = Encoding.UTF8.GetBytes("license-attest:" + key);
+#if NET471
+        using var sha = SHA256.Create();
+        return Convert.ToBase64String(sha.ComputeHash(bytes));
+#else
+        return Convert.ToBase64String(SHA256.HashData(bytes));
+#endif
+    }
+
+    /// <summary>HMAC-SHA256 with a machine-derived key (same domain-separated scheme as TrialStateManager) — binds
+    /// the attestation to this machine and makes the timestamp unforgeable.</summary>
+    private static string Sign(string data)
+    {
+        string machineId = MachineFingerprint.GetMachineId();
+        byte[] keyMaterial = Encoding.UTF8.GetBytes("AiDotNet.OnlineValidation.v1:" + machineId);
+#if NET471
+        using var sha = SHA256.Create();
+        byte[] signingKey = sha.ComputeHash(keyMaterial);
+#else
+        byte[] signingKey = SHA256.HashData(keyMaterial);
+#endif
+        using var hmac = new HMACSHA256(signingKey);
+        return Convert.ToBase64String(hmac.ComputeHash(Encoding.UTF8.GetBytes(data)));
+    }
+
+    private static bool ConstantTimeEquals(string a, string b)
+    {
+        if (a.Length != b.Length)
+        {
+            return false;
+        }
+
+        int result = 0;
+        for (int i = 0; i < a.Length; i++)
+        {
+            result |= a[i] ^ b[i];
+        }
+
+        return result == 0;
+    }
+
+    private sealed class PathOverrideScope : IDisposable
+    {
+        private readonly string? _previous;
+        public PathOverrideScope(string? previous) => _previous = previous;
+        public void Dispose() => _pathOverrideForTests = _previous;
+    }
+}

--- a/tests/AiDotNet.Tests/Helpers/OnlineValidationAttestationTests.cs
+++ b/tests/AiDotNet.Tests/Helpers/OnlineValidationAttestationTests.cs
@@ -1,0 +1,76 @@
+using System;
+using System.IO;
+using AiDotNet.Helpers;
+using Xunit;
+
+namespace AiDotNet.Tests.Helpers;
+
+/// <summary>
+/// Tests the online-validation attestation that closes the "block the license server → unbounded ValidationPending
+/// → free persistence" bypass. The attestation must: honour a recent record for the SAME key, reject a different
+/// key, reject when absent (never validated), reject once the window lapses, and reject a tampered file.
+/// </summary>
+public sealed class OnlineValidationAttestationTests : IDisposable
+{
+    private readonly string _dir;
+    private readonly string _path;
+    private readonly IDisposable _override;
+
+    public OnlineValidationAttestationTests()
+    {
+        _dir = Path.Combine(Path.GetTempPath(), "aidn-att-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_dir);
+        _path = Path.Combine(_dir, "validation.att");
+        _override = OnlineValidationAttestation.OverridePathForTesting(_path);
+    }
+
+    public void Dispose()
+    {
+        _override.Dispose();
+        try { Directory.Delete(_dir, recursive: true); } catch { /* best effort */ }
+    }
+
+    [Fact]
+    public void Recorded_key_is_valid_within_window()
+    {
+        OnlineValidationAttestation.Record("aidn.abc.def");
+        Assert.True(OnlineValidationAttestation.HasValidWithin("aidn.abc.def", TimeSpan.FromDays(30)));
+    }
+
+    [Fact]
+    public void Different_key_is_not_honoured()
+    {
+        OnlineValidationAttestation.Record("aidn.abc.def");
+        Assert.False(OnlineValidationAttestation.HasValidWithin("AIDN-PROD-somethingelse", TimeSpan.FromDays(30)));
+    }
+
+    [Fact]
+    public void Absent_attestation_fails_closed()
+    {
+        // Never recorded — this is the bypass case (blocked server, never validated) and MUST be denied.
+        Assert.False(OnlineValidationAttestation.HasValidWithin("aidn.abc.def", TimeSpan.FromDays(30)));
+    }
+
+    [Fact]
+    public void Lapsed_window_is_rejected()
+    {
+        OnlineValidationAttestation.Record("aidn.abc.def");
+        // A zero-length window means "must have validated in the last instant" — the just-written record is already
+        // outside it, proving the time bound is enforced (a permanently-blocked server eventually fails closed).
+        Assert.False(OnlineValidationAttestation.HasValidWithin("aidn.abc.def", TimeSpan.Zero));
+    }
+
+    [Fact]
+    public void Tampered_file_is_rejected()
+    {
+        OnlineValidationAttestation.Record("aidn.abc.def");
+        // Flip the signature line — the HMAC no longer verifies, so the record is rejected.
+        var lines = File.ReadAllText(_path);
+        File.WriteAllText(_path, lines + "TAMPER");
+        Assert.False(OnlineValidationAttestation.HasValidWithin("aidn.abc.def", TimeSpan.FromDays(30)));
+
+        // Garbage content is also rejected.
+        File.WriteAllText(_path, "not-a-valid-envelope");
+        Assert.False(OnlineValidationAttestation.HasValidWithin("aidn.abc.def", TimeSpan.FromDays(30)));
+    }
+}


### PR DESCRIPTION
## Security fix — closes a persistence-gate bypass

`ModelPersistenceGuard` allowed `LicenseKeyStatus.ValidationPending` — the status `LicenseValidator` returns when the license server is unreachable and the key was never validated in-process. On its own that is a bypass: **blocking the license server** (a firewall rule, an `/etc/hosts` entry) yields `ValidationPending` indefinitely and therefore **unbounded unlicensed persistence**.

## Fix (option B — require at least one successful online validation)

`ValidationPending` is now honoured **only** when the key carries a machine-bound attestation of a recent successful **online** validation:

- **`OnlineValidationAttestation`** — a tamper-evident record written on each successful online validation. The **plaintext key is never stored** (only its SHA-256 hash), and the record is **HMAC-SHA256 signed with a machine-fingerprint-derived key** (same scheme as `TrialStateManager`), so it can't be forged, back-dated, or copied to another machine. Valid **30 days** per success — a licensed user validates online at least monthly; a permanently-blocked server eventually fails closed.
- **`LicenseValidator`** records the attestation on every `Active` online result (sync + async), best-effort (an IO error never breaks a successful validation).
- **`ModelPersistenceGuard`**: `Active` → allow; `ValidationPending` → allow only with a valid in-window attestation, else `LicenseRequiredException`.

## Who is (not) affected

- **Signed offline `aidn.*` keys** — unaffected; they verify locally by HMAC → `Active`, never `Pending`.
- **Community / open-source keys** — keep working **fully offline for 30 days** after each online validation, so genuinely-offline licensed users are not inconvenienced.
- **Never-validated key + blocked server** — now denied (this was the bypass).

## Tests

5 new (`OnlineValidationAttestationTests`): honours the same key in-window, rejects a different key, **fails closed when absent** (the bypass case), rejects a lapsed window, rejects a tampered/garbage file. 274 existing license / trial / persistence tests stay green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)