### PR TITLE
chore: credit-rule zoo: Kolen-Pollack, Direct-KP, DRTP, Normalized-DFA + fix zero-hidden-gradient bug

### DIFF
--- a/src/Enums/CreditRule.cs
+++ b/src/Enums/CreditRule.cs
@@ -45,4 +45,38 @@ public enum CreditRule
     /// FA/DFA the feedback tracks the live weight signs each step rather than being fixed at random.
     /// </summary>
     SignSymmetric = 3,
+
+    /// <summary>
+    /// <b>Kolen-Pollack (KP)</b> — Kolen &amp; Pollack, 1994; Akrout et al., 2019 ("Deep Learning without Weight
+    /// Transport"). Sequential feedback like FA, but the feedback matrices are <i>learned</i> rather than fixed:
+    /// each step every feedback matrix receives the same outer-product increment (plus weight decay) that its
+    /// forward weight receives, so the feedback converges to the transpose of the forward weight and credit
+    /// assignment approaches back-propagation quality. Unlike FA/DFA this closes the alignment gap on deep nets.
+    /// </summary>
+    KolenPollack = 4,
+
+    /// <summary>
+    /// <b>Direct Kolen-Pollack (DKP)</b> — Kolen-Pollack learning applied in the Direct Feedback Alignment
+    /// topology: the global output error is projected directly onto every hidden layer through per-layer
+    /// feedback matrices, but those matrices are <i>learned</i> (each aligns to the effective forward Jacobian
+    /// from its layer to the output) rather than fixed at random. Combines DFA's parallel/attention-friendly
+    /// routing with KP's learned alignment.
+    /// </summary>
+    DirectKolenPollack = 5,
+
+    /// <summary>
+    /// <b>Direct Random Target Projection (DRTP)</b> — Frenkel, Lefebvre &amp; Bol, 2021 ("Learning without
+    /// Feedback"). Each hidden layer's teaching signal is a <i>fixed random projection of the one-hot target</i>
+    /// (not of the output error). Requires no backward error signal at all, making it the most hardware-friendly
+    /// of the family; the target's sign supplies a valid descent direction on average.
+    /// </summary>
+    DRTP = 6,
+
+    /// <summary>
+    /// <b>Normalized Direct Feedback Alignment</b> — Launay et al., 2020 style. Vanilla DFA with per-layer
+    /// normalization of the feedback projection so the teaching-signal magnitude stays stable across depth
+    /// (the feedback columns are unit-normalized and each layer's teaching signal is rescaled to the output
+    /// error's per-sample magnitude). This is the DFA variant intended to train deep / Transformer networks.
+    /// </summary>
+    DFANormalized = 7,
 }

--- a/src/Interfaces/ICreditRule.cs
+++ b/src/Interfaces/ICreditRule.cs
@@ -91,6 +91,34 @@ public interface ICreditAssignmentContext<T>
 
     /// <summary>A deterministic random source the rule may use to build fixed feedback matrices, for reproducibility.</summary>
     Random Random { get; }
+
+    /// <summary>
+    /// The training target aligned to the prediction shape <c>[batchSize, outputFeatures]</c> — a one-hot matrix
+    /// for classification, or the raw regression target. Related to <see cref="OutputError"/> by
+    /// <c>OutputError = prediction − Target</c>. Used by target-driven rules such as Direct Random Target
+    /// Projection (DRTP), which project the target rather than the error.
+    /// </summary>
+    Tensor<T> Target { get; }
+}
+
+/// <summary>
+/// Optional extension of <see cref="ICreditRule{T}"/> for rules whose feedback state is <b>learned</b> across
+/// training steps (e.g. Kolen-Pollack and Direct Kolen-Pollack, whose feedback matrices are updated each step to
+/// align with the forward weights). The training engine calls <see cref="OnParametersUpdated"/> once per gradient
+/// computation, after the step's teaching signals and gradients have been produced, while the per-layer forward
+/// activations are still available on the context. Rules with fixed (non-learned) feedback do not implement this
+/// interface, so existing rules are entirely unaffected.
+/// </summary>
+/// <typeparam name="T">The numeric data type.</typeparam>
+public interface IFeedbackLearningRule<T> : ICreditRule<T>
+{
+    /// <summary>
+    /// Updates the rule's learned feedback state for this training step, using the same context (forward
+    /// activations, output error and teaching signals) that produced the step's gradients. Invoked once per
+    /// gradient computation. Must not mutate the network's forward weights.
+    /// </summary>
+    /// <param name="context">The credit-assignment context for the just-computed step.</param>
+    void OnParametersUpdated(ICreditAssignmentContext<T> context);
 }
 
 /// <summary>
@@ -114,6 +142,14 @@ public interface ICreditLayer<T>
 
     /// <summary>The layer's forward output tensor for this step (available if a rule needs the activations; most rules use only shapes).</summary>
     Tensor<T> Output { get; }
+
+    /// <summary>
+    /// The tensor fed <i>into</i> this layer's forward pass for this step — the activation from the previous
+    /// (sub-)layer, shaped like this layer's input. Feedback-learning rules such as Kolen-Pollack need it to form
+    /// the outer-product update <c>Δfeedback ∝ teachingSignalᵀ · input</c> that aligns a learned feedback matrix to
+    /// the forward weight. Fixed-feedback rules can ignore it.
+    /// </summary>
+    Tensor<T> Input { get; }
 
     /// <summary>
     /// The layer's weight matrix (shape <c>[outputDim, inputDim]</c>) if it exposes a single one (dense layers),

--- a/src/NeuralNetworks/CreditAssignment/CreditAssignmentContext.cs
+++ b/src/NeuralNetworks/CreditAssignment/CreditAssignmentContext.cs
@@ -9,10 +9,11 @@ namespace AiDotNet.NeuralNetworks.CreditAssignment;
 /// </summary>
 internal sealed class CreditLayer<T> : ICreditLayer<T>
 {
-    internal CreditLayer(int index, bool isOutputLayer, Tensor<T> output, Matrix<T>? weights)
+    internal CreditLayer(int index, bool isOutputLayer, Tensor<T> input, Tensor<T> output, Matrix<T>? weights)
     {
         Index = index;
         IsOutputLayer = isOutputLayer;
+        Input = input;
         Output = output;
         OutputShape = output.Shape.ToArray();
         Weights = weights;
@@ -27,6 +28,7 @@ internal sealed class CreditLayer<T> : ICreditLayer<T>
     public bool IsOutputLayer { get; }
     public int[] OutputShape { get; }
     public int FlatFeatureSize { get; }
+    public Tensor<T> Input { get; }
     public Tensor<T> Output { get; }
     public Matrix<T>? Weights { get; }
     public Tensor<T>? TeachingSignal { get; set; }
@@ -40,17 +42,20 @@ internal sealed class CreditAssignmentContext<T> : ICreditAssignmentContext<T>
     internal CreditAssignmentContext(
         IReadOnlyList<ICreditLayer<T>> layers,
         Tensor<T> outputError,
+        Tensor<T> target,
         INumericOperations<T> numOps,
         Random random)
     {
         Layers = layers;
         OutputError = outputError;
+        Target = target;
         NumOps = numOps;
         Random = random;
     }
 
     public IReadOnlyList<ICreditLayer<T>> Layers { get; }
     public Tensor<T> OutputError { get; }
+    public Tensor<T> Target { get; }
     public int BatchSize => OutputError.Shape[0];
     public INumericOperations<T> NumOps { get; }
     public Random Random { get; }

--- a/src/NeuralNetworks/CreditAssignment/CreditAssignmentGradientComputer.cs
+++ b/src/NeuralNetworks/CreditAssignment/CreditAssignmentGradientComputer.cs
@@ -50,41 +50,48 @@ internal static class CreditAssignmentGradientComputer<T>
                 "CategoricalCrossEntropyLoss or MeanSquaredErrorLoss).");
         }
 
-        IEngine engine = AiDotNetEngine.Current;
         var layers = network.Layers;
         bool prevTrainingMode = network.IsTrainingMode;
         network.SetTrainingMode(true);
 
         try
         {
-            using var tape = new GradientTape<T>();
-
-            // Forward pass under the tape, capturing each layer's output node.
-            var outputs = new Tensor<T>[layers.Count];
-            var current = input;
-            for (int i = 0; i < layers.Count; i++)
-            {
-                current = layers[i].Forward(current);
-                outputs[i] = current;
-            }
-            var predictionNode = current; // final (post-softmax) network output, tracked
-
-            // Constant output error e = prediction - target (detached from the tape).
-            var predConst = Detach(predictionNode);
-            var targetTensor = BuildTargetTensor(target, predConst.Shape.ToArray());
-            var outputError = SubtractConst(predConst, targetTensor);
-
-            // Collect the trainable layers (those with at least one trainable parameter tensor), in order.
+            // ---- Capture pass: run the full forward once to identify the trainable layers, each layer's input
+            // activation, and the network's output error. Values are detached to constants; graph is discarded.
             var trainableLayers = new List<ILayer<T>>();
             var trainableParams = new List<IReadOnlyList<Tensor<T>>>();
-            var trainableOutputs = new List<Tensor<T>>();
-            for (int i = 0; i < layers.Count; i++)
+            var trainableInputs = new List<Tensor<T>>();   // detached (constant) input to each trainable layer
+            var trainableOutputs = new List<Tensor<T>>();  // detached (constant) output of each trainable layer
+            var trainableLayerIndex = new List<int>();      // index into `layers` of each trainable layer
+            Tensor<T> targetTensor;
+            Tensor<T> outputError;
+
+            using (var captureTape = new GradientTape<T>())
             {
-                var ps = CollectParameters(layers[i]);
-                if (ps.Count == 0) continue;
-                trainableLayers.Add(layers[i]);
-                trainableParams.Add(ps);
-                trainableOutputs.Add(outputs[i]);
+                var inputs = new Tensor<T>[layers.Count];
+                var outputs = new Tensor<T>[layers.Count];
+                var current = input;
+                for (int i = 0; i < layers.Count; i++)
+                {
+                    inputs[i] = current;
+                    current = layers[i].Forward(current);
+                    outputs[i] = current;
+                }
+
+                var predConst = Detach(current);
+                targetTensor = BuildTargetTensor(target, predConst.Shape.ToArray());
+                outputError = SubtractConst(predConst, targetTensor);
+
+                for (int i = 0; i < layers.Count; i++)
+                {
+                    var ps = CollectParameters(layers[i]);
+                    if (ps.Count == 0) continue;
+                    trainableLayers.Add(layers[i]);
+                    trainableParams.Add(ps);
+                    trainableInputs.Add(Detach(inputs[i]));
+                    trainableOutputs.Add(Detach(outputs[i]));
+                    trainableLayerIndex.Add(i);
+                }
             }
 
             if (trainableLayers.Count == 0)
@@ -101,32 +108,71 @@ internal static class CreditAssignmentGradientComputer<T>
                 creditLayers.Add(new CreditLayer<T>(
                     index: k,
                     isOutputLayer: isOutput,
+                    input: trainableInputs[k],
                     output: trainableOutputs[k],
                     weights: TryGetWeightMatrix(trainableLayers[k])));
             }
 
-            var context = new CreditAssignmentContext<T>(creditLayers, outputError, Ops, random);
+            var context = new CreditAssignmentContext<T>(creditLayers, outputError, targetTensor, Ops, random);
             rule.Initialize(context);
             rule.ComputeTeachingSignals(context);
 
-            var grads = new Dictionary<Tensor<T>, Tensor<T>>();
+            int last = trainableLayers.Count - 1;
+
+            // ---- Gradient pass: a SINGLE combined objective backpropagated once. The teaching-driven design needs
+            // each trainable layer's gradient to be a LOCAL VJP (its output treated as a function of only its own
+            // parameters). We achieve that by re-running the forward and DETACHING the input immediately before each
+            // trainable layer, so that layer's output depends on nothing below it. The objective is
+            //     loss(prediction)  +  Σ_hidden  sum(output_k ⊙ teachingSignal_k)
+            // whose gradient w.r.t. each layer's parameters is exactly that layer's intended update: the exact loss
+            // gradient for the output layer, the teaching-driven VJP for every hidden layer, with no cross-layer
+            // leakage. A single backward pass is required because GradientTape is single-use — one backward frees
+            // the graph, so calling it once per layer silently zeroed every layer after the first.
+            var isTrainable = new bool[layers.Count];
+            var trainOrderOf = new int[layers.Count];
+            for (int t = 0; t < trainableLayerIndex.Count; t++)
+            {
+                isTrainable[trainableLayerIndex[t]] = true;
+                trainOrderOf[trainableLayerIndex[t]] = t;
+            }
+
+            using var tape = new GradientTape<T>();
+            IEngine engine = AiDotNetEngine.Current; // the tape's recording engine (installed for this scope)
+
+            var trainOutputNode = new Tensor<T>[trainableLayers.Count];
+            var current2 = input;
+            for (int i = 0; i < layers.Count; i++)
+            {
+                if (isTrainable[i])
+                    current2 = Detach(current2); // isolate this trainable layer's params from everything below
+                current2 = layers[i].Forward(current2);
+                if (isTrainable[i])
+                    trainOutputNode[trainOrderOf[i]] = current2;
+            }
+            var predictionNode = current2;
 
             // Output layer: exact loss gradient (handles the softmax head + matched loss correctly).
-            var lossTensor = tapeLoss.ComputeTapeLoss(predictionNode, targetTensor);
-            Merge(grads, tape.ComputeGradients(lossTensor, sources: trainableParams[trainableLayers.Count - 1]));
+            Tensor<T> combined = ReduceToScalar(engine, tapeLoss.ComputeTapeLoss(predictionNode, targetTensor));
+            var allSources = new List<Tensor<T>>(trainableParams[last]);
 
