### PR TITLE
refactor(optimizers): delete the cached typed options copy, 42 updateoptions overrides to 6

### DIFF
--- a/src/AiDotNet.Generators/AnalyzerReleases.Unshipped.md
+++ b/src/AiDotNet.Generators/AnalyzerReleases.Unshipped.md
@@ -81,3 +81,4 @@ AIDN097 | AiDotNet.FacadeConfiguration | Warning | FacadeConfigurationValidation
 AIDN098 | AiDotNet.ParameterAutomation | Warning | TrainableParameterGenerator, Declared parameter axis cannot be proven resolved
 AIDN099 | AiDotNet.ParameterAutomation | Warning | TrainableParameterGenerator, [TrainableParameter] on a non-partial class does nothing
 AIDN046 | AiDotNet.TestCoverage | Warning | TestScaffoldGenerator, Layer cannot be scaffolded and produces no generated tests
+AIDN077 | AiDotNet.GoldenPattern | Warning | GoldenPatternValidationGenerator, Optimizer builds its own random generator instead of drawing from the seeded OptimizerBase.Random

--- a/src/AiDotNet.Generators/GoldenPatternValidationGenerator.cs
+++ b/src/AiDotNet.Generators/GoldenPatternValidationGenerator.cs
@@ -68,6 +68,19 @@ public class GoldenPatternValidationGenerator : IIncrementalGenerator
                      "share a seed. Use RandomHelper.CreateSeededRandom(seed) when reproducibility is required, " +
                      "RandomHelper.CreateSecureRandom() otherwise.");
 
+    internal static readonly DiagnosticDescriptor OptimizerOwnsRandomGenerator = new(
+        id: "AIDN077",
+        title: "Optimizer builds its own random generator",
+        messageFormat: "'{0}' creates a generator of its own; draw from the inherited OptimizerBase.Random, which is built from Options.Seed",
+        category: Category,
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        description: "OptimizerBase derives its Random from Options.Seed and re-derives it when options are " +
+                     "restored, so an optimizer that owns a private generator silently ignores the seed the " +
+                     "caller configured - every run unrepeatable, on the path a model actually uses. " +
+                     "ParticleSwarmOptimizer and SimulatedAnnealingOptimizer both did exactly that. Draw from " +
+                     "the inherited Random instead; there is then nothing left to forget to seed.");
+
     internal static readonly DiagnosticDescriptor RegexWithoutTimeout = new(
         id: "AIDN073",
         title: "Regex without a timeout (ReDoS)",
@@ -257,6 +270,28 @@ public class GoldenPatternValidationGenerator : IIncrementalGenerator
         return null;
     }
 
+
+    /// <summary>
+    /// Whether this node sits inside a type that inherits <c>OptimizerBase</c>'s seeded generator.
+    /// </summary>
+    /// <remarks>
+    /// <c>OptimizerBase</c> itself is excluded: it is the one type that must build the generator,
+    /// and it is where <c>Options.Seed</c> is honoured on behalf of everything below it.
+    /// </remarks>
+    private static bool IsInsideOptimizer(GeneratorSyntaxContext ctx, SyntaxNode node)
+    {
+        var declaration = node.FirstAncestorOrSelf<TypeDeclarationSyntax>();
+        if (declaration is null) return false;
+        if (ctx.SemanticModel.GetDeclaredSymbol(declaration) is not INamedTypeSymbol type) return false;
+
+        for (var current = type.BaseType; current is not null; current = current.BaseType)
+        {
+            if (current.Name == "OptimizerBase") return true;
+        }
+
+        return false;
+    }
+
     private static Finding? AnalyzeObjectCreation(GeneratorSyntaxContext ctx, BaseObjectCreationExpressionSyntax creation)
     {
         var type = ctx.SemanticModel.GetSymbolInfo(creation).Symbol?.ContainingType
@@ -266,7 +301,9 @@ public class GoldenPatternValidationGenerator : IIncrementalGenerator
         switch (name)
         {
             case "System.Random":
-                return new Finding(RawRandomConstruction, creation.GetLocation());
+                return IsInsideOptimizer(ctx, creation)
+                    ? new Finding(OptimizerOwnsRandomGenerator, creation.GetLocation(), "new Random(...)")
+                    : new Finding(RawRandomConstruction, creation.GetLocation());
 
             case "System.NotImplementedException":
                 // A virtual member whose whole body is this throw is abstract-by-convention: it
@@ -291,6 +328,16 @@ public class GoldenPatternValidationGenerator : IIncrementalGenerator
             return null;
 
         var owner = method.ContainingType?.ToDisplayString();
+
+        // RandomHelper is the right answer everywhere EXCEPT inside an optimizer, which already
+        // inherits a generator built from Options.Seed. Calling it there is how the seed gets lost.
+        if (owner == "AiDotNet.Tensors.Helpers.RandomHelper"
+            && (method.Name == "CreateSecureRandom" || method.Name == "CreateSeededRandom")
+            && IsInsideOptimizer(ctx, invocation))
+        {
+            return new Finding(
+                OptimizerOwnsRandomGenerator, invocation.GetLocation(), $"RandomHelper.{method.Name}()");
+        }
 
         if (owner == "System.Console" && (method.Name == "WriteLine" || method.Name == "Write"))
         {

--- a/src/Optimizers/AMSGradOptimizer.cs
+++ b/src/Optimizers/AMSGradOptimizer.cs
@@ -29,7 +29,9 @@ public partial class AMSGradOptimizer<T, TInput, TOutput> : GradientBasedOptimiz
     /// <summary>
     /// The options specific to the AMSGrad optimizer.
     /// </summary>
-    private AMSGradOptimizerOptions<T, TInput, TOutput> _options;
+    /// <summary>Read from the single instance OptimizerBase.Options holds, so there is
+    /// no second copy that could disagree with it.</summary>
+    private AMSGradOptimizerOptions<T, TInput, TOutput> _options => (AMSGradOptimizerOptions<T, TInput, TOutput>)Options;
 
     /// <summary>
     /// The first moment vector (moving average of gradients).
@@ -70,7 +72,6 @@ public partial class AMSGradOptimizer<T, TInput, TOutput> : GradientBasedOptimiz
         IEngine? engine = null)
         : base(model, options ?? new())
     {
-        _options = options ?? new AMSGradOptimizerOptions<T, TInput, TOutput>();
 
         InitializeAdaptiveParameters();
     }
@@ -101,7 +102,6 @@ public partial class AMSGradOptimizer<T, TInput, TOutput> : GradientBasedOptimiz
     private AMSGradOptimizer(AMSGradOptimizerOptions<T, TInput, TOutput>? options)
         : base(null, options ?? new())
     {
-        _options = options ?? new AMSGradOptimizerOptions<T, TInput, TOutput>();
 
         InitializeAdaptiveParameters();
     }
@@ -558,28 +558,6 @@ public partial class AMSGradOptimizer<T, TInput, TOutput> : GradientBasedOptimiz
         }
     }
 
-    /// <summary>
-    /// Updates the optimizer's options with new settings.
-    /// </summary>
-    /// <param name="options">The new options to be applied to the optimizer.</param>
-    /// <exception cref="ArgumentException">Thrown when the provided options are not of the correct type.</exception>
-    /// <remarks>
-    /// <para><b>For Beginners:</b> This method allows you to change the settings of the AMSGrad optimizer while it's running.
-    /// It's like adjusting the controls on a machine that's already operating. If you provide the wrong type of settings,
-    /// it will stop and let you know there's an error.
-    /// </para>
-    /// </remarks>
-    protected override void UpdateOptions(OptimizationAlgorithmOptions<T, TInput, TOutput> options)
-    {
-        if (options is AMSGradOptimizerOptions<T, TInput, TOutput> amsGradOptions)
-        {
-            _options = amsGradOptions;
-        }
-        else
-        {
-            throw new ArgumentException("Invalid options type. Expected AMSGradOptimizerOptions.");
-        }
-    }
 
     /// <summary>
     /// Retrieves the current options of the optimizer.

--- a/src/Optimizers/ASGDOptimizer.cs
+++ b/src/Optimizers/ASGDOptimizer.cs
@@ -55,7 +55,9 @@ public partial class ASGDOptimizer<T, TInput, TOutput> : GradientBasedOptimizerB
     /// <summary>
     /// The options specific to the ASGD optimizer.
     /// </summary>
-    private ASGDOptimizerOptions<T, TInput, TOutput> _options;
+    /// <summary>Read from the single instance OptimizerBase.Options holds, so there is
+    /// no second copy that could disagree with it.</summary>
+    private ASGDOptimizerOptions<T, TInput, TOutput> _options => (ASGDOptimizerOptions<T, TInput, TOutput>)Options;
 
     /// <summary>
     /// The running average of the iterates (the <c>ax</c> of the reference implementation).
@@ -83,7 +85,6 @@ public partial class ASGDOptimizer<T, TInput, TOutput> : GradientBasedOptimizerB
         ASGDOptimizerOptions<T, TInput, TOutput>? options = null)
         : base(model, options ?? new())
     {
-        _options = options ?? new ASGDOptimizerOptions<T, TInput, TOutput>();
 
         InitializeAdaptiveParameters();
     }
@@ -478,22 +479,6 @@ public partial class ASGDOptimizer<T, TInput, TOutput> : GradientBasedOptimizerB
         }
     }
 
-    /// <summary>
-    /// Updates the optimizer's options with new settings.
-    /// </summary>
-    /// <param name="options">The new options to be applied to the optimizer.</param>
-    /// <exception cref="ArgumentException">Thrown when the provided options are not of the correct type.</exception>
-    protected override void UpdateOptions(OptimizationAlgorithmOptions<T, TInput, TOutput> options)
-    {
-        if (options is ASGDOptimizerOptions<T, TInput, TOutput> asgdOptions)
-        {
-            _options = asgdOptions;
-        }
-        else
-        {
-            throw new ArgumentException("Invalid options type. Expected ASGDOptimizerOptions.");
-        }
-    }
 
     /// <summary>
     /// Retrieves the current options of the optimizer.

--- a/src/Optimizers/AdaDeltaOptimizer.cs
+++ b/src/Optimizers/AdaDeltaOptimizer.cs
@@ -67,7 +67,9 @@ public partial class AdaDeltaOptimizer<T, TInput, TOutput> : GradientBasedOptimi
     /// These settings can be customized to make the optimizer work better for different types of problems.
     /// </para>
     /// </remarks>
-    private AdaDeltaOptimizerOptions<T, TInput, TOutput> _options;
+    /// <summary>Read from the single instance OptimizerBase.Options holds, so there is
+    /// no second copy that could disagree with it.</summary>
+    private AdaDeltaOptimizerOptions<T, TInput, TOutput> _options => (AdaDeltaOptimizerOptions<T, TInput, TOutput>)Options;
 
     /// <summary>
     /// Stores the exponential moving average of squared gradients for each parameter.
@@ -148,7 +150,6 @@ public partial class AdaDeltaOptimizer<T, TInput, TOutput> : GradientBasedOptimi
         IEngine? engine = null)
         : base(model, options ?? new())
     {
-        _options = options ?? new AdaDeltaOptimizerOptions<T, TInput, TOutput>();
 
         InitializeAdaptiveParameters();
     }
@@ -179,7 +180,6 @@ public partial class AdaDeltaOptimizer<T, TInput, TOutput> : GradientBasedOptimi
     private AdaDeltaOptimizer(AdaDeltaOptimizerOptions<T, TInput, TOutput>? options)
         : base(null, options ?? new())
     {
-        _options = options ?? new AdaDeltaOptimizerOptions<T, TInput, TOutput>();
 
         InitializeAdaptiveParameters();
     }
@@ -680,34 +680,6 @@ public partial class AdaDeltaOptimizer<T, TInput, TOutput> : GradientBasedOptimi
         }
     }
 
-    /// <summary>
-    /// Updates the optimizer options.
-    /// </summary>
-    /// <param name="options">The new options to set.</param>
-    /// <exception cref="ArgumentException">Thrown when the provided options are not of type AdaDeltaOptimizerOptions.</exception>
-    /// <remarks>
-    /// <para>
-    /// This method updates the optimizer's options with new settings. It ensures that only
-    /// AdaDeltaOptimizerOptions are used with this optimizer.
-    /// </para>
-    /// <para><b>For Beginners:</b> This is like changing the settings on your learning assistant.
-    /// 
-    /// You can use this to adjust how the optimizer works, but you need to make sure you're
-    /// using the right type of settings (AdaDeltaOptimizerOptions). If you try to use the wrong
-    /// type of settings, it will give you an error message.
-    /// </para>
-    /// </remarks>
-    protected override void UpdateOptions(OptimizationAlgorithmOptions<T, TInput, TOutput> options)
-    {
-        if (options is AdaDeltaOptimizerOptions<T, TInput, TOutput> adaDeltaOptions)
-        {
-            _options = adaDeltaOptions;
-        }
-        else
-        {
-            throw new ArgumentException("Invalid options type. Expected AdaDeltaOptimizerOptions.");
-        }
-    }
 
     /// <summary>
     /// Gets the current optimizer options.

--- a/src/Optimizers/AdaMaxOptimizer.cs
+++ b/src/Optimizers/AdaMaxOptimizer.cs
@@ -65,7 +65,9 @@ public partial class AdaMaxOptimizer<T, TInput, TOutput> : GradientBasedOptimize
     /// and how it balances new information with what it already knows.
     /// </para>
     /// </remarks>
-    private AdaMaxOptimizerOptions<T, TInput, TOutput> _options;
+    /// <summary>Read from the single instance OptimizerBase.Options holds, so there is
+    /// no second copy that could disagree with it.</summary>
+    private AdaMaxOptimizerOptions<T, TInput, TOutput> _options => (AdaMaxOptimizerOptions<T, TInput, TOutput>)Options;
 
     /// <summary>
     /// The first moment vector that tracks the exponentially weighted moving average of gradients.
@@ -155,7 +157,6 @@ public partial class AdaMaxOptimizer<T, TInput, TOutput> : GradientBasedOptimize
         IEngine? engine = null)
         : base(model, options ?? new())
     {
-        _options = options ?? new AdaMaxOptimizerOptions<T, TInput, TOutput>();
         InitializeAdaptiveParameters();
     }
 
@@ -185,7 +186,6 @@ public partial class AdaMaxOptimizer<T, TInput, TOutput> : GradientBasedOptimize
     private AdaMaxOptimizer(AdaMaxOptimizerOptions<T, TInput, TOutput>? options)
         : base(null, options ?? new())
     {
-        _options = options ?? new AdaMaxOptimizerOptions<T, TInput, TOutput>();
         InitializeAdaptiveParameters();
     }
 
@@ -615,37 +615,6 @@ public partial class AdaMaxOptimizer<T, TInput, TOutput> : GradientBasedOptimize
         }
     }
 
-    /// <summary>
-    /// Updates the optimizer options with new AdaMax-specific options.
-    /// </summary>
-    /// <param name="options">The new options to set.</param>
-    /// <exception cref="ArgumentException">Thrown when the provided options are not of type AdaMaxOptimizerOptions.</exception>
-    /// <remarks>
-    /// <para>
-    /// This method updates the optimizer's configuration with new options. It ensures that only valid
-    /// AdaMax-specific options are applied.
-    /// </para>
-    /// <para><b>For Beginners:</b> This method is like updating the settings on your learning assistant.
-    /// 
-    /// Imagine you have a robot helper for studying:
-    /// - You can give it new instructions on how to help you (new options)
-    /// - But you need to make sure you're giving it the right kind of instructions (AdaMax-specific)
-    /// - If you try to give it instructions for a different type of helper, it will let you know there's a mistake
-    /// 
-    /// This ensures that your optimizer always has the correct and up-to-date settings to work with.
-    /// </para>
-    /// </remarks>
-    protected override void UpdateOptions(OptimizationAlgorithmOptions<T, TInput, TOutput> options)
-    {
-        if (options is AdaMaxOptimizerOptions<T, TInput, TOutput> adaMaxOptions)
-        {
-            _options = adaMaxOptions;
-        }
-        else
-        {
-            throw new ArgumentException("Invalid options type. Expected AdaMaxOptimizerOptions.");
-        }
-    }
 
     /// <summary>
     /// Gets the current options of the AdaMax optimizer.

--- a/src/Optimizers/AdagradOptimizer.cs
+++ b/src/Optimizers/AdagradOptimizer.cs
@@ -66,7 +66,9 @@ public partial class AdagradOptimizer<T, TInput, TOutput> : GradientBasedOptimiz
     /// These settings can be customized to make the optimizer work better for different types of problems.
     /// </para>
     /// </remarks>
-    private AdagradOptimizerOptions<T, TInput, TOutput> _options;
+    /// <summary>Read from the single instance OptimizerBase.Options holds, so there is
+    /// no second copy that could disagree with it.</summary>
+    private AdagradOptimizerOptions<T, TInput, TOutput> _options => (AdagradOptimizerOptions<T, TInput, TOutput>)Options;
 
     /// <summary>
     /// Stores the sum of squared gradients for each parameter during optimization.
@@ -116,7 +118,6 @@ public partial class AdagradOptimizer<T, TInput, TOutput> : GradientBasedOptimiz
         AdagradOptimizerOptions<T, TInput, TOutput>? options = null)
         : base(model, options ?? new())
     {
-        _options = options ?? new AdagradOptimizerOptions<T, TInput, TOutput>();
 
         InitializeAdaptiveParameters();
     }
@@ -147,7 +148,6 @@ public partial class AdagradOptimizer<T, TInput, TOutput> : GradientBasedOptimiz
     private AdagradOptimizer(AdagradOptimizerOptions<T, TInput, TOutput>? options)
         : base(null, options ?? new())
     {
-        _options = options ?? new AdagradOptimizerOptions<T, TInput, TOutput>();
 
         InitializeAdaptiveParameters();
     }
@@ -490,36 +490,6 @@ public partial class AdagradOptimizer<T, TInput, TOutput> : GradientBasedOptimiz
         }
     }
 
-    /// <summary>
-    /// Updates the options for the Adagrad optimizer.
-    /// </summary>
-    /// <param name="options">The new options to be set.</param>
-    /// <exception cref="ArgumentException">Thrown when the provided options are not of type AdagradOptimizerOptions.</exception>
-    /// <remarks>
-    /// <para>
-    /// This method updates the optimizer's configuration with new options. It ensures that only
-    /// AdagradOptimizerOptions are used to configure this optimizer.
-    /// </para>
-    /// <para><b>For Beginners:</b> This is like updating the instructions for your learning assistant.
-    /// 
-    /// - It checks if the new instructions are the right type for this specific assistant (Adagrad)
-    /// - If they are, it updates the assistant's settings
-    /// - If they're not, it reports an error
-    /// 
-    /// This helps prevent accidentally using the wrong type of settings, which could cause problems.
-    /// </para>
-    /// </remarks>
-    protected override void UpdateOptions(OptimizationAlgorithmOptions<T, TInput, TOutput> options)
-    {
-        if (options is AdagradOptimizerOptions<T, TInput, TOutput> adagradOptions)
-        {
-            _options = adagradOptions;
-        }
-        else
-        {
-            throw new ArgumentException("Invalid options type. Expected AdagradOptimizerOptions.");
-        }
-    }
 
     /// <summary>
     /// Retrieves the current options of the Adagrad optimizer.

--- a/src/Optimizers/Adam8BitOptimizer.cs
+++ b/src/Optimizers/Adam8BitOptimizer.cs
@@ -99,7 +99,9 @@ public class Adam8BitOptimizer<T, TInput, TOutput> : GradientBasedOptimizerBase<
     /// <summary>
     /// The options specific to the 8-bit Adam optimizer.
     /// </summary>
