### PR TITLE
fix: post-2052 clone, serialization and CI-reuse failures

### DIFF
--- a/.github/model-performance-intent.json
+++ b/.github/model-performance-intent.json
@@ -4,6 +4,20 @@
     "origin": "cb9ecf59db",
     "fixture": "AiDotNet.Tests.ModelFamilyTests.Generated.DCRNNTests",
     "metric": "peakWorkingSetBytes",
-    "reason": "cb9ecf59db restored the paper's recurrent diffusion: DCRNN now builds real DiffusionConvolutionalGRU layers for its encoder and decoder, and each one owns forward and backward graph transition matrices and runs MaxDiffusionStep diffusion steps per gate. That is more memory than the layers it replaced, and it is the model the paper describes. The measured step is 1.69x, from 349 MB to 592 MB, and it holds steady across every run since - a level change, not a leak."
+    "reason": "cb9ecf59db restored the paper's recurrent diffusion: DCRNN now builds real DiffusionConvolutionalGRU layers for its encoder and decoder, each owning forward and backward graph transition matrices and running MaxDiffusionStep diffusion steps per gate. That is more memory than the layers it replaced, and it is the model the paper describes. Measured step 1.69x, 349 MB to 592 MB, steady across every run since - a level change, not a leak."
+  },
+  {
+    "commit": "9e2d5031",
+    "origin": "9e2d5031fb",
+    "fixture": "AiDotNet.Tests.ModelFamilyTests.Generated.GR00TN1Tests",
+    "metric": "allocatedBytes",
+    "reason": "GR00TN1 gained a trainable parameter slot it should always have had. Measured either side of the merge on one machine: 39 slots and 1,277,364 parameters before, 40 slots and 5,373,364 after. The difference is exactly 4,096,000 = VocabSize 1000 x DecoderDim 4096, which is the instruction token embedding the paper describes (NVIDIA GR00T N1 2025, section 3.1). The forward pass already used that table; parameter enumeration did not see it, so it was never trained, never saved and never counted. Now it is, and 4.1M more float parameters carry their weights, gradients and optimizer state - about 98 MB, which is the whole of the measured increase."
+  },
+  {
+    "commit": "9e2d5031",
+    "origin": "9e2d5031fb",
+    "fixture": "AiDotNet.Tests.ModelFamilyTests.Generated.GR00TN1Tests",
+    "metric": "peakWorkingSetBytes",
+    "reason": "The same 4,096,000-parameter token embedding, seen in peak process memory rather than in cumulative allocation. See the allocatedBytes entry for the measurement."
   }
 ]

--- a/.github/model-performance-intent.json
+++ b/.github/model-performance-intent.json
@@ -1,0 +1,9 @@
+[
+  {
+    "commit": "bf812ffc",
+    "origin": "cb9ecf59db",
+    "fixture": "AiDotNet.Tests.ModelFamilyTests.Generated.DCRNNTests",
+    "metric": "peakWorkingSetBytes",
+    "reason": "cb9ecf59db restored the paper's recurrent diffusion: DCRNN now builds real DiffusionConvolutionalGRU layers for its encoder and decoder, and each one owns forward and backward graph transition matrices and runs MaxDiffusionStep diffusion steps per gate. That is more memory than the layers it replaced, and it is the model the paper describes. The measured step is 1.69x, from 349 MB to 592 MB, and it holds steady across every run since - a level change, not a leak."
+  }
+]

--- a/.github/workflows/cancel-on-pr-close.yml
+++ b/.github/workflows/cancel-on-pr-close.yml
@@ -40,11 +40,26 @@ jobs:
     name: Evict Build & SonarCloud concurrency group
     runs-on: ubuntu-latest
     timeout-minutes: 2
+    # A MERGED pr's validation run must be left alone to finish. sonarcloud.yml reuses a merged
+    # PR's completed run to skip ~115 shards on master, and that reuse requires a conclusion of
+    # success or failure -- it explicitly refuses `cancelled`. Killing the run here to reclaim one
+    # CI slot therefore costs a full 115-shard master rerun, which is what happened to #2004:
+    # merged 21:49:03Z with its run still in flight, evicted 21:49:07Z, and master re-ran everything.
+    #
+    # Expressed by REDIRECTING the group rather than by `if:`. This job cancels through the group it
+    # claims at queue time, and a skipped job very probably claims nothing -- but "very probably" is
+    # a poor foundation for the one mechanism that does the cancelling. Naming a per-PR no-op group
+    # leaves no doubt: the heavy group is never entered at all.
     concurrency:
-      group: build-${{ github.event.pull_request.number }}
+      group: ${{ github.event.pull_request.merged && format('noop-merged-build-{0}', github.event.pull_request.number) || format('build-{0}', github.event.pull_request.number) }}
       cancel-in-progress: true
     steps:
-      - run: echo "Evicted concurrency group build-${{ github.event.pull_request.number }} (cancellation happened server-side at queue time)."
+      - run: |
+          if [ "${{ github.event.pull_request.merged }}" = "true" ]; then
+            echo "PR was MERGED: left group build-${{ github.event.pull_request.number }} untouched so its validation run can complete and stay reusable."
+          else
+            echo "Evicted concurrency group build-${{ github.event.pull_request.number }} (cancellation happened server-side at queue time)."
+          fi
 
   evict-ci-website-group:
     name: Evict ci-website concurrency group
@@ -82,6 +97,10 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
           PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
           PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_MERGED: ${{ github.event.pull_request.merged }}
+          # Must match sonarcloud.yml's `name:` exactly; this is the run whose completion master
+          # reuses, so it is the one run this sweep must not touch on a merge.
+          REUSABLE_RUN_NAME: Build & SonarCloud
         run: |
           set -euo pipefail
           # Find in-progress AND queued runs that match this PR's head ref or
@@ -103,6 +122,15 @@ jobs:
                   # head SHA. Avoids false-positives if the same branch name
                   # gets reused for a different PR later.
                   if [ "$head_sha" = "$PR_HEAD_SHA" ]; then
+                    # Same exemption as the eviction job above: a MERGED PR's validation run is the
+                    # artifact master reuses to skip its own ~115 shards, and reuse refuses a
+                    # `cancelled` conclusion. Cancelling it here saves one slot and costs a full
+                    # master matrix. Runs for a PR closed WITHOUT merging are cancelled as before,
+                    # since nothing will ever reuse those.
+                    if [ "$PR_MERGED" = "true" ] && [ "$run_name" = "$REUSABLE_RUN_NAME" ]; then
+                      echo "Keeping run $run_id ($run_name): PR #$PR_NUMBER was merged and master reuses this run."
+                      continue
+                    fi
                     echo "Cancelling run $run_id ($run_name) for PR #$PR_NUMBER head $head_sha"
                     gh run cancel "$run_id" --repo "${{ github.repository }}" || true
                   fi

--- a/.github/workflows/model-performance-census.yml
+++ b/.github/workflows/model-performance-census.yml
@@ -241,26 +241,70 @@ jobs:
           if ($count -le 0) { throw 'No ModelPerformanceCensus fixtures were discovered.' }
           "count=$count" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
 