-            // Hidden layers: local VJP seeded by the rule's teaching signal.
-            for (int k = 0; k < trainableLayers.Count - 1; k++)
+            // Hidden layers: teaching-driven local VJP, seeded by the rule's teaching signal.
+            for (int k = 0; k < last; k++)
             {
                 var teaching = creditLayers[k].TeachingSignal
                     ?? throw new InvalidOperationException(
                         $"Credit rule '{rule.Name}' did not set a teaching signal for hidden layer {k}.");
-
-                var prod = engine.TensorMultiply(trainableOutputs[k], teaching);
-                var allAxes = Enumerable.Range(0, prod.Shape.Length).ToArray();
-                var scalar = engine.ReduceSum(prod, allAxes, keepDims: false);
-                Merge(grads, tape.ComputeGradients(scalar, sources: trainableParams[k]));
+                var prod = engine.TensorMultiply(trainOutputNode[k], teaching);
+                combined = engine.TensorAdd(combined, ReduceToScalar(engine, prod));
+                allSources.AddRange(trainableParams[k]);
             }
+
+            var grads = new Dictionary<Tensor<T>, Tensor<T>>();
+            Merge(grads, tape.ComputeGradients(combined, sources: allSources));
+
+            // Feedback-learning rules (Kolen-Pollack / Direct Kolen-Pollack) update their learned feedback state
+            // once per step, using the same activations, output error and teaching signals just consumed above.
+            if (rule is IFeedbackLearningRule<T> feedbackLearner)
+                feedbackLearner.OnParametersUpdated(context);
 
             return Flatten(network, grads);
         }
@@ -142,6 +188,14 @@ internal static class CreditAssignmentGradientComputer<T>
     {
         foreach (var kv in from)
             into[kv.Key] = kv.Value;
+    }
+
+    /// <summary>Reduces a tensor to a single scalar (sum over every axis) so heterogeneous terms can be added into one objective.</summary>
+    private static Tensor<T> ReduceToScalar(IEngine engine, Tensor<T> t)
+    {
+        if (t.Shape.Length == 0) return t;
+        var axes = Enumerable.Range(0, t.Shape.Length).ToArray();
+        return engine.ReduceSum(t, axes, keepDims: false);
     }
 
     /// <summary>Recursively collects a layer's trainable parameter tensors (including composite sub-layers), deduped by reference.</summary>

--- a/src/NeuralNetworks/CreditAssignment/CreditRuleBase.cs
+++ b/src/NeuralNetworks/CreditAssignment/CreditRuleBase.cs
@@ -4,14 +4,62 @@ using AiDotNet.LinearAlgebra;
 namespace AiDotNet.NeuralNetworks.CreditAssignment;
 
 /// <summary>
-/// Shared base + linear-algebra helpers for the built-in credit-assignment rules. Not part of the public API.
+/// Public, extensible base class for <b>credit-assignment (learning) rules</b> in the Direct-Feedback-Alignment
+/// family. Subclass this to author your own rule with minimal code: the base owns all the shared machinery — the
+/// per-layer feedback-matrix cache (lazily built and re-initialized when the network shape changes), the
+/// error/target projection and teaching-signal shaping helpers, feedback normalization/sign helpers, seeded random
+/// generation, and an overridable per-step feedback-update hook — so a subclass usually only implements
+/// <see cref="ComputeTeachingSignals"/> (and, for a learned-feedback rule, <see cref="UpdateFeedback"/>).
 /// </summary>
-/// <typeparam name="T">The numeric data type.</typeparam>
-internal abstract class CreditRuleBase<T> : ICreditRule<T>
+/// <typeparam name="T">The numeric data type used for calculations (e.g. <see cref="float"/>, <see cref="double"/>).</typeparam>
+/// <remarks>
+/// <para>
+/// <b>For Beginners:</b> when a neural network is wrong, every layer needs a message that says "here's how your
+/// output should change." Standard back-propagation computes that message exactly by chaining backwards through
+/// all later layers. The rules in this family instead hand each layer a cheaper <i>shortcut</i> message — usually
+/// the final output error pushed through a small random (or learned) matrix — and the network still learns. This
+/// base class already contains the plumbing those shortcuts need; to invent your own rule you mostly just decide
+/// how to turn the output error into each layer's teaching signal.
+/// </para>
+/// <para>
+/// <b>Writing a custom rule.</b> A minimal Direct-Feedback-Alignment-style rule looks like this:
+/// <code>
+/// public sealed class MyRule&lt;T&gt; : CreditRuleBase&lt;T&gt;
+/// {
+///     public MyRule(int? seed = null) : base(seed) { }
+///     public override string Name =&gt; "MyRule";
+///
+///     public override void ComputeTeachingSignals(ICreditAssignmentContext&lt;T&gt; context)
+///     {
+///         // One fixed random [outputs, features_i] matrix per hidden layer, cached and shape-aware:
+///         var feedback = EnsureFeedback(context, (layers, i) =&gt;
+///             layers[i].IsOutputLayer ? null : (context.OutputError.Shape[1], layers[i].FlatFeatureSize));
+///         var error = ErrorMatrix(context); // [batch, outputs]
+///         foreach (var layer in context.Layers)
+///         {
+///             if (layer.IsOutputLayer) continue; // the engine trains the output layer with the exact loss gradient
+///             var projected = ProjectThrough(error, feedback[layer.Index]!); // [batch, features_i]
+///             layer.TeachingSignal = ToTeachingSignal(projected, layer.OutputShape);
+///         }
+///     }
+/// }
+/// // Plug it in without touching the library:  builder.ConfigureCreditRule(new MyRule&lt;float&gt;(seed: 42));
+/// </code>
+/// For a rule whose feedback is <i>learned</i> (e.g. Kolen-Pollack), also override <see cref="UpdateFeedback"/>.
+/// </para>
+/// </remarks>
+public abstract class CreditRuleBase<T> : IFeedbackLearningRule<T>
 {
-    /// <summary>Optional explicit RNG seed (set via the <c>CreditRules</c> factory) for reproducible feedback matrices.</summary>
+    /// <summary>Optional explicit RNG seed for reproducible feedback matrices (set via the factory or constructor).</summary>
     protected readonly int? Seed;
 
+    // Shared per-layer feedback-matrix cache. Indexed by trainable-layer position; null entries have no matrix
+    // (e.g. the output layer, or the first layer for a sequential rule). Rebuilt when the layer shapes change.
+    private Matrix<T>?[]? _feedback;
+    private int[]? _signature;
+
+    /// <summary>Creates the rule with an optional RNG seed for reproducible feedback matrices.</summary>
+    /// <param name="seed">Optional RNG seed; when null the context's shared random source is used.</param>
     protected CreditRuleBase(int? seed = null) => Seed = seed;
 
     /// <inheritdoc />
@@ -26,18 +74,112 @@ internal abstract class CreditRuleBase<T> : ICreditRule<T>
     /// <inheritdoc />
     public abstract void ComputeTeachingSignals(ICreditAssignmentContext<T> context);
 
+    /// <summary>
+    /// The cached per-layer feedback matrices (may contain null entries). Populated by <see cref="EnsureFeedback"/>.
+    /// </summary>
+    protected IReadOnlyList<Matrix<T>?> Feedback => _feedback ?? System.Array.Empty<Matrix<T>?>();
+
+    void IFeedbackLearningRule<T>.OnParametersUpdated(ICreditAssignmentContext<T> context) => UpdateFeedback(context);
+
+    /// <summary>
+    /// Overridable per-step hook for rules whose feedback is <b>learned</b>. Called once per training step, after
+    /// the step's teaching signals and gradients were produced and while the per-layer activations are still on the
+    /// context. The default is a no-op, so fixed-feedback rules need not override it. Learned-feedback rules
+    /// (Kolen-Pollack, Direct Kolen-Pollack) override it to nudge their feedback matrices toward the forward weights.
+    /// </summary>
+    /// <param name="context">The credit-assignment context for the just-computed step.</param>
+    protected virtual void UpdateFeedback(ICreditAssignmentContext<T> context) { }
+
     /// <summary>Returns the RNG this rule should use: its own seeded generator if a seed was supplied, else the context's.</summary>
     protected Random ResolveRandom(ICreditAssignmentContext<T> context)
         => Seed.HasValue ? new Random(Seed.Value) : context.Random;
 
-    /// <summary>The output error as a <c>[batch, features]</c> matrix.</summary>
-    protected static Matrix<T> ErrorMatrix(ICreditAssignmentContext<T> context)
+    // ---- feedback cache -----------------------------------------------------------------------
+
+    /// <summary>
+    /// Lazily builds and caches one feedback matrix per trainable layer, sized by <paramref name="size"/>. The
+    /// cache is rebuilt automatically whenever the network's per-layer shapes change (so the same rule instance can
+    /// be reused across architectures). <paramref name="size"/> receives the ordered trainable layers and an index
+    /// and returns the <c>(rows, cols)</c> of that layer's matrix, or <c>null</c> for layers that have no matrix.
+    /// </summary>
+    /// <param name="context">The credit-assignment context.</param>
+    /// <param name="size">Per-layer matrix sizing; return null for layers without a feedback matrix.</param>
+    /// <param name="normalizeColumns">When true, each built matrix has its columns L2-normalized (for magnitude-stable variants).</param>
+    protected Matrix<T>?[] EnsureFeedback(
+        ICreditAssignmentContext<T> context,
+        Func<IReadOnlyList<ICreditLayer<T>>, int, (int rows, int cols)?> size,
+        bool normalizeColumns = false)
     {
-        var e = context.OutputError; // [B, C]
-        var m = new Matrix<T>(e.Shape[0], e.Shape[1]);
-        for (int b = 0; b < e.Shape[0]; b++)
-            for (int c = 0; c < e.Shape[1]; c++)
-                m[b, c] = e[b, c];
+        var layers = context.Layers;
+        var sig = BuildSignature(layers);
+        if (_feedback is not null && _signature is not null && SignatureEquals(_signature, sig))
+            return _feedback;
+
+        var random = ResolveRandom(context);
+        var fb = new Matrix<T>?[layers.Count];
+        for (int i = 0; i < layers.Count; i++)
+        {
+            var s = size(layers, i);
+            if (s is null) { fb[i] = null; continue; }
+            var m = RandomGaussian(s.Value.rows, s.Value.cols, s.Value.rows, random, context.NumOps);
+            if (normalizeColumns) NormalizeColumns(m, context.NumOps);
+            fb[i] = m;
+        }
+        _feedback = fb;
+        _signature = sig;
+        return fb;
+    }
+
+    private static int[] BuildSignature(IReadOnlyList<ICreditLayer<T>> layers)
+    {
+        var sig = new int[layers.Count * 2];
+        for (int i = 0; i < layers.Count; i++)
+        {
+            sig[2 * i] = layers[i].FlatFeatureSize;
+            sig[2 * i + 1] = InFeatures(layers[i]);
+        }
+        return sig;
+    }
+
+    private static bool SignatureEquals(int[] a, int[] b)
+    {
+        if (a.Length != b.Length) return false;
+        for (int i = 0; i < a.Length; i++) if (a[i] != b[i]) return false;
+        return true;
+    }
+
+    /// <summary>The flattened feature count of a layer's forward <see cref="ICreditLayer{T}.Input"/> (product of the non-batch axes).</summary>
+    protected static int InFeatures(ICreditLayer<T> layer)
+    {
+        var shape = layer.Input.Shape;
+        int flat = 1;
+        for (int i = 1; i < shape.Length; i++) flat *= shape[i];
+        return flat;
+    }
+
+    // ---- projection / shaping ----------------------------------------------------------------
+
+    /// <summary>The output error as a <c>[batch, features]</c> matrix (prediction − target).</summary>
+    protected static Matrix<T> ErrorMatrix(ICreditAssignmentContext<T> context) => FlatMatrix(context.OutputError);
+
+    /// <summary>The one-hot / regression target as a <c>[batch, features]</c> matrix.</summary>
+    protected static Matrix<T> TargetMatrix(ICreditAssignmentContext<T> context) => FlatMatrix(context.Target);
+
+    /// <summary>Projects a <c>[batch, C]</c> signal (error or target) through a <c>[C, M]</c> feedback matrix, giving <c>[batch, M]</c>.</summary>
+    protected static Matrix<T> ProjectThrough(Matrix<T> signal, Matrix<T> feedback) => signal.Multiply(feedback);
+
+    /// <summary>Flattens a <c>[batch, …]</c> tensor to a <c>[batch, flatFeatures]</c> matrix (row-major over the non-batch axes).</summary>
+    protected static Matrix<T> FlatMatrix(Tensor<T> t)
+    {
+        int batch = t.Shape[0];
+        int flat = 1;
+        for (int i = 1; i < t.Shape.Length; i++) flat *= t.Shape[i];
+        var v = t.ToVector();
+        var m = new Matrix<T>(batch, flat);
+        int idx = 0;
+        for (int b = 0; b < batch; b++)
+            for (int j = 0; j < flat; j++)
+                m[b, j] = v[idx++];
         return m;
     }
 
@@ -57,27 +199,51 @@ internal abstract class CreditRuleBase<T> : ICreditRule<T>
         return new Tensor<T>(outputShape, data);
     }
 
-    /// <summary>Flattens a <c>[batch, …]</c> tensor to a <c>[batch, flatFeatures]</c> matrix (row-major over the non-batch axes).</summary>
-    protected static Matrix<T> FlatMatrix(Tensor<T> t)
+    // ---- feedback math helpers ---------------------------------------------------------------
+
+    /// <summary>Element-wise sign matrix (−1 / 0 / +1) of <paramref name="w"/>.</summary>
+    protected static Matrix<T> SignMatrix(Matrix<T> w, INumericOperations<T> ops)
     {
-        int batch = t.Shape[0];
-        int flat = 1;
-        for (int i = 1; i < t.Shape.Length; i++) flat *= t.Shape[i];
-        var v = t.ToVector();
-        var m = new Matrix<T>(batch, flat);
-        int idx = 0;
-        for (int b = 0; b < batch; b++)
-            for (int j = 0; j < flat; j++)
-                m[b, j] = v[idx++];
-        return m;
+        var s = new Matrix<T>(w.Rows, w.Columns);
+        for (int i = 0; i < w.Rows; i++)
+            for (int j = 0; j < w.Columns; j++)
+                s[i, j] = ops.SignOrZero(w[i, j]);
+        return s;
     }
 
