### PR TITLE
feat(deepar): pluggable predictive-distribution head (Gaussian | Student-t | spline)

### DIFF
--- a/src/Models/Options/DeepAROptions.cs
+++ b/src/Models/Options/DeepAROptions.cs
@@ -57,6 +57,7 @@ public class DeepAROptions<T> : TimeSeriesRegressionOptions<T>
         BatchSize = other.BatchSize;
         NumSamples = other.NumSamples;
         LikelihoodType = other.LikelihoodType;
+        StudentTDegreesOfFreedom = other.StudentTDegreesOfFreedom;
         CovariateSize = other.CovariateSize;
         EmbeddingDimension = other.EmbeddingDimension;
     }
@@ -155,6 +156,23 @@ public class DeepAROptions<T> : TimeSeriesRegressionOptions<T>
     /// </para>
     /// </remarks>
     public string LikelihoodType { get; set; } = "Gaussian";
+
+    /// <summary>
+    /// Gets or sets the fixed degrees-of-freedom ν for the Student-t likelihood head.
+    /// </summary>
+    /// <value>The degrees of freedom, defaulting to 4.0.</value>
+    /// <remarks>
+    /// <para>
+    /// Only used when <see cref="LikelihoodType"/> is "StudentT". Lower ν means heavier tails (more
+    /// probability on extreme moves); ν must exceed 2 for a finite variance. ν≈4 is a strong default for
+    /// financial returns. The value is fixed (not learned) so the likelihood stays differentiable in
+    /// (mean, scale) without needing a differentiable log-Gamma.
+    /// </para>
+    /// <para><b>For Beginners:</b> Controls how "fat" the tails of the predicted distribution are — how much
+    /// room the model leaves for rare, large surprises. Smaller = expects bigger surprises more often.
+    /// </para>
+    /// </remarks>
+    public double StudentTDegreesOfFreedom { get; set; } = 4.0;
 
     /// <summary>
     /// Gets or sets the number of covariates (external features).

