### PR TITLE
fix(diffusion): predictnoisebatched must not drop the batch dim (#1843 regression)

### DIFF
--- a/src/Diffusion/DiffusionModelBase.cs
+++ b/src/Diffusion/DiffusionModelBase.cs
@@ -840,9 +840,25 @@ public abstract class DiffusionModelBase<T> : IDiffusionModel<T>, IConfigurableM
                 $"timesteps length {timesteps.Length} does not match batch size {batchSize}.",
                 nameof(timesteps));
 
+        // Batch of 1 (the overwhelmingly common training/eval case): the "per element" slice IS
+        // the whole tensor, so call PredictNoise directly on the full batched tensor. This is the
+        // exact pre-#1843 contract (Train fed the full [1, C, H, W] tensor straight to PredictNoise)
+        // and it keeps the forward on the gradient tape. The per-element loop below instead rebuilds
+        // each element via host-side AsSpan copies, which (a) dropped the leading batch dim so the
+        // scalar PredictNoise saw a rank-3 [C, H, W] — breaking the UNet noise predictors (DreamFusion
+        // "Tensor shapes must match. Got [1, 64, 32, 32] and [64, 32, 32]" in the ResBlock residual
+        // add; DDPM's Rank==4 gate falling back to a zero prediction so its lazy layers never
+        // initialized -> "no trainable parameters") — and (b) detached the prediction from the tape.
+        // #1843 regression fix.
+        if (batchSize == 1)
+            return PredictNoise(noisyBatch, timesteps[0]);
+
         int perElement = noisyBatch.Length / batchSize;
-        var elemShape = new int[noisyBatch.Rank - 1];
-        for (int i = 1; i < noisyBatch.Rank; i++) elemShape[i - 1] = noisyBatch.Shape[i];
+        // batch > 1: keep each per-element slice at the SAME rank as noisyBatch by preserving a
+        // leading batch dim of 1 ([B, C, H, W] -> [1, C, H, W]), NOT dropping it to [C, H, W].
+        var elemShape = new int[noisyBatch.Rank];
+        elemShape[0] = 1;
+        for (int i = 1; i < noisyBatch.Rank; i++) elemShape[i] = noisyBatch.Shape[i];
         var result = new Tensor<T>(noisyBatch._shape);
         var nbSpan = noisyBatch.AsSpan();
         var resSpan = result.AsWritableSpan();


### PR DESCRIPTION
## Problem

PR #1843's new default `DiffusionModelBase.PredictNoiseBatched` sliced each batch element to **rank-(R-1)**, dropping the leading batch dim and handing rank-3 `[C,H,W]` tensors to the scalar `PredictNoise`. This turned the **ModelFamily → Diffusion D-I** shard red (5 tests):

- **DreamFusion** (3 tests): the UNet ResBlock's conv re-adds a batch dim to the main path while the residual/skip keeps the input shape → the residual add throws `Tensor shapes must match. Got [1, 64, 32, 32] and [64, 32, 32]`.
- **DDPM** (2 tests): `PredictNoise` gates the UNet on `Rank == 4` and falls back to a zero prediction for rank-3 input, so the UNet never runs and its lazy layers never initialize → `Train` throws `no trainable parameters discoverable via CollectTrainableParameters`.

Bisected to master `a5e69caf` (#1843): the shard was green on the prior commit `e790723d`.

## Fix

In `PredictNoiseBatched`:
- **batchSize == 1** (the case these tests use): call `PredictNoise` directly on the full `[1, C, H, W]` tensor — the exact pre-#1843 contract, tape-connected, no host-side span copy.
- **batchSize > 1**: keep the per-element loop but preserve the leading batch dim (`[1, C, H, W]`, not `[C, H, W]`).

## Verification

- **DreamFusion + DDPM ModelFamily tests: 26/26 pass** locally (were the 5 shard failures).
- The heavy **Genie2** video-model test times out at the 120s xUnit limit on the dev machine **both with and without this change** (confirmed on clean master) — an environmental timeout, not a regression; it passes on CI's dedicated runners.

🤖 Generated with [Claude Code](https://claude.com/claude-code)