### PR TITLE
fix(generators): scope AIDN001 model-metadata validation to the AiDotNet library

### DIFF
--- a/src/AiDotNet.Generators/ModelMetadataValidationGenerator.cs
+++ b/src/AiDotNet.Generators/ModelMetadataValidationGenerator.cs
@@ -162,6 +162,24 @@ public class ModelMetadataValidationGenerator : IIncrementalGenerator
         if (candidates.IsDefaultOrEmpty)
             return;
 
+        // Scope governance to AiDotNet's OWN shipped models only.
+        //
+        // This generator is meant to enforce metadata on the models AiDotNet SHIPS. When the
+        // generator is referenced as an analyzer by any OTHER compilation (the test project's
+        // IFullModel doubles like FakeCodeModel/TestExposingTransformer, or a downstream user's
+        // own IFullModel subclasses), it must NOT fire — those types legitimately lack the
+        // metadata attributes and the AIDN001 Error would spuriously break their builds.
+        //
+        // Detection: the required attribute types (e.g. ModelDomainAttribute) are DEFINED in the
+        // AiDotNet core library. If the compilation being analyzed is that library, the attribute
+        // symbol's ContainingAssembly is the compilation's OWN assembly. In any consumer/test
+        // compilation the attribute is merely REFERENCED (defined in the referenced AiDotNet
+        // assembly), so ContainingAssembly != compilation.Assembly. This is sturdier than a raw
+        // AssemblyName == "AiDotNet" string check (survives renames). When it's not the library
+        // assembly, the generator no-ops entirely (AIDN001/AIDN020 + AIDN010/011/012).
+        if (!IsAiDotNetLibraryCompilation(compilation))
+            return;
+
         // Resolve attribute type symbols for comparison
         var domainAttr = compilation.GetTypeByMetadataName(ModelDomainAttributeName);
         var categoryAttr = compilation.GetTypeByMetadataName(ModelCategoryAttributeName);
@@ -196,6 +214,23 @@ public class ModelMetadataValidationGenerator : IIncrementalGenerator
             ValidatePaperUrls(context, modelClass, paperAttr);
             ValidateXmlDocumentation(context, modelClass);
         }
