### PR TITLE
fix: correct sequence layer shape contracts

### DIFF
--- a/src/NeuralNetworks/Layers/ActivationLayer.cs
+++ b/src/NeuralNetworks/Layers/ActivationLayer.cs
@@ -131,8 +131,11 @@ public class ActivationLayer<T> : LayerBase<T>
     /// </summary>
     protected override void OnFirstForward(Tensor<T> input)
     {
-        var shape = input.Shape.ToArray();
-        ResolveShapes(shape, shape);
+        int[] runtimeShape = input.Shape.ToArray();
+        int[] sampleShape = runtimeShape.Length > 1
+            ? runtimeShape[1..]
+            : runtimeShape;
+        ResolveShapes(sampleShape, sampleShape);
     }
 
     /// <summary>

--- a/src/NeuralNetworks/Layers/ActivationLayer.cs
+++ b/src/NeuralNetworks/Layers/ActivationLayer.cs
@@ -132,9 +132,12 @@ public class ActivationLayer<T> : LayerBase<T>
     protected override void OnFirstForward(Tensor<T> input)
     {
         int[] runtimeShape = input.Shape.ToArray();
-        int[] sampleShape = runtimeShape.Length > 1
-            ? runtimeShape[1..]
-            : runtimeShape;
+        int[] sampleShape = runtimeShape;
+        if (runtimeShape.Length > 1)
+        {
+            sampleShape = new int[runtimeShape.Length - 1];
+            Array.Copy(runtimeShape, 1, sampleShape, 0, sampleShape.Length);
+        }
         ResolveShapes(sampleShape, sampleShape);
     }
 

--- a/src/NeuralNetworks/Layers/PreLNTransformerBlock.cs
+++ b/src/NeuralNetworks/Layers/PreLNTransformerBlock.cs
@@ -62,7 +62,7 @@ public partial class PreLNTransformerBlock<T> : LayerBase<T>
         int ffnDim,
         LayerBase<T> attention,
         IActivationFunction<T>? ffnActivation = null)
-        : base(new[] { hiddenSize }, new[] { hiddenSize })
+        : base(new[] { -1, hiddenSize }, new[] { -1, hiddenSize })
     {
         if (hiddenSize <= 0)
             throw new ArgumentOutOfRangeException(nameof(hiddenSize));

--- a/src/NeuralNetworks/Layers/SequenceTokenSliceLayer.cs
+++ b/src/NeuralNetworks/Layers/SequenceTokenSliceLayer.cs
@@ -54,7 +54,7 @@ public partial class SequenceTokenSliceLayer<T> : LayerBase<T>
     /// sequence axis (axis 1 of a rank-3 input).
     /// </summary>
     public SequenceTokenSliceLayer(Position position = Position.Last)
-        : base(new[] { -1, -1, -1 }, new[] { -1, -1 })
+        : base(new[] { -1, -1 }, new[] { -1 })
     {
         _position = position;
     }
@@ -74,11 +74,12 @@ public partial class SequenceTokenSliceLayer<T> : LayerBase<T>
                 $"[batch, seq, dim]; got rank {input.Shape.Length}.",
                 nameof(input));
 
-        int rank = input.Shape.Length;
-        var inShape = new int[rank];
-        for (int i = 0; i < rank; i++) inShape[i] = input.Shape[i];
-        var outShape = new[] { inShape[0], inShape[2] };
-        ResolveShapes(inShape, outShape);
+        // Layer shape metadata is per-sample and excludes the leading batch
+        // dimension. Keeping the runtime batch here corrupts architecture
+        // validation when the resolved layer chain is later deep-copied.
+        ResolveShapes(
+            new[] { input.Shape[1], input.Shape[2] },
+            new[] { input.Shape[2] });
     }
 
     /// <inheritdoc />

--- a/tests/AiDotNet.Tests/IntegrationTests/NeuralNetworks/ActivationLayerShapeContractTests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/NeuralNetworks/ActivationLayerShapeContractTests.cs
@@ -17,7 +17,7 @@ public sealed class ActivationLayerShapeContractTests
 
         Tensor<float> output = layer.Forward(input);
 
-        Assert.Equal([38, 2], output.Shape);
+        Assert.Equal([38, 2], output.Shape.ToArray());
         Assert.Equal([2], layer.GetInputShape());
         Assert.Equal([2], layer.GetOutputShape());
     }

