### PR TITLE
fix(ci): group the vi/vi alternation before excluding video

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -1234,7 +1234,7 @@ jobs:
             framework: net10.0
             filter: >-
               FullyQualifiedName~ModelFamilyTests.Generated&
-              ((FullyQualifiedName~Generated.Vi|FullyQualifiedName~Generated.VI&FullyQualifiedName!~Generated.Video)|FullyQualifiedName~Generated.VM)
+              (((FullyQualifiedName~Generated.Vi|FullyQualifiedName~Generated.VI)&FullyQualifiedName!~Generated.Video)|FullyQualifiedName~Generated.VM)
           - name: ModelFamily - Generated Layers Vo-VR
             project: tests/AiDotNet.Tests/AiDotNetTests.csproj
             framework: net10.0


### PR DESCRIPTION
The `ModelFamily - Generated Layers Vi-VM` shard means to take `Vi*` and `VI*` while leaving
`Video*` to its own dedicated shard. It does not.

VSTest binds `&` tighter than `|`, so

```
(A | B & C) | D    parses as    (A | (B & C)) | D
```

which applies the `!~Generated.Video` exclusion only to the `VI` branch. Matching is also
case-insensitive, so `Generated.Video` enters through the `Generated.Vi` branch and the exclusion
never sees it.

**Every Video test runs twice** — once in `Vi-VM`, once in the `Video` shard.

## Measured, not reasoned

A three-class probe (`VideoTests`, `VisionTests`, `VMTests` under `ModelFamilyTests.Generated`),
listing tests per filter against real VSTest:

| filter | tests selected |
|---|---|
| `Vi-VM`, current | `VMTests`, **`VideoTests`**, `VisionTests` |
| `Vi-VM`, fixed | `VMTests`, `VisionTests` |
| `Video` shard | `VideoTests` |

The union across both shards is unchanged, so nothing stops running — the fix only stops `Video`
running twice.

Parenthesising the alternation explicitly also makes the expression correct whichever way the
precedence question is answered, rather than depending on it.

## Scope

Swept the other 115 shard filters for the same shape (an ungrouped alternation followed by an `&`
exclusion). This was the only one.

Found by CodeRabbit on #2072, where the shard definitions are being relocated; it is pre-existing
on master, so it is fixed here rather than there.
