### PR TITLE
ci: skip serving deploy gracefully when publish profile is unset

### DIFF
--- a/.github/workflows/deploy-serving.yml
+++ b/.github/workflows/deploy-serving.yml
@@ -17,6 +17,12 @@ jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
 
+    # Presence of the Azure publish profile decides whether we actually deploy. When the secret is
+    # not configured, the job still builds/publishes (so a broken serving build is caught) but skips
+    # the Azure deploy with a warning instead of hard-failing every master push.
+    env:
+      HAS_PUBLISH_PROFILE: ${{ secrets.AZURE_WEBAPP_PUBLISH_PROFILE != '' }}
+
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
@@ -40,8 +46,14 @@ jobs:
           rm -rf cs de es fr it ja ko pl pt-BR ru tr zh-Hans zh-Hant
 
       - name: Deploy to Azure App Service
+        if: env.HAS_PUBLISH_PROFILE == 'true'
         uses: azure/webapps-deploy@02a81bead70021f5284939794bcec79c271ab383 # v3
         with:
           app-name: aidotnet-api
           publish-profile: ${{ secrets.AZURE_WEBAPP_PUBLISH_PROFILE }}
           package: ./publish
+
+      - name: Skip deploy (publish profile not configured)
+        if: env.HAS_PUBLISH_PROFILE != 'true'
+        run: |
+          echo "::warning title=Serving deploy skipped::AZURE_WEBAPP_PUBLISH_PROFILE is not set, so the Azure App Service deploy was skipped (build/publish still validated). Configure the secret to enable deployment."


### PR DESCRIPTION
## Problem
`Deploy AiDotNet Serving API` (deploy-serving.yml) has hard-failed on **every** master push for months (07-18, 06-22, 06-17, … 04-04) with:

> Deployment Failed, Error: Publish profile is invalid for app-name and slot-name provided.

The `AZURE_WEBAPP_PUBLISH_PROFILE` secret is not configured (or empty), and `azure/webapps-deploy` fails on an empty/invalid profile — turning every qualifying push red.

## Change
Gate the Azure deploy on the secret being present (`env.HAS_PUBLISH_PROFILE`):
- The job still **builds + publishes** the serving project (so a broken serving build is still caught).
- When the secret is **unset/empty**, the deploy step is skipped and the job prints a `::warning::` instead of failing.
- When the secret **is** configured, the deploy runs exactly as before — and a genuinely bad credential still fails loudly (not masked).

## Follow-up (repo owner)
To actually deploy, set the `AZURE_WEBAPP_PUBLISH_PROFILE` repository secret to a current publish profile for the `aidotnet-api` App Service (see PR discussion / instructions).

Generated with Claude Code