### PR TITLE
fix(layers): keep the engine registration on the live tensor after a Dense resize

### DIFF
--- a/src/NeuralNetworks/Layers/DenseLayer.cs
+++ b/src/NeuralNetworks/Layers/DenseLayer.cs
@@ -1408,6 +1408,17 @@ public partial class DenseLayer<T> : LayerBase<T>, IAuxiliaryLossLayer<T>
             }
         }
 
+        // Move the engine's persistent-tensor registration onto the new tensor, in place. Training
+        // itself already follows the resize — the generated GetTrainableParameters() reads the
+        // _weights FIELD — but _registeredTensors is a separate list, and leaving it on the dead
+        // tensor means a GPU engine keeps a persistent handle on weights no forward reads while the
+        // live ones are never marked persistent, disposal unregisters the wrong tensor, and the old
+        // matrix stays reachable for the layer's lifetime. Positional replace, not
+        // unregister+register: the latter appends, and SetTrainableParameters pairs by index against
+        // GetTrainableParameters()' (weights, biases) order, so reordering would hand a clone its
+        // biases as weights.
+        ReplaceTrainableParameter(_weights, resizedWeights, PersistentTensorRole.Weights);
+
         _weights = resizedWeights;
         _weightsGradient = null;
         UpdateInputShape([actualInputSize]);

--- a/src/NeuralNetworks/Layers/LayerBase.cs
+++ b/src/NeuralNetworks/Layers/LayerBase.cs
@@ -3691,6 +3691,57 @@ public abstract class LayerBase<T> : ILayer<T>, ITrainableLayer<T>, IDisposable
     }
 
     /// <summary>
