### PR TITLE
feat(optimizer): divergence guard + ReduceLROnPlateau coordinated with early stopping

### DIFF
--- a/src/Models/Options/OptimizationAlgorithmOptions.cs
+++ b/src/Models/Options/OptimizationAlgorithmOptions.cs
@@ -159,6 +159,26 @@ public class OptimizationAlgorithmOptions<T, TInput, TOutput> : ModelOptions
     public double MaxLearningRate { get; set; } = 1.0;
 
     /// <summary>
+    /// Gets or sets how many times the learning rate is REDUCED on a validation/fitness plateau before early
+    /// stopping actually fires (ReduceLROnPlateau coordinated with early stopping — "reduce first, stop only
+    /// once reduction stops helping").
+    /// </summary>
+    /// <value>The maximum plateau reductions, defaulting to 0 (stop immediately on plateau — historical behavior).</value>
+    /// <remarks>
+    /// <para><b>For Beginners:</b> When training stops improving, instead of quitting right away this first
+    /// takes smaller steps (a lower learning rate) to see if it can squeeze out a better result, and only quits
+    /// once even the smaller steps stop helping. Each reduction gives training a fresh patience window.</para>
+    /// </remarks>
+    public int MaxLearningRateReductionsOnPlateau { get; set; } = 0;
+
+    /// <summary>
+    /// Gets or sets the factor the learning rate is multiplied by at each plateau reduction (floored at
+    /// <see cref="MinLearningRate"/>). Only used when <see cref="MaxLearningRateReductionsOnPlateau"/> &gt; 0.
+    /// </summary>
+    /// <value>The plateau reduction factor, defaulting to 0.5 (halve the learning rate).</value>
+    public double PlateauLearningRateReductionFactor { get; set; } = 0.5;
+
+    /// <summary>
     /// Gets or sets whether to automatically adjust the momentum during training.
     /// </summary>
     /// <value>True to use adaptive momentum (default), false otherwise.</value>

--- a/src/Optimizers/OptimizerBase.cs
+++ b/src/Optimizers/OptimizerBase.cs
@@ -116,6 +116,14 @@ public abstract class OptimizerBase<T, TInput, TOutput> : IOptimizer<T, TInput, 
     /// </summary>
     protected T CurrentLearningRate;
 
+    // ReduceLROnPlateau-coordinated-with-stopping state (opt-in via Options.MaxLearningRateReductionsOnPlateau).
+    // _plateauReductionsUsed counts how many times the LR has been halved on a plateau this run;
+    // _earlyStopHistoryFloor is the iteration-history index from which ShouldEarlyStop measures its window, so a
+    // reduction clears the plateau window and grants the lowered LR a fresh patience budget. Floor 0 (the
+    // default when the feature is off) makes ShouldEarlyStop byte-for-byte the historical behavior.
+    private int _plateauReductionsUsed;
+    private int _earlyStopHistoryFloor;
+
     /// <summary>
     /// The current momentum used in the optimization process.
     /// </summary>
@@ -1593,6 +1601,8 @@ public abstract class OptimizerBase<T, TInput, TOutput> : IOptimizer<T, TInput, 
         CurrentMomentum = NumOps.FromDouble(Options.InitialMomentum);
         IterationsWithoutImprovement = 0;
         IterationsWithImprovement = 0;
+        _plateauReductionsUsed = 0;
+        _earlyStopHistoryFloor = 0;
     }
 
     /// <summary>
@@ -1779,9 +1789,28 @@ public abstract class OptimizerBase<T, TInput, TOutput> : IOptimizer<T, TInput, 
             return true; // stop before NaNs corrupt the model
         }
 
-        // Check for early stopping
+        // Check for early stopping — coordinated with ReduceLROnPlateau when enabled.
         if (Options.UseEarlyStopping && ShouldEarlyStop())
         {
+            // Reduce-first, stop-only-once-reduction-stops-helping: on a plateau, HALVE the learning rate up to
+            // MaxLearningRateReductionsOnPlateau times before actually stopping, each reduction clearing the
+            // plateau window so the lowered LR gets a fresh patience budget. Only stop once reductions are
+            // exhausted (or the LR is already at the floor). Default (0 reductions) stops immediately, exactly
+            // as before. The returned model is still the global best (UpdateBestSolution is unaffected), so a
+            // reduction can only help — it trades a few more epochs at a finer LR for a possibly-better optimum.
+            if (Options.MaxLearningRateReductionsOnPlateau > 0
+                && _plateauReductionsUsed < Options.MaxLearningRateReductionsOnPlateau
+                && Convert.ToDouble(CurrentLearningRate) > Options.MinLearningRate)
+            {
+                _plateauReductionsUsed++;
+                double reduced = Math.Max(
+                    Options.MinLearningRate,
+                    Convert.ToDouble(CurrentLearningRate) * Options.PlateauLearningRateReductionFactor);
+                CurrentLearningRate = NumOps.FromDouble(reduced);
+                _earlyStopHistoryFloor = IterationHistoryList.Count; // fresh window for the reduced LR
+                return false; // keep training at the lower learning rate
+            }
+
             return true; // Signal to stop the optimization
         }
 
