### PR TITLE
feat(adamw): let a recipe exempt parameters from decoupled weight decay

### DIFF
--- a/src/Models/Options/AdamWOptimizerOptions.cs
+++ b/src/Models/Options/AdamWOptimizerOptions.cs
@@ -142,6 +142,36 @@ public class AdamWOptimizerOptions<T, TInput, TOutput> : GradientBasedOptimizerO
     public double WeightDecay { get; set; } = 0.01;
 
     /// <summary>
+    /// Gets or sets a per-parameter multiplier applied to the decay term, or <c>null</c> to decay
+    /// every parameter equally.
+    /// </summary>
+    /// <value>A vector as long as the flat parameter vector, or <c>null</c>. Defaults to <c>null</c>.</value>
+    /// <remarks>
+    /// <para>
+    /// <see cref="WeightDecay"/> is a single coefficient applied to the whole flat parameter vector, so
+    /// there is otherwise no way to express "decay these parameters but not those". Published recipes
+    /// routinely need exactly that: RecurrentGemma (Botev et al., 2024) Section 2 states "we do not
+    /// apply weight decay to the parameters of the recurrent (RG-LRU) layers during training", and the
+    /// usual transformer recipe exempts biases and normalization gains.
+    /// </para>
+    /// <para>
+    /// Entries multiply the decay term elementwise: 1 decays normally, 0 exempts, and values in
+    /// between scale it. The gradient update is untouched -- this is decoupled decay only.
+    /// </para>
+    /// <para>
+    /// <b>Setting this opts the optimizer out of fused compilation.</b> The fused config carries decay
+    /// as a single float, so a masked run cannot be expressed there; rather than let the compiled path
+    /// silently decay parameters the eager path exempts,
+    /// <c>TryGetFusedOptimizerConfig</c> declines when a mask is present.
+    /// </para>
+    /// <para><b>For Beginners:</b> Leave this null unless a recipe tells you some layers must not be
+    /// decayed. Weight decay pulls weights toward zero, which helps most layers generalize but corrupts
+    /// parameters whose value carries meaning rather than magnitude -- a recurrence's decay rate, for
+    /// instance.</para>
+    /// </remarks>
+    public Vector<T>? WeightDecayMask { get; set; }
+
+    /// <summary>
     /// Gets or sets whether to apply AMSGrad variant for improved convergence guarantees.
     /// </summary>
     /// <value>True to use AMSGrad variant, false for standard AdamW. Default: false</value>

--- a/src/Optimizers/AdamWOptimizer.cs
+++ b/src/Optimizers/AdamWOptimizer.cs
@@ -148,6 +148,10 @@ public class AdamWOptimizer<T, TInput, TOutput> : GradientBasedOptimizerBase<T, 
     {
         config = default;
         if (_options.UseAdaptiveLearningRate) return false;
+        // A masked run cannot be expressed here: the config below carries decay as a single float, so
+        // the compiled kernel would decay every parameter including the ones the mask exempts. Decline
+        // rather than diverge from the eager path.
+        if (_options.WeightDecayMask is not null) return false;
         if (!TryGetFusedLrSchedule(out var schedule)) return false;
         // AdamW + AMSGrad uses the same max-second-moment kernel; decoupled weight
         // decay is carried in WeightDecay and applied by the AdamW update path.
@@ -360,6 +364,10 @@ public class AdamWOptimizer<T, TInput, TOutput> : GradientBasedOptimizerBase<T, 
         // DECOUPLED WEIGHT DECAY: Apply weight decay directly to parameters
         // AdamW: parameters = parameters - lr * adam_update - lr * weight_decay * parameters
         var weightDecayTerm = (Vector<T>)Engine.Multiply(parameters, weightDecay);
+        // Per-parameter exemption (see AdamWOptimizerOptions.WeightDecayMask). Null means decay
+        // everything, which is the behaviour every caller had before the mask existed.
+        if (_options.WeightDecayMask is { } decayMask)
+            weightDecayTerm = (Vector<T>)Engine.Multiply(weightDecayTerm, decayMask);
         var scaledWeightDecay = (Vector<T>)Engine.Multiply(weightDecayTerm, CurrentLearningRate);
 
         // Combine: parameters = parameters - scaledAdamUpdate - scaledWeightDecay
@@ -454,6 +462,8 @@ public class AdamWOptimizer<T, TInput, TOutput> : GradientBasedOptimizerBase<T, 
         var outSpan = updatedParameters.AsWritableSpan();
         bool amsGrad = _options.UseAMSGrad && _vMax != null;
         var vMaxSpan = amsGrad ? _vMax!.AsWritableSpan() : default;
+        // Empty when no mask is configured, which keeps the per-element branch off the common path.
+        var maskSpan = _options.WeightDecayMask is { } wdMask ? wdMask.AsWritableSpan() : default;
         T learningRate = CurrentLearningRate;
 
         for (int i = 0; i < pSpan.Length; i++)
@@ -481,9 +491,14 @@ public class AdamWOptimizer<T, TInput, TOutput> : GradientBasedOptimizerBase<T, 
 
             T adamUpdate = NumOps.Divide(mHat, NumOps.Add(NumOps.Sqrt(vHat), epsilon));
             T afterAdam = NumOps.Subtract(p, NumOps.Multiply(adamUpdate, learningRate));
+            // Per-parameter exemption (see AdamWOptimizerOptions.WeightDecayMask). Null means decay
+            // everything, which is the behaviour every caller had before the mask existed.
+            T decayForThisParameter = weightDecay;
+            if (maskSpan.Length > 0)
+                decayForThisParameter = NumOps.Multiply(decayForThisParameter, maskSpan[i]);
             outSpan[i] = NumOps.Subtract(
                 afterAdam,
-                NumOps.Multiply(NumOps.Multiply(p, weightDecay), learningRate));
+                NumOps.Multiply(NumOps.Multiply(p, decayForThisParameter), learningRate));
         }
 
         return updatedParameters;
