### PR TITLE
fix(ci): stop master duplicating pr validation, and video running twice

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -185,8 +185,13 @@ jobs:
           # temporary merge commit rather than the PR head. So recent ones are listed unfiltered
           # and left to the tree comparison below. That comparison is the actual safety property;
           # how a candidate was discovered cannot weaken it.
+          #
+          # Merge-queue runs go FIRST. Evaluating a candidate is not free - each one downloads an
+          # artifact zip and resolves a tree through the API - and a merge_group run is the one
+          # most likely to match, so checking the pull_request runs ahead of it spends those calls
+          # on the weaker candidates. Ordering changes only cost here, never the answer.
           if mq_json=$(gh api --method GET             "repos/${GITHUB_REPOSITORY}/actions/workflows/sonarcloud.yml/runs"             -f event=merge_group -f status=completed -f per_page=20 2>/dev/null); then
-            runs_json=$(jq -n --argjson a "$runs_json" --argjson b "$mq_json"               '{workflow_runs: (($a.workflow_runs // []) + ($b.workflow_runs // []))}')
+            runs_json=$(jq -n --argjson a "$runs_json" --argjson b "$mq_json"               '{workflow_runs: (($b.workflow_runs // []) + ($a.workflow_runs // []))}')
           fi
 
           # A red test ledger may still be an accepted improvement over baseline, so failure is a

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -176,6 +176,19 @@ jobs:
             return 2
           fi
 
+          # Merge-queue runs are candidates too, and better ones. A merge_group run validates the
+          # exact commit that is about to become master, so its tree matches by construction -
+          # whereas a pull_request run matches only while master has not moved, which in a busy
+          # repo means almost never.
+          #
+          # They cannot be found by head_sha, because a merge_group run's head is the queue's
+          # temporary merge commit rather than the PR head. So recent ones are listed unfiltered
+          # and left to the tree comparison below. That comparison is the actual safety property;
+          # how a candidate was discovered cannot weaken it.
+          if mq_json=$(gh api --method GET             "repos/${GITHUB_REPOSITORY}/actions/workflows/sonarcloud.yml/runs"             -f event=merge_group -f status=completed -f per_page=20 2>/dev/null); then
+            runs_json=$(jq -n --argjson a "$runs_json" --argjson b "$mq_json"               '{workflow_runs: (($a.workflow_runs // []) + ($b.workflow_runs // []))}')
+          fi
+
           # A red test ledger may still be an accepted improvement over baseline, so failure is a
           # usable completed conclusion. Cancelled/timed-out runs are never reusable.
           while IFS= read -r run_id; do
@@ -1234,7 +1247,7 @@ jobs:
             framework: net10.0
             filter: >-
               FullyQualifiedName~ModelFamilyTests.Generated&
-              ((FullyQualifiedName~Generated.Vi|FullyQualifiedName~Generated.VI&FullyQualifiedName!~Generated.Video)|FullyQualifiedName~Generated.VM)
+              (((FullyQualifiedName~Generated.Vi|FullyQualifiedName~Generated.VI)&FullyQualifiedName!~Generated.Video)|FullyQualifiedName~Generated.VM)
           - name: ModelFamily - Generated Layers Vo-VR
             project: tests/AiDotNet.Tests/AiDotNetTests.csproj
             framework: net10.0


### PR DESCRIPTION
Two independent savings, split out of #2072 so they can land without waiting on the
coverage-derived shard selection that PR is still proving. One file, 14 lines.

## 1. Master duplicates a run it already has

Reuse looked broken. It is not — its precondition is that the merged tree equals a tested tree, and
master keeps moving while a PR is open, so the merge commit's tree is a combination nothing tested.

Measured on master run `33445195460`, the push for the #2073 merge. Every precondition passed
except one:

| precondition | result |
|---|---|
| completed PR run found | ✅ `33413151330` |
| conclusion `success` **or** `failure` | ✅ failure is explicitly allowed |
| `ci-test-analysis` + 49 `coverage-*` artifacts | ✅ unexpired |
| PR-tested tree == master merge tree | ❌ `fd1f3501…` vs `f3bd7790…` |

64 commits landed on master during the six hours #2073 was open. Master then re-ran all 116 shards
to rediscover the same 3 pre-existing failures the PR had already found across 115.

A `merge_group` run does not have that problem: it validates the exact commit about to become
master, so its tree matches **by construction**. Reuse queried only `event=pull_request`, so
merge-queue runs were invisible to it. They cannot be found by `head_sha` — a `merge_group` head is
the queue's temporary merge commit, not the PR head — so recent ones are listed and left to the
existing tree comparison, which is the actual safety property. How a candidate is discovered cannot
weaken it.

**What the duplicate costs, measured on a full run:** 1455 runner-minutes, and a 73-minute
throughput floor at the account's 20 concurrent jobs.

Degrades safely: if the merge-queue query fails or returns nothing, `runs_json` is unchanged and
behaviour is exactly as before.

## 2. Every Video test runs twice

VSTest binds `&` tighter than `|`, so

```
(A | B & C) | D    parses as    (A | (B & C)) | D
```

The `!~Generated.Video` exclusion bound only to the `VI` branch, and matching is case-insensitive,
so `Generated.Video` entered through `Generated.Vi`. Those tests ran in **both** `Vi-VM` and the
dedicated `Video` shard.

Measured against real VSTest with a three-class probe (`VideoTests`, `VisionTests`, `VMTests` under
`ModelFamilyTests.Generated`), listing tests per filter:

| filter | tests selected |
|---|---|
| `Vi-VM`, current | `VMTests`, **`VideoTests`**, `VisionTests` |
| `Vi-VM`, fixed | `VMTests`, `VisionTests` |
| `Video` shard | `VideoTests` |

The union across both shards is unchanged, so nothing stops running — only the duplicate goes away.
Parenthesising the alternation explicitly also makes the expression correct whichever way the
precedence question is answered, rather than depending on it.

Swept the other 115 shard filters for the same shape (an ungrouped alternation followed by an `&`
exclusion). This was the only one.
