### PR TITLE
ci: pass AIDOTNET_LICENSE_KEY secret into the test jobs

### DIFF
--- a/.github/workflows/heavy-timeout-nightly.yml
+++ b/.github/workflows/heavy-timeout-nightly.yml
@@ -32,6 +32,9 @@ jobs:
     name: Heavy Timeout Models
     runs-on: ubuntu-latest
     timeout-minutes: 350   # generous budget; these models are the slow ones by definition
+    # Licensed key so save/load-heavy suites don't trip the unlicensed free-trial operation limit.
+    env:
+      AIDOTNET_LICENSE_KEY: ${{ secrets.AIDOTNET_LICENSE_KEY }}
     steps:
       - name: Checkout code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v4

--- a/.github/workflows/heavy-timeout-nightly.yml
+++ b/.github/workflows/heavy-timeout-nightly.yml
@@ -32,9 +32,6 @@ jobs:
     name: Heavy Timeout Models
     runs-on: ubuntu-latest
     timeout-minutes: 350   # generous budget; these models are the slow ones by definition
-    # Licensed key so save/load-heavy suites don't trip the unlicensed free-trial operation limit.
-    env:
-      AIDOTNET_LICENSE_KEY: ${{ secrets.AIDOTNET_LICENSE_KEY }}
     steps:
       - name: Checkout code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v4
@@ -61,6 +58,10 @@ jobs:
         # stack memory and OOM/cancel the lane instead of giving the visibility this workflow exists for.
         shell: pwsh
         continue-on-error: true
+        # Scoped to this test step only (not job-wide) so the credential is not exposed to other steps or
+        # third-party actions. Licensed key keeps save/load-heavy suites under the free-trial op limit.
+        env:
+          AIDOTNET_LICENSE_KEY: ${{ secrets.AIDOTNET_LICENSE_KEY }}
         run: |
           $runnerJson = 'tests/AiDotNet.Tests/bin/Release/net10.0/xunit.runner.json'
           if (Test-Path $runnerJson) {

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -292,6 +292,11 @@ jobs:
     needs: build
     timeout-minutes: 45
     if: ${{ (github.event.pull_request.draft != true) && !startsWith(github.head_ref, 'release-please--') }}
+    # Run tests under the repo's licensed key so save/load-heavy suites do not trip the unlicensed
+    # free-trial operation limit (TrialStateManager). The secrets context is only available in job/step
+    # env, not workflow-level env, so it is set here.
+    env:
+      AIDOTNET_LICENSE_KEY: ${{ secrets.AIDOTNET_LICENSE_KEY }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -292,11 +292,6 @@ jobs:
     needs: build
     timeout-minutes: 45
     if: ${{ (github.event.pull_request.draft != true) && !startsWith(github.head_ref, 'release-please--') }}
-    # Run tests under the repo's licensed key so save/load-heavy suites do not trip the unlicensed
-    # free-trial operation limit (TrialStateManager). The secrets context is only available in job/step
-    # env, not workflow-level env, so it is set here.
-    env:
-      AIDOTNET_LICENSE_KEY: ${{ secrets.AIDOTNET_LICENSE_KEY }}
     strategy:
       fail-fast: false
       matrix:
@@ -884,6 +879,10 @@ jobs:
         # pwsh (PowerShell Core) is pre-installed on ubuntu-latest runners and runs
         # the existing scripts cross-platform without a rewrite.
         shell: pwsh
+        # Scoped to this test step only (not job-wide) so the credential is not exposed to other steps or
+        # third-party actions. Licensed key keeps save/load-heavy suites under the free-trial op limit.
+        env:
+          AIDOTNET_LICENSE_KEY: ${{ secrets.AIDOTNET_LICENSE_KEY }}
         run: |
           # Sanitize shard name: remove/replace all characters invalid in file paths
           $shardName = "${{ matrix.shard.name }}"


### PR DESCRIPTION
## Problem

The repo stores an `AIDOTNET_LICENSE_KEY` secret, but the test workflows never passed it into the environment — it was referenced only in `automated-release.yml.disabled` (a disabled workflow). So CI runs **unlicensed**, and save/load-heavy suites trip the free-trial 10-operation limit (`TrialStateManager` → `LicenseRequiredException`).

This currently makes `FederatedCoordinatorIntegrationTests` (and any other suite exceeding 10 save/load operations) fail on every PR and on master.

## Fix

Set `AIDOTNET_LICENSE_KEY` from secrets at the **job level** (GitHub's `secrets` context is not available in workflow-level `env`) for:
- `sonarcloud.yml` → `test-net10-sharded` (the sharded PR test job, which includes the `AiDotNet.Serving.Tests` shard)
- `heavy-timeout-nightly.yml` → `heavy-timeout`

Tests now run licensed and never hit the trial limit.

## Scope

Two-line change to two workflow files; no source or test changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated nightly heavy-timeout and sharded test workflows to use configured licensing credentials.
  * Improved consistency of automated validation for license-restricted test scenarios.
  * No changes were made to publicly exposed features or APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->