--- a/tests/AiDotNet.Tests/IntegrationTests/NeuralNetworks/ActivationLayerShapeContractTests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/NeuralNetworks/ActivationLayerShapeContractTests.cs
@@ -1,0 +1,24 @@
+using AiDotNet.ActivationFunctions;
+using AiDotNet.Interfaces;
+using AiDotNet.NeuralNetworks.Layers;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNetTests.IntegrationTests.NeuralNetworks;
+
+public sealed class ActivationLayerShapeContractTests
+{
+    [Fact]
+    public void Forward_ResolvesPerSampleShapeWithoutBatchDimension()
+    {
+        var layer = new ActivationLayer<float>(
+            (IVectorActivationFunction<float>)new SoftmaxActivation<float>());
+        var input = new Tensor<float>([38, 2]);
+
+        Tensor<float> output = layer.Forward(input);
+
+        Assert.Equal([38, 2], output.Shape);
+        Assert.Equal([2], layer.GetInputShape());
+        Assert.Equal([2], layer.GetOutputShape());
+    }
+}

--- a/tests/AiDotNet.Tests/IntegrationTests/NeuralNetworks/HrePaperAChainShapeValidatorTests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/NeuralNetworks/HrePaperAChainShapeValidatorTests.cs
@@ -30,9 +30,9 @@ public class HrePaperAChainShapeValidatorTests
 {
     /// <summary>
     /// Validator runs at chain-construction time and rejects the chain if any
-    /// adjacent-layer pair fails <c>AreShapesCompatible</c>. This is the first
-    /// time the rank-N declared (MHA <c>[-1, embDim]</c>) vs rank-(N+1)
-    /// resolved (Slice <c>[batch, ctxLen, embDim]</c>) shape pair is checked.
+    /// adjacent-layer pair fails <c>AreShapesCompatible</c>. This verifies the
+    /// MHA sequence output is accepted by the slice layer's per-sample input
+    /// contract.
     /// Pre-fix the chain construction threw with
     /// "Layer N (MultiHeadAttention) is not compatible with Layer N+1 (SequenceTokenSliceLayer)".
     /// </summary>
@@ -52,15 +52,14 @@ public class HrePaperAChainShapeValidatorTests
     }
 
     /// <summary>
-    /// After a real <c>Forward</c> mutates the slice layer's shape from
-    /// <c>[-1, -1, -1]</c> to a concrete <c>[batch, ctxLen, embDim]</c>, a
-    /// downstream <c>DeepCopy</c> re-runs the validator on the (now resolved)
-    /// chain — this is the exact failure path from HarmonicEngine PR #149,
+    /// After a real <c>Forward</c> resolves the slice layer's per-sample shape
+    /// to <c>[ctxLen, embDim]</c>, a downstream <c>DeepCopy</c> re-runs the validator
+    /// on the resolved chain — this is the exact failure path from HarmonicEngine PR #149,
     /// triggered by <c>AdamOptimizer.Optimize</c> →
     /// <c>OptimizerBase.PrepareAndEvaluateSolution</c> → <c>DeepCopy</c>.
     /// Pre-fix the post-forward revalidation threw because the validator
     /// couldn't reconcile MHA's still-declared rank-2 output with Slice's
-    /// now-rank-3 resolved input.
+    /// resolved per-sample input.
     /// </summary>
     [Fact]
     public void HreChain_DeepCopyAfterForward_PassesRevalidation()
@@ -69,8 +68,7 @@ public class HrePaperAChainShapeValidatorTests
         var model = new Transformer<float>(arch, lossFunction: new CategoricalCrossEntropyLoss<float>());
 
         // Real forward — this is what causes SequenceTokenSliceLayer to call
-        // ResolveShapes with a concrete batch dim, mutating the chain's
-        // observable shape state.
+        // ResolveShapes with the concrete per-sample sequence dimensions.
         var input = new Tensor<float>(new[] { Batch, CtxLen });
         var span = input.AsWritableSpan();
         for (int i = 0; i < span.Length; i++) span[i] = i % VocabSize;