-    /// <summary>The one-hot / regression target as a <c>[batch, features]</c> matrix.</summary>
-    protected static Matrix<T> TargetMatrix(ICreditAssignmentContext<T> context) => FlatMatrix(context.Target);
+    /// <summary>Scales each column of <paramref name="m"/> to unit L2 norm (in place) — used by magnitude-stable variants.</summary>
+    protected static void NormalizeColumns(Matrix<T> m, INumericOperations<T> ops)
+    {
+        for (int j = 0; j < m.Columns; j++)
+        {
+            double sq = 0;
+            for (int i = 0; i < m.Rows; i++) { double v = ops.ToDouble(m[i, j]); sq += v * v; }
+            double norm = Math.Sqrt(sq);
+            if (norm <= 1e-12) continue;
+            T inv = ops.FromDouble(1.0 / norm);
+            for (int i = 0; i < m.Rows; i++) m[i, j] = ops.Multiply(m[i, j], inv);
+        }
+    }
+
+    /// <summary>Rescales each row of <paramref name="signal"/> so its L2 norm matches the same row of <paramref name="reference"/> (in place).</summary>
+    protected static void RescaleRowsToMatch(Matrix<T> signal, Matrix<T> reference, INumericOperations<T> ops)
+    {
+        for (int b = 0; b < signal.Rows; b++)
+        {
+            double sig = 0, refN = 0;
+            for (int j = 0; j < signal.Columns; j++) { double v = ops.ToDouble(signal[b, j]); sig += v * v; }
+            for (int c = 0; c < reference.Columns; c++) { double v = ops.ToDouble(reference[b, c]); refN += v * v; }
+            double sigNorm = Math.Sqrt(sig);
+            if (sigNorm <= 1e-12) continue;
+            double scale = Math.Sqrt(refN) / sigNorm;
+            T s = ops.FromDouble(scale);
+            for (int j = 0; j < signal.Columns; j++) signal[b, j] = ops.Multiply(signal[b, j], s);
+        }
+    }
 
     /// <summary>
-    /// Outer-product accumulation <c>result[i,j] = (1/batch) · Σ_b a[b,i] · b[b,j]</c> — i.e. <c>aᵀ·b / batch</c>,
-    /// the mean per-sample outer product used to form Kolen-Pollack feedback updates.
+    /// Mean per-sample outer product <c>result[i,j] = (1/batch) · Σ_b a[b,i]·b[b,j]</c> (i.e. <c>aᵀ·b / batch</c>) —
+    /// the increment used to form Kolen-Pollack feedback updates.
     /// </summary>
     protected static Matrix<T> MeanOuter(Matrix<T> a, Matrix<T> b, INumericOperations<T> ops)
     {
@@ -105,19 +271,9 @@ internal abstract class CreditRuleBase<T> : ICreditRule<T>
                 b[i, j] = ops.Subtract(ops.Multiply(keep, b[i, j]), ops.Multiply(rate, grad[i, j]));
     }
 
-    /// <summary>Element-wise sign matrix (−1 / 0 / +1) of <paramref name="w"/>.</summary>
-    protected static Matrix<T> SignMatrix(Matrix<T> w, INumericOperations<T> ops)
-    {
-        var s = new Matrix<T>(w.Rows, w.Columns);
-        for (int i = 0; i < w.Rows; i++)
-            for (int j = 0; j < w.Columns; j++)
-                s[i, j] = ops.SignOrZero(w[i, j]);
-        return s;
-    }
-
     /// <summary>
     /// Draws an <c>[rows, cols]</c> matrix of i.i.d. Gaussian entries with standard deviation
-    /// <c>1/sqrt(fanForScale)</c> (a stable default for fixed feedback matrices), using the supplied RNG.
+    /// <c>1/sqrt(fanForScale)</c> (a stable default for feedback matrices), using the supplied RNG.
     /// </summary>
     protected static Matrix<T> RandomGaussian(int rows, int cols, int fanForScale, Random random, INumericOperations<T> ops)
     {

--- a/src/NeuralNetworks/CreditAssignment/CreditRuleBase.cs
+++ b/src/NeuralNetworks/CreditAssignment/CreditRuleBase.cs
@@ -57,6 +57,54 @@ internal abstract class CreditRuleBase<T> : ICreditRule<T>
         return new Tensor<T>(outputShape, data);
     }
 
+    /// <summary>Flattens a <c>[batch, …]</c> tensor to a <c>[batch, flatFeatures]</c> matrix (row-major over the non-batch axes).</summary>
+    protected static Matrix<T> FlatMatrix(Tensor<T> t)
+    {
+        int batch = t.Shape[0];
+        int flat = 1;
+        for (int i = 1; i < t.Shape.Length; i++) flat *= t.Shape[i];
+        var v = t.ToVector();
+        var m = new Matrix<T>(batch, flat);
+        int idx = 0;
+        for (int b = 0; b < batch; b++)
+            for (int j = 0; j < flat; j++)
+                m[b, j] = v[idx++];
+        return m;
+    }
+
+    /// <summary>The one-hot / regression target as a <c>[batch, features]</c> matrix.</summary>
+    protected static Matrix<T> TargetMatrix(ICreditAssignmentContext<T> context) => FlatMatrix(context.Target);
+
+    /// <summary>
+    /// Outer-product accumulation <c>result[i,j] = (1/batch) · Σ_b a[b,i] · b[b,j]</c> — i.e. <c>aᵀ·b / batch</c>,
+    /// the mean per-sample outer product used to form Kolen-Pollack feedback updates.
+    /// </summary>
+    protected static Matrix<T> MeanOuter(Matrix<T> a, Matrix<T> b, INumericOperations<T> ops)
+    {
+        int rows = a.Columns, cols = b.Columns, batch = a.Rows;
+        var g = new Matrix<T>(rows, cols);
+        T invBatch = ops.FromDouble(1.0 / Math.Max(1, batch));
+        for (int i = 0; i < rows; i++)
+            for (int j = 0; j < cols; j++)
+            {
+                T acc = ops.Zero;
+                for (int n = 0; n < batch; n++)
+                    acc = ops.Add(acc, ops.Multiply(a[n, i], b[n, j]));
+                g[i, j] = ops.Multiply(acc, invBatch);
+            }
+        return g;
+    }
+
+    /// <summary>In-place Kolen-Pollack update of a feedback matrix: <c>B ← (1−decay)·B − lr·grad</c>.</summary>
+    protected static void KpUpdate(Matrix<T> b, Matrix<T> grad, double lr, double decay, INumericOperations<T> ops)
+    {
+        T keep = ops.FromDouble(1.0 - decay);
+        T rate = ops.FromDouble(lr);
+        for (int i = 0; i < b.Rows; i++)
+            for (int j = 0; j < b.Columns; j++)
+                b[i, j] = ops.Subtract(ops.Multiply(keep, b[i, j]), ops.Multiply(rate, grad[i, j]));
+    }
+
     /// <summary>Element-wise sign matrix (−1 / 0 / +1) of <paramref name="w"/>.</summary>
     protected static Matrix<T> SignMatrix(Matrix<T> w, INumericOperations<T> ops)
     {

--- a/src/NeuralNetworks/CreditAssignment/CreditRuleFactory.cs
+++ b/src/NeuralNetworks/CreditAssignment/CreditRuleFactory.cs
@@ -21,6 +21,10 @@ public static class CreditRuleFactory<T>
         CreditRule.FeedbackAlignment => new FeedbackAlignmentCreditRule<T>(seed),
         CreditRule.DirectFeedbackAlignment => new DirectFeedbackAlignmentCreditRule<T>(seed),
         CreditRule.SignSymmetric => new SignSymmetricCreditRule<T>(seed),
+        CreditRule.KolenPollack => new KolenPollackCreditRule<T>(seed),
+        CreditRule.DirectKolenPollack => new DirectKolenPollackCreditRule<T>(seed),
+        CreditRule.DRTP => new DrtpCreditRule<T>(seed),
+        CreditRule.DFANormalized => new NormalizedDfaCreditRule<T>(seed),
         _ => throw new ArgumentOutOfRangeException(nameof(rule), rule, "Unknown credit rule."),
     };
 }

--- a/src/NeuralNetworks/CreditAssignment/CreditRules.cs
+++ b/src/NeuralNetworks/CreditAssignment/CreditRules.cs
@@ -38,4 +38,39 @@ public static class CreditRules
     /// </summary>
     /// <param name="seed">Unused (kept for signature symmetry); Sign-Symmetric holds no random state.</param>
     public static ICreditRule<T> SignSymmetric<T>(int? seed = null) => new SignSymmetricCreditRule<T>(seed);
+
+    /// <summary>
+    /// Kolen-Pollack (Kolen &amp; Pollack, 1994; Akrout et al., 2019): sequential feedback whose matrices are
+    /// <i>learned</i> — each converges to its forward weight — so credit assignment approaches back-propagation on
+    /// deep dense stacks.
+    /// </summary>
+    /// <param name="seed">Optional RNG seed for the initial feedback matrices (reproducibility).</param>
+    /// <param name="feedbackLearningRate">Step size for the feedback-matrix (alignment) update.</param>
+    /// <param name="weightDecay">Weight decay applied to the feedback matrices (drives convergence to the forward weights).</param>
+    public static ICreditRule<T> KolenPollack<T>(int? seed = null, double feedbackLearningRate = 0.05, double weightDecay = 0.001)
+        => new KolenPollackCreditRule<T>(seed, feedbackLearningRate, weightDecay);
+
+    /// <summary>
+    /// Direct Kolen-Pollack: Kolen-Pollack learning in the Direct Feedback Alignment topology (direct
+    /// output→layer feedback matrices that are <i>learned</i> rather than fixed). Scales to attention like DFA.
+    /// </summary>
+    /// <param name="seed">Optional RNG seed for the initial feedback matrices (reproducibility).</param>
+    /// <param name="feedbackLearningRate">Step size for the feedback-matrix (alignment) update.</param>
+    /// <param name="weightDecay">Weight decay applied to the feedback matrices.</param>
+    public static ICreditRule<T> DirectKolenPollack<T>(int? seed = null, double feedbackLearningRate = 0.05, double weightDecay = 0.001)
+        => new DirectKolenPollackCreditRule<T>(seed, feedbackLearningRate, weightDecay);
+
+    /// <summary>
+    /// Direct Random Target Projection (Frenkel &amp; Bol, 2021): each hidden layer's teaching signal is a fixed
+    /// random projection of the one-hot target — no backward error path is needed.
+    /// </summary>
+    /// <param name="seed">Optional RNG seed for the fixed feedback matrices (reproducibility).</param>
+    public static ICreditRule<T> DRTP<T>(int? seed = null) => new DrtpCreditRule<T>(seed);
+
+    /// <summary>
+    /// Normalized Direct Feedback Alignment (Launay et al., 2020 style): DFA with unit-norm feedback columns and
+    /// per-layer teaching-signal rescaling so the signal magnitude stays stable across depth.
+    /// </summary>
+    /// <param name="seed">Optional RNG seed for the fixed feedback matrices (reproducibility).</param>
+    public static ICreditRule<T> DFANormalized<T>(int? seed = null) => new NormalizedDfaCreditRule<T>(seed);
 }

--- a/src/NeuralNetworks/CreditAssignment/DirectFeedbackAlignmentCreditRule.cs
+++ b/src/NeuralNetworks/CreditAssignment/DirectFeedbackAlignmentCreditRule.cs
@@ -1,5 +1,4 @@
 using AiDotNet.Interfaces;
-using AiDotNet.LinearAlgebra;
 
 namespace AiDotNet.NeuralNetworks.CreditAssignment;
 
@@ -8,63 +7,34 @@ namespace AiDotNet.NeuralNetworks.CreditAssignment;
 /// propagating the error sequentially through the network, DFA projects the <i>global</i> output error directly
 /// onto every hidden layer through a per-layer fixed random matrix. Each layer's teaching signal depends only on
 /// the output error — there is no backward chain — so the rule applies uniformly to dense, attention,
-/// feed-forward, LayerNorm and embedding layers. The training engine turns each teaching signal into that layer's
-/// parameter gradients via a local vector-Jacobian product (which supplies the layer's own activation Jacobian).
+/// feed-forward, LayerNorm and embedding layers.
 /// </summary>
 /// <typeparam name="T">The numeric data type.</typeparam>
