### PR TITLE
fix(tests): build model inputs from the effective shape, not the declared one

### DIFF
--- a/src/AiDotNet.Generators/TestScaffoldGenerator.cs
+++ b/src/AiDotNet.Generators/TestScaffoldGenerator.cs
@@ -13344,12 +13344,17 @@ public class TestScaffoldGenerator : IIncrementalGenerator
             sb.AppendLine("        using var _arena = AiDotNet.Tensors.Helpers.TensorArena.Create();");
             sb.AppendLine("        var rng = AiDotNet.Tests.ModelFamilyTests.Base.ModelTestHelpers.CreateSeededRandom();");
             sb.AppendLine("        using var network = CreateNetwork();");
-            sb.AppendLine("        var trainInput = CreateRandomTensor(InputShape, rng);");
+            // EffectiveInputShape, not InputShape. The fixture helpers resolve the model's value
+            // domain by matching the requested shape against EffectiveInputShape; handed the raw
+            // declared shape they find no match, fall back to Continuous, and fill an embedding's
+            // input with rng.NextDouble(). The target below already used the Effective variant --
+            // only the input side was missed.
+            sb.AppendLine("        var trainInput = CreateRandomTensor(EffectiveInputShape, rng);");
             sb.AppendLine("        var trainTarget = CreateRandomTargetTensor(EffectiveOutputShape, rng);");
             sb.AppendLine("        int iterations = ResolveConformanceTrainingIterations(network, TrainingIterations);");
             sb.AppendLine("        for (int i = 0; i < iterations; i++) network.Train(trainInput, trainTarget);");
-            sb.AppendLine("        var input1 = CreateConstantTensor(InputShape, 0.1);");
-            sb.AppendLine("        var input2 = CreateConstantTensor(InputShape, 0.9);");
+            sb.AppendLine("        var input1 = CreateConstantTensor(EffectiveInputShape, 0.1);");
+            sb.AppendLine("        var input2 = CreateConstantTensor(EffectiveInputShape, 0.9);");
             sb.AppendLine("        var output1 = network.Predict(input1);");
             sb.AppendLine("        var output2 = network.Predict(input2);");
             sb.AppendLine("        double sumSquared = 0;");
@@ -13514,15 +13519,20 @@ public class TestScaffoldGenerator : IIncrementalGenerator
                 sb.AppendLine("        using var _arena = AiDotNet.Tensors.Helpers.TensorArena.Create();");
                 sb.AppendLine("        var rng = AiDotNet.Tests.ModelFamilyTests.Base.ModelTestHelpers.CreateSeededRandom();");
                 sb.AppendLine("        using var network = CreateNetwork();");
-                sb.AppendLine("        var trainInput = CreateRandomTensor(InputShape, rng);");
+                // EffectiveInputShape, not InputShape -- see the sibling emission above. The training
+                // input here is what actually threw: CreateRandomTensor could not match the raw
+                // declared shape against EffectiveInputShape, fell back to Continuous, and handed the
+                // embedding rng.NextDouble(). The hand-built token tensors below are integral and so
+                // survived the value check, but they must span the same shape the model accepts.
+                sb.AppendLine("        var trainInput = CreateRandomTensor(EffectiveInputShape, rng);");
                 sb.AppendLine("        var trainTarget = CreateRandomTargetTensor(EffectiveOutputShape, rng);");
                 sb.AppendLine("        int iterations = ResolveConformanceTrainingIterations(network, TrainingIterations);");
                 sb.AppendLine("        for (int i = 0; i < iterations; i++) network.Train(trainInput, trainTarget);");
                 sb.AppendLine("        // Build two DIFFERENT integer-token sequences so EmbeddingLayer's");
                 sb.AppendLine("        // int-truncation produces distinct lookups (constant float inputs all");
                 sb.AppendLine("        // collapse to token 0 under (int) truncation).");
-                sb.AppendLine("        var input1 = new AiDotNet.Tensors.LinearAlgebra.Tensor<double>(InputShape);");
-                sb.AppendLine("        var input2 = new AiDotNet.Tensors.LinearAlgebra.Tensor<double>(InputShape);");
+                sb.AppendLine("        var input1 = new AiDotNet.Tensors.LinearAlgebra.Tensor<double>(EffectiveInputShape);");
+                sb.AppendLine("        var input2 = new AiDotNet.Tensors.LinearAlgebra.Tensor<double>(EffectiveInputShape);");
                 sb.AppendLine($"        for (int i = 0; i < input1.Length; i++) input1[i] = {elemCast}(i % 50);");
                 sb.AppendLine($"        for (int i = 0; i < input2.Length; i++) input2[i] = {elemCast}((i + 25) % 50);");
                 sb.AppendLine("        var output1 = network.Predict(input1);");