+    /// Swaps a registered trainable tensor for a replacement, keeping its POSITION in the
+    /// registration order.
+    /// </summary>
+    /// <param name="existing">The currently-registered tensor to replace.</param>
+    /// <param name="replacement">The tensor taking its place.</param>
+    /// <param name="role">The role to register <paramref name="replacement"/> under.</param>
+    /// <returns>
+    /// <c>true</c> if <paramref name="existing"/> was registered and has been replaced;
+    /// <c>false</c> if it was not registered, in which case nothing changed.
+    /// </returns>
+    /// <remarks>
+    /// <para>
+    /// Use this instead of <see cref="UnregisterTrainableParameter"/> followed by
+    /// <see cref="RegisterTrainableParameter"/> whenever a layer rebinds a parameter FIELD to a new
+    /// tensor (a resize or shape correction). Register appends, so the unregister/register pair
+    /// moves the parameter to the END of the list. That reordering is silently destructive:
+    /// <see cref="SetTrainableParameters"/> pairs the incoming list with <c>_registeredTensors</c>
+    /// BY INDEX against the order <see cref="GetTrainableParameters"/> returns, so a layer whose
+    /// registration order no longer matches its field order gets its parameters transposed on the
+    /// next copy-on-write clone — a DenseLayer would receive its biases as weights.
+    /// </para>
+    /// <para>
+    /// Rebinding a field without calling this leaves the engine holding a persistent handle on a
+    /// tensor no forward reads: on a GPU engine the live weights are never marked persistent,
+    /// disposal unregisters the wrong tensor, and the dead one stays reachable for the layer's
+    /// lifetime.
+    /// </para>
+    /// </remarks>
+    protected bool ReplaceTrainableParameter(
+        Tensor<T> existing, Tensor<T> replacement, PersistentTensorRole role)
+    {
+        if (existing is null || replacement is null || ReferenceEquals(existing, replacement))
+            return false;
+
+        for (int i = 0; i < _registeredTensors.Count; i++)
+        {
+            if (!ReferenceEquals(_registeredTensors[i], existing))
+                continue;
+
+            Engine.UnregisterPersistentTensor(existing);
+            Engine.RegisterPersistentTensor(replacement, role);
+            _registeredTensors[i] = replacement;
+            _registeredTensorRoles[i] = role;
+            _cachedParameterCount = -1;
+            return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>
     /// Registers a child layer for automatic discovery by the recursive parameter collection system.
     /// This is the equivalent of assigning an <c>nn.Module</c> as an attribute in PyTorch —
     /// the framework automatically discovers it via <see cref="GetSubLayers"/>.

--- a/tests/AiDotNet.Tests/UnitTests/NeuralNetworks/Layers/DenseLayerRegistrationSwapTests.cs
+++ b/tests/AiDotNet.Tests/UnitTests/NeuralNetworks/Layers/DenseLayerRegistrationSwapTests.cs
@@ -1,0 +1,113 @@
+using System;
+using System.Linq;
+using System.Reflection;
+using AiDotNet.ActivationFunctions;
+using AiDotNet.Interfaces;
+using AiDotNet.NeuralNetworks.Layers;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace AiDotNet.Tests.UnitTests.NeuralNetworks.Layers;
+
+/// <summary>
+/// Establishes what actually happens to a DenseLayer's trainable surface and its engine
+/// registration when the weight tensor is REPLACED by a resize.
+/// </summary>
+public class DenseLayerRegistrationSwapTests
+{
+    private readonly ITestOutputHelper _out;
+    public DenseLayerRegistrationSwapTests(ITestOutputHelper o) => _out = o;
+
+    private static DenseLayer<double> MakeLayer(int outputSize = 3)
+        => new(outputSize, (IActivationFunction<double>)new ReLUActivation<double>());
+
+    /// <summary>Reads the private _registeredTensors list that backs engine persistence.</summary>
+    private static Tensor<double>[] RegisteredTensors(DenseLayer<double> layer)
+    {
+        var f = typeof(LayerBase<double>).GetField("_registeredTensors",
+            BindingFlags.Instance | BindingFlags.NonPublic)!;
+        return ((System.Collections.Generic.List<Tensor<double>>)f.GetValue(layer)!).ToArray();
+    }
+
+    [Fact]
+    public void AfterResize_TrainableSurfaceAndEngineRegistrationBothTrackTheLiveTensor()
+    {
+        var layer = MakeLayer();
+        layer.Forward(new Tensor<double>([2, 4]));
+
+        var beforeTrainable = layer.GetTrainableParameters().First(p => p.Shape.Length == 2);
+        var beforeRegistered = RegisteredTensors(layer).First(p => p.Shape.Length == 2);
+        _out.WriteLine($"pre-resize : trainable[{beforeTrainable.Shape[0]},{beforeTrainable.Shape[1]}] " +
+                       $"registered[{beforeRegistered.Shape[0]},{beforeRegistered.Shape[1]}] " +
+                       $"same={ReferenceEquals(beforeTrainable, beforeRegistered)}");
+
+        // Widen the input: DenseLayer.EnsureWeightShapeForInput rebuilds the weight tensor.
+        layer.Forward(new Tensor<double>([2, 7]));
+
+        var afterTrainable = layer.GetTrainableParameters().First(p => p.Shape.Length == 2);
+        var afterRegistered = RegisteredTensors(layer).First(p => p.Shape.Length == 2);
+        _out.WriteLine($"post-resize: trainable[{afterTrainable.Shape[0]},{afterTrainable.Shape[1]}] " +
+                       $"registered[{afterRegistered.Shape[0]},{afterRegistered.Shape[1]}] " +
+                       $"same={ReferenceEquals(afterTrainable, afterRegistered)}");
+        _out.WriteLine($"registered still == pre-resize tensor? {ReferenceEquals(afterRegistered, beforeTrainable)}");
+
+        // The trainable surface is what the tape training step collects and the optimizer writes to.
+        Assert.Equal(7, afterTrainable.Shape[0]);
+
+        // The engine registration must track the same tensor; otherwise a GPU engine keeps a
+        // persistent handle on a tensor no forward reads, and dispose unregisters the wrong one.
+        Assert.True(ReferenceEquals(afterTrainable, afterRegistered),
+            $"engine registration points at a [{afterRegistered.Shape[0]},{afterRegistered.Shape[1]}] " +
+            $"tensor while the live weights are [{afterTrainable.Shape[0]},{afterTrainable.Shape[1]}].");
+    }
+
+    /// <summary>
+    /// The registration must keep its ORDER across a resize, not just its contents.
+    /// </summary>
+    /// <remarks>
+    /// SetTrainableParameters pairs the incoming list with _registeredTensors by index against the
+    /// order GetTrainableParameters() returns — (weights, biases) for DenseLayer. Fixing the stale
+    /// registration by unregister-then-register would append the weights AFTER the biases, so the
+    /// next copy-on-write clone would assign the source's weights into this layer's biases. That
+    /// swap is shape-compatible only by accident and would corrupt silently.
+    /// </remarks>
+    [Fact]
+    public void AfterResize_RegistrationOrderStillMatchesTrainableOrder()
+    {
+        var layer = MakeLayer(outputSize: 3);
+        layer.Forward(new Tensor<double>([2, 4]));
+        layer.Forward(new Tensor<double>([2, 7]));   // triggers the resize
+
+        var trainable = layer.GetTrainableParameters();
+        var registered = RegisteredTensors(layer);
+
+        _out.WriteLine("trainable : " + string.Join(", ", trainable.Select(t => $"[{string.Join(",", t.Shape)}]")));
+        _out.WriteLine("registered: " + string.Join(", ", registered.Select(t => $"[{string.Join(",", t.Shape)}]")));
+
+        Assert.Equal(trainable.Count, registered.Length);
+        for (int i = 0; i < trainable.Count; i++)
+            Assert.True(ReferenceEquals(trainable[i], registered[i]),
+                $"position {i} differs: GetTrainableParameters() has " +
+                $"[{string.Join(",", trainable[i].Shape)}] but the registration has " +
+                $"[{string.Join(",", registered[i].Shape)}]. SetTrainableParameters pairs these by " +
+                "index, so a clone would receive them transposed.");
+    }
+
+    /// <summary>Repeated width changes must not leave dead tensors registered.</summary>
+    [Fact]
+    public void RepeatedResizes_DoNotAccumulateRegistrations()
+    {
+        var layer = MakeLayer(outputSize: 3);
+        layer.Forward(new Tensor<double>([2, 4]));
+        foreach (int width in new[] { 6, 9, 5, 11 })
+            layer.Forward(new Tensor<double>([2, width]));
+
+        var registered = RegisteredTensors(layer);
+        _out.WriteLine("registered after 4 resizes: " +
+            string.Join(", ", registered.Select(t => $"[{string.Join(",", t.Shape)}]")));
+
+        Assert.Equal(2, registered.Length);   // exactly one weights + one biases
+        Assert.Equal(11, registered.First(t => t.Shape.Length == 2).Shape[0]);
+    }
+}


### PR DESCRIPTION
## What

`DenseLayer.EnsureWeightShapeForInput` rebuilds `_weights` when a lazily-sized layer is forwarded at an input width other than the one it materialized at (#1643). It rebound the field but left `_registeredTensors` — the list behind the engine's persistent-tensor registry — pointing at the dead tensor.

## What is and isn't affected

**Training was never broken.** The generated `GetTrainableParameters()` override returns the `_weights` *field*, so the tape training step and the optimizer already followed the resized tensor.

What went stale is the engine registration:

- a GPU engine keeps a persistent handle on weights no forward reads, while the live weights are never marked persistent
- disposal unregisters the wrong tensor, leaking the live one's registration
- the dead matrix stays reachable for the layer's lifetime, and every further resize adds another

## Why a new `LayerBase.ReplaceTrainableParameter`

The swap must preserve **position**, so this can't be `UnregisterTrainableParameter` + `RegisterTrainableParameter`. Register *appends*, and `SetTrainableParameters` pairs the incoming list with `_registeredTensors` **by index** against the order `GetTrainableParameters()` returns.

Appending would leave `DenseLayer` registered as `(biases, weights)` while its getter still reports `(weights, biases)` — so the next copy-on-write clone would assign the source's weights into this layer's biases. Shape-compatible only by accident, and silent. `AfterResize_RegistrationOrderStillMatchesTrainableOrder` pins that.

## Verification

The suite is flaky under parallel execution, which made several unrelated tests look implicated on individual runs. Run serially, the signal is clean:

| | result |
|---|---|
| without this change | **3 failed / 664 passed** — exactly the three new tests |
| with this change | **0 failed / 667 passed** |

## Scope

The resize path is not hit by every model — it fires for lazily-sized Dense layers fed a width other than the one they materialized at (the NTM controller Dense and MMDiT's `_timeEmbed1` are the documented cases). A probe over `ContextNet` and `RWKVForecaster` recorded **zero** resize events, so this is not the cause of any currently-failing test I could identify.

Stacked on #1789 (its head is this branch's base), so the diff here is the single commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)