### PR TITLE
fix(facade): unblock BuildAsync for radiance-field models (#1826)

### DIFF
--- a/src/NeuralRadianceFields/Models/GaussianSplatting.cs
+++ b/src/NeuralRadianceFields/Models/GaussianSplatting.cs
@@ -2162,7 +2162,9 @@ public class GaussianSplatting<T> : NeuralNetworkBase<T>, IRadianceField<T>
                 { "DefaultPointSpacing", DefaultPointSpacing },
                 { "MinScale", MinScale }
             },
-            ModelData = Serialize()
+            // License-safe metadata bytes — see NeRF.GetModelMetadata for the
+            // same rationale. Fixes #1826.
+            ModelData = SerializeForMetadata()
         };
     }
 

--- a/src/NeuralRadianceFields/Models/InstantNGP.cs
+++ b/src/NeuralRadianceFields/Models/InstantNGP.cs
@@ -1719,7 +1719,9 @@ public class InstantNGP<T> : NeuralNetworkBase<T>, IRadianceField<T>
                 { "LayerCount", Layers.Count },
                 { "TotalParameters", ParameterCount + hashParameterCount }
             },
-            ModelData = Serialize()
+            // License-safe metadata bytes — see NeRF.GetModelMetadata for the
+            // same rationale. Fixes #1826.
+            ModelData = SerializeForMetadata()
         };
     }
 

--- a/src/NeuralRadianceFields/Models/NeRF.cs
+++ b/src/NeuralRadianceFields/Models/NeRF.cs
@@ -1228,7 +1228,14 @@ public class NeRF<T> : NeuralNetworkBase<T>, IRadianceField<T>
                 { "LayerCount", Layers.Count },
                 { "TotalParameters", ParameterCount }
             },
-            ModelData = Serialize()
+            // Use SerializeForMetadata (license-safe): returns [] instead of
+            // throwing when the persistence license has expired. Without this
+            // guard, AiModelBuilder.BuildAsync — which unconditionally calls
+            // GetModelMetadata to wrap the trained model in AiModelResult —
+            // throws LicenseRequiredException on the very first facade Build,
+            // even when the caller has no intention of saving the model.
+            // Matches Transformer.GetModelMetadata. Fixes #1826.
+            ModelData = SerializeForMetadata()
         };
     }
 

--- a/src/Optimizers/OptimizerBase.cs
+++ b/src/Optimizers/OptimizerBase.cs
@@ -4,6 +4,7 @@ global using AiDotNet.Models.Inputs;
 using AiDotNet.Helpers;
 using AiDotNet.Caching;
 using AiDotNet.NeuralNetworks;
+using AiDotNet.NeuralRadianceFields.Interfaces;
 using AiDotNet.Tensors.LinearAlgebra;
 using Newtonsoft.Json;
 
@@ -376,9 +377,25 @@ public abstract class OptimizerBase<T, TInput, TOutput> : IOptimizer<T, TInput, 
     /// break the shape contract. Used by <see cref="PrepareAndEvaluateSolutionCore"/> and
     /// <see cref="ApplyFeatureSelection"/> to skip feature selection/subsetting entirely,
     /// generalizing the embedding-only <see cref="IsEmbeddingBasedModel"/> handling. Fixes #1468.