-    private Adam8BitOptimizerOptions<T, TInput, TOutput> _options;
+    /// <summary>Read from the single instance OptimizerBase.Options holds, so there is
+    /// no second copy that could disagree with it.</summary>
+    private Adam8BitOptimizerOptions<T, TInput, TOutput> _options => (Adam8BitOptimizerOptions<T, TInput, TOutput>)Options;
 
     /// <summary>
     /// Quantized first moment vector (moving average of gradients).
@@ -169,7 +171,6 @@ public class Adam8BitOptimizer<T, TInput, TOutput> : GradientBasedOptimizerBase<
         : base(model, options ?? new())
     {
         _t = 0;
-        _options = options ?? new();
         _currentBeta1 = NumOps.Zero;
         _currentBeta2 = NumOps.Zero;
 
@@ -1454,20 +1455,6 @@ public class Adam8BitOptimizer<T, TInput, TOutput> : GradientBasedOptimizerBase<
         _tapeStep = 0;
     }
 
-    /// <summary>
-    /// Updates the optimizer's options.
-    /// </summary>
-    protected override void UpdateOptions(OptimizationAlgorithmOptions<T, TInput, TOutput> options)
-    {
-        if (options is Adam8BitOptimizerOptions<T, TInput, TOutput> adamOptions)
-        {
-            _options = adamOptions;
-        }
-        else
-        {
-            throw new ArgumentException("Invalid options type. Expected Adam8BitOptimizerOptions.");
-        }
-    }
 
     /// <summary>
     /// Gets the current optimizer options.
@@ -2173,9 +2160,12 @@ public class Adam8BitOptimizer<T, TInput, TOutput> : GradientBasedOptimizerBase<
             byte[] baseData = reader.ReadBytes(baseDataLength);
             base.Deserialize(baseData);
 
-            // Deserialize options
+            // Consume the options JSON. The read itself still matters - the stream position
+            // depends on it and a malformed payload must fail here - but the VALUE is discarded:
+            // base.Deserialize above already adopted the authoritative copy into Options, which
+            // _options now reads through. Keeping a second copy is what this refactor removed.
             string optionsJson = reader.ReadString();
-            _options = JsonConvert.DeserializeObject<Adam8BitOptimizerOptions<T, TInput, TOutput>>(optionsJson)
+            _ = JsonConvert.DeserializeObject<Adam8BitOptimizerOptions<T, TInput, TOutput>>(optionsJson)
                 ?? throw new InvalidOperationException("Failed to deserialize optimizer options.");
 
             // Read magic header + format version (added in #1240 follow-

--- a/src/Optimizers/AdamOptimizer.cs
+++ b/src/Optimizers/AdamOptimizer.cs
@@ -29,7 +29,9 @@ public partial class AdamOptimizer<T, TInput, TOutput> : GradientBasedOptimizerB
     /// <summary>
     /// The options specific to the Adam optimizer.
     /// </summary>
-    private AdamOptimizerOptions<T, TInput, TOutput> _options;
+    /// <summary>Read from the single instance OptimizerBase.Options holds, so there is
+    /// no second copy that could disagree with it.</summary>
+    private AdamOptimizerOptions<T, TInput, TOutput> _options => (AdamOptimizerOptions<T, TInput, TOutput>)Options;
 
     /// <summary>
     /// The first moment vector (moving average of gradients).
@@ -100,7 +102,6 @@ public partial class AdamOptimizer<T, TInput, TOutput> : GradientBasedOptimizerB
         _m = Vector<T>.Empty();
         _v = Vector<T>.Empty();
         _t = 0;
-        _options = options ?? new();
         _currentBeta1 = NumOps.Zero;
         _currentBeta2 = NumOps.Zero;
 
@@ -1395,27 +1396,6 @@ public partial class AdamOptimizer<T, TInput, TOutput> : GradientBasedOptimizerB
         _tapeStep = 0;
     }
 
-    /// <summary>
-    /// Updates the optimizer's options.
-    /// </summary>
-    /// <param name="options">The new options to be set.</param>
-    /// <exception cref="ArgumentException">Thrown when the provided options are not of type AdamOptimizerOptions.</exception>
-    /// <remarks>
-    /// <para><b>For Beginners:</b> This method allows you to change the optimizer's settings mid-way.
-    /// It's like adjusting the personal trainer's approach based on new instructions.
-    /// </para>
-    /// </remarks>
-    protected override void UpdateOptions(OptimizationAlgorithmOptions<T, TInput, TOutput> options)
-    {
-        if (options is AdamOptimizerOptions<T, TInput, TOutput> adamOptions)
-        {
-            _options = adamOptions;
-        }
-        else
-        {
-            throw new ArgumentException("Invalid options type. Expected AdamOptimizerOptions.");
-        }
-    }
 
     /// <summary>
     /// Gets the current optimizer options.

--- a/src/Optimizers/AdamWOptimizer.cs
+++ b/src/Optimizers/AdamWOptimizer.cs
@@ -51,7 +51,9 @@ public partial class AdamWOptimizer<T, TInput, TOutput> : GradientBasedOptimizer
     /// <summary>
     /// The options specific to the AdamW optimizer.
     /// </summary>
-    private AdamWOptimizerOptions<T, TInput, TOutput> _options;
+    /// <summary>Read from the single instance OptimizerBase.Options holds, so there is
+    /// no second copy that could disagree with it.</summary>
+    private AdamWOptimizerOptions<T, TInput, TOutput> _options => (AdamWOptimizerOptions<T, TInput, TOutput>)Options;
 
     /// <summary>
     /// The first moment vector (moving average of gradients).
@@ -116,7 +118,6 @@ public partial class AdamWOptimizer<T, TInput, TOutput> : GradientBasedOptimizer
         _m = Vector<T>.Empty();
         _v = Vector<T>.Empty();
         _t = 0;
-        _options = options ?? new();
         _currentBeta1 = NumOps.Zero;
         _currentBeta2 = NumOps.Zero;
 
@@ -933,20 +934,6 @@ public partial class AdamWOptimizer<T, TInput, TOutput> : GradientBasedOptimizer
         _tapeStep = 0;
     }
 
-    /// <summary>
-    /// Updates the optimizer's options.
-    /// </summary>
-    protected override void UpdateOptions(OptimizationAlgorithmOptions<T, TInput, TOutput> options)
-    {
-        if (options is AdamWOptimizerOptions<T, TInput, TOutput> adamWOptions)
-        {
-            _options = adamWOptions;
-        }
-        else
-        {
-            throw new ArgumentException("Invalid options type. Expected AdamWOptimizerOptions.");
-        }
-    }
 
     /// <summary>
     /// Gets the current optimizer options.

--- a/src/Optimizers/AntColonyOptimizer.cs
+++ b/src/Optimizers/AntColonyOptimizer.cs
@@ -29,7 +29,9 @@ public partial class AntColonyOptimizer<T, TInput, TOutput> : OptimizerBase<T, T
     /// <summary>
     /// Options specific to the Ant Colony Optimization algorithm.
     /// </summary>
-    private AntColonyOptimizationOptions<T, TInput, TOutput> _antColonyOptions;
+    /// <summary>Read from the single instance OptimizerBase.Options holds, so there is
+    /// no second copy that could disagree with it.</summary>
+    private AntColonyOptimizationOptions<T, TInput, TOutput> _antColonyOptions => (AntColonyOptimizationOptions<T, TInput, TOutput>)Options;
 
     /// <summary>
     /// The current rate at which pheromone evaporates from the trails.
@@ -58,7 +60,6 @@ public partial class AntColonyOptimizer<T, TInput, TOutput> : OptimizerBase<T, T
         IEngine? engine = null)
         : base(model, options ?? new())
     {
-        _antColonyOptions = options ?? new AntColonyOptimizationOptions<T, TInput, TOutput>();
         _currentPheromoneEvaporationRate = NumOps.Zero;
         _currentPheromoneIntensity = NumOps.Zero;
 
@@ -384,26 +385,6 @@ public partial class AntColonyOptimizer<T, TInput, TOutput> : OptimizerBase<T, T
         }
     }
 
-    /// <summary>
-    /// Updates the options for the Ant Colony Optimization algorithm.
-    /// </summary>
-    /// <param name="options">The new options to be set.</param>
-    /// <exception cref="ArgumentException">Thrown when the provided options are not of the correct type.</exception>
-    /// <remarks>
-    /// <para><b>For Beginners:</b> This method allows you to change how the ant colony algorithm behaves
-    /// by updating its settings. It checks to make sure you're providing the right kind of settings.</para>
-    /// </remarks>
-    protected override void UpdateOptions(OptimizationAlgorithmOptions<T, TInput, TOutput> options)
-    {
-        if (options is AntColonyOptimizationOptions<T, TInput, TOutput> antColonyOptions)
-        {
-            _antColonyOptions = antColonyOptions;
-        }
-        else
-        {
-            throw new ArgumentException("Invalid options type. Expected AntColonyOptimizationOptions.");
-        }
-    }
 
     /// <summary>
     /// Gets the current options for the Ant Colony Optimization algorithm.
@@ -429,7 +410,6 @@ public partial class AntColonyOptimizer<T, TInput, TOutput> : OptimizerBase<T, T
     private AntColonyOptimizer(AntColonyOptimizationOptions<T, TInput, TOutput>? options)
         : base(null, options ?? new())
     {
-        _antColonyOptions = options ?? new AntColonyOptimizationOptions<T, TInput, TOutput>();
         _currentPheromoneEvaporationRate = NumOps.Zero;
         _currentPheromoneIntensity = NumOps.Zero;
 

--- a/src/Optimizers/BFGSOptimizer.cs
+++ b/src/Optimizers/BFGSOptimizer.cs
@@ -56,7 +56,9 @@ public partial class BFGSOptimizer<T, TInput, TOutput> : GradientBasedOptimizerB
     /// <summary>
     /// The options specific to the BFGS optimization algorithm.
     /// </summary>
-    private BFGSOptimizerOptions<T, TInput, TOutput> _options;
+    /// <summary>Read from the single instance OptimizerBase.Options holds, so there is
+    /// no second copy that could disagree with it.</summary>
+    private BFGSOptimizerOptions<T, TInput, TOutput> _options => (BFGSOptimizerOptions<T, TInput, TOutput>)Options;
 
     /// <summary>
     /// The approximation of the inverse Hessian matrix.
@@ -95,7 +97,6 @@ public partial class BFGSOptimizer<T, TInput, TOutput> : GradientBasedOptimizerB
         IEngine? engine = null)
         : base(model, options ?? new())
     {
-        _options = options ?? new BFGSOptimizerOptions<T, TInput, TOutput>();
         InitializeAdaptiveParameters();
     }
 
@@ -125,7 +126,6 @@ public partial class BFGSOptimizer<T, TInput, TOutput> : GradientBasedOptimizerB
     private BFGSOptimizer(BFGSOptimizerOptions<T, TInput, TOutput>? options)
         : base(null, options ?? new())
     {
-        _options = options ?? new BFGSOptimizerOptions<T, TInput, TOutput>();
         InitializeAdaptiveParameters();
     }
 
@@ -330,27 +330,6 @@ public partial class BFGSOptimizer<T, TInput, TOutput> : GradientBasedOptimizerB
         }
     }
 
-    /// <summary>
-    /// Updates the options for the BFGS optimizer.
-    /// </summary>
-    /// <param name="options">The new options to be set.</param>
-    /// <exception cref="ArgumentException">Thrown when the provided options are not of the correct type.</exception>
-    /// <remarks>
-    /// <para><b>For Beginners:</b> This method allows you to change the settings of the BFGS optimizer during runtime.
-    /// It checks to make sure you're providing the right kind of options specific to the BFGS algorithm.
-    /// </para>
-    /// </remarks>
-    protected override void UpdateOptions(OptimizationAlgorithmOptions<T, TInput, TOutput> options)
-    {
-        if (options is BFGSOptimizerOptions<T, TInput, TOutput> bfgsOptions)
-        {
-            _options = bfgsOptions;
-        }
-        else
-        {
-            throw new ArgumentException("Invalid options type. Expected BFGSOptimizerOptions.");
-        }
-    }
 
     /// <summary>
     /// Updates parameters using the BFGS algorithm with inverse Hessian approximation.

--- a/src/Optimizers/CMAESOptimizer.cs
+++ b/src/Optimizers/CMAESOptimizer.cs
@@ -30,7 +30,9 @@ public partial class CMAESOptimizer<T, TInput, TOutput> : OptimizerBase<T, TInpu
     /// <summary>
     /// The options specific to the CMA-ES optimization algorithm.
     /// </summary>
-    private CMAESOptimizerOptions<T, TInput, TOutput> _options;
+    /// <summary>Read from the single instance OptimizerBase.Options holds, so there is
+    /// no second copy that could disagree with it.</summary>
+    private CMAESOptimizerOptions<T, TInput, TOutput> _options => (CMAESOptimizerOptions<T, TInput, TOutput>)Options;
 
     /// <summary>
     /// The current population of candidate solutions.
@@ -84,7 +86,6 @@ public partial class CMAESOptimizer<T, TInput, TOutput> : OptimizerBase<T, TInpu
         IEngine? engine = null)
         : base(model, options ?? new())
     {
-        _options = (CMAESOptimizerOptions<T, TInput, TOutput>)Options;
         _population = Matrix<T>.Empty();
         _mean = Vector<T>.Empty();
         _C = Matrix<T>.Empty();
@@ -461,27 +462,6 @@ public partial class CMAESOptimizer<T, TInput, TOutput> : OptimizerBase<T, TInpu
         )));
     }
 
-    /// <summary>
-    /// Updates the options for the CMA-ES optimizer.
-    /// </summary>
-    /// <param name="options">The new options to be set.</param>
-    /// <exception cref="ArgumentException">Thrown when the provided options are not of the correct type.</exception>
-    /// <remarks>
-    /// <para><b>For Beginners:</b> This method allows you to change the settings of the CMA-ES optimizer during runtime.
-    /// It checks to make sure you're providing the right kind of options specific to the CMA-ES algorithm.
-    /// </para>
-    /// </remarks>
-    protected override void UpdateOptions(OptimizationAlgorithmOptions<T, TInput, TOutput> options)
-    {
-        if (options is CMAESOptimizerOptions<T, TInput, TOutput> cmaesOptions)
-        {
-            _options = cmaesOptions;
-        }
-        else
-        {
-            throw new ArgumentException("Invalid options type. Expected CMAESOptimizerOptions.");
-        }
-    }
 
     /// <summary>
     /// Gets the current options of the CMA-ES optimizer.
@@ -509,7 +489,6 @@ public partial class CMAESOptimizer<T, TInput, TOutput> : OptimizerBase<T, TInpu
     private CMAESOptimizer(CMAESOptimizerOptions<T, TInput, TOutput>? options)
         : base(null, options ?? new())
     {
-        _options = (CMAESOptimizerOptions<T, TInput, TOutput>)Options;
         _population = Matrix<T>.Empty();
         _mean = Vector<T>.Empty();
         _C = Matrix<T>.Empty();

--- a/src/Optimizers/ConjugateGradientOptimizer.cs
+++ b/src/Optimizers/ConjugateGradientOptimizer.cs
@@ -30,7 +30,9 @@ public partial class ConjugateGradientOptimizer<T, TInput, TOutput> : GradientBa
     /// <summary>
     /// The options specific to the Conjugate Gradient optimization algorithm.
     /// </summary>
-    private ConjugateGradientOptimizerOptions<T, TInput, TOutput> _options;
+    /// <summary>Read from the single instance OptimizerBase.Options holds, so there is
+    /// no second copy that could disagree with it.</summary>
+    private ConjugateGradientOptimizerOptions<T, TInput, TOutput> _options => (ConjugateGradientOptimizerOptions<T, TInput, TOutput>)Options;
 
     /// <summary>
     /// The direction vector from the previous iteration.
@@ -64,7 +66,6 @@ public partial class ConjugateGradientOptimizer<T, TInput, TOutput> : GradientBa
         IEngine? engine = null)
         : base(model, options ?? new())
     {
-        _options = options ?? new ConjugateGradientOptimizerOptions<T, TInput, TOutput>();
         _previousGradient = Vector<T>.Empty();
         InitializeAdaptiveParameters();
     }
@@ -95,7 +96,6 @@ public partial class ConjugateGradientOptimizer<T, TInput, TOutput> : GradientBa
     private ConjugateGradientOptimizer(ConjugateGradientOptimizerOptions<T, TInput, TOutput>? options)
         : base(null, options ?? new())
     {
-        _options = options ?? new ConjugateGradientOptimizerOptions<T, TInput, TOutput>();
         _previousGradient = Vector<T>.Empty();
         InitializeAdaptiveParameters();
     }
@@ -286,27 +286,6 @@ public partial class ConjugateGradientOptimizer<T, TInput, TOutput> : GradientBa
         }
     }
 
-    /// <summary>
-    /// Updates the options for the Conjugate Gradient optimizer.
-    /// </summary>
-    /// <param name="options">The new options to be set.</param>
-    /// <exception cref="ArgumentException">Thrown when the provided options are not of the correct type.</exception>
-    /// <remarks>
-    /// <para><b>For Beginners:</b> This method allows you to change the settings of the Conjugate Gradient optimizer during runtime.
-    /// It checks to make sure you're providing the right kind of options specific to this algorithm.
-    /// </para>
-    /// </remarks>
-    protected override void UpdateOptions(OptimizationAlgorithmOptions<T, TInput, TOutput> options)
-    {
-        if (options is ConjugateGradientOptimizerOptions<T, TInput, TOutput> cgOptions)
-        {
-            _options = cgOptions;
-        }
-        else
-        {
-            throw new ArgumentException("Invalid options type. Expected ConjugateGradientOptimizerOptions.");
-        }
-    }
 
     /// <summary>
     /// Updates parameters using GPU-accelerated conjugate gradient.

--- a/src/Optimizers/CoordinateDescentOptimizer.cs
+++ b/src/Optimizers/CoordinateDescentOptimizer.cs
@@ -74,7 +74,9 @@ public partial class CoordinateDescentOptimizer<T, TInput, TOutput> : GradientBa
     /// <summary>
     /// The options specific to the Coordinate Descent optimization algorithm.
     /// </summary>
-    private CoordinateDescentOptimizerOptions<T, TInput, TOutput> _options;
+    /// <summary>Read from the single instance OptimizerBase.Options holds, so there is
+    /// no second copy that could disagree with it.</summary>
+    private CoordinateDescentOptimizerOptions<T, TInput, TOutput> _options => (CoordinateDescentOptimizerOptions<T, TInput, TOutput>)Options;
 
     /// <summary>
     /// Vector of learning rates for each coordinate (variable) in the optimization problem.
