### PR TITLE
ci: grant issues write to release-please for autorelease labels

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -21,6 +21,7 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  issues: write # release-please creates/applies the `autorelease:` labels via the Issues API
 
 # Serialize (never cancel): a release cut / PR update must finish. Runs are cheap when they only
 # update the Release PR, and must be atomic when they actually publish.

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -21,7 +21,6 @@ on:
 permissions:
   contents: write
   pull-requests: write
-  issues: write # release-please creates/applies the `autorelease:` labels via the Issues API
 
 # Serialize (never cancel): a release cut / PR update must finish. Runs are cheap when they only
 # update the Release PR, and must be atomic when they actually publish.
@@ -33,6 +32,13 @@ jobs:
   release-please:
     name: Maintain Release PR / cut release
     runs-on: ubuntu-latest
+    # Scope issues:write (label mutations) to this job only, following least-privilege —
+    # a job-level permissions block OVERRIDES the workflow default, so contents/pull-requests
+    # are re-declared here; the publish job keeps the workflow-level contents:write it needs.
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write # release-please creates/applies the `autorelease:` labels via the Issues API
     outputs:
       release_created: ${{ steps.rp.outputs.release_created }}
       tag_name: ${{ steps.rp.outputs.tag_name }}


### PR DESCRIPTION
## Problem

The **Release Please** workflow has been failing on every push to `master` with:

```
release-please failed: Resource not accessible by personal access token
```

release-please gets all the way through creating the tree/commit, updating the branch ref, and creating the Release PR (#1814) — then 403s on the **labeling** step. It applies `autorelease: pending` / `autorelease: tagged` to the Release PR via GitHub's **Issues API**, which needs `issues: write`. The workflow only granted `contents: write` + `pull-requests: write`.

## Fix

Add `issues: write` to the `permissions:` block so the label management works (and the `GITHUB_TOKEN` fallback path is fully functional).

## Note

The workflow authenticates with `AUTOFIX_PAT`, and a token's permissions aren't governed by the workflow `permissions:` block — so the **`AUTOFIX_PAT` fine-grained token also needs `Issues: Read and write`** added for the primary (PAT) path. That's a settings change on the token itself; this PR covers the workflow side. The two `autorelease:` labels have also been pre-created in the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release automation permissions so it can manage release labels and complete automated publishing more reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->