### PR TITLE
fix(transformer): label smoothing (paper eps=0.1) un-freezes batched training (#1559)

### DIFF
--- a/src/LossFunctions/CategoricalCrossEntropyLoss.cs
+++ b/src/LossFunctions/CategoricalCrossEntropyLoss.cs
@@ -40,10 +40,27 @@ namespace AiDotNet.LossFunctions;
 public class CategoricalCrossEntropyLoss<T> : LossFunctionBase<T>
 {
     /// <summary>
+    /// Label-smoothing coefficient ε in [0, 1). 0 disables smoothing (plain one-hot targets).
+    /// </summary>
+    private readonly double _labelSmoothing;
+
+    /// <summary>
     /// Initializes a new instance of the CategoricalCrossEntropyLoss class.
     /// </summary>
-    public CategoricalCrossEntropyLoss()
+    /// <param name="labelSmoothing">
+    /// Label-smoothing coefficient ε in [0, 1), default 0 (no smoothing). When ε &gt; 0 the one-hot
+    /// target y is replaced by <c>(1 - ε)·y + ε/K</c> (K = number of classes) before the loss and
+    /// gradient are computed — the "Attention Is All You Need" (Vaswani et al. 2017) regularizer
+    /// (they use ε = 0.1). Smoothing keeps the optimal softmax output off the hard 0/1 rail, so the
+    /// softmax gradient never vanishes into a saturated state — this is what lets batched
+    /// (averaged-gradient) training keep learning instead of overshooting into a frozen local optimum.
+    /// </param>
+    public CategoricalCrossEntropyLoss(double labelSmoothing = 0.0)
     {
+        if (labelSmoothing < 0.0 || labelSmoothing >= 1.0)
+            throw new ArgumentOutOfRangeException(
+                nameof(labelSmoothing), labelSmoothing, "Label smoothing must be in [0, 1).");
+        _labelSmoothing = labelSmoothing;
     }
 
     /// <summary>
@@ -55,6 +72,7 @@ public class CategoricalCrossEntropyLoss<T> : LossFunctionBase<T>
     public override T CalculateLoss(Vector<T> predicted, Vector<T> actual)
     {
         ValidateVectorLengths(predicted, actual);
+        actual = SmoothActual(actual);
 
         T sum = NumOps.Zero;
         for (int i = 0; i < predicted.Length; i++)
@@ -75,6 +93,7 @@ public class CategoricalCrossEntropyLoss<T> : LossFunctionBase<T>
     public override Vector<T> CalculateDerivative(Vector<T> predicted, Vector<T> actual)
     {
         ValidateVectorLengths(predicted, actual);
+        actual = SmoothActual(actual);
 
         // Derivative of -Σ actual_i * log(predicted_i) with respect to predicted_i = -actual_i / predicted_i
         // Note: When composed with softmax, this simplifies to (predicted - actual),
@@ -105,6 +124,7 @@ public class CategoricalCrossEntropyLoss<T> : LossFunctionBase<T>
             return base.CalculateLossAndGradientGpu(predicted, actual);
         }
 
+        actual = SmoothTarget(actual);
         int size = predicted.Length;
 
         // Compute loss on GPU
@@ -145,6 +165,7 @@ public class CategoricalCrossEntropyLoss<T> : LossFunctionBase<T>
     public override Tensor<T> ComputeTapeLoss(Tensor<T> predicted, Tensor<T> target)
     {
         target = EnsureTargetMatchesPredicted(predicted, target);
+        target = SmoothTarget(target);
         // Categorical CE per sample = -Σ_class target * log(predicted + eps),
         // summed over the class (last) axis, then averaged over any remaining
         // batch / sequence axes. This matches PyTorch's
@@ -175,5 +196,40 @@ public class CategoricalCrossEntropyLoss<T> : LossFunctionBase<T>
         var batchAxes = Enumerable.Range(0, perSample.Shape.Length).ToArray();
         var mean = Engine.ReduceMean(perSample, batchAxes, keepDims: false);
         return Engine.TensorNegate(mean);
+    }
+
+    /// <summary>
+    /// Applies label smoothing to a one-hot target VECTOR: <c>(1 - ε)·y + ε/K</c> where K is the
+    /// class count. Returns the input unchanged when smoothing is disabled (ε = 0).
+    /// </summary>
+    private Vector<T> SmoothActual(Vector<T> actual)
+    {
+        if (_labelSmoothing <= 0.0) return actual;
+        int k = actual.Length;
+        if (k == 0) return actual;
+        T keep = NumOps.FromDouble(1.0 - _labelSmoothing);
+        T add = NumOps.FromDouble(_labelSmoothing / k);
+        var smoothed = new Vector<T>(k);
+        for (int i = 0; i < k; i++)
+            smoothed[i] = NumOps.Add(NumOps.Multiply(actual[i], keep), add);
+        return smoothed;
+    }
+
+    /// <summary>
+    /// Applies label smoothing to a one-hot target TENSOR along its last (class) axis:
+    /// <c>(1 - ε)·y + ε/K</c>. Returns the input unchanged when smoothing is disabled (ε = 0).
+    /// The target is a constant (not a tape variable), so these element-wise ops do not affect the
+    /// back-propagated gradient path — they only reshape the loss's target distribution.
+    /// </summary>
+    private Tensor<T> SmoothTarget(Tensor<T> target)
+    {
+        if (_labelSmoothing <= 0.0) return target;
+        int rank = target.Shape.Length;
+        if (rank == 0) return target;
+        int k = target.Shape[rank - 1];
+        if (k == 0) return target;
+        return Engine.TensorAddScalar(
+            Engine.TensorMultiplyScalar(target, NumOps.FromDouble(1.0 - _labelSmoothing)),
+            NumOps.FromDouble(_labelSmoothing / k));
     }
 }

--- a/src/NeuralNetworks/Transformer.cs
+++ b/src/NeuralNetworks/Transformer.cs
@@ -220,6 +220,24 @@ public class Transformer<T> : NeuralNetworkBase<T>, IAuxiliaryLossLayer<T>
     }
 
     /// <summary>
+    /// Resolves the default loss for a Transformer when the caller passes none. Starts from the task's
+    /// generic default (<see cref="NeuralNetworkHelper{T}.GetDefaultLossFunction"/>) and, when that is
+    /// categorical cross-entropy, upgrades it to the label-smoothed variant (ε = 0.1). "Attention Is All
+    /// You Need" (Vaswani et al. 2017) trains with label smoothing 0.1, and it is the default in
+    /// transformer recipes (fairseq label_smoothed_cross_entropy, the annotated transformer); it was
+    /// missing here, which let batched (averaged-gradient) training overshoot the Noam warmup into a
+    /// saturated, frozen softmax and stall short of convergence (ooples/AiDotNet#1559). Non-classification
+    /// defaults (regression MSE, etc.) are returned unchanged; an explicitly-supplied loss always wins.
+    /// </summary>
+    private static ILossFunction<T> ResolveDefaultLoss(TransformerArchitecture<T> architecture)
+    {
+        var defaultLoss = NeuralNetworkHelper<T>.GetDefaultLossFunction(architecture.TaskType);
+        return defaultLoss is CategoricalCrossEntropyLoss<T>
+            ? new CategoricalCrossEntropyLoss<T>(labelSmoothing: 0.1)
+            : defaultLoss;
+    }
+
+    /// <summary>
     /// Creates a new Transformer neural network with the specified architecture.
     /// </summary>
     /// <param name="architecture">
@@ -244,7 +262,7 @@ public class Transformer<T> : NeuralNetworkBase<T>, IAuxiliaryLossLayer<T>
     /// </remarks>
     public Transformer(TransformerArchitecture<T> architecture, ILossFunction<T>? lossFunction = null,
         IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>>? optimizer = null, TransformerOptions? options = null) :
-        base(architecture, lossFunction ?? NeuralNetworkHelper<T>.GetDefaultLossFunction(architecture.TaskType))
+        base(architecture, lossFunction ?? ResolveDefaultLoss(architecture))
     {
         _options = options ?? new TransformerOptions();
         Options = _options;

--- a/tests/AiDotNet.Tests/IntegrationTests/ConfigureMethodCoverage/Issue1559BatchedLabelSmoothingTests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/ConfigureMethodCoverage/Issue1559BatchedLabelSmoothingTests.cs
@@ -1,0 +1,75 @@
+using AiDotNet.LossFunctions;
+using AiDotNet.NeuralNetworks;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace AiDotNet.Tests.IntegrationTests.ConfigureMethodCoverage;
+
+/// <summary>
+/// #1559 guard: batched (averaged-gradient) transformer training on the tiny memorization canary
+/// used to overshoot the Noam warmup LR into hard softmax saturation — reaching 100% around step 6
+/// then REGRESSING and FREEZING at ~75% (the softmax pins to one-hot, so its gradient vanishes and
+/// the two wrong examples can never be corrected). Label smoothing (Vaswani et al. 2017, ε = 0.1 —
+/// previously missing from <see cref="CategoricalCrossEntropyLoss{T}"/>) keeps the optimal softmax
+/// off the hard 0/1 rail, so the gradient stays alive and batched keeps learning instead of freezing.
+/// </summary>
+public sealed class Issue1559BatchedLabelSmoothingTests : ConfigureMethodTestBase
+{
+    private readonly ITestOutputHelper _o;
+    public Issue1559BatchedLabelSmoothingTests(ITestOutputHelper o) { _o = o; }
+
+    [Fact]
+    public void BatchedTraining_LabelSmoothing_UnfreezesAndBeatsUnsmoothedBaseline()
+    {
+        var (features, labels) = MakeMemorizationSet();
+        int batch = features.Shape[0], ctx = features.Shape[1], vocab = labels.Shape[1];
+
+        // Per-example one-hot pairs that TrainBatched stacks into a [B, ctx] / [B, vocab] batch.
+        var inputs = new Tensor<float>[batch];
+        var targets = new Tensor<float>[batch];
+        for (int b = 0; b < batch; b++)
+        {
+            inputs[b] = new Tensor<float>([1, ctx]);
+            for (int s = 0; s < ctx; s++) inputs[b][0, s] = features[b, s];
+            targets[b] = new Tensor<float>([1, vocab]);
+            for (int v = 0; v < vocab; v++) targets[b][0, v] = labels[b, v];
+        }
+
+        const int steps = 300;
+
+        // Baseline: plain one-hot CE → overshoots into saturation and FREEZES at ~75%.
+        var baseline = new Transformer<float>(MakeCanaryArch(42), new CategoricalCrossEntropyLoss<float>());
+        baseline.SetTrainingMode(true);
+        for (int s = 0; s < steps; s++) baseline.TrainBatched(inputs, targets);
+        double baseTop = MeasureTrainingTopOne(baseline, features, labels);
+        double baseSpread = MeasurePredictionSpread(baseline, features);
+
+        // Fix: label smoothing ε = 0.1 → the softmax never hard-saturates, so the gradient stays alive.
+        var smoothed = new Transformer<float>(
+            MakeCanaryArch(42), new CategoricalCrossEntropyLoss<float>(labelSmoothing: 0.1));
+        smoothed.SetTrainingMode(true);
+        for (int s = 0; s < steps; s++) smoothed.TrainBatched(inputs, targets);
+        double smoothTop = MeasureTrainingTopOne(smoothed, features, labels);
+        double smoothSpread = MeasurePredictionSpread(smoothed, features);
+
+        _o.WriteLine($"baseline (no LS):  top1={baseTop:P1} spread={baseSpread:F4}");
+        _o.WriteLine($"smoothed (LS 0.1): top1={smoothTop:P1} spread={smoothSpread:F4}");
+
+        // 1) Label smoothing strictly improves batched convergence over the un-smoothed frozen path.
+        Assert.True(smoothTop > baseTop,
+            $"Label smoothing should lift batched convergence above the un-smoothed baseline; "
+            + $"got smoothed={smoothTop:P1} vs baseline={baseTop:P1}.");
+
+        // 2) ...and reaches a healthy top-1 on the memorization set (the frozen baseline sits at ~75%).
+        Assert.True(smoothTop >= 0.80,
+            $"Batched training with label smoothing should reach >=80% top-1 on the {batch}-example "
+            + $"memorization set; got {smoothTop:P1}.");
+
+        // 3) ...and leaves the softmax OFF the hard 0/1 rail — a spread pinned at ~1.0 is exactly the
+        //    saturated, dead-gradient state that froze the un-smoothed run (#1559).
+        Assert.True(smoothSpread < 0.99,
+            $"With label smoothing the softmax must stay off the hard 0/1 rail (spread < 0.99); "
+            + $"got {smoothSpread:F4}.");
+    }
+}


### PR DESCRIPTION
Closes #1559.

## Root cause
Batched (averaged-gradient) transformer training overshoots the Noam **warmup** LR into **hard softmax saturation**: on the V=8 canary it reaches 100% top-1 around step 6, then regresses and **freezes at 75%** (prediction spread pinned at `1.0` → the softmax gradient vanishes and the wrong examples can't be corrected). Per-example (SGD) avoids it — faster Noam-step advance + gradient noise. The existing global-norm gradient clip doesn't help because Adam normalizes the gradient (`step ≈ LR·m/√v`) — the overshoot is LR-driven, not magnitude-driven.

## Fix (paper-accurate)
"Attention Is All You Need" (Vaswani et al. 2017) specifies **label smoothing ε=0.1**, which the library was missing. `CategoricalCrossEntropyLoss` now takes a `labelSmoothing` parameter (default `0.0` = unchanged) applying `(1-ε)·y + ε/K` across the tape / vector / GPU paths. Soft targets keep the softmax off the 0/1 rail, so the gradient stays alive.

**V=8 canary (batched):** frozen 75% → stable **87.5%**, softmax no longer saturated (spread `1.0 → ~0.88`). Realistic scale (V=256) already converged and is unaffected; the residual vs per-example 100% is inherent batch-GD-vs-SGD dynamics on the tiny model.

## Validation
- New guard `Issue1559BatchedLabelSmoothingTests`: trains batched canary with/without smoothing, asserts smoothing beats the frozen baseline, reaches ≥80%, keeps the softmax off the hard rail.
- 54/54 loss + guard tests green; default 0.0 is a verified no-op for existing `CategoricalCrossEntropy` tests. net10.0 + net471 build clean.

## Follow-up (in progress on this branch)
Making label smoothing the Transformer's **default** classification loss (ε=0.1 per the paper) so `AiModelBuilder`-trained models get it automatically — updating the affected loss-value tests to the paper-accurate values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)