@@ -111,7 +113,6 @@ public partial class CoordinateDescentOptimizer<T, TInput, TOutput> : GradientBa
         IEngine? engine = null)
         : base(model, options ?? new())
     {
-        _options = options ?? new CoordinateDescentOptimizerOptions<T, TInput, TOutput>();
         _learningRates = Vector<T>.Empty();
         _momentums = Vector<T>.Empty();
         _previousUpdate = Vector<T>.Empty();
@@ -143,7 +144,6 @@ public partial class CoordinateDescentOptimizer<T, TInput, TOutput> : GradientBa
     private CoordinateDescentOptimizer(CoordinateDescentOptimizerOptions<T, TInput, TOutput>? options)
         : base(null, options ?? new())
     {
-        _options = options ?? new CoordinateDescentOptimizerOptions<T, TInput, TOutput>();
         _learningRates = Vector<T>.Empty();
         _momentums = Vector<T>.Empty();
         _previousUpdate = Vector<T>.Empty();
@@ -373,27 +373,6 @@ public partial class CoordinateDescentOptimizer<T, TInput, TOutput> : GradientBa
         _momentums = _momentums.Transform(mom => MathHelper.Clamp(mom, minMom, maxMom));
     }
 
-    /// <summary>
-    /// Updates the options for the Coordinate Descent optimizer.
-    /// </summary>
-    /// <param name="options">The new options to be set.</param>
-    /// <exception cref="ArgumentException">Thrown when the provided options are not of type CoordinateDescentOptimizerOptions.</exception>
-    /// <remarks>
-    /// <para><b>For Beginners:</b> This method allows you to change the settings of the optimizer during runtime.
-    /// It ensures that only the correct type of options (specific to Coordinate Descent) can be used.
-    /// </para>
-    /// </remarks>
-    protected override void UpdateOptions(OptimizationAlgorithmOptions<T, TInput, TOutput> options)
-    {
-        if (options is CoordinateDescentOptimizerOptions<T, TInput, TOutput> cdOptions)
-        {
-            _options = cdOptions;
-        }
-        else
-        {
-            throw new ArgumentException("Options must be of type CoordinateDescentOptimizerOptions", nameof(options));
-        }
-    }
 
     /// <summary>
     /// Retrieves the current options of the Coordinate Descent optimizer.

--- a/src/Optimizers/DFPOptimizer.cs
+++ b/src/Optimizers/DFPOptimizer.cs
@@ -52,7 +52,9 @@ public partial class DFPOptimizer<T, TInput, TOutput> : GradientBasedOptimizerBa
     /// <summary>
     /// The options specific to the DFP optimization algorithm.
     /// </summary>
-    private DFPOptimizerOptions<T, TInput, TOutput> _options;
+    /// <summary>Read from the single instance OptimizerBase.Options holds, so there is
+    /// no second copy that could disagree with it.</summary>
+    private DFPOptimizerOptions<T, TInput, TOutput> _options => (DFPOptimizerOptions<T, TInput, TOutput>)Options;
 
     /// <summary>
     /// The inverse Hessian matrix approximation used in the DFP algorithm.
@@ -95,7 +97,6 @@ public partial class DFPOptimizer<T, TInput, TOutput> : GradientBasedOptimizerBa
         IEngine? engine = null)
         : base(model, options ?? new())
     {
-        _options = options ?? new DFPOptimizerOptions<T, TInput, TOutput>();
         _previousGradient = Vector<T>.Empty();
         _inverseHessian = Matrix<T>.Empty();
         _adaptiveLearningRate = NumOps.Zero;
@@ -129,7 +130,6 @@ public partial class DFPOptimizer<T, TInput, TOutput> : GradientBasedOptimizerBa
     private DFPOptimizer(DFPOptimizerOptions<T, TInput, TOutput>? options)
         : base(null, options ?? new())
     {
-        _options = options ?? new DFPOptimizerOptions<T, TInput, TOutput>();
         _previousGradient = Vector<T>.Empty();
         _inverseHessian = Matrix<T>.Empty();
         _adaptiveLearningRate = NumOps.Zero;
@@ -336,27 +336,6 @@ public partial class DFPOptimizer<T, TInput, TOutput> : GradientBasedOptimizerBa
         }
     }
 
-    /// <summary>
-    /// Updates the options for the DFP optimizer.
-    /// </summary>
-    /// <param name="options">The new options to be set.</param>
-    /// <exception cref="ArgumentException">Thrown when the provided options are not of type DFPOptimizerOptions.</exception>
-    /// <remarks>
-    /// <para><b>For Beginners:</b> This method allows you to change the settings of the optimizer during runtime.
-    /// It ensures that only the correct type of options (specific to DFP) can be used.
-    /// </para>
-    /// </remarks>
-    protected override void UpdateOptions(OptimizationAlgorithmOptions<T, TInput, TOutput> options)
-    {
-        if (options is DFPOptimizerOptions<T, TInput, TOutput> dfpOptions)
-        {
-            _options = dfpOptions;
-        }
-        else
-        {
-            throw new ArgumentException("Options must be of type DFPOptimizerOptions", nameof(options));
-        }
-    }
 
     /// <summary>
     /// Retrieves the current options of the DFP optimizer.

--- a/src/Optimizers/DifferentialEvolutionOptimizer.cs
+++ b/src/Optimizers/DifferentialEvolutionOptimizer.cs
@@ -39,7 +39,9 @@ public partial class DifferentialEvolutionOptimizer<T, TInput, TOutput> : Optimi
     /// (refining good solutions).
     /// </para>
     /// </remarks>
-    private DifferentialEvolutionOptions<T, TInput, TOutput> _deOptions;
+    /// <summary>Read from the single instance OptimizerBase.Options holds, so there is
+    /// no second copy that could disagree with it.</summary>
+    private DifferentialEvolutionOptions<T, TInput, TOutput> _deOptions => (DifferentialEvolutionOptions<T, TInput, TOutput>)Options;
 
     /// <summary>
     /// The current crossover rate used in the optimization process.
@@ -88,7 +90,6 @@ public partial class DifferentialEvolutionOptimizer<T, TInput, TOutput> : Optimi
         IEngine? engine = null)
         : base(model, options ?? new())
     {
-        _deOptions = options ?? new DifferentialEvolutionOptions<T, TInput, TOutput>();
         _currentCrossoverRate = NumOps.Zero;
         _currentMutationRate = NumOps.Zero;
 
@@ -248,27 +249,6 @@ public partial class DifferentialEvolutionOptimizer<T, TInput, TOutput> : Optimi
         return InterfaceGuard.Parameterizable(currentModel).WithParameters(trialParams);
     }
 
-    /// <summary>
-    /// Updates the options for the Differential Evolution optimizer.
-    /// </summary>
-    /// <param name="options">The new options to be set.</param>
-    /// <exception cref="ArgumentException">Thrown when the provided options are not of type DifferentialEvolutionOptions.</exception>
-    /// <remarks>
-    /// <para><b>For Beginners:</b> This method allows you to change the settings of the optimizer during runtime.
-    /// It ensures that only the correct type of options (specific to Differential Evolution) can be used.
-    /// </para>
-    /// </remarks>
-    protected override void UpdateOptions(OptimizationAlgorithmOptions<T, TInput, TOutput> options)
-    {
-        if (options is DifferentialEvolutionOptions<T, TInput, TOutput> deOptions)
-        {
-            _deOptions = deOptions;
-        }
-        else
-        {
-            throw new ArgumentException("Options must be of type DifferentialEvolutionOptions", nameof(options));
-        }
-    }
 
     /// <summary>
     /// Retrieves the current options of the Differential Evolution optimizer.
@@ -296,7 +276,6 @@ public partial class DifferentialEvolutionOptimizer<T, TInput, TOutput> : Optimi
     private DifferentialEvolutionOptimizer(DifferentialEvolutionOptions<T, TInput, TOutput>? options)
         : base(null, options ?? new())
     {
-        _deOptions = options ?? new DifferentialEvolutionOptions<T, TInput, TOutput>();
         _currentCrossoverRate = NumOps.Zero;
         _currentMutationRate = NumOps.Zero;
 

--- a/src/Optimizers/FTRLOptimizer.cs
+++ b/src/Optimizers/FTRLOptimizer.cs
@@ -99,7 +99,9 @@ public partial class FTRLOptimizer<T, TInput, TOutput> : GradientBasedOptimizerB
     /// <summary>
     /// The options specific to the FTRL algorithm.
     /// </summary>
-    private FTRLOptimizerOptions<T, TInput, TOutput> _options;
+    /// <summary>Read from the single instance OptimizerBase.Options holds, so there is
+    /// no second copy that could disagree with it.</summary>
+    private FTRLOptimizerOptions<T, TInput, TOutput> _options => (FTRLOptimizerOptions<T, TInput, TOutput>)Options;
 
     /// <summary>
     /// Auxiliary vector used in the FTRL update rule.
@@ -148,7 +150,6 @@ public partial class FTRLOptimizer<T, TInput, TOutput> : GradientBasedOptimizerB
         IEngine? engine = null)
         : base(model, options ?? new())
     {
-        _options = options ?? new FTRLOptimizerOptions<T, TInput, TOutput>();
 
         InitializeAdaptiveParameters();
     }
@@ -179,7 +180,6 @@ public partial class FTRLOptimizer<T, TInput, TOutput> : GradientBasedOptimizerB
     private FTRLOptimizer(FTRLOptimizerOptions<T, TInput, TOutput>? options)
         : base(null, options ?? new())
     {
-        _options = options ?? new FTRLOptimizerOptions<T, TInput, TOutput>();
 
         InitializeAdaptiveParameters();
     }
@@ -627,28 +627,6 @@ public partial class FTRLOptimizer<T, TInput, TOutput> : GradientBasedOptimizerB
         }
     }
 
-    /// <summary>
-    /// Updates the options for the FTRL optimizer.
-    /// </summary>
-    /// <remarks>
-    /// <para><b>For Beginners:</b> This method allows you to change the settings of the optimizer while it's running.
-    /// It's like adjusting the controls on a machine while it's operating. This can be useful if you want to
-    /// fine-tune the optimizer's behavior based on its performance or other factors.
-    /// </para>
-    /// </remarks>
-    /// <param name="options">The new options to be set.</param>
-    /// <exception cref="ArgumentException">Thrown when the provided options are not of type FTRLOptimizerOptions.</exception>
-    protected override void UpdateOptions(OptimizationAlgorithmOptions<T, TInput, TOutput> options)
-    {
-        if (options is FTRLOptimizerOptions<T, TInput, TOutput> ftrlOptions)
-        {
-            _options = ftrlOptions;
-        }
-        else
-        {
-            throw new ArgumentException("Invalid options type. Expected FTRLOptimizerOptions.");
-        }
-    }
 
     /// <summary>
     /// Retrieves the current options of the FTRL optimizer.

--- a/src/Optimizers/GeneticAlgorithmOptimizer.cs
+++ b/src/Optimizers/GeneticAlgorithmOptimizer.cs
@@ -34,7 +34,9 @@ public partial class GeneticAlgorithmOptimizer<T, TInput, TOutput> : OptimizerBa
     /// <summary>
     /// The options specific to the Genetic Algorithm.
     /// </summary>
-    private GeneticAlgorithmOptimizerOptions<T, TInput, TOutput> _geneticOptions;
+    /// <summary>Read from the single instance OptimizerBase.Options holds, so there is
+    /// no second copy that could disagree with it.</summary>
+    private GeneticAlgorithmOptimizerOptions<T, TInput, TOutput> _geneticOptions => (GeneticAlgorithmOptimizerOptions<T, TInput, TOutput>)Options;
 
     /// <summary>
     /// The current crossover rate, which determines how often solutions are combined.
@@ -68,7 +70,6 @@ public partial class GeneticAlgorithmOptimizer<T, TInput, TOutput> : OptimizerBa
         IFitnessCalculator<T, TInput, TOutput>? fitnessCalculator = null)
         : base(model, options ?? new())
     {
-        _geneticOptions = options ?? new GeneticAlgorithmOptimizerOptions<T, TInput, TOutput>();
         _currentCrossoverRate = NumOps.Zero;
         _currentMutationRate = NumOps.Zero;
 
@@ -188,27 +189,6 @@ public partial class GeneticAlgorithmOptimizer<T, TInput, TOutput> : OptimizerBa
         return CreateOptimizationResult(bestStepData, inputData);
     }
 
-    /// <summary>
-    /// Updates the options for the genetic algorithm optimizer.
-    /// </summary>
-    /// <remarks>
-    /// <para><b>For Beginners:</b> This method allows you to change the settings of the genetic algorithm
-    /// while it's running. It's like adjusting the rules of your cooking competition mid-way through.
-    /// </para>
-    /// </remarks>
-    /// <param name="options">The new options to apply to the optimizer.</param>
-    /// <exception cref="ArgumentException">Thrown when the provided options are not of the correct type.</exception>
-    protected override void UpdateOptions(OptimizationAlgorithmOptions<T, TInput, TOutput> options)
-    {
-        if (options is GeneticAlgorithmOptimizerOptions<T, TInput, TOutput> geneticOptions)
-        {
-            _geneticOptions = geneticOptions;
-        }
-        else
-        {
-            throw new ArgumentException("Invalid options type. Expected GeneticAlgorithmOptimizerOptions.");
-        }
-    }
 
     /// <summary>
     /// Gets the current options for the genetic algorithm optimizer.

--- a/src/Optimizers/GradientDescentOptimizer.cs
+++ b/src/Optimizers/GradientDescentOptimizer.cs
@@ -65,7 +65,9 @@ public partial class GradientDescentOptimizer<T, TInput, TOutput> : GradientBase
     /// <summary>
     /// Options specific to the Gradient Descent optimizer.
     /// </summary>
-    private GradientDescentOptimizerOptions<T, TInput, TOutput> _gdOptions;
+    /// <summary>Read from the single instance OptimizerBase.Options holds, so there is
+    /// no second copy that could disagree with it.</summary>
+    private GradientDescentOptimizerOptions<T, TInput, TOutput> _gdOptions => (GradientDescentOptimizerOptions<T, TInput, TOutput>)Options;
 
     /// <summary>
     /// The regularization technique used to prevent overfitting.
@@ -89,7 +91,6 @@ public partial class GradientDescentOptimizer<T, TInput, TOutput> : GradientBase
         IEngine? engine = null)
         : base(model, options ?? new GradientDescentOptimizerOptions<T, TInput, TOutput>())
     {
-        _gdOptions = options ?? new GradientDescentOptimizerOptions<T, TInput, TOutput>();
         _regularization = _gdOptions.Regularization ?? CreateRegularization(_gdOptions);
     }
 
@@ -119,7 +120,6 @@ public partial class GradientDescentOptimizer<T, TInput, TOutput> : GradientBase
     private GradientDescentOptimizer(GradientDescentOptimizerOptions<T, TInput, TOutput>? options)
         : base(null, options ?? new())
     {
-        _gdOptions = options ?? new GradientDescentOptimizerOptions<T, TInput, TOutput>();
         _regularization = _gdOptions.Regularization ?? CreateRegularization(_gdOptions);
     }
 
@@ -325,27 +325,6 @@ public partial class GradientDescentOptimizer<T, TInput, TOutput> : GradientBase
         return NumOps.Add(loss, regularizationTerm);
     }
 
-    /// <summary>
-    /// Updates the options for the Gradient Descent optimizer.
-    /// </summary>
-    /// <remarks>
-    /// <para><b>For Beginners:</b> This method allows you to change the settings of the optimizer
-    /// while it's running. It's like adjusting your hiking strategy mid-journey based on the terrain you encounter.
-    /// </para>
-    /// </remarks>
-    /// <param name="options">The new options to apply to the optimizer.</param>
-    /// <exception cref="ArgumentException">Thrown when the provided options are not of the correct type.</exception>
-    protected override void UpdateOptions(OptimizationAlgorithmOptions<T, TInput, TOutput> options)
-    {
-        if (options is GradientDescentOptimizerOptions<T, TInput, TOutput> gdOptions)
-        {
-            _gdOptions = gdOptions;
-        }
-        else
-        {
-            throw new ArgumentException("Invalid options type. Expected GradientDescentOptions.");
-        }
-    }
 
     /// <summary>
     /// Retrieves the current options for the Gradient Descent optimizer.

--- a/src/Optimizers/LAMBOptimizer.cs
+++ b/src/Optimizers/LAMBOptimizer.cs
@@ -85,7 +85,9 @@ public partial class LAMBOptimizer<T, TInput, TOutput> : GradientBasedOptimizerB
     /// <summary>
     /// The options specific to the LAMB optimizer.
     /// </summary>
-    private LAMBOptimizerOptions<T, TInput, TOutput> _options;
+    /// <summary>Read from the single instance OptimizerBase.Options holds, so there is
+    /// no second copy that could disagree with it.</summary>
+    private LAMBOptimizerOptions<T, TInput, TOutput> _options => (LAMBOptimizerOptions<T, TInput, TOutput>)Options;
 
     /// <summary>
     /// The first moment vector (moving average of gradients).
@@ -145,7 +147,6 @@ public partial class LAMBOptimizer<T, TInput, TOutput> : GradientBasedOptimizerB
         _v = Vector<T>.Empty();
         _t = 0;
         _warmupSteps = 0;
-        _options = options ?? new();
 
         InitializeAdaptiveParameters();
     }
@@ -828,20 +829,6 @@ public partial class LAMBOptimizer<T, TInput, TOutput> : GradientBasedOptimizerB
         _t = 0;
     }
 
-    /// <summary>
-    /// Updates the optimizer's options.
-    /// </summary>
-    protected override void UpdateOptions(OptimizationAlgorithmOptions<T, TInput, TOutput> options)
-    {
-        if (options is LAMBOptimizerOptions<T, TInput, TOutput> lambOptions)
-        {
-            _options = lambOptions;
-        }
-        else
-        {
-            throw new ArgumentException("Invalid options type. Expected LAMBOptimizerOptions.");
-        }
-    }
 
     /// <summary>
     /// Gets the current optimizer options.

--- a/src/Optimizers/LARSOptimizer.cs
+++ b/src/Optimizers/LARSOptimizer.cs
@@ -55,7 +55,9 @@ public partial class LARSOptimizer<T, TInput, TOutput> : GradientBasedOptimizerB
     /// <summary>
     /// The options specific to the LARS optimizer.
     /// </summary>
-    private LARSOptimizerOptions<T, TInput, TOutput> _options;
+    /// <summary>Read from the single instance OptimizerBase.Options holds, so there is
+    /// no second copy that could disagree with it.</summary>
+    private LARSOptimizerOptions<T, TInput, TOutput> _options => (LARSOptimizerOptions<T, TInput, TOutput>)Options;
 
     /// <summary>
     /// The velocity/momentum buffer for each parameter.
@@ -103,7 +105,6 @@ public partial class LARSOptimizer<T, TInput, TOutput> : GradientBasedOptimizerB
         _velocity = Vector<T>.Empty();
         _t = 0;
         _warmupSteps = 0;
-        _options = options ?? new();
 
         InitializeAdaptiveParameters();
     }
@@ -666,20 +667,6 @@ public partial class LARSOptimizer<T, TInput, TOutput> : GradientBasedOptimizerB
         _t = 0;
     }
 
-    /// <summary>
-    /// Updates the optimizer's options.
-    /// </summary>
-    protected override void UpdateOptions(OptimizationAlgorithmOptions<T, TInput, TOutput> options)
-    {
-        if (options is LARSOptimizerOptions<T, TInput, TOutput> larsOptions)
-        {
-            _options = larsOptions;
-        }
-        else
-        {
-            throw new ArgumentException("Invalid options type. Expected LARSOptimizerOptions.");
-        }
-    }
 
     /// <summary>
     /// Gets the current optimizer options.

--- a/src/Optimizers/LBFGSOptimizer.cs
+++ b/src/Optimizers/LBFGSOptimizer.cs
@@ -79,7 +79,9 @@ public partial class LBFGSOptimizer<T, TInput, TOutput> : GradientBasedOptimizer
     /// <summary>
     /// Options specific to the L-BFGS optimizer.
     /// </summary>
-    private LBFGSOptimizerOptions<T, TInput, TOutput> _options;
+    /// <summary>Read from the single instance OptimizerBase.Options holds, so there is
+    /// no second copy that could disagree with it.</summary>
+    private LBFGSOptimizerOptions<T, TInput, TOutput> _options => (LBFGSOptimizerOptions<T, TInput, TOutput>)Options;
 
     /// <summary>
     /// List of position (solution) differences used in the L-BFGS update.