@@ -578,6 +593,10 @@ public class AdamWOptimizer<T, TInput, TOutput> : GradientBasedOptimizerBase<T, 
 
         // Decoupled weight decay
         var weightDecayTerm = (Vector<T>)Engine.Multiply(parameters, weightDecay);
+        // Per-parameter exemption (see AdamWOptimizerOptions.WeightDecayMask). Null means decay
+        // everything, which is the behaviour every caller had before the mask existed.
+        if (_options.WeightDecayMask is { } decayMask)
+            weightDecayTerm = (Vector<T>)Engine.Multiply(weightDecayTerm, decayMask);
         var scaledWeightDecay = (Vector<T>)Engine.Multiply(weightDecayTerm, CurrentLearningRate);
 
         var afterAdamUpdate = (Vector<T>)Engine.Subtract(parameters, scaledAdamUpdate);

--- a/tests/AiDotNet.Tests/UnitTests/Optimizers/AdamWWeightDecayMaskTests.cs
+++ b/tests/AiDotNet.Tests/UnitTests/Optimizers/AdamWWeightDecayMaskTests.cs
@@ -1,0 +1,93 @@
+using AiDotNet.Models.Options;
+using AiDotNet.Optimizers;
+using Xunit;
+
+namespace AiDotNet.Tests.UnitTests.Optimizers;
+
+/// <summary>
+/// Pins <see cref="AdamWOptimizerOptions{T, TInput, TOutput}.WeightDecayMask"/>.
+/// </summary>
+/// <remarks>
+/// Decoupled decay is applied to the whole flat parameter vector, so without a mask there is no way to
+/// express a recipe that exempts particular parameters -- RecurrentGemma (Botev et al., 2024) Section 2
+/// exempts the recurrent layers, and the usual transformer recipe exempts biases and normalization
+/// gains. These assert the exemption actually reaches the update rather than being a setting that
+/// silently does nothing.
+/// </remarks>
+public class AdamWWeightDecayMaskTests
+{
+    private static Vector<double> StepOnce(Vector<double>? mask, double weightDecay)
+    {
+        var options = new AdamWOptimizerOptions<double, Matrix<double>, Vector<double>>
+        {
+            InitialLearningRate = 0.1,
+            WeightDecay = weightDecay,
+            Beta1 = 0.9,
+            Beta2 = 0.999,
+            Epsilon = 1e-8,
+            WeightDecayMask = mask,
+        };
+        var optimizer = new AdamWOptimizer<double, Matrix<double>, Vector<double>>(null, options);
+
+        // A ZERO gradient isolates the decay term: with no gradient the Adam update contributes
+        // nothing, so whatever moves a parameter is decay and only decay.
+        var parameters = new Vector<double>(new[] { 1.0, 1.0, 1.0, 1.0 });
+        var gradient = new Vector<double>(new[] { 0.0, 0.0, 0.0, 0.0 });
+        return optimizer.UpdateParameters(parameters, gradient);
+    }
+
+    [Fact]
+    public void NullMask_DecaysEveryParameter_WhichIsTheBehaviourWithoutTheFeature()
+    {
+        var updated = StepOnce(mask: null, weightDecay: 0.5);
+
+        for (int i = 0; i < updated.Length; i++)
+            Assert.True(updated[i] < 1.0, $"parameter {i} was not decayed: {updated[i]}");
+    }
+
+    [Fact]
+    public void ZeroMaskEntries_ExemptExactlyThoseParameters()
+    {
+        // Exempt 0 and 2, decay 1 and 3.
+        var mask = new Vector<double>(new[] { 0.0, 1.0, 0.0, 1.0 });
+        var updated = StepOnce(mask, weightDecay: 0.5);
+
+        Assert.Equal(1.0, updated[0], 12);
+        Assert.Equal(1.0, updated[2], 12);
+        Assert.True(updated[1] < 1.0, $"parameter 1 should have been decayed, got {updated[1]}");
+        Assert.True(updated[3] < 1.0, $"parameter 3 should have been decayed, got {updated[3]}");
+    }
+
+    [Fact]
+    public void FractionalMaskEntries_ScaleTheDecay()
+    {
+        var full = StepOnce(new Vector<double>(new[] { 1.0, 1.0, 1.0, 1.0 }), weightDecay: 0.5);
+        var half = StepOnce(new Vector<double>(new[] { 0.5, 0.5, 0.5, 0.5 }), weightDecay: 0.5);
+
+        // Decay moves the parameter down from 1; halving the mask halves that movement.
+        double fullDrop = 1.0 - full[0];
+        double halfDrop = 1.0 - half[0];
+        Assert.True(fullDrop > 0, "the unmasked run did not decay at all");
+        Assert.Equal(fullDrop / 2.0, halfDrop, 12);
+    }
+
+    [Fact]
+    public void MaskPresent_DeclinesFusedCompilation()
+    {
+        // The fused config carries decay as a single float, so a masked run cannot be expressed
+        // there. Declining is what stops the compiled path decaying parameters the eager path exempts.
+        var masked = new AdamWOptimizerOptions<double, Matrix<double>, Vector<double>>
+        {
+            WeightDecayMask = new Vector<double>(new[] { 0.0, 1.0 }),
+        };
+        var unmasked = new AdamWOptimizerOptions<double, Matrix<double>, Vector<double>>();
+
+        var withMask = (AiDotNet.Optimizers.Fused.IFusedOptimizerSpec)new AdamWOptimizer<double, Matrix<double>, Vector<double>>(null, masked);
+        var withoutMask = (AiDotNet.Optimizers.Fused.IFusedOptimizerSpec)new AdamWOptimizer<double, Matrix<double>, Vector<double>>(null, unmasked);
+
+        Assert.False(withMask.TryGetFusedOptimizerConfig(out _),
+            "a masked optimizer must not report a fused config");
+        Assert.True(withoutMask.TryGetFusedOptimizerConfig(out _),
+            "an unmasked optimizer should still fuse exactly as before");
+    }
+}