--- a/tests/AiDotNet.Tests/ModelFamilyTests/Base/FinancialModelTestBase.cs
+++ b/tests/AiDotNet.Tests/ModelFamilyTests/Base/FinancialModelTestBase.cs
@@ -33,7 +33,7 @@ public abstract class FinancialModelTestBase<T> : NeuralNetworkModelTestBase<T>
         using var _arena = TensorArena.Create();
         var rng = ModelTestHelpers.CreateSeededRandom();
         var network = CreateNetwork();
-        var input = CreateRandomTensor(InputShape, rng);
+        var input = CreateRandomTensor(EffectiveInputShape, rng);
 
         var output = network.Predict(input);
         Assert.True(output.Length > 0, "Financial model produced empty output.");
@@ -59,8 +59,8 @@ public abstract class FinancialModelTestBase<T> : NeuralNetworkModelTestBase<T>
         using var _arena = TensorArena.Create();
         var network = CreateNetwork();
 
-        var bullish = CreateConstantTensor(InputShape, 0.8);  // simulating upward data
-        var bearish = CreateConstantTensor(InputShape, 0.2);  // simulating downward data
+        var bullish = CreateConstantTensor(EffectiveInputShape, 0.8);  // simulating upward data
+        var bearish = CreateConstantTensor(EffectiveInputShape, 0.2);  // simulating downward data
 
         var predBull = network.Predict(bullish);
         var predBear = network.Predict(bearish);
@@ -93,7 +93,7 @@ public abstract class FinancialModelTestBase<T> : NeuralNetworkModelTestBase<T>
         using var _arena = TensorArena.Create();
         var rng = ModelTestHelpers.CreateSeededRandom();
         var network = CreateNetwork();
-        var input = CreateRandomTensor(InputShape, rng);
+        var input = CreateRandomTensor(EffectiveInputShape, rng);
 
         var output = network.Predict(input);
         for (int i = 0; i < output.Length; i++)
@@ -116,7 +116,7 @@ public abstract class FinancialModelTestBase<T> : NeuralNetworkModelTestBase<T>
         await Task.Yield();
         using var _arena = TensorArena.Create();
         var network = CreateNetwork();
-        var zeroInput = CreateConstantTensor(InputShape, 0.0);
+        var zeroInput = CreateConstantTensor(EffectiveInputShape, 0.0);
 
         var output = network.Predict(zeroInput);
         Assert.True(output.Length > 0, "Financial model produced empty output for zero input.");

--- a/tests/AiDotNet.Tests/ModelFamilyTests/Base/FinancialNLPTestBase.cs
+++ b/tests/AiDotNet.Tests/ModelFamilyTests/Base/FinancialNLPTestBase.cs
@@ -44,8 +44,8 @@ public abstract class FinancialNLPTestBase<T> : FinancialModelTestBase<T>
         await Task.Yield();
         using var _arena = TensorArena.Create();
         var network = CreateNetwork();
-        var positive = CreateConstantTensor(InputShape, 0.9);
-        var negative = CreateConstantTensor(InputShape, 0.1);
+        var positive = CreateConstantTensor(EffectiveInputShape, 0.9);
+        var negative = CreateConstantTensor(EffectiveInputShape, 0.1);
 
         var out1 = network.Predict(positive);
         var out2 = network.Predict(negative);
@@ -71,7 +71,7 @@ public abstract class FinancialNLPTestBase<T> : FinancialModelTestBase<T>
         using var _arena = TensorArena.Create();
         var rng = ModelTestHelpers.CreateSeededRandom();
         var network = CreateNetwork();
-        var input = CreateRandomTensor(InputShape, rng);
+        var input = CreateRandomTensor(EffectiveInputShape, rng);
         var output = network.Predict(input);
 
         for (int i = 0; i < output.Length; i++)

--- a/tests/AiDotNet.Tests/ModelFamilyTests/Base/ForecastingModelTestBase.cs
+++ b/tests/AiDotNet.Tests/ModelFamilyTests/Base/ForecastingModelTestBase.cs
@@ -20,7 +20,7 @@ public abstract class ForecastingModelTestBase<T> : FinancialModelTestBase<T>
         using var _arena = TensorArena.Create();
         var rng = ModelTestHelpers.CreateSeededRandom();
         var network = CreateNetwork();
-        var input = CreateRandomTensor(InputShape, rng);
+        var input = CreateRandomTensor(EffectiveInputShape, rng);
         var output = network.Predict(input);
         Assert.True(output.Length > 0, "Forecasting model produced empty forecast.");
     }
