### PR TITLE
feat: device-agnostic execution + GGUF Q8_0 quantized serving + CPU decode/prefill perf

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -266,7 +266,7 @@
          weights. Fixes real GGUF-decoder-under-GPU serving (greedy first token 7042 " Paris" was 32084);
          pairs with this branch's LlamaModelBuilder.WriteGamma routing gamma through SetParameters so its
          persistent buffer refreshes too. -->
-    <PackageVersion Include="AiDotNet.Tensors" Version="0.117.200-devexec" />
+    <PackageVersion Include="AiDotNet.Tensors" Version="0.117.201-devexec" />
     <PackageVersion Include="AiDotNet.Native.OneDNN" Version="0.114.0" />
     <PackageVersion Include="AiDotNet.Native.OpenBLAS" Version="0.114.0" />
     <PackageVersion Include="AiDotNet.Native.CLBlast" Version="0.114.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -266,7 +266,7 @@
          weights. Fixes real GGUF-decoder-under-GPU serving (greedy first token 7042 " Paris" was 32084);
          pairs with this branch's LlamaModelBuilder.WriteGamma routing gamma through SetParameters so its
          persistent buffer refreshes too. -->
-    <PackageVersion Include="AiDotNet.Tensors" Version="0.117.201-devexec" />
+    <PackageVersion Include="AiDotNet.Tensors" Version="0.118.10-q8" />
     <PackageVersion Include="AiDotNet.Native.OneDNN" Version="0.114.0" />
     <PackageVersion Include="AiDotNet.Native.OpenBLAS" Version="0.114.0" />
     <PackageVersion Include="AiDotNet.Native.CLBlast" Version="0.114.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -266,7 +266,7 @@
          weights. Fixes real GGUF-decoder-under-GPU serving (greedy first token 7042 " Paris" was 32084);
          pairs with this branch's LlamaModelBuilder.WriteGamma routing gamma through SetParameters so its
          persistent buffer refreshes too. -->
-    <PackageVersion Include="AiDotNet.Tensors" Version="0.117.2" />
+    <PackageVersion Include="AiDotNet.Tensors" Version="0.117.200-devexec" />
     <PackageVersion Include="AiDotNet.Native.OneDNN" Version="0.114.0" />
     <PackageVersion Include="AiDotNet.Native.OpenBLAS" Version="0.114.0" />
     <PackageVersion Include="AiDotNet.Native.CLBlast" Version="0.114.0" />

--- a/benchmarks/AiDotNet.Serving.DevHost/Program.cs
+++ b/benchmarks/AiDotNet.Serving.DevHost/Program.cs
@@ -35,6 +35,32 @@ else
     Console.WriteLine($"[DevHost] CPU engine ({AiDotNetEngine.Current.GetType().Name}).");
 }
 
+// Profiling mode: DEVHOST_PROFILE=<gguf-path> runs a steady-state forward loop (NO web server) so a sampler
+// (dotnet-trace / PerfView) can capture the real GGUF decoder's CPU hot paths + allocations. The engine is
+// whatever was selected above (DEVHOST_GPU). Loops the 128-token prefill forward (constant shape = clean
+// steady state; it is the per-forward hot path both prefill and the stateless decode share). Runs until killed.
+string? profileGguf = Environment.GetEnvironmentVariable("DEVHOST_PROFILE");
+if (!string.IsNullOrWhiteSpace(profileGguf))
+{
+    if (!File.Exists(profileGguf)) { Console.Error.WriteLine($"[Profile] GGUF not found: {profileGguf}"); return; }
+    int profLen = int.TryParse(Environment.GetEnvironmentVariable("DEVHOST_PROFILE_LEN"), out var pl) && pl > 0 ? pl : 128;
+    Console.WriteLine($"[Profile] loading {profileGguf} (prefill len={profLen}, engine={AiDotNetEngine.Current.GetType().Name})");
+    var (profModel, _) = PretrainedLoader<float>.LoadGgufWithTokenizer(profileGguf);
+    var profInput = new Tensor<float>(new[] { 1, profLen });
+    for (int i = 0; i < profLen; i++) profInput[0, i] = (i % 100) + 5;
+    Console.WriteLine("[Profile] warmup (compile kernels / JIT)...");
+    for (int w = 0; w < 3; w++) _ = profModel.Predict(profInput).Contiguous().AsSpan()[0];
+    Console.WriteLine("[Profile] steady-state loop — attach dotnet-trace to this PID, then kill to stop.");
+    long profIter = 0;
+    var profSw = System.Diagnostics.Stopwatch.StartNew();
+    while (true)
+    {
+        _ = profModel.Predict(profInput).Contiguous().AsSpan()[0];
+        if (++profIter % 20 == 0)
+            Console.WriteLine($"[Profile] {profIter} forwards, {profIter * profLen / profSw.Elapsed.TotalSeconds:F0} tok/s");
+    }
+}
+
 // ---------------------------------------------------------------------------
 // DEV/BENCHMARK host. Wires the REAL OpenAI controller + generation engine +
 // tokenizer registry, with NO auth/DB, plus a SYNTHETIC generative model, so

--- a/benchmarks/AiDotNet.Serving.DevHost/Program.cs
+++ b/benchmarks/AiDotNet.Serving.DevHost/Program.cs
@@ -4,6 +4,7 @@ using AiDotNet.Enums;
 using AiDotNet.ModelLoading.Pretrained;
 using AiDotNet.NeuralNetworks;
 using AiDotNet.NeuralNetworks.Layers;
+using AiDotNet.Serving.Configuration;
 using AiDotNet.Serving.Controllers;
 using AiDotNet.Serving.Models;
 using AiDotNet.Serving.Services;
@@ -122,6 +123,41 @@ if (!string.IsNullOrWhiteSpace(ggufPath))
 
     repo.LoadModel<float>(ModelName, ggufWrapper);
     tokenizers.Register(ModelName, ggufTokenizer);
+
+    // Decode-throughput benchmark: DEVHOST_DECODE=1 drives the REAL incremental (paged KV-cache) generation
+    // path and reports tokens/second + ms/token — the metric competitors quote as "tg" (token generation).
+    // NO web server; runs and exits. DEVHOST_DECODE_PROMPT / DEVHOST_DECODE_LEN tune the prompt + generated
+    // length.
+    if (Environment.GetEnvironmentVariable("DEVHOST_DECODE") == "1")
+    {
+        var genSvc = app.Services.GetRequiredService<ITextGenerationService>();
+        int promptLen = EnvInt("DEVHOST_DECODE_PROMPT", 16);
+        int genLen = EnvInt("DEVHOST_DECODE_LEN", 64);
+        var prompt = new int[promptLen];
+        for (int i = 0; i < promptLen; i++) prompt[i] = (i % 100) + 5;
+        var req = new SpeculativeDecodingRequest
+        {
+            InputTokens = prompt,
+            MaxNewTokens = genLen,
+            EosTokenId = -1, // out of range -> generate to the token limit
+            NumDraftTokens = 0,
+            Temperature = 0, // greedy
+        };
+        Console.WriteLine($"[Decode] incrementalPaged={ggufWrapper.SupportsIncrementalGeneration} warmup...");
+        _ = genSvc.Generate(ModelName, NumericType.Float, req);
+        const int runs = 3;
+        var dsw = System.Diagnostics.Stopwatch.StartNew();
+        int produced = 0;
+        for (int r = 0; r < runs; r++)
+        {
+            var gt = genSvc.Generate(ModelName, NumericType.Float, req).GeneratedTokens;
+            produced += gt is null ? 0 : System.Linq.Enumerable.Count(gt);
+        }
+        dsw.Stop();
+        double msPerTok = dsw.Elapsed.TotalMilliseconds / Math.Max(1, produced);
+        Console.WriteLine($"[Decode] prompt={promptLen} gen={genLen} produced={produced} : {1000.0 / msPerTok:F1} tok/s ({msPerTok:F2} ms/token)");
+        return;
+    }
 
     app.MapControllers();
     app.Logger.LogInformation(

--- a/src/Agentic/Models/Local/GgufFile.cs
+++ b/src/Agentic/Models/Local/GgufFile.cs
@@ -207,6 +207,42 @@ public sealed class GgufFile : INamedTensorSource
         }
     }
 
+    /// <summary>
+    /// Reads a Q8_0 tensor's raw quantized blocks WITHOUT dequantizing: the int8 quants
+    /// (<paramref name="qs"/>, length = element count) and one fp32 scale per 32-value block
+    /// (<paramref name="scales"/>, length = count/32). This is the native ggml Q8_0 payload —
+    /// keeping it quantized lets a block-Q8_0 GEMM run directly on it (no fp32 expansion, ~3.76×
+    /// less weight memory). Returns <c>false</c> for tensors that are not Q8_0.
+    /// </summary>
+    public bool TryReadQ8_0Raw(string name, out sbyte[] qs, out float[] scales)
+    {
+        Guard.NotNull(name);
+        qs = System.Array.Empty<sbyte>();
+        scales = System.Array.Empty<float>();
+        if (!_byName.TryGetValue(name, out var tensor)) return false;
+        if (tensor.GgmlType != GgufTensorInfo.TypeQ8_0) return false;
+
+        var count = checked((int)tensor.ElementCount);
+        const int blockBytes = 34; // fp16 scale (2) + 32 int8
+        var blocks = count / GgufTensorInfo.QuantBlockSize;
+        var offset = ValidateBlockSpan(tensor, count, blockBytes, GgufTensorInfo.QuantBlockSize);
+
+        qs = new sbyte[count];
+        scales = new float[blocks];
+        for (var b = 0; b < blocks; b++)
+        {
+            var p = offset + (b * blockBytes);
+            scales[b] = (float)HalfToFloat(BitConverter.ToUInt16(_data, p));
+            var qbase = p + 2;
+            var outBase = b * GgufTensorInfo.QuantBlockSize;
+            for (var j = 0; j < GgufTensorInfo.QuantBlockSize; j++)
+            {
+                qs[outBase + j] = unchecked((sbyte)_data[qbase + j]);
+            }
+        }
+        return true;
+    }
+
     // Q8_0: per block = fp16 scale + 32 signed 8-bit quants; value = q * scale.
     private void DequantizeQ8_0(int offset, int count, double[] result)
     {

--- a/src/AiModelBuilder.Pretrained.cs
+++ b/src/AiModelBuilder.Pretrained.cs
@@ -28,4 +28,24 @@ public partial class AiModelBuilder<T, TInput, TOutput>
 
         return ConfigureModel(typed);
     }
+
+    /// <inheritdoc/>
+    public IAiModelBuilder<T, TInput, TOutput> ConfigureModel(
+        PretrainedSource source, AiDotNet.Tensors.DeviceInfo device)
+    {
+        Guard.NotNull(source);
+
+        var model = PretrainedLoader<T>.Load(source);
+        if (model is not IFullModel<T, TInput, TOutput> typed)
+            throw new InvalidOperationException(
+                $"Pretrained source '{source}' produces a Tensor<{typeof(T).Name}> -> Tensor<{typeof(T).Name}> " +
+                $"model, but this builder is configured for {typeof(TInput).Name} -> {typeof(TOutput).Name}. " +
+                "Configure the builder as AiModelBuilder<T, Tensor<T>, Tensor<T>> to load decoder models.");
+
+        // Place the whole model (weights + buffers) on the requested device so its forward runs there.
+        if (typed is AiDotNet.NeuralNetworks.NeuralNetworkBase<T> network)
+            network.To(device);
+
+        return ConfigureModel(typed);
+    }
 }

--- a/src/Helpers/DeserializationHelper.cs
+++ b/src/Helpers/DeserializationHelper.cs
@@ -2116,6 +2116,47 @@ public static class DeserializationHelper
                 cfgMethod?.Invoke(instance, new object[] { peG, ropeThetaG, seqLen });
             }
         }
+        else if (genericDef.Name == "PreLNTransformerBlock`1")
+        {
+            // (int hiddenSize, int ffnDim, LayerBase<T> attention, IActivationFunction<T>? ffnActivation, bool gated).
+            // The ctor rebuilds the RMSNorms + FFN from hiddenSize/ffnDim/gated/ffnActivation; only the injected
+            // (polymorphic) attention sublayer must round-trip, so PreLNTransformerBlock.GetMetadata persists it
+            // as an "Attn."-prefixed sub-blob (type + its own metadata + shapes) which we rebuild recursively.
+            int hsPln = TryGetInt(additionalParams, "HiddenSize")
+                ?? throw new InvalidOperationException($"{genericDef.Name} requires 'HiddenSize' metadata.");
+            int ffPln = TryGetInt(additionalParams, "FfnDim")
+                ?? throw new InvalidOperationException($"{genericDef.Name} requires 'FfnDim' metadata.");
+            bool gatedPln = TryGetBool(additionalParams, "Gated") ?? false;
+            var activationFuncTypePln = typeof(IActivationFunction<>).MakeGenericType(typeof(T));
+            object? ffnActivationPln = TryCreateActivationInstance(additionalParams, "FfnActivationType", activationFuncTypePln);
+
+            string? attnTypePlnRaw = additionalParams != null && additionalParams.TryGetValue("Attn.LayerType", out var atObj)
+                ? atObj?.ToString() : null;
+            if (attnTypePlnRaw is null || attnTypePlnRaw.Length == 0)
+                throw new InvalidOperationException(
+                    $"{genericDef.Name} requires 'Attn.LayerType' metadata to rebuild its attention sublayer.");
+            string attnTypePln = attnTypePlnRaw;
+            int[] attnInPln = TryGetIntArray(additionalParams, "Attn.InputShape") ?? inputShape;
+            int[] attnOutPln = TryGetIntArray(additionalParams, "Attn.OutputShape") ?? outputShape;
+            var attnParamsPln = new Dictionary<string, object>();
+            if (additionalParams != null)
+            {
+                foreach (var kv in additionalParams)
+                {
+                    if (kv.Key.Length > 5 && kv.Key.StartsWith("Attn.", StringComparison.Ordinal)
+                        && kv.Key != "Attn.LayerType" && kv.Key != "Attn.InputShape" && kv.Key != "Attn.OutputShape")
+                    {
+                        attnParamsPln[kv.Key.Substring(5)] = kv.Value;
+                    }
+                }
+            }
+            var attnLayerPln = CreateLayerFromType<T>(attnTypePln, attnInPln, attnOutPln, attnParamsPln) as LayerBase<T>
+                ?? throw new InvalidOperationException(
+                    $"{genericDef.Name}: rebuilt attention '{attnTypePln}' is not a LayerBase<T>.");
+
+            instance = new NeuralNetworks.Layers.PreLNTransformerBlock<T>(
+                hsPln, ffPln, attnLayerPln, (IActivationFunction<T>?)ffnActivationPln, gatedPln);
+        }
         else if (genericDef.Name == "MesaNetLayer`1")
         {
             // (sequenceLength, modelDimension, numHeads, regularization, IActivation, IInitStrategy)

--- a/src/Helpers/DeserializationHelper.cs
+++ b/src/Helpers/DeserializationHelper.cs
@@ -2069,6 +2069,14 @@ public static class DeserializationHelper
                     $"{genericDef.Name} divisibility violation: embeddingDimension ({embDim}) " +
                     $"must be a multiple of numHeads ({numHeads}). Serialized metadata is corrupt.");
             }
+            // Restore the remaining shape/behaviour ctor arguments (added so clones stay functionally
+            // identical): custom head dimension (Gemma), causal mask, Q/K/V projection bias (Qwen2), and the
+            // attention logit soft-cap (Gemma-2). Missing => the pre-metadata default, preserving old payloads.
+            int? headDimG = TryGetInt(additionalParams, "HeadDimension");
+            bool useCausalMaskG = TryGetBool(additionalParams, "UseCausalMask") ?? false;
+            bool useProjBiasG = TryGetBool(additionalParams, "UseProjectionBias") ?? false;
+            double softcapG = TryGetDouble(additionalParams, "AttnLogitSoftcap") ?? 0.0;
+
             var ctorG = type.GetConstructors().OrderByDescending(c => c.GetParameters().Length).FirstOrDefault() ?? throw new MissingLayerCtorException($"Cannot find any public constructor for {layerType} during deserialization.");
             var psG = ctorG.GetParameters();
             var argsG = new object?[psG.Length];
@@ -2082,6 +2090,10 @@ public static class DeserializationHelper
                     (Type t, _) when t == typeof(int) && n == "embeddingdimension" => embDim,
                     (Type t, _) when t == typeof(int) && n == "numheads" => numHeads,
                     (Type t, _) when t == typeof(int) && n == "numkvheads" => numKVHeads,
+                    (Type t, _) when t == typeof(int?) && n == "headdimension" => headDimG,
+                    (Type t, _) when t == typeof(bool) && n == "usecausalmask" => useCausalMaskG,
+                    (Type t, _) when t == typeof(bool) && n == "useprojectionbias" => useProjBiasG,
+                    (Type t, _) when t == typeof(double) && n == "attnlogitsoftcap" => softcapG,
                     (Type t, _) when t == typeof(int) && n.Contains("layerindex") => 0,
                     (Type t, _) when t == typeof(int) => 1,
                     (Type t, _) when t == typeof(bool) => p.HasDefaultValue ? p.DefaultValue : false,
@@ -2089,6 +2101,20 @@ public static class DeserializationHelper
                 };
             }
             instance = ctorG.Invoke(argsG);