+    }
+
+    /// <summary>
+    /// Returns <c>true</c> only when the compilation being analyzed IS the AiDotNet core library
+    /// — i.e. the assembly that DEFINES the model-metadata attributes — rather than a consumer or
+    /// test assembly that merely references it. Governance (AIDN001/AIDN020 and the AIDN010/011/012
+    /// warnings) applies exclusively to AiDotNet's own shipped models.
+    /// </summary>
+    private static bool IsAiDotNetLibraryCompilation(Compilation compilation)
+    {
+        var domainAttr = compilation.GetTypeByMetadataName(ModelDomainAttributeName);
+
+        // The attribute type must be DEFINED in this compilation's own assembly. When AiDotNet is
+        // referenced (test project, downstream consumers), the symbol resolves to the referenced
+        // assembly instead, so the equality is false and the generator no-ops.
+        return domainAttr is not null &&
+               SymbolEqualityComparer.Default.Equals(domainAttr.ContainingAssembly, compilation.Assembly);
     }
 
     private static void ValidateRequiredAttributes(

--- a/tests/AiDotNet.Tests/AiDotNetTests.csproj
+++ b/tests/AiDotNet.Tests/AiDotNetTests.csproj
@@ -7,9 +7,6 @@
 	  <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
 	  <LangVersion>latest</LangVersion>
-	  <!-- Suppress AIDN001 (missing model metadata) for test mock classes.
-	       Mock/fake IFullModel implementations in tests don't need real metadata. -->
-	  <NoWarn>$(NoWarn);AIDN001</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>
@@ -53,6 +50,11 @@
        compiled assembly is not callable from tests; this pulls in just the pure-string helper. -->
   <ItemGroup>
     <Compile Include="..\..\src\AiDotNet.Generators\GeneratedTestFloatify.cs" Link="Generators\GeneratedTestFloatify.cs" />
+    <!-- Shared-compile the model-metadata validator so its assembly-scoping logic (AIDN001 must
+         fire for AiDotNet's own library models but NOT for consumer/test IFullModel doubles) can
+         be driven directly in a Roslyn generator unit test. Referenced above only as an analyzer,
+         whose compiled assembly is not callable from tests. -->
+    <Compile Include="..\..\src\AiDotNet.Generators\ModelMetadataValidationGenerator.cs" Link="Generators\ModelMetadataValidationGenerator.cs" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">

--- a/tests/AiDotNet.Tests/Generators/ModelMetadataValidationGeneratorTests.cs
+++ b/tests/AiDotNet.Tests/Generators/ModelMetadataValidationGeneratorTests.cs
@@ -1,0 +1,157 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Reflection;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Xunit;
+
+namespace AiDotNet.Tests.Generators;
+
+/// <summary>
+/// Regression tests for <see cref="AiDotNet.Generators.ModelMetadataValidationGenerator"/> proving
+/// the AIDN001 governance is SCOPED to AiDotNet's own shipped library.
+/// </summary>
+/// <remarks>
+/// The generator's AIDN001 diagnostic is a compile Error that fires on any non-abstract
+/// <c>IFullModel</c> implementer missing the required metadata attributes. Before the scoping fix it
+/// fired against the test project's own IFullModel doubles (and would fire against any downstream
+/// consumer's models), producing ~732 spurious errors that blocked the test suite. The fix no-ops
+/// the generator unless the compilation being analyzed IS the assembly that DEFINES the metadata
+/// attributes (the AiDotNet core library). These tests drive the generator over two synthetic
+/// compilations to lock that behavior in:
+///   * a library-like compilation that DEFINES the attributes and a model missing one → AIDN001 fires;
+///   * a consumer compilation that only REFERENCES the attribute-defining assembly → AIDN001 does NOT fire.
+/// </remarks>
+public class ModelMetadataValidationGeneratorTests
+{
+    // Minimal stand-ins for the real AiDotNet metadata attributes and IFullModel interface. The
+    // generator matches purely by fully-qualified metadata name, so these reproduce the exact
+    // namespaces/names it looks for. A model class is left MISSING the [ModelDomain] attribute so a
+    // correctly-scoped run reports AIDN001 for it.
+    private const string AttributesAndInterfaceSource = @"
+namespace AiDotNet.Attributes
+{
+    using System;
+    [AttributeUsage(AttributeTargets.Class)] public sealed class ModelDomainAttribute : Attribute { public ModelDomainAttribute(int d) { } }
+    [AttributeUsage(AttributeTargets.Class)] public sealed class ModelCategoryAttribute : Attribute { public ModelCategoryAttribute(int c) { } }
+    [AttributeUsage(AttributeTargets.Class)] public sealed class ModelTaskAttribute : Attribute { public ModelTaskAttribute(int t) { } }
+    [AttributeUsage(AttributeTargets.Class)] public sealed class ModelComplexityAttribute : Attribute { public ModelComplexityAttribute(int c) { } }
+    [AttributeUsage(AttributeTargets.Class)] public sealed class ModelInputAttribute : Attribute { public ModelInputAttribute(int i) { } }
+    [AttributeUsage(AttributeTargets.Class)] public sealed class ResearchPaperAttribute : Attribute { public ResearchPaperAttribute(string title, string url) { } }
+    [AttributeUsage(AttributeTargets.Class)] public sealed class ModelMetadataExemptAttribute : Attribute { }
+}
+namespace AiDotNet.Interfaces
+{
+    public interface IFullModel<T, TInput, TOutput> { }
+}";
+
+    // A concrete IFullModel implementer with NO metadata attributes. Placed in the library
+    // compilation it must trigger AIDN001; placed in a consumer compilation it must not.
+    private const string ModelSource = @"
+namespace SampleModels
+{
+    using AiDotNet.Interfaces;
+    public class UnannotatedModel : IFullModel<double, double, double> { }
+}";
+
+    private static ImmutableArray<MetadataReference> BaseReferences()
+    {
+        // Reference the same core BCL assemblies this test process is running against so the
+        // synthetic compilations resolve System.Object / System.Attribute, etc.
+        var refs = new List<MetadataReference>();
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var asm in AppDomain.CurrentDomain.GetAssemblies())
+        {
+            if (asm.IsDynamic)
+                continue;
+            var loc = asm.Location;
+            if (string.IsNullOrEmpty(loc) || !seen.Add(loc))
+                continue;
+            try
+            {
+                refs.Add(MetadataReference.CreateFromFile(loc));
+            }
+            catch
+            {
+                // Skip assemblies that can't be turned into a metadata reference.
+            }
+        }
+        return refs.ToImmutableArray();
+    }
+
+    private static ImmutableArray<Diagnostic> RunGenerator(CSharpCompilation compilation)
+    {
+        var generator = new AiDotNet.Generators.ModelMetadataValidationGenerator();
+        GeneratorDriver driver = CSharpGeneratorDriver.Create(generator);
+        driver = driver.RunGeneratorsAndUpdateCompilation(
+            compilation, out _, out var diagnostics);
+        return diagnostics;
+    }
+
+    private static bool HasAidn001(ImmutableArray<Diagnostic> diagnostics)
+        => diagnostics.Any(d => d.Id == "AIDN001");
+
+    /// <summary>
+    /// When the compilation DEFINES the metadata attributes (i.e. it IS the AiDotNet core library),
+    /// a concrete model missing a required attribute must raise AIDN001.
+    /// </summary>
+    [Fact]
+    public void Fires_AIDN001_For_Library_Model_Missing_Attribute()
+    {
+        var baseRefs = BaseReferences();
+        // Attributes + interface + the unannotated model all live in ONE assembly named "AiDotNet",
+        // reproducing the core library: the attribute types are defined in this compilation itself.
+        var library = CSharpCompilation.Create(
+            assemblyName: "AiDotNet",
+            syntaxTrees: new[]
+            {
+                CSharpSyntaxTree.ParseText(AttributesAndInterfaceSource),
+                CSharpSyntaxTree.ParseText(ModelSource),
+            },
+            references: baseRefs,
+            options: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+        var diagnostics = RunGenerator(library);
+
+        Assert.True(
+            HasAidn001(diagnostics),
+            "Expected AIDN001 to fire for a library model missing [ModelDomain], but it did not. " +
+            "Diagnostics: " + string.Join(", ", diagnostics.Select(d => d.Id)));
+    }
+
+    /// <summary>
+    /// When the compilation only REFERENCES the attribute-defining assembly (a downstream consumer,
+    /// or the test project with its IFullModel doubles), the generator must no-op — AIDN001 must NOT
+    /// fire even though the consumer's model lacks the metadata attributes.
+    /// </summary>
+    [Fact]
+    public void Does_Not_Fire_AIDN001_For_Consumer_Assembly_Model()
+    {
+        var baseRefs = BaseReferences();
+        // The attribute/interface definitions live in a SEPARATE referenced library.
+        var library = CSharpCompilation.Create(
+            assemblyName: "AiDotNet",
+            syntaxTrees: new[] { CSharpSyntaxTree.ParseText(AttributesAndInterfaceSource) },
+            references: baseRefs,
+            options: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+        // The consumer defines its own IFullModel model but only REFERENCES the attribute assembly.
+        var consumer = CSharpCompilation.Create(
+            assemblyName: "ConsumerApp",
+            syntaxTrees: new[] { CSharpSyntaxTree.ParseText(ModelSource) },
+            references: baseRefs.Add(library.ToMetadataReference()),
+            options: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+        // Sanity: the consumer model genuinely implements IFullModel and lacks the attributes, so
+        // an UNSCOPED generator WOULD have flagged it. (The library compilation itself, run above,
+        // proves the flagging path is live.)
+        var diagnostics = RunGenerator(consumer);
+
+        Assert.False(
+            HasAidn001(diagnostics),
+            "AIDN001 must NOT fire for a consumer/test assembly that only references AiDotNet, " +
+            "but it did. Diagnostics: " + string.Join(", ", diagnostics.Select(d => d.Id)));
+    }
+}


### PR DESCRIPTION
## Problem

`ModelMetadataValidationGenerator` (diagnostic **AIDN001**, `defaultSeverity: Error`) fired on **every** non-abstract `IFullModel` implementer missing the required metadata attributes — including the test project's scaffolding doubles (`FakeCodeModel`, `TestExposingTransformer`, …) and, worse, any **downstream consumer's** own `IFullModel` subclasses. Those types legitimately have no shipped-model metadata, so the Error spuriously broke their builds. `tests/AiDotNet.Tests` only compiled because of a `<NoWarn>AIDN001</NoWarn>` band-aid.

The governance is meant for AiDotNet's **shipped models only**.

## Fix

`Execute()` now no-ops unless the compilation being analyzed **is the AiDotNet core library** — the assembly that *defines* the metadata attributes. Detection (`IsAiDotNetLibraryCompilation`):

```csharp
var domainAttr = compilation.GetTypeByMetadataName("AiDotNet.Attributes.ModelDomainAttribute");
return domainAttr is not null &&
       SymbolEqualityComparer.Default.Equals(domainAttr.ContainingAssembly, compilation.Assembly);
```

When AiDotNet is *referenced* (test project, downstream consumers), the attribute symbol resolves to the referenced assembly, so `ContainingAssembly != compilation.Assembly` and the generator skips all validation (AIDN001/AIDN020 + AIDN010/011/012). This is sturdier than an `AssemblyName == "AiDotNet"` string check (survives renames). All existing per-class logic — including `[ModelMetadataExempt]` — is untouched for when it IS the library.

Also removed the now-moot `<NoWarn>AIDN001</NoWarn>` from `AiDotNetTests.csproj` so nothing is masked.

## Before / After metrics

`dotnet build tests/AiDotNet.Tests/AiDotNetTests.csproj -c Debug` (with the moot `NoWarn` removed):

| | AIDN001 errors in tests/AiDotNet.Tests | Build result |
|---|---|---|
| **BEFORE** (unscoped generator) | 732 | FAILS |
| **AFTER** (assembly-scoped) | 0 | Succeeds |

## Validator still fires on real library models

The scoping does **not** over-reach — AiDotNet's own models remain validated. New regression test `ModelMetadataValidationGeneratorTests` drives the generator over two synthetic compilations:

| Scenario | Compilation defines the attributes? | AIDN001 fires? |
|---|---|---|
| Library model missing `[ModelDomain]` | yes (assembly == "AiDotNet") | **YES** (before & after — governance preserved) |
| Consumer/test model missing attributes | no (only references AiDotNet) | **NO** (fixed; was YES before) |

Both cases assert directly on generator `Diagnostic`s. `Fires_AIDN001_For_Library_Model_Missing_Attribute` proves the flagging path stays live; `Does_Not_Fire_AIDN001_For_Consumer_Assembly_Model` proves the scope. Both pass (`Passed: 2, Failed: 0`).

This unblocks in-suite verification for the #1823 / #1824 redos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