@@ -1839,16 +1868,21 @@ public abstract class OptimizerBase<T, TInput, TOutput> : IOptimizer<T, TInput, 
     /// </remarks>
     public virtual bool ShouldEarlyStop()
     {
-        if (IterationHistoryList.Count < Options.EarlyStoppingPatience)
+        // Measure the plateau over the CURRENT window only. Without ReduceLROnPlateau the floor is 0, so this is
+        // the whole history (byte-for-byte the historical behavior); after a plateau LR reduction the floor
+        // advances so the lowered LR is judged on its own fresh window, not against the pre-reduction best.
+        int floor = Math.Min(_earlyStopHistoryFloor, IterationHistoryList.Count);
+        var window = IterationHistoryList.Skip(floor).ToList();
+        if (window.Count < Options.EarlyStoppingPatience)
         {
             return false;
         }
 
-        var recentIterations = IterationHistoryList.Skip(Math.Max(0, IterationHistoryList.Count - Options.EarlyStoppingPatience)).ToList();
+        var recentIterations = window.Skip(Math.Max(0, window.Count - Options.EarlyStoppingPatience)).ToList();
 
-        // Find the best fitness score
-        T bestFitness = IterationHistoryList[0].Fitness;
-        foreach (var iteration in IterationHistoryList)
+        // Find the best fitness score (within the current window)
+        T bestFitness = window[0].Fitness;
+        foreach (var iteration in window)
         {
             if (FitnessCalculator.IsBetterFitness(iteration.Fitness, bestFitness))
             {

--- a/src/Optimizers/OptimizerBase.cs
+++ b/src/Optimizers/OptimizerBase.cs
@@ -1747,29 +1747,36 @@ public abstract class OptimizerBase<T, TInput, TOutput> : IOptimizer<T, TInput, 
             FitDetectionResult = stepData.FitDetectionResult
         });
 
-        // Notify the per-epoch progress observer (if any). Report the CURRENT iteration's
-        // fitness (stashed by UpdateBestSolution) so observers see live loss — including a
-        // diverging or NaN loss — rather than the monotonic best-so-far value passed here.
-        // A false return means an observer (e.g. a user training callback or health monitor)
-        // requested an abort, which we honor by signalling the optimizer to stop.
+        // The CURRENT iteration's live fitness (stashed by UpdateBestSolution) — including a diverging or NaN
+        // loss — rather than the monotonic best-so-far in stepData. Captured BEFORE the observer block consumes
+        // the stash so both the observer and the divergence guard below see the same live value. When an
+        // optimizer evaluates multiple candidates per iteration this is the LAST candidate stashed this
+        // iteration (falling back to the monotonic best when nothing was stashed).
+        T liveFitness = (_hasObservedFitness && _lastObservedFitness is { } observed) ? observed : stepData.FitnessScore;
+
+        // Notify the per-epoch progress observer (if any). A false return means an observer (e.g. a user
+        // training callback or health monitor) requested an abort, which we honor by signalling a stop.
         if (_epochProgressCallback is not null)
         {
-            T reported = stepData.FitnessScore;
-            if (_hasObservedFitness && _lastObservedFitness is { } observed)
-            {
-                reported = observed;
-            }
-            // Consume the stash so each iteration reports a value stashed DURING that iteration: without this
-            // reset, an iteration that never calls UpdateBestSolution would re-report the previous iteration's
-            // stale fitness. When an optimizer evaluates multiple candidates per iteration, `reported` is the
-            // LAST candidate stashed this iteration (falling back to the monotonic best `stepData.FitnessScore`
-            // when nothing was stashed) — the seam targets per-epoch gradient optimizers that call
-            // UpdateBestSolution exactly once per epoch (see SetEpochProgressCallback).
+            // Consume the stash so each iteration reports a value stashed DURING that iteration (see
+            // SetEpochProgressCallback): without this reset an iteration that never calls UpdateBestSolution
+            // would re-report the previous iteration's stale fitness.
             _hasObservedFitness = false;
-            if (!_epochProgressCallback(iteration, reported))
+            if (!_epochProgressCallback(iteration, liveFitness))
             {
                 return true; // Observer requested an early stop
             }
+        }
+
+        // Divergence guard — ALWAYS on, independent of any configured observer. A non-finite live fitness means
+        // the optimization has blown up (NaN/Inf gradients/loss); stop now so the run returns the best FINITE
+        // solution tracked so far (a NaN never wins UpdateBestSolution) instead of iterating on NaNs. This fires
+        // even on the facade's bare no-observer path, where nothing else would catch divergence — a safety floor
+        // under every model trained through the optimizer. Most optimizers keep iterating on NaN.
+        double liveFitnessMagnitude = Convert.ToDouble(liveFitness);
+        if (double.IsNaN(liveFitnessMagnitude) || double.IsInfinity(liveFitnessMagnitude))
+        {
+            return true; // stop before NaNs corrupt the model
         }
 
         // Check for early stopping

--- a/tests/AiDotNet.Tests/IntegrationTests/TrainingCallbacks/FacadeTrainingCallbackTests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/TrainingCallbacks/FacadeTrainingCallbackTests.cs
@@ -204,6 +204,32 @@ public class FacadeTrainingCallbackTests
         Assert.NotNull(result.StopReason);
     }
 
