### PR TITLE
fix(optimizer): bound eval cache + O(tokens) mini-batch-loss fitness mode

### DIFF
--- a/src/Caching/DefaultModelCache.cs
+++ b/src/Caching/DefaultModelCache.cs
@@ -36,6 +36,47 @@ public class DefaultModelCache<T, TInput, TOutput> : IModelCache<T, TInput, TOut
     private readonly ConcurrentDictionary<string, OptimizationStepData<T, TInput, TOutput>> _cache = new();
 
     /// <summary>
+    /// Default maximum number of distinct step-data entries retained before the oldest are evicted.
+    /// </summary>
+    public const int DefaultCapacity = 8;
+
+    /// <summary>
+    /// Maximum number of distinct keys retained. Once exceeded, the oldest-inserted entries are evicted.
+    /// </summary>
+    private readonly int _capacity;
+
+    /// <summary>
+    /// Insertion-order record of cache keys, used to evict the oldest entry when the cache is full.
+    /// </summary>
+    private readonly ConcurrentQueue<string> _insertionOrder = new();
+
+    /// <summary>
+    /// Initializes a new cache with the <see cref="DefaultCapacity"/> bound.
+    /// </summary>
+    public DefaultModelCache() : this(DefaultCapacity)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new cache that retains at most <paramref name="capacity"/> distinct entries.
+    /// </summary>
+    /// <param name="capacity">
+    /// Maximum number of step-data entries to keep. Once exceeded, the oldest-inserted entry is
+    /// evicted (FIFO). This bounds memory: an optimizer's per-epoch evaluation writes a fresh
+    /// entry every epoch (the parameter-content key changes as the model trains), so without a
+    /// bound the cache — which retains a deep-copied model and O(N) predictions per entry — would
+    /// grow without limit across a long training run, driving per-epoch memory and wall-clock up.
+    /// A gradient optimizer never re-queries a prior epoch's key (parameters keep changing), and
+    /// population optimizers only hit on exact-duplicate parameter vectors (rare in continuous
+    /// search), so a small bound preserves the cache's real value while eliminating the leak.
+    /// Values &lt;= 0 fall back to <see cref="DefaultCapacity"/>.
+    /// </param>
+    public DefaultModelCache(int capacity)
+    {
+        _capacity = capacity > 0 ? capacity : DefaultCapacity;
+    }
+
+    /// <summary>
     /// Removes all cached optimization step data from the cache.
     /// </summary>
     /// <remarks>
@@ -47,6 +88,7 @@ public class DefaultModelCache<T, TInput, TOutput> : IModelCache<T, TInput, TOut
     public void ClearCache()
     {
         _cache.Clear();
+        while (_insertionOrder.TryDequeue(out _)) { }
     }
 
     /// <summary>
@@ -95,7 +137,24 @@ public class DefaultModelCache<T, TInput, TOutput> : IModelCache<T, TInput, TOut
         if (key == null) throw new ArgumentNullException(nameof(key), "Cache key cannot be null.");
         if (stepData == null) throw new ArgumentNullException(nameof(stepData), "Step data cannot be null.");
 
+        bool isNewKey = !_cache.ContainsKey(key);
         _cache[key] = stepData;
+
+        // Bound the cache (FIFO eviction). Only track insertion order for genuinely new keys so
+        // re-writing an existing key (an in-place update of the same entry) doesn't inflate the
+        // count. Overshoot by one transiently under concurrency is harmless — the loop trims back
+        // to capacity. A dequeued key that was already removed (or re-added) simply no-ops.
+        if (isNewKey)
+        {
+            _insertionOrder.Enqueue(key);
+            while (_cache.Count > _capacity && _insertionOrder.TryDequeue(out var oldestKey))
+            {
+                if (!string.Equals(oldestKey, key, StringComparison.Ordinal))
+                {
+                    _cache.TryRemove(oldestKey, out _);
+                }
+            }
+        }
     }
 
     /// <summary>