+    ///
+    /// <para>Also treats <see cref="IRadianceField{T}"/> models (NeRF, GaussianSplatting,
+    /// InstantNGP) as non-flat regardless of the first layer's shape rank. Radiance-field
+    /// inputs are semantically multi-dimensional (a 3D position + a viewing direction),
+    /// but that <c>[N, 6]</c> input tensor gets positionally-encoded into a 1-D feature
+    /// vector before the first dense layer — so the shape-rank check alone would fail to
+    /// exclude them, feature indices up to 5 (or beyond, after encoding) would reach
+    /// <see cref="NeuralNetworkBase{T}.SetActiveFeatureIndices"/>, and it would throw
+    /// "Feature index N exceeds the input dimension 1" mid-<c>BuildAsync</c>. Fixes #1826.</para>
     /// </summary>
     protected static bool HasNonFlatNeuralInput(IFullModel<T, TInput, TOutput> model)
     {
+        // Radiance-field models are semantically non-flat even when their first dense
+        // layer sees a 1-D positionally-encoded vector. Check the interface directly
+        // rather than the layer shape; adding a new radiance-field type shouldn't have
+        // to re-teach this guard.
+        if (model is IRadianceField<T>)
+            return true;
+
         return model is NeuralNetworks.NeuralNetworkBase<T> nn
             && nn.Layers.Count > 0
             && nn.Layers[0].GetInputShape() is { Length: > 1 };

--- a/tests/AiDotNet.Tests/IntegrationTests/Optimizers/BuildAsyncFacadeRadianceFieldTests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/Optimizers/BuildAsyncFacadeRadianceFieldTests.cs
@@ -1,0 +1,184 @@
+using System.Threading.Tasks;
+using AiDotNet;
+using AiDotNet.Data.Loaders;
+using AiDotNet.NeuralRadianceFields.Models;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace AiDotNet.Tests.IntegrationTests.Optimizers;
+
+/// <summary>
+/// Facade-entry integration tests for issue #1826 — passing a radiance-field
+/// model (<see cref="NeRF{T}"/>, <see cref="GaussianSplatting{T}"/>,
+/// <see cref="InstantNGP{T}"/>) into
+/// <c>AiModelBuilder&lt;T, Tensor&lt;T&gt;, Tensor&lt;T&gt;&gt;
+/// .ConfigureModel(...).ConfigureDataLoader(...).BuildAsync()</c> used to
+/// throw <see cref="System.ArgumentOutOfRangeException"/>
+/// ("Feature index N exceeds the input dimension 1") from
+/// <c>NeuralNetworkBase.SetActiveFeatureIndices</c> during optimizer
+/// feature-selection. The root cause was
+/// <c>OptimizerBase.HasNonFlatNeuralInput</c> checking only the first
+/// layer's shape rank — radiance fields feed their <c>[N, 6]</c> input
+/// through a positional-encoding stage into a 1-D vector before the first
+/// dense layer, so the shape-rank guard failed to exclude them, the
+/// optimizer treated the 6-column tensor as tabular features, and the
+/// feature-selection path blew up on flat indices past the (encoded)
+/// first-layer input dimension.
+///
+/// <para>The fix extends <c>HasNonFlatNeuralInput</c> to also return true
+/// for any <see cref="AiDotNet.NeuralRadianceFields.Interfaces.IRadianceField{T}"/>.
+/// These tests pin that contract at the facade surface — the same surface
+/// every documented AiDotNet consumer (and every downstream training-demo
+/// / weekly-project code) actually uses.</para>
+/// </summary>
+[Collection("NonParallelIntegration")]
+public class BuildAsyncFacadeRadianceFieldTests
+{
+    private readonly ITestOutputHelper _output;
+
+    public BuildAsyncFacadeRadianceFieldTests(ITestOutputHelper output)
+    {
+        _output = output;
+    }
+
+    // Tiny fixture — enough to exercise the facade path end-to-end without
+    // spending real training time. The feature-selection bug fired on the
+    // very first PrepareAndEvaluateSolutionCore call, so we don't need to
+    // train to convergence to prove the fix.
+    private const int SampleCount = 64;
+
+    private static (Tensor<float> input, Tensor<float> target) SmallCubeBatch(int seed)
+    {
+        var rng = new System.Random(seed);
+        var input = new float[SampleCount * 6];
+        var target = new float[SampleCount * 4];
+        for (int i = 0; i < SampleCount; i++)
+        {
+            // Position ∈ [-0.7, 0.7]³
+            float x = (float)(rng.NextDouble() * 1.4 - 0.7);
+            float y = (float)(rng.NextDouble() * 1.4 - 0.7);
+            float z = (float)(rng.NextDouble() * 1.4 - 0.7);
+            // Unit-length viewing direction
+            float dx, dy, dz, ln;
+            do
+            {
+                dx = (float)(rng.NextDouble() * 2 - 1);
+                dy = (float)(rng.NextDouble() * 2 - 1);
+                dz = (float)(rng.NextDouble() * 2 - 1);
+                ln = System.MathF.Sqrt(dx * dx + dy * dy + dz * dz);
+            } while (ln < 1e-4f);
+            dx /= ln; dy /= ln; dz /= ln;
+            input[i * 6 + 0] = x;  input[i * 6 + 1] = y;  input[i * 6 + 2] = z;
+            input[i * 6 + 3] = dx; input[i * 6 + 4] = dy; input[i * 6 + 5] = dz;
+
+            // Colored-cube target: rgb = 0.5, density = 4 if inside unit cube else 0
+            bool inside = System.MathF.Abs(x) <= 0.5f && System.MathF.Abs(y) <= 0.5f && System.MathF.Abs(z) <= 0.5f;
+            target[i * 4 + 0] = 0.5f;
+            target[i * 4 + 1] = 0.5f;
+            target[i * 4 + 2] = 0.5f;
+            target[i * 4 + 3] = inside ? 4f : 0f;
+        }
+        return (new Tensor<float>(new[] { SampleCount, 6 }, new Vector<float>(input)),
+                new Tensor<float>(new[] { SampleCount, 4 }, new Vector<float>(target)));
+    }
+
+    /// <summary>
+    /// #1826 — the exact reproducer from the issue. Before the fix,
+    /// BuildAsync throws mid-way through the optimizer's feature-selection
+    /// pass. After the fix, BuildAsync returns a result and the NeRF's
+    /// parameters have moved from their random init.
+    /// </summary>
+    [Fact(Timeout = 300_000)]
+    public async Task BuildAsync_NeRF_ConfigureModel_DoesNotThrowFromFeatureSelection()
+    {
+        var nerf = new NeRF<float>(
+            positionEncodingLevels: 4,
+            directionEncodingLevels: 2,
+            hiddenDim: 32,
+            numLayers: 2,
+            colorHiddenDim: 16,
+            colorNumLayers: 1,
+            useHierarchicalSampling: false,
+            renderSamples: 8,
+            renderNearBound: 1.0,
+            renderFarBound: 4.0,
+            learningRate: 1e-3);
+
+        var (xTrain, yTrain) = SmallCubeBatch(seed: 1826);
+
+        // Snapshot the initial parameters so we can verify BuildAsync
+        // actually reached the optimizer (proves the fix went beyond
+        // "no throw" and the training path is now live).
+        var before = nerf.GetParameters();
+        var beforeCopy = new float[before.Length];
+        for (int i = 0; i < before.Length; i++) beforeCopy[i] = before[i];
+
+        var loader = DataLoaders.FromTensors(xTrain, yTrain);
+
+        // This is the exact call that used to throw
+        // "Feature index N exceeds the input dimension 1" from
+        // NeuralNetworkBase.SetActiveFeatureIndices during
+        // NormalOptimizer.Optimize's feature-selection pass.
+        var result = await new AiModelBuilder<float, Tensor<float>, Tensor<float>>()
+            .ConfigureDataLoader(loader)
+            .ConfigureModel(nerf)
+            .BuildAsync();
+
+        Assert.NotNull(result);
+
+        // The passed-in NeRF instance should have been trained in place.
+        // Some parameters must have moved from their init values.
+        var after = nerf.GetParameters();
+        Assert.Equal(before.Length, after.Length);
+
+        int movedCount = 0;
+        double maxDelta = 0;
+        for (int i = 0; i < after.Length; i++)
+        {
+            float delta = System.MathF.Abs(after[i] - beforeCopy[i]);
+            if (delta > 1e-8f) movedCount++;
+            if (delta > maxDelta) maxDelta = delta;
+        }
+        _output.WriteLine($"NeRF params: {after.Length}, moved: {movedCount}, max Δ = {maxDelta:E3}");
+        Assert.True(movedCount > 0,
+            "AiModelBuilder.BuildAsync returned without throwing but no NeRF parameters " +
+            "moved from init — the facade path is silently dropping the optimizer's " +
+            "parameter updates for radiance-field models.");
+    }
+
+    /// <summary>
+    /// #1826 — same contract for <see cref="GaussianSplatting{T}"/>, which
+    /// implements <c>IRadianceField&lt;T&gt;</c> and hit the identical
+    /// feature-selection failure. The <c>IRadianceField&lt;T&gt;</c> guard
+    /// covers all three shipping radiance-field models at once.
+    /// </summary>
+    [Fact(Timeout = 300_000)]
+    public async Task BuildAsync_GaussianSplatting_ConfigureModel_DoesNotThrowFromFeatureSelection()
+    {
+        var gs = new GaussianSplatting<float>();
+        var (xTrain, yTrain) = SmallCubeBatch(seed: 18261);
+
+        var before = gs.GetParameters();
+        var beforeCopy = new float[before.Length];
+        for (int i = 0; i < before.Length; i++) beforeCopy[i] = before[i];
+
+        var loader = DataLoaders.FromTensors(xTrain, yTrain);
+        var result = await new AiModelBuilder<float, Tensor<float>, Tensor<float>>()
+            .ConfigureDataLoader(loader)
+            .ConfigureModel(gs)
+            .BuildAsync();
+
+        Assert.NotNull(result);
+
+        var after = gs.GetParameters();
+        Assert.Equal(before.Length, after.Length);
+        int movedCount = 0;
+        for (int i = 0; i < after.Length; i++)
+            if (System.MathF.Abs(after[i] - beforeCopy[i]) > 1e-8f) movedCount++;
+        _output.WriteLine($"GS params: {after.Length}, moved: {movedCount}");
+        Assert.True(movedCount > 0,
+            "AiModelBuilder.BuildAsync returned without throwing but no GaussianSplatting " +
+            "parameters moved from init.");
+    }
+}


### PR DESCRIPTION
## Summary

Two changes needed to make `AiModelBuilder.BuildAsync` work end-to-end for radiance-field models — both blockers surfaced sequentially while wiring up a real facade call from a downstream demo.

- Extend `OptimizerBase.HasNonFlatNeuralInput` to also treat any `IRadianceField<T>` (NeRF / GaussianSplatting / InstantNGP) as non-flat, so feature selection is skipped for radiance-field models.
- Switch `NeRF.GetModelMetadata`, `GaussianSplatting.GetModelMetadata`, and `InstantNGP.GetModelMetadata` from calling `Serialize()` directly to calling `SerializeForMetadata()` — the license-safe wrapper the base class provides, and the same pattern `Transformer.GetModelMetadata` already uses. Without this, the very first `BuildAsync` call unconditionally throws `LicenseRequiredException` when it wraps the result in `AiModelResult`, even though the caller had no intention of saving the model.
- Add integration tests that pin the `AiModelBuilder<float, Tensor<float>, Tensor<float>>().ConfigureModel(...).ConfigureDataLoader(...).BuildAsync()` contract for both `NeRF<float>` and `GaussianSplatting<float>`.

Closes #1826.

## The bug

Handing a radiance-field model to the facade —

```csharp
var nerf = new NeRF<float>(/* … */);
var loader = DataLoaders.FromTensors(inputs /* [N,6] */, targets /* [N,4] */);
var result = await new AiModelBuilder<float, Tensor<float>, Tensor<float>>()
    .ConfigureDataLoader(loader)
    .ConfigureModel(nerf)
    .BuildAsync();
```

— threw during the optimizer's feature-selection pass:

```
System.ArgumentOutOfRangeException: Feature index 4 exceeds the input dimension 1.
   at AiDotNet.NeuralNetworks.NeuralNetworkBase.SetActiveFeatureIndices(...)
   at AiDotNet.Optimizers.OptimizerBase.ApplyFeatureSelection(...)
   at AiDotNet.Optimizers.OptimizerBase.PrepareAndEvaluateSolutionCore(...)
   at AiDotNet.Optimizers.NormalOptimizer.Optimize(...)
   at AiDotNet.AiModelBuilder.BuildSupervisedInternalAsync(...)
```

## Root cause

`OptimizerBase.HasNonFlatNeuralInput` (`src/Optimizers/OptimizerBase.cs:380`) guards feature selection for models whose input is semantically multi-dimensional, but the check was purely structural:

```csharp
return model is NeuralNetworks.NeuralNetworkBase<T> nn
    && nn.Layers.Count > 0
    && nn.Layers[0].GetInputShape() is { Length: > 1 };
```

Radiance-field models take an `[N, 6]` input (position + view direction), but the first *layer* they hit is a `DenseLayer<T>` receiving a 1-D positionally-encoded feature vector. So `Layers[0].GetInputShape().Length == 1`, the guard doesn't fire, `ApplyFeatureSelection` treats the six columns as tabular features, and `SetActiveFeatureIndices` throws when it tries to enable column 4 of a 1-column input.

## Fix

Add an interface-level check in front of the layer-shape check:

```csharp
if (model is IRadianceField<T>)
    return true;
```

`IRadianceField<T>` covers `NeRF<T>`, `GaussianSplatting<T>`, and `InstantNGP<T>`, and any future radiance-field model that implements the same interface picks the guard up automatically. The layer-shape check remains for CNN / RNN / ViT / ResNet.

## Tests

`tests/AiDotNet.Tests/IntegrationTests/Optimizers/BuildAsyncFacadeRadianceFieldTests.cs` — two integration tests that:

1. Instantiate a `NeRF<float>` / `GaussianSplatting<float>`
2. Snapshot the initial parameter vector
3. Drive it through `AiModelBuilder.BuildAsync` via `ConfigureDataLoader + ConfigureModel`
4. Assert `BuildAsync` doesn't throw
5. Assert some parameters moved from init (proves the optimizer actually reached the model, not just that the exception went away)

Both would have failed at step 3 pre-fix with the exact `ArgumentOutOfRangeException` above.

## Test plan

- [ ] `dotnet build src/AiDotNet.csproj` succeeds
- [ ] `dotnet test tests/AiDotNet.Tests --filter FullyQualifiedName~BuildAsyncFacadeRadianceFieldTests` passes both tests
- [ ] Existing feature-selection tests still pass (`--filter FullyQualifiedName~FeatureSelection`)
- [ ] Existing radiance-field integration tests still pass (`--filter Category=NeuralRadianceFields`)

## Discovered while

Building the Week 11 Session B "3D AI & Neural Rendering" training demo (NerfLab) — the demo, mini-HW, and weekly project all need the facade path. Verified against AiDotNet `master` at commit `803330ca9`.
