### PR TITLE
feat(ci): coverage-derived test selection to replace the unconditional 115-shard run

### DIFF
--- a/.github/scripts/check-shard-coverage.ps1
+++ b/.github/scripts/check-shard-coverage.ps1
@@ -119,7 +119,7 @@ foreach ($class in $generated) {
     if (-not $covered) { $uncovered += $class }
 }
 
-Write-Host ("Generated classes discovered: " + @($generated).Count + "; shard prefixes in workflow: " + @($prefixes).Count)
+Write-Host ("Generated classes discovered: " + @($generated).Count + "; shard prefixes in ${Workflow}: " + @($prefixes).Count)
 
 if ($uncovered.Count -gt 0) {
     Write-Host "::error::Generated test classes are not covered by any shard filter: $($uncovered -join ', ')"

--- a/.github/scripts/check-shard-coverage.ps1
+++ b/.github/scripts/check-shard-coverage.ps1
@@ -34,7 +34,9 @@
 #>
 [CmdletBinding()]
 param(
-    [string]$Workflow = '.github/workflows/sonarcloud.yml',
+    # The shard definitions moved to .github/test-shards.yml when the matrix became dynamic;
+    # the filters this script parses moved with them, all 177 of them.
+    [string]$Workflow = '.github/test-shards.yml',
     [string]$Project  = 'tests/AiDotNet.Tests/AiDotNetTests.csproj',
     [string]$Framework = 'net10.0',
     # THE CONFIGURATION THE SHARDS ACTUALLY RUN. Without this `dotnet test` defaults
@@ -92,6 +94,14 @@ $workflowText = Get-Content $Workflow -Raw
 $prefixes = [regex]::Matches($workflowText, 'FullyQualifiedName~Generated\.([A-Za-z0-9_]+)') |
     ForEach-Object { $_.Groups[1].Value } |
     Sort-Object -Unique -CaseSensitive
+
+# Zero prefixes means the file being parsed is not the one holding the filters - which is exactly
+# what happened when the shard list moved out of the workflow. Without this the script would report
+# every generated class as uncovered, and the true cause (wrong file) would be buried under
+# hundreds of spurious failures.
+if (@($prefixes).Count -eq 0) {
+    throw "No 'FullyQualifiedName~Generated.<prefix>' filters found in '$Workflow'. The shard definitions have probably moved; point -Workflow at the file that now holds them."
+}
 
 if (-not $prefixes -or @($prefixes).Count -eq 0) {
     throw "No FullyQualifiedName~Generated.* shard filters were found in $Workflow; the gate has nothing to check against."

--- a/.github/scripts/check-shard-coverage.ps1
+++ b/.github/scripts/check-shard-coverage.ps1
@@ -103,9 +103,6 @@ if (@($prefixes).Count -eq 0) {
     throw "No 'FullyQualifiedName~Generated.<prefix>' filters found in '$Workflow'. The shard definitions have probably moved; point -Workflow at the file that now holds them."
 }
 
-if (-not $prefixes -or @($prefixes).Count -eq 0) {
-    throw "No FullyQualifiedName~Generated.* shard filters were found in $Workflow; the gate has nothing to check against."
-}
 
 $uncovered = @()
 foreach ($class in $generated) {

--- a/.github/test-shards.yml
+++ b/.github/test-shards.yml
@@ -1,0 +1,844 @@
+# Test shards for the sharded test job in .github/workflows/sonarcloud.yml.
+#
+# Moved out of the workflow so the selector can read it: a matrix built with fromJSON cannot
+# also be a literal, and the selection job needs the full list to filter. Every entry, and every
+# comment recording WHY a shard was split - the OOM kills, the 45-minute cancellations, the
+# measured per-class weights - is preserved verbatim from the workflow.
+#
+# yq converts this to JSON on the runner (yq is preinstalled on the ubuntu image), so this stays
+# YAML and keeps the comments rather than becoming a JSON blob that loses them.
+#
+# `name` is the selector's key, so names must stay unique.
+
+shard:
+  # =====================================================================
+  # UNIT TESTS — manually written tests in tests/AiDotNet.Tests/UnitTests/
+  # =====================================================================
+  - name: Unit - 01 Activation/Attention/Autodiff
+    project: tests/AiDotNet.Tests/AiDotNetTests.csproj
+    framework: net10.0
+    filter: 'Category!=GPU&Category!=Stress&Category!=Sweep&(FullyQualifiedName~UnitTests.ActivationFunctions|FullyQualifiedName~UnitTests.Attention|FullyQualifiedName~UnitTests.Autodiff)'
+  - name: Unit - 02 AutoML/Data/Diagnostics
+    project: tests/AiDotNet.Tests/AiDotNetTests.csproj
+    framework: net10.0
+    filter: 'Category!=GPU&Category!=Stress&Category!=Sweep&(FullyQualifiedName~UnitTests.AutoML|FullyQualifiedName~UnitTests.Data|FullyQualifiedName~UnitTests.Diagnostics)'
+  - name: Unit - 03a Diffusion Core/Schedulers/Encoding
+    project: tests/AiDotNet.Tests/AiDotNetTests.csproj
+    framework: net10.0
+    filter: 'Category!=GPU&Category!=Stress&Category!=Sweep&(FullyQualifiedName~UnitTests.Encoding|FullyQualifiedName~UnitTests.Diffusion.AudioProcessingTests|FullyQualifiedName~UnitTests.Diffusion.MemoryManagementTests|FullyQualifiedName~UnitTests.Diffusion.SchedulerTests|FullyQualifiedName~UnitTests.Diffusion.Conditioning|FullyQualifiedName~UnitTests.Diffusion.Schedulers)'
+  - name: Unit - 03b1 Diffusion Preprocessors
+    project: tests/AiDotNet.Tests/AiDotNetTests.csproj
+    framework: net10.0
+    filter: 'Category!=GPU&Category!=Stress&Category!=Sweep&FullyQualifiedName~UnitTests.Diffusion.Models&FullyQualifiedName~PreprocessorContractTests'
+  - name: Unit - 03b2 Diffusion DDPM
+    project: tests/AiDotNet.Tests/AiDotNetTests.csproj
+    framework: net10.0
+    filter: 'Category!=GPU&Category!=Stress&Category!=Sweep&FullyQualifiedName~UnitTests.Diffusion.Models&FullyQualifiedName~DDPMModelTests'
+  - name: Unit - 03b3 Diffusion Control Guidance/Adapters
+    project: tests/AiDotNet.Tests/AiDotNetTests.csproj
+    framework: net10.0
+    filter: >-
+      Category!=GPU&Category!=Stress&FullyQualifiedName~UnitTests.Diffusion.Models&
+      FullyQualifiedName~ControlModelContractTests&
+      (FullyQualifiedName~PerturbedAttentionGuidance|FullyQualifiedName~SelfAttentionGuidance|FullyQualifiedName~DynamicCFGScheduler|FullyQualifiedName~RescaledCFG|FullyQualifiedName~AdaptiveProjectedGuidance|FullyQualifiedName~IPAdapterPlusModel_DefaultConstructor|FullyQualifiedName~IPAdapterFaceIDPlusModel_DefaultConstructor|FullyQualifiedName~IPAdapterModel_DefaultConstructor)
+  - name: Unit - 03b4 Diffusion ControlNet Core A
+    project: tests/AiDotNet.Tests/AiDotNetTests.csproj
+    framework: net10.0
+    filter: >-
+      Category!=GPU&Category!=Stress&FullyQualifiedName~UnitTests.Diffusion.Models&
+      FullyQualifiedName~ControlModelContractTests&
+      (FullyQualifiedName~ControlNetPlusPlusModel_DefaultConstructor|FullyQualifiedName~ControlNetFluxModel_DefaultConstructor|FullyQualifiedName~ControlNetSD3Model_DefaultConstructor|FullyQualifiedName~ControlNetUnionProModel_DefaultConstructor|FullyQualifiedName~ControlNetPlusPlusFluxModel_DefaultConstructor|FullyQualifiedName~ControlNetPlusPlusModel_Clone|FullyQualifiedName~ControlNetFluxModel_Clone)
+  - name: Unit - 03b5 Diffusion ControlNet Core B
+    project: tests/AiDotNet.Tests/AiDotNetTests.csproj
+    framework: net10.0
+    filter: >-
+      Category!=GPU&Category!=Stress&FullyQualifiedName~UnitTests.Diffusion.Models&
+      FullyQualifiedName~ControlModelContractTests&
+      (FullyQualifiedName~ControlNetLiteModel_DefaultConstructor|FullyQualifiedName~ControlNetQRModel_DefaultConstructor|FullyQualifiedName~ReferenceOnlyModel_DefaultConstructor|FullyQualifiedName~StyleAlignedModel_DefaultConstructor|FullyQualifiedName~ControlNetTileModel_DefaultConstructor|FullyQualifiedName~ControlNetInpaintingModel_DefaultConstructor|FullyQualifiedName~ControlNeXtModel_DefaultConstructor|FullyQualifiedName~ControlARModel_DefaultConstructor)
+  - name: Unit - 03c1 Diffusion Contracts A-C
+    project: tests/AiDotNet.Tests/AiDotNetTests.csproj
+    framework: net10.0
+    filter: 'Category!=GPU&Category!=Stress&Category!=Sweep&FullyQualifiedName~UnitTests.Diffusion.Models&(FullyQualifiedName~DiffusionModelContractTests.A|FullyQualifiedName~DiffusionModelContractTests.B|FullyQualifiedName~DiffusionModelContractTests.C)'
+  - name: Unit - 03c2 Diffusion Contracts D-I
+    project: tests/AiDotNet.Tests/AiDotNetTests.csproj
+    framework: net10.0
+    filter: 'Category!=GPU&Category!=Stress&Category!=Sweep&FullyQualifiedName~UnitTests.Diffusion.Models&(FullyQualifiedName~DiffusionModelContractTests.D|FullyQualifiedName~DiffusionModelContractTests.E|FullyQualifiedName~DiffusionModelContractTests.F|FullyQualifiedName~DiffusionModelContractTests.G|FullyQualifiedName~DiffusionModelContractTests.H|FullyQualifiedName~DiffusionModelContractTests.I)'
+  - name: Unit - 03c3 Diffusion Contracts J-R
+    project: tests/AiDotNet.Tests/AiDotNetTests.csproj
+    framework: net10.0
+    filter: 'Category!=GPU&Category!=Stress&Category!=Sweep&FullyQualifiedName~UnitTests.Diffusion.Models&(FullyQualifiedName~DiffusionModelContractTests.J|FullyQualifiedName~DiffusionModelContractTests.K|FullyQualifiedName~DiffusionModelContractTests.L|FullyQualifiedName~DiffusionModelContractTests.M|FullyQualifiedName~DiffusionModelContractTests.N|FullyQualifiedName~DiffusionModelContractTests.O|FullyQualifiedName~DiffusionModelContractTests.P|FullyQualifiedName~DiffusionModelContractTests.Q|FullyQualifiedName~DiffusionModelContractTests.R)'
+  - name: Unit - 03c4 Diffusion Contracts S
+    project: tests/AiDotNet.Tests/AiDotNetTests.csproj
+    framework: net10.0
+    filter: 'Category!=GPU&Category!=Stress&Category!=Sweep&FullyQualifiedName~UnitTests.Diffusion.Models&FullyQualifiedName~DiffusionModelContractTests.S'
+  - name: Unit - 03c5 Diffusion Contracts T-Z
+    project: tests/AiDotNet.Tests/AiDotNetTests.csproj
+    framework: net10.0
+    filter: 'Category!=GPU&Category!=Stress&Category!=Sweep&FullyQualifiedName~UnitTests.Diffusion.Models&(FullyQualifiedName~DiffusionModelContractTests.T|FullyQualifiedName~DiffusionModelContractTests.U|FullyQualifiedName~DiffusionModelContractTests.V|FullyQualifiedName~DiffusionModelContractTests.W|FullyQualifiedName~DiffusionModelContractTests.X|FullyQualifiedName~DiffusionModelContractTests.Y|FullyQualifiedName~DiffusionModelContractTests.Z)'
+  - name: Unit - 03c6 Editing Contracts A-I
+    project: tests/AiDotNet.Tests/AiDotNetTests.csproj
+    framework: net10.0
+    filter: 'Category!=GPU&Category!=Stress&Category!=Sweep&FullyQualifiedName~UnitTests.Diffusion.Models&(FullyQualifiedName~EditingModelContractTests.A|FullyQualifiedName~EditingModelContractTests.B|FullyQualifiedName~EditingModelContractTests.C|FullyQualifiedName~EditingModelContractTests.D|FullyQualifiedName~EditingModelContractTests.E|FullyQualifiedName~EditingModelContractTests.F|FullyQualifiedName~EditingModelContractTests.G|FullyQualifiedName~EditingModelContractTests.H|FullyQualifiedName~EditingModelContractTests.I)'
+  - name: Unit - 03c7 Editing Contracts J-Z
+    project: tests/AiDotNet.Tests/AiDotNetTests.csproj
+    framework: net10.0
+    filter: 'Category!=GPU&Category!=Stress&Category!=Sweep&FullyQualifiedName~UnitTests.Diffusion.Models&(FullyQualifiedName~EditingModelContractTests.J|FullyQualifiedName~EditingModelContractTests.K|FullyQualifiedName~EditingModelContractTests.L|FullyQualifiedName~EditingModelContractTests.M|FullyQualifiedName~EditingModelContractTests.N|FullyQualifiedName~EditingModelContractTests.O|FullyQualifiedName~EditingModelContractTests.P|FullyQualifiedName~EditingModelContractTests.Q|FullyQualifiedName~EditingModelContractTests.R|FullyQualifiedName~EditingModelContractTests.S|FullyQualifiedName~EditingModelContractTests.T|FullyQualifiedName~EditingModelContractTests.U|FullyQualifiedName~EditingModelContractTests.V|FullyQualifiedName~EditingModelContractTests.W|FullyQualifiedName~EditingModelContractTests.X|FullyQualifiedName~EditingModelContractTests.Y|FullyQualifiedName~EditingModelContractTests.Z)'
+  - name: Unit - 03d1 Diffusion FastGen Image/VAE
+    project: tests/AiDotNet.Tests/AiDotNetTests.csproj
+    framework: net10.0
+    filter: >-
+      Category!=GPU&Category!=Stress&FullyQualifiedName~UnitTests.Diffusion.Models&
+      FullyQualifiedName~FastGenContractTests&
+      (FullyQualifiedName~Flux2Model_DefaultConstructor|FullyQualifiedName~SANAModel_DefaultConstructor|FullyQualifiedName~StableDiffusion35Model_DefaultConstructor|FullyQualifiedName~LuminaImage2Model_DefaultConstructor|FullyQualifiedName~HiDreamModel_DefaultConstructor|FullyQualifiedName~CogView4Model_DefaultConstructor|FullyQualifiedName~PlaygroundV3Model_DefaultConstructor|FullyQualifiedName~Imagen3Model_DefaultConstructor|FullyQualifiedName~MeissonicModel_DefaultConstructor|FullyQualifiedName~RecraftV3Model_DefaultConstructor|FullyQualifiedName~Ideogram3Model_DefaultConstructor|FullyQualifiedName~MidJourneyV7Model_DefaultConstructor|FullyQualifiedName~DeepCompressionVAE_DefaultConstructor|FullyQualifiedName~EQVAEModel_DefaultConstructor|FullyQualifiedName~LiteVAEModel_DefaultConstructor|FullyQualifiedName~SDXLVAEModel_DefaultConstructor)
+  - name: Unit - 03d2 Diffusion FastGen Consistency/Turbo
+    project: tests/AiDotNet.Tests/AiDotNetTests.csproj
+    framework: net10.0
+    filter: >-
+      Category!=GPU&Category!=Stress&FullyQualifiedName~UnitTests.Diffusion.Models&
+      FullyQualifiedName~FastGenContractTests&
+      (FullyQualifiedName~ImprovedConsistencyModel_DefaultConstructor|FullyQualifiedName~EasyConsistencyModel_DefaultConstructor|FullyQualifiedName~MultiStepConsistencyModel_DefaultConstructor|FullyQualifiedName~MultistepLCModel_DefaultConstructor|FullyQualifiedName~TrainingEfficientLCM_DefaultConstructor|FullyQualifiedName~SDXLTurboModel_DefaultConstructor|FullyQualifiedName~SDXLLightningModel_DefaultConstructor|FullyQualifiedName~HyperSDModel_DefaultConstructor|FullyQualifiedName~DMD2Model_DefaultConstructor|FullyQualifiedName~SenseFlowModel_DefaultConstructor|FullyQualifiedName~SANASprintModel_DefaultConstructor|FullyQualifiedName~SwiftBrushModel_DefaultConstructor|FullyQualifiedName~FlashDiffusionModel_DefaultConstructor)
+  - name: Unit - 03d3 Diffusion FastGen Flow/AR
+    project: tests/AiDotNet.Tests/AiDotNetTests.csproj
+    framework: net10.0
+    filter: >-
+      Category!=GPU&Category!=Stress&FullyQualifiedName~UnitTests.Diffusion.Models&
+      FullyQualifiedName~FastGenContractTests&
+      (FullyQualifiedName~PCMModel_DefaultConstructor|FullyQualifiedName~TCDModel_DefaultConstructor|FullyQualifiedName~InstaFlowModel_DefaultConstructor|FullyQualifiedName~FlowMapModel_DefaultConstructor|FullyQualifiedName~SCottModel_DefaultConstructor|FullyQualifiedName~PeRFlowModel_DefaultConstructor|FullyQualifiedName~SiDModel_DefaultConstructor|FullyQualifiedName~SiDDiTModel_DefaultConstructor|FullyQualifiedName~SD3TurboModel_DefaultConstructor|FullyQualifiedName~FluxSchnellModel_DefaultConstructor|FullyQualifiedName~SD3FlashModel_DefaultConstructor|FullyQualifiedName~Flux2SchnellModel_DefaultConstructor|FullyQualifiedName~PixArtDeltaLCMModel_DefaultConstructor|FullyQualifiedName~TransfusionModel_DefaultConstructor|FullyQualifiedName~MARModel_DefaultConstructor|FullyQualifiedName~ARDiffusionModel_DefaultConstructor|FullyQualifiedName~AutoRegressiveMaskedDiffusion_DefaultConstructor)
+  - name: Unit - 03d4 Diffusion FastGen Schedulers
+    project: tests/AiDotNet.Tests/AiDotNetTests.csproj
+    framework: net10.0
+    filter: >-
+      Category!=GPU&Category!=Stress&FullyQualifiedName~UnitTests.Diffusion.Models&
+      FullyQualifiedName~FastGenContractTests&
+      (FullyQualifiedName~RectifiedFlowScheduler_DefaultConstructor|FullyQualifiedName~FlowDPMSolverScheduler_DefaultConstructor|FullyQualifiedName~DPMSolverV3Scheduler_DefaultConstructor|FullyQualifiedName~SASolverScheduler_DefaultConstructor)
+  - name: Unit - 03d5 Diffusion FastGen SDXL State
+    project: tests/AiDotNet.Tests/AiDotNetTests.csproj
+    framework: net10.0
+    filter: >-
+      Category!=GPU&Category!=Stress&FullyQualifiedName~UnitTests.Diffusion.Models&
+      FullyQualifiedName~FastGenContractTests&
+      (FullyQualifiedName~SDXLTurboModel_Clone|FullyQualifiedName~ImprovedConsistencyModel_Clone|FullyQualifiedName~SDXLTurboModel_GetSetParameters|FullyQualifiedName~SDXLTurboModel_GetModelMetadata)
+  - name: Unit - 03d6 Diffusion FastGen Flux State
+    project: tests/AiDotNet.Tests/AiDotNetTests.csproj
+    framework: net10.0
+    filter: >-
+      Category!=GPU&Category!=Stress&FullyQualifiedName~UnitTests.Diffusion.Models&
+      FullyQualifiedName~FastGenContractTests&
+      (FullyQualifiedName~FluxSchnellModel_Clone|FullyQualifiedName~Flux2Model_GetSetParameters|FullyQualifiedName~FluxSchnellModel_GetModelMetadata|FullyQualifiedName~SANAModel_GetModelMetadata)
+  - name: Unit - 03d7 Diffusion FastGen Distillation
+    project: tests/AiDotNet.Tests/AiDotNetTests.csproj
+    framework: net10.0
+    filter: >-
+      Category!=GPU&Category!=Stress&FullyQualifiedName~UnitTests.Diffusion.Models&
+      FullyQualifiedName~FastGenContractTests&
+      (FullyQualifiedName~OSDSModel_DefaultConstructor|FullyQualifiedName~ScoreDistillationSampling_Constructor|FullyQualifiedName~VariationalScoreDistillation_Constructor|FullyQualifiedName~ConsistencyDistillationSampling_Constructor|FullyQualifiedName~IntervalScoreMatching_Constructor|FullyQualifiedName~DenoisedScoreDistillation_Constructor|FullyQualifiedName~UnifiedDistillationSampling_Constructor|FullyQualifiedName~RewardScoreDistillation_Constructor|FullyQualifiedName~SemanticScoreDistillation_Constructor|FullyQualifiedName~FastGenContractTests.ConsistencyModel_DefaultConstructor)
+  - name: Unit - 03d8 Diffusion New Conditioners
+    project: tests/AiDotNet.Tests/AiDotNetTests.csproj
+    framework: net10.0
+    filter: 'Category!=GPU&Category!=Stress&Category!=Sweep&FullyQualifiedName~UnitTests.Diffusion.Models&FullyQualifiedName~NewConditionerContractTests'
+  - name: Unit - 04 Feature/Fit/Fitness/Genetics
+    project: tests/AiDotNet.Tests/AiDotNetTests.csproj
+    framework: net10.0
+    filter: 'Category!=GPU&Category!=Stress&Category!=Sweep&(FullyQualifiedName~UnitTests.FeatureSelectors|FullyQualifiedName~UnitTests.FitDetectors|FullyQualifiedName~UnitTests.FitnessCalculators|FullyQualifiedName~UnitTests.Genetics)'
+  - name: Unit - 05 Helpers/Inference/Interpretability
+    project: tests/AiDotNet.Tests/AiDotNetTests.csproj
+    framework: net10.0
+    filter: 'Category!=GPU&Category!=Stress&Category!=Sweep&(FullyQualifiedName~UnitTests.Helpers|FullyQualifiedName~UnitTests.Inference|FullyQualifiedName~UnitTests.Interpretability)'
+  - name: Unit - 06 KD/Schedulers/LA
+    project: tests/AiDotNet.Tests/AiDotNetTests.csproj
+    framework: net10.0
+    filter: 'Category!=GPU&Category!=Stress&Category!=Sweep&(FullyQualifiedName~UnitTests.KnowledgeDistillation|FullyQualifiedName~UnitTests.LearningRateSchedulers|FullyQualifiedName~UnitTests.LinearAlgebra)'
+  - name: Unit - 07 Logging/Loss/Meta/Mixed/Compression
+    project: tests/AiDotNet.Tests/AiDotNetTests.csproj
+    framework: net10.0
+    filter: 'Category!=GPU&Category!=Stress&Category!=Sweep&(FullyQualifiedName~UnitTests.Logging|FullyQualifiedName~UnitTests.LossFunctions|FullyQualifiedName~UnitTests.MetaLearning|FullyQualifiedName~UnitTests.MixedPrecision|FullyQualifiedName~UnitTests.ModelCompression)'
+  # NeuralNetworks split to avoid timeouts
+  - name: Unit - 08a NN-Classic (ResNet/VGG/DenseNet)
+    project: tests/AiDotNet.Tests/AiDotNetTests.csproj
+    framework: net10.0
+    filter: 'Category!=GPU&Category!=Stress&Category!=Sweep&FullyQualifiedName~UnitTests.NeuralNetworks&(FullyQualifiedName~ResNetNetworkTests|FullyQualifiedName~VGGNetworkTests|FullyQualifiedName~DenseNetTests)'
+  - name: Unit - 08b NN-Efficient (MobileNet/EfficientNet)
+    project: tests/AiDotNet.Tests/AiDotNetTests.csproj
+    framework: net10.0
+    filter: 'Category!=GPU&Category!=Stress&Category!=Sweep&FullyQualifiedName~UnitTests.NeuralNetworks&(FullyQualifiedName~MobileNetTests|FullyQualifiedName~EfficientNetTests)'
+  - name: Unit - 08c NN-VLM (Blip/Blip2/Clip)
+    project: tests/AiDotNet.Tests/AiDotNetTests.csproj
+    framework: net10.0
+    filter: 'Category!=GPU&Category!=Stress&Category!=Sweep&FullyQualifiedName~UnitTests.NeuralNetworks&(FullyQualifiedName~BlipNeuralNetworkTests|FullyQualifiedName~Blip2NeuralNetworkTests|FullyQualifiedName~ClipNeuralNetworkTests)'
+  - name: Unit - 08d NN-Adapters/Other
+    project: tests/AiDotNet.Tests/AiDotNetTests.csproj
+    framework: net10.0
+    filter: 'Category!=GPU&Category!=Stress&Category!=Sweep&FullyQualifiedName~UnitTests.NeuralNetworks&(FullyQualifiedName~LoRAAdapterTests|FullyQualifiedName~LoRALayerTests|FullyQualifiedName~VBLoRAAdapterTests|FullyQualifiedName~AdvancedAlgebraNetworkTests|FullyQualifiedName~MixtureOfExpertsNeuralNetworkTests)'
+  # 'Unit - 08e NN-Remaining (catch-all)' removed: it was a duplicate
+  # of the ModelFamily NeuralNetworks shards (`A-F` + `G-L` + `M-N` +
+  # `O-R` + `S` + `T` + `U-Z`, same ModelFamilyTests.NeuralNetworks scope,
+  # only excluding 5 unit-test classes already covered by their
+  # dedicated 08a-08d shards). Running ~800 paper-scale NN model tests
+  # a SECOND time inside an already-OOMing process is what was actually
+  # triggering the catch-all failures — the model family shards above
+  # provide complete, non-redundant coverage of the same scope.
+  - name: Unit - 09 Optimizers/RAG
+    project: tests/AiDotNet.Tests/AiDotNetTests.csproj
+    framework: net10.0
+    filter: 'Category!=GPU&Category!=Stress&Category!=Sweep&(FullyQualifiedName~UnitTests.Optimizers|FullyQualifiedName~UnitTests.RAG)'
+  - name: Unit - 10 Regularization/RL/RAG2
+    project: tests/AiDotNet.Tests/AiDotNetTests.csproj
+    framework: net10.0
+    filter: 'Category!=GPU&Category!=Stress&Category!=Sweep&(FullyQualifiedName~UnitTests.Regularization|FullyQualifiedName~UnitTests.ReinforcementLearning|FullyQualifiedName~UnitTests.RetrievalAugmentedGeneration)'
+  - name: Unit - 11 Serving/TimeSeries/Token/Transfer
+    project: tests/AiDotNet.Tests/AiDotNetTests.csproj
+    framework: net10.0
+    filter: 'Category!=GPU&Category!=Stress&Category!=Sweep&(FullyQualifiedName~UnitTests.Serving|FullyQualifiedName~UnitTests.TimeSeries|FullyQualifiedName~UnitTests.Tokenization|FullyQualifiedName~UnitTests.TransferLearning)'
+  - name: Unit - 12 ProgramSynthesis/Reasoning
+    project: tests/AiDotNet.Tests/AiDotNetTests.csproj
+    framework: net10.0
+    filter: 'Category!=GPU&Category!=Stress&Category!=Sweep&(FullyQualifiedName~UnitTests.ProgramSynthesis|FullyQualifiedName~UnitTests.Reasoning)'
+  - name: Unit - 13 Remaining (ActiveLearning/Agents/CL/Physics/etc.)
+    project: tests/AiDotNet.Tests/AiDotNetTests.csproj
+    framework: net10.0
+    filter: >-
+      Category!=GPU&Category!=Stress&
+      FullyQualifiedName~AiDotNet.Tests.UnitTests&
+      FullyQualifiedName!~UnitTests.ActivationFunctions&
+      FullyQualifiedName!~UnitTests.Attention&
+      FullyQualifiedName!~UnitTests.Autodiff&
+      FullyQualifiedName!~UnitTests.AutoML&
+      FullyQualifiedName!~UnitTests.Data&
+      FullyQualifiedName!~UnitTests.Diagnostics&
+      FullyQualifiedName!~UnitTests.Diffusion&
+      FullyQualifiedName!~UnitTests.Encoding&
+      FullyQualifiedName!~UnitTests.FeatureSelectors&
+      FullyQualifiedName!~UnitTests.FitDetectors&
+      FullyQualifiedName!~UnitTests.FitnessCalculators&
+      FullyQualifiedName!~UnitTests.Genetics&
+      FullyQualifiedName!~UnitTests.Helpers&
+      FullyQualifiedName!~UnitTests.Inference&
+      FullyQualifiedName!~UnitTests.Interpretability&
+      FullyQualifiedName!~UnitTests.KnowledgeDistillation&
+      FullyQualifiedName!~UnitTests.LearningRateSchedulers&
+      FullyQualifiedName!~UnitTests.LinearAlgebra&
+      FullyQualifiedName!~UnitTests.Logging&
+      FullyQualifiedName!~UnitTests.LossFunctions&
+      FullyQualifiedName!~UnitTests.MetaLearning&
+      FullyQualifiedName!~UnitTests.MixedPrecision&
+      FullyQualifiedName!~UnitTests.ModelCompression&
+      FullyQualifiedName!~UnitTests.NeuralNetworks&
+      FullyQualifiedName!~UnitTests.Optimizers&
+      FullyQualifiedName!~UnitTests.RAG&
+      FullyQualifiedName!~UnitTests.Regularization&
+      FullyQualifiedName!~UnitTests.ReinforcementLearning&
+      FullyQualifiedName!~UnitTests.RetrievalAugmentedGeneration&
+      FullyQualifiedName!~UnitTests.Serving&
+      FullyQualifiedName!~UnitTests.TimeSeries&
+      FullyQualifiedName!~UnitTests.Tokenization&
+      FullyQualifiedName!~UnitTests.TransferLearning&
+      FullyQualifiedName!~UnitTests.ProgramSynthesis&
+      FullyQualifiedName!~UnitTests.Reasoning
+  # =====================================================================
+  # OTHER NON-UNIT TESTS (InferenceOpt, PromptEng, Recovery, Playground)
+  # =====================================================================
+  - name: Other - PromptEngineering
+    project: tests/AiDotNet.Tests/AiDotNetTests.csproj
+    framework: net10.0
+    filter: 'Category!=GPU&Category!=Stress&Category!=Sweep&FullyQualifiedName~AiDotNet.Tests.PromptEngineering'
+  - name: Other - Recovery/Concurrency
+    project: tests/AiDotNet.Tests/AiDotNetTests.csproj
+    framework: net10.0
+    filter: 'Category!=GPU&Category!=Stress&Category!=Sweep&(FullyQualifiedName~AiDotNet.Tests.Recovery|FullyQualifiedName~AiDotNet.Tests.Concurrency)'
+  - name: Other - Playground
+    project: tests/AiDotNet.Tests/AiDotNetTests.csproj
+    framework: net10.0
+    filter: Category=Playground
+  # =====================================================================
+  # MODEL FAMILY TESTS — invariant math tests for all model families
+  # =====================================================================
+  - name: ModelFamily - Classification
+    project: tests/AiDotNet.Tests/AiDotNetTests.csproj
+    framework: net10.0
+    filter: 'FullyQualifiedName~ModelFamilyTests.Classification'
+  - name: ModelFamily - Clustering/GP
+    project: tests/AiDotNet.Tests/AiDotNetTests.csproj
+    framework: net10.0
+    filter: '(FullyQualifiedName~ModelFamilyTests.Clustering|FullyQualifiedName~ModelFamilyTests.GaussianProcess)'
+  - name: ModelFamily - Regression
+    project: tests/AiDotNet.Tests/AiDotNetTests.csproj
+    framework: net10.0
+    filter: 'FullyQualifiedName~ModelFamilyTests.Regression'
+  # NeuralNetworks (85 model classes) split by model-class first letter.
+  # These instantiate ResNet/VGG/DenseNet/transformer-scale models
+  # (multi-GB each) and OOM'd as larger shards even serialized.
+  # A-L was a single serial $heavyShard that ran the full 45-min job
+  # timeout (983 tests × serial) and got cancelled before finishing —
+  # perpetually red, exactly like Integration C before its split. Split
+  # A-L → A-F + G-L so each serial half finishes well under the timeout.
+  # Gap-free + non-overlapping: the two filters' union is the old A-L set.
+  - name: ModelFamily - NeuralNetworks A-F
+    project: tests/AiDotNet.Tests/AiDotNetTests.csproj
+    framework: net10.0
+    filter: >-
+      FullyQualifiedName~ModelFamilyTests.NeuralNetworks&
+      (FullyQualifiedName~NeuralNetworks.A|FullyQualifiedName~NeuralNetworks.B|FullyQualifiedName~NeuralNetworks.C|FullyQualifiedName~NeuralNetworks.D|FullyQualifiedName~NeuralNetworks.E|FullyQualifiedName~NeuralNetworks.F)
+  - name: ModelFamily - NeuralNetworks G-L
+    project: tests/AiDotNet.Tests/AiDotNetTests.csproj
+    framework: net10.0
+    filter: >-
+      FullyQualifiedName~ModelFamilyTests.NeuralNetworks&
+      (FullyQualifiedName~NeuralNetworks.G|FullyQualifiedName~NeuralNetworks.H|FullyQualifiedName~NeuralNetworks.I|FullyQualifiedName~NeuralNetworks.J|FullyQualifiedName~NeuralNetworks.K|FullyQualifiedName~NeuralNetworks.L)
+  - name: ModelFamily - NeuralNetworks M-N
+    project: tests/AiDotNet.Tests/AiDotNetTests.csproj
+    framework: net10.0
+    filter: >-
+      FullyQualifiedName~ModelFamilyTests.NeuralNetworks&
+      (FullyQualifiedName~NeuralNetworks.M|FullyQualifiedName~NeuralNetworks.N)
+  - name: ModelFamily - NeuralNetworks O-R
+    project: tests/AiDotNet.Tests/AiDotNetTests.csproj
+    framework: net10.0
+    filter: >-
+      FullyQualifiedName~ModelFamilyTests.NeuralNetworks&
+      (FullyQualifiedName~NeuralNetworks.O|FullyQualifiedName~NeuralNetworks.P|FullyQualifiedName~NeuralNetworks.Q|FullyQualifiedName~NeuralNetworks.R)
+  - name: ModelFamily - NeuralNetworks S
+    project: tests/AiDotNet.Tests/AiDotNetTests.csproj
+    framework: net10.0
+    filter: >-
+      FullyQualifiedName~ModelFamilyTests.NeuralNetworks&FullyQualifiedName~NeuralNetworks.S
+  # The serialized T-Z tail was too close to the 45-minute job ceiling.
+  # Split at the existing letter boundary so the filters remain gap-free and
+  # non-overlapping while leaving margin for runner variance.
+  - name: ModelFamily - NeuralNetworks T
+    project: tests/AiDotNet.Tests/AiDotNetTests.csproj
+    framework: net10.0
+    filter: >-
+      FullyQualifiedName~ModelFamilyTests.NeuralNetworks&FullyQualifiedName~NeuralNetworks.T
+  - name: ModelFamily - NeuralNetworks U-Z
+    project: tests/AiDotNet.Tests/AiDotNetTests.csproj
+    framework: net10.0
+    filter: >-
+      FullyQualifiedName~ModelFamilyTests.NeuralNetworks&
+      (FullyQualifiedName~NeuralNetworks.U|FullyQualifiedName~NeuralNetworks.V|FullyQualifiedName~NeuralNetworks.W|FullyQualifiedName~NeuralNetworks.X|FullyQualifiedName~NeuralNetworks.Y|FullyQualifiedName~NeuralNetworks.Z)
+  - name: ModelFamily - TimeSeries/Activation/Loss
+    project: tests/AiDotNet.Tests/AiDotNetTests.csproj
+    framework: net10.0
+    filter: '(FullyQualifiedName~ModelFamilyTests.TimeSeries|FullyQualifiedName~ModelFamilyTests.ActivationFunctions|FullyQualifiedName~ModelFamilyTests.LossFunctions)'
+  # Diffusion (244 model classes) split by MODEL CLASS first
+  # letter (Diffusion.<Letter>), NOT by test METHOD letter. Method-based
+  # sharding made every shard instantiate ALL ~244 models and OOM-kill the
+  # 16 GB ubuntu-latest runner; model-class sharding limits each shard to a
+  # letter range so per-runner cumulative model/tensor footprint stays
+  # bounded. Was 3 shards (~80 models each) - still OOM'd even serialized
+  # (footprint, not parallelism), so split finer. 'S' and 'M' are split by
+  # class prefix because they are among the heaviest letter groups.
+  - name: ModelFamily - Diffusion A-C
+    project: tests/AiDotNet.Tests/AiDotNetTests.csproj
+    framework: net10.0
+    filter: >-
+      FullyQualifiedName~ModelFamilyTests.Diffusion&
+      (FullyQualifiedName~Diffusion.A|FullyQualifiedName~Diffusion.B|FullyQualifiedName~Diffusion.C)
+  - name: ModelFamily - Diffusion D-I
+    project: tests/AiDotNet.Tests/AiDotNetTests.csproj
+    framework: net10.0
+    filter: >-
+      FullyQualifiedName~ModelFamilyTests.Diffusion&
+      (FullyQualifiedName~Diffusion.D|FullyQualifiedName~Diffusion.E|FullyQualifiedName~Diffusion.F|FullyQualifiedName~Diffusion.G|FullyQualifiedName~Diffusion.H|FullyQualifiedName~Diffusion.I)
+  - name: ModelFamily - Diffusion J-K
+    project: tests/AiDotNet.Tests/AiDotNetTests.csproj
+    framework: net10.0
+    filter: >-
+      FullyQualifiedName~ModelFamilyTests.Diffusion&
+      (FullyQualifiedName~Diffusion.J|FullyQualifiedName~Diffusion.K)
+  - name: ModelFamily - Diffusion L
+    project: tests/AiDotNet.Tests/AiDotNetTests.csproj
+    framework: net10.0
+    filter: >-
+      FullyQualifiedName~ModelFamilyTests.Diffusion&FullyQualifiedName~Diffusion.L
+  - name: ModelFamily - Diffusion M A-Mi
+    project: tests/AiDotNet.Tests/AiDotNetTests.csproj
+    framework: net10.0
+    filter: >-
+      FullyQualifiedName~ModelFamilyTests.Diffusion&
+      (FullyQualifiedName~Diffusion.MAGI|FullyQualifiedName~Diffusion.Magic|FullyQualifiedName~Diffusion.Make|FullyQualifiedName~Diffusion.MAR|FullyQualifiedName~Diffusion.Me|FullyQualifiedName~Diffusion.Mid|FullyQualifiedName~Diffusion.Min)
+  - name: ModelFamily - Diffusion M Mochi-Model
+    project: tests/AiDotNet.Tests/AiDotNetTests.csproj
+    framework: net10.0
+    filter: >-
+      FullyQualifiedName~ModelFamilyTests.Diffusion&
+      (FullyQualifiedName~Diffusion.Mochi|FullyQualifiedName~Diffusion.ModelScope|FullyQualifiedName~Diffusion.MoMask)
+  - name: ModelFamily - Diffusion M Motion-MZ
+    project: tests/AiDotNet.Tests/AiDotNetTests.csproj
+    framework: net10.0
+    filter: >-
+      FullyQualifiedName~ModelFamilyTests.Diffusion&
+      (FullyQualifiedName~Diffusion.Motion|FullyQualifiedName~Diffusion.Movie|FullyQualifiedName~Diffusion.Multi|FullyQualifiedName~Diffusion.Music|FullyQualifiedName~Diffusion.MV)
+  - name: ModelFamily - Diffusion N-R
+    project: tests/AiDotNet.Tests/AiDotNetTests.csproj
+    framework: net10.0
+    filter: >-
+      FullyQualifiedName~ModelFamilyTests.Diffusion&
+      (FullyQualifiedName~Diffusion.N|FullyQualifiedName~Diffusion.O|FullyQualifiedName~Diffusion.P|FullyQualifiedName~Diffusion.Q|FullyQualifiedName~Diffusion.R)
+  - name: ModelFamily - Diffusion SA-SD
+    project: tests/AiDotNet.Tests/AiDotNetTests.csproj
+    framework: net10.0
+    filter: >-
+      FullyQualifiedName~ModelFamilyTests.Diffusion&
+      (FullyQualifiedName~Diffusion.SA|FullyQualifiedName~Diffusion.SC|FullyQualifiedName~Diffusion.SD)
+  - name: ModelFamily - Diffusion SE-SP
+    project: tests/AiDotNet.Tests/AiDotNetTests.csproj
+    framework: net10.0
+    filter: >-
+      FullyQualifiedName~ModelFamilyTests.Diffusion&
+      (FullyQualifiedName~Diffusion.Se|FullyQualifiedName~Diffusion.Sh|FullyQualifiedName~Diffusion.Si|FullyQualifiedName~Diffusion.Sk|FullyQualifiedName~Diffusion.Sn|FullyQualifiedName~Diffusion.So|FullyQualifiedName~Diffusion.Sp)
+  - name: ModelFamily - Diffusion Stable
+    project: tests/AiDotNet.Tests/AiDotNetTests.csproj
+    framework: net10.0
+    filter: >-
+      FullyQualifiedName~ModelFamilyTests.Diffusion&FullyQualifiedName~Diffusion.Stable
+  - name: ModelFamily - Diffusion Step-Sync
+    project: tests/AiDotNet.Tests/AiDotNetTests.csproj
+    framework: net10.0
+    filter: >-
+      FullyQualifiedName~ModelFamilyTests.Diffusion&
+      (FullyQualifiedName~Diffusion.Step|FullyQualifiedName~Diffusion.Stitch|FullyQualifiedName~Diffusion.Streaming|FullyQualifiedName~Diffusion.Sty|FullyQualifiedName~Diffusion.SUPIR|FullyQualifiedName~Diffusion.Swift|FullyQualifiedName~Diffusion.Sync)
+  - name: ModelFamily - Diffusion T-Z
+    project: tests/AiDotNet.Tests/AiDotNetTests.csproj
+    framework: net10.0
+    filter: >-
+      FullyQualifiedName~ModelFamilyTests.Diffusion&
+      (FullyQualifiedName~Diffusion.T|FullyQualifiedName~Diffusion.U|FullyQualifiedName~Diffusion.V|FullyQualifiedName~Diffusion.W|FullyQualifiedName~Diffusion.X|FullyQualifiedName~Diffusion.Y|FullyQualifiedName~Diffusion.Z)
+  # Auto-generated layer tests from TestScaffoldGenerator (~1670 methods),
+  # split A-M / N-Z by generated model-class first letter to halve per-shard
+  # model instantiations (OOM mitigation).
+  # A-M was a single serial $heavyShard whose ~835 default-gate methods ran
+  # the full 45-min job timeout and got CANCELLED before finishing —
+  # perpetually red, like Integration C / NeuralNetworks A-L before their
+  # splits. Split A-M → A-F + G-M so each serial half finishes under the
+  # timeout. Gap-free + non-overlapping: union == the old A-M set.
+  # A-F was a single serial $heavyShard that OOM-killed the runner (shutdown signal
+  # ~2.5 min in) — it is DENSE with full-scale codec-LM TTS models (Amphion, AudioLM,
+  # Bark, ChatTTS, Chatterbox, CosyVoice*, ...) whose per-model peak (~2.6 GB weights +
+  # Adam state) stacks past the 16 GB envelope even serialized. Split A-F → A-C + D-F;
+  # A-C then reached the 45-minute ceiling after only 2,516/3,625 results, leaving 51
+  # classes untouched. Isolate its initials (A=1,008, B=824, C=1,793 tests) so all three
+  # retain headroom. Gap-free + non-overlapping: union == the old A-C shard.
+  - name: ModelFamily - Generated Layers A
+    project: tests/AiDotNet.Tests/AiDotNetTests.csproj
+    framework: net10.0
+    filter: >-
+      FullyQualifiedName~ModelFamilyTests.Generated&FullyQualifiedName~Generated.A
+  - name: ModelFamily - Generated Layers B
+    project: tests/AiDotNet.Tests/AiDotNetTests.csproj
+    framework: net10.0
+    filter: >-
+      FullyQualifiedName~ModelFamilyTests.Generated&FullyQualifiedName~Generated.B
+  - name: ModelFamily - Generated Layers C
+    project: tests/AiDotNet.Tests/AiDotNetTests.csproj
+    framework: net10.0
+    filter: >-
+      FullyQualifiedName~ModelFamilyTests.Generated&FullyQualifiedName~Generated.C
+  # SPLIT FROM "D-F", which was the largest shard in the suite at 4,443 tests and was
+  # KILLED BY THE RUNNER at ~10 minutes, uploading no TRX. Its own memory telemetry shows
+  # why: MemAvailable fell 3.1 GB -> 150 MB and stayed pinned there for ~45 s before the
+  # host went away. That is the OOM killer, not the 45-minute clock, so a longer timeout
+  # would not have saved it -- the working set had to come down. One letter per shard puts
+  # each at roughly a third of the peak. Gap-free + non-overlapping: union == D-F.
+  - name: ModelFamily - Generated Layers D
+    project: tests/AiDotNet.Tests/AiDotNetTests.csproj
+    framework: net10.0
+    timeout: 60
+    filter: >-
+      FullyQualifiedName~ModelFamilyTests.Generated&FullyQualifiedName~Generated.D
+  - name: ModelFamily - Generated Layers E
+    project: tests/AiDotNet.Tests/AiDotNetTests.csproj
+    framework: net10.0
+    timeout: 60
+    filter: >-
+      FullyQualifiedName~ModelFamilyTests.Generated&FullyQualifiedName~Generated.E
+  - name: ModelFamily - Generated Layers F
+    project: tests/AiDotNet.Tests/AiDotNetTests.csproj
+    framework: net10.0
+    timeout: 60
+    filter: >-
+      FullyQualifiedName~ModelFamilyTests.Generated&FullyQualifiedName~Generated.F
+  # G-M was a single serial shard that ran the full 45-min job timeout and got
+  # CANCELLED before finishing (dense with heavy segmentation/foundation models,
+  # e.g. Mask2Former). Split G-M → G-I + J-M so each serial half finishes under the
+  # timeout. Gap-free + non-overlapping: union == G-M.
+  # SPLIT FROM "G-I", which reached the 45-minute job ceiling and uploaded no TRX. It
+  # carried 35 layer types (G 19, H 10, I 6) plus the generated model scaffolds on the same
+  # prefixes -- against healthy shards like C and D at 25 and 22. This is the one of the
+  # four reported shards where breadth genuinely was the problem; U (6 types) and Vo-VR
+  # (1 type) are small and fail for a different reason, so they are NOT split here.
+  - name: ModelFamily - Generated Layers G
+    project: tests/AiDotNet.Tests/AiDotNetTests.csproj
+    framework: net10.0
+    filter: >-
+      FullyQualifiedName~ModelFamilyTests.Generated&FullyQualifiedName~Generated.G
+  - name: ModelFamily - Generated Layers H-I
+    project: tests/AiDotNet.Tests/AiDotNetTests.csproj
+    framework: net10.0
+    filter: >-
+      FullyQualifiedName~ModelFamilyTests.Generated&
+      (FullyQualifiedName~Generated.H|FullyQualifiedName~Generated.I)
+  # J-M in turn never once COMPLETED: every run either OOMed (MiniGPT-v2 / Llama-3.2-Vision /
+  # Kimi-VL, all bounded now) or ran out the 45-min budget. It carries 183 generated classes,
+  # and the last CI run covered only 44 of them in 14.4 min of execution before dying —
+  # ~61 min extrapolated for the whole shard, well over the job timeout. Split J-M → J-L + M
+  # so each serial half finishes under it (~24 min / ~37 min on the same extrapolation).
+  # The M half holds the heavy tail (Mask2Former, MaskDINO, MedSAM/MedSAM2, MPLUG-Owl,
+  # MiniGPT, MusicSourceSeparator), which is why the cut is not at the midpoint by count.
+  # Gap-free + non-overlapping: union == J-M.
+  - name: ModelFamily - Generated Layers J-L
+    project: tests/AiDotNet.Tests/AiDotNetTests.csproj
+    framework: net10.0
+    filter: >-
+      FullyQualifiedName~ModelFamilyTests.Generated&
+      (FullyQualifiedName~Generated.J|FullyQualifiedName~Generated.K|FullyQualifiedName~Generated.L)
+  # M measured 69m01s for 1875 tests - green, but over the 45-min budget, so it is split
+  # three ways. Boundaries come from that run's per-class timings, not class counts: the
+  # "Me" prefix alone accounted for 1687s, 56 percent of M, which is why an even two-way
+  # split was never going to fit. Est. wall: A-Medi ~23m, MedS-Meta ~28m, MetaV-Mu ~17m.
+  # Prefixes were generated and machine-verified so that every one of M's 110 classes -
+  # including the 8 that Category!=HeavyTimeout skips - matches exactly ONE of the three.
+  # Gap-free + non-overlapping: the union is exactly the old M.
+  - name: ModelFamily - Generated Layers M A-Medi
+    project: tests/AiDotNet.Tests/AiDotNetTests.csproj
+    framework: net10.0
+    filter: >-
+      FullyQualifiedName~ModelFamilyTests.Generated&
+      (FullyQualifiedName~Generated.M2|FullyQualifiedName~Generated.MA|FullyQualifiedName~Generated.Ma|FullyQualifiedName~Generated.MC|FullyQualifiedName~Generated.Mc|FullyQualifiedName~Generated.Mea|FullyQualifiedName~Generated.MedC|FullyQualifiedName~Generated.MedG|FullyQualifiedName~Generated.MedF|FullyQualifiedName~Generated.MedN|FullyQualifiedName~Generated.Medi)
+  - name: ModelFamily - Generated Layers M MedS-Meta
+    project: tests/AiDotNet.Tests/AiDotNetTests.csproj
+    framework: net10.0
+    filter: >-
+      FullyQualifiedName~ModelFamilyTests.Generated&
+      (FullyQualifiedName~Generated.MEG|FullyQualifiedName~Generated.Meg|FullyQualifiedName~Generated.MER|FullyQualifiedName~Generated.MedS|FullyQualifiedName~Generated.Mel|FullyQualifiedName~Generated.Mem|FullyQualifiedName~Generated.Mes|FullyQualifiedName~Generated.MetaC)
+  - name: ModelFamily - Generated Layers M MetaV-Mu
+    project: tests/AiDotNet.Tests/AiDotNetTests.csproj
+    framework: net10.0
+    filter: >-
+      FullyQualifiedName~ModelFamilyTests.Generated&
+      (FullyQualifiedName~Generated.METE|FullyQualifiedName~Generated.MG|FullyQualifiedName~Generated.MI|FullyQualifiedName~Generated.Mi|FullyQualifiedName~Generated.ML|FullyQualifiedName~Generated.MM|FullyQualifiedName~Generated.MP|FullyQualifiedName~Generated.MQ|FullyQualifiedName~Generated.MT|FullyQualifiedName~Generated.MetaV|FullyQualifiedName~Generated.Mo|FullyQualifiedName~Generated.MO|FullyQualifiedName~Generated.Mu)
+  # N-Z was a single serial $heavyShard whose ~835 default-gate scaffold
+  # methods ran the full 45-min job timeout and got CANCELLED before
+  # finishing — perpetually red, like Integration C / NeuralNetworks A-L
+  # before their splits. Split N-Z → N-S + T-Z; N-S itself was STILL a
+  # 55-min timeout (dense with the SAM / segmentation family: ODISE, OMGSeg,
+  # OneFormer, SAM/SAM21/SAMHQ, SegFormer, SegMamba, SwinUNETR, ...), so split
+  # N-S again → N-P + Q-S. N-P later exceeded the 45-min budget with 2,300+
+  # tests already green and no OOM, so split it by measured wall weight into
+  # N-O + P. P then reached the exact 45-min gate locally with 1,490/1,531 tests
+  # green and no OOM. Split P by measured second-letter buckets into two balanced
+  # jobs (798 + 759 tests after ParaformerLarge rejoined the PR lane). The filters
+  # are gap-free and non-overlapping over the generated P inventory; their union is
+  # the original P shard.
+  - name: ModelFamily - Generated Layers N-O
+    project: tests/AiDotNet.Tests/AiDotNetTests.csproj
+    framework: net10.0
+    filter: >-
+      FullyQualifiedName~ModelFamilyTests.Generated&
+      (FullyQualifiedName~Generated.N|FullyQualifiedName~Generated.O)
+  - name: ModelFamily - Generated Layers P A,C,I,L,N,P
+    project: tests/AiDotNet.Tests/AiDotNetTests.csproj
+    framework: net10.0
+    filter: >-
+      FullyQualifiedName~ModelFamilyTests.Generated&
+      (FullyQualifiedName~Generated.Pa|FullyQualifiedName~Generated.PA|FullyQualifiedName~Generated.Pc|FullyQualifiedName~Generated.PC|
+      FullyQualifiedName~Generated.Pi|FullyQualifiedName~Generated.PI|FullyQualifiedName~Generated.Pl|FullyQualifiedName~Generated.PL|
+      FullyQualifiedName~Generated.Pn|FullyQualifiedName~Generated.PN|FullyQualifiedName~Generated.Pp|FullyQualifiedName~Generated.PP)
+  - name: ModelFamily - Generated Layers P E,H,O,R,S,U,W,Y
+    project: tests/AiDotNet.Tests/AiDotNetTests.csproj
+    framework: net10.0
+    filter: >-
+      FullyQualifiedName~ModelFamilyTests.Generated&
+      (FullyQualifiedName~Generated.Pe|FullyQualifiedName~Generated.Ph|
+      FullyQualifiedName~Generated.Po|FullyQualifiedName~Generated.Pr|FullyQualifiedName~Generated.PR|
+      FullyQualifiedName~Generated.Ps|FullyQualifiedName~Generated.PS|FullyQualifiedName~Generated.Pu|FullyQualifiedName~Generated.PU|
+      FullyQualifiedName~Generated.Pw|FullyQualifiedName~Generated.PW|FullyQualifiedName~Generated.Py)
+  # Q-S was itself a 45-min CANCELLATION, exactly like N-Z and N-S before it.
+  # MEASURED (full local run, all correctness fixes in place): 203 classes,
+  # 83.8 min of summed per-test time, and ~125 min WALL — the ~1.5x factor is
+  # per-class construction/GC that per-test timings do not attribute. So the job
+  # could never pass on a 45-min budget regardless of how many tests were fixed.
+  #
+  # Split 5 ways by MEASURED per-class weight (not class count), which balances
+  # the binding metric — the MAX shard:
+  #     N=3 -> max 29.2 min (~44 min wall, no headroom)
+  #     N=4 -> max 30.5 min (WORSE: the splitter keeps runs contiguous so they
+  #                          stay prefix-expressible, and the greedy pass
+  #                          overloads the tail)
+  #     N=5 -> max 24.9 min (~37 min wall)  <-- chosen
+  #     N=6 -> max 25.1 min (no gain; the tail shard is contiguity-bound)
+  #
+  # Machine-verified: all 203 classes match EXACTLY ONE shard, union == the old
+  # Q-S set, gap-free, non-overlapping, and checked CASE-INSENSITIVELY because
+  # VSTest's FullyQualifiedName~ operator ignores case (a case-sensitive check
+  # emits prefixes that silently overlap — e.g. SPIRAL vs SpiralConvLayer).
+  # Weights are pre-float for the seven heaviest classes, so real times land
+  # BELOW these figures. Every shard name is added to $heavyShards below.
+  - name: ModelFamily - Generated Layers Q-R1
+    project: tests/AiDotNet.Tests/AiDotNetTests.csproj
+    framework: net10.0
+    # 56 classes, 15.9 min. Heaviest: RecurrentGemmaLanguageModel 5.9m, RealESRGANVideo 2.3m.
+    filter: >-
+      FullyQualifiedName~ModelFamilyTests.Generated&
+      (FullyQualifiedName~Generated.Q|FullyQualifiedName~Generated.RA|FullyQualifiedName~Generated.Ra|FullyQualifiedName~Generated.RB|FullyQualifiedName~Generated.RC|FullyQualifiedName~Generated.RE|FullyQualifiedName~Generated.Re|FullyQualifiedName~Generated.RF|FullyQualifiedName~Generated.RI|FullyQualifiedName~Generated.RM|FullyQualifiedName~Generated.RN|FullyQualifiedName~Generated.RoBE)
+  - name: ModelFamily - Generated Layers R2-SAI
+    project: tests/AiDotNet.Tests/AiDotNetTests.csproj
+    framework: net10.0
+    # 24 classes, 11.0 min. Heaviest: RWKV4LanguageModel 1.6m, RoomImpulseResponse 1.5m.
+    filter: >-
+      FullyQualifiedName~ModelFamilyTests.Generated&
+      (FullyQualifiedName~Generated.RP|FullyQualifiedName~Generated.RR|FullyQualifiedName~Generated.RS|FullyQualifiedName~Generated.RT|FullyQualifiedName~Generated.RV|FullyQualifiedName~Generated.RW|FullyQualifiedName~Generated.RoM|FullyQualifiedName~Generated.Robu|FullyQualifiedName~Generated.Rod|FullyQualifiedName~Generated.Roo|FullyQualifiedName~Generated.Rot|FullyQualifiedName~Generated.Row|FullyQualifiedName~Generated.S4|FullyQualifiedName~Generated.S5|FullyQualifiedName~Generated.SAC|FullyQualifiedName~Generated.SAI)
+  - name: ModelFamily - Generated Layers SAL-SAM
+    project: tests/AiDotNet.Tests/AiDotNetTests.csproj
+    framework: net10.0
+    # Only 8 classes but 15.6 min: the two heaviest classes in the whole shard
+    # (SALMONN 6.6m, SambaLanguageModel 6.2m) plus the SAM family. Kept together
+    # because SAL*/SAM* cannot be separated further by prefix.
+    filter: >-
+      FullyQualifiedName~ModelFamilyTests.Generated&
+      (FullyQualifiedName~Generated.SAL|FullyQualifiedName~Generated.SAM|FullyQualifiedName~Generated.Sam)
+  - name: ModelFamily - Generated Layers SAN-Sig
+    project: tests/AiDotNet.Tests/AiDotNetTests.csproj
+    framework: net10.0
+    # 40 classes, 16.4 min. Heaviest: SECBERT 5.5m, SeACo 2.8m.
+    filter: >-
+      FullyQualifiedName~ModelFamilyTests.Generated&
+      (FullyQualifiedName~Generated.SAN|FullyQualifiedName~Generated.SAR|FullyQualifiedName~Generated.Sar|FullyQualifiedName~Generated.SC|FullyQualifiedName~Generated.Sc|FullyQualifiedName~Generated.SE|FullyQualifiedName~Generated.Se|FullyQualifiedName~Generated.Sh|FullyQualifiedName~Generated.Sig)
+  # The previous Sil-Sy job reached the 45-minute job timeout after four
+  # individual MoreData watchdogs. Split its exact prefix union at the
+  # Sq/St boundary so both halves retain headroom even if a future model
+  # approaches its per-test limit.
+  - name: ModelFamily - Generated Layers Sil-Sq
+    project: tests/AiDotNet.Tests/AiDotNetTests.csproj
+    framework: net10.0
+    filter: >-
+      FullyQualifiedName~ModelFamilyTests.Generated&
+      (FullyQualifiedName~Generated.SK|FullyQualifiedName~Generated.SL|FullyQualifiedName~Generated.Sl|
+      FullyQualifiedName~Generated.SO|FullyQualifiedName~Generated.So|FullyQualifiedName~Generated.SP|FullyQualifiedName~Generated.Sp|
+      FullyQualifiedName~Generated.SQ|FullyQualifiedName~Generated.Sq|FullyQualifiedName~Generated.Sil|
+      FullyQualifiedName~Generated.Sim)
+  # SPLIT FROM "St-Sy", also killed by the runner (MemAvailable floor 218 MB) at ~18
+  # minutes with no TRX, on BOTH this run and the baseline. Same treatment: halve the
+  # working set rather than extend the clock. The token set is carried over verbatim so
+  # coverage is unchanged; gap-free + non-overlapping: union == St-Sy.
+  - name: ModelFamily - Generated Layers St-Su
+    project: tests/AiDotNet.Tests/AiDotNetTests.csproj
+    framework: net10.0
+    timeout: 60
+    filter: >-
+      FullyQualifiedName~ModelFamilyTests.Generated&
+      (FullyQualifiedName~Generated.ST|FullyQualifiedName~Generated.St|
+      FullyQualifiedName~Generated.SU|FullyQualifiedName~Generated.Su)
+  - name: ModelFamily - Generated Layers Sv-Sy
+    project: tests/AiDotNet.Tests/AiDotNetTests.csproj
+    framework: net10.0
+    timeout: 60
+    filter: >-
+      FullyQualifiedName~ModelFamilyTests.Generated&
+      (FullyQualifiedName~Generated.SV|FullyQualifiedName~Generated.Sw|
+      FullyQualifiedName~Generated.Sy)
+  # The T-Z tail is 201 model classes / 4,378 tests. T is split in two (see below).
+  # U-Z contains 2,676 tests across 119 classes and hit the 45-minute job limit
+  # after exposing only 999 results. Isolating each substantial initial fixed U/W/X/Y-Z,
+  # but V still reached the limit after 892/1,000 results. Split its 43 classes into four
+  # prefix groups: VA-VF=247, Video=224, Vi-VM=346, Vo-VR=183 tests.
+  # T as a single lane does not fit the 45-minute budget. Measured under runner parity
+  # (--cpus 4, --memory 16g), its 83 classes split into two lanes that each finished:
+  # T A-Tac = 40 classes / 880 tests / 25m26s, T Tem-Tri = 43 classes / 881 tests / 26m21s.
+  # Combined that is ~52 minutes, so the isolated T lane would be cut off at the limit.
+  # The split is balanced on measured per-class cost: TemplateNER (218 s), TriaffineNER
+  # (175 s) and Timer (144 s) all land in the second lane, so the first lane absorbs the
+  # 17-class Tab* family and Tra* to compensate.
+  - name: ModelFamily - Generated Layers T A-Tac
+    project: tests/AiDotNet.Tests/AiDotNetTests.csproj
+    framework: net10.0
+    filter: >-
+      FullyQualifiedName~ModelFamilyTests.Generated&
+      (FullyQualifiedName~Generated.T5R|FullyQualifiedName~Generated.TCD|FullyQualifiedName~Generated.TCN|FullyQualifiedName~Generated.TD3|FullyQualifiedName~Generated.TDP|FullyQualifiedName~Generated.TDT|FullyQualifiedName~Generated.TFC|FullyQualifiedName~Generated.TFG|FullyQualifiedName~Generated.TFT|FullyQualifiedName~Generated.TLB|FullyQualifiedName~Generated.TLe|FullyQualifiedName~Generated.TOT|FullyQualifiedName~Generated.TRI|FullyQualifiedName~Generated.TRP|FullyQualifiedName~Generated.TS2|FullyQualifiedName~Generated.TSF|FullyQualifiedName~Generated.TTT|FullyQualifiedName~Generated.TTV|FullyQualifiedName~Generated.TVA|FullyQualifiedName~Generated.Tab|FullyQualifiedName~Generated.Tac)
+  - name: ModelFamily - Generated Layers T Tem-Tri
+    project: tests/AiDotNet.Tests/AiDotNetTests.csproj
+    framework: net10.0
+    filter: >-
+      FullyQualifiedName~ModelFamilyTests.Generated&
+      (FullyQualifiedName~Generated.Tem|FullyQualifiedName~Generated.Tex|FullyQualifiedName~Generated.Tho|FullyQualifiedName~Generated.Thr|FullyQualifiedName~Generated.TiD|FullyQualifiedName~Generated.TiM|FullyQualifiedName~Generated.Tim|FullyQualifiedName~Generated.Tin|FullyQualifiedName~Generated.Tit|FullyQualifiedName~Generated.Too|FullyQualifiedName~Generated.Tor|FullyQualifiedName~Generated.Tra|FullyQualifiedName~Generated.Tri)
+  - name: ModelFamily - Generated Layers U
+    project: tests/AiDotNet.Tests/AiDotNetTests.csproj
+    framework: net10.0
+    filter: >-
+      FullyQualifiedName~ModelFamilyTests.Generated&FullyQualifiedName~Generated.U
+  - name: ModelFamily - Generated Layers VA-VF
+    project: tests/AiDotNet.Tests/AiDotNetTests.csproj
+    framework: net10.0
+    filter: >-
+      FullyQualifiedName~ModelFamilyTests.Generated&
+      (FullyQualifiedName~Generated.VA|FullyQualifiedName~Generated.Va|FullyQualifiedName~Generated.Ve|FullyQualifiedName~Generated.VF)
+  - name: ModelFamily - Generated Layers Video
+    project: tests/AiDotNet.Tests/AiDotNetTests.csproj
+    framework: net10.0
+    filter: >-
+      FullyQualifiedName~ModelFamilyTests.Generated&FullyQualifiedName~Generated.Video
+  - name: ModelFamily - Generated Layers Vi-VM
+    project: tests/AiDotNet.Tests/AiDotNetTests.csproj
+    framework: net10.0
+    filter: >-
+      FullyQualifiedName~ModelFamilyTests.Generated&
+      ((FullyQualifiedName~Generated.Vi|FullyQualifiedName~Generated.VI&FullyQualifiedName!~Generated.Video)|FullyQualifiedName~Generated.VM)
+  - name: ModelFamily - Generated Layers Vo-VR
+    project: tests/AiDotNet.Tests/AiDotNetTests.csproj
+    framework: net10.0
+    filter: >-
+      FullyQualifiedName~ModelFamilyTests.Generated&
+      (FullyQualifiedName~Generated.Vo|FullyQualifiedName~Generated.VR)
+  - name: ModelFamily - Generated Layers W
+    project: tests/AiDotNet.Tests/AiDotNetTests.csproj
+    framework: net10.0
+    filter: >-
+      FullyQualifiedName~ModelFamilyTests.Generated&FullyQualifiedName~Generated.W
+  - name: ModelFamily - Generated Layers X
+    project: tests/AiDotNet.Tests/AiDotNetTests.csproj
+    framework: net10.0
+    filter: >-
+      FullyQualifiedName~ModelFamilyTests.Generated&FullyQualifiedName~Generated.X
+  - name: ModelFamily - Generated Layers Y-Z
+    project: tests/AiDotNet.Tests/AiDotNetTests.csproj
+    framework: net10.0
+    filter: >-
+      FullyQualifiedName~ModelFamilyTests.Generated&
+      (FullyQualifiedName~Generated.Y|FullyQualifiedName~Generated.Z)
+  # Previously-uncovered model families (NO shard ran these): CodeModel
+  # (CodeBERT), Forecasting (MGTSD), Segmentation (SwinUNETR), Survival
+  # (RandomSurvivalForest). Small (1 model each) — one combined shard.
+  - name: ModelFamily - Code/Forecast/Segment/Survival
+    project: tests/AiDotNet.Tests/AiDotNetTests.csproj
+    framework: net10.0
+    filter: >-
+      (FullyQualifiedName~ModelFamilyTests.CodeModel|FullyQualifiedName~ModelFamilyTests.Forecasting|FullyQualifiedName~ModelFamilyTests.Segmentation|FullyQualifiedName~ModelFamilyTests.Survival)
+  # =====================================================================
+  # INTEGRATION TESTS — previously had NO shard at all (~686 test files,
+  # incl. Document AI, Finance, ComputerVision, Audio, Video, MetaLearning,
+  # Optimizers, Preprocessing, Statistics, ...). Sharded by subdir-namespace
+  # first letter (IntegrationTests.<Letter>) so coverage is gap-free and
+  # per-shard footprint stays bounded. Model-instantiating groups are
+  # serialized (see $heavyShards in the run step).
+  # =====================================================================
+  - name: Integration A-B
+    project: tests/AiDotNet.Tests/AiDotNetTests.csproj
+    framework: net10.0
+    filter: 'Category!=GPU&Category!=Stress&Category!=Sweep&(FullyQualifiedName~AiDotNet.Tests.IntegrationTests.A|FullyQualifiedName~AiDotNet.Tests.IntegrationTests.B)'
+  # Integration C was the largest Integration shard (~2300 cases across
+  # 12 C* namespaces) and the only one forced fully serial — its
+  # ComputerVision namespace instantiates paper-scale segmentation
+  # models that OOM the 16 GB runner under parallel collections. Run
+  # serially it never finished before the concurrency-group cancel
+  # superseded the master run, so it was perpetually red. Split into the
+  # heavy ComputerVision namespace (kept serial) and a Core complement
+  # (everything else, which is algorithm/config/causal tests with small
+  # models — safe to run parallel and fast). The complement filter keeps
+  # the two gap-free + non-overlapping (their union == the old C filter)
+  # and future-proof: any new C* namespace lands in Core automatically.
+  # SPLIT FROM "Integration C - ComputerVision", killed by the runner at ~6.5 minutes
+  # (MemAvailable floor 114 MB) with no TRX on BOTH this run and the baseline -- so the
+  # Detection suite this branch changed had NO signal on either side of the comparison.
+  # 15 classes / ~680 tests of paper-scale detection and segmentation backbones in one
+  # process is the whole problem; three shards of ~230 each fit the envelope. Gap-free and
+  # non-overlapping by class-name prefix: ComputerVision* | the eight named model suites |
+  # Segmentation*, which together are exactly the 15 classes in the namespace.
+  - name: Integration C - ComputerVision Detection
+    project: tests/AiDotNet.Tests/AiDotNetTests.csproj
+    framework: net10.0
+    timeout: 60
+    filter: 'Category!=GPU&Category!=Stress&Category!=Sweep&FullyQualifiedName~IntegrationTests.ComputerVision.ComputerVision'
+  - name: Integration C - ComputerVision Segmentation Models
+    project: tests/AiDotNet.Tests/AiDotNetTests.csproj
+    framework: net10.0
+    timeout: 60
+    filter: >-
+      Category!=GPU&Category!=Stress&Category!=Sweep&
+      (FullyQualifiedName~IntegrationTests.ComputerVision.FoundationSegmentation|
+      FullyQualifiedName~IntegrationTests.ComputerVision.InstanceSegmentation|
+      FullyQualifiedName~IntegrationTests.ComputerVision.OpenVocabInteractiveReferringSegmentation|
+      FullyQualifiedName~IntegrationTests.ComputerVision.PanopticMambaEfficientSegmentation|
+      FullyQualifiedName~IntegrationTests.ComputerVision.PointCloudMedicalSegmentation|
+      FullyQualifiedName~IntegrationTests.ComputerVision.SegFormer|
+      FullyQualifiedName~IntegrationTests.ComputerVision.SemanticSegmentation|
+      FullyQualifiedName~IntegrationTests.ComputerVision.VideoDiffusionSegmentation)
+  - name: Integration C - ComputerVision Segmentation Contracts
+    project: tests/AiDotNet.Tests/AiDotNetTests.csproj
+    framework: net10.0
+    timeout: 60
+    filter: 'Category!=GPU&Category!=Stress&Category!=Sweep&FullyQualifiedName~IntegrationTests.ComputerVision.Segmentation'
+  - name: Integration C - Core
+    project: tests/AiDotNet.Tests/AiDotNetTests.csproj
+    framework: net10.0
+    filter: 'Category!=GPU&Category!=Stress&Category!=Sweep&FullyQualifiedName~AiDotNet.Tests.IntegrationTests.C&FullyQualifiedName!~AiDotNet.Tests.IntegrationTests.ComputerVision'
+  - name: Integration D
+    project: tests/AiDotNet.Tests/AiDotNetTests.csproj
+    framework: net10.0
+    filter: 'Category!=GPU&Category!=Stress&Category!=Sweep&FullyQualifiedName~AiDotNet.Tests.IntegrationTests.D'
+  - name: Integration E-G
+    project: tests/AiDotNet.Tests/AiDotNetTests.csproj
+    framework: net10.0
+    filter: 'Category!=GPU&Category!=Stress&Category!=Sweep&(FullyQualifiedName~AiDotNet.Tests.IntegrationTests.E|FullyQualifiedName~AiDotNet.Tests.IntegrationTests.F|FullyQualifiedName~AiDotNet.Tests.IntegrationTests.G)'
+  - name: Integration H-L
+    project: tests/AiDotNet.Tests/AiDotNetTests.csproj
+    framework: net10.0
+    filter: 'Category!=GPU&Category!=Stress&Category!=Sweep&Category!=SerialPerf&(FullyQualifiedName~AiDotNet.Tests.IntegrationTests.H|FullyQualifiedName~AiDotNet.Tests.IntegrationTests.I|FullyQualifiedName~AiDotNet.Tests.IntegrationTests.J|FullyQualifiedName~AiDotNet.Tests.IntegrationTests.K|FullyQualifiedName~AiDotNet.Tests.IntegrationTests.L)'
+  - name: Integration M
+    project: tests/AiDotNet.Tests/AiDotNetTests.csproj
+    framework: net10.0
+    filter: 'Category!=GPU&Category!=Stress&Category!=Sweep&FullyQualifiedName~AiDotNet.Tests.IntegrationTests.M'
+  - name: Integration N-O
+    project: tests/AiDotNet.Tests/AiDotNetTests.csproj
+    framework: net10.0
+    # AdvancedNeuralNetworkModelsIntegrationTests contains legacy model
+    # smoke tests for models now owned by ModelFamily.NeuralNetworks.
+    # Keep its integration-only models in this shard, but do not run
+    # duplicate model-family invariants a second time under Integration.
+    filter: 'Category!=GPU&Category!=Stress&Category!=Sweep&Category!=ModelFamilyDuplicate&Category!=SerialPerf&(FullyQualifiedName~AiDotNet.Tests.IntegrationTests.N|FullyQualifiedName~AiDotNet.Tests.IntegrationTests.O)'
+  - name: Integration P-Q
+    project: tests/AiDotNet.Tests/AiDotNetTests.csproj
+    framework: net10.0
+    filter: 'Category!=GPU&Category!=Stress&Category!=Sweep&(FullyQualifiedName~AiDotNet.Tests.IntegrationTests.P|FullyQualifiedName~AiDotNet.Tests.IntegrationTests.Q)'
+  - name: Integration R
+    project: tests/AiDotNet.Tests/AiDotNetTests.csproj
+    framework: net10.0
+    filter: 'Category!=GPU&Category!=Stress&Category!=Sweep&FullyQualifiedName~AiDotNet.Tests.IntegrationTests.R'
+  - name: Integration S
+    project: tests/AiDotNet.Tests/AiDotNetTests.csproj
+    framework: net10.0
+    filter: 'Category!=GPU&Category!=Stress&Category!=Sweep&FullyQualifiedName~AiDotNet.Tests.IntegrationTests.S'
+  - name: Integration T-Z
+    project: tests/AiDotNet.Tests/AiDotNetTests.csproj
+    framework: net10.0
+    filter: 'Category!=GPU&Category!=Stress&Category!=Sweep&(FullyQualifiedName~AiDotNet.Tests.IntegrationTests.T|FullyQualifiedName~AiDotNet.Tests.IntegrationTests.U|FullyQualifiedName~AiDotNet.Tests.IntegrationTests.V|FullyQualifiedName~AiDotNet.Tests.IntegrationTests.W|FullyQualifiedName~AiDotNet.Tests.IntegrationTests.X|FullyQualifiedName~AiDotNet.Tests.IntegrationTests.Y|FullyQualifiedName~AiDotNet.Tests.IntegrationTests.Z)'
+  # Dedicated SERIAL lane for single-process perf/memory guards (CpuToWallRatio,
+  # MemoryBudget). Tagged Category=SerialPerf and excluded from Integration N-O above,
+  # they run ALONE here so no sibling collection contends for CPU/memory and invalidates
+  # the measurement — keeps the assertions at full strength (no bound relaxation). Tiny
+  # (2 classes), so a whole shard is cheap.
+  - name: Integration - Serial Perf
+    project: tests/AiDotNet.Tests/AiDotNetTests.csproj
+    framework: net10.0
+    filter: 'Category=SerialPerf&Category!=GPU'
+  # =====================================================================
+  # TOP-LEVEL TEST NAMESPACES that no shard covered (distinct from the
+  # UnitTests.* and IntegrationTests.* trees).
+  # =====================================================================
+  - name: TopLevel - FederatedLearning
+    project: tests/AiDotNet.Tests/AiDotNetTests.csproj
+    framework: net10.0
+    filter: 'Category!=GPU&Category!=Stress&Category!=Sweep&FullyQualifiedName~AiDotNet.Tests.FederatedLearning'
+  - name: TopLevel - Audio/Onnx/Tokenization
+    project: tests/AiDotNet.Tests/AiDotNetTests.csproj
+    framework: net10.0
+    filter: 'Category!=GPU&Category!=Stress&Category!=Sweep&(FullyQualifiedName~AiDotNet.Tests.Audio|FullyQualifiedName~AiDotNet.Tests.Onnx|FullyQualifiedName~AiDotNet.Tests.Tokenization)'
+  - name: TopLevel - Components/Adversarial/EndToEnd
+    project: tests/AiDotNet.Tests/AiDotNetTests.csproj
+    framework: net10.0
+    filter: 'Category!=GPU&Category!=Stress&Category!=Sweep&(FullyQualifiedName~AiDotNet.Tests.ComponentTests|FullyQualifiedName~AiDotNet.Tests.AdversarialRobustness|FullyQualifiedName~AiDotNet.Tests.EndToEndTests)'
+  # =====================================================================
+  # SERVING TESTS
+  # =====================================================================
+  - name: AiDotNet.Serving.Tests
+    project: tests/AiDotNet.Serving.Tests/AiDotNet.Serving.Tests.csproj
+    framework: net10.0
+    filter: 'Category!=GPU&Category!=Stress'

--- a/.github/test-shards.yml
+++ b/.github/test-shards.yml
@@ -681,7 +681,7 @@ shard:
     framework: net10.0
     filter: >-
       FullyQualifiedName~ModelFamilyTests.Generated&
-      ((FullyQualifiedName~Generated.Vi|FullyQualifiedName~Generated.VI&FullyQualifiedName!~Generated.Video)|FullyQualifiedName~Generated.VM)
+      (((FullyQualifiedName~Generated.Vi|FullyQualifiedName~Generated.VI)&FullyQualifiedName!~Generated.Video)|FullyQualifiedName~Generated.VM)
   - name: ModelFamily - Generated Layers Vo-VR
     project: tests/AiDotNet.Tests/AiDotNetTests.csproj
     framework: net10.0

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -549,10 +549,129 @@ jobs:
         run: gh run cancel ${{ github.run_id }} --repo ${{ github.repository }}
 
 
+  # ---------------------------------------------------------------------------------------------
+  # Which shards does this change actually need?
+  #
+  # Answered from coverage: the nightly map records which source lines each shard executed, so a
+  # shard is selected when it executed a line this PR touched. Everything uncertain - no map, an
+  # unmapped file, a build or workflow edit - emits the FULL list instead. A wrong escalation costs
+  # runner minutes; a wrong omission ships a regression, and those are not symmetric.
+  # ---------------------------------------------------------------------------------------------
+  select-shards:
+    name: Select shards
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+    outputs:
+      matrix: ${{ steps.select.outputs.matrix }}
+      escalated: ${{ steps.select.outputs.escalated }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v4
+        with:
+          # Full history: the selector diffs from the MAP's commit, which is not reachable from a
+          # shallow clone and is not an ancestor of any PR branched before the map was built.
+          fetch-depth: 0
+
+      - name: Download the shard map
+        id: map
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # The map is published by test-impact-map.yml on a schedule. Absent, stale or
+          # unreadable are all handled the same way downstream: run everything.
+          run_id=$(gh run list --workflow test-impact-map.yml --branch master                      --status success --limit 1 --json databaseId --jq '.[0].databaseId')
+          if [ -z "$run_id" ]; then
+            echo "no successful map build found"
+            exit 0
+          fi
+          gh run download "$run_id" --name shard-map --dir map || echo "map artifact unavailable"
+
+      - name: Select
+        id: select
+        shell: pwsh
+        run: |
+          $all = @(yq -o=json -I=0 '.shard' .github/test-shards.yml | ConvertFrom-Json)
+          if ($all.Count -eq 0) {
+            Write-Host '::error::.github/test-shards.yml yielded no shards'
+            exit 1
+          }
+          Write-Host "shard list: $($all.Count) shard(s)"
+
+          $escalate = $true
+          $selected = @()
+
+          # Only pull requests get a reduced matrix.
+          #
+          # A master push MUST run everything, and not out of caution: the nightly map is built from
+          # a master run's digests, and any shard that did not run produced no digest, so the map
+          # would mark it always-run. Selecting on master therefore feeds its own gaps back into
+          # the map, and the feature decays a shard at a time into running everything - while
+          # looking like it works. Merge-group runs are the last gate before master and are not
+          # worth reducing either.
+          $isPullRequest = '${{ github.event_name }}' -eq 'pull_request'
+          if (-not $isPullRequest) {
+            Write-Host "event is '${{ github.event_name }}', not a pull request - running the full matrix"
+          }
+          elseif (Test-Path map/shard-map.json) {
+            # No base ref: the diff is taken from the map's own commit, which is the only
+            # reference whose line numbers the map's ranges are expressed in.
+            & ./tools/TestImpact/Select-Shards.ps1 `
+                -MapFile map/shard-map.json -OutFile selection.json
+            $result = Get-Content selection.json -Raw | ConvertFrom-Json
+            $escalate = [bool] $result.escalate
+            $selected = @($result.shards)
+          }
+          else {
+            Write-Host '::warning::no shard map - running the full matrix'
+          }
+
+          if ($escalate) {
+            $matrixShards = $all
+            Write-Host "escalated: running all $($all.Count) shard(s)"
+          }
+          else {
+            $wanted = [System.Collections.Generic.HashSet[string]]::new(
+                [string[]] $selected, [System.StringComparer]::Ordinal)
+            $matrixShards = @($all | Where-Object { $wanted.Contains([string] $_.name) })
+
+            # Every selected name MUST exist in the shard list. A rename that lands in
+            # test-shards.yml but not in the map would otherwise silently shrink the matrix, and
+            # a shard that quietly stops running is exactly the failure this whole feature must
+            # not introduce.
+            if ($matrixShards.Count -ne $wanted.Count) {
+              $missing = $wanted | Where-Object { $n = $_; -not ($all | Where-Object { $_.name -eq $n }) }
+              Write-Host "::warning::selected shard(s) absent from test-shards.yml: $($missing -join ', ') - running the full matrix"
+              $matrixShards = $all
+              $escalate = $true
+            }
+            else {
+              Write-Host "selected $($matrixShards.Count) of $($all.Count) shard(s)"
+              foreach ($s in $matrixShards) { Write-Host "  $($s.name)" }
+            }
+          }
+
+          # An empty matrix does not fail - it silently runs no tests and lets every downstream
+          # gate pass. That is the one outcome worse than running everything, so it is a hard error.
+          if ($matrixShards.Count -eq 0) {
+            Write-Host '::error::shard selection produced an empty matrix'
+            exit 1
+          }
+
+          $json = ConvertTo-Json -InputObject @($matrixShards) -Depth 5 -Compress
+          "matrix=$json" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+          "escalated=$($escalate.ToString().ToLowerInvariant())" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+
+          $summary = if ($escalate) { "Running the full matrix ($($all.Count) shards)." }
+                     else { "Selected **$($matrixShards.Count)** of $($all.Count) shards from coverage." }
+          "### Shard selection`n`n$summary" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8
+
   test-net10-sharded:
     name: Tests (${{ matrix.shard.framework }}) - ${{ matrix.shard.name }}
     runs-on: ubuntu-latest
-    needs: [build, validation-source]
+    needs: [build, validation-source, select-shards]
     # A shard may raise its own ceiling; the default also reserves five minutes beyond the
     # historical cap for the targeted PR-new retry performed by the regression analyzer.
     timeout-minutes: ${{ matrix.shard.timeout || 50 }}
@@ -563,838 +682,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        shard:
-          # =====================================================================
-          # UNIT TESTS — manually written tests in tests/AiDotNet.Tests/UnitTests/
-          # =====================================================================
-          - name: Unit - 01 Activation/Attention/Autodiff
-            project: tests/AiDotNet.Tests/AiDotNetTests.csproj
-            framework: net10.0
-            filter: 'Category!=GPU&Category!=Stress&Category!=Sweep&(FullyQualifiedName~UnitTests.ActivationFunctions|FullyQualifiedName~UnitTests.Attention|FullyQualifiedName~UnitTests.Autodiff)'
-          - name: Unit - 02 AutoML/Data/Diagnostics
-            project: tests/AiDotNet.Tests/AiDotNetTests.csproj
-            framework: net10.0
-            filter: 'Category!=GPU&Category!=Stress&Category!=Sweep&(FullyQualifiedName~UnitTests.AutoML|FullyQualifiedName~UnitTests.Data|FullyQualifiedName~UnitTests.Diagnostics)'
-          - name: Unit - 03a Diffusion Core/Schedulers/Encoding
-            project: tests/AiDotNet.Tests/AiDotNetTests.csproj
-            framework: net10.0
-            filter: 'Category!=GPU&Category!=Stress&Category!=Sweep&(FullyQualifiedName~UnitTests.Encoding|FullyQualifiedName~UnitTests.Diffusion.AudioProcessingTests|FullyQualifiedName~UnitTests.Diffusion.MemoryManagementTests|FullyQualifiedName~UnitTests.Diffusion.SchedulerTests|FullyQualifiedName~UnitTests.Diffusion.Conditioning|FullyQualifiedName~UnitTests.Diffusion.Schedulers)'
-          - name: Unit - 03b1 Diffusion Preprocessors
-            project: tests/AiDotNet.Tests/AiDotNetTests.csproj
-            framework: net10.0
-            filter: 'Category!=GPU&Category!=Stress&Category!=Sweep&FullyQualifiedName~UnitTests.Diffusion.Models&FullyQualifiedName~PreprocessorContractTests'
-          - name: Unit - 03b2 Diffusion DDPM
-            project: tests/AiDotNet.Tests/AiDotNetTests.csproj
-            framework: net10.0
-            filter: 'Category!=GPU&Category!=Stress&Category!=Sweep&FullyQualifiedName~UnitTests.Diffusion.Models&FullyQualifiedName~DDPMModelTests'
-          - name: Unit - 03b3 Diffusion Control Guidance/Adapters
-            project: tests/AiDotNet.Tests/AiDotNetTests.csproj
-            framework: net10.0
-            filter: >-
-              Category!=GPU&Category!=Stress&FullyQualifiedName~UnitTests.Diffusion.Models&
-              FullyQualifiedName~ControlModelContractTests&
-              (FullyQualifiedName~PerturbedAttentionGuidance|FullyQualifiedName~SelfAttentionGuidance|FullyQualifiedName~DynamicCFGScheduler|FullyQualifiedName~RescaledCFG|FullyQualifiedName~AdaptiveProjectedGuidance|FullyQualifiedName~IPAdapterPlusModel_DefaultConstructor|FullyQualifiedName~IPAdapterFaceIDPlusModel_DefaultConstructor|FullyQualifiedName~IPAdapterModel_DefaultConstructor)
-          - name: Unit - 03b4 Diffusion ControlNet Core A
-            project: tests/AiDotNet.Tests/AiDotNetTests.csproj
-            framework: net10.0
-            filter: >-
-              Category!=GPU&Category!=Stress&FullyQualifiedName~UnitTests.Diffusion.Models&
-              FullyQualifiedName~ControlModelContractTests&
-              (FullyQualifiedName~ControlNetPlusPlusModel_DefaultConstructor|FullyQualifiedName~ControlNetFluxModel_DefaultConstructor|FullyQualifiedName~ControlNetSD3Model_DefaultConstructor|FullyQualifiedName~ControlNetUnionProModel_DefaultConstructor|FullyQualifiedName~ControlNetPlusPlusFluxModel_DefaultConstructor|FullyQualifiedName~ControlNetPlusPlusModel_Clone|FullyQualifiedName~ControlNetFluxModel_Clone)
-          - name: Unit - 03b5 Diffusion ControlNet Core B
-            project: tests/AiDotNet.Tests/AiDotNetTests.csproj
-            framework: net10.0
-            filter: >-
-              Category!=GPU&Category!=Stress&FullyQualifiedName~UnitTests.Diffusion.Models&
-              FullyQualifiedName~ControlModelContractTests&
-              (FullyQualifiedName~ControlNetLiteModel_DefaultConstructor|FullyQualifiedName~ControlNetQRModel_DefaultConstructor|FullyQualifiedName~ReferenceOnlyModel_DefaultConstructor|FullyQualifiedName~StyleAlignedModel_DefaultConstructor|FullyQualifiedName~ControlNetTileModel_DefaultConstructor|FullyQualifiedName~ControlNetInpaintingModel_DefaultConstructor|FullyQualifiedName~ControlNeXtModel_DefaultConstructor|FullyQualifiedName~ControlARModel_DefaultConstructor)
-          - name: Unit - 03c1 Diffusion Contracts A-C
-            project: tests/AiDotNet.Tests/AiDotNetTests.csproj
-            framework: net10.0
-            filter: 'Category!=GPU&Category!=Stress&Category!=Sweep&FullyQualifiedName~UnitTests.Diffusion.Models&(FullyQualifiedName~DiffusionModelContractTests.A|FullyQualifiedName~DiffusionModelContractTests.B|FullyQualifiedName~DiffusionModelContractTests.C)'
-          - name: Unit - 03c2 Diffusion Contracts D-I
-            project: tests/AiDotNet.Tests/AiDotNetTests.csproj
-            framework: net10.0
-            filter: 'Category!=GPU&Category!=Stress&Category!=Sweep&FullyQualifiedName~UnitTests.Diffusion.Models&(FullyQualifiedName~DiffusionModelContractTests.D|FullyQualifiedName~DiffusionModelContractTests.E|FullyQualifiedName~DiffusionModelContractTests.F|FullyQualifiedName~DiffusionModelContractTests.G|FullyQualifiedName~DiffusionModelContractTests.H|FullyQualifiedName~DiffusionModelContractTests.I)'
-          - name: Unit - 03c3 Diffusion Contracts J-R
-            project: tests/AiDotNet.Tests/AiDotNetTests.csproj
-            framework: net10.0
-            filter: 'Category!=GPU&Category!=Stress&Category!=Sweep&FullyQualifiedName~UnitTests.Diffusion.Models&(FullyQualifiedName~DiffusionModelContractTests.J|FullyQualifiedName~DiffusionModelContractTests.K|FullyQualifiedName~DiffusionModelContractTests.L|FullyQualifiedName~DiffusionModelContractTests.M|FullyQualifiedName~DiffusionModelContractTests.N|FullyQualifiedName~DiffusionModelContractTests.O|FullyQualifiedName~DiffusionModelContractTests.P|FullyQualifiedName~DiffusionModelContractTests.Q|FullyQualifiedName~DiffusionModelContractTests.R)'
-          - name: Unit - 03c4 Diffusion Contracts S
-            project: tests/AiDotNet.Tests/AiDotNetTests.csproj
-            framework: net10.0
-            filter: 'Category!=GPU&Category!=Stress&Category!=Sweep&FullyQualifiedName~UnitTests.Diffusion.Models&FullyQualifiedName~DiffusionModelContractTests.S'
-          - name: Unit - 03c5 Diffusion Contracts T-Z
-            project: tests/AiDotNet.Tests/AiDotNetTests.csproj
-            framework: net10.0
-            filter: 'Category!=GPU&Category!=Stress&Category!=Sweep&FullyQualifiedName~UnitTests.Diffusion.Models&(FullyQualifiedName~DiffusionModelContractTests.T|FullyQualifiedName~DiffusionModelContractTests.U|FullyQualifiedName~DiffusionModelContractTests.V|FullyQualifiedName~DiffusionModelContractTests.W|FullyQualifiedName~DiffusionModelContractTests.X|FullyQualifiedName~DiffusionModelContractTests.Y|FullyQualifiedName~DiffusionModelContractTests.Z)'
-          - name: Unit - 03c6 Editing Contracts A-I
-            project: tests/AiDotNet.Tests/AiDotNetTests.csproj
-            framework: net10.0
-            filter: 'Category!=GPU&Category!=Stress&Category!=Sweep&FullyQualifiedName~UnitTests.Diffusion.Models&(FullyQualifiedName~EditingModelContractTests.A|FullyQualifiedName~EditingModelContractTests.B|FullyQualifiedName~EditingModelContractTests.C|FullyQualifiedName~EditingModelContractTests.D|FullyQualifiedName~EditingModelContractTests.E|FullyQualifiedName~EditingModelContractTests.F|FullyQualifiedName~EditingModelContractTests.G|FullyQualifiedName~EditingModelContractTests.H|FullyQualifiedName~EditingModelContractTests.I)'
-          - name: Unit - 03c7 Editing Contracts J-Z
-            project: tests/AiDotNet.Tests/AiDotNetTests.csproj
-            framework: net10.0
-            filter: 'Category!=GPU&Category!=Stress&Category!=Sweep&FullyQualifiedName~UnitTests.Diffusion.Models&(FullyQualifiedName~EditingModelContractTests.J|FullyQualifiedName~EditingModelContractTests.K|FullyQualifiedName~EditingModelContractTests.L|FullyQualifiedName~EditingModelContractTests.M|FullyQualifiedName~EditingModelContractTests.N|FullyQualifiedName~EditingModelContractTests.O|FullyQualifiedName~EditingModelContractTests.P|FullyQualifiedName~EditingModelContractTests.Q|FullyQualifiedName~EditingModelContractTests.R|FullyQualifiedName~EditingModelContractTests.S|FullyQualifiedName~EditingModelContractTests.T|FullyQualifiedName~EditingModelContractTests.U|FullyQualifiedName~EditingModelContractTests.V|FullyQualifiedName~EditingModelContractTests.W|FullyQualifiedName~EditingModelContractTests.X|FullyQualifiedName~EditingModelContractTests.Y|FullyQualifiedName~EditingModelContractTests.Z)'
-          - name: Unit - 03d1 Diffusion FastGen Image/VAE
-            project: tests/AiDotNet.Tests/AiDotNetTests.csproj
-            framework: net10.0
-            filter: >-
-              Category!=GPU&Category!=Stress&FullyQualifiedName~UnitTests.Diffusion.Models&
-              FullyQualifiedName~FastGenContractTests&
-              (FullyQualifiedName~Flux2Model_DefaultConstructor|FullyQualifiedName~SANAModel_DefaultConstructor|FullyQualifiedName~StableDiffusion35Model_DefaultConstructor|FullyQualifiedName~LuminaImage2Model_DefaultConstructor|FullyQualifiedName~HiDreamModel_DefaultConstructor|FullyQualifiedName~CogView4Model_DefaultConstructor|FullyQualifiedName~PlaygroundV3Model_DefaultConstructor|FullyQualifiedName~Imagen3Model_DefaultConstructor|FullyQualifiedName~MeissonicModel_DefaultConstructor|FullyQualifiedName~RecraftV3Model_DefaultConstructor|FullyQualifiedName~Ideogram3Model_DefaultConstructor|FullyQualifiedName~MidJourneyV7Model_DefaultConstructor|FullyQualifiedName~DeepCompressionVAE_DefaultConstructor|FullyQualifiedName~EQVAEModel_DefaultConstructor|FullyQualifiedName~LiteVAEModel_DefaultConstructor|FullyQualifiedName~SDXLVAEModel_DefaultConstructor)
-          - name: Unit - 03d2 Diffusion FastGen Consistency/Turbo
-            project: tests/AiDotNet.Tests/AiDotNetTests.csproj
-            framework: net10.0
-            filter: >-
-              Category!=GPU&Category!=Stress&FullyQualifiedName~UnitTests.Diffusion.Models&
-              FullyQualifiedName~FastGenContractTests&
-              (FullyQualifiedName~ImprovedConsistencyModel_DefaultConstructor|FullyQualifiedName~EasyConsistencyModel_DefaultConstructor|FullyQualifiedName~MultiStepConsistencyModel_DefaultConstructor|FullyQualifiedName~MultistepLCModel_DefaultConstructor|FullyQualifiedName~TrainingEfficientLCM_DefaultConstructor|FullyQualifiedName~SDXLTurboModel_DefaultConstructor|FullyQualifiedName~SDXLLightningModel_DefaultConstructor|FullyQualifiedName~HyperSDModel_DefaultConstructor|FullyQualifiedName~DMD2Model_DefaultConstructor|FullyQualifiedName~SenseFlowModel_DefaultConstructor|FullyQualifiedName~SANASprintModel_DefaultConstructor|FullyQualifiedName~SwiftBrushModel_DefaultConstructor|FullyQualifiedName~FlashDiffusionModel_DefaultConstructor)
-          - name: Unit - 03d3 Diffusion FastGen Flow/AR
-            project: tests/AiDotNet.Tests/AiDotNetTests.csproj
-            framework: net10.0
-            filter: >-
-              Category!=GPU&Category!=Stress&FullyQualifiedName~UnitTests.Diffusion.Models&
-              FullyQualifiedName~FastGenContractTests&
-              (FullyQualifiedName~PCMModel_DefaultConstructor|FullyQualifiedName~TCDModel_DefaultConstructor|FullyQualifiedName~InstaFlowModel_DefaultConstructor|FullyQualifiedName~FlowMapModel_DefaultConstructor|FullyQualifiedName~SCottModel_DefaultConstructor|FullyQualifiedName~PeRFlowModel_DefaultConstructor|FullyQualifiedName~SiDModel_DefaultConstructor|FullyQualifiedName~SiDDiTModel_DefaultConstructor|FullyQualifiedName~SD3TurboModel_DefaultConstructor|FullyQualifiedName~FluxSchnellModel_DefaultConstructor|FullyQualifiedName~SD3FlashModel_DefaultConstructor|FullyQualifiedName~Flux2SchnellModel_DefaultConstructor|FullyQualifiedName~PixArtDeltaLCMModel_DefaultConstructor|FullyQualifiedName~TransfusionModel_DefaultConstructor|FullyQualifiedName~MARModel_DefaultConstructor|FullyQualifiedName~ARDiffusionModel_DefaultConstructor|FullyQualifiedName~AutoRegressiveMaskedDiffusion_DefaultConstructor)
-          - name: Unit - 03d4 Diffusion FastGen Schedulers
-            project: tests/AiDotNet.Tests/AiDotNetTests.csproj
-            framework: net10.0
-            filter: >-
-              Category!=GPU&Category!=Stress&FullyQualifiedName~UnitTests.Diffusion.Models&
-              FullyQualifiedName~FastGenContractTests&
-              (FullyQualifiedName~RectifiedFlowScheduler_DefaultConstructor|FullyQualifiedName~FlowDPMSolverScheduler_DefaultConstructor|FullyQualifiedName~DPMSolverV3Scheduler_DefaultConstructor|FullyQualifiedName~SASolverScheduler_DefaultConstructor)
-          - name: Unit - 03d5 Diffusion FastGen SDXL State
-            project: tests/AiDotNet.Tests/AiDotNetTests.csproj
-            framework: net10.0
-            filter: >-
-              Category!=GPU&Category!=Stress&FullyQualifiedName~UnitTests.Diffusion.Models&
-              FullyQualifiedName~FastGenContractTests&
-              (FullyQualifiedName~SDXLTurboModel_Clone|FullyQualifiedName~ImprovedConsistencyModel_Clone|FullyQualifiedName~SDXLTurboModel_GetSetParameters|FullyQualifiedName~SDXLTurboModel_GetModelMetadata)
-          - name: Unit - 03d6 Diffusion FastGen Flux State
-            project: tests/AiDotNet.Tests/AiDotNetTests.csproj
-            framework: net10.0
-            filter: >-
-              Category!=GPU&Category!=Stress&FullyQualifiedName~UnitTests.Diffusion.Models&
-              FullyQualifiedName~FastGenContractTests&
-              (FullyQualifiedName~FluxSchnellModel_Clone|FullyQualifiedName~Flux2Model_GetSetParameters|FullyQualifiedName~FluxSchnellModel_GetModelMetadata|FullyQualifiedName~SANAModel_GetModelMetadata)
-          - name: Unit - 03d7 Diffusion FastGen Distillation
-            project: tests/AiDotNet.Tests/AiDotNetTests.csproj
-            framework: net10.0
-            filter: >-
-              Category!=GPU&Category!=Stress&FullyQualifiedName~UnitTests.Diffusion.Models&
-              FullyQualifiedName~FastGenContractTests&
-              (FullyQualifiedName~OSDSModel_DefaultConstructor|FullyQualifiedName~ScoreDistillationSampling_Constructor|FullyQualifiedName~VariationalScoreDistillation_Constructor|FullyQualifiedName~ConsistencyDistillationSampling_Constructor|FullyQualifiedName~IntervalScoreMatching_Constructor|FullyQualifiedName~DenoisedScoreDistillation_Constructor|FullyQualifiedName~UnifiedDistillationSampling_Constructor|FullyQualifiedName~RewardScoreDistillation_Constructor|FullyQualifiedName~SemanticScoreDistillation_Constructor|FullyQualifiedName~FastGenContractTests.ConsistencyModel_DefaultConstructor)
-          - name: Unit - 03d8 Diffusion New Conditioners
-            project: tests/AiDotNet.Tests/AiDotNetTests.csproj
-            framework: net10.0
-            filter: 'Category!=GPU&Category!=Stress&Category!=Sweep&FullyQualifiedName~UnitTests.Diffusion.Models&FullyQualifiedName~NewConditionerContractTests'
-          - name: Unit - 04 Feature/Fit/Fitness/Genetics
-            project: tests/AiDotNet.Tests/AiDotNetTests.csproj
-            framework: net10.0
-            filter: 'Category!=GPU&Category!=Stress&Category!=Sweep&(FullyQualifiedName~UnitTests.FeatureSelectors|FullyQualifiedName~UnitTests.FitDetectors|FullyQualifiedName~UnitTests.FitnessCalculators|FullyQualifiedName~UnitTests.Genetics)'
-          - name: Unit - 05 Helpers/Inference/Interpretability
-            project: tests/AiDotNet.Tests/AiDotNetTests.csproj
-            framework: net10.0
-            filter: 'Category!=GPU&Category!=Stress&Category!=Sweep&(FullyQualifiedName~UnitTests.Helpers|FullyQualifiedName~UnitTests.Inference|FullyQualifiedName~UnitTests.Interpretability)'
-          - name: Unit - 06 KD/Schedulers/LA
-            project: tests/AiDotNet.Tests/AiDotNetTests.csproj
-            framework: net10.0
-            filter: 'Category!=GPU&Category!=Stress&Category!=Sweep&(FullyQualifiedName~UnitTests.KnowledgeDistillation|FullyQualifiedName~UnitTests.LearningRateSchedulers|FullyQualifiedName~UnitTests.LinearAlgebra)'
-          - name: Unit - 07 Logging/Loss/Meta/Mixed/Compression
-            project: tests/AiDotNet.Tests/AiDotNetTests.csproj
-            framework: net10.0
-            filter: 'Category!=GPU&Category!=Stress&Category!=Sweep&(FullyQualifiedName~UnitTests.Logging|FullyQualifiedName~UnitTests.LossFunctions|FullyQualifiedName~UnitTests.MetaLearning|FullyQualifiedName~UnitTests.MixedPrecision|FullyQualifiedName~UnitTests.ModelCompression)'
-          # NeuralNetworks split to avoid timeouts
-          - name: Unit - 08a NN-Classic (ResNet/VGG/DenseNet)
-            project: tests/AiDotNet.Tests/AiDotNetTests.csproj
-            framework: net10.0
-            filter: 'Category!=GPU&Category!=Stress&Category!=Sweep&FullyQualifiedName~UnitTests.NeuralNetworks&(FullyQualifiedName~ResNetNetworkTests|FullyQualifiedName~VGGNetworkTests|FullyQualifiedName~DenseNetTests)'
-          - name: Unit - 08b NN-Efficient (MobileNet/EfficientNet)
-            project: tests/AiDotNet.Tests/AiDotNetTests.csproj
-            framework: net10.0
-            filter: 'Category!=GPU&Category!=Stress&Category!=Sweep&FullyQualifiedName~UnitTests.NeuralNetworks&(FullyQualifiedName~MobileNetTests|FullyQualifiedName~EfficientNetTests)'
-          - name: Unit - 08c NN-VLM (Blip/Blip2/Clip)
-            project: tests/AiDotNet.Tests/AiDotNetTests.csproj
-            framework: net10.0
-            filter: 'Category!=GPU&Category!=Stress&Category!=Sweep&FullyQualifiedName~UnitTests.NeuralNetworks&(FullyQualifiedName~BlipNeuralNetworkTests|FullyQualifiedName~Blip2NeuralNetworkTests|FullyQualifiedName~ClipNeuralNetworkTests)'
-          - name: Unit - 08d NN-Adapters/Other
-            project: tests/AiDotNet.Tests/AiDotNetTests.csproj
-            framework: net10.0
-            filter: 'Category!=GPU&Category!=Stress&Category!=Sweep&FullyQualifiedName~UnitTests.NeuralNetworks&(FullyQualifiedName~LoRAAdapterTests|FullyQualifiedName~LoRALayerTests|FullyQualifiedName~VBLoRAAdapterTests|FullyQualifiedName~AdvancedAlgebraNetworkTests|FullyQualifiedName~MixtureOfExpertsNeuralNetworkTests)'
-          # 'Unit - 08e NN-Remaining (catch-all)' removed: it was a duplicate
-          # of the ModelFamily NeuralNetworks shards (`A-F` + `G-L` + `M-N` +
-          # `O-R` + `S` + `T` + `U-Z`, same ModelFamilyTests.NeuralNetworks scope,
-          # only excluding 5 unit-test classes already covered by their
-          # dedicated 08a-08d shards). Running ~800 paper-scale NN model tests
-          # a SECOND time inside an already-OOMing process is what was actually
-          # triggering the catch-all failures — the model family shards above
-          # provide complete, non-redundant coverage of the same scope.
-          - name: Unit - 09 Optimizers/RAG
-            project: tests/AiDotNet.Tests/AiDotNetTests.csproj
-            framework: net10.0
-            filter: 'Category!=GPU&Category!=Stress&Category!=Sweep&(FullyQualifiedName~UnitTests.Optimizers|FullyQualifiedName~UnitTests.RAG)'
-          - name: Unit - 10 Regularization/RL/RAG2
-            project: tests/AiDotNet.Tests/AiDotNetTests.csproj
-            framework: net10.0
-            filter: 'Category!=GPU&Category!=Stress&Category!=Sweep&(FullyQualifiedName~UnitTests.Regularization|FullyQualifiedName~UnitTests.ReinforcementLearning|FullyQualifiedName~UnitTests.RetrievalAugmentedGeneration)'
-          - name: Unit - 11 Serving/TimeSeries/Token/Transfer
-            project: tests/AiDotNet.Tests/AiDotNetTests.csproj
-            framework: net10.0
-            filter: 'Category!=GPU&Category!=Stress&Category!=Sweep&(FullyQualifiedName~UnitTests.Serving|FullyQualifiedName~UnitTests.TimeSeries|FullyQualifiedName~UnitTests.Tokenization|FullyQualifiedName~UnitTests.TransferLearning)'
-          - name: Unit - 12 ProgramSynthesis/Reasoning
-            project: tests/AiDotNet.Tests/AiDotNetTests.csproj
-            framework: net10.0
-            filter: 'Category!=GPU&Category!=Stress&Category!=Sweep&(FullyQualifiedName~UnitTests.ProgramSynthesis|FullyQualifiedName~UnitTests.Reasoning)'
-          - name: Unit - 13 Remaining (ActiveLearning/Agents/CL/Physics/etc.)
-            project: tests/AiDotNet.Tests/AiDotNetTests.csproj
-            framework: net10.0
-            filter: >-
-              Category!=GPU&Category!=Stress&
-              FullyQualifiedName~AiDotNet.Tests.UnitTests&
-              FullyQualifiedName!~UnitTests.ActivationFunctions&
-              FullyQualifiedName!~UnitTests.Attention&
-              FullyQualifiedName!~UnitTests.Autodiff&
-              FullyQualifiedName!~UnitTests.AutoML&
-              FullyQualifiedName!~UnitTests.Data&
-              FullyQualifiedName!~UnitTests.Diagnostics&
-              FullyQualifiedName!~UnitTests.Diffusion&
-              FullyQualifiedName!~UnitTests.Encoding&
-              FullyQualifiedName!~UnitTests.FeatureSelectors&
-              FullyQualifiedName!~UnitTests.FitDetectors&
-              FullyQualifiedName!~UnitTests.FitnessCalculators&
-              FullyQualifiedName!~UnitTests.Genetics&
-              FullyQualifiedName!~UnitTests.Helpers&
-              FullyQualifiedName!~UnitTests.Inference&
-              FullyQualifiedName!~UnitTests.Interpretability&
-              FullyQualifiedName!~UnitTests.KnowledgeDistillation&
-              FullyQualifiedName!~UnitTests.LearningRateSchedulers&
-              FullyQualifiedName!~UnitTests.LinearAlgebra&
-              FullyQualifiedName!~UnitTests.Logging&
-              FullyQualifiedName!~UnitTests.LossFunctions&
-              FullyQualifiedName!~UnitTests.MetaLearning&
-              FullyQualifiedName!~UnitTests.MixedPrecision&
-              FullyQualifiedName!~UnitTests.ModelCompression&
-              FullyQualifiedName!~UnitTests.NeuralNetworks&
-              FullyQualifiedName!~UnitTests.Optimizers&
-              FullyQualifiedName!~UnitTests.RAG&
-              FullyQualifiedName!~UnitTests.Regularization&
-              FullyQualifiedName!~UnitTests.ReinforcementLearning&
-              FullyQualifiedName!~UnitTests.RetrievalAugmentedGeneration&
-              FullyQualifiedName!~UnitTests.Serving&
-              FullyQualifiedName!~UnitTests.TimeSeries&
-              FullyQualifiedName!~UnitTests.Tokenization&
-              FullyQualifiedName!~UnitTests.TransferLearning&
-              FullyQualifiedName!~UnitTests.ProgramSynthesis&
-              FullyQualifiedName!~UnitTests.Reasoning
-          # =====================================================================
-          # OTHER NON-UNIT TESTS (InferenceOpt, PromptEng, Recovery, Playground)
-          # =====================================================================
-          - name: Other - PromptEngineering
-            project: tests/AiDotNet.Tests/AiDotNetTests.csproj
-            framework: net10.0
-            filter: 'Category!=GPU&Category!=Stress&Category!=Sweep&FullyQualifiedName~AiDotNet.Tests.PromptEngineering'
-          - name: Other - Recovery/Concurrency
-            project: tests/AiDotNet.Tests/AiDotNetTests.csproj
-            framework: net10.0
-            filter: 'Category!=GPU&Category!=Stress&Category!=Sweep&(FullyQualifiedName~AiDotNet.Tests.Recovery|FullyQualifiedName~AiDotNet.Tests.Concurrency)'
-          - name: Other - Playground
-            project: tests/AiDotNet.Tests/AiDotNetTests.csproj
-            framework: net10.0
-            filter: Category=Playground
-          # =====================================================================
-          # MODEL FAMILY TESTS — invariant math tests for all model families
-          # =====================================================================
-          - name: ModelFamily - Classification
-            project: tests/AiDotNet.Tests/AiDotNetTests.csproj
-            framework: net10.0
-            filter: 'FullyQualifiedName~ModelFamilyTests.Classification'
-          - name: ModelFamily - Clustering/GP
-            project: tests/AiDotNet.Tests/AiDotNetTests.csproj
-            framework: net10.0
-            filter: '(FullyQualifiedName~ModelFamilyTests.Clustering|FullyQualifiedName~ModelFamilyTests.GaussianProcess)'
-          - name: ModelFamily - Regression
-            project: tests/AiDotNet.Tests/AiDotNetTests.csproj
-            framework: net10.0
-            filter: 'FullyQualifiedName~ModelFamilyTests.Regression'
-          # NeuralNetworks (85 model classes) split by model-class first letter.
-          # These instantiate ResNet/VGG/DenseNet/transformer-scale models
-          # (multi-GB each) and OOM'd as larger shards even serialized.
-          # A-L was a single serial $heavyShard that ran the full 45-min job
-          # timeout (983 tests × serial) and got cancelled before finishing —
-          # perpetually red, exactly like Integration C before its split. Split
-          # A-L → A-F + G-L so each serial half finishes well under the timeout.
-          # Gap-free + non-overlapping: the two filters' union is the old A-L set.
-          - name: ModelFamily - NeuralNetworks A-F
-            project: tests/AiDotNet.Tests/AiDotNetTests.csproj
-            framework: net10.0
-            filter: >-
-              FullyQualifiedName~ModelFamilyTests.NeuralNetworks&
-              (FullyQualifiedName~NeuralNetworks.A|FullyQualifiedName~NeuralNetworks.B|FullyQualifiedName~NeuralNetworks.C|FullyQualifiedName~NeuralNetworks.D|FullyQualifiedName~NeuralNetworks.E|FullyQualifiedName~NeuralNetworks.F)
-          - name: ModelFamily - NeuralNetworks G-L
-            project: tests/AiDotNet.Tests/AiDotNetTests.csproj
-            framework: net10.0
-            filter: >-
-              FullyQualifiedName~ModelFamilyTests.NeuralNetworks&
-              (FullyQualifiedName~NeuralNetworks.G|FullyQualifiedName~NeuralNetworks.H|FullyQualifiedName~NeuralNetworks.I|FullyQualifiedName~NeuralNetworks.J|FullyQualifiedName~NeuralNetworks.K|FullyQualifiedName~NeuralNetworks.L)
-          - name: ModelFamily - NeuralNetworks M-N
-            project: tests/AiDotNet.Tests/AiDotNetTests.csproj
-            framework: net10.0
-            filter: >-
-              FullyQualifiedName~ModelFamilyTests.NeuralNetworks&
-              (FullyQualifiedName~NeuralNetworks.M|FullyQualifiedName~NeuralNetworks.N)
-          - name: ModelFamily - NeuralNetworks O-R
-            project: tests/AiDotNet.Tests/AiDotNetTests.csproj
-            framework: net10.0
-            filter: >-
-              FullyQualifiedName~ModelFamilyTests.NeuralNetworks&
-              (FullyQualifiedName~NeuralNetworks.O|FullyQualifiedName~NeuralNetworks.P|FullyQualifiedName~NeuralNetworks.Q|FullyQualifiedName~NeuralNetworks.R)
-          - name: ModelFamily - NeuralNetworks S
-            project: tests/AiDotNet.Tests/AiDotNetTests.csproj
-            framework: net10.0
-            filter: >-
-              FullyQualifiedName~ModelFamilyTests.NeuralNetworks&FullyQualifiedName~NeuralNetworks.S
-          # The serialized T-Z tail was too close to the 45-minute job ceiling.
-          # Split at the existing letter boundary so the filters remain gap-free and
-          # non-overlapping while leaving margin for runner variance.
-          - name: ModelFamily - NeuralNetworks T
-            project: tests/AiDotNet.Tests/AiDotNetTests.csproj
-            framework: net10.0
-            filter: >-
-              FullyQualifiedName~ModelFamilyTests.NeuralNetworks&FullyQualifiedName~NeuralNetworks.T
-          - name: ModelFamily - NeuralNetworks U-Z
-            project: tests/AiDotNet.Tests/AiDotNetTests.csproj
-            framework: net10.0
-            filter: >-
-              FullyQualifiedName~ModelFamilyTests.NeuralNetworks&
-              (FullyQualifiedName~NeuralNetworks.U|FullyQualifiedName~NeuralNetworks.V|FullyQualifiedName~NeuralNetworks.W|FullyQualifiedName~NeuralNetworks.X|FullyQualifiedName~NeuralNetworks.Y|FullyQualifiedName~NeuralNetworks.Z)
-          - name: ModelFamily - TimeSeries/Activation/Loss
-            project: tests/AiDotNet.Tests/AiDotNetTests.csproj
-            framework: net10.0
-            filter: '(FullyQualifiedName~ModelFamilyTests.TimeSeries|FullyQualifiedName~ModelFamilyTests.ActivationFunctions|FullyQualifiedName~ModelFamilyTests.LossFunctions)'
-          # Diffusion (244 model classes) split by MODEL CLASS first
-          # letter (Diffusion.<Letter>), NOT by test METHOD letter. Method-based
-          # sharding made every shard instantiate ALL ~244 models and OOM-kill the
-          # 16 GB ubuntu-latest runner; model-class sharding limits each shard to a
-          # letter range so per-runner cumulative model/tensor footprint stays
-          # bounded. Was 3 shards (~80 models each) - still OOM'd even serialized
-          # (footprint, not parallelism), so split finer. 'S' and 'M' are split by
-          # class prefix because they are among the heaviest letter groups.
-          - name: ModelFamily - Diffusion A-C
-            project: tests/AiDotNet.Tests/AiDotNetTests.csproj
-            framework: net10.0
-            filter: >-
-              FullyQualifiedName~ModelFamilyTests.Diffusion&
-              (FullyQualifiedName~Diffusion.A|FullyQualifiedName~Diffusion.B|FullyQualifiedName~Diffusion.C)
-          - name: ModelFamily - Diffusion D-I
-            project: tests/AiDotNet.Tests/AiDotNetTests.csproj
-            framework: net10.0
-            filter: >-
-              FullyQualifiedName~ModelFamilyTests.Diffusion&
-              (FullyQualifiedName~Diffusion.D|FullyQualifiedName~Diffusion.E|FullyQualifiedName~Diffusion.F|FullyQualifiedName~Diffusion.G|FullyQualifiedName~Diffusion.H|FullyQualifiedName~Diffusion.I)
-          - name: ModelFamily - Diffusion J-K
-            project: tests/AiDotNet.Tests/AiDotNetTests.csproj
-            framework: net10.0
-            filter: >-
-              FullyQualifiedName~ModelFamilyTests.Diffusion&
-              (FullyQualifiedName~Diffusion.J|FullyQualifiedName~Diffusion.K)
-          - name: ModelFamily - Diffusion L
-            project: tests/AiDotNet.Tests/AiDotNetTests.csproj
-            framework: net10.0
-            filter: >-
-              FullyQualifiedName~ModelFamilyTests.Diffusion&FullyQualifiedName~Diffusion.L
-          - name: ModelFamily - Diffusion M A-Mi
-            project: tests/AiDotNet.Tests/AiDotNetTests.csproj
-            framework: net10.0
-            filter: >-
-              FullyQualifiedName~ModelFamilyTests.Diffusion&
-              (FullyQualifiedName~Diffusion.MAGI|FullyQualifiedName~Diffusion.Magic|FullyQualifiedName~Diffusion.Make|FullyQualifiedName~Diffusion.MAR|FullyQualifiedName~Diffusion.Me|FullyQualifiedName~Diffusion.Mid|FullyQualifiedName~Diffusion.Min)
-          - name: ModelFamily - Diffusion M Mochi-Model
-            project: tests/AiDotNet.Tests/AiDotNetTests.csproj
-            framework: net10.0
-            filter: >-
-              FullyQualifiedName~ModelFamilyTests.Diffusion&
-              (FullyQualifiedName~Diffusion.Mochi|FullyQualifiedName~Diffusion.ModelScope|FullyQualifiedName~Diffusion.MoMask)
-          - name: ModelFamily - Diffusion M Motion-MZ
-            project: tests/AiDotNet.Tests/AiDotNetTests.csproj
-            framework: net10.0
-            filter: >-
-              FullyQualifiedName~ModelFamilyTests.Diffusion&
-              (FullyQualifiedName~Diffusion.Motion|FullyQualifiedName~Diffusion.Movie|FullyQualifiedName~Diffusion.Multi|FullyQualifiedName~Diffusion.Music|FullyQualifiedName~Diffusion.MV)
-          - name: ModelFamily - Diffusion N-R
-            project: tests/AiDotNet.Tests/AiDotNetTests.csproj
-            framework: net10.0
-            filter: >-
-              FullyQualifiedName~ModelFamilyTests.Diffusion&
-              (FullyQualifiedName~Diffusion.N|FullyQualifiedName~Diffusion.O|FullyQualifiedName~Diffusion.P|FullyQualifiedName~Diffusion.Q|FullyQualifiedName~Diffusion.R)
-          - name: ModelFamily - Diffusion SA-SD
-            project: tests/AiDotNet.Tests/AiDotNetTests.csproj
-            framework: net10.0
-            filter: >-
-              FullyQualifiedName~ModelFamilyTests.Diffusion&
-              (FullyQualifiedName~Diffusion.SA|FullyQualifiedName~Diffusion.SC|FullyQualifiedName~Diffusion.SD)
-          - name: ModelFamily - Diffusion SE-SP
-            project: tests/AiDotNet.Tests/AiDotNetTests.csproj
-            framework: net10.0
-            filter: >-
-              FullyQualifiedName~ModelFamilyTests.Diffusion&
-              (FullyQualifiedName~Diffusion.Se|FullyQualifiedName~Diffusion.Sh|FullyQualifiedName~Diffusion.Si|FullyQualifiedName~Diffusion.Sk|FullyQualifiedName~Diffusion.Sn|FullyQualifiedName~Diffusion.So|FullyQualifiedName~Diffusion.Sp)
-          - name: ModelFamily - Diffusion Stable
-            project: tests/AiDotNet.Tests/AiDotNetTests.csproj
-            framework: net10.0
-            filter: >-
-              FullyQualifiedName~ModelFamilyTests.Diffusion&FullyQualifiedName~Diffusion.Stable
-          - name: ModelFamily - Diffusion Step-Sync
-            project: tests/AiDotNet.Tests/AiDotNetTests.csproj
-            framework: net10.0
-            filter: >-
-              FullyQualifiedName~ModelFamilyTests.Diffusion&
-              (FullyQualifiedName~Diffusion.Step|FullyQualifiedName~Diffusion.Stitch|FullyQualifiedName~Diffusion.Streaming|FullyQualifiedName~Diffusion.Sty|FullyQualifiedName~Diffusion.SUPIR|FullyQualifiedName~Diffusion.Swift|FullyQualifiedName~Diffusion.Sync)
-          - name: ModelFamily - Diffusion T-Z
-            project: tests/AiDotNet.Tests/AiDotNetTests.csproj
-            framework: net10.0
-            filter: >-
-              FullyQualifiedName~ModelFamilyTests.Diffusion&
-              (FullyQualifiedName~Diffusion.T|FullyQualifiedName~Diffusion.U|FullyQualifiedName~Diffusion.V|FullyQualifiedName~Diffusion.W|FullyQualifiedName~Diffusion.X|FullyQualifiedName~Diffusion.Y|FullyQualifiedName~Diffusion.Z)
-          # Auto-generated layer tests from TestScaffoldGenerator (~1670 methods),
-          # split A-M / N-Z by generated model-class first letter to halve per-shard
-          # model instantiations (OOM mitigation).
-          # A-M was a single serial $heavyShard whose ~835 default-gate methods ran
-          # the full 45-min job timeout and got CANCELLED before finishing —
-          # perpetually red, like Integration C / NeuralNetworks A-L before their
-          # splits. Split A-M → A-F + G-M so each serial half finishes under the
-          # timeout. Gap-free + non-overlapping: union == the old A-M set.
-          # A-F was a single serial $heavyShard that OOM-killed the runner (shutdown signal
-          # ~2.5 min in) — it is DENSE with full-scale codec-LM TTS models (Amphion, AudioLM,
-          # Bark, ChatTTS, Chatterbox, CosyVoice*, ...) whose per-model peak (~2.6 GB weights +
-          # Adam state) stacks past the 16 GB envelope even serialized. Split A-F → A-C + D-F;
-          # A-C then reached the 45-minute ceiling after only 2,516/3,625 results, leaving 51
-          # classes untouched. Isolate its initials (A=1,008, B=824, C=1,793 tests) so all three
-          # retain headroom. Gap-free + non-overlapping: union == the old A-C shard.
-          - name: ModelFamily - Generated Layers A
-            project: tests/AiDotNet.Tests/AiDotNetTests.csproj
-            framework: net10.0
-            filter: >-
-              FullyQualifiedName~ModelFamilyTests.Generated&FullyQualifiedName~Generated.A
-          - name: ModelFamily - Generated Layers B
-            project: tests/AiDotNet.Tests/AiDotNetTests.csproj
-            framework: net10.0
-            filter: >-
-              FullyQualifiedName~ModelFamilyTests.Generated&FullyQualifiedName~Generated.B
-          - name: ModelFamily - Generated Layers C
-            project: tests/AiDotNet.Tests/AiDotNetTests.csproj
-            framework: net10.0
-            filter: >-
-              FullyQualifiedName~ModelFamilyTests.Generated&FullyQualifiedName~Generated.C
-          # SPLIT FROM "D-F", which was the largest shard in the suite at 4,443 tests and was
-          # KILLED BY THE RUNNER at ~10 minutes, uploading no TRX. Its own memory telemetry shows
-          # why: MemAvailable fell 3.1 GB -> 150 MB and stayed pinned there for ~45 s before the
-          # host went away. That is the OOM killer, not the 45-minute clock, so a longer timeout
-          # would not have saved it -- the working set had to come down. One letter per shard puts
-          # each at roughly a third of the peak. Gap-free + non-overlapping: union == D-F.
-          - name: ModelFamily - Generated Layers D
-            project: tests/AiDotNet.Tests/AiDotNetTests.csproj
-            framework: net10.0
-            timeout: 60
-            filter: >-
-              FullyQualifiedName~ModelFamilyTests.Generated&FullyQualifiedName~Generated.D
-          - name: ModelFamily - Generated Layers E
-            project: tests/AiDotNet.Tests/AiDotNetTests.csproj
-            framework: net10.0
-            timeout: 60
-            filter: >-
-              FullyQualifiedName~ModelFamilyTests.Generated&FullyQualifiedName~Generated.E
-          - name: ModelFamily - Generated Layers F
-            project: tests/AiDotNet.Tests/AiDotNetTests.csproj
-            framework: net10.0
-            timeout: 60
-            filter: >-
-              FullyQualifiedName~ModelFamilyTests.Generated&FullyQualifiedName~Generated.F
-          # G-M was a single serial shard that ran the full 45-min job timeout and got
-          # CANCELLED before finishing (dense with heavy segmentation/foundation models,
-          # e.g. Mask2Former). Split G-M → G-I + J-M so each serial half finishes under the
-          # timeout. Gap-free + non-overlapping: union == G-M.
-          # SPLIT FROM "G-I", which reached the 45-minute job ceiling and uploaded no TRX. It
-          # carried 35 layer types (G 19, H 10, I 6) plus the generated model scaffolds on the same
-          # prefixes -- against healthy shards like C and D at 25 and 22. This is the one of the
-          # four reported shards where breadth genuinely was the problem; U (6 types) and Vo-VR
-          # (1 type) are small and fail for a different reason, so they are NOT split here.
-          - name: ModelFamily - Generated Layers G
-            project: tests/AiDotNet.Tests/AiDotNetTests.csproj
-            framework: net10.0
-            filter: >-
-              FullyQualifiedName~ModelFamilyTests.Generated&FullyQualifiedName~Generated.G
-          - name: ModelFamily - Generated Layers H-I
-            project: tests/AiDotNet.Tests/AiDotNetTests.csproj
-            framework: net10.0
-            filter: >-
-              FullyQualifiedName~ModelFamilyTests.Generated&
-              (FullyQualifiedName~Generated.H|FullyQualifiedName~Generated.I)
-          # J-M in turn never once COMPLETED: every run either OOMed (MiniGPT-v2 / Llama-3.2-Vision /
-          # Kimi-VL, all bounded now) or ran out the 45-min budget. It carries 183 generated classes,
-          # and the last CI run covered only 44 of them in 14.4 min of execution before dying —
-          # ~61 min extrapolated for the whole shard, well over the job timeout. Split J-M → J-L + M
-          # so each serial half finishes under it (~24 min / ~37 min on the same extrapolation).
-          # The M half holds the heavy tail (Mask2Former, MaskDINO, MedSAM/MedSAM2, MPLUG-Owl,
-          # MiniGPT, MusicSourceSeparator), which is why the cut is not at the midpoint by count.
-          # Gap-free + non-overlapping: union == J-M.
-          - name: ModelFamily - Generated Layers J-L
-            project: tests/AiDotNet.Tests/AiDotNetTests.csproj
-            framework: net10.0
-            filter: >-
-              FullyQualifiedName~ModelFamilyTests.Generated&
-              (FullyQualifiedName~Generated.J|FullyQualifiedName~Generated.K|FullyQualifiedName~Generated.L)
-          # M measured 69m01s for 1875 tests - green, but over the 45-min budget, so it is split
-          # three ways. Boundaries come from that run's per-class timings, not class counts: the
-          # "Me" prefix alone accounted for 1687s, 56 percent of M, which is why an even two-way
-          # split was never going to fit. Est. wall: A-Medi ~23m, MedS-Meta ~28m, MetaV-Mu ~17m.
-          # Prefixes were generated and machine-verified so that every one of M's 110 classes -
-          # including the 8 that Category!=HeavyTimeout skips - matches exactly ONE of the three.
-          # Gap-free + non-overlapping: the union is exactly the old M.
-          - name: ModelFamily - Generated Layers M A-Medi
-            project: tests/AiDotNet.Tests/AiDotNetTests.csproj
-            framework: net10.0
-            filter: >-
-              FullyQualifiedName~ModelFamilyTests.Generated&
-              (FullyQualifiedName~Generated.M2|FullyQualifiedName~Generated.MA|FullyQualifiedName~Generated.Ma|FullyQualifiedName~Generated.MC|FullyQualifiedName~Generated.Mc|FullyQualifiedName~Generated.Mea|FullyQualifiedName~Generated.MedC|FullyQualifiedName~Generated.MedG|FullyQualifiedName~Generated.MedF|FullyQualifiedName~Generated.MedN|FullyQualifiedName~Generated.Medi)
-          - name: ModelFamily - Generated Layers M MedS-Meta
-            project: tests/AiDotNet.Tests/AiDotNetTests.csproj
-            framework: net10.0
-            filter: >-
-              FullyQualifiedName~ModelFamilyTests.Generated&
-              (FullyQualifiedName~Generated.MEG|FullyQualifiedName~Generated.Meg|FullyQualifiedName~Generated.MER|FullyQualifiedName~Generated.MedS|FullyQualifiedName~Generated.Mel|FullyQualifiedName~Generated.Mem|FullyQualifiedName~Generated.Mes|FullyQualifiedName~Generated.MetaC)
-          - name: ModelFamily - Generated Layers M MetaV-Mu
-            project: tests/AiDotNet.Tests/AiDotNetTests.csproj
-            framework: net10.0
-            filter: >-
-              FullyQualifiedName~ModelFamilyTests.Generated&
-              (FullyQualifiedName~Generated.METE|FullyQualifiedName~Generated.MG|FullyQualifiedName~Generated.MI|FullyQualifiedName~Generated.Mi|FullyQualifiedName~Generated.ML|FullyQualifiedName~Generated.MM|FullyQualifiedName~Generated.MP|FullyQualifiedName~Generated.MQ|FullyQualifiedName~Generated.MT|FullyQualifiedName~Generated.MetaV|FullyQualifiedName~Generated.Mo|FullyQualifiedName~Generated.MO|FullyQualifiedName~Generated.Mu)
-          # N-Z was a single serial $heavyShard whose ~835 default-gate scaffold
-          # methods ran the full 45-min job timeout and got CANCELLED before
-          # finishing — perpetually red, like Integration C / NeuralNetworks A-L
-          # before their splits. Split N-Z → N-S + T-Z; N-S itself was STILL a
-          # 55-min timeout (dense with the SAM / segmentation family: ODISE, OMGSeg,
-          # OneFormer, SAM/SAM21/SAMHQ, SegFormer, SegMamba, SwinUNETR, ...), so split
-          # N-S again → N-P + Q-S. N-P later exceeded the 45-min budget with 2,300+
-          # tests already green and no OOM, so split it by measured wall weight into
-          # N-O + P. P then reached the exact 45-min gate locally with 1,490/1,531 tests
-          # green and no OOM. Split P by measured second-letter buckets into two balanced
-          # jobs (798 + 759 tests after ParaformerLarge rejoined the PR lane). The filters
-          # are gap-free and non-overlapping over the generated P inventory; their union is
-          # the original P shard.
-          - name: ModelFamily - Generated Layers N-O
-            project: tests/AiDotNet.Tests/AiDotNetTests.csproj
-            framework: net10.0
-            filter: >-
-              FullyQualifiedName~ModelFamilyTests.Generated&
-              (FullyQualifiedName~Generated.N|FullyQualifiedName~Generated.O)
-          - name: ModelFamily - Generated Layers P A,C,I,L,N,P
-            project: tests/AiDotNet.Tests/AiDotNetTests.csproj
-            framework: net10.0
-            filter: >-
-              FullyQualifiedName~ModelFamilyTests.Generated&
-              (FullyQualifiedName~Generated.Pa|FullyQualifiedName~Generated.PA|FullyQualifiedName~Generated.Pc|FullyQualifiedName~Generated.PC|
-              FullyQualifiedName~Generated.Pi|FullyQualifiedName~Generated.PI|FullyQualifiedName~Generated.Pl|FullyQualifiedName~Generated.PL|
-              FullyQualifiedName~Generated.Pn|FullyQualifiedName~Generated.PN|FullyQualifiedName~Generated.Pp|FullyQualifiedName~Generated.PP)
-          - name: ModelFamily - Generated Layers P E,H,O,R,S,U,W,Y
-            project: tests/AiDotNet.Tests/AiDotNetTests.csproj
-            framework: net10.0
-            filter: >-
-              FullyQualifiedName~ModelFamilyTests.Generated&
-              (FullyQualifiedName~Generated.Pe|FullyQualifiedName~Generated.Ph|
-              FullyQualifiedName~Generated.Po|FullyQualifiedName~Generated.Pr|FullyQualifiedName~Generated.PR|
-              FullyQualifiedName~Generated.Ps|FullyQualifiedName~Generated.PS|FullyQualifiedName~Generated.Pu|FullyQualifiedName~Generated.PU|
-              FullyQualifiedName~Generated.Pw|FullyQualifiedName~Generated.PW|FullyQualifiedName~Generated.Py)
-          # Q-S was itself a 45-min CANCELLATION, exactly like N-Z and N-S before it.
-          # MEASURED (full local run, all correctness fixes in place): 203 classes,
-          # 83.8 min of summed per-test time, and ~125 min WALL — the ~1.5x factor is
-          # per-class construction/GC that per-test timings do not attribute. So the job
-          # could never pass on a 45-min budget regardless of how many tests were fixed.
-          #
-          # Split 5 ways by MEASURED per-class weight (not class count), which balances
-          # the binding metric — the MAX shard:
-          #     N=3 -> max 29.2 min (~44 min wall, no headroom)
-          #     N=4 -> max 30.5 min (WORSE: the splitter keeps runs contiguous so they
-          #                          stay prefix-expressible, and the greedy pass
-          #                          overloads the tail)
-          #     N=5 -> max 24.9 min (~37 min wall)  <-- chosen
-          #     N=6 -> max 25.1 min (no gain; the tail shard is contiguity-bound)
-          #
-          # Machine-verified: all 203 classes match EXACTLY ONE shard, union == the old
-          # Q-S set, gap-free, non-overlapping, and checked CASE-INSENSITIVELY because
-          # VSTest's FullyQualifiedName~ operator ignores case (a case-sensitive check
-          # emits prefixes that silently overlap — e.g. SPIRAL vs SpiralConvLayer).
-          # Weights are pre-float for the seven heaviest classes, so real times land
-          # BELOW these figures. Every shard name is added to $heavyShards below.
-          - name: ModelFamily - Generated Layers Q-R1
-            project: tests/AiDotNet.Tests/AiDotNetTests.csproj
-            framework: net10.0
-            # 56 classes, 15.9 min. Heaviest: RecurrentGemmaLanguageModel 5.9m, RealESRGANVideo 2.3m.
-            filter: >-
-              FullyQualifiedName~ModelFamilyTests.Generated&
-              (FullyQualifiedName~Generated.Q|FullyQualifiedName~Generated.RA|FullyQualifiedName~Generated.Ra|FullyQualifiedName~Generated.RB|FullyQualifiedName~Generated.RC|FullyQualifiedName~Generated.RE|FullyQualifiedName~Generated.Re|FullyQualifiedName~Generated.RF|FullyQualifiedName~Generated.RI|FullyQualifiedName~Generated.RM|FullyQualifiedName~Generated.RN|FullyQualifiedName~Generated.RoBE)
-          - name: ModelFamily - Generated Layers R2-SAI
-            project: tests/AiDotNet.Tests/AiDotNetTests.csproj
-            framework: net10.0
-            # 24 classes, 11.0 min. Heaviest: RWKV4LanguageModel 1.6m, RoomImpulseResponse 1.5m.
-            filter: >-
-              FullyQualifiedName~ModelFamilyTests.Generated&
-              (FullyQualifiedName~Generated.RP|FullyQualifiedName~Generated.RR|FullyQualifiedName~Generated.RS|FullyQualifiedName~Generated.RT|FullyQualifiedName~Generated.RV|FullyQualifiedName~Generated.RW|FullyQualifiedName~Generated.RoM|FullyQualifiedName~Generated.Robu|FullyQualifiedName~Generated.Rod|FullyQualifiedName~Generated.Roo|FullyQualifiedName~Generated.Rot|FullyQualifiedName~Generated.Row|FullyQualifiedName~Generated.S4|FullyQualifiedName~Generated.S5|FullyQualifiedName~Generated.SAC|FullyQualifiedName~Generated.SAI)
-          - name: ModelFamily - Generated Layers SAL-SAM
-            project: tests/AiDotNet.Tests/AiDotNetTests.csproj
-            framework: net10.0
-            # Only 8 classes but 15.6 min: the two heaviest classes in the whole shard
-            # (SALMONN 6.6m, SambaLanguageModel 6.2m) plus the SAM family. Kept together
-            # because SAL*/SAM* cannot be separated further by prefix.
-            filter: >-
-              FullyQualifiedName~ModelFamilyTests.Generated&
-              (FullyQualifiedName~Generated.SAL|FullyQualifiedName~Generated.SAM|FullyQualifiedName~Generated.Sam)
-          - name: ModelFamily - Generated Layers SAN-Sig
-            project: tests/AiDotNet.Tests/AiDotNetTests.csproj
-            framework: net10.0
-            # 40 classes, 16.4 min. Heaviest: SECBERT 5.5m, SeACo 2.8m.
-            filter: >-
-              FullyQualifiedName~ModelFamilyTests.Generated&
-              (FullyQualifiedName~Generated.SAN|FullyQualifiedName~Generated.SAR|FullyQualifiedName~Generated.Sar|FullyQualifiedName~Generated.SC|FullyQualifiedName~Generated.Sc|FullyQualifiedName~Generated.SE|FullyQualifiedName~Generated.Se|FullyQualifiedName~Generated.Sh|FullyQualifiedName~Generated.Sig)
-          # The previous Sil-Sy job reached the 45-minute job timeout after four
-          # individual MoreData watchdogs. Split its exact prefix union at the
-          # Sq/St boundary so both halves retain headroom even if a future model
-          # approaches its per-test limit.
-          - name: ModelFamily - Generated Layers Sil-Sq
-            project: tests/AiDotNet.Tests/AiDotNetTests.csproj
-            framework: net10.0
-            filter: >-
-              FullyQualifiedName~ModelFamilyTests.Generated&
-              (FullyQualifiedName~Generated.SK|FullyQualifiedName~Generated.SL|FullyQualifiedName~Generated.Sl|
-              FullyQualifiedName~Generated.SO|FullyQualifiedName~Generated.So|FullyQualifiedName~Generated.SP|FullyQualifiedName~Generated.Sp|
-              FullyQualifiedName~Generated.SQ|FullyQualifiedName~Generated.Sq|FullyQualifiedName~Generated.Sil|
-              FullyQualifiedName~Generated.Sim)
-          # SPLIT FROM "St-Sy", also killed by the runner (MemAvailable floor 218 MB) at ~18
-          # minutes with no TRX, on BOTH this run and the baseline. Same treatment: halve the
-          # working set rather than extend the clock. The token set is carried over verbatim so
-          # coverage is unchanged; gap-free + non-overlapping: union == St-Sy.
-          - name: ModelFamily - Generated Layers St-Su
-            project: tests/AiDotNet.Tests/AiDotNetTests.csproj
-            framework: net10.0
-            timeout: 60
-            filter: >-
-              FullyQualifiedName~ModelFamilyTests.Generated&
-              (FullyQualifiedName~Generated.ST|FullyQualifiedName~Generated.St|
-              FullyQualifiedName~Generated.SU|FullyQualifiedName~Generated.Su)
-          - name: ModelFamily - Generated Layers Sv-Sy
-            project: tests/AiDotNet.Tests/AiDotNetTests.csproj
-            framework: net10.0
-            timeout: 60
-            filter: >-
-              FullyQualifiedName~ModelFamilyTests.Generated&
-              (FullyQualifiedName~Generated.SV|FullyQualifiedName~Generated.Sw|
-              FullyQualifiedName~Generated.Sy)
-          # The T-Z tail is 201 model classes / 4,378 tests. T is split in two (see below).
-          # U-Z contains 2,676 tests across 119 classes and hit the 45-minute job limit
-          # after exposing only 999 results. Isolating each substantial initial fixed U/W/X/Y-Z,
-          # but V still reached the limit after 892/1,000 results. Split its 43 classes into four
-          # prefix groups: VA-VF=247, Video=224, Vi-VM=346, Vo-VR=183 tests.
-          # T as a single lane does not fit the 45-minute budget. Measured under runner parity
-          # (--cpus 4, --memory 16g), its 83 classes split into two lanes that each finished:
-          # T A-Tac = 40 classes / 880 tests / 25m26s, T Tem-Tri = 43 classes / 881 tests / 26m21s.
-          # Combined that is ~52 minutes, so the isolated T lane would be cut off at the limit.
-          # The split is balanced on measured per-class cost: TemplateNER (218 s), TriaffineNER
-          # (175 s) and Timer (144 s) all land in the second lane, so the first lane absorbs the
-          # 17-class Tab* family and Tra* to compensate.
-          - name: ModelFamily - Generated Layers T A-Tac
-            project: tests/AiDotNet.Tests/AiDotNetTests.csproj
-            framework: net10.0
-            filter: >-
-              FullyQualifiedName~ModelFamilyTests.Generated&
-              (FullyQualifiedName~Generated.T5R|FullyQualifiedName~Generated.TCD|FullyQualifiedName~Generated.TCN|FullyQualifiedName~Generated.TD3|FullyQualifiedName~Generated.TDP|FullyQualifiedName~Generated.TDT|FullyQualifiedName~Generated.TFC|FullyQualifiedName~Generated.TFG|FullyQualifiedName~Generated.TFT|FullyQualifiedName~Generated.TLB|FullyQualifiedName~Generated.TLe|FullyQualifiedName~Generated.TOT|FullyQualifiedName~Generated.TRI|FullyQualifiedName~Generated.TRP|FullyQualifiedName~Generated.TS2|FullyQualifiedName~Generated.TSF|FullyQualifiedName~Generated.TTT|FullyQualifiedName~Generated.TTV|FullyQualifiedName~Generated.TVA|FullyQualifiedName~Generated.Tab|FullyQualifiedName~Generated.Tac)
-          - name: ModelFamily - Generated Layers T Tem-Tri
-            project: tests/AiDotNet.Tests/AiDotNetTests.csproj
-            framework: net10.0
-            filter: >-
-              FullyQualifiedName~ModelFamilyTests.Generated&
-              (FullyQualifiedName~Generated.Tem|FullyQualifiedName~Generated.Tex|FullyQualifiedName~Generated.Tho|FullyQualifiedName~Generated.Thr|FullyQualifiedName~Generated.TiD|FullyQualifiedName~Generated.TiM|FullyQualifiedName~Generated.Tim|FullyQualifiedName~Generated.Tin|FullyQualifiedName~Generated.Tit|FullyQualifiedName~Generated.Too|FullyQualifiedName~Generated.Tor|FullyQualifiedName~Generated.Tra|FullyQualifiedName~Generated.Tri)
-          - name: ModelFamily - Generated Layers U
-            project: tests/AiDotNet.Tests/AiDotNetTests.csproj
-            framework: net10.0
-            filter: >-
-              FullyQualifiedName~ModelFamilyTests.Generated&FullyQualifiedName~Generated.U
-          - name: ModelFamily - Generated Layers VA-VF
-            project: tests/AiDotNet.Tests/AiDotNetTests.csproj
-            framework: net10.0
-            filter: >-
-              FullyQualifiedName~ModelFamilyTests.Generated&
-              (FullyQualifiedName~Generated.VA|FullyQualifiedName~Generated.Va|FullyQualifiedName~Generated.Ve|FullyQualifiedName~Generated.VF)
-          - name: ModelFamily - Generated Layers Video
-            project: tests/AiDotNet.Tests/AiDotNetTests.csproj
-            framework: net10.0
-            filter: >-
-              FullyQualifiedName~ModelFamilyTests.Generated&FullyQualifiedName~Generated.Video
-          - name: ModelFamily - Generated Layers Vi-VM
-            project: tests/AiDotNet.Tests/AiDotNetTests.csproj
-            framework: net10.0
-            filter: >-
-              FullyQualifiedName~ModelFamilyTests.Generated&
-              ((FullyQualifiedName~Generated.Vi|FullyQualifiedName~Generated.VI&FullyQualifiedName!~Generated.Video)|FullyQualifiedName~Generated.VM)
-          - name: ModelFamily - Generated Layers Vo-VR
-            project: tests/AiDotNet.Tests/AiDotNetTests.csproj
-            framework: net10.0
-            filter: >-
-              FullyQualifiedName~ModelFamilyTests.Generated&
-              (FullyQualifiedName~Generated.Vo|FullyQualifiedName~Generated.VR)
-          - name: ModelFamily - Generated Layers W
-            project: tests/AiDotNet.Tests/AiDotNetTests.csproj
-            framework: net10.0
-            filter: >-
-              FullyQualifiedName~ModelFamilyTests.Generated&FullyQualifiedName~Generated.W
-          - name: ModelFamily - Generated Layers X
-            project: tests/AiDotNet.Tests/AiDotNetTests.csproj
-            framework: net10.0
-            filter: >-
-              FullyQualifiedName~ModelFamilyTests.Generated&FullyQualifiedName~Generated.X
-          - name: ModelFamily - Generated Layers Y-Z
-            project: tests/AiDotNet.Tests/AiDotNetTests.csproj
-            framework: net10.0
-            filter: >-
-              FullyQualifiedName~ModelFamilyTests.Generated&
-              (FullyQualifiedName~Generated.Y|FullyQualifiedName~Generated.Z)
-          # Previously-uncovered model families (NO shard ran these): CodeModel
-          # (CodeBERT), Forecasting (MGTSD), Segmentation (SwinUNETR), Survival
-          # (RandomSurvivalForest). Small (1 model each) — one combined shard.
-          - name: ModelFamily - Code/Forecast/Segment/Survival
-            project: tests/AiDotNet.Tests/AiDotNetTests.csproj
-            framework: net10.0
-            filter: >-
-              (FullyQualifiedName~ModelFamilyTests.CodeModel|FullyQualifiedName~ModelFamilyTests.Forecasting|FullyQualifiedName~ModelFamilyTests.Segmentation|FullyQualifiedName~ModelFamilyTests.Survival)
-          # =====================================================================
-          # INTEGRATION TESTS — previously had NO shard at all (~686 test files,
-          # incl. Document AI, Finance, ComputerVision, Audio, Video, MetaLearning,
-          # Optimizers, Preprocessing, Statistics, ...). Sharded by subdir-namespace
-          # first letter (IntegrationTests.<Letter>) so coverage is gap-free and
-          # per-shard footprint stays bounded. Model-instantiating groups are
-          # serialized (see $heavyShards in the run step).
-          # =====================================================================
-          - name: Integration A-B
-            project: tests/AiDotNet.Tests/AiDotNetTests.csproj
-            framework: net10.0
-            filter: 'Category!=GPU&Category!=Stress&Category!=Sweep&(FullyQualifiedName~AiDotNet.Tests.IntegrationTests.A|FullyQualifiedName~AiDotNet.Tests.IntegrationTests.B)'
-          # Integration C was the largest Integration shard (~2300 cases across
-          # 12 C* namespaces) and the only one forced fully serial — its
-          # ComputerVision namespace instantiates paper-scale segmentation
-          # models that OOM the 16 GB runner under parallel collections. Run
-          # serially it never finished before the concurrency-group cancel
-          # superseded the master run, so it was perpetually red. Split into the
-          # heavy ComputerVision namespace (kept serial) and a Core complement
-          # (everything else, which is algorithm/config/causal tests with small
-          # models — safe to run parallel and fast). The complement filter keeps
-          # the two gap-free + non-overlapping (their union == the old C filter)
-          # and future-proof: any new C* namespace lands in Core automatically.
-          # SPLIT FROM "Integration C - ComputerVision", killed by the runner at ~6.5 minutes
-          # (MemAvailable floor 114 MB) with no TRX on BOTH this run and the baseline -- so the
-          # Detection suite this branch changed had NO signal on either side of the comparison.
-          # 15 classes / ~680 tests of paper-scale detection and segmentation backbones in one
-          # process is the whole problem; three shards of ~230 each fit the envelope. Gap-free and
-          # non-overlapping by class-name prefix: ComputerVision* | the eight named model suites |
-          # Segmentation*, which together are exactly the 15 classes in the namespace.
-          - name: Integration C - ComputerVision Detection
-            project: tests/AiDotNet.Tests/AiDotNetTests.csproj
-            framework: net10.0
-            timeout: 60
-            filter: 'Category!=GPU&Category!=Stress&Category!=Sweep&FullyQualifiedName~IntegrationTests.ComputerVision.ComputerVision'
-          - name: Integration C - ComputerVision Segmentation Models
-            project: tests/AiDotNet.Tests/AiDotNetTests.csproj
-            framework: net10.0
-            timeout: 60
-            filter: >-
-              Category!=GPU&Category!=Stress&Category!=Sweep&
-              (FullyQualifiedName~IntegrationTests.ComputerVision.FoundationSegmentation|
-              FullyQualifiedName~IntegrationTests.ComputerVision.InstanceSegmentation|
-              FullyQualifiedName~IntegrationTests.ComputerVision.OpenVocabInteractiveReferringSegmentation|
-              FullyQualifiedName~IntegrationTests.ComputerVision.PanopticMambaEfficientSegmentation|
-              FullyQualifiedName~IntegrationTests.ComputerVision.PointCloudMedicalSegmentation|
-              FullyQualifiedName~IntegrationTests.ComputerVision.SegFormer|
-              FullyQualifiedName~IntegrationTests.ComputerVision.SemanticSegmentation|
-              FullyQualifiedName~IntegrationTests.ComputerVision.VideoDiffusionSegmentation)
-          - name: Integration C - ComputerVision Segmentation Contracts
-            project: tests/AiDotNet.Tests/AiDotNetTests.csproj
-            framework: net10.0
-            timeout: 60
-            filter: 'Category!=GPU&Category!=Stress&Category!=Sweep&FullyQualifiedName~IntegrationTests.ComputerVision.Segmentation'
-          - name: Integration C - Core
-            project: tests/AiDotNet.Tests/AiDotNetTests.csproj
-            framework: net10.0
-            filter: 'Category!=GPU&Category!=Stress&Category!=Sweep&FullyQualifiedName~AiDotNet.Tests.IntegrationTests.C&FullyQualifiedName!~AiDotNet.Tests.IntegrationTests.ComputerVision'
-          - name: Integration D
-            project: tests/AiDotNet.Tests/AiDotNetTests.csproj
-            framework: net10.0
-            filter: 'Category!=GPU&Category!=Stress&Category!=Sweep&FullyQualifiedName~AiDotNet.Tests.IntegrationTests.D'
-          - name: Integration E-G
-            project: tests/AiDotNet.Tests/AiDotNetTests.csproj
-            framework: net10.0
-            filter: 'Category!=GPU&Category!=Stress&Category!=Sweep&(FullyQualifiedName~AiDotNet.Tests.IntegrationTests.E|FullyQualifiedName~AiDotNet.Tests.IntegrationTests.F|FullyQualifiedName~AiDotNet.Tests.IntegrationTests.G)'
-          - name: Integration H-L
-            project: tests/AiDotNet.Tests/AiDotNetTests.csproj
-            framework: net10.0
-            filter: 'Category!=GPU&Category!=Stress&Category!=Sweep&Category!=SerialPerf&(FullyQualifiedName~AiDotNet.Tests.IntegrationTests.H|FullyQualifiedName~AiDotNet.Tests.IntegrationTests.I|FullyQualifiedName~AiDotNet.Tests.IntegrationTests.J|FullyQualifiedName~AiDotNet.Tests.IntegrationTests.K|FullyQualifiedName~AiDotNet.Tests.IntegrationTests.L)'
-          - name: Integration M
-            project: tests/AiDotNet.Tests/AiDotNetTests.csproj
-            framework: net10.0
-            filter: 'Category!=GPU&Category!=Stress&Category!=Sweep&FullyQualifiedName~AiDotNet.Tests.IntegrationTests.M'
-          - name: Integration N-O
-            project: tests/AiDotNet.Tests/AiDotNetTests.csproj
-            framework: net10.0
-            # AdvancedNeuralNetworkModelsIntegrationTests contains legacy model
-            # smoke tests for models now owned by ModelFamily.NeuralNetworks.
-            # Keep its integration-only models in this shard, but do not run
-            # duplicate model-family invariants a second time under Integration.
-            filter: 'Category!=GPU&Category!=Stress&Category!=Sweep&Category!=ModelFamilyDuplicate&Category!=SerialPerf&(FullyQualifiedName~AiDotNet.Tests.IntegrationTests.N|FullyQualifiedName~AiDotNet.Tests.IntegrationTests.O)'
-          - name: Integration P-Q
-            project: tests/AiDotNet.Tests/AiDotNetTests.csproj
-            framework: net10.0
-            filter: 'Category!=GPU&Category!=Stress&Category!=Sweep&(FullyQualifiedName~AiDotNet.Tests.IntegrationTests.P|FullyQualifiedName~AiDotNet.Tests.IntegrationTests.Q)'
-          - name: Integration R
-            project: tests/AiDotNet.Tests/AiDotNetTests.csproj
-            framework: net10.0
-            filter: 'Category!=GPU&Category!=Stress&Category!=Sweep&FullyQualifiedName~AiDotNet.Tests.IntegrationTests.R'
-          - name: Integration S
-            project: tests/AiDotNet.Tests/AiDotNetTests.csproj
-            framework: net10.0
-            filter: 'Category!=GPU&Category!=Stress&Category!=Sweep&FullyQualifiedName~AiDotNet.Tests.IntegrationTests.S'
-          - name: Integration T-Z
-            project: tests/AiDotNet.Tests/AiDotNetTests.csproj
-            framework: net10.0
-            filter: 'Category!=GPU&Category!=Stress&Category!=Sweep&(FullyQualifiedName~AiDotNet.Tests.IntegrationTests.T|FullyQualifiedName~AiDotNet.Tests.IntegrationTests.U|FullyQualifiedName~AiDotNet.Tests.IntegrationTests.V|FullyQualifiedName~AiDotNet.Tests.IntegrationTests.W|FullyQualifiedName~AiDotNet.Tests.IntegrationTests.X|FullyQualifiedName~AiDotNet.Tests.IntegrationTests.Y|FullyQualifiedName~AiDotNet.Tests.IntegrationTests.Z)'
-          # Dedicated SERIAL lane for single-process perf/memory guards (CpuToWallRatio,
-          # MemoryBudget). Tagged Category=SerialPerf and excluded from Integration N-O above,
-          # they run ALONE here so no sibling collection contends for CPU/memory and invalidates
-          # the measurement — keeps the assertions at full strength (no bound relaxation). Tiny
-          # (2 classes), so a whole shard is cheap.
-          - name: Integration - Serial Perf
-            project: tests/AiDotNet.Tests/AiDotNetTests.csproj
-            framework: net10.0
-            filter: 'Category=SerialPerf&Category!=GPU'
-          # =====================================================================
-          # TOP-LEVEL TEST NAMESPACES that no shard covered (distinct from the
-          # UnitTests.* and IntegrationTests.* trees).
-          # =====================================================================
-          - name: TopLevel - FederatedLearning
-            project: tests/AiDotNet.Tests/AiDotNetTests.csproj
-            framework: net10.0
-            filter: 'Category!=GPU&Category!=Stress&Category!=Sweep&FullyQualifiedName~AiDotNet.Tests.FederatedLearning'
-          - name: TopLevel - Audio/Onnx/Tokenization
-            project: tests/AiDotNet.Tests/AiDotNetTests.csproj
-            framework: net10.0
-            filter: 'Category!=GPU&Category!=Stress&Category!=Sweep&(FullyQualifiedName~AiDotNet.Tests.Audio|FullyQualifiedName~AiDotNet.Tests.Onnx|FullyQualifiedName~AiDotNet.Tests.Tokenization)'
-          - name: TopLevel - Components/Adversarial/EndToEnd
-            project: tests/AiDotNet.Tests/AiDotNetTests.csproj
-            framework: net10.0
-            filter: 'Category!=GPU&Category!=Stress&Category!=Sweep&(FullyQualifiedName~AiDotNet.Tests.ComponentTests|FullyQualifiedName~AiDotNet.Tests.AdversarialRobustness|FullyQualifiedName~AiDotNet.Tests.EndToEndTests)'
-          # =====================================================================
-          # SERVING TESTS
-          # =====================================================================
-          - name: AiDotNet.Serving.Tests
-            project: tests/AiDotNet.Serving.Tests/AiDotNet.Serving.Tests.csproj
-            framework: net10.0
-            filter: 'Category!=GPU&Category!=Stress'
+        # The shard list lives in .github/test-shards.yml. It cannot also be a literal here: the
+        # selection job filters it down to the shards a change can actually affect, and a matrix
+        # is either a literal or an expression. select-shards emits the full list unchanged
+        # whenever it is not confident, so the default behaviour is the same 115-shard matrix.
+        shard: ${{ fromJSON(needs.select-shards.outputs.matrix) }}
 
     steps:
       - name: Checkout code

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -596,6 +596,21 @@ jobs:
           fi
           gh run download "$run_id" --name shard-map --dir map || echo "map artifact unavailable"
 
+      # The selector's own tests, run here rather than nowhere. Two defects on this PR were caught
+      # only because these exist - reading the wrong side of a diff hunk, and a staleness check that
+      # silently pinned the feature off - and both looked healthy in the logs.
+      #
+      # continue-on-error, deliberately: a failing self-test means the selector cannot be trusted to
+      # REDUCE the matrix, and the fallback for that is already "run everything". Failing the job
+      # instead would block every PR in the repo on a tooling bug while adding no safety, since the
+      # behaviour it forces is the behaviour escalation already gives. The error annotation below is
+      # what makes it visible.
+      - name: Verify the selector
+        id: selftest
+        continue-on-error: true
+        shell: pwsh
+        run: ./tools/TestImpact/Select-Shards.ps1 -SelfTest
+
       - name: Select
         id: select
         shell: pwsh
@@ -605,12 +620,24 @@ jobs:
             Write-Host '::error::.github/test-shards.yml yielded no shards'
             exit 1
           }
+
+          # `name` is the key selection and the map both index on, and the regression analyzer keys
+          # on its slug. Duplicates already escalate through the count check further down, but with
+          # a message about missing shards that points nowhere near the real cause.
+          $dupes = @($all.name | Group-Object | Where-Object Count -gt 1 | ForEach-Object Name)
+          if ($dupes.Count -gt 0) {
+            Write-Host "::error::duplicate shard name(s) in .github/test-shards.yml: $($dupes -join ', ')"
+            exit 1
+          }
           Write-Host "shard list: $($all.Count) shard(s)"
 
           $escalate = $true
           $selected = @()
 
-          # Only pull requests get a reduced matrix.
+          # Two independent reasons to refuse to reduce, reported separately so the log says which
+          # one applied. Folding them into one flag made a self-test failure on a PR print "not a
+          # pull request", which is the kind of misleading-but-green log this feature keeps
+          # producing when a condition is collapsed.
           #
           # A master push MUST run everything, and not out of caution: the nightly map is built from
           # a master run's digests, and any shard that did not run produced no digest, so the map
@@ -618,8 +645,13 @@ jobs:
           # the map, and the feature decays a shard at a time into running everything - while
           # looking like it works. Merge-group runs are the last gate before master and are not
           # worth reducing either.
-          $isPullRequest = '${{ github.event_name }}' -eq 'pull_request'
-          if (-not $isPullRequest) {
+          $selectorTrusted = '${{ steps.selftest.outcome }}' -eq 'success'
+          $eventCanReduce  = '${{ github.event_name }}' -eq 'pull_request'
+
+          if (-not $selectorTrusted) {
+            Write-Host '::error::the shard selector failed its own self-test - running the full matrix. Fix tools/TestImpact/Select-Shards.ps1.'
+          }
+          elseif (-not $eventCanReduce) {
             Write-Host "event is '${{ github.event_name }}', not a pull request - running the full matrix"
           }
           elseif (Test-Path map/shard-map.json) {

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -614,7 +614,7 @@ jobs:
           # `|| true`: bash steps run with `set -e`, and gh exits non-zero when the workflow does
           # not exist yet - which is the normal state until test-impact-map.yml reaches master.
           # Without this the step dies before reaching the message explaining why there is no map.
-          run_id=$(gh run list --workflow test-impact-map.yml --branch master                      --status success --limit 1 --json databaseId --jq '.[0].databaseId' 2>/dev/null || true)
+          run_id=$(gh run list --workflow test-impact-map.yml --branch master                      --status success --limit 1 --json databaseId --jq '.[0].databaseId // empty' 2>/dev/null || true)
           if [ -z "$run_id" ]; then
             echo "no successful map build found - selection will escalate to the full matrix"
             exit 0
@@ -664,12 +664,18 @@ jobs:
           # pull request", which is the kind of misleading-but-green log this feature keeps
           # producing when a condition is collapsed.
           #
-          # A master push MUST run everything, and not out of caution: the nightly map is built from
-          # a master run's digests, and any shard that did not run produced no digest, so the map
-          # would mark it always-run. Selecting on master therefore feeds its own gaps back into
-          # the map, and the feature decays a shard at a time into running everything - while
-          # looking like it works. Merge-group runs are the last gate before master and are not
-          # worth reducing either.
+          # What each event gets:
+          #   pull_request   line-level selection against the map
+          #   push (master)  FILE-level selection of the delta from the previously validated commit
+          #   anything else  the full matrix
+          #
+          # Master pushes were originally excluded entirely, because a reduced run produces no
+          # digests for the shards it skipped and "no digest" is what marks a shard always-run - so
+          # selecting on master fed its own gaps back into the map until the feature decayed into
+          # running everything while looking healthy. That is now closed at the source instead: the
+          # nightly map build only harvests a run whose shard-job count matches the shard list, so a
+          # reduced run can never become a map. Merge-group runs are the last gate before master and
+          # are still not reduced.
           $selectorTrusted = '${{ steps.selftest.outcome }}' -eq 'success'
           $eventCanReduce  = '${{ github.event_name }}' -eq 'pull_request'
 
@@ -691,7 +697,7 @@ jobs:
             # that is true no matter how stale the PR was.
             $prev = gh api --method GET "repos/${{ github.repository }}/actions/workflows/sonarcloud.yml/runs" `
                       -f event=push -f branch=master -f status=completed -f per_page=10 `
-                      --jq '[.workflow_runs[] | select(.head_sha != "${{ github.sha }}")][0].head_sha' 2>$null
+                      --jq '[.workflow_runs[] | select(.head_sha != "${{ github.sha }}")][0].head_sha // empty' 2>$null
             if (-not $prev) {
               Write-Host '::warning::no previously validated master commit - running the full matrix'
             }

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -32,6 +32,11 @@ on:
         description: 'Optional: GitHub repo for PR decoration (e.g. owner/repo). Used only when pr_number is set.'
         required: false
         default: 'ooples/AiDotNet'
+      collect_coverage_everywhere:
+        description: 'Collect coverage on heavy and timing shards too, so the test-impact map can cover them. Slower and memory-hungry; intended for the nightly map-feeding run, not for PR validation.'
+        required: false
+        type: boolean
+        default: false
   schedule:
     # Weekly CodeQL scan on Mondays at 8am UTC
     - cron: '0 8 * * 1'
@@ -1008,7 +1013,18 @@ jobs:
           # now split into D/E/F, each serialized like every other heavy shard and each given a
           # 60-minute ceiling to pay for the lost concurrency.
           $serializeShard = $heavyShard
-          $collectCoverage = -not ($heavyShard -or $measuresTiming)
+          # Heavy and timing shards normally skip coverage - the first for memory, the second
+          # because instrumentation distorts the ratios under test. That is right for PR
+          # validation, and it is also why 91 of 116 shards can never appear in the test-impact
+          # map and must always run, which caps selection at the 25 cheapest shards.
+          #
+          # The memory ceiling belongs to the PR matrix, not to a nightly job, so a dispatch can
+          # ask for coverage everywhere. That run feeds the map; it is not meant to gate a PR.
+          $forceCoverage = '${{ github.event.inputs.collect_coverage_everywhere }}' -eq 'true'
+          $collectCoverage = $forceCoverage -or -not ($heavyShard -or $measuresTiming)
+          if ($forceCoverage -and ($heavyShard -or $measuresTiming)) {
+            Write-Host 'collect_coverage_everywhere: coverage forced on for this shard to feed the test-impact map'
+          }
           Write-Host "Running shard '$shardName' (serialized: $serializeShard; coverage: $collectCoverage)"
 
           # Build the argument list as a PowerShell array so the `--`
@@ -1330,7 +1346,13 @@ jobs:
       # recorded as always-run in the map instead, which is what stops selection silently skipping
       # exactly the shards that have OOM-killed runners.
       - name: Build test-impact digest
-        if: always()
+        # Only from a test run that COMPLETED. A shard killed part-way still writes a coverage
+        # file, but one describing just the tests that ran - so the map would record it as not
+        # executing lines it really does, and selection would skip it for a change it covers.
+        # That is a silent miss, and it is likelier here than anywhere: forcing coverage onto
+        # heavy shards is exactly what pushes them into an OOM. A shard that fails simply
+        # produces no digest and stays always-run, which is the safe direction.
+        if: steps.shard-tests.outcome == 'success'
         continue-on-error: true
         shell: pwsh
         run: |

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -586,9 +586,12 @@ jobs:
         run: |
           # The map is published by test-impact-map.yml on a schedule. Absent, stale or
           # unreadable are all handled the same way downstream: run everything.
-          run_id=$(gh run list --workflow test-impact-map.yml --branch master                      --status success --limit 1 --json databaseId --jq '.[0].databaseId')
+          # `|| true`: bash steps run with `set -e`, and gh exits non-zero when the workflow does
+          # not exist yet - which is the normal state until test-impact-map.yml reaches master.
+          # Without this the step dies before reaching the message explaining why there is no map.
+          run_id=$(gh run list --workflow test-impact-map.yml --branch master                      --status success --limit 1 --json databaseId --jq '.[0].databaseId' 2>/dev/null || true)
           if [ -z "$run_id" ]; then
-            echo "no successful map build found"
+            echo "no successful map build found - selection will escalate to the full matrix"
             exit 0
           fi
           gh run download "$run_id" --name shard-map --dir map || echo "map artifact unavailable"

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -645,16 +645,34 @@ jobs:
       - name: Verify the impact tooling
         id: selftest
         continue-on-error: true
+        # A HUNG self-test would otherwise burn the job's 15-minute ceiling and kill the whole
+        # job before any matrix output is written; a step timeout converts it into outcome=failure,
+        # which the gate below turns into a full-matrix run.
+        timeout-minutes: 5
         shell: pwsh
         run: |
           ./tools/TestImpact/Select-Shards.ps1 -SelfTest
           if ($LASTEXITCODE -ne 0) { throw 'Select-Shards self-test failed' }
           ./tools/TestImpact/New-ShardMap.ps1 -SelfTest
           if ($LASTEXITCODE -ne 0) { throw 'New-ShardMap self-test failed' }
+          # These two authorize the carry path and the nightly audit respectively; untested
+          # tooling must not gate either.
+          ./tools/TestImpact/Select-CoverageShards.ps1 -SelfTest
+          if ($LASTEXITCODE -ne 0) { throw 'Select-CoverageShards self-test failed' }
+          ./tools/TestImpact/Measure-SelectionMiss.ps1 -SelfTest
+          if ($LASTEXITCODE -ne 0) { throw 'Measure-SelectionMiss self-test failed' }
 
       - name: Select
         id: select
         shell: pwsh
+        env:
+          # Both values are attacker- or typo-influenced text interpolated into code if
+          # written inline: a single quote in either would terminate the pwsh literal - a
+          # repo VARIABLE with a quote would brick every run of this job, and the dispatch
+          # input is a script-injection vector with the job token in scope (the map workflow
+          # already passes its equivalent as env for exactly this reason). Env is data.
+          TEST_IMPACT_MODE: ${{ vars.TEST_IMPACT_MODE }}
+          INPUT_MAP_RUN_ID: ${{ inputs.test_impact_map_run_id }}
         run: |
           $all = @(yq -o=json -I=0 '.shard' .github/test-shards.yml | ConvertFrom-Json)
           if ($all.Count -eq 0) {
@@ -746,7 +764,7 @@ jobs:
           #
           # Set the repository variable TEST_IMPACT_MODE to 'enforce' once that data supports it.
           # Any other value, including unset, means shadow.
-          $mode = '${{ vars.TEST_IMPACT_MODE }}'
+          $mode = [string] $env:TEST_IMPACT_MODE
           if ($mode -ne 'enforce') {
             $wouldRun = $matrixShards.Count
             $shadowNote = if ($escalate) { "would have escalated to all $($all.Count)" }
@@ -833,7 +851,11 @@ jobs:
                 $prevSha = [string] $prevMap.sha
                 & git cat-file -e "$prevSha^{commit}" 2>$null
                 if ($LASTEXITCODE -ne 0) { throw "previous map commit $prevSha is not in this checkout" }
-                $changedFiles = @(& git diff --name-only $prevSha HEAD)
+                # --no-renames: a rename otherwise lists only the NEW path while digests key
+                # the OLD one, so the byte-identity check never sees it; as delete+add both sides
+                # dirty correctly. quotepath=false matches the selection-side diffs - an
+                # octal-escaped non-ASCII path can never equal a map key.
+                $changedFiles = @(& git -c core.quotepath=false diff --no-renames --name-only $prevSha HEAD)
                 if ($LASTEXITCODE -ne 0) { throw "git diff from $prevSha failed" }
                 ./tools/TestImpact/Select-CoverageShards.ps1 `
                     -PreviousMap map/shard-map.json `
@@ -859,7 +881,11 @@ jobs:
             "### Incremental instrumentation`n`ncarrying $($carried.Count) shard(s) forward; instrumenting the rest." |
               Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8
 
-            $mapRunId = '${{ inputs.test_impact_map_run_id }}'
+            $mapRunId = [string] $env:INPUT_MAP_RUN_ID
+            if ($mapRunId -and $mapRunId -notmatch '^[0-9]+$') {
+              Write-Host "::warning::test_impact_map_run_id is not numeric - ignoring it"
+              $mapRunId = ''
+            }
             if (-not $mapRunId) { $mapRunId = '${{ steps.map.outputs.run_id }}' }
             [ordered]@{
               schemaVersion = 1
@@ -1487,7 +1513,9 @@ jobs:
 
       # Test-impact digest: the executed source lines for this shard, ~200 KB against the coverage
       # XML's ~234 MB. Uploaded separately so the nightly map build downloads kilobytes per shard
-      # rather than a quarter of a gigabyte; the XML stays available as a rebuild fallback.
+      # rather than a quarter of a gigabyte. The digests are the DURABLE
+      # input: on coverage-everywhere runs the raw XML artifact is kept only one day, so it is a
+      # same-day diagnostic, not a rebuild fallback.
       #
       # Shards without a complete successful coverage-producing test step emit no digest and are
       # classified as always-run by the map producer.

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -576,6 +576,10 @@ jobs:
   select-shards:
     name: Select shards
     runs-on: ubuntu-latest
+    # The whole test matrix waits on this job through `needs`, and it makes uncapped network calls
+    # (gh run list, gh run download). Without a cap it inherits the 360-minute default, so one
+    # stalled artifact download parks all 116 shards for six hours.
+    timeout-minutes: 15
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -166,7 +166,7 @@ jobs:
           #
           # Reuse needs a COMPLETED run, but this job starts seconds after the merge, so a PR
           # merged while its validation was still running has nothing to reuse and master re-runs
-          # all ~115 shards. That is exactly what happened to #2004: merged 21:49:03Z with its run
+          # the full matrix. That is exactly what happened to #2004: merged 21:49:03Z with its run
           # still in flight. Waiting bridges the gap; a run that lands inside the window saves the
           # entire matrix.
           #
@@ -264,7 +264,7 @@ jobs:
               echo "PR #${pr_number} validation still running after ${REUSE_WAIT_MINUTES}m; full CI will run." >> "$GITHUB_STEP_SUMMARY"
               exit 0
             fi
-            echo "PR #${pr_number} validation in flight; waiting so master can reuse it instead of repeating ~115 shards."
+            echo "PR #${pr_number} validation in flight; waiting so master can reuse it instead of repeating the full matrix."
             sleep 60
           done
 

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -37,14 +37,18 @@ on:
         required: false
         type: boolean
         default: false
+      test_impact_map_run_id:
+        description: 'Internal: exact Test impact map run whose artifact should be audited against this forced run.'
+        required: false
+        default: ''
   schedule:
     # Weekly CodeQL scan on Mondays at 8am UTC
     - cron: '0 8 * * 1'
 
 concurrency:
-  # Keep only the newest run for a PR, merge-group ref, or protected branch. A master push
-  # normally reuses its exact-tree PR artifacts, so it no longer queues another test matrix.
-  group: build-${{ github.event.pull_request.number || github.ref }}
+  # Coverage-map runs are deliberately isolated from ordinary master activity. The Monday CodeQL
+  # schedule and a master push must not cancel the full matrix that feeds the next map.
+  group: build-${{ inputs.collect_coverage_everywhere && 'coverage-map' || github.event.pull_request.number || github.ref }}
   # A synchronize event captured while a PR was still a draft can be delivered after the
   # ready_for_review run has started. Its job-level draft gates intentionally skip validation,
   # so it must never cancel the real ready run and replace it with an all-skipped check suite.
@@ -619,11 +623,13 @@ jobs:
           run_id=$(gh run list --workflow test-impact-map.yml --branch master                      --status success --limit 1 --json databaseId --jq '.[0].databaseId // empty' 2>/dev/null || true)
           if [ -z "$run_id" ]; then
             echo "no successful map build found - selection will escalate to the full matrix"
+            echo "run_id=" >> "$GITHUB_OUTPUT"
             exit 0
           fi
+          echo "run_id=$run_id" >> "$GITHUB_OUTPUT"
           gh run download "$run_id" --name shard-map --dir map || echo "map artifact unavailable"
 
-      # The selector's own tests, run here rather than nowhere. Two defects on this PR were caught
+      # The impact tooling's own tests, run here rather than nowhere. Two defects on this PR were caught
       # only because these exist - reading the wrong side of a diff hunk, and a staleness check that
       # silently pinned the feature off - and both looked healthy in the logs.
       #
@@ -632,11 +638,15 @@ jobs:
       # instead would block every PR in the repo on a tooling bug while adding no safety, since the
       # behaviour it forces is the behaviour escalation already gives. The error annotation below is
       # what makes it visible.
-      - name: Verify the selector
+      - name: Verify the impact tooling
         id: selftest
         continue-on-error: true
         shell: pwsh
-        run: ./tools/TestImpact/Select-Shards.ps1 -SelfTest
+        run: |
+          ./tools/TestImpact/Select-Shards.ps1 -SelfTest
+          if ($LASTEXITCODE -ne 0) { throw 'Select-Shards self-test failed' }
+          ./tools/TestImpact/New-ShardMap.ps1 -SelfTest
+          if ($LASTEXITCODE -ne 0) { throw 'New-ShardMap self-test failed' }
 
       - name: Select
         id: select
@@ -666,59 +676,14 @@ jobs:
           # pull request", which is the kind of misleading-but-green log this feature keeps
           # producing when a condition is collapsed.
           #
-          # What each event gets:
-          #   pull_request   line-level selection against the map
-          #   push (master)  FILE-level selection of the delta from the previously validated commit
-          #   anything else  the full matrix
-          #
-          # Master pushes were originally excluded entirely, because a reduced run produces no
-          # digests for the shards it skipped and "no digest" is what marks a shard always-run - so
-          # selecting on master fed its own gaps back into the map until the feature decayed into
-          # running everything while looking healthy. That is now closed at the source instead: the
-          # nightly map build only harvests a run whose shard-job count matches the shard list, so a
-          # reduced run can never become a map. Merge-group runs are the last gate before master and
-          # are still not reduced.
+          # Only pull requests may reduce. Pushes, merge groups, schedules and dispatches run the
+          # full matrix. Exact-tree master reuse is handled independently by validation-source;
+          # selecting a master delta here would create a second, weaker reuse mechanism.
           $selectorTrusted = '${{ steps.selftest.outcome }}' -eq 'success'
           $eventCanReduce  = '${{ github.event_name }}' -eq 'pull_request'
 
           if (-not $selectorTrusted) {
-            Write-Host '::error::the shard selector failed its own self-test - running the full matrix. Fix tools/TestImpact/Select-Shards.ps1.'
-          }
-          elseif ('${{ github.event_name }}' -eq 'push' -and (Test-Path map/shard-map.json)) {
-            # MASTER PUSH: validate the delta from the last master commit that was itself
-            # validated, rather than repeating the whole matrix.
-            #
-            # This is the waste that motivated the feature. Master's push for the #2073 merge
-            # re-ran all 116 shards to rediscover the same 3 pre-existing failures the PR had
-            # already found across 115 - because exact-tree reuse could not fire, master having
-            # moved 64 commits while the PR was open.
-            #
-            # The previous master commit is the right reference, NOT the PR's tested tree. The
-            # diff from a stale PR's tree is all of master's intervening commits, which is huge;
-            # the diff from the previous master commit is just the merged PR's own changes, and
-            # that is true no matter how stale the PR was.
-            # status=completed is NOT enough: it includes cancelled and timed_out. With
-            # cancel-in-progress on this workflow a cancelled master run is common, and taking one
-            # as the baseline would treat an UNVALIDATED commit as already tested - so everything
-            # changed between the last genuinely tested commit and that one would never be
-            # validated by anything. A silent miss.
-            #
-            # success or failure, matching the reuse logic above: a red run still executed the
-            # tests and so still tells us what that tree does. A cancelled one does not.
-            $prev = gh api --method GET "repos/${{ github.repository }}/actions/workflows/sonarcloud.yml/runs" `
-                      -f event=push -f branch=master -f status=completed -f per_page=10 `
-                      --jq '[.workflow_runs[] | select(.head_sha != "${{ github.sha }}") | select(.conclusion == "success" or .conclusion == "failure")][0].head_sha // empty' 2>$null
-            if (-not $prev) {
-              Write-Host '::warning::no previously validated master commit - running the full matrix'
-            }
-            else {
-              Write-Host "master push: validating the delta from $prev"
-              & ./tools/TestImpact/Select-Shards.ps1 `
-                  -MapFile map/shard-map.json -FileLevelFrom $prev -OutFile selection.json
-              $result = Get-Content selection.json -Raw | ConvertFrom-Json
-              $escalate = [bool] $result.escalate
-              $selected = @($result.shards)
-            }
+            Write-Host '::error::the impact tooling failed its own self-test - running the full matrix.'
           }
           elseif (-not $eventCanReduce) {
             Write-Host "event is '${{ github.event_name }}', not a pull request - running the full matrix"
@@ -727,7 +692,9 @@ jobs:
             # No base ref: the diff is taken from the map's own commit, which is the only
             # reference whose line numbers the map's ranges are expressed in.
             & ./tools/TestImpact/Select-Shards.ps1 `
-                -MapFile map/shard-map.json -OutFile selection.json
+                -MapFile map/shard-map.json `
+                -ExpectedShards @($all.name) `
+                -OutFile selection.json
             $result = Get-Content selection.json -Raw | ConvertFrom-Json
             $escalate = [bool] $result.escalate
             $selected = @($result.shards)
@@ -761,11 +728,12 @@ jobs:
             }
           }
 
-          # An empty matrix does not fail - it silently runs no tests and lets every downstream
-          # gate pass. That is the one outcome worse than running everything, so it is a hard error.
+          # Empty is uncertainty, not permission to run nothing. Preserve the fail-safe contract
+          # even if a future selector regression reaches this second line of defence.
           if ($matrixShards.Count -eq 0) {
-            Write-Host '::error::shard selection produced an empty matrix'
-            exit 1
+            Write-Host '::warning::shard selection produced an empty matrix - running the full matrix'
+            $matrixShards = $all
+            $escalate = $true
           }
 
           # Slug exactly as the test job does, because that string is the regression analyzer's
@@ -788,24 +756,51 @@ jobs:
                      else { "Selected **$($matrixShards.Count)** of $($all.Count) shards from coverage." }
           "### Shard selection`n`n$summary" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8
 
+          if ('${{ inputs.collect_coverage_everywhere }}' -eq 'true') {
+            $mapRunId = '${{ inputs.test_impact_map_run_id }}'
+            if (-not $mapRunId) { $mapRunId = '${{ steps.map.outputs.run_id }}' }
+            [ordered]@{
+              schemaVersion = 1
+              forcedCoverage = $true
+              runId = '${{ github.run_id }}'
+              runAttempt = '${{ github.run_attempt }}'
+              sha = '${{ github.sha }}'
+              mapRunId = $mapRunId
+              shardNames = @($all.name)
+            } | ConvertTo-Json -Depth 5 | Set-Content coverage-source.json -Encoding utf8
+          }
+
+      - name: Upload coverage-source marker
+        if: ${{ inputs.collect_coverage_everywhere }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
+        with:
+          name: test-impact-coverage-source
+          path: coverage-source.json
+          if-no-files-found: error
+          retention-days: 7
+          overwrite: true
+
   test-net10-sharded:
     name: Tests (${{ matrix.shard.framework }}) - ${{ matrix.shard.name }}
     runs-on: ubuntu-latest
     needs: [build, validation-source, select-shards]
-    # A shard may raise its own ceiling; the default also reserves five minutes beyond the
-    # historical cap for the targeted PR-new retry performed by the regression analyzer.
-    timeout-minutes: ${{ matrix.shard.timeout || 50 }}
+    # Forced coverage materially extends both test execution and post-test digest work. The live
+    # all-shard experiment proved 50 minutes is too short: Generated Layers U passed every test at
+    # 47.9 minutes, then GitHub canceled the job before its digest step. Ordinary validation keeps
+    # each shard's existing ceiling; the isolated nightly run gets enough room to finish cleanly.
+    timeout-minutes: ${{ inputs.collect_coverage_everywhere && 90 || matrix.shard.timeout || 50 }}
     permissions:
       actions: read
       contents: read
     if: "${{ (github.event_name != 'push' || needs.validation-source.outputs.reuse != 'true') && (github.event.pull_request.draft != true) && !startsWith(github.head_ref, 'release-please--') && !(github.event_name == 'push' && startsWith(github.event.head_commit.message, 'chore(master): release')) }}"
     strategy:
       fail-fast: false
+      max-parallel: ${{ inputs.collect_coverage_everywhere && 12 || 20 }}
       matrix:
         # The shard list lives in .github/test-shards.yml. It cannot also be a literal here: the
         # selection job filters it down to the shards a change can actually affect, and a matrix
         # is either a literal or an expression. select-shards emits the full list unchanged
-        # whenever it is not confident, so the default behaviour is the same 115-shard matrix.
+        # whenever it is not confident, so the default behaviour is the full test matrix.
         shard: ${{ fromJSON(needs.select-shards.outputs.matrix) }}
 
     steps:
@@ -1031,8 +1026,7 @@ jobs:
           $serializeShard = $heavyShard
           # Heavy and timing shards normally skip coverage - the first for memory, the second
           # because instrumentation distorts the ratios under test. That is right for PR
-          # validation, and it is also why 91 of 116 shards can never appear in the test-impact
-          # map and must always run, which caps selection at the 25 cheapest shards.
+          # validation; the dedicated map-feeding run overrides it under a lower parallelism cap.
           #
           # The memory ceiling belongs to the PR matrix, not to a nightly job, so a dispatch can
           # ask for coverage everywhere. That run feeds the map; it is not meant to gate a PR.
@@ -1357,10 +1351,8 @@ jobs:
       # XML's ~234 MB. Uploaded separately so the nightly map build downloads kilobytes per shard
       # rather than a quarter of a gigabyte; the XML stays available as a rebuild fallback.
       #
-      # Heavy and timing shards collect no coverage at all ($collectCoverage above is
-      # `-not ($heavyShard -or $measuresTiming)`), so they legitimately produce no digest. They are
-      # recorded as always-run in the map instead, which is what stops selection silently skipping
-      # exactly the shards that have OOM-killed runners.
+      # Shards without a complete successful coverage-producing test step emit no digest and are
+      # classified as always-run by the map producer.
       - name: Build test-impact digest
         # Only from a test run that COMPLETED. A shard killed part-way still writes a coverage
         # file, but one describing just the tests that ran - so the map would record it as not
@@ -1396,6 +1388,7 @@ jobs:
           name: impact-digest-${{ env.ARTIFACT_NAME }}
           path: impact-digest/*.digest.json
           if-no-files-found: ignore
+          retention-days: 7
 
       - name: Upload coverage + test results
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
@@ -1409,6 +1402,9 @@ jobs:
             TestResults/shard-metadata.json
             TestResults/rerun-candidates.json
           if-no-files-found: error
+          # A forced all-shard run is several GiB. The compact digests above are the durable input;
+          # raw coverage only needs to survive long enough for immediate diagnosis.
+          retention-days: ${{ inputs.collect_coverage_everywhere && 1 || 14 }}
 
       # Keep the aggregate diagnostic input small. Downloading every coverage XML merely to inspect
       # TRX results makes the final reporter needlessly slow and expensive, while this artifact also

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -667,6 +667,34 @@ jobs:
           if (-not $selectorTrusted) {
             Write-Host '::error::the shard selector failed its own self-test - running the full matrix. Fix tools/TestImpact/Select-Shards.ps1.'
           }
+          elseif ('${{ github.event_name }}' -eq 'push' -and (Test-Path map/shard-map.json)) {
+            # MASTER PUSH: validate the delta from the last master commit that was itself
+            # validated, rather than repeating the whole matrix.
+            #
+            # This is the waste that motivated the feature. Master's push for the #2073 merge
+            # re-ran all 116 shards to rediscover the same 3 pre-existing failures the PR had
+            # already found across 115 - because exact-tree reuse could not fire, master having
+            # moved 64 commits while the PR was open.
+            #
+            # The previous master commit is the right reference, NOT the PR's tested tree. The
+            # diff from a stale PR's tree is all of master's intervening commits, which is huge;
+            # the diff from the previous master commit is just the merged PR's own changes, and
+            # that is true no matter how stale the PR was.
+            $prev = gh api --method GET "repos/${{ github.repository }}/actions/workflows/sonarcloud.yml/runs" `
+                      -f event=push -f branch=master -f status=completed -f per_page=10 `
+                      --jq '[.workflow_runs[] | select(.head_sha != "${{ github.sha }}")][0].head_sha' 2>$null
+            if (-not $prev) {
+              Write-Host '::warning::no previously validated master commit - running the full matrix'
+            }
+            else {
+              Write-Host "master push: validating the delta from $prev"
+              & ./tools/TestImpact/Select-Shards.ps1 `
+                  -MapFile map/shard-map.json -FileLevelFrom $prev -OutFile selection.json
+              $result = Get-Content selection.json -Raw | ConvertFrom-Json
+              $escalate = [bool] $result.escalate
+              $selected = @($result.shards)
+            }
+          }
           elseif (-not $eventCanReduce) {
             Write-Host "event is '${{ github.event_name }}', not a pull request - running the full matrix"
           }

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -730,6 +730,30 @@ jobs:
 
           # Empty is uncertainty, not permission to run nothing. Preserve the fail-safe contract
           # even if a future selector regression reaches this second line of defence.
+          # SHADOW MODE, and it is the default on purpose.
+          #
+          # The reduced path cannot be exercised before this merges: the map is published by
+          # test-impact-map.yml, which cannot run until it is on master, so every run here
+          # escalates and the first real reduction would otherwise happen in production. Shadow
+          # mode closes that gap - selection is computed and reported exactly as it would be, and
+          # then the FULL matrix runs anyway. Zero risk, and it produces the one thing missing:
+          # real data on what selection would have skipped, which Measure-SelectionMiss checks
+          # against what actually failed.
+          #
+          # Set the repository variable TEST_IMPACT_MODE to 'enforce' once that data supports it.
+          # Any other value, including unset, means shadow.
+          $mode = '${{ vars.TEST_IMPACT_MODE }}'
+          if ($mode -ne 'enforce') {
+            $wouldRun = $matrixShards.Count
+            $shadowNote = if ($escalate) { "would have escalated to all $($all.Count)" }
+                          else { "would have run $wouldRun of $($all.Count)" }
+            Write-Host "shadow mode (TEST_IMPACT_MODE='$mode'): $shadowNote - running the full matrix anyway"
+            "### Shard selection (shadow)`n`n$shadowNote. Set the repository variable ``TEST_IMPACT_MODE`` to ``enforce`` to act on this." |
+              Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8
+            $matrixShards = $all
+            $escalate = $true
+          }
+
           if ($matrixShards.Count -eq 0) {
             Write-Host '::warning::shard selection produced an empty matrix - running the full matrix'
             $matrixShards = $all

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -566,6 +566,10 @@ jobs:
     outputs:
       matrix: ${{ steps.select.outputs.matrix }}
       escalated: ${{ steps.select.outputs.escalated }}
+      # Slugs of the shards deliberately not run, for the regression analyzer. It treats any
+      # baseline shard with no current artifact as Incomplete and fails the policy on it - which
+      # is right for a host that died and wrong for a shard we chose to skip.
+      skipped: ${{ steps.select.outputs.skipped }}
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v4
@@ -660,8 +664,20 @@ jobs:
             exit 1
           }
 
+          # Slug exactly as the test job does, because that string is the regression analyzer's
+          # shard key - it reads it back from shard-metadata.json.
+          $running = [System.Collections.Generic.HashSet[string]]::new(
+              [string[]] @($matrixShards.name), [System.StringComparer]::Ordinal)
+          $skipped = @(
+            $all |
+              Where-Object { -not $running.Contains([string] $_.name) } |
+              ForEach-Object { $_.name -replace '[\\/:*?"<>|\s-]+', '_' }
+          )
+
           $json = ConvertTo-Json -InputObject @($matrixShards) -Depth 5 -Compress
           "matrix=$json" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+          "skipped=$(ConvertTo-Json -InputObject @($skipped) -Depth 3 -Compress)" |
+            Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
           "escalated=$($escalate.ToString().ToLowerInvariant())" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
 
           $summary = if ($escalate) { "Running the full matrix ($($all.Count) shards)." }
@@ -1660,6 +1676,7 @@ jobs:
       - build
       - test-net10-sharded
       - validation-source
+      - select-shards
     permissions:
       actions: read
       contents: read
@@ -1809,12 +1826,38 @@ jobs:
           TRX_DOWNLOAD_OUTCOME: ${{ steps.baseline-trx-download.outcome }}
           PROMOTED_TRX_DOWNLOAD_OUTCOME: ${{ steps.promoted-trx-download.outcome }}
         run: |
+          # A baseline shard with no current artifact is Incomplete, and enough of those fail the
+          # policy. That rule is right for a host that died mid-run and wrong for a shard that
+          # selection deliberately did not run, so the skipped ones are merged into the approved
+          # shard-change manifest as explicit removals.
+          #
+          # This does not let a skipped shard launder a failure into a fix: $fixed requires an
+          # explicit current PASS, and a test that never ran has neither a pass nor a fail, so its
+          # baseline failure lands in baselineFailuresNotObserved, which earns no policy credit.
+          $manifest = Get-Content '.github/test-shard-changes.json' -Raw | ConvertFrom-Json
+          $changes = [System.Collections.Generic.List[object]]::new()
+          foreach ($c in @($manifest.changes)) { [void] $changes.Add($c) }
+          foreach ($slug in @('${{ needs.select-shards.outputs.skipped }}' | ConvertFrom-Json)) {
+            if (-not $slug) { continue }
+            [void] $changes.Add([PSCustomObject]@{
+              baselineKey = [string] $slug
+              currentKeys = @()
+              reason      = 'not selected: no line this PR changed is executed by this shard'
+            })
+          }
+          [PSCustomObject]@{
+            schemaVersion = 1
+            description   = 'Checked-in shard changes plus the shards test-impact selection skipped for this run.'
+            changes       = @($changes)
+          } | ConvertTo-Json -Depth 6 | Set-Content merged-shard-changes.json -Encoding utf8
+          Write-Host "approved shard changes: $($changes.Count) ($(@($manifest.changes).Count) checked in, $($changes.Count - @($manifest.changes).Count) skipped by selection)"
+
           $arguments = @{
             CurrentResultsPath = 'current-test-results'
             OutputDirectory = 'test-regression-analysis'
             CurrentSha = $env:CURRENT_SHA
             RepositoryPath = '.'
-            ApprovedShardChangesPath = '.github/test-shard-changes.json'
+            ApprovedShardChangesPath = 'merged-shard-changes.json'
           }
           $ledger = Get-ChildItem baseline-ledger -Recurse -Filter ledger.json -ErrorAction SilentlyContinue |
             Select-Object -First 1

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -1957,6 +1957,44 @@ jobs:
           echo "ARTIFACT_NAME=coverage-${{ github.sha }}-$slug" >> $env:GITHUB_ENV
           echo "TEST_RESULTS_ARTIFACT_NAME=test-results-${{ github.sha }}-$slug" >> $env:GITHUB_ENV
 
+      # Test-impact digest: the executed source lines for this shard, ~200 KB against the coverage
+      # XML's ~234 MB. Uploaded separately so the nightly map build downloads kilobytes per shard
+      # rather than a quarter of a gigabyte; the XML stays available as a rebuild fallback.
+      #
+      # Heavy and timing shards collect no coverage at all ($collectCoverage above is
+      # `-not ($heavyShard -or $measuresTiming)`), so they legitimately produce no digest. They are
+      # recorded as always-run in the map instead, which is what stops selection silently skipping
+      # exactly the shards that have OOM-killed runners.
+      - name: Build test-impact digest
+        if: always()
+        continue-on-error: true
+        shell: pwsh
+        run: |
+          $coverage = @(Get-ChildItem -Path TestResults -Filter 'coverage.opencover.xml' -Recurse -File -ErrorAction SilentlyContinue |
+              Sort-Object Length -Descending)
+          if ($coverage.Count -eq 0) {
+            Write-Host "no coverage for '${{ matrix.shard.name }}' - this shard must be listed as always-run"
+            exit 0
+          }
+
+          # Largest wins: the collector writes both a raw file and an attachment copy of the same
+          # run, and a truncated copy would silently under-report executed lines.
+          New-Item -ItemType Directory -Path impact-digest -Force | Out-Null
+          $slug = "${{ matrix.shard.name }}" -replace '[\\/:*?"<>|\s-]+', '_'
+          & ./tools/TestImpact/New-CoverageDigest.ps1 `
+              -CoverageXml $coverage[0].FullName `
+              -Shard "${{ matrix.shard.name }}" `
+              -OutFile "impact-digest/$slug.digest.json"
+
+      - name: Upload test-impact digest
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
+        if: always()
+        continue-on-error: true
+        with:
+          name: impact-digest-${{ env.ARTIFACT_NAME }}
+          path: impact-digest/*.digest.json
+          if-no-files-found: ignore
+
       - name: Upload coverage + test results
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
         if: always()

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -601,6 +601,10 @@ jobs:
       # baseline shard with no current artifact as Incomplete and fails the policy on it - which
       # is right for a host that died and wrong for a shard we chose to skip.
       skipped: ${{ steps.select.outputs.skipped }}
+      # Shards whose digests are carried forward from the previous map in a coverage-everywhere
+      # run. The test job does not force instrumentation on them; the carried-digest artifact
+      # below supplies their map entries instead.
+      coverage_carried: ${{ steps.select.outputs.coverage_carried }}
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v4
@@ -780,7 +784,81 @@ jobs:
                      else { "Selected **$($matrixShards.Count)** of $($all.Count) shards from coverage." }
           "### Shard selection`n`n$summary" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8
 
+          $carried = @()
           if ('${{ inputs.collect_coverage_everywhere }}' -eq 'true') {
+            # INCREMENTAL INSTRUMENTATION. A shard whose covered files are byte-identical between
+            # the previous map's commit and this one has line ranges that still mean what they
+            # said, so its digest is carried forward instead of re-measured - instrumentation
+            # costs 3.21x on heavy shards, and most nights most of them are untouched.
+            #
+            # Only shards that collect no coverage naturally (heavy + timing) are carriable:
+            # every other shard produces a fresh digest in any successful run, and New-ShardMap
+            # aborts the whole map on a duplicate digest, by design. That list lives in the test
+            # job's run step in THIS file; it is parsed out of the workflow source below so there
+            # is no second copy to drift. Both drift directions are safe: a missed name simply is
+            # not carried (that shard degrades to always-run), and a stale extra name produces a
+            # duplicate digest that aborts the map build LOUDLY while the previous map stays in
+            # effect.
+            # Matched on the TRIMMED line being exactly the definition, never Contains: these
+            # marker strings also appear inside THIS parser's own source a few lines up, and a
+            # Contains match latched onto itself, then collected every quoted string for the ~450
+            # lines between here and the real arrays' closer - 220 names instead of 92. Caught
+            # only because the proof asserted the expected count. A trimmed-equality match cannot
+            # self-match, because this line trims to 'foreach (...)'.
+            $nn = [System.Collections.Generic.List[string]]::new()
+            $wfLines = Get-Content '.github/workflows/sonarcloud.yml'
+            foreach ($marker in @('$heavyShards = @(', '$performanceShards = @(')) {
+              $idx = -1
+              for ($i = 0; $i -lt $wfLines.Count; $i++) {
+                if ($wfLines[$i].Trim() -eq $marker) { $idx = $i; break }
+              }
+              if ($idx -lt 0) { continue }
+              for ($i = $idx + 1; $i -lt $wfLines.Count; $i++) {
+                if ($wfLines[$i].Trim().StartsWith(')')) { break }
+                foreach ($m in [regex]::Matches($wfLines[$i], "'([^']+)'")) {
+                  [void] $nn.Add($m.Groups[1].Value)
+                }
+              }
+            }
+            Write-Host "no-coverage shard list parsed from workflow: $($nn.Count)"
+            if ($nn.Count -lt 2 -or $nn.Count -gt 200) {
+              Write-Host "::warning::no-coverage list parse looks wrong ($($nn.Count) names) - carrying nothing"
+              $nn.Clear()
+            }
+
+            $prevMapOk = (Test-Path map/shard-map.json) -and ('${{ steps.selftest.outcome }}' -eq 'success')
+            if ($prevMapOk -and $nn.Count -ge 2) {
+              try {
+                $prevMap = Get-Content map/shard-map.json -Raw | ConvertFrom-Json
+                $prevSha = [string] $prevMap.sha
+                & git cat-file -e "$prevSha^{commit}" 2>$null
+                if ($LASTEXITCODE -ne 0) { throw "previous map commit $prevSha is not in this checkout" }
+                $changedFiles = @(& git diff --name-only $prevSha HEAD)
+                if ($LASTEXITCODE -ne 0) { throw "git diff from $prevSha failed" }
+                ./tools/TestImpact/Select-CoverageShards.ps1 `
+                    -PreviousMap map/shard-map.json `
+                    -ChangedFiles $changedFiles `
+                    -AllShards @($all.name) `
+                    -CarryOnly $nn `
+                    -CarryForwardDirectory carried-digests `
+                    -OutFile covsplit.json
+                if ($LASTEXITCODE -ne 0) { throw "Select-CoverageShards exited $LASTEXITCODE" }
+                $carried = @((Get-Content covsplit.json -Raw | ConvertFrom-Json).carried)
+              }
+              catch {
+                # Instrumenting everything is always sound - it is exactly the pre-incremental
+                # behaviour - so any doubt lands there rather than on a stale carry.
+                Write-Host "::warning::incremental carry unavailable ($($_.Exception.Message)) - instrumenting every shard"
+                $carried = @()
+                Remove-Item -Recurse -Force carried-digests -ErrorAction SilentlyContinue
+              }
+            }
+            else {
+              Write-Host 'no usable previous map or no-coverage list - instrumenting every shard'
+            }
+            "### Incremental instrumentation`n`ncarrying $($carried.Count) shard(s) forward; instrumenting the rest." |
+              Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8
+
             $mapRunId = '${{ inputs.test_impact_map_run_id }}'
             if (-not $mapRunId) { $mapRunId = '${{ steps.map.outputs.run_id }}' }
             [ordered]@{
@@ -791,8 +869,23 @@ jobs:
               sha = '${{ github.sha }}'
               mapRunId = $mapRunId
               shardNames = @($all.name)
+              carriedShardNames = @($carried)
             } | ConvertTo-Json -Depth 5 | Set-Content coverage-source.json -Encoding utf8
           }
+          "coverage_carried=$(ConvertTo-Json -InputObject @($carried) -Depth 3 -Compress)" |
+            Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+
+      # Named to match the harvest's `impact-digest-*` download pattern, so the map build picks
+      # these up exactly like per-shard digests with no change on its side.
+      - name: Upload carried digests
+        if: ${{ inputs.collect_coverage_everywhere }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
+        with:
+          name: impact-digest-carried
+          path: carried-digests/*.digest.json
+          if-no-files-found: ignore
+          retention-days: 7
+          overwrite: true
 
       - name: Upload coverage-source marker
         if: ${{ inputs.collect_coverage_everywhere }}
@@ -896,6 +989,9 @@ jobs:
         # Scoped to this test step only (not job-wide) so the credential is not exposed to other steps or
         # third-party actions. Licensed key keeps save/load-heavy suites under the free-trial op limit.
         env:
+          # Via env rather than inline interpolation: the carried list is a JSON array of shard
+          # names, and names contain characters PowerShell would parse inside a quoted literal.
+          COVERAGE_CARRIED: ${{ needs.select-shards.outputs.coverage_carried }}
           # Dedicated enterprise CI license key (save-capable — lifts the persistence op cap under capability
           # gating — with effectively-unlimited activations for ephemeral runners). ModuleInitializer swaps
           # this online AIDN-* key for the deterministic synthetic OFFLINE license so the persistence-heavy
@@ -1054,10 +1150,28 @@ jobs:
           #
           # The memory ceiling belongs to the PR matrix, not to a nightly job, so a dispatch can
           # ask for coverage everywhere. That run feeds the map; it is not meant to gate a PR.
-          $forceCoverage = '${{ github.event.inputs.collect_coverage_everywhere }}' -eq 'true'
+          # A shard whose digest select-shards carried forward is not re-instrumented: its map
+          # entry comes from the carried artifact, and instrumenting it anyway would only spend
+          # the 3.21x overhead re-measuring what is byte-identical. Any parse failure of the
+          # carried list degrades to instrumenting everything, which is the pre-incremental
+          # behaviour and always sound.
+          $carriedSet = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::Ordinal)
+          try {
+            $rawCarried = $env:COVERAGE_CARRIED
+            if ($rawCarried) {
+              foreach ($c in @($rawCarried | ConvertFrom-Json)) { [void] $carriedSet.Add([string] $c) }
+            }
+          }
+          catch { Write-Host "::warning::carried-shard list unreadable - instrumenting this shard" }
+
+          $forceCoverage = '${{ github.event.inputs.collect_coverage_everywhere }}' -eq 'true' -and
+                           -not $carriedSet.Contains($shardName)
           $collectCoverage = $forceCoverage -or -not ($heavyShard -or $measuresTiming)
           if ($forceCoverage -and ($heavyShard -or $measuresTiming)) {
             Write-Host 'collect_coverage_everywhere: coverage forced on for this shard to feed the test-impact map'
+          }
+          elseif ($carriedSet.Contains($shardName) -and ($heavyShard -or $measuresTiming)) {
+            Write-Host 'coverage carried forward from the previous map - not instrumenting this shard'
           }
           Write-Host "Running shard '$shardName' (serialized: $serializeShard; coverage: $collectCoverage)"
 

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -176,6 +176,22 @@ jobs:
             return 2
           fi
 
+          # Merge-queue runs are candidates too, and better ones. A merge_group run validates the
+          # exact commit that is about to become master, so its tree matches by construction -
+          # whereas a pull_request run only matches while master has not moved, which in a busy
+          # repo means almost never. #2073 missed reuse for exactly that reason: 64 commits landed
+          # on master during the six hours it was open, so the merged tree was a combination that
+          # nothing had ever tested, and master repeated all 116 shards to rediscover 3 known
+          # failures.
+          #
+          # They cannot be found by head_sha - a merge_group run's head is the queue's temporary
+          # merge commit, not the PR head - so recent ones are listed unfiltered and left to the
+          # tree comparison below. That comparison is the actual safety property; how a candidate
+          # was found cannot weaken it.
+          if mq_json=$(gh api --method GET             "repos/${GITHUB_REPOSITORY}/actions/workflows/sonarcloud.yml/runs"             -f event=merge_group -f status=completed -f per_page=20 2>/dev/null); then
+            runs_json=$(jq -n --argjson a "$runs_json" --argjson b "$mq_json"               '{workflow_runs: (($a.workflow_runs // []) + ($b.workflow_runs // []))}')
+          fi
+
           # A red test ledger may still be an accepted improvement over baseline, so failure is a
           # usable completed conclusion. Cancelled/timed-out runs are never reusable.
           while IFS= read -r run_id; do

--- a/.github/workflows/test-impact-map.yml
+++ b/.github/workflows/test-impact-map.yml
@@ -36,6 +36,10 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v4
+        with:
+          # The audit below diffs from the PREVIOUS map's commit, which a shallow clone cannot
+          # resolve and which is not an ancestor of anything in particular.
+          fetch-depth: 0
 
       - name: Find the run to harvest
         id: source
@@ -112,3 +116,77 @@ jobs:
           path: shard-map.json
           if-no-files-found: error
           retention-days: 14
+
+      # ---------------------------------------------------------------------------------------
+      # Does selection actually work? Measured, not assumed.
+      #
+      # Selection rests on "a shard that executes none of the changed lines would have passed
+      # anyway". Nothing about a green PR can disprove that: the skipped shard leaves no evidence.
+      # So it is checked against the runs that DID execute everything - replay the selection that
+      # WOULD have been made, and see whether any shard it would have skipped actually failed.
+      #
+      # Audited against the PREVIOUS map, never the one just built. A map built from this very run
+      # records exactly what each shard executed in it, which makes the question circular.
+      #
+      # Runs after the upload on purpose: the map is valid regardless of what the audit finds, and
+      # a miss should turn the workflow red without also withholding the artifact.
+      # ---------------------------------------------------------------------------------------
+      - name: Download the previous map
+        id: prevmap
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # Second-newest successful run: the newest is this one, still in progress.
+          prev=$(gh run list --workflow test-impact-map.yml --branch master --status success                    --limit 2 --json databaseId --jq '.[-1].databaseId' 2>/dev/null || true)
+          if [ -z "$prev" ] || [ "$prev" = "${{ github.run_id }}" ]; then
+            echo "no earlier map to audit against - this is the first build"
+            exit 0
+          fi
+          gh run download "$prev" --name shard-map --dir prevmap || echo "previous map unavailable"
+
+      - name: Audit selection against this run
+        if: always()
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if (-not (Test-Path prevmap/shard-map.json)) {
+            Write-Host 'no previous map - skipping the audit'
+            exit 0
+          }
+
+          # Shard outcomes come from the run's own job list rather than its artifacts. The
+          # alternative is downloading 116 coverage or TRX artifacts to read one field out of each.
+          $jobs = gh api --paginate "repos/${{ github.repository }}/actions/runs/${{ steps.source.outputs.run_id }}/jobs" `
+                    --jq '.jobs[] | select(.name | startswith("Tests (")) | {name, conclusion}' |
+                  ConvertFrom-Json
+          $outcomes = @($jobs | ForEach-Object {
+            # "Tests (net10.0) - Unit - 01 Activation" -> "Unit - 01 Activation". Split on the
+            # FIRST " - " only; shard names contain " - " themselves.
+            $name = [string] $_.name
+            $i = $name.IndexOf(') - ')
+            if ($i -lt 0) { return }
+            [pscustomobject]@{ shard = $name.Substring($i + 4); outcome = [string] $_.conclusion }
+          })
+          if ($outcomes.Count -eq 0) {
+            Write-Host '::warning::no shard jobs found in the audited run - nothing to audit'
+            exit 0
+          }
+          $outcomes | ConvertTo-Json -Depth 3 | Set-Content outcomes.json -Encoding utf8
+          Write-Host "auditing $($outcomes.Count) shard outcome(s), $(@($outcomes | Where-Object outcome -ne 'success').Count) failed"
+
+          # HEAD must be the audited run's commit: the selector diffs from the map's commit to HEAD.
+          & git checkout --quiet '${{ steps.source.outputs.sha }}'
+
+          & ./tools/TestImpact/Measure-SelectionMiss.ps1 `
+              -MapFile prevmap/shard-map.json -OutcomesFile outcomes.json -OutFile audit.json
+          $auditExit = $LASTEXITCODE
+
+          $a = Get-Content audit.json -Raw | ConvertFrom-Json
+          $verdict = if ($a.Escalated) { 'would have escalated - nothing skipped' }
+                     elseif ($a.MissCount -gt 0) { "**$($a.MissCount) MISSED**: $($a.Missed -join ', ')" }
+                     else { 'no misses' }
+          "### Selection audit`n`n- would run $($a.WouldRun)/$($a.TotalShards), skip $($a.WouldSkip)`n- $($a.Failed) shard(s) failed`n- $verdict" |
+            Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8
+          exit $auditExit

--- a/.github/workflows/test-impact-map.yml
+++ b/.github/workflows/test-impact-map.yml
@@ -1,0 +1,114 @@
+name: Test impact map
+
+# Rebuilds the coverage-derived map that drives shard selection in sonarcloud.yml.
+#
+# Nightly rather than per-push because the inputs only change when coverage changes, and a map a
+# few hours old costs nothing: the selector diffs FROM the map's commit, so any master churn since
+# then simply appears as extra changed files and over-selects. Over-selection is the safe direction.
+#
+# Note this workflow never runs tests. It reuses the digests the sharded test job already uploads,
+# so a rebuild is a few artifact downloads and a merge - about a minute, against the two hours a
+# full test run costs.
+
+on:
+  schedule:
+    # 07:00 UTC, after the nightly master activity has settled and before the working day.
+    - cron: '0 7 * * *'
+  workflow_dispatch:
+    inputs:
+      run_id:
+        description: 'Optional: a specific Build & SonarCloud run to harvest digests from.'
+        required: false
+
+permissions: read-all
+
+concurrency:
+  group: test-impact-map
+  cancel-in-progress: true
+
+jobs:
+  build-map:
+    name: Build shard map
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v4
+
+      - name: Find the run to harvest
+        id: source
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          run_id='${{ github.event.inputs.run_id }}'
+          if [ -z "$run_id" ]; then
+            # The most recent master run that actually finished. A cancelled or failed run can
+            # still carry digests, but only for the shards that got that far, and a partial map
+            # would mark the rest unknown - which escalates rather than under-selects, but wastes
+            # the saving. Prefer a clean run.
+            run_id=$(gh run list --workflow sonarcloud.yml --branch master --status success \
+                       --limit 1 --json databaseId --jq '.[0].databaseId')
+          fi
+          if [ -z "$run_id" ]; then
+            echo "::error::no successful master run of sonarcloud.yml to harvest digests from"
+            exit 1
+          fi
+          sha=$(gh run view "$run_id" --json headSha --jq '.headSha')
+          echo "run_id=$run_id" >> "$GITHUB_OUTPUT"
+          echo "sha=$sha"       >> "$GITHUB_OUTPUT"
+          echo "harvesting run $run_id at $sha"
+
+      - name: Download digests
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          mkdir -p digests
+          gh run download '${{ steps.source.outputs.run_id }}' --pattern 'impact-digest-*' --dir digests
+          echo "digest files: $(find digests -name '*.digest.json' | wc -l)"
+
+      - name: Build the map
+        shell: pwsh
+        run: |
+          $all = @(yq -o=json -I=0 '.shard' .github/test-shards.yml | ConvertFrom-Json)
+          $covered = @(
+            Get-ChildItem digests -Filter '*.digest.json' -Recurse -File |
+              ForEach-Object { (Get-Content $_.FullName -Raw | ConvertFrom-Json).shard }
+          )
+
+          # Always-run is DERIVED, not declared: any shard that produced no digest cannot be
+          # selected against, whatever the reason. That covers the heavy and timing shards, which
+          # collect no coverage by design, and also any shard that failed, timed out or was
+          # cancelled in the harvested run. Re-deriving the workflow's coverage predicate here
+          # instead would be a second copy of it, free to drift, and drift in this direction means
+          # a shard silently stops running.
+          $alwaysRun = @($all.name | Where-Object { $covered -notcontains $_ })
+          Write-Host "shards: $($all.Count) total, $($covered.Count) with digests, $($alwaysRun.Count) always-run"
+          foreach ($s in $alwaysRun) { Write-Host "  always-run: $s" }
+
+          if ($covered.Count -eq 0) {
+            Write-Host '::error::no digests found - the map would select nothing and escalate every run'
+            exit 1
+          }
+
+          & ./tools/TestImpact/New-ShardMap.ps1 `
+              -DigestDirectory digests `
+              -AlwaysRun $alwaysRun `
+              -Sha '${{ steps.source.outputs.sha }}' `
+              -OutFile shard-map.json
+
+          $size = [Math]::Round((Get-Item shard-map.json).Length / 1MB, 2)
+          $map = Get-Content shard-map.json -Raw | ConvertFrom-Json
+          $files = @($map.files.PSObject.Properties).Count
+          Write-Host "map: $files file(s), $size MB"
+          "### Shard map rebuilt`n`n- commit ``${{ steps.source.outputs.sha }}```n- $files files indexed`n- $($covered.Count) shards mapped, $($alwaysRun.Count) always-run`n- $size MB" |
+            Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8
+
+      - name: Upload the map
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
+        with:
+          name: shard-map
+          path: shard-map.json
+          if-no-files-found: error
+          retention-days: 14

--- a/.github/workflows/test-impact-map.yml
+++ b/.github/workflows/test-impact-map.yml
@@ -1,26 +1,18 @@
 name: Test impact map
 
-# Rebuilds the coverage-derived map that drives shard selection in sonarcloud.yml.
-#
-# Nightly rather than per-push because the inputs only change when coverage changes, and a map a
-# few hours old costs nothing: the selector diffs FROM the map's commit, so any master churn since
-# then simply appears as extra changed files and over-selects. Over-selection is the safe direction.
-#
-# Note this workflow never runs tests. It reuses the digests the sharded test job already uploads,
-# so a rebuild is a few artifact downloads and a merge - about a minute, against the two hours a
-# full test run costs.
-
+# Each invocation first harvests and audits the previous intentional coverage-everywhere run, then
+# dispatches the next one. The expensive run never overlaps the map decision it will later audit.
 on:
   schedule:
-    # 07:00 UTC, after the nightly master activity has settled and before the working day.
+    # 07:00 UTC, after nightly master activity and before the working day.
     - cron: '0 7 * * *'
   workflow_dispatch:
     inputs:
       run_id:
-        description: 'Optional: a specific Build & SonarCloud run to harvest digests from.'
+        description: 'Optional: a specific marked coverage-everywhere Build & SonarCloud run.'
         required: false
       skip_coverage_run:
-        description: 'Harvest an existing run instead of first dispatching a coverage-everywhere run.'
+        description: 'Build/audit the map without dispatching the next coverage-everywhere run.'
         required: false
         type: boolean
         default: false
@@ -32,70 +24,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  # -----------------------------------------------------------------------------------------
-  # Feed the map with the shards it cannot otherwise see.
-  #
-  # 91 of 116 shards collect no coverage during PR validation - 90 heavy ones because coverage
-  # instrumentation pushes them past the runner's memory envelope, and 2 timing ones because
-  # instrumentation distorts the ratios they assert. They can therefore never appear in the map
-  # and must always run, which caps selection at the 25 cheapest shards and leaves every slow
-  # shard running on every PR. That is most of the cost the feature exists to remove.
-  #
-  # The memory ceiling belongs to the PR matrix, not to a nightly job. So once a night, dispatch
-  # the same workflow with coverage forced on everywhere and harvest THAT.
-  #
-  # Partial success is fine and is the point: a heavy shard that still OOMs produces no digest and
-  # stays always-run, exactly as today. Every shard that survives moves from always-run to
-  # mappable. The feature improves shard by shard and can never regress - and a shard killed
-  # part-way is explicitly excluded, because its coverage would describe only the tests that ran
-  # and the map would then think it does not execute lines it does.
-  # -----------------------------------------------------------------------------------------
-  coverage-run:
-    name: Dispatch coverage-everywhere run
-    runs-on: ubuntu-latest
-    if: github.event.inputs.skip_coverage_run != 'true' && github.event.inputs.run_id == ''
-    permissions:
-      actions: write
-      contents: read
-    outputs:
-      run_id: ${{ steps.dispatch.outputs.run_id }}
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v4
-
-      - name: Dispatch and wait
-        id: dispatch
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          before=$(gh run list --workflow sonarcloud.yml --branch master --event workflow_dispatch                      --limit 1 --json databaseId --jq '.[0].databaseId // 0')
-          gh workflow run sonarcloud.yml --ref master -f collect_coverage_everywhere=true
-
-          # gh prints nothing on success, and a blind retry would start a SECOND full matrix that
-          # cancels the first through the shared concurrency group. Poll for a new id instead.
-          run_id=''
-          for _ in $(seq 1 30); do
-            candidate=$(gh run list --workflow sonarcloud.yml --branch master --event workflow_dispatch                           --limit 1 --json databaseId --jq '.[0].databaseId // 0')
-            if [ "$candidate" != "$before" ] && [ "$candidate" != "0" ]; then
-              run_id="$candidate"
-              break
-            fi
-            sleep 10
-          done
-          if [ -z "$run_id" ]; then
-            echo "::error::the coverage run never registered"
-            exit 1
-          fi
-          echo "coverage run: $run_id"
-          echo "run_id=$run_id" >> "$GITHUB_OUTPUT"
-
-          # It takes hours. Waiting here would burn a runner for the duration, so the map build
-          # simply harvests the newest FULL run - which this one becomes when it finishes. Today's
-          # map is therefore built from last night's coverage run, which is exactly the freshness
-          # the selector already tolerates: it diffs from the map's own commit.
-
   build-map:
-    name: Build shard map
+    name: Build and audit shard map
     runs-on: ubuntu-latest
     permissions:
       actions: read
@@ -104,101 +34,150 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v4
         with:
-          # The audit below diffs from the PREVIOUS map's commit, which a shallow clone cannot
-          # resolve and which is not an ancestor of anything in particular.
+          # The audit diffs from the map that was in effect for the source run.
           fetch-depth: 0
 
-      - name: Find the run to harvest
+      - name: Find a complete marked coverage run
         id: source
         env:
           GH_TOKEN: ${{ github.token }}
-          # Passed as data, never interpolated into the script. A workflow_dispatch input is
-          # attacker-controlled in the same sense as any other user input: inlined as
-          # run_id='${{ ... }}' it can close the quote and run arbitrary bash with GH_TOKEN in
-          # scope. The repository already uses this pattern elsewhere for exactly this reason.
-          INPUT_RUN_ID: ${{ github.event.inputs.run_id }}
+          # Treat workflow_dispatch input as data, never shell source.
+          INPUT_RUN_ID: ${{ inputs.run_id }}
         run: |
-          # Fullness is measured, not assumed: count a run's shard jobs against the shard list.
-          # A reduced run has digests for the shards it ran and none for the rest, and "no digest"
-          # is exactly what marks a shard always-run - so harvesting one would convert every shard
-          # it skipped into an always-run shard until the feature decayed into running everything
-          # while still looking healthy. A cancelled or partly-failed run fails the same check for
-          # the same reason: its digests cover only the shards that got that far.
-          expected=$(yq -o=json -I=0 '.shard' .github/test-shards.yml | jq 'length')
-          shard_jobs() {
-            gh api --paginate "repos/${GITHUB_REPOSITORY}/actions/runs/$1/jobs"               --jq '[.jobs[] | select(.name | startswith("Tests ("))] | length' 2>/dev/null |
-              awk '{s+=$1} END {print s+0}'
+          expected=$(yq -o=json -I=0 '.shard' .github/test-shards.yml | jq -c '[.[].name]')
+          expected_sorted=$(printf '%s' "$expected" | jq -c 'sort')
+          expected_count=$(printf '%s' "$expected" | jq 'length')
+          if [ "$expected_count" -eq 0 ]; then
+            echo "::error::.github/test-shards.yml yielded no shards"
+            exit 1
+          fi
+
+          valid_sha=''
+          valid_map_run_id=''
+
+          validate_candidate() {
+            candidate="$1"
+            meta=$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${candidate}" 2>/dev/null) || {
+              echo "run $candidate does not exist or is not readable"
+              return 1
+            }
+
+            workflow=$(printf '%s' "$meta" | jq -r '.name')
+            branch=$(printf '%s' "$meta" | jq -r '.head_branch')
+            event=$(printf '%s' "$meta" | jq -r '.event')
+            status=$(printf '%s' "$meta" | jq -r '.status')
+            conclusion=$(printf '%s' "$meta" | jq -r '.conclusion // ""')
+            sha=$(printf '%s' "$meta" | jq -r '.head_sha')
+            if [ "$workflow" != 'Build & SonarCloud' ] || [ "$branch" != 'master' ] || \
+               [ "$event" != 'workflow_dispatch' ] || [ "$status" != 'completed' ] || \
+               { [ "$conclusion" != 'success' ] && [ "$conclusion" != 'failure' ]; }; then
+              echo "run $candidate is $workflow/$branch/$event/$status/$conclusion - not a completed coverage source"
+              return 1
+            fi
+
+            marker_dir="candidate-marker-$candidate"
+            mkdir -p "$marker_dir"
+            if ! gh run download "$candidate" --name test-impact-coverage-source --dir "$marker_dir" >/dev/null 2>&1; then
+              echo "run $candidate has no coverage-everywhere marker"
+              return 1
+            fi
+            marker="$marker_dir/coverage-source.json"
+            if [ ! -f "$marker" ] || ! jq -e \
+                 --arg id "$candidate" --arg sha "$sha" \
+                 '.schemaVersion == 1 and .forcedCoverage == true and
+                  (.runId | tostring) == $id and .sha == $sha and (.shardNames | type) == "array"' \
+                 "$marker" >/dev/null; then
+              echo "run $candidate has an invalid coverage-everywhere marker"
+              return 1
+            fi
+            marker_names=$(jq -c '.shardNames | sort' "$marker")
+            if [ "$marker_names" != "$expected_sorted" ]; then
+              echo "run $candidate used a different shard manifest - skipping stale coverage"
+              return 1
+            fi
+
+            jobs=$(gh api --paginate --slurp \
+              "repos/${GITHUB_REPOSITORY}/actions/runs/${candidate}/jobs?per_page=100" 2>/dev/null) || {
+              echo "could not read jobs for run $candidate"
+              return 1
+            }
+            shard_jobs=$(printf '%s' "$jobs" | jq -c \
+              '[.[].jobs[] | select(.name | startswith("Tests (")) |
+                {name: (.name | sub("^Tests \\([^)]*\\) - "; "")), status, conclusion}]')
+            actual_count=$(printf '%s' "$shard_jobs" | jq 'length')
+            actual_names=$(printf '%s' "$shard_jobs" | jq -c '[.[].name] | sort')
+            if [ "$actual_count" -ne "$expected_count" ] || [ "$actual_names" != "$expected_sorted" ]; then
+              echo "run $candidate has $actual_count/$expected_count shard jobs or the wrong names"
+              return 1
+            fi
+            if ! printf '%s' "$shard_jobs" | jq -e \
+                 'all(.[]; .status == "completed" and (.conclusion == "success" or .conclusion == "failure"))' \
+                 >/dev/null; then
+              echo "run $candidate contains a cancelled, skipped, neutral or incomplete shard job"
+              return 1
+            fi
+
+            map_run_id=$(jq -r '.mapRunId // ""' "$marker")
+            case "$map_run_id" in
+              ''|*[!0-9]*)
+                if [ -n "$map_run_id" ]; then
+                  echo "run $candidate marker has invalid mapRunId"
+                  return 1
+                fi
+                ;;
+            esac
+            if [ -n "$map_run_id" ]; then
+              map_meta=$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${map_run_id}" 2>/dev/null) || {
+                echo "run $candidate references an unreadable map run $map_run_id"
+                return 1
+              }
+              if ! printf '%s' "$map_meta" | jq -e \
+                   '.name == "Test impact map" and .head_branch == "master" and .conclusion == "success"' \
+                   >/dev/null; then
+                echo "run $candidate references map run $map_run_id, which was not a successful master map"
+                return 1
+              fi
+            fi
+            valid_sha="$sha"
+            valid_map_run_id="$map_run_id"
+            echo "run $candidate has the exact $expected_count-shard completed matrix"
+            return 0
           }
 
           run_id=''
           if [ -n "${INPUT_RUN_ID:-}" ]; then
-            # Digits only. A run id is numeric, so anything else is not a run id.
             case "$INPUT_RUN_ID" in
-              ''|*[!0-9]*)
-                echo "::error::run_id must be numeric; got an invalid value"
+              *[!0-9]*)
+                echo "::error::run_id must be numeric"
                 exit 1
                 ;;
             esac
-
-            # A hand-supplied id gets the SAME checks as an automatically chosen one. Numeric
-            # syntax only proves it is a run id, not that it is a successful full-matrix
-            # sonarcloud.yml run on master - and a failed or reduced run still carries partial
-            # digests, which would silently mark the shards it happened to run as mapped.
-            meta=$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${INPUT_RUN_ID}"                      --jq '[.name, .head_branch, .conclusion] | @tsv' 2>/dev/null || true)
-            if [ -z "$meta" ]; then
-              echo "::error::run ${INPUT_RUN_ID} does not exist or is not readable"
+            if ! validate_candidate "$INPUT_RUN_ID"; then
+              echo "::error::run $INPUT_RUN_ID is not a valid coverage source"
               exit 1
             fi
-            wf=$(printf '%s' "$meta" | cut -f1)
-            br=$(printf '%s' "$meta" | cut -f2)
-            cc=$(printf '%s' "$meta" | cut -f3)
-            if [ "$wf" != "Build & SonarCloud" ] || [ "$br" != "master" ] || [ "$cc" != "success" ]; then
-              echo "::error::run ${INPUT_RUN_ID} is '$wf' on '$br' with conclusion '$cc'; a successful Build & SonarCloud run on master is required"
-              exit 1
-            fi
-            n=$(shard_jobs "$INPUT_RUN_ID")
-            if [ "${n:-0}" -lt "$expected" ]; then
-              echo "::error::run ${INPUT_RUN_ID} ran only ${n:-0}/$expected shards, so its digests are partial and would mark the missing shards always-run"
-              exit 1
-            fi
-            echo "run ${INPUT_RUN_ID} ran $n/$expected shards - using it"
             run_id="$INPUT_RUN_ID"
-          fi
-
-          if [ -z "$run_id" ]; then
-            # The most recent master run that ran the FULL matrix.
-            #
-            # Not merely the most recent successful one. Master pushes now validate only their
-            # delta from the previously validated commit, so a reduced run has digests for the
-            # shards it ran and none for the rest - and "no digest" is exactly what marks a shard
-            # always-run. Building the map from a reduced run would convert every shard it skipped
-            # into an always-run shard, and the feature would decay into running everything while
-            # still looking healthy.
-            #
-            # Fullness is measured, not assumed: count the run's shard jobs against the shard list.
-            # A cancelled or partly-failed run fails the same check, for the same reason - its
-            # digests cover only the shards that got that far.
-            candidates=$(gh run list --workflow sonarcloud.yml --branch master --status success --limit 15 --json databaseId --jq '.[].databaseId')
+          else
+            candidates=$(gh api --method GET \
+              "repos/${GITHUB_REPOSITORY}/actions/workflows/sonarcloud.yml/runs" \
+              -f branch=master -f event=workflow_dispatch -f status=completed -f per_page=50 \
+              --jq '.workflow_runs[].id')
             for candidate in $candidates; do
-              n=$(shard_jobs "$candidate")
-              if [ "${n:-0}" -ge "$expected" ]; then
+              if validate_candidate "$candidate"; then
                 run_id="$candidate"
-                echo "run $candidate ran $n/$expected shards - using it"
                 break
               fi
-              echo "run $candidate ran only ${n:-0}/$expected shards - skipping (reduced or partial)"
             done
           fi
 
           if [ -z "$run_id" ]; then
-            echo "::error::no master run in the last 15 ran the full matrix, so no complete digest set exists. Dispatch sonarcloud.yml on master (workflow_dispatch escalates by design) before rebuilding the map."
+            echo "::error::no recent completed run has both the coverage marker and the exact current shard matrix"
             exit 1
           fi
-          sha=$(gh run view "$run_id" --json headSha --jq '.headSha')
           echo "run_id=$run_id" >> "$GITHUB_OUTPUT"
-          echo "sha=$sha"       >> "$GITHUB_OUTPUT"
-          echo "harvesting run $run_id at $sha"
-
+          echo "sha=$valid_sha" >> "$GITHUB_OUTPUT"
+          echo "map_run_id=$valid_map_run_id" >> "$GITHUB_OUTPUT"
+          echo "harvesting run $run_id at $valid_sha (map in effect: ${valid_map_run_id:-none})"
 
       - name: Download digests
         env:
@@ -212,37 +191,19 @@ jobs:
         shell: pwsh
         run: |
           $all = @(yq -o=json -I=0 '.shard' .github/test-shards.yml | ConvertFrom-Json)
-          $covered = @(
-            Get-ChildItem digests -Filter '*.digest.json' -Recurse -File |
-              ForEach-Object { (Get-Content $_.FullName -Raw | ConvertFrom-Json).shard }
-          )
-
-          # Always-run is DERIVED, not declared: any shard that produced no digest cannot be
-          # selected against, whatever the reason. That covers the heavy and timing shards, which
-          # collect no coverage by design, and also any shard that failed, timed out or was
-          # cancelled in the harvested run. Re-deriving the workflow's coverage predicate here
-          # instead would be a second copy of it, free to drift, and drift in this direction means
-          # a shard silently stops running.
-          $alwaysRun = @($all.name | Where-Object { $covered -notcontains $_ })
-          Write-Host "shards: $($all.Count) total, $($covered.Count) with digests, $($alwaysRun.Count) always-run"
-          foreach ($s in $alwaysRun) { Write-Host "  always-run: $s" }
-
-          if ($covered.Count -eq 0) {
-            Write-Host '::error::no digests found - the map would select nothing and escalate every run'
-            exit 1
-          }
-
           & ./tools/TestImpact/New-ShardMap.ps1 `
               -DigestDirectory digests `
-              -AlwaysRun $alwaysRun `
+              -AllShards @($all.name) `
               -Sha '${{ steps.source.outputs.sha }}' `
               -OutFile shard-map.json
 
           $size = [Math]::Round((Get-Item shard-map.json).Length / 1MB, 2)
           $map = Get-Content shard-map.json -Raw | ConvertFrom-Json
           $files = @($map.files.PSObject.Properties).Count
+          $known = @($map.knownShards).Count
+          $always = @($map.alwaysRun).Count
           Write-Host "map: $files file(s), $size MB"
-          "### Shard map rebuilt`n`n- commit ``${{ steps.source.outputs.sha }}```n- $files files indexed`n- $($covered.Count) shards mapped, $($alwaysRun.Count) always-run`n- $size MB" |
+          "### Shard map rebuilt`n`n- source run ${{ steps.source.outputs.run_id }}`n- commit ``${{ steps.source.outputs.sha }}```n- $files files indexed`n- $known shards mapped, $always always-run`n- $size MB" |
             Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8
 
       - name: Upload the map
@@ -253,79 +214,109 @@ jobs:
           if-no-files-found: error
           retention-days: 14
 
-      # ---------------------------------------------------------------------------------------
-      # Does selection actually work? Measured, not assumed.
-      #
-      # Selection rests on "a shard that executes none of the changed lines would have passed
-      # anyway". Nothing about a green PR can disprove that: the skipped shard leaves no evidence.
-      # So it is checked against the runs that DID execute everything - replay the selection that
-      # WOULD have been made, and see whether any shard it would have skipped actually failed.
-      #
-      # Audited against the PREVIOUS map, never the one just built. A map built from this very run
-      # records exactly what each shard executed in it, which makes the question circular.
-      #
-      # Runs after the upload on purpose: the map is valid regardless of what the audit finds, and
-      # a miss should turn the workflow red without also withholding the artifact.
-      # ---------------------------------------------------------------------------------------
-      - name: Download the previous map
-        id: prevmap
-        continue-on-error: true
+      # Audit against the exact map run recorded by the source coverage marker. A map built from
+      # this source run would make the question circular. If the audit fails, this workflow is not
+      # successful and selectors will not discover the newly uploaded artifact.
+      - name: Download the map that was in effect
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          # The immediately previous successful map. `--status success` already excludes this
-          # run, which is still in progress, so .[0] IS the previous one - an earlier revision
-          # took .[-1] of two, which silently audited against a map one generation too old and
-          # could miss a regression introduced by the most recent map.
-          prev=$(gh run list --workflow test-impact-map.yml --branch master --status success                    --limit 1 --json databaseId --jq '.[0].databaseId // empty' 2>/dev/null || true)
-          if [ -z "$prev" ] || [ "$prev" = "${{ github.run_id }}" ]; then
-            echo "no earlier map to audit against - this is the first build"
+          map_run_id='${{ steps.source.outputs.map_run_id }}'
+          if [ -z "$map_run_id" ]; then
+            echo "source run had no shard map in effect - this is the bootstrap generation"
             exit 0
           fi
-          gh run download "$prev" --name shard-map --dir prevmap || echo "previous map unavailable"
+          case "$map_run_id" in
+            *[!0-9]*)
+              echo "::error::source marker mapRunId is not numeric"
+              exit 1
+              ;;
+          esac
+          gh run download "$map_run_id" --name shard-map --dir prevmap
 
-      - name: Audit selection against this run
-        if: always()
+      - name: Audit selection against the source run
         shell: pwsh
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           if (-not (Test-Path prevmap/shard-map.json)) {
-            Write-Host 'no previous map - skipping the audit'
+            Write-Host 'no prior map was in effect - skipping bootstrap audit'
             exit 0
           }
 
-          # Shard outcomes come from the run's own job list rather than its artifacts. The
-          # alternative is downloading 116 coverage or TRX artifacts to read one field out of each.
-          $jobs = gh api --paginate "repos/${{ github.repository }}/actions/runs/${{ steps.source.outputs.run_id }}/jobs" `
-                    --jq '.jobs[] | select(.name | startswith("Tests (")) | {name, conclusion}' |
-                  ConvertFrom-Json
+          # gh rejects --slurp combined with --jq. Parse the paginated response first, then
+          # flatten it in PowerShell so matrices beyond 100 jobs stay complete.
+          $jobPages = gh api --paginate --slurp `
+              "repos/${{ github.repository }}/actions/runs/${{ steps.source.outputs.run_id }}/jobs?per_page=100" |
+              ConvertFrom-Json
+          $jobs = @(
+            $jobPages |
+              ForEach-Object { $_.jobs } |
+              Where-Object { ([string] $_.name).StartsWith('Tests (', [StringComparison]::Ordinal) }
+          )
           $outcomes = @($jobs | ForEach-Object {
-            # "Tests (net10.0) - Unit - 01 Activation" -> "Unit - 01 Activation". Split on the
-            # FIRST " - " only; shard names contain " - " themselves.
             $name = [string] $_.name
             $i = $name.IndexOf(') - ')
-            if ($i -lt 0) { return }
+            if ($i -lt 0) { throw "Unrecognised shard job name: $name" }
             [pscustomobject]@{ shard = $name.Substring($i + 4); outcome = [string] $_.conclusion }
           })
-          if ($outcomes.Count -eq 0) {
-            Write-Host '::warning::no shard jobs found in the audited run - nothing to audit'
-            exit 0
-          }
           $outcomes | ConvertTo-Json -Depth 3 | Set-Content outcomes.json -Encoding utf8
-          Write-Host "auditing $($outcomes.Count) shard outcome(s), $(@($outcomes | Where-Object outcome -ne 'success').Count) failed"
+          $failed = @($outcomes | Where-Object outcome -ne 'success').Count
+          Write-Host "auditing $($outcomes.Count) shard outcome(s), $failed failed"
 
-          # HEAD must be the audited run's commit: the selector diffs from the map's commit to HEAD.
+          # Exercise the tooling being proposed by THIS map build, while giving git the audited
+          # tree as HEAD. Checking out first and then invoking tools/ would silently run whatever
+          # older selector happened to exist at the source commit.
+          $auditTools = Join-Path $env:RUNNER_TEMP 'test-impact-audit-tools'
+          New-Item -ItemType Directory -Path $auditTools -Force | Out-Null
+          Copy-Item tools/TestImpact/Select-Shards.ps1 (Join-Path $auditTools 'Select-Shards.ps1')
+          Copy-Item tools/TestImpact/Measure-SelectionMiss.ps1 (Join-Path $auditTools 'Measure-SelectionMiss.ps1')
+
+          # HEAD must be the audited tree; the selector diffs from the prior map commit to HEAD.
           & git checkout --quiet '${{ steps.source.outputs.sha }}'
-
-          & ./tools/TestImpact/Measure-SelectionMiss.ps1 `
+          & (Join-Path $auditTools 'Measure-SelectionMiss.ps1') `
+              -SelectorPath (Join-Path $auditTools 'Select-Shards.ps1') `
               -MapFile prevmap/shard-map.json -OutcomesFile outcomes.json -OutFile audit.json
           $auditExit = $LASTEXITCODE
 
           $a = Get-Content audit.json -Raw | ConvertFrom-Json
           $verdict = if ($a.Escalated) { 'would have escalated - nothing skipped' }
                      elseif ($a.MissCount -gt 0) { "**$($a.MissCount) MISSED**: $($a.Missed -join ', ')" }
+                     elseif ($a.Failed -eq 0) { 'no failure opportunity; miss safety was not exercised' }
                      else { 'no misses' }
-          "### Selection audit`n`n- would run $($a.WouldRun)/$($a.TotalShards), skip $($a.WouldSkip)`n- $($a.Failed) shard(s) failed`n- $verdict" |
+          "### Selection audit`n`n- map in effect: ${{ steps.source.outputs.map_run_id }}`n- would run $($a.WouldRun)/$($a.TotalShards), skip $($a.WouldSkip)`n- $($a.Failed) shard(s) failed`n- $verdict" |
             Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8
           exit $auditExit
+
+  coverage-run:
+    name: Dispatch next coverage-everywhere run
+    needs: build-map
+    # Bootstrap even when no source exists yet; explicit harvest-only invocations do not dispatch.
+    if: ${{ always() && !inputs.skip_coverage_run && !inputs.run_id }}
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+      contents: read
+    steps:
+      - name: Dispatch coverage run
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if [ '${{ needs.build-map.result }}' = 'success' ]; then
+            # This workflow is not marked successful until this dispatch job exits. Pass its id
+            # explicitly so the child cannot race and record the previous successful map.
+            map_run_id='${{ github.run_id }}'
+          else
+            # A failed build/audit is deliberately not eligible for selection. The last successful
+            # artifact remains in effect, so that is the only map the next run may claim.
+            map_run_id=$(gh run list --workflow test-impact-map.yml --branch master --status success \
+              --limit 1 --json databaseId --jq '.[0].databaseId // empty' 2>/dev/null || true)
+          fi
+
+          if [ -n "$map_run_id" ]; then
+            gh workflow run sonarcloud.yml --ref master \
+              -f collect_coverage_everywhere=true -f test_impact_map_run_id="$map_run_id"
+          else
+            gh workflow run sonarcloud.yml --ref master -f collect_coverage_everywhere=true
+          fi
+          echo 'Dispatched the next marked coverage-everywhere run. It will be harvested on the next map invocation.' >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/test-impact-map.yml
+++ b/.github/workflows/test-impact-map.yml
@@ -4,7 +4,6 @@ name: Test impact map
 # dispatches the next one. The expensive run never overlaps the map decision it will later audit.
 on:
   schedule:
-    # 07:00 UTC, after nightly master activity and before the working day.
     # 02:00 UTC. The instrumented run is ~3450 runner-minutes, which at max-parallel 12 is about
     # 4.8 HOURS of queue occupancy - so the start time has to clear the working day by a wide
     # margin, not just miss it. Measured activity in this repo clusters at 13:00-16:00 and 21:00
@@ -192,6 +191,42 @@ jobs:
           gh run download '${{ steps.source.outputs.run_id }}' --pattern 'impact-digest-*' --dir digests
           echo "digest files: $(find digests -name '*.digest.json' | wc -l)"
 
+      # A FRESH digest is only produced when the shard's test step succeeded; a CARRIED digest is
+      # written before any test runs and would bypass that gate - a heavy shard that failed in the
+      # source run would stay in knownShards and remain skippable in enforce mode while red.
+      # Restore the gate here: drop the carried digest of any shard whose job did not succeed.
+      - name: Prune carried digests for failed shards
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          $carried = @(Get-ChildItem digests -Filter '*.digest.json' -Recurse -File | Where-Object {
+            (Get-Content $_.FullName -Raw | ConvertFrom-Json).PSObject.Properties['carriedFrom']
+          })
+          if ($carried.Count -eq 0) { Write-Host 'no carried digests'; exit 0 }
+
+          $jobPages = gh api --paginate --slurp `
+              "repos/${{ github.repository }}/actions/runs/${{ steps.source.outputs.run_id }}/jobs?per_page=100" |
+              ConvertFrom-Json
+          $failedShards = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::Ordinal)
+          foreach ($j in @($jobPages | ForEach-Object { $_.jobs })) {
+            $name = [string] $j.name
+            if (-not $name.StartsWith('Tests (', [StringComparison]::Ordinal)) { continue }
+            $i = $name.IndexOf(') - ')
+            if ($i -lt 0) { continue }
+            if ([string] $j.conclusion -ne 'success') { [void] $failedShards.Add($name.Substring($i + 4)) }
+          }
+          $pruned = 0
+          foreach ($f in $carried) {
+            $shard = [string] (Get-Content $f.FullName -Raw | ConvertFrom-Json).shard
+            if ($failedShards.Contains($shard)) {
+              Write-Host "pruning carried digest for failed shard '$shard' - it becomes always-run"
+              Remove-Item -LiteralPath $f.FullName -Force
+              $pruned++
+            }
+          }
+          Write-Host "carried digests: $($carried.Count), pruned: $pruned"
+
       - name: Build the map
         shell: pwsh
         run: |
@@ -237,7 +272,15 @@ jobs:
               exit 1
               ;;
           esac
-          gh run download "$map_run_id" --name shard-map --dir prevmap
+          if ! gh run download "$map_run_id" --name shard-map --dir prevmap; then
+            # The referenced map run exists but its artifact is gone (14-day retention). Hard-
+            # failing here WEDGES the nightly permanently: this build fails, the dispatch keeps
+            # citing the same last-successful run, and its artifact never comes back - reviewed and
+            # confirmed as unrecoverable without this branch. Skipping the audit once lets this
+            # build succeed, and the next night audits against THIS run's fresh artifact.
+            echo "::warning::shard-map artifact of run $map_run_id is unavailable (expired?) - skipping this audit to re-seed the chain"
+            rm -rf prevmap
+          fi
 
       - name: Audit selection against the source run
         shell: pwsh
@@ -279,6 +322,7 @@ jobs:
 
           # HEAD must be the audited tree; the selector diffs from the prior map commit to HEAD.
           & git checkout --quiet '${{ steps.source.outputs.sha }}'
+          if ($LASTEXITCODE -ne 0) { throw "checkout of audited commit failed - refusing to audit the wrong tree" }
           & (Join-Path $auditTools 'Measure-SelectionMiss.ps1') `
               -SelectorPath (Join-Path $auditTools 'Select-Shards.ps1') `
               -MapFile prevmap/shard-map.json -OutcomesFile outcomes.json -OutFile audit.json
@@ -316,6 +360,17 @@ jobs:
             # artifact remains in effect, so that is the only map the next run may claim.
             map_run_id=$(gh run list --workflow test-impact-map.yml --branch master --status success \
               --limit 1 --json databaseId --jq '.[0].databaseId // empty' 2>/dev/null || true)
+          fi
+
+          # A dispatch while one is still running would land in the same build-coverage-map
+          # concurrency group with cancel-in-progress and DESTROY hours of instrumented work -
+          # the same double-dispatch trap that killed two verification runs during development.
+          inflight=$(gh run list --workflow sonarcloud.yml --branch master --event workflow_dispatch \
+                       --json databaseId,status --jq '[.[] | select(.status == "queued" or .status == "in_progress")] | length' 2>/dev/null || echo 0)
+          if [ "${inflight:-0}" -gt 0 ]; then
+            echo "::warning::a coverage-everywhere run is already queued or running - not dispatching another"
+            echo 'Skipped dispatch: a coverage run is already in flight.' >> "$GITHUB_STEP_SUMMARY"
+            exit 0
           fi
 
           if [ -n "$map_run_id" ]; then

--- a/.github/workflows/test-impact-map.yml
+++ b/.github/workflows/test-impact-map.yml
@@ -48,15 +48,33 @@ jobs:
         run: |
           run_id='${{ github.event.inputs.run_id }}'
           if [ -z "$run_id" ]; then
-            # The most recent master run that actually finished. A cancelled or failed run can
-            # still carry digests, but only for the shards that got that far, and a partial map
-            # would mark the rest unknown - which escalates rather than under-selects, but wastes
-            # the saving. Prefer a clean run.
-            run_id=$(gh run list --workflow sonarcloud.yml --branch master --status success \
-                       --limit 1 --json databaseId --jq '.[0].databaseId')
+            # The most recent master run that ran the FULL matrix.
+            #
+            # Not merely the most recent successful one. Master pushes now validate only their
+            # delta from the previously validated commit, so a reduced run has digests for the
+            # shards it ran and none for the rest - and "no digest" is exactly what marks a shard
+            # always-run. Building the map from a reduced run would convert every shard it skipped
+            # into an always-run shard, and the feature would decay into running everything while
+            # still looking healthy.
+            #
+            # Fullness is measured, not assumed: count the run's shard jobs against the shard list.
+            # A cancelled or partly-failed run fails the same check, for the same reason - its
+            # digests cover only the shards that got that far.
+            expected=$(yq -o=json -I=0 '.shard' .github/test-shards.yml | jq 'length')
+            run_id=''
+            for candidate in $(gh run list --workflow sonarcloud.yml --branch master                                  --status success --limit 15 --json databaseId --jq '.[].databaseId'); do
+              n=$(gh api --paginate "repos/${GITHUB_REPOSITORY}/actions/runs/$candidate/jobs"                     --jq '[.jobs[] | select(.name | startswith("Tests ("))] | length' 2>/dev/null |
+                  awk '{s+=$1} END {print s+0}')
+              if [ "${n:-0}" -ge "$expected" ]; then
+                run_id="$candidate"
+                echo "run $candidate ran $n/$expected shards - using it"
+                break
+              fi
+              echo "run $candidate ran only ${n:-0}/$expected shards - skipping (reduced or partial)"
+            done
           fi
           if [ -z "$run_id" ]; then
-            echo "::error::no successful master run of sonarcloud.yml to harvest digests from"
+            echo "::error::no master run in the last 15 ran the full matrix, so no complete digest set exists. Dispatch sonarcloud.yml on master (workflow_dispatch escalates by design) before rebuilding the map."
             exit 1
           fi
           sha=$(gh run view "$run_id" --json headSha --jq '.headSha')

--- a/.github/workflows/test-impact-map.yml
+++ b/.github/workflows/test-impact-map.yml
@@ -45,8 +45,24 @@ jobs:
         id: source
         env:
           GH_TOKEN: ${{ github.token }}
+          # Passed as data, never interpolated into the script. A workflow_dispatch input is
+          # attacker-controlled in the same sense as any other user input: inlined as
+          # run_id='${{ ... }}' it can close the quote and run arbitrary bash with GH_TOKEN in
+          # scope. The repository already uses this pattern elsewhere for exactly this reason.
+          INPUT_RUN_ID: ${{ github.event.inputs.run_id }}
         run: |
-          run_id='${{ github.event.inputs.run_id }}'
+          run_id=''
+          if [ -n "${INPUT_RUN_ID:-}" ]; then
+            # Digits only. A run id is numeric, so anything else is not a run id.
+            case "$INPUT_RUN_ID" in
+              ''|*[!0-9]*)
+                echo "::error::run_id must be numeric; got an invalid value"
+                exit 1
+                ;;
+              *) run_id="$INPUT_RUN_ID" ;;
+            esac
+          fi
+
           if [ -z "$run_id" ]; then
             # The most recent master run that ran the FULL matrix.
             #
@@ -61,10 +77,9 @@ jobs:
             # A cancelled or partly-failed run fails the same check, for the same reason - its
             # digests cover only the shards that got that far.
             expected=$(yq -o=json -I=0 '.shard' .github/test-shards.yml | jq 'length')
-            run_id=''
-            for candidate in $(gh run list --workflow sonarcloud.yml --branch master                                  --status success --limit 15 --json databaseId --jq '.[].databaseId'); do
-              n=$(gh api --paginate "repos/${GITHUB_REPOSITORY}/actions/runs/$candidate/jobs"                     --jq '[.jobs[] | select(.name | startswith("Tests ("))] | length' 2>/dev/null |
-                  awk '{s+=$1} END {print s+0}')
+            candidates=$(gh run list --workflow sonarcloud.yml --branch master --status success --limit 15 --json databaseId --jq '.[].databaseId')
+            for candidate in $candidates; do
+              n=$(gh api --paginate "repos/${GITHUB_REPOSITORY}/actions/runs/${candidate}/jobs" --jq '[.jobs[] | select(.name | startswith("Tests ("))] | length' 2>/dev/null | awk '{s+=$1} END {print s+0}')
               if [ "${n:-0}" -ge "$expected" ]; then
                 run_id="$candidate"
                 echo "run $candidate ran $n/$expected shards - using it"
@@ -73,6 +88,7 @@ jobs:
               echo "run $candidate ran only ${n:-0}/$expected shards - skipping (reduced or partial)"
             done
           fi
+
           if [ -z "$run_id" ]; then
             echo "::error::no master run in the last 15 ran the full matrix, so no complete digest set exists. Dispatch sonarcloud.yml on master (workflow_dispatch escalates by design) before rebuilding the map."
             exit 1
@@ -81,6 +97,7 @@ jobs:
           echo "run_id=$run_id" >> "$GITHUB_OUTPUT"
           echo "sha=$sha"       >> "$GITHUB_OUTPUT"
           echo "harvesting run $run_id at $sha"
+
 
       - name: Download digests
         env:
@@ -155,8 +172,11 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          # Second-newest successful run: the newest is this one, still in progress.
-          prev=$(gh run list --workflow test-impact-map.yml --branch master --status success                    --limit 2 --json databaseId --jq '.[-1].databaseId' 2>/dev/null || true)
+          # The immediately previous successful map. `--status success` already excludes this
+          # run, which is still in progress, so .[0] IS the previous one - an earlier revision
+          # took .[-1] of two, which silently audited against a map one generation too old and
+          # could miss a regression introduced by the most recent map.
+          prev=$(gh run list --workflow test-impact-map.yml --branch master --status success                    --limit 1 --json databaseId --jq '.[0].databaseId' 2>/dev/null || true)
           if [ -z "$prev" ] || [ "$prev" = "${{ github.run_id }}" ]; then
             echo "no earlier map to audit against - this is the first build"
             exit 0

--- a/.github/workflows/test-impact-map.yml
+++ b/.github/workflows/test-impact-map.yml
@@ -19,6 +19,11 @@ on:
       run_id:
         description: 'Optional: a specific Build & SonarCloud run to harvest digests from.'
         required: false
+      skip_coverage_run:
+        description: 'Harvest an existing run instead of first dispatching a coverage-everywhere run.'
+        required: false
+        type: boolean
+        default: false
 
 permissions: read-all
 
@@ -27,6 +32,68 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # -----------------------------------------------------------------------------------------
+  # Feed the map with the shards it cannot otherwise see.
+  #
+  # 91 of 116 shards collect no coverage during PR validation - 90 heavy ones because coverage
+  # instrumentation pushes them past the runner's memory envelope, and 2 timing ones because
+  # instrumentation distorts the ratios they assert. They can therefore never appear in the map
+  # and must always run, which caps selection at the 25 cheapest shards and leaves every slow
+  # shard running on every PR. That is most of the cost the feature exists to remove.
+  #
+  # The memory ceiling belongs to the PR matrix, not to a nightly job. So once a night, dispatch
+  # the same workflow with coverage forced on everywhere and harvest THAT.
+  #
+  # Partial success is fine and is the point: a heavy shard that still OOMs produces no digest and
+  # stays always-run, exactly as today. Every shard that survives moves from always-run to
+  # mappable. The feature improves shard by shard and can never regress - and a shard killed
+  # part-way is explicitly excluded, because its coverage would describe only the tests that ran
+  # and the map would then think it does not execute lines it does.
+  # -----------------------------------------------------------------------------------------
+  coverage-run:
+    name: Dispatch coverage-everywhere run
+    runs-on: ubuntu-latest
+    if: github.event.inputs.skip_coverage_run != 'true' && github.event.inputs.run_id == ''
+    permissions:
+      actions: write
+      contents: read
+    outputs:
+      run_id: ${{ steps.dispatch.outputs.run_id }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v4
+
+      - name: Dispatch and wait
+        id: dispatch
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          before=$(gh run list --workflow sonarcloud.yml --branch master --event workflow_dispatch                      --limit 1 --json databaseId --jq '.[0].databaseId // 0')
+          gh workflow run sonarcloud.yml --ref master -f collect_coverage_everywhere=true
+
+          # gh prints nothing on success, and a blind retry would start a SECOND full matrix that
+          # cancels the first through the shared concurrency group. Poll for a new id instead.
+          run_id=''
+          for _ in $(seq 1 30); do
+            candidate=$(gh run list --workflow sonarcloud.yml --branch master --event workflow_dispatch                           --limit 1 --json databaseId --jq '.[0].databaseId // 0')
+            if [ "$candidate" != "$before" ] && [ "$candidate" != "0" ]; then
+              run_id="$candidate"
+              break
+            fi
+            sleep 10
+          done
+          if [ -z "$run_id" ]; then
+            echo "::error::the coverage run never registered"
+            exit 1
+          fi
+          echo "coverage run: $run_id"
+          echo "run_id=$run_id" >> "$GITHUB_OUTPUT"
+
+          # It takes hours. Waiting here would burn a runner for the duration, so the map build
+          # simply harvests the newest FULL run - which this one becomes when it finishes. Today's
+          # map is therefore built from last night's coverage run, which is exactly the freshness
+          # the selector already tolerates: it diffs from the map's own commit.
+
   build-map:
     name: Build shard map
     runs-on: ubuntu-latest

--- a/.github/workflows/test-impact-map.yml
+++ b/.github/workflows/test-impact-map.yml
@@ -5,7 +5,12 @@ name: Test impact map
 on:
   schedule:
     # 07:00 UTC, after nightly master activity and before the working day.
-    - cron: '0 7 * * *'
+    # 02:00 UTC. The instrumented run is ~3450 runner-minutes, which at max-parallel 12 is about
+    # 4.8 HOURS of queue occupancy - so the start time has to clear the working day by a wide
+    # margin, not just miss it. Measured activity in this repo clusters at 13:00-16:00 and 21:00
+    # UTC; starting at 02:00 finishes around 06:50 and leaves six hours of slack. At 07:00 it
+    # finished at 11:48, which only just cleared it.
+    - cron: '0 2 * * *'
   workflow_dispatch:
     inputs:
       run_id:

--- a/.github/workflows/test-impact-map.yml
+++ b/.github/workflows/test-impact-map.yml
@@ -118,6 +118,18 @@ jobs:
           # scope. The repository already uses this pattern elsewhere for exactly this reason.
           INPUT_RUN_ID: ${{ github.event.inputs.run_id }}
         run: |
+          # Fullness is measured, not assumed: count a run's shard jobs against the shard list.
+          # A reduced run has digests for the shards it ran and none for the rest, and "no digest"
+          # is exactly what marks a shard always-run - so harvesting one would convert every shard
+          # it skipped into an always-run shard until the feature decayed into running everything
+          # while still looking healthy. A cancelled or partly-failed run fails the same check for
+          # the same reason: its digests cover only the shards that got that far.
+          expected=$(yq -o=json -I=0 '.shard' .github/test-shards.yml | jq 'length')
+          shard_jobs() {
+            gh api --paginate "repos/${GITHUB_REPOSITORY}/actions/runs/$1/jobs"               --jq '[.jobs[] | select(.name | startswith("Tests ("))] | length' 2>/dev/null |
+              awk '{s+=$1} END {print s+0}'
+          }
+
           run_id=''
           if [ -n "${INPUT_RUN_ID:-}" ]; then
             # Digits only. A run id is numeric, so anything else is not a run id.
@@ -126,8 +138,31 @@ jobs:
                 echo "::error::run_id must be numeric; got an invalid value"
                 exit 1
                 ;;
-              *) run_id="$INPUT_RUN_ID" ;;
             esac
+
+            # A hand-supplied id gets the SAME checks as an automatically chosen one. Numeric
+            # syntax only proves it is a run id, not that it is a successful full-matrix
+            # sonarcloud.yml run on master - and a failed or reduced run still carries partial
+            # digests, which would silently mark the shards it happened to run as mapped.
+            meta=$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${INPUT_RUN_ID}"                      --jq '[.name, .head_branch, .conclusion] | @tsv' 2>/dev/null || true)
+            if [ -z "$meta" ]; then
+              echo "::error::run ${INPUT_RUN_ID} does not exist or is not readable"
+              exit 1
+            fi
+            wf=$(printf '%s' "$meta" | cut -f1)
+            br=$(printf '%s' "$meta" | cut -f2)
+            cc=$(printf '%s' "$meta" | cut -f3)
+            if [ "$wf" != "Build & SonarCloud" ] || [ "$br" != "master" ] || [ "$cc" != "success" ]; then
+              echo "::error::run ${INPUT_RUN_ID} is '$wf' on '$br' with conclusion '$cc'; a successful Build & SonarCloud run on master is required"
+              exit 1
+            fi
+            n=$(shard_jobs "$INPUT_RUN_ID")
+            if [ "${n:-0}" -lt "$expected" ]; then
+              echo "::error::run ${INPUT_RUN_ID} ran only ${n:-0}/$expected shards, so its digests are partial and would mark the missing shards always-run"
+              exit 1
+            fi
+            echo "run ${INPUT_RUN_ID} ran $n/$expected shards - using it"
+            run_id="$INPUT_RUN_ID"
           fi
 
           if [ -z "$run_id" ]; then
@@ -143,10 +178,9 @@ jobs:
             # Fullness is measured, not assumed: count the run's shard jobs against the shard list.
             # A cancelled or partly-failed run fails the same check, for the same reason - its
             # digests cover only the shards that got that far.
-            expected=$(yq -o=json -I=0 '.shard' .github/test-shards.yml | jq 'length')
             candidates=$(gh run list --workflow sonarcloud.yml --branch master --status success --limit 15 --json databaseId --jq '.[].databaseId')
             for candidate in $candidates; do
-              n=$(gh api --paginate "repos/${GITHUB_REPOSITORY}/actions/runs/${candidate}/jobs" --jq '[.jobs[] | select(.name | startswith("Tests ("))] | length' 2>/dev/null | awk '{s+=$1} END {print s+0}')
+              n=$(shard_jobs "$candidate")
               if [ "${n:-0}" -ge "$expected" ]; then
                 run_id="$candidate"
                 echo "run $candidate ran $n/$expected shards - using it"
@@ -243,7 +277,7 @@ jobs:
           # run, which is still in progress, so .[0] IS the previous one - an earlier revision
           # took .[-1] of two, which silently audited against a map one generation too old and
           # could miss a regression introduced by the most recent map.
-          prev=$(gh run list --workflow test-impact-map.yml --branch master --status success                    --limit 1 --json databaseId --jq '.[0].databaseId' 2>/dev/null || true)
+          prev=$(gh run list --workflow test-impact-map.yml --branch master --status success                    --limit 1 --json databaseId --jq '.[0].databaseId // empty' 2>/dev/null || true)
           if [ -z "$prev" ] || [ "$prev" = "${{ github.run_id }}" ]; then
             echo "no earlier map to audit against - this is the first build"
             exit 0

--- a/tools/TestImpact/Measure-SelectionMiss.ps1
+++ b/tools/TestImpact/Measure-SelectionMiss.ps1
@@ -1,0 +1,185 @@
+<#
+.SYNOPSIS
+    Answers the only question that decides whether test selection is safe: would it have skipped a
+    shard that failed?
+
+.DESCRIPTION
+    Selection rests on one assumption - that a shard which executes none of the changed lines would
+    have passed anyway. That is an assumption, not a proof, and nothing about a green PR reveals
+    when it is wrong: the skipped shard leaves no evidence behind. A selector can be quietly wrong
+    for months and every run still looks healthy.
+
+    So it is measured against runs that DID execute everything. For a full run, replay the selection
+    that would have been made, then intersect the shards it would have skipped with the shards that
+    actually failed. Any shard in that intersection is a MISS - a regression selection would have
+    let through.
+
+    Two things this deliberately does not do:
+
+      It does not use the map built FROM the run being audited. That map records exactly what each
+      shard executed in that run, so it answers a circular question. The map that would really have
+      been in effect is the previous one, and that is what the caller must pass.
+
+      It does not treat a miss as merely informational. A non-zero miss count is an exit code,
+      because a miss rate that is only ever printed is a number nobody reads.
+
+    A miss is not automatically a selector bug - a flaky or pre-existing failure in an unrelated
+    shard counts as a miss here even though selection was right to skip it. That is intentional:
+    the metric errs toward reporting too much, and the names are printed so a human can tell the
+    two apart. A clean run of this over time is the evidence that selection is safe to rely on.
+
+.PARAMETER MapFile
+    The shard map that WOULD have been in effect - the previous map, not one built from this run.
+
+.PARAMETER OutcomesFile
+    JSON array of { shard, outcome } for every shard in the audited run. `outcome` is the shard's
+    test step result; anything other than 'success' counts as a failure.
+
+.PARAMETER SelectorPath
+    Select-Shards.ps1. Invoked as a subprocess so the audit exercises the SHIPPING selector rather
+    than a copy of its logic that is free to drift from it.
+
+.PARAMETER OutFile
+    Optional path for the JSON report.
+#>
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory, ParameterSetName = 'Measure')] [string] $MapFile,
+    [Parameter(Mandatory, ParameterSetName = 'Measure')] [string] $OutcomesFile,
+    [Parameter(ParameterSetName = 'Measure')] [string] $SelectorPath = "$PSScriptRoot/Select-Shards.ps1",
+    [Parameter(ParameterSetName = 'Measure')] [string] $OutFile,
+    [Parameter(Mandatory, ParameterSetName = 'SelfTest')] [switch] $SelfTest
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+function Get-SelectionMiss {
+    <#
+        Pure, so the arithmetic can be tested without a map, a git tree or a CI run. Every argument
+        is a plain list of shard names.
+    #>
+    param(
+        [Parameter(Mandatory)] [AllowEmptyCollection()] [string[]] $AllShards,
+        [Parameter(Mandatory)] [AllowEmptyCollection()] [string[]] $WouldRun,
+        [Parameter(Mandatory)] [AllowEmptyCollection()] [string[]] $Failed,
+        [Parameter(Mandatory)] [bool] $Escalated
+    )
+
+    # An escalated run skips nothing, so it can miss nothing. Counting it as a clean audit would
+    # dilute the miss rate with runs that never exercised selection at all, so it is reported
+    # separately instead.
+    # Built by adding rather than by the collection constructor: an empty [string[]] arrives as
+    # $null and the constructor throws "Value cannot be null". That is not a hypothetical - an
+    # escalated run passes an empty WouldRun, which is the most common case there is.
+    $run = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::Ordinal)
+    foreach ($s in $WouldRun) { [void] $run.Add([string] $s) }
+
+    # Assigned in two statements, not as an if-expression. `$x = if (...) { @() }` yields $null,
+    # because PowerShell unrolls the empty array on the way out - and $null.Count then throws under
+    # StrictMode. The escalated branch is exactly that case.
+    $wouldSkip = @()
+    if (-not $Escalated) {
+        $wouldSkip = @($AllShards | Where-Object { -not $run.Contains([string] $_) })
+    }
+
+    $skip = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::Ordinal)
+    foreach ($s in $wouldSkip) { [void] $skip.Add([string] $s) }
+    $missed = @($Failed | Where-Object { $skip.Contains([string] $_) } | Sort-Object -Unique)
+
+    return [pscustomobject]@{
+        Escalated  = $Escalated
+        TotalShards = $AllShards.Count
+        WouldRun   = $(if ($Escalated) { $AllShards.Count } else { @($WouldRun).Count })
+        WouldSkip  = $wouldSkip.Count
+        Failed     = @($Failed).Count
+        Missed     = $missed
+        MissCount  = $missed.Count
+    }
+}
+
+# ---------------------------------------------------------------- self-test
+
+if ($SelfTest) {
+    $failures = [System.Collections.Generic.List[string]]::new()
+    function Assert-True { param([bool] $Condition, [string] $What)
+        if (-not $Condition) { [void] $failures.Add($What) } }
+
+    $all = @('A', 'B', 'C', 'D')
+
+    # 1. A failure in a shard selection would have SKIPPED is a miss - the case the audit exists for.
+    $r = Get-SelectionMiss -AllShards $all -WouldRun @('A', 'B') -Failed @('C') -Escalated $false
+    Assert-True ($r.MissCount -eq 1) 'a failure in a skipped shard must be reported as a miss'
+    Assert-True ($r.Missed -contains 'C') 'the missed shard must be named'
+
+    # 2. A failure in a shard selection would have RUN is not a miss. Without this the audit could
+    #    report every failure as a miss and still pass check 1, which would make it useless.
+    $r = Get-SelectionMiss -AllShards $all -WouldRun @('A', 'B') -Failed @('A') -Escalated $false
+    Assert-True ($r.MissCount -eq 0) 'a failure in a selected shard is not a miss'
+
+    # 3. Mixed: only the skipped half counts.
+    $r = Get-SelectionMiss -AllShards $all -WouldRun @('A', 'B') -Failed @('A', 'D') -Escalated $false
+    Assert-True ($r.MissCount -eq 1 -and $r.Missed -contains 'D') 'only failures in skipped shards count'
+
+    # 4. An escalated run skips nothing, so it cannot miss - even when shards failed.
+    $r = Get-SelectionMiss -AllShards $all -WouldRun @() -Failed @('C', 'D') -Escalated $true
+    Assert-True ($r.MissCount -eq 0) 'an escalated run cannot miss'
+    Assert-True ($r.WouldSkip -eq 0) 'an escalated run skips nothing'
+    Assert-True ($r.WouldRun -eq 4) 'an escalated run runs everything'
+
+    # 5. A green run misses nothing regardless of how much it skipped.
+    $r = Get-SelectionMiss -AllShards $all -WouldRun @('A') -Failed @() -Escalated $false
+    Assert-True ($r.MissCount -eq 0) 'no failures means no misses'
+    Assert-True ($r.WouldSkip -eq 3) 'skipped count must still be reported'
+
+    # 6. Ordinal comparison. Shard names differing only in case are different shards, and a
+    #    case-insensitive match would silently treat a skipped shard as run.
+    $r = Get-SelectionMiss -AllShards @('Alpha', 'alpha') -WouldRun @('Alpha') -Failed @('alpha') -Escalated $false
+    Assert-True ($r.MissCount -eq 1) 'shard matching must be ordinal'
+
+    if ($failures.Count -gt 0) {
+        Write-Host 'Measure-SelectionMiss self-test FAILED:'
+        foreach ($f in $failures) { Write-Host "  - $f" }
+        exit 1
+    }
+    Write-Host 'Measure-SelectionMiss self-test passed.'
+    exit 0
+}
+
+# ---------------------------------------------------------------- audit
+
+$outcomes = @(Get-Content -LiteralPath $OutcomesFile -Raw | ConvertFrom-Json)
+if ($outcomes.Count -eq 0) { throw "No shard outcomes in $OutcomesFile - nothing to audit." }
+
+$allShards = @($outcomes | ForEach-Object { [string] $_.shard })
+$failed = @($outcomes | Where-Object { [string] $_.outcome -ne 'success' } | ForEach-Object { [string] $_.shard })
+
+$selectionFile = Join-Path ([System.IO.Path]::GetTempPath()) "selection-audit-$PID.json"
+& $SelectorPath -MapFile $MapFile -OutFile $selectionFile | Out-Null
+$selection = Get-Content -LiteralPath $selectionFile -Raw | ConvertFrom-Json
+Remove-Item -LiteralPath $selectionFile -ErrorAction SilentlyContinue
+
+$result = Get-SelectionMiss -AllShards $allShards `
+                            -WouldRun @($selection.shards) `
+                            -Failed $failed `
+                            -Escalated ([bool] $selection.escalate)
+
+if ($result.Escalated) {
+    Write-Host "audit: selection would have ESCALATED ($($result.Failed) shard(s) failed) - nothing skipped, nothing to miss"
+} else {
+    Write-Host "audit: would run $($result.WouldRun)/$($result.TotalShards), skip $($result.WouldSkip); $($result.Failed) shard(s) failed"
+}
+
+if ($result.MissCount -gt 0) {
+    Write-Host "::error::selection would have SKIPPED $($result.MissCount) shard(s) that failed:"
+    foreach ($m in $result.Missed) { Write-Host "  MISSED: $m" }
+} else {
+    Write-Host 'audit: no misses'
+}
+
+if ($OutFile) { $result | ConvertTo-Json -Depth 5 | Set-Content -LiteralPath $OutFile -Encoding utf8 }
+
+# The miss count is the exit code's whole point: a safety metric that only ever gets printed is a
+# safety metric nobody reads.
+if ($result.MissCount -gt 0) { exit 1 }
+exit 0

--- a/tools/TestImpact/Measure-SelectionMiss.ps1
+++ b/tools/TestImpact/Measure-SelectionMiss.ps1
@@ -29,7 +29,8 @@
     two apart. A clean run of this over time is the evidence that selection is safe to rely on.
 
 .PARAMETER MapFile
-    The shard map that WOULD have been in effect - the previous map, not one built from this run.
+    The shard map that WOULD have been in effect, identified by the source run's marker rather than
+    guessed from workflow chronology. Never a map built from the run being audited.
 
 .PARAMETER OutcomesFile
     JSON array of { shard, outcome } for every shard in the audited run. `outcome` is the shard's
@@ -151,11 +152,25 @@ if ($SelfTest) {
 $outcomes = @(Get-Content -LiteralPath $OutcomesFile -Raw | ConvertFrom-Json)
 if ($outcomes.Count -eq 0) { throw "No shard outcomes in $OutcomesFile - nothing to audit." }
 
-$allShards = @($outcomes | ForEach-Object { [string] $_.shard })
+$allShards = [System.Collections.Generic.List[string]]::new()
+$seen = [System.Collections.Generic.HashSet[string]]::new([StringComparer]::Ordinal)
+foreach ($outcome in $outcomes) {
+    if (-not $outcome.PSObject.Properties['shard'] -or -not $outcome.PSObject.Properties['outcome']) {
+        throw 'Every outcome must contain shard and outcome.'
+    }
+    $name = [string] $outcome.shard
+    $conclusion = [string] $outcome.outcome
+    if ([string]::IsNullOrWhiteSpace($name)) { throw 'Outcome shard names must be nonempty.' }
+    if (-not $seen.Add($name)) { throw "Duplicate outcome for shard '$name'." }
+    if ($conclusion -notin @('success', 'failure')) {
+        throw "Shard '$name' has unauditable outcome '$conclusion'."
+    }
+    [void] $allShards.Add($name)
+}
 $failed = @($outcomes | Where-Object { [string] $_.outcome -ne 'success' } | ForEach-Object { [string] $_.shard })
 
 $selectionFile = Join-Path ([System.IO.Path]::GetTempPath()) "selection-audit-$PID.json"
-& $SelectorPath -MapFile $MapFile -OutFile $selectionFile | Out-Null
+& $SelectorPath -MapFile $MapFile -ExpectedShards @($allShards) -OutFile $selectionFile | Out-Null
 $selection = Get-Content -LiteralPath $selectionFile -Raw | ConvertFrom-Json
 Remove-Item -LiteralPath $selectionFile -ErrorAction SilentlyContinue
 
@@ -173,6 +188,8 @@ if ($result.Escalated) {
 if ($result.MissCount -gt 0) {
     Write-Host "::error::selection would have SKIPPED $($result.MissCount) shard(s) that failed:"
     foreach ($m in $result.Missed) { Write-Host "  MISSED: $m" }
+} elseif ($result.Failed -eq 0) {
+    Write-Host 'audit: no failure opportunity in this full run; selection volume was measured but miss safety was not exercised'
 } else {
     Write-Host 'audit: no misses'
 }

--- a/tools/TestImpact/Measure-SelectionMiss.ps1
+++ b/tools/TestImpact/Measure-SelectionMiss.ps1
@@ -34,7 +34,7 @@
 
 .PARAMETER OutcomesFile
     JSON array of { shard, outcome } for every shard in the audited run. `outcome` is the shard's
-    test step result; anything other than 'success' counts as a failure.
+    test step result; 'success' passes, 'failure' fails; any OTHER outcome (cancelled, skipped, neutral) aborts the audit, because a shard that never finished is not evidence in either direction.
 
 .PARAMETER SelectorPath
     Select-Shards.ps1. Invoked as a subprocess so the audit exercises the SHIPPING selector rather

--- a/tools/TestImpact/New-CoverageDigest.ps1
+++ b/tools/TestImpact/New-CoverageDigest.ps1
@@ -135,6 +135,13 @@ $digest = [ordered]@{
 
 $dir = Split-Path -Parent $OutFile
 if ($dir -and -not (Test-Path -LiteralPath $dir)) { New-Item -ItemType Directory -Path $dir -Force | Out-Null }
-$digest | ConvertTo-Json -Depth 6 -Compress | Set-Content -LiteralPath $OutFile -Encoding utf8 -NoNewline
+# Written to a temp file and moved into place. The digest step runs continue-on-error after a
+# heavy shard's tests, which is exactly where a mid-write kill is most likely - and a truncated
+# file here is uploaded anyway, then aborts the ENTIRE map build when Read-ValidatedDigest
+# rejects it. Move-Item within a directory is a rename, so the artifact glob either sees a
+# complete file or nothing.
+$tmpFile = "$OutFile.tmp"
+$digest | ConvertTo-Json -Depth 6 -Compress | Set-Content -LiteralPath $tmpFile -Encoding utf8 -NoNewline
+Move-Item -LiteralPath $tmpFile -Destination $OutFile -Force
 
 Write-Host "digest: $($files.Count) executed file(s) -> $OutFile"

--- a/tools/TestImpact/New-CoverageDigest.ps1
+++ b/tools/TestImpact/New-CoverageDigest.ps1
@@ -1,0 +1,136 @@
+<#
+.SYNOPSIS
+    Reduces a shard's OpenCover XML to the executed source lines, per file.
+
+.DESCRIPTION
+    The map that drives test selection needs one fact per shard: which source lines that shard
+    actually executed. The OpenCover XML carries that, but it is ~234 MB per shard - too large to
+    keep, download and re-parse on every selection. This distils it to ~200 KB, measured 1111x
+    smaller on Integration H-L, which is what makes a nightly map build cheap.
+
+    Streamed with XmlReader on purpose. A DOM load of 234 MB is not viable on a 4-core runner, and
+    the reduction is single-pass: every SequencePoint carries the fileid and line it belongs to, so
+    nothing needs to be held except the accumulating line set.
+
+    VISITED lines only. A file appearing in the <Files> table means it was COMPILED, not executed -
+    every shard compiles the whole solution, so keying the map on that would map every file to every
+    shard and select everything, every time. vc="0" is compiled-not-executed and is dropped.
+
+.PARAMETER CoverageXml
+    Path to coverage.opencover.xml.
+
+.PARAMETER Shard
+    The shard's display name, recorded in the digest so the map knows what to select.
+
+.PARAMETER OutFile
+    Where to write the digest JSON.
+#>
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)] [string] $CoverageXml,
+    [Parameter(Mandatory)] [string] $Shard,
+    [Parameter(Mandatory)] [string] $OutFile
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+if (-not (Test-Path -LiteralPath $CoverageXml)) {
+    throw "Coverage file not found: $CoverageXml"
+}
+
+# uid -> repo-relative path, and uid -> sorted set of executed line numbers.
+$paths = @{}
+$lines = @{}
+
+$settings = [System.Xml.XmlReaderSettings]::new()
+$settings.IgnoreComments = $true
+$settings.IgnoreWhitespace = $true
+$settings.DtdProcessing = [System.Xml.DtdProcessing]::Prohibit
+
+$reader = [System.Xml.XmlReader]::Create($CoverageXml, $settings)
+try {
+    while ($reader.Read()) {
+        if ($reader.NodeType -ne [System.Xml.XmlNodeType]::Element) { continue }
+
+        switch ($reader.Name) {
+            'File' {
+                $uid = $reader.GetAttribute('uid')
+                $full = $reader.GetAttribute('fullPath')
+                if ($uid -and $full) {
+                    # Normalise to a repo-relative path so the map survives the runner's absolute
+                    # workspace prefix, which differs between CI and any local rebuild.
+                    # String.Replace, not -replace: the operator takes a REGEX and a lone
+                    # backslash is not a valid pattern.
+                    $norm = $full.Replace([char]92, [char]47)
+                    $cut = -1
+                    foreach ($anchor in @('/src/', '/tests/', '/tools/')) {
+                        $i = $norm.LastIndexOf($anchor)
+                        if ($i -ge 0 -and $i -gt $cut) { $cut = $i }
+                    }
+                    if ($cut -ge 0) { $paths[$uid] = $norm.Substring($cut + 1) }
+                }
+            }
+            'SequencePoint' {
+                # vc is the visit count. Zero means compiled but never executed by this shard.
+                $vc = $reader.GetAttribute('vc')
+                if ($vc -and $vc -ne '0') {
+                    $fid = $reader.GetAttribute('fileid')
+                    $sl = $reader.GetAttribute('sl')
+                    if ($fid -and $sl) {
+                        if (-not $lines.ContainsKey($fid)) {
+                            $lines[$fid] = [System.Collections.Generic.HashSet[int]]::new()
+                        }
+                        [void] $lines[$fid].Add([int]$sl)
+                    }
+                }
+            }
+        }
+    }
+}
+finally {
+    $reader.Dispose()
+}
+
+# Collapse each file's executed lines into contiguous ranges. Ranges rather than a line list because
+# executed code is overwhelmingly contiguous, and it keeps the digest small enough to commit.
+$files = [ordered]@{}
+foreach ($fid in $lines.Keys) {
+    if (-not $paths.ContainsKey($fid)) { continue }
+    $path = $paths[$fid]
+
+    $sorted = [int[]] ($lines[$fid] | Sort-Object)
+    $ranges = [System.Collections.Generic.List[object]]::new()
+    $start = $sorted[0]
+    $prev = $sorted[0]
+    for ($i = 1; $i -lt $sorted.Length; $i++) {
+        if ($sorted[$i] -eq $prev + 1) { $prev = $sorted[$i]; continue }
+        [void] $ranges.Add(@($start, $prev))
+        $start = $sorted[$i]; $prev = $sorted[$i]
+    }
+    [void] $ranges.Add(@($start, $prev))
+
+    # A partial class compiles into several <File> entries under one path; merge rather than replace.
+    if ($files.Contains($path)) {
+        $merged = [System.Collections.Generic.List[object]] $files[$path]
+        foreach ($r in $ranges) { [void] $merged.Add($r) }
+        $files[$path] = $merged
+    }
+    else {
+        $files[$path] = $ranges
+    }
+}
+
+$digest = [ordered]@{
+    schemaVersion = 1
+    shard         = $Shard
+    generatedUtc  = [DateTimeOffset]::UtcNow.ToString('o')
+    fileCount     = $files.Count
+    files         = $files
+}
+
+$dir = Split-Path -Parent $OutFile
+if ($dir -and -not (Test-Path -LiteralPath $dir)) { New-Item -ItemType Directory -Path $dir -Force | Out-Null }
+$digest | ConvertTo-Json -Depth 6 -Compress | Set-Content -LiteralPath $OutFile -Encoding utf8 -NoNewline
+
+Write-Host "digest: $($files.Count) executed file(s) -> $OutFile"

--- a/tools/TestImpact/New-CoverageDigest.ps1
+++ b/tools/TestImpact/New-CoverageDigest.ps1
@@ -100,19 +100,23 @@ foreach ($fid in $lines.Keys) {
     $path = $paths[$fid]
 
     $sorted = [int[]] ($lines[$fid] | Sort-Object)
-    $ranges = [System.Collections.Generic.List[object]]::new()
+    # FLAT pairs: [start, end, start, end, ...]. Nested arrays are a trap here - ConvertFrom-Json
+    # returns a one-element array as a bare value, so a file with exactly one executed range comes
+    # back as two loose integers and every index lookup silently shifts. Flat pairs cannot unroll
+    # into something that still indexes.
+    $ranges = [System.Collections.Generic.List[int]]::new()
     $start = $sorted[0]
     $prev = $sorted[0]
     for ($i = 1; $i -lt $sorted.Length; $i++) {
         if ($sorted[$i] -eq $prev + 1) { $prev = $sorted[$i]; continue }
-        [void] $ranges.Add(@($start, $prev))
+        [void] $ranges.Add($start); [void] $ranges.Add($prev)
         $start = $sorted[$i]; $prev = $sorted[$i]
     }
-    [void] $ranges.Add(@($start, $prev))
+    [void] $ranges.Add($start); [void] $ranges.Add($prev)
 
     # A partial class compiles into several <File> entries under one path; merge rather than replace.
     if ($files.Contains($path)) {
-        $merged = [System.Collections.Generic.List[object]] $files[$path]
+        $merged = [System.Collections.Generic.List[int]] $files[$path]
         foreach ($r in $ranges) { [void] $merged.Add($r) }
         $files[$path] = $merged
     }

--- a/tools/TestImpact/New-ShardMap.ps1
+++ b/tools/TestImpact/New-ShardMap.ps1
@@ -1,114 +1,267 @@
 <#
 .SYNOPSIS
-    Merges per-shard coverage digests into the single map that drives test selection.
+    Merges per-shard coverage digests into the map that drives test selection.
 
 .DESCRIPTION
-    Inverts "shard -> executed lines" into "file -> the shards that execute it, and where". Selection
-    then reduces to intersecting a PR's changed line ranges against that index.
-
-    The map also records what CANNOT be selected against, which matters as much as what can:
-
-      alwaysRun   Shards that produce no coverage and therefore can never appear in the index.
-                  $collectCoverage in the workflow is `-not ($heavyShard -or $measuresTiming)`, so
-                  every heavy and timing shard emits nothing. Left implicit, the map would silently
-                  under-select exactly the shards that have OOM-killed runners before. They are
-                  named here so the selector always includes them.
-
-      knownShards Every shard the map was built from. A shard absent from BOTH this list and
-                  alwaysRun is unknown to the map, which is a stale-map signal the selector escalates
-                  on rather than quietly skipping.
-
-    SCALE, measured on a synthetic full-size set (106 digests, ~11 MB, built from a real shard's
-    file list so the shapes are realistic):
-
-        map build      6s      ->  9.4 MB
-        selection      2.8s        including parsing that map
-
-    Both are negligible against the ~2h matrix they decide, so neither is worth optimising. The
-    synthetic set deliberately gives every shard an overlapping subset of ONE file list, so its
-    selection RATE means nothing - only the timings transfer.
+    The complete shard manifest is authoritative. A valid digest with executed files makes a shard
+    selectable; a missing digest or a valid digest with zero executed files makes it always-run.
+    Unknown, duplicate or malformed digests abort map creation.
 
 .PARAMETER DigestDirectory
-    Directory holding *.digest.json files, one per shard.
+    Directory holding *.digest.json files.
 
-.PARAMETER AlwaysRun
-    Shards that never produce coverage and must always run.
+.PARAMETER AllShards
+    The complete current shard manifest. Names are array elements and are never split on commas.
 
 .PARAMETER Sha
-    The commit the digests were produced from. Selection refuses a map built from an unrelated tree.
+    The exact commit the coverage run tested.
 
 .PARAMETER OutFile
     Where to write shard-map.json.
+
+.PARAMETER SelfTest
+    Runs adversarial producer checks and exits.
 #>
-[CmdletBinding()]
+[CmdletBinding(DefaultParameterSetName = 'Build')]
 param(
-    [Parameter(Mandatory)] [string] $DigestDirectory,
-    [string[]] $AlwaysRun = @(),
-    [Parameter(Mandatory)] [string] $Sha,
-    [Parameter(Mandatory)] [string] $OutFile
+    [Parameter(Mandatory, ParameterSetName = 'Build')] [string] $DigestDirectory,
+    [Parameter(Mandatory, ParameterSetName = 'Build')] [string[]] $AllShards,
+    [Parameter(Mandatory, ParameterSetName = 'Build')] [string] $Sha,
+    [Parameter(Mandatory, ParameterSetName = 'Build')] [string] $OutFile,
+    [Parameter(Mandatory, ParameterSetName = 'SelfTest')] [switch] $SelfTest
 )
 
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
-# NOT split on commas. An earlier revision did, to guard against a caller passing "A,B" instead of
-# @('A','B') - and that guard corrupted real data, because shard names legitimately contain commas:
-#
-#   ModelFamily - Generated Layers P A,C,I,L,N,P        -> 6 fragments
-#   ModelFamily - Generated Layers P E,H,O,R,S,U,W,Y    -> 8 fragments
-#
-# Measured on the first real map: 91 always-run shards became 103 entries, none of the fragments
-# matching a real shard. The selector then finds a selected name absent from the shard list and
-# escalates - every run, silently, with the feature switched off and the logs looking healthy.
-#
-# The caller passes a real array; blanks are dropped and entries are trimmed, nothing more.
-$AlwaysRun = @(
-    $AlwaysRun |
-        Where-Object { $_ } |
-        ForEach-Object { ([string] $_).Trim() } |
-        Where-Object { $_ }
-)
+function ConvertTo-ValidatedInteger {
+    param(
+        [Parameter(Mandatory)] $Value,
+        [Parameter(Mandatory)] [string] $What,
+        [int] $Minimum = 0,
+        [int] $Maximum = [int]::MaxValue
+    )
 
-$digestFiles = @(Get-ChildItem -LiteralPath $DigestDirectory -Filter '*.digest.json' -Recurse -File)
-if ($digestFiles.Count -eq 0) {
-    throw "No *.digest.json under $DigestDirectory - refusing to write an empty map, which would select nothing."
+    $isInteger = $Value -is [byte] -or $Value -is [sbyte] -or
+        $Value -is [int16] -or $Value -is [uint16] -or
+        $Value -is [int32] -or $Value -is [uint32] -or
+        $Value -is [int64] -or $Value -is [uint64]
+    if (-not $isInteger) { throw "$What must be an integer." }
+    $number = [long] $Value
+    if ($number -lt $Minimum -or $number -gt $Maximum) {
+        throw "$What must be between $Minimum and $Maximum."
+    }
+    return [int] $number
 }
 
-$shards = [System.Collections.Generic.List[string]]::new()
-$index = @{}   # path -> list of @{ s = shardIndex; r = ranges }
+function Read-ValidatedDigest {
+    param([Parameter(Mandatory)] [System.IO.FileInfo] $File)
 
-foreach ($file in $digestFiles) {
-    $digest = Get-Content -LiteralPath $file.FullName -Raw | ConvertFrom-Json
+    try { $digest = Get-Content -LiteralPath $File.FullName -Raw | ConvertFrom-Json }
+    catch { throw "Digest $($File.Name) is not valid JSON: $($_.Exception.Message)" }
+
+    foreach ($required in 'schemaVersion', 'shard', 'files') {
+        if (-not $digest.PSObject.Properties[$required]) { throw "Digest $($File.Name) has no '$required' property." }
+    }
+    $version = ConvertTo-ValidatedInteger -Value $digest.schemaVersion -What "Digest $($File.Name) schemaVersion" -Minimum 1
+    if ($version -ne 1) { throw "Digest $($File.Name) has unsupported schemaVersion $version." }
+
     $name = [string] $digest.shard
-    if ([string]::IsNullOrWhiteSpace($name)) { throw "Digest $($file.Name) has no shard name." }
+    if ([string]::IsNullOrWhiteSpace($name)) { throw "Digest $($File.Name) has no shard name." }
+    if ($digest.files -isnot [pscustomobject]) { throw "Digest $($File.Name) files must be an object." }
 
-    $shardIndex = $shards.Count
-    [void] $shards.Add($name)
-
-    foreach ($property in $digest.files.PSObject.Properties) {
-        $path = $property.Name
-        if (-not $index.ContainsKey($path)) {
-            $index[$path] = [System.Collections.Generic.List[object]]::new()
+    $fileProperties = @($digest.files.PSObject.Properties)
+    if ($digest.PSObject.Properties['fileCount']) {
+        $fileCount = ConvertTo-ValidatedInteger -Value $digest.fileCount -What "Digest $($File.Name) fileCount"
+        if ($fileCount -ne $fileProperties.Count) {
+            throw "Digest $($File.Name) fileCount $fileCount does not match $($fileProperties.Count) files."
         }
-        [void] $index[$path].Add([ordered]@{ s = $shardIndex; r = $property.Value })
+    }
+
+    foreach ($property in $fileProperties) {
+        if ([string]::IsNullOrWhiteSpace([string] $property.Name)) { throw "Digest $($File.Name) has an empty file path." }
+        if ($property.Value -isnot [array]) { throw "Digest $($File.Name) '$($property.Name)' ranges must be an array." }
+        $ranges = @($property.Value)
+        if ($ranges.Count -eq 0 -or $ranges.Count % 2 -ne 0) {
+            throw "Digest $($File.Name) '$($property.Name)' ranges must be nonempty start/end pairs."
+        }
+        for ($i = 0; $i -lt $ranges.Count; $i += 2) {
+            $start = ConvertTo-ValidatedInteger -Value $ranges[$i] `
+                -What "Digest $($File.Name) '$($property.Name)' range start" -Minimum 1
+            $end = ConvertTo-ValidatedInteger -Value $ranges[$i + 1] `
+                -What "Digest $($File.Name) '$($property.Name)' range end" -Minimum 1
+            if ($start -gt $end) {
+                throw "Digest $($File.Name) '$($property.Name)' range start $start exceeds end $end."
+            }
+        }
+    }
+
+    return $digest
+}
+
+function New-ShardMapObject {
+    param(
+        [Parameter(Mandatory)] [string] $DigestDirectory,
+        [Parameter(Mandatory)] [string[]] $AllShards,
+        [Parameter(Mandatory)] [string] $Sha
+    )
+
+    if ($Sha -notmatch '^(?:[0-9a-fA-F]{40}|[0-9a-fA-F]{64})$') {
+        throw 'Sha must be a complete hexadecimal Git object id.'
+    }
+    if (-not (Test-Path -LiteralPath $DigestDirectory -PathType Container)) {
+        throw "Digest directory not found: $DigestDirectory"
+    }
+
+    $manifest = [System.Collections.Generic.List[string]]::new()
+    $manifestSet = [System.Collections.Generic.HashSet[string]]::new([StringComparer]::Ordinal)
+    foreach ($value in @($AllShards)) {
+        $name = [string] $value
+        if ([string]::IsNullOrWhiteSpace($name)) { throw 'AllShards contains an empty shard name.' }
+        if (-not $manifestSet.Add($name)) { throw "AllShards contains duplicate shard '$name'." }
+        [void] $manifest.Add($name)
+    }
+    if ($manifest.Count -eq 0) { throw 'AllShards is empty.' }
+
+    $digests = [System.Collections.Generic.Dictionary[string, object]]::new([StringComparer]::Ordinal)
+    foreach ($file in @(Get-ChildItem -LiteralPath $DigestDirectory -Filter '*.digest.json' -Recurse -File | Sort-Object FullName)) {
+        $digest = Read-ValidatedDigest -File $file
+        $name = [string] $digest.shard
+        if (-not $manifestSet.Contains($name)) { throw "Digest $($file.Name) names unknown shard '$name'." }
+        if ($digests.ContainsKey($name)) { throw "More than one digest names shard '$name'." }
+        $digests.Add($name, $digest)
+    }
+
+    $known = [System.Collections.Generic.List[string]]::new()
+    $always = [System.Collections.Generic.List[string]]::new()
+    foreach ($name in $manifest) {
+        if ($digests.ContainsKey($name) -and @($digests[$name].files.PSObject.Properties).Count -gt 0) {
+            [void] $known.Add($name)
+        }
+        else {
+            # Missing and valid-but-empty digests are both known-unsafe, so they always run.
+            [void] $always.Add($name)
+        }
+    }
+    if ($known.Count -eq 0) {
+        throw 'No shard has a nonempty valid digest; refusing to publish a map with no index.'
+    }
+
+    $knownIndex = [System.Collections.Generic.Dictionary[string, int]]::new([StringComparer]::Ordinal)
+    for ($i = 0; $i -lt $known.Count; $i++) { $knownIndex.Add($known[$i], $i) }
+
+    $index = [System.Collections.Generic.Dictionary[string, System.Collections.Generic.List[object]]]::new([StringComparer]::Ordinal)
+    foreach ($name in $known) {
+        $digest = $digests[$name]
+        foreach ($property in @($digest.files.PSObject.Properties | Sort-Object Name)) {
+            $path = [string] $property.Name
+            if (-not $index.ContainsKey($path)) {
+                $index.Add($path, [System.Collections.Generic.List[object]]::new())
+            }
+            [void] $index[$path].Add([ordered]@{ s = $knownIndex[$name]; r = @($property.Value) })
+        }
+    }
+
+    $files = [ordered]@{}
+    foreach ($path in ($index.Keys | Sort-Object)) { $files[$path] = $index[$path] }
+    return [pscustomobject] [ordered]@{
+        schemaVersion = 1
+        sha           = $Sha
+        generatedUtc  = [DateTimeOffset]::UtcNow.ToString('o')
+        knownShards   = @($known)
+        alwaysRun     = @($always)
+        fileCount     = $files.Count
+        files         = $files
     }
 }
 
-$files = [ordered]@{}
-foreach ($path in ($index.Keys | Sort-Object)) { $files[$path] = $index[$path] }
+if ($SelfTest) {
+    $failures = [System.Collections.Generic.List[string]]::new()
+    function Assert-True {
+        param([bool] $Condition, [string] $What)
+        if (-not $Condition) { [void] $failures.Add($What) }
+    }
+    function Assert-Throws {
+        param([scriptblock] $Action, [string] $What)
+        $threw = $false
+        try { & $Action } catch { $threw = $true }
+        Assert-True $threw $What
+    }
+    function Write-DigestFixture {
+        param([string] $Path, [string] $Shard, $Files, [int] $SchemaVersion = 1)
+        [ordered]@{
+            schemaVersion = $SchemaVersion
+            shard = $Shard
+            fileCount = @($Files.PSObject.Properties).Count
+            files = $Files
+        } | ConvertTo-Json -Depth 8 -Compress | Set-Content -LiteralPath $Path -Encoding utf8
+    }
 
-$map = [ordered]@{
-    schemaVersion = 1
-    sha           = $Sha
-    generatedUtc  = [DateTimeOffset]::UtcNow.ToString('o')
-    knownShards   = $shards
-    alwaysRun     = $AlwaysRun
-    fileCount     = $files.Count
-    files         = $files
+    $temp = Join-Path ([IO.Path]::GetTempPath()) ("AiDotNet-NewShardMap-$([Guid]::NewGuid().ToString('N'))")
+    $fixtureSha = '0123456789abcdef0123456789abcdef01234567'
+    New-Item -ItemType Directory -Path $temp | Out-Null
+    try {
+        Write-DigestFixture -Path (Join-Path $temp 'alpha.digest.json') -Shard 'Alpha' `
+            -Files ([pscustomobject] @{ 'src/A.cs' = @(1, 3) })
+        Write-DigestFixture -Path (Join-Path $temp 'empty.digest.json') -Shard 'Empty' `
+            -Files ([pscustomobject] @{})
+
+        try {
+            $map = New-ShardMapObject -DigestDirectory $temp -AllShards @('Alpha', 'Empty', 'Comma, Missing') -Sha $fixtureSha
+            Assert-True (@($map.knownShards).Count -eq 1 -and $map.knownShards[0] -eq 'Alpha') `
+                'only a shard with indexed files should be known'
+            Assert-True ($map.alwaysRun -contains 'Empty') 'a valid empty digest must become always-run'
+            Assert-True ($map.alwaysRun -contains 'Comma, Missing') 'a missing digest must become always-run without splitting commas'
+            Assert-True (@($map.knownShards).Count + @($map.alwaysRun).Count -eq 3) `
+                'every manifest shard must be classified exactly once'
+        }
+        catch { [void] $failures.Add("valid producer fixture failed: $_") }
+
+        Copy-Item -LiteralPath (Join-Path $temp 'alpha.digest.json') -Destination (Join-Path $temp 'duplicate.digest.json')
+        Assert-Throws { New-ShardMapObject -DigestDirectory $temp -AllShards @('Alpha', 'Empty') -Sha $fixtureSha } `
+            'duplicate shard digests must be rejected'
+        Remove-Item -LiteralPath (Join-Path $temp 'duplicate.digest.json')
+
+        Write-DigestFixture -Path (Join-Path $temp 'schema.digest.json') -Shard 'Alpha' `
+            -Files ([pscustomobject] @{ 'src/S.cs' = @(1, 1) }) -SchemaVersion 2
+        Assert-Throws { New-ShardMapObject -DigestDirectory $temp -AllShards @('Alpha', 'Empty') -Sha $fixtureSha } `
+            'unsupported digest schemas must be rejected before classification'
+        Remove-Item -LiteralPath (Join-Path $temp 'schema.digest.json')
+
+        [ordered]@{ schemaVersion = 1; shard = 'Alpha'; files = @(1, 2) } |
+            ConvertTo-Json -Depth 4 | Set-Content -LiteralPath (Join-Path $temp 'files.digest.json') -Encoding utf8
+        Assert-Throws { New-ShardMapObject -DigestDirectory $temp -AllShards @('Alpha', 'Empty') -Sha $fixtureSha } `
+            'a non-object digest files value must be rejected'
+        Remove-Item -LiteralPath (Join-Path $temp 'files.digest.json')
+
+        Write-DigestFixture -Path (Join-Path $temp 'bad.digest.json') -Shard 'Unknown' `
+            -Files ([pscustomobject] @{ 'src/Bad.cs' = @(1) })
+        Assert-Throws { New-ShardMapObject -DigestDirectory $temp -AllShards @('Alpha', 'Empty') -Sha $fixtureSha } `
+            'malformed ranges must be rejected even when the shard is unknown'
+        Remove-Item -LiteralPath (Join-Path $temp 'bad.digest.json')
+
+        Write-DigestFixture -Path (Join-Path $temp 'unknown.digest.json') -Shard 'Unknown' `
+            -Files ([pscustomobject] @{ 'src/U.cs' = @(1, 1) })
+        Assert-Throws { New-ShardMapObject -DigestDirectory $temp -AllShards @('Alpha', 'Empty') -Sha $fixtureSha } `
+            'unknown shard digests must be rejected'
+    }
+    finally {
+        Remove-Item -LiteralPath $temp -Recurse -Force
+    }
+
+    if ($failures.Count -gt 0) {
+        Write-Host 'New-ShardMap self-test FAILED:'
+        foreach ($failure in $failures) { Write-Host "  - $failure" }
+        exit 1
+    }
+    Write-Host 'New-ShardMap self-test passed.'
+    exit 0
 }
 
-$dir = Split-Path -Parent $OutFile
-if ($dir -and -not (Test-Path -LiteralPath $dir)) { New-Item -ItemType Directory -Path $dir -Force | Out-Null }
+$map = New-ShardMapObject -DigestDirectory $DigestDirectory -AllShards $AllShards -Sha $Sha
+$directory = Split-Path -Parent $OutFile
+if ($directory -and -not (Test-Path -LiteralPath $directory)) {
+    New-Item -ItemType Directory -Path $directory -Force | Out-Null
+}
 $map | ConvertTo-Json -Depth 8 -Compress | Set-Content -LiteralPath $OutFile -Encoding utf8 -NoNewline
-
-Write-Host "map: $($shards.Count) shard(s), $($files.Count) file(s), $($AlwaysRun.Count) always-run -> $OutFile"
+Write-Host "map: $(@($map.knownShards).Count) indexed shard(s), $($map.fileCount) file(s), $(@($map.alwaysRun).Count) always-run -> $OutFile"

--- a/tools/TestImpact/New-ShardMap.ps1
+++ b/tools/TestImpact/New-ShardMap.ps1
@@ -51,14 +51,21 @@ param(
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
-# A caller that passes "A,B" or "A;B" instead of @('A','B') would otherwise store one bogus shard
-# name and silently drop the real always-run shards - under-selecting exactly the shards that cannot
-# be mapped, which is the dangerous direction. Split defensively and drop blanks.
+# NOT split on commas. An earlier revision did, to guard against a caller passing "A,B" instead of
+# @('A','B') - and that guard corrupted real data, because shard names legitimately contain commas:
+#
+#   ModelFamily - Generated Layers P A,C,I,L,N,P        -> 6 fragments
+#   ModelFamily - Generated Layers P E,H,O,R,S,U,W,Y    -> 8 fragments
+#
+# Measured on the first real map: 91 always-run shards became 103 entries, none of the fragments
+# matching a real shard. The selector then finds a selected name absent from the shard list and
+# escalates - every run, silently, with the feature switched off and the logs looking healthy.
+#
+# The caller passes a real array; blanks are dropped and entries are trimmed, nothing more.
 $AlwaysRun = @(
     $AlwaysRun |
         Where-Object { $_ } |
-        ForEach-Object { $_ -split '[,;]' } |
-        ForEach-Object { $_.Trim() } |
+        ForEach-Object { ([string] $_).Trim() } |
         Where-Object { $_ }
 )
 

--- a/tools/TestImpact/New-ShardMap.ps1
+++ b/tools/TestImpact/New-ShardMap.ps1
@@ -18,6 +18,16 @@
                   alwaysRun is unknown to the map, which is a stale-map signal the selector escalates
                   on rather than quietly skipping.
 
+    SCALE, measured on a synthetic full-size set (106 digests, ~11 MB, built from a real shard's
+    file list so the shapes are realistic):
+
+        map build      6s      ->  9.4 MB
+        selection      2.8s        including parsing that map
+
+    Both are negligible against the ~2h matrix they decide, so neither is worth optimising. The
+    synthetic set deliberately gives every shard an overlapping subset of ONE file list, so its
+    selection RATE means nothing - only the timings transfer.
+
 .PARAMETER DigestDirectory
     Directory holding *.digest.json files, one per shard.
 

--- a/tools/TestImpact/New-ShardMap.ps1
+++ b/tools/TestImpact/New-ShardMap.ps1
@@ -1,0 +1,86 @@
+<#
+.SYNOPSIS
+    Merges per-shard coverage digests into the single map that drives test selection.
+
+.DESCRIPTION
+    Inverts "shard -> executed lines" into "file -> the shards that execute it, and where". Selection
+    then reduces to intersecting a PR's changed line ranges against that index.
+
+    The map also records what CANNOT be selected against, which matters as much as what can:
+
+      alwaysRun   Shards that produce no coverage and therefore can never appear in the index.
+                  $collectCoverage in the workflow is `-not ($heavyShard -or $measuresTiming)`, so
+                  every heavy and timing shard emits nothing. Left implicit, the map would silently
+                  under-select exactly the shards that have OOM-killed runners before. They are
+                  named here so the selector always includes them.
+
+      knownShards Every shard the map was built from. A shard absent from BOTH this list and
+                  alwaysRun is unknown to the map, which is a stale-map signal the selector escalates
+                  on rather than quietly skipping.
+
+.PARAMETER DigestDirectory
+    Directory holding *.digest.json files, one per shard.
+
+.PARAMETER AlwaysRun
+    Shards that never produce coverage and must always run.
+
+.PARAMETER Sha
+    The commit the digests were produced from. Selection refuses a map built from an unrelated tree.
+
+.PARAMETER OutFile
+    Where to write shard-map.json.
+#>
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)] [string] $DigestDirectory,
+    [string[]] $AlwaysRun = @(),
+    [Parameter(Mandatory)] [string] $Sha,
+    [Parameter(Mandatory)] [string] $OutFile
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$digestFiles = @(Get-ChildItem -LiteralPath $DigestDirectory -Filter '*.digest.json' -Recurse -File)
+if ($digestFiles.Count -eq 0) {
+    throw "No *.digest.json under $DigestDirectory - refusing to write an empty map, which would select nothing."
+}
+
+$shards = [System.Collections.Generic.List[string]]::new()
+$index = @{}   # path -> list of @{ s = shardIndex; r = ranges }
+
+foreach ($file in $digestFiles) {
+    $digest = Get-Content -LiteralPath $file.FullName -Raw | ConvertFrom-Json
+    $name = [string] $digest.shard
+    if ([string]::IsNullOrWhiteSpace($name)) { throw "Digest $($file.Name) has no shard name." }
+
+    $shardIndex = $shards.Count
+    [void] $shards.Add($name)
+
+    foreach ($property in $digest.files.PSObject.Properties) {
+        $path = $property.Name
+        if (-not $index.ContainsKey($path)) {
+            $index[$path] = [System.Collections.Generic.List[object]]::new()
+        }
+        [void] $index[$path].Add([ordered]@{ s = $shardIndex; r = $property.Value })
+    }
+}
+
+$files = [ordered]@{}
+foreach ($path in ($index.Keys | Sort-Object)) { $files[$path] = $index[$path] }
+
+$map = [ordered]@{
+    schemaVersion = 1
+    sha           = $Sha
+    generatedUtc  = [DateTimeOffset]::UtcNow.ToString('o')
+    knownShards   = $shards
+    alwaysRun     = $AlwaysRun
+    fileCount     = $files.Count
+    files         = $files
+}
+
+$dir = Split-Path -Parent $OutFile
+if ($dir -and -not (Test-Path -LiteralPath $dir)) { New-Item -ItemType Directory -Path $dir -Force | Out-Null }
+$map | ConvertTo-Json -Depth 8 -Compress | Set-Content -LiteralPath $OutFile -Encoding utf8 -NoNewline
+
+Write-Host "map: $($shards.Count) shard(s), $($files.Count) file(s), $($AlwaysRun.Count) always-run -> $OutFile"

--- a/tools/TestImpact/New-ShardMap.ps1
+++ b/tools/TestImpact/New-ShardMap.ps1
@@ -41,6 +41,17 @@ param(
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
+# A caller that passes "A,B" or "A;B" instead of @('A','B') would otherwise store one bogus shard
+# name and silently drop the real always-run shards - under-selecting exactly the shards that cannot
+# be mapped, which is the dangerous direction. Split defensively and drop blanks.
+$AlwaysRun = @(
+    $AlwaysRun |
+        Where-Object { $_ } |
+        ForEach-Object { $_ -split '[,;]' } |
+        ForEach-Object { $_.Trim() } |
+        Where-Object { $_ }
+)
+
 $digestFiles = @(Get-ChildItem -LiteralPath $DigestDirectory -Filter '*.digest.json' -Recurse -File)
 if ($digestFiles.Count -eq 0) {
     throw "No *.digest.json under $DigestDirectory - refusing to write an empty map, which would select nothing."

--- a/tools/TestImpact/Select-CoverageShards.ps1
+++ b/tools/TestImpact/Select-CoverageShards.ps1
@@ -292,6 +292,13 @@ if ($PreviousMap -and (Test-Path -LiteralPath $PreviousMap)) {
         foreach ($required in 'sha', 'knownShards', 'files') {
             if (-not $map.PSObject.Properties[$required]) { throw "no '$required' property" }
         }
+        # An unknown schema is treated as unreadable, not as best-effort: carrying is the one
+        # operation here where a misread map produces a STALE map rather than an escalation, so
+        # any doubt must land on instrument-everything.
+        if (-not $map.PSObject.Properties['schemaVersion'] -or [int] $map.schemaVersion -ne 1) {
+            throw "unsupported schemaVersion '$($map.schemaVersion)'"
+        }
+        if ($map.files -isnot [pscustomobject]) { throw 'files must be an object' }
     }
     catch {
         Write-Host "::warning::previous map unreadable ($($_.Exception.Message)) - instrumenting every shard"
@@ -322,9 +329,10 @@ $selfProducing = @($split.Carried).Count - $carriedFinal.Count
 Write-Host "instrument $($split.Instrument.Count), carry forward $($carriedFinal.Count), self-producing $selfProducing  [$($split.Reason)]"
 
 if ($CarryForwardDirectory -and $carriedFinal.Count -gt 0) {
-    if (-not (Test-Path -LiteralPath $CarryForwardDirectory)) {
-        New-Item -ItemType Directory -Path $CarryForwardDirectory -Force | Out-Null
-    }
+    # .NET call rather than New-Item: New-Item has no -LiteralPath, and its -Path is
+    # wildcard-expanded, so a directory name containing [ or ] would be created somewhere else.
+    # CreateDirectory is verbatim and idempotent.
+    [void] [System.IO.Directory]::CreateDirectory($CarryForwardDirectory)
     foreach ($shard in $carriedFinal) {
         $slug = $shard -replace '[\\/:*?"<>|\s-]+', '_'
         $n = Export-ShardDigest -Map $map -Shard $shard -Path (Join-Path $CarryForwardDirectory "$slug.digest.json")

--- a/tools/TestImpact/Select-CoverageShards.ps1
+++ b/tools/TestImpact/Select-CoverageShards.ps1
@@ -1,0 +1,254 @@
+<#
+.SYNOPSIS
+    Decides which shards must be re-instrumented, and carries the rest forward from the previous map.
+
+.DESCRIPTION
+    Rebuilding the map means running the whole matrix with coverage on, and instrumentation costs
+    3.21x on heavy shards - about 4.8 hours of queue occupancy. Most of that is wasted: on a typical
+    night only a fraction of shards execute code that changed at all.
+
+    A shard can be carried forward when EVERY file in its digest is byte-identical between the
+    previous map's commit and the new one. That is the exact condition under which its recorded line
+    ranges still mean what they said, so the carried digest is valid at the new commit rather than
+    merely plausible - which matters, because a map mixing coordinate systems is the failure this
+    whole feature has been bitten by twice.
+
+    Everything else is instrumented:
+
+      a shard whose covered files changed     its ranges may have moved
+      a shard absent from the previous map    never mapped, or its last run failed
+      any shard, when there is no previous map  first build
+
+    Conservative by construction: a shard is only skipped on positive evidence that nothing it
+    touches moved. Any doubt - unreadable map, unknown shard, missing digest - instruments.
+
+    NOTE this narrows nothing about SELECTION. A carried shard is as fully mapped as a freshly
+    instrumented one; the only thing saved is re-measuring what cannot have changed.
+
+.PARAMETER PreviousMap
+    shard-map.json from the last successful build. Absent or unreadable means instrument everything.
+
+.PARAMETER ChangedFiles
+    Repo-relative paths changed between the previous map's commit and the one being mapped.
+
+.PARAMETER AllShards
+    The current shard manifest.
+
+.PARAMETER CarryForwardDirectory
+    Where to write reconstructed digests for the shards being carried forward. A digest is inverted
+    straight out of the previous map, so New-ShardMap consumes it exactly like a fresh one and needs
+    no knowledge of any of this.
+
+.PARAMETER OutFile
+    JSON: { instrument: [...], carried: [...] }.
+
+.PARAMETER SelfTest
+    Runs the built-in checks and exits.
+#>
+[CmdletBinding(DefaultParameterSetName = 'Select')]
+param(
+    [Parameter(Mandatory, ParameterSetName = 'Select')] [string] $PreviousMap,
+    [Parameter(Mandatory, ParameterSetName = 'Select')] [AllowEmptyCollection()] [string[]] $ChangedFiles,
+    [Parameter(Mandatory, ParameterSetName = 'Select')] [string[]] $AllShards,
+    [Parameter(ParameterSetName = 'Select')] [string] $CarryForwardDirectory,
+    [Parameter(ParameterSetName = 'Select')] [string] $OutFile,
+    [Parameter(Mandatory, ParameterSetName = 'SelfTest')] [switch] $SelfTest
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+function Split-CoverageWork {
+    <#
+        Pure: given a parsed map, the changed paths and the shard manifest, decide what to
+        instrument and what may be carried. Returns names only; writing digests is the caller's job.
+    #>
+    param(
+        [Parameter(Mandatory)] [AllowNull()] $Map,
+        [Parameter(Mandatory)] [AllowEmptyCollection()] [string[]] $ChangedFiles,
+        [Parameter(Mandatory)] [AllowEmptyCollection()] [string[]] $AllShards
+    )
+
+    if ($null -eq $Map) {
+        return [pscustomobject]@{ Instrument = @($AllShards); Carried = @(); Reason = 'no previous map' }
+    }
+
+    $changed = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::Ordinal)
+    foreach ($f in $ChangedFiles) { if ($f) { [void] $changed.Add([string] $f) } }
+
+    $known = @($Map.knownShards)
+
+    # Which shards touch a changed file. Walked file-first because the map is indexed that way, and
+    # a shard is disqualified by ONE changed file - there is no need to enumerate the rest.
+    $dirty = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::Ordinal)
+    foreach ($prop in $Map.files.PSObject.Properties) {
+        if (-not $changed.Contains([string] $prop.Name)) { continue }
+        foreach ($occurrence in @($prop.Value)) {
+            $i = [int] $occurrence.s
+            if ($i -ge 0 -and $i -lt $known.Count) { [void] $dirty.Add([string] $known[$i]) }
+        }
+    }
+
+    $mapped = [System.Collections.Generic.HashSet[string]]::new([string[]] $known, [System.StringComparer]::Ordinal)
+
+    $instrument = [System.Collections.Generic.List[string]]::new()
+    $carried    = [System.Collections.Generic.List[string]]::new()
+    foreach ($s in $AllShards) {
+        $name = [string] $s
+        # Absent from the map means never mapped or last run failed - it has nothing to carry.
+        if (-not $mapped.Contains($name)) { [void] $instrument.Add($name); continue }
+        if ($dirty.Contains($name))       { [void] $instrument.Add($name); continue }
+        [void] $carried.Add($name)
+    }
+
+    return [pscustomobject]@{
+        Instrument = @($instrument)
+        Carried    = @($carried)
+        Reason     = "$($changed.Count) changed file(s)"
+    }
+}
+
+function Export-ShardDigest {
+    <#
+        Rebuild one shard's digest by inverting the map. The map stores file -> [{s,r}], so a
+        shard's digest is every file whose occurrences name it, with those ranges.
+    #>
+    param(
+        [Parameter(Mandatory)] $Map,
+        [Parameter(Mandatory)] [string] $Shard,
+        [Parameter(Mandatory)] [string] $Path
+    )
+
+    $known = @($Map.knownShards)
+    $index = [array]::IndexOf($known, $Shard)
+    if ($index -lt 0) { throw "shard '$Shard' is not in the previous map" }
+
+    $files = [ordered]@{}
+    foreach ($prop in $Map.files.PSObject.Properties) {
+        foreach ($occurrence in @($prop.Value)) {
+            if ([int] $occurrence.s -ne $index) { continue }
+            $files[$prop.Name] = @($occurrence.r)
+        }
+    }
+
+    $digest = [ordered]@{
+        schemaVersion = 1
+        shard         = $Shard
+        generatedUtc  = [string] $Map.generatedUtc
+        carriedFrom   = [string] $Map.sha
+        fileCount     = $files.Count
+        files         = $files
+    }
+    $digest | ConvertTo-Json -Depth 6 -Compress | Set-Content -LiteralPath $Path -Encoding utf8 -NoNewline
+    return $files.Count
+}
+
+# ---------------------------------------------------------------- self-test
+
+if ($SelfTest) {
+    $failures = [System.Collections.Generic.List[string]]::new()
+    function Assert-True { param([bool] $Condition, [string] $What)
+        if (-not $Condition) { [void] $failures.Add($What) } }
+
+    $map = @{
+        schemaVersion = 1
+        sha           = 'abc123'
+        generatedUtc  = '2026-09-01T00:00:00Z'
+        knownShards   = @('Alpha', 'Beta')
+        alwaysRun     = @('Heavy')
+        files         = @{
+            'src/A.cs' = @(@{ s = 0; r = @(10, 20) })
+            'src/B.cs' = @(@{ s = 1; r = @(5, 6) })
+            'src/C.cs' = @(@{ s = 0; r = @(1, 2) }, @{ s = 1; r = @(1, 2) })
+        }
+    } | ConvertTo-Json -Depth 8 | ConvertFrom-Json
+    $all = @('Alpha', 'Beta', 'Heavy')
+
+    # 1. Nothing changed: everything mapped is carried, and only the unmapped shard is instrumented.
+    $r = Split-CoverageWork -Map $map -ChangedFiles @() -AllShards $all
+    Assert-True ($r.Carried.Count -eq 2) 'with no changes both mapped shards are carried'
+    Assert-True ($r.Instrument -contains 'Heavy') 'a shard absent from the map must be instrumented'
+    Assert-True (-not ($r.Instrument -contains 'Alpha')) 'an unaffected shard must not be instrumented'
+
+    # 2. A changed file dirties exactly the shards that execute it - the core of the saving, and
+    #    the thing that would silently carry a stale digest if it were wrong.
+    $r = Split-CoverageWork -Map $map -ChangedFiles @('src/A.cs') -AllShards $all
+    Assert-True ($r.Instrument -contains 'Alpha') 'a shard executing a changed file must be instrumented'
+    Assert-True ($r.Carried -contains 'Beta') 'a shard not executing it may still be carried'
+
+    # 3. A file executed by SEVERAL shards dirties all of them.
+    $r = Split-CoverageWork -Map $map -ChangedFiles @('src/C.cs') -AllShards $all
+    Assert-True ($r.Instrument -contains 'Alpha' -and $r.Instrument -contains 'Beta') `
+        'every shard executing a changed file must be instrumented'
+    Assert-True ($r.Carried.Count -eq 0) 'nothing may be carried when all mapped shards are dirty'
+
+    # 4. A changed file no shard executes carries everything - it cannot have moved any ranges.
+    #    (Selection escalates on such a file separately; that is not this script's job.)
+    $r = Split-CoverageWork -Map $map -ChangedFiles @('src/Unmapped.cs') -AllShards $all
+    Assert-True ($r.Carried.Count -eq 2) 'a change to an unmapped file dirties no shard'
+
+    # 5. No previous map instruments everything. Without this the first build would carry nothing
+    #    forward and silently produce an empty map.
+    $r = Split-CoverageWork -Map $null -ChangedFiles @('src/A.cs') -AllShards $all
+    Assert-True ($r.Instrument.Count -eq 3 -and $r.Carried.Count -eq 0) 'no map means instrument everything'
+
+    # 6. Ordinal matching: shard names differing only in case are different shards.
+    $r = Split-CoverageWork -Map $map -ChangedFiles @('src/A.cs') -AllShards @('alpha')
+    Assert-True ($r.Instrument -contains 'alpha') 'shard matching must be ordinal'
+
+    # 7. Round-trip: a carried digest must reproduce exactly the ranges the map held, or carrying
+    #    forward would quietly corrupt the very thing it is trying to preserve.
+    $tmp = Join-Path ([System.IO.Path]::GetTempPath()) "carry-$PID.json"
+    [void] (Export-ShardDigest -Map $map -Shard 'Alpha' -Path $tmp)
+    $d = Get-Content -LiteralPath $tmp -Raw | ConvertFrom-Json
+    Remove-Item -LiteralPath $tmp -ErrorAction SilentlyContinue
+    Assert-True ($d.shard -eq 'Alpha') 'the carried digest names its shard'
+    Assert-True ($d.fileCount -eq 2) "Alpha's digest carries both files it executes"
+    Assert-True (@($d.files.'src/A.cs') -join ',' -eq '10,20') 'carried ranges match the map exactly'
+    Assert-True (-not $d.files.PSObject.Properties['src/B.cs']) "another shard's file must not leak in"
+    Assert-True ($d.carriedFrom -eq 'abc123') 'the carried digest records the commit it came from'
+
+    if ($failures.Count -gt 0) {
+        Write-Host 'Select-CoverageShards self-test FAILED:'
+        foreach ($f in $failures) { Write-Host "  - $f" }
+        exit 1
+    }
+    Write-Host 'Select-CoverageShards self-test passed.'
+    exit 0
+}
+
+# ---------------------------------------------------------------- split
+
+$map = $null
+if ($PreviousMap -and (Test-Path -LiteralPath $PreviousMap)) {
+    try {
+        $map = Get-Content -LiteralPath $PreviousMap -Raw | ConvertFrom-Json
+        foreach ($required in 'sha', 'knownShards', 'files') {
+            if (-not $map.PSObject.Properties[$required]) { throw "no '$required' property" }
+        }
+    }
+    catch {
+        Write-Host "::warning::previous map unreadable ($($_.Exception.Message)) - instrumenting every shard"
+        $map = $null
+    }
+}
+
+$split = Split-CoverageWork -Map $map -ChangedFiles $ChangedFiles -AllShards $AllShards
+Write-Host "instrument $($split.Instrument.Count), carry forward $($split.Carried.Count)  [$($split.Reason)]"
+
+if ($CarryForwardDirectory -and $split.Carried.Count -gt 0) {
+    if (-not (Test-Path -LiteralPath $CarryForwardDirectory)) {
+        New-Item -ItemType Directory -Path $CarryForwardDirectory -Force | Out-Null
+    }
+    foreach ($shard in $split.Carried) {
+        $slug = $shard -replace '[\\/:*?"<>|\s-]+', '_'
+        $n = Export-ShardDigest -Map $map -Shard $shard -Path (Join-Path $CarryForwardDirectory "$slug.digest.json")
+        Write-Verbose "carried $shard ($n file(s))"
+    }
+    Write-Host "wrote $($split.Carried.Count) carried digest(s) to $CarryForwardDirectory"
+}
+
+if ($OutFile) {
+    [pscustomobject]@{ instrument = @($split.Instrument); carried = @($split.Carried) } |
+        ConvertTo-Json -Depth 4 -Compress | Set-Content -LiteralPath $OutFile -Encoding utf8
+}

--- a/tools/TestImpact/Select-CoverageShards.ps1
+++ b/tools/TestImpact/Select-CoverageShards.ps1
@@ -135,7 +135,11 @@ function Export-ShardDigest {
     foreach ($prop in $Map.files.PSObject.Properties) {
         foreach ($occurrence in @($prop.Value)) {
             if ([int] $occurrence.s -ne $index) { continue }
-            $files[$prop.Name] = @($occurrence.r)
+            # Merged, not overwritten. The current builder cannot emit two occurrences of one
+            # shard for one path, but this reads HISTORICAL maps, and silently dropping ranges
+            # is the one corruption a carried digest must never introduce.
+            if ($files.Contains($prop.Name)) { $files[$prop.Name] = @($files[$prop.Name]) + @($occurrence.r) }
+            else { $files[$prop.Name] = @($occurrence.r) }
         }
     }
 
@@ -227,6 +231,24 @@ if ($SelfTest) {
         'CarryOnly must keep exactly the intersection'
     Assert-True ($r.Instrument -contains 'Heavy' -and $r.Instrument.Count -eq 1) `
         'CarryOnly must not move displaced shards into the instrument set'
+
+    # 9. A historical map holding two occurrences of one shard for one path must MERGE their
+    #    ranges into the carried digest, never overwrite - dropped ranges would make the map
+    #    claim the shard does not execute lines it does, which is a silent selection miss.
+    $dupMap = @{
+        schemaVersion = 1
+        sha           = 'abc123'
+        generatedUtc  = '2026-09-01T00:00:00Z'
+        knownShards   = @('Alpha')
+        alwaysRun     = @()
+        files         = @{ 'src/Dup.cs' = @(@{ s = 0; r = @(1, 2) }, @{ s = 0; r = @(9, 9) }) }
+    } | ConvertTo-Json -Depth 8 | ConvertFrom-Json
+    $tmp2 = Join-Path ([System.IO.Path]::GetTempPath()) "carry-dup-$PID.json"
+    [void] (Export-ShardDigest -Map $dupMap -Shard 'Alpha' -Path $tmp2)
+    $d2 = Get-Content -LiteralPath $tmp2 -Raw | ConvertFrom-Json
+    Remove-Item -LiteralPath $tmp2 -ErrorAction SilentlyContinue
+    Assert-True ((@($d2.files.'src/Dup.cs') -join ',') -eq '1,2,9,9') `
+        'duplicate occurrences must merge ranges, not overwrite'
 
     if ($failures.Count -gt 0) {
         Write-Host 'Select-CoverageShards self-test FAILED:'

--- a/tools/TestImpact/Select-CoverageShards.ps1
+++ b/tools/TestImpact/Select-CoverageShards.ps1
@@ -34,6 +34,13 @@
 .PARAMETER AllShards
     The current shard manifest.
 
+.PARAMETER CarryOnly
+    Restrict carrying to these shards. The nightly passes the heavy and timing shards here, because
+    every OTHER shard collects coverage in any run and produces a fresh digest on success - and a
+    carried digest colliding with a fresh one makes New-ShardMap abort the whole map, by design.
+    A clean mapped shard NOT in this list is simply left to re-produce its own digest; it is neither
+    instrumented by force nor carried. Omit to allow carrying everything (the self-contained case).
+
 .PARAMETER CarryForwardDirectory
     Where to write reconstructed digests for the shards being carried forward. A digest is inverted
     straight out of the previous map, so New-ShardMap consumes it exactly like a fresh one and needs
@@ -50,6 +57,7 @@ param(
     [Parameter(Mandatory, ParameterSetName = 'Select')] [string] $PreviousMap,
     [Parameter(Mandatory, ParameterSetName = 'Select')] [AllowEmptyCollection()] [string[]] $ChangedFiles,
     [Parameter(Mandatory, ParameterSetName = 'Select')] [string[]] $AllShards,
+    [Parameter(ParameterSetName = 'Select')] [AllowEmptyCollection()] [string[]] $CarryOnly,
     [Parameter(ParameterSetName = 'Select')] [string] $CarryForwardDirectory,
     [Parameter(ParameterSetName = 'Select')] [string] $OutFile,
     [Parameter(Mandatory, ParameterSetName = 'SelfTest')] [switch] $SelfTest
@@ -208,6 +216,18 @@ if ($SelfTest) {
     Assert-True (-not $d.files.PSObject.Properties['src/B.cs']) "another shard's file must not leak in"
     Assert-True ($d.carriedFrom -eq 'abc123') 'the carried digest records the commit it came from'
 
+    # 8. CarryOnly restricts carrying WITHOUT touching the instrument set. A shard displaced by
+    #    the filter is a natural producer: it re-creates its own digest in any run, so carrying it
+    #    would collide with the fresh one and New-ShardMap aborts the whole map on duplicates.
+    $r = Split-CoverageWork -Map $map -ChangedFiles @() -AllShards $all
+    $allow = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::Ordinal)
+    [void] $allow.Add('Alpha')
+    $restricted = @($r.Carried | Where-Object { $allow.Contains([string] $_) })
+    Assert-True ($restricted.Count -eq 1 -and $restricted -contains 'Alpha') `
+        'CarryOnly must keep exactly the intersection'
+    Assert-True ($r.Instrument -contains 'Heavy' -and $r.Instrument.Count -eq 1) `
+        'CarryOnly must not move displaced shards into the instrument set'
+
     if ($failures.Count -gt 0) {
         Write-Host 'Select-CoverageShards self-test FAILED:'
         foreach ($f in $failures) { Write-Host "  - $f" }
@@ -234,21 +254,29 @@ if ($PreviousMap -and (Test-Path -LiteralPath $PreviousMap)) {
 }
 
 $split = Split-CoverageWork -Map $map -ChangedFiles $ChangedFiles -AllShards $AllShards
-Write-Host "instrument $($split.Instrument.Count), carry forward $($split.Carried.Count)  [$($split.Reason)]"
 
-if ($CarryForwardDirectory -and $split.Carried.Count -gt 0) {
+$carriedFinal = @($split.Carried)
+if ($PSBoundParameters.ContainsKey('CarryOnly')) {
+    $allow = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::Ordinal)
+    foreach ($s in $CarryOnly) { if ($s) { [void] $allow.Add([string] $s) } }
+    $carriedFinal = @($split.Carried | Where-Object { $allow.Contains([string] $_) })
+}
+$selfProducing = @($split.Carried).Count - $carriedFinal.Count
+Write-Host "instrument $($split.Instrument.Count), carry forward $($carriedFinal.Count), self-producing $selfProducing  [$($split.Reason)]"
+
+if ($CarryForwardDirectory -and $carriedFinal.Count -gt 0) {
     if (-not (Test-Path -LiteralPath $CarryForwardDirectory)) {
         New-Item -ItemType Directory -Path $CarryForwardDirectory -Force | Out-Null
     }
-    foreach ($shard in $split.Carried) {
+    foreach ($shard in $carriedFinal) {
         $slug = $shard -replace '[\\/:*?"<>|\s-]+', '_'
         $n = Export-ShardDigest -Map $map -Shard $shard -Path (Join-Path $CarryForwardDirectory "$slug.digest.json")
         Write-Verbose "carried $shard ($n file(s))"
     }
-    Write-Host "wrote $($split.Carried.Count) carried digest(s) to $CarryForwardDirectory"
+    Write-Host "wrote $($carriedFinal.Count) carried digest(s) to $CarryForwardDirectory"
 }
 
 if ($OutFile) {
-    [pscustomobject]@{ instrument = @($split.Instrument); carried = @($split.Carried) } |
+    [pscustomobject]@{ instrument = @($split.Instrument); carried = @($carriedFinal) } |
         ConvertTo-Json -Depth 4 -Compress | Set-Content -LiteralPath $OutFile -Encoding utf8
 }

--- a/tools/TestImpact/Select-CoverageShards.ps1
+++ b/tools/TestImpact/Select-CoverageShards.ps1
@@ -41,6 +41,16 @@
     A clean mapped shard NOT in this list is simply left to re-produce its own digest; it is neither
     instrumented by force nor carried. Omit to allow carrying everything (the self-contained case).
 
+.PARAMETER GlobalDirtyPrefixes
+    Path prefixes whose changes invalidate EVERY carry (default: tests/). Coverage digests contain
+    only product code - coverlet excludes the test assemblies - so a change that only touches test
+    code is invisible to the per-shard dirty check, yet a new test can create coverage edges the
+    map must learn. Reviewed and confirmed as a permanent silent-miss vector in enforce mode: a
+    heavy shard whose suite gained a test covering src lines mapped to another shard would be
+    re-carried nightly, and a PR touching those lines would skip it forever. When any changed path
+    matches, nothing is carried and the night instruments everything, which re-measures all
+    coverage edges including the new ones.
+
 .PARAMETER CarryForwardDirectory
     Where to write reconstructed digests for the shards being carried forward. A digest is inverted
     straight out of the previous map, so New-ShardMap consumes it exactly like a fresh one and needs
@@ -58,6 +68,7 @@ param(
     [Parameter(Mandatory, ParameterSetName = 'Select')] [AllowEmptyCollection()] [string[]] $ChangedFiles,
     [Parameter(Mandatory, ParameterSetName = 'Select')] [string[]] $AllShards,
     [Parameter(ParameterSetName = 'Select')] [AllowEmptyCollection()] [string[]] $CarryOnly,
+    [Parameter(ParameterSetName = 'Select')] [string[]] $GlobalDirtyPrefixes = @('tests/'),
     [Parameter(ParameterSetName = 'Select')] [string] $CarryForwardDirectory,
     [Parameter(ParameterSetName = 'Select')] [string] $OutFile,
     [Parameter(Mandatory, ParameterSetName = 'SelfTest')] [switch] $SelfTest
@@ -250,6 +261,19 @@ if ($SelfTest) {
     Assert-True ((@($d2.files.'src/Dup.cs') -join ',') -eq '1,2,9,9') `
         'duplicate occurrences must merge ranges, not overwrite'
 
+    # 10. TEST-CODE changes must invalidate every carry. Digests hold only product code, so a
+    #     tests/** change is invisible to the per-shard dirty check - yet a new test can create
+    #     coverage edges the map must learn, and re-carrying would hide them from enforce-mode
+    #     selection permanently. The pure split cannot see this; the caller-level rule must.
+    #     (Exercised via the CLI path in the workflow; here the rule's building blocks:)
+    $r = Split-CoverageWork -Map $map -ChangedFiles @('tests/AiDotNet.Tests/NewTest.cs') -AllShards $all
+    Assert-True ($r.Carried.Count -eq 2) 'the pure split alone does NOT see test files (by design)'
+    $hit = $false
+    foreach ($p in @('tests/')) {
+        if ('tests/AiDotNet.Tests/NewTest.cs'.StartsWith($p, [StringComparison]::OrdinalIgnoreCase)) { $hit = $true }
+    }
+    Assert-True $hit 'the global-dirty prefix rule must catch the same path the split misses'
+
     if ($failures.Count -gt 0) {
         Write-Host 'Select-CoverageShards self-test FAILED:'
         foreach ($f in $failures) { Write-Host "  - $f" }
@@ -278,6 +302,17 @@ if ($PreviousMap -and (Test-Path -LiteralPath $PreviousMap)) {
 $split = Split-CoverageWork -Map $map -ChangedFiles $ChangedFiles -AllShards $AllShards
 
 $carriedFinal = @($split.Carried)
+foreach ($path in $ChangedFiles) {
+    if (-not $path) { continue }
+    foreach ($prefix in $GlobalDirtyPrefixes) {
+        if (([string] $path).StartsWith($prefix, [StringComparison]::OrdinalIgnoreCase)) {
+            Write-Host "change under '$prefix' ($path) - test code is invisible to digests, so nothing is carried tonight"
+            $carriedFinal = @()
+            break
+        }
+    }
+    if ($carriedFinal.Count -eq 0) { break }
+}
 if ($PSBoundParameters.ContainsKey('CarryOnly')) {
     $allow = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::Ordinal)
     foreach ($s in $CarryOnly) { if ($s) { [void] $allow.Add([string] $s) } }

--- a/tools/TestImpact/Select-Shards.ps1
+++ b/tools/TestImpact/Select-Shards.ps1
@@ -11,7 +11,8 @@
     omission ships a regression - those are not symmetric, and the code treats them accordingly.
     Escalation triggers:
 
-      no map / unreadable        nothing to select against
+      no map                     nothing to select against
+      map unreadable / malformed read or parse failed, or a required property is absent
       map commit not present     its line numbers cannot be resolved against this checkout
       changed file not in index  never executed by ANY shard, or new - impact unknown
       shared-infrastructure path build, workflow or global config, whose blast radius is not
@@ -287,14 +288,48 @@ if ($SelfTest) {
 
 # ---------------------------------------------------------------- selection
 
-if (-not (Test-Path -LiteralPath $MapFile)) {
-    Write-Host "::warning::no shard map at $MapFile - running the full matrix"
-    $result = [pscustomobject]@{ escalate = $true; reason = 'map-missing'; reasons = @(); shards = @() }
+function Exit-Escalated {
+    <#
+        Emit the full-matrix result and stop. Every "we cannot be confident" path ends here, and
+        they must all write the SAME artifact: the caller reads selection.json to decide the matrix,
+        so a path that exits without writing it does not escalate - it kills the job, and the test
+        matrix never runs at all.
+    #>
+    param([Parameter(Mandatory)] [string] $Reason, [string] $Message)
+
+    if ($Message) { Write-Host "::warning::$Message" }
+    $result = [pscustomobject]@{ escalate = $true; reason = $Reason; reasons = @(); shards = @() }
     if ($OutFile) { $result | ConvertTo-Json -Depth 5 -Compress | Set-Content -LiteralPath $OutFile -Encoding utf8 }
     exit 0
 }
 
-$map = Get-Content -LiteralPath $MapFile -Raw | ConvertFrom-Json
+if (-not (Test-Path -LiteralPath $MapFile)) {
+    Exit-Escalated -Reason 'map-missing' -Message "no shard map at $MapFile - running the full matrix"
+}
+
+# Read and shape-check together, because both failures mean the same thing: the map cannot be
+# trusted to say which shards cover a line.
+#
+# The try/catch is load-bearing, not defensive habit. $ErrorActionPreference is Stop, so a truncated
+# or malformed map made ConvertFrom-Json THROW - and a throw exits before any result is written, so
+# the caller sees no selection.json, the job fails, and the matrix never runs. The header has always
+# listed "no map / unreadable" as an escalation trigger; only the missing half was implemented.
+$map = $null
+try {
+    $map = Get-Content -LiteralPath $MapFile -Raw | ConvertFrom-Json
+
+    # A map missing any of these is not a map. Checked explicitly because the failure is otherwise
+    # silent and much later: a null .files makes every changed file look unmapped, which escalates
+    # for a misleading reason, and a null .knownShards indexes as empty so every selected shard
+    # resolves to a blank name.
+    foreach ($required in 'sha', 'knownShards', 'alwaysRun', 'files') {
+        if (-not $map.PSObject.Properties[$required]) { throw "no '$required' property" }
+    }
+}
+catch {
+    Exit-Escalated -Reason 'map-unreadable' `
+        -Message "the shard map at $MapFile could not be read - running the full matrix ($($_.Exception.Message))"
+}
 
 # The map's own commit is the reference, NOT the merge base. An earlier revision required
 # map.sha -eq mergeBase, which reads like prudence and is in fact a switch that pins the feature
@@ -307,10 +342,8 @@ $map = Get-Content -LiteralPath $MapFile -Raw | ConvertFrom-Json
 $mapSha = [string] $map.sha
 & git cat-file -e "$mapSha^{commit}" 2>$null
 if ($LASTEXITCODE -ne 0) {
-    Write-Host "::warning::the map's commit $mapSha is not present in this checkout - running the full matrix"
-    $result = [pscustomobject]@{ escalate = $true; reason = 'map-unresolvable'; reasons = @(); shards = @() }
-    if ($OutFile) { $result | ConvertTo-Json -Depth 5 -Compress | Set-Content -LiteralPath $OutFile -Encoding utf8 }
-    exit 0
+    Exit-Escalated -Reason 'map-unresolvable' `
+        -Message "the map's commit $mapSha is not present in this checkout - running the full matrix"
 }
 
 $changed = Get-ChangedRanges -MapSha $mapSha

--- a/tools/TestImpact/Select-Shards.ps1
+++ b/tools/TestImpact/Select-Shards.ps1
@@ -74,9 +74,25 @@ function ConvertTo-ChangedRanges {
 
     $changed = @{}
     $current = $null
+    $deletedPath = $null
     foreach ($line in $DiffLines) {
-        if ($line.StartsWith('+++ b/')) {
-            $current = $line.Substring(6).Trim()
+        if ($line.StartsWith('--- ')) {
+            # Both header lines are tracked, and $current is RESET here.
+            #
+            # A deletion is `--- a/<path>` followed by `+++ /dev/null`, so matching only `+++ b/`
+            # left $current pointing at the PREVIOUS file: the deleted file's hunk was appended to
+            # that file's ranges, and the deleted path was never reported at all. Shards executing
+            # it were therefore not selected AND the unmapped-file escalation never fired - a
+            # silent miss. Measured on a real two-file diff, an edit at line 100 of A plus a
+            # deletion of B produced `src/A.cs -> 100,100,1,200` and no B.
+            $from = $line.Substring(4).Trim()
+            $deletedPath = if ($from -eq '/dev/null') { $null } else { $from -replace '^a/', '' }
+            $current = $null
+        }
+        elseif ($line.StartsWith('+++ ')) {
+            $to = $line.Substring(4).Trim()
+            # `+++ /dev/null` means the file was deleted; attribute its hunks to the path it had.
+            $current = if ($to -eq '/dev/null') { $deletedPath } else { $to -replace '^b/', '' }
         }
         elseif ($current -and $line.StartsWith('@@')) {
             # @@ -old,n +new,m @@ ; n omitted means 1, n = 0 means a pure insertion.
@@ -358,6 +374,28 @@ if ($SelfTest) {
     Assert-True (-not $r.Escalate) 'an empty delta must not escalate'
     Assert-True ($r.Shards.Count -eq 1 -and $r.Shards -contains 'HeavyNoCoverage') `
         'an empty delta selects only the always-run shards'
+
+    # 12. DELETIONS. git writes `--- a/<path>` then `+++ /dev/null`, so a parser keyed only on
+    #     `+++ b/` leaves the previous file current: the deletion's hunk lands on THAT file and the
+    #     deleted path is never reported, so shards executing it are not selected and the
+    #     unmapped-file escalation never fires. Both halves are checked.
+    $diff = @(
+        '--- a/src/Covered.cs',
+        '+++ b/src/Covered.cs',
+        '@@ -100 +100 @@',
+        '--- a/src/Deleted.cs',
+        '+++ /dev/null',
+        '@@ -1,200 +0,0 @@'
+    )
+    $r = ConvertTo-ChangedRanges -DiffLines $diff
+    Assert-True ($r.ContainsKey('src/Deleted.cs')) 'a deleted file must be reported under its own path'
+    Assert-True (@($r['src/Covered.cs']).Count -eq 2) 'a deletion must not append its ranges to the previous file'
+
+    # 13. Additions are the mirror: `--- /dev/null` then `+++ b/<path>`.
+    $diff = @('--- /dev/null', '+++ b/src/Added.cs', '@@ -0,0 +1,50 @@')
+    $r = ConvertTo-ChangedRanges -DiffLines $diff
+    Assert-True ($r.ContainsKey('src/Added.cs')) 'an added file must be reported under its new path'
+    Assert-True (-not $r.ContainsKey('/dev/null')) '/dev/null must never appear as a path'
 
     if ($failures.Count -gt 0) {
         Write-Host 'Select-Shards self-test FAILED:'

--- a/tools/TestImpact/Select-Shards.ps1
+++ b/tools/TestImpact/Select-Shards.ps1
@@ -466,6 +466,12 @@ if ($LASTEXITCODE -ne 0) {
         -Message "the map's commit $mapSha is not present in this checkout - running the full matrix"
 }
 
+# Everything from here is wrapped, because the whole design rests on "when unsure, run everything"
+# and an uncaught throw does the opposite: $ErrorActionPreference is Stop, so the script would die
+# before writing selection.json, the caller would find no result, the job would fail, and the matrix
+# would never run. That is worse than any wrong selection, so every failure below escalates instead.
+try {
+
 if ($FileLevelFrom) {
     # Master-push mode: validate only what differs from the tree a PR run already tested.
     & git cat-file -e "$FileLevelFrom^{commit}" 2>$null
@@ -502,3 +508,9 @@ $result = [pscustomobject]@{
     shards   = $selection.Shards
 }
 if ($OutFile) { $result | ConvertTo-Json -Depth 5 -Compress | Set-Content -LiteralPath $OutFile -Encoding utf8 }
+
+}
+catch {
+    Exit-Escalated -Reason 'selection-failed' `
+        -Message "shard selection failed, so the full matrix will run: $($_.Exception.Message)"
+}

--- a/tools/TestImpact/Select-Shards.ps1
+++ b/tools/TestImpact/Select-Shards.ps1
@@ -33,6 +33,7 @@
 param(
     [Parameter(Mandatory, ParameterSetName = 'Select')] [string] $MapFile,
     [Parameter(ParameterSetName = 'Select')] [string] $OutFile,
+    [Parameter(ParameterSetName = 'Select')] [string] $FileLevelFrom,
     [Parameter(Mandatory, ParameterSetName = 'SelfTest')] [switch] $SelfTest
 )
 
@@ -131,6 +132,58 @@ function Get-ChangedRanges {
     $diff = & git diff -U0 $MapSha HEAD
     if ($LASTEXITCODE -ne 0) { throw "git diff from the map commit '$MapSha' failed." }
     return ConvertTo-ChangedRanges -DiffLines $diff
+}
+
+function Select-ImpactedShardsByFile {
+    <#
+        FILE-level selection between two arbitrary trees, for the master-push case.
+
+        Master pushes a merge commit whose tree nothing tested, but a PR run DID test a real tree;
+        the only unverified part of master is diff(testedTree, master). A shard whose coverage
+        touches none of those files behaves identically on both trees, so its result from that run
+        still holds and it does not need running again.
+
+        File-level, not line-level, and that is forced rather than lazy. The map's ranges are in
+        the coordinates of the map's commit, while this diff is between two entirely different
+        commits, so line numbers from it cannot be looked up in the map at all - the same
+        coordinate mismatch that silently dropped covering shards before. File containment needs no
+        coordinates, so it stays correct across any pair of trees. It over-selects, which is the
+        safe direction.
+    #>
+    param(
+        [Parameter(Mandatory)] $Map,
+        [Parameter(Mandatory)] [AllowEmptyCollection()] [string[]] $ChangedFiles
+    )
+
+    $selected = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::Ordinal)
+    foreach ($shard in $Map.alwaysRun) { [void] $selected.Add([string] $shard) }
+
+    $reasons = [System.Collections.Generic.List[string]]::new()
+    $escalate = $false
+
+    foreach ($path in ($ChangedFiles | Sort-Object -Unique)) {
+        if (-not $path) { continue }
+        if (Test-SharedInfrastructure -Path $path) {
+            $escalate = $true
+            [void] $reasons.Add("shared infrastructure: $path")
+            continue
+        }
+        $entry = $Map.files.PSObject.Properties[$path]
+        if (-not $entry) {
+            $escalate = $true
+            [void] $reasons.Add("not executed by any mapped shard: $path")
+            continue
+        }
+        foreach ($occurrence in @($entry.Value)) {
+            [void] $selected.Add([string] $Map.knownShards[[int] $occurrence.s])
+        }
+    }
+
+    return [pscustomobject]@{
+        Escalate = $escalate
+        Reasons  = $reasons
+        Shards   = @($selected | Sort-Object)
+    }
 }
 
 function Select-ImpactedShards {
@@ -277,6 +330,35 @@ if ($SelfTest) {
     $r = Select-ImpactedShards -Map $map -Changed (ConvertTo-ChangedRanges -DiffLines $diff)
     Assert-True ($r.Shards -contains 'Alpha') 'a one-line insertion above an edit must not lose the covering shard'
 
+    # 8. FILE-level selection, used when master validates only its delta from a tested tree.
+    #    It must select every shard touching a changed file regardless of WHERE in the file, since
+    #    the two trees share no line numbering.
+    $r = Select-ImpactedShardsByFile -Map $map -ChangedFiles @('src/Covered.cs')
+    Assert-True ($r.Shards -contains 'Alpha' -and $r.Shards -contains 'Beta') `
+        'file-level selection must select every shard executing that file'
+    Assert-True (-not $r.Escalate) 'a mapped file must not escalate'
+
+    # 9. And it must still refuse: an untouched file selects nothing beyond always-run. Without
+    #    this a selector returning everything would satisfy 8.
+    $r = Select-ImpactedShardsByFile -Map $map -ChangedFiles @('src/SingleRange.cs')
+    Assert-True ($r.Shards -contains 'Alpha') 'the shard executing the changed file is selected'
+    Assert-True (-not ($r.Shards -contains 'Beta')) 'a shard not executing the changed file is not selected'
+    Assert-True ($r.Shards -contains 'HeavyNoCoverage') 'always-run shards still appear'
+
+    # 10. Same fail-safes as line-level selection.
+    $r = Select-ImpactedShardsByFile -Map $map -ChangedFiles @('src/Unmapped.cs')
+    Assert-True $r.Escalate 'an unmapped file must escalate'
+    $r = Select-ImpactedShardsByFile -Map $map -ChangedFiles @('Directory.Packages.props')
+    Assert-True $r.Escalate 'shared infrastructure must escalate'
+
+    # 11. No changed files at all - the delta is empty, so only always-run shards remain. This is
+    #     the case worth the most: master merged a tree whose difference from the tested one
+    #     touches nothing, and the entire matrix collapses.
+    $r = Select-ImpactedShardsByFile -Map $map -ChangedFiles @()
+    Assert-True (-not $r.Escalate) 'an empty delta must not escalate'
+    Assert-True ($r.Shards.Count -eq 1 -and $r.Shards -contains 'HeavyNoCoverage') `
+        'an empty delta selects only the always-run shards'
+
     if ($failures.Count -gt 0) {
         Write-Host 'Select-Shards self-test FAILED:'
         foreach ($f in $failures) { Write-Host "  - $f" }
@@ -346,10 +428,23 @@ if ($LASTEXITCODE -ne 0) {
         -Message "the map's commit $mapSha is not present in this checkout - running the full matrix"
 }
 
-$changed = Get-ChangedRanges -MapSha $mapSha
-Write-Host "changed files: $($changed.Count)"
-
-$selection = Select-ImpactedShards -Map $map -Changed $changed
+if ($FileLevelFrom) {
+    # Master-push mode: validate only what differs from the tree a PR run already tested.
+    & git cat-file -e "$FileLevelFrom^{commit}" 2>$null
+    if ($LASTEXITCODE -ne 0) {
+        Exit-Escalated -Reason 'tested-sha-unresolvable' `
+            -Message "the tested commit $FileLevelFrom is not present in this checkout - running the full matrix"
+    }
+    $files = @(& git diff --name-only $FileLevelFrom HEAD)
+    if ($LASTEXITCODE -ne 0) { Exit-Escalated -Reason 'diff-failed' -Message "git diff from $FileLevelFrom failed" }
+    Write-Host "delta from $FileLevelFrom : $($files.Count) changed file(s)"
+    $selection = Select-ImpactedShardsByFile -Map $map -ChangedFiles $files
+}
+else {
+    $changed = Get-ChangedRanges -MapSha $mapSha
+    Write-Host "changed files: $($changed.Count)"
+    $selection = Select-ImpactedShards -Map $map -Changed $changed
+}
 if ($selection.Escalate) {
     Write-Host '::warning::selection escalated to the full matrix'
     foreach ($reason in $selection.Reasons) { Write-Host "  reason: $reason" }

--- a/tools/TestImpact/Select-Shards.ps1
+++ b/tools/TestImpact/Select-Shards.ps1
@@ -1,47 +1,32 @@
 <#
 .SYNOPSIS
-    Chooses which CI shards a change needs, from the coverage-derived shard map.
+    Chooses which CI shards a pull request needs, from the coverage-derived shard map.
 
 .DESCRIPTION
-    Intersects the PR's changed line ranges against the map's file -> shard index. A shard is
-    selected when it executed at least one line the PR touched.
-
-    FAIL SAFE IS THE POINT. Selection only ever saves time when it is confident; every uncertainty
-    escalates to the full matrix and says why. A wrong escalation costs runner minutes, a wrong
-    omission ships a regression - those are not symmetric, and the code treats them accordingly.
-    Escalation triggers:
-
-      no map                     nothing to select against
-      map unreadable / malformed read or parse failed, or a required property is absent
-      map commit not present     its line numbers cannot be resolved against this checkout
-      changed file not in index  never executed by ANY shard, or new - impact unknown
-      shared-infrastructure path build, workflow or global config, whose blast radius is not
-                                 expressible as executed lines
-
-    Line-level, not file-level, deliberately: on Integration H-L, 29,528 executed lines sit inside
-    files also containing 169,732 unexecuted ones, so 85% of a file's lines belong to no shard by
-    way of that file. LayerHelper.cs alone spans 25,980 lines with 703 executed and a 21,328-line
-    gap. Selecting on the file would pull in shards that never run the changed code.
+    Intersects changed line ranges against the map's file -> shard index. Selection is deliberately
+    fail-safe: every changed file and every changed hunk must be accounted for, or the caller is told
+    to run the full matrix.
 
 .PARAMETER MapFile
     shard-map.json from New-ShardMap.ps1.
 
+.PARAMETER ExpectedShards
+    The complete current shard manifest. A map for a different shard universe is never trusted.
+
 .PARAMETER SelfTest
-    Runs the built-in checks and exits. Proves selection both fires and refuses to fire.
+    Runs the built-in adversarial checks and exits.
 #>
 [CmdletBinding(DefaultParameterSetName = 'Select')]
 param(
     [Parameter(Mandatory, ParameterSetName = 'Select')] [string] $MapFile,
+    [Parameter(Mandatory, ParameterSetName = 'Select')] [string[]] $ExpectedShards,
     [Parameter(ParameterSetName = 'Select')] [string] $OutFile,
-    [Parameter(ParameterSetName = 'Select')] [string] $FileLevelFrom,
     [Parameter(Mandatory, ParameterSetName = 'SelfTest')] [switch] $SelfTest
 )
 
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
-# Paths whose effect is not expressible as executed source lines. A build property or workflow edit
-# can change what every shard compiles or how it runs, so no coverage evidence can bound it.
 $script:SharedInfrastructure = @(
     '.github/',
     'Directory.Build.props', 'Directory.Build.targets', 'Directory.Packages.props',
@@ -63,143 +48,160 @@ function Test-RangeOverlap {
     return -not ($AEnd -lt $BStart -or $BEnd -lt $AStart)
 }
 
+function ConvertTo-ValidatedInteger {
+    param(
+        [Parameter(Mandatory)] $Value,
+        [Parameter(Mandatory)] [string] $What,
+        [int] $Minimum = 0,
+        [int] $Maximum = [int]::MaxValue
+    )
+
+    $isInteger = $Value -is [byte] -or $Value -is [sbyte] -or
+        $Value -is [int16] -or $Value -is [uint16] -or
+        $Value -is [int32] -or $Value -is [uint32] -or
+        $Value -is [int64] -or $Value -is [uint64]
+    if (-not $isInteger) { throw "$What must be an integer." }
+
+    $number = [long] $Value
+    if ($number -lt $Minimum -or $number -gt $Maximum) {
+        throw "$What must be between $Minimum and $Maximum."
+    }
+    return [int] $number
+}
+
+function Assert-ShardMap {
+    param(
+        [Parameter(Mandatory)] $Map,
+        [Parameter(Mandatory)] [string[]] $Expected
+    )
+
+    foreach ($required in 'schemaVersion', 'sha', 'knownShards', 'alwaysRun', 'files') {
+        if (-not $Map.PSObject.Properties[$required]) { throw "no '$required' property" }
+    }
+    $schemaVersion = ConvertTo-ValidatedInteger -Value $Map.schemaVersion -What 'schemaVersion' -Minimum 1
+    if ($schemaVersion -ne 1) { throw "unsupported schemaVersion $schemaVersion" }
+    if ([string] $Map.sha -notmatch '^(?:[0-9a-fA-F]{40}|[0-9a-fA-F]{64})$') {
+        throw 'sha must be a complete hexadecimal Git object id'
+    }
+    if ($Map.knownShards -isnot [array] -or $Map.alwaysRun -isnot [array]) {
+        throw 'knownShards and alwaysRun must be arrays'
+    }
+    if ($Map.files -isnot [pscustomobject]) { throw 'files must be an object' }
+
+    $expectedSet = [System.Collections.Generic.HashSet[string]]::new([StringComparer]::Ordinal)
+    foreach ($name in @($Expected)) {
+        if ([string]::IsNullOrWhiteSpace([string] $name)) { throw 'expected shard names must be nonempty' }
+        if (-not $expectedSet.Add([string] $name)) { throw "duplicate expected shard '$name'" }
+    }
+    if ($expectedSet.Count -eq 0) { throw 'the expected shard manifest is empty' }
+
+    $known = @($Map.knownShards)
+    $always = @($Map.alwaysRun)
+    if ($known.Count -eq 0) { throw 'knownShards is empty' }
+
+    $mapSet = [System.Collections.Generic.HashSet[string]]::new([StringComparer]::Ordinal)
+    foreach ($group in @(@{ Name = 'knownShards'; Values = $known }, @{ Name = 'alwaysRun'; Values = $always })) {
+        foreach ($nameValue in $group.Values) {
+            $name = [string] $nameValue
+            if ([string]::IsNullOrWhiteSpace($name)) { throw "$($group.Name) contains an empty shard name" }
+            if (-not $mapSet.Add($name)) { throw "duplicate or overlapping shard '$name'" }
+        }
+    }
+
+    $missing = @($expectedSet | Where-Object { -not $mapSet.Contains($_) } | Sort-Object)
+    $extra = @($mapSet | Where-Object { -not $expectedSet.Contains($_) } | Sort-Object)
+    if ($missing.Count -gt 0 -or $extra.Count -gt 0) {
+        throw "map shard universe differs from the manifest (missing: $($missing -join ', '); extra: $($extra -join ', '))"
+    }
+
+    $fileProperties = @($Map.files.PSObject.Properties)
+    if ($fileProperties.Count -eq 0) { throw 'files index is empty' }
+    if ($Map.PSObject.Properties['fileCount']) {
+        $fileCount = ConvertTo-ValidatedInteger -Value $Map.fileCount -What 'fileCount'
+        if ($fileCount -ne $fileProperties.Count) { throw 'fileCount does not match the files index' }
+    }
+    foreach ($fileProperty in $fileProperties) {
+        if ([string]::IsNullOrWhiteSpace([string] $fileProperty.Name)) { throw 'files contains an empty path' }
+        if ($fileProperty.Value -isnot [array]) { throw "'$($fileProperty.Name)' occurrences must be an array" }
+        $occurrences = @($fileProperty.Value)
+        if ($occurrences.Count -eq 0) { throw "'$($fileProperty.Name)' has no occurrences" }
+        foreach ($occurrence in $occurrences) {
+            if (-not $occurrence.PSObject.Properties['s'] -or -not $occurrence.PSObject.Properties['r']) {
+                throw "'$($fileProperty.Name)' has an occurrence without s or r"
+            }
+            [void] (ConvertTo-ValidatedInteger -Value $occurrence.s -What "'$($fileProperty.Name)' shard index" `
+                -Minimum 0 -Maximum ($known.Count - 1))
+            if ($occurrence.r -isnot [array]) { throw "'$($fileProperty.Name)' ranges must be an array" }
+            $ranges = @($occurrence.r)
+            if ($ranges.Count -eq 0 -or $ranges.Count % 2 -ne 0) {
+                throw "'$($fileProperty.Name)' ranges must be nonempty start/end pairs"
+            }
+            for ($i = 0; $i -lt $ranges.Count; $i += 2) {
+                $start = ConvertTo-ValidatedInteger -Value $ranges[$i] -What "'$($fileProperty.Name)' range start" -Minimum 1
+                $end = ConvertTo-ValidatedInteger -Value $ranges[$i + 1] -What "'$($fileProperty.Name)' range end" -Minimum 1
+                if ($start -gt $end) { throw "'$($fileProperty.Name)' range start $start exceeds end $end" }
+            }
+        }
+    }
+}
+
 function ConvertTo-ChangedRanges {
     <#
-        Changed line ranges per file, from unified-diff hunk headers with zero context.
-
-        Pure so it can be self-tested: the coordinate choice below is the single most dangerous
-        decision in the selector and a git fixture would hide it behind plumbing.
+        Parses zero-context hunks in the map commit's coordinates. ChangedFiles is authoritative:
+        rename-only, binary and mode-only changes do not necessarily have an @@ header, but they
+        must still reach the fail-safe selector.
     #>
-    param([string[]] $DiffLines)
+    param(
+        [AllowEmptyCollection()] [string[]] $DiffLines,
+        [AllowEmptyCollection()] [string[]] $ChangedFiles = @()
+    )
 
     $changed = @{}
     $current = $null
     $deletedPath = $null
     foreach ($line in $DiffLines) {
         if ($line.StartsWith('--- ')) {
-            # Both header lines are tracked, and $current is RESET here.
-            #
-            # A deletion is `--- a/<path>` followed by `+++ /dev/null`, so matching only `+++ b/`
-            # left $current pointing at the PREVIOUS file: the deleted file's hunk was appended to
-            # that file's ranges, and the deleted path was never reported at all. Shards executing
-            # it were therefore not selected AND the unmapped-file escalation never fired - a
-            # silent miss. Measured on a real two-file diff, an edit at line 100 of A plus a
-            # deletion of B produced `src/A.cs -> 100,100,1,200` and no B.
             $from = $line.Substring(4).Trim()
             $deletedPath = if ($from -eq '/dev/null') { $null } else { $from -replace '^a/', '' }
             $current = $null
         }
         elseif ($line.StartsWith('+++ ')) {
             $to = $line.Substring(4).Trim()
-            # `+++ /dev/null` means the file was deleted; attribute its hunks to the path it had.
             $current = if ($to -eq '/dev/null') { $deletedPath } else { $to -replace '^b/', '' }
         }
-        elseif ($current -and $line.StartsWith('@@')) {
-            # @@ -old,n +new,m @@ ; n omitted means 1, n = 0 means a pure insertion.
-            #
-            # The OLD side, deliberately. The map's ranges are in the coordinates of the commit it
-            # was built at, and the caller diffs from exactly that commit, so the '-old' numbers are
-            # already in the map's coordinate system. Reading '+new' instead looks correct and
-            # silently misses: insert fifty lines above an edit and the edited line is looked up
-            # fifty lines below where the map recorded it, so the shard covering it is not selected.
-            if ($line -match '-(\d+)(?:,(\d+))?') {
-                $start = [int] $Matches[1]
-                $count = if ($Matches[2]) { [int] $Matches[2] } else { 1 }
-                if (-not $changed.ContainsKey($current)) {
-                    $changed[$current] = [System.Collections.Generic.List[int]]::new()
-                }
-                if ($count -gt 0) {
-                    # Parenthesised deliberately: inside @(...) the comma binds tighter than +,
-                    # so @($start, $start + $count - 1) parses as ($start, $start) + $count - 1,
-                    # i.e. array concatenation followed by subtraction from an array.
-                    [void] $changed[$current].Add($start)
-                    [void] $changed[$current].Add($start + $count - 1)
-                }
-                else {
-                    # A pure insertion occupies no line on this side, but it changed the meaning of
-                    # the code around it. Treat the lines either side of the insertion point as
-                    # touched rather than invisible.
-                    [void] $changed[$current].Add([Math]::Max(1, $start))
-                    [void] $changed[$current].Add([Math]::Max(1, $start + 1))
-                }
+        elseif ($current -and $line.StartsWith('@@') -and $line -match '-(\d+)(?:,(\d+))?') {
+            $start = [int] $Matches[1]
+            $count = if ($Matches[2]) { [int] $Matches[2] } else { 1 }
+            if (-not $changed.ContainsKey($current)) {
+                $changed[$current] = [System.Collections.Generic.List[int]]::new()
             }
+            if ($count -gt 0) {
+                [void] $changed[$current].Add($start)
+                [void] $changed[$current].Add($start + $count - 1)
+            }
+            else {
+                [void] $changed[$current].Add([Math]::Max(1, $start))
+                [void] $changed[$current].Add([Math]::Max(1, $start + 1))
+            }
+        }
+    }
+
+    foreach ($path in $ChangedFiles) {
+        if (-not [string]::IsNullOrWhiteSpace($path) -and -not $changed.ContainsKey($path)) {
+            $changed[$path] = [System.Collections.Generic.List[int]]::new()
         }
     }
     return $changed
 }
 
 function Get-ChangedRanges {
-    <#
-        Diffs from the commit the MAP was built at, two-dot, so the '-old' side of every hunk is
-        already in the map's coordinate system.
-
-        Two-dot, not three-dot, and this is the whole design. Three-dot would diff from
-        merge-base(map, HEAD), whose line numbers belong to neither the map nor the PR, which is the
-        coordinate bug this function exists to avoid. Two-dot also drops the requirement that the
-        map commit be an ancestor of HEAD - it is not, for any PR branched before last night's map -
-        so no ancestry check is needed or wanted.
-
-        The cost is over-selection: master commits between the PR's base and the map appear as
-        changes too. That is one night of churn, it is the safe direction, and it is churn the PR
-        merges with anyway.
-    #>
     param([string] $MapSha)
 
-    $diff = & git diff -U0 $MapSha HEAD
-    if ($LASTEXITCODE -ne 0) { throw "git diff from the map commit '$MapSha' failed." }
-    return ConvertTo-ChangedRanges -DiffLines $diff
-}
-
-function Select-ImpactedShardsByFile {
-    <#
-        FILE-level selection between two arbitrary trees, for the master-push case.
-
-        Master pushes a merge commit whose tree nothing tested, but a PR run DID test a real tree;
-        the only unverified part of master is diff(testedTree, master). A shard whose coverage
-        touches none of those files behaves identically on both trees, so its result from that run
-        still holds and it does not need running again.
-
-        File-level, not line-level, and that is forced rather than lazy. The map's ranges are in
-        the coordinates of the map's commit, while this diff is between two entirely different
-        commits, so line numbers from it cannot be looked up in the map at all - the same
-        coordinate mismatch that silently dropped covering shards before. File containment needs no
-        coordinates, so it stays correct across any pair of trees. It over-selects, which is the
-        safe direction.
-    #>
-    param(
-        [Parameter(Mandatory)] $Map,
-        [Parameter(Mandatory)] [AllowEmptyCollection()] [string[]] $ChangedFiles
-    )
-
-    $selected = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::Ordinal)
-    foreach ($shard in $Map.alwaysRun) { [void] $selected.Add([string] $shard) }
-
-    $reasons = [System.Collections.Generic.List[string]]::new()
-    $escalate = $false
-
-    foreach ($path in ($ChangedFiles | Sort-Object -Unique)) {
-        if (-not $path) { continue }
-        if (Test-SharedInfrastructure -Path $path) {
-            $escalate = $true
-            [void] $reasons.Add("shared infrastructure: $path")
-            continue
-        }
-        $entry = $Map.files.PSObject.Properties[$path]
-        if (-not $entry) {
-            $escalate = $true
-            [void] $reasons.Add("not executed by any mapped shard: $path")
-            continue
-        }
-        foreach ($occurrence in @($entry.Value)) {
-            [void] $selected.Add([string] $Map.knownShards[[int] $occurrence.s])
-        }
-    }
-
-    return [pscustomobject]@{
-        Escalate = $escalate
-        Reasons  = $reasons
-        Shards   = @($selected | Sort-Object)
-    }
+    $changedFiles = @(& git -c core.quotepath=false diff --name-only $MapSha HEAD --)
+    if ($LASTEXITCODE -ne 0) { throw "git diff --name-only from '$MapSha' failed" }
+    $diff = @(& git -c core.quotepath=false diff --no-ext-diff -U0 $MapSha HEAD --)
+    if ($LASTEXITCODE -ne 0) { throw "git diff from '$MapSha' failed" }
+    return ConvertTo-ChangedRanges -DiffLines $diff -ChangedFiles $changedFiles
 }
 
 function Select-ImpactedShards {
@@ -208,9 +210,8 @@ function Select-ImpactedShards {
         [Parameter(Mandatory)] [hashtable] $Changed
     )
 
-    $selected = [System.Collections.Generic.HashSet[string]]::new()
-    foreach ($shard in $Map.alwaysRun) { [void] $selected.Add([string] $shard) }
-
+    $selected = [System.Collections.Generic.HashSet[string]]::new([StringComparer]::Ordinal)
+    foreach ($shard in @($Map.alwaysRun)) { [void] $selected.Add([string] $shard) }
     $reasons = [System.Collections.Generic.List[string]]::new()
     $escalate = $false
 
@@ -228,26 +229,44 @@ function Select-ImpactedShards {
             continue
         }
 
+        $hunks = @($Changed[$path])
+        if ($hunks.Count -eq 0 -or $hunks.Count % 2 -ne 0) {
+            $escalate = $true
+            [void] $reasons.Add("changed file has no trustworthy line hunks: $path")
+            continue
+        }
+
+        $covered = [bool[]]::new([int] ($hunks.Count / 2))
         foreach ($occurrence in @($entry.Value)) {
-            $shardName = [string] $Map.knownShards[[int] $occurrence.s]
-            if ($selected.Contains($shardName)) { continue }
-            # Both sides are FLAT [start, end, start, end, ...]. Nested arrays are a trap: a file
-            # with exactly one executed range comes back from ConvertFrom-Json as two loose
-            # integers, and @() on a one-element collection flattens the same way, so every index
-            # silently shifts. Flat pairs cannot be unrolled into something that still indexes.
             $ranges = @($occurrence.r)
-            $hunks = @($Changed[$path])
-            $hit = $false
-            for ($i = 0; $i + 1 -lt $ranges.Count -and -not $hit; $i += 2) {
-                for ($j = 0; $j + 1 -lt $hunks.Count; $j += 2) {
-                    if (Test-RangeOverlap -AStart ([int] $hunks[$j]) -AEnd ([int] $hunks[$j + 1]) `
+            $shardName = [string] $Map.knownShards[[int] $occurrence.s]
+            for ($h = 0; $h + 1 -lt $hunks.Count; $h += 2) {
+                $hit = $false
+                for ($i = 0; $i + 1 -lt $ranges.Count; $i += 2) {
+                    if (Test-RangeOverlap -AStart ([int] $hunks[$h]) -AEnd ([int] $hunks[$h + 1]) `
                                           -BStart ([int] $ranges[$i]) -BEnd ([int] $ranges[$i + 1])) {
-                        $hit = $true; break
+                        $hit = $true
+                        break
                     }
                 }
+                if ($hit) {
+                    $covered[[int] ($h / 2)] = $true
+                    [void] $selected.Add($shardName)
+                }
             }
-            if ($hit) { [void] $selected.Add($shardName) }
         }
+
+        for ($h = 0; $h + 1 -lt $hunks.Count; $h += 2) {
+            if (-not $covered[[int] ($h / 2)]) {
+                $escalate = $true
+                [void] $reasons.Add("changed range $($hunks[$h])-$($hunks[$h + 1]) is not executed by any mapped shard: $path")
+            }
+        }
+    }
+
+    if ($selected.Count -eq 0) {
+        $escalate = $true
+        [void] $reasons.Add('selection was empty')
     }
 
     return [pscustomobject]@{
@@ -261,13 +280,20 @@ function Select-ImpactedShards {
 
 if ($SelfTest) {
     $failures = [System.Collections.Generic.List[string]]::new()
-    function Assert-True { param([bool] $Condition, [string] $What)
-        if (-not $Condition) { [void] $failures.Add($What) } }
+    function Assert-True {
+        param([bool] $Condition, [string] $What)
+        if (-not $Condition) { [void] $failures.Add($What) }
+    }
+    function Assert-Throws {
+        param([scriptblock] $Action, [string] $What)
+        $threw = $false
+        try { & $Action } catch { $threw = $true }
+        Assert-True $threw $What
+    }
 
-    # Round-tripped through JSON: an in-memory map hides ConvertFrom-Json's single-element
-    # unrolling, which is exactly what broke the real path while this self-test passed.
     $map = @{
         schemaVersion = 1
+        sha           = '0123456789abcdef0123456789abcdef01234567'
         knownShards   = @('Alpha', 'Beta')
         alwaysRun     = @('HeavyNoCoverage')
         files         = @{
@@ -278,128 +304,97 @@ if ($SelfTest) {
             'src/SingleRange.cs' = @( @{ s = 0; r = @(5, 6) } )
         }
     } | ConvertTo-Json -Depth 8 -Compress | ConvertFrom-Json
+    $expected = @('Alpha', 'Beta', 'HeavyNoCoverage')
+    try { Assert-ShardMap -Map $map -Expected $expected } catch { [void] $failures.Add("valid map rejected: $_") }
 
-    # 1. A change on a line a shard executed selects that shard - the gate must FIRE.
     $r = Select-ImpactedShards -Map $map -Changed @{ 'src/Covered.cs' = @(12, 14) }
-    Assert-True (-not $r.Escalate) 'a mapped, covered change must not escalate'
-    Assert-True ($r.Shards -contains 'Alpha') 'a change on Alpha''s executed lines must select Alpha'
-    Assert-True (-not ($r.Shards -contains 'Beta')) 'a change outside Beta''s lines must NOT select Beta'
+    Assert-True (-not $r.Escalate) 'a mapped, fully covered change must not escalate'
+    Assert-True ($r.Shards -contains 'Alpha') 'a change on Alpha lines must select Alpha'
+    Assert-True (-not ($r.Shards -contains 'Beta')) 'a change outside Beta lines must not select Beta'
+    Assert-True ($r.Shards -contains 'HeavyNoCoverage') 'always-run shards must always be selected'
 
+    $r = Select-ImpactedShards -Map $map -Changed @{ 'src/Covered.cs' = @(12, 14, 50, 60) }
+    Assert-True $r.Escalate 'mixed covered and uncovered hunks must escalate'
+    Assert-True ($r.Shards -contains 'Alpha') 'covered hunks are still reported before escalation'
 
-    # 2. A change in a GAP selects neither - the gate must REFUSE to fire. Without this check a
-    #    selector that returned every shard for every input would satisfy check 1 and be useless.
-    $r = Select-ImpactedShards -Map $map -Changed @{ 'src/Covered.cs' = @(50, 60) }
-    Assert-True (-not ($r.Shards -contains 'Alpha')) 'a change in an unexecuted gap must not select Alpha'
-    Assert-True (-not ($r.Shards -contains 'Beta')) 'a change in an unexecuted gap must not select Beta'
+    foreach ($change in @(
+        @{ Path = 'src/Unmapped.cs'; Why = 'an unmapped file must escalate' },
+        @{ Path = 'Directory.Packages.props'; Why = 'dependency infrastructure must escalate' },
+        @{ Path = '.github/workflows/ci.yml'; Why = 'workflow infrastructure must escalate' }
+    )) {
+        $r = Select-ImpactedShards -Map $map -Changed @{ $change.Path = @(1, 2) }
+        Assert-True $r.Escalate $change.Why
+    }
 
-    # 3. Always-run shards appear regardless, including when nothing else is selected.
-    Assert-True ($r.Shards -contains 'HeavyNoCoverage') 'shards without coverage must always be selected'
-
-    # 4. Fail safe: an unmapped file, and shared infrastructure, both escalate.
-    $r = Select-ImpactedShards -Map $map -Changed @{ 'src/Unmapped.cs' = @(1, 5) }
-    Assert-True $r.Escalate 'an unmapped file must escalate to the full matrix'
-    $r = Select-ImpactedShards -Map $map -Changed @{ 'Directory.Packages.props' = @(1, 2) }
-    Assert-True $r.Escalate 'a dependency-property change must escalate'
-    $r = Select-ImpactedShards -Map $map -Changed @{ '.github/workflows/ci.yml' = @(1, 2) }
-    Assert-True $r.Escalate 'a workflow change must escalate'
-
-    # 5. Boundaries. The first and last executed line count as hits; the lines either side do not.
     foreach ($edge in @(10, 20)) {
         $r = Select-ImpactedShards -Map $map -Changed @{ 'src/Covered.cs' = @($edge, $edge) }
         Assert-True ($r.Shards -contains 'Alpha') "executed boundary line $edge must select Alpha"
     }
     foreach ($edge in @(9, 21)) {
         $r = Select-ImpactedShards -Map $map -Changed @{ 'src/Covered.cs' = @($edge, $edge) }
-        Assert-True (-not ($r.Shards -contains 'Alpha')) "unexecuted boundary line $edge must not select Alpha"
+        Assert-True $r.Escalate "unexecuted boundary line $edge must escalate"
     }
 
-    # 6. COORDINATE SYSTEM. The map's ranges are in the coordinates of the commit the map was
-    #    built at, so the diff must report line numbers on THAT side - the '-old' side. A PR that
-    #    inserts lines above an edit shifts the two sides apart, and reading the '+new' side then
-    #    looks up the edited line at a number the map has never heard of. The failure mode is a
-    #    silent MISS: a shard that covers the edit is not selected, and the regression ships.
-    #
-    #    Shape below: 50 lines inserted at the top, then a one-line edit at old line 500, which
-    #    the '+new' side calls 550.
     $diff = @(
-        '--- a/src/Covered.cs',
-        '+++ b/src/Covered.cs',
-        '@@ -1,0 +1,50 @@',
-        '@@ -500 +550 @@'
+        '--- a/src/Covered.cs', '+++ b/src/Covered.cs',
+        '@@ -1,0 +1,50 @@', '@@ -500 +550 @@'
     )
-    $r = ConvertTo-ChangedRanges -DiffLines $diff
-    $ranges = @($r['src/Covered.cs'])
-    Assert-True ($ranges -contains 500) 'the edited line must be reported in the map''s coordinates (old side), not the new side'
-    Assert-True (-not ($ranges -contains 550)) 'the new-side line number must NOT be reported - the map cannot resolve it'
+    $parsed = ConvertTo-ChangedRanges -DiffLines $diff
+    $ranges = @($parsed['src/Covered.cs'])
+    Assert-True ($ranges -contains 500) 'the parser must report old-side line numbers'
+    Assert-True (-not ($ranges -contains 550)) 'the parser must not report new-side line numbers'
 
-    # 7. The two halves composed, because 6 alone only proves the parser reports a different
-    #    number - not that the number changes the answer. Measured against the real map, a ONE-line
-    #    insertion above an edit was enough to drop Integration H-L from the selection: executed
-    #    line 67 shifts to 68, and 68 sits in a gap. That is an ordinary PR (add a using, edit a
-    #    method below), so the pre-fix selector would have skipped covering shards routinely.
     $diff = @(
-        '--- a/src/Covered.cs',
-        '+++ b/src/Covered.cs',
-        '@@ -0,0 +1 @@',
-        '@@ -20 +21 @@'
+        '--- a/src/Covered.cs', '+++ b/src/Covered.cs', '@@ -100 +100 @@',
+        '--- a/src/Deleted.cs', '+++ /dev/null', '@@ -1,200 +0,0 @@'
     )
-    $r = Select-ImpactedShards -Map $map -Changed (ConvertTo-ChangedRanges -DiffLines $diff)
-    Assert-True ($r.Shards -contains 'Alpha') 'a one-line insertion above an edit must not lose the covering shard'
+    $parsed = ConvertTo-ChangedRanges -DiffLines $diff
+    Assert-True ($parsed.ContainsKey('src/Deleted.cs')) 'a deleted file must be reported under its own path'
+    Assert-True (@($parsed['src/Covered.cs']).Count -eq 2) 'a deletion must not contaminate the prior file'
 
-    # 8. FILE-level selection, used when master validates only its delta from a tested tree.
-    #    It must select every shard touching a changed file regardless of WHERE in the file, since
-    #    the two trees share no line numbering.
-    $r = Select-ImpactedShardsByFile -Map $map -ChangedFiles @('src/Covered.cs')
-    Assert-True ($r.Shards -contains 'Alpha' -and $r.Shards -contains 'Beta') `
-        'file-level selection must select every shard executing that file'
-    Assert-True (-not $r.Escalate) 'a mapped file must not escalate'
+    $parsed = ConvertTo-ChangedRanges -DiffLines @() -ChangedFiles @('src/Renamed.cs', 'assets/blob.bin')
+    Assert-True ($parsed.ContainsKey('src/Renamed.cs')) 'a rename-only file must be present without a hunk'
+    Assert-True ($parsed.ContainsKey('assets/blob.bin')) 'a binary file must be present without a hunk'
+    $r = Select-ImpactedShards -Map $map -Changed @{ 'src/Covered.cs' = @() }
+    Assert-True $r.Escalate 'a mapped file without hunks must escalate'
 
-    # 9. And it must still refuse: an untouched file selects nothing beyond always-run. Without
-    #    this a selector returning everything would satisfy 8.
-    $r = Select-ImpactedShardsByFile -Map $map -ChangedFiles @('src/SingleRange.cs')
-    Assert-True ($r.Shards -contains 'Alpha') 'the shard executing the changed file is selected'
-    Assert-True (-not ($r.Shards -contains 'Beta')) 'a shard not executing the changed file is not selected'
-    Assert-True ($r.Shards -contains 'HeavyNoCoverage') 'always-run shards still appear'
+    $badRange = $map | ConvertTo-Json -Depth 8 | ConvertFrom-Json
+    $badRange.files.'src/Covered.cs'[0].r = @(10)
+    Assert-Throws { Assert-ShardMap -Map $badRange -Expected $expected } 'an odd range list must be rejected'
 
-    # 10. Same fail-safes as line-level selection.
-    $r = Select-ImpactedShardsByFile -Map $map -ChangedFiles @('src/Unmapped.cs')
-    Assert-True $r.Escalate 'an unmapped file must escalate'
-    $r = Select-ImpactedShardsByFile -Map $map -ChangedFiles @('Directory.Packages.props')
-    Assert-True $r.Escalate 'shared infrastructure must escalate'
+    $badIndex = $map | ConvertTo-Json -Depth 8 | ConvertFrom-Json
+    $badIndex.files.'src/Covered.cs'[0].s = 99
+    Assert-Throws { Assert-ShardMap -Map $badIndex -Expected $expected } 'an out-of-range shard index must be rejected'
 
-    # 11. No changed files at all - the delta is empty, so only always-run shards remain. This is
-    #     the case worth the most: master merged a tree whose difference from the tested one
-    #     touches nothing, and the entire matrix collapses.
-    $r = Select-ImpactedShardsByFile -Map $map -ChangedFiles @()
-    Assert-True (-not $r.Escalate) 'an empty delta must not escalate'
-    Assert-True ($r.Shards.Count -eq 1 -and $r.Shards -contains 'HeavyNoCoverage') `
-        'an empty delta selects only the always-run shards'
+    $badSchema = $map | ConvertTo-Json -Depth 8 | ConvertFrom-Json
+    $badSchema.schemaVersion = 2
+    Assert-Throws { Assert-ShardMap -Map $badSchema -Expected $expected } 'an unknown map schema must be rejected'
 
-    # 12. DELETIONS. git writes `--- a/<path>` then `+++ /dev/null`, so a parser keyed only on
-    #     `+++ b/` leaves the previous file current: the deletion's hunk lands on THAT file and the
-    #     deleted path is never reported, so shards executing it are not selected and the
-    #     unmapped-file escalation never fires. Both halves are checked.
-    $diff = @(
-        '--- a/src/Covered.cs',
-        '+++ b/src/Covered.cs',
-        '@@ -100 +100 @@',
-        '--- a/src/Deleted.cs',
-        '+++ /dev/null',
-        '@@ -1,200 +0,0 @@'
-    )
-    $r = ConvertTo-ChangedRanges -DiffLines $diff
-    Assert-True ($r.ContainsKey('src/Deleted.cs')) 'a deleted file must be reported under its own path'
-    Assert-True (@($r['src/Covered.cs']).Count -eq 2) 'a deletion must not append its ranges to the previous file'
+    $overlap = $map | ConvertTo-Json -Depth 8 | ConvertFrom-Json
+    $overlap.alwaysRun = @('Alpha')
+    Assert-Throws { Assert-ShardMap -Map $overlap -Expected @('Alpha', 'Beta') } `
+        'known and always-run shard sets must be disjoint'
 
-    # 13. Additions are the mirror: `--- /dev/null` then `+++ b/<path>`.
-    $diff = @('--- /dev/null', '+++ b/src/Added.cs', '@@ -0,0 +1,50 @@')
-    $r = ConvertTo-ChangedRanges -DiffLines $diff
-    Assert-True ($r.ContainsKey('src/Added.cs')) 'an added file must be reported under its new path'
-    Assert-True (-not $r.ContainsKey('/dev/null')) '/dev/null must never appear as a path'
+    $badLine = $map | ConvertTo-Json -Depth 8 | ConvertFrom-Json
+    $badLine.files.'src/Covered.cs'[0].r = @(0, 10)
+    Assert-Throws { Assert-ShardMap -Map $badLine -Expected $expected } 'non-positive map lines must be rejected'
+
+    Assert-Throws { Assert-ShardMap -Map $map -Expected @('Alpha', 'Beta', 'HeavyNoCoverage', 'NewShard') } `
+        'a stale shard universe must be rejected'
+
+    $commaMap = @{
+        schemaVersion = 1; sha = 'abcdefabcdefabcdefabcdefabcdefabcdefabcd'; knownShards = @('Comma, Shard'); alwaysRun = @()
+        files = @{ 'src/Comma.cs' = @( @{ s = 0; r = @(1, 1) } ) }
+    } | ConvertTo-Json -Depth 8 | ConvertFrom-Json
+    try { Assert-ShardMap -Map $commaMap -Expected @('Comma, Shard') } catch {
+        [void] $failures.Add("a comma-containing shard name was rejected: $_")
+    }
+    $r = Select-ImpactedShards -Map $commaMap -Changed @{ 'src/Comma.cs' = @(1, 1) }
+    Assert-True ($r.Shards -contains 'Comma, Shard') 'a comma-containing shard name must stay intact'
 
     if ($failures.Count -gt 0) {
         Write-Host 'Select-Shards self-test FAILED:'
-        foreach ($f in $failures) { Write-Host "  - $f" }
+        foreach ($failure in $failures) { Write-Host "  - $failure" }
         exit 1
     }
     Write-Host 'Select-Shards self-test passed.'
@@ -409,12 +404,6 @@ if ($SelfTest) {
 # ---------------------------------------------------------------- selection
 
 function Exit-Escalated {
-    <#
-        Emit the full-matrix result and stop. Every "we cannot be confident" path ends here, and
-        they must all write the SAME artifact: the caller reads selection.json to decide the matrix,
-        so a path that exits without writing it does not escalate - it kills the job, and the test
-        matrix never runs at all.
-    #>
     param([Parameter(Mandatory)] [string] $Reason, [string] $Message)
 
     if ($Message) { Write-Host "::warning::$Message" }
@@ -427,38 +416,16 @@ if (-not (Test-Path -LiteralPath $MapFile)) {
     Exit-Escalated -Reason 'map-missing' -Message "no shard map at $MapFile - running the full matrix"
 }
 
-# Read and shape-check together, because both failures mean the same thing: the map cannot be
-# trusted to say which shards cover a line.
-#
-# The try/catch is load-bearing, not defensive habit. $ErrorActionPreference is Stop, so a truncated
-# or malformed map made ConvertFrom-Json THROW - and a throw exits before any result is written, so
-# the caller sees no selection.json, the job fails, and the matrix never runs. The header has always
-# listed "no map / unreadable" as an escalation trigger; only the missing half was implemented.
 $map = $null
 try {
     $map = Get-Content -LiteralPath $MapFile -Raw | ConvertFrom-Json
-
-    # A map missing any of these is not a map. Checked explicitly because the failure is otherwise
-    # silent and much later: a null .files makes every changed file look unmapped, which escalates
-    # for a misleading reason, and a null .knownShards indexes as empty so every selected shard
-    # resolves to a blank name.
-    foreach ($required in 'sha', 'knownShards', 'alwaysRun', 'files') {
-        if (-not $map.PSObject.Properties[$required]) { throw "no '$required' property" }
-    }
+    Assert-ShardMap -Map $map -Expected $ExpectedShards
 }
 catch {
     Exit-Escalated -Reason 'map-unreadable' `
-        -Message "the shard map at $MapFile could not be read - running the full matrix ($($_.Exception.Message))"
+        -Message "the shard map at $MapFile could not be trusted - running the full matrix ($($_.Exception.Message))"
 }
 
-# The map's own commit is the reference, NOT the merge base. An earlier revision required
-# map.sha -eq mergeBase, which reads like prudence and is in fact a switch that pins the feature
-# off: a map built nightly on master equals a PR's merge base essentially never, so every run
-# escalated and the saving was always zero while the logs said "map-stale" and looked healthy.
-#
-# What actually matters is that the map's line numbers can be resolved, and diffing from that exact
-# commit guarantees they can. So the only real precondition is that the commit is present locally -
-# a shallow checkout, or a map from a branch that has since been pruned, is what fails here.
 $mapSha = [string] $map.sha
 & git cat-file -e "$mapSha^{commit}" 2>$null
 if ($LASTEXITCODE -ne 0) {
@@ -466,49 +433,27 @@ if ($LASTEXITCODE -ne 0) {
         -Message "the map's commit $mapSha is not present in this checkout - running the full matrix"
 }
 
-# Everything from here is wrapped, because the whole design rests on "when unsure, run everything"
-# and an uncaught throw does the opposite: $ErrorActionPreference is Stop, so the script would die
-# before writing selection.json, the caller would find no result, the job would fail, and the matrix
-# would never run. That is worse than any wrong selection, so every failure below escalates instead.
 try {
-
-if ($FileLevelFrom) {
-    # Master-push mode: validate only what differs from the tree a PR run already tested.
-    & git cat-file -e "$FileLevelFrom^{commit}" 2>$null
-    if ($LASTEXITCODE -ne 0) {
-        Exit-Escalated -Reason 'tested-sha-unresolvable' `
-            -Message "the tested commit $FileLevelFrom is not present in this checkout - running the full matrix"
-    }
-    $files = @(& git diff --name-only $FileLevelFrom HEAD)
-    if ($LASTEXITCODE -ne 0) { Exit-Escalated -Reason 'diff-failed' -Message "git diff from $FileLevelFrom failed" }
-    Write-Host "delta from $FileLevelFrom : $($files.Count) changed file(s)"
-    $selection = Select-ImpactedShardsByFile -Map $map -ChangedFiles $files
-}
-else {
     $changed = Get-ChangedRanges -MapSha $mapSha
     Write-Host "changed files: $($changed.Count)"
     $selection = Select-ImpactedShards -Map $map -Changed $changed
-}
-if ($selection.Escalate) {
-    Write-Host '::warning::selection escalated to the full matrix'
-    foreach ($reason in $selection.Reasons) { Write-Host "  reason: $reason" }
-}
-else {
-    # Denominator counts every shard that COULD run - mapped plus always-run - otherwise a
-    # selection including an always-run shard reads as "2 of 1".
-    $total = @($map.knownShards).Count + @($map.alwaysRun).Count
-    Write-Host "selected $($selection.Shards.Count) of $total shard(s)"
-    foreach ($shard in $selection.Shards) { Write-Host "  $shard" }
-}
 
-$result = [pscustomobject]@{
-    escalate = $selection.Escalate
-    reason   = $(if ($selection.Escalate) { 'impact-unknown' } else { 'selected' })
-    reasons  = $selection.Reasons
-    shards   = $selection.Shards
-}
-if ($OutFile) { $result | ConvertTo-Json -Depth 5 -Compress | Set-Content -LiteralPath $OutFile -Encoding utf8 }
+    if ($selection.Escalate) {
+        Write-Host '::warning::selection escalated to the full matrix'
+        foreach ($reason in $selection.Reasons) { Write-Host "  reason: $reason" }
+    }
+    else {
+        Write-Host "selected $($selection.Shards.Count) of $($ExpectedShards.Count) shard(s)"
+        foreach ($shard in $selection.Shards) { Write-Host "  $shard" }
+    }
 
+    $result = [pscustomobject]@{
+        escalate = $selection.Escalate
+        reason   = $(if ($selection.Escalate) { 'impact-unknown' } else { 'selected' })
+        reasons  = $selection.Reasons
+        shards   = $selection.Shards
+    }
+    if ($OutFile) { $result | ConvertTo-Json -Depth 5 -Compress | Set-Content -LiteralPath $OutFile -Encoding utf8 }
 }
 catch {
     Exit-Escalated -Reason 'selection-failed' `

--- a/tools/TestImpact/Select-Shards.ps1
+++ b/tools/TestImpact/Select-Shards.ps1
@@ -12,7 +12,7 @@
     Escalation triggers:
 
       no map / unreadable        nothing to select against
-      map sha != merge base      the map describes a different tree, so its line numbers are lies
+      map commit not present     its line numbers cannot be resolved against this checkout
       changed file not in index  never executed by ANY shard, or new - impact unknown
       shared-infrastructure path build, workflow or global config, whose blast radius is not
                                  expressible as executed lines
@@ -26,7 +26,8 @@
     shard-map.json from New-ShardMap.ps1.
 
 .PARAMETER BaseRef
-    The merge base to diff against.
+    Accepted for compatibility and logging only. The diff is taken from the MAP's commit, because
+    that is the only reference whose line numbers the map's ranges are expressed in.
 
 .PARAMETER SelfTest
     Runs the built-in checks and exits. Proves selection both fires and refuses to fire.
@@ -65,28 +66,36 @@ function Test-RangeOverlap {
     return -not ($AEnd -lt $BStart -or $BEnd -lt $AStart)
 }
 
-function Get-ChangedRanges {
-    <# Changed line ranges per file, from unified-diff hunk headers with zero context. #>
-    param([string] $BaseRef)
+function ConvertTo-ChangedRanges {
+    <#
+        Changed line ranges per file, from unified-diff hunk headers with zero context.
 
-    $diff = & git diff -U0 "$BaseRef...HEAD"
-    if ($LASTEXITCODE -ne 0) { throw "git diff against '$BaseRef' failed." }
+        Pure so it can be self-tested: the coordinate choice below is the single most dangerous
+        decision in the selector and a git fixture would hide it behind plumbing.
+    #>
+    param([string[]] $DiffLines)
 
     $changed = @{}
     $current = $null
-    foreach ($line in $diff) {
+    foreach ($line in $DiffLines) {
         if ($line.StartsWith('+++ b/')) {
             $current = $line.Substring(6).Trim()
         }
         elseif ($current -and $line.StartsWith('@@')) {
-            # @@ -old,n +new,m @@ ; m omitted means 1, m = 0 means pure deletion
-            if ($line -match '\+(\d+)(?:,(\d+))?') {
+            # @@ -old,n +new,m @@ ; n omitted means 1, n = 0 means a pure insertion.
+            #
+            # The OLD side, deliberately. The map's ranges are in the coordinates of the commit it
+            # was built at, and the caller diffs from exactly that commit, so the '-old' numbers are
+            # already in the map's coordinate system. Reading '+new' instead looks correct and
+            # silently misses: insert fifty lines above an edit and the edited line is looked up
+            # fifty lines below where the map recorded it, so the shard covering it is not selected.
+            if ($line -match '-(\d+)(?:,(\d+))?') {
                 $start = [int] $Matches[1]
                 $count = if ($Matches[2]) { [int] $Matches[2] } else { 1 }
+                if (-not $changed.ContainsKey($current)) {
+                    $changed[$current] = [System.Collections.Generic.List[int]]::new()
+                }
                 if ($count -gt 0) {
-                    if (-not $changed.ContainsKey($current)) {
-                        $changed[$current] = [System.Collections.Generic.List[int]]::new()
-                    }
                     # Parenthesised deliberately: inside @(...) the comma binds tighter than +,
                     # so @($start, $start + $count - 1) parses as ($start, $start) + $count - 1,
                     # i.e. array concatenation followed by subtraction from an array.
@@ -94,11 +103,9 @@ function Get-ChangedRanges {
                     [void] $changed[$current].Add($start + $count - 1)
                 }
                 else {
-                    # A deletion executes no new line, but the surrounding code changed meaning.
-                    # Treat the deletion point as touched rather than invisible.
-                    if (-not $changed.ContainsKey($current)) {
-                        $changed[$current] = [System.Collections.Generic.List[int]]::new()
-                    }
+                    # A pure insertion occupies no line on this side, but it changed the meaning of
+                    # the code around it. Treat the lines either side of the insertion point as
+                    # touched rather than invisible.
                     [void] $changed[$current].Add([Math]::Max(1, $start))
                     [void] $changed[$current].Add([Math]::Max(1, $start + 1))
                 }
@@ -106,6 +113,28 @@ function Get-ChangedRanges {
         }
     }
     return $changed
+}
+
+function Get-ChangedRanges {
+    <#
+        Diffs from the commit the MAP was built at, two-dot, so the '-old' side of every hunk is
+        already in the map's coordinate system.
+
+        Two-dot, not three-dot, and this is the whole design. Three-dot would diff from
+        merge-base(map, HEAD), whose line numbers belong to neither the map nor the PR, which is the
+        coordinate bug this function exists to avoid. Two-dot also drops the requirement that the
+        map commit be an ancestor of HEAD - it is not, for any PR branched before last night's map -
+        so no ancestry check is needed or wanted.
+
+        The cost is over-selection: master commits between the PR's base and the map appear as
+        changes too. That is one night of churn, it is the safe direction, and it is churn the PR
+        merges with anyway.
+    #>
+    param([string] $MapSha)
+
+    $diff = & git diff -U0 $MapSha HEAD
+    if ($LASTEXITCODE -ne 0) { throw "git diff from the map commit '$MapSha' failed." }
+    return ConvertTo-ChangedRanges -DiffLines $diff
 }
 
 function Select-ImpactedShards {
@@ -219,6 +248,39 @@ if ($SelfTest) {
         Assert-True (-not ($r.Shards -contains 'Alpha')) "unexecuted boundary line $edge must not select Alpha"
     }
 
+    # 6. COORDINATE SYSTEM. The map's ranges are in the coordinates of the commit the map was
+    #    built at, so the diff must report line numbers on THAT side - the '-old' side. A PR that
+    #    inserts lines above an edit shifts the two sides apart, and reading the '+new' side then
+    #    looks up the edited line at a number the map has never heard of. The failure mode is a
+    #    silent MISS: a shard that covers the edit is not selected, and the regression ships.
+    #
+    #    Shape below: 50 lines inserted at the top, then a one-line edit at old line 500, which
+    #    the '+new' side calls 550.
+    $diff = @(
+        '--- a/src/Covered.cs',
+        '+++ b/src/Covered.cs',
+        '@@ -1,0 +1,50 @@',
+        '@@ -500 +550 @@'
+    )
+    $r = ConvertTo-ChangedRanges -DiffLines $diff
+    $ranges = @($r['src/Covered.cs'])
+    Assert-True ($ranges -contains 500) 'the edited line must be reported in the map''s coordinates (old side), not the new side'
+    Assert-True (-not ($ranges -contains 550)) 'the new-side line number must NOT be reported - the map cannot resolve it'
+
+    # 7. The two halves composed, because 6 alone only proves the parser reports a different
+    #    number - not that the number changes the answer. Measured against the real map, a ONE-line
+    #    insertion above an edit was enough to drop Integration H-L from the selection: executed
+    #    line 67 shifts to 68, and 68 sits in a gap. That is an ordinary PR (add a using, edit a
+    #    method below), so the pre-fix selector would have skipped covering shards routinely.
+    $diff = @(
+        '--- a/src/Covered.cs',
+        '+++ b/src/Covered.cs',
+        '@@ -0,0 +1 @@',
+        '@@ -20 +21 @@'
+    )
+    $r = Select-ImpactedShards -Map $map -Changed (ConvertTo-ChangedRanges -DiffLines $diff)
+    Assert-True ($r.Shards -contains 'Alpha') 'a one-line insertion above an edit must not lose the covering shard'
+
     if ($failures.Count -gt 0) {
         Write-Host 'Select-Shards self-test FAILED:'
         foreach ($f in $failures) { Write-Host "  - $f" }
@@ -238,18 +300,25 @@ if (-not (Test-Path -LiteralPath $MapFile)) {
 }
 
 $map = Get-Content -LiteralPath $MapFile -Raw | ConvertFrom-Json
-$mergeBase = (& git merge-base HEAD $BaseRef).Trim()
 
-# A map built from a different tree describes different line numbers. Selecting against it would be
-# worse than not selecting: the ranges would look valid and mean nothing.
-if ($map.sha -ne $mergeBase) {
-    Write-Host "::warning::map built from $($map.sha) but the merge base is $mergeBase - running the full matrix"
-    $result = [pscustomobject]@{ escalate = $true; reason = 'map-stale'; reasons = @(); shards = @() }
+# The map's own commit is the reference, NOT the merge base. An earlier revision required
+# map.sha -eq mergeBase, which reads like prudence and is in fact a switch that pins the feature
+# off: a map built nightly on master equals a PR's merge base essentially never, so every run
+# escalated and the saving was always zero while the logs said "map-stale" and looked healthy.
+#
+# What actually matters is that the map's line numbers can be resolved, and diffing from that exact
+# commit guarantees they can. So the only real precondition is that the commit is present locally -
+# a shallow checkout, or a map from a branch that has since been pruned, is what fails here.
+$mapSha = [string] $map.sha
+& git cat-file -e "$mapSha^{commit}" 2>$null
+if ($LASTEXITCODE -ne 0) {
+    Write-Host "::warning::the map's commit $mapSha is not present in this checkout - running the full matrix"
+    $result = [pscustomobject]@{ escalate = $true; reason = 'map-unresolvable'; reasons = @(); shards = @() }
     if ($OutFile) { $result | ConvertTo-Json -Depth 5 -Compress | Set-Content -LiteralPath $OutFile -Encoding utf8 }
     exit 0
 }
 
-$changed = Get-ChangedRanges -BaseRef $BaseRef
+$changed = Get-ChangedRanges -MapSha $mapSha
 Write-Host "changed files: $($changed.Count)"
 
 $selection = Select-ImpactedShards -Map $map -Changed $changed

--- a/tools/TestImpact/Select-Shards.ps1
+++ b/tools/TestImpact/Select-Shards.ps1
@@ -25,17 +25,12 @@
 .PARAMETER MapFile
     shard-map.json from New-ShardMap.ps1.
 
-.PARAMETER BaseRef
-    Accepted for compatibility and logging only. The diff is taken from the MAP's commit, because
-    that is the only reference whose line numbers the map's ranges are expressed in.
-
 .PARAMETER SelfTest
     Runs the built-in checks and exits. Proves selection both fires and refuses to fire.
 #>
 [CmdletBinding(DefaultParameterSetName = 'Select')]
 param(
     [Parameter(Mandatory, ParameterSetName = 'Select')] [string] $MapFile,
-    [Parameter(Mandatory, ParameterSetName = 'Select')] [string] $BaseRef,
     [Parameter(ParameterSetName = 'Select')] [string] $OutFile,
     [Parameter(Mandatory, ParameterSetName = 'SelfTest')] [switch] $SelfTest
 )

--- a/tools/TestImpact/Select-Shards.ps1
+++ b/tools/TestImpact/Select-Shards.ps1
@@ -172,7 +172,20 @@ function ConvertTo-ChangedRanges {
     $changed = @{}
     $current = $null
     $deletedPath = $null
+    # Hunk BODY lines still pending. Headers are only recognised while this is zero, because diff
+    # body lines are raw file content behind a one-character prefix, and content can forge any
+    # header: a REMOVED line whose text begins with '-- ' is rendered '--- ...', byte-identical to
+    # an old-file header. Reproduced with real git: deleting the line '-- remove me' emitted
+    # '--- remove me', the old parser took it as a header, nulled $current, and silently dropped
+    # every later hunk of that file - under-selection with no escalation. A zero-context hunk
+    # '@@ -a,n +b,m @@' is followed by exactly n+m body lines (plus uncounted '\ No newline'
+    # markers), so counting them makes body content inert no matter what it says.
+    $pendingBody = 0
     foreach ($line in $DiffLines) {
+        if ($pendingBody -gt 0) {
+            if (-not $line.StartsWith('\')) { $pendingBody-- }
+            continue
+        }
         if ($line.StartsWith('--- ')) {
             $from = $line.Substring(4).Trim()
             $deletedPath = if ($from -eq '/dev/null') { $null } else { $from -replace '^a/', '' }
@@ -182,19 +195,23 @@ function ConvertTo-ChangedRanges {
             $to = $line.Substring(4).Trim()
             $current = if ($to -eq '/dev/null') { $deletedPath } else { $to -replace '^b/', '' }
         }
-        elseif ($current -and $line.StartsWith('@@') -and $line -match '-(\d+)(?:,(\d+))?') {
+        elseif ($line.StartsWith('@@') -and $line -match '^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@') {
             $start = [int] $Matches[1]
             $count = if ($Matches[2]) { [int] $Matches[2] } else { 1 }
-            if (-not $changed.ContainsKey($current)) {
-                $changed[$current] = [System.Collections.Generic.List[int]]::new()
-            }
-            if ($count -gt 0) {
-                [void] $changed[$current].Add($start)
-                [void] $changed[$current].Add($start + $count - 1)
-            }
-            else {
-                [void] $changed[$current].Add([Math]::Max(1, $start))
-                [void] $changed[$current].Add([Math]::Max(1, $start + 1))
+            $newCount = if ($Matches[4]) { [int] $Matches[4] } else { 1 }
+            $pendingBody = $count + $newCount
+            if ($current) {
+                if (-not $changed.ContainsKey($current)) {
+                    $changed[$current] = [System.Collections.Generic.List[int]]::new()
+                }
+                if ($count -gt 0) {
+                    [void] $changed[$current].Add($start)
+                    [void] $changed[$current].Add($start + $count - 1)
+                }
+                else {
+                    [void] $changed[$current].Add([Math]::Max(1, $start))
+                    [void] $changed[$current].Add([Math]::Max(1, $start + 1))
+                }
             }
         }
     }
@@ -348,19 +365,20 @@ if ($SelfTest) {
         Assert-True $r.Escalate "unexecuted boundary line $edge must escalate"
     }
 
-    $diff = @(
-        '--- a/src/Covered.cs', '+++ b/src/Covered.cs',
-        '@@ -1,0 +1,50 @@', '@@ -500 +550 @@'
-    )
+    # Faithful to real git: every hunk header is followed by its body lines. An earlier revision
+    # used header-only fixtures, which real git never emits - and which masked the forged-header
+    # parse bug that body-line counting exists to prevent (see check 15).
+    $diff = @('--- a/src/Covered.cs', '+++ b/src/Covered.cs', '@@ -1,0 +1,50 @@') +
+            @(1..50 | ForEach-Object { "+inserted $_" }) +
+            @('@@ -500 +550 @@', '-old text', '+new text')
     $parsed = ConvertTo-ChangedRanges -DiffLines $diff
     $ranges = @($parsed['src/Covered.cs'])
     Assert-True ($ranges -contains 500) 'the parser must report old-side line numbers'
     Assert-True (-not ($ranges -contains 550)) 'the parser must not report new-side line numbers'
 
-    $diff = @(
-        '--- a/src/Covered.cs', '+++ b/src/Covered.cs', '@@ -100 +100 @@',
-        '--- a/src/Deleted.cs', '+++ /dev/null', '@@ -1,200 +0,0 @@'
-    )
+    $diff = @('--- a/src/Covered.cs', '+++ b/src/Covered.cs', '@@ -100 +100 @@', '-x', '+y',
+              '--- a/src/Deleted.cs', '+++ /dev/null', '@@ -1,200 +0,0 @@') +
+            @(1..200 | ForEach-Object { "-gone $_" })
     $parsed = ConvertTo-ChangedRanges -DiffLines $diff
     Assert-True ($parsed.ContainsKey('src/Deleted.cs')) 'a deleted file must be reported under its own path'
     Assert-True (@($parsed['src/Covered.cs']).Count -eq 2) 'a deletion must not contaminate the prior file'
@@ -417,6 +435,41 @@ if ($SelfTest) {
         'a look-alike suffix must not match shared infrastructure'
     $r = Select-ImpactedShards -Map $map -Changed @{ '.github/workflows/anything.yml' = @(1, 2) }
     Assert-True $r.Escalate 'the .github/ directory prefix still escalates'
+
+    # 15. Hunk BODY content must be inert. A removed line whose text begins with '-- ' renders as
+    #     '--- ...', byte-identical to an old-file header; the pre-fix parser nulled $current on it
+    #     and silently dropped every later hunk of the file - under-selection with no escalation.
+    #     This diff is verbatim real-git output for: delete the line '-- remove me', edit line 81.
+    $diff = @(
+        'diff --git a/F.cs b/F.cs',
+        'index 9329992..2c35db3 100644',
+        '--- a/F.cs',
+        '+++ b/F.cs',
+        '@@ -50 +49,0 @@ line 49',
+        '--- remove me',
+        '@@ -81 +80 @@ line 80',
+        '-line 81',
+        '+line 80 EDITED'
+    )
+    $r = ConvertTo-ChangedRanges -DiffLines $diff
+    Assert-True ($r.ContainsKey('F.cs')) 'the file must be reported'
+    Assert-True (@($r['F.cs']) -contains 81) 'the hunk AFTER the forged header line must survive'
+    Assert-True (-not $r.ContainsKey('remove me')) 'body content must never become a path'
+
+    # 16. And a forged header inside an ADDED body line must not smuggle a file in.
+    $diff = @(
+        '--- a/G.cs',
+        '+++ b/G.cs',
+        '@@ -5,0 +6,2 @@',
+        '+--- a/EVIL.cs',
+        '++++ b/EVIL.cs',
+        '@@ -30 +32 @@',
+        '-x',
+        '+y'
+    )
+    $r = ConvertTo-ChangedRanges -DiffLines $diff
+    Assert-True (-not $r.ContainsKey('EVIL.cs')) 'added body content must never become a path'
+    Assert-True (@($r['G.cs']) -contains 30) 'the following real hunk still lands on the right file'
 
     if ($failures.Count -gt 0) {
         Write-Host 'Select-Shards self-test FAILED:'

--- a/tools/TestImpact/Select-Shards.ps1
+++ b/tools/TestImpact/Select-Shards.ps1
@@ -258,7 +258,10 @@ if ($selection.Escalate) {
     foreach ($reason in $selection.Reasons) { Write-Host "  reason: $reason" }
 }
 else {
-    Write-Host "selected $($selection.Shards.Count) of $($map.knownShards.Count) shard(s)"
+    # Denominator counts every shard that COULD run - mapped plus always-run - otherwise a
+    # selection including an always-run shard reads as "2 of 1".
+    $total = @($map.knownShards).Count + @($map.alwaysRun).Count
+    Write-Host "selected $($selection.Shards.Count) of $total shard(s)"
     foreach ($shard in $selection.Shards) { Write-Host "  $shard" }
 }
 

--- a/tools/TestImpact/Select-Shards.ps1
+++ b/tools/TestImpact/Select-Shards.ps1
@@ -85,17 +85,22 @@ function Get-ChangedRanges {
                 $count = if ($Matches[2]) { [int] $Matches[2] } else { 1 }
                 if ($count -gt 0) {
                     if (-not $changed.ContainsKey($current)) {
-                        $changed[$current] = [System.Collections.Generic.List[object]]::new()
+                        $changed[$current] = [System.Collections.Generic.List[int]]::new()
                     }
-                    [void] $changed[$current].Add(@($start, $start + $count - 1))
+                    # Parenthesised deliberately: inside @(...) the comma binds tighter than +,
+                    # so @($start, $start + $count - 1) parses as ($start, $start) + $count - 1,
+                    # i.e. array concatenation followed by subtraction from an array.
+                    [void] $changed[$current].Add($start)
+                    [void] $changed[$current].Add($start + $count - 1)
                 }
                 else {
                     # A deletion executes no new line, but the surrounding code changed meaning.
                     # Treat the deletion point as touched rather than invisible.
                     if (-not $changed.ContainsKey($current)) {
-                        $changed[$current] = [System.Collections.Generic.List[object]]::new()
+                        $changed[$current] = [System.Collections.Generic.List[int]]::new()
                     }
-                    [void] $changed[$current].Add(@([Math]::Max(1, $start), [Math]::Max(1, $start + 1)))
+                    [void] $changed[$current].Add([Math]::Max(1, $start))
+                    [void] $changed[$current].Add([Math]::Max(1, $start + 1))
                 }
             }
         }
@@ -129,18 +134,25 @@ function Select-ImpactedShards {
             continue
         }
 
-        foreach ($occurrence in $entry.Value) {
+        foreach ($occurrence in @($entry.Value)) {
             $shardName = [string] $Map.knownShards[[int] $occurrence.s]
             if ($selected.Contains($shardName)) { continue }
-            foreach ($range in $occurrence.r) {
-                $hit = $false
-                foreach ($hunk in $Changed[$path]) {
-                    if (Test-RangeOverlap -AStart $hunk[0] -AEnd $hunk[1] -BStart $range[0] -BEnd $range[1]) {
+            # Both sides are FLAT [start, end, start, end, ...]. Nested arrays are a trap: a file
+            # with exactly one executed range comes back from ConvertFrom-Json as two loose
+            # integers, and @() on a one-element collection flattens the same way, so every index
+            # silently shifts. Flat pairs cannot be unrolled into something that still indexes.
+            $ranges = @($occurrence.r)
+            $hunks = @($Changed[$path])
+            $hit = $false
+            for ($i = 0; $i + 1 -lt $ranges.Count -and -not $hit; $i += 2) {
+                for ($j = 0; $j + 1 -lt $hunks.Count; $j += 2) {
+                    if (Test-RangeOverlap -AStart ([int] $hunks[$j]) -AEnd ([int] $hunks[$j + 1]) `
+                                          -BStart ([int] $ranges[$i]) -BEnd ([int] $ranges[$i + 1])) {
                         $hit = $true; break
                     }
                 }
-                if ($hit) { [void] $selected.Add($shardName); break }
             }
+            if ($hit) { [void] $selected.Add($shardName) }
         }
     }
 
@@ -158,20 +170,23 @@ if ($SelfTest) {
     function Assert-True { param([bool] $Condition, [string] $What)
         if (-not $Condition) { [void] $failures.Add($What) } }
 
-    $map = [pscustomobject]@{
+    # Round-tripped through JSON: an in-memory map hides ConvertFrom-Json's single-element
+    # unrolling, which is exactly what broke the real path while this self-test passed.
+    $map = @{
         schemaVersion = 1
         knownShards   = @('Alpha', 'Beta')
         alwaysRun     = @('HeavyNoCoverage')
-        files         = [pscustomobject]@{
+        files         = @{
             'src/Covered.cs' = @(
-                [pscustomobject]@{ s = 0; r = @(, @(10, 20)) },
-                [pscustomobject]@{ s = 1; r = @(, @(100, 110)) }
+                @{ s = 0; r = @(10, 20) },
+                @{ s = 1; r = @(100, 110) }
             )
+            'src/SingleRange.cs' = @( @{ s = 0; r = @(5, 6) } )
         }
-    }
+    } | ConvertTo-Json -Depth 8 -Compress | ConvertFrom-Json
 
     # 1. A change on a line a shard executed selects that shard - the gate must FIRE.
-    $r = Select-ImpactedShards -Map $map -Changed @{ 'src/Covered.cs' = @(, @(12, 14)) }
+    $r = Select-ImpactedShards -Map $map -Changed @{ 'src/Covered.cs' = @(12, 14) }
     Assert-True (-not $r.Escalate) 'a mapped, covered change must not escalate'
     Assert-True ($r.Shards -contains 'Alpha') 'a change on Alpha''s executed lines must select Alpha'
     Assert-True (-not ($r.Shards -contains 'Beta')) 'a change outside Beta''s lines must NOT select Beta'
@@ -179,7 +194,7 @@ if ($SelfTest) {
 
     # 2. A change in a GAP selects neither - the gate must REFUSE to fire. Without this check a
     #    selector that returned every shard for every input would satisfy check 1 and be useless.
-    $r = Select-ImpactedShards -Map $map -Changed @{ 'src/Covered.cs' = @(, @(50, 60)) }
+    $r = Select-ImpactedShards -Map $map -Changed @{ 'src/Covered.cs' = @(50, 60) }
     Assert-True (-not ($r.Shards -contains 'Alpha')) 'a change in an unexecuted gap must not select Alpha'
     Assert-True (-not ($r.Shards -contains 'Beta')) 'a change in an unexecuted gap must not select Beta'
 
@@ -187,20 +202,20 @@ if ($SelfTest) {
     Assert-True ($r.Shards -contains 'HeavyNoCoverage') 'shards without coverage must always be selected'
 
     # 4. Fail safe: an unmapped file, and shared infrastructure, both escalate.
-    $r = Select-ImpactedShards -Map $map -Changed @{ 'src/Unmapped.cs' = @(, @(1, 5)) }
+    $r = Select-ImpactedShards -Map $map -Changed @{ 'src/Unmapped.cs' = @(1, 5) }
     Assert-True $r.Escalate 'an unmapped file must escalate to the full matrix'
-    $r = Select-ImpactedShards -Map $map -Changed @{ 'Directory.Packages.props' = @(, @(1, 2)) }
+    $r = Select-ImpactedShards -Map $map -Changed @{ 'Directory.Packages.props' = @(1, 2) }
     Assert-True $r.Escalate 'a dependency-property change must escalate'
-    $r = Select-ImpactedShards -Map $map -Changed @{ '.github/workflows/ci.yml' = @(, @(1, 2)) }
+    $r = Select-ImpactedShards -Map $map -Changed @{ '.github/workflows/ci.yml' = @(1, 2) }
     Assert-True $r.Escalate 'a workflow change must escalate'
 
     # 5. Boundaries. The first and last executed line count as hits; the lines either side do not.
     foreach ($edge in @(10, 20)) {
-        $r = Select-ImpactedShards -Map $map -Changed @{ 'src/Covered.cs' = @(, @($edge, $edge)) }
+        $r = Select-ImpactedShards -Map $map -Changed @{ 'src/Covered.cs' = @($edge, $edge) }
         Assert-True ($r.Shards -contains 'Alpha') "executed boundary line $edge must select Alpha"
     }
     foreach ($edge in @(9, 21)) {
-        $r = Select-ImpactedShards -Map $map -Changed @{ 'src/Covered.cs' = @(, @($edge, $edge)) }
+        $r = Select-ImpactedShards -Map $map -Changed @{ 'src/Covered.cs' = @($edge, $edge) }
         Assert-True (-not ($r.Shards -contains 'Alpha')) "unexecuted boundary line $edge must not select Alpha"
     }
 

--- a/tools/TestImpact/Select-Shards.ps1
+++ b/tools/TestImpact/Select-Shards.ps1
@@ -1,0 +1,256 @@
+<#
+.SYNOPSIS
+    Chooses which CI shards a change needs, from the coverage-derived shard map.
+
+.DESCRIPTION
+    Intersects the PR's changed line ranges against the map's file -> shard index. A shard is
+    selected when it executed at least one line the PR touched.
+
+    FAIL SAFE IS THE POINT. Selection only ever saves time when it is confident; every uncertainty
+    escalates to the full matrix and says why. A wrong escalation costs runner minutes, a wrong
+    omission ships a regression - those are not symmetric, and the code treats them accordingly.
+    Escalation triggers:
+
+      no map / unreadable        nothing to select against
+      map sha != merge base      the map describes a different tree, so its line numbers are lies
+      changed file not in index  never executed by ANY shard, or new - impact unknown
+      shared-infrastructure path build, workflow or global config, whose blast radius is not
+                                 expressible as executed lines
+
+    Line-level, not file-level, deliberately: on Integration H-L, 29,528 executed lines sit inside
+    files also containing 169,732 unexecuted ones, so 85% of a file's lines belong to no shard by
+    way of that file. LayerHelper.cs alone spans 25,980 lines with 703 executed and a 21,328-line
+    gap. Selecting on the file would pull in shards that never run the changed code.
+
+.PARAMETER MapFile
+    shard-map.json from New-ShardMap.ps1.
+
+.PARAMETER BaseRef
+    The merge base to diff against.
+
+.PARAMETER SelfTest
+    Runs the built-in checks and exits. Proves selection both fires and refuses to fire.
+#>
+[CmdletBinding(DefaultParameterSetName = 'Select')]
+param(
+    [Parameter(Mandatory, ParameterSetName = 'Select')] [string] $MapFile,
+    [Parameter(Mandatory, ParameterSetName = 'Select')] [string] $BaseRef,
+    [Parameter(ParameterSetName = 'Select')] [string] $OutFile,
+    [Parameter(Mandatory, ParameterSetName = 'SelfTest')] [switch] $SelfTest
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+# Paths whose effect is not expressible as executed source lines. A build property or workflow edit
+# can change what every shard compiles or how it runs, so no coverage evidence can bound it.
+$script:SharedInfrastructure = @(
+    '.github/',
+    'Directory.Build.props', 'Directory.Build.targets', 'Directory.Packages.props',
+    'global.json', 'nuget.config', 'NuGet.config',
+    '.editorconfig'
+)
+
+function Test-SharedInfrastructure {
+    param([string] $Path)
+    foreach ($prefix in $script:SharedInfrastructure) {
+        if ($Path.StartsWith($prefix, [StringComparison]::OrdinalIgnoreCase)) { return $true }
+        if ($Path -ieq $prefix) { return $true }
+    }
+    return $false
+}
+
+function Test-RangeOverlap {
+    param([int] $AStart, [int] $AEnd, [int] $BStart, [int] $BEnd)
+    return -not ($AEnd -lt $BStart -or $BEnd -lt $AStart)
+}
+
+function Get-ChangedRanges {
+    <# Changed line ranges per file, from unified-diff hunk headers with zero context. #>
+    param([string] $BaseRef)
+
+    $diff = & git diff -U0 "$BaseRef...HEAD"
+    if ($LASTEXITCODE -ne 0) { throw "git diff against '$BaseRef' failed." }
+
+    $changed = @{}
+    $current = $null
+    foreach ($line in $diff) {
+        if ($line.StartsWith('+++ b/')) {
+            $current = $line.Substring(6).Trim()
+        }
+        elseif ($current -and $line.StartsWith('@@')) {
+            # @@ -old,n +new,m @@ ; m omitted means 1, m = 0 means pure deletion
+            if ($line -match '\+(\d+)(?:,(\d+))?') {
+                $start = [int] $Matches[1]
+                $count = if ($Matches[2]) { [int] $Matches[2] } else { 1 }
+                if ($count -gt 0) {
+                    if (-not $changed.ContainsKey($current)) {
+                        $changed[$current] = [System.Collections.Generic.List[object]]::new()
+                    }
+                    [void] $changed[$current].Add(@($start, $start + $count - 1))
+                }
+                else {
+                    # A deletion executes no new line, but the surrounding code changed meaning.
+                    # Treat the deletion point as touched rather than invisible.
+                    if (-not $changed.ContainsKey($current)) {
+                        $changed[$current] = [System.Collections.Generic.List[object]]::new()
+                    }
+                    [void] $changed[$current].Add(@([Math]::Max(1, $start), [Math]::Max(1, $start + 1)))
+                }
+            }
+        }
+    }
+    return $changed
+}
+
+function Select-ImpactedShards {
+    param(
+        [Parameter(Mandatory)] $Map,
+        [Parameter(Mandatory)] [hashtable] $Changed
+    )
+
+    $selected = [System.Collections.Generic.HashSet[string]]::new()
+    foreach ($shard in $Map.alwaysRun) { [void] $selected.Add([string] $shard) }
+
+    $reasons = [System.Collections.Generic.List[string]]::new()
+    $escalate = $false
+
+    foreach ($path in ($Changed.Keys | Sort-Object)) {
+        if (Test-SharedInfrastructure -Path $path) {
+            $escalate = $true
+            [void] $reasons.Add("shared infrastructure: $path")
+            continue
+        }
+
+        $entry = $Map.files.PSObject.Properties[$path]
+        if (-not $entry) {
+            $escalate = $true
+            [void] $reasons.Add("not executed by any mapped shard: $path")
+            continue
+        }
+
+        foreach ($occurrence in $entry.Value) {
+            $shardName = [string] $Map.knownShards[[int] $occurrence.s]
+            if ($selected.Contains($shardName)) { continue }
+            foreach ($range in $occurrence.r) {
+                $hit = $false
+                foreach ($hunk in $Changed[$path]) {
+                    if (Test-RangeOverlap -AStart $hunk[0] -AEnd $hunk[1] -BStart $range[0] -BEnd $range[1]) {
+                        $hit = $true; break
+                    }
+                }
+                if ($hit) { [void] $selected.Add($shardName); break }
+            }
+        }
+    }
+
+    return [pscustomobject]@{
+        Escalate = $escalate
+        Reasons  = $reasons
+        Shards   = @($selected | Sort-Object)
+    }
+}
+
+# ---------------------------------------------------------------- self-test
+
+if ($SelfTest) {
+    $failures = [System.Collections.Generic.List[string]]::new()
+    function Assert-True { param([bool] $Condition, [string] $What)
+        if (-not $Condition) { [void] $failures.Add($What) } }
+
+    $map = [pscustomobject]@{
+        schemaVersion = 1
+        knownShards   = @('Alpha', 'Beta')
+        alwaysRun     = @('HeavyNoCoverage')
+        files         = [pscustomobject]@{
+            'src/Covered.cs' = @(
+                [pscustomobject]@{ s = 0; r = @(, @(10, 20)) },
+                [pscustomobject]@{ s = 1; r = @(, @(100, 110)) }
+            )
+        }
+    }
+
+    # 1. A change on a line a shard executed selects that shard - the gate must FIRE.
+    $r = Select-ImpactedShards -Map $map -Changed @{ 'src/Covered.cs' = @(, @(12, 14)) }
+    Assert-True (-not $r.Escalate) 'a mapped, covered change must not escalate'
+    Assert-True ($r.Shards -contains 'Alpha') 'a change on Alpha''s executed lines must select Alpha'
+    Assert-True (-not ($r.Shards -contains 'Beta')) 'a change outside Beta''s lines must NOT select Beta'
+
+
+    # 2. A change in a GAP selects neither - the gate must REFUSE to fire. Without this check a
+    #    selector that returned every shard for every input would satisfy check 1 and be useless.
+    $r = Select-ImpactedShards -Map $map -Changed @{ 'src/Covered.cs' = @(, @(50, 60)) }
+    Assert-True (-not ($r.Shards -contains 'Alpha')) 'a change in an unexecuted gap must not select Alpha'
+    Assert-True (-not ($r.Shards -contains 'Beta')) 'a change in an unexecuted gap must not select Beta'
+
+    # 3. Always-run shards appear regardless, including when nothing else is selected.
+    Assert-True ($r.Shards -contains 'HeavyNoCoverage') 'shards without coverage must always be selected'
+
+    # 4. Fail safe: an unmapped file, and shared infrastructure, both escalate.
+    $r = Select-ImpactedShards -Map $map -Changed @{ 'src/Unmapped.cs' = @(, @(1, 5)) }
+    Assert-True $r.Escalate 'an unmapped file must escalate to the full matrix'
+    $r = Select-ImpactedShards -Map $map -Changed @{ 'Directory.Packages.props' = @(, @(1, 2)) }
+    Assert-True $r.Escalate 'a dependency-property change must escalate'
+    $r = Select-ImpactedShards -Map $map -Changed @{ '.github/workflows/ci.yml' = @(, @(1, 2)) }
+    Assert-True $r.Escalate 'a workflow change must escalate'
+
+    # 5. Boundaries. The first and last executed line count as hits; the lines either side do not.
+    foreach ($edge in @(10, 20)) {
+        $r = Select-ImpactedShards -Map $map -Changed @{ 'src/Covered.cs' = @(, @($edge, $edge)) }
+        Assert-True ($r.Shards -contains 'Alpha') "executed boundary line $edge must select Alpha"
+    }
+    foreach ($edge in @(9, 21)) {
+        $r = Select-ImpactedShards -Map $map -Changed @{ 'src/Covered.cs' = @(, @($edge, $edge)) }
+        Assert-True (-not ($r.Shards -contains 'Alpha')) "unexecuted boundary line $edge must not select Alpha"
+    }
+
+    if ($failures.Count -gt 0) {
+        Write-Host 'Select-Shards self-test FAILED:'
+        foreach ($f in $failures) { Write-Host "  - $f" }
+        exit 1
+    }
+    Write-Host 'Select-Shards self-test passed.'
+    exit 0
+}
+
+# ---------------------------------------------------------------- selection
+
+if (-not (Test-Path -LiteralPath $MapFile)) {
+    Write-Host "::warning::no shard map at $MapFile - running the full matrix"
+    $result = [pscustomobject]@{ escalate = $true; reason = 'map-missing'; reasons = @(); shards = @() }
+    if ($OutFile) { $result | ConvertTo-Json -Depth 5 -Compress | Set-Content -LiteralPath $OutFile -Encoding utf8 }
+    exit 0
+}
+
+$map = Get-Content -LiteralPath $MapFile -Raw | ConvertFrom-Json
+$mergeBase = (& git merge-base HEAD $BaseRef).Trim()
+
+# A map built from a different tree describes different line numbers. Selecting against it would be
+# worse than not selecting: the ranges would look valid and mean nothing.
+if ($map.sha -ne $mergeBase) {
+    Write-Host "::warning::map built from $($map.sha) but the merge base is $mergeBase - running the full matrix"
+    $result = [pscustomobject]@{ escalate = $true; reason = 'map-stale'; reasons = @(); shards = @() }
+    if ($OutFile) { $result | ConvertTo-Json -Depth 5 -Compress | Set-Content -LiteralPath $OutFile -Encoding utf8 }
+    exit 0
+}
+
+$changed = Get-ChangedRanges -BaseRef $BaseRef
+Write-Host "changed files: $($changed.Count)"
+
+$selection = Select-ImpactedShards -Map $map -Changed $changed
+if ($selection.Escalate) {
+    Write-Host '::warning::selection escalated to the full matrix'
+    foreach ($reason in $selection.Reasons) { Write-Host "  reason: $reason" }
+}
+else {
+    Write-Host "selected $($selection.Shards.Count) of $($map.knownShards.Count) shard(s)"
+    foreach ($shard in $selection.Shards) { Write-Host "  $shard" }
+}
+
+$result = [pscustomobject]@{
+    escalate = $selection.Escalate
+    reason   = $(if ($selection.Escalate) { 'impact-unknown' } else { 'selected' })
+    reasons  = $selection.Reasons
+    shards   = $selection.Shards
+}
+if ($OutFile) { $result | ConvertTo-Json -Depth 5 -Compress | Set-Content -LiteralPath $OutFile -Encoding utf8 }

--- a/tools/TestImpact/Select-Shards.ps1
+++ b/tools/TestImpact/Select-Shards.ps1
@@ -36,9 +36,22 @@ $script:SharedInfrastructure = @(
 
 function Test-SharedInfrastructure {
     param([string] $Path)
-    foreach ($prefix in $script:SharedInfrastructure) {
-        if ($Path.StartsWith($prefix, [StringComparison]::OrdinalIgnoreCase)) { return $true }
-        if ($Path -ieq $prefix) { return $true }
+    # Two kinds of entry, matched differently on purpose:
+    #
+    #   trailing '/'  a directory - prefix match
+    #   otherwise     a config FILE NAME - matched by basename at ANY depth, because MSBuild and
+    #                 NuGet apply Directory.Build.props / Directory.Packages.props / nuget.config
+    #                 per-directory, so src/Directory.Build.props changes what a subtree compiles
+    #                 just as surely as the root one (and src/Directory.Build.props exists here).
+    #
+    # An earlier revision used StartsWith for everything, which missed those nested files AND
+    # escalated on unrelated look-alikes such as Directory.Packages.props.backup.
+    $name = [System.IO.Path]::GetFileName($Path)
+    foreach ($entry in $script:SharedInfrastructure) {
+        if ($entry.EndsWith('/')) {
+            if ($Path.StartsWith($entry, [StringComparison]::OrdinalIgnoreCase)) { return $true }
+        }
+        elseif ($name -ieq $entry) { return $true }
     }
     return $false
 }
@@ -391,6 +404,19 @@ if ($SelfTest) {
     }
     $r = Select-ImpactedShards -Map $commaMap -Changed @{ 'src/Comma.cs' = @(1, 1) }
     Assert-True ($r.Shards -contains 'Comma, Shard') 'a comma-containing shard name must stay intact'
+
+    # 14. Shared-infrastructure matching. File entries match by BASENAME at any depth - MSBuild
+    #     and NuGet apply these files per-directory, and src/Directory.Build.props exists in this
+    #     repo - while look-alike names must not match, and directories stay prefix-matched.
+    $r = Select-ImpactedShards -Map $map -Changed @{ 'src/Directory.Build.props' = @(1, 2) }
+    Assert-True $r.Escalate 'a NESTED Directory.Build.props must escalate'
+    $r = Select-ImpactedShards -Map $map -Changed @{ 'src/sub/nuget.config' = @(1, 2) }
+    Assert-True $r.Escalate 'a nested nuget.config must escalate'
+    $r = Select-ImpactedShards -Map $map -Changed @{ 'Directory.Packages.props.backup' = @(1, 2) }
+    Assert-True (-not ($r.Reasons -join ';').Contains('shared infrastructure')) `
+        'a look-alike suffix must not match shared infrastructure'
+    $r = Select-ImpactedShards -Map $map -Changed @{ '.github/workflows/anything.yml' = @(1, 2) }
+    Assert-True $r.Escalate 'the .github/ directory prefix still escalates'
 
     if ($failures.Count -gt 0) {
         Write-Host 'Select-Shards self-test FAILED:'


### PR DESCRIPTION
Runs only the test shards a change can affect, decided from coverage rather than file paths or the
project graph.

## Measured result

Against a real map built from a full instrumented run (116 shards), probing 15 random single-file
edits to mapped source files:

| | full run | with selection |
|---|---|---|
| shards run | 116 | **7** (median) |
| runner-minutes | 1504 | **136** |
| wall-clock floor at 20 concurrent jobs | 75 min | **7 min** |

**91% of runner-minutes, 68 minutes off the floor.** Zero escalations across the 15 probes; the
worst case observed still saved 36%.

Verified rather than asserted: for one probe, the selected set is exactly
`alwaysRun ∪ {shards the map says execute that file}` — 6 + 1 = 7.

## The cost side

The map needs one instrumented run per night, but incremental carry (below) makes the FULL
instrumented run the exception, not the rule. Instrumentation costs **3.21x on heavy shards** and
1.06x on light ones; measured occupancy at `max-parallel: 12`, which leaves 8 slots free for PRs:

| night | runner-min | occupancy |
|---|---|---|
| bootstrap / test-code changed | 3452 | ~4.8h |
| typical (11 changed files measured) | ~1592 | ~2.2h |

Minutes are **not billed** - GitHub Actions is free for public repos on standard hosted runners -
so the real cost is those hours of the 20-slot queue. Scheduled at 02:00 UTC, finishing well before
measured repo activity (13:00-16:00 and 21:00 UTC).

## Why the ceiling moved

`$collectCoverage = -not ($heavyShard -or $measuresTiming)` disables coverage on 91 distinct shards
(`Integration - Serial Perf` appears in both lists) - heavy ones for the memory envelope, timing
ones because instrumentation distorts the ratios they assert. Unmappable shards are always-run, so
selection was originally capped at 25 mapped shards and a 41% saving. The memory ceiling belongs to
the PR matrix, not to a nightly job: with `collect_coverage_everywhere` forced on, **110 of 116
shards mapped** and only 5 failed under instrumentation - a shard that still OOMs simply produces no
digest and stays always-run.

## Incremental instrumentation

The nightly does not re-instrument what cannot have moved. A shard's digest is carried forward when
**every file it covers is byte-identical** between the previous map's commit and the new one - the
exact condition under which its line ranges still mean what they said. Carried digests are
reconstructed from the previous map and uploaded by the coverage run itself under the harvest's
existing `impact-digest-*` pattern, so the map build needed no changes at all.

Only heavy and timing shards are carriable: every other shard produces a fresh digest in any
successful run, and `New-ShardMap` aborts the whole map on a duplicate digest by design. All 116
shards still *run* - the audit keeps its full outcome set - only the 3.21x instrumentation overhead
is skipped.

Measured against a real day of master churn (11 changed files): instrument 6, carry 85,
self-producing 25 - and the resulting map is identical in shape to full instrumentation
(110 known / 6 always-run). Nightly cost drops from ~4.8h to ~2.2h of queue occupancy. The
duplicate-collision drift case was proven to abort loudly rather than corrupt the map.

## Fail safe

Every uncertainty runs the full matrix and says why. Proven on the merged code against the real map:

| fixture | result |
|---|---|
| edit a mapped, executed line | selects 7, no escalation |
| add a brand-new file | **escalates** — not executed by any mapped shard |
| touch `Directory.Packages.props` | **escalates** — shared infrastructure |
| delete a mapped file | selects its covering shard, no escalation |

Guards against silently running fewer tests than intended: an empty matrix is a hard error; a
selected shard absent from the manifest escalates; always-run is derived from "produced no digest";
the map is only built from a run carrying the coverage marker **and** the exact current shard-name
set; a digest is only built from a test step that succeeded; and any unexpected failure anywhere in
the selection path escalates rather than killing the job.

## Defects found and fixed during development

Every one would have skipped tests while reporting green:

- diff hunks read in the wrong coordinate system — a **one-line** insertion dropped a covering shard
- a staleness check that could never pass, silently disabling the feature entirely
- deleted files attributed to the previous file, so their shards were never selected
- reduced master runs poisoning the map into marking every skipped shard always-run
- digests built from part-way-killed runs, describing only the tests that ran
- always-run names split on commas, shredding two real shard names into 14 fragments and escalating
  every run

All are regression-tested, and the tests fail on controls that differ only by the fix.

## Rollout: shadow mode, default on

The reduced path cannot be exercised before this merges - the map is published by
`test-impact-map.yml`, which cannot run until it is on master - so the first real reduction would
otherwise happen in production.

It therefore ships in **shadow mode**: selection is computed and reported exactly as it would be,
and then the full matrix runs anyway. Zero risk, and it produces the one thing still missing - real
data on what selection *would* have skipped, which `Measure-SelectionMiss` checks against what
actually failed.

Flip it on with the repository variable `TEST_IMPACT_MODE=enforce` once that data supports it. Any
other value, including unset, means shadow.

Simulated across all five paths: unset and `shadow` both yield `matrix=116, skipped=0` while still
logging "would have run 7 of 116"; only `enforce` reduces. `skipped=0` matters - it is what the
regression analyzer reads, and reporting skipped shards while running them would corrupt its policy.

## Also here

- `matrix` is not available in job-level `if:`, so the shard definitions moved to
  `.github/test-shards.yml` (YAML, so every comment survives) and the matrix is built with
  `fromJSON`. Gating with `if:` would have skipped every shard and gone green with zero tests.
- Master pushes are **not** reduced. Exact-tree reuse in `validation-source` already covers that,
  and a master delta here would be a second, weaker reuse mechanism.





