### PR TITLE
feat(finance-rl): greenfield portfolio-manager RL core — env + risk-adjusted rewards + honest-eval harness

### DIFF
--- a/src/AiModelBuilder.BuildPipeline.cs
+++ b/src/AiModelBuilder.BuildPipeline.cs
@@ -277,6 +277,82 @@ public partial class AiModelBuilder<T, TInput, TOutput>
     }
 
     /// <summary>
+    /// Auto-evaluates a financial or time-series forecasting model with financial-performance metrics — the
+    /// money-side analogue of <see cref="ComputeClusterEvaluation"/>. Runs whenever the trained model is a
+    /// financial/forecasting family (<see cref="Finance.Interfaces.IFinancialModel{T}"/> or
+    /// <see cref="Interfaces.ITimeSeriesModel{T}"/>), scoring its held-out predictions as a trading signal and mirroring
+    /// the metric values into <see cref="AiModelResult{T,TInput,TOutput}.ConfiguredMetrics"/>.
+    /// </summary>
+    /// <remarks>
+    /// The model's level forecasts are differenced against the previous realized value to per-step changes
+    /// (<c>predictedChange[i] = predicted[i] - actual[i-1]</c>, <c>realizedChange[i] = actual[i] - actual[i-1]</c>),
+    /// so the strategy goes long when the model forecasts a rise above the last realized value. Computed on the
+    /// held-out test partition, so this is an out-of-sample measure. Any metric added via
+    /// <c>ConfigureFinancialMetric</c> extends the default set. Failures are swallowed with a trace warning —
+    /// the trained model is unaffected and <see cref="AiModelResult{T,TInput,TOutput}.FinancialEvaluation"/>
+    /// is left null.
+    /// </remarks>
+    private void ComputeFinancialEvaluation(
+        AiModelResult<T, TInput, TOutput> result,
+        OptimizationResult<T, TInput, TOutput>.DatasetResult testResult)
+    {
+        if (_model is not (Finance.Interfaces.IFinancialModel<T> or Interfaces.ITimeSeriesModel<T>))
+        {
+            return;
+        }
+
+        try
+        {
+            var predicted = ConversionsHelper.ConvertToVector<T, TOutput>(testResult.Predictions);
+            var actual = ConversionsHelper.ConvertToVector<T, TOutput>(testResult.Y);
+
+            int n = Math.Min(predicted.Length, actual.Length);
+            if (n < 3)
+            {
+                // Need at least two return steps (differencing drops one) for the metrics to be defined.
+                return;
+            }
+
+            // Difference the level forecasts to per-step CHANGES: at step i the model forecasts predicted[i]
+            // against the last realized value actual[i-1], and the realized change is actual[i]-actual[i-1].
+            // sign(predictedChange) is then the long/short signal the financial metrics score.
+            var predictedChange = new double[n - 1];
+            var realizedChange = new double[n - 1];
+            for (int i = 1; i < n; i++)
+            {
+                double prevActual = Convert.ToDouble(actual[i - 1]);
+                predictedChange[i - 1] = Convert.ToDouble(predicted[i]) - prevActual;
+                realizedChange[i - 1] = Convert.ToDouble(actual[i]) - prevActual;
+            }
+
+            var evaluator = new Finance.Evaluation.FinancialEvaluator<T>();
+            if (_configuredFinancialMetric is not null)
+            {
+                evaluator.AddMetric(_configuredFinancialMetric);
+            }
+
+            var evaluation = evaluator.Evaluate(predictedChange, realizedChange);
+
+            var numOps = MathHelper.GetNumericOperations<T>();
+            foreach (var kv in evaluation.Metrics)
+            {
+                if (!double.IsNaN(kv.Value) && !double.IsInfinity(kv.Value))
+                {
+                    result.SetConfiguredMetric(kv.Key, numOps.FromDouble(kv.Value));
+                }
+            }
+
+            result.SetFinancialEvaluation(evaluation);
+        }
+        catch (Exception ex)
+        {
+            System.Diagnostics.Trace.TraceWarning(
+                $"Financial evaluation could not be computed: {ex.Message}. The trained model is " +
+                "unaffected; AiModelResult.FinancialEvaluation is null.");
+        }
+    }
+
+    /// <summary>
     /// Calibrates the configured drift detector on the training residuals, checks it against the test
     /// residuals, and attaches the attributed <see cref="DriftDetection.DriftReport"/> plus the live
     /// <see cref="DriftDetection.DriftMonitor{T}"/> to the result.
@@ -5430,6 +5506,7 @@ public partial class AiModelBuilder<T, TInput, TOutput>
         RunConfiguredCrossValidation(finalResult, preparedX, preparedY, optimizer);
         ComputeConfiguredMetrics(finalResult, optimizationResult.TestResult);
         ComputeClusterEvaluation(finalResult, preparedX, preparedY);
+        ComputeFinancialEvaluation(finalResult, optimizationResult.TestResult);
         ComputeDriftMonitoring(finalResult, optimizationResult);
         ComputeActiveLearningSelection(finalResult, optimizationResult);
         ComputeQueryStrategySelection(finalResult);

--- a/src/AiModelBuilder.BuildPipeline.cs
+++ b/src/AiModelBuilder.BuildPipeline.cs
@@ -287,7 +287,8 @@ public partial class AiModelBuilder<T, TInput, TOutput>
     /// The model's level forecasts are differenced against the previous realized value to per-step changes
     /// (<c>predictedChange[i] = predicted[i] - actual[i-1]</c>, <c>realizedChange[i] = actual[i] - actual[i-1]</c>),
     /// so the strategy goes long when the model forecasts a rise above the last realized value. Computed on the
-    /// held-out test partition, so this is an out-of-sample measure. Any metric added via
+    /// held-out test partition when one is available, otherwise on the training partition the direct-training path
+    /// falls back to — so it is out-of-sample only when a held-out split exists. Any metric added via
     /// <c>ConfigureFinancialMetric</c> extends the default set. Failures are swallowed with a trace warning —
     /// the trained model is unaffected and <see cref="AiModelResult{T,TInput,TOutput}.FinancialEvaluation"/>
     /// is left null.

--- a/src/AiModelBuilder.Coverage.cs
+++ b/src/AiModelBuilder.Coverage.cs
@@ -28,6 +28,7 @@ public partial class AiModelBuilder<T, TInput, TOutput>
     private ITextVectorizer<T>? _configuredTextVectorizer;
     private IClusterMetric<T>? _configuredClusterMetric;
     private IExternalClusterMetric<T>? _configuredExternalClusterMetric;
+    private Finance.Evaluation.IFinancialMetric<T>? _configuredFinancialMetric;
     private ICurriculumScheduler<T>? _configuredCurriculumScheduler;
     private ReinforcementLearning.Policies.Exploration.IExplorationStrategy<T>? _configuredExplorationStrategy;
     private ReinforcementLearning.IntrinsicMotivation.IIntrinsicRewardModule<T>? _configuredIntrinsicRewardModule;
@@ -137,6 +138,26 @@ public partial class AiModelBuilder<T, TInput, TOutput>
     public IAiModelBuilder<T, TInput, TOutput> ConfigureClusterMetric(IClusterMetric<T> metric)
     {
         _configuredClusterMetric = metric;
+        return this;
+    }
+
+    /// <summary>
+    /// Configures an extra financial metric to score a forecasting/financial model on, on top of the default
+    /// set (directional accuracy, strategy Sharpe/Sortino, max drawdown, profit factor, information coefficient).
+    /// </summary>
+    /// <param name="metric">The financial metric implementation to add.</param>
+    /// <returns>The builder instance for method chaining.</returns>
+    /// <remarks>
+    /// <para><b>For Beginners:</b> Financial metrics judge a forecaster on <i>money</i> rather than error:
+    /// they treat the model's prediction as a trading signal (go long when it forecasts a rise) and measure
+    /// how that would have performed on the held-out data. The default set runs automatically for any
+    /// financial or time-series forecasting model — you do not need to configure anything. This is the
+    /// optional extension knob (the money-side analogue of <see cref="ConfigureClusterMetric"/>): it adds one
+    /// more metric on top of the default set and does not replace it.</para>
+    /// </remarks>
+    public IAiModelBuilder<T, TInput, TOutput> ConfigureFinancialMetric(Finance.Evaluation.IFinancialMetric<T> metric)
+    {
+        _configuredFinancialMetric = metric;
         return this;
     }
 

--- a/src/Finance/Evaluation/FinancialMetrics.cs
+++ b/src/Finance/Evaluation/FinancialMetrics.cs
@@ -199,14 +199,14 @@ public sealed class FinancialEvaluator<T>
     /// <summary>Adds a metric to the default set (does not replace it).</summary>
     public void AddMetric(IFinancialMetric<T> metric)
     {
-        ArgumentNullException.ThrowIfNull(metric);
+        if (metric is null) throw new ArgumentNullException(nameof(metric));
         _metrics.Add(metric);
     }
 
     public FinancialEvaluationResult Evaluate(IReadOnlyList<double> predicted, IReadOnlyList<double> actual)
     {
-        ArgumentNullException.ThrowIfNull(predicted);
-        ArgumentNullException.ThrowIfNull(actual);
+        if (predicted is null) throw new ArgumentNullException(nameof(predicted));
+        if (actual is null) throw new ArgumentNullException(nameof(actual));
 
         var results = new Dictionary<string, double>(StringComparer.Ordinal);
         foreach (var m in _metrics)

--- a/src/Finance/Evaluation/FinancialMetrics.cs
+++ b/src/Finance/Evaluation/FinancialMetrics.cs
@@ -1,0 +1,222 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace AiDotNet.Finance.Evaluation;
+
+/// <summary>
+/// A financial-performance metric for a FORECASTING/financial model — the analogue of a cluster-validity index
+/// for a clustering model. It scores how a model's predictions would have performed as a trading signal
+/// (sign(prediction) taken against the realized return), so a forecaster is judged on money, not just error.
+/// </summary>
+/// <typeparam name="T">The model's numeric type (metrics compute in double internally).</typeparam>
+public interface IFinancialMetric<T>
+{
+    /// <summary>Metric name (e.g. "StrategySharpe", "DirectionalAccuracy").</summary>
+    string Name { get; }
+
+    /// <summary>Higher is better for ranking (drawdown metrics negate so "higher is better" holds uniformly).</summary>
+    bool HigherIsBetter { get; }
+
+    /// <summary>Computes the metric from aligned predicted and realized (actual) return series.</summary>
+    double Compute(IReadOnlyList<double> predicted, IReadOnlyList<double> actual);
+}
+
+/// <summary>The financial evaluation of a model: a name→value map of the metrics that were run.</summary>
+public sealed class FinancialEvaluationResult
+{
+    public IReadOnlyDictionary<string, double> Metrics { get; }
+
+    public FinancialEvaluationResult(IReadOnlyDictionary<string, double> metrics) => Metrics = metrics;
+
+    public double this[string name] => Metrics.TryGetValue(name, out var v) ? v : double.NaN;
+}
+
+/// <summary>Shared math over a signal-following strategy: strategy return series = sign(prediction)·actual.</summary>
+internal static class FinancialMath
+{
+    public const double PeriodsPerYear = 252.0;
+
+    /// <summary>Strategy per-step returns: go long when the forecast is positive, short when negative.</summary>
+    public static double[] StrategyReturns(IReadOnlyList<double> predicted, IReadOnlyList<double> actual)
+    {
+        int n = Math.Min(predicted.Count, actual.Count);
+        var r = new double[n];
+        for (int i = 0; i < n; i++)
+        {
+            double sign = predicted[i] > 0 ? 1.0 : predicted[i] < 0 ? -1.0 : 0.0;
+            r[i] = sign * actual[i];
+        }
+
+        return r;
+    }
+
+    public static (double mean, double std, double downsideStd) Moments(double[] r)
+    {
+        if (r.Length == 0) return (0, 0, 0);
+        double s = 0, s2 = 0, d2 = 0;
+        foreach (var x in r)
+        {
+            s += x;
+            s2 += x * x;
+            if (x < 0) d2 += x * x;
+        }
+        double mean = s / r.Length;
+        double std = Math.Sqrt(Math.Max(0, s2 / r.Length - mean * mean));
+        double downsideStd = Math.Sqrt(d2 / r.Length);
+        return (mean, std, downsideStd);
+    }
+
+    /// <summary>Max drawdown of the compounded strategy equity curve, in [0, 1].</summary>
+    public static double MaxDrawdown(double[] r)
+    {
+        double equity = 1.0, peak = 1.0, maxDd = 0.0;
+        foreach (var x in r)
+        {
+            equity *= 1.0 + x;
+            if (equity > peak) peak = equity;
+            if (peak > 0) maxDd = Math.Max(maxDd, (peak - equity) / peak);
+        }
+        return maxDd;
+    }
+}
+
+/// <summary>Fraction of steps where the forecast got the DIRECTION right (sign match) — the hit rate.</summary>
+public sealed class DirectionalAccuracyMetric<T> : IFinancialMetric<T>
+{
+    public string Name => "DirectionalAccuracy";
+    public bool HigherIsBetter => true;
+
+    public double Compute(IReadOnlyList<double> predicted, IReadOnlyList<double> actual)
+    {
+        int n = Math.Min(predicted.Count, actual.Count), correct = 0, counted = 0;
+        for (int i = 0; i < n; i++)
+        {
+            if (actual[i] == 0) continue;
+            counted++;
+            if (Math.Sign(predicted[i]) == Math.Sign(actual[i])) correct++;
+        }
+        return counted > 0 ? (double)correct / counted : 0.0;
+    }
+}
+
+/// <summary>Annualized Sharpe ratio of the signal-following strategy.</summary>
+public sealed class StrategySharpeMetric<T> : IFinancialMetric<T>
+{
+    public string Name => "StrategySharpe";
+    public bool HigherIsBetter => true;
+
+    public double Compute(IReadOnlyList<double> predicted, IReadOnlyList<double> actual)
+    {
+        var (mean, std, _) = FinancialMath.Moments(FinancialMath.StrategyReturns(predicted, actual));
+        return std > 1e-12 ? mean / std * Math.Sqrt(FinancialMath.PeriodsPerYear) : 0.0;
+    }
+}
+
+/// <summary>Annualized Sortino ratio (downside-only volatility) of the signal-following strategy.</summary>
+public sealed class StrategySortinoMetric<T> : IFinancialMetric<T>
+{
+    public string Name => "StrategySortino";
+    public bool HigherIsBetter => true;
+
+    public double Compute(IReadOnlyList<double> predicted, IReadOnlyList<double> actual)
+    {
+        var (mean, _, downside) = FinancialMath.Moments(FinancialMath.StrategyReturns(predicted, actual));
+        return downside > 1e-12 ? mean / downside * Math.Sqrt(FinancialMath.PeriodsPerYear) : 0.0;
+    }
+}
+
+/// <summary>Max drawdown of the strategy equity curve (NEGATED so higher is better for uniform ranking).</summary>
+public sealed class MaxDrawdownMetric<T> : IFinancialMetric<T>
+{
+    public string Name => "StrategyMaxDrawdown";
+    public bool HigherIsBetter => true; // reports -drawdown
+
+    public double Compute(IReadOnlyList<double> predicted, IReadOnlyList<double> actual)
+        => -FinancialMath.MaxDrawdown(FinancialMath.StrategyReturns(predicted, actual));
+}
+
+/// <summary>Profit factor: gross profit / gross loss of the signal-following strategy.</summary>
+public sealed class ProfitFactorMetric<T> : IFinancialMetric<T>
+{
+    public string Name => "ProfitFactor";
+    public bool HigherIsBetter => true;
+
+    public double Compute(IReadOnlyList<double> predicted, IReadOnlyList<double> actual)
+    {
+        double up = 0, down = 0;
+        foreach (var x in FinancialMath.StrategyReturns(predicted, actual))
+        {
+            if (x > 0) up += x;
+            else down -= x;
+        }
+        return down > 1e-12 ? up / down : (up > 0 ? double.PositiveInfinity : 0.0);
+    }
+}
+
+/// <summary>Information coefficient: Pearson correlation between predicted and realized returns.</summary>
+public sealed class InformationCoefficientMetric<T> : IFinancialMetric<T>
+{
+    public string Name => "InformationCoefficient";
+    public bool HigherIsBetter => true;
+
+    public double Compute(IReadOnlyList<double> predicted, IReadOnlyList<double> actual)
+    {
+        int n = Math.Min(predicted.Count, actual.Count);
+        if (n < 2) return 0.0;
+        double mp = 0, ma = 0;
+        for (int i = 0; i < n; i++) { mp += predicted[i]; ma += actual[i]; }
+        mp /= n; ma /= n;
+        double cov = 0, vp = 0, va = 0;
+        for (int i = 0; i < n; i++)
+        {
+            double dp = predicted[i] - mp, da = actual[i] - ma;
+            cov += dp * da; vp += dp * dp; va += da * da;
+        }
+        double denom = Math.Sqrt(vp * va);
+        return denom > 1e-12 ? cov / denom : 0.0;
+    }
+}
+
+/// <summary>
+/// Runs a set of financial metrics over a model's predicted-vs-realized returns. The default set —
+/// directional accuracy, strategy Sharpe/Sortino, max drawdown, profit factor, information coefficient — runs
+/// with no configuration (the analogue of the default cluster-validity indices); <see cref="AddMetric"/> extends
+/// it, matching how <c>ConfigureClusterMetric</c> extends the default clustering indices.
+/// </summary>
+public sealed class FinancialEvaluator<T>
+{
+    private readonly List<IFinancialMetric<T>> _metrics =
+    [
+        new DirectionalAccuracyMetric<T>(),
+        new StrategySharpeMetric<T>(),
+        new StrategySortinoMetric<T>(),
+        new MaxDrawdownMetric<T>(),
+        new ProfitFactorMetric<T>(),
+        new InformationCoefficientMetric<T>(),
+    ];
+
+    /// <summary>Adds a metric to the default set (does not replace it).</summary>
+    public void AddMetric(IFinancialMetric<T> metric)
+    {
+        ArgumentNullException.ThrowIfNull(metric);
+        _metrics.Add(metric);
+    }
+
+    public FinancialEvaluationResult Evaluate(IReadOnlyList<double> predicted, IReadOnlyList<double> actual)
+    {
+        ArgumentNullException.ThrowIfNull(predicted);
+        ArgumentNullException.ThrowIfNull(actual);
+
+        var results = new Dictionary<string, double>(StringComparer.Ordinal);
+        foreach (var m in _metrics)
+        {
+            double v;
+            try { v = m.Compute(predicted, actual); }
+            catch { v = double.NaN; }
+            results[m.Name] = v;
+        }
+
+        return new FinancialEvaluationResult(results);
+    }
+}

--- a/src/Finance/Trading/Agents/FeedforwardPolicyAgent.cs
+++ b/src/Finance/Trading/Agents/FeedforwardPolicyAgent.cs
@@ -51,6 +51,7 @@ public sealed class FeedforwardPolicyAgent<T> : IPortfolioAgent<T>
     {
         if (stateDim <= 0) throw new ArgumentOutOfRangeException(nameof(stateDim));
         if (actionDim <= 0) throw new ArgumentOutOfRangeException(nameof(actionDim));
+        if (hidden <= 0) throw new ArgumentOutOfRangeException(nameof(hidden));
 
         _stateDim = stateDim;
         _actionDim = actionDim;
@@ -103,13 +104,22 @@ public sealed class FeedforwardPolicyAgent<T> : IPortfolioAgent<T>
             action[a] = NumOps.FromDouble(Math.Clamp(v, -1.0, 1.0));
         }
 
-        _states.Add(s);
-        _actions.Add(action);
+        // Pure inference: no rollout is recorded here, so evaluating the policy (e.g. a greedy backtest that
+        // never calls StoreExperience) cannot grow or contaminate the training buffers.
         return new Vector<T>(action);
     }
 
     public void StoreExperience(Vector<T> state, Vector<T> action, T reward, Vector<T> nextState, bool done)
     {
+        // The rollout is recorded HERE (owning a copy of the supplied state/action) — the transition the trainer
+        // actually stored — rather than in SelectAction, so only true training steps populate the buffers.
+        var s = new T[_stateDim];
+        for (int i = 0; i < _stateDim && i < state.Length; i++) s[i] = state[i];
+        var a = new T[_actionDim];
+        for (int i = 0; i < _actionDim && i < action.Length; i++) a[i] = action[i];
+
+        _states.Add(s);
+        _actions.Add(a);
         _rewards.Add(ToD(reward));
         _episodeDone = done;
     }

--- a/src/Finance/Trading/Agents/FeedforwardPolicyAgent.cs
+++ b/src/Finance/Trading/Agents/FeedforwardPolicyAgent.cs
@@ -1,0 +1,185 @@
+using System;
+using System.Collections.Generic;
+using AiDotNet.Autodiff;
+using AiDotNet.Finance.Trading.Evaluation;
+using AiDotNet.Helpers;
+using AiDotNet.Interfaces;
+using AiDotNet.Models.Options;
+using AiDotNet.Optimizers;
+using AiDotNet.Tensors;
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.Engines.Autodiff;
+using AiDotNet.Tensors.LinearAlgebra;
+
+namespace AiDotNet.Finance.Trading.Agents;
+
+/// <summary>
+/// A MEMORYLESS (feed-forward MLP) continuous policy for the portfolio-manager harness — the controlled
+/// counterpart to <see cref="RecurrentPolicyAgent{T}"/>. It uses the SAME on-policy REINFORCE-with-baseline
+/// training, exploration σ, and objective, differing ONLY in that the policy is a plain MLP over the current
+/// observation with no hidden state carried across steps. That makes recurrent-vs-MLP a clean controlled
+/// experiment: run both through <see cref="Evaluation.PortfolioExperimentRunner"/> / study and rank on the
+/// untouched holdout — any gap is attributable to memory, not the algorithm.
+/// </summary>
+/// <typeparam name="T">Element type (float/double).</typeparam>
+public sealed class FeedforwardPolicyAgent<T> : IPortfolioAgent<T>
+{
+    private static readonly INumericOperations<T> NumOps = MathHelper.GetNumericOperations<T>();
+    private static IEngine Engine => AiDotNetEngine.Current;
+
+    private readonly int _stateDim;
+    private readonly int _actionDim;
+    private readonly double _sigma;
+    private readonly double _gamma;
+    private readonly Random _rng;
+
+    private readonly Tensor<T> _w1;   // [hidden, stateDim]
+    private readonly Tensor<T> _b1;   // [hidden, 1]
+    private readonly Tensor<T> _meanW; // [actionDim, hidden]
+    private readonly Tensor<T> _meanB; // [actionDim, 1]
+    private readonly IReadOnlyList<Tensor<T>> _trainable;
+    private readonly AdamOptimizer<T, Matrix<T>, Vector<T>> _optimizer;
+
+    private readonly List<T[]> _states = new();
+    private readonly List<T[]> _actions = new();
+    private readonly List<double> _rewards = new();
+    private bool _episodeDone;
+
+    public FeedforwardPolicyAgent(
+        int stateDim, int actionDim, int hidden = 32, double explorationSigma = 0.2,
+        double learningRate = 1e-3, double gamma = 0.99, int seed = 0)
+    {
+        if (stateDim <= 0) throw new ArgumentOutOfRangeException(nameof(stateDim));
+        if (actionDim <= 0) throw new ArgumentOutOfRangeException(nameof(actionDim));
+
+        _stateDim = stateDim;
+        _actionDim = actionDim;
+        _sigma = explorationSigma > 1e-6 ? explorationSigma : 1e-6;
+        _gamma = gamma;
+        _rng = RandomHelper.CreateSeededRandom(seed);
+
+        _w1 = CreateRandom(new[] { hidden, stateDim }, Math.Sqrt(2.0 / stateDim), seed + 1);
+        _b1 = new Tensor<T>(new[] { hidden, 1 });
+        _meanW = CreateRandom(new[] { actionDim, hidden }, Math.Sqrt(2.0 / hidden), seed + 2);
+        _meanB = new Tensor<T>(new[] { actionDim, 1 });
+        _trainable = new List<Tensor<T>> { _w1, _b1, _meanW, _meanB };
+
+        _optimizer = new AdamOptimizer<T, Matrix<T>, Vector<T>>(
+            null, new AdamOptimizerOptions<T, Matrix<T>, Vector<T>> { InitialLearningRate = learningRate });
+    }
+
+    private static Tensor<T> CreateRandom(int[] shape, double stddev, int seed)
+    {
+        var rng = RandomHelper.CreateSeededRandom(seed);
+        var t = new Tensor<T>(shape);
+        for (int i = 0; i < t.Length; i++)
+            t[i] = NumOps.FromDouble((rng.NextDouble() * 2 - 1) * stddev);
+        return t;
+    }
+
+    private static double ToD(T v) => Convert.ToDouble(v);
+
+    /// <summary>Mean action tensor [actionDim,1] for one state tensor [stateDim,1]: tanh(meanW·tanh(W1·x+b1)+meanB).</summary>
+    private Tensor<T> MeanOf(Tensor<T> x)
+    {
+        var h = Engine.Tanh(Engine.TensorBroadcastAdd(Engine.TensorMatMul(_w1, x), _b1));
+        return Engine.Tanh(Engine.TensorBroadcastAdd(Engine.TensorMatMul(_meanW, h), _meanB));
+    }
+
+    public Vector<T> SelectAction(Vector<T> state, bool explore)
+    {
+        var s = new T[_stateDim];
+        for (int i = 0; i < _stateDim && i < state.Length; i++) s[i] = state[i];
+
+        var xt = new Tensor<T>(new[] { _stateDim, 1 });
+        for (int i = 0; i < _stateDim; i++) xt[i, 0] = s[i];
+        var mean = MeanOf(xt);
+
+        var action = new T[_actionDim];
+        for (int a = 0; a < _actionDim; a++)
+        {
+            double m = ToD(mean[a, 0]);
+            double v = explore ? m + _sigma * _rng.NextGaussian() : m;
+            action[a] = NumOps.FromDouble(Math.Clamp(v, -1.0, 1.0));
+        }
+
+        _states.Add(s);
+        _actions.Add(action);
+        return new Vector<T>(action);
+    }
+
+    public void StoreExperience(Vector<T> state, Vector<T> action, T reward, Vector<T> nextState, bool done)
+    {
+        _rewards.Add(ToD(reward));
+        _episodeDone = done;
+    }
+
+    public T Train()
+    {
+        if (!_episodeDone || _states.Count == 0 || _states.Count != _rewards.Count)
+        {
+            return NumOps.Zero;
+        }
+
+        int n = _states.Count;
+        var returns = new double[n];
+        double g = 0;
+        for (int t = n - 1; t >= 0; t--)
+        {
+            g = _rewards[t] + _gamma * g;
+            returns[t] = g;
+        }
+        double mean = 0;
+        for (int t = 0; t < n; t++) mean += returns[t];
+        mean /= n;
+        double var = 0;
+        for (int t = 0; t < n; t++) var += (returns[t] - mean) * (returns[t] - mean);
+        double std = Math.Sqrt(var / Math.Max(1, n)) + 1e-8;
+        var advantage = new double[n];
+        for (int t = 0; t < n; t++) advantage[t] = (returns[t] - mean) / std;
+
+        double invSigma2 = 1.0 / (_sigma * _sigma);
+        using var tape = new GradientTape<T>();
+        Tensor<T>? loss = null;
+        for (int t = 0; t < n; t++)
+        {
+            var xt = new Tensor<T>(new[] { _stateDim, 1 });
+            for (int i = 0; i < _stateDim; i++) xt[i, 0] = _states[t][i];
+            var meanT = MeanOf(xt); // memoryless: each step independent
+
+            var actionT = new Tensor<T>(new[] { _actionDim, 1 });
+            for (int a = 0; a < _actionDim; a++) actionT[a, 0] = _actions[t][a];
+
+            var diff = Engine.TensorSubtract(actionT, meanT);
+            var sq = Engine.ReduceSum(Engine.TensorMultiply(diff, diff), new[] { 0, 1 }, keepDims: false);
+            var term = Engine.TensorMultiplyScalar(sq, NumOps.FromDouble(0.5 * invSigma2 * advantage[t]));
+            loss = loss is null ? term : Engine.TensorAdd(loss, term);
+        }
+
+        T reported = NumOps.Zero;
+        if (loss is not null)
+        {
+            var grads = tape.ComputeGradients(loss, sources: null);
+            var picked = new Dictionary<Tensor<T>, Tensor<T>>(TensorReferenceComparer<Tensor<T>>.Instance);
+            foreach (var p in _trainable)
+                if (grads.TryGetValue(p, out var gr)) picked[p] = gr;
+
+            reported = loss.Length > 0 ? loss[0] : NumOps.Zero;
+            _optimizer.Step(new TapeStepContext<T>(_trainable, picked, reported));
+        }
+
+        _states.Clear();
+        _actions.Clear();
+        _rewards.Clear();
+        _episodeDone = false;
+        return reported;
+    }
+
+    public void ResetEpisode()
+    {
+        _states.Clear();
+        _actions.Clear();
+        _rewards.Clear();
+        _episodeDone = false;
+    }
+}

