### PR TITLE
feat(checkpoint): typed model-state restore via ICheckpointableModel sidecar

### DIFF
--- a/src/CheckpointManagement/CheckpointManager.cs
+++ b/src/CheckpointManagement/CheckpointManager.cs
@@ -32,6 +32,14 @@ public class CheckpointManager<T, TInput, TOutput> : CheckpointManagerBase<T, TI
     }
 
     /// <summary>
+    /// Suffix for the sidecar file that holds the model's own <see cref="ICheckpointableModel"/>
+    /// state next to the checkpoint JSON. The JSON only round-trips the model as an untyped JSON
+    /// object (models are not JSON-round-trippable); this sidecar is what <see cref="RestoreModelState(string, ICheckpointableModel)"/>
+    /// reads to bring a real, typed model back to the exact saved state.
+    /// </summary>
+    private const string StateSuffix = ".state";
+
+    /// <summary>
     /// Saves a checkpoint of the current training state.
     /// </summary>
     public override string SaveCheckpoint<TMetadata>(
@@ -58,6 +66,16 @@ public class CheckpointManager<T, TInput, TOutput> : CheckpointManagerBase<T, TI
             File.WriteAllText(checkpointPath, json);
 
             checkpoint.FilePath = checkpointPath;
+
+            // Persist the model's OWN state via the ICheckpointableModel contract to a sidecar file.
+            // LoadCheckpoint's JSON deserializes the model as an un-rehydrated JObject (NN models are
+            // not JSON-round-trippable), so it can't produce a usable model. This sidecar is the
+            // typed restore path consumed by RestoreModelState.
+            if (model is ICheckpointableModel checkpointable)
+            {
+                using var stateStream = File.Create(checkpointPath + StateSuffix);
+                checkpointable.SaveState(stateStream);
+            }
 
             // Store metadata
             var checkpointMetadata = new CheckpointMetadata<T>
@@ -121,6 +139,65 @@ public class CheckpointManager<T, TInput, TOutput> : CheckpointManagerBase<T, TI
                 .FirstOrDefault();
 
             return latest != null ? LoadCheckpoint(latest.CheckpointId) : null;
+        }
+    }
+
+    /// <summary>
+    /// Restores a checkpoint's saved model state into <paramref name="target"/> — a live model of
+    /// the matching type — via the <see cref="ICheckpointableModel"/> contract. This is the TYPED
+    /// counterpart to <see cref="LoadCheckpoint"/>, whose <c>Model</c> deserializes only to an
+    /// un-rehydrated JSON object. After a successful call, <paramref name="target"/> is at the exact
+    /// state that was saved (parameters + configuration), so it reproduces the checkpointed model's
+    /// predictions.
+    /// </summary>
+    /// <param name="checkpointId">The checkpoint to restore from.</param>
+    /// <param name="target">A model instance (matching architecture) to load the state into.</param>
+    /// <returns>
+    /// <c>true</c> if the state was restored; <c>false</c> if the checkpoint has no saved-state
+    /// sidecar (e.g. a legacy checkpoint written before this feature).
+    /// </returns>
+    public bool RestoreModelState(string checkpointId, ICheckpointableModel target)
+    {
+        if (target == null)
+            throw new ArgumentNullException(nameof(target));
+
+        lock (SyncLock)
+        {
+            if (!_checkpoints.TryGetValue(checkpointId, out var metadata) || metadata.FilePath == null)
+                throw new ArgumentException($"Checkpoint with ID '{checkpointId}' not found.", nameof(checkpointId));
+
+            var statePath = metadata.FilePath + StateSuffix;
+            if (!File.Exists(statePath))
+                return false;
+
+            ValidatePathWithinDirectory(statePath, CheckpointDirectory);
+            using var stateStream = File.OpenRead(statePath);
+            target.LoadState(stateStream);
+            return true;
+        }
+    }
+
+    /// <summary>
+    /// Restores the most recent checkpoint's saved model state into <paramref name="target"/>.
+    /// This is the typed resume counterpart to <see cref="LoadLatestCheckpoint"/>.
+    /// </summary>
+    /// <param name="target">A model instance (matching architecture) to load the state into.</param>
+    /// <returns>
+    /// <c>true</c> if the latest checkpoint's state was restored; <c>false</c> if there are no
+    /// checkpoints, or the latest one has no saved-state sidecar.
+    /// </returns>
+    public bool RestoreLatestModelState(ICheckpointableModel target)
+    {
+        if (target == null)
+            throw new ArgumentNullException(nameof(target));
+
+        lock (SyncLock)
+        {
+            var latest = _checkpoints.Values
+                .OrderByDescending(c => c.CreatedAt)
+                .FirstOrDefault();
+
+            return latest != null && RestoreModelState(latest.CheckpointId, target);
         }
     }
 