+    [Fact(Timeout = 120000)]
+    public async Task DivergenceGuard_StopsOptimizer_EvenWhenNoObserverVetoes()
+    {
+        await Task.Yield();
+        const int epochs = 30;
+        var (x, y) = BuildData();
+        // Inject a NaN target so the fitness is non-finite from the first epoch. The callback below only COUNTS
+        // epochs and never asks to stop, so the ONLY thing that can cut training short is the optimizer's
+        // always-on divergence guard. Without it, all 30 epochs run (propagating NaNs).
+        y[0, 0] = float.NaN;
+        var optimizer = BuildOptimizer(epochs, 5.0);
+        var model = BuildModel(optimizer);
+
+        int epochCount = 0;
+        var result = await new AiModelBuilder<float, Tensor<float>, Tensor<float>>()
+            .ConfigureModel(model)
+            .ConfigureOptimizer(optimizer)
+            .ConfigureDataLoader(new InMemoryDataLoader<float, Tensor<float>, Tensor<float>>(x, y))
+            .ConfigureTrainingCallback(_ => { epochCount++; return true; }) // never vetoes — only counts
+            .BuildAsync();
+
+        Assert.NotNull(result);
+        Assert.True(epochCount < epochs,
+            $"divergence guard did not stop the optimizer on non-finite fitness (ran {epochCount}/{epochs} epochs)");
+    }
+
     // --- Learnable probe task: "most-frequent token in the window" ---------------------------
     // Order-invariant and generalizing: a strict-majority token m is planted in each window and
     // the label is m. A correct SequenceClassification transformer learns this FAR above chance

--- a/tests/AiDotNet.Tests/IntegrationTests/TrainingCallbacks/FacadeTrainingCallbackTests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/TrainingCallbacks/FacadeTrainingCallbackTests.cs
@@ -230,6 +230,62 @@ public class FacadeTrainingCallbackTests
             $"divergence guard did not stop the optimizer on non-finite fitness (ran {epochCount}/{epochs} epochs)");
     }
 