--- a/src/Finance/Trading/Agents/FeedforwardPolicyAgent.cs
+++ b/src/Finance/Trading/Agents/FeedforwardPolicyAgent.cs
@@ -101,7 +101,7 @@ public sealed class FeedforwardPolicyAgent<T> : IPortfolioAgent<T>
         {
             double m = ToD(mean[a, 0]);
             double v = explore ? m + _sigma * _rng.NextGaussian() : m;
-            action[a] = NumOps.FromDouble(Math.Clamp(v, -1.0, 1.0));
+            action[a] = NumOps.FromDouble(MathPolyfill.Clamp(v, -1.0, 1.0));
         }
 
         // Pure inference: no rollout is recorded here, so evaluating the policy (e.g. a greedy backtest that

--- a/src/Finance/Trading/Agents/RecurrentPolicyAgent.cs
+++ b/src/Finance/Trading/Agents/RecurrentPolicyAgent.cs
@@ -136,7 +136,7 @@ public sealed class RecurrentPolicyAgent<T> : IPortfolioAgent<T>
         {
             double m = ToD(mean[a]);
             double v = explore ? m + _sigma * _rng.NextGaussian() : m;
-            action[a] = NumOps.FromDouble(Math.Clamp(v, -1.0, 1.0));
+            action[a] = NumOps.FromDouble(MathPolyfill.Clamp(v, -1.0, 1.0));
         }
 
         // The hidden state advances above (a recurrent policy must), but the rollout is NOT recorded here — so a

--- a/src/Finance/Trading/Agents/RecurrentPolicyAgent.cs
+++ b/src/Finance/Trading/Agents/RecurrentPolicyAgent.cs
@@ -65,6 +65,7 @@ public sealed class RecurrentPolicyAgent<T> : IPortfolioAgent<T>
     {
         if (stateDim <= 0) throw new ArgumentOutOfRangeException(nameof(stateDim));
         if (actionDim <= 0) throw new ArgumentOutOfRangeException(nameof(actionDim));
+        if (hidden <= 0) throw new ArgumentOutOfRangeException(nameof(hidden));
 
         _stateDim = stateDim;
         _actionDim = actionDim;
@@ -129,7 +130,7 @@ public sealed class RecurrentPolicyAgent<T> : IPortfolioAgent<T>
         var s = new T[_stateDim];
         for (int i = 0; i < _stateDim && i < state.Length; i++) s[i] = state[i];
 
-        var mean = Forward(s);
+        var mean = Forward(s); // advances the recurrent state (must happen on every act, incl. inference)
         var action = new T[_actionDim];
         for (int a = 0; a < _actionDim; a++)
         {
@@ -138,13 +139,22 @@ public sealed class RecurrentPolicyAgent<T> : IPortfolioAgent<T>
             action[a] = NumOps.FromDouble(Math.Clamp(v, -1.0, 1.0));
         }
 
-        _states.Add(s);
-        _actions.Add(action);
+        // The hidden state advances above (a recurrent policy must), but the rollout is NOT recorded here — so a
+        // greedy backtest that never calls StoreExperience cannot grow or contaminate the training buffers.
         return new Vector<T>(action);
     }
 
     public void StoreExperience(Vector<T> state, Vector<T> action, T reward, Vector<T> nextState, bool done)
     {
+        // Record the rollout HERE (owning a copy of the supplied state/action) — the transition the trainer
+        // actually stored — so only true training steps feed the BPTT replay.
+        var s = new T[_stateDim];
+        for (int i = 0; i < _stateDim && i < state.Length; i++) s[i] = state[i];
+        var a = new T[_actionDim];
+        for (int i = 0; i < _actionDim && i < action.Length; i++) a[i] = action[i];
+
+        _states.Add(s);
+        _actions.Add(a);
         _rewards.Add(ToD(reward));
         _episodeDone = done;
     }

--- a/src/Finance/Trading/Agents/RecurrentPolicyAgent.cs
+++ b/src/Finance/Trading/Agents/RecurrentPolicyAgent.cs
@@ -1,0 +1,232 @@
+using System;
+using System.Collections.Generic;
+using AiDotNet.Autodiff;
+using AiDotNet.Enums;
+using AiDotNet.Finance.Trading.Evaluation;
+using AiDotNet.Helpers;
+using AiDotNet.Interfaces;
+using AiDotNet.Models.Options;
+using AiDotNet.Optimizers;
+using AiDotNet.Tensors;
+using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.Engines.Autodiff;
+using AiDotNet.Tensors.LinearAlgebra;
+using AiDotNet.TimeSeries;
+
+namespace AiDotNet.Finance.Trading.Agents;
+
+/// <summary>
+/// A RECURRENT continuous policy for the portfolio-manager harness: an LSTM carries hidden state across the
+/// episode, so the policy conditions each action on the whole history it has seen — not just the fixed
+/// observation window an MLP policy is limited to. This is the recurrent-policy path for the greenfield
+/// trading-agent research: partial observability (regime, position history) is exactly where a recurrent policy
+/// should beat a memoryless one, and the experiment runner ranks that on the untouched holdout.
+/// <para>
+/// Trained on-policy with REINFORCE + a return baseline, back-propagating through time over each episode's
+/// rollout (the natural fit for recurrence — on-policy methods learn from full sequences, no sequence-replay
+/// surgery). Exploration uses a fixed Gaussian σ, so the policy-gradient objective reduces to
+/// <c>Σ advantageₜ · ½‖actionₜ − μₜ‖² / σ²</c> — a numerically robust loss (no exp/log of parameters). Reuses
+/// the tape-trainable LSTM cell + Adam path proven by the DeepAR model. Implements the narrow
+/// <see cref="IPortfolioAgent{T}"/> so it drops straight into <see cref="PortfolioExperimentRunner"/>.
+/// </para>
+/// </summary>
+/// <typeparam name="T">Element type (float/double).</typeparam>
+public sealed class RecurrentPolicyAgent<T> : IPortfolioAgent<T>
+{
+    private static readonly INumericOperations<T> NumOps = MathHelper.GetNumericOperations<T>();
+    private static IEngine Engine => AiDotNetEngine.Current;
+
+    private readonly int _stateDim;
+    private readonly int _actionDim;
+    private readonly int _hidden;
+    private readonly double _sigma;
+    private readonly double _gamma;
+    private readonly Random _rng;
+
+    private readonly DeepARLstmCellTape<T> _cell;   // recurrent core (tape-trainable)
+    private readonly Tensor<T> _meanW;              // [actionDim, hidden]
+    private readonly Tensor<T> _meanB;              // [actionDim, 1]
+    private readonly IReadOnlyList<Tensor<T>> _trainable;
+    private readonly AdamOptimizer<T, Matrix<T>, Vector<T>> _optimizer;
+
+    // Per-episode recurrent state (eager act path).
+    private Tensor<T> _h = null!;
+    private Tensor<T> _c = null!;
+
+    // Current-episode rollout.
+    private readonly List<T[]> _states = new();
+    private readonly List<T[]> _actions = new();
+    private readonly List<double> _rewards = new();
+    private bool _episodeDone;
+
+    public RecurrentPolicyAgent(
+        int stateDim, int actionDim, int hidden = 32, double explorationSigma = 0.2,
+        double learningRate = 1e-3, double gamma = 0.99, int seed = 0)
+    {
+        if (stateDim <= 0) throw new ArgumentOutOfRangeException(nameof(stateDim));
+        if (actionDim <= 0) throw new ArgumentOutOfRangeException(nameof(actionDim));
+
+        _stateDim = stateDim;
+        _actionDim = actionDim;
+        _hidden = hidden;
+        _sigma = explorationSigma > 1e-6 ? explorationSigma : 1e-6;
+        _gamma = gamma;
+        _rng = RandomHelper.CreateSeededRandom(seed);
+
+        _cell = new DeepARLstmCellTape<T>(stateDim, hidden, seed);
+        double stddev = Math.Sqrt(2.0 / hidden);
+        _meanW = CreateRandom(new[] { actionDim, hidden }, stddev, seed + 7);
+        _meanB = new Tensor<T>(new[] { actionDim, 1 });
+
+        var trainable = new List<Tensor<T>>();
+        trainable.AddRange(Training.TapeTrainingStep<T>.CollectParameters(new NeuralNetworks.Layers.LayerBase<T>[] { _cell }, -1));
+        trainable.Add(_meanW);
+        trainable.Add(_meanB);
+        _trainable = trainable;
+
+        _optimizer = new AdamOptimizer<T, Matrix<T>, Vector<T>>(
+            null, new AdamOptimizerOptions<T, Matrix<T>, Vector<T>> { InitialLearningRate = learningRate });
+
+        ResetHidden();
+    }
+
+    private static Tensor<T> CreateRandom(int[] shape, double stddev, int seed)
+    {
+        var rng = RandomHelper.CreateSeededRandom(seed);
+        var t = new Tensor<T>(shape);
+        for (int i = 0; i < t.Length; i++)
+            t[i] = NumOps.FromDouble((rng.NextDouble() * 2 - 1) * stddev);
+        return t;
+    }
+
+    private void ResetHidden()
+    {
+        _h = new Tensor<T>(new[] { _hidden, 1 });
+        _c = new Tensor<T>(new[] { _hidden, 1 });
+    }
+
+    private static double ToD(T v) => Convert.ToDouble(v);
+
+    /// <summary>Eager mean action for one observation, advancing the recurrent state. tanh-bounded to [-1, 1].</summary>
+    private T[] Forward(T[] state)
+    {
+        var xt = new Tensor<T>(new[] { _stateDim, 1 });
+        for (int i = 0; i < _stateDim; i++) xt[i, 0] = state[i];
+
+        var (h, c) = _cell.Step(xt, _h, _c);
+        _h = h;
+        _c = c;
+
+        var proj = Engine.TensorBroadcastAdd(Engine.TensorMatMul(_meanW, h), _meanB); // [A,1]
+        var mean = Engine.Tanh(proj);
+        var result = new T[_actionDim];
+        for (int a = 0; a < _actionDim; a++) result[a] = mean[a, 0];
+        return result;
+    }
+
+    public Vector<T> SelectAction(Vector<T> state, bool explore)
+    {
+        var s = new T[_stateDim];
+        for (int i = 0; i < _stateDim && i < state.Length; i++) s[i] = state[i];
+
+        var mean = Forward(s);
+        var action = new T[_actionDim];
+        for (int a = 0; a < _actionDim; a++)
+        {
+            double m = ToD(mean[a]);
+            double v = explore ? m + _sigma * _rng.NextGaussian() : m;
+            action[a] = NumOps.FromDouble(Math.Clamp(v, -1.0, 1.0));
+        }
+
+        _states.Add(s);
+        _actions.Add(action);
+        return new Vector<T>(action);
+    }
+
+    public void StoreExperience(Vector<T> state, Vector<T> action, T reward, Vector<T> nextState, bool done)
+    {
+        _rewards.Add(ToD(reward));
+        _episodeDone = done;
+    }
+
+    public T Train()
+    {
+        // On-policy: only update at the end of a complete episode rollout.
+        if (!_episodeDone || _states.Count == 0 || _states.Count != _rewards.Count)
+        {
+            return NumOps.Zero;
+        }
+
+        int n = _states.Count;
+
+        // Discounted returns, then a whitened baseline (return − mean) as the advantage. Detached constants.
+        var returns = new double[n];
+        double g = 0;
+        for (int t = n - 1; t >= 0; t--)
+        {
+            g = _rewards[t] + _gamma * g;
+            returns[t] = g;
+        }
+        double mean = 0;
+        for (int t = 0; t < n; t++) mean += returns[t];
+        mean /= n;
+        double var = 0;
+        for (int t = 0; t < n; t++) var += (returns[t] - mean) * (returns[t] - mean);
+        double std = Math.Sqrt(var / Math.Max(1, n)) + 1e-8;
+        var advantage = new double[n];
+        for (int t = 0; t < n; t++) advantage[t] = (returns[t] - mean) / std;
+
+        // BPTT: replay the rollout through the LSTM under a tape; minimize Σ adv·½‖a−μ‖²/σ².
+        double invSigma2 = 1.0 / (_sigma * _sigma);
+        using var tape = new GradientTape<T>();
+        var h = new Tensor<T>(new[] { _hidden, 1 });
+        var c = new Tensor<T>(new[] { _hidden, 1 });
+        Tensor<T>? loss = null;
+
+        for (int t = 0; t < n; t++)
+        {
+            var xt = new Tensor<T>(new[] { _stateDim, 1 });
+            for (int i = 0; i < _stateDim; i++) xt[i, 0] = _states[t][i];
+            var (hNew, cNew) = _cell.Step(xt, h, c);
+            h = hNew;
+            c = cNew;
+
+            var meanT = Engine.Tanh(Engine.TensorBroadcastAdd(Engine.TensorMatMul(_meanW, h), _meanB)); // [A,1]
+            var actionT = new Tensor<T>(new[] { _actionDim, 1 });
+            for (int a = 0; a < _actionDim; a++) actionT[a, 0] = _actions[t][a];
+
+            var diff = Engine.TensorSubtract(actionT, meanT);
+            var sq = Engine.ReduceSum(Engine.TensorMultiply(diff, diff), new[] { 0, 1 }, keepDims: false); // scalar
+            // weight = advantage_t · 0.5 / σ²  (constant w.r.t. params)
+            var term = Engine.TensorMultiplyScalar(sq, NumOps.FromDouble(0.5 * invSigma2 * advantage[t]));
+            loss = loss is null ? term : Engine.TensorAdd(loss, term);
+        }
+
+        T reported = NumOps.Zero;
+        if (loss is not null)
+        {
+            var grads = tape.ComputeGradients(loss, sources: null);
+            var picked = new Dictionary<Tensor<T>, Tensor<T>>(Helpers.TensorReferenceComparer<Tensor<T>>.Instance);
+            foreach (var p in _trainable)
+                if (grads.TryGetValue(p, out var gr)) picked[p] = gr;
+
+            reported = loss.Length > 0 ? loss[0] : NumOps.Zero;
+            _optimizer.Step(new TapeStepContext<T>(_trainable, picked, reported));
+        }
+
+        _states.Clear();
+        _actions.Clear();
+        _rewards.Clear();
+        _episodeDone = false;
+        return reported;
+    }
+
+    public void ResetEpisode()
+    {
+        ResetHidden();
+        _states.Clear();
+        _actions.Clear();
+        _rewards.Clear();
+        _episodeDone = false;
+    }
+}

--- a/src/Finance/Trading/Environments/PortfolioManagerEnvironment.cs
+++ b/src/Finance/Trading/Environments/PortfolioManagerEnvironment.cs
@@ -1,0 +1,262 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using AiDotNet.Finance.Trading.Rewards;
+using AiDotNet.Tensors.LinearAlgebra;
+
+namespace AiDotNet.Finance.Trading.Environments;
+
+/// <summary>
+/// A SOTA cross-sectional portfolio-manager environment: the agent manages a whole book at once. Each step it
+/// emits a target-weight VECTOR over the tradable universe (one weight per asset, in [-1, 1], subject to a
+/// gross-leverage budget), and the environment reconciles every position toward its target — so entry, exit,
+/// sizing, and rotation across names are a single learned decision. This is the cross-sectional counterpart to
+/// the single-asset <see cref="TradingEnvironment{T}"/>, and it goes beyond the basic
+/// <see cref="PortfolioTradingEnvironment{T}"/> (which forces weights to sum to 1 — always fully invested, no
+/// cash, no leverage budget, every column tradable, default return reward, no realistic frictions).
+/// <para>
+/// It differs in four SOTA-relevant ways: (1) a gross-leverage BUDGET (<c>sum(|w|) &lt;= maxLeverage</c>) so the
+/// agent can hold cash and lever deliberately; (2) observation-only FEATURE columns (per-name forecasts,
+/// uncertainty, "analyst" recommendations for a hierarchical setup) that ride in the observation but are never
+/// traded; (3) a pluggable <see cref="IPortfolioReward"/> objective (total return, differential Sharpe,
+/// drawdown-penalized) so the reward is an experiment knob; (4) realistic FRICTIONS — transaction cost,
+/// turnover-proportional slippage, short-borrow financing, and gross carry — all deducted from cash so portfolio
+/// value reflects true costs. Each asset's position and cash are already in the base observation, so the policy
+/// conditions its exits on what it holds.
+/// </para>
+/// </summary>
+/// <typeparam name="T">Element type — <c>float</c> (GPU) or <c>double</c> (CPU/accuracy).</typeparam>
+public class PortfolioManagerEnvironment<T> : TradingEnvironment<T>
+{
+    private readonly int _tradableCount;
+    private readonly IPortfolioReward _reward;
+    private readonly double _maxLeverage;
+    private readonly double _slippageCoefficient;
+    private readonly double _borrowCostPerStep;
+    private readonly double _holdingCostPerStep;
+
+    private double _lastTurnover;
+    private double _grossExposure;
+    private double _shortExposure;
+    private double _peakValue;
+
+    /// <param name="assetPrices">Price series per TRADABLE asset (all equal length). Column i is tradable asset i.</param>
+    /// <param name="featureColumns">Observation-only columns (forecasts/signals/etc.), same length — never traded.</param>
+    /// <param name="reward">The objective. Swap it to run reward experiments on the same environment.</param>
+    /// <param name="maxLeverage">Gross-leverage budget: target weights are scaled so sum(|w_i|) &lt;= this.</param>
+    /// <param name="transactionCost">Proportional per-trade cost (fraction of trade notional).</param>
+    /// <param name="slippageCoefficient">Extra cost = coefficient x turnover notional (market-impact proxy).</param>
+    /// <param name="annualBorrowCost">Annualized short-borrow financing rate (applied per step / 252).</param>
+    /// <param name="annualHoldingCost">Annualized carry/financing on gross exposure (applied per step / 252).</param>
+    public PortfolioManagerEnvironment(
+        IReadOnlyList<double[]> assetPrices,
+        IReadOnlyList<double[]>? featureColumns,
+        int windowSize,
+        double initialCapital,
+        IPortfolioReward reward,
+        double maxLeverage = 1.0,
+        double transactionCost = 0.001,
+        double slippageCoefficient = 0.0005,
+        double annualBorrowCost = 0.03,
+        double annualHoldingCost = 0.0,
+        bool allowShortSelling = true,
+        int? seed = null)
+        : base(BuildTensor(assetPrices, featureColumns), windowSize, FromDouble(initialCapital), transactionCost,
+               allowShortSelling, randomStart: false, maxEpisodeLength: 0, seed: seed)
+    {
+        ArgumentNullException.ThrowIfNull(assetPrices);
+        if (assetPrices.Count == 0)
+        {
+            throw new ArgumentException("At least one tradable asset is required.", nameof(assetPrices));
+        }
+
+        _tradableCount = assetPrices.Count;
+        _reward = reward ?? throw new ArgumentNullException(nameof(reward));
+        _maxLeverage = maxLeverage > 0 ? maxLeverage : throw new ArgumentOutOfRangeException(nameof(maxLeverage));
+        _slippageCoefficient = Math.Max(0.0, slippageCoefficient);
+        _borrowCostPerStep = Math.Max(0.0, annualBorrowCost) / 252.0;
+        _holdingCostPerStep = Math.Max(0.0, annualHoldingCost) / 252.0;
+        _peakValue = initialCapital;
+    }
+
+    /// <summary>One target weight per tradable asset (feature columns are never traded).</summary>
+    public override int ActionSpaceSize => _tradableCount;
+
+    /// <summary>Continuous target-weight vector.</summary>
+    public override bool IsContinuousActionSpace => true;
+
+    private static double ToDouble(T value) => Convert.ToDouble(value, CultureInfo.InvariantCulture);
+
+    private static T FromDouble(double value) => (T)Convert.ChangeType(value, typeof(T), CultureInfo.InvariantCulture);
+
+    private static Tensor<T> BuildTensor(IReadOnlyList<double[]> assetPrices, IReadOnlyList<double[]>? featureColumns)
+    {
+        ArgumentNullException.ThrowIfNull(assetPrices);
+        int n = assetPrices.Count;
+        int m = featureColumns?.Count ?? 0;
+        int time = assetPrices[0].Length;
+        int assets = n + m;
+        var data = new T[time * assets];
+
+        for (int t = 0; t < time; t++)
+        {
+            for (int i = 0; i < n; i++)
+            {
+                data[(t * assets) + i] = FromDouble(t < assetPrices[i].Length ? assetPrices[i][t] : 0.0);
+            }
+
+            for (int j = 0; j < m; j++)
+            {
+                var col = featureColumns![j];
+                data[(t * assets) + n + j] = FromDouble(t < col.Length ? col[t] : 0.0);
+            }
+        }
+
+        return new Tensor<T>([time, assets], new Vector<T>(data));
+    }
+
+    /// <summary>
+    /// Reconciles every tradable position toward the action's target weights, then applies financing frictions.
+    /// Target weights are clamped to [-1, 1] and scaled down so gross leverage sum(|w|) does not exceed the
+    /// budget. Only assets [0, tradableCount) are traded; feature columns keep a zero position and never affect
+    /// portfolio value.
+    /// </summary>
+    protected override void ApplyAction(Vector<T> action, Vector<T> prices)
+    {
+        double portfolioValue = ToDouble(_portfolioValue);
+        if (!(portfolioValue > 0))
+        {
+            _lastTurnover = 0;
+            return;
+        }
+
+        // Decode + clamp target weights, then enforce the gross-leverage budget.
+        var weights = new double[_tradableCount];
+        double gross = 0;
+        for (int i = 0; i < _tradableCount; i++)
+        {
+            double w = i < action.Length ? ToDouble(action[i]) : 0.0;
+            if (double.IsNaN(w) || double.IsInfinity(w))
+            {
+                w = 0.0;
+            }
+
+            w = Math.Clamp(w, -1.0, 1.0);
+            weights[i] = w;
+            gross += Math.Abs(w);
+        }
+
+        if (gross > _maxLeverage && gross > 0)
+        {
+            double scale = _maxLeverage / gross;
+            for (int i = 0; i < _tradableCount; i++)
+            {
+                weights[i] *= scale;
+            }
+        }
+
+        // Reconcile each position toward its target; accumulate traded notional. Sells first (frees cash),
+        // then buys — same ordering the base env's own portfolio variant uses.
+        double turnoverNotional = 0;
+        for (int pass = 0; pass < 2; pass++)
+        {
+            for (int i = 0; i < _tradableCount; i++)
+            {
+                double price = ToDouble(prices[i]);
+                if (!(price > 0))
+                {
+                    continue;
+                }
+
+                // 0.98 headroom leaves room for transaction cost so a full-weight buy isn't rejected for cash.
+                double desiredUnits = 0.98 * weights[i] * (portfolioValue / price);
+                if (double.IsNaN(desiredUnits) || double.IsInfinity(desiredUnits))
+                {
+                    continue;
+                }
+
+                double delta = desiredUnits - ToDouble(_positions[i]);
+                bool isSell = delta < 0;
+                if ((pass == 0) != isSell)
+                {
+                    continue; // pass 0 = sells, pass 1 = buys
+                }
+
+                turnoverNotional += Math.Abs(delta) * price;
+                ExecuteTrade(i, FromDouble(delta), prices[i]);
+            }
+        }
+
+        _lastTurnover = turnoverNotional / portfolioValue;
+
+        // Post-trade exposures (tradable assets only).
+        double grossNotional = 0, shortNotional = 0;
+        for (int i = 0; i < _tradableCount; i++)
+        {
+            double notional = ToDouble(_positions[i]) * ToDouble(prices[i]);
+            grossNotional += Math.Abs(notional);
+            if (notional < 0)
+            {
+                shortNotional += -notional;
+            }
+        }
+
+        _grossExposure = grossNotional / portfolioValue;
+        _shortExposure = shortNotional / portfolioValue;
+
+        // Financing frictions deducted from cash so portfolio value reflects true costs: turnover-proportional
+        // slippage + short-borrow + gross carry. (The per-trade transaction cost is already applied inside
+        // ExecuteTrade.)
+        double financing = (_slippageCoefficient * turnoverNotional)
+                           + (_borrowCostPerStep * shortNotional)
+                           + (_holdingCostPerStep * grossNotional);
+        if (financing > 0 && double.IsFinite(financing))
+        {
+            _cash = FromDouble(ToDouble(_cash) - financing);
+        }
+    }
+
+    /// <summary>
+    /// Reward = the pluggable objective applied to this step's net portfolio return, with turnover, exposure, and
+    /// drawdown context. Frictions are already reflected in the return (deducted from cash in
+    /// <see cref="ApplyAction"/>), so the objective sees the true, cost-net outcome.
+    /// </summary>
+    protected override T ComputeReward(T previousValue, T currentValue)
+    {
+        double previous = ToDouble(previousValue);
+        double current = ToDouble(currentValue);
+        double portfolioReturn = previous > 0 && double.IsFinite(previous) && double.IsFinite(current)
+            ? (current - previous) / previous
+            : 0.0;
+
+        if (current > _peakValue)
+        {
+            _peakValue = current;
+        }
+        double drawdown = _peakValue > 0 ? Math.Max(0.0, (_peakValue - current) / _peakValue) : 0.0;
+
+        var context = new PortfolioRewardContext(portfolioReturn, _lastTurnover, _grossExposure, _shortExposure, drawdown);
+        double reward = _reward.Reward(in context);
+        return FromDouble(double.IsNaN(reward) || double.IsInfinity(reward) ? 0.0 : reward);
+    }
+
+    /// <summary>Turnover (fraction of portfolio value traded) on the most recent step — for logging/tests.</summary>
+    public double LastTurnover => _lastTurnover;
+
+    /// <summary>Gross exposure after the most recent step (sum |position notional| / value).</summary>
+    public double GrossExposure => _grossExposure;
+
+    /// <summary>
+    /// Resets the per-episode reward statistics and drawdown peak. Call after <see cref="TradingEnvironment{T}.Reset"/>
+    /// when reusing one environment instance across independent episodes (e.g. evaluation). Not needed for the
+    /// default single-pass training configuration (one episode over the full series).
+    /// </summary>
+    public void ResetEpisodeState()
+    {
+        _reward.Reset();
+        _peakValue = ToDouble(InitialCapital);
+        _lastTurnover = 0;
+        _grossExposure = 0;
+        _shortExposure = 0;
+    }
+}