--- a/tests/AiDotNet.Tests/IntegrationTests/NeuralNetworks/PreLNTransformerBlockShapeContractTests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/NeuralNetworks/PreLNTransformerBlockShapeContractTests.cs
@@ -1,0 +1,47 @@
+using AiDotNet.ActivationFunctions;
+using AiDotNet.Enums;
+using AiDotNet.Interfaces;
+using AiDotNet.LossFunctions;
+using AiDotNet.NeuralNetworks;
+using AiDotNet.NeuralNetworks.Layers;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNetTests.IntegrationTests.NeuralNetworks;
+
+public sealed class PreLNTransformerBlockShapeContractTests
+{
+    private const int SequenceLength = 8;
+    private const int HiddenSize = 16;
+
+    [Fact]
+    public void Sequence_chain_validates_and_forwards_batched_input()
+    {
+        var layers = new List<ILayer<float>>
+        {
+            new InputLayer<float>([SequenceLength, HiddenSize]),
+            new PreLNTransformerBlock<float>(
+                HiddenSize,
+                4 * HiddenSize,
+                new MultiHeadAttentionLayer<float>(headCount: 4, headDimension: 4)),
+            new SequenceTokenSliceLayer<float>(SequenceTokenSliceLayer<float>.Position.Last),
+            new DenseLayer<float>(2, (IActivationFunction<float>)new IdentityActivation<float>()),
+        };
+        var architecture = new NeuralNetworkArchitecture<float>(
+            inputType: InputType.TwoDimensional,
+            taskType: NeuralNetworkTaskType.MultiClassClassification,
+            inputHeight: SequenceLength,
+            inputWidth: HiddenSize,
+            outputSize: 2,
+            layers: layers);
+        var network = new FeedForwardNeuralNetwork<float>(
+            architecture,
+            lossFunction: new CategoricalCrossEntropyLoss<float>());
+
+        Tensor<float> output = network.Predict(new Tensor<float>([2, SequenceLength, HiddenSize]));
+
+        Assert.Equal([2, 2], output.Shape);
+        Assert.Equal([-1, HiddenSize], network.Layers[1].GetInputShape());
+        Assert.Equal([-1, HiddenSize], network.Layers[1].GetOutputShape());
+    }
+}

--- a/tests/AiDotNet.Tests/IntegrationTests/NeuralNetworks/PreLNTransformerBlockShapeContractTests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/NeuralNetworks/PreLNTransformerBlockShapeContractTests.cs
@@ -40,7 +40,7 @@ public sealed class PreLNTransformerBlockShapeContractTests
 
         Tensor<float> output = network.Predict(new Tensor<float>([2, SequenceLength, HiddenSize]));
 
-        Assert.Equal([2, 2], output.Shape);
+        Assert.Equal([2, 2], output.Shape.ToArray());
         Assert.Equal([-1, HiddenSize], network.Layers[1].GetInputShape());
         Assert.Equal([-1, HiddenSize], network.Layers[1].GetOutputShape());
     }

--- a/tests/AiDotNet.Tests/IntegrationTests/NeuralNetworks/SequenceTokenSliceLayerShapeContractTests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/NeuralNetworks/SequenceTokenSliceLayerShapeContractTests.cs
@@ -1,4 +1,5 @@
 using AiDotNet;
+using AiDotNet.ActivationFunctions;
 using AiDotNet.Data.Loaders;
 using AiDotNet.Enums;
 using AiDotNet.Interfaces;
@@ -46,6 +47,7 @@ public sealed class SequenceTokenSliceLayerShapeContractTests
             new InputLayer<float>([SequenceLength, FeatureCount]),
             new SequenceTokenSliceLayer<float>(),
             new DenseLayer<float>(ClassCount),
+            new ActivationLayer<float>((IVectorActivationFunction<float>)new SoftmaxActivation<float>()),
         };
         var architecture = new NeuralNetworkArchitecture<float>(
             inputType: InputType.TwoDimensional,
@@ -64,6 +66,8 @@ public sealed class SequenceTokenSliceLayerShapeContractTests
         Assert.NotSame(network, copy);
         Assert.Equal([SequenceLength, FeatureCount], network.Layers[1].GetInputShape());
         Assert.Equal([FeatureCount], network.Layers[1].GetOutputShape());
+        Assert.Equal([ClassCount], network.Layers[3].GetInputShape());
+        Assert.Equal([ClassCount], network.Layers[3].GetOutputShape());
         Assert.Equal(network.Layers.Select(layer => layer.GetType()),
             copy.Layers.Select(layer => layer.GetType()));
     }
@@ -84,6 +88,7 @@ public sealed class SequenceTokenSliceLayerShapeContractTests
             new InputLayer<float>([SequenceLength, FeatureCount]),
             new SequenceTokenSliceLayer<float>(),
             new DenseLayer<float>(ClassCount),