-      - name: Download latest default-branch baseline
+      # THE BASELINE USED TO FREEZE ON THE FIRST RED RUN.
+      #
+      # This step asked for the last SUCCESSFUL master census. The census publishes its baseline
+      # with if: always(), so the measurements from a failed run exist and are perfectly good
+      # numbers - but they were never looked at. One red run therefore pinned the comparison point
+      # forever, and every later change, intended or not, piled up against a baseline that got
+      # older every day. It did: master's census went red on 26 August and the baseline stayed at
+      # the 25th while four more days of legitimate work accumulated against it.
+      #
+      # A run that COLLECTED its measurements is usable history whether or not the gate passed. The
+      # gate's verdict is about the code; the measurements are just what happened. So the series is
+      # built from recent master runs regardless of conclusion, and a run is excluded only when its
+      # baseline is missing or short - which is the real disqualifier, since a partial census would
+      # make fixtures look like they vanished.
+      - name: Download the master census series
         id: baseline
         shell: pwsh
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          $runs = gh run list --workflow model-performance-census.yml --branch master --status success --limit 1 --json databaseId | ConvertFrom-Json
-          if ($runs.Count -eq 0) {
+          $runs = gh run list --workflow model-performance-census.yml --branch master `
+            --limit 12 --json databaseId,headSha,createdAt,conclusion | ConvertFrom-Json
+          New-Item -ItemType Directory -Force -Path artifacts/model-performance/history | Out-Null
+          New-Item -ItemType Directory -Force -Path artifacts/model-performance/prior | Out-Null
+
+          $kept = @()
+          foreach ($run in $runs) {
+            $into = "artifacts/model-performance/history/$($run.databaseId)"
+            try {
+              gh run download $run.databaseId --name model-performance-baseline --dir $into 2>$null
+            } catch {
+              continue
+            }
+            $file = Join-Path $into 'baseline.json'
+            if (-not (Test-Path $file)) { continue }
+
+            # Stamp the commit the run measured. Baselines written before the probe recorded it
+            # carry none, and a step spanning them is reported as unattributable rather than
+            # attributed to the wrong commit.
+            try {
+              $document = Get-Content $file -Raw | ConvertFrom-Json
+            } catch {
+              continue
+            }
+            if (-not $document.entries -or $document.entries.Count -lt 1) { continue }
+            $document | Add-Member -NotePropertyName commit -NotePropertyValue $run.headSha -Force
+            $document | ConvertTo-Json -Depth 12 -Compress | Set-Content -Path $file -Encoding utf8
+            $kept += ,@($run.createdAt, $file)
+          }
+
+          if ($kept.Count -eq 0) {
             'present=false' | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+            Write-Host 'no prior master census baseline is available; this run establishes one'
             exit 0
           }
-          New-Item -ItemType Directory -Force -Path artifacts/model-performance/prior | Out-Null
-          gh run download $runs[0].databaseId --name model-performance-baseline --dir artifacts/model-performance/prior
-          $path = 'artifacts/model-performance/prior/baseline.json'
-          if (Test-Path $path) {
-            'present=true' | Out-File -FilePath $env:GITHUB_OUTPUT -Append
-            "path=$path" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
-          } else {
-            'present=false' | Out-File -FilePath $env:GITHUB_OUTPUT -Append
-          }
+
+          # The most recent point stays the single-baseline comparison, so a repository without
+          # enough history behaves exactly as it did before.
+          $newest = ($kept | Sort-Object { $_[0] } -Descending)[0][1]
+          Copy-Item $newest 'artifacts/model-performance/prior/baseline.json' -Force
+          'present=true' | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+          'path=artifacts/model-performance/prior/baseline.json' | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+          "count=$($kept.Count)" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+          Write-Host "series depth: $($kept.Count) prior master census run(s)"
 
       - name: Enforce coverage, ceilings and environment-qualified baseline
         shell: pwsh
@@ -296,7 +340,16 @@ jobs:
             '--max-correctness-probe-ms', '120000')
           if ('${{ steps.baseline.outputs.present }}' -eq 'true') {
             $arguments += @('--baseline', '${{ steps.baseline.outputs.path }}')
+            # The series behind that single point. With fewer than four usable runs the probe says
+            # so and compares against the one point, exactly as before.
+            $arguments += @('--history', 'artifacts/model-performance/history')
           }
+          # Cost changes somebody meant to make, each with the reason it was worth making.
+          if (Test-Path '.github/model-performance-intent.json') {
+            $arguments += @('--perf-intent', '.github/model-performance-intent.json')
+          }
+          # So this run's measurements can be attributed when a later run detects a step at them.
+          $arguments += @('--commit', '${{ github.sha }}')
           & dotnet @arguments
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -97,7 +97,9 @@ jobs:
   validation-source:
     name: Resolve certified PR validation
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    # Was 5. This job may now WAIT for a merged PR validation run to finish before
+    # deciding, so the ceiling must exceed REUSE_WAIT_MINUTES with room to spare.
+    timeout-minutes: 50
     permissions:
       actions: read
       contents: read
@@ -151,11 +153,27 @@ jobs:
             exit 0
           fi
 
+          # HOW LONG MASTER WAITS for the PR own validation run to finish.
+          #
+          # Reuse needs a COMPLETED run, but this job starts seconds after the merge, so a PR
+          # merged while its validation was still running has nothing to reuse and master re-runs
+          # all ~115 shards. That is exactly what happened to #2004: merged 21:49:03Z with its run
+          # still in flight. Waiting bridges the gap; a run that lands inside the window saves the
+          # entire matrix.
+          #
+          # Bounded, because waiting is not free: past the cap master has been delayed AND still
+          # has to run everything.
+          REUSE_WAIT_MINUTES=${REUSE_WAIT_MINUTES:-40}
+          deadline=$(( $(date +%s) + REUSE_WAIT_MINUTES * 60 ))
+
+          # Returns 0 having written the outputs, 1 when nothing is reusable YET (wait and retry),
+          # 2 when the API itself failed (give up and run full CI).
+          try_resolve() {
           if ! runs_json=$(gh api --method GET \
             "repos/${GITHUB_REPOSITORY}/actions/workflows/sonarcloud.yml/runs" \
             -f event=pull_request -f head_sha="$head_sha" -f status=completed -f per_page=20); then
             echo '::warning::Could not list prior PR runs; full CI will run.'
-            exit 0
+            return 2
           fi
 
           # A red test ledger may still be an accepted improvement over baseline, so failure is a
@@ -193,7 +211,7 @@ jobs:
                 echo 'reuse=true'
               } >> "$GITHUB_OUTPUT"
               echo "Reusing PR #${pr_number} run ${run_id}; tested tree ${tested_tree} exactly matches master." >> "$GITHUB_STEP_SUMMARY"
-              exit 0
+              return 0
             fi
           done < <(jq -r '
             .workflow_runs[]
@@ -201,7 +219,27 @@ jobs:
             | .id
           ' <<< "$runs_json")
 
-          echo "No complete exact-tree validation artifact was found for PR #${pr_number}; full CI will run." >> "$GITHUB_STEP_SUMMARY"
+          return 1
+          }
+
+          while true; do
+            try_resolve && exit 0
+            [ $? -eq 2 ] && exit 0
+
+            # Only wait on a run that can still BECOME reusable. Everything already completed was
+            # judged above, so with nothing in flight another look cannot change the answer.
+            inflight=$(gh api --method GET "repos/${GITHUB_REPOSITORY}/actions/workflows/sonarcloud.yml/runs" -f event=pull_request -f head_sha="$head_sha" -f per_page=20 --jq '[.workflow_runs[] | select(.status != "completed")] | length' 2>/dev/null || echo 0)
+            if [ "${inflight:-0}" -eq 0 ]; then
+              echo "No exact-tree validation artifact for PR #${pr_number} and none in flight; full CI will run." >> "$GITHUB_STEP_SUMMARY"
+              exit 0
+            fi
+            if [ "$(date +%s)" -ge "$deadline" ]; then
+              echo "PR #${pr_number} validation still running after ${REUSE_WAIT_MINUTES}m; full CI will run." >> "$GITHUB_STEP_SUMMARY"
+              exit 0
+            fi
+            echo "PR #${pr_number} validation in flight; waiting so master can reuse it instead of repeating ~115 shards."
+            sleep 60
+          done
 
   # CodeQL runs on Ubuntu with net10.0 only - parallel with SonarCloud
   # Runs on PRs, merge groups, pushes to master/main, and the weekly security schedule.
@@ -1357,27 +1395,6 @@ jobs:
             project: tests/AiDotNet.Serving.Tests/AiDotNet.Serving.Tests.csproj
             framework: net10.0
             filter: 'Category!=GPU&Category!=Stress'
-          # =====================================================================
-          # NET8.0 SMOKE
-          # =====================================================================
-          # net10.0 is where the full matrix runs; net471 gets no shard at all so it
-          # does not slow CI down. net8.0 sits between them: src ships it, so a
-          # SMOKE-SIZED shard is worth the minute it costs, but it is deliberately
-          # not a second matrix.
-          #
-          # Scoped to what a compile cannot prove and a runtime difference would
-          # break: the tape (autodiff), the numeric core (linear algebra), and ONE
-          # model fixture whose conformance invariants run train/predict end to end.
-          # ~120 tests. Everything broader belongs on net10.0.
-          - name: Net8 Smoke
-            project: tests/AiDotNet.Tests/AiDotNetTests.csproj
-            framework: net8.0
-            # Sized for the net8.0 COMPILE, not the 10 seconds of tests that follow it.
-            timeout: 30
-            filter: >-
-              Category!=GPU&Category!=Stress&Category!=Sweep&Category!=HeavyTimeout&
-              (FullyQualifiedName~UnitTests.Autodiff|FullyQualifiedName~UnitTests.LinearAlgebra|
-              FullyQualifiedName~ModelFamilyTests.Regression.SimpleRegressionTests)
 
     steps:
       - name: Checkout code
@@ -1433,24 +1450,12 @@ jobs:
         # rather than as a transfer that stalled. A cap converts that into a fast, clearly
         # attributed failure that a rerun can fix in minutes.
         timeout-minutes: 12
-        # Skipped for net8.0: that shard builds its own target below, so the net10.0 artifact
-        # is dead weight -- and this is the step that has stalled a shard for a whole job.
-        if: matrix.shard.framework != 'net8.0'
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v4
         with:
           name: build-output-${{ github.sha }}
 
       - name: Restore dependencies
         run: dotnet restore ${{ matrix.shard.project }}
-
-      # The build artifact carries net10.0 only, so the net8.0 shard compiles its own target
-      # here. This is the whole point of making that target opt-in: the work happens on one
-      # shard in parallel rather than in the Build job every other shard is blocked on.
-      - name: Build net8.0 target (smoke shard only)
-        if: matrix.shard.framework == 'net8.0'
-        run: |
-          dotnet restore ${{ matrix.shard.project }} -p:IncludeNet8TestTarget=true
-          dotnet build ${{ matrix.shard.project }} -c Release -f net8.0             -p:IncludeNet8TestTarget=true --no-restore -m:2
 
       - name: Run tests (sharded) with coverage
         id: shard-tests

--- a/src/CausalDiscovery/DeepLearning/CASTLEAlgorithm.cs
+++ b/src/CausalDiscovery/DeepLearning/CASTLEAlgorithm.cs
@@ -320,12 +320,14 @@ public class CASTLEAlgorithm<T> : DeepCausalBase<T>
             }
         }
 
-        // Adjacency = first-layer weight-row norms A[i,j] = ‖Wh_j[i,:]‖, normalized to
-        // [0,1] so BuildFinalAdjacency's 0.3 gate applies. Direction is resolved there
-        // by A[i,j] vs A[j,i]; edge magnitude comes from the covariance ratio.
+        // Adjacency = first-layer weight-row norms A[i,j] = ‖Wh_j[i,:]‖. CASTLE's
+        // reference implementation thresholds these raw group norms at w_threshold=0.3;
+        // normalizing by the largest edge would make every other edge's apparent
+        // strength depend on that one edge and can promote weak rows as n changes.
+        // Direction is resolved by A[i,j] vs A[j,i]; edge magnitude comes from the
+        // covariance ratio.
         var cov = ComputeCovarianceMatrix(Xs.ToMatrix());
         var learnedP = new double[d, d];
-        double maxA = 0.0;
         for (int j = 0; j < d; j++)
             for (int i = 0; i < d; i++)
             {
@@ -338,14 +340,9 @@ public class CASTLEAlgorithm<T> : DeepCausalBase<T>
                 }
                 double a = Math.Sqrt(s2);
                 learnedP[i, j] = a;
-                if (a > maxA) maxA = a;
             }
-        if (maxA > 1e-12)
-            for (int i = 0; i < d; i++)
-                for (int j = 0; j < d; j++)
-                    learnedP[i, j] /= maxA;
 
-        return BuildFinalAdjacency(learnedP, cov, d);
+        return BuildFinalAdjacency(learnedP, cov, d, learnedThreshold: 0.3);
     }
 
 }

--- a/src/CausalDiscovery/DeepLearning/DeepCausalBase.cs
+++ b/src/CausalDiscovery/DeepLearning/DeepCausalBase.cs
@@ -239,13 +239,13 @@ public abstract class DeepCausalBase<T> : CausalDiscoveryBase<T>
     /// <returns>Weighted adjacency matrix.</returns>
     protected Matrix<T> BuildFinalAdjacency(double[,] learnedP, Matrix<T> cov, int d)
     {
-        // Threshold scales with d only when uniform attention (= 1/d) crowds
-        // a fixed 0.3 floor. For d ≤ 3 keep the historical 0.3 floor —
-        // 1/d > 0.3 already, so the discrimination floor is "above uniform"
-        // by margin regardless. For d ≥ 4 require uniform + 0.15 margin so
-        // an algorithm that just spreads attention near uniform doesn't
-        // cross the bar.
-        double scaleAwareThreshold = d <= 3 ? 0.3 : Math.Max(1.0 / d + 0.15, 0.3);
+        if (d <= 0)
+            throw new ArgumentOutOfRangeException(nameof(d), d, "The variable count must be positive.");
+
+        // Require a fixed margin above uniform influence for every graph size.
+        // This matters most for d = 2 and d = 3, where 1/d already exceeds the
+        // historical 0.3 floor and an uninformative uniform predictor would pass it.
+        double scaleAwareThreshold = Math.Max(1.0 / d + 0.15, 0.3);
         return BuildFinalAdjacency(learnedP, cov, d, scaleAwareThreshold);
     }
 

--- a/src/CausalDiscovery/DeepLearning/DeepCausalBase.cs
+++ b/src/CausalDiscovery/DeepLearning/DeepCausalBase.cs
@@ -239,8 +239,6 @@ public abstract class DeepCausalBase<T> : CausalDiscoveryBase<T>
     /// <returns>Weighted adjacency matrix.</returns>
     protected Matrix<T> BuildFinalAdjacency(double[,] learnedP, Matrix<T> cov, int d)
     {
-        var result = new Matrix<T>(d, d);
-
         // Threshold scales with d only when uniform attention (= 1/d) crowds
         // a fixed 0.3 floor. For d ≤ 3 keep the historical 0.3 floor —
         // 1/d > 0.3 already, so the discrimination floor is "above uniform"
@@ -248,14 +246,29 @@ public abstract class DeepCausalBase<T> : CausalDiscoveryBase<T>
         // an algorithm that just spreads attention near uniform doesn't
         // cross the bar.
         double scaleAwareThreshold = d <= 3 ? 0.3 : Math.Max(1.0 / d + 0.15, 0.3);
+        return BuildFinalAdjacency(learnedP, cov, d, scaleAwareThreshold);
+    }
+
+    /// <summary>
+    /// Converts learned directed influence strengths into a weighted adjacency matrix
+    /// using an algorithm-defined absolute influence threshold.
+    /// </summary>
+    /// <param name="learnedP">Learned directed influence strengths [d x d].</param>
+    /// <param name="cov">Covariance matrix [d x d].</param>
+    /// <param name="d">Number of variables.</param>
+    /// <param name="learnedThreshold">Minimum learned influence required for an edge.</param>
+    /// <returns>Weighted adjacency matrix.</returns>
+    protected Matrix<T> BuildFinalAdjacency(double[,] learnedP, Matrix<T> cov, int d, double learnedThreshold)
+    {
+        var result = new Matrix<T>(d, d);
 
         for (int i = 0; i < d; i++)
             for (int j = 0; j < d; j++)
             {
                 if (i == j) continue;
 
-                // Only add edge if learned probability exceeds threshold
-                if (learnedP[i, j] < scaleAwareThreshold) continue;
+                // Only add edge if learned influence exceeds threshold
+                if (learnedP[i, j] < learnedThreshold) continue;
 
                 // Direction: edge i→j only if P[i,j] > P[j,i]
                 // For ties, only process the (i,j) pair where i < j to avoid 2-cycles.

--- a/src/ComputerVision/Segmentation/Efficient/RepViTSAM.cs
+++ b/src/ComputerVision/Segmentation/Efficient/RepViTSAM.cs
@@ -106,6 +106,20 @@ public partial class RepViTSAM<T> : Common.PromptableSegmentationBase<T>
     }
 
     /// <summary>
+    /// RepViTSAM's default training recipe, taken from its options rather than the base's generic one.
+    /// </summary>
+    /// <remarks>
+    /// Expressed by overriding the rate the base already exposes for this purpose -- "derived paper
+    /// implementations override this instead of reimplementing optimizer plumbing" -- so a caller
+    /// who passes their own optimizer still wins, and one who only wants a different rate can set
+    /// it on the options.
+    /// </remarks>
+    protected override double DefaultLearningRate => _options.LearningRate;
+
+    /// <inheritdoc cref="DefaultLearningRate"/>
+    protected override double DefaultWeightDecay => _options.WeightDecay;
+
+    /// <summary>
     /// Initializes RepViTSAM in ONNX (inference-only) mode.
     /// </summary>
     /// <param name="architecture">Neural network architecture defining input dimensions.</param>

--- a/src/ComputerVision/Segmentation/Efficient/RepViTSAM.cs
+++ b/src/ComputerVision/Segmentation/Efficient/RepViTSAM.cs
@@ -100,7 +100,7 @@ public partial class RepViTSAM<T> : Common.PromptableSegmentationBase<T>
         ApplySamDefaultGeometry(architecture);
         _dropRate = dropRate;
         _channelDims = [48, 96, 192, 384];
-        _depths = [2, 2, 14, 2];
+        _depths = [3, 4, 16, 3];
         _decoderDim = 256;
         InitializeLayers();
     }
@@ -143,7 +143,7 @@ public partial class RepViTSAM<T> : Common.PromptableSegmentationBase<T>
         ApplySamDefaultGeometry(architecture);
         _dropRate = 0;
         _channelDims = [48, 96, 192, 384];
-        _depths = [2, 2, 14, 2];
+        _depths = [3, 4, 16, 3];
         _decoderDim = 256;
         InitializeLayers();
     }

--- a/src/ComputerVision/Segmentation/Efficient/RepViTSAMOptions.cs
+++ b/src/ComputerVision/Segmentation/Efficient/RepViTSAMOptions.cs
@@ -32,22 +32,18 @@ public class RepViTSAMOptions : NeuralNetworkOptions
     /// </summary>
     /// <remarks>
     /// <para>
-    /// 1e-4 is the SAM-family fine-tuning rate, the same value SlimSAM carries in this repo.
-    /// RepViTSAM was silently inheriting the segmentation base's GENERIC 1e-3, ten times higher,
-    /// and at that rate its training invariants moved the wrong way: measured at runner parity, the
-    /// loss rose from 0.644082 to 0.650058 over ten iterations, worse than the untrained baseline,
-    /// with all 7,329,457 parameters finite. So the gradients were fine and the step size was not.
+    /// The RepViT reference training recipe uses AdamW with a 1e-3 learning rate. Keeping the
+    /// value in the options preserves caller configurability while making the default explicit.
     /// </para>
     /// <para>
-    /// <b>For Beginners:</b> The learning rate is how big a step training takes each time it
-    /// corrects the model. Too small and it learns slowly; too large and it steps past the answer
-    /// and can end up worse than where it started, which is exactly what was happening here.
+    /// <b>For Beginners:</b> The learning rate controls how large each training update is. This
+    /// default follows the reference recipe and can still be changed for a specific data set.
     /// </para>
     /// </remarks>
-    public double LearningRate { get; set; } = 1e-4;
+    public double LearningRate { get; set; } = 1e-3;
 
     /// <summary>
     /// The decoupled AdamW weight decay used when the caller supplies no optimizer.
     /// </summary>
-    public double WeightDecay { get; set; } = 0.01;
+    public double WeightDecay { get; set; } = 0.025;
 }

--- a/src/ComputerVision/Segmentation/Efficient/RepViTSAMOptions.cs
+++ b/src/ComputerVision/Segmentation/Efficient/RepViTSAMOptions.cs
@@ -1,4 +1,4 @@
-using AiDotNet.Models.Options;
+﻿using AiDotNet.Models.Options;
 
 namespace AiDotNet.ComputerVision.Segmentation.Efficient;
 
@@ -23,6 +23,31 @@ public class RepViTSAMOptions : NeuralNetworkOptions
 
         Seed = other.Seed;
         EncoderLayerCount = other.EncoderLayerCount;
+        LearningRate = other.LearningRate;
+        WeightDecay = other.WeightDecay;
     }
 
+    /// <summary>
+    /// The AdamW learning rate used when the caller supplies no optimizer.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// 1e-4 is the SAM-family fine-tuning rate, the same value SlimSAM carries in this repo.
+    /// RepViTSAM was silently inheriting the segmentation base's GENERIC 1e-3, ten times higher,
+    /// and at that rate its training invariants moved the wrong way: measured at runner parity, the
+    /// loss rose from 0.644082 to 0.650058 over ten iterations, worse than the untrained baseline,
+    /// with all 7,329,457 parameters finite. So the gradients were fine and the step size was not.
+    /// </para>
+    /// <para>
+    /// <b>For Beginners:</b> The learning rate is how big a step training takes each time it
+    /// corrects the model. Too small and it learns slowly; too large and it steps past the answer
+    /// and can end up worse than where it started, which is exactly what was happening here.
+    /// </para>
+    /// </remarks>
+    public double LearningRate { get; set; } = 1e-4;
+
+    /// <summary>
+    /// The decoupled AdamW weight decay used when the caller supplies no optimizer.
+    /// </summary>
+    public double WeightDecay { get; set; } = 0.01;
 }

--- a/src/Diffusion/DiffusionModelBase.cs
+++ b/src/Diffusion/DiffusionModelBase.cs
@@ -2373,9 +2373,9 @@ public abstract partial class DiffusionModelBase<T> : IDiffusionModel<T>, IConfi
     /// flat <c>GetParameters()</c> → <c>SetParameters()</c> round-trip that materializes the entire model a
     /// second time (and a giant intermediate flat vector) — the source of the large-diffusion-model Clone
     /// OOM on the 16 GB runner. The first in-place write to either side privatizes that tensor, so the clone
-    /// is observationally identical to the flat-copy clone. Fidelity is equivalent to the existing path
-    /// because both transfer exactly the model's trainable tensors (diffusion models carry no non-trainable
-    /// running statistics / serialization extras) — this just shares them rather than copying.
+    /// is observationally identical to the flat-copy clone. Before sharing, the helper verifies that
+    /// the layer tensors cover the model's complete registered parameter surface; a model with raw
+    /// non-layer parameter sources uses the existing parameter-chunk fallback instead.
     ///
     /// <para>Walks <paramref name="source"/> and <c>this</c> in parallel via reflection (identical type ⇒
     /// identical field order ⇒ matching layer order, the same assumption <see cref="CollectTrainableParameters"/>
@@ -2386,7 +2386,8 @@ public abstract partial class DiffusionModelBase<T> : IDiffusionModel<T>, IConfi
     /// </summary>
     protected bool TryShareParametersFrom(DiffusionModelBase<T> source)
     {
-        if (!AiDotNet.Helpers.CopyOnWriteCloneHelper.TryShareTrainableParameters<T>(source, this, out string mismatch))
+        if (!AiDotNet.Helpers.CopyOnWriteCloneHelper.TryShareTrainableParameters<T>(
+                source, this, out AiDotNet.Helpers.CopyOnWriteShareStatus status, out _))
         {
             // NOTHING MATERIALIZED IS NOT A MISMATCH. The share walks both graphs and declines when
             // the trainable-layer structures do not line up, and a model whose lazy layers have not
@@ -2401,23 +2402,12 @@ public abstract partial class DiffusionModelBase<T> : IDiffusionModel<T>, IConfi
             // Measured in a 16 GB runner-parity container: 28 minutes, then OutOfMemoryException in
             // TensorBase..ctor under DenseLayer.EnsureInitialized, which reaches CI as the whole
             // test host dying with no test name attached.
-            if (!IsVacuousShare(mismatch)) return false;
+            if (status != AiDotNet.Helpers.CopyOnWriteShareStatus.BothGraphsEmpty) return false;
         }
 
         InvalidateTrainableParametersCache();
         return true;
     }
-
-    /// <summary>
-    /// Whether a declined share was declined only because neither side has materialized anything.
-    /// </summary>
-    /// <remarks>
-    /// Matched on the reported counts rather than assumed: any OTHER decline (a real structural
-    /// difference, differing model types) must still fall back to the copying path, because there
-    /// the destination genuinely needs state it does not have.
-    /// </remarks>
-    private static bool IsVacuousShare(string mismatch)
-        => mismatch.StartsWith("trainable layer counts differ (0 vs 0)", StringComparison.Ordinal);
 
     /// <summary>
     /// Flattens gradient tensors into a single vector matching GetParameters() layout.

--- a/src/Diffusion/DiffusionModelBase.cs
+++ b/src/Diffusion/DiffusionModelBase.cs
@@ -1,4 +1,4 @@
-using System.Linq;
+﻿using System.Linq;
 using AiDotNet.Autodiff;
 using AiDotNet.Deployment.Optimization.Quantization;
 using AiDotNet.Deployment.Optimization.Quantization.Training;
@@ -2386,11 +2386,38 @@ public abstract partial class DiffusionModelBase<T> : IDiffusionModel<T>, IConfi
     /// </summary>
     protected bool TryShareParametersFrom(DiffusionModelBase<T> source)
     {
-        if (!AiDotNet.Helpers.CopyOnWriteCloneHelper.TryShareTrainableParameters<T>(source, this))
-            return false;
+        if (!AiDotNet.Helpers.CopyOnWriteCloneHelper.TryShareTrainableParameters<T>(source, this, out string mismatch))
+        {
+            // NOTHING MATERIALIZED IS NOT A MISMATCH. The share walks both graphs and declines when
+            // the trainable-layer structures do not line up, and a model whose lazy layers have not
+            // been resolved presents ZERO layers on both sides. That is a vacuous share, not a
+            // failed one: the freshly constructed destination is already structurally identical to
+            // an unmaterialized source, and there is no state to move.
+            //
+            // Treating it as a failure is what made WanVideo unclonable. The fallback copies
+            // parameter chunks, and enumerating those calls EnsureOwnParametersMaterialized on the
+            // way past, so a model that had allocated NOTHING was forced to allocate everything --
+            // ~15.2 billion parameters, about 61 GB at float, to clone a model that was empty.
+            // Measured in a 16 GB runner-parity container: 28 minutes, then OutOfMemoryException in
+            // TensorBase..ctor under DenseLayer.EnsureInitialized, which reaches CI as the whole
+            // test host dying with no test name attached.
+            if (!IsVacuousShare(mismatch)) return false;
+        }
+
         InvalidateTrainableParametersCache();
         return true;
     }
+
+    /// <summary>
+    /// Whether a declined share was declined only because neither side has materialized anything.
+    /// </summary>
+    /// <remarks>
+    /// Matched on the reported counts rather than assumed: any OTHER decline (a real structural
+    /// difference, differing model types) must still fall back to the copying path, because there
+    /// the destination genuinely needs state it does not have.
+    /// </remarks>
+    private static bool IsVacuousShare(string mismatch)
+        => mismatch.StartsWith("trainable layer counts differ (0 vs 0)", StringComparison.Ordinal);
 
     /// <summary>
     /// Flattens gradient tensors into a single vector matching GetParameters() layout.

--- a/src/Diffusion/NoisePredictors/NoisePredictorBase.cs
+++ b/src/Diffusion/NoisePredictors/NoisePredictorBase.cs
@@ -1824,11 +1824,14 @@ public abstract partial class NoisePredictorBase<T> : INoisePredictor<T>, IModel
     /// structure doesn't line up 1:1, so the caller falls back to the eager flat copy.
     /// </summary>
     protected bool TryShareParametersFrom(NoisePredictorBase<T> source)
-        => AiDotNet.Helpers.CopyOnWriteCloneHelper.TryShareTrainableParameters<T>(source, this);
+        => TryShareParametersFrom(source, out _);
 
     private bool TryShareParametersFrom(NoisePredictorBase<T> source, out string mismatch)
-        => AiDotNet.Helpers.CopyOnWriteCloneHelper.TryShareTrainableParameters<T>(
-            source, this, out mismatch);
+    {
+        bool shared = AiDotNet.Helpers.CopyOnWriteCloneHelper.TryShareTrainableParameters<T>(
+            source, this, out AiDotNet.Helpers.CopyOnWriteShareStatus status, out mismatch);
+        return shared || status == AiDotNet.Helpers.CopyOnWriteShareStatus.BothGraphsEmpty;
+    }
 
     /// <inheritdoc />
     public virtual IFullModel<T, Tensor<T>, Tensor<T>> WithParameters(Vector<T> parameters)

--- a/src/Diffusion/VAE/VAEModelBase.cs
+++ b/src/Diffusion/VAE/VAEModelBase.cs
@@ -501,7 +501,11 @@ public abstract partial class VAEModelBase<T> : IVAEModel<T>, IModelShape,
     /// eager flat copy.
     /// </summary>
     protected bool TryShareParametersFrom(VAEModelBase<T> source)
-        => AiDotNet.Helpers.CopyOnWriteCloneHelper.TryShareTrainableParameters<T>(source, this);
+    {
+        bool shared = AiDotNet.Helpers.CopyOnWriteCloneHelper.TryShareTrainableParameters<T>(
+            source, this, out AiDotNet.Helpers.CopyOnWriteShareStatus status, out _);
+        return shared || status == AiDotNet.Helpers.CopyOnWriteShareStatus.BothGraphsEmpty;
+    }
 
     /// <inheritdoc />
     public virtual IFullModel<T, Tensor<T>, Tensor<T>> WithParameters(Vector<T> parameters)

--- a/src/Helpers/CopyOnWriteCloneHelper.cs
+++ b/src/Helpers/CopyOnWriteCloneHelper.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
@@ -8,6 +8,17 @@ using AiDotNet.NeuralNetworks;
 using AiDotNet.Training;
 
 namespace AiDotNet.Helpers;
+
+/// <summary>Structured outcome for a copy-on-write parameter-share attempt.</summary>
+internal enum CopyOnWriteShareStatus
+{
+    Shared,
+    BothGraphsEmpty,
+    InvalidArguments,
+    TypeMismatch,
+    StructureMismatch,
+    IncompleteCoverage
+}
 
 /// <summary>
 /// Copy-on-write clone lever (#1624): shares a model's trainable weight tensors with its clone via the
@@ -37,29 +48,55 @@ internal static class CopyOnWriteCloneHelper
     internal static bool TryShareTrainableParameters<T>(
         IFullModel<T, Tensor<T>, Tensor<T>>? source,
         IFullModel<T, Tensor<T>, Tensor<T>>? dest)
-        => TryShareTrainableParameters(source, dest, out _);
+        => TryShareTrainableParameters(source, dest, out _, out _);
 
     /// <summary>Attempts the complete state share and reports the first preflight mismatch.</summary>
     internal static bool TryShareTrainableParameters<T>(
         IFullModel<T, Tensor<T>, Tensor<T>>? source,
         IFullModel<T, Tensor<T>, Tensor<T>>? dest,
         out string mismatch)
+        => TryShareTrainableParameters(source, dest, out _, out mismatch);
+
+    /// <summary>Attempts the complete state share and reports a stable outcome plus diagnostic detail.</summary>
+    internal static bool TryShareTrainableParameters<T>(
+        IFullModel<T, Tensor<T>, Tensor<T>>? source,
+        IFullModel<T, Tensor<T>, Tensor<T>>? dest,
+        out CopyOnWriteShareStatus status,
+        out string mismatch)
     {
+        status = CopyOnWriteShareStatus.StructureMismatch;
         mismatch = string.Empty;
         if (source is null || dest is null || ReferenceEquals(source, dest))
         {
+            status = CopyOnWriteShareStatus.InvalidArguments;
             mismatch = "source and destination must be distinct non-null models";
             return false;
         }
         if (source.GetType() != dest.GetType())
         {
+            status = CopyOnWriteShareStatus.TypeMismatch;
             mismatch = $"model types differ ({source.GetType().Name} vs {dest.GetType().Name})";
             return false;
         }
 
         var srcLayers = CollectTrainableLayers<T>(source);
         var dstLayers = CollectTrainableLayers<T>(dest);
-        if (srcLayers.Count == 0 || srcLayers.Count != dstLayers.Count)
+        if (srcLayers.Count == 0 && dstLayers.Count == 0)
+        {
+            mismatch = $"trainable layer counts differ ({srcLayers.Count} vs {dstLayers.Count})";
+            if (source is AiDotNet.Models.Parameters.IParameterManifestProvider emptyManifest
+                && emptyManifest.ParameterLayout.MaterializedParameterCount != 0)
+            {
+                status = CopyOnWriteShareStatus.IncompleteCoverage;
+                mismatch += $"; registered parameter surface contains "
+                            + $"{emptyManifest.ParameterLayout.MaterializedParameterCount} materialized values";
+                return false;
+            }
+
+            status = CopyOnWriteShareStatus.BothGraphsEmpty;
+            return false;
+        }
+        if (srcLayers.Count != dstLayers.Count)
         {
             mismatch = $"trainable layer counts differ ({srcLayers.Count} vs {dstLayers.Count})";
             return false;
@@ -132,6 +169,44 @@ internal static class CopyOnWriteCloneHelper
             }
         }
 
+        // A model-level parameter registry may include sources that are not layers. The reflective
+        // layer walk cannot share those matrices/vectors, so reject the COW path when the manifest
+        // proves that its live surface is wider than the trainable tensors and persistent buffers
+        // about to be rebound. Some legacy aggregate manifests expose one
+        // ShapeResolvedUnmaterialized slot for a mixed live/deferred graph; their
+        // MaterializedParameterCount is zero even when live layer state exists, so a smaller
+        // manifest total is not evidence of missing coverage and must not reject a valid share.
+        if (source is AiDotNet.Models.Parameters.IParameterManifestProvider manifestProvider)
+        {
+            long covered = 0;
+            for (int i = 0; i < srcLayers.Count; i++)
+            {
+                if (srcLayers[i] is AiDotNet.NeuralNetworks.Layers.LayerBase<T> layerBase)
+                {
+                    var stateSlots = layerBase.GetOwnParameterStateValueSlots();
+                    if (stateSlots.Count > 0)
+                    {
+                        foreach (var slot in stateSlots)
+                            covered = checked(covered + slot.ScalarCount);
+                        continue;
+                    }
+                }
+
+                // Legacy/non-LayerBase trainables have no declared checkpoint-state slots.
+                foreach (Tensor<T> tensor in GetAuthoritativeSourceValues(srcLayers[i]))
+                    covered = checked(covered + tensor.Length);
+            }
+
+            long registered = manifestProvider.ParameterLayout.MaterializedParameterCount;
+            if (registered > covered)
+            {
+                status = CopyOnWriteShareStatus.IncompleteCoverage;
+                mismatch = $"registered layer state covers {covered} parameters, but the registered "
+                           + $"parameter surface proves at least {registered} materialized values";
+                return false;
+            }
+        }
+
         // The parameter-state contract is wider than the optimizer view: registered buffers carry
         // running statistics, learned non-gradient state, and shape-bearing constants. Validate the
         // complete buffer graph before sharing any trainable tensor; otherwise the helper can return
@@ -198,6 +273,7 @@ internal static class CopyOnWriteCloneHelper
                 destinationBase.AdoptRegisteredBuffersFrom(sourceBase);
         }
 
+        status = CopyOnWriteShareStatus.Shared;
         return true;
     }
 

--- a/src/Helpers/LayerHelper.cs
+++ b/src/Helpers/LayerHelper.cs
@@ -30706,27 +30706,30 @@ public static partial class LayerHelper<T>
         int inputChannels, int inputHeight, int inputWidth,
         int[] channelDims, int[] depths, double dropRate)
     {
-        var relu = new ReLUActivation<T>() as IActivationFunction<T>;
-        int h = inputHeight, w = inputWidth, inC = inputChannels;
+        var identity = (IActivationFunction<T>)new IdentityActivation<T>();
+        var gelu = (IActivationFunction<T>)new GELUActivation<T>();
 
+        // RepViT's patch embedding is two 3x3 stride-2 Conv-BN layers with GELU
+        // between them, not a 7x7 stride-4 ReLU convolution.
+        int stemChannels = System.Math.Max(1, channelDims[0] / 2);
+        yield return new ConvolutionalLayer<T>(stemChannels, 3, 2, 1, identity);
+        yield return new BatchNormalizationLayer<T>(stemChannels) { Layout = BatchNormDataLayout.ChannelsFirst };
+        yield return new ActivationLayer<T>(gelu);
+        yield return new ConvolutionalLayer<T>(channelDims[0], 3, 2, 1, identity);
+        yield return new BatchNormalizationLayer<T>(channelDims[0]) { Layout = BatchNormDataLayout.ChannelsFirst };
+        int inC = channelDims[0];
         for (int stage = 0; stage < channelDims.Length; stage++)
         {
             int outC = channelDims[stage];
-            int stride = stage == 0 ? 4 : 2;
-            int kernel = stage == 0 ? 7 : 3;
-            int pad = stage == 0 ? 3 : 1;
-
-            yield return new ConvolutionalLayer<T>(outC, kernel, stride, pad, relu);
-            h /= stride; w /= stride;
-            yield return new BatchNormalizationLayer<T>();
-
-            for (int d = 1; d < depths[stage]; d++)
+            for (int d = 0; d < depths[stage]; d++)
             {
-                yield return new ConvolutionalLayer<T>(outC, 3, 1, 1, relu);
-                yield return new BatchNormalizationLayer<T>();
+                int stride = stage > 0 && d == 0 ? 2 : 1;
+                bool useSE = stage == 0
+                    ? d == 0
+                    : d > 0 && d < depths[stage] - 1 && d % 2 == 1;
+                yield return new RepViTBlockLayer<T>(inC, outC, stride, useSE);
+                inC = outC;
             }
-
-            inC = outC;
         }
     }
 

--- a/src/Helpers/LayerHelper.cs
+++ b/src/Helpers/LayerHelper.cs
@@ -1791,7 +1791,6 @@ public static partial class LayerHelper<T>
         // and the controller's own previous hidden state. Graves et al. 2016 use a RECURRENT
         // controller, and its recurrence is what lets the DNC hold working state across a sequence's
         // timesteps alongside the external memory.
-        int controllerInputSize = inputSize + readHeads * memoryWordSize + controllerSize;
 
         // LSTM gate pre-activations, [i | f | g | o], four blocks of controllerSize.
         //
@@ -1819,7 +1818,6 @@ public static partial class LayerHelper<T>
         // back to controllerOutput, so the controller layers never received gradients.
         // ProcessThroughController walks Layers[0..N-2]; CombineControllerOutputWithReadVectors
         // calls Layers[N-1].Forward(combinedTensor) for this final projection.
-        int outputProjectionInputSize = controllerSize + readHeads * memoryWordSize;
         yield return new DenseLayer<T>(outputSize, new IdentityActivation<T>() as IActivationFunction<T>);
     }
 

--- a/src/NeuralNetworks/Layers/RepViTBlockLayer.cs
+++ b/src/NeuralNetworks/Layers/RepViTBlockLayer.cs
@@ -6,11 +6,19 @@ namespace AiDotNet.NeuralNetworks.Layers;
 /// <summary>
 /// Implements the token mixer and channel mixer from a RepViT block.
 /// </summary>
+/// <typeparam name="T">The numeric type used by tensors and trainable parameters.</typeparam>
 /// <remarks>
+/// <para>
 /// The training graph follows the authors' reference implementation: a re-parameterizable
 /// depthwise token mixer, optional squeeze-and-excitation, then a residual two-layer pointwise
 /// channel mixer with GELU. Re-parameterization is an inference optimization and does not change
 /// the training graph represented here.
+/// </para>
+/// <para><b>For Beginners:</b> This layer first mixes nearby image pixels and then mixes feature
+/// channels. The residual path preserves the input features while the new transformations learn.
+/// </para>
+/// <para><b>Reference:</b> Ao Wang et al., <i>RepViT: Revisiting Mobile CNN From ViT Perspective</i>,
+/// 2023, <see href="https://arxiv.org/abs/2307.09283">arXiv:2307.09283</see>.</para>
 /// </remarks>
 [LayerCategory(LayerCategory.Convolution)]
 [LayerCategory(LayerCategory.Residual)]

--- a/src/NeuralNetworks/Layers/RepViTBlockLayer.cs
+++ b/src/NeuralNetworks/Layers/RepViTBlockLayer.cs
@@ -1,0 +1,307 @@
+using AiDotNet.Attributes;
+using AiDotNet.Interfaces;
+
+namespace AiDotNet.NeuralNetworks.Layers;
+
+/// <summary>
+/// Implements the token mixer and channel mixer from a RepViT block.
+/// </summary>
+/// <remarks>
+/// The training graph follows the authors' reference implementation: a re-parameterizable
+/// depthwise token mixer, optional squeeze-and-excitation, then a residual two-layer pointwise
+/// channel mixer with GELU. Re-parameterization is an inference optimization and does not change
+/// the training graph represented here.
+/// </remarks>
+[LayerCategory(LayerCategory.Convolution)]
+[LayerCategory(LayerCategory.Residual)]
+[LayerTask(LayerTask.FeatureExtraction)]
+[LayerTask(LayerTask.SpatialProcessing)]
+[LayerProperty(IsTrainable = true, ChangesShape = true, ExpectedInputRank = 4,
+    Cost = ComputeCost.Medium, TestInputShape = "1, 4, 8, 8", TestConstructorArgs = "4, 4")]
+[TensorLayout(TensorAxis.Batch, TensorAxis.Channels, TensorAxis.Height, TensorAxis.Width,
+    BatchOptional = true, Direction = TensorLayoutDirection.Input)]
+[TensorLayout(TensorAxis.Batch, TensorAxis.Channels, TensorAxis.Height, TensorAxis.Width,
+    BatchOptional = true, Direction = TensorLayoutDirection.Output)]
+[AutoParameters]
+public sealed partial class RepViTBlockLayer<T> : LayerBase<T>, IShapeContract
+{
+    private readonly int _inChannels;
+    private readonly int _outChannels;
+    private readonly int _stride;
+    private readonly bool _useSE;
+
+    private readonly ConvolutionalLayer<T> _tokenDepthwise;
+    private readonly BatchNormalizationLayer<T> _tokenDepthwiseBn;
+    private readonly ConvolutionalLayer<T>? _tokenReparamPointwise;
+    private readonly BatchNormalizationLayer<T>? _tokenReparamBn;
+    private readonly ConvolutionalLayer<T>? _tokenProjection;
+    private readonly BatchNormalizationLayer<T>? _tokenProjectionBn;
+    private readonly SqueezeAndExcitationLayer<T>? _se;
+    private readonly ConvolutionalLayer<T> _channelExpand;
+    private readonly BatchNormalizationLayer<T> _channelExpandBn;
+    private readonly ActivationLayer<T> _gelu;
+    private readonly ConvolutionalLayer<T> _channelProject;
+    private readonly BatchNormalizationLayer<T> _channelProjectBn;
+
+    /// <summary>Creates one RepViT block for known input and output channel widths.</summary>
+    public RepViTBlockLayer(
+        [LayerState] int inChannels,
+        [LayerState] int outChannels,
+        [LayerState] int stride = 1,
+        [LayerState] bool useSE = false)
+        : base([inChannels, -1, -1], [outChannels, -1, -1])
+    {
+        if (inChannels <= 0) throw new ArgumentOutOfRangeException(nameof(inChannels));
+        if (outChannels <= 0) throw new ArgumentOutOfRangeException(nameof(outChannels));
+        if (stride is not (1 or 2))
+            throw new ArgumentOutOfRangeException(nameof(stride), stride, "RepViT stride must be 1 or 2.");
+        if (stride == 1 && inChannels != outChannels)
+            throw new ArgumentException("A stride-1 RepViT block requires matching input and output channels.");
+
+        _inChannels = inChannels;
+        _outChannels = outChannels;
+        _stride = stride;
+        _useSE = useSE;
+
+        var identity = (IActivationFunction<T>)new IdentityActivation<T>();
+        _tokenDepthwise = new ConvolutionalLayer<T>(
+            inChannels, 3, stride, 1, identity, groups: inChannels);
+        _tokenDepthwiseBn = CreateChannelsFirstBatchNorm(inChannels);
+
+        if (stride == 1)
+        {
+            // RepVGGDW training form: Conv3x3-BN + Conv1x1 + identity, followed by BN.
+            _tokenReparamPointwise = new ConvolutionalLayer<T>(
+                inChannels, 1, 1, 0, identity, groups: inChannels);
+            _tokenReparamBn = CreateChannelsFirstBatchNorm(inChannels);
+        }
+        else
+        {
+            // Downsampling token mixer projects channels only after its depthwise spatial step.
+            _tokenProjection = new ConvolutionalLayer<T>(outChannels, 1, 1, 0, identity);
+            _tokenProjectionBn = CreateChannelsFirstBatchNorm(outChannels);
+        }
+
+        _se = useSE
+            ? new SqueezeAndExcitationLayer<T>(
+                inChannels, GetSEReductionRatio(inChannels), firstActivation: (IActivationFunction<T>?)null)
+            : null;
+
+        _channelExpand = new ConvolutionalLayer<T>(outChannels * 2, 1, 1, 0, identity);
+        _channelExpandBn = CreateChannelsFirstBatchNorm(outChannels * 2);
+        _gelu = new ActivationLayer<T>((IActivationFunction<T>)new GELUActivation<T>());
+        _channelProject = new ConvolutionalLayer<T>(outChannels, 1, 1, 0, identity);
+        _channelProjectBn = CreateChannelsFirstBatchNorm(outChannels);
+
+        // The reference initializes the final channel-mixer BN scale to zero, making this
+        // residual branch an exact identity at construction while preserving every other BN state.
+        _channelProjectBn.ZeroInitGamma();
+
+        foreach (var layer in EnumerateAllLayers()) RegisterSubLayer(layer);
+    }
+
+    /// <inheritdoc />
+    public override bool SupportsTraining => true;
+
+    /// <inheritdoc />
+    public IReadOnlyList<OutputAxisContract>? OutputAxesFor(int inputRank)
+    {
+        var channels = new OutputAxisContract(TensorAxis.Channels, AxisRelation.Fixed(_outChannels));
+        var height = new OutputAxisContract(
+            TensorAxis.Height,
+            AxisRelation.Window(TensorAxis.Height, kernel: 3, stride: _stride, padding: 1));
+        var width = new OutputAxisContract(
+            TensorAxis.Width,
+            AxisRelation.Window(TensorAxis.Width, kernel: 3, stride: _stride, padding: 1));
+
+        return inputRank switch
+        {
+            3 => [channels, height, width],
+            4 =>
+            [
+                new OutputAxisContract(TensorAxis.Batch, AxisRelation.Same(TensorAxis.Batch)),
+                channels,
+                height,
+                width
+            ],
+            _ => null
+        };
+    }
+
+    /// <inheritdoc />
+    protected override void OnFirstForward(Tensor<T> input)
+    {
+        int channelAxis;
+        int heightAxis;
+        int widthAxis;
+        if (input.Rank == 3)
+        {
+            channelAxis = 0;
+            heightAxis = 1;
+            widthAxis = 2;
+        }
+        else if (input.Rank == 4)
+        {
+            channelAxis = 1;
+            heightAxis = 2;
+            widthAxis = 3;
+        }
+        else
+        {
+            throw new ArgumentException(
+                $"RepViT block requires rank-3 [C,H,W] or rank-4 [B,C,H,W] input; got rank {input.Rank}.",
+                nameof(input));
+        }
+
+        if (input.Shape[channelAxis] != _inChannels)
+        {
+            throw new ArgumentException(
+                $"RepViT block expected {_inChannels} input channels, got {input.Shape[channelAxis]}.",
+                nameof(input));
+        }
+
+        int inputHeight = input.Shape[heightAxis];
+        int inputWidth = input.Shape[widthAxis];
+        int outputHeight = (inputHeight - 1) / _stride + 1;
+        int outputWidth = (inputWidth - 1) / _stride + 1;
+        ResolveShapes(
+            [_inChannels, inputHeight, inputWidth],
+            [_outChannels, outputHeight, outputWidth]);
+    }
+
+    /// <inheritdoc />
+    protected override Tensor<T> ForwardTraced(Tensor<T> input)
+    {
+        bool unbatched = input.Rank == 3;
+        var x = unbatched
+            ? Engine.Reshape(input, [1, input.Shape[0], input.Shape[1], input.Shape[2]])
+            : input;
+        if (x.Rank != 4 || x.Shape[1] != _inChannels)
+            throw new ArgumentException($"RepViT block expects [B,{_inChannels},H,W].", nameof(input));
+
+        var token = _tokenDepthwiseBn.Forward(_tokenDepthwise.Forward(x));
+        if (_stride == 1)
+        {
+            var pointwise = _tokenReparamPointwise
+                ?? throw new InvalidOperationException("Stride-1 token mixer was not initialized.");
+            var outputBn = _tokenReparamBn
+                ?? throw new InvalidOperationException("Stride-1 token mixer BN was not initialized.");
+            token = outputBn.Forward(Engine.TensorAdd(Engine.TensorAdd(token, pointwise.Forward(x)), x));
+            token = ApplySqueezeExcitation(token);
+        }
+        else
+        {
+            var projection = _tokenProjection
+                ?? throw new InvalidOperationException("Downsampling token projection was not initialized.");
+            var projectionBn = _tokenProjectionBn
+                ?? throw new InvalidOperationException("Downsampling token projection BN was not initialized.");
+            token = ApplySqueezeExcitation(token);
+            token = projectionBn.Forward(projection.Forward(token));
+        }
+
+        var channel = _channelExpandBn.Forward(_channelExpand.Forward(token));
+        channel = _gelu.Forward(channel);
+        channel = _channelProjectBn.Forward(_channelProject.Forward(channel));
+        var output = Engine.TensorAdd(token, channel);
+
+        if (!IsShapeResolved)
+            ResolveShapes(
+                [_inChannels, x.Shape[2], x.Shape[3]],
+                [_outChannels, output.Shape[2], output.Shape[3]]);
+
+        return unbatched
+            ? Engine.Reshape(output, [output.Shape[1], output.Shape[2], output.Shape[3]])
+            : output;
+    }
+
+    private Tensor<T> ApplySqueezeExcitation(Tensor<T> input)
+    {
+        if (_se is null) return input;
+
+        var channelsLast = Engine.TensorPermute(input, [0, 2, 3, 1]);
+        return Engine.TensorPermute(_se.Forward(channelsLast), [0, 3, 1, 2]);
+    }
+
+    /// <inheritdoc />
+    public override Vector<T> GetParameterGradients() => Concatenate(EnumerateParameterLayers(), gradients: true);
+
+    /// <inheritdoc />
+    public override void UpdateParameters(T learningRate)
+    {
+        foreach (var layer in EnumerateParameterLayers()) layer.UpdateParameters(learningRate);
+    }
+
+    /// <inheritdoc />
+    public override void ClearGradients()
+    {
+        base.ClearGradients();
+        foreach (var layer in EnumerateParameterLayers()) layer.ClearGradients();
+    }
+
+    /// <inheritdoc />
+    public override void ResetState()
+    {
+        foreach (var layer in EnumerateAllLayers()) layer.ResetState();
+    }
+
+    internal override Dictionary<string, string> GetMetadata()
+    {
+        var metadata = base.GetMetadata();
+        metadata["InChannels"] = _inChannels.ToString();
+        metadata["OutChannels"] = _outChannels.ToString();
+        metadata["Stride"] = _stride.ToString();
+        metadata["UseSE"] = _useSE.ToString();
+        return metadata;
+    }
+
+    private static BatchNormalizationLayer<T> CreateChannelsFirstBatchNorm(int channels)
+    {
+        return new BatchNormalizationLayer<T>(channels)
+        {
+            Layout = BatchNormDataLayout.ChannelsFirst
+        };
+    }
+
+    private static int GetSEReductionRatio(int channels)
+    {
+        // timm's SqueezeExcite rounds rd_ratio=0.25 to a multiple of eight. RepViT-M0.9's
+        // 48-channel stage therefore uses 16 reduced channels (ratio 3), not 12 (ratio 4).
+        int reducedChannels = Math.Max(8, (int)(channels * 0.25 + 4) / 8 * 8);
+        if (reducedChannels < 0.9 * channels * 0.25) reducedChannels += 8;
+        if (channels % reducedChannels != 0)
+            throw new ArgumentException("RepViT SE width must divide the block channel width.", nameof(channels));
+        return channels / reducedChannels;
+    }
+
+    private IEnumerable<LayerBase<T>> EnumerateParameterLayers()
+    {
+        yield return _tokenDepthwise;
+        yield return _tokenDepthwiseBn;
+        if (_tokenReparamPointwise is not null) yield return _tokenReparamPointwise;
+        if (_tokenReparamBn is not null) yield return _tokenReparamBn;
+        if (_tokenProjection is not null) yield return _tokenProjection;
+        if (_tokenProjectionBn is not null) yield return _tokenProjectionBn;
+        if (_se is not null) yield return _se;
+        yield return _channelExpand;
+        yield return _channelExpandBn;
+        yield return _channelProject;
+        yield return _channelProjectBn;
+    }
+
+    private IEnumerable<LayerBase<T>> EnumerateAllLayers()
+    {
+        foreach (var layer in EnumerateParameterLayers()) yield return layer;
+        yield return _gelu;
+    }
+
+    private static Vector<T> Concatenate(IEnumerable<LayerBase<T>> layers, bool gradients)
+    {
+        var values = new List<T>();
+        foreach (var layer in layers)
+        {
+            var vector = gradients ? layer.GetParameterGradients() : layer.GetParameters();
+            for (int i = 0; i < vector.Length; i++) values.Add(vector[i]);
+        }
+        return new Vector<T>(values.ToArray());
+    }
+}

--- a/src/NeuralNetworks/NeuralNetworkBase.cs
+++ b/src/NeuralNetworks/NeuralNetworkBase.cs
@@ -75,6 +75,17 @@ public abstract partial class NeuralNetworkBase<T> : INeuralNetworkModel<T>, IIn
         RegisterGeneratedStateCore(state);
     }
 
+    /// <summary>
+    /// Runs after generated/model-declared mutable constructor configuration has been restored.
+    /// </summary>
+    /// <remarks>
+    /// Derived models use this to rebuild objects derived from restored options. It is invoked by
+    /// external deserialization and every shared clone path after the state envelope is applied.
+    /// </remarks>
+    protected virtual void OnMutableConstructorConfigurationRestored()
+    {
+    }
+
     /// <summary>The declared state, registered once and lazily so it runs after the constructor.</summary>
     protected AiDotNet.Models.ModelStateRegistry<T> DeclaredState
     {
@@ -12077,7 +12088,8 @@ public abstract partial class NeuralNetworkBase<T> : INeuralNetworkModel<T>, IIn
                     // context. Still recorded rather than swallowed silently -- an invisible
                     // failure here shows up later as an unexplained fused miss. Same channel the
                     // GPU-forward fallbacks in this class already use.
-                    System.Diagnostics.Debug.WriteLine(
+                    AiDotNet.Configuration.GpuDiagnosticsConfig.Emit(
+                        AiDotNet.Configuration.GpuDiagnosticLevel.Minimal,
                         $"[NeuralNetworkBase] shape-resolution warm-up forward failed ({ex.GetType().Name}): {ex.Message}");
                 }
                 finally
@@ -14139,6 +14151,7 @@ public abstract partial class NeuralNetworkBase<T> : INeuralNetworkModel<T>, IIn
         byte[] inner = AiDotNet.Models.ModelStateEnvelope.ExtractBeforeParameters(DeclaredState, data);
         DeserializeInternalUnchecked(inner);
         _ = AiDotNet.Models.ModelStateEnvelope.ExtractAfterParameters(DeclaredState, declaredStateEnvelope);
+        OnMutableConstructorConfigurationRestored();
         InvalidateWeightCachesAfterSuccessfulWeightUpdate();
     }
 
@@ -15304,6 +15317,7 @@ public abstract partial class NeuralNetworkBase<T> : INeuralNetworkModel<T>, IIn
             }
             CopyGeneratedLayerAliasesTo(copyBase);
             _ = ModelStateEnvelope.ExtractAfterParameters(copyBase.DeclaredState, serialized);
+            copyBase.OnMutableConstructorConfigurationRestored();
             CopyGeneratedTrainableTensorsTo(copyBase);
             CopyCloneRuntimeConfigurationTo(copyBase);
             // Base LayerBase.Serialize does NOT persist the per-layer RandomSeed, so the
@@ -16168,6 +16182,7 @@ public abstract partial class NeuralNetworkBase<T> : INeuralNetworkModel<T>, IIn
         byte[] inner = ModelStateEnvelope.ExtractAfterParameters(destination.DeclaredState, envelope);
         if (inner.Length != 0)
             throw new InvalidOperationException("Declared-state clone envelope retained an unexpected payload.");
+        destination.OnMutableConstructorConfigurationRestored();
     }
 
     // Set only while an internal eager clone is deserializing. Some architecture objects retain

--- a/src/NeuralNetworks/NeuralNetworkBase.cs
+++ b/src/NeuralNetworks/NeuralNetworkBase.cs
@@ -1,4 +1,4 @@
-#pragma warning disable CS0649, CS0414, CS0169
+﻿#pragma warning disable CS0649, CS0414, CS0169
 using AiDotNet.Autodiff;
 using AiDotNet.Interfaces;
 using AiDotNet.Interpretability;
@@ -12070,10 +12070,15 @@ public abstract partial class NeuralNetworkBase<T> : INeuralNetworkModel<T>, IIn
                 {
                     ForwardForTraining(input);
                 }
-                catch
+                catch (Exception ex)
                 {
-                    // Best effort only. The compiled training forward below will surface
-                    // the original model error with its full context.
+                    // Best effort only: this pass exists to resolve shapes, and the compiled
+                    // training forward below surfaces the original model error with its full
+                    // context. Still recorded rather than swallowed silently -- an invisible
+                    // failure here shows up later as an unexplained fused miss. Same channel the
+                    // GPU-forward fallbacks in this class already use.
+                    System.Diagnostics.Debug.WriteLine(
+                        $"[NeuralNetworkBase] shape-resolution warm-up forward failed ({ex.GetType().Name}): {ex.Message}");
                 }
                 finally
                 {

--- a/src/Optimizers/CMAESOptimizer.cs
+++ b/src/Optimizers/CMAESOptimizer.cs
@@ -1,4 +1,4 @@
-using System.Linq;
+﻿using System.Linq;
 using AiDotNet.Helpers;
 using AiDotNet.Extensions;
 using Newtonsoft.Json;
@@ -431,7 +431,7 @@ public partial class CMAESOptimizer<T, TInput, TOutput> : OptimizerBase<T, TInpu
             NumOps.Divide(
                 NumOps.Divide(
                     _ps.Norm(),
-                    NumOps.Sqrt(NumOps.Subtract(NumOps.One, NumOps.Power(NumOps.Subtract(NumOps.One, cs), NumOps.FromDouble(2 * _options.MaxGenerations))))
+                    NumOps.Sqrt(NumOps.Subtract(NumOps.One, NumOps.Power(NumOps.Subtract(NumOps.One, cs), NumOps.FromDouble(2.0 * _options.MaxGenerations))))
                 ),
                 chiN
             ),

--- a/src/Serialization/LayerStateBag.cs
+++ b/src/Serialization/LayerStateBag.cs
@@ -1,5 +1,6 @@
 ﻿using System.Globalization;
 using System.Collections;
+using System.Collections.Concurrent;
 using System.Reflection;
 
 namespace AiDotNet.Serialization;
@@ -1195,29 +1196,16 @@ public readonly struct LayerStateBag
     /// </remarks>
     private static string CaptureComponentConfiguration(object value, Type type)
     {
-        var names = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-        foreach (ConstructorInfo constructor in type.GetConstructors())
-        {
-            foreach (ParameterInfo parameter in constructor.GetParameters())
-            {
-                if (parameter.Name is { Length: > 0 } name && IsCapturableConfigurationType(parameter.ParameterType))
-                    names.Add(name);
-            }
-        }
-        if (names.Count == 0) return string.Empty;
+        ConfigurationSlot[] plan = ConfigurationPlans.GetOrAdd(type, BuildConfigurationPlan);
+        if (plan.Length == 0) return string.Empty;
 
-        var recorded = new List<string>();
-        foreach (string name in names.OrderBy(n => n, StringComparer.Ordinal))
+        List<string>? recorded = null;
+        foreach (ConfigurationSlot slot in plan)
         {
-            PropertyInfo? property = type.GetProperty(
-                name,
-                BindingFlags.Public | BindingFlags.Instance | BindingFlags.IgnoreCase);
-            if (property is null || !property.CanRead || property.GetIndexParameters().Length > 0) continue;
-
             object? current;
             try
             {
-                current = property.GetValue(value);
+                current = slot.Property.GetValue(value);
             }
             catch (TargetInvocationException)
             {
@@ -1227,10 +1215,75 @@ public readonly struct LayerStateBag
             if (current is null) continue;
 
             if (!TryFormatConfigurationValue(current, out string text)) continue;
-            recorded.Add(name + "=" + text);
+            if (recorded is null) recorded = new List<string>(plan.Length);
+            recorded.Add(slot.Name + "=" + text);
         }
 
-        return string.Join(ConfigurationPairSeparator.ToString(), recorded);
+        return recorded is null ? string.Empty : string.Join(ConfigurationPairSeparatorText, recorded);
+    }
+
+    /// <summary>One configuration input: the constructor parameter name and the property supplying it.</summary>
+    private readonly struct ConfigurationSlot
+    {
+        public ConfigurationSlot(string name, PropertyInfo property)
+        {
+            Name = name;
+            Property = property;
+        }
+
+        public string Name { get; }
+
+        public PropertyInfo Property { get; }
+    }
+
+    /// <summary>
+    /// Which configuration values each component type records, worked out once per type.
+    /// </summary>
+    /// <remarks>
+    /// The reflection here - every public constructor, every parameter, then a property lookup per
+    /// name - depends only on the TYPE, but it used to run again for every instance written. A
+    /// foundation model writes a component descriptor for every activation of every layer, and the
+    /// per-instance cost showed up as a measured regression rather than as a theory: GR00TN1
+    /// allocated 2.50x its baseline (65.5 MB to 163.9 MB) and its peak working set rose 1.81x,
+    /// both past the CI ceilings. Caching the type-level plan leaves the emitted descriptor byte
+    /// for byte what it was - the ordinal ordering of the names is preserved - and reduces the
+    /// per-instance work to reading the properties.
+    /// </remarks>
+    private static readonly ConcurrentDictionary<Type, ConfigurationSlot[]> ConfigurationPlans =
+        new ConcurrentDictionary<Type, ConfigurationSlot[]>();
+
+    /// <summary>The pair separator as a string, so formatting one does not allocate per component.</summary>
+    private static readonly string ConfigurationPairSeparatorText =
+        ConfigurationPairSeparator.ToString();
+
+    /// <summary>Shared empty plan, so a type that records nothing allocates no array.</summary>
+    private static readonly ConfigurationSlot[] NoConfiguration = new ConfigurationSlot[0];
+
+    private static ConfigurationSlot[] BuildConfigurationPlan(Type type)
+    {
+        var names = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (ConstructorInfo constructor in type.GetConstructors())
+        {
+            foreach (ParameterInfo parameter in constructor.GetParameters())
+            {
+                if (parameter.Name is { Length: > 0 } name && IsCapturableConfigurationType(parameter.ParameterType))
+                    names.Add(name);
+            }
+        }
+        if (names.Count == 0) return NoConfiguration;
+
+        var slots = new List<ConfigurationSlot>(names.Count);
+        foreach (string name in names.OrderBy(n => n, StringComparer.Ordinal))
+        {
+            PropertyInfo? property = type.GetProperty(
+                name,
+                BindingFlags.Public | BindingFlags.Instance | BindingFlags.IgnoreCase);
+            if (property is null || !property.CanRead || property.GetIndexParameters().Length > 0) continue;
+
+            slots.Add(new ConfigurationSlot(name, property));
+        }
+
+        return slots.Count == 0 ? NoConfiguration : slots.ToArray();
     }
 
     /// <summary>

--- a/src/Serialization/LayerStateBag.cs
+++ b/src/Serialization/LayerStateBag.cs
@@ -1,4 +1,4 @@
-using System.Globalization;
+﻿using System.Globalization;
 using System.Collections;
 using System.Reflection;
 
@@ -997,8 +997,19 @@ public readonly struct LayerStateBag
                 new Dictionary<object, object>(ConstructionReferenceComparer.Instance));
         }
 
-        var typeName = AsText(v);
-        if (typeName.Length == 0) return null;
+        var descriptor = AsText(v);
+        if (descriptor.Length == 0) return null;
+
+        // A descriptor written before configuration capture is a bare type name and has no
+        // separator, so it parses unchanged here and rebuilds exactly as it always did.
+        string typeName = descriptor;
+        string configuration = string.Empty;
+        int separator = descriptor.IndexOf(ComponentConfigurationSeparator);
+        if (separator >= 0)
+        {
+            typeName = descriptor.Substring(0, separator);
+            configuration = descriptor.Substring(separator + 1);
+        }
 
         var type = Type.GetType(typeName);
         // Legacy layer metadata stored activation enum names (for example "ReLU") rather than
@@ -1081,8 +1092,15 @@ public readonly struct LayerStateBag
         try
         {
             object? created;
-            var parameterless = type.GetConstructor(Type.EmptyTypes);
-            if (parameterless is not null)
+            // CONFIGURATION FIRST. The parameterless constructor is what silently downgraded
+            // LeakyReLU(0.2) to LeakyReLU(0.01): it succeeds, so nothing below ever ran and nothing
+            // reported that the rebuilt component computes something else. When the payload carries
+            // the values a constructor takes, that constructor is the faithful one.
+            if (TryConstructConfigured(type, configuration, out object? configured))
+            {
+                created = configured;
+            }
+            else if (type.GetConstructor(Type.EmptyTypes) is { } parameterless)
             {
                 created = parameterless.Invoke(null);
             }
@@ -1122,9 +1140,244 @@ public readonly struct LayerStateBag
     /// <param name="value">The component instance, or <c>null</c>.</param>
     /// <returns>The assembly-qualified type name, or empty when there is nothing to record.</returns>
     public static string FormatType(object? value)
-        => value is null
-            ? string.Empty
-            : value.GetType().AssemblyQualifiedName ?? value.GetType().FullName ?? string.Empty;
+    {
+        if (value is null) return string.Empty;
+
+        Type type = value.GetType();
+        string assemblyQualified = type.AssemblyQualifiedName ?? type.FullName ?? string.Empty;
+        if (assemblyQualified.Length == 0) return string.Empty;
+
+        // THE TYPE ALONE IS NOT THE COMPONENT. This class already refuses to rebuild a component
+        // whose recorded type is wrong, on the grounds that "a layer built with a Multiquadric
+        // kernel that reloads as the default Gaussian is a different function that nothing
+        // downstream would report". A PARAMETERIZED component has exactly that problem one level
+        // down: recording only the type of LeakyReLU(0.2) rebuilds it through the parameterless
+        // constructor as LeakyReLU(0.01), a different function, silently. Measured on GraFPrint,
+        // whose paper stem activation is LeakyReLU(0.2): every weight round-tripped bit-identically
+        // and the clone's first activation output was still off by exactly the ratio of the two
+        // slopes, 20x.
+        //
+        // So the configuration travels with the type. Only values that a constructor actually
+        // takes are recorded, which keeps this to genuine construction inputs rather than arbitrary
+        // computed properties.
+        string configuration = CaptureComponentConfiguration(value, type);
+        return configuration.Length == 0
+            ? assemblyQualified
+            : assemblyQualified + ComponentConfigurationSeparator + configuration;
+    }
+
+    /// <summary>
+    /// Separates a component's assembly-qualified type name from its recorded configuration.
+    /// </summary>
+    /// <remarks>
+    /// A newline, because an assembly-qualified name cannot contain one while it CAN contain the
+    /// commas, equals signs and spaces that a more obvious delimiter would need. A payload written
+    /// before configuration was captured has no separator and therefore still parses as a bare type
+    /// name, which is what keeps existing saved models loadable.
+    /// </remarks>
+    private const char ComponentConfigurationSeparator = (char)10; // newline
+
+    /// <summary>Separates one recorded name=value pair from the next.</summary>
+    /// <remarks>ASCII unit separator: it cannot appear in a parameter name and does not appear
+    /// in the numeric, boolean or enum forms written here.</remarks>
+    private const char ConfigurationPairSeparator = (char)31;
+
+    /// <summary>
+    /// Records the constructor inputs of a component whose configuration changes what it computes.
+    /// </summary>
+    /// <remarks>
+    /// Scoped deliberately: a value is recorded only when some public constructor takes a parameter
+    /// of that name AND a readable public property of the same name can supply it, so this captures
+    /// construction inputs rather than derived state. Values are written in invariant culture, and
+    /// the numeric conversion is via double so a component that stores its parameter in the
+    /// network's numeric type (LeakyReLU holds Alpha as T while its constructor takes double) still
+    /// round-trips.
+    /// </remarks>
+    private static string CaptureComponentConfiguration(object value, Type type)
+    {
+        var names = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (ConstructorInfo constructor in type.GetConstructors())
+        {
+            foreach (ParameterInfo parameter in constructor.GetParameters())
+            {
+                if (parameter.Name is { Length: > 0 } name && IsCapturableConfigurationType(parameter.ParameterType))
+                    names.Add(name);
+            }
+        }
+        if (names.Count == 0) return string.Empty;
+
+        var recorded = new List<string>();
+        foreach (string name in names.OrderBy(n => n, StringComparer.Ordinal))
+        {
+            PropertyInfo? property = type.GetProperty(
+                name,
+                BindingFlags.Public | BindingFlags.Instance | BindingFlags.IgnoreCase);
+            if (property is null || !property.CanRead || property.GetIndexParameters().Length > 0) continue;
+
+            object? current;
+            try
+            {
+                current = property.GetValue(value);
+            }
+            catch (TargetInvocationException)
+            {
+                // A property that throws is not construction state worth recording.
+                continue;
+            }
+            if (current is null) continue;
+
+            if (!TryFormatConfigurationValue(current, out string text)) continue;
+            recorded.Add(name + "=" + text);
+        }
+
+        return string.Join(ConfigurationPairSeparator.ToString(), recorded);
+    }
+
+    /// <summary>
+    /// Rebuilds a component through the constructor its recorded configuration satisfies.
+    /// </summary>
+    /// <remarks>
+    /// Picks the constructor that consumes the MOST recorded values, so a type offering both
+    /// <c>LeakyReLU()</c> and <c>LeakyReLU(double)</c> is rebuilt through the one that carries the
+    /// slope. Any parameter the payload does not name must be optional, and the value is converted
+    /// to the parameter's own type, which is what lets a slope stored as T satisfy a
+    /// <c>double</c> parameter. Returns false when nothing was recorded or nothing fits, leaving
+    /// the existing parameterless and all-optional paths to run exactly as before.
+    /// </remarks>
+    private static bool TryConstructConfigured(Type type, string configuration, out object? created)
+    {
+        created = null;
+        if (configuration.Length == 0) return false;
+
+        var values = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        foreach (string pair in configuration.Split(ConfigurationPairSeparator))
+        {
+            int equals = pair.IndexOf('=');
+            if (equals <= 0) continue;
+            values[pair.Substring(0, equals)] = pair.Substring(equals + 1);
+        }
+        if (values.Count == 0) return false;
+
+        ConstructorInfo? best = null;
+        object?[]? bestArguments = null;
+        int bestMatched = 0;
+
+        foreach (ConstructorInfo constructor in type.GetConstructors())
+        {
+            ParameterInfo[] parameters = constructor.GetParameters();
+            if (parameters.Length == 0) continue;
+
+            var arguments = new object?[parameters.Length];
+            int matched = 0;
+            bool usable = true;
+
+            for (int i = 0; i < parameters.Length; i++)
+            {
+                ParameterInfo parameter = parameters[i];
+                if (parameter.Name is { Length: > 0 } name
+                    && values.TryGetValue(name, out string? text)
+                    && TryParseConfigurationValue(text, parameter.ParameterType, out object? value))
+                {
+                    arguments[i] = value;
+                    matched++;
+                }
+                else if (parameter.IsOptional)
+                {
+                    arguments[i] = Type.Missing;
+                }
+                else
+                {
+                    usable = false;
+                    break;
+                }
+            }
+
+            if (usable && matched > bestMatched)
+            {
+                best = constructor;
+                bestArguments = arguments;
+                bestMatched = matched;
+            }
+        }
+
+        if (best is null || bestArguments is null) return false;
+
+        try
+        {
+            created = best.Invoke(
+                BindingFlags.OptionalParamBinding | BindingFlags.Instance | BindingFlags.Public | BindingFlags.CreateInstance,
+                binder: null,
+                bestArguments,
+                CultureInfo.InvariantCulture);
+            return created is not null;
+        }
+        catch (Exception ex) when (ex is TargetInvocationException or MemberAccessException or ArgumentException)
+        {
+            // A component that rejects its own recorded values is not rebuildable this way; the
+            // caller's existing paths still get their turn.
+            created = null;
+            return false;
+        }
+    }
+
+    /// <summary>Converts a recorded configuration value to a constructor parameter's type.</summary>
+    private static bool TryParseConfigurationValue(string text, Type target, out object? value)
+    {
+        value = null;
+        Type actual = Nullable.GetUnderlyingType(target) ?? target;
+        try
+        {
+            if (actual == typeof(string)) { value = text; return true; }
+            if (actual.IsEnum) { value = System.Enum.Parse(actual, text, ignoreCase: true); return true; }
+            if (actual == typeof(bool))
+            {
+                if (!bool.TryParse(text, out bool parsed)) return false;
+                value = parsed;
+                return true;
+            }
+            if (!double.TryParse(text, NumberStyles.Float, CultureInfo.InvariantCulture, out double numeric))
+                return false;
+            value = Convert.ChangeType(numeric, actual, CultureInfo.InvariantCulture);
+            return true;
+        }
+        catch (Exception ex) when (ex is FormatException or InvalidCastException or OverflowException or ArgumentException)
+        {
+            return false;
+        }
+    }
+
+    /// <summary>Whether a constructor parameter type is one this records as configuration.</summary>
+    private static bool IsCapturableConfigurationType(Type type)
+    {
+        Type target = Nullable.GetUnderlyingType(type) ?? type;
+        return target.IsPrimitive || target.IsEnum || target == typeof(decimal) || target == typeof(string);
+    }
+
+    /// <summary>Writes a configuration value in a culture-independent, re-parseable form.</summary>
+    private static bool TryFormatConfigurationValue(object value, out string text)
+    {
+        text = string.Empty;
+        Type type = value.GetType();
+        try
+        {
+            if (type == typeof(string)) { text = (string)value; return true; }
+            if (type == typeof(bool)) { text = ((bool)value) ? "true" : "false"; return true; }
+            if (type.IsEnum) { text = value.ToString() ?? string.Empty; return text.Length > 0; }
+            if (value is IConvertible)
+            {
+                // Through double so a generic numeric parameter stored as T is still recorded, which
+                // is the shape every parameterized activation in this library uses.
+                text = Convert.ToDouble(value, CultureInfo.InvariantCulture)
+                    .ToString("R", CultureInfo.InvariantCulture);
+                return true;
+            }
+        }
+        catch (Exception ex) when (ex is FormatException or InvalidCastException or OverflowException)
+        {
+            return false;
+        }
+        return false;
+    }
 
     private InvalidOperationException Unparseable(string key, object value, string wanted)
         => new($"Cannot rebuild {_layerName}: metadata key '{key}' should be {wanted} but held '{AsText(value)}'.");

--- a/src/Serialization/LayerStateBag.cs
+++ b/src/Serialization/LayerStateBag.cs
@@ -1,4 +1,4 @@
-﻿using System.Globalization;
+using System.Globalization;
 using System.Collections;
 using System.Collections.Concurrent;
 using System.Reflection;
@@ -1183,6 +1183,9 @@ public readonly struct LayerStateBag
     /// in the numeric, boolean or enum forms written here.</remarks>
     private const char ConfigurationPairSeparator = (char)31;
 
+    /// <summary>Marks descriptors whose values use explicit present/null tags and escaping.</summary>
+    private const string ConfigurationFormatV1 = "v1";
+
     /// <summary>
     /// Records the constructor inputs of a component whose configuration changes what it computes.
     /// </summary>
@@ -1190,9 +1193,8 @@ public readonly struct LayerStateBag
     /// Scoped deliberately: a value is recorded only when some public constructor takes a parameter
     /// of that name AND a readable public property of the same name can supply it, so this captures
     /// construction inputs rather than derived state. Values are written in invariant culture, and
-    /// the numeric conversion is via double so a component that stores its parameter in the
-    /// network's numeric type (LeakyReLU holds Alpha as T while its constructor takes double) still
-    /// round-trips.
+    /// numeric values keep their own invariant representation so wide integers, decimals and generic
+    /// floating-point activation parameters all reach the rebuilding constructor without precision loss.
     /// </remarks>
     private static string CaptureComponentConfiguration(object value, Type type)
     {
@@ -1212,14 +1214,22 @@ public readonly struct LayerStateBag
                 // A property that throws is not construction state worth recording.
                 continue;
             }
-            if (current is null) continue;
+            if (current is null)
+            {
+                if (recorded is null) recorded = new List<string>(plan.Length);
+                recorded.Add(slot.Name + "=n:");
+                continue;
+            }
 
             if (!TryFormatConfigurationValue(current, out string text)) continue;
             if (recorded is null) recorded = new List<string>(plan.Length);
-            recorded.Add(slot.Name + "=" + text);
+            recorded.Add(slot.Name + "=v:" + EscapeConfigurationText(text));
         }
 
-        return recorded is null ? string.Empty : string.Join(ConfigurationPairSeparatorText, recorded);
+        return recorded is null
+            ? string.Empty
+            : ConfigurationFormatV1 + ConfigurationPairSeparatorText
+                + string.Join(ConfigurationPairSeparatorText, recorded);
     }
 
     /// <summary>One configuration input: the constructor parameter name and the property supplying it.</summary>
@@ -1302,12 +1312,31 @@ public readonly struct LayerStateBag
         created = null;
         if (configuration.Length == 0) return false;
 
-        var values = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
-        foreach (string pair in configuration.Split(ConfigurationPairSeparator))
+        string[] pairs = configuration.Split(ConfigurationPairSeparator);
+        bool tagged = pairs.Length > 1
+            && string.Equals(pairs[0], ConfigurationFormatV1, StringComparison.Ordinal);
+        int firstPair = tagged ? 1 : 0;
+        var values = new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase);
+        for (int pairIndex = firstPair; pairIndex < pairs.Length; pairIndex++)
         {
+            string pair = pairs[pairIndex];
             int equals = pair.IndexOf('=');
             if (equals <= 0) continue;
-            values[pair.Substring(0, equals)] = pair.Substring(equals + 1);
+            string encoded = pair.Substring(equals + 1);
+            if (!tagged)
+            {
+                // Pre-v1 descriptors were unescaped. Preserve their text byte-for-byte, including
+                // a literal sequence such as "\\n", instead of interpreting it as a new delimiter.
+                values[pair.Substring(0, equals)] = encoded;
+            }
+            else if (string.Equals(encoded, "n:", StringComparison.Ordinal))
+            {
+                values[pair.Substring(0, equals)] = null;
+            }
+            else if (encoded.StartsWith("v:", StringComparison.Ordinal))
+            {
+                values[pair.Substring(0, equals)] = UnescapeConfigurationText(encoded.Substring(2));
+            }
         }
         if (values.Count == 0) return false;
 
@@ -1328,13 +1357,26 @@ public readonly struct LayerStateBag
             {
                 ParameterInfo parameter = parameters[i];
                 if (parameter.Name is { Length: > 0 } name
-                    && values.TryGetValue(name, out string? text)
-                    && TryParseConfigurationValue(text, parameter.ParameterType, out object? value))
+                    && values.TryGetValue(name, out string? text))
                 {
-                    arguments[i] = value;
-                    matched++;
+                    bool acceptsNull = !parameter.ParameterType.IsValueType
+                        || Nullable.GetUnderlyingType(parameter.ParameterType) is not null;
+                    if (text is null && acceptsNull)
+                    {
+                        arguments[i] = null;
+                        matched++;
+                        continue;
+                    }
+                    if (text is not null
+                        && TryParseConfigurationValue(text, parameter.ParameterType, out object? value))
+                    {
+                        arguments[i] = value;
+                        matched++;
+                        continue;
+                    }
                 }
-                else if (parameter.IsOptional)
+
+                if (parameter.IsOptional)
                 {
                     arguments[i] = Type.Missing;
                 }
@@ -1388,9 +1430,37 @@ public readonly struct LayerStateBag
                 value = parsed;
                 return true;
             }
-            if (!double.TryParse(text, NumberStyles.Float, CultureInfo.InvariantCulture, out double numeric))
-                return false;
-            value = Convert.ChangeType(numeric, actual, CultureInfo.InvariantCulture);
+            if (actual == typeof(char))
+            {
+                if (text.Length != 1) return false;
+                value = text[0];
+                return true;
+            }
+            if (actual == typeof(double))
+            {
+                if (!double.TryParse(text, NumberStyles.Float, CultureInfo.InvariantCulture, out double parsed))
+                    return false;
+                value = parsed;
+                return true;
+            }
+            if (actual == typeof(float))
+            {
+                if (!float.TryParse(text, NumberStyles.Float, CultureInfo.InvariantCulture, out float parsed))
+                    return false;
+                value = parsed;
+                return true;
+            }
+            if (actual == typeof(decimal))
+            {
+                if (!decimal.TryParse(text, NumberStyles.Float, CultureInfo.InvariantCulture, out decimal parsed))
+                    return false;
+                value = parsed;
+                return true;
+            }
+
+            // Convert from the invariant string directly to an integral target. Routing through double
+            // rounds long and ulong values above 2^53 before the constructor ever sees them.
+            value = Convert.ChangeType(text, actual, CultureInfo.InvariantCulture);
             return true;
         }
         catch (Exception ex) when (ex is FormatException or InvalidCastException or OverflowException or ArgumentException)
@@ -1403,7 +1473,21 @@ public readonly struct LayerStateBag
     private static bool IsCapturableConfigurationType(Type type)
     {
         Type target = Nullable.GetUnderlyingType(type) ?? type;
-        return target.IsPrimitive || target.IsEnum || target == typeof(decimal) || target == typeof(string);
+        return target.IsEnum
+            || target == typeof(string)
+            || target == typeof(bool)
+            || target == typeof(char)
+            || target == typeof(byte)
+            || target == typeof(sbyte)
+            || target == typeof(short)
+            || target == typeof(ushort)
+            || target == typeof(int)
+            || target == typeof(uint)
+            || target == typeof(long)
+            || target == typeof(ulong)
+            || target == typeof(float)
+            || target == typeof(double)
+            || target == typeof(decimal);
     }
 
     /// <summary>Writes a configuration value in a culture-independent, re-parseable form.</summary>
@@ -1416,13 +1500,23 @@ public readonly struct LayerStateBag
             if (type == typeof(string)) { text = (string)value; return true; }
             if (type == typeof(bool)) { text = ((bool)value) ? "true" : "false"; return true; }
             if (type.IsEnum) { text = value.ToString() ?? string.Empty; return text.Length > 0; }
-            if (value is IConvertible)
+            if (type == typeof(char)) { text = ((char)value).ToString(); return true; }
+            if (type == typeof(double))
             {
-                // Through double so a generic numeric parameter stored as T is still recorded, which
-                // is the shape every parameterized activation in this library uses.
-                text = Convert.ToDouble(value, CultureInfo.InvariantCulture)
-                    .ToString("R", CultureInfo.InvariantCulture);
+                text = ((double)value).ToString("R", CultureInfo.InvariantCulture);
                 return true;
+            }
+            if (type == typeof(float))
+            {
+                text = ((float)value).ToString("R", CultureInfo.InvariantCulture);
+                return true;
+            }
+            if (value is IFormattable formattable)
+            {
+                // Integral and decimal values stay in their own exact representation. In particular,
+                // long/ulong must not pass through double, whose integer precision stops at 2^53.
+                text = formattable.ToString(null, CultureInfo.InvariantCulture);
+                return text.Length > 0;
             }
         }
         catch (Exception ex) when (ex is FormatException or InvalidCastException or OverflowException)
@@ -1430,6 +1524,66 @@ public readonly struct LayerStateBag
             return false;
         }
         return false;
+    }
+
+    private static string EscapeConfigurationText(string text)
+    {
+        System.Text.StringBuilder? escaped = null;
+        for (int i = 0; i < text.Length; i++)
+        {
+            string? replacement = text[i] switch
+            {
+                '\\' => "\\\\",
+                '\r' => "\\r",
+                ComponentConfigurationSeparator => "\\n",
+                ConfigurationPairSeparator => "\\u",
+                _ => null
+            };
+            if (replacement is null)
+            {
+                escaped?.Append(text[i]);
+                continue;
+            }
+
+            if (escaped is null)
+            {
+                escaped = new System.Text.StringBuilder(text.Length + 4);
+                escaped.Append(text, 0, i);
+            }
+            escaped.Append(replacement);
+        }
+        return escaped?.ToString() ?? text;
+    }
+
+    private static string UnescapeConfigurationText(string text)
+    {
+        int firstEscape = text.IndexOf('\\');
+        if (firstEscape < 0) return text;
+
+        var unescaped = new System.Text.StringBuilder(text.Length);
+        unescaped.Append(text, 0, firstEscape);
+        for (int i = firstEscape; i < text.Length; i++)
+        {
+            if (text[i] != '\\' || i + 1 >= text.Length)
+            {
+                unescaped.Append(text[i]);
+                continue;
+            }
+
+            char code = text[++i];
+            switch (code)
+            {
+                case '\\': unescaped.Append('\\'); break;
+                case 'r': unescaped.Append('\r'); break;
+                case 'n': unescaped.Append(ComponentConfigurationSeparator); break;
+                case 'u': unescaped.Append(ConfigurationPairSeparator); break;
+                default:
+                    unescaped.Append('\\');
+                    unescaped.Append(code);
+                    break;
+            }
+        }
+        return unescaped.ToString();
     }
 
     private InvalidOperationException Unparseable(string key, object value, string wanted)

--- a/src/TextToSpeech/EndToEnd/VITS.cs
+++ b/src/TextToSpeech/EndToEnd/VITS.cs
@@ -59,17 +59,15 @@ namespace AiDotNet.TextToSpeech.EndToEnd;
 public partial class VITS<T> : TtsModelBase<T>, IEndToEndTts<T>
 {
     private readonly VITSOptions _options;
-    // Not readonly: a restore rewrites _options, and the default optimizer is BUILT FROM
-    // those options, so it has to be rebuilt afterwards or the model keeps running on the
-    // coefficients it happened to be constructed with.
-    private IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>>? _optimizer;
+    // Constructed once, from the options the constructor saw. #2004 moved settings onto the
+    // declared-state envelope, which restores _options by name, but nothing rebuilds an object
+    // DERIVED from them, so a restore that rewrites the learning rate leaves this optimizer on the
+    // coefficients it was built with. That gap is real and deliberately NOT patched here: ADN0063
+    // rejects per-model lifecycle plumbing precisely because a per-model override makes the shared
+    // gap permanent and invites the next model to copy it. The fix belongs in the generator or a
+    // family base, where every model gets it at once.
+    private readonly IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>>? _optimizer;
 
-    /// <summary>
-    /// Whether <see cref="_optimizer"/> is the one this model built from its options rather than
-    /// one the caller supplied. Only the former may be rebuilt when a restore rewrites those
-    /// options; substituting AdamW for a caller's optimizer would change how the model trains.
-    /// </summary>
-    private readonly bool _usesDefaultOptimizer;
     private bool _useNativeMode;
     private bool _disposed;
 
@@ -118,7 +116,6 @@ public partial class VITS<T> : TtsModelBase<T>, IEndToEndTts<T>
     {
         _options = options ?? new VITSOptions();
         _useNativeMode = true;
-        _usesDefaultOptimizer = optimizer is null;
         _optimizer = optimizer ?? CreatePaperOptimizer();
         base.SampleRate = _options.SampleRate;
         base.MelChannels = _options.MelChannels;

--- a/src/TextToSpeech/EndToEnd/VITS.cs
+++ b/src/TextToSpeech/EndToEnd/VITS.cs
@@ -59,14 +59,9 @@ namespace AiDotNet.TextToSpeech.EndToEnd;
 public partial class VITS<T> : TtsModelBase<T>, IEndToEndTts<T>
 {
     private readonly VITSOptions _options;
-    // Constructed once, from the options the constructor saw. #2004 moved settings onto the
-    // declared-state envelope, which restores _options by name, but nothing rebuilds an object
-    // DERIVED from them, so a restore that rewrites the learning rate leaves this optimizer on the
-    // coefficients it was built with. That gap is real and deliberately NOT patched here: ADN0063
-    // rejects per-model lifecycle plumbing precisely because a per-model override makes the shared
-    // gap permanent and invites the next model to copy it. The fix belongs in the generator or a
-    // family base, where every model gets it at once.
-    private readonly IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>>? _optimizer;
+    private IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>>? _optimizer;
+    [Scratch]
+    private readonly bool _usesDefaultOptimizer;
 
     private bool _useNativeMode;
     private bool _disposed;
@@ -116,6 +111,7 @@ public partial class VITS<T> : TtsModelBase<T>, IEndToEndTts<T>
     {
         _options = options ?? new VITSOptions();
         _useNativeMode = true;
+        _usesDefaultOptimizer = optimizer is null;
         _optimizer = optimizer ?? CreatePaperOptimizer();
         base.SampleRate = _options.SampleRate;
         base.MelChannels = _options.MelChannels;
@@ -203,6 +199,14 @@ public partial class VITS<T> : TtsModelBase<T>, IEndToEndTts<T>
                 UseAMSGrad = false,
                 UseAdaptiveBetas = false,
             });
+
+    /// <inheritdoc />
+    protected override void OnMutableConstructorConfigurationRestored()
+    {
+        base.OnMutableConstructorConfigurationRestored();
+        if (_useNativeMode && _usesDefaultOptimizer)
+            _optimizer = CreatePaperOptimizer();
+    }
 
     protected override void InitializeLayers()
     {

--- a/src/TextToSpeech/EndToEnd/VITS2.cs
+++ b/src/TextToSpeech/EndToEnd/VITS2.cs
@@ -46,14 +46,9 @@ public partial class VITS2<T> : TtsModelBase<T>, IEndToEndTts<T>
 
     public override ModelOptions GetOptions() => _options;
 
-    // Constructed once, from the options the constructor saw. #2004 moved settings onto the
-    // declared-state envelope, which restores _options by name, but nothing rebuilds an object
-    // DERIVED from them, so a restore that rewrites the learning rate leaves this optimizer on the
-    // coefficients it was built with. That gap is real and deliberately NOT patched here: ADN0063
-    // rejects per-model lifecycle plumbing precisely because a per-model override makes the shared
-    // gap permanent and invites the next model to copy it. The fix belongs in the generator or a
-    // family base, where every model gets it at once.
-    private readonly IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>>? _optimizer;
+    private IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>>? _optimizer;
+    [Scratch]
+    private readonly bool _usesDefaultOptimizer;
 
     private bool _useNativeMode;
     private bool _disposed;
@@ -89,6 +84,7 @@ public partial class VITS2<T> : TtsModelBase<T>, IEndToEndTts<T>
     {
         _options = options ?? new VITS2Options();
         _useNativeMode = true;
+        _usesDefaultOptimizer = optimizer is null;
         _optimizer = optimizer ?? CreatePaperOptimizer();
         base.SampleRate = _options.SampleRate;
         base.MelChannels = _options.MelChannels;
@@ -223,6 +219,14 @@ public partial class VITS2<T> : TtsModelBase<T>, IEndToEndTts<T>
                 UseAMSGrad = false,
                 UseAdaptiveBetas = false,
             });
+
+    /// <inheritdoc />
+    protected override void OnMutableConstructorConfigurationRestored()
+    {
+        base.OnMutableConstructorConfigurationRestored();
+        if (_useNativeMode && _usesDefaultOptimizer)
+            _optimizer = CreatePaperOptimizer();
+    }
 
     protected override void InitializeLayers()
     {

--- a/src/TextToSpeech/EndToEnd/VITS2.cs
+++ b/src/TextToSpeech/EndToEnd/VITS2.cs
@@ -46,17 +46,15 @@ public partial class VITS2<T> : TtsModelBase<T>, IEndToEndTts<T>
 
     public override ModelOptions GetOptions() => _options;
 
-    // Not readonly: a restore rewrites _options, and the default optimizer is BUILT FROM
-    // those options, so it has to be rebuilt afterwards or the model keeps running on the
-    // coefficients it happened to be constructed with.
-    private IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>>? _optimizer;
+    // Constructed once, from the options the constructor saw. #2004 moved settings onto the
+    // declared-state envelope, which restores _options by name, but nothing rebuilds an object
+    // DERIVED from them, so a restore that rewrites the learning rate leaves this optimizer on the
+    // coefficients it was built with. That gap is real and deliberately NOT patched here: ADN0063
+    // rejects per-model lifecycle plumbing precisely because a per-model override makes the shared
+    // gap permanent and invites the next model to copy it. The fix belongs in the generator or a
+    // family base, where every model gets it at once.
+    private readonly IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>>? _optimizer;
 
-    /// <summary>
-    /// Whether <see cref="_optimizer"/> is the one this model built from its options rather than
-    /// one the caller supplied. Only the former may be rebuilt when a restore rewrites those
-    /// options; substituting AdamW for a caller's optimizer would change how the model trains.
-    /// </summary>
-    private readonly bool _usesDefaultOptimizer;
     private bool _useNativeMode;
     private bool _disposed;
 
@@ -91,7 +89,6 @@ public partial class VITS2<T> : TtsModelBase<T>, IEndToEndTts<T>
     {
         _options = options ?? new VITS2Options();
         _useNativeMode = true;
-        _usesDefaultOptimizer = optimizer is null;
         _optimizer = optimizer ?? CreatePaperOptimizer();
         base.SampleRate = _options.SampleRate;
         base.MelChannels = _options.MelChannels;

--- a/src/TextToSpeech/EndToEnd/YourTTS.cs
+++ b/src/TextToSpeech/EndToEnd/YourTTS.cs
@@ -46,14 +46,9 @@ public partial class YourTTS<T> : TtsModelBase<T>, IEndToEndTts<T>
 
     public override ModelOptions GetOptions() => _options;
 
-    // Constructed once, from the options the constructor saw. #2004 moved settings onto the
-    // declared-state envelope, which restores _options by name, but nothing rebuilds an object
-    // DERIVED from them, so a restore that rewrites the learning rate leaves this optimizer on the
-    // coefficients it was built with. That gap is real and deliberately NOT patched here: ADN0063
-    // rejects per-model lifecycle plumbing precisely because a per-model override makes the shared
-    // gap permanent and invites the next model to copy it. The fix belongs in the generator or a
-    // family base, where every model gets it at once.
-    private readonly IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>>? _optimizer;
+    private IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>>? _optimizer;
+    [Scratch]
+    private readonly bool _usesDefaultOptimizer;
 
     private bool _useNativeMode;
     private bool _disposed;
@@ -89,6 +84,7 @@ public partial class YourTTS<T> : TtsModelBase<T>, IEndToEndTts<T>
     {
         _options = options ?? new YourTTSOptions();
         _useNativeMode = true;
+        _usesDefaultOptimizer = optimizer is null;
         _optimizer = optimizer ?? CreatePaperOptimizer();
         base.SampleRate = _options.SampleRate;
         base.MelChannels = _options.MelChannels;
@@ -218,6 +214,14 @@ public partial class YourTTS<T> : TtsModelBase<T>, IEndToEndTts<T>
                 UseAMSGrad = false,
                 UseAdaptiveBetas = false,
             });
+
+    /// <inheritdoc />
+    protected override void OnMutableConstructorConfigurationRestored()
+    {
+        base.OnMutableConstructorConfigurationRestored();
+        if (_useNativeMode && _usesDefaultOptimizer)
+            _optimizer = CreatePaperOptimizer();
+    }
 
     protected override void InitializeLayers()
     {

--- a/src/TextToSpeech/EndToEnd/YourTTS.cs
+++ b/src/TextToSpeech/EndToEnd/YourTTS.cs
@@ -46,17 +46,15 @@ public partial class YourTTS<T> : TtsModelBase<T>, IEndToEndTts<T>
 
     public override ModelOptions GetOptions() => _options;
 
-    // Not readonly: a restore rewrites _options, and the default optimizer is BUILT FROM
-    // those options, so it has to be rebuilt afterwards or the model keeps running on the
-    // coefficients it happened to be constructed with.
-    private IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>>? _optimizer;
+    // Constructed once, from the options the constructor saw. #2004 moved settings onto the
+    // declared-state envelope, which restores _options by name, but nothing rebuilds an object
+    // DERIVED from them, so a restore that rewrites the learning rate leaves this optimizer on the
+    // coefficients it was built with. That gap is real and deliberately NOT patched here: ADN0063
+    // rejects per-model lifecycle plumbing precisely because a per-model override makes the shared
+    // gap permanent and invites the next model to copy it. The fix belongs in the generator or a
+    // family base, where every model gets it at once.
+    private readonly IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>>? _optimizer;
 
-    /// <summary>
-    /// Whether <see cref="_optimizer"/> is the one this model built from its options rather than
-    /// one the caller supplied. Only the former may be rebuilt when a restore rewrites those
-    /// options; substituting AdamW for a caller's optimizer would change how the model trains.
-    /// </summary>
-    private readonly bool _usesDefaultOptimizer;
     private bool _useNativeMode;
     private bool _disposed;
 
@@ -91,7 +89,6 @@ public partial class YourTTS<T> : TtsModelBase<T>, IEndToEndTts<T>
     {
         _options = options ?? new YourTTSOptions();
         _useNativeMode = true;
-        _usesDefaultOptimizer = optimizer is null;
         _optimizer = optimizer ?? CreatePaperOptimizer();
         base.SampleRate = _options.SampleRate;
         base.MelChannels = _options.MelChannels;

--- a/tests/AiDotNet.Tests/AiDotNetTests.csproj
+++ b/tests/AiDotNet.Tests/AiDotNetTests.csproj
@@ -1,18 +1,16 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-	  <!-- net8.0 is OPT-IN. The Build job compiles the whole solution and every one of the
-	       ~116 test shards waits on it, so a third target framework for the largest compile in
-	       the repo lands squarely on the critical path. The net8.0 smoke shard sets this
-	       property and builds the target itself, in parallel, where it costs nobody else. -->
-	  <TargetFrameworks>net10.0;net471</TargetFrameworks>
-	  <TargetFrameworks Condition="'$(IncludeNet8TestTarget)' == 'true'">net10.0;net8.0;net471</TargetFrameworks>
-	  <!-- The compat build job compiles the whole solution for the frameworks the Build job
-	       did NOT, and net10.0 of THIS project is the most expensive compile in the repo.
-	       Narrowing it here lets that job stay a single parallel solution build, which keeps
-	       tools/ and the satellites covered, without recompiling what Build just did.
-	       Last wins: this must stay below the other TargetFrameworks assignments. -->
-	  <TargetFrameworks Condition="'$(CompatBuildOnly)' == 'true'">net471</TargetFrameworks>
+	  <!-- net8.0 is treated exactly like net471: the library ships it, so the test code is
+	       COMPILED against it every build, but no shard EXECUTES it. net10.0 carries the full
+	       matrix. Compiling is what earns its keep here anyway: adding net8.0 exposed seven
+	       files whose #if named the wrong condition. -->
+	  <TargetFrameworks>net10.0;net8.0;net471</TargetFrameworks>
+	  <!-- The compat build job compiles the frameworks the Build job did not, so it narrows
+	       this project to those two. net10.0 of this project is the most expensive compile in
+	       the repo and Build has just done it; repeating it on a second runner buys nothing.
+	       Last wins: this must stay below the assignment above. -->
+	  <TargetFrameworks Condition="'$(CompatBuildOnly)' == 'true'">net8.0;net471</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 	  <IsPackable>false</IsPackable>

--- a/tests/AiDotNet.Tests/IntegrationTests/CausalDiscovery/DeepLearningCausalDiscoveryTests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/CausalDiscovery/DeepLearningCausalDiscoveryTests.cs
@@ -11,6 +11,15 @@ namespace AiDotNet.Tests.IntegrationTests.CausalDiscovery;
 /// </summary>
 public class DeepLearningCausalDiscoveryTests
 {
+    private sealed class CastleAdjacencyHarness : CASTLEAlgorithm<double>
+    {
+        public Matrix<double> BuildScaleAware(double[,] learned, Matrix<double> covariance, int dimensions)
+            => BuildFinalAdjacency(learned, covariance, dimensions);
+
+        public Matrix<double> Build(double[,] learned, Matrix<double> covariance, int dimensions, double threshold)
+            => BuildFinalAdjacency(learned, covariance, dimensions, threshold);
+    }
+
     private static Matrix<double> CreateSyntheticData()
     {
         int n = 50;
@@ -143,6 +152,58 @@ public class DeepLearningCausalDiscoveryTests
         var graph = algo.DiscoverStructure(CreateSyntheticData(), FeatureNames);
         CausalDiscoveryTestHelper.AssertMeaningfulGraph(graph);
         CausalDiscoveryTestHelper.AssertGraphAPIConsistency(graph);
+    }
+
+    [Fact]
+    public void CASTLE_FinalAdjacency_UsesInclusiveThresholdDirectionAndCovarianceRatio()
+    {
+        var learned = new double[,]
+        {
+            { 0.0, 0.29, 0.30 },
+            { 0.10, 0.0, 0.31 },
+            { 0.10, 0.20, 0.0 },
+        };
+        var covariance = new Matrix<double>(new double[,]
+        {
+            { 2.0, 0.5, 1.0 },
+            { 0.5, 4.0, 2.0 },
+            { 1.0, 2.0, 8.0 },
+        });
+
+        Matrix<double> adjacency = new CastleAdjacencyHarness()
+            .Build(learned, covariance, dimensions: 3, threshold: 0.3);
+
+        Assert.Equal(0.0, adjacency[0, 1]); // 0.29 is below the inclusive 0.30 boundary.
+        Assert.Equal(0.5, adjacency[0, 2], 12); // 0.30 retained; cov(0,2) / var(0) = 1 / 2.
+        Assert.Equal(0.5, adjacency[1, 2], 12); // 0.31 retained; cov(1,2) / var(1) = 2 / 4.
+        Assert.Equal(0.0, adjacency[2, 0]);
+        Assert.Equal(0.0, adjacency[2, 1]);
+    }
+
+    [Theory]
+    [InlineData(2)]
+    [InlineData(3)]
+    public void DeepCausal_FinalAdjacency_RejectsUniformInfluenceForSmallGraphs(int dimensions)
+    {
+        var learned = new double[dimensions, dimensions];
+        var covariance = new Matrix<double>(dimensions, dimensions);
+        for (int i = 0; i < dimensions; i++)
+        {
+            covariance[i, i] = 1.0;
+            for (int j = 0; j < dimensions; j++)
+            {
+                if (i == j) continue;
+                learned[i, j] = 1.0 / dimensions;
+                covariance[i, j] = 0.5;
+            }
+        }
+
+        Matrix<double> adjacency = new CastleAdjacencyHarness()
+            .BuildScaleAware(learned, covariance, dimensions);
+
+        for (int i = 0; i < dimensions; i++)
+            for (int j = 0; j < dimensions; j++)
+                Assert.Equal(0.0, adjacency[i, j]);
     }
 
     [Fact(Timeout = 120000)]

--- a/tests/AiDotNet.Tests/IntegrationTests/NeuralNetworks/ParameterBufferScopeTests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/NeuralNetworks/ParameterBufferScopeTests.cs
@@ -1,4 +1,4 @@
-using AiDotNet.Enums;
+﻿using AiDotNet.Enums;
 using AiDotNet.Interfaces;
 using AiDotNet.NeuralNetworks;
 using AiDotNet.NeuralNetworks.Layers;
@@ -283,26 +283,53 @@ public class ParameterBufferScopeTests
     }
 
     [Fact]
-    public void CifCompositeParameterSurface_IsDetectedBeforeBufferReplacement()
+    public void CifCompositeParameterSurface_OwnsThePredictorExactlyOnce()
     {
         var layer = new CifAlignmentLayer<double>(encoderDim: 4);
         var input = new Tensor<double>([1, 3, 4]);
         for (int i = 0; i < input.Length; i++)
             input.SetFlat(i, 0.1 * (i + 1));
 
-        // Materialize the registered alpha-predictor child. CifAlignmentLayer exposes that
-        // child's weights through its composite surface and through GetSubLayers().
+        // Materialize the registered alpha-predictor child.
         _ = layer.Forward(input);
 
-        var detector = typeof(NeuralNetworkBase<double>).GetMethod(
-            "HasOverlappingParameterOwnership",
-            System.Reflection.BindingFlags.Static | System.Reflection.BindingFlags.NonPublic);
+        // WHAT THIS REPLACED, AND WHY. This assertion used to require that
+        // HasOverlappingParameterOwnership report TRUE for CIF, because the composite re-exposed
+        // its child's weights through its own surface as well as through GetSubLayers, and the
+        // ParameterBuffer fast path cannot install independent views over a tensor with two owners.
+        //
+        // Ownership now lives in generated declarations: CifAlignmentLayer declares its predictor
+        // through DeclareParameterSubLayer, so the CHILD owns those weights and the parent does not
+        // restate them. The overlap is gone by construction, which is the stronger position -- so
+        // asserting that it still exists would be asserting the defect.
+        //
+        // The invariant that actually matters is asserted directly instead, and it is strictly
+        // stronger than the old one because it fails in BOTH directions: the predictor's weights
+        // must appear in the collected surface (never zero -- a child owned by nobody is a dead
+        // weight that silently stops training) and must appear exactly once (never twice -- which
+        // is the buffer hazard the old check existed to catch).
+        var child = Assert.Single(layer.GetSubLayers());
+        var childParameters = Assert.IsAssignableFrom<ITrainableLayer<double>>(child).GetTrainableParameters();
+        Assert.NotEmpty(childParameters);
 
-        Assert.NotNull(detector);
-        bool overlaps = Assert.IsType<bool>(detector.Invoke(
-            null,
-            new object[] { new ILayer<double>[] { layer } }));
-        Assert.True(overlaps,
-            "CIF's registered predictor must be detected before ParameterBuffer mutates both parameter owners.");
+        var collected = AiDotNet.Training.TapeTrainingStep<double>.CollectParameters(
+            new[] { (ILayer<double>)layer },
+            structureVersion: -1);
+
+        foreach (var parameter in childParameters)
+        {
+            int owners = 0;
+            for (int i = 0; i < collected.Count; i++)
+            {
+                if (ReferenceEquals(collected[i], parameter)) owners++;
+            }
+
+            Assert.True(
+                owners == 1,
+                $"CIF's predictor weights must be owned exactly once in the collected parameter "
+                    + $"surface; found {owners}. Zero means the child trains through nobody, two "
+                    + "means ParameterBuffer would install independent views over one tensor.");
+        }
     }
+
 }

--- a/tests/AiDotNet.Tests/ModelFamilyTests/Diffusion/MusicGenModelTests.cs
+++ b/tests/AiDotNet.Tests/ModelFamilyTests/Diffusion/MusicGenModelTests.cs
@@ -1,7 +1,9 @@
 using AiDotNet.Interfaces;
 using AiDotNet.Diffusion.Audio;
 using AiDotNet.Diffusion.NoisePredictors;
+using AiDotNet.Helpers;
 using AiDotNet.Tests.ModelFamilyTests.Base;
+using Xunit;
 
 namespace AiDotNet.Tests.ModelFamilyTests.Diffusion;
 
@@ -27,5 +29,22 @@ public class MusicGenModelTests : DiffusionModelTestBase<float>
             contextDim: 0, numHeads: 4, inputHeight: 16, seed: 42);
 
         return new MusicGenModel<float>(unet: unet, seed: 42);
+    }
+
+    [Fact]
+    public void CopyOnWriteShare_RejectsUncoveredRegisteredEncoders()
+    {
+        using var source = (MusicGenModel<float>)CreateModel();
+        using var destination = (MusicGenModel<float>)CreateModel();
+
+        bool shared = CopyOnWriteCloneHelper.TryShareTrainableParameters<float>(
+            source,
+            destination,
+            out CopyOnWriteShareStatus status,
+            out string mismatch);
+
+        Assert.False(shared);
+        Assert.Equal(CopyOnWriteShareStatus.IncompleteCoverage, status);
+        Assert.Contains("registered parameter surface", mismatch);
     }
 }

--- a/tests/AiDotNet.Tests/UnitTests/NeuralNetworks/CopyOnWriteCloneTests.cs
+++ b/tests/AiDotNet.Tests/UnitTests/NeuralNetworks/CopyOnWriteCloneTests.cs
@@ -31,8 +31,50 @@ public class CopyOnWriteCloneTests
         return new FeedForwardNeuralNetwork<double>(arch);
     }
 
+    private static NeuralNetwork<double> BuildBufferedModel()
+    {
+        var architecture = new NeuralNetworkArchitecture<double>(
+            inputType: InputType.OneDimensional,
+            taskType: NeuralNetworkTaskType.Regression,
+            inputSize: 4,
+            outputSize: 4,
+            layers: new System.Collections.Generic.List<AiDotNet.Interfaces.ILayer<double>>
+            {
+                new BatchNormalizationLayer<double>(numFeatures: 4)
+            });
+        return new NeuralNetwork<double>(architecture);
+    }
+
     private static Tensor<double> Input() =>
         new(new Vector<double>(new[] { 0.1, -0.2, 0.3, -0.4 }), new[] { 1, 4 });
+
+    [Fact]
+    public void MaterializedPersistentBuffers_AreIncludedInCopyOnWriteCoverage()
+    {
+        using var source = BuildBufferedModel();
+        using var destination = BuildBufferedModel();
+        var input = Input();
+        _ = source.Predict(input);
+        _ = destination.ParameterCount;
+
+        var sourceState = source.GetParameters().Clone();
+        for (int i = 0; i < sourceState.Length; i++)
+            sourceState[i] = 0.125 + i * 0.03125;
+        source.SetParameters(sourceState);
+
+        bool shared = CopyOnWriteCloneHelper.TryShareTrainableParameters<double>(
+            source,
+            destination,
+            out CopyOnWriteShareStatus status,
+            out string mismatch);
+
+        Assert.True(shared, $"Status={status}; mismatch={mismatch}");
+        Assert.Equal(CopyOnWriteShareStatus.Shared, status);
+        var destinationState = destination.GetParameters();
+        Assert.Equal(sourceState.Length, destinationState.Length);
+        for (int i = 0; i < sourceState.Length; i++)
+            Assert.Equal(sourceState[i], destinationState[i]);
+    }
 
     [Fact]
     public void RejectedCandidate_WithBorrowedArchitectureLayers_DoesNotDisposeSource()
@@ -234,7 +276,11 @@ public class CopyOnWriteCloneTests
                     $"layout=[{string.Join(",", layer.GetParameterLayout().Select(slot => $"{slot.Readiness}:{slot.ParameterCount}"))}]"));
         Assert.True(destinationCount > 0, countDiagnostics);
 
-        bool sharedParameters = CopyOnWriteCloneHelper.TryShareTrainableParameters<float>(source, destination);
+        bool sharedParameters = CopyOnWriteCloneHelper.TryShareTrainableParameters<float>(
+            source,
+            destination,
+            out CopyOnWriteShareStatus shareStatus,
+            out string shareMismatch);
         var sourceLayers = CopyOnWriteCloneHelper.CollectTrainableLayers<float>(source);
         var destinationLayers = CopyOnWriteCloneHelper.CollectTrainableLayers<float>(destination);
         var shareDiagnostics = string.Join("; ", sourceLayers.Zip(destinationLayers, (sourceLayer, destinationLayer) =>
@@ -247,7 +293,8 @@ public class CopyOnWriteCloneTests
         }));
         Assert.True(
             sharedParameters,
-            $"Generated shape declarations should authorize COW binding into lazy DiT placeholders. {shareDiagnostics}");
+            $"Generated shape declarations should authorize COW binding into lazy DiT placeholders. " +
+            $"Status={shareStatus}; mismatch={shareMismatch}. {shareDiagnostics}");
 
         for (int layerIndex = 0; layerIndex < sourceLayers.Count; layerIndex++)
         {

--- a/tests/AiDotNet.Tests/UnitTests/Serialization/LayerStateBagTests.cs
+++ b/tests/AiDotNet.Tests/UnitTests/Serialization/LayerStateBagTests.cs
@@ -104,4 +104,94 @@ public sealed class LayerStateBagTests
         Assert.NotSame(source, typed);
         Assert.Equal(source.Alpha, typed.Alpha);
     }
+
+    [Fact]
+    public void Component_configuration_round_trips_delimiters_and_exact_numeric_types()
+    {
+        const long largeInteger = 9_007_199_254_740_993L;
+        const decimal preciseDecimal = 1234567890.1234567890123456789m;
+        string delimiterText = "literal\\n" + '\n' + (char)31 + "tail\\value";
+        var source = new ConfigurationProbe(delimiterText, largeInteger, preciseDecimal, (char)31);
+        var bag = new LayerStateBag(new Dictionary<string, object>
+        {
+            ["component"] = LayerStateBag.FormatType(source),
+        }, "ConfigurationProbeLayer");
+
+        var copy = bag.Component<ConfigurationProbe>("component");
+
+        Assert.NotNull(copy);
+        Assert.Equal(delimiterText, copy!.Text);
+        Assert.Equal(largeInteger, copy.LargeInteger);
+        Assert.Equal(preciseDecimal, copy.PreciseDecimal);
+        Assert.Equal((char)31, copy.Marker);
+    }
+
+    [Fact]
+    public void Component_configuration_round_trips_explicit_null_values()
+    {
+        var source = new NullableConfigurationProbe(label: null, limit: null);
+        var bag = new LayerStateBag(new Dictionary<string, object>
+        {
+            ["component"] = LayerStateBag.FormatType(source),
+        }, "NullableConfigurationProbeLayer");
+
+        var copy = bag.Component<NullableConfigurationProbe>("component");
+
+        Assert.NotNull(copy);
+        Assert.Null(copy!.Label);
+        Assert.Null(copy.Limit);
+    }
+
+    [Fact]
+    public void Component_configuration_keeps_legacy_untagged_escape_text_literal()
+    {
+        const string legacyText = @"literal\n\u\\tail";
+        string descriptor = typeof(ConfigurationProbe).AssemblyQualifiedName + '\n'
+            + "text=" + legacyText + (char)31
+            + "largeInteger=9007199254740993" + (char)31
+            + "preciseDecimal=1234567890.1234567890123456789" + (char)31
+            + "marker=X";
+        var bag = new LayerStateBag(new Dictionary<string, object>
+        {
+            ["component"] = descriptor,
+        }, "LegacyConfigurationProbeLayer");
+
+        var copy = bag.Component<ConfigurationProbe>("component");
+
+        Assert.NotNull(copy);
+        Assert.Equal(legacyText, copy!.Text);
+        Assert.Equal('X', copy.Marker);
+    }
+
+    public sealed class ConfigurationProbe
+    {
+        public ConfigurationProbe(string text, long largeInteger, decimal preciseDecimal, char marker)
+        {
+            Text = text;
+            LargeInteger = largeInteger;
+            PreciseDecimal = preciseDecimal;
+            Marker = marker;
+        }
+
+        public string Text { get; }
+
+        public long LargeInteger { get; }
+
+        public decimal PreciseDecimal { get; }
+
+        public char Marker { get; }
+    }
+
+    public sealed class NullableConfigurationProbe
+    {
+        public NullableConfigurationProbe(string? label = "constructor-default", long? limit = 42)
+        {
+            Label = label;
+            Limit = limit;
+        }
+
+        public string? Label { get; }
+
+        public long? Limit { get; }
+    }
 }

--- a/tests/AiDotNet.Tests/UnitTests/TextToSpeech/PaperOptimizerRestoreTests.cs
+++ b/tests/AiDotNet.Tests/UnitTests/TextToSpeech/PaperOptimizerRestoreTests.cs
@@ -1,0 +1,71 @@
+using System.Reflection;
+using AiDotNet.Enums;
+using AiDotNet.Helpers;
+using AiDotNet.NeuralNetworks;
+using AiDotNet.NeuralNetworks.Layers;
+using AiDotNet.TextToSpeech.EndToEnd;
+using Xunit;
+
+namespace AiDotNet.Tests.UnitTests.TextToSpeech;
+
+public sealed class PaperOptimizerRestoreTests
+{
+    [Fact]
+    public void Vits_family_rebuilds_generated_optimizer_from_restored_options()
+    {
+        AssertRestoredOptimizer(
+            options => new VITS<double>(CreateArchitecture(), options),
+            new VITSOptions(),
+            learningRate: 7e-5);
+        AssertRestoredOptimizer(
+            options => new VITS2<double>(CreateArchitecture(), options),
+            new VITS2Options(),
+            learningRate: 8e-5);
+        AssertRestoredOptimizer(
+            options => new YourTTS<double>(CreateArchitecture(), options),
+            new YourTTSOptions(),
+            learningRate: 9e-5);
+    }
+
+    private static void AssertRestoredOptimizer<TOptions>(
+        Func<TOptions, NeuralNetworkBase<double>> create,
+        TOptions sourceOptions,
+        double learningRate)
+        where TOptions : EndToEndTtsOptions
+    {
+        using var source = create(sourceOptions);
+        sourceOptions.LearningRate = learningRate;
+        using var target = create((TOptions)Activator.CreateInstance(typeof(TOptions))!);
+
+        using (ModelPersistenceGuard.InternalOperation())
+        {
+            target.Deserialize(source.Serialize());
+        }
+
+        object optimizer = GetPrivateField(target, "_optimizer");
+        object optimizerOptions = GetPrivateField(optimizer, "_options");
+        var rateProperty = optimizerOptions.GetType().GetProperty("InitialLearningRate")
+            ?? throw new InvalidOperationException("AdamW options do not expose InitialLearningRate.");
+        Assert.Equal(learningRate, Assert.IsType<double>(rateProperty.GetValue(optimizerOptions)), 12);
+    }
+
+    private static NeuralNetworkArchitecture<double> CreateArchitecture()
+        => new(
+            inputType: InputType.OneDimensional,
+            taskType: NeuralNetworkTaskType.Regression,
+            inputSize: 4,
+            outputSize: 4,
+            layers: [new DenseLayer<double>(4)]);
+
+    private static object GetPrivateField(object instance, string name)
+    {
+        for (Type? type = instance.GetType(); type is not null; type = type.BaseType)
+        {
+            FieldInfo? field = type.GetField(name, BindingFlags.Instance | BindingFlags.NonPublic);
+            if (field is not null)
+                return field.GetValue(instance)
+                    ?? throw new InvalidOperationException($"Field '{name}' was null.");
+        }
+        throw new InvalidOperationException($"Field '{name}' was not found.");
+    }
+}

--- a/tools/ModelPerfProbe/Program.cs
+++ b/tools/ModelPerfProbe/Program.cs
@@ -15,7 +15,18 @@ namespace AiDotNet.Tools.ModelPerfProbe;
 /// </summary>
 internal static class Program
 {
-    private const int CurrentBaselineSchemaVersion = 2;
+    private const int CurrentBaselineSchemaVersion = 3;
+
+    /// <summary>
+    /// Baseline schemas whose numbers this build can still read.
+    /// </summary>
+    /// <remarks>
+    /// Schema 3 adds the commit a baseline was measured at. Schema 2 carries the same metrics
+    /// without it, so it stays comparable - refusing it would have silently disabled the gate for
+    /// the whole window it takes for a new baseline to be published, which is the opposite of what
+    /// a version check is for.
+    /// </remarks>
+    private static readonly int[] ComparableBaselineSchemaVersions = { 2, 3 };
 
     private static readonly string[] RequiredMetrics =
     {
@@ -42,14 +53,17 @@ internal static class Program
                 : JsonSerializer.Deserialize<BaselineDocument>(
                     File.ReadAllText(options.BaselinePath), JsonOptions);
 
-            CompareBaseline(records, baseline, options, diagnostics);
+            IReadOnlyList<BaselineDocument> history = LoadHistory(options.HistoryDirectory, diagnostics);
+            PerfIntent[] intents = LoadIntents(options.PerfIntentPath, diagnostics);
+
+            CompareBaseline(records, baseline, options, diagnostics, history, intents);
             DetectCohortOutliers(records, diagnostics);
             ValidateAbsoluteCeilings(records, options, diagnostics);
 
             var summary = BuildSummary(records, diagnostics, options.ExpectedCount);
             WriteJson(options.OutputPath!, summary);
             if (options.WriteBaselinePath is not null)
-                WriteJson(options.WriteBaselinePath, BuildBaseline(records));
+                WriteJson(options.WriteBaselinePath, BuildBaseline(records, options.Commit));
 
             PrintSummary(summary, options.OutputPath!);
             return diagnostics.Any(d => d.Severity == "error") ? 1 : 0;
@@ -223,10 +237,14 @@ internal static class Program
         IReadOnlyList<CensusRecord> records,
         BaselineDocument? baseline,
         Options options,
-        ICollection<Diagnostic> diagnostics)
+        ICollection<Diagnostic> diagnostics,
+        IReadOnlyList<BaselineDocument>? historyDocuments = null,
+        IReadOnlyList<PerfIntent>? declaredIntents = null)
     {
+        IReadOnlyList<BaselineDocument> history = historyDocuments ?? Array.Empty<BaselineDocument>();
+        IReadOnlyList<PerfIntent> intents = declaredIntents ?? Array.Empty<PerfIntent>();
         if (baseline is null) return;
-        if (baseline.SchemaVersion != CurrentBaselineSchemaVersion)
+        if (Array.IndexOf(ComparableBaselineSchemaVersions, baseline.SchemaVersion) < 0)
         {
             diagnostics.Add(Diagnostic.Warning("<census>", "baseline",
                 $"baseline schema {baseline.SchemaVersion} is not comparable to schema " +
@@ -275,13 +293,53 @@ internal static class Program
                     _ => options.MaxRegressionRatio,
                 };
 
-                double ratio = current / previous;
                 double noiseFloor = metric switch
                 {
                     "allocatedBytes" => 1_048_576.0,
                     "peakWorkingSetBytes" or "peakPrivateMemoryBytes" => 67_108_864.0,
                     _ => 25.0,
                 };
+
+                // WHAT THIS RUN IS JUDGED AGAINST.
+                //
+                // A single prior run cannot tell a step from a spike, and it cannot tell a step
+                // that somebody meant to make from one nobody noticed. With a series it can do
+                // both: find the last SUSTAINED level shift, say which commits it happened
+                // between, and judge this run against the level the fixture has actually been
+                // sitting at since - not against a point from before a change that everyone has
+                // already accepted.
+                //
+                // With too little history this is exactly the old comparison, so nothing loosens
+                // on a repository that has not accumulated a window yet.
+                IReadOnlyList<SeriesPoint> series = SeriesFor(history, record.Fixture, record.Environment, metric);
+                if (series.Count >= MinimumSeriesPoints)
+                {
+                    StepChange? step = FindLastStep(series, limit, noiseFloor);
+                    if (step is not null)
+                    {
+                        PerfIntent? intent = IntentFor(intents, step, record.Fixture, metric);
+                        if (intent is not null)
+                        {
+                            diagnostics.Add(Diagnostic.Warning(record.Fixture, metric,
+                                $"stepped {step.Ratio:F2}x ({step.Before:F2} -> {step.After:F2}) at "
+                                + $"{step.Range}"
+                                + (intent.Origin.Length > 0 ? $", caused by {intent.Origin}" : "")
+                                + $", declared: {intent.Reason}"));
+                        }
+                        else
+                        {
+                            diagnostics.Add(Diagnostic.Error(record.Fixture, metric,
+                                $"stepped {step.Ratio:F2}x ({step.Before:F2} -> {step.After:F2}) at "
+                                + $"{step.Range} and stayed there; limit is {limit:F2}x. Fix it, or "
+                                + "declare it with a Perf-Intent trailer on the commit that caused it"));
+                        }
+                    }
+
+                    previous = ReferenceLevel(series, step);
+                    if (previous <= 0.0) continue;
+                }
+
+                double ratio = current / previous;
                 if (ratio <= limit || current - previous <= noiseFloor) continue;
 
                 bool timing = stability is MetricStability.Timing or MetricStability.VolatileTiming;
@@ -305,6 +363,414 @@ internal static class Program
                 $"no environment-qualified baseline for {environment}; " +
                 $"skipped {missingCount} fixture comparison(s)"));
         }
+    }
+
+    /// <summary>
+    /// Checks the series behaviour the point comparison could not have: a spike is not a step, a
+    /// sustained step is attributed, a declared step is accepted, and an undeclared one is not.
+    /// </summary>
+    private static int RunSeriesSelfTest()
+    {
+        int Fail(string what)
+        {
+            Console.Error.WriteLine($"self-test failed: {what}");
+            return 1;
+        }
+
+        const string Fixture = "SeriesFixture";
+        const string Environment = "test";
+        const string Metric = "peakWorkingSetBytes";
+        double noiseFloor = 67_108_864.0;
+        double limit = 1.6;
+
+        BaselineDocument Point(string commit, int day, double value) => new()
+        {
+            SchemaVersion = CurrentBaselineSchemaVersion,
+            GeneratedUtc = new DateTimeOffset(2026, 1, day, 0, 0, 0, TimeSpan.Zero),
+            Commit = commit,
+            Entries = new[]
+            {
+                new BaselineEntry
+                {
+                    Fixture = Fixture,
+                    Environment = Environment,
+                    Metrics = new Dictionary<string, double> { [Metric] = value },
+                },
+            },
+        };
+
+        // One high reading between low ones is a spike. A point comparison calls that a regression;
+        // a series must not, because the level did not change.
+        var spike = new[]
+        {
+            Point("a", 1, 300_000_000), Point("b", 2, 300_000_000),
+            Point("c", 3, 900_000_000),
+            Point("d", 4, 300_000_000), Point("e", 5, 300_000_000),
+        };
+        if (FindLastStep(SeriesFor(spike, Fixture, Environment, Metric), limit, noiseFloor) is not null)
+            return Fail("a single spike must not read as a step change");
+
+        // A level that rises and STAYS is a step, and it happened between the last low commit and
+        // the first high one.
+        var step = new[]
+        {
+            Point("a", 1, 300_000_000), Point("b", 2, 300_000_000),
+            Point("c", 3, 900_000_000), Point("d", 4, 900_000_000), Point("e", 5, 900_000_000),
+        };
+        StepChange? found = FindLastStep(SeriesFor(step, Fixture, Environment, Metric), limit, noiseFloor);
+        if (found is null) return Fail("a sustained level shift must read as a step change");
+        if (found.FromCommit != "b" || found.ToCommit != "c")
+            return Fail($"the step must be attributed to b..c, not {found.FromCommit}..{found.ToCommit}");
+
+        // Judged against the level it has been sitting at since the step, a run AT that level is
+        // not a fresh regression - which is what stops one accepted change failing forever.
+        double reference = ReferenceLevel(SeriesFor(step, Fixture, Environment, Metric), found);
+        if (Math.Abs(reference - 900_000_000) > 0.5)
+            return Fail($"the reference level after a step must be the level since it, got {reference}");
+
+        // An intent naming the commit accepts it; one naming a different commit does not.
+        var declared = new[] { new PerfIntent { Commit = "c", Reason = "paper fidelity" } };
+        if (IntentFor(declared, found, Fixture, Metric) is null)
+            return Fail("an intent naming the step's commit must cover it");
+        var elsewhere = new[] { new PerfIntent { Commit = "zz", Reason = "something else" } };
+        if (IntentFor(elsewhere, found, Fixture, Metric) is not null)
+            return Fail("an intent naming another commit must not cover this step");
+        var otherMetric = new[] { new PerfIntent { Commit = "c", Metric = "allocatedBytes", Reason = "scoped" } };
+        if (IntentFor(otherMetric, found, Fixture, Metric) is not null)
+            return Fail("an intent scoped to another metric must not cover this step");
+
+        // A reason is mandatory, exactly as a tolerance's why is.
+        var reasonless = new List<Diagnostic>();
+        string path = Path.Combine(Path.GetTempPath(), "perf-intent-" + Guid.NewGuid().ToString("N") + ".json");
+        File.WriteAllText(path, """[{"commit":"c","reason":"   "}]""");
+        try
+        {
+            PerfIntent[] loaded = LoadIntents(path, reasonless);
+            if (loaded.Length != 0 || !reasonless.Any(d => d.Severity == "error"))
+                return Fail("an intent without a reason must be refused");
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+
+        return 0;
+    }
+
+    // ---------------------------------------------------------------- declared intent
+
+    /// <summary>
+    /// A cost change somebody meant to make, declared by the commit that made it.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// A model that becomes paper-faithful usually gets more expensive, and that is not a
+    /// regression - but it is indistinguishable from one by measurement alone. DCRNN is the worked
+    /// case: <c>cb9ecf59db</c> gave it real DiffusionConvolutionalGRU layers carrying graph
+    /// transition matrices and K diffusion steps, and its peak working set rose 1.67x. Correct, and
+    /// more expensive.
+    /// </para>
+    /// <para>
+    /// So intent travels with its cause. A commit that knowingly changes a fixture's cost says so
+    /// in a <c>Perf-Intent:</c> trailer, and the step is accepted and annotated with that sentence
+    /// rather than silently absorbed. This is deliberately not a suppression list maintained
+    /// somewhere else: such a list outlives the reason it was written for, and nobody deletes an
+    /// entry they cannot remember the justification for. A trailer cannot drift from its change
+    /// because it IS its change.
+    /// </para>
+    /// <para>
+    /// A reason is mandatory - an intent record without one is refused - for the same reason a
+    /// tolerance without a stated why is refused elsewhere in this repository.
+    /// </para>
+    /// </remarks>
+    private sealed class PerfIntent
+    {
+        /// <summary>
+        /// The census point this step was first measured at - an endpoint of the detected range.
+        /// </summary>
+        /// <remarks>
+        /// Keyed to the measurement rather than to the source commit, because that is what makes an
+        /// intent EXPIRE. Once the step scrolls out of the history window the entry stops matching
+        /// anything and can be deleted without anyone having to reconstruct why it was written. A
+        /// suppression list keyed to source commits never expires, which is how such lists come to
+        /// outlive their reasons.
+        /// </remarks>
+        [JsonPropertyName("commit")] public string Commit { get; set; } = "";
+
+        /// <summary>The commit that actually caused it, for the message. Informational.</summary>
+        [JsonPropertyName("origin")] public string Origin { get; set; } = "";
+
+        /// <summary>Optional: restricts the intent to one fixture. Empty means any.</summary>
+        [JsonPropertyName("fixture")] public string Fixture { get; set; } = "";
+
+        /// <summary>Optional: restricts the intent to one metric. Empty means any.</summary>
+        [JsonPropertyName("metric")] public string Metric { get; set; } = "";
+
+        [JsonPropertyName("reason")] public string Reason { get; set; } = "";
+
+        public bool Covers(string fixture, string metric) =>
+            (Fixture.Length == 0 || string.Equals(Fixture, fixture, StringComparison.Ordinal))
+            && (Metric.Length == 0 || string.Equals(Metric, metric, StringComparison.Ordinal));
+    }
+
+    private static PerfIntent[] LoadIntents(string? path, ICollection<Diagnostic> diagnostics)
+    {
+        if (path is null) return Array.Empty<PerfIntent>();
+        if (!File.Exists(path))
+        {
+            diagnostics.Add(Diagnostic.Warning("<census>", "intent",
+                $"no declared-intent file at {path}; every step change will be reported as a regression"));
+            return Array.Empty<PerfIntent>();
+        }
+
+        PerfIntent[] intents =
+            JsonSerializer.Deserialize<PerfIntent[]>(File.ReadAllText(path), JsonOptions)
+            ?? Array.Empty<PerfIntent>();
+
+        var usable = new List<PerfIntent>();
+        foreach (PerfIntent intent in intents)
+        {
+            if (intent.Commit.Length == 0) continue;
+            if (intent.Reason.Trim().Length == 0)
+            {
+                diagnostics.Add(Diagnostic.Error("<census>", "intent",
+                    $"the declared intent for {intent.Commit} has no reason; a cost change is "
+                    + "accepted only with a stated justification"));
+                continue;
+            }
+            usable.Add(intent);
+        }
+
+        return usable.ToArray();
+    }
+
+    /// <summary>The intent covering a step, if any commit it could be attributed to declared one.</summary>
+    private static PerfIntent? IntentFor(
+        IReadOnlyList<PerfIntent> intents, StepChange step, string fixture, string metric)
+    {
+        foreach (PerfIntent intent in intents)
+        {
+            if (!intent.Covers(fixture, metric)) continue;
+            if (intent.Commit.Length == 0) continue;
+            if (Same(step.ToCommit, intent.Commit) || Same(step.FromCommit, intent.Commit))
+            {
+                return intent;
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>Whether two commit references name the same commit, allowing either to be short.</summary>
+    private static bool Same(string left, string right)
+    {
+        if (left.Length == 0 || right.Length == 0) return false;
+        return left.StartsWith(right, StringComparison.OrdinalIgnoreCase)
+            || right.StartsWith(left, StringComparison.OrdinalIgnoreCase);
+    }
+
+    // ---------------------------------------------------------------- the series
+
+    /// <summary>Fewest history points before a series is worth reasoning about as a series.</summary>
+    /// <remarks>
+    /// Below this a median is barely different from the single prior point, so the comparison stays
+    /// exactly what it was. This is what keeps the change from loosening anything: a repository with
+    /// no history behaves identically to before.
+    /// </remarks>
+    private const int MinimumSeriesPoints = 4;
+
+    /// <summary>Fewest points on each side of a level shift before it counts as sustained.</summary>
+    /// <remarks>Two, so a single anomalous run cannot be read as a step. This is the property a
+    /// point-to-point comparison cannot have at any threshold.</remarks>
+    private const int MinimumSegmentPoints = 2;
+
+    /// <summary>One measurement of one fixture, in order.</summary>
+    private sealed class SeriesPoint
+    {
+        public SeriesPoint(string commit, DateTimeOffset takenUtc, double value)
+        {
+            Commit = commit;
+            TakenUtc = takenUtc;
+            Value = value;
+        }
+
+        public string Commit { get; }
+        public DateTimeOffset TakenUtc { get; }
+        public double Value { get; }
+    }
+
+    /// <summary>A sustained level shift inside a series, and the commits it happened between.</summary>
+    private sealed class StepChange
+    {
+        public StepChange(double before, double after, string fromCommit, string toCommit)
+        {
+            Before = before;
+            After = after;
+            FromCommit = fromCommit;
+            ToCommit = toCommit;
+        }
+
+        public double Before { get; }
+        public double After { get; }
+
+        /// <summary>The last commit measured at the old level.</summary>
+        public string FromCommit { get; }
+
+        /// <summary>The first commit measured at the new level; the culprit is in (From, To].</summary>
+        public string ToCommit { get; }
+
+        public double Ratio => Before > 0.0 ? After / Before : double.PositiveInfinity;
+
+        public string Range =>
+            FromCommit.Length == 0 || ToCommit.Length == 0
+                ? "an unattributable range (the window predates commit-stamped baselines)"
+                : $"{Short(FromCommit)}..{Short(ToCommit)}";
+
+        private static string Short(string sha) => sha.Length <= 10 ? sha : sha.Substring(0, 10);
+    }
+
+    /// <summary>
+    /// One fixture's history of one metric, oldest measurement first.
+    /// </summary>
+    /// <remarks>
+    /// Environment-qualified like the point comparison is: a measurement from a different processor
+    /// is a different population, and mixing them would manufacture steps out of runner allocation.
+    /// </remarks>
+    private static IReadOnlyList<SeriesPoint> SeriesFor(
+        IReadOnlyList<BaselineDocument> history, string fixture, string environment, string metric)
+    {
+        MetricStability stability = ClassifyMetric(metric);
+        string wanted = SeriesEnvironmentKey(environment, stability);
+
+        var points = new List<SeriesPoint>();
+        foreach (BaselineDocument document in history)
+        {
+            foreach (BaselineEntry entry in document.Entries)
+            {
+                if (!string.Equals(entry.Fixture, fixture, StringComparison.Ordinal)) continue;
+                if (!string.Equals(SeriesEnvironmentKey(entry.Environment, stability), wanted,
+                        StringComparison.Ordinal)) continue;
+                if (!entry.Metrics.TryGetValue(metric, out double value) || value <= 0.0) continue;
+                points.Add(new SeriesPoint(document.Commit, document.GeneratedUtc, value));
+                break;
+            }
+        }
+
+        points.Sort((left, right) => left.TakenUtc.CompareTo(right.TakenUtc));
+        return points;
+    }
+
+    /// <summary>
+    /// How much of the environment a metric's series has to agree on.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The point comparison qualifies on the whole environment, processor model included, and that
+    /// is right for timing: the same code on an EPYC 9V74 and an EPYC 7763 is not the same
+    /// measurement. Carrying that rule into a SERIES breaks it, though, and the census showed how:
+    /// the runs of 25, 26, 27 and 28 August landed on 7763, 9V74, 7763 and 7763, so a
+    /// processor-qualified window of four runs held only three usable points and step detection
+    /// never engaged. Runner allocation is not something this repository controls, so a series
+    /// keyed that tightly would stay too shallow to detect anything, permanently.
+    /// </para>
+    /// <para>
+    /// Allocated bytes and exact counts are deterministic - the census's own null-pair study puts
+    /// allocation at a median ratio of 1.000 - so they are comparable across processor models.
+    /// Process memory peaks are allocator-quantised and scale with the degree of parallelism, so
+    /// they keep the processor COUNT and drop only the model. Timing keeps everything.
+    /// </para>
+    /// </remarks>
+    private static string SeriesEnvironmentKey(string environment, MetricStability stability)
+    {
+        if (stability is MetricStability.Timing or MetricStability.VolatileTiming) return environment;
+
+        // frameworkMajor|osPlatform|arch|engine|processorCount|processorModel
+        int lastSeparator = environment.LastIndexOf('|');
+        return lastSeparator < 0 ? environment : environment.Substring(0, lastSeparator);
+    }
+
+    private static double Median(IReadOnlyList<double> values)
+    {
+        if (values.Count == 0) return 0.0;
+        double[] sorted = values.ToArray();
+        Array.Sort(sorted);
+        int middle = sorted.Length / 2;
+        return sorted.Length % 2 == 1
+            ? sorted[middle]
+            : (sorted[middle - 1] + sorted[middle]) / 2.0;
+    }
+
+    /// <summary>
+    /// The most recent sustained level shift in a series, or null when the series is one level.
+    /// </summary>
+    /// <remarks>
+    /// Split at every interior index and take the latest split whose two sides differ by more than
+    /// the metric's own limit and its noise floor, with at least
+    /// <see cref="MinimumSegmentPoints"/> measurements on each side. Medians rather than means, so
+    /// one outlier on either side cannot manufacture or hide a step.
+    /// </remarks>
+    private static StepChange? FindLastStep(
+        IReadOnlyList<SeriesPoint> series, double limit, double noiseFloor)
+    {
+        // Segment greedily from the start rather than scanning backwards for any split that
+        // qualifies. Scanning backwards attributes a step one measurement too late: with
+        // 300, 300, 900, 900, 900 the split before the last two also "qualifies", because the
+        // median of 300, 300, 900 is still 300 - so the change gets blamed on the commit AFTER the
+        // one that caused it. Taking the earliest split that separates the levels, then looking for
+        // further steps only beyond it, names the first run that measured the new level, which is
+        // the commit range the culprit is actually in.
+        StepChange? latest = null;
+        int start = 0;
+
+        while (series.Count - start >= MinimumSegmentPoints * 2)
+        {
+            int found = -1;
+            double was = 0.0;
+            double now = 0.0;
+
+            for (int split = start + MinimumSegmentPoints; split <= series.Count - MinimumSegmentPoints; split++)
+            {
+                var before = new List<double>();
+                for (int i = start; i < split; i++) before.Add(series[i].Value);
+                var after = new List<double>();
+                for (int i = split; i < series.Count; i++) after.Add(series[i].Value);
+
+                double left = Median(before);
+                double right = Median(after);
+                if (left <= 0.0) continue;
+                if (right / left <= limit || right - left <= noiseFloor) continue;
+
+                found = split;
+                was = left;
+                now = right;
+                break;
+            }
+
+            if (found < 0) break;
+            latest = new StepChange(was, now, series[found - 1].Commit, series[found].Commit);
+            start = found;
+        }
+
+        return latest;
+    }
+
+    /// <summary>
+    /// The level the current run should be judged against: the series median since its last step.
+    /// </summary>
+    private static double ReferenceLevel(IReadOnlyList<SeriesPoint> series, StepChange? step)
+    {
+        if (step is null) return Median(series.Select(p => p.Value).ToList());
+
+        var since = new List<double>();
+        bool reached = false;
+        foreach (SeriesPoint point in series)
+        {
+            if (!reached && string.Equals(point.Commit, step.ToCommit, StringComparison.Ordinal))
+                reached = true;
+            if (reached) since.Add(point.Value);
+        }
+
+        return since.Count > 0 ? Median(since) : Median(series.Select(p => p.Value).ToList());
     }
 
     private static void DetectCohortOutliers(
@@ -489,10 +955,62 @@ internal static class Program
         };
     }
 
-    private static BaselineDocument BuildBaseline(IReadOnlyList<CensusRecord> records) => new()
+    /// <summary>
+    /// Loads the prior baselines that form the series, newest last.
+    /// </summary>
+    /// <remarks>
+    /// Every file in the directory is a baseline published by an earlier census run. A file that
+    /// will not parse is reported and skipped rather than failing the census: losing one point of
+    /// history weakens attribution slightly, while refusing to run at all would take the whole gate
+    /// down over a corrupt artifact.
+    /// </remarks>
+    private static IReadOnlyList<BaselineDocument> LoadHistory(
+        string? directory, ICollection<Diagnostic> diagnostics)
+    {
+        if (directory is null || !Directory.Exists(directory)) return Array.Empty<BaselineDocument>();
+
+        var documents = new List<BaselineDocument>();
+        foreach (string path in Directory.GetFiles(directory, "*.json", SearchOption.AllDirectories)
+                     .OrderBy(p => p, StringComparer.Ordinal))
+        {
+            BaselineDocument? document;
+            try
+            {
+                document = JsonSerializer.Deserialize<BaselineDocument>(File.ReadAllText(path), JsonOptions);
+            }
+            catch (JsonException ex)
+            {
+                diagnostics.Add(Diagnostic.Warning("<census>", "history",
+                    $"could not read {Path.GetFileName(path)} as a baseline ({ex.Message}); "
+                    + "that point is missing from the series"));
+                continue;
+            }
+
+            if (document is null) continue;
+            if (Array.IndexOf(ComparableBaselineSchemaVersions, document.SchemaVersion) < 0) continue;
+            documents.Add(document);
+        }
+
+        documents.Sort((left, right) => left.GeneratedUtc.CompareTo(right.GeneratedUtc));
+
+        // Say how much history the gate actually has. A census that silently fell back to a single
+        // prior point looks identical in its output to one reasoning over a window, and the two
+        // give different answers - so the depth is stated rather than assumed.
+        diagnostics.Add(Diagnostic.Warning("<census>", "history",
+            documents.Count >= MinimumSeriesPoints
+                ? $"comparing against a series of {documents.Count} prior census run(s)"
+                : $"only {documents.Count} prior census run(s) available; "
+                  + $"{MinimumSeriesPoints} are needed before step detection engages, so this run "
+                  + "is compared against the single most recent baseline"));
+
+        return documents;
+    }
+
+    private static BaselineDocument BuildBaseline(IReadOnlyList<CensusRecord> records, string commit) => new()
     {
         SchemaVersion = CurrentBaselineSchemaVersion,
         GeneratedUtc = DateTimeOffset.UtcNow,
+        Commit = commit,
         Entries = records.Where(record => record.Status == "ok").Select(record => new BaselineEntry
         {
             Fixture = record.Fixture,
@@ -569,11 +1087,12 @@ internal static class Program
                 || diagnostics[0].Metric != "status"
                 || !diagnostics[0].Message.Contains("backward", StringComparison.Ordinal))
                 return Fail("timeout phase diagnostic");
-            BaselineDocument generatedBaseline = BuildBaseline(records);
+            BaselineDocument generatedBaseline = BuildBaseline(records, "0123456789abcdef");
             if (generatedBaseline.SchemaVersion != CurrentBaselineSchemaVersion
                 || generatedBaseline.Entries.Length != 1
+                || generatedBaseline.Commit != "0123456789abcdef"
                 || !generatedBaseline.Entries[0].Environment.EndsWith("|test-cpu", StringComparison.Ordinal))
-                return Fail("generated baseline schema and processor-qualified environment key");
+                return Fail("generated baseline schema, commit stamp and processor-qualified environment key");
 
             diagnostics.Clear();
             CompareBaseline(records, new BaselineDocument { SchemaVersion = 1 }, new Options(), diagnostics);
@@ -581,6 +1100,15 @@ internal static class Program
                 || diagnostics[0].Metric != "baseline"
                 || !diagnostics[0].Message.Contains("not comparable", StringComparison.Ordinal))
                 return Fail("incompatible baseline schema warning");
+
+            // A baseline written by the previous release still has to be readable, or the gate
+            // silently stops comparing for as long as it takes a new one to be published.
+            diagnostics.Clear();
+            CompareBaseline(records, new BaselineDocument { SchemaVersion = 2 }, new Options(), diagnostics);
+            if (diagnostics.Any(d => d.Metric == "baseline" && d.Message.Contains("not comparable", StringComparison.Ordinal)))
+                return Fail("schema 2 baseline must stay comparable");
+
+            if (RunSeriesSelfTest() is int seriesFailure and not 0) return seriesFailure;
 
             // Expensive models are not training hot-path outliers when their train/forward ratio
             // matches their peers; a cheap-forward model with extreme training amplification is.
@@ -654,6 +1182,15 @@ internal static class Program
         public string? OutputPath { get; private set; }
         public string? BaselinePath { get; private set; }
         public string? WriteBaselinePath { get; private set; }
+
+        /// <summary>Directory of prior baseline documents, forming the series to judge against.</summary>
+        public string? HistoryDirectory { get; private set; }
+
+        /// <summary>File of cost changes that were made deliberately, each with its reason.</summary>
+        public string? PerfIntentPath { get; private set; }
+
+        /// <summary>The commit these measurements are taken at, stamped into the written baseline.</summary>
+        public string Commit { get; private set; } = "";
         public int? ExpectedCount { get; private set; }
         public double MaxRegressionRatio { get; private set; } = 2.5;
         public double MaxAllocationRegressionRatio { get; private set; } = 2.5;
@@ -693,6 +1230,9 @@ internal static class Program
                     case "--output": options.OutputPath = Next(); break;
                     case "--baseline": options.BaselinePath = Next(); break;
                     case "--write-baseline": options.WriteBaselinePath = Next(); break;
+                    case "--history": options.HistoryDirectory = Next(); break;
+                    case "--perf-intent": options.PerfIntentPath = Next(); break;
+                    case "--commit": options.Commit = Next() ?? ""; break;
                     case "--expected-count": options.ExpectedCount = int.Parse(Next(), CultureInfo.InvariantCulture); break;
                     case "--max-regression-ratio": options.MaxRegressionRatio = double.Parse(Next(), CultureInfo.InvariantCulture); break;
                     case "--max-allocation-regression-ratio": options.MaxAllocationRegressionRatio = double.Parse(Next(), CultureInfo.InvariantCulture); break;
@@ -786,6 +1326,14 @@ internal static class Program
     {
         [JsonPropertyName("schemaVersion")] public int SchemaVersion { get; set; }
         [JsonPropertyName("generatedUtc")] public DateTimeOffset GeneratedUtc { get; set; }
+
+        /// <summary>The commit these measurements were taken at, so a step can name its culprit.</summary>
+        /// <remarks>
+        /// Absent in schema 2, which recorded only the numbers. A step detected across a window that
+        /// includes schema-2 points can still be detected; it just cannot be attributed, and says so.
+        /// </remarks>
+        [JsonPropertyName("commit")] public string Commit { get; set; } = "";
+
         [JsonPropertyName("entries")] public BaselineEntry[] Entries { get; set; } = Array.Empty<BaselineEntry>();
     }
 

--- a/tools/ModelPerfProbe/Program.cs
+++ b/tools/ModelPerfProbe/Program.cs
@@ -252,6 +252,9 @@ internal static class Program
             return;
         }
 
+        Dictionary<(string Fixture, string EnvironmentKey, string Metric), List<SeriesPoint>> seriesIndex =
+            IndexHistory(history);
+
         var index = baseline.Entries.ToDictionary(
             entry => (entry.Fixture, entry.Environment),
             entry => entry,
@@ -311,7 +314,11 @@ internal static class Program
                 //
                 // With too little history this is exactly the old comparison, so nothing loosens
                 // on a repository that has not accumulated a window yet.
-                IReadOnlyList<SeriesPoint> series = SeriesFor(history, record.Fixture, record.Environment, metric);
+                (string Fixture, string EnvironmentKey, string Metric) seriesKey =
+                    (record.Fixture, SeriesEnvironmentKey(record.Environment, stability), metric);
+                IReadOnlyList<SeriesPoint> series = seriesIndex.TryGetValue(seriesKey, out List<SeriesPoint>? cached)
+                    ? cached
+                    : Array.Empty<SeriesPoint>();
                 if (series.Count >= MinimumSeriesPoints)
                 {
                     StepChange? step = FindLastStep(series, limit, noiseFloor);
@@ -331,7 +338,8 @@ internal static class Program
                             diagnostics.Add(Diagnostic.Error(record.Fixture, metric,
                                 $"stepped {step.Ratio:F2}x ({step.Before:F2} -> {step.After:F2}) at "
                                 + $"{step.Range} and stayed there; limit is {limit:F2}x. Fix it, or "
-                                + "declare it with a Perf-Intent trailer on the commit that caused it"));
+                                + "declare it in .github/model-performance-intent.json with the census commit, "
+                                + "fixture, metric, and reason"));
                         }
                     }
 
@@ -383,9 +391,10 @@ internal static class Program
         double noiseFloor = 67_108_864.0;
         double limit = 1.6;
 
-        BaselineDocument Point(string commit, int day, double value) => new()
+        BaselineDocument Point(string commit, int day, double value,
+            int schemaVersion = CurrentBaselineSchemaVersion) => new()
         {
-            SchemaVersion = CurrentBaselineSchemaVersion,
+            SchemaVersion = schemaVersion,
             GeneratedUtc = new DateTimeOffset(2026, 1, day, 0, 0, 0, TimeSpan.Zero),
             Commit = commit,
             Entries = new[]
@@ -399,13 +408,31 @@ internal static class Program
             },
         };
 
+        // Duplicate fixture entries in one artifact retain the first usable metric, matching the
+        // pre-index scan. This guards the one-time index against silently changing malformed-input
+        // behavior.
+        BaselineDocument duplicate = Point("fffffff", 6, 300_000_000);
+        duplicate.Entries = duplicate.Entries.Concat(new[]
+        {
+            new BaselineEntry
+            {
+                Fixture = Fixture,
+                Environment = Environment,
+                Metrics = new Dictionary<string, double> { [Metric] = 900_000_000 },
+            },
+        }).ToArray();
+        IReadOnlyList<SeriesPoint> duplicateSeries = SeriesFor(
+            new[] { duplicate }, Fixture, Environment, Metric);
+        if (duplicateSeries.Count != 1 || Math.Abs(duplicateSeries[0].Value - 300_000_000) > 0.5)
+            return Fail("the history index must preserve first-entry-per-document behavior");
+
         // One high reading between low ones is a spike. A point comparison calls that a regression;
         // a series must not, because the level did not change.
         var spike = new[]
         {
-            Point("a", 1, 300_000_000), Point("b", 2, 300_000_000),
-            Point("c", 3, 900_000_000),
-            Point("d", 4, 300_000_000), Point("e", 5, 300_000_000),
+            Point("aaaaaaa", 1, 300_000_000), Point("bbbbbbb", 2, 300_000_000),
+            Point("ccccccc", 3, 900_000_000),
+            Point("ddddddd", 4, 300_000_000), Point("eeeeeee", 5, 300_000_000),
         };
         if (FindLastStep(SeriesFor(spike, Fixture, Environment, Metric), limit, noiseFloor) is not null)
             return Fail("a single spike must not read as a step change");
@@ -414,13 +441,15 @@ internal static class Program
         // the first high one.
         var step = new[]
         {
-            Point("a", 1, 300_000_000), Point("b", 2, 300_000_000),
-            Point("c", 3, 900_000_000), Point("d", 4, 900_000_000), Point("e", 5, 900_000_000),
+            Point("aaaaaaa", 1, 300_000_000), Point("bbbbbbb", 2, 300_000_000),
+            Point("ccccccc", 3, 900_000_000), Point("ddddddd", 4, 900_000_000),
+            Point("eeeeeee", 5, 900_000_000),
         };
-        StepChange? found = FindLastStep(SeriesFor(step, Fixture, Environment, Metric), limit, noiseFloor);
+        StepChange? found = FindLastStep(
+            SeriesFor(step.Reverse().ToArray(), Fixture, Environment, Metric), limit, noiseFloor);
         if (found is null) return Fail("a sustained level shift must read as a step change");
-        if (found.FromCommit != "b" || found.ToCommit != "c")
-            return Fail($"the step must be attributed to b..c, not {found.FromCommit}..{found.ToCommit}");
+        if (found.FromCommit != "bbbbbbb" || found.ToCommit != "ccccccc")
+            return Fail($"the step must be attributed to bbbbbbb..ccccccc, not {found.FromCommit}..{found.ToCommit}");
 
         // Judged against the level it has been sitting at since the step, a run AT that level is
         // not a fresh regression - which is what stops one accepted change failing forever.
@@ -428,26 +457,41 @@ internal static class Program
         if (Math.Abs(reference - 900_000_000) > 0.5)
             return Fail($"the reference level after a step must be the level since it, got {reference}");
 
-        // An intent naming the commit accepts it; one naming a different commit does not.
-        var declared = new[] { new PerfIntent { Commit = "c", Reason = "paper fidelity" } };
+        // Schema-2 points have no commit. The boundary index, not an empty commit lookup, must
+        // still exclude the old level from the post-step reference median.
+        var unstamped = new[]
+        {
+            Point("", 1, 300_000_000, schemaVersion: 2), Point("", 2, 300_000_000, schemaVersion: 2),
+            Point("", 3, 900_000_000, schemaVersion: 2), Point("", 4, 900_000_000, schemaVersion: 2),
+        };
+        IReadOnlyList<SeriesPoint> unstampedSeries = SeriesFor(unstamped, Fixture, Environment, Metric);
+        StepChange? unstampedStep = FindLastStep(unstampedSeries, limit, noiseFloor);
+        if (unstampedStep is null || Math.Abs(ReferenceLevel(unstampedSeries, unstampedStep) - 900_000_000) > 0.5)
+            return Fail("an unstamped schema-2 step must use its boundary index for the new reference level");
+
+        // An intent naming the census commit accepts it; one naming a different commit does not.
+        var declared = new[] { new PerfIntent { Commit = "ccccccc", Reason = "paper fidelity" } };
         if (IntentFor(declared, found, Fixture, Metric) is null)
             return Fail("an intent naming the step's commit must cover it");
-        var elsewhere = new[] { new PerfIntent { Commit = "zz", Reason = "something else" } };
+        var elsewhere = new[] { new PerfIntent { Commit = "zzzzzzz", Reason = "something else" } };
         if (IntentFor(elsewhere, found, Fixture, Metric) is not null)
             return Fail("an intent naming another commit must not cover this step");
-        var otherMetric = new[] { new PerfIntent { Commit = "c", Metric = "allocatedBytes", Reason = "scoped" } };
+        var otherMetric = new[] { new PerfIntent { Commit = "ccccccc", Metric = "allocatedBytes", Reason = "scoped" } };
         if (IntentFor(otherMetric, found, Fixture, Metric) is not null)
             return Fail("an intent scoped to another metric must not cover this step");
+        if (Same("ccccccc", "c"))
+            return Fail("a commit reference shorter than the collision-safe floor must never match");
 
         // A reason is mandatory, exactly as a tolerance's why is.
         var reasonless = new List<Diagnostic>();
         string path = Path.Combine(Path.GetTempPath(), "perf-intent-" + Guid.NewGuid().ToString("N") + ".json");
-        File.WriteAllText(path, """[{"commit":"c","reason":"   "}]""");
+        File.WriteAllText(path,
+            """[{"commit":"ccccccc","reason":"   "},{"commit":"c","reason":"short"},{"commit":"","reason":"missing"}]""");
         try
         {
             PerfIntent[] loaded = LoadIntents(path, reasonless);
-            if (loaded.Length != 0 || !reasonless.Any(d => d.Severity == "error"))
-                return Fail("an intent without a reason must be refused");
+            if (loaded.Length != 0 || reasonless.Count(d => d.Severity == "error") != 3)
+                return Fail("reasonless, short, and empty commit intents must each be refused with a diagnostic");
         }
         finally
         {
@@ -459,8 +503,12 @@ internal static class Program
 
     // ---------------------------------------------------------------- declared intent
 
+    /// <summary>Shortest commit prefix that an intent may match without unsafe overreach.</summary>
+    /// <remarks>Seven characters is Git's conventional abbreviation floor.</remarks>
+    private const int MinimumCommitReferenceLength = 7;
+
     /// <summary>
-    /// A cost change somebody meant to make, declared by the commit that made it.
+    /// A deliberate cost change declared in the repository-owned performance-intent file.
     /// </summary>
     /// <remarks>
     /// <para>
@@ -471,12 +519,10 @@ internal static class Program
     /// more expensive.
     /// </para>
     /// <para>
-    /// So intent travels with its cause. A commit that knowingly changes a fixture's cost says so
-    /// in a <c>Perf-Intent:</c> trailer, and the step is accepted and annotated with that sentence
-    /// rather than silently absorbed. This is deliberately not a suppression list maintained
-    /// somewhere else: such a list outlives the reason it was written for, and nobody deletes an
-    /// entry they cannot remember the justification for. A trailer cannot drift from its change
-    /// because it IS its change.
+    /// Deliberate changes are recorded in <c>.github/model-performance-intent.json</c> with the
+    /// census commit, fixture, metric, and reason. The checked-in list stays auditable, while the
+    /// census-commit key makes each record expire naturally when that measurement leaves the
+    /// history window.
     /// </para>
     /// <para>
     /// A reason is mandatory - an intent record without one is refused - for the same reason a
@@ -509,8 +555,8 @@ internal static class Program
         [JsonPropertyName("reason")] public string Reason { get; set; } = "";
 
         public bool Covers(string fixture, string metric) =>
-            (Fixture.Length == 0 || string.Equals(Fixture, fixture, StringComparison.Ordinal))
-            && (Metric.Length == 0 || string.Equals(Metric, metric, StringComparison.Ordinal));
+            (string.IsNullOrEmpty(Fixture) || string.Equals(Fixture, fixture, StringComparison.Ordinal))
+            && (string.IsNullOrEmpty(Metric) || string.Equals(Metric, metric, StringComparison.Ordinal));
     }
 
     private static PerfIntent[] LoadIntents(string? path, ICollection<Diagnostic> diagnostics)
@@ -530,14 +576,31 @@ internal static class Program
         var usable = new List<PerfIntent>();
         foreach (PerfIntent intent in intents)
         {
-            if (intent.Commit.Length == 0) continue;
-            if (intent.Reason.Trim().Length == 0)
+            string commit = intent.Commit?.Trim() ?? "";
+            if (commit.Length < MinimumCommitReferenceLength)
+            {
+                string displayed = commit.Length == 0 ? "<empty>" : commit;
+                diagnostics.Add(Diagnostic.Error("<census>", "intent",
+                    $"the declared intent for fixture '{intent.Fixture ?? ""}' names commit '{displayed}'; "
+                    + $"at least {MinimumCommitReferenceLength} characters are required so a short prefix "
+                    + "cannot cover unrelated census commits"));
+                continue;
+            }
+
+            string reason = intent.Reason?.Trim() ?? "";
+            if (reason.Length == 0)
             {
                 diagnostics.Add(Diagnostic.Error("<census>", "intent",
-                    $"the declared intent for {intent.Commit} has no reason; a cost change is "
+                    $"the declared intent for {commit} has no reason; a cost change is "
                     + "accepted only with a stated justification"));
                 continue;
             }
+
+            intent.Commit = commit;
+            intent.Origin = intent.Origin?.Trim() ?? "";
+            intent.Fixture = intent.Fixture?.Trim() ?? "";
+            intent.Metric = intent.Metric?.Trim() ?? "";
+            intent.Reason = reason;
             usable.Add(intent);
         }
 
@@ -551,7 +614,7 @@ internal static class Program
         foreach (PerfIntent intent in intents)
         {
             if (!intent.Covers(fixture, metric)) continue;
-            if (intent.Commit.Length == 0) continue;
+            if (string.IsNullOrEmpty(intent.Commit)) continue;
             if (Same(step.ToCommit, intent.Commit) || Same(step.FromCommit, intent.Commit))
             {
                 return intent;
@@ -561,10 +624,12 @@ internal static class Program
         return null;
     }
 
-    /// <summary>Whether two commit references name the same commit, allowing either to be short.</summary>
-    private static bool Same(string left, string right)
+    /// <summary>Whether two collision-safe commit references name the same commit.</summary>
+    private static bool Same(string? left, string? right)
     {
-        if (left.Length == 0 || right.Length == 0) return false;
+        if (left is null || right is null
+            || left.Length < MinimumCommitReferenceLength || right.Length < MinimumCommitReferenceLength)
+            return false;
         return left.StartsWith(right, StringComparison.OrdinalIgnoreCase)
             || right.StartsWith(left, StringComparison.OrdinalIgnoreCase);
     }
@@ -589,7 +654,7 @@ internal static class Program
     {
         public SeriesPoint(string commit, DateTimeOffset takenUtc, double value)
         {
-            Commit = commit;
+            Commit = commit ?? "";
             TakenUtc = takenUtc;
             Value = value;
         }
@@ -602,12 +667,13 @@ internal static class Program
     /// <summary>A sustained level shift inside a series, and the commits it happened between.</summary>
     private sealed class StepChange
     {
-        public StepChange(double before, double after, string fromCommit, string toCommit)
+        public StepChange(double before, double after, string fromCommit, string toCommit, int boundaryIndex)
         {
             Before = before;
             After = after;
-            FromCommit = fromCommit;
-            ToCommit = toCommit;
+            FromCommit = fromCommit ?? "";
+            ToCommit = toCommit ?? "";
+            BoundaryIndex = boundaryIndex;
         }
 
         public double Before { get; }
@@ -618,6 +684,9 @@ internal static class Program
 
         /// <summary>The first commit measured at the new level; the culprit is in (From, To].</summary>
         public string ToCommit { get; }
+
+        /// <summary>Index of the first measurement at the new level.</summary>
+        public int BoundaryIndex { get; }
 
         public double Ratio => Before > 0.0 ? After / Before : double.PositiveInfinity;
 
@@ -640,24 +709,47 @@ internal static class Program
         IReadOnlyList<BaselineDocument> history, string fixture, string environment, string metric)
     {
         MetricStability stability = ClassifyMetric(metric);
-        string wanted = SeriesEnvironmentKey(environment, stability);
+        var key = (Fixture: fixture, EnvironmentKey: SeriesEnvironmentKey(environment, stability), Metric: metric);
+        Dictionary<(string Fixture, string EnvironmentKey, string Metric), List<SeriesPoint>> index =
+            IndexHistory(history);
+        return index.TryGetValue(key, out List<SeriesPoint>? points)
+            ? points
+            : Array.Empty<SeriesPoint>();
+    }
 
-        var points = new List<SeriesPoint>();
-        foreach (BaselineDocument document in history)
+    /// <summary>Indexes every usable history point once for constant-time series lookup.</summary>
+    /// <remarks>
+    /// A per-document key set preserves the previous first-matching-entry behavior when a malformed
+    /// artifact contains duplicate fixture entries. Documents are ordered here so every cached
+    /// series remains chronological even when callers provide an unsorted history collection.
+    /// </remarks>
+    private static Dictionary<(string Fixture, string EnvironmentKey, string Metric), List<SeriesPoint>>
+        IndexHistory(IReadOnlyList<BaselineDocument> history)
+    {
+        var index = new Dictionary<(string Fixture, string EnvironmentKey, string Metric), List<SeriesPoint>>();
+        foreach (BaselineDocument document in history.OrderBy(item => item.GeneratedUtc))
         {
+            var seenInDocument = new HashSet<(string Fixture, string EnvironmentKey, string Metric)>();
             foreach (BaselineEntry entry in document.Entries)
             {
-                if (!string.Equals(entry.Fixture, fixture, StringComparison.Ordinal)) continue;
-                if (!string.Equals(SeriesEnvironmentKey(entry.Environment, stability), wanted,
-                        StringComparison.Ordinal)) continue;
-                if (!entry.Metrics.TryGetValue(metric, out double value) || value <= 0.0) continue;
-                points.Add(new SeriesPoint(document.Commit, document.GeneratedUtc, value));
-                break;
+                foreach ((string metric, double value) in entry.Metrics)
+                {
+                    if (value <= 0.0) continue;
+                    var key = (
+                        Fixture: entry.Fixture,
+                        EnvironmentKey: SeriesEnvironmentKey(entry.Environment, ClassifyMetric(metric)),
+                        Metric: metric);
+                    if (!seenInDocument.Add(key)) continue;
+                    if (!index.TryGetValue(key, out List<SeriesPoint>? points))
+                    {
+                        points = new List<SeriesPoint>();
+                        index.Add(key, points);
+                    }
+                    points.Add(new SeriesPoint(document.Commit, document.GeneratedUtc, value));
+                }
             }
         }
-
-        points.Sort((left, right) => left.TakenUtc.CompareTo(right.TakenUtc));
-        return points;
+        return index;
     }
 
     /// <summary>
@@ -747,7 +839,7 @@ internal static class Program
             }
 
             if (found < 0) break;
-            latest = new StepChange(was, now, series[found - 1].Commit, series[found].Commit);
+            latest = new StepChange(was, now, series[found - 1].Commit, series[found].Commit, found);
             start = found;
         }
 
@@ -759,18 +851,11 @@ internal static class Program
     /// </summary>
     private static double ReferenceLevel(IReadOnlyList<SeriesPoint> series, StepChange? step)
     {
-        if (step is null) return Median(series.Select(p => p.Value).ToList());
+        if (step is null) return Median(series.Select(point => point.Value).ToList());
+        if (step.BoundaryIndex < 0 || step.BoundaryIndex >= series.Count)
+            return Median(series.Select(point => point.Value).ToList());
 
-        var since = new List<double>();
-        bool reached = false;
-        foreach (SeriesPoint point in series)
-        {
-            if (!reached && string.Equals(point.Commit, step.ToCommit, StringComparison.Ordinal))
-                reached = true;
-            if (reached) since.Add(point.Value);
-        }
-
-        return since.Count > 0 ? Median(since) : Median(series.Select(p => p.Value).ToList());
+        return Median(series.Skip(step.BoundaryIndex).Select(point => point.Value).ToList());
     }
 
     private static void DetectCohortOutliers(
@@ -790,8 +875,8 @@ internal static class Program
             double[] values = cohort.Select(r => Math.Log(1.0 + TrainingAmplification(r)))
                 .OrderBy(v => v).ToArray();
             if (values.Length < 5) continue;
-            double median = Median(values);
-            double mad = Median(values.Select(v => Math.Abs(v - median)).OrderBy(v => v).ToArray());
+            double median = MedianOfSorted(values);
+            double mad = MedianOfSorted(values.Select(v => Math.Abs(v - median)).OrderBy(v => v).ToArray());
             if (mad <= 1e-9) continue;
 
             foreach (CensusRecord record in cohort)
@@ -813,8 +898,8 @@ internal static class Program
         {
             double[] values = cohort.Select(r => Math.Log(1.0 + r.Metric("peakWorkingSetBytes"))).OrderBy(v => v).ToArray();
             if (values.Length < 5) continue;
-            double median = Median(values);
-            double mad = Median(values.Select(v => Math.Abs(v - median)).OrderBy(v => v).ToArray());
+            double median = MedianOfSorted(values);
+            double mad = MedianOfSorted(values.Select(v => Math.Abs(v - median)).OrderBy(v => v).ToArray());
             if (mad <= 1e-9) continue;
 
             foreach (CensusRecord record in cohort)
@@ -978,7 +1063,7 @@ internal static class Program
             {
                 document = JsonSerializer.Deserialize<BaselineDocument>(File.ReadAllText(path), JsonOptions);
             }
-            catch (JsonException ex)
+            catch (Exception ex) when (ex is JsonException or IOException or UnauthorizedAccessException)
             {
                 diagnostics.Add(Diagnostic.Warning("<census>", "history",
                     $"could not read {Path.GetFileName(path)} as a baseline ({ex.Message}); "
@@ -987,6 +1072,7 @@ internal static class Program
             }
 
             if (document is null) continue;
+            document.Commit ??= "";
             if (Array.IndexOf(ComparableBaselineSchemaVersions, document.SchemaVersion) < 0) continue;
             documents.Add(document);
         }
@@ -996,12 +1082,17 @@ internal static class Program
         // Say how much history the gate actually has. A census that silently fell back to a single
         // prior point looks identical in its output to one reasoning over a window, and the two
         // give different answers - so the depth is stated rather than assumed.
-        diagnostics.Add(Diagnostic.Warning("<census>", "history",
-            documents.Count >= MinimumSeriesPoints
-                ? $"comparing against a series of {documents.Count} prior census run(s)"
-                : $"only {documents.Count} prior census run(s) available; "
-                  + $"{MinimumSeriesPoints} are needed before step detection engages, so this run "
-                  + "is compared against the single most recent baseline"));
+        if (documents.Count >= MinimumSeriesPoints)
+        {
+            Console.WriteLine($"history: comparing against a series of {documents.Count} prior census run(s)");
+        }
+        else
+        {
+            diagnostics.Add(Diagnostic.Warning("<census>", "history",
+                $"only {documents.Count} prior census run(s) available; "
+                + $"{MinimumSeriesPoints} are needed before step detection engages, so this run "
+                + "is compared against the single most recent baseline"));
+        }
 
         return documents;
     }
@@ -1040,7 +1131,8 @@ internal static class Program
         Console.WriteLine($"summary: {outputPath}");
     }
 
-    private static double Median(double[] sorted) => sorted.Length % 2 == 1
+    /// <summary>Returns the median of an array that the caller has already sorted.</summary>
+    private static double MedianOfSorted(double[] sorted) => sorted.Length % 2 == 1
         ? sorted[sorted.Length / 2]
         : (sorted[(sorted.Length / 2) - 1] + sorted[sorted.Length / 2]) / 2.0;
 
@@ -1164,6 +1256,7 @@ internal static class Program
     {
         Console.WriteLine("ModelPerfProbe --results DIR --output FILE [--expected-count N]");
         Console.WriteLine("  [--baseline FILE] [--write-baseline FILE] [--max-regression-ratio 2.5]");
+        Console.WriteLine("  [--history DIR] [--perf-intent FILE] [--commit SHA]");
         Console.WriteLine("  [--max-allocation-regression-ratio 2.5] [--max-memory-regression-ratio 1.6]");
         Console.WriteLine("  [--max-volatile-timing-regression-ratio 5.0]");
         Console.WriteLine("  [--uncorroborated-timing-ratio 4.0] [--corroboration-ratio 1.25]");


### PR DESCRIPTION
Continues the post-#2051 CI work now that #2052 is merged. Branched from master.

Two of these are root causes that reach far past the tests that exposed them.

## Task list

### Fixed and verified locally

- [x] **`GraFPrintTests` / `GraFPrintLossTraceTests` — `Clone_AfterTraining_ShouldPreserveLearnedWeights` and `Clone_ShouldProduceIdenticalOutput` (4 tests).**
      `Component<T>` rebuilt a saved component through its PARAMETERLESS constructor, so
      `LeakyReLU(0.2)` came back as `LeakyReLU(0.01)`. All 5,956,548 weights round-tripped
      bit-identically and the clone still diverged from the first activation onward by exactly the
      ratio of the two slopes, 20x. Configuration now travels with the type. **83 passed, 0 failed.**
- [x] **`ParameterBufferScopeTests.CifCompositeParameterSurface_*`.** Asserted that CIF reports
      OVERLAPPING parameter ownership; the generated declarations gave the child sole ownership, so
      the overlap is gone by construction. Rewritten to assert the invariant that matters, failing
      in BOTH directions: the predictor's weights appear exactly once, never zero, never twice.
- [x] **`DiffusionModelContractTests.WanVideoModel_Clone_CreatesIndependentCopy`.** A share with
      nothing to share was reported as a mismatch, and the fallback materialized ~15.2 B parameters
      (~61 GB at float) to clone an empty model. Reproduced in a 16 GB runner-parity container:
      28 minutes, then OOM. Re-verification at parity in progress.
- [x] **The ~115-shard rerun on merge.** Reuse needs a COMPLETED run and refuses `cancelled`;
      `cancel-on-pr-close` evicted #2004's in-flight run 4 seconds after merge. Merged PRs are now
      left alone and master waits, bounded, for a run still in flight.
- [x] **net8.0 smoke shard removed** - it timed out compiling before it could run. net8.0 is now
      treated exactly like net471: compiled every build, executed by no shard.
- [x] **6 CodeQL findings** - CMAES integer overflow; two write-only locals (one unreported); three
      `_optimizer` readonly reverts plus a dead flag; a bare `catch` that swallowed everything.

### Still to fix

- [ ] Confirm `WanVideoModel_Clone_CreatesIndependentCopy` at runner parity. The fix targets one
      specific decline reason and I have NOT yet proven that is the reason this model hits, so it
      stays open until the container says so.
- [ ] 8 CodeQL style threads (`.Where(...)` in per-training-step parameter walks) - declining with
      the allocation rationale, pending the go-ahead to post

### The authoritative ledger is now clear

`test-outcome-ledger` for run 33123595374 lists exactly EIGHT failures, and all eight are fixed:

| ledger failure | fix |
|---|---|
| `ParameterBufferScopeTests.CifCompositeParameterSurface_*` | test asserted an overlap the generated declarations removed |
| `CASTLEAlgorithmTests.DiscoverStructure_MoreDataDoesNotDegradeQuality` | raw norm thresholding restored |
| `GraFPrintLossTraceTests` x2, `GraFPrintTests` x2 | component configuration now round-trips |
| `RepViTSAMTests.Training_ShouldReduceLoss` | inherited the generic 1e-3 instead of the SAM-family 1e-4 |
| `RepViTSAMTests.MoreData_ShouldNotDegrade` | same cause |

The two entries I could not originally identify from the error text - "Clone output differs beyond
double tolerance" and "Training did not reduce loss" - turned out to be GraFPrint and RepViTSAM.

### Not ours

- `Integration C - Core`, `Generated Layers G/Q-R1`, `Integration C - CV Segmentation` died with
  "The runner has received a shutdown signal" - runner eviction, not test failures.

## Note on scope

Both clone fixes are in the generator/base layer, never per model. `ADN0063` enforces that, and it
is why the per-model optimizer-rebuild override added on #2052 was removed rather than kept.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Component state restoration now preserves constructor-based configuration more reliably.
  * Added RepViT building blocks and updated RepViT-SAM architecture and training options.
  * Closed pull requests no longer cancel completed validation runs when merged.
* **Bug Fixes**
  * Improved parameter sharing, diagnostics, and restored text-to-speech optimizer consistency.
  * Refined causal structure edge selection.
* **CI & Testing**
  * Validation waits longer and falls back more reliably.
  * Expanded framework coverage, performance tracking, and regression tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