--- a/src/Finance/Trading/Environments/PortfolioManagerEnvironment.cs
+++ b/src/Finance/Trading/Environments/PortfolioManagerEnvironment.cs
@@ -26,7 +26,7 @@ namespace AiDotNet.Finance.Trading.Environments;
 /// </para>
 /// </summary>
 /// <typeparam name="T">Element type — <c>float</c> (GPU) or <c>double</c> (CPU/accuracy).</typeparam>
-public class PortfolioManagerEnvironment<T> : TradingEnvironment<T>
+public sealed class PortfolioManagerEnvironment<T> : TradingEnvironment<T>
 {
     private readonly int _tradableCount;
     private readonly IPortfolioReward _reward;
@@ -64,12 +64,8 @@ public class PortfolioManagerEnvironment<T> : TradingEnvironment<T>
         : base(BuildTensor(assetPrices, featureColumns), windowSize, FromDouble(initialCapital), transactionCost,
                allowShortSelling, randomStart: false, maxEpisodeLength: 0, seed: seed)
     {
-        ArgumentNullException.ThrowIfNull(assetPrices);
-        if (assetPrices.Count == 0)
-        {
-            throw new ArgumentException("At least one tradable asset is required.", nameof(assetPrices));
-        }
-
+        // assetPrices is already validated (non-null, non-empty, equal-length series) by BuildTensor, which
+        // runs in the base(...) initializer above before this body.
         _tradableCount = assetPrices.Count;
         _reward = reward ?? throw new ArgumentNullException(nameof(reward));
         _maxLeverage = maxLeverage > 0 ? maxLeverage : throw new ArgumentOutOfRangeException(nameof(maxLeverage));
@@ -92,23 +88,54 @@ public class PortfolioManagerEnvironment<T> : TradingEnvironment<T>
     private static Tensor<T> BuildTensor(IReadOnlyList<double[]> assetPrices, IReadOnlyList<double[]>? featureColumns)
     {
         ArgumentNullException.ThrowIfNull(assetPrices);
+        if (assetPrices.Count == 0)
+        {
+            throw new ArgumentException("At least one tradable asset series is required.", nameof(assetPrices));
+        }
+
+        if (assetPrices[0] is null || assetPrices[0].Length == 0)
+        {
+            throw new ArgumentException("Asset series must be non-empty.", nameof(assetPrices));
+        }
+
         int n = assetPrices.Count;
         int m = featureColumns?.Count ?? 0;
         int time = assetPrices[0].Length;
+
+        // Every asset and feature series must be present and share the exact time length. Zero-padding a short
+        // or missing series would manufacture prices/signals the model would then trade on, so reject instead.
+        for (int i = 0; i < n; i++)
+        {
+            if (assetPrices[i] is null || assetPrices[i].Length != time)
+            {
+                throw new ArgumentException(
+                    $"All asset series must be non-null and of equal length ({time}); series {i} does not match.",
+                    nameof(assetPrices));
+            }
+        }
+
+        for (int j = 0; j < m; j++)
+        {
+            if (featureColumns![j] is null || featureColumns[j].Length != time)
+            {
+                throw new ArgumentException(
+                    $"All feature series must be non-null and match the asset-series length ({time}); feature {j} does not match.",
+                    nameof(featureColumns));
+            }
+        }
+
         int assets = n + m;
         var data = new T[time * assets];
-
         for (int t = 0; t < time; t++)
         {
             for (int i = 0; i < n; i++)
             {
-                data[(t * assets) + i] = FromDouble(t < assetPrices[i].Length ? assetPrices[i][t] : 0.0);
+                data[(t * assets) + i] = FromDouble(assetPrices[i][t]);
             }
 
             for (int j = 0; j < m; j++)
             {
-                var col = featureColumns![j];
-                data[(t * assets) + n + j] = FromDouble(t < col.Length ? col[t] : 0.0);
+                data[(t * assets) + n + j] = FromDouble(featureColumns![j][t]);
             }
         }
 
@@ -123,6 +150,12 @@ public class PortfolioManagerEnvironment<T> : TradingEnvironment<T>
     /// </summary>
     protected override void ApplyAction(Vector<T> action, Vector<T> prices)
     {
+        if (action.Length != _tradableCount)
+        {
+            throw new ArgumentException(
+                $"Action length {action.Length} must equal the tradable-asset count {_tradableCount}.", nameof(action));
+        }
+
         double portfolioValue = ToDouble(_portfolioValue);
         if (!(portfolioValue > 0))
         {
@@ -135,7 +168,7 @@ public class PortfolioManagerEnvironment<T> : TradingEnvironment<T>
         double gross = 0;
         for (int i = 0; i < _tradableCount; i++)
         {
-            double w = i < action.Length ? ToDouble(action[i]) : 0.0;
+            double w = ToDouble(action[i]);
             if (double.IsNaN(w) || double.IsInfinity(w))
             {
                 w = 0.0;
@@ -155,8 +188,9 @@ public class PortfolioManagerEnvironment<T> : TradingEnvironment<T>
             }
         }
 
-        // Reconcile each position toward its target; accumulate traded notional. Sells first (frees cash),
-        // then buys — same ordering the base env's own portfolio variant uses.
+        // Reconcile each position toward its exact target weight. Sells run first (they free cash), then buys —
+        // so buy sizing sees the cash the sells released. Turnover accumulates the quantity ACTUALLY filled
+        // (ExecuteTrade caps a buy to available cash and clamps a no-short sell), not the requested delta.
         double turnoverNotional = 0;
         for (int pass = 0; pass < 2; pass++)
         {
@@ -168,8 +202,7 @@ public class PortfolioManagerEnvironment<T> : TradingEnvironment<T>
                     continue;
                 }
 
-                // 0.98 headroom leaves room for transaction cost so a full-weight buy isn't rejected for cash.
-                double desiredUnits = 0.98 * weights[i] * (portfolioValue / price);
+                double desiredUnits = weights[i] * (portfolioValue / price);
                 if (double.IsNaN(desiredUnits) || double.IsInfinity(desiredUnits))
                 {
                     continue;
@@ -182,18 +215,40 @@ public class PortfolioManagerEnvironment<T> : TradingEnvironment<T>
                     continue; // pass 0 = sells, pass 1 = buys
                 }
 
-                turnoverNotional += Math.Abs(delta) * price;
+                if (!isSell)
+                {
+                    // Cost-aware fill: a buy can only draw the cash on hand after the transaction and slippage
+                    // charges it will incur, so cap the increase to what cash affords rather than reserving a
+                    // fixed headroom fraction. This also keeps ExecuteTrade (which checks cash before filling)
+                    // from silently rejecting the whole order.
+                    double unitCost = price * (1.0 + TransactionCost + _slippageCoefficient);
+                    double affordable = unitCost > 0 ? ToDouble(_cash) / unitCost : 0.0;
+                    if (delta > affordable)
+                    {
+                        delta = affordable;
+                    }
+
+                    if (delta <= 0)
+                    {
+                        continue;
+                    }
+                }
+
+                double before = ToDouble(_positions[i]);
                 ExecuteTrade(i, FromDouble(delta), prices[i]);
+                double filled = ToDouble(_positions[i]) - before;
+                turnoverNotional += Math.Abs(filled) * price;
             }
         }
 
         _lastTurnover = turnoverNotional / portfolioValue;
 
-        // Post-trade exposures (tradable assets only).
-        double grossNotional = 0, shortNotional = 0;
+        // Post-trade positions marked at current prices.
+        double grossNotional = 0, shortNotional = 0, positionValue = 0;
         for (int i = 0; i < _tradableCount; i++)
         {
             double notional = ToDouble(_positions[i]) * ToDouble(prices[i]);
+            positionValue += notional;
             grossNotional += Math.Abs(notional);
             if (notional < 0)
             {
@@ -201,18 +256,28 @@ public class PortfolioManagerEnvironment<T> : TradingEnvironment<T>
             }
         }
 
-        _grossExposure = grossNotional / portfolioValue;
-        _shortExposure = shortNotional / portfolioValue;
-
-        // Financing frictions deducted from cash so portfolio value reflects true costs: turnover-proportional
-        // slippage + short-borrow + gross carry. (The per-trade transaction cost is already applied inside
-        // ExecuteTrade.)
+        // Financing frictions are deducted from cash FIRST — turnover-proportional slippage + short-borrow +
+        // gross carry (the per-trade transaction cost is already applied inside ExecuteTrade) — THEN exposures
+        // are taken against the resulting post-cost NAV, so the cached ratios and the reward context reflect
+        // every cost rather than the pre-cost book.
         double financing = (_slippageCoefficient * turnoverNotional)
                            + (_borrowCostPerStep * shortNotional)
                            + (_holdingCostPerStep * grossNotional);
         if (financing > 0 && double.IsFinite(financing))
         {
             _cash = FromDouble(ToDouble(_cash) - financing);
+        }
+
+        double nav = ToDouble(_cash) + positionValue;
+        if (nav > 0 && double.IsFinite(nav))
+        {
+            _grossExposure = grossNotional / nav;
+            _shortExposure = shortNotional / nav;
+        }
+        else
+        {
+            _grossExposure = 0;
+            _shortExposure = 0;
         }
     }
 
@@ -245,6 +310,10 @@ public class PortfolioManagerEnvironment<T> : TradingEnvironment<T>
 
     /// <summary>Gross exposure after the most recent step (sum |position notional| / value).</summary>
     public double GrossExposure => _grossExposure;
+
+    /// <summary>Current portfolio value (cash + marked positions). Equals the initial capital right after
+    /// <see cref="TradingEnvironment{T}.Reset"/>, before any step — the pre-trade baseline a backtest seeds with.</summary>
+    public double CurrentValue => ToDouble(_portfolioValue);
 
     /// <summary>
     /// Resets the per-episode reward statistics and drawdown peak. Call after <see cref="TradingEnvironment{T}.Reset"/>

--- a/src/Finance/Trading/Environments/PortfolioManagerEnvironment.cs
+++ b/src/Finance/Trading/Environments/PortfolioManagerEnvironment.cs
@@ -87,7 +87,7 @@ public sealed class PortfolioManagerEnvironment<T> : TradingEnvironment<T>
 
     private static Tensor<T> BuildTensor(IReadOnlyList<double[]> assetPrices, IReadOnlyList<double[]>? featureColumns)
     {
-        ArgumentNullException.ThrowIfNull(assetPrices);
+        if (assetPrices is null) throw new ArgumentNullException(nameof(assetPrices));
         if (assetPrices.Count == 0)
         {
             throw new ArgumentException("At least one tradable asset series is required.", nameof(assetPrices));
@@ -174,7 +174,7 @@ public sealed class PortfolioManagerEnvironment<T> : TradingEnvironment<T>
                 w = 0.0;
             }
 
-            w = Math.Clamp(w, -1.0, 1.0);
+            w = MathPolyfill.Clamp(w, -1.0, 1.0);
             weights[i] = w;
             gross += Math.Abs(w);
         }
@@ -263,13 +263,13 @@ public sealed class PortfolioManagerEnvironment<T> : TradingEnvironment<T>
         double financing = (_slippageCoefficient * turnoverNotional)
                            + (_borrowCostPerStep * shortNotional)
                            + (_holdingCostPerStep * grossNotional);
-        if (financing > 0 && double.IsFinite(financing))
+        if (financing > 0 && (!double.IsNaN(financing) && !double.IsInfinity(financing)))
         {
             _cash = FromDouble(ToDouble(_cash) - financing);
         }
 
         double nav = ToDouble(_cash) + positionValue;
-        if (nav > 0 && double.IsFinite(nav))
+        if (nav > 0 && (!double.IsNaN(nav) && !double.IsInfinity(nav)))
         {
             _grossExposure = grossNotional / nav;
             _shortExposure = shortNotional / nav;
@@ -290,7 +290,7 @@ public sealed class PortfolioManagerEnvironment<T> : TradingEnvironment<T>
     {
         double previous = ToDouble(previousValue);
         double current = ToDouble(currentValue);
-        double portfolioReturn = previous > 0 && double.IsFinite(previous) && double.IsFinite(current)
+        double portfolioReturn = previous > 0 && (!double.IsNaN(previous) && !double.IsInfinity(previous)) && (!double.IsNaN(current) && !double.IsInfinity(current))
             ? (current - previous) / previous
             : 0.0;
 

--- a/src/Finance/Trading/Evaluation/PortfolioAgentTraining.cs
+++ b/src/Finance/Trading/Evaluation/PortfolioAgentTraining.cs
@@ -53,8 +53,8 @@ public static class PortfolioAgentTrainer
     /// </summary>
     public static double Train<T>(IPortfolioAgent<T> agent, PortfolioManagerEnvironment<T> environment, int episodes)
     {
-        ArgumentNullException.ThrowIfNull(agent);
-        ArgumentNullException.ThrowIfNull(environment);
+        if (agent is null) throw new ArgumentNullException(nameof(agent));
+        if (environment is null) throw new ArgumentNullException(nameof(environment));
         if (episodes <= 0)
         {
             throw new ArgumentOutOfRangeException(nameof(episodes));
@@ -145,10 +145,10 @@ public static class PortfolioExperimentRunner
         Func<int, int, IPortfolioAgent<T>> agentFactory,
         int trainEpisodes)
     {
-        ArgumentNullException.ThrowIfNull(trainAssetPrices);
-        ArgumentNullException.ThrowIfNull(holdoutAssetPrices);
-        ArgumentNullException.ThrowIfNull(experiments);
-        ArgumentNullException.ThrowIfNull(agentFactory);
+        if (trainAssetPrices is null) throw new ArgumentNullException(nameof(trainAssetPrices));
+        if (holdoutAssetPrices is null) throw new ArgumentNullException(nameof(holdoutAssetPrices));
+        if (experiments is null) throw new ArgumentNullException(nameof(experiments));
+        if (agentFactory is null) throw new ArgumentNullException(nameof(agentFactory));
 
         // Train and holdout must share the same observation schema — same tradable-asset count and the same
         // number of feature columns — or the agent trained on one cannot be evaluated on the other.

--- a/src/Finance/Trading/Evaluation/PortfolioAgentTraining.cs
+++ b/src/Finance/Trading/Evaluation/PortfolioAgentTraining.cs
@@ -88,10 +88,35 @@ public static class PortfolioAgentTrainer
     }
 }
 
-/// <summary>One experiment in the greenfield trading-agent research: a named objective to train + evaluate.
-/// Swapping the <see cref="Reward"/> (and, later, frictions / policy / algorithm) is how the options become
-/// experiments ranked on the holdout rather than an either/or pick.</summary>
-public sealed record PortfolioExperiment(string Name, IPortfolioReward Reward);
+/// <summary>The friction knobs for an experiment's environment — a market-realism axis. Cheaper frictions flatter
+/// a churning policy; heavier ones reward patience. Sweeping them is how "is the edge real net of costs?" becomes
+/// an experiment rather than an assumption.</summary>
+public sealed record PortfolioFrictions(
+    double TransactionCost = 0.001,
+    double SlippageCoefficient = 0.0005,
+    double AnnualBorrowCost = 0.03,
+    double AnnualHoldingCost = 0.0);
+
+/// <summary>One experiment in the greenfield trading-agent research: a named environment configuration to train +
+/// evaluate. Every SOTA-relevant axis is a knob here — objective (<see cref="Reward"/>), leverage budget
+/// (<see cref="MaxLeverage"/>), and market frictions (<see cref="Frictions"/>) — so the options become experiments
+/// ranked on the holdout rather than an either/or pick. (Policy/algorithm is the agent factory's axis.)</summary>
+public sealed record PortfolioExperiment(
+    string Name,
+    IPortfolioReward Reward,
+    double MaxLeverage = 1.0,
+    PortfolioFrictions? Frictions = null)
+{
+    /// <summary>Builds the environment this experiment specifies over the given data.</summary>
+    public PortfolioManagerEnvironment<T> BuildEnvironment<T>(
+        IReadOnlyList<double[]> assetPrices, IReadOnlyList<double[]>? featureColumns, int windowSize, double initialCapital)
+    {
+        var f = Frictions ?? new PortfolioFrictions();
+        return new PortfolioManagerEnvironment<T>(
+            assetPrices, featureColumns, windowSize, initialCapital, Reward, MaxLeverage,
+            f.TransactionCost, f.SlippageCoefficient, f.AnnualBorrowCost, f.AnnualHoldingCost);
+    }
+}
 
 /// <summary>The holdout result of one experiment: the trained agent's performance vs the no-skill equal-weight
 /// baseline on the untouched holdout, and whether it beat the baseline (higher Sharpe).</summary>
@@ -116,7 +141,6 @@ public static class PortfolioExperimentRunner
         IReadOnlyList<double[]>? holdoutFeatureColumns,
         int windowSize,
         double initialCapital,
-        double maxLeverage,
         IReadOnlyList<PortfolioExperiment> experiments,
         Func<int, int, IPortfolioAgent<T>> agentFactory,
         int trainEpisodes)
@@ -131,20 +155,18 @@ public static class PortfolioExperimentRunner
 
         foreach (var experiment in experiments)
         {
-            // Train a fresh agent on the training split under this experiment's objective.
-            var trainEnv = new PortfolioManagerEnvironment<T>(
-                trainAssetPrices, trainFeatureColumns, windowSize, initialCapital, experiment.Reward, maxLeverage);
+            // Each experiment fully specifies its environment (reward + leverage + frictions), so the harness
+            // sweeps all those axes, not just the objective.
+            var trainEnv = experiment.BuildEnvironment<T>(trainAssetPrices, trainFeatureColumns, windowSize, initialCapital);
             var agent = agentFactory(trainEnv.ObservationSpaceDimension, trainEnv.ActionSpaceSize);
             PortfolioAgentTrainer.Train(agent, trainEnv, trainEpisodes);
 
             // Evaluate the trained agent on the untouched holdout (greedy — no exploration).
-            var agentEnv = new PortfolioManagerEnvironment<T>(
-                holdoutAssetPrices, holdoutFeatureColumns, windowSize, initialCapital, experiment.Reward, maxLeverage);
+            var agentEnv = experiment.BuildEnvironment<T>(holdoutAssetPrices, holdoutFeatureColumns, windowSize, initialCapital);
             var agentResult = PortfolioBacktest.Run(agentEnv, s => agent.SelectAction(s, explore: false));
 
-            // The no-skill control on the SAME holdout.
-            var baseEnv = new PortfolioManagerEnvironment<T>(
-                holdoutAssetPrices, holdoutFeatureColumns, windowSize, initialCapital, experiment.Reward, maxLeverage);
+            // The no-skill control on the SAME holdout environment (same frictions/leverage).
+            var baseEnv = experiment.BuildEnvironment<T>(holdoutAssetPrices, holdoutFeatureColumns, windowSize, initialCapital);
             var baseResult = PortfolioBacktest.Run(baseEnv, BaselinePolicies.EqualWeight<T>(tradableCount));
 
             outcomes.Add(new PortfolioExperimentOutcome(

--- a/src/Finance/Trading/Evaluation/PortfolioAgentTraining.cs
+++ b/src/Finance/Trading/Evaluation/PortfolioAgentTraining.cs
@@ -150,6 +150,24 @@ public static class PortfolioExperimentRunner
         ArgumentNullException.ThrowIfNull(experiments);
         ArgumentNullException.ThrowIfNull(agentFactory);
 
+        // Train and holdout must share the same observation schema — same tradable-asset count and the same
+        // number of feature columns — or the agent trained on one cannot be evaluated on the other.
+        if (trainAssetPrices.Count != holdoutAssetPrices.Count)
+        {
+            throw new ArgumentException(
+                $"Train and holdout must have the same number of tradable assets ({trainAssetPrices.Count} vs {holdoutAssetPrices.Count}).",
+                nameof(holdoutAssetPrices));
+        }
+
+        int trainFeatures = trainFeatureColumns?.Count ?? 0;
+        int holdoutFeatures = holdoutFeatureColumns?.Count ?? 0;
+        if (trainFeatures != holdoutFeatures)
+        {
+            throw new ArgumentException(
+                $"Train and holdout must have the same number of feature columns ({trainFeatures} vs {holdoutFeatures}).",
+                nameof(holdoutFeatureColumns));
+        }
+
         int tradableCount = holdoutAssetPrices.Count;
         var outcomes = new List<PortfolioExperimentOutcome>(experiments.Count);
 
@@ -161,7 +179,10 @@ public static class PortfolioExperimentRunner
             var agent = agentFactory(trainEnv.ObservationSpaceDimension, trainEnv.ActionSpaceSize);
             PortfolioAgentTrainer.Train(agent, trainEnv, trainEpisodes);
 
-            // Evaluate the trained agent on the untouched holdout (greedy — no exploration).
+            // Evaluate the trained agent on the untouched holdout (greedy — no exploration). Reset the agent's
+            // per-episode state first so a recurrent policy starts the holdout with a clean hidden state rather
+            // than one carried over from the last training step.
+            agent.ResetEpisode();
             var agentEnv = experiment.BuildEnvironment<T>(holdoutAssetPrices, holdoutFeatureColumns, windowSize, initialCapital);
             var agentResult = PortfolioBacktest.Run(agentEnv, s => agent.SelectAction(s, explore: false));
 

--- a/src/Finance/Trading/Evaluation/PortfolioAgentTraining.cs
+++ b/src/Finance/Trading/Evaluation/PortfolioAgentTraining.cs
@@ -1,0 +1,157 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using AiDotNet.Finance.Trading.Environments;
+using AiDotNet.Finance.Trading.Rewards;
+using AiDotNet.Interfaces;
+using AiDotNet.Tensors.LinearAlgebra;
+
+namespace AiDotNet.Finance.Trading.Evaluation;
+
+/// <summary>
+/// The MINIMAL agent surface the portfolio trainer needs: choose an action, remember a transition, learn, and
+/// reset per episode. Kept narrow (rather than the full <see cref="IRLAgent{T}"/>, which pulls in the entire
+/// IFullModel surface) so the trainer depends on nothing more than the RL loop, and a test double is trivial.
+/// Wrap any real AiDotNet agent with <see cref="PortfolioAgent.From{T}"/>.
+/// </summary>
+public interface IPortfolioAgent<T>
+{
+    Vector<T> SelectAction(Vector<T> state, bool explore);
+    void StoreExperience(Vector<T> state, Vector<T> action, T reward, Vector<T> nextState, bool done);
+    T Train();
+    void ResetEpisode();
+}
+
+/// <summary>Adapts a full <see cref="IRLAgent{T}"/> (PPO/SAC/TD3/…) to the narrow <see cref="IPortfolioAgent{T}"/>.</summary>
+public static class PortfolioAgent
+{
+    public static IPortfolioAgent<T> From<T>(IRLAgent<T> agent) => new RlAgentAdapter<T>(agent);
+
+    private sealed class RlAgentAdapter<T> : IPortfolioAgent<T>
+    {
+        private readonly IRLAgent<T> _agent;
+        public RlAgentAdapter(IRLAgent<T> agent) => _agent = agent ?? throw new ArgumentNullException(nameof(agent));
+        public Vector<T> SelectAction(Vector<T> state, bool explore) => _agent.SelectAction(state, explore);
+        public void StoreExperience(Vector<T> state, Vector<T> action, T reward, Vector<T> nextState, bool done)
+            => _agent.StoreExperience(state, action, reward, nextState, done);
+        public T Train() => _agent.Train();
+        public void ResetEpisode() => _agent.ResetEpisode();
+    }
+}
+
+/// <summary>
+/// Drives one agent through a <see cref="PortfolioManagerEnvironment{T}"/> for a number of episodes — the
+/// standard experience-collection loop (select action, step, store transition, learn).
+/// </summary>
+public static class PortfolioAgentTrainer
+{
+    /// <summary>
+    /// Trains <paramref name="agent"/> on <paramref name="environment"/> for <paramref name="episodes"/> passes.
+    /// Each episode resets the environment (and its per-episode reward/peak state), then loops
+    /// select → step → store → learn until the episode ends. Returns the mean episode return (sum of rewards),
+    /// a rough progress signal — NOT a performance claim; rank agents on a held-out <see cref="PortfolioBacktest"/>.
+    /// </summary>
+    public static double Train<T>(IPortfolioAgent<T> agent, PortfolioManagerEnvironment<T> environment, int episodes)
+    {
+        ArgumentNullException.ThrowIfNull(agent);
+        ArgumentNullException.ThrowIfNull(environment);
+        if (episodes <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(episodes));
+        }
+
+        double totalEpisodeReturn = 0;
+        for (int ep = 0; ep < episodes; ep++)
+        {
+            environment.ResetEpisodeState();
+            agent.ResetEpisode();
+            var state = environment.Reset();
+
+            bool done = false;
+            double episodeReturn = 0;
+            while (!done)
+            {
+                var action = agent.SelectAction(state, explore: true);
+                var (nextState, reward, isDone, _) = environment.Step(action);
+                agent.StoreExperience(state, action, reward, nextState, isDone);
+                agent.Train();
+
+                episodeReturn += Convert.ToDouble(reward);
+                state = nextState;
+                done = isDone;
+            }
+
+            totalEpisodeReturn += episodeReturn;
+        }
+
+        return totalEpisodeReturn / episodes;
+    }
+}
+
+/// <summary>One experiment in the greenfield trading-agent research: a named objective to train + evaluate.
+/// Swapping the <see cref="Reward"/> (and, later, frictions / policy / algorithm) is how the options become
+/// experiments ranked on the holdout rather than an either/or pick.</summary>
+public sealed record PortfolioExperiment(string Name, IPortfolioReward Reward);
+
+/// <summary>The holdout result of one experiment: the trained agent's performance vs the no-skill equal-weight
+/// baseline on the untouched holdout, and whether it beat the baseline (higher Sharpe).</summary>
+public sealed record PortfolioExperimentOutcome(
+    string Name,
+    PortfolioBacktestResult Agent,
+    PortfolioBacktestResult BaselineEqualWeight,
+    bool BeatBaseline);
+
+/// <summary>
+/// Runs a set of reward experiments: for each, train a FRESH agent on the training split, then evaluate it and
+/// the equal-weight baseline on the UNTOUCHED holdout split, and rank by holdout Sharpe. This is the honest-eval
+/// harness for the trading-agent research — chronological train/holdout, vs-baseline, ranked on risk-adjusted
+/// holdout performance, never training loss.
+/// </summary>
+public static class PortfolioExperimentRunner
+{
+    public static IReadOnlyList<PortfolioExperimentOutcome> Run<T>(
+        IReadOnlyList<double[]> trainAssetPrices,
+        IReadOnlyList<double[]>? trainFeatureColumns,
+        IReadOnlyList<double[]> holdoutAssetPrices,
+        IReadOnlyList<double[]>? holdoutFeatureColumns,
+        int windowSize,
+        double initialCapital,
+        double maxLeverage,
+        IReadOnlyList<PortfolioExperiment> experiments,
+        Func<int, int, IPortfolioAgent<T>> agentFactory,
+        int trainEpisodes)
+    {
+        ArgumentNullException.ThrowIfNull(trainAssetPrices);
+        ArgumentNullException.ThrowIfNull(holdoutAssetPrices);
+        ArgumentNullException.ThrowIfNull(experiments);
+        ArgumentNullException.ThrowIfNull(agentFactory);
+
+        int tradableCount = holdoutAssetPrices.Count;
+        var outcomes = new List<PortfolioExperimentOutcome>(experiments.Count);
+
+        foreach (var experiment in experiments)
+        {
+            // Train a fresh agent on the training split under this experiment's objective.
+            var trainEnv = new PortfolioManagerEnvironment<T>(
+                trainAssetPrices, trainFeatureColumns, windowSize, initialCapital, experiment.Reward, maxLeverage);
+            var agent = agentFactory(trainEnv.ObservationSpaceDimension, trainEnv.ActionSpaceSize);
+            PortfolioAgentTrainer.Train(agent, trainEnv, trainEpisodes);
+
+            // Evaluate the trained agent on the untouched holdout (greedy — no exploration).
+            var agentEnv = new PortfolioManagerEnvironment<T>(
+                holdoutAssetPrices, holdoutFeatureColumns, windowSize, initialCapital, experiment.Reward, maxLeverage);
+            var agentResult = PortfolioBacktest.Run(agentEnv, s => agent.SelectAction(s, explore: false));
+
+            // The no-skill control on the SAME holdout.
+            var baseEnv = new PortfolioManagerEnvironment<T>(
+                holdoutAssetPrices, holdoutFeatureColumns, windowSize, initialCapital, experiment.Reward, maxLeverage);
+            var baseResult = PortfolioBacktest.Run(baseEnv, BaselinePolicies.EqualWeight<T>(tradableCount));
+
+            outcomes.Add(new PortfolioExperimentOutcome(
+                experiment.Name, agentResult, baseResult, agentResult.AnnualizedSharpe > baseResult.AnnualizedSharpe));
+        }
+
+        // Best holdout Sharpe first.
+        return outcomes.OrderByDescending(o => o.Agent.AnnualizedSharpe).ToList();
+    }
+}

--- a/src/Finance/Trading/Evaluation/PortfolioBacktest.cs
+++ b/src/Finance/Trading/Evaluation/PortfolioBacktest.cs
@@ -160,4 +160,54 @@ public static class BaselinePolicies
     /// <summary>Flat (all-cash) policy: never take a position. The zero-risk control.</summary>
     public static Func<Vector<T>, Vector<T>> Flat<T>(int tradableCount)
         => _ => new Vector<T>(tradableCount);
+
+    /// <summary>
+    /// Cross-sectional MOMENTUM baseline: go equal-weight long the tradable assets whose price rose over the
+    /// observation window (recent winners), flat the rest. A far harder benchmark than equal-weight — momentum
+    /// is a real, persistent effect — so beating it on the holdout is a much stronger signal of skill.
+    /// <para>
+    /// Decodes the environment's observation layout: the first <c>windowSize * totalColumns</c> entries are the
+    /// per-step price/feature window (row-major by time then asset), so asset i's window-start and window-end
+    /// prices are <c>obs[i]</c> and <c>obs[(windowSize-1)*totalColumns + i]</c>. <paramref name="totalColumns"/>
+    /// is the env's NumAssets (tradable + feature columns); only the first <paramref name="tradableCount"/> are
+    /// traded.
+    /// </para>
+    /// </summary>
+    public static Func<Vector<T>, Vector<T>> Momentum<T>(int windowSize, int totalColumns, int tradableCount)
+    {
+        if (windowSize < 2) throw new ArgumentOutOfRangeException(nameof(windowSize), "Momentum needs a window of at least 2.");
+        if (tradableCount <= 0 || tradableCount > totalColumns) throw new ArgumentOutOfRangeException(nameof(tradableCount));
+
+        int lastRow = (windowSize - 1) * totalColumns;
+        return state =>
+        {
+            var winners = new bool[tradableCount];
+            int count = 0;
+            for (int i = 0; i < tradableCount; i++)
+            {
+                double first = Convert.ToDouble(state[i]);
+                double last = Convert.ToDouble(state[lastRow + i]);
+                if (last > first)
+                {
+                    winners[i] = true;
+                    count++;
+                }
+            }
+
+            var action = new Vector<T>(tradableCount);
+            if (count > 0)
+            {
+                var w = (T)Convert.ChangeType(1.0 / count, typeof(T), System.Globalization.CultureInfo.InvariantCulture);
+                for (int i = 0; i < tradableCount; i++)
+                {
+                    if (winners[i])
+                    {
+                        action[i] = w;
+                    }
+                }
+            }
+
+            return action;
+        };
+    }
 }

--- a/src/Finance/Trading/Evaluation/PortfolioBacktest.cs
+++ b/src/Finance/Trading/Evaluation/PortfolioBacktest.cs
@@ -14,7 +14,9 @@ public sealed record PortfolioBacktestResult(
     double FinalValue,
     double TotalReturn,
     double AnnualizedSharpe,
+    double AnnualizedSortino,
     double MaxDrawdown,
+    double Calmar,
     double AverageTurnover,
     int Steps);
 
@@ -75,15 +77,15 @@ public static class PortfolioBacktest
         if (values.Count < 2)
         {
             double single = values.Count == 1 ? values[0] : 0.0;
-            return new PortfolioBacktestResult(single, 0.0, 0.0, 0.0, 0.0, steps);
+            return new PortfolioBacktestResult(single, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, steps);
         }
 
         double start = values[0];
         double final = values[^1];
         double totalReturn = start > 0 ? (final - start) / start : 0.0;
 
-        // Per-step returns → annualized Sharpe.
-        double sumR = 0, sumR2 = 0;
+        // Per-step returns → annualized Sharpe + Sortino (Sortino penalizes only DOWNSIDE volatility).
+        double sumR = 0, sumR2 = 0, sumDown2 = 0;
         int n = 0;
         for (int i = 1; i < values.Count; i++)
         {
@@ -96,16 +98,22 @@ public static class PortfolioBacktest
             double r = (values[i] - prev) / prev;
             sumR += r;
             sumR2 += r * r;
+            if (r < 0)
+            {
+                sumDown2 += r * r;
+            }
             n++;
         }
 
-        double sharpe = 0.0;
+        double sharpe = 0.0, sortino = 0.0, mean = 0.0;
         if (n > 1)
         {
-            double mean = sumR / n;
+            mean = sumR / n;
             double variance = Math.Max(0.0, (sumR2 / n) - (mean * mean));
             double std = Math.Sqrt(variance);
             sharpe = std > 1e-12 ? (mean / std) * Math.Sqrt(PeriodsPerYear) : 0.0;
+            double downsideDev = Math.Sqrt(sumDown2 / n);
+            sortino = downsideDev > 1e-12 ? (mean / downsideDev) * Math.Sqrt(PeriodsPerYear) : 0.0;
         }
 
         // Max drawdown from the running peak.
@@ -123,8 +131,12 @@ public static class PortfolioBacktest
             }
         }
 
+        // Calmar = annualized return / max drawdown (return per unit of worst-case loss).
+        double annualizedReturn = mean * PeriodsPerYear;
+        double calmar = maxDd > 1e-12 ? annualizedReturn / maxDd : 0.0;
+
         double avgTurnover = steps > 0 ? turnoverSum / steps : 0.0;
-        return new PortfolioBacktestResult(final, totalReturn, sharpe, maxDd, avgTurnover, steps);
+        return new PortfolioBacktestResult(final, totalReturn, sharpe, sortino, maxDd, calmar, avgTurnover, steps);
     }
 }
 