@@ -148,7 +150,6 @@ public partial class LBFGSOptimizer<T, TInput, TOutput> : GradientBasedOptimizer
         IEngine? engine = null)
         : base(model, options ?? new())
     {
-        _options = options ?? new LBFGSOptimizerOptions<T, TInput, TOutput>();
         _s = new List<Vector<T>>();
         _y = new List<Vector<T>>();
         _lbfgsInverseHessianScale = NumOps.One;
@@ -181,7 +182,6 @@ public partial class LBFGSOptimizer<T, TInput, TOutput> : GradientBasedOptimizer
     private LBFGSOptimizer(LBFGSOptimizerOptions<T, TInput, TOutput>? options)
         : base(null, options ?? new())
     {
-        _options = options ?? new LBFGSOptimizerOptions<T, TInput, TOutput>();
         _s = new List<Vector<T>>();
         _y = new List<Vector<T>>();
         _lbfgsInverseHessianScale = NumOps.One;
@@ -845,32 +845,6 @@ public partial class LBFGSOptimizer<T, TInput, TOutput> : GradientBasedOptimizer
         return direction;
     }
 
-    /// <summary>
-    /// Updates the optimizer's options with new settings.
-    /// </summary>
-    /// <remarks>
-    /// <para>
-    /// This method updates the optimizer's configuration with new options. It ensures that only valid
-    /// LBFGSOptimizerOptions are applied to this optimizer.
-    /// </para>
-    /// <para><b>For Beginners:</b>
-    /// This is like changing the settings on the optimizer. It makes sure you're using the right kind of settings
-    /// for this specific type of optimizer.
-    /// </para>
-    /// </remarks>
-    /// <param name="options">The new options to apply to the optimizer.</param>
-    /// <exception cref="ArgumentException">Thrown when the provided options are not of type LBFGSOptimizerOptions.</exception>
-    protected override void UpdateOptions(OptimizationAlgorithmOptions<T, TInput, TOutput> options)
-    {
-        if (options is LBFGSOptimizerOptions<T, TInput, TOutput> lbfgsOptions)
-        {
-            _options = lbfgsOptions;
-        }
-        else
-        {
-            throw new ArgumentException("Invalid options type. Expected LBFGSOptimizerOptions.");
-        }
-    }
 
     /// <summary>
     /// Retrieves the current options of the optimizer.

--- a/src/Optimizers/LevenbergMarquardtOptimizer.cs
+++ b/src/Optimizers/LevenbergMarquardtOptimizer.cs
@@ -55,7 +55,9 @@ public partial class LevenbergMarquardtOptimizer<T, TInput, TOutput> : GradientB
     /// <summary>
     /// The options specific to the Levenberg-Marquardt algorithm.
     /// </summary>
-    private LevenbergMarquardtOptimizerOptions<T, TInput, TOutput> _options;
+    /// <summary>Read from the single instance OptimizerBase.Options holds, so there is
+    /// no second copy that could disagree with it.</summary>
+    private LevenbergMarquardtOptimizerOptions<T, TInput, TOutput> _options => (LevenbergMarquardtOptimizerOptions<T, TInput, TOutput>)Options;
 
     /// <summary>
     /// The current iteration count of the optimization process.
@@ -90,7 +92,6 @@ public partial class LevenbergMarquardtOptimizer<T, TInput, TOutput> : GradientB
         IEngine? engine = null)
         : base(model, options ?? new())
     {
-        _options = options ?? new LevenbergMarquardtOptimizerOptions<T, TInput, TOutput>();
         _dampingFactor = NumOps.Zero;
 
         InitializeAdaptiveParameters();
@@ -122,7 +123,6 @@ public partial class LevenbergMarquardtOptimizer<T, TInput, TOutput> : GradientB
     private LevenbergMarquardtOptimizer(LevenbergMarquardtOptimizerOptions<T, TInput, TOutput>? options)
         : base(null, options ?? new())
     {
-        _options = options ?? new LevenbergMarquardtOptimizerOptions<T, TInput, TOutput>();
         _dampingFactor = NumOps.Zero;
 
         InitializeAdaptiveParameters();
@@ -455,33 +455,6 @@ public partial class LevenbergMarquardtOptimizer<T, TInput, TOutput> : GradientB
         }
     }
 
-    /// <summary>
-    /// Updates the optimizer's options with new settings.
-    /// </summary>
-    /// <remarks>
-    /// <para>
-    /// This method allows updating the optimizer's settings during runtime. It ensures that only compatible
-    /// option types are used with this optimizer.
-    /// </para>
-    /// <para><b>For Beginners:</b>
-    /// This is like changing the settings on a machine while it's running. It makes sure that we're only
-    /// using settings that work for this specific type of optimizer. If someone tries to use the wrong
-    /// type of settings, it lets them know there's a problem.
-    /// </para>
-    /// </remarks>
-    /// <param name="options">The new options to be applied to the optimizer.</param>
-    /// <exception cref="ArgumentException">Thrown when the provided options are not of the correct type.</exception>
-    protected override void UpdateOptions(OptimizationAlgorithmOptions<T, TInput, TOutput> options)
-    {
-        if (options is LevenbergMarquardtOptimizerOptions<T, TInput, TOutput> lmOptions)
-        {
-            _options = lmOptions;
-        }
-        else
-        {
-            throw new ArgumentException("Invalid options type. Expected LevenbergMarquardtOptimizerOptions.");
-        }
-    }
 
     /// <summary>
     /// Retrieves the current options of the optimizer.

--- a/src/Optimizers/MiniBatchGradientDescentOptimizer.cs
+++ b/src/Optimizers/MiniBatchGradientDescentOptimizer.cs
@@ -61,7 +61,9 @@ public partial class MiniBatchGradientDescentOptimizer<T, TInput, TOutput> : Gra
     /// how many times to repeat the process, and how to adjust your step size.
     /// </para>
     /// </remarks>
-    private MiniBatchGradientDescentOptions<T, TInput, TOutput> _options;
+    /// <summary>Read from the single instance OptimizerBase.Options holds, so there is
+    /// no second copy that could disagree with it.</summary>
+    private MiniBatchGradientDescentOptions<T, TInput, TOutput> _options => (MiniBatchGradientDescentOptions<T, TInput, TOutput>)Options;
 
     /// <summary>
     /// Initializes a new instance of the MiniBatchGradientDescentOptimizer class.
@@ -83,7 +85,6 @@ public partial class MiniBatchGradientDescentOptimizer<T, TInput, TOutput> : Gra
         IEngine? engine = null)
         : base(model, options ?? new())
     {
-        _options = options ?? new MiniBatchGradientDescentOptions<T, TInput, TOutput>();
 
         InitializeAdaptiveParameters();
     }
@@ -114,7 +115,6 @@ public partial class MiniBatchGradientDescentOptimizer<T, TInput, TOutput> : Gra
     private MiniBatchGradientDescentOptimizer(MiniBatchGradientDescentOptions<T, TInput, TOutput>? options)
         : base(null, options ?? new())
     {
-        _options = options ?? new MiniBatchGradientDescentOptions<T, TInput, TOutput>();
 
         InitializeAdaptiveParameters();
     }
@@ -328,32 +328,6 @@ public partial class MiniBatchGradientDescentOptimizer<T, TInput, TOutput> : Gra
         }
     }
 
-    /// <summary>
-    /// Updates the optimizer's options with new settings.
-    /// </summary>
-    /// <remarks>
-    /// <para>
-    /// This method allows updating the optimizer's settings during runtime. It ensures that only compatible
-    /// option types are used with this optimizer.
-    /// </para>
-    /// <para><b>For Beginners:</b>
-    /// This is like changing your hiking strategy mid-journey. It makes sure you're only using strategies 
-    /// that work for this specific type of journey (Mini-Batch Gradient Descent).
-    /// </para>
-    /// </remarks>
-    /// <param name="options">The new options to be applied to the optimizer.</param>
-    /// <exception cref="ArgumentException">Thrown when the provided options are not of the correct type.</exception>
-    protected override void UpdateOptions(OptimizationAlgorithmOptions<T, TInput, TOutput> options)
-    {
-        if (options is MiniBatchGradientDescentOptions<T, TInput, TOutput> mbgdOptions)
-        {
-            _options = mbgdOptions;
-        }
-        else
-        {
-            throw new ArgumentException("Invalid options type. Expected MiniBatchGradientDescentOptions.");
-        }
-    }
 
     /// <summary>
     /// Gets the current optimization algorithm options.

--- a/src/Optimizers/MomentumOptimizer.cs
+++ b/src/Optimizers/MomentumOptimizer.cs
@@ -77,7 +77,9 @@ public partial class MomentumOptimizer<T, TInput, TOutput> : GradientBasedOptimi
     /// its previous direction (momentum), and whether these properties change automatically during the experiment.
     /// </para>
     /// </remarks>
-    private MomentumOptimizerOptions<T, TInput, TOutput> _options;
+    /// <summary>Read from the single instance OptimizerBase.Options holds, so there is
+    /// no second copy that could disagree with it.</summary>
+    private MomentumOptimizerOptions<T, TInput, TOutput> _options => (MomentumOptimizerOptions<T, TInput, TOutput>)Options;
 
     /// <summary>
     /// Stores the current velocity vector for each parameter in the model.
@@ -116,7 +118,6 @@ public partial class MomentumOptimizer<T, TInput, TOutput> : GradientBasedOptimi
         MomentumOptimizerOptions<T, TInput, TOutput>? options = null)
         : base(model, options ?? new())
     {
-        _options = options ?? new MomentumOptimizerOptions<T, TInput, TOutput>();
         InitializeAdaptiveParameters();
     }
 
@@ -146,7 +147,6 @@ public partial class MomentumOptimizer<T, TInput, TOutput> : GradientBasedOptimi
     private MomentumOptimizer(MomentumOptimizerOptions<T, TInput, TOutput>? options)
         : base(null, options ?? new())
     {
-        _options = options ?? new MomentumOptimizerOptions<T, TInput, TOutput>();
         InitializeAdaptiveParameters();
     }
 
@@ -501,32 +501,6 @@ public partial class MomentumOptimizer<T, TInput, TOutput> : GradientBasedOptimi
         }
     }
 
-    /// <summary>
-    /// Updates the optimizer's options with new settings.
-    /// </summary>
-    /// <remarks>
-    /// <para>
-    /// This method allows updating the optimizer's settings during runtime. It ensures that only compatible
-    /// option types are used with this optimizer.
-    /// </para>
-    /// <para><b>For Beginners:</b>
-    /// This is like changing the rules of how you're rolling the ball mid-experiment. It makes sure you're only
-    /// using rules that work for this specific type of ball-rolling (Momentum optimization).
-    /// </para>
-    /// </remarks>
-    /// <param name="options">The new options to be applied to the optimizer.</param>
-    /// <exception cref="ArgumentException">Thrown when the provided options are not of the correct type.</exception>
-    protected override void UpdateOptions(OptimizationAlgorithmOptions<T, TInput, TOutput> options)
-    {
-        if (options is MomentumOptimizerOptions<T, TInput, TOutput> momentumOptions)
-        {
-            _options = momentumOptions;
-        }
-        else
-        {
-            throw new ArgumentException("Invalid options type. Expected MomentumOptimizerOptions.");
-        }
-    }
 
     /// <summary>
     /// Gets the current optimization algorithm options.

--- a/src/Optimizers/NadamOptimizer.cs
+++ b/src/Optimizers/NadamOptimizer.cs
@@ -50,7 +50,9 @@ public partial class NadamOptimizer<T, TInput, TOutput> : GradientBasedOptimizer
     /// <summary>
     /// The options specific to the Nadam optimizer.
     /// </summary>
-    private NadamOptimizerOptions<T, TInput, TOutput> _options;
+    /// <summary>Read from the single instance OptimizerBase.Options holds, so there is
+    /// no second copy that could disagree with it.</summary>
+    private NadamOptimizerOptions<T, TInput, TOutput> _options => (NadamOptimizerOptions<T, TInput, TOutput>)Options;
 
     /// <summary>
     /// The first moment vector (momentum).
@@ -112,7 +114,6 @@ public partial class NadamOptimizer<T, TInput, TOutput> : GradientBasedOptimizer
         NadamOptimizerOptions<T, TInput, TOutput>? options = null)
         : base(model, options ?? new())
     {
-        _options = options ?? new NadamOptimizerOptions<T, TInput, TOutput>();
 
         InitializeAdaptiveParameters();
     }
@@ -143,7 +144,6 @@ public partial class NadamOptimizer<T, TInput, TOutput> : GradientBasedOptimizer
     private NadamOptimizer(NadamOptimizerOptions<T, TInput, TOutput>? options)
         : base(null, options ?? new())
     {
-        _options = options ?? new NadamOptimizerOptions<T, TInput, TOutput>();
 
         InitializeAdaptiveParameters();
     }
@@ -624,32 +624,6 @@ public partial class NadamOptimizer<T, TInput, TOutput> : GradientBasedOptimizer
         }
     }
 
-    /// <summary>
-    /// Updates the optimizer's options with new settings.
-    /// </summary>
-    /// <remarks>
-    /// <para>
-    /// This method ensures that only compatible option types are used with this optimizer.
-    /// It updates the internal options if the provided options are of the correct type.
-    /// </para>
-    /// <para><b>For Beginners:</b>
-    /// This is like changing the rules of how your smart ball rolls mid-experiment. It makes sure you're only
-    /// using rules that work for this specific type of smart ball (Nadam optimization).
-    /// </para>
-    /// </remarks>
-    /// <param name="options">The new options to be applied to the optimizer.</param>
-    /// <exception cref="ArgumentException">Thrown when the provided options are not of the correct type.</exception>
-    protected override void UpdateOptions(OptimizationAlgorithmOptions<T, TInput, TOutput> options)
-    {
-        if (options is NadamOptimizerOptions<T, TInput, TOutput> nadamOptions)
-        {
-            _options = nadamOptions;
-        }
-        else
-        {
-            throw new ArgumentException("Invalid options type. Expected NadamOptimizerOptions.");
-        }
-    }
 
     /// <summary>
     /// Gets the current optimization algorithm options.

--- a/src/Optimizers/NelderMeadOptimizer.cs
+++ b/src/Optimizers/NelderMeadOptimizer.cs
@@ -29,7 +29,9 @@ public partial class NelderMeadOptimizer<T, TInput, TOutput> : OptimizerBase<T, 
     /// <summary>
     /// The options specific to the Nelder-Mead optimizer.
     /// </summary>
-    private NelderMeadOptimizerOptions<T, TInput, TOutput> _options;
+    /// <summary>Read from the single instance OptimizerBase.Options holds, so there is
+    /// no second copy that could disagree with it.</summary>
+    private NelderMeadOptimizerOptions<T, TInput, TOutput> _options => (NelderMeadOptimizerOptions<T, TInput, TOutput>)Options;
 
     /// <summary>
     /// The current iteration count.
@@ -76,7 +78,6 @@ public partial class NelderMeadOptimizer<T, TInput, TOutput> : OptimizerBase<T, 
         NelderMeadOptimizerOptions<T, TInput, TOutput>? options = null)
         : base(model, options ?? new())
     {
-        _options = options ?? new NelderMeadOptimizerOptions<T, TInput, TOutput>();
         _alpha = NumOps.Zero;
         _beta = NumOps.Zero;
         _gamma = NumOps.Zero;
@@ -104,7 +105,6 @@ public partial class NelderMeadOptimizer<T, TInput, TOutput> : OptimizerBase<T, 
     public NelderMeadOptimizer(NelderMeadOptimizerOptions<T, TInput, TOutput>? options = null)
         : base(null, options ?? new())
     {
-        _options = options ?? new NelderMeadOptimizerOptions<T, TInput, TOutput>();
         _alpha = NumOps.Zero;
         _beta = NumOps.Zero;
         _gamma = NumOps.Zero;
@@ -637,31 +637,6 @@ public partial class NelderMeadOptimizer<T, TInput, TOutput> : OptimizerBase<T, 
         base.UpdateAdaptiveParameters(currentStepData, previousStepData);
     }
 
-    /// <summary>
-    /// Updates the optimizer's options with new settings.
-    /// </summary>
-    /// <remarks>
-    /// <para>
-    /// This method ensures that only compatible option types are used with this optimizer.
-    /// It updates the internal options if the provided options are of the correct type.
-    /// </para>
-    /// <para><b>For Beginners:</b>
-    /// This is like changing the rules for how the explorers should search. It makes sure you're only using rules that work for this specific type of search (Nelder-Mead method).
-    /// </para>
-    /// </remarks>
-    /// <param name="options">The new options to be applied to the optimizer.</param>
-    /// <exception cref="ArgumentException">Thrown when the provided options are not of the correct type.</exception>
-    protected override void UpdateOptions(OptimizationAlgorithmOptions<T, TInput, TOutput> options)
-    {
-        if (options is NelderMeadOptimizerOptions<T, TInput, TOutput> nmOptions)
-        {
-            _options = nmOptions;
-        }
-        else
-        {
-            throw new ArgumentException("Invalid options type. Expected NelderMeadOptimizerOptions.");
-        }
-    }
 
     /// <summary>
     /// Gets the current options of the Nelder-Mead optimizer.

--- a/src/Optimizers/NesterovAcceleratedGradientOptimizer.cs
+++ b/src/Optimizers/NesterovAcceleratedGradientOptimizer.cs
@@ -71,7 +71,9 @@ public partial class NesterovAcceleratedGradientOptimizer<T, TInput, TOutput> : 
     /// <summary>
     /// The options specific to the Nesterov Accelerated Gradient optimizer.
     /// </summary>
-    private NesterovAcceleratedGradientOptimizerOptions<T, TInput, TOutput> _options;
+    /// <summary>Read from the single instance OptimizerBase.Options holds, so there is
+    /// no second copy that could disagree with it.</summary>
+    private NesterovAcceleratedGradientOptimizerOptions<T, TInput, TOutput> _options => (NesterovAcceleratedGradientOptimizerOptions<T, TInput, TOutput>)Options;
 
     /// <summary>
     /// The velocity vector used in the NAG algorithm.
@@ -105,7 +107,6 @@ public partial class NesterovAcceleratedGradientOptimizer<T, TInput, TOutput> : 
         IEngine? engine = null)
         : base(model, options ?? new())
     {
-        _options = options ?? new NesterovAcceleratedGradientOptimizerOptions<T, TInput, TOutput>();
 
         InitializeAdaptiveParameters();
     }
@@ -136,7 +137,6 @@ public partial class NesterovAcceleratedGradientOptimizer<T, TInput, TOutput> : 
     private NesterovAcceleratedGradientOptimizer(NesterovAcceleratedGradientOptimizerOptions<T, TInput, TOutput>? options)
         : base(null, options ?? new())
     {
-        _options = options ?? new NesterovAcceleratedGradientOptimizerOptions<T, TInput, TOutput>();
 
         InitializeAdaptiveParameters();
     }
@@ -541,31 +541,6 @@ public partial class NesterovAcceleratedGradientOptimizer<T, TInput, TOutput> : 
         }
     }
 