+/// <remarks>
+/// <para>
+/// <b>For Beginners:</b> DFA hands every hidden layer a <i>fixed random shortcut</i> of the final output error
+/// instead of the exact back-propagated signal, and the network still learns because the forward weights rotate to
+/// align with the random feedback. It is the simplest member of this family and the one that scales to Transformers.
+/// </para>
+/// </remarks>
 internal sealed class DirectFeedbackAlignmentCreditRule<T> : CreditRuleBase<T>
 {
-    // _feedback[i] maps the output error [B, C] to hidden layer i's flat feature space [B, M_i].
-    // Shape: [C, M_i]. The output layer is trained with the exact loss gradient (no feedback matrix).
-    private Matrix<T>?[]? _feedback;
-    private int[]? _shapeSignature;
-
     public DirectFeedbackAlignmentCreditRule(int? seed = null) : base(seed) { }
 
     public override string Name => "DirectFeedbackAlignment";
 
-    public override void Initialize(ICreditAssignmentContext<T> context)
-    {
-        if (IsInitializedFor(context)) return;
-
-        var layers = context.Layers;
-        int outputFeatures = layers[layers.Count - 1].FlatFeatureSize;
-        var random = ResolveRandom(context);
-
-        _feedback = new Matrix<T>?[layers.Count];
-        _shapeSignature = new int[layers.Count + 1];
-        _shapeSignature[layers.Count] = outputFeatures;
-        for (int i = 0; i < layers.Count; i++)
-        {
-            var layer = layers[i];
-            _feedback[i] = layer.IsOutputLayer
-                ? null
-                : RandomGaussian(outputFeatures, layer.FlatFeatureSize, outputFeatures, random, context.NumOps);
-            _shapeSignature[i] = layer.FlatFeatureSize;
-        }
-    }
-
     public override void ComputeTeachingSignals(ICreditAssignmentContext<T> context)
     {
-        if (!IsInitializedFor(context)) Initialize(context);
-        var error = ErrorMatrix(context); // [B, C]
+        int outputFeatures = context.OutputError.Shape[1];
+        var feedback = EnsureFeedback(context, (layers, i) =>
+            layers[i].IsOutputLayer ? null : (outputFeatures, layers[i].FlatFeatureSize));
 
+        var error = ErrorMatrix(context); // [B, C]
         foreach (var layer in context.Layers)
         {
             if (layer.IsOutputLayer) continue; // engine uses the exact loss gradient here
-            var projected = error.Multiply(_feedback![layer.Index]!); // [B, C] · [C, M_i] = [B, M_i]
+            var projected = ProjectThrough(error, feedback[layer.Index]!); // [B, C] · [C, M_i] = [B, M_i]
             layer.TeachingSignal = ToTeachingSignal(projected, layer.OutputShape);
         }
-    }
-
-    private bool IsInitializedFor(ICreditAssignmentContext<T> context)
-    {
-        if (_feedback is null || _shapeSignature is null) return false;
-        var layers = context.Layers;
-        if (_feedback.Length != layers.Count) return false;
-        if (_shapeSignature[layers.Count] != layers[layers.Count - 1].FlatFeatureSize) return false;
-        for (int i = 0; i < layers.Count; i++)
-            if (_shapeSignature[i] != layers[i].FlatFeatureSize) return false;
-        return true;
     }
 }

--- a/src/NeuralNetworks/CreditAssignment/DirectFeedbackVariants.cs
+++ b/src/NeuralNetworks/CreditAssignment/DirectFeedbackVariants.cs
@@ -1,0 +1,178 @@
+using AiDotNet.Interfaces;
+using AiDotNet.LinearAlgebra;
+
+namespace AiDotNet.NeuralNetworks.CreditAssignment;
+
+/// <summary>
+/// <b>Direct Random Target Projection (DRTP)</b> — Frenkel, Lefebvre &amp; Bol, 2021 ("Learning without Feedback:
+/// Fixed Random Learning Signals Allow for Feedforward Training of Deep Neural Networks"). Each hidden layer's
+/// teaching signal is a <i>fixed random projection of the one-hot target</i> rather than of the output error — so
+/// no backward error path is needed at all. Because the (negated) target supplies a valid descent direction on
+/// average (the output error <c>prediction − target ≈ −target</c> early in training), projecting the target through
+/// a fixed random matrix still trains the hidden layers. The rule holds only fixed random state, so it applies
+/// uniformly to dense, attention, feed-forward, LayerNorm and embedding layers.
+/// </summary>
+/// <typeparam name="T">The numeric data type.</typeparam>
+internal sealed class DrtpCreditRule<T> : CreditRuleBase<T>
+{
+    // _feedback[i] : [outputFeatures, features_i], fixed random. The output layer has no feedback matrix.
+    private Matrix<T>?[]? _feedback;
+    private int[]? _shapeSignature;
+
+    public DrtpCreditRule(int? seed = null) : base(seed) { }
+
+    public override string Name => "DRTP";
+
+    public override void Initialize(ICreditAssignmentContext<T> context)
+    {
+        if (IsInitializedFor(context)) return;
+
+        var layers = context.Layers;
+        int outputFeatures = layers[layers.Count - 1].FlatFeatureSize;
+        var random = ResolveRandom(context);
+
+        _feedback = new Matrix<T>?[layers.Count];
+        _shapeSignature = new int[layers.Count + 1];
+        _shapeSignature[layers.Count] = outputFeatures;
+        for (int i = 0; i < layers.Count; i++)
+        {
+            _feedback[i] = layers[i].IsOutputLayer
+                ? null
+                : RandomGaussian(outputFeatures, layers[i].FlatFeatureSize, outputFeatures, random, context.NumOps);
+            _shapeSignature[i] = layers[i].FlatFeatureSize;
+        }
+    }
+
+    public override void ComputeTeachingSignals(ICreditAssignmentContext<T> context)
+    {
+        if (!IsInitializedFor(context)) Initialize(context);
+        var target = TargetMatrix(context); // [B, C] one-hot
+        var ops = context.NumOps;
+
+        foreach (var layer in context.Layers)
+        {
+            if (layer.IsOutputLayer) continue;
+            // Project the target, then negate: the descent direction matches DFA's error projection because
+            // (prediction − target) ≈ −target while the prediction is still near-uniform.
+            var projected = target.Multiply(_feedback![layer.Index]!); // [B, C] · [C, M_i] = [B, M_i]
+            for (int b = 0; b < projected.Rows; b++)
+                for (int j = 0; j < projected.Columns; j++)
+                    projected[b, j] = ops.Negate(projected[b, j]);
+            layer.TeachingSignal = ToTeachingSignal(projected, layer.OutputShape);
+        }
+    }
+
+    private bool IsInitializedFor(ICreditAssignmentContext<T> context)
+    {
+        if (_feedback is null || _shapeSignature is null) return false;
+        var layers = context.Layers;
+        if (_feedback.Length != layers.Count) return false;
+        if (_shapeSignature[layers.Count] != layers[layers.Count - 1].FlatFeatureSize) return false;
+        for (int i = 0; i < layers.Count; i++)
+            if (_shapeSignature[i] != layers[i].FlatFeatureSize) return false;
+        return true;
+    }
+}
+
+/// <summary>
+/// <b>Normalized Direct Feedback Alignment</b> (Launay et al., 2020 style). Vanilla DFA projects the global output
+/// error onto every hidden layer through a fixed random matrix; without care the projected signal's magnitude
+/// drifts with layer width and depth, which destabilizes training of deep / Transformer networks. This variant
+/// keeps the magnitude stable: the feedback matrices are built with <b>unit-norm columns</b>, and each layer's
+/// projected teaching signal is rescaled per sample to match the output error's magnitude. Otherwise identical to
+/// Direct Feedback Alignment.
+/// </summary>
+/// <typeparam name="T">The numeric data type.</typeparam>
+internal sealed class NormalizedDfaCreditRule<T> : CreditRuleBase<T>
+{
+    private Matrix<T>?[]? _feedback;
+    private int[]? _shapeSignature;
+
+    public NormalizedDfaCreditRule(int? seed = null) : base(seed) { }
+
+    public override string Name => "DFANormalized";
+
+    public override void Initialize(ICreditAssignmentContext<T> context)
+    {
+        if (IsInitializedFor(context)) return;
+
+        var layers = context.Layers;
+        int outputFeatures = layers[layers.Count - 1].FlatFeatureSize;
+        var random = ResolveRandom(context);
+        var ops = context.NumOps;
+
+        _feedback = new Matrix<T>?[layers.Count];
+        _shapeSignature = new int[layers.Count + 1];
+        _shapeSignature[layers.Count] = outputFeatures;
+        for (int i = 0; i < layers.Count; i++)
+        {
+            if (layers[i].IsOutputLayer) { _feedback[i] = null; _shapeSignature[i] = layers[i].FlatFeatureSize; continue; }
+            var b = RandomGaussian(outputFeatures, layers[i].FlatFeatureSize, outputFeatures, random, ops);
+            NormalizeColumns(b, ops);
+            _feedback[i] = b;
+            _shapeSignature[i] = layers[i].FlatFeatureSize;
+        }
+    }
+
+    public override void ComputeTeachingSignals(ICreditAssignmentContext<T> context)
+    {
+        if (!IsInitializedFor(context)) Initialize(context);
+        var error = ErrorMatrix(context); // [B, C]
+        var ops = context.NumOps;
+
+        foreach (var layer in context.Layers)
+        {
+            if (layer.IsOutputLayer) continue;
+            var projected = error.Multiply(_feedback![layer.Index]!); // [B, M_i]
+            RescaleRowsToMatch(projected, error, ops);                 // depth-stable magnitude
+            layer.TeachingSignal = ToTeachingSignal(projected, layer.OutputShape);
+        }
+    }
+
+    /// <summary>Scales each column of <paramref name="m"/> to unit L2 norm (in place).</summary>
+    private static void NormalizeColumns(Matrix<T> m, INumericOperations<T> ops)
+    {
+        for (int j = 0; j < m.Columns; j++)
+        {
+            double sq = 0;
+            for (int i = 0; i < m.Rows; i++)
+            {
+                double v = ops.ToDouble(m[i, j]);
+                sq += v * v;
+            }
+            double norm = Math.Sqrt(sq);
+            if (norm <= 1e-12) continue;
+            T inv = ops.FromDouble(1.0 / norm);
+            for (int i = 0; i < m.Rows; i++)
+                m[i, j] = ops.Multiply(m[i, j], inv);
+        }
+    }
+
+    /// <summary>Rescales each row of <paramref name="signal"/> so its L2 norm matches the same row of <paramref name="reference"/>.</summary>
+    private static void RescaleRowsToMatch(Matrix<T> signal, Matrix<T> reference, INumericOperations<T> ops)
+    {
+        for (int b = 0; b < signal.Rows; b++)
+        {
+            double sig = 0, refN = 0;
+            for (int j = 0; j < signal.Columns; j++) { double v = ops.ToDouble(signal[b, j]); sig += v * v; }
+            for (int c = 0; c < reference.Columns; c++) { double v = ops.ToDouble(reference[b, c]); refN += v * v; }
+            double sigNorm = Math.Sqrt(sig);
+            if (sigNorm <= 1e-12) continue;
+            double scale = Math.Sqrt(refN) / sigNorm;
+            T s = ops.FromDouble(scale);
+            for (int j = 0; j < signal.Columns; j++)
+                signal[b, j] = ops.Multiply(signal[b, j], s);
+        }
+    }
+
+    private bool IsInitializedFor(ICreditAssignmentContext<T> context)
+    {
+        if (_feedback is null || _shapeSignature is null) return false;
+        var layers = context.Layers;
+        if (_feedback.Length != layers.Count) return false;
+        if (_shapeSignature[layers.Count] != layers[layers.Count - 1].FlatFeatureSize) return false;
+        for (int i = 0; i < layers.Count; i++)
+            if (_shapeSignature[i] != layers[i].FlatFeatureSize) return false;
+        return true;
+    }
+}

--- a/src/NeuralNetworks/CreditAssignment/DirectFeedbackVariants.cs
+++ b/src/NeuralNetworks/CreditAssignment/DirectFeedbackVariants.cs
@@ -9,68 +9,41 @@ namespace AiDotNet.NeuralNetworks.CreditAssignment;
 /// teaching signal is a <i>fixed random projection of the one-hot target</i> rather than of the output error — so
 /// no backward error path is needed at all. Because the (negated) target supplies a valid descent direction on
 /// average (the output error <c>prediction − target ≈ −target</c> early in training), projecting the target through
-/// a fixed random matrix still trains the hidden layers. The rule holds only fixed random state, so it applies
-/// uniformly to dense, attention, feed-forward, LayerNorm and embedding layers.
+/// a fixed random matrix still trains the hidden layers.
 /// </summary>
 /// <typeparam name="T">The numeric data type.</typeparam>
+/// <remarks>
+/// <para>
+/// <b>For Beginners:</b> DRTP is the most hardware-friendly rule in this family — it never sends any error signal
+/// backward. It only needs to know the correct answer (the target), which it projects through a fixed random matrix
+/// to tell each layer which way to adjust. Surprisingly, that alone is enough for the network to learn.
+/// </para>
+/// </remarks>
 internal sealed class DrtpCreditRule<T> : CreditRuleBase<T>
 {
-    // _feedback[i] : [outputFeatures, features_i], fixed random. The output layer has no feedback matrix.
-    private Matrix<T>?[]? _feedback;
-    private int[]? _shapeSignature;
-
     public DrtpCreditRule(int? seed = null) : base(seed) { }
 
     public override string Name => "DRTP";
 
-    public override void Initialize(ICreditAssignmentContext<T> context)
-    {
-        if (IsInitializedFor(context)) return;
-
-        var layers = context.Layers;
-        int outputFeatures = layers[layers.Count - 1].FlatFeatureSize;
-        var random = ResolveRandom(context);
-
-        _feedback = new Matrix<T>?[layers.Count];
-        _shapeSignature = new int[layers.Count + 1];
-        _shapeSignature[layers.Count] = outputFeatures;
-        for (int i = 0; i < layers.Count; i++)
-        {
-            _feedback[i] = layers[i].IsOutputLayer
-                ? null
-                : RandomGaussian(outputFeatures, layers[i].FlatFeatureSize, outputFeatures, random, context.NumOps);
-            _shapeSignature[i] = layers[i].FlatFeatureSize;
-        }
-    }
-
     public override void ComputeTeachingSignals(ICreditAssignmentContext<T> context)
     {
-        if (!IsInitializedFor(context)) Initialize(context);
+        int outputFeatures = context.OutputError.Shape[1];
+        var feedback = EnsureFeedback(context, (layers, i) =>
+            layers[i].IsOutputLayer ? null : (outputFeatures, layers[i].FlatFeatureSize));
+
         var target = TargetMatrix(context); // [B, C] one-hot
         var ops = context.NumOps;
-
         foreach (var layer in context.Layers)
         {
             if (layer.IsOutputLayer) continue;
             // Project the target, then negate: the descent direction matches DFA's error projection because
             // (prediction − target) ≈ −target while the prediction is still near-uniform.
-            var projected = target.Multiply(_feedback![layer.Index]!); // [B, C] · [C, M_i] = [B, M_i]
+            var projected = ProjectThrough(target, feedback[layer.Index]!); // [B, C] · [C, M_i] = [B, M_i]
             for (int b = 0; b < projected.Rows; b++)
                 for (int j = 0; j < projected.Columns; j++)
                     projected[b, j] = ops.Negate(projected[b, j]);
             layer.TeachingSignal = ToTeachingSignal(projected, layer.OutputShape);
         }
-    }
-
-    private bool IsInitializedFor(ICreditAssignmentContext<T> context)
-    {
-        if (_feedback is null || _shapeSignature is null) return false;
-        var layers = context.Layers;
-        if (_feedback.Length != layers.Count) return false;
-        if (_shapeSignature[layers.Count] != layers[layers.Count - 1].FlatFeatureSize) return false;
-        for (int i = 0; i < layers.Count; i++)
-            if (_shapeSignature[i] != layers[i].FlatFeatureSize) return false;
-        return true;
     }
 }
 
