### PR TITLE
fix: fix compiled training graph contracts

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -248,8 +248,13 @@
          PersistentInputRegistry}; the src/Training mirror classes stay as the consumer-side primitives
          (the fused-primitive centralization in #1847/#1848 wires every consumer through them) and now
          run against the fixed engine. 0.113.0 is PUBLISHED to NuGet and is a superset of 0.112.0 (also
-         carries #765 compiled-ReduceMax axis fill), so all rationale above is retained. -->
-    <PackageVersion Include="AiDotNet.Tensors" Version="0.114.0" />
+         carries #765 compiled-ReduceMax axis fill), so all rationale above is retained.
+
+         Bumped 0.114.0 -> 0.114.3: brings AiDotNet.Tensors #779 (AiDotNet#1856), which clamps the
+         internal IRFFT length for a degenerate length-1 RFFT axis. Without it, RFFT autodiff can
+         compute nFft=0 and index outside the spectrum while training TFC. 0.114.3 is PUBLISHED to
+         NuGet and is a managed-only superset of 0.114.0, so native package versions remain unchanged. -->
+    <PackageVersion Include="AiDotNet.Tensors" Version="0.114.3" />
     <PackageVersion Include="AiDotNet.Native.OneDNN" Version="0.114.0" />
     <PackageVersion Include="AiDotNet.Native.OpenBLAS" Version="0.114.0" />
     <PackageVersion Include="AiDotNet.Native.CLBlast" Version="0.114.0" />

--- a/src/Finance/Forecasting/Foundation/CSDI.cs
+++ b/src/Finance/Forecasting/Foundation/CSDI.cs
@@ -687,11 +687,11 @@ public class CSDI<T> : TimeSeriesFoundationModelBase<T>
     public override Tensor<T> ApplyInstanceNormalization(Tensor<T> input)
     {
         int batchSize = input.Rank > 1 ? input.Shape[0] : 1;
-        int seqLen = input.Rank > 1 ? input.Shape[1] : input.Length;
-        if (seqLen <= 0) return input;
+        int instanceSize = input.Length / batchSize;
+        if (instanceSize <= 0) return input;
 
         bool reshaped = input.Rank != 2;
-        var flat = reshaped ? Engine.Reshape(input, new[] { batchSize, seqLen }) : input;
+        var flat = reshaped ? Engine.Reshape(input, new[] { batchSize, instanceSize }) : input;
         var mean = Engine.ReduceMean(flat, new[] { 1 }, keepDims: true);
         var variance = Engine.ReduceVariance(flat, new[] { 1 }, keepDims: true);
         var std = Engine.TensorSqrt(Engine.TensorAddScalar(variance, NumOps.FromDouble(1e-5)));

--- a/src/Finance/Forecasting/Foundation/TFC.cs
+++ b/src/Finance/Forecasting/Foundation/TFC.cs
@@ -919,13 +919,19 @@ public class TFC<T> : TimeSeriesFoundationModelBase<T>
     /// </remarks>
     private Tensor<T> ComputeFrequencyRepresentation(Tensor<T> input)
     {
-        int n = input.Rank > 1 ? input.Shape[^1] : input.Length;
-        int numSamples = input.Rank > 1 ? input.Length / n : 1;
+        bool isMultivariateTimeSeries = input.Rank == 3;
+        int n = isMultivariateTimeSeries ? input.Shape[1] : input.Rank > 1 ? input.Shape[^1] : input.Length;
+        int numSamples = input.Length / n;
         int halfN = n / 2 + 1;
 
-        // Normalize to [B, n] for the batched RFFT contract.
-        bool reshaped = input.Rank != 2;
-        var flat = reshaped ? Engine.Reshape(input, new[] { numSamples, n }) : input;
+        // Finance time-series tensors use [batch, time, features]. Move time to the
+        // final axis so RFFT transforms each feature's temporal series independently.
+        // Rank-1 and rank-2 inputs already have time on their final axis.
+        Tensor<T> seriesMajor = isMultivariateTimeSeries
+            ? Engine.TensorPermute(input, new[] { 0, 2, 1 })
+            : input;
+        bool reshaped = seriesMajor.Rank != 2;
+        var flat = reshaped ? Engine.Reshape(seriesMajor, new[] { numSamples, n }) : seriesMajor;
 
         // RFFT returns interleaved [re0, im0, re1, im1, ..., re(halfN-1), im(halfN-1)],
         // shape [B, halfN * 2] = [B, n + 2].
@@ -953,6 +959,14 @@ public class TFC<T> : TimeSeriesFoundationModelBase<T>
         else
         {
             full = oneSided;
+        }
+
+        if (isMultivariateTimeSeries)
+        {
+            int batchSize = input.Shape[0];
+            int featureCount = input.Shape[2];
+            var restored = Engine.Reshape(full, new[] { batchSize, featureCount, n });
+            return Engine.TensorPermute(restored, new[] { 0, 2, 1 });
         }
 
         return reshaped ? Engine.Reshape(full, input._shape) : full;

--- a/src/NeuralNetworks/Layers/ConditionalRandomFieldLayer.cs
+++ b/src/NeuralNetworks/Layers/ConditionalRandomFieldLayer.cs
@@ -567,35 +567,29 @@ public partial class ConditionalRandomFieldLayer<T> : LayerBase<T>
     /// </remarks>
     private void InitializeParameters()
     {
-        // VECTORIZED: Initialize parameters with scaled random values
         T scale = NumOps.Sqrt(NumOps.FromDouble(2.0 / (_numClasses + _numClasses)));
         T half = NumOps.FromDouble(0.5);
 
-        // Initialize transition matrix: (random - 0.5) * scale
-        var transRandom = Tensor<T>.CreateRandom(_transitionMatrix.Length, 1).Reshape(_transitionMatrix._shape);
-        var transHalf = new Tensor<T>(_transitionMatrix._shape);
-        transHalf.Fill(half);
-        var transCentered = Engine.TensorSubtract(transRandom, transHalf);
-        _transitionMatrix = Engine.TensorMultiplyScalar(transCentered, scale);
-
-        // Initialize start scores: (random - 0.5) * scale
-        var startRandom = Tensor<T>.CreateRandom(_startScores.Length, 1).Reshape(_startScores._shape);
-        var startHalf = new Tensor<T>(_startScores._shape);
-        startHalf.Fill(half);
-        var startCentered = Engine.TensorSubtract(startRandom, startHalf);
-        _startScores = Engine.TensorMultiplyScalar(startCentered, scale);
-
-        // Initialize end scores: (random - 0.5) * scale
-        var endRandom = Tensor<T>.CreateRandom(_endScores.Length, 1).Reshape(_endScores._shape);
-        var endHalf = new Tensor<T>(_endScores._shape);
-        endHalf.Fill(half);
-        var endCentered = Engine.TensorSubtract(endRandom, endHalf);
-        _endScores = Engine.TensorMultiplyScalar(endCentered, scale);
+        _transitionMatrix = CreatePersistentParameter([_numClasses, _numClasses], half, scale);
+        _startScores = CreatePersistentParameter([_numClasses], half, scale);
+        _endScores = CreatePersistentParameter([_numClasses], half, scale);
 
         // Register after all reassignments so references are to final tensors
         RegisterTrainableParameter(_transitionMatrix, PersistentTensorRole.Weights);
         RegisterTrainableParameter(_startScores, PersistentTensorRole.Weights);
         RegisterTrainableParameter(_endScores, PersistentTensorRole.Weights);
+    }
+
+    private Tensor<T> CreatePersistentParameter(int[] shape, T half, T scale)
+    {
+        var random = Tensor<T>.CreateRandom(shape);
+        var parameter = TensorAllocator.RentPinned<T>(shape);
+        for (int i = 0; i < parameter.Length; i++)
+        {
+            parameter[i] = NumOps.Multiply(NumOps.Subtract(random[i], half), scale);
+        }
+
+        return parameter;
     }
 
     /// <summary>

--- a/src/NeuralNetworks/Layers/GraphAttentionLayer.cs
+++ b/src/NeuralNetworks/Layers/GraphAttentionLayer.cs
@@ -251,7 +251,42 @@ public partial class GraphAttentionLayer<T> : LayerBase<T>, IGraphConvolutionLay
     /// <inheritdoc/>
     public void SetAdjacencyMatrix(Tensor<T> adjacencyMatrix)
     {
+        if (adjacencyMatrix == null)
+            throw new ArgumentNullException(nameof(adjacencyMatrix));
+
         _adjacencyMatrix = adjacencyMatrix;
+
+        // GraphAttention has a complete tape backward for node features and
+        // attention vectors. Convert the common dense 2D contract to edges so
+        // Forward can compose it without copying through detached scratch.
+        if (adjacencyMatrix.Rank == 2)
+        {
+            int numTargets = adjacencyMatrix.Shape[0];
+            int numSources = adjacencyMatrix.Shape[1];
+            var sources = new List<int>();
+            var targets = new List<int>();
+            for (int target = 0; target < numTargets; target++)
+            {
+                for (int source = 0; source < numSources; source++)
+                {
+                    if (!NumOps.Equals(adjacencyMatrix[target, source], NumOps.Zero))
+                    {
+                        sources.Add(source);
+                        targets.Add(target);
+                    }
+                }
+            }
+
+            _edgeSourceIndices = new Tensor<int>(sources.ToArray(), [sources.Count]);
+            _edgeTargetIndices = new Tensor<int>(targets.ToArray(), [targets.Count]);
+            _useSparseAggregation = true;
+        }
+        else
+        {
+            _edgeSourceIndices = null;
+            _edgeTargetIndices = null;
+            _useSparseAggregation = false;
+        }
     }
 
     /// <inheritdoc/>
@@ -359,45 +394,61 @@ public partial class GraphAttentionLayer<T> : LayerBase<T>, IGraphConvolutionLay
 
         if (_useSparseAggregation && _edgeSourceIndices != null && _edgeTargetIndices != null)
         {
-            // Sparse aggregation using Engine.MultiHeadGraphAttention (production-recommended).
-            // _attentionWeights is laid out as [numHeads, 2 * outputFeatures] with the
-            // source-half occupying columns [0, outputFeatures) and the target-half
-            // [outputFeatures, 2 * outputFeatures). Engine.TensorSlice returns each half
-            // as a view-style operation in one call instead of the per-(h, f) copy loop.
-            var attnWeightsSource = Engine.TensorSlice(_attentionWeights, [0, 0], [_numHeads, _outputFeatures]);
-            var attnWeightsTarget = Engine.TensorSlice(_attentionWeights, [0, _outputFeatures], [_numHeads, _outputFeatures]);
-
-            output = TensorAllocator.Rent<T>([batchSize, numNodes, _outputFeatures]);
-            output.Fill(NumOps.Zero);
-
-            for (int b = 0; b < batchSize; b++)
+            // Compose each head from tape-recorded primitives. The aggregate
+            // MultiHeadGraphAttention kernel does not expose a backward for its
+            // head projection, while GraphAttention does.
+            var transformedHeads = new Tensor<T>[_numHeads];
+            var headOutputs = new Tensor<T>[_numHeads];
+            var headCoefficients = new Tensor<T>[_numHeads];
+            for (int h = 0; h < _numHeads; h++)
             {
-                // Extract batch features using Slice: [numNodes, inputFeatures]
-                var batchFeatures = processInput.Slice(b);
+                var headWeight = Engine.Reshape(
+                    Engine.TensorSlice(
+                        _weights,
+                        [h, 0, 0],
+                        [1, _inputFeatures, _outputFeatures]),
+                    [_inputFeatures, _outputFeatures]);
+                var transformed = BatchedMatMul3Dx2D(
+                    processInput,
+                    headWeight,
+                    batchSize,
+                    numNodes,
+                    _inputFeatures,
+                    _outputFeatures);
+                var attnSource = Engine.Reshape(
+                    Engine.TensorSlice(_attentionWeights, [h, 0], [1, _outputFeatures]),
+                    [_outputFeatures]);
+                var attnTarget = Engine.Reshape(
+                    Engine.TensorSlice(
+                        _attentionWeights,
+                        [h, _outputFeatures],
+                        [1, _outputFeatures]),
+                    [_outputFeatures]);
 
-                // Call Engine.MultiHeadGraphAttention
-                var batchOutput = Engine.MultiHeadGraphAttention(
-                    batchFeatures,
+                var headOutput = Engine.GraphAttention(
+                    transformed,
                     _edgeSourceIndices,
                     _edgeTargetIndices,
-                    _weights,
-                    attnWeightsSource,
-                    attnWeightsTarget,
+                    attnSource,
+                    attnTarget,
                     NumOps.ToDouble(_alpha),
-                    concatenate: false,  // Average heads
-                    out var batchAttnCoeffs);
+                    out var coefficients);
 
-                // Add bias using broadcasting and set in output
-                var biasBroadcast = Engine.Reshape(_bias, [1, _outputFeatures]);
-                var biasedOutput = Engine.TensorBroadcastAdd(batchOutput, biasBroadcast);
-                output.SetSlice(b, biasedOutput);
+                transformedHeads[h] = transformed;
+                headOutputs[h] = headOutput;
+                headCoefficients[h] = coefficients;
             }
 
-            // Store cached values for backward pass
-            _lastTransformed = null;
+            var stackedHeads = Engine.TensorStack(headOutputs, axis: 1);
+            var sparseHeadSum = Engine.ReduceSum(stackedHeads, [1], keepDims: false);
+            var sparseHeadAverage = Engine.TensorDivideScalar(sparseHeadSum, NumOps.FromDouble(_numHeads));
+            var biasBroadcast = Engine.Reshape(_bias, [1, 1, _outputFeatures]);
+            output = Engine.TensorBroadcastAdd(sparseHeadAverage, biasBroadcast);
+
+            _lastTransformed = cacheBwd ? Engine.TensorStack(transformedHeads, axis: 1) : null;
             _lastPreSoftmaxScores = null;
-            _lastAttentionCoefficients = null;
-            _lastHeadOutputs = null;
+            _lastAttentionCoefficients = cacheBwd ? Engine.TensorStack(headCoefficients, axis: 1) : null;
+            _lastHeadOutputs = cacheBwd ? stackedHeads : null;
 
             activatedOutput = ApplyActivation(output);
 

--- a/src/NeuralNetworks/Layers/MeshEdgeConvLayer.cs
+++ b/src/NeuralNetworks/Layers/MeshEdgeConvLayer.cs
@@ -309,9 +309,8 @@ public partial class MeshEdgeConvLayer<T> : LayerBase<T>
         _lastInput = ShouldCacheForBackward ? input : null; // #1668: skip in inference (arena safety)
 
         int numEdges = input.Shape[0];
-        int aggregatedFeatures = InputChannels * (1 + NumNeighbors);
 
-        var aggregatedInput = AggregateEdgeFeatures(input, _lastEdgeAdjacency, numEdges, aggregatedFeatures);
+        var aggregatedInput = AggregateEdgeFeatures(input, _lastEdgeAdjacency, numEdges);
 
         // Forward: output = aggregatedInput @ weights.T + biases
         var weightsTransposed = Engine.TensorTranspose(_weights);
@@ -363,8 +362,7 @@ public partial class MeshEdgeConvLayer<T> : LayerBase<T>
     /// <param name="input">Input edge features [numEdges, InputChannels].</param>
     /// <param name="adjacency">Edge adjacency [numEdges, NumNeighbors].</param>
     /// <param name="numEdges">Number of edges.</param>
-    /// <param name="aggregatedSize">Size of aggregated feature vector.</param>
-    /// <returns>Aggregated features [numEdges, aggregatedSize].</returns>
+    /// <returns>Aggregated features [numEdges, InputChannels * (1 + NumNeighbors)].</returns>
     /// <remarks>
     /// <para>
     /// This method uses vectorized gather operations to efficiently collect neighbor features.
@@ -372,50 +370,38 @@ public partial class MeshEdgeConvLayer<T> : LayerBase<T>
     /// [self_features | neighbor_1_features | neighbor_2_features | ... | neighbor_N_features]
     /// </para>
     /// </remarks>
-    private Tensor<T> AggregateEdgeFeatures(Tensor<T> input, int[,] adjacency, int numEdges, int aggregatedSize)
+    private Tensor<T> AggregateEdgeFeatures(Tensor<T> input, int[,] adjacency, int numEdges)
     {
-        // Create result tensor [numEdges, aggregatedSize]
-        var result = TensorAllocator.Rent<T>([numEdges, aggregatedSize]);
+        var featureBlocks = new Tensor<T>[NumNeighbors + 1];
+        featureBlocks[0] = input;
 
-        // Step 1: Copy self-features (first InputChannels columns)
-        result = Engine.TensorSetSlice(result, input, [0, 0]);
-
-        // Step 2: Gather neighbor features for each neighbor position
         for (int n = 0; n < NumNeighbors; n++)
         {
-            int featureOffset = InputChannels * (1 + n);
-
-            // Create indices tensor for this neighbor position
             var neighborIndices = new int[numEdges];
+            var maskData = new T[numEdges];
+            bool hasInvalidNeighbor = false;
             for (int e = 0; e < numEdges; e++)
             {
                 int idx = adjacency[e, n];
-                // Clamp invalid indices to 0 and we'll zero them out after
-                neighborIndices[e] = (idx >= 0 && idx < numEdges) ? idx : 0;
+                bool isValid = idx >= 0 && idx < numEdges;
+                neighborIndices[e] = isValid ? idx : 0;
+                maskData[e] = isValid ? NumOps.One : NumOps.Zero;
+                hasInvalidNeighbor |= !isValid;
             }
 
             var indicesTensor = new Tensor<int>(neighborIndices, [numEdges]);
-
-            // Gather neighbor features using vectorized operation
             var gathered = Engine.TensorGather(input, indicesTensor, axis: 0);
 
-            // Create mask for invalid neighbors and zero them out
-            var maskData = new T[numEdges];
-            for (int e = 0; e < numEdges; e++)
+            if (hasInvalidNeighbor)
             {
-                int idx = adjacency[e, n];
-                maskData[e] = (idx >= 0 && idx < numEdges) ? NumOps.One : NumOps.Zero;
+                var mask = new Tensor<T>(maskData, [numEdges, 1]);
+                gathered = Engine.TensorMultiply(gathered, mask);
             }
-            var mask = new Tensor<T>(maskData, [numEdges, 1]);
 
-            // Apply mask (multiply gathered features by mask to zero out invalid neighbors)
-            gathered = Engine.TensorMultiply(gathered, Engine.TensorTile(mask, [1, InputChannels]));
-
-            // Set the gathered features into the result at the appropriate offset
-            result = Engine.TensorSetSlice(result, gathered, [0, featureOffset]);
+            featureBlocks[n + 1] = gathered;
         }
 
-        return result;
+        return Engine.TensorConcatenate(featureBlocks, axis: 1);
     }
 
     /// <summary>
@@ -626,7 +612,7 @@ public partial class MeshEdgeConvLayer<T> : LayerBase<T>
 
             // Mask the gradients to zero out invalid neighbors
             var mask = new Tensor<T>(validMask, [numEdges, 1]);
-            var maskedGrad = Engine.TensorMultiply(neighborGrad, Engine.TensorTile(mask, [1, InputChannels]));
+            var maskedGrad = Engine.TensorMultiply(neighborGrad, mask);
 
             // Scatter-add the gradients back to their original positions
             inputGrad = Engine.TensorScatterAdd(inputGrad, indicesTensor, maskedGrad, axis: 0);

--- a/src/NeuralNetworks/Layers/MeshPoolLayer.cs
+++ b/src/NeuralNetworks/Layers/MeshPoolLayer.cs
@@ -524,7 +524,7 @@ public partial class MeshPoolLayer<T> : LayerBase<T>
         var gradScale = Engine.ReduceSum(outputGradient, [1], keepDims: true);
 
         // Element-wise multiply scales with features: [numKept, InputChannels]
-        var scaledFeatures = Engine.TensorMultiply(keptFeatures, Engine.TensorTile(gradScale, [1, InputChannels]));
+        var scaledFeatures = Engine.TensorMultiply(keptFeatures, gradScale);
 
         // Sum over kept edges to get final gradient [InputChannels]
         return Engine.ReduceSum(scaledFeatures, [0], keepDims: false);

--- a/src/NeuralNetworks/Layers/SpiralConvLayer.cs
+++ b/src/NeuralNetworks/Layers/SpiralConvLayer.cs
@@ -730,91 +730,32 @@ public partial class SpiralConvLayer<T> : LayerBase<T>
     /// <returns>Output tensor [batch, numVertices, OutputChannels].</returns>
     private Tensor<T> ProcessBatched(Tensor<T> input, int batchSize, int numVertices, bool cacheBwd)
     {
-        var outputData = new T[batchSize * numVertices * OutputChannels];
-
-        // Thread-local storage for gathered features per batch sample
-        var localGatheredFeatures = new Tensor<T>[batchSize];
+        var gatheredFeatures = new Tensor<T>[batchSize];
+        var outputs = new Tensor<T>[batchSize];
         var transposedWeights = Engine.TensorTranspose(_weights);
 
-        Parallel.For(0, batchSize, b =>
-        {
-            var singleInput = ExtractBatchSlice(input, b, numVertices);
-
-            // Gather spiral features (thread-safe, result stored per-batch)
-            var gathered = GatherSpiralFeatures(singleInput, numVertices);
-            localGatheredFeatures[b] = gathered;
-
-            // Compute output using pre-transposed weights
-            var singleOutput = Engine.TensorMatMul(gathered, transposedWeights);
-            singleOutput = AddBiases(singleOutput, numVertices);
-
-            // Activation is applied exactly once by Forward() after ProcessBatched returns, so the
-            // per-sample output must stay PRE-activation here (matches the ProcessSingle path).
-            var singleData = singleOutput.ToArray();
-            int offset = b * numVertices * OutputChannels;
-            Array.Copy(singleData, 0, outputData, offset, singleData.Length);
-        });
-
-        // Combine gathered features for backward pass (sum across batch)
-        // For backward pass, we need the gathered features. Store the first batch's for gradient computation.
-        // A more complete solution would store all or use a different gradient strategy.
-        // #1668: _gatheredFeatures is a backward-only cache; only build+retain it when an eager
-        // Backward will read it, so inference holds no gathered arena scratch across a Reset.
-        if (cacheBwd && batchSize > 0 && localGatheredFeatures[0] != null)
-        {
-            _gatheredFeatures = CombineGatheredFeatures(localGatheredFeatures, batchSize, numVertices);
-        }
-        else
-        {
-            _gatheredFeatures = null;
-        }
-
-        return new Tensor<T>(outputData, [batchSize, numVertices, OutputChannels]);
-    }
-
-    /// <summary>
-    /// Combines gathered features from all batch samples for backward pass.
-    /// </summary>
-    /// <param name="localGatheredFeatures">Array of gathered features per batch sample.</param>
-    /// <param name="batchSize">Number of batch samples.</param>
-    /// <param name="numVertices">Number of vertices per sample.</param>
-    /// <returns>Combined gathered features tensor.</returns>
-    private Tensor<T> CombineGatheredFeatures(Tensor<T>[] localGatheredFeatures, int batchSize, int numVertices)
-    {
-        int featureDim = SpiralLength * InputChannels;
-        var combinedData = new T[batchSize * numVertices * featureDim];
-
+        // GradientTape is thread-local. Keep the per-sample engine operations on
+        // the recording thread and combine them with TensorStack.
         for (int b = 0; b < batchSize; b++)
         {
-            var batchData = localGatheredFeatures[b].ToArray();
-            int offset = b * numVertices * featureDim;
-            Array.Copy(batchData, 0, combinedData, offset, batchData.Length);
+            var singleInput = Engine.Reshape(
+                Engine.TensorSlice(
+                    input,
+                    [b, 0, 0],
+                    [1, numVertices, InputChannels]),
+                [numVertices, InputChannels]);
+            var gathered = GatherSpiralFeatures(singleInput, numVertices);
+            gatheredFeatures[b] = gathered;
+
+            var singleOutput = Engine.TensorMatMul(gathered, transposedWeights);
+            outputs[b] = AddBiases(singleOutput, numVertices);
         }
 
-        return new Tensor<T>(combinedData, [batchSize, numVertices, featureDim]);
-    }
+        _gatheredFeatures = cacheBwd
+            ? Engine.TensorStack(gatheredFeatures, axis: 0)
+            : null;
 
-    /// <summary>
-    /// Extracts a single sample from a batched tensor.
-    /// </summary>
-    /// <param name="batched">Batched tensor [batch, vertices, channels].</param>
-    /// <param name="batchIndex">Index of the batch to extract.</param>
-    /// <param name="numVertices">Number of vertices.</param>
-    /// <returns>Single sample tensor [vertices, channels].</returns>
-    private Tensor<T> ExtractBatchSlice(Tensor<T> batched, int batchIndex, int numVertices)
-    {
-        int channels = batched.Shape[2];
-        var data = new T[numVertices * channels];
-
-        for (int v = 0; v < numVertices; v++)
-        {
-            for (int c = 0; c < channels; c++)
-            {
-                data[v * channels + c] = batched[batchIndex, v, c];
-            }
-        }
-
-        return new Tensor<T>(data, [numVertices, channels]);
+        return Engine.TensorStack(outputs, axis: 0);
     }
 
     /// <summary>
@@ -834,19 +775,15 @@ public partial class SpiralConvLayer<T> : LayerBase<T>
         if (_spiralIndices == null)
             throw new InvalidOperationException("Spiral indices not set.");
 
-        int gatheredSize = InputChannels * SpiralLength;
-
-        // Create result tensor
-        var gathered = new Tensor<T>([numVertices, gatheredSize]);
+        var featureBlocks = new Tensor<T>[SpiralLength];
 
         // Gather features for each spiral position using vectorized operations
         for (int s = 0; s < SpiralLength; s++)
         {
-            int featureOffset = s * InputChannels;
-
             // Create indices for this spiral position
             var spiralPositionIndices = new int[numVertices];
             var validMask = new T[numVertices];
+            bool hasInvalidNeighbor = false;
 
             for (int v = 0; v < numVertices; v++)
             {
@@ -860,6 +797,7 @@ public partial class SpiralConvLayer<T> : LayerBase<T>
                 {
                     spiralPositionIndices[v] = 0; // Placeholder, will be masked to zero
                     validMask[v] = NumOps.Zero;
+                    hasInvalidNeighbor = true;
                 }
             }
 
@@ -868,15 +806,16 @@ public partial class SpiralConvLayer<T> : LayerBase<T>
             // Gather neighbor features
             var neighborFeatures = Engine.TensorGather(input, indicesTensor, axis: 0);
 
-            // Apply mask to zero out invalid neighbors
-            var mask = new Tensor<T>(validMask, [numVertices, 1]);
-            neighborFeatures = Engine.TensorMultiply(neighborFeatures, Engine.TensorTile(mask, [1, InputChannels]));
+            if (hasInvalidNeighbor)
+            {
+                var mask = new Tensor<T>(validMask, [numVertices, 1]);
+                neighborFeatures = Engine.TensorMultiply(neighborFeatures, mask);
+            }
 
-            // Set the gathered features into the result at the appropriate offset
-            gathered = Engine.TensorSetSlice(gathered, neighborFeatures, [0, featureOffset]);
+            featureBlocks[s] = neighborFeatures;
         }
 
-        return gathered;
+        return Engine.TensorConcatenate(featureBlocks, axis: 1);
     }
 
     /// <summary>

--- a/tests/AiDotNet.Tests/IntegrationTests/Finance/FinanceCategoryIntegrationTests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/Finance/FinanceCategoryIntegrationTests.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using AiDotNet.Finance.Forecasting.Foundation;
+using AiDotNet.Models.Options;
 using Xunit;
 using System.Threading.Tasks;
 
@@ -106,6 +108,50 @@ public class FinanceCategoryIntegrationTests
         Assert.NotEmpty(FinanceModelTestFactory.GetPortfolioModelTypes<float>());
         Assert.NotEmpty(FinanceModelTestFactory.GetVolatilityModelTypes<float>());
         Assert.NotEmpty(FinanceModelTestFactory.GetFactorModelTypes<float>());
+    }
+
+    [Fact]
+    public void CsdiInstanceNormalization_RankThreeInput_PreservesShape()
+    {
+        var options = new CSDIOptions<double>
+        {
+            SequenceLength = 4,
+            NumFeatures = 2,
+            HiddenDimension = 8,
+            NumResidualLayers = 1,
+            NumDiffusionSteps = 1,
+            NumHeads = 1,
+            TimeEmbeddingDim = 4
+        };
+        var model = new CSDI<double>(FinanceTestHelpers.CreateArchitecture<double>(8, 8), options);
+        var input = FinanceTestHelpers.CreateTimeSeriesInput<double>(2, 4, 2);
+
+        var normalized = model.ApplyInstanceNormalization(input);
+
+        Assert.Equal(input.Shape, normalized.Shape);
+        Assert.Equal(input.Length, normalized.Length);
+    }
+
+    [Fact]
+    public void TfcTraining_RankThreeInput_BackpropagatesThroughTemporalFft()
+    {
+        var options = new TFCOptions<double>
+        {
+            ContextLength = 8,
+            ForecastHorizon = 4,
+            HiddenDimension = 8,
+            ProjectionDimension = 4,
+            NumTimeLayers = 1,
+            NumFreqLayers = 1,
+            DropoutRate = 0.0
+        };
+        var model = new TFC<double>(FinanceTestHelpers.CreateArchitecture<double>(8, 4), options);
+        var input = FinanceTestHelpers.CreateTimeSeriesInput<double>(1, 8, 1);
+        var target = model.Predict(input);
+
+        model.Train(input, target);
+
+        Assert.True(model.GetFinancialMetrics().ContainsKey("LastLoss"));
     }
 
     [Theory]

--- a/tests/AiDotNet.Tests/ModelFamilyTests/NeuralNetworks/BiLSTMCRFTests.cs
+++ b/tests/AiDotNet.Tests/ModelFamilyTests/NeuralNetworks/BiLSTMCRFTests.cs
@@ -3,11 +3,13 @@ using AiDotNet.Interfaces;
 using AiDotNet.NER.Options;
 using AiDotNet.NER.SequenceLabeling;
 using AiDotNet.NeuralNetworks;
+using AiDotNet.NeuralNetworks.Layers;
 using AiDotNet.Tensors;
 using AiDotNet.Tensors.Helpers;
 using AiDotNet.Tensors.LinearAlgebra;
 using AiDotNet.Tests.ModelFamilyTests.Base;
 using System;
+using System.Linq;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -135,6 +137,40 @@ public class BiLSTMCRFTests : SequenceLabelingNERTestBase
             }
         }
         return (input, labels);
+    }
+
+    [Fact]
+    public void CrfParameterShapes_RemainCanonicalAfterTrainingStep()
+    {
+        using var arena = TensorArena.Create();
+        using var model = CreateSmallModel();
+        var crf = Assert.Single(model.Layers.OfType<ConditionalRandomFieldLayer<double>>());
+
+        Assert.Equal(new[] { RegressionLabels, RegressionLabels }, crf.GetTrainableParameters()[0].Shape.ToArray());
+        Assert.Equal(new[] { RegressionLabels }, crf.GetTrainableParameters()[1].Shape.ToArray());
+        Assert.Equal(new[] { RegressionLabels }, crf.GetTrainableParameters()[2].Shape.ToArray());
+
+        model.SetTrainingMode(true);
+        Assert.Equal(new[] { RegressionLabels, RegressionLabels }, crf.GetTrainableParameters()[0].Shape.ToArray());
+        Assert.Equal(new[] { RegressionLabels }, crf.GetTrainableParameters()[1].Shape.ToArray());
+        Assert.Equal(new[] { RegressionLabels }, crf.GetTrainableParameters()[2].Shape.ToArray());
+
+        _ = AiDotNet.Training.TapeTrainingStep<double>.CollectParameters(model.Layers);
+        Assert.Equal(new[] { RegressionLabels, RegressionLabels }, crf.GetTrainableParameters()[0].Shape.ToArray());
+
+        var diagnosticExample = MakeExample(0);
+        _ = model.ForwardForTraining(diagnosticExample.input);
+        Assert.Equal(new[] { RegressionLabels, RegressionLabels }, crf.GetTrainableParameters()[0].Shape.ToArray());
+
+        for (int step = 0; step < 3; step++)
+        {
+            var (input, labels) = MakeExample(step);
+            model.Train(input, labels);
+
+            Assert.Equal(new[] { RegressionLabels, RegressionLabels }, crf.GetTrainableParameters()[0].Shape.ToArray());
+            Assert.Equal(new[] { RegressionLabels }, crf.GetTrainableParameters()[1].Shape.ToArray());
+            Assert.Equal(new[] { RegressionLabels }, crf.GetTrainableParameters()[2].Shape.ToArray());
+        }
     }
 
     /// <summary>