-    /// <summary>
-    /// Updates the optimizer's options with new settings.
-    /// </summary>
-    /// <remarks>
-    /// <para>
-    /// This method ensures that only compatible option types are used with this optimizer.
-    /// It updates the internal options if the provided options are of the correct type.
-    /// </para>
-    /// <para><b>For Beginners:</b>
-    /// This is like changing the rules for how the skier should navigate the slope. It makes sure you're only using rules that work for this specific type of skiing technique (Nesterov Accelerated Gradient method).
-    /// </para>
-    /// </remarks>
-    /// <param name="options">The new options to be applied to the optimizer.</param>
-    /// <exception cref="ArgumentException">Thrown when the provided options are not of the correct type.</exception>
-    protected override void UpdateOptions(OptimizationAlgorithmOptions<T, TInput, TOutput> options)
-    {
-        if (options is NesterovAcceleratedGradientOptimizerOptions<T, TInput, TOutput> nagOptions)
-        {
-            _options = nagOptions;
-        }
-        else
-        {
-            throw new ArgumentException("Invalid options type. Expected NesterovAcceleratedGradientOptimizerOptions.");
-        }
-    }
 
     /// <summary>
     /// Gets the current options of the Nesterov Accelerated Gradient optimizer.

--- a/src/Optimizers/NewtonMethodOptimizer.cs
+++ b/src/Optimizers/NewtonMethodOptimizer.cs
@@ -53,7 +53,9 @@ public partial class NewtonMethodOptimizer<T, TInput, TOutput> : GradientBasedOp
     /// <summary>
     /// The options specific to the Newton's Method optimizer.
     /// </summary>
-    private NewtonMethodOptimizerOptions<T, TInput, TOutput> _options;
+    /// <summary>Read from the single instance OptimizerBase.Options holds, so there is
+    /// no second copy that could disagree with it.</summary>
+    private NewtonMethodOptimizerOptions<T, TInput, TOutput> _options => (NewtonMethodOptimizerOptions<T, TInput, TOutput>)Options;
 
     /// <summary>
     /// The current iteration count of the optimization process.
@@ -80,7 +82,6 @@ public partial class NewtonMethodOptimizer<T, TInput, TOutput> : GradientBasedOp
         NewtonMethodOptimizerOptions<T, TInput, TOutput>? options = null)
         : base(model, options ?? new())
     {
-        _options = options ?? new NewtonMethodOptimizerOptions<T, TInput, TOutput>();
 
         InitializeAdaptiveParameters();
     }
@@ -111,7 +112,6 @@ public partial class NewtonMethodOptimizer<T, TInput, TOutput> : GradientBasedOp
     private NewtonMethodOptimizer(NewtonMethodOptimizerOptions<T, TInput, TOutput>? options)
         : base(null, options ?? new())
     {
-        _options = options ?? new NewtonMethodOptimizerOptions<T, TInput, TOutput>();
 
         InitializeAdaptiveParameters();
     }
@@ -405,32 +405,6 @@ public partial class NewtonMethodOptimizer<T, TInput, TOutput> : GradientBasedOp
         }
     }
 
-    /// <summary>
-    /// Updates the optimizer's options with new settings.
-    /// </summary>
-    /// <remarks>
-    /// <para>
-    /// This method ensures that only compatible option types are used with this optimizer.
-    /// It updates the internal options if the provided options are of the correct type.
-    /// </para>
-    /// <para><b>For Beginners:</b>
-    /// This is like changing the rules for how you navigate the valley. It makes sure you're only using rules that work for
-    /// Newton's Method of exploring the valley.
-    /// </para>
-    /// </remarks>
-    /// <param name="options">The new options to be applied to the optimizer.</param>
-    /// <exception cref="ArgumentException">Thrown when the provided options are not of the correct type.</exception>
-    protected override void UpdateOptions(OptimizationAlgorithmOptions<T, TInput, TOutput> options)
-    {
-        if (options is NewtonMethodOptimizerOptions<T, TInput, TOutput> newtonOptions)
-        {
-            _options = newtonOptions;
-        }
-        else
-        {
-            throw new ArgumentException("Invalid options type. Expected NewtonMethodOptimizerOptions.");
-        }
-    }
 
     /// <summary>
     /// Gets the current options of the optimizer.

--- a/src/Optimizers/NormalOptimizer.cs
+++ b/src/Optimizers/NormalOptimizer.cs
@@ -27,7 +27,9 @@ public partial class NormalOptimizer<T, TInput, TOutput> : OptimizerBase<T, TInp
     /// <summary>
     /// Options specific to the normal optimizer, including parameters inherited from genetic algorithms.
     /// </summary>
-    private GeneticAlgorithmOptimizerOptions<T, TInput, TOutput> _normalOptions;
+    /// <summary>Read from the single instance OptimizerBase.Options holds, so there is
+    /// no second copy that could disagree with it.</summary>
+    private GeneticAlgorithmOptimizerOptions<T, TInput, TOutput> _normalOptions => (GeneticAlgorithmOptimizerOptions<T, TInput, TOutput>)Options;
     private int _configuredMinFeatures;
     // Effective upper bound for the adaptive feature-selection range. Equals the
     // user-configured MaximumFeatures when explicitly set; otherwise totalFeatures
@@ -59,7 +61,6 @@ public partial class NormalOptimizer<T, TInput, TOutput> : OptimizerBase<T, TInp
     public NormalOptimizer(IFullModel<T, TInput, TOutput> model, GeneticAlgorithmOptimizerOptions<T, TInput, TOutput>? options = null)
         : base(model, options ?? new())
     {
-        _normalOptions = options ?? new();
 
         InitializeAdaptiveParameters();
     }
@@ -406,30 +407,4 @@ public partial class NormalOptimizer<T, TInput, TOutput> : OptimizerBase<T, TInp
         return _normalOptions;
     }
 
-    /// <summary>
-    /// Updates the optimization algorithm options.
-    /// </summary>
-    /// <remarks>
-    /// <para>
-    /// This method updates the optimizer's options with a new set of options. It checks if the provided options
-    /// are of the correct type before applying them.
-    /// </para>
-    /// <para><b>For Beginners:</b>
-    /// This is like updating your hiking plan with new information or equipment. You're making sure the new plan
-    /// is compatible with your current approach before adopting it.
-    /// </para>
-    /// </remarks>
-    /// <param name="options">The new optimization algorithm options to apply.</param>
-    /// <exception cref="ArgumentException">Thrown when the provided options are not of the expected type.</exception>
-    protected override void UpdateOptions(OptimizationAlgorithmOptions<T, TInput, TOutput> options)
-    {
-        if (options is GeneticAlgorithmOptimizerOptions<T, TInput, TOutput> geneticOptions)
-        {
-            _normalOptions = geneticOptions;
-        }
-        else
-        {
-            throw new ArgumentException("Invalid options type. Expected NormalOptimizerOptions.");
-        }
-    }
 }

--- a/src/Optimizers/OptimizerBase.cs
+++ b/src/Optimizers/OptimizerBase.cs
@@ -96,12 +96,12 @@ public abstract class OptimizerBase<T, TInput, TOutput> : IOptimizer<T, TInput, 
     /// the same contract for the model-based path, which draws from here for feature selection and
     /// solution initialisation.
     /// </remarks>
-    protected readonly Random Random;
+    protected Random Random;
 
     /// <summary>
     /// Contains the configuration options for the optimization algorithm.
     /// </summary>
-    protected readonly OptimizationAlgorithmOptions<T, TInput, TOutput> Options;
+    protected OptimizationAlgorithmOptions<T, TInput, TOutput> Options;
 
     /// <summary>
     /// Options for prediction statistics calculations.
@@ -292,9 +292,7 @@ public abstract class OptimizerBase<T, TInput, TOutput> : IOptimizer<T, TInput, 
         // line above the Options assignment, which could not have honoured a seed even if it had
         // tried to - and left every model-based Optimize(inputData) run unrepeatable, since
         // RandomlySelectFeatures and InitializeRandomSolution both draw from here.
-        Random = Options.Seed.HasValue
-            ? AiDotNet.Tensors.Helpers.RandomHelper.CreateSeededRandom(Options.Seed.Value)
-            : AiDotNet.Tensors.Helpers.RandomHelper.CreateSecureRandom();
+        Random = CreateOptionsRandom(Options);
         PredictionOptions = Options.PredictionOptions;
         ModelStatsOptions = Options.ModelStatsOptions;
         FitDetector = Options.FitDetector;
@@ -304,6 +302,42 @@ public abstract class OptimizerBase<T, TInput, TOutput> : IOptimizer<T, TInput, 
         ModelCache = Options.ModelCache;
         CurrentLearningRate = NumOps.Zero;
         CurrentMomentum = NumOps.Zero;
+    }
+
+
+    /// <summary>
+    /// The shared generator for a given set of options.
+    /// </summary>
+    /// <param name="options">The options whose <c>Seed</c> decides reproducibility.</param>
+    /// <returns>A seeded generator when a seed was given, a cryptographically secure one otherwise.</returns>
+    private static Random CreateOptionsRandom(OptimizationAlgorithmOptions<T, TInput, TOutput> options)
+        => options.Seed.HasValue
+            ? AiDotNet.Tensors.Helpers.RandomHelper.CreateSeededRandom(options.Seed.Value)
+            : AiDotNet.Tensors.Helpers.RandomHelper.CreateSecureRandom();
+
+    /// <summary>
+    /// Adopts a restored set of options, so the base agrees with what the caller deserialized.
+    /// </summary>
+    /// <param name="options">The options read back from the stream.</param>
+    /// <remarks>
+    /// <para>
+    /// <see cref="Deserialize"/> already hands restored options to <see cref="UpdateOptions"/> so a
+    /// derived optimizer can react, but the base kept its constructor values. That was invisible
+    /// while the shared generator ignored <c>Seed</c> entirely; once it honours the seed, a restored
+    /// optimizer would otherwise draw velocities from the restored seed and select features from the
+    /// original one - two different runs claiming to be the same.
+    /// </para>
+    /// <para>
+    /// Deliberately narrow: the option-derived collaborators cached at construction
+    /// (<see cref="FitDetector"/>, <see cref="FitnessCalculator"/> and the statistics options) are
+    /// left alone. Replacing live collaborators mid-lifetime is a separate concern from
+    /// reproducibility, and nothing here needs it.
+    /// </para>
+    /// </remarks>
+    private void AdoptRestoredOptions(OptimizationAlgorithmOptions<T, TInput, TOutput> options)
+    {
+        Options = options;
+        Random = CreateOptionsRandom(options);
     }
 
     /// <summary>
@@ -2071,9 +2105,11 @@ public abstract class OptimizerBase<T, TInput, TOutput> : IOptimizer<T, TInput, 
         object? deserializedOptions = JsonConvert.DeserializeObject(optionsJson, optionsType);
         var options = deserializedOptions as OptimizationAlgorithmOptions<T, TInput, TOutput>;
 
-        // Update the options
+        // Update the options. The base adopts them first so that its own state - the shared
+        // generator above all - matches what was restored, then the derived class reacts.
         if (options != null)
         {
+            AdoptRestoredOptions(options);
             UpdateOptions(options);
         }
 

--- a/src/Optimizers/OptimizerBase.cs
+++ b/src/Optimizers/OptimizerBase.cs
@@ -89,6 +89,13 @@ public abstract class OptimizerBase<T, TInput, TOutput> : IOptimizer<T, TInput, 
     /// <summary>
     /// Provides random number generation for all derived classes.
     /// </summary>
+    /// <remarks>
+    /// Seeded from <see cref="OptimizationAlgorithmOptions{T, TInput, TOutput}.Seed"/> when the
+    /// caller supplies one, and cryptographically secure otherwise. The function-minimisation
+    /// overloads have always honoured that seed through <see cref="CreateSearchRandom"/>; this is
+    /// the same contract for the model-based path, which draws from here for feature selection and
+    /// solution initialisation.
+    /// </remarks>
     protected readonly Random Random;
 
     /// <summary>
@@ -277,9 +284,17 @@ public abstract class OptimizerBase<T, TInput, TOutput> : IOptimizer<T, TInput, 
         OptimizationAlgorithmOptions<T, TInput, TOutput> options)
     {
         _model = model;
-        Random = new();
         NumOps = MathHelper.GetNumericOperations<T>();
         Options = options ?? new OptimizationAlgorithmOptions<T, TInput, TOutput>();
+
+        // Ordered deliberately: Options has to be assigned before the generator is built, because
+        // the generator is derived from Options.Seed. This previously read `Random = new()` on the
+        // line above the Options assignment, which could not have honoured a seed even if it had
+        // tried to - and left every model-based Optimize(inputData) run unrepeatable, since
+        // RandomlySelectFeatures and InitializeRandomSolution both draw from here.
+        Random = Options.Seed.HasValue
+            ? AiDotNet.Tensors.Helpers.RandomHelper.CreateSeededRandom(Options.Seed.Value)
+            : AiDotNet.Tensors.Helpers.RandomHelper.CreateSecureRandom();
         PredictionOptions = Options.PredictionOptions;
         ModelStatsOptions = Options.ModelStatsOptions;
         FitDetector = Options.FitDetector;
@@ -2452,7 +2467,10 @@ public abstract class OptimizerBase<T, TInput, TOutput> : IOptimizer<T, TInput, 
             {
                 var current = nnCloneParameterizable.GetParameters();
                 var perturbed = new Vector<T>(current.Length);
-                var rng = AiDotNet.Tensors.Helpers.RandomHelper.CreateSecureRandom();
+                // The shared generator, so a seeded run perturbs identically. A fresh secure
+                // generator here would reintroduce the nondeterminism Options.Seed exists to
+                // remove, and this perturbation seeds every candidate the search starts from.
+                var rng = Random;
                 for (int i = 0; i < current.Length; i++)
                 {
                     // Gaussian noise ~ N(0, σ²) where σ = max(|current[i]|, ε) * 0.1.

--- a/src/Optimizers/OptimizerBase.cs
+++ b/src/Optimizers/OptimizerBase.cs
@@ -106,22 +106,22 @@ public abstract class OptimizerBase<T, TInput, TOutput> : IOptimizer<T, TInput, 
     /// <summary>
     /// Options for prediction statistics calculations.
     /// </summary>
-    protected readonly PredictionStatsOptions PredictionOptions;
+    protected PredictionStatsOptions PredictionOptions;
 
     /// <summary>
     /// Options for model statistics calculations.
     /// </summary>
-    protected readonly ModelStatsOptions ModelStatsOptions;
+    protected ModelStatsOptions ModelStatsOptions;
 
     /// <summary>
     /// Detects the quality of fit for models.
     /// </summary>
-    protected readonly IFitDetector<T, TInput, TOutput> FitDetector;
+    protected IFitDetector<T, TInput, TOutput> FitDetector;
 
     /// <summary>
     /// Calculates the fitness score of models.
     /// </summary>
-    protected readonly IFitnessCalculator<T, TInput, TOutput> FitnessCalculator;
+    protected IFitnessCalculator<T, TInput, TOutput> FitnessCalculator;
 
     /// <summary>
     /// Stores the fitness scores of evaluated models.
@@ -285,59 +285,48 @@ public abstract class OptimizerBase<T, TInput, TOutput> : IOptimizer<T, TInput, 
     {
         _model = model;
         NumOps = MathHelper.GetNumericOperations<T>();
-        Options = options ?? new OptimizationAlgorithmOptions<T, TInput, TOutput>();
-
-        // Ordered deliberately: Options has to be assigned before the generator is built, because
-        // the generator is derived from Options.Seed. This previously read `Random = new()` on the
-        // line above the Options assignment, which could not have honoured a seed even if it had
-        // tried to - and left every model-based Optimize(inputData) run unrepeatable, since
-        // RandomlySelectFeatures and InitializeRandomSolution both draw from here.
-        Random = CreateOptionsRandom(Options);
-        PredictionOptions = Options.PredictionOptions;
-        ModelStatsOptions = Options.ModelStatsOptions;
-        FitDetector = Options.FitDetector;
-        FitnessCalculator = Options.FitnessCalculator;
+        ApplyOptions(options ?? new OptimizationAlgorithmOptions<T, TInput, TOutput>());
         FitnessList = new List<T>();
         IterationHistoryList = new List<OptimizationIterationInfo<T>>();
-        ModelCache = Options.ModelCache;
         CurrentLearningRate = NumOps.Zero;
         CurrentMomentum = NumOps.Zero;
     }
 
 
     /// <summary>
-    /// The shared generator for a given set of options.
+    /// Adopts an option set: every piece of base state that is derived from options, in one place.
     /// </summary>
-    /// <param name="options">The options whose <c>Seed</c> decides reproducibility.</param>
-    /// <returns>A seeded generator when a seed was given, a cryptographically secure one otherwise.</returns>
-    private static Random CreateOptionsRandom(OptimizationAlgorithmOptions<T, TInput, TOutput> options)
-        => options.Seed.HasValue
-            ? AiDotNet.Tensors.Helpers.RandomHelper.CreateSeededRandom(options.Seed.Value)
-            : AiDotNet.Tensors.Helpers.RandomHelper.CreateSecureRandom();
-
-    /// <summary>
-    /// Adopts a restored set of options, so the base agrees with what the caller deserialized.
-    /// </summary>
-    /// <param name="options">The options read back from the stream.</param>
+    /// <param name="options">The options to take effect.</param>
     /// <remarks>
     /// <para>
-    /// <see cref="Deserialize"/> already hands restored options to <see cref="UpdateOptions"/> so a
-    /// derived optimizer can react, but the base kept its constructor values. That was invisible
-    /// while the shared generator ignored <c>Seed</c> entirely; once it honours the seed, a restored
-    /// optimizer would otherwise draw velocities from the restored seed and select features from the
-    /// original one - two different runs claiming to be the same.
+    /// The constructor and <see cref="Deserialize"/> both route through here so the two cannot drift.
+    /// Adopting only part of an option set is worse than adopting none of it: an optimizer built with
+    /// configuration A and restored from configuration B would evaluate with B's settings and A's
+    /// evaluator, which is a state neither configuration describes. Any future option-derived field
+    /// belongs in this method rather than in the constructor, and then it is restored for free.
     /// </para>
     /// <para>
-    /// Deliberately narrow: the option-derived collaborators cached at construction
-    /// (<see cref="FitDetector"/>, <see cref="FitnessCalculator"/> and the statistics options) are
-    /// left alone. Replacing live collaborators mid-lifetime is a separate concern from
-    /// reproducibility, and nothing here needs it.
+    /// The generator is included because it is derived from <c>Options.Seed</c>. Before this it read
+    /// <c>Random = new()</c> on the line ABOVE the <c>Options</c> assignment, so it could not have
+    /// honoured a seed even in principle - which left every model-based <c>Optimize(inputData)</c>
+    /// run unrepeatable, since <c>RandomlySelectFeatures</c> and <c>InitializeRandomSolution</c>
+    /// both draw from here.
     /// </para>
     /// </remarks>
-    private void AdoptRestoredOptions(OptimizationAlgorithmOptions<T, TInput, TOutput> options)
+    [System.Diagnostics.CodeAnalysis.MemberNotNull(
+        nameof(Options), nameof(Random), nameof(PredictionOptions), nameof(ModelStatsOptions),
+        nameof(FitDetector), nameof(FitnessCalculator), nameof(ModelCache))]
+    private void ApplyOptions(OptimizationAlgorithmOptions<T, TInput, TOutput> options)
     {
         Options = options;
-        Random = CreateOptionsRandom(options);
+        Random = options.Seed.HasValue
+            ? AiDotNet.Tensors.Helpers.RandomHelper.CreateSeededRandom(options.Seed.Value)
+            : AiDotNet.Tensors.Helpers.RandomHelper.CreateSecureRandom();
+        PredictionOptions = options.PredictionOptions;
+        ModelStatsOptions = options.ModelStatsOptions;
+        FitDetector = options.FitDetector;
+        FitnessCalculator = options.FitnessCalculator;
+        ModelCache = options.ModelCache;
     }
 
     /// <summary>
@@ -2105,11 +2094,25 @@ public abstract class OptimizerBase<T, TInput, TOutput> : IOptimizer<T, TInput, 
         object? deserializedOptions = JsonConvert.DeserializeObject(optionsJson, optionsType);
         var options = deserializedOptions as OptimizationAlgorithmOptions<T, TInput, TOutput>;
 
-        // Update the options. The base adopts them first so that its own state - the shared
-        // generator above all - matches what was restored, then the derived class reacts.
+        // Update the options. The base adopts them first so its own state - the shared generator
+        // above all - matches what was restored, then the derived class reacts.
         if (options != null)
         {
-            AdoptRestoredOptions(options);
+            // The interface-typed collaborators do NOT survive the options JSON round-trip: with no
+            // type information in the payload, Newtonsoft rebuilds each one as its property
+            // initializer's default. Measured - an optimizer configured with
+            // MeanSquaredErrorFitnessCalculator serializes and comes back holding
+            // RSquaredFitnessCalculator, the default. Adopting them wholesale would therefore
+            // replace a caller's configured evaluator, detector and cache with defaults on every
+            // deserialize, which is a worse outcome than the stale-but-correct ones already held.
+            // So the restored payload contributes its VALUES, and the live collaborators are
+            // carried across - which also keeps Options and the cached fields in agreement rather
+            // than adopting half an option set.
+            options.FitnessCalculator = FitnessCalculator;
+            options.FitDetector = FitDetector;
+            options.ModelCache = ModelCache;
+
+            ApplyOptions(options);
             UpdateOptions(options);
         }
 

--- a/src/Optimizers/OptimizerBase.cs
+++ b/src/Optimizers/OptimizerBase.cs
@@ -2217,7 +2217,29 @@ public abstract class OptimizerBase<T, TInput, TOutput> : IOptimizer<T, TInput, 
     /// or might have additional specialized options.
     /// </para>
     /// </remarks>
-    protected abstract void UpdateOptions(OptimizationAlgorithmOptions<T, TInput, TOutput> options);
+    /// <remarks>
+    /// <para>
+    /// Overriding this is now the EXCEPTION rather than the rule. It used to be abstract, so all 42
+    /// concrete optimizers implemented it, and 36 of those implementations were the same eight lines:
+    /// downcast the options, assign them to a private typed field, throw otherwise. That field was a
+    /// second copy of state the base already owns, and keeping two copies in step is the whole
+    /// reason the method existed.
+    /// </para>
+    /// <para>
+    /// Those optimizers now read their typed options through a computed property over
+    /// <see cref="Options"/>, so there is no second copy and nothing to synchronise - which also
+    /// closed a latent bug, since a constructor written as <c>base(model, options ?? new())</c>
+    /// alongside <c>_options = options ?? new()</c> built TWO different default instances whenever
+    /// the caller passed null.
+    /// </para>
+    /// <para>
+    /// Override it only to REACT to a new option set - rebuilding a regularizer, updating a kernel,
+    /// validating hyperparameters. Six optimizers do. Do not override it merely to hold a typed copy.
+    /// </para>
+    /// </remarks>
+    protected virtual void UpdateOptions(OptimizationAlgorithmOptions<T, TInput, TOutput> options)
+    {
+    }
 
     /// <summary>
     /// Performs a single optimization step, updating the model parameters based on gradients.

--- a/src/Optimizers/ParticleSwarmOptimizer.cs
+++ b/src/Optimizers/ParticleSwarmOptimizer.cs
@@ -40,7 +40,9 @@ public partial class ParticleSwarmOptimizer<T, TInput, TOutput> : OptimizerBase<
     /// <summary>
     /// Configuration options specific to Particle Swarm Optimization.
     /// </summary>
-    private ParticleSwarmOptimizationOptions<T, TInput, TOutput> _psoOptions;
+    /// <summary>Read from the single instance OptimizerBase.Options holds, so there is
+    /// no second copy that could disagree with it.</summary>
+    private ParticleSwarmOptimizationOptions<T, TInput, TOutput> _psoOptions => (ParticleSwarmOptimizationOptions<T, TInput, TOutput>)Options;
 
     /// <summary>
     /// The current inertia weight that controls a particle's tendency to continue its current trajectory.
@@ -67,7 +69,6 @@ public partial class ParticleSwarmOptimizer<T, TInput, TOutput> : OptimizerBase<
         ParticleSwarmOptimizationOptions<T, TInput, TOutput>? options = null)
         : base(model, options ?? new())
     {
-        _psoOptions = options ?? new ParticleSwarmOptimizationOptions<T, TInput, TOutput>();
 
         InitializeAdaptiveParameters();
     }
@@ -255,22 +256,6 @@ public partial class ParticleSwarmOptimizer<T, TInput, TOutput> : OptimizerBase<
             Math.Min(_psoOptions.MaxSocialWeight, _currentSocialWeight * _psoOptions.SocialWeightAdaptationRate));
     }
 