@@ -204,6 +216,63 @@ public static class BaselinePolicies
                     {
                         action[i] = w;
                     }
+                }
+            }
+
+            return action;
+        };
+    }
+
+    /// <summary>
+    /// RISK-PARITY (inverse-volatility) baseline: allocate long weights proportional to 1/σ of each tradable
+    /// asset's recent returns, so every name contributes roughly equal risk (calmer assets get more capital).
+    /// A standard institutional benchmark that usually earns a HIGHER Sharpe than equal-weight, making it a
+    /// tougher control. Decodes the same observation window as <see cref="Momentum{T}"/>.
+    /// </summary>
+    public static Func<Vector<T>, Vector<T>> RiskParity<T>(int windowSize, int totalColumns, int tradableCount)
+    {
+        if (windowSize < 3) throw new ArgumentOutOfRangeException(nameof(windowSize), "Risk-parity needs a window of at least 3.");
+        if (tradableCount <= 0 || tradableCount > totalColumns) throw new ArgumentOutOfRangeException(nameof(tradableCount));
+
+        return state =>
+        {
+            var invVol = new double[tradableCount];
+            double sum = 0;
+            for (int i = 0; i < tradableCount; i++)
+            {
+                // Per-step returns of asset i across the window.
+                double sr = 0, sr2 = 0;
+                int m = 0;
+                for (int t = 1; t < windowSize; t++)
+                {
+                    double prev = Convert.ToDouble(state[(t - 1) * totalColumns + i]);
+                    double cur = Convert.ToDouble(state[t * totalColumns + i]);
+                    if (prev > 0)
+                    {
+                        double r = (cur - prev) / prev;
+                        sr += r;
+                        sr2 += r * r;
+                        m++;
+                    }
+                }
+
+                double vol = 1e-6;
+                if (m > 1)
+                {
+                    double mu = sr / m;
+                    vol = Math.Sqrt(Math.Max(0.0, (sr2 / m) - (mu * mu))) + 1e-6;
+                }
+
+                invVol[i] = 1.0 / vol;
+                sum += invVol[i];
+            }
+
+            var action = new Vector<T>(tradableCount);
+            if (sum > 0)
+            {
+                for (int i = 0; i < tradableCount; i++)
+                {
+                    action[i] = (T)Convert.ChangeType(invVol[i] / sum, typeof(T), System.Globalization.CultureInfo.InvariantCulture);
                 }
             }
 

--- a/src/Finance/Trading/Evaluation/PortfolioBacktest.cs
+++ b/src/Finance/Trading/Evaluation/PortfolioBacktest.cs
@@ -46,7 +46,9 @@ public static class PortfolioBacktest
         environment.ResetEpisodeState();
         var state = environment.Reset();
 
-        var values = new List<double>();
+        // Seed with the pre-trade baseline (initial capital) so total return, Sharpe, and drawdown all include
+        // the very first step's move rather than starting the series one step in.
+        var values = new List<double> { environment.CurrentValue };
         double turnoverSum = 0;
         int steps = 0;
         bool done = false;

--- a/src/Finance/Trading/Evaluation/PortfolioBacktest.cs
+++ b/src/Finance/Trading/Evaluation/PortfolioBacktest.cs
@@ -133,8 +133,18 @@ public static class PortfolioBacktest
             }
         }
 
-        // Calmar = annualized return / max drawdown (return per unit of worst-case loss).
-        double annualizedReturn = mean * PeriodsPerYear;
+        // Calmar = annualized return / max drawdown (return per unit of worst-case loss). Annualize the
+        // COMPOUNDED total return over the n observed periods geometrically, not the arithmetic per-step mean.
+        double annualizedReturn;
+        if (n > 0 && (1.0 + totalReturn) > 0.0)
+        {
+            annualizedReturn = Math.Pow(1.0 + totalReturn, PeriodsPerYear / n) - 1.0;
+        }
+        else
+        {
+            annualizedReturn = mean * PeriodsPerYear; // degenerate (total loss / no periods): fall back to linear.
+        }
+
         double calmar = maxDd > 1e-12 ? annualizedReturn / maxDd : 0.0;
 
         double avgTurnover = steps > 0 ? turnoverSum / steps : 0.0;
@@ -258,14 +268,19 @@ public static class BaselinePolicies
                     }
                 }
 
-                double vol = 1e-6;
+                // Exclude any asset without enough valid returns to estimate a volatility — otherwise a
+                // degenerate near-zero vol would hand it a runaway inverse-vol weight. Excluded = zero weight.
                 if (m > 1)
                 {
                     double mu = sr / m;
-                    vol = Math.Sqrt(Math.Max(0.0, (sr2 / m) - (mu * mu))) + 1e-6;
+                    double vol = Math.Sqrt(Math.Max(0.0, (sr2 / m) - (mu * mu))) + 1e-6;
+                    invVol[i] = 1.0 / vol;
+                }
+                else
+                {
+                    invVol[i] = 0.0;
                 }
 
-                invVol[i] = 1.0 / vol;
                 sum += invVol[i];
             }
 

--- a/src/Finance/Trading/Evaluation/PortfolioBacktest.cs
+++ b/src/Finance/Trading/Evaluation/PortfolioBacktest.cs
@@ -1,0 +1,163 @@
+using System;
+using System.Collections.Generic;
+using AiDotNet.Finance.Trading.Environments;
+using AiDotNet.Tensors.LinearAlgebra;
+
+namespace AiDotNet.Finance.Trading.Evaluation;
+
+/// <summary>
+/// Risk-and-cost-aware performance of running one policy through a <see cref="PortfolioManagerEnvironment{T}"/>
+/// once. These are the numbers an experiment is RANKED on when comparing candidate agents/rewards on an
+/// untouched holdout — never training loss.
+/// </summary>
+public sealed record PortfolioBacktestResult(
+    double FinalValue,
+    double TotalReturn,
+    double AnnualizedSharpe,
+    double MaxDrawdown,
+    double AverageTurnover,
+    int Steps);
+
+/// <summary>
+/// Runs a policy through a portfolio environment deterministically and scores it. A "policy" is just
+/// <c>state → action</c>, so this evaluates a scripted baseline and a trained RL agent
+/// (<c>s => agent.SelectAction(s, training:false)</c>) the same way — the honest-eval seam for the greenfield
+/// trading-agent research: hold out a chronological tail, run each candidate, and compare on these metrics.
+/// </summary>
+public static class PortfolioBacktest
+{
+    /// <summary>Trading days per year, for annualizing the Sharpe ratio.</summary>
+    private const double PeriodsPerYear = 252.0;
+
+    /// <summary>
+    /// Runs <paramref name="policy"/> through <paramref name="environment"/> for one full episode and returns
+    /// its risk/cost-adjusted performance. The environment is reset first; its per-episode reward/peak state is
+    /// cleared so a reused instance scores cleanly.
+    /// </summary>
+    public static PortfolioBacktestResult Run<T>(
+        PortfolioManagerEnvironment<T> environment,
+        Func<Vector<T>, Vector<T>> policy)
+    {
+        ArgumentNullException.ThrowIfNull(environment);
+        ArgumentNullException.ThrowIfNull(policy);
+
+        environment.ResetEpisodeState();
+        var state = environment.Reset();
+
+        var values = new List<double>();
+        double turnoverSum = 0;
+        int steps = 0;
+        bool done = false;
+
+        while (!done)
+        {
+            var action = policy(state);
+            var (nextState, _, isDone, info) = environment.Step(action);
+
+            double value = info.TryGetValue("portfolioValue", out var pv) ? Convert.ToDouble(pv) : double.NaN;
+            if (!double.IsNaN(value))
+            {
+                values.Add(value);
+            }
+
+            turnoverSum += environment.LastTurnover;
+            steps++;
+            state = nextState;
+            done = isDone;
+        }
+
+        return Score(values, turnoverSum, steps);
+    }
+
+    /// <summary>Computes the performance metrics from a per-step portfolio-value series.</summary>
+    private static PortfolioBacktestResult Score(IReadOnlyList<double> values, double turnoverSum, int steps)
+    {
+        if (values.Count < 2)
+        {
+            double single = values.Count == 1 ? values[0] : 0.0;
+            return new PortfolioBacktestResult(single, 0.0, 0.0, 0.0, 0.0, steps);
+        }
+
+        double start = values[0];
+        double final = values[^1];
+        double totalReturn = start > 0 ? (final - start) / start : 0.0;
+
+        // Per-step returns → annualized Sharpe.
+        double sumR = 0, sumR2 = 0;
+        int n = 0;
+        for (int i = 1; i < values.Count; i++)
+        {
+            double prev = values[i - 1];
+            if (prev <= 0)
+            {
+                continue;
+            }
+
+            double r = (values[i] - prev) / prev;
+            sumR += r;
+            sumR2 += r * r;
+            n++;
+        }
+
+        double sharpe = 0.0;
+        if (n > 1)
+        {
+            double mean = sumR / n;
+            double variance = Math.Max(0.0, (sumR2 / n) - (mean * mean));
+            double std = Math.Sqrt(variance);
+            sharpe = std > 1e-12 ? (mean / std) * Math.Sqrt(PeriodsPerYear) : 0.0;
+        }
+
+        // Max drawdown from the running peak.
+        double peak = values[0], maxDd = 0.0;
+        foreach (var v in values)
+        {
+            if (v > peak)
+            {
+                peak = v;
+            }
+
+            if (peak > 0)
+            {
+                maxDd = Math.Max(maxDd, (peak - v) / peak);
+            }
+        }
+
+        double avgTurnover = steps > 0 ? turnoverSum / steps : 0.0;
+        return new PortfolioBacktestResult(final, totalReturn, sharpe, maxDd, avgTurnover, steps);
+    }
+}
+
+/// <summary>
+/// No-skill baseline policies to rank a learned agent against. If a trained portfolio manager cannot beat these
+/// on the untouched holdout, it has learned nothing worth trading (see the honest-eval discipline).
+/// </summary>
+public static class BaselinePolicies
+{
+    /// <summary>Equal-weight long book: allocate 1/N to each of the <paramref name="tradableCount"/> assets every
+    /// step (the environment holds the mix, so this is effectively rebalanced buy-and-hold — the classic
+    /// no-skill control).</summary>
+    public static Func<Vector<T>, Vector<T>> EqualWeight<T>(int tradableCount)
+    {
+        if (tradableCount <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(tradableCount));
+        }
+
+        var w = (T)Convert.ChangeType(1.0 / tradableCount, typeof(T), System.Globalization.CultureInfo.InvariantCulture);
+        return _ =>
+        {
+            var a = new Vector<T>(tradableCount);
+            for (int i = 0; i < tradableCount; i++)
+            {
+                a[i] = w;
+            }
+
+            return a;
+        };
+    }
+
+    /// <summary>Flat (all-cash) policy: never take a position. The zero-risk control.</summary>
+    public static Func<Vector<T>, Vector<T>> Flat<T>(int tradableCount)
+        => _ => new Vector<T>(tradableCount);
+}

