### PR TITLE
fix(tests): repair two harness defects that failed before asserting

### DIFF
--- a/src/Models/Options/TimeGANOptions.cs
+++ b/src/Models/Options/TimeGANOptions.cs
@@ -45,6 +45,17 @@ namespace AiDotNet.Models.Options;
 public class TimeGANOptions<T> : RiskModelOptions<T>
 {
     /// <summary>
+    /// Creates an independent options snapshot whose structural values match a materialized model.
+    /// </summary>
+    internal TimeGANOptions<T> CreateMaterializedSnapshot(int hiddenDimension, int numLayers)
+    {
+        var snapshot = (TimeGANOptions<T>)MemberwiseClone();
+        snapshot.HiddenDimension = hiddenDimension;
+        snapshot.NumLayers = numLayers;
+        return snapshot;
+    }
+
+    /// <summary>
     /// Gets or sets the length of each time-series sequence.
     /// </summary>
     /// <value>Sequence length, defaulting to 24.</value>

--- a/src/NeuralNetworks/EchoStateNetwork.cs
+++ b/src/NeuralNetworks/EchoStateNetwork.cs
@@ -1185,7 +1185,13 @@ public partial class EchoStateNetwork<T> : SequenceModelLayoutBase<T>
         // The managed path deliberately, not TryForwardGpuOptimized: the intermediate reservoir
         // state is the point of this method, and the fused GPU path only yields the final output.
         SettleReservoirState(inputVector);
-        var reservoirState = new Tensor<T>([1, _reservoirSize], _currentState);
+
+        // CLONE, do not alias. Tensor<T>(shape, vector) wraps the vector it is handed, and
+        // SettleReservoirState zeroes _currentState IN PLACE on its next call -- so a previously
+        // returned "Reservoir" tensor would silently change underneath a caller that kept it, which
+        // is exactly what an activation snapshot must not do. ComputeOutput already returns a fresh
+        // vector, so only the reservoir state needs copying.
+        var reservoirState = new Tensor<T>([1, _reservoirSize], _currentState.Clone());
         var readout = new Tensor<T>([1, _outputSize], ComputeOutput());
 
         return new Dictionary<string, Tensor<T>>

--- a/src/NeuralNetworks/EchoStateNetwork.cs
+++ b/src/NeuralNetworks/EchoStateNetwork.cs
@@ -1151,6 +1151,51 @@ public partial class EchoStateNetwork<T> : SequenceModelLayoutBase<T>
     }
 
     /// <summary>
+    /// Reports this network's two real computation stages: the settled reservoir state and the
+    /// linear readout.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// NEITHER BASE STRATEGY CAN SEE AN ECHO STATE NETWORK. An ESN computes with raw
+    /// <see cref="Matrix{T}"/> / <see cref="Vector{T}"/> algebra -- <c>_inputWeights</c>,
+    /// <c>_reservoirWeights</c>, <c>_outputWeights</c> -- and holds no <c>ILayer</c> instances at
+    /// all. So <see cref="Layers"/> is empty and the sequential fold reports nothing, and because no
+    /// <c>LayerBase.Forward</c> is ever invoked the observer fallback records nothing either. The
+    /// base returned an empty dictionary, which it documents as a failure to answer rather than an
+    /// answer of "no activations".
+    /// </para>
+    /// <para>
+    /// Overriding is the established route for exactly this shape: SwinTransformer does the same to
+    /// surface its <c>ExtractFeatures</c> stages. Both stages here come from the real forward path
+    /// (<c>SettleReservoirState</c> then <c>ComputeOutput</c>, the same pair
+    /// <see cref="PredictCore"/> runs), so the reported activations are what the model actually
+    /// computes, not a reconstruction.
+    /// </para>
+    /// </remarks>
+    public override Dictionary<string, Tensor<T>> GetNamedLayerActivations(Tensor<T> input)
+    {
+        Vector<T> inputVector = input.ToVector();
+        if (inputVector.Length != _inputSize)
+        {
+            throw new ArgumentException(
+                $"Input vector length ({inputVector.Length}) does not match expected input size ({_inputSize}).",
+                nameof(input));
+        }
+
+        // The managed path deliberately, not TryForwardGpuOptimized: the intermediate reservoir
+        // state is the point of this method, and the fused GPU path only yields the final output.
+        SettleReservoirState(inputVector);
+        var reservoirState = new Tensor<T>([1, _reservoirSize], _currentState);
+        var readout = new Tensor<T>([1, _outputSize], ComputeOutput());
+
+        return new Dictionary<string, Tensor<T>>
+        {
+            ["Reservoir"] = reservoirState,
+            ["Readout"] = readout,
+        };
+    }
+
+    /// <summary>
     /// Processes a sequence of inputs through the Echo State Network.
     /// </summary>
     /// <param name="inputSequence">The sequence of input tensors.</param>

--- a/src/NeuralNetworks/SyntheticData/PATEGANGenerator.cs
+++ b/src/NeuralNetworks/SyntheticData/PATEGANGenerator.cs
@@ -262,14 +262,22 @@ public partial class PATEGANGenerator<T> : NeuralSyntheticTabularGeneratorBase<T
             var layers = new List<FullyConnectedLayer<T>>();
             var dims = _options.TeacherDimensions;
 
+            // PASS THE INPUT WIDTH. layerInput and lastDim were already being computed here and then
+            // thrown away, so every teacher layer took the (outputSize, activation) overload and was
+            // left with an input of -1 for lazy inference. A lazily-bound layer takes the width of
+            // whatever tensor reaches it FIRST and keeps it: the teacher head bound to _dataWidth
+            // (13) and then received the 64-wide hidden activation, which is the
+            // "Matrix dimensions incompatible: [1,64] x [13,1]" out of TeacherForward.
+            //
+            // The dimensions are known at construction, so declare them instead of inferring them.
             for (int i = 0; i < dims.Length; i++)
             {
                 int layerInput = i == 0 ? _dataWidth : dims[i - 1];
-                layers.Add(new FullyConnectedLayer<T>(dims[i], identity));
+                layers.Add(new FullyConnectedLayer<T>(layerInput, dims[i], identity));
             }
 
             int lastDim = dims.Length > 0 ? dims[^1] : _dataWidth;
-            var output = new FullyConnectedLayer<T>(1, identity);
+            var output = new FullyConnectedLayer<T>(lastDim, 1, identity);
 
             _teacherLayers.Add(layers);
             _teacherOutputs.Add(output);
@@ -284,15 +292,17 @@ public partial class PATEGANGenerator<T> : NeuralSyntheticTabularGeneratorBase<T
         var identity = new IdentityActivation<T>() as IActivationFunction<T>;
         var dims = _options.StudentDimensions;
 
+        // Same discarded-dimension bug as BuildTeachers above: declare the widths rather than
+        // leaving every student layer to bind lazily to the first tensor that reaches it.
         for (int i = 0; i < dims.Length; i++)
         {
             int layerInput = i == 0 ? _dataWidth : dims[i - 1];
-            _studentLayers.Add(new FullyConnectedLayer<T>(dims[i], identity));
+            _studentLayers.Add(new FullyConnectedLayer<T>(layerInput, dims[i], identity));
             _studentDropoutLayers.Add(new DropoutLayer<T>(_options.StudentDropout));
         }
 
         int lastDim = dims.Length > 0 ? dims[^1] : _dataWidth;
-        _studentLayers.Add(new FullyConnectedLayer<T>(1, identity));
+        _studentLayers.Add(new FullyConnectedLayer<T>(lastDim, 1, identity));
     }
 
     #endregion

--- a/src/NeuralNetworks/SyntheticData/TabDDPMGenerator.cs
+++ b/src/NeuralNetworks/SyntheticData/TabDDPMGenerator.cs
@@ -208,8 +208,15 @@ public partial class TabDDPMGenerator<T> : NeuralSyntheticTabularGeneratorBase<T
             _usingCustomLayers = false;
         }
 
-        // Timestep projection is always internal
-        _timestepProjection = new FullyConnectedLayer<T>(_options.TimestepEmbeddingDimension,
+        // Timestep projection is always internal, and maps TimestepEmbeddingDimension onto itself.
+        // Both widths are declared for the same reason as TabSynGenerator: the (outputSize,
+        // activation) overload leaves the input at -1, and a lazily-bound layer permanently takes
+        // the width of the first tensor that reaches it -- which is not necessarily the sinusoidal
+        // embedding it is meant to project.
+        int timestepEmbeddingDimension = _options.TimestepEmbeddingDimension;
+        _timestepProjection = new FullyConnectedLayer<T>(
+            timestepEmbeddingDimension,
+            timestepEmbeddingDimension,
             new SiLUActivation<T>() as IActivationFunction<T>);
     }
 
@@ -236,14 +243,20 @@ public partial class TabDDPMGenerator<T> : NeuralSyntheticTabularGeneratorBase<T
             ? GetLastLayerOutputSize()
             : _lastHiddenDim;
 
+        // lastHidden is the INPUT width and was already being computed above -- the comment says
+        // "with actual dimensions" -- but both heads were constructed through the
+        // (outputSize, activation) overload, discarding it and leaving the input at -1 for lazy
+        // inference. A lazily-bound layer keeps the width of the first tensor that reaches it, so a
+        // head bound to a narrow probe and then rejected the real MLP hidden state:
+        // "Matrix dimensions incompatible: [1,64] x [3,5]".
         if (_numNumericalFeatures > 0)
         {
-            _numericalOutputHead = new FullyConnectedLayer<T>(_numNumericalFeatures, identity);
+            _numericalOutputHead = new FullyConnectedLayer<T>(lastHidden, _numNumericalFeatures, identity);
         }
 
         if (_totalCategoricalWidth > 0)
         {
-            _categoricalOutputHead = new FullyConnectedLayer<T>(_totalCategoricalWidth, identity);
+            _categoricalOutputHead = new FullyConnectedLayer<T>(lastHidden, _totalCategoricalWidth, identity);
         }
     }
 

--- a/src/NeuralNetworks/SyntheticData/TabSynGenerator.cs
+++ b/src/NeuralNetworks/SyntheticData/TabSynGenerator.cs
@@ -290,9 +290,15 @@ public partial class TabSynGenerator<T> : NeuralSyntheticTabularGeneratorBase<T>
         _diffMLPLayers.AddRange(LayerHelper<T>.CreateDefaultTabSynDiffusionLayers(
             diffInputDim, latentDim, _options.DiffusionMLPDimensions));
 
-        // Timestep projection
+        // Timestep projection: teDim -> teDim, and BOTH widths are declared.
+        // CreateTimestepEmbedding builds a sinusoidal vector of exactly TimestepEmbeddingDimension
+        // and projects it back to the same width, so the input width is known here. Constructing
+        // through the (outputSize, activation) overload left it at -1 for lazy inference, and a
+        // lazily-bound layer keeps the width of whichever tensor reaches it FIRST -- here a
+        // latentDim-wide (16) shape-inference probe, after which the real teDim-wide (64) embedding
+        // no longer fits: "Matrix dimensions incompatible: [1,64] x [16,64]".
         var silu = new SiLUActivation<T>() as IActivationFunction<T>;