-    /// <summary>
-    /// Updates the optimizer's options with the provided options.
-    /// </summary>
-    /// <param name="options">The options to apply to this optimizer.</param>
-    /// <exception cref="ArgumentException">Thrown when the options are not of the expected type.</exception>
-    protected override void UpdateOptions(OptimizationAlgorithmOptions<T, TInput, TOutput> options)
-    {
-        if (options is ParticleSwarmOptimizationOptions<T, TInput, TOutput> psoOptions)
-        {
-            _psoOptions = psoOptions;
-        }
-        else
-        {
-            throw new ArgumentException("Invalid options type. Expected ParticleSwarmOptimizationOptions.");
-        }
-    }
 
     /// <summary>
     /// Gets the current options for this optimizer.
@@ -293,7 +278,6 @@ public partial class ParticleSwarmOptimizer<T, TInput, TOutput> : OptimizerBase<
     private ParticleSwarmOptimizer(ParticleSwarmOptimizationOptions<T, TInput, TOutput>? options)
         : base(null, options ?? new())
     {
-        _psoOptions = options ?? new ParticleSwarmOptimizationOptions<T, TInput, TOutput>();
 
         InitializeAdaptiveParameters();
     }

--- a/src/Optimizers/ParticleSwarmOptimizer.cs
+++ b/src/Optimizers/ParticleSwarmOptimizer.cs
@@ -36,17 +36,6 @@ namespace AiDotNet.Optimizers;
 [PipelineStage(PipelineStage.Training)]
 public partial class ParticleSwarmOptimizer<T, TInput, TOutput> : OptimizerBase<T, TInput, TOutput>, IDerivativeFreeFunctionOptimizer<T>
 {
-    /// <summary>
-    /// Random number generator for stochastic components of the algorithm.
-    /// </summary>
-    /// <remarks>
-    /// Derived from <see cref="OptimizationAlgorithmOptions{T, TInput, TOutput}.Seed"/> when the
-    /// caller supplies one, so a seeded swarm is reproducible on the model-based path as well as on
-    /// the function-minimisation one. It is not readonly because <see cref="UpdateOptions"/> can
-    /// replace the options, and a generator still drawing from the previous seed would contradict
-    /// them.
-    /// </remarks>
-    private Random _random;
 
     /// <summary>
     /// Configuration options specific to Particle Swarm Optimization.
@@ -69,22 +58,6 @@ public partial class ParticleSwarmOptimizer<T, TInput, TOutput> : OptimizerBase<
     private double _currentSocialWeight;
 
     /// <summary>
-    /// The generator this optimizer draws from, honouring a caller-supplied seed.
-    /// </summary>
-    /// <param name="options">The options whose <c>Seed</c> decides reproducibility.</param>
-    /// <returns>A seeded generator when a seed was given, a cryptographically secure one otherwise.</returns>
-    /// <remarks>
-    /// Every method in this family is stochastic, so a run is a random variable. One that cannot be
-    /// repeated cannot be debugged, and a benchmark from a single unrepeatable run says more about
-    /// its seed than about the method - which is the same reasoning behind
-    /// <c>OptimizerBase.CreateSearchRandom</c>, used by the function-minimisation overload.
-    /// </remarks>
-    private static Random CreateSwarmRandom(ParticleSwarmOptimizationOptions<T, TInput, TOutput> options)
-        => options.Seed.HasValue
-            ? RandomHelper.CreateSeededRandom(options.Seed.Value)
-            : RandomHelper.CreateSecureRandom();
-
-    /// <summary>
     /// Initializes a new instance of the ParticleSwarmOptimizer class with the specified options.
     /// </summary>
     /// <param name="model">The model to be optimized.</param>
@@ -95,7 +68,6 @@ public partial class ParticleSwarmOptimizer<T, TInput, TOutput> : OptimizerBase<
         : base(model, options ?? new())
     {
         _psoOptions = options ?? new ParticleSwarmOptimizationOptions<T, TInput, TOutput>();
-        _random = CreateSwarmRandom(_psoOptions);
 
         InitializeAdaptiveParameters();
     }
@@ -134,7 +106,7 @@ public partial class ParticleSwarmOptimizer<T, TInput, TOutput> : OptimizerBase<
             var velocity = new Vector<T>(dimensions);
             for (int j = 0; j < dimensions; j++)
             {
-                velocity[j] = NumOps.FromDouble(_random.NextDouble() * 0.1 - 0.05);
+                velocity[j] = NumOps.FromDouble(Random.NextDouble() * 0.1 - 0.05);
             }
             velocities.Add(velocity);
         }
@@ -251,8 +223,8 @@ public partial class ParticleSwarmOptimizer<T, TInput, TOutput> : OptimizerBase<
         var socialRandom = new Vector<T>(velocity.Length);
         for (int i = 0; i < velocity.Length; i++)
         {
-            cognitiveRandom[i] = NumOps.Multiply(cognitiveWeight, NumOps.FromDouble(_random.NextDouble()));
-            socialRandom[i] = NumOps.Multiply(socialWeight, NumOps.FromDouble(_random.NextDouble()));
+            cognitiveRandom[i] = NumOps.Multiply(cognitiveWeight, NumOps.FromDouble(Random.NextDouble()));
+            socialRandom[i] = NumOps.Multiply(socialWeight, NumOps.FromDouble(Random.NextDouble()));
         }
 
         // Vectorized computation: velocity = inertia*velocity + cognitive*personalDiff + social*globalDiff
@@ -293,10 +265,6 @@ public partial class ParticleSwarmOptimizer<T, TInput, TOutput> : OptimizerBase<
         if (options is ParticleSwarmOptimizationOptions<T, TInput, TOutput> psoOptions)
         {
             _psoOptions = psoOptions;
-
-            // The generator belongs to the options: leaving it on the previous seed would make the
-            // optimizer disagree with the configuration it reports.
-            _random = CreateSwarmRandom(_psoOptions);
         }
         else
         {
@@ -326,7 +294,6 @@ public partial class ParticleSwarmOptimizer<T, TInput, TOutput> : OptimizerBase<
         : base(null, options ?? new())
     {
         _psoOptions = options ?? new ParticleSwarmOptimizationOptions<T, TInput, TOutput>();
-        _random = CreateSwarmRandom(_psoOptions);
 
         InitializeAdaptiveParameters();
     }

--- a/src/Optimizers/ParticleSwarmOptimizer.cs
+++ b/src/Optimizers/ParticleSwarmOptimizer.cs
@@ -39,7 +39,14 @@ public partial class ParticleSwarmOptimizer<T, TInput, TOutput> : OptimizerBase<
     /// <summary>
     /// Random number generator for stochastic components of the algorithm.
     /// </summary>
-    private readonly Random _random;
+    /// <remarks>
+    /// Derived from <see cref="OptimizationAlgorithmOptions{T, TInput, TOutput}.Seed"/> when the
+    /// caller supplies one, so a seeded swarm is reproducible on the model-based path as well as on
+    /// the function-minimisation one. It is not readonly because <see cref="UpdateOptions"/> can
+    /// replace the options, and a generator still drawing from the previous seed would contradict
+    /// them.
+    /// </remarks>
+    private Random _random;
 
     /// <summary>
     /// Configuration options specific to Particle Swarm Optimization.
@@ -62,6 +69,22 @@ public partial class ParticleSwarmOptimizer<T, TInput, TOutput> : OptimizerBase<
     private double _currentSocialWeight;
 
     /// <summary>
+    /// The generator this optimizer draws from, honouring a caller-supplied seed.
+    /// </summary>
+    /// <param name="options">The options whose <c>Seed</c> decides reproducibility.</param>
+    /// <returns>A seeded generator when a seed was given, a cryptographically secure one otherwise.</returns>
+    /// <remarks>
+    /// Every method in this family is stochastic, so a run is a random variable. One that cannot be
+    /// repeated cannot be debugged, and a benchmark from a single unrepeatable run says more about
+    /// its seed than about the method - which is the same reasoning behind
+    /// <c>OptimizerBase.CreateSearchRandom</c>, used by the function-minimisation overload.
+    /// </remarks>
+    private static Random CreateSwarmRandom(ParticleSwarmOptimizationOptions<T, TInput, TOutput> options)
+        => options.Seed.HasValue
+            ? RandomHelper.CreateSeededRandom(options.Seed.Value)
+            : RandomHelper.CreateSecureRandom();
+
+    /// <summary>
     /// Initializes a new instance of the ParticleSwarmOptimizer class with the specified options.
     /// </summary>
     /// <param name="model">The model to be optimized.</param>
@@ -71,8 +94,8 @@ public partial class ParticleSwarmOptimizer<T, TInput, TOutput> : OptimizerBase<
         ParticleSwarmOptimizationOptions<T, TInput, TOutput>? options = null)
         : base(model, options ?? new())
     {
-        _random = RandomHelper.CreateSecureRandom();
         _psoOptions = options ?? new ParticleSwarmOptimizationOptions<T, TInput, TOutput>();
+        _random = CreateSwarmRandom(_psoOptions);
 
         InitializeAdaptiveParameters();
     }
@@ -270,6 +293,10 @@ public partial class ParticleSwarmOptimizer<T, TInput, TOutput> : OptimizerBase<
         if (options is ParticleSwarmOptimizationOptions<T, TInput, TOutput> psoOptions)
         {
             _psoOptions = psoOptions;
+
+            // The generator belongs to the options: leaving it on the previous seed would make the
+            // optimizer disagree with the configuration it reports.
+            _random = CreateSwarmRandom(_psoOptions);
         }
         else
         {
@@ -298,8 +325,8 @@ public partial class ParticleSwarmOptimizer<T, TInput, TOutput> : OptimizerBase<
     private ParticleSwarmOptimizer(ParticleSwarmOptimizationOptions<T, TInput, TOutput>? options)
         : base(null, options ?? new())
     {
-        _random = RandomHelper.CreateSecureRandom();
         _psoOptions = options ?? new ParticleSwarmOptimizationOptions<T, TInput, TOutput>();
+        _random = CreateSwarmRandom(_psoOptions);
 
         InitializeAdaptiveParameters();
     }

--- a/src/Optimizers/PowellOptimizer.cs
+++ b/src/Optimizers/PowellOptimizer.cs
@@ -52,7 +52,9 @@ public partial class PowellOptimizer<T, TInput, TOutput> : OptimizerBase<T, TInp
     /// Adjusting these settings can help the algorithm work better for different types of problems.
     /// </para>
     /// </remarks>
-    private PowellOptimizerOptions<T, TInput, TOutput> _options;
+    /// <summary>Read from the single instance OptimizerBase.Options holds, so there is
+    /// no second copy that could disagree with it.</summary>
+    private PowellOptimizerOptions<T, TInput, TOutput> _options => (PowellOptimizerOptions<T, TInput, TOutput>)Options;
 
     /// <summary>
     /// The current iteration count of the optimization process.
@@ -123,7 +125,6 @@ public partial class PowellOptimizer<T, TInput, TOutput> : OptimizerBase<T, TInp
         IEngine? engine = null)
         : base(model, options ?? new())
     {
-        _options = options ?? new PowellOptimizerOptions<T, TInput, TOutput>();
         _adaptiveStepSize = NumOps.Zero;
 
         InitializeAdaptiveParameters();
@@ -457,39 +458,6 @@ public partial class PowellOptimizer<T, TInput, TOutput> : OptimizerBase<T, TInp
         }
     }
 
-    /// <summary>
-    /// Updates the optimizer's options with the provided options.
-    /// </summary>
-    /// <param name="options">The options to apply to this optimizer.</param>
-    /// <exception cref="ArgumentException">Thrown when the options are not of the expected type.</exception>
-    /// <remarks>
-    /// <para>
-    /// This method overrides the base implementation to update the Powell-specific options.
-    /// It checks that the provided options are of the correct type (PowellOptimizerOptions)
-    /// and throws an exception if they are not.
-    /// </para>
-    /// <para><b>For Beginners:</b> This method updates the settings that control how the optimizer works.
-    /// 
-    /// It's like changing the rules of the game:
-    /// - You provide a set of options to use
-    /// - The method checks that these are the right kind of options for a Powell optimizer
-    /// - If they are, it applies these new settings
-    /// - If not, it lets you know there's a problem
-    /// 
-    /// This ensures that only appropriate settings are used with this specific optimizer.
-    /// </para>
-    /// </remarks>
-    protected override void UpdateOptions(OptimizationAlgorithmOptions<T, TInput, TOutput> options)
-    {
-        if (options is PowellOptimizerOptions<T, TInput, TOutput> powellOptions)
-        {
-            _options = powellOptions;
-        }
-        else
-        {
-            throw new ArgumentException("Invalid options type. Expected PowellOptimizerOptions.");
-        }
-    }
 
     /// <summary>
     /// Gets the current options for this optimizer.
@@ -527,7 +495,6 @@ public partial class PowellOptimizer<T, TInput, TOutput> : OptimizerBase<T, TInp
     private PowellOptimizer(PowellOptimizerOptions<T, TInput, TOutput>? options)
         : base(null, options ?? new())
     {
-        _options = options ?? new PowellOptimizerOptions<T, TInput, TOutput>();
         _adaptiveStepSize = NumOps.Zero;
 
         InitializeAdaptiveParameters();

--- a/src/Optimizers/RAdamOptimizer.cs
+++ b/src/Optimizers/RAdamOptimizer.cs
@@ -60,7 +60,9 @@ public partial class RAdamOptimizer<T, TInput, TOutput> : GradientBasedOptimizer
     /// <summary>
     /// The options specific to the RAdam optimizer.
     /// </summary>
-    private RAdamOptimizerOptions<T, TInput, TOutput> _options;
+    /// <summary>Read from the single instance OptimizerBase.Options holds, so there is
+    /// no second copy that could disagree with it.</summary>
+    private RAdamOptimizerOptions<T, TInput, TOutput> _options => (RAdamOptimizerOptions<T, TInput, TOutput>)Options;
 
     /// <summary>
     /// The first moment vector (exponential moving average of gradients).
@@ -93,7 +95,6 @@ public partial class RAdamOptimizer<T, TInput, TOutput> : GradientBasedOptimizer
         RAdamOptimizerOptions<T, TInput, TOutput>? options = null)
         : base(model, options ?? new())
     {
-        _options = options ?? new RAdamOptimizerOptions<T, TInput, TOutput>();
 
         InitializeAdaptiveParameters();
     }
@@ -494,22 +495,6 @@ public partial class RAdamOptimizer<T, TInput, TOutput> : GradientBasedOptimizer
         }
     }
 