+    private static AdamOptimizer<float, Tensor<float>, Tensor<float>> BuildEarlyStopOptimizer(
+        int maxIterations, double learningRate, int patience, int plateauReductions)
+    {
+        var options = new AdamOptimizerOptions<float, Tensor<float>, Tensor<float>>
+        {
+            InitialLearningRate = learningRate,
+            MaxIterations = maxIterations,
+            UseAdaptiveLearningRate = false,
+            UseEarlyStopping = true,
+            EarlyStoppingPatience = patience,
+            Tolerance = 0.0,
+            MaxLearningRateReductionsOnPlateau = plateauReductions,
+            PlateauLearningRateReductionFactor = 0.5,
+            FitnessCalculator = new MeanSquaredErrorFitnessCalculator<float, Tensor<float>, Tensor<float>>()
+        };
+        return new AdamOptimizer<float, Tensor<float>, Tensor<float>>(null, options);
+    }
+
+    [Fact(Timeout = 120000)]
+    public async Task ReduceLROnPlateau_defers_early_stop_and_trains_longer()
+    {
+        await Task.Yield();
+        const int maxEpochs = 80;
+        const int patience = 3;
+
+        // Unlearnable (noise) target → the model plateaus fast at the variance floor, so early stopping fires
+        // well before maxEpochs. With plateau LR reductions enabled, each reduction grants a fresh patience
+        // window, so training must run STRICTLY MORE epochs before it finally gives up.
+        var (x, y) = BuildData();
+        var noise = new System.Random(99);
+        for (int i = 0; i < N; i++) y[i, 0] = (float)(noise.NextDouble() * 2 - 1);
+
+        int epochsBaseline = 0;
+        var opt0 = BuildEarlyStopOptimizer(maxEpochs, 0.01, patience, plateauReductions: 0);
+        await new AiModelBuilder<float, Tensor<float>, Tensor<float>>()
+            .ConfigureModel(BuildModel(opt0))
+            .ConfigureOptimizer(opt0)
+            .ConfigureDataLoader(new InMemoryDataLoader<float, Tensor<float>, Tensor<float>>(x, y))
+            .ConfigureTrainingCallback(_ => { epochsBaseline++; return true; })
+            .BuildAsync();
+
+        int epochsWithReductions = 0;
+        var opt3 = BuildEarlyStopOptimizer(maxEpochs, 0.01, patience, plateauReductions: 3);
+        await new AiModelBuilder<float, Tensor<float>, Tensor<float>>()
+            .ConfigureModel(BuildModel(opt3))
+            .ConfigureOptimizer(opt3)
+            .ConfigureDataLoader(new InMemoryDataLoader<float, Tensor<float>, Tensor<float>>(x, y))
+            .ConfigureTrainingCallback(_ => { epochsWithReductions++; return true; })
+            .BuildAsync();
+
+        Assert.True(epochsBaseline < maxEpochs,
+            $"baseline should early-stop on the plateau, not run all {maxEpochs} (ran {epochsBaseline})");
+        Assert.True(epochsWithReductions > epochsBaseline,
+            $"ReduceLROnPlateau should train longer before stopping ({epochsWithReductions} vs baseline {epochsBaseline})");
+    }
+
     // --- Learnable probe task: "most-frequent token in the window" ---------------------------
     // Order-invariant and generalizing: a strict-majority token m is planted in each window and
     // the label is m. A correct SequenceClassification transformer learns this FAR above chance


### PR DESCRIPTION
## What

Two coordinated hardening changes to every gradient optimizer's per-epoch check, so the facade's training defaults exceed the mainstream ecosystem:

### 1. Always-on divergence guard
Training stops the moment the **live** fitness goes non-finite (NaN/Inf), returning the best *finite* solution instead of iterating on NaNs. `UseEarlyStopping` only fires on a *plateau*, and the facade's default path takes a bare `Optimize()` with **no** observer, so nothing caught divergence there. The guard lives at the source (`UpdateIterationHistoryAndCheckEarlyStopping`), protecting both the observer and the bare path. Mainstream optimizers keep iterating on NaN.

### 2. ReduceLROnPlateau coordinated with early stopping (reduce-then-stop)
On a plateau, the optimizer now **halves the learning rate** up to `MaxLearningRateReductionsOnPlateau` times before actually stopping — "reduce first, stop only once reduction stops helping". Each reduction advances a `ShouldEarlyStop` window floor so the lowered LR gets a fresh patience budget. The returned model is still the global best, so a reduction can only help.

**Default `MaxLearningRateReductionsOnPlateau = 0`** → stop immediately on plateau, window floor stays 0 → `ShouldEarlyStop` is **byte-for-byte** the historical behavior. Opt-in via the new option (+ `PlateauLearningRateReductionFactor`, default 0.5).

## Tests
- Divergence: a NaN-injected run whose callback never vetoes is still cut short by the guard.
- ReduceLROnPlateau: a plateauing (noise-target) run early-stops before max epochs at 0 reductions and trains **strictly longer** with 3 reductions — bypass-sensitive.
- Callback + divergence suites 11/11; early-stopping / convergence / contract-parity 92/92.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