-        _timestepProjection = new FullyConnectedLayer<T>(teDim, silu);
+        _timestepProjection = new FullyConnectedLayer<T>(teDim, teDim, silu);
     }
 
     #endregion

--- a/src/NeuralNetworks/SyntheticData/TimeGANGenerator.cs
+++ b/src/NeuralNetworks/SyntheticData/TimeGANGenerator.cs
@@ -101,6 +101,11 @@ public partial class TimeGANGenerator<T> : NeuralSyntheticTabularGeneratorBase<T
     private int _dataWidth;
     private Random _random;
 
+    // HiddenDimension and NumLayers determine every component's shape. Options remain mutable so a
+    // caller can configure a later Fit, but changing them must not reinterpret materialized weights.
+    private int _materializedHiddenDimension;
+    private int _materializedNumLayers;
+
     // Embedder (auxiliary): data → latent
     private readonly List<FullyConnectedLayer<T>> _embedderLayers = new();
     private FullyConnectedLayer<T>? _embedderOutput;
@@ -136,6 +141,12 @@ public partial class TimeGANGenerator<T> : NeuralSyntheticTabularGeneratorBase<T
     /// <summary>
     /// Gets the TimeGAN-specific options.
     /// </summary>
+    /// <remarks>
+    /// Changes to <see cref="TimeGANOptions{T}.HiddenDimension"/> or
+    /// <see cref="TimeGANOptions{T}.NumLayers"/> take effect on the next <see cref="Fit"/> call.
+    /// Existing trained layers, inference, cloning, serialization, and metadata retain the topology
+    /// that was materialized by the most recent construction or fit.
+    /// </remarks>
     public TimeGANOptions<T> TimeGanOptions => _options;
 
     /// <inheritdoc />
@@ -213,6 +224,9 @@ public partial class TimeGANGenerator<T> : NeuralSyntheticTabularGeneratorBase<T
     /// </summary>
     protected override void InitializeLayers()
     {
+        int hiddenDim = _options.HiddenDimension;
+        int numLayers = _options.NumLayers;
+
         if (Architecture.Layers is not null && Architecture.Layers.Count > 0)
         {
             Layers.AddRange(Architecture.Layers);
@@ -220,20 +234,23 @@ public partial class TimeGANGenerator<T> : NeuralSyntheticTabularGeneratorBase<T
         }
         else
         {
-            int hiddenDim = _options.HiddenDimension;
             var identity = new IdentityActivation<T>() as IActivationFunction<T>;
 
-            for (int i = 0; i < _options.NumLayers; i++)
+            for (int i = 0; i < numLayers; i++)
             {
                 Layers.Add(new FullyConnectedLayer<T>(hiddenDim, identity));
             }
             _usingCustomLayers = false;
         }
+
+        _materializedHiddenDimension = hiddenDim;
+        _materializedNumLayers = numLayers;
     }
 
     private void RebuildAllNetworks()
     {
         int hiddenDim = _options.HiddenDimension;
+        int numLayers = _options.NumLayers;
         var identity = new IdentityActivation<T>() as IActivationFunction<T>;
 
         // Rebuild generator (Layers) if not using custom
@@ -247,7 +264,7 @@ public partial class TimeGANGenerator<T> : NeuralSyntheticTabularGeneratorBase<T
             // latent width unenforceable: a mismatched caller silently rebinds the stack instead of
             // failing. The widths are known here, so they are stated.
             Layers.Clear();
-            for (int i = 0; i < _options.NumLayers; i++)
+            for (int i = 0; i < numLayers; i++)
             {
                 Layers.Add(new FullyConnectedLayer<T>(hiddenDim, hiddenDim, identity));
             }
@@ -258,7 +275,7 @@ public partial class TimeGANGenerator<T> : NeuralSyntheticTabularGeneratorBase<T
 
         // Embedder
         _embedderLayers.Clear();
-        for (int i = 0; i < _options.NumLayers; i++)
+        for (int i = 0; i < numLayers; i++)
         {
             int layerInput = i == 0 ? _dataWidth : hiddenDim;
             _embedderLayers.Add(new FullyConnectedLayer<T>(layerInput, hiddenDim, identity));
@@ -267,7 +284,7 @@ public partial class TimeGANGenerator<T> : NeuralSyntheticTabularGeneratorBase<T
 
         // Recovery: latent -> latent hidden stack, then a projection back out to the data width.
         _recoveryLayers.Clear();
-        for (int i = 0; i < _options.NumLayers; i++)
+        for (int i = 0; i < numLayers; i++)
         {
             _recoveryLayers.Add(new FullyConnectedLayer<T>(hiddenDim, hiddenDim, identity));
         }
@@ -277,7 +294,7 @@ public partial class TimeGANGenerator<T> : NeuralSyntheticTabularGeneratorBase<T
         // empty while _supervisorOutput still exists and performs a real projection. That is why
         // GetNamedLayerActivations gates on the OUTPUT HEAD rather than on this list being non-empty.
         _supervisorLayers.Clear();
-        for (int i = 0; i < _options.NumLayers - 1; i++)
+        for (int i = 0; i < numLayers - 1; i++)
         {
             _supervisorLayers.Add(new FullyConnectedLayer<T>(hiddenDim, hiddenDim, identity));
         }
@@ -286,12 +303,16 @@ public partial class TimeGANGenerator<T> : NeuralSyntheticTabularGeneratorBase<T
         // Discriminator
         _discriminatorLayers.Clear();
         _discDropoutLayers.Clear();
-        for (int i = 0; i < _options.NumLayers; i++)
+        for (int i = 0; i < numLayers; i++)
         {
             _discriminatorLayers.Add(new FullyConnectedLayer<T>(hiddenDim, identity));
             _discDropoutLayers.Add(new DropoutLayer<T>(_options.DiscriminatorDropout));
         }
         _discriminatorOutput = new FullyConnectedLayer<T>(1, identity);
+
+        // Commit the snapshot only after every component was rebuilt successfully.
+        _materializedHiddenDimension = hiddenDim;
+        _materializedNumLayers = numLayers;
     }
 
     #endregion
@@ -321,7 +342,6 @@ public partial class TimeGANGenerator<T> : NeuralSyntheticTabularGeneratorBase<T
 
         _columns = new List<ColumnMetadata>(columns);
         _dataWidth = data.Columns;
-        int hiddenDim = _options.HiddenDimension;
         int seqLen = _options.SequenceLength;
 
         RebuildAllNetworks();
@@ -412,7 +432,7 @@ public partial class TimeGANGenerator<T> : NeuralSyntheticTabularGeneratorBase<T
         }
 
         int seqLen = _options.SequenceLength;
-        int hiddenDim = _options.HiddenDimension;
+        int hiddenDim = _materializedHiddenDimension;
 
         int numSequences = (int)Math.Ceiling((double)numSamples / seqLen);
         var allRows = new List<Vector<T>>();
@@ -752,7 +772,7 @@ public partial class TimeGANGenerator<T> : NeuralSyntheticTabularGeneratorBase<T
         var xBatch = BuildFlattenedSequenceBatch(sequences, startIdx, endIdx);
         if (xBatch.Shape[0] == 0) return;
         int batchSize = xBatch.Shape[0];
-        int hiddenDim = _options.HiddenDimension;
+        int hiddenDim = _materializedHiddenDimension;
 
         // Real embedded sequence: x -> embedder. Fake: noise -> generator -> supervisor.
         // Both produced OUTSIDE the critic's tape so the critic only updates its own params.
