### PR TITLE
fix(optimizers): bound DefaultGradientCache to stop unbounded training-loop memory leak

### DIFF
--- a/src/AiModelBuilder.BuildPipeline.cs
+++ b/src/AiModelBuilder.BuildPipeline.cs
@@ -1249,6 +1249,17 @@ public partial class AiModelBuilder<T, TInput, TOutput>
             optimizer = new NormalOptimizer<T, TInput, TOutput>(_model);
         }
 
+        // Wire ConfigureCaching through to the optimizer's in-training caches (gradient + model-eval).
+        // ConfigureCaching stored a CacheConfig on the builder but nothing consumed it, so the bounded
+        // gradient/model caches always ran at their built-in defaults. Apply the user's capacity /
+        // eviction-policy / enabled choices here; ApplyCacheConfiguration swaps the caches at runtime so
+        // an optimizer constructed before ConfigureCaching was called still honors the config.
+        if (_cacheConfig is not null
+            && optimizer is Optimizers.OptimizerBase<T, TInput, TOutput> optForCache)
+        {
+            optForCache.ApplyCacheConfiguration(_cacheConfig);
+        }
+
         // Wire ConfigureRegularization through to the optimizer. Without
         // this, the user's regularization was stored on the builder
         // (_regularization) but the gradient-application loop inside

--- a/src/Caching/BoundedEvictingStore.cs
+++ b/src/Caching/BoundedEvictingStore.cs
@@ -1,0 +1,151 @@
+global using System.Collections.Concurrent;
+using System.Collections.Generic;
+using AiDotNet.Enums;
+
+using CacheEvictionPolicy = AiDotNet.Enums.CacheEvictionPolicy;
+namespace AiDotNet.Caching;
+
+/// <summary>
+/// A thread-safe, string-keyed store bounded to a fixed capacity that evicts an entry per a
+/// configurable <see cref="CacheEvictionPolicy"/> once full. Shared by the optimizer's gradient and
+/// model-evaluation caches so the bounded-eviction logic lives in exactly one place instead of being
+/// re-implemented per cache.
+/// </summary>
+/// <typeparam name="TValue">The cached value type (a reference type — the caches store class payloads).</typeparam>
+/// <remarks>
+/// Eviction victim selection:
+/// <list type="bullet">
+/// <item><description><b>FIFO</b> — the oldest <i>inserted</i> key (access does not change position).</description></item>
+/// <item><description><b>LRU</b> — the least-recently <i>used</i> key (a get or an update refreshes recency).</description></item>
+/// <item><description><b>LFU</b> — the least-frequently <i>used</i> key (fewest gets/updates; ties broken by age).</description></item>
+/// </list>
+/// All mutations run under a single lock so the capacity bound holds under concurrency; FIFO reads are
+/// lock-free because they never mutate eviction metadata.
+/// </remarks>
+internal sealed class BoundedEvictingStore<TValue> where TValue : class
+{
+    private readonly ConcurrentDictionary<string, TValue> _values = new(StringComparer.Ordinal);
+    // Insertion tick (FIFO) or last-access tick (LRU). Mutated only under _lock.
+    private readonly Dictionary<string, long> _tick = new(StringComparer.Ordinal);
+    // Access frequency (LFU). Mutated only under _lock.
+    private readonly Dictionary<string, long> _frequency = new(StringComparer.Ordinal);
+    private readonly object _lock = new();
+    private long _clock;
+
+    /// <summary>Maximum number of distinct keys retained before an eviction occurs.</summary>
+    public int Capacity { get; }
+
+    /// <summary>The policy that chooses the eviction victim once the store is over capacity.</summary>
+    public CacheEvictionPolicy EvictionPolicy { get; }
+
+    /// <summary>Current number of live entries.</summary>
+    public int Count => _values.Count;
+
+    public BoundedEvictingStore(int capacity, CacheEvictionPolicy evictionPolicy)
+    {
+        if (capacity <= 0)
+            throw new ArgumentOutOfRangeException(nameof(capacity), capacity, "Cache capacity must be positive.");
+        Capacity = capacity;
+        EvictionPolicy = evictionPolicy;
+    }
+
+    /// <summary>Returns the value for <paramref name="key"/>, or <c>null</c> if absent.</summary>
+    public TValue? Get(string key)
+    {
+        if (key is null) throw new ArgumentNullException(nameof(key));
+        if (!_values.TryGetValue(key, out var value))
+            return null;
+
+        // FIFO is access-order-agnostic, so its read stays lock-free. LRU/LFU must record the access.
+        if (EvictionPolicy != CacheEvictionPolicy.FIFO)
+        {
+            lock (_lock)
+            {
+                if (_values.ContainsKey(key))
+                    RecordUseUnlocked(key);
+            }
+        }
+        return value;
+    }
+
+    /// <summary>Inserts or updates <paramref name="key"/>, evicting per policy when over capacity.</summary>
+    public void Set(string key, TValue value)
+    {
+        if (key is null) throw new ArgumentNullException(nameof(key));
+        if (value is null) throw new ArgumentNullException(nameof(value));
+
+        lock (_lock)
+        {
+            bool isNew = !_values.ContainsKey(key);
+            _values[key] = value;
+
+            if (isNew)
+            {
+                // A brand-new key: seed its metadata and evict back to capacity.
+                _tick[key] = ++_clock;
+                _frequency[key] = 1;
+                while (_values.Count > Capacity)
+                {
+                    string victim = SelectVictimUnlocked();
+                    _values.TryRemove(victim, out _);
+                    _tick.Remove(victim);
+                    _frequency.Remove(victim);
+                }
+            }
+            else
+            {
+                // An in-place update counts as a use for LRU/LFU; FIFO keeps the original position.
+                RecordUseUnlocked(key);
+            }
+        }
+    }
+
+    /// <summary>Removes every entry.</summary>
+    public void Clear()
+    {
+        lock (_lock)
+        {
+            _values.Clear();
+            _tick.Clear();
+            _frequency.Clear();
+        }
+    }
+
+    // Refresh the access metadata for a key already present. Caller holds _lock.
+    private void RecordUseUnlocked(string key)
+    {
+        switch (EvictionPolicy)
+        {
+            case CacheEvictionPolicy.LRU:
+                _tick[key] = ++_clock;
+                break;
+            case CacheEvictionPolicy.LFU:
+                _frequency[key] = _frequency.TryGetValue(key, out var f) ? f + 1 : 1;
+                break;
+            // FIFO: insertion order is fixed; a use does not move the key.
+        }
+    }
+
+    // Pick the eviction victim per policy. Caller holds _lock; _tick is never empty here (over capacity).
+    private string SelectVictimUnlocked()
+    {
+        string? victim = null;
+        long bestTick = long.MaxValue;
+        long bestFreq = long.MaxValue;
+        foreach (var entry in _tick)
+        {
+            long tick = entry.Value;
+            long freq = _frequency.TryGetValue(entry.Key, out var f) ? f : 0;
+            bool better = EvictionPolicy == CacheEvictionPolicy.LFU
+                ? victim is null || freq < bestFreq || (freq == bestFreq && tick < bestTick)  // fewest uses, then oldest
+                : victim is null || tick < bestTick;                                          // FIFO/LRU: smallest tick
+            if (better)
+            {
+                victim = entry.Key;
+                bestTick = tick;
+                bestFreq = freq;
+            }
+        }
+        return victim ?? throw new InvalidOperationException("Eviction requested on an empty cache.");
+    }
+}

--- a/src/Caching/DefaultGradientCache.cs
+++ b/src/Caching/DefaultGradientCache.cs
@@ -12,22 +12,52 @@ namespace AiDotNet.Caching;
 /// <para>
 /// <b>For Beginners:</b> A gradient cache is like a memory bank that stores pre-calculated mathematical operations
 /// that are frequently used during machine learning model training.
-/// 
+///
 /// In machine learning, "gradients" are calculations that show how much a model's error would change
 /// if we slightly adjusted a specific parameter. These calculations can be complex and time-consuming,
 /// especially if they need to be repeated many times.
-/// 
+///
 /// By storing these calculations in a cache (a temporary storage area), we can avoid recalculating the
 /// same gradients repeatedly, which makes the training process much faster. Think of it like remembering
 /// the answer to a difficult math problem so you don't have to solve it again when you need the same answer later.