@@ -83,96 +56,34 @@ internal sealed class DrtpCreditRule<T> : CreditRuleBase<T>
 /// Direct Feedback Alignment.
 /// </summary>
 /// <typeparam name="T">The numeric data type.</typeparam>
+/// <remarks>
+/// <para>
+/// <b>For Beginners:</b> this is DFA with a volume knob. In a deep network the plain random-shortcut signal can
+/// grow or shrink from layer to layer and derail training; the normalized version keeps every layer's message at a
+/// steady, comparable strength, which is what lets DFA-style learning work on deep and Transformer models.
+/// </para>
+/// </remarks>
 internal sealed class NormalizedDfaCreditRule<T> : CreditRuleBase<T>
 {
-    private Matrix<T>?[]? _feedback;
-    private int[]? _shapeSignature;
-
     public NormalizedDfaCreditRule(int? seed = null) : base(seed) { }
 
     public override string Name => "DFANormalized";
 
-    public override void Initialize(ICreditAssignmentContext<T> context)
-    {
-        if (IsInitializedFor(context)) return;
-
-        var layers = context.Layers;
-        int outputFeatures = layers[layers.Count - 1].FlatFeatureSize;
-        var random = ResolveRandom(context);
-        var ops = context.NumOps;
-
-        _feedback = new Matrix<T>?[layers.Count];
-        _shapeSignature = new int[layers.Count + 1];
-        _shapeSignature[layers.Count] = outputFeatures;
-        for (int i = 0; i < layers.Count; i++)
-        {
-            if (layers[i].IsOutputLayer) { _feedback[i] = null; _shapeSignature[i] = layers[i].FlatFeatureSize; continue; }
-            var b = RandomGaussian(outputFeatures, layers[i].FlatFeatureSize, outputFeatures, random, ops);
-            NormalizeColumns(b, ops);
-            _feedback[i] = b;
-            _shapeSignature[i] = layers[i].FlatFeatureSize;
-        }
-    }
-
     public override void ComputeTeachingSignals(ICreditAssignmentContext<T> context)
     {
-        if (!IsInitializedFor(context)) Initialize(context);
+        int outputFeatures = context.OutputError.Shape[1];
+        var feedback = EnsureFeedback(context, (layers, i) =>
+            layers[i].IsOutputLayer ? null : (outputFeatures, layers[i].FlatFeatureSize),
+            normalizeColumns: true);
+
         var error = ErrorMatrix(context); // [B, C]
         var ops = context.NumOps;
-
         foreach (var layer in context.Layers)
         {
             if (layer.IsOutputLayer) continue;
-            var projected = error.Multiply(_feedback![layer.Index]!); // [B, M_i]
-            RescaleRowsToMatch(projected, error, ops);                 // depth-stable magnitude
+            var projected = ProjectThrough(error, feedback[layer.Index]!); // [B, M_i]
+            RescaleRowsToMatch(projected, error, ops);                      // depth-stable magnitude
             layer.TeachingSignal = ToTeachingSignal(projected, layer.OutputShape);
         }
-    }
-
-    /// <summary>Scales each column of <paramref name="m"/> to unit L2 norm (in place).</summary>
-    private static void NormalizeColumns(Matrix<T> m, INumericOperations<T> ops)
-    {
-        for (int j = 0; j < m.Columns; j++)
-        {
-            double sq = 0;
-            for (int i = 0; i < m.Rows; i++)
-            {
-                double v = ops.ToDouble(m[i, j]);
-                sq += v * v;
-            }
-            double norm = Math.Sqrt(sq);
-            if (norm <= 1e-12) continue;
-            T inv = ops.FromDouble(1.0 / norm);
-            for (int i = 0; i < m.Rows; i++)
-                m[i, j] = ops.Multiply(m[i, j], inv);
-        }
-    }
-
-    /// <summary>Rescales each row of <paramref name="signal"/> so its L2 norm matches the same row of <paramref name="reference"/>.</summary>
-    private static void RescaleRowsToMatch(Matrix<T> signal, Matrix<T> reference, INumericOperations<T> ops)
-    {
-        for (int b = 0; b < signal.Rows; b++)
-        {
-            double sig = 0, refN = 0;
-            for (int j = 0; j < signal.Columns; j++) { double v = ops.ToDouble(signal[b, j]); sig += v * v; }
-            for (int c = 0; c < reference.Columns; c++) { double v = ops.ToDouble(reference[b, c]); refN += v * v; }
-            double sigNorm = Math.Sqrt(sig);
-            if (sigNorm <= 1e-12) continue;
-            double scale = Math.Sqrt(refN) / sigNorm;
-            T s = ops.FromDouble(scale);
-            for (int j = 0; j < signal.Columns; j++)
-                signal[b, j] = ops.Multiply(signal[b, j], s);
-        }
-    }
-
-    private bool IsInitializedFor(ICreditAssignmentContext<T> context)
-    {
-        if (_feedback is null || _shapeSignature is null) return false;
-        var layers = context.Layers;
-        if (_feedback.Length != layers.Count) return false;
-        if (_shapeSignature[layers.Count] != layers[layers.Count - 1].FlatFeatureSize) return false;
-        for (int i = 0; i < layers.Count; i++)
-            if (_shapeSignature[i] != layers[i].FlatFeatureSize) return false;
-        return true;
     }
 }

--- a/src/NeuralNetworks/CreditAssignment/DirectKolenPollackCreditRule.cs
+++ b/src/NeuralNetworks/CreditAssignment/DirectKolenPollackCreditRule.cs
@@ -13,12 +13,15 @@ namespace AiDotNet.NeuralNetworks.CreditAssignment;
 /// Jacobian from that layer to the output and the routed teaching signal approaches the true error.
 /// </summary>
 /// <typeparam name="T">The numeric data type.</typeparam>
-internal sealed class DirectKolenPollackCreditRule<T> : CreditRuleBase<T>, IFeedbackLearningRule<T>
+/// <remarks>
+/// <para>
+/// <b>For Beginners:</b> DKP starts like DFA (a random shortcut to each layer) but then <i>trains</i> those
+/// shortcuts every step so they steadily become better estimates of the exact feedback — combining DFA's
+/// attention-friendly wiring with back-propagation-like accuracy.
+/// </para>
+/// </remarks>
+internal sealed class DirectKolenPollackCreditRule<T> : CreditRuleBase<T>
 {
-    // _feedback[i] : [outputFeatures, features_i], learned. The output layer has no feedback matrix.
-    private Matrix<T>?[]? _feedback;
-    private int[]? _shapeSignature;
-
     private readonly double _feedbackLearningRate;
     private readonly double _weightDecay;
 
@@ -31,42 +34,25 @@ internal sealed class DirectKolenPollackCreditRule<T> : CreditRuleBase<T>, IFeed
 
     public override string Name => "DirectKolenPollack";
 
-    public override void Initialize(ICreditAssignmentContext<T> context)
-    {
-        if (IsInitializedFor(context)) return;
-
-        var layers = context.Layers;
-        int outputFeatures = layers[layers.Count - 1].FlatFeatureSize;
-        var random = ResolveRandom(context);
-
-        _feedback = new Matrix<T>?[layers.Count];
-        _shapeSignature = new int[layers.Count + 1];
-        _shapeSignature[layers.Count] = outputFeatures;
-        for (int i = 0; i < layers.Count; i++)
-        {
-            _feedback[i] = layers[i].IsOutputLayer
-                ? null
-                : RandomGaussian(outputFeatures, layers[i].FlatFeatureSize, outputFeatures, random, context.NumOps);
-            _shapeSignature[i] = layers[i].FlatFeatureSize;
-        }
-    }
-
     public override void ComputeTeachingSignals(ICreditAssignmentContext<T> context)
     {
-        if (!IsInitializedFor(context)) Initialize(context);
-        var error = ErrorMatrix(context); // [B, C]
+        int outputFeatures = context.OutputError.Shape[1];
+        var feedback = EnsureFeedback(context, (layers, i) =>
+            layers[i].IsOutputLayer ? null : (outputFeatures, layers[i].FlatFeatureSize));
 
+        var error = ErrorMatrix(context); // [B, C]
         foreach (var layer in context.Layers)
         {
             if (layer.IsOutputLayer) continue;
-            var projected = error.Multiply(_feedback![layer.Index]!); // [B, C] · [C, M_i] = [B, M_i]
+            var projected = ProjectThrough(error, feedback[layer.Index]!); // [B, C] · [C, M_i] = [B, M_i]
             layer.TeachingSignal = ToTeachingSignal(projected, layer.OutputShape);
         }
     }
 
-    public void OnParametersUpdated(ICreditAssignmentContext<T> context)
+    protected override void UpdateFeedback(ICreditAssignmentContext<T> context)
     {
-        if (_feedback is null) return;
+        var feedback = Feedback;
+        if (feedback.Count == 0) return;
         var error = ErrorMatrix(context); // [B, C]
         var ops = context.NumOps;
 
@@ -77,18 +63,7 @@ internal sealed class DirectKolenPollackCreditRule<T> : CreditRuleBase<T>, IFeed
             if (layer.IsOutputLayer) continue;
             Matrix<T> activation = FlatMatrix(layer.Output); // [B, M_i]
             Matrix<T> grad = MeanOuter(error, activation, ops); // [C, M_i]
-            KpUpdate(_feedback[layer.Index]!, grad, _feedbackLearningRate, _weightDecay, ops);
+            KpUpdate(feedback[layer.Index]!, grad, _feedbackLearningRate, _weightDecay, ops);
         }
-    }
-
-    private bool IsInitializedFor(ICreditAssignmentContext<T> context)
-    {
-        if (_feedback is null || _shapeSignature is null) return false;
-        var layers = context.Layers;
-        if (_feedback.Length != layers.Count) return false;
-        if (_shapeSignature[layers.Count] != layers[layers.Count - 1].FlatFeatureSize) return false;
-        for (int i = 0; i < layers.Count; i++)
-            if (_shapeSignature[i] != layers[i].FlatFeatureSize) return false;
-        return true;
     }
 }

--- a/src/NeuralNetworks/CreditAssignment/DirectKolenPollackCreditRule.cs
+++ b/src/NeuralNetworks/CreditAssignment/DirectKolenPollackCreditRule.cs
@@ -1,0 +1,94 @@
+using AiDotNet.Interfaces;
+using AiDotNet.LinearAlgebra;
+
+namespace AiDotNet.NeuralNetworks.CreditAssignment;
+
+/// <summary>
+/// <b>Direct Kolen-Pollack (DKP)</b>: Kolen-Pollack feedback learning applied in the Direct Feedback Alignment
+/// topology. As in DFA the global output error is projected directly onto every hidden layer through a per-layer
+/// feedback matrix <c>B_i</c> (shape <c>[outputFeatures, features_i]</c>), so the rule applies uniformly to dense,
+/// attention, feed-forward, LayerNorm and embedding layers. Unlike DFA the matrices are <b>learned</b>: each step
+/// <c>B_i</c> receives the same outer-product increment (plus weight decay) that a direct linear read-out from
+/// layer <c>i</c>'s activation to the output error would receive, so <c>B_i</c> aligns to the effective forward
+/// Jacobian from that layer to the output and the routed teaching signal approaches the true error.
+/// </summary>
+/// <typeparam name="T">The numeric data type.</typeparam>
+internal sealed class DirectKolenPollackCreditRule<T> : CreditRuleBase<T>, IFeedbackLearningRule<T>
+{
+    // _feedback[i] : [outputFeatures, features_i], learned. The output layer has no feedback matrix.
+    private Matrix<T>?[]? _feedback;
+    private int[]? _shapeSignature;
+
+    private readonly double _feedbackLearningRate;
+    private readonly double _weightDecay;
+
+    public DirectKolenPollackCreditRule(int? seed = null, double feedbackLearningRate = 0.05, double weightDecay = 0.001)
+        : base(seed)
+    {
+        _feedbackLearningRate = feedbackLearningRate;
+        _weightDecay = weightDecay;
+    }
+
+    public override string Name => "DirectKolenPollack";
+
+    public override void Initialize(ICreditAssignmentContext<T> context)
+    {
+        if (IsInitializedFor(context)) return;
+
+        var layers = context.Layers;
+        int outputFeatures = layers[layers.Count - 1].FlatFeatureSize;
+        var random = ResolveRandom(context);
+
+        _feedback = new Matrix<T>?[layers.Count];
+        _shapeSignature = new int[layers.Count + 1];
+        _shapeSignature[layers.Count] = outputFeatures;
+        for (int i = 0; i < layers.Count; i++)
+        {
+            _feedback[i] = layers[i].IsOutputLayer
+                ? null
+                : RandomGaussian(outputFeatures, layers[i].FlatFeatureSize, outputFeatures, random, context.NumOps);
+            _shapeSignature[i] = layers[i].FlatFeatureSize;
+        }
+    }
+
+    public override void ComputeTeachingSignals(ICreditAssignmentContext<T> context)
+    {
+        if (!IsInitializedFor(context)) Initialize(context);
+        var error = ErrorMatrix(context); // [B, C]
+
+        foreach (var layer in context.Layers)
+        {
+            if (layer.IsOutputLayer) continue;
+            var projected = error.Multiply(_feedback![layer.Index]!); // [B, C] · [C, M_i] = [B, M_i]
+            layer.TeachingSignal = ToTeachingSignal(projected, layer.OutputShape);
+        }
+    }
+
+    public void OnParametersUpdated(ICreditAssignmentContext<T> context)
+    {
+        if (_feedback is null) return;
+        var error = ErrorMatrix(context); // [B, C]
+        var ops = context.NumOps;
+
+        // Align B_i to the effective forward map from layer i to the output: give it the increment a direct linear
+        // read-out (output ≈ activation_i · B_iᵀ) trained against the error would receive: ΔB_i ∝ errorᵀ · activation_i.
+        foreach (var layer in context.Layers)
+        {
+            if (layer.IsOutputLayer) continue;
+            Matrix<T> activation = FlatMatrix(layer.Output); // [B, M_i]
+            Matrix<T> grad = MeanOuter(error, activation, ops); // [C, M_i]
+            KpUpdate(_feedback[layer.Index]!, grad, _feedbackLearningRate, _weightDecay, ops);
+        }
+    }
+
+    private bool IsInitializedFor(ICreditAssignmentContext<T> context)
+    {
+        if (_feedback is null || _shapeSignature is null) return false;
+        var layers = context.Layers;
+        if (_feedback.Length != layers.Count) return false;
+        if (_shapeSignature[layers.Count] != layers[layers.Count - 1].FlatFeatureSize) return false;
+        for (int i = 0; i < layers.Count; i++)
+            if (_shapeSignature[i] != layers[i].FlatFeatureSize) return false;
+        return true;
+    }
+}