--- a/src/TimeSeries/DeepARDistributionHeads.cs
+++ b/src/TimeSeries/DeepARDistributionHeads.cs
@@ -1,0 +1,591 @@
+using AiDotNet.Autodiff;
+using AiDotNet.Enums;
+using AiDotNet.Helpers;
+using AiDotNet.Tensors;
+
+namespace AiDotNet.TimeSeries;
+
+/// <summary>
+/// The predictive distribution DeepAR emits for a single future step, in NORMALIZED space (the model
+/// denormalizes before returning to callers). Every head exposes the same three things so the model's
+/// prediction/quantile code is head-agnostic: a point forecast (<see cref="MeanNorm"/>), a representative
+/// spread for symmetric intervals (<see cref="ScaleNorm"/>), and a sampler for Monte-Carlo predictive paths.
+/// Heads that own a closed-form quantile function (e.g. the spline head) also set <see cref="QuantileNorm"/>,
+/// which yields genuinely ASYMMETRIC bands — the property the downstream skew-aware sizing relies on.
+/// </summary>
+internal sealed class DeepARPredictiveDist<T>
+{
+    /// <summary>Point forecast (the distribution's location/median) in normalized space.</summary>
+    public required T MeanNorm { get; init; }
+
+    /// <summary>Representative standard deviation in normalized space (drives symmetric predictive intervals).</summary>
+    public required T ScaleNorm { get; init; }
+
+    /// <summary>Draws one sample from the predictive distribution in normalized space.</summary>
+    public required Func<Random, T> SampleNorm { get; init; }
+
+    /// <summary>Closed-form quantile function q(p), p in (0,1), in normalized space — null when the head has
+    /// no analytic quantile (callers then fall back to Monte-Carlo sampling of <see cref="SampleNorm"/>).</summary>
+    public Func<double, T>? QuantileNorm { get; init; }
+}
+
+/// <summary>
+/// Base class for DeepAR's pluggable predictive-distribution head. It projects the top LSTM hidden state to
+/// the parameters of a chosen distribution and owns the training loss + predictive sampling for that
+/// distribution. Concrete heads (Gaussian / Student-t / spline-quantile) let DeepAR trade off calibration
+/// against tail-weight and skew without touching the recurrence. All projection tensors register as
+/// trainable parameters, and this base handles their flatten/serialize uniformly so heads only declare
+/// projections and implement the distribution math. Activations are column-major <c>[*, batch]</c>, and every
+/// op is an <c>Engine.Tensor*</c> call so a <see cref="GradientTape{T}"/> differentiates the loss w.r.t. the
+/// projection weights (BPTT flows back through the shared LSTM stack).
+/// </summary>
+internal abstract class DeepARDistributionHead<T> : NeuralNetworks.Layers.LayerBase<T>
+{
+    private readonly List<Tensor<T>> _params = new();
+    protected readonly int Hidden;
+
+    protected DeepARDistributionHead(int hiddenSize, int outputDim)
+        : base(new[] { hiddenSize }, new[] { outputDim })
+    {
+        Hidden = hiddenSize;
+    }
+
+    /// <summary>Human-readable name recorded in model metadata (e.g. "Gaussian", "StudentT", "Spline").</summary>
+    public abstract string LikelihoodName { get; }
+
+    /// <summary>
+    /// Batched training loss (scalar tensor), built from tape-tracked engine ops. <paramref name="hiddenSteps"/>
+    /// holds the top-layer hidden state <c>[H, B]</c> for each of the L timesteps; <paramref name="obsSteps"/>
+    /// holds the corresponding observation input <c>[1, B]</c> (the value the residual-mean skip is added to);
+    /// <paramref name="target"/> is the one-step-ahead target window <c>[B, L]</c>.
+    /// </summary>
+    public abstract Tensor<T> ComputeBatchLoss(
+        IReadOnlyList<Tensor<T>> hiddenSteps, IReadOnlyList<Tensor<T>> obsSteps, Tensor<T> target);
+
+    /// <summary>
+    /// Eager single-step predictive distribution (batch = 1) in normalized space, from the final hidden state
+    /// <paramref name="hLast"/> <c>[H, 1]</c> and the last normalized observation <paramref name="lastObsNorm"/>
+    /// (for the residual-mean skip). Same ops as training, run outside a tape.
+    /// </summary>
+    public abstract DeepARPredictiveDist<T> PredictNorm(Tensor<T> hLast, T lastObsNorm);
+
+    // --- shared projection helpers ------------------------------------------------------------------
+
+    /// <summary>Creates + registers a linear projection: weight <c>[outDim, H]</c> and bias <c>[outDim]</c>.</summary>
+    protected (Tensor<T> w, Tensor<T> b) AddProjection(int outDim, Random random)
+    {
+        double stddev = Math.Sqrt(2.0 / Hidden);
+        var w = new Tensor<T>(new[] { outDim, Hidden });
+        for (int i = 0; i < w.Length; i++)
+            w[i] = NumOps.FromDouble((random.NextDouble() * 2 - 1) * stddev);
+        var b = new Tensor<T>(new[] { outDim });
+
+        RegisterTrainableParameter(w, PersistentTensorRole.Weights);
+        RegisterTrainableParameter(b, PersistentTensorRole.Biases);
+        _params.Add(w);
+        _params.Add(b);
+        return (w, b);
+    }
+
+    /// <summary>Applies a registered projection to hidden state <paramref name="h"/> <c>[H, B]</c> → <c>[outDim, B]</c>.</summary>
+    protected Tensor<T> Linear(Tensor<T> w, Tensor<T> b, Tensor<T> h)
+    {
+        var o = Engine.TensorMatMul(w, h);
+        var bCol = Engine.Reshape(b, new[] { b.Length, 1 });
+        return Engine.TensorBroadcastAdd(o, bCol);
+    }
+
+    /// <summary>Numerically-stable scalar softplus (matches the model's inference-time softplus).</summary>
+    protected T Softplus(T v)
+    {
+        if (NumOps.GreaterThan(v, NumOps.FromDouble(20.0)))
+            return v;
+        if (NumOps.LessThan(v, NumOps.FromDouble(-20.0)))
+            return NumOps.Exp(v);
+        return NumOps.Log(NumOps.Add(NumOps.One, NumOps.Exp(v)));
+    }
+
+    /// <summary>Concatenates per-step <c>[1, B]</c> slices into <c>[L, B]</c> then permutes to <c>[B, L]</c>.</summary>
+    protected Tensor<T> StackStepsToBL(Tensor<T>[] steps)
+    {
+        var lb = Engine.TensorConcatenate(steps, axis: 0);
+        return Engine.TensorPermute(lb, new[] { 1, 0 });
+    }
+
+    // --- LayerBase plumbing (uniform over the registered projection tensors) ------------------------
+
+    public override bool SupportsTraining => true;
+    public override void ResetState() { }
+    public override void UpdateParameters(T learningRate) { /* tape-based optimizer updates registered params */ }
+
+    public override long ParameterCount
+    {
+        get
+        {
+            long count = 0;
+            foreach (var p in _params)
+                count += p.Length;
+            return count;
+        }
+    }
+
+    public override Vector<T> GetParameters()
+    {
+        long total = ParameterCount;
+        var arr = new T[total];
+        int idx = 0;
+        foreach (var p in _params)
+            for (int i = 0; i < p.Length; i++)
+                arr[idx++] = p[i];
+        return new Vector<T>(arr);
+    }
+
+    public override void SetParameters(Vector<T> parameters)
+    {
+        int idx = 0;
+        foreach (var p in _params)
+            for (int i = 0; i < p.Length; i++)
+                p[i] = parameters[idx++];
+    }
+
+    public override void Serialize(BinaryWriter writer)
+    {
+        writer.Write(Hidden);
+        writer.Write(_params.Count);
+        foreach (var p in _params)
+            WriteTensor(writer, p);
+    }
+
+    public override void Deserialize(BinaryReader reader)
+    {
+        reader.ReadInt32(); // hidden
+        int count = reader.ReadInt32();
+        for (int i = 0; i < count && i < _params.Count; i++)
+            ReadTensorInto(reader, _params[i]);
+    }
+
+    protected static void WriteTensor(BinaryWriter writer, Tensor<T> tensor)
+    {
+        writer.Write(tensor.Shape.Length);
+        for (int d = 0; d < tensor.Shape.Length; d++)
+            writer.Write(tensor.Shape[d]);
+        for (int i = 0; i < tensor.Length; i++)
+            writer.Write(Convert.ToDouble(tensor[i]));
+    }
+
+    protected void ReadTensorInto(BinaryReader reader, Tensor<T> tensor)
+    {
+        int rank = reader.ReadInt32();
+        int total = 1;
+        for (int d = 0; d < rank; d++)
+            total *= reader.ReadInt32();
+        for (int i = 0; i < total; i++)
+        {
+            double v = reader.ReadDouble();
+            if (i < tensor.Length)
+                tensor[i] = NumOps.FromDouble(v);
+        }
+    }
+}
+
+/// <summary>
+/// Gaussian likelihood head: emits a residual mean (μ = x + Δ(h)) and a softplus scale. The training loss
+/// splits into an undivided MSE on μ (so the mean always tracks the target) plus a Gaussian NLL on the
+/// detached mean for σ (so the scale learns the residual spread without an "inflate σ to kill the μ gradient"
+/// escape hatch). This is the historical DeepAR head, preserved bit-for-bit as the default.
+/// </summary>
+internal sealed class DeepARGaussianHead<T> : DeepARDistributionHead<T>
+{
+    private readonly Tensor<T> _meanW, _meanB, _scaleW, _scaleB;
+
+    public override string LikelihoodName => "Gaussian";
+
+    public DeepARGaussianHead(int hiddenSize, int seed = 12345)
+        : base(hiddenSize, outputDim: 1)
+    {
+        var random = RandomHelper.CreateSeededRandom(seed);
+        (_meanW, _meanB) = AddProjection(1, random);
+        (_scaleW, _scaleB) = AddProjection(1, random);
+    }
+
+    public override Tensor<T> Forward(Tensor<T> input) => Linear(_meanW, _meanB, input);
+
+    public override Tensor<T> ComputeBatchLoss(
+        IReadOnlyList<Tensor<T>> hiddenSteps, IReadOnlyList<Tensor<T>> obsSteps, Tensor<T> target)
+    {
+        int L = hiddenSteps.Count;
+        var meanSteps = new Tensor<T>[L];
+        var scaleRawSteps = new Tensor<T>[L];
+        for (int t = 0; t < L; t++)
+        {
+            var delta = Linear(_meanW, _meanB, hiddenSteps[t]);        // [1, B]
+            meanSteps[t] = Engine.TensorAdd(obsSteps[t], delta);       // residual skip
+            scaleRawSteps[t] = Linear(_scaleW, _scaleB, hiddenSteps[t]);
+        }
+
+        var mean = StackStepsToBL(meanSteps);                          // [B, L]
+        var scale = Engine.Softplus(StackStepsToBL(scaleRawSteps));    // [B, L]
+        var allAxes = Enumerable.Range(0, mean.Shape.Length).ToArray();
+
+        // Mean branch: plain MSE — gradient (μ − y) is independent of σ, so μ always tracks.
+        var diffMean = Engine.TensorSubtract(mean, target);
+        var meanMse = Engine.ReduceMean(Engine.TensorMultiply(diffMean, diffMean), allAxes, keepDims: false);
+
+        // Scale branch: Gaussian NLL over the detached mean.
+        var eps = NumOps.FromDouble(1e-6);
+        var muDetached = Engine.StopGradient(mean);
+        var diff = Engine.TensorSubtract(target, muDetached);
+        var diff2 = Engine.TensorMultiply(diff, diff);
+        var variance = Engine.TensorMultiply(scale, scale);
+        var twoVar = Engine.TensorAddScalar(Engine.TensorMultiplyScalar(variance, NumOps.FromDouble(2.0)), eps);
+        var quad = Engine.TensorDivide(diff2, twoVar);
+        var logSigma = Engine.TensorLog(Engine.TensorAddScalar(scale, eps));
+        var scaleTerm = Engine.ReduceMean(Engine.TensorAdd(quad, logSigma), allAxes, keepDims: false);
+
+        return Engine.TensorAdd(meanMse, scaleTerm);
+    }
+
+    public override DeepARPredictiveDist<T> PredictNorm(Tensor<T> hLast, T lastObsNorm)
+    {
+        var delta = Linear(_meanW, _meanB, hLast);
+        var scaleRaw = Linear(_scaleW, _scaleB, hLast);
+        T meanNorm = NumOps.Add(lastObsNorm, delta[0, 0]);
+        T scaleNorm = Softplus(scaleRaw[0, 0]);
+        if (NumOps.LessThan(scaleNorm, NumOps.FromDouble(1e-6)))
+            scaleNorm = NumOps.FromDouble(1e-6);
+
+        return new DeepARPredictiveDist<T>
+        {
+            MeanNorm = meanNorm,
+            ScaleNorm = scaleNorm,
+            SampleNorm = rng => NumOps.Add(meanNorm, NumOps.Multiply(scaleNorm, NumOps.FromDouble(rng.NextGaussian()))),
+            QuantileNorm = p => NumOps.Add(meanNorm, NumOps.Multiply(scaleNorm, NumOps.FromDouble(DeepARDistMath.Probit(p)))),
+        };
+    }
+}
+
+/// <summary>
+/// Student-t likelihood head: same residual mean + softplus scale as the Gaussian, but a Student-t
+/// negative log-likelihood with FIXED degrees-of-freedom ν (finance default ν≈4). Heavy tails mean the head
+/// stops under-estimating the probability of large moves — the exact failure mode a Gaussian head has on
+/// returns — so predictive intervals and the uncertainty they feed to sizing are far better calibrated on
+/// fat-tailed data. ν is fixed (not learned) so the log-Γ normalisation constants are true constants and the
+/// loss stays fully differentiable in (μ, σ) with standard tape ops — no differentiable log-Γ required.
+/// </summary>
+internal sealed class DeepARStudentTHead<T> : DeepARDistributionHead<T>
+{
+    private readonly Tensor<T> _meanW, _meanB, _scaleW, _scaleB;
+    private readonly double _nu;
+    private readonly T _nuT, _halfNuPlus1, _logNormConst, _stdScale;
+
+    public override string LikelihoodName => "StudentT";
+
+    public DeepARStudentTHead(int hiddenSize, double degreesOfFreedom, int seed = 12345)
+        : base(hiddenSize, outputDim: 1)
+    {
+        // ν must exceed 2 for a finite variance (so predictive std is defined). Clamp defensively.
+        _nu = degreesOfFreedom > 2.0001 ? degreesOfFreedom : 2.0001;
+        var random = RandomHelper.CreateSeededRandom(seed);
+        (_meanW, _meanB) = AddProjection(1, random);
+        (_scaleW, _scaleB) = AddProjection(1, random);
+
+        _nuT = NumOps.FromDouble(_nu);
+        _halfNuPlus1 = NumOps.FromDouble((_nu + 1.0) / 2.0);
+        // Constant term of the t NLL: -logΓ((ν+1)/2) + logΓ(ν/2) + 0.5·log(νπ). Affects only the loss value,
+        // not the (μ, σ) gradients, but included so the reported loss is a genuine NLL.
+        double logConst = -DeepARDistMath.LogGamma((_nu + 1.0) / 2.0)
+                          + DeepARDistMath.LogGamma(_nu / 2.0)
+                          + 0.5 * Math.Log(_nu * Math.PI);
+        _logNormConst = NumOps.FromDouble(logConst);
+        _stdScale = NumOps.FromDouble(Math.Sqrt(_nu / (_nu - 2.0))); // std = σ·sqrt(ν/(ν−2))
+    }
+
+    public override Tensor<T> Forward(Tensor<T> input) => Linear(_meanW, _meanB, input);
+
+    public override Tensor<T> ComputeBatchLoss(
+        IReadOnlyList<Tensor<T>> hiddenSteps, IReadOnlyList<Tensor<T>> obsSteps, Tensor<T> target)
+    {
+        int L = hiddenSteps.Count;
+        var meanSteps = new Tensor<T>[L];
+        var scaleRawSteps = new Tensor<T>[L];
+        for (int t = 0; t < L; t++)
+        {
+            var delta = Linear(_meanW, _meanB, hiddenSteps[t]);
+            meanSteps[t] = Engine.TensorAdd(obsSteps[t], delta);
+            scaleRawSteps[t] = Linear(_scaleW, _scaleB, hiddenSteps[t]);
+        }
+
+        var mean = StackStepsToBL(meanSteps);
+        var scale = Engine.Softplus(StackStepsToBL(scaleRawSteps));
+        var allAxes = Enumerable.Range(0, mean.Shape.Length).ToArray();
+
+        // Mean branch: undivided MSE (same stability rationale as the Gaussian head).
+        var diffMean = Engine.TensorSubtract(mean, target);
+        var meanMse = Engine.ReduceMean(Engine.TensorMultiply(diffMean, diffMean), allAxes, keepDims: false);
+
+        // Tail branch: Student-t NLL over the detached mean.
+        //   NLL_t = const + log σ + ((ν+1)/2)·log(1 + z²/ν),  z = (y − μ)/σ.
+        var eps = NumOps.FromDouble(1e-6);
+        var muDetached = Engine.StopGradient(mean);
+        var z = Engine.TensorDivide(Engine.TensorSubtract(target, muDetached), Engine.TensorAddScalar(scale, eps));
+        var z2OverNu = Engine.TensorDivideScalar(Engine.TensorMultiply(z, z), _nuT);
+        var logTail = Engine.TensorMultiplyScalar(
+            Engine.TensorLog(Engine.TensorAddScalar(z2OverNu, NumOps.One)), _halfNuPlus1);
+        var logSigma = Engine.TensorLog(Engine.TensorAddScalar(scale, eps));
+        var perStep = Engine.TensorAddScalar(Engine.TensorAdd(logSigma, logTail), _logNormConst);
+        var tailTerm = Engine.ReduceMean(perStep, allAxes, keepDims: false);
+
+        return Engine.TensorAdd(meanMse, tailTerm);
+    }
+
+    public override DeepARPredictiveDist<T> PredictNorm(Tensor<T> hLast, T lastObsNorm)
+    {
+        var delta = Linear(_meanW, _meanB, hLast);
+        var scaleRaw = Linear(_scaleW, _scaleB, hLast);
+        T meanNorm = NumOps.Add(lastObsNorm, delta[0, 0]);
+        T sigma = Softplus(scaleRaw[0, 0]);
+        if (NumOps.LessThan(sigma, NumOps.FromDouble(1e-6)))
+            sigma = NumOps.FromDouble(1e-6);
+
+        double nu = _nu;
+        return new DeepARPredictiveDist<T>
+        {
+            MeanNorm = meanNorm,
+            ScaleNorm = NumOps.Multiply(sigma, _stdScale),
+            SampleNorm = rng => NumOps.Add(meanNorm, NumOps.Multiply(sigma, NumOps.FromDouble(DeepARDistMath.SampleStudentT(nu, rng)))),
+            QuantileNorm = p => NumOps.Add(meanNorm, NumOps.Multiply(sigma, NumOps.FromDouble(DeepARDistMath.StudentTQuantile(p, nu)))),
+        };
+    }
+}
+
+/// <summary>
+/// Spline (monotone piecewise-linear quantile-function) head: instead of assuming a parametric shape, it
+/// emits the forecast's quantiles directly on a fixed probability grid and is trained with the pinball
+/// (quantile) loss — a proper scoring rule that approximates the CRPS. Monotonicity is guaranteed by
+/// construction (q at the first grid point, then cumulative softplus increments), so the predictive
+/// distribution can be ASYMMETRIC and multi-modal-ish — the head that actually models skew, which the
+/// downstream skew-aware sizing consumes via the closed-form quantile function.
+/// </summary>
+internal sealed class DeepARSplineHead<T> : DeepARDistributionHead<T>
+{
+    // Fixed probability grid (must be strictly increasing, symmetric around 0.5 for a sane median).
+    private static readonly double[] Grid = { 0.05, 0.1, 0.25, 0.5, 0.75, 0.9, 0.95 };
+    private const int MedianIndex = 3; // Grid[3] == 0.5
+
+    private readonly Tensor<T> _knotW, _knotB; // projects hidden → [K] raw knot params
+    private readonly int _k = Grid.Length;
+
+    public override string LikelihoodName => "Spline";
+
+    public DeepARSplineHead(int hiddenSize, int seed = 12345)
+        : base(hiddenSize, outputDim: Grid.Length)
+    {
+        var random = RandomHelper.CreateSeededRandom(seed);
+        (_knotW, _knotB) = AddProjection(Grid.Length, random);
+    }
+
+    public override Tensor<T> Forward(Tensor<T> input) => Linear(_knotW, _knotB, input);
+
+    // Builds the K monotone knot quantiles for every step as [B, L] tensors (index k → q at Grid[k]).
+    // q[0] = obs + raw[0];  q[k] = q[k-1] + softplus(raw[k]) for k>0  → strictly non-decreasing in k.
+    private Tensor<T>[] BuildKnotsBL(IReadOnlyList<Tensor<T>> hiddenSteps, IReadOnlyList<Tensor<T>> obsSteps)
+    {
+        int L = hiddenSteps.Count;
+        var rawSteps = new Tensor<T>[L];      // each [K, B]
+        for (int t = 0; t < L; t++)
+            rawSteps[t] = Linear(_knotW, _knotB, hiddenSteps[t]);
+
+        var knots = new Tensor<T>[_k];        // knots[k] → [B, L]
+        for (int k = 0; k < _k; k++)
+        {
+            var stepK = new Tensor<T>[L];     // [1, B] per step for knot k
+            for (int t = 0; t < L; t++)
+                stepK[t] = Engine.TensorNarrow(rawSteps[t], 0, k, 1); // [1, B]
+            var rawKnotBL = StackStepsToBL(stepK); // [B, L]
+
+            if (k == 0)
+            {
+                var obsBL = StackStepsToBL(obsSteps.ToArray()); // [B, L]
+                knots[0] = Engine.TensorAdd(obsBL, rawKnotBL);  // base quantile = obs + raw[0]
+            }
+            else
+            {
+                knots[k] = Engine.TensorAdd(knots[k - 1], Engine.Softplus(rawKnotBL)); // + positive increment
+            }
+        }
+
+        return knots;
+    }
+
+    public override Tensor<T> ComputeBatchLoss(
+        IReadOnlyList<Tensor<T>> hiddenSteps, IReadOnlyList<Tensor<T>> obsSteps, Tensor<T> target)
+    {
+        var knots = BuildKnotsBL(hiddenSteps, obsSteps);
+        var allAxes = Enumerable.Range(0, target.Shape.Length).ToArray();
+        var half = NumOps.FromDouble(0.5);
+
+        Tensor<T>? loss = null;
+        for (int k = 0; k < _k; k++)
+        {
+            // pinball(τ, q, y) = τ·(y−q) + relu(q−y);  relu(x) = (|x| + x)/2.
+            var e = Engine.TensorSubtract(target, knots[k]);                 // y − q
+            var negE = Engine.TensorSubtract(knots[k], target);              // q − y
+            var reluNegE = Engine.TensorMultiplyScalar(
+                Engine.TensorAdd(Engine.TensorAbs(negE), negE), half);
+            var pinball = Engine.TensorAdd(Engine.TensorMultiplyScalar(e, NumOps.FromDouble(Grid[k])), reluNegE);
+            var term = Engine.ReduceMean(pinball, allAxes, keepDims: false);
+            loss = loss is null ? term : Engine.TensorAdd(loss, term);
+        }
+
+        // Mean of per-knot pinball terms (keeps the loss scale independent of grid size).
+        return Engine.TensorMultiplyScalar(loss!, NumOps.FromDouble(1.0 / _k));
+    }
+
+    public override DeepARPredictiveDist<T> PredictNorm(Tensor<T> hLast, T lastObsNorm)
+    {
+        var raw = Linear(_knotW, _knotB, hLast); // [K, 1]
+        var q = new double[_k];
+        q[0] = Convert.ToDouble(lastObsNorm) + Convert.ToDouble(raw[0, 0]);
+        for (int k = 1; k < _k; k++)
+            q[k] = q[k - 1] + Convert.ToDouble(Softplus(raw[k, 0]));
+
+        double median = q[MedianIndex];
+        // Robust spread proxy: (q95 − q05) / (2·1.645) ≈ σ for a Gaussian, but honest about the fitted tails.
+        double scale = Math.Max((q[_k - 1] - q[0]) / (2.0 * 1.645), 1e-6);
+
+        double InterpQuantile(double p)
+        {
+            if (p <= Grid[0]) return q[0];
+            if (p >= Grid[_k - 1]) return q[_k - 1];
+            for (int k = 1; k < _k; k++)
+            {
+                if (p <= Grid[k])
+                {
+                    double w = (p - Grid[k - 1]) / (Grid[k] - Grid[k - 1]);
+                    return q[k - 1] + w * (q[k] - q[k - 1]);
+                }
+            }
+
+            return q[_k - 1];
+        }
+
+        return new DeepARPredictiveDist<T>
+        {
+            MeanNorm = NumOps.FromDouble(median),
+            ScaleNorm = NumOps.FromDouble(scale),
+            // Inverse-CDF sampling through the piecewise-linear quantile function → respects the fitted skew.
+            SampleNorm = rng => NumOps.FromDouble(InterpQuantile(rng.NextDouble())),
+            QuantileNorm = p => NumOps.FromDouble(InterpQuantile(p)),
+        };
+    }
+}
+
+/// <summary>
+/// Small distribution-math helpers (log-Γ, inverse normal CDF, Student-t sampling/quantiles) used by the
+/// DeepAR heads. All operate on <see cref="double"/> — they compute per-scalar constants or draw samples
+/// outside the gradient tape, so no autodiff is required.
+/// </summary>
+internal static class DeepARDistMath
+{
+    // Lanczos approximation to log Γ(x) for x > 0.
+    private static readonly double[] LanczosG = {
+        676.5203681218851, -1259.1392167224028, 771.32342877765313, -176.61502916214059,
+        12.507343278686905, -0.13857109526572012, 9.9843695780195716e-6, 1.5056327351493116e-7,
+    };
+
+    public static double LogGamma(double x)
+    {
+        if (x < 0.5)
+        {
+            // Reflection formula: Γ(x)Γ(1−x) = π / sin(πx).
+            return Math.Log(Math.PI / Math.Sin(Math.PI * x)) - LogGamma(1.0 - x);
+        }
+
+        x -= 1.0;
+        double a = 0.99999999999980993;
+        double tt = x + 7.5;
+        for (int i = 0; i < LanczosG.Length; i++)
+            a += LanczosG[i] / (x + i + 1);
+        return 0.5 * Math.Log(2 * Math.PI) + (x + 0.5) * Math.Log(tt) - tt + Math.Log(a);
+    }
+
+    // Acklam's rational approximation to the inverse standard-normal CDF (probit).
+    public static double Probit(double p)
+    {
+        if (p <= 0.0) return -8.0;
+        if (p >= 1.0) return 8.0;
+
+        double[] a = { -39.6968302866538, 220.946098424521, -275.928510446969, 138.357751867269, -30.6647980661472, 2.50662827745924 };
+        double[] b = { -54.4760987982241, 161.585836858041, -155.698979859887, 66.8013118877197, -13.2806815528857 };
+        double[] c = { -0.00778489400243029, -0.322396458041136, -2.40075827716184, -2.54973253934373, 4.37466414146497, 2.93816398269878 };
+        double[] d = { 0.00778469570904146, 0.32246712907004, 2.445134137143, 3.75440866190742 };
+        double pLow = 0.02425, pHigh = 1 - pLow;
+
+        if (p < pLow)
+        {
+            double qq = Math.Sqrt(-2 * Math.Log(p));
+            return (((((c[0] * qq + c[1]) * qq + c[2]) * qq + c[3]) * qq + c[4]) * qq + c[5]) /
+                   ((((d[0] * qq + d[1]) * qq + d[2]) * qq + d[3]) * qq + 1);
+        }
+
+        if (p <= pHigh)
+        {
+            double qq = p - 0.5;
+            double r = qq * qq;
+            return (((((a[0] * r + a[1]) * r + a[2]) * r + a[3]) * r + a[4]) * r + a[5]) * qq /
+                   (((((b[0] * r + b[1]) * r + b[2]) * r + b[3]) * r + b[4]) * r + 1);
+        }
+
+        double q2 = Math.Sqrt(-2 * Math.Log(1 - p));
+        return -(((((c[0] * q2 + c[1]) * q2 + c[2]) * q2 + c[3]) * q2 + c[4]) * q2 + c[5]) /
+                ((((d[0] * q2 + d[1]) * q2 + d[2]) * q2 + d[3]) * q2 + 1);
+    }
+
+    // Draw a standard Student-t(ν) sample as z / sqrt(g/ν), z~N(0,1), g~ChiSq(ν)=Gamma(ν/2, 2).
+    public static double SampleStudentT(double nu, Random rng)
+    {
+        double z = rng.NextGaussian();
+        double g = SampleGamma(nu / 2.0, 2.0, rng);
+        double denom = Math.Sqrt(g / nu);
+        return denom > 1e-12 ? z / denom : z;
+    }
+
+    // Marsaglia–Tsang gamma sampler (shape k > 0, scale θ).
+    private static double SampleGamma(double k, double theta, Random rng)
+    {
+        if (k < 1.0)
+        {
+            // Boost: Gamma(k) = Gamma(k+1) · U^(1/k).
+            double u = rng.NextDouble();
+            return SampleGamma(k + 1.0, theta, rng) * Math.Pow(u <= 0 ? 1e-12 : u, 1.0 / k);
+        }
+
+        double d = k - 1.0 / 3.0;
+        double c = 1.0 / Math.Sqrt(9.0 * d);
+        while (true)
+        {
+            double x = rng.NextGaussian();
+            double v = 1.0 + c * x;
+            if (v <= 0) continue;
+            v = v * v * v;
+            double u = rng.NextDouble();
+            if (u < 1.0 - 0.0331 * x * x * x * x)
+                return d * v * theta;
+            if (Math.Log(u <= 0 ? 1e-12 : u) < 0.5 * x * x + d * (1.0 - v + Math.Log(v)))
+                return d * v * theta;
+        }
+    }
+
+    // Student-t quantile via a Cornish-Fisher expansion off the normal quantile (accurate for ν ≳ 3, the
+    // regime we use). Symmetric about 0.
+    public static double StudentTQuantile(double p, double nu)
+    {
+        double z = Probit(p);
+        double z3 = z * z * z;
+        double z5 = z3 * z * z;
+        double g1 = (z3 + z) / 4.0;
+        double g2 = (5 * z5 + 16 * z3 + 3 * z) / 96.0;
+        double g3 = (3 * z5 * z * z + 19 * z5 + 17 * z3 - 15 * z) / 384.0;
+        return z + g1 / nu + g2 / (nu * nu) + g3 / (nu * nu * nu);
+    }
+}