--- a/src/Models/Options/GradientBasedOptimizerOptions.cs
+++ b/src/Models/Options/GradientBasedOptimizerOptions.cs
@@ -282,6 +282,39 @@ public class GradientBasedOptimizerOptions<T, TInput, TOutput> : OptimizationAlg
     /// </para>
     /// </remarks>
     public SchedulerStepMode SchedulerStepMode { get; set; } = SchedulerStepMode.StepPerEpoch;
+
+    /// <summary>
+    /// Gets or sets whether the optimizer uses the running mean of the per-mini-batch
+    /// training loss as each epoch's fitness, instead of running a separate full-dataset
+    /// forward pass every epoch.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// By default (false) a gradient-based optimizer evaluates the WHOLE dataset once per
+    /// epoch to compute the fitness score used for progress reporting, best-solution
+    /// tracking and early stopping. For a mini-batch trainer this doubles the forward cost
+    /// (every sample is run through the model an extra time) AND — because the evaluation
+    /// step deep-copies the model and retains O(N) predictions in the model cache — it
+    /// grows per-epoch memory and wall-clock on large datasets.
+    /// </para>
+    /// <para>
+    /// When this is true the optimizer instead accumulates the loss the model already
+    /// computes during each mini-batch's forward/backward pass (via
+    /// <c>GetLastLoss</c>) and averages it over the epoch. No extra full-dataset forward
+    /// pass is run, no per-epoch model deep-copy or prediction cache entry is created, and
+    /// the returned model is the in-place-trained working model. Per-epoch cost is therefore
+    /// O(tokens trained), and epoch wall-clock stays flat across a long run.
+    /// </para>
+    /// <para><b>For Beginners:</b> Turn this on when you are training a large model on a lot
+    /// of data with mini-batches (e.g. a language model). It skips a redundant "grade the
+    /// whole dataset again" step each epoch, using the loss the model already measured while
+    /// learning. Pair it with an error-style fitness calculator (lower = better, e.g.
+    /// mean-squared-error) so the reported best fitness is meaningful. Leave it off for
+    /// closed-form / small-data models where a full-dataset validation score each epoch is
+    /// cheap and desirable.
+    /// </para>
+    /// </remarks>
+    public bool UseTrainingLossAsFitness { get; set; } = false;
 }
 
 /// <summary>