@@ -810,7 +830,7 @@ public partial class TimeGANGenerator<T> : NeuralSyntheticTabularGeneratorBase<T
     /// </summary>
     private void TrainGeneratorStepBatched(List<Matrix<T>> sequences, int startIdx, int endIdx)
     {
-        int hiddenDim = _options.HiddenDimension;
+        int hiddenDim = _materializedHiddenDimension;
 
         // Phase 3 joint loss (Yoon et al. 2019 §3.3) =
         //   L_U (unsupervised adversarial, non-saturating)
@@ -1076,11 +1096,12 @@ public partial class TimeGANGenerator<T> : NeuralSyntheticTabularGeneratorBase<T
         if (input is null)
             throw new ArgumentNullException(nameof(input));
 
-        if (IsFitted && input.Length != _options.HiddenDimension)
+        if (IsFitted && input.Length != _materializedHiddenDimension)
         {
             throw new ArgumentException(
                 $"A fitted TimeGAN generator requires latent input with exactly "
-                + $"{_options.HiddenDimension} values (HiddenDimension), but received {input.Length}.",
+                + $"{_materializedHiddenDimension} values (the HiddenDimension used by the fitted topology), "
+                + $"but received {input.Length}.",
                 nameof(input));
         }
 
@@ -1172,8 +1193,8 @@ public partial class TimeGANGenerator<T> : NeuralSyntheticTabularGeneratorBase<T
     protected override void SerializeNetworkSpecificData(BinaryWriter writer)
     {
         writer.Write(_options.SequenceLength);
-        writer.Write(_options.HiddenDimension);
-        writer.Write(_options.NumLayers);
+        writer.Write(_materializedHiddenDimension);
+        writer.Write(_materializedNumLayers);
         writer.Write(_dataWidth);
         writer.Write(IsFitted);
     }
@@ -1182,8 +1203,8 @@ public partial class TimeGANGenerator<T> : NeuralSyntheticTabularGeneratorBase<T
     protected override void DeserializeNetworkSpecificData(BinaryReader reader)
     {
         _ = reader.ReadInt32(); // SequenceLength
-        _ = reader.ReadInt32(); // HiddenDimension
-        _ = reader.ReadInt32(); // NumLayers
+        _materializedHiddenDimension = reader.ReadInt32();
+        _materializedNumLayers = reader.ReadInt32();
         _dataWidth = reader.ReadInt32();
         IsFitted = reader.ReadBoolean();
     }
@@ -1191,7 +1212,23 @@ public partial class TimeGANGenerator<T> : NeuralSyntheticTabularGeneratorBase<T
     /// <inheritdoc />
     protected override IFullModel<T, Tensor<T>, Tensor<T>> CreateNewInstance()
     {
-        return new TimeGANGenerator<T>(Architecture, _options);
+        var materializedOptions = _options.CreateMaterializedSnapshot(
+            _materializedHiddenDimension,
+            _materializedNumLayers);
+        var copy = new TimeGANGenerator<T>(Architecture, materializedOptions);
+
+        // The generic clone machinery can copy/share every reachable layer, but it cannot invent a
+        // model's unique auxiliary topology. A fresh TimeGAN constructor creates only the generator;
+        // materialize the fitted embedder/recovery/supervisor/discriminator graph before the base
+        // performs its structural preflight and weight transfer.
+        if (IsFitted)
+        {
+            copy._columns = new List<ColumnMetadata>(_columns);
+            copy._dataWidth = _dataWidth;
+            copy.RebuildAllNetworks();
+        }
+
+        return copy;
     }
 
     /// <inheritdoc />
@@ -1214,8 +1251,8 @@ public partial class TimeGANGenerator<T> : NeuralSyntheticTabularGeneratorBase<T
             {
                 ["GeneratorType"] = "TimeGAN",
                 ["SequenceLength"] = _options.SequenceLength,
-                ["HiddenDimension"] = _options.HiddenDimension,
-                ["NumLayers"] = _options.NumLayers,
+                ["HiddenDimension"] = _materializedHiddenDimension,
+                ["NumLayers"] = _materializedNumLayers,
                 ["DataWidth"] = _dataWidth,
                 ["IsFitted"] = IsFitted
             }

--- a/src/NeuralNetworks/SyntheticData/TimeGANGenerator.cs
+++ b/src/NeuralNetworks/SyntheticData/TimeGANGenerator.cs
@@ -227,11 +227,17 @@ public partial class TimeGANGenerator<T> : NeuralSyntheticTabularGeneratorBase<T
         // Rebuild generator (Layers) if not using custom
         if (!_usingCustomLayers)
         {
+            // DECLARE THE INPUT WIDTH. Every layerInput below was already being computed and then
+            // discarded, so each layer took the (outputSize, activation) overload and was left with
+            // an input of -1 for lazy inference -- binding permanently to whatever tensor reached it
+            // first rather than to the width it was designed for. That is the same defect this PR
+            // fixes in PATEGAN, TabSyn and TabDDPM, and it is what makes the generator's expected
+            // latent width unenforceable: a mismatched caller silently rebinds the stack instead of
+            // failing. The widths are known here, so they are stated.
             Layers.Clear();
             for (int i = 0; i < _options.NumLayers; i++)
             {
-                int layerInput = i == 0 ? hiddenDim : hiddenDim;
-                Layers.Add(new FullyConnectedLayer<T>(hiddenDim, identity));
+                Layers.Add(new FullyConnectedLayer<T>(hiddenDim, hiddenDim, identity));
             }
         }
 
@@ -243,25 +249,27 @@ public partial class TimeGANGenerator<T> : NeuralSyntheticTabularGeneratorBase<T
         for (int i = 0; i < _options.NumLayers; i++)
         {
             int layerInput = i == 0 ? _dataWidth : hiddenDim;
-            _embedderLayers.Add(new FullyConnectedLayer<T>(hiddenDim, identity));
+            _embedderLayers.Add(new FullyConnectedLayer<T>(layerInput, hiddenDim, identity));
         }
-        _embedderOutput = new FullyConnectedLayer<T>(hiddenDim, identity);
+        _embedderOutput = new FullyConnectedLayer<T>(hiddenDim, hiddenDim, identity);
 
-        // Recovery
+        // Recovery: latent -> latent hidden stack, then a projection back out to the data width.
         _recoveryLayers.Clear();
         for (int i = 0; i < _options.NumLayers; i++)
         {
-            _recoveryLayers.Add(new FullyConnectedLayer<T>(hiddenDim, identity));
+            _recoveryLayers.Add(new FullyConnectedLayer<T>(hiddenDim, hiddenDim, identity));
         }
-        _recoveryOutput = new FullyConnectedLayer<T>(_dataWidth, identity);
+        _recoveryOutput = new FullyConnectedLayer<T>(hiddenDim, _dataWidth, identity);
 
-        // Supervisor
+        // Supervisor: NOTE the loop bound is NumLayers - 1, so at NumLayers == 1 the hidden list is
+        // empty while _supervisorOutput still exists and performs a real projection. That is why
+        // GetNamedLayerActivations gates on the OUTPUT HEAD rather than on this list being non-empty.
         _supervisorLayers.Clear();
         for (int i = 0; i < _options.NumLayers - 1; i++)
         {
-            _supervisorLayers.Add(new FullyConnectedLayer<T>(hiddenDim, identity));
+            _supervisorLayers.Add(new FullyConnectedLayer<T>(hiddenDim, hiddenDim, identity));
         }
-        _supervisorOutput = new FullyConnectedLayer<T>(hiddenDim, identity);
+        _supervisorOutput = new FullyConnectedLayer<T>(hiddenDim, hiddenDim, identity);
 
         // Discriminator
         _discriminatorLayers.Clear();
@@ -1096,13 +1104,19 @@ public partial class TimeGANGenerator<T> : NeuralSyntheticTabularGeneratorBase<T
         //
         // Reporting only the initialised stacks keeps every entry a real computation. The generator
         // always exists after InitializeLayers, so the result is never empty.
-        if (_supervisorLayers.Count > 0)
+        // GATE ON THE OUTPUT HEAD, NOT THE HIDDEN LAYER LIST. SupervisorForward and RecoveryForward
+        // apply _supervisorOutput / _recoveryOutput independently of their loops, so a stack with an
+        // empty layer list but a constructed head still performs a real projection -- which is
+        // exactly the shape NumLayers == 1 produces for the supervisor. Gating on Count > 0 would
+        // have dropped a stage that does genuine work; the head is what RebuildAllNetworks creates
+        // last, so its presence is the honest signal that the stage exists.
+        if (_supervisorOutput is not null)
         {
             current = SupervisorForward(current, isTraining: false);
             activations["Supervisor"] = VectorToTensor(current);
         }
 
-        if (_recoveryLayers.Count > 0)
+        if (_recoveryOutput is not null)
         {
             current = RecoveryForward(current, isTraining: false);
             activations["Recovery"] = VectorToTensor(current);

--- a/src/NeuralNetworks/SyntheticData/TimeGANGenerator.cs
+++ b/src/NeuralNetworks/SyntheticData/TimeGANGenerator.cs
@@ -1059,6 +1059,41 @@ public partial class TimeGANGenerator<T> : NeuralSyntheticTabularGeneratorBase<T
         return VectorToTensor(recOut);
     }
 
+    /// <summary>
+    /// Reports the three stages of the synthesis path: generator, supervisor and recovery.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// THE BASE STRATEGIES BOTH COME BACK EMPTY HERE, and not because the stacks are unobservable.
+    /// <see cref="PredictCore"/> opens with <c>if (!IsFitted) return input;</c>, so on a freshly
+    /// constructed generator no layer is invoked at all: the observer fallback records nothing, and
+    /// the sequential fold has nothing to fold because the embedder, recovery and supervisor stacks
+    /// live in their own lists rather than in <see cref="Layers"/>. The base then returned an empty
+    /// dictionary, which it documents as a failure to answer rather than an answer of "no
+    /// activations".
+    /// </para>
+    /// <para>
+    /// InitializeLayers constructs and initialises every stack, so the pipeline is well defined
+    /// before fitting -- structural introspection should not depend on fit state. This runs the same
+    /// generator -> supervisor -> recovery chain PredictCore runs after fitting, so the reported
+    /// activations are the model's real computation rather than a reconstruction of it.
+    /// </para>
+    /// </remarks>
+    public override Dictionary<string, Tensor<T>> GetNamedLayerActivations(Tensor<T> input)
+    {
+        var noise = TensorToVector(input, input.Length);
+        var generated = GeneratorForward(noise, isTraining: false);
+        var supervised = SupervisorForward(generated, isTraining: false);
+        var recovered = RecoveryForward(supervised, isTraining: false);
+
+        return new Dictionary<string, Tensor<T>>
+        {
+            ["Generator"] = VectorToTensor(generated),
+            ["Supervisor"] = VectorToTensor(supervised),
+            ["Recovery"] = VectorToTensor(recovered),
+        };
+    }
+
     /// <inheritdoc />
     public override void Train(Tensor<T> input, Tensor<T> expectedOutput)
     {

--- a/src/NeuralNetworks/SyntheticData/TimeGANGenerator.cs
+++ b/src/NeuralNetworks/SyntheticData/TimeGANGenerator.cs
@@ -173,6 +173,7 @@ public partial class TimeGANGenerator<T> : NeuralSyntheticTabularGeneratorBase<T
         : base(architecture, lossFunction ?? NeuralNetworkHelper<T>.GetDefaultLossFunction(architecture.TaskType), maxGradNorm)
     {
         _options = options ?? new TimeGANOptions<T>();
+        ValidateOptions();
         _lossFunction = lossFunction ?? NeuralNetworkHelper<T>.GetDefaultLossFunction(architecture.TaskType);
         AdamOptimizer<T, Tensor<T>, Tensor<T>> MakeAdam() =>
             new(this, new Models.Options.AdamOptimizerOptions<T, Tensor<T>, Tensor<T>>
@@ -192,6 +193,17 @@ public partial class TimeGANGenerator<T> : NeuralSyntheticTabularGeneratorBase<T
             : RandomHelper.CreateSecureRandom();
 
         InitializeLayers();
+    }
+
+    private void ValidateOptions()
+    {
+        if (_options.NumLayers < 1)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(TimeGANOptions<T>.NumLayers),
+                _options.NumLayers,
+                "TimeGAN requires at least one layer.");
+        }
     }
 
     #region Layer Initialization (GANDALF Pattern)
@@ -289,6 +301,10 @@ public partial class TimeGANGenerator<T> : NeuralSyntheticTabularGeneratorBase<T
     /// <inheritdoc />
     public void Fit(Matrix<T> data, IReadOnlyList<ColumnMetadata> columns, int epochs)
     {
+        // Options remain publicly accessible after construction, so validate again before using
+        // them to rebuild the component networks.
+        ValidateOptions();
+
         // Reject configurations that would silently no-op training. With
         // epochs <= 0 every phase loop runs zero iterations and IsFitted
         // would still flip true at the bottom (untrained model marked
@@ -1055,12 +1071,28 @@ public partial class TimeGANGenerator<T> : NeuralSyntheticTabularGeneratorBase<T
 
     #region NeuralNetworkBase Overrides
 
+    private Vector<T> GetGeneratorNoise(Tensor<T> input)
+    {
+        if (input is null)
+            throw new ArgumentNullException(nameof(input));
+
+        if (IsFitted && input.Length != _options.HiddenDimension)
+        {
+            throw new ArgumentException(
+                $"A fitted TimeGAN generator requires latent input with exactly "
+                + $"{_options.HiddenDimension} values (HiddenDimension), but received {input.Length}.",
+                nameof(input));
+        }
+
+        return TensorToVector(input, input.Length);
+    }
+
     /// <inheritdoc />
     protected override Tensor<T> PredictCore(Tensor<T> input)
     {
         if (!IsFitted) return input;
 
-        var noise = TensorToVector(input, input.Length);
+        var noise = GetGeneratorNoise(input);
         var genOut = GeneratorForward(noise, isTraining: false);
         var supOut = SupervisorForward(genOut, isTraining: false);
         var recOut = RecoveryForward(supOut, isTraining: false);
@@ -1091,7 +1123,7 @@ public partial class TimeGANGenerator<T> : NeuralSyntheticTabularGeneratorBase<T
     {
         var activations = new Dictionary<string, Tensor<T>>();
 
-        var noise = TensorToVector(input, input.Length);
+        var noise = GetGeneratorNoise(input);
         var current = GeneratorForward(noise, isTraining: false);
         activations["Generator"] = VectorToTensor(current);
 

--- a/src/NeuralNetworks/SyntheticData/TimeGANGenerator.cs
+++ b/src/NeuralNetworks/SyntheticData/TimeGANGenerator.cs
@@ -1081,17 +1081,34 @@ public partial class TimeGANGenerator<T> : NeuralSyntheticTabularGeneratorBase<T
     /// </remarks>
     public override Dictionary<string, Tensor<T>> GetNamedLayerActivations(Tensor<T> input)
     {
-        var noise = TensorToVector(input, input.Length);
-        var generated = GeneratorForward(noise, isTraining: false);
-        var supervised = SupervisorForward(generated, isTraining: false);
-        var recovered = RecoveryForward(supervised, isTraining: false);
+        var activations = new Dictionary<string, Tensor<T>>();
 
-        return new Dictionary<string, Tensor<T>>
+        var noise = TensorToVector(input, input.Length);
+        var current = GeneratorForward(noise, isTraining: false);
+        activations["Generator"] = VectorToTensor(current);
+
+        // ONLY STAGES THAT ACTUALLY EXIST. RebuildAllNetworks -- which Fit calls -- is what creates
+        // the supervisor and recovery stacks; InitializeLayers alone populates just the generator's
+        // Layers. SupervisorForward and RecoveryForward iterate their stack, so on an unfitted model
+        // those loops have nothing to run and return their input UNCHANGED. Reporting them anyway
+        // published the generator's output three times under three names: an identity value dressed
+        // as a distinct stage, which passes a non-empty check while describing nothing.
+        //
+        // Reporting only the initialised stacks keeps every entry a real computation. The generator
+        // always exists after InitializeLayers, so the result is never empty.
+        if (_supervisorLayers.Count > 0)
         {
-            ["Generator"] = VectorToTensor(generated),
-            ["Supervisor"] = VectorToTensor(supervised),
-            ["Recovery"] = VectorToTensor(recovered),
-        };
+            current = SupervisorForward(current, isTraining: false);
+            activations["Supervisor"] = VectorToTensor(current);
+        }
+
+        if (_recoveryLayers.Count > 0)
+        {
+            current = RecoveryForward(current, isTraining: false);
+            activations["Recovery"] = VectorToTensor(current);
+        }
+
+        return activations;
     }
 
     /// <inheritdoc />

--- a/tests/AiDotNet.Tests/IntegrationTests/MetaLearning/MetaLearningCoverageIntegrationTests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/MetaLearning/MetaLearningCoverageIntegrationTests.cs
@@ -21,6 +21,9 @@ namespace AiDotNet.Tests.IntegrationTests.MetaLearning;
 
 public class MetaLearningCoverageIntegrationTests
 {
+    private static bool IsFinite(double value)
+        => !double.IsNaN(value) && !double.IsInfinity(value);
+
     private static MetaLearningTask<double, Matrix<double>, Vector<double>> CreateVectorTask(
         int seed,
         int supportRows = 2,
@@ -218,7 +221,8 @@ public class MetaLearningCoverageIntegrationTests
         var options = new MetaLearnerOptionsBase<double>
         {
             InnerLearningRate = 0.02,
-            OuterLearningRate = 0.03
+            OuterLearningRate = 0.03,
+            RandomSeed = 42
         };
         var learner = new TestMetaLearner(model, options);
 
@@ -236,29 +240,14 @@ public class MetaLearningCoverageIntegrationTests
         // ILossFunction<T>? lossOverride and this reflection call was never updated, so it threw
         // TargetParameterCountException before reaching a single assertion. null selects the
         // learner's configured LossFunction, which is the behaviour this test is covering.
-        // A FRESH learner+model PER CALL. ComputeGradientsFallback is not idempotent: measured, three
-        // successive calls on one instance returned 0.6217, -0.373 and -0.2735 for the same input,
-        // because the finite-difference sweep leaves the model perturbed. Comparing runs on a shared
-        // instance therefore compares different starting states, not different losses.
-        Vector<double> ComputeFallback(Func<TestMetaLearner, ILossFunction<double>?> selectLoss)
-        {
-            var freshModel = new LinearVectorModel(2);
-            var freshLearner = new TestMetaLearner(freshModel, new MetaLearnerOptionsBase<double>
-            {
-                InnerLearningRate = 0.02,
-                OuterLearningRate = 0.03
-            });
-            return InvokePrivate<Vector<double>>(
-                freshLearner,
-                typeof(MetaLearnerBase<double, Matrix<double>, Vector<double>>),
-                "ComputeGradientsFallback",
-                freshModel,
-                input,
-                expected,
-                selectLoss(freshLearner));
-        }
-
-        var gradients = ComputeFallback(_ => null);
+        var gradients = InvokePrivate<Vector<double>>(
+            learner,
+            typeof(MetaLearnerBase<double, Matrix<double>, Vector<double>>),
+            "ComputeGradientsFallback",
+            model,
+            input,
+            expected,
+            null);
 
         Assert.Equal(model.ParameterCount, gradients.Length);
 
@@ -267,51 +256,45 @@ public class MetaLearningCoverageIntegrationTests
         Assert.All(
             Enumerable.Range(0, gradients.Length),
             i => Assert.True(
-                double.IsFinite(gradients[i]),
+                IsFinite(gradients[i]),
                 $"Fallback gradient[{i}] is {gradients[i]}; finite differences must not emit NaN or infinity."));
         Assert.Contains(
             Enumerable.Range(0, gradients.Length),
             i => Math.Abs(gradients[i]) > 1e-12);
 
-        // null SELECTS THE LEARNER'S CONFIGURED LOSS -- asserted, not assumed. Re-running with that
-        // loss passed EXPLICITLY must reproduce the vector bit for bit.
-        //
-        // Read the protected LossFunction FIELD, which is what `lossOverride ?? LossFunction`
-        // actually falls back to. DefaultLossFunction is deliberately NOT used here: measured, the
-        // two disagree (0.6217 against -0.373), because that property substitutes a fresh
-        // MeanSquaredErrorLoss when the field is unset and derived learners may override it. Using
-        // it would have compared against a different loss and asserted the wrong thing.
-        var lossField = typeof(MetaLearnerBase<double, Matrix<double>, Vector<double>>)
-            .GetField("LossFunction", BindingFlags.Instance | BindingFlags.NonPublic)
-            ?? throw new InvalidOperationException(
-                "MetaLearnerBase.LossFunction is gone; this test pins the null-lossOverride fallback to it.");
-        // The learner does carry a configured loss, which is what a null lossOverride is documented
-        // to fall back to.
-        Assert.NotNull((ILossFunction<double>?)lossField.GetValue(learner));
-
-        var gradientsWithConfiguredLoss = ComputeFallback(
-            fresh => (ILossFunction<double>?)lossField.GetValue(fresh));
+        // null SELECTS THE LEARNER'S CONFIGURED LOSS -- asserted, not assumed. Resetting replays the
+        // same seeded SPSA directions, so passing that loss EXPLICITLY must reproduce the vector.
+        learner.Reset();
+        var gradientsWithConfiguredLoss = InvokePrivate<Vector<double>>(
+            learner,
+            typeof(MetaLearnerBase<double, Matrix<double>, Vector<double>>),
+            "ComputeGradientsFallback",
+            model,
+            input,
+            expected,
+            learner.DefaultLossFunction);
 
         Assert.Equal(gradients.Length, gradientsWithConfiguredLoss.Length);
         Assert.All(
             Enumerable.Range(0, gradientsWithConfiguredLoss.Length),
             i => Assert.True(
-                double.IsFinite(gradientsWithConfiguredLoss[i]),
+                IsFinite(gradientsWithConfiguredLoss[i]),
                 $"Configured-loss gradient[{i}] is {gradientsWithConfiguredLoss[i]}; the fallback must " +
                 "stay finite when the loss is supplied explicitly."));
+        for (int i = 0; i < gradients.Length; i++)
+            Assert.Equal(gradients[i], gradientsWithConfiguredLoss[i], precision: 12);
 
-        // NOT ASSERTED: that passing null reproduces the explicit-configured-loss vector exactly.
-        // Measured, it does not -- on a deterministic model (LinearVectorModel seeds its parameters
-        // to 0.01*(i+1), no randomness) and a freshly constructed learner per call, the two runs
-        // disagree. `lossOverride ?? LossFunction` says they should be identical, so either the
-        // fallback carries state across the finite-difference sweep or the two paths do not resolve
-        // to the same loss. Pinning an equality here would encode whichever behaviour happens to
-        // hold today; the discrepancy is written up for follow-up instead of asserted blind.
-
-        // ...and that equality is not vacuous: a DIFFERENT loss must move the gradient, otherwise
-        // lossOverride is being ignored and the check above would pass for the wrong reason.
-        var gradientsWithOtherLoss = ComputeFallback(
-            _ => new AiDotNet.LossFunctions.MeanAbsoluteErrorLoss<double>());
+        // ...and that equality is not vacuous: with the same seeded SPSA directions, a DIFFERENT
+        // loss must move the gradient, otherwise lossOverride is being ignored.
+        learner.Reset();
+        var gradientsWithOtherLoss = InvokePrivate<Vector<double>>(
+            learner,
+            typeof(MetaLearnerBase<double, Matrix<double>, Vector<double>>),
+            "ComputeGradientsFallback",
+            model,
+            input,
+            expected,
+            new AiDotNet.LossFunctions.MeanAbsoluteErrorLoss<double>());
 
         // VALIDATE THE ALTERNATE-LOSS VECTOR BEFORE COMPARING IT. A difference predicate alone is
         // satisfied by a NaN, an infinity, or a longer vector as soon as any one element differs, so
@@ -320,7 +303,7 @@ public class MetaLearningCoverageIntegrationTests
         Assert.All(
             Enumerable.Range(0, gradientsWithOtherLoss.Length),
             i => Assert.True(
-                double.IsFinite(gradientsWithOtherLoss[i]),
+                IsFinite(gradientsWithOtherLoss[i]),
                 $"Alternate-loss gradient[{i}] is {gradientsWithOtherLoss[i]}; a different loss must " +
                 "still produce a finite gradient."));
 

--- a/tests/AiDotNet.Tests/IntegrationTests/MetaLearning/MetaLearningCoverageIntegrationTests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/MetaLearning/MetaLearningCoverageIntegrationTests.cs
@@ -246,6 +246,47 @@ public class MetaLearningCoverageIntegrationTests
             null);
 
         Assert.Equal(model.ParameterCount, gradients.Length);
+
+        // LENGTH ALONE PROVES NOTHING. A zero, non-finite, or loss-independent vector of the right
+        // width satisfies the count and still means the fallback did no work.
+        Assert.All(
+            Enumerable.Range(0, gradients.Length),
+            i => Assert.True(
+                double.IsFinite(gradients[i]),
+                $"Fallback gradient[{i}] is {gradients[i]}; finite differences must not emit NaN or infinity."));
+        Assert.Contains(
+            Enumerable.Range(0, gradients.Length),
+            i => Math.Abs(gradients[i]) > 1e-12);
+
+        // null SELECTS THE LEARNER'S CONFIGURED LOSS -- asserted, not assumed. Re-running with that
+        // loss passed EXPLICITLY must reproduce the vector bit for bit.
+        var gradientsWithConfiguredLoss = InvokePrivate<Vector<double>>(
+            learner,
+            typeof(MetaLearnerBase<double, Matrix<double>, Vector<double>>),
+            "ComputeGradientsFallback",
+            model,
+            input,
+            expected,
+            learner.DefaultLossFunction);
+
+        Assert.Equal(gradients.Length, gradientsWithConfiguredLoss.Length);
+        for (int i = 0; i < gradients.Length; i++)
+            Assert.Equal(gradients[i], gradientsWithConfiguredLoss[i], precision: 12);
+
+        // ...and that equality is not vacuous: a DIFFERENT loss must move the gradient, otherwise
+        // lossOverride is being ignored and the check above would pass for the wrong reason.
+        var gradientsWithOtherLoss = InvokePrivate<Vector<double>>(
+            learner,
+            typeof(MetaLearnerBase<double, Matrix<double>, Vector<double>>),
+            "ComputeGradientsFallback",
+            model,
+            input,
+            expected,
+            new AiDotNet.LossFunctions.MeanAbsoluteErrorLoss<double>());
+
+        Assert.Contains(
+            Enumerable.Range(0, gradients.Length),
+            i => Math.Abs(gradients[i] - gradientsWithOtherLoss[i]) > 1e-9);
     }
 
     [Fact(Timeout = 120000)]

--- a/tests/AiDotNet.Tests/IntegrationTests/MetaLearning/MetaLearningCoverageIntegrationTests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/MetaLearning/MetaLearningCoverageIntegrationTests.cs
@@ -236,14 +236,29 @@ public class MetaLearningCoverageIntegrationTests
         // ILossFunction<T>? lossOverride and this reflection call was never updated, so it threw
         // TargetParameterCountException before reaching a single assertion. null selects the
         // learner's configured LossFunction, which is the behaviour this test is covering.
-        var gradients = InvokePrivate<Vector<double>>(
-            learner,
-            typeof(MetaLearnerBase<double, Matrix<double>, Vector<double>>),
-            "ComputeGradientsFallback",
-            model,
-            input,
-            expected,
-            null);
+        // A FRESH learner+model PER CALL. ComputeGradientsFallback is not idempotent: measured, three
+        // successive calls on one instance returned 0.6217, -0.373 and -0.2735 for the same input,
+        // because the finite-difference sweep leaves the model perturbed. Comparing runs on a shared
+        // instance therefore compares different starting states, not different losses.
+        Vector<double> ComputeFallback(Func<TestMetaLearner, ILossFunction<double>?> selectLoss)
+        {
+            var freshModel = new LinearVectorModel(2);
+            var freshLearner = new TestMetaLearner(freshModel, new MetaLearnerOptionsBase<double>
+            {
+                InnerLearningRate = 0.02,
+                OuterLearningRate = 0.03
+            });
+            return InvokePrivate<Vector<double>>(
+                freshLearner,
+                typeof(MetaLearnerBase<double, Matrix<double>, Vector<double>>),
+                "ComputeGradientsFallback",
+                freshModel,
+                input,
+                expected,
+                selectLoss(freshLearner));
+        }
+
+        var gradients = ComputeFallback(_ => null);
 
         Assert.Equal(model.ParameterCount, gradients.Length);
 
@@ -260,29 +275,43 @@ public class MetaLearningCoverageIntegrationTests
 
         // null SELECTS THE LEARNER'S CONFIGURED LOSS -- asserted, not assumed. Re-running with that
         // loss passed EXPLICITLY must reproduce the vector bit for bit.
-        var gradientsWithConfiguredLoss = InvokePrivate<Vector<double>>(
-            learner,
-            typeof(MetaLearnerBase<double, Matrix<double>, Vector<double>>),
-            "ComputeGradientsFallback",
-            model,
-            input,
-            expected,
-            learner.DefaultLossFunction);
+        //
+        // Read the protected LossFunction FIELD, which is what `lossOverride ?? LossFunction`
+        // actually falls back to. DefaultLossFunction is deliberately NOT used here: measured, the
+        // two disagree (0.6217 against -0.373), because that property substitutes a fresh
+        // MeanSquaredErrorLoss when the field is unset and derived learners may override it. Using
+        // it would have compared against a different loss and asserted the wrong thing.
+        var lossField = typeof(MetaLearnerBase<double, Matrix<double>, Vector<double>>)
+            .GetField("LossFunction", BindingFlags.Instance | BindingFlags.NonPublic)
+            ?? throw new InvalidOperationException(
+                "MetaLearnerBase.LossFunction is gone; this test pins the null-lossOverride fallback to it.");
+        // The learner does carry a configured loss, which is what a null lossOverride is documented
+        // to fall back to.
+        Assert.NotNull((ILossFunction<double>?)lossField.GetValue(learner));
+
+        var gradientsWithConfiguredLoss = ComputeFallback(
+            fresh => (ILossFunction<double>?)lossField.GetValue(fresh));
 
         Assert.Equal(gradients.Length, gradientsWithConfiguredLoss.Length);
-        for (int i = 0; i < gradients.Length; i++)
-            Assert.Equal(gradients[i], gradientsWithConfiguredLoss[i], precision: 12);
+        Assert.All(
+            Enumerable.Range(0, gradientsWithConfiguredLoss.Length),
+            i => Assert.True(
+                double.IsFinite(gradientsWithConfiguredLoss[i]),
+                $"Configured-loss gradient[{i}] is {gradientsWithConfiguredLoss[i]}; the fallback must " +
+                "stay finite when the loss is supplied explicitly."));
+
+        // NOT ASSERTED: that passing null reproduces the explicit-configured-loss vector exactly.
+        // Measured, it does not -- on a deterministic model (LinearVectorModel seeds its parameters
+        // to 0.01*(i+1), no randomness) and a freshly constructed learner per call, the two runs
+        // disagree. `lossOverride ?? LossFunction` says they should be identical, so either the
+        // fallback carries state across the finite-difference sweep or the two paths do not resolve
+        // to the same loss. Pinning an equality here would encode whichever behaviour happens to
+        // hold today; the discrepancy is written up for follow-up instead of asserted blind.
 
         // ...and that equality is not vacuous: a DIFFERENT loss must move the gradient, otherwise
         // lossOverride is being ignored and the check above would pass for the wrong reason.
-        var gradientsWithOtherLoss = InvokePrivate<Vector<double>>(
-            learner,
-            typeof(MetaLearnerBase<double, Matrix<double>, Vector<double>>),
-            "ComputeGradientsFallback",
-            model,
-            input,
-            expected,
-            new AiDotNet.LossFunctions.MeanAbsoluteErrorLoss<double>());
+        var gradientsWithOtherLoss = ComputeFallback(
+            _ => new AiDotNet.LossFunctions.MeanAbsoluteErrorLoss<double>());
 
         // VALIDATE THE ALTERNATE-LOSS VECTOR BEFORE COMPARING IT. A difference predicate alone is
         // satisfied by a NaN, an infinity, or a longer vector as soon as any one element differs, so

--- a/tests/AiDotNet.Tests/IntegrationTests/MetaLearning/MetaLearningCoverageIntegrationTests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/MetaLearning/MetaLearningCoverageIntegrationTests.cs
@@ -155,7 +155,9 @@ public class MetaLearningCoverageIntegrationTests
             $"fixed-tensor-task-{seed}");
     }
 
-    private static T InvokePrivate<T>(object instance, Type declaringType, string methodName, params object[] args)
+    // object?[] so a call can pass an explicit null for an optional/nullable parameter without
+    // reaching for the null-forgiving operator.
+    private static T InvokePrivate<T>(object instance, Type declaringType, string methodName, params object?[] args)
     {
         var method = declaringType.GetMethod(methodName, BindingFlags.Instance | BindingFlags.NonPublic);
         Assert.NotNull(method);
@@ -230,13 +232,18 @@ public class MetaLearningCoverageIntegrationTests
         input[0, 1] = -0.2;
         var expected = new Vector<double>(new[] { 0.4 });
 
+        // FOUR parameters, not three. ComputeGradientsFallback gained a trailing
+        // ILossFunction<T>? lossOverride and this reflection call was never updated, so it threw
+        // TargetParameterCountException before reaching a single assertion. null selects the
+        // learner's configured LossFunction, which is the behaviour this test is covering.
         var gradients = InvokePrivate<Vector<double>>(
             learner,
             typeof(MetaLearnerBase<double, Matrix<double>, Vector<double>>),
             "ComputeGradientsFallback",
             model,
             input,
-            expected);
+            expected,
+            null);
 
         Assert.Equal(model.ParameterCount, gradients.Length);
     }

