### PR TITLE
feat(training): wire additional WGAN-GP + diffusion consumers

### DIFF
--- a/src/NeuralNetworks/SyntheticData/AutoDiffTabGenerator.cs
+++ b/src/NeuralNetworks/SyntheticData/AutoDiffTabGenerator.cs
@@ -718,23 +718,77 @@ public class AutoDiffTabGenerator<T> : NeuralNetworkBase<T>, ISyntheticTabularGe
     private void TrainBatch(Matrix<T> data, int startRow, int endRow, T lr)
     {
         if (_alphasCumprod is null) return;
-        for (int row = startRow; row < endRow; row++)
+
+        // Cache MultiSlotFusedStep across rows so the compiled plan is built
+        // once and replayed via slot-data refresh for subsequent rows. See
+        // ooples/AiDotNet#1846.
+        AiDotNet.Training.MultiSlotFusedStep<T>? multiSlotStep = null;
+        try
         {
-            int t = _random.Next(_numTimesteps);
-            var x0 = GetRow(data, row);
-            var noise = CreateStandardNormalVector(_dataWidth);
-            double sqrtAbar = Math.Sqrt(NumOps.ToDouble(_alphasCumprod[t]));
-            double sqrtOneMinusAbar = Math.Sqrt(1.0 - NumOps.ToDouble(_alphasCumprod[t]));
+            var denoiserLayers = BuildDenoiserLayerList();
+            var trainableParams = Training.TapeTrainingStep<T>.CollectParameters(denoiserLayers).ToArray();
+            AiDotNet.Tensors.Engines.Compilation.OptimizerType mfsOptType = default;
+            float mfsLr = 0f, mfsB1 = 0f, mfsB2 = 0f, mfsEps = 0f, mfsWd = 0f;
+            bool fusedEligible = false;
+            if (trainableParams.Length > 0)
+            {
+                fusedEligible = NeuralNetworkBase<T>.TryMapToFusedOptimizerConfig(
+                    _optimizer,
+                    out mfsOptType, out mfsLr, out mfsB1, out mfsB2,
+                    out mfsEps, out mfsWd, out _, out _);
+            }
 
-            var xt = new Vector<T>(_dataWidth);
-            for (int j = 0; j < _dataWidth; j++)
-                xt[j] = NumOps.FromDouble(sqrtAbar * NumOps.ToDouble(x0[j]) + sqrtOneMinusAbar * NumOps.ToDouble(noise[j]));
+            for (int row = startRow; row < endRow; row++)
+            {
+                int t = _random.Next(_numTimesteps);
+                var x0 = GetRow(data, row);
+                var noise = CreateStandardNormalVector(_dataWidth);
+                double sqrtAbar = Math.Sqrt(NumOps.ToDouble(_alphasCumprod[t]));
+                double sqrtOneMinusAbar = Math.Sqrt(1.0 - NumOps.ToDouble(_alphasCumprod[t]));
 
-            using var tape = new GradientTape<T>();
-            var pred = DenoiserForward(BuildDenoiserInput(xt, t));
-            var target = VectorToTensor(noise);
-            var loss = ReduceToScalar(Engine.TensorSquare(Engine.TensorSubtract(pred, target)));
-            TapeStepOver(tape, loss, BuildDenoiserLayerList());
+                var xt = new Vector<T>(_dataWidth);
+                for (int j = 0; j < _dataWidth; j++)
+                    xt[j] = NumOps.FromDouble(sqrtAbar * NumOps.ToDouble(x0[j]) + sqrtOneMinusAbar * NumOps.ToDouble(noise[j]));
+
+                // Preferred fused path: MultiSlotFusedStep with (denoiserInput, targetNoise)
+                // as persistent slots. The denoiser layer set replays per row with fresh slots.
+                if (fusedEligible)
+                {
+                    multiSlotStep ??= new AiDotNet.Training.MultiSlotFusedStep<T>();
+                    var denoiserInput = BuildDenoiserInput(xt, t);
+                    var targetNoiseT = VectorToTensor(noise);
+                    var slots = new[] { denoiserInput, targetNoiseT };
+                    Tensor<T> ForwardFromSlots(IReadOnlyList<Tensor<T>> s) => DenoiserForward(s[0]);
+                    Tensor<T> ComputeLossFromSlots(Tensor<T> pred, IReadOnlyList<Tensor<T>> s) =>
+                        ReduceToScalar(Engine.TensorSquare(Engine.TensorSubtract(pred, s[1])));
+                    if (multiSlotStep.TryStep(
+                            parameters: trainableParams,
+                            zeroGradAction: null,
+                            freshSlotData: slots,
+                            forward: ForwardFromSlots,
+                            computeLoss: ComputeLossFromSlots,
+                            optimizerType: mfsOptType,
+                            learningRate: mfsLr,
+                            beta1: mfsB1,
+                            beta2: mfsB2,
+                            epsilon: mfsEps,
+                            weightDecay: mfsWd,
+                            out T _))
+                    {
+                        continue;
+                    }
+                }
+
+                using var tape = new GradientTape<T>();
+                var pred = DenoiserForward(BuildDenoiserInput(xt, t));
+                var target = VectorToTensor(noise);
+                var loss = ReduceToScalar(Engine.TensorSquare(Engine.TensorSubtract(pred, target)));
+                TapeStepOver(tape, loss, denoiserLayers);
+            }
+        }
+        finally
+        {
+            multiSlotStep?.Dispose();
         }
     }
 