-/// 
+///
 /// This class provides a simple way to store and retrieve these gradient calculations using string keys
 /// (like names or identifiers) to look them up quickly.
+/// </para>
+/// <para>
+/// <b>Bounded capacity (memory-leak fix):</b> the cache evicts its oldest entry once the number of
+/// stored gradients exceeds <see cref="Capacity"/>. This matters because the optimizer's gradient
+/// cache key (<c>GradientBasedOptimizerBase.GenerateGradientCacheKey</c>) folds in a per-step
+/// parameter-state fingerprint AND the per-batch input/target reference identities. During the batched
+/// <c>Optimize</c> training loop every mini-batch step therefore produces a BRAND-NEW key that will
+/// never be looked up again (the parameters have already moved on by the next step). Without a bound
+/// the dictionary grew by one full parameter-sized gradient <c>Vector&lt;T&gt;</c> every step and was
+/// only ever cleared by <c>Reset()</c> (which the training loop never calls) — a linear managed-heap
+/// leak that made each epoch's GC progressively more expensive and per-epoch wall-time climb roughly
+/// linearly with the epoch index. Bounding the cache is numerically transparent: a cache <i>hit</i>
+/// returns the identical gradient that would otherwise be recomputed, and a <i>miss</i> (because an
+/// old entry was evicted) simply recomputes that same gradient deterministically. The legitimate reuse
+/// cases the cache exists for — line search / trust-region re-evaluation of the same solution, or a
+/// caller invoking <c>CalculateGradient</c> twice in a row with identical arguments — all reuse a key
+/// within a handful of consecutive calls, well inside the retained window, so they still hit.
 /// </para>
 /// </remarks>
 [InfraType(InfraType.Cache)]
 public class DefaultGradientCache<T> : IGradientCache<T>
 {
+    /// <summary>
+    /// Default maximum number of gradient entries retained before the oldest is evicted.
+    /// </summary>
+    /// <remarks>
+    /// Chosen to comfortably cover every legitimate short-window reuse pattern (numerical
+    /// gradient-check double-evaluation, line-search / trust-region re-evaluation, DDP AllReduce
+    /// read-back) while keeping the resident footprint bounded and independent of the number of
+    /// training steps. Bounding at count rather than bytes keeps the policy model-size agnostic;
+    /// the entry payload scales with the model, but the growth is capped at a constant multiple
+    /// of a single gradient snapshot instead of growing without limit.
+    /// </remarks>
+    public const int DefaultCapacity = 8;
+
     /// <summary>
     /// The internal dictionary that stores gradient models, allowing concurrent access from multiple threads.
     /// </summary>
@@ -35,6 +65,40 @@ public class DefaultGradientCache<T> : IGradientCache<T>
     /// ConcurrentDictionary is used to ensure thread safety when multiple operations might access the cache simultaneously.
     /// </remarks>
     private readonly ConcurrentDictionary<string, IGradientModel<T>> _cache = new();
+
+    /// <summary>
+    /// FIFO record of the order in which keys were first inserted, used to pick the eviction victim
+    /// when the cache is over capacity. Only NEW keys are enqueued (updates to an existing key keep
+    /// their original position), so the queue length tracks the live-entry insertion history.
+    /// </summary>
+    private readonly ConcurrentQueue<string> _insertionOrder = new();
+
+    /// <summary>Guards the compound "insert + evict-to-capacity" sequence so the bound holds under concurrency.</summary>
+    private readonly object _writeLock = new();
+
+    /// <summary>
+    /// Maximum number of gradient entries retained before the oldest entry is evicted.
+    /// </summary>
+    public int Capacity { get; }
+
+    /// <summary>
+    /// Creates a gradient cache bounded to <see cref="DefaultCapacity"/> entries.
+    /// </summary>
+    public DefaultGradientCache() : this(DefaultCapacity)
+    {
+    }
+
+    /// <summary>
+    /// Creates a gradient cache bounded to <paramref name="capacity"/> entries.
+    /// </summary>
+    /// <param name="capacity">Maximum number of gradient entries to retain (must be positive).</param>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="capacity"/> is not positive.</exception>
+    public DefaultGradientCache(int capacity)
+    {
+        if (capacity <= 0)
+            throw new ArgumentOutOfRangeException(nameof(capacity), capacity, "Gradient cache capacity must be positive.");
+        Capacity = capacity;
+    }
 
     /// <summary>
     /// Retrieves a cached gradient model using the specified key.
@@ -45,7 +109,7 @@ public class DefaultGradientCache<T> : IGradientCache<T>
     /// <para>
     /// <b>For Beginners:</b> This method works like looking up a word in a dictionary. You provide a key (like a word),
     /// and it returns the corresponding gradient model (like the definition) if it exists in the cache.
-    /// 
+    ///
     /// If the key doesn't exist in the cache, the method returns null, indicating that the gradient
     /// needs to be calculated from scratch.
     /// </para>
@@ -66,11 +130,13 @@ public class DefaultGradientCache<T> : IGradientCache<T>
     /// <remarks>
     /// <para>
     /// <b>For Beginners:</b> This method saves a gradient model in the cache so it can be retrieved later.
-    /// 
+    ///
     /// It's like writing down the answer to a complex math problem with a label (the key) so you can
     /// look it up quickly next time instead of solving the problem again.
-    /// 
+    ///
     /// If a gradient with the same key already exists in the cache, it will be replaced with the new one.
+    /// Once the cache holds <see cref="Capacity"/> distinct keys, inserting a new one evicts the oldest
+    /// so the cache never grows without bound (see the class remarks for why this matters).
     /// </para>
     /// </remarks>
     public void CacheGradient(string key, IGradientModel<T> gradient)
@@ -78,7 +144,27 @@ public class DefaultGradientCache<T> : IGradientCache<T>
         if (key == null) throw new ArgumentNullException(nameof(key), "Cache key cannot be null.");
         if (gradient == null) throw new ArgumentNullException(nameof(gradient), "Gradient cannot be null.");
 
-        _cache[key] = gradient;
+        lock (_writeLock)
+        {
+            // TryAdd distinguishes a brand-new key (needs an insertion-order slot + a
+            // capacity check) from an update to an existing key (payload swapped in place,
+            // position unchanged, no growth).
+            if (_cache.TryAdd(key, gradient))
+            {
+                _insertionOrder.Enqueue(key);
+
+                // Evict oldest-first until back within capacity. A dequeued key that is no
+                // longer present (already evicted or explicitly cleared) is simply skipped.
+                while (_cache.Count > Capacity && _insertionOrder.TryDequeue(out var oldest))
+                {
+                    _cache.TryRemove(oldest, out _);
+                }
+            }
+            else
+            {
+                _cache[key] = gradient;
+            }
+        }
     }
 
     /// <summary>
@@ -92,6 +178,10 @@ public class DefaultGradientCache<T> : IGradientCache<T>
     /// </remarks>
     public void ClearCache()
     {
-        _cache.Clear();
+        lock (_writeLock)
+        {
+            _cache.Clear();
+            while (_insertionOrder.TryDequeue(out _)) { }
+        }
     }
 }

--- a/src/Caching/DefaultGradientCache.cs
+++ b/src/Caching/DefaultGradientCache.cs
@@ -2,6 +2,7 @@ global using System.Collections.Concurrent;
 using AiDotNet.Attributes;
 using AiDotNet.Enums;
 
+using CacheEvictionPolicy = AiDotNet.Enums.CacheEvictionPolicy;
 namespace AiDotNet.Caching;
 
 /// <summary>
@@ -59,45 +60,59 @@ public class DefaultGradientCache<T> : IGradientCache<T>
     public const int DefaultCapacity = 8;
 
     /// <summary>
-    /// The internal dictionary that stores gradient models, allowing concurrent access from multiple threads.
+    /// Recommended default eviction policy: oldest-inserted first. A gradient key is reused only within
+    /// a handful of consecutive calls, so FIFO retains exactly the recent window that legitimately hits.
     /// </summary>
