### PR TITLE
chore(deps): align entity framework core family at 10.0.11

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -372,10 +372,10 @@
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.11" />
     <PackageVersion Include="System.IdentityModel.Tokens.Jwt" Version="8.22.0" />
     <!-- Entity Framework Core -->
-    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="10.0.9" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.9" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.9" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="10.0.11" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.11" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.11" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.11" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.11" />
     <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.2" />
     <PackageVersion Include="Npgsql" Version="10.0.1" />


### PR DESCRIPTION
Master has not built since 09:18 UTC today. **0 of the last 12 master runs succeeded.**

## Cause

Dependabot raised `Microsoft.EntityFrameworkCore.Sqlite` 10.0.9 -> 10.0.11 on its own, leaving the
rest of the family at 10.0.9. Sqlite 10.0.11 resolves `Sqlite.Core 10.0.11`, which requires
`Relational >= 10.0.11`, so central package management hits NU1605:

```
error NU1605: Detected package downgrade: Microsoft.EntityFrameworkCore.Relational
from 10.0.11 to 10.0.9
  AiDotNet.Serving -> ...Sqlite 10.0.11 -> ...Sqlite.Core 10.0.11 -> ...Relational (>= 10.0.11)
  AiDotNet.Serving -> ...Relational (>= 10.0.9)
```

It hits `AiDotNet.Serving` and `AiDotNet.Serving.Tests`.

## Why it looked like something else

Restore failing takes the whole run with it: the build job's "Cancel the run if this build failed"
step cancels everything downstream. So the runs read as **cancelled**, not failed, which looks like
concurrency cancellation from rapid pushes rather than a build break.

It is also invisible on draft PRs, which skip the build job entirely and report green.

## Fix

Bumps the four EF Core packages still on 10.0.9 so the family sits at one patch level. Four lines.

Verified locally, both arms:

| arm | result |
|---|---|
| fix reverted, `dotnet restore src/AiDotNet.Serving` | exit 1, the same NU1605 |
| fix applied, `dotnet restore src/AiDotNet.Serving` | exit 0 |
| fix applied, `dotnet restore` (full solution) | exit 0 |

## Deliberately left alone

- `Microsoft.AspNetCore.DataProtection.EntityFrameworkCore` stays at 10.0.9. It only requires EF Core
  `>= 10.0.9`, which 10.0.11 satisfies - raising a resolved version is never a downgrade.
- `Npgsql.EntityFrameworkCore.PostgreSQL` and `Pomelo.EntityFrameworkCore.MySql` track their own
  cadence and are unaffected.
- Pre-existing and **not** addressed here: `System.Security.Cryptography.Xml` 10.0.9 raises three
  NU1903 high-severity vulnerability warnings during restore. They are warnings, not errors, so they
  are not part of this outage.

Typed `chore` rather than `fix` so it cannot trigger a release without approval.

## Follow-up worth considering

Dependabot bumping one package out of a lock-step family will do this again. A grouped update rule
for `Microsoft.EntityFrameworkCore.*` in `.github/dependabot.yml` would prevent the recurrence.