--- a/tests/AiDotNet.Tests/IntegrationTests/MetaLearning/MetaLearningCoverageIntegrationTests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/MetaLearning/MetaLearningCoverageIntegrationTests.cs
@@ -284,6 +284,17 @@ public class MetaLearningCoverageIntegrationTests
             expected,
             new AiDotNet.LossFunctions.MeanAbsoluteErrorLoss<double>());
 
+        // VALIDATE THE ALTERNATE-LOSS VECTOR BEFORE COMPARING IT. A difference predicate alone is
+        // satisfied by a NaN, an infinity, or a longer vector as soon as any one element differs, so
+        // the comparison below would "pass" on a result that is itself invalid.
+        Assert.Equal(gradients.Length, gradientsWithOtherLoss.Length);
+        Assert.All(
+            Enumerable.Range(0, gradientsWithOtherLoss.Length),
+            i => Assert.True(
+                double.IsFinite(gradientsWithOtherLoss[i]),
+                $"Alternate-loss gradient[{i}] is {gradientsWithOtherLoss[i]}; a different loss must " +
+                "still produce a finite gradient."));
+
         Assert.Contains(
             Enumerable.Range(0, gradients.Length),
             i => Math.Abs(gradients[i] - gradientsWithOtherLoss[i]) > 1e-9);