--- a/src/Finance/Trading/Evaluation/PortfolioBacktest.cs
+++ b/src/Finance/Trading/Evaluation/PortfolioBacktest.cs
@@ -40,8 +40,8 @@ public static class PortfolioBacktest
         PortfolioManagerEnvironment<T> environment,
         Func<Vector<T>, Vector<T>> policy)
     {
-        ArgumentNullException.ThrowIfNull(environment);
-        ArgumentNullException.ThrowIfNull(policy);
+        if (environment is null) throw new ArgumentNullException(nameof(environment));
+        if (policy is null) throw new ArgumentNullException(nameof(policy));
 
         environment.ResetEpisodeState();
         var state = environment.Reset();

--- a/src/Finance/Trading/Evaluation/PortfolioStudy.cs
+++ b/src/Finance/Trading/Evaluation/PortfolioStudy.cs
@@ -1,0 +1,81 @@
+using System;
+using System.Collections.Generic;
+using AiDotNet.Finance.Trading.Rewards;
+
+namespace AiDotNet.Finance.Trading.Evaluation;
+
+/// <summary>
+/// Generates the cross-product of experiment axes — objective x leverage x frictions — as a flat list of
+/// <see cref="PortfolioExperiment"/>. Turns "which reward / how much leverage / what cost regime?" into a swept
+/// grid ranked on the holdout, the research framing for the greenfield trading-agent core.
+/// </summary>
+public static class PortfolioExperimentMatrix
+{
+    public static List<PortfolioExperiment> Cross(
+        IReadOnlyList<(string Name, IPortfolioReward Reward)> rewards,
+        IReadOnlyList<double>? leverages = null,
+        IReadOnlyList<(string Name, PortfolioFrictions Frictions)>? frictions = null)
+    {
+        ArgumentNullException.ThrowIfNull(rewards);
+        if (rewards.Count == 0)
+        {
+            throw new ArgumentException("At least one reward is required.", nameof(rewards));
+        }
+
+        var levels = leverages is { Count: > 0 } ? leverages : new List<double> { 1.0 };
+        var frics = frictions is { Count: > 0 } ? frictions : new List<(string, PortfolioFrictions)> { ("default", new PortfolioFrictions()) };
+
+        var experiments = new List<PortfolioExperiment>(rewards.Count * levels.Count * frics.Count);
+        foreach (var (rewardName, reward) in rewards)
+        {
+            foreach (var lev in levels)
+            {
+                foreach (var (fricName, fric) in frics)
+                {
+                    experiments.Add(new PortfolioExperiment(
+                        $"{rewardName}|lev{lev:0.##}|{fricName}", reward, lev, fric));
+                }
+            }
+        }
+
+        return experiments;
+    }
+}
+
+/// <summary>
+/// One-call research entry point: given the FULL history, split it walk-forward (train on the past, hold out a
+/// strictly-later tail with an embargo gap), run every experiment through
+/// <see cref="PortfolioExperimentRunner"/>, and return the outcomes ranked by holdout Sharpe. This is the honest
+/// study loop end-to-end — the seam a researcher calls to compare candidate objectives / leverage / frictions /
+/// agents on data the agents never trained on.
+/// </summary>
+public static class PortfolioStudy
+{
+    public static IReadOnlyList<PortfolioExperimentOutcome> Run<T>(
+        IReadOnlyList<double[]> assetPrices,
+        IReadOnlyList<double[]>? featureColumns,
+        double trainFraction,
+        int embargo,
+        int windowSize,
+        double initialCapital,
+        IReadOnlyList<PortfolioExperiment> experiments,
+        Func<int, int, IPortfolioAgent<T>> agentFactory,
+        int trainEpisodes)
+    {
+        ArgumentNullException.ThrowIfNull(assetPrices);
+
+        var (trainPrices, holdoutPrices) = WalkForwardSplit.Split(assetPrices, trainFraction, embargo);
+
+        List<double[]>? trainFeatures = null, holdoutFeatures = null;
+        if (featureColumns is { Count: > 0 })
+        {
+            var (tf, hf) = WalkForwardSplit.Split(featureColumns, trainFraction, embargo);
+            trainFeatures = tf;
+            holdoutFeatures = hf;
+        }
+
+        return PortfolioExperimentRunner.Run(
+            trainPrices, trainFeatures, holdoutPrices, holdoutFeatures,
+            windowSize, initialCapital, experiments, agentFactory, trainEpisodes);
+    }
+}

--- a/src/Finance/Trading/Evaluation/PortfolioStudy.cs
+++ b/src/Finance/Trading/Evaluation/PortfolioStudy.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using AiDotNet.Finance.Trading.Rewards;
 
 namespace AiDotNet.Finance.Trading.Evaluation;
@@ -32,8 +33,10 @@ public static class PortfolioExperimentMatrix
             {
                 foreach (var (fricName, fric) in frics)
                 {
+                    // Round-trip, culture-invariant leverage in the name so it is lossless (no rounding) and
+                    // stable across locales (never a comma decimal separator).
                     experiments.Add(new PortfolioExperiment(
-                        $"{rewardName}|lev{lev:0.##}|{fricName}", reward, lev, fric));
+                        $"{rewardName}|lev{lev.ToString("R", CultureInfo.InvariantCulture)}|{fricName}", reward, lev, fric));
                 }
             }
         }
@@ -63,6 +66,23 @@ public static class PortfolioStudy
         int trainEpisodes)
     {
         ArgumentNullException.ThrowIfNull(assetPrices);
+
+        // Feature columns must align to the price rows (same time length) BEFORE splitting, or the train/holdout
+        // features would not line up with the prices they annotate. (WalkForwardSplit checks equal length within
+        // each set; this checks price-vs-feature alignment across the two.)
+        if (featureColumns is { Count: > 0 } && assetPrices.Count > 0)
+        {
+            int priceLength = assetPrices[0]?.Length ?? 0;
+            foreach (var col in featureColumns)
+            {
+                if (col is null || col.Length != priceLength)
+                {
+                    throw new ArgumentException(
+                        $"Every feature column must be non-null and the same length as the price series ({priceLength}).",
+                        nameof(featureColumns));
+                }
+            }
+        }
 
         var (trainPrices, holdoutPrices) = WalkForwardSplit.Split(assetPrices, trainFraction, embargo);
 

--- a/src/Finance/Trading/Evaluation/PortfolioStudy.cs
+++ b/src/Finance/Trading/Evaluation/PortfolioStudy.cs
@@ -17,7 +17,7 @@ public static class PortfolioExperimentMatrix
         IReadOnlyList<double>? leverages = null,
         IReadOnlyList<(string Name, PortfolioFrictions Frictions)>? frictions = null)
     {
-        ArgumentNullException.ThrowIfNull(rewards);
+        if (rewards is null) throw new ArgumentNullException(nameof(rewards));
         if (rewards.Count == 0)
         {
             throw new ArgumentException("At least one reward is required.", nameof(rewards));
@@ -65,7 +65,7 @@ public static class PortfolioStudy
         Func<int, int, IPortfolioAgent<T>> agentFactory,
         int trainEpisodes)
     {
-        ArgumentNullException.ThrowIfNull(assetPrices);
+        if (assetPrices is null) throw new ArgumentNullException(nameof(assetPrices));
 
         // Feature columns must align to the price rows (same time length) BEFORE splitting, or the train/holdout
         // features would not line up with the prices they annotate. (WalkForwardSplit checks equal length within

--- a/src/Finance/Trading/Evaluation/WalkForwardSplit.cs
+++ b/src/Finance/Trading/Evaluation/WalkForwardSplit.cs
@@ -1,0 +1,56 @@
+using System;
+using System.Collections.Generic;
+
+namespace AiDotNet.Finance.Trading.Evaluation;
+
+/// <summary>
+/// Chronological train/holdout split for portfolio experiments: train on the earlier history, evaluate on a
+/// strictly-later UNTOUCHED tail, with an optional embargo gap dropped at the boundary so no information leaks
+/// across it. This is the honest-eval discipline for time-series RL — a random split would let the agent train
+/// on the future it is later scored on. Mirrors the purged/embargoed split used for supervised training.
+/// </summary>
+public static class WalkForwardSplit
+{
+    /// <summary>
+    /// Splits each column of <paramref name="series"/> (all equal length) at <paramref name="trainFraction"/>
+    /// into (train = earlier rows, holdout = later rows), dropping <paramref name="embargo"/> rows at the
+    /// boundary. Feature columns should be split with the SAME parameters so they stay aligned to prices.
+    /// </summary>
+    public static (List<double[]> Train, List<double[]> Holdout) Split(
+        IReadOnlyList<double[]> series, double trainFraction, int embargo = 0)
+    {
+        ArgumentNullException.ThrowIfNull(series);
+        if (series.Count == 0)
+        {
+            throw new ArgumentException("At least one series column is required.", nameof(series));
+        }
+
+        if (trainFraction <= 0.0 || trainFraction >= 1.0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(trainFraction), "trainFraction must be in (0, 1).");
+        }
+
+        embargo = Math.Max(0, embargo);
+        int n = series[0].Length;
+        for (int i = 1; i < series.Count; i++)
+        {
+            if (series[i].Length != n)
+            {
+                throw new ArgumentException("All series columns must have the same length.", nameof(series));
+            }
+        }
+
+        int splitIndex = (int)(n * trainFraction);
+        int holdoutStart = Math.Min(n, splitIndex + embargo);
+
+        var train = new List<double[]>(series.Count);
+        var holdout = new List<double[]>(series.Count);
+        foreach (var col in series)
+        {
+            train.Add(col[..splitIndex]);
+            holdout.Add(col[holdoutStart..]);
+        }
+
+        return (train, holdout);
+    }
+}

--- a/src/Finance/Trading/Evaluation/WalkForwardSplit.cs
+++ b/src/Finance/Trading/Evaluation/WalkForwardSplit.cs
@@ -19,18 +19,24 @@ public static class WalkForwardSplit
     public static (List<double[]> Train, List<double[]> Holdout) Split(
         IReadOnlyList<double[]> series, double trainFraction, int embargo = 0)
     {
-        ArgumentNullException.ThrowIfNull(series);
+        if (series is null) throw new ArgumentNullException(nameof(series));
         if (series.Count == 0)
         {
             throw new ArgumentException("At least one series column is required.", nameof(series));
         }
 
-        if (trainFraction <= 0.0 || trainFraction >= 1.0)
+        // NaN slips through a plain range check (every NaN comparison is false), so test finiteness explicitly.
+        if ((double.IsNaN(trainFraction) || double.IsInfinity(trainFraction)) || trainFraction <= 0.0 || trainFraction >= 1.0)
         {
-            throw new ArgumentOutOfRangeException(nameof(trainFraction), "trainFraction must be in (0, 1).");
+            throw new ArgumentOutOfRangeException(nameof(trainFraction), "trainFraction must be a finite value in (0, 1).");
         }
 
-        embargo = Math.Max(0, embargo);
+        // Reject a negative embargo rather than silently rewriting it to 0 — a negative gap is a caller bug.
+        if (embargo < 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(embargo), "embargo must be non-negative.");
+        }
+
         int n = series[0].Length;
         for (int i = 1; i < series.Count; i++)
         {
@@ -55,10 +61,17 @@ public static class WalkForwardSplit
 
         var train = new List<double[]>(series.Count);
         var holdout = new List<double[]>(series.Count);
+        int holdoutLength = n - holdoutStart;
         foreach (var col in series)
         {
-            train.Add(col[..splitIndex]);
-            holdout.Add(col[holdoutStart..]);
+            // Manual slices (net471 has no array-range/GetSubArray support): train = [0, splitIndex),
+            // holdout = [holdoutStart, n).
+            var trainCol = new double[splitIndex];
+            Array.Copy(col, 0, trainCol, 0, splitIndex);
+            var holdoutCol = new double[holdoutLength];
+            Array.Copy(col, holdoutStart, holdoutCol, 0, holdoutLength);
+            train.Add(trainCol);
+            holdout.Add(holdoutCol);
         }
 
         return (train, holdout);

--- a/src/Finance/Trading/Evaluation/WalkForwardSplit.cs
+++ b/src/Finance/Trading/Evaluation/WalkForwardSplit.cs
@@ -43,6 +43,16 @@ public static class WalkForwardSplit
         int splitIndex = (int)(n * trainFraction);
         int holdoutStart = Math.Min(n, splitIndex + embargo);
 
+        // Reject a split that leaves either partition empty (series too short, or trainFraction/embargo too
+        // extreme) rather than returning a zero-row train or holdout that fails downstream.
+        if (splitIndex <= 0 || holdoutStart >= n)
+        {
+            throw new ArgumentException(
+                $"Split leaves an empty partition (length {n}, train rows {splitIndex}, holdout rows {n - holdoutStart}); " +
+                "reduce the embargo or adjust trainFraction / provide a longer series.",
+                nameof(series));
+        }
+
         var train = new List<double[]>(series.Count);
         var holdout = new List<double[]>(series.Count);
         foreach (var col in series)

--- a/src/Finance/Trading/Rewards/PortfolioRewards.cs
+++ b/src/Finance/Trading/Rewards/PortfolioRewards.cs
@@ -1,0 +1,150 @@
+using System;
+
+namespace AiDotNet.Finance.Trading.Rewards;
+
+/// <summary>
+/// The information a portfolio reward function needs at each environment step. All values are in double
+/// precision (reward shaping is scale-sensitive and does not need the environment's generic numeric type):
+/// the realized one-step portfolio return (ALREADY net of trading frictions, which the environment deducts
+/// from cash), plus exposure/turnover/drawdown context so a reward can penalize churn, leverage, or losses.
+/// </summary>
+public readonly struct PortfolioRewardContext
+{
+    /// <summary>One-step portfolio return, net of all frictions the environment applied this step.</summary>
+    public double PortfolioReturn { get; }
+
+    /// <summary>Fraction of portfolio value traded this step (sum of |Δnotional| / value) — turnover.</summary>
+    public double Turnover { get; }
+
+    /// <summary>Gross exposure after the step: sum of |position notional| / portfolio value (1 = fully invested).</summary>
+    public double GrossExposure { get; }
+
+    /// <summary>Short exposure after the step: sum of short position notional / portfolio value (>= 0).</summary>
+    public double ShortExposure { get; }
+
+    /// <summary>Current drawdown from the running peak portfolio value, in [0, 1].</summary>
+    public double Drawdown { get; }
+
+    public PortfolioRewardContext(double portfolioReturn, double turnover, double grossExposure, double shortExposure, double drawdown)
+    {
+        PortfolioReturn = portfolioReturn;
+        Turnover = turnover;
+        GrossExposure = grossExposure;
+        ShortExposure = shortExposure;
+        Drawdown = drawdown;
+    }
+}
+
+/// <summary>
+/// A pluggable portfolio reward function for reinforcement-learning trading agents. Making the objective
+/// swappable is what lets the same environment run the reward as an EXPERIMENT — total return vs a
+/// risk-adjusted (Sharpe) objective vs a drawdown-penalized one — and rank them on an untouched holdout.
+/// Stateful rewards (e.g. the online Sharpe) must reset their running statistics in <see cref="Reset"/>.
+/// </summary>
+public interface IPortfolioReward
+{
+    /// <summary>Reward for one environment step given its <paramref name="context"/>.</summary>
+    double Reward(in PortfolioRewardContext context);
+
+    /// <summary>Clears any running statistics at the start of an episode.</summary>
+    void Reset();
+}
+
+/// <summary>
+/// Plain total-return reward with optional turnover and drawdown penalties: <c>return − turnoverPenalty·turnover
+/// − drawdownPenalty·drawdown</c>. The simplest baseline objective; use it as the control an
+/// <see cref="IPortfolioReward"/> experiment compares against.
+/// </summary>
+public sealed class TotalReturnReward : IPortfolioReward
+{
+    private readonly double _turnoverPenalty;
+    private readonly double _drawdownPenalty;
+
+    public TotalReturnReward(double turnoverPenalty = 0.0, double drawdownPenalty = 0.0)
+    {
+        _turnoverPenalty = turnoverPenalty;
+        _drawdownPenalty = drawdownPenalty;
+    }
+
+    public double Reward(in PortfolioRewardContext context)
+    {
+        double r = context.PortfolioReturn - (_turnoverPenalty * context.Turnover) - (_drawdownPenalty * context.Drawdown);
+        return double.IsNaN(r) || double.IsInfinity(r) ? 0.0 : r;
+    }
+
+    public void Reset()
+    {
+    }
+}
+
+/// <summary>
+/// Differential Sharpe Ratio reward (Moody &amp; Saffell, 1998) — the canonical risk-adjusted objective for RL
+/// trading. It rewards the MARGINAL contribution of each step's return to the online Sharpe ratio, so the agent
+/// is pushed toward smooth, consistent gains rather than volatile ones (a big gain that spikes variance can
+/// score LOWER than a smaller steady gain). Maintains exponentially-weighted first (A) and second (B) moments of
+/// the return with decay <c>eta</c>; the differential is
+/// <c>D_t = (B·ΔA − 0.5·A·ΔB) / (B − A²)^{3/2}</c>, which is the derivative of the Sharpe ratio w.r.t. the EWMA
+/// weight — a per-step, online, backprop-free shaping signal. An optional turnover penalty is subtracted.
+/// </summary>
+public sealed class DifferentialSharpeReward : IPortfolioReward
+{
+    private readonly double _eta;
+    private readonly double _turnoverPenalty;
+    private double _a; // EWMA of returns
+    private double _b; // EWMA of squared returns
+    private bool _initialized;
+
+    /// <param name="eta">EWMA decay for the moment estimates (smaller = longer memory). Default 0.04.</param>
+    /// <param name="turnoverPenalty">Optional penalty per unit turnover, subtracted from the differential.</param>
+    public DifferentialSharpeReward(double eta = 0.04, double turnoverPenalty = 0.0)
+    {
+        if (eta <= 0.0 || eta >= 1.0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(eta), "eta must be in (0, 1).");
+        }
+
+        _eta = eta;
+        _turnoverPenalty = turnoverPenalty;
+    }
+
+    public double Reward(in PortfolioRewardContext context)
+    {
+        double r = context.PortfolioReturn;
+        if (double.IsNaN(r) || double.IsInfinity(r))
+        {
+            r = 0.0;
+        }
+
+        double reward;
+        if (!_initialized)
+        {
+            // Bootstrap: no variance estimate yet, so the marginal Sharpe is undefined — fall back to the raw
+            // return so the very first step still gives a sensible signal.
+            _a = r;
+            _b = r * r;
+            _initialized = true;
+            reward = r;
+        }
+        else
+        {
+            double deltaA = r - _a;
+            double deltaB = (r * r) - _b;
+            double variance = _b - (_a * _a);
+            double denom = variance > 1e-12 ? Math.Pow(variance, 1.5) : 0.0;
+            reward = denom > 0.0 ? ((_b * deltaA) - (0.5 * _a * deltaB)) / denom : r;
+
+            _a += _eta * deltaA;
+            _b += _eta * deltaB;
+        }
+
+        reward -= _turnoverPenalty * context.Turnover;
+        return double.IsNaN(reward) || double.IsInfinity(reward) ? 0.0 : reward;
+    }
+
+    public void Reset()
+    {
+        _a = 0.0;
+        _b = 0.0;
+        _initialized = false;
+    }
+}

--- a/src/Finance/Trading/Rewards/PortfolioRewards.cs
+++ b/src/Finance/Trading/Rewards/PortfolioRewards.cs
@@ -62,12 +62,12 @@ public sealed class TotalReturnReward : IPortfolioReward
 
     public TotalReturnReward(double turnoverPenalty = 0.0, double drawdownPenalty = 0.0)
     {
-        if (!double.IsFinite(turnoverPenalty) || turnoverPenalty < 0.0)
+        if ((double.IsNaN(turnoverPenalty) || double.IsInfinity(turnoverPenalty)) || turnoverPenalty < 0.0)
         {
             throw new ArgumentOutOfRangeException(nameof(turnoverPenalty), "Penalty must be finite and non-negative.");
         }
 
-        if (!double.IsFinite(drawdownPenalty) || drawdownPenalty < 0.0)
+        if ((double.IsNaN(drawdownPenalty) || double.IsInfinity(drawdownPenalty)) || drawdownPenalty < 0.0)
         {
             throw new ArgumentOutOfRangeException(nameof(drawdownPenalty), "Penalty must be finite and non-negative.");
         }
@@ -108,12 +108,12 @@ public sealed class DifferentialSharpeReward : IPortfolioReward
     /// <param name="turnoverPenalty">Optional penalty per unit turnover, subtracted from the differential.</param>
     public DifferentialSharpeReward(double eta = 0.04, double turnoverPenalty = 0.0)
     {
-        if (!double.IsFinite(eta) || eta <= 0.0 || eta >= 1.0)
+        if ((double.IsNaN(eta) || double.IsInfinity(eta)) || eta <= 0.0 || eta >= 1.0)
         {
             throw new ArgumentOutOfRangeException(nameof(eta), "eta must be finite and strictly between 0 and 1.");
         }
 
-        if (!double.IsFinite(turnoverPenalty) || turnoverPenalty < 0.0)
+        if ((double.IsNaN(turnoverPenalty) || double.IsInfinity(turnoverPenalty)) || turnoverPenalty < 0.0)
         {
             throw new ArgumentOutOfRangeException(nameof(turnoverPenalty), "Penalty must be finite and non-negative.");
         }

--- a/src/Finance/Trading/Rewards/PortfolioRewards.cs
+++ b/src/Finance/Trading/Rewards/PortfolioRewards.cs
@@ -62,6 +62,16 @@ public sealed class TotalReturnReward : IPortfolioReward
 
     public TotalReturnReward(double turnoverPenalty = 0.0, double drawdownPenalty = 0.0)
     {
+        if (!double.IsFinite(turnoverPenalty) || turnoverPenalty < 0.0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(turnoverPenalty), "Penalty must be finite and non-negative.");
+        }
+
+        if (!double.IsFinite(drawdownPenalty) || drawdownPenalty < 0.0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(drawdownPenalty), "Penalty must be finite and non-negative.");
+        }
+
         _turnoverPenalty = turnoverPenalty;
         _drawdownPenalty = drawdownPenalty;
     }
@@ -98,9 +108,14 @@ public sealed class DifferentialSharpeReward : IPortfolioReward
     /// <param name="turnoverPenalty">Optional penalty per unit turnover, subtracted from the differential.</param>
     public DifferentialSharpeReward(double eta = 0.04, double turnoverPenalty = 0.0)
     {
-        if (eta <= 0.0 || eta >= 1.0)
+        if (!double.IsFinite(eta) || eta <= 0.0 || eta >= 1.0)
         {
-            throw new ArgumentOutOfRangeException(nameof(eta), "eta must be in (0, 1).");
+            throw new ArgumentOutOfRangeException(nameof(eta), "eta must be finite and strictly between 0 and 1.");
+        }
+
+        if (!double.IsFinite(turnoverPenalty) || turnoverPenalty < 0.0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(turnoverPenalty), "Penalty must be finite and non-negative.");
         }
 
         _eta = eta;

--- a/src/Interfaces/IAiModelBuilder.cs
+++ b/src/Interfaces/IAiModelBuilder.cs
@@ -2249,6 +2249,15 @@ public interface IAiModelBuilder<T, TInput, TOutput>
     IAiModelBuilder<T, TInput, TOutput> ConfigureClusterMetric(Clustering.Evaluation.IClusterMetric<T> metric);
 
     /// <summary>
+    /// Configures an extra financial metric to score a forecasting/financial model on (money-side analogue of
+    /// <see cref="ConfigureClusterMetric"/>), added on top of the default financial-metric set that runs
+    /// automatically for any financial or time-series forecasting model.
+    /// </summary>
+    /// <param name="metric">The financial metric implementation to add.</param>
+    /// <returns>The builder instance for method chaining.</returns>
+    IAiModelBuilder<T, TInput, TOutput> ConfigureFinancialMetric(Finance.Evaluation.IFinancialMetric<T> metric);
+
+    /// <summary>
     /// Configures an external cluster metric for evaluating clustering quality against ground truth labels.
     /// </summary>
     /// <param name="metric">The external cluster metric implementation to use.</param>

--- a/src/Models/Results/AiModelResult.cs
+++ b/src/Models/Results/AiModelResult.cs
@@ -555,9 +555,10 @@ public partial class AiModelResult<T, TInput, TOutput> : IFullModel<T, TInput, T
     /// <see cref="ConfiguredMetrics"/> for uniform access.
     /// </para>
     /// <para>
-    /// Computed on the held-out test partition (predicted vs realized), so — unlike cluster validity — this
-    /// is an out-of-sample measure. The model's level forecasts are differenced to per-step changes first,
-    /// so the strategy goes long when the model forecasts a rise above the last realized value.
+    /// Computed on the held-out test partition (predicted vs realized) when one is available — so it is
+    /// out-of-sample in that case; the direct-training path falls back to the training partition when no
+    /// held-out split exists. The model's level forecasts are differenced to per-step changes first, so the
+    /// strategy goes long when the model forecasts a rise above the last realized value.
     /// </para>
     /// </remarks>
     public Finance.Evaluation.FinancialEvaluationResult? FinancialEvaluation { get; private set; }

--- a/src/Models/Results/AiModelResult.cs
+++ b/src/Models/Results/AiModelResult.cs
@@ -542,6 +542,31 @@ public partial class AiModelResult<T, TInput, TOutput> : IFullModel<T, TInput, T
         => ClusteringEvaluation = evaluation;
 
     /// <summary>
+    /// The financial evaluation of a forecasting/financial model — how its held-out predictions would have
+    /// performed as a trading signal (directional accuracy, strategy Sharpe/Sortino, max drawdown, profit
+    /// factor, information coefficient), or <c>null</c> when the model is not a financial/forecasting family
+    /// or the evaluation could not be computed.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The analogue of <see cref="ClusteringEvaluation"/> for a clustering model: it runs automatically
+    /// whenever the trained model is a financial or time-series forecasting family, scoring the forecaster on
+    /// money rather than error alone. The individual metric values are also copied into
+    /// <see cref="ConfiguredMetrics"/> for uniform access.
+    /// </para>
+    /// <para>
+    /// Computed on the held-out test partition (predicted vs realized), so — unlike cluster validity — this
+    /// is an out-of-sample measure. The model's level forecasts are differenced to per-step changes first,
+    /// so the strategy goes long when the model forecasts a rise above the last realized value.
+    /// </para>
+    /// </remarks>
+    public Finance.Evaluation.FinancialEvaluationResult? FinancialEvaluation { get; private set; }
+
+    /// <summary>Records the financial evaluation. Called by the builder during Build.</summary>
+    internal void SetFinancialEvaluation(Finance.Evaluation.FinancialEvaluationResult evaluation)
+        => FinancialEvaluation = evaluation;
+
+    /// <summary>
     /// The attributed drift assessment computed on the held-out test stream, or <c>null</c> when no drift
     /// detector was configured via <c>ConfigureDriftDetection(...)</c>.
     /// </summary>

--- a/tests/AiDotNet.Tests/IntegrationTests/Finance/FinancialAutoEvaluationBuildTests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/Finance/FinancialAutoEvaluationBuildTests.cs
@@ -1,0 +1,107 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using AiDotNet;
+using AiDotNet.Data.Loaders;
+using AiDotNet.Finance.Evaluation;
+using AiDotNet.Models.Options;
+using AiDotNet.TimeSeries;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tests.IntegrationTests.Finance;
+
+/// <summary>
+/// Asserts that building a financial/forecasting model auto-evaluates it with financial-performance metrics
+/// (the money-side analogue of clustering auto-evaluation), and that ConfigureFinancialMetric adds a custom
+/// metric to that default set.
+/// </summary>
+/// <remarks>
+/// Pins the observable facade behaviour: for any time-series/financial model, AiModelResult.FinancialEvaluation
+/// is populated on the held-out partition with the default metric set (directional accuracy, strategy
+/// Sharpe/Sortino, max drawdown, profit factor, information coefficient), those values are mirrored by name
+/// into ConfiguredMetrics, and a configured custom financial metric appears alongside the defaults. It runs
+/// purely by model type — no configuration is required to get the default set.
+/// </remarks>
+public class FinancialAutoEvaluationBuildTests
+{
+    // A stationary, mean-reverting series an AR model can actually fit, so the held-out predictions carry
+    // real directional information for the strategy metrics.
+    private static (Matrix<double> x, Vector<double> y) StationaryData(int n)
+    {
+        var y = new Vector<double>(n);
+        var x = new Matrix<double>(n, 1);
+        for (int i = 0; i < n; i++)
+        {
+            y[i] = Math.Sin(2.0 * Math.PI * i / 20.0);
+            x[i, 0] = i;
+        }
+
+        return (x, y);
+    }
+
+    private static (ARModel<double> model, InMemoryDataLoader<double, Matrix<double>, Vector<double>> loader)
+        BuildArSetup()
+    {
+        var (x, y) = StationaryData(120);
+        var model = new ARModel<double>(new ARModelOptions<double> { AROrder = 3, MaxIterations = 100 });
+        var loader = new InMemoryDataLoader<double, Matrix<double>, Vector<double>>(x, y);
+        return (model, loader);
+    }
+
+    [Fact(Timeout = 120000)]
+    public async Task Build_ForecastingModel_AutoEvaluatesWithDefaultFinancialMetrics()
+    {
+        var (model, loader) = BuildArSetup();
+
+        var result = await new AiModelBuilder<double, Matrix<double>, Vector<double>>()
+            .ConfigureModel(model)
+            .ConfigureDataLoader(loader)
+            .BuildAsync();
+
+        Assert.NotNull(result.FinancialEvaluation);
+        // The default financial metrics run for any forecasting model, with no configuration.
+        foreach (var name in new[] { "DirectionalAccuracy", "StrategySharpe", "StrategySortino", "StrategyMaxDrawdown", "ProfitFactor", "InformationCoefficient" })
+        {
+            Assert.True(result.FinancialEvaluation!.Metrics.ContainsKey(name), $"missing default financial metric {name}");
+        }
+
+        // Same values are mirrored, by name, into ConfiguredMetrics (finite ones).
+        Assert.Contains("DirectionalAccuracy", result.ConfiguredMetrics.Keys);
+    }
+
+    [Fact(Timeout = 120000)]
+    public async Task ConfigureFinancialMetric_AddsCustomMetricToTheDefaultSet()
+    {
+        var (model, loader) = BuildArSetup();
+
+        var result = await new AiModelBuilder<double, Matrix<double>, Vector<double>>()
+            .ConfigureModel(model)
+            .ConfigureDataLoader(loader)
+            .ConfigureFinancialMetric(new TradeCountMetric<double>())
+            .BuildAsync();
+
+        Assert.NotNull(result.FinancialEvaluation);
+        // The configured custom metric appears alongside the defaults, not replacing them.
+        Assert.True(result.FinancialEvaluation!.Metrics.ContainsKey("TradeCount"), "custom metric missing from the evaluation");
+        Assert.True(result.FinancialEvaluation.Metrics.ContainsKey("StrategySharpe"), "default metric was dropped");
+    }
+
+    /// <summary>A trivial custom financial metric (distinct name) proving ConfigureFinancialMetric extends the set.</summary>
+    private sealed class TradeCountMetric<T> : IFinancialMetric<T>
+    {
+        public string Name => "TradeCount";
+        public bool HigherIsBetter => true;
+
+        public double Compute(IReadOnlyList<double> predicted, IReadOnlyList<double> actual)
+        {
+            int n = Math.Min(predicted.Count, actual.Count), trades = 0;
+            for (int i = 0; i < n; i++)
+            {
+                if (predicted[i] != 0) trades++;
+            }
+
+            return trades;
+        }
+    }
+}

--- a/tests/AiDotNet.Tests/UnitTests/Finance/FeedforwardPolicyAgentTests.cs
+++ b/tests/AiDotNet.Tests/UnitTests/Finance/FeedforwardPolicyAgentTests.cs
@@ -41,6 +41,37 @@ public sealed class FeedforwardPolicyAgentTests
         Assert.Equal(actA[1], actB[1], 12);
     }
 