+
+            // Reconstruct RoPE / ALiBi. Both GQA layers configure positional encoding AFTER construction (it is
+            // not a ctor argument), so a clone that skipped this lost RoPE entirely and diverged. Configure it
+            // from the persisted type + theta via the layer's public method.
+            var posEncStrG = additionalParams != null && additionalParams.TryGetValue("PositionalEncoding", out var peObj)
+                ? peObj?.ToString() : null;
+            if (!string.IsNullOrEmpty(posEncStrG) && posEncStrG != "None"
+                && Enum.TryParse<Enums.PositionalEncodingType>(posEncStrG, out var peG)
+                && peG != Enums.PositionalEncodingType.None)
+            {
+                double ropeThetaG = TryGetDouble(additionalParams, "RoPETheta") ?? 10000.0;
+                var cfgMethod = type.GetMethod("ConfigurePositionalEncoding");
+                cfgMethod?.Invoke(instance, new object[] { peG, ropeThetaG, seqLen });
+            }
         }
         else if (genericDef.Name == "MesaNetLayer`1")
         {

--- a/src/Inference/CachedGroupedQueryAttention.cs
+++ b/src/Inference/CachedGroupedQueryAttention.cs
@@ -234,28 +234,41 @@ internal class CachedGroupedQueryAttention<T> : LayerBase<T>
 
         var cache = _cache ?? throw new InvalidOperationException("KV cache has not been initialized.");
 
-        // Apply RoPE with position offset
+        // Apply RoPE with the fused, graph-recordable engine op (ApplyRoPEInterleaved) instead of the layer's
+        // managed rotation, so the whole forward can be captured/fused on GPU; the CPU path is identical.
         if (_ropeLayer != null)
         {
             int startPosition = _cache.CurrentLength;
-            (queries, newKeys) = _ropeLayer.ApplyRoPE(queries, newKeys, startPosition);
+            var (cosCache, sinCache) = _ropeLayer.GetInterleavedCaches(startPosition + seqLen);
+            queries = Engine.ApplyRoPEInterleaved(queries, cosCache, sinCache, startPosition);
+            newKeys = Engine.ApplyRoPEInterleaved(newKeys, cosCache, sinCache, startPosition);
         }
 
-        // Append to cache (cache stores numKVHeads, not numHeads)
+        // Append to cache (cache stores numKVHeads, not numHeads).
         var (keys, values) = _cache.Append(_layerIndex, newKeys, newValues);
-
-        // Expand KV heads to match Q heads
         int cachedSeqLen = keys.Shape[2];
-        var expandedKeys = ExpandKVHeads(keys, batchSize, cachedSeqLen);
-        var expandedValues = ExpandKVHeads(values, batchSize, cachedSeqLen);
 
-        // Compute attention
-        Tensor<T> attentionOutput = _useFlashAttention || _alibiLayer != null
-            ? FlashAttention<T>.Forward(queries, expandedKeys, expandedValues,
+        Tensor<T> attentionOutput;
+        if (_alibiLayer != null)
+        {
+            // ALiBi carries a positional bias the fused GQA op does not model, so keep the expand +
+            // FlashAttention path for it. RoPE decoders (the common case) take the recordable GQA path below.
+            var expandedKeys = ExpandKVHeads(keys, batchSize, cachedSeqLen);
+            var expandedValues = ExpandKVHeads(values, batchSize, cachedSeqLen);
+            attentionOutput = FlashAttention<T>.Forward(queries, expandedKeys, expandedValues,
                 new FlashAttentionConfig { UseCausalMask = _useCausalMask },
                 queryOffset: Math.Max(0, cachedSeqLen - seqLen),
-                attentionBias: _alibiLayer?.ComputeBias(seqLen, cachedSeqLen, _useCausalMask)).Output
-            : StandardAttention(queries, expandedKeys, expandedValues, _useCausalMask);
+                attentionBias: _alibiLayer.ComputeBias(seqLen, cachedSeqLen, _useCausalMask)).Output;
+        }
+        else
+        {
+            // Grouped-query attention with UNEXPANDED K/V as ONE device-agnostic, GPU-recordable op — the KV
+            // heads broadcast inside the op (or the fused kernel), dropping the managed ExpandKVHeads hotspot.
+            attentionOutput = Engine.ScaledDotProductAttentionGqa(
+                queries, keys, values,
+                scale: 1.0 / Math.Sqrt(_headDimension),
+                isCausal: _useCausalMask);
+        }
 
         // Reshape and project output
         attentionOutput = attentionOutput.Transpose([0, 2, 1, 3]).Reshape(batchSize, seqLen, _embeddingDimension);

--- a/src/Inference/InferenceOptimizer.cs
+++ b/src/Inference/InferenceOptimizer.cs
@@ -1011,6 +1011,10 @@ internal class InferenceOptimizer<T>
                 yield return decoderBlock.SelfAttentionLayer;
                 yield return decoderBlock.CrossAttentionLayer;
             }
+            // LLaMA / GGUF decoders host their (grouped-query) attention inside PreLNTransformerBlock, so every
+            // KV-cache / detection / quantization scan must reach it too — not just the top-level layer.
+            else if (layer is PreLNTransformerBlock<T> preLnBlock)
+                yield return preLnBlock.AttentionLayer;
         }
     }
 

--- a/src/Inference/InferenceOptimizer.cs
+++ b/src/Inference/InferenceOptimizer.cs
@@ -718,53 +718,77 @@ internal class InferenceOptimizer<T>
                 anyRewritten = true;
             }
 
-            // Handle Grouped-Query Attention -> CachedGroupedQueryAttention
-            // GQA rewrite: use CachedGroupedQueryAttention for regular KV cache.
-            // Paged KV cache does not yet support GQA, so fall back to regular cache.
+            // Handle Grouped-Query Attention -> CachedGroupedQueryAttention (regular KV cache; paged KV does
+            // not yet support GQA, so it falls back to the regular cache).
             if (layer is GroupedQueryAttentionLayer<T> gqa && enableKVCache)
             {
-                var inputShape = gqa.GetInputShape();
-                if (inputShape.Length < 2)
-                    continue;
-
-                int seqLen = inputShape[0];
-                int embDim = inputShape[1];
-                var activation = gqa.ScalarActivation;
-
-                var cachedGqa = new CachedGroupedQueryAttention<T>(
-                    sequenceLength: seqLen,
-                    embeddingDimension: embDim,
-                    numHeads: gqa.NumHeads,
-                    numKVHeads: gqa.NumKVHeads,
-                    useFlashAttention: enableFlashAttention,
-                    layerIndex: 0,
-                    useCausalMask: useCausalMask,
-                    activationFunction: activation);
-                cachedGqa.SetParameters(gqa.GetParameters());
-
-                // Preserve positional encoding
-                if (gqa.PositionalEncoding != PositionalEncodingType.None)
+                var cachedGqa = BuildCachedGqaReplacement(gqa, enableFlashAttention, useCausalMask);
+                if (cachedGqa is not null)
                 {
-                    cachedGqa.ConfigurePositionalEncoding(
-                        gqa.PositionalEncoding,
-                        ropeTheta: gqa.RoPETheta,
-                        maxSequenceLength: seqLen);
+                    model.Layers[i] = cachedGqa;
+                    anyRewritten = true;
                 }
-                else if (_config.PositionalEncoding == PositionalEncodingType.Rotary ||
-                         _config.PositionalEncoding == PositionalEncodingType.ALiBi)
-                {
-                    cachedGqa.ConfigurePositionalEncoding(
-                        _config.PositionalEncoding,
-                        ropeTheta: _config.RoPETheta,
-                        maxSequenceLength: seqLen);
-                }
+                continue;
+            }
 
-                model.Layers[i] = cachedGqa;
-                anyRewritten = true;
+            // Decoder blocks (LLaMA / GGUF) host their GQA INSIDE a PreLNTransformerBlock, so the top-level scan
+            // above never reaches it (the shard-05-class "no applicable layers" gap, GQA edition). Recurse into
+            // the block and swap its attention to the KV-cached variant in place via ReplaceAttention.
+            if (layer is PreLNTransformerBlock<T> preLnBlock && enableKVCache
+                && preLnBlock.AttentionLayer is GroupedQueryAttentionLayer<T> blockGqa)
+            {
+                var cachedGqa = BuildCachedGqaReplacement(blockGqa, enableFlashAttention, useCausalMask);
+                if (cachedGqa is not null)
+                {
+                    preLnBlock.ReplaceAttention(cachedGqa);
+                    anyRewritten = true;
+                }
+                continue;
             }
         }
 
         return anyRewritten;
+    }
+
+    /// <summary>
+    /// Builds the KV-cached replacement for a <see cref="GroupedQueryAttentionLayer{T}"/> — copying its
+    /// parameters and RoPE/ALiBi positional configuration — or <see langword="null"/> when the layer's input
+    /// shape is not yet resolvable. Shared by the top-level GQA rewrite and the PreLNTransformerBlock recursion.
+    /// </summary>
+    private CachedGroupedQueryAttention<T>? BuildCachedGqaReplacement(
+        GroupedQueryAttentionLayer<T> gqa, bool enableFlashAttention, bool useCausalMask)
+    {
+        var inputShape = gqa.GetInputShape();
+        if (inputShape.Length < 2)
+            return null;
+
+        int seqLen = inputShape[0];
+        int embDim = inputShape[1];
+
+        var cachedGqa = new CachedGroupedQueryAttention<T>(
+            sequenceLength: seqLen,
+            embeddingDimension: embDim,
+            numHeads: gqa.NumHeads,
+            numKVHeads: gqa.NumKVHeads,
+            useFlashAttention: enableFlashAttention,
+            layerIndex: 0,
+            useCausalMask: useCausalMask,
+            activationFunction: gqa.ScalarActivation);
+        cachedGqa.SetParameters(gqa.GetParameters());
+
+        if (gqa.PositionalEncoding != PositionalEncodingType.None)
+        {
+            cachedGqa.ConfigurePositionalEncoding(
+                gqa.PositionalEncoding, ropeTheta: gqa.RoPETheta, maxSequenceLength: seqLen);
+        }
+        else if (_config.PositionalEncoding == PositionalEncodingType.Rotary ||
+                 _config.PositionalEncoding == PositionalEncodingType.ALiBi)
+        {
+            cachedGqa.ConfigurePositionalEncoding(
+                _config.PositionalEncoding, ropeTheta: _config.RoPETheta, maxSequenceLength: seqLen);
+        }
+
+        return cachedGqa;
     }
 
     private bool ApplyWeightOnlyQuantization(NeuralNetworkBase<T> model)

--- a/src/Inference/InferenceOptimizer.cs
+++ b/src/Inference/InferenceOptimizer.cs
@@ -416,17 +416,21 @@ internal class InferenceOptimizer<T>
         }
 
         var firstLayer = attentionLayers[0];
-        int numHeads = firstLayer.HeadCount;
+        int numHeads = firstLayer.HeadCount;      // query heads
+        int numKVHeads = firstLayer.KVHeadCount;  // KV heads the cache physically stores (== numHeads for MHA)
         int headDim = firstLayer.HeadDimension;
         int numLayers = attentionLayers.Count;
 
         long availableBytes = (long)_config.KVCacheMaxSizeMB * 1024 * 1024;
         int blockSize = _config.PagedKVCacheBlockSize;
 
