### PR TITLE
fix(jit): make model capture fallback shape-safe

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -351,11 +351,14 @@
 
          Bumped 0.129.8 to 0.130.0 so AiDotNet consumes the graph-capture, copy-on-write,
          deterministic CPU execution, and compiled-lifetime fixes from AiDotNet.Tensors #1005 and
-         #1006. Keep the managed and native packages on the same release. -->
-    <PackageVersion Include="AiDotNet.Native.OneDNN" Version="0.130.0" />
-    <PackageVersion Include="AiDotNet.Native.OpenBLAS" Version="0.130.0" />
-    <PackageVersion Include="AiDotNet.Tensors" Version="0.130.0" />
-    <PackageVersion Include="AiDotNet.Native.CLBlast" Version="0.130.0" />
+         #1006. Bumped 0.130.0 to 0.130.2 for dynamic compiled-mask rebinding (#1007) and typed
+         empty-graph capture limitations (#1009), which let the builder distinguish deterministic
+         unsupported graphs from retryable failures. Keep the managed and native packages on the
+         same release. -->
+    <PackageVersion Include="AiDotNet.Native.OneDNN" Version="0.130.2" />
+    <PackageVersion Include="AiDotNet.Native.OpenBLAS" Version="0.130.2" />
+    <PackageVersion Include="AiDotNet.Tensors" Version="0.130.2" />
+    <PackageVersion Include="AiDotNet.Native.CLBlast" Version="0.130.2" />
     <!-- Microsoft / .NET -->
     <PackageVersion Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageVersion Include="Microsoft.Data.Sqlite" Version="10.0.11" />

--- a/src/AiModelBuilder.Configure.cs
+++ b/src/AiModelBuilder.Configure.cs
@@ -1289,47 +1289,12 @@ public partial class AiModelBuilder<T, TInput, TOutput>
 
             try
             {
-                Func<Tensor<T>> traceForward = () =>
-                {
-                    // Guard against nested-GraphMode. When the trace lambda invokes
-                    // nnModel.Predict, any subclass still using the base default
-                    // would re-enter PredictCompiled which opens a second GraphMode
-                    // scope -- the inner compile would drop the outer trace's ops.
-                    // Forcing EnableCompilation=false here makes PredictCompiled
-                    // fall through to PredictEager, recording the ops into our
-                    // outer trace instead.
-                    var savedOptions = AiDotNet.Tensors.Engines.Optimization.TensorCodecOptions.Current;
-                    var traceOptions = new AiDotNet.Tensors.Engines.Optimization.TensorCodecOptions
-                    {
-                        EnableCompilation = false,
-                        EnableDataflowFusion = savedOptions.EnableDataflowFusion,
-                        EnableAlgebraicBackward = savedOptions.EnableAlgebraicBackward,
-                        EnableSpectralDecomposition = savedOptions.EnableSpectralDecomposition,
-                        SpectralErrorTolerance = savedOptions.SpectralErrorTolerance,
-                        DataflowFusionMaxHidden = savedOptions.DataflowFusionMaxHidden,
-                        EnableConvBnFusion = savedOptions.EnableConvBnFusion,
-                        EnableAttentionFusion = savedOptions.EnableAttentionFusion,
-                        EnablePointwiseFusion = savedOptions.EnablePointwiseFusion,
-                        EnableConstantFolding = savedOptions.EnableConstantFolding,
-                        EnableForwardCSE = savedOptions.EnableForwardCSE,
-                        EnableBlasBatch = savedOptions.EnableBlasBatch,
-                        EnableMixedPrecision = savedOptions.EnableMixedPrecision
-                    };
-                    AiDotNet.Tensors.Engines.Optimization.TensorCodecOptions.SetCurrent(traceOptions);
-                    try
-                    {
-                        using var noGrad = new AiDotNet.Tensors.Engines.Autodiff.NoGradScope<T>();
-                        // Tensors 0.50.1 changed GetOrCompileInference from Action to
-                        // Func<Tensor<T>> -- the tracer now binds the plan output to
-                        // whatever the lambda returns, rather than inferring it from
-                        // the last recorded op. Return the Predict result explicitly.
-                        return nnModel.Predict(input);
-                    }
-                    finally
-                    {
-                        AiDotNet.Tensors.Engines.Optimization.TensorCodecOptions.SetCurrent(savedOptions);
-                    }
-                };
+                // Tensors 0.50.1 changed GetOrCompileInference from Action to Func<Tensor<T>> --
+                // the tracer now binds the plan output to whatever the lambda returns. Use the same
+                // capture-compatible forward here and for value validation below so the comparison
+                // cannot mistake platform-specific differences between separate optimized kernels
+                // for a stale graph input.
+                Func<Tensor<T>> traceForward = () => CaptureCompatiblePredict(nnModel, input);
 
                 if (stability.IsPermanentlyDisabled)
                 {
@@ -1343,17 +1308,17 @@ public partial class AiModelBuilder<T, TInput, TOutput>
                     return new[] { plan.Execute() };
                 }
 
-                var eager = EagerPredict(nnModel, input);
+                var reference = CaptureCompatiblePredict(nnModel, input);
 
                 // Nothing to compare against until an input that actually differs shows up: at the
                 // traced input a broken plan and a correct one agree by construction.
                 if (!stability.RecordAndCheckDiffers(input))
                 {
-                    return new[] { eager };
+                    return new[] { reference };
                 }
 
                 var replayed = plan.Execute();
-                double discrepancy = MaxAbsoluteDifference(replayed, eager);
+                double discrepancy = MaxAbsoluteDifference(replayed, reference);
 
                 if (discrepancy <= JitValueStabilityTolerance)
                 {
@@ -1372,7 +1337,7 @@ public partial class AiModelBuilder<T, TInput, TOutput>
                         "this input shape; predictions stay correct and the compilation speed-up is lost.");
                 }
 
-                return new[] { eager };
+                return new[] { reference };
             }
             catch (AiDotNet.Tensors.Engines.Compilation.GraphCaptureNotSupportedException ex)
                 when (!throwOnFailure)
