### PR TITLE
fix(training): Transformer.Train() silent no-op — fused compiled step didn't persist to live params (#1822)

### DIFF
--- a/src/NeuralNetworks/NeuralNetworkBase.cs
+++ b/src/NeuralNetworks/NeuralNetworkBase.cs
@@ -8268,7 +8268,12 @@ public abstract class NeuralNetworkBase<T> : INeuralNetworkModel<T>, IInterpreta
             {
                 double fusedParamChecksumAfter = FusedTrainableParamChecksum(trainableLayers);
                 bool persisted = fusedParamChecksumAfter != fusedParamChecksumBefore;
-                if (!persisted && fusedParamChecksumBefore != 0.0 && !NumOps.IsNaN(lossValue))
+                // Do NOT gate on fusedParamChecksumBefore != 0.0: the checksum is a sum of
+                // squares, so 0.0 means every trainable parameter starts exactly at zero. A
+                // non-persisting fused step then leaves it at 0.0 too (persisted == false),
+                // which is exactly the silent no-op we must catch — skipping it for all-zero
+                // init would commit the decoupled path unverified (ooples/AiDotNet#1822 review).
+                if (!persisted && !NumOps.IsNaN(lossValue))
                 {
                     _fusedTrainingDisabled = true;
                     _pendingFusedMissReason =

--- a/src/NeuralNetworks/NeuralNetworkBase.cs
+++ b/src/NeuralNetworks/NeuralNetworkBase.cs
@@ -2041,6 +2041,7 @@ public abstract class NeuralNetworkBase<T> : INeuralNetworkModel<T>, IInterpreta
         Training.CompiledTapeTrainingStep<T>.Invalidate();
         _fusedTrainingDisabled = false;
         _fusedTrainingCommitted = false;
+        _fusedPersistenceVerified = false;
     }
 
     /// <summary>
@@ -7925,6 +7926,26 @@ public abstract class NeuralNetworkBase<T> : INeuralNetworkModel<T>, IInterpreta
     private bool _fusedTrainingCommitted;
 
     /// <summary>
+    /// #1822 silent-no-op guard. The fused compiled-training fast path is
+    /// contracted to mutate the LIVE parameter tensors in place (exactly like
+    /// the eager <c>opt.Step</c>). For some model graphs — notably
+    /// token/embedding <see cref="Transformer{T}"/>s whose specialized
+    /// compiled forward captures parameter DATA by copy rather than aliasing
+    /// the live backing array — <c>plan.Step()</c> trains an internal buffer
+    /// and reports a decreasing loss, yet NEVER writes the update back to the
+    /// network's parameters. That is a SILENT no-op: <see cref="GetParameters"/>,
+    /// serialization, and the eager Predict path all see an untrained model
+    /// even though <c>Train()</c> "ran". No kernel throws, so the
+    /// exception-based fallbacks never fire. We therefore verify persistence
+    /// directly on the FIRST fused step (snapshot a parameter checksum before
+    /// and after); once a model is proven to persist, this latch is set and the
+    /// O(params) check is never repeated. See <see cref="TryTrainWithFusedOptimizer"/>.
+    /// Reset alongside <see cref="_fusedTrainingCommitted"/> at every explicit
+    /// training-state reset point.
+    /// </summary>
+    private bool _fusedPersistenceVerified;
+
+    /// <summary>
     /// Reason string set by <see cref="EmitFusedMissAndFallback"/> when
     /// <see cref="TryTrainWithFusedOptimizer"/> bails out early, consumed
     /// (and cleared) by the post-success diagnostic block in
@@ -8071,6 +8092,34 @@ public abstract class NeuralNetworkBase<T> : INeuralNetworkModel<T>, IInterpreta
         return false;
     }
 