-        _pagedKVCache = PagedKVCache<T>.FromMemorySize(availableBytes, numLayers, numHeads, headDim, blockSize);
+        // The paged cache stores K/V, so it is sized by the KV head count. The kernel also needs the query-head
+        // count (NumQueryHeads) so it repeats each KV head across its query-head group under grouped-query attention.
+        _pagedKVCache = PagedKVCache<T>.FromMemorySize(availableBytes, numLayers, numKVHeads, headDim, blockSize);
         _pagedKernel = new PagedAttentionKernel<T>(_pagedKVCache, new PagedAttentionConfig
         {
-            NumHeads = numHeads,
+            NumHeads = numKVHeads,
+            NumQueryHeads = numHeads,
             HeadDimension = headDim,
             BlockSize = blockSize,
             MaxBatchSize = _config.MaxBatchSize,
@@ -718,14 +722,18 @@ internal class InferenceOptimizer<T>
                 anyRewritten = true;
             }
 
-            // Handle Grouped-Query Attention -> CachedGroupedQueryAttention (regular KV cache; paged KV does
-            // not yet support GQA, so it falls back to the regular cache).
+            // Handle Grouped-Query Attention. Prefer the PAGED GQA replacement when paged KV is enabled (it feeds
+            // the incremental-generation path); fall back to the contiguous CachedGroupedQueryAttention when the
+            // paged layer cannot represent the source (e.g. Qwen2-style Q/K/V projection bias).
             if (layer is GroupedQueryAttentionLayer<T> gqa && enableKVCache)
             {
-                var cachedGqa = BuildCachedGqaReplacement(gqa, enableFlashAttention, useCausalMask);
-                if (cachedGqa is not null)
+                LayerBase<T>? replacement = enablePagedKVCache
+                    ? BuildPagedGqaReplacement(gqa, useCausalMask)
+                    : null;
+                replacement ??= BuildCachedGqaReplacement(gqa, enableFlashAttention, useCausalMask);
+                if (replacement is not null)
                 {
-                    model.Layers[i] = cachedGqa;
+                    model.Layers[i] = replacement;
                     anyRewritten = true;
                 }
                 continue;
@@ -733,14 +741,17 @@ internal class InferenceOptimizer<T>
 
             // Decoder blocks (LLaMA / GGUF) host their GQA INSIDE a PreLNTransformerBlock, so the top-level scan
             // above never reaches it (the shard-05-class "no applicable layers" gap, GQA edition). Recurse into
-            // the block and swap its attention to the KV-cached variant in place via ReplaceAttention.
+            // the block and swap its attention in place via ReplaceAttention, preferring the paged variant.
             if (layer is PreLNTransformerBlock<T> preLnBlock && enableKVCache
                 && preLnBlock.AttentionLayer is GroupedQueryAttentionLayer<T> blockGqa)
             {
-                var cachedGqa = BuildCachedGqaReplacement(blockGqa, enableFlashAttention, useCausalMask);
-                if (cachedGqa is not null)
+                LayerBase<T>? replacement = enablePagedKVCache
+                    ? BuildPagedGqaReplacement(blockGqa, useCausalMask)
+                    : null;
+                replacement ??= BuildCachedGqaReplacement(blockGqa, enableFlashAttention, useCausalMask);
+                if (replacement is not null)
                 {
-                    preLnBlock.ReplaceAttention(cachedGqa);
+                    preLnBlock.ReplaceAttention(replacement);
                     anyRewritten = true;
                 }
                 continue;
@@ -789,6 +800,59 @@ internal class InferenceOptimizer<T>
         }
 
         return cachedGqa;
+    }
+
+    /// <summary>
+    /// Builds the PAGED KV-cache replacement for a <see cref="GroupedQueryAttentionLayer{T}"/> — a
+    /// <see cref="PagedCachedMultiHeadAttention{T}"/> with the source's KV-head count — so grouped-query
+    /// decoders reach the incremental paged-generation path. Copies parameters and RoPE/ALiBi positional
+    /// configuration. Returns <see langword="null"/> when the source cannot be represented on the paged layer
+    /// (its input shape is unresolved, or it uses Q/K/V projection bias which the paged layer has no slot for),
+    /// so the caller falls back to the contiguous <see cref="CachedGroupedQueryAttention{T}"/>.
+    /// </summary>
+    private PagedCachedMultiHeadAttention<T>? BuildPagedGqaReplacement(
+        GroupedQueryAttentionLayer<T> gqa, bool useCausalMask)
+    {
+        // The paged layer stores only an output bias; it cannot carry Q/K/V projection biases, and the source's
+        // flattened parameter vector would not line up. Let the caller use the contiguous cache in that case.
+        if (gqa.UsesProjectionBias)
+        {
+            return null;
+        }
+
+        var inputShape = gqa.GetInputShape();
+        if (inputShape.Length < 2)
+        {
+            return null;
+        }
+
+        int seqLen = inputShape[0];
+        int embDim = inputShape[1];
+
+        var paged = new PagedCachedMultiHeadAttention<T>(
+            sequenceLength: seqLen,
+            embeddingDimension: embDim,
+            headCount: gqa.NumHeads,
+            useCausalMask: useCausalMask,
+            activationFunction: gqa.ScalarActivation,
+            kvHeadCount: gqa.NumKVHeads);
+        paged.EnableWeightOnlyQuantization = _config.EnableWeightOnlyQuantization;
+        // Same [Q][K][V][O][outBias] layout (no projection bias => the source's q/k/v bias blocks are empty).
+        paged.SetParameters(gqa.GetParameters());
+
+        if (gqa.PositionalEncoding != PositionalEncodingType.None)
+        {
+            paged.ConfigurePositionalEncoding(
+                gqa.PositionalEncoding, ropeTheta: gqa.RoPETheta, maxSequenceLength: seqLen);
+        }
+        else if (_config.PositionalEncoding == PositionalEncodingType.Rotary ||
+                 _config.PositionalEncoding == PositionalEncodingType.ALiBi)
+        {
+            paged.ConfigurePositionalEncoding(
+                _config.PositionalEncoding, ropeTheta: _config.RoPETheta, maxSequenceLength: seqLen);
+        }
+
+        return paged;
     }
 
     private bool ApplyWeightOnlyQuantization(NeuralNetworkBase<T> model)

--- a/src/Inference/PagedAttention/PagedAttentionKernel.cs
+++ b/src/Inference/PagedAttention/PagedAttentionKernel.cs
@@ -244,10 +244,16 @@ internal class PagedAttentionKernel<T>
         var maxScores = floatPool.Rent(numQueryHeads);
         var sumExps = floatPool.Rent(numQueryHeads);
         var accumulators = floatPool.Rent(numQueryHeads * headDim);
-        var keyBuffer = tPool.Rent(numKVHeads * headDim);
-        var valueBuffer = tPool.Rent(numKVHeads * headDim);
+        // Bulk-read the WHOLE KV history for this layer under ONE lock instead of a lock per position: the
+        // per-position ReadKey/ReadValue took O(seqLen) contended Monitor.Enter per layer per token — profiled
+        // as ~51% of decode time. keyAll/valueAll are laid out [seqLen, numKVHeads*headDim].
+        int perPos = numKVHeads * headDim;
+        var keyAll = tPool.Rent(seqLen * perPos);
+        var valueAll = tPool.Rent(seqLen * perPos);
         try
         {
+        _kvCache.ReadKeyValueRange(sequenceId, 0, seqLen, layer,
+            keyAll.AsSpan(0, seqLen * perPos), valueAll.AsSpan(0, seqLen * perPos));
         Array.Clear(accumulators, 0, numQueryHeads * headDim);
         for (int head = 0; head < numQueryHeads; head++)
         {
@@ -273,21 +279,20 @@ internal class PagedAttentionKernel<T>
                 // Sliding window: skip positions before the window start.
                 if (pos < windowStart) continue;
 
-                // Read KV from this position
-                _kvCache.ReadKey(sequenceId, pos, layer, keyBuffer.AsSpan());
-                _kvCache.ReadValue(sequenceId, pos, layer, valueBuffer.AsSpan());
+                // KV for this position was bulk-read into keyAll/valueAll under a single lock above.
+                int posBase = pos * perPos;
 
                 // Update each query head; under GQA it reads the KV head it shares (kvHead = head / group).
                 for (int head = 0; head < numQueryHeads; head++)
                 {
                     int offset = head * headDim;            // query / accumulator / output (per query head)
-                    int kvOffset = (head / group) * headDim; // key / value (per shared KV head)
+                    int kvOffset = posBase + (head / group) * headDim; // key / value (per shared KV head, this pos)
 
                     // Compute score = Q dot K * scale
                     float score = 0;
                     for (int d = 0; d < headDim; d++)
                     {
-                        score += query[offset + d] * ToFloat(keyBuffer[kvOffset + d]);
+                        score += query[offset + d] * ToFloat(keyAll[kvOffset + d]);
                     }
                     score *= scale;
 
@@ -307,7 +312,7 @@ internal class PagedAttentionKernel<T>
                     // Update accumulator
                     for (int d = 0; d < headDim; d++)
                     {
-                        accumulators[offset + d] = accumulators[offset + d] * expOld + expNew * ToFloat(valueBuffer[kvOffset + d]);
+                        accumulators[offset + d] = accumulators[offset + d] * expOld + expNew * ToFloat(valueAll[kvOffset + d]);
                     }
 
                     // Update sum and max
@@ -345,8 +350,8 @@ internal class PagedAttentionKernel<T>
             floatPool.Return(maxScores);
             floatPool.Return(sumExps);
             floatPool.Return(accumulators);
-            tPool.Return(keyBuffer);
-            tPool.Return(valueBuffer);
+            tPool.Return(keyAll);
+            tPool.Return(valueAll);
         }
     }
 

--- a/src/Inference/PagedAttention/PagedAttentionKernel.cs
+++ b/src/Inference/PagedAttention/PagedAttentionKernel.cs
@@ -68,7 +68,9 @@ internal class PagedAttentionKernel<T>
         float scale,
         bool causalMask = true)
     {
-        int numHeads = _config.NumHeads;
+        int numKVHeads = _config.NumHeads;
+        int numQueryHeads = _config.NumQueryHeads > 0 ? _config.NumQueryHeads : numKVHeads;
+        int group = numQueryHeads / numKVHeads; // GQA repeat factor; 1 for standard multi-head attention
         int headDim = _config.HeadDimension;
         int seqLen = _kvCache.GetSequenceLength(sequenceId);
 
@@ -84,15 +86,17 @@ internal class PagedAttentionKernel<T>
         // below, so the softmax is normalized over the window only. 0 => full causal attention.
         int windowStart = _config.WindowSize > 0 ? Math.Max(0, seqLen - _config.WindowSize) : 0;
 
-        // Allocate working memory
+        // Allocate working memory. K/V buffers hold the (possibly fewer) KV heads the cache stores; the query
+        // and output are laid out over the full query-head count.
         var scores = new float[seqLen];
-        var keyBuffer = new T[numHeads * headDim];
-        var valueBuffer = new T[numHeads * headDim];
+        var keyBuffer = new T[numKVHeads * headDim];
+        var valueBuffer = new T[numKVHeads * headDim];
 
-        // Process each head
-        for (int head = 0; head < numHeads; head++)
+        // Process each query head; under GQA it reads the KV head it shares (kvHead = head / group).
+        for (int head = 0; head < numQueryHeads; head++)
         {
             int queryOffset = head * headDim;
+            int kvOffset = (head / group) * headDim;
 
             // Compute attention scores for all positions
             float maxScore = float.NegativeInfinity;
@@ -104,10 +108,9 @@ internal class PagedAttentionKernel<T>
 
                 // Compute Q @ K^T for this head
                 float score = 0;
-                int keyOffset = head * headDim;
                 for (int d = 0; d < headDim; d++)
                 {
-                    score += query[queryOffset + d] * ToFloat(keyBuffer[keyOffset + d]);
+                    score += query[queryOffset + d] * ToFloat(keyBuffer[kvOffset + d]);
                 }
                 score *= scale;
 
@@ -146,10 +149,9 @@ internal class PagedAttentionKernel<T>
 
                 _kvCache.ReadValue(sequenceId, pos, layer, valueBuffer.AsSpan());
 
-                int valueOffset = head * headDim;
                 for (int d = 0; d < headDim; d++)
                 {
-                    headOutput[d] += scores[pos] * ToFloat(valueBuffer[valueOffset + d]);
+                    headOutput[d] += scores[pos] * ToFloat(valueBuffer[kvOffset + d]);
                 }
             }
 
@@ -178,7 +180,10 @@ internal class PagedAttentionKernel<T>
         float scale)
     {
         int batchSize = sequenceIds.Length;
-        int headSize = _config.NumHeads * _config.HeadDimension;
+        // Query/output are laid out over the full query-head count (GQA-aware); the cache still stores fewer
+        // KV heads internally.
+        int numQueryHeads = _config.NumQueryHeads > 0 ? _config.NumQueryHeads : _config.NumHeads;
+        int headSize = numQueryHeads * _config.HeadDimension;
 
         // Process each batch item (could be parallelized)
         for (int b = 0; b < batchSize; b++)
@@ -205,7 +210,9 @@ internal class PagedAttentionKernel<T>
         float[]? alibiSlopes = null,
         int queryPosition = -1)
     {
-        int numHeads = _config.NumHeads;
+        int numKVHeads = _config.NumHeads;
+        int numQueryHeads = _config.NumQueryHeads > 0 ? _config.NumQueryHeads : numKVHeads;
+        int group = numQueryHeads / numKVHeads; // GQA repeat factor; 1 for standard multi-head attention
         int headDim = _config.HeadDimension;
         int blockSize = _config.BlockSize;
         int seqLen = _kvCache.GetSequenceLength(sequenceId);
@@ -226,22 +233,23 @@ internal class PagedAttentionKernel<T>
 
         int numBlocks = blockTable.Length;
 
-        // Per-head online-softmax scratch. Pooled: this method runs once per decode token, per layer, per
-        // sequence, so a fresh new[] here was the top compute-path allocation site (dotnet-trace). The
-        // pooled arrays may be longer than requested; only [0, numHeads*headDim) is used, so the tail is
-        // ignored. accumulators is zero-initialized for the used region below; keyBuffer/valueBuffer are
-        // fully overwritten by ReadKey/ReadValue before each read.
+        // Per-QUERY-head online-softmax scratch (softmax is independent per query head, even when several share
+        // a KV head under GQA). Pooled: this method runs once per decode token, per layer, per sequence, so a
+        // fresh new[] here was the top compute-path allocation site (dotnet-trace). The pooled arrays may be
+        // longer than requested; only the used prefix is touched. accumulators is zero-initialized for the used
+        // region below; keyBuffer/valueBuffer (sized to the KV heads the cache stores) are fully overwritten by
+        // ReadKey/ReadValue before each read.
         var floatPool = ArrayPool<float>.Shared;
         var tPool = ArrayPool<T>.Shared;
-        var maxScores = floatPool.Rent(numHeads);
-        var sumExps = floatPool.Rent(numHeads);
-        var accumulators = floatPool.Rent(numHeads * headDim);
-        var keyBuffer = tPool.Rent(numHeads * headDim);
-        var valueBuffer = tPool.Rent(numHeads * headDim);
+        var maxScores = floatPool.Rent(numQueryHeads);
+        var sumExps = floatPool.Rent(numQueryHeads);
+        var accumulators = floatPool.Rent(numQueryHeads * headDim);
+        var keyBuffer = tPool.Rent(numKVHeads * headDim);
+        var valueBuffer = tPool.Rent(numKVHeads * headDim);
         try
         {
-        Array.Clear(accumulators, 0, numHeads * headDim);
-        for (int head = 0; head < numHeads; head++)
+        Array.Clear(accumulators, 0, numQueryHeads * headDim);
+        for (int head = 0; head < numQueryHeads; head++)
         {
             maxScores[head] = float.NegativeInfinity;
             sumExps[head] = 0f;
@@ -269,16 +277,17 @@ internal class PagedAttentionKernel<T>
                 _kvCache.ReadKey(sequenceId, pos, layer, keyBuffer.AsSpan());
                 _kvCache.ReadValue(sequenceId, pos, layer, valueBuffer.AsSpan());
 
-                // Update each head
-                for (int head = 0; head < numHeads; head++)
+                // Update each query head; under GQA it reads the KV head it shares (kvHead = head / group).
+                for (int head = 0; head < numQueryHeads; head++)
                 {
-                    int offset = head * headDim;
+                    int offset = head * headDim;            // query / accumulator / output (per query head)
+                    int kvOffset = (head / group) * headDim; // key / value (per shared KV head)
 
                     // Compute score = Q dot K * scale
                     float score = 0;
                     for (int d = 0; d < headDim; d++)
                     {
-                        score += query[offset + d] * ToFloat(keyBuffer[offset + d]);
+                        score += query[offset + d] * ToFloat(keyBuffer[kvOffset + d]);
                     }
                     score *= scale;
 
@@ -298,7 +307,7 @@ internal class PagedAttentionKernel<T>
                     // Update accumulator
                     for (int d = 0; d < headDim; d++)
                     {
-                        accumulators[offset + d] = accumulators[offset + d] * expOld + expNew * ToFloat(valueBuffer[offset + d]);
+                        accumulators[offset + d] = accumulators[offset + d] * expOld + expNew * ToFloat(valueBuffer[kvOffset + d]);
                     }
 
                     // Update sum and max
@@ -308,8 +317,8 @@ internal class PagedAttentionKernel<T>
             }
         }
 
-        // Normalize and write output
-        for (int head = 0; head < numHeads; head++)
+        // Normalize and write output (one entry per query head)
+        for (int head = 0; head < numQueryHeads; head++)
         {
             int offset = head * headDim;
             float invSum = sumExps[head] > 0 ? 1.0f / sumExps[head] : 0;
@@ -355,11 +364,11 @@ internal class PagedAttentionKernel<T>
     /// cache-agnostic (the caller persists KV separately for the decode continuation) and does NOT support
     /// sliding-window eviction — callers must keep the per-token paged path when a window is configured.
     /// </remarks>
-    /// <param name="queries">Query buffer [rowLen, numHeads*headDim], RoPE-applied if the model uses RoPE.</param>
-    /// <param name="keys">Key buffer [rowLen, numHeads*headDim], RoPE-applied if the model uses RoPE.</param>
-    /// <param name="values">Value buffer [rowLen, numHeads*headDim].</param>
+    /// <param name="queries">Query buffer [rowLen, numQueryHeads*headDim], RoPE-applied if the model uses RoPE.</param>
+    /// <param name="keys">Key buffer [rowLen, numKVHeads*headDim] (numKVHeads &lt; numQueryHeads under GQA), RoPE-applied if the model uses RoPE.</param>
+    /// <param name="values">Value buffer [rowLen, numKVHeads*headDim].</param>
     /// <param name="rowLen">Number of query/key positions in this prefill block.</param>
-    /// <param name="output">Output buffer [rowLen, numHeads*headDim].</param>
+    /// <param name="output">Output buffer [rowLen, numQueryHeads*headDim].</param>
     /// <param name="scale">Attention scale factor (typically 1/sqrt(head_dim)).</param>
     /// <param name="alibiSlopes">Optional per-head ALiBi slopes; null for RoPE/no positional bias.</param>
     public void ComputeContiguousCausalPrefill(
@@ -371,23 +380,26 @@ internal class PagedAttentionKernel<T>
         float scale,
         float[]? alibiSlopes = null)
     {
-        int numHeads = _config.NumHeads;
+        int numKVHeads = _config.NumHeads;
+        int numQueryHeads = _config.NumQueryHeads > 0 ? _config.NumQueryHeads : numKVHeads;
+        int group = numQueryHeads / numKVHeads; // GQA repeat factor; 1 for standard multi-head attention
         int headDim = _config.HeadDimension;
-        int projDim = numHeads * headDim;
+        int qProjDim = numQueryHeads * headDim;  // query/output row stride
+        int kvProjDim = numKVHeads * headDim;    // key/value row stride (fewer heads under GQA)
 
         var pool = ArrayPool<float>.Shared;
-        var accumulators = pool.Rent(numHeads * headDim);
-        var maxScores = pool.Rent(numHeads);
-        var sumExps = pool.Rent(numHeads);
+        var accumulators = pool.Rent(numQueryHeads * headDim);
+        var maxScores = pool.Rent(numQueryHeads);
+        var sumExps = pool.Rent(numQueryHeads);
         try
         {
             for (int q = 0; q < rowLen; q++)
             {
-                int qBase = q * projDim;
+                int qBase = q * qProjDim;
 
                 // Reset per-query online-softmax accumulators.
-                Array.Clear(accumulators, 0, numHeads * headDim);
-                for (int head = 0; head < numHeads; head++)
+                Array.Clear(accumulators, 0, numQueryHeads * headDim);
+                for (int head = 0; head < numQueryHeads; head++)
                 {
                     maxScores[head] = float.NegativeInfinity;
                     sumExps[head] = 0f;
@@ -396,15 +408,16 @@ internal class PagedAttentionKernel<T>
                 // Causal: query position q attends only to key positions [0..q].
                 for (int pos = 0; pos <= q; pos++)
                 {
-                    int kBase = pos * projDim;
-                    for (int head = 0; head < numHeads; head++)
+                    int kBase = pos * kvProjDim;
+                    for (int head = 0; head < numQueryHeads; head++)
                     {
-                        int offset = head * headDim;
+                        int offset = head * headDim;             // query / accumulator / output
+                        int kvOffset = (head / group) * headDim; // shared KV head
 
                         float score = 0;
                         for (int d = 0; d < headDim; d++)
                         {
-                            score += queries[qBase + offset + d] * keys[kBase + offset + d];
+                            score += queries[qBase + offset + d] * keys[kBase + kvOffset + d];
                         }
                         score *= scale;
 
@@ -423,7 +436,7 @@ internal class PagedAttentionKernel<T>
                         for (int d = 0; d < headDim; d++)
                         {
                             accumulators[offset + d] =
-                                accumulators[offset + d] * expOld + expNew * values[kBase + offset + d];
+                                accumulators[offset + d] * expOld + expNew * values[kBase + kvOffset + d];
                         }
 
                         sumExps[head] = sumExps[head] * expOld + expNew;
@@ -432,7 +445,7 @@ internal class PagedAttentionKernel<T>
                 }
 
                 // Normalize and write this query's output.
-                for (int head = 0; head < numHeads; head++)
+                for (int head = 0; head < numQueryHeads; head++)
                 {
                     int offset = head * headDim;
                     float invSum = sumExps[head] > 0 ? 1.0f / sumExps[head] : 0;
@@ -491,10 +504,10 @@ internal class PagedAttentionKernel<T>
     /// Performs a full forward pass: projects QKV, updates cache, computes attention.
     /// </summary>
     /// <param name="hiddenStates">Input hidden states [hidden_dim].</param>
-    /// <param name="wQ">Query weight matrix [hidden_dim, num_heads * head_dim].</param>
-    /// <param name="wK">Key weight matrix [hidden_dim, num_heads * head_dim].</param>
-    /// <param name="wV">Value weight matrix [hidden_dim, num_heads * head_dim].</param>
-    /// <param name="wO">Output weight matrix [num_heads * head_dim, hidden_dim].</param>
+    /// <param name="wQ">Query weight matrix [hidden_dim, numQueryHeads * head_dim].</param>
+    /// <param name="wK">Key weight matrix [hidden_dim, numKVHeads * head_dim] (numKVHeads &lt; numQueryHeads under GQA).</param>
+    /// <param name="wV">Value weight matrix [hidden_dim, numKVHeads * head_dim].</param>
+    /// <param name="wO">Output weight matrix [numQueryHeads * head_dim, hidden_dim].</param>
     /// <param name="sequenceId">Sequence ID.</param>
     /// <param name="position">Current token position.</param>
     /// <param name="layer">Layer index.</param>
@@ -511,39 +524,43 @@ internal class PagedAttentionKernel<T>
         Span<float> output)
     {
         int hiddenDim = hiddenStates.Length;
-        int numHeads = _config.NumHeads;
+        int numKVHeads = _config.NumHeads;
+        int numQueryHeads = _config.NumQueryHeads > 0 ? _config.NumQueryHeads : numKVHeads;
         int headDim = _config.HeadDimension;
-        int projDim = numHeads * headDim;
+        // Q and O are laid out over the query heads; K/V over the (possibly fewer) KV heads the cache stores.
+        // Under standard multi-head attention the two counts are equal. Mirrors HF q_proj vs k_proj/v_proj.
+        int qProjDim = numQueryHeads * headDim;
+        int kvProjDim = numKVHeads * headDim;
         float scale = 1.0f / MathF.Sqrt(headDim);
 
         var pool = ArrayPool<float>.Shared;
-        var queryBuf = pool.Rent(projDim);
-        var keyBuf = pool.Rent(projDim);
-        var valueBuf = pool.Rent(projDim);
-        var attnBuf = pool.Rent(projDim);
+        var queryBuf = pool.Rent(qProjDim);
+        var keyBuf = pool.Rent(kvProjDim);
+        var valueBuf = pool.Rent(kvProjDim);
+        var attnBuf = pool.Rent(qProjDim);
 
         try
         {
-            var query = queryBuf.AsSpan(0, projDim);
-            var key = keyBuf.AsSpan(0, projDim);
-            var value = valueBuf.AsSpan(0, projDim);
-            var attnOutput = attnBuf.AsSpan(0, projDim);
+            var query = queryBuf.AsSpan(0, qProjDim);
+            var key = keyBuf.AsSpan(0, kvProjDim);
+            var value = valueBuf.AsSpan(0, kvProjDim);
+            var attnOutput = attnBuf.AsSpan(0, qProjDim);
 
-            // Q = hidden @ wQ
-            MatVecMul(hiddenStates, wQ, query, hiddenDim, projDim);
-            // K = hidden @ wK
-            MatVecMul(hiddenStates, wK, key, hiddenDim, projDim);
-            // V = hidden @ wV
-            MatVecMul(hiddenStates, wV, value, hiddenDim, projDim);
+            // Q = hidden @ wQ (query heads)
+            MatVecMul(hiddenStates, wQ, query, hiddenDim, qProjDim);
+            // K = hidden @ wK (KV heads)
+            MatVecMul(hiddenStates, wK, key, hiddenDim, kvProjDim);
+            // V = hidden @ wV (KV heads)
+            MatVecMul(hiddenStates, wV, value, hiddenDim, kvProjDim);
 
             // Update cache with new K, V
             UpdateCache(key, value, sequenceId, position, layer);
 
-            // Compute attention
+            // Compute attention (GQA-aware: repeats each KV head across its query-head group)
             ComputeTiledPagedAttention(query, sequenceId, layer, attnOutput, scale);
 
             // Project output: out = attn @ wO
-            MatVecMul(attnOutput, wO, output, projDim, hiddenDim);
+            MatVecMul(attnOutput, wO, output, qProjDim, hiddenDim);
         }
         finally
         {
@@ -566,28 +583,31 @@ internal class PagedAttentionKernel<T>
         Span<float> output)
     {
         int hiddenDim = hiddenStates.Length;
-        int numHeads = _config.NumHeads;
+        int numKVHeads = _config.NumHeads;
+        int numQueryHeads = _config.NumQueryHeads > 0 ? _config.NumQueryHeads : numKVHeads;
         int headDim = _config.HeadDimension;
-        int projDim = numHeads * headDim;
+        // Q/O over query heads, K/V over the (possibly fewer) KV heads — same asymmetry as HF q_proj vs k_proj.
+        int qProjDim = numQueryHeads * headDim;
+        int kvProjDim = numKVHeads * headDim;
         float scale = 1.0f / MathF.Sqrt(headDim);
 
-        if (wQ.Cols != hiddenDim || wK.Cols != hiddenDim || wV.Cols != hiddenDim || wO.Cols != projDim)
+        if (wQ.Cols != hiddenDim || wK.Cols != hiddenDim || wV.Cols != hiddenDim || wO.Cols != qProjDim)
         {
             throw new ArgumentException("Quantized weight dimensions do not match expected shapes.");
         }
 
         var pool = ArrayPool<float>.Shared;
-        var queryBuf = pool.Rent(projDim);
-        var keyBuf = pool.Rent(projDim);
-        var valueBuf = pool.Rent(projDim);
-        var attnBuf = pool.Rent(projDim);
+        var queryBuf = pool.Rent(qProjDim);
+        var keyBuf = pool.Rent(kvProjDim);
+        var valueBuf = pool.Rent(kvProjDim);
+        var attnBuf = pool.Rent(qProjDim);
 
         try
         {
-            var query = queryBuf.AsSpan(0, projDim);
-            var key = keyBuf.AsSpan(0, projDim);
-            var value = valueBuf.AsSpan(0, projDim);
-            var attnOutput = attnBuf.AsSpan(0, projDim);
+            var query = queryBuf.AsSpan(0, qProjDim);
+            var key = keyBuf.AsSpan(0, kvProjDim);
+            var value = valueBuf.AsSpan(0, kvProjDim);
+            var attnOutput = attnBuf.AsSpan(0, qProjDim);
 
             MatVecMulInt8(hiddenStates, wQ, query);
             MatVecMulInt8(hiddenStates, wK, key);
@@ -697,8 +717,20 @@ internal class PagedAttentionKernel<T>
 /// </summary>
 internal class PagedAttentionConfig
 {
-    /// <summary>Number of attention heads.</summary>
+    /// <summary>
+    /// Number of KEY/VALUE attention heads. This is the head count the paged KV cache physically stores, so
+    /// it is always the cache's head count. Under multi-head attention it equals the number of query heads;
+    /// under grouped-query attention (GQA) it is smaller (see <see cref="NumQueryHeads"/>).
+    /// </summary>
     public int NumHeads { get; set; } = 32;
+
+    /// <summary>
+    /// Number of QUERY attention heads. Under grouped-query attention the query heads outnumber the KV heads
+    /// (<see cref="NumHeads"/>): each KV head is shared by <c>NumQueryHeads / NumHeads</c> query heads, and
+    /// query head <c>q</c> reads KV head <c>q / (NumQueryHeads / NumHeads)</c>. 0 (the default) means "same as
+    /// <see cref="NumHeads"/>" — standard multi-head attention with no KV sharing.
+    /// </summary>
+    public int NumQueryHeads { get; set; }
 
     /// <summary>Dimension of each head.</summary>
     public int HeadDimension { get; set; } = 128;

--- a/src/Inference/PagedAttention/PagedKVCache.cs
+++ b/src/Inference/PagedAttention/PagedKVCache.cs
@@ -361,6 +361,44 @@ internal class PagedKVCache<T> : IDisposable
     }
 
     /// <summary>
+    /// Bulk-reads Key AND Value for a contiguous range of token positions [startPosition, startPosition+count)
+    /// for one layer, under a SINGLE lock, into contiguous per-position slices of <paramref name="keyDst"/>
+    /// and <paramref name="valueDst"/> (each laid out [count, NumHeads*HeadDimension]). Decode attention reads
+    /// the whole KV history every token; doing that as one locked bulk copy instead of a lock per position
+    /// removes O(seqLen) lock acquisitions per layer per token — the dominant decode cost (profiled at ~51%
+    /// of decode time as contended Monitor.Enter).
+    /// </summary>
+    public virtual void ReadKeyValueRange(
+        long sequenceId, int startPosition, int count, int layer, Span<T> keyDst, Span<T> valueDst)
+    {
+        int perPos = _config.NumHeads * _config.HeadDimension;
+        if (keyDst.Length < count * perPos || valueDst.Length < count * perPos)
+            throw new ArgumentException("Destination spans are too small for the requested range.");
+        lock (_lock)
+        {
+            var table = _blockTableManager.GetBlockTable(sequenceId);
+            if (table == null)
+                throw new InvalidOperationException($"No block table for sequence {sequenceId}");
+
+            for (int i = 0; i < count; i++)
+            {
+                int pos = startPosition + i;
+                var (blockId, offset) = table.GetBlockAndOffset(pos);
+                var blockStorage = _kvBlocks[blockId];
+                int posBase = i * perPos;
+                for (int head = 0; head < _config.NumHeads; head++)
+                {
+                    int dataOffset = posBase + head * _config.HeadDimension;
+                    int kOff = GetBlockStorageOffset(layer, isValue: false, offset, head);
+                    int vOff = GetBlockStorageOffset(layer, isValue: true, offset, head);
+                    blockStorage.AsSpan(kOff, _config.HeadDimension).CopyTo(keyDst.Slice(dataOffset, _config.HeadDimension));
+                    blockStorage.AsSpan(vOff, _config.HeadDimension).CopyTo(valueDst.Slice(dataOffset, _config.HeadDimension));
+                }
+            }
+        }
+    }
+
+    /// <summary>
     /// Gets the block table for a sequence (for paged attention kernel).
     /// </summary>
     public virtual int[]? GetBlockTable(long sequenceId)

--- a/src/Inference/PagedCachedMultiHeadAttention.cs
+++ b/src/Inference/PagedCachedMultiHeadAttention.cs
@@ -863,9 +863,40 @@ internal class PagedCachedMultiHeadAttention<T> : LayerBase<T>, IContextAwareInf
         }
     }
 
+    // Decode projection: output[outDim] = mat[outDim, inDim] · vec[inDim]. This runs 7× per layer per token
+    // (q/k/v/o + FFN) on the critical decode path, so the inner dot is vectorized with AVX2 FMA (8 lanes)
+    // instead of a scalar loop — the scalar version was the dominant decode cost. net471 uses the scalar tail.
+#if NET5_0_OR_GREATER
     private static void MatVecMul(ReadOnlySpan<float> vec, ReadOnlySpan<float> mat, Span<float> output, int inDim, int outDim)
     {
-        output.Clear();
+        int w = System.Numerics.Vector<float>.Count;
+        if (inDim < w)
+        {
+            MatVecMulScalar(vec, mat, output, inDim, outDim);
+            return;
+        }
+        for (int i = 0; i < outDim; i++)
+        {
+            var row = mat.Slice(i * inDim, inDim);
+            var acc = System.Numerics.Vector<float>.Zero;
+            int j = 0;
+            for (; j <= inDim - w; j += w)
+            {
+                acc += new System.Numerics.Vector<float>(vec.Slice(j, w))
+                     * new System.Numerics.Vector<float>(row.Slice(j, w));
+            }
+            float sum = System.Numerics.Vector.Dot(acc, System.Numerics.Vector<float>.One);
+            for (; j < inDim; j++) sum += vec[j] * row[j];
+            output[i] = sum;
+        }
+    }
+#else
+    private static void MatVecMul(ReadOnlySpan<float> vec, ReadOnlySpan<float> mat, Span<float> output, int inDim, int outDim)
+        => MatVecMulScalar(vec, mat, output, inDim, outDim);
+#endif
+
+    private static void MatVecMulScalar(ReadOnlySpan<float> vec, ReadOnlySpan<float> mat, Span<float> output, int inDim, int outDim)
+    {
         for (int i = 0; i < outDim; i++)
         {
             float sum = 0;

--- a/src/Inference/PagedCachedMultiHeadAttention.cs
+++ b/src/Inference/PagedCachedMultiHeadAttention.cs
@@ -23,6 +23,7 @@ namespace AiDotNet.Inference;
 internal class PagedCachedMultiHeadAttention<T> : LayerBase<T>, IContextAwareInferenceLayer<T>
 {
     private readonly int _headCount;
+    private readonly int _kvHeadCount;
     private readonly int _headDimension;
     private readonly int _embeddingDimension;
     private readonly bool _useCausalMask;
@@ -69,9 +70,16 @@ internal class PagedCachedMultiHeadAttention<T> : LayerBase<T>, IContextAwareInf
     public override bool SupportsTraining => false;
 
     /// <summary>
-    /// Gets the number of attention heads.
+    /// Gets the number of query attention heads.
     /// </summary>
     public int HeadCount => _headCount;
+
+    /// <summary>
+    /// Gets the number of key/value attention heads. Equals <see cref="HeadCount"/> for standard multi-head
+    /// attention; under grouped-query attention it is smaller (each KV head is shared by
+    /// <c>HeadCount / KVHeadCount</c> query heads).
+    /// </summary>
+    public int KVHeadCount => _kvHeadCount;
 
     /// <summary>
     /// Gets the dimension of each attention head.
@@ -108,12 +116,18 @@ internal class PagedCachedMultiHeadAttention<T> : LayerBase<T>, IContextAwareInf
     /// </summary>
     public double RoPETheta => _ropeLayer?.Theta ?? 10000.0;
 
+    /// <param name="kvHeadCount">
+    /// Number of key/value heads for grouped-query attention. 0 (the default) means "same as
+    /// <paramref name="headCount"/>" — standard multi-head attention. When smaller, K/V project to
+    /// <c>kvHeadCount * headDim</c> and each KV head is shared by <c>headCount / kvHeadCount</c> query heads.
+    /// </param>
     public PagedCachedMultiHeadAttention(
         int sequenceLength,
         int embeddingDimension,
         int headCount,
         bool useCausalMask,
-        IActivationFunction<T>? activationFunction = null)
+        IActivationFunction<T>? activationFunction = null,
+        int kvHeadCount = 0)
         : base(
             [sequenceLength, embeddingDimension],
             [sequenceLength, embeddingDimension],
@@ -126,14 +140,25 @@ internal class PagedCachedMultiHeadAttention<T> : LayerBase<T>, IContextAwareInf
                 nameof(headCount));
         }
 
+        int resolvedKvHeadCount = kvHeadCount > 0 ? kvHeadCount : headCount;
+        if (headCount % resolvedKvHeadCount != 0)
+        {
+            throw new ArgumentException(
+                $"Query head count ({headCount}) must be divisible by KV head count ({resolvedKvHeadCount}) for grouped-query attention.",
+                nameof(kvHeadCount));
+        }
+
         _embeddingDimension = embeddingDimension;
         _headCount = headCount;
+        _kvHeadCount = resolvedKvHeadCount;
         _headDimension = embeddingDimension / headCount;
         _useCausalMask = useCausalMask;
 
+        // K/V project to the (possibly fewer) KV heads; Q/O span the full query heads. Weights are [inDim, outDim].
+        int kvProjDim = _kvHeadCount * _headDimension;
         _queryWeights = new Matrix<T>(embeddingDimension, embeddingDimension);
-        _keyWeights = new Matrix<T>(embeddingDimension, embeddingDimension);
-        _valueWeights = new Matrix<T>(embeddingDimension, embeddingDimension);
+        _keyWeights = new Matrix<T>(embeddingDimension, kvProjDim);
+        _valueWeights = new Matrix<T>(embeddingDimension, kvProjDim);
         _outputWeights = new Matrix<T>(embeddingDimension, embeddingDimension);
         _outputBias = new Vector<T>(embeddingDimension);
 
@@ -330,17 +355,18 @@ internal class PagedCachedMultiHeadAttention<T> : LayerBase<T>, IContextAwareInf
                 }
             }
 
-            int projDim = _headCount * _headDimension;
+            int projDim = _headCount * _headDimension;       // query/output projection width
+            int kvProjDim = _kvHeadCount * _headDimension;    // key/value projection width (fewer heads under GQA)
             var queryBuf = pool.Rent(projDim);
-            var keyBuf = pool.Rent(projDim);
-            var valueBuf = pool.Rent(projDim);
+            var keyBuf = pool.Rent(kvProjDim);
+            var valueBuf = pool.Rent(kvProjDim);
             var attnBuf = pool.Rent(projDim);
 
             try
             {
                 var querySpan = queryBuf.AsSpan(0, projDim);
-                var keySpan = keyBuf.AsSpan(0, projDim);
-                var valueSpan = valueBuf.AsSpan(0, projDim);
+                var keySpan = keyBuf.AsSpan(0, kvProjDim);
+                var valueSpan = valueBuf.AsSpan(0, kvProjDim);
                 var attnOutput = attnBuf.AsSpan(0, projDim);
 
                 // Each batch row is an INDEPENDENT sequence (seqIds[b]) at its own start position
@@ -373,15 +399,15 @@ internal class PagedCachedMultiHeadAttention<T> : LayerBase<T>, IContextAwareInf
                         else
                         {
                             MatVecMul(hidden, wQ, querySpan, embDim, projDim);
-                            MatVecMul(hidden, wK, keySpan, embDim, projDim);
-                            MatVecMul(hidden, wV, valueSpan, embDim, projDim);
+                            MatVecMul(hidden, wK, keySpan, embDim, kvProjDim);
+                            MatVecMul(hidden, wV, valueSpan, embDim, kvProjDim);
                         }
 
-                        // Step 2: Apply RoPE to Q and K
+                        // Step 2: Apply RoPE to Q (query heads) and K (KV heads)
                         if (_ropeLayer != null)
                         {
-                            ApplyRoPEToSpan(querySpan, position);
-                            ApplyRoPEToSpan(keySpan, position);
+                            ApplyRoPEToSpan(querySpan, position, _headCount);
+                            ApplyRoPEToSpan(keySpan, position, _kvHeadCount);
                         }
 
                         // Step 3: Update cache and compute attention via kernel
@@ -473,7 +499,8 @@ internal class PagedCachedMultiHeadAttention<T> : LayerBase<T>, IContextAwareInf
         int batchSize = input.Shape[0];
         int seqLen = input.Shape[1];
         int embDim = input.Shape[2];
-        int projDim = _headCount * _headDimension;
+        int projDim = _headCount * _headDimension;       // query/output width
+        int kvProjDim = _kvHeadCount * _headDimension;    // key/value width (fewer heads under GQA)
         int rows = batchSize * seqLen;
         float scale = 1.0f / MathF.Sqrt(_headDimension);
 
@@ -482,8 +509,8 @@ internal class PagedCachedMultiHeadAttention<T> : LayerBase<T>, IContextAwareInf
         EnsureProjectionWeightTensors();
         var input2D = Engine.Reshape(input, new[] { rows, embDim });
         var q2D = Engine.TensorMatMul(input2D, _wqTensor!); // [rows, projDim]
-        var k2D = Engine.TensorMatMul(input2D, _wkTensor!);
-        var v2D = Engine.TensorMatMul(input2D, _wvTensor!);
+        var k2D = Engine.TensorMatMul(input2D, _wkTensor!); // [rows, kvProjDim]
+        var v2D = Engine.TensorMatMul(input2D, _wvTensor!); // [rows, kvProjDim]
         // Materialize the projected Q/K/V to flat row-major spans once so the causal per-token loop reads
         // them without per-element Tensor indexing (which would round-trip a GPU-resident GEMM result).
         var qFlat = q2D.AsSpan();
@@ -506,14 +533,14 @@ internal class PagedCachedMultiHeadAttention<T> : LayerBase<T>, IContextAwareInf
         var attnData = new T[rows * projDim];
         var pool = ArrayPool<float>.Shared;
         var qBuf = pool.Rent(projDim);
-        var kBuf = pool.Rent(projDim);
-        var vBuf = pool.Rent(projDim);
+        var kBuf = pool.Rent(kvProjDim);
+        var vBuf = pool.Rent(kvProjDim);
         var aBuf = pool.Rent(projDim);
         try
         {
             var q = qBuf.AsSpan(0, projDim);
-            var k = kBuf.AsSpan(0, projDim);
-            var v = vBuf.AsSpan(0, projDim);
+            var k = kBuf.AsSpan(0, kvProjDim);
+            var v = vBuf.AsSpan(0, kvProjDim);
             var a = aBuf.AsSpan(0, projDim);
 
             // Each batch row is an INDEPENDENT sequence (seqIds[b]) starting at basePositions[b]. Tokens are
@@ -532,25 +559,29 @@ internal class PagedCachedMultiHeadAttention<T> : LayerBase<T>, IContextAwareInf
                 // keep the per-token paged path below, which reads prior cached KV and evicts window blocks.
                 if (rowLen > 1 && position == 0 && kernel.Config.WindowSize == 0)
                 {
-                    PrefillRowContiguous(b, sequenceId, seqLen, rowLen, projDim, scale,
+                    PrefillRowContiguous(b, sequenceId, seqLen, rowLen, projDim, kvProjDim, scale,
                         qFlat, kFlat, vFlat, attnData, alibiSlopes, kernel);
                     continue;
                 }
 
                 for (int t = 0; t < rowLen; t++)
                 {
-                    int rowBase = (b * seqLen + t) * projDim;
+                    int qRowBase = (b * seqLen + t) * projDim;    // Q/output row (query heads)
+                    int kvRowBase = (b * seqLen + t) * kvProjDim; // K/V row (KV heads)
                     for (int d = 0; d < projDim; d++)
                     {
-                        q[d] = Convert.ToSingle(qFlat[rowBase + d]);
-                        k[d] = Convert.ToSingle(kFlat[rowBase + d]);
-                        v[d] = Convert.ToSingle(vFlat[rowBase + d]);
+                        q[d] = Convert.ToSingle(qFlat[qRowBase + d]);
+                    }
+                    for (int d = 0; d < kvProjDim; d++)
+                    {
+                        k[d] = Convert.ToSingle(kFlat[kvRowBase + d]);
+                        v[d] = Convert.ToSingle(vFlat[kvRowBase + d]);
                     }
 
                     if (_ropeLayer != null)
                     {
-                        ApplyRoPEToSpan(q, position);
-                        ApplyRoPEToSpan(k, position);
+                        ApplyRoPEToSpan(q, position, _headCount);
+                        ApplyRoPEToSpan(k, position, _kvHeadCount);
                     }
 
                     kernel.UpdateCache(k, v, sequenceId, position, LayerIndex);
@@ -559,7 +590,7 @@ internal class PagedCachedMultiHeadAttention<T> : LayerBase<T>, IContextAwareInf
 
                     for (int d = 0; d < projDim; d++)
                     {
-                        attnData[rowBase + d] = NumOps.FromDouble(a[d]);
+                        attnData[qRowBase + d] = NumOps.FromDouble(a[d]);
                     }
 
                     position++;
@@ -605,36 +636,42 @@ internal class PagedCachedMultiHeadAttention<T> : LayerBase<T>, IContextAwareInf
     /// RoPE, same online-softmax order) but avoids O(seqLen^2) paged block-table reads plus per-token allocs.
     /// </summary>
     private void PrefillRowContiguous(
-        int b, long sequenceId, int seqLen, int rowLen, int projDim, float scale,
+        int b, long sequenceId, int seqLen, int rowLen, int projDim, int kvProjDim, float scale,
         ReadOnlySpan<T> qFlat, ReadOnlySpan<T> kFlat, ReadOnlySpan<T> vFlat,
         T[] attnData, float[]? alibiSlopes, PagedAttentionKernel<T> kernel)
     {
-        int rowStart = b * seqLen * projDim;
-        int n = rowLen * projDim;
+        int qRowStart = b * seqLen * projDim;     // Q/output rows (query heads)
+        int kvRowStart = b * seqLen * kvProjDim;  // K/V rows (KV heads)
+        int qn = rowLen * projDim;
+        int kvn = rowLen * kvProjDim;
         var pool = ArrayPool<float>.Shared;
-        var qRoped = pool.Rent(n);
-        var kRoped = pool.Rent(n);
-        var vLocal = pool.Rent(n);
-        var attnLocal = pool.Rent(n);
+        var qRoped = pool.Rent(qn);
+        var kRoped = pool.Rent(kvn);
+        var vLocal = pool.Rent(kvn);
+        var attnLocal = pool.Rent(qn);
         try
         {
             for (int t = 0; t < rowLen; t++)
             {
-                int src = rowStart + t * projDim;
+                int qSrc = qRowStart + t * projDim;
+                int kvSrc = kvRowStart + t * kvProjDim;
                 var qSpan = qRoped.AsSpan(t * projDim, projDim);
-                var kSpan = kRoped.AsSpan(t * projDim, projDim);
-                var vSpan = vLocal.AsSpan(t * projDim, projDim);
+                var kSpan = kRoped.AsSpan(t * kvProjDim, kvProjDim);
+                var vSpan = vLocal.AsSpan(t * kvProjDim, kvProjDim);
                 for (int d = 0; d < projDim; d++)
                 {
-                    qSpan[d] = Convert.ToSingle(qFlat[src + d]);
-                    kSpan[d] = Convert.ToSingle(kFlat[src + d]);
-                    vSpan[d] = Convert.ToSingle(vFlat[src + d]);
+                    qSpan[d] = Convert.ToSingle(qFlat[qSrc + d]);
+                }
+                for (int d = 0; d < kvProjDim; d++)
+                {
+                    kSpan[d] = Convert.ToSingle(kFlat[kvSrc + d]);
+                    vSpan[d] = Convert.ToSingle(vFlat[kvSrc + d]);
                 }
 
                 if (_ropeLayer != null)
                 {
-                    ApplyRoPEToSpan(qSpan, t);
-                    ApplyRoPEToSpan(kSpan, t);
+                    ApplyRoPEToSpan(qSpan, t, _headCount);
+                    ApplyRoPEToSpan(kSpan, t, _kvHeadCount);
                 }
 
                 // Persist RoPE-applied K/V so the decode continuation reads keys consistent with this prefill.
@@ -642,8 +679,8 @@ internal class PagedCachedMultiHeadAttention<T> : LayerBase<T>, IContextAwareInf
             }
 
             kernel.ComputeContiguousCausalPrefill(
-                qRoped.AsSpan(0, n), kRoped.AsSpan(0, n), vLocal.AsSpan(0, n),
-                rowLen, attnLocal.AsSpan(0, n), scale, alibiSlopes);
+                qRoped.AsSpan(0, qn), kRoped.AsSpan(0, kvn), vLocal.AsSpan(0, kvn),
+                rowLen, attnLocal.AsSpan(0, qn), scale, alibiSlopes);
 
             for (int t = 0; t < rowLen; t++)
             {
@@ -704,10 +741,11 @@ internal class PagedCachedMultiHeadAttention<T> : LayerBase<T>, IContextAwareInf
         // Compute Q,K,V projections.
         var (q, k, v) = ComputeQkv(input);
 
-        // FlashAttention expects [B, H, S, D]
-        var qh = SplitHeads(q);
-        var kh = SplitHeads(k);
-        var vh = SplitHeads(v);
+        // FlashAttention expects [B, H, S, D]. Under GQA, K/V carry fewer heads: split them over the KV heads,
+        // then repeat each KV head across its query-head group (HF repeat_kv) so all three have headCount heads.
+        var qh = SplitHeads(q, _headCount);
+        var kh = RepeatKV(SplitHeads(k, _kvHeadCount));
+        var vh = RepeatKV(SplitHeads(v, _kvHeadCount));
 
         // Apply RoPE to Q and K if configured (position starts at 0 for standard forward)
         if (_ropeLayer != null)
@@ -755,65 +793,59 @@ internal class PagedCachedMultiHeadAttention<T> : LayerBase<T>, IContextAwareInf
         return (q, k, v);
     }
 
-    private Tensor<T> SplitHeads(Tensor<T> x)
+    private Tensor<T> SplitHeads(Tensor<T> x, int headCount)
     {
         int batchSize = x.Shape[0];
         int seqLen = x.Shape[1];
-        var reshaped = new Tensor<T>([batchSize, _headCount, seqLen, _headDimension]);
+        // [B, S, headCount*D] -> [B, S, headCount, D] -> [B, headCount, S, D] via vectorized reshape+transpose.
+        return x.Reshape(batchSize, seqLen, headCount, _headDimension).Transpose([0, 2, 1, 3]);
+    }
 
-        for (int b = 0; b < batchSize; b++)
+    /// <summary>
+    /// Repeats each KV head across its query-head group so a [B, kvHeadCount, S, D] tensor becomes
+    /// [B, headCount, S, D] (HF <c>repeat_kv</c>). Identity for standard multi-head attention. Uses a
+    /// vectorized gather on the head axis (index h -&gt; h / group) rather than a scalar copy loop.
+    /// </summary>
+    private Tensor<T> RepeatKV(Tensor<T> kv)
+    {
+        if (_kvHeadCount == _headCount)
         {
-            for (int s = 0; s < seqLen; s++)
-            {
-                for (int h = 0; h < _headCount; h++)
-                {
-                    int baseOffset = h * _headDimension;
-                    for (int d = 0; d < _headDimension; d++)
-                    {
-                        reshaped[b, h, s, d] = x[b, s, baseOffset + d];
-                    }
-                }
-            }
+            return kv;
         }
 
-        return reshaped;
+        int group = _headCount / _kvHeadCount;
+        // Tiny 1-D index vector (length = headCount): head h reads KV head h / group.
+        var idx = new int[_headCount];
+        for (int h = 0; h < _headCount; h++)
+        {
+            idx[h] = h / group;
+        }
+
+        var indices = new Tensor<int>(idx, new[] { _headCount });
+        return Engine.TensorGather(kv, indices, axis: 1); // [B, kvHeadCount, S, D] -> [B, headCount, S, D]
     }
 
     private Tensor<T> MergeHeads(Tensor<T> x)
     {
         int batchSize = x.Shape[0];
         int seqLen = x.Shape[2];
-        var merged = new Tensor<T>([batchSize, seqLen, _embeddingDimension]);
-
-        for (int b = 0; b < batchSize; b++)
-        {
-            for (int s = 0; s < seqLen; s++)
-            {
-                for (int h = 0; h < _headCount; h++)
-                {
-                    int baseOffset = h * _headDimension;
-                    for (int d = 0; d < _headDimension; d++)
-                    {
-                        merged[b, s, baseOffset + d] = x[b, h, s, d];
-                    }
-                }
-            }
-        }
-
-        return merged;
+        // [B, headCount, S, D] -> [B, S, headCount, D] -> [B, S, E] via vectorized transpose+reshape.
+        return x.Transpose([0, 2, 1, 3]).Reshape(batchSize, seqLen, _embeddingDimension);
     }
 
     /// <summary>
     /// Applies RoPE rotation to a projected Q or K span in-place.
-    /// The span contains [numHeads * headDim] floats, laid out as [head0_d0..head0_dH, head1_d0..head1_dH, ...].
+    /// The span contains [headCount * headDim] floats, laid out as [head0_d0..head0_dH, head1_d0..head1_dH, ...].
+    /// <paramref name="headCount"/> is the number of heads in this span — the query head count for Q, the
+    /// (possibly smaller) KV head count for K under grouped-query attention.
     /// </summary>
-    private void ApplyRoPEToSpan(Span<float> projected, int position)
+    private void ApplyRoPEToSpan(Span<float> projected, int position, int headCount)
     {
         if (_ropeLayer == null) return;
 
         double theta = _ropeLayer.Theta;
 
-        for (int h = 0; h < _headCount; h++)
+        for (int h = 0; h < headCount; h++)
         {
             int offset = h * _headDimension;
             for (int d = 0; d < _headDimension / 2; d++)
@@ -885,7 +917,13 @@ internal class PagedCachedMultiHeadAttention<T> : LayerBase<T>, IContextAwareInf
 
     public override Vector<T> GetParameters()
     {
-        int totalParams = _queryWeights.Rows * _queryWeights.Columns * 4 + _outputBias.Length;
+        // Q/O are embDim x embDim; K/V are embDim x (kvHeadCount*headDim) — smaller under GQA. Sum actual sizes.
+        int totalParams =
+            _queryWeights.Rows * _queryWeights.Columns +
+            _keyWeights.Rows * _keyWeights.Columns +
+            _valueWeights.Rows * _valueWeights.Columns +
+            _outputWeights.Rows * _outputWeights.Columns +
+            _outputBias.Length;
         var parameters = new Vector<T>(totalParams);
         int index = 0;
 
@@ -910,7 +948,12 @@ internal class PagedCachedMultiHeadAttention<T> : LayerBase<T>, IContextAwareInf
 
     public override void SetParameters(Vector<T> parameters)
     {
-        int expectedParams = _queryWeights.Rows * _queryWeights.Columns * 4 + _outputBias.Length;
+        int expectedParams =
+            _queryWeights.Rows * _queryWeights.Columns +
+            _keyWeights.Rows * _keyWeights.Columns +
+            _valueWeights.Rows * _valueWeights.Columns +
+            _outputWeights.Rows * _outputWeights.Columns +
+            _outputBias.Length;
         if (parameters.Length != expectedParams)
         {
             throw new ArgumentException($"Expected {expectedParams} parameters, got {parameters.Length}");
@@ -988,6 +1031,7 @@ internal class PagedCachedMultiHeadAttention<T> : LayerBase<T>, IContextAwareInf
         if (enableQuantization)
         {
             int projDim = _headCount * _headDimension;
+            int kvProjDim = _kvHeadCount * _headDimension; // K/V project to fewer heads under GQA
             int hiddenDim = _embeddingDimension;
 
             var wq = _cachedWQ ?? localWQ;
@@ -998,8 +1042,8 @@ internal class PagedCachedMultiHeadAttention<T> : LayerBase<T>, IContextAwareInf
             if (wq != null && wk != null && wv != null && wo != null)
             {
                 localWQInt8 = Int8WeightOnlyQuantization.QuantizePerRow(wq, projDim, hiddenDim);
-                localWKInt8 = Int8WeightOnlyQuantization.QuantizePerRow(wk, projDim, hiddenDim);
-                localWVInt8 = Int8WeightOnlyQuantization.QuantizePerRow(wv, projDim, hiddenDim);
+                localWKInt8 = Int8WeightOnlyQuantization.QuantizePerRow(wk, kvProjDim, hiddenDim);
+                localWVInt8 = Int8WeightOnlyQuantization.QuantizePerRow(wv, kvProjDim, hiddenDim);
                 localWOInt8 = Int8WeightOnlyQuantization.QuantizePerRow(wo, hiddenDim, projDim);
             }
         }

--- a/src/Interfaces/IAiModelBuilder.cs
+++ b/src/Interfaces/IAiModelBuilder.cs
@@ -293,6 +293,19 @@ public interface IAiModelBuilder<T, TInput, TOutput>
     IAiModelBuilder<T, TInput, TOutput> ConfigureModel(AiDotNet.ModelLoading.Pretrained.PretrainedSource source);
 
     /// <summary>
+    /// Configures the model from a pretrained checkpoint and places it on the given device — the common
+    /// "load this model straight onto my GPU" case. Equivalent to
+    /// <c>ConfigureModel(source)</c> followed by moving the model with
+    /// <see cref="AiDotNet.NeuralNetworks.NeuralNetworkBase{T}.To(AiDotNet.Tensors.DeviceInfo)"/>.
+    /// </summary>
+    /// <param name="source">The pretrained-source descriptor.</param>
+    /// <param name="device">The target device, e.g. <c>DeviceInfo.Cuda(0)</c> or <c>DeviceInfo.OpenCL()</c>.
+    /// Type-safe (enum-based) — no device strings.</param>
+    /// <returns>The builder instance for method chaining.</returns>
+    IAiModelBuilder<T, TInput, TOutput> ConfigureModel(
+        AiDotNet.ModelLoading.Pretrained.PretrainedSource source, AiDotNet.Tensors.DeviceInfo device);
+
+    /// <summary>
     /// Configures the optimization algorithm for the model.
     /// </summary>
     /// <remarks>

--- a/src/ModelLoading/Pretrained/GgufModelSource.cs
+++ b/src/ModelLoading/Pretrained/GgufModelSource.cs
@@ -114,6 +114,20 @@ public sealed class GgufModelSource : INamedTensorSource, IDisposable
         throw new ArgumentException($"Tensor '{name}' is not present in this GGUF model.", nameof(name));
     }
 
+    /// <summary>
+    /// Reads a directly-mapped tensor's native Q8_0 blocks (int8 payload + one fp32 scale per 32-value
+    /// block) WITHOUT dequantizing, resolving the Hugging-Face <paramref name="hfName"/> to its GGUF name.
+    /// Returns <c>false</c> for non-Q8_0 tensors and for stacked expert slices (which are not directly
+    /// mapped). Lets the builder keep frozen linear weights quantized for a block-Q8_0 GEMM.
+    /// </summary>
+    public bool TryReadQ8_0(string hfName, out sbyte[] qs, out float[] scales)
+    {
+        qs = System.Array.Empty<sbyte>();
+        scales = System.Array.Empty<float>();
+        if (hfName is null) return false;
+        return _hfToGguf.TryGetValue(hfName, out var ggufName) && _file.TryReadQ8_0Raw(ggufName, out qs, out scales);
+    }
+
     // Reads one expert's weight as the index-th of `count` equal slices of the stacked GGUF expert tensor.
     // GGUF lays the stack out expert-major (ne = [in, out, n_expert]), so slice e is a contiguous run whose
     // shape/layout matches a standalone GGUF expert weight — the builder applies its own [out,in] transpose.

--- a/src/ModelLoading/Pretrained/LlamaModelBuilder.cs
+++ b/src/ModelLoading/Pretrained/LlamaModelBuilder.cs
@@ -186,6 +186,22 @@ public static class LlamaModelBuilder<T>
         var wInOut = TransposeOutInToInOut(weights, name, outDim, inDim);
         var full = Concat(wInOut, new T[outDim]); // trailing zeros = bias
         dense.SetParameters(new Vector<T>(full));
+        InstallQ8IfAvailable(dense, weights, name, outDim, inDim);
+    }
+
+    // If the source is a GGUF file whose weight is stored Q8_0 and this is a float model, install the native
+    // Q8_0 blocks on the layer so inference runs the block-Q8_0 GEMM directly on int8 (no fp32 expansion).
+    // GGUF's native Q8_0 linear layout is [out, in] with 32-value blocks contiguous along `in` — exactly the
+    // block-Q8_0 kernel's expected [N, K] layout, so no transpose is applied. The fp32 weights loaded above
+    // stay as the training/serialization source of truth.
+    private static void InstallQ8IfAvailable(DenseLayer<T> dense, INamedTensorSource weights, string name, int outDim, int inDim)
+    {
+        if (typeof(T) != typeof(float)) return;
+        if ((inDim % 32) != 0) return;
+        if (weights is not GgufModelSource gguf) return;
+        if (!gguf.TryReadQ8_0(name, out var qs, out var scales)) return;
+        if (qs.Length != (long)outDim * inDim || scales.Length != (long)outDim * (inDim / 32)) return;
+        dense.SetQuantizedWeightsQ8_0(qs, scales, inDim, outDim);
     }
 
     // Reads a bias tensor if present, otherwise returns a zero vector of the given length.

--- a/src/NeuralNetworks/Layers/DenseLayer.cs
+++ b/src/NeuralNetworks/Layers/DenseLayer.cs
@@ -264,6 +264,38 @@ public partial class DenseLayer<T> : LayerBase<T>, IAuxiliaryLossLayer<T>
     /// </summary>
     private Tensor<T>? _fusedLinearScratch;
 
+    // Q8_0 quantized weight (llama.cpp / ggml native layout: weight kept int8 [out,in] with one fp32
+    // scale per 32-element block along the contraction dim). Populated for frozen GGUF inference weights
+    // via SetQuantizedWeightsQ8_0; when present (and running float inference off the tape) Forward runs the
+    // block-Q8_0 GEMM instead of expanding to fp32 — ~3.76× less weight memory + int8 dot throughput.
+    private sbyte[]? _weightsQ8;
+    private float[]? _weightScalesQ8;
+    private int _q8In;
+    private int _q8Out;
+
+    /// <summary>
+    /// Installs a frozen Q8_0 quantized weight for inference. <paramref name="qs"/> is the native ggml
+    /// Q8_0 int8 payload for a weight logically shaped [outFeatures, inFeatures] (blocks of 32 contiguous
+    /// along inFeatures); <paramref name="scales"/> holds one fp32 scale per block. inFeatures must be a
+    /// multiple of 32. The fp32 <c>_weights</c> stay as the training/serialization source of truth; the
+    /// quantized copy is used only on the float inference forward path.
+    /// </summary>
+    public void SetQuantizedWeightsQ8_0(sbyte[] qs, float[] scales, int inFeatures, int outFeatures)
+    {
+        if (qs is null) throw new ArgumentNullException(nameof(qs));
+        if (scales is null) throw new ArgumentNullException(nameof(scales));
+        if (inFeatures <= 0 || (inFeatures % 32) != 0)
+            throw new ArgumentException($"inFeatures ({inFeatures}) must be a positive multiple of 32 for Q8_0.", nameof(inFeatures));
+        if (qs.Length != (long)inFeatures * outFeatures)
+            throw new ArgumentException($"qs length {qs.Length} != inFeatures*outFeatures {(long)inFeatures * outFeatures}.");
+        if (scales.Length != (long)outFeatures * (inFeatures / 32))
+            throw new ArgumentException($"scales length {scales.Length} != outFeatures*(inFeatures/32) {(long)outFeatures * (inFeatures / 32)}.");
+        _weightsQ8 = qs;
+        _weightScalesQ8 = scales;
+        _q8In = inFeatures;
+        _q8Out = outFeatures;
+    }
+
     // GPU-resident cached tensors for GPU training pipeline
     private Tensor<T>? _lastInputGpu;
     private Tensor<T>? _lastPreActivationGpu; // Pre-activation for GPU backward pass
@@ -1045,7 +1077,32 @@ public partial class DenseLayer<T> : LayerBase<T>, IAuxiliaryLossLayer<T>
 
         Tensor<T> result;
 
-        if (fusedActivation != FusedActivationType.None && !IsTrainingMode && !DeterministicForward)
+        // Q8_0 quantized-weight inference fast path: run the block-Q8_0 GEMM directly on the int8 weight
+        // (llama.cpp / ggml_vec_dot_q8_0_q8_0), never expanding it to fp32. Float inference only, off the
+        // gradient tape — training/serialization still use the fp32 _weights.
+        // The naive block-Q8_0 kernel is memory-bandwidth-bound: it beats fp32 BLAS at small M (decode /
+        // small batch, where each weight byte is read once) but loses at large M (prefill, where the weight
+        // is reused across many rows and the fp32 GEMM is compute-bound + register-tiled). Gate on M so the
+        // quantized path is only taken where it is faster; large-M prefill stays on fp32 until the int8 GEMM
+        // is register-tiled.
+        const int q8MaxRowsForNaiveKernel = 16;
+        if (_weightsQ8 is not null && _weightScalesQ8 is not null
+            && !IsTrainingMode && !DeterministicForward
+            && typeof(T) == typeof(float)
+            && AiDotNet.Tensors.Engines.Autodiff.GradientTape<T>.Current is null
+            && _q8In == inputSize
+            && batchDim <= q8MaxRowsForNaiveKernel)
+        {
+            int mM = batchDim, kK = _q8In, nN = _q8Out;
+            var inF = (float[])(object)flattenedInput.ToArray();
+            var outArr = new float[mM * nN];
+            AiDotNet.Tensors.Engines.Simd.Q8BlockGemm.MatMul(inF, _weightsQ8, _weightScalesQ8, outArr, mM, kK, nN);
+            var linear = (Tensor<T>)(object)new Tensor<float>(outArr, [mM, nN]);
+            // Bias + activation epilogue (matches the unfused training path's math).
+            var biased = Engine.TensorBroadcastAdd(linear, Engine.Reshape(_biases, [1, nN]));
+            result = ApplyActivation(biased);
+        }
+        else if (fusedActivation != FusedActivationType.None && !IsTrainingMode && !DeterministicForward)
         {
             // Inference: use fused activation for maximum performance (no tape needed). This whole
             // fast block is gated above on !DeterministicForward, so when DeterministicForward is set

--- a/src/NeuralNetworks/Layers/DenseLayer.cs
+++ b/src/NeuralNetworks/Layers/DenseLayer.cs
@@ -273,6 +273,17 @@ public partial class DenseLayer<T> : LayerBase<T>, IAuxiliaryLossLayer<T>
     private int _q8In;
     private int _q8Out;
 
+    // The quantized forward is only faster than the fp32 BLAS when the CPU can do the int8 dot in one VNNI
+    // instruction (vpdpbusd). Detected once at startup; false on AVX2-only CPUs and on net471 (no intrinsics),
+    // where the fp32 path is used instead.
+#if NET5_0_OR_GREATER
+    private static readonly bool Q8SpeedFavorable =
+        System.Runtime.Intrinsics.X86.AvxVnni.IsSupported
+        || System.Runtime.Intrinsics.X86.Avx512BW.IsSupported;
+#else
+    private const bool Q8SpeedFavorable = false;
+#endif
+
     /// <summary>
     /// Installs a frozen Q8_0 quantized weight for inference. <paramref name="qs"/> is the native ggml
     /// Q8_0 int8 payload for a weight logically shaped [outFeatures, inFeatures] (blocks of 32 contiguous
@@ -1080,13 +1091,14 @@ public partial class DenseLayer<T> : LayerBase<T>, IAuxiliaryLossLayer<T>
         // Q8_0 quantized-weight inference fast path: run the block-Q8_0 GEMM directly on the int8 weight
         // (llama.cpp / ggml_vec_dot_q8_0_q8_0), never expanding it to fp32. Float inference only, off the
         // gradient tape — training/serialization still use the fp32 _weights.
-        // The naive block-Q8_0 kernel is memory-bandwidth-bound: it beats fp32 BLAS at small M (decode /
-        // small batch, where each weight byte is read once) but loses at large M (prefill, where the weight
-        // is reused across many rows and the fp32 GEMM is compute-bound + register-tiled). Gate on M so the
-        // quantized path is only taken where it is faster; large-M prefill stays on fp32 until the int8 GEMM
-        // is register-tiled.
+        // The block-Q8_0 kernel's int8 dot needs a 1-instruction VNNI multiply-accumulate (vpdpbusd) to beat
+        // the mature fp32 BLAS: on AVX-VNNI / AVX-512-VNNI hardware it wins on both compute AND weight
+        // bandwidth; on AVX2-only CPUs the 3-instruction int8 dot is no faster than fp32 FMA, so the fp32 BLAS
+        // wins and the quantized path is skipped (no regression). Also gated to small M — even on VNNI the
+        // large-M prefill path favors the fp32 BLAS's 2D register tiling until the int8 GEMM is 2D-tiled.
         const int q8MaxRowsForNaiveKernel = 16;
         if (_weightsQ8 is not null && _weightScalesQ8 is not null
+            && Q8SpeedFavorable
             && !IsTrainingMode && !DeterministicForward
             && typeof(T) == typeof(float)
             && AiDotNet.Tensors.Engines.Autodiff.GradientTape<T>.Current is null

--- a/src/NeuralNetworks/Layers/GroupedQueryAttentionLayer.cs
+++ b/src/NeuralNetworks/Layers/GroupedQueryAttentionLayer.cs
@@ -140,6 +140,12 @@ internal partial class GroupedQueryAttentionLayer<T> : LayerBase<T>
     public int NumKVHeads => _numKVHeads;
 
     /// <summary>
+    /// Gets whether this layer adds separate learned biases to the Q/K/V projections (e.g. Qwen2-style).
+    /// Standard LLaMA-family models leave this off.
+    /// </summary>
+    public bool UsesProjectionBias => _useProjectionBias;
+
+    /// <summary>
     /// Gets the dimension of each attention head.
     /// </summary>
     public int HeadDimension => _headDimension;

--- a/src/NeuralNetworks/Layers/GroupedQueryAttentionLayer.cs
+++ b/src/NeuralNetworks/Layers/GroupedQueryAttentionLayer.cs
@@ -441,38 +441,73 @@ internal partial class GroupedQueryAttentionLayer<T> : LayerBase<T>
             Engine.Reshape(V_flat, new[] { batchSize, seqLen, _numKVHeads, _headDimension }),
             new[] { 0, 2, 1, 3 });
 
-        // Apply RoPE to Q and K (before KV head expansion)
-        if (_ropeLayer != null)
+        Tensor<T> context;
+        if (!cacheBwd && _alibiLayer == null)
         {
-            (queries, keys) = _ropeLayer.ApplyRoPE(queries, keys, startPosition: 0);
+            // ── Inference fast path ──────────────────────────────────────────────
+            // Fused interleaved RoPE + GQA-aware scaled-dot-product attention, both
+            // dispatched to the device engine (float-specialized CPU / GPU kernels).
+            // This eliminates the two dominant CPU self-time costs on the decoder
+            // forward: the managed RoPE rotate loop (RotateTensor) and the scalar
+            // ExpandKVHeads copy. The SDPA kernel broadcasts the shared KV heads
+            // internally, so no expanded [batch, numHeads, seq, headDim] K/V is ever
+            // materialized. Numerically identical to the training path below:
+            //   - ApplyRoPEInterleaved matches RotateTensor exactly (GPT-J/GGML 2i,2i+1)
+            //   - ScaledDotProductAttentionGqa uses scale = 1/sqrt(headDim), the same
+            //     causal offset (key j visible to query i iff j <= i + (seqK - seqQ)),
+            //     and the same attn-logit soft-cap.
+            // Only taken outside training (no backward caches / no tape) and without
+            // ALiBi (which needs the additive-bias FlashAttention path).
+            if (_ropeLayer != null)
+            {
+                var (cosCache, sinCache) = _ropeLayer.GetInterleavedCaches(seqLen);
+                queries = Engine.ApplyRoPEInterleaved(queries, cosCache, sinCache, startPosition: 0);
+                keys = Engine.ApplyRoPEInterleaved(keys, cosCache, sinCache, startPosition: 0);
+            }
+
+            context = Engine.ScaledDotProductAttentionGqa(
+                queries, keys, values,
+                scale: 1.0 / Math.Sqrt(_headDimension),
+                isCausal: _useCausalMask,
+                softcap: _attnLogitSoftcap);
         }
-
-        _lastProjectedQueries = cacheBwd ? queries : null;
-        _lastProjectedKeys = cacheBwd ? keys : null;
-        _lastProjectedValues = cacheBwd ? values : null;
-
-        // Expand K/V heads to match Q heads via repeat
-        var expandedKeys = ExpandKVHeads(keys, batchSize, seqLen);
-        var expandedValues = ExpandKVHeads(values, batchSize, seqLen);
-
-        _lastExpandedKeys = cacheBwd ? expandedKeys : null;
-        _lastExpandedValues = cacheBwd ? expandedValues : null;
-
-        // Compute attention with weights caching: [batch, numHeads, seqQ, seqKV]
-        // The attention-logit soft-cap flows only through the standard fused SDPA path; the ALiBi
-        // FlashAttention path has no soft-cap parameter, so reject the (never-faithful) combination
-        // rather than silently dropping the cap.
-        if (_alibiLayer != null && _attnLogitSoftcap > 0.0)
+        else
         {
-            throw new InvalidOperationException(
-                "attnLogitSoftcap is not supported together with ALiBi positional bias; " +
-                "the soft-cap applies only to the standard scaled dot-product attention path.");
-        }
-        var (context, attentionWeights) = _alibiLayer != null
-            ? ComputeALiBiAttention(queries, expandedKeys, expandedValues, seqLen, batchSize)
-            : ComputeStandardAttentionWithWeights(queries, expandedKeys, expandedValues);
+            // ── Training / ALiBi path (tape-recorded, manual-backward caches) ─────
+            // Apply RoPE to Q and K (before KV head expansion)
+            if (_ropeLayer != null)
+            {
+                (queries, keys) = _ropeLayer.ApplyRoPE(queries, keys, startPosition: 0);
+            }
 
-        _lastAttentionWeights = cacheBwd ? attentionWeights : null;
+            _lastProjectedQueries = cacheBwd ? queries : null;
+            _lastProjectedKeys = cacheBwd ? keys : null;
+            _lastProjectedValues = cacheBwd ? values : null;
+
+            // Expand K/V heads to match Q heads via repeat
+            var expandedKeys = ExpandKVHeads(keys, batchSize, seqLen);
+            var expandedValues = ExpandKVHeads(values, batchSize, seqLen);
+
+            _lastExpandedKeys = cacheBwd ? expandedKeys : null;
+            _lastExpandedValues = cacheBwd ? expandedValues : null;
+
+            // Compute attention with weights caching: [batch, numHeads, seqQ, seqKV]
+            // The attention-logit soft-cap flows only through the standard fused SDPA path; the ALiBi
+            // FlashAttention path has no soft-cap parameter, so reject the (never-faithful) combination
+            // rather than silently dropping the cap.
+            if (_alibiLayer != null && _attnLogitSoftcap > 0.0)
+            {
+                throw new InvalidOperationException(
+                    "attnLogitSoftcap is not supported together with ALiBi positional bias; " +
+                    "the soft-cap applies only to the standard scaled dot-product attention path.");
+            }
+            var (ctx, attentionWeights) = _alibiLayer != null
+                ? ComputeALiBiAttention(queries, expandedKeys, expandedValues, seqLen, batchSize)
+                : ComputeStandardAttentionWithWeights(queries, expandedKeys, expandedValues);
+
+            _lastAttentionWeights = cacheBwd ? attentionWeights : null;
+            context = ctx;
+        }
 
         // Reshape back: [batch, numHeads, seq, headDim] -> [batch, seq, embDim]
         var contextPermuted = Engine.TensorPermute(context, new[] { 0, 2, 1, 3 });

--- a/src/NeuralNetworks/Layers/GroupedQueryAttentionLayer.cs
+++ b/src/NeuralNetworks/Layers/GroupedQueryAttentionLayer.cs
@@ -791,6 +791,7 @@ internal partial class GroupedQueryAttentionLayer<T> : LayerBase<T>
         // SequenceLength + EmbeddingDimension here, the deser path would fall
         // back to inputShape[0]/[1] (correct for rank-2 [seq, dim] payloads)
         // or to hardcoded 16/64 if the shape is degenerate — issue #1239.
+        var ci = System.Globalization.CultureInfo.InvariantCulture;
         metadata["SequenceLength"] = InputShape[0].ToString();
         metadata["EmbeddingDimension"] = _embeddingDimension.ToString();
         metadata["NumHeads"] = _numHeads.ToString();
@@ -798,6 +799,15 @@ internal partial class GroupedQueryAttentionLayer<T> : LayerBase<T>
         metadata["HeadsPerGroup"] = _headsPerGroup.ToString();
         metadata["Variant"] = Variant.ToString();
         metadata["PositionalEncoding"] = PositionalEncoding.ToString();
+        // Persist the remaining shape/behaviour-affecting ctor arguments so a deserialized (cloned) layer is
+        // functionally identical. Without these a clone silently lost its causal mask, custom head dimension
+        // (Gemma), Q/K/V projection bias (Qwen2), attention logit soft-cap (Gemma-2), and RoPE — producing
+        // wrong outputs on the cloned model (e.g. the paged incremental-serving clone of a GGUF decoder).
+        metadata["HeadDimension"] = _headDimension.ToString(ci);
+        metadata["UseCausalMask"] = _useCausalMask.ToString();
+        metadata["UseProjectionBias"] = _useProjectionBias.ToString();
+        metadata["AttnLogitSoftcap"] = _attnLogitSoftcap.ToString(ci);
+        metadata["RoPETheta"] = RoPETheta.ToString(ci);
         return metadata;
     }
 

--- a/src/NeuralNetworks/Layers/LayerBase.cs
+++ b/src/NeuralNetworks/Layers/LayerBase.cs
@@ -3612,6 +3612,31 @@ public abstract class LayerBase<T> : ILayer<T>, ITrainableLayer<T>, IDisposable
     public virtual IReadOnlyList<Tensor<T>> GetTrainableParameters() => _registeredTensors;
 
     /// <summary>
+    /// Moves this layer's parameters and buffers (and, recursively, every registered sub-layer) to the given
+    /// device — the layer-level equivalent of PyTorch's <c>module.to(device)</c>. Each persistent tensor is moved
+    /// in place via <see cref="Tensor{T}.To(AiDotNet.Tensors.DeviceInfo)"/>, so subsequent ops on those tensors
+    /// dispatch to that device. Deferred (zero-length, not-yet-materialized) parameters are skipped and move on
+    /// first use. Returns this layer for fluent chaining.
+    /// </summary>
+    /// <param name="device">The target device (e.g. <c>DeviceInfo.Cuda(0)</c>, <c>DeviceInfo.OpenCL()</c>, <c>DeviceInfo.CPU</c>).</param>
+    public virtual LayerBase<T> To(AiDotNet.Tensors.DeviceInfo device)
+    {
+        for (int i = 0; i < _registeredTensors.Count; i++)
+        {
+            var t = _registeredTensors[i];
+            if (t is not null && t.Length > 0) t.To(device);
+        }
+        for (int i = 0; i < _registeredBuffers.Count; i++)
+        {
+            var t = _registeredBuffers[i].Tensor;
+            if (t is not null && t.Length > 0) t.To(device);
+        }
+        for (int i = 0; i < _registeredSubLayers.Count; i++)
+            (_registeredSubLayers[i] as LayerBase<T>)?.To(device);
+        return this;
+    }
+
+    /// <summary>
     /// Registers a single custom autograd node on the active gradient tape for a layer whose
     /// <see cref="Forward"/> is a manual (non-Engine-op) computation but which can supply a
     /// hand-written backward. This is the layer-level analog of PyTorch's

--- a/src/NeuralNetworks/Layers/PreLNTransformerBlock.cs
+++ b/src/NeuralNetworks/Layers/PreLNTransformerBlock.cs
@@ -33,7 +33,10 @@ namespace AiDotNet.NeuralNetworks.Layers;
 public partial class PreLNTransformerBlock<T> : LayerBase<T>
 {
     private readonly RMSNormalizationLayer<T> _norm1;
-    private readonly LayerBase<T> _attention;
+    // Non-readonly so the inference optimizer can swap the attention sublayer in place (e.g.
+    // GroupedQueryAttentionLayer -> CachedGroupedQueryAttention for KV-cached decode) via ReplaceAttention,
+    // the same contract TransformerEncoderBlock uses.
+    private LayerBase<T> _attention;
     private readonly RMSNormalizationLayer<T> _norm2;
     private readonly DenseLayer<T>? _ffnGate;
     private readonly DenseLayer<T> _ffnUp;
@@ -53,6 +56,20 @@ public partial class PreLNTransformerBlock<T> : LayerBase<T>
 
     /// <summary>The self-attention sublayer (exposed for tensor-parallel serving partitioning).</summary>
     public LayerBase<T> AttentionLayer => _attention;
+
+    /// <summary>
+    /// Swaps the attention sublayer in place (e.g. the inference optimizer replacing
+    /// <see cref="GroupedQueryAttentionLayer{T}"/> with a KV-cached
+    /// <see cref="AiDotNet.Inference.PagedAttention.CachedGroupedQueryAttention{T}"/> for incremental decode).
+    /// Keeps the registered-sublayer set consistent so parameter enumeration still discovers the block's weights.
+    /// </summary>
+    public void ReplaceAttention(LayerBase<T> replacement)
+    {
+        if (replacement is null) throw new ArgumentNullException(nameof(replacement));
+        UnregisterSubLayer(_attention);
+        _attention = replacement;
+        RegisterSubLayer(_attention);
+    }
 
     /// <summary>
     /// The FFN gate-projection DenseLayer (hidden -&gt; ffnDim, activation), present only in

--- a/src/NeuralNetworks/Layers/PreLNTransformerBlock.cs
+++ b/src/NeuralNetworks/Layers/PreLNTransformerBlock.cs
@@ -218,6 +218,30 @@ public partial class PreLNTransformerBlock<T> : LayerBase<T>
     }
 
     /// <summary>
+    /// Resolves every sublayer's shape without a data-carrying forward. This block overrides
+    /// <see cref="Forward"/> directly (bypassing the base lazy-init hook), so this runs ONLY via
+    /// <see cref="LayerBase{T}.ResolveFromShape"/> — the deserialization / shape-oracle path. The norms and
+    /// FFN DenseLayers are lazy (input dim resolved on first use), so without this the reconstructed block
+    /// reported a too-small <see cref="ParameterCount"/> and <c>SetParameters</c> rejected the saved vector.
+    /// Sublayers resolve in forward order so any RNG-based weight init consumes the stream exactly as a
+    /// natural forward would.
+    /// </summary>
+    protected override void OnFirstForward(Tensor<T> input)
+    {
+        int hidden = _hiddenSize;
+        var hiddenShape = new[] { 1, hidden };
+        if (!_norm1.IsShapeResolved) _norm1.ResolveFromShape(hiddenShape);
+        if (!_attention.IsShapeResolved) _attention.ResolveFromShape(hiddenShape);
+        if (!_norm2.IsShapeResolved) _norm2.ResolveFromShape(hiddenShape);
+        if (_ffnGate is not null && !_ffnGate.IsShapeResolved) _ffnGate.ResolveFromShape(hiddenShape);
+        if (!_ffnUp.IsShapeResolved) _ffnUp.ResolveFromShape(hiddenShape);
+        if (!_ffnDown.IsShapeResolved) _ffnDown.ResolveFromShape(new[] { 1, _ffnDim });
+
+        int seq = input.Shape.Length >= 2 ? input.Shape[input.Shape.Length - 2] : 1;
+        ResolveShapes(new[] { seq, hidden }, new[] { seq, hidden });
+    }
+
+    /// <summary>
     /// The block's sublayers in flat-parameter order. The gate (when present) sits
     /// immediately before the up-projection, so a non-gated block keeps its original
     /// layout and a gated block appends the gate deterministically.
@@ -274,6 +298,31 @@ public partial class PreLNTransformerBlock<T> : LayerBase<T>
         var slice = source.Slice(offset, count);
         layer.SetParameters(slice);
         offset += count;
+    }
+
+    /// <inheritdoc/>
+    internal override System.Collections.Generic.Dictionary<string, string> GetMetadata()
+    {
+        var metadata = base.GetMetadata();
+        var ci = System.Globalization.CultureInfo.InvariantCulture;
+        metadata["HiddenSize"] = _hiddenSize.ToString(ci);
+        metadata["FfnDim"] = _ffnDim.ToString(ci);
+        metadata["Gated"] = _gated.ToString();
+        metadata["FfnActivationType"] = _ffnActivation.GetType().AssemblyQualifiedName
+            ?? _ffnActivation.GetType().FullName ?? string.Empty;
+
+        // Persist the injected (polymorphic T5 / MHA / GQA) attention sublayer as a self-contained sub-blob
+        // under an "Attn." prefix: its concrete type, its own metadata, and its shapes. The block's ctor
+        // rebuilds the norms + FFN from HiddenSize/FfnDim/Gated/FfnActivation, so only the attention needs to
+        // round-trip; the deserializer reconstructs it recursively via CreateLayerFromType (which restores its
+        // full config, e.g. GQA RoPE / causal mask). Without this the block had no known deserialization
+        // constructor and cloning it threw — leaving the paged incremental-serving clone of a decoder inert.
+        foreach (var kv in _attention.GetMetadata())
+            metadata["Attn." + kv.Key] = kv.Value;
+        metadata["Attn.LayerType"] = _attention.GetType().Name;
+        metadata["Attn.InputShape"] = string.Join(",", _attention.GetInputShape());
+        metadata["Attn.OutputShape"] = string.Join(",", _attention.GetOutputShape());
+        return metadata;
     }
 
     /// <inheritdoc/>

--- a/src/NeuralNetworks/Layers/RotaryPositionalEncodingLayer.cs
+++ b/src/NeuralNetworks/Layers/RotaryPositionalEncodingLayer.cs
@@ -118,6 +118,18 @@ internal partial class RotaryPositionalEncodingLayer<T> : LayerBase<T>
     /// <summary>
     /// Ensures the cache covers at least up to the specified sequence length.
     /// </summary>
+    /// <summary>
+    /// Ensures the cos/sin caches cover <paramref name="requiredLength"/> positions and returns them as
+    /// <c>[maxSeq, headDim/2]</c> tensors laid out for the fused interleaved-RoPE engine op
+    /// (<see cref="AiDotNet.Tensors.Engines.IEngine.ApplyRoPEInterleaved"/>). Lets a caller apply RoPE as a
+    /// single device-agnostic (and, on GPU, graph-recordable) op instead of this layer's managed rotation.
+    /// </summary>
+    public (Tensor<T> Cos, Tensor<T> Sin) GetInterleavedCaches(int requiredLength)
+    {
+        EnsureCacheLength(requiredLength);
+        return (_cosCache, _sinCache);
+    }
+
     private void EnsureCacheLength(int requiredLength)
     {
         if (requiredLength <= _maxSequenceLength)

--- a/src/NeuralNetworks/NeuralNetworkBase.cs
+++ b/src/NeuralNetworks/NeuralNetworkBase.cs
@@ -67,6 +67,20 @@ public abstract class NeuralNetworkBase<T> : INeuralNetworkModel<T>, IInterpreta
     public List<ILayer<T>> Layers => _layers;
 
     /// <summary>
+    /// Moves the whole model — every layer's parameters and buffers — to the given device, the model-level
+    /// equivalent of PyTorch's <c>model.to(device)</c>. After <c>model.To(DeviceInfo.OpenCL())</c> the weights are
+    /// device-resident, so <see cref="Predict"/>/forward compute stays on that device (ops dispatch by where their
+    /// operand tensors live) with no per-call engine swap. Returns this model for fluent chaining.
+    /// </summary>
+    /// <param name="device">The target device (e.g. <c>DeviceInfo.Cuda(0)</c>, <c>DeviceInfo.OpenCL()</c>, <c>DeviceInfo.CPU</c>).</param>
+    public virtual NeuralNetworkBase<T> To(AiDotNet.Tensors.DeviceInfo device)
+    {
+        for (int i = 0; i < _layers.Count; i++)
+            (_layers[i] as Layers.LayerBase<T>)?.To(device);
+        return this;
+    }
+
+    /// <summary>
     /// Gets the collection of layers that make up this neural network (internal read-only access).
     /// </summary>
     /// <remarks>

--- a/tests/AiDotNet.Serving.Tests/IntegrationTests/IncrementalGenerationEndToEndTests.cs
+++ b/tests/AiDotNet.Serving.Tests/IntegrationTests/IncrementalGenerationEndToEndTests.cs
@@ -94,6 +94,72 @@ public class IncrementalGenerationEndToEndTests
         Assert.Equal(new[] { 1, 2, 3 }, resp.AllTokens[..3]);
     }
 
+    /// <summary>
+    /// A grouped-query (numHeads &gt; numKVHeads) PreLN decoder served through ServableModelWrapper must build
+    /// the paged KV-cached incremental path — the end-to-end proof that the paged-GQA support (GQA-aware kernel
+    /// + narrow-K/V paged layer + optimizer rewrite + PreLNTransformerBlock/GQA cloning) actually engages in
+    /// serving. Before it, BuildIncrementalModel's clone threw and the wrapper silently fell back to the
+    /// stateless path (SupportsIncrementalGeneration was false for every LLaMA/GGUF-style decoder).
+    /// </summary>
+    [Fact(Timeout = 120000)]
+    public async Task ServedGqaDecoder_BuildsIncrementalPagedPath_AndGenerates()
+    {
+        await Task.Yield();
+        var model = BuildGqaLm();
+        var wrapper = new ServableModelWrapper<float>(
+            "gqa", model, inputShape: new[] { 1 }, generationForward: model.Predict);
+        var repo = new OneModelRepo("gqa", wrapper);
+        var service = new TextGenerationService(repo, NullLogger<TextGenerationService>.Instance);
+
+        Assert.True(wrapper.SupportsIncrementalGeneration,
+            "wrapper should build the paged KV-cached incremental path for a grouped-query PreLN decoder");
+
+        var resp = service.Generate("gqa", NumericType.Float, Req(new[] { 1, 2, 3 }));
+
+        Assert.Null(resp.Error);
+        Assert.Equal(5, resp.NumGenerated);
+        Assert.All(resp.GeneratedTokens, t => Assert.InRange(t, 0, Vocab - 1));
+    }
+
+    private static NeuralNetwork<float> BuildGqaLm()
+    {
+        const int numHeads = 4;
+        const int numKVHeads = 2;
+        const int ffnDim = 16;
+
+        var gqa = new GroupedQueryAttentionLayer<float>(
+            sequenceLength: 1,
+            embeddingDimension: EmbDim,
+            numHeads: numHeads,
+            numKVHeads: numKVHeads,
+            activationFunction: new AiDotNet.ActivationFunctions.IdentityActivation<float>(),
+            useCausalMask: true);
+        gqa.ConfigurePositionalEncoding(PositionalEncodingType.Rotary, ropeTheta: 10000.0, maxSequenceLength: 512);
+
+        var layers = new List<AiDotNet.Interfaces.ILayer<float>>
+        {
+            new EmbeddingLayer<float>(Vocab, EmbDim),
+            new PreLNTransformerBlock<float>(hiddenSize: EmbDim, ffnDim: ffnDim, attention: gqa, gated: true),
+            new RMSNormalizationLayer<float>(),
+            new DenseLayer<float>(Vocab, activationFunction: new AiDotNet.ActivationFunctions.IdentityActivation<float>())
+        };
+
+        var architecture = new NeuralNetworkArchitecture<float>(
+            inputType: InputType.OneDimensional,
+            taskType: NeuralNetworkTaskType.TextGeneration,
+            complexity: NetworkComplexity.Simple,
+            inputSize: 1,
+            outputSize: Vocab,
+            layers: layers);
+
+        var model = new NeuralNetwork<float>(architecture);
+        var p = model.GetParameters();
+        var det = new float[p.Length];
+        for (int i = 0; i < det.Length; i++) det[i] = ((i % 17) - 8) / 16.0f;
+        model.UpdateParameters(new Vector<float>(det));
+        return model;
+    }
+
     [Fact(Timeout = 120000)]
     public async Task StructuredConstraint_IsHonored_OnIncrementalPagedPath()
     {

--- a/tests/AiDotNet.Tests/ModelLoading/GgufEndToEndTests.cs
+++ b/tests/AiDotNet.Tests/ModelLoading/GgufEndToEndTests.cs
@@ -139,6 +139,77 @@ namespace AiDotNet.Tests.ModelLoading
         }
 
         /// <summary>
+        /// Phase-2 transparent-fusion feasibility: run the WHOLE decoder forward inside a deferred scope
+        /// (BeginDeferredScope), which records the eager op stream into an execution graph, optimizes it, and
+        /// replays the fused graph on Execute() — the torch.compile-class lever. Confirms the deferred/fusion
+        /// path produces llama.cpp's greedy token (7042) for a real decoder, i.e. that transparent fusion is
+        /// viable before wiring it into Predict. Falls back to eager when the backend has no deferred support.
+        /// Gated on the real SmolLM2 GGUF + a GPU.
+        /// </summary>
+        /// <remarks>
+        /// KNOWN GAP (Phase 2 WIP): today the deferred/graph path returns token 0 (all-zero logits) for the
+        /// decoder — the captured graph does not materialize the correct output. Transparent fusion needs the
+        /// graph capture/replay (output binding + the decoder op set: RoPE/GQA-SDPA/RMSNorm) debugged before it
+        /// can wrap Predict. Skipped until that lands; this test is the acceptance check for it.
+        /// </remarks>
+        [Fact(Skip = "Phase-2 WIP: DeferredScope graph capture/replay returns token 0 for the decoder (output " +
+                     "not materialized); transparent fusion needs the graph path fixed for the decoder op set.")]
+        public void Gguf_DeferredScopeFusion_Runs7042_SmolLM2()
+        {
+            string? path = Environment.GetEnvironmentVariable("AIDOTNET_SMOLLM2_GGUF");
+            if (string.IsNullOrEmpty(path) || !File.Exists(path)) return;
+
+            bool gpuOk;
+            using (var probe = new AiDotNet.Tensors.Engines.DirectGpuTensorEngine()) gpuOk = probe.IsGpuAvailable;
+            if (!gpuOk) return;
+
+            var gpuEngine = new AiDotNet.Tensors.Engines.DirectGpuTensorEngine();
+            AiDotNet.Tensors.Engines.AiDotNetEngine.Current = gpuEngine;
+            try
+            {
+                var (model, _) = PretrainedLoader<float>.LoadGgufWithTokenizer(path);
+                var net = (NeuralNetworkBase<float>)model;
+                var ids = new[] { 504, 3575, 282, 4649, 314 };
+                var input = new Tensor<float>(new[] { 1, ids.Length });
+                for (int i = 0; i < ids.Length; i++) input[0, i] = ids[i];
+
+                int next;
+                var scope = gpuEngine.BeginDeferredScope();
+                if (scope is null)
+                {
+                    next = ArgmaxLast(net.Predict(input)); // deferred not supported: eager
+                }
+                else
+                {
+                    using (scope)
+                    {
+                        var logits = net.Predict(input); // ops record into the execution graph
+                        scope.Execute();                 // optimize + replay the fused graph
+                        next = ArgmaxLast(logits);
+                    }
+                }
+                Assert.Equal(7042, next);
+            }
+            finally
+            {
+                AiDotNet.Tensors.Engines.AiDotNetEngine.ResetToCpu();
+                gpuEngine.Dispose();
+            }
+        }
+
+        private static int ArgmaxLast(Tensor<float> logits) // [1, seq, vocab] -> argmax over the last position
+        {
+            int seq = logits.Shape[1], vocab = logits.Shape[2], best = 0;
+            float bestVal = float.NegativeInfinity;
+            for (int v = 0; v < vocab; v++)
+            {
+                float x = Convert.ToSingle(logits[0, seq - 1, v]);
+                if (x > bestVal) { bestVal = x; best = v; }
+            }
+            return best;
+        }
+
+        /// <summary>
         /// Per-layer OpenCL-vs-CPU decoder guard: runs the whole forward on the GPU engine and on the CPU
         /// engine and reports each layer's max abs diff. Asserts (a) no layer diverges at CORRUPTION scale —
         /// the stale-persistent-weight bug (a model built while a DirectGpuTensorEngine is Current, fixed by

--- a/tests/AiDotNet.Tests/ModelLoading/GgufEndToEndTests.cs
+++ b/tests/AiDotNet.Tests/ModelLoading/GgufEndToEndTests.cs
@@ -105,6 +105,40 @@ namespace AiDotNet.Tests.ModelLoading
         }
 
         /// <summary>
+        /// Device-model placement: instead of relying on the "GPU engine uploads everything" path, explicitly
+        /// place the whole model on the GPU with <c>model.To(DeviceInfo.OpenCL())</c> and confirm the forward
+        /// still produces llama.cpp's greedy token (7042 " Paris"). Proves the PyTorch-style placement API
+        /// drives correct GPU execution. Gated on the real SmolLM2 GGUF + a GPU being present.
+        /// </summary>
+        [Fact]
+        public void Gguf_ModelToOpenCL_Placement_Runs7042_SmolLM2()
+        {
+            string? path = Environment.GetEnvironmentVariable("AIDOTNET_SMOLLM2_GGUF");
+            if (string.IsNullOrEmpty(path) || !File.Exists(path)) return;
+
+            // Use the production wiring: AutoDetectAndConfigureGpu sets BOTH the dispatcher (Current) AND the
+            // global backend registry that Tensor.To(device) uses, so placement and execution share one backend.
+            // (A manually-constructed engine wires Current only, and To() then can't find a backend.) Skip when
+            // no GPU is wired in this environment.
+            if (!AiDotNet.Tensors.Engines.AiDotNetEngine.AutoDetectAndConfigureGpu()) return;
+            try
+            {
+                var (model, _) = PretrainedLoader<float>.LoadGgufWithTokenizer(path);
+                var net = (NeuralNetworkBase<float>)model;
+
+                // The device-model UX: move the whole model (weights + buffers) onto the GPU explicitly.
+                net.To(AiDotNet.Tensors.DeviceInfo.OpenCL());
+
+                int next = GreedyNext(net, new[] { 504, 3575, 282, 4649, 314 });
+                Assert.Equal(7042, next);
+            }
+            finally
+            {
+                AiDotNet.Tensors.Engines.AiDotNetEngine.ResetToCpu();
+            }
+        }
+
+        /// <summary>
         /// Per-layer OpenCL-vs-CPU decoder guard: runs the whole forward on the GPU engine and on the CPU
         /// engine and reports each layer's max abs diff. Asserts (a) no layer diverges at CORRUPTION scale —
         /// the stale-persistent-weight bug (a model built while a DirectGpuTensorEngine is Current, fixed by

--- a/tests/AiDotNet.Tests/UnitTests/Inference/InferenceOptimizerTests.cs
+++ b/tests/AiDotNet.Tests/UnitTests/Inference/InferenceOptimizerTests.cs
@@ -302,7 +302,6 @@ public class InferenceOptimizerTests
             input[i] = ((i % 13) - 6) / 6.0f;
         }
 
-        // Capture the reference output BEFORE optimization so an in-place rewrite still yields a valid baseline.
         var baseline = model.Predict(input);
 
         var config = new InferenceOptimizationConfig
@@ -314,7 +313,9 @@ public class InferenceOptimizerTests
         };
 
         var optimizer = new InferenceOptimizer<float>(config);
-        var (optimized, anyApplied) = optimizer.OptimizeForInference(model, cloneModel: false);
+        // cloneModel: true is the serving path (ServableModelWrapper.BuildIncrementalModel clones), which
+        // requires PreLNTransformerBlock + its nested GQA to round-trip through serialize/deserialize.
+        var (optimized, anyApplied) = optimizer.OptimizeForInference(model, cloneModel: true);
 
         // The GQA was rewritten onto the paged path, and the paged KV cache is live (incremental-generation ready).
         Assert.True(anyApplied);

--- a/tests/AiDotNet.Tests/UnitTests/Inference/InferenceOptimizerTests.cs
+++ b/tests/AiDotNet.Tests/UnitTests/Inference/InferenceOptimizerTests.cs
@@ -331,6 +331,82 @@ public class InferenceOptimizerTests
         }
     }
 
+    /// <summary>
+    /// Cloning a model goes through serialize → deserialize, so a GroupedQueryAttentionLayer must round-trip
+    /// every shape/behaviour argument. This pins the fix for a clone silently dropping RoPE and the causal mask
+    /// (they are not restored from metadata) — which diverged the cloned model and, downstream, broke the
+    /// incremental-serving clone of a GGUF decoder. A convention/loss bug shows up as a large divergence here.
+    /// </summary>
+    [Fact(Timeout = 60000)]
+    public async Task GroupedQueryAttention_RoundTripsThroughClone_PreservingRoPEAndCausalMask()
+    {
+        var model = CreateTinyGqaAttentionModel();
+
+        var input = new AiDotNet.Tensors.LinearAlgebra.Tensor<float>(new[] { 1, 32 });
+        for (int i = 0; i < input.Length; i++)
+        {
+            input[i] = ((i % 11) - 5) / 5.0f;
+        }
+
+        var baseline = model.Predict(input);
+        var clone = model.Clone();
+        var y = clone.Predict(input);
+
+        Assert.Equal(baseline.Shape.ToArray(), y.Shape.ToArray());
+        for (int i = 0; i < y.Length; i++)
+        {
+            Assert.True(Math.Abs(baseline[i] - y[i]) < 1e-4f,
+                $"Cloned GQA diverged from the original at {i}: {baseline[i]} vs {y[i]}");
+        }
+    }
+
+    private static NeuralNetworkBase<float> CreateTinyGqaAttentionModel()
+    {
+        const int seqLen = 4;
+        const int embDim = 8;
+        const int numHeads = 4;
+        const int numKVHeads = 2;
+        const int flatSize = seqLen * embDim;
+
+        var gqa = new GroupedQueryAttentionLayer<float>(
+            sequenceLength: seqLen,
+            embeddingDimension: embDim,
+            numHeads: numHeads,
+            numKVHeads: numKVHeads,
+            activationFunction: new AiDotNet.ActivationFunctions.IdentityActivation<float>(),
+            useCausalMask: true);
+        gqa.ConfigurePositionalEncoding(PositionalEncodingType.Rotary, ropeTheta: 10000.0, maxSequenceLength: seqLen);
+
+        var layers = new List<AiDotNet.Interfaces.ILayer<float>>
+        {
+            new InputLayer<float>(flatSize),
+            new ReshapeLayer<float>(new[] { seqLen, embDim }),
+            gqa,
+            new FlattenLayer<float>(),
+            new DenseLayer<float>(flatSize, activationFunction: new AiDotNet.ActivationFunctions.IdentityActivation<float>())
+        };
+
+        var architecture = new NeuralNetworkArchitecture<float>(
+            inputType: InputType.OneDimensional,
+            taskType: NeuralNetworkTaskType.TextGeneration,
+            complexity: NetworkComplexity.Simple,
+            inputSize: flatSize,
+            outputSize: flatSize,
+            layers: layers);
+
+        var model = new NeuralNetwork<float>(architecture);
+
+        var p = model.GetParameters();
+        var deterministic = new float[p.Length];
+        for (int i = 0; i < deterministic.Length; i++)
+        {
+            deterministic[i] = ((i % 17) - 8) / 16.0f;
+        }
+        model.UpdateParameters(new AiDotNet.Tensors.LinearAlgebra.Vector<float>(deterministic));
+
+        return model;
+    }
+
     private static NeuralNetworkBase<float> CreateTinyGqaDecoder()
     {
         const int seqLen = 4;

--- a/tests/AiDotNet.Tests/UnitTests/Inference/InferenceOptimizerTests.cs
+++ b/tests/AiDotNet.Tests/UnitTests/Inference/InferenceOptimizerTests.cs
@@ -266,6 +266,120 @@ public class InferenceOptimizerTests
         Assert.Contains(optimized.Layers, l => l is GraphAttentionLayer<float>);
     }
 
+    /// <summary>
+    /// A grouped-query decoder (numHeads &gt; numKVHeads) hosts its attention inside a PreLNTransformerBlock,
+    /// so enumerate the block's attention sublayer too.
+    /// </summary>
+    private static IEnumerable<ILayer<float>> PagedAttentionHosts(NeuralNetworkBase<float> model)
+    {
+        foreach (var layer in model.Layers)
+        {
+            yield return layer;
+            if (layer is PreLNTransformerBlock<float> preLn)
+                yield return preLn.AttentionLayer;
+        }
+    }
+
+    /// <summary>
+    /// End-to-end proof that the paged grouped-query attention path is numerically faithful: a tiny GQA decoder
+    /// (numHeads=4, numKVHeads=2, RoPE) is optimized with the paged KV cache enabled, and the optimized model's
+    /// forward must match the original within fp tolerance. This exercises the whole paged-GQA subsystem — the
+    /// kernel's repeat-KV, the layer's narrow K/V projections, the [Q][K][V][O][outBias] weight copy, and (the
+    /// key risk) that the paged layer's interleaved RoPE matches the source RotaryPositionalEncodingLayer. A
+    /// convention or wiring bug shows up as a large logit divergence here.
+    /// </summary>
+    [Fact(Timeout = 60000)]
+    public async Task InferenceOptimizer_PagedGroupedQueryAttention_MatchesOriginal_AndEnablesPagedCache()
+    {
+        var model = CreateTinyGqaDecoder();
+
+        // Original hosts a GroupedQueryAttentionLayer nested in a PreLNTransformerBlock.
+        Assert.Contains(PagedAttentionHosts(model), l => l is GroupedQueryAttentionLayer<float>);
+
+        var input = new AiDotNet.Tensors.LinearAlgebra.Tensor<float>(new[] { 1, 32 });
+        for (int i = 0; i < input.Length; i++)
+        {
+            input[i] = ((i % 13) - 6) / 6.0f;
+        }
+
+        // Capture the reference output BEFORE optimization so an in-place rewrite still yields a valid baseline.
+        var baseline = model.Predict(input);
+
+        var config = new InferenceOptimizationConfig
+        {
+            EnableKVCache = true,
+            EnablePagedKVCache = true,
+            EnableFlashAttention = false,
+            AttentionMasking = AttentionMaskingMode.Auto
+        };
+
+        var optimizer = new InferenceOptimizer<float>(config);
+        var (optimized, anyApplied) = optimizer.OptimizeForInference(model, cloneModel: false);
+
+        // The GQA was rewritten onto the paged path, and the paged KV cache is live (incremental-generation ready).
+        Assert.True(anyApplied);
+        Assert.NotNull(optimizer.PagedKVCache);
+        Assert.Contains(PagedAttentionHosts(optimized), l => l is PagedCachedMultiHeadAttention<float>);
+        Assert.DoesNotContain(PagedAttentionHosts(optimized), l => l is GroupedQueryAttentionLayer<float>);
+
+        var y = optimized.Predict(input);
+        Assert.Equal(baseline.Shape.ToArray(), y.Shape.ToArray());
+        for (int i = 0; i < y.Length; i++)
+        {
+            Assert.True(Math.Abs(baseline[i] - y[i]) < 1e-3f,
+                $"Paged-GQA diverged from the original at {i}: {baseline[i]} vs {y[i]}");
+        }
+    }
+
+    private static NeuralNetworkBase<float> CreateTinyGqaDecoder()
+    {
+        const int seqLen = 4;
+        const int embDim = 8;
+        const int numHeads = 4;
+        const int numKVHeads = 2;
+        const int ffnDim = 16;
+        const int flatSize = seqLen * embDim;
+
+        var gqa = new GroupedQueryAttentionLayer<float>(
+            sequenceLength: seqLen,
+            embeddingDimension: embDim,
+            numHeads: numHeads,
+            numKVHeads: numKVHeads,
+            activationFunction: new AiDotNet.ActivationFunctions.IdentityActivation<float>(),
+            useCausalMask: true);
+        gqa.ConfigurePositionalEncoding(PositionalEncodingType.Rotary, ropeTheta: 10000.0, maxSequenceLength: seqLen);
+
+        var layers = new List<AiDotNet.Interfaces.ILayer<float>>
+        {
+            new InputLayer<float>(flatSize),
+            new ReshapeLayer<float>(new[] { seqLen, embDim }),
+            new PreLNTransformerBlock<float>(hiddenSize: embDim, ffnDim: ffnDim, attention: gqa, gated: true),
+            new FlattenLayer<float>(),
+            new DenseLayer<float>(flatSize, activationFunction: new AiDotNet.ActivationFunctions.IdentityActivation<float>())
+        };
+
+        var architecture = new NeuralNetworkArchitecture<float>(
+            inputType: InputType.OneDimensional,
+            taskType: NeuralNetworkTaskType.TextGeneration,
+            complexity: NetworkComplexity.Simple,
+            inputSize: flatSize,
+            outputSize: flatSize,
+            layers: layers);
+
+        var model = new NeuralNetwork<float>(architecture);
+
+        // Deterministic parameters for a stable, reproducible parity comparison.
+        var p = model.GetParameters();
+        var deterministic = new float[p.Length];
+        for (int i = 0; i < deterministic.Length; i++)
+        {
+            deterministic[i] = ((i % 17) - 8) / 16.0f;
+        }
+        model.UpdateParameters(new AiDotNet.Tensors.LinearAlgebra.Vector<float>(deterministic));
+
+        return model;
+    }
+
     private static Transformer<float> CreateTinyTransformer(NeuralNetworkTaskType taskType)
     {
         var architecture = new TransformerArchitecture<float>(

--- a/tests/AiDotNet.Tests/UnitTests/Inference/InferenceOptimizerTests.cs
+++ b/tests/AiDotNet.Tests/UnitTests/Inference/InferenceOptimizerTests.cs
@@ -333,6 +333,46 @@ public class InferenceOptimizerTests
     }
 
     /// <summary>
+    /// The non-paged inference path routes the decoder's GQA to CachedGroupedQueryAttention, whose forward now
+    /// applies RoPE and grouped-query attention through the device-agnostic engine ops (ApplyRoPEInterleaved +
+    /// ScaledDotProductAttentionGqa — dropping managed RoPE + ExpandKVHeads and making the forward GPU-graph
+    /// recordable). The optimized model's forward must still match the original managed GQA decoder within fp
+    /// tolerance, proving the rewrite onto the recordable ops is numerically faithful.
+    /// </summary>
+    [Fact(Timeout = 60000)]
+    public async Task InferenceOptimizer_CachedGroupedQueryAttention_RewrittenForward_MatchesOriginal()
+    {
+        var model = CreateTinyGqaDecoder();
+        Assert.Contains(PagedAttentionHosts(model), l => l is GroupedQueryAttentionLayer<float>);
+
+        var input = new AiDotNet.Tensors.LinearAlgebra.Tensor<float>(new[] { 1, 32 });
+        for (int i = 0; i < input.Length; i++) input[i] = ((i % 13) - 6) / 6.0f;
+
+        var baseline = model.Predict(input);
+
+        var config = new InferenceOptimizationConfig
+        {
+            EnableKVCache = true,
+            EnablePagedKVCache = false, // non-paged -> CachedGroupedQueryAttention (the rewritten layer)
+            EnableFlashAttention = false,
+            AttentionMasking = AttentionMaskingMode.Auto
+        };
+
+        var optimizer = new InferenceOptimizer<float>(config);
+        var (optimized, anyApplied) = optimizer.OptimizeForInference(model, cloneModel: true);
+
+        Assert.True(anyApplied);
+        Assert.Contains(PagedAttentionHosts(optimized), l => l is CachedGroupedQueryAttention<float>);
+        Assert.DoesNotContain(PagedAttentionHosts(optimized), l => l is GroupedQueryAttentionLayer<float>);
+
+        var y = optimized.Predict(input);
+        Assert.Equal(baseline.Shape.ToArray(), y.Shape.ToArray());
+        for (int i = 0; i < y.Length; i++)
+            Assert.True(Math.Abs(baseline[i] - y[i]) < 1e-3f,
+                $"Rewritten CachedGQA diverged from the original at {i}: {baseline[i]} vs {y[i]}");
+    }
+
+    /// <summary>
     /// Cloning a model goes through serialize → deserialize, so a GroupedQueryAttentionLayer must round-trip
     /// every shape/behaviour argument. This pins the fix for a clone silently dropping RoPE and the causal mask
     /// (they are not restored from metadata) — which diverged the cloned model and, downstream, broke the


### PR DESCRIPTION
## Summary

Device-agnostic execution + GGUF Q8_0 quantized serving + CPU decode/prefill performance, stacked on the unified continuous-batching engine (#1888).

Verified end-to-end on real SmolLM2-135M GGUF, **llama.cpp parity preserved throughout** (greedy next-token = 7042 " Paris" at every step).

### Performance (SmolLM2-135M Q8_0, this AVX2 box)
| | before | after |
|---|---|---|
| Prefill | 205 tok/s | **451** (2.2×) |
| Decode | 3.9 tok/s | **11.3** (2.9×) |

### What's here
- **Q8_0 quantized serving**: keep GGUF Q8_0 weights quantized instead of expanding to fp32 at load (`GgufFile.TryReadQ8_0Raw` -> `GgufModelSource.TryReadQ8_0` -> `LlamaModelBuilder.LoadDense` -> `DenseLayer.SetQuantizedWeightsQ8_0`), running the block-Q8_0 GEMM (Tensors `Q8BlockGemm`) directly on int8. 3.76x less weight RAM. The quantized *forward* is gated on VNNI hardware (`AvxVnni`/`Avx512`) — on this AVX2 box it stays on fp32 (the int8 dot needs `vpdpbusd` to beat the tuned fp32 BLAS), auto-engaging on the CUDA+Linux serving target.
- **Decode perf**: vectorized the scalar per-token projection matvec (`PagedCachedMultiHeadAttention.MatVecMul`, AVX2 FMA); bulk-read the paged KV history under one lock (`PagedKVCache.ReadKeyValueRange`) instead of a lock per position.
- **Device-agnostic API** (from the branch): `model.To(DeviceInfo)` / `layer.To(...)` placement, `ConfigureModel(source, DeviceInfo)` facade overload, GQA paged incremental wiring (`InferenceOptimizer` recurses into `PreLNTransformerBlock`).
- **Benchmark harnesses**: `DEVHOST_PROFILE` (steady-state prefill for dotnet-trace) and `DEVHOST_DECODE` (real incremental generation -> tok/s).

### Release gate
The pin is a **local probe** (`AiDotNet.Tensors 0.118.10-q8`) — this consumer work depends on **Tensors `feat/q8-block-gemm`** (the `Q8BlockGemm` kernel + the float-RoPE/NumOps/mask-cache perf fixes, opened as a separate PR) plus #828 (already merged). **CI will be red until that Tensors branch is released to nuget.org and the pin is bumped to the released version.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