### PR DESCRIPTION
## Status

Draft pending merge and release of `ooples/AiDotNet.Tensors#785`. The local validation used a package built from that exact Tensors branch. No local feed or local package version is committed here.

## What changed

- preserve canonical pinned CRF parameter tensors through compiled training
- normalize rank-3 CSDI instances without dropping feature dimensions
- run TFC RFFT along the temporal axis and restore `[batch, time, features]`
- convert dense GraphAttention adjacency to sparse edges and compose heads from differentiable primitives
- keep SpiralConv batch slicing/stacking on the recording thread
- replace repeated mesh/spiral set-slice assembly with differentiable concatenate
- replace tiled channel masks/scales with broadcasting to remove redundant tile gradients
- add focused CRF and finance regressions

## Root causes

Several model implementations detached values from the training graph through scratch arrays, raw copies, or aggregate kernels without a complete backward path. CRF initialization also replaced pinned parameter tensors with ordinary temporaries. CSDI flattened rank-3 input using only its sequence dimension, while TFC transformed the feature axis instead of time.

The upstream tensor audit additionally found missing eager/compiled autodiff for `TensorSetSlice`, a discarded out-of-place result in split backward, and a slow recursive path for contiguous last-axis concatenation. Those engine fixes are isolated in `AiDotNet.Tensors#785`.

## Validation

- `net10.0` Release test project build: passed
- CRF/finance/complete GraphAttention group: 25/25 passed after rebasing onto current master
- SpiralNet gradient, convergence, optimizer, finite-output, input-sensitivity, and 50-vs-200 iteration data-scaling contracts: 6/6 passed after rebase
- MeshCNN equivalent six-contract group: 6/6 passed; unchanged 250-step data-scaling test completes below its individual 120-second timeout
- Tensors dependency: full solution build and CI green in `ooples/AiDotNet.Tensors#785`

## Dependency before ready

After `AiDotNet.Tensors#785` is merged and its package is published, update `AiDotNet.Tensors` from 0.114.3 to that real version, restore from NuGet, rerun the focused suites, and remove this draft block.