+    /// <summary>
+    /// #1822: sum-of-squares checksum over the LIVE trainable parameter tensors
+    /// (the exact set the fused kernel and the eager <c>opt.Step</c> both mutate).
+    /// Used once per model, on the first fused step, to detect a fused compiled
+    /// step that reported a loss but did not actually write its update back to the
+    /// parameters — a silent no-op. Any real parameter change (even a tiny
+    /// warmup-LR one) shifts the sum, so an unchanged checksum is a reliable
+    /// "nothing was persisted" signal.
+    /// </summary>
+    private double FusedTrainableParamChecksum(IReadOnlyList<ITrainableLayer<T>> layers)
+    {
+        double acc = 0.0;
+        for (int li = 0; li < layers.Count; li++)
+        {
+            foreach (var p in layers[li].GetTrainableParameters())
+            {
+                if (p is null) continue;
+                var span = p.AsSpan();
+                for (int i = 0; i < span.Length; i++)
+                {
+                    double v = NumOps.ToDouble(span[i]);
+                    acc += v * v;
+                }
+            }
+        }
+        return acc;
+    }
+
     private bool TryTrainWithFusedOptimizer(
         Tensor<T> input,
         Tensor<T> expected,
@@ -8153,6 +8202,14 @@ public abstract class NeuralNetworkBase<T> : INeuralNetworkModel<T>, IInterpreta
         // transient ring alive across the switch would waste memory under pressure and
         // nest the streaming path inside a transient scope. try/finally also releases the
         // arena if the fused call throws.
+        // #1822: on the first fused step for this model, snapshot a checksum of
+        // the live trainable parameters so we can verify AFTER the step that the
+        // fused kernel actually persisted its update (see _fusedPersistenceVerified).
+        bool verifyFusedPersistence = !_fusedPersistenceVerified && !_fusedTrainingCommitted;
+        double fusedParamChecksumBefore = verifyFusedPersistence
+            ? FusedTrainableParamChecksum(trainableLayers)
+            : 0.0;
+
         bool ran;
         T lossValue;
         try
@@ -8199,6 +8256,37 @@ public abstract class NeuralNetworkBase<T> : INeuralNetworkModel<T>, IInterpreta
 
         if (ran)
         {
+            // #1822 silent-no-op guard: confirm the fused step actually moved the
+            // live parameters before we COMMIT to the fused path. If the compiled
+            // plan reported a real (finite) loss but left every trainable parameter
+            // byte-for-byte unchanged, its optimizer step is decoupled from the
+            // network's live tensors — a silent no-op. Sticky-disable fused and let
+            // this step (and all subsequent ones) run on the eager tape, which
+            // mutates the live tensors correctly. Not yet committed here, so this
+            // is a clean fall-through (no plan-embedded moment state to lose).
+            if (verifyFusedPersistence)
+            {
+                double fusedParamChecksumAfter = FusedTrainableParamChecksum(trainableLayers);
+                bool persisted = fusedParamChecksumAfter != fusedParamChecksumBefore;
+                if (!persisted && fusedParamChecksumBefore != 0.0 && !NumOps.IsNaN(lossValue))
+                {
+                    _fusedTrainingDisabled = true;
+                    _pendingFusedMissReason =
+                        "fused compiled step ran (loss " + NumOps.ToDouble(lossValue).ToString("G6") +
+                        ") but did not persist ANY parameter update — the compiled plan is decoupled " +
+                        "from the model's live parameter tensors; routing to the eager tape so Train() " +
+                        "actually learns (ooples/AiDotNet#1822)";
+                    if (string.IsNullOrEmpty(Environment.GetEnvironmentVariable("AIDOTNET_QUIET")))
+                    {
+                        System.Diagnostics.Trace.TraceWarning(
+                            "[AiDotNet] " + _pendingFusedMissReason + " (model: " + GetType().Name + ").");
+                    }
+                    return false; // fall through to the eager tape path in TrainWithTape
+                }
+                // Proven to persist for this model — never re-run the check.
+                _fusedPersistenceVerified = true;
+            }
+
             LastLoss = lossValue;
             // First successful fused step commits this model to the fused
             // path for the rest of the session — Adam m/v are now
@@ -8350,6 +8438,7 @@ public abstract class NeuralNetworkBase<T> : INeuralNetworkModel<T>, IInterpreta
         // the eager/streaming fallback allocates its first backward buffers.
         _fusedTrainingDisabled = stickyDisableFused;
         _fusedTrainingCommitted = false;
+        _fusedPersistenceVerified = false;
         ReclaimGpuTransientsAfterFusedFailure();
     }
 
@@ -9278,6 +9367,7 @@ public abstract class NeuralNetworkBase<T> : INeuralNetworkModel<T>, IInterpreta
         // is no longer needed, and the next run can engage fused fresh.
         _fusedTrainingDisabled = false;
         _fusedTrainingCommitted = false;
+        _fusedPersistenceVerified = false;
     }
 
     /// <summary>