+            new ActivationLayer<float>((IVectorActivationFunction<float>)new SoftmaxActivation<float>()),
         };
         var architecture = new NeuralNetworkArchitecture<float>(
             inputType: InputType.TwoDimensional,
@@ -120,5 +125,7 @@ public sealed class SequenceTokenSliceLayerShapeContractTests
         Assert.NotNull(result);
         Assert.Equal([SequenceLength, FeatureCount], network.Layers[1].GetInputShape());
         Assert.Equal([FeatureCount], network.Layers[1].GetOutputShape());
+        Assert.Equal([ClassCount], network.Layers[3].GetInputShape());
+        Assert.Equal([ClassCount], network.Layers[3].GetOutputShape());
     }
 }

--- a/tests/AiDotNet.Tests/IntegrationTests/NeuralNetworks/SequenceTokenSliceLayerShapeContractTests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/NeuralNetworks/SequenceTokenSliceLayerShapeContractTests.cs
@@ -1,0 +1,124 @@
+using AiDotNet;
+using AiDotNet.Data.Loaders;
+using AiDotNet.Enums;
+using AiDotNet.Interfaces;
+using AiDotNet.LossFunctions;
+using AiDotNet.Models.Options;
+using AiDotNet.NeuralNetworks;
+using AiDotNet.NeuralNetworks.Layers;
+using AiDotNet.Optimizers;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNetTests.IntegrationTests.NeuralNetworks;
+
+/// <summary>
+/// Guards the per-sample shape contract of <see cref="SequenceTokenSliceLayer{T}"/>.
+/// Runtime tensors include a leading batch dimension, but layer metadata must not
+/// retain it because architecture validation and cloning compare sample shapes.
+/// </summary>
+[Collection("NonParallelIntegration")]
+public sealed class SequenceTokenSliceLayerShapeContractTests
+{
+    private const int BatchSize = 7;
+    private const int SequenceLength = 8;
+    private const int FeatureCount = 16;
+    private const int ClassCount = 2;
+
+    [Fact]
+    public void Forward_ResolvesPerSampleShapesWithoutBatchDimension()
+    {
+        var layer = new SequenceTokenSliceLayer<float>();
+        var input = new Tensor<float>([BatchSize, SequenceLength, FeatureCount]);
+
+        Tensor<float> output = layer.Forward(input);
+
+        Assert.Equal([BatchSize, FeatureCount], output.Shape);
+        Assert.Equal([SequenceLength, FeatureCount], layer.GetInputShape());
+        Assert.Equal([FeatureCount], layer.GetOutputShape());
+    }
+
+    [Fact]
+    public void DeepCopy_AfterBatchedForward_PreservesSliceToDenseShapeContract()
+    {
+        var layers = new List<ILayer<float>>
+        {
+            new InputLayer<float>([SequenceLength, FeatureCount]),
+            new SequenceTokenSliceLayer<float>(),
+            new DenseLayer<float>(ClassCount),
+        };
+        var architecture = new NeuralNetworkArchitecture<float>(
+            inputType: InputType.TwoDimensional,
+            taskType: NeuralNetworkTaskType.MultiClassClassification,
+            inputHeight: SequenceLength,
+            inputWidth: FeatureCount,
+            outputSize: ClassCount,
+            layers: layers);
+        var network = new FeedForwardNeuralNetwork<float>(architecture);
+        var input = new Tensor<float>([BatchSize, SequenceLength, FeatureCount]);
+
+        Tensor<float> prediction = network.Predict(input);
+        var copy = (FeedForwardNeuralNetwork<float>)network.DeepCopy();
+
+        Assert.Equal([BatchSize, ClassCount], prediction.Shape);
+        Assert.NotSame(network, copy);
+        Assert.Equal([SequenceLength, FeatureCount], network.Layers[1].GetInputShape());
+        Assert.Equal([FeatureCount], network.Layers[1].GetOutputShape());
+        Assert.Equal(network.Layers.Select(layer => layer.GetType()),
+            copy.Layers.Select(layer => layer.GetType()));
+    }
+
+    [Fact(Timeout = 120_000)]
+    public async Task BuildAsync_WithSequenceSliceAndDenseHead_CompletesOptimizerCopyPath()
+    {
+        var optimizer = new AdamOptimizer<float, Tensor<float>, Tensor<float>>(
+            null,
+            new AdamOptimizerOptions<float, Tensor<float>, Tensor<float>>
+            {
+                MaxIterations = 1,
+                InitialLearningRate = 1e-3,
+                UseAdaptiveLearningRate = false,
+            });
+        var layers = new List<ILayer<float>>
+        {
+            new InputLayer<float>([SequenceLength, FeatureCount]),
+            new SequenceTokenSliceLayer<float>(),
+            new DenseLayer<float>(ClassCount),
+        };
+        var architecture = new NeuralNetworkArchitecture<float>(
+            inputType: InputType.TwoDimensional,
+            taskType: NeuralNetworkTaskType.MultiClassClassification,
+            inputHeight: SequenceLength,
+            inputWidth: FeatureCount,
+            outputSize: ClassCount,
+            layers: layers);
+        var network = new FeedForwardNeuralNetwork<float>(
+            architecture,
+            optimizer,
+            new CategoricalCrossEntropyLoss<float>());
+        var inputs = new Tensor<float>([48, SequenceLength, FeatureCount]);
+        var targets = new Tensor<float>([48, ClassCount]);
+        Span<float> inputValues = inputs.AsWritableSpan();
+        Span<float> targetValues = targets.AsWritableSpan();
+        for (int sample = 0; sample < inputs.Shape[0]; sample++)
+        {
+            for (int feature = 0; feature < SequenceLength * FeatureCount; feature++)
+            {
+                inputValues[sample * SequenceLength * FeatureCount + feature] =
+                    ((sample + feature) % 17 - 8) / 8f;
+            }
+
+            targetValues[sample * ClassCount + sample % ClassCount] = 1;
+        }
+
+        var result = await new AiModelBuilder<float, Tensor<float>, Tensor<float>>()
+            .ConfigureModel(network)
+            .ConfigureOptimizer(optimizer)
+            .ConfigureDataLoader(DataLoaders.FromTensors(inputs, targets))
+            .BuildAsync();
+
+        Assert.NotNull(result);
+        Assert.Equal([SequenceLength, FeatureCount], network.Layers[1].GetInputShape());
+        Assert.Equal([FeatureCount], network.Layers[1].GetOutputShape());
+    }
+}