@@ -31,8 +31,8 @@ public abstract class ForecastingModelTestBase<T> : FinancialModelTestBase<T>
         await Task.Yield();
         using var _arena = TensorArena.Create();
         var network = CreateNetwork();
-        var history1 = CreateConstantTensor(InputShape, 0.1);
-        var history2 = CreateConstantTensor(InputShape, 0.9);
+        var history1 = CreateConstantTensor(EffectiveInputShape, 0.1);
+        var history2 = CreateConstantTensor(EffectiveInputShape, 0.9);
 
         var forecast1 = network.Predict(history1);
         var forecast2 = network.Predict(history2);

--- a/tests/AiDotNet.Tests/ModelFamilyTests/Base/TTSModelTestBase.cs
+++ b/tests/AiDotNet.Tests/ModelFamilyTests/Base/TTSModelTestBase.cs
@@ -27,8 +27,8 @@ public abstract class TTSModelTestBase<T> : NeuralNetworkModelTestBase<T>
         using var _arena = TensorArena.Create();
         var network = CreateNetwork();
 
-        var text1 = CreateConstantTensor(InputShape, 0.2);
-        var text2 = CreateConstantTensor(InputShape, 0.8);
+        var text1 = CreateConstantTensor(EffectiveInputShape, 0.2);
+        var text2 = CreateConstantTensor(EffectiveInputShape, 0.8);
 
         var audio1 = network.Predict(text1);
         var audio2 = network.Predict(text2);
@@ -59,7 +59,7 @@ public abstract class TTSModelTestBase<T> : NeuralNetworkModelTestBase<T>
         using var _arena = TensorArena.Create();
         var rng = ModelTestHelpers.CreateSeededRandom();
         var network = CreateNetwork();