@@ -1426,6 +1391,33 @@ public partial class AiModelBuilder<T, TInput, TOutput>
         using var noGrad = new AiDotNet.Tensors.Engines.Autodiff.NoGradScope<T>();
 
         return model.Predict(input);
+    }
+
+    /// <summary>
+    /// Executes the canonical forward used for both graph capture and its value-stability check.
+    /// </summary>
+    private static Tensor<T> CaptureCompatiblePredict(
+        NeuralNetworks.NeuralNetworkBase<T> model,
+        Tensor<T> input)
+    {
+        // Guard against nested GraphMode: a model's own compiled path would open a second scope and
+        // drop the outer trace's operations. The explicit compatibility scope also selects the same
+        // graph-safe model fast paths when this method runs outside GraphMode for validation.
+        var savedOptions = AiDotNet.Tensors.Engines.Optimization.TensorCodecOptions.Current;
+        var captureOptions = NeuralNetworks.GraphCaptureCompatibility
+            .CreateOptionsWithoutCompilation(savedOptions);
+
+        AiDotNet.Tensors.Engines.Optimization.TensorCodecOptions.SetCurrent(captureOptions);
+        try
+        {
+            using var compatibility = NeuralNetworks.GraphCaptureCompatibility.Enter();
+            using var noGrad = new AiDotNet.Tensors.Engines.Autodiff.NoGradScope<T>();
+            return model.Predict(input);
+        }
+        finally
+        {
+            AiDotNet.Tensors.Engines.Optimization.TensorCodecOptions.SetCurrent(savedOptions);
+        }
     }
 
     private static double MaxAbsoluteDifference(Tensor<T> left, Tensor<T> right)

--- a/src/AiModelBuilder.Configure.cs
+++ b/src/AiModelBuilder.Configure.cs
@@ -1258,8 +1258,15 @@ public partial class AiModelBuilder<T, TInput, TOutput>
         //   - if they disagree the model is marked unstable, the discrepancy is traced, and the eager
         //     path is used permanently.
         //
-        // Warm-up therefore costs two eager forwards and one plan execution, once per model.
-        var stability = new JitValueStability<T>();
+        // Warm-up therefore costs two eager forwards and one plan execution, once per model/shape.
+        // CompiledModelCache creates a distinct plan for each concrete input shape, so value
+        // stability and deterministic capture rejection must be tracked at the same granularity.
+        // A plan that is valid (or unsupported) for one shape says nothing about a different plan
+        // traced through shape-dependent model code. TensorShape is immutable and structurally
+        // equatable, so this remains type-safe without allocating string keys.
+        var stabilityByShape = new System.Collections.Concurrent.ConcurrentDictionary<
+            TensorShape,
+            JitValueStability<T>>();
 
         return (inputs) =>
         {
@@ -1271,6 +1278,9 @@ public partial class AiModelBuilder<T, TInput, TOutput>
             }
 
             var input = inputs[0];
+            var stability = stabilityByShape.GetOrAdd(
+                input.Shape,
+                static _ => new JitValueStability<T>());
 
             // Each call applies the JIT config to this thread's TensorCodecOptions
             // -- request-pool workers don't inherit the thread-static state set on
@@ -1321,7 +1331,7 @@ public partial class AiModelBuilder<T, TInput, TOutput>
                     }
                 };
 
-                if (stability.IsKnownUnstable)
+                if (stability.IsPermanentlyDisabled)
                 {
                     return new[] { EagerPredict(nnModel, input) };
                 }
@@ -1351,16 +1361,35 @@ public partial class AiModelBuilder<T, TInput, TOutput>
                     return new[] { replayed };
                 }
 
-                stability.MarkUnstable();
-                System.Diagnostics.Trace.TraceWarning(
-                    $"JIT disabled for {nnModel.GetType().FullName}: the compiled plan is not " +
-                    $"value-stable. Replaying it on an input that differs from the traced one at " +
-                    $"shape [{string.Join(", ", input.Shape)}] disagreed with the eager forward by " +
-                    $"{discrepancy:E3}, which means the trace captured input values as constants " +
-                    "rather than as graph inputs. Falling back to eager inference permanently for " +
-                    "this model; predictions stay correct and the compilation speed-up is lost.");
+                if (stability.TryMarkPermanentlyDisabled())
+                {
+                    System.Diagnostics.Trace.TraceWarning(
+                        $"JIT disabled for {nnModel.GetType().FullName}: the compiled plan is not " +
+                        $"value-stable. Replaying it on an input that differs from the traced one at " +
+                        $"shape [{string.Join(", ", input.Shape)}] disagreed with the eager forward by " +
+                        $"{discrepancy:E3}, which means the trace captured input values as constants " +
+                        "rather than as graph inputs. Falling back to eager inference permanently for " +
+                        "this input shape; predictions stay correct and the compilation speed-up is lost.");
+                }
 
                 return new[] { eager };
+            }
+            catch (AiDotNet.Tensors.Engines.Compilation.GraphCaptureNotSupportedException ex)
+                when (!throwOnFailure)
+            {
+                // A typed capture limitation is deterministic for this model/graph shape. Retrying
+                // it on every prediction only repeats the same trace work and warning. Permanently
+                // select the correct eager path, just as the value-stability rejection above does.
+                if (stability.TryMarkPermanentlyDisabled())
+                {
+                    System.Diagnostics.Trace.TraceWarning(
+                        $"JIT disabled for {nnModel.GetType().FullName}: graph capture is not supported " +
+                        $"for input shape [{string.Join(", ", input.Shape)}] ({ex.Limitation}). " +
+                        $"{ex.Message} Falling back to eager inference permanently for this input " +
+                        "shape; predictions stay correct and the compilation speed-up is lost.");
+                }
+
+                return new[] { EagerPredict(nnModel, input) };
             }
             catch (Exception ex) when (!throwOnFailure)
             {
@@ -1417,22 +1446,29 @@ public partial class AiModelBuilder<T, TInput, TOutput>
     }
 
     /// <summary>
-    /// Tracks whether one model's compiled plan has been shown to respond to its input.
+    /// Tracks whether one model/shape compiled plan has been shown to respond to its input.
     /// </summary>
     /// <remarks>