--- a/src/NeuralNetworks/NeuralNetworkBase.cs
+++ b/src/NeuralNetworks/NeuralNetworkBase.cs
@@ -11202,6 +11202,13 @@ public abstract class NeuralNetworkBase<T> : INeuralNetworkModel<T>, IInterpreta
         if (resolved is LossFunctions.LossFunctionBase<T> tapeLoss)
         {
             lossTensor = tapeLoss.ComputeTapeLoss(prediction, target);
+            // Record the scalar loss so GetLastLoss() reflects this gradient step. The
+            // IGradientComputable fast-path (used by every gradient-based optimizer's
+            // CalculateGradient) previously left LastLoss stale/zero, so callers reading the
+            // per-batch training loss — e.g. AdamOptimizer's UseTrainingLossAsFitness mode —
+            // saw 0 even though the true batch loss was computed right here. The other training
+            // paths (TrainWithTape / fused step) already set LastLoss the same way.
+            LastLoss = lossTensor.Length > 0 ? lossTensor[0] : NumOps.Zero;
         }
         else
         {

--- a/src/Optimizers/AdamOptimizer.cs
+++ b/src/Optimizers/AdamOptimizer.cs
@@ -220,9 +220,29 @@ public class AdamOptimizer<T, TInput, TOutput> : GradientBasedOptimizerBase<T, T
         // instance in the finally block. (PR #1364 review.)
         (currentSolution as AiDotNet.Interfaces.INeuralNetwork<T>)?.SetTrainingMode(true);
 
+        // MINI-BATCH-LM FITNESS MODE (Options.UseTrainingLossAsFitness): skip the redundant
+        // full-dataset forward pass that EvaluateSolution runs every epoch. Instead accumulate
+        // the loss the model already computes during each batch's forward/backward (GetLastLoss)
+        // and use its epoch mean as the fitness. This eliminates (a) the O(N) extra forward,
+        // (b) the per-epoch model DeepCopy, and (c) the O(N) prediction cache entry — the three
+        // costs that made per-epoch wall-clock grow on large datasets. The returned model is the
+        // in-place-trained working solution (Adam's single-trajectory contract), so no best-
+        // solution deep copy is needed. See GradientBasedOptimizerOptions.UseTrainingLossAsFitness.
+        bool useTrainingLoss = _options.UseTrainingLossAsFitness;
+
         try
         {
-            var previousStepData = PrepareAndEvaluateSolution(currentSolution, inputData);
+            // Baseline eval: the full-dataset PrepareAndEvaluateSolution also runs an initial
+            // full Train pass and a full forward; skip it entirely in mini-batch-loss mode.
+            var previousStepData = useTrainingLoss
+                ? BuildTrainingLossStepData(currentSolution, NumOps.FromDouble(double.MaxValue))
+                : PrepareAndEvaluateSolution(currentSolution, inputData);
+            if (useTrainingLoss)
+            {
+                // Gradient-based optimizers skip Train() inside evaluation; mark the flag so any
+                // shared code that consults it behaves as it would after the first real eval.
+                OnInitialTrainingCompleted();
+            }
 
             for (int epoch = 0; epoch < _options.MaxIterations; epoch++)
             {
@@ -232,11 +252,27 @@ public class AdamOptimizer<T, TInput, TOutput> : GradientBasedOptimizerBase<T, T
                 // Create batcher for the current epoch using DataLoader infrastructure
                 var batcher = CreateBatcher(inputData, _options.BatchSize);
 
+                double epochLossSum = 0.0;
+                int epochBatchCount = 0;
+
                 foreach (var (xBatch, yBatch, batchIndices) in batcher.GetBatches())
                 {
                     _t++;
                     // Calculate gradient on the batch
                     var gradient = CalculateGradient(currentSolution, xBatch, yBatch);
+
+                    // Mini-batch-loss mode: read the loss the model just computed on this batch
+                    // (ComputeGradients/tape step sets LastLoss) BEFORE UpdateSolution swaps the
+                    // live instance. Skipped and zero-cost when the mode is off.
+                    if (useTrainingLoss && currentSolution is AiDotNet.NeuralNetworks.NeuralNetworkBase<T> nnLoss)
+                    {
+                        double batchLoss = NumOps.ToDouble(nnLoss.GetLastLoss());
+                        if (!double.IsNaN(batchLoss) && !double.IsInfinity(batchLoss))
+                        {
+                            epochLossSum += batchLoss;
+                            epochBatchCount++;
+                        }
+                    }
 
                     // Update solution using Adam algorithm
                     var newSolution = UpdateSolution(currentSolution, gradient);
@@ -257,9 +293,34 @@ public class AdamOptimizer<T, TInput, TOutput> : GradientBasedOptimizerBase<T, T
                     OnBatchEnd();
                 }
 
-                // Evaluate after processing all batches in the epoch
-                var currentStepData = EvaluateSolution(currentSolution, inputData);
+                // Evaluate after processing all batches in the epoch. Mini-batch-loss mode uses
+                // the accumulated per-batch training loss (no extra forward / no deep copy / no
+                // cache entry); the default path runs the full-dataset fitness forward.
+                OptimizationStepData<T, TInput, TOutput> currentStepData;
+                if (useTrainingLoss)
+                {
+                    T epochLoss = epochBatchCount > 0
+                        ? NumOps.FromDouble(epochLossSum / epochBatchCount)
+                        : NumOps.FromDouble(double.MaxValue);
+                    FitnessList.Add(epochLoss);
+                    currentStepData = BuildTrainingLossStepData(currentSolution, epochLoss);
+                }
+                else
+                {
+                    currentStepData = EvaluateSolution(currentSolution, inputData);
+                }
                 UpdateBestSolution(currentStepData, ref bestStepData);
+                // Mini-batch-loss mode does not deep-copy the model per epoch, and each Adam
+                // step returns a fresh WithParameters(...) instance, so the reference captured
+                // by UpdateBestSolution on an earlier epoch would go stale. Point the best
+                // solution at the current live (in-place-trained) instance every epoch — this
+                // matches Adam's single-trajectory contract of returning the final trained
+                // model. (Best-epoch weight restoration would require per-epoch deep copies,
+                // which this mode deliberately avoids.)
+                if (useTrainingLoss)
+                {
+                    bestStepData.Solution = currentSolution;
+                }
                 UpdateAdaptiveParameters(currentStepData, previousStepData);
 
                 // Check early stopping criteria
@@ -314,6 +375,25 @@ public class AdamOptimizer<T, TInput, TOutput> : GradientBasedOptimizerBase<T, T
             // accidentally engage dropout / batchnorm-train-stats.
             (currentSolution as AiDotNet.Interfaces.INeuralNetwork<T>)?.SetTrainingMode(false);
         }
+    }
+
+    /// <summary>
+    /// Builds a lightweight step-data record for the mini-batch-loss fitness mode
+    /// (<see cref="AdamOptimizerOptions{T, TInput, TOutput}.UseTrainingLossAsFitness"/>).
+    /// It carries the live trained solution and the epoch's mean per-batch training loss as
+    /// the fitness score, with no full-dataset <c>EvaluationData</c> and no model deep copy —
+    /// the whole point of the mode is to avoid the per-epoch full-dataset forward pass and the
+    /// unbounded prediction/model retention it drives.
+    /// </summary>
+    private OptimizationStepData<T, TInput, TOutput> BuildTrainingLossStepData(
+        IFullModel<T, TInput, TOutput> solution, T loss)
+    {
+        return new OptimizationStepData<T, TInput, TOutput>
+        {
+            Solution = solution,
+            FitnessScore = loss,
+            IsUninitializedPlaceholder = false
+        };
     }
 
     /// <summary>

--- a/tests/AiDotNet.Tests/IntegrationTests/Caching/DefaultModelCacheIntegrationTests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/Caching/DefaultModelCacheIntegrationTests.cs
@@ -18,6 +18,60 @@ public class DefaultModelCacheIntegrationTests
         return new OptimizationStepData<double, Matrix<double>, Vector<double>>();
     }
 