@@ -196,6 +273,16 @@ public class CheckpointManager<T, TInput, TOutput> : CheckpointManagerBase<T, TI
             if (metadata.FilePath != null && File.Exists(metadata.FilePath))
             {
                 File.Delete(metadata.FilePath);
+            }
+
+            // Delete the model-state sidecar written by SaveCheckpoint, if present.
+            if (metadata.FilePath != null)
+            {
+                var statePath = metadata.FilePath + StateSuffix;
+                if (File.Exists(statePath))
+                {
+                    File.Delete(statePath);
+                }
             }
 
             // Remove from tracking

--- a/tests/AiDotNet.Tests/UnitTests/TrainingInfrastructure/CheckpointManagerTests.cs
+++ b/tests/AiDotNet.Tests/UnitTests/TrainingInfrastructure/CheckpointManagerTests.cs
@@ -52,6 +52,43 @@ public class CheckpointManagerTests : IDisposable
         public ModelMetadata<double> GetModelMetadata() => new() { Name = Name };
     }
 
+    /// <summary>
+    /// A model that opts in to <see cref="ICheckpointableModel"/> by round-tripping its
+    /// weights through the state stream, so we can verify typed restore reproduces state.
+    /// </summary>
+    private class CheckpointableMockModel : IModel<double[], double, ModelMetadata<double>>, ICheckpointableModel
+    {
+        public string Name { get; set; } = "CheckpointableMockModel";
+        public double[] Weights { get; set; } = new double[] { 1.0, 2.0, 3.0 };
+
+        public void Train(double[] input, double expectedOutput) { }
+        public double Predict(double[] input) => Weights.Sum();
+        public ModelMetadata<double> GetModelMetadata() => new() { Name = Name };
+
+        public void SaveState(Stream stream)
+        {
+            var writer = new BinaryWriter(stream);
+            writer.Write(Weights.Length);
+            foreach (var w in Weights)
+            {
+                writer.Write(w);
+            }
+            writer.Flush();
+        }
+
+        public void LoadState(Stream stream)
+        {
+            var reader = new BinaryReader(stream);
+            var count = reader.ReadInt32();
+            var restored = new double[count];
+            for (int i = 0; i < count; i++)
+            {
+                restored[i] = reader.ReadDouble();
+            }
+            Weights = restored;
+        }
+    }
+
     private class MockOptimizer : IOptimizer<double, double[], double>
     {
         public double LearningRate { get; set; } = 0.001;
@@ -616,6 +653,136 @@ public class CheckpointManagerTests : IDisposable
         // Assert
         Assert.Equal(0, deletedCount);
         Assert.Equal(2, _manager.ListCheckpoints().Count);
+    }
+
+    #endregion
+
+    #region RestoreModelState Tests
+
+    [Fact(Timeout = 60000)]
+    public async Task RestoreModelState_WithCheckpointableModel_RestoresSavedState()
+    {
+        await Task.Yield();
+
+        // Arrange - a checkpointable model with distinctive weights
+        var model = new CheckpointableMockModel { Weights = new[] { 3.14, 2.71, 1.41, 1.61 } };
+        var optimizer = new MockOptimizer();
+        var checkpointId = _manager.SaveCheckpoint(model, optimizer, epoch: 7, step: 700,
+            new Dictionary<string, double> { ["loss"] = 0.05 });
+
+        // Act - restore into a FRESH model with different weights
+        var target = new CheckpointableMockModel { Weights = new[] { 0.0 } };
+        var restored = _manager.RestoreModelState(checkpointId, target);
+
+        // Assert - the fresh model now reproduces the saved model's state exactly
+        Assert.True(restored);
+        Assert.Equal(model.Weights, target.Weights);
+        Assert.Equal(model.Predict(Array.Empty<double>()), target.Predict(Array.Empty<double>()));
+    }
+
+    [Fact(Timeout = 60000)]
+    public async Task RestoreLatestModelState_RestoresNewestCheckpointState()
+    {
+        await Task.Yield();
+
+        // Arrange - three checkpoints; the newest has distinctive weights
+        var optimizer = new MockOptimizer();
+        _manager.SaveCheckpoint(new CheckpointableMockModel { Weights = new[] { 1.0 } },
+            optimizer, epoch: 1, step: 10, new Dictionary<string, double> { ["loss"] = 0.9 });
+        Thread.Sleep(50);
+        _manager.SaveCheckpoint(new CheckpointableMockModel { Weights = new[] { 2.0 } },
+            optimizer, epoch: 2, step: 20, new Dictionary<string, double> { ["loss"] = 0.7 });
+        Thread.Sleep(50);
+        _manager.SaveCheckpoint(new CheckpointableMockModel { Weights = new[] { 10.0, 20.0, 30.0 } },
+            optimizer, epoch: 3, step: 30, new Dictionary<string, double> { ["loss"] = 0.5 });
+
+        // Act
+        var target = new CheckpointableMockModel();
+        var restored = _manager.RestoreLatestModelState(target);
+
+        // Assert - restores the NEWEST checkpoint's state
+        Assert.True(restored);
+        Assert.Equal(new[] { 10.0, 20.0, 30.0 }, target.Weights);
+    }
+
+    [Fact(Timeout = 60000)]
+    public async Task RestoreLatestModelState_WhenNoCheckpoints_ReturnsFalse()
+    {
+        await Task.Yield();
+
+        // Act
+        var target = new CheckpointableMockModel();
+        var restored = _manager.RestoreLatestModelState(target);
+
+        // Assert
+        Assert.False(restored);
+    }
+
+    [Fact(Timeout = 60000)]
+    public async Task RestoreModelState_WhenNoStateSidecar_ReturnsFalse()
+    {
+        await Task.Yield();
+
+        // Arrange - a non-checkpointable model writes no state sidecar
+        var model = new MockModel();
+        var optimizer = new MockOptimizer();
+        var checkpointId = _manager.SaveCheckpoint(model, optimizer, epoch: 1, step: 10,
+            new Dictionary<string, double> { ["loss"] = 0.5 });
+
+        // Act
+        var target = new CheckpointableMockModel();
+        var restored = _manager.RestoreModelState(checkpointId, target);
+
+        // Assert - no sidecar to restore from
+        Assert.False(restored);
+    }
+
+    [Fact(Timeout = 60000)]
+    public async Task RestoreModelState_WithInvalidId_ThrowsArgumentException()
+    {
+        await Task.Yield();
+
+        // Act & Assert
+        var target = new CheckpointableMockModel();
+        Assert.Throws<ArgumentException>(() => _manager.RestoreModelState("nonexistent-id", target));
+    }
+
+    [Fact(Timeout = 60000)]
+    public async Task RestoreModelState_WithNullTarget_ThrowsArgumentNullException()
+    {
+        await Task.Yield();
+
+        // Arrange
+        var model = new CheckpointableMockModel();
+        var optimizer = new MockOptimizer();
+        var checkpointId = _manager.SaveCheckpoint(model, optimizer, epoch: 1, step: 10,
+            new Dictionary<string, double> { ["loss"] = 0.5 });
+
+        // Act & Assert
+        Assert.Throws<ArgumentNullException>(() => _manager.RestoreModelState(checkpointId, null!));
+    }
+
+    [Fact(Timeout = 60000)]
+    public async Task DeleteCheckpoint_RemovesStateSidecar()
+    {
+        await Task.Yield();
+
+        // Arrange
+        var model = new CheckpointableMockModel { Weights = new[] { 5.0, 6.0 } };
+        var optimizer = new MockOptimizer();
+        var checkpointId = _manager.SaveCheckpoint(model, optimizer, epoch: 1, step: 10,
+            new Dictionary<string, double> { ["loss"] = 0.5 });
+
+        // Sanity: a sidecar exists to restore from
+        var probe = new CheckpointableMockModel();
+        Assert.True(_manager.RestoreModelState(checkpointId, probe));
+
+        // Act
+        _manager.DeleteCheckpoint(checkpointId);
+
+        // Assert - the sidecar is gone along with the checkpoint
+        var sidecars = Directory.GetFiles(_testDirectory, "*" + ".state");
+        Assert.Empty(sidecars);
     }
 
     #endregion


