### PR TITLE
fix(ci): retry timed-out build artifact downloads

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -1462,11 +1462,20 @@ jobs:
             nuget-${{ runner.os }}-
 
       - name: Download build artifacts
+        id: download-build-artifacts
+        continue-on-error: true
         # CAPPED. build-output is ~1.5 GB and this step has hung on it: the
         # Components/Adversarial/EndToEnd shard sat here for the full 45-minute job budget and was
         # cancelled without running a single test, which reads downstream as an unmeasured shard
         # rather than as a transfer that stalled. A cap converts that into a fast, clearly
-        # attributed failure that a rerun can fix in minutes.
+        # attributed first-attempt failure; the next step performs one bounded automatic retry.
+        timeout-minutes: 12
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v4
+        with:
+          name: build-output-${{ github.sha }}
+
+      - name: Retry build artifact download
+        if: steps.download-build-artifacts.outcome == 'failure'
         timeout-minutes: 12
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v4
         with:
@@ -2259,11 +2268,20 @@ jobs:
             nuget-${{ runner.os }}-
 
       - name: Download build artifacts
+        id: download-build-artifacts
+        continue-on-error: true
         # CAPPED. build-output is ~1.5 GB and this step has hung on it: the
         # Components/Adversarial/EndToEnd shard sat here for the full 45-minute job budget and was
         # cancelled without running a single test, which reads downstream as an unmeasured shard
         # rather than as a transfer that stalled. A cap converts that into a fast, clearly
-        # attributed failure that a rerun can fix in minutes.
+        # attributed first-attempt failure; the next step performs one bounded automatic retry.
+        timeout-minutes: 12
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v4
+        with:
+          name: build-output-${{ github.sha }}
+
+      - name: Retry build artifact download
+        if: steps.download-build-artifacts.outcome == 'failure'
         timeout-minutes: 12
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v4
         with:


### PR DESCRIPTION
## Scope

Narrow follow-up to the final PR #2054 Build & SonarCloud run (`33429474086`), stacked on PR #2056.

PR #2056 already resolves the two code/test roots from that run:
- PatchGAN serialization mismatch via Tensors 0.129.8
- WhisperLargeV3 timeout and the 22 process-guard cascade entries

The remaining failed job never ran tests: `Download build artifacts` timed out after 12 minutes in the Diffusion A-C shard.

## Change

Give each consumer of the large `build-output-${{ github.sha }}` artifact one bounded retry using the same SHA-pinned `actions/download-artifact` action.

The first attempt uses `continue-on-error` only so its pre-policy `outcome` can trigger the retry. The retry itself is not masked, so a second failure remains red.

## Proof

- `dotnet build tests\AiDotNet.Tests\AiDotNetTests.csproj -c Release -f net10.0 --no-restore -p:RunAnalyzers=false '-clp:ErrorsOnly;Summary'`: **0 errors** on the latest #2056 head
- Exact formerly failing PatchGAN serialization test: **1/1 passed**
- Entire generated PatchGAN test class: **11/11 passed**
- Original C-Core clone shard (`AIDOTNET_SWEEP_SHARD=21`): **24/24 passed in 18s**
- YAML parse: **13 jobs loaded**
- Structural assertions: exactly the two build-artifact consumers have an identical 12-minute retry; only the first attempt is masked; retry failure remains fatal
- `git diff --check`: passed

## Adversarial review

- First download succeeds: retry condition is false, so there is no added transfer or runtime.
- First download fails/times out: GitHub exposes `steps.<id>.outcome` before `continue-on-error`, so the retry runs.
- Retry fails/times out: it has no `continue-on-error`, so the job still fails loudly.
- No model, generator, clone-harness, test, or package files are changed.

Depends on #2056.