+    #region Capacity Bound (leak regression)
+
+    [Fact(Timeout = 120000)]
+    public async Task CacheStepData_BeyondCapacity_EvictsOldestAndBoundsCount()
+    {
+        // Regression for the optimizer per-epoch memory leak: the parameter-content cache key
+        // changes every epoch as the model trains, so an unbounded cache would retain one
+        // deep-copied model + O(N) predictions per epoch forever. The cache must bound itself.
+        int cap = DefaultModelCache<double, Matrix<double>, Vector<double>>.DefaultCapacity;
+        var cache = new DefaultModelCache<double, Matrix<double>, Vector<double>>(cap);
+
+        // Insert 5x the capacity of distinct keys (simulating 5*cap training epochs).
+        int inserted = cap * 5;
+        for (int i = 0; i < inserted; i++)
+        {
+            cache.CacheStepData($"epoch_{i}", CreateStepData());
+        }
+
+        // The most-recently inserted `cap` keys must still be present...
+        for (int i = inserted - cap; i < inserted; i++)
+        {
+            Assert.NotNull(cache.GetCachedStepData($"epoch_{i}"));
+        }
+
+        // ...and the earliest keys must have been evicted (memory does not grow without bound).
+        Assert.Null(cache.GetCachedStepData("epoch_0"));
+        Assert.Null(cache.GetCachedStepData($"epoch_{inserted - cap - 1}"));
+    }
+
+    [Fact(Timeout = 120000)]
+    public async Task CacheStepData_RepeatedSameKey_DoesNotEvictOthers()
+    {
+        // Overwriting an existing key must not count as a new insertion (which would spuriously
+        // evict live entries). Fill to capacity, then hammer one key; the rest must survive.
+        int cap = DefaultModelCache<double, Matrix<double>, Vector<double>>.DefaultCapacity;
+        var cache = new DefaultModelCache<double, Matrix<double>, Vector<double>>(cap);
+
+        for (int i = 0; i < cap; i++)
+        {
+            cache.CacheStepData($"k{i}", CreateStepData());
+        }
+        for (int r = 0; r < cap * 10; r++)
+        {
+            cache.CacheStepData("k0", CreateStepData());
+        }
+
+        for (int i = 0; i < cap; i++)
+        {
+            Assert.NotNull(cache.GetCachedStepData($"k{i}"));
+        }
+    }
+
+    #endregion
+
     #region Basic CRUD Operations
 
     [Fact(Timeout = 120000)]