--- a/src/TimeSeries/DeepARModel.cs
+++ b/src/TimeSeries/DeepARModel.cs
@@ -7,6 +7,7 @@ using AiDotNet.Optimizers;
 using AiDotNet.Models.Options;
 using AiDotNet.Tensors;
 using AiDotNet.Tensors.Engines.Autodiff;
+using AiDotNet.Validation;
 
 namespace AiDotNet.TimeSeries;
 
@@ -617,9 +618,9 @@ public class DeepARModel<T> : TimeSeriesModelBase<T>
         int cov = _options.CovariateSize;
         if (cov <= 0)
             throw new InvalidOperationException("ForecastWithCovariates requires CovariateSize > 0; use ForecastWithQuantiles for the univariate model.");
-        ArgumentNullException.ThrowIfNull(history);
-        ArgumentNullException.ThrowIfNull(historyCovariates);
-        ArgumentNullException.ThrowIfNull(futureCovariates);
+        Guard.NotNull(history);
+        Guard.NotNull(historyCovariates);
+        Guard.NotNull(futureCovariates);
 
         int L = history.Length;
         if (historyCovariates.Rows != L || historyCovariates.Columns < cov)
@@ -677,8 +678,8 @@ public class DeepARModel<T> : TimeSeriesModelBase<T>
         int cov = _options.CovariateSize;
         if (cov <= 0)
             throw new InvalidOperationException("PredictNextWithCovariates requires CovariateSize > 0; use PredictSingle for the univariate model.");
-        ArgumentNullException.ThrowIfNull(historyWindow);
-        ArgumentNullException.ThrowIfNull(historyCovariates);
+        Guard.NotNull(historyWindow);
+        Guard.NotNull(historyCovariates);
         if (historyCovariates.Rows != historyWindow.Length || historyCovariates.Columns < cov)
             throw new ArgumentException($"historyCovariates must be [{historyWindow.Length}, >={cov}]; got [{historyCovariates.Rows}, {historyCovariates.Columns}].");
 

--- a/src/TimeSeries/DeepARModel.cs
+++ b/src/TimeSeries/DeepARModel.cs
@@ -67,9 +67,10 @@ public class DeepARModel<T> : TimeSeriesModelBase<T>
     private readonly Random _random;
     private Vector<T> _trainingSeries = Vector<T>.Empty();
 
-    // Tape-trainable LSTM cells (one per layer) and the Gaussian output head.
+    // Tape-trainable LSTM cells (one per layer) and the pluggable predictive-distribution head
+    // (Gaussian / Student-t / spline-quantile, selected by DeepAROptions.LikelihoodType).
     private readonly List<DeepARLstmCellTape<T>> _lstmLayers;
