### PR TITLE
fix(ci): make impact selection and exact-tree reuse effective

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -114,28 +114,40 @@ jobs:
       contents: read
       pull-requests: read
     outputs:
-      run_id: ${{ steps.resolve.outputs.run_id }}
-      pr_number: ${{ steps.resolve.outputs.pr_number }}
-      tested_sha: ${{ steps.resolve.outputs.tested_sha }}
-      reuse: ${{ steps.resolve.outputs.reuse }}
+      run_id: ${{ steps.resolve.outputs.run_id || steps.defaults.outputs.run_id }}
+      pr_number: ${{ steps.resolve.outputs.pr_number || steps.defaults.outputs.pr_number }}
+      tested_sha: ${{ steps.resolve.outputs.tested_sha || steps.defaults.outputs.tested_sha }}
+      reuse: ${{ steps.resolve.outputs.reuse || steps.defaults.outputs.reuse }}
+      # JSON boolean, consumed through fromJSON at every expensive job boundary. A missing or
+      # malformed value fails the workflow instead of accidentally authorizing a skip.
+      execute_expensive: ${{ steps.resolve.outputs.execute_expensive || steps.defaults.outputs.execute_expensive }}
 
     steps:
+      - name: Initialize fail-closed validation decision
+        id: defaults
+        shell: bash
+        run: |
+          {
+            echo 'run_id='
+            echo 'pr_number='
+            echo 'tested_sha='
+            echo 'reuse=false'
+            echo 'execute_expensive=true'
+          } >> "$GITHUB_OUTPUT"
+
       - name: Resolve exact-tree PR run
         id: resolve
-        if: github.event_name == 'push'
+        continue-on-error: true
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -uo pipefail
 
-          # Empty output is deliberately the safe default: downstream jobs perform full CI.
-          {
-            echo 'run_id='
-            echo 'pr_number='
-            echo 'tested_sha='
-            echo 'reuse=false'
-          } >> "$GITHUB_OUTPUT"
+          if [ "$GITHUB_EVENT_NAME" != 'push' ]; then
+            echo "Event '$GITHUB_EVENT_NAME' requires normal validation." >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
 
           if ! pulls_json=$(gh api \
             -H 'Accept: application/vnd.github+json' \
@@ -211,12 +223,22 @@ jobs:
               "repos/${GITHUB_REPOSITORY}/actions/runs/${run_id}/artifacts?per_page=100" 2>/dev/null || true)
             [ -n "$artifacts_json" ] || continue
 
-            analysis_id=$(jq -r --arg expected "ci-test-analysis-${head_sha}" '
-              [.[] | .artifacts[]? | select(.expired == false and .name == $expected)]
+            # A pull_request run keys this artifact by the PR head; a merge_group run keys it by
+            # the queue commit. There is exactly one analysis artifact per run, and the downloaded
+            # payload plus certificate are both bound to tested_sha below, so discovery need not
+            # guess which event produced the candidate.
+            analysis_id=$(jq -r '
+              [.[] | .artifacts[]? |
+                select(.expired == false and (.name | startswith("ci-test-analysis-")))]
+              | sort_by(.created_at) | reverse | .[0].id // empty
+            ' <<< "$artifacts_json")
+            certificate_id=$(jq -r '
+              [.[] | .artifacts[]? |
+                select(.expired == false and (.name | startswith("ci-validation-certificate-")))]
               | sort_by(.created_at) | reverse | .[0].id // empty
             ' <<< "$artifacts_json")
             coverage_count=$(jq '[.[] | .artifacts[]? | select(.expired == false and (.name | startswith("coverage-")))] | length' <<< "$artifacts_json")
-            if [ -z "$analysis_id" ] || [ "$coverage_count" -eq 0 ]; then
+            if [ -z "$analysis_id" ] || [ -z "$certificate_id" ] || [ "$coverage_count" -eq 0 ]; then
               continue
             fi
 
@@ -228,6 +250,20 @@ jobs:
             [ -n "$entry" ] || continue
             tested_sha=$(unzip -p "$archive" "$entry" | jq -r '.source.commitSha // empty')
             [ -n "$tested_sha" ] || continue
+
+            certificate_archive="$RUNNER_TEMP/ci-validation-certificate-${run_id}.zip"
+            if ! gh api "repos/${GITHUB_REPOSITORY}/actions/artifacts/${certificate_id}/zip" > "$certificate_archive"; then
+              continue
+            fi
+            certificate_entry=$(unzip -Z1 "$certificate_archive" | awk '/(^|\/)validation-certificate\.json$/ { print; exit }')
+            [ -n "$certificate_entry" ] || continue
+            if ! unzip -p "$certificate_archive" "$certificate_entry" | jq -e \
+                 --arg run "$run_id" --arg sha "$tested_sha" \
+                 '.schemaVersion == 1 and (.runId | tostring) == $run and .testedSha == $sha and
+                  (.event == "pull_request" or .event == "merge_group") and .ciGateConclusion == "success"' \
+                 >/dev/null; then
+              continue
+            fi
             tested_tree=$(gh api "repos/${GITHUB_REPOSITORY}/git/commits/${tested_sha}" --jq '.tree.sha' 2>/dev/null || true)
 
             if [ -n "$tested_tree" ] && [ "$tested_tree" = "$master_tree" ]; then
@@ -236,6 +272,7 @@ jobs:
                 echo "pr_number=$pr_number"
                 echo "tested_sha=$tested_sha"
                 echo 'reuse=true'
+                echo 'execute_expensive=false'
               } >> "$GITHUB_OUTPUT"
               echo "Reusing PR #${pr_number} run ${run_id}; tested tree ${tested_tree} exactly matches master." >> "$GITHUB_STEP_SUMMARY"
               return 0
@@ -268,17 +305,24 @@ jobs:
             sleep 60
           done
 
+      - name: Report resolver fallback
+        if: steps.resolve.outcome == 'failure'
+        run: |
+          echo '::warning::exact-tree resolver failed unexpectedly; fail-closed defaults authorize full validation'
+          echo 'Resolver failure: full validation remains enabled.' >> "$GITHUB_STEP_SUMMARY"
+
   # CodeQL runs on Ubuntu with net10.0 only - parallel with SonarCloud
   # Runs on PRs, merge groups, pushes to master/main, and the weekly security schedule.
   codeql:
     name: CodeQL Analysis
     runs-on: ubuntu-latest
+    needs: validation-source
     # The traced net10 build takes about 31 minutes on generated-source-heavy PRs. The #2032
     # analysis was still running when the 60-minute ceiling cancelled it, while master's #2026
     # baseline completed in 57:48. Give extraction, SARIF generation, and upload enough margin
     # for normal hosted-runner variance without hiding a genuinely hung job.
     timeout-minutes: 75
-    if: "${{ (github.event.pull_request.draft != true) && !startsWith(github.head_ref, 'release-please--') && !(github.event_name == 'push' && startsWith(github.event.head_commit.message, 'chore(master): release')) }}"
+    if: "${{ fromJSON(needs.validation-source.outputs.execute_expensive) && (github.event.pull_request.draft != true) && !startsWith(github.head_ref, 'release-please--') && !(github.event_name == 'push' && startsWith(github.event.head_commit.message, 'chore(master): release')) }}"
     permissions:
       contents: read
       security-events: write
@@ -344,11 +388,12 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
+    needs: validation-source
     timeout-minutes: 45
     permissions:
       contents: read
       actions: write
-    if: "${{ (github.event.pull_request.draft != true) && !startsWith(github.head_ref, 'release-please--') && !(github.event_name == 'push' && startsWith(github.event.head_commit.message, 'chore(master): release')) }}"
+    if: "${{ fromJSON(needs.validation-source.outputs.execute_expensive) && (github.event.pull_request.draft != true) && !startsWith(github.head_ref, 'release-please--') && !(github.event_name == 'push' && startsWith(github.event.head_commit.message, 'chore(master): release')) }}"
 
     steps:
       - name: Checkout code
@@ -496,7 +541,7 @@ jobs:
       contents: read
       actions: write
     needs: validation-source
-    if: "${{ (github.event_name != 'push' || needs.validation-source.outputs.reuse != 'true') && (github.event.pull_request.draft != true) && !startsWith(github.head_ref, 'release-please--') && !(github.event_name == 'push' && startsWith(github.event.head_commit.message, 'chore(master): release')) }}"
+    if: "${{ fromJSON(needs.validation-source.outputs.execute_expensive) && (github.event.pull_request.draft != true) && !startsWith(github.head_ref, 'release-please--') && !(github.event_name == 'push' && startsWith(github.event.head_commit.message, 'chore(master): release')) }}"
 
     steps:
       - name: Checkout code
@@ -587,6 +632,8 @@ jobs:
   select-shards:
     name: Select shards
     runs-on: ubuntu-latest
+    needs: validation-source
+    if: "${{ fromJSON(needs.validation-source.outputs.execute_expensive) && (github.event.pull_request.draft != true) && !startsWith(github.head_ref, 'release-please--') && !(github.event_name == 'push' && startsWith(github.event.head_commit.message, 'chore(master): release')) }}"
     # The whole test matrix waits on this job through `needs`, and it makes uncapped network calls
     # (gh run list, gh run download). Without a cap it inherits the 360-minute default, so one
     # stalled artifact download parks all 116 shards for six hours.
@@ -618,33 +665,65 @@ jobs:
         continue-on-error: true
         env:
           GH_TOKEN: ${{ github.token }}
+          INPUT_MAP_RUN_ID: ${{ inputs.test_impact_map_run_id }}
+          FORCE_COVERAGE: ${{ inputs.collect_coverage_everywhere }}
         run: |
-          # The map is published by test-impact-map.yml on a schedule. Absent, stale or
-          # unreadable are all handled the same way downstream: run everything.
-          # `|| true`: bash steps run with `set -e`, and gh exits non-zero when the workflow does
-          # not exist yet - which is the normal state until test-impact-map.yml reaches master.
-          # Without this the step dies before reaching the message explaining why there is no map.
-          run_id=$(gh run list --workflow test-impact-map.yml --branch master                      --status success --limit 1 --json databaseId --jq '.[0].databaseId // empty' 2>/dev/null || true)
+          # Normal PRs may consume only an audited/certified map. The forced full-coverage run is
+          # different: it consumes the exact candidate named by its dispatch input so that the next
+          # map invocation can audit that candidate against the complete outcome set.
+          rm -rf map map-probe
+          run_id=''
+          kind=''
+          if [ "$FORCE_COVERAGE" = 'true' ]; then
+            case "${INPUT_MAP_RUN_ID:-}" in
+              '')
+                echo 'bootstrap coverage run has no candidate map in effect'
+                ;;
+              *[!0-9]*)
+                echo '::warning::test_impact_map_run_id is not numeric - running without a candidate map'
+                ;;
+              *)
+                if gh run download "$INPUT_MAP_RUN_ID" --repo "$GITHUB_REPOSITORY" \
+                     --name candidate-shard-map --dir map; then
+                  run_id="$INPUT_MAP_RUN_ID"
+                  kind='candidate'
+                else
+                  echo "::warning::candidate map from run $INPUT_MAP_RUN_ID is unavailable"
+                  rm -rf map
+                fi
+                ;;
+            esac
+          else
+            candidates=$(gh run list --repo "$GITHUB_REPOSITORY" --workflow test-impact-map.yml \
+              --branch master --status success --limit 20 --json databaseId \
+              --jq '.[].databaseId' 2>/dev/null || true)
+            for candidate in $candidates; do
+              rm -rf map-probe
+              if gh run download "$candidate" --repo "$GITHUB_REPOSITORY" \
+                   --name certified-shard-map --dir map-probe >/dev/null 2>&1; then
+                mv map-probe map
+                run_id="$candidate"
+                kind='certified'
+                break
+              fi
+            done
+          fi
+
           if [ -z "$run_id" ]; then
-            echo "no successful map build found - selection will escalate to the full matrix"
-            echo "run_id=" >> "$GITHUB_OUTPUT"
-            exit 0
+            echo 'no usable map found - selection will escalate to the full matrix'
           fi
           echo "run_id=$run_id" >> "$GITHUB_OUTPUT"
-          gh run download "$run_id" --name shard-map --dir map || echo "map artifact unavailable"
+          echo "kind=$kind" >> "$GITHUB_OUTPUT"
 
       # The impact tooling's own tests, run here rather than nowhere. Two defects on this PR were caught
       # only because these exist - reading the wrong side of a diff hunk, and a staleness check that
       # silently pinned the feature off - and both looked healthy in the logs.
       #
-      # continue-on-error, deliberately: a failing self-test means the selector cannot be trusted to
-      # REDUCE the matrix, and the fallback for that is already "run everything". Failing the job
-      # instead would block every PR in the repo on a tooling bug while adding no safety, since the
-      # behaviour it forces is the behaviour escalation already gives. The error annotation below is
-      # what makes it visible.
+      # These are deterministic contract tests for checked-in CI code. Runtime uncertainty (missing
+      # map, expired artifact, unmapped line) falls back to all shards, but a broken selector or
+      # workflow contract must block the change rather than merge green with the feature disabled.
       - name: Verify the impact tooling
         id: selftest
-        continue-on-error: true
         # A HUNG self-test would otherwise burn the job's 15-minute ceiling and kill the whole
         # job before any matrix output is written; a step timeout converts it into outcome=failure,
         # which the gate below turns into a full-matrix run.
@@ -661,18 +740,21 @@ jobs:
           if ($LASTEXITCODE -ne 0) { throw 'Select-CoverageShards self-test failed' }
           ./tools/TestImpact/Measure-SelectionMiss.ps1 -SelfTest
           if ($LASTEXITCODE -ne 0) { throw 'Measure-SelectionMiss self-test failed' }