+    [Fact]
+    [Trait("category", "unit")]
+    public void Training_moves_the_greedy_policy_toward_higher_reward_actions()
+    {
+        // A genuine learns-test: feed a reward that INCREASES with action[0] (reward = the sampled action[0]),
+        // so REINFORCE has a real gradient direction. After several episodes the greedy policy's action[0] must
+        // move up — proving Train() actually updates the parameters (not just runs without error).
+        var agent = new FeedforwardPolicyAgent<double>(
+            stateDim: 4, actionDim: 2, hidden: 8, explorationSigma: 0.3, learningRate: 5e-2, seed: 5);
+        var probe = State(0.3, -0.2, 0.5, 0.1);
+
+        double before = agent.SelectAction(probe, explore: false)[0];
+
+        for (int ep = 0; ep < 30; ep++)
+        {
+            agent.ResetEpisode();
+            for (int t = 0; t < 6; t++)
+            {
+                var s = State(0.3, -0.2, 0.5, 0.1);
+                var act = agent.SelectAction(s, explore: true);
+                // Higher action[0] earns higher reward → the policy should learn to raise action[0].
+                agent.StoreExperience(s, act, reward: act[0], nextState: s, done: t == 5);
+            }
+            agent.Train();
+        }
+
+        double after = agent.SelectAction(probe, explore: false)[0];
+        Assert.True(Math.Abs(after - before) > 1e-6, $"training should move the greedy policy output (before {before}, after {after})");
+        Assert.True(after > before, $"reward rewards higher action[0], so the greedy action[0] should rise (before {before}, after {after})");
+    }
+
     [Fact(Timeout = 120000)]
     [Trait("category", "unit")]
     public async Task Trains_end_to_end_through_the_harness_with_finite_holdout_metrics()

--- a/tests/AiDotNet.Tests/UnitTests/Finance/FeedforwardPolicyAgentTests.cs
+++ b/tests/AiDotNet.Tests/UnitTests/Finance/FeedforwardPolicyAgentTests.cs
@@ -1,0 +1,70 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using AiDotNet.Finance.Trading.Agents;
+using AiDotNet.Finance.Trading.Environments;
+using AiDotNet.Finance.Trading.Evaluation;
+using AiDotNet.Finance.Trading.Rewards;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tests.UnitTests.Finance;
+
+/// <summary>
+/// Tests for the feed-forward (memoryless) policy agent — the controlled counterpart to
+/// <see cref="RecurrentPolicyAgent{T}"/>. It must be MEMORYLESS (same current input → same action regardless of
+/// history — the opposite of the recurrent agent), and train end-to-end through the harness. Together the two
+/// agents make recurrent-vs-MLP a clean experiment where only memory differs.
+/// </summary>
+public sealed class FeedforwardPolicyAgentTests
+{
+    private static Vector<double> State(params double[] v) => new(v);
+
+    [Fact]
+    [Trait("category", "unit")]
+    public void Policy_is_memoryless_same_input_same_action_regardless_of_history()
+    {
+        var a = new FeedforwardPolicyAgent<double>(stateDim: 3, actionDim: 2, hidden: 8, seed: 1);
+        var b = new FeedforwardPolicyAgent<double>(stateDim: 3, actionDim: 2, hidden: 8, seed: 1);
+
+        // Different histories fed to identical-weight agents.
+        a.SelectAction(State(1, 0, 0), explore: false);
+        a.SelectAction(State(1, 1, 0), explore: false);
+        b.SelectAction(State(-1, 0, 1), explore: false);
+
+        // Same current observation → the memoryless policy must give the SAME action (history is ignored).
+        var actA = a.SelectAction(State(0.5, 0.5, 0.5), explore: false);
+        var actB = b.SelectAction(State(0.5, 0.5, 0.5), explore: false);
+
+        Assert.Equal(actA[0], actB[0], 12);
+        Assert.Equal(actA[1], actB[1], 12);
+    }
+
+    [Fact(Timeout = 120000)]
+    [Trait("category", "unit")]
+    public async Task Trains_end_to_end_through_the_harness_with_finite_holdout_metrics()
+    {
+        await Task.Yield();
+        var prices = new List<double[]>
+        {
+            Enumerable.Range(0, 40).Select(i => 100.0 + i).ToArray(),
+            Enumerable.Range(0, 40).Select(i => 100.0 + 0.5 * i).ToArray(),
+        };
+        var trainEnv = new PortfolioManagerEnvironment<double>(
+            prices, null, windowSize: 5, initialCapital: 100_000, reward: new DifferentialSharpeReward());
+
+        var agent = new FeedforwardPolicyAgent<double>(
+            trainEnv.ObservationSpaceDimension, trainEnv.ActionSpaceSize, hidden: 16, learningRate: 1e-3, seed: 3);
+
+        double meanReturn = PortfolioAgentTrainer.Train(agent, trainEnv, episodes: 3);
+        Assert.True(double.IsFinite(meanReturn), $"training return {meanReturn} not finite");
+
+        var evalEnv = new PortfolioManagerEnvironment<double>(
+            prices, null, windowSize: 5, initialCapital: 100_000, reward: new DifferentialSharpeReward());
+        var result = PortfolioBacktest.Run(evalEnv, s => agent.SelectAction(s, explore: false));
+
+        Assert.True(double.IsFinite(result.FinalValue) && result.FinalValue > 0, $"final value {result.FinalValue}");
+        Assert.True(result.Steps > 0);
+    }
+}

--- a/tests/AiDotNet.Tests/UnitTests/Finance/FeedforwardPolicyAgentTests.cs
+++ b/tests/AiDotNet.Tests/UnitTests/Finance/FeedforwardPolicyAgentTests.cs
@@ -88,14 +88,27 @@ public sealed class FeedforwardPolicyAgentTests
         var agent = new FeedforwardPolicyAgent<double>(
             trainEnv.ObservationSpaceDimension, trainEnv.ActionSpaceSize, hidden: 16, learningRate: 1e-3, seed: 3);
 
-        double meanReturn = PortfolioAgentTrainer.Train(agent, trainEnv, episodes: 3);
-        Assert.True(double.IsFinite(meanReturn), $"training return {meanReturn} not finite");
+        // Deterministic probe observation; record the greedy action BEFORE training so we can prove training
+        // actually updated the policy (not just ran without error).
+        var probe = new Vector<double>(Enumerable.Range(0, trainEnv.ObservationSpaceDimension)
+            .Select(i => 0.05 * ((i % 7) - 3)).ToArray());
+        double probeBefore = agent.SelectAction(probe, explore: false)[0];
 
+        double meanReturn = PortfolioAgentTrainer.Train(agent, trainEnv, episodes: 3);
+        Assert.True((!double.IsNaN(meanReturn) && !double.IsInfinity(meanReturn)), $"training return {meanReturn} not finite");
+
+        // The greedy action for the fixed probe must change after training — proof the parameters were updated.
+        double probeAfter = agent.SelectAction(probe, explore: false)[0];
+        Assert.True(Math.Abs(probeAfter - probeBefore) > 1e-9,
+            $"training should change the greedy policy output (before {probeBefore}, after {probeAfter})");
+
+        // Reset the agent before the holdout so evaluation starts from a clean state.
+        agent.ResetEpisode();
         var evalEnv = new PortfolioManagerEnvironment<double>(
             prices, null, windowSize: 5, initialCapital: 100_000, reward: new DifferentialSharpeReward());
         var result = PortfolioBacktest.Run(evalEnv, s => agent.SelectAction(s, explore: false));
 
-        Assert.True(double.IsFinite(result.FinalValue) && result.FinalValue > 0, $"final value {result.FinalValue}");
+        Assert.True((!double.IsNaN(result.FinalValue) && !double.IsInfinity(result.FinalValue)) && result.FinalValue > 0, $"final value {result.FinalValue}");
         Assert.True(result.Steps > 0);
     }
 }

--- a/tests/AiDotNet.Tests/UnitTests/Finance/FinancialMetricsTests.cs
+++ b/tests/AiDotNet.Tests/UnitTests/Finance/FinancialMetricsTests.cs
@@ -1,0 +1,90 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using AiDotNet.Finance.Evaluation;
+using Xunit;
+
+namespace AiDotNet.Tests.UnitTests.Finance;
+
+/// <summary>
+/// Tests for the financial-metrics core: scoring a forecaster on money (signal-following strategy) rather than
+/// error. A perfect direction forecast maxes the money metrics; an anti-forecast inverts them.
+/// </summary>
+public sealed class FinancialMetricsTests
+{
+    // A choppy but net-varying realized return series (so the metrics are finite / well-defined).
+    private static readonly double[] Actual =
+        { 0.02, -0.01, 0.03, -0.02, 0.015, -0.008, 0.025, -0.012, 0.018, -0.02, 0.03, -0.015 };
+
+    private static double[] Perfect() => Actual.ToArray();                 // forecast matches direction exactly
+    private static double[] Anti() => Actual.Select(a => -a).ToArray();    // forecast is exactly wrong
+
+    [Fact]
+    [Trait("category", "unit")]
+    public void Directional_accuracy_is_1_for_a_perfect_forecast_and_0_for_the_anti_forecast()
+    {
+        var m = new DirectionalAccuracyMetric<double>();
+        Assert.Equal(1.0, m.Compute(Perfect(), Actual), 10);
+        Assert.Equal(0.0, m.Compute(Anti(), Actual), 10);
+    }
+
+    [Fact]
+    [Trait("category", "unit")]
+    public void Strategy_sharpe_is_positive_for_a_perfect_forecast_and_negative_for_the_anti()
+    {
+        var sharpe = new StrategySharpeMetric<double>();
+        var sortino = new StrategySortinoMetric<double>();
+
+        Assert.True(sharpe.Compute(Perfect(), Actual) > 0);
+        Assert.True(sharpe.Compute(Anti(), Actual) < 0);
+        // A perfect forecast has NO losing trades → zero downside → Sortino is degenerate (0). The anti-forecast
+        // loses every trade → full downside → a clearly negative Sortino.
+        Assert.True(sortino.Compute(Anti(), Actual) < 0);
+    }
+
+    [Fact]
+    [Trait("category", "unit")]
+    public void Information_coefficient_is_1_when_predictions_equal_actuals_and_minus_1_when_inverted()
+    {
+        var ic = new InformationCoefficientMetric<double>();
+        Assert.Equal(1.0, ic.Compute(Perfect(), Actual), 6);
+        Assert.Equal(-1.0, ic.Compute(Anti(), Actual), 6);
+    }
+
+    [Fact]
+    [Trait("category", "unit")]
+    public void Max_drawdown_metric_is_non_positive_and_worse_for_the_anti_forecast()
+    {
+        var dd = new MaxDrawdownMetric<double>(); // reports -drawdown (higher is better)
+        double perfect = dd.Compute(Perfect(), Actual);
+        double anti = dd.Compute(Anti(), Actual);
+        Assert.True(perfect <= 0 && anti <= 0);
+        Assert.True(perfect >= anti, "the perfect forecast should have the smaller (less negative) drawdown");
+    }
+
+    [Fact]
+    [Trait("category", "unit")]
+    public void Evaluator_runs_the_full_default_metric_set()
+    {
+        var eval = new FinancialEvaluator<double>();
+        var result = eval.Evaluate(Perfect(), Actual);
+
+        foreach (var name in new[] { "DirectionalAccuracy", "StrategySharpe", "StrategySortino", "StrategyMaxDrawdown", "ProfitFactor", "InformationCoefficient" })
+        {
+            Assert.True(result.Metrics.ContainsKey(name), $"missing default metric {name}");
+        }
+
+        Assert.Equal(1.0, result["DirectionalAccuracy"], 10);
+        Assert.True(result["StrategySharpe"] > 0);
+    }
+
+    [Fact]
+    [Trait("category", "unit")]
+    public void Configured_metric_extends_the_default_set()
+    {
+        var eval = new FinancialEvaluator<double>();
+        eval.AddMetric(new ProfitFactorMetric<double>()); // adding another instance still shows up (extends, not replaces)
+        var result = eval.Evaluate(Perfect(), Actual);
+        Assert.True(result.Metrics.Count >= 6);
+    }
+}

--- a/tests/AiDotNet.Tests/UnitTests/Finance/PortfolioAgentTrainingTests.cs
+++ b/tests/AiDotNet.Tests/UnitTests/Finance/PortfolioAgentTrainingTests.cs
@@ -61,7 +61,8 @@ public sealed class PortfolioAgentTrainingTests
         double meanReturn = PortfolioAgentTrainer.Train(agent, env, episodes: 3);
 
         Assert.Equal(3, agent.ResetCalls);                     // one reset per episode
-        Assert.True(agent.SelectCalls > 0);                    // stepped
+        // 30 observations with a window of 5 → 25 steps per episode → 75 across 3 episodes.
+        Assert.Equal(75, agent.SelectCalls);
         Assert.Equal(agent.SelectCalls, agent.StoreCalls);     // one transition stored per action
         Assert.Equal(agent.SelectCalls, agent.TrainCalls);     // learned each step
         Assert.True(double.IsFinite(meanReturn));
@@ -69,27 +70,37 @@ public sealed class PortfolioAgentTrainingTests
 
     [Fact]
     [Trait("category", "unit")]
-    public void Experiment_runner_flags_an_agent_that_beats_the_baseline_on_holdout()
+    public void Experiment_runner_ranks_by_holdout_sharpe_and_flags_beat_baseline_per_experiment()
     {
-        // Holdout: asset 0 rises steadily, asset 1 DECLINES. An agent concentrated in the riser must beat the
-        // equal-weight baseline on Sharpe — the baseline holds half its book in the decliner, which both lowers
-        // return and adds variance, dragging its risk-adjusted score below the pure-riser agent's.
+        // Holdout: asset 0 rises steadily, asset 1 DECLINES. The two experiments get DISTINGUISHABLE policies
+        // (assigned by the factory call order the runner iterates in): the first concentrates in the riser
+        // (positive Sharpe, beats the equal-weight baseline), the second holds only the decliner (negative
+        // Sharpe, loses to it). That makes both the ranking and the per-experiment beat-baseline flags
+        // non-vacuous — a single shared policy would give both experiments identical holdout metrics.
         var holdoutPrices = new List<double[]> { Ramp(100, 3, 50), Ramp(100, -1, 50) };
         var trainPrices = new List<double[]> { Ramp(100, 2, 50), Ramp(100, -0.8, 50) };
         var experiments = new List<PortfolioExperiment>
         {
-            new("total-return", new TotalReturnReward()),
-            new("diff-sharpe", new DifferentialSharpeReward()),
+            new("riser", new TotalReturnReward()),
+            new("decliner", new DifferentialSharpeReward()),
         };
 
+        int call = 0;
         var outcomes = PortfolioExperimentRunner.Run<double>(
             trainPrices, null, holdoutPrices, null, windowSize: 5, initialCapital: 100_000,
-            experiments, agentFactory: (_, _) => new FixedWeightAgent(new[] { 1.0, 0.0 }), trainEpisodes: 1);
+            experiments,
+            agentFactory: (_, _) => new FixedWeightAgent(call++ == 0 ? new[] { 1.0, 0.0 } : new[] { 0.0, 1.0 }),
+            trainEpisodes: 1);
 
         Assert.Equal(2, outcomes.Count);
-        Assert.All(outcomes, o => Assert.True(o.BeatBaseline, $"{o.Name}: agent Sharpe {o.Agent.AnnualizedSharpe} vs base {o.BaselineEqualWeight.AnnualizedSharpe}"));
-        // Ranked by holdout Sharpe (descending).
-        Assert.True(outcomes[0].Agent.AnnualizedSharpe >= outcomes[1].Agent.AnnualizedSharpe);
+        // Ranked by holdout Sharpe (descending) — the riser experiment must come first, by exact name.
+        Assert.Equal("riser", outcomes[0].Name);
+        Assert.Equal("decliner", outcomes[1].Name);
+        Assert.True(outcomes[0].Agent.AnnualizedSharpe > outcomes[1].Agent.AnnualizedSharpe,
+            $"riser Sharpe {outcomes[0].Agent.AnnualizedSharpe} should exceed decliner {outcomes[1].Agent.AnnualizedSharpe}");
+        // The riser beats the equal-weight baseline; the pure-decliner does not.
+        Assert.True(outcomes[0].BeatBaseline, $"riser should beat baseline: {outcomes[0].Agent.AnnualizedSharpe} vs {outcomes[0].BaselineEqualWeight.AnnualizedSharpe}");
+        Assert.False(outcomes[1].BeatBaseline, $"decliner should not beat baseline: {outcomes[1].Agent.AnnualizedSharpe} vs {outcomes[1].BaselineEqualWeight.AnnualizedSharpe}");
     }
 
     [Fact]

--- a/tests/AiDotNet.Tests/UnitTests/Finance/PortfolioAgentTrainingTests.cs
+++ b/tests/AiDotNet.Tests/UnitTests/Finance/PortfolioAgentTrainingTests.cs
@@ -176,8 +176,12 @@ public sealed class PortfolioAgentTrainingTests
         double meanReturn = PortfolioAgentTrainer.Train(agent, trainEnv, episodes: 2);
         Assert.True(double.IsFinite(meanReturn), $"training return {meanReturn} was not finite");
 
+        // Evaluate on genuinely UNSEEN prices (a different regime/level than the training series), so the smoke
+        // test exercises the agent on data it never trained on — the honest-eval discipline.
+        var evalPrices = new List<double[]> { Ramp(120, 0.8, 40), Ramp(90, 1.2, 40) };
+        agent.ResetEpisode();
         var evalEnv = new PortfolioManagerEnvironment<double>(
-            prices, null, windowSize: 5, initialCapital: 100_000, reward: new DifferentialSharpeReward());
+            evalPrices, null, windowSize: 5, initialCapital: 100_000, reward: new DifferentialSharpeReward());
         var result = PortfolioBacktest.Run(evalEnv, s => agent.SelectAction(s, explore: false));
 
         Assert.True(double.IsFinite(result.FinalValue) && result.FinalValue > 0, $"final value {result.FinalValue}");

--- a/tests/AiDotNet.Tests/UnitTests/Finance/PortfolioAgentTrainingTests.cs
+++ b/tests/AiDotNet.Tests/UnitTests/Finance/PortfolioAgentTrainingTests.cs
@@ -83,7 +83,7 @@ public sealed class PortfolioAgentTrainingTests
         };
 
         var outcomes = PortfolioExperimentRunner.Run<double>(
-            trainPrices, null, holdoutPrices, null, windowSize: 5, initialCapital: 100_000, maxLeverage: 1.0,
+            trainPrices, null, holdoutPrices, null, windowSize: 5, initialCapital: 100_000,
             experiments, agentFactory: (_, _) => new FixedWeightAgent(new[] { 1.0, 0.0 }), trainEpisodes: 1);
 
         Assert.Equal(2, outcomes.Count);
@@ -100,12 +100,35 @@ public sealed class PortfolioAgentTrainingTests
         // the flat agent must NOT be flagged as beating it — the honest-eval guard against false positives.
         var prices = new List<double[]> { Ramp(100, 2, 50), Ramp(100, 2, 50) };
         var outcomes = PortfolioExperimentRunner.Run<double>(
-            prices, null, prices, null, windowSize: 5, initialCapital: 100_000, maxLeverage: 1.0,
+            prices, null, prices, null, windowSize: 5, initialCapital: 100_000,
             new List<PortfolioExperiment> { new("flat", new TotalReturnReward()) },
             agentFactory: (_, _) => new FixedWeightAgent(new[] { 0.0, 0.0 }), trainEpisodes: 1);
 
         Assert.Single(outcomes);
         Assert.False(outcomes[0].BeatBaseline);
+    }
+
+    [Fact]
+    [Trait("category", "unit")]
+    public void Frictions_are_an_experiment_axis_carry_cost_drags_the_holdout()
+    {
+        // Same objective + policy; two experiments differ ONLY in holding/carry cost. The held long book pays
+        // carry every step, so the heavy-friction experiment must end below the frictionless one — proving
+        // frictions are a real experiment axis, not a fixed assumption.
+        var prices = new List<double[]> { Ramp(100, 1, 50) };
+        var experiments = new List<PortfolioExperiment>
+        {
+            new("frictionless", new TotalReturnReward(), MaxLeverage: 1.0, Frictions: new PortfolioFrictions(AnnualHoldingCost: 0.0)),
+            new("heavy-carry", new TotalReturnReward(), MaxLeverage: 1.0, Frictions: new PortfolioFrictions(AnnualHoldingCost: 1.0)),
+        };
+
+        var outcomes = PortfolioExperimentRunner.Run<double>(
+            prices, null, prices, null, windowSize: 5, initialCapital: 100_000,
+            experiments, agentFactory: (_, _) => new FixedWeightAgent(new[] { 1.0 }), trainEpisodes: 1);
+
+        double frictionless = System.Linq.Enumerable.First(outcomes, o => o.Name == "frictionless").Agent.FinalValue;
+        double heavyCarry = System.Linq.Enumerable.First(outcomes, o => o.Name == "heavy-carry").Agent.FinalValue;
+        Assert.True(frictionless > heavyCarry, $"carry should drag the book: frictionless {frictionless} !> heavy {heavyCarry}");
     }
 
     [Fact(Timeout = 120000)]