-    private DeepARGaussianHead<T> _head;
+    private DeepARDistributionHead<T> _head;
 
     // Normalization statistics computed during training (zero-mean / unit-variance of the
     // training series). Applied to inputs before the network and inverted on the network
@@ -131,7 +132,22 @@ public class DeepARModel<T> : TimeSeriesModelBase<T>
             _lstmLayers.Add(new DeepARLstmCellTape<T>(layerInputSize, _options.HiddenSize, 42 + i * 1000));
         }
 
-        _head = new DeepARGaussianHead<T>(_options.HiddenSize, seed: 12345);
+        _head = CreateHead();
+    }
+
+    /// <summary>
+    /// Builds the predictive-distribution head selected by <see cref="DeepAROptions{T}.LikelihoodType"/>:
+    /// "StudentT" (heavy-tailed, ν = <see cref="DeepAROptions{T}.StudentTDegreesOfFreedom"/>), "Spline"
+    /// (non-parametric asymmetric quantile function trained with the pinball loss), or "Gaussian" (default).
+    /// </summary>
+    private DeepARDistributionHead<T> CreateHead()
+    {
+        string kind = _options.LikelihoodType?.Trim() ?? "Gaussian";
+        if (string.Equals(kind, "StudentT", StringComparison.OrdinalIgnoreCase))
+            return new DeepARStudentTHead<T>(_options.HiddenSize, _options.StudentTDegreesOfFreedom, seed: 12345);
+        if (string.Equals(kind, "Spline", StringComparison.OrdinalIgnoreCase))
+            return new DeepARSplineHead<T>(_options.HiddenSize, seed: 12345);
+        return new DeepARGaussianHead<T>(_options.HiddenSize, seed: 12345);
     }
 
     private IReadOnlyList<Interfaces.ILayer<T>> AllLayers()
@@ -273,8 +289,10 @@ public class DeepARModel<T> : TimeSeriesModelBase<T>
 
                 using var tape = new GradientTape<T>();
 
-                var (meanBL, scaleBL) = ForwardTape(inputSteps, b);
-                var batchLoss = ComputeTrainingLoss(meanBL, scaleBL, batchTarget);
+                // Unroll the LSTM to per-step top hidden states, then let the selected distribution head
+                // build its own likelihood loss (the head owns the residual-mean skip + distribution math).
+                var hiddenSteps = ForwardHidden(inputSteps, b);
+                var batchLoss = _head.ComputeBatchLoss(hiddenSteps, inputSteps, batchTarget);
 
                 var allGrads = tape.ComputeGradients(batchLoss, sources: null);
                 var grads = new Dictionary<Tensor<T>, Tensor<T>>(
@@ -324,11 +342,12 @@ public class DeepARModel<T> : TimeSeriesModelBase<T>
 
     /// <summary>
     /// Tape-tracked batched forward: unrolls the LSTM over the timesteps in
-    /// <paramref name="inputSteps"/> (each <c>[1, B]</c>) and returns the per-step Gaussian
-    /// parameters as <c>([B, L] mean, [B, L] scale)</c>. Uses <c>Engine.Tensor*</c> ops so
+    /// <paramref name="inputSteps"/> (each <c>[1, B]</c>) and returns the top-layer hidden state
+    /// <c>[H, B]</c> at every timestep. The selected <see cref="DeepARDistributionHead{T}"/> turns those
+    /// hidden states into its likelihood loss. Uses <c>Engine.Tensor*</c> ops so
     /// <see cref="GradientTape{T}"/> differentiates the loss w.r.t. every registered weight.
     /// </summary>
-    private (Tensor<T> mean, Tensor<T> scale) ForwardTape(Tensor<T>[] inputSteps, int batch)
+    private List<Tensor<T>> ForwardHidden(Tensor<T>[] inputSteps, int batch)
     {
         int layers = _lstmLayers.Count;
         int h = _options.HiddenSize;
@@ -342,12 +361,10 @@ public class DeepARModel<T> : TimeSeriesModelBase<T>
             cState[l] = new Tensor<T>(new[] { h, batch });
         }
 
-        var meanSteps = new Tensor<T>[inputSteps.Length];
-        var scaleRawSteps = new Tensor<T>[inputSteps.Length];
-
+        var hiddenSteps = new List<Tensor<T>>(inputSteps.Length);
         for (int t = 0; t < inputSteps.Length; t++)
         {
-            Tensor<T> layerInput = inputSteps[t]; // [1, B]
+            Tensor<T> layerInput = inputSteps[t]; // [inputSize, B]
             for (int l = 0; l < layers; l++)
             {
                 var (hNew, cNew) = _lstmLayers[l].Step(layerInput, hState[l], cState[l]);
@@ -356,64 +373,13 @@ public class DeepARModel<T> : TimeSeriesModelBase<T>
                 layerInput = hNew; // feed to next layer
             }
 
-            // Top-layer hidden -> Gaussian parameters for the next value. The head predicts a
-            // RESIDUAL (delta) that is added to the current observation, so the mean is
-            // μ_t = x_t + Δ(h_t). This residual/skip parameterization keeps the model at the
-            // strong persistence prior (μ ≈ last value) at initialization and lets training
-            // learn only the one-step change — the plain "predict the level from hidden" head
-            // otherwise collapses to a smoothed mean on series with a fast seasonal component.
-            var (deltaT, scaleRawT) = _head.Project(hState[layers - 1]); // each [1, B]
-            meanSteps[t] = Engine.TensorAdd(inputSteps[t], deltaT);
-            scaleRawSteps[t] = scaleRawT;
+            // Each Step returns a fresh tensor, so storing the current top-layer hidden captures this
+            // timestep's state before the next iteration overwrites hState[layers-1]. The head applies the
+            // residual-mean skip (μ_t = x_t + Δ(h_t)) itself, keeping the strong persistence prior at init.
+            hiddenSteps.Add(hState[layers - 1]);
         }
 
-        // Concatenate the per-step [1, B] slices along axis 0 -> [L, B], then permute to [B, L].
-        var meanLB = Engine.TensorConcatenate(meanSteps, axis: 0);
-        var scaleRawLB = Engine.TensorConcatenate(scaleRawSteps, axis: 0);
-        var meanBL = Engine.TensorPermute(meanLB, new[] { 1, 0 });
-        var scaleRawBL = Engine.TensorPermute(scaleRawLB, new[] { 1, 0 });
-
-        // Softplus for a strictly-positive scale.
-        var scaleBL = Engine.Softplus(scaleRawBL);
-        return (meanBL, scaleBL);
-    }
-
-    /// <summary>
-    /// Training loss for the Gaussian head, built entirely from tape-tracked engine ops:
-    /// <c>MSE(μ, y) + mean( log σ + (y − μ_detached)² / (2σ²) )</c>.
-    /// </summary>
-    /// <remarks>
-    /// A pure Gaussian negative log-likelihood couples μ and σ through <c>∂NLL/∂μ = (μ−y)/σ²</c>:
-    /// when the mean is hard to fit early in training the optimizer inflates σ, which vanishes
-    /// that gradient and collapses μ to the series mean (verified empirically — μ froze at the
-    /// global mean and never tracked). Splitting the objective fixes this: the mean is pulled to
-    /// the target by an undivided MSE gradient (no σ escape hatch), while σ is still trained to
-    /// the residual scale via the NLL term with the mean <see cref="IEngine.StopGradient"/>-ed
-    /// so the σ branch cannot perturb μ. The Gaussian likelihood head therefore stays fully
-    /// trained and usable for predictive intervals. This mirrors the MSE-for-stability choice in
-    /// NBEATSModel and is the "train the mean on MSE" simplification permitted for this model.
-    /// </remarks>
-    private Tensor<T> ComputeTrainingLoss(Tensor<T> mean, Tensor<T> scale, Tensor<T> target)
-    {
-        var allAxes = Enumerable.Range(0, mean.Shape.Length).ToArray();
-
-        // Mean branch: plain MSE — gradient (μ − y) is independent of σ, so μ always tracks.
-        var diffMean = Engine.TensorSubtract(mean, target);
-        var meanMse = Engine.ReduceMean(Engine.TensorMultiply(diffMean, diffMean), allAxes, keepDims: false);
-
-        // Scale branch: Gaussian NLL over the detached mean so σ learns the residual spread
-        // without feeding gradient back into μ.
-        var eps = NumOps.FromDouble(1e-6);
-        var muDetached = Engine.StopGradient(mean);
-        var diff = Engine.TensorSubtract(target, muDetached);
-        var diff2 = Engine.TensorMultiply(diff, diff);
-        var variance = Engine.TensorMultiply(scale, scale);
-        var twoVar = Engine.TensorAddScalar(Engine.TensorMultiplyScalar(variance, NumOps.FromDouble(2.0)), eps);
-        var quad = Engine.TensorDivide(diff2, twoVar);
-        var logSigma = Engine.TensorLog(Engine.TensorAddScalar(scale, eps));
-        var scaleTerm = Engine.ReduceMean(Engine.TensorAdd(quad, logSigma), allAxes, keepDims: false);
-
-        return Engine.TensorAdd(meanMse, scaleTerm);
+        return hiddenSteps;
     }
 
     private List<Vector<T>> SnapshotParameters()
@@ -458,12 +424,26 @@ public class DeepARModel<T> : TimeSeriesModelBase<T>
     }
 
     /// <summary>
-    /// Predicts the Gaussian parameters (mean and scale, in the ORIGINAL data scale) for the
-    /// value that follows the provided lookback window. Runs the same <c>Engine.Tensor*</c>
-    /// LSTM recurrence used in training (B = 1, sequential unroll) so there is no
-    /// scalar/tape divergence between inference and training.
+    /// Predicts the point mean and representative scale (in the ORIGINAL data scale) for the value that
+    /// follows the provided lookback window, from whichever distribution head is configured.
     /// </summary>
     private (T mean, T scale) PredictDistribution(Vector<T> input)
+    {
+        var dist = PredictDistNorm(input);
+        T mean = NumOps.Add(NumOps.Multiply(dist.MeanNorm, _normStd), _normMean);
+        T scale = NumOps.Multiply(dist.ScaleNorm, _normStd);
+        T minScale = NumOps.FromDouble(1e-6);
+        if (NumOps.LessThan(scale, minScale))
+            scale = minScale;
+        return (mean, scale);
+    }
+
+    /// <summary>
+    /// Runs the eager (B = 1) LSTM recurrence over the lookback window — the same <c>Engine.Tensor*</c> ops
+    /// used in training, so there is no scalar/tape divergence — and returns the head's predictive
+    /// distribution in NORMALIZED space (point, scale, sampler, and optional closed-form quantile function).
+    /// </summary>
+    private DeepARPredictiveDist<T> PredictDistNorm(Vector<T> input)
     {
         // If the window is shorter than the lookback, LEFT-PAD it with its own first value while keeping the
         // caller's real values (in particular the most-recent one, which drives the residual skip at the head).
@@ -518,35 +498,16 @@ public class DeepARModel<T> : TimeSeriesModelBase<T>
             }
         }
 
-        var (deltaT, scaleRawT) = _head.Project(hState[layers - 1]); // each [1, 1]
-        // μ = last observed value + learned residual (matches the training parameterization).
-        T meanNorm = NumOps.Add(lastNorm, deltaT[0, 0]);
-        T scaleNorm = Softplus(scaleRawT[0, 0]);
-
-        // Denormalize into the original data scale.
-        T mean = NumOps.Add(NumOps.Multiply(meanNorm, _normStd), _normMean);
-        T scale = NumOps.Multiply(scaleNorm, _normStd);
-
-        T minScale = NumOps.FromDouble(1e-6);
-        if (NumOps.LessThan(scale, minScale))
-            scale = minScale;
-
-        return (mean, scale);
-    }
-
-    private T Softplus(T v)
-    {
-        T threshold = NumOps.FromDouble(20.0);
-        if (NumOps.GreaterThan(v, threshold))
-            return v;
-        if (NumOps.LessThan(v, NumOps.FromDouble(-20.0)))
-            return NumOps.Exp(v);
-        return NumOps.Log(NumOps.Add(NumOps.One, NumOps.Exp(v)));
+        // The head owns the residual-mean skip and the distribution math; hand it the final hidden state
+        // and the last normalized observation, and return its normalized predictive distribution.
+        return _head.PredictNorm(hState[layers - 1], lastNorm);
     }
 
     /// <summary>
     /// Generates probabilistic forecasts with quantile predictions by Monte-Carlo sampling
