### PR TITLE
feat(licensing): asymmetric public-key signatures (aidn2) — replace extractable symmetric HMAC

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -248,6 +248,12 @@
     <PackageVersion Include="Microsoft.Azure.Functions.Worker.ApplicationInsights" Version="2.50.0" />
     <PackageVersion Include="Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore" Version="2.1.0" />
     <PackageVersion Include="Microsoft.Azure.Functions.Worker.Sdk" Version="2.0.7" />
+    <!-- Cryptography -->
+    <!-- BouncyCastle.Cryptography (Org.BouncyCastle) provides Ed25519 (EdDSA) uniformly across
+         net471/net8/net10 — .NET's System.Security.Cryptography ships NO Ed25519 type on any of
+         those TFMs. Used by the asymmetric (aidn2) license verifier. Well-audited, single dep,
+         targets net461+/netstandard2.0. -->
+    <PackageVersion Include="BouncyCastle.Cryptography" Version="2.6.1" />
     <!-- Serialization and data -->
     <PackageVersion Include="Google.Protobuf" Version="3.35.1" />
     <PackageVersion Include="MatFileHandler" Version="1.3.0" />

--- a/src/AiDotNet.csproj
+++ b/src/AiDotNet.csproj
@@ -96,6 +96,8 @@
 	       of the core package. -->
 	  <!-- <PackageReference Include="Elastic.Clients.Elasticsearch" /> -->
 
+	  <!-- Ed25519 (EdDSA) for asymmetric aidn2 license verification — no BCL Ed25519 on any TFM. -->
+	  <PackageReference Include="BouncyCastle.Cryptography" />
 	  <PackageReference Include="Google.Protobuf" />
 	  <PackageReference Include="Microsoft.CSharp" />
 	  <PackageReference Include="Microsoft.Extensions.AI.Abstractions" />
@@ -273,10 +275,11 @@
 	    <LogicalName>AiDotNet.BuildKey</LogicalName>
 	  </EmbeddedResource>
 	  <!-- Asymmetric license PUBLIC signing key(s) used by LicensePublicKeyProvider to verify
-	       aidn2.{claims}.{signature} tokens offline. Unlike BuildKey this is a PUBLIC key and is
-	       safe to ship/extract (worthless to a forger). Injected during official CI/CD builds;
-	       CI generates the RSA keypair, keeps the PRIVATE key in a secret store (never committed),
-	       and drops the public half here as JWK-like JSON: { "keys": [ { "kid", "n", "e" } ] }.
+	       aidn2.{claims}.{signature} tokens offline (Ed25519 / EdDSA). Unlike BuildKey this is a
+	       PUBLIC key and is safe to ship/extract (worthless to a forger). Injected during official
+	       CI/CD builds; CI generates the Ed25519 keypair, keeps the PRIVATE key in a secret store
+	       (never committed), and drops the public half here as JWK OKP JSON:
+	       { "keys": [ { "kty":"OKP", "crv":"Ed25519", "kid":"...", "x":"<base64url 32-byte pubkey>" } ] }.
 	       See LicensePublicKeyProvider.cs. -->
 	  <EmbeddedResource Include="BuildKey\LicensePublicKey.json" Condition="Exists('BuildKey\LicensePublicKey.json')">
 	    <LogicalName>AiDotNet.LicensePublicKey</LogicalName>

--- a/src/AiDotNet.csproj
+++ b/src/AiDotNet.csproj
@@ -272,6 +272,15 @@
 	  <EmbeddedResource Include="BuildKey\BuildKey.bin" Condition="Exists('BuildKey\BuildKey.bin')">
 	    <LogicalName>AiDotNet.BuildKey</LogicalName>
 	  </EmbeddedResource>
+	  <!-- Asymmetric license PUBLIC signing key(s) used by LicensePublicKeyProvider to verify
+	       aidn2.{claims}.{signature} tokens offline. Unlike BuildKey this is a PUBLIC key and is
+	       safe to ship/extract (worthless to a forger). Injected during official CI/CD builds;
+	       CI generates the RSA keypair, keeps the PRIVATE key in a secret store (never committed),
+	       and drops the public half here as JWK-like JSON: { "keys": [ { "kid", "n", "e" } ] }.
+	       See LicensePublicKeyProvider.cs. -->
+	  <EmbeddedResource Include="BuildKey\LicensePublicKey.json" Condition="Exists('BuildKey\LicensePublicKey.json')">
+	    <LogicalName>AiDotNet.LicensePublicKey</LogicalName>
+	  </EmbeddedResource>
 	  <EmbeddedResource Include="IntegrityHash\IntegrityHash.bin" Condition="Exists('IntegrityHash\IntegrityHash.bin')">
 	    <LogicalName>AiDotNet.IntegrityHash</LogicalName>
 	  </EmbeddedResource>

--- a/src/Helpers/AsymmetricLicenseVerifier.cs
+++ b/src/Helpers/AsymmetricLicenseVerifier.cs
@@ -39,6 +39,13 @@ internal static class AsymmetricLicenseVerifier
     private const int Ed25519SignatureSize = 64;
 
     /// <summary>
+    /// Upper bound for a Unix-seconds <c>exp</c> claim (9999-12-31T23:59:59Z), the max
+    /// <see cref="DateTimeOffset"/> can represent. Values outside (0, MaxUnixSeconds] are rejected
+    /// up front so <see cref="DateTimeOffset.FromUnixTimeSeconds"/> can never throw.
+    /// </summary>
+    private const long MaxUnixSeconds = 253402300799L;
+
+    /// <summary>
     /// Allowed clock skew when checking expiry, so a token that is a few seconds past <c>exp</c>
     /// due to clock drift between the signing server and the client is not spuriously rejected.
     /// Kept small — expiry is the primary bound on offline use.
@@ -79,6 +86,36 @@ internal static class AsymmetricLicenseVerifier
             || (c >= '0' && c <= '9')
             || c == '-'
             || c == '_';
+    }
+
+    /// <summary>
+    /// Cheaply decodes the <c>kid</c> claim from an <c>aidn2.</c> token WITHOUT verifying the signature.
+    /// Used only for routing (to decide whether this build embeds the matching public key). It never
+    /// grants a license — <see cref="Verify"/> remains the sole path that can return
+    /// <see cref="LicenseKeyStatus.Active"/>. Returns false on any malformed input or absent kid.
+    /// </summary>
+    internal static bool TryGetKid(string? key, out string kid)
+    {
+        kid = string.Empty;
+        if (!IsAsymmetricKeyFormat(key)) return false;
+
+        // key is non-null and 3 parts here (IsAsymmetricKeyFormat guaranteed it).
+        var parts = key!.Split('.');
+        try
+        {
+            byte[] claimsBytes = Base64UrlHelper.Decode(parts[1]);
+            if (claimsBytes.Length == 0) return false;
+            string claimsJson = System.Text.Encoding.UTF8.GetString(claimsBytes);
+            LicenseClaims? claims = LicenseClaims.TryParse(claimsJson);
+            string? parsedKid = claims?.Kid;
+            if (parsedKid is null || parsedKid.Length == 0) return false;
+            kid = parsedKid;
+            return true;
+        }
+        catch (Exception ex) when (ex is FormatException or ArgumentException)
+        {
+            return false;
+        }
     }
 
     /// <summary>
@@ -191,9 +228,19 @@ internal static class AsymmetricLicenseVerifier
             return Invalid("License signature verification failed.");
         }
 
-        // Signature is authentic. Now enforce expiry (bounds offline use of a leaked token).
+        // Signature is authentic. Fail CLOSED on a missing / non-positive / out-of-range exp claim
+        // BEFORE converting it: a malformed exp must never be treated as "non-expiring" (that would let
+        // a token with no/garbage expiry live forever offline), and DateTimeOffset.FromUnixTimeSeconds
+        // throws on out-of-range input. Every legitimately-issued aidn2 token carries a positive,
+        // bounded exp (offline use is expiry-bounded by design).
+        if (claims.Exp <= 0 || claims.Exp > MaxUnixSeconds)
+        {
+            return Invalid("License token has a missing or invalid expiry (exp).");
+        }
+
+        // Enforce expiry (bounds offline use of a leaked token).
         DateTimeOffset expiresAt = DateTimeOffset.FromUnixTimeSeconds(claims.Exp);
