### PR TITLE
refactor(loss): make the autodiff tape the only source of gradients

### DIFF
--- a/AiDotNetBenchmarkTests/BenchmarkTests/LossFunctionsBenchmarks.cs
+++ b/AiDotNetBenchmarkTests/BenchmarkTests/LossFunctionsBenchmarks.cs
@@ -1,9 +1,15 @@
 using AiDotNet.LossFunctions;
+using AiDotNet.Interfaces;
 using AiDotNet.Tensors.Helpers;
 using AiDotNet.Tensors.LinearAlgebra;
 using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Jobs;
 
+// Gradient benchmarks measure the TAPE gradient: every loss derivative in the library is
+// now obtained by differentiating ComputeTapeLoss, and the hand-written analytic
+// derivatives these once measured are deleted. Expect different absolute numbers -- a tape
+// records and replays a graph where a closed form did not -- and note that the comparison
+// against the old figures is not like-for-like.
 namespace AiDotNetBenchmarkTests.BenchmarkTests;
 
 /// <summary>
@@ -126,9 +132,9 @@ public class LossFunctionsBenchmarks
     }
 
     [Benchmark]
-    public Vector<double> MSE_CalculateDerivative()
+    public Vector<double> MSE_ComputeGradient()
     {
-        return _mse.CalculateDerivative(_predicted, _actual);
+        return _mse.ComputeGradient(_predicted, _actual);
     }
 
     #endregion
@@ -142,9 +148,9 @@ public class LossFunctionsBenchmarks
     }
 
     [Benchmark]
-    public Vector<double> MAE_CalculateDerivative()
+    public Vector<double> MAE_ComputeGradient()
     {
-        return _mae.CalculateDerivative(_predicted, _actual);
+        return _mae.ComputeGradient(_predicted, _actual);
     }
 
     #endregion
@@ -158,9 +164,9 @@ public class LossFunctionsBenchmarks
     }
 
     [Benchmark]
-    public Vector<double> RMSE_CalculateDerivative()
+    public Vector<double> RMSE_ComputeGradient()
     {
-        return _rmse.CalculateDerivative(_predicted, _actual);
+        return _rmse.ComputeGradient(_predicted, _actual);
     }
 
     #endregion
@@ -174,9 +180,9 @@ public class LossFunctionsBenchmarks
     }
 
     [Benchmark]
-    public Vector<double> Huber_CalculateDerivative()
+    public Vector<double> Huber_ComputeGradient()
     {
-        return _huber.CalculateDerivative(_predicted, _actual);
+        return _huber.ComputeGradient(_predicted, _actual);
     }
 
     #endregion
@@ -190,9 +196,9 @@ public class LossFunctionsBenchmarks
     }
 
     [Benchmark]
-    public Vector<double> Quantile_CalculateDerivative()
+    public Vector<double> Quantile_ComputeGradient()
     {
-        return _quantile.CalculateDerivative(_predicted, _actual);
+        return _quantile.ComputeGradient(_predicted, _actual);
     }
 
     #endregion
@@ -206,9 +212,9 @@ public class LossFunctionsBenchmarks
     }
 
     [Benchmark]
-    public Vector<double> LogCosh_CalculateDerivative()
+    public Vector<double> LogCosh_ComputeGradient()
     {
-        return _logCosh.CalculateDerivative(_predicted, _actual);
+        return _logCosh.ComputeGradient(_predicted, _actual);
     }
 
     #endregion
@@ -222,9 +228,9 @@ public class LossFunctionsBenchmarks
     }
 
     [Benchmark]
-    public Vector<double> BCE_CalculateDerivative()
+    public Vector<double> BCE_ComputeGradient()
     {
-        return _bce.CalculateDerivative(_binaryPredicted, _binaryActual);
+        return _bce.ComputeGradient(_binaryPredicted, _binaryActual);
     }
 
     #endregion
@@ -239,10 +245,10 @@ public class LossFunctionsBenchmarks
     }
 
     [Benchmark]
-    public Vector<double> CrossEntropy_CalculateDerivative()
+    public Vector<double> CrossEntropy_ComputeGradient()
     {
         // Use softmax predicted and one-hot encoded actual for proper multi-class classification
-        return _crossEntropy.CalculateDerivative(_softmaxPredicted, _oneHotActual);
+        return _crossEntropy.ComputeGradient(_softmaxPredicted, _oneHotActual);
     }
 
     #endregion
@@ -256,9 +262,9 @@ public class LossFunctionsBenchmarks
     }
 
     [Benchmark]
-    public Vector<double> Focal_CalculateDerivative()
+    public Vector<double> Focal_ComputeGradient()
     {
-        return _focal.CalculateDerivative(_binaryPredicted, _binaryActual);
+        return _focal.ComputeGradient(_binaryPredicted, _binaryActual);
     }
 
     #endregion
@@ -273,10 +279,10 @@ public class LossFunctionsBenchmarks
     }
 
     [Benchmark]
-    public Vector<double> Hinge_CalculateDerivative()
+    public Vector<double> Hinge_ComputeGradient()
     {
         // Hinge loss expects {-1, +1} labels for max(0, 1 - y*f(x)) formula
-        return _hinge.CalculateDerivative(_binaryPredicted, _hingeBinaryActual);
+        return _hinge.ComputeGradient(_binaryPredicted, _hingeBinaryActual);
     }
 
     #endregion
@@ -290,9 +296,9 @@ public class LossFunctionsBenchmarks
     }
 
     [Benchmark]
-    public Vector<double> Cosine_CalculateDerivative()
+    public Vector<double> Cosine_ComputeGradient()
     {
-        return _cosine.CalculateDerivative(_predicted, _actual);
+        return _cosine.ComputeGradient(_predicted, _actual);
     }
 
     #endregion
@@ -306,9 +312,9 @@ public class LossFunctionsBenchmarks
     }
 
     [Benchmark]
-    public Vector<double> Dice_CalculateDerivative()
+    public Vector<double> Dice_ComputeGradient()
     {
-        return _dice.CalculateDerivative(_binaryPredicted, _binaryActual);
+        return _dice.ComputeGradient(_binaryPredicted, _binaryActual);
     }
 
     #endregion
@@ -322,9 +328,9 @@ public class LossFunctionsBenchmarks
     }
 
     [Benchmark]
-    public Vector<double> Jaccard_CalculateDerivative()
+    public Vector<double> Jaccard_ComputeGradient()
     {
-        return _jaccard.CalculateDerivative(_binaryPredicted, _binaryActual);
+        return _jaccard.ComputeGradient(_binaryPredicted, _binaryActual);
     }
 
     #endregion

--- a/AiDotNetBenchmarkTests/Helpers/MockLossFunction.cs
+++ b/AiDotNetBenchmarkTests/Helpers/MockLossFunction.cs
@@ -1,4 +1,6 @@
 using AiDotNet.Helpers;
+using System;
+using AiDotNet.Tensors.Engines;
 using AiDotNet.Interfaces;
 using AiDotNet.LinearAlgebra;
 using AiDotNet.Tensors.Helpers;
@@ -42,30 +44,6 @@ public class MockLossFunction<T> : ILossFunction<T>
         return NumOps.Zero;
     }
 
-    /// <summary>
-    /// Calculates the derivative of the loss function.
-    /// </summary>
-    public Vector<T> CalculateDerivative(Vector<T> predicted, Vector<T> actual)
-    {
-        int length = Math.Min(predicted.Length, actual.Length);
-        var derivative = new Vector<T>(length);
-
-        // Guard against division by zero for empty vectors
-        if (length == 0)
-        {
-            return derivative;
-        }
-
-        T twoOverN = NumOps.Divide(NumOps.FromDouble(2.0), NumOps.FromDouble(length));
-
-        for (int i = 0; i < length; i++)
-        {
-            T diff = NumOps.Subtract(predicted[i], actual[i]);
-            derivative[i] = NumOps.Multiply(twoOverN, diff);
-        }
-
-        return derivative;
-    }
 
     /// <summary>
     /// GPU loss and gradient calculation - not supported in mock.
@@ -73,5 +51,28 @@ public class MockLossFunction<T> : ILossFunction<T>
     public (T Loss, Tensor<T> Gradient) CalculateLossAndGradientGpu(Tensor<T> predicted, Tensor<T> actual)
     {
         throw new NotSupportedException("GPU operations are not supported in MockLossFunction.");
+    }
+
+    /// <summary>
+    /// Computes the loss as a tape-differentiable scalar tensor.
+    /// </summary>
+    /// <param name="predicted">The predicted tensor.</param>
+    /// <param name="target">The target tensor.</param>
+    /// <returns>A rank-0 scalar tensor holding the mean squared error.</returns>
+    /// <remarks>
+    /// Built from engine operations so the gradient tape can differentiate it. The mock supplies
+    /// no derivative of its own, exactly like a real loss function.
+    /// </remarks>
+    public Tensor<T> ComputeTapeLoss(Tensor<T> predicted, Tensor<T> target)
+    {
+        var engine = AiDotNetEngine.Current;
+        var diff = engine.TensorSubtract(predicted, target);
+        var squared = engine.TensorMultiply(diff, diff);
+
+        var axes = new int[squared.Shape.Length];
+        for (int i = 0; i < axes.Length; i++) axes[i] = i;
+
+        var summed = engine.ReduceSum(squared, axes, keepDims: false);
+        return engine.TensorDivideScalar(summed, NumOps.FromDouble(Math.Max(1, squared.Length)));
     }
 }

--- a/docs/FACADE_CONFIG_AUDIT.md
+++ b/docs/FACADE_CONFIG_AUDIT.md
@@ -149,6 +149,11 @@ Swappable (all plain MSE): NBEATS (`:298`, `:625`), NHiTS (`:265`, `:524`), Info
 
 ### The contract is wider than training can honor
 
+> **RESOLVED (#1992).** `ILossFunction<T>` now declares `ComputeTapeLoss` and no longer
+> declares `CalculateDerivative`, so the downcasts described below are gone and any type
+> implementing the interface is tape-trainable by construction. The finding is kept as a
+> record of what was wrong.
+
 `ILossFunction<T>` (`src/Interfaces/ILossFunction.cs:26`) has three members: `CalculateLoss` (`:34`), `CalculateDerivative` (`:42`), `CalculateLossAndGradientGpu` (`:54`). It has **no `ComputeTapeLoss`** — that lives on the abstract `LossFunctionBase<T>`, and the tape paths hard-require the downcast:
 
 ```

--- a/src/AiDotNet.Playground/Services/ExampleService.cs
+++ b/src/AiDotNet.Playground/Services/ExampleService.cs
@@ -3989,7 +3989,7 @@ var mseLoss = new MeanSquaredErrorLoss<double>();
 var loss = mseLoss.CalculateLoss(predicted, actual);
 
 // Calculate the derivative (gradient)
-var gradient = mseLoss.CalculateDerivative(predicted, actual);
+var gradient = mseLoss.ComputeGradient(predicted, actual);
 
 Console.WriteLine(""Mean Squared Error Loss:"");
 Console.WriteLine($""  Predicted: [{string.Join("", "", predicted.ToArray())}]"");
@@ -4020,7 +4020,7 @@ var actual = new Vector<double>(new double[] { 1.0, 0.0, 0.0 });
 var ceLoss = new CrossEntropyLoss<double>();
 
 var loss = ceLoss.CalculateLoss(predicted, actual);
-var gradient = ceLoss.CalculateDerivative(predicted, actual);
+var gradient = ceLoss.ComputeGradient(predicted, actual);
 
 Console.WriteLine(""Cross Entropy Loss:"");
 Console.WriteLine($""  Predicted probs: [{string.Join("", "", predicted.ToArray().Select(p => p.ToString(""F2"")))}]"");

--- a/src/Audio/Enhancement/DCCRN.cs
+++ b/src/Audio/Enhancement/DCCRN.cs
@@ -521,10 +521,6 @@ public class DCCRN<T> : AudioNeuralNetworkBase<T>, IAudioEnhancer<T>
         // SI-SNR or MSE loss on STFT
         var loss = _lossFunction.CalculateLoss(enhancedVector, cleanVector);
 
-        // Backward pass
-        var gradientVector = _lossFunction.CalculateDerivative(enhancedVector, cleanVector);
-        var gradientTensor = Tensor<T>.FromVector(gradientVector, enhancedStft._shape);
-
         // Update parameters via optimizer
         _optimizer?.UpdateParameters(Layers);
 

--- a/src/Audio/LanguageIdentification/ECAPATDNNLanguageIdentifier.cs
+++ b/src/Audio/LanguageIdentification/ECAPATDNNLanguageIdentifier.cs
@@ -430,8 +430,6 @@ public class ECAPATDNNLanguageIdentifier<T> : AudioNeuralNetworkBase<T>, ILangua
         var expectedVector = expectedOutput.ToVector();
 
         var loss = _lossFunction.CalculateLoss(predictedVector, expectedVector);
-        var gradientVector = _lossFunction.CalculateDerivative(predictedVector, expectedVector);
-        var gradientTensor = Tensor<T>.FromVector(gradientVector, predicted._shape);
 
         _optimizer?.UpdateParameters(Layers);
 

--- a/src/Audio/LanguageIdentification/VoxLingua107Identifier.cs
+++ b/src/Audio/LanguageIdentification/VoxLingua107Identifier.cs
@@ -464,8 +464,6 @@ public class VoxLingua107Identifier<T> : AudioNeuralNetworkBase<T>, ILanguageIde
         var expectedVector = expectedOutput.ToVector();
 
         var loss = _lossFunction.CalculateLoss(predictedVector, expectedVector);
-        var gradientVector = _lossFunction.CalculateDerivative(predictedVector, expectedVector);
-        var gradientTensor = Tensor<T>.FromVector(gradientVector, predicted._shape);
 
         _optimizer?.UpdateParameters(Layers);
 

--- a/src/Audio/LanguageIdentification/Wav2Vec2LanguageIdentifier.cs
+++ b/src/Audio/LanguageIdentification/Wav2Vec2LanguageIdentifier.cs
@@ -412,8 +412,6 @@ public class Wav2Vec2LanguageIdentifier<T> : AudioNeuralNetworkBase<T>, ILanguag
         var expectedVector = expectedOutput.ToVector();
 
         var loss = _lossFunction.CalculateLoss(predictedVector, expectedVector);
-        var gradientVector = _lossFunction.CalculateDerivative(predictedVector, expectedVector);
-        var gradientTensor = Tensor<T>.FromVector(gradientVector, predicted._shape);
 
         _optimizer?.UpdateParameters(Layers);
 

--- a/src/Classification/Boosting/HistGradientBoostingClassifier.cs
+++ b/src/Classification/Boosting/HistGradientBoostingClassifier.cs
@@ -796,37 +796,6 @@ public class HistGradientBoostingClassifier<T> : ClassifierBase<T>
     }
 
     /// <summary>
-    /// Computes gradients for the model parameters.
-    /// </summary>
-    /// <param name="input">Input feature matrix.</param>
-    /// <param name="target">Target labels.</param>
-    /// <param name="lossFunction">Optional custom loss function.</param>
-    /// <returns>Gradient vector.</returns>
-    /// <remarks>
-    /// <para><b>For Beginners:</b> Gradient boosting models are trained iteratively, not by
-    /// computing a single gradient over all parameters. This returns a placeholder gradient.</para>
-    /// </remarks>
-    public Vector<T> ComputeGradients(Matrix<T> input, Vector<T> target, ILossFunction<T>? lossFunction = null)
-    {
-        // Tree models don't use gradient-based parameter updates in the traditional sense
-        return new Vector<T>(1) { [0] = NumOps.Zero };
-    }
-
-    /// <summary>
-    /// Applies gradients to update model parameters.
-    /// </summary>
-    /// <param name="gradients">Gradient vector.</param>
-    /// <param name="learningRate">Learning rate.</param>
-    /// <remarks>
-    /// <para><b>For Beginners:</b> Tree models are not updated via gradient descent on parameters.
-    /// They're trained by building trees iteratively.</para>
-    /// </remarks>
-    public void ApplyGradients(Vector<T> gradients, T learningRate)
-    {
-        // Tree models don't support gradient-based parameter updates
-    }
-
-    /// <summary>
     /// Gets feature importance based on total gain reduction.
     /// </summary>
     /// <returns>Dictionary mapping feature names to importance scores.</returns>

--- a/src/Classification/Calibration/CalibratedClassifier.cs
+++ b/src/Classification/Calibration/CalibratedClassifier.cs
@@ -54,7 +54,7 @@ namespace AiDotNet.Classification.Calibration;
 [ModelInput(typeof(Matrix<>), typeof(Vector<>))]
 [ResearchPaper("Predicting Good Probabilities with Supervised Learning", "https://doi.org/10.1145/1102351.1102430")]
 public class CalibratedClassifier<T> : ProbabilisticClassifierBase<T>,
-    IParameterizable<T, Matrix<T>, Vector<T>>, IGradientComputable<T, Matrix<T>, Vector<T>>
+    IParameterizable<T, Matrix<T>, Vector<T>>
 {
     /// <summary>
     /// The base classifier being calibrated.
@@ -866,21 +866,6 @@ public class CalibratedClassifier<T> : ProbabilisticClassifierBase<T>,
             calibrated.SetParameters(parameters);
         }
         return newModel;
-    }
-
-    /// <inheritdoc/>
-    public Vector<T> ComputeGradients(Matrix<T> input, Vector<T> target, ILossFunction<T>? lossFunction = null)
-    {
-        // Calibration wrappers don't use gradient-based optimization
-        // The calibration is fitted using closed-form solutions or simple optimization
-        return new Vector<T>(6); // 6 calibration parameters
-    }
-
-    /// <inheritdoc/>
-    public void ApplyGradients(Vector<T> gradients, T learningRate)
-    {
-        // Calibration wrappers don't use gradient-based optimization
-        // This is a no-op for compatibility
     }
 
     /// <inheritdoc/>

--- a/src/Classification/DiscriminantAnalysis/LinearDiscriminantAnalysis.cs
+++ b/src/Classification/DiscriminantAnalysis/LinearDiscriminantAnalysis.cs
@@ -75,7 +75,7 @@ namespace AiDotNet.Classification.DiscriminantAnalysis;
 [ModelInput(typeof(Matrix<>), typeof(Vector<>))]
 [ResearchPaper("The Use of Multiple Measurements in Taxonomic Problems", "https://doi.org/10.1111/j.1469-1809.1936.tb02137.x")]
 public class LinearDiscriminantAnalysis<T> : ProbabilisticClassifierBase<T>,
-    IParameterizable<T, Matrix<T>, Vector<T>>, IGradientComputable<T, Matrix<T>, Vector<T>>
+    IParameterizable<T, Matrix<T>, Vector<T>>
 {
     /// <summary>
     /// LDA computes parameters from class covariance matrices during training.
@@ -639,21 +639,6 @@ public class LinearDiscriminantAnalysis<T> : ProbabilisticClassifierBase<T>,
     {
         // Return a fresh instance — LDA parameters come from training, not direct setting
         return CreateNewInstance();
-    }
-
-    /// <inheritdoc/>
-    public Vector<T> ComputeGradients(Matrix<T> input, Vector<T> target, ILossFunction<T>? lossFunction = null)
-    {
-        // LDA is a closed-form solution, not gradient-based
-        // Return zero gradients
-        return new Vector<T>(NumClasses * NumFeatures);
-    }
-
-    /// <inheritdoc/>
-    public void ApplyGradients(Vector<T> gradients, T learningRate)
-    {
-        // LDA is a closed-form solution, not gradient-based
-        // This is a no-op
     }
 
     /// <inheritdoc/>

--- a/src/Classification/DiscriminantAnalysis/QuadraticDiscriminantAnalysis.cs
+++ b/src/Classification/DiscriminantAnalysis/QuadraticDiscriminantAnalysis.cs
@@ -64,7 +64,7 @@ namespace AiDotNet.Classification.DiscriminantAnalysis;
 [ModelInput(typeof(Matrix<>), typeof(Vector<>))]
 [ResearchPaper("The Use of Multiple Measurements in Taxonomic Problems", "https://doi.org/10.1111/j.1469-1809.1936.tb02137.x")]
 public class QuadraticDiscriminantAnalysis<T> : ProbabilisticClassifierBase<T>,
-    IParameterizable<T, Matrix<T>, Vector<T>>, IGradientComputable<T, Matrix<T>, Vector<T>>
+    IParameterizable<T, Matrix<T>, Vector<T>>
 {
     /// <summary>
     /// Gets the QDA-specific options.
@@ -709,21 +709,6 @@ public class QuadraticDiscriminantAnalysis<T> : ProbabilisticClassifierBase<T>,
     public IFullModel<T, Matrix<T>, Vector<T>> WithParameters(Vector<T> parameters)
     {
         return CreateNewInstance();
-    }
-
-    /// <inheritdoc/>
-    public Vector<T> ComputeGradients(Matrix<T> input, Vector<T> target, ILossFunction<T>? lossFunction = null)
-    {
-        // QDA is a closed-form solution, not gradient-based
-        // Return zero gradients
-        return new Vector<T>(NumClasses * NumFeatures);
-    }
-
-    /// <inheritdoc/>
-    public void ApplyGradients(Vector<T> gradients, T learningRate)
-    {
-        // QDA is a closed-form solution, not gradient-based
-        // This is a no-op
     }
 
     /// <inheritdoc/>

--- a/src/Classification/ImbalancedEnsemble/BalancedBaggingClassifier.cs
+++ b/src/Classification/ImbalancedEnsemble/BalancedBaggingClassifier.cs
@@ -600,34 +600,6 @@ public class BalancedBaggingClassifier<T> : ClassifierBase<T>
     }
 
     /// <summary>
-    /// Computes gradients (not applicable for tree ensembles).
-    /// </summary>
-    /// <param name="input">Input feature matrix.</param>
-    /// <param name="target">Target labels.</param>
-    /// <param name="lossFunction">Optional loss function.</param>
-    /// <returns>Zero gradient vector.</returns>
-    /// <remarks>
-    /// <para><b>For Beginners:</b> Tree ensembles don't use gradient descent.</para>
-    /// </remarks>
-    public Vector<T> ComputeGradients(Matrix<T> input, Vector<T> target, ILossFunction<T>? lossFunction = null)
-    {
-        return new Vector<T>(1) { [0] = NumOps.Zero };
-    }
-
-    /// <summary>
-    /// Applies gradients (not applicable for tree ensembles).
-    /// </summary>
-    /// <param name="gradients">Gradient vector.</param>
-    /// <param name="learningRate">Learning rate.</param>
-    /// <remarks>
-    /// <para><b>For Beginners:</b> Tree ensembles don't support gradient updates.</para>
-    /// </remarks>
-    public void ApplyGradients(Vector<T> gradients, T learningRate)
-    {
-        // Tree ensembles don't support gradient-based updates
-    }
-
-    /// <summary>
     /// Gets feature importance based on split usage.
     /// </summary>
     /// <returns>Dictionary mapping feature names to importance scores.</returns>

--- a/src/Classification/ImbalancedEnsemble/BalancedRandomForestClassifier.cs
+++ b/src/Classification/ImbalancedEnsemble/BalancedRandomForestClassifier.cs
@@ -646,34 +646,6 @@ public class BalancedRandomForestClassifier<T> : ClassifierBase<T>
     }
 
     /// <summary>
-    /// Computes gradients (not applicable for tree models).
-    /// </summary>
-    /// <param name="input">Input feature matrix.</param>
-    /// <param name="target">Target labels.</param>
-    /// <param name="lossFunction">Optional loss function.</param>
-    /// <returns>Zero gradient vector.</returns>
-    /// <remarks>
-    /// <para><b>For Beginners:</b> Tree models don't use gradient descent.</para>
-    /// </remarks>
-    public Vector<T> ComputeGradients(Matrix<T> input, Vector<T> target, ILossFunction<T>? lossFunction = null)
-    {
-        return new Vector<T>(1) { [0] = NumOps.Zero };
-    }
-
-    /// <summary>
-    /// Applies gradients (not applicable for tree models).
-    /// </summary>
-    /// <param name="gradients">Gradient vector.</param>
-    /// <param name="learningRate">Learning rate.</param>
-    /// <remarks>
-    /// <para><b>For Beginners:</b> Tree models don't support gradient updates.</para>
-    /// </remarks>
-    public void ApplyGradients(Vector<T> gradients, T learningRate)
-    {
-        // Tree models don't support gradient-based updates
-    }
-
-    /// <summary>
     /// Gets feature importance based on split usage.
     /// </summary>
     /// <returns>Dictionary mapping feature names to importance scores.</returns>

--- a/src/Classification/ImbalancedEnsemble/EasyEnsembleClassifier.cs
+++ b/src/Classification/ImbalancedEnsemble/EasyEnsembleClassifier.cs
@@ -706,34 +706,6 @@ public class EasyEnsembleClassifier<T> : ClassifierBase<T>
     }
 
     /// <summary>
-    /// Computes gradients (not applicable for ensemble models).
-    /// </summary>
-    /// <param name="input">Input feature matrix.</param>
-    /// <param name="target">Target labels.</param>
-    /// <param name="lossFunction">Optional loss function.</param>
-    /// <returns>Zero gradient vector.</returns>
-    /// <remarks>
-    /// <para><b>For Beginners:</b> Ensemble models don't use gradient descent.</para>
-    /// </remarks>
-    public Vector<T> ComputeGradients(Matrix<T> input, Vector<T> target, ILossFunction<T>? lossFunction = null)
-    {
-        return new Vector<T>(1) { [0] = NumOps.Zero };
-    }
-
-    /// <summary>
-    /// Applies gradients (not applicable for ensemble models).
-    /// </summary>
-    /// <param name="gradients">Gradient vector.</param>
-    /// <param name="learningRate">Learning rate.</param>
-    /// <remarks>
-    /// <para><b>For Beginners:</b> Ensemble models don't support gradient updates.</para>
-    /// </remarks>
-    public void ApplyGradients(Vector<T> gradients, T learningRate)
-    {
-        // Ensemble models don't support gradient-based updates
-    }
-
-    /// <summary>
     /// Gets feature importance based on weak learner usage.
     /// </summary>
     /// <returns>Dictionary mapping feature names to importance scores.</returns>

--- a/src/Classification/Meta/MetaClassifierBase.cs
+++ b/src/Classification/Meta/MetaClassifierBase.cs
@@ -26,7 +26,7 @@ namespace AiDotNet.Classification.Meta;
 /// </para>
 /// </remarks>
 public abstract class MetaClassifierBase<T> : ProbabilisticClassifierBase<T>,
-    IParameterizable<T, Matrix<T>, Vector<T>>, IGradientComputable<T, Matrix<T>, Vector<T>>
+    IParameterizable<T, Matrix<T>, Vector<T>>
 {
     /// <summary>
     /// Gets the meta classifier specific options.
@@ -87,19 +87,6 @@ public abstract class MetaClassifierBase<T> : ProbabilisticClassifierBase<T>,
     public IFullModel<T, Matrix<T>, Vector<T>> WithParameters(Vector<T> parameters)
     {
         return CreateNewInstance();
-    }
-
-    /// <inheritdoc/>
-    public Vector<T> ComputeGradients(Matrix<T> input, Vector<T> target, ILossFunction<T>? lossFunction = null)
-    {
-        // Meta classifiers delegate to base estimators
-        return new Vector<T>(0);
-    }
-
-    /// <inheritdoc/>
-    public void ApplyGradients(Vector<T> gradients, T learningRate)
-    {
-        // No-op for meta classifiers
     }
 }
 

--- a/src/Classification/MultiLabel/MultiLabelClassifierBase.cs
+++ b/src/Classification/MultiLabel/MultiLabelClassifierBase.cs
@@ -1,6 +1,7 @@
 using AiDotNet.Autodiff;
 using AiDotNet.Enums;
 using AiDotNet.Interfaces;
+using AiDotNet.LossFunctions;
 using AiDotNet.Tensors.Engines;
 using AiDotNet.Tensors.Engines.Gpu;
 using Newtonsoft.Json;
@@ -517,57 +518,5 @@ public abstract class MultiLabelClassifierBase<T> : IMultiLabelClassifier<T>, IC
     protected void ThrowIfDisposed()
     {
         if (_disposed) throw new System.ObjectDisposedException(GetType().FullName);
-    }
-
-    /// <summary>
-    /// Binary cross-entropy loss for multi-label classification.
-    /// </summary>
-    private class BinaryCrossEntropyLoss<TLoss> : ILossFunction<TLoss>
-    {
-        private static INumericOperations<TLoss> NumOps => MathHelper.GetNumericOperations<TLoss>();
-
-        public TLoss CalculateLoss(Vector<TLoss> predicted, Vector<TLoss> actual)
-        {
-            double loss = 0;
-            for (int i = 0; i < predicted.Length; i++)
-            {
-                double p = Math.Max(1e-15, Math.Min(1 - 1e-15, NumOps.ToDouble(predicted[i])));
-                double y = NumOps.ToDouble(actual[i]);
-                loss -= y * Math.Log(p) + (1 - y) * Math.Log(1 - p);
-            }
-            return NumOps.FromDouble(loss / Math.Max(1, predicted.Length));
-        }
-
-        public Vector<TLoss> CalculateDerivative(Vector<TLoss> predicted, Vector<TLoss> actual)
-        {
-            var derivative = new Vector<TLoss>(predicted.Length);
-            for (int i = 0; i < predicted.Length; i++)
-            {
-                double p = Math.Max(1e-15, Math.Min(1 - 1e-15, NumOps.ToDouble(predicted[i])));
-                double y = NumOps.ToDouble(actual[i]);
-                derivative[i] = NumOps.FromDouble((p - y) / (p * (1 - p) + 1e-15));
-            }
-            return derivative;
-        }
-
-        public (TLoss Loss, Tensor<TLoss> Gradient) CalculateLossAndGradientGpu(Tensor<TLoss> predicted, Tensor<TLoss> actual)
-        {
-            var predictedCpu = predicted;
-            var actualCpu = actual;
-            var predictedVector = new Vector<TLoss>(predictedCpu.Data.ToArray());
-            var actualVector = new Vector<TLoss>(actualCpu.Data.ToArray());
-
-            var loss = CalculateLoss(predictedVector, actualVector);
-            var gradientVector = CalculateDerivative(predictedVector, actualVector);
-            var gradientTensor = new Tensor<TLoss>(predictedCpu._shape, gradientVector);
-
-            var engine = AiDotNetEngine.Current as DirectGpuTensorEngine;
-            var backend = engine?.GetBackend() ?? throw new InvalidOperationException("GPU backend not available");
-            var gradientGpu = GpuTensorHelper.UploadToGpu<TLoss>(backend, gradientTensor, GpuTensorRole.Gradient);
-
-            return (loss, gradientGpu);
-        }
-
-        public string Name => "BinaryCrossEntropy";
     }
 }

--- a/src/Classification/NaiveBayes/NaiveBayesBase.cs
+++ b/src/Classification/NaiveBayes/NaiveBayesBase.cs
@@ -23,7 +23,7 @@ namespace AiDotNet.Classification.NaiveBayes;
 /// </para>
 /// </remarks>
 public abstract class NaiveBayesBase<T> : ProbabilisticClassifierBase<T>,
-    IParameterizable<T, Matrix<T>, Vector<T>>, IGradientComputable<T, Matrix<T>, Vector<T>>
+    IParameterizable<T, Matrix<T>, Vector<T>>
 {
     /// <summary>
     /// Naive Bayes models compute parameters from class statistics during training.
@@ -295,21 +295,6 @@ public abstract class NaiveBayesBase<T> : ProbabilisticClassifierBase<T>,
         {
             LogPriors[i] = parameters[i];
         }
-    }
-
-    /// <inheritdoc/>
-    public Vector<T> ComputeGradients(Matrix<T> input, Vector<T> target, ILossFunction<T>? lossFunction = null)
-    {
-        // Naive Bayes doesn't typically use gradient-based optimization
-        // Return zero gradients for compatibility
-        return new Vector<T>(NumClasses);
-    }
-
-    /// <inheritdoc/>
-    public void ApplyGradients(Vector<T> gradients, T learningRate)
-    {
-        // Naive Bayes doesn't typically use gradient-based optimization
-        // This is a no-op for compatibility
     }
 
     /// <inheritdoc/>

--- a/src/Classification/Neighbors/KNeighborsClassifier.cs
+++ b/src/Classification/Neighbors/KNeighborsClassifier.cs
@@ -251,7 +251,6 @@ public class KNeighborsClassifier<T> : ProbabilisticClassifierBase<T>
         };
     }
 
-
     /// <summary>
     /// Computes Manhattan (L1) distance.
     /// </summary>
@@ -432,21 +431,6 @@ public class KNeighborsClassifier<T> : ProbabilisticClassifierBase<T>
     public void SetParameters(Vector<T> parameters)
     {
         // KNN is a lazy learner - it doesn't have traditional model parameters
-        // This is a no-op for compatibility
-    }
-
-    /// <inheritdoc/>
-    public Vector<T> ComputeGradients(Matrix<T> input, Vector<T> target, ILossFunction<T>? lossFunction = null)
-    {
-        // KNN doesn't use gradient-based optimization
-        // Return zero gradients for compatibility
-        return new Vector<T>(NumFeatures);
-    }
-
-    /// <inheritdoc/>
-    public void ApplyGradients(Vector<T> gradients, T learningRate)
-    {
-        // KNN doesn't use gradient-based optimization
         // This is a no-op for compatibility
     }
 

--- a/src/Classification/Online/AdaptiveRandomForestClassifier.cs
+++ b/src/Classification/Online/AdaptiveRandomForestClassifier.cs
@@ -553,19 +553,6 @@ public class AdaptiveRandomForestClassifier<T> : ClassifierBase<T>, IOnlineClass
         return new AdaptiveRandomForestClassifier<T>(_options);
     }
 
-    /// <inheritdoc />
-    public Vector<T> ComputeGradients(Matrix<T> input, Vector<T> target, ILossFunction<T>? lossFunction = null)
-    {
-        // Tree ensemble - no gradients
-        return new Vector<T>(0);
-    }
-
-    /// <inheritdoc />
-    public void ApplyGradients(Vector<T> gradients, T learningRate)
-    {
-        // Tree ensemble - no gradient application
-    }
-
     /// <summary>
     /// Serializes the trained ARF ensemble including all Hoeffding trees and metadata.
     /// </summary>

--- a/src/Classification/Online/HoeffdingTreeClassifier.cs
+++ b/src/Classification/Online/HoeffdingTreeClassifier.cs
@@ -747,19 +747,6 @@ public class HoeffdingTreeClassifier<T> : ClassifierBase<T>, IOnlineClassifier<T
         return new HoeffdingTreeClassifier<T>(_options);
     }
 
-    /// <inheritdoc />
-    public Vector<T> ComputeGradients(Matrix<T> input, Vector<T> target, ILossFunction<T>? lossFunction = null)
-    {
-        // Tree-based model - no gradients
-        return new Vector<T>(0);
-    }
-
-    /// <inheritdoc />
-    public void ApplyGradients(Vector<T> gradients, T learningRate)
-    {
-        // Tree-based model - no gradient application
-    }
-
     /// <summary>
     /// Serializes the trained Hoeffding tree including all nodes and statistics.
     /// </summary>

--- a/src/Classification/Online/OnlineNaiveBayesClassifier.cs
+++ b/src/Classification/Online/OnlineNaiveBayesClassifier.cs
@@ -74,7 +74,7 @@ namespace AiDotNet.Classification.Online;
 [ModelInput(typeof(Matrix<>), typeof(Vector<>))]
 [ResearchPaper("A Comparison of Event Models for Naive Bayes Text Classification", "https://www.cs.cmu.edu/~knigam/papers/multinomial-aaaiws98.pdf")]
 public class OnlineNaiveBayesClassifier<T> : ClassifierBase<T>, IOnlineClassifier<T>,
-    IParameterizable<T, Matrix<T>, Vector<T>>, IGradientComputable<T, Matrix<T>, Vector<T>>
+    IParameterizable<T, Matrix<T>, Vector<T>>
 {
     private readonly OnlineNaiveBayesOptions<T> _options;
 
@@ -437,19 +437,6 @@ public class OnlineNaiveBayesClassifier<T> : ClassifierBase<T>, IOnlineClassifie
     protected override IFullModel<T, Matrix<T>, Vector<T>> CreateNewInstance()
     {
         return new OnlineNaiveBayesClassifier<T>(_options);
-    }
-
-    /// <inheritdoc />
-    public Vector<T> ComputeGradients(Matrix<T> input, Vector<T> target, ILossFunction<T>? lossFunction = null)
-    {
-        // Naive Bayes doesn't use gradients
-        return new Vector<T>(GetParameters().Length);
-    }
-
-    /// <inheritdoc />
-    public void ApplyGradients(Vector<T> gradients, T learningRate)
-    {
-        // Naive Bayes doesn't use gradients
     }
 
     /// <summary>

--- a/src/Classification/SVM/SVMBase.cs
+++ b/src/Classification/SVM/SVMBase.cs
@@ -27,7 +27,7 @@ namespace AiDotNet.Classification.SVM;
 /// </para>
 /// </remarks>
 public abstract class SVMBase<T> : ProbabilisticClassifierBase<T>, IDecisionFunctionClassifier<T>,
-    IParameterizable<T, Matrix<T>, Vector<T>>, IGradientComputable<T, Matrix<T>, Vector<T>>
+    IParameterizable<T, Matrix<T>, Vector<T>>
 {
     /// <summary>
     /// Gets the SVM specific options.
@@ -252,20 +252,6 @@ public abstract class SVMBase<T> : ProbabilisticClassifierBase<T>, IDecisionFunc
                 _intercept[i] = parameters[i];
             }
         }
-    }
-
-    /// <inheritdoc/>
-    public Vector<T> ComputeGradients(Matrix<T> input, Vector<T> target, ILossFunction<T>? lossFunction = null)
-    {
-        // SVMs don't use gradient-based optimization in the typical sense
-        // They use quadratic programming
-        return new Vector<T>(NumFeatures);
-    }
-
-    /// <inheritdoc/>
-    public void ApplyGradients(Vector<T> gradients, T learningRate)
-    {
-        // SVMs don't use gradient-based optimization
     }
 
     /// <inheritdoc/>

--- a/src/Classification/SemiSupervised/LabelPropagation.cs
+++ b/src/Classification/SemiSupervised/LabelPropagation.cs
@@ -1089,42 +1089,6 @@ public class LabelPropagation<T> : SemiSupervisedClassifierBase<T>
     }
 
     /// <summary>
-    /// Computes gradients for gradient-based optimization.
-    /// </summary>
-    /// <param name="input">The input features.</param>
-    /// <param name="target">The target labels.</param>
-    /// <param name="lossFunction">The loss function (optional).</param>
-    /// <returns>An empty gradient vector as Label Propagation doesn't use gradients.</returns>
-    /// <remarks>
-    /// <para>
-    /// <b>For Beginners:</b> Label Propagation is not trained with gradient descent like neural
-    /// networks. Instead, it uses graph-based iterative label spreading. Therefore, there are
-    /// no gradients to compute.
-    /// </para>
-    /// </remarks>
-    public Vector<T> ComputeGradients(Matrix<T> input, Vector<T> target, ILossFunction<T>? lossFunction = null)
-    {
-        // Label Propagation is not gradient-based
-        return new Vector<T>(0);
-    }
-
-    /// <summary>
-    /// Applies gradients to update model parameters.
-    /// </summary>
-    /// <param name="gradients">The gradients to apply (ignored).</param>
-    /// <param name="learningRate">The learning rate (ignored).</param>
-    /// <remarks>
-    /// <para>
-    /// <b>For Beginners:</b> Since Label Propagation doesn't use gradient-based learning,
-    /// this method does nothing.
-    /// </para>
-    /// </remarks>
-    public void ApplyGradients(Vector<T> gradients, T learningRate)
-    {
-        // Non-parametric model - no gradients to apply
-    }
-
-    /// <summary>
     /// Creates a new instance of this classifier with default configuration.
     /// </summary>
     /// <returns>A new LabelPropagation instance.</returns>

--- a/src/Classification/SemiSupervised/LabelSpreading.cs
+++ b/src/Classification/SemiSupervised/LabelSpreading.cs
@@ -1142,42 +1142,6 @@ public class LabelSpreading<T> : SemiSupervisedClassifierBase<T>
     }
 
     /// <summary>
-    /// Computes gradients for gradient-based optimization.
-    /// </summary>
-    /// <param name="input">The input features.</param>
-    /// <param name="target">The target labels.</param>
-    /// <param name="lossFunction">The loss function (optional).</param>
-    /// <returns>An empty gradient vector as Label Spreading doesn't use gradients.</returns>
-    /// <remarks>
-    /// <para>
-    /// <b>For Beginners:</b> Label Spreading is not trained with gradient descent like neural
-    /// networks. Instead, it uses graph-based iterative label spreading with clamping. Therefore,
-    /// there are no gradients to compute.
-    /// </para>
-    /// </remarks>
-    public Vector<T> ComputeGradients(Matrix<T> input, Vector<T> target, ILossFunction<T>? lossFunction = null)
-    {
-        // Label Spreading is not gradient-based
-        return new Vector<T>(0);
-    }
-
-    /// <summary>
-    /// Applies gradients to update model parameters.
-    /// </summary>
-    /// <param name="gradients">The gradients to apply (ignored).</param>
-    /// <param name="learningRate">The learning rate (ignored).</param>
-    /// <remarks>
-    /// <para>
-    /// <b>For Beginners:</b> Since Label Spreading doesn't use gradient-based learning,
-    /// this method does nothing.
-    /// </para>
-    /// </remarks>
-    public void ApplyGradients(Vector<T> gradients, T learningRate)
-    {
-        // Non-parametric model - no gradients to apply
-    }
-
-    /// <summary>
     /// Creates a new instance of this classifier with default configuration.
     /// </summary>
     /// <returns>A new LabelSpreading instance.</returns>

--- a/src/Classification/TimeSeries/MiniRocketClassifier.cs
+++ b/src/Classification/TimeSeries/MiniRocketClassifier.cs
@@ -75,7 +75,7 @@ namespace AiDotNet.Classification.TimeSeries;
 [ModelInput(typeof(Tensor<>), typeof(Vector<>))]
 [ResearchPaper("MiniRocket: A Very Fast (Almost) Deterministic Transform for Time Series Classification", "https://arxiv.org/abs/2012.08791", Year = 2021, Authors = "Angus Dempster, Daniel F. Schmidt, Geoffrey I. Webb")]
 public class MiniRocketClassifier<T> : ClassifierBase<T>, ITimeSeriesClassifier<T>,
-    IParameterizable<T, Matrix<T>, Vector<T>>, IGradientComputable<T, Matrix<T>, Vector<T>>
+    IParameterizable<T, Matrix<T>, Vector<T>>
 {
     private readonly MiniRocketOptions<T> _options;
 
@@ -295,25 +295,6 @@ public class MiniRocketClassifier<T> : ClassifierBase<T>, ITimeSeriesClassifier<
     protected override IFullModel<T, Matrix<T>, Vector<T>> CreateNewInstance()
     {
         return new MiniRocketClassifier<T>(_options);
-    }
-
-    /// <inheritdoc />
-    public Vector<T> ComputeGradients(Matrix<T> input, Vector<T> target, ILossFunction<T>? lossFunction = null)
-    {
-        // Ridge regression is closed-form, gradients not typically used
-        return new Vector<T>(GetParameters().Length);
-    }
-
-    /// <inheritdoc />
-    public void ApplyGradients(Vector<T> gradients, T learningRate)
-    {
-        if (_weights is null) return;
-
-        for (int i = 0; i < _weights.Length; i++)
-        {
-            _weights[i] = NumOps.Subtract(_weights[i],
-                NumOps.Multiply(learningRate, gradients[i]));
-        }
     }
 
     /// <inheritdoc />

--- a/src/Classification/TimeSeries/RocketClassifier.cs
+++ b/src/Classification/TimeSeries/RocketClassifier.cs
@@ -83,7 +83,7 @@ namespace AiDotNet.Classification.TimeSeries;
 [ModelInput(typeof(Tensor<>), typeof(Vector<>))]
 [ResearchPaper("ROCKET: Exceptionally fast and accurate time series classification using random convolutional kernels", "https://arxiv.org/abs/1910.13051", Year = 2020, Authors = "Angus Dempster, Francois Petitjean, Geoffrey I. Webb")]
 public class RocketClassifier<T> : ClassifierBase<T>, ITimeSeriesClassifier<T>,
-    IParameterizable<T, Matrix<T>, Vector<T>>, IGradientComputable<T, Matrix<T>, Vector<T>>{
+    IParameterizable<T, Matrix<T>, Vector<T>>{
     private readonly List<RocketKernel> _kernels;
     private readonly RocketOptions<T> _rocketOptions;
     private readonly Random _random;
@@ -512,26 +512,6 @@ public class RocketClassifier<T> : ClassifierBase<T>, ITimeSeriesClassifier<T>,
     protected override IFullModel<T, Matrix<T>, Vector<T>> CreateNewInstance()
     {
         return new RocketClassifier<T>(_rocketOptions);
-    }
-
-    /// <inheritdoc />
-    public Vector<T> ComputeGradients(Matrix<T> input, Vector<T> target, ILossFunction<T>? lossFunction = null)
-    {
-        // Ridge regression doesn't use gradients in the traditional sense
-        // Return zeros for now
-        return new Vector<T>(_internalWeights?.Length ?? 0);
-    }
-
-    /// <inheritdoc />
-    public void ApplyGradients(Vector<T> gradients, T learningRate)
-    {
-        if (_internalWeights is null) return;
-
-        for (int i = 0; i < _internalWeights.Length && i < gradients.Length; i++)
-        {
-            _internalWeights[i] = NumOps.Subtract(_internalWeights[i],
-                NumOps.Multiply(learningRate, gradients[i]));
-        }
     }
 
     /// <inheritdoc />

--- a/src/Classification/TimeSeries/TimeSeriesForestClassifier.cs
+++ b/src/Classification/TimeSeries/TimeSeriesForestClassifier.cs
@@ -343,19 +343,6 @@ public class TimeSeriesForestClassifier<T> : ClassifierBase<T>, ITimeSeriesClass
     }
 
     /// <inheritdoc />
-    public Vector<T> ComputeGradients(Matrix<T> input, Vector<T> target, ILossFunction<T>? lossFunction = null)
-    {
-        // Tree-based model - no gradient computation
-        return new Vector<T>(0);
-    }
-
-    /// <inheritdoc />
-    public void ApplyGradients(Vector<T> gradients, T learningRate)
-    {
-        // Tree-based model - no gradient application
-    }
-
-    /// <inheritdoc />
     public override byte[] Serialize()
     {
         var metadata = GetModelMetadata();

--- a/src/Classification/Trees/DecisionTreeClassifier.cs
+++ b/src/Classification/Trees/DecisionTreeClassifier.cs
@@ -667,21 +667,6 @@ public class DecisionTreeClassifier<T> : ProbabilisticClassifierBase<T>, ITreeBa
     }
 
     /// <inheritdoc/>
-    public Vector<T> ComputeGradients(Matrix<T> input, Vector<T> target, ILossFunction<T>? lossFunction = null)
-    {
-        // Decision trees don't typically use gradient-based optimization
-        // Return zero gradients for compatibility
-        return new Vector<T>(NumFeatures);
-    }
-
-    /// <inheritdoc/>
-    public void ApplyGradients(Vector<T> gradients, T learningRate)
-    {
-        // Decision trees don't typically use gradient-based optimization
-        // This is a no-op for compatibility
-    }
-
-    /// <inheritdoc/>
     public override ModelMetadata<T> GetModelMetadata()
     {
         var metadata = base.GetModelMetadata();

--- a/src/Clustering/Base/ClusteringBase.cs
+++ b/src/Clustering/Base/ClusteringBase.cs
@@ -676,7 +676,7 @@ public abstract class ClusteringBase<T> : IClustering<T>, IConfigurableModel<T>,
     {
         var loss = lossFunction ?? _defaultLossFunction;
         var predictions = Predict(input);
-        return loss.CalculateDerivative(predictions, target);
+        return loss.ComputeGradient(predictions, target);
     }
 
     /// <inheritdoc/>

--- a/src/ComputerVision/Detection/Losses/CIoULoss.cs
+++ b/src/ComputerVision/Detection/Losses/CIoULoss.cs
@@ -75,43 +75,6 @@ public class CIoULoss<T> : LossFunctionBase<T>
     }
 
     /// <summary>
-    /// Calculates the gradient of CIoU loss with respect to predicted boxes.
-    /// </summary>
-    public override Vector<T> CalculateDerivative(Vector<T> predicted, Vector<T> actual)
-    {
-        ValidateVectorLengths(predicted, actual);
-
-        var gradient = new Vector<T>(predicted.Length);
-        double eps = 1e-7;
-
-        // Create a copy of predicted for perturbation to avoid mutating the input
-        var perturbedPredicted = new Vector<T>(predicted.Length);
-        for (int j = 0; j < predicted.Length; j++)
-        {
-            perturbedPredicted[j] = predicted[j];
-        }
-
-        for (int i = 0; i < predicted.Length; i++)
-        {
-            double original = NumOps.ToDouble(predicted[i]);
-
-            // Forward perturbation (on copy)
-            perturbedPredicted[i] = NumOps.FromDouble(original + eps);
-            double lossPlus = NumOps.ToDouble(CalculateLoss(perturbedPredicted, actual));
-
-            // Backward perturbation (on copy)
-            perturbedPredicted[i] = NumOps.FromDouble(original - eps);
-            double lossMinus = NumOps.ToDouble(CalculateLoss(perturbedPredicted, actual));
-
-            // Restore copy and compute gradient
-            perturbedPredicted[i] = NumOps.FromDouble(original);
-            gradient[i] = NumOps.FromDouble((lossPlus - lossMinus) / (2 * eps));
-        }
-
-        return gradient;
-    }
-
-    /// <summary>
     /// Calculates the CIoU loss between predicted and target bounding boxes.
     /// </summary>
     /// <param name="predicted">Predicted boxes tensor [batch, num_boxes, 4] in XYXY format.</param>

--- a/src/ComputerVision/Detection/Losses/CIoULoss.cs
+++ b/src/ComputerVision/Detection/Losses/CIoULoss.cs
@@ -138,13 +138,48 @@ public class CIoULoss<T> : LossFunctionBase<T>
     /// <inheritdoc />
     public override Tensor<T> ComputeTapeLoss(Tensor<T> predicted, Tensor<T> target)
     {
-        if (predicted.Shape.Length != 2 || predicted.Shape[1] != 4)
-            throw new ArgumentException("Predicted must be [N, 4] in (x1, y1, x2, y2) format.", nameof(predicted));
-        if (target.Shape.Length != 2 || target.Shape[1] != 4 || target.Shape[0] != predicted.Shape[0])
-            throw new ArgumentException("Target must be [N, 4] matching predicted batch size.", nameof(target));
+        // Accept the FLAT layout CalculateLoss(Vector, Vector) takes -- a rank-1 run of boxes whose
+        // length is a multiple of 4 -- by folding it to [N, 4]. Without this the two forwards
+        // disagreed about what they accept: the vector API validated "multiple of 4" and the tape
+        // API rejected anything that was not already rank 2, so the same input was valid for the
+        // loss and invalid for its gradient.
+        predicted = NormalizeBoxes(predicted, nameof(predicted));
+        target = NormalizeBoxes(target, nameof(target));
+
+        if (target.Shape[0] != predicted.Shape[0])
+        {
+            throw new ArgumentException(
+                $"Target batch size ({target.Shape[0]}) must match predicted ({predicted.Shape[0]}).",
+                nameof(target));
+        }
 
         var perBoxLoss = Engine.TensorCIoULoss(predicted, target);
         var allAxes = Enumerable.Range(0, perBoxLoss.Shape.Length).ToArray();
         return Engine.ReduceMean(perBoxLoss, allAxes, keepDims: false);
+    }
+
+    /// <summary>
+    /// Folds a flat run of box coordinates into the [N, 4] layout the IoU kernels require.
+    /// </summary>
+    /// <param name="boxes">Either an [N, 4] tensor or a rank-1 run of 4N coordinates.</param>
+    /// <param name="parameterName">Name used when reporting an invalid shape.</param>
+    /// <returns>The tensor as [N, 4].</returns>
+    /// <exception cref="ArgumentException">Thrown when the shape is neither form.</exception>
+    private Tensor<T> NormalizeBoxes(Tensor<T> boxes, string parameterName)
+    {
+        if (boxes.Shape.Length == 2 && boxes.Shape[1] == 4)
+        {
+            return boxes;
+        }
+
+        if (boxes.Shape.Length == 1 && boxes.Length % 4 == 0 && boxes.Length > 0)
+        {
+            return Engine.Reshape(boxes, new[] { boxes.Length / 4, 4 });
+        }
+
+        throw new ArgumentException(
+            $"Boxes must be [N, 4] in (x1, y1, x2, y2) format, or a flat run of 4N coordinates, "
+            + $"but were [{string.Join(", ", boxes.Shape.ToArray())}].",
+            parameterName);
     }
 }

--- a/src/ComputerVision/Detection/Losses/DETRSetLoss.cs
+++ b/src/ComputerVision/Detection/Losses/DETRSetLoss.cs
@@ -75,40 +75,6 @@ public class DETRSetLoss<T> : LossFunctionBase<T>
     }
 
     /// <summary>
-    /// Calculates the gradient of DETR loss with respect to predicted values.
-    /// </summary>
-    public override Vector<T> CalculateDerivative(Vector<T> predicted, Vector<T> actual)
-    {
-        ValidateVectorLengths(predicted, actual);
-
-        var gradient = new Vector<T>(predicted.Length);
-        double eps = 1e-5;
-
-        // Create a copy for perturbation to avoid mutating the original input
-        var perturbedPredicted = new Vector<T>(predicted.Length);
-        for (int j = 0; j < predicted.Length; j++)
-        {
-            perturbedPredicted[j] = predicted[j];
-        }
-
-        for (int i = 0; i < predicted.Length; i++)
-        {
-            double original = NumOps.ToDouble(perturbedPredicted[i]);
-
-            perturbedPredicted[i] = NumOps.FromDouble(original + eps);
-            double lossPlus = NumOps.ToDouble(CalculateLoss(perturbedPredicted, actual));
-
-            perturbedPredicted[i] = NumOps.FromDouble(original - eps);
-            double lossMinus = NumOps.ToDouble(CalculateLoss(perturbedPredicted, actual));
-
-            perturbedPredicted[i] = NumOps.FromDouble(original);
-            gradient[i] = NumOps.FromDouble((lossPlus - lossMinus) / (2 * eps));
-        }
-
-        return gradient;
-    }
-
-    /// <summary>
     /// Calculates the DETR set loss.
     /// </summary>
     /// <param name="predicted">Predicted tensor containing class logits and boxes.</param>

--- a/src/ComputerVision/Detection/Losses/DETRSetLoss.cs
+++ b/src/ComputerVision/Detection/Losses/DETRSetLoss.cs
@@ -120,39 +120,6 @@ public class DETRSetLoss<T> : LossFunctionBase<T>
     }
 
     /// <summary>
-    /// Calculates the gradient of the DETR loss.
-    /// </summary>
-    public Tensor<T> CalculateDerivative(Tensor<T> predicted, Tensor<T> targets)
-    {
-        // Numerical gradient for now - analytical gradients are complex for Hungarian matching
-        var gradient = new Tensor<T>(predicted._shape);
-        double eps = 1e-5;
-
-        // Create a copy for perturbation to avoid mutating the original input
-        var perturbedPredicted = new Tensor<T>(predicted._shape);
-        for (int j = 0; j < predicted.Length; j++)
-        {
-            perturbedPredicted[j] = predicted[j];
-        }
-
-        for (int i = 0; i < predicted.Length; i++)
-        {
-            double original = NumOps.ToDouble(perturbedPredicted[i]);
-
-            perturbedPredicted[i] = NumOps.FromDouble(original + eps);
-            double lossPlus = NumOps.ToDouble(CalculateLoss(perturbedPredicted, targets));
-
-            perturbedPredicted[i] = NumOps.FromDouble(original - eps);
-            double lossMinus = NumOps.ToDouble(CalculateLoss(perturbedPredicted, targets));
-
-            perturbedPredicted[i] = NumOps.FromDouble(original);
-            gradient[i] = NumOps.FromDouble((lossPlus - lossMinus) / (2 * eps));
-        }
-
-        return gradient;
-    }
-
-    /// <summary>
     /// Performs Hungarian matching between predictions and ground truth.
     /// </summary>
     /// <param name="predBoxes">Predicted bounding boxes.</param>

--- a/src/ComputerVision/Detection/Losses/DIoULoss.cs
+++ b/src/ComputerVision/Detection/Losses/DIoULoss.cs
@@ -71,43 +71,6 @@ public class DIoULoss<T> : LossFunctionBase<T>
     }
 
     /// <summary>
-    /// Calculates the gradient of DIoU loss with respect to predicted boxes.
-    /// </summary>
-    public override Vector<T> CalculateDerivative(Vector<T> predicted, Vector<T> actual)
-    {
-        ValidateVectorLengths(predicted, actual);
-
-        var gradient = new Vector<T>(predicted.Length);
-        double eps = 1e-7;
-
-        // Create a copy of predicted for perturbation to avoid mutating the input
-        var perturbedPredicted = new Vector<T>(predicted.Length);
-        for (int j = 0; j < predicted.Length; j++)
-        {
-            perturbedPredicted[j] = predicted[j];
-        }
-
-        for (int i = 0; i < predicted.Length; i++)
-        {
-            double original = NumOps.ToDouble(predicted[i]);
-
-            // Forward perturbation (on copy)
-            perturbedPredicted[i] = NumOps.FromDouble(original + eps);
-            double lossPlus = NumOps.ToDouble(CalculateLoss(perturbedPredicted, actual));
-
-            // Backward perturbation (on copy)
-            perturbedPredicted[i] = NumOps.FromDouble(original - eps);
-            double lossMinus = NumOps.ToDouble(CalculateLoss(perturbedPredicted, actual));
-
-            // Restore copy and compute gradient
-            perturbedPredicted[i] = NumOps.FromDouble(original);
-            gradient[i] = NumOps.FromDouble((lossPlus - lossMinus) / (2 * eps));
-        }
-
-        return gradient;
-    }
-
-    /// <summary>
     /// Calculates the DIoU loss between predicted and target bounding boxes.
     /// </summary>
     /// <param name="predicted">Predicted boxes tensor [batch, num_boxes, 4] in XYXY format.</param>

--- a/src/ComputerVision/Detection/Losses/DIoULoss.cs
+++ b/src/ComputerVision/Detection/Losses/DIoULoss.cs
@@ -134,13 +134,48 @@ public class DIoULoss<T> : LossFunctionBase<T>
     /// <inheritdoc />
     public override Tensor<T> ComputeTapeLoss(Tensor<T> predicted, Tensor<T> target)
     {
-        if (predicted.Shape.Length != 2 || predicted.Shape[1] != 4)
-            throw new ArgumentException("Predicted must be [N, 4] in (x1, y1, x2, y2) format.", nameof(predicted));
-        if (target.Shape.Length != 2 || target.Shape[1] != 4 || target.Shape[0] != predicted.Shape[0])
-            throw new ArgumentException("Target must be [N, 4] matching predicted batch size.", nameof(target));
+        // Accept the FLAT layout CalculateLoss(Vector, Vector) takes -- a rank-1 run of boxes whose
+        // length is a multiple of 4 -- by folding it to [N, 4]. Without this the two forwards
+        // disagreed about what they accept: the vector API validated "multiple of 4" and the tape
+        // API rejected anything that was not already rank 2, so the same input was valid for the
+        // loss and invalid for its gradient.
+        predicted = NormalizeBoxes(predicted, nameof(predicted));
+        target = NormalizeBoxes(target, nameof(target));
+
+        if (target.Shape[0] != predicted.Shape[0])
+        {
+            throw new ArgumentException(
+                $"Target batch size ({target.Shape[0]}) must match predicted ({predicted.Shape[0]}).",
+                nameof(target));
+        }
 
         var perBoxLoss = Engine.TensorDIoULoss(predicted, target);
         var allAxes = Enumerable.Range(0, perBoxLoss.Shape.Length).ToArray();
         return Engine.ReduceMean(perBoxLoss, allAxes, keepDims: false);
+    }
+
+    /// <summary>
+    /// Folds a flat run of box coordinates into the [N, 4] layout the IoU kernels require.
+    /// </summary>
+    /// <param name="boxes">Either an [N, 4] tensor or a rank-1 run of 4N coordinates.</param>
+    /// <param name="parameterName">Name used when reporting an invalid shape.</param>
+    /// <returns>The tensor as [N, 4].</returns>
+    /// <exception cref="ArgumentException">Thrown when the shape is neither form.</exception>
+    private Tensor<T> NormalizeBoxes(Tensor<T> boxes, string parameterName)
+    {
+        if (boxes.Shape.Length == 2 && boxes.Shape[1] == 4)
+        {
+            return boxes;
+        }
+
+        if (boxes.Shape.Length == 1 && boxes.Length % 4 == 0 && boxes.Length > 0)
+        {
+            return Engine.Reshape(boxes, new[] { boxes.Length / 4, 4 });
+        }
+
+        throw new ArgumentException(
+            $"Boxes must be [N, 4] in (x1, y1, x2, y2) format, or a flat run of 4N coordinates, "
+            + $"but were [{string.Join(", ", boxes.Shape.ToArray())}].",
+            parameterName);
     }
 }

--- a/src/ComputerVision/Detection/Losses/GIoULoss.cs
+++ b/src/ComputerVision/Detection/Losses/GIoULoss.cs
@@ -125,13 +125,48 @@ public class GIoULoss<T> : LossFunctionBase<T>
     /// <inheritdoc />
     public override Tensor<T> ComputeTapeLoss(Tensor<T> predicted, Tensor<T> target)
     {
-        if (predicted.Shape.Length != 2 || predicted.Shape[1] != 4)
-            throw new ArgumentException("Predicted must be [N, 4] in (x1, y1, x2, y2) format.", nameof(predicted));
-        if (target.Shape.Length != 2 || target.Shape[1] != 4 || target.Shape[0] != predicted.Shape[0])
-            throw new ArgumentException("Target must be [N, 4] matching predicted batch size.", nameof(target));
+        // Accept the FLAT layout CalculateLoss(Vector, Vector) takes -- a rank-1 run of boxes whose
+        // length is a multiple of 4 -- by folding it to [N, 4]. Without this the two forwards
+        // disagreed about what they accept: the vector API validated "multiple of 4" and the tape
+        // API rejected anything that was not already rank 2, so the same input was valid for the
+        // loss and invalid for its gradient.
+        predicted = NormalizeBoxes(predicted, nameof(predicted));
+        target = NormalizeBoxes(target, nameof(target));
+
+        if (target.Shape[0] != predicted.Shape[0])
+        {
+            throw new ArgumentException(
+                $"Target batch size ({target.Shape[0]}) must match predicted ({predicted.Shape[0]}).",
+                nameof(target));
+        }
 
         var perBoxLoss = Engine.TensorGIoULoss(predicted, target);
         var allAxes = Enumerable.Range(0, perBoxLoss.Shape.Length).ToArray();
         return Engine.ReduceMean(perBoxLoss, allAxes, keepDims: false);
+    }
+
+    /// <summary>
+    /// Folds a flat run of box coordinates into the [N, 4] layout the IoU kernels require.
+    /// </summary>
+    /// <param name="boxes">Either an [N, 4] tensor or a rank-1 run of 4N coordinates.</param>
+    /// <param name="parameterName">Name used when reporting an invalid shape.</param>
+    /// <returns>The tensor as [N, 4].</returns>
+    /// <exception cref="ArgumentException">Thrown when the shape is neither form.</exception>
+    private Tensor<T> NormalizeBoxes(Tensor<T> boxes, string parameterName)
+    {
+        if (boxes.Shape.Length == 2 && boxes.Shape[1] == 4)
+        {
+            return boxes;
+        }
+
+        if (boxes.Shape.Length == 1 && boxes.Length % 4 == 0 && boxes.Length > 0)
+        {
+            return Engine.Reshape(boxes, new[] { boxes.Length / 4, 4 });
+        }
+
+        throw new ArgumentException(
+            $"Boxes must be [N, 4] in (x1, y1, x2, y2) format, or a flat run of 4N coordinates, "
+            + $"but were [{string.Join(", ", boxes.Shape.ToArray())}].",
+            parameterName);
     }
 }

--- a/src/ComputerVision/Detection/Losses/GIoULoss.cs
+++ b/src/ComputerVision/Detection/Losses/GIoULoss.cs
@@ -71,43 +71,6 @@ public class GIoULoss<T> : LossFunctionBase<T>
     }
 
     /// <summary>
-    /// Calculates the gradient of GIoU loss with respect to predicted boxes.
-    /// </summary>
-    public override Vector<T> CalculateDerivative(Vector<T> predicted, Vector<T> actual)
-    {
-        ValidateVectorLengths(predicted, actual);
-
-        var gradient = new Vector<T>(predicted.Length);
-        double eps = 1e-7;
-
-        // Create a copy of predicted for perturbation to avoid mutating the input
-        var perturbedPredicted = new Vector<T>(predicted.Length);
-        for (int j = 0; j < predicted.Length; j++)
-        {
-            perturbedPredicted[j] = predicted[j];
-        }
-
-        for (int i = 0; i < predicted.Length; i++)
-        {
-            double original = NumOps.ToDouble(predicted[i]);
-
-            // Forward perturbation (on copy)
-            perturbedPredicted[i] = NumOps.FromDouble(original + eps);
-            double lossPlus = NumOps.ToDouble(CalculateLoss(perturbedPredicted, actual));
-
-            // Backward perturbation (on copy)
-            perturbedPredicted[i] = NumOps.FromDouble(original - eps);
-            double lossMinus = NumOps.ToDouble(CalculateLoss(perturbedPredicted, actual));
-
-            // Restore copy and compute gradient
-            perturbedPredicted[i] = NumOps.FromDouble(original);
-            gradient[i] = NumOps.FromDouble((lossPlus - lossMinus) / (2 * eps));
-        }
-
-        return gradient;
-    }
-
-    /// <summary>
     /// Calculates GIoU loss for tensor inputs.
     /// </summary>
     /// <param name="predicted">Predicted boxes tensor [batch, num_boxes, 4] in XYXY format.</param>

--- a/src/Diffusion/VAE/VAEModelBase.cs
+++ b/src/Diffusion/VAE/VAEModelBase.cs
@@ -605,7 +605,7 @@ public abstract class VAEModelBase<T> : IVAEModel<T>, IModelShape
         {
             var predicted = ForwardForTraining(input);
 
-            var lossGrad = effectiveLossFunction.CalculateDerivative(
+            var lossGrad = effectiveLossFunction.ComputeGradient(
                 predicted.ToVector(), target.ToVector());
             var lossGradTensor = new Tensor<T>(predicted._shape, lossGrad);
 

--- a/src/Finance/Base/PortfolioOptimizerBase.cs
+++ b/src/Finance/Base/PortfolioOptimizerBase.cs
@@ -328,7 +328,6 @@ public abstract class PortfolioOptimizerBase<T> : FinancialModelBase<T>, IPortfo
         SetTrainingMode(true);
         try
         {
-            var grad = LossFunction.CalculateDerivative(output.ToVector(), target.ToVector());
             // Backward pass would be implemented here or in derived classes
         }
         finally

--- a/src/Finance/Forecasting/Foundation/CCDM.cs
+++ b/src/Finance/Forecasting/Foundation/CCDM.cs
@@ -124,7 +124,6 @@ public class CCDM<T> : TimeSeriesFoundationModelBase<T>
         // ILossFunction<T> interface). Reject any user-supplied loss
         // that doesn't derive from it at construction time instead of
         // bubbling up a bare InvalidCastException on first Train().
-        RequireTapeCompatibleLossFunction(lossFunction);
         options ??= new CCDMOptions<T>(); _options = options; Options = _options;
         _useNativeMode = false; OnnxModelPath = onnxModelPath; OnnxSession = new InferenceSession(onnxModelPath);
         _optimizer = optimizer ?? new AdamOptimizer<T, Tensor<T>, Tensor<T>>(this); _lossFunction = lossFunction ?? new MeanSquaredErrorLoss<T>();
@@ -135,30 +134,10 @@ public class CCDM<T> : TimeSeriesFoundationModelBase<T>
         CCDMOptions<T>? options = null, IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>>? optimizer = null, ILossFunction<T>? lossFunction = null)
         : base(architecture, lossFunction ?? new MeanSquaredErrorLoss<T>(), 1.0)
     {
-        RequireTapeCompatibleLossFunction(lossFunction);
         options ??= new CCDMOptions<T>(); _options = options; Options = _options;
         _useNativeMode = true; OnnxSession = null; OnnxModelPath = null;
         _optimizer = optimizer ?? new AdamOptimizer<T, Tensor<T>, Tensor<T>>(this); _lossFunction = lossFunction ?? new MeanSquaredErrorLoss<T>();
         CopyOptionsToFields(options); InitializeLayers();
-    }
-
-    /// <summary>
-    /// Enforces the constructor contract that a user-supplied
-    /// <see cref="ILossFunction{T}"/> must derive from
-    /// <see cref="LossFunctions.LossFunctionBase{T}"/> for CCDM's
-    /// tape-based training to work. Throws at construction time rather
-    /// than letting a mismatched implementation reach
-    /// <c>TrainWithTape</c>, where the failure is an opaque cast.
-    /// </summary>
-    private static void RequireTapeCompatibleLossFunction(ILossFunction<T>? lossFunction)
-    {
-        if (lossFunction is not null && lossFunction is not LossFunctions.LossFunctionBase<T>)
-            throw new ArgumentException(
-                "CCDM tape-based training requires a LossFunctionBase<T> implementation " +
-                "(ComputeTapeLoss is defined there, not on ILossFunction<T>). " +
-                "Derive your custom loss from LossFunctionBase<T>, or pass null to use " +
-                "the default MeanSquaredErrorLoss.",
-                nameof(lossFunction));
     }
 
     private void CopyOptionsToFields(CCDMOptions<T> options)

--- a/src/Finance/Forecasting/Foundation/CSDI.cs
+++ b/src/Finance/Forecasting/Foundation/CSDI.cs
@@ -281,9 +281,7 @@ public class CSDI<T> : TimeSeriesFoundationModelBase<T>
         // the whole pipeline back into _inputProjection, the residual
         // stack, and _outputProjection.
 
-        var loss = LossFunction as LossFunctions.LossFunctionBase<T>
-            ?? throw new InvalidOperationException(
-                "LossFunction must derive from LossFunctionBase<T> for CSDI tape-based training.");
+        var loss = LossFunction;
 
         var trainableParams = Training.TapeTrainingStep<T>.CollectParameters(Layers).ToArray();
 

--- a/src/Finance/Forecasting/Foundation/TFC.cs
+++ b/src/Finance/Forecasting/Foundation/TFC.cs
@@ -275,9 +275,7 @@ public class TFC<T> : TimeSeriesFoundationModelBase<T>
         if (!_useNativeMode)
             throw new InvalidOperationException("Training is only supported in native mode.");
 
-        var loss = LossFunction as LossFunctions.LossFunctionBase<T>
-            ?? throw new InvalidOperationException(
-                "LossFunction must derive from LossFunctionBase<T> for TFC tape-based training.");
+        var loss = LossFunction;
 
         var trainableParams = Training.TapeTrainingStep<T>.CollectParameters(Layers).ToArray();
 

--- a/src/Finance/Forecasting/Foundation/TOTEM.cs
+++ b/src/Finance/Forecasting/Foundation/TOTEM.cs
@@ -324,9 +324,7 @@ public class TOTEM<T> : TimeSeriesFoundationModelBase<T>
         // arbitrarily far from the codebook. Run a custom tape step
         // that combines both.
 
-        var loss = LossFunction as LossFunctions.LossFunctionBase<T>
-            ?? throw new InvalidOperationException(
-                "LossFunction must derive from LossFunctionBase<T> for TOTEM tape-based training.");
+        var loss = LossFunction;
 
         var trainableParams = Training.TapeTrainingStep<T>.CollectParameters(Layers).ToArray();
 

--- a/src/Finance/Forecasting/Neural/DeepAR.cs
+++ b/src/Finance/Forecasting/Neural/DeepAR.cs
@@ -1154,7 +1154,7 @@ public class DeepAR<T> : ForecastingModelBase<T>
     /// </remarks>
     private Tensor<T> ComputeGradient(Tensor<T> predictions, Tensor<T> targets)
     {
-        var gradVector = LossFunction.CalculateDerivative(predictions.ToVector(), targets.ToVector());
+        var gradVector = LossFunction.ComputeGradient(predictions.ToVector(), targets.ToVector());
         return Tensor<T>.FromVector(gradVector, predictions._shape);
     }
 

--- a/src/Finance/Forecasting/Transformers/PatchTST.cs
+++ b/src/Finance/Forecasting/Transformers/PatchTST.cs
@@ -536,9 +536,6 @@ public class PatchTST<T> : ForecastingModelBase<T>
     {
         SetTrainingMode(true);
 
-        // Backward pass
-        var outputGradient = LossFunction.CalculateDerivative(output.ToVector(), target.ToVector());
-
         // Update parameters
         _optimizer.UpdateParameters(Layers);
 

--- a/src/Finance/NLP/BloombergGPT.cs
+++ b/src/Finance/NLP/BloombergGPT.cs
@@ -214,7 +214,6 @@ public class BloombergGPT<T> : FinancialNLPModelBase<T>
     protected override void TrainCore(Tensor<T> input, Tensor<T> target, Tensor<T> output)
     {
         SetTrainingMode(true);
-        var grad = LossFunction.CalculateDerivative(output.ToVector(), target.ToVector());
         _optimizer.UpdateParameters(Layers);
         SetTrainingMode(false);
     }

--- a/src/Finance/NLP/FinBERTTone.cs
+++ b/src/Finance/NLP/FinBERTTone.cs
@@ -213,7 +213,6 @@ public class FinBERTTone<T> : FinancialNLPModelBase<T>
     protected override void TrainCore(Tensor<T> input, Tensor<T> target, Tensor<T> output)
     {
         SetTrainingMode(true);
-        var grad = LossFunction.CalculateDerivative(output.ToVector(), target.ToVector());
         _optimizer.UpdateParameters(Layers);
         SetTrainingMode(false);
     }

--- a/src/Finance/NLP/FinGPT.cs
+++ b/src/Finance/NLP/FinGPT.cs
@@ -214,7 +214,6 @@ public class FinGPT<T> : FinancialNLPModelBase<T>
     protected override void TrainCore(Tensor<T> input, Tensor<T> target, Tensor<T> output)
     {
         SetTrainingMode(true);
-        var grad = LossFunction.CalculateDerivative(output.ToVector(), target.ToVector());
         _optimizer.UpdateParameters(Layers);
         SetTrainingMode(false);
     }

--- a/src/Finance/NLP/FinMA.cs
+++ b/src/Finance/NLP/FinMA.cs
@@ -217,7 +217,6 @@ public class FinMA<T> : FinancialNLPModelBase<T>
     protected override void TrainCore(Tensor<T> input, Tensor<T> target, Tensor<T> output)
     {
         SetTrainingMode(true);
-        var grad = LossFunction.CalculateDerivative(output.ToVector(), target.ToVector());
         _optimizer.UpdateParameters(Layers);
         SetTrainingMode(false);
     }

--- a/src/Finance/NLP/FinancialBERT.cs
+++ b/src/Finance/NLP/FinancialBERT.cs
@@ -213,7 +213,6 @@ public class FinancialBERT<T> : FinancialNLPModelBase<T>
     protected override void TrainCore(Tensor<T> input, Tensor<T> target, Tensor<T> output)
     {
         SetTrainingMode(true);
-        var grad = LossFunction.CalculateDerivative(output.ToVector(), target.ToVector());
         _optimizer.UpdateParameters(Layers);
         SetTrainingMode(false);
     }

--- a/src/Finance/NLP/InvestLM.cs
+++ b/src/Finance/NLP/InvestLM.cs
@@ -214,7 +214,6 @@ public class InvestLM<T> : FinancialNLPModelBase<T>
     protected override void TrainCore(Tensor<T> input, Tensor<T> target, Tensor<T> output)
     {
         SetTrainingMode(true);
-        var grad = LossFunction.CalculateDerivative(output.ToVector(), target.ToVector());
         _optimizer.UpdateParameters(Layers);
         SetTrainingMode(false);
     }

--- a/src/Finance/NLP/SECBERT.cs
+++ b/src/Finance/NLP/SECBERT.cs
@@ -218,7 +218,6 @@ public class SECBERT<T> : FinancialNLPModelBase<T>
     protected override void TrainCore(Tensor<T> input, Tensor<T> target, Tensor<T> output)
     {
         SetTrainingMode(true);
-        var grad = LossFunction.CalculateDerivative(output.ToVector(), target.ToVector());
         _optimizer.UpdateParameters(Layers);
         SetTrainingMode(false);
     }

--- a/src/Finance/Trading/Agents/FinRLAgent.cs
+++ b/src/Finance/Trading/Agents/FinRLAgent.cs
@@ -44,7 +44,7 @@ namespace AiDotNet.Finance.Trading.Agents;
 [ModelComplexity(ModelComplexity.High)]
 [ModelInput(typeof(Tensor<>), typeof(Tensor<>))]
 [ResearchPaper("FinRL: Deep Reinforcement Learning Framework to Automate Trading in Quantitative Finance", "https://arxiv.org/abs/2011.09607", Year = 2021, Authors = "Xiao-Yang Liu, Hongyang Yang, Jiechao Gao, Christina Dan Wang")]
-public class FinRLAgent<T> : TradingAgentBase<T>
+public class FinRLAgent<T> : TradingAgentBase<T>, IGradientComputable<T, Vector<T>, Vector<T>>
 {
     #region Fields
 
@@ -53,6 +53,24 @@ public class FinRLAgent<T> : TradingAgentBase<T>
     private readonly FinRLAlgorithm _algorithm;
     private readonly NeuralNetworkArchitecture<T> _primaryArchitecture;
     private readonly NeuralNetworkArchitecture<T>? _secondaryArchitecture;
+
+
+    /// <summary>
+    /// The wrapped agent, viewed as a gradient-computable model.
+    /// </summary>
+    /// <exception cref="NotSupportedException">
+    /// Thrown when the wrapped agent does not compute gradients.
+    /// </exception>
+    /// <remarks>
+    /// Resolved on the instance rather than assumed from the static type: agents that learn by
+    /// Bellman backup or eligibility traces no longer claim IGradientComputable, so which inner
+    /// agents support this is a runtime property of the one that was supplied.
+    /// </remarks>
+    private IGradientComputable<T, Vector<T>, Vector<T>> InnerGradientModel =>
+        _innerAgent as IGradientComputable<T, Vector<T>, Vector<T>>
+        ?? throw new NotSupportedException(
+            $"The wrapped agent ({_innerAgent.GetType().Name}) does not compute gradients, so "
+            + "FinRLAgent cannot either. Wrap a gradient-trained agent such as PPOAgent or SACAgent.");
 
     /// <inheritdoc/>
     public override ModelOptions GetOptions() => _options;
@@ -321,9 +339,9 @@ public class FinRLAgent<T> : TradingAgentBase<T>
     /// <b>For Beginners:</b> In the FinRLAgent model, ComputeGradients performs a supporting step in the workflow. It keeps the FinRLAgent architecture pipeline consistent.
     /// </para>
     /// </remarks>
-    public override Vector<T> ComputeGradients(Vector<T> input, Vector<T> target, ILossFunction<T>? lossFunction = null)
+    public Vector<T> ComputeGradients(Vector<T> input, Vector<T> target, ILossFunction<T>? lossFunction = null)
     {
-        return _innerAgent.ComputeGradients(input, target, lossFunction);
+        return InnerGradientModel.ComputeGradients(input, target, lossFunction);
     }
 
     /// <inheritdoc/>
@@ -332,9 +350,9 @@ public class FinRLAgent<T> : TradingAgentBase<T>
     /// <b>For Beginners:</b> In the FinRLAgent model, ApplyGradients performs a supporting step in the workflow. It keeps the FinRLAgent architecture pipeline consistent.
     /// </para>
     /// </remarks>
-    public override void ApplyGradients(Vector<T> gradients, T learningRate)
+    public void ApplyGradients(Vector<T> gradients, T learningRate)
     {
-        _innerAgent.ApplyGradients(gradients, learningRate);
+        InnerGradientModel.ApplyGradients(gradients, learningRate);
     }
 
     #endregion

--- a/src/Finance/Trading/Agents/FinancialA2CAgent.cs
+++ b/src/Finance/Trading/Agents/FinancialA2CAgent.cs
@@ -51,7 +51,7 @@ namespace AiDotNet.Finance.Trading.Agents;
 [ModelComplexity(ModelComplexity.High)]
 [ResearchPaper("Asynchronous Methods for Deep Reinforcement Learning", "https://arxiv.org/abs/1602.01783")]
     [ModelInput(typeof(Tensor<>), typeof(Tensor<>))]
-public class FinancialA2CAgent<T> : TradingAgentBase<T>
+public class FinancialA2CAgent<T> : TradingAgentBase<T>, IGradientComputable<T, Vector<T>, Vector<T>>
 {
     #region Fields
 
@@ -411,7 +411,7 @@ public class FinancialA2CAgent<T> : TradingAgentBase<T>
     /// <b>For Beginners:</b> In the FinancialA2CAgent model, ComputeGradients performs a supporting step in the workflow. It keeps the FinancialA2CAgent architecture pipeline consistent.
     /// </para>
     /// </remarks>
-    public override Vector<T> ComputeGradients(Vector<T> input, Vector<T> target, ILossFunction<T>? lossFunction = null)
+    public Vector<T> ComputeGradients(Vector<T> input, Vector<T> target, ILossFunction<T>? lossFunction = null)
     {
         return _actor.ComputeGradients(Tensor<T>.FromVector(input), Tensor<T>.FromVector(target), lossFunction);
     }
@@ -424,7 +424,7 @@ public class FinancialA2CAgent<T> : TradingAgentBase<T>
     /// <b>For Beginners:</b> In the FinancialA2CAgent model, ApplyGradients performs a supporting step in the workflow. It keeps the FinancialA2CAgent architecture pipeline consistent.
     /// </para>
     /// </remarks>
-    public override void ApplyGradients(Vector<T> gradients, T learningRate)
+    public void ApplyGradients(Vector<T> gradients, T learningRate)
     {
         _actor.ApplyGradients(gradients, learningRate);
     }

--- a/src/Finance/Trading/Agents/FinancialDQNAgent.cs
+++ b/src/Finance/Trading/Agents/FinancialDQNAgent.cs
@@ -49,7 +49,7 @@ namespace AiDotNet.Finance.Trading.Agents;
 [ModelComplexity(ModelComplexity.High)]
 [ModelInput(typeof(Tensor<>), typeof(Tensor<>))]
 [ResearchPaper("Playing Atari with Deep Reinforcement Learning", "https://arxiv.org/abs/1312.5602", Year = 2013, Authors = "Volodymyr Mnih, Koray Kavukcuoglu, David Silver, Alex Graves, Ioannis Antonoglou, Daan Wierstra, Martin Riedmiller")]
-public class FinancialDQNAgent<T> : TradingAgentBase<T>
+public class FinancialDQNAgent<T> : TradingAgentBase<T>, IGradientComputable<T, Vector<T>, Vector<T>>
 {
     #region Fields
 
@@ -414,7 +414,7 @@ public class FinancialDQNAgent<T> : TradingAgentBase<T>
     /// <b>For Beginners:</b> In the FinancialDQNAgent model, ComputeGradients performs a supporting step in the workflow. It keeps the FinancialDQNAgent architecture pipeline consistent.
     /// </para>
     /// </remarks>
-    public override Vector<T> ComputeGradients(Vector<T> input, Vector<T> target, ILossFunction<T>? lossFunction = null)
+    public Vector<T> ComputeGradients(Vector<T> input, Vector<T> target, ILossFunction<T>? lossFunction = null)
     {
         return _qNetwork.ComputeGradients(Tensor<T>.FromVector(input), Tensor<T>.FromVector(target), lossFunction);
     }
@@ -425,7 +425,7 @@ public class FinancialDQNAgent<T> : TradingAgentBase<T>
     /// <b>For Beginners:</b> In the FinancialDQNAgent model, ApplyGradients performs a supporting step in the workflow. It keeps the FinancialDQNAgent architecture pipeline consistent.
     /// </para>
     /// </remarks>
-    public override void ApplyGradients(Vector<T> gradients, T learningRate)
+    public void ApplyGradients(Vector<T> gradients, T learningRate)
     {
         _qNetwork.ApplyGradients(gradients, learningRate);
         UpdateTargetNetwork();

--- a/src/Finance/Trading/Agents/FinancialPPOAgent.cs
+++ b/src/Finance/Trading/Agents/FinancialPPOAgent.cs
@@ -52,7 +52,7 @@ namespace AiDotNet.Finance.Trading.Agents;
 [ModelComplexity(ModelComplexity.High)]
 [ModelInput(typeof(Tensor<>), typeof(Tensor<>))]
 [ResearchPaper("Proximal Policy Optimization Algorithms", "https://arxiv.org/abs/1707.06347", Year = 2017, Authors = "John Schulman, Filip Wolski, Prafulla Dhariwal, Alec Radford, Oleg Klimov")]
-public class FinancialPPOAgent<T> : TradingAgentBase<T>
+public class FinancialPPOAgent<T> : TradingAgentBase<T>, IGradientComputable<T, Vector<T>, Vector<T>>
 {
     #region Fields
 
@@ -941,7 +941,7 @@ public class FinancialPPOAgent<T> : TradingAgentBase<T>
     /// <b>For Beginners:</b> In the FinancialPPOAgent model, ComputeGradients performs a supporting step in the workflow. It keeps the FinancialPPOAgent architecture pipeline consistent.
     /// </para>
     /// </remarks>
-    public override Vector<T> ComputeGradients(Vector<T> input, Vector<T> target, ILossFunction<T>? lossFunction = null)
+    public Vector<T> ComputeGradients(Vector<T> input, Vector<T> target, ILossFunction<T>? lossFunction = null)
     {
         return _actor.ComputeGradients(
             CreateStateTensor(NormalizeObservation(input, updateStatistics: false)),
@@ -957,7 +957,7 @@ public class FinancialPPOAgent<T> : TradingAgentBase<T>
     /// <b>For Beginners:</b> In the FinancialPPOAgent model, ApplyGradients performs a supporting step in the workflow. It keeps the FinancialPPOAgent architecture pipeline consistent.
     /// </para>
     /// </remarks>
-    public override void ApplyGradients(Vector<T> gradients, T learningRate)
+    public void ApplyGradients(Vector<T> gradients, T learningRate)
     {
         _actor.ApplyGradients(gradients, learningRate);
     }

--- a/src/Finance/Trading/Agents/FinancialSACAgent.cs
+++ b/src/Finance/Trading/Agents/FinancialSACAgent.cs
@@ -50,7 +50,7 @@ namespace AiDotNet.Finance.Trading.Agents;
 [ModelComplexity(ModelComplexity.High)]
 [ModelInput(typeof(Tensor<>), typeof(Tensor<>))]
 [ResearchPaper("Soft Actor-Critic: Off-Policy Maximum Entropy Deep Reinforcement Learning with a Stochastic Actor", "https://arxiv.org/abs/1801.01290", Year = 2018, Authors = "Tuomas Haarnoja, Aurick Zhou, Pieter Abbeel, Sergey Levine")]
-public class FinancialSACAgent<T> : TradingAgentBase<T>
+public class FinancialSACAgent<T> : TradingAgentBase<T>, IGradientComputable<T, Vector<T>, Vector<T>>
 {
     #region Fields
 
@@ -417,7 +417,7 @@ public class FinancialSACAgent<T> : TradingAgentBase<T>
     /// <b>For Beginners:</b> In the FinancialSACAgent model, ComputeGradients performs a supporting step in the workflow. It keeps the FinancialSACAgent architecture pipeline consistent.
     /// </para>
     /// </remarks>
-    public override Vector<T> ComputeGradients(Vector<T> input, Vector<T> target, ILossFunction<T>? lossFunction = null)
+    public Vector<T> ComputeGradients(Vector<T> input, Vector<T> target, ILossFunction<T>? lossFunction = null)
     {
         return _actor.ComputeGradients(Tensor<T>.FromVector(input), Tensor<T>.FromVector(target), lossFunction);
     }
@@ -430,7 +430,7 @@ public class FinancialSACAgent<T> : TradingAgentBase<T>
     /// <b>For Beginners:</b> In the FinancialSACAgent model, ApplyGradients performs a supporting step in the workflow. It keeps the FinancialSACAgent architecture pipeline consistent.
     /// </para>
     /// </remarks>
-    public override void ApplyGradients(Vector<T> gradients, T learningRate)
+    public void ApplyGradients(Vector<T> gradients, T learningRate)
     {
         _actor.ApplyGradients(gradients, learningRate);
     }

--- a/src/Finance/Trading/Agents/MarketMakingAgent.cs
+++ b/src/Finance/Trading/Agents/MarketMakingAgent.cs
@@ -48,7 +48,7 @@ namespace AiDotNet.Finance.Trading.Agents;
 [ModelComplexity(ModelComplexity.High)]
 [ModelInput(typeof(Tensor<>), typeof(Tensor<>))]
 [ResearchPaper("Extending Deep Reinforcement Learning Frameworks in Cryptocurrency Market Making", "https://arxiv.org/abs/2004.06985")]
-public class MarketMakingAgent<T> : TradingAgentBase<T>
+public class MarketMakingAgent<T> : TradingAgentBase<T>, IGradientComputable<T, Vector<T>, Vector<T>>
 {
     #region Fields
 
@@ -417,7 +417,7 @@ public class MarketMakingAgent<T> : TradingAgentBase<T>
     /// <b>For Beginners:</b> In the MarketMakingAgent model, ComputeGradients performs a supporting step in the workflow. It keeps the MarketMakingAgent architecture pipeline consistent.
     /// </para>
     /// </remarks>
-    public override Vector<T> ComputeGradients(Vector<T> input, Vector<T> target, ILossFunction<T>? lossFunction = null)
+    public Vector<T> ComputeGradients(Vector<T> input, Vector<T> target, ILossFunction<T>? lossFunction = null)
     {
         return _policyNetwork.ComputeGradients(Tensor<T>.FromVector(input), Tensor<T>.FromVector(target), lossFunction);
     }
@@ -430,7 +430,7 @@ public class MarketMakingAgent<T> : TradingAgentBase<T>
     /// <b>For Beginners:</b> In the MarketMakingAgent model, ApplyGradients performs a supporting step in the workflow. It keeps the MarketMakingAgent architecture pipeline consistent.
     /// </para>
     /// </remarks>
-    public override void ApplyGradients(Vector<T> gradients, T learningRate)
+    public void ApplyGradients(Vector<T> gradients, T learningRate)
     {
         _policyNetwork.ApplyGradients(gradients, learningRate);
     }

--- a/src/Interfaces/ILossFunction.cs
+++ b/src/Interfaces/ILossFunction.cs
@@ -17,9 +17,11 @@ namespace AiDotNet.Interfaces;
 /// Different types of problems require different loss functions. For example:
 /// - Mean Squared Error is often used for regression problems (predicting numeric values)
 /// - Cross Entropy is commonly used for classification problems (categorizing inputs)
-/// 
-/// The derivative of a loss function is equally important, as it tells the network which direction to adjust
-/// its weights during training to reduce the loss.
+///
+/// Training also needs the loss's <i>derivative</i> — the direction to adjust weights in. You do not
+/// write that derivative yourself. Implement <see cref="ComputeTapeLoss"/> with engine operations and
+/// the gradient tape differentiates it for you, exactly as PyTorch differentiates an
+/// <c>nn.Module.forward</c>. A loss defines its forward math once; the tape supplies the backward.
 /// </para>
 /// </remarks>
 [AiDotNet.Configuration.YamlConfigurable("LossFunction")]
@@ -34,12 +36,30 @@ public interface ILossFunction<T>
     T CalculateLoss(Vector<T> predicted, Vector<T> actual);
 
     /// <summary>
-    /// Calculates the derivative (gradient) of the loss function.
+    /// Computes the loss as a scalar tensor using tape-differentiable engine operations, so that
+    /// gradients flow through it automatically via <c>GradientTape</c>.
     /// </summary>
-    /// <param name="predicted">The predicted values from the model.</param>
-    /// <param name="actual">The actual (target) values.</param>
-    /// <returns>A vector containing the derivatives of the loss with respect to each prediction.</returns>
-    Vector<T> CalculateDerivative(Vector<T> predicted, Vector<T> actual);
+    /// <param name="predicted">The predicted tensor from the forward pass.</param>
+    /// <param name="target">The target tensor.</param>
+    /// <returns>A rank-0 scalar tensor containing the loss value.</returns>
+    /// <remarks>
+    /// <para>
+    /// This is the <b>only</b> place a loss function defines its math. There is deliberately no
+    /// member on this interface for a hand-written derivative: gradients come from the tape, which
+    /// makes it impossible for an analytic backward to drift out of step with the forward it is
+    /// supposed to differentiate. Callers obtain gradients either by recording this call on their
+    /// own training tape — the preferred form, since one tape then spans forward and loss together —
+    /// or via <see cref="LossFunctionExtensions.ComputeGradient{T}"/> for a standalone gradient.
+    /// </para>
+    /// <para>
+    /// Implementations must return a <b>rank-0</b> tensor. A rank-1 <c>[1]</c> result leaves the tape
+    /// without a scalar to seed the backward pass from, and silently produces no gradients.
+    /// </para>
+    /// <para><b>For Beginners:</b> Write the formula for your loss using tensor operations and stop
+    /// there. The library works out the calculus for you.
+    /// </para>
+    /// </remarks>
+    Tensor<T> ComputeTapeLoss(Tensor<T> predicted, Tensor<T> target);
 
     /// <summary>
     /// Calculates both loss and gradient on GPU in a single pass.

--- a/src/Interfaces/IRLAgent.cs
+++ b/src/Interfaces/IRLAgent.cs
@@ -27,7 +27,7 @@ namespace AiDotNet.Interfaces;
 /// </remarks>
 [AiDotNet.Configuration.YamlConfigurable("RLAgent")]
 public interface IRLAgent<T> : IFullModel<T, Vector<T>, Vector<T>>,
-    IParameterizable<T, Vector<T>, Vector<T>>, IFeatureAware, IGradientComputable<T, Vector<T>, Vector<T>>
+    IParameterizable<T, Vector<T>, Vector<T>>, IFeatureAware
 {
     /// <summary>
     /// Selects an action given the current state observation.

--- a/src/Interfaces/LossFunctionExtensions.cs
+++ b/src/Interfaces/LossFunctionExtensions.cs
@@ -77,6 +77,43 @@ public static class LossFunctionExtensions
     }
 
     /// <summary>
+    /// Computes the gradient of the loss with respect to <paramref name="predicted"/> for callers
+    /// working in vector shape.
+    /// </summary>
+    /// <param name="lossFunction">The loss function to differentiate.</param>
+    /// <param name="predicted">The predicted values; the gradient is taken with respect to these.</param>
+    /// <param name="actual">The actual (target) values, treated as a constant.</param>
+    /// <returns>A vector holding d(loss)/d(predicted), the same length as <paramref name="predicted"/>.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when any argument is null.</exception>
+    /// <remarks>
+    /// A shape adapter over <see cref="ComputeGradient{T}(ILossFunction{T}, Tensor{T}, Tensor{T})"/>,
+    /// not a second implementation — the gradient still comes from differentiating
+    /// <see cref="ILossFunction{T}.ComputeTapeLoss"/>. This exists for the hand-rolled backward chains
+    /// that consume the loss gradient as a vector and propagate it through layers themselves.
+    /// </remarks>
+    public static Vector<T> ComputeGradient<T>(
+        this ILossFunction<T> lossFunction,
+        Vector<T> predicted,
+        Vector<T> actual)
+    {
+        if (predicted == null)
+        {
+            throw new ArgumentNullException(nameof(predicted));
+        }
+        if (actual == null)
+        {
+            throw new ArgumentNullException(nameof(actual));
+        }
+
+        var gradient = ComputeGradient(
+            lossFunction,
+            Tensor<T>.FromVector(predicted),
+            Tensor<T>.FromVector(actual));
+
+        return gradient.ToVector();
+    }
+
+    /// <summary>
     /// Computes the loss value and its gradient with respect to <paramref name="predicted"/> from a
     /// <b>single</b> tape recording.
     /// </summary>

--- a/src/Interfaces/LossFunctionExtensions.cs
+++ b/src/Interfaces/LossFunctionExtensions.cs
@@ -1,10 +1,39 @@
-﻿using System;
+using System;
+using System.Collections.Generic;
+using AiDotNet.Tensors.Engines.Autodiff;
 using AiDotNet.Tensors.LinearAlgebra;
 
 namespace AiDotNet.Interfaces;
 
+/// <summary>
+/// Tensor-shaped conveniences over <see cref="ILossFunction{T}"/>, including the library's single
+/// implementation of "gradient of a loss with respect to a prediction".
+/// </summary>
+/// <remarks>
+/// <para>
+/// Every loss gradient in the library is produced by differentiating
+/// <see cref="ILossFunction{T}.ComputeTapeLoss"/> on a <see cref="GradientTape{T}"/>. Loss functions
+/// no longer carry a hand-written derivative, so a backward can no longer disagree with the forward
+/// it belongs to — the two are the same expression.
+/// </para>
+/// <para>
+/// <b>Prefer your own tape when you have one.</b> <see cref="ComputeGradient{T}"/> opens a tape,
+/// records one loss, and discards it. If you are already running a forward pass under a tape, record
+/// <c>ComputeTapeLoss</c> on <i>that</i> tape instead: one tape then spans forward and loss, you get
+/// parameter gradients directly, and the intermediate prediction-space gradient never has to be
+/// materialized. These helpers are for callers holding nothing but two finished tensors.
+/// </para>
+/// </remarks>
 public static class LossFunctionExtensions
 {
+    /// <summary>
+    /// Evaluates the loss for tensor-shaped predictions and targets.
+    /// </summary>
+    /// <param name="lossFunction">The loss function to evaluate.</param>
+    /// <param name="predicted">The predicted values.</param>
+    /// <param name="actual">The actual (target) values.</param>
+    /// <returns>The scalar loss value.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when any argument is null.</exception>
     public static T ComputeLoss<T>(
         this ILossFunction<T> lossFunction,
         Tensor<T> predicted,
@@ -26,7 +55,46 @@ public static class LossFunctionExtensions
         return lossFunction.CalculateLoss(predicted.ToVector(), actual.ToVector());
     }
 
+    /// <summary>
+    /// Computes the gradient of the loss with respect to <paramref name="predicted"/> by
+    /// differentiating <see cref="ILossFunction{T}.ComputeTapeLoss"/> on a gradient tape.
+    /// </summary>
+    /// <param name="lossFunction">The loss function to differentiate.</param>
+    /// <param name="predicted">The predicted values; the gradient is taken with respect to these.</param>
+    /// <param name="actual">The actual (target) values, treated as a constant.</param>
+    /// <returns>A tensor shaped like <paramref name="predicted"/> holding d(loss)/d(predicted).</returns>
+    /// <exception cref="ArgumentNullException">Thrown when any argument is null.</exception>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when the loss does not actually depend on <paramref name="predicted"/> through
+    /// tape-recorded operations, which would otherwise return a silently-zero gradient.
+    /// </exception>
     public static Tensor<T> ComputeGradient<T>(
+        this ILossFunction<T> lossFunction,
+        Tensor<T> predicted,
+        Tensor<T> actual)
+    {
+        return ComputeLossAndGradient(lossFunction, predicted, actual).Gradient;
+    }
+
+    /// <summary>
+    /// Computes the loss value and its gradient with respect to <paramref name="predicted"/> from a
+    /// <b>single</b> tape recording.
+    /// </summary>
+    /// <param name="lossFunction">The loss function to evaluate and differentiate.</param>
+    /// <param name="predicted">The predicted values; the gradient is taken with respect to these.</param>
+    /// <param name="actual">The actual (target) values, treated as a constant.</param>
+    /// <returns>The loss value and d(loss)/d(predicted).</returns>
+    /// <exception cref="ArgumentNullException">Thrown when any argument is null.</exception>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when the loss does not actually depend on <paramref name="predicted"/> through
+    /// tape-recorded operations.
+    /// </exception>
+    /// <remarks>
+    /// Reading both from one recording is why this overload exists: computing them separately would
+    /// evaluate the forward twice, and — before loss gradients came from the tape — allowed the value
+    /// and the gradient to come from two expressions that were not required to agree.
+    /// </remarks>
+    public static (T Loss, Tensor<T> Gradient) ComputeLossAndGradient<T>(
         this ILossFunction<T> lossFunction,
         Tensor<T> predicted,
         Tensor<T> actual)
@@ -44,7 +112,40 @@ public static class LossFunctionExtensions
             throw new ArgumentNullException(nameof(actual));
         }
 
-        var derivative = lossFunction.CalculateDerivative(predicted.ToVector(), actual.ToVector());
-        return new Tensor<T>(predicted._shape, derivative);
+        using var tape = new GradientTape<T>();
+
+        var lossTensor = lossFunction.ComputeTapeLoss(predicted, actual);
+        if (lossTensor is null || lossTensor.Length == 0)
+        {
+            throw new InvalidOperationException(
+                $"{lossFunction.GetType().Name}.ComputeTapeLoss returned no value. It must return a "
+                + "rank-0 scalar tensor.");
+        }
+
+        var lossValue = lossTensor[0];
+
+        // A loss whose forward never routes the prediction through a recorded operation cannot be
+        // differentiated with respect to it. The tape reports that as "no recorded operations";
+        // translated here because the bare tape message does not name the loss that caused it.
+        if (tape.EntryCount == 0)
+        {
+            throw new InvalidOperationException(
+                $"{lossFunction.GetType().Name}.ComputeTapeLoss recorded no operations on the gradient "
+                + "tape, so no gradient with respect to the prediction exists. Build the loss from "
+                + "engine operations on the supplied tensors rather than computing it element-wise "
+                + "outside the tape.");
+        }
+
+        var gradients = tape.ComputeGradients(lossTensor, new List<Tensor<T>> { predicted });
+
+        if (!gradients.TryGetValue(predicted, out var gradient) || gradient is null)
+        {
+            throw new InvalidOperationException(
+                $"{lossFunction.GetType().Name}.ComputeTapeLoss produced a loss that does not depend on "
+                + "the prediction, so its gradient is undefined. Check that the forward uses the "
+                + "'predicted' tensor it was given rather than a copy of it.");
+        }
+
+        return (lossValue, gradient);
     }
 }

--- a/src/KnowledgeDistillation/DistillationLossAdapter.cs
+++ b/src/KnowledgeDistillation/DistillationLossAdapter.cs
@@ -51,23 +51,6 @@ public sealed class DistillationLossAdapter<T> : LossFunctionBase<T>
 
     /// <inheritdoc />
     /// <remarks>
-    /// <paramref name="predicted"/> is the student output, <paramref name="actual"/> the teacher
-    /// output. Returns the distillation gradient with respect to the student output.
-    /// </remarks>
-    public override Vector<T> CalculateDerivative(Vector<T> predicted, Vector<T> actual)
-    {
-        var gradient = _strategy.ComputeGradient(ToRow(predicted), ToRow(actual), LabelRow());
-        var result = new Vector<T>(predicted.Length);
-        for (int i = 0; i < predicted.Length; i++)
-        {
-            result[i] = gradient[0, i];
-        }
-
-        return result;
-    }
-
-    /// <inheritdoc />
-    /// <remarks>
     /// Builds the surrogate <c>Σ (g · ŷ)</c> where <c>g</c> is the strategy's gradient at the current
     /// prediction values, held as a constant. Differentiating this on the tape yields <c>g</c> as the
     /// prediction cotangent, which is exactly what distillation needs to propagate.

--- a/src/LossFunctions/BinaryCrossEntropyLoss.cs
+++ b/src/LossFunctions/BinaryCrossEntropyLoss.cs
@@ -70,34 +70,6 @@ public class BinaryCrossEntropyLoss<T> : LossFunctionBase<T>
     }
 
     /// <summary>
-    /// Calculates the derivative of the Binary Cross Entropy loss function.
-    /// </summary>
-    /// <param name="predicted">The predicted values (probabilities between 0 and 1).</param>
-    /// <param name="actual">The actual (target) values (typically 0 or 1).</param>
-    /// <returns>A vector containing the derivatives of BCE for each prediction.</returns>
-    public override Vector<T> CalculateDerivative(Vector<T> predicted, Vector<T> actual)
-    {
-        ValidateVectorLengths(predicted, actual);
-
-        Vector<T> derivative = new Vector<T>(predicted.Length);
-        for (int i = 0; i < predicted.Length; i++)
-        {
-            // Clamp values to prevent division by zero using NumericalStabilityHelper
-            T p = NumericalStabilityHelper.ClampProbability(predicted[i], NumericalStabilityHelper.SmallEpsilon);
-
-            // -(y/p - (1-y)/(1-p)) with safe division
-            T denominator = NumOps.Multiply(p, NumOps.Subtract(NumOps.One, p));
-            derivative[i] = NumericalStabilityHelper.SafeDiv(
-                NumOps.Subtract(p, actual[i]),
-                denominator,
-                NumericalStabilityHelper.SmallEpsilon
-            );
-        }
-
-        return derivative.Divide(NumOps.FromDouble(predicted.Length));
-    }
-
-    /// <summary>
     /// Calculates both BCE loss and gradient on GPU in a single efficient pass.
     /// </summary>
     /// <param name="predicted">The predicted GPU tensor (probabilities between 0 and 1).</param>

--- a/src/LossFunctions/BinaryCrossEntropyWithLogitsLoss.cs
+++ b/src/LossFunctions/BinaryCrossEntropyWithLogitsLoss.cs
@@ -91,50 +91,6 @@ public class BinaryCrossEntropyWithLogitsLoss<T> : LossFunctionBase<T>
         return NumOps.Divide(sum, NumOps.FromDouble(predicted.Length));
     }
 
-    /// <summary>
-    /// Calculates the derivative of BCE loss with respect to logits.
-    /// </summary>
-    /// <param name="predicted">Raw logits.</param>
-    /// <param name="actual">Binary target values.</param>
-    /// <returns>Gradient: (sigmoid(x) - y) / N.</returns>
-    /// <remarks>
-    /// <para>
-    /// The gradient simplification <c>sigmoid(x) - y</c> is what makes the fused
-    /// sigmoid-plus-BCE loss preferable to applying them separately: it avoids the
-    /// catastrophic cancellation that occurs in <c>-y/p + (1-y)/(1-p)</c> when
-    /// <c>p</c> approaches 0 or 1.
-    /// </para>
-    /// </remarks>
-    public override Vector<T> CalculateDerivative(Vector<T> predicted, Vector<T> actual)
-    {
-        ValidateVectorLengths(predicted, actual);
-
-        var derivative = new Vector<T>(predicted.Length);
-        T n = NumOps.FromDouble(predicted.Length);
-        for (int i = 0; i < predicted.Length; i++)
-        {
-            // Numerically stable sigmoid:
-            //   if x >= 0: 1 / (1 + exp(-x))
-            //   if x <  0: exp(x) / (1 + exp(x))
-            T x = predicted[i];
-            T sigmoid;
-            if (NumOps.GreaterThanOrEquals(x, NumOps.Zero))
-            {
-                T expNegX = NumOps.Exp(NumOps.Negate(x));
-                sigmoid = NumOps.Divide(NumOps.One, NumOps.Add(NumOps.One, expNegX));
-            }
-            else
-            {
-                T expX = NumOps.Exp(x);
-                sigmoid = NumOps.Divide(expX, NumOps.Add(NumOps.One, expX));
-            }
-
-            derivative[i] = NumOps.Divide(NumOps.Subtract(sigmoid, actual[i]), n);
-        }
-
-        return derivative;
-    }
-
     /// <inheritdoc />
     public override Tensor<T> ComputeTapeLoss(Tensor<T> predicted, Tensor<T> target)
     {

--- a/src/LossFunctions/BornRuleMseLoss.cs
+++ b/src/LossFunctions/BornRuleMseLoss.cs
@@ -47,25 +47,6 @@ public class BornRuleMseLoss<T> : LossFunctionBase<T>
     }
 
     /// <inheritdoc />
-    public override Vector<T> CalculateDerivative(Vector<T> predicted, Vector<T> actual)
-    {
-        ValidateVectorLengths(predicted, actual);
-
-        var derivative = new Vector<T>(predicted.Length);
-        T fourOverN = NumOps.FromDouble(4.0 / predicted.Length);
-        for (int i = 0; i < predicted.Length; i++)
-        {
-            T a = predicted[i];
-            T p = NumOps.Multiply(a, a);
-            T diff = NumOps.Subtract(p, actual[i]);
-            // d/da mean((a² − t)²) = (4/n) · a · (a² − t)
-            derivative[i] = NumOps.Multiply(fourOverN, NumOps.Multiply(a, diff));
-        }
-
-        return derivative;
-    }
-
-    /// <inheritdoc />
     public override Tensor<T> ComputeTapeLoss(Tensor<T> predicted, Tensor<T> target)
     {
         // measured = predicted²  (Born's rule), then MSE(measured, target).

--- a/src/LossFunctions/CTCLoss.cs
+++ b/src/LossFunctions/CTCLoss.cs
@@ -490,53 +490,6 @@ public class CTCLoss<T> : LossFunctionBase<T>, ISequenceLossFunction<T>
         return CalculateLoss(logProbs, targets, inputLengths, targetLengths);
     }
 
-    /// <summary>
-    /// Calculates the gradient of CTC loss from flattened vectors.
-    /// </summary>
-    public override Vector<T> CalculateDerivative(Vector<T> predicted, Vector<T> actual)
-    {
-        if (predicted is null) throw new ArgumentNullException(nameof(predicted));
-        if (actual is null) throw new ArgumentNullException(nameof(actual));
-
-        int batchSize = (int)Convert.ToDouble(actual[0]);
-        if (batchSize <= 0)
-            throw new ArgumentException("Invalid batch size encoded in actual vector");
-
-        int timeStepsTotal = predicted.Length / (_numClasses * batchSize);
-        var logProbs = new Tensor<T>(new[] { batchSize, timeStepsTotal, _numClasses });
-
-        int index = 0;
-        for (int b = 0; b < batchSize; b++)
-            for (int t = 0; t < timeStepsTotal; t++)
-                for (int c = 0; c < _numClasses; c++)
-                    logProbs[new[] { b, t, c }] = predicted[index++];
-
-        int actualIndex = 1;
-        var targets = new int[batchSize][];
-        var inputLengths = new int[batchSize];
-        var targetLengths = new int[batchSize];
-
-        for (int b = 0; b < batchSize; b++)
-        {
-            targetLengths[b] = (int)Convert.ToDouble(actual[actualIndex++]);
-            inputLengths[b] = timeStepsTotal;
-            targets[b] = new int[targetLengths[b]];
-            for (int i = 0; i < targetLengths[b]; i++)
-                targets[b][i] = (int)Convert.ToDouble(actual[actualIndex++]);
-        }
-
-        var gradientTensor = CalculateGradient(logProbs, targets, inputLengths, targetLengths);
-        var gradientVector = new Vector<T>(predicted.Length);
-
-        index = 0;
-        for (int b = 0; b < batchSize; b++)
-            for (int t = 0; t < timeStepsTotal; t++)
-                for (int c = 0; c < _numClasses; c++)
-                    gradientVector[index++] = gradientTensor[new[] { b, t, c }];
-
-        return gradientVector;
-    }
-
     /// <inheritdoc />
     /// <remarks>
     /// Uses the tape-tracked TensorCTCLoss engine op for differentiable CTC loss.

--- a/src/LossFunctions/CategoricalCrossEntropyLoss.cs
+++ b/src/LossFunctions/CategoricalCrossEntropyLoss.cs
@@ -85,30 +85,6 @@ public class CategoricalCrossEntropyLoss<T> : LossFunctionBase<T>
     }
 
     /// <summary>
-    /// Calculates the derivative of the Categorical Cross Entropy loss function.
-    /// </summary>
-    /// <param name="predicted">The predicted values (probabilities that sum to 1 across categories).</param>
-    /// <param name="actual">The actual (target) values (typically one-hot encoded).</param>
-    /// <returns>A vector containing the derivatives of CCE for each prediction.</returns>
-    public override Vector<T> CalculateDerivative(Vector<T> predicted, Vector<T> actual)
-    {
-        ValidateVectorLengths(predicted, actual);
-        actual = SmoothActual(actual);
-
-        // Derivative of -Σ actual_i * log(predicted_i) with respect to predicted_i = -actual_i / predicted_i
-        // Note: When composed with softmax, this simplifies to (predicted - actual),
-        // but the standalone derivative must use the correct formula.
-        Vector<T> derivative = new Vector<T>(predicted.Length);
-        for (int i = 0; i < predicted.Length; i++)
-        {
-            derivative[i] = NumOps.Negate(
-                NumericalStabilityHelper.SafeDiv(actual[i], predicted[i], NumericalStabilityHelper.SmallEpsilon));
-        }
-
-        return derivative;
-    }
-
-    /// <summary>
     /// Calculates both Categorical Cross Entropy loss and gradient on GPU in a single efficient pass.
     /// </summary>
     /// <param name="predicted">The predicted GPU tensor from the model.</param>

--- a/src/LossFunctions/CharbonnierLoss.cs
+++ b/src/LossFunctions/CharbonnierLoss.cs
@@ -103,39 +103,6 @@ public class CharbonnierLoss<T> : LossFunctionBase<T>
     }
 
     /// <summary>
-    /// Calculates the derivative of the Charbonnier loss function.
-    /// </summary>
-    /// <param name="predicted">The predicted values from the model.</param>
-    /// <param name="actual">The actual (target) values.</param>
-    /// <returns>A vector containing the derivatives of Charbonnier loss for each prediction.</returns>
-    /// <remarks>
-    /// <para>
-    /// The derivative is: (predicted - actual) / sqrt((predicted - actual)² + ε²)
-    ///
-    /// This derivative is always well-defined (unlike L1 loss) because the denominator
-    /// is always at least ε, avoiding division by zero.
-    /// </para>
-    /// </remarks>
-    public override Vector<T> CalculateDerivative(Vector<T> predicted, Vector<T> actual)
-    {
-        ValidateVectorLengths(predicted, actual);
-
-        Vector<T> derivative = new Vector<T>(predicted.Length);
-        T n = NumOps.FromDouble(predicted.Length);
-
-        for (int i = 0; i < predicted.Length; i++)
-        {
-            T diff = NumOps.Subtract(predicted[i], actual[i]);
-            T diffSquared = NumOps.Multiply(diff, diff);
-            // diff / sqrt(diff² + ε²)
-            T denominator = NumOps.Sqrt(NumOps.Add(diffSquared, _epsilonSquared));
-            derivative[i] = NumOps.Divide(NumOps.Divide(diff, denominator), n);
-        }
-
-        return derivative;
-    }
-
-    /// <summary>
     /// Calculates both Charbonnier loss and gradient on GPU in a single efficient pass.
     /// </summary>
     /// <param name="predicted">The predicted GPU tensor from the model.</param>

--- a/src/LossFunctions/ContrastiveLoss.cs
+++ b/src/LossFunctions/ContrastiveLoss.cs
@@ -81,57 +81,6 @@ public class ContrastiveLoss<T> : LossFunctionBase<T>
         return NumOps.Add(similarTerm, dissimilarTerm);
     }
 
-    /// <summary>
-    /// Calculates the gradients of the Contrastive Loss function for both output vectors.
-    /// </summary>
-    /// <param name="output1">The first output vector.</param>
-    /// <param name="output2">The second output vector.</param>
-    /// <param name="similarityLabel">A value of 1 indicates similar pairs, 0 indicates dissimilar pairs.</param>
-    /// <returns>A tuple containing the gradients for both output vectors.</returns>
-    public (Vector<T>, Vector<T>) CalculateDerivative(Vector<T> output1, Vector<T> output2, T similarityLabel)
-    {
-        T distance = VectorHelper.EuclideanDistance(output1, output2);
-        Vector<T> grad1 = new Vector<T>(output1.Length);
-        Vector<T> grad2 = new Vector<T>(output2.Length);
-
-        for (int i = 0; i < output1.Length; i++)
-        {
-            T diff = NumOps.Subtract(output1[i], output2[i]);
-
-            if (NumOps.Equals(similarityLabel, NumOps.One))
-            {
-                // Gradient for similar pairs: 2 * (output1 - output2)
-                grad1[i] = NumOps.Multiply(NumOps.FromDouble(2), diff);
-                grad2[i] = NumOps.Multiply(NumOps.FromDouble(-2), diff);
-            }
-            else
-            {
-                // For dissimilar pairs, only apply gradient if they're closer than the margin
-                if (NumOps.LessThan(distance, _margin))
-                {
-                    // Gradient: -2 * (margin - distance) * (output1 - output2) / distance
-                    T scaleFactor = NumOps.Multiply(
-                        NumOps.FromDouble(-2),
-                        NumOps.Divide(
-                            NumOps.Subtract(_margin, distance),
-                            distance
-                        )
-                    );
-
-                    grad1[i] = NumOps.Multiply(scaleFactor, diff);
-                    grad2[i] = NumOps.Multiply(NumOps.Negate(scaleFactor), diff);
-                }
-                else
-                {
-                    // If distance >= margin, gradient is zero
-                    grad1[i] = NumOps.Zero;
-                    grad2[i] = NumOps.Zero;
-                }
-            }
-        }
-
-        return (grad1, grad2);
-    }
 
     /// <summary>
     /// This method is not used for Contrastive Loss as it requires two input vectors and a similarity label.
@@ -211,5 +160,65 @@ public class ContrastiveLoss<T> : LossFunctionBase<T>
         var result = Engine.TensorAdd(positivePart, negativePart);
         var allAxes = Enumerable.Range(0, result.Shape.Length).ToArray();
         return Engine.ReduceMean(result, allAxes, keepDims: false);
+    }
+
+    /// <summary>
+    /// Computes the contrastive loss as a tape-differentiable scalar from an embedding PAIR and
+    /// its similarity label.
+    /// </summary>
+    /// <param name="output1">First embedding of the pair.</param>
+    /// <param name="output2">Second embedding of the pair, same shape.</param>
+    /// <param name="similarityLabel">1 for a similar pair, 0 for a dissimilar one.</param>
+    /// <returns>A rank-0 scalar tensor holding y*d^2 + (1-y)*max(0, margin - d)^2.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when either embedding is null.</exception>
+    /// <exception cref="ArgumentException">Thrown when the two shapes differ.</exception>
+    /// <remarks>
+    /// <para>
+    /// Only the DISTANCE is computed here; the pair rule itself is the two-argument
+    /// <see cref="ComputeTapeLoss(Tensor{T}, Tensor{T})"/>, which already consumes a distance and a
+    /// label. Keeping the rule in one place means the pair API and the pointwise API cannot
+    /// disagree about what the loss is.
+    /// </para>
+    /// <para>
+    /// The label carries no gradient -- it is data, not a parameter -- so the backward pass reaches
+    /// both embeddings and nothing else.
+    /// </para>
+    /// </remarks>
+    public Tensor<T> ComputeTapeLoss(Tensor<T> output1, Tensor<T> output2, T similarityLabel)
+    {
+        if (output1 is null) throw new ArgumentNullException(nameof(output1));
+        if (output2 is null) throw new ArgumentNullException(nameof(output2));
+
+        if (!output1._shape.SequenceEqual(output2._shape))
+        {
+            throw new ArgumentException(
+                "Both embeddings must have the same shape, but were "
+                + $"[{string.Join(", ", output1.Shape.ToArray())}] and "
+                + $"[{string.Join(", ", output2.Shape.ToArray())}].",
+                nameof(output2));
+        }
+
+        var delta = Engine.TensorSubtract(output1, output2);
+        var squared = Engine.TensorMultiply(delta, delta);
+        var featureAxis = new[] { squared.Shape.Length - 1 };
+        var summed = Engine.ReduceSum(squared, featureAxis, keepDims: false);
+
+        // A single un-batched pair reduces to rank 0 here, and the pointwise overload below then
+        // calls ReduceMean over an EMPTY axis list, whose backward rejects the empty shape. Keeping
+        // one sample as [1] makes the un-batched case take the same path as a batch of one.
+        if (summed.Shape.Length == 0)
+        {
+            summed = Engine.Reshape(summed, new[] { 1 });
+        }
+
+        // Offset under the root: d(sqrt(x))/dx is unbounded at x = 0, and a similar pair converges
+        // to exactly zero distance, so without it the gradient becomes NaN precisely when training
+        // is succeeding.
+        var distance = Engine.TensorSqrt(Engine.TensorAddScalar(summed, NumOps.FromDouble(1e-12)));
+
+        var label = new Tensor<T>(distance._shape);
+        label.Fill(similarityLabel);
+
+        return ComputeTapeLoss(distance, label);
     }
 }

--- a/src/LossFunctions/ContrastiveLoss.cs
+++ b/src/LossFunctions/ContrastiveLoss.cs
@@ -149,22 +149,6 @@ public class ContrastiveLoss<T> : LossFunctionBase<T>
     }
 
     /// <summary>
-    /// This method is not used for Contrastive Loss as it requires two input vectors and a similarity label.
-    /// </summary>
-    /// <param name="predicted">The predicted values vector.</param>
-    /// <param name="actual">The actual (target) values vector.</param>
-    /// <returns>Throws NotSupportedException.</returns>
-    /// <exception cref="NotSupportedException">Always thrown as ContrastiveLoss requires two input vectors and a similarity label.</exception>
-    public override Vector<T> CalculateDerivative(Vector<T> predicted, Vector<T> actual)
-    {
-        throw new NotSupportedException(
-            "ContrastiveLoss requires two input vectors and a similarity label. " +
-            "Use the CalculateDerivative(Vector<T>, Vector<T>, T) method instead."
-        );
-    }
-
-
-    /// <summary>
     /// Calculates Contrastive Loss on GPU for batched input tensors.
     /// </summary>
     /// <param name="output1">The first output GPU tensor.</param>

--- a/src/LossFunctions/CosineSimilarityLoss.cs
+++ b/src/LossFunctions/CosineSimilarityLoss.cs
@@ -70,45 +70,6 @@ public class CosineSimilarityLoss<T> : LossFunctionBase<T>
         return NumOps.Subtract(NumOps.One, cosineSimilarity);
     }
 
-    /// <summary>
-    /// Calculates the derivative of the Cosine Similarity Loss with respect to the predicted values.
-    /// </summary>
-    /// <param name="predicted">The predicted vector from the model.</param>
-    /// <param name="actual">The actual (target) vector.</param>
-    /// <returns>A vector containing the gradient of the loss with respect to each prediction.</returns>
-    public override Vector<T> CalculateDerivative(Vector<T> predicted, Vector<T> actual)
-    {
-        ValidateVectorLengths(predicted, actual);
-
-        T dotProduct = Engine.DotProduct(predicted, actual);
-        T normPredicted = Engine.DotProduct(predicted, predicted);
-        T normActual = Engine.DotProduct(actual, actual);
-
-        T normPredSqrt = NumOps.Sqrt(normPredicted);
-        T normProduct = NumOps.Multiply(normPredSqrt, NumOps.Sqrt(normActual));
-
-        Vector<T> derivative = new Vector<T>(predicted.Length);
-        for (int i = 0; i < predicted.Length; i++)
-        {
-            // ?(cos similarity)/?p_i = (a_i*||p||^2 - p_i*(p·a)) / (||p||^3 * ||a||)
-            T numerator = NumOps.Subtract(
-                NumOps.Multiply(actual[i], normPredicted),
-                NumOps.Multiply(predicted[i], dotProduct)
-            );
-
-            // ||p||^3 * ||a|| = ||p|| * ||p||^2 * ||a|| / ||p|| ...
-            // normPredSqrt = ||p||, normPredicted = ||p||^2
-            // normPredSqrt * normPredicted = ||p||^3
-            T normPredCubed = NumOps.Multiply(normPredSqrt, normPredicted);
-            T denominator = NumOps.Multiply(normPredCubed, NumOps.Sqrt(normActual));
-
-            // Derivative of the loss is negative of the derivative of cosine similarity
-            derivative[i] = NumOps.Negate(NumericalStabilityHelper.SafeDiv(numerator, denominator, NumericalStabilityHelper.SmallEpsilon));
-        }
-
-        return derivative;
-    }
-
     /// <inheritdoc />
     public override Tensor<T> ComputeTapeLoss(Tensor<T> predicted, Tensor<T> target)
     {

--- a/src/LossFunctions/CrossEntropyLoss.cs
+++ b/src/LossFunctions/CrossEntropyLoss.cs
@@ -62,29 +62,6 @@ public class CrossEntropyLoss<T> : LossFunctionBase<T>
     }
 
     /// <summary>
-    /// Calculates the derivative of the Cross-Entropy loss function.
-    /// </summary>
-    /// <param name="predicted">The predicted probability distribution.</param>
-    /// <param name="actual">The actual (target) probability distribution.</param>
-    /// <returns>A vector containing the derivative of Cross-Entropy loss for each element.</returns>
-    public override Vector<T> CalculateDerivative(Vector<T> predicted, Vector<T> actual)
-    {
-        ValidateVectorLengths(predicted, actual);
-
-        Vector<T> derivative = new Vector<T>(predicted.Length);
-        for (int i = 0; i < predicted.Length; i++)
-        {
-            // Clamp predicted values to prevent division by zero using NumericalStabilityHelper
-            T p = NumericalStabilityHelper.ClampProbability(predicted[i], NumericalStabilityHelper.SmallEpsilon);
-
-            // -actual_i / predicted_i with safe division
-            derivative[i] = NumericalStabilityHelper.SafeDiv(NumOps.Negate(actual[i]), p, NumericalStabilityHelper.SmallEpsilon);
-        }
-
-        return derivative.Divide(NumOps.FromDouble(predicted.Length));
-    }
-
-    /// <summary>
     /// Calculates both Cross-Entropy loss and gradient on GPU in a single efficient pass.
     /// </summary>
     /// <param name="predicted">The predicted GPU tensor (probability distribution).</param>

--- a/src/LossFunctions/CrossEntropyWithLogitsLoss.cs
+++ b/src/LossFunctions/CrossEntropyWithLogitsLoss.cs
@@ -70,53 +70,6 @@ public class CrossEntropyWithLogitsLoss<T> : LossFunctionBase<T>
         return NumOps.Negate(loss);
     }
 
-    /// <summary>
-    /// Calculates the derivative of cross-entropy loss with respect to logits.
-    /// </summary>
-    /// <param name="predicted">Raw logits.</param>
-    /// <param name="actual">One-hot encoded target vector.</param>
-    /// <returns>Gradient: softmax(logits) - targets.</returns>
-    /// <remarks>
-    /// <para>
-    /// The gradient of cross-entropy loss with respect to logits has the elegant form:
-    ///   d(loss)/d(logit_i) = softmax(logit_i) - target_i
-    ///
-    /// This is one of the key advantages of combining softmax and cross-entropy:
-    /// the gradient is simply the difference between the predicted probabilities
-    /// and the targets, which is both easy to compute and numerically stable.
-    /// </para>
-    /// </remarks>
-    public override Vector<T> CalculateDerivative(Vector<T> predicted, Vector<T> actual)
-    {
-        ValidateVectorLengths(predicted, actual);
-
-        // Compute softmax probabilities
-        T maxLogit = predicted[0];
-        for (int i = 1; i < predicted.Length; i++)
-        {
-            if (NumOps.GreaterThan(predicted[i], maxLogit))
-                maxLogit = predicted[i];
-        }
-
-        var expValues = new Vector<T>(predicted.Length);
-        T sumExp = NumOps.Zero;
-        for (int i = 0; i < predicted.Length; i++)
-        {
-            expValues[i] = NumOps.Exp(NumOps.Subtract(predicted[i], maxLogit));
-            sumExp = NumOps.Add(sumExp, expValues[i]);
-        }
-
-        // Gradient = softmax(logits) - targets
-        var derivative = new Vector<T>(predicted.Length);
-        for (int i = 0; i < predicted.Length; i++)
-        {
-            T softmaxI = NumOps.Divide(expValues[i], sumExp);
-            derivative[i] = NumOps.Subtract(softmaxI, actual[i]);
-        }
-
-        return derivative;
-    }
-
     /// <inheritdoc />
     public override Tensor<T> ComputeTapeLoss(Tensor<T> predicted, Tensor<T> target)
     {

--- a/src/LossFunctions/DiceLoss.cs
+++ b/src/LossFunctions/DiceLoss.cs
@@ -79,15 +79,22 @@ public class DiceLoss<T> : LossFunctionBase<T>
     /// <inheritdoc />
     public override Tensor<T> ComputeTapeLoss(Tensor<T> predicted, Tensor<T> target)
     {
-        // Dice = 1 - (2 * intersection + smooth) / (|pred| + |target| + smooth)
+        // Dice = 1 - 2 * intersection / (|pred| + |target|), matching CalculateLoss above.
+        // This added a smoothing constant of 1 to both numerator and denominator while
+        // CalculateLoss added none, so the two forwards computed different losses and their
+        // gradients disagreed by a factor that depended on the batch totals.
         var intersection = Engine.TensorMultiply(predicted, target);
         var allAxes = Enumerable.Range(0, intersection.Shape.Length).ToArray();
         var interSum = Engine.ReduceSum(intersection, allAxes, keepDims: false);
         var predSum = Engine.ReduceSum(predicted, allAxes, keepDims: false);
         var targSum = Engine.ReduceSum(target, allAxes, keepDims: false);
-        var twoInter = Engine.TensorMultiplyScalar(interSum, NumOps.FromDouble(2.0));
-        var numerator = Engine.TensorAddScalar(twoInter, NumOps.One);
-        var denominator = Engine.TensorAddScalar(Engine.TensorAdd(predSum, targSum), NumOps.One);
+        var numerator = Engine.TensorMultiplyScalar(interSum, NumOps.FromDouble(2.0));
+
+        // Guard the division the way CalculateLoss does with SafeDiv, rather than by smoothing:
+        // an epsilon keeps an all-zero prediction and target finite without changing the value
+        // for any real input.
+        var denominator = Engine.TensorAddScalar(
+            Engine.TensorAdd(predSum, targSum), NumOps.FromDouble(1e-12));
         var dice = Engine.TensorDivide(numerator, denominator);
         return Engine.ScalarMinusTensor(NumOps.One, dice);
     }

--- a/src/LossFunctions/DiceLoss.cs
+++ b/src/LossFunctions/DiceLoss.cs
@@ -76,51 +76,6 @@ public class DiceLoss<T> : LossFunctionBase<T>
         return NumOps.Subtract(NumOps.One, diceCoefficient);
     }
 
-    /// <summary>
-    /// Calculates the derivative of the Dice loss function.
-    /// </summary>
-    /// <param name="predicted">The predicted values.</param>
-    /// <param name="actual">The actual (target) values.</param>
-    /// <returns>A vector containing the derivatives of Dice loss for each prediction.</returns>
-    public override Vector<T> CalculateDerivative(Vector<T> predicted, Vector<T> actual)
-    {
-        ValidateVectorLengths(predicted, actual);
-
-        T intersection = Engine.DotProduct(predicted, actual);
-
-        T sumPredicted = NumOps.Zero;
-        T sumActual = NumOps.Zero;
-        for (int i = 0; i < predicted.Length; i++)
-        {
-            sumPredicted = NumOps.Add(sumPredicted, predicted[i]);
-            sumActual = NumOps.Add(sumActual, actual[i]);
-        }
-
-        T denominator = NumOps.Add(sumPredicted, sumActual);
-
-        var result = new T[predicted.Length];
-        for (int i = 0; i < predicted.Length; i++)
-        {
-            // Derivative of Dice loss wrt p_i:
-            // loss = 1 - 2*intersection/denom
-            // d(loss)/dp_i = -2 * (a_i * denom - intersection) / denom^2
-            // (quotient rule: d(intersection)/dp_i = a_i, d(denom)/dp_i = 1)
-            T numerator = NumOps.Subtract(
-                NumOps.Multiply(actual[i], denominator),
-                intersection
-            );
-            result[i] = NumOps.Negate(
-                NumericalStabilityHelper.SafeDiv(
-                    NumOps.Multiply(NumOps.FromDouble(2.0), numerator),
-                    NumOps.Multiply(denominator, denominator),
-                    NumericalStabilityHelper.SmallEpsilon
-                )
-            );
-        }
-
-        return new Vector<T>(result);
-    }
-
     /// <inheritdoc />
     public override Tensor<T> ComputeTapeLoss(Tensor<T> predicted, Tensor<T> target)
     {

--- a/src/LossFunctions/ElasticNetLoss.cs
+++ b/src/LossFunctions/ElasticNetLoss.cs
@@ -111,47 +111,6 @@ public class ElasticNetLoss<T> : LossFunctionBase<T>
     }
 
     /// <summary>
-    /// Calculates the derivative of the Elastic Net Loss function.
-    /// </summary>
-    /// <param name="predicted">The predicted values vector.</param>
-    /// <param name="actual">The actual (ground truth) values vector.</param>
-    /// <returns>A vector containing the derivatives of the elastic net loss with respect to each predicted value.</returns>
-    public override Vector<T> CalculateDerivative(Vector<T> predicted, Vector<T> actual)
-    {
-        ValidateVectorLengths(predicted, actual);
-
-        Vector<T> derivative = new Vector<T>(predicted.Length);
-        for (int i = 0; i < predicted.Length; i++)
-        {
-            // MSE gradient component: 2*(predicted - actual)/n
-            T mseGradient = NumOps.Multiply(
-                NumOps.FromDouble(2),
-                NumOps.Divide(
-                    NumOps.Subtract(predicted[i], actual[i]),
-                    NumOps.FromDouble(predicted.Length)
-                )
-            );
-
-            // L1 gradient component: a * l1Ratio * sign(predicted)
-            T l1Gradient = NumOps.Multiply(
-                NumOps.Multiply(_alpha, _l1Ratio),
-                SignOf(predicted[i])
-            );
-
-            // L2 gradient component: a * (1-l1Ratio) * predicted
-            T l2Gradient = NumOps.Multiply(
-                NumOps.Multiply(_alpha, NumOps.Subtract(NumOps.One, _l1Ratio)),
-                predicted[i]
-            );
-
-            // Combine all gradient components
-            derivative[i] = NumOps.Add(NumOps.Add(mseGradient, l1Gradient), l2Gradient);
-        }
-
-        return derivative;
-    }
-
-    /// <summary>
     /// Returns the sign of a value: -1 for negative, 1 for positive, 0 for zero.
     /// </summary>
     /// <param name="value">The value to determine the sign of.</param>

--- a/src/LossFunctions/ExponentialLoss.cs
+++ b/src/LossFunctions/ExponentialLoss.cs
@@ -61,30 +61,6 @@ public class ExponentialLoss<T> : LossFunctionBase<T>
     }
 
     /// <summary>
-    /// Calculates the derivative of the Exponential Loss function.
-    /// </summary>
-    /// <param name="predicted">The predicted values vector.</param>
-    /// <param name="actual">The actual (ground truth) values vector, typically -1 or 1.</param>
-    /// <returns>A vector containing the derivatives of the exponential loss with respect to each prediction.</returns>
-    public override Vector<T> CalculateDerivative(Vector<T> predicted, Vector<T> actual)
-    {
-        ValidateVectorLengths(predicted, actual);
-
-        Vector<T> derivative = new Vector<T>(predicted.Length);
-        for (int i = 0; i < predicted.Length; i++)
-        {
-            // -y * exp(-y * f(x))
-            T exponent = NumOps.Negate(NumOps.Multiply(actual[i], predicted[i]));
-            derivative[i] = NumOps.Multiply(
-                NumOps.Negate(actual[i]),
-                NumOps.Exp(exponent)
-            );
-        }
-
-        return derivative.Divide(NumOps.FromDouble(predicted.Length));
-    }
-
-    /// <summary>
     /// Calculates both Exponential loss and gradient on GPU in a single efficient pass.
     /// </summary>
     /// <param name="predicted">The predicted GPU tensor from the model.</param>

--- a/src/LossFunctions/FocalLoss.cs
+++ b/src/LossFunctions/FocalLoss.cs
@@ -101,42 +101,6 @@ public class FocalLoss<T> : LossFunctionBase<T>
     }
 
     /// <summary>
-    /// Calculates the derivative of the Focal Loss with respect to the predicted values.
-    /// </summary>
-    /// <param name="predicted">The predicted probabilities from the model.</param>
-    /// <param name="actual">The actual (target) values (typically 0 or 1).</param>
-    /// <returns>A vector containing the gradient of the loss with respect to each prediction.</returns>
-    public override Vector<T> CalculateDerivative(Vector<T> predicted, Vector<T> actual)
-    {
-        ValidateVectorLengths(predicted, actual);
-
-        var result = new T[predicted.Length];
-
-        for (int i = 0; i < predicted.Length; i++)
-        {
-            T p = NumericalStabilityHelper.ClampProbability(predicted[i], NumericalStabilityHelper.SmallEpsilon);
-            T y = actual[i];
-
-            T pt = NumOps.Equals(y, NumOps.One) ? p : NumOps.Subtract(NumOps.One, p);
-            T alphaT = NumOps.Equals(y, NumOps.One) ? _alpha : NumOps.Subtract(NumOps.One, _alpha);
-
-            T focusingTerm = NumOps.Power(NumOps.Subtract(NumOps.One, pt), _gamma);
-            T logPt = NumericalStabilityHelper.SafeLog(pt, NumericalStabilityHelper.SmallEpsilon);
-
-            // Derivative of focal loss with respect to p
-            T gammaFactor = NumOps.Multiply(_gamma, NumOps.Power(NumOps.Subtract(NumOps.One, pt), NumOps.Subtract(_gamma, NumOps.One)));
-            T term1 = NumOps.Multiply(gammaFactor, logPt);
-            T term2 = NumOps.Divide(focusingTerm, pt);
-
-            T grad = NumOps.Multiply(alphaT, NumOps.Subtract(term1, term2));
-
-            result[i] = NumOps.Equals(y, NumOps.One) ? grad : NumOps.Negate(grad);
-        }
-
-        return new Vector<T>(result).Divide(NumOps.FromDouble(predicted.Length));
-    }
-
-    /// <summary>
     /// Calculates both Focal Loss and gradient on GPU in a single efficient pass.
     /// </summary>
     /// <param name="predicted">The predicted GPU tensor from the model.</param>

--- a/src/LossFunctions/HingeLoss.cs
+++ b/src/LossFunctions/HingeLoss.cs
@@ -60,37 +60,6 @@ public class HingeLoss<T> : LossFunctionBase<T>
     }
 
     /// <summary>
-    /// Calculates the derivative of the Hinge loss function.
-    /// </summary>
-    /// <param name="predicted">The predicted values from the model.</param>
-    /// <param name="actual">The actual (target) values, typically -1 or 1.</param>
-    /// <returns>A vector containing the derivatives of Hinge loss for each prediction.</returns>
-    public override Vector<T> CalculateDerivative(Vector<T> predicted, Vector<T> actual)
-    {
-        ValidateVectorLengths(predicted, actual);
-
-        var result = new T[predicted.Length];
-
-        for (int i = 0; i < predicted.Length; i++)
-        {
-            T margin = NumOps.Subtract(NumOps.One, NumOps.Multiply(actual[i], predicted[i]));
-
-            if (NumOps.GreaterThan(margin, NumOps.Zero))
-            {
-                // Derivative is -y when margin > 0
-                result[i] = NumOps.Negate(actual[i]);
-            }
-            else
-            {
-                // Derivative is 0 when margin <= 0
-                result[i] = NumOps.Zero;
-            }
-        }
-
-        return new Vector<T>(result).Divide(NumOps.FromDouble(predicted.Length));
-    }
-
-    /// <summary>
     /// Calculates both Hinge loss and gradient on GPU in a single efficient pass.
     /// </summary>
     /// <param name="predicted">The predicted GPU tensor from the model.</param>

--- a/src/LossFunctions/HuberLoss.cs
+++ b/src/LossFunctions/HuberLoss.cs
@@ -90,38 +90,6 @@ public class HuberLoss<T> : LossFunctionBase<T>
     }
 
     /// <summary>
-    /// Calculates the derivative of the Huber loss function.
-    /// </summary>
-    /// <param name="predicted">The predicted values from the model.</param>
-    /// <param name="actual">The actual (target) values.</param>
-    /// <returns>A vector containing the derivatives of Huber loss for each prediction.</returns>
-    public override Vector<T> CalculateDerivative(Vector<T> predicted, Vector<T> actual)
-    {
-        ValidateVectorLengths(predicted, actual);
-
-        var result = new T[predicted.Length];
-
-        for (int i = 0; i < predicted.Length; i++)
-        {
-            T diff = NumOps.Subtract(predicted[i], actual[i]);
-            T absDiff = NumOps.Abs(diff);
-
-            if (NumOps.LessThanOrEquals(absDiff, _delta))
-            {
-                // Quadratic region: derivative is diff
-                result[i] = diff;
-            }
-            else
-            {
-                // Linear region: derivative is delta * sign(diff)
-                result[i] = NumOps.Multiply(_delta, NumOps.SignOrZero(diff));
-            }
-        }
-
-        return new Vector<T>(result).Divide(NumOps.FromDouble(predicted.Length));
-    }
-
-    /// <summary>
     /// Calculates both Huber loss and gradient on GPU in a single efficient pass.
     /// </summary>
     /// <param name="predicted">The predicted GPU tensor from the model.</param>

--- a/src/LossFunctions/JaccardLoss.cs
+++ b/src/LossFunctions/JaccardLoss.cs
@@ -79,52 +79,6 @@ public class JaccardLoss<T> : LossFunctionBase<T>
         return NumOps.Subtract(NumOps.One, NumericalStabilityHelper.SafeDiv(intersection, union, NumericalStabilityHelper.SmallEpsilon));
     }
 
-    /// <summary>
-    /// Calculates the derivative of the Jaccard loss function.
-    /// </summary>
-    /// <param name="predicted">The predicted values vector.</param>
-    /// <param name="actual">The actual (ground truth) values vector.</param>
-    /// <returns>A vector containing the derivatives of the Jaccard loss with respect to each predicted value.</returns>
-    public override Vector<T> CalculateDerivative(Vector<T> predicted, Vector<T> actual)
-    {
-        ValidateVectorLengths(predicted, actual);
-
-        // Soft IoU derivative: d(1 - IoU)/d(p_i)
-        // IoU = intersection / union
-        // intersection = Σ(p*a), union = Σp + Σa - Σ(p*a)
-        // d(IoU)/d(p_i) = (a_i * union - intersection * (1 - a_i)) / union²
-        // d(loss)/d(p_i) = -d(IoU)/d(p_i)
-        T intersection = NumOps.Zero;
-        T sumPredicted = NumOps.Zero;
-        T sumActual = NumOps.Zero;
-
-        for (int i = 0; i < predicted.Length; i++)
-        {
-            intersection = NumOps.Add(intersection, NumOps.Multiply(predicted[i], actual[i]));
-            sumPredicted = NumOps.Add(sumPredicted, predicted[i]);
-            sumActual = NumOps.Add(sumActual, actual[i]);
-        }
-
-        T union = NumOps.Subtract(NumOps.Add(sumPredicted, sumActual), intersection);
-        T unionSquared = NumOps.Multiply(union, union);
-
-        Vector<T> derivative = new Vector<T>(predicted.Length);
-        for (int i = 0; i < predicted.Length; i++)
-        {
-            // d(IoU)/d(p_i) = (a_i * union - intersection * (1 - a_i)) / union²
-            T numerator = NumOps.Subtract(
-                NumOps.Multiply(actual[i], union),
-                NumOps.Multiply(intersection, NumOps.Subtract(NumOps.One, actual[i]))
-            );
-            // loss = 1 - IoU, so derivative is negated
-            derivative[i] = NumOps.Negate(
-                NumericalStabilityHelper.SafeDiv(numerator, unionSquared, NumericalStabilityHelper.SmallEpsilon)
-            );
-        }
-
-        return derivative;
-    }
-
     /// <inheritdoc />
     public override Tensor<T> ComputeTapeLoss(Tensor<T> predicted, Tensor<T> target)
     {

--- a/src/LossFunctions/KullbackLeiblerDivergence.cs
+++ b/src/LossFunctions/KullbackLeiblerDivergence.cs
@@ -68,26 +68,6 @@ public class KullbackLeiblerDivergence<T> : LossFunctionBase<T>
         return sum;
     }
 
-    /// <summary>
-    /// Calculates the derivative of the Kullback-Leibler Divergence.
-    /// </summary>
-    /// <param name="predicted">The predicted probability distribution.</param>
-    /// <param name="actual">The actual (target) probability distribution.</param>
-    /// <returns>A vector containing the gradient of the KL divergence with respect to each prediction.</returns>
-    public override Vector<T> CalculateDerivative(Vector<T> predicted, Vector<T> actual)
-    {
-        ValidateVectorLengths(predicted, actual);
-
-        Vector<T> derivative = new Vector<T>(predicted.Length);
-        for (int i = 0; i < predicted.Length; i++)
-        {
-            // The derivative of KL(P||Q) with respect to Q is -P/Q
-            derivative[i] = NumOps.Negate(NumericalStabilityHelper.SafeDiv(actual[i], predicted[i], NumericalStabilityHelper.SmallEpsilon));
-        }
-
-        return derivative;
-    }
-
     /// <inheritdoc />
     public override Tensor<T> ComputeTapeLoss(Tensor<T> predicted, Tensor<T> target)
     {

--- a/src/LossFunctions/LogCoshLoss.cs
+++ b/src/LossFunctions/LogCoshLoss.cs
@@ -75,33 +75,6 @@ public class LogCoshLoss<T> : LossFunctionBase<T>
     }
 
     /// <summary>
-    /// Calculates the derivative of the Log-Cosh loss function.
-    /// </summary>
-    /// <param name="predicted">The predicted values from the model.</param>
-    /// <param name="actual">The actual (target) values.</param>
-    /// <returns>A vector containing the derivatives of Log-Cosh loss for each prediction.</returns>
-    public override Vector<T> CalculateDerivative(Vector<T> predicted, Vector<T> actual)
-    {
-        ValidateVectorLengths(predicted, actual);
-
-        var result = new T[predicted.Length];
-
-        for (int i = 0; i < predicted.Length; i++)
-        {
-            T diff = NumOps.Subtract(predicted[i], actual[i]);
-            // Derivative of log(cosh(x)) is tanh(x) = (e^x - e^-x) / (e^x + e^-x)
-            T expPos = NumOps.Exp(diff);
-            T expNeg = NumOps.Exp(NumOps.Negate(diff));
-            result[i] = NumOps.Divide(
-                NumOps.Subtract(expPos, expNeg),
-                NumOps.Add(expPos, expNeg)
-            );
-        }
-
-        return new Vector<T>(result).Divide(NumOps.FromDouble(predicted.Length));
-    }
-
-    /// <summary>
     /// Calculates both Log-Cosh loss and gradient on GPU in a single efficient pass.
     /// </summary>
     /// <param name="predicted">The predicted GPU tensor from the model.</param>

--- a/src/LossFunctions/LossFunctionBase.cs
+++ b/src/LossFunctions/LossFunctionBase.cs
@@ -36,43 +36,48 @@ public abstract class LossFunctionBase<T> : ILossFunction<T>
     public abstract T CalculateLoss(Vector<T> predicted, Vector<T> actual);
 
     /// <summary>
-    /// Calculates the derivative (gradient) of the loss function.
-    /// </summary>
-    /// <param name="predicted">The predicted values from the model.</param>
-    /// <param name="actual">The actual (target) values.</param>
-    /// <returns>A vector containing the derivatives of the loss with respect to each prediction.</returns>
-    public abstract Vector<T> CalculateDerivative(Vector<T> predicted, Vector<T> actual);
-
-    /// <summary>
     /// Computes the loss as a scalar tensor using tape-differentiable engine operations.
     /// Gradients flow through this computation automatically via the gradient tape.
     /// </summary>
     /// <param name="predicted">The predicted tensor from the forward pass.</param>
     /// <param name="target">The target tensor.</param>
-    /// <returns>A scalar tensor containing the loss value.</returns>
+    /// <returns>A rank-0 scalar tensor containing the loss value.</returns>
+    /// <remarks>
+    /// Implementations define their math here and nowhere else. There is no hand-written
+    /// derivative to keep in step with it, because the tape differentiates this method.
+    /// </remarks>
     public abstract Tensor<T> ComputeTapeLoss(Tensor<T> predicted, Tensor<T> target);
 
     /// <summary>
     /// Calculates both loss and gradient on GPU in a single pass.
-    /// Default implementation falls back to separate calls.
+    /// Default implementation differentiates <see cref="ComputeTapeLoss"/> on the CPU and uploads
+    /// the result; override to compute both in a single GPU kernel invocation.
     /// </summary>
     /// <param name="predicted">The predicted GPU tensor from the model.</param>
     /// <param name="actual">The actual (target) GPU tensor.</param>
     /// <returns>A tuple containing the loss value and gradient tensor.</returns>
+    /// <remarks>
+    /// <para>
+    /// The loss value and the gradient are read from a <b>single</b> tape recording rather than from
+    /// two independent computations. Previously this method called the forward and a separately
+    /// hand-written derivative, so the pair could disagree with no way to detect it; taking both from
+    /// one differentiated forward makes that class of mismatch unrepresentable.
+    /// </para>
+    /// <para>
+    /// The tape is scoped to this call because a GPU caller supplies already-materialized tensors and
+    /// has no surrounding tape to record onto. Callers that do own a training tape should record
+    /// <see cref="ComputeTapeLoss"/> on it directly instead of coming through here.
+    /// </para>
+    /// </remarks>
     public virtual (T Loss, Tensor<T> Gradient) CalculateLossAndGradientGpu(Tensor<T> predicted, Tensor<T> actual)
     {
-        // Default: fall back to CPU
-        var predictedCpu = predicted;
-        var actualCpu = actual;
-
-        var loss = CalculateLoss(predictedCpu.ToVector(), actualCpu.ToVector());
-        var gradientCpu = CalculateDerivative(predictedCpu.ToVector(), actualCpu.ToVector());
-
-        var gradientTensor = new Tensor<T>(predictedCpu._shape);
-        Array.Copy(gradientCpu.ToArray(), gradientTensor.Data.ToArray(), gradientCpu.Length);
+        if (predicted is null) throw new ArgumentNullException(nameof(predicted));
+        if (actual is null) throw new ArgumentNullException(nameof(actual));
 
         var engine = AiDotNetEngine.Current as DirectGpuTensorEngine;
         var backend = engine?.GetBackend() ?? throw new InvalidOperationException("GPU backend not available");
+
+        var (loss, gradientTensor) = LossFunctionExtensions.ComputeLossAndGradient<T>(this, predicted, actual);
         var gradientGpu = GpuTensorHelper.UploadToGpu<T>(backend, gradientTensor, GpuTensorRole.Gradient);
 
         return (loss, gradientGpu);

--- a/src/LossFunctions/MarginLoss.cs
+++ b/src/LossFunctions/MarginLoss.cs
@@ -84,42 +84,6 @@ public class MarginLoss<T> : LossFunctionBase<T>
         return NumOps.Divide(loss, NumOps.FromDouble(predicted.Length));
     }
 
-    /// <summary>
-    /// Calculates the derivative of the Margin loss function.
-    /// </summary>
-    /// <param name="predicted">The predicted values from the model.</param>
-    /// <param name="actual">The actual (target) values.</param>
-    /// <returns>A vector containing the derivatives of Margin loss for each prediction.</returns>
-    public override Vector<T> CalculateDerivative(Vector<T> predicted, Vector<T> actual)
-    {
-        ValidateVectorLengths(predicted, actual);
-
-        Vector<T> derivative = new Vector<T>(predicted.Length);
-        for (int i = 0; i < predicted.Length; i++)
-        {
-            T v = predicted[i];
-            T y = actual[i];
-
-            T term1 = NumOps.Multiply(y, NumOps.Subtract(_mPlus, v));
-            T term2 = NumOps.Multiply(NumOps.Subtract(NumOps.One, y), NumOps.Subtract(v, _mMinus));
-
-            if (NumOps.GreaterThan(term1, NumOps.Zero))
-            {
-                derivative[i] = NumOps.Negate(NumOps.Multiply(NumOps.FromDouble(2), term1));
-            }
-            else if (NumOps.GreaterThan(term2, NumOps.Zero))
-            {
-                derivative[i] = NumOps.Multiply(_lambda, NumOps.Multiply(NumOps.FromDouble(2), term2));
-            }
-            else
-            {
-                derivative[i] = NumOps.Zero;
-            }
-        }
-
-        return derivative.Divide(NumOps.FromDouble(predicted.Length));
-    }
-
     /// <inheritdoc />
     public override Tensor<T> ComputeTapeLoss(Tensor<T> predicted, Tensor<T> target)
     {

--- a/src/LossFunctions/MeanAbsoluteErrorLoss.cs
+++ b/src/LossFunctions/MeanAbsoluteErrorLoss.cs
@@ -46,34 +46,6 @@ public class MeanAbsoluteErrorLoss<T> : LossFunctionBase<T>
         return StatisticsHelper<T>.CalculateMeanAbsoluteError(predicted, actual);
     }
 
-    /// <summary>
-    /// Calculates the derivative of the Mean Absolute Error loss function.
-    /// </summary>
-    /// <param name="predicted">The predicted values from the model.</param>
-    /// <param name="actual">The actual (target) values.</param>
-    /// <returns>A vector containing the derivatives of MAE for each prediction.</returns>
-    /// <remarks>
-    /// The derivative of MAE is sign(predicted-actual)/n where:
-    /// - sign(x) = 1 if x > 0
-    /// - sign(x) = -1 if x &lt; 0
-    /// - sign(x) = 0 if x = 0 (subgradient at the kink point)
-    /// </remarks>
-    public override Vector<T> CalculateDerivative(Vector<T> predicted, Vector<T> actual)
-    {
-        ValidateVectorLengths(predicted, actual);
-
-        // The derivative of MAE is sign(predicted-actual)/n
-        return predicted.Subtract(actual).Transform(x =>
-        {
-            if (NumOps.GreaterThan(x, NumOps.Zero))
-                return NumOps.One;
-            else if (NumOps.LessThan(x, NumOps.Zero))
-                return NumOps.FromDouble(-1);
-            else
-                return NumOps.Zero; // Subgradient at 0
-        }).Divide(NumOps.FromDouble(predicted.Length));
-    }
-
     /// <inheritdoc />
     public override Tensor<T> ComputeTapeLoss(Tensor<T> predicted, Tensor<T> target)
     {

--- a/src/LossFunctions/MeanBiasErrorLoss.cs
+++ b/src/LossFunctions/MeanBiasErrorLoss.cs
@@ -67,33 +67,6 @@ public class MeanBiasErrorLoss<T> : LossFunctionBase<T>
         return NumOps.Divide(sum, NumOps.FromDouble(predicted.Length));
     }
 
-    /// <summary>
-    /// Calculates the derivative of the Mean Bias Error loss function.
-    /// </summary>
-    /// <param name="predicted">The predicted values from the model.</param>
-    /// <param name="actual">The actual (target) values.</param>
-    /// <returns>A vector containing the derivatives of MBE for each prediction.</returns>
-    /// <remarks>
-    /// The derivative is constant: d(MBE)/d(predicted) = -1/n for all elements.
-    /// This means each prediction contributes equally to reducing bias, regardless of the current error.
-    /// </remarks>
-    public override Vector<T> CalculateDerivative(Vector<T> predicted, Vector<T> actual)
-    {
-        ValidateVectorLengths(predicted, actual);
-
-        // The derivative of MBE with respect to predicted is -1/n for all elements
-        T derivativeValue = NumOps.Negate(NumOps.Divide(NumOps.One, NumOps.FromDouble(predicted.Length)));
-
-        // Create a vector filled with this constant derivative
-        Vector<T> derivative = new Vector<T>(predicted.Length);
-        for (int i = 0; i < predicted.Length; i++)
-        {
-            derivative[i] = derivativeValue;
-        }
-
-        return derivative;
-    }
-
     /// <inheritdoc />
     public override Tensor<T> ComputeTapeLoss(Tensor<T> predicted, Tensor<T> target)
     {

--- a/src/LossFunctions/MeanBiasErrorLoss.cs
+++ b/src/LossFunctions/MeanBiasErrorLoss.cs
@@ -70,7 +70,13 @@ public class MeanBiasErrorLoss<T> : LossFunctionBase<T>
     /// <inheritdoc />
     public override Tensor<T> ComputeTapeLoss(Tensor<T> predicted, Tensor<T> target)
     {
-        var diff = Engine.TensorSubtract(predicted, target);
+        // MBE = mean(actual - predicted), matching CalculateLoss above. This subtracted in the
+        // opposite order, so the tape forward and the vector forward were the same loss with
+        // opposite SIGNS: the value the model reported and the value it trained against
+        // disagreed, and gradient descent on this loss ascended it. The mismatch was invisible
+        // while gradients came from a hand-written derivative that happened to agree with
+        // CalculateLoss rather than with the tape.
+        var diff = Engine.TensorSubtract(target, predicted);
         var allAxes = Enumerable.Range(0, diff.Shape.Length).ToArray();
         return Engine.ReduceMean(diff, allAxes, keepDims: false);
     }

--- a/src/LossFunctions/MeanSquaredErrorLoss.cs
+++ b/src/LossFunctions/MeanSquaredErrorLoss.cs
@@ -45,22 +45,6 @@ public class MeanSquaredErrorLoss<T> : LossFunctionBase<T>
         return StatisticsHelper<T>.CalculateMeanSquaredError(predicted, actual);
     }
 
-    /// <summary>
-    /// Calculates the derivative of the Mean Squared Error loss function.
-    /// </summary>
-    /// <param name="predicted">The predicted values from the model.</param>
-    /// <param name="actual">The actual (target) values.</param>
-    /// <returns>A vector containing the derivatives of MSE for each prediction.</returns>
-    public override Vector<T> CalculateDerivative(Vector<T> predicted, Vector<T> actual)
-    {
-        ValidateVectorLengths(predicted, actual);
-
-        // The derivative of MSE is 2*(predicted-actual)/n
-        return predicted.Subtract(actual).Transform(x =>
-            NumOps.Multiply(NumOps.FromDouble(2), x)
-        ).Divide(NumOps.FromDouble(predicted.Length));
-    }
-
     /// <inheritdoc />
     public override Tensor<T> ComputeTapeLoss(Tensor<T> predicted, Tensor<T> target)
     {

--- a/src/LossFunctions/ModifiedHuberLoss.cs
+++ b/src/LossFunctions/ModifiedHuberLoss.cs
@@ -71,48 +71,6 @@ public class ModifiedHuberLoss<T> : LossFunctionBase<T>
     }
 
     /// <summary>
-    /// Calculates the derivative of the Modified Huber Loss function.
-    /// </summary>
-    /// <param name="predicted">The predicted values vector.</param>
-    /// <param name="actual">The actual (ground truth) values vector, typically -1 or 1.</param>
-    /// <returns>A vector containing the derivatives of the modified huber loss with respect to each prediction.</returns>
-    public override Vector<T> CalculateDerivative(Vector<T> predicted, Vector<T> actual)
-    {
-        ValidateVectorLengths(predicted, actual);
-
-        Vector<T> derivative = new Vector<T>(predicted.Length);
-        for (int i = 0; i < predicted.Length; i++)
-        {
-            // z = y * f(x)
-            T z = NumOps.Multiply(actual[i], predicted[i]);
-
-            if (NumOps.GreaterThanOrEquals(z, NumOps.FromDouble(-1)))
-            {
-                if (NumOps.LessThan(z, NumOps.One))
-                {
-                    // For -1 = z < 1: -2 * y * (1 - z)
-                    derivative[i] = NumOps.Multiply(
-                        NumOps.Multiply(NumOps.FromDouble(-2), actual[i]),
-                        NumOps.Subtract(NumOps.One, z)
-                    );
-                }
-                else
-                {
-                    // For z = 1: 0
-                    derivative[i] = NumOps.Zero;
-                }
-            }
-            else
-            {
-                // For z < -1: -4 * y
-                derivative[i] = NumOps.Multiply(NumOps.FromDouble(-4), actual[i]);
-            }
-        }
-
-        return derivative.Divide(NumOps.FromDouble(predicted.Length));
-    }
-
-    /// <summary>
     /// Calculates both Modified Huber loss and gradient on GPU in a single efficient pass.
     /// </summary>
     /// <param name="predicted">The predicted GPU tensor from the model.</param>

--- a/src/LossFunctions/NoiseContrastiveEstimationLoss.cs
+++ b/src/LossFunctions/NoiseContrastiveEstimationLoss.cs
@@ -97,53 +97,6 @@ public class NoiseContrastiveEstimationLoss<T> : LossFunctionBase<T>
         return NumOps.Divide(loss, NumOps.FromDouble(targetLogits.Length));
     }
 
-    /// <summary>
-    /// Calculates the gradient of the NCE loss function.
-    /// </summary>
-    /// <param name="targetLogits">The logits for the true target samples.</param>
-    /// <param name="noiseLogits">The logits for the noise samples.</param>
-    /// <returns>A tuple containing the gradients for target and noise logits.</returns>
-    public (Vector<T>, Matrix<T>) CalculateDerivative(Vector<T> targetLogits, Matrix<T> noiseLogits)
-    {
-        // Ensure dimensions match
-        if (targetLogits.Length != noiseLogits.Rows)
-        {
-            throw new ArgumentException("Number of target samples must match number of rows in noise samples.");
-        }
-
-        if (noiseLogits.Columns != _numNoiseSamples)
-        {
-            throw new ArgumentException("Number of noise samples per target must match the configured value.");
-        }
-
-        Vector<T> targetGradient = new Vector<T>(targetLogits.Length);
-        Matrix<T> noiseGradient = new Matrix<T>(noiseLogits.Rows, noiseLogits.Columns);
-
-        for (int i = 0; i < targetLogits.Length; i++)
-        {
-            // P(target is real | target)
-            T targetProb = Sigmoid(targetLogits[i]);
-
-            // -(1 - P(target is real | target))
-            targetGradient[i] = NumOps.Negate(NumOps.Subtract(NumOps.One, targetProb));
-
-            for (int j = 0; j < _numNoiseSamples; j++)
-            {
-                // P(noise is real | noise)
-                T noiseProb = Sigmoid(noiseLogits[i, j]);
-
-                // P(noise is real | noise)
-                noiseGradient[i, j] = noiseProb;
-            }
-        }
-
-        // Scale by batch size
-        T scale = NumOps.Divide(NumOps.One, NumOps.FromDouble(targetLogits.Length));
-        targetGradient = targetGradient.Transform(x => NumOps.Multiply(x, scale));
-        noiseGradient = noiseGradient.Transform((x, _, __) => NumOps.Multiply(x, scale));
-
-        return (targetGradient, noiseGradient);
-    }
 
     /// <summary>
     /// This method is not used for NCE Loss as it requires specific input formats.

--- a/src/LossFunctions/NoiseContrastiveEstimationLoss.cs
+++ b/src/LossFunctions/NoiseContrastiveEstimationLoss.cs
@@ -161,21 +161,6 @@ public class NoiseContrastiveEstimationLoss<T> : LossFunctionBase<T>
     }
 
     /// <summary>
-    /// This method is not used for NCE Loss as it requires specific input formats.
-    /// </summary>
-    /// <param name="predicted">The predicted values vector.</param>
-    /// <param name="actual">The actual (target) values vector.</param>
-    /// <returns>Throws NotSupportedException.</returns>
-    /// <exception cref="NotSupportedException">Always thrown as NCE Loss requires specific input formats.</exception>
-    public override Vector<T> CalculateDerivative(Vector<T> predicted, Vector<T> actual)
-    {
-        throw new NotSupportedException(
-            "NCE Loss requires specific input formats. " +
-            "Use the CalculateDerivative(Vector<T>, Matrix<T>) method instead."
-        );
-    }
-
-    /// <summary>
     /// Applies the sigmoid function to a scalar value.
     /// </summary>
     /// <param name="x">The input value.</param>

--- a/src/LossFunctions/NoiseContrastiveEstimationLoss.cs
+++ b/src/LossFunctions/NoiseContrastiveEstimationLoss.cs
@@ -181,6 +181,19 @@ public class NoiseContrastiveEstimationLoss<T> : LossFunctionBase<T>
     /// </remarks>
     public override Tensor<T> ComputeTapeLoss(Tensor<T> predicted, Tensor<T> target)
     {
+        // NCE is not a pointwise (predicted, actual) loss: `target` carries the NOISE LOGITS,
+        // one row of K samples per example, and the noise term reduces over that second axis.
+        // A rank-1 argument used to reach ReduceSum(axis: 1) and fail there with an axis-range
+        // message that said nothing about NCE.
+        if (target.Rank < 2)
+        {
+            throw new ArgumentException(
+                "NoiseContrastiveEstimationLoss expects the second argument to be the noise "
+                + $"logits with shape [batch, numNoiseSamples], but it has rank {target.Rank}. "
+                + "Use Calculate(Vector targetLogits, Matrix noiseLogits) for the vector API.",
+                nameof(target));
+        }
+
         // Target term: -log(sigma(predicted))
         var targetSigmoid = Engine.TensorSigmoid(predicted);
         var eps = NumOps.FromDouble(1e-7);

--- a/src/LossFunctions/OrdinalRegressionLoss.cs
+++ b/src/LossFunctions/OrdinalRegressionLoss.cs
@@ -90,43 +90,6 @@ public class OrdinalRegressionLoss<T> : LossFunctionBase<T>
         return loss;
     }
 
-    /// <summary>
-    /// Calculates the derivative of the Ordinal Regression Loss function.
-    /// </summary>
-    /// <param name="predicted">The predicted values vector.</param>
-    /// <param name="actual">The actual (ground truth) values vector, typically integers representing ordinal categories.</param>
-    /// <returns>A vector containing the derivatives of the ordinal regression loss with respect to each prediction.</returns>
-    public override Vector<T> CalculateDerivative(Vector<T> predicted, Vector<T> actual)
-    {
-        ValidateVectorLengths(predicted, actual);
-
-        Vector<T> derivative = new Vector<T>(predicted.Length);
-        for (int i = 0; i < predicted.Length; i++)
-        {
-            T sum = NumOps.Zero;
-            for (int j = 0; j < _numClasses - 1; j++)
-            {
-                // Binary indicator: 1 if actual > j, 0 otherwise
-                T indicator = NumOps.GreaterThan(actual[i], NumOps.FromDouble(j)) ?
-                    NumOps.One : NumOps.Zero;
-
-                // exp(-indicator * predicted)
-                T expTerm = NumOps.Exp(NumOps.Negate(NumOps.Multiply(indicator, predicted[i])));
-
-                // -indicator * exp(-indicator * predicted) / (1 + exp(-indicator * predicted))
-                T term = NumOps.Divide(
-                    NumOps.Negate(NumOps.Multiply(indicator, expTerm)),
-                    NumOps.Add(NumOps.One, expTerm)
-                );
-
-                sum = NumOps.Add(sum, term);
-            }
-            derivative[i] = sum;
-        }
-
-        return derivative;
-    }
-
     /// <inheritdoc />
     public override Tensor<T> ComputeTapeLoss(Tensor<T> predicted, Tensor<T> target)
     {

--- a/src/LossFunctions/PairwiseRankingLoss.cs
+++ b/src/LossFunctions/PairwiseRankingLoss.cs
@@ -228,113 +228,78 @@ public class PairwiseRankingLoss<T> : LossFunctionBase<T>
     }
 
     /// <summary>
-    /// Calculates the gradient of the (tail-weighted) pairwise RankNet loss with respect to each
-    /// predicted score.
-    /// </summary>
-    /// <param name="predicted">The predicted scores, one per item in the ranking group.</param>
-    /// <param name="actual">The true relevance/return values, one per item.</param>
-    /// <returns>A vector of partial derivatives dL/ds_k, one per item.</returns>
-    /// <remarks>
-    /// For a single pair (i, j) with i the true winner, dloss/ds_i = -sigma(-(s_i - s_j)) and
-    /// dloss/ds_j = +sigma(-(s_i - s_j)). These contributions accumulate over every pair an item
-    /// participates in, each scaled by the pair weight and divided by the total weight so the
-    /// gradient matches the averaged loss above.
-    /// </remarks>
-    public override Vector<T> CalculateDerivative(Vector<T> predicted, Vector<T> actual)
-    {
-        ValidateVectorLengths(predicted, actual);
-
-        int n = predicted.Length;
-        var extremity = ComputeExtremities(actual);
-        var grad = new double[n];
-
-        double weightSum = 0.0;
-
-        for (int i = 0; i < n; i++)
-        {
-            double ai = NumOps.ToDouble(actual[i]);
-            double si = NumOps.ToDouble(predicted[i]);
-            for (int j = 0; j < n; j++)
-            {
-                double aj = NumOps.ToDouble(actual[j]);
-                if (ai <= aj) continue;
-
-                double sj = NumOps.ToDouble(predicted[j]);
-                double w = PairWeight(extremity, i, j);
-
-                // d/ds_i log(1+exp(-(s_i - s_j))) = -sigmoid(-(s_i - s_j))
-                double g = Sigmoid(-(si - sj));
-                grad[i] += w * (-g);
-                grad[j] += w * (g);
-                weightSum += w;
-            }
-        }
-
-        var result = new T[n];
-        if (weightSum <= 0.0)
-        {
-            for (int k = 0; k < n; k++) result[k] = NumOps.Zero;
-            return new Vector<T>(result);
-        }
-
-        for (int k = 0; k < n; k++)
-        {
-            // Per-item normalization (÷ n), consistent with CalculateLoss — the RankNet per-pair gradient
-            // accumulation, scaled so the per-item gradient is O(1) at any group size rather than O(1/n).
-            result[k] = NumOps.FromDouble(grad[k] / n);
-        }
-
-        return new Vector<T>(result);
-    }
-
-    /// <summary>
     /// Computes the loss as a tape-differentiable scalar tensor for automatic backpropagation.
     /// </summary>
     /// <param name="predicted">The predicted scores tensor from the forward pass.</param>
     /// <param name="target">The true relevance/return tensor.</param>
-    /// <returns>A scalar tensor whose gradient w.r.t. <paramref name="predicted"/> equals the analytic RankNet gradient.</returns>
+    /// <returns>A rank-0 scalar tensor holding the weighted RankNet loss.</returns>
     /// <remarks>
     /// <para>
-    /// The pairwise RankNet objective is not a pointwise function of the predictions, so it cannot
-    /// be expressed directly with the broadcasting tensor primitives. Instead this builds a
-    /// first-order surrogate scalar
+    /// RankNet is a genuinely pairwise objective, so the forward is built over the full n x n grid of
+    /// score differences rather than element-wise. The grid is formed with two rank-1 matrix products
+    /// against constant one-vectors -- <c>A[i,j] = s_i</c> and <c>B[i,j] = s_j</c> -- because the
+    /// element-wise engine operations require matching shapes and do not broadcast.
     /// </para>
     /// <para>
-    /// L_tape = &#931;_k predicted_k * stopgrad(g_k)
+    /// L = (1/n) * sum_ij W[i,j] * softplus(-(s_i - s_j))
     /// </para>
     /// <para>
-    /// where g_k is the exact analytic gradient from <see cref="CalculateDerivative"/> treated as a
-    /// constant (no gradient flows through the target side). Because dL_tape/dpredicted_k = g_k,
-    /// the gradient that flows back through the tape is exactly the RankNet gradient, which is all
-    /// the optimizer needs. The reported scalar value is the true RankNet loss for monitoring.
+    /// <c>W</c> depends only on the targets -- it is the tail weight where <c>a_i &gt; a_j</c> and zero
+    /// elsewhere, so ties and reversed pairs drop out -- which makes it a constant with respect to the
+    /// predictions and therefore safe to materialize outside the tape.
+    /// </para>
+    /// <para>
+    /// Normalization is per ITEM (divide by n), not per pair. Dividing by the pair count (~n^2) shrinks
+    /// the per-item gradient to O(1/n), which is too weak for the optimizer to learn from on larger
+    /// groups and collapses the model to a constant output.
     /// </para>
     /// </remarks>
     public override Tensor<T> ComputeTapeLoss(Tensor<T> predicted, Tensor<T> target)
     {
-        var predVec = predicted.ToVector();
         var targetVec = target.ToVector();
+        int n = targetVec.Length;
 
-        // Constant analytic gradient (the target side carries no gradient).
-        var g = CalculateDerivative(predVec, targetVec);
-        var gradConst = new Tensor<T>(predicted._shape, g);
-
-        // L_tape = sum(predicted * g)  =>  dL_tape/dpredicted = g  (g is a leaf constant).
-        var weighted = Engine.TensorMultiply(predicted, gradConst);
-        var allAxes = Enumerable.Range(0, weighted.Shape.Length).ToArray();
-        var surrogate = Engine.ReduceSum(weighted, allAxes, keepDims: false);
-
-        // Add the true loss as a detached constant so GetLastLoss reports a meaningful value
-        // without changing the gradient (constant => zero gradient contribution).
-        double trueLoss = NumOps.ToDouble(CalculateLoss(predVec, targetVec));
-        double surrogateValue = 0.0;
-        for (int k = 0; k < predVec.Length; k++)
+        if (predicted.Length != n)
         {
-            surrogateValue += NumOps.ToDouble(predVec[k]) * NumOps.ToDouble(g[k]);
+            throw new ArgumentException(
+                $"Predicted length ({predicted.Length}) must match target length ({n}).",
+                nameof(predicted));
         }
 
-        // surrogate currently equals surrogateValue; shift it to report trueLoss while keeping
-        // the same gradient (adding a scalar constant does not change the derivative).
-        var shift = NumOps.FromDouble(trueLoss - surrogateValue);
-        return Engine.TensorAddScalar(surrogate, shift);
+        // Pair weights are a function of the targets alone, so they are a tape constant.
+        var extremity = ComputeExtremities(targetVec);
+        var weights = new Tensor<T>(new[] { n, n });
+        for (int i = 0; i < n; i++)
+        {
+            double ai = NumOps.ToDouble(targetVec[i]);
+            for (int j = 0; j < n; j++)
+            {
+                // Only ordered pairs where i is the true winner contribute; ties contribute nothing.
+                if (ai <= NumOps.ToDouble(targetVec[j])) continue;
+                weights[(i * n) + j] = NumOps.FromDouble(PairWeight(extremity, i, j));
+            }
+        }
+
+        var onesRow = new Tensor<T>(new[] { 1, n });
+        var onesCol = new Tensor<T>(new[] { n, 1 });
+        for (int k = 0; k < n; k++)
+        {
+            onesRow[k] = NumOps.One;
+            onesCol[k] = NumOps.One;
+        }
+
+        var scoreCol = Engine.Reshape(predicted, new[] { n, 1 });
+        var scoreRow = Engine.Reshape(predicted, new[] { 1, n });
+
+        var sI = Engine.TensorMatMul(scoreCol, onesRow);   // [n,n], sI[i,j] = s_i
+        var sJ = Engine.TensorMatMul(onesCol, scoreRow);   // [n,n], sJ[i,j] = s_j
+
+        var negDiff = Engine.TensorMultiplyScalar(
+            Engine.TensorSubtract(sI, sJ), NumOps.FromDouble(-1.0));
+
+        var perPair = Engine.TensorMultiply(Engine.Softplus(negDiff), weights);
+        var summed = Engine.ReduceSum(perPair, new[] { 0, 1 }, keepDims: false);
+
+        return Engine.TensorDivideScalar(summed, NumOps.FromDouble(n));
     }
 }

--- a/src/LossFunctions/PerceptualLoss.cs
+++ b/src/LossFunctions/PerceptualLoss.cs
@@ -142,20 +142,6 @@ public class PerceptualLoss<T> : LossFunctionBase<T>
     }
 
     /// <summary>
-    /// This method is not used for Perceptual Loss as it requires image matrices.
-    /// </summary>
-    /// <param name="predicted">The predicted values vector.</param>
-    /// <param name="actual">The actual (target) values vector.</param>
-    /// <returns>Throws NotSupportedException.</returns>
-    /// <exception cref="NotSupportedException">Always thrown as Perceptual Loss requires image matrices.</exception>
-    public override Vector<T> CalculateDerivative(Vector<T> predicted, Vector<T> actual)
-    {
-        throw new NotSupportedException(
-            "Perceptual Loss requires image matrices and is typically calculated using automatic differentiation."
-        );
-    }
-
-    /// <summary>
     /// Optional neural network feature extractor for tape-based training.
     /// Set via <see cref="SetFeatureExtractorNetwork"/> before calling <see cref="ComputeTapeLoss"/>.
     /// </summary>

--- a/src/LossFunctions/PoissonLoss.cs
+++ b/src/LossFunctions/PoissonLoss.cs
@@ -71,26 +71,6 @@ public class PoissonLoss<T> : LossFunctionBase<T>
     }
 
     /// <summary>
-    /// Calculates the derivative of the Poisson loss function.
-    /// </summary>
-    /// <param name="predicted">The predicted values from the model (should be positive).</param>
-    /// <param name="actual">The actual (target) values (typically counts or rates).</param>
-    /// <returns>A vector containing the gradient of the loss with respect to each prediction.</returns>
-    public override Vector<T> CalculateDerivative(Vector<T> predicted, Vector<T> actual)
-    {
-        ValidateVectorLengths(predicted, actual);
-
-        Vector<T> derivative = new Vector<T>(predicted.Length);
-        for (int i = 0; i < predicted.Length; i++)
-        {
-            // The derivative is 1 - actual/predicted
-            derivative[i] = NumOps.Subtract(NumOps.One, NumericalStabilityHelper.SafeDiv(actual[i], predicted[i], NumericalStabilityHelper.SmallEpsilon));
-        }
-
-        return derivative.Divide(NumOps.FromDouble(predicted.Length));
-    }
-
-    /// <summary>
     /// Calculates both Poisson loss and gradient on GPU in a single efficient pass.
     /// </summary>
     /// <param name="predicted">The predicted GPU tensor from the model.</param>

--- a/src/LossFunctions/QuantileLoss.cs
+++ b/src/LossFunctions/QuantileLoss.cs
@@ -89,37 +89,6 @@ public class QuantileLoss<T> : LossFunctionBase<T>
     }
 
     /// <summary>
-    /// Calculates the derivative of the Quantile loss function.
-    /// </summary>
-    /// <param name="predicted">The predicted values from the model.</param>
-    /// <param name="actual">The actual (target) values.</param>
-    /// <returns>A vector containing the derivatives of Quantile loss for each prediction.</returns>
-    public override Vector<T> CalculateDerivative(Vector<T> predicted, Vector<T> actual)
-    {
-        ValidateVectorLengths(predicted, actual);
-
-        var result = new T[predicted.Length];
-
-        for (int i = 0; i < predicted.Length; i++)
-        {
-            T diff = NumOps.Subtract(actual[i], predicted[i]);
-
-            if (NumOps.GreaterThan(diff, NumOps.Zero))
-            {
-                // Underestimation: derivative is -quantile
-                result[i] = NumOps.Negate(_quantile);
-            }
-            else
-            {
-                // Overestimation: derivative is (1 - quantile)
-                result[i] = NumOps.Subtract(NumOps.One, _quantile);
-            }
-        }
-
-        return new Vector<T>(result).Divide(NumOps.FromDouble(predicted.Length));
-    }
-
-    /// <summary>
     /// Calculates both Quantile loss and gradient on GPU in a single efficient pass.
     /// </summary>
     /// <param name="predicted">The predicted GPU tensor from the model.</param>

--- a/src/LossFunctions/QuantumLoss.cs
+++ b/src/LossFunctions/QuantumLoss.cs
@@ -49,41 +49,6 @@ public class QuantumLoss<T> : LossFunctionBase<T>
         return NumOps.Subtract(NumOps.One, fidelity);
     }
 
-    /// <summary>
-    /// Calculates the derivative of the quantum loss function.
-    /// </summary>
-    /// <param name="predicted">The predicted quantum state.</param>
-    /// <param name="expected">The expected quantum state.</param>
-    /// <returns>The gradient of the loss with respect to the predicted values.</returns>
-    public override Vector<T> CalculateDerivative(Vector<T> predicted, Vector<T> expected)
-    {
-        if (predicted.Length != expected.Length)
-            throw new ArgumentException("Predicted and expected vectors must have the same length.");
-
-        var complexOps = MathHelper.GetNumericOperations<Complex<T>>();
-        var gradient = new Vector<T>(predicted.Length);
-
-        for (int i = 0; i < predicted.Length; i += 2)
-        {
-            Complex<T> predictedComplex = new(predicted[i], predicted[i + 1]);
-            Complex<T> expectedComplex = new(expected[i], expected[i + 1]);
-
-            T magnitude = NumOps.Sqrt(NumOps.Add(
-                NumOps.Multiply(predictedComplex.Real, predictedComplex.Real),
-                NumOps.Multiply(predictedComplex.Imaginary, predictedComplex.Imaginary)
-            ));
-
-            Complex<T> gradientComplex = complexOps.Multiply(expectedComplex.Conjugate(),
-                new Complex<T>(NumOps.Divide(NumOps.One, magnitude), NumOps.Zero)
-            );
-
-            gradient[i] = gradientComplex.Real;
-            gradient[i + 1] = gradientComplex.Imaginary;
-        }
-
-        return gradient;
-    }
-
     /// <inheritdoc />
     /// <remarks>
     /// Quantum fidelity loss on interleaved complex representation [re0, im0, re1, im1, ...].

--- a/src/LossFunctions/RealESRGANLoss.cs
+++ b/src/LossFunctions/RealESRGANLoss.cs
@@ -271,27 +271,6 @@ public class RealESRGANLoss<T> : LossFunctionBase<T>
     }
 
     /// <summary>
-    /// Calculates the derivative of the combined loss for backpropagation.
-    /// </summary>
-    /// <param name="predicted">The predicted values.</param>
-    /// <param name="actual">The actual (target) values.</param>
-    /// <returns>The gradient vector.</returns>
-    public override Vector<T> CalculateDerivative(Vector<T> predicted, Vector<T> actual)
-    {
-        ValidateVectorLengths(predicted, actual);
-
-        // L1 loss derivative: sign(predicted - actual) / n
-        Vector<T> l1Gradient = _l1Loss.CalculateDerivative(predicted, actual);
-
-        // Scale by L1 weight
-        l1Gradient = l1Gradient.Multiply(NumOps.FromDouble(_l1Weight));
-
-        // Note: Perceptual and GAN gradients are computed separately in the training loop
-        // as they require the feature extractor network and discriminator
-        return l1Gradient;
-    }
-
-    /// <summary>
     /// Calculates the L2 distance between feature tensors.
     /// </summary>
     private T CalculateFeatureLoss(Tensor<T> predictedFeatures, Tensor<T> actualFeatures)

--- a/src/LossFunctions/RootMeanSquaredErrorLoss.cs
+++ b/src/LossFunctions/RootMeanSquaredErrorLoss.cs
@@ -45,6 +45,11 @@ public class RootMeanSquaredErrorLoss<T> : LossFunctionBase<T>
         var squared = Engine.TensorMultiply(diff, diff);
         var allAxes = Enumerable.Range(0, squared.Shape.Length).ToArray();
         var mse = Engine.ReduceMean(squared, allAxes, keepDims: false);
-        return Engine.TensorSqrt(mse);
+
+        // Offset before the square root. d(sqrt(x))/dx = 1/(2*sqrt(x)) is unbounded as x -> 0, so
+        // a PERFECT prediction -- mse exactly 0 -- produced 0 * infinity = NaN and poisoned every
+        // downstream parameter gradient. The offset is far below any meaningful loss, and it makes
+        // the gradient at a perfect fit 0, which is the mathematically right answer there.
+        return Engine.TensorSqrt(Engine.TensorAddScalar(mse, NumOps.FromDouble(1e-12)));
     }
 }

--- a/src/LossFunctions/RootMeanSquaredErrorLoss.cs
+++ b/src/LossFunctions/RootMeanSquaredErrorLoss.cs
@@ -38,33 +38,6 @@ public class RootMeanSquaredErrorLoss<T> : LossFunctionBase<T>
         return StatisticsHelper<T>.CalculateRootMeanSquaredError(predicted, actual);
     }
 
-    /// <summary>
-    /// Calculates the derivative of the RMSE loss with respect to predicted values.
-    /// </summary>
-    /// <param name="predicted">The predicted values.</param>
-    /// <param name="actual">The actual (ground truth) values.</param>
-    /// <returns>A vector of gradients for each predicted value.</returns>
-    /// <exception cref="ArgumentException">Thrown when predicted and actual vectors have different lengths.</exception>
-    public override Vector<T> CalculateDerivative(Vector<T> predicted, Vector<T> actual)
-    {
-        ValidateVectorLengths(predicted, actual);
-
-        var diff = predicted - actual;
-        var mse = diff.PointwiseMultiply(diff).Average();
-        var rmse = NumOps.Sqrt(mse);
-
-        if (NumOps.Equals(rmse, NumOps.Zero))
-        {
-            var zeros = new T[predicted.Length];
-            for (int i = 0; i < zeros.Length; i++)
-                zeros[i] = NumOps.Zero;
-            return new Vector<T>(zeros);
-        }
-
-        var n = NumOps.FromDouble(predicted.Length);
-        return diff.Divide(NumOps.Multiply(rmse, n));
-    }
-
     /// <inheritdoc />
     public override Tensor<T> ComputeTapeLoss(Tensor<T> predicted, Tensor<T> target)
     {

--- a/src/LossFunctions/RotationPredictionLoss.cs
+++ b/src/LossFunctions/RotationPredictionLoss.cs
@@ -336,22 +336,6 @@ public class RotationPredictionLoss<T> : LossFunctionBase<T>, ISelfSupervisedLos
         return NumOps.Divide(loss, NumOps.FromDouble(predicted.Length / 4.0));
     }
 
-    /// <summary>
-    /// Gradient of categorical cross-entropy: -target / predicted.
-    /// </summary>
-    public override Vector<T> CalculateDerivative(Vector<T> predicted, Vector<T> target)
-    {
-        var gradient = new Vector<T>(predicted.Length);
-        T eps = NumOps.FromDouble(1e-7);
-        T scale = NumOps.FromDouble(4.0 / predicted.Length);
-        for (int i = 0; i < predicted.Length; i++)
-        {
-            var clipped = NumOps.Add(predicted[i], eps);
-            gradient[i] = NumOps.Multiply(NumOps.Negate(NumOps.Divide(target[i], clipped)), scale);
-        }
-        return gradient;
-    }
-
     /// <inheritdoc />
     /// <remarks>
     /// Categorical cross-entropy via engine ops: -mean(sum(target * log(predicted + eps)))

--- a/src/LossFunctions/ScaleInvariantDepthLoss.cs
+++ b/src/LossFunctions/ScaleInvariantDepthLoss.cs
@@ -68,37 +68,6 @@ public class ScaleInvariantDepthLoss<T> : LossFunctionBase<T>
         return NumOps.FromDouble(loss);
     }
 
-    /// <inheritdoc/>
-    public override Vector<T> CalculateDerivative(Vector<T> predicted, Vector<T> actual)
-    {
-        ValidateVectorLengths(predicted, actual);
-
-        int n = predicted.Length;
-        var derivative = new Vector<T>(n);
-
-        double sumDiff = 0;
-        for (int i = 0; i < n; i++)
-        {
-            double predLog = Math.Log(Convert.ToDouble(predicted[i]) + 1e-8);
-            double actLog = Math.Log(Convert.ToDouble(actual[i]) + 1e-8);
-            sumDiff += predLog - actLog;
-        }
-
-        for (int i = 0; i < n; i++)
-        {
-            double pred = Convert.ToDouble(predicted[i]);
-            double predLog = Math.Log(pred + 1e-8);
-            double actLog = Math.Log(Convert.ToDouble(actual[i]) + 1e-8);
-            double diff = predLog - actLog;
-
-            // Derivative: (2/n) * d / pred - (2*lambda/n^2) * sum(d) / pred
-            double grad = (2.0 / n) * diff / (pred + 1e-8) - (2.0 * _lambda / (n * n)) * sumDiff / (pred + 1e-8);
-            derivative[i] = NumOps.FromDouble(grad);
-        }
-
-        return derivative;
-    }
-
     /// <inheritdoc />
     public override Tensor<T> ComputeTapeLoss(Tensor<T> predicted, Tensor<T> target)
     {

--- a/src/LossFunctions/SparseCategoricalCrossEntropyLoss.cs
+++ b/src/LossFunctions/SparseCategoricalCrossEntropyLoss.cs
@@ -112,11 +112,14 @@ public class SparseCategoricalCrossEntropyLoss<T> : LossFunctionBase<T>
     /// <inheritdoc />
     public override Tensor<T> ComputeTapeLoss(Tensor<T> predicted, Tensor<T> target)
     {
-        // True sparse implementation: gather log-probabilities at target indices
-        // instead of one-hot encoding (avoids O(batch * numClasses) allocation).
-        var softmaxed = Engine.Softmax(predicted);
-        var safeSoftmax = Engine.TensorAddScalar(softmaxed, NumOps.FromDouble(1e-7));
-        var logP = Engine.TensorLog(safeSoftmax);
+        // `predicted` holds class PROBABILITIES, not logits. This applied Engine.Softmax first,
+        // so the tape forward and CalculateLoss were computing different losses: CalculateLoss
+        // takes -log(p[class]) of the values it is given, while this re-normalized them and took
+        // -log(softmax(p)[class]). The library keeps the logit convention in separate
+        // *WithLogitsLoss classes precisely so these do not have to be guessed at, and
+        // CrossEntropyWithLogitsLoss is the one to use for unnormalized scores.
+        var safeP = Engine.TensorAddScalar(predicted, NumOps.FromDouble(1e-12));
+        var logP = Engine.TensorLog(safeP);
 
         // If target has the same shape as predicted, treat as one-hot/dense targets
         if (target.Rank == predicted.Rank && target._shape.SequenceEqual(predicted._shape))
@@ -128,10 +131,18 @@ public class SparseCategoricalCrossEntropyLoss<T> : LossFunctionBase<T>
             return Engine.TensorNegate(mean);
         }
 
-        // Sparse path: target contains integer class indices
+        // Sparse path: target contains integer class indices.
+        //
+        // The selection is expressed as a constant one-hot MASK multiplied into logP, rather than
+        // by indexing logP element-by-element into a fresh tensor. Indexing severs the tape: the
+        // gathered values become a leaf constant with no path back to `predicted`, so the loss had
+        // no gradient at all and anything training on the sparse path silently learned nothing.
+        // A mask keeps logP itself in the graph, and the selection carries no gradient of its own
+        // because the indices are data, not parameters.
         int batchSize = target.Length;
         int numClasses = predicted.Shape[^1];
-        var gatheredLogP = new Tensor<T>(target._shape);
+
+        var selection = new Tensor<T>(predicted._shape);
         for (int i = 0; i < batchSize; i++)
         {
             double rawIdx = NumOps.ToDouble(target[i]);
@@ -141,17 +152,22 @@ public class SparseCategoricalCrossEntropyLoss<T> : LossFunctionBase<T>
                     $"Target at position {i} is {rawIdx}, expected an integer class index.",
                     nameof(target));
             if (classIdx < 0 || classIdx >= numClasses)
-                throw new ArgumentOutOfRangeException(nameof(target),
-                    $"Target index {classIdx} at position {i} is out of range [0, {numClasses}).");
-            gatheredLogP[i] = predicted.Rank == 1
-                ? logP[classIdx]
-                : logP[i * numClasses + classIdx];
+                throw new ArgumentException(
+                    $"Class index {classIdx} at position {i} is out of bounds. " +
+                    $"Expected value between 0 and {numClasses - 1}.",
+                    nameof(target));
+
+            // Accumulate rather than assign: a rank-1 prediction scored against several target
+            // indices can name the same class twice, and that sample must count twice.
+            int slot = predicted.Rank == 1 ? classIdx : (i * numClasses) + classIdx;
+            selection[slot] = NumOps.Add(selection[slot], NumOps.One);
         }
 
-        // loss = -mean(gathered log-probs)
-        var sum = Engine.ReduceSum(gatheredLogP, null, keepDims: false);
-        var batchT = new Tensor<T>(new[] { 1 });
-        batchT[0] = NumOps.FromDouble(batchSize);
-        return Engine.TensorNegate(Engine.TensorDivide(sum, batchT));
+        // loss = -(1 / batch) * sum_over_all(selection * logP)
+        var selected = Engine.TensorMultiply(logP, selection);
+        var selectedAxes = Enumerable.Range(0, selected.Shape.Length).ToArray();
+        var sum = Engine.ReduceSum(selected, selectedAxes, keepDims: false);
+
+        return Engine.TensorNegate(Engine.TensorDivideScalar(sum, NumOps.FromDouble(batchSize)));
     }
 }

--- a/src/LossFunctions/SparseCategoricalCrossEntropyLoss.cs
+++ b/src/LossFunctions/SparseCategoricalCrossEntropyLoss.cs
@@ -109,64 +109,6 @@ public class SparseCategoricalCrossEntropyLoss<T> : LossFunctionBase<T>
         return NumOps.Divide(sum, NumOps.FromDouble(sampleCount));
     }
 
-    /// <summary>
-    /// Calculates the derivative of the Sparse Categorical Cross Entropy loss function.
-    /// </summary>
-    /// <param name="predicted">The predicted probability values for all classes (length = num_classes).</param>
-    /// <param name="actual">The actual class indices as floating-point values (length = batch_size or 1 for single sample).</param>
-    /// <returns>A vector containing the derivatives for each class probability.</returns>
-    /// <remarks>
-    /// The derivative is:
-    /// - For the correct class: -1 / predicted[correct_class]
-    /// - For all other classes: 0
-    ///
-    /// When used with softmax activation, this combines with the softmax derivative
-    /// to produce the simplified gradient (predicted - one_hot_actual).
-    /// </remarks>
-    /// <exception cref="ArgumentException">Thrown when class indices are invalid or vectors are empty.</exception>
-    public override Vector<T> CalculateDerivative(Vector<T> predicted, Vector<T> actual)
-    {
-        // Note: We do NOT validate that predicted and actual have the same length
-        // In sparse categorical cross-entropy, they can differ
-
-        if (predicted.Length == 0)
-        {
-            throw new ArgumentException("Predicted vector cannot be empty.");
-        }
-
-        // Initialize gradient vector with zeros
-        var gradient = new Vector<T>(predicted.Length);
-
-        // Process each sample
-        for (int i = 0; i < actual.Length; i++)
-        {
-            // Extract class index from actual
-            int classIndex = NumOps.ToInt32(actual[i]);
-
-            // Validate class index
-            if (classIndex < 0 || classIndex >= predicted.Length)
-            {
-                throw new ArgumentException(
-                    $"Class index {classIndex} at position {i} is out of bounds. " +
-                    $"Expected value between 0 and {predicted.Length - 1}.");
-            }
-
-            // Clamp to prevent division by zero using NumericalStabilityHelper
-            T predictedProb = NumericalStabilityHelper.ClampProbability(
-                predicted[classIndex],
-                NumericalStabilityHelper.SmallEpsilon);
-
-            // Derivative for the correct class: -1 / predicted[correct_class] with safe division
-            T derivative = NumOps.Negate(NumericalStabilityHelper.SafeDiv(NumOps.One, predictedProb, NumericalStabilityHelper.SmallEpsilon));
-
-            // Accumulate gradient (in case multiple samples point to the same class)
-            gradient[classIndex] = NumOps.Add(gradient[classIndex], derivative);
-        }
-
-        // Average the gradients
-        return gradient.Divide(NumOps.FromDouble(actual.Length));
-    }
-
     /// <inheritdoc />
     public override Tensor<T> ComputeTapeLoss(Tensor<T> predicted, Tensor<T> target)
     {

--- a/src/LossFunctions/SparseCategoricalCrossEntropyLoss.cs
+++ b/src/LossFunctions/SparseCategoricalCrossEntropyLoss.cs
@@ -121,8 +121,12 @@ public class SparseCategoricalCrossEntropyLoss<T> : LossFunctionBase<T>
         var safeP = Engine.TensorAddScalar(predicted, NumOps.FromDouble(1e-12));
         var logP = Engine.TensorLog(safeP);
 
-        // If target has the same shape as predicted, treat as one-hot/dense targets
-        if (target.Rank == predicted.Rank && target._shape.SequenceEqual(predicted._shape))
+        // Dense/one-hot targets, but ONLY for a batched prediction. The shape test alone is
+        // ambiguous for a rank-1 prediction: N class indices against N classes matches it exactly,
+        // so [0, 1, 2] against three classes was read as one-hot VALUES rather than indices and
+        // produced a gradient of zero for every class. CalculateLoss has no such ambiguity -- a
+        // vector `actual` is always class indices -- so rank 1 follows the sparse path.
+        if (predicted.Rank >= 2 && target.Rank == predicted.Rank && target._shape.SequenceEqual(predicted._shape))
         {
             target = EnsureTargetMatchesPredicted(predicted, target);
             var product = Engine.TensorMultiply(target, logP);

--- a/src/LossFunctions/SquaredHingeLoss.cs
+++ b/src/LossFunctions/SquaredHingeLoss.cs
@@ -66,40 +66,6 @@ public class SquaredHingeLoss<T> : LossFunctionBase<T>
     }
 
     /// <summary>
-    /// Calculates the derivative of the Squared Hinge Loss function.
-    /// </summary>
-    /// <param name="predicted">The predicted values vector.</param>
-    /// <param name="actual">The actual (ground truth) values vector, typically -1 or 1.</param>
-    /// <returns>A vector containing the derivatives of the squared hinge loss with respect to each predicted value.</returns>
-    public override Vector<T> CalculateDerivative(Vector<T> predicted, Vector<T> actual)
-    {
-        ValidateVectorLengths(predicted, actual);
-
-        var result = new T[predicted.Length];
-
-        for (int i = 0; i < predicted.Length; i++)
-        {
-            T margin = NumOps.Subtract(NumOps.One, NumOps.Multiply(actual[i], predicted[i]));
-
-            if (NumOps.GreaterThan(margin, NumOps.Zero))
-            {
-                // Derivative is -2 * margin * y when margin > 0
-                result[i] = NumOps.Multiply(
-                    NumOps.FromDouble(-2.0),
-                    NumOps.Multiply(margin, actual[i])
-                );
-            }
-            else
-            {
-                // Derivative is 0 when margin <= 0
-                result[i] = NumOps.Zero;
-            }
-        }
-
-        return new Vector<T>(result).Divide(NumOps.FromDouble(predicted.Length));
-    }
-
-    /// <summary>
     /// Calculates both Squared Hinge loss and gradient on GPU in a single efficient pass.
     /// </summary>
     /// <param name="predicted">The predicted GPU tensor from the model.</param>

--- a/src/LossFunctions/TripletLoss.cs
+++ b/src/LossFunctions/TripletLoss.cs
@@ -97,85 +97,6 @@ public class TripletLoss<T> : LossFunctionBase<T>
         return NumOps.Divide(totalLoss, NumOps.FromDouble(batchSize));
     }
 
-    /// <summary>
-    /// Calculates the gradients of the Triplet Loss function for anchor, positive, and negative samples.
-    /// </summary>
-    /// <param name="anchor">The anchor samples matrix.</param>
-    /// <param name="positive">The positive samples matrix (similar to anchor).</param>
-    /// <param name="negative">The negative samples matrix (dissimilar to anchor).</param>
-    /// <returns>A tuple containing the gradients for anchor, positive, and negative samples.</returns>
-    /// <exception cref="ArgumentException">Thrown when input matrices have inconsistent dimensions.</exception>
-    public (Matrix<T>, Matrix<T>, Matrix<T>) CalculateDerivative(Matrix<T> anchor, Matrix<T> positive, Matrix<T> negative)
-    {
-        // Validate input dimensions
-        if (anchor.Rows != positive.Rows || anchor.Rows != negative.Rows ||
-            anchor.Columns != positive.Columns || anchor.Columns != negative.Columns)
-        {
-            throw new ArgumentException("Anchor, positive, and negative matrices must have the same dimensions.");
-        }
-
-        var batchSize = anchor.Rows;
-        var featureCount = anchor.Columns;
-
-        var anchorGradient = new Matrix<T>(batchSize, featureCount);
-        var positiveGradient = new Matrix<T>(batchSize, featureCount);
-        var negativeGradient = new Matrix<T>(batchSize, featureCount);
-
-        for (int i = 0; i < batchSize; i++)
-        {
-            var anchorSample = anchor.GetRow(i);
-            var positiveSample = positive.GetRow(i);
-            var negativeSample = negative.GetRow(i);
-
-            var positiveDistance = VectorHelper.EuclideanDistance(anchorSample, positiveSample);
-            var negativeDistance = VectorHelper.EuclideanDistance(anchorSample, negativeSample);
-
-            var loss = NumOps.Subtract(
-                NumOps.Add(positiveDistance, _margin),
-                negativeDistance
-            );
-
-            if (NumOps.GreaterThan(loss, NumOps.Zero))
-            {
-                // Only compute gradients if loss > 0 (the triplet is active)
-                for (int j = 0; j < featureCount; j++)
-                {
-                    var anchorPositiveDiff = NumOps.Subtract(anchorSample[j], positiveSample[j]);
-                    var anchorNegativeDiff = NumOps.Subtract(anchorSample[j], negativeSample[j]);
-
-                    // Gradient for anchor: 2*(anchor - positive) - 2*(anchor - negative)
-                    anchorGradient[i, j] = NumOps.Multiply(
-                        NumOps.FromDouble(2),
-                        NumOps.Subtract(anchorPositiveDiff, anchorNegativeDiff)
-                    );
-
-                    // Gradient for positive: -2*(anchor - positive)
-                    positiveGradient[i, j] = NumOps.Multiply(
-                        NumOps.FromDouble(-2),
-                        anchorPositiveDiff
-                    );
-
-                    // Gradient for negative: 2*(anchor - negative)
-                    negativeGradient[i, j] = NumOps.Multiply(
-                        NumOps.FromDouble(2),
-                        anchorNegativeDiff
-                    );
-                }
-            }
-            else
-            {
-                // If the triplet loss is zero or negative, the gradients are zero
-                for (int j = 0; j < featureCount; j++)
-                {
-                    anchorGradient[i, j] = NumOps.Zero;
-                    positiveGradient[i, j] = NumOps.Zero;
-                    negativeGradient[i, j] = NumOps.Zero;
-                }
-            }
-        }
-
-        return (anchorGradient, positiveGradient, negativeGradient);
-    }
 
     /// <summary>
     /// This method is not used for Triplet Loss as it requires multiple input vectors.
@@ -248,5 +169,78 @@ public class TripletLoss<T> : LossFunctionBase<T>
         var clamped = Engine.TensorMax(shifted, zeros);
         var allAxes = Enumerable.Range(0, clamped.Shape.Length).ToArray();
         return Engine.ReduceMean(clamped, allAxes, keepDims: false);
+    }
+
+    /// <summary>
+    /// Computes the triplet loss as a tape-differentiable scalar from the three embedding sets.
+    /// </summary>
+    /// <param name="anchor">Anchor embeddings, shaped [batch, features] (or [features] for one triplet).</param>
+    /// <param name="positive">Embeddings that should be close to the anchor, same shape.</param>
+    /// <param name="negative">Embeddings that should be far from the anchor, same shape.</param>
+    /// <returns>A rank-0 scalar tensor holding mean(max(0, d(a,p) - d(a,n) + margin)).</returns>
+    /// <exception cref="ArgumentNullException">Thrown when any argument is null.</exception>
+    /// <exception cref="ArgumentException">Thrown when the three shapes differ.</exception>
+    /// <remarks>
+    /// <para>
+    /// This computes only the GEOMETRY -- the two Euclidean distances -- and then hands the
+    /// distance difference to the two-argument <see cref="ComputeTapeLoss(Tensor{T}, Tensor{T})"/>,
+    /// which owns the hinge. The margin rule therefore exists in exactly one place and the two
+    /// entry points cannot drift apart.
+    /// </para>
+    /// <para>
+    /// Gradients flow to all three inputs, which is what a triplet objective needs: the anchor is
+    /// pulled toward the positive and pushed from the negative in the same backward pass.
+    /// </para>
+    /// </remarks>
+    public Tensor<T> ComputeTapeLoss(Tensor<T> anchor, Tensor<T> positive, Tensor<T> negative)
+    {
+        if (anchor is null) throw new ArgumentNullException(nameof(anchor));
+        if (positive is null) throw new ArgumentNullException(nameof(positive));
+        if (negative is null) throw new ArgumentNullException(nameof(negative));
+
+        if (!anchor._shape.SequenceEqual(positive._shape) || !anchor._shape.SequenceEqual(negative._shape))
+        {
+            throw new ArgumentException(
+                "Anchor, positive and negative must have the same shape, but were "
+                + $"[{string.Join(", ", anchor.Shape.ToArray())}], "
+                + $"[{string.Join(", ", positive.Shape.ToArray())}] and "
+                + $"[{string.Join(", ", negative.Shape.ToArray())}].",
+                nameof(positive));
+        }
+
+        var difference = Engine.TensorSubtract(
+            EuclideanDistance(anchor, positive),
+            EuclideanDistance(anchor, negative));
+
+        // The two-argument overload ignores its target; it reads the distance difference only.
+        return ComputeTapeLoss(difference, new Tensor<T>(difference._shape));
+    }
+
+    /// <summary>
+    /// Row-wise Euclidean distance between two equally shaped embedding tensors.
+    /// </summary>
+    /// <remarks>
+    /// The small offset under the root is not cosmetic: d(sqrt(x))/dx is unbounded as x approaches
+    /// zero, so two IDENTICAL embeddings -- the exact case a positive pair converges to -- would
+    /// otherwise produce a NaN gradient and destroy the whole backward pass.
+    /// </remarks>
+    private Tensor<T> EuclideanDistance(Tensor<T> left, Tensor<T> right)
+    {
+        var delta = Engine.TensorSubtract(left, right);
+        var squared = Engine.TensorMultiply(delta, delta);
+
+        // Reduce the feature axis, keeping one distance per sample.
+        var featureAxis = new[] { squared.Shape.Length - 1 };
+        var summed = Engine.ReduceSum(squared, featureAxis, keepDims: false);
+
+        // A single un-batched triplet reduces to rank 0, and the hinge overload then calls
+        // ReduceMean over an EMPTY axis list, whose backward rejects the empty shape. Keeping one
+        // sample as [1] makes the un-batched case take the same path as a batch of one.
+        if (summed.Shape.Length == 0)
+        {
+            summed = Engine.Reshape(summed, new[] { 1 });
+        }
+
+        return Engine.TensorSqrt(Engine.TensorAddScalar(summed, NumOps.FromDouble(1e-12)));
     }
 }

--- a/src/LossFunctions/TripletLoss.cs
+++ b/src/LossFunctions/TripletLoss.cs
@@ -193,22 +193,6 @@ public class TripletLoss<T> : LossFunctionBase<T>
     }
 
     /// <summary>
-    /// This method is not used for Triplet Loss as it requires multiple input vectors.
-    /// </summary>
-    /// <param name="predicted">The predicted values vector.</param>
-    /// <param name="actual">The actual (target) values vector.</param>
-    /// <returns>Throws NotSupportedException.</returns>
-    /// <exception cref="NotSupportedException">Always thrown as TripletLoss requires three input matrices.</exception>
-    public override Vector<T> CalculateDerivative(Vector<T> predicted, Vector<T> actual)
-    {
-        throw new NotSupportedException(
-            "TripletLoss requires three input matrices (anchor, positive, negative). " +
-            "Use the CalculateDerivative(Matrix<T>, Matrix<T>, Matrix<T>) method instead."
-        );
-    }
-
-
-    /// <summary>
     /// Calculates Triplet Loss on GPU for batched input tensors.
     /// </summary>
     /// <param name="anchor">The anchor GPU tensor (batch of embeddings).</param>

--- a/src/LossFunctions/WassersteinLoss.cs
+++ b/src/LossFunctions/WassersteinLoss.cs
@@ -89,57 +89,6 @@ public class WassersteinLoss<T> : LossFunctionBase<T>
         return NumOps.Negate(mean);
     }
 
-    /// <summary>
-    /// Calculates the derivative of the Wasserstein loss function.
-    /// </summary>
-    /// <param name="predicted">The critic's output scores for each sample.</param>
-    /// <param name="actual">The labels: +1 for real samples, -1 for fake samples.</param>
-    /// <returns>A vector containing the derivatives of the Wasserstein loss for each prediction.</returns>
-    /// <remarks>
-    /// <para>
-    /// The derivative of the Wasserstein loss with respect to the predicted scores is simply
-    /// the negative of the labels (after accounting for the mean).
-    /// </para>
-    /// <para>
-    /// <b>Mathematical Derivation:</b>
-    /// <list type="bullet">
-    /// <item><description>Loss = -mean(predicted * actual) = -(1/n) * sum(predicted_i * actual_i)</description></item>
-    /// <item><description>dLoss/d(predicted_i) = -actual_i / n</description></item>
-    /// </list>
-    /// </para>
-    /// <para>
-    /// <b>For Beginners:</b> The derivative tells the network which direction to adjust.
-    ///
-    /// For a real sample (label = +1):
-    /// <list type="bullet">
-    /// <item><description>Derivative is negative, so increasing the score decreases the loss</description></item>
-    /// <item><description>This pushes the critic to give higher scores to real images</description></item>
-    /// </list>
-    ///
-    /// For a fake sample (label = -1):
-    /// <list type="bullet">
-    /// <item><description>Derivative is positive, so decreasing the score decreases the loss</description></item>
-    /// <item><description>This pushes the critic to give lower scores to fake images</description></item>
-    /// </list>
-    /// </para>
-    /// </remarks>
-    public override Vector<T> CalculateDerivative(Vector<T> predicted, Vector<T> actual)
-    {
-        ValidateVectorLengths(predicted, actual);
-
-        // d/d(predicted) of -mean(predicted * actual) = -actual / n
-        Vector<T> derivative = new Vector<T>(predicted.Length);
-        T divisor = NumOps.FromDouble(predicted.Length);
-
-        for (int i = 0; i < predicted.Length; i++)
-        {
-            // Derivative: -actual[i] / n
-            derivative[i] = NumOps.Divide(NumOps.Negate(actual[i]), divisor);
-        }
-
-        return derivative;
-    }
-
     /// <inheritdoc />
     public override Tensor<T> ComputeTapeLoss(Tensor<T> predicted, Tensor<T> target)
     {

--- a/src/LossFunctions/WeightedCrossEntropyLoss.cs
+++ b/src/LossFunctions/WeightedCrossEntropyLoss.cs
@@ -96,46 +96,6 @@ public class WeightedCrossEntropyLoss<T> : LossFunctionBase<T>
         return NumOps.Negate(NumOps.Divide(loss, NumOps.FromDouble(predicted.Length)));
     }
 
-    /// <summary>
-    /// Calculates the derivative of the Weighted Cross Entropy loss function.
-    /// </summary>
-    /// <param name="predicted">The predicted values (probabilities between 0 and 1).</param>
-    /// <param name="actual">The actual (target) values (typically 0 or 1).</param>
-    /// <returns>A vector containing the derivatives of the weighted cross entropy loss with respect to each prediction.</returns>
-    public override Vector<T> CalculateDerivative(Vector<T> predicted, Vector<T> actual)
-    {
-        ValidateVectorLengths(predicted, actual);
-
-        // If weights are not provided, use uniform weights
-        Vector<T> weights = _weights;
-        if (weights == null || weights.Length != predicted.Length)
-        {
-            weights = new Vector<T>(predicted.Length);
-            for (int i = 0; i < predicted.Length; i++)
-            {
-                weights[i] = NumOps.One;
-            }
-        }
-
-        Vector<T> derivative = new Vector<T>(predicted.Length);
-        for (int i = 0; i < predicted.Length; i++)
-        {
-            // weight * [(p - y)/(p*(1-p))]
-            T denominator = NumOps.Multiply(predicted[i], NumOps.Subtract(NumOps.One, predicted[i]));
-            derivative[i] = NumOps.Multiply(
-                weights[i],
-                NumericalStabilityHelper.SafeDiv(
-                    NumOps.Subtract(predicted[i], actual[i]),
-                    denominator,
-                    NumericalStabilityHelper.SmallEpsilon
-                )
-            );
-        }
-
-        // Return the average derivative (consistent with BinaryCrossEntropyLoss)
-        return derivative.Divide(NumOps.FromDouble(predicted.Length));
-    }
-
     /// <inheritdoc />
     public override Tensor<T> ComputeTapeLoss(Tensor<T> predicted, Tensor<T> target)
     {

--- a/src/MetaLearning/Models/LinearVectorModel.cs
+++ b/src/MetaLearning/Models/LinearVectorModel.cs
@@ -162,7 +162,7 @@ public class LinearVectorModel : ModelBase<double, Matrix<double>, Vector<double
 
         // Use the provided loss function if available, otherwise fall back to MSE
         var loss = lossFunction ?? DefaultLossFunction;
-        var lossGradient = loss.CalculateDerivative(predictions, target);
+        var lossGradient = loss.ComputeGradient(predictions, target);
 
         double scale = 1.0 / count;
         for (int r = 0; r < count; r++)

--- a/src/Models/VectorModel.cs
+++ b/src/Models/VectorModel.cs
@@ -297,7 +297,7 @@ public class VectorModel<T> : ModelBase<T, Matrix<T>, Vector<T>>, IInterpretable
         var predictions = PredictInternal(input);
 
         // Compute loss gradient w.r.t. predictions: ∂L/∂y_pred
-        var predictionGradient = loss.CalculateDerivative(predictions, target);
+        var predictionGradient = loss.ComputeGradient(predictions, target);
 
         // Compute gradient w.r.t. coefficients: ∂L/∂coefficients = (1/n) * X^T * ∂L/∂y_pred
         // Pre-extract columns from input for Engine.DotProduct

--- a/src/NER/SequenceLabeling/LSTMCRF.cs
+++ b/src/NER/SequenceLabeling/LSTMCRF.cs
@@ -230,8 +230,6 @@ public class LSTMCRF<T> : SequenceLabelingNERBase<T>, INERModel<T>
                     var output = Forward(preprocessed);
                     double loss = NumOps.ToDouble(LossFunction.CalculateLoss(
                         output.ToVector(), preprocessedLabels.ToVector()));
-                    var grad = LossFunction.CalculateDerivative(output.ToVector(), preprocessedLabels.ToVector());
-                    var gt = Tensor<T>.FromVector(grad);
                     // Backward removed — tape-based training handles gradients
                     _optimizer.UpdateParameters(Layers);
 

--- a/src/NER/SpanBased/SpanBasedNERBase.cs
+++ b/src/NER/SpanBased/SpanBasedNERBase.cs
@@ -185,8 +185,6 @@ public abstract class SpanBasedNERBase<T> : SequenceLabeling.SequenceLabelingNER
                     var output = Forward(preprocessed);
                     double loss = NumOps.ToDouble(LossFunction.CalculateLoss(
                         output.ToVector(), preprocessedLabels.ToVector()));
-                    var grad = LossFunction.CalculateDerivative(output.ToVector(), preprocessedLabels.ToVector());
-                    var gt = Tensor<T>.FromVector(grad);
                     // Backward removed — tape-based training handles gradients
                     _optimizer.UpdateParameters(Layers);
 

--- a/src/NER/TransformerBased/TransformerNERBase.cs
+++ b/src/NER/TransformerBased/TransformerNERBase.cs
@@ -191,8 +191,6 @@ public abstract class TransformerNERBase<T> : SequenceLabeling.SequenceLabelingN
                     var output = Forward(preprocessed);
                     double loss = NumOps.ToDouble(LossFunction.CalculateLoss(
                         output.ToVector(), preprocessedLabels.ToVector()));
-                    var grad = LossFunction.CalculateDerivative(output.ToVector(), preprocessedLabels.ToVector());
-                    var gt = Tensor<T>.FromVector(grad);
                     // Backward removed — tape-based training handles gradients
                     _optimizer.UpdateParameters(Layers);
 

--- a/src/NeuralNetworks/AudioVisualCorrespondenceNetwork.cs
+++ b/src/NeuralNetworks/AudioVisualCorrespondenceNetwork.cs
@@ -543,7 +543,7 @@ public class AudioVisualCorrespondenceNetwork<T> : NeuralNetworkBase<T>, IAudioV
                         new Vector<T>(1) { [0] = target });
 
                     // Backward pass: compute gradients for contrastive loss
-                    var outputGrad = _lossFunction.CalculateDerivative(
+                    var outputGrad = _lossFunction.ComputeGradient(
                         new Vector<T>(1) { [0] = similarity },
                         new Vector<T>(1) { [0] = target });
 

--- a/src/NeuralNetworks/Autoencoder.cs
+++ b/src/NeuralNetworks/Autoencoder.cs
@@ -545,7 +545,7 @@ public class Autoencoder<T> : NeuralNetworkBase<T>, IAuxiliaryLossLayer<T>
         Vector<T> expectedVector = expected.ToVector();
 
         // Calculate the derivative of the loss function
-        Vector<T> gradientVector = _lossFunction.CalculateDerivative(predictedVector, expectedVector);
+        Vector<T> gradientVector = _lossFunction.ComputeGradient(predictedVector, expectedVector);
 
         // Reshape the gradient back to the original tensor shape
         return new Tensor<T>(predicted._shape, gradientVector);

--- a/src/NeuralNetworks/Blip2NeuralNetwork.cs
+++ b/src/NeuralNetworks/Blip2NeuralNetwork.cs
@@ -2255,7 +2255,7 @@ public class Blip2NeuralNetwork<T> : NeuralNetworkBase<T>, IBlip2Model<T>
         LastLoss = LossFunction.CalculateLoss(imageOutput.ToVector(), expectedOutput.ToVector());
 
         // Backward pass - compute gradients
-        var lossGradient = LossFunction.CalculateDerivative(imageOutput.ToVector(), expectedOutput.ToVector());
+        var lossGradient = LossFunction.ComputeGradient(imageOutput.ToVector(), expectedOutput.ToVector());
         var gradient = Tensor<T>.FromVector(lossGradient);
 
         // Apply gradient descent update using the computed gradients

--- a/src/NeuralNetworks/ConvolutionalNeuralNetwork.cs
+++ b/src/NeuralNetworks/ConvolutionalNeuralNetwork.cs
@@ -521,7 +521,7 @@ public class ConvolutionalNeuralNetwork<T> : NeuralNetworkBase<T>
     /// </remarks>
     private Vector<T> CalculateOutputGradient(Tensor<T> prediction, Tensor<T> expectedOutput)
     {
-        return _lossFunction.CalculateDerivative(prediction.ToVector(), expectedOutput.ToVector());
+        return _lossFunction.ComputeGradient(prediction.ToVector(), expectedOutput.ToVector());
     }
 
     /// <inheritdoc/>

--- a/src/NeuralNetworks/DeepBeliefNetwork.cs
+++ b/src/NeuralNetworks/DeepBeliefNetwork.cs
@@ -663,7 +663,7 @@ public class DeepBeliefNetwork<T> : NeuralNetworkBase<T>
     /// </remarks>
     private Vector<T> CalculateOutputGradients(Vector<T> predicted, Vector<T> expected)
     {
-        return _lossFunction.CalculateDerivative(predicted, expected);
+        return _lossFunction.ComputeGradient(predicted, expected);
     }
 
     /// <summary>

--- a/src/NeuralNetworks/Gpt4VisionNeuralNetwork.cs
+++ b/src/NeuralNetworks/Gpt4VisionNeuralNetwork.cs
@@ -1556,9 +1556,6 @@ For each category, indicate if it's flagged (YES/NO) and confidence level (HIGH/
         var targetEmbedding = TensorToVector(expectedOutput);
         LastLoss = LossFunction.CalculateLoss(predictedEmbedding, targetEmbedding);
 
-        // Compute gradient of loss w.r.t. output
-        var lossGradient = LossFunction.CalculateDerivative(predictedEmbedding, targetEmbedding);
-
         // Get parameter gradients and apply gradient descent update
         var paramGradients = GetGpt4VParameterGradients();
         UpdateParameters(paramGradients);

--- a/src/NeuralNetworks/GraphGenerationModel.cs
+++ b/src/NeuralNetworks/GraphGenerationModel.cs
@@ -242,13 +242,6 @@ public class GraphGenerationModel<T> : NeuralNetworkBase<T>
         // configurations fail at construction with a clear message instead
         // of throwing mid-training when the user has already paid the cost
         // of the forward pass.
-        if (_lossFunction is not LossFunctions.LossFunctionBase<T>)
-        {
-            throw new ArgumentException(
-                "GraphGenerationModel requires a tape-capable loss function. " +
-                $"Pass a LossFunctionBase<T> implementation (got {_lossFunction.GetType().Name}).",
-                nameof(lossFunction));
-        }
         var adamOpts = new AdamOptimizerOptions<T, Tensor<T>, Tensor<T>>
         {
             InitialLearningRate = 0.001,
@@ -989,7 +982,7 @@ public class GraphGenerationModel<T> : NeuralNetworkBase<T>
         // handled internally) when the caller didn't supply one. The
         // constructor enforces LossFunctionBase<T> so this cast cannot
         // fail at runtime.
-        var tapeLoss = (LossFunctions.LossFunctionBase<T>)_lossFunction;
+        var tapeLoss = _lossFunction;
         var reconLoss = tapeLoss.ComputeTapeLoss(reconstructed, adjacencyMatrix);
 
         // KL divergence to N(0, I) per Kipf & Welling 2016 §3.2:

--- a/src/NeuralNetworks/NeuralNetworkBase.cs
+++ b/src/NeuralNetworks/NeuralNetworkBase.cs
@@ -3729,9 +3729,7 @@ public abstract class NeuralNetworkBase<T> : INeuralNetworkModel<T>, IInterpreta
                 nameof(target));
         }
 
-        var loss = LossFunction as LossFunctions.LossFunctionBase<T>
-            ?? throw new InvalidOperationException(
-                "TrainWithGradientAccumulation requires a LossFunctionBase<T> for ComputeTapeLoss.");
+        var loss = LossFunction;
 
         // Collect any network-level trainable tensors so models with
         // raw trainable parameters on the network (not on a layer) keep
@@ -6901,9 +6899,7 @@ public abstract class NeuralNetworkBase<T> : INeuralNetworkModel<T>, IInterpreta
         IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>> resolvedOptimizer,
         bool useStreamingDefaults)
     {
-        var loss = LossFunction as LossFunctions.LossFunctionBase<T>
-            ?? throw new InvalidOperationException(
-                "LossFunction must derive from LossFunctionBase<T> for tape-based training.");
+        var loss = LossFunction;
 
         // Global grad-norm clipping (MaxGradNorm > 0, the default) needs the TOTAL
         // gradient norm before any parameter is updated, which a single
@@ -7405,8 +7401,7 @@ public abstract class NeuralNetworkBase<T> : INeuralNetworkModel<T>, IInterpreta
                 extraTrainableTensors.Add(t);
             }
 
-            var loss = LossFunction as LossFunctions.LossFunctionBase<T>
-                ?? throw new InvalidOperationException("LossFunction must derive from LossFunctionBase<T> for tape-based training.");
+            var loss = LossFunction;
 
             // ---------------- Mixed-precision (#1354) — pre-forward setup ----------------
             // When _mixedPrecisionContext != null we are running mixed-precision
@@ -8416,9 +8411,7 @@ public abstract class NeuralNetworkBase<T> : INeuralNetworkModel<T>, IInterpreta
         if (trainableLayers.Length == 0)
             return EmitFusedMissAndFallback("no trainable layers");
 
-        var loss = LossFunction as LossFunctions.LossFunctionBase<T>;
-        if (loss is null)
-            return EmitFusedMissAndFallback("loss function not derived from LossFunctionBase<T>");
+        var loss = LossFunction;
 
         // Mirror the eager path's bidirectional shape alignment exactly:
         // (a) forward has extra leading dim → reshape FORWARD to target shape
@@ -9155,7 +9148,6 @@ public abstract class NeuralNetworkBase<T> : INeuralNetworkModel<T>, IInterpreta
         // Correctness-necessary gates (apply even when forced): a batch big enough to chunk, a tape loss,
         // and no cross-batch normalization (else accumulation ≠ full-batch step).
         if (input.Rank < 1 || input.Shape[0] <= MicroBatchChunkSize) return false;
-        if (LossFunction is not LossFunctions.LossFunctionBase<T>) return false;
         if (HasCrossBatchNormalization()) return false;
 
         // Must have something tape-trainable to accumulate over. Check trainable LAYERS (which exist even
@@ -11544,15 +11536,6 @@ public abstract class NeuralNetworkBase<T> : INeuralNetworkModel<T>, IInterpreta
                 "The loss function cannot be changed after training has begun; construct a new model instead.");
         }
 
-        if (lossFunction is not LossFunctions.LossFunctionBase<T>)
-        {
-            throw new ArgumentException(
-                $"Loss function '{lossFunction.GetType().Name}' must derive from LossFunctionBase<T> " +
-                "to be used for tape-based training. Implementing ILossFunction<T> alone is not " +
-                "sufficient: the tape path needs ComputeTapeLoss, which the interface does not declare.",
-                nameof(lossFunction));
-        }
-
         // Architecture-specific gate: models whose objective is intrinsic (a specific likelihood or a
         // fixed-shape output head) override this to reject an incompatible loss up front rather than failing
         // deep inside training.
@@ -11648,7 +11631,7 @@ public abstract class NeuralNetworkBase<T> : INeuralNetworkModel<T>, IInterpreta
             // producing zero gradients from a disconnected scalar tensor.
             var predVec = prediction.ToVector();
             var targetVec = target.ToVector();
-            var derivVec = resolved.CalculateDerivative(predVec, targetVec);
+            var derivVec = resolved.ComputeGradient(predVec, targetVec);
             lossTensor = new Tensor<T>(prediction._shape, derivVec);
         }
 

--- a/src/NeuralNetworks/NeuralNetworkBase.cs
+++ b/src/NeuralNetworks/NeuralNetworkBase.cs
@@ -11611,29 +11611,15 @@ public abstract class NeuralNetworkBase<T> : INeuralNetworkModel<T>, IInterpreta
         // Integer-class → one-hot matching is handled inside each loss function's
         // ComputeTapeLoss via EnsureTargetMatchesPredicted.
         var resolved = lossFunction ?? LossFunction;
-        Tensor<T> lossTensor;
-        if (resolved is LossFunctions.LossFunctionBase<T> tapeLoss)
-        {
-            lossTensor = tapeLoss.ComputeTapeLoss(prediction, target);
-            // Record the scalar loss so GetLastLoss() reflects this gradient step. The
-            // IGradientComputable fast-path (used by every gradient-based optimizer's
-            // CalculateGradient) previously left LastLoss stale/zero, so callers reading the
-            // per-batch training loss — e.g. AdamOptimizer's UseTrainingLossAsFitness mode —
-            // saw 0 even though the true batch loss was computed right here. The other training
-            // paths (TrainWithTape / fused step) already set LastLoss the same way.
-            LastLoss = lossTensor.Length > 0 ? lossTensor[0] : NumOps.Zero;
-        }
-        else
-        {
-            // Fallback for custom ILossFunction: use CalculateDerivative to get
-            // the loss gradient w.r.t. predictions, then backpropagate manually.
-            // This preserves the IGradientComputable contract without silently
-            // producing zero gradients from a disconnected scalar tensor.
-            var predVec = prediction.ToVector();
-            var targetVec = target.ToVector();
-            var derivVec = resolved.ComputeGradient(predVec, targetVec);
-            lossTensor = new Tensor<T>(prediction._shape, derivVec);
-        }
+        var lossTensor = resolved.ComputeTapeLoss(prediction, target);
+
+        // Record the scalar loss so GetLastLoss() reflects this gradient step. The
+        // IGradientComputable fast-path (used by every gradient-based optimizer's
+        // CalculateGradient) previously left LastLoss stale/zero, so callers reading the
+        // per-batch training loss — e.g. AdamOptimizer's UseTrainingLossAsFitness mode —
+        // saw 0 even though the true batch loss was computed right here. The other training
+        // paths (TrainWithTape / fused step) already set LastLoss the same way.
+        LastLoss = lossTensor.Length > 0 ? lossTensor[0] : NumOps.Zero;
 
         // Reverse-mode AD: compute gradients across the FULL tape, then
         // filter to trainable parameters via reference-keyed lookup. The

--- a/src/NeuralNetworks/ResNetNetwork.cs
+++ b/src/NeuralNetworks/ResNetNetwork.cs
@@ -539,7 +539,7 @@ public class ResNetNetwork<T> : NeuralNetworkBase<T>
     /// </summary>
     private Vector<T> CalculateOutputGradient(Tensor<T> prediction, Tensor<T> expectedOutput)
     {
-        return _lossFunction.CalculateDerivative(prediction.ToVector(), expectedOutput.ToVector());
+        return _lossFunction.ComputeGradient(prediction.ToVector(), expectedOutput.ToVector());
     }
 
     /// <summary>

--- a/src/NeuralNetworks/SpiralNet.cs
+++ b/src/NeuralNetworks/SpiralNet.cs
@@ -451,9 +451,6 @@ public class SpiralNet<T> : NeuralNetworkBase<T>
                 var loss = _lossFunction.CalculateLoss(output.ToVector(), target);
                 epochLoss += NumOps.ToDouble(loss);
 
-                var lossGrad = _lossFunction.CalculateDerivative(output.ToVector(), target);
-                var lossGradTensor = new Tensor<T>(lossGrad.ToArray(), output._shape);
-
                 UpdateParameters(learningRate);
             }
 

--- a/src/NeuralNetworks/VGGNetwork.cs
+++ b/src/NeuralNetworks/VGGNetwork.cs
@@ -422,7 +422,7 @@ public class VGGNetwork<T> : NeuralNetworkBase<T>
     /// </summary>
     private Vector<T> CalculateOutputGradient(Tensor<T> prediction, Tensor<T> expectedOutput)
     {
-        return _lossFunction.CalculateDerivative(prediction.ToVector(), expectedOutput.ToVector());
+        return _lossFunction.ComputeGradient(prediction.ToVector(), expectedOutput.ToVector());
     }
 
     /// <summary>

--- a/src/Optimizers/GradientBasedOptimizerBase.cs
+++ b/src/Optimizers/GradientBasedOptimizerBase.cs
@@ -1106,11 +1106,11 @@ public abstract class GradientBasedOptimizerBase<T, TInput, TOutput> : Optimizer
                         tensorY = tensorY.Reshape(tensorPredictions.Shape.ToArray());
                     }
                 }
-                gradient = LossFunction.CalculateDerivative(tensorPredictions.ToVector(), tensorY.ToVector());
+                gradient = LossFunction.ComputeGradient(tensorPredictions.ToVector(), tensorY.ToVector());
             }
             else if (predictions is Vector<T> vectorPredictions && y is Vector<T> vectorY)
             {
-                gradient = LossFunction.CalculateDerivative(vectorPredictions, vectorY);
+                gradient = LossFunction.ComputeGradient(vectorPredictions, vectorY);
             }
             else
             {

--- a/src/PhysicsInformed/NeuralOperators/DeepOperatorNetwork.cs
+++ b/src/PhysicsInformed/NeuralOperators/DeepOperatorNetwork.cs
@@ -606,7 +606,7 @@ namespace AiDotNet.PhysicsInformed.NeuralOperators
                         var predictions = Engine.TensorMatMul(trunkOutput2D, branchOutputT);
 
                         // Compute loss under the same tape
-                        var lossTensor = ((LossFunctions.LossFunctionBase<T>)lossFunction)
+                        var lossTensor = lossFunction
                             .ComputeTapeLoss(predictions, targets);
                         T lossVal = lossTensor.Length > 0 ? lossTensor[0] : NumOps.Zero;
                         totalLoss = NumOps.Add(totalLoss, lossVal);
@@ -620,7 +620,7 @@ namespace AiDotNet.PhysicsInformed.NeuralOperators
                             allParams, grads, lossVal,
                             branchInput, targets,
                             (inp, _) => ForwardForTraining(inp),
-                            (pred, tgt) => ((LossFunctions.LossFunctionBase<T>)lossFunction).ComputeTapeLoss(pred, tgt),
+                            (pred, tgt) => lossFunction.ComputeTapeLoss(pred, tgt),
                             null);
                         opt.Step(context);
                     }

--- a/src/PhysicsInformed/PhysicsInformedLoss.cs
+++ b/src/PhysicsInformed/PhysicsInformedLoss.cs
@@ -555,17 +555,6 @@ namespace AiDotNet.PhysicsInformed
             return NumOps.Divide(sumSquaredError, NumOps.FromDouble(count));
         }
 
-        /// <summary>
-        /// Computes the derivative of the loss with respect to predictions.
-        /// Required by the ILossFunction interface.
-        /// </summary>
-        public T[] ComputeDerivative(T[] predictions, T[] targets)
-        {
-            // Delegate to vectorized overload
-            var result = CalculateDerivative(new Vector<T>(predictions), new Vector<T>(targets));
-            return result.ToArray();
-        }
-
         /// <inheritdoc/>
         public override T CalculateLoss(Vector<T> predicted, Vector<T> actual)
         {
@@ -575,16 +564,6 @@ namespace AiDotNet.PhysicsInformed
             var error = (Vector<T>)Engine.Subtract(predicted, actual);
             T sumSquaredError = VectorHelper.DotProduct(error, error);
             return NumOps.Divide(sumSquaredError, NumOps.FromDouble(predicted.Length));
-        }
-
-        /// <inheritdoc/>
-        public override Vector<T> CalculateDerivative(Vector<T> predicted, Vector<T> actual)
-        {
-            ValidateVectorLengths(predicted, actual);
-
-            // Vectorized MSE derivative: 2/N * (predicted - actual)
-            T scale = NumOps.Divide(NumOps.FromDouble(2.0), NumOps.FromDouble(predicted.Length));
-            return (Vector<T>)Engine.Multiply(Engine.Subtract(predicted, actual), scale);
         }
 
         /// <summary>

--- a/src/Regression/DecisionTreeAsyncRegressionBase.cs
+++ b/src/Regression/DecisionTreeAsyncRegressionBase.cs
@@ -977,7 +977,7 @@ public abstract class AsyncDecisionTreeRegressionBase<T> : IAsyncTreeBasedModel<
         // For gradient boosting: compute per-sample loss derivatives (pseudo-residuals)
         // These are ∂Loss/∂predictions, NOT ∂Loss/∂parameters
         // In gradient boosting, subsequent trees are fit to these negative gradients
-        var sampleGradients = loss.CalculateDerivative(predictions, target);
+        var sampleGradients = loss.ComputeGradient(predictions, target);
 
         // Snapshot the int-narrowed count ONCE — both the Vector<T>
         // allocation and the loop bound below reuse this single value.

--- a/src/Regression/DecisionTreeRegressionBase.cs
+++ b/src/Regression/DecisionTreeRegressionBase.cs
@@ -1062,7 +1062,7 @@ public abstract class DecisionTreeRegressionBase<T> : ITreeBasedRegression<T>, I
         // For gradient boosting: compute per-sample loss derivatives (pseudo-residuals)
         // These are ∂Loss/∂predictions, NOT ∂Loss/∂parameters
         // In gradient boosting, subsequent trees are fit to these negative gradients
-        var sampleGradients = loss.CalculateDerivative(predictions, target);
+        var sampleGradients = loss.ComputeGradient(predictions, target);
 
         // Snapshot the int-narrowed count ONCE — both the Vector<T>
         // allocation and the loop bound below reuse this single value.

--- a/src/Regression/MultilayerPerceptronRegression.cs
+++ b/src/Regression/MultilayerPerceptronRegression.cs
@@ -665,7 +665,7 @@ public class MultilayerPerceptronRegression<T> : NonLinearRegressionBase<T>
 
         if (_options.LossFunction != null)
         {
-            error = _options.LossFunction.CalculateDerivative(predictions, targets);
+            error = _options.LossFunction.ComputeGradient(predictions, targets);
         }
         else
         {

--- a/src/Regression/NeuralNetworkRegression.cs
+++ b/src/Regression/NeuralNetworkRegression.cs
@@ -403,7 +403,7 @@ public class NeuralNetworkRegression<T> : NonLinearRegressionBase<T>
 
         // Output layer error
         int lastIndex = activations.Count - 1;
-        Vector<T> error = _options.LossFunction.CalculateDerivative(activations[lastIndex], target);
+        Vector<T> error = _options.LossFunction.ComputeGradient(activations[lastIndex], target);
         Vector<T> delta = error.PointwiseMultiply(ApplyActivationDerivative(activations[lastIndex], true));
         deltas.Add(delta);
 

--- a/src/ReinforcementLearning/Agents/A2CAgent.cs
+++ b/src/ReinforcementLearning/Agents/A2CAgent.cs
@@ -57,7 +57,7 @@ namespace AiDotNet.ReinforcementLearning.Agents.A2C;
     "https://arxiv.org/abs/1602.01783",
     Year = 2016,
     Authors = "Mnih, V., Badia, A. P., Mirza, M., Graves, A., Lillicrap, T., Harley, T., Silver, D., & Kavukcuoglu, K.")]
-public class A2CAgent<T> : DeepReinforcementLearningAgentBase<T>
+public class A2CAgent<T> : DeepReinforcementLearningAgentBase<T>, IGradientComputable<T, Vector<T>, Vector<T>>
 {
     private A2COptions<T> _a2cOptions;
 
@@ -544,7 +544,7 @@ public class A2CAgent<T> : DeepReinforcementLearningAgentBase<T>
     }
 
     /// <inheritdoc/>
-    public override Vector<T> ComputeGradients(
+    public Vector<T> ComputeGradients(
         Vector<T> input, Vector<T> target, ILossFunction<T>? lossFunction = null)
     {
         return GetParameters();

--- a/src/ReinforcementLearning/Agents/A3CAgent.cs
+++ b/src/ReinforcementLearning/Agents/A3CAgent.cs
@@ -61,7 +61,7 @@ namespace AiDotNet.ReinforcementLearning.Agents.A3C;
     "https://arxiv.org/abs/1602.01783",
     Year = 2016,
     Authors = "Mnih, V., Badia, A. P., Mirza, M., Graves, A., Lillicrap, T., Harley, T., Silver, D., & Kavukcuoglu, K.")]
-public class A3CAgent<T> : DeepReinforcementLearningAgentBase<T>
+public class A3CAgent<T> : DeepReinforcementLearningAgentBase<T>, IGradientComputable<T, Vector<T>, Vector<T>>
 {
     private readonly A3COptions<T> _options;
 
@@ -814,7 +814,7 @@ public class A3CAgent<T> : DeepReinforcementLearningAgentBase<T>
     }
 
     /// <inheritdoc/>
-    public override Vector<T> ComputeGradients(
+    public Vector<T> ComputeGradients(
         Vector<T> input, Vector<T> target, ILossFunction<T>? lossFunction = null)
     {
         return GetParameters();

--- a/src/ReinforcementLearning/Agents/CQLAgent.cs
+++ b/src/ReinforcementLearning/Agents/CQLAgent.cs
@@ -58,7 +58,7 @@ namespace AiDotNet.ReinforcementLearning.Agents.CQL;
     "https://arxiv.org/abs/2006.04779",
     Year = 2020,
     Authors = "Kumar, A., Zhou, A., Tucker, G., & Levine, S.")]
-public class CQLAgent<T> : DeepReinforcementLearningAgentBase<T>
+public class CQLAgent<T> : DeepReinforcementLearningAgentBase<T>, IGradientComputable<T, Vector<T>, Vector<T>>
 {
     private CQLOptions<T> _options;
 
@@ -604,7 +604,7 @@ public class CQLAgent<T> : DeepReinforcementLearningAgentBase<T>
     }
 
     /// <inheritdoc/>
-    public override Vector<T> ComputeGradients(
+    public Vector<T> ComputeGradients(
         Vector<T> input, Vector<T> target, ILossFunction<T>? lossFunction = null)
     {
         // CQL uses custom gradient computation - return zero gradients as placeholder

--- a/src/ReinforcementLearning/Agents/DDPGAgent.cs
+++ b/src/ReinforcementLearning/Agents/DDPGAgent.cs
@@ -63,7 +63,7 @@ namespace AiDotNet.ReinforcementLearning.Agents.DDPG;
     "https://arxiv.org/abs/1509.02971",
     Year = 2016,
     Authors = "Lillicrap, T. P., Hunt, J. J., Pritzel, A., Heess, N., Erez, T., Tassa, Y., Silver, D., & Wierstra, D.")]
-public class DDPGAgent<T> : DeepReinforcementLearningAgentBase<T>
+public class DDPGAgent<T> : DeepReinforcementLearningAgentBase<T>, IGradientComputable<T, Vector<T>, Vector<T>>
 {
     private DDPGOptions<T> _options;
 
@@ -549,7 +549,7 @@ public class DDPGAgent<T> : DeepReinforcementLearningAgentBase<T>
     }
 
     /// <inheritdoc/>
-    public override Vector<T> ComputeGradients(
+    public Vector<T> ComputeGradients(
         Vector<T> input, Vector<T> target, ILossFunction<T>? lossFunction = null)
     {
         throw new NotSupportedException(

--- a/src/ReinforcementLearning/Agents/DQNAgent.cs
+++ b/src/ReinforcementLearning/Agents/DQNAgent.cs
@@ -60,7 +60,7 @@ namespace AiDotNet.ReinforcementLearning.Agents.DQN;
     "https://arxiv.org/abs/1312.5602",
     Year = 2015,
     Authors = "Mnih, V., Kavukcuoglu, K., Silver, D., Rusu, A. A., Veness, J., Bellemare, M. G., et al.")]
-public class DQNAgent<T> : DeepReinforcementLearningAgentBase<T>, IActionValueProvider<T>
+public class DQNAgent<T> : DeepReinforcementLearningAgentBase<T>, IActionValueProvider<T>, IGradientComputable<T, Vector<T>, Vector<T>>
 {
     private DQNOptions<T> _dqnOptions;
 
@@ -403,7 +403,7 @@ public class DQNAgent<T> : DeepReinforcementLearningAgentBase<T>, IActionValuePr
     /// <c>ApplyGradients</c> requires. The gradient comes from the network's own tape pass, so no
     /// derivative is written by hand here.
     /// </remarks>
-    public override Vector<T> ComputeGradients(
+    public Vector<T> ComputeGradients(
         Vector<T> input,
         Vector<T> target,
         ILossFunction<T>? lossFunction = null)

--- a/src/ReinforcementLearning/Agents/DQNAgent.cs
+++ b/src/ReinforcementLearning/Agents/DQNAgent.cs
@@ -391,22 +391,29 @@ public class DQNAgent<T> : DeepReinforcementLearningAgentBase<T>, IActionValuePr
         return clone;
     }
 
-    /// <inheritdoc/>
+    /// <summary>
+    /// Computes gradients of the loss with respect to this agent's parameters, without updating them.
+    /// </summary>
+    /// <param name="input">The input state.</param>
+    /// <param name="target">The target output.</param>
+    /// <param name="lossFunction">The loss to differentiate, or null to use the agent's own.</param>
+    /// <returns>A gradient vector the same length as <c>GetParameters()</c>.</returns>
+    /// <remarks>
+    /// Returns PARAMETER-space gradients, as <c>IGradientComputable</c> documents and as
+    /// <c>ApplyGradients</c> requires. The gradient comes from the network's own tape pass, so no
+    /// derivative is written by hand here.
+    /// </remarks>
     public override Vector<T> ComputeGradients(
         Vector<T> input,
         Vector<T> target,
         ILossFunction<T>? lossFunction = null)
     {
-        var loss = lossFunction ?? LossFunction;
-        var inputTensor = Tensor<T>.FromVector(input);
-        var outputTensor = _qNetwork.Predict(inputTensor);
-        var output = outputTensor.ToVector();
-        var lossValue = loss.CalculateLoss(output, target);
-        var gradient = loss.CalculateDerivative(output, target);
-
-        var gradientTensor = Tensor<T>.FromVector(gradient);
-
-        return gradient;
+        return ComputeGradientsForNetwork(
+            _qNetwork,
+            new[] { _qNetwork },
+            input,
+            target,
+            lossFunction);
     }
 
     /// <inheritdoc/>
@@ -414,13 +421,11 @@ public class DQNAgent<T> : DeepReinforcementLearningAgentBase<T>, IActionValuePr
     {
         var currentParams = GetParameters();
 
-        // Validate that gradients vector has the correct length (parameter-space, not output-space)
         if (gradients.Length != currentParams.Length)
         {
             throw new ArgumentException(
-                $"Gradient vector length ({gradients.Length}) must match parameter vector length ({currentParams.Length}). " +
-                $"ApplyGradients expects parameter-space gradients (w.r.t. all network weights), not output-space gradients (w.r.t. network outputs). " +
-                $"Use _qNetwork.GetParameterGradients() after backpropagation to obtain parameter-space gradients.",
+                $"Gradient vector length ({gradients.Length}) must match parameter vector length "
+                + $"({currentParams.Length}).",
                 nameof(gradients));
         }
 

--- a/src/ReinforcementLearning/Agents/DecisionTransformerAgent.cs
+++ b/src/ReinforcementLearning/Agents/DecisionTransformerAgent.cs
@@ -447,17 +447,29 @@ public class DecisionTransformerAgent<T> : DeepReinforcementLearningAgentBase<T>
         return clone;
     }
 
+    /// <summary>
+    /// Computes gradients of the loss with respect to this agent's parameters, without updating them.
+    /// </summary>
+    /// <param name="input">The input state.</param>
+    /// <param name="target">The target output.</param>
+    /// <param name="lossFunction">The loss to differentiate, or null to use the agent's own.</param>
+    /// <returns>A gradient vector the same length as <c>GetParameters()</c>.</returns>
+    /// <remarks>
+    /// Returns PARAMETER-space gradients, as <c>IGradientComputable</c> documents and as
+    /// <c>ApplyGradients</c> requires. The gradient comes from the network's own tape pass, so no
+    /// derivative is written by hand here.
+    /// </remarks>
     public override Vector<T> ComputeGradients(
         Vector<T> input,
         Vector<T> target,
         ILossFunction<T>? lossFunction = null)
     {
-        var prediction = Predict(input);
-        var usedLossFunction = lossFunction ?? LossFunction;
-        var loss = usedLossFunction.CalculateLoss(prediction, target);
-
-        var gradient = usedLossFunction.CalculateDerivative(prediction, target);
-        return gradient;
+        return ComputeGradientsForNetwork(
+            _transformerNetwork,
+            new[] { _transformerNetwork },
+            input,
+            target,
+            lossFunction);
     }
 
     public override void SaveModel(string filepath)

--- a/src/ReinforcementLearning/Agents/DecisionTransformerAgent.cs
+++ b/src/ReinforcementLearning/Agents/DecisionTransformerAgent.cs
@@ -61,7 +61,7 @@ namespace AiDotNet.ReinforcementLearning.Agents.DecisionTransformer;
     "https://arxiv.org/abs/2106.01345",
     Year = 2021,
     Authors = "Chen, L., Lu, K., Rajeswaran, A., Lee, K., Grover, A., Laskin, M., Abbeel, P., Srinivas, A., & Mordatch, I.")]
-public class DecisionTransformerAgent<T> : DeepReinforcementLearningAgentBase<T>
+public class DecisionTransformerAgent<T> : DeepReinforcementLearningAgentBase<T>, IGradientComputable<T, Vector<T>, Vector<T>>
 {
     private DecisionTransformerOptions<T> _options;
 
@@ -459,7 +459,7 @@ public class DecisionTransformerAgent<T> : DeepReinforcementLearningAgentBase<T>
     /// <c>ApplyGradients</c> requires. The gradient comes from the network's own tape pass, so no
     /// derivative is written by hand here.
     /// </remarks>
-    public override Vector<T> ComputeGradients(
+    public Vector<T> ComputeGradients(
         Vector<T> input,
         Vector<T> target,
         ILossFunction<T>? lossFunction = null)

--- a/src/ReinforcementLearning/Agents/DeepReinforcementLearningAgentBase.cs
+++ b/src/ReinforcementLearning/Agents/DeepReinforcementLearningAgentBase.cs
@@ -137,4 +137,101 @@ public abstract class DeepReinforcementLearningAgentBase<T> : ReinforcementLearn
         // JIT compilation has been removed — always returns null
         return null;
     }
+
+    /// <summary>
+    /// Computes gradients of the loss with respect to this agent's PARAMETERS, laid out to match
+    /// <c>GetParameters()</c> so the result can be handed straight to <c>ApplyGradients</c>.
+    /// </summary>
+    /// <param name="trainedNetwork">The network on the forward path, whose parameters receive gradients.</param>
+    /// <param name="parameterOrder">
+    /// Every network contributing to <c>GetParameters()</c>, in the exact order that method
+    /// concatenates them. Networks other than <paramref name="trainedNetwork"/> get a zero slice.
+    /// </param>
+    /// <param name="input">The input state.</param>
+    /// <param name="target">The target output.</param>
+    /// <param name="lossFunction">The loss to differentiate, or null to use the agent's own.</param>
+    /// <returns>A gradient vector the same length as <c>GetParameters()</c>.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when a required argument is null.</exception>
+    /// <exception cref="NotSupportedException">
+    /// Thrown when <paramref name="trainedNetwork"/> cannot produce parameter gradients.
+    /// </exception>
+    /// <remarks>
+    /// <para>
+    /// <b>This returns parameter-space gradients, not output-space ones.</b> That is what
+    /// <see cref="IGradientComputable{T, TInput, TOutput}.ComputeGradients"/> promises -- "gradients
+    /// with respect to all model parameters" -- and what every consumer assumes: ApplyGradients
+    /// subtracts the vector from the parameters element-wise, and Elastic Weight Consolidation,
+    /// Gradient Episodic Memory and Memory Aware Synapses all build Fisher-information estimates
+    /// out of it. Returning the loss gradient with respect to the network OUTPUT, as these agents
+    /// previously did, produced a vector of the wrong length and the wrong meaning.
+    /// </para>
+    /// <para>
+    /// The gradient itself comes from the network's own tape pass, so the agent never expresses a
+    /// derivative of its own; a frozen target network is simply absent from the forward path and
+    /// therefore correctly receives zeros rather than being skipped and shifting the layout.
+    /// </para>
+    /// </remarks>
+    protected Vector<T> ComputeGradientsForNetwork(
+        INeuralNetwork<T> trainedNetwork,
+        IReadOnlyList<INeuralNetwork<T>> parameterOrder,
+        Vector<T> input,
+        Vector<T> target,
+        ILossFunction<T>? lossFunction)
+    {
+        if (trainedNetwork is null) throw new ArgumentNullException(nameof(trainedNetwork));
+        if (parameterOrder is null) throw new ArgumentNullException(nameof(parameterOrder));
+        if (input is null) throw new ArgumentNullException(nameof(input));
+        if (target is null) throw new ArgumentNullException(nameof(target));
+
+        if (trainedNetwork is not IGradientComputable<T, Tensor<T>, Tensor<T>> computable)
+        {
+            throw new NotSupportedException(
+                $"{GetType().Name} cannot compute parameter gradients because its network "
+                + $"({trainedNetwork.GetType().Name}) does not implement "
+                + "IGradientComputable<T, Tensor<T>, Tensor<T>>. Networks deriving from "
+                + "NeuralNetworkBase<T> do.");
+        }
+
+        var trainedGradients = computable.ComputeGradients(
+            Tensor<T>.FromVector(input),
+            Tensor<T>.FromVector(target),
+            lossFunction ?? LossFunction);
+
+        // Single-network agents are the common case and need no copying.
+        if (parameterOrder.Count == 1)
+        {
+            return trainedGradients;
+        }
+
+        int total = 0;
+        foreach (var network in parameterOrder)
+        {
+            total += (int)network.ParameterCount;
+        }
+
+        var gradients = new Vector<T>(total);
+        int offset = 0;
+        foreach (var network in parameterOrder)
+        {
+            int width = (int)network.ParameterCount;
+            if (ReferenceEquals(network, trainedNetwork))
+            {
+                if (trainedGradients.Length != width)
+                {
+                    throw new InvalidOperationException(
+                        $"{trainedNetwork.GetType().Name} returned {trainedGradients.Length} gradients "
+                        + $"for {width} parameters. The gradient layout must match GetParameters().");
+                }
+
+                for (int i = 0; i < width; i++)
+                {
+                    gradients[offset + i] = trainedGradients[i];
+                }
+            }
+
+            offset += width;
+        }
+
+        return gradients;
+    }
 }

--- a/src/ReinforcementLearning/Agents/DeepReinforcementLearningAgentBase.cs
+++ b/src/ReinforcementLearning/Agents/DeepReinforcementLearningAgentBase.cs
@@ -139,6 +139,43 @@ public abstract class DeepReinforcementLearningAgentBase<T> : ReinforcementLearn
     }
 
     /// <summary>
+    /// Applies pre-computed parameter-space gradients as a single gradient-descent step.
+    /// </summary>
+    /// <param name="gradients">Gradients laid out like <c>GetParameters()</c>.</param>
+    /// <param name="learningRate">The step size.</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="gradients"/> is null.</exception>
+    /// <exception cref="ArgumentException">
+    /// Thrown when <paramref name="gradients"/> is not the same length as the parameter vector.
+    /// </exception>
+    /// <remarks>
+    /// The length check is the point of this method rather than an afterthought: it is what
+    /// separates a genuine parameter-space gradient from the output-space vector these agents used
+    /// to return, which is shorter and means something else entirely. Failing loudly beats applying
+    /// a mismatched vector by index.
+    /// </remarks>
+    public virtual void ApplyGradients(Vector<T> gradients, T learningRate)
+    {
+        if (gradients is null) throw new ArgumentNullException(nameof(gradients));
+
+        var currentParams = GetParameters();
+        if (gradients.Length != currentParams.Length)
+        {
+            throw new ArgumentException(
+                $"Gradient vector length ({gradients.Length}) must match parameter vector length "
+                + $"({currentParams.Length}).",
+                nameof(gradients));
+        }
+
+        var updated = new Vector<T>(currentParams.Length);
+        for (int i = 0; i < currentParams.Length; i++)
+        {
+            updated[i] = NumOps.Subtract(currentParams[i], NumOps.Multiply(learningRate, gradients[i]));
+        }
+
+        SetParameters(updated);
+    }
+
+    /// <summary>
     /// Computes gradients of the loss with respect to this agent's PARAMETERS, laid out to match
     /// <c>GetParameters()</c> so the result can be handed straight to <c>ApplyGradients</c>.
     /// </summary>

--- a/src/ReinforcementLearning/Agents/DoubleDQNAgent.cs
+++ b/src/ReinforcementLearning/Agents/DoubleDQNAgent.cs
@@ -363,22 +363,29 @@ public class DoubleDQNAgent<T> : DeepReinforcementLearningAgentBase<T>, IActionV
         return clone;
     }
 
-    /// <inheritdoc/>
+    /// <summary>
+    /// Computes gradients of the loss with respect to this agent's parameters, without updating them.
+    /// </summary>
+    /// <param name="input">The input state.</param>
+    /// <param name="target">The target output.</param>
+    /// <param name="lossFunction">The loss to differentiate, or null to use the agent's own.</param>
+    /// <returns>A gradient vector the same length as <c>GetParameters()</c>.</returns>
+    /// <remarks>
+    /// Returns PARAMETER-space gradients, as <c>IGradientComputable</c> documents and as
+    /// <c>ApplyGradients</c> requires. The gradient comes from the network's own tape pass, so no
+    /// derivative is written by hand here.
+    /// </remarks>
     public override Vector<T> ComputeGradients(
         Vector<T> input,
         Vector<T> target,
         ILossFunction<T>? lossFunction = null)
     {
-        var loss = lossFunction ?? LossFunction;
-        var inputTensor = Tensor<T>.FromVector(input);
-        var outputTensor = _qNetwork.Predict(inputTensor);
-        var output = outputTensor.ToVector();
-        var lossValue = loss.CalculateLoss(output, target);
-        var gradient = loss.CalculateDerivative(output, target);
-
-        var gradientTensor = Tensor<T>.FromVector(gradient);
-
-        return gradient;
+        return ComputeGradientsForNetwork(
+            _qNetwork,
+            new[] { _qNetwork },
+            input,
+            target,
+            lossFunction);
     }
 
     /// <summary>

--- a/src/ReinforcementLearning/Agents/DoubleDQNAgent.cs
+++ b/src/ReinforcementLearning/Agents/DoubleDQNAgent.cs
@@ -61,7 +61,7 @@ namespace AiDotNet.ReinforcementLearning.Agents.DoubleDQN;
     "https://arxiv.org/abs/1509.06461",
     Year = 2016,
     Authors = "van Hasselt, H., Guez, A., & Silver, D.")]
-public class DoubleDQNAgent<T> : DeepReinforcementLearningAgentBase<T>, IActionValueProvider<T>
+public class DoubleDQNAgent<T> : DeepReinforcementLearningAgentBase<T>, IActionValueProvider<T>, IGradientComputable<T, Vector<T>, Vector<T>>
 {
     private DoubleDQNOptions<T> _options;
 
@@ -375,7 +375,7 @@ public class DoubleDQNAgent<T> : DeepReinforcementLearningAgentBase<T>, IActionV
     /// <c>ApplyGradients</c> requires. The gradient comes from the network's own tape pass, so no
     /// derivative is written by hand here.
     /// </remarks>
-    public override Vector<T> ComputeGradients(
+    public Vector<T> ComputeGradients(
         Vector<T> input,
         Vector<T> target,
         ILossFunction<T>? lossFunction = null)

--- a/src/ReinforcementLearning/Agents/DoubleQLearningAgent.cs
+++ b/src/ReinforcementLearning/Agents/DoubleQLearningAgent.cs
@@ -50,7 +50,7 @@ namespace AiDotNet.ReinforcementLearning.Agents.DoubleQLearning;
     "https://papers.nips.cc/paper/2010/hash/091d584fced301b442654dd8c23b3fc9-Abstract.html",
     Year = 2010,
     Authors = "van Hasselt, H.")]
-public class DoubleQLearningAgent<T> : ReinforcementLearningAgentBase<T>
+public class DoubleQLearningAgent<T> : ReinforcementLearningAgentBase<T>, IGradientComputable<T, Vector<T>, Vector<T>>
 {
     private DoubleQLearningOptions<T> _options;
 
@@ -363,12 +363,12 @@ public class DoubleQLearningAgent<T> : ReinforcementLearningAgentBase<T>
         return clone;
     }
 
-    public override Vector<T> ComputeGradients(Vector<T> input, Vector<T> target, ILossFunction<T>? lossFunction = null)
+    public Vector<T> ComputeGradients(Vector<T> input, Vector<T> target, ILossFunction<T>? lossFunction = null)
     {
         return GetParameters();
     }
 
-    public override void ApplyGradients(Vector<T> gradients, T learningRate) { }
+    public void ApplyGradients(Vector<T> gradients, T learningRate) { }
 
     public override void SaveModel(string filepath)
     {

--- a/src/ReinforcementLearning/Agents/DreamerAgent.cs
+++ b/src/ReinforcementLearning/Agents/DreamerAgent.cs
@@ -483,41 +483,6 @@ public class DreamerAgent<T> : DeepReinforcementLearningAgentBase<T>
         return clone;
     }
 
-    /// <summary>
-    /// Computes gradients for supervised learning scenarios.
-    /// </summary>
-    /// <remarks>
-    /// FIX ISSUE 9: This method uses simple supervised loss for compatibility with base class API.
-    /// It does NOT match the agent's internal training procedure which uses:
-    /// - World model losses (dynamics, reward, continue prediction)
-    /// - Imagination-based policy gradients
-    /// - Value function TD errors
-    ///
-    /// For actual agent training, use Train() which implements the full Dreamer algorithm.
-    /// This method is provided only for API compatibility and simple supervised fine-tuning scenarios.
-    /// </remarks>
-    public override Vector<T> ComputeGradients(
-        Vector<T> input,
-        Vector<T> target,
-        ILossFunction<T>? lossFunction = null)
-    {
-        var prediction = Predict(input);
-        var usedLossFunction = lossFunction ?? LossFunction;
-        var loss = usedLossFunction.CalculateLoss(prediction, target);
-
-        var gradient = usedLossFunction.CalculateDerivative(prediction, target);
-        return gradient;
-    }
-
-    public override void ApplyGradients(Vector<T> gradients, T learningRate)
-    {
-        throw new NotSupportedException(
-            "Dreamer agent requires per-network gradient distribution for six networks " +
-            "(VAE encoder/decoder, RNN world model, reward/continue/value predictors). " +
-            "The current signature cannot distribute gradients appropriately. " +
-            "Use the internal Train() method for training, which handles multi-network updates correctly.");
-    }
-
     public override void SaveModel(string filepath)
     {
         // FIX ISSUE 8: Throw NotSupportedException since Serialize is not supported

--- a/src/ReinforcementLearning/Agents/DuelingDQNAgent.cs
+++ b/src/ReinforcementLearning/Agents/DuelingDQNAgent.cs
@@ -213,7 +213,7 @@ public class DuelingDQNAgent<T> : DeepReinforcementLearningAgentBase<T>, IAction
             totalLoss = NumOps.Add(totalLoss, loss);
 
             // Backward pass through dueling architecture
-            var gradients = LossFunction.CalculateDerivative(currentQValues, targetQValues);
+            var gradients = LossFunction.ComputeGradient(currentQValues, targetQValues);
 
             // Update parameters
             _qNetwork.UpdateWeights(gradients, LearningRate);
@@ -345,41 +345,6 @@ public class DuelingDQNAgent<T> : DeepReinforcementLearningAgentBase<T>, IAction
         return clone;
     }
 
-    /// <inheritdoc/>
-    public override Vector<T> ComputeGradients(
-        Vector<T> input,
-        Vector<T> target,
-        ILossFunction<T>? lossFunction = null)
-    {
-        throw new NotSupportedException(
-            "ComputeGradients is not supported for DuelingDQNAgent; " +
-            "use the agent's internal Train() loop or expose layer gradients. " +
-            "DuelingNetwork stores gradients internally but does not expose them.");
-    }
-
-    /// <inheritdoc/>
-    public override void ApplyGradients(Vector<T> gradients, T learningRate)
-    {
-        var flatParams = _qNetwork.GetFlattenedParameters();
-        var currentParams = new Vector<T>(flatParams.Rows);
-        for (int i = 0; i < flatParams.Rows; i++)
-            currentParams[i] = flatParams[i, 0];
-
-        var newParams = new Vector<T>(currentParams.Length);
-
-        for (int i = 0; i < currentParams.Length; i++)
-        {
-            var gradValue = (i < gradients.Length) ? gradients[i] : NumOps.Zero;
-            var update = NumOps.Multiply(learningRate, gradValue);
-            newParams[i] = NumOps.Subtract(currentParams[i], update);
-        }
-
-        var matrix = new Matrix<T>(newParams.Length, 1);
-        for (int i = 0; i < newParams.Length; i++)
-            matrix[i, 0] = newParams[i];
-        _qNetwork.SetFlattenedParameters(matrix);
-    }
-
     // Helper methods
     private void CopyNetworkWeights(DuelingNetwork<T> source, DuelingNetwork<T> target)
     {
@@ -431,7 +396,7 @@ public class DuelingDQNAgent<T> : DeepReinforcementLearningAgentBase<T>, IAction
 /// <summary>
 /// Custom dueling network architecture that separates value and advantage streams.
 /// </summary>
-internal class DuelingNetwork<T>
+public class DuelingNetwork<T>
 {
     private readonly INumericOperations<T> _numOps;
     private readonly List<DenseLayer<T>> _sharedLayers;

--- a/src/ReinforcementLearning/Agents/DynaQAgent.cs
+++ b/src/ReinforcementLearning/Agents/DynaQAgent.cs
@@ -324,20 +324,6 @@ public class DynaQAgent<T> : ReinforcementLearningAgentBase<T>
         return clone;
     }
 
-    public override Vector<T> ComputeGradients(Vector<T> input, Vector<T> target, ILossFunction<T>? lossFunction = null)
-    {
-        var pred = Predict(input);
-        var lf = lossFunction ?? LossFunction;
-        var loss = lf.CalculateLoss(pred, target);
-        var grad = lf.CalculateDerivative(pred, target);
-        return grad;
-    }
-
-    public override void ApplyGradients(Vector<T> gradients, T learningRate)
-    {
-        throw new NotSupportedException("Dyna-Q uses direct Q-value updates via temporal difference learning, not gradient-based optimization.");
-    }
-
     public override void SaveModel(string filepath)
     {
         if (string.IsNullOrWhiteSpace(filepath))

--- a/src/ReinforcementLearning/Agents/DynaQPlusAgent.cs
+++ b/src/ReinforcementLearning/Agents/DynaQPlusAgent.cs
@@ -329,13 +329,6 @@ public class DynaQPlusAgent<T> : ReinforcementLearningAgentBase<T>
 
         return clone;
     }
-    public override Vector<T> ComputeGradients(Vector<T> input, Vector<T> target, ILossFunction<T>? lossFunction = null) { var pred = Predict(input); var lf = lossFunction ?? LossFunction; var loss = lf.CalculateLoss(pred, target); var grad = lf.CalculateDerivative(pred, target); return grad; }
-    public override void ApplyGradients(Vector<T> gradients, T learningRate)
-    {
-        // Dyna-Q+ uses model-based planning with Q-learning updates, not gradient-based optimization
-        // This method is not applicable for tabular Q-learning methods
-        throw new NotSupportedException("Dyna-Q+ uses model-based planning with Q-learning updates, not gradient-based optimization. Use StoreExperience for updates.");
-    }
     public override void SaveModel(string filepath)
     {
         if (string.IsNullOrWhiteSpace(filepath))

--- a/src/ReinforcementLearning/Agents/EpsilonGreedyBanditAgent.cs
+++ b/src/ReinforcementLearning/Agents/EpsilonGreedyBanditAgent.cs
@@ -195,8 +195,6 @@ public class EpsilonGreedyBanditAgent<T> : ReinforcementLearningAgentBase<T>
         }
         return clone;
     }
-    public override Vector<T> ComputeGradients(Vector<T> input, Vector<T> target, ILossFunction<T>? lossFunction = null) { var pred = Predict(input); var lf = lossFunction ?? LossFunction; var predMatrix = new Matrix<T>(new[] { pred }); var targetMatrix = new Matrix<T>(new[] { target }); var loss = lf.CalculateLoss(predMatrix.GetRow(0), targetMatrix.GetRow(0)); var grad = lf.CalculateDerivative(predMatrix.GetRow(0), targetMatrix.GetRow(0)); return grad; }
-    public override void ApplyGradients(Vector<T> gradients, T learningRate) { }
     public override void SaveModel(string filepath) { var data = Serialize(); System.IO.File.WriteAllBytes(filepath, data); }
     public override void LoadModel(string filepath) { var data = System.IO.File.ReadAllBytes(filepath); Deserialize(data); }
 }

--- a/src/ReinforcementLearning/Agents/EveryVisitMonteCarloAgent.cs
+++ b/src/ReinforcementLearning/Agents/EveryVisitMonteCarloAgent.cs
@@ -40,7 +40,7 @@ namespace AiDotNet.ReinforcementLearning.Agents.MonteCarlo;
     "https://incompleteideas.net/book/the-book-2nd.html",
     Year = 2018,
     Authors = "Sutton, R. S. & Barto, A. G.")]
-public class EveryVisitMonteCarloAgent<T> : ReinforcementLearningAgentBase<T>
+public class EveryVisitMonteCarloAgent<T> : ReinforcementLearningAgentBase<T>, IGradientComputable<T, Vector<T>, Vector<T>>
 {
     private MonteCarloOptions<T> _options;
 
@@ -371,12 +371,12 @@ public class EveryVisitMonteCarloAgent<T> : ReinforcementLearningAgentBase<T>
         return clone;
     }
 
-    public override Vector<T> ComputeGradients(Vector<T> input, Vector<T> target, ILossFunction<T>? lossFunction = null)
+    public Vector<T> ComputeGradients(Vector<T> input, Vector<T> target, ILossFunction<T>? lossFunction = null)
     {
         return GetParameters();
     }
 
-    public override void ApplyGradients(Vector<T> gradients, T learningRate) { }
+    public void ApplyGradients(Vector<T> gradients, T learningRate) { }
 
     public override void SaveModel(string filepath)
     {

--- a/src/ReinforcementLearning/Agents/ExpectedSARSAAgent.cs
+++ b/src/ReinforcementLearning/Agents/ExpectedSARSAAgent.cs
@@ -52,7 +52,7 @@ namespace AiDotNet.ReinforcementLearning.Agents.ExpectedSARSA;
     "https://doi.org/10.1109/ADPRL.2009.4927542",
     Year = 2009,
     Authors = "van Seijen, H., van Hasselt, H., Whiteson, S., & Wiering, M.")]
-public class ExpectedSARSAAgent<T> : ReinforcementLearningAgentBase<T>
+public class ExpectedSARSAAgent<T> : ReinforcementLearningAgentBase<T>, IGradientComputable<T, Vector<T>, Vector<T>>
 {
     private ExpectedSARSAOptions<T> _options;
 
@@ -345,12 +345,12 @@ public class ExpectedSARSAAgent<T> : ReinforcementLearningAgentBase<T>
         return clone;
     }
 
-    public override Vector<T> ComputeGradients(Vector<T> input, Vector<T> target, ILossFunction<T>? lossFunction = null)
+    public Vector<T> ComputeGradients(Vector<T> input, Vector<T> target, ILossFunction<T>? lossFunction = null)
     {
         return GetParameters();
     }
 
-    public override void ApplyGradients(Vector<T> gradients, T learningRate) { }
+    public void ApplyGradients(Vector<T> gradients, T learningRate) { }
 
     public override void SaveModel(string filepath)
     {

--- a/src/ReinforcementLearning/Agents/FirstVisitMonteCarloAgent.cs
+++ b/src/ReinforcementLearning/Agents/FirstVisitMonteCarloAgent.cs
@@ -53,7 +53,7 @@ namespace AiDotNet.ReinforcementLearning.Agents.MonteCarlo;
     "https://incompleteideas.net/book/the-book-2nd.html",
     Year = 2018,
     Authors = "Sutton, R. S. & Barto, A. G.")]
-public class FirstVisitMonteCarloAgent<T> : ReinforcementLearningAgentBase<T>
+public class FirstVisitMonteCarloAgent<T> : ReinforcementLearningAgentBase<T>, IGradientComputable<T, Vector<T>, Vector<T>>
 {
     private MonteCarloOptions<T> _options;
 
@@ -363,12 +363,12 @@ public class FirstVisitMonteCarloAgent<T> : ReinforcementLearningAgentBase<T>
         return clone;
     }
 
-    public override Vector<T> ComputeGradients(Vector<T> input, Vector<T> target, ILossFunction<T>? lossFunction = null)
+    public Vector<T> ComputeGradients(Vector<T> input, Vector<T> target, ILossFunction<T>? lossFunction = null)
     {
         return GetParameters();
     }
 
-    public override void ApplyGradients(Vector<T> gradients, T learningRate) { }
+    public void ApplyGradients(Vector<T> gradients, T learningRate) { }
 
     public override void SaveModel(string filepath)
     {

--- a/src/ReinforcementLearning/Agents/GradientBanditAgent.cs
+++ b/src/ReinforcementLearning/Agents/GradientBanditAgent.cs
@@ -286,8 +286,6 @@ public class GradientBanditAgent<T> : ReinforcementLearningAgentBase<T>
         clone._totalSteps = _totalSteps;
         return clone;
     }
-    public override Vector<T> ComputeGradients(Vector<T> input, Vector<T> target, ILossFunction<T>? lossFunction = null) { var pred = Predict(input); var lf = lossFunction ?? LossFunction; var predMatrix = new Matrix<T>(new[] { pred }); var targetMatrix = new Matrix<T>(new[] { target }); var loss = lf.CalculateLoss(predMatrix.GetRow(0), targetMatrix.GetRow(0)); var grad = lf.CalculateDerivative(predMatrix.GetRow(0), targetMatrix.GetRow(0)); return grad; }
-    public override void ApplyGradients(Vector<T> gradients, T learningRate) { }
     public override void SaveModel(string filepath) { var data = Serialize(); System.IO.File.WriteAllBytes(filepath, data); }
     public override void LoadModel(string filepath) { var data = System.IO.File.ReadAllBytes(filepath); Deserialize(data); }
 }

--- a/src/ReinforcementLearning/Agents/IQLAgent.cs
+++ b/src/ReinforcementLearning/Agents/IQLAgent.cs
@@ -63,7 +63,7 @@ namespace AiDotNet.ReinforcementLearning.Agents.IQL;
     "https://arxiv.org/abs/2110.06169",
     Year = 2022,
     Authors = "Kostrikov, I., Nair, A., & Levine, S.")]
-public class IQLAgent<T> : DeepReinforcementLearningAgentBase<T>
+public class IQLAgent<T> : DeepReinforcementLearningAgentBase<T>, IGradientComputable<T, Vector<T>, Vector<T>>
 {
     private IQLOptions<T> _options;
 
@@ -498,7 +498,7 @@ public class IQLAgent<T> : DeepReinforcementLearningAgentBase<T>
     }
 
     /// <inheritdoc/>
-    public override Vector<T> ComputeGradients(
+    public Vector<T> ComputeGradients(
         Vector<T> input,
         Vector<T> target,
         ILossFunction<T>? lossFunction = null)

--- a/src/ReinforcementLearning/Agents/LSPIAgent.cs
+++ b/src/ReinforcementLearning/Agents/LSPIAgent.cs
@@ -503,19 +503,6 @@ public class LSPIAgent<T> : ReinforcementLearningAgentBase<T>
         clone._iterations = _iterations;
         return clone;
     }
-
-    public override Vector<T> ComputeGradients(Vector<T> input, Vector<T> target, ILossFunction<T>? lossFunction = null)
-    {
-        var pred = Predict(input);
-        var lf = lossFunction ?? LossFunction;
-        var predMatrix = new Matrix<T>(new[] { pred });
-        var targetMatrix = new Matrix<T>(new[] { target });
-        var loss = lf.CalculateLoss(predMatrix.GetRow(0), targetMatrix.GetRow(0));
-        var grad = lf.CalculateDerivative(predMatrix.GetRow(0), targetMatrix.GetRow(0));
-        return grad;
-    }
-
-    public override void ApplyGradients(Vector<T> gradients, T learningRate) { }
     public override void SaveModel(string filepath) { var data = Serialize(); System.IO.File.WriteAllBytes(filepath, data); }
     public override void LoadModel(string filepath) { var data = System.IO.File.ReadAllBytes(filepath); Deserialize(data); }
 }

--- a/src/ReinforcementLearning/Agents/LSTDAgent.cs
+++ b/src/ReinforcementLearning/Agents/LSTDAgent.cs
@@ -419,19 +419,6 @@ public class LSTDAgent<T> : ReinforcementLearningAgentBase<T>
         return clone;
     }
 
-    public override Vector<T> ComputeGradients(Vector<T> input, Vector<T> target, ILossFunction<T>? lossFunction = null)
-    {
-        var pred = Predict(input);
-        var lf = lossFunction ?? LossFunction;
-        var predMatrix = new Matrix<T>(new[] { pred });
-        var targetMatrix = new Matrix<T>(new[] { target });
-        var loss = lf.CalculateLoss(predMatrix.GetRow(0), targetMatrix.GetRow(0));
-        var grad = lf.CalculateDerivative(predMatrix.GetRow(0), targetMatrix.GetRow(0));
-        return grad;
-    }
-
-    public override void ApplyGradients(Vector<T> gradients, T learningRate) { }
-
     public override void SaveModel(string filepath)
     {
         if (string.IsNullOrWhiteSpace(filepath))

--- a/src/ReinforcementLearning/Agents/LinearQLearningAgent.cs
+++ b/src/ReinforcementLearning/Agents/LinearQLearningAgent.cs
@@ -318,42 +318,6 @@ public class LinearQLearningAgent<T> : ReinforcementLearningAgentBase<T>
     }
 
     public override IFullModel<T, Vector<T>, Vector<T>> Clone() => new LinearQLearningAgent<T>(_options);
-
-    public override Vector<T> ComputeGradients(Vector<T> input, Vector<T> target, ILossFunction<T>? lossFunction = null)
-    {
-        var pred = Predict(input);
-        var lf = lossFunction ?? LossFunction;
-        var loss = lf.CalculateLoss(pred, target);
-        var gradients = lf.CalculateDerivative(pred, target);
-        return gradients;
-    }
-
-    public override void ApplyGradients(Vector<T> gradients, T learningRate)
-    {
-        if (gradients == null)
-        {
-            throw new ArgumentNullException(nameof(gradients));
-        }
-
-        // Gradients should be flattened from weight matrix [ActionSize x FeatureSize]
-        int expectedSize = _options.ActionSize * _options.FeatureSize;
-        if (gradients.Length != expectedSize)
-        {
-            throw new ArgumentException($"Gradient vector length {gradients.Length} does not match expected size {expectedSize}");
-        }
-
-        // Apply gradients to weight matrix
-        int index = 0;
-        for (int a = 0; a < _options.ActionSize; a++)
-        {
-            for (int f = 0; f < _options.FeatureSize; f++)
-            {
-                T update = NumOps.Multiply(learningRate, gradients[index]);
-                _weights[a, f] = NumOps.Subtract(_weights[a, f], update);  // Gradient descent
-                index++;
-            }
-        }
-    }
     public override void SaveModel(string filepath) { var data = Serialize(); System.IO.File.WriteAllBytes(filepath, data); }
     public override void LoadModel(string filepath) { var data = System.IO.File.ReadAllBytes(filepath); Deserialize(data); }
 }

--- a/src/ReinforcementLearning/Agents/LinearSARSAAgent.cs
+++ b/src/ReinforcementLearning/Agents/LinearSARSAAgent.cs
@@ -302,17 +302,6 @@ public class LinearSARSAAgent<T> : ReinforcementLearningAgentBase<T>
     }
 
     public override IFullModel<T, Vector<T>, Vector<T>> Clone() => new LinearSARSAAgent<T>(_options);
-
-    public override Vector<T> ComputeGradients(Vector<T> input, Vector<T> target, ILossFunction<T>? lossFunction = null)
-    {
-        var pred = Predict(input);
-        var lf = lossFunction ?? LossFunction;
-        var loss = lf.CalculateLoss(pred, target);
-        var grad = lf.CalculateDerivative(pred, target);
-        return grad;
-    }
-
-    public override void ApplyGradients(Vector<T> gradients, T learningRate) { }
     public override void SaveModel(string filepath) { var data = Serialize(); System.IO.File.WriteAllBytes(filepath, data); }
     public override void LoadModel(string filepath) { var data = System.IO.File.ReadAllBytes(filepath); Deserialize(data); }
 }

--- a/src/ReinforcementLearning/Agents/MADDPGAgent.cs
+++ b/src/ReinforcementLearning/Agents/MADDPGAgent.cs
@@ -884,34 +884,6 @@ public class MADDPGAgent<T> : DeepReinforcementLearningAgentBase<T>
         return clonedAgent;
     }
 
-    public override Vector<T> ComputeGradients(
-        Vector<T> input,
-        Vector<T> target,
-        ILossFunction<T>? lossFunction = null)
-    {
-        var prediction = Predict(input);
-        var usedLossFunction = lossFunction ?? LossFunction;
-        var loss = usedLossFunction.CalculateLoss(prediction, target);
-
-        var gradient = usedLossFunction.CalculateDerivative(prediction, target);
-        return gradient;
-    }
-
-    /// <summary>
-    /// Not supported for MADDPGAgent. Use the agent's internal Train() loop instead.
-    /// </summary>
-    /// <param name="gradients">Not used.</param>
-    /// <param name="learningRate">Not used.</param>
-    /// <exception cref="NotSupportedException">
-    /// Always thrown. MADDPG manages gradient computation and parameter updates internally through backpropagation.
-    /// </exception>
-    public override void ApplyGradients(Vector<T> gradients, T learningRate)
-    {
-        throw new NotSupportedException(
-            "ApplyGradients is not supported for MADDPGAgent; use the agent's internal Train() loop. " +
-            "MADDPG manages gradient computation and parameter updates internally through backpropagation.");
-    }
-
     /// <summary>
     /// Saves the trained model to a file.
     /// </summary>

--- a/src/ReinforcementLearning/Agents/ModifiedPolicyIterationAgent.cs
+++ b/src/ReinforcementLearning/Agents/ModifiedPolicyIterationAgent.cs
@@ -439,23 +439,6 @@ public class ModifiedPolicyIterationAgent<T> : ReinforcementLearningAgentBase<T>
         return clone;
     }
 
-    public override Vector<T> ComputeGradients(
-        Vector<T> input,
-        Vector<T> target,
-        ILossFunction<T>? lossFunction = null)
-    {
-        var prediction = Predict(input);
-        var usedLossFunction = lossFunction ?? LossFunction;
-        var loss = usedLossFunction.CalculateLoss(prediction, target);
-        var gradient = usedLossFunction.CalculateDerivative(prediction, target);
-        return gradient;
-    }
-
-    public override void ApplyGradients(Vector<T> gradients, T learningRate)
-    {
-        // DP methods don't use gradients
-    }
-
     public override void SaveModel(string filepath)
     {
         if (string.IsNullOrWhiteSpace(filepath))

--- a/src/ReinforcementLearning/Agents/MonteCarloExploringStartsAgent.cs
+++ b/src/ReinforcementLearning/Agents/MonteCarloExploringStartsAgent.cs
@@ -392,24 +392,6 @@ public class MonteCarloExploringStartsAgent<T> : ReinforcementLearningAgentBase<
         return clone;
     }
 
-    public override Vector<T> ComputeGradients(
-        Vector<T> input,
-        Vector<T> target,
-        ILossFunction<T>? lossFunction = null)
-    {
-        var prediction = Predict(input);
-        var usedLossFunction = lossFunction ?? LossFunction;
-        // Loss computation not used in Monte Carlo methods
-
-        var gradient = usedLossFunction.CalculateDerivative(prediction, target);
-        return gradient;
-    }
-
-    public override void ApplyGradients(Vector<T> gradients, T learningRate)
-    {
-        // Monte Carlo methods don't use gradients in the traditional sense
-    }
-
     public override void SaveModel(string filepath)
     {
         if (string.IsNullOrWhiteSpace(filepath))

--- a/src/ReinforcementLearning/Agents/MuZeroAgent.cs
+++ b/src/ReinforcementLearning/Agents/MuZeroAgent.cs
@@ -647,7 +647,6 @@ public class MuZeroAgent<T> : DeepReinforcementLearningAgentBase<T>
         net.UpdateParameters(updated);
     }
 
-
     private Vector<T> ConcatenateVectors(Vector<T> a, Vector<T> b)
     {
         var result = new Vector<T>(a.Length + b.Length);
@@ -923,30 +922,6 @@ public class MuZeroAgent<T> : DeepReinforcementLearningAgentBase<T>
         var copy = new MuZeroAgent<T>(new MuZeroOptions<T>(_options));
         copy.SetParameters(GetParameters());
         return copy;
-    }
-
-    public override Vector<T> ComputeGradients(
-        Vector<T> input,
-        Vector<T> target,
-        ILossFunction<T>? lossFunction = null)
-    {
-        var prediction = Predict(input);
-        var usedLossFunction = lossFunction ?? LossFunction;
-        var gradient = usedLossFunction.CalculateDerivative(prediction, target);
-        return gradient;
-    }
-
-    public override void ApplyGradients(Vector<T> gradients, T learningRate)
-    {
-        var currentParams = GetParameters();
-        if (gradients.Length != currentParams.Length)
-        {
-            throw new ArgumentException(
-                $"Gradient vector length ({gradients.Length}) must match parameter count ({currentParams.Length}).",
-                nameof(gradients));
-        }
-
-        SetParameters(Engine.Subtract(currentParams, Engine.Multiply(gradients, learningRate)));
     }
 
     public override void SaveModel(string filepath)

--- a/src/ReinforcementLearning/Agents/NStepQLearningAgent.cs
+++ b/src/ReinforcementLearning/Agents/NStepQLearningAgent.cs
@@ -39,7 +39,7 @@ namespace AiDotNet.ReinforcementLearning.Agents.NStepQLearning;
     "https://incompleteideas.net/book/the-book-2nd.html",
     Year = 2018,
     Authors = "Sutton, R. S. & Barto, A. G.")]
-public class NStepQLearningAgent<T> : ReinforcementLearningAgentBase<T>
+public class NStepQLearningAgent<T> : ReinforcementLearningAgentBase<T>, IGradientComputable<T, Vector<T>, Vector<T>>
 {
     private NStepQLearningOptions<T> _options;
 
@@ -301,12 +301,12 @@ public class NStepQLearningAgent<T> : ReinforcementLearningAgentBase<T>
         return clone;
     }
 
-    public override Vector<T> ComputeGradients(Vector<T> input, Vector<T> target, ILossFunction<T>? lossFunction = null)
+    public Vector<T> ComputeGradients(Vector<T> input, Vector<T> target, ILossFunction<T>? lossFunction = null)
     {
         return GetParameters();
     }
 
-    public override void ApplyGradients(Vector<T> gradients, T learningRate) { }
+    public void ApplyGradients(Vector<T> gradients, T learningRate) { }
 
     public override void SaveModel(string filepath)
     {

--- a/src/ReinforcementLearning/Agents/NStepSARSAAgent.cs
+++ b/src/ReinforcementLearning/Agents/NStepSARSAAgent.cs
@@ -52,7 +52,7 @@ namespace AiDotNet.ReinforcementLearning.Agents.NStepSARSA;
     "https://incompleteideas.net/book/the-book-2nd.html",
     Year = 2018,
     Authors = "Sutton, R. S. & Barto, A. G.")]
-public class NStepSARSAAgent<T> : ReinforcementLearningAgentBase<T>
+public class NStepSARSAAgent<T> : ReinforcementLearningAgentBase<T>, IGradientComputable<T, Vector<T>, Vector<T>>
 {
     private NStepSARSAOptions<T> _options;
 
@@ -322,12 +322,12 @@ public class NStepSARSAAgent<T> : ReinforcementLearningAgentBase<T>
         return clone;
     }
 
-    public override Vector<T> ComputeGradients(Vector<T> input, Vector<T> target, ILossFunction<T>? lossFunction = null)
+    public Vector<T> ComputeGradients(Vector<T> input, Vector<T> target, ILossFunction<T>? lossFunction = null)
     {
         return GetParameters();
     }
 
-    public override void ApplyGradients(Vector<T> gradients, T learningRate) { }
+    public void ApplyGradients(Vector<T> gradients, T learningRate) { }
 
     public override void SaveModel(string filepath)
     {

--- a/src/ReinforcementLearning/Agents/OffPolicyMonteCarloAgent.cs
+++ b/src/ReinforcementLearning/Agents/OffPolicyMonteCarloAgent.cs
@@ -393,24 +393,6 @@ public class OffPolicyMonteCarloAgent<T> : ReinforcementLearningAgentBase<T>
         return clone;
     }
 
-    public override Vector<T> ComputeGradients(
-        Vector<T> input,
-        Vector<T> target,
-        ILossFunction<T>? lossFunction = null)
-    {
-        var prediction = Predict(input);
-        var usedLossFunction = lossFunction ?? LossFunction;
-        // Loss computation not used in Monte Carlo methods
-
-        var gradient = usedLossFunction.CalculateDerivative(prediction, target);
-        return gradient;
-    }
-
-    public override void ApplyGradients(Vector<T> gradients, T learningRate)
-    {
-        // Monte Carlo methods don't use gradients in the traditional sense
-    }
-
     public override void SaveModel(string filepath)
     {
         if (string.IsNullOrWhiteSpace(filepath))

--- a/src/ReinforcementLearning/Agents/OnPolicyMonteCarloAgent.cs
+++ b/src/ReinforcementLearning/Agents/OnPolicyMonteCarloAgent.cs
@@ -387,24 +387,6 @@ public class OnPolicyMonteCarloAgent<T> : ReinforcementLearningAgentBase<T>
         return clone;
     }
 
-    public override Vector<T> ComputeGradients(
-        Vector<T> input,
-        Vector<T> target,
-        ILossFunction<T>? lossFunction = null)
-    {
-        var prediction = Predict(input);
-        var usedLossFunction = lossFunction ?? LossFunction;
-        // Loss computation not used in Monte Carlo methods
-
-        var gradient = usedLossFunction.CalculateDerivative(prediction, target);
-        return gradient;
-    }
-
-    public override void ApplyGradients(Vector<T> gradients, T learningRate)
-    {
-        // Monte Carlo methods don't use gradients in the traditional sense
-    }
-
     public override void SaveModel(string filepath)
     {
         throw new NotSupportedException(

--- a/src/ReinforcementLearning/Agents/PPOAgent.cs
+++ b/src/ReinforcementLearning/Agents/PPOAgent.cs
@@ -64,7 +64,7 @@ namespace AiDotNet.ReinforcementLearning.Agents.PPO;
     "https://arxiv.org/abs/1707.06347",
     Year = 2017,
     Authors = "Schulman, J., Wolski, F., Dhariwal, P., Radford, A., & Klimov, O.")]
-public class PPOAgent<T> : DeepReinforcementLearningAgentBase<T>
+public class PPOAgent<T> : DeepReinforcementLearningAgentBase<T>, IGradientComputable<T, Vector<T>, Vector<T>>
 {
     private PPOOptions<T> _ppoOptions;
 
@@ -688,7 +688,7 @@ public class PPOAgent<T> : DeepReinforcementLearningAgentBase<T>
     }
 
     /// <inheritdoc/>
-    public override Vector<T> ComputeGradients(
+    public Vector<T> ComputeGradients(
         Vector<T> input,
         Vector<T> target,
         ILossFunction<T>? lossFunction = null)

--- a/src/ReinforcementLearning/Agents/PolicyIterationAgent.cs
+++ b/src/ReinforcementLearning/Agents/PolicyIterationAgent.cs
@@ -401,23 +401,6 @@ public class PolicyIterationAgent<T> : ReinforcementLearningAgentBase<T>
         return clone;
     }
 
-    public override Vector<T> ComputeGradients(
-        Vector<T> input,
-        Vector<T> target,
-        ILossFunction<T>? lossFunction = null)
-    {
-        var prediction = Predict(input);
-        var usedLossFunction = lossFunction ?? LossFunction;
-        var loss = usedLossFunction.CalculateLoss(prediction, target);
-        var gradient = usedLossFunction.CalculateDerivative(prediction, target);
-        return gradient;
-    }
-
-    public override void ApplyGradients(Vector<T> gradients, T learningRate)
-    {
-        // DP methods don't use gradients
-    }
-
     public override void SaveModel(string filepath)
     {
         if (string.IsNullOrWhiteSpace(filepath))

--- a/src/ReinforcementLearning/Agents/PrioritizedSweepingAgent.cs
+++ b/src/ReinforcementLearning/Agents/PrioritizedSweepingAgent.cs
@@ -357,11 +357,6 @@ public class PrioritizedSweepingAgent<T> : ReinforcementLearningAgentBase<T>
 
         return cloned;
     }
-    public override Vector<T> ComputeGradients(Vector<T> input, Vector<T> target, ILossFunction<T>? lossFunction = null) { var pred = Predict(input); var lf = lossFunction ?? LossFunction; var loss = lf.CalculateLoss(pred, target); var grad = lf.CalculateDerivative(pred, target); return grad; }
-    public override void ApplyGradients(Vector<T> gradients, T learningRate)
-    {
-        throw new NotSupportedException("Gradient-based updates are not supported for tabular reinforcement learning agents. Q-values are updated directly through temporal difference learning in StoreExperience().");
-    }
 
     public override void SaveModel(string filepath)
     {

--- a/src/ReinforcementLearning/Agents/QLambdaAgent.cs
+++ b/src/ReinforcementLearning/Agents/QLambdaAgent.cs
@@ -339,8 +339,6 @@ public class QLambdaAgent<T> : ReinforcementLearningAgentBase<T>
 
         return clone;
     }
-    public override Vector<T> ComputeGradients(Vector<T> input, Vector<T> target, ILossFunction<T>? lossFunction = null) { var pred = Predict(input); var lf = lossFunction ?? LossFunction; var loss = lf.CalculateLoss(pred, target); var grad = lf.CalculateDerivative(pred, target); return grad; }
-    public override void ApplyGradients(Vector<T> gradients, T learningRate) { }
     public override void SaveModel(string filepath)
     {
         if (string.IsNullOrWhiteSpace(filepath))

--- a/src/ReinforcementLearning/Agents/QMIXAgent.cs
+++ b/src/ReinforcementLearning/Agents/QMIXAgent.cs
@@ -818,17 +818,29 @@ public class QMIXAgent<T> : DeepReinforcementLearningAgentBase<T>
         return clonedAgent;
     }
 
+    /// <summary>
+    /// Computes gradients of the loss with respect to this agent's parameters, without updating them.
+    /// </summary>
+    /// <param name="input">The input state.</param>
+    /// <param name="target">The target output.</param>
+    /// <param name="lossFunction">The loss to differentiate, or null to use the agent's own.</param>
+    /// <returns>A gradient vector the same length as <c>GetParameters()</c>.</returns>
+    /// <remarks>
+    /// Returns PARAMETER-space gradients, as <c>IGradientComputable</c> documents and as
+    /// <c>ApplyGradients</c> requires. The gradient comes from the network's own tape pass, so no
+    /// derivative is written by hand here.
+    /// </remarks>
     public override Vector<T> ComputeGradients(
         Vector<T> input,
         Vector<T> target,
         ILossFunction<T>? lossFunction = null)
     {
-        var prediction = Predict(input);
-        var usedLossFunction = lossFunction ?? LossFunction;
-        var loss = usedLossFunction.CalculateLoss(prediction, target);
-
-        var gradient = usedLossFunction.CalculateDerivative(prediction, target);
-        return gradient;
+        return ComputeGradientsForNetwork(
+            _mixingNetwork,
+            new[] { _mixingNetwork },
+            input,
+            target,
+            lossFunction);
     }
 
     public override void SaveModel(string filepath)

--- a/src/ReinforcementLearning/Agents/QMIXAgent.cs
+++ b/src/ReinforcementLearning/Agents/QMIXAgent.cs
@@ -61,7 +61,7 @@ namespace AiDotNet.ReinforcementLearning.Agents.QMIX;
     "https://arxiv.org/abs/1803.11485",
     Year = 2018,
     Authors = "Rashid, T., Samvelyan, M., de Witt, C. S., Farquhar, G., Foerster, J., & Whiteson, S.")]
-public class QMIXAgent<T> : DeepReinforcementLearningAgentBase<T>
+public class QMIXAgent<T> : DeepReinforcementLearningAgentBase<T>, IGradientComputable<T, Vector<T>, Vector<T>>
 {
     private QMIXOptions<T> _options;
 
@@ -830,7 +830,7 @@ public class QMIXAgent<T> : DeepReinforcementLearningAgentBase<T>
     /// <c>ApplyGradients</c> requires. The gradient comes from the network's own tape pass, so no
     /// derivative is written by hand here.
     /// </remarks>
-    public override Vector<T> ComputeGradients(
+    public Vector<T> ComputeGradients(
         Vector<T> input,
         Vector<T> target,
         ILossFunction<T>? lossFunction = null)

--- a/src/ReinforcementLearning/Agents/REINFORCEAgent.cs
+++ b/src/ReinforcementLearning/Agents/REINFORCEAgent.cs
@@ -67,7 +67,7 @@ namespace AiDotNet.ReinforcementLearning.Agents.REINFORCE;
     "https://link.springer.com/article/10.1007/BF00992696",
     Year = 1992,
     Authors = "Williams, R. J.")]
-public class REINFORCEAgent<T> : DeepReinforcementLearningAgentBase<T>
+public class REINFORCEAgent<T> : DeepReinforcementLearningAgentBase<T>, IGradientComputable<T, Vector<T>, Vector<T>>
 {
     private REINFORCEOptions<T> _reinforceOptions;
 
@@ -465,7 +465,7 @@ public class REINFORCEAgent<T> : DeepReinforcementLearningAgentBase<T>
     }
 
     /// <inheritdoc/>
-    public override Vector<T> ComputeGradients(
+    public Vector<T> ComputeGradients(
         Vector<T> input, Vector<T> target, ILossFunction<T>? lossFunction = null)
     {
         return GetParameters();

--- a/src/ReinforcementLearning/Agents/RainbowDQNAgent.cs
+++ b/src/ReinforcementLearning/Agents/RainbowDQNAgent.cs
@@ -60,7 +60,7 @@ namespace AiDotNet.ReinforcementLearning.Agents.Rainbow;
     "https://arxiv.org/abs/1710.02298",
     Year = 2018,
     Authors = "Hessel, M., Modayil, J., van Hasselt, H., Schaul, T., Ostrovski, G., Dabney, W., Horgan, D., Piot, B., Azar, M., & Silver, D.")]
-public class RainbowDQNAgent<T> : DeepReinforcementLearningAgentBase<T>, IActionValueProvider<T>
+public class RainbowDQNAgent<T> : DeepReinforcementLearningAgentBase<T>, IActionValueProvider<T>, IGradientComputable<T, Vector<T>, Vector<T>>
 {
     private RainbowDQNOptions<T> _options;
 
@@ -743,7 +743,7 @@ public class RainbowDQNAgent<T> : DeepReinforcementLearningAgentBase<T>, IAction
     /// <c>ApplyGradients</c> requires. The gradient comes from the network's own tape pass, so no
     /// derivative is written by hand here.
     /// </remarks>
-    public override Vector<T> ComputeGradients(
+    public Vector<T> ComputeGradients(
         Vector<T> input,
         Vector<T> target,
         ILossFunction<T>? lossFunction = null)

--- a/src/ReinforcementLearning/Agents/RainbowDQNAgent.cs
+++ b/src/ReinforcementLearning/Agents/RainbowDQNAgent.cs
@@ -731,32 +731,51 @@ public class RainbowDQNAgent<T> : DeepReinforcementLearningAgentBase<T>, IAction
         return clone;
     }
 
+    /// <summary>
+    /// Computes gradients of the loss with respect to this agent's parameters, without updating them.
+    /// </summary>
+    /// <param name="input">The input state.</param>
+    /// <param name="target">The target output.</param>
+    /// <param name="lossFunction">The loss to differentiate, or null to use the agent's own.</param>
+    /// <returns>A gradient vector the same length as <c>GetParameters()</c>.</returns>
+    /// <remarks>
+    /// Returns PARAMETER-space gradients, as <c>IGradientComputable</c> documents and as
+    /// <c>ApplyGradients</c> requires. The gradient comes from the network's own tape pass, so no
+    /// derivative is written by hand here.
+    /// </remarks>
     public override Vector<T> ComputeGradients(
         Vector<T> input,
         Vector<T> target,
         ILossFunction<T>? lossFunction = null)
     {
-        var loss = lossFunction ?? LossFunction;
-        var inputTensor = Tensor<T>.FromVector(input);
-        var outputTensor = _onlineNetwork.Predict(inputTensor);
-        var output = outputTensor.ToVector();
-        var lossValue = loss.CalculateLoss(output, target);
-        var gradient = loss.CalculateDerivative(output, target);
-
-        var gradientTensor = Tensor<T>.FromVector(gradient);
-
-        return gradient;
+        return ComputeGradientsForNetwork(
+            _onlineNetwork,
+            new[] { _onlineNetwork, _targetNetwork },
+            input,
+            target,
+            lossFunction);
     }
 
     public override void ApplyGradients(Vector<T> gradients, T learningRate)
     {
         var currentParams = GetParameters();
-        var newParams = new Vector<T>(currentParams.Length);
 
+        // ComputeGradients returns a parameter-space vector laid out exactly like GetParameters(),
+        // so this is a straight element-wise step. It previously indexed gradients[i % length],
+        // cycling a short OUTPUT-space vector across the whole parameter vector -- which applied
+        // output neuron (i mod n)'s gradient to parameter i, an arbitrary pairing.
+        if (gradients.Length != currentParams.Length)
+        {
+            throw new ArgumentException(
+                $"Gradient vector length ({gradients.Length}) must match parameter vector length "
+                + $"({currentParams.Length}).",
+                nameof(gradients));
+        }
+
+        var newParams = new Vector<T>(currentParams.Length);
         for (int i = 0; i < currentParams.Length; i++)
         {
-            var update = NumOps.Multiply(learningRate, gradients[i % gradients.Length]);
-            newParams[i] = NumOps.Subtract(currentParams[i], update);
+            newParams[i] = NumOps.Subtract(currentParams[i], NumOps.Multiply(learningRate, gradients[i]));
         }
 
         SetParameters(newParams);

--- a/src/ReinforcementLearning/Agents/ReinforcementLearningAgentBase.cs
+++ b/src/ReinforcementLearning/Agents/ReinforcementLearningAgentBase.cs
@@ -421,22 +421,6 @@ public abstract class ReinforcementLearningAgentBase<T> : IRLAgent<T>, IConfigur
         return clone;
     }
 
-    /// <summary>
-    /// Computes gradients for the agent.
-    /// </summary>
-    public abstract Vector<T> ComputeGradients(
-        Vector<T> input,
-        Vector<T> target,
-        ILossFunction<T>? lossFunction = null);
-
-    /// <summary>
-    /// Applies gradients to update the agent.
-    /// </summary>
-    public virtual void ApplyGradients(Vector<T> gradients, T learningRate)
-    {
-        // Default: tape-based training handles parameter updates via TrainWithTape
-    }
-
     /// <inheritdoc/>
     public virtual int[] GetInputShape()
     {

--- a/src/ReinforcementLearning/Agents/SACAgent.cs
+++ b/src/ReinforcementLearning/Agents/SACAgent.cs
@@ -63,7 +63,7 @@ namespace AiDotNet.ReinforcementLearning.Agents.SAC;
     "https://arxiv.org/abs/1801.01290",
     Year = 2018,
     Authors = "Haarnoja, T., Zhou, A., Abbeel, P., & Levine, S.")]
-public class SACAgent<T> : DeepReinforcementLearningAgentBase<T>
+public class SACAgent<T> : DeepReinforcementLearningAgentBase<T>, IGradientComputable<T, Vector<T>, Vector<T>>
 {
     private SACOptions<T> _sacOptions;
 
@@ -726,7 +726,7 @@ public class SACAgent<T> : DeepReinforcementLearningAgentBase<T>
     }
 
     /// <inheritdoc/>
-    public override Vector<T> ComputeGradients(
+    public Vector<T> ComputeGradients(
         Vector<T> input, Vector<T> target, ILossFunction<T>? lossFunction = null)
     {
         return GetParameters();

--- a/src/ReinforcementLearning/Agents/SARSAAgent.cs
+++ b/src/ReinforcementLearning/Agents/SARSAAgent.cs
@@ -55,7 +55,7 @@ namespace AiDotNet.ReinforcementLearning.Agents.SARSA;
     "https://citeseerx.ist.psu.edu/doc/10.1.1.17.2539",
     Year = 1994,
     Authors = "Rummery, G. A. & Niranjan, M.")]
-public class SARSAAgent<T> : ReinforcementLearningAgentBase<T>
+public class SARSAAgent<T> : ReinforcementLearningAgentBase<T>, IGradientComputable<T, Vector<T>, Vector<T>>
 {
     private SARSAOptions<T> _options;
 
@@ -324,7 +324,7 @@ public class SARSAAgent<T> : ReinforcementLearningAgentBase<T>
         return clone;
     }
 
-    public override Vector<T> ComputeGradients(
+    public Vector<T> ComputeGradients(
         Vector<T> input,
         Vector<T> target,
         ILossFunction<T>? lossFunction = null)
@@ -332,7 +332,7 @@ public class SARSAAgent<T> : ReinforcementLearningAgentBase<T>
         return GetParameters();
     }
 
-    public override void ApplyGradients(Vector<T> gradients, T learningRate)
+    public void ApplyGradients(Vector<T> gradients, T learningRate)
     {
         // Tabular methods don't use gradients
     }

--- a/src/ReinforcementLearning/Agents/SARSALambdaAgent.cs
+++ b/src/ReinforcementLearning/Agents/SARSALambdaAgent.cs
@@ -264,8 +264,6 @@ public class SARSALambdaAgent<T> : ReinforcementLearningAgentBase<T>
 
         return clone;
     }
-    public override Vector<T> ComputeGradients(Vector<T> input, Vector<T> target, ILossFunction<T>? lossFunction = null) { var pred = Predict(input); var lf = lossFunction ?? LossFunction; var loss = lf.CalculateLoss(pred, target); var grad = lf.CalculateDerivative(pred, target); return grad; }
-    public override void ApplyGradients(Vector<T> gradients, T learningRate) { }
     public override void SaveModel(string filepath)
     {
         if (string.IsNullOrWhiteSpace(filepath))

--- a/src/ReinforcementLearning/Agents/TD3Agent.cs
+++ b/src/ReinforcementLearning/Agents/TD3Agent.cs
@@ -59,7 +59,7 @@ namespace AiDotNet.ReinforcementLearning.Agents.TD3;
     "https://arxiv.org/abs/1802.09477",
     Year = 2018,
     Authors = "Fujimoto, S., van Hoof, H., & Meger, D.")]
-public class TD3Agent<T> : DeepReinforcementLearningAgentBase<T>
+public class TD3Agent<T> : DeepReinforcementLearningAgentBase<T>, IGradientComputable<T, Vector<T>, Vector<T>>
 {
     private TD3Options<T> _options;
 
@@ -541,7 +541,7 @@ public class TD3Agent<T> : DeepReinforcementLearningAgentBase<T>
     }
 
     /// <inheritdoc/>
-    public override Vector<T> ComputeGradients(
+    public Vector<T> ComputeGradients(
         Vector<T> input, Vector<T> target, ILossFunction<T>? lossFunction = null)
     {
         throw new NotSupportedException(

--- a/src/ReinforcementLearning/Agents/TRPOAgent.cs
+++ b/src/ReinforcementLearning/Agents/TRPOAgent.cs
@@ -60,7 +60,7 @@ namespace AiDotNet.ReinforcementLearning.Agents.TRPO;
     "https://arxiv.org/abs/1502.05477",
     Year = 2015,
     Authors = "Schulman, J., Levine, S., Moritz, P., Jordan, M. I., & Abbeel, P.")]
-public class TRPOAgent<T> : DeepReinforcementLearningAgentBase<T>
+public class TRPOAgent<T> : DeepReinforcementLearningAgentBase<T>, IGradientComputable<T, Vector<T>, Vector<T>>
 {
     private TRPOOptions<T> _options;
 
@@ -701,7 +701,7 @@ public class TRPOAgent<T> : DeepReinforcementLearningAgentBase<T>
     /// <c>ApplyGradients</c> requires. The gradient comes from the network's own tape pass, so no
     /// derivative is written by hand here.
     /// </remarks>
-    public override Vector<T> ComputeGradients(
+    public Vector<T> ComputeGradients(
         Vector<T> input,
         Vector<T> target,
         ILossFunction<T>? lossFunction = null)

--- a/src/ReinforcementLearning/Agents/TRPOAgent.cs
+++ b/src/ReinforcementLearning/Agents/TRPOAgent.cs
@@ -689,17 +689,29 @@ public class TRPOAgent<T> : DeepReinforcementLearningAgentBase<T>
         return clone;
     }
 
+    /// <summary>
+    /// Computes gradients of the loss with respect to this agent's parameters, without updating them.
+    /// </summary>
+    /// <param name="input">The input state.</param>
+    /// <param name="target">The target output.</param>
+    /// <param name="lossFunction">The loss to differentiate, or null to use the agent's own.</param>
+    /// <returns>A gradient vector the same length as <c>GetParameters()</c>.</returns>
+    /// <remarks>
+    /// Returns PARAMETER-space gradients, as <c>IGradientComputable</c> documents and as
+    /// <c>ApplyGradients</c> requires. The gradient comes from the network's own tape pass, so no
+    /// derivative is written by hand here.
+    /// </remarks>
     public override Vector<T> ComputeGradients(
         Vector<T> input,
         Vector<T> target,
         ILossFunction<T>? lossFunction = null)
     {
-        var prediction = Predict(input);
-        var usedLossFunction = lossFunction ?? LossFunction;
-        var loss = usedLossFunction.CalculateLoss(prediction, target);
-
-        var gradient = usedLossFunction.CalculateDerivative(prediction, target);
-        return gradient;
+        return ComputeGradientsForNetwork(
+            _policyNetwork,
+            new[] { _policyNetwork, _valueNetwork },
+            input,
+            target,
+            lossFunction);
     }
 
     public override void SaveModel(string filepath)

--- a/src/ReinforcementLearning/Agents/TabularActorCriticAgent.cs
+++ b/src/ReinforcementLearning/Agents/TabularActorCriticAgent.cs
@@ -271,15 +271,6 @@ public class TabularActorCriticAgent<T> : ReinforcementLearningAgentBase<T>
         }
         return clone;
     }
-    public override Vector<T> ComputeGradients(Vector<T> input, Vector<T> target, ILossFunction<T>? lossFunction = null)
-    {
-        var pred = Predict(input);
-        var lf = lossFunction ?? LossFunction;
-        var loss = lf.CalculateLoss(pred, target);
-        var gradients = lf.CalculateDerivative(pred, target);
-        return gradients;
-    }
-    public override void ApplyGradients(Vector<T> gradients, T learningRate) { }
     public override void SaveModel(string filepath) { var data = Serialize(); System.IO.File.WriteAllBytes(filepath, data); }
     public override void LoadModel(string filepath) { var data = System.IO.File.ReadAllBytes(filepath); Deserialize(data); }
 }

--- a/src/ReinforcementLearning/Agents/TabularQLearningAgent.cs
+++ b/src/ReinforcementLearning/Agents/TabularQLearningAgent.cs
@@ -52,7 +52,7 @@ namespace AiDotNet.ReinforcementLearning.Agents.TabularQLearning;
     "https://www.cs.rhul.ac.uk/~chrisw/new_thesis.pdf",
     Year = 1989,
     Authors = "Watkins, C. J. C. H.")]
-public class TabularQLearningAgent<T> : ReinforcementLearningAgentBase<T>
+public class TabularQLearningAgent<T> : ReinforcementLearningAgentBase<T>, IGradientComputable<T, Vector<T>, Vector<T>>
 {
     private TabularQLearningOptions<T> _options;
 
@@ -319,7 +319,7 @@ public class TabularQLearningAgent<T> : ReinforcementLearningAgentBase<T>
         return clone;
     }
 
-    public override Vector<T> ComputeGradients(
+    public Vector<T> ComputeGradients(
         Vector<T> input,
         Vector<T> target,
         ILossFunction<T>? lossFunction = null)
@@ -328,7 +328,7 @@ public class TabularQLearningAgent<T> : ReinforcementLearningAgentBase<T>
         return GetParameters();
     }
 
-    public override void ApplyGradients(Vector<T> gradients, T learningRate)
+    public void ApplyGradients(Vector<T> gradients, T learningRate)
     {
         // Tabular methods don't use gradients
     }

--- a/src/ReinforcementLearning/Agents/ThompsonSamplingAgent.cs
+++ b/src/ReinforcementLearning/Agents/ThompsonSamplingAgent.cs
@@ -262,8 +262,6 @@ public class ThompsonSamplingAgent<T> : ReinforcementLearningAgentBase<T>
         }
         return clone;
     }
-    public override Vector<T> ComputeGradients(Vector<T> input, Vector<T> target, ILossFunction<T>? lossFunction = null) { var pred = Predict(input); var lf = lossFunction ?? LossFunction; var predMatrix = new Matrix<T>(new[] { pred }); var targetMatrix = new Matrix<T>(new[] { target }); var loss = lf.CalculateLoss(predMatrix.GetRow(0), targetMatrix.GetRow(0)); var grad = lf.CalculateDerivative(predMatrix.GetRow(0), targetMatrix.GetRow(0)); return grad; }
-    public override void ApplyGradients(Vector<T> gradients, T learningRate) { }
     public override void SaveModel(string filepath) { var data = Serialize(); System.IO.File.WriteAllBytes(filepath, data); }
     public override void LoadModel(string filepath) { var data = System.IO.File.ReadAllBytes(filepath); Deserialize(data); }
 }

--- a/src/ReinforcementLearning/Agents/UCBBanditAgent.cs
+++ b/src/ReinforcementLearning/Agents/UCBBanditAgent.cs
@@ -217,8 +217,6 @@ public class UCBBanditAgent<T> : ReinforcementLearningAgentBase<T>
 
         return clone;
     }
-    public override Vector<T> ComputeGradients(Vector<T> input, Vector<T> target, ILossFunction<T>? lossFunction = null) { var pred = Predict(input); var lf = lossFunction ?? LossFunction; var predMatrix = new Matrix<T>(new[] { pred }); var targetMatrix = new Matrix<T>(new[] { target }); var loss = lf.CalculateLoss(predMatrix.GetRow(0), targetMatrix.GetRow(0)); var grad = lf.CalculateDerivative(predMatrix.GetRow(0), targetMatrix.GetRow(0)); return grad; }
-    public override void ApplyGradients(Vector<T> gradients, T learningRate) { }
     public override void SaveModel(string filepath) { var data = Serialize(); System.IO.File.WriteAllBytes(filepath, data); }
     public override void LoadModel(string filepath) { var data = System.IO.File.ReadAllBytes(filepath); Deserialize(data); }
 }

--- a/src/ReinforcementLearning/Agents/ValueIterationAgent.cs
+++ b/src/ReinforcementLearning/Agents/ValueIterationAgent.cs
@@ -372,23 +372,6 @@ public class ValueIterationAgent<T> : ReinforcementLearningAgentBase<T>
         return clone;
     }
 
-    public override Vector<T> ComputeGradients(
-        Vector<T> input,
-        Vector<T> target,
-        ILossFunction<T>? lossFunction = null)
-    {
-        var prediction = Predict(input);
-        var usedLossFunction = lossFunction ?? LossFunction;
-        var loss = usedLossFunction.CalculateLoss(prediction, target);
-        var gradient = usedLossFunction.CalculateDerivative(prediction, target);
-        return gradient;
-    }
-
-    public override void ApplyGradients(Vector<T> gradients, T learningRate)
-    {
-        // DP methods don't use gradients
-    }
-
     public override void SaveModel(string filepath)
     {
         if (string.IsNullOrWhiteSpace(filepath))

--- a/src/ReinforcementLearning/Agents/WatkinsQLambdaAgent.cs
+++ b/src/ReinforcementLearning/Agents/WatkinsQLambdaAgent.cs
@@ -237,8 +237,6 @@ public class WatkinsQLambdaAgent<T> : ReinforcementLearningAgentBase<T>
         clone._epsilon = _epsilon;
         return clone;
     }
-    public override Vector<T> ComputeGradients(Vector<T> input, Vector<T> target, ILossFunction<T>? lossFunction = null) { var pred = Predict(input); var lf = lossFunction ?? LossFunction; var loss = lf.CalculateLoss(pred, target); var grad = lf.CalculateDerivative(pred, target); return grad; }
-    public override void ApplyGradients(Vector<T> gradients, T learningRate) { }
     public override void SaveModel(string filepath) { var data = Serialize(); System.IO.File.WriteAllBytes(filepath, data); }
     public override void LoadModel(string filepath) { var data = System.IO.File.ReadAllBytes(filepath); Deserialize(data); }
 }

--- a/src/ReinforcementLearning/Agents/WorldModelsAgent.cs
+++ b/src/ReinforcementLearning/Agents/WorldModelsAgent.cs
@@ -756,18 +756,6 @@ public class WorldModelsAgent<T> : DeepReinforcementLearningAgentBase<T>
         return clone;
     }
 
-    public override Vector<T> ComputeGradients(
-        Vector<T> input,
-        Vector<T> target,
-        ILossFunction<T>? lossFunction = null)
-    {
-
-        var prediction = Predict(input);
-        var usedLossFunction = lossFunction ?? LossFunction;
-        var gradient = usedLossFunction.CalculateDerivative(prediction, target);
-        return gradient;
-    }
-
     public override void SaveModel(string filepath)
     {
         var data = Serialize();

--- a/src/TimeSeries/TimeSeriesModelBase.cs
+++ b/src/TimeSeries/TimeSeriesModelBase.cs
@@ -82,14 +82,6 @@ public abstract class TimeSeriesModelBase<T> : ITimeSeriesModel<T>, IConfigurabl
                 "The loss function cannot be changed after training; construct a new model instead.");
         }
 
-        if (lossFunction is not LossFunctions.LossFunctionBase<T>)
-        {
-            throw new ArgumentException(
-                $"Loss function '{lossFunction.GetType().Name}' must derive from LossFunctionBase<T>: " +
-                "tape-based training needs ComputeTapeLoss, which ILossFunction<T> does not declare.",
-                nameof(lossFunction));
-        }
-
         _defaultLossFunction = lossFunction;
 
         // Mirror onto the options so a TrainCore that reads Options.LossFunction and the
@@ -107,11 +99,7 @@ public abstract class TimeSeriesModelBase<T> : ITimeSeriesModel<T>, IConfigurabl
     /// surfacing from inside a backward pass. Defaults to the model's configured loss, which is
     /// mean squared error unless the caller supplied another.
     /// </remarks>
-    protected LossFunctions.LossFunctionBase<T> TrainingLoss =>
-        DefaultLossFunction as LossFunctions.LossFunctionBase<T>
-        ?? throw new InvalidOperationException(
-            $"Loss function '{DefaultLossFunction.GetType().Name}' must derive from LossFunctionBase<T> " +
-            "for tape-based training; ILossFunction<T> alone does not provide ComputeTapeLoss.");
+    protected ILossFunction<T> TrainingLoss => DefaultLossFunction;
 
     /// <inheritdoc />
     public Func<TrainingProgress<T>, bool>? TrainingEpochCallback { get; set; }
@@ -2185,7 +2173,7 @@ public abstract class TimeSeriesModelBase<T> : ITimeSeriesModel<T>, IConfigurabl
         {
             var predicted = Predict(input);
 
-            var lossGrad = loss.CalculateDerivative(predicted, target);
+            var lossGrad = loss.ComputeGradient(predicted, target);
             var lossGradTensor = Tensor<T>.FromVector(lossGrad);
 
             BackpropagateLayers(lossGradTensor);

--- a/tests/AiDotNet.Tests/IntegrationTests/ComputerVision/ComputerVisionDetectionDeepMathIntegrationTests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/ComputerVision/ComputerVisionDetectionDeepMathIntegrationTests.cs
@@ -1,4 +1,5 @@
 using AiDotNet.Augmentation.Image;
+using AiDotNet.Interfaces;
 using AiDotNet.ComputerVision.Detection.Anchors;
 using AiDotNet.ComputerVision.Detection.Losses;
 using AiDotNet.ComputerVision.Detection.PostProcessing;
@@ -573,7 +574,7 @@ public class ComputerVisionDetectionDeepMathIntegrationTests
         var pred = new Vector<double>(new double[] { 0, 0, 10, 10 });
         var actual = new Vector<double>(new double[] { 5, 5, 15, 15 });
 
-        var gradient = loss.CalculateDerivative(pred, actual);
+        var gradient = loss.ComputeGradient(pred, actual);
 
         for (int i = 0; i < gradient.Length; i++)
         {
@@ -589,7 +590,7 @@ public class ComputerVisionDetectionDeepMathIntegrationTests
         var pred = new Vector<double>(new double[] { 0, 0, 10, 10 });
         var actual = new Vector<double>(new double[] { 5, 5, 15, 15 });
 
-        var gradient = loss.CalculateDerivative(pred, actual);
+        var gradient = loss.ComputeGradient(pred, actual);
 
         for (int i = 0; i < gradient.Length; i++)
         {

--- a/tests/AiDotNet.Tests/IntegrationTests/ComputerVision/ComputerVisionExtendedIntegrationTests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/ComputerVision/ComputerVisionExtendedIntegrationTests.cs
@@ -1,4 +1,5 @@
 using AiDotNet.Augmentation.Image;
+using AiDotNet.Interfaces;
 using AiDotNet.ComputerVision.Detection.Anchors;
 using AiDotNet.ComputerVision.Detection.Losses;
 using AiDotNet.ComputerVision.Detection.ObjectDetection;
@@ -420,7 +421,7 @@ public class ComputerVisionExtendedIntegrationTests
         var predicted = new Vector<double>(new[] { 0.0, 0.0, 100.0, 100.0 });
         var actual = new Vector<double>(new[] { 20.0, 20.0, 120.0, 120.0 });
 
-        var gradient = loss.CalculateDerivative(predicted, actual);
+        var gradient = loss.ComputeGradient(predicted, actual);
 
         Assert.Equal(4, gradient.Length);
         // Gradient should not be all zeros since boxes differ
@@ -441,7 +442,7 @@ public class ComputerVisionExtendedIntegrationTests
         var actual = new Vector<double>(new[] { 20.0, 20.0, 120.0, 120.0 });
 
         double originalLoss = loss.CalculateLoss(predicted, actual);
-        var gradient = loss.CalculateDerivative(predicted, actual);
+        var gradient = loss.ComputeGradient(predicted, actual);
 
         // Take a small step in the negative gradient direction
         double stepSize = 0.1;
@@ -547,7 +548,7 @@ public class ComputerVisionExtendedIntegrationTests
         var actual = new Vector<double>(new[] { 20.0, 20.0, 120.0, 120.0 });
 
         double originalLoss = loss.CalculateLoss(predicted, actual);
-        var gradient = loss.CalculateDerivative(predicted, actual);
+        var gradient = loss.ComputeGradient(predicted, actual);
 
         double stepSize = 0.1;
         var stepped = new Vector<double>(4);
@@ -621,7 +622,7 @@ public class ComputerVisionExtendedIntegrationTests
         var predicted = new Vector<double>(new[] { 1.0, 2.0, 3.0, 4.0 });
         var actual = new Vector<double>(new[] { 1.5, 2.5, 3.5, 4.5 });
 
-        var gradient = loss.CalculateDerivative(predicted, actual);
+        var gradient = loss.ComputeGradient(predicted, actual);
 
         Assert.Equal(4, gradient.Length);
         bool hasNonZero = false;

--- a/tests/AiDotNet.Tests/IntegrationTests/ComputerVision/ComputerVisionIntegrationTests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/ComputerVision/ComputerVisionIntegrationTests.cs
@@ -1,4 +1,5 @@
 using AiDotNet.Augmentation.Image;
+using AiDotNet.Interfaces;
 using AiDotNet.ComputerVision.Detection.Losses;
 using AiDotNet.ComputerVision.Detection.ObjectDetection;
 using AiDotNet.ComputerVision.Detection.PostProcessing;
@@ -677,7 +678,7 @@ public class ComputerVisionIntegrationTests
         var predicted = new Vector<double>(new[] { 0.0, 0.0, 100.0, 100.0 });
         var actual = new Vector<double>(new[] { 10.0, 10.0, 110.0, 110.0 });
 
-        var gradient = loss.CalculateDerivative(predicted, actual);
+        var gradient = loss.ComputeGradient(predicted, actual);
 
         Assert.Equal(4, gradient.Length);
         // Gradient should not be all zeros when boxes differ

--- a/tests/AiDotNet.Tests/IntegrationTests/LossFunctions/AdvancedLossFunctionsIntegrationTests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/LossFunctions/AdvancedLossFunctionsIntegrationTests.cs
@@ -339,7 +339,12 @@ public class AdvancedLossFunctionsIntegrationTests
 
         // Act & Assert
         Assert.Throws<NotSupportedException>(() => nceLoss.CalculateLoss(predicted, actual));
-        Assert.Throws<NotSupportedException>(() => nceLoss.ComputeGradient(predicted, actual));
+        // NCE's second argument is the noise-logit MATRIX, not a pointwise target, so the
+        // two-argument path cannot serve it. It used to fail through a thrown
+        // CalculateDerivative; it now fails in ComputeTapeLoss with a message naming the real
+        // problem and the API to use instead.
+        var ex = Assert.Throws<ArgumentException>(() => nceLoss.ComputeGradient(predicted, actual));
+        Assert.Contains("noise logits", ex.Message);
     }
 
     [Fact(Timeout = 120000)]
@@ -487,7 +492,12 @@ public class AdvancedLossFunctionsIntegrationTests
 
         // Act & Assert
         Assert.Throws<NotSupportedException>(() => perceptualLoss.CalculateLoss(predicted, actual));
-        Assert.Throws<NotSupportedException>(() => perceptualLoss.ComputeGradient(predicted, actual));
+        // PerceptualLoss compares activations of a feature-extractor network. Without one
+        // configured there is nothing to compare, which is now reported as exactly that rather
+        // than as a blanket "not supported" from a hand-written derivative.
+        var ex = Assert.Throws<InvalidOperationException>(
+            () => perceptualLoss.ComputeGradient(predicted, actual));
+        Assert.Contains("Feature extractor", ex.Message);
     }
 
     [Fact(Timeout = 120000)]

--- a/tests/AiDotNet.Tests/IntegrationTests/LossFunctions/AdvancedLossFunctionsIntegrationTests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/LossFunctions/AdvancedLossFunctionsIntegrationTests.cs
@@ -1,4 +1,5 @@
 using AiDotNet.Interfaces;
+using AiDotNet.Tensors.Engines.Autodiff;
 using AiDotNet.LinearAlgebra;
 using AiDotNet.LossFunctions;
 using Xunit;
@@ -296,7 +297,16 @@ public class AdvancedLossFunctionsIntegrationTests
         }
 
         // Act
-        var (targetGradient, noiseGradient) = nceLoss.CalculateDerivative(targetLogits, noiseLogits);
+        using var tape = new GradientTape<double>();
+
+        var targetT = Tensor<double>.FromVector(targetLogits);
+        var noiseT = Tensor<double>.FromMatrix(noiseLogits);
+
+        var scalar = nceLoss.ComputeTapeLoss(targetT, noiseT);
+        var gradients = tape.ComputeGradients(scalar, new[] { targetT, noiseT });
+
+        var targetGradient = gradients[targetT].ToVector();
+        var noiseGradient = gradients[noiseT].ToMatrix();
 
         // Assert
         Assert.Equal(targetLogits.Length, targetGradient.Length);

--- a/tests/AiDotNet.Tests/IntegrationTests/LossFunctions/AdvancedLossFunctionsIntegrationTests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/LossFunctions/AdvancedLossFunctionsIntegrationTests.cs
@@ -339,7 +339,7 @@ public class AdvancedLossFunctionsIntegrationTests
 
         // Act & Assert
         Assert.Throws<NotSupportedException>(() => nceLoss.CalculateLoss(predicted, actual));
-        Assert.Throws<NotSupportedException>(() => nceLoss.CalculateDerivative(predicted, actual));
+        Assert.Throws<NotSupportedException>(() => nceLoss.ComputeGradient(predicted, actual));
     }
 
     [Fact(Timeout = 120000)]
@@ -487,7 +487,7 @@ public class AdvancedLossFunctionsIntegrationTests
 
         // Act & Assert
         Assert.Throws<NotSupportedException>(() => perceptualLoss.CalculateLoss(predicted, actual));
-        Assert.Throws<NotSupportedException>(() => perceptualLoss.CalculateDerivative(predicted, actual));
+        Assert.Throws<NotSupportedException>(() => perceptualLoss.ComputeGradient(predicted, actual));
     }
 
     [Fact(Timeout = 120000)]
@@ -574,7 +574,7 @@ public class AdvancedLossFunctionsIntegrationTests
         var expected = new Vector<double>(new[] { 1.0, 0.0, 0.0, 0.0 });
 
         // Act
-        var gradient = quantumLoss.CalculateDerivative(predicted, expected);
+        var gradient = quantumLoss.ComputeGradient(predicted, expected);
 
         // Assert
         Assert.Equal(predicted.Length, gradient.Length);

--- a/tests/AiDotNet.Tests/IntegrationTests/LossFunctions/LossFunctionDeepMathIntegrationTests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/LossFunctions/LossFunctionDeepMathIntegrationTests.cs
@@ -1,4 +1,5 @@
 using System;
+using AiDotNet.Interfaces;
 using System.Linq;
 using AiDotNet.LinearAlgebra;
 using AiDotNet.LossFunctions;
@@ -59,7 +60,7 @@ public class LossFunctionDeepMathIntegrationTests
         // dMSE/dp_i = 2*(p_i - a_i)/n
         // = [2*(3-1)/2, 2*(5-2)/2] = [2.0, 3.0]
         var loss = new MeanSquaredErrorLoss<double>();
-        var grad = loss.CalculateDerivative(V(3, 5), V(1, 2));
+        var grad = loss.ComputeGradient(V(3, 5), V(1, 2));
         Assert.Equal(2.0, grad[0], Tolerance);
         Assert.Equal(3.0, grad[1], Tolerance);
     }
@@ -137,7 +138,7 @@ public class LossFunctionDeepMathIntegrationTests
         // delta=1.0, error=0.5 (< delta)
         // Derivative = diff / n = 0.5 / 1 = 0.5
         var loss = new HuberLoss<double>(delta: 1.0);
-        var grad = loss.CalculateDerivative(V(1.5), V(1.0));
+        var grad = loss.ComputeGradient(V(1.5), V(1.0));
         Assert.Equal(0.5, grad[0], Tolerance);
     }
 
@@ -147,7 +148,7 @@ public class LossFunctionDeepMathIntegrationTests
         // delta=1.0, error=3.0 (> delta), sign=+1
         // Derivative = delta * sign(diff) / n = 1.0 * 1 / 1 = 1.0
         var loss = new HuberLoss<double>(delta: 1.0);
-        var grad = loss.CalculateDerivative(V(4.0), V(1.0));
+        var grad = loss.ComputeGradient(V(4.0), V(1.0));
         Assert.Equal(1.0, grad[0], Tolerance);
     }
 
@@ -213,7 +214,7 @@ public class LossFunctionDeepMathIntegrationTests
         // = (0.8 - 1.0) / (0.8 * 0.2) / 1
         // = -0.2 / 0.16 = -1.25
         var loss = new BinaryCrossEntropyLoss<double>();
-        var grad = loss.CalculateDerivative(V(0.8), V(1.0));
+        var grad = loss.ComputeGradient(V(0.8), V(1.0));
         Assert.Equal(-1.25, grad[0], 1e-4);
     }
 
@@ -270,7 +271,7 @@ public class LossFunctionDeepMathIntegrationTests
         // P=[0.4, 0.6], Q=[0.5, 0.5]
         // derivative = [-0.4/0.5, -0.6/0.5] = [-0.8, -1.2]
         var loss = new KullbackLeiblerDivergence<double>();
-        var grad = loss.CalculateDerivative(V(0.5, 0.5), V(0.4, 0.6));
+        var grad = loss.ComputeGradient(V(0.5, 0.5), V(0.4, 0.6));
         Assert.Equal(-0.8, grad[0], 1e-6);
         Assert.Equal(-1.2, grad[1], 1e-6);
     }
@@ -536,7 +537,7 @@ public class LossFunctionDeepMathIntegrationTests
         // diff = 5-3 = 2 > 0 → underestimation
         // derivative = -quantile / n = -0.75 / 1 = -0.75
         var loss = new QuantileLoss<double>(quantile: 0.75);
-        var grad = loss.CalculateDerivative(V(3), V(5));
+        var grad = loss.ComputeGradient(V(3), V(5));
         Assert.Equal(-0.75, grad[0], Tolerance);
     }
 
@@ -547,7 +548,7 @@ public class LossFunctionDeepMathIntegrationTests
         // diff = 5-7 = -2 <= 0 → overestimation
         // derivative = (1-quantile) / n = 0.25 / 1 = 0.25
         var loss = new QuantileLoss<double>(quantile: 0.75);
-        var grad = loss.CalculateDerivative(V(7), V(5));
+        var grad = loss.ComputeGradient(V(7), V(5));
         Assert.Equal(0.25, grad[0], Tolerance);
     }
 
@@ -600,7 +601,7 @@ public class LossFunctionDeepMathIntegrationTests
         // d/dx log(cosh(x)) = tanh(x)
         // error=0.5 → tanh(0.5) ≈ 0.46212
         var loss = new LogCoshLoss<double>();
-        var grad = loss.CalculateDerivative(V(1.5), V(1.0));
+        var grad = loss.ComputeGradient(V(1.5), V(1.0));
         Assert.Equal(Math.Tanh(0.5), grad[0], 1e-6);
     }
 
@@ -649,7 +650,7 @@ public class LossFunctionDeepMathIntegrationTests
         // predicted=3.0, actual=2.0
         // = (1 - 2/3) / 1 = 1/3 ≈ 0.3333
         var loss = new PoissonLoss<double>();
-        var grad = loss.CalculateDerivative(V(3.0), V(2.0));
+        var grad = loss.ComputeGradient(V(3.0), V(2.0));
         Assert.Equal(1.0 / 3.0, grad[0], 1e-6);
     }
 
@@ -658,7 +659,7 @@ public class LossFunctionDeepMathIntegrationTests
     {
         // At optimal: d/dp = (1 - actual/predicted) = 0 when predicted = actual
         var loss = new PoissonLoss<double>();
-        var grad = loss.CalculateDerivative(V(5.0), V(5.0));
+        var grad = loss.ComputeGradient(V(5.0), V(5.0));
         Assert.Equal(0.0, grad[0], 1e-6);
     }
 
@@ -702,7 +703,7 @@ public class LossFunctionDeepMathIntegrationTests
         // derivative = diff / sqrt(diff² + ε²) / n
         // at diff=0: 0 / sqrt(0 + ε²) = 0
         var loss = new CharbonnierLoss<double>(epsilon: 1e-6);
-        var grad = loss.CalculateDerivative(V(5.0), V(5.0));
+        var grad = loss.ComputeGradient(V(5.0), V(5.0));
         Assert.Equal(0.0, grad[0], 1e-6);
     }
 
@@ -713,7 +714,7 @@ public class LossFunctionDeepMathIntegrationTests
         // diff = 2, diffSquared = 4
         // derivative = 2 / sqrt(4 + 1e-12) / 1 ≈ 2/2 = 1.0
         var loss = new CharbonnierLoss<double>(epsilon: 1e-6);
-        var grad = loss.CalculateDerivative(V(3.0), V(1.0));
+        var grad = loss.ComputeGradient(V(3.0), V(1.0));
         Assert.Equal(2.0 / Math.Sqrt(4.0 + 1e-12), grad[0], 1e-6);
     }
 
@@ -959,7 +960,7 @@ public class LossFunctionDeepMathIntegrationTests
         var loss = new MeanSquaredErrorLoss<double>();
         var pred = V(2.0, 4.0);
         var actual = V(1.0, 3.0);
-        var analyticalGrad = loss.CalculateDerivative(pred, actual);
+        var analyticalGrad = loss.ComputeGradient(pred, actual);
 
         double h = 1e-7;
         for (int i = 0; i < pred.Length; i++)
@@ -980,7 +981,7 @@ public class LossFunctionDeepMathIntegrationTests
         var loss = new HuberLoss<double>(delta: 1.0);
         var pred = V(2.0, 4.0);
         var actual = V(1.5, 1.0); // 0.5 (quadratic) and 3.0 (linear)
-        var analyticalGrad = loss.CalculateDerivative(pred, actual);
+        var analyticalGrad = loss.ComputeGradient(pred, actual);
 
         double h = 1e-7;
         for (int i = 0; i < pred.Length; i++)
@@ -1001,7 +1002,7 @@ public class LossFunctionDeepMathIntegrationTests
         var loss = new LogCoshLoss<double>();
         var pred = V(2.5, 0.5);
         var actual = V(1.0, 3.0);
-        var analyticalGrad = loss.CalculateDerivative(pred, actual);
+        var analyticalGrad = loss.ComputeGradient(pred, actual);
 
         double h = 1e-7;
         for (int i = 0; i < pred.Length; i++)
@@ -1022,7 +1023,7 @@ public class LossFunctionDeepMathIntegrationTests
         var loss = new PoissonLoss<double>();
         var pred = V(2.0, 5.0);
         var actual = V(3.0, 4.0);
-        var analyticalGrad = loss.CalculateDerivative(pred, actual);
+        var analyticalGrad = loss.ComputeGradient(pred, actual);
 
         double h = 1e-7;
         for (int i = 0; i < pred.Length; i++)
@@ -1043,7 +1044,7 @@ public class LossFunctionDeepMathIntegrationTests
         var loss = new CharbonnierLoss<double>(epsilon: 1e-3);
         var pred = V(2.0, 0.5);
         var actual = V(1.0, 3.0);
-        var analyticalGrad = loss.CalculateDerivative(pred, actual);
+        var analyticalGrad = loss.ComputeGradient(pred, actual);
 
         double h = 1e-7;
         for (int i = 0; i < pred.Length; i++)
@@ -1064,7 +1065,7 @@ public class LossFunctionDeepMathIntegrationTests
         var loss = new DiceLoss<double>();
         var pred = V(0.8, 0.3, 0.6);
         var actual = V(1.0, 0.0, 1.0);
-        var analyticalGrad = loss.CalculateDerivative(pred, actual);
+        var analyticalGrad = loss.ComputeGradient(pred, actual);
 
         double h = 1e-7;
         for (int i = 0; i < pred.Length; i++)
@@ -1085,7 +1086,7 @@ public class LossFunctionDeepMathIntegrationTests
         var loss = new CosineSimilarityLoss<double>();
         var pred = V(3.0, 4.0);
         var actual = V(1.0, 2.0);
-        var analyticalGrad = loss.CalculateDerivative(pred, actual);
+        var analyticalGrad = loss.ComputeGradient(pred, actual);
 
         double h = 1e-7;
         for (int i = 0; i < pred.Length; i++)
@@ -1106,7 +1107,7 @@ public class LossFunctionDeepMathIntegrationTests
         var loss = new KullbackLeiblerDivergence<double>();
         var pred = V(0.4, 0.6);
         var actual = V(0.3, 0.7);
-        var analyticalGrad = loss.CalculateDerivative(pred, actual);
+        var analyticalGrad = loss.ComputeGradient(pred, actual);
 
         double h = 1e-7;
         for (int i = 0; i < pred.Length; i++)
@@ -1148,7 +1149,7 @@ public class LossFunctionDeepMathIntegrationTests
     {
         var loss = new ContrastiveLoss<double>();
         Assert.Throws<NotSupportedException>(() => loss.CalculateLoss(V(1), V(2)));
-        Assert.Throws<NotSupportedException>(() => loss.CalculateDerivative(V(1), V(2)));
+        Assert.Throws<NotSupportedException>(() => loss.ComputeGradient(V(1), V(2)));
     }
 
     [Fact(Timeout = 120000)]
@@ -1156,7 +1157,7 @@ public class LossFunctionDeepMathIntegrationTests
     {
         var loss = new TripletLoss<double>();
         Assert.Throws<NotSupportedException>(() => loss.CalculateLoss(V(1), V(2)));
-        Assert.Throws<NotSupportedException>(() => loss.CalculateDerivative(V(1), V(2)));
+        Assert.Throws<NotSupportedException>(() => loss.ComputeGradient(V(1), V(2)));
     }
 
     [Fact(Timeout = 120000)]

--- a/tests/AiDotNet.Tests/IntegrationTests/LossFunctions/LossFunctionDeepMathIntegrationTests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/LossFunctions/LossFunctionDeepMathIntegrationTests.cs
@@ -1145,19 +1145,38 @@ public class LossFunctionDeepMathIntegrationTests
     }
 
     [Fact(Timeout = 120000)]
-    public async Task Contrastive_StandardOverload_ThrowsNotSupported()
+    public async Task Contrastive_StandardOverload_LossUnsupported_GradientFromTape()
     {
         var loss = new ContrastiveLoss<double>();
+
+        // The pointwise loss VALUE is still unsupported: contrastive loss is defined on a PAIR of
+        // embeddings with a similarity label, which the two-argument overload cannot express.
         Assert.Throws<NotSupportedException>(() => loss.CalculateLoss(V(1), V(2)));
-        Assert.Throws<NotSupportedException>(() => loss.ComputeGradient(V(1), V(2)));
+
+        // The gradient no longer throws. It used to, because CalculateDerivative threw here; that
+        // hand-written derivative is gone and the gradient is differentiated from ComputeTapeLoss,
+        // which is defined for this shape. A finite gradient is the honest outcome.
+        var gradient = loss.ComputeGradient(V(1), V(2));
+        Assert.Equal(1, gradient.Length);
+        Assert.False(double.IsNaN(gradient[0]));
+        Assert.False(double.IsInfinity(gradient[0]));
     }
 
     [Fact(Timeout = 120000)]
-    public async Task Triplet_StandardOverload_ThrowsNotSupported()
+    public async Task Triplet_StandardOverload_LossUnsupported_GradientFromTape()
     {
         var loss = new TripletLoss<double>();
+
+        // Triplet loss needs anchor, positive and negative; two arguments cannot carry that, so
+        // the pointwise loss value stays unsupported.
         Assert.Throws<NotSupportedException>(() => loss.CalculateLoss(V(1), V(2)));
-        Assert.Throws<NotSupportedException>(() => loss.ComputeGradient(V(1), V(2)));
+
+        // The gradient comes from ComputeTapeLoss now rather than a hand-written derivative that
+        // threw, so it returns a real value instead of refusing.
+        var gradient = loss.ComputeGradient(V(1), V(2));
+        Assert.Equal(1, gradient.Length);
+        Assert.False(double.IsNaN(gradient[0]));
+        Assert.False(double.IsInfinity(gradient[0]));
     }
 
     [Fact(Timeout = 120000)]

--- a/tests/AiDotNet.Tests/IntegrationTests/LossFunctions/LossFunctionDeepMathIntegrationTests2.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/LossFunctions/LossFunctionDeepMathIntegrationTests2.cs
@@ -1,4 +1,5 @@
 using System;
+using AiDotNet.Interfaces;
 using System.Linq;
 using AiDotNet.LinearAlgebra;
 using AiDotNet.LossFunctions;
@@ -69,7 +70,7 @@ public class LossFunctionDeepMathIntegrationTests2
         // y=1, f(x)=0.5 => margin=0.5>0 => deriv = -y/n = -1/2
         // y=1, f(x)=2.0 => margin=-1<=0 => deriv = 0
         var loss = new HingeLoss<double>();
-        var deriv = loss.CalculateDerivative(V(0.5, 2.0), V(1.0, 1.0));
+        var deriv = loss.ComputeGradient(V(0.5, 2.0), V(1.0, 1.0));
         Assert.Equal(-0.5, deriv[0], Tolerance);
         Assert.Equal(0.0, deriv[1], Tolerance);
     }
@@ -80,7 +81,7 @@ public class LossFunctionDeepMathIntegrationTests2
         // y=-1, f(x)=-0.5 => margin = 1-(-1)(-0.5) = 1-0.5 = 0.5 > 0
         // deriv = -(-1)/1 = 1/1 = 1.0
         var loss = new HingeLoss<double>();
-        var deriv = loss.CalculateDerivative(V(-0.5), V(-1.0));
+        var deriv = loss.ComputeGradient(V(-0.5), V(-1.0));
         Assert.Equal(1.0, deriv[0], Tolerance);
     }
 
@@ -127,7 +128,7 @@ public class LossFunctionDeepMathIntegrationTests2
     {
         // y=1, f(x)=0.5 => margin=0.5 > 0 => deriv = -2*margin*y/n = -2*0.5*1/1 = -1.0
         var loss = new SquaredHingeLoss<double>();
-        var deriv = loss.CalculateDerivative(V(0.5), V(1.0));
+        var deriv = loss.ComputeGradient(V(0.5), V(1.0));
         Assert.Equal(-1.0, deriv[0], Tolerance);
     }
 
@@ -136,7 +137,7 @@ public class LossFunctionDeepMathIntegrationTests2
     {
         // y=1, f(x)=2 => margin=-1 <= 0 => deriv = 0
         var loss = new SquaredHingeLoss<double>();
-        var deriv = loss.CalculateDerivative(V(2.0), V(1.0));
+        var deriv = loss.ComputeGradient(V(2.0), V(1.0));
         Assert.Equal(0.0, deriv[0], Tolerance);
     }
 
@@ -196,7 +197,7 @@ public class LossFunctionDeepMathIntegrationTests2
         // predicted=[3, 1, 2], actual=[2, 2, 2]
         // signs: [1, -1, 0], /3 = [1/3, -1/3, 0]
         var loss = new MeanAbsoluteErrorLoss<double>();
-        var deriv = loss.CalculateDerivative(V(3, 1, 2), V(2, 2, 2));
+        var deriv = loss.ComputeGradient(V(3, 1, 2), V(2, 2, 2));
         Assert.Equal(1.0 / 3.0, deriv[0], Tolerance);
         Assert.Equal(-1.0 / 3.0, deriv[1], Tolerance);
         Assert.Equal(0.0, deriv[2], Tolerance);
@@ -258,7 +259,7 @@ public class LossFunctionDeepMathIntegrationTests2
         // predicted=[1, 3], actual=[2, 5], diff=[-1, -2], RMSE=sqrt(2.5)
         // deriv[0] = -1 / (2 * sqrt(2.5)), deriv[1] = -2 / (2 * sqrt(2.5))
         var loss = new RootMeanSquaredErrorLoss<double>();
-        var deriv = loss.CalculateDerivative(V(1, 3), V(2, 5));
+        var deriv = loss.ComputeGradient(V(1, 3), V(2, 5));
         double rmse = Math.Sqrt(2.5);
         Assert.Equal(-1.0 / (2.0 * rmse), deriv[0], Tolerance);
         Assert.Equal(-2.0 / (2.0 * rmse), deriv[1], Tolerance);
@@ -329,7 +330,7 @@ public class LossFunctionDeepMathIntegrationTests2
         // z = 1*0.5 = 0.5, -1 <= z < 1
         // deriv = -2*y*(1-z)/n = -2*1*(1-0.5)/1 = -1.0
         var loss = new ModifiedHuberLoss<double>();
-        var deriv = loss.CalculateDerivative(V(0.5), V(1.0));
+        var deriv = loss.ComputeGradient(V(0.5), V(1.0));
         Assert.Equal(-1.0, deriv[0], Tolerance);
     }
 
@@ -339,7 +340,7 @@ public class LossFunctionDeepMathIntegrationTests2
         // z = 1*(-2) = -2 < -1
         // deriv = -4*y/n = -4*1/1 = -4.0
         var loss = new ModifiedHuberLoss<double>();
-        var deriv = loss.CalculateDerivative(V(-2.0), V(1.0));
+        var deriv = loss.ComputeGradient(V(-2.0), V(1.0));
         Assert.Equal(-4.0, deriv[0], Tolerance);
     }
 
@@ -348,7 +349,7 @@ public class LossFunctionDeepMathIntegrationTests2
     {
         // z = 1*2 = 2 >= 1 => deriv = 0
         var loss = new ModifiedHuberLoss<double>();
-        var deriv = loss.CalculateDerivative(V(2.0), V(1.0));
+        var deriv = loss.ComputeGradient(V(2.0), V(1.0));
         Assert.Equal(0.0, deriv[0], Tolerance);
     }
 
@@ -400,7 +401,7 @@ public class LossFunctionDeepMathIntegrationTests2
     {
         // d(MBE)/d(predicted_i) = -1/n for all i
         var loss = new MeanBiasErrorLoss<double>();
-        var deriv = loss.CalculateDerivative(V(1, 2, 3, 4), V(5, 6, 7, 8));
+        var deriv = loss.ComputeGradient(V(1, 2, 3, 4), V(5, 6, 7, 8));
         for (int i = 0; i < 4; i++)
         {
             Assert.Equal(-0.25, deriv[i], Tolerance); // -1/4
@@ -470,7 +471,7 @@ public class LossFunctionDeepMathIntegrationTests2
         // actual=[1, -1], n=2
         // deriv = [-0.5, 0.5]
         var loss = new WassersteinLoss<double>();
-        var deriv = loss.CalculateDerivative(V(3, -3), V(1, -1));
+        var deriv = loss.ComputeGradient(V(3, -3), V(1, -1));
         Assert.Equal(-0.5, deriv[0], Tolerance);
         Assert.Equal(0.5, deriv[1], Tolerance);
     }
@@ -611,7 +612,7 @@ public class LossFunctionDeepMathIntegrationTests2
         // term1 = 1*(0.9-0.7) = 0.2 > 0
         // deriv = -2*term1/n = -2*0.2/1 = -0.4
         var loss = new MarginLoss<double>(mPlus: 0.9, mMinus: 0.1, lambda: 0.5);
-        var deriv = loss.CalculateDerivative(V(0.7), V(1.0));
+        var deriv = loss.ComputeGradient(V(0.7), V(1.0));
         Assert.Equal(-0.4, deriv[0], Tolerance);
     }
 
@@ -663,7 +664,7 @@ public class LossFunctionDeepMathIntegrationTests2
         // deriv[i] = -y[i] * exp(-y[i]*f[i]) / n
         // y=1, f=2: -1*exp(-2)/1 = -exp(-2) = -0.13533...
         var loss = new ExponentialLoss<double>();
-        var deriv = loss.CalculateDerivative(V(2.0), V(1.0));
+        var deriv = loss.ComputeGradient(V(2.0), V(1.0));
         Assert.Equal(-Math.Exp(-2.0), deriv[0], Tolerance);
     }
 
@@ -880,7 +881,7 @@ public class LossFunctionDeepMathIntegrationTests2
         double fMinus = loss.CalculateLoss(V(0.3 - eps), actual);
         double numericalGrad = (fPlus - fMinus) / (2 * eps);
 
-        var analyticalGrad = loss.CalculateDerivative(pred, actual);
+        var analyticalGrad = loss.ComputeGradient(pred, actual);
         Assert.Equal(numericalGrad, analyticalGrad[0], 1e-4);
     }
 
@@ -896,7 +897,7 @@ public class LossFunctionDeepMathIntegrationTests2
         double fMinus = loss.CalculateLoss(V(0.3 - eps), actual);
         double numericalGrad = (fPlus - fMinus) / (2 * eps);
 
-        var analyticalGrad = loss.CalculateDerivative(pred, actual);
+        var analyticalGrad = loss.ComputeGradient(pred, actual);
         Assert.Equal(numericalGrad, analyticalGrad[0], 1e-4);
     }
 
@@ -912,7 +913,7 @@ public class LossFunctionDeepMathIntegrationTests2
         double fMinus = loss.CalculateLoss(V(0.5 - eps), actual);
         double numericalGrad = (fPlus - fMinus) / (2 * eps);
 
-        var analyticalGrad = loss.CalculateDerivative(V(0.5), actual);
+        var analyticalGrad = loss.ComputeGradient(V(0.5), actual);
         Assert.Equal(numericalGrad, analyticalGrad[0], 1e-4);
     }
 
@@ -928,7 +929,7 @@ public class LossFunctionDeepMathIntegrationTests2
         double fMinus = loss.CalculateLoss(V(-2.0 - eps), actual);
         double numericalGrad = (fPlus - fMinus) / (2 * eps);
 
-        var analyticalGrad = loss.CalculateDerivative(V(-2.0), actual);
+        var analyticalGrad = loss.ComputeGradient(V(-2.0), actual);
         Assert.Equal(numericalGrad, analyticalGrad[0], 1e-4);
     }
 
@@ -943,7 +944,7 @@ public class LossFunctionDeepMathIntegrationTests2
         double fMinus = loss.CalculateLoss(V(1.5 - eps), actual);
         double numericalGrad = (fPlus - fMinus) / (2 * eps);
 
-        var analyticalGrad = loss.CalculateDerivative(V(1.5), actual);
+        var analyticalGrad = loss.ComputeGradient(V(1.5), actual);
         Assert.Equal(numericalGrad, analyticalGrad[0], 1e-4);
     }
 
@@ -958,7 +959,7 @@ public class LossFunctionDeepMathIntegrationTests2
         double fMinus = loss.CalculateLoss(V(3.0 - eps), actual);
         double numericalGrad = (fPlus - fMinus) / (2 * eps);
 
-        var analyticalGrad = loss.CalculateDerivative(V(3.0), actual);
+        var analyticalGrad = loss.ComputeGradient(V(3.0), actual);
         Assert.Equal(numericalGrad, analyticalGrad[0], 1e-4);
     }
 
@@ -973,7 +974,7 @@ public class LossFunctionDeepMathIntegrationTests2
         double fMinus = loss.CalculateLoss(V(0.7 - eps), actual);
         double numericalGrad = (fPlus - fMinus) / (2 * eps);
 
-        var analyticalGrad = loss.CalculateDerivative(V(0.7), actual);
+        var analyticalGrad = loss.ComputeGradient(V(0.7), actual);
         Assert.Equal(numericalGrad, analyticalGrad[0], 1e-4);
     }
 
@@ -990,7 +991,7 @@ public class LossFunctionDeepMathIntegrationTests2
         double fMinus = loss.CalculateLoss(V(1.0 - eps, 3.0), actual);
         double numericalGrad0 = (fPlus - fMinus) / (2 * eps);
 
-        var analyticalGrad = loss.CalculateDerivative(pred, actual);
+        var analyticalGrad = loss.ComputeGradient(pred, actual);
         Assert.Equal(numericalGrad0, analyticalGrad[0], 1e-4);
     }
 

--- a/tests/AiDotNet.Tests/IntegrationTests/LossFunctions/LossFunctionDeepMathIntegrationTests3.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/LossFunctions/LossFunctionDeepMathIntegrationTests3.cs
@@ -1,4 +1,5 @@
 using AiDotNet.LossFunctions;
+using AiDotNet.Interfaces;
 using Xunit;
 using System.Threading.Tasks;
 
@@ -77,7 +78,7 @@ public class LossFunctionDeepMathIntegrationTests3
         var loss = new ScaleInvariantDepthLoss<double>(0.5);
         var pred = new Vector<double>(new[] { 1.5, 2.5, 3.5 });
         var actual = new Vector<double>(new[] { 1.0, 2.0, 3.0 });
-        var analytical = loss.CalculateDerivative(pred, actual);
+        var analytical = loss.ComputeGradient(pred, actual);
 
         double h = 1e-5;
         for (int i = 0; i < pred.Length; i++)

--- a/tests/AiDotNet.Tests/IntegrationTests/LossFunctions/LossFunctionsIntegrationTests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/LossFunctions/LossFunctionsIntegrationTests.cs
@@ -55,7 +55,7 @@ public class LossFunctionsIntegrationTests
         var actual = new Vector<double>(new[] { 0.0, 0.0, 0.0 });
 
         // Act
-        var derivative = mse.CalculateDerivative(predicted, actual);
+        var derivative = mse.ComputeGradient(predicted, actual);
 
         // Assert - derivative is 2*(predicted-actual)/n
         Assert.Equal(3, derivative.Length);
@@ -125,7 +125,7 @@ public class LossFunctionsIntegrationTests
         var actual = new Vector<double>(new[] { 3.0, 2.0, 3.0 });
 
         // Act
-        var derivative = mae.CalculateDerivative(predicted, actual);
+        var derivative = mae.ComputeGradient(predicted, actual);
 
         // Assert
         Assert.Equal(3, derivative.Length);
@@ -190,7 +190,7 @@ public class LossFunctionsIntegrationTests
         var actual = new Vector<double>(new[] { 1.0, 0.0 });
 
         // Act
-        var derivative = bce.CalculateDerivative(predicted, actual);
+        var derivative = bce.ComputeGradient(predicted, actual);
 
         // Assert
         Assert.Equal(2, derivative.Length);
@@ -258,7 +258,7 @@ public class LossFunctionsIntegrationTests
         var actual = new Vector<double>(new[] { 0.0, 0.0 });
 
         // Act
-        var derivative = huber.CalculateDerivative(predicted, actual);
+        var derivative = huber.ComputeGradient(predicted, actual);
 
         // Assert
         Assert.Equal(2, derivative.Length);
@@ -322,7 +322,7 @@ public class LossFunctionsIntegrationTests
         var actual = new Vector<double>(new[] { 1.0, -1.0 });
 
         // Act
-        var derivative = hinge.CalculateDerivative(predicted, actual);
+        var derivative = hinge.ComputeGradient(predicted, actual);
 
         // Assert
         Assert.Equal(2, derivative.Length);
@@ -590,7 +590,7 @@ public class LossFunctionsIntegrationTests
         // Act & Assert
         foreach (var loss in losses)
         {
-            var derivative = loss.CalculateDerivative(predicted, actual);
+            var derivative = loss.ComputeGradient(predicted, actual);
             Assert.Equal(predicted.Length, derivative.Length);
         }
     }

--- a/tests/AiDotNet.Tests/IntegrationTests/LossFunctions/LossFunctionsMathematicalTests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/LossFunctions/LossFunctionsMathematicalTests.cs
@@ -50,7 +50,7 @@ public class LossFunctionsMathematicalTests
         var predicted = new Vector<double>(new[] { 1.0, 2.0, 3.0 });
         var actual = new Vector<double>(new[] { 2.0, 4.0, 6.0 });
 
-        var derivative = mse.CalculateDerivative(predicted, actual);
+        var derivative = mse.ComputeGradient(predicted, actual);
 
         // derivative = 2*(predicted - actual)/n
         // = 2*[1-2, 2-4, 3-6]/3
@@ -68,7 +68,7 @@ public class LossFunctionsMathematicalTests
         var predicted = new Vector<double>(new[] { 1.5, 2.5, 3.5 });
         var actual = new Vector<double>(new[] { 1.0, 2.0, 3.0 });
 
-        var analyticalGradient = mse.CalculateDerivative(predicted, actual);
+        var analyticalGradient = mse.ComputeGradient(predicted, actual);
 
         // Numerical gradient check
         for (int i = 0; i < predicted.Length; i++)
@@ -119,7 +119,7 @@ public class LossFunctionsMathematicalTests
         var predicted = new Vector<double>(new[] { 5.0, 1.0, 3.0 });
         var actual = new Vector<double>(new[] { 2.0, 4.0, 3.0 });
 
-        var derivative = mae.CalculateDerivative(predicted, actual);
+        var derivative = mae.ComputeGradient(predicted, actual);
 
         // sign(predicted - actual)/n
         // signs = [sign(3), sign(-3), sign(0)] = [1, -1, 0]
@@ -180,7 +180,7 @@ public class LossFunctionsMathematicalTests
         var predicted = new Vector<double>(new[] { 0.7, 0.3 });
         var actual = new Vector<double>(new[] { 1.0, 0.0 });
 
-        var analyticalGradient = bce.CalculateDerivative(predicted, actual);
+        var analyticalGradient = bce.ComputeGradient(predicted, actual);
 
         for (int i = 0; i < predicted.Length; i++)
         {
@@ -228,7 +228,7 @@ public class LossFunctionsMathematicalTests
         var predicted = new Vector<double>(new[] { 0.6, 0.3, 0.1 });
         var actual = new Vector<double>(new[] { 1.0, 0.0, 0.0 });
 
-        var analyticalGradient = ce.CalculateDerivative(predicted, actual);
+        var analyticalGradient = ce.ComputeGradient(predicted, actual);
 
         for (int i = 0; i < predicted.Length; i++)
         {
@@ -292,7 +292,7 @@ public class LossFunctionsMathematicalTests
         var predicted = new Vector<double>(new[] { 0.5, 2.0 });
         var actual = new Vector<double>(new[] { 0.0, 0.0 });
 
-        var analyticalGradient = huber.CalculateDerivative(predicted, actual);
+        var analyticalGradient = huber.ComputeGradient(predicted, actual);
 
         for (int i = 0; i < predicted.Length; i++)
         {
@@ -424,7 +424,7 @@ public class LossFunctionsMathematicalTests
         var predicted = new Vector<double>(new[] { 0.5, 1.5 });
         var actual = new Vector<double>(new[] { 0.0, 1.0 });
 
-        var analyticalGradient = logCosh.CalculateDerivative(predicted, actual);
+        var analyticalGradient = logCosh.ComputeGradient(predicted, actual);
 
         for (int i = 0; i < predicted.Length; i++)
         {
@@ -814,7 +814,7 @@ public class LossFunctionsMathematicalTests
         var predicted = new Vector<double>(new[] { 0.5, 0.3, 0.2 });
         var actual = new Vector<double>(new[] { 1.0, 0.0, 0.0 });
 
-        var gradient = cce.CalculateDerivative(predicted, actual);
+        var gradient = cce.ComputeGradient(predicted, actual);
 
         // Analytical: dL/dp_i = -a_i / p_i.
         Assert.Equal(-1.0 / 0.5, gradient[0], Tolerance); // = -2
@@ -913,7 +913,7 @@ public class LossFunctionsMathematicalTests
         var predicted = new Vector<double>(new[] { 0.3, 1.5, -0.5 });
         var actual = new Vector<double>(new[] { 1.0, 1.0, -1.0 });
 
-        var analyticalGradient = sqHinge.CalculateDerivative(predicted, actual);
+        var analyticalGradient = sqHinge.ComputeGradient(predicted, actual);
 
         for (int i = 0; i < predicted.Length; i++)
         {
@@ -989,7 +989,7 @@ public class LossFunctionsMathematicalTests
         var predicted = new Vector<double>(new[] { 0.5, -0.5 });
         var actual = new Vector<double>(new[] { 1.0, -1.0 });
 
-        var analyticalGradient = exp.CalculateDerivative(predicted, actual);
+        var analyticalGradient = exp.ComputeGradient(predicted, actual);
 
         for (int i = 0; i < predicted.Length; i++)
         {
@@ -1129,7 +1129,7 @@ public class LossFunctionsMathematicalTests
         var predicted = new Vector<double>(new[] { 1.0, 2.0, 3.0 });
         var actual = new Vector<double>(new[] { 5.0, 10.0, 15.0 });
 
-        var derivative = mbe.CalculateDerivative(predicted, actual);
+        var derivative = mbe.ComputeGradient(predicted, actual);
 
         // Derivative of MBE w.r.t. predicted is -1/n for all elements
         double expected = -1.0 / 3.0;
@@ -1258,7 +1258,7 @@ public class LossFunctionsMathematicalTests
         var predicted = new Vector<double>(new[] { 1.0, -1.0 });
         var actual = new Vector<double>(new[] { 1.0, -1.0 });
 
-        var analyticalGradient = wass.CalculateDerivative(predicted, actual);
+        var analyticalGradient = wass.ComputeGradient(predicted, actual);
 
         for (int i = 0; i < predicted.Length; i++)
         {
@@ -1626,7 +1626,7 @@ public class LossFunctionsMathematicalTests
         var predicted = new Vector<double>(new[] { 0.3, 0.5, 0.2 });
         var actual = new Vector<double>(new[] { 1.0 }); // Class index 1
 
-        var gradient = scce.CalculateDerivative(predicted, actual);
+        var gradient = scce.ComputeGradient(predicted, actual);
 
         // Gradient should be -1/p for the correct class, 0 for others
         // For class 1 (index 1): gradient = -1 / 0.5 = -2

--- a/tests/AiDotNet.Tests/IntegrationTests/LossFunctions/MultiInputTapeGradientTests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/LossFunctions/MultiInputTapeGradientTests.cs
@@ -1,0 +1,208 @@
+using System;
+using System.Threading.Tasks;
+using AiDotNet.LossFunctions;
+using AiDotNet.Tensors.Engines.Autodiff;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tests.IntegrationTests.LossFunctions;
+
+/// <summary>
+/// Cross-checks the multi-input tape forwards against central finite differences.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Triplet, contrastive and noise-contrastive losses are not pointwise: they are defined over
+/// three embedding sets, an embedding pair, or a target vector plus a noise matrix. Each used to
+/// ship a hand-written derivative returning one gradient per input, and those derivatives were
+/// the only way to obtain gradients for them. They are deleted, so what needs proving is that the
+/// tape reaches EVERY input correctly, not just that it produces a number.
+/// </para>
+/// <para>
+/// Finite differences are taken from each loss's own forward, so this is independent of both the
+/// tape and the deleted math. A gradient that reached only one of three inputs -- the failure mode
+/// that matters here, and the one a "gradients are finite" assertion cannot see -- shows up
+/// immediately as a mismatch against a non-zero numerical slope.
+/// </para>
+/// </remarks>
+public class MultiInputTapeGradientTests
+{
+    private const double Step = 1e-5;
+    private const double Tolerance = 1e-4;
+
+    [Fact(Timeout = 120000)]
+    public async Task TripletLoss_TapeGradients_MatchFiniteDifferences_ForAllThreeInputs()
+    {
+        await Task.Yield();
+
+        var loss = new TripletLoss<double>(margin: 1.0);
+
+        // Chosen so the hinge is ACTIVE: the positive is not yet closer than the negative by the
+        // margin, so the loss is non-zero and every input has a real gradient. On the flat side of
+        // the hinge all three gradients are legitimately zero and the test would prove nothing.
+        var anchor = Matrix(new[,] { { 0.10, 0.20, 0.30 }, { -0.40, 0.50, 0.10 } });
+        var positive = Matrix(new[,] { { 0.35, 0.05, 0.60 }, { -0.10, 0.20, 0.45 } });
+        var negative = Matrix(new[,] { { 0.20, 0.25, 0.40 }, { -0.35, 0.40, 0.20 } });
+
+        var (a, p, n) = TripletGradients(loss, anchor, positive, negative);
+
+        AssertMatchesNumeric("anchor", a, anchor,
+            m => LossOf(loss, m, positive, negative));
+        AssertMatchesNumeric("positive", p, positive,
+            m => LossOf(loss, anchor, m, negative));
+        AssertMatchesNumeric("negative", n, negative,
+            m => LossOf(loss, anchor, positive, m));
+    }
+
+    [Theory(Timeout = 120000)]
+    [InlineData(1.0)]
+    [InlineData(0.0)]
+    public async Task ContrastiveLoss_TapeGradients_MatchFiniteDifferences_ForBothEmbeddings(
+        double similarityLabel)
+    {
+        await Task.Yield();
+
+        var loss = new ContrastiveLoss<double>(margin: 1.0);
+
+        // Both labels are exercised because they select different branches of the loss: a similar
+        // pair is driven by d^2, a dissimilar one by max(0, margin - d)^2, and a derivative correct
+        // for one can be wrong for the other.
+        var v1 = new Vector<double>(new[] { 0.50, 1.00, -0.30 });
+        var v2 = new Vector<double>(new[] { 0.62, 0.85, -0.15 });
+
+        using var tape = new GradientTape<double>();
+        var t1 = Tensor<double>.FromVector(v1);
+        var t2 = Tensor<double>.FromVector(v2);
+        var scalar = loss.ComputeTapeLoss(t1, t2, similarityLabel);
+        var gradients = tape.ComputeGradients(scalar, new[] { t1, t2 });
+
+        AssertVectorMatchesNumeric("output1", gradients[t1].ToVector(), v1,
+            v => ScalarOf(loss.ComputeTapeLoss(
+                Tensor<double>.FromVector(v), Tensor<double>.FromVector(v2), similarityLabel)));
+        AssertVectorMatchesNumeric("output2", gradients[t2].ToVector(), v2,
+            v => ScalarOf(loss.ComputeTapeLoss(
+                Tensor<double>.FromVector(v1), Tensor<double>.FromVector(v), similarityLabel)));
+    }
+
+    [Fact(Timeout = 120000)]
+    public async Task NceLoss_TapeGradients_MatchFiniteDifferences_ForTargetAndNoise()
+    {
+        await Task.Yield();
+
+        var loss = new NoiseContrastiveEstimationLoss<double>(numNoiseSamples: 2);
+
+        var targetLogits = new Vector<double>(new[] { 0.80, -0.40 });
+        var noiseLogits = Matrix(new[,] { { -0.30, 0.25 }, { 0.60, -0.75 } });
+
+        using var tape = new GradientTape<double>();
+        var targetT = Tensor<double>.FromVector(targetLogits);
+        var noiseT = Tensor<double>.FromMatrix(noiseLogits);
+        var scalar = loss.ComputeTapeLoss(targetT, noiseT);
+        var gradients = tape.ComputeGradients(scalar, new[] { targetT, noiseT });
+
+        AssertVectorMatchesNumeric("targetLogits", gradients[targetT].ToVector(), targetLogits,
+            v => ScalarOf(loss.ComputeTapeLoss(
+                Tensor<double>.FromVector(v), Tensor<double>.FromMatrix(noiseLogits))));
+        AssertMatchesNumeric("noiseLogits", gradients[noiseT].ToMatrix(), noiseLogits,
+            m => ScalarOf(loss.ComputeTapeLoss(
+                Tensor<double>.FromVector(targetLogits), Tensor<double>.FromMatrix(m))));
+    }
+
+    // ---------------------------------------------------------------------
+    // Helpers
+    // ---------------------------------------------------------------------
+
+    private static (Matrix<double> Anchor, Matrix<double> Positive, Matrix<double> Negative)
+        TripletGradients(TripletLoss<double> loss,
+                         Matrix<double> anchor, Matrix<double> positive, Matrix<double> negative)
+    {
+        using var tape = new GradientTape<double>();
+
+        var a = Tensor<double>.FromMatrix(anchor);
+        var p = Tensor<double>.FromMatrix(positive);
+        var n = Tensor<double>.FromMatrix(negative);
+
+        var scalar = loss.ComputeTapeLoss(a, p, n);
+        var gradients = tape.ComputeGradients(scalar, new[] { a, p, n });
+
+        return (gradients[a].ToMatrix(), gradients[p].ToMatrix(), gradients[n].ToMatrix());
+    }
+
+    private static double LossOf(TripletLoss<double> loss,
+                                 Matrix<double> anchor, Matrix<double> positive, Matrix<double> negative)
+        => ScalarOf(loss.ComputeTapeLoss(
+            Tensor<double>.FromMatrix(anchor),
+            Tensor<double>.FromMatrix(positive),
+            Tensor<double>.FromMatrix(negative)));
+
+    private static double ScalarOf(Tensor<double> t) => t[0];
+
+    private static void AssertMatchesNumeric(
+        string name, Matrix<double> gradient, Matrix<double> point, Func<Matrix<double>, double> evaluate)
+    {
+        for (int r = 0; r < point.Rows; r++)
+        {
+            for (int c = 0; c < point.Columns; c++)
+            {
+                double numerical = (Shifted(evaluate, point, r, c, Step)
+                                    - Shifted(evaluate, point, r, c, -Step)) / (2 * Step);
+                Compare($"{name}[{r},{c}]", gradient[r, c], numerical);
+            }
+        }
+    }
+
+    private static void AssertVectorMatchesNumeric(
+        string name, Vector<double> gradient, Vector<double> point, Func<Vector<double>, double> evaluate)
+    {
+        for (int i = 0; i < point.Length; i++)
+        {
+            double numerical = (ShiftedVector(evaluate, point, i, Step)
+                                - ShiftedVector(evaluate, point, i, -Step)) / (2 * Step);
+            Compare($"{name}[{i}]", gradient[i], numerical);
+        }
+    }
+
+    private static void Compare(string label, double got, double numerical)
+    {
+        Assert.False(double.IsNaN(got), $"{label}: tape gradient is NaN.");
+        Assert.False(double.IsInfinity(got), $"{label}: tape gradient is Infinity.");
+
+        double allowed = Tolerance * Math.Max(1.0, Math.Abs(numerical));
+        Assert.True(
+            Math.Abs(got - numerical) <= allowed,
+            $"{label}: tape gives {got:G17} but central differences give {numerical:G17} "
+            + $"(difference {Math.Abs(got - numerical):G6} exceeds {allowed:G6}).");
+    }
+
+    private static double Shifted(
+        Func<Matrix<double>, double> evaluate, Matrix<double> point, int row, int col, double delta)
+    {
+        var copy = new Matrix<double>(point.Rows, point.Columns);
+        for (int r = 0; r < point.Rows; r++)
+            for (int c = 0; c < point.Columns; c++)
+                copy[r, c] = point[r, c];
+
+        copy[row, col] += delta;
+        return evaluate(copy);
+    }
+
+    private static double ShiftedVector(
+        Func<Vector<double>, double> evaluate, Vector<double> point, int index, double delta)
+    {
+        var copy = new Vector<double>(point.Length);
+        for (int i = 0; i < point.Length; i++) copy[i] = point[i];
+
+        copy[index] += delta;
+        return evaluate(copy);
+    }
+
+    private static Matrix<double> Matrix(double[,] values)
+    {
+        var m = new Matrix<double>(values.GetLength(0), values.GetLength(1));
+        for (int r = 0; r < values.GetLength(0); r++)
+            for (int c = 0; c < values.GetLength(1); c++)
+                m[r, c] = values[r, c];
+
+        return m;
+    }
+}

--- a/tests/AiDotNet.Tests/IntegrationTests/LossFunctions/TapeGradientFiniteDifferenceTests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/LossFunctions/TapeGradientFiniteDifferenceTests.cs
@@ -1,0 +1,140 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using AiDotNet.Interfaces;
+using AiDotNet.LossFunctions;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tests.IntegrationTests.LossFunctions;
+
+/// <summary>
+/// Checks every loss function's tape gradient against numerical finite differences.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The rest of the suite asserts gradient VALUES that were originally written against the
+/// hand-written analytic derivatives this change deleted. That proves the tape agrees with what
+/// was there before -- but if a hand-written derivative was itself wrong, the test enshrined the
+/// error and still passes. Finite differences are computed from the loss's own forward pass and
+/// nothing else, so they are an independent check: they can disagree with both.
+/// </para>
+/// <para>
+/// This also covers the losses that never had an analytic derivative at all, whose
+/// CalculateDerivative threw. They had no gradient test that could run; now they do.
+/// </para>
+/// <para>
+/// The check is the central-difference approximation
+/// <c>dL/dx_i ~= (L(x + h e_i) - L(x - h e_i)) / 2h</c>, whose error is O(h^2) rather than the
+/// O(h) of a forward difference, so a loose tolerance is not hiding a real disagreement.
+/// </para>
+/// </remarks>
+public class TapeGradientFiniteDifferenceTests
+{
+    // Large enough that (L(x+h) - L(x-h)) keeps enough significant digits in double precision,
+    // small enough that the O(h^2) truncation term stays well under the tolerance.
+    private const double Step = 1e-5;
+    private const double Tolerance = 1e-4;
+
+    /// <summary>
+    /// Losses paired with an input that is valid for them, since several are only defined on a
+    /// restricted domain -- probabilities in (0, 1), targets in {0, 1}, or {-1, +1} margins.
+    /// </summary>
+    public static IEnumerable<object[]> Losses()
+    {
+        // Regression: unrestricted real predictions and targets.
+        var reg = new double[] { 0.7, -0.4, 1.3, 0.2 };
+        var regTarget = new double[] { 0.5, -0.1, 1.0, 0.35 };
+
+        yield return Case(new MeanSquaredErrorLoss<double>(), reg, regTarget);
+        yield return Case(new MeanAbsoluteErrorLoss<double>(), reg, regTarget);
+        yield return Case(new RootMeanSquaredErrorLoss<double>(), reg, regTarget);
+        yield return Case(new HuberLoss<double>(), reg, regTarget);
+        yield return Case(new LogCoshLoss<double>(), reg, regTarget);
+        yield return Case(new MeanBiasErrorLoss<double>(), reg, regTarget);
+        yield return Case(new CharbonnierLoss<double>(), reg, regTarget);
+        yield return Case(new QuantileLoss<double>(), reg, regTarget);
+
+        // Probabilities: predictions strictly inside (0, 1); targets are 0/1 labels.
+        var prob = new double[] { 0.7, 0.2, 0.6, 0.35 };
+        var binary = new double[] { 1.0, 0.0, 1.0, 0.0 };
+
+        yield return Case(new BinaryCrossEntropyLoss<double>(), prob, binary);
+        yield return Case(new CrossEntropyLoss<double>(), prob, binary);
+        yield return Case(new DiceLoss<double>(), prob, binary);
+        yield return Case(new JaccardLoss<double>(), prob, binary);
+        yield return Case(new FocalLoss<double>(), prob, binary);
+
+        // Margin-based: targets in {-1, +1}, predictions unrestricted scores.
+        var scores = new double[] { 0.8, -0.6, 0.3, -1.2 };
+        var signs = new double[] { 1.0, -1.0, 1.0, -1.0 };
+
+        yield return Case(new HingeLoss<double>(), scores, signs);
+        yield return Case(new SquaredHingeLoss<double>(), scores, signs);
+        yield return Case(new ExponentialLoss<double>(), scores, signs);
+        yield return Case(new ModifiedHuberLoss<double>(), scores, signs);
+
+        // Logits: unrestricted, with the sigmoid/softmax applied inside the loss.
+        yield return Case(new BinaryCrossEntropyWithLogitsLoss<double>(), scores, binary);
+
+        // Strictly positive predictions and targets.
+        var positive = new double[] { 1.4, 0.6, 2.1, 0.9 };
+        var positiveTarget = new double[] { 1.1, 0.8, 1.7, 1.2 };
+
+        yield return Case(new PoissonLoss<double>(), positive, positiveTarget);
+        yield return Case(new KullbackLeiblerDivergence<double>(), prob, new double[] { 0.6, 0.25, 0.55, 0.4 });
+    }
+
+    private static object[] Case(ILossFunction<double> loss, double[] predicted, double[] actual)
+        => new object[] { loss.GetType().Name, loss, predicted, actual };
+
+    [Theory(Timeout = 120000)]
+    [MemberData(nameof(Losses))]
+    public async Task TapeGradient_MatchesCentralFiniteDifference(
+        string name, ILossFunction<double> loss, double[] predicted, double[] actual)
+    {
+        await Task.Yield();
+
+        var target = Tensor<double>.FromVector(new Vector<double>(actual));
+        var analytic = loss.ComputeGradient(
+            Tensor<double>.FromVector(new Vector<double>(predicted)), target);
+
+        Assert.Equal(predicted.Length, analytic.Length);
+
+        for (int i = 0; i < predicted.Length; i++)
+        {
+            double numerical = (Evaluate(loss, predicted, actual, i, Step)
+                                - Evaluate(loss, predicted, actual, i, -Step)) / (2 * Step);
+
+            double got = analytic[i];
+
+            Assert.False(double.IsNaN(got), $"{name}: tape gradient[{i}] is NaN.");
+            Assert.False(double.IsInfinity(got), $"{name}: tape gradient[{i}] is Infinity.");
+
+            // Relative where the gradient is large, absolute where it is near zero -- a fixed
+            // absolute bound would be vacuous for one and unreachable for the other.
+            double allowed = Tolerance * Math.Max(1.0, Math.Abs(numerical));
+            Assert.True(
+                Math.Abs(got - numerical) <= allowed,
+                $"{name}: gradient[{i}] = {got:G17} but central differences give {numerical:G17} "
+                + $"(difference {Math.Abs(got - numerical):G6} exceeds {allowed:G6}).");
+        }
+    }
+
+    /// <summary>
+    /// Evaluates the loss with a single component of the prediction displaced, using the loss's
+    /// own tape forward so the comparison is against the same expression being differentiated.
+    /// </summary>
+    private static double Evaluate(
+        ILossFunction<double> loss, double[] predicted, double[] actual, int index, double delta)
+    {
+        var shifted = (double[])predicted.Clone();
+        shifted[index] += delta;
+
+        var value = loss.ComputeTapeLoss(
+            Tensor<double>.FromVector(new Vector<double>(shifted)),
+            Tensor<double>.FromVector(new Vector<double>(actual)));
+
+        return value[0];
+    }
+}

--- a/tests/AiDotNet.Tests/IntegrationTests/PhysicsInformed/PhysicsInformedExtendedIntegrationTests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/PhysicsInformed/PhysicsInformedExtendedIntegrationTests.cs
@@ -1,4 +1,5 @@
 using AiDotNet.Engines;
+using AiDotNet.Interfaces;
 using AiDotNet.PhysicsInformed;
 using AiDotNet.PhysicsInformed.Benchmarks;
 using AiDotNet.PhysicsInformed.Interfaces;
@@ -1445,7 +1446,10 @@ public class PhysicsInformedExtendedIntegrationTests
         var predictions = new double[] { 1.0, 2.0, 3.0 };
         var targets = new double[] { 1.5, 1.5, 2.5 };
 
-        var derivative = loss.ComputeDerivative(predictions, targets);
+        // The analytic derivative is gone; the same quantity now comes from differentiating
+        // ComputeTapeLoss, which is what every gradient in the library is built from.
+        var derivative = loss.ComputeGradient(
+            new Vector<double>(predictions), new Vector<double>(targets));
 
         Assert.Equal(3, derivative.Length);
         // MSE derivative = 2/N * (pred - target)

--- a/tests/AiDotNet.Tests/IntegrationTests/PhysicsInformed/PhysicsInformedIntegrationTests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/PhysicsInformed/PhysicsInformedIntegrationTests.cs
@@ -161,7 +161,7 @@ public class PhysicsInformedIntegrationTests
         var predicted = new Vector<double>(new double[] { 2.0 });
         var actual = new Vector<double>(new double[] { 1.0 });
 
-        var gradient = loss.CalculateDerivative(predicted, actual);
+        var gradient = loss.ComputeGradient(predicted, actual);
 
         Assert.Single(gradient);
         // Gradient of MSE: 2*(predicted - actual)/n = 2*(2-1)/1 = 2

--- a/tests/AiDotNet.Tests/IntegrationTests/ReinforcementLearning/BaseClassesIntegrationTests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/ReinforcementLearning/BaseClassesIntegrationTests.cs
@@ -271,7 +271,7 @@ public class BaseClassesIntegrationTests
             return new TestDeepAgent(Options);
         }
 
-        public override Vector<double> ComputeGradients(
+        public Vector<double> ComputeGradients(
             Vector<double> input,
             Vector<double> target,
             ILossFunction<double>? lossFunction = null)
@@ -279,10 +279,7 @@ public class BaseClassesIntegrationTests
             return new Vector<double>(1);
         }
 
-        public override void ApplyGradients(Vector<double> gradients, double learningRate)
-        {
-        }
-
+        
         public override void SaveModel(string filepath)
         {
         }
@@ -378,7 +375,7 @@ public class BaseClassesIntegrationTests
             return clone;
         }
 
-        public override Vector<double> ComputeGradients(
+        public Vector<double> ComputeGradients(
             Vector<double> input,
             Vector<double> target,
             ILossFunction<double>? lossFunction = null)
@@ -386,10 +383,7 @@ public class BaseClassesIntegrationTests
             return new Vector<double>((int)ParameterCount);
         }
 
-        public override void ApplyGradients(Vector<double> gradients, double learningRate)
-        {
-        }
-
+        
         public override void SaveModel(string filepath)
         {
             var data = Serialize();

--- a/tests/AiDotNet.Tests/IntegrationTests/Training/ConfiguredLossFunctionTests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/Training/ConfiguredLossFunctionTests.cs
@@ -1,4 +1,5 @@
 using System;
+using AiDotNet.Tensors.Engines;
 using System.Threading.Tasks;
 using AiDotNet;
 using AiDotNet.Data.Loaders;
@@ -59,11 +60,12 @@ public class ConfiguredLossFunctionTests
     {
         var model = new NBeatsProbe(new NBEATSModelOptions<double> { LookbackWindow = 4, ForecastHorizon = 1 });
 
-        // Tape training needs ComputeTapeLoss, which lives on LossFunctionBase<T>. Rejecting here
-        // turns a failure deep in the first backward pass into an immediate, legible error.
-        var ex = Assert.Throws<ArgumentException>(
-            () => ((ISupportsLossFunction<double>)model).SetLossFunction(new NotATapeLoss()));
-        Assert.Contains("LossFunctionBase", ex.Message);
+        // ComputeTapeLoss is declared on ILossFunction<double> itself, so implementing the
+        // interface is sufficient for tape training and there is nothing left to reject. This
+        // previously asserted an ArgumentException naming LossFunctionBase.
+        var custom = new CustomTapeLoss();
+        ((ISupportsLossFunction<double>)model).SetLossFunction(custom);
+        Assert.Same(custom, model.DefaultLossFunction);
         await Task.CompletedTask;
     }
 
@@ -129,19 +131,25 @@ public class ConfiguredLossFunctionTests
     }
 
     [Fact(Timeout = 120000)]
-    public async Task Facade_InvalidNonTapeLoss_IsRejected()
+    public async Task Facade_CustomInterfaceOnlyLoss_TrainsThroughTheTape()
     {
         var (x, y) = BuildSeries();
         var model = new NBeatsProbe(new NBEATSModelOptions<double> { LookbackWindow = 4, ForecastHorizon = 1, Epochs = 2 });
 
-        // A non-tape loss must be rejected through the facade up front, not accepted and then failing deep
-        // in the first backward pass.
-        var builder = new AiModelBuilder<double, Matrix<double>, Vector<double>>()
-            .ConfigureModel(model)
-            .ConfigureLossFunction(new NotATapeLoss())
-            .ConfigureDataLoader(new InMemoryDataLoader<double, Matrix<double>, Vector<double>>(x, y));
+        // This previously asserted the OPPOSITE: a loss implementing ILossFunction<double> without
+        // deriving from LossFunctionBase<double> was rejected up front, because ComputeTapeLoss was
+        // declared on the base class and the tape path could not reach it. The interface declares it
+        // now, so a custom loss that implements the interface is trainable by construction and there
+        // is no "non-tape loss" left to reject.
+        var custom = new CustomTapeLoss();
 
-        await Assert.ThrowsAsync<ArgumentException>(() => builder.BuildAsync());
+        await new AiModelBuilder<double, Matrix<double>, Vector<double>>()
+            .ConfigureModel(model)
+            .ConfigureLossFunction(custom)
+            .ConfigureDataLoader(new InMemoryDataLoader<double, Matrix<double>, Vector<double>>(x, y))
+            .BuildAsync();
+
+        Assert.Same(custom, model.DefaultLossFunction);
     }
 
     /// <summary>Exposes the protected default loss for assertions.</summary>
@@ -150,14 +158,43 @@ public class ConfiguredLossFunctionTests
         public NBeatsProbe(NBEATSModelOptions<double> options) : base(options) { }
     }
 
-    /// <summary>An ILossFunction that is deliberately NOT a LossFunctionBase.</summary>
-    private sealed class NotATapeLoss : ILossFunction<double>
+    /// <summary>
+    /// A mean-squared-error loss implementing ILossFunction&lt;double&gt; directly, without deriving
+    /// from LossFunctionBase&lt;double&gt;.
+    /// </summary>
+    /// <remarks>
+    /// It defines its math once, in ComputeTapeLoss, and supplies no derivative of its own -- the
+    /// tape differentiates the forward. That is the whole contract a custom loss has to meet.
+    /// </remarks>
+    private sealed class CustomTapeLoss : ILossFunction<double>
     {
-        public double CalculateLoss(Vector<double> predicted, Vector<double> actual) => 0;
+        private static IEngine Engine => AiDotNetEngine.Current;
 
-        public Vector<double> CalculateDerivative(Vector<double> predicted, Vector<double> actual) => predicted;
+        public double CalculateLoss(Vector<double> predicted, Vector<double> actual)
+        {
+            double sum = 0;
+            for (int i = 0; i < predicted.Length; i++)
+            {
+                double d = predicted[i] - actual[i];
+                sum += d * d;
+            }
 
-        public (double Loss, Tensor<double> Gradient) CalculateLossAndGradientGpu(Tensor<double> predicted, Tensor<double> actual)
-            => (0, predicted);
+            return predicted.Length == 0 ? 0 : sum / predicted.Length;
+        }
+
+        public Tensor<double> ComputeTapeLoss(Tensor<double> predicted, Tensor<double> target)
+        {
+            var diff = Engine.TensorSubtract(predicted, target);
+            var squared = Engine.TensorMultiply(diff, diff);
+            var axes = new int[squared.Shape.Length];
+            for (int i = 0; i < axes.Length; i++) axes[i] = i;
+
+            var summed = Engine.ReduceSum(squared, axes, keepDims: false);
+            return Engine.TensorDivideScalar(summed, (double)Math.Max(1, squared.Length));
+        }
+
+        public (double Loss, Tensor<double> Gradient) CalculateLossAndGradientGpu(
+            Tensor<double> predicted, Tensor<double> actual)
+            => this.ComputeLossAndGradient(predicted, actual);
     }
 }

--- a/tests/AiDotNet.Tests/IntegrationTests/Training/TrainingDeepMathIntegrationTests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/Training/TrainingDeepMathIntegrationTests.cs
@@ -1,4 +1,5 @@
 using AiDotNet.Enums;
+using AiDotNet.Interfaces;
 using AiDotNet.LinearAlgebra;
 using AiDotNet.Training.Factories;
 using Xunit;
@@ -204,7 +205,7 @@ public class TrainingDeepMathIntegrationTests
         var predicted = new Vector<double>(new double[] { 1.0, 2.0, 3.0 });
         var actual = new Vector<double>(new double[] { 1.0, 2.0, 3.0 });
 
-        var derivative = loss.CalculateDerivative(predicted, actual);
+        var derivative = loss.ComputeGradient(predicted, actual);
         for (int i = 0; i < derivative.Length; i++)
         {
             Assert.Equal(0.0, derivative[i], 1e-10);
@@ -219,7 +220,7 @@ public class TrainingDeepMathIntegrationTests
         var predicted = new Vector<double>(new double[] { 5.0 });
         var actual = new Vector<double>(new double[] { 3.0 });
 
-        var derivative = loss.CalculateDerivative(predicted, actual);
+        var derivative = loss.ComputeGradient(predicted, actual);
         Assert.True(derivative[0] > 0, $"Derivative should be positive when predicted > actual, got {derivative[0]}");
     }
 
@@ -231,7 +232,7 @@ public class TrainingDeepMathIntegrationTests
         var predicted = new Vector<double>(new double[] { 1.0 });
         var actual = new Vector<double>(new double[] { 5.0 });
 
-        var derivative = loss.CalculateDerivative(predicted, actual);
+        var derivative = loss.ComputeGradient(predicted, actual);
         Assert.True(derivative[0] < 0, $"Derivative should be negative when predicted < actual, got {derivative[0]}");
     }
 
@@ -246,7 +247,7 @@ public class TrainingDeepMathIntegrationTests
         var predicted = new Vector<double>(new double[] { 1.0, 2.0, 3.0, 4.0 });
         var actual = new Vector<double>(new double[] { 1.5, 2.5, 3.5, 4.5 });
 
-        var derivative = loss.CalculateDerivative(predicted, actual);
+        var derivative = loss.ComputeGradient(predicted, actual);
         Assert.Equal(predicted.Length, derivative.Length);
     }
 }

--- a/tests/AiDotNet.Tests/ModelFamilyTests/Base/ContrastiveLossTestBase.cs
+++ b/tests/AiDotNet.Tests/ModelFamilyTests/Base/ContrastiveLossTestBase.cs
@@ -1,4 +1,5 @@
 using AiDotNet.LossFunctions;
+using AiDotNet.Tensors.Engines.Autodiff;
 using AiDotNet.Interfaces;
 using AiDotNet.Tensors.LinearAlgebra;
 using Xunit;
@@ -123,7 +124,18 @@ public abstract class ContrastiveLossTestBase
                 noiseLogits[i, j] = -0.5;
         }
 
-        var (targetGrad, noiseGrad) = loss.CalculateDerivative(targetLogits, noiseLogits);
+        // NCE's tape forward already takes the target logits and the noise-logit matrix, so the
+        // two gradients come straight off one backward pass.
+        using var tape = new GradientTape<double>();
+
+        var targetT = Tensor<double>.FromVector(targetLogits);
+        var noiseT = Tensor<double>.FromMatrix(noiseLogits);
+
+        var scalar = loss.ComputeTapeLoss(targetT, noiseT);
+        var gradients = tape.ComputeGradients(scalar, new[] { targetT, noiseT });
+
+        var targetGrad = gradients[targetT].ToVector();
+        var noiseGrad = gradients[noiseT].ToMatrix();
 
         for (int i = 0; i < batchSize; i++)
         {

--- a/tests/AiDotNet.Tests/ModelFamilyTests/Base/ContrastiveLossTestBase.cs
+++ b/tests/AiDotNet.Tests/ModelFamilyTests/Base/ContrastiveLossTestBase.cs
@@ -1,4 +1,5 @@
 using AiDotNet.LossFunctions;
+using AiDotNet.Interfaces;
 using AiDotNet.Tensors.LinearAlgebra;
 using Xunit;
 using System.Threading.Tasks;

--- a/tests/AiDotNet.Tests/ModelFamilyTests/Base/LossFunctionTestBase.cs
+++ b/tests/AiDotNet.Tests/ModelFamilyTests/Base/LossFunctionTestBase.cs
@@ -174,7 +174,7 @@ public abstract class LossFunctionTestBase
         var predicted = new Vector<double>(TestPredicted);
         var actual = new Vector<double>(TestActual);
 
-        var derivative = loss.CalculateDerivative(predicted, actual);
+        var derivative = loss.ComputeGradient(predicted, actual);
 
         Assert.Equal(predicted.Length, derivative.Length);
         for (int i = 0; i < derivative.Length; i++)
@@ -200,7 +200,7 @@ public abstract class LossFunctionTestBase
         var loss = CreateLoss();
         var values = new Vector<double>(new[] { 0.3, 0.5, 0.7 });
 
-        var derivative = loss.CalculateDerivative(values, values);
+        var derivative = loss.ComputeGradient(values, values);
 
         for (int i = 0; i < derivative.Length; i++)
         {
@@ -225,7 +225,7 @@ public abstract class LossFunctionTestBase
         var actual = new Vector<double>(TestActual);
         double epsilon = 1e-5;
 
-        var analyticalGrad = loss.CalculateDerivative(predicted, actual);
+        var analyticalGrad = loss.ComputeGradient(predicted, actual);
 
         for (int i = 0; i < predicted.Length; i++)
         {
@@ -266,7 +266,7 @@ public abstract class LossFunctionTestBase
         var predicted = new Vector<double>(SignTestPredicted);
         var actual = new Vector<double>(SignTestActual);
 
-        var derivative = loss.CalculateDerivative(predicted, actual);
+        var derivative = loss.ComputeGradient(predicted, actual);
 
         // For standard regression losses, positive error → positive gradient
         Assert.True(derivative[0] > -1e-10,

--- a/tests/AiDotNet.Tests/ModelFamilyTests/Base/PairedContrastiveLossTestBase.cs
+++ b/tests/AiDotNet.Tests/ModelFamilyTests/Base/PairedContrastiveLossTestBase.cs
@@ -1,4 +1,5 @@
 using AiDotNet.LossFunctions;
+using AiDotNet.Tensors.Engines.Autodiff;
 using AiDotNet.Tensors.LinearAlgebra;
 using Xunit;
 using System.Threading.Tasks;
@@ -139,8 +140,9 @@ public abstract class PairedContrastiveLossTestBase
         var v1 = new Vector<double>(new[] { 0.5, 1.0, -0.3 });
         var v2 = new Vector<double>(new[] { 0.6, 0.9, -0.2 });
 
-        var (grad1Similar, grad2Similar) = loss.CalculateDerivative(v1, v2, 1.0);
-        var (grad1Dissimilar, grad2Dissimilar) = loss.CalculateDerivative(v1, v2, 0.0);
+        // One gradient per embedding, from the tape rather than a hand-written derivative.
+        var (grad1Similar, grad2Similar) = PairGradients(loss, v1, v2, 1.0);
+        var (grad1Dissimilar, grad2Dissimilar) = PairGradients(loss, v1, v2, 0.0);
 
         for (int i = 0; i < v1.Length; i++)
         {
@@ -149,5 +151,22 @@ public abstract class PairedContrastiveLossTestBase
             Assert.False(double.IsNaN(grad1Dissimilar[i]), $"Dissimilar grad1[{i}] is NaN.");
             Assert.False(double.IsNaN(grad2Dissimilar[i]), $"Dissimilar grad2[{i}] is NaN.");
         }
+    }
+
+    /// <summary>
+    /// Differentiates the pair loss with respect to BOTH embeddings in a single backward pass.
+    /// </summary>
+    private static (Vector<double> Grad1, Vector<double> Grad2) PairGradients(
+        ContrastiveLoss<double> loss, Vector<double> v1, Vector<double> v2, double similarityLabel)
+    {
+        using var tape = new GradientTape<double>();
+
+        var t1 = Tensor<double>.FromVector(v1);
+        var t2 = Tensor<double>.FromVector(v2);
+
+        var scalar = loss.ComputeTapeLoss(t1, t2, similarityLabel);
+        var gradients = tape.ComputeGradients(scalar, new[] { t1, t2 });
+
+        return (gradients[t1].ToVector(), gradients[t2].ToVector());
     }
 }

--- a/tests/AiDotNet.Tests/ModelFamilyTests/Base/SparseCategoricalLossTestBase.cs
+++ b/tests/AiDotNet.Tests/ModelFamilyTests/Base/SparseCategoricalLossTestBase.cs
@@ -107,7 +107,7 @@ public abstract class SparseCategoricalLossTestBase
         var predicted = new Vector<double>(new[] { 0.1, 0.2, 0.6, 0.1 });
         var actual = new Vector<double>(new[] { 2.0 });
 
-        var derivative = loss.CalculateDerivative(predicted, actual);
+        var derivative = loss.ComputeGradient(predicted, actual);
 
         Assert.Equal(predicted.Length, derivative.Length);
         for (int i = 0; i < derivative.Length; i++)
@@ -130,7 +130,7 @@ public abstract class SparseCategoricalLossTestBase
         var predicted = new Vector<double>(new[] { 0.3, 0.4, 0.3 });
         var actual = new Vector<double>(new[] { 1.0 }); // class 1
 
-        var derivative = loss.CalculateDerivative(predicted, actual);
+        var derivative = loss.ComputeGradient(predicted, actual);
 
         // Gradient at the correct class should be negative (to increase probability)
         Assert.True(derivative[1] < 0,

--- a/tests/AiDotNet.Tests/ModelFamilyTests/Base/TripletLossTestBase.cs
+++ b/tests/AiDotNet.Tests/ModelFamilyTests/Base/TripletLossTestBase.cs
@@ -1,4 +1,5 @@
 using AiDotNet.LossFunctions;
+using AiDotNet.Tensors.Engines.Autodiff;
 using AiDotNet.Tensors.LinearAlgebra;
 using Xunit;
 using System.Threading.Tasks;
@@ -125,7 +126,21 @@ public abstract class TripletLossTestBase
         var positive = CreateMatrix(2, 3, 0.15);
         var negative = CreateMatrix(2, 3, 0.9);
 
-        var (anchorGrad, positiveGrad, negativeGrad) = loss.CalculateDerivative(anchor, positive, negative);
+        // All three gradients come from one backward pass over the triplet forward, which is what
+        // the objective needs: the anchor is pulled toward the positive and pushed from the
+        // negative in the same step.
+        using var tape = new GradientTape<double>();
+
+        var a = Tensor<double>.FromMatrix(anchor);
+        var pos = Tensor<double>.FromMatrix(positive);
+        var neg = Tensor<double>.FromMatrix(negative);
+
+        var scalar = loss.ComputeTapeLoss(a, pos, neg);
+        var gradients = tape.ComputeGradients(scalar, new[] { a, pos, neg });
+
+        var anchorGrad = gradients[a].ToMatrix();
+        var positiveGrad = gradients[pos].ToMatrix();
+        var negativeGrad = gradients[neg].ToMatrix();
 
         for (int i = 0; i < anchorGrad.Rows; i++)
         {

--- a/tests/AiDotNet.Tests/UnitTests/LossFunctions/CrossEntropyLossTests.cs
+++ b/tests/AiDotNet.Tests/UnitTests/LossFunctions/CrossEntropyLossTests.cs
@@ -1,4 +1,5 @@
 using System;
+using AiDotNet.Interfaces;
 using AiDotNet.LinearAlgebra;
 using AiDotNet.LossFunctions;
 using AiDotNet.Tensors.LinearAlgebra;
@@ -98,7 +99,7 @@ namespace AiDotNetTests.UnitTests.LossFunctions
             var actual = new Vector<double>(new double[] { 1.0, 0.0, 0.0 });
 
             // Act
-            var result = loss.CalculateDerivative(predicted, actual);
+            var result = loss.ComputeGradient(predicted, actual);
 
             // Assert
             // Derivative = -actual / predicted / n
@@ -115,7 +116,7 @@ namespace AiDotNetTests.UnitTests.LossFunctions
             var actual = new Vector<double>(new double[] { 1.0, 0.0, 0.0 });
 
             // Act & Assert
-            Assert.Throws<ArgumentException>(() => loss.CalculateDerivative(predicted, actual));
+            Assert.Throws<ArgumentException>(() => loss.ComputeGradient(predicted, actual));
         }
 
         [Fact(Timeout = 60000)]
@@ -127,7 +128,7 @@ namespace AiDotNetTests.UnitTests.LossFunctions
             var actual = new Vector<double>(new double[] { 0.0, 1.0, 0.0 });
 
             // Act
-            var result = loss.CalculateDerivative(predicted, actual);
+            var result = loss.ComputeGradient(predicted, actual);
 
             // Assert
             // Should handle zero probabilities without throwing or returning NaN/Infinity
@@ -161,7 +162,7 @@ namespace AiDotNetTests.UnitTests.LossFunctions
             var actual = new Vector<float>(new float[] { 1.0f, 0.0f, 0.0f });
 
             // Act
-            var result = loss.CalculateDerivative(predicted, actual);
+            var result = loss.ComputeGradient(predicted, actual);
 
             // Assert
             Assert.True(result[0] < 0.0f);
@@ -210,7 +211,7 @@ namespace AiDotNetTests.UnitTests.LossFunctions
             var actual = new Vector<double>(new double[] { 1.0, 0.0, 0.0 });
 
             // Act
-            var result = loss.CalculateDerivative(predicted, actual);
+            var result = loss.ComputeGradient(predicted, actual);
 
             // Assert
             Assert.Equal(predicted.Length, result.Length);

--- a/tests/AiDotNet.Tests/UnitTests/LossFunctions/HuberLossTests.cs
+++ b/tests/AiDotNet.Tests/UnitTests/LossFunctions/HuberLossTests.cs
@@ -1,4 +1,5 @@
 using System;
+using AiDotNet.Interfaces;
 using AiDotNet.LinearAlgebra;
 using AiDotNet.LossFunctions;
 using AiDotNet.Tensors.LinearAlgebra;
@@ -147,7 +148,7 @@ namespace AiDotNetTests.UnitTests.LossFunctions
             var actual = new Vector<double>(new double[] { 1.0, 2.0, 3.0 });
 
             // Act
-            var result = loss.CalculateDerivative(predicted, actual);
+            var result = loss.ComputeGradient(predicted, actual);
 
             // Assert
             Assert.All(result, item => Assert.Equal(0.0, item, 10));
@@ -162,7 +163,7 @@ namespace AiDotNetTests.UnitTests.LossFunctions
             var actual = new Vector<double>(new double[] { 0.0, 0.0 });
 
             // Act
-            var result = loss.CalculateDerivative(predicted, actual);
+            var result = loss.ComputeGradient(predicted, actual);
 
             // Assert
             // For small errors (< delta), derivative = diff / n
@@ -179,7 +180,7 @@ namespace AiDotNetTests.UnitTests.LossFunctions
             var actual = new Vector<double>(new double[] { 0.0, 0.0 });
 
             // Act
-            var result = loss.CalculateDerivative(predicted, actual);
+            var result = loss.ComputeGradient(predicted, actual);
 
             // Assert
             // For large errors (> delta), derivative = delta * sign(diff) / n
@@ -196,7 +197,7 @@ namespace AiDotNetTests.UnitTests.LossFunctions
             var actual = new Vector<double>(new double[] { 1.0, 2.0 });
 
             // Act & Assert
-            Assert.Throws<ArgumentException>(() => loss.CalculateDerivative(predicted, actual));
+            Assert.Throws<ArgumentException>(() => loss.ComputeGradient(predicted, actual));
         }
 
         [Fact(Timeout = 60000)]
@@ -223,7 +224,7 @@ namespace AiDotNetTests.UnitTests.LossFunctions
             var actual = new Vector<float>(new float[] { 0.0f, 0.0f });
 
             // Act
-            var result = loss.CalculateDerivative(predicted, actual);
+            var result = loss.ComputeGradient(predicted, actual);
 
             // Assert
             Assert.Equal(0.25f, result[0], 5);

--- a/tests/AiDotNet.Tests/UnitTests/LossFunctions/MeanAbsoluteErrorLossTests.cs
+++ b/tests/AiDotNet.Tests/UnitTests/LossFunctions/MeanAbsoluteErrorLossTests.cs
@@ -1,4 +1,5 @@
 using System;
+using AiDotNet.Interfaces;
 using AiDotNet.LinearAlgebra;
 using AiDotNet.LossFunctions;
 using AiDotNet.Tensors.LinearAlgebra;
@@ -93,7 +94,7 @@ namespace AiDotNetTests.UnitTests.LossFunctions
             var actual = new Vector<double>(new double[] { 1.0, 2.0, 3.0 });
 
             // Act
-            var result = loss.CalculateDerivative(predicted, actual);
+            var result = loss.ComputeGradient(predicted, actual);
 
             // Assert
             Assert.All(result, item => Assert.Equal(0.0, item, 10));
@@ -108,7 +109,7 @@ namespace AiDotNetTests.UnitTests.LossFunctions
             var actual = new Vector<double>(new double[] { 1.0, 2.0, 3.0 });
 
             // Act
-            var result = loss.CalculateDerivative(predicted, actual);
+            var result = loss.ComputeGradient(predicted, actual);
 
             // Assert
             // Derivative = sign(predicted - actual) / n
@@ -126,7 +127,7 @@ namespace AiDotNetTests.UnitTests.LossFunctions
             var actual = new Vector<double>(new double[] { 2.0, 4.0, 6.0 });
 
             // Act
-            var result = loss.CalculateDerivative(predicted, actual);
+            var result = loss.ComputeGradient(predicted, actual);
 
             // Assert
             // Derivative = sign(predicted - actual) / n
@@ -144,7 +145,7 @@ namespace AiDotNetTests.UnitTests.LossFunctions
             var actual = new Vector<double>(new double[] { 1.0, 2.0 });
 
             // Act & Assert
-            Assert.Throws<ArgumentException>(() => loss.CalculateDerivative(predicted, actual));
+            Assert.Throws<ArgumentException>(() => loss.ComputeGradient(predicted, actual));
         }
 
         [Fact(Timeout = 60000)]
@@ -171,7 +172,7 @@ namespace AiDotNetTests.UnitTests.LossFunctions
             var actual = new Vector<float>(new float[] { 1.0f, 2.0f, 3.0f });
 
             // Act
-            var result = loss.CalculateDerivative(predicted, actual);
+            var result = loss.ComputeGradient(predicted, actual);
 
             // Assert
             Assert.All(result, item => Assert.True(item > 0.0f));
@@ -223,7 +224,7 @@ namespace AiDotNetTests.UnitTests.LossFunctions
             var actual = new Vector<double>(new double[] { 1.0, 2.0, 3.0 });
 
             // Act
-            var result = loss.CalculateDerivative(predicted, actual);
+            var result = loss.ComputeGradient(predicted, actual);
 
             // Assert
             // MAE derivative has constant magnitude (1/n) regardless of error size

--- a/tests/AiDotNet.Tests/UnitTests/LossFunctions/MeanBiasErrorLossTests.cs
+++ b/tests/AiDotNet.Tests/UnitTests/LossFunctions/MeanBiasErrorLossTests.cs
@@ -1,4 +1,5 @@
 using System;
+using AiDotNet.Interfaces;
 using AiDotNet.LinearAlgebra;
 using AiDotNet.LossFunctions;
 using AiDotNet.Tensors.LinearAlgebra;
@@ -128,7 +129,7 @@ namespace AiDotNetTests.UnitTests.LossFunctions
             var actual = new Vector<double>(new double[] { 1.0, 2.0, 3.0 });
 
             // Act
-            var result = loss.CalculateDerivative(predicted, actual);
+            var result = loss.ComputeGradient(predicted, actual);
 
             // Assert
             // Derivative = -1/n = -1/3 = -0.3333... for all elements
@@ -145,7 +146,7 @@ namespace AiDotNetTests.UnitTests.LossFunctions
             var actual = new Vector<double>(new double[] { 1.0, 2.0, 3.0 });
 
             // Act
-            var result = loss.CalculateDerivative(predicted, actual);
+            var result = loss.ComputeGradient(predicted, actual);
 
             // Assert
             // Derivative is always -1/n regardless of prediction accuracy
@@ -162,7 +163,7 @@ namespace AiDotNetTests.UnitTests.LossFunctions
             var actual = new Vector<double>(new double[] { 3.0 });
 
             // Act
-            var result = loss.CalculateDerivative(predicted, actual);
+            var result = loss.ComputeGradient(predicted, actual);
 
             // Assert
             // Derivative = -1/1 = -1.0
@@ -179,7 +180,7 @@ namespace AiDotNetTests.UnitTests.LossFunctions
             var actual = new Vector<double>(new double[] { 1.0, 2.0 });
 
             // Act & Assert
-            Assert.Throws<ArgumentException>(() => loss.CalculateDerivative(predicted, actual));
+            Assert.Throws<ArgumentException>(() => loss.ComputeGradient(predicted, actual));
         }
 
         [Fact(Timeout = 60000)]
@@ -207,7 +208,7 @@ namespace AiDotNetTests.UnitTests.LossFunctions
             var actual = new Vector<float>(new float[] { 1.0f, 2.0f, 3.0f });
 
             // Act
-            var result = loss.CalculateDerivative(predicted, actual);
+            var result = loss.ComputeGradient(predicted, actual);
 
             // Assert
             // Derivative = -1/3 for all elements
@@ -286,19 +287,19 @@ namespace AiDotNetTests.UnitTests.LossFunctions
             // Length 2: derivative should be -0.5
             var predicted2 = new Vector<double>(new double[] { 1.0, 2.0 });
             var actual2 = new Vector<double>(new double[] { 1.0, 2.0 });
-            var result2 = loss.CalculateDerivative(predicted2, actual2);
+            var result2 = loss.ComputeGradient(predicted2, actual2);
             Assert.All(result2, item => Assert.Equal(-0.5, item, 10));
 
             // Length 5: derivative should be -0.2
             var predicted5 = new Vector<double>(new double[] { 1.0, 2.0, 3.0, 4.0, 5.0 });
             var actual5 = new Vector<double>(new double[] { 1.0, 2.0, 3.0, 4.0, 5.0 });
-            var result5 = loss.CalculateDerivative(predicted5, actual5);
+            var result5 = loss.ComputeGradient(predicted5, actual5);
             Assert.All(result5, item => Assert.Equal(-0.2, item, 10));
 
             // Length 10: derivative should be -0.1
             var predicted10 = new Vector<double>(new double[] { 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0 });
             var actual10 = new Vector<double>(new double[] { 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0 });
-            var result10 = loss.CalculateDerivative(predicted10, actual10);
+            var result10 = loss.ComputeGradient(predicted10, actual10);
             Assert.All(result10, item => Assert.Equal(-0.1, item, 10));
         }
     }

--- a/tests/AiDotNet.Tests/UnitTests/LossFunctions/MeanSquaredErrorLossTests.cs
+++ b/tests/AiDotNet.Tests/UnitTests/LossFunctions/MeanSquaredErrorLossTests.cs
@@ -1,4 +1,5 @@
 using System;
+using AiDotNet.Interfaces;
 using AiDotNet.LinearAlgebra;
 using AiDotNet.LossFunctions;
 using AiDotNet.Tensors.LinearAlgebra;
@@ -93,7 +94,7 @@ namespace AiDotNetTests.UnitTests.LossFunctions
             var actual = new Vector<double>(new double[] { 1.0, 2.0, 3.0 });
 
             // Act
-            var result = loss.CalculateDerivative(predicted, actual);
+            var result = loss.ComputeGradient(predicted, actual);
 
             // Assert
             Assert.All(result, item => Assert.Equal(0.0, item, 10));
@@ -108,7 +109,7 @@ namespace AiDotNetTests.UnitTests.LossFunctions
             var actual = new Vector<double>(new double[] { 1.0, 2.0, 3.0 });
 
             // Act
-            var result = loss.CalculateDerivative(predicted, actual);
+            var result = loss.ComputeGradient(predicted, actual);
 
             // Assert
             // Derivative = 2*(predicted-actual)/n = 2*[1,2,3]/3 = [2/3, 4/3, 6/3]
@@ -126,7 +127,7 @@ namespace AiDotNetTests.UnitTests.LossFunctions
             var actual = new Vector<double>(new double[] { 2.0, 4.0, 6.0 });
 
             // Act
-            var result = loss.CalculateDerivative(predicted, actual);
+            var result = loss.ComputeGradient(predicted, actual);
 
             // Assert
             // Derivative = 2*(predicted-actual)/n = 2*[-1,-2,-3]/3 = [-2/3, -4/3, -6/3]
@@ -144,7 +145,7 @@ namespace AiDotNetTests.UnitTests.LossFunctions
             var actual = new Vector<double>(new double[] { 1.0, 2.0 });
 
             // Act & Assert
-            Assert.Throws<ArgumentException>(() => loss.CalculateDerivative(predicted, actual));
+            Assert.Throws<ArgumentException>(() => loss.ComputeGradient(predicted, actual));
         }
 
         [Fact(Timeout = 60000)]
@@ -172,7 +173,7 @@ namespace AiDotNetTests.UnitTests.LossFunctions
             var actual = new Vector<float>(new float[] { 1.0f, 2.0f, 3.0f });
 
             // Act
-            var result = loss.CalculateDerivative(predicted, actual);
+            var result = loss.ComputeGradient(predicted, actual);
 
             // Assert
             // Derivative = 2*(predicted-actual)/n = 2*[1,2,3]/3

--- a/tests/AiDotNet.Tests/UnitTests/LossFunctions/PairwiseRankingLossTests.cs
+++ b/tests/AiDotNet.Tests/UnitTests/LossFunctions/PairwiseRankingLossTests.cs
@@ -1,4 +1,5 @@
 using System;
+using AiDotNet.Interfaces;
 using AiDotNet.LinearAlgebra;
 using AiDotNet.LossFunctions;
 using AiDotNet.Metrics;
@@ -67,7 +68,7 @@ namespace AiDotNetTests.UnitTests.LossFunctions
             var predicted = new Vector<double>(new double[] { 0.0, 2.0 });
             var actual = new Vector<double>(new double[] { 1.0, 0.0 });
 
-            var grad = loss.CalculateDerivative(predicted, actual);
+            var grad = loss.ComputeGradient(predicted, actual);
 
             // To DECREASE loss we must raise s0 and lower s1. Gradient descent steps along
             // -grad, so grad[0] must be negative (push s0 up) and grad[1] positive (push s1 down).
@@ -85,7 +86,7 @@ namespace AiDotNetTests.UnitTests.LossFunctions
             var predicted = new Vector<double>(new double[] { 0.3, -0.1, 1.2, 0.7 });
             var actual = new Vector<double>(new double[] { 0.05, -0.02, 0.10, -0.08 });
 
-            var analytic = loss.CalculateDerivative(predicted, actual);
+            var analytic = loss.ComputeGradient(predicted, actual);
 
             double eps = 1e-6;
             for (int k = 0; k < predicted.Length; k++)
@@ -170,7 +171,7 @@ namespace AiDotNetTests.UnitTests.LossFunctions
             var actual = new Vector<double>(new double[] { 5.0, 5.0, 5.0 });
 
             Assert.Equal(0.0, loss.CalculateLoss(predicted, actual), 12);
-            var grad = loss.CalculateDerivative(predicted, actual);
+            var grad = loss.ComputeGradient(predicted, actual);
             for (int i = 0; i < grad.Length; i++) Assert.Equal(0.0, grad[i], 12);
         }
 

--- a/tests/AiDotNet.Tests/UnitTests/LossFunctions/RootMeanSquaredErrorLossTests.cs
+++ b/tests/AiDotNet.Tests/UnitTests/LossFunctions/RootMeanSquaredErrorLossTests.cs
@@ -1,4 +1,5 @@
 using System;
+using AiDotNet.Interfaces;
 using AiDotNet.LinearAlgebra;
 using AiDotNet.LossFunctions;
 using AiDotNet.Tensors.LinearAlgebra;
@@ -96,7 +97,7 @@ namespace AiDotNetTests.UnitTests.LossFunctions
             var actual = new Vector<double>(new double[] { 1.0, 2.0, 3.0 });
 
             // Act
-            var result = loss.CalculateDerivative(predicted, actual);
+            var result = loss.ComputeGradient(predicted, actual);
 
             // Assert
             Assert.All(result, item => Assert.Equal(0.0, item, 10));
@@ -111,7 +112,7 @@ namespace AiDotNetTests.UnitTests.LossFunctions
             var actual = new Vector<double>(new double[] { 1.0, 2.0, 3.0 });
 
             // Act
-            var result = loss.CalculateDerivative(predicted, actual);
+            var result = loss.ComputeGradient(predicted, actual);
 
             // Assert
             // Differences: [1, 2, 3]
@@ -131,7 +132,7 @@ namespace AiDotNetTests.UnitTests.LossFunctions
             var actual = new Vector<double>(new double[] { 2.0, 4.0, 6.0 });
 
             // Act
-            var result = loss.CalculateDerivative(predicted, actual);
+            var result = loss.ComputeGradient(predicted, actual);
 
             // Assert
             // Differences: [-1, -2, -3]
@@ -153,7 +154,7 @@ namespace AiDotNetTests.UnitTests.LossFunctions
             var actual = new Vector<double>(new double[] { 1.0, 2.0 });
 
             // Act & Assert
-            Assert.Throws<ArgumentException>(() => loss.CalculateDerivative(predicted, actual));
+            Assert.Throws<ArgumentException>(() => loss.ComputeGradient(predicted, actual));
         }
 
         [Fact(Timeout = 60000)]
@@ -181,7 +182,7 @@ namespace AiDotNetTests.UnitTests.LossFunctions
             var actual = new Vector<float>(new float[] { 1.0f, 2.0f, 3.0f });
 
             // Act
-            var result = loss.CalculateDerivative(predicted, actual);
+            var result = loss.ComputeGradient(predicted, actual);
 
             // Assert
             Assert.Equal(0.15430334996209191f, result[0], 5);

--- a/tests/AiDotNet.Tests/UnitTests/LossFunctions/SparseCategoricalCrossEntropyLossTests.cs
+++ b/tests/AiDotNet.Tests/UnitTests/LossFunctions/SparseCategoricalCrossEntropyLossTests.cs
@@ -133,13 +133,17 @@ namespace AiDotNetTests.UnitTests.LossFunctions
             var result = loss.ComputeGradient(predicted, actual);
 
             // Assert
+            // Tolerance is 6 places, not 10: ComputeTapeLoss offsets the probability by a
+            // small epsilon before the log so that p = 0 cannot produce -infinity, which makes
+            // the true gradient -1/(p + eps) rather than -1/p. The deleted analytic derivative
+            // used -1/p and ignored the offset its own forward applied.
             // Gradient should be 0 for classes 0, 1, 3
             // Gradient should be -1/0.6 = -1.6666... for class 2
             Assert.Equal(4, result.Length);
-            Assert.Equal(0.0, result[0], 10);
-            Assert.Equal(0.0, result[1], 10);
-            Assert.Equal(-1.6666666666666667, result[2], 10);
-            Assert.Equal(0.0, result[3], 10);
+            Assert.Equal(0.0, result[0], 6);
+            Assert.Equal(0.0, result[1], 6);
+            Assert.Equal(-1.6666666666666667, result[2], 6);
+            Assert.Equal(0.0, result[3], 6);
         }
 
         [Fact(Timeout = 60000)]
@@ -155,11 +159,15 @@ namespace AiDotNetTests.UnitTests.LossFunctions
             var result = loss.ComputeGradient(predicted, actual);
 
             // Assert
+            // Tolerance is 6 places, not 10: ComputeTapeLoss offsets the probability by a
+            // small epsilon before the log so that p = 0 cannot produce -infinity, which makes
+            // the true gradient -1/(p + eps) rather than -1/p. The deleted analytic derivative
+            // used -1/p and ignored the offset its own forward applied.
             // Gradient for class 0: -1/0.7 = -1.4285... (accumulated twice, then averaged)
             // Average: -2 * (1/0.7) / 2 = -1.4285...
-            Assert.Equal(-1.4285714285714286, result[0], 10);
-            Assert.Equal(0.0, result[1], 10);
-            Assert.Equal(0.0, result[2], 10);
+            Assert.Equal(-1.4285714285714286, result[0], 6);
+            Assert.Equal(0.0, result[1], 6);
+            Assert.Equal(0.0, result[2], 6);
         }
 
         [Fact(Timeout = 60000)]
@@ -175,12 +183,16 @@ namespace AiDotNetTests.UnitTests.LossFunctions
             var result = loss.ComputeGradient(predicted, actual);
 
             // Assert
+            // Tolerance is 6 places, not 10: ComputeTapeLoss offsets the probability by a
+            // small epsilon before the log so that p = 0 cannot produce -infinity, which makes
+            // the true gradient -1/(p + eps) rather than -1/p. The deleted analytic derivative
+            // used -1/p and ignored the offset its own forward applied.
             // Gradient for class 0: -1/0.5 / 3 = -0.6666...
             // Gradient for class 1: -1/0.3 / 3 = -1.1111...
             // Gradient for class 2: -1/0.2 / 3 = -1.6666...
-            Assert.Equal(-0.6666666666666666, result[0], 10);
-            Assert.Equal(-1.1111111111111112, result[1], 10);
-            Assert.Equal(-1.6666666666666667, result[2], 10);
+            Assert.Equal(-0.6666666666666666, result[0], 6);
+            Assert.Equal(-1.1111111111111112, result[1], 6);
+            Assert.Equal(-1.6666666666666667, result[2], 6);
         }
 
         [Fact(Timeout = 60000)]

--- a/tests/AiDotNet.Tests/UnitTests/LossFunctions/SparseCategoricalCrossEntropyLossTests.cs
+++ b/tests/AiDotNet.Tests/UnitTests/LossFunctions/SparseCategoricalCrossEntropyLossTests.cs
@@ -1,4 +1,5 @@
 using System;
+using AiDotNet.Interfaces;
 using AiDotNet.LinearAlgebra;
 using AiDotNet.LossFunctions;
 using AiDotNet.Tensors.LinearAlgebra;
@@ -129,7 +130,7 @@ namespace AiDotNetTests.UnitTests.LossFunctions
             var actual = new Vector<double>(new double[] { 2.0 }); // class index 2
 
             // Act
-            var result = loss.CalculateDerivative(predicted, actual);
+            var result = loss.ComputeGradient(predicted, actual);
 
             // Assert
             // Gradient should be 0 for classes 0, 1, 3
@@ -151,7 +152,7 @@ namespace AiDotNetTests.UnitTests.LossFunctions
             var actual = new Vector<double>(new double[] { 0.0, 0.0 });
 
             // Act
-            var result = loss.CalculateDerivative(predicted, actual);
+            var result = loss.ComputeGradient(predicted, actual);
 
             // Assert
             // Gradient for class 0: -1/0.7 = -1.4285... (accumulated twice, then averaged)
@@ -171,7 +172,7 @@ namespace AiDotNetTests.UnitTests.LossFunctions
             var actual = new Vector<double>(new double[] { 0.0, 1.0, 2.0 });
 
             // Act
-            var result = loss.CalculateDerivative(predicted, actual);
+            var result = loss.ComputeGradient(predicted, actual);
 
             // Assert
             // Gradient for class 0: -1/0.5 / 3 = -0.6666...
@@ -191,7 +192,7 @@ namespace AiDotNetTests.UnitTests.LossFunctions
             var actual = new Vector<double>(new double[] { 3.0 }); // out of bounds
 
             // Act & Assert
-            var exception = Assert.Throws<ArgumentException>(() => loss.CalculateDerivative(predicted, actual));
+            var exception = Assert.Throws<ArgumentException>(() => loss.ComputeGradient(predicted, actual));
             Assert.Contains("out of bounds", exception.Message);
         }
 
@@ -220,7 +221,7 @@ namespace AiDotNetTests.UnitTests.LossFunctions
             var actual = new Vector<float>(new float[] { 2.0f });
 
             // Act
-            var result = loss.CalculateDerivative(predicted, actual);
+            var result = loss.ComputeGradient(predicted, actual);
 
             // Assert
             Assert.Equal(0.0f, result[0], 5);

--- a/tests/AiDotNet.Tests/UnitTests/MetaLearning/Helpers/MockLossFunction.cs
+++ b/tests/AiDotNet.Tests/UnitTests/MetaLearning/Helpers/MockLossFunction.cs
@@ -1,4 +1,6 @@
 using AiDotNet.Interfaces;
+using System;
+using AiDotNet.Tensors.Engines;
 using AiDotNet.LinearAlgebra;
 using AiDotNet.Tensors.Helpers;
 using AiDotNet.Tensors.Interfaces;
@@ -41,38 +43,36 @@ public class MockLossFunction<T> : ILossFunction<T>
         return NumOps.Zero;
     }
 
-    /// <summary>
-    /// Calculates the derivative of the loss function.
-    /// </summary>
-    public Vector<T> CalculateDerivative(Vector<T> predicted, Vector<T> actual)
-    {
-        int length = Math.Min(predicted.Length, actual.Length);
-        var derivative = new Vector<T>(length);
-
-        if (length == 0)
-        {
-            return derivative;
-        }
-
-        T twoOverN = NumOps.Divide(NumOps.FromDouble(2.0), NumOps.FromDouble(length));
-
-        for (int i = 0; i < length; i++)
-        {
-            T diff = NumOps.Subtract(predicted[i], actual[i]);
-            derivative[i] = NumOps.Multiply(twoOverN, diff);
-        }
-
-        return derivative;
-    }
 
     /// <summary>
     /// GPU loss and gradient calculation - not supported in mock.
     /// </summary>
     public (T Loss, Tensor<T> Gradient) CalculateLossAndGradientGpu(Tensor<T> predicted, Tensor<T> actual)
     {
-        // CPU fallback for mock: compute MSE loss and gradient
-        var loss = CalculateLoss(predicted.ToVector(), actual.ToVector());
-        var gradient = CalculateDerivative(predicted.ToVector(), actual.ToVector());
-        return (loss, Tensor<T>.FromVector(gradient));
+        // Both the value and the gradient come from one differentiated forward.
+        return this.ComputeLossAndGradient(predicted, actual);
+    }
+
+    /// <summary>
+    /// Computes the loss as a tape-differentiable scalar tensor.
+    /// </summary>
+    /// <param name="predicted">The predicted tensor.</param>
+    /// <param name="target">The target tensor.</param>
+    /// <returns>A rank-0 scalar tensor holding the mean squared error.</returns>
+    /// <remarks>
+    /// Built from engine operations rather than an element-wise loop so the gradient tape can
+    /// differentiate it. The mock supplies no derivative of its own, exactly like a real loss.
+    /// </remarks>
+    public Tensor<T> ComputeTapeLoss(Tensor<T> predicted, Tensor<T> target)
+    {
+        var engine = AiDotNetEngine.Current;
+        var diff = engine.TensorSubtract(predicted, target);
+        var squared = engine.TensorMultiply(diff, diff);
+
+        var axes = new int[squared.Shape.Length];
+        for (int i = 0; i < axes.Length; i++) axes[i] = i;
+
+        var summed = engine.ReduceSum(squared, axes, keepDims: false);
+        return engine.TensorDivideScalar(summed, NumOps.FromDouble(Math.Max(1, squared.Length)));
     }
 }

--- a/tests/AiDotNet.Tests/UnitTests/NeuralNetworks/GANs/Helpers/MockLossFunction.cs
+++ b/tests/AiDotNet.Tests/UnitTests/NeuralNetworks/GANs/Helpers/MockLossFunction.cs
@@ -1,4 +1,5 @@
 using System;
+using AiDotNet.Tensors.Engines;
 using AiDotNet.Interfaces;
 
 namespace AiDotNetTests.UnitTests.NeuralNetworks.GANs.Helpers;
@@ -39,13 +40,6 @@ public class MockLossFunction<T> : ILossFunction<T>
         return _lossFunc(predicted, actual);
     }
 
-    public Vector<T> CalculateDerivative(Vector<T> predicted, Vector<T> actual)
-    {
-        CalculateDerivativeCallCount++;
-        LastPredicted = predicted;
-        LastActual = actual;
-        return _derivativeFunc(predicted, actual);
-    }
 
     public void Reset()
     {
@@ -61,5 +55,28 @@ public class MockLossFunction<T> : ILossFunction<T>
     public (T Loss, Tensor<T> Gradient) CalculateLossAndGradientGpu(Tensor<T> predicted, Tensor<T> actual)
     {
         throw new NotSupportedException("GPU operations are not supported in MockLossFunction.");
+    }
+
+    /// <summary>
+    /// Computes the loss as a tape-differentiable scalar tensor.
+    /// </summary>
+    /// <param name="predicted">The predicted tensor.</param>
+    /// <param name="target">The target tensor.</param>
+    /// <returns>A rank-0 scalar tensor holding the mean squared error.</returns>
+    /// <remarks>
+    /// Built from engine operations rather than an element-wise loop so the gradient tape can
+    /// differentiate it. The mock supplies no derivative of its own, exactly like a real loss.
+    /// </remarks>
+    public Tensor<T> ComputeTapeLoss(Tensor<T> predicted, Tensor<T> target)
+    {
+        var engine = AiDotNetEngine.Current;
+        var diff = engine.TensorSubtract(predicted, target);
+        var squared = engine.TensorMultiply(diff, diff);
+
+        var axes = new int[squared.Shape.Length];
+        for (int i = 0; i < axes.Length; i++) axes[i] = i;
+
+        var summed = engine.ReduceSum(squared, axes, keepDims: false);
+        return engine.TensorDivideScalar(summed, MathHelper.GetNumericOperations<T>().FromDouble(Math.Max(1, squared.Length)));
     }
 }

--- a/website/src/content/docs/reference/loss-functions.md
+++ b/website/src/content/docs/reference/loss-functions.md
@@ -6,7 +6,7 @@ section: "Reference"
 ---
 
 
-Reference for the loss functions in AiDotNet. They live in `AiDotNet.LossFunctions`, implement `ILossFunction<T>` (`CalculateLoss` / `CalculateDerivative`), and plug into training via `ConfigureLossFunction(...)`.
+Reference for the loss functions in AiDotNet. They live in `AiDotNet.LossFunctions`, implement `ILossFunction<T>` (`CalculateLoss` / `ComputeTapeLoss`), and plug into training via `ConfigureLossFunction(...)`.
 
 ---
 
@@ -103,9 +103,16 @@ var ctc = new CTCLoss<float>();
 
 ## Evaluating a Loss
 
-`CalculateLoss(predicted, actual)` returns the scalar loss; `CalculateDerivative(...)` returns the gradient.
+`CalculateLoss(predicted, actual)` returns the scalar loss. Gradients come from the autodiff tape:
+`ComputeGradient(...)` differentiates the loss's own `ComputeTapeLoss` forward.
+
+A loss function never defines its own derivative. It writes its formula once, in `ComputeTapeLoss`,
+using tensor operations, and the tape works out the calculus — the same arrangement as PyTorch,
+where an `nn.Module` loss defines `forward` and autograd supplies the backward. That is why a
+hand-written gradient cannot fall out of step with the loss it belongs to.
 
 ```csharp
+using AiDotNet.Interfaces;
 using AiDotNet.LossFunctions;
 using AiDotNet.Tensors.LinearAlgebra;
 
@@ -115,7 +122,7 @@ var predicted = new Vector<float>(new[] { 0.9f, 0.2f, 0.7f });
 var actual = new Vector<float>(new[] { 1.0f, 0.0f, 1.0f });
 
 float value = loss.CalculateLoss(predicted, actual);
-var gradient = loss.CalculateDerivative(predicted, actual);
+var gradient = loss.ComputeGradient(predicted, actual);
 Console.WriteLine($"Loss: {value:F4}, gradient length: {gradient.Length}");
 ```
 


### PR DESCRIPTION
Closes #1992.

Loss functions defined their math twice: a forward, and a hand-written analytic derivative that nothing forced to agree with it. This deletes the second one. `ILossFunction<T>` now declares `ComputeTapeLoss` and no longer declares `CalculateDerivative`, so there is no interface slot in which a loss could supply a backward that disagrees with its forward — the PyTorch arrangement, where an `nn.Module` loss defines `forward` only and a hand-written backward exists solely in `torch.autograd.Function`, opted into by defining both together.

## Scope

| | |
|---|---|
| `.CalculateDerivative(` call sites | **205 → 0** (74 in `src`, 131 in tests) |
| `CalculateDerivative` declarations remaining | **0** |
| Analytic derivative implementations deleted | **50** (46 pointwise + 3 multi-input + 1 finite-difference) |
| Loss classes implementing `ComputeTapeLoss` | **46 / 46** |
| Runtime downcast guards deleted | **16** |
| Vestigial call sites deleted | **18** |
| Models no longer claiming a capability they lack | **46** (26 RL + 20 Classification) |

## Bugs this surfaced

Keeping the existing numerical expectations while switching the gradient source turned silent inconsistencies into failing tests. 19 failed. Every one was a real defect.

**`MeanBiasErrorLoss` trained in the wrong direction.** `CalculateLoss` returns `mean(actual − predicted)`; `ComputeTapeLoss` returned `mean(predicted − target)`. The reported loss and the trained loss were negatives of each other, so gradient descent on MBE *ascended* it. Invisible because gradients came from a derivative that agreed with `CalculateLoss` rather than with the tape training actually used.

**`SparseCategoricalCrossEntropyLoss` produced no gradient at all** on its sparse path. It gathered log-probabilities by indexing element-by-element into a fresh tensor, which severs the tape: the result is a leaf constant with no path back to the prediction. Anything training through that path learned nothing. Two further defects: it applied `Softmax` while `CalculateLoss` took `−log(p[class])` directly (the class documents "probabilities from a softmax layer" and declares `RequiresProbabilityInputs`), and it misread its own targets whenever sample count equalled class count, since `[0,1,2]` against three classes matches the dense-shape test exactly.

**`RootMeanSquaredErrorLoss` returned NaN for a perfect prediction.** `d(sqrt(x))/dx` is unbounded as `x → 0`, so an mse of exactly zero gave `0 × ∞` and poisoned every downstream parameter gradient.

**`DiceLoss` computed a different formula in each forward** — the tape smoothed `+1` in numerator and denominator, `CalculateLoss` smoothed with nothing.

**`MultiLabelClassifierBase` held a private `BinaryCrossEntropyLoss`** that had already drifted from the library's own: its `CalculateLoss` divided by N and its derivative did not, disagreeing by a factor of N.

**`PairwiseRankingLoss.ComputeTapeLoss` was not tape math.** It called the analytic derivative and built `sum(predicted * stopgrad(g))` — a surrogate whose tape gradient happens to equal `g` — then shifted the scalar to report the true loss. Replaced with a real pairwise forward over the n×n grid of score differences.

## Multi-input losses

Triplet, contrastive and noise-contrastive losses are not pointwise, so the two-argument forward could not serve them and each kept a hand-written derivative returning one gradient per input. `TripletLoss.ComputeTapeLoss(anchor, positive, negative)` and `ContrastiveLoss.ComputeTapeLoss(output1, output2, similarityLabel)` now cover them; NCE's existing forward already had the right shape.

The new overloads compute only the **geometry** — the Euclidean distances — and hand off to the existing two-argument overload that owns the hinge and pair rule, so the margin logic exists in exactly one place per loss. Both distance helpers offset under the square root, because `d(sqrt(x))/dx` is unbounded at zero and zero distance is exactly what a positive pair converges to: without it the gradient goes NaN precisely when training is succeeding.

`DETRSetLoss.CalculateDerivative` is deleted as well — no callers, and it computed gradients by finite differences (2N forward passes each) with a comment conceding analytic gradients are hard for Hungarian matching.

## The capability contract

`IGradientComputable.ComputeGradients` documents *"gradients with respect to all model parameters"*, and `ApplyGradients` consumes exactly that. 32 RL agents returned the loss gradient with respect to the network **output** instead — wrong length, wrong quantity. EWC, GEM and MAS build Fisher-information estimates from this vector.

The structural cause: `IRLAgent<T>` *inherited* `IGradientComputable`, forcing the member onto every agent — contradicting `IFullModel`'s own documentation that a model *"may not implement IParameterizable or IGradientComputable"*. It no longer does. 29 agents that genuinely compute gradients declare it explicitly; 26 that learn by Bellman backup, eligibility traces, running averages or least squares no longer claim it.

The same defect ran through Classification: 20 models — decision trees, naive Bayes, KNN, SVMs, discriminant analysis, label propagation, Rocket variants, tree ensembles — implemented `ComputeGradients` by returning a **zero vector**. That is worse than not offering it: EWC computes zero importance for every parameter, protects nothing against catastrophic forgetting, and reports success.

Two workarounds became unnecessary and are deleted: `RainbowDQNAgent.ApplyGradients` indexed `gradients[i % gradients.Length]`, cycling a short output-space vector across the whole parameter vector; `DQNAgent.ApplyGradients` carried a guard whose message told callers to bypass `ComputeGradients` entirely.

`DuelingNetwork<T>` becomes public — it was `internal`, so users could neither subclass nor substitute it.

## Verification

- `src` builds **0 errors on all three TFMs** (net10.0, net8.0, net471); tests build 0 errors on net10.0 and net471.
- **983** loss / triplet / contrastive / continual-learning tests pass.
- Classifiers touched by the sweep: **119/119** in isolation.
- **`TapeGradientFiniteDifferenceTests`** — 20 losses across four input domains, checked against central finite differences. Independent of both the tape and the deleted math, since it is computed from each loss's own forward. Also gives gradient coverage to losses whose `CalculateDerivative` threw and so had no runnable gradient test.
- **`MultiInputTapeGradientTests`** — checks all three multi-input losses against finite differences for **every** input. A gradient reaching one of three inputs and not the others is the realistic failure here, and a "gradients are finite" assertion cannot see it. Triplet inputs are chosen so the hinge is active (on its flat side all three gradients are legitimately zero); contrastive is checked at both similarity labels because they select different branches.

## Note for reviewers

Build verification had to run where method bodies actually bind. The first build after the interface change reported 47 errors, **all declaration-level**, and zero of the 70 call-site errors — those appeared only once the declarations were clean. An "error count before and after" comparison would have proven nothing here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
