### PR TITLE
ci(release): stop cancelling in-flight releases so versions actually publish

### DIFF
--- a/.github/workflows/automated-release.yml
+++ b/.github/workflows/automated-release.yml
@@ -20,7 +20,15 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true  # Cancel stale release when new push to master arrives
+  # NEVER cancel an in-flight release. cancel-in-progress: true meant that any new push to master
+  # killed the running pipeline — and because master gets frequent pushes, releases were cancelled
+  # mid-flight (observed: Version+Build+Pack succeed, then Publish/GitHub-release get CANCELLED), so
+  # NO version ever published to NuGet. Worse, cancelling between the NuGet push and the git tag /
+  # GitHub release leaves a half-completed release (package pushed, tag missing). Publishing an
+  # immutable versioned artifact must be atomic. With false, the group still SERIALIZES runs (only
+  # one release at a time — no double-publish race), but each queued release runs to completion, so
+  # every should_release commit actually ships its version.
+  cancel-in-progress: false
 
 permissions:
   contents: write


### PR DESCRIPTION
## Problem
`automated-release.yml` set concurrency `cancel-in-progress: true`. Master gets frequent pushes, so every new commit **cancels the running release mid-flight**. Across recent runs:
- `Version:succ Pack:succ Publish:CANCELLED Create:CANCELLED`
- `Version:succ Pack:CANCELLED`
- (plus stale smoke-gate failures, since fixed)

Net effect: **no version has been publishing to NuGet, and no GitHub release is created.** Cancelling *between* the NuGet push and the git-tag/GitHub-release steps also risks a half-done release (package pushed, tag missing) — publishing an immutable versioned artifact must be atomic.

## Fix
`cancel-in-progress: false`. The concurrency group still **serializes** releases (one at a time — no double-publish race), but each queued release now **runs to completion**, so every `should_release` commit ships its version.

Single-line workflow change; no code impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)