### PR DESCRIPTION
Follow-up to #2029, which needed this and could not have it.

## Why

`WeightDecay` is a single coefficient applied to the **whole flat parameter vector**, so there is no way to express *"decay these parameters but not those"*. Published recipes routinely need exactly that:

- **RecurrentGemma** (Botev et al., 2024) §2: *"we do not apply weight decay to the parameters of the recurrent (RG-LRU) layers during training."*
- The ordinary transformer recipe exempts biases and normalization gains.

The reason is the same in both cases: decay pulls weights toward zero, which helps where magnitude is what's being regularized, and corrupts parameters whose **value** carries meaning — a recurrence's own decay rate, for instance.

In #2029 I left this measure out rather than ship a property that silently did nothing. This is the capability that makes it expressible.

## What changed

`WeightDecayMask` — an optional per-parameter multiplier on the decay term.

- **`null` decays everything**, which is exactly what every caller had before. No existing model changes behaviour.
- Entries multiply elementwise: `1` decays normally, `0` exempts, fractions scale.
- The gradient update is untouched — this is decoupled decay only.
- Applied at **all three** eager sites (two vector paths and the element-wise span loop) so they cannot disagree.

## The fused path

`TryGetFusedOptimizerConfig` now **declines** when a mask is set.

The fused config carries decay as a single `float`, so a masked run cannot be represented in it — the compiled kernel would keep decaying the parameters the eager path exempts. Declining is the same mechanism that method already uses for adaptive learning rates.

Silently diverging between the compiled and eager paths would be the worst option available: it would surface only as a slow accuracy drift, with nothing pointing at the optimizer.

## Verification

| Test | Asserts |
|---|---|
| `NullMask_DecaysEveryParameter...` | the default is unchanged behaviour |
| `ZeroMaskEntries_ExemptExactlyThoseParameters` | exemption reaches the update |
| `FractionalMaskEntries_ScaleTheDecay` | 0.5 mask produces exactly half the movement |
| `MaskPresent_DeclinesFusedCompilation` | masked declines, unmasked still fuses |

Each isolates the decay term by stepping with a **zero gradient**, so anything that moves a parameter is decay and only decay.

**75 optimizer tests pass unchanged**, including `FusedSpecMatchesEagerBehaviour` and the copy-constructor suite — this touches an optimizer every model uses, so that regression check is the point.

## Note for reviewers

This is shared-optimizer code. The two things that make it safe are the `null` default (byte-identical behaviour for every current caller) and the fusion opt-out, and both are directly tested rather than asserted.

A natural next step, not included here: have `RecurrentGemmaLanguageModel` build a mask that zeroes its `RealGatedLinearRecurrenceLayer` slots, which would complete the paper's third measure. That needs a layer-to-flat-slot mapping and is worth its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)