--- a/tests/AiDotNet.Tests/UnitTests/Finance/PortfolioAgentTrainingTests.cs
+++ b/tests/AiDotNet.Tests/UnitTests/Finance/PortfolioAgentTrainingTests.cs
@@ -65,7 +65,7 @@ public sealed class PortfolioAgentTrainingTests
         Assert.Equal(75, agent.SelectCalls);
         Assert.Equal(agent.SelectCalls, agent.StoreCalls);     // one transition stored per action
         Assert.Equal(agent.SelectCalls, agent.TrainCalls);     // learned each step
-        Assert.True(double.IsFinite(meanReturn));
+        Assert.True((!double.IsNaN(meanReturn) && !double.IsInfinity(meanReturn)));
     }
 
     [Fact]
@@ -174,7 +174,7 @@ public sealed class PortfolioAgentTrainingTests
         var agent = PortfolioAgent.From(new SACAgent<double>(options));
 
         double meanReturn = PortfolioAgentTrainer.Train(agent, trainEnv, episodes: 2);
-        Assert.True(double.IsFinite(meanReturn), $"training return {meanReturn} was not finite");
+        Assert.True((!double.IsNaN(meanReturn) && !double.IsInfinity(meanReturn)), $"training return {meanReturn} was not finite");
 
         // Evaluate on genuinely UNSEEN prices (a different regime/level than the training series), so the smoke
         // test exercises the agent on data it never trained on — the honest-eval discipline.
@@ -184,7 +184,7 @@ public sealed class PortfolioAgentTrainingTests
             evalPrices, null, windowSize: 5, initialCapital: 100_000, reward: new DifferentialSharpeReward());
         var result = PortfolioBacktest.Run(evalEnv, s => agent.SelectAction(s, explore: false));
 
-        Assert.True(double.IsFinite(result.FinalValue) && result.FinalValue > 0, $"final value {result.FinalValue}");
+        Assert.True((!double.IsNaN(result.FinalValue) && !double.IsInfinity(result.FinalValue)) && result.FinalValue > 0, $"final value {result.FinalValue}");
         Assert.True(result.Steps > 0);
     }
 }

--- a/tests/AiDotNet.Tests/UnitTests/Finance/PortfolioAgentTrainingTests.cs
+++ b/tests/AiDotNet.Tests/UnitTests/Finance/PortfolioAgentTrainingTests.cs
@@ -1,0 +1,107 @@
+using System;
+using System.Collections.Generic;
+using AiDotNet.Finance.Trading.Environments;
+using AiDotNet.Finance.Trading.Evaluation;
+using AiDotNet.Finance.Trading.Rewards;
+using AiDotNet.Interfaces;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tests.UnitTests.Finance;
+
+/// <summary>
+/// Tests for the portfolio agent trainer + experiment runner (the greenfield trading-agent harness). Uses a
+/// fixed-policy test double for the agent, so the loop mechanics and holdout-vs-baseline ranking are
+/// deterministic — RL convergence itself is a research result, not a unit test.
+/// </summary>
+public sealed class PortfolioAgentTrainingTests
+{
+    /// <summary>An <see cref="IRLAgent{T}"/> that always emits the same target weights and counts lifecycle
+    /// calls — lets a test drive the harness without RL stochasticity.</summary>
+    private sealed class FixedWeightAgent : IPortfolioAgent<double>
+    {
+        private readonly double[] _weights;
+        public int SelectCalls, StoreCalls, TrainCalls, ResetCalls;
+
+        public FixedWeightAgent(double[] weights) => _weights = weights;
+
+        public Vector<double> SelectAction(Vector<double> state, bool explore = true)
+        {
+            SelectCalls++;
+            return new Vector<double>((double[])_weights.Clone());
+        }
+
+        public void StoreExperience(Vector<double> state, Vector<double> action, double reward, Vector<double> nextState, bool done)
+            => StoreCalls++;
+
+        public double Train() { TrainCalls++; return 0.0; }
+
+        public void ResetEpisode() => ResetCalls++;
+    }
+
+    private static double[] Ramp(double start, double step, int n)
+    {
+        var a = new double[n];
+        for (int i = 0; i < n; i++) a[i] = start + i * step;
+        return a;
+    }
+
+    [Fact]
+    [Trait("category", "unit")]
+    public void Trainer_drives_the_full_experience_loop_each_episode()
+    {
+        var env = new PortfolioManagerEnvironment<double>(
+            new List<double[]> { Ramp(100, 1, 30) }, null, windowSize: 5, initialCapital: 100_000,
+            reward: new TotalReturnReward());
+        var agent = new FixedWeightAgent(new[] { 1.0 });
+
+        double meanReturn = PortfolioAgentTrainer.Train(agent, env, episodes: 3);
+
+        Assert.Equal(3, agent.ResetCalls);                     // one reset per episode
+        Assert.True(agent.SelectCalls > 0);                    // stepped
+        Assert.Equal(agent.SelectCalls, agent.StoreCalls);     // one transition stored per action
+        Assert.Equal(agent.SelectCalls, agent.TrainCalls);     // learned each step
+        Assert.True(double.IsFinite(meanReturn));
+    }
+
+    [Fact]
+    [Trait("category", "unit")]
+    public void Experiment_runner_flags_an_agent_that_beats_the_baseline_on_holdout()
+    {
+        // Holdout: asset 0 rises steadily, asset 1 DECLINES. An agent concentrated in the riser must beat the
+        // equal-weight baseline on Sharpe — the baseline holds half its book in the decliner, which both lowers
+        // return and adds variance, dragging its risk-adjusted score below the pure-riser agent's.
+        var holdoutPrices = new List<double[]> { Ramp(100, 3, 50), Ramp(100, -1, 50) };
+        var trainPrices = new List<double[]> { Ramp(100, 2, 50), Ramp(100, -0.8, 50) };
+        var experiments = new List<PortfolioExperiment>
+        {
+            new("total-return", new TotalReturnReward()),
+            new("diff-sharpe", new DifferentialSharpeReward()),
+        };
+
+        var outcomes = PortfolioExperimentRunner.Run<double>(
+            trainPrices, null, holdoutPrices, null, windowSize: 5, initialCapital: 100_000, maxLeverage: 1.0,
+            experiments, agentFactory: (_, _) => new FixedWeightAgent(new[] { 1.0, 0.0 }), trainEpisodes: 1);
+
+        Assert.Equal(2, outcomes.Count);
+        Assert.All(outcomes, o => Assert.True(o.BeatBaseline, $"{o.Name}: agent Sharpe {o.Agent.AnnualizedSharpe} vs base {o.BaselineEqualWeight.AnnualizedSharpe}"));
+        // Ranked by holdout Sharpe (descending).
+        Assert.True(outcomes[0].Agent.AnnualizedSharpe >= outcomes[1].Agent.AnnualizedSharpe);
+    }
+
+    [Fact]
+    [Trait("category", "unit")]
+    public void Experiment_runner_does_not_flag_a_flat_agent_as_beating_the_baseline()
+    {
+        // A do-nothing (all-cash) agent earns zero on a rising market; equal-weight earns a positive Sharpe, so
+        // the flat agent must NOT be flagged as beating it — the honest-eval guard against false positives.
+        var prices = new List<double[]> { Ramp(100, 2, 50), Ramp(100, 2, 50) };
+        var outcomes = PortfolioExperimentRunner.Run<double>(
+            prices, null, prices, null, windowSize: 5, initialCapital: 100_000, maxLeverage: 1.0,
+            new List<PortfolioExperiment> { new("flat", new TotalReturnReward()) },
+            agentFactory: (_, _) => new FixedWeightAgent(new[] { 0.0, 0.0 }), trainEpisodes: 1);
+
+        Assert.Single(outcomes);
+        Assert.False(outcomes[0].BeatBaseline);
+    }
+}

--- a/tests/AiDotNet.Tests/UnitTests/Finance/PortfolioAgentTrainingTests.cs
+++ b/tests/AiDotNet.Tests/UnitTests/Finance/PortfolioAgentTrainingTests.cs
@@ -1,9 +1,12 @@
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using AiDotNet.Finance.Trading.Environments;
 using AiDotNet.Finance.Trading.Evaluation;
 using AiDotNet.Finance.Trading.Rewards;
 using AiDotNet.Interfaces;
+using AiDotNet.Models.Options;
+using AiDotNet.ReinforcementLearning.Agents.SAC;
 using AiDotNet.Tensors.LinearAlgebra;
 using Xunit;
 
@@ -103,5 +106,47 @@ public sealed class PortfolioAgentTrainingTests
 
         Assert.Single(outcomes);
         Assert.False(outcomes[0].BeatBaseline);
+    }
+
+    [Fact(Timeout = 120000)]
+    [Trait("category", "unit")]
+    public async Task Harness_trains_a_real_SAC_agent_end_to_end_and_produces_finite_holdout_metrics()
+    {
+        await Task.Yield();
+        // Integration smoke: drive a REAL AiDotNet SAC agent (via the adapter) through the trainer + holdout
+        // evaluator. Asserts the wiring runs end-to-end and yields finite, sane metrics — NOT that it converges
+        // (RL convergence is a research result, not a unit test).
+        var prices = new List<double[]> { Ramp(100, 1, 40), Ramp(100, 0.5, 40) };
+        var trainEnv = new PortfolioManagerEnvironment<double>(
+            prices, null, windowSize: 5, initialCapital: 100_000, reward: new DifferentialSharpeReward());
+
+        var options = new SACOptions<double>
+        {
+            StateSize = trainEnv.ObservationSpaceDimension,
+            ActionSize = trainEnv.ActionSpaceSize,
+            PolicyLearningRate = 3e-4,
+            QLearningRate = 3e-4,
+            AlphaLearningRate = 3e-4,
+            DiscountFactor = 0.99,
+            InitialTemperature = 0.2,
+            TargetUpdateTau = 0.005,
+            BatchSize = 8,
+            ReplayBufferSize = 2000,
+            WarmupSteps = 4,
+            PolicyHiddenLayers = new List<int> { 32, 32 },
+            QHiddenLayers = new List<int> { 32, 32 },
+            Seed = 1,
+        };
+        var agent = PortfolioAgent.From(new SACAgent<double>(options));
+
+        double meanReturn = PortfolioAgentTrainer.Train(agent, trainEnv, episodes: 2);
+        Assert.True(double.IsFinite(meanReturn), $"training return {meanReturn} was not finite");
+
+        var evalEnv = new PortfolioManagerEnvironment<double>(
+            prices, null, windowSize: 5, initialCapital: 100_000, reward: new DifferentialSharpeReward());
+        var result = PortfolioBacktest.Run(evalEnv, s => agent.SelectAction(s, explore: false));
+
+        Assert.True(double.IsFinite(result.FinalValue) && result.FinalValue > 0, $"final value {result.FinalValue}");
+        Assert.True(result.Steps > 0);
     }
 }

--- a/tests/AiDotNet.Tests/UnitTests/Finance/PortfolioBacktestTests.cs
+++ b/tests/AiDotNet.Tests/UnitTests/Finance/PortfolioBacktestTests.cs
@@ -81,6 +81,42 @@ public sealed class PortfolioBacktestTests
 
     [Fact]
     [Trait("category", "unit")]
+    public void Sortino_and_calmar_are_computed_and_sane_on_a_rising_but_choppy_market()
+    {
+        // A net-rising series WITH regular small dips (so downside deviation is defined). Sortino must be
+        // positive and, since it penalizes only downside, at least the Sharpe; Calmar (annual return / max DD)
+        // must be positive on a net gain.
+        var choppy = new double[80];
+        double p = 100;
+        for (int i = 0; i < 80; i++)
+        {
+            choppy[i] = p;
+            p += (i % 4 == 3) ? -0.8 : 1.2; // three up steps, one down — rises net, with real downside
+        }
+
+        var r = PortfolioBacktest.Run(Env(new List<double[]> { choppy }), _ => new Vector<double>(new[] { 1.0 }));
+
+        Assert.True(r.AnnualizedSortino > 0, $"sortino {r.AnnualizedSortino}");
+        Assert.True(r.AnnualizedSortino >= r.AnnualizedSharpe - 1e-9, "sortino only penalizes downside, so >= sharpe");
+        Assert.True(r.Calmar > 0, $"calmar {r.Calmar}");
+    }
+
+    [Fact]
+    [Trait("category", "unit")]
+    public void RiskParity_allocates_more_to_the_calmer_asset()
+    {
+        // windowSize 3, 2 tradable columns. Asset 0 is steady (low vol); asset 1 is volatile (high vol).
+        // Observation layout: [t0a0,t0a1, t1a0,t1a1, t2a0,t2a1].
+        var state = new Vector<double>(new[] { 100.0, 100.0, 101.0, 110.0, 102.0, 95.0 });
+        var policy = BaselinePolicies.RiskParity<double>(windowSize: 3, totalColumns: 2, tradableCount: 2);
+
+        var w = policy(state);
+        Assert.True(w[0] > w[1], $"risk-parity should over-weight the calmer asset: {w[0]} vs {w[1]}");
+        Assert.True(Math.Abs((w[0] + w[1]) - 1.0) < 1e-9, "long-only weights should sum to 1");
+    }
+
+    [Fact]
+    [Trait("category", "unit")]
     public void Drawdown_is_captured_when_the_market_rises_then_falls()
     {
         // Rise to a peak, then fall well below it — a full-long book must record a real drawdown.

--- a/tests/AiDotNet.Tests/UnitTests/Finance/PortfolioBacktestTests.cs
+++ b/tests/AiDotNet.Tests/UnitTests/Finance/PortfolioBacktestTests.cs
@@ -1,0 +1,79 @@
+using System;
+using System.Collections.Generic;
+using AiDotNet.Finance.Trading.Environments;
+using AiDotNet.Finance.Trading.Evaluation;
+using AiDotNet.Finance.Trading.Rewards;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tests.UnitTests.Finance;
+
+/// <summary>
+/// Tests for the portfolio backtest evaluator + no-skill baselines — the honest-eval seam a greenfield
+/// trading-agent experiment is ranked on (untouched holdout, vs baseline), never training loss.
+/// </summary>
+public sealed class PortfolioBacktestTests
+{
+    private static double[] Ramp(double start, double step, int n)
+    {
+        var a = new double[n];
+        for (int i = 0; i < n; i++) a[i] = start + i * step;
+        return a;
+    }
+
+    private static PortfolioManagerEnvironment<double> Env(IReadOnlyList<double[]> prices, double lev = 1.0) =>
+        new(prices, null, windowSize: 5, initialCapital: 100_000, reward: new TotalReturnReward(),
+            maxLeverage: lev, transactionCost: 0.0, slippageCoefficient: 0.0, annualBorrowCost: 0.0);
+
+    [Fact]
+    [Trait("category", "unit")]
+    public void Full_long_on_a_rising_market_scores_positive_return_and_sharpe()
+    {
+        var env = Env(new List<double[]> { Ramp(100, 1, 60) });
+        var result = PortfolioBacktest.Run(env, _ => new Vector<double>(new[] { 1.0 }));
+
+        Assert.True(result.FinalValue > 100_000, $"final {result.FinalValue}");
+        Assert.True(result.TotalReturn > 0, $"total return {result.TotalReturn}");
+        Assert.True(result.AnnualizedSharpe > 0, $"sharpe {result.AnnualizedSharpe}");
+        Assert.True(result.MaxDrawdown < 0.02, $"a monotone rise should have ~0 drawdown, got {result.MaxDrawdown}");
+        Assert.True(result.Steps > 0);
+    }
+
+    [Fact]
+    [Trait("category", "unit")]
+    public void Flat_policy_holds_capital_and_takes_no_drawdown()
+    {
+        var env = Env(new List<double[]> { Ramp(100, 1, 60) });
+        var result = PortfolioBacktest.Run(env, BaselinePolicies.Flat<double>(1));
+
+        Assert.Equal(100_000.0, result.FinalValue, 0);
+        Assert.Equal(0.0, result.TotalReturn, 6);
+        Assert.Equal(0.0, result.MaxDrawdown, 6);
+        Assert.Equal(0.0, result.AverageTurnover, 6);
+    }
+
+    [Fact]
+    [Trait("category", "unit")]
+    public void Equal_weight_baseline_grows_on_a_rising_multi_asset_market()
+    {
+        var env = Env(new List<double[]> { Ramp(100, 2, 60), Ramp(50, 1, 60) });
+        var result = PortfolioBacktest.Run(env, BaselinePolicies.EqualWeight<double>(2));
+
+        Assert.True(result.TotalReturn > 0, $"equal-weight on a rising market should grow, got {result.TotalReturn}");
+        Assert.Equal(60 - 5, result.Steps); // time - windowSize
+    }
+
+    [Fact]
+    [Trait("category", "unit")]
+    public void Drawdown_is_captured_when_the_market_rises_then_falls()
+    {
+        // Rise to a peak, then fall well below it — a full-long book must record a real drawdown.
+        var prices = new double[60];
+        for (int i = 0; i < 30; i++) prices[i] = 100 + i * 2;      // 100 → 158
+        for (int i = 30; i < 60; i++) prices[i] = 158 - (i - 29) * 3; // fall back toward ~68
+        var env = Env(new List<double[]> { prices });
+
+        var result = PortfolioBacktest.Run(env, _ => new Vector<double>(new[] { 1.0 }));
+        Assert.True(result.MaxDrawdown > 0.10, $"expected a material drawdown, got {result.MaxDrawdown}");
+    }
+}

--- a/tests/AiDotNet.Tests/UnitTests/Finance/PortfolioBacktestTests.cs
+++ b/tests/AiDotNet.Tests/UnitTests/Finance/PortfolioBacktestTests.cs
@@ -65,6 +65,22 @@ public sealed class PortfolioBacktestTests
 
     [Fact]
     [Trait("category", "unit")]
+    public void Momentum_baseline_longs_the_winner_and_beats_equal_weight_on_a_trend()
+    {
+        // Asset 0 trends up, asset 1 trends down. Momentum should hold ONLY the winner and beat equal-weight,
+        // which wastes half its book on the falling asset. (2 assets, no feature columns → totalColumns == 2.)
+        var prices = new List<double[]> { Ramp(100, 2, 60), Ramp(100, -1.5, 60) };
+
+        var momentum = PortfolioBacktest.Run(Env(prices), BaselinePolicies.Momentum<double>(windowSize: 5, totalColumns: 2, tradableCount: 2));
+        var equalWeight = PortfolioBacktest.Run(Env(prices), BaselinePolicies.EqualWeight<double>(2));
+
+        Assert.True(momentum.TotalReturn > 0, $"momentum should grow on the up-trending winner, got {momentum.TotalReturn}");
+        Assert.True(momentum.TotalReturn > equalWeight.TotalReturn,
+            $"momentum ({momentum.TotalReturn}) should beat equal-weight ({equalWeight.TotalReturn}) by avoiding the loser");
+    }
+
+    [Fact]
+    [Trait("category", "unit")]
     public void Drawdown_is_captured_when_the_market_rises_then_falls()
     {
         // Rise to a peak, then fall well below it — a full-long book must record a real drawdown.

--- a/tests/AiDotNet.Tests/UnitTests/Finance/PortfolioManagerEnvironmentTests.cs
+++ b/tests/AiDotNet.Tests/UnitTests/Finance/PortfolioManagerEnvironmentTests.cs
@@ -1,0 +1,133 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using AiDotNet.Finance.Trading.Environments;
+using AiDotNet.Finance.Trading.Rewards;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tests.UnitTests.Finance;
+
+/// <summary>
+/// Tests for the greenfield portfolio-manager RL environment + pluggable rewards: the differential Sharpe reward
+/// is genuinely risk-adjusted (prefers smooth gains), the gross-leverage budget is enforced, observation-only
+/// feature columns are never traded, and a long book grows on a rising market.
+/// </summary>
+public sealed class PortfolioManagerEnvironmentTests
+{
+    // ---- reward math (deterministic) ----------------------------------------------------------
+
+    [Fact]
+    [Trait("category", "unit")]
+    public void DifferentialSharpe_prefers_smooth_gains_over_volatile_ones_of_equal_mean()
+    {
+        // Two return streams with the SAME mean (+1%/step) but different variance. A risk-adjusted objective must
+        // score the smooth one higher — that is the whole point of the differential Sharpe ratio.
+        var smooth = Enumerable.Repeat(0.01, 40).ToArray();
+        var volatile1 = new double[40];
+        for (int i = 0; i < 40; i++) volatile1[i] = (i % 2 == 0) ? 0.05 : -0.03; // mean = 0.01
+
+        double SumReward(double[] returns)
+        {
+            var reward = new DifferentialSharpeReward(eta: 0.05);
+            double sum = 0;
+            foreach (var r in returns)
+                sum += reward.Reward(new PortfolioRewardContext(r, 0, 1, 0, 0));
+            return sum;
+        }
+
+        Assert.True(SumReward(smooth) > SumReward(volatile1),
+            "differential Sharpe should reward the smooth stream more than the equal-mean volatile one");
+    }
+
+    [Fact]
+    [Trait("category", "unit")]
+    public void TotalReturnReward_applies_turnover_and_drawdown_penalties()
+    {
+        var reward = new TotalReturnReward(turnoverPenalty: 0.5, drawdownPenalty: 0.2);
+        // return 0.02, turnover 0.1, drawdown 0.05 → 0.02 − 0.5·0.1 − 0.2·0.05 = 0.02 − 0.05 − 0.01 = -0.04
+        double r = reward.Reward(new PortfolioRewardContext(0.02, 0.1, 1.0, 0.0, 0.05));
+        Assert.Equal(-0.04, r, 10);
+    }
+
+    [Fact]
+    [Trait("category", "unit")]
+    public void DifferentialSharpe_reset_clears_running_statistics()
+    {
+        var reward = new DifferentialSharpeReward(eta: 0.05);
+        // VARIED returns build up nonzero variance, so mid-run the reward is a differential (not the raw return).
+        foreach (var r in new[] { 0.05, -0.02, 0.04, -0.01, 0.03, 0.06, -0.03, 0.02 })
+            reward.Reward(new PortfolioRewardContext(r, 0, 1, 0, 0));
+        double afterRun = reward.Reward(new PortfolioRewardContext(0.03, 0, 1, 0, 0));
+        reward.Reset();
+        double afterReset = reward.Reward(new PortfolioRewardContext(0.03, 0, 1, 0, 0));
+        // Post-reset first step bootstraps to the raw return (0.03); mid-run it is a differential, not 0.03.
+        Assert.Equal(0.03, afterReset, 10);
+        Assert.NotEqual(0.03, afterRun, 6);
+    }
+
+    // ---- environment behavior ----------------------------------------------------------------
+
+    private static double[] Ramp(double start, double stepUp, int n)
+    {
+        var a = new double[n];
+        for (int i = 0; i < n; i++) a[i] = start + i * stepUp;
+        return a;
+    }
+
+    [Fact]
+    [Trait("category", "unit")]
+    public void Action_space_is_tradable_count_and_feature_columns_are_not_traded()
+    {
+        var prices = new List<double[]> { Ramp(100, 1, 30), Ramp(50, 0.5, 30) };   // 2 tradable
+        var features = new List<double[]> { Ramp(0.01, 0, 30), Ramp(-0.02, 0, 30) }; // 2 observation-only
+        var env = new PortfolioManagerEnvironment<double>(
+            prices, features, windowSize: 5, initialCapital: 100_000, reward: new TotalReturnReward());
+
+        Assert.Equal(2, env.ActionSpaceSize);              // == tradable count, NOT 2+2
+        Assert.True(env.IsContinuousActionSpace);
+
+        env.Reset();
+        // Hold everything flat (zero weights) → no trades, feature columns can never create exposure.
+        var (_, _, _, info) = env.Step(new Vector<double>(new[] { 0.0, 0.0 }));
+        Assert.Equal(100_000.0, Convert.ToDouble(info["portfolioValue"]), 0); // flat book stays at capital
+    }
+
+    [Fact]
+    [Trait("category", "unit")]
+    public void Gross_leverage_budget_is_enforced()
+    {
+        var prices = new List<double[]> { Ramp(100, 1, 40), Ramp(100, 1, 40), Ramp(100, 1, 40) };
+        var env = new PortfolioManagerEnvironment<double>(
+            prices, null, windowSize: 5, initialCapital: 100_000, reward: new TotalReturnReward(),
+            maxLeverage: 1.0, transactionCost: 0.0, slippageCoefficient: 0.0, annualBorrowCost: 0.0);
+
+        env.Reset();
+        // Ask for 1.0 in every name → gross 3.0, well over the 1.0 budget. Must be scaled down.
+        env.Step(new Vector<double>(new[] { 1.0, 1.0, 1.0 }));
+        Assert.True(env.GrossExposure <= 1.0 + 1e-6, $"gross exposure {env.GrossExposure} exceeded the leverage budget");
+    }
+
+    [Fact]
+    [Trait("category", "unit")]
+    public void Long_book_grows_on_a_rising_market()
+    {
+        // Two steadily-rising assets; go fully long and hold. Value must end above starting capital.
+        var prices = new List<double[]> { Ramp(100, 2, 40), Ramp(80, 1.5, 40) };
+        var env = new PortfolioManagerEnvironment<double>(
+            prices, null, windowSize: 5, initialCapital: 100_000, reward: new TotalReturnReward(),
+            maxLeverage: 1.0, transactionCost: 0.0005, slippageCoefficient: 0.0001, annualBorrowCost: 0.0);
+
+        env.Reset();
+        double value = 100_000;
+        var action = new Vector<double>(new[] { 0.5, 0.5 }); // fully invested, within budget
+        for (int i = 0; i < 25; i++)
+        {
+            var (_, _, done, info) = env.Step(action);
+            value = Convert.ToDouble(info["portfolioValue"]);
+            if (done) break;
+        }
+
+        Assert.True(value > 100_000, $"a long book on a rising market should grow (ended at {value:N0})");
+    }
+}

--- a/tests/AiDotNet.Tests/UnitTests/Finance/PortfolioStudyTests.cs
+++ b/tests/AiDotNet.Tests/UnitTests/Finance/PortfolioStudyTests.cs
@@ -62,6 +62,9 @@ public sealed class PortfolioStudyTests
             new List<(string, IPortfolioReward)> { ("r", new TotalReturnReward()) });
         Assert.Single(grid);
         Assert.Equal(1.0, grid[0].MaxLeverage);
+        // Defaults to the built-in friction configuration, tagged "default" in the experiment name.
+        Assert.Equal(new PortfolioFrictions(), grid[0].Frictions);
+        Assert.Contains("default", grid[0].Name);
     }
 
     [Fact]