-    /// <summary>
-    /// Updates the optimizer's options with new settings.
-    /// </summary>
-    /// <param name="options">The new options to be applied to the optimizer.</param>
-    /// <exception cref="ArgumentException">Thrown when the provided options are not of the correct type.</exception>
-    protected override void UpdateOptions(OptimizationAlgorithmOptions<T, TInput, TOutput> options)
-    {
-        if (options is RAdamOptimizerOptions<T, TInput, TOutput> radamOptions)
-        {
-            _options = radamOptions;
-        }
-        else
-        {
-            throw new ArgumentException("Invalid options type. Expected RAdamOptimizerOptions.");
-        }
-    }
 
     /// <summary>
     /// Retrieves the current options of the optimizer.

--- a/src/Optimizers/RootMeanSquarePropagationOptimizer.cs
+++ b/src/Optimizers/RootMeanSquarePropagationOptimizer.cs
@@ -127,7 +127,10 @@ public partial class RootMeanSquarePropagationOptimizer<T, TInput, TOutput> : Gr
     /// Adjusting these settings can help the algorithm work better for different types of problems.
     /// </para>
     /// </remarks>
-    private RootMeanSquarePropagationOptimizerOptions<T, TInput, TOutput> _options;
+    /// <summary>Read from the single instance OptimizerBase.Options holds, so there is
+    /// no second copy that could disagree with it.</summary>
+    private RootMeanSquarePropagationOptimizerOptions<T, TInput, TOutput> _options
+        => (RootMeanSquarePropagationOptimizerOptions<T, TInput, TOutput>)Options;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="RootMeanSquarePropagationOptimizer{T}"/> class with the specified options and components.
@@ -159,7 +162,6 @@ public partial class RootMeanSquarePropagationOptimizer<T, TInput, TOutput> : Gr
     {
         _t = 0;
         _squaredGradient = Vector<T>.Empty();
-        _options = options ?? new();
     }
 
     /// <summary>
@@ -190,7 +192,6 @@ public partial class RootMeanSquarePropagationOptimizer<T, TInput, TOutput> : Gr
     {
         _t = 0;
         _squaredGradient = Vector<T>.Empty();
-        _options = options ?? new();
     }
 
     /// <summary>

--- a/src/Optimizers/SimulatedAnnealingOptimizer.cs
+++ b/src/Optimizers/SimulatedAnnealingOptimizer.cs
@@ -51,7 +51,9 @@ public partial class SimulatedAnnealingOptimizer<T, TInput, TOutput> : Optimizer
     /// Adjusting these settings can help the algorithm work better for different types of problems.
     /// </para>
     /// </remarks>
-    private SimulatedAnnealingOptions<T, TInput, TOutput> _saOptions;
+    /// <summary>Read from the single instance OptimizerBase.Options holds, so there is
+    /// no second copy that could disagree with it.</summary>
+    private SimulatedAnnealingOptions<T, TInput, TOutput> _saOptions => (SimulatedAnnealingOptions<T, TInput, TOutput>)Options;
 
     /// <summary>
     /// The current temperature controlling the acceptance probability of worse solutions.
@@ -104,7 +106,6 @@ public partial class SimulatedAnnealingOptimizer<T, TInput, TOutput> : Optimizer
         IEngine? engine = null)
         : base(model, options ?? new())
     {
-        _saOptions = options ?? new SimulatedAnnealingOptions<T, TInput, TOutput>();
         _currentTemperature = NumOps.FromDouble(_saOptions.InitialTemperature);
     }
 
@@ -346,39 +347,6 @@ public partial class SimulatedAnnealingOptimizer<T, TInput, TOutput> : Optimizer
         return Random.NextDouble() < acceptanceProbability;
     }
 
-    /// <summary>
-    /// Updates the optimizer's options with the provided options.
-    /// </summary>
-    /// <param name="options">The options to apply to this optimizer.</param>
-    /// <exception cref="ArgumentException">Thrown when the options are not of the expected type.</exception>
-    /// <remarks>
-    /// <para>
-    /// This method overrides the base implementation to update the Simulated Annealing-specific options.
-    /// It checks that the provided options are of the correct type (SimulatedAnnealingOptions)
-    /// and throws an exception if they are not.
-    /// </para>
-    /// <para><b>For Beginners:</b> This method updates the settings that control how the optimizer works.
-    /// 
-    /// It's like changing the rule book:
-    /// - You provide a set of options to use
-    /// - The method checks that these are the right kind of options for a Simulated Annealing optimizer
-    /// - If they are, it applies these new settings
-    /// - If not, it lets you know there's a problem
-    /// 
-    /// This ensures that only appropriate settings are used with this specific optimizer.
-    /// </para>
-    /// </remarks>
-    protected override void UpdateOptions(OptimizationAlgorithmOptions<T, TInput, TOutput> options)
-    {
-        if (options is SimulatedAnnealingOptions<T, TInput, TOutput> saOptions)
-        {
-            _saOptions = saOptions;
-        }
-        else
-        {
-            throw new ArgumentException("Invalid options type. Expected SimulatedAnnealingOptions.");
-        }
-    }
 
     /// <summary>
     /// Gets the current options for this optimizer.
@@ -478,7 +446,6 @@ public partial class SimulatedAnnealingOptimizer<T, TInput, TOutput> : Optimizer
     private SimulatedAnnealingOptimizer(SimulatedAnnealingOptions<T, TInput, TOutput>? options)
         : base(null, options ?? new())
     {
-        _saOptions = options ?? new SimulatedAnnealingOptions<T, TInput, TOutput>();
         _currentTemperature = NumOps.FromDouble(_saOptions.InitialTemperature);
     }
 

--- a/src/Optimizers/SimulatedAnnealingOptimizer.cs
+++ b/src/Optimizers/SimulatedAnnealingOptimizer.cs
@@ -30,26 +30,6 @@ using Newtonsoft.Json;
 [PipelineStage(PipelineStage.Training)]
 public partial class SimulatedAnnealingOptimizer<T, TInput, TOutput> : OptimizerBase<T, TInput, TOutput>, IDerivativeFreeFunctionOptimizer<T>
 {
-    /// <summary>
-    /// Random number generator for stochastic decision-making.
-    /// </summary>
-    /// <remarks>
-    /// <para>
-    /// This field provides a source of randomness for the Simulated Annealing algorithm. It is used
-    /// to generate random perturbations when creating neighbor solutions and to make probabilistic
-    /// decisions about accepting worse solutions.
-    /// </para>
-    /// <para><b>For Beginners:</b> This is like the hiker's dice that helps make unpredictable choices.
-    /// 
-    /// The random number generator:
-    /// - Creates random variations when generating new solutions to try
-    /// - Determines whether to accept a worse solution based on probability
-    /// - Adds the element of chance that is essential to the algorithm's effectiveness
-    /// 
-    /// This randomness is crucial for the algorithm to escape local optima and explore the solution space effectively.
-    /// </para>
-    /// </remarks>
-    private readonly Random _random;
 
     /// <summary>
     /// Configuration options specific to the Simulated Annealing algorithm.
@@ -124,7 +104,6 @@ public partial class SimulatedAnnealingOptimizer<T, TInput, TOutput> : Optimizer
         IEngine? engine = null)
         : base(model, options ?? new())
     {
-        _random = RandomHelper.CreateSecureRandom();
         _saOptions = options ?? new SimulatedAnnealingOptions<T, TInput, TOutput>();
         _currentTemperature = NumOps.FromDouble(_saOptions.InitialTemperature);
     }
@@ -364,7 +343,7 @@ public partial class SimulatedAnnealingOptimizer<T, TInput, TOutput> : Optimizer
             _currentTemperature
         )));
 
-        return _random.NextDouble() < acceptanceProbability;
+        return Random.NextDouble() < acceptanceProbability;
     }
 
     /// <summary>
@@ -478,7 +457,7 @@ public partial class SimulatedAnnealingOptimizer<T, TInput, TOutput> : Optimizer
         var perturbations = new Vector<T>(parameters.Length);
         for (int i = 0; i < parameters.Length; i++)
         {
-            perturbations[i] = NumOps.FromDouble((_random.NextDouble() * 2 - 1) * _saOptions.NeighborGenerationRange);
+            perturbations[i] = NumOps.FromDouble((Random.NextDouble() * 2 - 1) * _saOptions.NeighborGenerationRange);
         }
 
         // Add perturbations to parameters using vectorized Engine operation
@@ -499,7 +478,6 @@ public partial class SimulatedAnnealingOptimizer<T, TInput, TOutput> : Optimizer
     private SimulatedAnnealingOptimizer(SimulatedAnnealingOptions<T, TInput, TOutput>? options)
         : base(null, options ?? new())
     {
-        _random = RandomHelper.CreateSecureRandom();
         _saOptions = options ?? new SimulatedAnnealingOptions<T, TInput, TOutput>();
         _currentTemperature = NumOps.FromDouble(_saOptions.InitialTemperature);
     }

--- a/src/Optimizers/StochasticGradientDescentOptimizer.cs
+++ b/src/Optimizers/StochasticGradientDescentOptimizer.cs
@@ -32,7 +32,9 @@ namespace AiDotNet.Optimizers;
 [PipelineStage(PipelineStage.Training)]
 public partial class StochasticGradientDescentOptimizer<T, TInput, TOutput> : GradientBasedOptimizerBase<T, TInput, TOutput>, Fused.IFusedOptimizerSpec
 {
-    private StochasticGradientDescentOptimizerOptions<T, TInput, TOutput> _options;
+    /// <summary>Read from the single instance OptimizerBase.Options holds, so there is
+    /// no second copy that could disagree with it.</summary>
+    private StochasticGradientDescentOptimizerOptions<T, TInput, TOutput> _options => (StochasticGradientDescentOptimizerOptions<T, TInput, TOutput>)Options;
 
     /// <summary>
     /// Initializes a new instance of the StochasticGradientDescentOptimizer class.
@@ -64,7 +66,6 @@ public partial class StochasticGradientDescentOptimizer<T, TInput, TOutput> : Gr
         IEngine? engine = null)
         : base(model, options ?? new())
     {
-        _options = options ?? new();
     }
 
     /// <summary>
@@ -93,7 +94,6 @@ public partial class StochasticGradientDescentOptimizer<T, TInput, TOutput> : Gr
     private StochasticGradientDescentOptimizer(StochasticGradientDescentOptimizerOptions<T, TInput, TOutput>? options)
         : base(null, options ?? new())
     {
-        _options = options ?? new();
     }
 
     /// <inheritdoc/>
@@ -266,34 +266,6 @@ public partial class StochasticGradientDescentOptimizer<T, TInput, TOutput> : Gr
         return InterfaceGuard.Parameterizable(currentSolution).WithParameters(updatedCoefficients);
     }
 
-    /// <summary>
-    /// Updates the optimizer's options with the provided options.
-    /// </summary>
-    /// <param name="options">The options to apply to this optimizer.</param>
-    /// <exception cref="ArgumentException">Thrown when the options are not of the expected type.</exception>
-    /// <remarks>
-    /// <para>
-    /// This method ensures that only StochasticGradientDescentOptimizerOptions can be applied to this optimizer.
-    /// </para>
-    /// <para><b>For Beginners:</b> This is like giving the hiker new instructions mid-journey:
-    /// 
-    /// - You can only give instructions specific to this type of hike (SGD)
-    /// - If you try to give the wrong type of instructions, it will cause an error
-    /// 
-    /// This ensures that the optimizer always has the correct type of settings.
-    /// </para>
-    /// </remarks>
-    protected override void UpdateOptions(OptimizationAlgorithmOptions<T, TInput, TOutput> options)
-    {
-        if (options is StochasticGradientDescentOptimizerOptions<T, TInput, TOutput> sgdOptions)
-        {
-            _options = sgdOptions;
-        }
-        else
-        {
-            throw new ArgumentException("Invalid options type. Expected StochasticGradientDescentOptimizerOptions.");
-        }
-    }
 
     /// <summary>
     /// Gets the current options for this optimizer.

--- a/src/Optimizers/TabuSearchOptimizer.cs
+++ b/src/Optimizers/TabuSearchOptimizer.cs
@@ -32,7 +32,9 @@ public partial class TabuSearchOptimizer<T, TInput, TOutput> : OptimizerBase<T, 
     /// <summary>
     /// The options specific to the Tabu Search algorithm.
     /// </summary>
-    private TabuSearchOptions<T, TInput, TOutput> _tabuOptions;
+    /// <summary>Read from the single instance OptimizerBase.Options holds, so there is
+    /// no second copy that could disagree with it.</summary>
+    private TabuSearchOptions<T, TInput, TOutput> _tabuOptions => (TabuSearchOptions<T, TInput, TOutput>)Options;
 
     /// <summary>
     /// The current mutation rate used in generating neighboring solutions.
@@ -69,7 +71,6 @@ public partial class TabuSearchOptimizer<T, TInput, TOutput> : OptimizerBase<T, 
         IEngine? engine = null)
         : base(model, options ?? new())
     {
-        _tabuOptions = options ?? new TabuSearchOptions<T, TInput, TOutput>();
 
         // If no genetic algorithm is provided, create a default StandardGeneticAlgorithm
         if (geneticAlgorithm == null)
@@ -320,22 +321,6 @@ public partial class TabuSearchOptimizer<T, TInput, TOutput> : OptimizerBase<T, 
         tabuList.Add(solutionHash);
     }
 
-    /// <summary>
-    /// Updates the options for the Tabu Search algorithm.
-    /// </summary>
-    /// <param name="options">The new options to set.</param>
-    /// <exception cref="ArgumentException">Thrown when the provided options are not of type TabuSearchOptions.</exception>
-    protected override void UpdateOptions(OptimizationAlgorithmOptions<T, TInput, TOutput> options)
-    {
-        if (options is TabuSearchOptions<T, TInput, TOutput> tabuOptions)
-        {
-            _tabuOptions = tabuOptions;
-        }
-        else
-        {
-            throw new ArgumentException("Invalid options type. Expected TabuSearchOptions.");
-        }
-    }
 
     /// <summary>
     /// Gets the current options for the Tabu Search algorithm.
@@ -358,7 +343,6 @@ public partial class TabuSearchOptimizer<T, TInput, TOutput> : OptimizerBase<T, 
     private TabuSearchOptimizer(TabuSearchOptions<T, TInput, TOutput>? options)
         : base(null, options ?? new())
     {
-        _tabuOptions = options ?? new TabuSearchOptions<T, TInput, TOutput>();
 
         // With no model to clone, the genetic machinery the model-training path uses gets a
         // trivial factory. Minimize never touches it.

--- a/src/Optimizers/TrustRegionOptimizer.cs
+++ b/src/Optimizers/TrustRegionOptimizer.cs
@@ -84,7 +84,9 @@ public partial class TrustRegionOptimizer<T, TInput, TOutput> : GradientBasedOpt
     /// It includes parameters such as initial trust region radius, expansion and contraction factors,
     /// and thresholds for determining the success of each optimization step.
     /// </remarks>
-    private TrustRegionOptimizerOptions<T, TInput, TOutput> _options;
+    /// <summary>Read from the single instance OptimizerBase.Options holds, so there is
+    /// no second copy that could disagree with it.</summary>
+    private TrustRegionOptimizerOptions<T, TInput, TOutput> _options => (TrustRegionOptimizerOptions<T, TInput, TOutput>)Options;
 
     /// <summary>
     /// The current radius of the trust region.
@@ -128,7 +130,6 @@ public partial class TrustRegionOptimizer<T, TInput, TOutput> : GradientBasedOpt
         IEngine? engine = null)
         : base(model, options ?? new())
     {
-        _options = options ?? new TrustRegionOptimizerOptions<T, TInput, TOutput>();
         _trustRegionRadius = NumOps.Zero;
 
         InitializeAdaptiveParameters();
@@ -160,7 +161,6 @@ public partial class TrustRegionOptimizer<T, TInput, TOutput> : GradientBasedOpt
     private TrustRegionOptimizer(TrustRegionOptimizerOptions<T, TInput, TOutput>? options)
         : base(null, options ?? new())
     {
-        _options = options ?? new TrustRegionOptimizerOptions<T, TInput, TOutput>();
         _trustRegionRadius = NumOps.Zero;
 
         InitializeAdaptiveParameters();
@@ -707,32 +707,6 @@ public partial class TrustRegionOptimizer<T, TInput, TOutput> : GradientBasedOpt
         }
     }
 
-    /// <summary>
-    /// Updates the optimizer options.
-    /// </summary>
-    /// <param name="options">The new options to be set.</param>
-    /// <exception cref="ArgumentException">Thrown when the provided options are not of type TrustRegionOptimizerOptions.</exception>
-    /// <remarks>
-    /// This method allows updating the optimizer's configuration during runtime. It ensures that only
-    /// the correct type of options (TrustRegionOptimizerOptions) can be set for this optimizer.
-    /// 
-    /// <para><b>For Beginners:</b> This is like changing the settings on your GPS mid-journey:
-    /// - You can adjust how the optimizer behaves without starting over.
-    /// - It checks to make sure you're using the right kind of settings for this specific optimizer.
-    /// - If you try to use the wrong type of settings, it will let you know with an error.
-    /// </para>
-    /// </remarks>
-    protected override void UpdateOptions(OptimizationAlgorithmOptions<T, TInput, TOutput> options)
-    {
-        if (options is TrustRegionOptimizerOptions<T, TInput, TOutput> trustRegionOptions)
-        {
-            _options = trustRegionOptions;
-        }
-        else
-        {
-            throw new ArgumentException("Invalid options type. Expected TrustRegionOptimizerOptions.");
-        }
-    }
 
     /// <summary>
     /// Retrieves the current options of the optimizer.

--- a/tests/AiDotNet.Tests/IntegrationTests/Optimizers/MetaheuristicOptimizerIntegrationTests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/Optimizers/MetaheuristicOptimizerIntegrationTests.cs
@@ -1247,5 +1247,60 @@ public class MetaheuristicOptimizerIntegrationTests
     }
 
 
+
+    /// <summary>
+    /// Deserializing restores the adaptive state a run had reached, rather than re-seeding it from
+    /// the options.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This exists to refuse a plausible-looking change. The constructor seeds
+    /// <c>_currentInertia</c> and its siblings from <c>Initial*</c> on the options, and no
+    /// <c>UpdateOptions</c> override re-runs <c>InitializeAdaptiveParameters</c> - which reads like
+    /// a restored optimizer keeping the configuration it was BUILT with. It is not: the state layer
+    /// carries the live values, so a mid-run optimizer serialized at inertia 0.137 comes back at
+    /// 0.137, not at whatever its options call the initial value.
+    /// </para>
+    /// <para>
+    /// Calling <c>ResetAdaptiveParameters()</c> from <c>Deserialize</c> to "fix" the apparent
+    /// staleness therefore DESTROYS restored state, silently rewinding a resumed optimizer to the
+    /// start of its schedule. Measured: with that call added this test reads 0.42 instead of 0.137.
+    /// The distinction is invisible unless the live value is driven away from the initial one, which
+    /// is why this test sets it explicitly rather than trusting a short run to diverge.
+    /// </para>
+    /// </remarks>
+    [Fact(Timeout = 120000)]
+    public async Task Deserialize_RestoresLiveAdaptiveState_RatherThanReseedingFromOptions()
+    {
+        await Task.Yield();
+
+        const double LiveInertia = 0.137;
+        const double SourceInitial = 0.42;
+        const double DestinationInitial = 0.91;
+
+        static ParticleSwarmOptimizer<double, Matrix<double>, Vector<double>> Build(double initialInertia) =>
+            new(null, new ParticleSwarmOptimizationOptions<double, Matrix<double>, Vector<double>>
+            {
+                MaxIterations = 10,
+                SwarmSize = 8,
+                InitialInertia = initialInertia,
+            });
+
+        static FieldInfo Inertia() =>
+            typeof(ParticleSwarmOptimizer<double, Matrix<double>, Vector<double>>)
+                .GetField("_currentInertia", BindingFlags.Instance | BindingFlags.NonPublic)!;
+
+        var source = Build(SourceInitial);
+        Inertia().SetValue(source, LiveInertia);
+
+        var restored = Build(DestinationInitial);
+        Assert.Equal(DestinationInitial, (double)Inertia().GetValue(restored)!, 12);
+
+        restored.Deserialize(source.Serialize());
+
+        // The live value, not either side's Initial*.
+        Assert.Equal(LiveInertia, (double)Inertia().GetValue(restored)!, 12);
+    }
+
     #endregion
 }