-    /// <remarks>
-    /// ConcurrentDictionary is used to ensure thread safety when multiple operations might access the cache simultaneously.
-    /// </remarks>
-    private readonly ConcurrentDictionary<string, IGradientModel<T>> _cache = new();
+    public const CacheEvictionPolicy DefaultEvictionPolicy = CacheEvictionPolicy.FIFO;
+
+    /// <summary>Bounded, policy-evicting backing store (capacity + FIFO/LRU/LFU live here).</summary>
+    private readonly BoundedEvictingStore<IGradientModel<T>> _store;
+
+    /// <summary>When false the cache is a pass-through: every lookup misses and stores are dropped, so
+    /// the optimizer always recomputes (numerically identical, just uncached).</summary>
+    private readonly bool _enabled;
+
+    /// <summary>Whether the cache actually stores entries (false = disabled pass-through).</summary>
+    public bool Enabled => _enabled;
 
     /// <summary>
-    /// FIFO record of the order in which keys were first inserted, used to pick the eviction victim
-    /// when the cache is over capacity. Only NEW keys are enqueued (updates to an existing key keep
-    /// their original position), so the queue length tracks the live-entry insertion history.
+    /// Maximum number of gradient entries retained before an entry is evicted.
     /// </summary>
-    private readonly ConcurrentQueue<string> _insertionOrder = new();
+    public int Capacity => _store.Capacity;
 
-    /// <summary>Guards the compound "insert + evict-to-capacity" sequence so the bound holds under concurrency.</summary>
-    private readonly object _writeLock = new();
+    /// <summary>The policy used to choose the eviction victim once the cache is full.</summary>
+    public CacheEvictionPolicy EvictionPolicy => _store.EvictionPolicy;
 
     /// <summary>
-    /// Maximum number of gradient entries retained before the oldest entry is evicted.
+    /// Creates a gradient cache with the recommended defaults: <see cref="DefaultCapacity"/> entries,
+    /// <see cref="DefaultEvictionPolicy"/> eviction.
     /// </summary>
-    public int Capacity { get; }
-
-    /// <summary>
-    /// Creates a gradient cache bounded to <see cref="DefaultCapacity"/> entries.
-    /// </summary>
-    public DefaultGradientCache() : this(DefaultCapacity)
+    public DefaultGradientCache() : this(DefaultCapacity, DefaultEvictionPolicy)
     {
     }
 
     /// <summary>
-    /// Creates a gradient cache bounded to <paramref name="capacity"/> entries.
+    /// Creates a gradient cache bounded to <paramref name="capacity"/> entries with the recommended
+    /// <see cref="DefaultEvictionPolicy"/> eviction.
     /// </summary>
     /// <param name="capacity">Maximum number of gradient entries to retain (must be positive).</param>
     /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="capacity"/> is not positive.</exception>
-    public DefaultGradientCache(int capacity)
+    public DefaultGradientCache(int capacity) : this(capacity, DefaultEvictionPolicy)
     {
-        if (capacity <= 0)
-            throw new ArgumentOutOfRangeException(nameof(capacity), capacity, "Gradient cache capacity must be positive.");
-        Capacity = capacity;
+    }
+
+    /// <summary>
+    /// Creates a gradient cache bounded to <paramref name="capacity"/> entries evicting per
+    /// <paramref name="evictionPolicy"/>.
+    /// </summary>
+    /// <param name="capacity">Maximum number of gradient entries to retain (must be positive).</param>
+    /// <param name="evictionPolicy">Which entry to evict once the cache is full (FIFO / LRU / LFU).</param>
+    /// <param name="enabled">When false the cache is a pass-through that never stores (always recomputes).</param>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="capacity"/> is not positive.</exception>
+    public DefaultGradientCache(int capacity, CacheEvictionPolicy evictionPolicy, bool enabled = true)
+    {
+        _store = new BoundedEvictingStore<IGradientModel<T>>(capacity, evictionPolicy);
+        _enabled = enabled;
     }
 
     /// <summary>
@@ -117,9 +132,7 @@ public class DefaultGradientCache<T> : IGradientCache<T>
     public IGradientModel<T>? GetCachedGradient(string key)
     {
         if (key == null) throw new ArgumentNullException(nameof(key), "Cache key cannot be null.");
-
-        _cache.TryGetValue(key, out var gradient);
-        return gradient;
+        return _enabled ? _store.Get(key) : null;
     }
 
     /// <summary>
@@ -143,28 +156,7 @@ public class DefaultGradientCache<T> : IGradientCache<T>
     {
         if (key == null) throw new ArgumentNullException(nameof(key), "Cache key cannot be null.");
         if (gradient == null) throw new ArgumentNullException(nameof(gradient), "Gradient cannot be null.");
-
-        lock (_writeLock)
-        {
-            // TryAdd distinguishes a brand-new key (needs an insertion-order slot + a
-            // capacity check) from an update to an existing key (payload swapped in place,
-            // position unchanged, no growth).
-            if (_cache.TryAdd(key, gradient))
-            {
-                _insertionOrder.Enqueue(key);
-
-                // Evict oldest-first until back within capacity. A dequeued key that is no
-                // longer present (already evicted or explicitly cleared) is simply skipped.
-                while (_cache.Count > Capacity && _insertionOrder.TryDequeue(out var oldest))
-                {
-                    _cache.TryRemove(oldest, out _);
-                }
-            }
-            else
-            {
-                _cache[key] = gradient;
-            }
-        }
+        if (_enabled) _store.Set(key, gradient);
     }
 
     /// <summary>
@@ -178,10 +170,6 @@ public class DefaultGradientCache<T> : IGradientCache<T>
     /// </remarks>
     public void ClearCache()
     {
-        lock (_writeLock)
-        {
-            _cache.Clear();
-            while (_insertionOrder.TryDequeue(out _)) { }
-        }
+        _store.Clear();
     }
 }

--- a/src/Caching/DefaultModelCache.cs
+++ b/src/Caching/DefaultModelCache.cs
@@ -1,6 +1,7 @@
 using AiDotNet.Attributes;
 using AiDotNet.Enums;
 using AiDotNet.Helpers;
+using CacheEvictionPolicy = AiDotNet.Enums.CacheEvictionPolicy;
 namespace AiDotNet.Caching;
 
 /// <summary>
