### PR TITLE
fix(finance): TFT/Informer train through the genuine tape forward

### DIFF
--- a/src/Finance/Forecasting/Transformers/Informer.cs
+++ b/src/Finance/Forecasting/Transformers/Informer.cs
@@ -733,6 +733,23 @@ public class Informer<T> : ForecastingModelBase<T>
     }
 
     /// <summary>
+    /// Tape-aware training forward. The base <c>ForwardNativeForTraining</c>
+    /// would call <see cref="Forecast"/>, which routes through
+    /// <see cref="ForecastNative"/> and flips the network to eval mode via
+    /// <c>SetTrainingMode(false)</c> mid-training-step — silently disabling
+    /// dropout during training (the exact seam the base-class documents:
+    /// models whose <c>Forecast</c> calls <c>SetTrainingMode(false)</c> MUST
+    /// override this). Route training through <see cref="Forward"/> directly —
+    /// the genuine tape-connected forward run under training mode — as the
+    /// other custom-forward finance transformers (TFT, Autoformer, FEDformer)
+    /// do.
+    /// </summary>
+    protected override Tensor<T> ForwardNativeForTraining(Tensor<T> input)
+    {
+        return Forward(input);
+    }
+
+    /// <summary>
     /// Performs ONNX mode forecasting.
     /// </summary>
     /// <remarks>

--- a/src/Finance/Forecasting/Transformers/TFT.cs
+++ b/src/Finance/Forecasting/Transformers/TFT.cs
@@ -833,6 +833,21 @@ public class TFT<T> : ForecastingModelBase<T>
     }
 
     /// <summary>
+    /// Tape-aware training forward. <see cref="Forecast"/> (the inference path
+    /// the base <c>ForwardNativeForTraining</c> would call) flips the network to
+    /// eval mode via <see cref="ForecastNative"/> and wraps the network in manual
+    /// per-element RevIN loops that detach the autograd graph, so gradients never
+    /// reach the layers and training leaves every parameter unchanged. Route
+    /// training through <see cref="Forward"/> directly — the genuine tape-connected
+    /// forward pass, run under training mode — exactly as the other custom-forward
+    /// finance transformers (Autoformer, FEDformer, iTransformer) do.
+    /// </summary>
+    protected override Tensor<T> ForwardNativeForTraining(Tensor<T> input)
+    {
+        return Forward(input);
+    }
+
+    /// <summary>
     /// Performs ONNX mode forecasting.
     /// </summary>
     /// <param name="input">Input historical data.</param>


### PR DESCRIPTION
## Problem
The Finance forecasting transformers **TFT** and **Informer** delegate `Train` to the tape flow (`FinancialModelBase` → `TrainWithTape` → `ForwardForTraining` → `ForwardNativeForTraining`). The base `ForwardNativeForTraining` calls `Forecast`, which for both routes through `ForecastNative` and flips the network to **eval mode** via `SetTrainingMode(false)` mid-training-step.

For **TFT** it additionally wraps the forward in manual per-element RevIN loops (`ApplyInstanceNormalization` / `ApplyRevIN`) that **detach the autograd graph** — so no gradient reaches the layers and training left **every parameter unchanged**. The generated `TFTTests` failed three training invariants: `Training_ShouldChangeParameters`, `GradientFlow_ShouldBeNonZeroAndFinite`, `LossStrictlyDecreasesOnMemorizationTask`.

## Fix
Both models override `ForwardNativeForTraining => Forward(input)` — the genuine tape-connected forward, run under training mode — exactly what the base-class docstring mandates (*models whose `Forecast` calls `SetTrainingMode(false)` MUST override this*) and what `Autoformer`/`FEDformer` already do. Informer's generated test passed before (no manual RevIN detach), but the eval-mode flip silently disabled dropout during training; the override closes that latent correctness seam too.

## Before / After
| | TFTTests | InformerTests |
|---|---|---|
| Before | 24/27 (3 training invariants failing) | pass |
| After | **27/27** | **27/27** |

Verified: `Generated.TFTTests + Generated.InformerTests` = **54/54** (`AIDOTNET_DISABLE_GPU=1`, isolated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)