--- a/src/NeuralNetworks/SyntheticData/FinDiffGenerator.cs
+++ b/src/NeuralNetworks/SyntheticData/FinDiffGenerator.cs
@@ -420,40 +420,101 @@ public class FinDiffGenerator<T> : NeuralNetworkBase<T>, ISyntheticTabularGenera
 
     private void TrainBatch(Matrix<T> data, int startRow, int endRow)
     {
-        for (int row = startRow; row < endRow; row++)
+        // Cache MultiSlotFusedStep across rows so the compiled plan is built
+        // once and replayed via slot-data refresh for subsequent rows. See
+        // ooples/AiDotNet#1846.
+        AiDotNet.Training.MultiSlotFusedStep<T>? multiSlotStep = null;
+        try
         {
-            int t = _random.Next(_options.NumTimesteps);
-            var x0 = GetRow(data, row);
-            var noise = CreateStandardNormalVector(_dataWidth);
-
-            double sqrtAlphaBar = Math.Sqrt(_alphasCumprod[t]);
-            double sqrtOneMinusAlphaBar = Math.Sqrt(1.0 - _alphasCumprod[t]);
-
-            // Build noisy input: xt = sqrt(alpha_bar) * x0 + sqrt(1-alpha_bar) * noise
-            var xt = new Vector<T>(_dataWidth);
-            for (int j = 0; j < _dataWidth; j++)
+            var trainableParams = Training.TapeTrainingStep<T>.CollectParameters(Layers).ToArray();
+            AiDotNet.Tensors.Engines.Compilation.OptimizerType mfsOptType = default;
+            float mfsLr = 0f, mfsB1 = 0f, mfsB2 = 0f, mfsEps = 0f, mfsWd = 0f;
+            bool fusedEligible = false;
+            if (trainableParams.Length > 0)
             {
-                xt[j] = NumOps.FromDouble(
-                    sqrtAlphaBar * NumOps.ToDouble(x0[j]) +
-                    sqrtOneMinusAlphaBar * NumOps.ToDouble(noise[j]));
+                fusedEligible = NeuralNetworkBase<T>.TryMapToFusedOptimizerConfig(
+                    _optimizer,
+                    out mfsOptType, out mfsLr, out mfsB1, out mfsB2,
+                    out mfsEps, out mfsWd, out _, out _);
             }
 
-            // Build target noise tensor
-            var targetNoise = new Tensor<T>([_dataWidth]);
-            for (int j = 0; j < _dataWidth; j++)
+            for (int row = startRow; row < endRow; row++)
             {
-                targetNoise[j] = noise[j];
+                int t = _random.Next(_options.NumTimesteps);
+                var x0 = GetRow(data, row);
+                var noise = CreateStandardNormalVector(_dataWidth);
+
+                double sqrtAlphaBar = Math.Sqrt(_alphasCumprod[t]);
+                double sqrtOneMinusAlphaBar = Math.Sqrt(1.0 - _alphasCumprod[t]);
+
+                // Build noisy input: xt = sqrt(alpha_bar) * x0 + sqrt(1-alpha_bar) * noise
+                var xt = new Vector<T>(_dataWidth);
+                for (int j = 0; j < _dataWidth; j++)
+                {
+                    xt[j] = NumOps.FromDouble(
+                        sqrtAlphaBar * NumOps.ToDouble(x0[j]) +
+                        sqrtOneMinusAlphaBar * NumOps.ToDouble(noise[j]));
+                }
+
+                // Build target noise tensor
+                var targetNoise = new Tensor<T>([_dataWidth]);
+                for (int j = 0; j < _dataWidth; j++)
+                {
+                    targetNoise[j] = noise[j];
+                }
+
+                // Create timestep embedding and build input tensor
+                var timeEmbed = CreateTimestepEmbedding(t);
+                int totalLen = xt.Length + timeEmbed.Length;
+                var input = new Tensor<T>([totalLen]);
+                for (int j = 0; j < xt.Length; j++) input[j] = xt[j];
+                for (int j = 0; j < timeEmbed.Length; j++) input[xt.Length + j] = timeEmbed[j];
+
+                // Preferred fused path: MultiSlotFusedStep with (packedInput, targetNoise)
+                // as persistent slots. Layers stay unchanged; the compiled plan replays
+                // the Layers forward per row with fresh slot data.
+                if (fusedEligible)
+                {
+                    multiSlotStep ??= new AiDotNet.Training.MultiSlotFusedStep<T>();
+                    var slots = new[] { input, targetNoise };
+                    Tensor<T> ForwardFromSlots(IReadOnlyList<Tensor<T>> s)
+                    {
+                        var current = s[0];
+                        foreach (var layer in Layers) current = layer.Forward(current);
+                        return current;
+                    }
+                    Tensor<T> ComputeLossFromSlots(Tensor<T> pred, IReadOnlyList<Tensor<T>> s)
+                    {
+                        var diff = Engine.TensorSubtract(pred, s[1]);
+                        var sq = Engine.TensorMultiply(diff, diff);
+                        var axes = Enumerable.Range(0, sq.Shape.Length).ToArray();
+                        return Engine.ReduceMean(sq, axes, keepDims: false);
+                    }
+                    if (multiSlotStep.TryStep(
+                            parameters: trainableParams,
+                            zeroGradAction: null,
+                            freshSlotData: slots,
+                            forward: ForwardFromSlots,
+                            computeLoss: ComputeLossFromSlots,
+                            optimizerType: mfsOptType,
+                            learningRate: mfsLr,
+                            beta1: mfsB1,
+                            beta2: mfsB2,
+                            epsilon: mfsEps,
+                            weightDecay: mfsWd,
+                            out T _))
+                    {
+                        continue;
+                    }
+                }
+
+                // Eager fallback: GANDALF pattern (forward -> loss -> backward -> update).
+                Train(input, targetNoise);
             }
-
-            // Create timestep embedding and build input tensor
-            var timeEmbed = CreateTimestepEmbedding(t);
-            int totalLen = xt.Length + timeEmbed.Length;
-            var input = new Tensor<T>([totalLen]);
-            for (int j = 0; j < xt.Length; j++) input[j] = xt[j];
-            for (int j = 0; j < timeEmbed.Length; j++) input[xt.Length + j] = timeEmbed[j];
-
-            // Use Train() method (GANDALF pattern: forward -> loss -> backward -> update)
-            Train(input, targetNoise);
+        }
+        finally
+        {
+            multiSlotStep?.Dispose();
         }
     }
 