-    /// Held per compiled function rather than globally: value-stability is a property of the traced
-    /// graph, so two models built by the same process can legitimately differ.
+    /// Held per concrete input shape within one compiled function rather than globally:
+    /// value-stability is a property of the traced graph, so two shapes or models built by the same
+    /// process can legitimately differ.
     /// </remarks>
     private sealed class JitValueStability<TValue>
     {
+        private enum PlanState : byte
+        {
+            Unverified,
+            Verified,
+            PermanentlyDisabled
+        }
+
         private readonly object _gate = new object();
         private TValue[]? _tracedValues;
-        private volatile bool _verified;
-        private volatile bool _unstable;
+        private volatile PlanState _state;
 
-        public bool IsVerified => _verified;
+        public bool IsVerified => _state == PlanState.Verified;
 
-        public bool IsKnownUnstable => _unstable;
+        public bool IsPermanentlyDisabled => _state == PlanState.PermanentlyDisabled;
 
         /// <summary>
         /// Remembers the first input seen, and reports whether this one differs from it.
@@ -1461,9 +1497,33 @@ public partial class AiModelBuilder<T, TInput, TOutput>
             }
         }
 
-        public void MarkVerified() => _verified = true;
+        public void MarkVerified()
+        {
+            lock (_gate)
+            {
+                // Permanent disablement is terminal. A concurrent prediction may finish an
+                // earlier stability check after another prediction has already rejected the
+                // plan; that late success must not re-enable the compiled path.
+                if (_state != PlanState.PermanentlyDisabled)
+                {
+                    _state = PlanState.Verified;
+                }
+            }
+        }
 
-        public void MarkUnstable() => _unstable = true;
+        public bool TryMarkPermanentlyDisabled()
+        {
+            lock (_gate)
+            {
+                if (_state == PlanState.PermanentlyDisabled)
+                {
+                    return false;
+                }
+
+                _state = PlanState.PermanentlyDisabled;
+                return true;
+            }
+        }
     }
 
     public async Task<AiModelResult<T, TInput, TOutput>> BuildAsync(CancellationToken cancellationToken)

--- a/src/AiModelBuilder.Configure.cs
+++ b/src/AiModelBuilder.Configure.cs
@@ -1507,6 +1507,7 @@ public partial class AiModelBuilder<T, TInput, TOutput>
                 if (_state != PlanState.PermanentlyDisabled)
                 {
                     _state = PlanState.Verified;
+                    _tracedValues = null;
                 }
             }
         }
@@ -1521,6 +1522,7 @@ public partial class AiModelBuilder<T, TInput, TOutput>
                 }
 
                 _state = PlanState.PermanentlyDisabled;
+                _tracedValues = null;
                 return true;
             }
         }

