### PR TITLE
fix(optimizer): bump Tensor.Version after in-place tape Step so GPU re-uploads updated weights

### DIFF
--- a/src/Optimizers/GradientBasedOptimizerBase.cs
+++ b/src/Optimizers/GradientBasedOptimizerBase.cs
@@ -1570,6 +1570,28 @@ public abstract class GradientBasedOptimizerBase<T, TInput, TOutput> : Optimizer
                 // Step mutates the parameter tensors in place via tape semantics;
                 // since we passed the live parameter-chunk refs, the model is
                 // already updated. No SetParameters call needed.
+                //
+                // GPU-cache coherency: Step writes the new weights straight into each parameter
+                // tensor's backing storage (via GetLiveBackingArrayOrNull()/AsWritableSpan()) WITHOUT
+                // going through a Tensor API that bumps the version. A GPU engine caches an uploaded
+                // copy of each weight tensor keyed by that backing array; without an explicit
+                // invalidation the version gate ('_gpuBufferVersion == Version') still matches and the
+                // NEXT forward reads the STALE device weights from step 0, so the model appears to
+                // train on the host (GetParameters changes) while the GPU forward never sees the
+                // update — GPU-engine training then diverges from the CPU engine. Tell the engine each
+                // updated parameter changed so it re-uploads on the next use. On the CPU engine this is
+                // a no-op. (The legacy SetParameters path below already refreshes device state.)
+                var updatedParams = ctx.Parameters;
+                for (int pi = 0; pi < updatedParams.Count; pi++)
+                {
+                    var updated = updatedParams[pi];
+                    // Bump the version so a GPU engine's version gate re-uploads the mutated weights
+                    // from the host backing store on the next forward. IncrementVersion is a lightweight
+                    // mark-dirty — unlike InvalidatePersistentTensor it does NOT download the current
+                    // device buffer to host (which, for a GPU-resident parameter, would overwrite the
+                    // Adam update we just wrote and freeze training).
+                    updated?.IncrementVersion();
+                }
                 return currentSolution;
             }
             // Fall through to legacy path if synthesis declined (e.g. no chunks).


### PR DESCRIPTION
## Summary
`GradientBasedOptimizerBase.UpdateSolution`'s tape path calls `Step(TapeStepContext)`, and every gradient optimizer's `Step` writes new weights straight into each parameter tensor's backing storage via `GetLiveBackingArrayOrNull()` / `AsWritableSpan()` (the fast in-place Adam/SGD path) **without** going through a Tensor API that bumps `Tensor.Version`.

`DirectGpuTensorEngine` caches an uploaded device copy of each weight tensor, guarded by a version gate (`_gpuBufferVersion == Version`). Because the in-place update never advances `Version`, the gate keeps matching and **every forward after the first step reads the stale device weights from step 0**. The model appears to train on the host (`GetParameters` reflects updates) while the GPU forward computes gradients on frozen step-0 weights, so GPU-engine training diverges from the CPU engine.

## Evidence (RTX 3080)
A tiny `Transformer<float>` trained through `AiModelBuilder.BuildAsync`:
- **Before:** nondeterministic, blown-up weights (paramL1 **3236 vs 11154** across identical runs) and **chance** held-out accuracy on the GPU engine; CpuEngine learned normally.
- **After:** GPU-engine training is **deterministic** (identical paramL1 across runs) and the transformer **learns** (held-out accuracy climbs well above chance) instead of diverging.

This was the last root-caused piece of a GPU-engine transformer-training investigation (alongside AiDotNet.Tensors #730 LayerNorm-rank3 and #732 CUDA-Dropout-100%-drop): a facade-trained transformer that learned on CpuEngine but sat at chance on the CUDA engine.

## Fix
After `Step` mutates the parameters in place, bump each parameter tensor's version so the GPU engine re-uploads the updated weights from the host backing on the next forward. `IncrementVersion` is a lightweight mark-dirty (internal, visible to AiDotNet via `InternalsVisibleTo`) — deliberately **not** `InvalidatePersistentTensor`, which calls `GetDataArray()` and would download the current device buffer to host, overwriting the Adam update we just wrote (for a GPU-resident parameter) and freezing training. On CpuEngine the bump is a no-op. Covers all gradient optimizers (Adam/AdamW/SGD/…) since they share this base `UpdateSolution` → `Step` path.

## Notes / remaining
- This is verified with `AIDOTNET_GPU_RESIDENT_PARAMS=0`. With the default GPU-resident-params path, a *separate* host-Adam/resident-buffer coherency issue (the forward reads a resident device buffer while the host-side Adam updates the host backing) still freezes training — that is a distinct two-training-path issue (the residency in `CompiledTapeTrainingStep` is intended to pair with on-device GPU Adam) and is out of scope here; recommend gating residency on GPU-Adam being active as a follow-up.
- A residual GPU-vs-CPU accuracy gap remains on very small/ill-conditioned tasks (float-level trajectory divergence between GPU and CPU compounding over many steps); it is not a correctness regression from this change.