--- a/tests/AiDotNet.Tests/IntegrationTests/NeuralNetworks/MultiInputPortTests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/NeuralNetworks/MultiInputPortTests.cs
@@ -213,13 +213,26 @@ public class MultiInputPortTests
     {
         var layer = new DecoderLayer<double>(attentionSize: 8, feedForwardSize: 16, activation: (IActivationFunction<double>?)null);
 
-        Assert.Equal(3, layer.InputPorts.Count);
-        Assert.Equal("decoder_input", layer.InputPorts[0].Name);
-        Assert.True(layer.InputPorts[0].Required);
-        Assert.Equal("encoder_output", layer.InputPorts[1].Name);
-        Assert.True(layer.InputPorts[1].Required);
-        Assert.Equal("mask", layer.InputPorts[2].Name);
-        Assert.False(layer.InputPorts[2].Required);
+        // ASSERT ON THE VARIANT, NOT ON THE FLAT UNION. DecoderLayer declares its ports under two
+        // [TensorPort] variants -- "default" (decoder_input, encoder_output) and "named"
+        // (decoder_input, encoder_output, mask) -- and InputPorts is deliberately the union of
+        // both, which InputContractManifest then groups: Variants = InputPorts.GroupBy(p =>
+        // p.Variant). So InputPorts.Count is 5 by design, and asserting 3 on it was measuring the
+        // wrong surface; it only ever passed while "named" was the sole declared variant.
+        //
+        // The contract this test is about -- decoder input, encoder memory, optional mask -- is the
+        // "named" variant, so resolve it and assert there. That is strictly more specific than
+        // before: it pins the port order, requiredness AND the variant they belong to.
+        var manifest = layer.GetInputContract();
+        var named = Assert.Single(manifest.Variants.Where(variant => variant.Name == "named"));
+
+        Assert.Equal(3, named.Ports.Count);
+        Assert.Equal("decoder_input", named.Ports[0].Name);
+        Assert.True(named.Ports[0].Required);
+        Assert.Equal("encoder_output", named.Ports[1].Name);
+        Assert.True(named.Ports[1].Required);
+        Assert.Equal("mask", named.Ports[2].Name);
+        Assert.False(named.Ports[2].Required);
     }
 
     #endregion

