### PR TITLE
fix(training): pass the configured optimizer to trainwithtape

### DIFF
--- a/src/ComputerVision/Segmentation/Medical/MedSAM.cs
+++ b/src/ComputerVision/Segmentation/Medical/MedSAM.cs
@@ -238,7 +238,7 @@ public class MedSAM<T> : NeuralNetworkBase<T>, IMedicalSegmentation<T>
         try
         {
             SetTrainingMode(true);
-            TrainWithTape(input, expectedOutput);
+            TrainWithTape(input, expectedOutput, _optimizer);
         }
         finally
         {

--- a/src/ComputerVision/Segmentation/Medical/MedSAM2.cs
+++ b/src/ComputerVision/Segmentation/Medical/MedSAM2.cs
@@ -227,7 +227,7 @@ public class MedSAM2<T> : NeuralNetworkBase<T>, IMedicalSegmentation<T>
         SetTrainingMode(true);
         try
         {
-            TrainWithTape(input, expectedOutput);
+            TrainWithTape(input, expectedOutput, _optimizer);
         }
         finally
         {

--- a/src/SpeechRecognition/CTCVariants/CTCEBranchformerOptions.cs
+++ b/src/SpeechRecognition/CTCVariants/CTCEBranchformerOptions.cs
@@ -32,6 +32,9 @@ public class CTCEBranchformerOptions : ModelOptions
         OnnxOptions = new OnnxModelOptions(other.OnnxOptions);
         DropoutRate = other.DropoutRate;
         Language = other.Language;
+        // Copy the array itself, not the reference: a clone that shared the original's vocabulary
+        // would see later edits to it, which is not what copying an options object should mean.
+        Vocabulary = other.Vocabulary is null ? null : (string[])other.Vocabulary.Clone();
     }
 
     public int SampleRate { get; set; } = 16000;

--- a/src/Video/Segmentation/SAM2.cs
+++ b/src/Video/Segmentation/SAM2.cs
@@ -582,7 +582,7 @@ public class SAM2<T> : NeuralNetworkBase<T>
         SetTrainingMode(true);
         try
         {
-            TrainWithTape(input, expectedOutput);
+            TrainWithTape(input, expectedOutput, _optimizer);
         }
         finally
         {

--- a/src/VisionLanguage/Encoders/DeCLIP.cs
+++ b/src/VisionLanguage/Encoders/DeCLIP.cs
@@ -236,7 +236,7 @@ public class DeCLIP<T> : VisionLanguageModelBase<T>, IContrastiveVisionLanguageM
         SetTrainingMode(true);
         try
         {
-            TrainWithTape(PreprocessImage(input), expected);
+            TrainWithTape(PreprocessImage(input), expected, _optimizer);
         }
         finally
         {


### PR DESCRIPTION
Five pre-existing bugs that the #1789 split does not cover, because the split only carries files #1789 actually changes.

## Dead optimizers (4 models)

`MedSAM`, `MedSAM2`, `SAM2` and `DeCLIP` each build a `IGradientBasedOptimizer` in their constructor and then call the **two-argument** `TrainWithTape(input, expected)`, which never reads it. Training silently ran on the framework default optimizer — including when a caller passed an optimizer explicitly to the constructor, which is the case where it matters most.

Each becomes `TrainWithTape(..., _optimizer)`.

## Copy constructor dropping a property

`CTCEBranchformerOptions` never copied `Vocabulary`, so a clone silently lost it. The array is cloned rather than shared, so a later edit to the original's vocabulary does not reach the copy — matching the sibling `ParaformerOptions` fix.

## Deliberately not included

`DRVI` and `TDPNet` have the same dead-optimizer bug, but **#1789 deletes both files**, so fixing them here would be undone at merge. Left alone on purpose.

## Verification

The identical edits build at **0 errors** on the #1789 snapshot branch.

They could **not** be verified against `master` directly, because master does not currently build for `net10.0` on its own — **864 errors**, all of the form:

```
error CS1061: 'IEngine' does not contain a definition for 'TensorBroadcastDivide'
error CS1061: 'IEngine' does not contain a definition for 'TensorBroadcastMultiply'
```

The source calls `AiDotNet.Tensors` APIs that the pinned package version does not expose. That is unrelated to this change, predates it, and is worth investigating separately — flagging it here because it means CI on this PR may be red for reasons that have nothing to do with the diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)