@@ -28,52 +29,63 @@ namespace AiDotNet.Caching;
 public class DefaultModelCache<T, TInput, TOutput> : IModelCache<T, TInput, TOutput>
 {
     /// <summary>
-    /// The internal dictionary that stores optimization step data, allowing concurrent access from multiple threads.
-    /// </summary>
-    /// <remarks>
-    /// ConcurrentDictionary is used to ensure thread safety when multiple operations might access the cache simultaneously.
-    /// </remarks>
-    private readonly ConcurrentDictionary<string, OptimizationStepData<T, TInput, TOutput>> _cache = new();
-
-    /// <summary>
-    /// Default maximum number of distinct step-data entries retained before the oldest are evicted.
+    /// Default maximum number of distinct step-data entries retained before eviction.
     /// </summary>
     public const int DefaultCapacity = 8;
 
-    /// <summary>
-    /// Maximum number of distinct keys retained. Once exceeded, the oldest-inserted entries are evicted.
-    /// </summary>
-    private readonly int _capacity;
+    /// <summary>Recommended default eviction policy: oldest-inserted first.</summary>
+    public const CacheEvictionPolicy DefaultEvictionPolicy = CacheEvictionPolicy.FIFO;
+
+    /// <summary>Bounded, policy-evicting backing store (capacity + FIFO/LRU/LFU live here).</summary>
+    private readonly BoundedEvictingStore<OptimizationStepData<T, TInput, TOutput>> _store;
+
+    /// <summary>When false the cache is a pass-through: every lookup misses and stores are dropped.</summary>
+    private readonly bool _enabled;
+
+    /// <summary>Whether the cache actually stores entries (false = disabled pass-through).</summary>
+    public bool Enabled => _enabled;
+
+    /// <summary>Maximum number of distinct keys retained before an entry is evicted.</summary>
+    public int Capacity => _store.Capacity;
+
+    /// <summary>The policy used to choose the eviction victim once the cache is full.</summary>
+    public CacheEvictionPolicy EvictionPolicy => _store.EvictionPolicy;
 
     /// <summary>
-    /// Insertion-order record of cache keys, used to evict the oldest entry when the cache is full.
+    /// Initializes a new cache with the recommended defaults: <see cref="DefaultCapacity"/> entries,
+    /// <see cref="DefaultEvictionPolicy"/> eviction.
     /// </summary>
-    private readonly ConcurrentQueue<string> _insertionOrder = new();
-
-    /// <summary>
-    /// Initializes a new cache with the <see cref="DefaultCapacity"/> bound.
-    /// </summary>
-    public DefaultModelCache() : this(DefaultCapacity)
+    public DefaultModelCache() : this(DefaultCapacity, DefaultEvictionPolicy)
     {
     }
 
     /// <summary>
-    /// Initializes a new cache that retains at most <paramref name="capacity"/> distinct entries.
+    /// Initializes a new cache that retains at most <paramref name="capacity"/> distinct entries,
+    /// evicting with the recommended <see cref="DefaultEvictionPolicy"/>.
     /// </summary>
     /// <param name="capacity">
-    /// Maximum number of step-data entries to keep. Once exceeded, the oldest-inserted entry is
-    /// evicted (FIFO). This bounds memory: an optimizer's per-epoch evaluation writes a fresh
-    /// entry every epoch (the parameter-content key changes as the model trains), so without a
-    /// bound the cache — which retains a deep-copied model and O(N) predictions per entry — would
-    /// grow without limit across a long training run, driving per-epoch memory and wall-clock up.
-    /// A gradient optimizer never re-queries a prior epoch's key (parameters keep changing), and
-    /// population optimizers only hit on exact-duplicate parameter vectors (rare in continuous
-    /// search), so a small bound preserves the cache's real value while eliminating the leak.
-    /// Values &lt;= 0 fall back to <see cref="DefaultCapacity"/>.
+    /// Maximum number of step-data entries to keep. This bounds memory: an optimizer's per-epoch
+    /// evaluation writes a fresh entry every epoch (the parameter-content key changes as the model
+    /// trains), so without a bound the cache — which retains a deep-copied model and O(N) predictions
+    /// per entry — would grow without limit across a long training run. Values &lt;= 0 fall back to
+    /// <see cref="DefaultCapacity"/>.
     /// </param>
-    public DefaultModelCache(int capacity)
+    public DefaultModelCache(int capacity) : this(capacity, DefaultEvictionPolicy)
     {
-        _capacity = capacity > 0 ? capacity : DefaultCapacity;
+    }
+
+    /// <summary>
+    /// Initializes a new cache that retains at most <paramref name="capacity"/> distinct entries,
+    /// evicting per <paramref name="evictionPolicy"/>.
+    /// </summary>
+    /// <param name="capacity">Maximum entries to keep; values &lt;= 0 fall back to <see cref="DefaultCapacity"/>.</param>
+    /// <param name="evictionPolicy">Which entry to evict once the cache is full (FIFO / LRU / LFU).</param>
+    /// <param name="enabled">When false the cache is a pass-through that never stores (always recomputes).</param>
+    public DefaultModelCache(int capacity, CacheEvictionPolicy evictionPolicy, bool enabled = true)
+    {
+        _store = new BoundedEvictingStore<OptimizationStepData<T, TInput, TOutput>>(
+            capacity > 0 ? capacity : DefaultCapacity, evictionPolicy);
+        _enabled = enabled;
     }
 
     /// <summary>
@@ -87,8 +99,7 @@ public class DefaultModelCache<T, TInput, TOutput> : IModelCache<T, TInput, TOut
     /// </remarks>
     public void ClearCache()
     {
-        _cache.Clear();
-        while (_insertionOrder.TryDequeue(out _)) { }
+        _store.Clear();
     }
 
     /// <summary>
@@ -111,8 +122,7 @@ public class DefaultModelCache<T, TInput, TOutput> : IModelCache<T, TInput, TOut
     public OptimizationStepData<T, TInput, TOutput>? GetCachedStepData(string key)
     {
         if (key == null) throw new ArgumentNullException(nameof(key), "Cache key cannot be null.");
-
-        return _cache.TryGetValue(key, out var model) ? model : null;
+        return _enabled ? _store.Get(key) : null;
     }
 
     /// <summary>
@@ -136,25 +146,7 @@ public class DefaultModelCache<T, TInput, TOutput> : IModelCache<T, TInput, TOut
     {
         if (key == null) throw new ArgumentNullException(nameof(key), "Cache key cannot be null.");
         if (stepData == null) throw new ArgumentNullException(nameof(stepData), "Step data cannot be null.");
-
-        bool isNewKey = !_cache.ContainsKey(key);
-        _cache[key] = stepData;
-
-        // Bound the cache (FIFO eviction). Only track insertion order for genuinely new keys so
-        // re-writing an existing key (an in-place update of the same entry) doesn't inflate the
-        // count. Overshoot by one transiently under concurrency is harmless — the loop trims back
-        // to capacity. A dequeued key that was already removed (or re-added) simply no-ops.
-        if (isNewKey)
-        {
-            _insertionOrder.Enqueue(key);
-            while (_cache.Count > _capacity && _insertionOrder.TryDequeue(out var oldestKey))
-            {
-                if (!string.Equals(oldestKey, key, StringComparison.Ordinal))
-                {
-                    _cache.TryRemove(oldestKey, out _);
-                }
-            }
-        }
+        if (_enabled) _store.Set(key, stepData);
     }
 
     /// <summary>

--- a/src/Deployment/Configuration/CacheConfig.cs
+++ b/src/Deployment/Configuration/CacheConfig.cs
@@ -114,4 +114,43 @@ public class CacheConfig
     /// </para>
     /// </remarks>
     public bool TrackStatistics { get; set; } = true;
+
+    // ---------------------------------------------------------------------------------------------
+    // Optimizer (training-time) caches
+    //
+    // The fields above govern the model-serving cache (loaded models kept in RAM). The fields below
+    // govern the two IN-TRAINING optimizer caches, which are a separate concern and independently
+    // tunable:
+    //   * the gradient cache (per-step gradients, DefaultGradientCache), and
+    //   * the model-evaluation cache (per-epoch fitness/step data, DefaultModelCache).
+    // These caches are numerically transparent — a miss simply recomputes the same deterministic
+    // value — so they exist purely to bound memory/time. Their defaults are the recommended values
+    // (small FIFO windows) that fix the unbounded-growth training-loop leak; raise them only if a
+    // workload legitimately re-queries older keys. When Enabled is false, both are disabled (every
+    // lookup misses and recomputes).
+    // ---------------------------------------------------------------------------------------------
+
+    /// <summary>
+    /// Maximum number of per-step gradients retained by the optimizer's gradient cache
+    /// (<c>DefaultGradientCache</c>). Default 8 — enough to cover every legitimate short-window reuse
+    /// (gradient-check double-eval, line-search / trust-region re-eval, DDP AllReduce read-back) while
+    /// keeping the footprint independent of the number of training steps. Values &lt;= 0 fall back to the default.
+    /// </summary>
+    public int GradientCacheCapacity { get; set; } = 8;
+
+    /// <summary>
+    /// Maximum number of per-evaluation step-data entries retained by the optimizer's model-evaluation
+    /// cache (<c>DefaultModelCache</c>). Default 8. Each entry retains a deep-copied model plus O(N)
+    /// predictions, so a small bound removes the per-epoch leak; a gradient optimizer never re-queries a
+    /// prior epoch's key anyway. Values &lt;= 0 fall back to the default.
+    /// </summary>
+    public int ModelCacheCapacity { get; set; } = 8;
+
+    /// <summary>
+    /// Eviction policy for BOTH optimizer caches (default: <see cref="Enums.CacheEvictionPolicy.FIFO"/>).
+    /// FIFO is recommended for training-time caches because reuse is a short consecutive window; LRU/LFU
+    /// are available for workloads that re-hit older keys. This is intentionally separate from
+    /// <see cref="EvictionPolicy"/> (which governs the serving cache and defaults to LRU).
+    /// </summary>
+    public Enums.CacheEvictionPolicy OptimizerCacheEvictionPolicy { get; set; } = Enums.CacheEvictionPolicy.FIFO;
 }

--- a/src/Optimizers/GradientBasedOptimizerBase.cs
+++ b/src/Optimizers/GradientBasedOptimizerBase.cs
@@ -1,4 +1,6 @@
 using AiDotNet.Helpers;
+using AiDotNet.Caching;
+using AiDotNet.Deployment.Configuration;
 using AiDotNet.Data.Sampling;
 using AiDotNet.Engines;
 using AiDotNet.LearningRateSchedulers;