--- a/src/NeuralNetworks/WGANGP.cs
+++ b/src/NeuralNetworks/WGANGP.cs
@@ -355,6 +355,48 @@ public class WGANGP<T> : NeuralNetworkBase<T>
     {
         Critic.SetTrainingMode(true);
 
+        // Preferred fused path: WganGpFusedStep runs the full WGAN-GP critic
+        // objective (Wasserstein + λ·GP with createGraph=true GP) in one
+        // compiled plan. Bypasses the legacy flat-vector round-trip (which
+        // needs to Predict the critic three times per step, extract flat
+        // gradients, combine host-side, then apply). See ooples/AiDotNet#1845.
+        var criticDiscParams = Training.TapeTrainingStep<T>.CollectParameters(Critic.Layers);
+        if (criticDiscParams.Count > 0
+            && TryMapToFusedOptimizerConfig(
+                _criticOptimizer,
+                out var wganOptType, out var wganLr, out var wganB1,
+                out var wganB2, out var wganEps, out var wganWd,
+                out _, out _))
+        {
+            using var wganStep = new AiDotNet.Training.WganGpFusedStep<T>();
+            Tensor<T> DiscFwd(Tensor<T> inp)
+            {
+                Tensor<T> current = inp;
+                foreach (var layer in Critic.Layers)
+                    current = layer.Forward(current);
+                return current;
+            }
+            Tensor<T> EpsilonSampler(int bs) =>
+                Engine.TensorRandomUniformRange<T>(new[] { bs, 1 }, NumOps.Zero, NumOps.One);
+            if (wganStep.TryStep(
+                    discParameters: criticDiscParams,
+                    realBatch: realImages,
+                    fakeBatch: fakeImages,
+                    discForward: DiscFwd,
+                    epsilonSampler: EpsilonSampler,
+                    gradientPenaltyWeight: _gradientPenaltyCoefficient,
+                    optimizerType: wganOptType,
+                    learningRate: wganLr,
+                    beta1: wganB1,
+                    beta2: wganB2,
+                    epsilon: wganEps,
+                    weightDecay: wganWd,
+                    out T fusedLoss))
+            {
+                return (fusedLoss, NumOps.Zero);
+            }
+        }
+
         // Forward pass on real images to compute scores using vectorized reduction
         var realScores = Critic.Predict(realImages);
         T realScore = NumOps.Divide(Engine.TensorSum(realScores), NumOps.FromDouble(batchSize));


### PR DESCRIPTION
Follow-up to PR #1847. A comprehensive audit surfaced additional WGAN-GP and diffusion consumers beyond the four named in issues #1845/#1846. This PR wires the ones that fit the primitives cleanly and documents the ones that need TFC/CSDI-scale rework first.

## Summary

**Wired (3 new consumers):**

- **`src/NeuralNetworks/WGANGP.cs`** — standalone WGAN-GP class. Was using the legacy flat-vector round-trip (`GetParameterGradients` + host-side combine + `UpdateCriticWithOptimizer`). Now attempts `WganGpFusedStep.TryStep` first with `Critic.Layers` as the parameter source.
- **`src/NeuralNetworks/SyntheticData/FinDiffGenerator.cs`** — per-row DDPM training (Sattarov et al. 2023). `TrainBatch` now caches a `MultiSlotFusedStep` across rows.
- **`src/NeuralNetworks/SyntheticData/AutoDiffTabGenerator.cs`** — same per-row pattern as FinDiff. `TrainBatch` caches `MultiSlotFusedStep` slots `(denoiserInput, targetNoise)`.

**Explicitly not wired (documented in commit message):**

- **`GenerativeAdversarialNetwork.cs`** — uses BCE + optional GP regularization, NOT Wasserstein + GP. Wiring WganGpFusedStep would change training semantics.
- **Finance/Forecasting/Foundation: CCDM, MGTSD, TSDiff, TimeDiff, TimeGrad, DiffusionTS** — each has `.Data.Span` host-side packs (same trace-freeze issue TFC/CSDI had in #1843). Each needs a TFC/CSDI-scale traceable rewrite BEFORE fused wiring is safe.
- **MetaLearning: MetaDDPMAlgorithm, MetaDMAlgorithm, MetaDiffAlgorithm** — hand-rolled `Vector<T>` params with index arithmetic, not ILayer/Engine/tape.
- **DiffusionModelBase subclasses (DDPMModel, DiffWaveModel, LatentDiffusionModelBase)** — the `SupportsFusedDenoising` opt-in hook from #1847 is available; flipping it requires per-class audit of `PredictNoise` → UNet traceability.

## Test plan

- [x] `dotnet build -f net8.0` — clean
- [x] `dotnet build -f net471` — clean
- [x] `dotnet build -f net10.0` — clean
- [ ] CI + CodeRabbit review pass
- [ ] Runtime verification once #1843 + #1847 merge to master

## Base branch

Targets `feat/gpu-resident-nonts` (PR #1843's branch, which already contains #1847's merge). Once #1843 merges to master, this PR will retarget to master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)