### PR TITLE
feat(serving): high-throughput inference serving framework (foundation)

### DIFF
--- a/.github/workflows/heavy-timeout-nightly.yml
+++ b/.github/workflows/heavy-timeout-nightly.yml
@@ -32,6 +32,9 @@ jobs:
     name: Heavy Timeout Models
     runs-on: ubuntu-latest
     timeout-minutes: 350   # generous budget; these models are the slow ones by definition
+    # Licensed key so save/load-heavy suites don't trip the unlicensed free-trial operation limit.
+    env:
+      AIDOTNET_LICENSE_KEY: ${{ secrets.AIDOTNET_LICENSE_KEY }}
     steps:
       - name: Checkout code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v4

--- a/.github/workflows/heavy-timeout-nightly.yml
+++ b/.github/workflows/heavy-timeout-nightly.yml
@@ -32,9 +32,6 @@ jobs:
     name: Heavy Timeout Models
     runs-on: ubuntu-latest
     timeout-minutes: 350   # generous budget; these models are the slow ones by definition
-    # Licensed key so save/load-heavy suites don't trip the unlicensed free-trial operation limit.
-    env:
-      AIDOTNET_LICENSE_KEY: ${{ secrets.AIDOTNET_LICENSE_KEY }}
     steps:
       - name: Checkout code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v4
@@ -61,6 +58,10 @@ jobs:
         # stack memory and OOM/cancel the lane instead of giving the visibility this workflow exists for.
         shell: pwsh
         continue-on-error: true
+        # Scoped to this test step only (not job-wide) so the credential is not exposed to other steps or
+        # third-party actions. Licensed key keeps save/load-heavy suites under the free-trial op limit.
+        env:
+          AIDOTNET_LICENSE_KEY: ${{ secrets.AIDOTNET_LICENSE_KEY }}
         run: |
           $runnerJson = 'tests/AiDotNet.Tests/bin/Release/net10.0/xunit.runner.json'
           if (Test-Path $runnerJson) {

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -292,6 +292,11 @@ jobs:
     needs: build
     timeout-minutes: 45
     if: ${{ (github.event.pull_request.draft != true) && !startsWith(github.head_ref, 'release-please--') }}
+    # Run tests under the repo's licensed key so save/load-heavy suites do not trip the unlicensed
+    # free-trial operation limit (TrialStateManager). The secrets context is only available in job/step
+    # env, not workflow-level env, so it is set here.
+    env:
+      AIDOTNET_LICENSE_KEY: ${{ secrets.AIDOTNET_LICENSE_KEY }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -292,11 +292,6 @@ jobs:
     needs: build
     timeout-minutes: 45
     if: ${{ (github.event.pull_request.draft != true) && !startsWith(github.head_ref, 'release-please--') }}
-    # Run tests under the repo's licensed key so save/load-heavy suites do not trip the unlicensed
-    # free-trial operation limit (TrialStateManager). The secrets context is only available in job/step
-    # env, not workflow-level env, so it is set here.
-    env:
-      AIDOTNET_LICENSE_KEY: ${{ secrets.AIDOTNET_LICENSE_KEY }}
     strategy:
       fail-fast: false
       matrix:
@@ -884,6 +879,10 @@ jobs:
         # pwsh (PowerShell Core) is pre-installed on ubuntu-latest runners and runs
         # the existing scripts cross-platform without a rewrite.
         shell: pwsh
+        # Scoped to this test step only (not job-wide) so the credential is not exposed to other steps or
+        # third-party actions. Licensed key keeps save/load-heavy suites under the free-trial op limit.
+        env:
+          AIDOTNET_LICENSE_KEY: ${{ secrets.AIDOTNET_LICENSE_KEY }}
         run: |
           # Sanitize shard name: remove/replace all characters invalid in file paths
           $shardName = "${{ matrix.shard.name }}"

--- a/src/AiDotNet.Serving/Engine/AsyncEngineHost.cs
+++ b/src/AiDotNet.Serving/Engine/AsyncEngineHost.cs
@@ -1,0 +1,176 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Channels;
+using System.Threading.Tasks;
+
+namespace AiDotNet.Serving.Engine;
+
+/// <summary>
+/// One incremental output for a streamed request: the tokens generated so far, whether it has finished, and
+/// why. The async host emits one of these per engine step for each in-flight request.
+/// </summary>
+public readonly struct GenerationUpdate
+{
+    /// <summary>Creates an update.</summary>
+    public GenerationUpdate(IReadOnlyList<int> tokenIds, bool isFinished, string? finishReason)
+    {
+        TokenIds = tokenIds;
+        IsFinished = isFinished;
+        FinishReason = finishReason;
+    }
+
+    /// <summary>All generated token ids so far (cumulative, excludes the prompt).</summary>
+    public IReadOnlyList<int> TokenIds { get; }
+
+    /// <summary>True once the request has finished.</summary>
+    public bool IsFinished { get; }
+
+    /// <summary>Reason it stopped ("stop", "length", "abort"), or null while running.</summary>
+    public string? FinishReason { get; }
+}
+
+/// <summary>
+/// Runs a <see cref="ContinuousBatchingEngine{T}"/> on a dedicated pump thread and exposes an async, concurrent
+/// submission API on top of it — the piece that lets many callers (or many HTTP connections) generate at the
+/// same time while a single loop advances the shared batch. This is the concurrency core beneath the HTTP
+/// server; it has no transport dependency and is unit-testable directly.
+/// </summary>
+/// <remarks>
+/// <para><b>For Beginners:</b> the engine itself advances one step at a time and must be driven from a single
+/// loop. This class runs that loop for you on a background thread and hands each caller an async result (or a
+/// live stream of tokens), so your web requests don't have to know anything about stepping the engine.</para>
+/// </remarks>
+/// <typeparam name="T">The model's numeric type.</typeparam>
+public sealed class AsyncEngineHost<T> : IDisposable
+{
+    private readonly IInferenceEngine _engine;
+    private readonly Thread _pumpThread;
+    private readonly SemaphoreSlim _wakeup = new(0);
+    private readonly ConcurrentDictionary<string, Channel<GenerationUpdate>> _sinks = new();
+    private volatile bool _running = true;
+    private long _counter;
+
+    /// <summary>Wraps and starts a pump over the given engine.</summary>
+    public AsyncEngineHost(IInferenceEngine engine)
+    {
+        _engine = engine ?? throw new ArgumentNullException(nameof(engine));
+        _pumpThread = new Thread(PumpLoop) { IsBackground = true, Name = "aidotnet-serving-pump" };
+        _pumpThread.Start();
+    }
+
+    /// <summary>A snapshot of engine load and KV-cache utilization.</summary>
+    public EngineStatistics GetStatistics() => _engine.GetStatistics();
+
+    /// <summary>
+    /// Streams generation updates for a prompt as tokens are produced. Cancelling the enumeration aborts the
+    /// request in the engine and frees its KV memory.
+    /// </summary>
+    public async IAsyncEnumerable<GenerationUpdate> StreamAsync(
+        IReadOnlyList<int> promptTokenIds,
+        SamplingParameters sampling,
+        [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        string id = Submit(promptTokenIds, sampling, out var reader);
+        try
+        {
+            while (await reader.WaitToReadAsync(cancellationToken).ConfigureAwait(false))
+            {
+                while (reader.TryRead(out var update))
+                {
+                    yield return update;
+                    if (update.IsFinished) yield break;
+                }
+            }
+        }
+        finally
+        {
+            if (_sinks.TryRemove(id, out _)) _engine.AbortRequest(id);
+        }
+    }
+
+    /// <summary>Generates a complete continuation for a prompt, returning the generated token ids.</summary>
+    public async Task<IReadOnlyList<int>> GenerateAsync(
+        IReadOnlyList<int> promptTokenIds,
+        SamplingParameters sampling,
+        CancellationToken cancellationToken = default)
+    {
+        IReadOnlyList<int> result = Array.Empty<int>();
+        await foreach (var update in StreamAsync(promptTokenIds, sampling, cancellationToken).ConfigureAwait(false))
+            result = update.TokenIds;
+        return result;
+    }
+
+    private string Submit(IReadOnlyList<int> promptTokenIds, SamplingParameters sampling, out ChannelReader<GenerationUpdate> reader)
+    {
+        if (promptTokenIds is null) throw new ArgumentNullException(nameof(promptTokenIds));
+        if (sampling is null) throw new ArgumentNullException(nameof(sampling));
+
+        string id = "req-" + Interlocked.Increment(ref _counter).ToString();
+        var channel = Channel.CreateUnbounded<GenerationUpdate>(new UnboundedChannelOptions { SingleReader = true, SingleWriter = true });
+        _sinks[id] = channel;
+        reader = channel.Reader;
+
+        _engine.AddRequest(new GenerationRequest(id, promptTokenIds, sampling));
+        _wakeup.Release();
+        return id;
+    }
+
+    private void PumpLoop()
+    {
+        while (_running)
+        {
+            IReadOnlyList<RequestOutput> outputs;
+            try
+            {
+                outputs = _engine.Step();
+            }
+            catch (Exception ex)
+            {
+                FailAllSinks(ex);
+                continue;
+            }
+
+            foreach (var output in outputs)
+                Dispatch(output);
+
+            if (outputs.Count == 0 && !_engine.HasUnfinishedRequests)
+                _wakeup.Wait(100); // sleep until a new request arrives (bounded so shutdown stays responsive)
+        }
+    }
+
+    private void Dispatch(RequestOutput output)
+    {
+        if (!_sinks.TryGetValue(output.RequestId, out var channel)) return;
+
+        var completion = output.Outputs.Count > 0 ? output.Outputs[0] : null;
+        var tokens = completion?.TokenIds ?? Array.Empty<int>();
+        channel.Writer.TryWrite(new GenerationUpdate(tokens, output.IsFinished, completion?.FinishReason));
+
+        if (output.IsFinished)
+        {
+            channel.Writer.TryComplete();
+            _sinks.TryRemove(output.RequestId, out _);
+        }
+    }
+
+    private void FailAllSinks(Exception ex)
+    {
+        foreach (var kvp in _sinks)
+        {
+            kvp.Value.Writer.TryComplete(ex);
+            _sinks.TryRemove(kvp.Key, out _);
+        }
+    }
+
+    /// <inheritdoc/>
+    public void Dispose()
+    {
+        _running = false;
+        _wakeup.Release();
+        if (_pumpThread.IsAlive) _pumpThread.Join(TimeSpan.FromSeconds(5));
+        foreach (var kvp in _sinks) kvp.Value.Writer.TryComplete();
+        _engine.Dispose();
+    }
+}

--- a/src/AiDotNet.Serving/Engine/BlockManager.cs
+++ b/src/AiDotNet.Serving/Engine/BlockManager.cs
@@ -1,0 +1,258 @@
+namespace AiDotNet.Serving.Engine;
+
+/// <summary>
+/// A copy-on-write instruction the block manager emits when prefix-shared sequences diverge: the runner must
+/// duplicate the key/value contents of <see cref="Source"/> into <see cref="Destination"/> (across all layers)
+/// before the writing sequence appends into what was a shared block.
+/// </summary>
+public readonly struct BlockCopy
+{
+    /// <summary>Creates a copy-on-write instruction.</summary>
+    public BlockCopy(int source, int destination)
+    {
+        Source = source;
+        Destination = destination;
+    }
+
+    /// <summary>Physical block id to copy KV from.</summary>
+    public int Source { get; }
+
+    /// <summary>Physical block id to copy KV into (freshly allocated, refcount 1).</summary>
+    public int Destination { get; }
+}
+
+/// <summary>
+/// Paged KV-cache block manager: the memory allocator at the heart of high-throughput serving. It partitions
+/// the KV cache into fixed-size <b>blocks</b> (each holding <see cref="BlockSize"/> token slots) and hands each
+/// sequence a <b>block table</b> (its ordered list of physical blocks). Blocks are reference counted so several
+/// sequences can share a common prompt prefix (copy-on-write), and are recycled to a free list when released.
+/// </summary>
+/// <remarks>
+/// <para><b>For Beginners:</b> a language model's "memory" of the tokens it has read (the KV cache) is large,
+/// and naive serving gives each request one big contiguous chunk — which wastes memory and limits how many
+/// requests fit at once. Paging (from vLLM's PagedAttention) instead cuts the cache into small fixed blocks,
+/// like pages of RAM, and gives each sequence a list of block numbers. Blocks can be shared between requests
+/// that start with the same prompt, and freed blocks go back into a pool for reuse. This class is the
+/// bookkeeper for that pool: who owns which blocks, when to copy a shared block before writing (copy-on-write),
+/// and when a block is free again.</para>
+/// <para>This type is deliberately decoupled from the model and from <see cref="Sequence"/>: it reasons purely
+/// about sequence ids and token counts, so it is fully unit-testable on its own. Its invariants — no physical
+/// block is ever handed out twice, and free blocks + referenced blocks always sum to the pool size — are the
+/// correctness backbone of the engine.</para>
+/// </remarks>
+public sealed class BlockManager
+{
+    private readonly int _blockSize;
+    private readonly int _totalBlocks;
+    private readonly int[] _refCounts;
+    private readonly Stack<int> _freeBlocks;
+    private readonly Dictionary<string, List<int>> _blockTables;
+    private readonly Dictionary<string, int> _lengths;
+
+    /// <summary>Creates a block manager over a pool of <paramref name="totalBlocks"/> blocks of the given size.</summary>
+    /// <param name="totalBlocks">Number of physical KV blocks in the pool (sizes total KV memory).</param>
+    /// <param name="blockSize">Token slots per block (must match the runner's block size).</param>
+    public BlockManager(int totalBlocks, int blockSize)
+    {
+        if (totalBlocks < 1) throw new ArgumentOutOfRangeException(nameof(totalBlocks), "Pool must have at least one block.");
+        if (blockSize < 1) throw new ArgumentOutOfRangeException(nameof(blockSize), "Block size must be at least one token.");
+
+        _blockSize = blockSize;
+        _totalBlocks = totalBlocks;
+        _refCounts = new int[totalBlocks];
+        _freeBlocks = new Stack<int>(totalBlocks);
+        // Push in descending order so ids are popped ascending (0,1,2,...) — nicer for tests/debugging.
+        for (int i = totalBlocks - 1; i >= 0; i--) _freeBlocks.Push(i);
+        _blockTables = new Dictionary<string, List<int>>();
+        _lengths = new Dictionary<string, int>();
+    }
+
+    /// <summary>Token slots per block.</summary>
+    public int BlockSize => _blockSize;
+
+    /// <summary>Total blocks in the pool.</summary>
+    public int TotalBlocks => _totalBlocks;
+
+    /// <summary>Blocks currently free (available for allocation).</summary>
+    public int NumFreeBlocks => _freeBlocks.Count;
+
+    /// <summary>Blocks currently referenced by at least one sequence.</summary>
+    public int NumUsedBlocks => _totalBlocks - _freeBlocks.Count;
+
+    /// <summary>Fraction (0..1) of the pool currently in use.</summary>
+    public double Usage => _totalBlocks == 0 ? 0.0 : (double)NumUsedBlocks / _totalBlocks;
+
+    /// <summary>Number of sequences currently holding a block table.</summary>
+    public int NumSequences => _blockTables.Count;
+
+    /// <summary>True if the given sequence currently has an allocation.</summary>
+    public bool Contains(string sequenceId) => _blockTables.ContainsKey(sequenceId);
+
+    /// <summary>Number of blocks needed to hold <paramref name="numTokens"/> tokens.</summary>
+    public int BlocksForTokens(int numTokens) => (numTokens + _blockSize - 1) / _blockSize;
+
+    /// <summary>True if the pool has enough free blocks to allocate a fresh sequence of <paramref name="numTokens"/> tokens.</summary>
+    public bool CanAllocate(int numTokens)
+    {
+        if (numTokens < 1) throw new ArgumentOutOfRangeException(nameof(numTokens));
+        return BlocksForTokens(numTokens) <= _freeBlocks.Count;
+    }
+
+    /// <summary>
+    /// Allocates blocks for a new sequence's initial tokens (its prompt / prefill). The sequence must not
+    /// already be allocated. Throws if the pool cannot satisfy the request (callers must check
+    /// <see cref="CanAllocate"/> first).
+    /// </summary>
+    /// <returns>The sequence's block table (physical block ids in logical order).</returns>
+    public IReadOnlyList<int> Allocate(string sequenceId, int numTokens)
+    {
+        if (string.IsNullOrEmpty(sequenceId)) throw new ArgumentException("Sequence id required.", nameof(sequenceId));
+        if (numTokens < 1) throw new ArgumentOutOfRangeException(nameof(numTokens));
+        if (_blockTables.ContainsKey(sequenceId))
+            throw new InvalidOperationException($"Sequence '{sequenceId}' is already allocated.");
+
+        int needed = BlocksForTokens(numTokens);
+        if (needed > _freeBlocks.Count)
+            throw new InvalidOperationException(
+                $"Out of KV blocks: need {needed}, have {_freeBlocks.Count}. Check CanAllocate first.");
+
+        var table = new List<int>(needed);
+        for (int i = 0; i < needed; i++)
+        {
+            int block = _freeBlocks.Pop();
+            _refCounts[block] = 1;
+            table.Add(block);
+        }
+        _blockTables[sequenceId] = table;
+        _lengths[sequenceId] = numTokens;
+        return table;
+    }
+
+    /// <summary>
+    /// True if the sequence can grow by <paramref name="numNewTokens"/> tokens: enough free blocks exist for any
+    /// new blocks required plus a copy-on-write duplicate if its last block is shared.
+    /// </summary>
+    public bool CanAppend(string sequenceId, int numNewTokens = 1)
+    {
+        if (numNewTokens < 1) throw new ArgumentOutOfRangeException(nameof(numNewTokens));
+        var table = RequireTable(sequenceId);
+        int length = _lengths[sequenceId];
+
+        int newBlocksNeeded = BlocksForTokens(length + numNewTokens) - table.Count;
+        int cowNeeded = LastBlockNeedsCow(table, length) ? 1 : 0;
+        return newBlocksNeeded + cowNeeded <= _freeBlocks.Count;
+    }
+
+    /// <summary>
+    /// Grows a sequence by <paramref name="numNewTokens"/> tokens (normally 1, per decode step), allocating new
+    /// blocks as needed and performing copy-on-write if its last block is shared with another sequence. Callers
+    /// must check <see cref="CanAppend"/> first. Returns any copy-on-write instructions the runner must execute
+    /// before writing the new token's KV (empty when no copy was needed).
+    /// </summary>
+    public IReadOnlyList<BlockCopy> Append(string sequenceId, int numNewTokens = 1)
+    {
+        if (numNewTokens < 1) throw new ArgumentOutOfRangeException(nameof(numNewTokens));
+        var table = RequireTable(sequenceId);
+        int length = _lengths[sequenceId];
+
+        int newBlocksNeeded = BlocksForTokens(length + numNewTokens) - table.Count;
+        bool cow = LastBlockNeedsCow(table, length);
+        if (newBlocksNeeded + (cow ? 1 : 0) > _freeBlocks.Count)
+            throw new InvalidOperationException(
+                $"Out of KV blocks appending to '{sequenceId}'. Check CanAppend first.");
+
+        List<BlockCopy>? copies = null;
+
+        // Copy-on-write: the last block still has room and is shared (prefix-shared via Fork). We must not
+        // write another sequence's token into a block others read, so duplicate it and rewire this sequence.
+        if (cow)
+        {
+            int lastIndex = table.Count - 1;
+            int oldBlock = table[lastIndex];
+            int newBlock = _freeBlocks.Pop();
+            _refCounts[newBlock] = 1;
+            _refCounts[oldBlock]--;
+            table[lastIndex] = newBlock;
+            copies = new List<BlockCopy>(1) { new BlockCopy(oldBlock, newBlock) };
+        }
+
+        for (int i = 0; i < newBlocksNeeded; i++)
+        {
+            int block = _freeBlocks.Pop();
+            _refCounts[block] = 1;
+            table.Add(block);
+        }
+
+        _lengths[sequenceId] = length + numNewTokens;
+        return copies ?? (IReadOnlyList<BlockCopy>)Array.Empty<BlockCopy>();
+    }
+
+    /// <summary>
+    /// Creates a child sequence that shares the parent's blocks (copy-on-write prefix sharing). Both sequences
+    /// read the same prefix KV until one of them writes into the shared tail, at which point <see cref="Append"/>
+    /// duplicates only the block being written. The child must not already exist.
+    /// </summary>
+    /// <returns>The child's block table (initially identical physical blocks to the parent).</returns>
+    public IReadOnlyList<int> Fork(string parentSequenceId, string childSequenceId)
+    {
+        var parentTable = RequireTable(parentSequenceId);
+        if (string.IsNullOrEmpty(childSequenceId)) throw new ArgumentException("Child id required.", nameof(childSequenceId));
+        if (_blockTables.ContainsKey(childSequenceId))
+            throw new InvalidOperationException($"Sequence '{childSequenceId}' already exists.");
+
+        var childTable = new List<int>(parentTable);
+        foreach (int block in childTable) _refCounts[block]++;
+        _blockTables[childSequenceId] = childTable;
+        _lengths[childSequenceId] = _lengths[parentSequenceId];
+        return childTable;
+    }
+
+    /// <summary>
+    /// Releases a sequence's blocks: each block's reference count is decremented, and blocks reaching zero
+    /// references return to the free pool. Safe to call once per sequence; unknown ids are ignored.
+    /// </summary>
+    public void Free(string sequenceId)
+    {
+        if (!_blockTables.TryGetValue(sequenceId, out var table)) return;
+        foreach (int block in table)
+        {
+            if (--_refCounts[block] == 0)
+                _freeBlocks.Push(block);
+            else if (_refCounts[block] < 0)
+                throw new InvalidOperationException($"Reference count underflow on block {block}.");
+        }
+        _blockTables.Remove(sequenceId);
+        _lengths.Remove(sequenceId);
+    }
+
+    /// <summary>Returns the sequence's current block table (throws if unknown).</summary>
+    public IReadOnlyList<int> GetBlockTable(string sequenceId) => RequireTable(sequenceId);
+
+    /// <summary>Number of token slots filled in the sequence's final block (0 &lt; value ≤ BlockSize), or 0 if unallocated.</summary>
+    public int FilledSlotsInLastBlock(string sequenceId)
+    {
+        if (!_lengths.TryGetValue(sequenceId, out int length) || length == 0) return 0;
+        int rem = length % _blockSize;
+        return rem == 0 ? _blockSize : rem;
+    }
+
+    /// <summary>Current logical token count of the sequence (throws if unknown).</summary>
+    public int GetLength(string sequenceId) => _lengths.TryGetValue(sequenceId, out int l)
+        ? l
+        : throw new KeyNotFoundException($"Unknown sequence '{sequenceId}'.");
+
+    private List<int> RequireTable(string sequenceId)
+        => _blockTables.TryGetValue(sequenceId, out var table)
+            ? table
+            : throw new KeyNotFoundException($"Unknown sequence '{sequenceId}'.");
+
+    // The last block must be copied-on-write iff it still has a free slot to be written AND it is shared with
+    // another sequence. A full last block is never written into (a new block is appended instead), and an
+    // unshared block can be written in place.
+    private bool LastBlockNeedsCow(List<int> table, int length)
+    {
+        if (table.Count == 0) return false;
+        bool lastHasRoom = length % _blockSize != 0;
+        return lastHasRoom && _refCounts[table[table.Count - 1]] > 1;
+    }
+}

--- a/src/AiDotNet.Serving/Engine/BlockManager.cs
+++ b/src/AiDotNet.Serving/Engine/BlockManager.cs
@@ -208,6 +208,39 @@ public sealed class BlockManager
     }
 
     /// <summary>
+    /// Creates a child sequence that shares only the <paramref name="prefixTokens"/>-token prefix of the parent
+    /// (copy-on-write), rather than the parent's whole current length. This is the primitive behind prefix
+    /// sharing / prefill-once: several sequences that begin with the same prompt reference one copy of the
+    /// prompt's KV blocks and only diverge (allocating fresh blocks) as they generate.
+    /// </summary>
+    /// <remarks>For clean semantics the caller should pass a block-aligned <paramref name="prefixTokens"/> so the
+    /// shared blocks contain exactly the prefix; a non-aligned prefix shares a final block whose tail also holds
+    /// the parent's continuation (a subsequent write copies-on-write).</remarks>
+    /// <returns>The child's block table (the shared prefix blocks).</returns>
+    public IReadOnlyList<int> ForkPrefix(string parentSequenceId, string childSequenceId, int prefixTokens)
+    {
+        var parentTable = RequireTable(parentSequenceId);
+        if (string.IsNullOrEmpty(childSequenceId)) throw new ArgumentException("Child id required.", nameof(childSequenceId));
+        if (_blockTables.ContainsKey(childSequenceId))
+            throw new InvalidOperationException($"Sequence '{childSequenceId}' already exists.");
+        if (prefixTokens < 1) throw new ArgumentOutOfRangeException(nameof(prefixTokens));
+        if (prefixTokens > _lengths[parentSequenceId])
+            throw new ArgumentOutOfRangeException(nameof(prefixTokens), "Prefix exceeds the parent's length.");
+
+        int prefixBlocks = BlocksForTokens(prefixTokens);
+        var childTable = new List<int>(prefixBlocks);
+        for (int i = 0; i < prefixBlocks; i++)
+        {
+            int block = parentTable[i];
+            _refCounts[block]++;
+            childTable.Add(block);
+        }
+        _blockTables[childSequenceId] = childTable;
+        _lengths[childSequenceId] = prefixTokens;
+        return childTable;
+    }
+
+    /// <summary>
     /// Releases a sequence's blocks: each block's reference count is decremented, and blocks reaching zero
     /// references return to the free pool. Safe to call once per sequence; unknown ids are ignored.
     /// </summary>

--- a/src/AiDotNet.Serving/Engine/ContinuousBatchingEngine.cs
+++ b/src/AiDotNet.Serving/Engine/ContinuousBatchingEngine.cs
@@ -1,0 +1,376 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using AiDotNet.Tensors.Helpers;
+using AiDotNet.Tensors.LinearAlgebra;
+
+namespace AiDotNet.Serving.Engine;
+
+/// <summary>
+/// The continuous- (in-flight-) batching inference engine: the loop that keeps many requests progressing at
+/// once over a paged KV cache, the way vLLM and TGI do. Requests are admitted any time via
+/// <see cref="AddRequest"/>; each <see cref="Step"/> schedules a batch (prefill for freshly admitted prompts,
+/// one-token decode for running sequences), runs the model once, samples a token per sequence, frees finished
+/// sequences, and — under KV-memory pressure — preempts by recompute so the batch always fits.
+/// </summary>
+/// <remarks>
+/// <para><b>For Beginners:</b> a naive server runs one request at a time. This engine instead interleaves them:
+/// every step it advances every in-flight request by one token and slots in new requests the moment memory is
+/// free, so the hardware stays busy and everyone's latency stays low. It borrows two ideas from vLLM — a paged
+/// KV cache (memory in small reusable blocks, see <see cref="BlockManager"/>) and continuous batching — behind
+/// a simple <see cref="IInferenceEngine"/> you just pump in a loop.</para>
+/// <para>The engine is model-agnostic: it drives an <see cref="IServingModelRunner{T}"/>, which is satisfied
+/// either by a paged fast path (a model's <see cref="ICausalLmRunner{T}"/> capability) or by a recompute
+/// fallback over any <see cref="AiDotNet.Interfaces.IFullModel{T, TInput, TOutput}"/>. This keeps the scheduler
+/// identical regardless of model, and lets it be tested against a deterministic fake runner.</para>
+/// <para>Not thread-safe for concurrent <see cref="Step"/> calls (drive it from one loop); <see cref="AddRequest"/>
+/// and <see cref="AbortRequest"/> are safe to call from other threads while stepping.</para>
+/// </remarks>
+/// <typeparam name="T">The model's numeric type.</typeparam>
+public sealed class ContinuousBatchingEngine<T> : IInferenceEngine
+{
+    private readonly IServingModelRunner<T> _runner;
+    private readonly EngineOptions _options;
+    private readonly BlockManager _blocks;
+
+    private readonly object _intakeLock = new();
+    private readonly LinkedList<Sequence> _waiting = new();
+    private readonly List<Sequence> _running = new();            // kept oldest-first (arrival order)
+    private readonly Dictionary<string, List<Sequence>> _byRequest = new();
+    private readonly Dictionary<string, Random> _rngBySequence = new();
+    private readonly Queue<GenerationRequest> _pendingAdds = new();
+    private readonly HashSet<string> _pendingAborts = new();
+
+    private long _totalPreemptions;
+    private long _totalFinishedRequests;
+    private bool _disposed;
+
+    /// <summary>Creates a continuous-batching engine over the given model runner.</summary>
+    public ContinuousBatchingEngine(IServingModelRunner<T> runner, EngineOptions? options = null)
+    {
+        _runner = runner ?? throw new ArgumentNullException(nameof(runner));
+        _options = options ?? new EngineOptions();
+        _options.Validate();
+        _blocks = new BlockManager(_options.NumKvBlocks, _options.BlockSize);
+    }
+
+    /// <inheritdoc/>
+    public void AddRequest(GenerationRequest request)
+    {
+        if (request is null) throw new ArgumentNullException(nameof(request));
+        lock (_intakeLock) _pendingAdds.Enqueue(request);
+    }
+
+    /// <inheritdoc/>
+    public bool AbortRequest(string requestId)
+    {
+        if (string.IsNullOrEmpty(requestId)) return false;
+        lock (_intakeLock)
+        {
+            _pendingAborts.Add(requestId);
+            // Report found if it is anywhere we know about (pending, waiting, or running).
+            return _byRequest.ContainsKey(requestId)
+                || _pendingAdds.Any(r => r.RequestId == requestId);
+        }
+    }
+
+    /// <inheritdoc/>
+    public bool HasUnfinishedRequests
+    {
+        get
+        {
+            lock (_intakeLock)
+                return _pendingAdds.Count > 0 || _waiting.Count > 0 || _running.Count > 0;
+        }
+    }
+
+    /// <inheritdoc/>
+    public IReadOnlyList<RequestOutput> Step()
+    {
+        var touchedRequests = new HashSet<string>();
+        DrainIntake(touchedRequests);
+
+        // Schedule this step's batch: running sequences decode (priority), then admit waiting prompts. Each
+        // scheduled sequence reserves the KV slot for the token it will generate at schedule time (before
+        // prefill admission consumes free blocks), so the post-sample append can never run out of memory.
+        var scheduled = new List<Sequence>();
+        int batchTokens = 0;
+
+        ScheduleDecode(scheduled, ref batchTokens);
+        SchedulePrefill(scheduled, ref batchTokens, touchedRequests);
+
+        if (scheduled.Count == 0)
+            return touchedRequests.Count == 0 ? Array.Empty<RequestOutput>() : CollectOutputs(touchedRequests);
+
+        // Build executions and run the model once for the whole batch.
+        var executions = new List<SequenceExecution<T>>(scheduled.Count);
+        foreach (var seq in scheduled)
+        {
+            bool isPrefill = seq.NumComputedTokens == 0;
+            executions.Add(new SequenceExecution<T>(
+                seq.SequenceId,
+                seq.TokenIds,
+                seq.NumComputedTokens,
+                _blocks.GetBlockTable(seq.SequenceId),
+                Array.Empty<BlockCopy>(),
+                isPrefill));
+        }
+
+        var logits = _runner.Execute(executions);
+        if (logits is null || logits.Count != scheduled.Count)
+            throw new InvalidOperationException(
+                $"Model runner returned {logits?.Count ?? 0} logit vectors for a batch of {scheduled.Count}.");
+
+        // Sample + advance each scheduled sequence.
+        for (int i = 0; i < scheduled.Count; i++)
+        {
+            AdvanceSequence(scheduled[i], logits[i]);
+            touchedRequests.Add(scheduled[i].Request.RequestId);
+        }
+
+        return CollectOutputs(touchedRequests);
+    }
+
+    /// <inheritdoc/>
+    public EngineStatistics GetStatistics()
+    {
+        lock (_intakeLock)
+        {
+            return new EngineStatistics
+            {
+                RunningSequences = _running.Count,
+                WaitingSequences = _waiting.Count,
+                SwappedSequences = 0, // recompute preemption returns sequences to Waiting, counted there
+                KvCacheUsage = _blocks.Usage,
+                TotalKvBlocks = _blocks.TotalBlocks,
+                FreeKvBlocks = _blocks.NumFreeBlocks,
+                TotalPreemptions = _totalPreemptions,
+                TotalFinishedRequests = _totalFinishedRequests,
+            };
+        }
+    }
+
+    // ---- Intake ---------------------------------------------------------------------------
+
+    private void DrainIntake(HashSet<string> touchedRequests)
+    {
+        lock (_intakeLock)
+        {
+            while (_pendingAdds.Count > 0)
+                AdmitNewRequest(_pendingAdds.Dequeue());
+
+            if (_pendingAborts.Count > 0)
+            {
+                foreach (string requestId in _pendingAborts)
+                    if (ApplyAbort(requestId)) touchedRequests.Add(requestId);
+                _pendingAborts.Clear();
+            }
+        }
+    }
+
+    private void AdmitNewRequest(GenerationRequest request)
+    {
+        int n = request.SamplingParameters.N;
+        var seqs = new List<Sequence>(n);
+        for (int i = 0; i < n; i++)
+        {
+            var seq = new Sequence(request, i);
+            seqs.Add(seq);
+            _waiting.AddLast(seq);
+            _rngBySequence[seq.SequenceId] = request.SamplingParameters.Seed is { } s
+                ? RandomHelper.CreateSeededRandom(s + i) // decorrelate parallel samples
+                : RandomHelper.CreateSecureRandom();
+        }
+        _byRequest[request.RequestId] = seqs;
+    }
+
+    private bool ApplyAbort(string requestId)
+    {
+        if (!_byRequest.TryGetValue(requestId, out var seqs)) return false;
+        foreach (var seq in seqs)
+        {
+            if (seq.State.IsFinished()) continue;
+            RemoveFromQueues(seq);
+            _blocks.Free(seq.SequenceId);
+            _rngBySequence.Remove(seq.SequenceId);
+            seq.Finish(SequenceState.FinishedAborted, "abort");
+        }
+        return true;
+    }
+
+    private void RemoveFromQueues(Sequence seq)
+    {
+        _running.Remove(seq);
+        var node = _waiting.Find(seq);
+        if (node is not null) _waiting.Remove(node);
+    }
+
+    // ---- Scheduling -----------------------------------------------------------------------
+
+    private void ScheduleDecode(List<Sequence> scheduled, ref int batchTokens)
+    {
+        // Oldest-first priority. Snapshot because preemption mutates _running.
+        var scheduledSet = new HashSet<Sequence>();
+        var snapshot = new List<Sequence>(_running);
+        foreach (var seq in snapshot)
+        {
+            if (seq.State != SequenceState.Running) continue; // may have been preempted as a victim
+
+            // Reserve the KV slot for the token this seq will generate this step; preempt other sequences
+            // (recompute) if the pool is full.
+            bool canRun = true;
+            while (!_blocks.CanAppend(seq.SequenceId, 1))
+            {
+                var victim = FindPreemptionVictim(scheduledSet, seq);
+                if (victim is null) { canRun = false; break; } // nothing left to free
+                PreemptRecompute(victim);
+                if (ReferenceEquals(victim, seq)) { canRun = false; break; } // preempted ourselves
+            }
+            if (!canRun || seq.State != SequenceState.Running) continue;
+
+            if (batchTokens + 1 > _options.MaxBatchedTokens && scheduled.Count > 0) continue; // budget; next step
+
+            _blocks.Append(seq.SequenceId, 1); // reserve the generation slot now
+            scheduled.Add(seq);
+            scheduledSet.Add(seq);
+            batchTokens += 1;
+        }
+    }
+
+    // Newest un-scheduled running sequence (may be the caller itself, meaning "preempt yourself").
+    private Sequence? FindPreemptionVictim(HashSet<Sequence> scheduledSet, Sequence current)
+    {
+        for (int i = _running.Count - 1; i >= 0; i--)
+        {
+            var cand = _running[i];
+            if (!scheduledSet.Contains(cand)) return cand;
+        }
+        return null;
+    }
+
+    private void SchedulePrefill(List<Sequence> scheduled, ref int batchTokens, HashSet<string> touchedRequests)
+    {
+        while (_waiting.First is { } node)
+        {
+            var seq = node.Value;
+            int needed = seq.Length; // fresh prompt, or prompt+generated for a recompute-preempted sequence
+
+            // A sequence whose prompt (plus one generation slot) can never fit the whole pool is a hard
+            // failure — finish it aborted so the loop does not stall forever.
+            if (_blocks.BlocksForTokens(needed + 1) > _blocks.TotalBlocks)
+            {
+                _waiting.Remove(node);
+                _rngBySequence.Remove(seq.SequenceId);
+                seq.Finish(SequenceState.FinishedAborted, "prompt_too_long");
+                touchedRequests.Add(seq.Request.RequestId);
+                continue;
+            }
+
+            if (_running.Count >= _options.MaxNumSequences) break;
+            // Need room for the prompt AND the first generated token's slot.
+            if (_blocks.BlocksForTokens(needed + 1) > _blocks.NumFreeBlocks) break; // wait for memory
+            if (batchTokens + needed > _options.MaxBatchedTokens && scheduled.Count > 0) break; // budget
+
+            _waiting.Remove(node);
+            _blocks.Allocate(seq.SequenceId, needed);
+            _blocks.Append(seq.SequenceId, 1); // reserve the generation slot now
+            seq.State = SequenceState.Running;
+            seq.NumComputedTokens = 0; // prefill (also re-prefill for recomputed sequences)
+            _running.Add(seq);
+            scheduled.Add(seq);
+            batchTokens += needed;
+        }
+    }
+
+    private void PreemptRecompute(Sequence victim)
+    {
+        _blocks.Free(victim.SequenceId);
+        victim.NumComputedTokens = 0;
+        victim.State = SequenceState.Waiting;
+        _running.Remove(victim);
+        _waiting.AddFirst(victim); // resume as soon as memory allows
+        _totalPreemptions++;
+    }
+
+    // ---- Advancing a sequence -------------------------------------------------------------
+
+    private void AdvanceSequence(Sequence seq, Vector<T> logits)
+    {
+        int lengthBefore = seq.Length;
+        seq.NumComputedTokens = lengthBefore; // all current tokens now have cached KV
+
+        int tokenId = LogitsSampler.Sample(logits, seq.Request.SamplingParameters, seq.TokenIds, _rngBySequence[seq.SequenceId]);
+        // The KV slot for this token was already reserved at schedule time; appending the token now keeps the
+        // block-manager length (seq.Length + 1 reserved) in step with the sequence.
+        seq.AppendToken(tokenId);
+
+        var (finished, terminalState, reason) = EvaluateStop(seq, tokenId);
+        if (finished)
+        {
+            _blocks.Free(seq.SequenceId);
+            _running.Remove(seq);
+            _rngBySequence.Remove(seq.SequenceId);
+            seq.Finish(terminalState, reason);
+        }
+    }
+
+    private (bool finished, SequenceState state, string reason) EvaluateStop(Sequence seq, int tokenId)
+    {
+        var p = seq.Request.SamplingParameters;
+        int generated = seq.GeneratedLength;
+
+        bool minReached = generated >= p.MinTokens;
+        if (minReached)
+        {
+            if (!p.IgnoreEos && _options.EosTokenId is { } eos && tokenId == eos)
+                return (true, SequenceState.FinishedStopped, "stop");
+            if (p.StopTokenIds is { } stops && stops.Contains(tokenId))
+                return (true, SequenceState.FinishedStopped, "stop");
+        }
+        if (generated >= p.MaxTokens)
+            return (true, SequenceState.FinishedLengthCapped, "length");
+
+        return (false, SequenceState.Running, string.Empty);
+    }
+
+    // ---- Output assembly ------------------------------------------------------------------
+
+    private IReadOnlyList<RequestOutput> CollectOutputs(HashSet<string> touchedRequests)
+    {
+        var outputs = new List<RequestOutput>(touchedRequests.Count);
+        foreach (string requestId in touchedRequests)
+        {
+            if (!_byRequest.TryGetValue(requestId, out var seqs)) continue;
+
+            var completions = new List<CompletionOutput>(seqs.Count);
+            bool allFinished = true;
+            foreach (var seq in seqs)
+            {
+                int promptLen = seq.PromptLength;
+                var generated = seq.Length > promptLen
+                    ? seq.TokenIds.Skip(promptLen).ToArray()
+                    : Array.Empty<int>();
+                bool seqFinished = seq.State.IsFinished();
+                allFinished &= seqFinished;
+                completions.Add(new CompletionOutput(seq.SequenceIndex, generated, seqFinished, seq.FinishReason));
+            }
+
+            outputs.Add(new RequestOutput(requestId, seqs[0].Request.PromptTokenIds, completions, allFinished));
+
+            if (allFinished)
+            {
+                _byRequest.Remove(requestId);
+                _totalFinishedRequests++;
+            }
+        }
+        return outputs;
+    }
+
+    /// <inheritdoc/>
+    public void Dispose()
+    {
+        if (_disposed) return;
+        _disposed = true;
+        if (_runner is IDisposable d) d.Dispose();
+    }
+}

--- a/src/AiDotNet.Serving/Engine/ContinuousBatchingEngine.cs
+++ b/src/AiDotNet.Serving/Engine/ContinuousBatchingEngine.cs
@@ -32,6 +32,7 @@ public sealed class ContinuousBatchingEngine<T> : IInferenceEngine
     private readonly IServingModelRunner<T> _runner;
     private readonly EngineOptions _options;
     private readonly BlockManager _blocks;
+    private readonly PrefixCache? _prefixCache;
 
     private readonly object _intakeLock = new();
     private readonly LinkedList<Sequence> _waiting = new();
@@ -55,6 +56,8 @@ public sealed class ContinuousBatchingEngine<T> : IInferenceEngine
         _options = options ?? new EngineOptions();
         _options.Validate();
         _blocks = new BlockManager(_options.NumKvBlocks, _options.BlockSize);
+        if (_options.EnablePrefixCache)
+            _prefixCache = new PrefixCache(_blocks, _options.BlockSize, _options.PrefixCacheCapacity);
     }
 
     /// <inheritdoc/>
@@ -97,10 +100,11 @@ public sealed class ContinuousBatchingEngine<T> : IInferenceEngine
         // scheduled sequence reserves the KV slot for the token it will generate at schedule time (before
         // prefill admission consumes free blocks), so the post-sample append can never run out of memory.
         var scheduled = new List<Sequence>();
+        var prefillThisStep = new HashSet<Sequence>();
         int batchTokens = 0;
 
         ScheduleDecode(scheduled, ref batchTokens);
-        SchedulePrefill(scheduled, ref batchTokens, touchedRequests);
+        SchedulePrefill(scheduled, prefillThisStep, ref batchTokens, touchedRequests);
 
         if (scheduled.Count == 0)
             return touchedRequests.Count == 0 ? Array.Empty<RequestOutput>() : CollectOutputs(touchedRequests);
@@ -109,7 +113,7 @@ public sealed class ContinuousBatchingEngine<T> : IInferenceEngine
         var executions = new List<SequenceExecution<T>>(scheduled.Count);
         foreach (var seq in scheduled)
         {
-            bool isPrefill = seq.NumComputedTokens == 0;
+            bool isPrefill = prefillThisStep.Contains(seq);
             executions.Add(new SequenceExecution<T>(
                 seq.SequenceId,
                 seq.TokenIds,
@@ -127,7 +131,7 @@ public sealed class ContinuousBatchingEngine<T> : IInferenceEngine
         // Sample + advance each scheduled sequence.
         for (int i = 0; i < scheduled.Count; i++)
         {
-            AdvanceSequence(scheduled[i], logits[i]);
+            AdvanceSequence(scheduled[i], logits[i], prefillThisStep.Contains(scheduled[i]));
             touchedRequests.Add(scheduled[i].Request.RequestId);
         }
 
@@ -256,7 +260,8 @@ public sealed class ContinuousBatchingEngine<T> : IInferenceEngine
         return null;
     }
 
-    private void SchedulePrefill(List<Sequence> scheduled, ref int batchTokens, HashSet<string> touchedRequests)
+    private void SchedulePrefill(
+        List<Sequence> scheduled, HashSet<Sequence> prefillThisStep, ref int batchTokens, HashSet<string> touchedRequests)
     {
         while (_waiting.First is { } node)
         {
@@ -275,18 +280,59 @@ public sealed class ContinuousBatchingEngine<T> : IInferenceEngine
             }
 
             if (_running.Count >= _options.MaxNumSequences) break;
-            // Need room for the prompt AND the first generated token's slot.
-            if (_blocks.BlocksForTokens(needed + 1) > _blocks.NumFreeBlocks) break; // wait for memory
-            if (batchTokens + needed > _options.MaxBatchedTokens && scheduled.Count > 0) break; // budget
+
+            // A shared prefix can come from two places: a sibling pre-forked from its prompt owner (already
+            // allocated here), or a cross-request cache hit. Either way we recompute only the non-shared tail.
+            bool preForked = _blocks.Contains(seq.SequenceId);
+            PrefixCache.Hit? hit = null;
+            int sharedLen;
+            if (preForked)
+            {
+                sharedLen = _blocks.GetLength(seq.SequenceId); // aligned prefix already shared for this sibling
+            }
+            else
+            {
+                bool fresh = seq.Length == seq.PromptLength;
+                hit = (_prefixCache is not null && fresh) ? _prefixCache.Lookup(seq.TokenIds) : null;
+                sharedLen = hit?.PrefixLength ?? 0;
+            }
+
+            int totalBlocks = _blocks.BlocksForTokens(needed + 1);
+            int sharedBlocks = sharedLen > 0 ? _blocks.BlocksForTokens(sharedLen) : 0;
+            int newBlocksNeeded = totalBlocks - sharedBlocks; // shared blocks are free-ridden
+            int tokensToCompute = needed - sharedLen;
+
+            // Under memory pressure, release cached prefixes (LRU) rather than stall — pinned cache blocks must
+            // never deadlock live requests.
+            while (newBlocksNeeded > _blocks.NumFreeBlocks && _prefixCache is { Count: > 0 })
+                _prefixCache.TryEvictOne();
+
+            if (newBlocksNeeded > _blocks.NumFreeBlocks) break; // wait for memory
+            if (batchTokens + tokensToCompute > _options.MaxBatchedTokens && scheduled.Count > 0) break; // budget
 
             _waiting.Remove(node);
-            _blocks.Allocate(seq.SequenceId, needed);
-            _blocks.Append(seq.SequenceId, 1); // reserve the generation slot now
+            if (preForked)
+            {
+                _blocks.Append(seq.SequenceId, tokensToCompute + 1); // remaining prompt + gen slot
+                seq.NumComputedTokens = sharedLen;                   // shared prefix KV valid; prefill computes the tail
+            }
+            else if (sharedLen > 0 && hit is { } h)
+            {
+                _blocks.ForkPrefix(h.CacheSequenceId, seq.SequenceId, sharedLen); // share the cached prefix KV
+                _blocks.Append(seq.SequenceId, tokensToCompute + 1);              // remaining prompt + gen slot
+                seq.NumComputedTokens = sharedLen; // cached prefix KV valid; prefill computes [sharedLen, needed)
+            }
+            else
+            {
+                _blocks.Allocate(seq.SequenceId, needed);
+                _blocks.Append(seq.SequenceId, 1); // reserve the generation slot now
+                seq.NumComputedTokens = 0;         // prefill (also re-prefill for recomputed sequences)
+            }
             seq.State = SequenceState.Running;
-            seq.NumComputedTokens = 0; // prefill (also re-prefill for recomputed sequences)
             _running.Add(seq);
             scheduled.Add(seq);
-            batchTokens += needed;
+            prefillThisStep.Add(seq);
+            batchTokens += tokensToCompute;
         }
     }
 
@@ -302,16 +348,19 @@ public sealed class ContinuousBatchingEngine<T> : IInferenceEngine
 
     // ---- Advancing a sequence -------------------------------------------------------------
 
-    private void AdvanceSequence(Sequence seq, Vector<T> logits)
+    private void AdvanceSequence(Sequence seq, Vector<T> logits, bool wasPrefill)
     {
         int lengthBefore = seq.Length;
-        bool wasPrefill = seq.NumComputedTokens == 0;
         seq.NumComputedTokens = lengthBefore; // all current tokens now have cached KV
 
         // The prompt owner just finished prefill: fork its now-computed prompt KV to any deferred siblings,
         // which sample their first token from these same final-position logits (prompt computed once).
         if (wasPrefill && seq.SequenceIndex == 0)
             SpawnDeferredSiblings(seq, logits);
+
+        // Register the freshly-computed prompt prefix for cross-request reuse (block-aligned; no-op if cached).
+        if (wasPrefill && _prefixCache is not null && seq.GeneratedLength == 0)
+            _prefixCache.Register(seq.TokenIds, seq.SequenceId);
 
         int tokenId = LogitsSampler.Sample(logits, seq.Request.SamplingParameters, seq.TokenIds, _rngBySequence[seq.SequenceId]);
         // The KV slot for this token was already reserved at schedule time; appending the token now keeps the
@@ -368,9 +417,22 @@ public sealed class ContinuousBatchingEngine<T> : IInferenceEngine
             }
             else
             {
+                // Non-block-aligned prompt: share the aligned full-block prefix (no partial-block copy-on-write
+                // hazard) and let the sibling prefill only the short remaining tail. Falls back to fully
+                // independent prefill when there is no whole shared block.
+                int alignedPrefix = promptLen / _options.BlockSize * _options.BlockSize;
+                int tailBlocks = _blocks.BlocksForTokens(promptLen + 1) - _blocks.BlocksForTokens(alignedPrefix);
+                if (alignedPrefix >= _options.BlockSize && _blocks.NumFreeBlocks >= tailBlocks)
+                {
+                    _blocks.ForkPrefix(owner.SequenceId, sibling.SequenceId, alignedPrefix);
+                    // SchedulePrefill sees it is already allocated (pre-forked) and prefills only the tail.
+                }
+                else
+                {
+                    sibling.NumComputedTokens = 0; // fully independent prefill
+                }
                 sibling.State = SequenceState.Waiting;
-                sibling.NumComputedTokens = 0;
-                _waiting.AddLast(sibling); // independent prefill
+                _waiting.AddLast(sibling);
             }
         }
     }
@@ -432,6 +494,7 @@ public sealed class ContinuousBatchingEngine<T> : IInferenceEngine
     {
         if (_disposed) return;
         _disposed = true;
+        _prefixCache?.Clear();
         if (_runner is IDisposable d) d.Dispose();
     }
 }

--- a/src/AiDotNet.Serving/Engine/ContinuousBatchingEngine.cs
+++ b/src/AiDotNet.Serving/Engine/ContinuousBatchingEngine.cs
@@ -40,6 +40,9 @@ public sealed class ContinuousBatchingEngine<T> : IInferenceEngine
     private readonly Dictionary<string, Random> _rngBySequence = new();
     private readonly Queue<GenerationRequest> _pendingAdds = new();
     private readonly HashSet<string> _pendingAborts = new();
+    // For N>1 parallel sampling: siblings that wait to be forked from the prompt owner once it has prefilled,
+    // so the prompt's KV is computed and stored once and shared (prefix sharing / prefill-once).
+    private readonly Dictionary<string, List<Sequence>> _deferredSiblings = new();
 
     private long _totalPreemptions;
     private long _totalFinishedRequests;
@@ -176,17 +179,22 @@ public sealed class ContinuousBatchingEngine<T> : IInferenceEngine
         {
             var seq = new Sequence(request, i);
             seqs.Add(seq);
-            _waiting.AddLast(seq);
             _rngBySequence[seq.SequenceId] = request.SamplingParameters.Seed is { } s
                 ? RandomHelper.CreateSeededRandom(s + i) // decorrelate parallel samples
                 : RandomHelper.CreateSecureRandom();
         }
         _byRequest[request.RequestId] = seqs;
+
+        // Only the prompt owner (index 0) is queued now. Its siblings are deferred and forked from its prompt
+        // KV once it has prefilled, so the shared prompt is processed and stored exactly once.
+        _waiting.AddLast(seqs[0]);
+        if (n > 1) _deferredSiblings[request.RequestId] = seqs.GetRange(1, n - 1);
     }
 
     private bool ApplyAbort(string requestId)
     {
         if (!_byRequest.TryGetValue(requestId, out var seqs)) return false;
+        _deferredSiblings.Remove(requestId); // drop any not-yet-forked siblings
         foreach (var seq in seqs)
         {
             if (seq.State.IsFinished()) continue;
@@ -297,7 +305,12 @@ public sealed class ContinuousBatchingEngine<T> : IInferenceEngine
     private void AdvanceSequence(Sequence seq, Vector<T> logits)
     {
         int lengthBefore = seq.Length;
+        bool wasPrefill = seq.NumComputedTokens == 0;
         seq.NumComputedTokens = lengthBefore; // all current tokens now have cached KV
+
+        // The prompt owner just finished prefill: fork its now-computed prompt KV to any deferred siblings.
+        if (wasPrefill && seq.SequenceIndex == 0)
+            SpawnDeferredSiblings(seq);
 
         int tokenId = LogitsSampler.Sample(logits, seq.Request.SamplingParameters, seq.TokenIds, _rngBySequence[seq.SequenceId]);
         // The KV slot for this token was already reserved at schedule time; appending the token now keeps the
@@ -311,6 +324,35 @@ public sealed class ContinuousBatchingEngine<T> : IInferenceEngine
             _running.Remove(seq);
             _rngBySequence.Remove(seq.SequenceId);
             seq.Finish(terminalState, reason);
+        }
+    }
+
+    private void SpawnDeferredSiblings(Sequence owner)
+    {
+        if (!_deferredSiblings.TryGetValue(owner.Request.RequestId, out var siblings)) return;
+        _deferredSiblings.Remove(owner.Request.RequestId);
+
+        int promptLen = owner.PromptLength;
+        // Clean sharing needs the prompt to fill whole blocks, so the shared blocks contain exactly the prompt
+        // (the owner's just-generated token lives in a fresh block beyond them). Otherwise fall back to giving
+        // each sibling its own prompt allocation (independent prefill via the waiting queue).
+        bool blockAligned = promptLen % _options.BlockSize == 0;
+
+        foreach (var sibling in siblings)
+        {
+            if (blockAligned)
+            {
+                _blocks.ForkPrefix(owner.SequenceId, sibling.SequenceId, promptLen); // shares KV, no new blocks
+                sibling.NumComputedTokens = promptLen; // prompt KV already computed (shared) — skip re-prefill
+                sibling.State = SequenceState.Running;
+                _running.Add(sibling);
+            }
+            else
+            {
+                sibling.State = SequenceState.Waiting;
+                sibling.NumComputedTokens = 0;
+                _waiting.AddLast(sibling); // independent prefill
+            }
         }
     }
 

--- a/src/AiDotNet.Serving/Engine/ContinuousBatchingEngine.cs
+++ b/src/AiDotNet.Serving/Engine/ContinuousBatchingEngine.cs
@@ -308,9 +308,10 @@ public sealed class ContinuousBatchingEngine<T> : IInferenceEngine
         bool wasPrefill = seq.NumComputedTokens == 0;
         seq.NumComputedTokens = lengthBefore; // all current tokens now have cached KV
 
-        // The prompt owner just finished prefill: fork its now-computed prompt KV to any deferred siblings.
+        // The prompt owner just finished prefill: fork its now-computed prompt KV to any deferred siblings,
+        // which sample their first token from these same final-position logits (prompt computed once).
         if (wasPrefill && seq.SequenceIndex == 0)
-            SpawnDeferredSiblings(seq);
+            SpawnDeferredSiblings(seq, logits);
 
         int tokenId = LogitsSampler.Sample(logits, seq.Request.SamplingParameters, seq.TokenIds, _rngBySequence[seq.SequenceId]);
         // The KV slot for this token was already reserved at schedule time; appending the token now keeps the
@@ -327,23 +328,41 @@ public sealed class ContinuousBatchingEngine<T> : IInferenceEngine
         }
     }
 
-    private void SpawnDeferredSiblings(Sequence owner)
+    private void SpawnDeferredSiblings(Sequence owner, Vector<T> promptFinalLogits)
     {
         if (!_deferredSiblings.TryGetValue(owner.Request.RequestId, out var siblings)) return;
         _deferredSiblings.Remove(owner.Request.RequestId);
 
         int promptLen = owner.PromptLength;
-        // Clean sharing needs the prompt to fill whole blocks, so the shared blocks contain exactly the prompt
-        // (the owner's just-generated token lives in a fresh block beyond them). Otherwise fall back to giving
+        // Clean sharing needs the prompt to fill whole blocks, so the shared blocks hold exactly the prompt and
+        // the first generated token lands in a fresh block (no copy-on-write). Otherwise fall back to giving
         // each sibling its own prompt allocation (independent prefill via the waiting queue).
         bool blockAligned = promptLen % _options.BlockSize == 0;
 
         foreach (var sibling in siblings)
         {
-            if (blockAligned)
+            // The shared prompt costs no new blocks; the sibling's first generated token needs one slot.
+            if (blockAligned && _blocks.NumFreeBlocks >= 1)
             {
-                _blocks.ForkPrefix(owner.SequenceId, sibling.SequenceId, promptLen); // shares KV, no new blocks
-                sibling.NumComputedTokens = promptLen; // prompt KV already computed (shared) — skip re-prefill
+                _blocks.ForkPrefix(owner.SequenceId, sibling.SequenceId, promptLen); // shares prompt KV
+
+                // Sample the sibling's first token from the SAME prompt-final logits (prompt computed once);
+                // greedy ⇒ same as the owner, stochastic ⇒ independent via the sibling's own RNG.
+                int firstToken = LogitsSampler.Sample(
+                    promptFinalLogits, sibling.Request.SamplingParameters, sibling.TokenIds, _rngBySequence[sibling.SequenceId]);
+                sibling.AppendToken(firstToken);
+
+                var (finished, terminalState, reason) = EvaluateStop(sibling, firstToken);
+                if (finished)
+                {
+                    _blocks.Free(sibling.SequenceId);
+                    _rngBySequence.Remove(sibling.SequenceId);
+                    sibling.Finish(terminalState, reason);
+                    continue;
+                }
+
+                _blocks.Append(sibling.SequenceId, 1);  // reserve the first generated token's KV slot
+                sibling.NumComputedTokens = promptLen;  // prompt KV cached (shared); the new token computes next step
                 sibling.State = SequenceState.Running;
                 _running.Add(sibling);
             }

--- a/src/AiDotNet.Serving/Engine/EngineOptions.cs
+++ b/src/AiDotNet.Serving/Engine/EngineOptions.cs
@@ -29,6 +29,13 @@ public sealed class EngineOptions
     /// <summary>Model EOS token id; generating it ends a sequence (unless <see cref="SamplingParameters.IgnoreEos"/>). Null = none.</summary>
     public int? EosTokenId { get; init; }
 
+    /// <summary>
+    /// KV-cache storage precision. Int8 lets a paged runner store roughly twice as much KV in the same memory,
+    /// so more sequences / longer contexts fit at once. Informational for the recompute path (no physical KV).
+    /// </summary>
+    public AiDotNet.Configuration.KVCacheQuantizationMode KvCacheQuantization { get; init; }
+        = AiDotNet.Configuration.KVCacheQuantizationMode.None;
+
     /// <summary>Validates the options, throwing <see cref="ArgumentException"/> on an invalid value.</summary>
     public void Validate()
     {

--- a/src/AiDotNet.Serving/Engine/EngineOptions.cs
+++ b/src/AiDotNet.Serving/Engine/EngineOptions.cs
@@ -1,0 +1,40 @@
+using System;
+
+namespace AiDotNet.Serving.Engine;
+
+/// <summary>
+/// Tuning knobs for the <see cref="ContinuousBatchingEngine{T}"/>. Every value has an industry-standard default,
+/// so the engine runs well with <c>new EngineOptions()</c>; the facade builder derives these automatically from
+/// the model and <see cref="AiDotNet.Configuration.InferenceOptimizationConfig"/> so a beginner never sets them.
+/// </summary>
+/// <remarks>
+/// <para><b>For Beginners:</b> these control how many requests run at once and how much KV-cache memory the
+/// engine may use. You almost never need to touch them — the library picks good values for your model and
+/// hardware. They exist so an expert can cap memory or concurrency for a specific deployment.</para>
+/// </remarks>
+public sealed class EngineOptions
+{
+    /// <summary>Maximum number of sequences running (being decoded) concurrently. Default 256.</summary>
+    public int MaxNumSequences { get; init; } = 256;
+
+    /// <summary>Maximum tokens processed across a single batch (prefill + decode). Bounds per-step compute. Default 8192.</summary>
+    public int MaxBatchedTokens { get; init; } = 8192;
+
+    /// <summary>Token slots per KV-cache block. Default 16 (vLLM's default).</summary>
+    public int BlockSize { get; init; } = 16;
+
+    /// <summary>Number of KV-cache blocks in the pool (sizes total KV memory). Default 4096.</summary>
+    public int NumKvBlocks { get; init; } = 4096;
+
+    /// <summary>Model EOS token id; generating it ends a sequence (unless <see cref="SamplingParameters.IgnoreEos"/>). Null = none.</summary>
+    public int? EosTokenId { get; init; }
+
+    /// <summary>Validates the options, throwing <see cref="ArgumentException"/> on an invalid value.</summary>
+    public void Validate()
+    {
+        if (MaxNumSequences < 1) throw new ArgumentException("MaxNumSequences must be >= 1.", nameof(MaxNumSequences));
+        if (MaxBatchedTokens < 1) throw new ArgumentException("MaxBatchedTokens must be >= 1.", nameof(MaxBatchedTokens));
+        if (BlockSize < 1) throw new ArgumentException("BlockSize must be >= 1.", nameof(BlockSize));
+        if (NumKvBlocks < 1) throw new ArgumentException("NumKvBlocks must be >= 1.", nameof(NumKvBlocks));
+    }
+}

--- a/src/AiDotNet.Serving/Engine/EngineOptions.cs
+++ b/src/AiDotNet.Serving/Engine/EngineOptions.cs
@@ -36,6 +36,16 @@ public sealed class EngineOptions
     public AiDotNet.Configuration.KVCacheQuantizationMode KvCacheQuantization { get; init; }
         = AiDotNet.Configuration.KVCacheQuantizationMode.None;
 
+    /// <summary>
+    /// Enables automatic cross-request prefix caching: a new request that begins with the same tokens as a
+    /// previous one reuses that prompt's cached KV instead of recomputing it (block-aligned prefixes only).
+    /// Off by default. On the paged fast path this is a real compute saving.
+    /// </summary>
+    public bool EnablePrefixCache { get; init; }
+
+    /// <summary>Maximum number of cached prefixes (LRU eviction beyond it). Default 128.</summary>
+    public int PrefixCacheCapacity { get; init; } = 128;
+
     /// <summary>Validates the options, throwing <see cref="ArgumentException"/> on an invalid value.</summary>
     public void Validate()
     {

--- a/src/AiDotNet.Serving/Engine/EngineStatistics.cs
+++ b/src/AiDotNet.Serving/Engine/EngineStatistics.cs
@@ -1,0 +1,33 @@
+namespace AiDotNet.Serving.Engine;
+
+/// <summary>
+/// A point-in-time snapshot of engine load and KV-cache utilization, used for admission control, autoscaling,
+/// and the <c>/metrics</c> endpoint. These are the same signals vLLM/TGI expose (running vs waiting counts,
+/// KV-cache usage, preemptions) so operators can reason about saturation and tune batch/memory limits.
+/// </summary>
+public sealed class EngineStatistics
+{
+    /// <summary>Number of sequences currently in the running batch.</summary>
+    public int RunningSequences { get; init; }
+
+    /// <summary>Number of sequences admitted but waiting for a batch slot / KV blocks.</summary>
+    public int WaitingSequences { get; init; }
+
+    /// <summary>Number of sequences preempted (swapped or recompute) and awaiting reschedule.</summary>
+    public int SwappedSequences { get; init; }
+
+    /// <summary>Fraction (0..1) of KV-cache blocks currently allocated.</summary>
+    public double KvCacheUsage { get; init; }
+
+    /// <summary>Total KV-cache blocks in the pool.</summary>
+    public int TotalKvBlocks { get; init; }
+
+    /// <summary>KV-cache blocks currently free.</summary>
+    public int FreeKvBlocks { get; init; }
+
+    /// <summary>Cumulative number of preemptions since start (a rising count signals under-provisioned KV memory).</summary>
+    public long TotalPreemptions { get; init; }
+
+    /// <summary>Cumulative number of requests finished since start.</summary>
+    public long TotalFinishedRequests { get; init; }
+}

--- a/src/AiDotNet.Serving/Engine/GenerationRequest.cs
+++ b/src/AiDotNet.Serving/Engine/GenerationRequest.cs
@@ -1,0 +1,56 @@
+namespace AiDotNet.Serving.Engine;
+
+/// <summary>
+/// A single generation request submitted to the inference engine: a tokenized prompt plus the sampling
+/// parameters that govern its decoding. The engine owns scheduling, KV-cache allocation, and batching for
+/// the request; the caller only supplies the prompt tokens (tokenization happens upstream) and consumes the
+/// streamed <see cref="RequestOutput"/>s the engine produces.
+/// </summary>
+/// <remarks>
+/// <para><b>For Beginners:</b> think of this as one "please generate text for me" job. It carries the prompt
+/// already converted to token ids, how to sample (<see cref="SamplingParameters"/>), and a unique
+/// <see cref="RequestId"/> so the engine can interleave your job with many others (continuous batching) and
+/// still route each generated token back to the right caller.</para>
+/// </remarks>
+public sealed class GenerationRequest
+{
+    /// <summary>Creates a generation request.</summary>
+    /// <param name="requestId">A unique id used to correlate outputs back to this request.</param>
+    /// <param name="promptTokenIds">The prompt already tokenized to model vocabulary ids.</param>
+    /// <param name="samplingParameters">How to decode. Validated on construction.</param>
+    /// <param name="arrivalTicks">Monotonic arrival timestamp (e.g. Stopwatch ticks) used by the scheduler
+    /// for fairness/priority; pass 0 if the scheduler assigns it.</param>
+    public GenerationRequest(
+        string requestId,
+        IReadOnlyList<int> promptTokenIds,
+        SamplingParameters samplingParameters,
+        long arrivalTicks = 0)
+    {
+        if (string.IsNullOrWhiteSpace(requestId))
+            throw new ArgumentException("RequestId must be non-empty.", nameof(requestId));
+        if (promptTokenIds is null || promptTokenIds.Count == 0)
+            throw new ArgumentException("A request must have at least one prompt token.", nameof(promptTokenIds));
+
+        (samplingParameters ?? throw new ArgumentNullException(nameof(samplingParameters))).Validate();
+
+        RequestId = requestId;
+        PromptTokenIds = promptTokenIds;
+        SamplingParameters = samplingParameters;
+        ArrivalTicks = arrivalTicks;
+    }
+
+    /// <summary>Unique id correlating this request to its <see cref="RequestOutput"/>s.</summary>
+    public string RequestId { get; }
+
+    /// <summary>The tokenized prompt (model vocabulary ids).</summary>
+    public IReadOnlyList<int> PromptTokenIds { get; }
+
+    /// <summary>Number of prompt tokens (the prefill length).</summary>
+    public int PromptLength => PromptTokenIds.Count;
+
+    /// <summary>How to decode this request.</summary>
+    public SamplingParameters SamplingParameters { get; }
+
+    /// <summary>Monotonic arrival timestamp used by the scheduler for ordering/fairness.</summary>
+    public long ArrivalTicks { get; }
+}

--- a/src/AiDotNet.Serving/Engine/Http/IChatTemplate.cs
+++ b/src/AiDotNet.Serving/Engine/Http/IChatTemplate.cs
@@ -1,0 +1,39 @@
+using System.Collections.Generic;
+using System.Text;
+
+namespace AiDotNet.Serving.Engine.Http;
+
+/// <summary>
+/// Renders a chat conversation (a list of role-tagged messages) into the single prompt string the model
+/// actually generates from. Different model families use different chat formats; this is the seam that lets a
+/// server speak the model's format while exposing the standard OpenAI chat API.
+/// </summary>
+public interface IChatTemplate
+{
+    /// <summary>Renders the conversation into a prompt, ending where the assistant's reply should begin.</summary>
+    string Render(IReadOnlyList<ChatMessage> messages);
+}
+
+/// <summary>
+/// A generic, model-agnostic chat template: each message is emitted as a role-tagged block and the prompt ends
+/// with an open assistant turn. Works out of the box; swap in a model-specific template via
+/// <see cref="ServeOptions"/> when a model was trained with a particular format.
+/// </summary>
+public sealed class DefaultChatTemplate : IChatTemplate
+{
+    /// <inheritdoc/>
+    public string Render(IReadOnlyList<ChatMessage> messages)
+    {
+        var sb = new StringBuilder();
+        if (messages is not null)
+        {
+            foreach (var message in messages)
+            {
+                string role = string.IsNullOrWhiteSpace(message.Role) ? "user" : message.Role;
+                sb.Append("<|").Append(role).Append("|>\n").Append(message.Content ?? string.Empty).Append('\n');
+            }
+        }
+        sb.Append("<|assistant|>\n");
+        return sb.ToString();
+    }
+}

--- a/src/AiDotNet.Serving/Engine/Http/InferenceServer.cs
+++ b/src/AiDotNet.Serving/Engine/Http/InferenceServer.cs
@@ -1,0 +1,229 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using AiDotNet.Agentic.Models.Local;
+using AiDotNet.Serving.Engine;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
+
+namespace AiDotNet.Serving.Engine.Http;
+
+/// <summary>
+/// A running, OpenAI-compatible HTTP server for a single model: continuous batching + paged KV under the hood,
+/// exposed at <c>/v1/completions</c> (streaming and non-streaming), <c>/v1/models</c>, and <c>/health</c>. This
+/// is what <c>model.Serve()</c> returns — a one-line, self-hosted inference endpoint that existing OpenAI
+/// clients can call unchanged.
+/// </summary>
+/// <remarks>
+/// <para><b>For Beginners:</b> this turns your model into a web service. Start it and point any OpenAI-style
+/// client at the URL in <see cref="Urls"/>; requests are batched together and answered efficiently. Dispose it
+/// (or the <c>using</c> block ends) to stop the server and free memory.</para>
+/// </remarks>
+/// <typeparam name="T">The model's numeric type.</typeparam>
+public sealed class InferenceServer<T> : IAsyncDisposable, IDisposable
+{
+    private readonly WebApplication _app;
+    private readonly AsyncEngineHost<T> _host;
+    private readonly IGenerationTokenizer _tokenizer;
+    private readonly string _modelName;
+    private readonly SamplingParameters _defaultSampling;
+    private bool _disposed;
+
+    internal InferenceServer(
+        AsyncEngineHost<T> host,
+        IGenerationTokenizer tokenizer,
+        string modelName,
+        SamplingParameters defaultSampling,
+        string[] urls)
+    {
+        _host = host;
+        _tokenizer = tokenizer;
+        _modelName = modelName;
+        _defaultSampling = defaultSampling;
+
+        var builder = WebApplication.CreateBuilder();
+        builder.WebHost.UseUrls(urls);
+        builder.Logging.ClearProviders(); // quiet by default; hosting apps can add their own
+        _app = builder.Build();
+        MapEndpoints(_app);
+        _app.Start(); // non-blocking; Kestrel resolves any dynamic (:0) ports here
+    }
+
+    /// <summary>The URLs the server is listening on (dynamic ports are resolved after start).</summary>
+    public IReadOnlyList<string> Urls => _app.Urls.ToArray();
+
+    /// <summary>A snapshot of engine load and KV-cache utilization.</summary>
+    public EngineStatistics GetStatistics() => _host.GetStatistics();
+
+    private void MapEndpoints(WebApplication app)
+    {
+        app.MapGet("/health", () => Results.Json(new { status = "ok" }));
+
+        app.MapGet("/v1/models", () => Results.Json(new
+        {
+            @object = "list",
+            data = new[] { new { id = _modelName, @object = "model", owned_by = "aidotnet" } },
+        }));
+
+        app.MapPost("/v1/completions", HandleCompletionAsync);
+    }
+
+    private async Task HandleCompletionAsync(HttpContext context)
+    {
+        OpenAiCompletionRequest? request;
+        try
+        {
+            using var reader = new System.IO.StreamReader(context.Request.Body);
+            string body = await reader.ReadToEndAsync().ConfigureAwait(false);
+            request = JsonConvert.DeserializeObject<OpenAiCompletionRequest>(body);
+        }
+        catch (JsonException)
+        {
+            await WriteErrorAsync(context, StatusCodes.Status400BadRequest, "Invalid JSON body.").ConfigureAwait(false);
+            return;
+        }
+
+        if (request is null || string.IsNullOrEmpty(request.Prompt))
+        {
+            await WriteErrorAsync(context, StatusCodes.Status400BadRequest, "A non-empty 'prompt' is required.").ConfigureAwait(false);
+            return;
+        }
+
+        SamplingParameters sampling;
+        IReadOnlyList<int> promptIds;
+        try
+        {
+            sampling = ToSamplingParameters(request);
+            sampling.Validate();
+            promptIds = _tokenizer.Encode(request.Prompt);
+            if (promptIds.Count == 0)
+                throw new ArgumentException("Prompt tokenized to zero tokens.");
+        }
+        catch (ArgumentException ex)
+        {
+            await WriteErrorAsync(context, StatusCodes.Status400BadRequest, ex.Message).ConfigureAwait(false);
+            return;
+        }
+
+        string id = "cmpl-" + Guid.NewGuid().ToString("N");
+        long created = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
+
+        if (request.Stream)
+            await StreamCompletionAsync(context, id, created, promptIds, sampling).ConfigureAwait(false);
+        else
+            await WriteCompletionAsync(context, id, created, promptIds, sampling).ConfigureAwait(false);
+    }
+
+    private async Task WriteCompletionAsync(
+        HttpContext context, string id, long created, IReadOnlyList<int> promptIds, SamplingParameters sampling)
+    {
+        var generated = await _host.GenerateAsync(promptIds, sampling, context.RequestAborted).ConfigureAwait(false);
+        string text = _tokenizer.Decode(generated);
+
+        var response = new OpenAiCompletionResponse
+        {
+            Id = id,
+            Created = created,
+            Model = _modelName,
+            Choices = new[]
+            {
+                new OpenAiCompletionChoice { Text = text, Index = 0, FinishReason = "stop" },
+            },
+            Usage = new OpenAiUsage
+            {
+                PromptTokens = promptIds.Count,
+                CompletionTokens = generated.Count,
+                TotalTokens = promptIds.Count + generated.Count,
+            },
+        };
+
+        context.Response.ContentType = "application/json";
+        await context.Response.WriteAsync(JsonConvert.SerializeObject(response), context.RequestAborted).ConfigureAwait(false);
+    }
+
+    private async Task StreamCompletionAsync(
+        HttpContext context, string id, long created, IReadOnlyList<int> promptIds, SamplingParameters sampling)
+    {
+        context.Response.ContentType = "text/event-stream";
+        context.Response.Headers["Cache-Control"] = "no-cache";
+
+        string previousText = string.Empty;
+        await foreach (var update in _host.StreamAsync(promptIds, sampling, context.RequestAborted).ConfigureAwait(false))
+        {
+            string fullText = _tokenizer.Decode(update.TokenIds);
+            string delta = fullText.StartsWith(previousText, StringComparison.Ordinal)
+                ? fullText.Substring(previousText.Length)
+                : fullText;
+            previousText = fullText;
+
+            var chunk = new OpenAiCompletionResponse
+            {
+                Id = id,
+                Created = created,
+                Model = _modelName,
+                Choices = new[]
+                {
+                    new OpenAiCompletionChoice
+                    {
+                        Text = delta,
+                        Index = 0,
+                        FinishReason = update.IsFinished ? (update.FinishReason ?? "stop") : null,
+                    },
+                },
+            };
+
+            await context.Response.WriteAsync($"data: {JsonConvert.SerializeObject(chunk)}\n\n", context.RequestAborted).ConfigureAwait(false);
+            await context.Response.Body.FlushAsync(context.RequestAborted).ConfigureAwait(false);
+        }
+
+        await context.Response.WriteAsync("data: [DONE]\n\n", context.RequestAborted).ConfigureAwait(false);
+        await context.Response.Body.FlushAsync(context.RequestAborted).ConfigureAwait(false);
+    }
+
+    private SamplingParameters ToSamplingParameters(OpenAiCompletionRequest r) => new()
+    {
+        Temperature = r.Temperature,
+        // OpenAI clients may send top_p = 0 meaning "unused"; our engine treats (0,1] as the valid nucleus, so
+        // map a non-positive value to the disabled default of 1.0.
+        TopP = r.TopP <= 0 ? 1.0 : r.TopP,
+        TopK = r.TopK,
+        PresencePenalty = r.PresencePenalty,
+        FrequencyPenalty = r.FrequencyPenalty,
+        Seed = r.Seed,
+        MaxTokens = r.MaxTokens < 1 ? _defaultSampling.MaxTokens : r.MaxTokens,
+    };
+
+    private static Task WriteErrorAsync(HttpContext context, int status, string message)
+    {
+        context.Response.StatusCode = status;
+        context.Response.ContentType = "application/json";
+        var payload = new { error = new { message, type = "invalid_request_error" } };
+        return context.Response.WriteAsync(JsonConvert.SerializeObject(payload));
+    }
+
+    /// <inheritdoc/>
+    public async ValueTask DisposeAsync()
+    {
+        if (_disposed) return;
+        _disposed = true;
+        await _app.StopAsync().ConfigureAwait(false);
+        await _app.DisposeAsync().ConfigureAwait(false);
+        _host.Dispose();
+    }
+
+    /// <inheritdoc/>
+    public void Dispose()
+    {
+        if (_disposed) return;
+        _disposed = true;
+        _app.StopAsync().GetAwaiter().GetResult();
+        (_app as IDisposable)?.Dispose();
+        _host.Dispose();
+    }
+}

--- a/src/AiDotNet.Serving/Engine/Http/InferenceServer.cs
+++ b/src/AiDotNet.Serving/Engine/Http/InferenceServer.cs
@@ -33,6 +33,7 @@ public sealed class InferenceServer<T> : IAsyncDisposable, IDisposable
     private readonly IGenerationTokenizer _tokenizer;
     private readonly string _modelName;
     private readonly SamplingParameters _defaultSampling;
+    private readonly IChatTemplate _chatTemplate;
     private bool _disposed;
 
     internal InferenceServer(
@@ -40,12 +41,14 @@ public sealed class InferenceServer<T> : IAsyncDisposable, IDisposable
         IGenerationTokenizer tokenizer,
         string modelName,
         SamplingParameters defaultSampling,
-        string[] urls)
+        string[] urls,
+        IChatTemplate? chatTemplate = null)
     {
         _host = host;
         _tokenizer = tokenizer;
         _modelName = modelName;
         _defaultSampling = defaultSampling;
+        _chatTemplate = chatTemplate ?? new DefaultChatTemplate();
 
         var builder = WebApplication.CreateBuilder();
         builder.WebHost.UseUrls(urls);
@@ -72,6 +75,127 @@ public sealed class InferenceServer<T> : IAsyncDisposable, IDisposable
         }));
 
         app.MapPost("/v1/completions", HandleCompletionAsync);
+        app.MapPost("/v1/chat/completions", HandleChatCompletionAsync);
+    }
+
+    private async Task HandleChatCompletionAsync(HttpContext context)
+    {
+        OpenAiChatRequest? request;
+        try
+        {
+            using var reader = new System.IO.StreamReader(context.Request.Body);
+            request = JsonConvert.DeserializeObject<OpenAiChatRequest>(await reader.ReadToEndAsync().ConfigureAwait(false));
+        }
+        catch (JsonException)
+        {
+            await WriteErrorAsync(context, StatusCodes.Status400BadRequest, "Invalid JSON body.").ConfigureAwait(false);
+            return;
+        }
+
+        if (request is null || request.Messages is null || request.Messages.Count == 0)
+        {
+            await WriteErrorAsync(context, StatusCodes.Status400BadRequest, "A non-empty 'messages' array is required.").ConfigureAwait(false);
+            return;
+        }
+
+        string prompt = _chatTemplate.Render(request.Messages);
+
+        SamplingParameters sampling;
+        IReadOnlyList<int> promptIds;
+        try
+        {
+            sampling = ToSamplingParameters(request.Temperature, request.TopP, request.TopK,
+                request.PresencePenalty, request.FrequencyPenalty, request.Seed, request.MaxTokens);
+            sampling.Validate();
+            promptIds = _tokenizer.Encode(prompt);
+            if (promptIds.Count == 0) throw new ArgumentException("Rendered chat prompt tokenized to zero tokens.");
+        }
+        catch (ArgumentException ex)
+        {
+            await WriteErrorAsync(context, StatusCodes.Status400BadRequest, ex.Message).ConfigureAwait(false);
+            return;
+        }
+
+        string id = "chatcmpl-" + Guid.NewGuid().ToString("N");
+        long created = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
+
+        if (request.Stream)
+            await StreamChatAsync(context, id, created, promptIds, sampling).ConfigureAwait(false);
+        else
+            await WriteChatAsync(context, id, created, promptIds, sampling).ConfigureAwait(false);
+    }
+
+    private async Task WriteChatAsync(
+        HttpContext context, string id, long created, IReadOnlyList<int> promptIds, SamplingParameters sampling)
+    {
+        var generated = await _host.GenerateAsync(promptIds, sampling, context.RequestAborted).ConfigureAwait(false);
+        string text = _tokenizer.Decode(generated);
+
+        var response = new OpenAiChatResponse
+        {
+            Id = id,
+            Created = created,
+            Model = _modelName,
+            Choices = new[]
+            {
+                new OpenAiChatChoice
+                {
+                    Index = 0,
+                    Message = new ChatChoiceMessage { Role = "assistant", Content = text },
+                    FinishReason = "stop",
+                },
+            },
+            Usage = new OpenAiUsage
+            {
+                PromptTokens = promptIds.Count,
+                CompletionTokens = generated.Count,
+                TotalTokens = promptIds.Count + generated.Count,
+            },
+        };
+
+        context.Response.ContentType = "application/json";
+        await context.Response.WriteAsync(JsonConvert.SerializeObject(response), context.RequestAborted).ConfigureAwait(false);
+    }
+
+    private async Task StreamChatAsync(
+        HttpContext context, string id, long created, IReadOnlyList<int> promptIds, SamplingParameters sampling)
+    {
+        context.Response.ContentType = "text/event-stream";
+        context.Response.Headers["Cache-Control"] = "no-cache";
+
+        // First chunk announces the assistant role.
+        await WriteChatChunkAsync(context, id, created, new ChatChoiceDelta { Role = "assistant" }, null).ConfigureAwait(false);
+
+        string previousText = string.Empty;
+        await foreach (var update in _host.StreamAsync(promptIds, sampling, context.RequestAborted).ConfigureAwait(false))
+        {
+            string fullText = _tokenizer.Decode(update.TokenIds);
+            string delta = fullText.StartsWith(previousText, StringComparison.Ordinal)
+                ? fullText.Substring(previousText.Length)
+                : fullText;
+            previousText = fullText;
+
+            await WriteChatChunkAsync(context, id, created, new ChatChoiceDelta { Content = delta },
+                update.IsFinished ? (update.FinishReason ?? "stop") : null).ConfigureAwait(false);
+        }
+
+        await context.Response.WriteAsync("data: [DONE]\n\n", context.RequestAborted).ConfigureAwait(false);
+        await context.Response.Body.FlushAsync(context.RequestAborted).ConfigureAwait(false);
+    }
+
+    private async Task WriteChatChunkAsync(
+        HttpContext context, string id, long created, ChatChoiceDelta delta, string? finishReason)
+    {
+        var chunk = new OpenAiChatResponse
+        {
+            Id = id,
+            Object = "chat.completion.chunk",
+            Created = created,
+            Model = _modelName,
+            Choices = new[] { new OpenAiChatChoice { Index = 0, Delta = delta, FinishReason = finishReason } },
+        };
+        await context.Response.WriteAsync($"data: {JsonConvert.SerializeObject(chunk)}\n\n", context.RequestAborted).ConfigureAwait(false);
+        await context.Response.Body.FlushAsync(context.RequestAborted).ConfigureAwait(false);
     }
 
     private async Task HandleCompletionAsync(HttpContext context)
@@ -186,17 +310,21 @@ public sealed class InferenceServer<T> : IAsyncDisposable, IDisposable
         await context.Response.Body.FlushAsync(context.RequestAborted).ConfigureAwait(false);
     }
 
-    private SamplingParameters ToSamplingParameters(OpenAiCompletionRequest r) => new()
+    private SamplingParameters ToSamplingParameters(OpenAiCompletionRequest r)
+        => ToSamplingParameters(r.Temperature, r.TopP, r.TopK, r.PresencePenalty, r.FrequencyPenalty, r.Seed, r.MaxTokens);
+
+    private SamplingParameters ToSamplingParameters(
+        double temperature, double topP, int topK, double presencePenalty, double frequencyPenalty, int? seed, int maxTokens) => new()
     {
-        Temperature = r.Temperature,
+        Temperature = temperature,
         // OpenAI clients may send top_p = 0 meaning "unused"; our engine treats (0,1] as the valid nucleus, so
         // map a non-positive value to the disabled default of 1.0.
-        TopP = r.TopP <= 0 ? 1.0 : r.TopP,
-        TopK = r.TopK,
-        PresencePenalty = r.PresencePenalty,
-        FrequencyPenalty = r.FrequencyPenalty,
-        Seed = r.Seed,
-        MaxTokens = r.MaxTokens < 1 ? _defaultSampling.MaxTokens : r.MaxTokens,
+        TopP = topP <= 0 ? 1.0 : topP,
+        TopK = topK,
+        PresencePenalty = presencePenalty,
+        FrequencyPenalty = frequencyPenalty,
+        Seed = seed,
+        MaxTokens = maxTokens < 1 ? _defaultSampling.MaxTokens : maxTokens,
     };
 
     private static Task WriteErrorAsync(HttpContext context, int status, string message)

--- a/src/AiDotNet.Serving/Engine/Http/OpenAiChatDtos.cs
+++ b/src/AiDotNet.Serving/Engine/Http/OpenAiChatDtos.cs
@@ -1,0 +1,106 @@
+using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace AiDotNet.Serving.Engine.Http;
+
+/// <summary>One message in a chat conversation (OpenAI Chat Completions format).</summary>
+public sealed class ChatMessage
+{
+    /// <summary>Role of the author: "system", "user", or "assistant".</summary>
+    [JsonProperty("role")] public string Role { get; set; } = "user";
+
+    /// <summary>The message text.</summary>
+    [JsonProperty("content")] public string Content { get; set; } = string.Empty;
+}
+
+/// <summary>OpenAI-compatible request body for <c>POST /v1/chat/completions</c>.</summary>
+public sealed class OpenAiChatRequest
+{
+    /// <summary>The model id.</summary>
+    [JsonProperty("model")] public string? Model { get; set; }
+
+    /// <summary>The conversation so far.</summary>
+    [JsonProperty("messages")] public IReadOnlyList<ChatMessage> Messages { get; set; } = new List<ChatMessage>();
+
+    /// <summary>Maximum tokens to generate.</summary>
+    [JsonProperty("max_tokens")] public int MaxTokens { get; set; } = 128;
+
+    /// <summary>Sampling temperature (0 = greedy).</summary>
+    [JsonProperty("temperature")] public double Temperature { get; set; } = 1.0;
+
+    /// <summary>Nucleus (top-p) sampling.</summary>
+    [JsonProperty("top_p")] public double TopP { get; set; } = 1.0;
+
+    /// <summary>Top-k sampling (0 disables).</summary>
+    [JsonProperty("top_k")] public int TopK { get; set; }
+
+    /// <summary>Presence penalty.</summary>
+    [JsonProperty("presence_penalty")] public double PresencePenalty { get; set; }
+
+    /// <summary>Frequency penalty.</summary>
+    [JsonProperty("frequency_penalty")] public double FrequencyPenalty { get; set; }
+
+    /// <summary>Optional RNG seed.</summary>
+    [JsonProperty("seed")] public int? Seed { get; set; }
+
+    /// <summary>Whether to stream the response as server-sent events.</summary>
+    [JsonProperty("stream")] public bool Stream { get; set; }
+}
+
+/// <summary>The assistant message in a chat completion choice.</summary>
+public sealed class ChatChoiceMessage
+{
+    /// <summary>Author role, always "assistant".</summary>
+    [JsonProperty("role")] public string Role { get; set; } = "assistant";
+
+    /// <summary>The generated content.</summary>
+    [JsonProperty("content")] public string Content { get; set; } = string.Empty;
+}
+
+/// <summary>A streamed delta fragment of the assistant message.</summary>
+public sealed class ChatChoiceDelta
+{
+    /// <summary>Author role (present on the first chunk).</summary>
+    [JsonProperty("role", NullValueHandling = NullValueHandling.Ignore)] public string? Role { get; set; }
+
+    /// <summary>Incremental content text.</summary>
+    [JsonProperty("content", NullValueHandling = NullValueHandling.Ignore)] public string? Content { get; set; }
+}
+
+/// <summary>One choice in a chat completion (non-streaming or streaming).</summary>
+public sealed class OpenAiChatChoice
+{
+    /// <summary>Choice index.</summary>
+    [JsonProperty("index")] public int Index { get; set; }
+
+    /// <summary>The full assistant message (non-streaming responses).</summary>
+    [JsonProperty("message", NullValueHandling = NullValueHandling.Ignore)] public ChatChoiceMessage? Message { get; set; }
+
+    /// <summary>The incremental delta (streaming chunks).</summary>
+    [JsonProperty("delta", NullValueHandling = NullValueHandling.Ignore)] public ChatChoiceDelta? Delta { get; set; }
+
+    /// <summary>Reason generation stopped, or null while streaming.</summary>
+    [JsonProperty("finish_reason")] public string? FinishReason { get; set; }
+}
+
+/// <summary>OpenAI-compatible chat completion response (also used for streamed chunks).</summary>
+public sealed class OpenAiChatResponse
+{
+    /// <summary>Unique response id.</summary>
+    [JsonProperty("id")] public string Id { get; set; } = string.Empty;
+
+    /// <summary>Object type: "chat.completion" or "chat.completion.chunk".</summary>
+    [JsonProperty("object")] public string Object { get; set; } = "chat.completion";
+
+    /// <summary>Unix creation timestamp.</summary>
+    [JsonProperty("created")] public long Created { get; set; }
+
+    /// <summary>The model id.</summary>
+    [JsonProperty("model")] public string Model { get; set; } = string.Empty;
+
+    /// <summary>The choices.</summary>
+    [JsonProperty("choices")] public IReadOnlyList<OpenAiChatChoice> Choices { get; set; } = new List<OpenAiChatChoice>();
+
+    /// <summary>Token usage (present on the final, non-streaming response).</summary>
+    [JsonProperty("usage", NullValueHandling = NullValueHandling.Ignore)] public OpenAiUsage? Usage { get; set; }
+}

--- a/src/AiDotNet.Serving/Engine/Http/OpenAiCompletionDtos.cs
+++ b/src/AiDotNet.Serving/Engine/Http/OpenAiCompletionDtos.cs
@@ -1,0 +1,90 @@
+using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace AiDotNet.Serving.Engine.Http;
+
+/// <summary>
+/// OpenAI-compatible request body for <c>POST /v1/completions</c>. Fields mirror the OpenAI Completions API so
+/// existing clients and SDKs work against an AiDotNet server unchanged.
+/// </summary>
+public sealed class OpenAiCompletionRequest
+{
+    /// <summary>The model id to generate with.</summary>
+    [JsonProperty("model")] public string? Model { get; set; }
+
+    /// <summary>The text prompt to continue.</summary>
+    [JsonProperty("prompt")] public string Prompt { get; set; } = string.Empty;
+
+    /// <summary>Maximum number of tokens to generate.</summary>
+    [JsonProperty("max_tokens")] public int MaxTokens { get; set; } = 16;
+
+    /// <summary>Sampling temperature (0 = greedy).</summary>
+    [JsonProperty("temperature")] public double Temperature { get; set; } = 1.0;
+
+    /// <summary>Nucleus (top-p) sampling.</summary>
+    [JsonProperty("top_p")] public double TopP { get; set; } = 1.0;
+
+    /// <summary>Top-k sampling (0 disables).</summary>
+    [JsonProperty("top_k")] public int TopK { get; set; }
+
+    /// <summary>Presence penalty.</summary>
+    [JsonProperty("presence_penalty")] public double PresencePenalty { get; set; }
+
+    /// <summary>Frequency penalty.</summary>
+    [JsonProperty("frequency_penalty")] public double FrequencyPenalty { get; set; }
+
+    /// <summary>Optional RNG seed for reproducible sampling.</summary>
+    [JsonProperty("seed")] public int? Seed { get; set; }
+
+    /// <summary>Whether to stream the response as server-sent events.</summary>
+    [JsonProperty("stream")] public bool Stream { get; set; }
+}
+
+/// <summary>One choice in a completion response.</summary>
+public sealed class OpenAiCompletionChoice
+{
+    /// <summary>The generated text (a delta in streaming chunks, the full text otherwise).</summary>
+    [JsonProperty("text")] public string Text { get; set; } = string.Empty;
+
+    /// <summary>Choice index.</summary>
+    [JsonProperty("index")] public int Index { get; set; }
+
+    /// <summary>Reason generation stopped ("stop", "length"), or null while streaming.</summary>
+    [JsonProperty("finish_reason")] public string? FinishReason { get; set; }
+}
+
+/// <summary>Token usage accounting.</summary>
+public sealed class OpenAiUsage
+{
+    /// <summary>Prompt token count.</summary>
+    [JsonProperty("prompt_tokens")] public int PromptTokens { get; set; }
+
+    /// <summary>Generated token count.</summary>
+    [JsonProperty("completion_tokens")] public int CompletionTokens { get; set; }
+
+    /// <summary>Sum of prompt and completion tokens.</summary>
+    [JsonProperty("total_tokens")] public int TotalTokens { get; set; }
+}
+
+/// <summary>OpenAI-compatible completion response (also used for each streamed chunk).</summary>
+public sealed class OpenAiCompletionResponse
+{
+    /// <summary>Unique response id.</summary>
+    [JsonProperty("id")] public string Id { get; set; } = string.Empty;
+
+    /// <summary>Object type: "text_completion".</summary>
+    [JsonProperty("object")] public string Object { get; set; } = "text_completion";
+
+    /// <summary>Unix creation timestamp.</summary>
+    [JsonProperty("created")] public long Created { get; set; }
+
+    /// <summary>The model id.</summary>
+    [JsonProperty("model")] public string Model { get; set; } = string.Empty;
+
+    /// <summary>The generated choices.</summary>
+    [JsonProperty("choices")] public IReadOnlyList<OpenAiCompletionChoice> Choices { get; set; }
+        = new List<OpenAiCompletionChoice>();
+
+    /// <summary>Token usage (present on the final, non-streaming response).</summary>
+    [JsonProperty("usage", NullValueHandling = NullValueHandling.Ignore)] public OpenAiUsage? Usage { get; set; }
+}

--- a/src/AiDotNet.Serving/Engine/Http/ServeOptions.cs
+++ b/src/AiDotNet.Serving/Engine/Http/ServeOptions.cs
@@ -20,4 +20,7 @@ public sealed class ServeOptions
 
     /// <summary>Sampling used when a request omits parameters. Defaults to greedy, 128 tokens.</summary>
     public SamplingParameters? DefaultSampling { get; init; }
+
+    /// <summary>Chat template rendering <c>/v1/chat/completions</c> messages to a prompt. Defaults to a generic template.</summary>
+    public IChatTemplate? ChatTemplate { get; init; }
 }

--- a/src/AiDotNet.Serving/Engine/Http/ServeOptions.cs
+++ b/src/AiDotNet.Serving/Engine/Http/ServeOptions.cs
@@ -1,0 +1,20 @@
+namespace AiDotNet.Serving.Engine.Http;
+
+/// <summary>
+/// Options for <c>model.Serve(...)</c>. Every value has a sensible default, so <c>model.Serve(tokenizer)</c>
+/// starts a working OpenAI-compatible server with no further configuration.
+/// </summary>
+public sealed class ServeOptions
+{
+    /// <summary>URLs to bind. Default binds a local port; use "http://0.0.0.0:8080" to expose externally.</summary>
+    public string[] Urls { get; init; } = new[] { "http://127.0.0.1:8080" };
+
+    /// <summary>The model id reported at <c>/v1/models</c> and echoed in responses. Default "aidotnet-model".</summary>
+    public string ModelName { get; init; } = "aidotnet-model";
+
+    /// <summary>Engine tuning (KV pool, batch limits). Defaults are derived automatically when null.</summary>
+    public EngineOptions? EngineOptions { get; init; }
+
+    /// <summary>Sampling used when a request omits parameters. Defaults to greedy, 128 tokens.</summary>
+    public SamplingParameters? DefaultSampling { get; init; }
+}

--- a/src/AiDotNet.Serving/Engine/Http/ServeOptions.cs
+++ b/src/AiDotNet.Serving/Engine/Http/ServeOptions.cs
@@ -12,8 +12,11 @@ public sealed class ServeOptions
     /// <summary>The model id reported at <c>/v1/models</c> and echoed in responses. Default "aidotnet-model".</summary>
     public string ModelName { get; init; } = "aidotnet-model";
 
-    /// <summary>Engine tuning (KV pool, batch limits). Defaults are derived automatically when null.</summary>
+    /// <summary>Engine tuning (KV pool, batch limits). Derived from <see cref="InferenceConfig"/> when null.</summary>
     public EngineOptions? EngineOptions { get; init; }
+
+    /// <summary>Inference-optimization config used to derive <see cref="EngineOptions"/> when it is null.</summary>
+    public AiDotNet.Configuration.InferenceOptimizationConfig? InferenceConfig { get; init; }
 
     /// <summary>Sampling used when a request omits parameters. Defaults to greedy, 128 tokens.</summary>
     public SamplingParameters? DefaultSampling { get; init; }

--- a/src/AiDotNet.Serving/Engine/ICausalLmRunner.cs
+++ b/src/AiDotNet.Serving/Engine/ICausalLmRunner.cs
@@ -49,6 +49,9 @@ public readonly struct SequenceKvLayout
 /// <typeparam name="T">The model's numeric type.</typeparam>
 public interface ICausalLmRunner<T>
 {
+    /// <summary>Vocabulary size (the width of the returned logits rows).</summary>
+    int VocabularySize { get; }
+
     /// <summary>Number of transformer layers whose KV must be cached (block pool is sized per layer).</summary>
     int NumLayers { get; }
 

--- a/src/AiDotNet.Serving/Engine/ICausalLmRunner.cs
+++ b/src/AiDotNet.Serving/Engine/ICausalLmRunner.cs
@@ -1,0 +1,94 @@
+using AiDotNet.Tensors.LinearAlgebra;
+
+namespace AiDotNet.Serving.Engine;
+
+/// <summary>
+/// Describes the physical location of a sequence's key/value cache: the ordered list of KV-cache blocks it
+/// occupies (its <b>block table</b>) plus how many token slots of the final block are actually filled. The
+/// engine hands one of these per sequence to the fast-path runner so attention can gather KV from the paged
+/// pool instead of a contiguous per-sequence buffer.
+/// </summary>
+public readonly struct SequenceKvLayout
+{
+    /// <summary>Creates a KV layout descriptor for one sequence.</summary>
+    public SequenceKvLayout(string sequenceId, IReadOnlyList<int> blockTable, int filledTokens)
+    {
+        SequenceId = sequenceId;
+        BlockTable = blockTable;
+        FilledTokens = filledTokens;
+    }
+
+    /// <summary>The sequence whose KV this describes.</summary>
+    public string SequenceId { get; }
+
+    /// <summary>Physical KV-cache block ids, in logical order, backing this sequence.</summary>
+    public IReadOnlyList<int> BlockTable { get; }
+
+    /// <summary>Total number of token slots already populated across the block table.</summary>
+    public int FilledTokens { get; }
+}
+
+/// <summary>
+/// Optional <b>fast-path</b> capability a model advertises to the serving engine: paged-KV, batched,
+/// incremental decoding. This is layered on top of <see cref="AiDotNet.Interfaces.IFullModel{T, TInput, TOutput}"/>
+/// (which remains the universal execution path); a model that implements it lets the engine avoid recomputing
+/// attention over the whole prefix every step, which is what makes throughput competitive with / better than
+/// vLLM and TGI.
+/// </summary>
+/// <remarks>
+/// <para><b>For Beginners:</b> a plain model only knows how to "read the whole prompt and answer" every time
+/// (<c>Predict</c>). That is correct but slow for serving, because generating token #500 would re-read tokens
+/// 1–499. A model that implements this interface instead keeps a <i>KV cache</i> — its memory of the tokens it
+/// already read — in a shared block pool the engine manages, so each new token only does O(1) new work. The
+/// engine calls <see cref="Prefill"/> once to load the prompt, then <see cref="DecodeStep"/> repeatedly, one
+/// token per sequence, over many sequences at once (batched).</para>
+/// <para>The engine owns KV memory (the block pool and block tables); the runner only reads/writes KV at the
+/// block locations the engine specifies via <see cref="SequenceKvLayout"/>, and honors the copy-on-write block
+/// copies the engine requests before a write into shared (prefix-shared) blocks.</para>
+/// </remarks>
+/// <typeparam name="T">The model's numeric type.</typeparam>
+public interface ICausalLmRunner<T>
+{
+    /// <summary>Number of transformer layers whose KV must be cached (block pool is sized per layer).</summary>
+    int NumLayers { get; }
+
+    /// <summary>Number of key/value heads (GQA/MQA aware) used to size a KV block.</summary>
+    int NumKvHeads { get; }
+
+    /// <summary>Per-head dimension used to size a KV block.</summary>
+    int HeadDim { get; }
+
+    /// <summary>Token capacity of a single KV-cache block (must match the engine's block manager block size).</summary>
+    int BlockSize { get; }
+
+    /// <summary>
+    /// Runs the prompt (prefill) for a batch of sequences, writing their KV into the specified block layouts
+    /// and returning the last-position logits for each sequence (shape: [batch, vocab]) used to sample the
+    /// first generated token. Supports chunked prefill: <paramref name="tokenCounts"/> may be a prefix of each
+    /// sequence's prompt.
+    /// </summary>
+    /// <param name="tokenIdsPerSequence">The prompt token ids to process this call, per sequence.</param>
+    /// <param name="layouts">Where each sequence's KV blocks live.</param>
+    /// <param name="tokenCounts">How many tokens of each sequence to process this call (chunked prefill).</param>
+    Tensor<T> Prefill(
+        IReadOnlyList<IReadOnlyList<int>> tokenIdsPerSequence,
+        IReadOnlyList<SequenceKvLayout> layouts,
+        IReadOnlyList<int> tokenCounts);
+
+    /// <summary>
+    /// Advances a batch of sequences by exactly one token each: reads cached KV via the block layouts, appends
+    /// the new token's KV, and returns next-token logits (shape: [batch, vocab]).
+    /// </summary>
+    /// <param name="lastTokenIds">The most recently produced token id for each sequence.</param>
+    /// <param name="layouts">Where each sequence's KV blocks live (last block is the write target).</param>
+    Tensor<T> DecodeStep(
+        IReadOnlyList<int> lastTokenIds,
+        IReadOnlyList<SequenceKvLayout> layouts);
+
+    /// <summary>
+    /// Executes engine-requested copy-on-write block copies before a write into shared blocks. Each copy
+    /// duplicates the KV contents of a source block into a freshly allocated destination block across all
+    /// layers. Called by the engine when prefix-shared sequences diverge.
+    /// </summary>
+    void CopyBlocks(IReadOnlyList<BlockCopy> copies);
+}

--- a/src/AiDotNet.Serving/Engine/IInferenceEngine.cs
+++ b/src/AiDotNet.Serving/Engine/IInferenceEngine.cs
@@ -1,0 +1,41 @@
+namespace AiDotNet.Serving.Engine;
+
+/// <summary>
+/// The core high-throughput inference engine contract: a continuously-batching, KV-cache-managed generation
+/// loop. Callers <see cref="AddRequest"/> jobs at any time; the engine interleaves them (continuous / in-flight
+/// batching), manages paged KV-cache memory with preemption, and streams <see cref="RequestOutput"/>s back.
+/// </summary>
+/// <remarks>
+/// <para><b>For Beginners:</b> this is the "brain" that actually runs the model for serving. Unlike a simple
+/// "call model, get text" function, a serving engine keeps many requests in flight at once and advances all of
+/// them a little each <see cref="Step"/>, so the GPU/CPU stays busy and latency stays low. You add requests
+/// whenever they arrive; you pump <see cref="Step"/> in a loop; each step returns the newly-produced tokens
+/// for every request that advanced.</para>
+/// <para>This mirrors vLLM's <c>LLMEngine</c> / TGI's batching server: the design goal is to meet or exceed
+/// their throughput and latency by combining paged KV memory, in-flight batching, chunked prefill, and
+/// (optionally) speculative decoding and quantized execution behind this single contract.</para>
+/// </remarks>
+public interface IInferenceEngine : IDisposable
+{
+    /// <summary>Admits a new request into the engine's waiting queue. Thread-safe; may be called while stepping.</summary>
+    void AddRequest(GenerationRequest request);
+
+    /// <summary>
+    /// Requests cancellation of an in-flight request by id. The request's sequences move to a terminal
+    /// aborted state and their KV blocks are freed at the next step. Returns true if the request was found.
+    /// </summary>
+    bool AbortRequest(string requestId);
+
+    /// <summary>
+    /// Advances the engine by one iteration: schedules a batch (prefill and/or decode), runs the model,
+    /// samples one token per running sequence, frees finished sequences, and returns the outputs that changed
+    /// this step. Returns an empty list when there is no work.
+    /// </summary>
+    IReadOnlyList<RequestOutput> Step();
+
+    /// <summary>True while any request is queued or running (i.e. <see cref="Step"/> still has work to do).</summary>
+    bool HasUnfinishedRequests { get; }
+
+    /// <summary>A snapshot of current load and KV-cache utilization.</summary>
+    EngineStatistics GetStatistics();
+}

--- a/src/AiDotNet.Serving/Engine/IProvidesGenerationTokenizer.cs
+++ b/src/AiDotNet.Serving/Engine/IProvidesGenerationTokenizer.cs
@@ -1,0 +1,19 @@
+using AiDotNet.Agentic.Models.Local;
+
+namespace AiDotNet.Serving.Engine;
+
+/// <summary>
+/// A model (or model wrapper) that carries its own tokenizer. When a served model implements this, the facade
+/// resolves the tokenizer automatically, so <c>model.Generate("text")</c> and <c>model.Serve()</c> need no
+/// explicitly-passed tokenizer — the zero-configuration path.
+/// </summary>
+/// <remarks>
+/// <para><b>For Beginners:</b> a model that already knows how to turn text into tokens (and back) can hand that
+/// knowledge to the serving layer. If yours does, you don't have to pass a tokenizer when you generate or
+/// serve — the library finds it.</para>
+/// </remarks>
+public interface IProvidesGenerationTokenizer
+{
+    /// <summary>Returns the tokenizer to use for text generation with this model.</summary>
+    IGenerationTokenizer GetGenerationTokenizer();
+}

--- a/src/AiDotNet.Serving/Engine/IServingModelRunner.cs
+++ b/src/AiDotNet.Serving/Engine/IServingModelRunner.cs
@@ -1,0 +1,71 @@
+using System.Collections.Generic;
+using AiDotNet.Tensors.LinearAlgebra;
+
+namespace AiDotNet.Serving.Engine;
+
+/// <summary>
+/// One sequence's execution descriptor for a single engine step: the tokens the model must process, how far its
+/// KV cache has already advanced, and where its KV blocks live. The engine builds one of these per scheduled
+/// sequence and hands the batch to an <see cref="IServingModelRunner{T}"/>.
+/// </summary>
+/// <typeparam name="T">The model's numeric type.</typeparam>
+public readonly struct SequenceExecution<T>
+{
+    /// <summary>Creates an execution descriptor.</summary>
+    public SequenceExecution(
+        string sequenceId,
+        IReadOnlyList<int> allTokenIds,
+        int numComputedTokens,
+        IReadOnlyList<int> blockTable,
+        IReadOnlyList<BlockCopy> blockCopies,
+        bool isPrefill)
+    {
+        SequenceId = sequenceId;
+        AllTokenIds = allTokenIds;
+        NumComputedTokens = numComputedTokens;
+        BlockTable = blockTable;
+        BlockCopies = blockCopies;
+        IsPrefill = isPrefill;
+    }
+
+    /// <summary>The sequence being executed.</summary>
+    public string SequenceId { get; }
+
+    /// <summary>Full token ids (prompt + generated) currently in the sequence.</summary>
+    public IReadOnlyList<int> AllTokenIds { get; }
+
+    /// <summary>
+    /// How many leading tokens already have cached KV. A paged runner processes only tokens
+    /// [<see cref="NumComputedTokens"/>, count); a recompute runner ignores this and reprocesses from the start.
+    /// </summary>
+    public int NumComputedTokens { get; }
+
+    /// <summary>Physical KV-cache block ids backing this sequence (in logical order).</summary>
+    public IReadOnlyList<int> BlockTable { get; }
+
+    /// <summary>Copy-on-write block copies the runner must perform before writing this sequence's new KV.</summary>
+    public IReadOnlyList<BlockCopy> BlockCopies { get; }
+
+    /// <summary>True if this is a prefill step (processing the prompt), false for a single-token decode step.</summary>
+    public bool IsPrefill { get; }
+}
+
+/// <summary>
+/// The engine's internal model driver: given the batch of sequences scheduled this step, produce each one's
+/// next-token logits. This is the single seam the <see cref="ContinuousBatchingEngine{T}"/> loop calls, so the
+/// scheduler is model-agnostic and testable. Two adapters satisfy it: a paged fast-path adapter over a model's
+/// <see cref="ICausalLmRunner{T}"/> capability, and a correctness fallback that recomputes via
+/// <see cref="AiDotNet.Interfaces.IFullModel{T, TInput, TOutput}"/>.
+/// </summary>
+/// <typeparam name="T">The model's numeric type.</typeparam>
+public interface IServingModelRunner<T>
+{
+    /// <summary>Vocabulary size (length of each returned logits vector).</summary>
+    int VocabularySize { get; }
+
+    /// <summary>
+    /// Executes the scheduled batch and returns per-sequence next-token logits, in the same order as
+    /// <paramref name="batch"/>. Each returned vector has length <see cref="VocabularySize"/>.
+    /// </summary>
+    IReadOnlyList<Vector<T>> Execute(IReadOnlyList<SequenceExecution<T>> batch);
+}

--- a/src/AiDotNet.Serving/Engine/LogitsSampler.cs
+++ b/src/AiDotNet.Serving/Engine/LogitsSampler.cs
@@ -72,6 +72,72 @@ public static class LogitsSampler
         return SampleFromCandidates(candidates, probabilities, rng);
     }
 
+    /// <summary>
+    /// Computes the full-vocabulary probability distribution this sampler would draw from under the given
+    /// parameters: penalties → temperature → softmax → top-k / min-p / top-p, with zero mass outside the kept
+    /// set (renormalized to sum to 1). Greedy parameters yield a point mass at the argmax. This is the exact
+    /// target distribution speculative decoding must preserve.
+    /// </summary>
+    public static double[] ComputeProbabilities<T>(
+        Vector<T> logits, SamplingParameters parameters, IReadOnlyList<int> contextTokenIds)
+    {
+        if (logits is null) throw new ArgumentNullException(nameof(logits));
+        if (parameters is null) throw new ArgumentNullException(nameof(parameters));
+        int vocab = logits.Length;
+        if (vocab == 0) throw new ArgumentException("Logits must be non-empty.", nameof(logits));
+
+        var scores = new double[vocab];
+        for (int i = 0; i < vocab; i++) scores[i] = Convert.ToDouble(logits[i]);
+        ApplyPenalties(scores, parameters, contextTokenIds);
+
+        var dist = new double[vocab];
+        if (parameters.IsGreedy)
+        {
+            dist[ArgMax(scores)] = 1.0;
+            return dist;
+        }
+
+        double temperature = parameters.Temperature;
+        for (int i = 0; i < vocab; i++) scores[i] /= temperature;
+        var probabilities = Softmax(scores);
+
+        var candidates = new List<int>(vocab);
+        for (int i = 0; i < vocab; i++) candidates.Add(i);
+        candidates.Sort((a, b) => probabilities[b].CompareTo(probabilities[a]));
+        ApplyTopK(candidates, parameters.TopK);
+        ApplyMinP(candidates, probabilities, parameters.MinP);
+        ApplyTopP(candidates, probabilities, parameters.TopP);
+
+        double total = 0.0;
+        foreach (int id in candidates) total += probabilities[id];
+        if (total <= 0.0) { dist[candidates[0]] = 1.0; return dist; }
+        foreach (int id in candidates) dist[id] = probabilities[id] / total;
+        return dist;
+    }
+
+    /// <summary>Draws an index from a probability distribution using the given RNG (inverse-CDF).</summary>
+    public static int SampleFromDistribution(double[] probabilities, Random rng)
+    {
+        if (probabilities is null) throw new ArgumentNullException(nameof(probabilities));
+        if (rng is null) throw new ArgumentNullException(nameof(rng));
+
+        double total = 0.0;
+        for (int i = 0; i < probabilities.Length; i++) total += probabilities[i];
+        if (total <= 0.0) return 0;
+
+        double threshold = rng.NextDouble() * total;
+        double accumulated = 0.0;
+        int last = 0;
+        for (int i = 0; i < probabilities.Length; i++)
+        {
+            if (probabilities[i] <= 0.0) continue;
+            last = i;
+            accumulated += probabilities[i];
+            if (threshold <= accumulated) return i;
+        }
+        return last;
+    }
+
     private static void ApplyPenalties(double[] scores, SamplingParameters p, IReadOnlyList<int> context)
     {
         bool anyPenalty = Math.Abs(p.RepetitionPenalty - 1.0) > 1e-12

--- a/src/AiDotNet.Serving/Engine/LogitsSampler.cs
+++ b/src/AiDotNet.Serving/Engine/LogitsSampler.cs
@@ -1,0 +1,188 @@
+using System;
+using System.Collections.Generic;
+using AiDotNet.Tensors.LinearAlgebra;
+
+namespace AiDotNet.Serving.Engine;
+
+/// <summary>
+/// Turns a row of next-token logits into a concrete token id under a set of <see cref="SamplingParameters"/>.
+/// This is the serving engine's decoding kernel: it applies repetition / presence / frequency penalties, then
+/// temperature, then the top-k / top-p (nucleus) / min-p filters, and finally samples (or takes the argmax for
+/// greedy decoding) — the same pipeline and ordering used by vLLM and Hugging Face so results line up with the
+/// wider ecosystem.
+/// </summary>
+/// <remarks>
+/// <para><b>For Beginners:</b> a model doesn't output a word — it outputs a score (logit) for every possible
+/// next token. This class is the referee that turns those thousands of scores into one chosen token. It first
+/// nudges scores to discourage repeating what was already said (penalties), then decides how adventurous to be
+/// (temperature), then narrows the field to the most plausible tokens (top-k / top-p / min-p), and finally
+/// either picks the single best one (greedy) or rolls a weighted die among the survivors.</para>
+/// <para>The method is pure and deterministic given the same logits, parameters, token history, and RNG state,
+/// which is what makes greedy decoding reproducible and seeded sampling repeatable.</para>
+/// </remarks>
+public static class LogitsSampler
+{
+    /// <summary>
+    /// Samples a token id from <paramref name="logits"/> under <paramref name="parameters"/>.
+    /// </summary>
+    /// <typeparam name="T">The model's numeric type.</typeparam>
+    /// <param name="logits">Next-token logits over the full vocabulary (length == vocab size).</param>
+    /// <param name="parameters">Decoding parameters (already validated).</param>
+    /// <param name="contextTokenIds">Tokens seen so far (prompt + generated) used for the repetition /
+    /// presence / frequency penalties. Pass an empty list to disable penalties.</param>
+    /// <param name="rng">RNG used for stochastic sampling; ignored on the greedy path. Seed it per request for
+    /// reproducibility.</param>
+    /// <returns>The chosen token id (an index into the vocabulary).</returns>
+    public static int Sample<T>(
+        Vector<T> logits,
+        SamplingParameters parameters,
+        IReadOnlyList<int> contextTokenIds,
+        Random rng)
+    {
+        if (logits is null) throw new ArgumentNullException(nameof(logits));
+        if (parameters is null) throw new ArgumentNullException(nameof(parameters));
+        if (rng is null) throw new ArgumentNullException(nameof(rng));
+
+        int vocab = logits.Length;
+        if (vocab == 0) throw new ArgumentException("Logits must be non-empty.", nameof(logits));
+
+        var scores = new double[vocab];
+        for (int i = 0; i < vocab; i++) scores[i] = Convert.ToDouble(logits[i]);
+
+        ApplyPenalties(scores, parameters, contextTokenIds);
+
+        // Greedy decoding: the argmax of the (penalized) logits. Temperature scaling by a positive constant
+        // does not change the argmax, so we can return here directly.
+        if (parameters.IsGreedy) return ArgMax(scores);
+
+        double temperature = parameters.Temperature;
+        for (int i = 0; i < vocab; i++) scores[i] /= temperature;
+
+        var probabilities = Softmax(scores);
+
+        // Candidate token ids sorted by descending probability so the filters slice from the front.
+        var candidates = new List<int>(vocab);
+        for (int i = 0; i < vocab; i++) candidates.Add(i);
+        candidates.Sort((a, b) => probabilities[b].CompareTo(probabilities[a]));
+
+        ApplyTopK(candidates, parameters.TopK);
+        ApplyMinP(candidates, probabilities, parameters.MinP);
+        ApplyTopP(candidates, probabilities, parameters.TopP);
+
+        return SampleFromCandidates(candidates, probabilities, rng);
+    }
+
+    private static void ApplyPenalties(double[] scores, SamplingParameters p, IReadOnlyList<int> context)
+    {
+        bool anyPenalty = Math.Abs(p.RepetitionPenalty - 1.0) > 1e-12
+            || p.PresencePenalty != 0.0
+            || p.FrequencyPenalty != 0.0;
+        if (!anyPenalty || context is null || context.Count == 0) return;
+
+        var counts = new Dictionary<int, int>();
+        foreach (int id in context)
+        {
+            if (id < 0 || id >= scores.Length) continue;
+            counts[id] = counts.TryGetValue(id, out int c) ? c + 1 : 1;
+        }
+
+        foreach (var kvp in counts)
+        {
+            int id = kvp.Key;
+            int count = kvp.Value;
+
+            // Repetition penalty (Keskar et al. 2019): divide positive logits / multiply negative logits by
+            // the penalty so already-seen tokens become less likely regardless of logit sign.
+            if (Math.Abs(p.RepetitionPenalty - 1.0) > 1e-12)
+                scores[id] = scores[id] > 0 ? scores[id] / p.RepetitionPenalty : scores[id] * p.RepetitionPenalty;
+
+            // Presence (once seen) and frequency (scaled by count) penalties, OpenAI-style additive form.
+            scores[id] -= p.PresencePenalty;
+            scores[id] -= p.FrequencyPenalty * count;
+        }
+    }
+
+    private static double[] Softmax(double[] scores)
+    {
+        double max = double.NegativeInfinity;
+        for (int i = 0; i < scores.Length; i++) if (scores[i] > max) max = scores[i];
+
+        var probs = new double[scores.Length];
+        double sum = 0.0;
+        for (int i = 0; i < scores.Length; i++)
+        {
+            double e = Math.Exp(scores[i] - max);
+            probs[i] = e;
+            sum += e;
+        }
+        if (sum <= 0.0 || double.IsNaN(sum)) // degenerate (e.g. all -inf); fall back to uniform.
+        {
+            double u = 1.0 / scores.Length;
+            for (int i = 0; i < scores.Length; i++) probs[i] = u;
+            return probs;
+        }
+        for (int i = 0; i < scores.Length; i++) probs[i] /= sum;
+        return probs;
+    }
+
+    private static void ApplyTopK(List<int> candidates, int topK)
+    {
+        if (topK > 0 && topK < candidates.Count)
+            candidates.RemoveRange(topK, candidates.Count - topK);
+    }
+
+    private static void ApplyMinP(List<int> candidates, double[] probs, double minP)
+    {
+        if (minP <= 0.0 || candidates.Count == 0) return;
+        // candidates[0] holds the max probability (list is sorted descending).
+        double threshold = minP * probs[candidates[0]];
+        int keep = candidates.Count;
+        for (int i = 0; i < candidates.Count; i++)
+        {
+            if (probs[candidates[i]] < threshold) { keep = i; break; }
+        }
+        if (keep < candidates.Count && keep >= 1)
+            candidates.RemoveRange(keep, candidates.Count - keep);
+    }
+
+    private static void ApplyTopP(List<int> candidates, double[] probs, double topP)
+    {
+        if (topP >= 1.0 || candidates.Count == 0) return;
+        double cumulative = 0.0;
+        int keep = candidates.Count;
+        for (int i = 0; i < candidates.Count; i++)
+        {
+            cumulative += probs[candidates[i]];
+            if (cumulative >= topP) { keep = i + 1; break; } // keep through the token that crosses the mass
+        }
+        if (keep < candidates.Count)
+            candidates.RemoveRange(keep, candidates.Count - keep);
+    }
+
+    private static int SampleFromCandidates(List<int> candidates, double[] probs, Random rng)
+    {
+        double total = 0.0;
+        foreach (int id in candidates) total += probs[id];
+        if (total <= 0.0) return candidates[0]; // degenerate; return the most probable survivor.
+
+        double threshold = rng.NextDouble() * total;
+        double accumulated = 0.0;
+        foreach (int id in candidates)
+        {
+            accumulated += probs[id];
+            if (threshold <= accumulated) return id;
+        }
+        return candidates[candidates.Count - 1]; // floating-point guard
+    }
+
+    private static int ArgMax(double[] scores)
+    {
+        int best = 0;
+        double bestScore = scores[0];
+        for (int i = 1; i < scores.Length; i++)
+        {
+            if (scores[i] > bestScore) { bestScore = scores[i]; best = i; }
+        }
+        return best;
+    }
+}

--- a/src/AiDotNet.Serving/Engine/PagedRunnerAdapter.cs
+++ b/src/AiDotNet.Serving/Engine/PagedRunnerAdapter.cs
@@ -1,0 +1,113 @@
+using System;
+using System.Collections.Generic;
+using AiDotNet.Tensors.LinearAlgebra;
+
+namespace AiDotNet.Serving.Engine;
+
+/// <summary>
+/// The fast-path model driver: adapts a model's paged <see cref="ICausalLmRunner{T}"/> capability to the
+/// engine's <see cref="IServingModelRunner{T}"/>. It splits each scheduled batch into its prefill and decode
+/// sub-batches, performs any copy-on-write block copies, invokes the runner's incremental
+/// <see cref="ICausalLmRunner{T}.Prefill"/> / <see cref="ICausalLmRunner{T}.DecodeStep"/>, and scatters the
+/// per-sequence logits back into scheduling order.
+/// </summary>
+/// <remarks>
+/// <para><b>For Beginners:</b> when a model supports the fast paged path (it keeps a real KV cache), this
+/// adapter is what actually calls it: it separates the requests that are still reading their prompt (prefill)
+/// from those generating one token at a time (decode), runs each group efficiently against the paged cache,
+/// and lines the results back up so the engine can sample.</para>
+/// </remarks>
+/// <typeparam name="T">The model's numeric type.</typeparam>
+public sealed class PagedRunnerAdapter<T> : IServingModelRunner<T>
+{
+    private readonly ICausalLmRunner<T> _runner;
+
+    /// <summary>Creates the adapter over a paged causal-LM runner.</summary>
+    public PagedRunnerAdapter(ICausalLmRunner<T> runner)
+    {
+        _runner = runner ?? throw new ArgumentNullException(nameof(runner));
+        if (_runner.VocabularySize < 1)
+            throw new ArgumentException("Runner vocabulary size must be positive.", nameof(runner));
+    }
+
+    /// <inheritdoc/>
+    public int VocabularySize => _runner.VocabularySize;
+
+    /// <inheritdoc/>
+    public IReadOnlyList<Vector<T>> Execute(IReadOnlyList<SequenceExecution<T>> batch)
+    {
+        if (batch is null) throw new ArgumentNullException(nameof(batch));
+
+        // Perform any engine-requested copy-on-write block copies before writes.
+        List<BlockCopy>? copies = null;
+        foreach (var exec in batch)
+        {
+            if (exec.BlockCopies.Count == 0) continue;
+            copies ??= new List<BlockCopy>();
+            copies.AddRange(exec.BlockCopies);
+        }
+        if (copies is { Count: > 0 }) _runner.CopyBlocks(copies);
+
+        var results = new Vector<T>[batch.Count];
+
+        var prefillTokens = new List<IReadOnlyList<int>>();
+        var prefillLayouts = new List<SequenceKvLayout>();
+        var prefillCounts = new List<int>();
+        var prefillPos = new List<int>();
+
+        var decodeLast = new List<int>();
+        var decodeLayouts = new List<SequenceKvLayout>();
+        var decodePos = new List<int>();
+
+        for (int i = 0; i < batch.Count; i++)
+        {
+            var exec = batch[i];
+            var layout = new SequenceKvLayout(exec.SequenceId, exec.BlockTable, exec.NumComputedTokens);
+            if (exec.IsPrefill)
+            {
+                prefillTokens.Add(exec.AllTokenIds);
+                prefillLayouts.Add(layout);
+                prefillCounts.Add(exec.AllTokenIds.Count - exec.NumComputedTokens);
+                prefillPos.Add(i);
+            }
+            else
+            {
+                decodeLast.Add(exec.AllTokenIds[exec.AllTokenIds.Count - 1]);
+                decodeLayouts.Add(layout);
+                decodePos.Add(i);
+            }
+        }
+
+        if (prefillPos.Count > 0)
+        {
+            var logits = _runner.Prefill(prefillTokens, prefillLayouts, prefillCounts);
+            ScatterRows(logits, prefillPos, results);
+        }
+        if (decodePos.Count > 0)
+        {
+            var logits = _runner.DecodeStep(decodeLast, decodeLayouts);
+            ScatterRows(logits, decodePos, results);
+        }
+
+        return results;
+    }
+
+    // Copies each row of a [subBatch, vocab] logits tensor into the result slot for that sequence.
+    private void ScatterRows(Tensor<T> logits, List<int> positions, Vector<T>[] results)
+    {
+        if (logits is null) throw new InvalidOperationException("Runner returned null logits.");
+        var shape = logits.Shape;
+        if (shape.Length != 2 || shape[0] != positions.Count || shape[1] != _runner.VocabularySize)
+            throw new InvalidOperationException(
+                $"Runner returned logits of rank {shape.Length} for {positions.Count} sequences; " +
+                $"expected [{positions.Count}, {_runner.VocabularySize}].");
+
+        int vocab = _runner.VocabularySize;
+        for (int k = 0; k < positions.Count; k++)
+        {
+            var row = new T[vocab];
+            for (int v = 0; v < vocab; v++) row[v] = logits[k, v];
+            results[positions[k]] = new Vector<T>(row);
+        }
+    }
+}

--- a/src/AiDotNet.Serving/Engine/PredictCausalLmAdapter.cs
+++ b/src/AiDotNet.Serving/Engine/PredictCausalLmAdapter.cs
@@ -1,0 +1,44 @@
+using System;
+using AiDotNet.Tensors.LinearAlgebra;
+
+namespace AiDotNet.Serving.Engine;
+
+/// <summary>
+/// Presents any token-in / logits-out forward function as an <see cref="AiDotNet.Interfaces.ICausalLmModel{T}"/>
+/// so the serving engine can drive a model that produces vocabulary-width predictions but has not implemented
+/// the capability interface directly. This is the widest-coverage fallback: give it the model's forward pass
+/// and its vocabulary size, and it serves.
+/// </summary>
+/// <remarks>
+/// <para><b>For Beginners:</b> some models already output a score for every possible next token but don't
+/// formally declare themselves a "language model" to the serving layer. This wrapper bridges that gap — you
+/// tell it the model's forward function and how many tokens are in the vocabulary, and it can be served like
+/// any other generator.</para>
+/// </remarks>
+/// <typeparam name="T">The model's numeric type.</typeparam>
+public sealed class PredictCausalLmAdapter<T> : AiDotNet.Interfaces.ICausalLmModel<T>
+{
+    private readonly Func<Tensor<T>, Tensor<T>> _forward;
+
+    /// <summary>Creates the adapter.</summary>
+    /// <param name="forward">The model's forward pass: token ids <c>[1, seq]</c> → logits (<c>[seq, vocab]</c>
+    /// or <c>[1, seq, vocab]</c>). Typically the model's <c>Predict</c>.</param>
+    /// <param name="vocabularySize">The model's vocabulary size.</param>
+    /// <param name="eosTokenId">The EOS token id, if any.</param>
+    public PredictCausalLmAdapter(Func<Tensor<T>, Tensor<T>> forward, int vocabularySize, int? eosTokenId = null)
+    {
+        _forward = forward ?? throw new ArgumentNullException(nameof(forward));
+        if (vocabularySize < 1) throw new ArgumentOutOfRangeException(nameof(vocabularySize));
+        VocabularySize = vocabularySize;
+        EosTokenId = eosTokenId;
+    }
+
+    /// <inheritdoc/>
+    public int VocabularySize { get; }
+
+    /// <inheritdoc/>
+    public int? EosTokenId { get; }
+
+    /// <inheritdoc/>
+    public Tensor<T> ForwardLogits(Tensor<T> tokenIds) => _forward(tokenIds);
+}

--- a/src/AiDotNet.Serving/Engine/PrefixCache.cs
+++ b/src/AiDotNet.Serving/Engine/PrefixCache.cs
@@ -1,0 +1,191 @@
+using System;
+using System.Collections.Generic;
+
+namespace AiDotNet.Serving.Engine;
+
+/// <summary>
+/// Automatic cross-request prefix caching (as in vLLM's APC): remembers the KV-cache blocks of previously-seen
+/// prompt prefixes so a later request that begins with the same tokens reuses that cached KV instead of
+/// recomputing it. Only block-aligned prefixes are cached, so a shared block contains exactly the shared tokens.
+/// </summary>
+/// <remarks>
+/// <para><b>For Beginners:</b> many requests share a common beginning — the same system prompt, the same few-shot
+/// examples, the same document. Without caching, the model re-reads that shared beginning for every request. This
+/// cache keeps the "memory" (KV) of shared beginnings around, so the next request that starts the same way skips
+/// straight past it. It holds a reference to those blocks to keep them alive, and evicts the least-recently-used
+/// entries when it is full.</para>
+/// <para>The cache pins blocks by forking them into an internal cache-owned sequence in the
+/// <see cref="BlockManager"/>; eviction frees that sequence, releasing the reference (blocks are reclaimed once
+/// no live sequence uses them too).</para>
+/// </remarks>
+public sealed class PrefixCache
+{
+    private sealed class Entry
+    {
+        public string CacheSequenceId = string.Empty;
+        public int[] PrefixTokens = Array.Empty<int>();
+        public LinkedListNode<long> LruNode = null!;
+    }
+
+    private readonly BlockManager _blocks;
+    private readonly int _blockSize;
+    private readonly int _capacity;
+    private readonly Dictionary<long, List<Entry>> _byKey = new(); // hash -> entries (collision chain)
+    private readonly Dictionary<long, Entry> _byLruId = new();
+    private readonly LinkedList<long> _lru = new(); // front = most recently used
+    private long _counter;
+
+    /// <summary>Creates a prefix cache over a block manager.</summary>
+    /// <param name="blockManager">The block manager whose blocks are cached.</param>
+    /// <param name="blockSize">KV block size (prefix lengths are multiples of this).</param>
+    /// <param name="capacity">Maximum number of cached prefixes (LRU eviction beyond it).</param>
+    public PrefixCache(BlockManager blockManager, int blockSize, int capacity = 128)
+    {
+        _blocks = blockManager ?? throw new ArgumentNullException(nameof(blockManager));
+        if (blockSize < 1) throw new ArgumentOutOfRangeException(nameof(blockSize));
+        if (capacity < 1) throw new ArgumentOutOfRangeException(nameof(capacity));
+        _blockSize = blockSize;
+        _capacity = capacity;
+    }
+
+    /// <summary>The number of cached prefixes.</summary>
+    public int Count => _byLruId.Count;
+
+    /// <summary>Result of a cache lookup.</summary>
+    public readonly struct Hit
+    {
+        /// <summary>Creates a hit.</summary>
+        public Hit(string cacheSequenceId, int prefixLength) { CacheSequenceId = cacheSequenceId; PrefixLength = prefixLength; }
+        /// <summary>The cache-owned sequence id whose blocks hold the shared prefix (fork from it).</summary>
+        public string CacheSequenceId { get; }
+        /// <summary>Number of shared prefix tokens (a positive multiple of the block size).</summary>
+        public int PrefixLength { get; }
+    }
+
+    /// <summary>
+    /// Finds the longest cached block-aligned prefix of <paramref name="promptTokens"/>. Returns null on a miss.
+    /// A hit is moved to most-recently-used.
+    /// </summary>
+    public Hit? Lookup(IReadOnlyList<int> promptTokens)
+    {
+        if (promptTokens is null) throw new ArgumentNullException(nameof(promptTokens));
+        int maxLen = promptTokens.Count / _blockSize * _blockSize;
+        for (int len = maxLen; len >= _blockSize; len -= _blockSize)
+        {
+            long key = HashPrefix(promptTokens, len);
+            if (!_byKey.TryGetValue(key, out var chain)) continue;
+            foreach (var entry in chain)
+            {
+                if (PrefixMatches(entry.PrefixTokens, promptTokens, len))
+                {
+                    Touch(entry);
+                    return new Hit(entry.CacheSequenceId, len);
+                }
+            }
+        }
+        return null;
+    }
+
+    /// <summary>
+    /// Caches every block-aligned prefix of a sequence's prompt by pinning its blocks (forking into cache-owned
+    /// sequences), so a later request that shares any block-aligned prefix reuses that KV. No-op below one block;
+    /// already-cached prefixes are just refreshed.
+    /// </summary>
+    public void Register(IReadOnlyList<int> promptTokens, string ownerSequenceId)
+    {
+        if (promptTokens is null) throw new ArgumentNullException(nameof(promptTokens));
+        int maxLen = promptTokens.Count / _blockSize * _blockSize;
+
+        for (int len = _blockSize; len <= maxLen; len += _blockSize)
+        {
+            long key = HashPrefix(promptTokens, len);
+            if (TryGetEntry(key, promptTokens, len, out var existing)) { Touch(existing); continue; }
+
+            // Pin these prefix blocks under a cache-owned sequence so they survive the owner being freed.
+            long id = ++_counter;
+            string cacheSeqId = "prefixcache:" + id.ToString();
+            _blocks.ForkPrefix(ownerSequenceId, cacheSeqId, len);
+
+            var prefix = new int[len];
+            for (int i = 0; i < len; i++) prefix[i] = promptTokens[i];
+            var entry = new Entry { CacheSequenceId = cacheSeqId, PrefixTokens = prefix };
+            entry.LruNode = _lru.AddFirst(id);
+            _byLruId[id] = entry;
+            if (!_byKey.TryGetValue(key, out var chain)) { chain = new List<Entry>(1); _byKey[key] = chain; }
+            chain.Add(entry);
+
+            if (_byLruId.Count > _capacity) EvictLeastRecentlyUsed();
+        }
+    }
+
+    private bool TryGetEntry(long key, IReadOnlyList<int> tokens, int len, out Entry entry)
+    {
+        entry = null!;
+        if (!_byKey.TryGetValue(key, out var chain)) return false;
+        foreach (var e in chain)
+            if (PrefixMatches(e.PrefixTokens, tokens, len)) { entry = e; return true; }
+        return false;
+    }
+
+    /// <summary>Evicts the least-recently-used entry (releasing its pinned blocks). Returns false if empty.</summary>
+    public bool TryEvictOne()
+    {
+        if (_lru.Last is null) return false;
+        EvictLeastRecentlyUsed();
+        return true;
+    }
+
+    /// <summary>Frees all cached prefixes (releasing their pinned blocks).</summary>
+    public void Clear()
+    {
+        foreach (var entry in _byLruId.Values) _blocks.Free(entry.CacheSequenceId);
+        _byLruId.Clear();
+        _byKey.Clear();
+        _lru.Clear();
+    }
+
+    private void Touch(Entry entry)
+    {
+        _lru.Remove(entry.LruNode);
+        _lru.AddFirst(entry.LruNode);
+    }
+
+    private void EvictLeastRecentlyUsed()
+    {
+        var node = _lru.Last;
+        if (node is null) return;
+        long id = node.Value;
+        _lru.RemoveLast();
+        if (!_byLruId.Remove(id, out var entry)) return;
+
+        _blocks.Free(entry.CacheSequenceId);
+        long key = HashPrefix(entry.PrefixTokens, entry.PrefixTokens.Length);
+        if (_byKey.TryGetValue(key, out var chain))
+        {
+            chain.Remove(entry);
+            if (chain.Count == 0) _byKey.Remove(key);
+        }
+    }
+
+    private static long HashPrefix(IReadOnlyList<int> tokens, int len)
+    {
+        // FNV-1a over the first `len` token ids.
+        unchecked
+        {
+            long hash = 1469598103934665603L;
+            for (int i = 0; i < len; i++)
+            {
+                hash ^= (uint)tokens[i];
+                hash *= 1099511628211L;
+            }
+            return hash;
+        }
+    }
+
+    private static bool PrefixMatches(int[] cached, IReadOnlyList<int> tokens, int len)
+    {
+        if (cached.Length != len) return false;
+        for (int i = 0; i < len; i++) if (cached[i] != tokens[i]) return false;
+        return true;
+    }
+}

--- a/src/AiDotNet.Serving/Engine/RecomputeModelRunner.cs
+++ b/src/AiDotNet.Serving/Engine/RecomputeModelRunner.cs
@@ -1,0 +1,105 @@
+using System;
+using System.Collections.Generic;
+using AiDotNet.Interfaces;
+using AiDotNet.Tensors.Helpers;
+using AiDotNet.Tensors.LinearAlgebra;
+
+namespace AiDotNet.Serving.Engine;
+
+/// <summary>
+/// The correctness-first model driver: adapts any <see cref="ICausalLmModel{T}"/> to the engine's
+/// <see cref="IServingModelRunner{T}"/> by recomputing next-token logits from the full token sequence each
+/// step. It needs no KV plumbing, so it works for every generative model out of the box — the universal
+/// fallback beneath the optional paged fast path.
+/// </summary>
+/// <remarks>
+/// <para><b>For Beginners:</b> this is the "simple but always-correct" way to run a model in the engine: every
+/// step it hands the model all the tokens so far and asks for the next-token scores. It ignores the paged KV
+/// cache (that is the fast path's job) and instead recomputes, which is why it pairs naturally with recompute
+/// preemption — a recomputing sequence and this runner do exactly the same work.</para>
+/// </remarks>
+/// <typeparam name="T">The model's numeric type.</typeparam>
+public sealed class RecomputeModelRunner<T> : IServingModelRunner<T>
+{
+    private readonly ICausalLmModel<T> _model;
+
+    /// <summary>Creates a recompute runner over a causal-LM model.</summary>
+    public RecomputeModelRunner(ICausalLmModel<T> model)
+    {
+        _model = model ?? throw new ArgumentNullException(nameof(model));
+        if (_model.VocabularySize < 1)
+            throw new ArgumentException("Model vocabulary size must be positive.", nameof(model));
+    }
+
+    /// <inheritdoc/>
+    public int VocabularySize => _model.VocabularySize;
+
+    /// <inheritdoc/>
+    public IReadOnlyList<Vector<T>> Execute(IReadOnlyList<SequenceExecution<T>> batch)
+    {
+        if (batch is null) throw new ArgumentNullException(nameof(batch));
+        var numOps = MathHelper.GetNumericOperations<T>();
+        var results = new List<Vector<T>>(batch.Count);
+
+        foreach (var exec in batch)
+        {
+            var tokens = exec.AllTokenIds;
+            int n = tokens.Count;
+            var input = new Tensor<T>(new[] { 1, n });
+            for (int i = 0; i < n; i++)
+                input[0, i] = numOps.FromDouble(tokens[i]);
+
+            var logits = _model.ForwardLogits(input);
+            results.Add(ExtractLastPositionLogits(logits, _model.VocabularySize));
+        }
+        return results;
+    }
+
+    // Reads the vocabulary logits at the final sequence position, tolerating the common output ranks a model
+    // might return: [vocab], [seq, vocab], or [1, seq, vocab] (optionally [1, vocab]).
+    private static Vector<T> ExtractLastPositionLogits(Tensor<T> logits, int vocab)
+    {
+        if (logits is null) throw new InvalidOperationException("Model returned null logits.");
+        var shape = logits.Shape;
+
+        switch (shape.Length)
+        {
+            case 1:
+            {
+                if (shape[0] != vocab) throw ShapeError(shape, vocab);
+                var row = new T[vocab];
+                for (int v = 0; v < vocab; v++) row[v] = logits[v];
+                return new Vector<T>(row);
+            }
+            case 2:
+            {
+                // [seq, vocab] (or [1, vocab]); take the last row.
+                if (shape[1] != vocab) throw ShapeError(shape, vocab);
+                int last = shape[0] - 1;
+                var row = new T[vocab];
+                for (int v = 0; v < vocab; v++) row[v] = logits[last, v];
+                return new Vector<T>(row);
+            }
+            case 3:
+            {
+                // [batch(1), seq, vocab]; take the last position of the first (only) batch item.
+                if (shape[2] != vocab) throw ShapeError(shape, vocab);
+                int last = shape[1] - 1;
+                var row = new T[vocab];
+                for (int v = 0; v < vocab; v++) row[v] = logits[0, last, v];
+                return new Vector<T>(row);
+            }
+            default:
+                throw ShapeError(shape, vocab);
+        }
+    }
+
+    private static InvalidOperationException ShapeError(TensorShape shape, int vocab)
+    {
+        var dims = new int[shape.Length];
+        for (int i = 0; i < shape.Length; i++) dims[i] = shape[i];
+        return new InvalidOperationException(
+            $"Model logits shape [{string.Join(",", dims)}] is not a recognized " +
+            $"[vocab] / [seq, vocab] / [1, seq, vocab] layout with vocabulary size {vocab}.");
+    }
+}

--- a/src/AiDotNet.Serving/Engine/ReferencePagedAttentionRunner.cs
+++ b/src/AiDotNet.Serving/Engine/ReferencePagedAttentionRunner.cs
@@ -38,6 +38,10 @@ public sealed class ReferencePagedAttentionRunner<T> : ICausalLmRunner<T>, ICaus
     private readonly double[][][] _kStore;   // [layer][maxBlocks*blockSize][dModel]
     private readonly double[][][] _vStore;
 
+    /// <summary>Number of token positions the paged path has actually computed (prefill + decode). Lets tests
+    /// observe compute savings from prefix caching: a cached prefix is not recomputed.</summary>
+    public long PositionsComputed { get; private set; }
+
     /// <summary>Builds a reference paged runner with deterministic (seeded) weights.</summary>
     public ReferencePagedAttentionRunner(
         int vocabularySize, int dModel = 32, int numLayers = 2, int numHeads = 4, int ffnDim = 64,
@@ -149,6 +153,7 @@ public sealed class ReferencePagedAttentionRunner<T> : ICausalLmRunner<T>, ICaus
     // attending causally over the sequence's cached KV (positions 0..pos via the block table).
     private double[] ForwardPositionPaged(int token, int pos, System.Collections.Generic.IReadOnlyList<int> blockTable)
     {
+        PositionsComputed++;
         var x = AddPos(_embed[token], pos);
         for (int l = 0; l < _numLayers; l++)
         {

--- a/src/AiDotNet.Serving/Engine/ReferencePagedAttentionRunner.cs
+++ b/src/AiDotNet.Serving/Engine/ReferencePagedAttentionRunner.cs
@@ -1,0 +1,318 @@
+using System;
+using AiDotNet.Interfaces;
+using AiDotNet.Tensors.Helpers;
+using AiDotNet.Tensors.LinearAlgebra;
+
+namespace AiDotNet.Serving.Engine;
+
+/// <summary>
+/// A correct, CPU reference implementation of a paged-attention causal language model: a small decoder-only
+/// transformer that stores its key/value cache in the engine's paged blocks and decodes incrementally. It
+/// implements the fast-path <see cref="ICausalLmRunner{T}"/> (paged prefill / single-token decode over block
+/// tables) and, for verification, the universal <see cref="ICausalLmModel{T}"/> (full recompute). The two paths
+/// produce identical logits — which is exactly the correctness contract a production (GPU-backed) paged runner
+/// must satisfy.
+/// </summary>
+/// <remarks>
+/// <para><b>For Beginners:</b> this is the "real" fast-path model the serving engine was built for. Instead of
+/// re-reading the whole conversation each token, it keeps its memory (the KV cache) in the paged blocks the
+/// engine manages and only computes the new token's contribution each step. It is intentionally small and runs
+/// on the CPU so it is easy to read and to test; a production runner would do the same math on a GPU. Because it
+/// also offers a plain full-recompute path, tests can prove the paged path gives the same answer.</para>
+/// </remarks>
+/// <typeparam name="T">The numeric type exposed to the engine.</typeparam>
+public sealed class ReferencePagedAttentionRunner<T> : ICausalLmRunner<T>, ICausalLmModel<T>
+{
+    private readonly int _vocab, _dModel, _numLayers, _numHeads, _headDim, _ffnDim, _blockSize, _maxBlocks;
+    private readonly double _attnScale;
+
+    // Weights (row-major [outDim][inDim]).
+    private readonly double[][] _embed;      // [vocab][dModel]
+    private readonly double[][] _posEnc;     // [maxPos][dModel]
+    private readonly double[][][] _wq, _wk, _wv, _wo; // [layer][dModel][dModel]
+    private readonly double[][][] _w1;       // [layer][ffnDim][dModel]
+    private readonly double[][][] _w2;       // [layer][dModel][ffnDim]
+    private readonly double[][] _outProj;    // [vocab][dModel]
+
+    // Paged KV store, indexed by global slot = blockId * blockSize + slotInBlock.
+    private readonly double[][][] _kStore;   // [layer][maxBlocks*blockSize][dModel]
+    private readonly double[][][] _vStore;
+
+    /// <summary>Builds a reference paged runner with deterministic (seeded) weights.</summary>
+    public ReferencePagedAttentionRunner(
+        int vocabularySize, int dModel = 32, int numLayers = 2, int numHeads = 4, int ffnDim = 64,
+        int blockSize = 8, int maxBlocks = 256, int maxPositions = 2048, int? eosTokenId = null, int seed = 12345)
+    {
+        if (dModel % numHeads != 0) throw new ArgumentException("dModel must be divisible by numHeads.");
+        _vocab = vocabularySize;
+        _dModel = dModel;
+        _numLayers = numLayers;
+        _numHeads = numHeads;
+        _headDim = dModel / numHeads;
+        _ffnDim = ffnDim;
+        _blockSize = blockSize;
+        _maxBlocks = maxBlocks;
+        _attnScale = 1.0 / Math.Sqrt(_headDim);
+        EosTokenId = eosTokenId;
+
+        var rng = RandomHelper.CreateSeededRandom(seed);
+        _embed = Matrix(rng, vocabularySize, dModel);
+        _posEnc = SinusoidalPositions(maxPositions, dModel);
+        _wq = Layers(rng, numLayers, dModel, dModel);
+        _wk = Layers(rng, numLayers, dModel, dModel);
+        _wv = Layers(rng, numLayers, dModel, dModel);
+        _wo = Layers(rng, numLayers, dModel, dModel);
+        _w1 = Layers(rng, numLayers, ffnDim, dModel);
+        _w2 = Layers(rng, numLayers, dModel, ffnDim);
+        _outProj = Matrix(rng, vocabularySize, dModel);
+
+        _kStore = new double[numLayers][][];
+        _vStore = new double[numLayers][][];
+        int slots = maxBlocks * blockSize;
+        for (int l = 0; l < numLayers; l++)
+        {
+            _kStore[l] = new double[slots][];
+            _vStore[l] = new double[slots][];
+        }
+    }
+
+    // ---- Contract properties ----
+    /// <inheritdoc/>
+    public int VocabularySize => _vocab;
+    /// <inheritdoc/>
+    public int NumLayers => _numLayers;
+    /// <inheritdoc/>
+    public int NumKvHeads => _numHeads;
+    /// <inheritdoc/>
+    public int HeadDim => _headDim;
+    /// <inheritdoc/>
+    public int BlockSize => _blockSize;
+    /// <inheritdoc/>
+    public int? EosTokenId { get; }
+
+    // ---- Fast path: paged prefill / decode ----
+
+    /// <inheritdoc/>
+    public Tensor<T> Prefill(
+        System.Collections.Generic.IReadOnlyList<System.Collections.Generic.IReadOnlyList<int>> tokenIdsPerSequence,
+        System.Collections.Generic.IReadOnlyList<SequenceKvLayout> layouts,
+        System.Collections.Generic.IReadOnlyList<int> tokenCounts)
+    {
+        var result = new Tensor<T>(new[] { tokenIdsPerSequence.Count, _vocab });
+        var numOps = MathHelper.GetNumericOperations<T>();
+        for (int s = 0; s < tokenIdsPerSequence.Count; s++)
+        {
+            var tokens = tokenIdsPerSequence[s];
+            var blockTable = layouts[s].BlockTable;
+            int start = layouts[s].FilledTokens;
+            int end = start + tokenCounts[s];
+            double[] last = Array.Empty<double>();
+            for (int pos = start; pos < end; pos++)
+                last = ForwardPositionPaged(tokens[pos], pos, blockTable);
+            for (int v = 0; v < _vocab; v++) result[s, v] = numOps.FromDouble(last[v]);
+        }
+        return result;
+    }
+
+    /// <inheritdoc/>
+    public Tensor<T> DecodeStep(
+        System.Collections.Generic.IReadOnlyList<int> lastTokenIds,
+        System.Collections.Generic.IReadOnlyList<SequenceKvLayout> layouts)
+    {
+        var result = new Tensor<T>(new[] { lastTokenIds.Count, _vocab });
+        var numOps = MathHelper.GetNumericOperations<T>();
+        for (int s = 0; s < lastTokenIds.Count; s++)
+        {
+            int pos = layouts[s].FilledTokens; // the position of the token being computed this step
+            double[] logits = ForwardPositionPaged(lastTokenIds[s], pos, layouts[s].BlockTable);
+            for (int v = 0; v < _vocab; v++) result[s, v] = numOps.FromDouble(logits[v]);
+        }
+        return result;
+    }
+
+    /// <inheritdoc/>
+    public void CopyBlocks(System.Collections.Generic.IReadOnlyList<BlockCopy> copies)
+    {
+        foreach (var copy in copies)
+        {
+            int src = copy.Source * _blockSize, dst = copy.Destination * _blockSize;
+            for (int l = 0; l < _numLayers; l++)
+                for (int i = 0; i < _blockSize; i++)
+                {
+                    _kStore[l][dst + i] = _kStore[l][src + i] is { } k ? (double[])k.Clone() : null!;
+                    _vStore[l][dst + i] = _vStore[l][src + i] is { } v ? (double[])v.Clone() : null!;
+                }
+        }
+    }
+
+    // Computes logits for one token at absolute position `pos`, writing its KV into the paged store and
+    // attending causally over the sequence's cached KV (positions 0..pos via the block table).
+    private double[] ForwardPositionPaged(int token, int pos, System.Collections.Generic.IReadOnlyList<int> blockTable)
+    {
+        var x = AddPos(_embed[token], pos);
+        for (int l = 0; l < _numLayers; l++)
+        {
+            var q = MatVec(_wq[l], x);
+            var k = MatVec(_wk[l], x);
+            var v = MatVec(_wv[l], x);
+            int slot = GlobalSlot(blockTable, pos);
+            _kStore[l][slot] = k;
+            _vStore[l][slot] = v;
+
+            var attn = new double[_dModel];
+            for (int h = 0; h < _numHeads; h++)
+            {
+                int off = h * _headDim;
+                var scores = new double[pos + 1];
+                for (int j = 0; j <= pos; j++)
+                {
+                    int js = GlobalSlot(blockTable, j);
+                    scores[j] = DotHead(q, _kStore[l][js], off) * _attnScale;
+                }
+                Softmax(scores);
+                for (int j = 0; j <= pos; j++)
+                {
+                    int js = GlobalSlot(blockTable, j);
+                    var vj = _vStore[l][js];
+                    for (int d = 0; d < _headDim; d++) attn[off + d] += scores[j] * vj[off + d];
+                }
+            }
+            AddInPlace(x, MatVec(_wo[l], attn));  // attention residual
+            AddInPlace(x, FeedForward(l, x));     // FFN residual
+        }
+        return MatVec(_outProj, x);
+    }
+
+    // ---- Universal path: full recompute (reference for correctness) ----
+
+    /// <inheritdoc/>
+    public Tensor<T> ForwardLogits(Tensor<T> tokenIds)
+    {
+        var numOps = MathHelper.GetNumericOperations<T>();
+        int n = tokenIds.Shape[tokenIds.Shape.Length - 1];
+        var tokens = new int[n];
+        for (int i = 0; i < n; i++) tokens[i] = (int)Math.Round(numOps.ToDouble(tokenIds[0, i]));
+
+        // Fresh local KV (no paging): identical math, so identical logits to the paged path.
+        var kLocal = new double[_numLayers][][];
+        var vLocal = new double[_numLayers][][];
+        for (int l = 0; l < _numLayers; l++) { kLocal[l] = new double[n][]; vLocal[l] = new double[n][]; }
+
+        var result = new Tensor<T>(new[] { 1, n, _vocab });
+        for (int pos = 0; pos < n; pos++)
+        {
+            var x = AddPos(_embed[tokens[pos]], pos);
+            for (int l = 0; l < _numLayers; l++)
+            {
+                var q = MatVec(_wq[l], x);
+                kLocal[l][pos] = MatVec(_wk[l], x);
+                vLocal[l][pos] = MatVec(_wv[l], x);
+
+                var attn = new double[_dModel];
+                for (int h = 0; h < _numHeads; h++)
+                {
+                    int off = h * _headDim;
+                    var scores = new double[pos + 1];
+                    for (int j = 0; j <= pos; j++) scores[j] = DotHead(q, kLocal[l][j], off) * _attnScale;
+                    Softmax(scores);
+                    for (int j = 0; j <= pos; j++)
+                        for (int d = 0; d < _headDim; d++) attn[off + d] += scores[j] * vLocal[l][j][off + d];
+                }
+                AddInPlace(x, MatVec(_wo[l], attn));
+                AddInPlace(x, FeedForward(l, x));
+            }
+            var logits = MatVec(_outProj, x);
+            for (int v = 0; v < _vocab; v++) result[0, pos, v] = numOps.FromDouble(logits[v]);
+        }
+        return result;
+    }
+
+    // ---- Math helpers ----
+
+    private int GlobalSlot(System.Collections.Generic.IReadOnlyList<int> blockTable, int pos)
+        => blockTable[pos / _blockSize] * _blockSize + (pos % _blockSize);
+
+    private double[] FeedForward(int layer, double[] x)
+    {
+        var h = MatVec(_w1[layer], x);
+        for (int i = 0; i < h.Length; i++) h[i] = Math.Max(0.0, h[i]); // ReLU
+        return MatVec(_w2[layer], h);
+    }
+
+    private double[] AddPos(double[] embed, int pos)
+    {
+        var x = new double[_dModel];
+        var pe = _posEnc[pos % _posEnc.Length];
+        for (int i = 0; i < _dModel; i++) x[i] = embed[i] + pe[i];
+        return x;
+    }
+
+    // Dot product of one head's slice ([off, off+headDim)) of two dModel-length vectors.
+    private double DotHead(double[] a, double[] b, int off)
+    {
+        double s = 0.0;
+        for (int d = 0; d < _headDim; d++) s += a[off + d] * b[off + d];
+        return s;
+    }
+
+    private static double[] MatVec(double[][] w, double[] x)
+    {
+        var y = new double[w.Length];
+        for (int o = 0; o < w.Length; o++)
+        {
+            double s = 0.0;
+            var row = w[o];
+            for (int i = 0; i < row.Length; i++) s += row[i] * x[i];
+            y[o] = s;
+        }
+        return y;
+    }
+
+    private static void AddInPlace(double[] x, double[] delta)
+    {
+        for (int i = 0; i < x.Length; i++) x[i] += delta[i];
+    }
+
+    private static void Softmax(double[] s)
+    {
+        double max = double.NegativeInfinity;
+        for (int i = 0; i < s.Length; i++) if (s[i] > max) max = s[i];
+        double sum = 0.0;
+        for (int i = 0; i < s.Length; i++) { s[i] = Math.Exp(s[i] - max); sum += s[i]; }
+        if (sum <= 0.0) sum = 1.0;
+        for (int i = 0; i < s.Length; i++) s[i] /= sum;
+    }
+
+    private static double[][] Matrix(Random rng, int rows, int cols)
+    {
+        var m = new double[rows][];
+        for (int r = 0; r < rows; r++)
+        {
+            m[r] = new double[cols];
+            for (int c = 0; c < cols; c++) m[r][c] = (rng.NextDouble() - 0.5) * 0.2; // ~U(-0.1, 0.1)
+        }
+        return m;
+    }
+
+    private static double[][][] Layers(Random rng, int layers, int rows, int cols)
+    {
+        var w = new double[layers][][];
+        for (int l = 0; l < layers; l++) w[l] = Matrix(rng, rows, cols);
+        return w;
+    }
+
+    private double[][] SinusoidalPositions(int maxPos, int dModel)
+    {
+        var pe = new double[maxPos][];
+        for (int pos = 0; pos < maxPos; pos++)
+        {
+            pe[pos] = new double[dModel];
+            for (int i = 0; i < dModel; i++)
+            {
+                double angle = pos / Math.Pow(10000.0, (2.0 * (i / 2)) / dModel);
+                pe[pos][i] = (i % 2 == 0) ? Math.Sin(angle) : Math.Cos(angle);
+            }
+        }
+        return pe;
+    }
+}

--- a/src/AiDotNet.Serving/Engine/RequestOutput.cs
+++ b/src/AiDotNet.Serving/Engine/RequestOutput.cs
@@ -1,0 +1,71 @@
+namespace AiDotNet.Serving.Engine;
+
+/// <summary>
+/// One output stream (one <see cref="Sequence"/>) of a request as reported by the engine: the tokens produced
+/// so far and, once terminal, why it stopped. A request with <c>N &gt; 1</c> yields several of these, one per
+/// <see cref="SequenceIndex"/>.
+/// </summary>
+public sealed class CompletionOutput
+{
+    /// <summary>Creates a completion output snapshot.</summary>
+    public CompletionOutput(int sequenceIndex, IReadOnlyList<int> tokenIds, bool isFinished, string? finishReason)
+    {
+        SequenceIndex = sequenceIndex;
+        TokenIds = tokenIds ?? throw new ArgumentNullException(nameof(tokenIds));
+        IsFinished = isFinished;
+        FinishReason = finishReason;
+    }
+
+    /// <summary>0-based index of this output stream within its request.</summary>
+    public int SequenceIndex { get; }
+
+    /// <summary>Generated token ids for this stream (excludes the prompt).</summary>
+    public IReadOnlyList<int> TokenIds { get; }
+
+    /// <summary>Number of generated tokens.</summary>
+    public int Count => TokenIds.Count;
+
+    /// <summary>True once this stream reached a terminal state.</summary>
+    public bool IsFinished { get; }
+
+    /// <summary>Reason it stopped ("stop", "length", "abort"), or null while still running.</summary>
+    public string? FinishReason { get; }
+}
+
+/// <summary>
+/// The engine's per-step report for a request: its prompt, every output stream's progress, and whether the
+/// whole request is done. In streaming mode the engine emits one of these per step carrying newly appended
+/// tokens; in non-streaming mode a single terminal output carries the full result.
+/// </summary>
+/// <remarks>
+/// <para><b>For Beginners:</b> this is the engine's answer envelope for one request. Each engine step, the
+/// engine hands back a RequestOutput saying "here is what request X looks like now" — which tokens exist and
+/// whether it has finished. The front end turns these into the streamed chunks a client sees.</para>
+/// </remarks>
+public sealed class RequestOutput
+{
+    /// <summary>Creates a request output snapshot.</summary>
+    public RequestOutput(
+        string requestId,
+        IReadOnlyList<int> promptTokenIds,
+        IReadOnlyList<CompletionOutput> outputs,
+        bool isFinished)
+    {
+        RequestId = requestId ?? throw new ArgumentNullException(nameof(requestId));
+        PromptTokenIds = promptTokenIds ?? throw new ArgumentNullException(nameof(promptTokenIds));
+        Outputs = outputs ?? throw new ArgumentNullException(nameof(outputs));
+        IsFinished = isFinished;
+    }
+
+    /// <summary>Id of the request this output belongs to.</summary>
+    public string RequestId { get; }
+
+    /// <summary>The request's prompt token ids (for echo / logprob alignment).</summary>
+    public IReadOnlyList<int> PromptTokenIds { get; }
+
+    /// <summary>Per-stream outputs (one per sampled sequence).</summary>
+    public IReadOnlyList<CompletionOutput> Outputs { get; }
+
+    /// <summary>True once every output stream of the request has finished.</summary>
+    public bool IsFinished { get; }
+}

--- a/src/AiDotNet.Serving/Engine/SamplingParameters.cs
+++ b/src/AiDotNet.Serving/Engine/SamplingParameters.cs
@@ -1,0 +1,75 @@
+namespace AiDotNet.Serving.Engine;
+
+/// <summary>
+/// Per-request sampling / decoding parameters for the inference engine. This is the engine-level, numeric-
+/// type-agnostic view of "how to turn the model's next-token logits into a token" — it mirrors the knobs
+/// exposed by vLLM's <c>SamplingParams</c>, TGI, and the OpenAI API so an OpenAI-compatible front end can map
+/// onto it directly.
+/// </summary>
+/// <remarks>
+/// <para><b>For Beginners:</b> a language model outputs, for each step, a score ("logit") for every possible
+/// next token. These parameters control how a concrete token is picked from those scores: how random the
+/// choice is (<see cref="Temperature"/>), how much of the probability mass to consider
+/// (<see cref="TopP"/>/<see cref="TopK"/>), how to discourage repetition
+/// (<see cref="RepetitionPenalty"/>/<see cref="PresencePenalty"/>/<see cref="FrequencyPenalty"/>), and when
+/// to stop (<see cref="MaxTokens"/>/<see cref="StopTokenIds"/>).</para>
+/// <para>This type is deliberately immutable and independent of the model's numeric type &lt;T&gt;: the
+/// scheduler and KV-cache manager reason about token ids (ints) and these scalar knobs, while the typed model
+/// runner applies them to the actual logits.</para>
+/// </remarks>
+public sealed class SamplingParameters
+{
+    /// <summary>Softmax temperature. 0 means greedy (argmax) decoding; higher values are more random. Default 1.0.</summary>
+    public double Temperature { get; init; } = 1.0;
+
+    /// <summary>Nucleus (top-p) sampling: keep the smallest set of tokens whose cumulative probability ≥ this. 1.0 disables. Default 1.0.</summary>
+    public double TopP { get; init; } = 1.0;
+
+    /// <summary>Top-k sampling: keep only the k highest-probability tokens. 0 (or negative) disables. Default 0.</summary>
+    public int TopK { get; init; }
+
+    /// <summary>Min-p sampling: drop tokens whose probability is below this fraction of the max probability. 0 disables. Default 0.</summary>
+    public double MinP { get; init; }
+
+    /// <summary>Multiplicative penalty applied to logits of previously seen tokens (&gt;1 discourages repetition). Default 1.0.</summary>
+    public double RepetitionPenalty { get; init; } = 1.0;
+
+    /// <summary>Additive penalty subtracted from the logit of any token that has appeared at least once. Default 0.</summary>
+    public double PresencePenalty { get; init; }
+
+    /// <summary>Additive penalty scaled by how many times a token has appeared. Default 0.</summary>
+    public double FrequencyPenalty { get; init; }
+
+    /// <summary>Maximum number of tokens to GENERATE (excludes the prompt). Required to bound work; default 16.</summary>
+    public int MaxTokens { get; init; } = 16;
+
+    /// <summary>Minimum number of tokens to generate before a stop token / EOS can end the sequence. Default 0.</summary>
+    public int MinTokens { get; init; }
+
+    /// <summary>Token ids that, when generated, end the sequence (in addition to the model's EOS). Optional.</summary>
+    public IReadOnlyList<int>? StopTokenIds { get; init; }
+
+    /// <summary>If false, a generated EOS token does not stop the sequence (it is emitted like any other). Default true.</summary>
+    public bool IgnoreEos { get; init; }
+
+    /// <summary>Number of independent output sequences to sample for this request (parallel sampling). Default 1.</summary>
+    public int N { get; init; } = 1;
+
+    /// <summary>Optional RNG seed for reproducible sampling. Null = nondeterministic.</summary>
+    public int? Seed { get; init; }
+
+    /// <summary>Greedy decoding is used when temperature is ~0 (argmax); otherwise stochastic sampling.</summary>
+    public bool IsGreedy => Temperature <= 1e-6;
+
+    /// <summary>Validates the parameters, throwing <see cref="ArgumentException"/> on an out-of-range value.</summary>
+    public void Validate()
+    {
+        if (Temperature < 0) throw new ArgumentException("Temperature must be >= 0.", nameof(Temperature));
+        if (TopP is <= 0 or > 1) throw new ArgumentException("TopP must be in (0, 1].", nameof(TopP));
+        if (MinP is < 0 or > 1) throw new ArgumentException("MinP must be in [0, 1].", nameof(MinP));
+        if (RepetitionPenalty <= 0) throw new ArgumentException("RepetitionPenalty must be > 0.", nameof(RepetitionPenalty));
+        if (MaxTokens < 1) throw new ArgumentException("MaxTokens must be >= 1.", nameof(MaxTokens));
+        if (MinTokens < 0 || MinTokens > MaxTokens) throw new ArgumentException("MinTokens must be in [0, MaxTokens].", nameof(MinTokens));
+        if (N < 1) throw new ArgumentException("N must be >= 1.", nameof(N));
+    }
+}

--- a/src/AiDotNet.Serving/Engine/Sequence.cs
+++ b/src/AiDotNet.Serving/Engine/Sequence.cs
@@ -1,0 +1,79 @@
+namespace AiDotNet.Serving.Engine;
+
+/// <summary>
+/// The engine's mutable, per-output-stream generation state for a request: the running token list (prompt +
+/// generated), the lifecycle <see cref="SequenceState"/>, and the bookkeeping the scheduler and KV-cache
+/// manager need. A request with <c>N &gt; 1</c> produces N sequences that share the prompt prefix.
+/// </summary>
+/// <remarks>
+/// <para><b>For Beginners:</b> a Sequence is "one answer being written, one token at a time." It starts as the
+/// prompt tokens; each engine step may append one generated token. The engine tracks how far it has been
+/// processed (prefill vs decode), whether it is finished, and which KV-cache blocks hold its attention state.
+/// This class holds the logical state only — the physical KV blocks live in the KV-cache manager, keyed by
+/// <see cref="SequenceId"/>.</para>
+/// </remarks>
+public sealed class Sequence
+{
+    private readonly List<int> _tokenIds;
+
+    /// <summary>Creates a sequence from a request and its per-sequence index (0..N-1).</summary>
+    public Sequence(GenerationRequest request, int sequenceIndex)
+    {
+        Request = request ?? throw new ArgumentNullException(nameof(request));
+        SequenceIndex = sequenceIndex;
+        SequenceId = request.SamplingParameters.N > 1 ? $"{request.RequestId}#{sequenceIndex}" : request.RequestId;
+        _tokenIds = new List<int>(request.PromptTokenIds);
+        PromptLength = request.PromptLength;
+        State = SequenceState.Waiting;
+        NumComputedTokens = 0;
+    }
+
+    /// <summary>The originating request (prompt, sampling params).</summary>
+    public GenerationRequest Request { get; }
+
+    /// <summary>0-based index of this output stream within its request (for parallel sampling, N &gt; 1).</summary>
+    public int SequenceIndex { get; }
+
+    /// <summary>Unique id for this sequence's KV state (== RequestId when N == 1).</summary>
+    public string SequenceId { get; }
+
+    /// <summary>Number of prompt tokens (the prefill length).</summary>
+    public int PromptLength { get; }
+
+    /// <summary>Lifecycle state.</summary>
+    public SequenceState State { get; set; }
+
+    /// <summary>Reason a finished sequence stopped ("stop", "length", "abort"), or null while running.</summary>
+    public string? FinishReason { get; private set; }
+
+    /// <summary>All token ids so far: prompt followed by generated tokens.</summary>
+    public IReadOnlyList<int> TokenIds => _tokenIds;
+
+    /// <summary>Total tokens (prompt + generated).</summary>
+    public int Length => _tokenIds.Count;
+
+    /// <summary>Number of tokens generated so far (excludes the prompt).</summary>
+    public int GeneratedLength => _tokenIds.Count - PromptLength;
+
+    /// <summary>
+    /// Number of tokens whose KV has already been computed and cached. During prefill this advances from 0 to
+    /// <see cref="PromptLength"/> (possibly in chunks — chunked prefill); during decode it tracks Length - 1.
+    /// The number of tokens still needing computation this step is <see cref="Length"/> - this value.
+    /// </summary>
+    public int NumComputedTokens { get; set; }
+
+    /// <summary>True once prefill is complete and the sequence is in the decode phase (one token/step).</summary>
+    public bool IsInDecodePhase => NumComputedTokens >= PromptLength;
+
+    /// <summary>Appends a newly generated token id.</summary>
+    public void AppendToken(int tokenId) => _tokenIds.Add(tokenId);
+
+    /// <summary>Marks the sequence finished with the given terminal state and reason.</summary>
+    public void Finish(SequenceState terminalState, string reason)
+    {
+        if (!terminalState.IsFinished())
+            throw new ArgumentException("Finish requires a terminal state.", nameof(terminalState));
+        State = terminalState;
+        FinishReason = reason;
+    }
+}

--- a/src/AiDotNet.Serving/Engine/SequenceState.cs
+++ b/src/AiDotNet.Serving/Engine/SequenceState.cs
@@ -1,0 +1,40 @@
+namespace AiDotNet.Serving.Engine;
+
+/// <summary>
+/// Lifecycle state of a <see cref="Sequence"/> inside the inference engine. Mirrors the states an in-flight
+/// batching engine (vLLM, TGI) tracks so the scheduler can move sequences between the waiting queue, the
+/// running batch, and (under memory pressure) CPU-swapped or preempted storage.
+/// </summary>
+public enum SequenceState
+{
+    /// <summary>Admitted but not yet scheduled — waiting for KV-cache blocks / a batch slot.</summary>
+    Waiting,
+
+    /// <summary>Currently in the running batch and being decoded each engine step.</summary>
+    Running,
+
+    /// <summary>Preempted under KV memory pressure and swapped to CPU (blocks can be swapped back in).</summary>
+    Swapped,
+
+    /// <summary>Preempted by RECOMPUTE — its KV was dropped and will be recomputed from tokens when rescheduled.</summary>
+    Preempted,
+
+    /// <summary>Finished because a stop token / EOS was produced.</summary>
+    FinishedStopped,
+
+    /// <summary>Finished because it reached its max token budget.</summary>
+    FinishedLengthCapped,
+
+    /// <summary>Finished because the caller aborted it (or the request was cancelled).</summary>
+    FinishedAborted,
+}
+
+/// <summary>Convenience helpers for <see cref="SequenceState"/>.</summary>
+public static class SequenceStateExtensions
+{
+    /// <summary>True for any terminal state (finished/aborted).</summary>
+    public static bool IsFinished(this SequenceState state)
+        => state is SequenceState.FinishedStopped
+            or SequenceState.FinishedLengthCapped
+            or SequenceState.FinishedAborted;
+}

--- a/src/AiDotNet.Serving/Engine/ServingConfigMapper.cs
+++ b/src/AiDotNet.Serving/Engine/ServingConfigMapper.cs
@@ -1,0 +1,62 @@
+using System;
+using AiDotNet.Configuration;
+
+namespace AiDotNet.Serving.Engine;
+
+/// <summary>
+/// Translates the library-wide <see cref="InferenceOptimizationConfig"/> (the facade builder's
+/// <c>ConfigureInferenceOptimizations</c> surface) into concrete <see cref="EngineOptions"/> for the serving
+/// engine. This is the bridge that makes "vLLM speed by default" real: a beginner sets nothing and the engine
+/// is configured from the same defaults the rest of the library already uses.
+/// </summary>
+/// <remarks>
+/// <para><b>For Beginners:</b> you configure inference once, in one place (<c>ConfigureInferenceOptimizations</c>),
+/// and every part of the library — including this serving engine — reads those settings. This class does the
+/// translation so you never hand-tune the engine's KV pool or batch limits.</para>
+/// </remarks>
+public static class ServingConfigMapper
+{
+    /// <summary>
+    /// Builds engine options from an inference-optimization config. When no config is supplied,
+    /// <see cref="InferenceOptimizationConfig.Default"/> is used.
+    /// </summary>
+    /// <param name="config">The inference config (null ⇒ defaults).</param>
+    /// <param name="eosTokenId">The model/tokenizer EOS token id, if known.</param>
+    /// <param name="maxContextTokens">Assumed maximum context length used to size the KV block pool so the
+    /// full batch fits at that length. Defaults to 4096.</param>
+    public static EngineOptions ToEngineOptions(
+        InferenceOptimizationConfig? config,
+        int? eosTokenId = null,
+        int maxContextTokens = 4096)
+    {
+        var c = config ?? InferenceOptimizationConfig.Default;
+        if (maxContextTokens < 1) throw new ArgumentOutOfRangeException(nameof(maxContextTokens));
+
+        int blockSize = c.PagedKVCacheBlockSize >= 1 ? c.PagedKVCacheBlockSize : 16;
+        int maxSequences = c.EnableBatching ? Math.Max(1, c.MaxBatchSize) : 1;
+
+        // Size the block pool so the whole batch can reach the assumed context length, plus a generation slot.
+        int blocksPerSequence = (maxContextTokens + blockSize - 1) / blockSize + 1;
+        int numKvBlocks = Math.Max(blocksPerSequence, checked(maxSequences * blocksPerSequence));
+
+        // Per-step compute budget: enough for one full-context prefill, or one decode token per running seq.
+        int maxBatchedTokens = Math.Max(maxContextTokens, maxSequences);
+
+        return new EngineOptions
+        {
+            BlockSize = blockSize,
+            MaxNumSequences = maxSequences,
+            NumKvBlocks = numKvBlocks,
+            MaxBatchedTokens = maxBatchedTokens,
+            EosTokenId = eosTokenId,
+        };
+    }
+
+    /// <summary>True if the config asks for speculative decoding.</summary>
+    public static bool IsSpeculativeEnabled(InferenceOptimizationConfig? config)
+        => (config ?? InferenceOptimizationConfig.Default).EnableSpeculativeDecoding;
+
+    /// <summary>The configured speculation depth (draft tokens per round), floored at 1.</summary>
+    public static int SpeculationDepth(InferenceOptimizationConfig? config)
+        => Math.Max(1, (config ?? InferenceOptimizationConfig.Default).SpeculationDepth);
+}

--- a/src/AiDotNet.Serving/Engine/ServingConfigMapper.cs
+++ b/src/AiDotNet.Serving/Engine/ServingConfigMapper.cs
@@ -39,6 +39,11 @@ public static class ServingConfigMapper
         int blocksPerSequence = (maxContextTokens + blockSize - 1) / blockSize + 1;
         int numKvBlocks = Math.Max(blocksPerSequence, checked(maxSequences * blocksPerSequence));
 
+        // Quantized KV takes less memory per token, so the same budget holds more blocks (higher concurrency /
+        // longer contexts). Int8 ≈ half the bytes of fp16 ⇒ ~2× the block capacity.
+        int quantFactor = c.KVCacheQuantization == KVCacheQuantizationMode.Int8 ? 2 : 1;
+        numKvBlocks = checked(numKvBlocks * quantFactor);
+
         // Per-step compute budget: enough for one full-context prefill, or one decode token per running seq.
         int maxBatchedTokens = Math.Max(maxContextTokens, maxSequences);
 
@@ -49,6 +54,7 @@ public static class ServingConfigMapper
             NumKvBlocks = numKvBlocks,
             MaxBatchedTokens = maxBatchedTokens,
             EosTokenId = eosTokenId,
+            KvCacheQuantization = c.KVCacheQuantization,
         };
     }
 

--- a/src/AiDotNet.Serving/Engine/ServingConfigMapper.cs
+++ b/src/AiDotNet.Serving/Engine/ServingConfigMapper.cs
@@ -58,6 +58,45 @@ public static class ServingConfigMapper
         };
     }
 
+    /// <summary>
+    /// Bytes one KV-cache block occupies for a model with the given attention shape: both keys and values,
+    /// across all layers, for every token slot in the block, at the KV storage precision (Int8 = 1 byte,
+    /// otherwise fp16 = 2 bytes).
+    /// </summary>
+    public static long KvBytesPerBlock(
+        int numLayers, int numKvHeads, int headDim, int blockSize, KVCacheQuantizationMode quantization)
+    {
+        int bytesPerElement = quantization == KVCacheQuantizationMode.Int8 ? 1 : 2;
+        return 2L * numLayers * numKvHeads * headDim * blockSize * bytesPerElement; // 2 = keys + values
+    }
+
+    /// <summary>
+    /// Builds engine options for a paged model of known attention shape, sizing the KV block pool <b>precisely</b>
+    /// from <see cref="InferenceOptimizationConfig.KVCacheMaxSizeMB"/> and the real per-block byte cost (rather
+    /// than the shape-agnostic nominal estimate). Quantized KV therefore fits proportionally more blocks.
+    /// </summary>
+    public static EngineOptions ToEngineOptionsForPagedModel(
+        InferenceOptimizationConfig? config, int? eosTokenId,
+        int numLayers, int numKvHeads, int headDim, int blockSize)
+    {
+        var c = config ?? InferenceOptimizationConfig.Default;
+        long budgetBytes = (long)Math.Max(1, c.KVCacheMaxSizeMB) * 1024 * 1024;
+        long bytesPerBlock = KvBytesPerBlock(numLayers, numKvHeads, headDim, blockSize, c.KVCacheQuantization);
+        long blocks = Math.Max(8, budgetBytes / Math.Max(1, bytesPerBlock)); // at least a handful of blocks
+        int numKvBlocks = (int)Math.Min(blocks, int.MaxValue);
+
+        int maxSequences = c.EnableBatching ? Math.Max(1, c.MaxBatchSize) : 1;
+        return new EngineOptions
+        {
+            BlockSize = blockSize,
+            MaxNumSequences = maxSequences,
+            NumKvBlocks = numKvBlocks,
+            MaxBatchedTokens = Math.Max(blockSize * numKvBlocks / Math.Max(1, maxSequences), maxSequences),
+            EosTokenId = eosTokenId,
+            KvCacheQuantization = c.KVCacheQuantization,
+        };
+    }
+
     /// <summary>True if the config asks for speculative decoding.</summary>
     public static bool IsSpeculativeEnabled(InferenceOptimizationConfig? config)
         => (config ?? InferenceOptimizationConfig.Default).EnableSpeculativeDecoding;

--- a/src/AiDotNet.Serving/Engine/ServingRunnerFactory.cs
+++ b/src/AiDotNet.Serving/Engine/ServingRunnerFactory.cs
@@ -1,5 +1,6 @@
 using System;
 using AiDotNet.Interfaces;
+using AiDotNet.Tensors.LinearAlgebra;
 
 namespace AiDotNet.Serving.Engine;
 
@@ -28,11 +29,17 @@ public static class ServingRunnerFactory
     }
 
     /// <summary>
-    /// Selects a runner for <paramref name="model"/>. A model advertising the paged fast path
-    /// (<see cref="ICausalLmRunner{T}"/>) is driven incrementally; any <see cref="ICausalLmModel{T}"/> is driven
-    /// by the recompute fallback. Throws a clear error for models that are not text generators.
+    /// Selects a runner for <paramref name="model"/>. Preference order: the paged fast path
+    /// (<see cref="ICausalLmRunner{T}"/>), then the recompute fallback over <see cref="ICausalLmModel{T}"/>, then
+    /// — when <paramref name="vocabularySize"/> is supplied — a Predict-based adapter over any
+    /// <see cref="IFullModel{T, TInput, TOutput}"/> whose forward output is vocabulary-width. Throws a clear
+    /// error for models that are not text generators.
     /// </summary>
-    public static Selection<T> Create<T>(object model)
+    /// <param name="model">The model to serve.</param>
+    /// <param name="vocabularySize">Vocabulary size, enabling the Predict-adapter fallback for models that do
+    /// not implement <see cref="ICausalLmModel{T}"/>. Ignored when the model implements a capability directly.</param>
+    /// <param name="eosTokenId">EOS token id for the Predict-adapter fallback.</param>
+    public static Selection<T> Create<T>(object model, int? vocabularySize = null, int? eosTokenId = null)
     {
         if (model is null) throw new ArgumentNullException(nameof(model));
 
@@ -42,11 +49,19 @@ public static class ServingRunnerFactory
         if (model is ICausalLmModel<T> lm)
             return new Selection<T>(new RecomputeModelRunner<T>(lm), lm.EosTokenId);
 
+        // Predict-adapter fallback: any full model whose forward produces vocab-width logits, given its vocab.
+        if (vocabularySize is { } vocab && model is IFullModel<T, Tensor<T>, Tensor<T>> full)
+        {
+            var adapter = new PredictCausalLmAdapter<T>(full.Predict, vocab, eosTokenId);
+            return new Selection<T>(new RecomputeModelRunner<T>(adapter), eosTokenId);
+        }
+
         throw new NotSupportedException(
             $"Model type '{model.GetType().Name}' cannot generate text: it implements neither the paged " +
             $"ICausalLmRunner<{typeof(T).Name}> fast path nor the ICausalLmModel<{typeof(T).Name}> capability. " +
-            "Implement ICausalLmModel (expose VocabularySize, EosTokenId, and ForwardLogits) to enable " +
-            "Generate()/Serve().");
+            $"Implement ICausalLmModel (VocabularySize, EosTokenId, ForwardLogits), or — if it is an " +
+            $"IFullModel<{typeof(T).Name}, Tensor, Tensor> that outputs vocab-width logits — supply a vocabulary " +
+            "size to use the Predict-based adapter.");
     }
 
     // The paged fast path carries EOS on the model side, not the runner; a model can implement both. When it

--- a/src/AiDotNet.Serving/Engine/ServingRunnerFactory.cs
+++ b/src/AiDotNet.Serving/Engine/ServingRunnerFactory.cs
@@ -1,0 +1,56 @@
+using System;
+using AiDotNet.Interfaces;
+
+namespace AiDotNet.Serving.Engine;
+
+/// <summary>
+/// Chooses the right <see cref="IServingModelRunner{T}"/> for a model, honoring the engine's layered design:
+/// the paged fast path when a model advertises it, otherwise the universal recompute path over any
+/// <see cref="ICausalLmModel{T}"/>. This is the seam the facade uses so a beginner never picks a runner.
+/// </summary>
+public static class ServingRunnerFactory
+{
+    /// <summary>The runner plus the EOS token id it implies (used to configure engine stop conditions).</summary>
+    public readonly struct Selection<T>
+    {
+        /// <summary>Creates a selection.</summary>
+        public Selection(IServingModelRunner<T> runner, int? eosTokenId)
+        {
+            Runner = runner;
+            EosTokenId = eosTokenId;
+        }
+
+        /// <summary>The chosen model runner.</summary>
+        public IServingModelRunner<T> Runner { get; }
+
+        /// <summary>The model's EOS token id, if any.</summary>
+        public int? EosTokenId { get; }
+    }
+
+    /// <summary>
+    /// Selects a runner for <paramref name="model"/>. A model advertising the paged fast path
+    /// (<see cref="ICausalLmRunner{T}"/>) is driven incrementally; any <see cref="ICausalLmModel{T}"/> is driven
+    /// by the recompute fallback. Throws a clear error for models that are not text generators.
+    /// </summary>
+    public static Selection<T> Create<T>(object model)
+    {
+        if (model is null) throw new ArgumentNullException(nameof(model));
+
+        if (model is ICausalLmRunner<T> paged)
+            return new Selection<T>(new PagedRunnerAdapter<T>(paged), EosFromRunner(paged));
+
+        if (model is ICausalLmModel<T> lm)
+            return new Selection<T>(new RecomputeModelRunner<T>(lm), lm.EosTokenId);
+
+        throw new NotSupportedException(
+            $"Model type '{model.GetType().Name}' cannot generate text: it implements neither the paged " +
+            $"ICausalLmRunner<{typeof(T).Name}> fast path nor the ICausalLmModel<{typeof(T).Name}> capability. " +
+            "Implement ICausalLmModel (expose VocabularySize, EosTokenId, and ForwardLogits) to enable " +
+            "Generate()/Serve().");
+    }
+
+    // The paged fast path carries EOS on the model side, not the runner; a model can implement both. When it
+    // does, prefer the model's declared EOS.
+    private static int? EosFromRunner<T>(ICausalLmRunner<T> runner)
+        => runner is ICausalLmModel<T> lm ? lm.EosTokenId : null;
+}

--- a/src/AiDotNet.Serving/Engine/Speculative/ISpeculativeDrafter.cs
+++ b/src/AiDotNet.Serving/Engine/Speculative/ISpeculativeDrafter.cs
@@ -1,0 +1,24 @@
+using System.Collections.Generic;
+
+namespace AiDotNet.Serving.Engine.Speculative;
+
+/// <summary>
+/// Proposes candidate continuation tokens ("draft") that the target model then verifies in a single forward
+/// pass. A good drafter is cheap and often right; because verification always corrects it, a drafter can never
+/// change the generated output — only the speed. This is the pluggable draft source of speculative decoding.
+/// </summary>
+/// <remarks>
+/// <para><b>For Beginners:</b> speculative decoding speeds up generation by <i>guessing</i> several next tokens
+/// with something cheap, then letting the real (expensive) model check all the guesses at once. This interface
+/// is the guesser. If the guesses are good, the model confirms many tokens in one step instead of one; if they
+/// are wrong, the model's own answer is used instead — so the result is always exactly what the model would
+/// have produced anyway.</para>
+/// </remarks>
+public interface ISpeculativeDrafter
+{
+    /// <summary>
+    /// Proposes up to <paramref name="maxDraftTokens"/> continuation tokens for the given context. May return
+    /// fewer (including none) when the drafter has no confident guess.
+    /// </summary>
+    IReadOnlyList<int> Draft(IReadOnlyList<int> contextTokenIds, int maxDraftTokens);
+}

--- a/src/AiDotNet.Serving/Engine/Speculative/PromptLookupDrafter.cs
+++ b/src/AiDotNet.Serving/Engine/Speculative/PromptLookupDrafter.cs
@@ -1,0 +1,80 @@
+using System;
+using System.Collections.Generic;
+
+namespace AiDotNet.Serving.Engine.Speculative;
+
+/// <summary>
+/// A model-free drafter (prompt-lookup / n-gram decoding, Saxena 2023): it proposes the continuation by finding
+/// the most recent earlier occurrence of the current trailing n-gram in the context and copying the tokens that
+/// followed it. It needs no second model, so it delivers speculative speedups "for free" on repetitive text —
+/// code, structured output, summarization that echoes the source.
+/// </summary>
+/// <remarks>
+/// <para><b>For Beginners:</b> lots of generated text repeats phrases that already appeared (variable names, a
+/// quoted sentence, boilerplate). This drafter simply says "last time I saw these few tokens, these came next —
+/// let's guess those again." It costs almost nothing and is often right on repetitive content; when it is
+/// wrong, the model corrects it, so quality never suffers.</para>
+/// </remarks>
+public sealed class PromptLookupDrafter : ISpeculativeDrafter
+{
+    private readonly int _maxNgram;
+    private readonly int _minNgram;
+
+    /// <summary>Creates a prompt-lookup drafter.</summary>
+    /// <param name="maxNgram">Longest trailing n-gram to match (tried first for higher-confidence guesses).</param>
+    /// <param name="minNgram">Shortest trailing n-gram to fall back to.</param>
+    public PromptLookupDrafter(int maxNgram = 3, int minNgram = 1)
+    {
+        if (minNgram < 1) throw new ArgumentOutOfRangeException(nameof(minNgram), "minNgram must be >= 1.");
+        if (maxNgram < minNgram) throw new ArgumentOutOfRangeException(nameof(maxNgram), "maxNgram must be >= minNgram.");
+        _maxNgram = maxNgram;
+        _minNgram = minNgram;
+    }
+
+    /// <inheritdoc/>
+    public IReadOnlyList<int> Draft(IReadOnlyList<int> contextTokenIds, int maxDraftTokens)
+    {
+        if (contextTokenIds is null) throw new ArgumentNullException(nameof(contextTokenIds));
+        if (maxDraftTokens < 1) return Array.Empty<int>();
+
+        int len = contextTokenIds.Count;
+        // Try the longest n-gram first: a longer match is a more specific (more confident) prediction.
+        for (int n = Math.Min(_maxNgram, len - 1); n >= _minNgram; n--)
+        {
+            var draft = TryMatch(contextTokenIds, n, maxDraftTokens);
+            if (draft.Count > 0) return draft;
+        }
+        return Array.Empty<int>();
+    }
+
+    private static IReadOnlyList<int> TryMatch(IReadOnlyList<int> ctx, int n, int maxDraftTokens)
+    {
+        int len = ctx.Count;
+        // Search backwards for the most recent prior occurrence of the trailing n-gram ctx[len-n .. len-1].
+        // The candidate window must end before the trailing n-gram itself (start + n <= len - 1) so we copy
+        // tokens that genuinely followed an earlier occurrence.
+        for (int start = len - n - 1; start >= 0; start--)
+        {
+            if (!MatchesTrailing(ctx, start, n)) continue;
+
+            int followStart = start + n;
+            int available = (len - 1) - followStart + 1; // tokens between the match and the trailing n-gram
+            int take = Math.Min(maxDraftTokens, available);
+            if (take <= 0) continue;
+
+            var draft = new int[take];
+            for (int i = 0; i < take; i++) draft[i] = ctx[followStart + i];
+            return draft;
+        }
+        return Array.Empty<int>();
+    }
+
+    // True if the n tokens starting at `start` equal the trailing n tokens ctx[len-n .. len-1].
+    private static bool MatchesTrailing(IReadOnlyList<int> ctx, int start, int n)
+    {
+        int tail = ctx.Count - n;
+        for (int i = 0; i < n; i++)
+            if (ctx[start + i] != ctx[tail + i]) return false;
+        return true;
+    }
+}

--- a/src/AiDotNet.Serving/Engine/Speculative/SpeculativeGenerator.cs
+++ b/src/AiDotNet.Serving/Engine/Speculative/SpeculativeGenerator.cs
@@ -6,6 +6,8 @@ using AiDotNet.Tensors.LinearAlgebra;
 
 namespace AiDotNet.Serving.Engine.Speculative;
 
+// RandomHelper (AiDotNet.Tensors.Helpers) provides seeded/secure RNG; MathHelper provides numeric ops.
+
 /// <summary>Counters describing how effective speculation was over a generation run.</summary>
 public sealed class SpeculationStatistics
 {
@@ -32,11 +34,12 @@ public sealed class SpeculationStatistics
 }
 
 /// <summary>
-/// Greedy speculative decoding over any <see cref="ICausalLmModel{T}"/> (Leviathan 2023 / Chen 2023): a cheap
+/// Speculative decoding over any <see cref="ICausalLmModel{T}"/> (Leviathan 2023 / Chen 2023): a cheap
 /// <see cref="ISpeculativeDrafter"/> proposes several next tokens, the target model verifies them all in one
-/// forward pass (its logits already cover every drafted position), and the longest correct prefix is accepted —
-/// plus one guaranteed correction or bonus token per round. The emitted sequence is <b>bit-identical</b> to
-/// plain greedy decoding; only the number of expensive target passes drops.
+/// forward pass (its logits already cover every drafted position), and each is accepted or corrected — plus one
+/// guaranteed bonus token per fully-accepted round. Supports both greedy decoding (output <b>bit-identical</b>
+/// to plain greedy) and stochastic sampling (the emitted-token distribution is provably <b>exactly</b> the
+/// target's sampling distribution). Either way only the number of expensive target passes drops.
 /// </summary>
 /// <remarks>
 /// <para><b>For Beginners:</b> normally a model makes one token per (slow) step. Here a fast guesser proposes,
@@ -79,15 +82,14 @@ public sealed class SpeculativeGenerator<T>
         if (promptTokenIds.Count == 0) throw new ArgumentException("Prompt must be non-empty.", nameof(promptTokenIds));
         if (sampling is null) throw new ArgumentNullException(nameof(sampling));
         sampling.Validate();
-        if (!sampling.IsGreedy)
-            throw new NotSupportedException(
-                "SpeculativeGenerator currently supports greedy decoding only (temperature 0). Use the " +
-                "standard generation path for stochastic sampling.");
 
         statistics = new SpeculationStatistics();
         var context = new List<int>(promptTokenIds);
         var generated = new List<int>();
         int vocab = _target.VocabularySize;
+        var rng = sampling.Seed is { } seed
+            ? RandomHelper.CreateSeededRandom(seed)
+            : RandomHelper.CreateSecureRandom();
 
         while (generated.Count < sampling.MaxTokens)
         {
@@ -103,36 +105,87 @@ public sealed class SpeculativeGenerator<T>
             statistics.TargetForwardPasses++;
 
             int basePos = context.Count - 1; // position whose logits predict the first continuation token
-            bool stopped = false;
-
-            // Accept the longest prefix of the draft that matches the target's greedy choice.
-            int i = 0;
-            for (; i < d; i++)
-            {
-                int targetToken = ArgMaxAt(logits, basePos + i, vocab);
-                if (targetToken != draft[i])
-                {
-                    // Reject here: emit the target's own token instead, then end this round.
-                    if (Emit(targetToken, context, generated, statistics, sampling)) stopped = true;
-                    break;
-                }
-                statistics.AcceptedTokens++;
-                if (Emit(draft[i], context, generated, statistics, sampling)) { stopped = true; i++; break; }
-            }
-
-            if (!stopped && i == d)
-            {
-                // Whole draft accepted (or empty): also emit the bonus token the target predicts after it.
-                int bonus = ArgMaxAt(logits, basePos + d, vocab);
-                Emit(bonus, context, generated, statistics, sampling);
-                // A stop here simply ends the outer loop on the next check.
-                if (IsStop(bonus, generated, sampling)) stopped = true;
-            }
+            bool stopped = sampling.IsGreedy
+                ? GreedyRound(logits, draft, basePos, vocab, context, generated, statistics, sampling)
+                : StochasticRound(logits, draft, basePos, vocab, context, generated, statistics, sampling, rng);
 
             if (stopped) break;
         }
 
         return generated;
+    }
+
+    // Greedy: accept a draft token iff it equals the target's argmax; emit the target's argmax on rejection,
+    // plus a bonus argmax when the whole draft is accepted. Output equals plain greedy decoding.
+    private bool GreedyRound(
+        Tensor<T> logits, IReadOnlyList<int> draft, int basePos, int vocab,
+        List<int> context, List<int> generated, SpeculationStatistics stats, SamplingParameters sampling)
+    {
+        int d = draft.Count;
+        int i = 0;
+        for (; i < d; i++)
+        {
+            int targetToken = ArgMaxAt(logits, basePos + i, vocab);
+            if (targetToken != draft[i])
+            {
+                Emit(targetToken, context, generated, stats, sampling);
+                return generated.Count >= sampling.MaxTokens || IsStop(targetToken, generated, sampling);
+            }
+            stats.AcceptedTokens++;
+            if (Emit(draft[i], context, generated, stats, sampling)) return true;
+        }
+        int bonus = ArgMaxAt(logits, basePos + d, vocab);
+        Emit(bonus, context, generated, stats, sampling);
+        return generated.Count >= sampling.MaxTokens || IsStop(bonus, generated, sampling);
+    }
+
+    // Stochastic speculative sampling (Leviathan 2023 / Chen 2023): with a point-mass drafter, accept draft
+    // token x with probability p(x) under the target's sampling distribution; on rejection sample from the
+    // residual (p with x removed, renormalized); emit a bonus draw from p when the whole draft is accepted. The
+    // emitted-token distribution is exactly the target's sampling distribution.
+    private bool StochasticRound(
+        Tensor<T> logits, IReadOnlyList<int> draft, int basePos, int vocab,
+        List<int> context, List<int> generated, SpeculationStatistics stats, SamplingParameters sampling, Random rng)
+    {
+        int d = draft.Count;
+        int i = 0;
+        for (; i < d; i++)
+        {
+            var p = LogitsSampler.ComputeProbabilities(RowVector(logits, basePos + i, vocab), sampling, context);
+            double acceptProb = p[draft[i]];
+            if (rng.NextDouble() < acceptProb)
+            {
+                stats.AcceptedTokens++;
+                if (Emit(draft[i], context, generated, stats, sampling)) return true;
+            }
+            else
+            {
+                var residual = (double[])p.Clone();
+                residual[draft[i]] = 0.0;
+                int replacement = LogitsSampler.SampleFromDistribution(residual, rng);
+                Emit(replacement, context, generated, stats, sampling);
+                return generated.Count >= sampling.MaxTokens || IsStop(replacement, generated, sampling);
+            }
+        }
+        var bonusP = LogitsSampler.ComputeProbabilities(RowVector(logits, basePos + d, vocab), sampling, context);
+        int bonus = LogitsSampler.SampleFromDistribution(bonusP, rng);
+        Emit(bonus, context, generated, stats, sampling);
+        return generated.Count >= sampling.MaxTokens || IsStop(bonus, generated, sampling);
+    }
+
+    // Extracts the vocabulary logits row at a sequence position as a Vector, tolerating [seq,vocab] / [1,seq,vocab].
+    private static Vector<T> RowVector(Tensor<T> logits, int position, int vocab)
+    {
+        var shape = logits.Shape;
+        var row = new T[vocab];
+        if (shape.Length == 2)
+            for (int v = 0; v < vocab; v++) row[v] = logits[position, v];
+        else if (shape.Length == 3)
+            for (int v = 0; v < vocab; v++) row[v] = logits[0, position, v];
+        else
+            throw new InvalidOperationException(
+                $"Speculative verification needs multi-position logits ([seq, vocab] or [1, seq, vocab]); got rank {shape.Length}.");
+        return new Vector<T>(row);
     }
 
     /// <summary>Convenience overload without statistics.</summary>

--- a/src/AiDotNet.Serving/Engine/Speculative/SpeculativeGenerator.cs
+++ b/src/AiDotNet.Serving/Engine/Speculative/SpeculativeGenerator.cs
@@ -1,0 +1,189 @@
+using System;
+using System.Collections.Generic;
+using AiDotNet.Interfaces;
+using AiDotNet.Tensors.Helpers;
+using AiDotNet.Tensors.LinearAlgebra;
+
+namespace AiDotNet.Serving.Engine.Speculative;
+
+/// <summary>Counters describing how effective speculation was over a generation run.</summary>
+public sealed class SpeculationStatistics
+{
+    /// <summary>Total draft tokens proposed by the drafter.</summary>
+    public long DraftedTokens { get; internal set; }
+
+    /// <summary>Draft tokens accepted by the target (matched its greedy choice).</summary>
+    public long AcceptedTokens { get; internal set; }
+
+    /// <summary>Total tokens emitted (accepted drafts + correction/bonus tokens).</summary>
+    public long GeneratedTokens { get; internal set; }
+
+    /// <summary>Number of target-model forward passes performed (one per speculation round).</summary>
+    public long TargetForwardPasses { get; internal set; }
+
+    /// <summary>Fraction of drafted tokens that were accepted (0..1); 0 when nothing was drafted.</summary>
+    public double AcceptanceRate => DraftedTokens == 0 ? 0.0 : (double)AcceptedTokens / DraftedTokens;
+
+    /// <summary>
+    /// Average tokens emitted per target forward pass. Greater than 1 means speculation paid off (each
+    /// expensive target pass produced more than one token).
+    /// </summary>
+    public double TokensPerForwardPass => TargetForwardPasses == 0 ? 0.0 : (double)GeneratedTokens / TargetForwardPasses;
+}
+
+/// <summary>
+/// Greedy speculative decoding over any <see cref="ICausalLmModel{T}"/> (Leviathan 2023 / Chen 2023): a cheap
+/// <see cref="ISpeculativeDrafter"/> proposes several next tokens, the target model verifies them all in one
+/// forward pass (its logits already cover every drafted position), and the longest correct prefix is accepted —
+/// plus one guaranteed correction or bonus token per round. The emitted sequence is <b>bit-identical</b> to
+/// plain greedy decoding; only the number of expensive target passes drops.
+/// </summary>
+/// <remarks>
+/// <para><b>For Beginners:</b> normally a model makes one token per (slow) step. Here a fast guesser proposes,
+/// say, 4 tokens; the slow model checks all 4 at once. Every guess the model agrees with is kept for free, and
+/// the model always contributes at least one token itself — so you can get several tokens out of a single slow
+/// step, with exactly the same result you would have gotten one-at-a-time.</para>
+/// </remarks>
+/// <typeparam name="T">The model's numeric type.</typeparam>
+public sealed class SpeculativeGenerator<T>
+{
+    private readonly ICausalLmModel<T> _target;
+    private readonly ISpeculativeDrafter _drafter;
+    private readonly int _maxDraftTokens;
+
+    /// <summary>Creates a greedy speculative generator.</summary>
+    /// <param name="target">The target (full-accuracy) model.</param>
+    /// <param name="drafter">The draft source. Defaults to a model-free <see cref="PromptLookupDrafter"/>.</param>
+    /// <param name="maxDraftTokens">Tokens proposed per round (the speculation length). Default 4.</param>
+    public SpeculativeGenerator(ICausalLmModel<T> target, ISpeculativeDrafter? drafter = null, int maxDraftTokens = 4)
+    {
+        _target = target ?? throw new ArgumentNullException(nameof(target));
+        if (maxDraftTokens < 1) throw new ArgumentOutOfRangeException(nameof(maxDraftTokens));
+        _drafter = drafter ?? new PromptLookupDrafter();
+        _maxDraftTokens = maxDraftTokens;
+    }
+
+    /// <summary>
+    /// Generates a continuation for a prompt using greedy speculative decoding, returning the generated token
+    /// ids and (optionally) speculation statistics.
+    /// </summary>
+    /// <param name="promptTokenIds">The prompt token ids.</param>
+    /// <param name="sampling">Sampling parameters. Must be greedy (temperature 0); stop conditions honored.</param>
+    /// <param name="statistics">Receives speculation counters for this run.</param>
+    public IReadOnlyList<int> Generate(
+        IReadOnlyList<int> promptTokenIds,
+        SamplingParameters sampling,
+        out SpeculationStatistics statistics)
+    {
+        if (promptTokenIds is null) throw new ArgumentNullException(nameof(promptTokenIds));
+        if (promptTokenIds.Count == 0) throw new ArgumentException("Prompt must be non-empty.", nameof(promptTokenIds));
+        if (sampling is null) throw new ArgumentNullException(nameof(sampling));
+        sampling.Validate();
+        if (!sampling.IsGreedy)
+            throw new NotSupportedException(
+                "SpeculativeGenerator currently supports greedy decoding only (temperature 0). Use the " +
+                "standard generation path for stochastic sampling.");
+
+        statistics = new SpeculationStatistics();
+        var context = new List<int>(promptTokenIds);
+        var generated = new List<int>();
+        int vocab = _target.VocabularySize;
+
+        while (generated.Count < sampling.MaxTokens)
+        {
+            var draft = _drafter.Draft(context, Math.Min(_maxDraftTokens, sampling.MaxTokens - generated.Count));
+            int d = draft.Count;
+            statistics.DraftedTokens += d;
+
+            // One target pass verifies all d drafted positions plus the next-token position after them.
+            var verifyInput = new List<int>(context.Count + d);
+            verifyInput.AddRange(context);
+            verifyInput.AddRange(draft);
+            var logits = Forward(verifyInput);
+            statistics.TargetForwardPasses++;
+
+            int basePos = context.Count - 1; // position whose logits predict the first continuation token
+            bool stopped = false;
+
+            // Accept the longest prefix of the draft that matches the target's greedy choice.
+            int i = 0;
+            for (; i < d; i++)
+            {
+                int targetToken = ArgMaxAt(logits, basePos + i, vocab);
+                if (targetToken != draft[i])
+                {
+                    // Reject here: emit the target's own token instead, then end this round.
+                    if (Emit(targetToken, context, generated, statistics, sampling)) stopped = true;
+                    break;
+                }
+                statistics.AcceptedTokens++;
+                if (Emit(draft[i], context, generated, statistics, sampling)) { stopped = true; i++; break; }
+            }
+
+            if (!stopped && i == d)
+            {
+                // Whole draft accepted (or empty): also emit the bonus token the target predicts after it.
+                int bonus = ArgMaxAt(logits, basePos + d, vocab);
+                Emit(bonus, context, generated, statistics, sampling);
+                // A stop here simply ends the outer loop on the next check.
+                if (IsStop(bonus, generated, sampling)) stopped = true;
+            }
+
+            if (stopped) break;
+        }
+
+        return generated;
+    }
+
+    /// <summary>Convenience overload without statistics.</summary>
+    public IReadOnlyList<int> Generate(IReadOnlyList<int> promptTokenIds, SamplingParameters sampling)
+        => Generate(promptTokenIds, sampling, out _);
+
+    // Appends a token to context+output; returns true if generation should stop after it.
+    private bool Emit(int token, List<int> context, List<int> generated, SpeculationStatistics stats, SamplingParameters sampling)
+    {
+        generated.Add(token);
+        context.Add(token);
+        stats.GeneratedTokens++;
+        return IsStop(token, generated, sampling) || generated.Count >= sampling.MaxTokens;
+    }
+
+    private bool IsStop(int token, List<int> generated, SamplingParameters sampling)
+    {
+        if (generated.Count < sampling.MinTokens) return false;
+        if (!sampling.IgnoreEos && _target.EosTokenId is { } eos && token == eos) return true;
+        if (sampling.StopTokenIds is { } stops && stops.Contains(token)) return true;
+        return false;
+    }
+
+    private Tensor<T> Forward(IReadOnlyList<int> tokens)
+    {
+        var numOps = MathHelper.GetNumericOperations<T>();
+        var input = new Tensor<T>(new[] { 1, tokens.Count });
+        for (int i = 0; i < tokens.Count; i++) input[0, i] = numOps.FromDouble(tokens[i]);
+        return _target.ForwardLogits(input);
+    }
+
+    // Argmax over the vocab at a specific sequence position, tolerating [seq,vocab] / [1,seq,vocab] logits.
+    private static int ArgMaxAt(Tensor<T> logits, int position, int vocab)
+    {
+        var numOps = MathHelper.GetNumericOperations<T>();
+        var shape = logits.Shape;
+        Func<int, double> at = shape.Length switch
+        {
+            2 => v => numOps.ToDouble(logits[position, v]),
+            3 => v => numOps.ToDouble(logits[0, position, v]),
+            _ => throw new InvalidOperationException(
+                $"Speculative verification needs multi-position logits ([seq, vocab] or [1, seq, vocab]); got rank {shape.Length}."),
+        };
+
+        int best = 0;
+        double bestScore = at(0);
+        for (int v = 1; v < vocab; v++)
+        {
+            double s = at(v);
+            if (s > bestScore) { bestScore = s; best = v; }
+        }
+        return best;
+    }
+}

--- a/src/AiDotNet.Serving/Engine/TextGenerator.cs
+++ b/src/AiDotNet.Serving/Engine/TextGenerator.cs
@@ -1,0 +1,117 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using AiDotNet.Agentic.Models.Local;
+
+namespace AiDotNet.Serving.Engine;
+
+/// <summary>
+/// The in-process text-generation facade: the one-object surface behind <c>model.Generate(...)</c>. It owns a
+/// <see cref="ContinuousBatchingEngine{T}"/> configured with the right runner for the model (paged fast path or
+/// recompute fallback) and, when a tokenizer is attached, turns strings into tokens and back. A beginner uses
+/// it without ever seeing block managers, schedulers, or sampling internals.
+/// </summary>
+/// <remarks>
+/// <para><b>For Beginners:</b> this is what "just generate text with my model" looks like. Give it a prompt and
+/// it returns the continuation — fast, batched, and memory-managed underneath. If you attached a tokenizer it
+/// speaks strings; otherwise it speaks token ids (numbers).</para>
+/// </remarks>
+/// <typeparam name="T">The model's numeric type.</typeparam>
+public sealed class TextGenerator<T> : IDisposable
+{
+    private readonly ContinuousBatchingEngine<T> _engine;
+    private readonly IGenerationTokenizer? _tokenizer;
+    private readonly SamplingParameters _defaultSampling;
+    private long _requestCounter;
+    private bool _disposed;
+
+    /// <summary>Builds a generator for a model, auto-selecting the runner and EOS handling.</summary>
+    /// <param name="model">The model to serve (must implement <see cref="AiDotNet.Interfaces.ICausalLmModel{T}"/>
+    /// or the paged <see cref="ICausalLmRunner{T}"/> capability).</param>
+    /// <param name="tokenizer">Optional tokenizer enabling the string overloads. When supplied and the model
+    /// declares no EOS, the tokenizer's EOS is used.</param>
+    /// <param name="options">Optional engine tuning. Its <see cref="EngineOptions.EosTokenId"/> is filled from
+    /// the model/tokenizer when not set.</param>
+    /// <param name="defaultSampling">Sampling used when a call passes none. Defaults to greedy, 128 tokens.</param>
+    public TextGenerator(
+        object model,
+        IGenerationTokenizer? tokenizer = null,
+        EngineOptions? options = null,
+        SamplingParameters? defaultSampling = null)
+    {
+        if (model is null) throw new ArgumentNullException(nameof(model));
+        _tokenizer = tokenizer;
+        _defaultSampling = defaultSampling ?? new SamplingParameters { Temperature = 0.0, MaxTokens = 128 };
+        _defaultSampling.Validate();
+
+        var selection = ServingRunnerFactory.Create<T>(model);
+        int? eos = selection.EosTokenId
+            ?? (tokenizer is not null && tokenizer.EosTokenId >= 0 ? tokenizer.EosTokenId : (int?)null);
+
+        var opts = options ?? new EngineOptions();
+        if (opts.EosTokenId is null && eos is not null)
+            opts = CloneWithEos(opts, eos);
+
+        _engine = new ContinuousBatchingEngine<T>(selection.Runner, opts);
+    }
+
+    /// <summary>Generates a continuation for a tokenized prompt, returning the generated token ids.</summary>
+    public IReadOnlyList<int> Generate(IReadOnlyList<int> promptTokenIds, SamplingParameters? sampling = null)
+    {
+        if (promptTokenIds is null) throw new ArgumentNullException(nameof(promptTokenIds));
+        if (promptTokenIds.Count == 0) throw new ArgumentException("Prompt must be non-empty.", nameof(promptTokenIds));
+
+        var sp = sampling ?? _defaultSampling;
+        string requestId = "gen-" + Interlocked.Increment(ref _requestCounter).ToString();
+        _engine.AddRequest(new GenerationRequest(requestId, promptTokenIds, sp));
+
+        // Pump the engine until this request finishes. Other in-flight requests advance too (continuous
+        // batching), but this call returns as soon as its own request is complete.
+        while (_engine.HasUnfinishedRequests)
+        {
+            foreach (var output in _engine.Step())
+            {
+                if (output.RequestId == requestId && output.IsFinished)
+                    return output.Outputs.Count > 0 ? output.Outputs[0].TokenIds : Array.Empty<int>();
+            }
+        }
+        return Array.Empty<int>();
+    }
+
+    /// <summary>Generates a continuation for a text prompt (requires a tokenizer). Returns the generated text.</summary>
+    public string Generate(string prompt, SamplingParameters? sampling = null)
+    {
+        if (prompt is null) throw new ArgumentNullException(nameof(prompt));
+        if (_tokenizer is null)
+            throw new InvalidOperationException(
+                "Generate(string) requires a tokenizer. Attach one when creating the generator, or call " +
+                "Generate(IReadOnlyList<int>) with pre-tokenized ids.");
+
+        var promptIds = _tokenizer.Encode(prompt);
+        if (promptIds.Count == 0)
+            throw new ArgumentException("Prompt tokenized to zero tokens.", nameof(prompt));
+
+        var generated = Generate(promptIds, sampling);
+        return _tokenizer.Decode(generated);
+    }
+
+    /// <summary>A snapshot of engine load and KV-cache utilization.</summary>
+    public EngineStatistics GetStatistics() => _engine.GetStatistics();
+
+    private static EngineOptions CloneWithEos(EngineOptions o, int? eos) => new()
+    {
+        MaxNumSequences = o.MaxNumSequences,
+        MaxBatchedTokens = o.MaxBatchedTokens,
+        BlockSize = o.BlockSize,
+        NumKvBlocks = o.NumKvBlocks,
+        EosTokenId = eos,
+    };
+
+    /// <inheritdoc/>
+    public void Dispose()
+    {
+        if (_disposed) return;
+        _disposed = true;
+        _engine.Dispose();
+    }
+}

--- a/src/AiDotNet.Serving/Engine/TextGenerator.cs
+++ b/src/AiDotNet.Serving/Engine/TextGenerator.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Threading;
 using AiDotNet.Agentic.Models.Local;
+using AiDotNet.Configuration;
 
 namespace AiDotNet.Serving.Engine;
 
@@ -33,22 +34,26 @@ public sealed class TextGenerator<T> : IDisposable
     /// <param name="options">Optional engine tuning. Its <see cref="EngineOptions.EosTokenId"/> is filled from
     /// the model/tokenizer when not set.</param>
     /// <param name="defaultSampling">Sampling used when a call passes none. Defaults to greedy, 128 tokens.</param>
+    /// <param name="config">Optional inference-optimization config. When <paramref name="options"/> is null,
+    /// engine options are derived from it (or from <see cref="InferenceOptimizationConfig.Default"/>).</param>
     public TextGenerator(
         object model,
         IGenerationTokenizer? tokenizer = null,
         EngineOptions? options = null,
-        SamplingParameters? defaultSampling = null)
+        SamplingParameters? defaultSampling = null,
+        InferenceOptimizationConfig? config = null)
     {
         if (model is null) throw new ArgumentNullException(nameof(model));
-        _tokenizer = tokenizer;
+        // Auto-resolve a tokenizer the model carries, so string generation needs no explicit tokenizer.
+        _tokenizer = tokenizer ?? (model as IProvidesGenerationTokenizer)?.GetGenerationTokenizer();
         _defaultSampling = defaultSampling ?? new SamplingParameters { Temperature = 0.0, MaxTokens = 128 };
         _defaultSampling.Validate();
 
         var selection = ServingRunnerFactory.Create<T>(model);
         int? eos = selection.EosTokenId
-            ?? (tokenizer is not null && tokenizer.EosTokenId >= 0 ? tokenizer.EosTokenId : (int?)null);
+            ?? (_tokenizer is not null && _tokenizer.EosTokenId >= 0 ? _tokenizer.EosTokenId : (int?)null);
 
-        var opts = options ?? new EngineOptions();
+        var opts = options ?? ServingConfigMapper.ToEngineOptions(config, eos);
         if (opts.EosTokenId is null && eos is not null)
             opts = CloneWithEos(opts, eos);
 

--- a/src/AiDotNet.Serving/Engine/TextGenerator.cs
+++ b/src/AiDotNet.Serving/Engine/TextGenerator.cs
@@ -53,7 +53,11 @@ public sealed class TextGenerator<T> : IDisposable
         int? eos = selection.EosTokenId
             ?? (_tokenizer is not null && _tokenizer.EosTokenId >= 0 ? _tokenizer.EosTokenId : (int?)null);
 
-        var opts = options ?? ServingConfigMapper.ToEngineOptions(config, eos);
+        // A paged model exposes its attention shape, so the KV pool can be sized precisely from the memory
+        // budget; otherwise fall back to the shape-agnostic nominal sizing.
+        var opts = options ?? (model is ICausalLmRunner<T> paged
+            ? ServingConfigMapper.ToEngineOptionsForPagedModel(config, eos, paged.NumLayers, paged.NumKvHeads, paged.HeadDim, paged.BlockSize)
+            : ServingConfigMapper.ToEngineOptions(config, eos));
         if (opts.EosTokenId is null && eos is not null)
             opts = CloneWithEos(opts, eos);
 

--- a/src/AiDotNet.Serving/Extensions/AiModelResultGenerationExtensions.cs
+++ b/src/AiDotNet.Serving/Extensions/AiModelResultGenerationExtensions.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using AiDotNet.Agentic.Models.Local;
+using AiDotNet.Configuration;
 using AiDotNet.Models.Results;
 using AiDotNet.Serving.Engine;
 
@@ -28,12 +29,13 @@ public static class AiModelResultGenerationExtensions
         this AiModelResult<T, TInput, TOutput> result,
         IGenerationTokenizer? tokenizer = null,
         EngineOptions? options = null,
-        SamplingParameters? defaultSampling = null)
+        SamplingParameters? defaultSampling = null,
+        InferenceOptimizationConfig? config = null)
     {
         if (result is null) throw new ArgumentNullException(nameof(result));
         var model = result.Model
             ?? throw new InvalidOperationException("The model has not been trained/initialized; cannot generate.");
-        return new TextGenerator<T>(model, tokenizer, options, defaultSampling);
+        return new TextGenerator<T>(model, tokenizer, options, defaultSampling, config);
     }
 
     /// <summary>Generates a continuation for a tokenized prompt, returning the generated token ids.</summary>

--- a/src/AiDotNet.Serving/Extensions/AiModelResultGenerationExtensions.cs
+++ b/src/AiDotNet.Serving/Extensions/AiModelResultGenerationExtensions.cs
@@ -1,0 +1,63 @@
+using System;
+using System.Collections.Generic;
+using AiDotNet.Agentic.Models.Local;
+using AiDotNet.Models.Results;
+using AiDotNet.Serving.Engine;
+
+namespace AiDotNet.Serving.Extensions;
+
+/// <summary>
+/// The beginner-facing text-generation surface on a built model. These extensions give a trained
+/// <see cref="AiModelResult{T, TInput, TOutput}"/> vLLM-class generation with zero configuration: a
+/// paged-KV, continuously-batched engine is created for the model automatically, using the fast path when the
+/// model advertises it and a correctness fallback otherwise.
+/// </summary>
+/// <remarks>
+/// <para><b>For Beginners:</b> after you build a language model, call <c>model.Generate("your prompt")</c> and
+/// you get the continuation — the high-performance serving engine is wired up for you. For repeated calls or
+/// many concurrent users, keep a single <see cref="TextGenerator{T}"/> from <see cref="AsTextGenerator"/> (or
+/// run a server) instead of calling the one-shot helpers in a loop.</para>
+/// </remarks>
+public static class AiModelResultGenerationExtensions
+{
+    /// <summary>
+    /// Creates a reusable <see cref="TextGenerator{T}"/> for the built model — the handle to hold when you
+    /// generate repeatedly. Auto-selects the paged fast path or the recompute fallback.
+    /// </summary>
+    public static TextGenerator<T> AsTextGenerator<T, TInput, TOutput>(
+        this AiModelResult<T, TInput, TOutput> result,
+        IGenerationTokenizer? tokenizer = null,
+        EngineOptions? options = null,
+        SamplingParameters? defaultSampling = null)
+    {
+        if (result is null) throw new ArgumentNullException(nameof(result));
+        var model = result.Model
+            ?? throw new InvalidOperationException("The model has not been trained/initialized; cannot generate.");
+        return new TextGenerator<T>(model, tokenizer, options, defaultSampling);
+    }
+
+    /// <summary>Generates a continuation for a tokenized prompt, returning the generated token ids.</summary>
+    public static IReadOnlyList<int> Generate<T, TInput, TOutput>(
+        this AiModelResult<T, TInput, TOutput> result,
+        IReadOnlyList<int> promptTokenIds,
+        SamplingParameters? sampling = null)
+    {
+        using var generator = result.AsTextGenerator();
+        return generator.Generate(promptTokenIds, sampling);
+    }
+
+    /// <summary>
+    /// Generates a text continuation for a text prompt using the supplied tokenizer. For repeated calls, prefer
+    /// holding a <see cref="TextGenerator{T}"/> from <see cref="AsTextGenerator"/> with the tokenizer attached.
+    /// </summary>
+    public static string Generate<T, TInput, TOutput>(
+        this AiModelResult<T, TInput, TOutput> result,
+        string prompt,
+        IGenerationTokenizer tokenizer,
+        SamplingParameters? sampling = null)
+    {
+        if (tokenizer is null) throw new ArgumentNullException(nameof(tokenizer));
+        using var generator = result.AsTextGenerator(tokenizer);
+        return generator.Generate(prompt, sampling);
+    }
+}

--- a/src/AiDotNet.Serving/Extensions/AiModelResultServeExtensions.cs
+++ b/src/AiDotNet.Serving/Extensions/AiModelResultServeExtensions.cs
@@ -19,31 +19,37 @@ public static class AiModelResultServeExtensions
     /// server to stop it and free resources.
     /// </summary>
     /// <param name="result">The built model.</param>
-    /// <param name="tokenizer">Tokenizer used to encode prompts and decode outputs for the HTTP text API.</param>
+    /// <param name="tokenizer">Tokenizer for the HTTP text API. May be null when the model carries its own
+    /// via <see cref="IProvidesGenerationTokenizer"/>.</param>
     /// <param name="options">Optional serving options (URLs, model name, engine tuning). Sensible defaults.</param>
     public static InferenceServer<T> Serve<T, TInput, TOutput>(
         this AiModelResult<T, TInput, TOutput> result,
-        IGenerationTokenizer tokenizer,
+        IGenerationTokenizer? tokenizer = null,
         ServeOptions? options = null)
     {
         if (result is null) throw new ArgumentNullException(nameof(result));
-        if (tokenizer is null) throw new ArgumentNullException(nameof(tokenizer));
 
         var model = result.Model
             ?? throw new InvalidOperationException("The model has not been trained/initialized; cannot serve.");
+
+        var resolvedTokenizer = tokenizer ?? (model as IProvidesGenerationTokenizer)?.GetGenerationTokenizer()
+            ?? throw new InvalidOperationException(
+                "Serve() needs a tokenizer for its HTTP text API: pass one, or have the model implement " +
+                "IProvidesGenerationTokenizer.");
 
         var opts = options ?? new ServeOptions();
         var defaultSampling = opts.DefaultSampling ?? new SamplingParameters { Temperature = 0.0, MaxTokens = 128 };
         defaultSampling.Validate();
 
         var selection = ServingRunnerFactory.Create<T>(model);
-        int? eos = selection.EosTokenId ?? (tokenizer.EosTokenId >= 0 ? tokenizer.EosTokenId : (int?)null);
+        int? eos = selection.EosTokenId ?? (resolvedTokenizer.EosTokenId >= 0 ? resolvedTokenizer.EosTokenId : (int?)null);
 
-        var engineOptions = ApplyEos(opts.EngineOptions ?? new EngineOptions(), eos);
+        var engineOptions = opts.EngineOptions ?? ServingConfigMapper.ToEngineOptions(opts.InferenceConfig, eos);
+        engineOptions = ApplyEos(engineOptions, eos);
         var engine = new ContinuousBatchingEngine<T>(selection.Runner, engineOptions);
         var host = new AsyncEngineHost<T>(engine);
 
-        return new InferenceServer<T>(host, tokenizer, opts.ModelName, defaultSampling, opts.Urls);
+        return new InferenceServer<T>(host, resolvedTokenizer, opts.ModelName, defaultSampling, opts.Urls);
     }
 
     private static EngineOptions ApplyEos(EngineOptions o, int? eos)

--- a/src/AiDotNet.Serving/Extensions/AiModelResultServeExtensions.cs
+++ b/src/AiDotNet.Serving/Extensions/AiModelResultServeExtensions.cs
@@ -1,0 +1,61 @@
+using System;
+using AiDotNet.Agentic.Models.Local;
+using AiDotNet.Models.Results;
+using AiDotNet.Serving.Engine;
+using AiDotNet.Serving.Engine.Http;
+
+namespace AiDotNet.Serving.Extensions;
+
+/// <summary>
+/// The one-line serving surface on a built model: <c>using var server = model.Serve(tokenizer);</c> starts a
+/// running, OpenAI-compatible HTTP endpoint backed by the paged-KV, continuously-batched engine. No engine
+/// arguments, KV math, or server plumbing — the vLLM-class deployment none of the expert-only frameworks make
+/// this easy.
+/// </summary>
+public static class AiModelResultServeExtensions
+{
+    /// <summary>
+    /// Starts an OpenAI-compatible inference server for the model and returns it running. Dispose the returned
+    /// server to stop it and free resources.
+    /// </summary>
+    /// <param name="result">The built model.</param>
+    /// <param name="tokenizer">Tokenizer used to encode prompts and decode outputs for the HTTP text API.</param>
+    /// <param name="options">Optional serving options (URLs, model name, engine tuning). Sensible defaults.</param>
+    public static InferenceServer<T> Serve<T, TInput, TOutput>(
+        this AiModelResult<T, TInput, TOutput> result,
+        IGenerationTokenizer tokenizer,
+        ServeOptions? options = null)
+    {
+        if (result is null) throw new ArgumentNullException(nameof(result));
+        if (tokenizer is null) throw new ArgumentNullException(nameof(tokenizer));
+
+        var model = result.Model
+            ?? throw new InvalidOperationException("The model has not been trained/initialized; cannot serve.");
+
+        var opts = options ?? new ServeOptions();
+        var defaultSampling = opts.DefaultSampling ?? new SamplingParameters { Temperature = 0.0, MaxTokens = 128 };
+        defaultSampling.Validate();
+
+        var selection = ServingRunnerFactory.Create<T>(model);
+        int? eos = selection.EosTokenId ?? (tokenizer.EosTokenId >= 0 ? tokenizer.EosTokenId : (int?)null);
+
+        var engineOptions = ApplyEos(opts.EngineOptions ?? new EngineOptions(), eos);
+        var engine = new ContinuousBatchingEngine<T>(selection.Runner, engineOptions);
+        var host = new AsyncEngineHost<T>(engine);
+
+        return new InferenceServer<T>(host, tokenizer, opts.ModelName, defaultSampling, opts.Urls);
+    }
+
+    private static EngineOptions ApplyEos(EngineOptions o, int? eos)
+    {
+        if (o.EosTokenId is not null || eos is null) return o;
+        return new EngineOptions
+        {
+            MaxNumSequences = o.MaxNumSequences,
+            MaxBatchedTokens = o.MaxBatchedTokens,
+            BlockSize = o.BlockSize,
+            NumKvBlocks = o.NumKvBlocks,
+            EosTokenId = eos,
+        };
+    }
+}

--- a/src/AiDotNet.Serving/Extensions/AiModelResultServeExtensions.cs
+++ b/src/AiDotNet.Serving/Extensions/AiModelResultServeExtensions.cs
@@ -49,7 +49,7 @@ public static class AiModelResultServeExtensions
         var engine = new ContinuousBatchingEngine<T>(selection.Runner, engineOptions);
         var host = new AsyncEngineHost<T>(engine);
 
-        return new InferenceServer<T>(host, resolvedTokenizer, opts.ModelName, defaultSampling, opts.Urls);
+        return new InferenceServer<T>(host, resolvedTokenizer, opts.ModelName, defaultSampling, opts.Urls, opts.ChatTemplate);
     }
 
     private static EngineOptions ApplyEos(EngineOptions o, int? eos)

--- a/src/AiDotNet.Serving/Extensions/AiModelResultSpeculativeExtensions.cs
+++ b/src/AiDotNet.Serving/Extensions/AiModelResultSpeculativeExtensions.cs
@@ -1,0 +1,55 @@
+using System;
+using System.Collections.Generic;
+using AiDotNet.Interfaces;
+using AiDotNet.Models.Results;
+using AiDotNet.Serving.Engine;
+using AiDotNet.Serving.Engine.Speculative;
+
+namespace AiDotNet.Serving.Extensions;
+
+/// <summary>
+/// Speculative-decoding surface on a built model: faster greedy generation with the same output. Uses model-free
+/// prompt-lookup drafting by default, so a beginner gets the speedup with no extra model and no configuration.
+/// </summary>
+/// <remarks>
+/// <para><b>For Beginners:</b> this generates the same text as <c>Generate</c> but can be faster on repetitive
+/// output, because it guesses several tokens ahead and lets the model confirm them in one shot. The result is
+/// identical to normal greedy generation — only the speed changes.</para>
+/// </remarks>
+public static class AiModelResultSpeculativeExtensions
+{
+    /// <summary>
+    /// Creates a reusable <see cref="SpeculativeGenerator{T}"/> for the model (requires the model to implement
+    /// <see cref="ICausalLmModel{T}"/>). Defaults to model-free prompt-lookup drafting.
+    /// </summary>
+    public static SpeculativeGenerator<T> AsSpeculativeGenerator<T, TInput, TOutput>(
+        this AiModelResult<T, TInput, TOutput> result,
+        ISpeculativeDrafter? drafter = null,
+        int maxDraftTokens = 4)
+    {
+        if (result is null) throw new ArgumentNullException(nameof(result));
+        var model = result.Model
+            ?? throw new InvalidOperationException("The model has not been trained/initialized; cannot generate.");
+        if (model is not ICausalLmModel<T> lm)
+            throw new NotSupportedException(
+                $"Speculative decoding requires the model to implement ICausalLmModel<{typeof(T).Name}> " +
+                "(it verifies drafts via multi-position ForwardLogits).");
+        return new SpeculativeGenerator<T>(lm, drafter, maxDraftTokens);
+    }
+
+    /// <summary>
+    /// Generates a continuation with greedy speculative decoding, returning the generated token ids. The output
+    /// is identical to <see cref="AiModelResultGenerationExtensions.Generate{T, TInput, TOutput}(AiModelResult{T, TInput, TOutput}, IReadOnlyList{int}, SamplingParameters)"/>
+    /// greedy generation — only faster.
+    /// </summary>
+    public static IReadOnlyList<int> GenerateSpeculative<T, TInput, TOutput>(
+        this AiModelResult<T, TInput, TOutput> result,
+        IReadOnlyList<int> promptTokenIds,
+        SamplingParameters? sampling = null,
+        ISpeculativeDrafter? drafter = null,
+        int maxDraftTokens = 4)
+    {
+        var generator = result.AsSpeculativeGenerator(drafter, maxDraftTokens);
+        return generator.Generate(promptTokenIds, sampling ?? new SamplingParameters { Temperature = 0.0, MaxTokens = 128 });
+    }
+}

--- a/src/Interfaces/ICausalLmModel.cs
+++ b/src/Interfaces/ICausalLmModel.cs
@@ -1,0 +1,36 @@
+using AiDotNet.Tensors.LinearAlgebra;
+
+namespace AiDotNet.Interfaces;
+
+/// <summary>
+/// A model that can act as a causal (autoregressive) language model for text generation: given a sequence of
+/// token ids it returns next-token logits over its vocabulary. Implementing this lets the serving engine drive
+/// the model with a correctness-guaranteed recompute path (no special KV plumbing required); models that also
+/// want the fast paged path additionally implement the serving engine's incremental runner capability.
+/// </summary>
+/// <remarks>
+/// <para><b>For Beginners:</b> a "causal language model" is one that predicts the next word from the words so
+/// far — the family GPT-style text generators belong to. This small interface is the promise a model makes to
+/// the serving engine: "give me the tokens read so far and I will score every possible next token." That is all
+/// the engine needs to generate text with it. A model that already produces vocabulary-sized logits (like
+/// <c>Transformer</c>) implements this almost for free.</para>
+/// </remarks>
+/// <typeparam name="T">The model's numeric type.</typeparam>
+public interface ICausalLmModel<T>
+{
+    /// <summary>Size of the token vocabulary (the length of each next-token logits row).</summary>
+    int VocabularySize { get; }
+
+    /// <summary>
+    /// The end-of-sequence token id, if the model defines one. Generating it ends a sequence unless the caller
+    /// opts out. Null when the model has no distinguished EOS token.
+    /// </summary>
+    int? EosTokenId { get; }
+
+    /// <summary>
+    /// Computes next-token logits for a token sequence. Given token ids shaped <c>[sequenceLength]</c> or
+    /// <c>[1, sequenceLength]</c>, returns logits shaped <c>[sequenceLength, vocabularySize]</c> (or with a
+    /// leading batch dimension of 1); the serving engine reads the final position to score the next token.
+    /// </summary>
+    Tensor<T> ForwardLogits(Tensor<T> tokenIds);
+}

--- a/tests/AiDotNet.Serving.Tests/AsyncEngineHostTests.cs
+++ b/tests/AiDotNet.Serving.Tests/AsyncEngineHostTests.cs
@@ -1,0 +1,104 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using AiDotNet.Serving.Engine;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Serving.Tests;
+
+/// <summary>
+/// Tests for <see cref="AsyncEngineHost{T}"/> — the background pump + concurrent async submission over the
+/// continuous-batching engine. Uses a deterministic counter runner so concurrent results can be asserted
+/// exactly.
+/// </summary>
+public class AsyncEngineHostTests
+{
+    private const int Vocab = 100;
+
+    private sealed class CounterRunner : IServingModelRunner<double>
+    {
+        public int VocabularySize => Vocab;
+        public IReadOnlyList<Vector<double>> Execute(IReadOnlyList<SequenceExecution<double>> batch)
+        {
+            var result = new List<Vector<double>>(batch.Count);
+            foreach (var exec in batch)
+            {
+                int last = exec.AllTokenIds[exec.AllTokenIds.Count - 1];
+                var row = new double[Vocab];
+                row[(last + 1) % Vocab] = 1.0;
+                result.Add(new Vector<double>(row));
+            }
+            return result;
+        }
+    }
+
+    private static AsyncEngineHost<double> NewHost()
+        => new(new ContinuousBatchingEngine<double>(new CounterRunner()));
+
+    private static SamplingParameters Greedy(int maxTokens) => new() { Temperature = 0.0, MaxTokens = maxTokens };
+
+    [Fact]
+    public async Task GenerateAsync_ReturnsDeterministicSequence()
+    {
+        using var host = NewHost();
+        var ids = await host.GenerateAsync(new[] { 5 }, Greedy(4));
+        Assert.Equal(new[] { 6, 7, 8, 9 }, ids);
+    }
+
+    [Fact]
+    public async Task ConcurrentRequests_AllReturnCorrectOutputs()
+    {
+        using var host = NewHost();
+        var tasks = Enumerable.Range(0, 32)
+            .Select(i => host.GenerateAsync(new[] { i }, Greedy(5)))
+            .ToArray();
+
+        var results = await Task.WhenAll(tasks);
+
+        for (int i = 0; i < 32; i++)
+        {
+            var expected = Enumerable.Range(1, 5).Select(k => (i + k) % Vocab).ToArray();
+            Assert.Equal(expected, results[i]);
+        }
+    }
+
+    [Fact]
+    public async Task StreamAsync_EmitsCumulativeUpdates_EndingFinished()
+    {
+        using var host = NewHost();
+        var updates = new List<GenerationUpdate>();
+        await foreach (var u in host.StreamAsync(new[] { 20 }, Greedy(3)))
+            updates.Add(u);
+
+        Assert.True(updates.Count >= 1);
+        var last = updates[updates.Count - 1];
+        Assert.True(last.IsFinished);
+        Assert.Equal("length", last.FinishReason);
+        Assert.Equal(new[] { 21, 22, 23 }, last.TokenIds);
+        // Token counts are non-decreasing across updates (cumulative).
+        for (int i = 1; i < updates.Count; i++)
+            Assert.True(updates[i].TokenIds.Count >= updates[i - 1].TokenIds.Count);
+    }
+
+    [Fact]
+    public async Task Cancellation_AbortsRequest()
+    {
+        using var host = NewHost();
+        using var cts = new CancellationTokenSource();
+        // Long generation; cancel after the first update.
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(async () =>
+        {
+            await foreach (var u in host.StreamAsync(new[] { 1 }, Greedy(100000), cts.Token))
+            {
+                cts.Cancel();
+            }
+        });
+
+        // After a moment the engine should have drained the aborted request.
+        for (int i = 0; i < 50 && host.GetStatistics().RunningSequences > 0; i++) await Task.Delay(10);
+        Assert.Equal(0, host.GetStatistics().RunningSequences);
+    }
+}

--- a/tests/AiDotNet.Serving.Tests/BlockManagerTests.cs
+++ b/tests/AiDotNet.Serving.Tests/BlockManagerTests.cs
@@ -1,0 +1,290 @@
+using System.Collections.Generic;
+using System.Linq;
+using AiDotNet.Serving.Engine;
+using Xunit;
+
+namespace AiDotNet.Serving.Tests;
+
+/// <summary>
+/// Invariant tests for <see cref="BlockManager"/> — the paged KV-cache allocator. These prove the correctness
+/// backbone every downstream component relies on: a physical block is never handed out twice, free + used
+/// blocks always sum to the pool size, copy-on-write duplicates exactly the block being written (and only when
+/// shared), and fork/free reference counting reclaims memory precisely.
+/// </summary>
+public class BlockManagerTests
+{
+    // ---- Construction / basic accounting -------------------------------------------------
+
+    [Fact]
+    public void NewManager_AllBlocksFree()
+    {
+        var bm = new BlockManager(totalBlocks: 8, blockSize: 4);
+        Assert.Equal(8, bm.TotalBlocks);
+        Assert.Equal(8, bm.NumFreeBlocks);
+        Assert.Equal(0, bm.NumUsedBlocks);
+        Assert.Equal(4, bm.BlockSize);
+        Assert.Equal(0, bm.NumSequences);
+        Assert.Equal(0.0, bm.Usage);
+    }
+
+    [Theory]
+    [InlineData(1, 4, 1)]
+    [InlineData(4, 4, 1)]
+    [InlineData(5, 4, 2)]
+    [InlineData(16, 4, 4)]
+    [InlineData(17, 4, 5)]
+    public void BlocksForTokens_CeilingDivision(int tokens, int blockSize, int expected)
+    {
+        var bm = new BlockManager(totalBlocks: 32, blockSize: blockSize);
+        Assert.Equal(expected, bm.BlocksForTokens(tokens));
+    }
+
+    // ---- Allocation ----------------------------------------------------------------------
+
+    [Fact]
+    public void Allocate_ConsumesCeilingBlocks_AndConserves()
+    {
+        var bm = new BlockManager(totalBlocks: 8, blockSize: 4);
+        var table = bm.Allocate("s1", numTokens: 6); // ceil(6/4) = 2 blocks
+
+        Assert.Equal(2, table.Count);
+        Assert.Equal(2, bm.NumUsedBlocks);
+        Assert.Equal(6, bm.NumFreeBlocks);
+        Assert.Equal(8, bm.NumFreeBlocks + bm.NumUsedBlocks); // conservation
+        Assert.True(bm.Contains("s1"));
+        Assert.Equal(6, bm.GetLength("s1"));
+        Assert.Equal(2, bm.FilledSlotsInLastBlock("s1")); // 6 % 4
+    }
+
+    [Fact]
+    public void Allocate_DistinctSequences_NeverShareBlocks()
+    {
+        var bm = new BlockManager(totalBlocks: 16, blockSize: 4);
+        var a = bm.Allocate("a", 8).ToArray();
+        var b = bm.Allocate("b", 8).ToArray();
+
+        Assert.Empty(a.Intersect(b)); // no double-allocation
+        Assert.Equal(4, bm.NumUsedBlocks);
+    }
+
+    [Fact]
+    public void Allocate_Twice_SameSequence_Throws()
+    {
+        var bm = new BlockManager(8, 4);
+        bm.Allocate("s1", 4);
+        Assert.Throws<System.InvalidOperationException>(() => bm.Allocate("s1", 4));
+    }
+
+    [Fact]
+    public void CanAllocate_RespectsPoolSize()
+    {
+        var bm = new BlockManager(totalBlocks: 2, blockSize: 4);
+        Assert.True(bm.CanAllocate(8));   // exactly 2 blocks
+        Assert.False(bm.CanAllocate(9));  // needs 3
+    }
+
+    [Fact]
+    public void Allocate_BeyondCapacity_Throws()
+    {
+        var bm = new BlockManager(totalBlocks: 2, blockSize: 4);
+        Assert.Throws<System.InvalidOperationException>(() => bm.Allocate("s1", 12)); // needs 3, have 2
+    }
+
+    // ---- Append (decode growth) ----------------------------------------------------------
+
+    [Fact]
+    public void Append_WithinLastBlock_NoNewBlock_NoCopy()
+    {
+        var bm = new BlockManager(8, 4);
+        bm.Allocate("s1", 2); // 1 block, 2/4 filled
+        var copies = bm.Append("s1", 1); // -> 3/4 filled, still 1 block
+
+        Assert.Empty(copies);
+        Assert.Single(bm.GetBlockTable("s1"));
+        Assert.Equal(3, bm.GetLength("s1"));
+        Assert.Equal(1, bm.NumUsedBlocks);
+    }
+
+    [Fact]
+    public void Append_CrossingBlockBoundary_AllocatesNewBlock()
+    {
+        var bm = new BlockManager(8, 4);
+        bm.Allocate("s1", 4);            // exactly 1 full block
+        var copies = bm.Append("s1", 1); // 5th token -> needs a 2nd block
+
+        Assert.Empty(copies);
+        Assert.Equal(2, bm.GetBlockTable("s1").Count);
+        Assert.Equal(5, bm.GetLength("s1"));
+        Assert.Equal(1, bm.FilledSlotsInLastBlock("s1"));
+    }
+
+    [Fact]
+    public void CanAppend_FalseWhenPoolExhausted()
+    {
+        var bm = new BlockManager(totalBlocks: 1, blockSize: 4);
+        bm.Allocate("s1", 4); // consumes the only block, now full
+        Assert.False(bm.CanAppend("s1", 1)); // would need a 2nd block, none free
+        Assert.Throws<System.InvalidOperationException>(() => bm.Append("s1", 1));
+    }
+
+    [Fact]
+    public void Append_ManyTokens_MaintainsConservationEveryStep()
+    {
+        var bm = new BlockManager(totalBlocks: 64, blockSize: 4);
+        bm.Allocate("s1", 1);
+        for (int i = 0; i < 100; i++)
+        {
+            if (!bm.CanAppend("s1", 1)) break;
+            bm.Append("s1", 1);
+            Assert.Equal(bm.TotalBlocks, bm.NumFreeBlocks + bm.NumUsedBlocks);
+        }
+        Assert.Equal(101, bm.GetLength("s1"));
+        Assert.Equal(bm.BlocksForTokens(101), bm.GetBlockTable("s1").Count);
+    }
+
+    // ---- Fork + copy-on-write ------------------------------------------------------------
+
+    [Fact]
+    public void Fork_SharesAllBlocks_NoNewAllocation()
+    {
+        var bm = new BlockManager(16, 4);
+        var parent = bm.Allocate("p", 8).ToArray(); // 2 blocks
+        int usedBefore = bm.NumUsedBlocks;
+
+        var child = bm.Fork("p", "c").ToArray();
+
+        Assert.Equal(parent, child);                 // identical physical blocks
+        Assert.Equal(usedBefore, bm.NumUsedBlocks);  // fork allocates nothing
+        Assert.Equal(8, bm.GetLength("c"));
+    }
+
+    [Fact]
+    public void Append_IntoSharedPartialBlock_TriggersCopyOnWrite()
+    {
+        var bm = new BlockManager(16, 4);
+        bm.Allocate("p", 2);        // 1 block, 2/4 filled (has room)
+        bm.Fork("p", "c");          // block now shared (refcount 2)
+        int freeBefore = bm.NumFreeBlocks;
+
+        var pTable = bm.GetBlockTable("p").ToArray();
+        var copies = bm.Append("c", 1); // c writes into the shared partial block -> COW
+
+        Assert.Single(copies);
+        var cTable = bm.GetBlockTable("c");
+        Assert.Equal(pTable[0], copies[0].Source);       // copied from the shared block
+        Assert.Equal(cTable[0], copies[0].Destination);  // into c's new block
+        Assert.NotEqual(pTable[0], cTable[0]);           // c no longer aliases p
+        Assert.Equal(freeBefore - 1, bm.NumFreeBlocks);  // exactly one new block consumed
+
+        // Parent's block table is untouched by the child's write.
+        Assert.Equal(pTable, bm.GetBlockTable("p").ToArray());
+    }
+
+    [Fact]
+    public void Append_IntoSharedFullBlock_AllocatesNewBlock_NoCopy()
+    {
+        var bm = new BlockManager(16, 4);
+        bm.Allocate("p", 4);   // exactly 1 FULL block
+        bm.Fork("p", "c");     // shared, but full -> next write goes to a fresh block, no copy
+        var copies = bm.Append("c", 1);
+
+        Assert.Empty(copies);
+        Assert.Equal(2, bm.GetBlockTable("c").Count);
+        Assert.Single(bm.GetBlockTable("p")); // parent unchanged
+    }
+
+    [Fact]
+    public void Append_Unshared_NeverCopies()
+    {
+        var bm = new BlockManager(16, 4);
+        bm.Allocate("s1", 2);
+        bm.Fork("s1", "s2");
+        bm.Free("s2");                    // s1's block is unshared again (refcount back to 1)
+        var copies = bm.Append("s1", 1);  // in-place, no COW
+
+        Assert.Empty(copies);
+    }
+
+    // ---- Free / reclamation --------------------------------------------------------------
+
+    [Fact]
+    public void Free_ReturnsBlocksToPool()
+    {
+        var bm = new BlockManager(8, 4);
+        bm.Allocate("s1", 8); // 2 blocks
+        Assert.Equal(2, bm.NumUsedBlocks);
+
+        bm.Free("s1");
+
+        Assert.Equal(0, bm.NumUsedBlocks);
+        Assert.Equal(8, bm.NumFreeBlocks);
+        Assert.False(bm.Contains("s1"));
+    }
+
+    [Fact]
+    public void Free_SharedBlocks_OnlyReclaimedAtLastReference()
+    {
+        var bm = new BlockManager(16, 4);
+        bm.Allocate("p", 8); // 2 blocks
+        bm.Fork("p", "c");   // both reference the same 2 blocks
+        Assert.Equal(2, bm.NumUsedBlocks);
+
+        bm.Free("p");
+        Assert.Equal(2, bm.NumUsedBlocks); // c still holds them
+        Assert.Equal(14, bm.NumFreeBlocks);
+
+        bm.Free("c");
+        Assert.Equal(0, bm.NumUsedBlocks); // now reclaimed
+        Assert.Equal(16, bm.NumFreeBlocks);
+    }
+
+    [Fact]
+    public void Free_UnknownSequence_IsNoOp()
+    {
+        var bm = new BlockManager(8, 4);
+        bm.Free("nope"); // must not throw
+        Assert.Equal(8, bm.NumFreeBlocks);
+    }
+
+    [Fact]
+    public void AllocateForkAppendFree_FullCycle_ReturnsPoolToPristine()
+    {
+        var bm = new BlockManager(totalBlocks: 32, blockSize: 4);
+
+        bm.Allocate("p", 10);       // 3 blocks
+        bm.Fork("p", "c1");
+        bm.Fork("p", "c2");
+        for (int i = 0; i < 20; i++)
+        {
+            if (bm.CanAppend("c1")) bm.Append("c1");
+            if (bm.CanAppend("c2")) bm.Append("c2");
+            if (bm.CanAppend("p")) bm.Append("p");
+            Assert.Equal(bm.TotalBlocks, bm.NumFreeBlocks + bm.NumUsedBlocks);
+        }
+
+        bm.Free("p");
+        bm.Free("c1");
+        bm.Free("c2");
+
+        Assert.Equal(0, bm.NumUsedBlocks);
+        Assert.Equal(32, bm.NumFreeBlocks); // every block reclaimed, no leak, no double-free
+        Assert.Equal(0, bm.NumSequences);
+    }
+
+    // ---- Reallocation after free (no double-alloc across lifecycles) ---------------------
+
+    [Fact]
+    public void ReAllocateAfterFree_ReusesBlocksWithoutOverlapAcrossLiveSequences()
+    {
+        var bm = new BlockManager(totalBlocks: 4, blockSize: 4); // tiny pool forces reuse
+        var first = bm.Allocate("s1", 16).ToArray(); // all 4 blocks
+        Assert.Equal(0, bm.NumFreeBlocks);
+
+        bm.Free("s1");
+        var live = bm.Allocate("s2", 8).ToArray(); // 2 blocks, reused from pool
+        var s3 = bm.Allocate("s3", 8).ToArray();   // other 2 blocks
+
+        Assert.Empty(live.Intersect(s3)); // two live sequences never overlap
+        Assert.Equal(4, bm.NumUsedBlocks);
+    }
+}

--- a/tests/AiDotNet.Serving.Tests/ChatTemplateTests.cs
+++ b/tests/AiDotNet.Serving.Tests/ChatTemplateTests.cs
@@ -1,0 +1,36 @@
+using System.Collections.Generic;
+using AiDotNet.Serving.Engine.Http;
+using Xunit;
+
+namespace AiDotNet.Serving.Tests;
+
+/// <summary>Tests for the default chat template that renders OpenAI chat messages into a model prompt.</summary>
+public class ChatTemplateTests
+{
+    [Fact]
+    public void DefaultTemplate_RendersRolesAndOpensAssistantTurn()
+    {
+        var template = new DefaultChatTemplate();
+        var prompt = template.Render(new List<ChatMessage>
+        {
+            new() { Role = "system", Content = "be nice" },
+            new() { Role = "user", Content = "hello" },
+        });
+
+        Assert.Equal("<|system|>\nbe nice\n<|user|>\nhello\n<|assistant|>\n", prompt);
+    }
+
+    [Fact]
+    public void DefaultTemplate_EmptyConversation_StillOpensAssistantTurn()
+    {
+        var prompt = new DefaultChatTemplate().Render(new List<ChatMessage>());
+        Assert.Equal("<|assistant|>\n", prompt);
+    }
+
+    [Fact]
+    public void DefaultTemplate_BlankRole_DefaultsToUser()
+    {
+        var prompt = new DefaultChatTemplate().Render(new List<ChatMessage> { new() { Role = "", Content = "x" } });
+        Assert.Equal("<|user|>\nx\n<|assistant|>\n", prompt);
+    }
+}

--- a/tests/AiDotNet.Serving.Tests/ContinuousBatchingEngineTests.cs
+++ b/tests/AiDotNet.Serving.Tests/ContinuousBatchingEngineTests.cs
@@ -1,0 +1,246 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using AiDotNet.Serving.Engine;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Serving.Tests;
+
+/// <summary>
+/// End-to-end scheduling tests for <see cref="ContinuousBatchingEngine{T}"/> driven by a deterministic fake
+/// model. Because the fake is a stateless counter (next token = last + 1, mod vocab), recompute-preemption
+/// produces byte-identical output — so these assert exact generated sequences even under KV-memory pressure,
+/// proving the scheduler, admission, preemption, stop conditions, batching, and abort paths are correct.
+/// </summary>
+public class ContinuousBatchingEngineTests
+{
+    private const int Vocab = 100;
+
+    /// <summary>
+    /// Deterministic stateless "model": the next token is always (last token + 1) mod vocab. Returned as a
+    /// one-hot logits row so greedy decoding selects it. Stateless ⇒ recompute yields identical results.
+    /// </summary>
+    private sealed class CounterRunner : IServingModelRunner<double>
+    {
+        public int VocabularySize => Vocab;
+        public int ExecuteCalls { get; private set; }
+        public int MaxBatchSeen { get; private set; }
+
+        public IReadOnlyList<Vector<double>> Execute(IReadOnlyList<SequenceExecution<double>> batch)
+        {
+            ExecuteCalls++;
+            MaxBatchSeen = Math.Max(MaxBatchSeen, batch.Count);
+            var result = new List<Vector<double>>(batch.Count);
+            foreach (var exec in batch)
+            {
+                int last = exec.AllTokenIds[exec.AllTokenIds.Count - 1];
+                int next = (last + 1) % Vocab;
+                var row = new double[Vocab];
+                row[next] = 1.0;
+                result.Add(new Vector<double>(row));
+            }
+            return result;
+        }
+    }
+
+    private static SamplingParameters Greedy(int maxTokens, int minTokens = 0, IReadOnlyList<int>? stops = null)
+        => new() { Temperature = 0.0, MaxTokens = maxTokens, MinTokens = minTokens, StopTokenIds = stops };
+
+    private static GenerationRequest Req(string id, int[] prompt, SamplingParameters p)
+        => new(id, prompt, p);
+
+    // Expected counter output: maxTokens tokens starting at (lastPrompt+1).
+    private static int[] ExpectedCounter(int lastPrompt, int count)
+        => Enumerable.Range(1, count).Select(k => (lastPrompt + k) % Vocab).ToArray();
+
+    private static Dictionary<string, RequestOutput> RunToCompletion(
+        ContinuousBatchingEngine<double> engine, int maxSteps = 10000)
+    {
+        var final = new Dictionary<string, RequestOutput>();
+        int steps = 0;
+        while (engine.HasUnfinishedRequests)
+        {
+            if (++steps > maxSteps) throw new InvalidOperationException("Engine did not converge.");
+            foreach (var output in engine.Step())
+                if (output.IsFinished) final[output.RequestId] = output;
+        }
+        return final;
+    }
+
+    // ---- Single request ------------------------------------------------------------------
+
+    [Fact]
+    public void SingleRequest_Greedy_GeneratesDeterministicSequence_LengthCapped()
+    {
+        using var engine = new ContinuousBatchingEngine<double>(new CounterRunner());
+        engine.AddRequest(Req("r1", new[] { 5 }, Greedy(maxTokens: 4)));
+
+        var final = RunToCompletion(engine);
+
+        var output = final["r1"];
+        var completion = Assert.Single(output.Outputs);
+        Assert.Equal(ExpectedCounter(5, 4), completion.TokenIds); // 6,7,8,9
+        Assert.True(completion.IsFinished);
+        Assert.Equal("length", completion.FinishReason);
+    }
+
+    [Fact]
+    public void EosToken_StopsGeneration_BeforeMaxTokens()
+    {
+        var runner = new CounterRunner();
+        using var engine = new ContinuousBatchingEngine<double>(runner, new EngineOptions { EosTokenId = 0 });
+        // prompt 98 -> 99, then 0 (== EOS) stops.
+        engine.AddRequest(Req("r1", new[] { 98 }, Greedy(maxTokens: 20)));
+
+        var output = RunToCompletion(engine)["r1"];
+        var completion = Assert.Single(output.Outputs);
+        Assert.Equal(new[] { 99, 0 }, completion.TokenIds);
+        Assert.Equal("stop", completion.FinishReason);
+    }
+
+    [Fact]
+    public void MinTokens_SuppressesEarlyEos()
+    {
+        using var engine = new ContinuousBatchingEngine<double>(new CounterRunner(), new EngineOptions { EosTokenId = 0 });
+        // EOS (0) would appear at position 2 (99,0,...) but MinTokens=5 suppresses it; hits length cap at 10.
+        engine.AddRequest(Req("r1", new[] { 98 }, Greedy(maxTokens: 10, minTokens: 5)));
+
+        var completion = Assert.Single(RunToCompletion(engine)["r1"].Outputs);
+        Assert.Equal(10, completion.TokenIds.Count);
+        Assert.Equal("length", completion.FinishReason);
+        Assert.Contains(0, completion.TokenIds); // the EOS token was emitted, not treated as a stop
+    }
+
+    [Fact]
+    public void CustomStopToken_EndsSequence()
+    {
+        using var engine = new ContinuousBatchingEngine<double>(new CounterRunner());
+        // prompt 40 -> 41,42,43 ; stop token 43.
+        engine.AddRequest(Req("r1", new[] { 40 }, Greedy(maxTokens: 50, stops: new[] { 43 })));
+
+        var completion = Assert.Single(RunToCompletion(engine)["r1"].Outputs);
+        Assert.Equal(new[] { 41, 42, 43 }, completion.TokenIds);
+        Assert.Equal("stop", completion.FinishReason);
+    }
+
+    // ---- Continuous batching -------------------------------------------------------------
+
+    [Fact]
+    public void ManyRequests_AllFinish_WithCorrectOutputs_AndBatchTogether()
+    {
+        var runner = new CounterRunner();
+        using var engine = new ContinuousBatchingEngine<double>(runner);
+
+        for (int i = 0; i < 16; i++)
+            engine.AddRequest(Req($"r{i}", new[] { i }, Greedy(maxTokens: 6)));
+
+        var final = RunToCompletion(engine);
+
+        Assert.Equal(16, final.Count);
+        for (int i = 0; i < 16; i++)
+        {
+            var completion = Assert.Single(final[$"r{i}"].Outputs);
+            Assert.Equal(ExpectedCounter(i, 6), completion.TokenIds);
+        }
+        Assert.True(runner.MaxBatchSeen > 1, "requests should have been batched together in at least one step");
+    }
+
+    // ---- Preemption under memory pressure ------------------------------------------------
+
+    [Fact]
+    public void TinyKvPool_ForcesPreemption_ButOutputsStayCorrect()
+    {
+        var runner = new CounterRunner();
+        // 3 blocks x 4 slots = 12 KV slots total; several concurrent sequences each want up to 2+8 slots.
+        var options = new EngineOptions { BlockSize = 4, NumKvBlocks = 3, MaxNumSequences = 8 };
+        using var engine = new ContinuousBatchingEngine<double>(runner, options);
+
+        for (int i = 0; i < 6; i++)
+            engine.AddRequest(Req($"r{i}", new[] { 10 + i, 20 + i }, Greedy(maxTokens: 8)));
+
+        var final = RunToCompletion(engine);
+
+        Assert.Equal(6, final.Count);
+        for (int i = 0; i < 6; i++)
+        {
+            var completion = Assert.Single(final[$"r{i}"].Outputs);
+            Assert.Equal(ExpectedCounter(20 + i, 8), completion.TokenIds); // last prompt token is 20+i
+            Assert.True(completion.IsFinished);
+        }
+        Assert.True(engine.GetStatistics().TotalPreemptions > 0, "tiny pool should have forced at least one preemption");
+    }
+
+    [Fact]
+    public void PromptLargerThanPool_IsAbortedGracefully()
+    {
+        using var engine = new ContinuousBatchingEngine<double>(
+            new CounterRunner(), new EngineOptions { BlockSize = 4, NumKvBlocks = 2 }); // 8 slots max
+        engine.AddRequest(Req("big", Enumerable.Range(1, 20).ToArray(), Greedy(maxTokens: 4))); // 20 > 8
+
+        var completion = Assert.Single(RunToCompletion(engine)["big"].Outputs);
+        Assert.True(completion.IsFinished);
+        Assert.Equal("abort", NormalizeAbort(completion.FinishReason));
+    }
+
+    private static string NormalizeAbort(string? reason)
+        => reason is "prompt_too_long" or "abort" ? "abort" : reason ?? "";
+
+    // ---- Parallel sampling (N > 1) -------------------------------------------------------
+
+    [Fact]
+    public void ParallelSampling_ProducesNCompletions()
+    {
+        using var engine = new ContinuousBatchingEngine<double>(new CounterRunner());
+        engine.AddRequest(Req("r1", new[] { 7 }, new SamplingParameters { Temperature = 0.0, MaxTokens = 3, N = 4 }));
+
+        var output = RunToCompletion(engine)["r1"];
+        Assert.Equal(4, output.Outputs.Count);
+        Assert.Equal(new[] { 0, 1, 2, 3 }, output.Outputs.Select(o => o.SequenceIndex).OrderBy(x => x).ToArray());
+        foreach (var completion in output.Outputs)
+            Assert.Equal(ExpectedCounter(7, 3), completion.TokenIds); // greedy ⇒ all identical
+    }
+
+    // ---- Abort ---------------------------------------------------------------------------
+
+    [Fact]
+    public void AbortRequest_FinishesAborted_AndFreesMemory()
+    {
+        using var engine = new ContinuousBatchingEngine<double>(new CounterRunner());
+        engine.AddRequest(Req("r1", new[] { 3 }, Greedy(maxTokens: 1000)));
+
+        engine.Step(); // admit + first token
+        Assert.True(engine.AbortRequest("r1"));
+
+        var final = RunToCompletion(engine);
+        Assert.False(engine.HasUnfinishedRequests);
+        Assert.Equal(0, engine.GetStatistics().RunningSequences);
+        Assert.Equal(0.0, engine.GetStatistics().KvCacheUsage); // blocks reclaimed
+        if (final.TryGetValue("r1", out var output))
+            Assert.Equal("abort", output.Outputs[0].FinishReason);
+    }
+
+    [Fact]
+    public void AbortUnknownRequest_ReturnsFalse()
+    {
+        using var engine = new ContinuousBatchingEngine<double>(new CounterRunner());
+        Assert.False(engine.AbortRequest("nope"));
+    }
+
+    // ---- Statistics ----------------------------------------------------------------------
+
+    [Fact]
+    public void Statistics_ReflectFinishedCount()
+    {
+        using var engine = new ContinuousBatchingEngine<double>(new CounterRunner());
+        for (int i = 0; i < 5; i++)
+            engine.AddRequest(Req($"r{i}", new[] { i }, Greedy(maxTokens: 2)));
+
+        RunToCompletion(engine);
+
+        var stats = engine.GetStatistics();
+        Assert.Equal(5, stats.TotalFinishedRequests);
+        Assert.Equal(0, stats.RunningSequences);
+        Assert.Equal(0, stats.WaitingSequences);
+    }
+}

--- a/tests/AiDotNet.Serving.Tests/InferenceServerHttpTests.cs
+++ b/tests/AiDotNet.Serving.Tests/InferenceServerHttpTests.cs
@@ -128,4 +128,54 @@ public class InferenceServerHttpTests
         var response = await client.PostAsync("/v1/completions", body);
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
     }
+
+    [Fact(Timeout = 60000)]
+    public async Task ChatCompletions_NonStreaming_ReturnsAssistantMessage()
+    {
+        using var server = StartServer();
+        using var client = new HttpClient { BaseAddress = new Uri(server.Urls[0]) };
+
+        // The default chat template renders the messages and ends with "<|assistant|>\n"; the last char fed to
+        // the counter model is '\n' (10) -> 11,12,13 = chars 0x0B,0x0C,0x0D. We only assert structure + length.
+        var body = new StringContent(
+            "{\"messages\":[{\"role\":\"user\",\"content\":\"hi\"}],\"max_tokens\":3,\"temperature\":0}",
+            Encoding.UTF8, "application/json");
+        var response = await client.PostAsync("/v1/chat/completions", body);
+        response.EnsureSuccessStatusCode();
+
+        var json = JObject.Parse(await response.Content.ReadAsStringAsync());
+        Assert.Equal("chat.completion", (string?)json["object"]);
+        Assert.Equal("assistant", (string?)json["choices"]![0]!["message"]!["role"]);
+        Assert.Equal("stop", (string?)json["choices"]![0]!["finish_reason"]);
+        Assert.Equal(3, (int)json["usage"]!["completion_tokens"]!);
+    }
+
+    [Fact(Timeout = 60000)]
+    public async Task ChatCompletions_Streaming_EmitsRoleThenDeltasThenDone()
+    {
+        using var server = StartServer();
+        using var client = new HttpClient { BaseAddress = new Uri(server.Urls[0]) };
+
+        var body = new StringContent(
+            "{\"messages\":[{\"role\":\"user\",\"content\":\"hi\"}],\"max_tokens\":3,\"temperature\":0,\"stream\":true}",
+            Encoding.UTF8, "application/json");
+        var response = await client.PostAsync("/v1/chat/completions", body);
+        response.EnsureSuccessStatusCode();
+        Assert.Contains("text/event-stream", response.Content.Headers.ContentType!.ToString());
+
+        string sse = await response.Content.ReadAsStringAsync();
+        Assert.Contains("data: [DONE]", sse);
+        Assert.Contains("chat.completion.chunk", sse);
+        Assert.Contains("\"role\":\"assistant\"", sse); // first chunk announces the role
+    }
+
+    [Fact(Timeout = 60000)]
+    public async Task ChatCompletions_MissingMessages_Returns400()
+    {
+        using var server = StartServer();
+        using var client = new HttpClient { BaseAddress = new Uri(server.Urls[0]) };
+        var body = new StringContent("{\"messages\":[]}", Encoding.UTF8, "application/json");
+        var response = await client.PostAsync("/v1/chat/completions", body);
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
 }

--- a/tests/AiDotNet.Serving.Tests/InferenceServerHttpTests.cs
+++ b/tests/AiDotNet.Serving.Tests/InferenceServerHttpTests.cs
@@ -1,0 +1,131 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+using AiDotNet.Agentic.Models.Local;
+using AiDotNet.Interfaces;
+using AiDotNet.Serving.Engine;
+using AiDotNet.Serving.Engine.Http;
+using AiDotNet.Tensors.LinearAlgebra;
+using Newtonsoft.Json.Linq;
+using Xunit;
+
+namespace AiDotNet.Serving.Tests;
+
+/// <summary>
+/// Integration tests for the OpenAI-compatible <see cref="InferenceServer{T}"/>: they start a real server on a
+/// dynamic local port and exercise /health, /v1/models, and /v1/completions (streaming + non-streaming) over
+/// HTTP with a deterministic char-level counter model, so exact generated text can be asserted.
+/// </summary>
+public class InferenceServerHttpTests
+{
+    private const int Vocab = 128;
+
+    // Char-level counter LM: next token = (last + 1) mod vocab, one-hot at [1, seq, vocab].
+    private sealed class CounterLm : ICausalLmModel<double>
+    {
+        public int VocabularySize => Vocab;
+        public int? EosTokenId => null;
+        public Tensor<double> ForwardLogits(Tensor<double> tokenIds)
+        {
+            int n = tokenIds.Shape[tokenIds.Shape.Length - 1];
+            int last = (int)Math.Round(Convert.ToDouble(tokenIds[0, n - 1]));
+            var t = new Tensor<double>(new[] { 1, n, Vocab });
+            t[0, n - 1, (last + 1) % Vocab] = 1.0;
+            return t;
+        }
+    }
+
+    private sealed class CharTokenizer : IGenerationTokenizer
+    {
+        public int EosTokenId => -1;
+        public IReadOnlyList<int> Encode(string text) => text.Select(c => (int)c).ToArray();
+        public string Decode(IReadOnlyList<int> tokenIds) => new string(tokenIds.Select(id => (char)id).ToArray());
+    }
+
+    private static InferenceServer<double> StartServer()
+    {
+        var engine = new ContinuousBatchingEngine<double>(new RecomputeModelRunner<double>(new CounterLm()));
+        var host = new AsyncEngineHost<double>(engine);
+        return new InferenceServer<double>(
+            host, new CharTokenizer(), "test-model",
+            new SamplingParameters { Temperature = 0.0, MaxTokens = 16 },
+            new[] { "http://127.0.0.1:0" });
+    }
+
+    [Fact(Timeout = 60000)]
+    public async Task Health_ReturnsOk()
+    {
+        using var server = StartServer();
+        using var client = new HttpClient { BaseAddress = new Uri(server.Urls[0]) };
+        var json = JObject.Parse(await client.GetStringAsync("/health"));
+        Assert.Equal("ok", (string?)json["status"]);
+    }
+
+    [Fact(Timeout = 60000)]
+    public async Task Models_ListsServedModel()
+    {
+        using var server = StartServer();
+        using var client = new HttpClient { BaseAddress = new Uri(server.Urls[0]) };
+        var json = JObject.Parse(await client.GetStringAsync("/v1/models"));
+        Assert.Equal("test-model", (string?)json["data"]![0]!["id"]);
+    }
+
+    [Fact(Timeout = 60000)]
+    public async Task Completions_NonStreaming_ReturnsGeneratedText()
+    {
+        using var server = StartServer();
+        using var client = new HttpClient { BaseAddress = new Uri(server.Urls[0]) };
+
+        var body = new StringContent(
+            "{\"prompt\":\"A\",\"max_tokens\":3,\"temperature\":0}", Encoding.UTF8, "application/json");
+        var response = await client.PostAsync("/v1/completions", body);
+        response.EnsureSuccessStatusCode();
+
+        var json = JObject.Parse(await response.Content.ReadAsStringAsync());
+        // 'A'(65) -> 66,67,68 = "BCD"
+        Assert.Equal("BCD", (string?)json["choices"]![0]!["text"]);
+        Assert.Equal("stop", (string?)json["choices"]![0]!["finish_reason"]);
+        Assert.Equal(3, (int)json["usage"]!["completion_tokens"]!);
+    }
+
+    [Fact(Timeout = 60000)]
+    public async Task Completions_Streaming_EmitsSseChunksEndingDone()
+    {
+        using var server = StartServer();
+        using var client = new HttpClient { BaseAddress = new Uri(server.Urls[0]) };
+
+        var body = new StringContent(
+            "{\"prompt\":\"A\",\"max_tokens\":3,\"temperature\":0,\"stream\":true}", Encoding.UTF8, "application/json");
+        var response = await client.PostAsync("/v1/completions", body);
+        response.EnsureSuccessStatusCode();
+        Assert.Contains("text/event-stream", response.Content.Headers.ContentType!.ToString());
+
+        string sse = await response.Content.ReadAsStringAsync();
+        Assert.Contains("data: [DONE]", sse);
+
+        // Reassemble the streamed deltas into the full text.
+        var text = new StringBuilder();
+        foreach (var line in sse.Split('\n'))
+        {
+            var trimmed = line.Trim();
+            if (!trimmed.StartsWith("data: ") || trimmed.Contains("[DONE]")) continue;
+            var chunk = JObject.Parse(trimmed.Substring("data: ".Length));
+            text.Append((string?)chunk["choices"]![0]!["text"]);
+        }
+        Assert.Equal("BCD", text.ToString());
+    }
+
+    [Fact(Timeout = 60000)]
+    public async Task Completions_MissingPrompt_Returns400()
+    {
+        using var server = StartServer();
+        using var client = new HttpClient { BaseAddress = new Uri(server.Urls[0]) };
+        var body = new StringContent("{\"max_tokens\":3}", Encoding.UTF8, "application/json");
+        var response = await client.PostAsync("/v1/completions", body);
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+}

--- a/tests/AiDotNet.Serving.Tests/LogitsSamplerTests.cs
+++ b/tests/AiDotNet.Serving.Tests/LogitsSamplerTests.cs
@@ -1,0 +1,174 @@
+using System;
+using System.Collections.Generic;
+using AiDotNet.Serving.Engine;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Serving.Tests;
+
+/// <summary>
+/// Correctness tests for <see cref="LogitsSampler"/> — the decoding kernel that turns logits into a token id.
+/// These pin the greedy path (argmax), the effect of each filter (top-k / top-p / min-p), the repetition /
+/// presence / frequency penalties, and seeded-sampling reproducibility, against hand-computed expectations.
+/// </summary>
+public class LogitsSamplerTests
+{
+    private static readonly IReadOnlyList<int> NoContext = Array.Empty<int>();
+
+    private static SamplingParameters Greedy() => new() { Temperature = 0.0 };
+
+    private static Vector<double> V(params double[] logits) => new(logits);
+
+    // ---- Greedy -------------------------------------------------------------------------
+
+    [Fact]
+    public void Greedy_ReturnsArgMax()
+    {
+        var logits = V(0.1, 3.5, 0.2, 1.0);
+        int token = LogitsSampler.Sample(logits, Greedy(), NoContext, new Random(0));
+        Assert.Equal(1, token);
+    }
+
+    [Fact]
+    public void Greedy_IsDeterministic_RegardlessOfRng()
+    {
+        var logits = V(2.0, 5.0, 1.0);
+        int a = LogitsSampler.Sample(logits, Greedy(), NoContext, new Random(1));
+        int b = LogitsSampler.Sample(logits, Greedy(), NoContext, new Random(999));
+        Assert.Equal(1, a);
+        Assert.Equal(a, b);
+    }
+
+    // ---- Filters collapse to argmax -----------------------------------------------------
+
+    [Fact]
+    public void TopK1_AlwaysPicksMostProbable()
+    {
+        var logits = V(0.5, 4.0, 0.6, 3.9);
+        var p = new SamplingParameters { Temperature = 1.0, TopK = 1 };
+        for (int seed = 0; seed < 20; seed++)
+            Assert.Equal(1, LogitsSampler.Sample(logits, p, NoContext, new Random(seed)));
+    }
+
+    [Fact]
+    public void TinyTopP_CollapsesToArgMax()
+    {
+        // With one clearly dominant logit, a tiny nucleus keeps only that token.
+        var logits = V(0.0, 10.0, 0.1, 0.2);
+        var p = new SamplingParameters { Temperature = 1.0, TopP = 0.05 };
+        for (int seed = 0; seed < 20; seed++)
+            Assert.Equal(1, LogitsSampler.Sample(logits, p, NoContext, new Random(seed)));
+    }
+
+    [Fact]
+    public void HighMinP_KeepsOnlyNearTopTokens()
+    {
+        // Two dominant tokens (index 1,3) far above the rest. A high min-p prunes the tail so only 1 and 3
+        // can ever be sampled.
+        var logits = V(-5.0, 5.0, -5.0, 5.0, -5.0);
+        var p = new SamplingParameters { Temperature = 1.0, MinP = 0.5 };
+        var seen = new HashSet<int>();
+        for (int seed = 0; seed < 50; seed++)
+            seen.Add(LogitsSampler.Sample(logits, p, NoContext, new Random(seed)));
+        Assert.Subset(new HashSet<int> { 1, 3 }, seen);
+    }
+
+    // ---- Reproducibility ----------------------------------------------------------------
+
+    [Fact]
+    public void SeededSampling_IsReproducible()
+    {
+        var logits = V(1.0, 1.2, 0.9, 1.1, 0.8);
+        var p = new SamplingParameters { Temperature = 1.5 };
+
+        var first = new List<int>();
+        var rng1 = new Random(12345);
+        for (int i = 0; i < 30; i++) first.Add(LogitsSampler.Sample(logits, p, NoContext, rng1));
+
+        var second = new List<int>();
+        var rng2 = new Random(12345);
+        for (int i = 0; i < 30; i++) second.Add(LogitsSampler.Sample(logits, p, NoContext, rng2));
+
+        Assert.Equal(first, second);
+    }
+
+    // ---- Penalties ----------------------------------------------------------------------
+
+    [Fact]
+    public void RepetitionPenalty_CanFlipGreedyChoiceAwayFromRepeatedToken()
+    {
+        // Token 0 has the highest raw logit, but it already appears in the context. A strong repetition
+        // penalty should divide its (positive) logit enough that token 1 wins the argmax.
+        var logits = V(2.0, 1.8, 0.1);
+        var context = new List<int> { 0, 0, 0 };
+
+        int withoutPenalty = LogitsSampler.Sample(logits, Greedy(), context, new Random(0));
+        Assert.Equal(0, withoutPenalty); // no penalty configured -> raw argmax
+
+        var penalized = new SamplingParameters { Temperature = 0.0, RepetitionPenalty = 2.0 };
+        int withPenalty = LogitsSampler.Sample(logits, penalized, context, new Random(0));
+        Assert.Equal(1, withPenalty); // 2.0/2.0 = 1.0 < 1.8 -> token 1 now wins
+    }
+
+    [Fact]
+    public void FrequencyPenalty_ScalesWithCount()
+    {
+        // Token 0 leads by a small margin but appears many times; frequency penalty scaled by count should
+        // subtract enough to hand the argmax to token 1.
+        var logits = V(1.5, 1.0, 0.0);
+        var context = new List<int> { 0, 0, 0, 0, 0 }; // count = 5
+        var p = new SamplingParameters { Temperature = 0.0, FrequencyPenalty = 0.2 };
+        // 1.5 - 0.2*5 = 0.5 < 1.0 -> token 1
+        int token = LogitsSampler.Sample(logits, p, context, new Random(0));
+        Assert.Equal(1, token);
+    }
+
+    [Fact]
+    public void PresencePenalty_AppliesOncePerSeenToken()
+    {
+        var logits = V(1.0, 0.7, 0.0);
+        var context = new List<int> { 0, 0, 0 }; // appears, but presence applies once
+        var p = new SamplingParameters { Temperature = 0.0, PresencePenalty = 0.5 };
+        // 1.0 - 0.5 = 0.5 < 0.7 -> token 1
+        int token = LogitsSampler.Sample(logits, p, context, new Random(0));
+        Assert.Equal(1, token);
+    }
+
+    // ---- Distribution sanity ------------------------------------------------------------
+
+    [Fact]
+    public void UniformLogits_SampleRoughlyUniform()
+    {
+        var logits = V(0.0, 0.0, 0.0, 0.0);
+        var p = new SamplingParameters { Temperature = 1.0 };
+        var counts = new int[4];
+        var rng = new Random(2024);
+        const int draws = 20000;
+        for (int i = 0; i < draws; i++) counts[LogitsSampler.Sample(logits, p, NoContext, rng)]++;
+
+        double expected = draws / 4.0;
+        foreach (int c in counts)
+            Assert.InRange(c, expected * 0.85, expected * 1.15); // within 15% of uniform
+    }
+
+    [Fact]
+    public void HigherLogit_SampledMoreOften()
+    {
+        var logits = V(0.0, 2.0); // softmax ~ [0.12, 0.88]
+        var p = new SamplingParameters { Temperature = 1.0 };
+        int hi = 0;
+        var rng = new Random(7);
+        const int draws = 10000;
+        for (int i = 0; i < draws; i++) if (LogitsSampler.Sample(logits, p, NoContext, rng) == 1) hi++;
+        Assert.InRange(hi / (double)draws, 0.82, 0.94); // near 0.88
+    }
+
+    // ---- Validation ---------------------------------------------------------------------
+
+    [Fact]
+    public void EmptyLogits_Throws()
+    {
+        Assert.Throws<ArgumentException>(() =>
+            LogitsSampler.Sample(new Vector<double>(Array.Empty<double>()), Greedy(), NoContext, new Random(0)));
+    }
+}

--- a/tests/AiDotNet.Serving.Tests/ModelAgnosticServingTests.cs
+++ b/tests/AiDotNet.Serving.Tests/ModelAgnosticServingTests.cs
@@ -1,0 +1,129 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using AiDotNet.Configuration;
+using AiDotNet.Interfaces;
+using AiDotNet.Serving.Engine;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Serving.Tests;
+
+/// <summary>
+/// Demonstrates that the serving engine is model-agnostic: because it drives a model only through
+/// <see cref="ICausalLmModel{T}"/>, models that internally quantize their weights, or shard their forward pass
+/// across tensor-parallel / pipeline-parallel workers, serve unchanged. Also verifies KV-cache quantization
+/// raises the derived block-pool capacity.
+/// </summary>
+public class ModelAgnosticServingTests
+{
+    private const int Vocab = 64;
+
+    /// <summary>Simulates a tensor-parallel output projection: two "workers" each fill half of the vocab
+    /// logits in parallel, then the halves are concatenated — mimicking column-parallel + gather.</summary>
+    private sealed class TensorParallelCounterLm : ICausalLmModel<double>
+    {
+        public int VocabularySize => Vocab;
+        public int? EosTokenId => null;
+        public Tensor<double> ForwardLogits(Tensor<double> tokenIds)
+        {
+            int n = tokenIds.Shape[tokenIds.Shape.Length - 1];
+            int last = (int)Math.Round(Convert.ToDouble(tokenIds[0, n - 1]));
+            int target = (last + 1) % Vocab;
+            var t = new Tensor<double>(new[] { 1, n, Vocab });
+
+            int half = Vocab / 2;
+            Parallel.Invoke(
+                () => { for (int v = 0; v < half; v++) t[0, n - 1, v] = v == target ? 1.0 : 0.0; },
+                () => { for (int v = half; v < Vocab; v++) t[0, n - 1, v] = v == target ? 1.0 : 0.0; });
+            return t;
+        }
+    }
+
+    /// <summary>Simulates pipeline-parallel execution: the forward runs through sequential "stages" before
+    /// producing logits (each stage is a no-op transform here; the point is multi-stage forward serves).</summary>
+    private sealed class PipelineParallelCounterLm : ICausalLmModel<double>
+    {
+        public int VocabularySize => Vocab;
+        public int? EosTokenId => null;
+        public Tensor<double> ForwardLogits(Tensor<double> tokenIds)
+        {
+            int n = tokenIds.Shape[tokenIds.Shape.Length - 1];
+            int value = (int)Math.Round(Convert.ToDouble(tokenIds[0, n - 1]));
+            // Three sequential stages, each transforming the activation and passing it to the next (pipeline).
+            Func<int, int>[] stages = { x => x + 1, x => x - 1, x => x }; // net-identity across the pipeline
+            foreach (var stage in stages) value = stage(value);
+            int target = (value + 1) % Vocab;
+            var t = new Tensor<double>(new[] { 1, n, Vocab });
+            t[0, n - 1, target] = 1.0;
+            return t;
+        }
+    }
+
+    /// <summary>Simulates INT8 weight quantization: logits are rounded to a coarse grid (as a quantized model's
+    /// would be), which must not change the argmax the sampler selects.</summary>
+    private sealed class QuantizedCounterLm : ICausalLmModel<double>
+    {
+        public int VocabularySize => Vocab;
+        public int? EosTokenId => null;
+        public Tensor<double> ForwardLogits(Tensor<double> tokenIds)
+        {
+            int n = tokenIds.Shape[tokenIds.Shape.Length - 1];
+            int last = (int)Math.Round(Convert.ToDouble(tokenIds[0, n - 1]));
+            int target = (last + 1) % Vocab;
+            var t = new Tensor<double>(new[] { 1, n, Vocab });
+            for (int v = 0; v < Vocab; v++)
+            {
+                double logit = v == target ? 5.0 : 0.1 * (v % 3); // small noise on non-target logits
+                t[0, n - 1, v] = Math.Round(logit * 16.0) / 16.0;  // quantize to a coarse grid
+            }
+            return t;
+        }
+    }
+
+    private static int[] Run(ICausalLmModel<double> model, int prompt, int maxTokens)
+    {
+        using var engine = new ContinuousBatchingEngine<double>(new RecomputeModelRunner<double>(model));
+        engine.AddRequest(new GenerationRequest("r", new[] { prompt },
+            new SamplingParameters { Temperature = 0.0, MaxTokens = maxTokens }));
+        RequestOutput? final = null;
+        int steps = 0;
+        while (engine.HasUnfinishedRequests)
+        {
+            if (++steps > 1000) throw new InvalidOperationException("no convergence");
+            foreach (var o in engine.Step()) if (o.IsFinished) final = o;
+        }
+        return System.Linq.Enumerable.ToArray(final!.Outputs[0].TokenIds);
+    }
+
+    [Fact]
+    public void TensorParallelModel_ServesCorrectly()
+        => Assert.Equal(new[] { 6, 7, 8, 9 }, Run(new TensorParallelCounterLm(), 5, 4));
+
+    [Fact]
+    public void PipelineParallelModel_ServesCorrectly()
+        => Assert.Equal(new[] { 6, 7, 8, 9 }, Run(new PipelineParallelCounterLm(), 5, 4));
+
+    [Fact]
+    public void QuantizedModel_ServesCorrectly()
+        => Assert.Equal(new[] { 6, 7, 8, 9 }, Run(new QuantizedCounterLm(), 5, 4));
+
+    [Fact]
+    public void KvCacheQuantization_RaisesDerivedBlockCapacity()
+    {
+        var baseline = new InferenceOptimizationConfig { MaxBatchSize = 4, PagedKVCacheBlockSize = 16 };
+        var quantized = new InferenceOptimizationConfig
+        {
+            MaxBatchSize = 4,
+            PagedKVCacheBlockSize = 16,
+            KVCacheQuantization = KVCacheQuantizationMode.Int8,
+        };
+
+        var baseOpts = ServingConfigMapper.ToEngineOptions(baseline, maxContextTokens: 2048);
+        var quantOpts = ServingConfigMapper.ToEngineOptions(quantized, maxContextTokens: 2048);
+
+        Assert.Equal(KVCacheQuantizationMode.None, baseOpts.KvCacheQuantization);
+        Assert.Equal(KVCacheQuantizationMode.Int8, quantOpts.KvCacheQuantization);
+        Assert.Equal(2 * baseOpts.NumKvBlocks, quantOpts.NumKvBlocks); // Int8 KV ⇒ ~2× capacity
+    }
+}

--- a/tests/AiDotNet.Serving.Tests/PredictCausalLmAdapterTests.cs
+++ b/tests/AiDotNet.Serving.Tests/PredictCausalLmAdapterTests.cs
@@ -1,0 +1,72 @@
+using System;
+using AiDotNet.Serving.Engine;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Serving.Tests;
+
+/// <summary>
+/// Tests for <see cref="PredictCausalLmAdapter{T}"/> — the widest-coverage fallback that presents any
+/// token-in / vocab-width-logits-out forward function as an ICausalLmModel. Verified end-to-end through the
+/// engine so the adapter's forward + the recompute runner + the scheduler all agree.
+/// </summary>
+public class PredictCausalLmAdapterTests
+{
+    private const int Vocab = 64;
+
+    // A forward function that returns [1, seq, vocab] one-hot at (last+1) mod vocab for each position.
+    private static Tensor<double> CounterForward(Tensor<double> tokenIds)
+    {
+        int n = tokenIds.Shape[tokenIds.Shape.Length - 1];
+        var t = new Tensor<double>(new[] { 1, n, Vocab });
+        for (int p = 0; p < n; p++)
+        {
+            int last = (int)Math.Round(Convert.ToDouble(tokenIds[0, p]));
+            t[0, p, (last + 1) % Vocab] = 1.0;
+        }
+        return t;
+    }
+
+    [Fact]
+    public void Properties_AreExposed()
+    {
+        var adapter = new PredictCausalLmAdapter<double>(CounterForward, Vocab, eosTokenId: 7);
+        Assert.Equal(Vocab, adapter.VocabularySize);
+        Assert.Equal(7, adapter.EosTokenId);
+    }
+
+    [Fact]
+    public void NullForward_Throws()
+        => Assert.Throws<ArgumentNullException>(() => new PredictCausalLmAdapter<double>(null!, Vocab));
+
+    [Fact]
+    public void ZeroVocab_Throws()
+        => Assert.Throws<ArgumentOutOfRangeException>(() => new PredictCausalLmAdapter<double>(CounterForward, 0));
+
+    [Fact]
+    public void EndToEnd_ThroughEngine_ProducesDeterministicOutput()
+    {
+        var adapter = new PredictCausalLmAdapter<double>(CounterForward, Vocab);
+        using var engine = new ContinuousBatchingEngine<double>(new RecomputeModelRunner<double>(adapter));
+        engine.AddRequest(new GenerationRequest("r1", new[] { 3 },
+            new SamplingParameters { Temperature = 0.0, MaxTokens = 4 }));
+
+        RequestOutput? final = null;
+        int steps = 0;
+        while (engine.HasUnfinishedRequests)
+        {
+            if (++steps > 1000) throw new InvalidOperationException("no convergence");
+            foreach (var o in engine.Step()) if (o.IsFinished) final = o;
+        }
+
+        var completion = Assert.Single(final!.Outputs);
+        Assert.Equal(new[] { 4, 5, 6, 7 }, completion.TokenIds);
+    }
+
+    [Fact]
+    public void Factory_WithoutCapabilityOrVocab_ThrowsHelpfulError()
+    {
+        var ex = Assert.Throws<NotSupportedException>(() => ServingRunnerFactory.Create<double>("plain string"));
+        Assert.Contains("Predict-based adapter", ex.Message);
+    }
+}

--- a/tests/AiDotNet.Serving.Tests/PrefixCacheTests.cs
+++ b/tests/AiDotNet.Serving.Tests/PrefixCacheTests.cs
@@ -1,0 +1,123 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using AiDotNet.Serving.Engine;
+using Xunit;
+
+namespace AiDotNet.Serving.Tests;
+
+/// <summary>
+/// Tests for automatic cross-request prefix caching: a new request sharing a block-aligned prompt prefix with an
+/// earlier one reuses the cached KV. Correctness must be unchanged (caching only affects speed), and on the
+/// paged path the shared prefix must actually be skipped (fewer positions recomputed).
+/// </summary>
+public class PrefixCacheTests
+{
+    private const int Vocab = 32;
+
+    private static ReferencePagedAttentionRunner<double> NewRunner()
+        => new(vocabularySize: Vocab, dModel: 32, numLayers: 2, numHeads: 4, ffnDim: 64,
+               blockSize: 8, maxBlocks: 128, seed: 99);
+
+    private static int[] Generate(ContinuousBatchingEngine<double> engine, string id, int[] prompt, int maxTokens)
+    {
+        engine.AddRequest(new GenerationRequest(id, prompt,
+            new SamplingParameters { Temperature = 0.0, MaxTokens = maxTokens }));
+        RequestOutput? final = null;
+        int steps = 0;
+        while (engine.HasUnfinishedRequests)
+        {
+            if (++steps > 4000) throw new InvalidOperationException("no convergence");
+            foreach (var o in engine.Step()) if (o.RequestId == id && o.IsFinished) final = o;
+        }
+        return final!.Outputs[0].TokenIds.ToArray();
+    }
+
+    // ---- PrefixCache unit behavior ----
+
+    [Fact]
+    public void Cache_LookupAfterRegister_ReturnsLongestBlockAlignedPrefix()
+    {
+        var bm = new BlockManager(totalBlocks: 64, blockSize: 8);
+        var cache = new PrefixCache(bm, blockSize: 8, capacity: 16);
+
+        var prompt = Enumerable.Range(1, 24).ToArray(); // 24 tokens = 3 blocks
+        bm.Allocate("owner", 24);
+        cache.Register(prompt, "owner");
+
+        // A new prompt sharing the first 16 tokens (2 blocks) -> hit at length 16.
+        var other = prompt.Take(16).Concat(new[] { 99, 98 }).ToArray();
+        var hit = cache.Lookup(other);
+        Assert.NotNull(hit);
+        Assert.Equal(16, hit!.Value.PrefixLength);
+
+        // No shared prefix -> miss.
+        Assert.Null(cache.Lookup(new[] { 500, 501, 502, 503, 504, 505, 506, 507 }));
+    }
+
+    [Fact]
+    public void Cache_Evicts_Lru_BeyondCapacity()
+    {
+        var bm = new BlockManager(64, 8);
+        var cache = new PrefixCache(bm, 8, capacity: 1);
+
+        bm.Allocate("a", 8); cache.Register(Enumerable.Range(0, 8).ToArray(), "a");
+        bm.Allocate("b", 8); cache.Register(Enumerable.Range(100, 8).ToArray(), "b");
+
+        Assert.Equal(1, cache.Count); // capacity 1 -> only the newest remains
+        Assert.Null(cache.Lookup(Enumerable.Range(0, 8).ToArray()));       // evicted
+        Assert.NotNull(cache.Lookup(Enumerable.Range(100, 8).ToArray()));  // retained
+    }
+
+    // ---- Engine correctness: caching must not change output ----
+
+    [Fact]
+    public void SharedPrefix_SecondRequest_SameOutputWithOrWithoutCache()
+    {
+        var prompt1 = new[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12 };  // 16-token shared prefix below
+        var prompt2 = new[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 20, 21 };
+
+        int[] noCache;
+        using (var e = new ContinuousBatchingEngine<double>(new PagedRunnerAdapter<double>(NewRunner()),
+            new EngineOptions { BlockSize = 8, NumKvBlocks = 128 }))
+        {
+            Generate(e, "warm", prompt1, 3);
+            noCache = Generate(e, "q", prompt2, 6);
+        }
+
+        int[] cached;
+        using (var e = new ContinuousBatchingEngine<double>(new PagedRunnerAdapter<double>(NewRunner()),
+            new EngineOptions { BlockSize = 8, NumKvBlocks = 128, EnablePrefixCache = true }))
+        {
+            Generate(e, "warm", prompt2, 3); // registers the 16-token prefix of prompt2
+            cached = Generate(e, "q", prompt2, 6);
+        }
+
+        Assert.Equal(noCache, cached); // caching never changes the result
+    }
+
+    // ---- Engine efficiency: cached prefix is not recomputed on the paged path ----
+
+    [Fact]
+    public void SharedPrefix_PagedPath_SkipsCachedPrefixCompute()
+    {
+        var runner = NewRunner();
+        using var engine = new ContinuousBatchingEngine<double>(new PagedRunnerAdapter<double>(runner),
+            new EngineOptions { BlockSize = 8, NumKvBlocks = 128, EnablePrefixCache = true });
+
+        // First request: prompt of 16 tokens (2 blocks) -> registers the 16-token prefix.
+        var first = Enumerable.Range(1, 16).ToArray();
+        Generate(engine, "a", first, 2);
+        long afterFirst = runner.PositionsComputed;
+
+        // Second request shares the full 16-token prefix, then 2 new prompt tokens (within vocab).
+        var second = first.Concat(new[] { 17, 18 }).ToArray();
+        long before = runner.PositionsComputed;
+        Generate(engine, "b", second, 2);
+        long secondCost = runner.PositionsComputed - before;
+
+        // Without caching the second prefill would recompute all 18 prompt positions; with the cached 16-token
+        // prefix it computes only the 2 new prompt positions (+2 decode steps) — far fewer than 18.
+        Assert.True(secondCost < 18, $"expected cached prefix to be skipped; second request computed {secondCost} positions");
+    }
+}

--- a/tests/AiDotNet.Serving.Tests/PrefixSharingTests.cs
+++ b/tests/AiDotNet.Serving.Tests/PrefixSharingTests.cs
@@ -143,6 +143,39 @@ public class PrefixSharingTests
     }
 
     [Fact]
+    public void ParallelSampling_NonAlignedPrompt_PagedPath_SharesAlignedPrefix_AndAgrees()
+    {
+        // Prompt length 10 with block size 8 -> aligned prefix of 8 tokens is shared; only the 2-token tail is
+        // recomputed per sibling. Uses the paged runner so we can observe the compute savings.
+        var runner = new ReferencePagedAttentionRunner<double>(
+            vocabularySize: 32, dModel: 32, numLayers: 2, numHeads: 4, ffnDim: 64, blockSize: 8, maxBlocks: 128, seed: 7);
+        using var engine = new ContinuousBatchingEngine<double>(new PagedRunnerAdapter<double>(runner),
+            new EngineOptions { BlockSize = 8, NumKvBlocks = 128, MaxNumSequences = 8 });
+
+        var prompt = Enumerable.Range(1, 10).ToArray(); // 10 tokens (not a multiple of 8)
+        engine.AddRequest(new GenerationRequest("r1", prompt,
+            new SamplingParameters { Temperature = 0.0, MaxTokens = 4, N = 3 }));
+
+        RequestOutput? final = null;
+        int steps = 0;
+        while (engine.HasUnfinishedRequests)
+        {
+            if (++steps > 4000) throw new InvalidOperationException("no convergence");
+            foreach (var o in engine.Step()) if (o.IsFinished) final = o;
+        }
+
+        Assert.Equal(3, final!.Outputs.Count);
+        var reference = final.Outputs[0].TokenIds.ToArray();
+        foreach (var completion in final.Outputs)
+            Assert.Equal(reference, completion.TokenIds.ToArray());
+
+        // Owner prefills all 10 prompt positions; each of the 2 siblings recomputes only the 2-token tail (not
+        // the full 10). So total prefill positions is far below 3 * 10 = 30 independent prefills.
+        // owner(10) + 2 siblings * 2 tail + decode steps (3 seqs * up to 4) << 30 + 12.
+        Assert.True(runner.PositionsComputed < 30, $"expected shared aligned prefix; computed {runner.PositionsComputed} positions");
+    }
+
+    [Fact]
     public void ParallelSampling_AbortBeforePrefill_CleansUp()
     {
         using var engine = new ContinuousBatchingEngine<double>(new CounterRunner(),

--- a/tests/AiDotNet.Serving.Tests/PrefixSharingTests.cs
+++ b/tests/AiDotNet.Serving.Tests/PrefixSharingTests.cs
@@ -1,0 +1,159 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using AiDotNet.Serving.Engine;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Serving.Tests;
+
+/// <summary>
+/// Tests for prefix sharing: the <see cref="BlockManager.ForkPrefix"/> primitive and its use by the engine to
+/// let N&gt;1 parallel samples share one copy of the prompt's KV (prefill-once). Correctness must be unchanged;
+/// memory usage must drop when the prompt is shared.
+/// </summary>
+public class PrefixSharingTests
+{
+    private const int Vocab = 100;
+
+    private sealed class CounterRunner : IServingModelRunner<double>
+    {
+        public int VocabularySize => Vocab;
+        public int ExecuteCalls { get; private set; }
+        public IReadOnlyList<Vector<double>> Execute(IReadOnlyList<SequenceExecution<double>> batch)
+        {
+            ExecuteCalls++;
+            var result = new List<Vector<double>>(batch.Count);
+            foreach (var exec in batch)
+            {
+                int last = exec.AllTokenIds[exec.AllTokenIds.Count - 1];
+                var row = new double[Vocab];
+                row[(last + 1) % Vocab] = 1.0;
+                result.Add(new Vector<double>(row));
+            }
+            return result;
+        }
+    }
+
+    // ---- BlockManager.ForkPrefix -----------------------------------------------------
+
+    [Fact]
+    public void ForkPrefix_SharesOnlyPrefixBlocks()
+    {
+        var bm = new BlockManager(totalBlocks: 16, blockSize: 4);
+        bm.Allocate("p", 8);            // 2 blocks
+        bm.Append("p", 4);             // grows to 12 tokens -> 3 blocks
+        int usedBefore = bm.NumUsedBlocks;
+
+        var child = bm.ForkPrefix("p", "c", prefixTokens: 8).ToArray(); // share first 2 blocks only
+        var parent = bm.GetBlockTable("p");
+
+        Assert.Equal(2, child.Length);
+        Assert.Equal(parent[0], child[0]);
+        Assert.Equal(parent[1], child[1]);
+        Assert.Equal(usedBefore, bm.NumUsedBlocks); // sharing allocates nothing
+        Assert.Equal(8, bm.GetLength("c"));
+    }
+
+    [Fact]
+    public void ForkPrefix_SharedBlocks_ReclaimedOnlyWhenAllRelease()
+    {
+        var bm = new BlockManager(16, 4);
+        bm.Allocate("p", 8); // 2 blocks
+        bm.ForkPrefix("p", "c", 8);
+        Assert.Equal(2, bm.NumUsedBlocks);
+
+        bm.Free("c");
+        Assert.Equal(2, bm.NumUsedBlocks); // p still holds them
+        bm.Free("p");
+        Assert.Equal(0, bm.NumUsedBlocks);
+        Assert.Equal(16, bm.NumFreeBlocks);
+    }
+
+    [Fact]
+    public void ForkPrefix_PrefixBeyondParentLength_Throws()
+    {
+        var bm = new BlockManager(16, 4);
+        bm.Allocate("p", 4);
+        Assert.Throws<ArgumentOutOfRangeException>(() => bm.ForkPrefix("p", "c", 8));
+    }
+
+    // ---- Engine prefix sharing (N > 1) -----------------------------------------------
+
+    private static Dictionary<string, RequestOutput> RunToCompletion(ContinuousBatchingEngine<double> engine)
+    {
+        var final = new Dictionary<string, RequestOutput>();
+        int steps = 0;
+        while (engine.HasUnfinishedRequests)
+        {
+            if (++steps > 10000) throw new InvalidOperationException("no convergence");
+            foreach (var o in engine.Step()) if (o.IsFinished) final[o.RequestId] = o;
+        }
+        return final;
+    }
+
+    [Fact]
+    public void ParallelSampling_AlignedPrompt_SharesPromptBlocks_AndStaysCorrect()
+    {
+        var runner = new CounterRunner();
+        // BlockSize 4, prompt length 4 (block-aligned) -> siblings fork the single prompt block.
+        var options = new EngineOptions { BlockSize = 4, NumKvBlocks = 32 };
+        using var engine = new ContinuousBatchingEngine<double>(runner, options);
+
+        engine.AddRequest(new GenerationRequest("r1", new[] { 1, 2, 3, 4 },
+            new SamplingParameters { Temperature = 0.0, MaxTokens = 3, N = 3 }));
+
+        // After the first step the owner has prefilled and the siblings are forked; peak block usage should be
+        // far below 3 independent prompt copies. Track the max usage across the run.
+        int maxUsed = 0;
+        var final = new Dictionary<string, RequestOutput>();
+        int steps = 0;
+        while (engine.HasUnfinishedRequests)
+        {
+            if (++steps > 10000) throw new InvalidOperationException("no convergence");
+            foreach (var o in engine.Step()) if (o.IsFinished) final[o.RequestId] = o;
+            maxUsed = Math.Max(maxUsed, engine.GetStatistics().TotalKvBlocks - engine.GetStatistics().FreeKvBlocks);
+        }
+
+        var output = final["r1"];
+        Assert.Equal(3, output.Outputs.Count);
+        foreach (var completion in output.Outputs)
+            Assert.Equal(new[] { 5, 6, 7 }, completion.TokenIds); // greedy from prompt ...4 -> 5,6,7
+
+        // 3 independent sequences would each need 1 prompt block + up to 1 growth block = up to 6 blocks;
+        // with a shared prompt block the prompt costs 1 (not 3), so peak usage stays well under 6.
+        Assert.True(maxUsed <= 4, $"expected shared-prompt usage <= 4 blocks, saw {maxUsed}");
+    }
+
+    [Fact]
+    public void ParallelSampling_NonAlignedPrompt_FallsBack_ButStaysCorrect()
+    {
+        var runner = new CounterRunner();
+        var options = new EngineOptions { BlockSize = 4, NumKvBlocks = 64 };
+        using var engine = new ContinuousBatchingEngine<double>(runner, options);
+
+        // prompt length 3 (not a multiple of 4) -> fallback to independent prefill for each sibling.
+        engine.AddRequest(new GenerationRequest("r1", new[] { 1, 2, 3 },
+            new SamplingParameters { Temperature = 0.0, MaxTokens = 3, N = 3 }));
+
+        var output = RunToCompletion(engine)["r1"];
+        Assert.Equal(3, output.Outputs.Count);
+        foreach (var completion in output.Outputs)
+            Assert.Equal(new[] { 4, 5, 6 }, completion.TokenIds);
+    }
+
+    [Fact]
+    public void ParallelSampling_AbortBeforePrefill_CleansUp()
+    {
+        using var engine = new ContinuousBatchingEngine<double>(new CounterRunner(),
+            new EngineOptions { BlockSize = 4, NumKvBlocks = 32 });
+        engine.AddRequest(new GenerationRequest("r1", new[] { 1, 2, 3, 4 },
+            new SamplingParameters { Temperature = 0.0, MaxTokens = 100, N = 3 }));
+
+        Assert.True(engine.AbortRequest("r1")); // abort before any step
+        RunToCompletion(engine);
+        Assert.False(engine.HasUnfinishedRequests);
+        Assert.Equal(0, engine.GetStatistics().RunningSequences);
+        Assert.Equal(0.0, engine.GetStatistics().KvCacheUsage);
+    }
+}

--- a/tests/AiDotNet.Serving.Tests/RecomputeModelRunnerTests.cs
+++ b/tests/AiDotNet.Serving.Tests/RecomputeModelRunnerTests.cs
@@ -1,0 +1,101 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using AiDotNet.Interfaces;
+using AiDotNet.Serving.Engine;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Serving.Tests;
+
+/// <summary>
+/// Tests for <see cref="RecomputeModelRunner{T}"/> — the adapter that drives any <see cref="ICausalLmModel{T}"/>
+/// in the engine by recomputing logits from the full token sequence. Covers last-position extraction across the
+/// output ranks a model may return ([vocab], [seq,vocab], [1,seq,vocab]) and an end-to-end run through the
+/// continuous-batching engine.
+/// </summary>
+public class RecomputeModelRunnerTests
+{
+    private const int Vocab = 100;
+
+    /// <summary>Deterministic counter LM: next token = (last token + 1) mod vocab, emitted as one-hot logits
+    /// at the requested output rank so the adapter's shape handling is exercised.</summary>
+    private sealed class CounterLm : ICausalLmModel<double>
+    {
+        private readonly int _rank;
+        public CounterLm(int rank) => _rank = rank;
+
+        public int VocabularySize => Vocab;
+        public int? EosTokenId => null;
+
+        public Tensor<double> ForwardLogits(Tensor<double> tokenIds)
+        {
+            int n = tokenIds.Shape[tokenIds.Shape.Length - 1];
+            int last = (int)Math.Round(Convert.ToDouble(tokenIds[0, n - 1]));
+
+            switch (_rank)
+            {
+                case 1:
+                {
+                    var t = new Tensor<double>(new[] { Vocab });
+                    t[(last + 1) % Vocab] = 1.0;
+                    return t;
+                }
+                case 2:
+                {
+                    var t = new Tensor<double>(new[] { n, Vocab });
+                    t[n - 1, (last + 1) % Vocab] = 1.0; // last position one-hot
+                    return t;
+                }
+                default:
+                {
+                    var t = new Tensor<double>(new[] { 1, n, Vocab });
+                    t[0, n - 1, (last + 1) % Vocab] = 1.0;
+                    return t;
+                }
+            }
+        }
+    }
+
+    private static SequenceExecution<double> Exec(params int[] tokens)
+        => new("s", tokens, tokens.Length, Array.Empty<int>(), Array.Empty<BlockCopy>(), true);
+
+    [Theory]
+    [InlineData(1)]
+    [InlineData(2)]
+    [InlineData(3)]
+    public void Execute_ExtractsLastPositionLogits_ForEachRank(int rank)
+    {
+        var runner = new RecomputeModelRunner<double>(new CounterLm(rank));
+        Assert.Equal(Vocab, runner.VocabularySize);
+
+        var logits = Assert.Single(runner.Execute(new[] { Exec(5, 6, 41) }));
+        // Argmax should be (41 + 1) = 42.
+        int argmax = Enumerable.Range(0, Vocab).Aggregate((a, b) => logits[b] > logits[a] ? b : a);
+        Assert.Equal(42, argmax);
+    }
+
+    [Fact]
+    public void NullModel_Throws()
+        => Assert.Throws<ArgumentNullException>(() => new RecomputeModelRunner<double>(null!));
+
+    [Fact]
+    public void EndToEnd_ThroughEngine_ProducesDeterministicCounterOutput()
+    {
+        using var engine = new ContinuousBatchingEngine<double>(new RecomputeModelRunner<double>(new CounterLm(3)));
+        engine.AddRequest(new GenerationRequest("r1", new[] { 5 },
+            new SamplingParameters { Temperature = 0.0, MaxTokens = 4 }));
+
+        RequestOutput? final = null;
+        int steps = 0;
+        while (engine.HasUnfinishedRequests)
+        {
+            if (++steps > 1000) throw new InvalidOperationException("no convergence");
+            foreach (var o in engine.Step()) if (o.IsFinished) final = o;
+        }
+
+        var completion = Assert.Single(final!.Outputs);
+        Assert.Equal(new[] { 6, 7, 8, 9 }, completion.TokenIds);
+        Assert.Equal("length", completion.FinishReason);
+    }
+}

--- a/tests/AiDotNet.Serving.Tests/ReferencePagedAttentionRunnerTests.cs
+++ b/tests/AiDotNet.Serving.Tests/ReferencePagedAttentionRunnerTests.cs
@@ -1,0 +1,103 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using AiDotNet.Serving.Engine;
+using Xunit;
+
+namespace AiDotNet.Serving.Tests;
+
+/// <summary>
+/// Tests for <see cref="ReferencePagedAttentionRunner{T}"/> — a real paged-attention causal LM. The load-bearing
+/// invariant: driving it via the paged fast path (incremental prefill + decode over block tables) yields output
+/// bit-identical to driving it via full recompute — proving the KV paging (block tables, per-step decode, prefix
+/// sharing) is correct. This is the conformance contract a production GPU paged runner must also meet.
+/// </summary>
+public class ReferencePagedAttentionRunnerTests
+{
+    private const int Vocab = 32;
+
+    private static ReferencePagedAttentionRunner<double> NewRunner()
+        => new(vocabularySize: Vocab, dModel: 32, numLayers: 2, numHeads: 4, ffnDim: 64,
+               blockSize: 8, maxBlocks: 64, seed: 2026);
+
+    private static EngineOptions Options()
+        => new() { BlockSize = 8, NumKvBlocks = 64, MaxNumSequences = 8 };
+
+    private static int[] Generate(ContinuousBatchingEngine<double> engine, string id, int[] prompt, int maxTokens)
+    {
+        engine.AddRequest(new GenerationRequest(id, prompt,
+            new SamplingParameters { Temperature = 0.0, MaxTokens = maxTokens }));
+        RequestOutput? final = null;
+        int steps = 0;
+        while (engine.HasUnfinishedRequests)
+        {
+            if (++steps > 2000) throw new InvalidOperationException("no convergence");
+            foreach (var o in engine.Step()) if (o.RequestId == id && o.IsFinished) final = o;
+        }
+        return final!.Outputs[0].TokenIds.ToArray();
+    }
+
+    [Fact]
+    public void PagedFastPath_MatchesFullRecompute()
+    {
+        var runner = NewRunner();
+        var prompt = new[] { 3, 1, 4, 1, 5, 9, 2, 6 }; // length 8 (block-aligned)
+
+        // Paged path: the runner is selected as ICausalLmRunner -> PagedRunnerAdapter (incremental KV).
+        int[] paged;
+        using (var engine = new ContinuousBatchingEngine<double>(new PagedRunnerAdapter<double>(runner), Options()))
+            paged = Generate(engine, "p", prompt, 12);
+
+        // Recompute path: same runner as ICausalLmModel -> full ForwardLogits each step.
+        int[] recompute;
+        using (var engine = new ContinuousBatchingEngine<double>(new RecomputeModelRunner<double>(runner), Options()))
+            recompute = Generate(engine, "r", prompt, 12);
+
+        Assert.Equal(recompute, paged); // paged incremental decode == full recompute
+        Assert.Equal(12, paged.Length);
+    }
+
+    [Fact]
+    public void Factory_SelectsPagedFastPath()
+    {
+        var selection = ServingRunnerFactory.Create<double>(NewRunner());
+        Assert.IsType<PagedRunnerAdapter<double>>(selection.Runner);
+    }
+
+    [Fact]
+    public void ServesThroughTextGenerator()
+    {
+        var runner = NewRunner();
+        using var gen = new TextGenerator<double>(runner, options: Options());
+        var ids = gen.Generate(new[] { 2, 7, 1, 8, 2, 8, 1, 8 }, new SamplingParameters { Temperature = 0.0, MaxTokens = 6 });
+        Assert.Equal(6, ids.Count);
+        Assert.All(ids, t => Assert.InRange(t, 0, Vocab - 1));
+    }
+
+    [Fact]
+    public void ParallelSampling_PagedPath_SharesPromptKv_AndAgrees()
+    {
+        var runner = NewRunner();
+        using var engine = new ContinuousBatchingEngine<double>(new PagedRunnerAdapter<double>(runner), Options());
+
+        var prompt = new[] { 1, 2, 3, 4, 5, 6, 7, 8 }; // length 8 = 1 block -> siblings fork the owner's KV
+        engine.AddRequest(new GenerationRequest("r1", prompt,
+            new SamplingParameters { Temperature = 0.0, MaxTokens = 5, N = 3 }));
+
+        RequestOutput? final = null;
+        int steps = 0;
+        while (engine.HasUnfinishedRequests)
+        {
+            if (++steps > 2000) throw new InvalidOperationException("no convergence");
+            foreach (var o in engine.Step()) if (o.IsFinished) final = o;
+        }
+
+        // All three sequences decode from the SHARED prompt KV (the owner's blocks). Greedy + same prompt =>
+        // identical outputs, which also confirms the siblings read the owner's cached prompt KV correctly.
+        Assert.Equal(3, final!.Outputs.Count);
+        var reference = final.Outputs[0].TokenIds.ToArray();
+        Assert.Equal(5, reference.Length);
+        foreach (var completion in final.Outputs)
+            Assert.Equal(reference, completion.TokenIds.ToArray());
+    }
+}

--- a/tests/AiDotNet.Serving.Tests/ServingConfigMapperTests.cs
+++ b/tests/AiDotNet.Serving.Tests/ServingConfigMapperTests.cs
@@ -87,6 +87,32 @@ public class ServingConfigMapperTests
     }
 
     [Fact]
+    public void PagedModelSizing_DerivesBlocksFromMemoryBudgetAndShape()
+    {
+        // 4 layers, 8 kv heads, headDim 64, block 16, fp16 -> 2*4*8*64*16*2 = 131,072 bytes = 128 KiB/block.
+        // A 64 MiB budget therefore yields 64 MiB / 128 KiB = 512 blocks.
+        var config = new InferenceOptimizationConfig { KVCacheMaxSizeMB = 64, MaxBatchSize = 8 };
+        long perBlock = ServingConfigMapper.KvBytesPerBlock(4, 8, 64, 16, KVCacheQuantizationMode.None);
+        Assert.Equal(131072L, perBlock);
+
+        var opts = ServingConfigMapper.ToEngineOptionsForPagedModel(config, null, 4, 8, 64, 16);
+        Assert.Equal(16, opts.BlockSize);
+        Assert.Equal(512, opts.NumKvBlocks); // 64 MiB / 128 KiB
+        opts.Validate();
+    }
+
+    [Fact]
+    public void PagedModelSizing_Int8_FitsTwiceAsManyBlocks()
+    {
+        var fp16 = new InferenceOptimizationConfig { KVCacheMaxSizeMB = 64 };
+        var int8 = new InferenceOptimizationConfig { KVCacheMaxSizeMB = 64, KVCacheQuantization = KVCacheQuantizationMode.Int8 };
+
+        var a = ServingConfigMapper.ToEngineOptionsForPagedModel(fp16, null, 4, 8, 64, 16);
+        var b = ServingConfigMapper.ToEngineOptionsForPagedModel(int8, null, 4, 8, 64, 16);
+        Assert.Equal(2 * a.NumKvBlocks, b.NumKvBlocks);
+    }
+
+    [Fact]
     public void SpeculationHelpers_ReadConfig()
     {
         Assert.False(ServingConfigMapper.IsSpeculativeEnabled(null));

--- a/tests/AiDotNet.Serving.Tests/ServingConfigMapperTests.cs
+++ b/tests/AiDotNet.Serving.Tests/ServingConfigMapperTests.cs
@@ -1,0 +1,116 @@
+using System;
+using System.Collections.Generic;
+using AiDotNet.Configuration;
+using AiDotNet.Interfaces;
+using AiDotNet.Agentic.Models.Local;
+using AiDotNet.Serving.Engine;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Serving.Tests;
+
+/// <summary>
+/// Tests for the config bridge (<see cref="ServingConfigMapper"/>) and tokenizer auto-resolution — the pieces
+/// that let the serving engine be configured from the library-wide <see cref="InferenceOptimizationConfig"/>
+/// with no hand-tuning, and let a model carry its own tokenizer.
+/// </summary>
+public class ServingConfigMapperTests
+{
+    private const int Vocab = 128;
+
+    private sealed class CounterLm : ICausalLmModel<double>
+    {
+        public int VocabularySize => Vocab;
+        public int? EosTokenId => null;
+        public Tensor<double> ForwardLogits(Tensor<double> tokenIds)
+        {
+            int n = tokenIds.Shape[tokenIds.Shape.Length - 1];
+            int last = (int)Math.Round(Convert.ToDouble(tokenIds[0, n - 1]));
+            var t = new Tensor<double>(new[] { 1, n, Vocab });
+            t[0, n - 1, (last + 1) % Vocab] = 1.0;
+            return t;
+        }
+    }
+
+    private sealed class CharTokenizer : IGenerationTokenizer
+    {
+        public int EosTokenId => -1;
+        public IReadOnlyList<int> Encode(string text) => System.Linq.Enumerable.ToArray(System.Linq.Enumerable.Select(text, c => (int)c));
+        public string Decode(IReadOnlyList<int> tokenIds) => new string(System.Linq.Enumerable.ToArray(System.Linq.Enumerable.Select(tokenIds, id => (char)id)));
+    }
+
+    // A model that carries its own tokenizer.
+    private sealed class SelfTokenizingLm : ICausalLmModel<double>, IProvidesGenerationTokenizer
+    {
+        private readonly CounterLm _inner = new();
+        public int VocabularySize => _inner.VocabularySize;
+        public int? EosTokenId => _inner.EosTokenId;
+        public Tensor<double> ForwardLogits(Tensor<double> tokenIds) => _inner.ForwardLogits(tokenIds);
+        public IGenerationTokenizer GetGenerationTokenizer() => new CharTokenizer();
+    }
+
+    [Fact]
+    public void Default_ProducesUsableOptions()
+    {
+        var opts = ServingConfigMapper.ToEngineOptions(null);
+        opts.Validate(); // must be valid
+        Assert.Equal(16, opts.BlockSize); // InferenceOptimizationConfig.Default PagedKVCacheBlockSize
+        Assert.True(opts.MaxNumSequences >= 1);
+        Assert.True(opts.NumKvBlocks >= opts.MaxNumSequences);
+    }
+
+    [Fact]
+    public void MapsBatchAndBlockSize_FromConfig()
+    {
+        var config = new InferenceOptimizationConfig
+        {
+            EnableBatching = true,
+            MaxBatchSize = 8,
+            PagedKVCacheBlockSize = 32,
+        };
+        var opts = ServingConfigMapper.ToEngineOptions(config, eosTokenId: 5, maxContextTokens: 2048);
+
+        Assert.Equal(32, opts.BlockSize);
+        Assert.Equal(8, opts.MaxNumSequences);
+        Assert.Equal(5, opts.EosTokenId);
+        // 8 sequences must each fit ceil(2048/32)+1 = 65 blocks -> pool >= 8*65.
+        Assert.True(opts.NumKvBlocks >= 8 * 65);
+        opts.Validate();
+    }
+
+    [Fact]
+    public void BatchingDisabled_UsesSingleSequence()
+    {
+        var config = new InferenceOptimizationConfig { EnableBatching = false, MaxBatchSize = 64 };
+        var opts = ServingConfigMapper.ToEngineOptions(config);
+        Assert.Equal(1, opts.MaxNumSequences);
+    }
+
+    [Fact]
+    public void SpeculationHelpers_ReadConfig()
+    {
+        Assert.False(ServingConfigMapper.IsSpeculativeEnabled(null));
+        var spec = new InferenceOptimizationConfig { EnableSpeculativeDecoding = true, SpeculationDepth = 6 };
+        Assert.True(ServingConfigMapper.IsSpeculativeEnabled(spec));
+        Assert.Equal(6, ServingConfigMapper.SpeculationDepth(spec));
+    }
+
+    [Fact]
+    public void TextGenerator_AutoResolvesTokenizer_FromModel()
+    {
+        using var gen = new TextGenerator<double>(new SelfTokenizingLm());
+        // No tokenizer passed; the model provides one. 'A'(65) -> 'B','C' via counter.
+        var text = gen.Generate("A", new SamplingParameters { Temperature = 0.0, MaxTokens = 2 });
+        Assert.Equal("BC", text);
+    }
+
+    [Fact]
+    public void TextGenerator_ConfigDerivesEngineOptions()
+    {
+        var config = new InferenceOptimizationConfig { MaxBatchSize = 4, PagedKVCacheBlockSize = 16 };
+        using var gen = new TextGenerator<double>(new CounterLm(), config: config);
+        // Still generates correctly with config-derived options.
+        var ids = gen.Generate(new[] { 1 }, new SamplingParameters { Temperature = 0.0, MaxTokens = 3 });
+        Assert.Equal(new[] { 2, 3, 4 }, ids);
+    }
+}

--- a/tests/AiDotNet.Serving.Tests/SpeculativeGeneratorTests.cs
+++ b/tests/AiDotNet.Serving.Tests/SpeculativeGeneratorTests.cs
@@ -144,12 +144,52 @@ public class SpeculativeGeneratorTests
         Assert.Equal(13, gen.Count);
     }
 
-    [Fact]
-    public void NonGreedySampling_Throws()
+    /// <summary>A model whose logits are a fixed distribution at every position (independent of input), so the
+    /// target's per-step sampling distribution is a known constant we can compare the empirical output against.</summary>
+    private sealed class FixedDistLm : ICausalLmModel<double>
     {
-        var spec = new SpeculativeGenerator<double>(new CycleLm());
-        Assert.Throws<NotSupportedException>(() =>
-            spec.Generate(new[] { 1 }, new SamplingParameters { Temperature = 1.0, MaxTokens = 5 }));
+        // softmax([ln .4, ln .3, ln .2, ln .1]) = [.4, .3, .2, .1]; remaining vocab strongly negative.
+        private static readonly double[] Probs = { 0.4, 0.3, 0.2, 0.1 };
+        public int VocabularySize => Vocab;
+        public int? EosTokenId => null;
+        public Tensor<double> ForwardLogits(Tensor<double> tokenIds)
+        {
+            int n = tokenIds.Shape[tokenIds.Shape.Length - 1];
+            var t = new Tensor<double>(new[] { 1, n, Vocab });
+            for (int p = 0; p < n; p++)
+                for (int v = 0; v < Vocab; v++)
+                    t[0, p, v] = v < Probs.Length ? System.Math.Log(Probs[v]) : -50.0;
+            return t;
+        }
+        public static double[] Distribution => Probs;
+    }
+
+    [Fact]
+    public void StochasticSpeculative_OutputDistribution_MatchesTargetDistribution()
+    {
+        // Speculative sampling's guarantee: the emitted-token distribution equals the target's sampling
+        // distribution, regardless of the (point-mass) drafter. Histogram a long run and compare.
+        var spec = new SpeculativeGenerator<double>(new FixedDistLm(), new PromptLookupDrafter(), maxDraftTokens: 4);
+        var gen = spec.Generate(new[] { 0 },
+            new SamplingParameters { Temperature = 1.0, MaxTokens = 6000, Seed = 12345 });
+
+        var counts = new int[4];
+        foreach (int tok in gen) if (tok < 4) counts[tok]++;
+
+        for (int v = 0; v < 4; v++)
+        {
+            double freq = counts[v] / (double)gen.Count;
+            Assert.InRange(freq, FixedDistLm.Distribution[v] - 0.03, FixedDistLm.Distribution[v] + 0.03);
+        }
+    }
+
+    [Fact]
+    public void StochasticSpeculative_Seeded_IsReproducible()
+    {
+        var spec = new SpeculativeGenerator<double>(new FixedDistLm(), new PromptLookupDrafter());
+        var a = spec.Generate(new[] { 0 }, new SamplingParameters { Temperature = 1.0, MaxTokens = 50, Seed = 7 });
+        var b = spec.Generate(new[] { 0 }, new SamplingParameters { Temperature = 1.0, MaxTokens = 50, Seed = 7 });
+        Assert.Equal(a, b);
     }
 
     // ---- Prompt-lookup drafter -----------------------------------------------------------

--- a/tests/AiDotNet.Serving.Tests/SpeculativeGeneratorTests.cs
+++ b/tests/AiDotNet.Serving.Tests/SpeculativeGeneratorTests.cs
@@ -1,0 +1,186 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using AiDotNet.Interfaces;
+using AiDotNet.Serving.Engine;
+using AiDotNet.Serving.Engine.Speculative;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Serving.Tests;
+
+/// <summary>
+/// Tests for greedy speculative decoding. The load-bearing invariant: speculative output is bit-identical to
+/// plain greedy decoding of the same model, regardless of draft quality. Also verifies that speculation
+/// actually accepts tokens (and beats one-token-per-pass) on predictable, repetitive output, plus the
+/// prompt-lookup drafter's matching behavior.
+/// </summary>
+public class SpeculativeGeneratorTests
+{
+    private const int Vocab = 20;
+
+    /// <summary>Strictly-increasing counter (no repeats ⇒ prompt-lookup finds nothing; tests correctness with
+    /// ~zero acceptance).</summary>
+    private sealed class CounterLm : ICausalLmModel<double>
+    {
+        public int VocabularySize => Vocab;
+        public int? EosTokenId => null;
+        public Tensor<double> ForwardLogits(Tensor<double> tokenIds)
+        {
+            int n = tokenIds.Shape[tokenIds.Shape.Length - 1];
+            var t = new Tensor<double>(new[] { 1, n, Vocab });
+            for (int p = 0; p < n; p++)
+            {
+                int last = (int)Math.Round(Convert.ToDouble(tokenIds[0, p]));
+                t[0, p, (last + 1) % Vocab] = 1.0;
+            }
+            return t;
+        }
+    }
+
+    /// <summary>Cyclic model (1→2→3→4→5→1…): its greedy output repeats with period 5, so prompt-lookup drafts
+    /// correctly after one period ⇒ high acceptance.</summary>
+    private sealed class CycleLm : ICausalLmModel<double>
+    {
+        public int VocabularySize => Vocab;
+        public int? EosTokenId => null;
+        public Tensor<double> ForwardLogits(Tensor<double> tokenIds)
+        {
+            int n = tokenIds.Shape[tokenIds.Shape.Length - 1];
+            var t = new Tensor<double>(new[] { 1, n, Vocab });
+            for (int p = 0; p < n; p++)
+            {
+                int last = (int)Math.Round(Convert.ToDouble(tokenIds[0, p]));
+                t[0, p, (last % 5) + 1] = 1.0;
+            }
+            return t;
+        }
+    }
+
+    // Reference plain-greedy decode (one token per forward pass).
+    private static int[] PlainGreedy(ICausalLmModel<double> model, int[] prompt, int maxTokens)
+    {
+        var ctx = new List<int>(prompt);
+        var gen = new List<int>();
+        while (gen.Count < maxTokens)
+        {
+            var input = new Tensor<double>(new[] { 1, ctx.Count });
+            for (int i = 0; i < ctx.Count; i++) input[0, i] = ctx[i];
+            var logits = model.ForwardLogits(input);
+            int last = ctx.Count - 1;
+            int best = 0; double bestScore = logits[0, last, 0];
+            for (int v = 1; v < Vocab; v++)
+                if (logits[0, last, v] > bestScore) { bestScore = logits[0, last, v]; best = v; }
+            gen.Add(best); ctx.Add(best);
+        }
+        return gen.ToArray();
+    }
+
+    private static SamplingParameters Greedy(int maxTokens, int minTokens = 0, IReadOnlyList<int>? stops = null)
+        => new() { Temperature = 0.0, MaxTokens = maxTokens, MinTokens = minTokens, StopTokenIds = stops };
+
+    // ---- Correctness invariant -----------------------------------------------------------
+
+    [Theory]
+    [InlineData(3)]
+    [InlineData(7)]
+    [InlineData(30)]
+    public void SpeculativeGreedy_MatchesPlainGreedy_OnCyclicModel(int maxTokens)
+    {
+        var model = new CycleLm();
+        var spec = new SpeculativeGenerator<double>(model, new PromptLookupDrafter(), maxDraftTokens: 4);
+
+        var expected = PlainGreedy(model, new[] { 1 }, maxTokens);
+        var actual = spec.Generate(new[] { 1 }, Greedy(maxTokens));
+
+        Assert.Equal(expected, actual);
+    }
+
+    [Fact]
+    public void SpeculativeGreedy_MatchesPlainGreedy_OnNonRepetitiveModel()
+    {
+        var model = new CounterLm();
+        var spec = new SpeculativeGenerator<double>(model, new PromptLookupDrafter(), maxDraftTokens: 4);
+
+        var expected = PlainGreedy(model, new[] { 5 }, 12);
+        var actual = spec.Generate(new[] { 5 }, Greedy(12), out var stats);
+
+        Assert.Equal(expected, actual);
+        // No repeats to draft from, but correctness still holds and every round still emits its bonus token.
+        Assert.Equal(12, stats.GeneratedTokens);
+    }
+
+    // ---- Speculation actually pays off ---------------------------------------------------
+
+    [Fact]
+    public void CyclicModel_AcceptsDrafts_AndBeatsOnePassPerToken()
+    {
+        var spec = new SpeculativeGenerator<double>(new CycleLm(), new PromptLookupDrafter(), maxDraftTokens: 4);
+        spec.Generate(new[] { 1 }, Greedy(40), out var stats);
+
+        Assert.True(stats.AcceptedTokens > 0, "cyclic output should let the drafter accept tokens");
+        Assert.True(stats.TargetForwardPasses < stats.GeneratedTokens,
+            "fewer target passes than tokens generated proves the speedup");
+        Assert.True(stats.TokensPerForwardPass > 1.0);
+        Assert.InRange(stats.AcceptanceRate, 0.0, 1.0);
+    }
+
+    // ---- Stop conditions honored ---------------------------------------------------------
+
+    [Fact]
+    public void StopToken_EndsSpeculativeGeneration()
+    {
+        var spec = new SpeculativeGenerator<double>(new CycleLm(), new PromptLookupDrafter());
+        // cycle from 1: 2,3,4,5,1,... stop at token 4.
+        var gen = spec.Generate(new[] { 1 }, Greedy(100, stops: new[] { 4 }));
+        Assert.Equal(new[] { 2, 3, 4 }, gen);
+    }
+
+    [Fact]
+    public void MaxTokens_IsNeverExceeded()
+    {
+        var spec = new SpeculativeGenerator<double>(new CycleLm(), new PromptLookupDrafter(), maxDraftTokens: 8);
+        var gen = spec.Generate(new[] { 1 }, Greedy(13));
+        Assert.Equal(13, gen.Count);
+    }
+
+    [Fact]
+    public void NonGreedySampling_Throws()
+    {
+        var spec = new SpeculativeGenerator<double>(new CycleLm());
+        Assert.Throws<NotSupportedException>(() =>
+            spec.Generate(new[] { 1 }, new SamplingParameters { Temperature = 1.0, MaxTokens = 5 }));
+    }
+
+    // ---- Prompt-lookup drafter -----------------------------------------------------------
+
+    [Fact]
+    public void PromptLookup_DraftsContinuationOfRepeatedNgram()
+    {
+        var drafter = new PromptLookupDrafter(maxNgram: 2, minNgram: 1);
+        // Trailing "7 8" last occurred at index 1..2; it was followed there by 9,4,5 — so those are drafted
+        // (draft accuracy is irrelevant; the target verifies every guess).
+        var context = new[] { 1, 7, 8, 9, 4, 5, 7, 8 };
+        var draft = drafter.Draft(context, maxDraftTokens: 3);
+        Assert.Equal(new[] { 9, 4, 5 }, draft.ToArray());
+    }
+
+    [Fact]
+    public void PromptLookup_NoMatch_ReturnsEmpty()
+    {
+        var drafter = new PromptLookupDrafter();
+        var draft = drafter.Draft(new[] { 1, 2, 3, 4, 5 }, 3);
+        Assert.Empty(draft);
+    }
+
+    [Fact]
+    public void PromptLookup_RespectsMaxDraftTokens()
+    {
+        var drafter = new PromptLookupDrafter(maxNgram: 1, minNgram: 1);
+        // repeated "9" pattern: 9 a b c 9 -> earlier "9" followed by a,b,c...
+        var context = new[] { 9, 3, 4, 5, 6, 9 };
+        var draft = drafter.Draft(context, maxDraftTokens: 2);
+        Assert.Equal(2, draft.Count);
+        Assert.Equal(new[] { 3, 4 }, draft.ToArray());
+    }
+}

--- a/tests/AiDotNet.Serving.Tests/TextGeneratorTests.cs
+++ b/tests/AiDotNet.Serving.Tests/TextGeneratorTests.cs
@@ -1,0 +1,144 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using AiDotNet.Agentic.Models.Local;
+using AiDotNet.Interfaces;
+using AiDotNet.Serving.Engine;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Serving.Tests;
+
+/// <summary>
+/// Tests for the beginner-facing generation facade: <see cref="TextGenerator{T}"/>, the
+/// <see cref="ServingRunnerFactory"/> runner selection, and the paged fast-path adapter. Uses deterministic
+/// counter models so exact output can be asserted.
+/// </summary>
+public class TextGeneratorTests
+{
+    private const int Vocab = 128;
+
+    private sealed class CounterLm : ICausalLmModel<double>
+    {
+        public int VocabularySize => Vocab;
+        public int? EosTokenId => null;
+        public Tensor<double> ForwardLogits(Tensor<double> tokenIds)
+        {
+            int n = tokenIds.Shape[tokenIds.Shape.Length - 1];
+            int last = (int)Math.Round(Convert.ToDouble(tokenIds[0, n - 1]));
+            var t = new Tensor<double>(new[] { 1, n, Vocab });
+            t[0, n - 1, (last + 1) % Vocab] = 1.0;
+            return t;
+        }
+    }
+
+    // Fast-path counter: implements the paged runner capability; ignores KV (stateless counter).
+    private sealed class CounterPagedRunner : ICausalLmRunner<double>
+    {
+        public int VocabularySize => Vocab;
+        public int NumLayers => 1;
+        public int NumKvHeads => 1;
+        public int HeadDim => 1;
+        public int BlockSize => 16;
+        public int PrefillCalls { get; private set; }
+        public int DecodeCalls { get; private set; }
+
+        public Tensor<double> Prefill(
+            IReadOnlyList<IReadOnlyList<int>> tokenIdsPerSequence,
+            IReadOnlyList<SequenceKvLayout> layouts,
+            IReadOnlyList<int> tokenCounts)
+        {
+            PrefillCalls++;
+            var t = new Tensor<double>(new[] { tokenIdsPerSequence.Count, Vocab });
+            for (int i = 0; i < tokenIdsPerSequence.Count; i++)
+            {
+                var seq = tokenIdsPerSequence[i];
+                int last = seq[seq.Count - 1];
+                t[i, (last + 1) % Vocab] = 1.0;
+            }
+            return t;
+        }
+
+        public Tensor<double> DecodeStep(IReadOnlyList<int> lastTokenIds, IReadOnlyList<SequenceKvLayout> layouts)
+        {
+            DecodeCalls++;
+            var t = new Tensor<double>(new[] { lastTokenIds.Count, Vocab });
+            for (int i = 0; i < lastTokenIds.Count; i++)
+                t[i, (lastTokenIds[i] + 1) % Vocab] = 1.0;
+            return t;
+        }
+
+        public void CopyBlocks(IReadOnlyList<BlockCopy> copies) { }
+    }
+
+    // Minimal char-level tokenizer: char <-> (int)char; no EOS.
+    private sealed class CharTokenizer : IGenerationTokenizer
+    {
+        public int EosTokenId => -1;
+        public IReadOnlyList<int> Encode(string text) => text.Select(c => (int)c).ToArray();
+        public string Decode(IReadOnlyList<int> tokenIds) => new string(tokenIds.Select(id => (char)id).ToArray());
+    }
+
+    private static SamplingParameters Greedy(int maxTokens) => new() { Temperature = 0.0, MaxTokens = maxTokens };
+
+    [Fact]
+    public void RecomputePath_GeneratesDeterministicIds()
+    {
+        using var gen = new TextGenerator<double>(new CounterLm());
+        var ids = gen.Generate(new[] { 5 }, Greedy(4));
+        Assert.Equal(new[] { 6, 7, 8, 9 }, ids);
+    }
+
+    [Fact]
+    public void FastPath_IsSelected_WhenModelImplementsPagedRunner()
+    {
+        var runner = new CounterPagedRunner();
+        var selection = ServingRunnerFactory.Create<double>(runner);
+        Assert.IsType<PagedRunnerAdapter<double>>(selection.Runner);
+
+        using var gen = new TextGenerator<double>(runner);
+        var ids = gen.Generate(new[] { 40 }, Greedy(3));
+        Assert.Equal(new[] { 41, 42, 43 }, ids);
+        Assert.True(runner.PrefillCalls >= 1);
+        Assert.True(runner.DecodeCalls >= 1);
+    }
+
+    [Fact]
+    public void StringOverload_RoundTripsThroughTokenizer()
+    {
+        using var gen = new TextGenerator<double>(new CounterLm(), new CharTokenizer());
+        // 'A' = 65 -> 66,67,68 = "BCD"
+        Assert.Equal("BCD", gen.Generate("A", Greedy(3)));
+    }
+
+    [Fact]
+    public void StringOverload_WithoutTokenizer_Throws()
+    {
+        using var gen = new TextGenerator<double>(new CounterLm());
+        Assert.Throws<InvalidOperationException>(() => gen.Generate("hi", Greedy(2)));
+    }
+
+    [Fact]
+    public void UnsupportedModel_ThrowsClearError()
+    {
+        var ex = Assert.Throws<NotSupportedException>(() => ServingRunnerFactory.Create<double>("not a model"));
+        Assert.Contains("cannot generate text", ex.Message);
+    }
+
+    [Fact]
+    public void EmptyPrompt_Throws()
+    {
+        using var gen = new TextGenerator<double>(new CounterLm());
+        Assert.Throws<ArgumentException>(() => gen.Generate(Array.Empty<int>(), Greedy(2)));
+    }
+
+    [Fact]
+    public void RepeatedGenerate_OnSameGenerator_IsConsistent()
+    {
+        using var gen = new TextGenerator<double>(new CounterLm());
+        var first = gen.Generate(new[] { 10 }, Greedy(3));
+        var second = gen.Generate(new[] { 10 }, Greedy(3));
+        Assert.Equal(first, second);
+        Assert.Equal(new[] { 11, 12, 13 }, first);
+    }
+}


### PR DESCRIPTION
## Goal

A cohesive, production-grade **inference serving framework** that meets or beats vLLM, TGI, TensorRT-LLM, and SGLang on throughput/latency — while keeping AiDotNet's defining trait: **beginner-friendly, smart defaults through the facade builder.**

### The differentiator none of them offer

vLLM/TGI/TensorRT-LLM deliver high throughput **only after expert setup** — engine args, KV block math, tensor-parallel wiring, server plumbing. AiDotNet delivers the same-or-better performance **with zero configuration and a progressive learning curve**:

```csharp
var model = await new AiModelBuilder<float, string, string>()
    .ConfigureModel(myTransformer)
    .ConfigureInferenceOptimizations()   // vLLM-class defaults already ON
    .BuildAsync();

var text = model.Generate("Hello");      // transparent: paged KV + fast, nothing new to learn
using var server = model.Serve();        // one line: continuous batching + OpenAI-compatible HTTP
```

"Exceeding industry standards" here means winning on **both** raw throughput **and** the on-ramp — a beginner gets vLLM-class serving by default; an expert can still reach every knob via `InferenceOptimizationConfig`.

## Design (agreed)

- **`IFullModel` is the universal floor** — every model serves correctly via `Predict` (recompute fallback). `ICausalLmRunner<T>` is an *optional* fast-path capability KV-cached models advertise (paged `Prefill`/`DecodeStep`); the engine uses it when present. The seam **extends** `IFullModel`, it does not replace it.
- **Smart defaults via the existing facade** — serving is driven by `InferenceOptimizationConfig` (`.Default` / `.HighPerformance`, KV cache + batching already on). No block sizes, pool sizing, or preemption policy exposed to beginners.
- **Preemption**: swap-to-CPU **and** recompute, recompute default (vLLM's dual strategy).

## In this PR so far (internal plumbing + engine core)

`AiDotNet.Serving.Engine` — numeric-type-agnostic core:

- **`SamplingParameters`** (temperature/top-p/top-k/min-p, penalties, stop tokens, N, seed; mirrors vLLM `SamplingParams` / OpenAI), **`GenerationRequest`**, **`Sequence` / `SequenceState`** (prefill-vs-decode via `NumComputedTokens`; swap/recompute preemption states), **`RequestOutput` / `CompletionOutput`**, **`EngineStatistics`**, **`IInferenceEngine`** (continuous-batching `AddRequest`/`Step`/`AbortRequest`).
- **`ICausalLmRunner<T>` + `SequenceKvLayout`** — the fast-path seam.

## Roadmap

1. ✅ **Paged KV-cache block manager** (`BlockManager` + `BlockCopy`) — fixed blocks, per-sequence block tables, reference-counted copy-on-write prefix sharing (PagedAttention, Kwon 2023), free-list — **done, 24 invariant tests** (no-double-alloc, free/used conservation, COW-only-on-shared-partial, fork/free reclamation).
2. ✅ **Sampling execution** — `LogitsSampler` (penalties → temp → top-k/p/min-p, greedy fast path, seeded RNG) — **done, 12 tests** vs hand-computed expectations.
3. ✅ **Continuous-batching engine + scheduler** — `ContinuousBatchingEngine<T>`: decode-priority scheduling, KV + token-budget admission, schedule-time generation-slot reservation, recompute preemption; drives an `IServingModelRunner<T>` (paged fast path or recompute fallback) — **done, 11 end-to-end tests** (deterministic counter model ⇒ exact tokens asserted even under preemption).
4. ✅ **Facade wiring — the beginner surface** — **done:**
   - `ICausalLmModel<T>` capability (core) + `RecomputeModelRunner<T>` (universal fallback) + `PagedRunnerAdapter<T>` (fast path) + `ServingRunnerFactory` (auto-select, clear error for non-generators).
   - `TextGenerator<T>` — the object behind `model.Generate(...)`; `Generate(ids)` and `Generate(string)` via an attached `IGenerationTokenizer`; auto-wired EOS.
   - `AsyncEngineHost<T>` — dedicated pump thread + concurrent `GenerateAsync` / `StreamAsync` (`IAsyncEnumerable`), cancellation aborts + frees KV.
   - **HTTP `model.Serve(tokenizer)`** — self-hosted Kestrel, OpenAI-compatible `/v1/completions` (JSON + SSE), `/v1/models`, `/health`; Newtonsoft; dynamic ports; **live-HTTP integration tests**.
   - Extensions on `AiModelResult`: `AsTextGenerator()` / `Generate()` / `Serve()`.
   - **7 (facade) + 4 (async host) + 5 (HTTP) tests.**

5. ✅ **Speculative decoding** — greedy speculative decoding over `ICausalLmModel` (Leviathan 2023 / Chen 2023): `PromptLookupDrafter` (model-free n-gram drafting, no second model) + `SpeculativeGenerator<T>` (draft → verify in one forward pass → accept longest correct prefix + bonus). **Output is bit-identical to plain greedy** — proven by invariant tests. Facade: `model.GenerateSpeculative(...)`. **11 tests.**

6. ✅ **Config bridge + tokenizer auto-attach** — `ServingConfigMapper` derives `EngineOptions` from `InferenceOptimizationConfig` (the `ConfigureInferenceOptimizations` surface); `IProvidesGenerationTokenizer` lets a model carry its tokenizer so `Generate(string)`/`Serve()` need none. **6 tests.**
7. ✅ **Predict-adapter fallback** — `PredictCausalLmAdapter` serves any `IFullModel` whose forward is vocab-width, given a vocab size. **5 tests.**
8. ✅ **`/v1/chat/completions`** — chat endpoint (JSON + SSE) with a pluggable `IChatTemplate` (generic default). **6 tests.**
9. ✅ **Prefix sharing** — `BlockManager.ForkPrefix` + engine prefill-once for N>1: siblings fork the owner's prompt KV, sharing one copy (peak blocks drop vs independent), identical output. **6 tests.**
10. ✅ **Quantized execution** — `EngineOptions.KvCacheQuantization` + config-mapped pool scaling (Int8 KV ⇒ ~2× capacity); the engine is model-agnostic so quantized-weight models serve unchanged. 
11. ✅ **Tensor/pipeline-parallel serving** — proven model-agnostic: tensor-parallel (parallel projection) and pipeline-parallel (multi-stage) models serve unchanged via the `ICausalLmModel` seam. **(10+11: 4 tests.)**

### Advanced stages — also complete

12. ✅ **Stochastic speculative sampling** — the Leviathan/Chen acceptance rule via `LogitsSampler.ComputeProbabilities`; the emitted-token distribution provably equals the target's sampling distribution (histogram-tested). Greedy path unchanged.
13. ✅ **Concrete paged runner** — `ReferencePagedAttentionRunner<T>`: a real paged-attention decoder transformer implementing the fast-path `ICausalLmRunner` and, for verification, `ICausalLmModel`. Invariant: paged incremental decode is **bit-identical to full recompute**.
14. ✅ **Paged prefill-compute sharing** — N>1 siblings sample their first token from the owner's prompt-final logits (prompt computed **once**) and decode from the shared prompt KV (proven on the paged runner).
15. ✅ **Cross-request prefix cache** — automatic prefix caching (vLLM APC), opt-in: a request sharing a block-aligned prefix reuses that KV; correctness-neutral; the paged path skips the cached-prefix compute; LRU + memory-pressure eviction.
16. ✅ **Non-block-aligned prefix sharing** — siblings share the aligned full-block prefix and recompute only the short tail (no partial-block hazard).
17. ✅ **Memory-precise KV sizing** — the pool is sized from `KVCacheMaxSizeMB` and the model's real per-block KV bytes (Int8 fits 2×).

**~150 serving-engine tests total, all green; full `dotnet build AiDotNet.sln -c Release` succeeds with 0 errors (all TFMs).**

> After merging `master`, 3 `FederatedCoordinatorIntegrationTests` fail with a `TrialStateManager` save/load license-limit — a pre-existing master baseline issue unrelated to serving (they passed before the merge; no serving code touches persistence/federated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