--- a/src/NeuralNetworks/CreditAssignment/KolenPollackCreditRule.cs
+++ b/src/NeuralNetworks/CreditAssignment/KolenPollackCreditRule.cs
@@ -15,22 +15,21 @@ namespace AiDotNet.NeuralNetworks.CreditAssignment;
 /// <typeparam name="T">The numeric data type.</typeparam>
 /// <remarks>
 /// <para>
-/// <b>Topology.</b> <c>B_j</c> (shape <c>[outFeatures_j, inFeatures_j]</c>) plays the exact role of the forward
-/// weight <c>W_j</c>: the teaching signal at layer <c>j</c>'s input is <c>δ_j · B_j</c>, which — when
-/// <c>B_j → W_j</c> — equals the true back-propagated error <c>δ_j · W_j</c>. That input-side teaching signal
-/// becomes the trainable layer below's output teaching signal (the layers must chain, i.e. each layer's input
-/// feature count equals the previous trainable layer's output feature count — as in a dense stack). For the
-/// attention/normalization case use <see cref="DirectKolenPollackCreditRule{T}"/>.
+/// <b>For Beginners:</b> KP is Feedback Alignment that <i>learns</i>: every step it nudges each layer's random
+/// feedback matrix to look a little more like the real forward weight, so after a while the shortcut messages it
+/// sends each layer are almost as good as exact back-propagation — which is why it keeps working on deep networks.
+/// </para>
+/// <para>
+/// <b>Topology.</b> <c>B_j</c> (shape <c>[outFeatures_j, inFeatures_j]</c>) plays the role of the forward weight
+/// <c>W_j</c>: the teaching signal at layer <c>j</c>'s input is <c>δ_j · B_j</c>, which — when <c>B_j → W_j</c> —
+/// equals the true back-propagated error <c>δ_j · W_j</c>. That input-side teaching signal becomes the trainable
+/// layer below's output teaching signal (the layers must chain, i.e. each layer's input feature count equals the
+/// previous trainable layer's output feature count — as in a dense stack). For attention/normalization use
+/// <see cref="DirectKolenPollackCreditRule{T}"/>.
 /// </para>
 /// </remarks>
-internal sealed class KolenPollackCreditRule<T> : CreditRuleBase<T>, IFeedbackLearningRule<T>
+internal sealed class KolenPollackCreditRule<T> : CreditRuleBase<T>
 {
-    // _feedback[j] : [outFeatures_j, inFeatures_j], learned toward W_j. _feedback[0] is unused (the first
-    // trainable layer needs no downward feedback matrix — nothing below it consumes its input teaching).
-    private Matrix<T>?[]? _feedback;
-    private int[]? _outSignature;
-    private int[]? _inSignature;
-
     private readonly double _feedbackLearningRate;
     private readonly double _weightDecay;
 
@@ -43,32 +42,13 @@ internal sealed class KolenPollackCreditRule<T> : CreditRuleBase<T>, IFeedbackLe
 
     public override string Name => "KolenPollack";
 
-    public override void Initialize(ICreditAssignmentContext<T> context)
-    {
-        if (IsInitializedFor(context)) return;
-
-        var layers = context.Layers;
-        var random = ResolveRandom(context);
-
-        _feedback = new Matrix<T>?[layers.Count];
-        _outSignature = new int[layers.Count];
-        _inSignature = new int[layers.Count];
-        for (int j = 0; j < layers.Count; j++)
-        {
-            int outFeatures = layers[j].FlatFeatureSize;
-            int inFeatures = InFeatures(layers[j]);
-            _outSignature[j] = outFeatures;
-            _inSignature[j] = inFeatures;
-            // j == 0 has no downstream trainable layer that consumes its input teaching, so no feedback matrix.
-            _feedback[j] = j == 0
-                ? null
-                : RandomGaussian(outFeatures, inFeatures, outFeatures, random, context.NumOps);
-        }
-    }
+    // B_j (j >= 1) maps layer j's output-teaching to its input-teaching; layer 0 needs none (nothing below consumes it).
+    private Matrix<T>?[] EnsureFeedback(ICreditAssignmentContext<T> context) =>
+        EnsureFeedback(context, (layers, j) => j == 0 ? null : (layers[j].FlatFeatureSize, InFeatures(layers[j])));
 
     public override void ComputeTeachingSignals(ICreditAssignmentContext<T> context)
     {
-        if (!IsInitializedFor(context)) Initialize(context);
+        var feedback = EnsureFeedback(context);
         var layers = context.Layers;
         int last = layers.Count - 1;
 
@@ -77,8 +57,8 @@ internal sealed class KolenPollackCreditRule<T> : CreditRuleBase<T>, IFeedbackLe
         Matrix<T> delta = ErrorMatrix(context); // [B, outFeatures_last]
         for (int j = last; j >= 1; j--)
         {
-            var b = _feedback![j]!;               // [outFeatures_j, inFeatures_j]
-            Matrix<T> teachingBelow = delta.Multiply(b); // [B, inFeatures_j] == below layer's output space
+            var b = feedback[j]!;                          // [outFeatures_j, inFeatures_j]
+            Matrix<T> teachingBelow = delta.Multiply(b);   // [B, inFeatures_j] == below layer's output space
 
             var below = layers[j - 1];
             if (teachingBelow.Columns != below.FlatFeatureSize)
@@ -94,9 +74,10 @@ internal sealed class KolenPollackCreditRule<T> : CreditRuleBase<T>, IFeedbackLe
         }
     }
 
-    public void OnParametersUpdated(ICreditAssignmentContext<T> context)
+    protected override void UpdateFeedback(ICreditAssignmentContext<T> context)
     {
-        if (_feedback is null) return;
+        var feedback = Feedback;
+        if (feedback.Count == 0) return;
         var layers = context.Layers;
         int last = layers.Count - 1;
         var ops = context.NumOps;
@@ -108,26 +89,7 @@ internal sealed class KolenPollackCreditRule<T> : CreditRuleBase<T>, IFeedbackLe
             Matrix<T> deltaOut = j == last ? ErrorMatrix(context) : FlatMatrix(layers[j].TeachingSignal!);
             Matrix<T> input = FlatMatrix(layers[j].Input); // [B, inFeatures_j]
             Matrix<T> grad = MeanOuter(deltaOut, input, ops); // [outFeatures_j, inFeatures_j]
-            KpUpdate(_feedback[j]!, grad, _feedbackLearningRate, _weightDecay, ops);
+            KpUpdate(feedback[j]!, grad, _feedbackLearningRate, _weightDecay, ops);
         }
-    }
-
-    private static int InFeatures(ICreditLayer<T> layer)
-    {
-        var shape = layer.Input.Shape;
-        int flat = 1;
-        for (int i = 1; i < shape.Length; i++) flat *= shape[i];
-        return flat;
-    }
-
-    private bool IsInitializedFor(ICreditAssignmentContext<T> context)
-    {
-        if (_feedback is null || _outSignature is null || _inSignature is null) return false;
-        var layers = context.Layers;
-        if (_feedback.Length != layers.Count) return false;
-        for (int j = 0; j < layers.Count; j++)
-            if (_outSignature[j] != layers[j].FlatFeatureSize || _inSignature[j] != InFeatures(layers[j]))
-                return false;
-        return true;
     }
 }

--- a/src/NeuralNetworks/CreditAssignment/KolenPollackCreditRule.cs
+++ b/src/NeuralNetworks/CreditAssignment/KolenPollackCreditRule.cs
@@ -1,0 +1,133 @@
+using AiDotNet.Interfaces;
+using AiDotNet.LinearAlgebra;
+
+namespace AiDotNet.NeuralNetworks.CreditAssignment;
+
+/// <summary>
+/// <b>Kolen-Pollack (KP)</b> feedback learning (Kolen &amp; Pollack, 1994; Akrout et al., 2019, "Deep Learning
+/// without Weight Transport"). Like Feedback Alignment the error is routed sequentially through per-layer feedback
+/// matrices instead of the transpose forward weights — but here the feedback matrices are <b>learned</b>. Each step
+/// every feedback matrix <c>B_j</c> receives the <i>same</i> outer-product increment (plus weight decay) that its
+/// forward weight <c>W_j</c> receives, so the difference <c>W_j − B_j</c> decays and <c>B_j</c> converges to
+/// <c>W_j</c>. As alignment improves, the routed teaching signal approaches the exact back-propagated error, so KP
+/// closes the credit-assignment gap that fixed-feedback FA/DFA leave open on deep networks.
+/// </summary>
+/// <typeparam name="T">The numeric data type.</typeparam>
+/// <remarks>
+/// <para>
+/// <b>Topology.</b> <c>B_j</c> (shape <c>[outFeatures_j, inFeatures_j]</c>) plays the exact role of the forward
+/// weight <c>W_j</c>: the teaching signal at layer <c>j</c>'s input is <c>δ_j · B_j</c>, which — when
+/// <c>B_j → W_j</c> — equals the true back-propagated error <c>δ_j · W_j</c>. That input-side teaching signal
+/// becomes the trainable layer below's output teaching signal (the layers must chain, i.e. each layer's input
+/// feature count equals the previous trainable layer's output feature count — as in a dense stack). For the
+/// attention/normalization case use <see cref="DirectKolenPollackCreditRule{T}"/>.
+/// </para>
+/// </remarks>
+internal sealed class KolenPollackCreditRule<T> : CreditRuleBase<T>, IFeedbackLearningRule<T>
+{
+    // _feedback[j] : [outFeatures_j, inFeatures_j], learned toward W_j. _feedback[0] is unused (the first
+    // trainable layer needs no downward feedback matrix — nothing below it consumes its input teaching).
+    private Matrix<T>?[]? _feedback;
+    private int[]? _outSignature;
+    private int[]? _inSignature;
+
+    private readonly double _feedbackLearningRate;
+    private readonly double _weightDecay;
+
+    public KolenPollackCreditRule(int? seed = null, double feedbackLearningRate = 0.05, double weightDecay = 0.001)
+        : base(seed)
+    {
+        _feedbackLearningRate = feedbackLearningRate;
+        _weightDecay = weightDecay;
+    }
+
+    public override string Name => "KolenPollack";
+
+    public override void Initialize(ICreditAssignmentContext<T> context)
+    {
+        if (IsInitializedFor(context)) return;
+
+        var layers = context.Layers;
+        var random = ResolveRandom(context);
+
+        _feedback = new Matrix<T>?[layers.Count];
+        _outSignature = new int[layers.Count];
+        _inSignature = new int[layers.Count];
+        for (int j = 0; j < layers.Count; j++)
+        {
+            int outFeatures = layers[j].FlatFeatureSize;
+            int inFeatures = InFeatures(layers[j]);
+            _outSignature[j] = outFeatures;
+            _inSignature[j] = inFeatures;
+            // j == 0 has no downstream trainable layer that consumes its input teaching, so no feedback matrix.
+            _feedback[j] = j == 0
+                ? null
+                : RandomGaussian(outFeatures, inFeatures, outFeatures, random, context.NumOps);
+        }
+    }
+
+    public override void ComputeTeachingSignals(ICreditAssignmentContext<T> context)
+    {
+        if (!IsInitializedFor(context)) Initialize(context);
+        var layers = context.Layers;
+        int last = layers.Count - 1;
+
+        // δ starts as the output error at the output layer's output space, then is transported down one trainable
+        // layer at a time via that layer's learned feedback matrix.
+        Matrix<T> delta = ErrorMatrix(context); // [B, outFeatures_last]
+        for (int j = last; j >= 1; j--)
+        {
+            var b = _feedback![j]!;               // [outFeatures_j, inFeatures_j]
+            Matrix<T> teachingBelow = delta.Multiply(b); // [B, inFeatures_j] == below layer's output space
+
+            var below = layers[j - 1];
+            if (teachingBelow.Columns != below.FlatFeatureSize)
+            {
+                throw new NotSupportedException(
+                    $"KolenPollack requires consecutive trainable layers to chain (layer {j}'s input feature count " +
+                    $"{teachingBelow.Columns} must equal layer {j - 1}'s output feature count {below.FlatFeatureSize}). " +
+                    "Use CreditRule.DirectKolenPollack for attention / non-chaining architectures.");
+            }
+
+            below.TeachingSignal = ToTeachingSignal(teachingBelow, below.OutputShape);
+            delta = teachingBelow;
+        }
+    }
+
+    public void OnParametersUpdated(ICreditAssignmentContext<T> context)
+    {
+        if (_feedback is null) return;
+        var layers = context.Layers;
+        int last = layers.Count - 1;
+        var ops = context.NumOps;
+
+        // Each feedback matrix receives the same mean outer-product increment its forward weight receives:
+        // ΔB_j ∝ (δ_j^out)ᵀ · input_j, with weight decay — driving B_j → W_j (Kolen-Pollack).
+        for (int j = 1; j <= last; j++)
+        {
+            Matrix<T> deltaOut = j == last ? ErrorMatrix(context) : FlatMatrix(layers[j].TeachingSignal!);
+            Matrix<T> input = FlatMatrix(layers[j].Input); // [B, inFeatures_j]
+            Matrix<T> grad = MeanOuter(deltaOut, input, ops); // [outFeatures_j, inFeatures_j]
+            KpUpdate(_feedback[j]!, grad, _feedbackLearningRate, _weightDecay, ops);
+        }
+    }
+
+    private static int InFeatures(ICreditLayer<T> layer)
+    {
+        var shape = layer.Input.Shape;
+        int flat = 1;
+        for (int i = 1; i < shape.Length; i++) flat *= shape[i];
+        return flat;
+    }
+
+    private bool IsInitializedFor(ICreditAssignmentContext<T> context)
+    {
+        if (_feedback is null || _outSignature is null || _inSignature is null) return false;
+        var layers = context.Layers;
+        if (_feedback.Length != layers.Count) return false;
+        for (int j = 0; j < layers.Count; j++)
+            if (_outSignature[j] != layers[j].FlatFeatureSize || _inSignature[j] != InFeatures(layers[j]))
+                return false;
+        return true;
+    }
+}

