### PR TITLE
ci: normalize line endings in the auto-fix workflow

### DIFF
--- a/.github/workflows/dotnet-format-autofix.yml
+++ b/.github/workflows/dotnet-format-autofix.yml
@@ -1,4 +1,4 @@
-name: Auto-Fix Formatting (dotnet format)
+name: Auto-Fix Formatting (dotnet format + EOL normalize)
 
 on:
   schedule:
@@ -46,11 +46,20 @@ jobs:
           export PATH="$PATH:$HOME/.dotnet/tools"
           dotnet format AiDotNet.sln
 
+      - name: Normalize line endings (.gitattributes)
+        shell: bash
+        run: |
+          # dotnet format does not normalize line endings. Re-apply the .gitattributes EOL policy
+          # to every tracked file so any blob committed with the wrong line endings is corrected,
+          # keeping diffs free of phantom EOL churn.
+          git add --renormalize .
+
       - name: Detect changes
         id: changes
         shell: bash
         run: |
-          if git diff --quiet; then
+          # Consider both unstaged (dotnet format) and staged (renormalize) changes.
+          if git diff --quiet && git diff --cached --quiet; then
             echo "has_changes=false" >> "$GITHUB_OUTPUT"
           else
             echo "has_changes=true" >> "$GITHUB_OUTPUT"
@@ -66,7 +75,7 @@ jobs:
         if: steps.changes.outputs.has_changes == 'true'
         run: |
           git add -A
-          git commit -m "chore: apply dotnet format"
+          git commit -m "chore: apply dotnet format and normalize line endings"
 
       - name: Push branch
         if: steps.changes.outputs.has_changes == 'true'
@@ -98,12 +107,13 @@ jobs:
             const head = `${owner}:automation/dotnet-format-autofix`;
             const base = 'master';
 
-            const title = 'chore: automated dotnet format';
+            const title = 'chore: automated dotnet format + line-ending normalization';
             const body = [
               'Automated formatting maintenance PR.',
               '',
               '- Runs `dotnet format AiDotNet.sln` on a schedule and opens/updates this PR.',
-              '- Intended to keep formatting drift from accumulating between feature PRs.',
+              '- Runs `git add --renormalize .` to enforce the `.gitattributes` EOL policy (dotnet format does not normalize line endings).',
+              '- Intended to keep formatting and line-ending drift from accumulating between feature PRs.',
               '',
               'If CI does not run automatically, ensure `AUTOFIX_PAT` is configured as a repository secret with `repo` and `workflow` scopes.'
             ].join('\n');


### PR DESCRIPTION
Extends the existing Auto-Fix Formatting workflow (dotnet-format-autofix.yml) to also normalize line endings.

- dotnet format does not touch EOL, so line-ending drift accumulated separately.
- Adds a `git add --renormalize .` step after dotnet format (enforces the existing .gitattributes EOL policy).
- Updates change-detection to also see staged changes so EOL-only drift is committed and opened as a PR.

The main repo is currently EOL-clean, so this is preventive. (The AiDotNet.Tensors repo, which had no .gitattributes, is fixed separately in ooples/AiDotNet.Tensors#802.)

Generated with Claude Code