### PR TITLE
fix(license): require a 32-byte signature to classify aidn. keys as offline-HMAC

### DIFF
--- a/src/Helpers/LicenseValidator.cs
+++ b/src/Helpers/LicenseValidator.cs
@@ -344,7 +344,38 @@ internal sealed class LicenseValidator
         for (int i = 0; i < parts[2].Length; i++)
             if (!IsBase64UrlChar(parts[2][i])) return false;
 
-        return true;
+        // The signature of an OFFLINE-verifiable key is an HMAC-SHA256 tag — exactly 32 bytes.
+        // Keys whose signature segment decodes to any other length are NOT offline-HMAC keys
+        // (e.g. short-form server-validated keys that merely share the `aidn.` prefix). Classifying
+        // them as signed routes them to the offline-only HMAC path (ServerUrl == "") where a
+        // sub-32-byte signature can never match a 32-byte HMAC tag → 100% false rejection on
+        // official builds, even for keys the license SERVER accepts. Returning false here lets such
+        // keys fall through to server validation (ServerUrl == null) instead.
+        return Base64UrlByteLength(parts[2]) == 32;
+    }
+
+    /// <summary>
+    /// Returns the decoded byte length of a base64url (RFC 4648 §5, no padding) segment, or -1 if it
+    /// is not valid base64url. Used to distinguish a 32-byte HMAC signature (offline-verifiable) from
+    /// shorter server-key identifiers that share the <c>aidn.</c> prefix.
+    /// </summary>
+    private static int Base64UrlByteLength(string b64url)
+    {
+        try
+        {
+            string s = b64url.Replace('-', '+').Replace('_', '/');
+            switch (s.Length % 4)
+            {
+                case 1: return -1;                 // never a valid base64 length
+                case 2: s += "=="; break;
+                case 3: s += "="; break;
+            }
+            return Convert.FromBase64String(s).Length;
+        }
+        catch (FormatException)
+        {
+            return -1;
+        }
     }
 
     /// <summary>

--- a/tests/AiDotNet.Tests/Helpers/LicenseValidatorTests.cs
+++ b/tests/AiDotNet.Tests/Helpers/LicenseValidatorTests.cs
@@ -22,6 +22,25 @@ public class LicenseValidatorTests
     private static readonly string ValidTestKey2 = LicenseTestSupport.SignedKey("cached12key3");
     private static readonly string ValidTestKey3 = LicenseTestSupport.SignedKey("grace12test3");
 
+    [Fact]
+    public void IsSignedKeyFormat_RequiresA32ByteSignature()
+    {
+        // A genuine offline-verifiable key has a 32-byte HMAC-SHA256 signature.
+        Assert.True(LicenseValidator.IsSignedKeyFormat(LicenseTestSupport.SignedKey("abc123def456")));
+
+        // Short-form server-validated keys share the `aidn.` prefix but their signature segment
+        // decodes to fewer than 32 bytes; they must NOT be classified as offline-HMAC (that routes
+        // them to the offline-only path where they can never validate — they belong on the server).
+        Assert.False(LicenseValidator.IsSignedKeyFormat("aidn.e284ddf8d8c6.b48e57387dbc47cf")); // 12-byte sig
+        Assert.False(LicenseValidator.IsSignedKeyFormat("aidn.0b7.1c2d"));                       // tiny sig
+
+        // Malformed / non-signed formats.
+        Assert.False(LicenseValidator.IsSignedKeyFormat("AIDN-PROD-abc-123"));  // server format, not aidn.
+        Assert.False(LicenseValidator.IsSignedKeyFormat("aidn..sig"));          // empty id
+        Assert.False(LicenseValidator.IsSignedKeyFormat("aidn.id."));           // empty sig
+        Assert.False(LicenseValidator.IsSignedKeyFormat(null!));
+    }
+
     [Fact(Timeout = 60000)]
     public async Task OfflineMode_ValidKey_ReturnsActive()
     {


### PR DESCRIPTION
## Summary

`LicenseValidator.IsSignedKeyFormat` classified **any** `aidn.{id}.{sig}` with non-empty base64url segments as an offline-verifiable signed key — regardless of the signature's length. But `ValidateOffline` verifies an **HMAC-SHA256** tag (exactly **32 bytes**). So a short-form key such as `aidn.e284ddf8d8c6.b48e57387dbc47cf` (signature decodes to **12 bytes**) is routed to the offline-only HMAC path (`ServerUrl == ""`) where a sub-32-byte signature can *never* match a 32-byte HMAC → **100% false rejection on official builds**, even for keys the license **server** accepts.

## Fix

Require the signature segment to base64url-decode to **exactly 32 bytes** for a key to be classified offline-verifiable. Keys with any other signature length fall through to **server validation** (`ServerUrl == null`) — the correct home for short-form server-validated keys that merely share the `aidn.` prefix.

- `IsSignedKeyFormat` now returns `Base64UrlByteLength(parts[2]) == 32` after the existing format/charset checks.
- Added `Base64UrlByteLength` (RFC 4648 §5, no padding; returns -1 on malformed).

## Tests

`IsSignedKeyFormat_RequiresA32ByteSignature`: a real 32-byte HMAC key (`LicenseTestSupport.SignedKey`) ⇒ true; short-form 12-byte-sig keys ⇒ false; malformed/empty/`AIDN-` server format ⇒ false. **All 26 `LicenseValidatorTests` pass (net10.0)** — existing offline-validation behavior for genuine signed keys is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