@@ -133,7 +187,10 @@ public class DefaultModelCacheIntegrationTests
     public async Task Cache_MultipleKeys_EachRetrievableIndependently()
     {
         // Arrange
-        var cache = new DefaultModelCache<double, Matrix<double>, Vector<double>>();
+        // The cache is now bounded (FIFO eviction) to stop the optimizer per-epoch leak; size it
+        // large enough to hold every key so this test still verifies independent retrieval of many
+        // distinct entries rather than the (removed) unbounded-retention behavior.
+        var cache = new DefaultModelCache<double, Matrix<double>, Vector<double>>(capacity: 128);
         var stepDataDict = new Dictionary<string, OptimizationStepData<double, Matrix<double>, Vector<double>>>();
 
         for (int i = 0; i < 100; i++)


### PR DESCRIPTION
## Problem

Gradient-based training through `AiModelBuilder.BuildAsync` grows per-epoch **wall-clock and memory** across a long run on large datasets instead of staying flat, capping trainable data size. Measured on a small Transformer LM: per-epoch time climbed 24→30→42→55→69→94→115→124s over 8 epochs.

### Root cause (the leak)

`OptimizerBase.EvaluateSolution` runs a **full-dataset fitness forward every epoch** and stores the result — including `solution.DeepCopy()` and O(N) `EvaluationData` predictions — into `DefaultModelCache`. The cache key is a **content hash of the parameters**, which changes every epoch as the model trains, so a fresh (never-re-queried) entry is added each epoch and the `ConcurrentDictionary` **grows without bound**. Accumulating deep-copied models + O(N) prediction arrays drive GC/allocator pressure → rising per-epoch time.

## Fixes

1. **`DefaultModelCache` is now bounded** (FIFO eviction, `DefaultCapacity=8`, ctor-configurable). A gradient optimizer never re-queries a prior epoch's key, and population optimizers only hit on exact-duplicate parameter vectors, so a small bound removes the leak with negligible impact on real hits. Correctness unaffected — a miss just recomputes.

2. **New `GradientBasedOptimizerOptions.UseTrainingLossAsFitness`** (default `false`). When enabled, `AdamOptimizer.Optimize` **skips the per-epoch full-dataset forward** and uses the running mean of the per-mini-batch training loss as the epoch fitness. Removes the O(N) extra forward, the per-epoch `DeepCopy`, and the cache write — per-epoch cost becomes **O(tokens trained)** and epoch wall-clock stays **flat**. Returned model is the in-place-trained working solution.

3. **`NeuralNetworkBase.ComputeGradients`** (the `IGradientComputable` fast-path used by every gradient optimizer's `CalculateGradient`) now records `LastLoss` from the scalar loss it already computes; previously `GetLastLoss()` was stale/zero after this path.

## Verification

WikiText-103 next-token, top-K vocab (V=4001), via `BuildAsync` with `UseTrainingLossAsFitness=true`:
- **Epoch time flat** across 10 epochs (~45–64 s/epoch, no upward trend) — leak fixed.
- **Training loss 6.02 → 4.19** monotonically (CPU) — the model learns.

## Tests
- `DefaultModelCache` capacity-bound + FIFO eviction; repeated-same-key non-eviction; existing multi-key test sized to the bound. All 21 pass on net10.0 + net471.

🤖 Generated with [Claude Code](https://claude.com/claude-code)