@@ -120,6 +122,22 @@ public abstract class GradientBasedOptimizerBase<T, TInput, TOutput> : Optimizer
     /// A cache for storing and retrieving gradients to improve performance.
     /// </summary>
     protected IGradientCache<T> GradientCache;
+
+    /// <summary>
+    /// Applies a <see cref="CacheConfig"/> to this optimizer's caches. Extends the base (which handles
+    /// the model-evaluation cache) by also replacing the gradient cache with one bounded to the
+    /// configured <see cref="CacheConfig.GradientCacheCapacity"/> + <see cref="CacheConfig.OptimizerCacheEvictionPolicy"/>
+    /// (or a disabled pass-through when <see cref="CacheConfig.Enabled"/> is false).
+    /// </summary>
+    /// <param name="config">The cache configuration to apply (must not be null).</param>
+    public override void ApplyCacheConfiguration(CacheConfig config)
+    {
+        base.ApplyCacheConfiguration(config);
+        int capacity = config.GradientCacheCapacity > 0
+            ? config.GradientCacheCapacity
+            : DefaultGradientCache<T>.DefaultCapacity;
+        GradientCache = new DefaultGradientCache<T>(capacity, config.OptimizerCacheEvictionPolicy, config.Enabled);
+    }
 
     /// <summary>
     /// A method used to compare the predicted values vs the actual values.

--- a/src/Optimizers/GradientBasedOptimizerBase.cs
+++ b/src/Optimizers/GradientBasedOptimizerBase.cs
@@ -130,7 +130,7 @@ public abstract class GradientBasedOptimizerBase<T, TInput, TOutput> : Optimizer
     /// (or a disabled pass-through when <see cref="CacheConfig.Enabled"/> is false).
     /// </summary>
     /// <param name="config">The cache configuration to apply (must not be null).</param>