+          ./tools/TestImpact/Test-CertifiedShardMap.ps1 -SelfTest
+          if ($LASTEXITCODE -ne 0) { throw 'Test-CertifiedShardMap self-test failed' }
+          ./tools/TestImpact/Test-CiImpactWorkflow.ps1
+          if ($LASTEXITCODE -ne 0) { throw 'CI impact workflow contract failed' }
+          ./tools/TestImpact/Test-TestImpactEndToEnd.ps1
+          if ($LASTEXITCODE -ne 0) { throw 'Test-impact end-to-end proof failed' }
+          ./tools/TestImpact/Test-CiGateModes.ps1
+          if ($LASTEXITCODE -ne 0) { throw 'CI Gate mode proof failed' }
 
       - name: Select
         id: select
         shell: pwsh
         env:
-          # Both values are attacker- or typo-influenced text interpolated into code if
-          # written inline: a single quote in either would terminate the pwsh literal - a
-          # repo VARIABLE with a quote would brick every run of this job, and the dispatch
-          # input is a script-injection vector with the job token in scope (the map workflow
-          # already passes its equivalent as env for exactly this reason). Env is data.
-          TEST_IMPACT_MODE: ${{ vars.TEST_IMPACT_MODE }}
-          INPUT_MAP_RUN_ID: ${{ inputs.test_impact_map_run_id }}
+          MAP_KIND: ${{ steps.map.outputs.kind }}
+          MAP_RUN_ID: ${{ steps.map.outputs.run_id }}
         run: |
           $all = @(yq -o=json -I=0 '.shard' .github/test-shards.yml | ConvertFrom-Json)
           if ($all.Count -eq 0) {
@@ -703,6 +785,22 @@ jobs:
           # selecting a master delta here would create a second, weaker reuse mechanism.
           $selectorTrusted = '${{ steps.selftest.outcome }}' -eq 'success'
           $eventCanReduce  = '${{ github.event_name }}' -eq 'pull_request'
+          $mapCertified = $false
+
+          if ($env:MAP_KIND -eq 'certified' -and (Test-Path map/shard-map.json) -and
+              (Test-Path map/certification.json)) {
+            try {
+              & ./tools/TestImpact/Test-CertifiedShardMap.ps1 `
+                  -MapFile map/shard-map.json `
+                  -CertificateFile map/certification.json `
+                  -CertificationRunId ([long] $env:MAP_RUN_ID)
+              if ($LASTEXITCODE -ne 0) { throw "certificate validator exited $LASTEXITCODE" }
+              $mapCertified = $true
+            }
+            catch {
+              Write-Host "::warning::certified map provenance is invalid ($($_.Exception.Message)) - running the full matrix"
+            }
+          }
 
           if (-not $selectorTrusted) {
             Write-Host '::error::the impact tooling failed its own self-test - running the full matrix.'
@@ -710,7 +808,7 @@ jobs:
           elseif (-not $eventCanReduce) {
             Write-Host "event is '${{ github.event_name }}', not a pull request - running the full matrix"
           }
-          elseif (Test-Path map/shard-map.json) {
+          elseif ($mapCertified) {
             # No base ref: the diff is taken from the map's own commit, which is the only
             # reference whose line numbers the map's ranges are expressed in.
             & ./tools/TestImpact/Select-Shards.ps1 `
@@ -722,7 +820,7 @@ jobs:
             $selected = @($result.shards)
           }
           else {
-            Write-Host '::warning::no shard map - running the full matrix'
+            Write-Host '::warning::no certified shard map - running the full matrix'
           }
 
           if ($escalate) {
@@ -752,30 +850,6 @@ jobs:
 
           # Empty is uncertainty, not permission to run nothing. Preserve the fail-safe contract
           # even if a future selector regression reaches this second line of defence.
-          # SHADOW MODE, and it is the default on purpose.
-          #
-          # The reduced path cannot be exercised before this merges: the map is published by
-          # test-impact-map.yml, which cannot run until it is on master, so every run here
-          # escalates and the first real reduction would otherwise happen in production. Shadow
-          # mode closes that gap - selection is computed and reported exactly as it would be, and
-          # then the FULL matrix runs anyway. Zero risk, and it produces the one thing missing:
-          # real data on what selection would have skipped, which Measure-SelectionMiss checks
-          # against what actually failed.
-          #
-          # Set the repository variable TEST_IMPACT_MODE to 'enforce' once that data supports it.
-          # Any other value, including unset, means shadow.
-          $mode = [string] $env:TEST_IMPACT_MODE
-          if ($mode -ne 'enforce') {
-            $wouldRun = $matrixShards.Count
-            $shadowNote = if ($escalate) { "would have escalated to all $($all.Count)" }
-                          else { "would have run $wouldRun of $($all.Count)" }
-            Write-Host "shadow mode (TEST_IMPACT_MODE='$mode'): $shadowNote - running the full matrix anyway"
-            "### Shard selection (shadow)`n`n$shadowNote. Set the repository variable ``TEST_IMPACT_MODE`` to ``enforce`` to act on this." |
-              Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8
-            $matrixShards = $all
-            $escalate = $true
-          }
-
           if ($matrixShards.Count -eq 0) {
             Write-Host '::warning::shard selection produced an empty matrix - running the full matrix'
             $matrixShards = $all
@@ -881,12 +955,9 @@ jobs:
             "### Incremental instrumentation`n`ncarrying $($carried.Count) shard(s) forward; instrumenting the rest." |
               Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8
 
-            $mapRunId = [string] $env:INPUT_MAP_RUN_ID
-            if ($mapRunId -and $mapRunId -notmatch '^[0-9]+$') {
-              Write-Host "::warning::test_impact_map_run_id is not numeric - ignoring it"
-              $mapRunId = ''
-            }
-            if (-not $mapRunId) { $mapRunId = '${{ steps.map.outputs.run_id }}' }
+            # Record only the map that was actually downloaded and validated by the preceding
+            # step. Never copy the raw dispatch input into provenance when its artifact was absent.
+            $mapRunId = [string] $env:MAP_RUN_ID
             [ordered]@{
               schemaVersion = 1
               forcedCoverage = $true
@@ -935,7 +1006,7 @@ jobs:
     permissions:
       actions: read
       contents: read
-    if: "${{ (github.event_name != 'push' || needs.validation-source.outputs.reuse != 'true') && (github.event.pull_request.draft != true) && !startsWith(github.head_ref, 'release-please--') && !(github.event_name == 'push' && startsWith(github.event.head_commit.message, 'chore(master): release')) }}"
+    if: "${{ fromJSON(needs.validation-source.outputs.execute_expensive) && (github.event.pull_request.draft != true) && !startsWith(github.head_ref, 'release-please--') && !(github.event_name == 'push' && startsWith(github.event.head_commit.message, 'chore(master): release')) }}"
     strategy:
       fail-fast: false
       max-parallel: ${{ inputs.collect_coverage_everywhere && 12 || 20 }}
@@ -1609,7 +1680,7 @@ jobs:
     # entirely -- on a push github.head_ref is empty, so this job ran on release
     # commits while every other job skipped, building the whole solution and
     # holding a runner for up to 60 minutes to do it.
-    if: "${{ (github.event_name != 'push' || needs.validation-source.outputs.reuse != 'true') && (github.event.pull_request.draft != true) && !startsWith(github.head_ref, 'release-please--') && !(github.event_name == 'push' && startsWith(github.event.head_commit.message, 'chore(master): release')) }}"
+    if: "${{ fromJSON(needs.validation-source.outputs.execute_expensive) && (github.event.pull_request.draft != true) && !startsWith(github.head_ref, 'release-please--') && !(github.event_name == 'push' && startsWith(github.event.head_commit.message, 'chore(master): release')) }}"
     # NO continue-on-error. It made the guards below decorative: the step printed
     # `::error::Sweep harness failed to START` and exited 1, and the job was marked
     # green anyway -- the loud failure those guards promise could never be heard.
@@ -1794,7 +1865,7 @@ jobs:
     # every concrete contract runs in a bounded child process and must agree with Predict. That makes
     # a window containing only honest declines valid while preserving strict failure for a mismatch,
     # crash, timeout, or unconstructable claimed contract.
-    if: "${{ (github.event_name != 'push' || needs.validation-source.outputs.reuse != 'true') && (github.event.pull_request.draft != true) && !startsWith(github.head_ref, 'release-please--') && !(github.event_name == 'push' && startsWith(github.event.head_commit.message, 'chore(master): release')) }}"
+    if: "${{ fromJSON(needs.validation-source.outputs.execute_expensive) && (github.event.pull_request.draft != true) && !startsWith(github.head_ref, 'release-please--') && !(github.event_name == 'push' && startsWith(github.event.head_commit.message, 'chore(master): release')) }}"
     strategy:
       fail-fast: false
       matrix:
@@ -1927,7 +1998,7 @@ jobs:
     name: Test regression analysis
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    if: "${{ always() && (github.event_name != 'push' || needs.validation-source.outputs.reuse != 'true') && (github.event.pull_request.draft != true) && !startsWith(github.head_ref, 'release-please--') && !(github.event_name == 'push' && startsWith(github.event.head_commit.message, 'chore(master): release')) }}"
+    if: "${{ always() && fromJSON(needs.validation-source.outputs.execute_expensive) && (github.event.pull_request.draft != true) && !startsWith(github.head_ref, 'release-please--') && !(github.event_name == 'push' && startsWith(github.event.head_commit.message, 'chore(master): release')) }}"
     needs:
       - build
       - test-net10-sharded
@@ -2181,12 +2252,13 @@ jobs:
     # check leaves the gate unsatisfied and every PR reads BLOCKED. That made "all 158 shards
     # green" the de facto merge bar via a `needs:` edge rather than a stated policy.
     #
-    # SonarCloud is code-quality analysis, not a test gate. It consumes coverage from either this
-    # validation or an exact-tree certified PR run, and those artifacts are uploaded whether a
-    # shard passed or failed. Test outcomes are gated explicitly by `ci-gate` below.
+    # SonarCloud is code-quality analysis, not a test gate. It consumes coverage from this
+    # validation, and those artifacts are uploaded whether a shard passed or failed. An exact-tree
+    # master push does not repeat the PR analysis; the scheduled full run refreshes default-branch
+    # analysis independently. Test outcomes are gated explicitly by `ci-gate` below.
     #
     # The build IS still required: without its artifacts the analysis would be meaningless.
-    if: "${{ always() && needs.build.result == 'success' && (github.event.pull_request.draft != true) && !startsWith(github.head_ref, 'release-please--') && !(github.event_name == 'push' && startsWith(github.event.head_commit.message, 'chore(master): release')) }}"
+    if: "${{ always() && fromJSON(needs.validation-source.outputs.execute_expensive) && needs.build.result == 'success' && (github.event.pull_request.draft != true) && !startsWith(github.head_ref, 'release-please--') && !(github.event_name == 'push' && startsWith(github.event.head_commit.message, 'chore(master): release')) }}"
     needs:
       - build
       - test-net10-sharded
@@ -2240,21 +2312,9 @@ jobs:
           dotnet tool update dotnet-sonarscanner --tool-path ${{ runner.temp }}/scanner
 
       - name: Download current-run coverage artifacts
-        if: needs.validation-source.outputs.reuse != 'true'
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v4
         with:
           pattern: coverage-${{ github.sha }}-*
-          path: TestResults
-          merge-multiple: true
-
-      - name: Download certified PR coverage artifacts
-        if: needs.validation-source.outputs.reuse == 'true'
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v4
-        with:
-          github-token: ${{ github.token }}
-          repository: ${{ github.repository }}
-          run-id: ${{ needs.validation-source.outputs.run_id }}
-          pattern: coverage-*
           path: TestResults
           merge-multiple: true
 
@@ -2326,7 +2386,7 @@ jobs:
 
   # Artifact size analysis
   size-check:
-    if: "${{ (github.event_name != 'push' || needs.validation-source.outputs.reuse != 'true') && !startsWith(github.head_ref, 'release-please--') && !(github.event_name == 'push' && startsWith(github.event.head_commit.message, 'chore(master): release')) }}"
+    if: "${{ fromJSON(needs.validation-source.outputs.execute_expensive) && !startsWith(github.head_ref, 'release-please--') && !(github.event_name == 'push' && startsWith(github.event.head_commit.message, 'chore(master): release')) }}"
     name: Artifact Size Check
     runs-on: ubuntu-latest
     needs: [build, validation-source]
@@ -2392,7 +2452,7 @@ jobs:
     name: Test analysis (aggregate)
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    if: "${{ always() && (github.event_name != 'push' || needs.validation-source.outputs.reuse != 'true') && (github.event.pull_request.draft != true) && !startsWith(github.head_ref, 'release-please--') && !(github.event_name == 'push' && startsWith(github.event.head_commit.message, 'chore(master): release')) }}"
+    if: "${{ always() && fromJSON(needs.validation-source.outputs.execute_expensive) && (github.event.pull_request.draft != true) && !startsWith(github.head_ref, 'release-please--') && !(github.event_name == 'push' && startsWith(github.event.head_commit.message, 'chore(master): release')) }}"
     needs:
       - test-net10-sharded
       - validation-source
@@ -2601,11 +2661,16 @@ jobs:
     if: "${{ always() && (github.event.pull_request.draft != true) && !startsWith(github.head_ref, 'release-please--') && !(github.event_name == 'push' && startsWith(github.event.head_commit.message, 'chore(master): release')) }}"
     needs:
       - validation-source
+      - codeql
       - build
       - build-compat
+      - select-shards
       - test-net10-sharded
+      - parameter-enumeration-sweep
+      - model-shape-conformance-windows
       - test-regression-analysis
       - ci-test-analysis
+      - size-check
       - promote-ci-test-analysis
       - sonarcloud
 
@@ -2614,10 +2679,15 @@ jobs:
         env:
           BUILD_RESULT: ${{ needs.build.result }}
           BUILD_COMPAT_RESULT: ${{ needs.build-compat.result }}
+          CODEQL_RESULT: ${{ needs.codeql.result }}
+          SELECT_RESULT: ${{ needs.select-shards.result }}
           TESTS_RESULT: ${{ needs.test-net10-sharded.result }}
+          PARAMETER_SWEEP_RESULT: ${{ needs.parameter-enumeration-sweep.result }}
+          MODEL_SHAPE_RESULT: ${{ needs.model-shape-conformance-windows.result }}
           REGRESSION_ANALYSIS_RESULT: ${{ needs.test-regression-analysis.result }}
           VERDICT_ENFORCED: ${{ needs.test-regression-analysis.outputs.verdict_enforced }}
           AGGREGATE_ANALYSIS_RESULT: ${{ needs.ci-test-analysis.result }}
+          SIZE_CHECK_RESULT: ${{ needs.size-check.result }}
           PROMOTION_RESULT: ${{ needs.promote-ci-test-analysis.result }}
           SONAR_RESULT: ${{ needs.sonarcloud.result }}
           SOURCE_RESULT: ${{ needs.validation-source.result }}
@@ -2637,21 +2707,36 @@ jobs:
             echo "| Job | Result |"
             echo "|---|---|"
             echo "| validation-source | $SOURCE_RESULT |"
+            echo "| codeql | $CODEQL_RESULT |"
             echo "| build | $BUILD_RESULT |"
             echo "| build-compat | $BUILD_COMPAT_RESULT |"
+            echo "| select-shards | $SELECT_RESULT |"
             echo "| test-net10-sharded | $TESTS_RESULT |"
+            echo "| parameter-enumeration-sweep | $PARAMETER_SWEEP_RESULT |"
+            echo "| model-shape-conformance-windows | $MODEL_SHAPE_RESULT |"
             echo "| test-regression-analysis | $REGRESSION_ANALYSIS_RESULT |"
             echo "| regression verdict enforced | ${VERDICT_ENFORCED:-false} |"
             echo "| ci-test-analysis | $AGGREGATE_ANALYSIS_RESULT |"
+            echo "| size-check | $SIZE_CHECK_RESULT |"
             echo "| promote-ci-test-analysis | $PROMOTION_RESULT |"
             echo "| sonarcloud | $SONAR_RESULT |"
           } >> "$GITHUB_STEP_SUMMARY"
 
           failed=0
-          required=("validation-source:$SOURCE_RESULT" "build:$BUILD_RESULT" "build-compat:$BUILD_COMPAT_RESULT" "sonarcloud:$SONAR_RESULT")
+          required=("validation-source:$SOURCE_RESULT")
           if [ "$REUSED_VALIDATION" = "true" ]; then
             required+=("promote-ci-test-analysis:$PROMOTION_RESULT")
           else
+            required+=(
+              "codeql:$CODEQL_RESULT"
+              "build:$BUILD_RESULT"
+              "build-compat:$BUILD_COMPAT_RESULT"
+              "select-shards:$SELECT_RESULT"
+              "parameter-enumeration-sweep:$PARAMETER_SWEEP_RESULT"
+              "model-shape-conformance-windows:$MODEL_SHAPE_RESULT"
+              "size-check:$SIZE_CHECK_RESULT"
+              "sonarcloud:$SONAR_RESULT"
+            )
             # The exact-base regression analyzer is authoritative when it could recover the
             # baseline ledger. This lets known master failures remain informational while still
             # failing on PR-new unique failures. If the exact baseline is unavailable, require the
@@ -2681,5 +2766,48 @@ jobs:
 
           echo "" >> "$GITHUB_STEP_SUMMARY"
           echo "**Gate PASSED** - all required jobs succeeded." >> "$GITHUB_STEP_SUMMARY"
+
+  # The aggregate analysis artifact proves that tests emitted data; it does not prove validation
+  # passed. Publish a separate, run-bound certificate only after the required CI Gate succeeds.
+  # Master exact-tree reuse requires this artifact and fails closed when it is absent or malformed.
+  certify-validation:
+    name: Publish certified validation proof
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    needs: ci-gate
+    if: "${{ always() && needs.ci-gate.result == 'success' && (github.event_name == 'pull_request' || github.event_name == 'merge_group') }}"
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout tested tree
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v4
+
+      - name: Write validation certificate
+        shell: bash
+        run: |
+          set -euo pipefail
+          tree=$(git rev-parse 'HEAD^{tree}')
+          jq -n \
+            --arg runId "$GITHUB_RUN_ID" \
+            --arg testedSha "$GITHUB_SHA" \
+            --arg testedTree "$tree" \
+            --arg event "$GITHUB_EVENT_NAME" \
+            '{
+              schemaVersion: 1,
+              runId: $runId,
+              testedSha: $testedSha,
+              testedTree: $testedTree,
+              event: $event,
+              ciGateConclusion: "success"
+            }' > validation-certificate.json
+
+      - name: Upload validation certificate
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
+        with:
+          name: ci-validation-certificate-${{ github.event.pull_request.head.sha || github.sha }}
+          path: validation-certificate.json
+          if-no-files-found: error
+          retention-days: 90
 
   # NOTE: Website deployment has moved to deploy-website.yml (deploys to Vercel at aidotnet.dev)

--- a/.github/workflows/test-impact-map.yml
+++ b/.github/workflows/test-impact-map.yml
@@ -368,8 +368,10 @@ jobs:
             Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8
 
           # Escalation is safe, but it proves only the fallback. Certification authorizes actual
-          # reduction, so require a non-escalated plan that would have skipped at least one shard.
-          if ($auditExit -eq 0 -and -not [bool] $a.Escalated -and [int] $a.WouldSkip -gt 0) {
+          # reduction, so require both a non-escalated plan that would skip work and at least one
+          # failing shard that gave the audit a real opportunity to observe a selection miss.
+          if ($auditExit -eq 0 -and -not [bool] $a.Escalated -and
+              [int] $a.WouldSkip -gt 0 -and [int] $a.Failed -gt 0) {
             $previousMap = Get-Content prevmap/shard-map.json -Raw | ConvertFrom-Json
             New-Item -ItemType Directory -Path certified-map -Force | Out-Null
             Copy-Item -LiteralPath prevmap/shard-map.json -Destination certified-map/shard-map.json
@@ -390,7 +392,7 @@ jobs:
           }
           else {
             "certified=false" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
-            Write-Host 'candidate was safe but did not exercise reduction - not certifying it'
+            Write-Host 'candidate did not exercise both failure detection and reduction - not certifying it'
           }
           exit $auditExit
 

--- a/.github/workflows/test-impact-map.yml
+++ b/.github/workflows/test-impact-map.yml
@@ -31,6 +31,8 @@ jobs:
   build-map:
     name: Build and audit shard map
     runs-on: ubuntu-latest
+    outputs:
+      candidate_ready: ${{ steps.source.outputs.found }}
     permissions:
       actions: read
       contents: read
@@ -40,6 +42,18 @@ jobs:
         with:
           # The audit diffs from the map that was in effect for the source run.
           fetch-depth: 0
+
+      - name: Verify impact lifecycle contracts
+        shell: pwsh
+        run: |
+          ./tools/TestImpact/Test-CertifiedShardMap.ps1 -SelfTest
+          if ($LASTEXITCODE -ne 0) { throw 'Test-CertifiedShardMap self-test failed' }
+          ./tools/TestImpact/Test-CiImpactWorkflow.ps1
+          if ($LASTEXITCODE -ne 0) { throw 'CI impact workflow contract failed' }
+          ./tools/TestImpact/Test-TestImpactEndToEnd.ps1
+          if ($LASTEXITCODE -ne 0) { throw 'Test-impact end-to-end proof failed' }
+          ./tools/TestImpact/Test-CiGateModes.ps1
+          if ($LASTEXITCODE -ne 0) { throw 'CI Gate mode proof failed' }
 
       - name: Find a complete marked coverage run
         id: source
@@ -175,15 +189,25 @@ jobs:
           fi
 
           if [ -z "$run_id" ]; then
-            echo "::error::no recent completed run has both the coverage marker and the exact current shard matrix"
-            exit 1
+            if [ -n "${INPUT_RUN_ID:-}" ]; then
+              echo "::error::run $INPUT_RUN_ID is not a valid coverage source"
+              exit 1
+            fi
+            # First-install bootstrap is an expected state, not a broken map build. The dispatch
+            # job below seeds a complete coverage run, and the next invocation harvests it.
+            echo 'found=false' >> "$GITHUB_OUTPUT"
+            echo "::notice::no complete marked coverage run exists yet - dispatching the bootstrap source"
+            echo 'Bootstrap: no source to harvest yet; the next coverage run will seed the first candidate map.' >> "$GITHUB_STEP_SUMMARY"
+            exit 0
           fi
+          echo 'found=true' >> "$GITHUB_OUTPUT"
           echo "run_id=$run_id" >> "$GITHUB_OUTPUT"
           echo "sha=$valid_sha" >> "$GITHUB_OUTPUT"
           echo "map_run_id=$valid_map_run_id" >> "$GITHUB_OUTPUT"
           echo "harvesting run $run_id at $valid_sha (map in effect: ${valid_map_run_id:-none})"
 
       - name: Download digests
+        if: steps.source.outputs.found == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -196,6 +220,7 @@ jobs:
       # source run would stay in knownShards and remain skippable in enforce mode while red.
       # Restore the gate here: drop the carried digest of any shard whose job did not succeed.
       - name: Prune carried digests for failed shards
+        if: steps.source.outputs.found == 'true'
         shell: pwsh
         env:
           GH_TOKEN: ${{ github.token }}
@@ -228,6 +253,7 @@ jobs:
           Write-Host "carried digests: $($carried.Count), pruned: $pruned"
 
       - name: Build the map
+        if: steps.source.outputs.found == 'true'
         shell: pwsh
         run: |
           $all = @(yq -o=json -I=0 '.shard' .github/test-shards.yml | ConvertFrom-Json)
@@ -246,10 +272,11 @@ jobs:
           "### Shard map rebuilt`n`n- source run ${{ steps.source.outputs.run_id }}`n- commit ``${{ steps.source.outputs.sha }}```n- $files files indexed`n- $known shards mapped, $always always-run`n- $size MB" |
             Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8
 
-      - name: Upload the map
+      - name: Upload candidate map
+        if: steps.source.outputs.found == 'true'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
         with:
-          name: shard-map
+          name: candidate-shard-map
           path: shard-map.json
           if-no-files-found: error
           retention-days: 14
@@ -258,6 +285,7 @@ jobs:
       # this source run would make the question circular. If the audit fails, this workflow is not
       # successful and selectors will not discover the newly uploaded artifact.
       - name: Download the map that was in effect
+        if: steps.source.outputs.found == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -272,7 +300,7 @@ jobs:
               exit 1
               ;;
           esac
-          if ! gh run download "$map_run_id" --name shard-map --dir prevmap; then
+          if ! gh run download "$map_run_id" --repo "$GITHUB_REPOSITORY" --name candidate-shard-map --dir prevmap; then
             # The referenced map run exists but its artifact is gone (14-day retention). Hard-
             # failing here WEDGES the nightly permanently: this build fails, the dispatch keeps
             # citing the same last-successful run, and its artifact never comes back - reviewed and
@@ -283,12 +311,15 @@ jobs:
           fi
 
       - name: Audit selection against the source run
+        id: audit
+        if: steps.source.outputs.found == 'true'
         shell: pwsh
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           if (-not (Test-Path prevmap/shard-map.json)) {
             Write-Host 'no prior map was in effect - skipping bootstrap audit'
+            "certified=false" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
             exit 0
           }
 
@@ -335,7 +366,42 @@ jobs:
                      else { 'no misses' }
           "### Selection audit`n`n- map in effect: ${{ steps.source.outputs.map_run_id }}`n- would run $($a.WouldRun)/$($a.TotalShards), skip $($a.WouldSkip)`n- $($a.Failed) shard(s) failed`n- $verdict" |
             Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8
+
+          # Escalation is safe, but it proves only the fallback. Certification authorizes actual
+          # reduction, so require a non-escalated plan that would have skipped at least one shard.
+          if ($auditExit -eq 0 -and -not [bool] $a.Escalated -and [int] $a.WouldSkip -gt 0) {
+            $previousMap = Get-Content prevmap/shard-map.json -Raw | ConvertFrom-Json
+            New-Item -ItemType Directory -Path certified-map -Force | Out-Null
+            Copy-Item -LiteralPath prevmap/shard-map.json -Destination certified-map/shard-map.json
+            [ordered]@{
+              schemaVersion = 1
+              candidateMapRunId = [long] '${{ steps.source.outputs.map_run_id }}'
+              candidateMapSha = [string] $previousMap.sha
+              auditSourceRunId = [long] '${{ steps.source.outputs.run_id }}'
+              auditSourceSha = '${{ steps.source.outputs.sha }}'
+              certificationRunId = [long] $env:GITHUB_RUN_ID
+              escalated = [bool] $a.Escalated
+              wouldRun = [int] $a.WouldRun
+              wouldSkip = [int] $a.WouldSkip
+              failedShards = [int] $a.Failed
+              missCount = [int] $a.MissCount
+            } | ConvertTo-Json -Depth 4 | Set-Content certified-map/certification.json -Encoding utf8
+            "certified=true" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+          }
+          else {
+            "certified=false" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+            Write-Host 'candidate was safe but did not exercise reduction - not certifying it'
+          }
           exit $auditExit
+
+      - name: Upload certified map
+        if: steps.audit.outputs.certified == 'true'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
+        with:
+          name: certified-shard-map
+          path: certified-map/
+          if-no-files-found: error
+          retention-days: 14
 
   coverage-run:
     name: Dispatch next coverage-everywhere run
@@ -351,21 +417,33 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          if [ '${{ needs.build-map.result }}' = 'success' ]; then
+          if [ '${{ needs.build-map.result }}' = 'success' ] && [ '${{ needs.build-map.outputs.candidate_ready }}' = 'true' ]; then
             # This workflow is not marked successful until this dispatch job exits. Pass its id
             # explicitly so the child cannot race and record the previous successful map.
             map_run_id='${{ github.run_id }}'
           else
             # A failed build/audit is deliberately not eligible for selection. The last successful
             # artifact remains in effect, so that is the only map the next run may claim.
-            map_run_id=$(gh run list --workflow test-impact-map.yml --branch master --status success \
-              --limit 1 --json databaseId --jq '.[0].databaseId // empty' 2>/dev/null || true)
+            map_run_id=''
+            candidates=$(gh run list --repo "$GITHUB_REPOSITORY" --workflow test-impact-map.yml \
+              --branch master --status success --limit 20 --json databaseId \
+              --jq '.[].databaseId' 2>/dev/null || true)
+            for candidate in $candidates; do
+              has_candidate=$(gh api \
+                "repos/${GITHUB_REPOSITORY}/actions/runs/${candidate}/artifacts?per_page=100" \
+                --jq '[.artifacts[] | select(.expired == false and .name == "candidate-shard-map")] | length' \
+                2>/dev/null || echo 0)
+              if [ "${has_candidate:-0}" -gt 0 ]; then
+                map_run_id="$candidate"
+                break
+              fi
+            done
           fi
 
           # A dispatch while one is still running would land in the same build-coverage-map
           # concurrency group with cancel-in-progress and DESTROY hours of instrumented work -
           # the same double-dispatch trap that killed two verification runs during development.
-          inflight=$(gh run list --workflow sonarcloud.yml --branch master --event workflow_dispatch \
+          inflight=$(gh run list --repo "$GITHUB_REPOSITORY" --workflow sonarcloud.yml --branch master --event workflow_dispatch \
                        --json databaseId,status --jq '[.[] | select(.status == "queued" or .status == "in_progress")] | length' 2>/dev/null || echo 0)
           if [ "${inflight:-0}" -gt 0 ]; then
             echo "::warning::a coverage-everywhere run is already queued or running - not dispatching another"
@@ -374,9 +452,9 @@ jobs:
           fi
 
           if [ -n "$map_run_id" ]; then
-            gh workflow run sonarcloud.yml --ref master \
+            gh workflow run sonarcloud.yml --repo "$GITHUB_REPOSITORY" --ref master \
               -f collect_coverage_everywhere=true -f test_impact_map_run_id="$map_run_id"
           else
-            gh workflow run sonarcloud.yml --ref master -f collect_coverage_everywhere=true
+            gh workflow run sonarcloud.yml --repo "$GITHUB_REPOSITORY" --ref master -f collect_coverage_everywhere=true
           fi
           echo 'Dispatched the next marked coverage-everywhere run. It will be harvested on the next map invocation.' >> "$GITHUB_STEP_SUMMARY"

--- a/tools/TestImpact/Test-CertifiedShardMap.ps1
+++ b/tools/TestImpact/Test-CertifiedShardMap.ps1
@@ -1,6 +1,6 @@
 <#
 .SYNOPSIS
-    Validates that a shard map carries a zero-miss audit certificate from its artifact run.
+    Validates that a shard map carries a failure-bearing, zero-miss audit certificate from its run.
 #>
 [CmdletBinding(DefaultParameterSetName = 'Validate')]
 param(
@@ -35,41 +35,47 @@ function Assert-CertifiedShardMap {
     }
     foreach ($name in 'schemaVersion', 'candidateMapRunId', 'candidateMapSha',
         'auditSourceRunId', 'auditSourceSha', 'certificationRunId', 'escalated',
-        'wouldRun', 'wouldSkip', 'missCount') {
+        'wouldRun', 'wouldSkip', 'failedShards', 'missCount') {
         if (-not $Certificate.PSObject.Properties[$name]) { throw "certificate is missing $name" }
     }
 
-    $schema = ConvertTo-RequiredInteger $Certificate.schemaVersion 'certificate schemaVersion' 1
+    $schema = ConvertTo-RequiredInteger -Value $Certificate.schemaVersion -Name 'certificate schemaVersion' -Minimum 1
     if ($schema -ne 1) { throw "unsupported certification schema $schema" }
-    $actualRun = ConvertTo-RequiredInteger $Certificate.certificationRunId 'certificationRunId' 1
+    $actualRun = ConvertTo-RequiredInteger -Value $Certificate.certificationRunId -Name 'certificationRunId' -Minimum 1
     if ($actualRun -ne $ExpectedCertificationRunId) {
         throw "certificate belongs to run $actualRun, not artifact run $ExpectedCertificationRunId"
     }
-    [void] (ConvertTo-RequiredInteger $Certificate.candidateMapRunId 'candidateMapRunId' 1)
-    [void] (ConvertTo-RequiredInteger $Certificate.auditSourceRunId 'auditSourceRunId' 1)
-    $misses = ConvertTo-RequiredInteger $Certificate.missCount 'missCount'
+    [void] (ConvertTo-RequiredInteger -Value $Certificate.candidateMapRunId -Name 'candidateMapRunId' -Minimum 1)
+    [void] (ConvertTo-RequiredInteger -Value $Certificate.auditSourceRunId -Name 'auditSourceRunId' -Minimum 1)
+    $misses = ConvertTo-RequiredInteger -Value $Certificate.missCount -Name 'missCount'
     if ($misses -ne 0) { throw "certificate records $misses selection miss(es)" }
     if ($Certificate.escalated -isnot [bool]) { throw 'escalated must be a JSON boolean' }
     if ([bool] $Certificate.escalated) { throw 'certificate records an escalated plan, not reduction' }
-    [void] (ConvertTo-RequiredInteger $Certificate.wouldRun 'wouldRun' 1)
-    [void] (ConvertTo-RequiredInteger $Certificate.wouldSkip 'wouldSkip' 1)
+    [void] (ConvertTo-RequiredInteger -Value $Certificate.wouldRun -Name 'wouldRun' -Minimum 1)
+    [void] (ConvertTo-RequiredInteger -Value $Certificate.wouldSkip -Name 'wouldSkip' -Minimum 1)
+    [void] (ConvertTo-RequiredInteger -Value $Certificate.failedShards -Name 'failedShards' -Minimum 1)
 
     $mapSha = [string] $Map.sha
     $candidateSha = [string] $Certificate.candidateMapSha
-    if ($mapSha -notmatch '^[0-9a-f]{40}$') { throw 'map sha is not a full lowercase commit id' }
+    if ($mapSha -cnotmatch '^[0-9a-f]{40}$') { throw 'map sha is not a full lowercase commit id' }
     if ($candidateSha -cne $mapSha) { throw 'certificate and map identify different source commits' }
-    if ([string] $Certificate.auditSourceSha -notmatch '^[0-9a-f]{40}$') {
+    if ([string] $Certificate.auditSourceSha -cnotmatch '^[0-9a-f]{40}$') {
         throw 'auditSourceSha is not a full lowercase commit id'
     }
 }
 
 if ($SelfTest) {
     $failures = [System.Collections.Generic.List[string]]::new()
-    function Assert-Throws {
-        param([scriptblock] $Action, [string] $What)
-        $threw = $false
-        try { & $Action } catch { $threw = $true }
-        if (-not $threw) { [void] $failures.Add($What) }
+    function Assert-Rejection {
+        param([scriptblock] $Action, [string] $What, [string] $ExpectedPattern)
+        $message = $null
+        try { & $Action } catch { $message = [string] $_.Exception.Message }
+        if ($null -eq $message) {
+            [void] $failures.Add($What)
+        }
+        elseif ($message -notmatch $ExpectedPattern) {
+            [void] $failures.Add("$What (rejected for the wrong reason: $message)")
+        }
     }
 
     $sha = '0123456789abcdef0123456789abcdef01234567'
@@ -84,26 +90,47 @@ if ($SelfTest) {
         escalated = $false
         wouldRun = 2
         wouldSkip = 1
+        failedShards = 1
         missCount = 0
     }
-    try { Assert-CertifiedShardMap $map $certificate 12 } catch {
+    try {
+        Assert-CertifiedShardMap -Map $map -Certificate $certificate -ExpectedCertificationRunId 12
+    }
+    catch {
         [void] $failures.Add("valid certificate rejected: $($_.Exception.Message)")
     }
 
     $bad = $certificate.PSObject.Copy(); $bad.missCount = 1
-    Assert-Throws { Assert-CertifiedShardMap $map $bad 12 } 'a miss-bearing certificate was accepted'
+    Assert-Rejection { Assert-CertifiedShardMap $map $bad 12 } `
+        'a miss-bearing certificate was accepted' 'selection miss'
     $bad = $certificate.PSObject.Copy(); $bad.certificationRunId = 99
-    Assert-Throws { Assert-CertifiedShardMap $map $bad 12 } 'a certificate from another run was accepted'
+    Assert-Rejection { Assert-CertifiedShardMap $map $bad 12 } `
+        'a certificate from another run was accepted' 'certificate belongs to run'
     $bad = $certificate.PSObject.Copy(); $bad.candidateMapSha = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
-    Assert-Throws { Assert-CertifiedShardMap $map $bad 12 } 'a certificate for another map was accepted'
+    Assert-Rejection { Assert-CertifiedShardMap $map $bad 12 } `
+        'a certificate for another map was accepted' 'different source commits'
     $bad = $certificate.PSObject.Copy(); $bad.escalated = $true
-    Assert-Throws { Assert-CertifiedShardMap $map $bad 12 } 'an escalated plan was accepted as reduction proof'
+    Assert-Rejection { Assert-CertifiedShardMap $map $bad 12 } `
+        'an escalated plan was accepted as reduction proof' 'escalated plan'
     $bad = $certificate.PSObject.Copy(); $bad.escalated = 'false'
-    Assert-Throws { Assert-CertifiedShardMap $map $bad 12 } 'a stringly typed escalation flag was accepted'
+    Assert-Rejection { Assert-CertifiedShardMap $map $bad 12 } `
+        'a stringly typed escalation flag was accepted' 'JSON boolean'
     $bad = $certificate.PSObject.Copy(); $bad.wouldSkip = 0
-    Assert-Throws { Assert-CertifiedShardMap $map $bad 12 } 'a plan that skipped nothing was accepted as reduction proof'
+    Assert-Rejection { Assert-CertifiedShardMap $map $bad 12 } `
+        'a plan that skipped nothing was accepted as reduction proof' 'wouldSkip must be at least 1'
+    $bad = $certificate.PSObject.Copy(); $bad.failedShards = 0
+    Assert-Rejection { Assert-CertifiedShardMap $map $bad 12 } `
+        'a certificate without a failure opportunity was accepted' 'failedShards must be at least 1'
+    $badMap = $map.PSObject.Copy(); $badMap.sha = $sha.ToUpperInvariant()
+    $bad = $certificate.PSObject.Copy(); $bad.candidateMapSha = $badMap.sha
+    Assert-Rejection { Assert-CertifiedShardMap $badMap $bad 12 } `
+        'an uppercase map commit ID was accepted' 'map sha is not a full lowercase commit id'
+    $bad = $certificate.PSObject.Copy(); $bad.auditSourceSha = $bad.auditSourceSha.ToUpperInvariant()
+    Assert-Rejection { Assert-CertifiedShardMap $map $bad 12 } `
+        'an uppercase audit source commit ID was accepted' 'auditSourceSha is not a full lowercase commit id'
     $bad = $certificate.PSObject.Copy(); $bad.PSObject.Properties.Remove('auditSourceRunId')
-    Assert-Throws { Assert-CertifiedShardMap $map $bad 12 } 'an incomplete certificate was accepted'
+    Assert-Rejection { Assert-CertifiedShardMap $map $bad 12 } `
+        'an incomplete certificate was accepted' 'certificate is missing auditSourceRunId'
 
     if ($failures.Count -gt 0) {
         Write-Host 'Certified shard-map self-test FAILED:'
@@ -118,3 +145,4 @@ $mapObject = Get-Content -LiteralPath $MapFile -Raw | ConvertFrom-Json
 $certificateObject = Get-Content -LiteralPath $CertificateFile -Raw | ConvertFrom-Json
 Assert-CertifiedShardMap $mapObject $certificateObject $CertificationRunId
 Write-Host "certified map provenance is valid for run $CertificationRunId"
+exit 0

--- a/tools/TestImpact/Test-CertifiedShardMap.ps1
+++ b/tools/TestImpact/Test-CertifiedShardMap.ps1
@@ -1,0 +1,120 @@
+<#
+.SYNOPSIS
+    Validates that a shard map carries a zero-miss audit certificate from its artifact run.
+#>
+[CmdletBinding(DefaultParameterSetName = 'Validate')]
+param(
+    [Parameter(Mandatory, ParameterSetName = 'Validate')] [string] $MapFile,
+    [Parameter(Mandatory, ParameterSetName = 'Validate')] [string] $CertificateFile,
+    [Parameter(Mandatory, ParameterSetName = 'Validate')] [long] $CertificationRunId,
+    [Parameter(Mandatory, ParameterSetName = 'SelfTest')] [switch] $SelfTest
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+function ConvertTo-RequiredInteger {
+    param([object] $Value, [string] $Name, [long] $Minimum = 0)
+    $parsed = 0L
+    if ($null -eq $Value -or -not [long]::TryParse(
+        [string] $Value,
+        [Globalization.NumberStyles]::Integer,
+        [Globalization.CultureInfo]::InvariantCulture,
+        [ref] $parsed)) {
+        throw "$Name must be an integer"
+    }
+    if ($parsed -lt $Minimum) { throw "$Name must be at least $Minimum" }
+    return $parsed
+}
+
+function Assert-CertifiedShardMap {
+    param([object] $Map, [object] $Certificate, [long] $ExpectedCertificationRunId)
+
+    foreach ($name in 'schemaVersion', 'sha') {
+        if (-not $Map.PSObject.Properties[$name]) { throw "map is missing $name" }
+    }
+    foreach ($name in 'schemaVersion', 'candidateMapRunId', 'candidateMapSha',
+        'auditSourceRunId', 'auditSourceSha', 'certificationRunId', 'escalated',
+        'wouldRun', 'wouldSkip', 'missCount') {
+        if (-not $Certificate.PSObject.Properties[$name]) { throw "certificate is missing $name" }
+    }
+
+    $schema = ConvertTo-RequiredInteger $Certificate.schemaVersion 'certificate schemaVersion' 1
+    if ($schema -ne 1) { throw "unsupported certification schema $schema" }
+    $actualRun = ConvertTo-RequiredInteger $Certificate.certificationRunId 'certificationRunId' 1
+    if ($actualRun -ne $ExpectedCertificationRunId) {
+        throw "certificate belongs to run $actualRun, not artifact run $ExpectedCertificationRunId"
+    }
+    [void] (ConvertTo-RequiredInteger $Certificate.candidateMapRunId 'candidateMapRunId' 1)
+    [void] (ConvertTo-RequiredInteger $Certificate.auditSourceRunId 'auditSourceRunId' 1)
+    $misses = ConvertTo-RequiredInteger $Certificate.missCount 'missCount'
+    if ($misses -ne 0) { throw "certificate records $misses selection miss(es)" }
+    if ($Certificate.escalated -isnot [bool]) { throw 'escalated must be a JSON boolean' }
+    if ([bool] $Certificate.escalated) { throw 'certificate records an escalated plan, not reduction' }
+    [void] (ConvertTo-RequiredInteger $Certificate.wouldRun 'wouldRun' 1)
+    [void] (ConvertTo-RequiredInteger $Certificate.wouldSkip 'wouldSkip' 1)
+
+    $mapSha = [string] $Map.sha
+    $candidateSha = [string] $Certificate.candidateMapSha
+    if ($mapSha -notmatch '^[0-9a-f]{40}$') { throw 'map sha is not a full lowercase commit id' }
+    if ($candidateSha -cne $mapSha) { throw 'certificate and map identify different source commits' }
+    if ([string] $Certificate.auditSourceSha -notmatch '^[0-9a-f]{40}$') {
+        throw 'auditSourceSha is not a full lowercase commit id'
+    }
+}
+
+if ($SelfTest) {
+    $failures = [System.Collections.Generic.List[string]]::new()
+    function Assert-Throws {
+        param([scriptblock] $Action, [string] $What)
+        $threw = $false
+        try { & $Action } catch { $threw = $true }
+        if (-not $threw) { [void] $failures.Add($What) }
+    }
+
+    $sha = '0123456789abcdef0123456789abcdef01234567'
+    $map = [pscustomobject]@{ schemaVersion = 1; sha = $sha }
+    $certificate = [pscustomobject]@{
+        schemaVersion = 1
+        candidateMapRunId = 10
+        candidateMapSha = $sha
+        auditSourceRunId = 11
+        auditSourceSha = '89abcdef0123456789abcdef0123456789abcdef'
+        certificationRunId = 12
+        escalated = $false
+        wouldRun = 2
+        wouldSkip = 1
+        missCount = 0
+    }
+    try { Assert-CertifiedShardMap $map $certificate 12 } catch {
+        [void] $failures.Add("valid certificate rejected: $($_.Exception.Message)")
+    }
+
+    $bad = $certificate.PSObject.Copy(); $bad.missCount = 1
+    Assert-Throws { Assert-CertifiedShardMap $map $bad 12 } 'a miss-bearing certificate was accepted'
+    $bad = $certificate.PSObject.Copy(); $bad.certificationRunId = 99
+    Assert-Throws { Assert-CertifiedShardMap $map $bad 12 } 'a certificate from another run was accepted'
+    $bad = $certificate.PSObject.Copy(); $bad.candidateMapSha = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+    Assert-Throws { Assert-CertifiedShardMap $map $bad 12 } 'a certificate for another map was accepted'
+    $bad = $certificate.PSObject.Copy(); $bad.escalated = $true
+    Assert-Throws { Assert-CertifiedShardMap $map $bad 12 } 'an escalated plan was accepted as reduction proof'
+    $bad = $certificate.PSObject.Copy(); $bad.escalated = 'false'
+    Assert-Throws { Assert-CertifiedShardMap $map $bad 12 } 'a stringly typed escalation flag was accepted'
+    $bad = $certificate.PSObject.Copy(); $bad.wouldSkip = 0
+    Assert-Throws { Assert-CertifiedShardMap $map $bad 12 } 'a plan that skipped nothing was accepted as reduction proof'
+    $bad = $certificate.PSObject.Copy(); $bad.PSObject.Properties.Remove('auditSourceRunId')
+    Assert-Throws { Assert-CertifiedShardMap $map $bad 12 } 'an incomplete certificate was accepted'
+
+    if ($failures.Count -gt 0) {
+        Write-Host 'Certified shard-map self-test FAILED:'
+        foreach ($failure in $failures) { Write-Host "  - $failure" }
+        exit 1
+    }
+    Write-Host 'Certified shard-map self-test passed.'
+    exit 0
+}
+
+$mapObject = Get-Content -LiteralPath $MapFile -Raw | ConvertFrom-Json
+$certificateObject = Get-Content -LiteralPath $CertificateFile -Raw | ConvertFrom-Json
+Assert-CertifiedShardMap $mapObject $certificateObject $CertificationRunId
+Write-Host "certified map provenance is valid for run $CertificationRunId"

--- a/tools/TestImpact/Test-CiGateModes.ps1
+++ b/tools/TestImpact/Test-CiGateModes.ps1
@@ -15,8 +15,14 @@ if (-not $nameLine) { throw 'Evaluate required jobs step is absent.' }
 
 $runLine = 0
 $indent = 0
+$stepIndent = $lines[$nameLine - 1].Length - $lines[$nameLine - 1].TrimStart().Length
 for ($i = $nameLine; $i -le $lines.Count; $i++) {
-    if ($lines[$i - 1] -match '^(\s*)run:\s*\|') {
+    $current = $lines[$i - 1]
+    $currentIndent = $current.Length - $current.TrimStart().Length
+    if ($i -gt $nameLine -and $current.Trim() -and $currentIndent -le $stepIndent) {
+        break
+    }
+    if ($current -match '^(\s*)run:\s*\|') {
         $runLine = $i
         $indent = $Matches[1].Length
         break
@@ -44,6 +50,7 @@ else {
 $tempRoot = [IO.Path]::GetFullPath([IO.Path]::GetTempPath())
 $fixture = Join-Path $tempRoot ("aidotnet-ci-gate-" + [guid]::NewGuid().ToString('N'))
 $failures = [System.Collections.Generic.List[string]]::new()
+$fixtureFailure = $null
 
 try {
     New-Item -ItemType Directory -Path $fixture -Force | Out-Null
@@ -53,6 +60,7 @@ try {
     function Invoke-GateCase {
         param(
             [string] $Name,
+            [string] $Source = 'success',
             [string] $Reuse,
             [string] $Promotion,
             [string] $CodeQL,
@@ -61,35 +69,76 @@ try {
             [int] $ExpectedExit
         )
 
-        $env:SOURCE_RESULT = 'success'
-        $env:BUILD_RESULT = 'success'
-        $env:BUILD_COMPAT_RESULT = 'success'
-        $env:CODEQL_RESULT = $CodeQL
-        $env:SELECT_RESULT = 'success'
-        $env:TESTS_RESULT = $Tests
-        $env:PARAMETER_SWEEP_RESULT = 'success'
-        $env:MODEL_SHAPE_RESULT = 'success'
-        $env:REGRESSION_ANALYSIS_RESULT = 'success'
-        $env:VERDICT_ENFORCED = $Verdict
-        $env:AGGREGATE_ANALYSIS_RESULT = 'success'
-        $env:SIZE_CHECK_RESULT = 'success'
-        $env:PROMOTION_RESULT = $Promotion
-        $env:SONAR_RESULT = 'success'
-        $env:REUSED_VALIDATION = $Reuse
-        $env:GITHUB_STEP_SUMMARY = Join-Path $fixture "$Name-summary.md"
+        $environmentNames = @(
+            'SOURCE_RESULT', 'BUILD_RESULT', 'BUILD_COMPAT_RESULT', 'CODEQL_RESULT',
+            'SELECT_RESULT', 'TESTS_RESULT', 'PARAMETER_SWEEP_RESULT', 'MODEL_SHAPE_RESULT',
+            'REGRESSION_ANALYSIS_RESULT', 'VERDICT_ENFORCED', 'AGGREGATE_ANALYSIS_RESULT',
+            'SIZE_CHECK_RESULT', 'PROMOTION_RESULT', 'SONAR_RESULT', 'REUSED_VALIDATION',
+            'GITHUB_STEP_SUMMARY'
+        )
+        $savedEnvironment = @{}
+        foreach ($variableName in $environmentNames) {
+            $savedEnvironment[$variableName] = [Environment]::GetEnvironmentVariable(
+                $variableName,
+                [EnvironmentVariableTarget]::Process)
+        }
 
-        & $bash $script 2>&1 | Out-Null
-        if ($LASTEXITCODE -ne $ExpectedExit) {
-            [void] $failures.Add("$Name expected exit $ExpectedExit, got $LASTEXITCODE")
+        try {
+            $env:SOURCE_RESULT = $Source
+            $env:BUILD_RESULT = 'success'
+            $env:BUILD_COMPAT_RESULT = 'success'
+            $env:CODEQL_RESULT = $CodeQL
+            $env:SELECT_RESULT = 'success'
+            $env:TESTS_RESULT = $Tests
+            $env:PARAMETER_SWEEP_RESULT = 'success'
+            $env:MODEL_SHAPE_RESULT = 'success'
+            $env:REGRESSION_ANALYSIS_RESULT = 'success'
+            $env:VERDICT_ENFORCED = $Verdict
+            $env:AGGREGATE_ANALYSIS_RESULT = 'success'
+            $env:SIZE_CHECK_RESULT = 'success'
+            $env:PROMOTION_RESULT = $Promotion
+            $env:SONAR_RESULT = 'success'
+            $env:REUSED_VALIDATION = $Reuse
+            $env:GITHUB_STEP_SUMMARY = Join-Path $fixture "$Name-summary.md"
+
+            & $bash $script 2>&1 | Out-Null
+            $actualExit = $LASTEXITCODE
+            if ($actualExit -ne $ExpectedExit) {
+                [void] $failures.Add("$Name expected exit $ExpectedExit, got $actualExit")
+            }
+        }
+        finally {
+            foreach ($variableName in $environmentNames) {
+                [Environment]::SetEnvironmentVariable(
+                    $variableName,
+                    $savedEnvironment[$variableName],
+                    [EnvironmentVariableTarget]::Process)
+            }
         }
     }
 
-    Invoke-GateCase reuse_success true success skipped skipped false 0
-    Invoke-GateCase reuse_missing_promotion true skipped skipped skipped false 1
-    Invoke-GateCase full_success false skipped success success true 0
-    Invoke-GateCase full_codeql_failure false skipped failure success true 1
-    Invoke-GateCase full_known_test_failure false skipped success failure true 0
-    Invoke-GateCase full_unenforced_test_failure false skipped success failure false 1
+    Invoke-GateCase -Name reuse_success -Reuse true -Promotion success -CodeQL skipped `
+        -Tests skipped -Verdict false -ExpectedExit 0
+    Invoke-GateCase -Name reuse_missing_promotion -Reuse true -Promotion skipped -CodeQL skipped `
+        -Tests skipped -Verdict false -ExpectedExit 1
+    Invoke-GateCase -Name full_success -Reuse false -Promotion skipped -CodeQL success `
+        -Tests success -Verdict true -ExpectedExit 0
+    Invoke-GateCase -Name full_codeql_failure -Reuse false -Promotion skipped -CodeQL failure `
+        -Tests success -Verdict true -ExpectedExit 1
+    Invoke-GateCase -Name full_known_test_failure -Reuse false -Promotion skipped -CodeQL success `
+        -Tests failure -Verdict true -ExpectedExit 0
+    Invoke-GateCase -Name full_unenforced_test_failure -Reuse false -Promotion skipped -CodeQL success `
+        -Tests failure -Verdict false -ExpectedExit 1
+    Invoke-GateCase -Name source_failure_blocks_reuse -Source failure -Reuse true `
+        -Promotion success -CodeQL skipped -Tests skipped -Verdict false -ExpectedExit 1
+    Invoke-GateCase -Name source_failure_blocks_full -Source failure -Reuse false `
+        -Promotion skipped -CodeQL success -Tests success -Verdict true -ExpectedExit 1
+    Invoke-GateCase -Name empty_reuse_takes_full_path -Reuse '' -Promotion skipped -CodeQL failure `
+        -Tests success -Verdict true -ExpectedExit 1
+}
+catch {
+    $fixtureFailure = $_
+    throw
 }
 finally {
     $resolvedFixture = [IO.Path]::GetFullPath($fixture)
@@ -98,7 +147,9 @@ finally {
         Remove-Item -LiteralPath $resolvedFixture -Recurse -Force -ErrorAction SilentlyContinue
     }
     else {
-        throw "refusing to remove unexpected fixture path '$resolvedFixture'"
+        $message = "refusing to remove unexpected fixture path '$resolvedFixture'"
+        if ($null -ne $fixtureFailure) { Write-Warning "$message; preserving the original failure" }
+        else { throw $message }
     }
 }
 
@@ -108,5 +159,5 @@ if ($failures.Count -gt 0) {
     exit 1
 }
 
-Write-Host 'CI Gate mode proof passed (reuse/full success and failure controls).'
+Write-Host 'CI Gate mode proof passed (reuse/full/default success and failure controls).'
 exit 0

--- a/tools/TestImpact/Test-CiGateModes.ps1
+++ b/tools/TestImpact/Test-CiGateModes.ps1
@@ -1,0 +1,112 @@
+<#
+.SYNOPSIS
+    Executes the checked-in CI Gate Bash body in full-validation and exact-reuse modes.
+#>
+[CmdletBinding()]
+param([string] $Workflow = '.github/workflows/sonarcloud.yml')
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$lines = Get-Content -LiteralPath $Workflow
+$nameLine = ($lines | Select-String -SimpleMatch '- name: Evaluate required jobs' |
+    Select-Object -First 1).LineNumber
+if (-not $nameLine) { throw 'Evaluate required jobs step is absent.' }
+
+$runLine = 0
+$indent = 0
+for ($i = $nameLine; $i -le $lines.Count; $i++) {
+    if ($lines[$i - 1] -match '^(\s*)run:\s*\|') {
+        $runLine = $i
+        $indent = $Matches[1].Length
+        break
+    }
+}
+if (-not $runLine) { throw 'CI Gate run block is absent.' }
+
+$body = [System.Collections.Generic.List[string]]::new()
+for ($i = $runLine + 1; $i -le $lines.Count; $i++) {
+    $line = $lines[$i - 1]
+    $lineIndent = $line.Length - $line.TrimStart().Length
+    if ($line.Trim() -and $lineIndent -le $indent) { break }
+    [void] $body.Add($(if ($line.Length -ge $indent + 2) { $line.Substring($indent + 2) } else { '' }))
+}
+
+$bash = if ($IsWindows) {
+    $candidate = Join-Path $env:ProgramFiles 'Git\bin\bash.exe'
+    if (-not (Test-Path -LiteralPath $candidate)) { throw 'Git Bash is required for this proof on Windows.' }
+    $candidate
+}
+else {
+    (Get-Command bash -ErrorAction Stop).Source
+}
+
+$tempRoot = [IO.Path]::GetFullPath([IO.Path]::GetTempPath())
+$fixture = Join-Path $tempRoot ("aidotnet-ci-gate-" + [guid]::NewGuid().ToString('N'))
+$failures = [System.Collections.Generic.List[string]]::new()
+
+try {
+    New-Item -ItemType Directory -Path $fixture -Force | Out-Null
+    $script = Join-Path $fixture 'gate.sh'
+    [IO.File]::WriteAllText($script, ($body -join "`n"), [Text.UTF8Encoding]::new($false))
+
+    function Invoke-GateCase {
+        param(
+            [string] $Name,
+            [string] $Reuse,
+            [string] $Promotion,
+            [string] $CodeQL,
+            [string] $Tests,
+            [string] $Verdict,
+            [int] $ExpectedExit
+        )
+
+        $env:SOURCE_RESULT = 'success'
+        $env:BUILD_RESULT = 'success'
+        $env:BUILD_COMPAT_RESULT = 'success'
+        $env:CODEQL_RESULT = $CodeQL
+        $env:SELECT_RESULT = 'success'
+        $env:TESTS_RESULT = $Tests
+        $env:PARAMETER_SWEEP_RESULT = 'success'
+        $env:MODEL_SHAPE_RESULT = 'success'
+        $env:REGRESSION_ANALYSIS_RESULT = 'success'
+        $env:VERDICT_ENFORCED = $Verdict
+        $env:AGGREGATE_ANALYSIS_RESULT = 'success'
+        $env:SIZE_CHECK_RESULT = 'success'
+        $env:PROMOTION_RESULT = $Promotion
+        $env:SONAR_RESULT = 'success'
+        $env:REUSED_VALIDATION = $Reuse
+        $env:GITHUB_STEP_SUMMARY = Join-Path $fixture "$Name-summary.md"
+
+        & $bash $script 2>&1 | Out-Null
+        if ($LASTEXITCODE -ne $ExpectedExit) {
+            [void] $failures.Add("$Name expected exit $ExpectedExit, got $LASTEXITCODE")
+        }
+    }
+
+    Invoke-GateCase reuse_success true success skipped skipped false 0
+    Invoke-GateCase reuse_missing_promotion true skipped skipped skipped false 1
+    Invoke-GateCase full_success false skipped success success true 0
+    Invoke-GateCase full_codeql_failure false skipped failure success true 1
+    Invoke-GateCase full_known_test_failure false skipped success failure true 0
+    Invoke-GateCase full_unenforced_test_failure false skipped success failure false 1
+}
+finally {
+    $resolvedFixture = [IO.Path]::GetFullPath($fixture)
+    if ($resolvedFixture.StartsWith($tempRoot, [StringComparison]::OrdinalIgnoreCase) -and
+        (Split-Path -Leaf $resolvedFixture).StartsWith('aidotnet-ci-gate-', [StringComparison]::Ordinal)) {
+        Remove-Item -LiteralPath $resolvedFixture -Recurse -Force -ErrorAction SilentlyContinue
+    }
+    else {
+        throw "refusing to remove unexpected fixture path '$resolvedFixture'"
+    }
+}
+
+if ($failures.Count -gt 0) {
+    Write-Host 'CI Gate mode proof FAILED:'
+    foreach ($failure in $failures) { Write-Host "  - $failure" }
+    exit 1
+}
+
+Write-Host 'CI Gate mode proof passed (reuse/full success and failure controls).'
+exit 0

--- a/tools/TestImpact/Test-CiImpactWorkflow.ps1
+++ b/tools/TestImpact/Test-CiImpactWorkflow.ps1
@@ -1,0 +1,157 @@
+<#
+.SYNOPSIS
+    Verifies the two CI time-saving contracts at the workflow wiring boundary.
+
+.DESCRIPTION
+    Script-level selector tests cannot prove that a GitHub Actions job actually consumes the
+    selector output, and the exact-tree resolver cannot save work if a newly added job forgets to
+    honor its decision. This test deliberately inspects the workflow graph as checked in.
+
+    It fails closed when:
+      * an expensive job can start without the certified-validation decision;
+      * shadow mode can silently replace a reduced matrix with the full matrix;
+      * the map lifecycle does not distinguish an unaudited candidate from a certified map; or
+      * a no-checkout dispatch job relies on an ambient git repository.
+#>
+[CmdletBinding()]
+param(
+    [string] $ValidationWorkflow = '.github/workflows/sonarcloud.yml',
+    [string] $MapWorkflow = '.github/workflows/test-impact-map.yml'
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$failures = [System.Collections.Generic.List[string]]::new()
+
+function Assert-Contract {
+    param([bool] $Condition, [string] $Message)
+    if (-not $Condition) { [void] $failures.Add($Message) }
+}
+
+function Get-JobBlock {
+    param([string] $WorkflowText, [string] $Job)
+
+    $escaped = [Regex]::Escape($Job)
+    $match = [Regex]::Match(
+        $WorkflowText,
+        "(?ms)^  ${escaped}:\s*\r?\n(?<body>.*?)(?=^  [A-Za-z0-9_-]+:\s*\r?\n|\z)")
+    if (-not $match.Success) {
+        [void] $failures.Add("workflow job '$Job' is absent")
+        return ''
+    }
+    return $match.Value
+}
+
+$validation = Get-Content -LiteralPath $ValidationWorkflow -Raw
+$map = Get-Content -LiteralPath $MapWorkflow -Raw
+
+# Every job in this list consumes meaningful runner time. Dependency-based incidental skipping is
+# not enough: a dependency can be removed during a refactor while the job remains runnable. Each
+# job must explicitly depend on validation-source and consume its JSON boolean decision.
+$expensiveJobs = @(
+    'codeql',
+    'build',
+    'build-compat',
+    'select-shards',
+    'test-net10-sharded',
+    'parameter-enumeration-sweep',
+    'model-shape-conformance-windows',
+    'test-regression-analysis',
+    'sonarcloud',
+    'size-check',
+    'ci-test-analysis'
+)
+
+foreach ($job in $expensiveJobs) {
+    $block = Get-JobBlock -WorkflowText $validation -Job $job
+    if (-not $block) { continue }
+    Assert-Contract ($block -match '(?m)^\s+needs:(?:[^\r\n]*validation-source|\s*\r?\n(?:\s+-[^\r\n]*\r?\n)*\s+- validation-source\s*$)') `
+        "expensive job '$job' does not explicitly depend on validation-source"
+    Assert-Contract ($block.Contains('fromJSON(needs.validation-source.outputs.execute_expensive)')) `
+        "expensive job '$job' does not consume the typed execute_expensive decision"
+}
+
+$resolver = Get-JobBlock -WorkflowText $validation -Job 'validation-source'
+Assert-Contract ($resolver.Contains('steps.resolve.outputs.execute_expensive || steps.defaults.outputs.execute_expensive')) `
+    'validation-source does not publish execute_expensive'
+Assert-Contract ($resolver.Contains("echo 'execute_expensive=true'")) `
+    'the resolver lacks a fail-closed full-validation default'
+Assert-Contract ($resolver.Contains("echo 'execute_expensive=false'")) `
+    'the resolver never suppresses expensive work after exact-tree certification'
+Assert-Contract ($resolver.Contains('continue-on-error: true')) `
+    'an unexpected resolver failure blocks dependents instead of retaining fail-closed defaults'
+
+$selectorJob = Get-JobBlock -WorkflowText $validation -Job 'select-shards'
+$selfTestStep = [Regex]::Match(
+    $selectorJob,
+    '(?ms)^\s+- name: Verify the impact tooling\s*$.*?(?=^\s+- name: |\z)').Value
+Assert-Contract (-not $selfTestStep.Contains('continue-on-error: true')) `
+    'checked-in impact tooling can fail its self-tests while CI remains green'
+
+$promotion = Get-JobBlock -WorkflowText $validation -Job 'promote-ci-test-analysis'
+Assert-Contract ($promotion.Contains("needs.validation-source.outputs.reuse == 'true'")) `
+    'certified artifact promotion is not restricted to exact-tree reuse'
+
+$validationCertificate = Get-JobBlock -WorkflowText $validation -Job 'certify-validation'
+Assert-Contract ($validationCertificate.Contains("needs.ci-gate.result == 'success'")) `
+    'validation certificate can be published before the required CI Gate succeeds'
+Assert-Contract ($validationCertificate.Contains('ci-validation-certificate-')) `
+    'validation certificate is not published as a distinct artifact'
+Assert-Contract ($resolver.Contains('ci-validation-certificate-')) `
+    'exact-tree resolver does not require the CI Gate validation certificate'
+
+$gate = Get-JobBlock -WorkflowText $validation -Job 'ci-gate'
+foreach ($job in $expensiveJobs) {
+    Assert-Contract ($gate -match "(?m)^\s+- $([Regex]::Escape($job))\s*$") `
+        "CI Gate does not depend on expensive job '$job', so its failure cannot block validation"
+}
+Assert-Contract ($gate -match 'required=\("validation-source:\$SOURCE_RESULT"\)') `
+    'the reuse-aware gate must start with only validation-source as universally required'
+Assert-Contract ($gate -match '(?s)if \[ "\$REUSED_VALIDATION" = "true" \].*?promote-ci-test-analysis.*?else.*?build:\$BUILD_RESULT.*?sonarcloud:\$SONAR_RESULT') `
+    'the gate does not exclude build and SonarCloud from certified-reuse mode'
+
+# A repository variable left the shipped feature permanently in shadow mode. Certification is the
+# authorization boundary now; no second switch may silently restore the full matrix.
+Assert-Contract (-not $validation.Contains('TEST_IMPACT_MODE')) `
+    'TEST_IMPACT_MODE shadow/enforce switching is still present'
+Assert-Contract ($validation.Contains('certified-shard-map')) `
+    'PR selection does not consume a certified map artifact'
+Assert-Contract ($validation.Contains('candidate-shard-map')) `
+    'coverage audit runs do not consume an explicit candidate map artifact'
+Assert-Contract ($validation -match '(?s)if \[ "\$FORCE_COVERAGE" = ''true'' \].*?--name candidate-shard-map.*?else.*?--name certified-shard-map') `
+    'candidate and certified artifacts are not separated at the execution boundary'
+
+# The map builder publishes a new candidate, but only the previous candidate that was exercised by
+# a complete coverage run may become certified. Reusing one artifact name for both states recreates
+# the original unproven-rollout bug.
+Assert-Contract ($map.Contains('name: candidate-shard-map')) `
+    'map workflow does not publish candidate-shard-map'
+Assert-Contract ($map.Contains('name: certified-shard-map')) `
+    'map workflow does not publish certified-shard-map'
+Assert-Contract ($map.Contains('certification.json')) `
+    'certified map artifact has no provenance record'
+Assert-Contract ($map.Contains('found=false')) `
+    'automatic no-source bootstrap is still represented as a workflow failure'
+Assert-Contract ($map.Contains("candidate_ready: `${{ steps.source.outputs.found }}")) `
+    'map workflow does not expose whether this invocation produced a candidate'
+Assert-Contract ($map.Contains("if: steps.audit.outputs.certified == 'true'")) `
+    'certified artifact upload is not gated by the audit decision'
+Assert-Contract ($map -match "if \[ '.*needs\.build-map\.result.*' = 'success' \] && \[ '.*candidate_ready.*' = 'true' \]") `
+    'coverage dispatch can cite the current map run when no candidate was produced'
+
+# coverage-run has no checkout by design. Every gh command in that job must therefore identify the
+# repository explicitly instead of asking git to infer it from a nonexistent worktree.
+$coverageRun = Get-JobBlock -WorkflowText $map -Job 'coverage-run'
+$repoTargets = [Regex]::Matches($coverageRun, '--repo\s+"\$GITHUB_REPOSITORY"').Count
+Assert-Contract ($repoTargets -ge 3) `
+    "coverage-run has only $repoTargets explicit repository target(s); run lookup, in-flight lookup, and dispatch all require one"
+
+if ($failures.Count -gt 0) {
+    Write-Host 'CI impact workflow contract FAILED:'
+    foreach ($failure in $failures) { Write-Host "  - $failure" }
+    exit 1
+}
+
+Write-Host "CI impact workflow contract passed ($($expensiveJobs.Count) expensive jobs gated)."
+exit 0

--- a/tools/TestImpact/Test-CiImpactWorkflow.ps1
+++ b/tools/TestImpact/Test-CiImpactWorkflow.ps1
@@ -43,6 +43,63 @@ function Get-JobBlock {
     return $match.Value
 }
 
+function Get-StepBlock {
+    param([string] $JobBlock, [string] $Step)
+
+    $escaped = [Regex]::Escape($Step)
+    return [Regex]::Match(
+        $JobBlock,
+        "(?ms)^      - name: ${escaped}\s*\r?\n.*?(?=^      - [A-Za-z0-9_-]+:|\z)").Value
+}
+
+function Get-JobHeader {
+    param([string] $JobBlock)
+
+    $steps = [Regex]::Match($JobBlock, '(?m)^    steps:\s*$')
+    if (-not $steps.Success) { return '' }
+    return $JobBlock.Substring(0, $steps.Index)
+}
+
+function Test-JobDependency {
+    param([string] $JobHeader, [string] $Dependency)
+
+    $match = [Regex]::Match($JobHeader, '(?m)^    needs:[ \t]*(?<inline>[^\r\n]*)[ \t]*\r?$')
+    if (-not $match.Success) { return $false }
+    $inline = $match.Groups['inline'].Value.Trim()
+    if ($inline.StartsWith('[', [StringComparison]::Ordinal) -and
+        $inline.EndsWith(']', [StringComparison]::Ordinal)) {
+        $values = @($inline.Substring(1, $inline.Length - 2).Split(',') |
+            ForEach-Object { $_.Trim().Trim("'`"") })
+        return $values -ccontains $Dependency
+    }
+    if ($inline) { return $inline.Trim("'`"") -ceq $Dependency }
+
+    $list = [Regex]::Match($JobHeader, '(?ms)^    needs:[ \t]*\r?\n(?<items>(?:      - [^\r\n]+\r?\n?)+)')
+    if (-not $list.Success) { return $false }
+    $values = @([Regex]::Matches($list.Groups['items'].Value, '(?m)^      -[ \t]*(?<value>[^\r\n]+?)[ \t]*\r?$') |
+        ForEach-Object { $_.Groups['value'].Value.Trim().Trim("'`"") })
+    return $values -ccontains $Dependency
+}
+
+function Get-ContinuedShellCommand {
+    param([string] $Text, [string] $CommandPattern)
+
+    $lines = [Regex]::Split($Text, '\r?\n')
+    $commands = [System.Collections.Generic.List[string]]::new()
+    for ($i = 0; $i -lt $lines.Count; $i++) {
+        if ($lines[$i] -notmatch $CommandPattern) { continue }
+        $parts = [System.Collections.Generic.List[string]]::new()
+        do {
+            $line = $lines[$i]
+            [void] $parts.Add($line.Trim())
+            $continued = $line.TrimEnd().EndsWith('\', [StringComparison]::Ordinal)
+            if ($continued) { $i++ }
+        } while ($continued -and $i -lt $lines.Count)
+        [void] $commands.Add($parts -join ' ')
+    }
+    return @($commands)
+}
+
 $validation = Get-Content -LiteralPath $ValidationWorkflow -Raw
 $map = Get-Content -LiteralPath $MapWorkflow -Raw
 
@@ -66,9 +123,16 @@ $expensiveJobs = @(
 foreach ($job in $expensiveJobs) {
     $block = Get-JobBlock -WorkflowText $validation -Job $job
     if (-not $block) { continue }
-    Assert-Contract ($block -match '(?m)^\s+needs:(?:[^\r\n]*validation-source|\s*\r?\n(?:\s+-[^\r\n]*\r?\n)*\s+- validation-source\s*$)') `
+    $header = Get-JobHeader -JobBlock $block
+    Assert-Contract ([bool] $header) `
+        "expensive job '$job' has no job-level header before its steps"
+    Assert-Contract (Test-JobDependency -JobHeader $header -Dependency 'validation-source') `
         "expensive job '$job' does not explicitly depend on validation-source"
-    Assert-Contract ($block.Contains('fromJSON(needs.validation-source.outputs.execute_expensive)')) `
+    $jobIf = [Regex]::Match($header, '(?m)^    if:\s*(?<value>[^\r\n]+)\s*$')
+    Assert-Contract $jobIf.Success `
+        "expensive job '$job' has no job-level execution condition"
+    Assert-Contract ($jobIf.Success -and
+        $jobIf.Groups['value'].Value.Contains('fromJSON(needs.validation-source.outputs.execute_expensive)')) `
         "expensive job '$job' does not consume the typed execute_expensive decision"
 }
 
@@ -79,13 +143,16 @@ Assert-Contract ($resolver.Contains("echo 'execute_expensive=true'")) `
     'the resolver lacks a fail-closed full-validation default'
 Assert-Contract ($resolver.Contains("echo 'execute_expensive=false'")) `
     'the resolver never suppresses expensive work after exact-tree certification'
-Assert-Contract ($resolver.Contains('continue-on-error: true')) `
+$resolveStep = Get-StepBlock -JobBlock $resolver -Step 'Resolve exact-tree PR run'
+Assert-Contract ([bool] $resolveStep) `
+    'the exact-tree resolver step is absent'
+Assert-Contract ($resolveStep.Contains('continue-on-error: true')) `
     'an unexpected resolver failure blocks dependents instead of retaining fail-closed defaults'
 
 $selectorJob = Get-JobBlock -WorkflowText $validation -Job 'select-shards'
-$selfTestStep = [Regex]::Match(
-    $selectorJob,
-    '(?ms)^\s+- name: Verify the impact tooling\s*$.*?(?=^\s+- name: |\z)').Value
+$selfTestStep = Get-StepBlock -JobBlock $selectorJob -Step 'Verify the impact tooling'
+Assert-Contract ([bool] $selfTestStep) `
+    'select-shards no longer runs the impact tooling self-tests'
 Assert-Contract (-not $selfTestStep.Contains('continue-on-error: true')) `
     'checked-in impact tooling can fail its self-tests while CI remains green'
 
@@ -137,15 +204,40 @@ Assert-Contract ($map.Contains("candidate_ready: `${{ steps.source.outputs.found
     'map workflow does not expose whether this invocation produced a candidate'
 Assert-Contract ($map.Contains("if: steps.audit.outputs.certified == 'true'")) `
     'certified artifact upload is not gated by the audit decision'
+Assert-Contract ($map -match '(?s)if \(\$auditExit -eq 0.*?\$a\.WouldSkip -gt 0.*?\$a\.Failed -gt 0\)') `
+    'map certification does not require a real failing-shard opportunity as well as reduction'
 Assert-Contract ($map -match "if \[ '.*needs\.build-map\.result.*' = 'success' \] && \[ '.*candidate_ready.*' = 'true' \]") `
     'coverage dispatch can cite the current map run when no candidate was produced'
 
 # coverage-run has no checkout by design. Every gh command in that job must therefore identify the
 # repository explicitly instead of asking git to infer it from a nonexistent worktree.
 $coverageRun = Get-JobBlock -WorkflowText $map -Job 'coverage-run'
-$repoTargets = [Regex]::Matches($coverageRun, '--repo\s+"\$GITHUB_REPOSITORY"').Count
-Assert-Contract ($repoTargets -ge 3) `
-    "coverage-run has only $repoTargets explicit repository target(s); run lookup, in-flight lookup, and dispatch all require one"
+$runListCommands = @(Get-ContinuedShellCommand -Text $coverageRun -CommandPattern `
+    '^\s*(?:[A-Za-z_][A-Za-z0-9_]*=\$\()?gh run list\b')
+Assert-Contract ($runListCommands.Count -ge 2) `
+    'coverage-run no longer performs both source and in-flight run lookups'
+foreach ($command in $runListCommands) {
+    Assert-Contract ($command.Contains('--repo "$GITHUB_REPOSITORY"')) `
+        "coverage-run has an unscoped gh run list command: $command"
+}
+
+$workflowRunCommands = @(Get-ContinuedShellCommand -Text $coverageRun -CommandPattern `
+    '^\s*gh workflow run\b')
+Assert-Contract ($workflowRunCommands.Count -ge 2) `
+    'coverage-run no longer covers both mapped and bootstrap dispatches'
+foreach ($command in $workflowRunCommands) {
+    Assert-Contract ($command.Contains('--repo "$GITHUB_REPOSITORY"')) `
+        "coverage-run has an unscoped gh workflow run command: $command"
+}
+
+$apiCommands = @(Get-ContinuedShellCommand -Text $coverageRun -CommandPattern `
+    '^\s*(?:[A-Za-z_][A-Za-z0-9_]*=\$\()?gh api\b')
+Assert-Contract ($apiCommands.Count -ge 1) `
+    'coverage-run no longer validates candidate artifact availability'
+foreach ($command in $apiCommands) {
+    Assert-Contract ($command.Contains('repos/${GITHUB_REPOSITORY}/')) `
+        "coverage-run has a gh api command without an explicit repository endpoint: $command"
+}
 
 if ($failures.Count -gt 0) {
     Write-Host 'CI impact workflow contract FAILED:'

--- a/tools/TestImpact/Test-TestImpactEndToEnd.ps1
+++ b/tools/TestImpact/Test-TestImpactEndToEnd.ps1
@@ -1,0 +1,121 @@
+<#
+.SYNOPSIS
+    Proves a certified map selects a strict subset in a real git diff and fails closed for infra.
+#>
+[CmdletBinding()]
+param()
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$selector = Join-Path $PSScriptRoot 'Select-Shards.ps1'
+$certificateValidator = Join-Path $PSScriptRoot 'Test-CertifiedShardMap.ps1'
+$tempRoot = [IO.Path]::GetFullPath([IO.Path]::GetTempPath())
+$fixture = Join-Path $tempRoot ("aidotnet-impact-e2e-" + [guid]::NewGuid().ToString('N'))
+$failures = [System.Collections.Generic.List[string]]::new()
+
+function Assert-True {
+    param([bool] $Condition, [string] $What)
+    if (-not $Condition) { [void] $failures.Add($What) }
+}
+
+try {
+    New-Item -ItemType Directory -Path (Join-Path $fixture 'src') -Force | Out-Null
+    Push-Location $fixture
+    try {
+        & git init --quiet
+        & git config user.email 'ci-impact-fixture@example.invalid'
+        & git config user.name 'CI impact fixture'
+        @('one', 'alpha before', 'three', 'beta unchanged', 'five') |
+            Set-Content -LiteralPath src/Feature.cs -Encoding utf8
+        & git add src/Feature.cs
+        & git commit --quiet -m baseline
+        $baseSha = (& git rev-parse HEAD).Trim()
+
+        $map = [ordered]@{
+            schemaVersion = 1
+            sha = $baseSha
+            knownShards = @('Alpha', 'Beta')
+            alwaysRun = @('Always')
+            files = [ordered]@{
+                'src/Feature.cs' = @(
+                    [ordered]@{ s = 0; r = @(2, 2) },
+                    [ordered]@{ s = 1; r = @(4, 4) }
+                )
+            }
+        }
+        $map | ConvertTo-Json -Depth 8 | Set-Content -LiteralPath shard-map.json -Encoding utf8
+        [ordered]@{
+            schemaVersion = 1
+            candidateMapRunId = 100
+            candidateMapSha = $baseSha
+            auditSourceRunId = 101
+            auditSourceSha = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+            certificationRunId = 102
+            escalated = $false
+            wouldRun = 2
+            wouldSkip = 1
+            failedShards = 1
+            missCount = 0
+        } | ConvertTo-Json -Depth 5 | Set-Content -LiteralPath certification.json -Encoding utf8
+
+        & $certificateValidator -MapFile shard-map.json -CertificateFile certification.json `
+            -CertificationRunId 102
+        Assert-True ($LASTEXITCODE -eq 0) 'the valid end-to-end certificate was rejected'
+
+        @('one', 'alpha after', 'three', 'beta unchanged', 'five') |
+            Set-Content -LiteralPath src/Feature.cs -Encoding utf8
+        & git add src/Feature.cs
+        & git commit --quiet -m narrow-change
+        & $selector -MapFile shard-map.json -ExpectedShards @('Alpha', 'Beta', 'Always') `
+            -OutFile selection.json
+        $selection = Get-Content selection.json -Raw | ConvertFrom-Json
+        Assert-True (-not [bool] $selection.escalate) 'a covered one-line edit escalated'
+        Assert-True (@($selection.shards).Count -eq 2) 'the covered edit did not select a strict 2/3 subset'
+        Assert-True ($selection.shards -contains 'Alpha') 'the covering shard was omitted'
+        Assert-True ($selection.shards -contains 'Always') 'the always-run shard was omitted'
+        Assert-True (-not ($selection.shards -contains 'Beta')) 'an unaffected shard was selected'
+
+        New-Item -ItemType Directory -Path .github/workflows -Force | Out-Null
+        'name: changed-ci' | Set-Content -LiteralPath .github/workflows/fixture.yml -Encoding utf8
+        & git add .github/workflows/fixture.yml
+        & git commit --quiet -m infrastructure-change
+        & $selector -MapFile shard-map.json -ExpectedShards @('Alpha', 'Beta', 'Always') `
+            -OutFile infrastructure-selection.json
+        $infrastructure = Get-Content infrastructure-selection.json -Raw | ConvertFrom-Json
+        Assert-True ([bool] $infrastructure.escalate) 'a workflow edit did not fail closed to the full matrix'
+
+        $badCertificate = Get-Content certification.json -Raw | ConvertFrom-Json
+        $badCertificate.missCount = 1
+        $badCertificate | ConvertTo-Json -Depth 5 | Set-Content bad-certification.json -Encoding utf8
+        $rejected = $false
+        try {
+            & $certificateValidator -MapFile shard-map.json -CertificateFile bad-certification.json `
+                -CertificationRunId 102 2>$null
+        }
+        catch { $rejected = $true }
+        Assert-True $rejected 'a certificate recording a selection miss was accepted'
+    }
+    finally {
+        Pop-Location
+    }
+}
+finally {
+    $resolvedFixture = [IO.Path]::GetFullPath($fixture)
+    if ($resolvedFixture.StartsWith($tempRoot, [StringComparison]::OrdinalIgnoreCase) -and
+        (Split-Path -Leaf $resolvedFixture).StartsWith('aidotnet-impact-e2e-', [StringComparison]::Ordinal)) {
+        Remove-Item -LiteralPath $resolvedFixture -Recurse -Force -ErrorAction SilentlyContinue
+    }
+    else {
+        throw "refusing to remove unexpected fixture path '$resolvedFixture'"
+    }
+}
+
+if ($failures.Count -gt 0) {
+    Write-Host 'Test-impact end-to-end proof FAILED:'
+    foreach ($failure in $failures) { Write-Host "  - $failure" }
+    exit 1
+}
+
+Write-Host 'Test-impact end-to-end proof passed: certified covered edit selected 2/3; CI edit escalated.'
+exit 0

--- a/tools/TestImpact/Test-TestImpactEndToEnd.ps1
+++ b/tools/TestImpact/Test-TestImpactEndToEnd.ps1
@@ -13,24 +13,62 @@ $certificateValidator = Join-Path $PSScriptRoot 'Test-CertifiedShardMap.ps1'
 $tempRoot = [IO.Path]::GetFullPath([IO.Path]::GetTempPath())
 $fixture = Join-Path $tempRoot ("aidotnet-impact-e2e-" + [guid]::NewGuid().ToString('N'))
 $failures = [System.Collections.Generic.List[string]]::new()
+$fixtureFailure = $null
 
 function Assert-True {
     param([bool] $Condition, [string] $What)
     if (-not $Condition) { [void] $failures.Add($What) }
 }
 
+function Invoke-Git {
+    param([Parameter(ValueFromRemainingArguments)] [string[]] $Arguments)
+
+    $output = & git @Arguments 2>&1
+    $exitCode = $LASTEXITCODE
+    if ($exitCode -ne 0) {
+        $details = ($output | Out-String).Trim()
+        throw "git $($Arguments -join ' ') failed with exit code $exitCode$(if ($details) { ": $details" })"
+    }
+    return $output
+}
+
+function Assert-CertificateRejected {
+    param([string] $CertificateFile, [string] $ExpectedPattern, [string] $What)
+
+    $message = $null
+    try {
+        & $certificateValidator -MapFile shard-map.json -CertificateFile $CertificateFile `
+            -CertificationRunId 102
+    }
+    catch { $message = [string] $_.Exception.Message }
+
+    if ($null -eq $message) {
+        [void] $failures.Add($What)
+    }
+    elseif ($message -notmatch $ExpectedPattern) {
+        [void] $failures.Add("$What (rejected for the wrong reason: $message)")
+    }
+}
+
 try {
     New-Item -ItemType Directory -Path (Join-Path $fixture 'src') -Force | Out-Null
     Push-Location $fixture
     try {
-        & git init --quiet
-        & git config user.email 'ci-impact-fixture@example.invalid'
-        & git config user.name 'CI impact fixture'
+        Invoke-Git init --quiet
+        Invoke-Git config user.email 'ci-impact-fixture@example.invalid'
+        Invoke-Git config user.name 'CI impact fixture'
+        Invoke-Git config commit.gpgSign false
+        $disabledHooks = Join-Path $fixture 'disabled-hooks'
+        New-Item -ItemType Directory -Path $disabledHooks -Force | Out-Null
+        Invoke-Git config core.hooksPath $disabledHooks
         @('one', 'alpha before', 'three', 'beta unchanged', 'five') |
             Set-Content -LiteralPath src/Feature.cs -Encoding utf8
-        & git add src/Feature.cs
-        & git commit --quiet -m baseline
-        $baseSha = (& git rev-parse HEAD).Trim()
+        Invoke-Git add src/Feature.cs
+        Invoke-Git commit --quiet -m baseline
+        $baseSha = ((Invoke-Git rev-parse HEAD) | Out-String).Trim()
+        if ($baseSha -cnotmatch '^[0-9a-f]{40}$') {
+            throw "fixture HEAD is not a full lowercase commit ID: '$baseSha'"
+        }
 
         $map = [ordered]@{
             schemaVersion = 1
@@ -59,14 +97,22 @@ try {
             missCount = 0
         } | ConvertTo-Json -Depth 5 | Set-Content -LiteralPath certification.json -Encoding utf8
 
-        & $certificateValidator -MapFile shard-map.json -CertificateFile certification.json `
-            -CertificationRunId 102
-        Assert-True ($LASTEXITCODE -eq 0) 'the valid end-to-end certificate was rejected'
+        $global:LASTEXITCODE = 97
+        try {
+            & $certificateValidator -MapFile shard-map.json -CertificateFile certification.json `
+                -CertificationRunId 102
+            if ($LASTEXITCODE -ne 0) {
+                throw "validator returned exit code $LASTEXITCODE"
+            }
+        }
+        catch {
+            [void] $failures.Add("the valid end-to-end certificate was rejected: $($_.Exception.Message)")
+        }
 
         @('one', 'alpha after', 'three', 'beta unchanged', 'five') |
             Set-Content -LiteralPath src/Feature.cs -Encoding utf8
-        & git add src/Feature.cs
-        & git commit --quiet -m narrow-change
+        Invoke-Git add src/Feature.cs
+        Invoke-Git commit --quiet -m narrow-change
         & $selector -MapFile shard-map.json -ExpectedShards @('Alpha', 'Beta', 'Always') `
             -OutFile selection.json
         $selection = Get-Content selection.json -Raw | ConvertFrom-Json
@@ -78,8 +124,8 @@ try {
 
         New-Item -ItemType Directory -Path .github/workflows -Force | Out-Null
         'name: changed-ci' | Set-Content -LiteralPath .github/workflows/fixture.yml -Encoding utf8
-        & git add .github/workflows/fixture.yml
-        & git commit --quiet -m infrastructure-change
+        Invoke-Git add .github/workflows/fixture.yml
+        Invoke-Git commit --quiet -m infrastructure-change
         & $selector -MapFile shard-map.json -ExpectedShards @('Alpha', 'Beta', 'Always') `
             -OutFile infrastructure-selection.json
         $infrastructure = Get-Content infrastructure-selection.json -Raw | ConvertFrom-Json
@@ -88,17 +134,24 @@ try {
         $badCertificate = Get-Content certification.json -Raw | ConvertFrom-Json
         $badCertificate.missCount = 1
         $badCertificate | ConvertTo-Json -Depth 5 | Set-Content bad-certification.json -Encoding utf8
-        $rejected = $false
-        try {
-            & $certificateValidator -MapFile shard-map.json -CertificateFile bad-certification.json `
-                -CertificationRunId 102 2>$null
-        }
-        catch { $rejected = $true }
-        Assert-True $rejected 'a certificate recording a selection miss was accepted'
+        Assert-CertificateRejected -CertificateFile bad-certification.json `
+            -ExpectedPattern 'selection miss' `
+            -What 'a certificate recording a selection miss was accepted'
+
+        $badCertificate = Get-Content certification.json -Raw | ConvertFrom-Json
+        $badCertificate.failedShards = 0
+        $badCertificate | ConvertTo-Json -Depth 5 | Set-Content no-failure-certification.json -Encoding utf8
+        Assert-CertificateRejected -CertificateFile no-failure-certification.json `
+            -ExpectedPattern 'failedShards must be at least 1' `
+            -What 'a certificate without a failure opportunity was accepted'
     }
     finally {
         Pop-Location
     }
+}
+catch {
+    $fixtureFailure = $_
+    throw
 }
 finally {
     $resolvedFixture = [IO.Path]::GetFullPath($fixture)
@@ -107,7 +160,9 @@ finally {
         Remove-Item -LiteralPath $resolvedFixture -Recurse -Force -ErrorAction SilentlyContinue
     }
     else {
-        throw "refusing to remove unexpected fixture path '$resolvedFixture'"
+        $message = "refusing to remove unexpected fixture path '$resolvedFixture'"
+        if ($null -ne $fixtureFailure) { Write-Warning "$message; preserving the original failure" }
+        else { throw $message }
     }
 }
 


### PR DESCRIPTION
## Outcome

Repairs both CI time-saving paths introduced by #2072 and turns their assumptions into executable contracts.

### PR impact selection

- removes the repository-variable shadow switch that always restored all 116 shards
- repairs automatic map bootstrap (the no-checkout dispatcher now targets the repository explicitly)
- separates newly measured `candidate-shard-map` artifacts from audited `certified-shard-map` artifacts
- allows normal PRs to reduce only from a run-bound certificate whose non-escalated audit skipped work, observed at least one failing shard, and recorded zero misses
- keeps missing, expired, corrupt, stale, unmapped, or uncertified data fail-closed to the full matrix
- records only the candidate artifact actually downloaded, never an unchecked dispatch input

### Exact-tree master reuse

- gives every expensive job one typed `execute_expensive` decision from the exact-tree resolver
- gates Build, compatibility build, CodeQL, shard selection/tests, parameter sweeps, model-shape conformance, regression analysis, SonarCloud, artifact size, and aggregate analysis
- exact-tree merge pushes run only resolution, test-ledger promotion, and the final gate
- resolver failures retain immutable full-validation defaults
- requires a dedicated validation certificate published only after `CI Gate` succeeds; aggregate test data alone is no longer treated as proof
- fixes merge-group artifact discovery while preserving independent tree equality verification

### Gate correctness found during adversarial review

CodeQL, parameter sweeps, model-shape conformance, selector failure, and artifact-size validation previously were not dependencies of the required `CI Gate`. They could fail while the required check passed. Full validation now requires them; exact-tree reuse intentionally requires only resolver success and artifact promotion.

## Proofs

All are checked in and run before matrix selection and map construction:

- selector, map builder, incremental coverage, and miss-audit self-tests
- certificate corruption/type/run/SHA/miss/escalation/failure-opportunity negative controls, each bound to its exact rejection reason
- real temporary git repository: a covered one-line edit selects 2/3 shards; a workflow edit escalates
- actual checked-in CI Gate Bash body executed in nine modes:
  - reuse success
  - reuse missing promotion
  - full success
  - CodeQL failure
  - accepted known test failure
  - unenforced test failure
  - resolver/source failure in reuse mode
  - resolver/source failure in full mode
  - empty reuse decision falling back to full validation
- workflow graph contract: all 11 expensive jobs depend on the resolver, consume `fromJSON(execute_expensive)`, and feed the required gate
- `actionlint` GitHub YAML/expression validation
- ShellCheck over every changed Bash block
- PowerShell parser and PSScriptAnalyzer 1.25.0 validation, plus a clean staged diff

## Bootstrap behavior

This PR itself correctly runs full CI because it changes shared `.github/` infrastructure. After merge, the scheduled lifecycle advances automatically:

1. no source -> dispatch complete bootstrap coverage run
2. harvest bootstrap -> publish candidate and dispatch full audit run using that exact candidate
3. harvest audit -> publish certified map when reduction and a real failure opportunity were exercised with zero misses
4. subsequent ordinary PRs consume the latest certified map automatically

No repository variable or manual activation step remains.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CI validation safeguards with fail-closed handling when validation results cannot be confirmed.
  * Prevented unverified test-impact shard maps from being used for test selection.
  * Added support for bootstrapping test-impact analysis when no prior coverage source is available.

* **Tests**
  * Added automated checks for workflow contracts, shard-map certification, CI gate behavior, and end-to-end test-impact selection.
  * Added certification artifacts to verify that reduced test runs maintain complete coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