--- a/tests/AiDotNet.Tests/IntegrationTests/NeuralNetworks/TransformerFusedTrainPersistenceIssue1822Tests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/NeuralNetworks/TransformerFusedTrainPersistenceIssue1822Tests.cs
@@ -1,0 +1,171 @@
+using System;
+using AiDotNet.Enums;
+using AiDotNet.LinearAlgebra;
+using AiDotNet.LossFunctions;
+using AiDotNet.Models.Options;
+using AiDotNet.NeuralNetworks;
+using AiDotNet.Optimizers;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace AiDotNetTests.IntegrationTests.NeuralNetworks;
+
+/// <summary>
+/// Regression suite for ooples/AiDotNet#1822 — <c>Transformer&lt;T&gt;.Train(input,
+/// expectedOutput)</c> was a SILENT NO-OP: it reported a decreasing loss yet
+/// applied no weight update, so <see cref="NeuralNetworkBase{T}.GetParameters"/>,
+/// serialization, and the eager Predict path all saw an untrained model.
+///
+/// <para>
+/// <b>Root cause:</b> for a token/embedding Transformer (SequenceClassification,
+/// 2-D integer input), the fused compiled-training fast path's specialized
+/// forward captured parameter DATA by copy rather than aliasing the live
+/// backing arrays. <c>plan.Step()</c> trained an internal buffer (so
+/// <c>GetLastLoss</c> fell), but never wrote the update back to the network's
+/// live parameter tensors — every layer's parameters stayed byte-for-byte at
+/// their initial values. The eager tape path updates the live tensors
+/// correctly; a plain <see cref="FeedForwardNeuralNetwork{T}"/> persists on the
+/// fused path (see FusedOptimizerParityTests), so the defect was specific to the
+/// embedding-graph shape.
+/// </para>
+///
+/// <para>
+/// <b>Fix:</b> <see cref="NeuralNetworkBase{T}"/> now verifies, on the first
+/// fused step for a model, that the step actually moved the live parameters. If
+/// a fused step reports a real loss but persists nothing, the fused path is
+/// sticky-disabled for that run and training falls through to the correct eager
+/// tape — so <c>model.Train(x, y)</c> always learns, whatever path it takes.
+/// </para>
+/// </summary>
+public class TransformerFusedTrainPersistenceIssue1822Tests
+{
+    private readonly ITestOutputHelper _output;
+
+    public TransformerFusedTrainPersistenceIssue1822Tests(ITestOutputHelper output)
+    {
+        _output = output;
+    }
+
+    private const int V = 16;
+    private const int Ctx = 6;
+    private const int N = 64;
+
+    private static TransformerArchitecture<float> MakeArch() => new(
+        inputType: InputType.TwoDimensional,
+        taskType: NeuralNetworkTaskType.SequenceClassification,
+        numEncoderLayers: 1,
+        numDecoderLayers: 0,
+        numHeads: 4,
+        modelDimension: 32,
+        feedForwardDimension: 64,
+        inputSize: Ctx,
+        outputSize: V,
+        maxSequenceLength: Ctx,
+        vocabularySize: V,
+        randomSeed: 123);
+
+    // Deterministic learnable batch: target token = (last context token + 1) mod V.
+    private static (Tensor<float> x, Tensor<float> y) MakeData()
+    {
+        var rng = new Random(7);
+        var x = new Tensor<float>(new[] { N, Ctx });
+        var y = new Tensor<float>(new[] { N, V });
+        for (int i = 0; i < N; i++)
+        {
+            int last = 0;
+            for (int s = 0; s < Ctx; s++) { int t = rng.Next(V); x[i, s] = t; last = t; }
+            y[i, (last + 1) % V] = 1f;
+        }
+        return (x, y);
+    }
+
+    private static double ParamL1(Vector<float> p)
+    {
+        double s = 0;
+        for (int i = 0; i < p.Length; i++) s += Math.Abs((double)p[i]);
+        return s;
+    }
+
+    // Cross-entropy from the model's ACTUAL predictions (the SequenceClassification
+    // head applies softmax, so rows are probabilities) — reflects what the model
+    // has really learned, independent of any fused-plan-internal buffer.
+    private static double PredictNll(Transformer<float> model, Tensor<float> x, Tensor<float> y)
+    {
+        var pred = model.Predict(x);
+        int rows = x.Shape[0];
+        double tot = 0;
+        for (int i = 0; i < rows; i++)
+            for (int v = 0; v < V; v++)
+                if (y[i, v] > 0.5f)
+                    tot += -Math.Log(Math.Max(1e-9, (double)pred[i, v]));
+        return tot / rows;
+    }
+
+    /// <summary>
+    /// The canonical #1822 guard: with the DEFAULT (fused-eligible) training path,
+    /// batched <c>model.Train(x, y)</c> must (a) actually change the model's
+    /// parameters and (b) drive the model's own predictions below the uniform-prior
+    /// loss ln(V). Before the fix both failed — parameters were frozen at init and
+    /// Predict stayed at ln(V).
+    /// </summary>
+    [Fact]
+    public void Transformer_BatchedTrain_PersistsUpdates_AndLearns()
+    {
+        var model = new Transformer<float>(
+            MakeArch(),
+            lossFunction: new CategoricalCrossEntropyLoss<float>(),
+            // Constant-LR Adam so the assertion isolates parameter PERSISTENCE,
+            // not the default Noam-warmup ramp (which is a separate, documented
+            // small-LR concern). The fused fast path still engages for this
+            // plain Adam — this is exactly the path #1822 found broken.
+            optimizer: new AdamOptimizer<float, Tensor<float>, Tensor<float>>(
+                null,
+                new AdamOptimizerOptions<float, Tensor<float>, Tensor<float>>
+                {
+                    InitialLearningRate = 3e-3,
+                    LearningRateScheduler = new AiDotNet.LearningRateSchedulers.ConstantLRScheduler(3e-3),
+                    UseAdaptiveLearningRate = false,
+                }));
+
+        var (x, y) = MakeData();
+
+        // Warm up lazy weight materialisation so the baseline snapshot is the real
+        // initialised weights, not the pre-Forward placeholders.
+        model.SetTrainingMode(false);
+        _ = model.Predict(x);
+        model.SetTrainingMode(true);
+
+        double lnV = Math.Log(V);
+        var pBefore = model.GetParameters();
+        double l1Before = ParamL1(pBefore);
+        double nllBefore = PredictNll(model, x, y);
+
+        for (int step = 0; step < 120; step++)
+            model.Train(x, y);
+
+        model.SetTrainingMode(false);
+        var pAfter = model.GetParameters();
+        double l1After = ParamL1(pAfter);
+        double nllAfter = PredictNll(model, x, y);
+
+        // Per-element parameter movement (not just an aggregate that could coincide).
+        double maxAbsDelta = 0;
+        Assert.Equal(pBefore.Length, pAfter.Length);
+        for (int i = 0; i < pBefore.Length; i++)
+            maxAbsDelta = Math.Max(maxAbsDelta, Math.Abs((double)pAfter[i] - (double)pBefore[i]));
+
+        _output.WriteLine($"paramL1 {l1Before:F4} -> {l1After:F4}  maxAbsDelta={maxAbsDelta:E3}");
+        _output.WriteLine($"PredictNll {nllBefore:F4} -> {nllAfter:F4}  (lnV={lnV:F4})");
+
+        // (a) Train() must persist a weight update to the model's live parameters.
+        Assert.True(maxAbsDelta > 1e-4,
+            $"Train() did not change the model parameters (maxAbsDelta={maxAbsDelta:E3}) — " +
+            "the fused compiled step reported a loss but never wrote back to the live tensors (#1822).");
+
+        // (b) The model's own predictions must actually improve past the uniform prior.
+        Assert.True(nllAfter < lnV - 0.25,
+            $"Predict loss {nllAfter:F4} did not drop meaningfully below ln(V)={lnV:F4} — the model did not learn (#1822).");
+        Assert.True(nllAfter < nllBefore - 0.25,
+            $"Predict loss did not improve over the untrained baseline ({nllBefore:F4} -> {nllAfter:F4}) (#1822).");
+    }
+}