@@ -73,15 +76,26 @@ public sealed class PortfolioStudyTests
         var experiments = PortfolioExperimentMatrix.Cross(
             new List<(string, IPortfolioReward)> { ("total", new TotalReturnReward()), ("sharpe", new DifferentialSharpeReward()) });
 
+        // Distinguishable policies (assigned by the factory call order the runner iterates in) make the ranking
+        // non-vacuous: the first experiment gets the PURE riser, the second gets a mostly-riser mix that carries
+        // 20% of the declining asset. Both beat the 50/50 equal-weight baseline (they hold more of the winner),
+        // but the pure riser has the higher risk-adjusted (Sharpe) score, so the ordering is meaningful. A single
+        // shared policy would give both experiments identical holdout metrics and a trivially-satisfied ordering.
+        int call = 0;
         var outcomes = PortfolioStudy.Run<double>(
             prices, null, trainFraction: 0.7, embargo: 3, windowSize: 5, initialCapital: 100_000,
-            experiments, agentFactory: (_, _) => new FixedWeightAgent(new[] { 1.0, 0.0 }), trainEpisodes: 1);
+            experiments,
+            agentFactory: (_, _) => new FixedWeightAgent(call++ == 0 ? new[] { 1.0, 0.0 } : new[] { 0.8, 0.2 }),
+            trainEpisodes: 1);
 
         Assert.Equal(2, outcomes.Count);
-        // Ranked by holdout Sharpe, descending.
-        Assert.True(outcomes[0].Agent.AnnualizedSharpe >= outcomes[1].Agent.AnnualizedSharpe);
-        // The riser-concentrated agent beats equal-weight (which holds the decliner) on the holdout.
-        Assert.All(outcomes, o => Assert.True(o.BeatBaseline));
+        // Ranked by holdout Sharpe (descending): the pure-riser experiment ("total") first, by exact name order.
+        Assert.StartsWith("total", outcomes[0].Name);
+        Assert.StartsWith("sharpe", outcomes[1].Name);
+        Assert.True(outcomes[0].Agent.AnnualizedSharpe > outcomes[1].Agent.AnnualizedSharpe,
+            $"pure-riser Sharpe {outcomes[0].Agent.AnnualizedSharpe} should exceed the mixed policy {outcomes[1].Agent.AnnualizedSharpe}");
+        // Both hold more of the winner than the 50/50 baseline, so both beat it on the holdout.
+        Assert.All(outcomes, o => Assert.True(o.BeatBaseline, $"{o.Name}: agent {o.Agent.AnnualizedSharpe} vs base {o.BaselineEqualWeight.AnnualizedSharpe}"));
         // Holdout has ~30 bars minus embargo minus the window warm-up — a positive, sane step count.
         Assert.All(outcomes, o => Assert.True(o.Agent.Steps > 0 && o.Agent.Steps < 30));
     }

--- a/tests/AiDotNet.Tests/UnitTests/Finance/PortfolioStudyTests.cs
+++ b/tests/AiDotNet.Tests/UnitTests/Finance/PortfolioStudyTests.cs
@@ -1,0 +1,88 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using AiDotNet.Finance.Trading.Evaluation;
+using AiDotNet.Finance.Trading.Rewards;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tests.UnitTests.Finance;
+
+/// <summary>
+/// Tests for the study entry point: the experiment-matrix cross-product and the one-call walk-forward study that
+/// splits the full history and ranks experiments on the untouched holdout.
+/// </summary>
+public sealed class PortfolioStudyTests
+{
+    private sealed class FixedWeightAgent : IPortfolioAgent<double>
+    {
+        private readonly double[] _w;
+        public FixedWeightAgent(double[] w) => _w = w;
+        public Vector<double> SelectAction(Vector<double> state, bool explore) => new((double[])_w.Clone());
+        public void StoreExperience(Vector<double> s, Vector<double> a, double r, Vector<double> n, bool d) { }
+        public double Train() => 0.0;
+        public void ResetEpisode() { }
+    }
+
+    private static double[] Ramp(double start, double step, int n)
+    {
+        var a = new double[n];
+        for (int i = 0; i < n; i++) a[i] = start + i * step;
+        return a;
+    }
+
+    [Fact]
+    [Trait("category", "unit")]
+    public void Matrix_produces_the_full_cross_product()
+    {
+        var rewards = new List<(string, IPortfolioReward)>
+        {
+            ("total", new TotalReturnReward()),
+            ("sharpe", new DifferentialSharpeReward()),
+        };
+        var leverages = new List<double> { 1.0, 2.0 };
+        var frictions = new List<(string, PortfolioFrictions)>
+        {
+            ("cheap", new PortfolioFrictions(TransactionCost: 0.0005)),
+            ("dear", new PortfolioFrictions(TransactionCost: 0.005)),
+        };
+
+        var grid = PortfolioExperimentMatrix.Cross(rewards, leverages, frictions);
+
+        Assert.Equal(2 * 2 * 2, grid.Count);                 // reward x leverage x frictions
+        Assert.Equal(grid.Count, grid.Select(e => e.Name).Distinct().Count()); // unique names
+        Assert.Contains(grid, e => e.MaxLeverage == 2.0);
+    }
+
+    [Fact]
+    [Trait("category", "unit")]
+    public void Matrix_defaults_to_single_leverage_and_frictions_when_omitted()
+    {
+        var grid = PortfolioExperimentMatrix.Cross(
+            new List<(string, IPortfolioReward)> { ("r", new TotalReturnReward()) });
+        Assert.Single(grid);
+        Assert.Equal(1.0, grid[0].MaxLeverage);
+    }
+
+    [Fact]
+    [Trait("category", "unit")]
+    public void Study_splits_walk_forward_and_ranks_experiments_on_the_holdout()
+    {
+        // Full 100-bar history; the study trains on the first 70% and evaluates on the untouched last 30%.
+        var prices = new List<double[]> { Ramp(100, 2, 100), Ramp(100, -1, 100) };
+        var experiments = PortfolioExperimentMatrix.Cross(
+            new List<(string, IPortfolioReward)> { ("total", new TotalReturnReward()), ("sharpe", new DifferentialSharpeReward()) });
+
+        var outcomes = PortfolioStudy.Run<double>(
+            prices, null, trainFraction: 0.7, embargo: 3, windowSize: 5, initialCapital: 100_000,
+            experiments, agentFactory: (_, _) => new FixedWeightAgent(new[] { 1.0, 0.0 }), trainEpisodes: 1);
+
+        Assert.Equal(2, outcomes.Count);
+        // Ranked by holdout Sharpe, descending.
+        Assert.True(outcomes[0].Agent.AnnualizedSharpe >= outcomes[1].Agent.AnnualizedSharpe);
+        // The riser-concentrated agent beats equal-weight (which holds the decliner) on the holdout.
+        Assert.All(outcomes, o => Assert.True(o.BeatBaseline));
+        // Holdout has ~30 bars minus embargo minus the window warm-up — a positive, sane step count.
+        Assert.All(outcomes, o => Assert.True(o.Agent.Steps > 0 && o.Agent.Steps < 30));
+    }
+}

--- a/tests/AiDotNet.Tests/UnitTests/Finance/RecurrentPolicyAgentTests.cs
+++ b/tests/AiDotNet.Tests/UnitTests/Finance/RecurrentPolicyAgentTests.cs
@@ -87,14 +87,29 @@ public sealed class RecurrentPolicyAgentTests
         var agent = new RecurrentPolicyAgent<double>(
             trainEnv.ObservationSpaceDimension, trainEnv.ActionSpaceSize, hidden: 16, learningRate: 1e-3, seed: 3);
 
-        double meanReturn = PortfolioAgentTrainer.Train(agent, trainEnv, episodes: 3);
-        Assert.True(double.IsFinite(meanReturn), $"training return {meanReturn} not finite");
+        // Deterministic probe read from a CLEAN hidden state before training, so a later read from the same clean
+        // state proves training updated the parameters (not just the recurrent state).
+        var probe = new Vector<double>(Enumerable.Range(0, trainEnv.ObservationSpaceDimension)
+            .Select(i => 0.05 * ((i % 7) - 3)).ToArray());
+        agent.ResetEpisode();
+        double probeBefore = agent.SelectAction(probe, explore: false)[0];
 
+        double meanReturn = PortfolioAgentTrainer.Train(agent, trainEnv, episodes: 3);
+        Assert.True((!double.IsNaN(meanReturn) && !double.IsInfinity(meanReturn)), $"training return {meanReturn} not finite");
+
+        // Same probe from a clean state after training must change — proof the parameters were updated.
+        agent.ResetEpisode();
+        double probeAfter = agent.SelectAction(probe, explore: false)[0];
+        Assert.True(Math.Abs(probeAfter - probeBefore) > 1e-9,
+            $"training should change the greedy policy output (before {probeBefore}, after {probeAfter})");
+
+        // Reset the recurrent state before the holdout so evaluation starts from a clean hidden state.
+        agent.ResetEpisode();
         var evalEnv = new PortfolioManagerEnvironment<double>(
             prices, null, windowSize: 5, initialCapital: 100_000, reward: new DifferentialSharpeReward());
         var result = PortfolioBacktest.Run(evalEnv, s => agent.SelectAction(s, explore: false));
 
-        Assert.True(double.IsFinite(result.FinalValue) && result.FinalValue > 0, $"final value {result.FinalValue}");
+        Assert.True((!double.IsNaN(result.FinalValue) && !double.IsInfinity(result.FinalValue)) && result.FinalValue > 0, $"final value {result.FinalValue}");
         Assert.True(result.Steps > 0);
     }
 }

--- a/tests/AiDotNet.Tests/UnitTests/Finance/RecurrentPolicyAgentTests.cs
+++ b/tests/AiDotNet.Tests/UnitTests/Finance/RecurrentPolicyAgentTests.cs
@@ -47,21 +47,28 @@ public sealed class RecurrentPolicyAgentTests
 
     [Fact]
     [Trait("category", "unit")]
-    public void Reset_episode_clears_recurrent_state()
+    public void Reset_episode_restores_the_agent_to_a_fresh_state()
     {
         var agent = new RecurrentPolicyAgent<double>(stateDim: 3, actionDim: 2, hidden: 8, seed: 2);
+        // A fresh, identical-weight agent (same seed) that only ever sees the probe — the reference for "clean state".
+        var fresh = new RecurrentPolicyAgent<double>(stateDim: 3, actionDim: 2, hidden: 8, seed: 2);
 
-        // Establish a history, then read the action for a probe observation.
+        // Establish a history on `agent`, then read the action for a probe observation.
         agent.SelectAction(State(1, 1, 1), explore: false);
         agent.SelectAction(State(1, 1, 1), explore: false);
         var afterHistory = agent.SelectAction(State(0.2, 0.2, 0.2), explore: false);
 
-        // Reset, then the SAME probe from a fresh state must differ from the mid-history read.
+        // After reset, the SAME probe from a clean state must (a) differ from the mid-history read, and
+        // (b) EXACTLY match the fresh agent's action for the probe — i.e. reset fully restores the hidden state,
+        // not merely perturbs it.
         agent.ResetEpisode();
         var afterReset = agent.SelectAction(State(0.2, 0.2, 0.2), explore: false);
+        var freshAction = fresh.SelectAction(State(0.2, 0.2, 0.2), explore: false);
 
-        double diff = Math.Abs(afterHistory[0] - afterReset[0]) + Math.Abs(afterHistory[1] - afterReset[1]);
-        Assert.True(diff > 1e-9, "hidden state should reset per episode");
+        double changed = Math.Abs(afterHistory[0] - afterReset[0]) + Math.Abs(afterHistory[1] - afterReset[1]);
+        Assert.True(changed > 1e-9, "hidden state should reset per episode (differs from the mid-history read)");
+        Assert.Equal(freshAction[0], afterReset[0], 12);
+        Assert.Equal(freshAction[1], afterReset[1], 12);
     }
 
     [Fact(Timeout = 120000)]

--- a/tests/AiDotNet.Tests/UnitTests/Finance/RecurrentPolicyAgentTests.cs
+++ b/tests/AiDotNet.Tests/UnitTests/Finance/RecurrentPolicyAgentTests.cs
@@ -1,0 +1,93 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using AiDotNet.Finance.Trading.Agents;
+using AiDotNet.Finance.Trading.Environments;
+using AiDotNet.Finance.Trading.Evaluation;
+using AiDotNet.Finance.Trading.Rewards;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tests.UnitTests.Finance;
+
+/// <summary>
+/// Tests for the recurrent (LSTM) portfolio policy agent: it is genuinely HISTORY-dependent (the defining
+/// property of a recurrent policy — same current input yields different actions depending on the past), its
+/// recurrent state resets per episode, and it trains end-to-end through the harness on the portfolio environment
+/// without error and yields finite holdout metrics. RL convergence itself is a research result (ranked via the
+/// experiment runner), not a unit assertion.
+/// </summary>
+public sealed class RecurrentPolicyAgentTests
+{
+    private static Vector<double> State(params double[] v) => new(v);
+
+    [Fact]
+    [Trait("category", "unit")]
+    public void Policy_is_history_dependent_same_input_different_past_gives_different_action()
+    {
+        // Two agents with identical weights (same seed). Feed them the SAME final observation but DIFFERENT
+        // history first. A memoryless policy would return the same action; a recurrent one must differ.
+        var a = new RecurrentPolicyAgent<double>(stateDim: 3, actionDim: 2, hidden: 8, seed: 1);
+        var b = new RecurrentPolicyAgent<double>(stateDim: 3, actionDim: 2, hidden: 8, seed: 1);
+
+        // Different histories.
+        a.SelectAction(State(1, 0, 0), explore: false);
+        a.SelectAction(State(1, 1, 0), explore: false);
+        b.SelectAction(State(-1, 0, 1), explore: false);
+        b.SelectAction(State(0, -1, 1), explore: false);
+
+        // Same current observation.
+        var actA = a.SelectAction(State(0.5, 0.5, 0.5), explore: false);
+        var actB = b.SelectAction(State(0.5, 0.5, 0.5), explore: false);
+
+        double diff = Math.Abs(actA[0] - actB[0]) + Math.Abs(actA[1] - actB[1]);
+        Assert.True(diff > 1e-9, "recurrent policy should condition on history — actions were identical");
+    }
+
+    [Fact]
+    [Trait("category", "unit")]
+    public void Reset_episode_clears_recurrent_state()
+    {
+        var agent = new RecurrentPolicyAgent<double>(stateDim: 3, actionDim: 2, hidden: 8, seed: 2);
+
+        // Establish a history, then read the action for a probe observation.
+        agent.SelectAction(State(1, 1, 1), explore: false);
+        agent.SelectAction(State(1, 1, 1), explore: false);
+        var afterHistory = agent.SelectAction(State(0.2, 0.2, 0.2), explore: false);
+
+        // Reset, then the SAME probe from a fresh state must differ from the mid-history read.
+        agent.ResetEpisode();
+        var afterReset = agent.SelectAction(State(0.2, 0.2, 0.2), explore: false);
+
+        double diff = Math.Abs(afterHistory[0] - afterReset[0]) + Math.Abs(afterHistory[1] - afterReset[1]);
+        Assert.True(diff > 1e-9, "hidden state should reset per episode");
+    }
+
+    [Fact(Timeout = 120000)]
+    [Trait("category", "unit")]
+    public async Task Trains_end_to_end_through_the_harness_with_finite_holdout_metrics()
+    {
+        await Task.Yield();
+        var prices = new List<double[]>
+        {
+            Enumerable.Range(0, 40).Select(i => 100.0 + i).ToArray(),
+            Enumerable.Range(0, 40).Select(i => 100.0 + 0.5 * i).ToArray(),
+        };
+        var trainEnv = new PortfolioManagerEnvironment<double>(
+            prices, null, windowSize: 5, initialCapital: 100_000, reward: new DifferentialSharpeReward());
+
+        var agent = new RecurrentPolicyAgent<double>(
+            trainEnv.ObservationSpaceDimension, trainEnv.ActionSpaceSize, hidden: 16, learningRate: 1e-3, seed: 3);
+
+        double meanReturn = PortfolioAgentTrainer.Train(agent, trainEnv, episodes: 3);
+        Assert.True(double.IsFinite(meanReturn), $"training return {meanReturn} not finite");
+
+        var evalEnv = new PortfolioManagerEnvironment<double>(
+            prices, null, windowSize: 5, initialCapital: 100_000, reward: new DifferentialSharpeReward());
+        var result = PortfolioBacktest.Run(evalEnv, s => agent.SelectAction(s, explore: false));
+
+        Assert.True(double.IsFinite(result.FinalValue) && result.FinalValue > 0, $"final value {result.FinalValue}");
+        Assert.True(result.Steps > 0);
+    }
+}

--- a/tests/AiDotNet.Tests/UnitTests/Finance/WalkForwardSplitTests.cs
+++ b/tests/AiDotNet.Tests/UnitTests/Finance/WalkForwardSplitTests.cs
@@ -65,4 +65,24 @@ public sealed class WalkForwardSplitTests
         Assert.Throws<ArgumentOutOfRangeException>(() => WalkForwardSplit.Split(new List<double[]> { Index(10) }, 1.0));
         Assert.Throws<ArgumentException>(() => WalkForwardSplit.Split(new List<double[]> { Index(10), Index(9) }, 0.5));
     }
+
+    [Fact]
+    [Trait("category", "unit")]
+    public void Rejects_nonfinite_fraction_negative_embargo_and_empty_partitions()
+    {
+        var series = new List<double[]> { Index(10) };
+
+        // NaN / infinity must not slip through the range check (every NaN comparison is false).
+        Assert.Throws<ArgumentOutOfRangeException>(() => WalkForwardSplit.Split(series, double.NaN));
+        Assert.Throws<ArgumentOutOfRangeException>(() => WalkForwardSplit.Split(series, double.PositiveInfinity));
+
+        // Negative embargo is a caller bug — rejected, not silently rewritten to 0.
+        Assert.Throws<ArgumentOutOfRangeException>(() => WalkForwardSplit.Split(series, 0.7, embargo: -1));
+
+        // Zero-length series → an empty train partition.
+        Assert.Throws<ArgumentException>(() => WalkForwardSplit.Split(new List<double[]> { Array.Empty<double>() }, 0.7));
+
+        // An embargo that consumes the whole tail → an empty holdout (splitIndex 7 + embargo 5 >= length 10).
+        Assert.Throws<ArgumentException>(() => WalkForwardSplit.Split(series, 0.7, embargo: 5));
+    }
 }

--- a/tests/AiDotNet.Tests/UnitTests/Finance/WalkForwardSplitTests.cs
+++ b/tests/AiDotNet.Tests/UnitTests/Finance/WalkForwardSplitTests.cs
@@ -1,0 +1,68 @@
+using System;
+using System.Collections.Generic;
+using AiDotNet.Finance.Trading.Evaluation;
+using Xunit;
+
+namespace AiDotNet.Tests.UnitTests.Finance;
+
+/// <summary>
+/// Tests for the chronological walk-forward train/holdout split — the honest-eval discipline for time-series RL
+/// (train on the past, evaluate on a strictly-later untouched tail, with an embargo gap to block leakage).
+/// Row value == index makes the boundary observable.
+/// </summary>
+public sealed class WalkForwardSplitTests
+{
+    private static double[] Index(int n)
+    {
+        var a = new double[n];
+        for (int i = 0; i < n; i++) a[i] = i;
+        return a;
+    }
+
+    [Fact]
+    [Trait("category", "unit")]
+    public void Splits_chronologically_at_the_fraction()
+    {
+        var (train, holdout) = WalkForwardSplit.Split(new List<double[]> { Index(100) }, trainFraction: 0.7);
+
+        Assert.Equal(70, train[0].Length);
+        Assert.Equal(30, holdout[0].Length);
+        Assert.Equal(0.0, train[0][0]);        // train starts at the beginning
+        Assert.Equal(69.0, train[0][^1]);      // ...ends just before the split
+        Assert.Equal(70.0, holdout[0][0]);     // holdout starts strictly after (chronological, no shuffle)
+    }
+
+    [Fact]
+    [Trait("category", "unit")]
+    public void Embargo_drops_a_gap_at_the_boundary()
+    {
+        var (train, holdout) = WalkForwardSplit.Split(new List<double[]> { Index(100) }, trainFraction: 0.7, embargo: 5);
+
+        Assert.Equal(70, train[0].Length);
+        Assert.Equal(70.0 - 1, train[0][^1]);        // train unchanged: rows [0,70)
+        Assert.Equal(75.0, holdout[0][0]);           // holdout starts 5 rows later — the gap is dropped
+        Assert.Equal(25, holdout[0].Length);         // 100 - 70 - 5
+    }
+
+    [Fact]
+    [Trait("category", "unit")]
+    public void All_columns_split_identically()
+    {
+        var (train, holdout) = WalkForwardSplit.Split(
+            new List<double[]> { Index(50), Index(50) }, trainFraction: 0.6, embargo: 2);
+
+        Assert.Equal(2, train.Count);
+        Assert.Equal(2, holdout.Count);
+        Assert.Equal(train[0].Length, train[1].Length);
+        Assert.Equal(holdout[0][0], holdout[1][0]); // same boundary for every column
+    }
+
+    [Fact]
+    [Trait("category", "unit")]
+    public void Rejects_invalid_fraction_and_ragged_columns()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => WalkForwardSplit.Split(new List<double[]> { Index(10) }, 0.0));
+        Assert.Throws<ArgumentOutOfRangeException>(() => WalkForwardSplit.Split(new List<double[]> { Index(10) }, 1.0));
+        Assert.Throws<ArgumentException>(() => WalkForwardSplit.Split(new List<double[]> { Index(10), Index(9) }, 0.5));
+    }
+}


### PR DESCRIPTION
## What

Phases 1–2 of a greenfield SOTA trading-agent core, built as a **research harness** (the options become experiments ranked on an untouched holdout, not an either/or pick).

### Phase 1 — the environment (the missing centerpiece)
`PortfolioManagerEnvironment<T>` — a **cross-sectional** MDP where the agent manages the whole book: target-weight vector over the universe, every position reconciled toward it, so **entry/exit/sizing/rotation is one learned decision** (a per-symbol agent can't rotate a book — the reason "sell when it falls off the top-movers list" is a hack). Beyond the basic `PortfolioTradingEnvironment` (weights forced to sum to 1, every column tradable, default reward, no real frictions) it adds: **gross-leverage budget** (hold cash / lever / short), **observation-only feature columns** (per-name "analyst" forecasts/uncertainty for the hierarchy), **pluggable `IPortfolioReward`**, and **realistic frictions** (transaction + slippage + short-borrow + carry, deducted from cash).

Rewards: `TotalReturnReward` (turnover/drawdown penalties) and `DifferentialSharpeReward` (Moody & Saffell online differential Sharpe — the canonical risk-adjusted RL objective).

### Phase 2 — the honest-eval harness
- `PortfolioBacktest` — scores any policy (`state → action`) on final value / total return / annualized Sharpe / max drawdown / turnover, so a scripted baseline and a trained agent evaluate identically.
- `BaselinePolicies` — equal-weight (rebalanced buy-and-hold) + flat (all-cash) no-skill controls.
- `IPortfolioAgent<T>` + `PortfolioAgentTrainer` — the experience-collection loop (`PortfolioAgent.From` adapts any AiDotNet PPO/SAC/TD3 agent).
- `PortfolioExperimentRunner` — train a fresh agent per reward experiment, evaluate it + the baseline on the **untouched holdout**, flag beat-baseline, rank by holdout Sharpe.

## Tests (14)

Env (6): differential Sharpe prefers smooth over equal-mean volatile; turnover/drawdown penalties; reset; action-space == tradable count (feature columns untraded); leverage budget enforced; long book grows on a rising market. Evaluator (4): full-long scores +return/+Sharpe/~0-DD; flat holds capital; equal-weight grows multi-asset; rise-then-fall records drawdown. Harness (4): trainer drives the full loop; runner flags a genuine winner and rejects a do-nothing flat agent; and a **real SACAgent trains end-to-end** through the harness with finite holdout metrics.

## Next (release-gated)

Phase 3 (Ooples): per-symbol "analyst" agents → this portfolio manager, run as a **parallel paper lane** vs the current strategies, cut over on a demonstrated holdout win. Gated on this shipping to NuGet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added portfolio management environments with continuous allocation, leverage limits, trading costs, exposure tracking, and configurable rewards.
  * Added feed-forward and recurrent policy agents for portfolio training.
  * Added portfolio backtesting with Sharpe, Sortino, drawdown, Calmar, turnover, and baseline strategies.
  * Added experiment runners, friction comparisons, and walk-forward evaluation with holdout ranking.
  * Added financial forecasting metrics, including directional accuracy, Sharpe, Sortino, drawdown, profit factor, and information coefficient.
  * Added support for configuring custom financial metrics during model building.
* **Tests**
  * Added comprehensive coverage for portfolio training, evaluation, agents, rewards, financial metrics, and time-series splitting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->