### PR TITLE
perf(timeseries): stop per-element GPU host reads in Autoformer/Informer/TFT forwards

### DIFF
--- a/src/TimeSeries/AutoformerModel.cs
+++ b/src/TimeSeries/AutoformerModel.cs
@@ -107,6 +107,10 @@ public class AutoformerModel<T> : TimeSeriesModelBase<T>, ISupportsLossFunction<
     // Input embedding
     private Tensor<T> _inputProjection;      // [embeddingDim, 1]
     private Tensor<T> _positionalEncoding;   // [maxLen, embeddingDim]
+    // Host-side copy of the (constant) positional encoding. The forward assembles a per-window PE tensor from
+    // it every step; indexing _positionalEncoding[i] on a GPU-resident tensor would sync per element (seqLen*dim
+    // reads per forward). The PE never changes after construction, so cache one host download and read that.
+    private T[]? _positionalEncodingHost;
 
     // Encoder components
     private readonly List<AutoformerEncoderLayer<T>> _encoderLayers;
@@ -195,6 +199,7 @@ public class AutoformerModel<T> : TimeSeriesModelBase<T>, ISupportsLossFunction<
         // Sinusoidal positional encoding
         int maxLen = Math.Max(_options.LookbackWindow, _options.ForecastHorizon) * 2;
         _positionalEncoding = CreateSinusoidalPositionalEncoding(maxLen, _options.EmbeddingDim);
+        _positionalEncodingHost = _positionalEncoding.GetCpuData();
 
         // Encoder layers with series decomposition and auto-correlation
         for (int i = 0; i < _options.NumEncoderLayers; i++)
@@ -468,7 +473,8 @@ public class AutoformerModel<T> : TimeSeriesModelBase<T>, ISupportsLossFunction<
         var inputTensor = new Tensor<T>(new[] { seqLen, 1 }, inData);
 
         var posData = new Vector<T>(seqLen * embDim);
-        for (int i = 0; i < seqLen * embDim; i++) posData[i] = _positionalEncoding[i];
+        var peHost = _positionalEncodingHost ??= _positionalEncoding.GetCpuData();
+        for (int i = 0; i < seqLen * embDim; i++) posData[i] = peHost[i];
         var posTensor = new Tensor<T>(new[] { seqLen, embDim }, posData);
 
         // Embedding: input @ inputProj(1×embDim) + positional encoding.
@@ -572,9 +578,13 @@ public class AutoformerModel<T> : TimeSeriesModelBase<T>, ISupportsLossFunction<
         var corr = Engine.Concat(corrParts, 0); // [corrLen]
 
         // Top-k delays by correlation value (host read of the forward values; the index choice is
-        // non-differentiable, like the paper's topk over the autocorrelation spectrum).
+        // non-differentiable, like the paper's topk over the autocorrelation spectrum). Download the whole
+        // [corrLen] vector in ONE device->host copy: indexing corr[lag] per element on a GPU-resident tensor
+        // forces a separate transfer + full pipeline sync each time (corrLen syncs per call, ×4 calls per
+        // forward, ×samples, ×epochs) — the dominant cost that left the GPU ~7% busy while the model timed out.
+        var corrHost = corr.GetCpuData();
         var corrVals = new double[corrLen];
-        for (int lag = 0; lag < corrLen; lag++) corrVals[lag] = _numOps.ToDouble(corr[lag]);
+        for (int lag = 0; lag < corrLen; lag++) corrVals[lag] = _numOps.ToDouble(corrHost[lag]);
         var topLags = Enumerable.Range(0, corrLen)
             .OrderByDescending(i => corrVals[i])
             .Take(topK)
@@ -886,6 +896,7 @@ public class AutoformerModel<T> : TimeSeriesModelBase<T>, ISupportsLossFunction<
         // Read tensors
         _inputProjection = ReadTensor(reader);
         _positionalEncoding = ReadTensor(reader);
+        _positionalEncodingHost = _positionalEncoding.GetCpuData();
         _decoderSeasonalInit = ReadTensor(reader);
         _decoderTrendInit = ReadTensor(reader);
         _seasonalProjection = ReadTensor(reader);