--- a/src/NeuralNetworks/CreditAssignment/SequentialFeedbackRule.cs
+++ b/src/NeuralNetworks/CreditAssignment/SequentialFeedbackRule.cs
@@ -44,47 +44,27 @@ internal abstract class SequentialFeedbackRule<T> : CreditRuleBase<T>
 /// <b>Feedback Alignment</b> (Lillicrap et al., 2016): the error is routed sequentially through a <i>fixed random</i>
 /// feedback matrix at each layer boundary instead of the transpose weights.
 /// </summary>
+/// <typeparam name="T">The numeric data type.</typeparam>
+/// <remarks>
+/// <para>
+/// <b>For Beginners:</b> Feedback Alignment replaces each layer's exact backward matrix with a fixed random one and
+/// passes the error back through those, one layer at a time. It still learns because the forward weights gradually
+/// rotate to line up with the random feedback — the original demonstration that back-propagation's exact weights
+/// are not strictly required.
+/// </para>
+/// </remarks>
 internal sealed class FeedbackAlignmentCreditRule<T> : SequentialFeedbackRule<T>
 {
-    private Matrix<T>[]? _feedback; // _feedback[i] : [M_{i+1}, M_i]
-    private int[]? _shapeSignature;
-
     public FeedbackAlignmentCreditRule(int? seed = null) : base(seed) { }
 
     public override string Name => "FeedbackAlignment";
 
-    public override void Initialize(ICreditAssignmentContext<T> context)
-    {
-        if (IsInitializedFor(context)) return;
-        var layers = context.Layers;
-        var random = ResolveRandom(context);
-
-        _feedback = new Matrix<T>[Math.Max(0, layers.Count - 1)];
-        _shapeSignature = new int[layers.Count];
-        for (int i = 0; i < layers.Count; i++)
-            _shapeSignature[i] = layers[i].FlatFeatureSize;
-        for (int i = 0; i < layers.Count - 1; i++)
-        {
-            int mNext = layers[i + 1].FlatFeatureSize;
-            int mThis = layers[i].FlatFeatureSize;
-            _feedback[i] = RandomGaussian(mNext, mThis, mNext, random, context.NumOps);
-        }
-    }
-
     protected override Matrix<T> FeedbackMatrix(int index, ICreditAssignmentContext<T> context)
     {
-        if (!IsInitializedFor(context)) Initialize(context);
-        return _feedback![index];
-    }
-
-    private bool IsInitializedFor(ICreditAssignmentContext<T> context)
-    {
-        if (_feedback is null || _shapeSignature is null) return false;
-        var layers = context.Layers;
-        if (_shapeSignature.Length != layers.Count) return false;
-        for (int i = 0; i < layers.Count; i++)
-            if (_shapeSignature[i] != layers[i].FlatFeatureSize) return false;
-        return true;
+        // Boundary matrix i maps layer i+1's output space to layer i's output space: [M_{i+1}, M_i].
+        var feedback = EnsureFeedback(context, (layers, i) =>
+            i < layers.Count - 1 ? (layers[i + 1].FlatFeatureSize, layers[i].FlatFeatureSize) : ((int, int)?)null);
+        return feedback[index]!;
     }
 }
 
@@ -94,6 +74,14 @@ internal sealed class FeedbackAlignmentCreditRule<T> : SequentialFeedbackRule<T>
 /// single weight matrix (dense layers); it is not defined for attention/normalization blocks, which have no single
 /// weight — use Direct Feedback Alignment for those architectures.
 /// </summary>
+/// <typeparam name="T">The numeric data type.</typeparam>
+/// <remarks>
+/// <para>
+/// <b>For Beginners:</b> Sign-Symmetric keeps only the <i>sign</i> (+/−) of each real weight for the backward pass
+/// and throws away the magnitude. Unlike the random rules its feedback tracks the live weight signs every step, so
+/// it stays closer to true back-propagation while still avoiding exact weight transport.
+/// </para>
+/// </remarks>
 internal sealed class SignSymmetricCreditRule<T> : SequentialFeedbackRule<T>
 {
     public SignSymmetricCreditRule(int? seed = null) : base(seed) { }
@@ -126,6 +114,7 @@ internal sealed class SignSymmetricCreditRule<T> : SequentialFeedbackRule<T>
 /// Standard reverse-mode back-propagation, exposed as a credit rule for API symmetry. Selecting it uses the
 /// network's exact gradient (identical to the default path); it produces no teaching signals.
 /// </summary>
+/// <typeparam name="T">The numeric data type.</typeparam>
 internal sealed class BackpropCreditRule<T> : CreditRuleBase<T>
 {
     public override string Name => "Backprop";

--- a/tests/AiDotNet.Tests/IntegrationTests/NeuralNetworks/CreditRuleFacadeTrainingTests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/NeuralNetworks/CreditRuleFacadeTrainingTests.cs
@@ -29,6 +29,9 @@ namespace AiDotNet.Tests.IntegrationTests.NeuralNetworks;
 /// </summary>
 public class CreditRuleFacadeTrainingTests
 {
+    private readonly Xunit.Abstractions.ITestOutputHelper _output;
+    public CreditRuleFacadeTrainingTests(Xunit.Abstractions.ITestOutputHelper output) => _output = output;
+
     // ---- shared metric ------------------------------------------------------------------------
 
     private static double Accuracy<T>(Func<Tensor<T>, Tensor<T>> predict, Tensor<T> testX, int[] labels, int numClasses)
@@ -113,6 +116,10 @@ public class CreditRuleFacadeTrainingTests
     [InlineData(CreditRule.FeedbackAlignment, 0.60)]
     [InlineData(CreditRule.DirectFeedbackAlignment, 0.60)]
     [InlineData(CreditRule.SignSymmetric, 0.60)]
+    [InlineData(CreditRule.KolenPollack, 0.60)]
+    [InlineData(CreditRule.DirectKolenPollack, 0.60)]
+    [InlineData(CreditRule.DRTP, 0.60)]
+    [InlineData(CreditRule.DFANormalized, 0.60)]
     public async Task ConfigureCreditRule_TrainsMlp_HeldOutAccuracyBeatsChance(CreditRule rule, double minAccuracy)
     {
         var (trainX, trainY, _) = MakeBlobs(300, seed: 1);
@@ -238,6 +245,171 @@ public class CreditRuleFacadeTrainingTests
     }
 
     // ===========================================================================================
+    // Per-rule learns table (every rule vs backprop vs chance) + depth-sensitive KP > DFA
+    // ===========================================================================================
+
+    /// <summary>
+    /// Trains a small MLP through the facade with EVERY built-in credit rule on the same learnable blob task and
+    /// reports a held-out top-1 accuracy table (rule → accuracy vs chance vs backprop). Every non-backprop rule
+    /// must clearly beat chance — the regression guard the prior credit-rule feature lacked.
+    /// </summary>
+    [Fact(Timeout = 300000)]
+    public async Task AllCreditRules_LearnMlp_HeldOutAccuracyTable()
+    {
+        var (trainX, trainY, _) = MakeBlobs(300, seed: 1);
+        var (testX, _, testLabels) = MakeBlobs(120, seed: 999);
+        double chance = 1.0 / MlpClasses;
+
+        var rules = new (string name, CreditRule rule)[]
+        {
+            ("Backprop", CreditRule.Backprop),
+            ("FeedbackAlignment", CreditRule.FeedbackAlignment),
+            ("DirectFeedbackAlignment", CreditRule.DirectFeedbackAlignment),
+            ("SignSymmetric", CreditRule.SignSymmetric),
+            ("KolenPollack", CreditRule.KolenPollack),
+            ("DirectKolenPollack", CreditRule.DirectKolenPollack),
+            ("DRTP", CreditRule.DRTP),
+            ("DFANormalized", CreditRule.DFANormalized),
+        };
+
+        _output.WriteLine($"rule                       heldout(top1)   chance={chance:F3}");
+        foreach (var (name, rule) in rules)
+        {
+            var mlp = BuildMlp();
+            var adam = new AdamOptimizer<double, Tensor<double>, Tensor<double>>(
+                null,
+                new AdamOptimizerOptions<double, Tensor<double>, Tensor<double>>
+                {
+                    InitialLearningRate = 0.03,
+                    MaxIterations = 80,
+                    BatchSize = 32,
+                });
+
+            var result = await new AiModelBuilder<double, Tensor<double>, Tensor<double>>()
+                .ConfigureModel(mlp)
+                .ConfigureOptimizer(adam)
+                .ConfigureCreditRule(rule, seed: 42)
+                .ConfigureLossFunction(new CategoricalCrossEntropyLoss<double>())
+                .ConfigureDataLoader(new InMemoryDataLoader<double, Tensor<double>, Tensor<double>>(trainX, trainY))
+                .BuildAsync();
+
+            double acc = Accuracy<double>(result.Predict, testX, testLabels, MlpClasses);
+            _output.WriteLine($"{name,-26} {acc,10:F3}");
+            Assert.True(acc >= 0.60,
+                $"{name}: held-out accuracy {acc:F3} did not clearly beat chance {chance:F3} (>= 0.60 required).");
+        }
+    }
+
+    // Concentric-rings task: nonlinear (the class is the radius band), backprop-solvable, and depth-sensitive —
+    // fixed random feedback (DFA) loses credit quality with depth, while Kolen-Pollack's learned feedback holds.
+    private const int RingDim = 2, RingClasses = 4;
+
+    private static (Tensor<double> x, Tensor<double> y, int[] labels) MakeRings(int samples, int seed)
+    {
+        var rng = new Random(seed);
+        var x = new Tensor<double>(new[] { samples, RingDim });
+        var y = new Tensor<double>(new[] { samples, RingClasses });
+        var labels = new int[samples];
+        double band = 1.5 / RingClasses;
+        for (int n = 0; n < samples; n++)
+        {
+            int lab = rng.Next(RingClasses);
+            double rMin = lab * band + 0.02, rMax = (lab + 1) * band - 0.02;
+            double r = rMin + rng.NextDouble() * (rMax - rMin);
+            double th = rng.NextDouble() * 2 * Math.PI;
+            x[n, 0] = r * Math.Cos(th);
+            x[n, 1] = r * Math.Sin(th);
+            labels[n] = lab;
+            for (int k = 0; k < RingClasses; k++) y[n, k] = k == lab ? 1.0 : 0.0;
+        }
+        return (x, y, labels);
+    }
+
+    private static NeuralNetwork<double> BuildDeepRingsNet(int hiddenLayers, int width = 32)
+    {
+        var layers = new List<ILayer<double>> { new FullyConnectedLayer<double>(RingDim, width, new ReLUActivation<double>()) };
+        for (int i = 0; i < hiddenLayers - 1; i++)
+            layers.Add(new FullyConnectedLayer<double>(width, width, new ReLUActivation<double>()));
+        layers.Add(new FullyConnectedLayer<double>(width, RingClasses, new SoftmaxActivation<double>()));
+        var architecture = new NeuralNetworkArchitecture<double>(
+            inputType: InputType.OneDimensional,
+            taskType: NeuralNetworkTaskType.MultiClassClassification,
+            complexity: NetworkComplexity.Medium,
+            inputSize: RingDim,
+            outputSize: RingClasses,
+            layers: layers);
+        return new NeuralNetwork<double>(architecture);
+    }
+
+    private async Task<Func<Tensor<double>, Tensor<double>>> TrainRings(CreditRule rule, int hiddenLayers, int seed, Tensor<double> trX, Tensor<double> trY)
+    {
+        var net = BuildDeepRingsNet(hiddenLayers);
+        var adam = new AdamOptimizer<double, Tensor<double>, Tensor<double>>(
+            null,
+            new AdamOptimizerOptions<double, Tensor<double>, Tensor<double>>
+            {
+                InitialLearningRate = 0.01,
+                MaxIterations = 150,
+                BatchSize = 32,
+            });
+        var builder = new AiModelBuilder<double, Tensor<double>, Tensor<double>>()
+            .ConfigureModel(net)
+            .ConfigureOptimizer(adam)
+            .ConfigureLossFunction(new CategoricalCrossEntropyLoss<double>())
+            .ConfigureDataLoader(new InMemoryDataLoader<double, Tensor<double>, Tensor<double>>(trX, trY));
+        if (rule != CreditRule.Backprop) builder = builder.ConfigureCreditRule(rule, seed: seed);
+        var result = await builder.BuildAsync();
+        return result.Predict;
+    }
+
+    /// <summary>
+    /// Depth-sensitive credit-assignment test: on a 4-hidden-layer net solving the nonlinear rings task,
+    /// Kolen-Pollack's LEARNED feedback must (a) clearly beat vanilla Direct Feedback Alignment's fixed random
+    /// feedback and (b) approach back-propagation. This is KP's defining advantage and only emerges with depth.
+    /// Both rules are averaged over several feedback-init seeds so the comparison is robust to that randomness.
+    /// </summary>
+    [Fact(Timeout = 600000)]
+    public async Task KolenPollack_BeatsVanillaDFA_OnDepthSensitiveRings()
+    {
+        const int hidden = 4;
+        var (trX, trY, _) = MakeRings(1500, seed: 1);
+        var (teX, _, teLab) = MakeRings(500, seed: 999);
+        double chance = 1.0 / RingClasses;
+
+        async Task<double> Run(CreditRule rule, int seed)
+        {
+            var predict = await TrainRings(rule, hidden, seed, trX, trY);
+            return Accuracy<double>(predict, teX, teLab, RingClasses);
+        }
+
+        double backprop = await Run(CreditRule.Backprop, 0);
+
+        var seeds = new[] { 1, 2, 3 };
+        double dfaSum = 0, kpSum = 0;
+        int perSeedKpWins = 0;
+        _output.WriteLine($"rings {hidden} hidden layers, chance={chance:F3}, backprop={backprop:F3}");
+        _output.WriteLine("  seed   DFA     KP");
+        foreach (int s in seeds)
+        {
+            double dfaS = await Run(CreditRule.DirectFeedbackAlignment, s);
+            double kpS = await Run(CreditRule.KolenPollack, s);
+            dfaSum += dfaS; kpSum += kpS;
+            if (kpS > dfaS) perSeedKpWins++;
+            _output.WriteLine($"  {s,-4} {dfaS,7:F3} {kpS,7:F3}");
+        }
+        double dfa = dfaSum / seeds.Length;
+        double kp = kpSum / seeds.Length;
+        _output.WriteLine($"  mean DFA={dfa:F3}  KP={kp:F3}  (KP wins {perSeedKpWins}/{seeds.Length} seeds)");
+
+        Assert.True(dfa > 0.60, $"DFA baseline should still learn (mean {dfa:F3}) for a fair comparison.");
+        Assert.True(kp >= 0.90, $"Kolen-Pollack should approach backprop ({backprop:F3}); got mean {kp:F3}.");
+        Assert.True(kp > dfa,
+            $"Kolen-Pollack's learned feedback (mean {kp:F3}) must beat vanilla DFA's fixed feedback (mean {dfa:F3}) at depth {hidden}.");
+        Assert.True(perSeedKpWins >= 2,
+            $"Kolen-Pollack should beat DFA on a majority of seeds; won {perSeedKpWins}/{seeds.Length}.");
+    }
+
+    // ===========================================================================================
     // API + scope
     // ===========================================================================================
 
@@ -265,11 +437,20 @@ public class CreditRuleFacadeTrainingTests
     }
 
     [Fact]
-    public void CreditRuleGradients_PositivelyAlignWithBackprop_OnFixedNet()
+    public void CreditRuleGradients_ReachEveryLayer_AndOutputMatchesBackprop_OnFixedNet()
     {
         var (x, y, _) = MakeBlobs(64, seed: 7);
         var mlp = BuildMlp();
         _ = mlp.Predict(x); // resolve shapes; weights are identical across all measurements below
+
+        // Parameter layout: [hidden W][hidden b][output W][output b]. The first chunk is the first hidden layer's
+        // weights (the layer furthest from the loss); the last two chunks are the output layer.
+        var chunkLens = new List<int>();
+        foreach (var c in mlp.GetParameterChunks()) chunkLens.Add(c.Length);
+        int firstLen = chunkLens[0];
+        int outputLen = chunkLens[chunkLens.Count - 1] + chunkLens[chunkLens.Count - 2];
+        int total = 0; foreach (var l in chunkLens) total += l;
+        int outputStart = total - outputLen;
 
         mlp.SetCreditRule(null);
         var backpropGrad = mlp.ComputeGradients(x, y);
@@ -280,9 +461,19 @@ public class CreditRuleFacadeTrainingTests
             var g = mlp.ComputeGradients(x, y);
             mlp.SetCreditRule(null);
 
-            double cos = Cosine(backpropGrad, g);
-            Assert.True(cos > 0.0,
-                $"{rule} gradient should be positively aligned with back-prop (cosine={cos:F4}).");
+            // Regression guard: credit must actually REACH the earliest hidden layer (a prior bug zeroed every
+            // hidden layer's gradient — only the output layer trained, and only linearly-separable tasks "passed").
+            double firstNorm = 0;
+            for (int i = 0; i < firstLen; i++) firstNorm += g[i] * g[i];
+            Assert.True(Math.Sqrt(firstNorm) > 1e-8,
+                $"{rule}: first hidden layer received a zero gradient — credit did not reach it.");
+
+            // The output layer is trained with the exact loss gradient, so its portion must match back-prop.
+            double dot = 0, na = 0, nb = 0;
+            for (int i = outputStart; i < total; i++) { dot += backpropGrad[i] * g[i]; na += backpropGrad[i] * backpropGrad[i]; nb += g[i] * g[i]; }
+            double outCos = (na == 0 || nb == 0) ? 0 : dot / (Math.Sqrt(na) * Math.Sqrt(nb));
+            Assert.True(outCos > 0.99,
+                $"{rule}: output-layer gradient should equal the exact back-prop loss gradient (cosine={outCos:F4}).");
         }
     }
 

--- a/tests/AiDotNet.Tests/IntegrationTests/NeuralNetworks/CreditRuleFacadeTrainingTests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/NeuralNetworks/CreditRuleFacadeTrainingTests.cs
@@ -509,4 +509,64 @@ public class CreditRuleFacadeTrainingTests
         if (na == 0 || nb == 0) return 0;
         return dot / (Math.Sqrt(na) * Math.Sqrt(nb));
     }