### PR DESCRIPTION
## Summary

`Transformer<T>.Train(input, expectedOutput)` (and the `NeuralNetworkBase` base) was a **silent no-op**: it reported a decreasing loss but applied no weight update. `GetParameters()`, serialization, and the eager Predict path all saw an untrained model with loss pinned at ~`ln(V)`, while `AiModelBuilder.BuildAsync` with an explicit optimizer "trained fine".

## Root cause

For a token/embedding Transformer (`SequenceClassification`, 2-D integer input), the **fused compiled-training fast path**'s specialized forward captures parameter **data by copy** instead of aliasing the live backing arrays. `plan.Step()` trains a plan-internal buffer — so `GetLastLoss` falls and the *compiled* Predict reflects it — but never writes the update back to the network's live parameter tensors. Every layer stays byte-for-byte at its initialised values (per-layer `delta = 0`). No kernel throws, so the existing exception-based fused fallbacks never fire.

A plain `FeedForwardNeuralNetwork` **does** persist correctly on the fused path (`FusedOptimizerParityTests` passes), so the defect is specific to the embedding-graph shape — which is exactly the LM/Transformer case.

### Reproduction (CPU, isolated per process)

| path | GetLastLoss | Predict NLL | learned? |
|---|---|---|---|
| default optimizer, **fused** (default) | 3.53 flat | 3.52 | **no** |
| default optimizer, **eager** | 1.93 | 1.70 | yes |
| explicit Adam, **fused** | 2.34 | 2.48 (weak) | partial |
| explicit Adam, **eager** | 0.0004 | **0.0000** | yes |