--- a/src/TimeSeries/InformerModel.cs
+++ b/src/TimeSeries/InformerModel.cs
@@ -76,6 +76,10 @@ public class InformerModel<T> : TimeSeriesModelBase<T>, ISupportsLossFunction<T>
     // Input embedding and positional encoding (Tensor-based)
     private Tensor<T> _inputProjection;      // [embeddingDim, 1]
     private Tensor<T> _positionalEncoding;   // [maxLen, embeddingDim]
+    // Host-side copy of the (constant) positional encoding. The forward assembles the per-batch PE from it
+    // every step; indexing _positionalEncoding[i] on a GPU-resident tensor syncs per element
+    // (batch*seqLen*dim reads per forward). The PE never changes, so cache one host download.
+    private T[]? _positionalEncodingHost;
 
     // Encoder components with distilling (Tensor-based)
     private readonly List<InformerEncoderLayerTensor<T>> _encoderLayers;
@@ -170,6 +174,7 @@ public class InformerModel<T> : TimeSeriesModelBase<T>, ISupportsLossFunction<T>
         // Sinusoidal positional encoding for the maximum sequence length
         int maxLen = Math.Max(_options.LookbackWindow, _options.ForecastHorizon) * 2;
         _positionalEncoding = CreateSinusoidalPositionalEncoding(maxLen, _options.EmbeddingDim);
+        _positionalEncodingHost = _positionalEncoding.GetCpuData();
 
         // Encoder layers with distilling
         int currentSeqLen = _options.LookbackWindow;
@@ -727,10 +732,11 @@ public class InformerModel<T> : TimeSeriesModelBase<T>, ISupportsLossFunction<T>
         var flatIn = Engine.Reshape(batchInput, new[] { batch * encLen0, 1 });
         var proj = Engine.TensorMatMul(flatIn, Engine.Reshape(_inputProjection, new[] { 1, d })); // [B*L, d]
         var posEnc = new Vector<T>(batch * encLen0 * d);
+        var peHost = _positionalEncodingHost ??= _positionalEncoding.GetCpuData();
         for (int bi = 0; bi < batch; bi++)
             for (int t = 0; t < encLen0; t++)
                 for (int j = 0; j < d; j++)
-                    posEnc[(bi * encLen0 + t) * d + j] = _positionalEncoding[t * d + j];
+                    posEnc[(bi * encLen0 + t) * d + j] = peHost[t * d + j];
         var embFlat = Engine.TensorAdd(proj, new Tensor<T>(new[] { batch * encLen0, d }, posEnc));
 
         // Encoder stack with distilling.
@@ -751,7 +757,7 @@ public class InformerModel<T> : TimeSeriesModelBase<T>, ISupportsLossFunction<T>
         var decPosData = new Vector<T>(horizon * d);
         for (int t = 0; t < horizon; t++)
             for (int j = 0; j < d; j++)