-    public override void ApplyCacheConfiguration(CacheConfig config)
+    internal override void ApplyCacheConfiguration(CacheConfig config)
     {
         base.ApplyCacheConfiguration(config);
         int capacity = config.GradientCacheCapacity > 0

--- a/src/Optimizers/OptimizerBase.cs
+++ b/src/Optimizers/OptimizerBase.cs
@@ -105,8 +105,9 @@ public abstract class OptimizerBase<T, TInput, TOutput> : IOptimizer<T, TInput, 
     private bool _hasObservedFitness;
 
     /// <summary>
-    /// Caches evaluated models to avoid redundant calculations. Reconfigurable post-construction via
-    /// <see cref="ApplyCacheConfiguration"/> (e.g. from the facade's <c>ConfigureCaching</c>).
+    /// Caches evaluated models to avoid redundant calculations. Reconfigured once at build time via
+    /// <see cref="ApplyCacheConfiguration"/> (the facade's <c>ConfigureCaching</c>) before any training
+    /// starts — it is not intended to be swapped concurrently with in-flight cache reads/writes.
     /// </summary>
     protected IModelCache<T, TInput, TOutput> ModelCache;
 
@@ -254,11 +255,13 @@ public abstract class OptimizerBase<T, TInput, TOutput> : IOptimizer<T, TInput, 
     /// <summary>
     /// Applies a <see cref="CacheConfig"/> to this optimizer's caches, replacing the model-evaluation
     /// cache with one bounded to the configured capacity + eviction policy (or a disabled pass-through
-    /// when <see cref="CacheConfig.Enabled"/> is false). Wired from the facade's <c>ConfigureCaching</c>.
-    /// Derived optimizers that own additional caches override this and call <c>base</c> first.
+    /// when <see cref="CacheConfig.Enabled"/> is false). Builder-only plumbing — called once from
+    /// <c>AiModelBuilder.BuildPipeline</c> (the facade's <c>ConfigureCaching</c>) before training starts,
+    /// not a public user API. Derived optimizers that own additional caches override this and call
+    /// <c>base</c> first.
     /// </summary>
     /// <param name="config">The cache configuration to apply (must not be null).</param>
-    public virtual void ApplyCacheConfiguration(CacheConfig config)
+    internal virtual void ApplyCacheConfiguration(CacheConfig config)
     {
         if (config is null) throw new ArgumentNullException(nameof(config));
         ModelCache = new DefaultModelCache<T, TInput, TOutput>(

--- a/src/Optimizers/OptimizerBase.cs
+++ b/src/Optimizers/OptimizerBase.cs
@@ -3,6 +3,7 @@ global using AiDotNet.Evaluation;
 global using AiDotNet.Models.Inputs;
 using AiDotNet.Helpers;
 using AiDotNet.Caching;
+using AiDotNet.Deployment.Configuration;
 using AiDotNet.NeuralNetworks;
 using AiDotNet.NeuralRadianceFields.Interfaces;
 using AiDotNet.Tensors.LinearAlgebra;
@@ -104,9 +105,10 @@ public abstract class OptimizerBase<T, TInput, TOutput> : IOptimizer<T, TInput, 
     private bool _hasObservedFitness;
 
     /// <summary>
-    /// Caches evaluated models to avoid redundant calculations.
+    /// Caches evaluated models to avoid redundant calculations. Reconfigurable post-construction via
+    /// <see cref="ApplyCacheConfiguration"/> (e.g. from the facade's <c>ConfigureCaching</c>).
     /// </summary>
-    protected readonly IModelCache<T, TInput, TOutput> ModelCache;
+    protected IModelCache<T, TInput, TOutput> ModelCache;
 
     /// <summary>
     /// The current learning rate used in the optimization process.
@@ -248,6 +250,20 @@ public abstract class OptimizerBase<T, TInput, TOutput> : IOptimizer<T, TInput, 
     /// <param name="inputData">The input data for the optimization process.</param>
     /// <returns>The result of the optimization process.</returns>
     public abstract OptimizationResult<T, TInput, TOutput> Optimize(OptimizationInputData<T, TInput, TOutput> inputData);
+
+    /// <summary>
+    /// Applies a <see cref="CacheConfig"/> to this optimizer's caches, replacing the model-evaluation
+    /// cache with one bounded to the configured capacity + eviction policy (or a disabled pass-through
+    /// when <see cref="CacheConfig.Enabled"/> is false). Wired from the facade's <c>ConfigureCaching</c>.
+    /// Derived optimizers that own additional caches override this and call <c>base</c> first.
+    /// </summary>
+    /// <param name="config">The cache configuration to apply (must not be null).</param>
+    public virtual void ApplyCacheConfiguration(CacheConfig config)
+    {
+        if (config is null) throw new ArgumentNullException(nameof(config));
+        ModelCache = new DefaultModelCache<T, TInput, TOutput>(
+            config.ModelCacheCapacity, config.OptimizerCacheEvictionPolicy, config.Enabled);
+    }
 
     /// <summary>
     /// Retrieves cached step data for a given solution.

--- a/tests/AiDotNet.Tests/IntegrationTests/Caching/DefaultGradientCacheIntegrationTests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/Caching/DefaultGradientCacheIntegrationTests.cs
@@ -89,8 +89,8 @@ public class DefaultGradientCacheIntegrationTests
     [Fact(Timeout = 120000)]
     public async Task Cache_MultipleKeys_EachRetrievableIndependently()
     {
-        // Arrange
-        var cache = new DefaultGradientCache<double>();
+        // Arrange - capacity sized above the working set so every key stays resident.
+        var cache = new DefaultGradientCache<double>(capacity: 200);
         var gradients = new Dictionary<string, TestGradientModel<double>>();
 
         for (int i = 0; i < 100; i++)
@@ -108,6 +108,113 @@ public class DefaultGradientCacheIntegrationTests
             Assert.NotNull(retrieved);
             Assert.Same(kvp.Value, retrieved);
         }
+    }
+
+    #endregion
+
+    #region Bounded-Capacity / Eviction Tests
+
+    // Regression guard for the managed-heap leak in the batched Optimize training
+    // loop: GradientBasedOptimizerBase.GenerateGradientCacheKey folds a per-step
+    // parameter-state fingerprint plus per-batch tensor identities into every key,
+    // so each training step produces a brand-new key that is never looked up again.
+    // With an unbounded cache the dictionary grew by one full parameter-sized
+    // gradient every step (only ever cleared by Reset(), which the training loop
+    // never calls), so per-epoch GC cost — and wall-time — climbed roughly linearly
+    // with the epoch index. The cache must therefore retain at most Capacity entries.
+
+    [Fact(Timeout = 120000)]
+    public async Task CacheGradient_ExceedingCapacity_EvictsOldestFirst()
+    {
+        // Arrange
+        const int capacity = 8;
+        var cache = new DefaultGradientCache<double>(capacity);
+
+        // Act - insert far more distinct keys than capacity (mirrors a training run
+        // where every step is a unique key).
+        const int inserted = 500;
+        for (int i = 0; i < inserted; i++)
+        {
+            cache.CacheGradient($"step_{i}", new TestGradientModel<double>(i));
+        }
+
+        // Assert - only the most recent `capacity` keys survive; everything older is evicted.
+        for (int i = 0; i < inserted - capacity; i++)
+        {
+            Assert.Null(cache.GetCachedGradient($"step_{i}"));
+        }
+        for (int i = inserted - capacity; i < inserted; i++)
+        {
+            Assert.NotNull(cache.GetCachedGradient($"step_{i}"));
+        }
+    }
+
+    [Fact(Timeout = 120000)]
+    public async Task CacheGradient_ManyUniqueKeys_DoesNotGrowUnbounded()
+    {
+        // Arrange
+        const int capacity = 16;
+        var cache = new DefaultGradientCache<double>(capacity);
+
+        // Act - a large number of unique keys, like a long training run.
+        const int steps = 100_000;
+        for (int i = 0; i < steps; i++)
+        {
+            cache.CacheGradient($"k{i}", new TestGradientModel<double>(i));
+        }
+
+        // Assert - live-entry count is bounded by capacity regardless of how many
+        // keys were inserted: everything except the last `capacity` keys is gone.
+        int survivors = 0;
+        for (int i = steps - capacity - 50; i < steps; i++)
+        {
+            if (cache.GetCachedGradient($"k{i}") is not null) survivors++;
+        }
+        Assert.Equal(capacity, survivors);
+        // Far-past keys are definitively evicted.
+        Assert.Null(cache.GetCachedGradient("k0"));
+        Assert.Null(cache.GetCachedGradient($"k{steps / 2}"));
+    }
+
+    [Fact(Timeout = 120000)]
+    public async Task CacheGradient_UpdatingSameKey_DoesNotConsumeCapacity()
+    {
+        // Arrange - repeatedly refreshing ONE key (e.g. line-search re-evaluation of
+        // the same solution) must not evict the other resident entries.
+        const int capacity = 4;
+        var cache = new DefaultGradientCache<double>(capacity);
+        cache.CacheGradient("a", new TestGradientModel<double>(1));
+        cache.CacheGradient("b", new TestGradientModel<double>(2));
+        cache.CacheGradient("c", new TestGradientModel<double>(3));
+
+        // Act - hammer key "a" many times (updates in place, no new slots).
+        for (int i = 0; i < 1000; i++)
+        {
+            cache.CacheGradient("a", new TestGradientModel<double>(100 + i));
+        }
+
+        // Assert - a, b, c all still present (updates never grew the entry count).
+        Assert.NotNull(cache.GetCachedGradient("a"));
+        Assert.NotNull(cache.GetCachedGradient("b"));
+        Assert.NotNull(cache.GetCachedGradient("c"));
+    }
+
+    [Fact(Timeout = 120000)]
+    public async Task DefaultCapacity_IsPositiveAndBounded()
+    {
+        Assert.True(DefaultGradientCache<double>.DefaultCapacity > 0);
+        var cache = new DefaultGradientCache<double>();
+        Assert.Equal(DefaultGradientCache<double>.DefaultCapacity, cache.Capacity);
+    }
+
+    [Theory(Timeout = 120000)]
+    [InlineData(0)]
+    [InlineData(-1)]
+    [InlineData(-100)]
+    public async Task Constructor_NonPositiveCapacity_Throws(int capacity)
+    {
+        var ex = Assert.Throws<ArgumentOutOfRangeException>(() => new DefaultGradientCache<double>(capacity));
+        Assert.Equal("capacity", ex.ParamName);
     }
 
     #endregion

--- a/tests/AiDotNet.Tests/IntegrationTests/Caching/DefaultGradientCacheIntegrationTests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/Caching/DefaultGradientCacheIntegrationTests.cs
@@ -18,6 +18,7 @@ public class DefaultGradientCacheIntegrationTests
     [Fact(Timeout = 120000)]
     public async Task GetCachedGradient_NonExistentKey_ReturnsNull()
     {
+        await Task.Yield();
         // Arrange
         var cache = new DefaultGradientCache<double>();
 
@@ -31,6 +32,7 @@ public class DefaultGradientCacheIntegrationTests
     [Fact(Timeout = 120000)]
     public async Task CacheGradient_ThenGet_ReturnsSameGradient()
     {
+        await Task.Yield();
         // Arrange
         var cache = new DefaultGradientCache<double>();
         var gradient = new TestGradientModel<double>(42.0);
@@ -48,6 +50,7 @@ public class DefaultGradientCacheIntegrationTests
     [Fact(Timeout = 120000)]
     public async Task CacheGradient_OverwriteExistingKey_ReturnsNewGradient()
     {
+        await Task.Yield();
         // Arrange
         var cache = new DefaultGradientCache<double>();
         var gradient1 = new TestGradientModel<double>(1.0);
@@ -67,6 +70,7 @@ public class DefaultGradientCacheIntegrationTests
     [Fact(Timeout = 120000)]
     public async Task ClearCache_RemovesAllEntries()
     {
+        await Task.Yield();
         // Arrange
         var cache = new DefaultGradientCache<double>();
         cache.CacheGradient("key1", new TestGradientModel<double>(1.0));
@@ -89,6 +93,7 @@ public class DefaultGradientCacheIntegrationTests
     [Fact(Timeout = 120000)]
     public async Task Cache_MultipleKeys_EachRetrievableIndependently()
     {
+        await Task.Yield();
         // Arrange - capacity sized above the working set so every key stays resident.
         var cache = new DefaultGradientCache<double>(capacity: 200);
         var gradients = new Dictionary<string, TestGradientModel<double>>();
@@ -126,6 +131,7 @@ public class DefaultGradientCacheIntegrationTests
     [Fact(Timeout = 120000)]
     public async Task CacheGradient_ExceedingCapacity_EvictsOldestFirst()
     {
+        await Task.Yield();
         // Arrange
         const int capacity = 8;
         var cache = new DefaultGradientCache<double>(capacity);
@@ -152,6 +158,7 @@ public class DefaultGradientCacheIntegrationTests
     [Fact(Timeout = 120000)]
     public async Task CacheGradient_ManyUniqueKeys_DoesNotGrowUnbounded()
     {
+        await Task.Yield();
         // Arrange
         const int capacity = 16;
         var cache = new DefaultGradientCache<double>(capacity);
@@ -257,6 +264,7 @@ public class DefaultGradientCacheIntegrationTests
     [Fact(Timeout = 120000)]
     public async Task CacheGradient_UpdatingSameKey_DoesNotConsumeCapacity()
     {
+        await Task.Yield();
         // Arrange - repeatedly refreshing ONE key (e.g. line-search re-evaluation of
         // the same solution) must not evict the other resident entries.
         const int capacity = 4;
@@ -280,6 +288,7 @@ public class DefaultGradientCacheIntegrationTests
     [Fact(Timeout = 120000)]
     public async Task DefaultCapacity_IsPositiveAndBounded()
     {
+        await Task.Yield();
         Assert.True(DefaultGradientCache<double>.DefaultCapacity > 0);
         var cache = new DefaultGradientCache<double>();
         Assert.Equal(DefaultGradientCache<double>.DefaultCapacity, cache.Capacity);
@@ -291,6 +300,7 @@ public class DefaultGradientCacheIntegrationTests
     [InlineData(-100)]
     public async Task Constructor_NonPositiveCapacity_Throws(int capacity)
     {
+        await Task.Yield();
         var ex = Assert.Throws<ArgumentOutOfRangeException>(() => new DefaultGradientCache<double>(capacity));
         Assert.Equal("capacity", ex.ParamName);
     }
@@ -302,6 +312,7 @@ public class DefaultGradientCacheIntegrationTests
     [Fact(Timeout = 120000)]
     public async Task ConcurrentCacheOperations_DoesNotThrow()
     {
+        await Task.Yield();
         // Arrange
         var cache = new DefaultGradientCache<double>();
         var exceptions = new List<Exception>();
@@ -350,6 +361,7 @@ public class DefaultGradientCacheIntegrationTests
     [Fact(Timeout = 120000)]
     public async Task ConcurrentReadWrite_SameKey_ThreadSafe()
     {
+        await Task.Yield();
         // Arrange
         var cache = new DefaultGradientCache<double>();
         const string sharedKey = "shared";
@@ -386,6 +398,7 @@ public class DefaultGradientCacheIntegrationTests
     [Fact(Timeout = 120000)]
     public async Task ConcurrentClearAndAccess_ThreadSafe()
     {
+        await Task.Yield();
         // Arrange
         var cache = new DefaultGradientCache<double>();
         var exceptions = new List<Exception>();
@@ -431,6 +444,7 @@ public class DefaultGradientCacheIntegrationTests
     [Fact(Timeout = 120000)]
     public async Task CacheGradient_EmptyKey_StoresSuccessfully()
     {
+        await Task.Yield();
         // Arrange
         var cache = new DefaultGradientCache<double>();
         var gradient = new TestGradientModel<double>(1.0);
@@ -446,6 +460,7 @@ public class DefaultGradientCacheIntegrationTests
     [Fact(Timeout = 120000)]
     public async Task CacheGradient_VeryLongKey_StoresSuccessfully()
     {
+        await Task.Yield();
         // Arrange
         var cache = new DefaultGradientCache<double>();
         var gradient = new TestGradientModel<double>(1.0);
@@ -462,6 +477,7 @@ public class DefaultGradientCacheIntegrationTests
     [Fact(Timeout = 120000)]
     public async Task CacheGradient_SpecialCharactersInKey_StoresSuccessfully()
     {
+        await Task.Yield();
         // Arrange
         var cache = new DefaultGradientCache<double>();
         var gradient = new TestGradientModel<double>(1.0);
@@ -478,6 +494,7 @@ public class DefaultGradientCacheIntegrationTests
     [Fact(Timeout = 120000)]
     public async Task ClearCache_OnEmptyCache_DoesNotThrow()
     {
+        await Task.Yield();
         // Arrange
         var cache = new DefaultGradientCache<double>();
 
@@ -489,6 +506,7 @@ public class DefaultGradientCacheIntegrationTests
     [Fact(Timeout = 120000)]
     public async Task ClearCache_CalledMultipleTimes_DoesNotThrow()
     {
+        await Task.Yield();
         // Arrange
         var cache = new DefaultGradientCache<double>();
         cache.CacheGradient("key", new TestGradientModel<double>(1.0));
@@ -506,6 +524,7 @@ public class DefaultGradientCacheIntegrationTests
     [Fact(Timeout = 120000)]
     public async Task GetCachedGradient_NullKey_ThrowsArgumentNullException()
     {
+        await Task.Yield();
         // Arrange
         var cache = new DefaultGradientCache<double>();
 
@@ -517,6 +536,7 @@ public class DefaultGradientCacheIntegrationTests
     [Fact(Timeout = 120000)]
     public async Task CacheGradient_NullKey_ThrowsArgumentNullException()
     {
+        await Task.Yield();
         // Arrange
         var cache = new DefaultGradientCache<double>();
         var gradient = new TestGradientModel<double>(1.0);
@@ -529,6 +549,7 @@ public class DefaultGradientCacheIntegrationTests
     [Fact(Timeout = 120000)]
     public async Task CacheGradient_NullGradient_ThrowsArgumentNullException()
     {
+        await Task.Yield();
         // Arrange
         var cache = new DefaultGradientCache<double>();
 
@@ -544,6 +565,7 @@ public class DefaultGradientCacheIntegrationTests
     [Fact(Timeout = 120000)]
     public async Task GradientCache_FloatType_WorksCorrectly()
     {
+        await Task.Yield();
         // Arrange
         var cache = new DefaultGradientCache<float>();
         var gradient = new TestGradientModel<float>(3.14f);
@@ -559,6 +581,7 @@ public class DefaultGradientCacheIntegrationTests
     [Fact(Timeout = 120000)]
     public async Task GradientCache_DecimalType_WorksCorrectly()
     {
+        await Task.Yield();
         // Arrange
         var cache = new DefaultGradientCache<decimal>();
         var gradient = new TestGradientModel<decimal>(3.14159265359m);

--- a/tests/AiDotNet.Tests/IntegrationTests/Caching/DefaultGradientCacheIntegrationTests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/Caching/DefaultGradientCacheIntegrationTests.cs
@@ -176,6 +176,84 @@ public class DefaultGradientCacheIntegrationTests
         Assert.Null(cache.GetCachedGradient($"k{steps / 2}"));
     }
 
+    #endregion
+
+    #region Eviction Policy + Customization
+
+    [Fact(Timeout = 120000)]
+    public async Task Constructor_CapacityAndPolicy_AreExposed()
+    {
+        await Task.Yield();
+        var cache = new DefaultGradientCache<double>(4, AiDotNet.Enums.CacheEvictionPolicy.LRU);
+
+        Assert.Equal(4, cache.Capacity);
+        Assert.Equal(AiDotNet.Enums.CacheEvictionPolicy.LRU, cache.EvictionPolicy);
+        Assert.True(cache.Enabled);
+    }
+
+    [Fact(Timeout = 120000)]
+    public async Task DefaultEvictionPolicy_IsFifo()
+    {
+        await Task.Yield();
+        Assert.Equal(AiDotNet.Enums.CacheEvictionPolicy.FIFO, new DefaultGradientCache<double>().EvictionPolicy);
+    }
+
+    [Fact(Timeout = 120000)]
+    public async Task LruPolicy_EvictsLeastRecentlyUsed()
+    {
+        await Task.Yield();
+        var cache = new DefaultGradientCache<double>(3, AiDotNet.Enums.CacheEvictionPolicy.LRU);
+        cache.CacheGradient("k0", new TestGradientModel<double>(0));
+        cache.CacheGradient("k1", new TestGradientModel<double>(1));
+        cache.CacheGradient("k2", new TestGradientModel<double>(2));
+
+        // Touch k0 so it becomes most-recently-used; k1 is now the least-recently-used.
+        Assert.NotNull(cache.GetCachedGradient("k0"));
+
+        // Inserting a 4th key evicts the LRU victim (k1), not the oldest-inserted (k0).
+        cache.CacheGradient("k3", new TestGradientModel<double>(3));
+
+        Assert.Null(cache.GetCachedGradient("k1"));      // least-recently-used → evicted
+        Assert.NotNull(cache.GetCachedGradient("k0"));   // recently touched → retained
+        Assert.NotNull(cache.GetCachedGradient("k2"));
+        Assert.NotNull(cache.GetCachedGradient("k3"));
+    }
+
+    [Fact(Timeout = 120000)]
+    public async Task LfuPolicy_EvictsLeastFrequentlyUsed()
+    {
+        await Task.Yield();
+        var cache = new DefaultGradientCache<double>(3, AiDotNet.Enums.CacheEvictionPolicy.LFU);
+        cache.CacheGradient("k0", new TestGradientModel<double>(0));
+        cache.CacheGradient("k1", new TestGradientModel<double>(1));
+        cache.CacheGradient("k2", new TestGradientModel<double>(2));
+
+        // Raise use counts: k0 used most, k1 once, k2 not at all.
+        cache.GetCachedGradient("k0");
+        cache.GetCachedGradient("k0");
+        cache.GetCachedGradient("k1");
+
+        // A 4th key evicts the least-frequently-used (k2), leaving the hot keys.
+        cache.CacheGradient("k3", new TestGradientModel<double>(3));
+
+        Assert.Null(cache.GetCachedGradient("k2"));      // never re-used → evicted
+        Assert.NotNull(cache.GetCachedGradient("k0"));
+        Assert.NotNull(cache.GetCachedGradient("k1"));
+        Assert.NotNull(cache.GetCachedGradient("k3"));
+    }
+
+    [Fact(Timeout = 120000)]
+    public async Task Disabled_Cache_IsPassThrough()
+    {
+        await Task.Yield();
+        var cache = new DefaultGradientCache<double>(8, AiDotNet.Enums.CacheEvictionPolicy.FIFO, enabled: false);
+
+        cache.CacheGradient("k", new TestGradientModel<double>(1));
+
+        Assert.False(cache.Enabled);
+        Assert.Null(cache.GetCachedGradient("k")); // stores are dropped → always a miss (recompute)
+    }
+
     [Fact(Timeout = 120000)]
     public async Task CacheGradient_UpdatingSameKey_DoesNotConsumeCapacity()
     {

--- a/tests/AiDotNet.Tests/IntegrationTests/Caching/DefaultModelCacheIntegrationTests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/Caching/DefaultModelCacheIntegrationTests.cs
@@ -475,4 +475,37 @@ public class DefaultModelCacheIntegrationTests
     }
 
     #endregion
+
+    #region Eviction Policy + Config Customization
+
+    [Fact(Timeout = 120000)]
+    public async Task Constructor_PolicyAndEnabled_AreHonored()
+    {
+        await Task.Yield();
+        var cache = new DefaultModelCache<double, Matrix<double>, Vector<double>>(
+            3, AiDotNet.Enums.CacheEvictionPolicy.LRU, enabled: false);
+
+        Assert.Equal(3, cache.Capacity);
+        Assert.Equal(AiDotNet.Enums.CacheEvictionPolicy.LRU, cache.EvictionPolicy);
+        Assert.False(cache.Enabled);
+
+        // Disabled → pass-through: stores are dropped, lookups always miss.
+        cache.CacheStepData("k", CreateStepData());
+        Assert.Null(cache.GetCachedStepData("k"));
+    }
+
+    [Fact(Timeout = 120000)]
+    public async Task CacheConfig_OptimizerCacheDefaults_AreRecommended()
+    {
+        await Task.Yield();
+        var config = new AiDotNet.Deployment.Configuration.CacheConfig();
+
+        // The recommended training-cache defaults that fix the unbounded-growth training-loop leak.
+        Assert.Equal(8, config.GradientCacheCapacity);
+        Assert.Equal(8, config.ModelCacheCapacity);
+        Assert.Equal(AiDotNet.Enums.CacheEvictionPolicy.FIFO, config.OptimizerCacheEvictionPolicy);
+        Assert.True(config.Enabled);
+    }
+
+    #endregion
 }


### PR DESCRIPTION
## Problem

Facade training (`AiModelBuilder.BuildAsync` → `AdamOptimizer.Optimize` → per-batch `CalculateGradient`) leaks managed heap linearly with the number of training steps, so **per-epoch wall-time grows roughly linearly with the epoch index** instead of staying flat.

Root cause: `GradientBasedOptimizerBase.GenerateGradientCacheKey` folds a per-step **parameter-state fingerprint** *and* the per-batch input/target **reference identities** into every gradient-cache key. In the batched `Optimize` loop every mini-batch step therefore produces a brand-new key that is never looked up again (the parameters have already moved on by the next step). `DefaultGradientCache` stored each entry in an **unbounded** `ConcurrentDictionary<string, IGradientModel<T>>` that is only ever emptied by `Reset()` — which the training loop never calls. The cache grew by one full parameter-sized gradient `Vector<T>` **every step**; the growing live set made each epoch's GC progressively more expensive.

## Reproduction

Facade `BuildAsync`, CPU engine, tiny transformer (d=64, heads=4, ff=128, ctx=8, V=32), batch=32, 2000 samples, 10 epochs:

| | epoch 1 | epoch 10 | heap (e1 → last) |
|---|---|---|---|
| **L=2 before** | 7.95s | **42.81s** | 229MB → **2259MB** |
| **L=8 before** | 15.4s | climbing to 90s+ | → **4.7GB+** |

## Fix

Give `DefaultGradientCache` a **bounded capacity** (default 8) with oldest-first (FIFO) eviction. Numerically transparent: a cache **hit** returns the identical gradient that would otherwise be recomputed, and a **miss** (evicted entry) simply recomputes that same deterministic gradient. The legitimate short-window reuse the cache exists for — numerical gradient-check double-evaluation, line-search / trust-region re-evaluation, DDP AllReduce read-back — all reuse a key within a handful of consecutive calls, well inside the retained window, so they still hit. Updating an existing key swaps the payload in place and does not consume a new slot.

### After fix (same repro)

| | epoch 1 | epoch 2–10 | heap | total |
|---|---|---|---|---|
| **L=2 after** | 4.98s (JIT warmup) | **~1.5–1.8s (flat)** | oscillates 28–292MB, no trend | 250s → **19.6s** |
| **L=8 after** | 5.49s | **~5.2–5.5s (flat)** | flat 100–580MB | → **53.4s** |

Per-epoch time is flat (epoch 10 ≈ epoch 2) and heap plateaus.

## Numerics unchanged

Verified **bit-identical** before/after on a seeded facade training run — trained-parameter checksum (`sum=163.5277290899212`, `absSum=4006.7189840424508`) and prediction checksum (`sum=500.0000004383037`) match to all printed digits between the unbounded and bounded builds.

## Tests

`DefaultGradientCacheIntegrationTests` extended with eviction / bounded-growth / capacity-validation cases (the existing multi-key test now constructs an explicit large-capacity cache). **25/25 pass on net10.0.**

---

## Update — full cache customization + `ConfigureCaching` wiring

The original change bounded `DefaultGradientCache` at a fixed capacity. This extends it to make **both** in-training optimizer caches (gradient + model-evaluation) fully user-customizable, with the leak-fix recommendations (**capacity 8, FIFO**) as the defaults — and fixes the missing wiring so the facade's `ConfigureCaching` actually controls them.

### The gap it fixes
`AiModelBuilder.ConfigureCaching(CacheConfig)` existed but the `CacheConfig` was **orphaned** — nothing consumed it, so the bounded gradient/model caches always ran at their built-in defaults. (`CacheConfig` was only referenced by the YAML doc/schema generators.)

### Changes
- **`BoundedEvictingStore<TValue>`** — one shared, thread-safe bounded store with **FIFO / LRU / LFU** eviction. Both caches delegate to it, so the eviction logic isn't re-implemented per cache.
- **`DefaultGradientCache` / `DefaultModelCache`** — refactored onto the shared store. Both now take `(capacity, evictionPolicy, enabled)` and expose `Capacity` / `EvictionPolicy` / `Enabled`. A **disabled** cache is a numerically-transparent pass-through (every lookup misses → recompute). Existing ctors/behavior (incl. the FIFO default and the non-positive-capacity throw) are preserved.
- **`CacheConfig`** — added dedicated training-cache fields: `GradientCacheCapacity` (8), `ModelCacheCapacity` (8), `OptimizerCacheEvictionPolicy` (FIFO). Kept **separate** from the serving-cache `MaxCacheSize` / `EvictionPolicy` so the two are independently tunable.
- **`OptimizerBase.ApplyCacheConfiguration(CacheConfig)`** + a `GradientBasedOptimizerBase` override (adds the gradient cache). The facade `BuildPipeline` applies the config to the chosen optimizer at build time — the same runtime-swap pattern already used for `ConfigureRegularization`.

### Usage
```csharp
builder.ConfigureCaching(new CacheConfig
{
    GradientCacheCapacity = 32,
    ModelCacheCapacity = 4,
    OptimizerCacheEvictionPolicy = CacheEvictionPolicy.LRU,
    // Enabled = false   // fully disable the training caches (always recompute)
});
```
Omitting `ConfigureCaching` (or leaving the fields at their defaults) keeps the recommended cap-8 / FIFO behavior that fixes the leak.

### Tests
`DefaultGradientCacheIntegrationTests` + `DefaultModelCacheIntegrationTests` extended with LRU / LFU eviction, disabled pass-through, capacity/policy exposure, and the recommended `CacheConfig` defaults. **53/53 cache tests pass on net10.0.**


🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable, bounded caching with eviction options for training-time caches.
  * Added cache settings to control capacity, eviction policy, and whether caching is enabled.
  * Training now respects configured cache settings during optimization.

* **Bug Fixes**
  * Caching behavior now correctly uses the configured limits instead of defaulting to unbounded storage.
  * Cache disablement now behaves as a pass-through mode, with no stored entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->