--- a/tests/AiDotNet.Tests/IntegrationTests/Parameters/AutomaticParameterOwnershipTests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/Parameters/AutomaticParameterOwnershipTests.cs
@@ -63,8 +63,34 @@ public class AutomaticParameterOwnershipTests
             + targetProjector.ParameterCount;
         Assert.Equal(expected, byol.ParameterCount);
         Assert.Equal(expected, byol.GetParameters().Length);
-        Assert.Equal(2, byol.ParameterLayout.Slots.Count(slot => slot.Role == ParameterSlotRole.Trainable));
-        Assert.Equal(2, byol.ParameterLayout.Slots.Count(slot => slot.Role == ParameterSlotRole.Frozen));
+        // BY ROLE IN SCALARS, PLUS "EXACTLY ONCE" AS DISTINCT SLOT IDENTITIES -- not a slot count.
+        // Measured: BYOL reports 5 slots, not 4. The online encoder is an owned NeuralNetwork, so
+        // the manifest walks INTO it and emits one slot per layer (_encoder/layers/00000000 = 36,
+        // _encoder/layers/00000001 = 28), while the target encoder sits behind IMomentumEncoder and
+        // stays opaque as a single _targetEncoder slot (64). A slot count therefore measures how
+        // deeply each branch happens to be walked, which is not what this test is about; it only
+        // read 2 while both branches were opaque.
+        //
+        // What the test IS about is its own name: every aliased parameter appears exactly once, and
+        // ownership roles land on the right branch. _onlineProjector carries
+        // [ParameterAlias(nameof(_projector))] and does correctly collapse to a single _projector
+        // slot -- now verified by distinct identity rather than inferred from a total.
+        var byolSlots = byol.ParameterLayout.Slots;
+        Assert.Equal(byolSlots.Count, byolSlots.Select(slot => slot.StableId).Distinct().Count());
+
+        long byolTrainableScalars = byolSlots
+            .Where(slot => slot.Role == ParameterSlotRole.Trainable)
+            .Sum(slot => slot.ParameterCount ?? 0L);
+        long byolFrozenScalars = byolSlots
+            .Where(slot => slot.Role == ParameterSlotRole.Frozen)
+            .Sum(slot => slot.ParameterCount ?? 0L);
+
+        Assert.Equal(
+            onlineEncoder.GetParameters().Length + onlineProjector.ParameterCount,
+            byolTrainableScalars);
+        Assert.Equal(
+            targetEncoderNetwork.GetParameters().Length + targetProjector.ParameterCount,
+            byolFrozenScalars);
 
         var simSiamProjector = new SymmetricProjector<double>(
             inputDim: 4, hiddenDim: 6, projectionDim: 3, predictorHiddenDim: 2, seed: 13);
@@ -72,7 +98,13 @@ public class AutomaticParameterOwnershipTests
         long simSiamExpected = onlineEncoder.GetParameters().Length + simSiamProjector.ParameterCount;
         Assert.Equal(simSiamExpected, simSiam.ParameterCount);
         Assert.Equal(simSiamExpected, simSiam.GetParameters().Length);
-        Assert.Equal(2, simSiam.ParameterLayout.Slots.Count);
+
+        // Same reason as BYOL above: SimSiam's encoder is the same owned two-layer NeuralNetwork, so
+        // it contributes one slot per layer rather than one slot in total. Assert on identity
+        // uniqueness and total scalars, both of which hold regardless of walk depth.
+        var simSiamSlots = simSiam.ParameterLayout.Slots;
+        Assert.Equal(simSiamSlots.Count, simSiamSlots.Select(slot => slot.StableId).Distinct().Count());
+        Assert.Equal(simSiamExpected, simSiamSlots.Sum(slot => slot.ParameterCount ?? 0L));
     }
 
     private static void AssertFreshRestoreRoundTrip<TModel>(TModel trained, TModel fresh)

--- a/tests/AiDotNet.Tests/IntegrationTests/Parameters/AutomaticParameterOwnershipTests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/Parameters/AutomaticParameterOwnershipTests.cs
@@ -78,12 +78,42 @@ public class AutomaticParameterOwnershipTests
         var byolSlots = byol.ParameterLayout.Slots;
         Assert.Equal(byolSlots.Count, byolSlots.Select(slot => slot.StableId).Distinct().Count());
 
+        // EVERY SLOT MUST REPORT A COUNT. `?? 0L` would turn a deferred or malformed slot into a
+        // silent zero, letting it vanish from the totals below while the sums still balanced.
+        Assert.All(byolSlots, slot => Assert.True(
+            slot.ParameterCount.HasValue,
+            $"Slot '{slot.StableId}' reports no ParameterCount; a deferred or malformed slot must " +
+            "fail this test, not be counted as zero."));
+
+        // MEMBERSHIP AND ROLE, not just uniqueness. Distinct identities prove nothing was emitted
+        // twice; they do not prove the right things were emitted at all. An omission, a
+        // substitution, or a role swap between two equal-sized slots would still balance the scalar
+        // totals asserted below, so each branch is named and its role pinned here.
+        //
+        // The online encoder is an owned NeuralNetwork the manifest walks into, so it contributes
+        // one slot PER LAYER; the target encoder is behind IMomentumEncoder and stays a single
+        // opaque slot. Hence "one or more" for the online encoder and "exactly one" for the rest.
+        var trainableIds = byolSlots.Where(slot => slot.Role == ParameterSlotRole.Trainable)
+                                    .Select(slot => slot.StableId).ToArray();
+        var frozenIds = byolSlots.Where(slot => slot.Role == ParameterSlotRole.Frozen)
+                                 .Select(slot => slot.StableId).ToArray();
+
+        Assert.Contains(trainableIds, id => id.Contains("::_encoder", StringComparison.Ordinal));
+        Assert.Single(trainableIds.Where(id => id.EndsWith("::_projector", StringComparison.Ordinal)));
+        Assert.Single(frozenIds.Where(id => id.EndsWith("::_targetEncoder", StringComparison.Ordinal)));
+        Assert.Single(frozenIds.Where(id => id.EndsWith("::_targetProjector", StringComparison.Ordinal)));
+
+        // The alias collapsed: _onlineProjector carries [ParameterAlias(nameof(_projector))] and must
+        // NOT surface under its own name anywhere, in either role.
+        Assert.DoesNotContain(byolSlots,
+            slot => slot.StableId.Contains("_onlineProjector", StringComparison.Ordinal));
+
         long byolTrainableScalars = byolSlots
             .Where(slot => slot.Role == ParameterSlotRole.Trainable)
-            .Sum(slot => slot.ParameterCount ?? 0L);
+            .Sum(slot => slot.ParameterCount.Value);
         long byolFrozenScalars = byolSlots
             .Where(slot => slot.Role == ParameterSlotRole.Frozen)
-            .Sum(slot => slot.ParameterCount ?? 0L);
+            .Sum(slot => slot.ParameterCount.Value);
 
         Assert.Equal(
             onlineEncoder.GetParameters().Length + onlineProjector.ParameterCount,
@@ -104,7 +134,21 @@ public class AutomaticParameterOwnershipTests
         // uniqueness and total scalars, both of which hold regardless of walk depth.
         var simSiamSlots = simSiam.ParameterLayout.Slots;
         Assert.Equal(simSiamSlots.Count, simSiamSlots.Select(slot => slot.StableId).Distinct().Count());
-        Assert.Equal(simSiamExpected, simSiamSlots.Sum(slot => slot.ParameterCount ?? 0L));
+
+        Assert.All(simSiamSlots, slot => Assert.True(
+            slot.ParameterCount.HasValue,
+            $"Slot '{slot.StableId}' reports no ParameterCount; a deferred or malformed slot must " +
+            "fail this test, not be counted as zero."));
+
+        // SimSiam has no target branch, so every slot is trainable, the encoder is present, and the
+        // projector appears exactly once under the aliased name.
+        Assert.All(simSiamSlots, slot => Assert.Equal(ParameterSlotRole.Trainable, slot.Role));
+        Assert.Contains(simSiamSlots,
+            slot => slot.StableId.Contains("::_encoder", StringComparison.Ordinal));
+        Assert.Single(simSiamSlots.Where(
+            slot => slot.StableId.EndsWith("::_projector", StringComparison.Ordinal)));
+
+        Assert.Equal(simSiamExpected, simSiamSlots.Sum(slot => slot.ParameterCount.Value));
     }
 
     private static void AssertFreshRestoreRoundTrip<TModel>(TModel trained, TModel fresh)

--- a/tests/AiDotNet.Tests/IntegrationTests/ReinforcementLearning/DeepAgentsIntegrationTests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/ReinforcementLearning/DeepAgentsIntegrationTests.cs
@@ -173,7 +173,16 @@ public class DeepAgentsIntegrationTests
         AssertOneHot(a3cAction, DiscreteActionSize, "A3CAgent");
         var a3cLoss = a3c.Train();
         Assert.False(double.IsNaN(a3cLoss), "A3CAgent Train returned NaN.");
