### PR TITLE
fix(tests): repair UTF-8 corruption in TrainingContractParityTests doc comment

### DIFF
--- a/tests/AiDotNet.Tests/IntegrationTests/Training/TrainingContractParityTests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/Training/TrainingContractParityTests.cs
@@ -22,7 +22,7 @@ namespace AiDotNet.Tests.IntegrationTests.Training;
 /// <remarks>
 /// Neural networks reach training through the optimizer path, which already drives the facade's
 /// per-epoch seam (OptimizerBase.SetEpochProgressCallback -> InvokeTrainingEpoch). TimeSeries models
-/// instead own their epoch loop inside Train(), which the facade calls once � so their callbacks fired
+/// instead own their epoch loop inside Train(), which the facade calls once — so their callbacks fired
 /// a single synthetic epoch after training had finished, and no veto could take effect. These tests
 /// assert the neural side genuinely works, so that the two families cannot silently diverge again.
 /// </remarks>


### PR DESCRIPTION
## Problem

`Utf8EncodingTests.SourceFiles_ShouldNotContainReplacementCharacter` is **failing on master**. `TrainingContractParityTests.cs` line 25 carries a `U+FFFD` replacement character where an em dash belongs:

```
/// instead own their epoch loop inside Train(), which the facade calls once <U+FFFD> so their callbacks fired
```

## Why fix it centrally

CI builds each PR **merged with master**, so this red check appears on every open PR in the repo regardless of what that PR touches. It surfaced on #1897, whose diff was confined to `src/TimeSeries/*` and could not have caused it. Fixing it at the source unblocks all of them rather than each PR carrying an unrelated red check.

## Change

One character: `U+FFFD` → em dash (`U+2014`), matching the surrounding comment style.

A repo-wide scan (`grep -rl $'\xef\xbf\xbd'` across `.cs`/`.md`/`.csproj`/`.json`, excluding `bin`/`obj`) confirms this was the **only** occurrence in tracked source, so this fully clears the check rather than fixing one instance of many.

## Verification

```
dotnet test --filter FullyQualifiedName~Utf8EncodingTests
Passed! - Failed: 0, Passed: 1
```
Test project builds clean on net10.0.

## Follow-up worth noting

The failure message advises running `python3 scripts/fix-encoding.py`, but **that script does not exist** in the repo. Either the script should be added or the message updated — I left both alone here to keep this PR to the one-character fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)