-    /// the autoregressive predictive path.
+    /// the autoregressive predictive path. Samples are drawn from the configured head's own predictive
+    /// distribution (heavy-tailed for Student-t, asymmetric for the spline head), so the quantile bands
+    /// reflect the fitted tail-weight and skew rather than a forced Gaussian shape.
     /// </summary>
     public Dictionary<double, Vector<T>> ForecastWithQuantiles(Vector<T> history, double[] quantiles)
     {
@@ -560,9 +521,10 @@ public class DeepARModel<T> : TimeSeriesModelBase<T>
 
             for (int hStep = 0; hStep < _options.ForecastHorizon; hStep++)
             {
-                var (mean, scale) = PredictDistribution(context);
-
-                T sample = NumOps.Add(mean, NumOps.Multiply(scale, NumOps.FromDouble(_random.NextGaussian())));
+                var dist = PredictDistNorm(context);
+                // Denormalize a head-drawn sample into the original data scale.
+                T sampleNorm = dist.SampleNorm(_random);
+                T sample = NumOps.Add(NumOps.Multiply(sampleNorm, _normStd), _normMean);
                 forecast[hStep] = sample;
 
                 var newContext = new Vector<T>(context.Length);
@@ -601,6 +563,10 @@ public class DeepARModel<T> : TimeSeriesModelBase<T>
     {
         writer.Write(_options.HiddenSize);
         writer.Write(_options.NumLayers);
+        // Persist the head selector so deserialize rebuilds the SAME distribution head regardless of the
+        // options passed to the deserializing constructor.
+        writer.Write(_options.LikelihoodType ?? "Gaussian");
+        writer.Write(_options.StudentTDegreesOfFreedom);
 
         writer.Write(_lstmLayers.Count);
         foreach (var lstm in _lstmLayers)
@@ -620,6 +586,8 @@ public class DeepARModel<T> : TimeSeriesModelBase<T>
     {
         _options.HiddenSize = reader.ReadInt32();
         _options.NumLayers = reader.ReadInt32();
+        _options.LikelihoodType = reader.ReadString();
+        _options.StudentTDegreesOfFreedom = reader.ReadDouble();
 
         InitializeModel();
 
@@ -650,7 +618,7 @@ public class DeepARModel<T> : TimeSeriesModelBase<T>
         return new ModelMetadata<T>
         {
             Name = "DeepAR",
-            Description = "Probabilistic forecasting with autoregressive recurrent networks (tape-trained BPTT, Gaussian likelihood)",
+            Description = $"Probabilistic forecasting with autoregressive recurrent networks (tape-trained BPTT, {_head.LikelihoodName} likelihood head)",
             Complexity = ParameterCount,
             FeatureCount = _options.LookbackWindow,
             AdditionalInfo = new Dictionary<string, object>
@@ -851,144 +819,6 @@ internal class DeepARLstmCellTape<T> : NeuralNetworks.Layers.LayerBase<T>
         ReadTensorInto(reader, _wx);
         ReadTensorInto(reader, _wh);
         ReadTensorInto(reader, _bias);
-    }
-
-    private static void WriteTensor(BinaryWriter writer, Tensor<T> tensor)
-    {
-        writer.Write(tensor.Shape.Length);
-        foreach (var dim in tensor._shape)
-            writer.Write(dim);
-        for (int i = 0; i < tensor.Length; i++)
-            writer.Write(Convert.ToDouble(tensor[i]));
-    }
-
-    private void ReadTensorInto(BinaryReader reader, Tensor<T> tensor)
-    {
-        int rank = reader.ReadInt32();
-        var shape = new int[rank];
-        for (int d = 0; d < rank; d++)
-            shape[d] = reader.ReadInt32();
-        int total = shape.Aggregate(1, (a, bb) => a * bb);
-        for (int i = 0; i < total; i++)
-        {
-            double v = reader.ReadDouble();
-            if (i < tensor.Length)
-                tensor[i] = NumOps.FromDouble(v);
-        }
-    }
-}
-
-/// <summary>
-/// Gaussian output head for DeepAR: projects the top LSTM hidden state to a mean and a raw
-/// scale (softplus is applied by the caller). Expressed with <c>Engine.Tensor*</c> ops so the
-/// tape differentiates the likelihood w.r.t. the projection weights. Activations are
-/// column-major <c>[*, batch]</c>.
-/// </summary>
-internal class DeepARGaussianHead<T> : NeuralNetworks.Layers.LayerBase<T>
-{
-    private readonly int _hiddenSize;
-
-    private readonly Tensor<T> _meanW;   // [1, H]
-    private readonly Tensor<T> _meanB;   // [1]
-    private readonly Tensor<T> _scaleW;  // [1, H]
-    private readonly Tensor<T> _scaleB;  // [1]
-
-    public override long ParameterCount => _meanW.Length + _meanB.Length + _scaleW.Length + _scaleB.Length;
-    public override bool SupportsTraining => true;
-    public override void ResetState() { }
-    public override void UpdateParameters(T learningRate) { /* tape-based optimizer updates registered params */ }
-
-    /// <summary>
-    /// Projects the hidden state <paramref name="input"/> <c>[H, B]</c> to the Gaussian mean
-    /// <c>[1, B]</c> (satisfies the <c>ILayer</c> contract; the model uses <see cref="Project"/>).
-    /// </summary>
-    public override Tensor<T> Forward(Tensor<T> input)
-    {
-        var (mean, _) = Project(input);
-        return mean;
-    }
-
-    public DeepARGaussianHead(int hiddenSize, int seed = 12345)
-        : base(new[] { hiddenSize }, new[] { 1 })
-    {
-        _hiddenSize = hiddenSize;
-
-        var random = RandomHelper.CreateSeededRandom(seed);
-        double stddev = Math.Sqrt(2.0 / hiddenSize);
-
-        _meanW = CreateRandomTensor(new[] { 1, hiddenSize }, stddev, random);
-        _meanB = new Tensor<T>(new[] { 1 });
-        _scaleW = CreateRandomTensor(new[] { 1, hiddenSize }, stddev, random);
-        _scaleB = new Tensor<T>(new[] { 1 });
-
-        RegisterTrainableParameter(_meanW, PersistentTensorRole.Weights);
-        RegisterTrainableParameter(_meanB, PersistentTensorRole.Biases);
-        RegisterTrainableParameter(_scaleW, PersistentTensorRole.Weights);
-        RegisterTrainableParameter(_scaleB, PersistentTensorRole.Biases);
-    }
-
-    private Tensor<T> CreateRandomTensor(int[] shape, double stddev, Random random)
-    {
-        var tensor = new Tensor<T>(shape);
-        int total = tensor.Length;
-        for (int i = 0; i < total; i++)
-            tensor[i] = NumOps.FromDouble((random.NextDouble() * 2 - 1) * stddev);
-        return tensor;
-    }
-
-    /// <summary>
-    /// Projects the top hidden state <paramref name="h"/> (<c>[H, B]</c>) to the Gaussian mean
-    /// and raw (pre-softplus) scale, each <c>[1, B]</c>. Same ops for tape and eager use.
-    /// </summary>
-    public (Tensor<T> mean, Tensor<T> scaleRaw) Project(Tensor<T> h)
-    {
-        var mean = Engine.TensorMatMul(_meanW, h);   // [1, B]
-        var meanBCol = Engine.Reshape(_meanB, new[] { 1, 1 });
-        mean = Engine.TensorBroadcastAdd(mean, meanBCol);
-
-        var scaleRaw = Engine.TensorMatMul(_scaleW, h); // [1, B]
-        var scaleBCol = Engine.Reshape(_scaleB, new[] { 1, 1 });
-        scaleRaw = Engine.TensorBroadcastAdd(scaleRaw, scaleBCol);
-
-        return (mean, scaleRaw);
-    }
-
-    public override Vector<T> GetParameters()
-    {
-        var p = new T[_meanW.Length + _meanB.Length + _scaleW.Length + _scaleB.Length];
-        int idx = 0;
-        for (int i = 0; i < _meanW.Length; i++) p[idx++] = _meanW[i];
-        for (int i = 0; i < _meanB.Length; i++) p[idx++] = _meanB[i];
-        for (int i = 0; i < _scaleW.Length; i++) p[idx++] = _scaleW[i];
-        for (int i = 0; i < _scaleB.Length; i++) p[idx++] = _scaleB[i];
-        return new Vector<T>(p);
-    }
-
-    public override void SetParameters(Vector<T> parameters)
-    {
-        int idx = 0;
-        for (int i = 0; i < _meanW.Length; i++) _meanW[i] = parameters[idx++];
-        for (int i = 0; i < _meanB.Length; i++) _meanB[i] = parameters[idx++];
-        for (int i = 0; i < _scaleW.Length; i++) _scaleW[i] = parameters[idx++];
-        for (int i = 0; i < _scaleB.Length; i++) _scaleB[i] = parameters[idx++];
-    }
-
-    public override void Serialize(BinaryWriter writer)
-    {
-        writer.Write(_hiddenSize);
-        WriteTensor(writer, _meanW);
-        WriteTensor(writer, _meanB);
-        WriteTensor(writer, _scaleW);
-        WriteTensor(writer, _scaleB);
-    }
-
-    public override void Deserialize(BinaryReader reader)
-    {
-        reader.ReadInt32(); // hiddenSize
-        ReadTensorInto(reader, _meanW);
-        ReadTensorInto(reader, _meanB);
-        ReadTensorInto(reader, _scaleW);
-        ReadTensorInto(reader, _scaleB);
     }
 
     private static void WriteTensor(BinaryWriter writer, Tensor<T> tensor)

--- a/src/TimeSeries/DeepARModel.cs
+++ b/src/TimeSeries/DeepARModel.cs
@@ -78,6 +78,11 @@ public class DeepARModel<T> : TimeSeriesModelBase<T>
     private T _normMean = MathHelper.GetNumericOperations<T>().Zero;
     private T _normStd = MathHelper.GetNumericOperations<T>().One;
 
+    // Per-covariate standardization stats (zero-mean / unit-variance over the training rows), populated only
+    // when DeepAROptions.CovariateSize > 0. Empty for the default univariate model.
+    private T[] _covMean = Array.Empty<T>();
+    private T[] _covStd = Array.Empty<T>();
+
     /// <summary>
     /// Initializes a new instance of the DeepARModel class.
     /// </summary>
@@ -123,12 +128,12 @@ public class DeepARModel<T> : TimeSeriesModelBase<T>
     {
         _lstmLayers.Clear();
 
-        // The recurrence consumes one series value per timestep (inputSize = 1). Covariates
-        // are not fed into the recurrence in this univariate formulation; CovariateSize is
-        // retained on the options for API compatibility but does not change the cell shape.
+        // The first layer consumes the series value plus any covariates (inputSize = 1 + CovariateSize);
+        // deeper layers consume the previous hidden state. CovariateSize = 0 (default) is the univariate model.
+        int firstInputSize = 1 + Math.Max(0, _options.CovariateSize);
         for (int i = 0; i < _options.NumLayers; i++)
         {
-            int layerInputSize = (i == 0) ? 1 : _options.HiddenSize;
+            int layerInputSize = (i == 0) ? firstInputSize : _options.HiddenSize;
             _lstmLayers.Add(new DeepARLstmCellTape<T>(layerInputSize, _options.HiddenSize, 42 + i * 1000));
         }
 
@@ -164,13 +169,14 @@ public class DeepARModel<T> : TimeSeriesModelBase<T>
     /// LSTM) and the Adam optimizer, on the Gaussian negative log-likelihood.
     /// </summary>
     /// <remarks>
-    /// The label vector <paramref name="y"/> is interpreted as the univariate series. Each
-    /// sample unrolls the LSTM over an L-step lookback window and is supervised one-step-ahead
-    /// at every timestep (teacher forcing): the input at step t is y_{s+t} and the target is
-    /// y_{s+t+1}. Autodiff yields gradients for every LSTM gate weight/bias and the Gaussian
-    /// head; the previous implementation used hand-derived per-sample scalar gradients, which
-    /// this rewrite removes entirely. The mean is emitted as a residual on the current
-    /// observation (μ_t = x_t + Δ(h_t)); see <see cref="ForwardTape"/>.
+    /// The label vector <paramref name="y"/> is the univariate series. Each sample unrolls the LSTM over an
+    /// L-step lookback window and is supervised one-step-ahead at every timestep (teacher forcing): the input
+    /// at step t is y_{s+t} and the target is y_{s+t+1}. When <see cref="DeepAROptions{T}.CovariateSize"/> &gt; 0,
+    /// <paramref name="x"/> must supply one covariate row per series index (<c>[N, ≥CovariateSize]</c>, aligned
+    /// to <paramref name="y"/>); those standardized covariates are concatenated to the series value at each
+    /// step, so the recurrence conditions on them. Autodiff yields gradients for every LSTM gate weight/bias
+    /// and the selected distribution head. The head emits the mean as a residual on the current observation
+    /// (μ_t = x_t + Δ(h_t)); see <see cref="ForwardHidden"/> and <see cref="DeepARDistributionHead{T}"/>.
     /// </remarks>
     protected override void TrainCore(Matrix<T> x, Vector<T> y)
     {
@@ -204,6 +210,45 @@ public class DeepARModel<T> : TimeSeriesModelBase<T>
         var yNorm = new Vector<T>(y.Length);
         for (int i = 0; i < y.Length; i++)
             yNorm[i] = NumOps.Divide(NumOps.Subtract(y[i], yMean), yStd);
+
+        // Covariate contract: when CovariateSize > 0, x must supply one covariate row per series index
+        // (x is [N, >=CovariateSize], aligned to y). Standardize each covariate column so the recurrence sees
+        // well-scaled inputs. When CovariateSize == 0 (default) x is the univariate series-window contract and
+        // is not consumed here.
+        int cov = Math.Max(0, _options.CovariateSize);
+        if (cov > 0)
+        {
+            if (x is null || x.Rows != y.Length || x.Columns < cov)
+            {
+                throw new ArgumentException(
+                    $"DeepAR covariate contract violated: with CovariateSize={cov}, x must be [{y.Length}, >={cov}] " +
+                    $"(one covariate row per series index), but got [{x?.Rows ?? 0}, {x?.Columns ?? 0}].");
+            }
+
+            _covMean = new T[cov];
+            _covStd = new T[cov];
+            for (int c = 0; c < cov; c++)
+            {
+                T m = NumOps.Zero;
+                for (int i = 0; i < x.Rows; i++)
+                    m = NumOps.Add(m, x[i, c]);
+                m = NumOps.Divide(m, NumOps.FromDouble(x.Rows));
+
+                T v = NumOps.Zero;
+                for (int i = 0; i < x.Rows; i++)
+                {
+                    T d = NumOps.Subtract(x[i, c], m);
+                    v = NumOps.Add(v, NumOps.Multiply(d, d));
+                }
+                v = NumOps.Divide(v, NumOps.FromDouble(x.Rows));
+                T s = NumOps.Sqrt(v);
+                if (NumOps.LessThanOrEquals(s, NumOps.FromDouble(1e-10)))
+                    s = NumOps.One;
+
+                _covMean[c] = m;
+                _covStd[c] = s;
+            }
+        }
 
         // Adam optimizer (Salinas et al. 2020 use Adam).
         var adamOptions = new AdamOptimizerOptions<T, Matrix<T>, Vector<T>>
@@ -265,17 +310,28 @@ public class DeepARModel<T> : TimeSeriesModelBase<T>
 
                 int b = validIndices.Count;
 
-                // Per-timestep input tensors [1, B] and the [B, L] target window.
-                var inputSteps = new Tensor<T>[lookback];
+                // Per-timestep observation [1, B] (drives the residual-mean skip) and LSTM input
+                // [1+cov, B] (series value + standardized covariates), plus the [B, L] target window.
+                int inputDim = 1 + cov;
+                var obsSteps = new Tensor<T>[lookback];
+                var lstmInputSteps = new Tensor<T>[lookback];
                 for (int t = 0; t < lookback; t++)
                 {
-                    var xt = new Tensor<T>(new[] { 1, b });
+                    var obs = new Tensor<T>(new[] { 1, b });
+                    var xt = new Tensor<T>(new[] { inputDim, b });
                     for (int bi = 0; bi < b; bi++)
                     {
                         int idx = validIndices[bi];
-                        xt[0, bi] = yNorm[idx - lookback + t];
+                        int seriesIdx = idx - lookback + t;
+                        T yv = yNorm[seriesIdx];
+                        obs[0, bi] = yv;
+                        xt[0, bi] = yv;
+                        for (int c = 0; c < cov; c++)
+                            xt[1 + c, bi] = NumOps.Divide(NumOps.Subtract(x[seriesIdx, c], _covMean[c]), _covStd[c]);
                     }
-                    inputSteps[t] = xt;
+
+                    obsSteps[t] = obs;
+                    lstmInputSteps[t] = xt;
                 }
 
                 var targetData = new T[b * lookback];
@@ -291,8 +347,8 @@ public class DeepARModel<T> : TimeSeriesModelBase<T>
 
                 // Unroll the LSTM to per-step top hidden states, then let the selected distribution head
                 // build its own likelihood loss (the head owns the residual-mean skip + distribution math).
-                var hiddenSteps = ForwardHidden(inputSteps, b);
-                var batchLoss = _head.ComputeBatchLoss(hiddenSteps, inputSteps, batchTarget);
+                var hiddenSteps = ForwardHidden(lstmInputSteps, b);
+                var batchLoss = _head.ComputeBatchLoss(hiddenSteps, obsSteps, batchTarget);
 
                 var allGrads = tape.ComputeGradients(batchLoss, sources: null);
                 var grads = new Dictionary<Tensor<T>, Tensor<T>>(
@@ -445,6 +501,13 @@ public class DeepARModel<T> : TimeSeriesModelBase<T>
     /// </summary>
     private DeepARPredictiveDist<T> PredictDistNorm(Vector<T> input)
     {
+        if (_options.CovariateSize > 0)
+        {
+            throw new InvalidOperationException(
+                "This DeepAR model was trained with covariates (CovariateSize > 0). Use ForecastWithCovariates(...), " +
+                "which supplies the aligned covariate rows — the univariate Predict path cannot fabricate them.");
+        }
+
         // If the window is shorter than the lookback, LEFT-PAD it with its own first value while keeping the
         // caller's real values (in particular the most-recent one, which drives the residual skip at the head).
         // NOTE: this previously replaced the window with a fixed slice of the TRAINING tail — identical for every
@@ -537,13 +600,110 @@ public class DeepARModel<T> : TimeSeriesModelBase<T>
             samples.Add(forecast);
         }
 
+        return BuildQuantiles(samples, quantiles);
+    }
+
+    /// <summary>
+    /// Covariate-aware probabilistic forecast: same Monte-Carlo autoregressive rollout as
+    /// <see cref="ForecastWithQuantiles"/>, but each step conditions on covariates. Requires
+    /// <see cref="DeepAROptions{T}.CovariateSize"/> &gt; 0. <paramref name="historyCovariates"/> is the
+    /// <c>[L, CovariateSize]</c> covariate block aligned to <paramref name="history"/>, and
+    /// <paramref name="futureCovariates"/> is the <c>[horizon, CovariateSize]</c> KNOWN-future block used as
+    /// each forecast step is rolled in. This is the inference path for a covariate-trained model.
+    /// </summary>
+    public Dictionary<double, Vector<T>> ForecastWithCovariates(
+        Vector<T> history, Matrix<T> historyCovariates, Matrix<T> futureCovariates, double[] quantiles)
+    {
+        int cov = _options.CovariateSize;
+        if (cov <= 0)
+            throw new InvalidOperationException("ForecastWithCovariates requires CovariateSize > 0; use ForecastWithQuantiles for the univariate model.");
+        ArgumentNullException.ThrowIfNull(history);
+        ArgumentNullException.ThrowIfNull(historyCovariates);
+        ArgumentNullException.ThrowIfNull(futureCovariates);
+
+        int L = history.Length;
+        if (historyCovariates.Rows != L || historyCovariates.Columns < cov)
+            throw new ArgumentException($"historyCovariates must be [{L}, >={cov}]; got [{historyCovariates.Rows}, {historyCovariates.Columns}].");
+        int horizon = _options.ForecastHorizon;
+        if (futureCovariates.Rows < horizon || futureCovariates.Columns < cov)
+            throw new ArgumentException($"futureCovariates must be [>={horizon}, >={cov}]; got [{futureCovariates.Rows}, {futureCovariates.Columns}].");
+
+        var samples = new List<Vector<T>>();
+        for (int s = 0; s < _options.NumSamples; s++)
+        {
+            var winVals = history.Clone();
+            var winCov = new T[L][];
+            for (int i = 0; i < L; i++)
+            {
+                winCov[i] = new T[cov];
+                for (int c = 0; c < cov; c++)
+                    winCov[i][c] = historyCovariates[i, c];
+            }
+
+            var forecast = new Vector<T>(horizon);
+            for (int hStep = 0; hStep < horizon; hStep++)
+            {
+                var dist = PredictDistNormCov(winVals, winCov);
+                T sampleNorm = dist.SampleNorm(_random);
+                T sample = NumOps.Add(NumOps.Multiply(sampleNorm, _normStd), _normMean);
+                forecast[hStep] = sample;
+
+                // Slide the window forward one step: drop the oldest (value, covariate row), append the drawn
+                // sample paired with the known-future covariate row for this step.
+                for (int i = 0; i < L - 1; i++)
+                {
+                    winVals[i] = winVals[i + 1];
+                    for (int c = 0; c < cov; c++)
+                        winCov[i][c] = winCov[i + 1][c];
+                }
+                winVals[L - 1] = sample;
+                for (int c = 0; c < cov; c++)
+                    winCov[L - 1][c] = futureCovariates[hStep, c];
+            }
+
+            samples.Add(forecast);
+        }
+
+        return BuildQuantiles(samples, quantiles);
+    }
+
+    /// <summary>
+    /// Covariate-aware point forecast (the head's mean, in original scale) for the value that follows the
+    /// given <c>[L]</c> series window and its aligned <c>[L, CovariateSize]</c> covariate rows. Deterministic
+    /// (no sampling). Requires <see cref="DeepAROptions{T}.CovariateSize"/> &gt; 0.
+    /// </summary>
+    public T PredictNextWithCovariates(Vector<T> historyWindow, Matrix<T> historyCovariates)
+    {
+        int cov = _options.CovariateSize;
+        if (cov <= 0)
+            throw new InvalidOperationException("PredictNextWithCovariates requires CovariateSize > 0; use PredictSingle for the univariate model.");
+        ArgumentNullException.ThrowIfNull(historyWindow);
+        ArgumentNullException.ThrowIfNull(historyCovariates);
+        if (historyCovariates.Rows != historyWindow.Length || historyCovariates.Columns < cov)
+            throw new ArgumentException($"historyCovariates must be [{historyWindow.Length}, >={cov}]; got [{historyCovariates.Rows}, {historyCovariates.Columns}].");
+
+        var covWindow = new T[historyWindow.Length][];
+        for (int i = 0; i < historyWindow.Length; i++)
+        {
+            covWindow[i] = new T[cov];
+            for (int c = 0; c < cov; c++)
+                covWindow[i][c] = historyCovariates[i, c];
+        }
+
+        var dist = PredictDistNormCov(historyWindow, covWindow);
+        return NumOps.Add(NumOps.Multiply(dist.MeanNorm, _normStd), _normMean);
+    }
+
+    /// <summary>Empirical quantile extraction shared by the univariate and covariate forecast paths.</summary>
+    private Dictionary<double, Vector<T>> BuildQuantiles(List<Vector<T>> samples, double[] quantiles)
+    {
+        var result = new Dictionary<double, Vector<T>>();
         foreach (var q in quantiles)
         {
             var quantileForecast = new Vector<T>(_options.ForecastHorizon);
-
             for (int hStep = 0; hStep < _options.ForecastHorizon; hStep++)
             {
-                var values = new List<double>();
+                var values = new List<double>(samples.Count);
                 foreach (var sample in samples)
                     values.Add(Convert.ToDouble(sample[hStep]));
                 values.Sort();
@@ -559,6 +719,48 @@ public class DeepARModel<T> : TimeSeriesModelBase<T>
         return result;
     }
 
+    /// <summary>
+    /// Covariate-aware eager unroll (B = 1): runs the LSTM over a <c>[L]</c> series window plus its aligned
+    /// <c>[L][CovariateSize]</c> covariate rows (both original-scale; standardized here with the training
+    /// stats) and returns the head's normalized predictive distribution.
+    /// </summary>
+    private DeepARPredictiveDist<T> PredictDistNormCov(Vector<T> seriesWindow, T[][] covWindow)
+    {
+        int layers = _lstmLayers.Count;
+        int hidden = _options.HiddenSize;
+        int cov = _options.CovariateSize;
+
+        var hState = new Tensor<T>[layers];
+        var cState = new Tensor<T>[layers];
+        for (int l = 0; l < layers; l++)
+        {
+            hState[l] = new Tensor<T>(new[] { hidden, 1 });
+            cState[l] = new Tensor<T>(new[] { hidden, 1 });
+        }
+
+        T lastNorm = NumOps.Zero;
+        for (int t = 0; t < seriesWindow.Length; t++)
+        {
+            T normValue = NumOps.Divide(NumOps.Subtract(seriesWindow[t], _normMean), _normStd);
+            lastNorm = normValue;
+            var xt = new Tensor<T>(new[] { 1 + cov, 1 });
+            xt[0, 0] = normValue;
+            for (int c = 0; c < cov; c++)
+                xt[1 + c, 0] = NumOps.Divide(NumOps.Subtract(covWindow[t][c], _covMean[c]), _covStd[c]);
+
+            Tensor<T> layerInput = xt;
+            for (int l = 0; l < layers; l++)
+            {
+                var (hNew, cNew) = _lstmLayers[l].Step(layerInput, hState[l], cState[l]);
+                hState[l] = hNew;
+                cState[l] = cNew;
+                layerInput = hNew;
+            }
+        }
+
+        return _head.PredictNorm(hState[layers - 1], lastNorm);
+    }
+
     protected override void SerializeCore(BinaryWriter writer)
     {
         writer.Write(_options.HiddenSize);
@@ -567,6 +769,7 @@ public class DeepARModel<T> : TimeSeriesModelBase<T>
         // options passed to the deserializing constructor.
         writer.Write(_options.LikelihoodType ?? "Gaussian");
         writer.Write(_options.StudentTDegreesOfFreedom);
+        writer.Write(_options.CovariateSize); // needed before InitializeModel to size the first LSTM layer
 
         writer.Write(_lstmLayers.Count);
         foreach (var lstm in _lstmLayers)
@@ -576,6 +779,14 @@ public class DeepARModel<T> : TimeSeriesModelBase<T>
 
         writer.Write(Convert.ToDouble(_normMean));
         writer.Write(Convert.ToDouble(_normStd));
+
+        // Covariate standardization stats (empty for the univariate model).
+        writer.Write(_covMean.Length);
+        for (int c = 0; c < _covMean.Length; c++)
+        {
+            writer.Write(Convert.ToDouble(_covMean[c]));
+            writer.Write(Convert.ToDouble(_covStd[c]));
+        }
 
         writer.Write(_trainingSeries.Length);
         for (int i = 0; i < _trainingSeries.Length; i++)
@@ -588,6 +799,7 @@ public class DeepARModel<T> : TimeSeriesModelBase<T>
         _options.NumLayers = reader.ReadInt32();
         _options.LikelihoodType = reader.ReadString();
         _options.StudentTDegreesOfFreedom = reader.ReadDouble();
+        _options.CovariateSize = reader.ReadInt32();
 
         InitializeModel();
 
@@ -599,6 +811,15 @@ public class DeepARModel<T> : TimeSeriesModelBase<T>
 
         _normMean = NumOps.FromDouble(reader.ReadDouble());
         _normStd = NumOps.FromDouble(reader.ReadDouble());
+
+        int covLen = reader.ReadInt32();
+        _covMean = new T[covLen];
+        _covStd = new T[covLen];
+        for (int c = 0; c < covLen; c++)
+        {
+            _covMean[c] = NumOps.FromDouble(reader.ReadDouble());
+            _covStd[c] = NumOps.FromDouble(reader.ReadDouble());
+        }
 
         try
         {
@@ -650,6 +871,8 @@ public class DeepARModel<T> : TimeSeriesModelBase<T>
             clone.ModelParameters = new Vector<T>(ModelParameters);
         clone._normMean = _normMean;
         clone._normStd = _normStd;
+        clone._covMean = (T[])_covMean.Clone();
+        clone._covStd = (T[])_covStd.Clone();
         return clone;
     }
 

--- a/tests/AiDotNet.Tests/UnitTests/TimeSeries/DeepARCovariateTests.cs
+++ b/tests/AiDotNet.Tests/UnitTests/TimeSeries/DeepARCovariateTests.cs
@@ -27,6 +27,9 @@ public sealed class DeepARCovariateTests
         CovariateSize = 1,
     };
 
+    // net471-safe finiteness check (double.IsFinite is .NET Core / netstandard2.1+ only).
+    private static bool IsFinite(double x) => !double.IsNaN(x) && !double.IsInfinity(x);
+
     // Series whose one-step change is DRIVEN by a covariate: y[t+1] - y[t] ≈ covariate[t]. A covariate-blind
     // model cannot fit this; a covariate-aware one can, so the trained model's next-step forecast must move
     // with the last covariate.
@@ -75,7 +78,7 @@ public sealed class DeepARCovariateTests
         var bands = model.ForecastWithCovariates(history, histCov, future, new[] { 0.1, 0.5, 0.9 });
         for (var h = 0; h < options.ForecastHorizon; h++)
         {
-            Assert.True(double.IsFinite(bands[0.5][h]), $"non-finite covariate forecast at h={h}");
+            Assert.True(IsFinite(bands[0.5][h]), $"non-finite covariate forecast at h={h}");
             Assert.True(bands[0.1][h] <= bands[0.5][h] + 1e-9 && bands[0.5][h] <= bands[0.9][h] + 1e-9, "non-monotone band");
         }
     }
@@ -106,7 +109,7 @@ public sealed class DeepARCovariateTests
         double fLow = model.PredictNextWithCovariates(history, covLow);
         double fHigh = model.PredictNextWithCovariates(history, covHigh);
 
-        Assert.True(double.IsFinite(fLow) && double.IsFinite(fHigh), "non-finite covariate point forecast");
+        Assert.True(IsFinite(fLow) && IsFinite(fHigh), "non-finite covariate point forecast");
         // A covariate that drives the next step must change the forecast, and in the right direction
         // (higher covariate → higher next value on this series).
         Assert.True(Math.Abs(fHigh - fLow) > 1e-4, $"covariate had no effect on the forecast ({fLow} vs {fHigh}) — x was ignored");

--- a/tests/AiDotNet.Tests/UnitTests/TimeSeries/DeepARCovariateTests.cs
+++ b/tests/AiDotNet.Tests/UnitTests/TimeSeries/DeepARCovariateTests.cs
@@ -1,0 +1,141 @@
+using System;
+using System.Linq;
+using AiDotNet.Models.Options;
+using AiDotNet.TimeSeries;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tests.UnitTests.TimeSeries;
+
+/// <summary>
+/// Tests for DeepAR covariate consumption (DeepAROptions.CovariateSize > 0): the model must actually
+/// condition on the covariates (not silently ignore x), validate the covariate contract, and reject the
+/// univariate predict path once trained with covariates.
+/// </summary>
+public sealed class DeepARCovariateTests
+{
+    private static DeepAROptions<double> CovOptions() => new()
+    {
+        LookbackWindow = 10,
+        ForecastHorizon = 3,
+        HiddenSize = 20,
+        NumLayers = 1,
+        Epochs = 60,
+        BatchSize = 8,
+        NumSamples = 100,
+        LikelihoodType = "Gaussian",
+        CovariateSize = 1,
+    };
+
+    // Series whose one-step change is DRIVEN by a covariate: y[t+1] - y[t] ≈ covariate[t]. A covariate-blind
+    // model cannot fit this; a covariate-aware one can, so the trained model's next-step forecast must move
+    // with the last covariate.
+    private static (Matrix<double> x, Vector<double> y, Matrix<double> cov) CovariateDrivenSeries(int n)
+    {
+        var rng = new Random(11);
+        var y = new Vector<double>(n);
+        var cov = new Matrix<double>(n, 1);
+        double level = 0.0;
+        for (var i = 0; i < n; i++)
+        {
+            double c = Math.Sin(i * 0.3) + (rng.NextDouble() - 0.5) * 0.1; // covariate at index i
+            cov[i, 0] = c;
+            y[i] = level;
+            level += c; // next level moves by the current covariate
+        }
+
+        // x doubles as the covariate matrix (the covariate contract: x is [N, CovariateSize] aligned to y).
+        var x = new Matrix<double>(n, 1);
+        for (var i = 0; i < n; i++)
+            x[i, 0] = cov[i, 0];
+        return (x, y, cov);
+    }
+
+    [Fact]
+    [Trait("category", "unit")]
+    public void Covariate_model_trains_and_forecasts_finite()
+    {
+        var options = CovOptions();
+        var model = new DeepARModel<double>(options);
+        var (x, y, cov) = CovariateDrivenSeries(160);
+        model.Train(x, y);
+
+        var history = new Vector<double>(options.LookbackWindow);
+        var histCov = new Matrix<double>(options.LookbackWindow, 1);
+        for (var j = 0; j < options.LookbackWindow; j++)
+        {
+            history[j] = y[100 + j];
+            histCov[j, 0] = cov[100 + j, 0];
+        }
+
+        var future = new Matrix<double>(options.ForecastHorizon, 1);
+        for (var h = 0; h < options.ForecastHorizon; h++)
+            future[h, 0] = 0.2;
+
+        var bands = model.ForecastWithCovariates(history, histCov, future, new[] { 0.1, 0.5, 0.9 });
+        for (var h = 0; h < options.ForecastHorizon; h++)
+        {
+            Assert.True(double.IsFinite(bands[0.5][h]), $"non-finite covariate forecast at h={h}");
+            Assert.True(bands[0.1][h] <= bands[0.5][h] + 1e-9 && bands[0.5][h] <= bands[0.9][h] + 1e-9, "non-monotone band");
+        }
+    }
+
+    [Fact]
+    [Trait("category", "unit")]
+    public void The_covariate_actually_moves_the_forecast()
+    {
+        var options = CovOptions();
+        var model = new DeepARModel<double>(options);
+        var (x, y, cov) = CovariateDrivenSeries(160);
+        model.Train(x, y);
+
+        // Same series window; two covariate windows that differ ONLY in the last row (the covariate that drives
+        // the next step). If x were ignored, the two point forecasts would be identical.
+        var history = new Vector<double>(options.LookbackWindow);
+        var covLow = new Matrix<double>(options.LookbackWindow, 1);
+        var covHigh = new Matrix<double>(options.LookbackWindow, 1);
+        for (var j = 0; j < options.LookbackWindow; j++)
+        {
+            history[j] = y[100 + j];
+            covLow[j, 0] = cov[100 + j, 0];
+            covHigh[j, 0] = cov[100 + j, 0];
+        }
+        covLow[options.LookbackWindow - 1, 0] = -1.0;
+        covHigh[options.LookbackWindow - 1, 0] = 1.0;
+
+        double fLow = model.PredictNextWithCovariates(history, covLow);
+        double fHigh = model.PredictNextWithCovariates(history, covHigh);
+
+        Assert.True(double.IsFinite(fLow) && double.IsFinite(fHigh), "non-finite covariate point forecast");
+        // A covariate that drives the next step must change the forecast, and in the right direction
+        // (higher covariate → higher next value on this series).
+        Assert.True(Math.Abs(fHigh - fLow) > 1e-4, $"covariate had no effect on the forecast ({fLow} vs {fHigh}) — x was ignored");
+        Assert.True(fHigh > fLow, $"forecast did not move with the covariate sign ({fLow} -> {fHigh})");
+    }
+
+    [Fact]
+    [Trait("category", "unit")]
+    public void Covariate_contract_is_validated()
+    {
+        var options = CovOptions();
+        options.CovariateSize = 2; // require 2 covariate columns
+        var model = new DeepARModel<double>(options);
+
+        var y = new Vector<double>(40);
+        var xTooFew = new Matrix<double>(40, 1); // only 1 column — violates the contract
+        Assert.Throws<ArgumentException>(() => model.Train(xTooFew, y));
+    }
+
+    [Fact]
+    [Trait("category", "unit")]
+    public void Univariate_predict_is_rejected_for_a_covariate_model()
+    {
+        var options = CovOptions();
+        var model = new DeepARModel<double>(options);
+        var (x, y, _) = CovariateDrivenSeries(120);
+        model.Train(x, y);
+
+        var window = new Vector<double>(options.LookbackWindow);
+        Assert.Throws<InvalidOperationException>(() => model.PredictSingle(window));
+    }
+}

--- a/tests/AiDotNet.Tests/UnitTests/TimeSeries/DeepARDistributionHeadTests.cs
+++ b/tests/AiDotNet.Tests/UnitTests/TimeSeries/DeepARDistributionHeadTests.cs
@@ -1,0 +1,143 @@
+using System;
+using System.Linq;
+using AiDotNet.Models.Options;
+using AiDotNet.TimeSeries;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tests.UnitTests.TimeSeries;
+
+/// <summary>
+/// Tests for DeepAR's pluggable predictive-distribution heads (Gaussian / Student-t / spline-quantile).
+/// Training is fully deterministic here (fixed seeds + deterministic data + Adam), so the learning and
+/// calibration assertions are stable, not statistical.
+/// </summary>
+public sealed class DeepARDistributionHeadTests
+{
+    private static DeepAROptions<double> Options(string likelihood) => new()
+    {
+        LookbackWindow = 12,
+        ForecastHorizon = 3,
+        HiddenSize = 16,
+        NumLayers = 1,
+        Epochs = 40,
+        BatchSize = 8,
+        NumSamples = 200,
+        LikelihoodType = likelihood,
+        StudentTDegreesOfFreedom = 4.0,
+    };
+
+    // A smooth, learnable series: the model should be able to reduce every head's training loss on it.
+    private static (Matrix<double> x, Vector<double> y) SmoothSeries(int n, int lookback)
+    {
+        var x = new Matrix<double>(n, lookback);
+        var y = new Vector<double>(n);
+        for (var i = 0; i < n; i++)
+        {
+            for (var j = 0; j < lookback; j++)
+                x[i, j] = Math.Sin((i + j) * 0.25) + (i + j) * 0.01;
+            y[i] = Math.Sin((i + lookback) * 0.25) + (i + lookback) * 0.01;
+        }
+
+        return (x, y);
+    }
+
+    [Theory]
+    [InlineData("Gaussian")]
+    [InlineData("StudentT")]
+    [InlineData("Spline")]
+    [Trait("category", "unit")]
+    public void Each_head_reduces_its_training_loss_and_predicts_finite(string likelihood)
+    {
+        var options = Options(likelihood);
+        var model = new DeepARModel<double>(options);
+        var (x, y) = SmoothSeries(140, options.LookbackWindow);
+
+        model.Train(x, y);
+
+        var history = model.TrainingLossHistory;
+        Assert.NotEmpty(history);
+        Assert.All(history, v => Assert.True(!double.IsNaN(v) && !double.IsInfinity(v), $"non-finite loss {v}"));
+        // The head actually learned: its best epoch loss is a real improvement on its first-epoch loss.
+        Assert.True(history.Min() < history[0] - 1e-9,
+            $"{likelihood} head did not reduce loss (first={history[0]}, best={history.Min()})");
+
+        var window = new Vector<double>(options.LookbackWindow);
+        for (var j = 0; j < options.LookbackWindow; j++)
+            window[j] = Math.Sin(j * 0.25) + j * 0.01;
+        var p = model.PredictSingle(window);
+        Assert.True(!double.IsNaN(p) && !double.IsInfinity(p), $"{likelihood} produced non-finite prediction {p}");
+    }
+
+    [Theory]
+    [InlineData("Gaussian")]
+    [InlineData("StudentT")]
+    [InlineData("Spline")]
+    [Trait("category", "unit")]
+    public void Quantile_bands_are_monotone_and_finite(string likelihood)
+    {
+        var options = Options(likelihood);
+        var model = new DeepARModel<double>(options);
+        var (x, y) = SmoothSeries(140, options.LookbackWindow);
+        model.Train(x, y);
+
+        var history = new Vector<double>(options.LookbackWindow);
+        for (var j = 0; j < options.LookbackWindow; j++)
+            history[j] = Math.Sin(j * 0.25) + j * 0.01;
+
+        var bands = model.ForecastWithQuantiles(history, new[] { 0.1, 0.5, 0.9 });
+        for (var h = 0; h < options.ForecastHorizon; h++)
+        {
+            double lo = bands[0.1][h], mid = bands[0.5][h], hi = bands[0.9][h];
+            Assert.True(!double.IsNaN(lo) && !double.IsNaN(mid) && !double.IsNaN(hi), $"{likelihood} NaN band at h={h}");
+            Assert.True(lo <= mid + 1e-9 && mid <= hi + 1e-9, $"{likelihood} non-monotone band [{lo},{mid},{hi}] at h={h}");
+        }
+    }
+
+    [Fact]
+    [Trait("category", "unit")]
+    public void StudentT_tail_is_heavier_than_the_normal_tail()
+    {
+        // The standardized Student-t 95th/99th percentiles must exceed the normal's — that heavier tail is the
+        // whole point of the Student-t head (it stops under-pricing large moves). Deterministic math, no training.
+        double zNormal95 = DeepARDistMath.Probit(0.95);
+        double zNormal99 = DeepARDistMath.Probit(0.99);
+        double t95 = DeepARDistMath.StudentTQuantile(0.95, 4.0);
+        double t99 = DeepARDistMath.StudentTQuantile(0.99, 4.0);
+
+        Assert.True(t95 > zNormal95, $"t95 {t95} should exceed normal {zNormal95}");
+        Assert.True(t99 > zNormal99, $"t99 {t99} should exceed normal {zNormal99}");
+        // Tail excess grows further out and shrinks as ν→∞ (t approaches normal).
+        Assert.True((t99 - zNormal99) > (t95 - zNormal95), "tail excess should grow toward the extreme");
+        double t99HighNu = DeepARDistMath.StudentTQuantile(0.99, 100.0);
+        Assert.True(Math.Abs(t99HighNu - zNormal99) < Math.Abs(t99 - zNormal99), "large ν should approach the normal");
+    }
+
+    [Fact]
+    [Trait("category", "unit")]
+    public void DistMath_loggamma_and_probit_match_known_values()
+    {
+        Assert.Equal(Math.Log(24.0), DeepARDistMath.LogGamma(5.0), 6);      // Γ(5) = 4! = 24
+        Assert.Equal(0.5 * Math.Log(Math.PI), DeepARDistMath.LogGamma(0.5), 6); // Γ(1/2) = √π
+        Assert.Equal(1.959963985, DeepARDistMath.Probit(0.975), 5);        // standard 97.5% z
+        Assert.Equal(0.0, DeepARDistMath.Probit(0.5), 6);                  // median
+    }
+
+    [Fact]
+    [Trait("category", "unit")]
+    public void StudentT_sampler_is_finite_and_symmetric_on_average()
+    {
+        var rng = new Random(7);
+        int n = 20000;
+        double sum = 0;
+        for (var i = 0; i < n; i++)
+        {
+            double s = DeepARDistMath.SampleStudentT(4.0, rng);
+            Assert.True(!double.IsNaN(s) && !double.IsInfinity(s), $"non-finite t sample {s}");
+            sum += s;
+        }
+
+        // Mean of a symmetric t is 0; a large sample should sit near it.
+        Assert.True(Math.Abs(sum / n) < 0.1, $"t sample mean {sum / n} not near zero");
+    }
+}


### PR DESCRIPTION
## What

Turns DeepAR from a fixed-Gaussian, covariate-blind forecaster into one with a **pluggable predictive-distribution head** *and* genuine **covariate conditioning** — both selected through options that already existed but were inert (`LikelihoodType`, `CovariateSize`). This gives downstream consumers calibrated, skew-aware probabilistic forecasts that can condition on external drivers.

## 1. Pluggable distribution head (`LikelihoodType`)

`DeepARDistributionHead<T>` owns the residual-mean skip, the likelihood loss, and predictive sampling, so DeepAR trades calibration against tail-weight/skew without touching the LSTM recurrence.

| `LikelihoodType` | Distribution | Loss | Why it matters |
|---|---|---|---|
| `Gaussian` (default) | Normal(μ, σ) | split MSE + Gaussian NLL | historical head, preserved **bit-for-bit** |
| `StudentT` | Student-t(μ, σ, ν) | Student-t NLL, fixed ν (`StudentTDegreesOfFreedom`, default 4) | heavy tails — stops under-pricing large moves (returns are fat-tailed) |
| `Spline` | monotone piecewise-linear quantile function | pinball loss (proper scoring rule ≈ CRPS) | models **asymmetric** distributions; closed-form quantile function for skew-aware sizing |

`ForecastWithQuantiles` now samples from the selected head, so bands reflect the fitted tails/skew instead of a forced Gaussian shape.

## 2. Covariate consumption (`CovariateSize`) — resolves "DeepAR ignores x"

Previously DeepAR trained on `y` and silently ignored the feature matrix. Now, when `CovariateSize > 0`: `x` must supply one aligned covariate row per series index (validated), the standardized covariates are concatenated to the series value at each step (first LSTM layer input = `1 + CovariateSize`), and inference goes through covariate-aware paths (`ForecastWithCovariates`, `PredictNextWithCovariates`). The univariate predict path throws a directive error for a covariate-trained model rather than fabricating covariates. `CovariateSize == 0` (default) is byte-identical to before.

## Tests

13 new deterministic tests + full DeepAR suite green (**71/71**):
- every head reduces its training loss + predicts finite; quantile bands monotone/finite;
- Student-t tail provably heavier than normal, approaches normal as ν→∞; log-Γ/probit/t-sampler correctness;
- covariate model trains + forecasts finite/monotone; the covariate **provably moves the forecast** in the right direction (proof `x` is consumed); contract validated; univariate predict rejected for a covariate model.

Serialization round-trips the head selector, ν, `CovariateSize`, and covariate stats.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