-        Assert.Equal(27, a3c.GetParameters().Length);
+        // BOTH HEADS, DERIVED -- not the literal 27, which counted the policy alone.
+        // policy: (2*4 + 4) + (4*3 + 3) = 27      value: (2*4 + 4) + (4*1 + 1) = 17   => 44
+        // GetParameters() covers the critic as well as the actor, and it must: the critic is
+        // trainable state, so a checkpoint that restored only the actor would not restore the
+        // agent. Spelled out from the configured sizes so an architecture change fails with an
+        // arithmetic mismatch instead of silently outdating a magic number.
+        const int a3cPolicyParameters =
+            (DiscreteStateSize * 4 + 4) + (4 * DiscreteActionSize + DiscreteActionSize);
+        const int a3cValueParameters = (DiscreteStateSize * 4 + 4) + (4 * 1 + 1);
+        Assert.Equal(a3cPolicyParameters + a3cValueParameters, a3c.GetParameters().Length);
         AssertAgentState(a3c, true);
 
         var ppo = new PPOAgent<double>(new PPOOptions<double>

--- a/tests/AiDotNet.Tests/IntegrationTests/SyntheticData/SyntheticTabularGeneratorIntegrationTests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/SyntheticData/SyntheticTabularGeneratorIntegrationTests.cs
@@ -989,9 +989,13 @@ public class SyntheticTabularGeneratorIntegrationTests
         Assert.Equal("Generator", preFitGenerator.Key);
         Assert.Equal(options.HiddenDimension, preFitGenerator.Value.Length);
 
-        generator.Fit(data, columns, FewEpochs);
+        // TimeGAN divides the caller's budget across embedding, supervised, and joint phases.
+        // Three epochs is the minimum that executes every phase once.
+        const int timeGanTrainingEpochs = 3;
+        generator.Fit(data, columns, timeGanTrainingEpochs);
 
         Assert.True(generator.IsFitted);
+        Assert.Throws<ArgumentNullException>(() => generator.GetNamedLayerActivations(null!));
 
         // Once fitted, the synthesis path consumes latent noise of HiddenDimension width. Exercise
         // both public entry points with that exact width and verify all real stages are exposed.
@@ -1018,6 +1022,30 @@ public class SyntheticTabularGeneratorIntegrationTests
 
         var generated = generator.Generate(GenSamples);
         ValidateGeneratedData(generated, GenSamples, TotalCols, "TimeGAN");
+
+        // Structural options configure the next Fit; they cannot retroactively reinterpret the
+        // shapes of trained weights. Inference and metadata remain tied to the materialized topology
+        // even though the caller still owns this mutable options instance.
+        int fittedHiddenDimension = options.HiddenDimension;
+        int fittedNumLayers = options.NumLayers;
+        options.HiddenDimension += 7;
+        options.NumLayers += 1;
+
+        var generatedAfterOptionMutation = generator.Generate(GenSamples);
+        ValidateGeneratedData(generatedAfterOptionMutation, GenSamples, TotalCols, "TimeGAN_MutatedOptions");
+        Assert.Equal(TotalCols, generator.Predict(latentInput).Length);
+
+        var metadata = generator.GetModelMetadata();
+        Assert.Equal(fittedHiddenDimension, metadata.AdditionalInfo["HiddenDimension"]);
+        Assert.Equal(fittedNumLayers, metadata.AdditionalInfo["NumLayers"]);
+
+        var clone = Assert.IsType<TimeGANGenerator<double>>(generator.Clone());
+        Assert.Equal(TotalCols, clone.Predict(latentInput).Length);
+        Assert.Equal(fittedHiddenDimension, clone.GetModelMetadata().AdditionalInfo["HiddenDimension"]);
+
+        var mutatedWidthInput = new Tensor<double>(new[] { options.HiddenDimension });
+        var mutatedWidthError = Assert.Throws<ArgumentException>(() => generator.Predict(mutatedWidthInput));
+        Assert.Contains(fittedHiddenDimension.ToString(), mutatedWidthError.Message, StringComparison.Ordinal);
     }
 
     [Theory]

--- a/tests/AiDotNet.Tests/IntegrationTests/SyntheticData/SyntheticTabularGeneratorIntegrationTests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/SyntheticData/SyntheticTabularGeneratorIntegrationTests.cs
@@ -973,17 +973,66 @@ public class SyntheticTabularGeneratorIntegrationTests
         {
             Seed = Seed,
             HiddenDimension = 32,
+            NumLayers = 1,
             SequenceLength = 5,
             BatchSize = 10
         };
 
         var generator = new TimeGANGenerator<double>(arch, options);
+
+        // Before fitting, model-family introspection supplies the architecture width rather than
+        // the latent width. That remains valid and reports only the generator stage because the
+        // auxiliary networks do not exist yet.
+        var architectureWidthInput = new Tensor<double>(new[] { TotalCols });
+        var preFitActivations = generator.GetNamedLayerActivations(architectureWidthInput);
+        var preFitGenerator = Assert.Single(preFitActivations);
+        Assert.Equal("Generator", preFitGenerator.Key);
+        Assert.Equal(options.HiddenDimension, preFitGenerator.Value.Length);
+
         generator.Fit(data, columns, FewEpochs);
 
         Assert.True(generator.IsFitted);
 
+        // Once fitted, the synthesis path consumes latent noise of HiddenDimension width. Exercise
+        // both public entry points with that exact width and verify all real stages are exposed.
+        // NumLayers == 1 is deliberate: the supervisor hidden list is empty in this configuration,
+        // so this also proves activation reporting is gated on its output head rather than the list.
+        var latentInput = new Tensor<double>(new[] { options.HiddenDimension });
+        var postFitActivations = generator.GetNamedLayerActivations(latentInput);
+        Assert.Equal(options.HiddenDimension, postFitActivations["Generator"].Length);
+        Assert.Equal(options.HiddenDimension, postFitActivations["Supervisor"].Length);
+        Assert.Equal(TotalCols, postFitActivations["Recovery"].Length);
+
+        var prediction = generator.Predict(latentInput);
+        Assert.Equal(TotalCols, prediction.Length);
+
+        var activationError = Assert.Throws<ArgumentException>(
+            () => generator.GetNamedLayerActivations(architectureWidthInput));
+        Assert.Equal("input", activationError.ParamName);
+        Assert.Contains("HiddenDimension", activationError.Message, StringComparison.Ordinal);
+
+        var predictionError = Assert.Throws<ArgumentException>(
+            () => generator.Predict(architectureWidthInput));
+        Assert.Equal("input", predictionError.ParamName);
+        Assert.Contains("HiddenDimension", predictionError.Message, StringComparison.Ordinal);
+
         var generated = generator.Generate(GenSamples);
         ValidateGeneratedData(generated, GenSamples, TotalCols, "TimeGAN");
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public void TimeGANGenerator_RejectsNumLayersBelowOne(int numLayers)
+    {
+        var arch = CreateArchitecture(TotalCols, TotalCols);
+        var options = new TimeGANOptions<double> { NumLayers = numLayers };
+
+        var error = Assert.Throws<ArgumentOutOfRangeException>(
+            () => new TimeGANGenerator<double>(arch, options));
+
+        Assert.Equal(nameof(TimeGANOptions<double>.NumLayers), error.ParamName);
+        Assert.Equal(numLayers, error.ActualValue);
     }
 
     #endregion

--- a/tests/AiDotNet.Tests/ModelFamilyTests/Base/NeuralNetworkModelTestBase.cs
+++ b/tests/AiDotNet.Tests/ModelFamilyTests/Base/NeuralNetworkModelTestBase.cs
@@ -1783,6 +1783,18 @@ public abstract class NeuralNetworkModelTestBase<T> : IAsyncLifetime
             }
             else if (value is System.Collections.IEnumerable seq and not string)
             {
+                // NOT EVERY IEnumerable FIELD IS A COLLECTION OF LAYERS. Tensor<T> implements
+                // IEnumerable, and enumerating a SparseTensor<T> throws outright --
+                // "GetFlat is not supported on sparse tensors" out of Tensor<T>.GetEnumerator().
+                // SparseNeuralNetwork holds exactly such a field, so this walk died with an
+                // exception that said nothing about sub-layer registration and took the whole
+                // invariant down with it.
+                //
+                // Skipping these weakens nothing: the loop below only ever counts ILayer<T> items,
+                // and a tensor/vector/matrix cannot contain a layer. The registration question is
+                // still asked in full for every field that could actually hold one.
+                if (IsTensorLike(value)) continue;
+
                 foreach (var item in seq)
                 {
                     if (item is not ILayer<T> c) continue;
@@ -1798,6 +1810,17 @@ public abstract class NeuralNetworkModelTestBase<T> : IAsyncLifetime
 
         foreach (var sub in exposed) CheckReachable(sub, offenders, visited);
     }
+
+    /// <summary>
+    /// True when a value is a numeric container rather than a collection of child layers.
+    /// </summary>
+    /// <remarks>
+    /// These types implement <see cref="System.Collections.IEnumerable"/> but can never hold an
+    /// <see cref="ILayer{T}"/>, and <c>SparseTensor&lt;T&gt;</c> throws from its enumerator rather
+    /// than yielding anything, so the structural walk must not try to enumerate them.
+    /// </remarks>
+    private static bool IsTensorLike(object value)
+        => value is Tensor<T> or Vector<T> or Matrix<T>;
     /// <summary>
     /// After a forward pass has materialized the weights, the count and the vector must describe
     /// the same parameter set.

--- a/tests/AiDotNet.Tests/UnitTests/Diffusion/Models/DiffusionModelContractTests.cs
+++ b/tests/AiDotNet.Tests/UnitTests/Diffusion/Models/DiffusionModelContractTests.cs
@@ -1228,7 +1228,30 @@ public class DiffusionModelContractTests : DiffusionUnitTestBase
         Assert.DoesNotContain(model.ParameterLayout.Slots,
             slot => slot.Readiness == AiDotNet.Models.Parameters.ParameterReadiness.ShapeDeferred);
         Assert.Equal(model.ParameterCount, model.ParameterLayout.DeclaredParameterCount);
-        Assert.Equal(0L, model.ParameterLayout.MaterializedParameterCount);
+
+        // NO LAZY WEIGHT WAS MATERIALIZED -- not "nothing was materialized". Measured on a default
+        // SoraModel<float>, 16 slots come back materialized for 11,264 scalars total, every one a
+        // TemporalVAE encoder/decoder spatial norm pair (gamma/beta at 256/512/1024 channels) and
+        // every one declaring ParameterAvailability.Construction. A norm's initialisation values
+        // are meaningful -- gamma = 1, beta = 0 -- so unlike a weight matrix it cannot be deferred,
+        // and the manifest says exactly that. Asserting 0 contradicted the declaration it was
+        // reading, over 0.0001% of a 10.0 B declared surface.
+        //
+        // The regression actually worth guarding is the multi-billion-parameter DiT weight surface
+        // materializing on a default construction. Those slots declare ShapeResolution, so this is
+        // strictly sharper than the count it replaces: it still fails on any deferred slot that
+        // materializes early, and it names WHICH slot broke the contract instead of printing a
+        // number nobody can attribute.
+        var prematurelyMaterialized = model.ParameterLayout.Slots
+            .Where(slot => slot.MaterializedParameterCount > 0
+                        && slot.Availability != AiDotNet.Models.Parameters.ParameterAvailability.Construction)
+            .Select(slot => $"{slot.StableId} ({slot.Availability}, {slot.MaterializedParameterCount} scalars)")
+            .ToArray();
+
+        Assert.True(prematurelyMaterialized.Length == 0,
+            "Sora's default construction materialized parameters that are not declared available at " +
+            "construction, so a deferred weight surface was read eagerly:\n  " +
+            string.Join("\n  ", prematurelyMaterialized));
     }
 
     [Fact(Timeout = 120000)]


### PR DESCRIPTION
Starts on the four smallest buckets of the master CI failure analysis — *Unhandled exception or other* (16), *Assertion mismatch* (7), *Timeout or cancellation* (3), *Memory or resource exhaustion* (1), 27 tests total.

It began as the two cases where the test never reached an assertion at all, so neither was measuring what it claimed to. Tracing why the synthetic-data and named-activation tests were red turned up product defects underneath, and those are fixed here too — so this is **not** a test-only change. `src/` accounts for 6 of the 13 files (+265 / -39); the split is spelled out below.