-        if (claims.Exp > 0 && expiresAt + ClockSkew < nowUtc)
+        if (expiresAt + ClockSkew < nowUtc)
         {
             return new LicenseValidationResult(
                 LicenseKeyStatus.Expired,
@@ -206,7 +253,7 @@ internal static class AsymmetricLicenseVerifier
         return new LicenseValidationResult(
             LicenseKeyStatus.Active,
             tier: claims.Tier,
-            expiresAt: claims.Exp > 0 ? expiresAt : (DateTimeOffset?)null,
+            expiresAt: expiresAt,
             seatsMax: claims.Seats > 0 ? claims.Seats : (int?)null,
             message: "Offline validation succeeded (signature verified).");
     }

--- a/src/Helpers/AsymmetricLicenseVerifier.cs
+++ b/src/Helpers/AsymmetricLicenseVerifier.cs
@@ -1,6 +1,7 @@
-using System.Security.Cryptography;
 using AiDotNet.Enums;
 using AiDotNet.Models;
+using Org.BouncyCastle.Crypto.Parameters;
+using Org.BouncyCastle.Crypto.Signers;
 
 namespace AiDotNet.Helpers;
 
@@ -15,21 +16,27 @@ namespace AiDotNet.Helpers;
 /// still cannot forge a valid token. This is strictly stronger than the old symmetric HMAC scheme,
 /// where the same secret had to ship in every DLL and could be used to mint unlimited fake keys.</para>
 ///
-/// <para><b>Primitive:</b> RSA-2048 (or larger) with RSASSA-PKCS1-v1.5 and SHA-256 — the exact
-/// algorithm behind JWT <c>RS256</c>. Chosen because it is available in
-/// <c>System.Security.Cryptography</c> on <b>every</b> target framework (net471/net8/net10) with no
-/// added dependency, and importing a public key from modulus+exponent works uniformly across all of
-/// them (unlike <c>ImportSubjectPublicKeyInfo</c>, which does not exist on net471, or Ed25519/PSS,
-/// which are not available on net471's default RSA implementation).</para>
+/// <para><b>Primitive:</b> Ed25519 (EdDSA over Curve25519, RFC 8032) — the modern, security-forward
+/// signature standard: fast, 32-byte public keys, 64-byte signatures, deterministic (no per-signature
+/// randomness to leak), side-channel-resistant by construction, and free of the RSA
+/// padding/parameter-oracle class of pitfalls. .NET's <c>System.Security.Cryptography</c> ships no
+/// Ed25519 type on ANY target framework (net471/net8/net10), so verification uses the well-audited
+/// <c>BouncyCastle.Cryptography</c> library, which provides Ed25519 uniformly across all three.</para>
 ///
 /// <para><b>Token grammar:</b> <c>aidn2.&lt;base64url(claims_json)&gt;.&lt;base64url(signature)&gt;</c>
 /// where the signature is computed over the raw UTF-8 bytes of <c>claims_json</c> (i.e. the exact
-/// bytes obtained by base64url-decoding the middle segment).</para>
+/// bytes obtained by base64url-decoding the middle segment). Claims carry <c>alg:"EdDSA"</c>.</para>
 /// </remarks>
 internal static class AsymmetricLicenseVerifier
 {
     /// <summary>The token version prefix for asymmetric (public-key-signed) licenses.</summary>
     internal const string Prefix = "aidn2";
+
+    /// <summary>The signature algorithm this verifier implements. Tokens must declare this (or omit alg).</summary>
+    internal const string Algorithm = "EdDSA";
+
+    /// <summary>Ed25519 signatures are exactly 64 bytes.</summary>
+    private const int Ed25519SignatureSize = 64;
 
     /// <summary>
     /// Allowed clock skew when checking expiry, so a token that is a few seconds past <c>exp</c>
@@ -75,8 +82,8 @@ internal static class AsymmetricLicenseVerifier
     }
 
     /// <summary>
-    /// Verifies an <c>aidn2.</c> token fully offline: checks the signature against the embedded public
-    /// key selected by the token's <c>kid</c>, then enforces expiry. Fails closed on any problem.
+    /// Verifies an <c>aidn2.</c> token fully offline: checks the Ed25519 signature against the embedded
+    /// public key selected by the token's <c>kid</c>, then enforces expiry. Fails closed on any problem.
     /// </summary>
     /// <param name="key">The full <c>aidn2.&lt;claims&gt;.&lt;sig&gt;</c> token.</param>
     /// <param name="nowUtc">The current UTC time (injectable for tests).</param>
@@ -84,7 +91,8 @@ internal static class AsymmetricLicenseVerifier
     /// An <see cref="LicenseValidationResult"/>: <see cref="LicenseKeyStatus.Active"/> when the
     /// signature verifies and the token is unexpired; <see cref="LicenseKeyStatus.Expired"/> when the
     /// signature verifies but <c>exp</c> has passed; <see cref="LicenseKeyStatus.Invalid"/> for a bad
-    /// signature, unknown <c>kid</c>, malformed token, or a build that embeds no public key.
+    /// signature, unknown <c>kid</c>, unsupported <c>alg</c>, malformed token, or a build that embeds
+    /// no public key.
     /// </returns>
     internal static LicenseValidationResult Verify(string key, DateTimeOffset nowUtc)
     {
@@ -116,6 +124,11 @@ internal static class AsymmetricLicenseVerifier
             return Invalid("License token is missing claims or signature.");
         }
 
+        if (signature.Length != Ed25519SignatureSize)
+        {
+            return Invalid("License signature is not a valid Ed25519 signature.");
+        }
+
         string claimsJson;
         try
         {
@@ -132,6 +145,15 @@ internal static class AsymmetricLicenseVerifier
             return Invalid("License token claims are malformed.");
         }
 
+        // Reject a token that declares a signature algorithm this verifier does not implement, so a
+        // future primitive can never be silently treated as Ed25519. A missing alg is tolerated
+        // (implicitly EdDSA for aidn2), but a present, mismatched alg fails closed.
+        if (claims.Alg is not null && claims.Alg.Length > 0 &&
+            !string.Equals(claims.Alg, Algorithm, StringComparison.Ordinal))
+        {
+            return Invalid("License token declares unsupported signature algorithm '" + claims.Alg + "'.");
+        }
+
         string? kid = claims.Kid;
         if (kid is null || kid.Length == 0)
         {
@@ -140,7 +162,7 @@ internal static class AsymmetricLicenseVerifier
 
         // A build that embeds no public key CANNOT verify a signature. It must NOT trust the token —
         // fail closed exactly like the HMAC path does when the build key is absent.
-        if (!LicensePublicKeyProvider.TryGetPublicKey(kid, out RSAParameters publicKey))
+        if (!LicensePublicKeyProvider.TryGetPublicKey(kid, out byte[] publicKey))
         {
             return Invalid(
                 "This build cannot verify the license signature: no embedded public key matches the " +
@@ -150,16 +172,17 @@ internal static class AsymmetricLicenseVerifier
         bool signatureValid;
         try
         {
-            using var rsa = RSA.Create();
-            rsa.ImportParameters(publicKey);
-            // RSASSA-PKCS1-v1.5 + SHA-256 == JWT RS256. Signature is over the raw claims bytes.
-            signatureValid = rsa.VerifyData(
-                claimsBytes, signature, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
+            var publicKeyParameters = new Ed25519PublicKeyParameters(publicKey, 0);
+            var verifier = new Ed25519Signer();
+            verifier.Init(false, publicKeyParameters);
+            verifier.BlockUpdate(claimsBytes, 0, claimsBytes.Length);
+            signatureValid = verifier.VerifySignature(signature);
         }
-        catch (CryptographicException ex)
+        catch (Exception ex)
         {
+            // BouncyCastle can throw on structurally-bad key/signature material — treat as invalid.
             System.Diagnostics.Trace.TraceWarning(
-                "AsymmetricLicenseVerifier: verification error: " + ex.Message);
+                "AsymmetricLicenseVerifier: verification error: " + ex.GetType().Name + ": " + ex.Message);
             return Invalid("License signature verification failed.");
         }
 

--- a/src/Helpers/AsymmetricLicenseVerifier.cs
+++ b/src/Helpers/AsymmetricLicenseVerifier.cs
@@ -1,0 +1,193 @@
+using System.Security.Cryptography;
+using AiDotNet.Enums;
+using AiDotNet.Models;
+
+namespace AiDotNet.Helpers;
+
+/// <summary>
+/// Verifies <c>aidn2.</c> asymmetric license tokens against the embedded PUBLIC signing key(s).
+/// </summary>
+/// <remarks>
+/// <para><b>For Beginners:</b> This is the security core of the new licensing scheme. A token looks
+/// like <c>aidn2.&lt;claims&gt;.&lt;signature&gt;</c>. We recompute nothing secret — we only check that
+/// the signature was produced by the holder of the private key (which lives on the server and never
+/// ships). Because verification uses a <b>public</b> key, an attacker who extracts it from the DLL
+/// still cannot forge a valid token. This is strictly stronger than the old symmetric HMAC scheme,
+/// where the same secret had to ship in every DLL and could be used to mint unlimited fake keys.</para>
+///
+/// <para><b>Primitive:</b> RSA-2048 (or larger) with RSASSA-PKCS1-v1.5 and SHA-256 — the exact
+/// algorithm behind JWT <c>RS256</c>. Chosen because it is available in
+/// <c>System.Security.Cryptography</c> on <b>every</b> target framework (net471/net8/net10) with no
+/// added dependency, and importing a public key from modulus+exponent works uniformly across all of
+/// them (unlike <c>ImportSubjectPublicKeyInfo</c>, which does not exist on net471, or Ed25519/PSS,
+/// which are not available on net471's default RSA implementation).</para>
+///
+/// <para><b>Token grammar:</b> <c>aidn2.&lt;base64url(claims_json)&gt;.&lt;base64url(signature)&gt;</c>
+/// where the signature is computed over the raw UTF-8 bytes of <c>claims_json</c> (i.e. the exact
+/// bytes obtained by base64url-decoding the middle segment).</para>
+/// </remarks>
+internal static class AsymmetricLicenseVerifier
+{
+    /// <summary>The token version prefix for asymmetric (public-key-signed) licenses.</summary>
+    internal const string Prefix = "aidn2";
+
+    /// <summary>
+    /// Allowed clock skew when checking expiry, so a token that is a few seconds past <c>exp</c>
+    /// due to clock drift between the signing server and the client is not spuriously rejected.
+    /// Kept small — expiry is the primary bound on offline use.
+    /// </summary>
+    private static readonly TimeSpan ClockSkew = TimeSpan.FromMinutes(5);
+
+    /// <summary>
+    /// Returns true if <paramref name="key"/> is in the asymmetric token shape:
+    /// <c>aidn2.&lt;base64url&gt;.&lt;base64url&gt;</c>. Does NOT verify the signature — this is a
+    /// cheap structural check used for routing (see <see cref="LicenseValidator"/>).
+    /// </summary>
+    internal static bool IsAsymmetricKeyFormat(string? key)
+    {
+        if (key is null) return false;
+        var parts = key.Split('.');
+        if (parts.Length != 3 || parts[0] != Prefix || parts[1].Length == 0 || parts[2].Length == 0)
+        {
+            return false;
+        }
+
+        for (int i = 0; i < parts[1].Length; i++)
+        {
+            if (!IsBase64UrlChar(parts[1][i])) return false;
+        }
+
+        for (int i = 0; i < parts[2].Length; i++)
+        {
+            if (!IsBase64UrlChar(parts[2][i])) return false;
+        }
+
+        return true;
+    }
+
+    private static bool IsBase64UrlChar(char c)
+    {
+        return (c >= 'A' && c <= 'Z')
+            || (c >= 'a' && c <= 'z')
+            || (c >= '0' && c <= '9')
+            || c == '-'
+            || c == '_';
+    }
+
+    /// <summary>
+    /// Verifies an <c>aidn2.</c> token fully offline: checks the signature against the embedded public
+    /// key selected by the token's <c>kid</c>, then enforces expiry. Fails closed on any problem.
+    /// </summary>
+    /// <param name="key">The full <c>aidn2.&lt;claims&gt;.&lt;sig&gt;</c> token.</param>
+    /// <param name="nowUtc">The current UTC time (injectable for tests).</param>
+    /// <returns>
+    /// An <see cref="LicenseValidationResult"/>: <see cref="LicenseKeyStatus.Active"/> when the
+    /// signature verifies and the token is unexpired; <see cref="LicenseKeyStatus.Expired"/> when the
+    /// signature verifies but <c>exp</c> has passed; <see cref="LicenseKeyStatus.Invalid"/> for a bad
+    /// signature, unknown <c>kid</c>, malformed token, or a build that embeds no public key.
+    /// </returns>
+    internal static LicenseValidationResult Verify(string key, DateTimeOffset nowUtc)
+    {
+        if (string.IsNullOrWhiteSpace(key))
+        {
+            return Invalid("License key is empty or missing.");
+        }
+
+        var parts = key.Split('.');
+        if (parts.Length != 3 || parts[0] != Prefix)
+        {
+            return Invalid("License token is not a valid aidn2 token.");
+        }
+
+        byte[] claimsBytes;
+        byte[] signature;
+        try
+        {
+            claimsBytes = Base64UrlHelper.Decode(parts[1]);
+            signature = Base64UrlHelper.Decode(parts[2]);
+        }
+        catch (FormatException)
+        {
+            return Invalid("License token encoding is malformed.");
+        }
+
+        if (claimsBytes.Length == 0 || signature.Length == 0)
+        {
+            return Invalid("License token is missing claims or signature.");
+        }
+
+        string claimsJson;
+        try
+        {
+            claimsJson = System.Text.Encoding.UTF8.GetString(claimsBytes);
+        }
+        catch (ArgumentException)
+        {
+            return Invalid("License token claims are not valid UTF-8.");
+        }
+
+        LicenseClaims? claims = LicenseClaims.TryParse(claimsJson);
+        if (claims is null)
+        {
+            return Invalid("License token claims are malformed.");
+        }
+
+        string? kid = claims.Kid;
+        if (kid is null || kid.Length == 0)
+        {
+            return Invalid("License token does not name a signing key (kid).");
+        }
+
+        // A build that embeds no public key CANNOT verify a signature. It must NOT trust the token —
+        // fail closed exactly like the HMAC path does when the build key is absent.
+        if (!LicensePublicKeyProvider.TryGetPublicKey(kid, out RSAParameters publicKey))
+        {
+            return Invalid(
+                "This build cannot verify the license signature: no embedded public key matches the " +
+                "token's key id (kid='" + kid + "'). Use an official build, or online validation.");
+        }
+
+        bool signatureValid;
+        try
+        {
+            using var rsa = RSA.Create();
+            rsa.ImportParameters(publicKey);
+            // RSASSA-PKCS1-v1.5 + SHA-256 == JWT RS256. Signature is over the raw claims bytes.
+            signatureValid = rsa.VerifyData(
+                claimsBytes, signature, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
+        }
+        catch (CryptographicException ex)
+        {
+            System.Diagnostics.Trace.TraceWarning(
+                "AsymmetricLicenseVerifier: verification error: " + ex.Message);
+            return Invalid("License signature verification failed.");
+        }
+
+        if (!signatureValid)
+        {
+            return Invalid("License signature verification failed.");
+        }
+
+        // Signature is authentic. Now enforce expiry (bounds offline use of a leaked token).
+        DateTimeOffset expiresAt = DateTimeOffset.FromUnixTimeSeconds(claims.Exp);
+        if (claims.Exp > 0 && expiresAt + ClockSkew < nowUtc)
+        {
+            return new LicenseValidationResult(
+                LicenseKeyStatus.Expired,
+                tier: claims.Tier,
+                expiresAt: expiresAt,
+                seatsMax: claims.Seats > 0 ? claims.Seats : (int?)null,
+                message: "License token expired on " + expiresAt.UtcDateTime.ToString("u") + ".");
+        }
+
+        return new LicenseValidationResult(
+            LicenseKeyStatus.Active,
+            tier: claims.Tier,
+            expiresAt: claims.Exp > 0 ? expiresAt : (DateTimeOffset?)null,
+            seatsMax: claims.Seats > 0 ? claims.Seats : (int?)null,
+            message: "Offline validation succeeded (signature verified).");
+    }
+
+    private static LicenseValidationResult Invalid(string message) =>
+        new(LicenseKeyStatus.Invalid, message: message);
+}

--- a/src/Helpers/Base64UrlHelper.cs
+++ b/src/Helpers/Base64UrlHelper.cs
@@ -1,0 +1,48 @@
+namespace AiDotNet.Helpers;
+
+/// <summary>
+/// Minimal Base64URL (RFC 4648 §5) encode/decode helper used by the asymmetric license
+/// token path. Base64URL uses '-'/'_' instead of '+'/'/' and omits padding.
+/// </summary>
+/// <remarks>
+/// <b>For Beginners:</b> License tokens are pieces of text that must survive being placed in
+/// URLs, environment variables, and files without special characters causing trouble. Base64URL
+/// is a text encoding that avoids the characters (<c>+</c>, <c>/</c>, <c>=</c>) that cause issues
+/// in those places. This helper converts between raw bytes and that safe text form.
+/// </remarks>
+internal static class Base64UrlHelper
+{
+    /// <summary>
+    /// Encodes bytes as Base64URL (no padding).
+    /// </summary>
+    internal static string Encode(byte[] bytes)
+    {
+        if (bytes is null || bytes.Length == 0) return string.Empty;
+        return Convert.ToBase64String(bytes)
+            .Replace('+', '-')
+            .Replace('/', '_')
+            .TrimEnd('=');
+    }
+
+    /// <summary>
+    /// Decodes a Base64URL string (with or without padding) to bytes. Throws
+    /// <see cref="FormatException"/> on malformed input.
+    /// </summary>
+    internal static byte[] Decode(string base64Url)
+    {
+        if (base64Url is null) throw new ArgumentNullException(nameof(base64Url));
+
+        string standard = base64Url
+            .Replace('-', '+')
+            .Replace('_', '/');
+
+        switch (standard.Length % 4)
+        {
+            case 2: standard += "=="; break;
+            case 3: standard += "="; break;
+            case 1: throw new FormatException("Invalid Base64URL length.");
+        }
+
+        return Convert.FromBase64String(standard);
+    }
+}

--- a/src/Helpers/LicenseClaims.cs
+++ b/src/Helpers/LicenseClaims.cs
@@ -1,0 +1,62 @@
+using Newtonsoft.Json;
+
+namespace AiDotNet.Helpers;
+
+/// <summary>
+/// The signed claim set carried by an <c>aidn2.</c> asymmetric license token.
+/// </summary>
+/// <remarks>
+/// <para><b>For Beginners:</b> A license token is a small block of JSON (these fields) plus a
+/// cryptographic signature over that exact JSON. Because the signature can only be produced with the
+/// server's private key, nobody can change any field (e.g. bump <c>exp</c> or upgrade <c>tier</c>)
+/// without invalidating the signature.</para>
+/// <para>Field names are intentionally short (JWT-style) to keep tokens compact.</para>
+/// </remarks>
+internal sealed class LicenseClaims
+{
+    /// <summary>Subject — the customer / license the token was issued to.</summary>
+    [JsonProperty("sub")]
+    public string? Sub { get; set; }
+
+    /// <summary>Tier: <c>community</c>, <c>pro</c>, or <c>enterprise</c>.</summary>
+    [JsonProperty("tier")]
+    public string? Tier { get; set; }
+
+    /// <summary>Number of licensed seats.</summary>
+    [JsonProperty("seats")]
+    public int Seats { get; set; }
+
+    /// <summary>Issued-at, Unix seconds (UTC).</summary>
+    [JsonProperty("iat")]
+    public long Iat { get; set; }
+
+    /// <summary>Expiry, Unix seconds (UTC). Bounds offline use — a leaked token self-expires.</summary>
+    [JsonProperty("exp")]
+    public long Exp { get; set; }
+
+    /// <summary>Key id — selects which embedded public key verifies this token (rotation).</summary>
+    [JsonProperty("kid")]
+    public string? Kid { get; set; }
+
+    /// <summary>
+    /// Serializes the claims to the canonical compact JSON that gets signed. Callers MUST sign/verify
+    /// over the exact bytes that appear in the token's middle segment; this helper is used by the
+    /// (server/test) signer. The verifier verifies over the raw decoded segment bytes as received.
+    /// </summary>
+    internal string ToCanonicalJson() => JsonConvert.SerializeObject(this, Formatting.None);
+
+    /// <summary>
+    /// Parses claims JSON. Returns null on malformed input.
+    /// </summary>
+    internal static LicenseClaims? TryParse(string json)
+    {
+        try
+        {
+            return JsonConvert.DeserializeObject<LicenseClaims>(json);
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+    }
+}

--- a/src/Helpers/LicenseClaims.cs
+++ b/src/Helpers/LicenseClaims.cs
@@ -39,6 +39,14 @@ internal sealed class LicenseClaims
     public string? Kid { get; set; }
 
     /// <summary>
+    /// Signature algorithm identifier. Always <c>"EdDSA"</c> for aidn2 tokens (Ed25519). Recorded in the
+    /// claims so a future primitive change / rotation is unambiguous — the verifier rejects any token
+    /// whose <c>alg</c> it does not implement rather than silently assuming Ed25519.
+    /// </summary>
+    [JsonProperty("alg")]
+    public string? Alg { get; set; }
+
+    /// <summary>
     /// Serializes the claims to the canonical compact JSON that gets signed. Callers MUST sign/verify
     /// over the exact bytes that appear in the token's middle segment; this helper is used by the
     /// (server/test) signer. The verifier verifies over the raw decoded segment bytes as received.

--- a/src/Helpers/LicensePublicKeyProvider.cs
+++ b/src/Helpers/LicensePublicKeyProvider.cs
@@ -1,11 +1,10 @@
-using System.Security.Cryptography;
 using Newtonsoft.Json;
 
 namespace AiDotNet.Helpers;
 
 /// <summary>
 /// Provides the PUBLIC license-signing key(s) embedded as a resource in official builds.
-/// Used to verify <c>aidn2.</c> asymmetric license tokens offline.
+/// Used to verify <c>aidn2.</c> asymmetric (Ed25519 / EdDSA) license tokens offline.
 /// </summary>
 /// <remarks>
 /// <para><b>For Beginners:</b> The new license format (<c>aidn2.</c>) is signed on the AiDotNet
@@ -15,21 +14,25 @@ namespace AiDotNet.Helpers;
 /// they still cannot forge a license without the private key.</para>
 ///
 /// <para>The embedded resource <c>AiDotNet.LicensePublicKey</c> is a small JSON document listing one
-/// or more public keys, each tagged with a <c>kid</c> (key id). A license token names the <c>kid</c>
-/// it was signed with, so the signing key can be <b>rotated</b> (retire a compromised key, issue a
-/// new one) without invalidating already-issued licenses that reference an older, still-trusted key.</para>
+/// or more Ed25519 public keys, each tagged with a <c>kid</c> (key id). A license token names the
+/// <c>kid</c> it was signed with, so the signing key can be <b>rotated</b> (retire a compromised key,
+/// issue a new one) without invalidating already-issued licenses that reference an older, still-trusted
+/// key.</para>
 ///
-/// <para>Resource schema (JWK-like — RSA public keys as base64url modulus <c>n</c> and exponent
-/// <c>e</c>, which import identically on net471/net8/net10):</para>
+/// <para>Resource schema (JWK OKP — RFC 8037; an Ed25519 public key is the 32-byte <c>x</c> value):</para>
 /// <code>
-/// { "keys": [ { "kid": "2026a", "n": "&lt;base64url modulus&gt;", "e": "&lt;base64url exponent&gt;" } ] }
+/// { "keys": [ { "kty": "OKP", "crv": "Ed25519", "kid": "2026a", "x": "&lt;base64url 32-byte pubkey&gt;" } ] }
 /// </code>
 /// </remarks>
 internal static class LicensePublicKeyProvider
 {
     private const string ResourceName = "AiDotNet.LicensePublicKey";
 
-    private static Dictionary<string, RSAParameters>? _cachedKeys;
+    /// <summary>Ed25519 raw public keys are exactly 32 bytes.</summary>
+    internal const int Ed25519PublicKeySize = 32;
+
+    // kid -> raw 32-byte Ed25519 public key.
+    private static Dictionary<string, byte[]>? _cachedKeys;
     private static bool _loaded;
     private static readonly object _lock = new();
 
@@ -38,12 +41,12 @@ internal static class LicensePublicKeyProvider
     /// public half and exercise the real signature-verification path. Pass <see langword="null"/> to
     /// simulate a dev/fork build (no embedded public key) and assert fail-closed offline behaviour.
     /// </summary>
-    internal static void OverrideForTesting(IReadOnlyDictionary<string, RSAParameters>? keys)
+    internal static void OverrideForTesting(IReadOnlyDictionary<string, byte[]>? keys)
     {
         lock (_lock)
         {
             _cachedKeys = keys is { Count: > 0 }
-                ? new Dictionary<string, RSAParameters>(CloneAll(keys), StringComparer.Ordinal)
+                ? CloneAll(keys)
                 : null;
             _loaded = true;
         }
@@ -52,14 +55,12 @@ internal static class LicensePublicKeyProvider
     /// <summary>
     /// Snapshots the currently-effective public key set (for scoped test overrides), or null if none.
     /// </summary>
-    internal static IReadOnlyDictionary<string, RSAParameters>? CurrentSnapshot()
+    internal static IReadOnlyDictionary<string, byte[]>? CurrentSnapshot()
     {
         lock (_lock)
         {
             EnsureLoadedNoLock();
-            return _cachedKeys is { Count: > 0 }
-                ? new Dictionary<string, RSAParameters>(CloneAll(_cachedKeys), StringComparer.Ordinal)
-                : null;
+            return _cachedKeys is { Count: > 0 } ? CloneAll(_cachedKeys) : null;
         }
     }
 
@@ -80,11 +81,12 @@ internal static class LicensePublicKeyProvider
     }
 
     /// <summary>
-    /// Resolves the public key for a given <c>kid</c>. Returns false if this build embeds no matching key.
+    /// Resolves the raw 32-byte Ed25519 public key for a given <c>kid</c>. Returns false if this build
+    /// embeds no matching key.
     /// </summary>
-    internal static bool TryGetPublicKey(string kid, out RSAParameters parameters)
+    internal static bool TryGetPublicKey(string kid, out byte[] publicKey)
     {
-        parameters = default;
+        publicKey = Array.Empty<byte>();
         if (string.IsNullOrEmpty(kid)) return false;
 
         lock (_lock)
@@ -92,7 +94,7 @@ internal static class LicensePublicKeyProvider
             EnsureLoadedNoLock();
             if (_cachedKeys is not null && _cachedKeys.TryGetValue(kid, out var found))
             {
-                parameters = Clone(found);
+                publicKey = (byte[])found.Clone();
                 return true;
             }
         }
@@ -131,9 +133,10 @@ internal static class LicensePublicKeyProvider
     }
 
     /// <summary>
-    /// Parses the JWK-like public-key manifest. Returns null when no usable key is present.
+    /// Parses the JWK OKP public-key manifest. Returns null when no usable Ed25519 key is present.
+    /// Non-Ed25519 / malformed / wrong-length entries are skipped (fail closed).
     /// </summary>
-    internal static Dictionary<string, RSAParameters>? Parse(string json)
+    internal static Dictionary<string, byte[]>? Parse(string json)
     {
         if (string.IsNullOrWhiteSpace(json)) return null;
 
@@ -144,27 +147,39 @@ internal static class LicensePublicKeyProvider
 
         if (doc?.keys is null || doc.keys.Count == 0) return null;
 
-        var result = new Dictionary<string, RSAParameters>(StringComparer.Ordinal);
+        var result = new Dictionary<string, byte[]>(StringComparer.Ordinal);
         foreach (var entry in doc.keys)
         {
             string? kid = entry?.kid;
-            string? n = entry?.n;
-            string? e = entry?.e;
+            string? x = entry?.x;
+            string? crv = entry?.crv;
             // Explicit is-null checks (not string.IsNullOrEmpty) so the nullable flow analysis narrows
             // uniformly across TFMs — net471's BCL lacks the [NotNullWhen] annotation on IsNullOrEmpty.
-            if (kid is null || kid.Length == 0 || n is null || n.Length == 0 || e is null || e.Length == 0)
+            if (kid is null || kid.Length == 0 || x is null || x.Length == 0)
             {
+                continue;
+            }
+
+            // Only Ed25519 OKP keys are accepted. A missing crv is tolerated for brevity but a present,
+            // non-Ed25519 crv is rejected so a future curve cannot be silently treated as Ed25519.
+            if (crv is not null && crv.Length > 0 && !string.Equals(crv, "Ed25519", StringComparison.Ordinal))
+            {
+                System.Diagnostics.Trace.TraceWarning(
+                    "LicensePublicKeyProvider: skipping key '" + kid + "' with unsupported crv '" + crv + "'.");
                 continue;
             }
 
             try
             {
-                var parameters = new RSAParameters
+                byte[] pub = Base64UrlHelper.Decode(x);
+                if (pub.Length != Ed25519PublicKeySize)
                 {
-                    Modulus = Base64UrlHelper.Decode(n),
-                    Exponent = Base64UrlHelper.Decode(e)
-                };
-                result[kid] = parameters;
+                    System.Diagnostics.Trace.TraceWarning(
+                        "LicensePublicKeyProvider: skipping key '" + kid + "' with wrong Ed25519 length " + pub.Length + ".");
+                    continue;
+                }
+
+                result[kid] = pub;
             }
             catch (FormatException ex)
             {
@@ -176,27 +191,22 @@ internal static class LicensePublicKeyProvider
         return result.Count > 0 ? result : null;
     }
 
-    private static Dictionary<string, RSAParameters> CloneAll(IReadOnlyDictionary<string, RSAParameters> src)
+    private static Dictionary<string, byte[]> CloneAll(IReadOnlyDictionary<string, byte[]> src)
     {
-        var copy = new Dictionary<string, RSAParameters>(StringComparer.Ordinal);
+        var copy = new Dictionary<string, byte[]>(StringComparer.Ordinal);
         foreach (var kvp in src)
         {
-            copy[kvp.Key] = Clone(kvp.Value);
+            copy[kvp.Key] = kvp.Value is null ? Array.Empty<byte>() : (byte[])kvp.Value.Clone();
         }
 
         return copy;
     }
 
-    private static RSAParameters Clone(RSAParameters p) => new()
-    {
-        Modulus = p.Modulus is null ? null : (byte[])p.Modulus.Clone(),
-        Exponent = p.Exponent is null ? null : (byte[])p.Exponent.Clone()
-    };
-
     private sealed class KeyEntry
     {
+        public string? kty { get; set; }
+        public string? crv { get; set; }
         public string? kid { get; set; }
-        public string? n { get; set; }
-        public string? e { get; set; }
+        public string? x { get; set; }
     }
 }

--- a/src/Helpers/LicensePublicKeyProvider.cs
+++ b/src/Helpers/LicensePublicKeyProvider.cs
@@ -1,0 +1,202 @@
+using System.Security.Cryptography;
+using Newtonsoft.Json;
+
+namespace AiDotNet.Helpers;
+
+/// <summary>
+/// Provides the PUBLIC license-signing key(s) embedded as a resource in official builds.
+/// Used to verify <c>aidn2.</c> asymmetric license tokens offline.
+/// </summary>
+/// <remarks>
+/// <para><b>For Beginners:</b> The new license format (<c>aidn2.</c>) is signed on the AiDotNet
+/// license server with a <b>private</b> key that never leaves the server. Every published DLL only
+/// embeds the matching <b>public</b> key. A public key can verify a signature but cannot create one,
+/// so — unlike the old symmetric build key — extracting it from the DLL gives an attacker nothing:
+/// they still cannot forge a license without the private key.</para>
+///
+/// <para>The embedded resource <c>AiDotNet.LicensePublicKey</c> is a small JSON document listing one
+/// or more public keys, each tagged with a <c>kid</c> (key id). A license token names the <c>kid</c>
+/// it was signed with, so the signing key can be <b>rotated</b> (retire a compromised key, issue a
+/// new one) without invalidating already-issued licenses that reference an older, still-trusted key.</para>
+///
+/// <para>Resource schema (JWK-like — RSA public keys as base64url modulus <c>n</c> and exponent
+/// <c>e</c>, which import identically on net471/net8/net10):</para>
+/// <code>
+/// { "keys": [ { "kid": "2026a", "n": "&lt;base64url modulus&gt;", "e": "&lt;base64url exponent&gt;" } ] }
+/// </code>
+/// </remarks>
+internal static class LicensePublicKeyProvider
+{
+    private const string ResourceName = "AiDotNet.LicensePublicKey";
+
+    private static Dictionary<string, RSAParameters>? _cachedKeys;
+    private static bool _loaded;
+    private static readonly object _lock = new();
+
+    /// <summary>
+    /// TEST-ONLY: overrides the embedded public key set so tests can inject an ephemeral test keypair's
+    /// public half and exercise the real signature-verification path. Pass <see langword="null"/> to
+    /// simulate a dev/fork build (no embedded public key) and assert fail-closed offline behaviour.
+    /// </summary>
+    internal static void OverrideForTesting(IReadOnlyDictionary<string, RSAParameters>? keys)
+    {
+        lock (_lock)
+        {
+            _cachedKeys = keys is { Count: > 0 }
+                ? new Dictionary<string, RSAParameters>(CloneAll(keys), StringComparer.Ordinal)
+                : null;
+            _loaded = true;
+        }
+    }
+
+    /// <summary>
+    /// Snapshots the currently-effective public key set (for scoped test overrides), or null if none.
+    /// </summary>
+    internal static IReadOnlyDictionary<string, RSAParameters>? CurrentSnapshot()
+    {
+        lock (_lock)
+        {
+            EnsureLoadedNoLock();
+            return _cachedKeys is { Count: > 0 }
+                ? new Dictionary<string, RSAParameters>(CloneAll(_cachedKeys), StringComparer.Ordinal)
+                : null;
+        }
+    }
+
+    /// <summary>
+    /// Gets whether this build embeds at least one license public key (i.e. it can verify
+    /// <c>aidn2.</c> tokens offline). The asymmetric analogue of <see cref="BuildKeyProvider.IsOfficialBuild"/>.
+    /// </summary>
+    internal static bool HasAnyKey
+    {
+        get
+        {
+            lock (_lock)
+            {
+                EnsureLoadedNoLock();
+                return _cachedKeys is { Count: > 0 };
+            }
+        }
+    }
+
+    /// <summary>
+    /// Resolves the public key for a given <c>kid</c>. Returns false if this build embeds no matching key.
+    /// </summary>
+    internal static bool TryGetPublicKey(string kid, out RSAParameters parameters)
+    {
+        parameters = default;
+        if (string.IsNullOrEmpty(kid)) return false;
+
+        lock (_lock)
+        {
+            EnsureLoadedNoLock();
+            if (_cachedKeys is not null && _cachedKeys.TryGetValue(kid, out var found))
+            {
+                parameters = Clone(found);
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static void EnsureLoadedNoLock()
+    {
+        if (_loaded) return;
+
+        try
+        {
+            var assembly = typeof(LicensePublicKeyProvider).Assembly;
+            using var stream = assembly.GetManifestResourceStream(ResourceName);
+            if (stream is null || stream.Length == 0)
+            {
+                _cachedKeys = null;
+                return;
+            }
+
+            using var reader = new StreamReader(stream, System.Text.Encoding.UTF8);
+            string json = reader.ReadToEnd();
+            _cachedKeys = Parse(json);
+        }
+        catch (Exception ex)
+        {
+            System.Diagnostics.Trace.TraceWarning(
+                "LicensePublicKeyProvider: failed to load public key(s): " + ex.GetType().Name + ": " + ex.Message);
+            _cachedKeys = null;
+        }
+        finally
+        {
+            _loaded = true;
+        }
+    }
+
+    /// <summary>
+    /// Parses the JWK-like public-key manifest. Returns null when no usable key is present.
+    /// </summary>
+    internal static Dictionary<string, RSAParameters>? Parse(string json)
+    {
+        if (string.IsNullOrWhiteSpace(json)) return null;
+
+        var doc = JsonConvert.DeserializeAnonymousType(json, new
+        {
+            keys = (System.Collections.Generic.List<KeyEntry>?)null
+        });
+
+        if (doc?.keys is null || doc.keys.Count == 0) return null;
+
+        var result = new Dictionary<string, RSAParameters>(StringComparer.Ordinal);
+        foreach (var entry in doc.keys)
+        {
+            string? kid = entry?.kid;
+            string? n = entry?.n;
+            string? e = entry?.e;
+            // Explicit is-null checks (not string.IsNullOrEmpty) so the nullable flow analysis narrows
+            // uniformly across TFMs — net471's BCL lacks the [NotNullWhen] annotation on IsNullOrEmpty.
+            if (kid is null || kid.Length == 0 || n is null || n.Length == 0 || e is null || e.Length == 0)
+            {
+                continue;
+            }
+
+            try
+            {
+                var parameters = new RSAParameters
+                {
+                    Modulus = Base64UrlHelper.Decode(n),
+                    Exponent = Base64UrlHelper.Decode(e)
+                };
+                result[kid] = parameters;
+            }
+            catch (FormatException ex)
+            {
+                System.Diagnostics.Trace.TraceWarning(
+                    "LicensePublicKeyProvider: skipping malformed key '" + kid + "': " + ex.Message);
+            }
+        }
+
+        return result.Count > 0 ? result : null;
+    }
+
+    private static Dictionary<string, RSAParameters> CloneAll(IReadOnlyDictionary<string, RSAParameters> src)
+    {
+        var copy = new Dictionary<string, RSAParameters>(StringComparer.Ordinal);
+        foreach (var kvp in src)
+        {
+            copy[kvp.Key] = Clone(kvp.Value);
+        }
+
+        return copy;
+    }
+
+    private static RSAParameters Clone(RSAParameters p) => new()
+    {
+        Modulus = p.Modulus is null ? null : (byte[])p.Modulus.Clone(),
+        Exponent = p.Exponent is null ? null : (byte[])p.Exponent.Clone()
+    };
+
+    private sealed class KeyEntry
+    {
+        public string? kid { get; set; }
+        public string? n { get; set; }
+        public string? e { get; set; }
+    }
+}

--- a/src/Helpers/LicenseValidator.cs
+++ b/src/Helpers/LicenseValidator.cs
@@ -95,8 +95,15 @@ internal sealed class LicenseValidator
         // offline; if the caller set an explicit custom ServerUrl they want online validation (e.g. for
         // revocation), so respect it. ServerUrl == "" is the explicit offline-only opt-in handled above.
         bool serverUrlIsDefault = _licenseKey.ServerUrl is null;
+        // A key can be verified offline when this build embeds the matching verifier material:
+        //   v1 (aidn.{id}.{sig})   → the symmetric HMAC build key
+        //   v2 (aidn2.{claims}.{sig}) → an embedded PUBLIC signing key (asymmetric; strictly stronger —
+        //       the public key is worthless to a forger, so it is safe to ship). exp bounds offline use.
+        bool v1Verifiable = IsSignedKeyFormat(_licenseKey.Key) && buildKeyEmbedded;
+        bool v2Verifiable = AsymmetricLicenseVerifier.IsAsymmetricKeyFormat(_licenseKey.Key)
+            && LicensePublicKeyProvider.HasAnyKey;
         bool useOfflineValidation = explicitOfflineOnly
-            || (serverUrlIsDefault && IsSignedKeyFormat(_licenseKey.Key) && buildKeyEmbedded);
+            || (serverUrlIsDefault && (v1Verifiable || v2Verifiable));
 
         if (useOfflineValidation)
         {
@@ -115,7 +122,7 @@ internal sealed class LicenseValidator
             // Future work: add Ed25519-signed AIDN-{ENV}-{TIER}-{V}-{ID}-{SIG}
             // format that CAN be validated offline against a SDK-shipped public
             // key. Until that lands, AIDN-* keys are server-only.
-            if (!IsSignedKeyFormat(_licenseKey.Key))
+            if (!IsOfflineVerifiableKeyFormat(_licenseKey.Key))
             {
                 // Cache the rejection so the sync path matches ValidateAsync()
                 // (line ~461) and CachedResult is non-null after the first call.
@@ -127,7 +134,8 @@ internal sealed class LicenseValidator
                     if (_cached is not null) return _cached;
                     var rejected = new LicenseValidationResult(
                         LicenseKeyStatus.Invalid,
-                        message: "Offline-only mode requires a signed license key (aidn.{id}.{signature} format). " +
+                        message: "Offline-only mode requires a signed license key (aidn2.{claims}.{signature} " +
+                                 "asymmetric format, or legacy aidn.{id}.{signature}). " +
                                  "Server-validated keys (AIDN-PROD-*, AIDN-DEV-*) require online validation — set ServerUrl " +
                                  "to null (default endpoint) or to a custom URL. To enable air-gapped operation, " +
                                  "request a signed license key from support.");
@@ -243,6 +251,16 @@ internal sealed class LicenseValidator
                 message: "License key is empty or missing.");
         }
 
+        // aidn2 asymmetric tokens: verify the signature against the embedded PUBLIC key selected by the
+        // token's kid, then enforce exp. This is the industry-standard, strictly-stronger path — the
+        // verifier holds only a public key, so it CANNOT forge a token. Fails closed on any problem
+        // (bad signature, unknown kid, no embedded public key, expired).
+        if (AsymmetricLicenseVerifier.IsAsymmetricKeyFormat(_licenseKey.Key))
+        {
+            return AsymmetricLicenseVerifier.Verify(_licenseKey.Key, DateTimeOffset.UtcNow);
+        }
+
+        // Legacy v1 (aidn.{id}.{signature}) symmetric-HMAC path below (deprecated, back-compat only).
         // Validate the key format: must be aidn.{id}.{signature}
         if (!ValidateKeyFormat(_licenseKey.Key))
         {
@@ -384,11 +402,25 @@ internal sealed class LicenseValidator
     }
 
     /// <summary>
-    /// Validates key format — accepts either signed (offline) or server-validated (online) format.
+    /// Validates key format — accepts asymmetric (aidn2), legacy signed (aidn), or
+    /// server-validated (AIDN-*) formats.
     /// </summary>
     internal static bool ValidateKeyFormat(string key)
     {
-        return IsSignedKeyFormat(key) || IsServerValidatedKeyFormat(key);
+        return AsymmetricLicenseVerifier.IsAsymmetricKeyFormat(key)
+            || IsSignedKeyFormat(key)
+            || IsServerValidatedKeyFormat(key);
+    }
+
+    /// <summary>
+    /// Returns true if the key is in a format that can be verified LOCALLY (offline) against
+    /// build-embedded material: the new asymmetric <c>aidn2.</c> tokens (verified against the embedded
+    /// public key) or the legacy <c>aidn.</c> HMAC tokens (verified against the embedded build key).
+    /// Server-validated <c>AIDN-*</c> keys are excluded — they carry no signature the SDK can verify.
+    /// </summary>
+    internal static bool IsOfflineVerifiableKeyFormat(string key)
+    {
+        return AsymmetricLicenseVerifier.IsAsymmetricKeyFormat(key) || IsSignedKeyFormat(key);
     }
 
     /// <summary>
@@ -521,13 +553,17 @@ internal sealed class LicenseValidator
         bool explicitOfflineOnly = _licenseKey.ServerUrl is not null && _licenseKey.ServerUrl.Trim().Length == 0;
         bool buildKeyEmbedded = BuildKeyProvider.GetBuildKey().Length > 0;
         bool serverUrlIsDefault = _licenseKey.ServerUrl is null;
-        if (explicitOfflineOnly || (serverUrlIsDefault && IsSignedKeyFormat(_licenseKey.Key) && buildKeyEmbedded))
+        bool v1Verifiable = IsSignedKeyFormat(_licenseKey.Key) && buildKeyEmbedded;
+        bool v2Verifiable = AsymmetricLicenseVerifier.IsAsymmetricKeyFormat(_licenseKey.Key)
+            && LicensePublicKeyProvider.HasAnyKey;
+        if (explicitOfflineOnly || (serverUrlIsDefault && (v1Verifiable || v2Verifiable)))
         {
-            if (!IsSignedKeyFormat(_licenseKey.Key))
+            if (!IsOfflineVerifiableKeyFormat(_licenseKey.Key))
             {
                 var rejected = new LicenseValidationResult(
                     LicenseKeyStatus.Invalid,
-                    message: "Offline-only mode requires a signed license key (aidn.{id}.{signature} format). " +
+                    message: "Offline-only mode requires a signed license key (aidn2.{claims}.{signature} " +
+                             "asymmetric format, or legacy aidn.{id}.{signature}). " +
                              "Server-validated keys (AIDN-PROD-*) require online validation.");
                 lock (_cacheLock) { _cached = rejected; }
                 return rejected;

--- a/src/Helpers/LicenseValidator.cs
+++ b/src/Helpers/LicenseValidator.cs
@@ -100,8 +100,12 @@ internal sealed class LicenseValidator
         //   v2 (aidn2.{claims}.{sig}) → an embedded PUBLIC signing key (asymmetric; strictly stronger —
         //       the public key is worthless to a forger, so it is safe to ship). exp bounds offline use.
         bool v1Verifiable = IsSignedKeyFormat(_licenseKey.Key) && buildKeyEmbedded;
-        bool v2Verifiable = AsymmetricLicenseVerifier.IsAsymmetricKeyFormat(_licenseKey.Key)
-            && LicensePublicKeyProvider.HasAnyKey;
+        // Opportunistic offline validation for a v2 token requires this build to embed the public key
+        // matching THIS token's kid — not merely "some" key. A token signed with a newer/rotated kid
+        // this build doesn't carry falls through to ONLINE validation (server is the source of truth)
+        // instead of being rejected offline. Explicit offline-only mode is unaffected (still fails closed).
+        bool v2Verifiable = AsymmetricLicenseVerifier.TryGetKid(_licenseKey.Key, out string v2Kid)
+            && LicensePublicKeyProvider.TryGetPublicKey(v2Kid, out _);
         bool useOfflineValidation = explicitOfflineOnly
             || (serverUrlIsDefault && (v1Verifiable || v2Verifiable));
 
@@ -554,8 +558,10 @@ internal sealed class LicenseValidator
         bool buildKeyEmbedded = BuildKeyProvider.GetBuildKey().Length > 0;
         bool serverUrlIsDefault = _licenseKey.ServerUrl is null;
         bool v1Verifiable = IsSignedKeyFormat(_licenseKey.Key) && buildKeyEmbedded;
-        bool v2Verifiable = AsymmetricLicenseVerifier.IsAsymmetricKeyFormat(_licenseKey.Key)
-            && LicensePublicKeyProvider.HasAnyKey;
+        // Same kid-match routing as the sync path: only validate a v2 token offline when this build
+        // embeds the public key for the token's kid; otherwise fall through to online validation.
+        bool v2Verifiable = AsymmetricLicenseVerifier.TryGetKid(_licenseKey.Key, out string v2Kid)
+            && LicensePublicKeyProvider.TryGetPublicKey(v2Kid, out _);
         if (explicitOfflineOnly || (serverUrlIsDefault && (v1Verifiable || v2Verifiable)))
         {
             if (!IsOfflineVerifiableKeyFormat(_licenseKey.Key))

--- a/src/Helpers/ModelPersistenceGuard.cs
+++ b/src/Helpers/ModelPersistenceGuard.cs
@@ -384,7 +384,7 @@ internal static class ModelPersistenceGuard
                     // Construct first so AiDotNetLicenseKey's Guard.NotNullOrWhiteSpace
                     // runs on the raw string before anything else inspects it.
                     keyConfig = new AiDotNetLicenseKey(licenseKey);
-                    if (LicenseValidator.IsSignedKeyFormat(licenseKey))
+                    if (LicenseValidator.IsOfflineVerifiableKeyFormat(licenseKey))
                     {
                         keyConfig.ServerUrl = string.Empty;
                     }

--- a/tests/AiDotNet.Tests/Helpers/AsymmetricLicenseTests.cs
+++ b/tests/AiDotNet.Tests/Helpers/AsymmetricLicenseTests.cs
@@ -1,7 +1,4 @@
 using System;
-using System.Collections.Generic;
-using System.Security.Cryptography;
-using System.Text;
 using System.Threading.Tasks;
 using AiDotNet.Enums;
 using AiDotNet.Helpers;
@@ -81,10 +78,11 @@ public class AsymmetricLicenseTests
     [Fact(Timeout = 60000)]
     public async Task Aidn2_ForgedSignature_ForeignKey_IsRejected()
     {
-        // The core security property: a token signed by a keypair whose public half is NOT embedded
-        // cannot be forged into validity. This is exactly what an attacker without the private key faces.
+        // The core security property: an Ed25519 token signed by a keypair whose public half is NOT
+        // embedded cannot be forged into validity. This is exactly what an attacker without the private
+        // key faces.
         await Task.Yield();
-        using RSA foreign = LicenseTestSupport.CreateForeignSigningKey();
+        var foreign = LicenseTestSupport.CreateForeignSigningKey();
         string forged = LicenseTestSupport.SignedKeyV2(signingKey: foreign); // kid still = TestKid
 
         var key = new AiDotNetLicenseKey(forged) { ServerUrl = string.Empty };
@@ -214,19 +212,21 @@ public class AsymmetricLicenseTests
     // ───────────── provider round-trip ─────────────
 
     [Fact(Timeout = 60000)]
-    public async Task LicensePublicKeyProvider_ParsesJwkManifest()
+    public async Task LicensePublicKeyProvider_ParsesJwkOkpManifest()
     {
         await Task.Yield();
-        RSAParameters pub = LicenseTestSupport.TestPublicKeyParameters;
+        byte[] pub = LicenseTestSupport.TestPublicKey;
+        Assert.Equal(LicensePublicKeyProvider.Ed25519PublicKeySize, pub.Length);
         string json = Newtonsoft.Json.JsonConvert.SerializeObject(new
         {
             keys = new[]
             {
                 new
                 {
+                    kty = "OKP",
+                    crv = "Ed25519",
                     kid = "roundtrip",
-                    n = Base64UrlHelper.Encode(pub.Modulus),
-                    e = Base64UrlHelper.Encode(pub.Exponent)
+                    x = Base64UrlHelper.Encode(pub)
                 }
             }
         });
@@ -235,7 +235,45 @@ public class AsymmetricLicenseTests
 
         Assert.NotNull(parsed);
         Assert.True(parsed!.ContainsKey("roundtrip"));
-        Assert.Equal(pub.Modulus, parsed["roundtrip"].Modulus);
-        Assert.Equal(pub.Exponent, parsed["roundtrip"].Exponent);
+        Assert.Equal(pub, parsed["roundtrip"]);
+    }
+
+    [Fact(Timeout = 60000)]
+    public async Task LicensePublicKeyProvider_RejectsNonEd25519Curve()
+    {
+        // A present, non-Ed25519 crv must be skipped (fail closed), never treated as Ed25519.
+        await Task.Yield();
+        string json = Newtonsoft.Json.JsonConvert.SerializeObject(new
+        {
+            keys = new[]
+            {
+                new
+                {
+                    kty = "OKP",
+                    crv = "X25519",
+                    kid = "wrong-curve",
+                    x = Base64UrlHelper.Encode(LicenseTestSupport.TestPublicKey)
+                }
+            }
+        });
+
+        var parsed = LicensePublicKeyProvider.Parse(json);
+
+        Assert.Null(parsed);
+    }
+
+    [Fact(Timeout = 60000)]
+    public async Task Aidn2_UnsupportedAlg_IsRejected()
+    {
+        // A token that (validly, with the test key) declares a non-EdDSA alg must be rejected so a future
+        // primitive can never be silently accepted as Ed25519.
+        await Task.Yield();
+        string token = LicenseTestSupport.SignedKeyV2(alg: "RS256");
+
+        var key = new AiDotNetLicenseKey(token) { ServerUrl = string.Empty };
+        var result = new LicenseValidator(key).Validate();
+
+        Assert.Equal(LicenseKeyStatus.Invalid, result.Status);
+        Assert.Contains("algorithm", result.Message, StringComparison.OrdinalIgnoreCase);
     }
 }

--- a/tests/AiDotNet.Tests/Helpers/AsymmetricLicenseTests.cs
+++ b/tests/AiDotNet.Tests/Helpers/AsymmetricLicenseTests.cs
@@ -1,0 +1,241 @@
+using System;
+using System.Collections.Generic;
+using System.Security.Cryptography;
+using System.Text;
+using System.Threading.Tasks;
+using AiDotNet.Enums;
+using AiDotNet.Helpers;
+using AiDotNet.Models;
+using Xunit;
+
+namespace AiDotNet.Tests.Helpers;
+
+/// <summary>
+/// Regression tests for the asymmetric (<c>aidn2.</c>) license scheme: a valid signed token is Active
+/// offline, a forged / tampered signature is rejected, an expired token is rejected, an unknown key-id is
+/// rejected, and a build without the embedded public key fails closed. These prove the scheme is strictly
+/// stronger than the retired symmetric HMAC path — a token cannot be minted without the private key, which
+/// never ships. Legacy <c>aidn.</c> keys must keep validating (back-compat) — see LicenseValidatorTests.
+/// </summary>
+[Collection("License")]
+public class AsymmetricLicenseTests
+{
+    // ───────────── structural / routing ─────────────
+
+    [Fact(Timeout = 60000)]
+    public async Task IsAsymmetricKeyFormat_RecognisesAidn2()
+    {
+        await Task.Yield();
+        Assert.True(AsymmetricLicenseVerifier.IsAsymmetricKeyFormat(LicenseTestSupport.SignedKeyV2()));
+        Assert.False(AsymmetricLicenseVerifier.IsAsymmetricKeyFormat(LicenseTestSupport.SignedKey("abc")));
+        Assert.False(AsymmetricLicenseVerifier.IsAsymmetricKeyFormat("AIDN-PROD-PRO-1234567890ABCDEF"));
+        Assert.False(AsymmetricLicenseVerifier.IsAsymmetricKeyFormat("aidn2.only-two-parts"));
+        Assert.False(AsymmetricLicenseVerifier.IsAsymmetricKeyFormat(null));
+    }
+
+    [Fact(Timeout = 60000)]
+    public async Task ValidateKeyFormat_AcceptsAidn2()
+    {
+        await Task.Yield();
+        Assert.True(LicenseValidator.ValidateKeyFormat(LicenseTestSupport.SignedKeyV2()));
+        Assert.True(LicenseValidator.IsOfflineVerifiableKeyFormat(LicenseTestSupport.SignedKeyV2()));
+        // Server-validated keys are NOT offline-verifiable.
+        Assert.False(LicenseValidator.IsOfflineVerifiableKeyFormat(
+            "AIDN-PROD-COMMUNITY-1234567890ABCDEF1234567890ABCDEF"));
+    }
+
+    // ───────────── valid token ─────────────
+
+    [Fact(Timeout = 60000)]
+    public async Task Aidn2_ValidToken_OfflineMode_ReturnsActive()
+    {
+        await Task.Yield();
+        var key = new AiDotNetLicenseKey(LicenseTestSupport.SignedKeyV2(tier: "enterprise", seats: 10))
+        {
+            ServerUrl = string.Empty // explicit offline-only
+        };
+
+        var result = new LicenseValidator(key).Validate();
+
+        Assert.Equal(LicenseKeyStatus.Active, result.Status);
+        Assert.Equal("enterprise", result.Tier);
+        Assert.Equal(10, result.SeatsMax);
+        Assert.Contains("signature verified", result.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact(Timeout = 60000)]
+    public async Task Aidn2_ValidToken_DefaultServer_VerifiesOfflineWithoutNetwork()
+    {
+        // ServerUrl == null (default). Because a public key is embedded (fixture) and the token is aidn2,
+        // the validator verifies offline and never touches the network — same opportunistic path as v1.
+        await Task.Yield();
+        var key = new AiDotNetLicenseKey(LicenseTestSupport.SignedKeyV2());
+
+        var result = new LicenseValidator(key).Validate();
+
+        Assert.Equal(LicenseKeyStatus.Active, result.Status);
+    }
+
+    // ───────────── forged / tampered ─────────────
+
+    [Fact(Timeout = 60000)]
+    public async Task Aidn2_ForgedSignature_ForeignKey_IsRejected()
+    {
+        // The core security property: a token signed by a keypair whose public half is NOT embedded
+        // cannot be forged into validity. This is exactly what an attacker without the private key faces.
+        await Task.Yield();
+        using RSA foreign = LicenseTestSupport.CreateForeignSigningKey();
+        string forged = LicenseTestSupport.SignedKeyV2(signingKey: foreign); // kid still = TestKid
+
+        var key = new AiDotNetLicenseKey(forged) { ServerUrl = string.Empty };
+        var result = new LicenseValidator(key).Validate();
+
+        Assert.Equal(LicenseKeyStatus.Invalid, result.Status);
+        Assert.Contains("signature", result.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact(Timeout = 60000)]
+    public async Task Aidn2_TamperedClaims_IsRejected()
+    {
+        // Take a valid token and flip a byte in the claims segment: the signature no longer matches.
+        await Task.Yield();
+        string valid = LicenseTestSupport.SignedKeyV2(tier: "community");
+        string[] parts = valid.Split('.');
+        byte[] claims = Base64UrlHelper.Decode(parts[1]);
+        // Upgrade "community" → "enterprise" would require re-signing; here just corrupt a byte.
+        claims[claims.Length / 2] ^= 0xFF;
+        string tampered = parts[0] + "." + Base64UrlHelper.Encode(claims) + "." + parts[2];
+
+        var key = new AiDotNetLicenseKey(tampered) { ServerUrl = string.Empty };
+        var result = new LicenseValidator(key).Validate();
+
+        Assert.Equal(LicenseKeyStatus.Invalid, result.Status);
+    }
+
+    // ───────────── expired ─────────────
+
+    [Fact(Timeout = 60000)]
+    public async Task Aidn2_ExpiredToken_IsRejected()
+    {
+        await Task.Yield();
+        string expired = LicenseTestSupport.SignedKeyV2(
+            iat: DateTimeOffset.UtcNow.AddDays(-60),
+            exp: DateTimeOffset.UtcNow.AddDays(-30)); // well past the clock-skew allowance
+
+        var key = new AiDotNetLicenseKey(expired) { ServerUrl = string.Empty };
+        var result = new LicenseValidator(key).Validate();
+
+        Assert.Equal(LicenseKeyStatus.Expired, result.Status);
+        Assert.Contains("expired", result.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    // ───────────── unknown kid / no embedded key (fail closed) ─────────────
+
+    [Fact(Timeout = 60000)]
+    public async Task Aidn2_UnknownKid_IsRejected()
+    {
+        await Task.Yield();
+        string token = LicenseTestSupport.SignedKeyV2(kid: "no-such-kid");
+
+        var key = new AiDotNetLicenseKey(token) { ServerUrl = string.Empty };
+        var result = new LicenseValidator(key).Validate();
+
+        Assert.Equal(LicenseKeyStatus.Invalid, result.Status);
+        Assert.Contains("kid", result.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact(Timeout = 60000)]
+    public async Task Aidn2_NoEmbeddedPublicKey_FailsClosed()
+    {
+        // Simulate a dev/fork build with no embedded public key: even a genuinely-signed token cannot be
+        // verified locally, so offline validation must reject it rather than fail open.
+        await Task.Yield();
+        string token = LicenseTestSupport.SignedKeyV2();
+
+        using (LicenseTestSupport.WithLicensePublicKeys(null))
+        {
+            var key = new AiDotNetLicenseKey(token) { ServerUrl = string.Empty };
+            var result = new LicenseValidator(key).Validate();
+
+            Assert.Equal(LicenseKeyStatus.Invalid, result.Status);
+        }
+    }
+
+    // ───────────── revocation is server-driven (online) ─────────────
+
+    [Fact(Timeout = 60000)]
+    public async Task Aidn2_CustomServer_RoutesOnline_NotOfflineActive()
+    {
+        // With an explicit custom ServerUrl the validator must go ONLINE (where the server can deny a
+        // revoked key) rather than short-circuiting to offline Active. An unreachable server yields
+        // ValidationPending — proving the token was NOT accepted purely offline.
+        await Task.Yield();
+        var key = new AiDotNetLicenseKey(LicenseTestSupport.SignedKeyV2())
+        {
+            ServerUrl = "https://192.0.2.1:1/validate" // RFC 5737 TEST-NET, unreachable
+        };
+
+        var result = new LicenseValidator(key).Validate();
+
+        Assert.Equal(LicenseKeyStatus.ValidationPending, result.Status);
+    }
+
+    [Fact(Timeout = 60000)]
+    public async Task Aidn2_RevokedByServer_ParseResponse_ReturnsRevoked()
+    {
+        // The server remains the source of truth for revocation: a revoked key returns license_revoked,
+        // which the client maps to Revoked (unchanged by the asymmetric offline path).
+        await Task.Yield();
+        string json = Newtonsoft.Json.JsonConvert.SerializeObject(new { valid = false, error = "license_revoked" });
+
+        var result = LicenseValidator.ParseResponse(json, 403);
+
+        Assert.Equal(LicenseKeyStatus.Revoked, result.Status);
+    }
+
+    // ───────────── back-compat: v1 and v2 coexist ─────────────
+
+    [Fact(Timeout = 60000)]
+    public async Task Aidn1_LegacyHmacKey_StillValidatesOffline()
+    {
+        // Deprecation window: legacy aidn. HMAC keys keep working against the embedded build key.
+        await Task.Yield();
+        var v1 = new AiDotNetLicenseKey(LicenseTestSupport.SignedKey("legacy-customer-1"))
+        {
+            ServerUrl = string.Empty
+        };
+
+        var result = new LicenseValidator(v1).Validate();
+
+        Assert.Equal(LicenseKeyStatus.Active, result.Status);
+        Assert.Contains("HMAC verified", result.Message, StringComparison.Ordinal);
+    }
+
+    // ───────────── provider round-trip ─────────────
+
+    [Fact(Timeout = 60000)]
+    public async Task LicensePublicKeyProvider_ParsesJwkManifest()
+    {
+        await Task.Yield();
+        RSAParameters pub = LicenseTestSupport.TestPublicKeyParameters;
+        string json = Newtonsoft.Json.JsonConvert.SerializeObject(new
+        {
+            keys = new[]
+            {
+                new
+                {
+                    kid = "roundtrip",
+                    n = Base64UrlHelper.Encode(pub.Modulus),
+                    e = Base64UrlHelper.Encode(pub.Exponent)
+                }
+            }
+        });
+
+        var parsed = LicensePublicKeyProvider.Parse(json);
+
+        Assert.NotNull(parsed);
+        Assert.True(parsed!.ContainsKey("roundtrip"));
+        Assert.Equal(pub.Modulus, parsed["roundtrip"].Modulus);
+        Assert.Equal(pub.Exponent, parsed["roundtrip"].Exponent);
+    }
+}

--- a/tests/AiDotNet.Tests/Helpers/AsymmetricLicenseTests.cs
+++ b/tests/AiDotNet.Tests/Helpers/AsymmetricLicenseTests.cs
@@ -170,7 +170,14 @@ public class AsymmetricLicenseTests
         await Task.Yield();
         var key = new AiDotNetLicenseKey(LicenseTestSupport.SignedKeyV2())
         {
-            ServerUrl = "https://192.0.2.1:1/validate" // RFC 5737 TEST-NET, unreachable
+            // Loopback port 1: the online branch fails IMMEDIATELY (connection refused on 127.0.0.1 —
+            // no DNS, no external network, no timeout wait), so the test can't hang. (A purely
+            // syntactically-invalid URL is not used because net471's WebClient path maps a malformed-URI
+            // failure to Invalid rather than ValidationPending; this loopback pattern is the one the
+            // existing licensing suite uses and yields ValidationPending uniformly on both TFMs.)
+            // The point stands: a v2 token with a custom ServerUrl is routed ONLINE, not accepted purely
+            // offline — yielding ValidationPending here.
+            ServerUrl = "http://127.0.0.1:1"
         };
 
         var result = new LicenseValidator(key).Validate();
@@ -263,6 +270,31 @@ public class AsymmetricLicenseTests
     }
 
     [Fact(Timeout = 60000)]
+    public async Task LicensePublicKeyProvider_RejectsWrongLengthKey()
+    {
+        // A key whose x is not a 32-byte Ed25519 public key must be skipped, so HasAnyKey never reports
+        // true for an unusable manifest entry.
+        await Task.Yield();
+        string json = Newtonsoft.Json.JsonConvert.SerializeObject(new
+        {
+            keys = new[]
+            {
+                new
+                {
+                    kty = "OKP",
+                    crv = "Ed25519",
+                    kid = "too-short",
+                    x = Base64UrlHelper.Encode(new byte[16]) // 16 bytes != 32
+                }
+            }
+        });
+
+        var parsed = LicensePublicKeyProvider.Parse(json);
+
+        Assert.Null(parsed);
+    }
+
+    [Fact(Timeout = 60000)]
     public async Task Aidn2_UnsupportedAlg_IsRejected()
     {
         // A token that (validly, with the test key) declares a non-EdDSA alg must be rejected so a future
@@ -275,5 +307,59 @@ public class AsymmetricLicenseTests
 
         Assert.Equal(LicenseKeyStatus.Invalid, result.Status);
         Assert.Contains("algorithm", result.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact(Timeout = 60000)]
+    public async Task Aidn2_MissingOrZeroExp_IsRejected()
+    {
+        // A validly-signed token with a missing / non-positive exp must FAIL CLOSED (Invalid), not be
+        // treated as a non-expiring license. exp=0 (Unix epoch) stands in for an absent exp claim.
+        await Task.Yield();
+        string token = LicenseTestSupport.SignedKeyV2(exp: DateTimeOffset.FromUnixTimeSeconds(0));
+
+        var key = new AiDotNetLicenseKey(token) { ServerUrl = string.Empty };
+        var result = new LicenseValidator(key).Validate();
+
+        Assert.Equal(LicenseKeyStatus.Invalid, result.Status);
+        Assert.Contains("expiry", result.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact(Timeout = 60000)]
+    public async Task Aidn2_KidMatchRouting_Predicate_IsNetworkFree()
+    {
+        // Finding #3: opportunistic offline validation must be gated on a kid MATCH, not merely
+        // "some key embedded". This unit-tests the exact predicate LicenseValidator routes on, without
+        // any network: TryGetKid decodes the token's kid, and only a kid this build embeds is
+        // offline-verifiable. An unknown-kid token is NOT offline-verifiable (→ falls through to online).
+        await Task.Yield();
+
+        string known = LicenseTestSupport.SignedKeyV2(kid: LicenseTestSupport.TestKid);
+        Assert.True(AsymmetricLicenseVerifier.TryGetKid(known, out string knownKid));
+        Assert.Equal(LicenseTestSupport.TestKid, knownKid);
+        Assert.True(LicensePublicKeyProvider.TryGetPublicKey(knownKid, out _)); // embedded → offline-verifiable
+
+        string unknown = LicenseTestSupport.SignedKeyV2(kid: "kid-this-build-does-not-embed");
+        Assert.True(AsymmetricLicenseVerifier.TryGetKid(unknown, out string unknownKid));
+        Assert.Equal("kid-this-build-does-not-embed", unknownKid);
+        Assert.False(LicensePublicKeyProvider.TryGetPublicKey(unknownKid, out _)); // not embedded → goes online
+
+        // TryGetKid is structural only and never applies to non-v2 keys.
+        Assert.False(AsymmetricLicenseVerifier.TryGetKid(LicenseTestSupport.SignedKey("v1id"), out _));
+        Assert.False(AsymmetricLicenseVerifier.TryGetKid(null, out _));
+    }
+
+    [Fact(Timeout = 60000)]
+    public async Task Aidn2_ExplicitOffline_UnknownKid_FailsClosed()
+    {
+        // The kid-match routing change must NOT weaken explicit offline-only mode: an unknown-kid token
+        // there cannot reach a server, so it still fails closed (Invalid), unchanged.
+        await Task.Yield();
+        string token = LicenseTestSupport.SignedKeyV2(kid: "kid-this-build-does-not-embed");
+        var key = new AiDotNetLicenseKey(token) { ServerUrl = string.Empty };
+
+        var result = new LicenseValidator(key).Validate();
+
+        Assert.Equal(LicenseKeyStatus.Invalid, result.Status);
+        Assert.Contains("kid", result.Message, StringComparison.OrdinalIgnoreCase);
     }
 }

--- a/tests/AiDotNet.Tests/Helpers/LicenseTestSupport.cs
+++ b/tests/AiDotNet.Tests/Helpers/LicenseTestSupport.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Security.Cryptography;
 using System.Text;
 using AiDotNet.Helpers;
@@ -37,6 +38,99 @@ internal static class LicenseTestSupport
         byte[] sig = hmac.ComputeHash(Encoding.UTF8.GetBytes(payload));
         string b64url = Convert.ToBase64String(sig).Replace('+', '-').Replace('/', '_').TrimEnd('=');
         return payload + "." + b64url;
+    }
+
+    // ───────────────────────── Asymmetric (aidn2) test support ─────────────────────────
+
+    /// <summary>
+    /// A fixed key-id for the ephemeral test signing keypair. Real builds embed CI-generated kids.
+    /// </summary>
+    internal const string TestKid = "test-kid-2026a";
+
+    /// <summary>
+    /// Ephemeral RSA-2048 test keypair (NEVER a real signing key). Its PUBLIC half is injected into
+    /// <see cref="LicensePublicKeyProvider"/> by the License collection fixture; its PRIVATE half signs
+    /// test tokens via <see cref="SignedKeyV2"/>. Regenerated per test process — nothing is committed.
+    /// </summary>
+    private static readonly RSA TestRsa = CreateTestRsa();
+
+    private static RSA CreateTestRsa()
+    {
+        var rsa = RSA.Create();
+        // Force RSA-2048 uniformly across TFMs (net471 default can be 1024; net8/net10 default is 2048).
+        if (rsa.KeySize != 2048)
+        {
+            rsa.KeySize = 2048;
+        }
+
+        // Materialize the key deterministically before first use.
+        _ = rsa.ExportParameters(false);
+        return rsa;
+    }
+
+    /// <summary>The PUBLIC parameters (modulus/exponent) of the ephemeral test signing keypair.</summary>
+    internal static RSAParameters TestPublicKeyParameters => TestRsa.ExportParameters(false);
+
+    /// <summary>The default embedded public-key set used by the License fixture: { TestKid → test public key }.</summary>
+    internal static Dictionary<string, RSAParameters> DefaultTestKeySet() =>
+        new(StringComparer.Ordinal) { [TestKid] = TestPublicKeyParameters };
+
+    /// <summary>
+    /// Produces a valid asymmetric token <c>aidn2.{base64url(claims)}.{base64url(sig)}</c> signed with the
+    /// ephemeral test PRIVATE key (RS256 = RSA PKCS#1 v1.5 + SHA-256), exactly what
+    /// <see cref="AsymmetricLicenseVerifier"/> verifies. Pass a foreign <paramref name="signingKey"/> to
+    /// forge a bad-signature token, or an <paramref name="exp"/> in the past for an expired token.
+    /// </summary>
+    internal static string SignedKeyV2(
+        string sub = "test-customer",
+        string tier = "pro",
+        int seats = 5,
+        DateTimeOffset? iat = null,
+        DateTimeOffset? exp = null,
+        string? kid = null,
+        RSA? signingKey = null)
+    {
+        var claims = new LicenseClaims
+        {
+            Sub = sub,
+            Tier = tier,
+            Seats = seats,
+            Iat = (iat ?? DateTimeOffset.UtcNow).ToUnixTimeSeconds(),
+            Exp = (exp ?? DateTimeOffset.UtcNow.AddDays(30)).ToUnixTimeSeconds(),
+            Kid = kid ?? TestKid
+        };
+
+        byte[] claimsBytes = Encoding.UTF8.GetBytes(claims.ToCanonicalJson());
+        RSA rsa = signingKey ?? TestRsa;
+        byte[] sig = rsa.SignData(claimsBytes, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
+        return AsymmetricLicenseVerifier.Prefix + "." +
+               Base64UrlHelper.Encode(claimsBytes) + "." +
+               Base64UrlHelper.Encode(sig);
+    }
+
+    /// <summary>
+    /// Creates a fresh, unrelated RSA-2048 keypair — used to sign a token whose signature will NOT verify
+    /// against the embedded test public key (forged-token regression).
+    /// </summary>
+    internal static RSA CreateForeignSigningKey() => CreateTestRsa();
+
+    /// <summary>
+    /// Scopes the embedded license public-key set to <paramref name="keys"/> for the duration of a test,
+    /// restoring the previous set on dispose. Pass <see langword="null"/> to simulate a dev/fork build with
+    /// NO embedded public key and assert fail-closed behaviour.
+    /// </summary>
+    internal static IDisposable WithLicensePublicKeys(IReadOnlyDictionary<string, RSAParameters>? keys)
+    {
+        var previous = LicensePublicKeyProvider.CurrentSnapshot();
+        LicensePublicKeyProvider.OverrideForTesting(keys);
+        return new RestorePublicKeys(previous);
+    }
+
+    private sealed class RestorePublicKeys : IDisposable
+    {
+        private readonly IReadOnlyDictionary<string, RSAParameters>? _previous;
+        public RestorePublicKeys(IReadOnlyDictionary<string, RSAParameters>? previous) => _previous = previous;
+        public void Dispose() => LicensePublicKeyProvider.OverrideForTesting(_previous);
     }
 
     /// <summary>
@@ -88,9 +182,21 @@ public sealed class LicenseBuildKeyFixture : IDisposable
     // so teardown restores it rather than clearing — an official-build run keeps its embedded key afterwards.
     private readonly byte[]? _previousKey = LicenseTestSupport.CurrentBuildKeySnapshot();
 
-    public LicenseBuildKeyFixture() => BuildKeyProvider.OverrideForTesting(LicenseTestSupport.TestBuildKey);
+    // Same restore discipline for the asymmetric (aidn2) public key set.
+    private readonly IReadOnlyDictionary<string, RSAParameters>? _previousPublicKeys =
+        LicensePublicKeyProvider.CurrentSnapshot();
 
-    public void Dispose() => BuildKeyProvider.OverrideForTesting(_previousKey);
+    public LicenseBuildKeyFixture()
+    {
+        BuildKeyProvider.OverrideForTesting(LicenseTestSupport.TestBuildKey);
+        LicensePublicKeyProvider.OverrideForTesting(LicenseTestSupport.DefaultTestKeySet());
+    }
+
+    public void Dispose()
+    {
+        BuildKeyProvider.OverrideForTesting(_previousKey);
+        LicensePublicKeyProvider.OverrideForTesting(_previousPublicKeys);
+    }
 }
 
 [CollectionDefinition("License", DisableParallelization = true)]

--- a/tests/AiDotNet.Tests/Helpers/LicenseTestSupport.cs
+++ b/tests/AiDotNet.Tests/Helpers/LicenseTestSupport.cs
@@ -48,38 +48,33 @@ internal static class LicenseTestSupport
     internal const string TestKid = "test-kid-2026a";
 
     /// <summary>
-    /// Ephemeral RSA-2048 test keypair (NEVER a real signing key). Its PUBLIC half is injected into
-    /// <see cref="LicensePublicKeyProvider"/> by the License collection fixture; its PRIVATE half signs
-    /// test tokens via <see cref="SignedKeyV2"/>. Regenerated per test process — nothing is committed.
+    /// Ephemeral Ed25519 test keypair (NEVER a real signing key). Its PUBLIC half (32 bytes) is injected
+    /// into <see cref="LicensePublicKeyProvider"/> by the License collection fixture; its PRIVATE half
+    /// signs test tokens via <see cref="SignedKeyV2"/>. Regenerated per test process — nothing committed.
     /// </summary>
-    private static readonly RSA TestRsa = CreateTestRsa();
+    private static readonly Org.BouncyCastle.Crypto.AsymmetricCipherKeyPair TestKeyPair = CreateEd25519KeyPair();
 
-    private static RSA CreateTestRsa()
+    private static Org.BouncyCastle.Crypto.AsymmetricCipherKeyPair CreateEd25519KeyPair()
     {
-        var rsa = RSA.Create();
-        // Force RSA-2048 uniformly across TFMs (net471 default can be 1024; net8/net10 default is 2048).
-        if (rsa.KeySize != 2048)
-        {
-            rsa.KeySize = 2048;
-        }
-
-        // Materialize the key deterministically before first use.
-        _ = rsa.ExportParameters(false);
-        return rsa;
+        var generator = new Org.BouncyCastle.Crypto.Generators.Ed25519KeyPairGenerator();
+        generator.Init(new Org.BouncyCastle.Crypto.Parameters.Ed25519KeyGenerationParameters(
+            new Org.BouncyCastle.Security.SecureRandom()));
+        return generator.GenerateKeyPair();
     }
 
-    /// <summary>The PUBLIC parameters (modulus/exponent) of the ephemeral test signing keypair.</summary>
-    internal static RSAParameters TestPublicKeyParameters => TestRsa.ExportParameters(false);
+    /// <summary>The raw 32-byte Ed25519 PUBLIC key of the ephemeral test signing keypair.</summary>
+    internal static byte[] TestPublicKey =>
+        ((Org.BouncyCastle.Crypto.Parameters.Ed25519PublicKeyParameters)TestKeyPair.Public).GetEncoded();
 
     /// <summary>The default embedded public-key set used by the License fixture: { TestKid → test public key }.</summary>
-    internal static Dictionary<string, RSAParameters> DefaultTestKeySet() =>
-        new(StringComparer.Ordinal) { [TestKid] = TestPublicKeyParameters };
+    internal static Dictionary<string, byte[]> DefaultTestKeySet() =>
+        new(StringComparer.Ordinal) { [TestKid] = TestPublicKey };
 
     /// <summary>
     /// Produces a valid asymmetric token <c>aidn2.{base64url(claims)}.{base64url(sig)}</c> signed with the
-    /// ephemeral test PRIVATE key (RS256 = RSA PKCS#1 v1.5 + SHA-256), exactly what
-    /// <see cref="AsymmetricLicenseVerifier"/> verifies. Pass a foreign <paramref name="signingKey"/> to
-    /// forge a bad-signature token, or an <paramref name="exp"/> in the past for an expired token.
+    /// ephemeral test PRIVATE key (Ed25519 / EdDSA), exactly what <see cref="AsymmetricLicenseVerifier"/>
+    /// verifies. Pass a foreign <paramref name="signingKey"/> to forge a bad-signature token, or an
+    /// <paramref name="exp"/> in the past for an expired token.
     /// </summary>
     internal static string SignedKeyV2(
         string sub = "test-customer",
@@ -88,7 +83,8 @@ internal static class LicenseTestSupport
         DateTimeOffset? iat = null,
         DateTimeOffset? exp = null,
         string? kid = null,
-        RSA? signingKey = null)
+        string? alg = "EdDSA",
+        Org.BouncyCastle.Crypto.AsymmetricKeyParameter? signingKey = null)
     {
         var claims = new LicenseClaims
         {
@@ -97,29 +93,34 @@ internal static class LicenseTestSupport
             Seats = seats,
             Iat = (iat ?? DateTimeOffset.UtcNow).ToUnixTimeSeconds(),
             Exp = (exp ?? DateTimeOffset.UtcNow.AddDays(30)).ToUnixTimeSeconds(),
-            Kid = kid ?? TestKid
+            Kid = kid ?? TestKid,
+            Alg = alg
         };
 
         byte[] claimsBytes = Encoding.UTF8.GetBytes(claims.ToCanonicalJson());
-        RSA rsa = signingKey ?? TestRsa;
-        byte[] sig = rsa.SignData(claimsBytes, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
+        var signer = new Org.BouncyCastle.Crypto.Signers.Ed25519Signer();
+        signer.Init(true, signingKey ?? TestKeyPair.Private);
+        signer.BlockUpdate(claimsBytes, 0, claimsBytes.Length);
+        byte[] sig = signer.GenerateSignature();
+
         return AsymmetricLicenseVerifier.Prefix + "." +
                Base64UrlHelper.Encode(claimsBytes) + "." +
                Base64UrlHelper.Encode(sig);
     }
 
     /// <summary>
-    /// Creates a fresh, unrelated RSA-2048 keypair — used to sign a token whose signature will NOT verify
-    /// against the embedded test public key (forged-token regression).
+    /// Creates a fresh, unrelated Ed25519 PRIVATE key — used to sign a token whose signature will NOT
+    /// verify against the embedded test public key (forged-token regression).
     /// </summary>
-    internal static RSA CreateForeignSigningKey() => CreateTestRsa();
+    internal static Org.BouncyCastle.Crypto.AsymmetricKeyParameter CreateForeignSigningKey() =>
+        CreateEd25519KeyPair().Private;
 
     /// <summary>
     /// Scopes the embedded license public-key set to <paramref name="keys"/> for the duration of a test,
     /// restoring the previous set on dispose. Pass <see langword="null"/> to simulate a dev/fork build with
     /// NO embedded public key and assert fail-closed behaviour.
     /// </summary>
-    internal static IDisposable WithLicensePublicKeys(IReadOnlyDictionary<string, RSAParameters>? keys)
+    internal static IDisposable WithLicensePublicKeys(IReadOnlyDictionary<string, byte[]>? keys)
     {
         var previous = LicensePublicKeyProvider.CurrentSnapshot();
         LicensePublicKeyProvider.OverrideForTesting(keys);
@@ -128,8 +129,8 @@ internal static class LicenseTestSupport
 
     private sealed class RestorePublicKeys : IDisposable
     {
-        private readonly IReadOnlyDictionary<string, RSAParameters>? _previous;
-        public RestorePublicKeys(IReadOnlyDictionary<string, RSAParameters>? previous) => _previous = previous;
+        private readonly IReadOnlyDictionary<string, byte[]>? _previous;
+        public RestorePublicKeys(IReadOnlyDictionary<string, byte[]>? previous) => _previous = previous;
         public void Dispose() => LicensePublicKeyProvider.OverrideForTesting(_previous);
     }
 
@@ -183,7 +184,7 @@ public sealed class LicenseBuildKeyFixture : IDisposable
     private readonly byte[]? _previousKey = LicenseTestSupport.CurrentBuildKeySnapshot();
 
     // Same restore discipline for the asymmetric (aidn2) public key set.
-    private readonly IReadOnlyDictionary<string, RSAParameters>? _previousPublicKeys =
+    private readonly IReadOnlyDictionary<string, byte[]>? _previousPublicKeys =
         LicensePublicKeyProvider.CurrentSnapshot();
 
     public LicenseBuildKeyFixture()


### PR DESCRIPTION
## Why (verified security hole)

Offline license verification used `HMAC-SHA256(BuildKey, payload)` for `aidn.{id}.{sig}` keys, where **`BuildKey` is a 32-byte SYMMETRIC secret embedded in every published DLL** (resource `AiDotNet.BuildKey`). HMAC needs the *same* secret to sign and verify → the verifier secret **must ship** → it is extractable in seconds via reflection, letting anyone forge unlimited valid keys. There was also no offline revocation bound.

## The fix: asymmetric public-key signatures (Ed25519 / EdDSA)

Sign licenses server-side with a **private** key that never ships; embed only the **public** key (safe to extract — worthless to a forger).

**Token format:** `aidn2.<base64url(claims_json)>.<base64url(ed25519_sig)>`, claims = `{ sub, tier, seats, iat, exp, kid, alg:"EdDSA" }`.

**Verification** (`AsymmetricLicenseVerifier.Verify`): Ed25519 signature over the raw claims bytes, against the embedded public key selected by `kid`, then enforce `exp`. Fails **closed** on every non-Active path (bad signature, tampered claims, unknown `kid`, unsupported `alg`, non-64-byte sig, no embedded public key, malformed, expired).

### Crypto primitive: Ed25519 (EdDSA), not RSA
Ed25519 is the modern, security-forward standard: deterministic (no per-signature nonce to leak), side-channel-resistant by construction, 32-byte public keys / 64-byte signatures, free of the RSA padding/parameter-oracle pitfalls. RSA/RS256 is merely the common baseline.

**Availability confirmed per TFM:** .NET's `System.Security.Cryptography` ships **no Ed25519 type on any** of `net471`/`net8`/`net10`. Verification uses the well-audited **`BouncyCastle.Cryptography`** (`Org.BouncyCastle`) — a single dep (net461+/netstandard2.0) covering all three TFMs — added to the core package. `alg:"EdDSA"` is recorded in claims so a future primitive change/rotation is unambiguous; the verifier rejects any token declaring an `alg` it does not implement.

### Rotation & revocation
- `kid` selects among multiple embedded Ed25519 public keys → rotate without breaking issued licenses.
- Revocation stays server-driven: a custom `ServerUrl` routes online; `exp` bounds offline use.

## Back-compat
Legacy `aidn.` (v1 HMAC) keys **still validate** unchanged; new issuance is `aidn2.`. `AIDN-*` → online (unchanged). All existing licensing tests pass untouched.

## Changes
- **New:** `Base64UrlHelper`, `LicenseClaims` (incl. `alg`), `LicensePublicKeyProvider` (kid→32-byte Ed25519 key from JWK OKP; test override + CI-injected resource), `AsymmetricLicenseVerifier` (Ed25519 via BouncyCastle).
- **Modified:** `LicenseValidator` (sync+async offline routing covers v2 when a public key is embedded; new `IsOfflineVerifiableKeyFormat`), `ModelPersistenceGuard` (env/file v2 keys route offline), `AiDotNet.csproj` (BouncyCastle ref + Condition-guarded `AiDotNet.LicensePublicKey` resource, mirroring `BuildKey`), `Directory.Packages.props` (BouncyCastle.Cryptography 2.6.1).

## Tests (all green)
`AsymmetricLicenseTests`: forged (foreign Ed25519 keypair) rejected, tampered claims rejected, expired rejected, unknown-kid rejected, unsupported-alg rejected, non-Ed25519-curve skipped, no-embedded-key fails closed, valid token Active offline, v1 back-compat still Active, custom-server routes online, revoked→Revoked, JWK-OKP round-trip.

- **net10.0:** 185/185 licensing tests pass.
- **net471:** 164/164 licensing tests pass (proves Ed25519-via-BouncyCastle verify works on .NET Framework).

## Remaining (server-side / CI — documented, not implemented)
- **CI must generate the Ed25519 keypair**, keep the **private** key in a secret store (like `AIDOTNET_BUILD_KEY` in `automated-release.yml`), and drop the **public** half at `src/BuildKey/LicensePublicKey.json` as JWK OKP `{ "keys":[{ "kty":"OKP","crv":"Ed25519","kid","x" }] }` so the `AiDotNet.LicensePublicKey` resource embeds. Until then, official builds embed no v2 key and `aidn2.` tokens fail closed (v1 unaffected).
- **Server-side `LicenseSigner`** lives in the license server / offline dev tool — deliberately not shipped in the client library.
- `BuildKey`-derived AIMF model-file encryption is a separate concern (still symmetric).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