+
+    // ===========================================================================================
+    // Public extensible base class — a user-authored rule outside the library trains through the facade
+    // ===========================================================================================
+
+    /// <summary>
+    /// A minimal custom credit rule authored "outside" the library by subclassing the public
+    /// <see cref="CreditRuleBase{T}"/> and using only its protected helpers — proving the base is genuinely
+    /// extensible and that <c>ConfigureCreditRule(ICreditRule&lt;T&gt;)</c> accepts it.
+    /// </summary>
+    private sealed class CustomDirectRule<T> : CreditRuleBase<T>
+    {
+        public CustomDirectRule(int? seed = null) : base(seed) { }
+        public override string Name => "CustomDirectRule";
+
+        public override void ComputeTeachingSignals(ICreditAssignmentContext<T> context)
+        {
+            int outputFeatures = context.OutputError.Shape[1];
+            var feedback = EnsureFeedback(context, (layers, i) =>
+                layers[i].IsOutputLayer ? null : (outputFeatures, layers[i].FlatFeatureSize));
+            var error = ErrorMatrix(context);
+            foreach (var layer in context.Layers)
+            {
+                if (layer.IsOutputLayer) continue;
+                var projected = ProjectThrough(error, feedback[layer.Index]!);
+                layer.TeachingSignal = ToTeachingSignal(projected, layer.OutputShape);
+            }
+        }
+    }
+
+    [Fact(Timeout = 300000)]
+    public async Task CustomCreditRuleBaseSubclass_TrainsMlp_ThroughFacade()
+    {
+        var (trainX, trainY, _) = MakeBlobs(300, seed: 1);
+        var (testX, _, testLabels) = MakeBlobs(120, seed: 999);
+
+        var mlp = BuildMlp();
+        double before = Accuracy<double>(mlp.Predict, testX, testLabels, MlpClasses);
+
+        var adam = new AdamOptimizer<double, Tensor<double>, Tensor<double>>(
+            null,
+            new AdamOptimizerOptions<double, Tensor<double>, Tensor<double>>
+            {
+                InitialLearningRate = 0.03,
+                MaxIterations = 80,
+                BatchSize = 32,
+            });
+
+        var result = await new AiModelBuilder<double, Tensor<double>, Tensor<double>>()
+            .ConfigureModel(mlp)
+            .ConfigureOptimizer(adam)
+            .ConfigureCreditRule(new CustomDirectRule<double>(seed: 42)) // ICreditRule<T> overload
+            .ConfigureLossFunction(new CategoricalCrossEntropyLoss<double>())
+            .ConfigureDataLoader(new InMemoryDataLoader<double, Tensor<double>, Tensor<double>>(trainX, trainY))
+            .BuildAsync();
+
+        double after = Accuracy<double>(result.Predict, testX, testLabels, MlpClasses);
+        Assert.True(after >= 0.60,
+            $"Custom CreditRuleBase subclass should learn (held-out {after:F3} >= 0.60, chance {1.0 / MlpClasses:F3}, before {before:F3}).");
+    }
 }


### PR DESCRIPTION
## Summary

Expands the pluggable credit-assignment (learning-rule) zoo with the full published DFA-family, promotes the rule base to a **public extensible class**, and fixes a root-cause bug that silently zeroed every hidden layer's gradient under all credit rules. Every rule is verified to learn end-to-end through the facade.

### New rules
| Rule | Enum | Idea |
|---|---|---|
| **KolenPollack (KP)** | `CreditRule.KolenPollack` | Sequential feedback whose matrices are *learned* — each `B_j` gets the same outer-product increment (+ weight decay) as its forward weight, so `B_j -> W_j` and credit approaches backprop. |
| **DirectKolenPollack (DKP)** | `CreditRule.DirectKolenPollack` | KP in the DFA (direct) topology; per-layer direct feedback matrices are learned rather than fixed. |
| **DRTP** (Frenkel & Bol 2021) | `CreditRule.DRTP` | Teaching signal = fixed random projection of the one-hot **target** (no backward error path). |
| **DFANormalized** (Launay 2020 style) | `CreditRule.DFANormalized` | DFA with unit-norm feedback columns + per-layer teaching-signal rescaling for depth-stable magnitude. |

Existing FA / DFA / SignSymmetric are unchanged.

### Public, extensible base class
`CreditRuleBase<T>` is now a **public abstract** class (matching `OptimizerBase` / `LossFunctionBase` / `LayerBase`) that all zoo rules derive from and users can subclass to author custom rules with minimal code. It owns the shared DFA-family machinery — a shape-aware feedback-matrix cache (`EnsureFeedback`), error/target projection + teaching-signal shaping, feedback normalization/sign helpers, Kolen-Pollack update helpers, seeded RNG, and an overridable `protected virtual void UpdateFeedback(context)` hook (default no-op; learned rules override it). "For Beginners" XML docs on the base (with a minimal custom-rule example) and every rule. A custom subclass authored outside the library trains through `ConfigureCreditRule(ICreditRule<T>)` (covered by a test).

### Interface extension (minimal, additive, net471-safe)
- `ICreditLayer<T>.Input` — the layer's forward input activation (KP forms `dB ~ teaching^T . input`).
- `ICreditAssignmentContext<T>.Target` — the aligned one-hot target (DRTP projects it).
- New optional `IFeedbackLearningRule<T> : ICreditRule<T>` with `OnParametersUpdated(ctx)`; the engine calls it once per step so learned rules update feedback. `CreditRuleBase<T>` implements it and forwards to `UpdateFeedback`, so fixed-feedback rules are unaffected.

### Correctness fix (root cause)
`CreditAssignmentGradientComputer` computed each layer's local VJP with a **separate** `tape.ComputeGradients` call — but `GradientTape` is **single-use** (the first backward frees the graph), so every hidden layer's gradient was silently **zero** and only the output layer trained. Prior tests "passed" only because their tasks were linearly separable (the output layer alone sufficed). Fixed by detaching each trainable layer's input during a single forward and backpropagating **one combined objective** (`loss + sum(teaching . output)`) in a single backward — every layer now gets its correct local gradient with no cross-layer leakage. Handles composite Transformer layers.

### Verification — held-out top-1 accuracy via `AiModelBuilder + ConfigureCreditRule + BuildAsync`
Per-rule learns table (learnable 3-class blobs, chance 0.333):

| Rule | Held-out top-1 |
|---|---|
| Backprop | 1.000 |
| FeedbackAlignment | 1.000 |
| DirectFeedbackAlignment | 1.000 |
| SignSymmetric | 1.000 |
| KolenPollack | 1.000 |
| DirectKolenPollack | 1.000 |
| DRTP | 1.000 |
| DFANormalized | 1.000 |

**Depth-sensitive KP > DFA** (concentric rings, 4 classes, 4 hidden layers, mean over 3 feedback seeds): backprop 0.968, **KP 0.983 vs DFA 0.947, KP wins 3/3 seeds** — KP's learned feedback beats DFA's fixed random feedback and approaches backprop.

Regression guards: credit now reaches every hidden layer (nonzero gradient) and the output-layer gradient equals the exact backprop loss gradient; a custom external `CreditRuleBase` subclass learns through the facade; DFA still trains a Transformer.

### Build / test status
- Builds `net10.0` + `net471`, 0 errors.
- All 15 credit facade tests green on net10.0; the credit tests that executed on net471 are green (full net471 suite run is blocked by a pre-existing test-host discovery limit on the ~10k-test assembly).

### Packaged
`AiDotNet 0.234.0-creditzoo` -> local NuGet feed.

Generated with Claude Code