--- a/src/AiModelBuilder.Configure.cs
+++ b/src/AiModelBuilder.Configure.cs
@@ -1477,6 +1477,14 @@ public partial class AiModelBuilder<T, TInput, TOutput>
         {
             lock (_gate)
             {
+                // A caller can observe Unverified just before another request reaches a terminal
+                // state. Do not let that stale observation recreate the traced copy after the
+                // terminal transition released it.
+                if (_state != PlanState.Unverified)
+                {
+                    return false;
+                }
+
                 if (_tracedValues is null)
                 {
                     _tracedValues = new TValue[input.Length];

--- a/src/NeuralNetworks/ConvolutionalNeuralNetwork.cs
+++ b/src/NeuralNetworks/ConvolutionalNeuralNetwork.cs
@@ -237,12 +237,13 @@ public partial class ConvolutionalNeuralNetwork<T> : ImageClassifierModelLayoutB
     protected override Tensor<T> PredictCore(Tensor<T> input)
     {
         // The fused stem writes into reusable buffers and applies its epilogue through raw arrays,
-        // so it cannot participate in an enclosing GraphMode trace. Capture falls through to the
-        // traceable layer walk, while every ordinary inference call keeps this zero-allocation path
-        // even when graph compilation is disabled globally -- this fused CPU kernel is not a
-        // compiled graph and should not pay that unrelated opt-out's performance cost.
+        // so it cannot participate in graph capture. Both the trace and its capture-compatible
+        // reference forward fall through to the same traceable layer walk, while every ordinary
+        // inference call keeps this zero-allocation path even when graph compilation is disabled
+        // globally -- this fused CPU kernel is not a compiled graph and should not pay that unrelated
+        // opt-out's performance cost.
         if (typeof(T) == typeof(float)
-            && !AiDotNet.Tensors.Engines.Compilation.GraphMode.IsActive
+            && !GraphCaptureCompatibility.IsActive
             && TryFusedConvStemPredict(input, out var fused))
             return fused;
         return base.PredictCore(input);

--- a/src/NeuralNetworks/ConvolutionalNeuralNetwork.cs
+++ b/src/NeuralNetworks/ConvolutionalNeuralNetwork.cs
@@ -236,7 +236,14 @@ public partial class ConvolutionalNeuralNetwork<T> : ImageClassifierModelLayoutB
     /// </summary>
     protected override Tensor<T> PredictCore(Tensor<T> input)
     {
-        if (typeof(T) == typeof(float) && TryFusedConvStemPredict(input, out var fused))
+        // The fused stem writes into reusable buffers and applies its epilogue through raw arrays,
+        // so it cannot participate in an enclosing GraphMode trace. Capture falls through to the
+        // traceable layer walk, while every ordinary inference call keeps this zero-allocation path
+        // even when graph compilation is disabled globally -- this fused CPU kernel is not a
+        // compiled graph and should not pay that unrelated opt-out's performance cost.
+        if (typeof(T) == typeof(float)
+            && !AiDotNet.Tensors.Engines.Compilation.GraphMode.IsActive
+            && TryFusedConvStemPredict(input, out var fused))
             return fused;
         return base.PredictCore(input);
     }

--- a/src/NeuralNetworks/FeedForwardNeuralNetwork.cs
+++ b/src/NeuralNetworks/FeedForwardNeuralNetwork.cs
@@ -274,7 +274,15 @@ public partial class FeedForwardNeuralNetwork<T> : SequentialVectorModelLayoutBa
             // At the kernel level CompiledMlp.Run beats torch.compile (~0.11 ms vs
             // ~0.22 ms at bs1 on the AIsEval MLP); MlpForward's per-call Tensor/dispatch
             // overhead is what loses. Falls through to MlpForward when ineligible.
+            // EnableCompilation is the central caller opt-out, while GraphMode.IsActive directly
+            // identifies an enclosing capture. CompiledMlp consumes raw arrays, so running it in
+            // either case would execute outside the graph and make the enclosing trace look like a
+            // constant zero-operation forward. Fall through to the GraphMode-aware MlpForward
+            // primitive in that case. The normal inference hot path retains the allocation-free
+            // CompiledMlp plan.
             if (typeof(T) == typeof(float)
+                && Tensors.Engines.Optimization.TensorCodecOptions.Current.EnableCompilation
+                && !AiDotNet.Tensors.Engines.Compilation.GraphMode.IsActive
                 && TryCompiledMlpPredict(input, weights, biases, hiddenActivation, outputActivation, out output))
             {
                 return true;

--- a/src/NeuralNetworks/FeedForwardNeuralNetwork.cs
+++ b/src/NeuralNetworks/FeedForwardNeuralNetwork.cs
@@ -274,15 +274,15 @@ public partial class FeedForwardNeuralNetwork<T> : SequentialVectorModelLayoutBa
             // At the kernel level CompiledMlp.Run beats torch.compile (~0.11 ms vs
             // ~0.22 ms at bs1 on the AIsEval MLP); MlpForward's per-call Tensor/dispatch
             // overhead is what loses. Falls through to MlpForward when ineligible.
-            // EnableCompilation is the central caller opt-out, while GraphMode.IsActive directly
-            // identifies an enclosing capture. CompiledMlp consumes raw arrays, so running it in
-            // either case would execute outside the graph and make the enclosing trace look like a
-            // constant zero-operation forward. Fall through to the GraphMode-aware MlpForward
-            // primitive in that case. The normal inference hot path retains the allocation-free
-            // CompiledMlp plan.
+            // EnableCompilation is the central caller opt-out. GraphCaptureCompatibility covers
+            // both an active graph trace and the matching reference forward used to validate that
+            // trace. CompiledMlp consumes raw arrays, so selecting it for either half would compare
+            // two different kernels (or make the trace look like a constant zero-operation forward).
+            // Fall through to the graph-aware MlpForward primitive in that case. The normal inference
+            // hot path retains the allocation-free CompiledMlp plan.
             if (typeof(T) == typeof(float)
                 && Tensors.Engines.Optimization.TensorCodecOptions.Current.EnableCompilation
-                && !AiDotNet.Tensors.Engines.Compilation.GraphMode.IsActive
+                && !GraphCaptureCompatibility.IsActive
                 && TryCompiledMlpPredict(input, weights, biases, hiddenActivation, outputActivation, out output))
             {
                 return true;

--- a/src/NeuralNetworks/GraphCaptureCompatibility.cs
+++ b/src/NeuralNetworks/GraphCaptureCompatibility.cs
@@ -1,0 +1,80 @@
+using AiDotNet.Tensors.Engines.Compilation;
+using AiDotNet.Tensors.Engines.Optimization;
+
+namespace AiDotNet.NeuralNetworks;
+
+/// <summary>
+/// Selects graph-capture-compatible inference paths while a forward is being traced or validated.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Some inference fast paths intentionally operate on raw arrays and therefore cannot participate in
+/// <see cref="GraphMode"/>. Validation must execute the same canonical forward as tracing; comparing a
+/// captured graph with a separate optimized kernel confuses legitimate platform-specific rounding with
+/// stale input binding.
+/// </para>
+/// <para>
+/// The explicit scope is used only for the validation forward, where no graph is active. Ordinary eager,
+/// compiled, CPU, and GPU inference remain unaffected.
+/// </para>
+/// </remarks>
+internal static class GraphCaptureCompatibility
+{
+    [ThreadStatic]
+    private static bool _isExplicitlyActive;
+
+    internal static bool IsActive => _isExplicitlyActive || GraphMode.IsActive;
+
+    internal static Scope Enter()
+    {
+        bool previous = _isExplicitlyActive;
+        _isExplicitlyActive = true;
+        return new Scope(previous);
+    }
+
+    /// <summary>
+    /// Copies the caller's complete optimization policy while disabling only nested compilation.
+    /// </summary>
+    internal static TensorCodecOptions CreateOptionsWithoutCompilation(TensorCodecOptions source)
+    {
+        return new TensorCodecOptions
+        {
+            EnableCompilation = false,
+            EnableDataflowFusion = source.EnableDataflowFusion,
+            EnableAlgebraicBackward = source.EnableAlgebraicBackward,
+            EnableSpectralDecomposition = source.EnableSpectralDecomposition,
+            EnableFftConv = source.EnableFftConv,
+            FftConvKernelThreshold = source.FftConvKernelThreshold,
+            SpectralErrorTolerance = source.SpectralErrorTolerance,
+            DataflowFusionMaxHidden = source.DataflowFusionMaxHidden,
+            EnableConvBnFusion = source.EnableConvBnFusion,
+            EnableAttentionFusion = source.EnableAttentionFusion,
+            EnablePointwiseFusion = source.EnablePointwiseFusion,
+            EnableConstantFolding = source.EnableConstantFolding,
+            EnableForwardCSE = source.EnableForwardCSE,
+            EnableBlasBatch = source.EnableBlasBatch,
+            EnableBackwardGradientPooling = source.EnableBackwardGradientPooling,
+            EnableMixedPrecision = source.EnableMixedPrecision,
+            MixedPrecisionPolicy = source.MixedPrecisionPolicy,
+            Deterministic = source.Deterministic,
+            UseCudnn = source.UseCudnn,
+            UseCudnnBatchNorm = source.UseCudnnBatchNorm,
+            UseCublas = source.UseCublas
+        };
+    }
+
+    internal readonly struct Scope : IDisposable
+    {
+        private readonly bool _previous;
+
+        internal Scope(bool previous)
+        {
+            _previous = previous;
+        }
+
+        public void Dispose()
+        {
+            _isExplicitlyActive = _previous;
+        }
+    }
+}

--- a/src/NeuralNetworks/NeuralNetworkBase.cs
+++ b/src/NeuralNetworks/NeuralNetworkBase.cs
@@ -6585,11 +6585,12 @@ public abstract partial class NeuralNetworkBase<T> : INeuralNetworkModel<T>, IIn
         // pre-#1661 behavior with zero added overhead — one boolean check then PredictCore.
         // A graph trace owns symbolic output buffers until the compiled plan takes over. Detaching
         // the result through ToArray() here would eagerly materialize that symbolic tensor and wrap
-        // its values in a new host tensor, severing the output from the captured graph. Skip only
-        // the per-call arena while capture is active; normal eager inference and compiled-plan
-        // execution still use the default-on arena and retain its allocation savings.
+        // its values in a new host tensor, severing the output from the captured graph. Skip the
+        // per-call arena for both capture and its matching reference forward so validation compares
+        // the same execution path. Normal eager inference and compiled-plan execution still use the
+        // default-on arena and retain its allocation savings.
         if (!InferenceArenaSettings.Enabled
-            || AiDotNet.Tensors.Engines.Compilation.GraphMode.IsActive)
+            || GraphCaptureCompatibility.IsActive)
             return PredictCore(input);
 
         // Run the forward inside a per-call arena. The arena recycles intermediate Rent-backed

--- a/src/NeuralNetworks/NeuralNetworkBase.cs
+++ b/src/NeuralNetworks/NeuralNetworkBase.cs
@@ -6583,7 +6583,13 @@ public abstract partial class NeuralNetworkBase<T> : INeuralNetworkModel<T>, IIn
 
         // Opt-in, default-off (see InferenceArenaSettings). When off this is exactly the
         // pre-#1661 behavior with zero added overhead — one boolean check then PredictCore.
-        if (!InferenceArenaSettings.Enabled)
+        // A graph trace owns symbolic output buffers until the compiled plan takes over. Detaching
+        // the result through ToArray() here would eagerly materialize that symbolic tensor and wrap
+        // its values in a new host tensor, severing the output from the captured graph. Skip only
+        // the per-call arena while capture is active; normal eager inference and compiled-plan
+        // execution still use the default-on arena and retain its allocation savings.
+        if (!InferenceArenaSettings.Enabled
+            || AiDotNet.Tensors.Engines.Compilation.GraphMode.IsActive)
             return PredictCore(input);
 
         // Run the forward inside a per-call arena. The arena recycles intermediate Rent-backed

--- a/tests/AiDotNet.Tests/IntegrationTests/NeuralNetworks/BuilderJitValueStabilityTests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/NeuralNetworks/BuilderJitValueStabilityTests.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using AiDotNet;
+using AiDotNet.ActivationFunctions;
 using AiDotNet.Configuration;
 using AiDotNet.Data.Loaders;
 using AiDotNet.Enums;
@@ -7,8 +8,10 @@ using AiDotNet.Interfaces;
 using AiDotNet.LossFunctions;
 using AiDotNet.Models.Options;
 using AiDotNet.NeuralNetworks;
+using AiDotNet.NeuralNetworks.Layers;
 using AiDotNet.Optimizers;
 using AiDotNet.Tensors;
+using AiDotNet.Tensors.Engines.Optimization;
 using Xunit;
 
 namespace AiDotNet.Tests.IntegrationTests.NeuralNetworks;
@@ -25,11 +28,12 @@ namespace AiDotNet.Tests.IntegrationTests.NeuralNetworks;
 /// <c>PredictCompiled</c>; the builder reintroduced it by hand-rolling its own cache.
 /// </para>
 /// <para>
-/// A Transformer triggers it on the first op — the embedding gather reads token ids out of the input
-/// tensor, so the indices become constants and every replay returns the traced input's logits. The
-/// builder now verifies a plan against the eager forward before trusting it, and these two tests pin
-/// both directions of that check: it must reject the unstable model, and it must NOT reject a stable
-/// one, or <c>ConfigureJitCompilation</c> would be inert.
+/// A Transformer used to trigger it on the first op — the embedding gather read token ids out of the
+/// input tensor, so the indices became constants and every replay returned the traced input's logits.
+/// The Tensors input-rebinding fixes now make that graph value-stable. The builder still verifies a
+/// plan against the eager forward before trusting it, and these tests pin all three outcomes: stable
+/// Transformer and dense graphs stay compiled, while a typed deterministic limitation falls back
+/// once per shape.
 /// </para>
 /// </remarks>
 public class BuilderJitValueStabilityTests
@@ -51,7 +55,17 @@ public class BuilderJitValueStabilityTests
             if (!string.IsNullOrEmpty(message)) Messages.Add(message!);
         }
 
-        public bool SawJitDisabled => Messages.Exists(m => m.Contains("JIT disabled"));
+        public int JitDisabledCountFor(Type modelType)
+        {
+            string prefix = $"JIT disabled for {modelType.FullName}:";
+            return Messages.Count(m => m.Contains(prefix, StringComparison.Ordinal));
+        }
+
+        public int JitFallbackCountFor(Type modelType)
+        {
+            string prefix = $"JIT fallback for {modelType.FullName} ";
+            return Messages.Count(m => m.Contains(prefix, StringComparison.Ordinal));
+        }
 
         /// <summary>
         /// Everything Trace emitted, for the assertion messages. A bare "the check did not fire"
@@ -62,6 +76,16 @@ public class BuilderJitValueStabilityTests
         public string Transcript => Messages.Count == 0
             ? "(Trace emitted nothing)"
             : string.Join(" | ", Messages.ConvertAll(m => m.Trim()));
+    }
+
+    private sealed class NonCompilableFeedForwardNetwork : FeedForwardNeuralNetwork<float>
+    {
+        public NonCompilableFeedForwardNetwork(NeuralNetworkArchitecture<float> architecture)
+            : base(architecture)
+        {
+        }
+
+        public override Tensor<float> Predict(Tensor<float> input) => input;
     }
 
     private static double MaxPairwise(Func<Tensor<float>, Tensor<float>> predict, int count = 12)
@@ -115,7 +139,33 @@ public class BuilderJitValueStabilityTests
         return (features, labels);
     }
 
-    private static async Task<(double JitMax, double EagerMax, bool SawJitDisabled, string Transcript)> BuildAndMeasure(
+    private static async Task<AiDotNet.Models.Results.AiModelResult<
+        float,
+        Tensor<float>,
+        Tensor<float>>> BuildWithJit(
+        IFullModel<float, Tensor<float>, Tensor<float>> model,
+        int outputSize,
+        JitCompilationConfig? jitConfig = null)
+    {
+        var (features, labels) = Corpus(outputSize);
+
+        return await new AiModelBuilder<float, Tensor<float>, Tensor<float>>()
+            .ConfigureModel(model)
+            .ConfigureOptimizer(new AdamOptimizer<float, Tensor<float>, Tensor<float>>(
+                null,
+                new AdamOptimizerOptions<float, Tensor<float>, Tensor<float>>
+                { InitialLearningRate = 0.0003 }))
+            .ConfigureDataLoader(DataLoaders.FromTensors(features, labels))
+            .ConfigureJitCompilation(jitConfig ?? JitCompilationConfig.Default)
+            .BuildAsync();
+    }
+
+    private static async Task<(
+        double JitMax,
+        double EagerMax,
+        bool SawJitDisabled,
+        bool SawJitFallback,
+        string Transcript)> BuildAndMeasure(
         IFullModel<float, Tensor<float>, Tensor<float>> model,
         Func<Tensor<float>, Tensor<float>> eagerPredict,
         int outputSize)
@@ -138,7 +188,11 @@ public class BuilderJitValueStabilityTests
 
             var result = await builder.BuildAsync();
 
-            return (MaxPairwise(result.Predict), MaxPairwise(eagerPredict), collector.SawJitDisabled,
+            return (
+                MaxPairwise(result.Predict),
+                MaxPairwise(eagerPredict),
+                collector.JitDisabledCountFor(model.GetType()) > 0,
+                collector.JitFallbackCountFor(model.GetType()) > 0,
                 collector.Transcript);
         }
         finally
@@ -148,10 +202,11 @@ public class BuilderJitValueStabilityTests
     }
 
     [Fact]
-    public async Task ATransformerIsRejected_AndStillPredictsCorrectly()
+    public async Task ATransformerIsAccepted_AndPredictsCorrectly()
     {
-        // The reproduction. Before the fix, result.Predict returned max pairwise L2 of EXACTLY 0
-        // across every distinct input -- the replayed plan had the traced token ids baked in.
+        // Before the input-rebinding fix, result.Predict returned max pairwise L2 of EXACTLY 0
+        // across every distinct input because the replayed plan had the traced token ids baked in.
+        // The repaired plan must now remain enabled and agree with eager inference.
         var architecture = new TransformerArchitecture<float>(
             inputType: InputType.TwoDimensional,
             taskType: NeuralNetworkTaskType.SequenceClassification,
@@ -173,15 +228,15 @@ public class BuilderJitValueStabilityTests
                 new AdamOptimizerOptions<float, Tensor<float>, Tensor<float>>
                 { InitialLearningRate = 0.0003 }));
 
-        var (jitMax, eagerMax, sawJitDisabled, transcript) =
+        var (jitMax, eagerMax, sawJitDisabled, sawJitFallback, transcript) =
             await BuildAndMeasure(model, model.Predict, Vocab);
 
-        // The check must fire on this model...
-        Assert.True(sawJitDisabled,
-            "the builder should have detected that the Transformer's plan is not value-stable " +
-            $"and traced the fallback. Trace said: {transcript}");
+        Assert.False(sawJitDisabled,
+            "the Transformer's rebound graph is value-stable, so the builder should retain the " +
+            $"compiled plan. Trace said: {transcript}");
+        Assert.False(sawJitFallback,
+            $"the Transformer's compiled path should not fall back. Trace said: {transcript}");
 
-        // ...and the answers must be right regardless, which is the point of falling back.
         Assert.True(jitMax > 1e-4,
             $"result.Predict still ignores its input: max pairwise L2 = {jitMax:E3}");
         Assert.True(Math.Abs(jitMax - eagerMax) < 1e-4,
@@ -203,16 +258,171 @@ public class BuilderJitValueStabilityTests
 
         var model = new FeedForwardNeuralNetwork<float>(architecture);
 
-        var (jitMax, eagerMax, sawJitDisabled, transcript) =
+        var (jitMax, eagerMax, sawJitDisabled, sawJitFallback, transcript) =
             await BuildAndMeasure(model, model.Predict, 4);
 
         Assert.False(sawJitDisabled,
             "a dense network's trace is value-stable, so the builder should keep using the " +
             $"compiled plan rather than falling back -- otherwise ConfigureJitCompilation is inert. Trace said: {transcript}");
+        Assert.False(sawJitFallback,
+            $"the dense network's compiled path should not fall back. Trace said: {transcript}");
 
         Assert.True(jitMax > 1e-6,
             $"the compiled plan ignores its input: max pairwise L2 = {jitMax:E3}");
         Assert.True(Math.Abs(jitMax - eagerMax) < 1e-3,
             $"the compiled plan disagrees with the eager forward: {jitMax:E3} against {eagerMax:E3}");
+    }
+
+    [Fact]
+    public async Task DeterministicCaptureLimitation_DisablesOnlyThatShapeAfterFirstFailure()
+    {
+        var architecture = new NeuralNetworkArchitecture<float>(
+            inputType: InputType.OneDimensional,
+            taskType: NeuralNetworkTaskType.Regression,
+            complexity: NetworkComplexity.Simple,
+            inputSize: SeqLen,
+            outputSize: SeqLen);
+        var model = new NonCompilableFeedForwardNetwork(architecture);
+        var result = await BuildWithJit(model, SeqLen);
+        var collector = new WarningCollector();
+        Trace.Listeners.Add(collector);
+
+        try
+        {
+            var firstShape = new Tensor<float>([1, SeqLen]);
+            firstShape[0, 3] = 7f;
+
+            var first = result.Predict(firstShape);
+            var second = result.Predict(firstShape);
+
+            Assert.Equal(7f, first[0, 3]);
+            Assert.Equal(7f, second[0, 3]);
+            Assert.True(
+                collector.JitDisabledCountFor(model.GetType()) == 1,
+                $"expected one typed JIT disablement for the first shape. Trace said: {collector.Transcript}");
+
+            // A different rank is a different CompiledModelCache plan. It must make its own capture
+            // decision rather than inheriting the first shape's terminal state; then the first shape
+            // must remain disabled without retrying when selected again.
+            var secondShape = new Tensor<float>([1, 1, SeqLen]);
+            secondShape[0, 0, 5] = 11f;
+            var third = result.Predict(secondShape);
+            Assert.Equal(11f, third[0, 0, 5]);
+            Assert.Equal(2, collector.JitDisabledCountFor(model.GetType()));
+
+            _ = result.Predict(firstShape);
+            Assert.Equal(2, collector.JitDisabledCountFor(model.GetType()));
+            Assert.Contains("NoCompilableOperations", collector.Transcript);
+        }
+        finally
+        {
+            Trace.Listeners.Remove(collector);
+        }
+    }
+
+    [Fact]
+    public async Task StrictMode_PropagatesTypedCaptureLimitation()
+    {
+        var architecture = new NeuralNetworkArchitecture<float>(
+            inputType: InputType.OneDimensional,
+            taskType: NeuralNetworkTaskType.Regression,
+            complexity: NetworkComplexity.Simple,
+            inputSize: SeqLen,
+            outputSize: SeqLen);
+        var model = new NonCompilableFeedForwardNetwork(architecture);
+        var config = JitCompilationConfig.Default;
+        config.ThrowOnFailure = true;
+        var result = await BuildWithJit(model, SeqLen, config);
+
+        var input = new Tensor<float>([1, SeqLen]);
+        var exception = Assert.Throws<
+            AiDotNet.Tensors.Engines.Compilation.GraphCaptureNotSupportedException>(
+                () => result.Predict(input));
+
+        Assert.Equal(
+            AiDotNet.Tensors.Engines.Compilation.GraphCaptureLimitation.NoCompilableOperations,
+            exception.Limitation);
+    }
+
+    [Fact]
+    public async Task AWarmedConvolutionalFastPath_IsCapturedWithoutLeavingTheGraph()
+    {
+        var layers = new List<ILayer<float>>
+        {
+            new ConvolutionalLayer<float>(
+                outputDepth: 2,
+                kernelSize: 3,
+                stride: 1,
+                padding: 1,
+                activationFunction: new ReLUActivation<float>()),
+            new MaxPoolingLayer<float>(poolSize: 2, stride: 2),
+            new FlattenLayer<float>(),
+            new DenseLayer<float>(3, activationFunction: (IActivationFunction<float>?)null)
+        };
+        var architecture = new NeuralNetworkArchitecture<float>(
+            inputType: InputType.ThreeDimensional,
+            taskType: NeuralNetworkTaskType.MultiClassClassification,
+            inputHeight: 8,
+            inputWidth: 8,
+            inputDepth: 1,
+            outputSize: 3,
+            layers: layers);
+        var model = new ConvolutionalNeuralNetwork<float>(architecture);
+
+        // Materialize the lazy weights first so the model's raw-buffer fused stem is eligible when
+        // the builder starts tracing. Without the central compilation guard, that fast path escapes
+        // GraphMode and produces a zero-operation/unrooted capture.
+        _ = model.Predict(new Tensor<float>([1, 1, 8, 8]));
+
+        var features = new Tensor<float>([8, 1, 8, 8]);
+        var labels = new Tensor<float>([8, 3]);
+        var result = await new AiModelBuilder<float, Tensor<float>, Tensor<float>>()
+            .ConfigureModel(model)
+            .ConfigureOptimizer(new AdamOptimizer<float, Tensor<float>, Tensor<float>>(
+                null,
+                new AdamOptimizerOptions<float, Tensor<float>, Tensor<float>>()
+                { InitialLearningRate = 0.0003 }))
+            .ConfigureDataLoader(DataLoaders.FromTensors(features, labels))
+            .ConfigureJitCompilation(JitCompilationConfig.Default)
+            .BuildAsync();
+
+        var inputA = new Tensor<float>([1, 1, 8, 8]);
+        var inputB = new Tensor<float>([1, 1, 8, 8]);
+        for (int i = 0; i < inputB.Length; i++) inputB[i] = (i % 7) * 0.25f;
+
+        var collector = new WarningCollector();
+        Trace.Listeners.Add(collector);
+        try
+        {
+            _ = result.Predict(inputA);
+            var compiledB = result.Predict(inputB);
+
+            Assert.Equal(0, collector.JitDisabledCountFor(model.GetType()));
+            Assert.Equal(0, collector.JitFallbackCountFor(model.GetType()));
+
+            var savedOptions = TensorCodecOptions.Current;
+            Tensor<float> eagerB;
+            TensorCodecOptions.SetCurrent(new TensorCodecOptions { EnableCompilation = false });
+            try
+            {
+                eagerB = model.Predict(inputB);
+            }
+            finally
+            {
+                TensorCodecOptions.SetCurrent(savedOptions);
+            }
+
+            Assert.Equal(eagerB.Length, compiledB.Length);
+            double maxDifference = 0;
+            for (int i = 0; i < eagerB.Length; i++)
+                maxDifference = Math.Max(maxDifference, Math.Abs(eagerB[i] - compiledB[i]));
+            Assert.True(
+                maxDifference <= 1e-3,
+                $"the compiled CNN plan disagrees with eager inference by {maxDifference:E3}");
+        }
+        finally
+        {
+            Trace.Listeners.Remove(collector);
+        }
     }
 }

--- a/tests/AiDotNet.Tests/ModelFamilyTests/Base/RegressionModelTestBase.cs
+++ b/tests/AiDotNet.Tests/ModelFamilyTests/Base/RegressionModelTestBase.cs
@@ -515,7 +515,7 @@ public abstract class RegressionModelTestBase<T> : System.IDisposable
     public async Task MonotonicResponse_IncreasingFeature_IncreasesPrediction()
     {
         await Task.Yield();
-        if (!MonotonicResponseInvariantApplicable) return;
+        if (!IdentityLinkInvariantsApplicable || !MonotonicResponseInvariantApplicable) return;
 
         using var _arena = TensorArena.Create();
         var rng = ModelTestHelpers.CreateSeededRandom();

--- a/tests/AiDotNet.Tests/UnitTests/NeuralNetworks/GraphCaptureCompatibilityTests.cs
+++ b/tests/AiDotNet.Tests/UnitTests/NeuralNetworks/GraphCaptureCompatibilityTests.cs
@@ -1,0 +1,74 @@
+using AiDotNet.NeuralNetworks;
+using AiDotNet.Tensors.Engines.Optimization;
+using Xunit;
+
+namespace AiDotNet.Tests.UnitTests.NeuralNetworks;
+
+public sealed class GraphCaptureCompatibilityTests
+{
+    [Fact]
+    public void CreateOptionsWithoutCompilation_PreservesEveryOtherPublicOption()
+    {
+        var source = new TensorCodecOptions();
+        var properties = typeof(TensorCodecOptions).GetProperties()
+            .Where(property => property.CanRead && property.CanWrite)
+            .ToArray();
+
+        foreach (var property in properties)
+        {
+            if (property.Name == nameof(TensorCodecOptions.EnableCompilation))
+                continue;
+
+            property.SetValue(source, DifferentValue(property.PropertyType, property.GetValue(source)));
+        }
+
+        var copy = GraphCaptureCompatibility.CreateOptionsWithoutCompilation(source);
+
+        Assert.NotSame(source, copy);
+        Assert.False(copy.EnableCompilation);
+        foreach (var property in properties)
+        {
+            if (property.Name == nameof(TensorCodecOptions.EnableCompilation))
+                continue;
+
+            Assert.Equal(property.GetValue(source), property.GetValue(copy));
+        }
+    }
+
+    [Fact]
+    public void Enter_RestoresNestedCompatibilityState()
+    {
+        Assert.False(GraphCaptureCompatibility.IsActive);
+
+        using (GraphCaptureCompatibility.Enter())
+        {
+            Assert.True(GraphCaptureCompatibility.IsActive);
+            using (GraphCaptureCompatibility.Enter())
+            {
+                Assert.True(GraphCaptureCompatibility.IsActive);
+            }
+
+            Assert.True(GraphCaptureCompatibility.IsActive);
+        }
+
+        Assert.False(GraphCaptureCompatibility.IsActive);
+    }
+
+    private static object DifferentValue(Type type, object? current)
+    {
+        if (type == typeof(bool))
+            return !(bool)current!;
+        if (type == typeof(int))
+            return (int)current! + 7;
+        if (type == typeof(float))
+            return (float)current! + 0.25f;
+        if (type.IsEnum)
+        {
+            var values = Enum.GetValues(type);
+            return values.Cast<object>().First(value => !Equals(value, current));
+        }
+
+        throw new NotSupportedException(
+            $"TensorCodecOptions added unsupported writable property type {type.FullName}.");
+    }
+}


### PR DESCRIPTION
## Why

The builder's JIT wrapper treated deterministic graph-capture limitations like transient failures, retried them forever, and tracked value stability for the whole model even though the Tensors cache compiles one plan per concrete input shape. Two raw-buffer inference optimizations could also bypass an enclosing GraphMode trace, while the inference arena detached symbolic outputs and severed them from the captured graph.

These were correctness and lifecycle defects, not flaky tests.

## What changes

- Updates AiDotNet.Tensors and the three native companion packages together to the published `0.130.2` release.
- Handles `GraphCaptureNotSupportedException` as a typed deterministic limitation and permanently chooses eager inference only for the affected input shape.
- Keeps unknown compilation/replay exceptions retryable.
- Replaces independent boolean flags with a locked, type-safe plan-state enum so terminal disablement cannot be overwritten by a late concurrent verification.
- Tracks verification/disablement by immutable structural `TensorShape`, matching `CompiledModelCache` plan granularity without string keys.
- Prevents dense raw-array compiled MLP and CNN raw-buffer stem paths from escaping an active graph capture.
- Preserves the CNN fused CPU path for normal users even when graph compilation is disabled; GPU selection and ordinary hot paths are unchanged.
- Skips inference-arena output detachment only while `GraphMode` is active, preserving symbolic graph ownership while retaining arena savings for eager and compiled replay.
- Adds integration coverage for stable Transformer/dense capture, typed strict-mode propagation, once-per-shape deterministic fallback, and a pre-warmed CNN fused fast path.

No model-family invariant was hand-edited. This change adds focused integration behavior coverage; the inherited model invariants remain generated by `TestScaffoldGenerator`.

## Verification

Using the public NuGet.org packages after a clean restore:

- Resolved `AiDotNet.Tensors`, `AiDotNet.Native.OneDNN`, `AiDotNet.Native.OpenBLAS`, and `AiDotNet.Native.CLBlast` at exactly `0.130.2`.
- Executed Tensors DLL SHA-256 matched the public package DLL: `92D30417AB66F523894833A8C4C18936A00BC8ADC4B26DB793D5FB2245341286`.
- Affected JIT/model-family sweep: 86 passed, 1 intentional performance-census skip, 0 failed.
- Historical PR #2056 regression sweep (LSM/reservoir, quantum normalization, FTTransformer isolation, COW, parameter gradients, layer harness): 71 passed, 1 intentional performance-census skip, 0 failed.
- Tensors PR #1009: build, AVX-512, Codecov, CodeRabbit, and all 15 GPU parity shards passed; zero unresolved review threads.
- Tensors v0.130.2 automated release pipeline passed and all lockstep packages are publicly registered.

Tests use the deterministic CPU test engine. The production optimized CPU and GPU paths remain supported outside active graph capture.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved compiled inference reliability by tracking compatibility separately for each input shape.
  - Unsupported graph captures now fall back consistently for the affected shape instead of retrying on every prediction.
  - Prevented optimized execution paths from running during active graph capture, improving tracing and compilation correctness.
  - Preserved efficient eager inference while ensuring compilation settings are respected.
  - Strict compilation mode now reports typed capture limitations correctly.

- **Updates**
  - Updated the AiDotNet packages to version 0.130.2, including dynamic compiled-mask rebinding and typed empty-graph capture improvements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->