### PR DESCRIPTION
## Problem

`CheckpointManager.SaveCheckpoint` serializes the whole `Checkpoint<T,TInput,TOutput>` (including the `Model`) as JSON. On `LoadCheckpoint`, the `Model` deserializes to an **un-rehydrated Newtonsoft `JObject`** — neural-network models are not cleanly JSON-round-trippable, so `((JObject)checkpoint.Model).ToObject<...>()` throws. In practice a checkpoint could be *inspected* (epoch/step/metrics/optimizer state all round-trip fine) but there was **no way to resume a live, typed model** to the saved state.

## Fix

Persist the model's own state through the existing `ICheckpointableModel` contract (`SaveState`/`LoadState`) to a `.state` **sidecar** file next to the checkpoint JSON, and add a typed restore API:

- **`bool RestoreModelState(string checkpointId, ICheckpointableModel target)`** — loads a checkpoint's saved state into a caller-supplied live model of the matching architecture. Returns `false` if the checkpoint has no sidecar (e.g. a legacy checkpoint or a model that doesn't implement `ICheckpointableModel`).
- **`bool RestoreLatestModelState(ICheckpointableModel target)`** — the typed resume counterpart to `LoadLatestCheckpoint`.

The caller-supplies-the-instance shape avoids reflection-based instantiation and works cleanly with the generic model types.

### Notes
- Sidecars are deleted alongside the checkpoint in `DeleteCheckpoint`.
- **Back-compat:** models that don't implement `ICheckpointableModel` write no sidecar; restore returns `false`. Existing checkpoints (no sidecar) are unaffected — JSON metadata/optimizer restore paths are unchanged.
- Path is validated with the existing `ValidatePathWithinDirectory` guard before reading.
- I chose the `Checkpoint`-object overload out because a *deserialized* `Checkpoint` regenerates its `CheckpointId` and has a null `FilePath` (set after serialization) — keying restore off a loaded checkpoint object would be unreliable. Restore keys off the stable in-memory metadata (`checkpointId` from `SaveCheckpoint`/`ListCheckpoints`, or "latest").

## Tests

7 new unit tests in `CheckpointManagerTests`: round-trip restore reproduces saved weights & predictions; `RestoreLatestModelState` picks the newest; no-sidecar → `false`; invalid id → `ArgumentException`; null target → `ArgumentNullException`; `DeleteCheckpoint` removes the sidecar. **35/35 `CheckpointManagerTests` pass on net10.0.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)