-                decPosData[t * d + j] = _positionalEncoding[(_options.LookbackWindow + t) * d + j];
+                decPosData[t * d + j] = peHost[(_options.LookbackWindow + t) * d + j];
         var decPos = new Tensor<T>(new[] { 1, horizon, d }, decPosData);
         var start3 = Engine.Reshape(_decoderStartToken, new[] { 1, 1, d });
         var dec3 = Engine.TensorBroadcastAdd(
@@ -972,6 +978,7 @@ public class InformerModel<T> : TimeSeriesModelBase<T>, ISupportsLossFunction<T>
         // Read main tensors
         _inputProjection = ReadTensor(reader);
         _positionalEncoding = ReadTensor(reader);
+        _positionalEncodingHost = _positionalEncoding.GetCpuData();
         _decoderStartToken = ReadTensor(reader);
         _outputProjection = ReadTensor(reader);
         _outputBias = ReadTensor(reader);

--- a/src/TimeSeries/TemporalFusionTransformer.cs
+++ b/src/TimeSeries/TemporalFusionTransformer.cs
@@ -60,6 +60,9 @@ public class TemporalFusionTransformer<T> : TimeSeriesModelBase<T>
 
     // Sinusoidal positional encoding [maxLen, hiddenSize] (replaces the LSTM scan).
     private Tensor<T> _positionalEncoding;
+    // Host-side copy of the (constant) positional encoding. The forward assembles the per-batch PE from it
+    // every step; indexing the tensor per element syncs the GPU batch*seq*dim times per forward.
+    private T[]? _positionalEncodingHost;
 
     // Variable selection (softmax-weighted feature combination).
     private GatedResidualNetwork<T> _vsnFeatureGrn; // processes embedded features
@@ -133,6 +136,7 @@ public class TemporalFusionTransformer<T> : TimeSeriesModelBase<T>
 
         // Positional encoding for the full lookback window.
         _positionalEncoding = CreateSinusoidalPositionalEncoding(Math.Max(1, _options.LookbackWindow), d);
+        _positionalEncodingHost = _positionalEncoding.GetCpuData();
 
         // Variable selection GRNs.
         _vsnFeatureGrn = new GatedResidualNetwork<T>(d, d, d, seed: _random.Next());
@@ -348,10 +352,11 @@ public class TemporalFusionTransformer<T> : TimeSeriesModelBase<T>
         var emb = Engine.TensorMatMul(flatIn, _inputEmbeddingWeight); // [B*L, d]
         emb = Engine.TensorBroadcastAdd(emb, Engine.Reshape(_inputEmbeddingBias, [1, d]));
         var posData = new Vector<T>(batch * seq * d);
+        var peHost = _positionalEncodingHost ??= _positionalEncoding.GetCpuData();
         for (int bi = 0; bi < batch; bi++)
             for (int t = 0; t < seq; t++)
                 for (int j = 0; j < d; j++)
-                    posData[(bi * seq + t) * d + j] = _positionalEncoding[t * d + j];
+                    posData[(bi * seq + t) * d + j] = peHost[t * d + j];
         emb = Engine.TensorAdd(emb, new Tensor<T>([batch * seq, d], posData));
 
         // 2. Variable selection: softmax-gated combination of processed features.


### PR DESCRIPTION
## Problem

`AutoformerModel`, `InformerModel` and `TemporalFusionTransformer` read GPU-resident tensors **element by element** inside their forward passes. On the DirectGpu engine every such index is a separate device→host transfer that flushes the pipeline, so one forward stalled the GPU hundreds to thousands of times.

Two hot-path sites:

1. **Autoformer auto-correlation top-k** — read the `[corrLen]` correlation vector one element at a time:
   ```csharp
   for (int lag = 0; lag < corrLen; lag++) corrVals[lag] = _numOps.ToDouble(corr[lag]);
   ```
   That is `corrLen` syncs per call, and the engine is called 4× per forward (encoder self-attention ×2, decoder self + cross). Now a single `corr.GetCpuData()` bulk download.

2. **Positional-encoding assembly (all three models)** — the per-window/per-batch PE was built by indexing `_positionalEncoding` per element every forward: `seqLen*dim` reads for Autoformer, `batch*seqLen*dim` for Informer and TFT. The PE is **constant** after construction, so it is now downloaded once into a host array and cached (refreshed on deserialize).

## Correctness

Behavior is unchanged — same values, same gradients. The correlation top-k index choice was already non-differentiable (as in the paper), and the PE was already a constant, no-grad input. This changes only *how the values reach the host*, not what they are.

## Measured (RTX 3080, FCHL research sweep, float models, 15-min bars)

| | before | after |
|---|---|---|
| GPU utilization, heavy-transformer training | ~7% | 10–15% |

## Honest scope — what this does NOT fix

These models were also **timing out** in that sweep, and this PR does **not** resolve that. Investigation showed the timeouts were not a code defect: one research cell runs **7 full trainings** (6 walk-forward folds + 1 hold-out refit), and at 8 epochs that needs ~300–520 s against the harness's 300 s cap. Measured cost is **~9.3 s per training at 1 epoch**; given an adequate budget the same cells complete with **0 timeouts and 0 faults**.

So this is a genuine but *incremental* GPU-efficiency fix, not a fix for the timeouts. I'm flagging that explicitly so the perf numbers here aren't read as more than they are.

## Build

Clean on net10.0, net8.0 and net471.

🤖 Generated with [Claude Code](https://claude.com/claude-code)