### PR TITLE
ci: skip PR checks on release-please release PRs

### DIFF
--- a/.github/workflows/ci-website.yml
+++ b/.github/workflows/ci-website.yml
@@ -18,6 +18,7 @@ concurrency:
 
 jobs:
   build:
+    if: ${{ !startsWith(github.head_ref, 'release-please--') }}
     name: Build & Validate
     runs-on: ubuntu-latest
     defaults:

--- a/.github/workflows/codacy.yml
+++ b/.github/workflows/codacy.yml
@@ -36,7 +36,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     # Skip draft PRs
-    if: github.event.pull_request.draft != true
+    if: ${{ (github.event.pull_request.draft != true) && !startsWith(github.head_ref, 'release-please--') }}
     permissions:
       contents: read
       security-events: write

--- a/.github/workflows/commitlint-fix.yml
+++ b/.github/workflows/commitlint-fix.yml
@@ -18,7 +18,7 @@ jobs:
     name: Check and Fix Non-Compliant Commits
     runs-on: ubuntu-latest
     # Skip for dependabot PRs (they have special handling)
-    if: github.actor != 'dependabot[bot]'
+    if: ${{ (github.actor != 'dependabot[bot]') && !startsWith(github.head_ref, 'release-please--') }}
 
     steps:
       - name: Checkout code
@@ -247,7 +247,7 @@ jobs:
     name: Handle Dependabot PR
     runs-on: ubuntu-latest
     # Only run for dependabot PRs
-    if: github.actor == 'dependabot[bot]'
+    if: ${{ (github.actor == 'dependabot[bot]') && !startsWith(github.head_ref, 'release-please--') }}
 
     steps:
       - name: Checkout code

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -9,6 +9,7 @@ concurrency:
 
 jobs:
   commitlint:
+    if: ${{ !startsWith(github.head_ref, 'release-please--') }}
     runs-on: ubuntu-latest
     steps:
       - name: Check out the PR

--- a/.github/workflows/copilot-review-gate.yml
+++ b/.github/workflows/copilot-review-gate.yml
@@ -14,6 +14,7 @@ permissions:
 
 jobs:
   gate:
+    if: ${{ !startsWith(github.head_ref, 'release-please--') }}
     runs-on: ubuntu-latest
     steps:
       - name: Check unresolved Copilot review threads

--- a/.github/workflows/docs-wiki.yml
+++ b/.github/workflows/docs-wiki.yml
@@ -31,6 +31,7 @@ concurrency:
 
 jobs:
   generate-and-gate:
+    if: ${{ !startsWith(github.head_ref, 'release-please--') }}
     name: Generate wiki + compile-check snippets
     runs-on: ubuntu-latest
     timeout-minutes: 45

--- a/.github/workflows/pr-title-lint.yml
+++ b/.github/workflows/pr-title-lint.yml
@@ -14,6 +14,7 @@ permissions:
 
 jobs:
   auto-fix-pr-title:
+    if: ${{ !startsWith(github.head_ref, 'release-please--') }}
     name: Auto-Fix PR Title
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/samples.yml
+++ b/.github/workflows/samples.yml
@@ -22,6 +22,7 @@ permissions:
 
 jobs:
   build-and-run:
+    if: ${{ !startsWith(github.head_ref, 'release-please--') }}
     name: Build & run samples
     runs-on: ubuntu-latest
     timeout-minutes: 45

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -127,7 +127,7 @@ jobs:
     name: CodeQL Analysis
     runs-on: ubuntu-latest
     timeout-minutes: 20
-    if: github.event.pull_request.draft != true
+    if: ${{ (github.event.pull_request.draft != true) && !startsWith(github.head_ref, 'release-please--') }}
     permissions:
       contents: read
       security-events: write
@@ -211,7 +211,7 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     timeout-minutes: 45
-    if: github.event.pull_request.draft != true
+    if: ${{ (github.event.pull_request.draft != true) && !startsWith(github.head_ref, 'release-please--') }}
 
     steps:
       - name: Checkout code
@@ -291,7 +291,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     timeout-minutes: 45
-    if: github.event.pull_request.draft != true
+    if: ${{ (github.event.pull_request.draft != true) && !startsWith(github.head_ref, 'release-please--') }}
     strategy:
       fail-fast: false
       matrix:
@@ -1113,7 +1113,7 @@ jobs:
     name: SonarCloud Analysis
     runs-on: ubuntu-latest
     timeout-minutes: 45
-    if: github.event.pull_request.draft != true
+    if: ${{ (github.event.pull_request.draft != true) && !startsWith(github.head_ref, 'release-please--') }}
     needs:
       - build
       - test-net10-sharded
@@ -1237,6 +1237,7 @@ jobs:
 
   # Artifact size analysis
   size-check:
+    if: ${{ !startsWith(github.head_ref, 'release-please--') }}
     name: Artifact Size Check
     runs-on: ubuntu-latest
     needs: build


### PR DESCRIPTION
## Problem
A feature PR passes the full CI (sonarcloud integration shards, codacy, commitlint, samples, etc.), then release-please opens a **Release PR** that only bumps the version + updates `CHANGELOG.md`/manifest — and that Release PR **re-runs the exact same checks**, which can't fail on a version/changelog-only diff.

## Fix
Guard every PR-triggered job across the check workflows with:
```yaml
!startsWith(github.head_ref, 'release-please--')
```
merged into each job's existing `if:` where one exists (e.g. sonarcloud's `draft != true`, commitlint-fix's dependabot split).
- **Release-please PR** → all jobs skip.
- **Normal PRs / pushes** → unaffected (`head_ref` is empty on push).

Workflows touched: `sonarcloud`, `codacy`, `commitlint`, `commitlint-fix`, `copilot-review-gate`, `ci-website`, `docs-wiki`, `pr-title-lint`, `samples`. (`cancel-on-pr-close` left alone — it's cleanup, not a check.)

## Why it's safe
- `master` is **unprotected** (no required status checks), so skipped checks don't block the Release PR.
- `release-please.yml` rebuilds/publishes from the tag at release time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)