Two runs with *different* optimizers/LRs ended with **bit-identical** layer tensors under the fused path — proof the optimizer step never reached the live parameters.

## Fix

Verify persistence on the **first** fused step for each model: snapshot a checksum of the live trainable parameters before and after the step. If a fused step reports a real (finite) loss yet moves nothing, sticky-disable the fused path for that run and fall through to the eager tape, which mutates the live tensors correctly. One `O(params)` check, first step only, then latched (`_fusedPersistenceVerified`) so models that genuinely persist keep the fused fast path with zero steady-state overhead. This extends the existing exception-based fallback to cover the silent "ran-but-didn't-write-back" case.

## Verification (CPU)

- New `TransformerFusedTrainPersistenceIssue1822Tests` — asserts parameters change **and** the model's own predictions drop below `ln(V)` after batched `Train()` under the default fused path. Fails before the fix (params frozen, Predict at `ln(V)`), passes after.
- `FusedOptimizerParityTests` (9), `TransformerByteLMConvergenceIssue1232Tests`, `TransformerNoamPerCallLRIssue1470Tests`, `FusedOptimizerIntegrationTests`, `CompiledTapeTrainingStepTests`, `FlashAttentionFusedCompiledTrainingIssue1346Tests`, `LstmFusedTrainingWiringTests` — all still pass (persisting models keep the fused path).

Closes #1822

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved training reliability by detecting when a fast training path does not actually update model parameters, then automatically falling back to a safer path.
  * Prevented silent “no-op” training so models continue learning as expected.

* **Tests**
  * Added a regression test to verify batched transformer training persists parameter updates and reduces loss over time.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->