-        var input = CreateRandomTensor(InputShape, rng);
+        var input = CreateRandomTensor(EffectiveInputShape, rng);
 
         var output = network.Predict(input);
         Assert.True(output.Length > 0,
@@ -79,7 +79,7 @@ public abstract class TTSModelTestBase<T> : NeuralNetworkModelTestBase<T>
         using var _arena = TensorArena.Create();
         var rng = ModelTestHelpers.CreateSeededRandom();
         var network = CreateNetwork();
-        var input = CreateRandomTensor(InputShape, rng);
+        var input = CreateRandomTensor(EffectiveInputShape, rng);
 
         var output = network.Predict(input);
         for (int i = 0; i < output.Length; i++)
@@ -106,7 +106,7 @@ public abstract class TTSModelTestBase<T> : NeuralNetworkModelTestBase<T>
         using var _arena = TensorArena.Create();
         var rng = ModelTestHelpers.CreateSeededRandom();
         var network = CreateNetwork();
-        var input = CreateRandomTensor(InputShape, rng);
+        var input = CreateRandomTensor(EffectiveInputShape, rng);
 
         var out1 = network.Predict(input);
         var out2 = network.Predict(input);


### PR DESCRIPTION
## Summary

Fixes **I1** from the master CI failure analysis — 63 failing assertions across 15 shards, the second-largest root-cause bucket (19.8%), all of the form:

```
InputContractViolationException : Tacotron`1.input requires token indices in [0, 256),
but element 0 is 0.3362129330635071
```

Every one of the 63 is the same defect, and it is in the **test fixture**, not in the models. No production model behaviour changes.

## Root cause

The domain-aware fixture work already exists: `CreateRandomTensor` and `CreateConstantTensor` ask the model which value domain it accepts and emit legal token indices when the first layer is an embedding. The lookup that answers that question is `InputDomainFor`, which matches the requested shape against `EffectiveInputShape` and returns `Continuous` for anything else. That comparison is deliberate — it is what separates an **input** tensor from a **target**, which is not consumed by the input layer.

Four base classes and two generator branches were still requesting fixtures at the raw declared `InputShape`. Where a model's shape constraint makes the two shapes differ, the match fails, the lookup silently falls back to `Continuous`, and the embedding is handed `rng.NextDouble()`.

Measured directly on Tacotron:

| | shape | resolved domain |
|---|---|---|
| `InputShape` | `[8, 80]` | `Continuous [0, 0)` |
| `EffectiveInputShape` | `[8, 32]` | `IntegerIndices [0, 256)` |

The silence is what made this hard to see: nothing reports a shape that failed to match, so the call site looks correct and the *model* takes the blame for rejecting its own input.

## What changed

Only tensors fed to the model **as input**. Targets still resolve through `CreateRandomTargetTensor` and the output shapes, which were already correct.

| Site | Sites | I1 failures |
|---|---:|---:|
| `TTSModelTestBase` | 5 | 48, across 12 TTS models |
| `FinancialModelTestBase` | 5 | Chronos, SECBERT |
| `FinancialNLPTestBase` | 3 | SECBERT |
| `ForecastingModelTestBase` | 3 | Chronos |
| `TestScaffoldGenerator`, both generated `DifferentInputs_AfterTraining` overrides | 2 | 5 recurrent language models |

The generator case shows the original miss plainly — the **target** on the adjacent line already used `EffectiveOutputShape`:

```diff
- var trainInput  = CreateRandomTensor(InputShape, rng);
+ var trainInput  = CreateRandomTensor(EffectiveInputShape, rng);
  var trainTarget = CreateRandomTargetTensor(EffectiveOutputShape, rng);
```

Only the input side was left on the declared shape.

## Verification

**62 of the 63 I1 tests pass, from 0 before.** Run against the exact test list in `AiDotNet-CI-Master-Failure-List-Run-32147073004.csv`:

```
Failed: 1, Passed: 62, Skipped: 0, Total: 63
```

The one remaining, `RecurrentGemmaLanguageModelTests.DifferentInputs_AfterTraining_ShouldProduceDifferentOutputs`, **no longer raises a contract violation**. It now fails on `L2 distance = NaN`, which is a pre-existing numerical defect in that model rather than an input-contract one: RecurrentGemma already fails **8 tests on master** — 4 `N1`, 1 `C1`, 2 `Z` and this `I1` — and locally its gradients contain 3,417,600 non-finite entries with param L2 going to `NaN` after a *single* training step. That belongs to the **N1** bucket and is untouched here.

Builds clean on net10.0 and net471.

### Note on local timeouts

Running all 19 affected model classes in one process makes several heavy tests exceed the 120 s per-test gate; CI shards them across 15 separate jobs. Run individually they pass in 1–2 s each (`TacotronTests.DifferentInputs_AfterTraining`, `GradTTSTests.GradientFlow_ShouldBeNonZeroAndFinite`, `SECBERTTests.Parameters_CountShouldMatchVector_AfterForward` all verified). None of those timeouts appear in the master baseline and none reproduce in isolation.

### Regression sweep

The full `ModelFamilyTests.Generated` namespace: **591 passed / 13 failed / 619 total**. None of the 13 are input-contract failures, and **all 13 pass when re-run in isolation** — five are NOTEARS/NTSNOTEARS causal-discovery tests this change cannot reach (no TTS/financial/forecasting base, no language-model override), which is what identified them as contention artifacts of running 619 heavy tests in one process. Verified individually: NOTEARS x4, NTSNOTEARS, LISA x2 (96/96 passed), plus ProDiff, RWKV4, WellSaidLabs, BSRoFormer, PIDNet and SED (6/6 passed).

**Zero regressions.**


## Scope

This PR is **I1 only**. T1 (training does not reduce loss, 83 failures) is being handled separately on another branch; the two do not touch the same files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

# Acceptance check against the master CI baseline

Method follows `AiDotNet-CI-Failure-Analysis.md`: **compare failing TEST counts, never failing shard
names**, and never treat a cancelled or runner-killed shard as green.

**Before —** master run [`32147073004`](https://github.com/ooples/AiDotNet/actions/runs/32147073004) at `9f73afe31b` (#2006). This is this branch's actual
merge-base, so the comparison isolates the change rather than mixing in later master commits.
**After —** this PR, run [`32172057580`](https://github.com/ooples/AiDotNet/actions/runs/32172057580) at `102d97e6cd`.

## 1. Scale

| Metric | Master `9f73afe31b` | This PR `102d97e6cd` | Δ |
|---|---:|---:|---:|
| Jobs in `Build & SonarCloud` | 160 | 160 | 0 |
| — successful | 101 | 101 | 0 |
| — failed | 59 | 58 | −1 |
| Check-runs on the commit (all workflows) | — | 58 fail / 145 pass / 3 cancelled / 1 neutral | — |
| **Distinct failing tests** | **315** | **249** | **−66** |
| (shard, test) failure rows | 318 | 252 | −66 |

Counts are given in two units on purpose: *jobs inside `Build & SonarCloud`* and *check-runs across
all eight workflows*, which is what the PR page totals. They differ — `CodeQL Analysis` is
`cancelled` as a job but renders as `fail` as a check.

## 2. Does it fix what it claims? — I1, yes: 63 → 1

| | I1 tests still failing |
|---|---:|
| Master `9f73afe31b` | **63 of 63** |
| This PR | **1 of 63** |

**62 of 63 fixed.** The holdout is
`RecurrentGemmaLanguageModelTests.DifferentInputs_AfterTraining_ShouldProduceDifferentOutputs`,
which is a D1 (dead-network) symptom surfacing once the input contract is satisfied, not an
input-contract failure.

71 tests flip master-fail → PR-pass in total — the 62 I1 plus 9 that were failing downstream of the
same bad fixture input.

## 3. Does it increase failing tests elsewhere? — 5 appear, 0 confirmed regressions

| Test | Shard | Verdict |
|---|---|---|
| `SegmentationModelSizeVariationTests.SegFormer_AllModelSizes(B4)` | Integration C - ComputerVision | **not comparable** — shard emitted no `Total tests:` summary in this run, and is the documented runner-killed shard on master |
| `SegmentationModelSizeVariationTests.SegFormer_AllModelSizes(B5)` | Integration C - ComputerVision | **not comparable** — same shard |
| `SpyNetLayerTests.TapeGradient_ShouldMatchNumericalGradient` | Generated Layers Sil-Sq | **flake, not this PR** — see below |
| `DeepBeliefNetworkTests.MoreData_ShouldNotDegrade` | ModelFamily - NeuralNetworks A-F | **pre-existing on current master** — fails on master `264780d8b2` (#2009) and on #2027; absent only from the older #2006 baseline |
| `BiaffineNERTests.GradientFlow_ShouldBeNonZeroAndFinite` | Generated Layers B | **newly exposed, single observation** — see below |

### `SpyNetLayerTests.TapeGradient` is not attributable to this PR

Cross-referenced across every run available:

| Run | SpyNet failing? |
|---|---|
| master `9f73afe31b` (#2006) | no |
| master `264780d8b2` (#2009) | no |
| **PR #2025** `102d97e6cd` | **yes** |
| **PR #2027** `05331385e3` | **yes** |
| **PR #2027** `81e2b0e996` | **yes** |

3/3 in PR runs, 0/2 in master runs, across two PRs that share nothing: this one changes 5
test-harness files and touches neither `Directory.Packages.props` nor SpyNet, while #2027 bumps
Tensors `0.127.0 → 0.128.0`. An earlier revision of #2027's description attributed this test to that
bump; this cross-reference disproves that. It is order- or environment-dependent and needs its own
investigation.

### `BiaffineNERTests.GradientFlow` is the one to look at

`BiaffineNERTests` is a generated test, and this PR changes what shape the generator feeds it
(`InputShape` → `EffectiveInputShape`). So this is plausibly the same phenomenon as the I1 fix
itself: the model now receives a correctly-shaped input and a real defect becomes visible, rather
than the fixture failing first. It is a single observation (0 in #2006, #2009 and #2027), so it
needs a second run to confirm before it is either accepted as newly-exposed or chased as a
regression.

## 4. Base drift, and why it does not block this

This branch is based on `9f73afe31b`; master is now `bc5111fdd6` (adds #2009 and #2027). The
comparison above therefore measures this change in isolation rather than against today's master.
That gap was assessed directly rather than assumed:

| Check | Result |
|---|---|
| File overlap with #2027 (141 files) | **none** — the 5 files here are untouched by it |
| Textual merge (`git merge-tree --write-tree origin/master`) | **clean**, no conflicts |
| Models in both populations | **1 of 18** — `AudioPaLM` |
| `AudioPaLM` on master today | still fails all 4 tests on `#2006`, `#2009` and `#2027`; this PR fixes all 4 |

The change is test-harness only — one source generator plus four test base classes, no production
model or runtime code — so its blast radius is what the generated tests feed models, not library
behaviour. Combined with a clean merge and a single overlapping model that moves in the right
direction, a pre-merge rebase-and-rerun is not required; the post-merge master run is the
verification.

**Watch on the next master baseline run:** whether `BiaffineNERTests.GradientFlow` reappears
(confirming a newly-exposed model defect rather than a one-off), and whether
`SpyNetLayerTests.TapeGradient` appears on master for the first time — the third sample that would
settle whether it is specific to PR-run environments.

## 5. Method

```bash
gh api "repos/ooples/AiDotNet/actions/runs/<run_id>/jobs?per_page=100&filter=latest" --paginate \
     --jq '.jobs[]|[.id,.conclusion,.name]|@tsv'
gh api "repos/ooples/AiDotNet/actions/jobs/<id>/logs"   # parse "Failed <fqn>" and "Total tests: N"
```

Set differences use `grep -Fxf`; `comm` mis-collates these fully-qualified names and under-reports
the intersection.