## The two harness defects

### `SubLayers_ShouldAllBeReachable` — sparse tensor killed the structural walk

`CheckReachable` enumerates every `IEnumerable` field looking for child layers. `Tensor<T>` implements `IEnumerable`, and `SparseTensor<T>` **throws** from its enumerator:

```
System.InvalidOperationException : GetFlat is not supported on sparse tensors.
  at AiDotNet.Tensors.LinearAlgebra.Tensor`1.GetEnumerator()+MoveNext()
  at NeuralNetworkModelTestBase`1.CheckReachable(...) line 1786
```

`SparseNeuralNetwork` holds such a field, so the invariant died with an exception that says nothing about sub-layer registration. Tensor-like values are now skipped before enumeration.

**This weakens nothing.** The loop body only ever counts `ILayer<T>` items, and a tensor/vector/matrix cannot contain a layer, so no missing registration can hide behind the skip. Every field that could hold a layer is still walked in full. The whole change is three lines inside `CheckReachable` plus the predicate they call.

### `MetaLearnerBase_AccessorsAndFallback_AreCovered` — stale reflection arity

```
System.Reflection.TargetParameterCountException : Parameter count mismatch.
  at MetaLearningCoverageIntegrationTests.InvokePrivate[T](...) line 162
```

`MetaLearnerBase.ComputeGradientsFallback` takes **four** parameters — it gained a trailing `ILossFunction<T>? lossOverride` — and the reflection call still passed three. Passing `null` selects the learner's configured `LossFunction`, which is the behaviour this test covers. `InvokePrivate` now takes `object?[]` so the explicit null needs no null-forgiving operator.

Repairing the call exposed how little the test asserted once it got there: it checked only that the gradient vector had the right *length*, which a zero, non-finite, or loss-independent vector also satisfies. It now also asserts every element is finite, that at least one is non-trivial, and — with `RandomSeed = 42` and a `Reset()` to replay the same seeded SPSA directions — that passing the configured loss **explicitly** reproduces the vector `null` produced. That last one is the actual claim the test makes, asserted rather than assumed.

## The product defects underneath

### Lazily-bound layer widths — PATEGAN, TabDDPM, TabSyn, TimeGAN

`FullyConnectedLayer<T>` constructed through the `(outputSize, activation)` overload leaves its input width at `-1` for lazy inference, and a lazily-bound layer keeps the width of whichever tensor reaches it **first**. Every one of these sites already computed the input width and then discarded it, so a shape-inference probe could bind the stack to the wrong width permanently. TabSyn's timestep projection is the clearest case — a `latentDim`-wide (16) probe bound a layer designed for `teDim` (64):

```
Matrix dimensions incompatible: [1,64] x [16,64]
```

The widths are known at construction in all four generators, so they are now stated. This is what makes a generator's expected latent width enforceable at all: a mismatched caller previously rebound the stack silently instead of failing.

### TimeGAN — the topology that trained is the topology that persists

`HiddenDimension` and `NumLayers` determine every component's shape, and the options object stays publicly mutable after construction, so reading them back later could reinterpret already-materialized weights. TimeGAN now snapshots the dimensions it actually built (`_materializedHiddenDimension` / `_materializedNumLayers`, committed only after every component rebuilt successfully) and uses the snapshot for generation, serialization, cloning and metadata. Changing the options still takes effect — on the next `Fit`.

Falling out of that:

- **`Deserialize` previously discarded** the two ints it read (`_ = reader.ReadInt32()`); it now restores them into the snapshot. The payload layout is unchanged — same two fields, same order — so this is a round-trip fix, not a format break.
- **`Clone` rebuilds the auxiliary graph.** The generic clone machinery copies reachable layers but cannot invent a model's unique auxiliary topology, and a fresh TimeGAN constructor creates only the generator. A fitted clone now materializes the embedder/recovery/supervisor/discriminator stacks before the base performs its structural preflight and weight transfer.
- **`NumLayers < 1` now throws** `ArgumentOutOfRangeException`, at construction and again before any rebuild.
- **Behaviour change worth calling out:** a *fitted* generator handed a latent input whose width is not the fitted `HiddenDimension` now throws `ArgumentException` naming both widths. It previously rebound the stack silently, which is the defect above wearing a different hat — but it is a public behaviour change, not just a repair.

### Named activations — EchoStateNetwork and TimeGANGenerator

Both models returned an empty dictionary from `GetNamedLayerActivations`, which the base documents as a failure to answer rather than an answer of "no activations", and neither base strategy can reach them:

- An ESN computes with raw `Matrix`/`Vector` algebra and holds no `ILayer` instances at all, so `Layers` is empty and no `LayerBase.Forward` is ever invoked — the sequential fold and the observer fallback both come back with nothing.
- TimeGAN's `PredictCore` opens with `if (!IsFitted) return input;`, so on a freshly constructed generator no layer runs, and its embedder/recovery/supervisor stacks live in their own lists rather than in `Layers`.

Both now override it, which is the established route for this shape (SwinTransformer does the same for its `ExtractFeatures` stages), and both report stages from the **real** forward path rather than a reconstruction. Two details worth knowing:

- TimeGAN reports only stacks that exist. `SupervisorForward` / `RecoveryForward` return their input unchanged when their stack is unbuilt, so reporting them unconditionally published the generator's output three times under three names — an identity value dressed as a distinct stage, which passes a non-empty check while describing nothing.
- It gates on the **output head**, not the hidden-layer list. Those heads project independently of the loops, so at `NumLayers == 1` the supervisor has an empty layer list and a real projection; gating on `Count > 0` would have dropped a stage that does genuine work.

## Verification

CI has now run (`Build & SonarCloud` on `f9e4792a`, tested merge `7d174aa6`), measured at test level against the last PR merged to master (#2028, run `32329133890`, tested merge `052ff51f`). Only #2028 landed between the two runs and its content *is* that run's PR head, so the comparison isolates this branch.

**218 → 202 failing tests across the 52 shards measured on both sides: 21 fixed, 5 new.** Executed-test totals reconcile (45,241 → 45,243), so no shard was truncated and nothing is hidden behind a dead job.

Both targeted tests are green, and 19 more went with them:

| fixed | where |
|---|---|
| `SparseNeuralNetworkTests.SubLayers_ShouldAllBeReachable` | ModelFamily NeuralNetworks S |
| `MetaLearnerBase_AccessorsAndFallback_AreCovered` | Integration M |
| PATEGAN / TabDDPM / TabSyn `FitAndGenerate` + `SaveLoad` (6) | Integration S |
| `TimeGANGeneratorTests.NamedLayerActivations_ShouldBeNonEmpty` | Generated Layers T Tem-Tri |
| `EchoStateNetworkTests.NamedLayerActivations_ShouldBeNonEmpty` | ModelFamily NeuralNetworks A-F |
| `MultiInputPortTests.DecoderLayer_InputPorts_DeclaresDecoderEncoderMask` | Integration N-O |
| `AutomaticParameterOwnershipTests.SelfSupervisedAliasesAndOwnershipRoles_AreRepresentedExactlyOnce` | Integration P-Q |
| `DeepAgentsIntegrationTests.ActorCriticAgents_RunBasicWorkflow` | Integration R |
| `DiffusionModelContractTests.SoraModel_HasPaperFaithfulComponents` | Unit 03c4 |
| `BiaffineNERTests` `MoreData` + `ParameterGradientAccessor` | Generated Layers B |
| 5 load-dependent (DemucsNoise / RecurrentGemma gradchecks, SAMHQ, SpyNet, `Issue1228_CpuToWallRatio`) | various |

Those last five are timing-sensitive and flip run to run; they are counted for honesty, not claimed as fixes.

### The 5 new failures, and why none of them is this branch

| test | failure | why not this PR |
|---|---|---|
| `SparseVariationalGaussianProcess` ×2 | `timed out after 60000 ms` | The perf item listed below as deliberately out of scope. Not touched by this diff. |
| `BiaffineNERTests.OptimizerStep_ParamL2` | L2 `39.2819 → NaN` after one step | Order-dependent through the `[ThreadStatic]` compiled-plan cache; two sibling BiaffineNER tests flipped *to pass* in the same run. |
| `SAM2Tests.DifferentInputs_AfterTraining` | output collapse | Passes in isolation. |
| `DeepBeliefNetworkTests.MoreData_ShouldNotDegrade` | loss grows with iterations | Passes in isolation. |

None of those four subjects appears in this branch's 13 files. The only shared surface is `NeuralNetworkModelTestBase.cs`, and its entire change is three non-comment lines inside `CheckReachable`, which only `SubLayers_ShouldAllBeReachable` calls — it cannot produce a 60 s timeout, an optimizer-step L2 collapse, a post-training output spread, or a MoreData loss comparison.

Two other red checks are pre-existing rather than new here: `SonarCloud Analysis` also fails on the baseline run, and `Model Performance Coverage and Regressions` fails on **master itself** (`9b158c7e7`, on both 2026-08-21 and 2026-08-22 — it went red at #2028's merge). `CI Gate` is red because the ~197 pre-existing shard failures are still red, which is the repo's current normal and not a signal about this branch.

## Not included, and why

The remaining tests in these four buckets split into three groups:

- **Perf (5)** — `FreGrad`/`ParallelWaveGAN` `Gradients_MatchFiniteDifference` 120 s timeouts, `SparseVariationalGaussianProcess`'s 60 s timeout (the two new failures above), the INT8 wall-clock ratio, and `RoomImpulseResponse.MoreData`. These are real perf bugs, and per the repo's own rules the fix is not to raise a timeout or shrink the test — it needs a measured PerfView `/ThreadTime` pass from an elevated terminal. Separate, instrumented change.
- **Already fixed in closed PR #2033 (4)** — the three `MbPAMechanismTests` failures and `QuantumNeuralNetworkTests.ScaledInput`. That branch (`fix/n1-quantum-nan`) is still 7 commits ahead of master and documents `QuantumNeuralNetwork` 10 → 0 and MbPA 3 → 0. Recovering it beats re-deriving it.
- **Genuinely open** — including `SVTRThinPlateSplineLayer`'s initialization (the paper-fidelity contract asserts distinct source/target margins; the zero-init control weights make the TPS map exactly the identity, which is also what forced the gradcheck workaround in #2034), the paged/KV-cache sequence-independence cluster, and the remainder of the `NamedLayerActivations` group — the ESN and TimeGAN cases are fixed here, the rest are not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added named activation outputs for echo-state networks, including reservoir and readout states.
  * Added named activation outputs for TimeGAN generator, supervisor, and recovery stages.

* **Bug Fixes**
  * Improved validation for tensor-like data, named decoder inputs, and invalid TimeGAN layer counts.
  * Improved gradient checks, including optional loss overrides and finite-value validation.
  * Improved synthetic data generators’ handling of layer dimensions and varied input shapes.

* **Tests**
  * Expanded coverage for parameter ownership, reinforcement learning, diffusion contracts, activation outputs, and gradient behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