--- a/tests/AiDotNet.Tests/IntegrationTests/Optimizers/MetaheuristicOptimizerIntegrationTests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/Optimizers/MetaheuristicOptimizerIntegrationTests.cs
@@ -6,6 +6,7 @@ using AiDotNet.Models.Results;
 using AiDotNet.Optimizers;
 using AiDotNet.Regression;
 using Xunit;
+using System.Reflection;
 using System.Threading.Tasks;
 
 namespace AiDotNet.Tests.IntegrationTests.Optimizers;
@@ -237,6 +238,91 @@ public class MetaheuristicOptimizerIntegrationTests
         var result = optimizer.Optimize(inputData);
 
         AssertValidOptimizationResult(result, "ParticleSwarm");
+    }
+
+    /// <summary>
+    /// Both generators a swarm draws from are seeded when the caller supplies a seed.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <c>Seed</c> lives on the shared options and the function-minimisation overload has always
+    /// honoured it through <c>CreateSearchRandom</c>. Two generators on the model-based path did
+    /// not. <c>OptimizerBase</c> ran <c>Random = new()</c> on the line ABOVE its <c>Options</c>
+    /// assignment, so it could not have read a seed even in principle, and
+    /// <c>ParticleSwarmOptimizer</c> built its own field with <c>CreateSecureRandom()</c>,
+    /// ignoring the seed outright. Feature selection, solution initialisation and every velocity
+    /// draw come from those two.
+    /// </para>
+    /// <para>
+    /// This asserts the generators, not a whole optimization run, because that is exactly what has
+    /// been fixed and no more. A same-seed <c>Optimize(inputData)</c> still does not reproduce - at
+    /// least one further source of nondeterminism remains on that path, and it is not parallel
+    /// reduction order, since neither type parallelises. Claiming reproducibility here would be
+    /// claiming more than is true.
+    /// </para>
+    /// </remarks>
+    [Fact(Timeout = 120000)]
+    public async Task ParticleSwarm_WithTheSameSeed_RepeatsItselfOnTheModelPath()
+    {
+        await Task.Yield();
+
+        var (X, y) = CreateSimpleRegressionData(30);
+        int numFeatures = X.Columns;
+
+        double RunWithSeed(int seed)
+        {
+            var optimizer = new ParticleSwarmOptimizer<double, Matrix<double>, Vector<double>>(
+                new MultipleRegression<double>(),
+                new ParticleSwarmOptimizationOptions<double, Matrix<double>, Vector<double>>
+                {
+                    MaxIterations = 20,
+                    SwarmSize = 20,
+                    MinimumFeatures = numFeatures,
+                    MaximumFeatures = numFeatures,
+                    Seed = seed,
+                });
+
+            return optimizer.Optimize(new OptimizationInputData<double, Matrix<double>, Vector<double>>
+            {
+                XTrain = X,
+                YTrain = y,
+                XValidation = X,
+                YValidation = y,
+                XTest = X,
+                YTest = y,
+            }).BestFitnessScore;
+        }
+
+        Assert.Equal(RunWithSeed(20250829), RunWithSeed(20250829));
+    }
+
+    [Fact(Timeout = 120000)]
+    public async Task ParticleSwarm_WithASeed_BuildsBothItsGeneratorsFromIt()
+    {
+        await Task.Yield();
+
+        static (int Shared, double Swarm) FirstDraws(int seed)
+        {
+            var optimizer = new ParticleSwarmOptimizer<double, Matrix<double>, Vector<double>>(
+                new MultipleRegression<double>(),
+                new ParticleSwarmOptimizationOptions<double, Matrix<double>, Vector<double>>
+                {
+                    SwarmSize = 8,
+                    Seed = seed,
+                });
+
+            var shared = (Random)typeof(OptimizerBase<double, Matrix<double>, Vector<double>>)
+                .GetField("Random", BindingFlags.Instance | BindingFlags.NonPublic)!
+                .GetValue(optimizer)!;
+            var swarm = (Random)typeof(ParticleSwarmOptimizer<double, Matrix<double>, Vector<double>>)
+                .GetField("_random", BindingFlags.Instance | BindingFlags.NonPublic)!
+                .GetValue(optimizer)!;
+
+            return (shared.Next(), swarm.NextDouble());
+        }
+
+        Assert.Equal(FirstDraws(20250829), FirstDraws(20250829));
+        Assert.NotEqual(FirstDraws(20250829), FirstDraws(19700101));
     }
 
     #endregion

--- a/tests/AiDotNet.Tests/IntegrationTests/Optimizers/MetaheuristicOptimizerIntegrationTests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/Optimizers/MetaheuristicOptimizerIntegrationTests.cs
@@ -1,6 +1,8 @@
 #nullable disable
 using AiDotNet.LinearAlgebra;
 using AiDotNet.Models.Inputs;
+using AiDotNet.FitnessCalculators;
+using AiDotNet.Interfaces;
 using AiDotNet.Models.Options;
 using AiDotNet.Models.Results;
 using AiDotNet.Optimizers;
@@ -362,6 +364,70 @@ public class MetaheuristicOptimizerIntegrationTests
         Assert.Equal(FirstDraw(Build(RestoredFrom)), FirstDraw(restored));
         Assert.NotEqual(FirstDraw(Build(BuiltWith)), FirstDraw(restored));
     }
+
+    /// <summary>
+    /// Deserializing leaves Options and every field derived from it in agreement.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Adopting some option-derived state and not the rest is worse than adopting none: an optimizer
+    /// built with configuration A and restored from B would evaluate with B's settings and A's
+    /// evaluator, a state neither configuration describes. Construction and restoration route
+    /// through one method so that cannot happen.
+    /// </para>
+    /// <para>
+    /// The collaborators are deliberately NOT taken from the payload. Interface-typed properties
+    /// carry no type information through the options JSON, so Newtonsoft rebuilds each as its
+    /// property initializer's default - an optimizer configured with MeanSquaredError comes back
+    /// holding RSquared. Adopting that would swap a caller's evaluator for a default on every
+    /// deserialize, so the live ones are carried across instead, and this pins that.
+    /// </para>
+    /// </remarks>
+    [Fact(Timeout = 120000)]
+    public async Task Deserialize_AdoptsEveryOptionDerivedCollaborator()
+    {
+        await Task.Yield();
+
+        static ParticleSwarmOptimizer<double, Matrix<double>, Vector<double>> Build(
+            int seed, int maxIterations, IFitnessCalculator<double, Matrix<double>, Vector<double>> calculator) =>
+            new(null, new ParticleSwarmOptimizationOptions<double, Matrix<double>, Vector<double>>
+            {
+                MaxIterations = maxIterations,
+                SwarmSize = 8,
+                Seed = seed,
+                FitnessCalculator = calculator,
+            });
+
+        var restored = Build(19700101, 99, new RSquaredFitnessCalculator<double, Matrix<double>, Vector<double>>());
+        restored.Deserialize(
+            Build(20250829, 7, new MeanSquaredErrorFitnessCalculator<double, Matrix<double>, Vector<double>>()).Serialize());
+
+        // The values travel.
+        Assert.Equal(7, restored.GetOptions().MaxIterations);
+        Assert.Equal(20250829, restored.GetOptions().Seed);
+
+        // The collaborators do not, so they are preserved rather than reset to the property
+        // defaults the payload decodes to. The optimizer was BUILT with RSquared, the payload was
+        // written by one using MeanSquaredError, and RSquared is what must survive - anything else
+        // means a deserialize silently swapped the caller's evaluator.
+        Assert.IsType<RSquaredFitnessCalculator<double, Matrix<double>, Vector<double>>>(
+            Field<IFitnessCalculator<double, Matrix<double>, Vector<double>>>(restored, "FitnessCalculator"));
+
+        // And whatever they hold, Options and the cached fields agree - which is the property that
+        // makes partial adoption impossible rather than merely unlikely.
+        Assert.Same(restored.GetOptions().FitnessCalculator, Field<object>(restored, "FitnessCalculator"));
+        Assert.Same(restored.GetOptions().FitDetector, Field<object>(restored, "FitDetector"));
+        Assert.Same(restored.GetOptions().PredictionOptions, Field<object>(restored, "PredictionOptions"));
+        Assert.Same(restored.GetOptions().ModelStatsOptions, Field<object>(restored, "ModelStatsOptions"));
+        Assert.Same(restored.GetOptions().ModelCache, Field<object>(restored, "ModelCache"));
+    }
+
+    /// <summary>Reads a protected base field, which is where the adopted state actually lands.</summary>
+    private static TField Field<TField>(
+        OptimizerBase<double, Matrix<double>, Vector<double>> optimizer, string name)
+        => (TField)typeof(OptimizerBase<double, Matrix<double>, Vector<double>>)
+            .GetField(name, BindingFlags.Instance | BindingFlags.NonPublic)!
+            .GetValue(optimizer)!;
 
     /// <summary>The first draw from the one generator an optimizer owns, which lives on the base.</summary>
     private static int FirstDraw(OptimizerBase<double, Matrix<double>, Vector<double>> optimizer)
@@ -1179,6 +1245,7 @@ public class MetaheuristicOptimizerIntegrationTests
         var result = optimizer.Optimize(inputData);
         AssertValidOptimizationResult(result, "Normal_SingleIteration");
     }
+
 
     #endregion
 }

--- a/tests/AiDotNet.Tests/IntegrationTests/Optimizers/MetaheuristicOptimizerIntegrationTests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/Optimizers/MetaheuristicOptimizerIntegrationTests.cs
@@ -241,25 +241,12 @@ public class MetaheuristicOptimizerIntegrationTests
     }
 
     /// <summary>
-    /// Both generators a swarm draws from are seeded when the caller supplies a seed.
+    /// The same seed gives the same optimization, which is the behaviour callers actually want.
     /// </summary>
     /// <remarks>
-    /// <para>
-    /// <c>Seed</c> lives on the shared options and the function-minimisation overload has always
-    /// honoured it through <c>CreateSearchRandom</c>. Two generators on the model-based path did
-    /// not. <c>OptimizerBase</c> ran <c>Random = new()</c> on the line ABOVE its <c>Options</c>
-    /// assignment, so it could not have read a seed even in principle, and
-    /// <c>ParticleSwarmOptimizer</c> built its own field with <c>CreateSecureRandom()</c>,
-    /// ignoring the seed outright. Feature selection, solution initialisation and every velocity
-    /// draw come from those two.
-    /// </para>
-    /// <para>
-    /// This asserts the generators, not a whole optimization run, because that is exactly what has
-    /// been fixed and no more. A same-seed <c>Optimize(inputData)</c> still does not reproduce - at
-    /// least one further source of nondeterminism remains on that path, and it is not parallel
-    /// reduction order, since neither type parallelises. Claiming reproducibility here would be
-    /// claiming more than is true.
-    /// </para>
+    /// The generator tests below localise a failure; this one states the contract. Equality rather
+    /// than a tolerance is deliberate - a seed either determines the run or it does not, and a
+    /// tolerance would let the defect back in unnoticed.
     /// </remarks>
     [Fact(Timeout = 120000)]
     public async Task ParticleSwarm_WithTheSameSeed_RepeatsItselfOnTheModelPath()
@@ -296,34 +283,91 @@ public class MetaheuristicOptimizerIntegrationTests
         Assert.Equal(RunWithSeed(20250829), RunWithSeed(20250829));
     }
 
+    /// <summary>
+    /// A seeded optimizer draws from a seeded generator, and a differently seeded one does not.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Asserted for two optimizers because the fix is a base-class contract, not a per-optimizer
+    /// patch. <c>OptimizerBase</c> owns the one generator every derived optimizer draws from, and it
+    /// is built from <c>Options.Seed</c>. Particle swarm and simulated annealing each used to carry
+    /// a private <c>Random</c> built with <c>CreateSecureRandom()</c>, which no seed could reach;
+    /// both now use the inherited one, so there is nothing left to forget to seed.
+    /// </para>
+    /// <para>
+    /// The second assertion pins the other half - different seeds must diverge - so that a
+    /// degenerate generator returning a constant would not satisfy the first.
+    /// </para>
+    /// </remarks>
     [Fact(Timeout = 120000)]
-    public async Task ParticleSwarm_WithASeed_BuildsBothItsGeneratorsFromIt()
+    public async Task SeededOptimizers_DrawFromTheSeedTheyWereGiven()
     {
         await Task.Yield();
 
-        static (int Shared, double Swarm) FirstDraws(int seed)
-        {
-            var optimizer = new ParticleSwarmOptimizer<double, Matrix<double>, Vector<double>>(
-                new MultipleRegression<double>(),
+        static int SwarmDraw(int seed) => FirstDraw(
+            new ParticleSwarmOptimizer<double, Matrix<double>, Vector<double>>(
+                null,
                 new ParticleSwarmOptimizationOptions<double, Matrix<double>, Vector<double>>
                 {
                     SwarmSize = 8,
                     Seed = seed,
-                });
+                }));
 
-            var shared = (Random)typeof(OptimizerBase<double, Matrix<double>, Vector<double>>)
-                .GetField("Random", BindingFlags.Instance | BindingFlags.NonPublic)!
-                .GetValue(optimizer)!;
-            var swarm = (Random)typeof(ParticleSwarmOptimizer<double, Matrix<double>, Vector<double>>)
-                .GetField("_random", BindingFlags.Instance | BindingFlags.NonPublic)!
-                .GetValue(optimizer)!;
+        static int AnnealingDraw(int seed) => FirstDraw(
+            new SimulatedAnnealingOptimizer<double, Matrix<double>, Vector<double>>(
+                null,
+                new SimulatedAnnealingOptions<double, Matrix<double>, Vector<double>>
+                {
+                    Seed = seed,
+                }));
 
-            return (shared.Next(), swarm.NextDouble());
-        }
+        Assert.Equal(SwarmDraw(20250829), SwarmDraw(20250829));
+        Assert.NotEqual(SwarmDraw(20250829), SwarmDraw(19700101));
 
-        Assert.Equal(FirstDraws(20250829), FirstDraws(20250829));
-        Assert.NotEqual(FirstDraws(20250829), FirstDraws(19700101));
+        Assert.Equal(AnnealingDraw(20250829), AnnealingDraw(20250829));
+        Assert.NotEqual(AnnealingDraw(20250829), AnnealingDraw(19700101));
     }
+
+    /// <summary>
+    /// A restored optimizer draws from the seed it was restored with, not the one it was built with.
+    /// </summary>
+    /// <remarks>
+    /// <c>Deserialize</c> hands the restored options to <c>UpdateOptions</c> so a derived optimizer
+    /// can react, but the base kept its constructor values. That was harmless while the shared
+    /// generator ignored <c>Seed</c> outright; once it honours the seed, a restored optimizer would
+    /// otherwise report one seed and draw from another. The base now adopts the restored options
+    /// before handing them on, which is why this holds for every optimizer rather than the one
+    /// tested here.
+    /// </remarks>
+    [Fact(Timeout = 120000)]
+    public async Task ParticleSwarm_AfterDeserialize_UsesTheRestoredSeed()
+    {
+        await Task.Yield();
+
+        const int BuiltWith = 19700101;
+        const int RestoredFrom = 20250829;
+
+        static ParticleSwarmOptimizer<double, Matrix<double>, Vector<double>> Build(int seed) =>
+            new(null, new ParticleSwarmOptimizationOptions<double, Matrix<double>, Vector<double>>
+            {
+                MaxIterations = 10,
+                SwarmSize = 8,
+                Seed = seed,
+            });
+
+        var restored = Build(BuiltWith);
+        restored.Deserialize(Build(RestoredFrom).Serialize());
+
+        Assert.Equal(RestoredFrom, restored.GetOptions().Seed);
+        Assert.Equal(FirstDraw(Build(RestoredFrom)), FirstDraw(restored));
+        Assert.NotEqual(FirstDraw(Build(BuiltWith)), FirstDraw(restored));
+    }
+
+    /// <summary>The first draw from the one generator an optimizer owns, which lives on the base.</summary>
+    private static int FirstDraw(OptimizerBase<double, Matrix<double>, Vector<double>> optimizer)
+        => ((Random)typeof(OptimizerBase<double, Matrix<double>, Vector<double>>)
+            .GetField("Random", BindingFlags.Instance | BindingFlags.NonPublic)!
+            .GetValue(optimizer)!).Next();
 
     #endregion
 


### PR DESCRIPTION
> **Stacked on #2055 and depends on it.** Base it there, not on master. #2055 makes the base adopt restored options in `Deserialize`; without that, a computed property would read the *constructor's* options after a restore rather than the restored ones.

## The problem

`UpdateOptions` was `abstract`, so all **42** concrete optimizers implemented it — and **36 were the same eight lines**:

```csharp
protected override void UpdateOptions(OptimizationAlgorithmOptions<T, TInput, TOutput> options)
{
    if (options is AdamOptimizerOptions<T, TInput, TOutput> adamOptions)
    {
        _options = adamOptions;
    }
    else
    {
        throw new ArgumentException("Invalid options type. Expected AdamOptimizerOptions.");
    }
}
```

That private field is a **second copy** of state the base already owns, and keeping two copies in step is the only reason the method existed. Every new optimizer inherited the obligation, and any change to how options are held meant 42 edits.

## The change

The 36 read their typed options through a computed property over the base's single instance:

```csharp
private AdamOptimizerOptions<T, TInput, TOutput> _options
    => (AdamOptimizerOptions<T, TInput, TOutput>)Options;
```

The override then has nothing to do and is deleted. `UpdateOptions` becomes `virtual` with a no-op default, to be overridden only to **react** to a new option set.

**Six still do, and keep both field and override:** ADMM and ProximalGradientDescent rebuild a regularizer, Bayesian updates a kernel, GradientBasedOptimizerBase caches a scheduler mode, Lion re-seeds adaptive parameters, Rprop validates hyperparameters.

## It closes a latent bug, not just noise

The constructors read:

```csharp
: base(model, options ?? new())
{
    _options = options ?? new AdamOptimizerOptions<T, TInput, TOutput>();
```

When the caller passes `null` those are **two different default instances** — the base holding one, the derived class the other, each blind to changes in the other. There is now one instance and no way to desynchronise them.

`Adam8BitOptimizer`'s hand-rolled `Deserialize` kept its own copy of the options JSON too. The read stays — the stream position depends on it and a malformed payload must still fail there — but the value is discarded, since `base.Deserialize` has already adopted the authoritative copy.

## Verification

- **1693 of 1693** optimizer tests pass.
- `src` builds clean on **net10.0, net8.0 and net471**.
- **42 → 6** overrides; net **-780** lines.

## Note on how this was produced

The mechanical conversion was scripted, but two passes had to be redone: a first regex over-reached into the six exception files and stripped constructor assignments they still need, and `RootMeanSquarePropagationOptimizer` is a `partial class` whose override lives in another file, so a per-file pass missed it. Both were caught by the compiler, not by inspection — worth knowing if this pattern is applied elsewhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U1HFtoj81avXvuLebTpWyk