--- a/tests/AiDotNet.Tests/IntegrationTests/NeuralNetworks/SequenceTokenSliceLayerShapeContractTests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/NeuralNetworks/SequenceTokenSliceLayerShapeContractTests.cs
@@ -34,7 +34,7 @@ public sealed class SequenceTokenSliceLayerShapeContractTests
 
         Tensor<float> output = layer.Forward(input);
 
-        Assert.Equal([BatchSize, FeatureCount], output.Shape);
+        Assert.Equal([BatchSize, FeatureCount], output.Shape.ToArray());
         Assert.Equal([SequenceLength, FeatureCount], layer.GetInputShape());
         Assert.Equal([FeatureCount], layer.GetOutputShape());
     }
@@ -62,7 +62,7 @@ public sealed class SequenceTokenSliceLayerShapeContractTests
         Tensor<float> prediction = network.Predict(input);
         var copy = (FeedForwardNeuralNetwork<float>)network.DeepCopy();
 
-        Assert.Equal([BatchSize, ClassCount], prediction.Shape);
+        Assert.Equal([BatchSize, ClassCount], prediction.Shape.ToArray());
         Assert.NotSame(network, copy);
         Assert.Equal([SequenceLength, FeatureCount], network.Layers[1].GetInputShape());
         Assert.Equal([FeatureCount], network.Layers[1].GetOutputShape());


### PR DESCRIPTION
## Summary
- keep `SequenceTokenSliceLayer` and `ActivationLayer` metadata per-sample after batched forwards
- declare `PreLNTransformerBlock` as a sequence-preserving `[-1, hidden] -> [-1, hidden]` layer, matching its documented/runtime behavior
- preserve batched runtime tensor shapes while maintaining the framework's layer-chain contract
- add forward, post-forward `DeepCopy`, facade optimizer, and Pre-LN Transformer chain regressions

## Root cause
Three sequence-layer metadata contracts disagreed with their runtime behavior. Sequence slicing and activation copied runtime batch axes into persistent architecture metadata, while the Pre-LN Transformer block omitted its sequence axis entirely. Architecture validation and optimizer model copying then rejected otherwise valid non-flat chains.

## Impact
Non-flat sequence models can now validate, execute, and pass through optimizer evaluation without batch or sequence axes being lost or persisted incorrectly. This unblocks external sequence architectures such as HarmonicEngine depth experiments while retaining existing runtime tensor semantics.

## Validation
- focused `net10.0` AiDotNet build passes
- 27/27 activation, sequence-slice, HRE chain, deserialization, multi-dimensional input, and facade optimizer regressions pass
- the new Pre-LN Transformer sequence-chain regression passes alongside the affected shape-contract suite (8/8)
- `git diff --check` passes

Existing package constraint, vulnerability, and analyzer warnings remain unchanged.