### PR TITLE
fix: in-place parameter updates (#1842) + CI cannot report a dead shard as success (#2086)

### DIFF
--- a/.github/scripts/get-selected-shard-names.ps1
+++ b/.github/scripts/get-selected-shard-names.ps1
@@ -1,0 +1,48 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [AllowEmptyString()]
+    [string] $MatrixJson
+)
+
+$ErrorActionPreference = 'Stop'
+
+if ([string]::IsNullOrWhiteSpace($MatrixJson)) {
+    throw 'Selected shard matrix is unavailable; refusing to publish an unverifiable test inventory.'
+}
+
+try {
+    $document = [System.Text.Json.JsonDocument]::Parse($MatrixJson)
+    if ($document.RootElement.ValueKind -ne [System.Text.Json.JsonValueKind]::Array) {
+        throw 'the root value must be an array'
+    }
+    $matrix = @($MatrixJson | ConvertFrom-Json -ErrorAction Stop)
+}
+catch {
+    throw "Could not parse the selected shard matrix: $($_.Exception.Message)"
+}
+finally {
+    if ($null -ne $document) { $document.Dispose() }
+}
+
+if ($matrix.Count -eq 0) {
+    throw 'Selected shard matrix contains no shards.'
+}
+
+$names = New-Object System.Collections.Generic.List[string]
+$keys = New-Object System.Collections.Generic.HashSet[string]([StringComparer]::Ordinal)
+foreach ($shard in $matrix) {
+    $name = [string] $shard.name
+    if ([string]::IsNullOrWhiteSpace($name)) {
+        throw 'Selected shard matrix contains a shard with no name.'
+    }
+
+    $key = $name -replace '[\\/:*?"<>|\s-]+', '_'
+    if (-not $keys.Add($key)) {
+        throw "Selected shard names collide after normalization: '$name' maps to '$key'."
+    }
+    $names.Add($name)
+}
+
+# The success stream is the contract consumed by the workflow.
+$names

--- a/.github/scripts/test-regression-analysis.ps1
+++ b/.github/scripts/test-regression-analysis.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
 Builds a machine-readable test ledger from TRX files and, when a baseline is
 available, evaluates AiDotNet's regression policy.
@@ -33,6 +33,11 @@ param(
     [string] $BaselineSha,
     [string] $RepositoryPath = '.',
     [string] $ApprovedShardChangesPath,
+    # Shard names the matrix actually dispatched for this run. Without it, inventory mode
+    # (no baseline) has NO expected set, so a shard whose runner died before uploading is
+    # indistinguishable from a shard that never existed -- it is simply absent, the counts
+    # are taken over whatever did arrive, and the run self-reports fully green. #2086.
+    [string[]] $ExpectedShardNames = @(),
     [switch] $FailOnPolicy
 )
 
@@ -469,8 +474,66 @@ $failureCsvPath = Join-Path $OutputDirectory 'failures.csv'
 $shardCsvPath = Join-Path $OutputDirectory 'shards.csv'
 
 $current = Read-TestLedger -Root $CurrentResultsPath -Sha $CurrentSha
+
+# #2086: a shard whose runner dies before uploading its artifact is simply ABSENT. The
+# baseline path already handles that -- it walks the baseline's shards and synthesizes a
+# 'Missing' entry for any that produced nothing. Inventory mode (no baseline) had no
+# expected set at all, so absence was unobservable there: the counts were taken over
+# whatever arrived, every arrived shard passed, and the run reported
+# "115 shards, 115 passed, 0 failed, 0 incomplete" while Integration D had died.
+#
+# The expected set is the matrix the run actually dispatched, passed in by the workflow.
+# Shards that selection deliberately skipped are excluded upstream (they are merged into
+# the approved shard-change manifest), so anything expected-but-absent here died.
+$missingExpectedShards = New-Object System.Collections.Generic.List[object]
+if ($ExpectedShardNames.Count -gt 0) {
+    $presentShardKeys = New-Object System.Collections.Generic.HashSet[string]([StringComparer]::Ordinal)
+    foreach ($shard in @($current.shards)) { [void] $presentShardKeys.Add([string] $shard.key) }
+
+    foreach ($expectedName in $ExpectedShardNames) {
+        if ([string]::IsNullOrWhiteSpace($expectedName)) { continue }
+        $expectedKey = ConvertTo-ShardKey $expectedName
+        if ($presentShardKeys.Contains($expectedKey)) { continue }
+
+        $missingExpectedShards.Add([PSCustomObject]@{
+            key = $expectedKey
+            name = [string] $expectedName
+            status = 'Missing'
+            policyStatus = 'Missing'
+            total = 0
+            executed = 0
+            notExecuted = 0
+            aborted = 0
+            failed = 0
+            confirmedFailed = 0
+            rerunPassedFailures = 0
+            missingTrx = $true
+            hostLifecycleFailed = $true
+            parseErrors = @('This shard was dispatched by the matrix but uploaded no artifact; its runner did not complete.')
+            testStepOutcome = 'missing'
+        })
+    }
+
+}
+
+# The ledger object itself is deliberately NOT mutated -- the baseline path keeps its own
+# synthesized 'Missing' shards in a separate list for the same reason, and reassigning the
+# List[object] that Read-TestLedger exposes trips a PSToObjectArrayBinder ArgumentException.
+# The rows are merged only where they are reported.
+$shardRows = New-Object System.Collections.Generic.List[object]
+foreach ($shard in @($current.shards)) { $shardRows.Add($shard) }
+foreach ($shard in $missingExpectedShards) { $shardRows.Add($shard) }
+
+# Stamp the hole onto the ledger itself. find-test-baseline.ps1 deliberately does NOT filter
+# baseline candidates by run conclusion ("master workflows can be cancelled by CodeQL after every
+# test shard has already uploaded a valid TRX"), so failing this run is not enough to stop an
+# incomplete ledger being adopted as a baseline later. Recording the missing shard names in the
+# artifact lets the consumer refuse it on its own evidence. #2086.
+$current | Add-Member -MemberType NoteProperty -Name missingExpectedShards `
+    -Value @($missingExpectedShards | ForEach-Object { [string] $_.name }) -Force
+
 Write-JsonFile $current $ledgerPath
-$current.shards |
+$shardRows |
     Select-Object key, name, status, policyStatus, total, executed, notExecuted, aborted,
         failed, confirmedFailed, rerunPassedFailures, missingTrx, hostLifecycleFailed, testStepOutcome |
     Export-Csv -LiteralPath $shardCsvPath -NoTypeInformation -Encoding utf8
@@ -504,19 +567,51 @@ if (($BaselineLedgerPath -or $BaselineResultsPath) -and
     throw "Resolved baseline '$BaselineSha' contains zero measured test shards; refusing to enforce a false regression comparison."
 }
 
+# A baseline that was itself missing a dispatched shard has a hole in it. Comparing against it
+# would silently inherit that blind spot: the absent shard is in neither side, so its failures
+# can never be classified as new. Refuse it rather than launder the gap forward. #2086.
+if ($baseline -and $baseline.PSObject.Properties['missingExpectedShards']) {
+    $baselineHoles = @($baseline.missingExpectedShards | Where-Object { $_ })
+    if ($baselineHoles.Count -gt 0) {
+        throw ("Resolved baseline '$BaselineSha' is incomplete: $($baselineHoles.Count) dispatched shard(s) " +
+            "uploaded no artifact ($($baselineHoles -join ', ')). Refusing to compare against a baseline with a hole in it.")
+    }
+}
+
 if (-not $baseline) {
+    # A ledger missing a dispatched shard must never be published as a baseline: later pull
+    # requests are diffed against it, so the gap would be normalised and that shard's future
+    # failures would go unnoticed too. #2086.
+    $inventoryComplete = $missingExpectedShards.Count -eq 0
     $summary = [PSCustomObject]@{
         mode = 'inventory'
         currentSha = $CurrentSha
         counts = $currentStats
         failureCategories = $currentCategories
-        policyPassed = $true
+        missingExpectedShards = @($missingExpectedShards | ForEach-Object { $_.name })
+        baselinePublishable = $inventoryComplete
+        policyPassed = $inventoryComplete
     }
-    $lines.Add("Current master ledger: **$($currentStats.shardCount) shards**, **$($currentStats.passedShards) passed**, **$($currentStats.failedShards) failed**, **$($currentStats.incompleteShards) incomplete**.")
+    # The shard count must include shards that uploaded nothing. Reporting only the artifacts
+    # that arrived is what made a run with a dead shard read as "115 shards, 115 passed".
+    $dispatchedShardCount = $currentStats.shardCount + $missingExpectedShards.Count
+    $missingClause = if ($missingExpectedShards.Count -gt 0) { ", **$($missingExpectedShards.Count) missing**" } else { '' }
+    $lines.Add("Current master ledger: **$dispatchedShardCount shards**, **$($currentStats.passedShards) passed**, **$($currentStats.failedShards) failed**, **$($currentStats.incompleteShards) incomplete**$missingClause.")
     $lines.Add('')
     $lines.Add("The TRX files report **$($currentStats.reportedFailureResults) failing results** representing **$($currentStats.distinctFailures) distinct failing tests**.")
     $lines.Add('')
-    $lines.Add('This push establishes the TRX baseline artifact used by later pull requests.')
+    if ($inventoryComplete) {
+        $lines.Add('This push establishes the TRX baseline artifact used by later pull requests.')
+    } else {
+        $lines.Add("> [!CAUTION]")
+        $lines.Add("> **$($missingExpectedShards.Count) dispatched shard(s) uploaded no artifact** and are recorded as ``Missing``:")
+        foreach ($shard in $missingExpectedShards) { $lines.Add("> - ``$($shard.name)``") }
+        $lines.Add('>')
+        $lines.Add('> A shard that dispatched but produced nothing did not pass - its runner did not')
+        $lines.Add('> complete. This ledger is therefore INCOMPLETE and is **not** published as the')
+        $lines.Add('> baseline, because later pull requests are diffed against the baseline and would')
+        $lines.Add('> inherit the blind spot.')
+    }
     $lines.Add('')
     $lines.Add('## Failure categories')
     $lines.Add('')
@@ -786,4 +881,17 @@ if ($env:GITHUB_STEP_SUMMARY) {
 if ($FailOnPolicy -and $baseline) {
     $result = Get-Content -LiteralPath $comparisonPath -Raw | ConvertFrom-Json
     if (-not $result.policyPassed) { exit 1 }
+}
+
+# Inventory mode has no baseline to compare against, so the check above never ran for it and a
+# dead shard could not fail the run. A dispatched shard that uploaded nothing is a hole in the
+# ledger regardless of whether a baseline exists, and this ledger becomes the baseline that
+# later pull requests are measured against -- so enforce it unconditionally. #2086.
+if (-not $baseline -and $missingExpectedShards.Count -gt 0) {
+    $names = ($missingExpectedShards | ForEach-Object { $_.name }) -join ', '
+    # Write-Host + exit rather than Write-Error: $ErrorActionPreference is 'Stop' here, so
+    # Write-Error would throw before `exit 1` ever ran and the caller would see a terminating
+    # error instead of a deterministic exit code.
+    Write-Host "::error::$($missingExpectedShards.Count) dispatched shard(s) uploaded no artifact and are recorded as Missing: $names. Refusing to publish an incomplete ledger as the baseline."
+    exit 1
 }

--- a/.github/scripts/test-regression-analysis.ps1
+++ b/.github/scripts/test-regression-analysis.ps1
@@ -466,6 +466,23 @@ function Add-MarkdownList {
     $Lines.Add('')
 }
 
+# Validate the expected inventory before creating any report files. Distinct display names can
+# collapse to the same artifact/ledger key (for example, "Shard A-B" and "Shard A B"). If that
+# ambiguity is accepted, one artifact can satisfy two dispatched rows and conceal a dead shard.
+$expectedShards = New-Object System.Collections.Generic.List[object]
+$expectedShardKeys = New-Object System.Collections.Generic.HashSet[string]([StringComparer]::Ordinal)
+foreach ($expectedName in $ExpectedShardNames) {
+    if ([string]::IsNullOrWhiteSpace($expectedName)) { continue }
+    $expectedKey = ConvertTo-ShardKey $expectedName
+    if (-not $expectedShardKeys.Add($expectedKey)) {
+        throw "Expected shard names collide after normalization: '$expectedName' maps to '$expectedKey'."
+    }
+    $expectedShards.Add([PSCustomObject]@{
+        key = $expectedKey
+        name = [string] $expectedName
+    })
+}
+
 New-Item -Path $OutputDirectory -ItemType Directory -Force | Out-Null
 $ledgerPath = Join-Path $OutputDirectory 'ledger.json'
 $comparisonPath = Join-Path $OutputDirectory 'comparison.json'
@@ -486,18 +503,16 @@ $current = Read-TestLedger -Root $CurrentResultsPath -Sha $CurrentSha
 # Shards that selection deliberately skipped are excluded upstream (they are merged into
 # the approved shard-change manifest), so anything expected-but-absent here died.
 $missingExpectedShards = New-Object System.Collections.Generic.List[object]
-if ($ExpectedShardNames.Count -gt 0) {
+if ($expectedShards.Count -gt 0) {
     $presentShardKeys = New-Object System.Collections.Generic.HashSet[string]([StringComparer]::Ordinal)
     foreach ($shard in @($current.shards)) { [void] $presentShardKeys.Add([string] $shard.key) }
 
-    foreach ($expectedName in $ExpectedShardNames) {
-        if ([string]::IsNullOrWhiteSpace($expectedName)) { continue }
-        $expectedKey = ConvertTo-ShardKey $expectedName
-        if ($presentShardKeys.Contains($expectedKey)) { continue }
+    foreach ($expectedShard in $expectedShards) {
+        if ($presentShardKeys.Contains($expectedShard.key)) { continue }
 
         $missingExpectedShards.Add([PSCustomObject]@{
-            key = $expectedKey
-            name = [string] $expectedName
+            key = $expectedShard.key
+            name = $expectedShard.name
             status = 'Missing'
             policyStatus = 'Missing'
             total = 0

--- a/.github/scripts/test-regression-analysis.ps1
+++ b/.github/scripts/test-regression-analysis.ps1
@@ -754,7 +754,26 @@ if (-not $baseline) {
     $touchedSurfaceClean = $touchedNew.Count -eq 0 -and
         ($touchedSurfaceKnown -or $confirmedNew.Count -eq 0)
     $baselineIncomplete = @($baseline.shards | Where-Object status -eq 'Incomplete')
-    $effectiveCurrentIncomplete = @($currentIncomplete) + @($missingCurrentShards.ToArray())
+    # The expected matrix is authoritative for this run. A missing expected shard can be new and
+    # therefore absent from the baseline-key walk above; merge all three sources by shard key so it
+    # is neither dropped nor double-counted when it also existed in the baseline.
+    $effectiveCurrentIncomplete = New-Object System.Collections.Generic.List[object]
+    $effectiveCurrentIncompleteKeys = New-Object System.Collections.Generic.HashSet[string]([StringComparer]::Ordinal)
+    foreach ($incompleteShard in @($currentIncomplete)) {
+        if ($effectiveCurrentIncompleteKeys.Add([string] $incompleteShard.key)) {
+            $effectiveCurrentIncomplete.Add($incompleteShard)
+        }
+    }
+    foreach ($incompleteShard in $missingCurrentShards.ToArray()) {
+        if ($effectiveCurrentIncompleteKeys.Add([string] $incompleteShard.key)) {
+            $effectiveCurrentIncomplete.Add($incompleteShard)
+        }
+    }
+    foreach ($incompleteShard in $missingExpectedShards.ToArray()) {
+        if ($effectiveCurrentIncompleteKeys.Add([string] $incompleteShard.key)) {
+            $effectiveCurrentIncomplete.Add($incompleteShard)
+        }
+    }
     $baselineStats = Get-LedgerStatistics $baseline
     $baselineCategories = @(Get-FailureCategories $baselineFailures)
     $greenToRedArray = @($greenToRed | ForEach-Object { $_ })
@@ -762,7 +781,9 @@ if (-not $baseline) {
     # when failures change, explicit current passes must at least offset genuinely new failures.
     $netImproved = $fixed.Count -ge $confirmedNew.Count
     $incompleteNotIncreased = $effectiveCurrentIncomplete.Count -le $baselineIncomplete.Count
-    $policyPassed = $netImproved -and $incompleteNotIncreased -and $greenToRed.Count -eq 0 -and $touchedSurfaceClean
+    $allDispatchedShardsReported = $missingExpectedShards.Count -eq 0
+    $policyPassed = $netImproved -and $incompleteNotIncreased -and
+        $greenToRed.Count -eq 0 -and $touchedSurfaceClean -and $allDispatchedShardsReported
 
     $resolvedBaselineSha = [string] $baseline.sha
     if ($BaselineSha) { $resolvedBaselineSha = [string] $BaselineSha }
@@ -776,6 +797,7 @@ if (-not $baseline) {
             incompleteShardsDidNotIncrease = $incompleteNotIncreased
             noPreviouslyGreenShardRegressed = $greenToRed.Count -eq 0
             noTouchedSurfaceRegression = $touchedSurfaceClean
+            allDispatchedShardsReported = $allDispatchedShardsReported
         }
         touchedTokenDiscovery = $touchedTokenResult
         counts = [PSCustomObject]@{
@@ -801,6 +823,7 @@ if (-not $baseline) {
             baselineIncompleteShards = $baselineIncomplete.Count
             currentIncompleteShards = $effectiveCurrentIncomplete.Count
             missingCurrentShardArtifacts = $missingCurrentShards.Count
+            missingExpectedShardArtifacts = $missingExpectedShards.Count
             approvedShardChanges = $approvedMissingShardChanges.Count
             greenToRedShards = $greenToRed.Count
             touchedNewFailures = $touchedNew.Count
@@ -813,7 +836,7 @@ if (-not $baseline) {
         fixedFailures = @($fixed)
         persistentFailures = @($persistent)
         baselineFailuresNotObserved = @($notObserved)
-        currentIncompleteShards = @($effectiveCurrentIncomplete)
+        currentIncompleteShards = $effectiveCurrentIncomplete.ToArray()
         missingCurrentShardArtifacts = $missingCurrentShards.ToArray()
         approvedShardChanges = $approvedMissingShardChanges.ToArray()
         baselineFailureCategories = $baselineCategories
@@ -840,6 +863,7 @@ if (-not $baseline) {
     $lines.Add("| Incomplete shards do not increase | $(if ($incompleteNotIncreased) { 'PASS' } else { 'FAIL' }) |")
     $lines.Add("| Previously-green shards stay green | $(if ($greenToRed.Count -eq 0) { 'PASS' } else { 'FAIL' }) |")
     $lines.Add("| No unresolved touched-surface regression risk | $(if ($touchedSurfaceClean) { 'PASS' } else { 'FAIL' }) |")
+    $lines.Add("| Every dispatched shard uploaded an artifact | $(if ($allDispatchedShardsReported) { 'PASS' } else { 'FAIL' }) |")
     $lines.Add('')
     if (-not $touchedSurfaceKnown) {
         $lines.Add("Touched-surface discovery is unavailable: **$(ConvertTo-MarkdownCell ([string] $touchedTokenResult.error))**")
@@ -878,20 +902,19 @@ if ($env:GITHUB_STEP_SUMMARY) {
     catch { Write-Warning "Could not write GitHub step summary: $($_.Exception.Message)" }
 }
 
-if ($FailOnPolicy -and $baseline) {
-    $result = Get-Content -LiteralPath $comparisonPath -Raw | ConvertFrom-Json
-    if (-not $result.policyPassed) { exit 1 }
-}
-
-# Inventory mode has no baseline to compare against, so the check above never ran for it and a
-# dead shard could not fail the run. A dispatched shard that uploaded nothing is a hole in the
-# ledger regardless of whether a baseline exists, and this ledger becomes the baseline that
-# later pull requests are measured against -- so enforce it unconditionally. #2086.
-if (-not $baseline -and $missingExpectedShards.Count -gt 0) {
+# A dispatched shard that uploaded nothing is a hole regardless of whether this is inventory or
+# comparison mode. Check it before the general policy verdict so both paths emit the actionable
+# shard names, and never let a baseline comparison hide a newly-added missing shard. #2086.
+if ($missingExpectedShards.Count -gt 0) {
     $names = ($missingExpectedShards | ForEach-Object { $_.name }) -join ', '
     # Write-Host + exit rather than Write-Error: $ErrorActionPreference is 'Stop' here, so
     # Write-Error would throw before `exit 1` ever ran and the caller would see a terminating
     # error instead of a deterministic exit code.
-    Write-Host "::error::$($missingExpectedShards.Count) dispatched shard(s) uploaded no artifact and are recorded as Missing: $names. Refusing to publish an incomplete ledger as the baseline."
+    Write-Host "::error::$($missingExpectedShards.Count) dispatched shard(s) uploaded no artifact and are recorded as Missing: $names. Refusing to accept an incomplete test ledger."
     exit 1
+}
+
+if ($FailOnPolicy -and $baseline) {
+    $result = Get-Content -LiteralPath $comparisonPath -Raw | ConvertFrom-Json
+    if (-not $result.policyPassed) { exit 1 }
 }

--- a/.github/scripts/test-regression-analysis.tests.ps1
+++ b/.github/scripts/test-regression-analysis.tests.ps1
@@ -1,4 +1,4 @@
-$ErrorActionPreference = 'Stop'
+﻿$ErrorActionPreference = 'Stop'
 
 $analyzer = Join-Path $PSScriptRoot 'test-regression-analysis.ps1'
 $retrySelector = Join-Path $PSScriptRoot 'find-pr-new-failures.ps1'
@@ -407,6 +407,86 @@ internal static class TouchedRegressionProbe
         'the failure digest explicitly reports a lifecycle failure'
     Assert-Matches 'VisibleFailure' $reporterOutput `
         'the failure digest still reports every recorded assertion alongside the lifecycle failure'
+
+    # ---- #2086: a dispatched shard that uploaded nothing must not read as success ----
+    # Before this, inventory mode (no baseline) had no expected set: counts were taken over
+    # whatever artifacts arrived, so a shard whose runner died was simply absent and the run
+    # reported "N shards, N passed, 0 failed, 0 incomplete". Integration D died twice in a row
+    # on master and the gate still published "Regression status: improved".
+    $missingShardRoot = Join-Path $testRoot 'missing-shard'
+    Write-SyntheticShard $missingShardRoot 'ac01' 'Shard Alpha' 'AlphaTest' 'Passed'
+    Write-SyntheticShard $missingShardRoot 'ac01' 'Shard Beta' 'BetaTest' 'Passed'
+
+    # Control arm: with every dispatched shard present, inventory mode still passes and the
+    # ledger is publishable. Without this, the assertions below could pass simply because the
+    # new code failed everything.
+    $completeOutput = Join-Path $testRoot 'missing-shard-complete'
+    & $analyzer -CurrentResultsPath $missingShardRoot -OutputDirectory $completeOutput -CurrentSha 'ac01' `
+        -ExpectedShardNames @('Shard Alpha', 'Shard Beta')
+    $complete = Get-Content -LiteralPath (Join-Path $completeOutput 'comparison.json') -Raw | ConvertFrom-Json
+    Assert-Equal 'inventory' $complete.mode 'no baseline means inventory mode'
+    Assert-Equal $true $complete.policyPassed 'every dispatched shard uploaded an artifact'
+    Assert-Equal $true $complete.baselinePublishable 'a complete ledger is publishable as the baseline'
+    Assert-Equal 0 @($complete.missingExpectedShards).Count 'nothing is missing when all shards reported'
+
+    # The real case: the matrix dispatched three shards and only two uploaded.
+    $incompleteOutput = Join-Path $testRoot 'missing-shard-incomplete'
+    & $analyzer -CurrentResultsPath $missingShardRoot -OutputDirectory $incompleteOutput -CurrentSha 'ac01' `
+        -ExpectedShardNames @('Shard Alpha', 'Shard Beta', 'Shard Gamma')
+    $incomplete = Get-Content -LiteralPath (Join-Path $incompleteOutput 'comparison.json') -Raw | ConvertFrom-Json
+    Assert-Equal $false $incomplete.policyPassed 'a dispatched shard that uploaded nothing fails the policy'
+    Assert-Equal $false $incomplete.baselinePublishable 'an incomplete ledger is not publishable as the baseline'
+    Assert-Equal 1 @($incomplete.missingExpectedShards).Count 'exactly the absent shard is reported'
+    Assert-Equal 'Shard Gamma' @($incomplete.missingExpectedShards)[0] 'the absent shard is named'
+
+    # It must appear in the shard inventory as Missing, not be silently omitted -- that omission
+    # is what let the aggregate report "0 failing shards" while a shard had died.
+    $missingShardRows = @(Import-Csv -LiteralPath (Join-Path $incompleteOutput 'shards.csv') |
+        Where-Object { $_.name -eq 'Shard Gamma' })
+    Assert-Equal 1 $missingShardRows.Count 'the dead shard is present in shards.csv rather than dropped'
+    Assert-Equal 'Missing' $missingShardRows[0].status 'the dead shard is recorded as Missing, never as Passed'
+
+    $missingSummary = Get-Content -LiteralPath (Join-Path $incompleteOutput 'summary.md') -Raw
+    Assert-Matches 'Shard Gamma' $missingSummary 'the summary names the shard that produced no artifact'
+    Assert-Matches 'not.*published as the' $missingSummary 'the summary states the baseline is withheld'
+
+    # Enforcement: this must be a nonzero process exit even though there is no baseline. The
+    # pre-existing -FailOnPolicy gate only fired when a baseline existed, which is precisely why
+    # a baseline-establishing master run could go green with a dead shard.
+    $missingExitOutput = Join-Path $testRoot 'missing-shard-exit'
+    $null = & pwsh -NoLogo -NoProfile -File $analyzer `
+        -CurrentResultsPath $missingShardRoot -OutputDirectory $missingExitOutput -CurrentSha 'ac01' `
+        -ExpectedShardNames @('Shard Alpha', 'Shard Beta', 'Shard Gamma') 2>&1
+    Assert-Equal 1 $LASTEXITCODE 'a missing dispatched shard fails the run even with no baseline present'
+
+    # The hole must be recorded in the ledger artifact itself, not only in shards.csv --
+    # find-test-baseline.ps1 picks baselines without filtering on run conclusion, so a failed run's
+    # ledger can still be adopted later. The artifact has to carry its own evidence.
+    $incompleteLedger = Get-Content -LiteralPath (Join-Path $incompleteOutput 'ledger.json') -Raw | ConvertFrom-Json
+    Assert-Equal 1 @($incompleteLedger.missingExpectedShards).Count 'the ledger artifact records its own hole'
+    Assert-Equal 'Shard Gamma' @($incompleteLedger.missingExpectedShards)[0] 'the recorded hole names the absent shard'
+
+    $completeLedger = Get-Content -LiteralPath (Join-Path $completeOutput 'ledger.json') -Raw | ConvertFrom-Json
+    Assert-Equal 0 @($completeLedger.missingExpectedShards).Count 'a complete ledger records no holes'
+
+    # And a baseline carrying a hole must be refused outright: comparing against it would inherit
+    # the blind spot, since the absent shard is in neither side and its failures could never be
+    # classified as new.
+    $holedBaselineOutput = Join-Path $testRoot 'holed-baseline'
+    $holedBaselineError = $null
+    try {
+        & $analyzer -CurrentResultsPath $missingShardRoot `
+            -BaselineLedgerPath (Join-Path $incompleteOutput 'ledger.json') `
+            -OutputDirectory $holedBaselineOutput -CurrentSha 'ac02' -BaselineSha 'ac01'
+    } catch { $holedBaselineError = $_.Exception.Message }
+    Assert-Matches 'incomplete' $holedBaselineError 'a baseline with a missing shard is refused, not silently used'
+
+    # Backward compatibility: callers that pass no expected set keep the old behaviour, so the
+    # change cannot break local or ad-hoc invocations of the analyzer.
+    $legacyOutput = Join-Path $testRoot 'missing-shard-legacy'
+    & $analyzer -CurrentResultsPath $missingShardRoot -OutputDirectory $legacyOutput -CurrentSha 'ac01'
+    $legacy = Get-Content -LiteralPath (Join-Path $legacyOutput 'comparison.json') -Raw | ConvertFrom-Json
+    Assert-Equal $true $legacy.policyPassed 'with no expected set supplied, inventory mode behaves as before'
 
     Write-Host 'test-regression-analysis.tests.ps1: all assertions passed.'
 }

--- a/.github/scripts/test-regression-analysis.tests.ps1
+++ b/.github/scripts/test-regression-analysis.tests.ps1
@@ -1,6 +1,7 @@
 ﻿$ErrorActionPreference = 'Stop'
 
 $analyzer = Join-Path $PSScriptRoot 'test-regression-analysis.ps1'
+$matrixParser = Join-Path $PSScriptRoot 'get-selected-shard-names.ps1'
 $retrySelector = Join-Path $PSScriptRoot 'find-pr-new-failures.ps1'
 $testRoot = Join-Path ([IO.Path]::GetTempPath()) ("aidotnet-trx-analysis-" + [Guid]::NewGuid().ToString('N'))
 
@@ -577,6 +578,35 @@ internal static class TouchedRegressionProbe
     & $analyzer -CurrentResultsPath $missingShardRoot -OutputDirectory $legacyOutput -CurrentSha 'ac01'
     $legacy = Get-Content -LiteralPath (Join-Path $legacyOutput 'comparison.json') -Raw | ConvertFrom-Json
     Assert-Equal $true $legacy.policyPassed 'with no expected set supplied, inventory mode behaves as before'
+
+    # Expected names are artifact keys after normalization. Two distinct display names must not
+    # be allowed to alias one uploaded artifact, and validation must happen before report output.
+    $collidingOutput = Join-Path $testRoot 'colliding-shard-names'
+    $collidingRun = Invoke-AnalyzerChild -Analyzer $analyzer `
+        -CurrentResultsPath $missingShardRoot -OutputDirectory $collidingOutput -CurrentSha 'ac01' `
+        -ExpectedShardNames @('Shard A-B', 'Shard A B')
+    Assert-Equal 1 $collidingRun.ExitCode 'normalized expected shard keys must be unique'
+    Assert-Matches 'collide after normalization' ($collidingRun.Output -join "`n") `
+        'the collision failure identifies the violated key contract'
+    Assert-Equal $false (Test-Path -LiteralPath (Join-Path $collidingOutput 'ledger.json')) `
+        'an ambiguous expected inventory is rejected before any reusable ledger is written'
+
+    # The workflow output is an array of shard objects, not an object with a `shard` property.
+    # Parse that exact shape and fail closed for every form that cannot prove a nonempty inventory.
+    $validMatrix = '[{"name":"Shard Alpha","framework":"net10.0"},{"name":"Shard Beta","framework":"net10.0"}]'
+    $parsedNames = @(& $matrixParser -MatrixJson $validMatrix)
+    Assert-Equal 2 $parsedNames.Count 'the selected-shard array yields every dispatched name'
+    Assert-Equal 'Shard Alpha' $parsedNames[0] 'the first selected shard is preserved'
+    Assert-Equal 'Shard Beta' $parsedNames[1] 'the second selected shard is preserved'
+
+    foreach ($invalidMatrix in @('', '{not-json', '[]', '{"name":"not-an-array"}', '[{"framework":"net10.0"}]',
+            '[{"name":"Shard A-B"},{"name":"Shard A B"}]')) {
+        $matrixError = $null
+        try { $null = & $matrixParser -MatrixJson $invalidMatrix }
+        catch { $matrixError = $_.Exception.Message }
+        Assert-Equal $false ([string]::IsNullOrWhiteSpace($matrixError)) `
+            "an unverifiable selected matrix fails closed: $invalidMatrix"
+    }
 
     Write-Host 'test-regression-analysis.tests.ps1: all assertions passed.'
 }

--- a/.github/scripts/test-regression-analysis.tests.ps1
+++ b/.github/scripts/test-regression-analysis.tests.ps1
@@ -93,6 +93,74 @@ function Invoke-Git {
     return $result
 }
 
+function Invoke-AnalyzerChild {
+    param(
+        [string] $Analyzer,
+        [string] $CurrentResultsPath,
+        [string] $OutputDirectory,
+        [string] $CurrentSha,
+        [string[]] $ExpectedShardNames,
+        [string] $BaselineLedgerPath,
+        [string] $BaselineSha,
+        [string] $RepositoryPath,
+        [switch] $FailOnPolicy
+    )
+
+    # pwsh -File cannot faithfully bind multiple command-line tokens to a string[] script
+    # parameter. Marshal the array as JSON through the child environment, then invoke the analyzer
+    # from inside that isolated process so its intentional `exit 1` cannot end this test runner.
+    $env:AIDOTNET_TEST_ANALYZER = $Analyzer
+    $env:AIDOTNET_TEST_CURRENT_RESULTS = $CurrentResultsPath
+    $env:AIDOTNET_TEST_OUTPUT = $OutputDirectory
+    $env:AIDOTNET_TEST_CURRENT_SHA = $CurrentSha
+    $env:AIDOTNET_TEST_EXPECTED_SHARDS = $ExpectedShardNames | ConvertTo-Json -Compress
+    $env:AIDOTNET_TEST_BASELINE_LEDGER = $BaselineLedgerPath
+    $env:AIDOTNET_TEST_BASELINE_SHA = $BaselineSha
+    $env:AIDOTNET_TEST_REPOSITORY = $RepositoryPath
+    $env:AIDOTNET_TEST_FAIL_ON_POLICY = if ($FailOnPolicy) { '1' } else { '0' }
+
+    try {
+        $childScript = @'
+$arguments = @{
+    CurrentResultsPath = $env:AIDOTNET_TEST_CURRENT_RESULTS
+    OutputDirectory = $env:AIDOTNET_TEST_OUTPUT
+    CurrentSha = $env:AIDOTNET_TEST_CURRENT_SHA
+    ExpectedShardNames = @($env:AIDOTNET_TEST_EXPECTED_SHARDS | ConvertFrom-Json)
+}
+if (-not [string]::IsNullOrWhiteSpace($env:AIDOTNET_TEST_BASELINE_LEDGER)) {
+    $arguments.BaselineLedgerPath = $env:AIDOTNET_TEST_BASELINE_LEDGER
+}
+if (-not [string]::IsNullOrWhiteSpace($env:AIDOTNET_TEST_BASELINE_SHA)) {
+    $arguments.BaselineSha = $env:AIDOTNET_TEST_BASELINE_SHA
+}
+if (-not [string]::IsNullOrWhiteSpace($env:AIDOTNET_TEST_REPOSITORY)) {
+    $arguments.RepositoryPath = $env:AIDOTNET_TEST_REPOSITORY
+}
+if ($env:AIDOTNET_TEST_FAIL_ON_POLICY -eq '1') {
+    $arguments.FailOnPolicy = $true
+}
+& $env:AIDOTNET_TEST_ANALYZER @arguments
+'@
+        $childOutput = & pwsh -NoLogo -NoProfile -Command $childScript 2>&1
+        return [PSCustomObject]@{
+            ExitCode = $LASTEXITCODE
+            Output = @($childOutput)
+        }
+    }
+    finally {
+        'AIDOTNET_TEST_ANALYZER',
+        'AIDOTNET_TEST_CURRENT_RESULTS',
+        'AIDOTNET_TEST_OUTPUT',
+        'AIDOTNET_TEST_CURRENT_SHA',
+        'AIDOTNET_TEST_EXPECTED_SHARDS',
+        'AIDOTNET_TEST_BASELINE_LEDGER',
+        'AIDOTNET_TEST_BASELINE_SHA',
+        'AIDOTNET_TEST_REPOSITORY',
+        'AIDOTNET_TEST_FAIL_ON_POLICY' |
+            ForEach-Object { Remove-Item -LiteralPath "Env:$_" -ErrorAction SilentlyContinue }
+    }
+}
+
 try {
     $baselineRoot = Join-Path $testRoot 'baseline'
     $currentRoot = Join-Path $testRoot 'current'
@@ -431,8 +499,10 @@ internal static class TouchedRegressionProbe
 
     # The real case: the matrix dispatched three shards and only two uploaded.
     $incompleteOutput = Join-Path $testRoot 'missing-shard-incomplete'
-    & $analyzer -CurrentResultsPath $missingShardRoot -OutputDirectory $incompleteOutput -CurrentSha 'ac01' `
+    $incompleteRun = Invoke-AnalyzerChild -Analyzer $analyzer `
+        -CurrentResultsPath $missingShardRoot -OutputDirectory $incompleteOutput -CurrentSha 'ac01' `
         -ExpectedShardNames @('Shard Alpha', 'Shard Beta', 'Shard Gamma')
+    Assert-Equal 1 $incompleteRun.ExitCode 'a missing dispatched shard fails inventory mode'
     $incomplete = Get-Content -LiteralPath (Join-Path $incompleteOutput 'comparison.json') -Raw | ConvertFrom-Json
     Assert-Equal $false $incomplete.policyPassed 'a dispatched shard that uploaded nothing fails the policy'
     Assert-Equal $false $incomplete.baselinePublishable 'an incomplete ledger is not publishable as the baseline'
@@ -454,10 +524,30 @@ internal static class TouchedRegressionProbe
     # pre-existing -FailOnPolicy gate only fired when a baseline existed, which is precisely why
     # a baseline-establishing master run could go green with a dead shard.
     $missingExitOutput = Join-Path $testRoot 'missing-shard-exit'
-    $null = & pwsh -NoLogo -NoProfile -File $analyzer `
+    $missingExitRun = Invoke-AnalyzerChild -Analyzer $analyzer `
         -CurrentResultsPath $missingShardRoot -OutputDirectory $missingExitOutput -CurrentSha 'ac01' `
-        -ExpectedShardNames @('Shard Alpha', 'Shard Beta', 'Shard Gamma') 2>&1
-    Assert-Equal 1 $LASTEXITCODE 'a missing dispatched shard fails the run even with no baseline present'
+        -ExpectedShardNames @('Shard Alpha', 'Shard Beta', 'Shard Gamma') -FailOnPolicy
+    Assert-Equal 1 $missingExitRun.ExitCode `
+        'a missing dispatched shard fails the run even with no baseline present'
+
+    # Comparison mode must enforce the same authoritative matrix. Shard Gamma is not in the
+    # baseline, so a baseline-only missing-key walk cannot discover it; ExpectedShardNames must.
+    $comparisonMissingOutput = Join-Path $testRoot 'missing-shard-comparison'
+    $comparisonMissingRun = Invoke-AnalyzerChild -Analyzer $analyzer `
+        -CurrentResultsPath $missingShardRoot `
+        -BaselineLedgerPath (Join-Path $completeOutput 'ledger.json') `
+        -OutputDirectory $comparisonMissingOutput -CurrentSha $repositoryHeadSha `
+        -BaselineSha $repositoryBaseSha -RepositoryPath $repository `
+        -ExpectedShardNames @('Shard Alpha', 'Shard Beta', 'Shard Gamma') -FailOnPolicy
+    Assert-Equal 1 $comparisonMissingRun.ExitCode 'a newly dispatched missing shard fails comparison mode'
+    $comparisonMissing = Get-Content -LiteralPath (Join-Path $comparisonMissingOutput 'comparison.json') -Raw | ConvertFrom-Json
+    Assert-Equal $false $comparisonMissing.policyPassed 'comparison policy records the missing expected shard'
+    Assert-Equal $false $comparisonMissing.criteria.allDispatchedShardsReported `
+        'comparison criteria identify the incomplete dispatched matrix'
+    Assert-Equal 1 @($comparisonMissing.currentIncompleteShards).Count `
+        'the new missing shard is included exactly once in comparison incompleteness'
+    Assert-Equal 'Shard Gamma' @($comparisonMissing.currentIncompleteShards)[0].name `
+        'comparison incompleteness names the newly dispatched missing shard'
 
     # The hole must be recorded in the ledger artifact itself, not only in shards.csv --
     # find-test-baseline.ps1 picks baselines without filtering on run conclusion, so a failed run's
@@ -498,3 +588,7 @@ finally {
         Remove-Item -LiteralPath $resolvedTestRoot -Recurse -Force
     }
 }
+
+# Native child processes used for expected-failure cases intentionally leave LASTEXITCODE=1.
+# This file is a standalone test executable; reaching here means every assertion passed.
+exit 0

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -2232,12 +2232,32 @@ jobs:
           } | ConvertTo-Json -Depth 6 | Set-Content merged-shard-changes.json -Encoding utf8
           Write-Host "approved shard changes: $($changes.Count) ($(@($manifest.changes).Count) checked in, $($changes.Count - @($manifest.changes).Count) skipped by selection)"
 
+          # The shards this run actually dispatched. Inventory mode (a master push, which has no
+          # baseline to diff against) previously had no expected set, so a shard whose runner died
+          # before uploading was simply absent: the counts were taken over whatever arrived and the
+          # run reported "115 shards, 115 passed, 0 failed" while Integration D had died. Shards
+          # that selection deliberately skipped are not in this matrix, so anything expected and
+          # absent here died rather than being skipped. #2086.
+          $expectedShardNames = @()
+          $matrixJson = '${{ needs.select-shards.outputs.matrix }}'
+          if (-not [string]::IsNullOrWhiteSpace($matrixJson)) {
+            try {
+              $expectedShardNames = @(($matrixJson | ConvertFrom-Json).shard |
+                ForEach-Object { [string] $_.name } |
+                Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
+            } catch {
+              Write-Warning "Could not parse the selected shard matrix; shard-completeness enforcement is skipped: $($_.Exception.Message)"
+            }
+          }
+          Write-Host "expected shards from the dispatched matrix: $($expectedShardNames.Count)"
+
           $arguments = @{
             CurrentResultsPath = 'current-test-results'
             OutputDirectory = 'test-regression-analysis'
             CurrentSha = $env:CURRENT_SHA
             RepositoryPath = '.'
             ApprovedShardChangesPath = 'merged-shard-changes.json'
+            ExpectedShardNames = $expectedShardNames
           }
           $ledger = Get-ChildItem baseline-ledger -Recurse -Filter ledger.json -ErrorAction SilentlyContinue |
             Select-Object -First 1

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -2197,6 +2197,7 @@ jobs:
         id: analyze
         shell: pwsh
         env:
+          EXPECTED_SHARD_MATRIX: ${{ needs.select-shards.outputs.matrix }}
           CURRENT_SHA: ${{ github.sha }}
           COMPARE: ${{ steps.comparison.outputs.compare }}
           BASE_SHA: ${{ steps.comparison.outputs.base_sha }}
@@ -2239,7 +2240,7 @@ jobs:
           # that selection deliberately skipped are not in this matrix, so anything expected and
           # absent here died rather than being skipped. #2086.
           $expectedShardNames = @()
-          $matrixJson = '${{ needs.select-shards.outputs.matrix }}'
+          $matrixJson = $env:EXPECTED_SHARD_MATRIX
           if (-not [string]::IsNullOrWhiteSpace($matrixJson)) {
             try {
               $expectedShardNames = @(($matrixJson | ConvertFrom-Json).shard |

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -777,6 +777,16 @@ jobs:
             Write-Host "::error::duplicate shard name(s) in .github/test-shards.yml: $($dupes -join ', ')"
             exit 1
           }
+          $slugDupes = @(
+            $all |
+              Group-Object { $_.name -replace '[\\/:*?"<>|\s-]+', '_' } |
+              Where-Object Count -gt 1 |
+              ForEach-Object Name
+          )
+          if ($slugDupes.Count -gt 0) {
+            Write-Host "::error::shard name(s) collide after artifact-key normalization: $($slugDupes -join ', ')"
+            exit 1
+          }
           Write-Host "shard list: $($all.Count) shard(s)"
 
           $escalate = $true
@@ -2239,17 +2249,11 @@ jobs:
           # run reported "115 shards, 115 passed, 0 failed" while Integration D had died. Shards
           # that selection deliberately skipped are not in this matrix, so anything expected and
           # absent here died rather than being skipped. #2086.
-          $expectedShardNames = @()
           $matrixJson = $env:EXPECTED_SHARD_MATRIX
-          if (-not [string]::IsNullOrWhiteSpace($matrixJson)) {
-            try {
-              $expectedShardNames = @(($matrixJson | ConvertFrom-Json).shard |
-                ForEach-Object { [string] $_.name } |
-                Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
-            } catch {
-              Write-Warning "Could not parse the selected shard matrix; shard-completeness enforcement is skipped: $($_.Exception.Message)"
-            }
-          }
+          $expectedShardNames = @(
+            & ./.github/scripts/get-selected-shard-names.ps1 -MatrixJson $matrixJson
+          )
+          "inventory_valid=true" | Add-Content -LiteralPath $env:GITHUB_OUTPUT
           Write-Host "expected shards from the dispatched matrix: $($expectedShardNames.Count)"
 
           $arguments = @{
@@ -2305,7 +2309,9 @@ jobs:
           ./.github/scripts/test-regression-analysis.ps1 @arguments
 
       - name: Upload final TRX ledger and comparison report
-        if: always()
+        # Missing/invalid selection output cannot prove which shards were dispatched. Do not
+        # publish a partial ledger that a later run could mistake for a complete baseline.
+        if: always() && steps.analyze.outputs.inventory_valid == 'true'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
         with:
           name: test-outcome-ledger-${{ github.sha }}

--- a/src/AiDotNet.Generators/AnalyzerReleases.Unshipped.md
+++ b/src/AiDotNet.Generators/AnalyzerReleases.Unshipped.md
@@ -82,3 +82,4 @@ AIDN098 | AiDotNet.ParameterAutomation | Warning | TrainableParameterGenerator, 
 AIDN099 | AiDotNet.ParameterAutomation | Warning | TrainableParameterGenerator, [TrainableParameter] on a non-partial class does nothing
 AIDN046 | AiDotNet.TestCoverage | Warning | TestScaffoldGenerator, Layer cannot be scaffolded and produces no generated tests
 AIDN077 | AiDotNet.GoldenPattern | Warning | GoldenPatternValidationGenerator, Optimizer builds its own random generator instead of drawing from the seeded OptimizerBase.Random
+AIDN100 | AiDotNet.ParameterAutomation | Error | ParameterUpdateInPlaceAnalyzer, Trainable parameter reassigned to an Engine result in UpdateParameters

--- a/src/AiDotNet.Generators/ParameterUpdateInPlaceAnalyzer.cs
+++ b/src/AiDotNet.Generators/ParameterUpdateInPlaceAnalyzer.cs
@@ -1,0 +1,196 @@
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace AiDotNet.Generators;
+
+/// <summary>
+/// Keeps a trainable weight from being rebound to an engine result inside
+/// <c>UpdateParameters</c>: reports <c>_field = Engine.Something(...)</c> and points at the
+/// in-place form instead.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <c>Engine.*</c> results can come from the per-step <c>TensorArena</c>, which recycles its
+/// buffers once the step ends. Assigning one to a trainable-parameter field makes that arena
+/// scratch the weight, so the next step's allocations overwrite it and training silently
+/// produces NaN or garbage rather than failing. Nothing throws; the numbers are simply wrong.
+/// </para>
+/// <para>
+/// The in-place forms exist and are zero-allocation -- <c>TensorAddInPlace(a, b)</c> is
+/// <c>a[i] += b[i]</c>, <c>TensorSubtractInPlace(a, b)</c> is <c>a[i] -= b[i]</c>. They write
+/// through the field's existing storage, so the weight keeps the buffer it was registered with
+/// and stays valid across steps. This is also what the GPU path already did: layers that had a
+/// <c>DirectGpuTensorEngine</c> branch called <c>SgdMomentumUpdateGpu(_gamma, ...)</c> in place
+/// while the CPU branch beside it rebound the field.
+/// </para>
+/// <para>
+/// This rule exists because the count grew rather than shrank while the issue (#1842) was open:
+/// ~31 sites when reported, 40 a month later, 587 across 83 files when finally measured. That is
+/// the signature of a pattern being copied from neighbouring layers, which prose cannot stop.
+/// All 587 are fixed; the analyzer is the ratchet that keeps it at zero.
+/// </para>
+/// <para>
+/// Deliberately narrow, to stay at zero false positives. It fires only inside
+/// <c>UpdateParameters</c>, only on instance fields, and never on a field the codebase has
+/// already marked as scratch or buffer storage -- those are meant to be rebound.
+/// </para>
+/// </remarks>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public class ParameterUpdateInPlaceAnalyzer : DiagnosticAnalyzer
+{
+    /// <summary>A persistent field rebound to an Engine result inside UpdateParameters.</summary>
+    private static readonly DiagnosticDescriptor ParameterReboundToEngineResult = new(
+        "AIDN100",
+        "Trainable parameter reassigned to an Engine result in UpdateParameters",
+        "'{0}' is reassigned to the result of '{1}' inside UpdateParameters, which can hand the "
+            + "parameter an arena-scratch buffer that is recycled before the next step reads it -- "
+            + "training then produces wrong numbers with no exception. Update it in place instead, "
+            + "e.g. 'Engine.TensorSubtractInPlace({0}, delta)' or 'Engine.TensorAddInPlace({0}, delta)', "
+            + "so the parameter keeps its own registered storage",
+        "AiDotNet.ParameterAutomation",
+        DiagnosticSeverity.Error,
+        isEnabledByDefault: true,
+        description: "Engine results may be arena scratch. A trainable parameter bound to one is "
+            + "silently corrupted when the arena recycles, so the failure surfaces as bad training "
+            + "results rather than an error.");
+
+    /// <inheritdoc />
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics
+        => ImmutableArray.Create(ParameterReboundToEngineResult);
+
+    /// <inheritdoc />
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+        context.RegisterSyntaxNodeAction(AnalyzeMethod, SyntaxKind.MethodDeclaration);
+    }
+
+    private static void AnalyzeMethod(SyntaxNodeAnalysisContext context)
+    {
+        var method = (MethodDeclarationSyntax)context.Node;
+        if (method.Identifier.Text != "UpdateParameters") return;
+        if (method.Body is null) return;
+
+        var model = context.SemanticModel;
+
+        foreach (var assignment in method.Body.DescendantNodes().OfType<AssignmentExpressionSyntax>())
+        {
+            if (!assignment.IsKind(SyntaxKind.SimpleAssignmentExpression)) continue;
+            if (model.GetSymbolInfo(assignment.Left).Symbol is not IFieldSymbol field) continue;
+            if (field.IsStatic || field.IsConst) continue;
+            if (IsScratchStorage(field)) continue;
+
+            string? engineCall = GetEngineCallName(assignment.Right);
+            if (engineCall is null) continue;
+            if (IsLazyInitialization(assignment, model)) continue;
+
+            context.ReportDiagnostic(Diagnostic.Create(
+                ParameterReboundToEngineResult,
+                assignment.GetLocation(),
+                field.Name,
+                engineCall));
+        }
+    }
+
+    /// <summary>
+    /// True when the assignment is a first-use allocation guarded by a null check on the same
+    /// field, e.g. <c>if (_tracesGpu == null) { _tracesGpu = gpuEngine.ZerosGpu&lt;T&gt;(...); }</c>.
+    /// </summary>
+    /// <remarks>
+    /// Lazy initialization CREATES the persistent buffer rather than rebinding a live weight to a
+    /// transient one, so it is not the defect this rule describes. Excluding it keeps the analyzer
+    /// at zero false positives: without this, every GPU-state layer that allocates its buffers on
+    /// first use would be reported, and a rule that cries wolf gets suppressed rather than obeyed.
+    /// </remarks>
+    private static bool IsLazyInitialization(AssignmentExpressionSyntax assignment, SemanticModel model)
+    {
+        for (SyntaxNode? node = assignment.Parent; node is not null; node = node.Parent)
+        {
+            if (node is MethodDeclarationSyntax) break;
+            if (node is not IfStatementSyntax ifStatement) continue;
+            // Only the true-branch is initialization; an assignment in the `else` is a live update.
+            if (!ifStatement.Statement.Span.Contains(assignment.Span)) continue;
+            if (TestsAnyFieldAgainstNull(ifStatement.Condition, model)) return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>True when the condition null-tests a field of the enclosing type.</summary>
+    /// <remarks>
+    /// Any field, not merely the one being assigned: layers commonly allocate a whole group of
+    /// buffers behind ONE guard, e.g.
+    /// <c>if (_presynapticTracesGpu == null) { _presynapticTracesGpu = ...; _postsynapticTracesGpu = ...; }</c>.
+    /// Requiring the guard to name each field individually would report the siblings. A genuine
+    /// parameter update is never wrapped in a null test on a field, so this stays specific.
+    /// </remarks>
+    private static bool TestsAnyFieldAgainstNull(ExpressionSyntax condition, SemanticModel model)
+    {
+        switch (condition)
+        {
+            case BinaryExpressionSyntax binary when binary.IsKind(SyntaxKind.EqualsExpression):
+                return IsFieldNullTest(binary.Left, binary.Right, model)
+                    || IsFieldNullTest(binary.Right, binary.Left, model);
+
+            // `_x is null`
+            case IsPatternExpressionSyntax isPattern
+                when isPattern.Pattern is ConstantPatternSyntax constant
+                    && constant.Expression.IsKind(SyntaxKind.NullLiteralExpression):
+                return model.GetSymbolInfo(isPattern.Expression).Symbol is IFieldSymbol;
+
+            // `_x == null || _y == null`, or a guard combined with other preconditions.
+            case BinaryExpressionSyntax logical
+                when logical.IsKind(SyntaxKind.LogicalOrExpression)
+                    || logical.IsKind(SyntaxKind.LogicalAndExpression):
+                return TestsAnyFieldAgainstNull(logical.Left, model)
+                    || TestsAnyFieldAgainstNull(logical.Right, model);
+
+            case ParenthesizedExpressionSyntax parenthesized:
+                return TestsAnyFieldAgainstNull(parenthesized.Expression, model);
+
+            default:
+                return false;
+        }
+    }
+
+    private static bool IsFieldNullTest(
+        ExpressionSyntax candidate, ExpressionSyntax other, SemanticModel model)
+        => other.IsKind(SyntaxKind.NullLiteralExpression)
+            && model.GetSymbolInfo(candidate).Symbol is IFieldSymbol;
+
+    /// <summary>
+    /// True for storage the codebase already declares as transient, which is meant to be rebound.
+    /// </summary>
+    private static bool IsScratchStorage(IFieldSymbol field)
+        => field.GetAttributes().Any(a => a.AttributeClass?.Name
+            is "ScratchAttribute" or "Scratch" or "BufferAttribute" or "Buffer");
+
+    /// <summary>
+    /// The invoked member name when the expression is (or wraps) an <c>Engine.X(...)</c> call.
+    /// Walks the outermost invocation only -- a nested Engine call used as an ARGUMENT is fine,
+    /// since only the value the field ends up bound to matters.
+    /// </summary>
+    private static string? GetEngineCallName(ExpressionSyntax expression)
+    {
+        if (expression is not InvocationExpressionSyntax invocation) return null;
+        if (invocation.Expression is not MemberAccessExpressionSyntax member) return null;
+
+        // Engine.X(...), this.Engine.X(...), or SomeEngine.X(...) where the receiver is the
+        // layer's engine property. Matching on the receiver's NAME keeps this analyzer free of
+        // a hard dependency on the Tensors assembly being resolvable during analysis.
+        string receiver = member.Expression switch
+        {
+            IdentifierNameSyntax identifier => identifier.Identifier.Text,
+            MemberAccessExpressionSyntax nested => nested.Name.Identifier.Text,
+            _ => string.Empty,
+        };
+
+        if (!receiver.EndsWith("Engine", System.StringComparison.Ordinal)) return null;
+        return $"{receiver}.{member.Name.Identifier.Text}";
+    }
+}

--- a/src/AiDotNet.Generators/ParameterUpdateInPlaceAnalyzer.cs
+++ b/src/AiDotNet.Generators/ParameterUpdateInPlaceAnalyzer.cs
@@ -74,20 +74,26 @@ public class ParameterUpdateInPlaceAnalyzer : DiagnosticAnalyzer
     {
         var method = (MethodDeclarationSyntax)context.Node;
         if (method.Identifier.Text != "UpdateParameters") return;
-        if (method.Body is null) return;
+        if (method.Body is null && method.ExpressionBody is null) return;
 
         var model = context.SemanticModel;
+        if (model.GetDeclaredSymbol(method) is not IMethodSymbol methodSymbol) return;
+        var registrations =
+            ParameterMemberSemanticModel.GetRegistrationClassifications(methodSymbol.ContainingType);
 
-        foreach (var assignment in method.Body.DescendantNodes().OfType<AssignmentExpressionSyntax>())
+        foreach (var assignment in method.DescendantNodes()
+            .OfType<AssignmentExpressionSyntax>()
+            .Where(candidate => candidate.IsKind(SyntaxKind.SimpleAssignmentExpression)))
         {
-            if (!assignment.IsKind(SyntaxKind.SimpleAssignmentExpression)) continue;
-            if (model.GetSymbolInfo(assignment.Left).Symbol is not IFieldSymbol field) continue;
+            var field = ResolveCurrentInstanceRootField(assignment.Left, model);
+            if (field is null) continue;
             if (field.IsStatic || field.IsConst) continue;
-            if (IsScratchStorage(field)) continue;
+            var classification =
+                ParameterMemberSemanticModel.ClassifyWithRegistrations(field, registrations);
+            if (classification.Kind != ParameterMemberSemanticModel.Kind.Trainable) continue;
 
             string? engineCall = GetEngineCallName(assignment.Right);
             if (engineCall is null) continue;
-            if (IsLazyInitialization(assignment, model)) continue;
 
             context.ReportDiagnostic(Diagnostic.Create(
                 ParameterReboundToEngineResult,
@@ -98,77 +104,43 @@ public class ParameterUpdateInPlaceAnalyzer : DiagnosticAnalyzer
     }
 
     /// <summary>
-    /// True when the assignment is a first-use allocation guarded by a null check on the same
-    /// field, e.g. <c>if (_tracesGpu == null) { _tracesGpu = gpuEngine.ZerosGpu&lt;T&gt;(...); }</c>.
+    /// Resolves the current instance's field for both direct assignments and container element
+    /// assignments such as <c>_weights[i] = ...</c> or <c>this._weights[key] = ...</c>.
     /// </summary>
-    /// <remarks>
-    /// Lazy initialization CREATES the persistent buffer rather than rebinding a live weight to a
-    /// transient one, so it is not the defect this rule describes. Excluding it keeps the analyzer
-    /// at zero false positives: without this, every GPU-state layer that allocates its buffers on
-    /// first use would be reported, and a rule that cries wolf gets suppressed rather than obeyed.
-    /// </remarks>
-    private static bool IsLazyInitialization(AssignmentExpressionSyntax assignment, SemanticModel model)
+    private static IFieldSymbol? ResolveCurrentInstanceRootField(
+        ExpressionSyntax left,
+        SemanticModel model)
     {
-        for (SyntaxNode? node = assignment.Parent; node is not null; node = node.Parent)
+        ExpressionSyntax candidate = left;
+        while (true)
         {
-            if (node is MethodDeclarationSyntax) break;
-            if (node is not IfStatementSyntax ifStatement) continue;
-            // Only the true-branch is initialization; an assignment in the `else` is a live update.
-            if (!ifStatement.Statement.Span.Contains(assignment.Span)) continue;
-            if (TestsAnyFieldAgainstNull(ifStatement.Condition, model)) return true;
-        }
+            switch (candidate)
+            {
+                case ParenthesizedExpressionSyntax parenthesized:
+                    candidate = parenthesized.Expression;
+                    continue;
 
-        return false;
-    }
+                case ElementAccessExpressionSyntax elementAccess:
+                    candidate = elementAccess.Expression;
+                    continue;
 
-    /// <summary>True when the condition null-tests a field of the enclosing type.</summary>
-    /// <remarks>
-    /// Any field, not merely the one being assigned: layers commonly allocate a whole group of
-    /// buffers behind ONE guard, e.g.
-    /// <c>if (_presynapticTracesGpu == null) { _presynapticTracesGpu = ...; _postsynapticTracesGpu = ...; }</c>.
-    /// Requiring the guard to name each field individually would report the siblings. A genuine
-    /// parameter update is never wrapped in a null test on a field, so this stays specific.
-    /// </remarks>
-    private static bool TestsAnyFieldAgainstNull(ExpressionSyntax condition, SemanticModel model)
-    {
-        switch (condition)
-        {
-            case BinaryExpressionSyntax binary when binary.IsKind(SyntaxKind.EqualsExpression):
-                return IsFieldNullTest(binary.Left, binary.Right, model)
-                    || IsFieldNullTest(binary.Right, binary.Left, model);
+                case IdentifierNameSyntax identifier:
+                    return model.GetSymbolInfo(identifier).Symbol as IFieldSymbol;
 
-            // `_x is null`
-            case IsPatternExpressionSyntax isPattern
-                when isPattern.Pattern is ConstantPatternSyntax constant
-                    && constant.Expression.IsKind(SyntaxKind.NullLiteralExpression):
-                return model.GetSymbolInfo(isPattern.Expression).Symbol is IFieldSymbol;
+                case MemberAccessExpressionSyntax memberAccess:
+                    if (model.GetSymbolInfo(memberAccess).Symbol is IFieldSymbol field)
+                    {
+                        return memberAccess.Expression is ThisExpressionSyntax or BaseExpressionSyntax
+                            ? field
+                            : null;
+                    }
+                    return null;
 
-            // `_x == null || _y == null`, or a guard combined with other preconditions.
-            case BinaryExpressionSyntax logical
-                when logical.IsKind(SyntaxKind.LogicalOrExpression)
-                    || logical.IsKind(SyntaxKind.LogicalAndExpression):
-                return TestsAnyFieldAgainstNull(logical.Left, model)
-                    || TestsAnyFieldAgainstNull(logical.Right, model);
-
-            case ParenthesizedExpressionSyntax parenthesized:
-                return TestsAnyFieldAgainstNull(parenthesized.Expression, model);
-
-            default:
-                return false;
+                default:
+                    return null;
+            }
         }
     }
-
-    private static bool IsFieldNullTest(
-        ExpressionSyntax candidate, ExpressionSyntax other, SemanticModel model)
-        => other.IsKind(SyntaxKind.NullLiteralExpression)
-            && model.GetSymbolInfo(candidate).Symbol is IFieldSymbol;
-
-    /// <summary>
-    /// True for storage the codebase already declares as transient, which is meant to be rebound.
-    /// </summary>
-    private static bool IsScratchStorage(IFieldSymbol field)
-        => field.GetAttributes().Any(a => a.AttributeClass?.Name
-            is "ScratchAttribute" or "Scratch" or "BufferAttribute" or "Buffer");
 
     /// <summary>
     /// The invoked member name when the expression is (or wraps) an <c>Engine.X(...)</c> call.

--- a/src/AiDotNet.Generators/TestScaffoldGenerator.cs
+++ b/src/AiDotNet.Generators/TestScaffoldGenerator.cs
@@ -2388,12 +2388,12 @@ public class TestScaffoldGenerator : IIncrementalGenerator
         sb.AppendLine("            }");
         sb.AppendLine("        }");
         sb.AppendLine();
-        sb.AppendLine("        Assert.NotNull(mutableSource);");
-        sb.AppendLine("        Assert.NotNull(mutableClone);");
-        sb.AppendLine("        float sourceValue = mutableSource![0];");
-        sb.AppendLine("        mutableClone![0] = sourceValue + 1.0f;");
-        sb.AppendLine("        Assert.Equal(sourceValue, mutableSource[0]);");
-        sb.AppendLine("        Assert.NotEqual(mutableSource[0], mutableClone[0]);");
+        sb.AppendLine("        var sourceToMutate = Assert.IsType<global::AiDotNet.Tensors.LinearAlgebra.Tensor<float>>(mutableSource);");
+        sb.AppendLine("        var cloneToMutate = Assert.IsType<global::AiDotNet.Tensors.LinearAlgebra.Tensor<float>>(mutableClone);");
+        sb.AppendLine("        float sourceValue = sourceToMutate[0];");
+        sb.AppendLine("        cloneToMutate[0] = sourceValue + 1.0f;");
+        sb.AppendLine("        Assert.Equal(sourceValue, sourceToMutate[0]);");
+        sb.AppendLine("        Assert.NotEqual(sourceToMutate[0], cloneToMutate[0]);");
         sb.AppendLine("    }");
         sb.AppendLine();
         sb.AppendLine("    [Fact(Timeout = 120000)]");
@@ -16357,6 +16357,33 @@ public class TestScaffoldGenerator : IIncrementalGenerator
             sb.AppendLine("        finally");
             sb.AppendLine("        {");
             sb.AppendLine("            global::AiDotNet.NeuralNetworks.Layers.LayerInitializationSeedScope.ResetForModelConstruction(null);");
+            sb.AppendLine("        }");
+            sb.AppendLine("    }");
+        }
+
+        if (layer.ClassName == "QuantumLayer")
+        {
+            // A parameter update reconstructs the complete circuit from its angles. If it applies
+            // those angles to the already-rotated circuit instead, a zero-sized update still changes
+            // predictions. Emit this with the layer scaffold so the invariant follows QuantumLayer's
+            // generated fixture and cannot drift into a separate hand-maintained test.
+            sb.AppendLine();
+            sb.AppendLine("    [Fact]");
+            sb.AppendLine("    public void ZeroLearningRateUpdate_PreservesCircuitBehavior()");
+            sb.AppendLine("    {");
+            sb.AppendLine("        using var arena = global::AiDotNet.Tensors.Helpers.TensorArena.Create();");
+            sb.AppendLine("        var layer = CreateLayer();");
+            sb.AppendLine($"        using var input = new global::AiDotNet.Tensors.LinearAlgebra.Tensor<{numericType}>(InputShape);");
+            sb.AppendLine("        for (int i = 0; i < input.Length; i++) input[i] = ToT((i + 1) * 0.125);");
+            sb.AppendLine("        var before = layer.Forward(input).ToArray();");
+            sb.AppendLine("        layer.UpdateParameters(NumOps.Zero);");
+            sb.AppendLine("        var after = layer.Forward(input).ToArray();");
+            sb.AppendLine("        Assert.Equal(before.Length, after.Length);");
+            sb.AppendLine("        for (int i = 0; i < before.Length; i++)");
+            sb.AppendLine("        {");
+            sb.AppendLine("            double delta = global::System.Math.Abs(ToD(before[i]) - ToD(after[i]));");
+            sb.AppendLine("            Assert.True(delta <= Tolerance,");
+            sb.AppendLine("                $\"A zero-learning-rate update changed circuit output {i} by {delta:R}.\");");
             sb.AppendLine("        }");
             sb.AppendLine("    }");
         }

--- a/src/DistributedTraining/InMemoryCommunicationBackend.cs
+++ b/src/DistributedTraining/InMemoryCommunicationBackend.cs
@@ -103,15 +103,25 @@ public class InMemoryCommunicationBackend<T> : CommunicationBackendBase<T>
     // Key format: "{environmentId}_msg_{sourceRank}_{destRank}_{tag}"
     private static readonly Dictionary<string, Queue<Vector<T>>> _messageQueues = new();
 
-    /// <summary>Live backends per environment, so the LAST one out can clear undelivered state.</summary>
+    /// <summary>Lifecycle state for the current generation of an environment.</summary>
     /// <remarks>
-    /// An undelivered queue is deliberately preserved while a peer might still receive from it (see
-    /// ClearEnvironmentState). That guard had no exit: once every backend had shut down, a non-empty
-    /// queue survived indefinitely, and the next session reusing the same environmentId -- including
-    /// the default "default" -- could dequeue a message from the previous one. Counting live backends
-    /// gives the guard a terminating condition.
+    /// A generation remains open while ranks that have not participated may still arrive. Once an
+    /// already-seen rank initializes after the environment becomes quiescent, that is the next
+    /// generation and any abandoned payload from the previous one must be discarded.
     /// </remarks>
-    private static readonly Dictionary<string, int> _activeBackends = new();
+    private sealed class EnvironmentLifecycle
+    {
+        public EnvironmentLifecycle(int worldSize)
+        {
+            WorldSize = worldSize;
+        }
+
+        public int WorldSize { get; }
+        public int ActiveBackends { get; set; }
+        public HashSet<int> ParticipatingRanks { get; } = new();
+    }
+
+    private static readonly Dictionary<string, EnvironmentLifecycle> _environmentLifecycles = new();
 
     private const int BarrierTimeoutMs = 30000; // 30 seconds
     private const int MessageTimeoutMs = 30000; // 30 seconds for point-to-point
@@ -191,8 +201,38 @@ public class InMemoryCommunicationBackend<T> : CommunicationBackendBase<T>
     {
         lock (_globalLock)
         {
-            _activeBackends[_environmentId] =
-                (_activeBackends.TryGetValue(_environmentId, out int live) ? live : 0) + 1;
+            if (_environmentLifecycles.TryGetValue(_environmentId, out var lifecycle))
+            {
+                if (lifecycle.WorldSize != _worldSize)
+                {
+                    throw new InvalidOperationException(
+                        $"Environment '{_environmentId}' is already configured for world size "
+                        + $"{lifecycle.WorldSize}, not {_worldSize}.");
+                }
+
+                if (lifecycle.ActiveBackends == 0 && lifecycle.ParticipatingRanks.Contains(_rank))
+                {
+                    // The same rank returning to a quiescent environment identifies a new session.
+                    // Force-clear any incomplete collective/message from the abandoned generation so
+                    // it cannot be consumed by this generation's peers.
+                    ClearEnvironmentState(_environmentId, force: true);
+                    lifecycle = new EnvironmentLifecycle(_worldSize);
+                    _environmentLifecycles[_environmentId] = lifecycle;
+                }
+                else if (lifecycle.ActiveBackends > 0 && lifecycle.ParticipatingRanks.Contains(_rank))
+                {
+                    throw new InvalidOperationException(
+                        $"Rank {_rank} is already active in environment '{_environmentId}'.");
+                }
+            }
+            else
+            {
+                lifecycle = new EnvironmentLifecycle(_worldSize);
+                _environmentLifecycles.Add(_environmentId, lifecycle);
+            }
+
+            lifecycle.ParticipatingRanks.Add(_rank);
+            lifecycle.ActiveBackends++;
         }
 
         // Base class handles initialization state
@@ -204,20 +244,23 @@ public class InMemoryCommunicationBackend<T> : CommunicationBackendBase<T>
     {
         lock (_globalLock)
         {
-            int live = _activeBackends.TryGetValue(_environmentId, out int n) ? n - 1 : 0;
-            if (live > 0)
+            if (!_environmentLifecycles.TryGetValue(_environmentId, out var lifecycle))
             {
-                _activeBackends[_environmentId] = live;
-            }
-            else
-            {
-                _activeBackends.Remove(_environmentId);
+                return;
             }
 
-            // Clear only this environment's shared state. FORCE once the last backend is gone: the
-            // in-flight guards exist to protect a PEER, and with no peer left there is nothing to
-            // protect -- only stale state for whoever reuses this environmentId next.
-            ClearEnvironmentState(_environmentId, force: live <= 0);
+            lifecycle.ActiveBackends = Math.Max(0, lifecycle.ActiveBackends - 1);
+            bool generationComplete = lifecycle.ActiveBackends == 0
+                && lifecycle.ParticipatingRanks.Count >= lifecycle.WorldSize;
+            if (generationComplete)
+            {
+                _environmentLifecycles.Remove(_environmentId);
+            }
+
+            // An incomplete generation keeps in-flight data for ranks that have not joined yet. Once
+            // every rank has participated and all are gone, no valid consumer remains, so abandoned
+            // state can be removed without contaminating a later session using the same environment.
+            ClearEnvironmentState(_environmentId, force: generationComplete);
         }
     }
 
@@ -238,7 +281,7 @@ public class InMemoryCommunicationBackend<T> : CommunicationBackendBase<T>
             // FORCE: this method's contract is "clears all shared state for an environment", which a
             // preserved in-flight queue would quietly violate -- and its stated purpose is test
             // isolation, where leaked state is exactly what it exists to prevent.
-            _activeBackends.Remove(environmentId);
+            _environmentLifecycles.Remove(environmentId);
             ClearEnvironmentState(environmentId, force: true);
         }
     }

--- a/src/Inference/CachedMultiHeadAttention.cs
+++ b/src/Inference/CachedMultiHeadAttention.cs
@@ -538,11 +538,11 @@ public partial class CachedMultiHeadAttention<T> : LayerBase<T>, IShapeContract
             throw new InvalidOperationException("Backward pass must be called before updating parameters.");
         }
 
-        _queryWeights = Engine.TensorSubtract(_queryWeights, Tensor<T>.FromMatrix(_queryWeightsGradient.Multiply(learningRate)));
-        _keyWeights = Engine.TensorSubtract(_keyWeights, Tensor<T>.FromMatrix(_keyWeightsGradient.Multiply(learningRate)));
-        _valueWeights = Engine.TensorSubtract(_valueWeights, Tensor<T>.FromMatrix(_valueWeightsGradient.Multiply(learningRate)));
-        _outputWeights = Engine.TensorSubtract(_outputWeights, Tensor<T>.FromMatrix(_outputWeightsGradient.Multiply(learningRate)));
-        _outputBias = Engine.TensorSubtract(_outputBias, new Tensor<T>([_outputBias.Length], _outputBiasGradient.Multiply(learningRate)));
+        Engine.TensorSubtractInPlace(_queryWeights, Tensor<T>.FromMatrix(_queryWeightsGradient.Multiply(learningRate)));
+        Engine.TensorSubtractInPlace(_keyWeights, Tensor<T>.FromMatrix(_keyWeightsGradient.Multiply(learningRate)));
+        Engine.TensorSubtractInPlace(_valueWeights, Tensor<T>.FromMatrix(_valueWeightsGradient.Multiply(learningRate)));
+        Engine.TensorSubtractInPlace(_outputWeights, Tensor<T>.FromMatrix(_outputWeightsGradient.Multiply(learningRate)));
+        Engine.TensorSubtractInPlace(_outputBias, new Tensor<T>([_outputBias.Length], _outputBiasGradient.Multiply(learningRate)));
     }
 
     /// <summary>

--- a/src/Inference/CachedMultiHeadAttention.cs
+++ b/src/Inference/CachedMultiHeadAttention.cs
@@ -538,11 +538,24 @@ public partial class CachedMultiHeadAttention<T> : LayerBase<T>, IShapeContract
             throw new InvalidOperationException("Backward pass must be called before updating parameters.");
         }
 
-        Engine.TensorSubtractInPlace(_queryWeights, Tensor<T>.FromMatrix(_queryWeightsGradient.Multiply(learningRate)));
-        Engine.TensorSubtractInPlace(_keyWeights, Tensor<T>.FromMatrix(_keyWeightsGradient.Multiply(learningRate)));
-        Engine.TensorSubtractInPlace(_valueWeights, Tensor<T>.FromMatrix(_valueWeightsGradient.Multiply(learningRate)));
-        Engine.TensorSubtractInPlace(_outputWeights, Tensor<T>.FromMatrix(_outputWeightsGradient.Multiply(learningRate)));
-        Engine.TensorSubtractInPlace(_outputBias, new Tensor<T>([_outputBias.Length], _outputBiasGradient.Multiply(learningRate)));
+        using var queryUpdate = Tensor<T>.FromMatrix(_queryWeightsGradient.Multiply(learningRate));
+        using var keyUpdate = Tensor<T>.FromMatrix(_keyWeightsGradient.Multiply(learningRate));
+        using var valueUpdate = Tensor<T>.FromMatrix(_valueWeightsGradient.Multiply(learningRate));
+        using var outputUpdate = Tensor<T>.FromMatrix(_outputWeightsGradient.Multiply(learningRate));
+        using var outputBiasUpdate =
+            new Tensor<T>([_outputBias.Length], _outputBiasGradient.Multiply(learningRate));
+
+        Engine.TensorSubtractInPlace(_queryWeights, queryUpdate);
+        Engine.TensorSubtractInPlace(_keyWeights, keyUpdate);
+        Engine.TensorSubtractInPlace(_valueWeights, valueUpdate);
+        Engine.TensorSubtractInPlace(_outputWeights, outputUpdate);
+        Engine.TensorSubtractInPlace(_outputBias, outputBiasUpdate);
+
+        Engine.InvalidatePersistentTensor(_queryWeights);
+        Engine.InvalidatePersistentTensor(_keyWeights);
+        Engine.InvalidatePersistentTensor(_valueWeights);
+        Engine.InvalidatePersistentTensor(_outputWeights);
+        Engine.InvalidatePersistentTensor(_outputBias);
     }
 
     /// <summary>

--- a/src/NeuralNetworks/Layers/BatchEnsembleLayer.cs
+++ b/src/NeuralNetworks/Layers/BatchEnsembleLayer.cs
@@ -441,22 +441,22 @@ public partial class BatchEnsembleLayer<T> : LayerBase<T>, IShapeContract
     {
         if (_weightsGrad != null)
         {
-            _weights = Engine.TensorSubtract(_weights, Engine.TensorMultiplyScalar(_weightsGrad, learningRate));
+            Engine.TensorSubtractInPlace(_weights, Engine.TensorMultiplyScalar(_weightsGrad, learningRate));
         }
 
         if (_bias != null && _biasGrad != null)
         {
-            _bias = Engine.TensorSubtract(_bias, Engine.TensorMultiplyScalar(_biasGrad, learningRate));
+            Engine.TensorSubtractInPlace(_bias, Engine.TensorMultiplyScalar(_biasGrad, learningRate));
         }
 
         if (_rVectorsGrad != null)
         {
-            _rVectors = Engine.TensorSubtract(_rVectors, Engine.TensorMultiplyScalar(_rVectorsGrad, learningRate));
+            Engine.TensorSubtractInPlace(_rVectors, Engine.TensorMultiplyScalar(_rVectorsGrad, learningRate));
         }
 
         if (_sVectorsGrad != null)
         {
-            _sVectors = Engine.TensorSubtract(_sVectors, Engine.TensorMultiplyScalar(_sVectorsGrad, learningRate));
+            Engine.TensorSubtractInPlace(_sVectors, Engine.TensorMultiplyScalar(_sVectorsGrad, learningRate));
         }
 
         // Register trainable parameters for tape-based autodiff

--- a/src/NeuralNetworks/Layers/BatchNormalizationLayer.cs
+++ b/src/NeuralNetworks/Layers/BatchNormalizationLayer.cs
@@ -1254,8 +1254,8 @@ public partial class BatchNormalizationLayer<T> : LayerBase<T>, ILayerSerializat
         else
         {
             // Production-grade: Use Engine operations instead of manual loops
-            _gamma = Engine.TensorSubtract(_gamma, Engine.TensorMultiplyScalar(_gammaGradient, learningRate));
-            _beta = Engine.TensorSubtract(_beta, Engine.TensorMultiplyScalar(_betaGradient, learningRate));
+            Engine.TensorSubtractInPlace(_gamma, Engine.TensorMultiplyScalar(_gammaGradient, learningRate));
+            Engine.TensorSubtractInPlace(_beta, Engine.TensorMultiplyScalar(_betaGradient, learningRate));
 
             // Notify GPU that tensor data has changed
             Engine.InvalidatePersistentTensor(_gamma);

--- a/src/NeuralNetworks/Layers/CapsuleLayer.cs
+++ b/src/NeuralNetworks/Layers/CapsuleLayer.cs
@@ -746,10 +746,10 @@ public partial class CapsuleLayer<T> : LayerBase<T>, IAuxiliaryLossLayer<T>, ISh
 
         // Use Engine operations for GPU/CPU acceleration
         var scaledTransformGrad = Engine.TensorMultiplyScalar(_transformationMatrixGradient, learningRate);
-        _transformationMatrix = Engine.TensorSubtract(_transformationMatrix, scaledTransformGrad);
+        Engine.TensorSubtractInPlace(_transformationMatrix, scaledTransformGrad);
 
         var scaledBiasGrad = Engine.TensorMultiplyScalar(_biasGradient, learningRate);
-        _bias = Engine.TensorSubtract(_bias, scaledBiasGrad);
+        Engine.TensorSubtractInPlace(_bias, scaledBiasGrad);
     }
 
     /// <summary>

--- a/src/NeuralNetworks/Layers/Conv3DLayer.cs
+++ b/src/NeuralNetworks/Layers/Conv3DLayer.cs
@@ -878,10 +878,10 @@ public partial class Conv3DLayer<T> : LayerBase<T>, IShapeContract
             throw new InvalidOperationException("Backward pass must be called before updating parameters.");
 
         var scaledKernelGrad = Engine.TensorMultiplyScalar(_kernelsGradient, learningRate);
-        _kernels = Engine.TensorSubtract(_kernels, scaledKernelGrad);
+        Engine.TensorSubtractInPlace(_kernels, scaledKernelGrad);
 
         var scaledBiasGrad = Engine.TensorMultiplyScalar(_biasesGradient, learningRate);
-        _biases = Engine.TensorSubtract(_biases, scaledBiasGrad);
+        Engine.TensorSubtractInPlace(_biases, scaledBiasGrad);
 
         // Invalidate GPU cache after parameter update
         Engine.InvalidatePersistentTensor(_kernels);

--- a/src/NeuralNetworks/Layers/DeformableConvolutionalLayer.cs
+++ b/src/NeuralNetworks/Layers/DeformableConvolutionalLayer.cs
@@ -982,23 +982,23 @@ public partial class DeformableConvolutionalLayer<T> : LayerBase<T>, IShapeContr
         // Update main convolution weights using Engine tensor ops
         if (_weightGradients != null)
         {
-            _weights = Engine.TensorSubtract(_weights, Engine.TensorMultiplyScalar(_weightGradients, learningRate));
+            Engine.TensorSubtractInPlace(_weights, Engine.TensorMultiplyScalar(_weightGradients, learningRate));
         }
 
         if (_biasGradients != null)
         {
-            _bias = Engine.TensorSubtract(_bias, Engine.TensorMultiplyScalar(_biasGradients, learningRate));
+            Engine.TensorSubtractInPlace(_bias, Engine.TensorMultiplyScalar(_biasGradients, learningRate));
         }
 
         // Update offset prediction network weights using Engine tensor ops
         if (_offsetWeightGradients != null)
         {
-            _offsetWeights = Engine.TensorSubtract(_offsetWeights, Engine.TensorMultiplyScalar(_offsetWeightGradients, learningRate));
+            Engine.TensorSubtractInPlace(_offsetWeights, Engine.TensorMultiplyScalar(_offsetWeightGradients, learningRate));
         }
 
         if (_offsetBiasGradients != null)
         {
-            _offsetBias = Engine.TensorSubtract(_offsetBias, Engine.TensorMultiplyScalar(_offsetBiasGradients, learningRate));
+            Engine.TensorSubtractInPlace(_offsetBias, Engine.TensorMultiplyScalar(_offsetBiasGradients, learningRate));
         }
 
         // Update mask prediction network weights (if using modulation) using Engine tensor ops
@@ -1006,12 +1006,12 @@ public partial class DeformableConvolutionalLayer<T> : LayerBase<T>, IShapeContr
         {
             if (_maskWeightGradients != null && _maskWeights != null)
             {
-                _maskWeights = Engine.TensorSubtract(_maskWeights, Engine.TensorMultiplyScalar(_maskWeightGradients, learningRate));
+                Engine.TensorSubtractInPlace(_maskWeights, Engine.TensorMultiplyScalar(_maskWeightGradients, learningRate));
             }
 
             if (_maskBiasGradients != null && _maskBias != null)
             {
-                _maskBias = Engine.TensorSubtract(_maskBias, Engine.TensorMultiplyScalar(_maskBiasGradients, learningRate));
+                Engine.TensorSubtractInPlace(_maskBias, Engine.TensorMultiplyScalar(_maskBiasGradients, learningRate));
             }
         }
 

--- a/src/NeuralNetworks/Layers/DepthwiseSeparableConvolutionalLayer.cs
+++ b/src/NeuralNetworks/Layers/DepthwiseSeparableConvolutionalLayer.cs
@@ -1331,9 +1331,9 @@ public partial class DepthwiseSeparableConvolutionalLayer<T> : LayerBase<T>, ISh
             throw new InvalidOperationException("Backward pass must be called before updating parameters.");
 
         // Use Engine operations for GPU/CPU acceleration
-        _depthwiseKernels = Engine.TensorSubtract(_depthwiseKernels, Engine.TensorMultiplyScalar(_depthwiseKernelsGradient, learningRate));
-        _pointwiseKernels = Engine.TensorSubtract(_pointwiseKernels, Engine.TensorMultiplyScalar(_pointwiseKernelsGradient, learningRate));
-        _biases = Engine.TensorSubtract(_biases, Engine.TensorMultiplyScalar(_biasesGradient, learningRate));
+        Engine.TensorSubtractInPlace(_depthwiseKernels, Engine.TensorMultiplyScalar(_depthwiseKernelsGradient, learningRate));
+        Engine.TensorSubtractInPlace(_pointwiseKernels, Engine.TensorMultiplyScalar(_pointwiseKernelsGradient, learningRate));
+        Engine.TensorSubtractInPlace(_biases, Engine.TensorMultiplyScalar(_biasesGradient, learningRate));
 
         // Invalidate GPU cache after parameter update
         Engine.InvalidatePersistentTensor(_depthwiseKernels);

--- a/src/NeuralNetworks/Layers/DiffusionConvLayer.cs
+++ b/src/NeuralNetworks/Layers/DiffusionConvLayer.cs
@@ -1676,11 +1676,11 @@ public partial class DiffusionConvLayer<T> : LayerBase<T>, IShapeContract
 
         // Update weights
         var scaledWeightGrad = Engine.TensorMultiplyScalar(_weightsGradient, learningRate);
-        _weights = Engine.TensorSubtract(_weights, scaledWeightGrad);
+        Engine.TensorSubtractInPlace(_weights, scaledWeightGrad);
 
         // Update biases
         var scaledBiasGrad = Engine.TensorMultiplyScalar(_biasesGradient, learningRate);
-        _biases = Engine.TensorSubtract(_biases, scaledBiasGrad);
+        Engine.TensorSubtractInPlace(_biases, scaledBiasGrad);
 
         // Update diffusion times if gradients are available
         if (_diffusionTimesGradient != null)

--- a/src/NeuralNetworks/Layers/DilatedConvolutionalLayer.cs
+++ b/src/NeuralNetworks/Layers/DilatedConvolutionalLayer.cs
@@ -929,8 +929,8 @@ public partial class DilatedConvolutionalLayer<T> : LayerBase<T>, IShapeContract
         }
 
         // Use Engine operations for GPU/CPU acceleration
-        _kernels = Engine.TensorSubtract(_kernels, Engine.TensorMultiplyScalar(_kernelGradients, learningRate));
-        _biases = Engine.TensorSubtract(_biases, Engine.TensorMultiplyScalar(_biasGradients, learningRate));
+        Engine.TensorSubtractInPlace(_kernels, Engine.TensorMultiplyScalar(_kernelGradients, learningRate));
+        Engine.TensorSubtractInPlace(_biases, Engine.TensorMultiplyScalar(_biasGradients, learningRate));
 
         // Invalidate GPU cache after parameter update
         Engine.InvalidatePersistentTensor(_kernels);

--- a/src/NeuralNetworks/Layers/DirectionalGraphLayer.cs
+++ b/src/NeuralNetworks/Layers/DirectionalGraphLayer.cs
@@ -1126,50 +1126,50 @@ public partial class DirectionalGraphLayer<T> : LayerBase<T>, IGraphConvolutionL
 
         // Update weights using Engine operations
         var scaledInGrad = Engine.TensorMultiplyScalar(_incomingWeightsGradient, learningRate);
-        _incomingWeights = Engine.TensorSubtract(_incomingWeights, scaledInGrad);
+        Engine.TensorSubtractInPlace(_incomingWeights, scaledInGrad);
 
         var scaledOutGrad = Engine.TensorMultiplyScalar(_outgoingWeightsGradient, learningRate);
-        _outgoingWeights = Engine.TensorSubtract(_outgoingWeights, scaledOutGrad);
+        Engine.TensorSubtractInPlace(_outgoingWeights, scaledOutGrad);
 
         var scaledSelfGrad = Engine.TensorMultiplyScalar(_selfWeightsGradient, learningRate);
-        _selfWeights = Engine.TensorSubtract(_selfWeights, scaledSelfGrad);
+        Engine.TensorSubtractInPlace(_selfWeights, scaledSelfGrad);
 
         var scaledCombGrad = Engine.TensorMultiplyScalar(_combinationWeightsGradient, learningRate);
-        _combinationWeights = Engine.TensorSubtract(_combinationWeights, scaledCombGrad);
+        Engine.TensorSubtractInPlace(_combinationWeights, scaledCombGrad);
 
         // Update biases
         if (_incomingBiasGradient != null)
         {
             var scaledInBiasGrad = Engine.TensorMultiplyScalar(_incomingBiasGradient, learningRate);
-            _incomingBias = Engine.TensorSubtract(_incomingBias, scaledInBiasGrad);
+            Engine.TensorSubtractInPlace(_incomingBias, scaledInBiasGrad);
         }
 
         if (_outgoingBiasGradient != null)
         {
             var scaledOutBiasGrad = Engine.TensorMultiplyScalar(_outgoingBiasGradient, learningRate);
-            _outgoingBias = Engine.TensorSubtract(_outgoingBias, scaledOutBiasGrad);
+            Engine.TensorSubtractInPlace(_outgoingBias, scaledOutBiasGrad);
         }
 
         if (_selfBiasGradient != null)
         {
             var scaledSelfBiasGrad = Engine.TensorMultiplyScalar(_selfBiasGradient, learningRate);
-            _selfBias = Engine.TensorSubtract(_selfBias, scaledSelfBiasGrad);
+            Engine.TensorSubtractInPlace(_selfBias, scaledSelfBiasGrad);
         }
 
         if (_combinationBiasGradient != null)
         {
             var scaledCombBiasGrad = Engine.TensorMultiplyScalar(_combinationBiasGradient, learningRate);
-            _combinationBias = Engine.TensorSubtract(_combinationBias, scaledCombBiasGrad);
+            Engine.TensorSubtractInPlace(_combinationBias, scaledCombBiasGrad);
         }
 
         // Update gating parameters if enabled
         if (_useGating && _gateWeightsGradient != null && _gateBiasGradient != null && _gateWeights != null && _gateBias != null)
         {
             var scaledGateWeightsGrad = Engine.TensorMultiplyScalar(_gateWeightsGradient, learningRate);
-            _gateWeights = Engine.TensorSubtract(_gateWeights, scaledGateWeightsGrad);
+            Engine.TensorSubtractInPlace(_gateWeights, scaledGateWeightsGrad);
 
             var scaledGateBiasGrad = Engine.TensorMultiplyScalar(_gateBiasGradient, learningRate);
-            _gateBias = Engine.TensorSubtract(_gateBias, scaledGateBiasGrad);
+            Engine.TensorSubtractInPlace(_gateBias, scaledGateBiasGrad);
         }
     }
 

--- a/src/NeuralNetworks/Layers/EdgeConditionalConvolutionalLayer.cs
+++ b/src/NeuralNetworks/Layers/EdgeConditionalConvolutionalLayer.cs
@@ -942,22 +942,22 @@ public partial class EdgeConditionalConvolutionalLayer<T> : LayerBase<T>, IGraph
 
         // Use Engine operations for parameter updates
         var scaledW1Grad = Engine.TensorMultiplyScalar(_edgeNetworkWeights1Gradient, learningRate);
-        _edgeNetworkWeights1 = Engine.TensorSubtract(_edgeNetworkWeights1, scaledW1Grad);
+        Engine.TensorSubtractInPlace(_edgeNetworkWeights1, scaledW1Grad);
 
         var scaledW2Grad = Engine.TensorMultiplyScalar(_edgeNetworkWeights2Gradient!, learningRate);
-        _edgeNetworkWeights2 = Engine.TensorSubtract(_edgeNetworkWeights2, scaledW2Grad);
+        Engine.TensorSubtractInPlace(_edgeNetworkWeights2, scaledW2Grad);
 
         var scaledSelfGrad = Engine.TensorMultiplyScalar(_selfWeightsGradient!, learningRate);
-        _selfWeights = Engine.TensorSubtract(_selfWeights, scaledSelfGrad);
+        Engine.TensorSubtractInPlace(_selfWeights, scaledSelfGrad);
 
         var scaledBias1Grad = Engine.TensorMultiplyScalar(_edgeNetworkBias1Gradient!, learningRate);
-        _edgeNetworkBias1 = Engine.TensorSubtract(_edgeNetworkBias1, scaledBias1Grad);
+        Engine.TensorSubtractInPlace(_edgeNetworkBias1, scaledBias1Grad);
 
         var scaledBias2Grad = Engine.TensorMultiplyScalar(_edgeNetworkBias2Gradient!, learningRate);
-        _edgeNetworkBias2 = Engine.TensorSubtract(_edgeNetworkBias2, scaledBias2Grad);
+        Engine.TensorSubtractInPlace(_edgeNetworkBias2, scaledBias2Grad);
 
         var scaledBiasGrad = Engine.TensorMultiplyScalar(_biasGradient!, learningRate);
-        _bias = Engine.TensorSubtract(_bias, scaledBiasGrad);
+        Engine.TensorSubtractInPlace(_bias, scaledBiasGrad);
 
         // Invalidate GPU cache after parameter updates
         Engine.InvalidatePersistentTensor(_edgeNetworkWeights1);

--- a/src/NeuralNetworks/Layers/EmbeddingLayer.cs
+++ b/src/NeuralNetworks/Layers/EmbeddingLayer.cs
@@ -796,7 +796,7 @@ public partial class EmbeddingLayer<T> : LayerBase<T>, IAuxiliaryLossLayer<T>, I
             throw new InvalidOperationException("Backward pass must be called before updating parameters.");
 
         var scaledGradient = Engine.TensorMultiplyScalar(_embeddingGradient, learningRate);
-        _embeddingTensor = Engine.TensorSubtract(_embeddingTensor, scaledGradient);
+        Engine.TensorSubtractInPlace(_embeddingTensor, scaledGradient);
 
         // Notify GPU that tensor data has changed
         Engine.InvalidatePersistentTensor(_embeddingTensor);

--- a/src/NeuralNetworks/Layers/GRULayer.cs
+++ b/src/NeuralNetworks/Layers/GRULayer.cs
@@ -1490,15 +1490,15 @@ public partial class GRULayer<T> : LayerBase<T>, IShapeContract
             var scaledBr = Engine.TensorMultiplyScalar(_dbr, learningRate);
             var scaledBh = Engine.TensorMultiplyScalar(_dbh, learningRate);
 
-            _Wz = Engine.TensorSubtract(_Wz, scaledWz);
-            _Wr = Engine.TensorSubtract(_Wr, scaledWr);
-            _Wh = Engine.TensorSubtract(_Wh, scaledWh);
-            _Uz = Engine.TensorSubtract(_Uz, scaledUz);
-            _Ur = Engine.TensorSubtract(_Ur, scaledUr);
-            _Uh = Engine.TensorSubtract(_Uh, scaledUh);
-            _bz = Engine.TensorSubtract(_bz, scaledBz);
-            _br = Engine.TensorSubtract(_br, scaledBr);
-            _bh = Engine.TensorSubtract(_bh, scaledBh);
+            Engine.TensorSubtractInPlace(_Wz, scaledWz);
+            Engine.TensorSubtractInPlace(_Wr, scaledWr);
+            Engine.TensorSubtractInPlace(_Wh, scaledWh);
+            Engine.TensorSubtractInPlace(_Uz, scaledUz);
+            Engine.TensorSubtractInPlace(_Ur, scaledUr);
+            Engine.TensorSubtractInPlace(_Uh, scaledUh);
+            Engine.TensorSubtractInPlace(_bz, scaledBz);
+            Engine.TensorSubtractInPlace(_br, scaledBr);
+            Engine.TensorSubtractInPlace(_bh, scaledBh);
 
             Engine.InvalidatePersistentTensor(_Wz);
             Engine.InvalidatePersistentTensor(_Wr);

--- a/src/NeuralNetworks/Layers/GraphAttentionLayer.cs
+++ b/src/NeuralNetworks/Layers/GraphAttentionLayer.cs
@@ -867,10 +867,10 @@ public partial class GraphAttentionLayer<T> : LayerBase<T>, IGraphConvolutionLay
         }
 
         // Update using Engine operations
-        _weights = Engine.TensorSubtract(_weights, Engine.TensorMultiplyScalar(_weightsGradient, learningRate));
-        _attentionWeights = Engine.TensorSubtract(_attentionWeights,
+        Engine.TensorSubtractInPlace(_weights, Engine.TensorMultiplyScalar(_weightsGradient, learningRate));
+        Engine.TensorSubtractInPlace(_attentionWeights,
             Engine.TensorMultiplyScalar(_attentionWeightsGradient, learningRate));
-        _bias = Engine.TensorSubtract(_bias, Engine.TensorMultiplyScalar(_biasGradient, learningRate));
+        Engine.TensorSubtractInPlace(_bias, Engine.TensorMultiplyScalar(_biasGradient, learningRate));
 
         // Notify GPU that tensor data has changed
         Engine.InvalidatePersistentTensor(_weights);

--- a/src/NeuralNetworks/Layers/GraphConvolutionalLayer.cs
+++ b/src/NeuralNetworks/Layers/GraphConvolutionalLayer.cs
@@ -1279,12 +1279,12 @@ public partial class GraphConvolutionalLayer<T> : LayerBase<T>, IAuxiliaryLossLa
         {
             // Use Engine operations for parameter updates
             var scaledWeightsGrad = Engine.TensorMultiplyScalar(_weightsGradient, learningRate);
-            _weights = Engine.TensorSubtract(_weights, scaledWeightsGrad);
+            Engine.TensorSubtractInPlace(_weights, scaledWeightsGrad);
 
             if (_useBias)
             {
                 var scaledBiasGrad = Engine.TensorMultiplyScalar(_biasGradient!, learningRate);
-                _bias = Engine.TensorSubtract(_bias, scaledBiasGrad);
+                Engine.TensorSubtractInPlace(_bias, scaledBiasGrad);
             }
 
             // Notify engine that parameters have changed (for GPU cache invalidation if needed)

--- a/src/NeuralNetworks/Layers/GraphIsomorphismLayer.cs
+++ b/src/NeuralNetworks/Layers/GraphIsomorphismLayer.cs
@@ -459,13 +459,13 @@ public partial class GraphIsomorphismLayer<T> : LayerBase<T>, IGraphConvolutionL
         }
 
         // Update using vectorized Engine operations
-        _mlpWeights1 = Engine.TensorSubtract(_mlpWeights1,
+        Engine.TensorSubtractInPlace(_mlpWeights1,
             Engine.TensorMultiplyScalar(_mlpWeights1Gradient, learningRate));
-        _mlpWeights2 = Engine.TensorSubtract(_mlpWeights2,
+        Engine.TensorSubtractInPlace(_mlpWeights2,
             Engine.TensorMultiplyScalar(_mlpWeights2Gradient, learningRate));
-        _mlpBias1 = Engine.TensorSubtract(_mlpBias1,
+        Engine.TensorSubtractInPlace(_mlpBias1,
             Engine.TensorMultiplyScalar(_mlpBias1Gradient, learningRate));
-        _mlpBias2 = Engine.TensorSubtract(_mlpBias2,
+        Engine.TensorSubtractInPlace(_mlpBias2,
             Engine.TensorMultiplyScalar(_mlpBias2Gradient, learningRate));
 
         // Update epsilon if learnable

--- a/src/NeuralNetworks/Layers/GraphSAGELayer.cs
+++ b/src/NeuralNetworks/Layers/GraphSAGELayer.cs
@@ -637,11 +637,11 @@ public partial class GraphSAGELayer<T> : LayerBase<T>, IGraphConvolutionLayer<T>
         }
 
         // Update using vectorized Engine operations
-        _selfWeights = Engine.TensorSubtract(_selfWeights,
+        Engine.TensorSubtractInPlace(_selfWeights,
             Engine.TensorMultiplyScalar(_selfWeightsGradient, learningRate));
-        _neighborWeights = Engine.TensorSubtract(_neighborWeights,
+        Engine.TensorSubtractInPlace(_neighborWeights,
             Engine.TensorMultiplyScalar(_neighborWeightsGradient, learningRate));
-        _bias = Engine.TensorSubtract(_bias,
+        Engine.TensorSubtractInPlace(_bias,
             Engine.TensorMultiplyScalar(_biasGradient, learningRate));
     }
 

--- a/src/NeuralNetworks/Layers/GraphTransformerLayer.cs
+++ b/src/NeuralNetworks/Layers/GraphTransformerLayer.cs
@@ -1223,31 +1223,31 @@ public partial class GraphTransformerLayer<T> : LayerBase<T>, IGraphConvolutionL
 
         // Update all parameters using Engine operations
         var scaledQueryGrad = Engine.TensorMultiplyScalar(_queryWeightsGradient, learningRate);
-        _queryWeights = Engine.TensorSubtract(_queryWeights, scaledQueryGrad);
+        Engine.TensorSubtractInPlace(_queryWeights, scaledQueryGrad);
 
         var scaledKeyGrad = Engine.TensorMultiplyScalar(_keyWeightsGradient, learningRate);
-        _keyWeights = Engine.TensorSubtract(_keyWeights, scaledKeyGrad);
+        Engine.TensorSubtractInPlace(_keyWeights, scaledKeyGrad);
 
         var scaledValueGrad = Engine.TensorMultiplyScalar(_valueWeightsGradient, learningRate);
-        _valueWeights = Engine.TensorSubtract(_valueWeights, scaledValueGrad);
+        Engine.TensorSubtractInPlace(_valueWeights, scaledValueGrad);
 
         var scaledOutputWeightsGrad = Engine.TensorMultiplyScalar(_outputWeightsGradient, learningRate);
-        _outputWeights = Engine.TensorSubtract(_outputWeights, scaledOutputWeightsGrad);
+        Engine.TensorSubtractInPlace(_outputWeights, scaledOutputWeightsGrad);
 
         var scaledOutputBiasGrad = Engine.TensorMultiplyScalar(_outputBiasGradient, learningRate);
-        _outputBias = Engine.TensorSubtract(_outputBias, scaledOutputBiasGrad);
+        Engine.TensorSubtractInPlace(_outputBias, scaledOutputBiasGrad);
 
         var scaledFFN1Grad = Engine.TensorMultiplyScalar(_ffnWeights1Gradient, learningRate);
-        _ffnWeights1 = Engine.TensorSubtract(_ffnWeights1, scaledFFN1Grad);
+        Engine.TensorSubtractInPlace(_ffnWeights1, scaledFFN1Grad);
 
         var scaledFFN2Grad = Engine.TensorMultiplyScalar(_ffnWeights2Gradient, learningRate);
-        _ffnWeights2 = Engine.TensorSubtract(_ffnWeights2, scaledFFN2Grad);
+        Engine.TensorSubtractInPlace(_ffnWeights2, scaledFFN2Grad);
 
         var scaledFFNBias1Grad = Engine.TensorMultiplyScalar(_ffnBias1Gradient, learningRate);
-        _ffnBias1 = Engine.TensorSubtract(_ffnBias1, scaledFFNBias1Grad);
+        Engine.TensorSubtractInPlace(_ffnBias1, scaledFFNBias1Grad);
 
         var scaledFFNBias2Grad = Engine.TensorMultiplyScalar(_ffnBias2Gradient, learningRate);
-        _ffnBias2 = Engine.TensorSubtract(_ffnBias2, scaledFFNBias2Grad);
+        Engine.TensorSubtractInPlace(_ffnBias2, scaledFFNBias2Grad);
     }
 
     /// <inheritdoc/>

--- a/src/NeuralNetworks/Layers/GroupedQueryAttentionLayer.cs
+++ b/src/NeuralNetworks/Layers/GroupedQueryAttentionLayer.cs
@@ -768,11 +768,11 @@ public partial class GroupedQueryAttentionLayer<T> : LayerBase<T>, IShapeContrac
         }
 
         T negLR = NumOps.Negate(learningRate);
-        _queryWeights = Engine.TensorAdd(_queryWeights, Engine.TensorMultiplyScalar(_queryWeightsGradient, negLR));
-        _keyWeights = Engine.TensorAdd(_keyWeights, Engine.TensorMultiplyScalar(_keyWeightsGradient, negLR));
-        _valueWeights = Engine.TensorAdd(_valueWeights, Engine.TensorMultiplyScalar(_valueWeightsGradient, negLR));
-        _outputWeights = Engine.TensorAdd(_outputWeights, Engine.TensorMultiplyScalar(_outputWeightsGradient, negLR));
-        _outputBias = Engine.TensorAdd(_outputBias, Engine.TensorMultiplyScalar(_outputBiasGradient, negLR));
+        Engine.TensorAddInPlace(_queryWeights, Engine.TensorMultiplyScalar(_queryWeightsGradient, negLR));
+        Engine.TensorAddInPlace(_keyWeights, Engine.TensorMultiplyScalar(_keyWeightsGradient, negLR));
+        Engine.TensorAddInPlace(_valueWeights, Engine.TensorMultiplyScalar(_valueWeightsGradient, negLR));
+        Engine.TensorAddInPlace(_outputWeights, Engine.TensorMultiplyScalar(_outputWeightsGradient, negLR));
+        Engine.TensorAddInPlace(_outputBias, Engine.TensorMultiplyScalar(_outputBiasGradient, negLR));
     }
 
     public override Vector<T> GetParameterGradients()

--- a/src/NeuralNetworks/Layers/HeterogeneousGraphLayer.cs
+++ b/src/NeuralNetworks/Layers/HeterogeneousGraphLayer.cs
@@ -1135,7 +1135,7 @@ public partial class HeterogeneousGraphLayer<T> : LayerBase<T>, IGraphConvolutio
         {
             // Update basis matrices
             var scaledBasisGrad = Engine.TensorMultiplyScalar(_basisMatricesGradient, learningRate);
-            _basisMatrices = Engine.TensorSubtract(_basisMatrices, scaledBasisGrad);
+            Engine.TensorSubtractInPlace(_basisMatrices, scaledBasisGrad);
 
             // Update basis coefficients
             foreach (var kvp in _basisCoefficients)

--- a/src/NeuralNetworks/Layers/HeterogeneousGraphLayer.cs
+++ b/src/NeuralNetworks/Layers/HeterogeneousGraphLayer.cs
@@ -1126,7 +1126,8 @@ public partial class HeterogeneousGraphLayer<T> : LayerBase<T>, IGraphConvolutio
                 if (_edgeTypeWeightsGradients.TryGetValue(edgeType, out var gradient))
                 {
                     var scaledGrad = Engine.TensorMultiplyScalar(gradient, learningRate);
-                    _edgeTypeWeights[edgeType] = Engine.TensorSubtract(_edgeTypeWeights[edgeType], scaledGrad);
+                    Engine.TensorSubtractInPlace(_edgeTypeWeights[edgeType], scaledGrad);
+                    Engine.InvalidatePersistentTensor(_edgeTypeWeights[edgeType]);
                 }
             }
         }
@@ -1136,6 +1137,7 @@ public partial class HeterogeneousGraphLayer<T> : LayerBase<T>, IGraphConvolutio
             // Update basis matrices
             var scaledBasisGrad = Engine.TensorMultiplyScalar(_basisMatricesGradient, learningRate);
             Engine.TensorSubtractInPlace(_basisMatrices, scaledBasisGrad);
+            Engine.InvalidatePersistentTensor(_basisMatrices);
 
             // Update basis coefficients
             foreach (var kvp in _basisCoefficients)
@@ -1144,7 +1146,8 @@ public partial class HeterogeneousGraphLayer<T> : LayerBase<T>, IGraphConvolutio
                 if (_basisCoefficientsGradients.TryGetValue(edgeType, out var gradient))
                 {
                     var scaledGrad = Engine.TensorMultiplyScalar(gradient, learningRate);
-                    _basisCoefficients[edgeType] = Engine.TensorSubtract(_basisCoefficients[edgeType], scaledGrad);
+                    Engine.TensorSubtractInPlace(_basisCoefficients[edgeType], scaledGrad);
+                    Engine.InvalidatePersistentTensor(_basisCoefficients[edgeType]);
                 }
             }
         }
@@ -1156,7 +1159,8 @@ public partial class HeterogeneousGraphLayer<T> : LayerBase<T>, IGraphConvolutio
             if (_selfLoopWeightsGradients.TryGetValue(nodeType, out var gradient))
             {
                 var scaledGrad = Engine.TensorMultiplyScalar(gradient, learningRate);
-                _selfLoopWeights[nodeType] = Engine.TensorSubtract(_selfLoopWeights[nodeType], scaledGrad);
+                Engine.TensorSubtractInPlace(_selfLoopWeights[nodeType], scaledGrad);
+                Engine.InvalidatePersistentTensor(_selfLoopWeights[nodeType]);
             }
         }
 
@@ -1167,7 +1171,8 @@ public partial class HeterogeneousGraphLayer<T> : LayerBase<T>, IGraphConvolutio
             if (_biasesGradients.TryGetValue(nodeType, out var gradient))
             {
                 var scaledGrad = Engine.TensorMultiplyScalar(gradient, learningRate);
-                _biases[nodeType] = Engine.TensorSubtract(_biases[nodeType], scaledGrad);
+                Engine.TensorSubtractInPlace(_biases[nodeType], scaledGrad);
+                Engine.InvalidatePersistentTensor(_biases[nodeType]);
             }
         }
     }

--- a/src/NeuralNetworks/Layers/HighwayLayer.cs
+++ b/src/NeuralNetworks/Layers/HighwayLayer.cs
@@ -808,10 +808,10 @@ public partial class HighwayLayer<T> : LayerBase<T>, IAuxiliaryLossLayer<T>, ISh
         var scaledGateWeightsGrad = Engine.TensorMultiplyScalar(_gateWeightsGradient, learningRate);
         var scaledGateBiasGrad = Engine.TensorMultiplyScalar(_gateBiasGradient, learningRate);
 
-        _transformWeights = Engine.TensorSubtract(_transformWeights, scaledTransformWeightsGrad);
-        _transformBias = Engine.TensorSubtract(_transformBias, scaledTransformBiasGrad);
-        _gateWeights = Engine.TensorSubtract(_gateWeights, scaledGateWeightsGrad);
-        _gateBias = Engine.TensorSubtract(_gateBias, scaledGateBiasGrad);
+        Engine.TensorSubtractInPlace(_transformWeights, scaledTransformWeightsGrad);
+        Engine.TensorSubtractInPlace(_transformBias, scaledTransformBiasGrad);
+        Engine.TensorSubtractInPlace(_gateWeights, scaledGateWeightsGrad);
+        Engine.TensorSubtractInPlace(_gateBias, scaledGateBiasGrad);
 
         // Notify engine that parameters have changed (for GPU cache invalidation)
         Engine.InvalidatePersistentTensor(_transformWeights);

--- a/src/NeuralNetworks/Layers/InteractingLayer.cs
+++ b/src/NeuralNetworks/Layers/InteractingLayer.cs
@@ -329,14 +329,14 @@ public partial class InteractingLayer<T> : LayerBase<T>, IShapeContract
     public override void UpdateParameters(T learningRate)
     {
         // w = w - lr * grad  =>  Engine.TensorSubtract(w, Engine.TensorMultiplyScalar(grad, lr))
-        _queryWeights = Engine.TensorSubtract(_queryWeights, Engine.TensorMultiplyScalar(_queryWeightsGrad, learningRate));
-        _keyWeights = Engine.TensorSubtract(_keyWeights, Engine.TensorMultiplyScalar(_keyWeightsGrad, learningRate));
-        _valueWeights = Engine.TensorSubtract(_valueWeights, Engine.TensorMultiplyScalar(_valueWeightsGrad, learningRate));
-        _outputWeights = Engine.TensorSubtract(_outputWeights, Engine.TensorMultiplyScalar(_outputWeightsGrad, learningRate));
+        Engine.TensorSubtractInPlace(_queryWeights, Engine.TensorMultiplyScalar(_queryWeightsGrad, learningRate));
+        Engine.TensorSubtractInPlace(_keyWeights, Engine.TensorMultiplyScalar(_keyWeightsGrad, learningRate));
+        Engine.TensorSubtractInPlace(_valueWeights, Engine.TensorMultiplyScalar(_valueWeightsGrad, learningRate));
+        Engine.TensorSubtractInPlace(_outputWeights, Engine.TensorMultiplyScalar(_outputWeightsGrad, learningRate));
 
         if (_residualWeights != null && _residualWeightsGrad != null)
         {
-            _residualWeights = Engine.TensorSubtract(_residualWeights, Engine.TensorMultiplyScalar(_residualWeightsGrad, learningRate));
+            Engine.TensorSubtractInPlace(_residualWeights, Engine.TensorMultiplyScalar(_residualWeightsGrad, learningRate));
         }
 
         // Register trainable parameters for tape-based autodiff

--- a/src/NeuralNetworks/Layers/LSTMLayer.cs
+++ b/src/NeuralNetworks/Layers/LSTMLayer.cs
@@ -2310,40 +2310,40 @@ public partial class LSTMLayer<T> : LayerBase<T>, IShapeContract
                 switch (paramName)
                 {
                     case "weightsFi":
-                        _weightsFi = Engine.TensorSubtract(_weightsFi, scaledGradient);
+                        Engine.TensorSubtractInPlace(_weightsFi, scaledGradient);
                         break;
                     case "weightsIi":
-                        _weightsIi = Engine.TensorSubtract(_weightsIi, scaledGradient);
+                        Engine.TensorSubtractInPlace(_weightsIi, scaledGradient);
                         break;
                     case "weightsCi":
-                        _weightsCi = Engine.TensorSubtract(_weightsCi, scaledGradient);
+                        Engine.TensorSubtractInPlace(_weightsCi, scaledGradient);
                         break;
                     case "weightsOi":
-                        _weightsOi = Engine.TensorSubtract(_weightsOi, scaledGradient);
+                        Engine.TensorSubtractInPlace(_weightsOi, scaledGradient);
                         break;
                     case "weightsFh":
-                        _weightsFh = Engine.TensorSubtract(_weightsFh, scaledGradient);
+                        Engine.TensorSubtractInPlace(_weightsFh, scaledGradient);
                         break;
                     case "weightsIh":
-                        _weightsIh = Engine.TensorSubtract(_weightsIh, scaledGradient);
+                        Engine.TensorSubtractInPlace(_weightsIh, scaledGradient);
                         break;
                     case "weightsCh":
-                        _weightsCh = Engine.TensorSubtract(_weightsCh, scaledGradient);
+                        Engine.TensorSubtractInPlace(_weightsCh, scaledGradient);
                         break;
                     case "weightsOh":
-                        _weightsOh = Engine.TensorSubtract(_weightsOh, scaledGradient);
+                        Engine.TensorSubtractInPlace(_weightsOh, scaledGradient);
                         break;
                     case "biasF":
-                        _biasF = Engine.TensorSubtract(_biasF, scaledGradient);
+                        Engine.TensorSubtractInPlace(_biasF, scaledGradient);
                         break;
                     case "biasI":
-                        _biasI = Engine.TensorSubtract(_biasI, scaledGradient);
+                        Engine.TensorSubtractInPlace(_biasI, scaledGradient);
                         break;
                     case "biasC":
-                        _biasC = Engine.TensorSubtract(_biasC, scaledGradient);
+                        Engine.TensorSubtractInPlace(_biasC, scaledGradient);
                         break;
                     case "biasO":
-                        _biasO = Engine.TensorSubtract(_biasO, scaledGradient);
+                        Engine.TensorSubtractInPlace(_biasO, scaledGradient);
                         break;
                 }
             }

--- a/src/NeuralNetworks/Layers/MemoryReadLayer.cs
+++ b/src/NeuralNetworks/Layers/MemoryReadLayer.cs
@@ -605,16 +605,16 @@ public partial class MemoryReadLayer<T> : LayerBase<T>, IAuxiliaryLossLayer<T>, 
 
         // Use Engine operations for parameter updates
         var scaledKeyGrad = Engine.TensorMultiplyScalar(_keyWeightsGradient, learningRate);
-        _keyWeights = Engine.TensorSubtract(_keyWeights, scaledKeyGrad);
+        Engine.TensorSubtractInPlace(_keyWeights, scaledKeyGrad);
 
         var scaledValueGrad = Engine.TensorMultiplyScalar(_valueWeightsGradient, learningRate);
-        _valueWeights = Engine.TensorSubtract(_valueWeights, scaledValueGrad);
+        Engine.TensorSubtractInPlace(_valueWeights, scaledValueGrad);
 
         var scaledOutputGrad = Engine.TensorMultiplyScalar(_outputWeightsGradient, learningRate);
-        _outputWeights = Engine.TensorSubtract(_outputWeights, scaledOutputGrad);
+        Engine.TensorSubtractInPlace(_outputWeights, scaledOutputGrad);
 
         var scaledBiasGrad = Engine.TensorMultiplyScalar(_outputBiasGradient, learningRate);
-        _outputBias = Engine.TensorSubtract(_outputBias, scaledBiasGrad);
+        Engine.TensorSubtractInPlace(_outputBias, scaledBiasGrad);
 
         // Notify GPU that tensor data has changed
         Engine.InvalidatePersistentTensor(_keyWeights);

--- a/src/NeuralNetworks/Layers/MemoryWriteLayer.cs
+++ b/src/NeuralNetworks/Layers/MemoryWriteLayer.cs
@@ -718,19 +718,19 @@ public partial class MemoryWriteLayer<T> : LayerBase<T>, IAuxiliaryLossLayer<T>,
 
         // Use Engine operations for parameter updates
         var scaledQueryGrad = Engine.TensorMultiplyScalar(_queryWeightsGradient, learningRate);
-        _queryWeights = Engine.TensorSubtract(_queryWeights, scaledQueryGrad);
+        Engine.TensorSubtractInPlace(_queryWeights, scaledQueryGrad);
 
         var scaledKeyGrad = Engine.TensorMultiplyScalar(_keyWeightsGradient, learningRate);
-        _keyWeights = Engine.TensorSubtract(_keyWeights, scaledKeyGrad);
+        Engine.TensorSubtractInPlace(_keyWeights, scaledKeyGrad);
 
         var scaledValueGrad = Engine.TensorMultiplyScalar(_valueWeightsGradient, learningRate);
-        _valueWeights = Engine.TensorSubtract(_valueWeights, scaledValueGrad);
+        Engine.TensorSubtractInPlace(_valueWeights, scaledValueGrad);
 
         var scaledOutputGrad = Engine.TensorMultiplyScalar(_outputWeightsGradient, learningRate);
-        _outputWeights = Engine.TensorSubtract(_outputWeights, scaledOutputGrad);
+        Engine.TensorSubtractInPlace(_outputWeights, scaledOutputGrad);
 
         var scaledBiasGrad = Engine.TensorMultiplyScalar(_outputBiasGradient, learningRate);
-        _outputBias = Engine.TensorSubtract(_outputBias, scaledBiasGrad);
+        Engine.TensorSubtractInPlace(_outputBias, scaledBiasGrad);
 
         // Notify GPU that tensor data has changed
         Engine.InvalidatePersistentTensor(_queryWeights);

--- a/src/NeuralNetworks/Layers/MeshEdgeConvLayer.cs
+++ b/src/NeuralNetworks/Layers/MeshEdgeConvLayer.cs
@@ -684,10 +684,10 @@ public partial class MeshEdgeConvLayer<T> : LayerBase<T>, IShapeContract
             throw new InvalidOperationException("Backward pass must be called before updating parameters.");
 
         var scaledWeightGrad = Engine.TensorMultiplyScalar(_weightsGradient, learningRate);
-        _weights = Engine.TensorSubtract(_weights, scaledWeightGrad);
+        Engine.TensorSubtractInPlace(_weights, scaledWeightGrad);
 
         var scaledBiasGrad = Engine.TensorMultiplyScalar(_biasesGradient, learningRate);
-        _biases = Engine.TensorSubtract(_biases, scaledBiasGrad);
+        Engine.TensorSubtractInPlace(_biases, scaledBiasGrad);
     }
 
     /// <summary>

--- a/src/NeuralNetworks/Layers/MeshPoolLayer.cs
+++ b/src/NeuralNetworks/Layers/MeshPoolLayer.cs
@@ -592,7 +592,7 @@ public partial class MeshPoolLayer<T> : LayerBase<T>, IShapeContract
             throw new InvalidOperationException("Backward pass must be called before updating parameters.");
 
         var scaledGrad = Engine.TensorMultiplyScalar(_importanceWeightsGradient, learningRate);
-        _importanceWeights = Engine.TensorSubtract(_importanceWeights, scaledGrad);
+        Engine.TensorSubtractInPlace(_importanceWeights, scaledGrad);
     }
 
     /// <summary>

--- a/src/NeuralNetworks/Layers/MessagePassingLayer.cs
+++ b/src/NeuralNetworks/Layers/MessagePassingLayer.cs
@@ -806,35 +806,35 @@ public partial class MessagePassingLayer<T> : LayerBase<T>, IGraphConvolutionLay
 
         // Update all weights using Engine operations
         var scaledGrad = Engine.TensorMultiplyScalar(_messageWeights1Gradient, learningRate);
-        _messageWeights1 = Engine.TensorSubtract(_messageWeights1, scaledGrad);
+        Engine.TensorSubtractInPlace(_messageWeights1, scaledGrad);
 
         scaledGrad = Engine.TensorMultiplyScalar(_messageWeights2Gradient, learningRate);
-        _messageWeights2 = Engine.TensorSubtract(_messageWeights2, scaledGrad);
+        Engine.TensorSubtractInPlace(_messageWeights2, scaledGrad);
 
         scaledGrad = Engine.TensorMultiplyScalar(_updateWeightsGradient, learningRate);
-        _updateWeights = Engine.TensorSubtract(_updateWeights, scaledGrad);
+        Engine.TensorSubtractInPlace(_updateWeights, scaledGrad);
 
         scaledGrad = Engine.TensorMultiplyScalar(_updateMessageWeightsGradient, learningRate);
-        _updateMessageWeights = Engine.TensorSubtract(_updateMessageWeights, scaledGrad);
+        Engine.TensorSubtractInPlace(_updateMessageWeights, scaledGrad);
 
         scaledGrad = Engine.TensorMultiplyScalar(_resetWeightsGradient, learningRate);
-        _resetWeights = Engine.TensorSubtract(_resetWeights, scaledGrad);
+        Engine.TensorSubtractInPlace(_resetWeights, scaledGrad);
 
         scaledGrad = Engine.TensorMultiplyScalar(_resetMessageWeightsGradient, learningRate);
-        _resetMessageWeights = Engine.TensorSubtract(_resetMessageWeights, scaledGrad);
+        Engine.TensorSubtractInPlace(_resetMessageWeights, scaledGrad);
 
         // Update biases
         scaledGrad = Engine.TensorMultiplyScalar(_messageBias1Gradient, learningRate);
-        _messageBias1 = Engine.TensorSubtract(_messageBias1, scaledGrad);
+        Engine.TensorSubtractInPlace(_messageBias1, scaledGrad);
 
         scaledGrad = Engine.TensorMultiplyScalar(_messageBias2Gradient, learningRate);
-        _messageBias2 = Engine.TensorSubtract(_messageBias2, scaledGrad);
+        Engine.TensorSubtractInPlace(_messageBias2, scaledGrad);
 
         scaledGrad = Engine.TensorMultiplyScalar(_updateBiasGradient, learningRate);
-        _updateBias = Engine.TensorSubtract(_updateBias, scaledGrad);
+        Engine.TensorSubtractInPlace(_updateBias, scaledGrad);
 
         scaledGrad = Engine.TensorMultiplyScalar(_resetBiasGradient, learningRate);
-        _resetBias = Engine.TensorSubtract(_resetBias, scaledGrad);
+        Engine.TensorSubtractInPlace(_resetBias, scaledGrad);
     }
 
     /// <summary>

--- a/src/NeuralNetworks/Layers/ObliviousDecisionTreeLayer.cs
+++ b/src/NeuralNetworks/Layers/ObliviousDecisionTreeLayer.cs
@@ -451,11 +451,11 @@ public partial class ObliviousDecisionTreeLayer<T> : LayerBase<T>, IShapeContrac
     /// <inheritdoc/>
     public override void UpdateParameters(T learningRate)
     {
-        _featureSelectionWeights = Engine.TensorSubtract(_featureSelectionWeights,
+        Engine.TensorSubtractInPlace(_featureSelectionWeights,
             Engine.TensorMultiplyScalar(_featureSelectionGrad, learningRate));
-        _thresholds = Engine.TensorSubtract(_thresholds,
+        Engine.TensorSubtractInPlace(_thresholds,
             Engine.TensorMultiplyScalar(_thresholdsGrad, learningRate));
-        _leafValues = Engine.TensorSubtract(_leafValues,
+        Engine.TensorSubtractInPlace(_leafValues,
             Engine.TensorMultiplyScalar(_leafValuesGrad, learningRate));
 
         // Register trainable parameters for tape-based autodiff

--- a/src/NeuralNetworks/Layers/PatchEmbeddingLayer.cs
+++ b/src/NeuralNetworks/Layers/PatchEmbeddingLayer.cs
@@ -694,8 +694,8 @@ public partial class PatchEmbeddingLayer<T> : LayerBase<T>, IShapeContract
             throw new InvalidOperationException("Backward pass must be called before updating parameters.");
         }
 
-        _projectionWeights = Engine.TensorSubtract(_projectionWeights, Engine.TensorMultiplyScalar(_projectionWeightsGradient, learningRate));
-        _projectionBias = Engine.TensorSubtract(_projectionBias, Engine.TensorMultiplyScalar(_projectionBiasGradient, learningRate));
+        Engine.TensorSubtractInPlace(_projectionWeights, Engine.TensorMultiplyScalar(_projectionWeightsGradient, learningRate));
+        Engine.TensorSubtractInPlace(_projectionBias, Engine.TensorMultiplyScalar(_projectionBiasGradient, learningRate));
 
         // Invalidate GPU cache after parameter updates
         Engine.InvalidatePersistentTensor(_projectionWeights);

--- a/src/NeuralNetworks/Layers/PiecewiseLinearEncodingLayer.cs
+++ b/src/NeuralNetworks/Layers/PiecewiseLinearEncodingLayer.cs
@@ -196,7 +196,7 @@ public partial class PiecewiseLinearEncodingLayer<T> : LayerBase<T>, IShapeContr
     /// <inheritdoc/>
     public override void UpdateParameters(T learningRate)
     {
-        _binBoundaries = Engine.TensorSubtract(_binBoundaries,
+        Engine.TensorSubtractInPlace(_binBoundaries,
             Engine.TensorMultiplyScalar(_binBoundaryGradients, learningRate));
     }
 

--- a/src/NeuralNetworks/Layers/PrimaryCapsuleLayer.cs
+++ b/src/NeuralNetworks/Layers/PrimaryCapsuleLayer.cs
@@ -907,10 +907,10 @@ public partial class PrimaryCapsuleLayer<T> : LayerBase<T>, IShapeContract
 
         // Use Engine operations for GPU/CPU acceleration
         var scaledWeightGrad = Engine.TensorMultiplyScalar(_convWeightsGradient, learningRate);
-        _convWeights = Engine.TensorSubtract(_convWeights, scaledWeightGrad);
+        Engine.TensorSubtractInPlace(_convWeights, scaledWeightGrad);
 
         var scaledBiasGrad = Engine.TensorMultiplyScalar(_convBiasGradient, learningRate);
-        _convBias = Engine.TensorSubtract(_convBias, scaledBiasGrad);
+        Engine.TensorSubtractInPlace(_convBias, scaledBiasGrad);
     }
 
     /// <summary>

--- a/src/NeuralNetworks/Layers/PrincipalNeighbourhoodAggregationLayer.cs
+++ b/src/NeuralNetworks/Layers/PrincipalNeighbourhoodAggregationLayer.cs
@@ -1193,21 +1193,21 @@ public partial class PrincipalNeighbourhoodAggregationLayer<T> : LayerBase<T>, I
         }
 
         // Update using vectorized Engine operations
-        _preTransformWeights = Engine.TensorSubtract(_preTransformWeights,
+        Engine.TensorSubtractInPlace(_preTransformWeights,
             Engine.TensorMultiplyScalar(_preTransformWeightsGradient, learningRate));
-        _preTransformBias = Engine.TensorSubtract(_preTransformBias,
+        Engine.TensorSubtractInPlace(_preTransformBias,
             Engine.TensorMultiplyScalar(_preTransformBiasGradient!, learningRate));
-        _postAggregationWeights1 = Engine.TensorSubtract(_postAggregationWeights1,
+        Engine.TensorSubtractInPlace(_postAggregationWeights1,
             Engine.TensorMultiplyScalar(_postAggregationWeights1Gradient, learningRate));
-        _postAggregationWeights2 = Engine.TensorSubtract(_postAggregationWeights2,
+        Engine.TensorSubtractInPlace(_postAggregationWeights2,
             Engine.TensorMultiplyScalar(_postAggregationWeights2Gradient, learningRate));
-        _postAggregationBias1 = Engine.TensorSubtract(_postAggregationBias1,
+        Engine.TensorSubtractInPlace(_postAggregationBias1,
             Engine.TensorMultiplyScalar(_postAggregationBias1Gradient!, learningRate));
-        _postAggregationBias2 = Engine.TensorSubtract(_postAggregationBias2,
+        Engine.TensorSubtractInPlace(_postAggregationBias2,
             Engine.TensorMultiplyScalar(_postAggregationBias2Gradient!, learningRate));
-        _selfWeights = Engine.TensorSubtract(_selfWeights,
+        Engine.TensorSubtractInPlace(_selfWeights,
             Engine.TensorMultiplyScalar(_selfWeightsGradient, learningRate));
-        _bias = Engine.TensorSubtract(_bias,
+        Engine.TensorSubtractInPlace(_bias,
             Engine.TensorMultiplyScalar(_biasGradient, learningRate));
     }
 

--- a/src/NeuralNetworks/Layers/QuantumLayer.cs
+++ b/src/NeuralNetworks/Layers/QuantumLayer.cs
@@ -552,7 +552,7 @@ public partial class QuantumLayer<T> : LayerBase<T>, IShapeContract
     {
         // Use Engine operations for gradient update
         var scaledGradients = Engine.TensorMultiplyScalar(_angleGradients, learningRate);
-        _rotationAngles = Engine.TensorSubtract(_rotationAngles, scaledGradients);
+        Engine.TensorSubtractInPlace(_rotationAngles, scaledGradients);
 
         // Ensure angles stay within [0, 2π] and apply rotations
         for (int i = 0; i < _numQubits; i++)

--- a/src/NeuralNetworks/Layers/QuantumLayer.cs
+++ b/src/NeuralNetworks/Layers/QuantumLayer.cs
@@ -554,6 +554,11 @@ public partial class QuantumLayer<T> : LayerBase<T>, IShapeContract
         var scaledGradients = Engine.TensorMultiplyScalar(_angleGradients, learningRate);
         Engine.TensorSubtractInPlace(_rotationAngles, scaledGradients);
 
+        // Reconstruct from identity. Applying the complete new angle set to the already-rotated
+        // circuit would compound every previous angle, so even a zero-learning-rate update would
+        // change the layer's behavior.
+        ResetQuantumCircuit();
+
         // Ensure angles stay within [0, 2π] and apply rotations
         for (int i = 0; i < _numQubits; i++)
         {
@@ -564,6 +569,9 @@ public partial class QuantumLayer<T> : LayerBase<T>, IShapeContract
             // Apply updated rotation
             ApplyRotation(i, _rotationAngles[i]);
         }
+
+        SynchronizeCircuitTensors();
+        Engine.InvalidatePersistentTensor(_rotationAngles);
 
         // Reset angle gradients for the next iteration
         _angleGradients = new Tensor<T>([_numQubits]);
@@ -657,7 +665,13 @@ public partial class QuantumLayer<T> : LayerBase<T>, IShapeContract
             ApplyRotation(i, _rotationAngles[i]);
         }
 
-        // Update circuit tensors to match the rotated _quantumCircuit
+        SynchronizeCircuitTensors();
+    }
+
+    /// <summary>Keeps the real-valued CPU/GPU parameter views aligned with the complex circuit.</summary>
+    private void SynchronizeCircuitTensors()
+    {
+        int dimension = 1 << _numQubits;
         for (int i = 0; i < dimension; i++)
         {
             for (int j = 0; j < dimension; j++)
@@ -666,6 +680,9 @@ public partial class QuantumLayer<T> : LayerBase<T>, IShapeContract
                 _circuitImag[i, j] = _quantumCircuit[i, j].Imaginary;
             }
         }
+
+        Engine.InvalidatePersistentTensor(_circuitReal);
+        Engine.InvalidatePersistentTensor(_circuitImag);
     }
 
     /// <summary>

--- a/src/NeuralNetworks/Layers/RBFLayer.cs
+++ b/src/NeuralNetworks/Layers/RBFLayer.cs
@@ -467,10 +467,10 @@ public partial class RBFLayer<T> : LayerBase<T>, IShapeContract
 
         // Use Engine.TensorSubtract and TensorMultiplyScalar for GPU/CPU acceleration
         var scaledCentersGradient = Engine.TensorMultiplyScalar(_centersGradient, learningRate);
-        _centers = Engine.TensorSubtract(_centers, scaledCentersGradient);
+        Engine.TensorSubtractInPlace(_centers, scaledCentersGradient);
 
         var scaledWidthsGradient = Engine.TensorMultiplyScalar(_widthsGradient, learningRate);
-        _widths = Engine.TensorSubtract(_widths, scaledWidthsGradient);
+        Engine.TensorSubtractInPlace(_widths, scaledWidthsGradient);
     }
 
     /// <inheritdoc/>

--- a/src/NeuralNetworks/Layers/RBFLayer.cs
+++ b/src/NeuralNetworks/Layers/RBFLayer.cs
@@ -468,9 +468,11 @@ public partial class RBFLayer<T> : LayerBase<T>, IShapeContract
         // Use Engine.TensorSubtract and TensorMultiplyScalar for GPU/CPU acceleration
         var scaledCentersGradient = Engine.TensorMultiplyScalar(_centersGradient, learningRate);
         Engine.TensorSubtractInPlace(_centers, scaledCentersGradient);
+        Engine.InvalidatePersistentTensor(_centers);
 
         var scaledWidthsGradient = Engine.TensorMultiplyScalar(_widthsGradient, learningRate);
         Engine.TensorSubtractInPlace(_widths, scaledWidthsGradient);
+        Engine.InvalidatePersistentTensor(_widths);
     }
 
     /// <inheritdoc/>

--- a/src/NeuralNetworks/Layers/ReadoutLayer.cs
+++ b/src/NeuralNetworks/Layers/ReadoutLayer.cs
@@ -498,11 +498,11 @@ public partial class ReadoutLayer<T> : LayerBase<T>, IShapeContract
     {
         // Update weights using Engine operations: w = w - lr * gradient
         var scaledWeightGradients = Engine.TensorMultiplyScalar(_weightGradients, learningRate);
-        _weights = Engine.TensorSubtract(_weights, scaledWeightGradients);
+        Engine.TensorSubtractInPlace(_weights, scaledWeightGradients);
 
         // Update biases using Engine operations: b = b - lr * gradient
         var scaledBiasGradients = Engine.TensorMultiplyScalar(_biasGradients, learningRate);
-        _bias = Engine.TensorSubtract(_bias, scaledBiasGradients);
+        Engine.TensorSubtractInPlace(_bias, scaledBiasGradients);
     }
 
     /// <summary>

--- a/src/NeuralNetworks/Layers/ReadoutLayer.cs
+++ b/src/NeuralNetworks/Layers/ReadoutLayer.cs
@@ -499,10 +499,12 @@ public partial class ReadoutLayer<T> : LayerBase<T>, IShapeContract
         // Update weights using Engine operations: w = w - lr * gradient
         var scaledWeightGradients = Engine.TensorMultiplyScalar(_weightGradients, learningRate);
         Engine.TensorSubtractInPlace(_weights, scaledWeightGradients);
+        Engine.InvalidatePersistentTensor(_weights);
 
         // Update biases using Engine operations: b = b - lr * gradient
         var scaledBiasGradients = Engine.TensorMultiplyScalar(_biasGradients, learningRate);
         Engine.TensorSubtractInPlace(_bias, scaledBiasGradients);
+        Engine.InvalidatePersistentTensor(_bias);
     }
 
     /// <summary>

--- a/src/NeuralNetworks/Layers/RecurrentLayer.cs
+++ b/src/NeuralNetworks/Layers/RecurrentLayer.cs
@@ -816,9 +816,9 @@ public partial class RecurrentLayer<T> : LayerBase<T>, IShapeContract
             var scaledHiddenGrad = Engine.TensorMultiplyScalar(_hiddenWeightsGradient, learningRate);
             var scaledBiasGrad = Engine.TensorMultiplyScalar(_biasesGradient, learningRate);
 
-            _inputWeights = Engine.TensorSubtract(_inputWeights, scaledInputGrad);
-            _hiddenWeights = Engine.TensorSubtract(_hiddenWeights, scaledHiddenGrad);
-            _biases = Engine.TensorSubtract(_biases, scaledBiasGrad);
+            Engine.TensorSubtractInPlace(_inputWeights, scaledInputGrad);
+            Engine.TensorSubtractInPlace(_hiddenWeights, scaledHiddenGrad);
+            Engine.TensorSubtractInPlace(_biases, scaledBiasGrad);
 
             Engine.InvalidatePersistentTensor(_inputWeights);
             Engine.InvalidatePersistentTensor(_hiddenWeights);

--- a/src/NeuralNetworks/Layers/SSM/ABCLayer.cs
+++ b/src/NeuralNetworks/Layers/SSM/ABCLayer.cs
@@ -426,16 +426,16 @@ public partial class ABCLayer<T> : LayerBase<T>, IShapeContract
             throw new InvalidOperationException("Backward pass must be called before updating parameters.");
 
         T negLR = NumOps.Negate(learningRate);
-        _queryWeights = Engine.TensorAdd(_queryWeights, Engine.TensorMultiplyScalar(_queryWeightsGradient, negLR));
-        _keyWeights = Engine.TensorAdd(_keyWeights, Engine.TensorMultiplyScalar(_keyWeightsGradient, negLR));
-        _valueWeights = Engine.TensorAdd(_valueWeights, Engine.TensorMultiplyScalar(_valueWeightsGradient, negLR));
-        _slotKeys = Engine.TensorAdd(_slotKeys, Engine.TensorMultiplyScalar(_slotKeysGradient, negLR));
-        _forgetGateWeights = Engine.TensorAdd(_forgetGateWeights, Engine.TensorMultiplyScalar(_forgetGateWeightsGradient, negLR));
-        _forgetGateBias = Engine.TensorAdd(_forgetGateBias, Engine.TensorMultiplyScalar(_forgetGateBiasGradient, negLR));
-        _outputGateWeights = Engine.TensorAdd(_outputGateWeights, Engine.TensorMultiplyScalar(_outputGateWeightsGradient, negLR));
-        _outputGateBias = Engine.TensorAdd(_outputGateBias, Engine.TensorMultiplyScalar(_outputGateBiasGradient, negLR));
-        _outputProjectionWeights = Engine.TensorAdd(_outputProjectionWeights, Engine.TensorMultiplyScalar(_outputProjectionWeightsGradient, negLR));
-        _outputProjectionBias = Engine.TensorAdd(_outputProjectionBias, Engine.TensorMultiplyScalar(_outputProjectionBiasGradient, negLR));
+        Engine.TensorAddInPlace(_queryWeights, Engine.TensorMultiplyScalar(_queryWeightsGradient, negLR));
+        Engine.TensorAddInPlace(_keyWeights, Engine.TensorMultiplyScalar(_keyWeightsGradient, negLR));
+        Engine.TensorAddInPlace(_valueWeights, Engine.TensorMultiplyScalar(_valueWeightsGradient, negLR));
+        Engine.TensorAddInPlace(_slotKeys, Engine.TensorMultiplyScalar(_slotKeysGradient, negLR));
+        Engine.TensorAddInPlace(_forgetGateWeights, Engine.TensorMultiplyScalar(_forgetGateWeightsGradient, negLR));
+        Engine.TensorAddInPlace(_forgetGateBias, Engine.TensorMultiplyScalar(_forgetGateBiasGradient, negLR));
+        Engine.TensorAddInPlace(_outputGateWeights, Engine.TensorMultiplyScalar(_outputGateWeightsGradient, negLR));
+        Engine.TensorAddInPlace(_outputGateBias, Engine.TensorMultiplyScalar(_outputGateBiasGradient, negLR));
+        Engine.TensorAddInPlace(_outputProjectionWeights, Engine.TensorMultiplyScalar(_outputProjectionWeightsGradient, negLR));
+        Engine.TensorAddInPlace(_outputProjectionBias, Engine.TensorMultiplyScalar(_outputProjectionBiasGradient, negLR));
 
         // Register trainable parameters for tape-based autodiff
         RegisterTrainableParameter(_queryWeights, PersistentTensorRole.Weights);

--- a/src/NeuralNetworks/Layers/SSM/BASEDLayer.cs
+++ b/src/NeuralNetworks/Layers/SSM/BASEDLayer.cs
@@ -757,17 +757,17 @@ public partial class BASEDLayer<T> : LayerBase<T>, IShapeContract
             throw new InvalidOperationException("Backward pass must be called before updating parameters.");
 
         T negLR = NumOps.Negate(learningRate);
-        _linearQueryWeights = Engine.TensorAdd(_linearQueryWeights, Engine.TensorMultiplyScalar(_linearQueryWeightsGradient, negLR));
-        _linearKeyWeights = Engine.TensorAdd(_linearKeyWeights, Engine.TensorMultiplyScalar(_linearKeyWeightsGradient, negLR));
-        _linearValueWeights = Engine.TensorAdd(_linearValueWeights, Engine.TensorMultiplyScalar(_linearValueWeightsGradient, negLR));
-        _windowQueryWeights = Engine.TensorAdd(_windowQueryWeights, Engine.TensorMultiplyScalar(_windowQueryWeightsGradient, negLR));
-        _windowKeyWeights = Engine.TensorAdd(_windowKeyWeights, Engine.TensorMultiplyScalar(_windowKeyWeightsGradient, negLR));
-        _windowValueWeights = Engine.TensorAdd(_windowValueWeights, Engine.TensorMultiplyScalar(_windowValueWeightsGradient, negLR));
-        _featureMapScale = Engine.TensorAdd(_featureMapScale, Engine.TensorMultiplyScalar(_featureMapScaleGradient, negLR));
-        _mixingGateWeights = Engine.TensorAdd(_mixingGateWeights, Engine.TensorMultiplyScalar(_mixingGateWeightsGradient, negLR));
-        _mixingGateBias = Engine.TensorAdd(_mixingGateBias, Engine.TensorMultiplyScalar(_mixingGateBiasGradient, negLR));
-        _outputProjectionWeights = Engine.TensorAdd(_outputProjectionWeights, Engine.TensorMultiplyScalar(_outputProjectionWeightsGradient, negLR));
-        _outputProjectionBias = Engine.TensorAdd(_outputProjectionBias, Engine.TensorMultiplyScalar(_outputProjectionBiasGradient, negLR));
+        Engine.TensorAddInPlace(_linearQueryWeights, Engine.TensorMultiplyScalar(_linearQueryWeightsGradient, negLR));
+        Engine.TensorAddInPlace(_linearKeyWeights, Engine.TensorMultiplyScalar(_linearKeyWeightsGradient, negLR));
+        Engine.TensorAddInPlace(_linearValueWeights, Engine.TensorMultiplyScalar(_linearValueWeightsGradient, negLR));
+        Engine.TensorAddInPlace(_windowQueryWeights, Engine.TensorMultiplyScalar(_windowQueryWeightsGradient, negLR));
+        Engine.TensorAddInPlace(_windowKeyWeights, Engine.TensorMultiplyScalar(_windowKeyWeightsGradient, negLR));
+        Engine.TensorAddInPlace(_windowValueWeights, Engine.TensorMultiplyScalar(_windowValueWeightsGradient, negLR));
+        Engine.TensorAddInPlace(_featureMapScale, Engine.TensorMultiplyScalar(_featureMapScaleGradient, negLR));
+        Engine.TensorAddInPlace(_mixingGateWeights, Engine.TensorMultiplyScalar(_mixingGateWeightsGradient, negLR));
+        Engine.TensorAddInPlace(_mixingGateBias, Engine.TensorMultiplyScalar(_mixingGateBiasGradient, negLR));
+        Engine.TensorAddInPlace(_outputProjectionWeights, Engine.TensorMultiplyScalar(_outputProjectionWeightsGradient, negLR));
+        Engine.TensorAddInPlace(_outputProjectionBias, Engine.TensorMultiplyScalar(_outputProjectionBiasGradient, negLR));
 
         // Register trainable parameters for tape-based autodiff
         RegisterTrainableParameter(_linearQueryWeights, PersistentTensorRole.Weights);

--- a/src/NeuralNetworks/Layers/SSM/DeltaFormerLayer.cs
+++ b/src/NeuralNetworks/Layers/SSM/DeltaFormerLayer.cs
@@ -397,13 +397,13 @@ public partial class DeltaFormerLayer<T> : LayerBase<T>, IShapeContract
             throw new InvalidOperationException("Backward pass must be called before updating parameters.");
 
         T negLR = NumOps.Negate(learningRate);
-        _queryWeights = Engine.TensorAdd(_queryWeights, Engine.TensorMultiplyScalar(_queryWeightsGradient, negLR));
-        _keyWeights = Engine.TensorAdd(_keyWeights, Engine.TensorMultiplyScalar(_keyWeightsGradient, negLR));
-        _valueWeights = Engine.TensorAdd(_valueWeights, Engine.TensorMultiplyScalar(_valueWeightsGradient, negLR));
-        _outputGateWeights = Engine.TensorAdd(_outputGateWeights, Engine.TensorMultiplyScalar(_outputGateWeightsGradient, negLR));
-        _outputGateBias = Engine.TensorAdd(_outputGateBias, Engine.TensorMultiplyScalar(_outputGateBiasGradient, negLR));
-        _outputProjectionWeights = Engine.TensorAdd(_outputProjectionWeights, Engine.TensorMultiplyScalar(_outputProjectionWeightsGradient, negLR));
-        _outputProjectionBias = Engine.TensorAdd(_outputProjectionBias, Engine.TensorMultiplyScalar(_outputProjectionBiasGradient, negLR));
+        Engine.TensorAddInPlace(_queryWeights, Engine.TensorMultiplyScalar(_queryWeightsGradient, negLR));
+        Engine.TensorAddInPlace(_keyWeights, Engine.TensorMultiplyScalar(_keyWeightsGradient, negLR));
+        Engine.TensorAddInPlace(_valueWeights, Engine.TensorMultiplyScalar(_valueWeightsGradient, negLR));
+        Engine.TensorAddInPlace(_outputGateWeights, Engine.TensorMultiplyScalar(_outputGateWeightsGradient, negLR));
+        Engine.TensorAddInPlace(_outputGateBias, Engine.TensorMultiplyScalar(_outputGateBiasGradient, negLR));
+        Engine.TensorAddInPlace(_outputProjectionWeights, Engine.TensorMultiplyScalar(_outputProjectionWeightsGradient, negLR));
+        Engine.TensorAddInPlace(_outputProjectionBias, Engine.TensorMultiplyScalar(_outputProjectionBiasGradient, negLR));
 
         // Register trainable parameters for tape-based autodiff
         RegisterTrainableParameter(_queryWeights, PersistentTensorRole.Weights);

--- a/src/NeuralNetworks/Layers/SSM/DeltaNetLayer.cs
+++ b/src/NeuralNetworks/Layers/SSM/DeltaNetLayer.cs
@@ -434,16 +434,16 @@ public partial class DeltaNetLayer<T> : LayerBase<T>, IShapeContract
             throw new InvalidOperationException("Backward pass must be called before updating parameters.");
 
         T negLR = NumOps.Negate(learningRate);
-        _queryWeights = Engine.TensorAdd(_queryWeights, Engine.TensorMultiplyScalar(_queryWeightsGradient, negLR));
-        _queryBias = Engine.TensorAdd(_queryBias, Engine.TensorMultiplyScalar(_queryBiasGradient!, negLR));
-        _keyWeights = Engine.TensorAdd(_keyWeights, Engine.TensorMultiplyScalar(_keyWeightsGradient!, negLR));
-        _keyBias = Engine.TensorAdd(_keyBias, Engine.TensorMultiplyScalar(_keyBiasGradient!, negLR));
-        _valueWeights = Engine.TensorAdd(_valueWeights, Engine.TensorMultiplyScalar(_valueWeightsGradient!, negLR));
-        _valueBias = Engine.TensorAdd(_valueBias, Engine.TensorMultiplyScalar(_valueBiasGradient!, negLR));
-        _betaWeights = Engine.TensorAdd(_betaWeights, Engine.TensorMultiplyScalar(_betaWeightsGradient!, negLR));
-        _betaBias = Engine.TensorAdd(_betaBias, Engine.TensorMultiplyScalar(_betaBiasGradient!, negLR));
-        _outputProjectionWeights = Engine.TensorAdd(_outputProjectionWeights, Engine.TensorMultiplyScalar(_outputProjectionWeightsGradient!, negLR));
-        _outputProjectionBias = Engine.TensorAdd(_outputProjectionBias, Engine.TensorMultiplyScalar(_outputProjectionBiasGradient!, negLR));
+        Engine.TensorAddInPlace(_queryWeights, Engine.TensorMultiplyScalar(_queryWeightsGradient, negLR));
+        Engine.TensorAddInPlace(_queryBias, Engine.TensorMultiplyScalar(_queryBiasGradient!, negLR));
+        Engine.TensorAddInPlace(_keyWeights, Engine.TensorMultiplyScalar(_keyWeightsGradient!, negLR));
+        Engine.TensorAddInPlace(_keyBias, Engine.TensorMultiplyScalar(_keyBiasGradient!, negLR));
+        Engine.TensorAddInPlace(_valueWeights, Engine.TensorMultiplyScalar(_valueWeightsGradient!, negLR));
+        Engine.TensorAddInPlace(_valueBias, Engine.TensorMultiplyScalar(_valueBiasGradient!, negLR));
+        Engine.TensorAddInPlace(_betaWeights, Engine.TensorMultiplyScalar(_betaWeightsGradient!, negLR));
+        Engine.TensorAddInPlace(_betaBias, Engine.TensorMultiplyScalar(_betaBiasGradient!, negLR));
+        Engine.TensorAddInPlace(_outputProjectionWeights, Engine.TensorMultiplyScalar(_outputProjectionWeightsGradient!, negLR));
+        Engine.TensorAddInPlace(_outputProjectionBias, Engine.TensorMultiplyScalar(_outputProjectionBiasGradient!, negLR));
 
         // Register trainable parameters for tape-based autodiff
         RegisterTrainableParameter(_queryWeights, PersistentTensorRole.Weights);

--- a/src/NeuralNetworks/Layers/SSM/DeltaProductLayer.cs
+++ b/src/NeuralNetworks/Layers/SSM/DeltaProductLayer.cs
@@ -565,14 +565,14 @@ public partial class DeltaProductLayer<T> : LayerBase<T>, IShapeContract
         var outputProjectionBiasGrad = _outputProjectionBiasGradient ?? throw new InvalidOperationException("Backward pass must be called before updating parameters.");
 
         T negLR = NumOps.Negate(learningRate);
-        _queryWeights = Engine.TensorAdd(_queryWeights, Engine.TensorMultiplyScalar(queryWeightsGrad, negLR));
-        _keyWeights = Engine.TensorAdd(_keyWeights, Engine.TensorMultiplyScalar(keyWeightsGrad, negLR));
-        _valueWeights = Engine.TensorAdd(_valueWeights, Engine.TensorMultiplyScalar(valueWeightsGrad, negLR));
-        _betaWeights = Engine.TensorAdd(_betaWeights, Engine.TensorMultiplyScalar(betaWeightsGrad, negLR));
-        _betaBias = Engine.TensorAdd(_betaBias, Engine.TensorMultiplyScalar(betaBiasGrad, negLR));
-        _householderWeights = Engine.TensorAdd(_householderWeights, Engine.TensorMultiplyScalar(householderWeightsGrad, negLR));
-        _outputProjectionWeights = Engine.TensorAdd(_outputProjectionWeights, Engine.TensorMultiplyScalar(outputProjectionWeightsGrad, negLR));
-        _outputProjectionBias = Engine.TensorAdd(_outputProjectionBias, Engine.TensorMultiplyScalar(outputProjectionBiasGrad, negLR));
+        Engine.TensorAddInPlace(_queryWeights, Engine.TensorMultiplyScalar(queryWeightsGrad, negLR));
+        Engine.TensorAddInPlace(_keyWeights, Engine.TensorMultiplyScalar(keyWeightsGrad, negLR));
+        Engine.TensorAddInPlace(_valueWeights, Engine.TensorMultiplyScalar(valueWeightsGrad, negLR));
+        Engine.TensorAddInPlace(_betaWeights, Engine.TensorMultiplyScalar(betaWeightsGrad, negLR));
+        Engine.TensorAddInPlace(_betaBias, Engine.TensorMultiplyScalar(betaBiasGrad, negLR));
+        Engine.TensorAddInPlace(_householderWeights, Engine.TensorMultiplyScalar(householderWeightsGrad, negLR));
+        Engine.TensorAddInPlace(_outputProjectionWeights, Engine.TensorMultiplyScalar(outputProjectionWeightsGrad, negLR));
+        Engine.TensorAddInPlace(_outputProjectionBias, Engine.TensorMultiplyScalar(outputProjectionBiasGrad, negLR));
 
         // Register trainable parameters for tape-based autodiff
         RegisterTrainableParameter(_queryWeights, PersistentTensorRole.Weights);

--- a/src/NeuralNetworks/Layers/SSM/ExtendedLSTMLayer.cs
+++ b/src/NeuralNetworks/Layers/SSM/ExtendedLSTMLayer.cs
@@ -482,17 +482,17 @@ public partial class ExtendedLSTMLayer<T> : LayerBase<T>, IShapeContract
             throw new InvalidOperationException("Backward pass must be called before updating parameters.");
 
         T negLR = NumOps.Negate(learningRate);
-        _inputGateWeights = Engine.TensorAdd(_inputGateWeights, Engine.TensorMultiplyScalar(_inputGateWeightsGradient, negLR));
-        _inputGateBias = Engine.TensorAdd(_inputGateBias, Engine.TensorMultiplyScalar(_inputGateBiasGradient!, negLR));
-        _forgetGateWeights = Engine.TensorAdd(_forgetGateWeights, Engine.TensorMultiplyScalar(_forgetGateWeightsGradient!, negLR));
-        _forgetGateBias = Engine.TensorAdd(_forgetGateBias, Engine.TensorMultiplyScalar(_forgetGateBiasGradient!, negLR));
-        _outputGateWeights = Engine.TensorAdd(_outputGateWeights, Engine.TensorMultiplyScalar(_outputGateWeightsGradient!, negLR));
-        _outputGateBias = Engine.TensorAdd(_outputGateBias, Engine.TensorMultiplyScalar(_outputGateBiasGradient!, negLR));
-        _queryWeights = Engine.TensorAdd(_queryWeights, Engine.TensorMultiplyScalar(_queryWeightsGradient!, negLR));
-        _keyWeights = Engine.TensorAdd(_keyWeights, Engine.TensorMultiplyScalar(_keyWeightsGradient!, negLR));
-        _valueWeights = Engine.TensorAdd(_valueWeights, Engine.TensorMultiplyScalar(_valueWeightsGradient!, negLR));
-        _outputProjectionWeights = Engine.TensorAdd(_outputProjectionWeights, Engine.TensorMultiplyScalar(_outputProjectionWeightsGradient!, negLR));
-        _outputProjectionBias = Engine.TensorAdd(_outputProjectionBias, Engine.TensorMultiplyScalar(_outputProjectionBiasGradient!, negLR));
+        Engine.TensorAddInPlace(_inputGateWeights, Engine.TensorMultiplyScalar(_inputGateWeightsGradient, negLR));
+        Engine.TensorAddInPlace(_inputGateBias, Engine.TensorMultiplyScalar(_inputGateBiasGradient!, negLR));
+        Engine.TensorAddInPlace(_forgetGateWeights, Engine.TensorMultiplyScalar(_forgetGateWeightsGradient!, negLR));
+        Engine.TensorAddInPlace(_forgetGateBias, Engine.TensorMultiplyScalar(_forgetGateBiasGradient!, negLR));
+        Engine.TensorAddInPlace(_outputGateWeights, Engine.TensorMultiplyScalar(_outputGateWeightsGradient!, negLR));
+        Engine.TensorAddInPlace(_outputGateBias, Engine.TensorMultiplyScalar(_outputGateBiasGradient!, negLR));
+        Engine.TensorAddInPlace(_queryWeights, Engine.TensorMultiplyScalar(_queryWeightsGradient!, negLR));
+        Engine.TensorAddInPlace(_keyWeights, Engine.TensorMultiplyScalar(_keyWeightsGradient!, negLR));
+        Engine.TensorAddInPlace(_valueWeights, Engine.TensorMultiplyScalar(_valueWeightsGradient!, negLR));
+        Engine.TensorAddInPlace(_outputProjectionWeights, Engine.TensorMultiplyScalar(_outputProjectionWeightsGradient!, negLR));
+        Engine.TensorAddInPlace(_outputProjectionBias, Engine.TensorMultiplyScalar(_outputProjectionBiasGradient!, negLR));
 
         // Register trainable parameters for tape-based autodiff
         RegisterTrainableParameter(_inputGateWeights, PersistentTensorRole.Weights);

--- a/src/NeuralNetworks/Layers/SSM/GatedDeltaNetLayer.cs
+++ b/src/NeuralNetworks/Layers/SSM/GatedDeltaNetLayer.cs
@@ -453,19 +453,19 @@ public partial class GatedDeltaNetLayer<T> : LayerBase<T>, IShapeContract
             throw new InvalidOperationException("Backward pass must be called before updating parameters.");
 
         T negLR = NumOps.Negate(learningRate);
-        _convWeights = Engine.TensorAdd(_convWeights, Engine.TensorMultiplyScalar(_convWeightsGradient, negLR));
-        _convBias = Engine.TensorAdd(_convBias, Engine.TensorMultiplyScalar(_convBiasGradient!, negLR));
-        _queryWeights = Engine.TensorAdd(_queryWeights, Engine.TensorMultiplyScalar(_queryWeightsGradient!, negLR));
-        _keyWeights = Engine.TensorAdd(_keyWeights, Engine.TensorMultiplyScalar(_keyWeightsGradient!, negLR));
-        _valueWeights = Engine.TensorAdd(_valueWeights, Engine.TensorMultiplyScalar(_valueWeightsGradient!, negLR));
-        _betaWeights = Engine.TensorAdd(_betaWeights, Engine.TensorMultiplyScalar(_betaWeightsGradient!, negLR));
-        _betaBias = Engine.TensorAdd(_betaBias, Engine.TensorMultiplyScalar(_betaBiasGradient!, negLR));
-        _alphaWeights = Engine.TensorAdd(_alphaWeights, Engine.TensorMultiplyScalar(_alphaWeightsGradient!, negLR));
-        _alphaBias = Engine.TensorAdd(_alphaBias, Engine.TensorMultiplyScalar(_alphaBiasGradient!, negLR));
-        _outputGateWeights = Engine.TensorAdd(_outputGateWeights, Engine.TensorMultiplyScalar(_outputGateWeightsGradient!, negLR));
-        _outputGateBias = Engine.TensorAdd(_outputGateBias, Engine.TensorMultiplyScalar(_outputGateBiasGradient!, negLR));
-        _outputProjectionWeights = Engine.TensorAdd(_outputProjectionWeights, Engine.TensorMultiplyScalar(_outputProjectionWeightsGradient!, negLR));
-        _outputProjectionBias = Engine.TensorAdd(_outputProjectionBias, Engine.TensorMultiplyScalar(_outputProjectionBiasGradient!, negLR));
+        Engine.TensorAddInPlace(_convWeights, Engine.TensorMultiplyScalar(_convWeightsGradient, negLR));
+        Engine.TensorAddInPlace(_convBias, Engine.TensorMultiplyScalar(_convBiasGradient!, negLR));
+        Engine.TensorAddInPlace(_queryWeights, Engine.TensorMultiplyScalar(_queryWeightsGradient!, negLR));
+        Engine.TensorAddInPlace(_keyWeights, Engine.TensorMultiplyScalar(_keyWeightsGradient!, negLR));
+        Engine.TensorAddInPlace(_valueWeights, Engine.TensorMultiplyScalar(_valueWeightsGradient!, negLR));
+        Engine.TensorAddInPlace(_betaWeights, Engine.TensorMultiplyScalar(_betaWeightsGradient!, negLR));
+        Engine.TensorAddInPlace(_betaBias, Engine.TensorMultiplyScalar(_betaBiasGradient!, negLR));
+        Engine.TensorAddInPlace(_alphaWeights, Engine.TensorMultiplyScalar(_alphaWeightsGradient!, negLR));
+        Engine.TensorAddInPlace(_alphaBias, Engine.TensorMultiplyScalar(_alphaBiasGradient!, negLR));
+        Engine.TensorAddInPlace(_outputGateWeights, Engine.TensorMultiplyScalar(_outputGateWeightsGradient!, negLR));
+        Engine.TensorAddInPlace(_outputGateBias, Engine.TensorMultiplyScalar(_outputGateBiasGradient!, negLR));
+        Engine.TensorAddInPlace(_outputProjectionWeights, Engine.TensorMultiplyScalar(_outputProjectionWeightsGradient!, negLR));
+        Engine.TensorAddInPlace(_outputProjectionBias, Engine.TensorMultiplyScalar(_outputProjectionBiasGradient!, negLR));
 
         // Register trainable parameters for tape-based autodiff
         RegisterTrainableParameter(_convWeights, PersistentTensorRole.Weights);

--- a/src/NeuralNetworks/Layers/SSM/GatedDeltaProductLayer.cs
+++ b/src/NeuralNetworks/Layers/SSM/GatedDeltaProductLayer.cs
@@ -605,18 +605,18 @@ public partial class GatedDeltaProductLayer<T> : LayerBase<T>, IShapeContract
         var outputProjectionBiasGrad = _outputProjectionBiasGradient ?? throw new InvalidOperationException("Backward pass must be called before updating parameters.");
 
         T negLR = NumOps.Negate(learningRate);
-        _queryWeights = Engine.TensorAdd(_queryWeights, Engine.TensorMultiplyScalar(queryWeightsGrad, negLR));
-        _keyWeights = Engine.TensorAdd(_keyWeights, Engine.TensorMultiplyScalar(keyWeightsGrad, negLR));
-        _valueWeights = Engine.TensorAdd(_valueWeights, Engine.TensorMultiplyScalar(valueWeightsGrad, negLR));
-        _betaWeights = Engine.TensorAdd(_betaWeights, Engine.TensorMultiplyScalar(betaWeightsGrad, negLR));
-        _betaBias = Engine.TensorAdd(_betaBias, Engine.TensorMultiplyScalar(betaBiasGrad, negLR));
-        _alphaWeights = Engine.TensorAdd(_alphaWeights, Engine.TensorMultiplyScalar(alphaWeightsGrad, negLR));
-        _alphaBias = Engine.TensorAdd(_alphaBias, Engine.TensorMultiplyScalar(alphaBiasGrad, negLR));
-        _householderWeights = Engine.TensorAdd(_householderWeights, Engine.TensorMultiplyScalar(householderWeightsGrad, negLR));
-        _outputGateWeights = Engine.TensorAdd(_outputGateWeights, Engine.TensorMultiplyScalar(outputGateWeightsGrad, negLR));
-        _outputGateBias = Engine.TensorAdd(_outputGateBias, Engine.TensorMultiplyScalar(outputGateBiasGrad, negLR));
-        _outputProjectionWeights = Engine.TensorAdd(_outputProjectionWeights, Engine.TensorMultiplyScalar(outputProjectionWeightsGrad, negLR));
-        _outputProjectionBias = Engine.TensorAdd(_outputProjectionBias, Engine.TensorMultiplyScalar(outputProjectionBiasGrad, negLR));
+        Engine.TensorAddInPlace(_queryWeights, Engine.TensorMultiplyScalar(queryWeightsGrad, negLR));
+        Engine.TensorAddInPlace(_keyWeights, Engine.TensorMultiplyScalar(keyWeightsGrad, negLR));
+        Engine.TensorAddInPlace(_valueWeights, Engine.TensorMultiplyScalar(valueWeightsGrad, negLR));
+        Engine.TensorAddInPlace(_betaWeights, Engine.TensorMultiplyScalar(betaWeightsGrad, negLR));
+        Engine.TensorAddInPlace(_betaBias, Engine.TensorMultiplyScalar(betaBiasGrad, negLR));
+        Engine.TensorAddInPlace(_alphaWeights, Engine.TensorMultiplyScalar(alphaWeightsGrad, negLR));
+        Engine.TensorAddInPlace(_alphaBias, Engine.TensorMultiplyScalar(alphaBiasGrad, negLR));
+        Engine.TensorAddInPlace(_householderWeights, Engine.TensorMultiplyScalar(householderWeightsGrad, negLR));
+        Engine.TensorAddInPlace(_outputGateWeights, Engine.TensorMultiplyScalar(outputGateWeightsGrad, negLR));
+        Engine.TensorAddInPlace(_outputGateBias, Engine.TensorMultiplyScalar(outputGateBiasGrad, negLR));
+        Engine.TensorAddInPlace(_outputProjectionWeights, Engine.TensorMultiplyScalar(outputProjectionWeightsGrad, negLR));
+        Engine.TensorAddInPlace(_outputProjectionBias, Engine.TensorMultiplyScalar(outputProjectionBiasGrad, negLR));
 
         // Register trainable parameters for tape-based autodiff
         RegisterTrainableParameter(_queryWeights, PersistentTensorRole.Weights);

--- a/src/NeuralNetworks/Layers/SSM/GatedLinearAttentionLayer.cs
+++ b/src/NeuralNetworks/Layers/SSM/GatedLinearAttentionLayer.cs
@@ -334,13 +334,13 @@ public partial class GatedLinearAttentionLayer<T> : LayerBase<T>, IShapeContract
         }
 
         T negLR = NumOps.Negate(learningRate);
-        _queryWeights = Engine.TensorAdd(_queryWeights, Engine.TensorMultiplyScalar(_queryWeightsGradient, negLR));
-        _keyWeights = Engine.TensorAdd(_keyWeights, Engine.TensorMultiplyScalar(_keyWeightsGradient, negLR));
-        _valueWeights = Engine.TensorAdd(_valueWeights, Engine.TensorMultiplyScalar(_valueWeightsGradient, negLR));
-        _gateWeights = Engine.TensorAdd(_gateWeights, Engine.TensorMultiplyScalar(_gateWeightsGradient, negLR));
-        _gateBias = Engine.TensorAdd(_gateBias, Engine.TensorMultiplyScalar(_gateBiasGradient, negLR));
-        _outputWeights = Engine.TensorAdd(_outputWeights, Engine.TensorMultiplyScalar(_outputWeightsGradient, negLR));
-        _outputBias = Engine.TensorAdd(_outputBias, Engine.TensorMultiplyScalar(_outputBiasGradient, negLR));
+        Engine.TensorAddInPlace(_queryWeights, Engine.TensorMultiplyScalar(_queryWeightsGradient, negLR));
+        Engine.TensorAddInPlace(_keyWeights, Engine.TensorMultiplyScalar(_keyWeightsGradient, negLR));
+        Engine.TensorAddInPlace(_valueWeights, Engine.TensorMultiplyScalar(_valueWeightsGradient, negLR));
+        Engine.TensorAddInPlace(_gateWeights, Engine.TensorMultiplyScalar(_gateWeightsGradient, negLR));
+        Engine.TensorAddInPlace(_gateBias, Engine.TensorMultiplyScalar(_gateBiasGradient, negLR));
+        Engine.TensorAddInPlace(_outputWeights, Engine.TensorMultiplyScalar(_outputWeightsGradient, negLR));
+        Engine.TensorAddInPlace(_outputBias, Engine.TensorMultiplyScalar(_outputBiasGradient, negLR));
 
         // Register trainable parameters for tape-based autodiff
         RegisterTrainableParameter(_queryWeights, PersistentTensorRole.Weights);

--- a/src/NeuralNetworks/Layers/SSM/GatedSlotAttentionLayer.cs
+++ b/src/NeuralNetworks/Layers/SSM/GatedSlotAttentionLayer.cs
@@ -588,18 +588,18 @@ public partial class GatedSlotAttentionLayer<T> : LayerBase<T>, IShapeContract
             throw new InvalidOperationException("Backward pass must be called before updating parameters.");
 
         T negLR = NumOps.Negate(learningRate);
-        _queryWeights = Engine.TensorAdd(_queryWeights, Engine.TensorMultiplyScalar(_queryWeightsGradient, negLR));
-        _keyWeights = Engine.TensorAdd(_keyWeights, Engine.TensorMultiplyScalar(_keyWeightsGradient!, negLR));
-        _valueWeights = Engine.TensorAdd(_valueWeights, Engine.TensorMultiplyScalar(_valueWeightsGradient!, negLR));
-        _forgetGateWeights = Engine.TensorAdd(_forgetGateWeights, Engine.TensorMultiplyScalar(_forgetGateWeightsGradient!, negLR));
-        _forgetGateBias = Engine.TensorAdd(_forgetGateBias, Engine.TensorMultiplyScalar(_forgetGateBiasGradient!, negLR));
-        _inputGateWeights = Engine.TensorAdd(_inputGateWeights, Engine.TensorMultiplyScalar(_inputGateWeightsGradient!, negLR));
-        _inputGateBias = Engine.TensorAdd(_inputGateBias, Engine.TensorMultiplyScalar(_inputGateBiasGradient!, negLR));
-        _initialSlots = Engine.TensorAdd(_initialSlots, Engine.TensorMultiplyScalar(_initialSlotsGradient!, negLR));
-        _outputGateWeights = Engine.TensorAdd(_outputGateWeights, Engine.TensorMultiplyScalar(_outputGateWeightsGradient!, negLR));
-        _outputGateBias = Engine.TensorAdd(_outputGateBias, Engine.TensorMultiplyScalar(_outputGateBiasGradient!, negLR));
-        _outputProjectionWeights = Engine.TensorAdd(_outputProjectionWeights, Engine.TensorMultiplyScalar(_outputProjectionWeightsGradient!, negLR));
-        _outputProjectionBias = Engine.TensorAdd(_outputProjectionBias, Engine.TensorMultiplyScalar(_outputProjectionBiasGradient!, negLR));
+        Engine.TensorAddInPlace(_queryWeights, Engine.TensorMultiplyScalar(_queryWeightsGradient, negLR));
+        Engine.TensorAddInPlace(_keyWeights, Engine.TensorMultiplyScalar(_keyWeightsGradient!, negLR));
+        Engine.TensorAddInPlace(_valueWeights, Engine.TensorMultiplyScalar(_valueWeightsGradient!, negLR));
+        Engine.TensorAddInPlace(_forgetGateWeights, Engine.TensorMultiplyScalar(_forgetGateWeightsGradient!, negLR));
+        Engine.TensorAddInPlace(_forgetGateBias, Engine.TensorMultiplyScalar(_forgetGateBiasGradient!, negLR));
+        Engine.TensorAddInPlace(_inputGateWeights, Engine.TensorMultiplyScalar(_inputGateWeightsGradient!, negLR));
+        Engine.TensorAddInPlace(_inputGateBias, Engine.TensorMultiplyScalar(_inputGateBiasGradient!, negLR));
+        Engine.TensorAddInPlace(_initialSlots, Engine.TensorMultiplyScalar(_initialSlotsGradient!, negLR));
+        Engine.TensorAddInPlace(_outputGateWeights, Engine.TensorMultiplyScalar(_outputGateWeightsGradient!, negLR));
+        Engine.TensorAddInPlace(_outputGateBias, Engine.TensorMultiplyScalar(_outputGateBiasGradient!, negLR));
+        Engine.TensorAddInPlace(_outputProjectionWeights, Engine.TensorMultiplyScalar(_outputProjectionWeightsGradient!, negLR));
+        Engine.TensorAddInPlace(_outputProjectionBias, Engine.TensorMultiplyScalar(_outputProjectionBiasGradient!, negLR));
 
     }
 

--- a/src/NeuralNetworks/Layers/SSM/HGRN2Layer.cs
+++ b/src/NeuralNetworks/Layers/SSM/HGRN2Layer.cs
@@ -395,15 +395,15 @@ public partial class HGRN2Layer<T> : LayerBase<T>, IShapeContract
             throw new InvalidOperationException("Backward pass must be called before updating parameters.");
 
         T negLR = NumOps.Negate(learningRate);
-        _queryWeights = Engine.TensorAdd(_queryWeights, Engine.TensorMultiplyScalar(_queryWeightsGradient, negLR));
-        _keyWeights = Engine.TensorAdd(_keyWeights, Engine.TensorMultiplyScalar(_keyWeightsGradient!, negLR));
-        _valueWeights = Engine.TensorAdd(_valueWeights, Engine.TensorMultiplyScalar(_valueWeightsGradient!, negLR));
-        _forgetGateWeights = Engine.TensorAdd(_forgetGateWeights, Engine.TensorMultiplyScalar(_forgetGateWeightsGradient!, negLR));
-        _forgetGateBias = Engine.TensorAdd(_forgetGateBias, Engine.TensorMultiplyScalar(_forgetGateBiasGradient!, negLR));
-        _outputGateWeights = Engine.TensorAdd(_outputGateWeights, Engine.TensorMultiplyScalar(_outputGateWeightsGradient!, negLR));
-        _outputGateBias = Engine.TensorAdd(_outputGateBias, Engine.TensorMultiplyScalar(_outputGateBiasGradient!, negLR));
-        _outputProjectionWeights = Engine.TensorAdd(_outputProjectionWeights, Engine.TensorMultiplyScalar(_outputProjectionWeightsGradient!, negLR));
-        _outputProjectionBias = Engine.TensorAdd(_outputProjectionBias, Engine.TensorMultiplyScalar(_outputProjectionBiasGradient!, negLR));
+        Engine.TensorAddInPlace(_queryWeights, Engine.TensorMultiplyScalar(_queryWeightsGradient, negLR));
+        Engine.TensorAddInPlace(_keyWeights, Engine.TensorMultiplyScalar(_keyWeightsGradient!, negLR));
+        Engine.TensorAddInPlace(_valueWeights, Engine.TensorMultiplyScalar(_valueWeightsGradient!, negLR));
+        Engine.TensorAddInPlace(_forgetGateWeights, Engine.TensorMultiplyScalar(_forgetGateWeightsGradient!, negLR));
+        Engine.TensorAddInPlace(_forgetGateBias, Engine.TensorMultiplyScalar(_forgetGateBiasGradient!, negLR));
+        Engine.TensorAddInPlace(_outputGateWeights, Engine.TensorMultiplyScalar(_outputGateWeightsGradient!, negLR));
+        Engine.TensorAddInPlace(_outputGateBias, Engine.TensorMultiplyScalar(_outputGateBiasGradient!, negLR));
+        Engine.TensorAddInPlace(_outputProjectionWeights, Engine.TensorMultiplyScalar(_outputProjectionWeightsGradient!, negLR));
+        Engine.TensorAddInPlace(_outputProjectionBias, Engine.TensorMultiplyScalar(_outputProjectionBiasGradient!, negLR));
 
         // Register trainable parameters for tape-based autodiff
         RegisterTrainableParameter(_queryWeights, PersistentTensorRole.Weights);

--- a/src/NeuralNetworks/Layers/SSM/HGRNLayer.cs
+++ b/src/NeuralNetworks/Layers/SSM/HGRNLayer.cs
@@ -377,21 +377,21 @@ public partial class HGRNLayer<T> : LayerBase<T>, IShapeContract
             throw new InvalidOperationException("Backward pass must be called before updating parameters.");
 
         T negLR = NumOps.Negate(learningRate);
-        _inputProjectionWeights = Engine.TensorAdd(_inputProjectionWeights,
+        Engine.TensorAddInPlace(_inputProjectionWeights,
             Engine.TensorMultiplyScalar(_inputProjectionWeightsGradient, negLR));
-        _inputProjectionBias = Engine.TensorAdd(_inputProjectionBias,
+        Engine.TensorAddInPlace(_inputProjectionBias,
             Engine.TensorMultiplyScalar(_inputProjectionBiasGradient!, negLR));
-        _forgetGateWeights = Engine.TensorAdd(_forgetGateWeights,
+        Engine.TensorAddInPlace(_forgetGateWeights,
             Engine.TensorMultiplyScalar(_forgetGateWeightsGradient!, negLR));
-        _forgetGateBias = Engine.TensorAdd(_forgetGateBias,
+        Engine.TensorAddInPlace(_forgetGateBias,
             Engine.TensorMultiplyScalar(_forgetGateBiasGradient!, negLR));
-        _inputGateWeights = Engine.TensorAdd(_inputGateWeights,
+        Engine.TensorAddInPlace(_inputGateWeights,
             Engine.TensorMultiplyScalar(_inputGateWeightsGradient!, negLR));
-        _inputGateBias = Engine.TensorAdd(_inputGateBias,
+        Engine.TensorAddInPlace(_inputGateBias,
             Engine.TensorMultiplyScalar(_inputGateBiasGradient!, negLR));
-        _outputProjectionWeights = Engine.TensorAdd(_outputProjectionWeights,
+        Engine.TensorAddInPlace(_outputProjectionWeights,
             Engine.TensorMultiplyScalar(_outputProjectionWeightsGradient!, negLR));
-        _outputProjectionBias = Engine.TensorAdd(_outputProjectionBias,
+        Engine.TensorAddInPlace(_outputProjectionBias,
             Engine.TensorMultiplyScalar(_outputProjectionBiasGradient!, negLR));
 
         // Register trainable parameters for tape-based autodiff

--- a/src/NeuralNetworks/Layers/SSM/HedgehogLayer.cs
+++ b/src/NeuralNetworks/Layers/SSM/HedgehogLayer.cs
@@ -537,17 +537,17 @@ public partial class HedgehogLayer<T> : LayerBase<T>, IShapeContract
             throw new InvalidOperationException("Backward pass must be called before updating parameters.");
 
         T negLR = NumOps.Negate(learningRate);
-        _queryWeights = Engine.TensorAdd(_queryWeights, Engine.TensorMultiplyScalar(_queryWeightsGradient, negLR));
-        _keyWeights = Engine.TensorAdd(_keyWeights, Engine.TensorMultiplyScalar(_keyWeightsGradient!, negLR));
-        _valueWeights = Engine.TensorAdd(_valueWeights, Engine.TensorMultiplyScalar(_valueWeightsGradient!, negLR));
-        _featureMapW1 = Engine.TensorAdd(_featureMapW1, Engine.TensorMultiplyScalar(_featureMapW1Gradient!, negLR));
-        _featureMapB1 = Engine.TensorAdd(_featureMapB1, Engine.TensorMultiplyScalar(_featureMapB1Gradient!, negLR));
-        _featureMapW2 = Engine.TensorAdd(_featureMapW2, Engine.TensorMultiplyScalar(_featureMapW2Gradient!, negLR));
-        _featureMapB2 = Engine.TensorAdd(_featureMapB2, Engine.TensorMultiplyScalar(_featureMapB2Gradient!, negLR));
-        _outputGateWeights = Engine.TensorAdd(_outputGateWeights, Engine.TensorMultiplyScalar(_outputGateWeightsGradient!, negLR));
-        _outputGateBias = Engine.TensorAdd(_outputGateBias, Engine.TensorMultiplyScalar(_outputGateBiasGradient!, negLR));
-        _outputProjectionWeights = Engine.TensorAdd(_outputProjectionWeights, Engine.TensorMultiplyScalar(_outputProjectionWeightsGradient!, negLR));
-        _outputProjectionBias = Engine.TensorAdd(_outputProjectionBias, Engine.TensorMultiplyScalar(_outputProjectionBiasGradient!, negLR));
+        Engine.TensorAddInPlace(_queryWeights, Engine.TensorMultiplyScalar(_queryWeightsGradient, negLR));
+        Engine.TensorAddInPlace(_keyWeights, Engine.TensorMultiplyScalar(_keyWeightsGradient!, negLR));
+        Engine.TensorAddInPlace(_valueWeights, Engine.TensorMultiplyScalar(_valueWeightsGradient!, negLR));
+        Engine.TensorAddInPlace(_featureMapW1, Engine.TensorMultiplyScalar(_featureMapW1Gradient!, negLR));
+        Engine.TensorAddInPlace(_featureMapB1, Engine.TensorMultiplyScalar(_featureMapB1Gradient!, negLR));
+        Engine.TensorAddInPlace(_featureMapW2, Engine.TensorMultiplyScalar(_featureMapW2Gradient!, negLR));
+        Engine.TensorAddInPlace(_featureMapB2, Engine.TensorMultiplyScalar(_featureMapB2Gradient!, negLR));
+        Engine.TensorAddInPlace(_outputGateWeights, Engine.TensorMultiplyScalar(_outputGateWeightsGradient!, negLR));
+        Engine.TensorAddInPlace(_outputGateBias, Engine.TensorMultiplyScalar(_outputGateBiasGradient!, negLR));
+        Engine.TensorAddInPlace(_outputProjectionWeights, Engine.TensorMultiplyScalar(_outputProjectionWeightsGradient!, negLR));
+        Engine.TensorAddInPlace(_outputProjectionBias, Engine.TensorMultiplyScalar(_outputProjectionBiasGradient!, negLR));
 
         // Register trainable parameters for tape-based autodiff
         RegisterTrainableParameter(_queryWeights, PersistentTensorRole.Weights);

--- a/src/NeuralNetworks/Layers/SSM/HybridBlockScheduler.cs
+++ b/src/NeuralNetworks/Layers/SSM/HybridBlockScheduler.cs
@@ -373,10 +373,13 @@ public partial class HybridBlockScheduler<T> : LayerBase<T>, IShapeContract
         {
             _blocks[i].UpdateParameters(learningRate);
 
-            _normGammas[i] = Engine.TensorAdd(_normGammas[i],
-                Engine.TensorMultiplyScalar(_normGammaGradients[i], negLR));
-            _normBetas[i] = Engine.TensorAdd(_normBetas[i],
-                Engine.TensorMultiplyScalar(_normBetaGradients[i], negLR));
+            var gammaUpdate = Engine.TensorMultiplyScalar(_normGammaGradients[i], negLR);
+            Engine.TensorAddInPlace(_normGammas[i], gammaUpdate);
+            Engine.InvalidatePersistentTensor(_normGammas[i]);
+
+            var betaUpdate = Engine.TensorMultiplyScalar(_normBetaGradients[i], negLR);
+            Engine.TensorAddInPlace(_normBetas[i], betaUpdate);
+            Engine.InvalidatePersistentTensor(_normBetas[i]);
         }
     }
 

--- a/src/NeuralNetworks/Layers/SSM/HyenaLayer.cs
+++ b/src/NeuralNetworks/Layers/SSM/HyenaLayer.cs
@@ -512,11 +512,9 @@ public partial class HyenaLayer<T> : LayerBase<T>, IShapeContract
         }
 
         // Update output projection
-        _outputProjectionWeights = Engine.TensorAdd(
-            _outputProjectionWeights,
+        Engine.TensorAddInPlace(_outputProjectionWeights,
             Engine.TensorMultiplyScalar(_outputProjectionWeightsGradient, negLR));
-        _outputProjectionBias = Engine.TensorAdd(
-            _outputProjectionBias,
+        Engine.TensorAddInPlace(_outputProjectionBias,
             Engine.TensorMultiplyScalar(_outputProjectionBiasGradient, negLR));
 
         // Register trainable parameters for tape-based autodiff

--- a/src/NeuralNetworks/Layers/SSM/HyenaLayer.cs
+++ b/src/NeuralNetworks/Layers/SSM/HyenaLayer.cs
@@ -486,29 +486,33 @@ public partial class HyenaLayer<T> : LayerBase<T>, IShapeContract
         // Update input projections
         for (int i = 0; i <= _order; i++)
         {
-            _inputProjectionWeights[i] = Engine.TensorAdd(
-                _inputProjectionWeights[i],
-                Engine.TensorMultiplyScalar(_inputProjectionWeightsGradients[i], negLR));
-            _inputProjectionBiases[i] = Engine.TensorAdd(
-                _inputProjectionBiases[i],
-                Engine.TensorMultiplyScalar(_inputProjectionBiasesGradients[i], negLR));
+            var weightUpdate = Engine.TensorMultiplyScalar(_inputProjectionWeightsGradients[i], negLR);
+            Engine.TensorAddInPlace(_inputProjectionWeights[i], weightUpdate);
+            Engine.InvalidatePersistentTensor(_inputProjectionWeights[i]);
+
+            var biasUpdate = Engine.TensorMultiplyScalar(_inputProjectionBiasesGradients[i], negLR);
+            Engine.TensorAddInPlace(_inputProjectionBiases[i], biasUpdate);
+            Engine.InvalidatePersistentTensor(_inputProjectionBiases[i]);
         }
 
         // Update filter networks
         for (int i = 0; i < _order; i++)
         {
-            _filterWeights1[i] = Engine.TensorAdd(
-                _filterWeights1[i],
-                Engine.TensorMultiplyScalar(_filterWeights1Gradients[i], negLR));
-            _filterBiases1[i] = Engine.TensorAdd(
-                _filterBiases1[i],
-                Engine.TensorMultiplyScalar(_filterBiases1Gradients[i], negLR));
-            _filterWeights2[i] = Engine.TensorAdd(
-                _filterWeights2[i],
-                Engine.TensorMultiplyScalar(_filterWeights2Gradients[i], negLR));
-            _filterBiases2[i] = Engine.TensorAdd(
-                _filterBiases2[i],
-                Engine.TensorMultiplyScalar(_filterBiases2Gradients[i], negLR));
+            var weight1Update = Engine.TensorMultiplyScalar(_filterWeights1Gradients[i], negLR);
+            Engine.TensorAddInPlace(_filterWeights1[i], weight1Update);
+            Engine.InvalidatePersistentTensor(_filterWeights1[i]);
+
+            var bias1Update = Engine.TensorMultiplyScalar(_filterBiases1Gradients[i], negLR);
+            Engine.TensorAddInPlace(_filterBiases1[i], bias1Update);
+            Engine.InvalidatePersistentTensor(_filterBiases1[i]);
+
+            var weight2Update = Engine.TensorMultiplyScalar(_filterWeights2Gradients[i], negLR);
+            Engine.TensorAddInPlace(_filterWeights2[i], weight2Update);
+            Engine.InvalidatePersistentTensor(_filterWeights2[i]);
+
+            var bias2Update = Engine.TensorMultiplyScalar(_filterBiases2Gradients[i], negLR);
+            Engine.TensorAddInPlace(_filterBiases2[i], bias2Update);
+            Engine.InvalidatePersistentTensor(_filterBiases2[i]);
         }
 
         // Update output projection
@@ -516,18 +520,8 @@ public partial class HyenaLayer<T> : LayerBase<T>, IShapeContract
             Engine.TensorMultiplyScalar(_outputProjectionWeightsGradient, negLR));
         Engine.TensorAddInPlace(_outputProjectionBias,
             Engine.TensorMultiplyScalar(_outputProjectionBiasGradient, negLR));
-
-        // Register trainable parameters for tape-based autodiff
-        // The array-held projections and filter MLPs are NOT registered by hand here. Their
-        // [TrainableParameter] attributes give TrainableParameterGenerator the whole surface via
-        // ParameterCollectionKind.Array, and an explicit loop would defeat that: the generator's
-        // HasUnmappableRegistration treats an INDEXED argument as unmappable and then declines to
-        // emit GetTrainableParameters/SetTrainableParameters at all. Writing those loops shrank the
-        // generated partial from a full surface to a bare AppendDeclaredParameterComponents and
-        // turned the round trip into "HyenaLayer has 0 registered parameters but received 16".
-        RegisterTrainableParameter(_outputProjectionWeights, PersistentTensorRole.Weights);
-        RegisterTrainableParameter(_outputProjectionBias, PersistentTensorRole.Biases);
-
+        Engine.InvalidatePersistentTensor(_outputProjectionWeights);
+        Engine.InvalidatePersistentTensor(_outputProjectionBias);
     }
 
     /// <inheritdoc />

--- a/src/NeuralNetworks/Layers/SSM/KimiLinearAttentionLayer.cs
+++ b/src/NeuralNetworks/Layers/SSM/KimiLinearAttentionLayer.cs
@@ -452,14 +452,14 @@ public partial class KimiLinearAttentionLayer<T> : LayerBase<T>, IShapeContract
             throw new InvalidOperationException("Backward pass must be called before updating parameters.");
 
         T negLR = NumOps.Negate(learningRate);
-        _queryWeights = Engine.TensorAdd(_queryWeights, Engine.TensorMultiplyScalar(_queryWeightsGradient, negLR));
-        _keyWeights = Engine.TensorAdd(_keyWeights, Engine.TensorMultiplyScalar(_keyWeightsGradient!, negLR));
-        _valueWeights = Engine.TensorAdd(_valueWeights, Engine.TensorMultiplyScalar(_valueWeightsGradient!, negLR));
-        _gateKVBias = Engine.TensorAdd(_gateKVBias, Engine.TensorMultiplyScalar(_gateKVBiasGradient!, negLR));
-        _outputGateWeights = Engine.TensorAdd(_outputGateWeights, Engine.TensorMultiplyScalar(_outputGateWeightsGradient!, negLR));
-        _outputGateBias = Engine.TensorAdd(_outputGateBias, Engine.TensorMultiplyScalar(_outputGateBiasGradient!, negLR));
-        _outputProjectionWeights = Engine.TensorAdd(_outputProjectionWeights, Engine.TensorMultiplyScalar(_outputProjectionWeightsGradient!, negLR));
-        _outputProjectionBias = Engine.TensorAdd(_outputProjectionBias, Engine.TensorMultiplyScalar(_outputProjectionBiasGradient!, negLR));
+        Engine.TensorAddInPlace(_queryWeights, Engine.TensorMultiplyScalar(_queryWeightsGradient, negLR));
+        Engine.TensorAddInPlace(_keyWeights, Engine.TensorMultiplyScalar(_keyWeightsGradient!, negLR));
+        Engine.TensorAddInPlace(_valueWeights, Engine.TensorMultiplyScalar(_valueWeightsGradient!, negLR));
+        Engine.TensorAddInPlace(_gateKVBias, Engine.TensorMultiplyScalar(_gateKVBiasGradient!, negLR));
+        Engine.TensorAddInPlace(_outputGateWeights, Engine.TensorMultiplyScalar(_outputGateWeightsGradient!, negLR));
+        Engine.TensorAddInPlace(_outputGateBias, Engine.TensorMultiplyScalar(_outputGateBiasGradient!, negLR));
+        Engine.TensorAddInPlace(_outputProjectionWeights, Engine.TensorMultiplyScalar(_outputProjectionWeightsGradient!, negLR));
+        Engine.TensorAddInPlace(_outputProjectionBias, Engine.TensorMultiplyScalar(_outputProjectionBiasGradient!, negLR));
 
         // Register trainable parameters for tape-based autodiff
         RegisterTrainableParameter(_queryWeights, PersistentTensorRole.Weights);

--- a/src/NeuralNetworks/Layers/SSM/LinearRecurrentUnitLayer.cs
+++ b/src/NeuralNetworks/Layers/SSM/LinearRecurrentUnitLayer.cs
@@ -602,17 +602,17 @@ public partial class LinearRecurrentUnitLayer<T> : LayerBase<T>, IShapeContract
             throw new InvalidOperationException("Backward pass must be called before updating parameters.");
 
         T negLR = NumOps.Negate(learningRate);
-        _nu = Engine.TensorAdd(_nu, Engine.TensorMultiplyScalar(_nuGradient, negLR));
-        _theta = Engine.TensorAdd(_theta, Engine.TensorMultiplyScalar(_thetaGradient!, negLR));
-        _bReal = Engine.TensorAdd(_bReal, Engine.TensorMultiplyScalar(_bRealGradient!, negLR));
-        _bImag = Engine.TensorAdd(_bImag, Engine.TensorMultiplyScalar(_bImagGradient!, negLR));
-        _cReal = Engine.TensorAdd(_cReal, Engine.TensorMultiplyScalar(_cRealGradient!, negLR));
-        _cImag = Engine.TensorAdd(_cImag, Engine.TensorMultiplyScalar(_cImagGradient!, negLR));
-        _dParam = Engine.TensorAdd(_dParam, Engine.TensorMultiplyScalar(_dParamGradient!, negLR));
-        _inputProjectionWeights = Engine.TensorAdd(_inputProjectionWeights, Engine.TensorMultiplyScalar(_inputProjectionWeightsGradient!, negLR));
-        _inputProjectionBias = Engine.TensorAdd(_inputProjectionBias, Engine.TensorMultiplyScalar(_inputProjectionBiasGradient!, negLR));
-        _outputProjectionWeights = Engine.TensorAdd(_outputProjectionWeights, Engine.TensorMultiplyScalar(_outputProjectionWeightsGradient!, negLR));
-        _outputProjectionBias = Engine.TensorAdd(_outputProjectionBias, Engine.TensorMultiplyScalar(_outputProjectionBiasGradient!, negLR));
+        Engine.TensorAddInPlace(_nu, Engine.TensorMultiplyScalar(_nuGradient, negLR));
+        Engine.TensorAddInPlace(_theta, Engine.TensorMultiplyScalar(_thetaGradient!, negLR));
+        Engine.TensorAddInPlace(_bReal, Engine.TensorMultiplyScalar(_bRealGradient!, negLR));
+        Engine.TensorAddInPlace(_bImag, Engine.TensorMultiplyScalar(_bImagGradient!, negLR));
+        Engine.TensorAddInPlace(_cReal, Engine.TensorMultiplyScalar(_cRealGradient!, negLR));
+        Engine.TensorAddInPlace(_cImag, Engine.TensorMultiplyScalar(_cImagGradient!, negLR));
+        Engine.TensorAddInPlace(_dParam, Engine.TensorMultiplyScalar(_dParamGradient!, negLR));
+        Engine.TensorAddInPlace(_inputProjectionWeights, Engine.TensorMultiplyScalar(_inputProjectionWeightsGradient!, negLR));
+        Engine.TensorAddInPlace(_inputProjectionBias, Engine.TensorMultiplyScalar(_inputProjectionBiasGradient!, negLR));
+        Engine.TensorAddInPlace(_outputProjectionWeights, Engine.TensorMultiplyScalar(_outputProjectionWeightsGradient!, negLR));
+        Engine.TensorAddInPlace(_outputProjectionBias, Engine.TensorMultiplyScalar(_outputProjectionBiasGradient!, negLR));
 
         // Register trainable parameters for tape-based autodiff
         // Register trainable parameters for tape-based autodiff. The state-space core belongs here

--- a/src/NeuralNetworks/Layers/SSM/LogLinearAttentionLayer.cs
+++ b/src/NeuralNetworks/Layers/SSM/LogLinearAttentionLayer.cs
@@ -523,18 +523,18 @@ public partial class LogLinearAttentionLayer<T> : LayerBase<T>, IShapeContract
             throw new InvalidOperationException("Backward pass must be called before updating parameters.");
 
         T negLR = NumOps.Negate(learningRate);
-        _queryWeights = Engine.TensorAdd(_queryWeights, Engine.TensorMultiplyScalar(_queryWeightsGradient, negLR));
-        _queryBias = Engine.TensorAdd(_queryBias, Engine.TensorMultiplyScalar(_queryBiasGradient!, negLR));
-        _keyWeights = Engine.TensorAdd(_keyWeights, Engine.TensorMultiplyScalar(_keyWeightsGradient!, negLR));
-        _keyBias = Engine.TensorAdd(_keyBias, Engine.TensorMultiplyScalar(_keyBiasGradient!, negLR));
-        _valueWeights = Engine.TensorAdd(_valueWeights, Engine.TensorMultiplyScalar(_valueWeightsGradient!, negLR));
-        _valueBias = Engine.TensorAdd(_valueBias, Engine.TensorMultiplyScalar(_valueBiasGradient!, negLR));
-        _levelMixWeights = Engine.TensorAdd(_levelMixWeights, Engine.TensorMultiplyScalar(_levelMixWeightsGradient!, negLR));
-        _compressionWeights = Engine.TensorAdd(_compressionWeights, Engine.TensorMultiplyScalar(_compressionWeightsGradient!, negLR));
-        _outputGateWeights = Engine.TensorAdd(_outputGateWeights, Engine.TensorMultiplyScalar(_outputGateWeightsGradient!, negLR));
-        _outputGateBias = Engine.TensorAdd(_outputGateBias, Engine.TensorMultiplyScalar(_outputGateBiasGradient!, negLR));
-        _outputProjectionWeights = Engine.TensorAdd(_outputProjectionWeights, Engine.TensorMultiplyScalar(_outputProjectionWeightsGradient!, negLR));
-        _outputProjectionBias = Engine.TensorAdd(_outputProjectionBias, Engine.TensorMultiplyScalar(_outputProjectionBiasGradient!, negLR));
+        Engine.TensorAddInPlace(_queryWeights, Engine.TensorMultiplyScalar(_queryWeightsGradient, negLR));
+        Engine.TensorAddInPlace(_queryBias, Engine.TensorMultiplyScalar(_queryBiasGradient!, negLR));
+        Engine.TensorAddInPlace(_keyWeights, Engine.TensorMultiplyScalar(_keyWeightsGradient!, negLR));
+        Engine.TensorAddInPlace(_keyBias, Engine.TensorMultiplyScalar(_keyBiasGradient!, negLR));
+        Engine.TensorAddInPlace(_valueWeights, Engine.TensorMultiplyScalar(_valueWeightsGradient!, negLR));
+        Engine.TensorAddInPlace(_valueBias, Engine.TensorMultiplyScalar(_valueBiasGradient!, negLR));
+        Engine.TensorAddInPlace(_levelMixWeights, Engine.TensorMultiplyScalar(_levelMixWeightsGradient!, negLR));
+        Engine.TensorAddInPlace(_compressionWeights, Engine.TensorMultiplyScalar(_compressionWeightsGradient!, negLR));
+        Engine.TensorAddInPlace(_outputGateWeights, Engine.TensorMultiplyScalar(_outputGateWeightsGradient!, negLR));
+        Engine.TensorAddInPlace(_outputGateBias, Engine.TensorMultiplyScalar(_outputGateBiasGradient!, negLR));
+        Engine.TensorAddInPlace(_outputProjectionWeights, Engine.TensorMultiplyScalar(_outputProjectionWeightsGradient!, negLR));
+        Engine.TensorAddInPlace(_outputProjectionBias, Engine.TensorMultiplyScalar(_outputProjectionBiasGradient!, negLR));
 
         // Register trainable parameters for tape-based autodiff
         RegisterTrainableParameter(_queryWeights, PersistentTensorRole.Weights);

--- a/src/NeuralNetworks/Layers/SSM/LonghornLayer.cs
+++ b/src/NeuralNetworks/Layers/SSM/LonghornLayer.cs
@@ -599,18 +599,18 @@ public partial class LonghornLayer<T> : LayerBase<T>, IShapeContract
             throw new InvalidOperationException("Backward pass must be called before updating parameters.");
 
         T negLR = NumOps.Negate(learningRate);
-        _queryWeights = Engine.TensorAdd(_queryWeights, Engine.TensorMultiplyScalar(_queryWeightsGradient, negLR));
-        _queryBias = Engine.TensorAdd(_queryBias, Engine.TensorMultiplyScalar(_queryBiasGradient!, negLR));
-        _keyWeights = Engine.TensorAdd(_keyWeights, Engine.TensorMultiplyScalar(_keyWeightsGradient!, negLR));
-        _keyBias = Engine.TensorAdd(_keyBias, Engine.TensorMultiplyScalar(_keyBiasGradient!, negLR));
-        _valueWeights = Engine.TensorAdd(_valueWeights, Engine.TensorMultiplyScalar(_valueWeightsGradient!, negLR));
-        _valueBias = Engine.TensorAdd(_valueBias, Engine.TensorMultiplyScalar(_valueBiasGradient!, negLR));
-        _alphaWeights = Engine.TensorAdd(_alphaWeights, Engine.TensorMultiplyScalar(_alphaWeightsGradient!, negLR));
-        _alphaBias = Engine.TensorAdd(_alphaBias, Engine.TensorMultiplyScalar(_alphaBiasGradient!, negLR));
-        _groupNormGamma = Engine.TensorAdd(_groupNormGamma, Engine.TensorMultiplyScalar(_groupNormGammaGradient!, negLR));
-        _groupNormBeta = Engine.TensorAdd(_groupNormBeta, Engine.TensorMultiplyScalar(_groupNormBetaGradient!, negLR));
-        _outputProjectionWeights = Engine.TensorAdd(_outputProjectionWeights, Engine.TensorMultiplyScalar(_outputProjectionWeightsGradient!, negLR));
-        _outputProjectionBias = Engine.TensorAdd(_outputProjectionBias, Engine.TensorMultiplyScalar(_outputProjectionBiasGradient!, negLR));
+        Engine.TensorAddInPlace(_queryWeights, Engine.TensorMultiplyScalar(_queryWeightsGradient, negLR));
+        Engine.TensorAddInPlace(_queryBias, Engine.TensorMultiplyScalar(_queryBiasGradient!, negLR));
+        Engine.TensorAddInPlace(_keyWeights, Engine.TensorMultiplyScalar(_keyWeightsGradient!, negLR));
+        Engine.TensorAddInPlace(_keyBias, Engine.TensorMultiplyScalar(_keyBiasGradient!, negLR));
+        Engine.TensorAddInPlace(_valueWeights, Engine.TensorMultiplyScalar(_valueWeightsGradient!, negLR));
+        Engine.TensorAddInPlace(_valueBias, Engine.TensorMultiplyScalar(_valueBiasGradient!, negLR));
+        Engine.TensorAddInPlace(_alphaWeights, Engine.TensorMultiplyScalar(_alphaWeightsGradient!, negLR));
+        Engine.TensorAddInPlace(_alphaBias, Engine.TensorMultiplyScalar(_alphaBiasGradient!, negLR));
+        Engine.TensorAddInPlace(_groupNormGamma, Engine.TensorMultiplyScalar(_groupNormGammaGradient!, negLR));
+        Engine.TensorAddInPlace(_groupNormBeta, Engine.TensorMultiplyScalar(_groupNormBetaGradient!, negLR));
+        Engine.TensorAddInPlace(_outputProjectionWeights, Engine.TensorMultiplyScalar(_outputProjectionWeightsGradient!, negLR));
+        Engine.TensorAddInPlace(_outputProjectionBias, Engine.TensorMultiplyScalar(_outputProjectionBiasGradient!, negLR));
 
     }
 

--- a/src/NeuralNetworks/Layers/SSM/MEGALayer.cs
+++ b/src/NeuralNetworks/Layers/SSM/MEGALayer.cs
@@ -645,21 +645,21 @@ public partial class MEGALayer<T> : LayerBase<T>, IShapeContract
             throw new InvalidOperationException("Backward pass must be called before updating parameters.");
 
         T negLR = NumOps.Negate(learningRate);
-        _emaAlphaLogit = Engine.TensorAdd(_emaAlphaLogit, Engine.TensorMultiplyScalar(_emaAlphaLogitGradient!, negLR));
-        _emaProjectInWeights = Engine.TensorAdd(_emaProjectInWeights, Engine.TensorMultiplyScalar(_emaProjectInWeightsGradient!, negLR));
-        _emaProjectInBias = Engine.TensorAdd(_emaProjectInBias, Engine.TensorMultiplyScalar(_emaProjectInBiasGradient!, negLR));
-        _emaProjectOutWeights = Engine.TensorAdd(_emaProjectOutWeights, Engine.TensorMultiplyScalar(_emaProjectOutWeightsGradient!, negLR));
-        _emaProjectOutBias = Engine.TensorAdd(_emaProjectOutBias, Engine.TensorMultiplyScalar(_emaProjectOutBiasGradient!, negLR));
-        _queryWeights = Engine.TensorAdd(_queryWeights, Engine.TensorMultiplyScalar(_queryWeightsGradient, negLR));
-        _queryBias = Engine.TensorAdd(_queryBias, Engine.TensorMultiplyScalar(_queryBiasGradient!, negLR));
-        _keyWeights = Engine.TensorAdd(_keyWeights, Engine.TensorMultiplyScalar(_keyWeightsGradient!, negLR));
-        _keyBias = Engine.TensorAdd(_keyBias, Engine.TensorMultiplyScalar(_keyBiasGradient!, negLR));
-        _valueWeights = Engine.TensorAdd(_valueWeights, Engine.TensorMultiplyScalar(_valueWeightsGradient!, negLR));
-        _valueBias = Engine.TensorAdd(_valueBias, Engine.TensorMultiplyScalar(_valueBiasGradient!, negLR));
-        _outputGateWeights = Engine.TensorAdd(_outputGateWeights, Engine.TensorMultiplyScalar(_outputGateWeightsGradient!, negLR));
-        _outputGateBias = Engine.TensorAdd(_outputGateBias, Engine.TensorMultiplyScalar(_outputGateBiasGradient!, negLR));
-        _outputProjectionWeights = Engine.TensorAdd(_outputProjectionWeights, Engine.TensorMultiplyScalar(_outputProjectionWeightsGradient!, negLR));
-        _outputProjectionBias = Engine.TensorAdd(_outputProjectionBias, Engine.TensorMultiplyScalar(_outputProjectionBiasGradient!, negLR));
+        Engine.TensorAddInPlace(_emaAlphaLogit, Engine.TensorMultiplyScalar(_emaAlphaLogitGradient!, negLR));
+        Engine.TensorAddInPlace(_emaProjectInWeights, Engine.TensorMultiplyScalar(_emaProjectInWeightsGradient!, negLR));
+        Engine.TensorAddInPlace(_emaProjectInBias, Engine.TensorMultiplyScalar(_emaProjectInBiasGradient!, negLR));
+        Engine.TensorAddInPlace(_emaProjectOutWeights, Engine.TensorMultiplyScalar(_emaProjectOutWeightsGradient!, negLR));
+        Engine.TensorAddInPlace(_emaProjectOutBias, Engine.TensorMultiplyScalar(_emaProjectOutBiasGradient!, negLR));
+        Engine.TensorAddInPlace(_queryWeights, Engine.TensorMultiplyScalar(_queryWeightsGradient, negLR));
+        Engine.TensorAddInPlace(_queryBias, Engine.TensorMultiplyScalar(_queryBiasGradient!, negLR));
+        Engine.TensorAddInPlace(_keyWeights, Engine.TensorMultiplyScalar(_keyWeightsGradient!, negLR));
+        Engine.TensorAddInPlace(_keyBias, Engine.TensorMultiplyScalar(_keyBiasGradient!, negLR));
+        Engine.TensorAddInPlace(_valueWeights, Engine.TensorMultiplyScalar(_valueWeightsGradient!, negLR));
+        Engine.TensorAddInPlace(_valueBias, Engine.TensorMultiplyScalar(_valueBiasGradient!, negLR));
+        Engine.TensorAddInPlace(_outputGateWeights, Engine.TensorMultiplyScalar(_outputGateWeightsGradient!, negLR));
+        Engine.TensorAddInPlace(_outputGateBias, Engine.TensorMultiplyScalar(_outputGateBiasGradient!, negLR));
+        Engine.TensorAddInPlace(_outputProjectionWeights, Engine.TensorMultiplyScalar(_outputProjectionWeightsGradient!, negLR));
+        Engine.TensorAddInPlace(_outputProjectionBias, Engine.TensorMultiplyScalar(_outputProjectionBiasGradient!, negLR));
 
     }
 

--- a/src/NeuralNetworks/Layers/SSM/Mamba2Block.cs
+++ b/src/NeuralNetworks/Layers/SSM/Mamba2Block.cs
@@ -1080,20 +1080,20 @@ public partial class Mamba2Block<T> : LayerBase<T>, IShapeContract
             throw new InvalidOperationException("Backward pass must be called before updating parameters.");
 
         T negLR = NumOps.Negate(learningRate);
-        _inputProjectionWeights = Engine.TensorAdd(_inputProjectionWeights, Engine.TensorMultiplyScalar(_inputProjectionWeightsGradient, negLR));
-        _inputProjectionBias = Engine.TensorAdd(_inputProjectionBias, Engine.TensorMultiplyScalar(_inputProjectionBiasGradient!, negLR));
-        _convWeights = Engine.TensorAdd(_convWeights, Engine.TensorMultiplyScalar(_convWeightsGradient!, negLR));
-        _convBias = Engine.TensorAdd(_convBias, Engine.TensorMultiplyScalar(_convBiasGradient!, negLR));
-        _bProjectionWeights = Engine.TensorAdd(_bProjectionWeights, Engine.TensorMultiplyScalar(_bProjectionWeightsGradient!, negLR));
-        _cProjectionWeights = Engine.TensorAdd(_cProjectionWeights, Engine.TensorMultiplyScalar(_cProjectionWeightsGradient!, negLR));
-        _aLog = Engine.TensorAdd(_aLog, Engine.TensorMultiplyScalar(_aLogGradient!, negLR));
-        _dtProjectionWeights = Engine.TensorAdd(_dtProjectionWeights, Engine.TensorMultiplyScalar(_dtProjectionWeightsGradient!, negLR));
-        _dtProjectionBias = Engine.TensorAdd(_dtProjectionBias, Engine.TensorMultiplyScalar(_dtProjectionBiasGradient!, negLR));
-        _dParam = Engine.TensorAdd(_dParam, Engine.TensorMultiplyScalar(_dParamGradient!, negLR));
-        _outputProjectionWeights = Engine.TensorAdd(_outputProjectionWeights, Engine.TensorMultiplyScalar(_outputProjectionWeightsGradient!, negLR));
-        _outputProjectionBias = Engine.TensorAdd(_outputProjectionBias, Engine.TensorMultiplyScalar(_outputProjectionBiasGradient!, negLR));
-        _normGamma = Engine.TensorAdd(_normGamma, Engine.TensorMultiplyScalar(_normGammaGradient!, negLR));
-        _normBeta = Engine.TensorAdd(_normBeta, Engine.TensorMultiplyScalar(_normBetaGradient!, negLR));
+        Engine.TensorAddInPlace(_inputProjectionWeights, Engine.TensorMultiplyScalar(_inputProjectionWeightsGradient, negLR));
+        Engine.TensorAddInPlace(_inputProjectionBias, Engine.TensorMultiplyScalar(_inputProjectionBiasGradient!, negLR));
+        Engine.TensorAddInPlace(_convWeights, Engine.TensorMultiplyScalar(_convWeightsGradient!, negLR));
+        Engine.TensorAddInPlace(_convBias, Engine.TensorMultiplyScalar(_convBiasGradient!, negLR));
+        Engine.TensorAddInPlace(_bProjectionWeights, Engine.TensorMultiplyScalar(_bProjectionWeightsGradient!, negLR));
+        Engine.TensorAddInPlace(_cProjectionWeights, Engine.TensorMultiplyScalar(_cProjectionWeightsGradient!, negLR));
+        Engine.TensorAddInPlace(_aLog, Engine.TensorMultiplyScalar(_aLogGradient!, negLR));
+        Engine.TensorAddInPlace(_dtProjectionWeights, Engine.TensorMultiplyScalar(_dtProjectionWeightsGradient!, negLR));
+        Engine.TensorAddInPlace(_dtProjectionBias, Engine.TensorMultiplyScalar(_dtProjectionBiasGradient!, negLR));
+        Engine.TensorAddInPlace(_dParam, Engine.TensorMultiplyScalar(_dParamGradient!, negLR));
+        Engine.TensorAddInPlace(_outputProjectionWeights, Engine.TensorMultiplyScalar(_outputProjectionWeightsGradient!, negLR));
+        Engine.TensorAddInPlace(_outputProjectionBias, Engine.TensorMultiplyScalar(_outputProjectionBiasGradient!, negLR));
+        Engine.TensorAddInPlace(_normGamma, Engine.TensorMultiplyScalar(_normGammaGradient!, negLR));
+        Engine.TensorAddInPlace(_normBeta, Engine.TensorMultiplyScalar(_normBetaGradient!, negLR));
 
         // Re-register against the new tensor instances created above so the autodiff registry tracks the
         // live weights (now the full parameter set, matching GetParameters).

--- a/src/NeuralNetworks/Layers/SSM/MambaBlock.cs
+++ b/src/NeuralNetworks/Layers/SSM/MambaBlock.cs
@@ -708,17 +708,17 @@ public partial class MambaBlock<T> : LayerBase<T>, IShapeContract
             throw new InvalidOperationException("Backward pass must be called before updating parameters.");
 
         T negLR = NumOps.Negate(learningRate);
-        _inputProjectionWeights = Engine.TensorAdd(_inputProjectionWeights, Engine.TensorMultiplyScalar(_inputProjectionWeightsGradient, negLR));
-        _inputProjectionBias = Engine.TensorAdd(_inputProjectionBias, Engine.TensorMultiplyScalar(_inputProjectionBiasGradient!, negLR));
-        _convWeights = Engine.TensorAdd(_convWeights, Engine.TensorMultiplyScalar(_convWeightsGradient!, negLR));
-        _convBias = Engine.TensorAdd(_convBias, Engine.TensorMultiplyScalar(_convBiasGradient!, negLR));
-        _xProjectionWeights = Engine.TensorAdd(_xProjectionWeights, Engine.TensorMultiplyScalar(_xProjectionWeightsGradient!, negLR));
-        _dtProjectionWeights = Engine.TensorAdd(_dtProjectionWeights, Engine.TensorMultiplyScalar(_dtProjectionWeightsGradient!, negLR));
-        _dtProjectionBias = Engine.TensorAdd(_dtProjectionBias, Engine.TensorMultiplyScalar(_dtProjectionBiasGradient!, negLR));
-        _aLog = Engine.TensorAdd(_aLog, Engine.TensorMultiplyScalar(_aLogGradient!, negLR));
-        _dParam = Engine.TensorAdd(_dParam, Engine.TensorMultiplyScalar(_dParamGradient!, negLR));
-        _outputProjectionWeights = Engine.TensorAdd(_outputProjectionWeights, Engine.TensorMultiplyScalar(_outputProjectionWeightsGradient!, negLR));
-        _outputProjectionBias = Engine.TensorAdd(_outputProjectionBias, Engine.TensorMultiplyScalar(_outputProjectionBiasGradient!, negLR));
+        Engine.TensorAddInPlace(_inputProjectionWeights, Engine.TensorMultiplyScalar(_inputProjectionWeightsGradient, negLR));
+        Engine.TensorAddInPlace(_inputProjectionBias, Engine.TensorMultiplyScalar(_inputProjectionBiasGradient!, negLR));
+        Engine.TensorAddInPlace(_convWeights, Engine.TensorMultiplyScalar(_convWeightsGradient!, negLR));
+        Engine.TensorAddInPlace(_convBias, Engine.TensorMultiplyScalar(_convBiasGradient!, negLR));
+        Engine.TensorAddInPlace(_xProjectionWeights, Engine.TensorMultiplyScalar(_xProjectionWeightsGradient!, negLR));
+        Engine.TensorAddInPlace(_dtProjectionWeights, Engine.TensorMultiplyScalar(_dtProjectionWeightsGradient!, negLR));
+        Engine.TensorAddInPlace(_dtProjectionBias, Engine.TensorMultiplyScalar(_dtProjectionBiasGradient!, negLR));
+        Engine.TensorAddInPlace(_aLog, Engine.TensorMultiplyScalar(_aLogGradient!, negLR));
+        Engine.TensorAddInPlace(_dParam, Engine.TensorMultiplyScalar(_dParamGradient!, negLR));
+        Engine.TensorAddInPlace(_outputProjectionWeights, Engine.TensorMultiplyScalar(_outputProjectionWeightsGradient!, negLR));
+        Engine.TensorAddInPlace(_outputProjectionBias, Engine.TensorMultiplyScalar(_outputProjectionBiasGradient!, negLR));
 
         // Re-register against the new tensor instances created by the updates above (TensorAdd returns new
         // tensors), so the autodiff registry tracks the live weights â€” now including _aLog and _dParam.

--- a/src/NeuralNetworks/Layers/SSM/MegalodonLayer.cs
+++ b/src/NeuralNetworks/Layers/SSM/MegalodonLayer.cs
@@ -870,21 +870,21 @@ public partial class MegalodonLayer<T> : LayerBase<T>, IShapeContract
             throw new InvalidOperationException("Backward pass must be called before updating parameters.");
 
         T negLR = NumOps.Negate(learningRate);
-        _emaAlphaReal = Engine.TensorAdd(_emaAlphaReal, Engine.TensorMultiplyScalar(_emaAlphaRealGradient, negLR));
-        _emaAlphaImag = Engine.TensorAdd(_emaAlphaImag, Engine.TensorMultiplyScalar(_emaAlphaImagGradient!, negLR));
-        _emaInputWeights = Engine.TensorAdd(_emaInputWeights, Engine.TensorMultiplyScalar(_emaInputWeightsGradient!, negLR));
-        _emaInputBias = Engine.TensorAdd(_emaInputBias, Engine.TensorMultiplyScalar(_emaInputBiasGradient!, negLR));
-        _emaOutputWeights = Engine.TensorAdd(_emaOutputWeights, Engine.TensorMultiplyScalar(_emaOutputWeightsGradient!, negLR));
-        _emaOutputBias = Engine.TensorAdd(_emaOutputBias, Engine.TensorMultiplyScalar(_emaOutputBiasGradient!, negLR));
-        _tsNormGamma = Engine.TensorAdd(_tsNormGamma, Engine.TensorMultiplyScalar(_tsNormGammaGradient!, negLR));
-        _tsNormBeta = Engine.TensorAdd(_tsNormBeta, Engine.TensorMultiplyScalar(_tsNormBetaGradient!, negLR));
-        _queryWeights = Engine.TensorAdd(_queryWeights, Engine.TensorMultiplyScalar(_queryWeightsGradient!, negLR));
-        _keyWeights = Engine.TensorAdd(_keyWeights, Engine.TensorMultiplyScalar(_keyWeightsGradient!, negLR));
-        _valueWeights = Engine.TensorAdd(_valueWeights, Engine.TensorMultiplyScalar(_valueWeightsGradient!, negLR));
-        _gateWeights = Engine.TensorAdd(_gateWeights, Engine.TensorMultiplyScalar(_gateWeightsGradient!, negLR));
-        _gateBias = Engine.TensorAdd(_gateBias, Engine.TensorMultiplyScalar(_gateBiasGradient!, negLR));
-        _outputProjectionWeights = Engine.TensorAdd(_outputProjectionWeights, Engine.TensorMultiplyScalar(_outputProjectionWeightsGradient!, negLR));
-        _outputProjectionBias = Engine.TensorAdd(_outputProjectionBias, Engine.TensorMultiplyScalar(_outputProjectionBiasGradient!, negLR));
+        Engine.TensorAddInPlace(_emaAlphaReal, Engine.TensorMultiplyScalar(_emaAlphaRealGradient, negLR));
+        Engine.TensorAddInPlace(_emaAlphaImag, Engine.TensorMultiplyScalar(_emaAlphaImagGradient!, negLR));
+        Engine.TensorAddInPlace(_emaInputWeights, Engine.TensorMultiplyScalar(_emaInputWeightsGradient!, negLR));
+        Engine.TensorAddInPlace(_emaInputBias, Engine.TensorMultiplyScalar(_emaInputBiasGradient!, negLR));
+        Engine.TensorAddInPlace(_emaOutputWeights, Engine.TensorMultiplyScalar(_emaOutputWeightsGradient!, negLR));
+        Engine.TensorAddInPlace(_emaOutputBias, Engine.TensorMultiplyScalar(_emaOutputBiasGradient!, negLR));
+        Engine.TensorAddInPlace(_tsNormGamma, Engine.TensorMultiplyScalar(_tsNormGammaGradient!, negLR));
+        Engine.TensorAddInPlace(_tsNormBeta, Engine.TensorMultiplyScalar(_tsNormBetaGradient!, negLR));
+        Engine.TensorAddInPlace(_queryWeights, Engine.TensorMultiplyScalar(_queryWeightsGradient!, negLR));
+        Engine.TensorAddInPlace(_keyWeights, Engine.TensorMultiplyScalar(_keyWeightsGradient!, negLR));
+        Engine.TensorAddInPlace(_valueWeights, Engine.TensorMultiplyScalar(_valueWeightsGradient!, negLR));
+        Engine.TensorAddInPlace(_gateWeights, Engine.TensorMultiplyScalar(_gateWeightsGradient!, negLR));
+        Engine.TensorAddInPlace(_gateBias, Engine.TensorMultiplyScalar(_gateBiasGradient!, negLR));
+        Engine.TensorAddInPlace(_outputProjectionWeights, Engine.TensorMultiplyScalar(_outputProjectionWeightsGradient!, negLR));
+        Engine.TensorAddInPlace(_outputProjectionBias, Engine.TensorMultiplyScalar(_outputProjectionBiasGradient!, negLR));
 
         // Register trainable parameters for tape-based autodiff
         RegisterTrainableParameter(_emaInputWeights, PersistentTensorRole.Weights);

--- a/src/NeuralNetworks/Layers/SSM/MesaNetLayer.cs
+++ b/src/NeuralNetworks/Layers/SSM/MesaNetLayer.cs
@@ -509,19 +509,19 @@ public partial class MesaNetLayer<T> : LayerBase<T>, IShapeContract
             throw new InvalidOperationException("Backward pass must be called before updating parameters.");
 
         T negLR = NumOps.Negate(learningRate);
-        _queryWeights = Engine.TensorAdd(_queryWeights, Engine.TensorMultiplyScalar(_queryWeightsGradient, negLR));
-        _queryBias = Engine.TensorAdd(_queryBias, Engine.TensorMultiplyScalar(_queryBiasGradient!, negLR));
-        _keyWeights = Engine.TensorAdd(_keyWeights, Engine.TensorMultiplyScalar(_keyWeightsGradient!, negLR));
-        _keyBias = Engine.TensorAdd(_keyBias, Engine.TensorMultiplyScalar(_keyBiasGradient!, negLR));
-        _valueWeights = Engine.TensorAdd(_valueWeights, Engine.TensorMultiplyScalar(_valueWeightsGradient!, negLR));
-        _valueBias = Engine.TensorAdd(_valueBias, Engine.TensorMultiplyScalar(_valueBiasGradient!, negLR));
-        _innerWeightsInit = Engine.TensorAdd(_innerWeightsInit, Engine.TensorMultiplyScalar(_innerWeightsInitGradient!, negLR));
-        _outputGateWeights = Engine.TensorAdd(_outputGateWeights, Engine.TensorMultiplyScalar(_outputGateWeightsGradient!, negLR));
-        _outputGateBias = Engine.TensorAdd(_outputGateBias, Engine.TensorMultiplyScalar(_outputGateBiasGradient!, negLR));
-        _outputProjectionWeights = Engine.TensorAdd(_outputProjectionWeights, Engine.TensorMultiplyScalar(_outputProjectionWeightsGradient!, negLR));
-        _outputProjectionBias = Engine.TensorAdd(_outputProjectionBias, Engine.TensorMultiplyScalar(_outputProjectionBiasGradient!, negLR));
-        _lnGamma = Engine.TensorAdd(_lnGamma, Engine.TensorMultiplyScalar(_lnGammaGradient!, negLR));
-        _lnBeta = Engine.TensorAdd(_lnBeta, Engine.TensorMultiplyScalar(_lnBetaGradient!, negLR));
+        Engine.TensorAddInPlace(_queryWeights, Engine.TensorMultiplyScalar(_queryWeightsGradient, negLR));
+        Engine.TensorAddInPlace(_queryBias, Engine.TensorMultiplyScalar(_queryBiasGradient!, negLR));
+        Engine.TensorAddInPlace(_keyWeights, Engine.TensorMultiplyScalar(_keyWeightsGradient!, negLR));
+        Engine.TensorAddInPlace(_keyBias, Engine.TensorMultiplyScalar(_keyBiasGradient!, negLR));
+        Engine.TensorAddInPlace(_valueWeights, Engine.TensorMultiplyScalar(_valueWeightsGradient!, negLR));
+        Engine.TensorAddInPlace(_valueBias, Engine.TensorMultiplyScalar(_valueBiasGradient!, negLR));
+        Engine.TensorAddInPlace(_innerWeightsInit, Engine.TensorMultiplyScalar(_innerWeightsInitGradient!, negLR));
+        Engine.TensorAddInPlace(_outputGateWeights, Engine.TensorMultiplyScalar(_outputGateWeightsGradient!, negLR));
+        Engine.TensorAddInPlace(_outputGateBias, Engine.TensorMultiplyScalar(_outputGateBiasGradient!, negLR));
+        Engine.TensorAddInPlace(_outputProjectionWeights, Engine.TensorMultiplyScalar(_outputProjectionWeightsGradient!, negLR));
+        Engine.TensorAddInPlace(_outputProjectionBias, Engine.TensorMultiplyScalar(_outputProjectionBiasGradient!, negLR));
+        Engine.TensorAddInPlace(_lnGamma, Engine.TensorMultiplyScalar(_lnGammaGradient!, negLR));
+        Engine.TensorAddInPlace(_lnBeta, Engine.TensorMultiplyScalar(_lnBetaGradient!, negLR));
 
         // Register trainable parameters for tape-based autodiff
         RegisterTrainableParameter(_queryWeights, PersistentTensorRole.Weights);

--- a/src/NeuralNetworks/Layers/SSM/MinGRULayer.cs
+++ b/src/NeuralNetworks/Layers/SSM/MinGRULayer.cs
@@ -387,21 +387,21 @@ public partial class MinGRULayer<T> : LayerBase<T>, IShapeContract
             throw new InvalidOperationException("Backward pass must be called before updating parameters.");
 
         T negLR = NumOps.Negate(learningRate);
-        _inputProjectionWeights = Engine.TensorAdd(_inputProjectionWeights,
+        Engine.TensorAddInPlace(_inputProjectionWeights,
             Engine.TensorMultiplyScalar(_inputProjectionWeightsGradient, negLR));
-        _inputProjectionBias = Engine.TensorAdd(_inputProjectionBias,
+        Engine.TensorAddInPlace(_inputProjectionBias,
             Engine.TensorMultiplyScalar(_inputProjectionBiasGradient!, negLR));
-        _gateWeights = Engine.TensorAdd(_gateWeights,
+        Engine.TensorAddInPlace(_gateWeights,
             Engine.TensorMultiplyScalar(_gateWeightsGradient!, negLR));
-        _gateBias = Engine.TensorAdd(_gateBias,
+        Engine.TensorAddInPlace(_gateBias,
             Engine.TensorMultiplyScalar(_gateBiasGradient!, negLR));
-        _candidateWeights = Engine.TensorAdd(_candidateWeights,
+        Engine.TensorAddInPlace(_candidateWeights,
             Engine.TensorMultiplyScalar(_candidateWeightsGradient!, negLR));
-        _candidateBias = Engine.TensorAdd(_candidateBias,
+        Engine.TensorAddInPlace(_candidateBias,
             Engine.TensorMultiplyScalar(_candidateBiasGradient!, negLR));
-        _outputProjectionWeights = Engine.TensorAdd(_outputProjectionWeights,
+        Engine.TensorAddInPlace(_outputProjectionWeights,
             Engine.TensorMultiplyScalar(_outputProjectionWeightsGradient!, negLR));
-        _outputProjectionBias = Engine.TensorAdd(_outputProjectionBias,
+        Engine.TensorAddInPlace(_outputProjectionBias,
             Engine.TensorMultiplyScalar(_outputProjectionBiasGradient!, negLR));
 
         // Register trainable parameters for tape-based autodiff

--- a/src/NeuralNetworks/Layers/SSM/MinLSTMLayer.cs
+++ b/src/NeuralNetworks/Layers/SSM/MinLSTMLayer.cs
@@ -453,16 +453,16 @@ public partial class MinLSTMLayer<T> : LayerBase<T>, IShapeContract
             throw new InvalidOperationException("Backward pass must be called before updating parameters.");
 
         T negLR = NumOps.Negate(learningRate);
-        _inputProjectionWeights = Engine.TensorAdd(_inputProjectionWeights, Engine.TensorMultiplyScalar(_inputProjectionWeightsGradient, negLR));
-        _inputProjectionBias = Engine.TensorAdd(_inputProjectionBias, Engine.TensorMultiplyScalar(_inputProjectionBiasGradient!, negLR));
-        _forgetGateWeights = Engine.TensorAdd(_forgetGateWeights, Engine.TensorMultiplyScalar(_forgetGateWeightsGradient!, negLR));
-        _forgetGateBias = Engine.TensorAdd(_forgetGateBias, Engine.TensorMultiplyScalar(_forgetGateBiasGradient!, negLR));
-        _inputGateWeights = Engine.TensorAdd(_inputGateWeights, Engine.TensorMultiplyScalar(_inputGateWeightsGradient!, negLR));
-        _inputGateBias = Engine.TensorAdd(_inputGateBias, Engine.TensorMultiplyScalar(_inputGateBiasGradient!, negLR));
-        _cellCandidateWeights = Engine.TensorAdd(_cellCandidateWeights, Engine.TensorMultiplyScalar(_cellCandidateWeightsGradient!, negLR));
-        _cellCandidateBias = Engine.TensorAdd(_cellCandidateBias, Engine.TensorMultiplyScalar(_cellCandidateBiasGradient!, negLR));
-        _outputProjectionWeights = Engine.TensorAdd(_outputProjectionWeights, Engine.TensorMultiplyScalar(_outputProjectionWeightsGradient!, negLR));
-        _outputProjectionBias = Engine.TensorAdd(_outputProjectionBias, Engine.TensorMultiplyScalar(_outputProjectionBiasGradient!, negLR));
+        Engine.TensorAddInPlace(_inputProjectionWeights, Engine.TensorMultiplyScalar(_inputProjectionWeightsGradient, negLR));
+        Engine.TensorAddInPlace(_inputProjectionBias, Engine.TensorMultiplyScalar(_inputProjectionBiasGradient!, negLR));
+        Engine.TensorAddInPlace(_forgetGateWeights, Engine.TensorMultiplyScalar(_forgetGateWeightsGradient!, negLR));
+        Engine.TensorAddInPlace(_forgetGateBias, Engine.TensorMultiplyScalar(_forgetGateBiasGradient!, negLR));
+        Engine.TensorAddInPlace(_inputGateWeights, Engine.TensorMultiplyScalar(_inputGateWeightsGradient!, negLR));
+        Engine.TensorAddInPlace(_inputGateBias, Engine.TensorMultiplyScalar(_inputGateBiasGradient!, negLR));
+        Engine.TensorAddInPlace(_cellCandidateWeights, Engine.TensorMultiplyScalar(_cellCandidateWeightsGradient!, negLR));
+        Engine.TensorAddInPlace(_cellCandidateBias, Engine.TensorMultiplyScalar(_cellCandidateBiasGradient!, negLR));
+        Engine.TensorAddInPlace(_outputProjectionWeights, Engine.TensorMultiplyScalar(_outputProjectionWeightsGradient!, negLR));
+        Engine.TensorAddInPlace(_outputProjectionBias, Engine.TensorMultiplyScalar(_outputProjectionBiasGradient!, negLR));
 
         // Register trainable parameters for tape-based autodiff
         RegisterTrainableParameter(_inputProjectionWeights, PersistentTensorRole.Weights);

--- a/src/NeuralNetworks/Layers/SSM/MixtureOfMambaLayer.cs
+++ b/src/NeuralNetworks/Layers/SSM/MixtureOfMambaLayer.cs
@@ -481,16 +481,16 @@ public partial class MixtureOfMambaLayer<T> : LayerBase<T>, IShapeContract
             throw new InvalidOperationException("Backward pass must be called before updating parameters.");
 
         T negLR = NumOps.Negate(learningRate);
-        _routerWeights = Engine.TensorAdd(_routerWeights, Engine.TensorMultiplyScalar(_routerWeightsGradient, negLR));
-        _routerBias = Engine.TensorAdd(_routerBias, Engine.TensorMultiplyScalar(_routerBiasGradient!, negLR));
-        _expertA = Engine.TensorAdd(_expertA, Engine.TensorMultiplyScalar(_expertAGradient!, negLR));
-        _expertB = Engine.TensorAdd(_expertB, Engine.TensorMultiplyScalar(_expertBGradient!, negLR));
-        _expertC = Engine.TensorAdd(_expertC, Engine.TensorMultiplyScalar(_expertCGradient!, negLR));
-        _expertD = Engine.TensorAdd(_expertD, Engine.TensorMultiplyScalar(_expertDGradient!, negLR));
-        _outputGateWeights = Engine.TensorAdd(_outputGateWeights, Engine.TensorMultiplyScalar(_outputGateWeightsGradient!, negLR));
-        _outputGateBias = Engine.TensorAdd(_outputGateBias, Engine.TensorMultiplyScalar(_outputGateBiasGradient!, negLR));
-        _outputProjectionWeights = Engine.TensorAdd(_outputProjectionWeights, Engine.TensorMultiplyScalar(_outputProjectionWeightsGradient!, negLR));
-        _outputProjectionBias = Engine.TensorAdd(_outputProjectionBias, Engine.TensorMultiplyScalar(_outputProjectionBiasGradient!, negLR));
+        Engine.TensorAddInPlace(_routerWeights, Engine.TensorMultiplyScalar(_routerWeightsGradient, negLR));
+        Engine.TensorAddInPlace(_routerBias, Engine.TensorMultiplyScalar(_routerBiasGradient!, negLR));
+        Engine.TensorAddInPlace(_expertA, Engine.TensorMultiplyScalar(_expertAGradient!, negLR));
+        Engine.TensorAddInPlace(_expertB, Engine.TensorMultiplyScalar(_expertBGradient!, negLR));
+        Engine.TensorAddInPlace(_expertC, Engine.TensorMultiplyScalar(_expertCGradient!, negLR));
+        Engine.TensorAddInPlace(_expertD, Engine.TensorMultiplyScalar(_expertDGradient!, negLR));
+        Engine.TensorAddInPlace(_outputGateWeights, Engine.TensorMultiplyScalar(_outputGateWeightsGradient!, negLR));
+        Engine.TensorAddInPlace(_outputGateBias, Engine.TensorMultiplyScalar(_outputGateBiasGradient!, negLR));
+        Engine.TensorAddInPlace(_outputProjectionWeights, Engine.TensorMultiplyScalar(_outputProjectionWeightsGradient!, negLR));
+        Engine.TensorAddInPlace(_outputProjectionBias, Engine.TensorMultiplyScalar(_outputProjectionBiasGradient!, negLR));
 
         // Register trainable parameters for tape-based autodiff
         RegisterTrainableParameter(_routerWeights, PersistentTensorRole.Weights);

--- a/src/NeuralNetworks/Layers/SSM/MixtureOfMemoriesLayer.cs
+++ b/src/NeuralNetworks/Layers/SSM/MixtureOfMemoriesLayer.cs
@@ -575,22 +575,22 @@ public partial class MixtureOfMemoriesLayer<T> : LayerBase<T>, IShapeContract
             throw new InvalidOperationException("Backward pass must be called before updating parameters.");
 
         T negLR = NumOps.Negate(learningRate);
-        _queryWeights = Engine.TensorAdd(_queryWeights, Engine.TensorMultiplyScalar(_queryWeightsGradient, negLR));
-        _queryBias = Engine.TensorAdd(_queryBias, Engine.TensorMultiplyScalar(_queryBiasGradient!, negLR));
-        _keyWeights = Engine.TensorAdd(_keyWeights, Engine.TensorMultiplyScalar(_keyWeightsGradient!, negLR));
-        _keyBias = Engine.TensorAdd(_keyBias, Engine.TensorMultiplyScalar(_keyBiasGradient!, negLR));
-        _valueWeights = Engine.TensorAdd(_valueWeights, Engine.TensorMultiplyScalar(_valueWeightsGradient!, negLR));
-        _valueBias = Engine.TensorAdd(_valueBias, Engine.TensorMultiplyScalar(_valueBiasGradient!, negLR));
-        _writeRouterWeights = Engine.TensorAdd(_writeRouterWeights, Engine.TensorMultiplyScalar(_writeRouterWeightsGradient!, negLR));
-        _writeRouterBias = Engine.TensorAdd(_writeRouterBias, Engine.TensorMultiplyScalar(_writeRouterBiasGradient!, negLR));
-        _readRouterWeights = Engine.TensorAdd(_readRouterWeights, Engine.TensorMultiplyScalar(_readRouterWeightsGradient!, negLR));
-        _readRouterBias = Engine.TensorAdd(_readRouterBias, Engine.TensorMultiplyScalar(_readRouterBiasGradient!, negLR));
-        _gateRouterWeights = Engine.TensorAdd(_gateRouterWeights, Engine.TensorMultiplyScalar(_gateRouterWeightsGradient!, negLR));
-        _gateRouterBias = Engine.TensorAdd(_gateRouterBias, Engine.TensorMultiplyScalar(_gateRouterBiasGradient!, negLR));
-        _outputGateWeights = Engine.TensorAdd(_outputGateWeights, Engine.TensorMultiplyScalar(_outputGateWeightsGradient!, negLR));
-        _outputGateBias = Engine.TensorAdd(_outputGateBias, Engine.TensorMultiplyScalar(_outputGateBiasGradient!, negLR));
-        _outputProjectionWeights = Engine.TensorAdd(_outputProjectionWeights, Engine.TensorMultiplyScalar(_outputProjectionWeightsGradient!, negLR));
-        _outputProjectionBias = Engine.TensorAdd(_outputProjectionBias, Engine.TensorMultiplyScalar(_outputProjectionBiasGradient!, negLR));
+        Engine.TensorAddInPlace(_queryWeights, Engine.TensorMultiplyScalar(_queryWeightsGradient, negLR));
+        Engine.TensorAddInPlace(_queryBias, Engine.TensorMultiplyScalar(_queryBiasGradient!, negLR));
+        Engine.TensorAddInPlace(_keyWeights, Engine.TensorMultiplyScalar(_keyWeightsGradient!, negLR));
+        Engine.TensorAddInPlace(_keyBias, Engine.TensorMultiplyScalar(_keyBiasGradient!, negLR));
+        Engine.TensorAddInPlace(_valueWeights, Engine.TensorMultiplyScalar(_valueWeightsGradient!, negLR));
+        Engine.TensorAddInPlace(_valueBias, Engine.TensorMultiplyScalar(_valueBiasGradient!, negLR));
+        Engine.TensorAddInPlace(_writeRouterWeights, Engine.TensorMultiplyScalar(_writeRouterWeightsGradient!, negLR));
+        Engine.TensorAddInPlace(_writeRouterBias, Engine.TensorMultiplyScalar(_writeRouterBiasGradient!, negLR));
+        Engine.TensorAddInPlace(_readRouterWeights, Engine.TensorMultiplyScalar(_readRouterWeightsGradient!, negLR));
+        Engine.TensorAddInPlace(_readRouterBias, Engine.TensorMultiplyScalar(_readRouterBiasGradient!, negLR));
+        Engine.TensorAddInPlace(_gateRouterWeights, Engine.TensorMultiplyScalar(_gateRouterWeightsGradient!, negLR));
+        Engine.TensorAddInPlace(_gateRouterBias, Engine.TensorMultiplyScalar(_gateRouterBiasGradient!, negLR));
+        Engine.TensorAddInPlace(_outputGateWeights, Engine.TensorMultiplyScalar(_outputGateWeightsGradient!, negLR));
+        Engine.TensorAddInPlace(_outputGateBias, Engine.TensorMultiplyScalar(_outputGateBiasGradient!, negLR));
+        Engine.TensorAddInPlace(_outputProjectionWeights, Engine.TensorMultiplyScalar(_outputProjectionWeightsGradient!, negLR));
+        Engine.TensorAddInPlace(_outputProjectionBias, Engine.TensorMultiplyScalar(_outputProjectionBiasGradient!, negLR));
 
         // Register trainable parameters for tape-based autodiff
         RegisterTrainableParameter(_queryWeights, PersistentTensorRole.Weights);

--- a/src/NeuralNetworks/Layers/SSM/MultiLatentAttentionLayer.cs
+++ b/src/NeuralNetworks/Layers/SSM/MultiLatentAttentionLayer.cs
@@ -441,15 +441,15 @@ public partial class MultiLatentAttentionLayer<T> : LayerBase<T>, IShapeContract
         var outputProjectionBiasGradient = _outputProjectionBiasGradient ?? throw new InvalidOperationException("Backward pass must be called before updating parameters.");
 
         T negLR = NumOps.Negate(learningRate);
-        _compressWeights = Engine.TensorAdd(_compressWeights, Engine.TensorMultiplyScalar(_compressWeightsGradient, negLR));
-        _compressBias = Engine.TensorAdd(_compressBias, Engine.TensorMultiplyScalar(compressBiasGradient, negLR));
-        _keyUpWeights = Engine.TensorAdd(_keyUpWeights, Engine.TensorMultiplyScalar(keyUpWeightsGradient, negLR));
-        _valueUpWeights = Engine.TensorAdd(_valueUpWeights, Engine.TensorMultiplyScalar(valueUpWeightsGradient, negLR));
-        _queryWeights = Engine.TensorAdd(_queryWeights, Engine.TensorMultiplyScalar(queryWeightsGradient, negLR));
-        _outputGateWeights = Engine.TensorAdd(_outputGateWeights, Engine.TensorMultiplyScalar(outputGateWeightsGradient, negLR));
-        _outputGateBias = Engine.TensorAdd(_outputGateBias, Engine.TensorMultiplyScalar(outputGateBiasGradient, negLR));
-        _outputProjectionWeights = Engine.TensorAdd(_outputProjectionWeights, Engine.TensorMultiplyScalar(outputProjectionWeightsGradient, negLR));
-        _outputProjectionBias = Engine.TensorAdd(_outputProjectionBias, Engine.TensorMultiplyScalar(outputProjectionBiasGradient, negLR));
+        Engine.TensorAddInPlace(_compressWeights, Engine.TensorMultiplyScalar(_compressWeightsGradient, negLR));
+        Engine.TensorAddInPlace(_compressBias, Engine.TensorMultiplyScalar(compressBiasGradient, negLR));
+        Engine.TensorAddInPlace(_keyUpWeights, Engine.TensorMultiplyScalar(keyUpWeightsGradient, negLR));
+        Engine.TensorAddInPlace(_valueUpWeights, Engine.TensorMultiplyScalar(valueUpWeightsGradient, negLR));
+        Engine.TensorAddInPlace(_queryWeights, Engine.TensorMultiplyScalar(queryWeightsGradient, negLR));
+        Engine.TensorAddInPlace(_outputGateWeights, Engine.TensorMultiplyScalar(outputGateWeightsGradient, negLR));
+        Engine.TensorAddInPlace(_outputGateBias, Engine.TensorMultiplyScalar(outputGateBiasGradient, negLR));
+        Engine.TensorAddInPlace(_outputProjectionWeights, Engine.TensorMultiplyScalar(outputProjectionWeightsGradient, negLR));
+        Engine.TensorAddInPlace(_outputProjectionBias, Engine.TensorMultiplyScalar(outputProjectionBiasGradient, negLR));
 
         // Register trainable parameters for tape-based autodiff
         RegisterTrainableParameter(_compressWeights, PersistentTensorRole.Weights);

--- a/src/NeuralNetworks/Layers/SSM/PaTHAttentionLayer.cs
+++ b/src/NeuralNetworks/Layers/SSM/PaTHAttentionLayer.cs
@@ -570,14 +570,14 @@ public partial class PaTHAttentionLayer<T> : LayerBase<T>, IShapeContract
             throw new InvalidOperationException("Backward pass must be called before updating parameters.");
 
         T negLR = NumOps.Negate(learningRate);
-        _queryWeights = Engine.TensorAdd(_queryWeights, Engine.TensorMultiplyScalar(_queryWeightsGradient, negLR));
-        _keyWeights = Engine.TensorAdd(_keyWeights, Engine.TensorMultiplyScalar(_keyWeightsGradient!, negLR));
-        _valueWeights = Engine.TensorAdd(_valueWeights, Engine.TensorMultiplyScalar(_valueWeightsGradient!, negLR));
-        _householderVectors = Engine.TensorAdd(_householderVectors, Engine.TensorMultiplyScalar(_householderVectorsGradient!, negLR));
-        _outputGateWeights = Engine.TensorAdd(_outputGateWeights, Engine.TensorMultiplyScalar(_outputGateWeightsGradient!, negLR));
-        _outputGateBias = Engine.TensorAdd(_outputGateBias, Engine.TensorMultiplyScalar(_outputGateBiasGradient!, negLR));
-        _outputProjectionWeights = Engine.TensorAdd(_outputProjectionWeights, Engine.TensorMultiplyScalar(_outputProjectionWeightsGradient!, negLR));
-        _outputProjectionBias = Engine.TensorAdd(_outputProjectionBias, Engine.TensorMultiplyScalar(_outputProjectionBiasGradient!, negLR));
+        Engine.TensorAddInPlace(_queryWeights, Engine.TensorMultiplyScalar(_queryWeightsGradient, negLR));
+        Engine.TensorAddInPlace(_keyWeights, Engine.TensorMultiplyScalar(_keyWeightsGradient!, negLR));
+        Engine.TensorAddInPlace(_valueWeights, Engine.TensorMultiplyScalar(_valueWeightsGradient!, negLR));
+        Engine.TensorAddInPlace(_householderVectors, Engine.TensorMultiplyScalar(_householderVectorsGradient!, negLR));
+        Engine.TensorAddInPlace(_outputGateWeights, Engine.TensorMultiplyScalar(_outputGateWeightsGradient!, negLR));
+        Engine.TensorAddInPlace(_outputGateBias, Engine.TensorMultiplyScalar(_outputGateBiasGradient!, negLR));
+        Engine.TensorAddInPlace(_outputProjectionWeights, Engine.TensorMultiplyScalar(_outputProjectionWeightsGradient!, negLR));
+        Engine.TensorAddInPlace(_outputProjectionBias, Engine.TensorMultiplyScalar(_outputProjectionBiasGradient!, negLR));
 
     }
 

--- a/src/NeuralNetworks/Layers/SSM/RWKVLayer.cs
+++ b/src/NeuralNetworks/Layers/SSM/RWKVLayer.cs
@@ -625,24 +625,24 @@ public partial class RWKVLayer<T> : LayerBase<T>, IShapeContract
         }
 
         T negLR = NumOps.Negate(learningRate);
-        _timeMixR = Engine.TensorAdd(_timeMixR, Engine.TensorMultiplyScalar(_timeMixRGradient, negLR));
-        _timeMixK = Engine.TensorAdd(_timeMixK, Engine.TensorMultiplyScalar(_timeMixKGradient, negLR));
-        _timeMixV = Engine.TensorAdd(_timeMixV, Engine.TensorMultiplyScalar(_timeMixVGradient, negLR));
-        _receptanceWeights = Engine.TensorAdd(_receptanceWeights, Engine.TensorMultiplyScalar(_receptanceWeightsGradient, negLR));
-        _keyWeights = Engine.TensorAdd(_keyWeights, Engine.TensorMultiplyScalar(_keyWeightsGradient, negLR));
-        _valueWeights = Engine.TensorAdd(_valueWeights, Engine.TensorMultiplyScalar(_valueWeightsGradient, negLR));
-        _outputWeights = Engine.TensorAdd(_outputWeights, Engine.TensorMultiplyScalar(_outputWeightsGradient, negLR));
-        _decayBias = Engine.TensorAdd(_decayBias, Engine.TensorMultiplyScalar(_decayBiasGradient, negLR));
-        _bonus = Engine.TensorAdd(_bonus, Engine.TensorMultiplyScalar(_bonusGradient, negLR));
-        _channelMixR = Engine.TensorAdd(_channelMixR, Engine.TensorMultiplyScalar(_channelMixRGradient, negLR));
-        _channelMixK = Engine.TensorAdd(_channelMixK, Engine.TensorMultiplyScalar(_channelMixKGradient, negLR));
-        _channelKeyWeights = Engine.TensorAdd(_channelKeyWeights, Engine.TensorMultiplyScalar(_channelKeyWeightsGradient, negLR));
-        _channelValueWeights = Engine.TensorAdd(_channelValueWeights, Engine.TensorMultiplyScalar(_channelValueWeightsGradient, negLR));
-        _channelReceptanceWeights = Engine.TensorAdd(_channelReceptanceWeights, Engine.TensorMultiplyScalar(_channelReceptanceWeightsGradient, negLR));
-        _normGamma1 = Engine.TensorAdd(_normGamma1, Engine.TensorMultiplyScalar(_normGamma1Gradient, negLR));
-        _normBeta1 = Engine.TensorAdd(_normBeta1, Engine.TensorMultiplyScalar(_normBeta1Gradient, negLR));
-        _normGamma2 = Engine.TensorAdd(_normGamma2, Engine.TensorMultiplyScalar(_normGamma2Gradient, negLR));
-        _normBeta2 = Engine.TensorAdd(_normBeta2, Engine.TensorMultiplyScalar(_normBeta2Gradient, negLR));
+        Engine.TensorAddInPlace(_timeMixR, Engine.TensorMultiplyScalar(_timeMixRGradient, negLR));
+        Engine.TensorAddInPlace(_timeMixK, Engine.TensorMultiplyScalar(_timeMixKGradient, negLR));
+        Engine.TensorAddInPlace(_timeMixV, Engine.TensorMultiplyScalar(_timeMixVGradient, negLR));
+        Engine.TensorAddInPlace(_receptanceWeights, Engine.TensorMultiplyScalar(_receptanceWeightsGradient, negLR));
+        Engine.TensorAddInPlace(_keyWeights, Engine.TensorMultiplyScalar(_keyWeightsGradient, negLR));
+        Engine.TensorAddInPlace(_valueWeights, Engine.TensorMultiplyScalar(_valueWeightsGradient, negLR));
+        Engine.TensorAddInPlace(_outputWeights, Engine.TensorMultiplyScalar(_outputWeightsGradient, negLR));
+        Engine.TensorAddInPlace(_decayBias, Engine.TensorMultiplyScalar(_decayBiasGradient, negLR));
+        Engine.TensorAddInPlace(_bonus, Engine.TensorMultiplyScalar(_bonusGradient, negLR));
+        Engine.TensorAddInPlace(_channelMixR, Engine.TensorMultiplyScalar(_channelMixRGradient, negLR));
+        Engine.TensorAddInPlace(_channelMixK, Engine.TensorMultiplyScalar(_channelMixKGradient, negLR));
+        Engine.TensorAddInPlace(_channelKeyWeights, Engine.TensorMultiplyScalar(_channelKeyWeightsGradient, negLR));
+        Engine.TensorAddInPlace(_channelValueWeights, Engine.TensorMultiplyScalar(_channelValueWeightsGradient, negLR));
+        Engine.TensorAddInPlace(_channelReceptanceWeights, Engine.TensorMultiplyScalar(_channelReceptanceWeightsGradient, negLR));
+        Engine.TensorAddInPlace(_normGamma1, Engine.TensorMultiplyScalar(_normGamma1Gradient, negLR));
+        Engine.TensorAddInPlace(_normBeta1, Engine.TensorMultiplyScalar(_normBeta1Gradient, negLR));
+        Engine.TensorAddInPlace(_normGamma2, Engine.TensorMultiplyScalar(_normGamma2Gradient, negLR));
+        Engine.TensorAddInPlace(_normBeta2, Engine.TensorMultiplyScalar(_normBeta2Gradient, negLR));
 
         // Register trainable parameters for tape-based autodiff
         RegisterTrainableParameter(_receptanceWeights, PersistentTensorRole.Weights);

--- a/src/NeuralNetworks/Layers/SSM/RealGatedLinearRecurrenceLayer.cs
+++ b/src/NeuralNetworks/Layers/SSM/RealGatedLinearRecurrenceLayer.cs
@@ -532,16 +532,16 @@ public partial class RealGatedLinearRecurrenceLayer<T> : LayerBase<T>, IShapeCon
             throw new InvalidOperationException("Backward pass must be called before updating parameters.");
 
         T negLR = NumOps.Negate(learningRate);
-        _inputProjectionWeights = Engine.TensorAdd(_inputProjectionWeights, Engine.TensorMultiplyScalar(_inputProjectionWeightsGradient, negLR));
-        _inputProjectionBias = Engine.TensorAdd(_inputProjectionBias, Engine.TensorMultiplyScalar(_inputProjectionBiasGradient!, negLR));
-        _recurrenceGateWeights = Engine.TensorAdd(_recurrenceGateWeights, Engine.TensorMultiplyScalar(_recurrenceGateWeightsGradient!, negLR));
-        _recurrenceGateBias = Engine.TensorAdd(_recurrenceGateBias, Engine.TensorMultiplyScalar(_recurrenceGateBiasGradient!, negLR));
-        _inputGateWeights = Engine.TensorAdd(_inputGateWeights, Engine.TensorMultiplyScalar(_inputGateWeightsGradient!, negLR));
-        _inputGateBias = Engine.TensorAdd(_inputGateBias, Engine.TensorMultiplyScalar(_inputGateBiasGradient!, negLR));
-        _valueProjectionWeights = Engine.TensorAdd(_valueProjectionWeights, Engine.TensorMultiplyScalar(_valueProjectionWeightsGradient!, negLR));
-        _decayParam = Engine.TensorAdd(_decayParam, Engine.TensorMultiplyScalar(_decayParamGradient!, negLR));
-        _outputProjectionWeights = Engine.TensorAdd(_outputProjectionWeights, Engine.TensorMultiplyScalar(_outputProjectionWeightsGradient!, negLR));
-        _outputProjectionBias = Engine.TensorAdd(_outputProjectionBias, Engine.TensorMultiplyScalar(_outputProjectionBiasGradient!, negLR));
+        Engine.TensorAddInPlace(_inputProjectionWeights, Engine.TensorMultiplyScalar(_inputProjectionWeightsGradient, negLR));
+        Engine.TensorAddInPlace(_inputProjectionBias, Engine.TensorMultiplyScalar(_inputProjectionBiasGradient!, negLR));
+        Engine.TensorAddInPlace(_recurrenceGateWeights, Engine.TensorMultiplyScalar(_recurrenceGateWeightsGradient!, negLR));
+        Engine.TensorAddInPlace(_recurrenceGateBias, Engine.TensorMultiplyScalar(_recurrenceGateBiasGradient!, negLR));
+        Engine.TensorAddInPlace(_inputGateWeights, Engine.TensorMultiplyScalar(_inputGateWeightsGradient!, negLR));
+        Engine.TensorAddInPlace(_inputGateBias, Engine.TensorMultiplyScalar(_inputGateBiasGradient!, negLR));
+        Engine.TensorAddInPlace(_valueProjectionWeights, Engine.TensorMultiplyScalar(_valueProjectionWeightsGradient!, negLR));
+        Engine.TensorAddInPlace(_decayParam, Engine.TensorMultiplyScalar(_decayParamGradient!, negLR));
+        Engine.TensorAddInPlace(_outputProjectionWeights, Engine.TensorMultiplyScalar(_outputProjectionWeightsGradient!, negLR));
+        Engine.TensorAddInPlace(_outputProjectionBias, Engine.TensorMultiplyScalar(_outputProjectionBiasGradient!, negLR));
 
     }
 

--- a/src/NeuralNetworks/Layers/SSM/RebasedLayer.cs
+++ b/src/NeuralNetworks/Layers/SSM/RebasedLayer.cs
@@ -676,13 +676,13 @@ public partial class RebasedLayer<T> : LayerBase<T>, IShapeContract
             throw new InvalidOperationException("Backward pass must be called before updating parameters.");
 
         T negLR = NumOps.Negate(learningRate);
-        _queryWeights = Engine.TensorAdd(_queryWeights, Engine.TensorMultiplyScalar(_queryWeightsGradient, negLR));
-        _keyWeights = Engine.TensorAdd(_keyWeights, Engine.TensorMultiplyScalar(_keyWeightsGradient!, negLR));
-        _valueWeights = Engine.TensorAdd(_valueWeights, Engine.TensorMultiplyScalar(_valueWeightsGradient!, negLR));
-        _outputGateWeights = Engine.TensorAdd(_outputGateWeights, Engine.TensorMultiplyScalar(_outputGateWeightsGradient!, negLR));
-        _outputGateBias = Engine.TensorAdd(_outputGateBias, Engine.TensorMultiplyScalar(_outputGateBiasGradient!, negLR));
-        _outputProjectionWeights = Engine.TensorAdd(_outputProjectionWeights, Engine.TensorMultiplyScalar(_outputProjectionWeightsGradient!, negLR));
-        _outputProjectionBias = Engine.TensorAdd(_outputProjectionBias, Engine.TensorMultiplyScalar(_outputProjectionBiasGradient!, negLR));
+        Engine.TensorAddInPlace(_queryWeights, Engine.TensorMultiplyScalar(_queryWeightsGradient, negLR));
+        Engine.TensorAddInPlace(_keyWeights, Engine.TensorMultiplyScalar(_keyWeightsGradient!, negLR));
+        Engine.TensorAddInPlace(_valueWeights, Engine.TensorMultiplyScalar(_valueWeightsGradient!, negLR));
+        Engine.TensorAddInPlace(_outputGateWeights, Engine.TensorMultiplyScalar(_outputGateWeightsGradient!, negLR));
+        Engine.TensorAddInPlace(_outputGateBias, Engine.TensorMultiplyScalar(_outputGateBiasGradient!, negLR));
+        Engine.TensorAddInPlace(_outputProjectionWeights, Engine.TensorMultiplyScalar(_outputProjectionWeightsGradient!, negLR));
+        Engine.TensorAddInPlace(_outputProjectionBias, Engine.TensorMultiplyScalar(_outputProjectionBiasGradient!, negLR));
 
         // Register trainable parameters for tape-based autodiff
         RegisterTrainableParameter(_queryWeights, PersistentTensorRole.Weights);

--- a/src/NeuralNetworks/Layers/SSM/RetNetLayer.cs
+++ b/src/NeuralNetworks/Layers/SSM/RetNetLayer.cs
@@ -613,19 +613,19 @@ public partial class RetNetLayer<T> : LayerBase<T>, IShapeContract
             throw new InvalidOperationException("Backward pass must be called before updating parameters.");
 
         T negLR = NumOps.Negate(learningRate);
-        _queryWeights = Engine.TensorAdd(_queryWeights, Engine.TensorMultiplyScalar(_queryWeightsGradient, negLR));
-        _queryBias = Engine.TensorAdd(_queryBias, Engine.TensorMultiplyScalar(_queryBiasGradient!, negLR));
-        _keyWeights = Engine.TensorAdd(_keyWeights, Engine.TensorMultiplyScalar(_keyWeightsGradient!, negLR));
-        _keyBias = Engine.TensorAdd(_keyBias, Engine.TensorMultiplyScalar(_keyBiasGradient!, negLR));
-        _valueWeights = Engine.TensorAdd(_valueWeights, Engine.TensorMultiplyScalar(_valueWeightsGradient!, negLR));
-        _valueBias = Engine.TensorAdd(_valueBias, Engine.TensorMultiplyScalar(_valueBiasGradient!, negLR));
-        _gammas = Engine.TensorAdd(_gammas, Engine.TensorMultiplyScalar(_gammasGradient!, negLR));
-        _outputGateWeights = Engine.TensorAdd(_outputGateWeights, Engine.TensorMultiplyScalar(_outputGateWeightsGradient!, negLR));
-        _outputGateBias = Engine.TensorAdd(_outputGateBias, Engine.TensorMultiplyScalar(_outputGateBiasGradient!, negLR));
-        _outputProjectionWeights = Engine.TensorAdd(_outputProjectionWeights, Engine.TensorMultiplyScalar(_outputProjectionWeightsGradient!, negLR));
-        _outputProjectionBias = Engine.TensorAdd(_outputProjectionBias, Engine.TensorMultiplyScalar(_outputProjectionBiasGradient!, negLR));
-        _groupNormScale = Engine.TensorAdd(_groupNormScale, Engine.TensorMultiplyScalar(_groupNormScaleGradient!, negLR));
-        _groupNormBias = Engine.TensorAdd(_groupNormBias, Engine.TensorMultiplyScalar(_groupNormBiasGradient!, negLR));
+        Engine.TensorAddInPlace(_queryWeights, Engine.TensorMultiplyScalar(_queryWeightsGradient, negLR));
+        Engine.TensorAddInPlace(_queryBias, Engine.TensorMultiplyScalar(_queryBiasGradient!, negLR));
+        Engine.TensorAddInPlace(_keyWeights, Engine.TensorMultiplyScalar(_keyWeightsGradient!, negLR));
+        Engine.TensorAddInPlace(_keyBias, Engine.TensorMultiplyScalar(_keyBiasGradient!, negLR));
+        Engine.TensorAddInPlace(_valueWeights, Engine.TensorMultiplyScalar(_valueWeightsGradient!, negLR));
+        Engine.TensorAddInPlace(_valueBias, Engine.TensorMultiplyScalar(_valueBiasGradient!, negLR));
+        Engine.TensorAddInPlace(_gammas, Engine.TensorMultiplyScalar(_gammasGradient!, negLR));
+        Engine.TensorAddInPlace(_outputGateWeights, Engine.TensorMultiplyScalar(_outputGateWeightsGradient!, negLR));
+        Engine.TensorAddInPlace(_outputGateBias, Engine.TensorMultiplyScalar(_outputGateBiasGradient!, negLR));
+        Engine.TensorAddInPlace(_outputProjectionWeights, Engine.TensorMultiplyScalar(_outputProjectionWeightsGradient!, negLR));
+        Engine.TensorAddInPlace(_outputProjectionBias, Engine.TensorMultiplyScalar(_outputProjectionBiasGradient!, negLR));
+        Engine.TensorAddInPlace(_groupNormScale, Engine.TensorMultiplyScalar(_groupNormScaleGradient!, negLR));
+        Engine.TensorAddInPlace(_groupNormBias, Engine.TensorMultiplyScalar(_groupNormBiasGradient!, negLR));
 
         // Clamp gammas to (0, 1) after update to maintain valid decay rates
         for (int h = 0; h < _numHeads; h++)

--- a/src/NeuralNetworks/Layers/SSM/RodimusLayer.cs
+++ b/src/NeuralNetworks/Layers/SSM/RodimusLayer.cs
@@ -521,17 +521,17 @@ public partial class RodimusLayer<T> : LayerBase<T>, IShapeContract
             throw new InvalidOperationException("Backward pass must be called before updating parameters.");
 
         T negLR = NumOps.Negate(learningRate);
-        _queryWeights = Engine.TensorAdd(_queryWeights, Engine.TensorMultiplyScalar(_queryWeightsGradient, negLR));
-        _keyWeights = Engine.TensorAdd(_keyWeights, Engine.TensorMultiplyScalar(_keyWeightsGradient!, negLR));
-        _valueWeights = Engine.TensorAdd(_valueWeights, Engine.TensorMultiplyScalar(_valueWeightsGradient!, negLR));
-        _temperatureWeights = Engine.TensorAdd(_temperatureWeights, Engine.TensorMultiplyScalar(_temperatureWeightsGradient!, negLR));
-        _temperatureBias = Engine.TensorAdd(_temperatureBias, Engine.TensorMultiplyScalar(_temperatureBiasGradient!, negLR));
-        _forgetGateWeights = Engine.TensorAdd(_forgetGateWeights, Engine.TensorMultiplyScalar(_forgetGateWeightsGradient!, negLR));
-        _forgetGateBias = Engine.TensorAdd(_forgetGateBias, Engine.TensorMultiplyScalar(_forgetGateBiasGradient!, negLR));
-        _outputGateWeights = Engine.TensorAdd(_outputGateWeights, Engine.TensorMultiplyScalar(_outputGateWeightsGradient!, negLR));
-        _outputGateBias = Engine.TensorAdd(_outputGateBias, Engine.TensorMultiplyScalar(_outputGateBiasGradient!, negLR));
-        _outputProjectionWeights = Engine.TensorAdd(_outputProjectionWeights, Engine.TensorMultiplyScalar(_outputProjectionWeightsGradient!, negLR));
-        _outputProjectionBias = Engine.TensorAdd(_outputProjectionBias, Engine.TensorMultiplyScalar(_outputProjectionBiasGradient!, negLR));
+        Engine.TensorAddInPlace(_queryWeights, Engine.TensorMultiplyScalar(_queryWeightsGradient, negLR));
+        Engine.TensorAddInPlace(_keyWeights, Engine.TensorMultiplyScalar(_keyWeightsGradient!, negLR));
+        Engine.TensorAddInPlace(_valueWeights, Engine.TensorMultiplyScalar(_valueWeightsGradient!, negLR));
+        Engine.TensorAddInPlace(_temperatureWeights, Engine.TensorMultiplyScalar(_temperatureWeightsGradient!, negLR));
+        Engine.TensorAddInPlace(_temperatureBias, Engine.TensorMultiplyScalar(_temperatureBiasGradient!, negLR));
+        Engine.TensorAddInPlace(_forgetGateWeights, Engine.TensorMultiplyScalar(_forgetGateWeightsGradient!, negLR));
+        Engine.TensorAddInPlace(_forgetGateBias, Engine.TensorMultiplyScalar(_forgetGateBiasGradient!, negLR));
+        Engine.TensorAddInPlace(_outputGateWeights, Engine.TensorMultiplyScalar(_outputGateWeightsGradient!, negLR));
+        Engine.TensorAddInPlace(_outputGateBias, Engine.TensorMultiplyScalar(_outputGateBiasGradient!, negLR));
+        Engine.TensorAddInPlace(_outputProjectionWeights, Engine.TensorMultiplyScalar(_outputProjectionWeightsGradient!, negLR));
+        Engine.TensorAddInPlace(_outputProjectionBias, Engine.TensorMultiplyScalar(_outputProjectionBiasGradient!, negLR));
 
         // Register trainable parameters for tape-based autodiff
         RegisterTrainableParameter(_queryWeights, PersistentTensorRole.Weights);

--- a/src/NeuralNetworks/Layers/SSM/S4DLayer.cs
+++ b/src/NeuralNetworks/Layers/SSM/S4DLayer.cs
@@ -1122,18 +1122,18 @@ public partial class S4DLayer<T> : LayerBase<T>, IShapeContract
             throw new InvalidOperationException("Backward pass must be called before updating parameters.");
 
         T negLR = NumOps.Negate(learningRate);
-        _aReal = Engine.TensorAdd(_aReal, Engine.TensorMultiplyScalar(_aRealGradient, negLR));
-        _aImag = Engine.TensorAdd(_aImag, Engine.TensorMultiplyScalar(_aImagGradient!, negLR));
-        _bReal = Engine.TensorAdd(_bReal, Engine.TensorMultiplyScalar(_bRealGradient!, negLR));
-        _bImag = Engine.TensorAdd(_bImag, Engine.TensorMultiplyScalar(_bImagGradient!, negLR));
-        _cReal = Engine.TensorAdd(_cReal, Engine.TensorMultiplyScalar(_cRealGradient!, negLR));
-        _cImag = Engine.TensorAdd(_cImag, Engine.TensorMultiplyScalar(_cImagGradient!, negLR));
-        _dParam = Engine.TensorAdd(_dParam, Engine.TensorMultiplyScalar(_dParamGradient!, negLR));
-        _logDelta = Engine.TensorAdd(_logDelta, Engine.TensorMultiplyScalar(_logDeltaGradient!, negLR));
-        _inputProjectionWeights = Engine.TensorAdd(_inputProjectionWeights, Engine.TensorMultiplyScalar(_inputProjectionWeightsGradient!, negLR));
-        _inputProjectionBias = Engine.TensorAdd(_inputProjectionBias, Engine.TensorMultiplyScalar(_inputProjectionBiasGradient!, negLR));
-        _outputProjectionWeights = Engine.TensorAdd(_outputProjectionWeights, Engine.TensorMultiplyScalar(_outputProjectionWeightsGradient!, negLR));
-        _outputProjectionBias = Engine.TensorAdd(_outputProjectionBias, Engine.TensorMultiplyScalar(_outputProjectionBiasGradient!, negLR));
+        Engine.TensorAddInPlace(_aReal, Engine.TensorMultiplyScalar(_aRealGradient, negLR));
+        Engine.TensorAddInPlace(_aImag, Engine.TensorMultiplyScalar(_aImagGradient!, negLR));
+        Engine.TensorAddInPlace(_bReal, Engine.TensorMultiplyScalar(_bRealGradient!, negLR));
+        Engine.TensorAddInPlace(_bImag, Engine.TensorMultiplyScalar(_bImagGradient!, negLR));
+        Engine.TensorAddInPlace(_cReal, Engine.TensorMultiplyScalar(_cRealGradient!, negLR));
+        Engine.TensorAddInPlace(_cImag, Engine.TensorMultiplyScalar(_cImagGradient!, negLR));
+        Engine.TensorAddInPlace(_dParam, Engine.TensorMultiplyScalar(_dParamGradient!, negLR));
+        Engine.TensorAddInPlace(_logDelta, Engine.TensorMultiplyScalar(_logDeltaGradient!, negLR));
+        Engine.TensorAddInPlace(_inputProjectionWeights, Engine.TensorMultiplyScalar(_inputProjectionWeightsGradient!, negLR));
+        Engine.TensorAddInPlace(_inputProjectionBias, Engine.TensorMultiplyScalar(_inputProjectionBiasGradient!, negLR));
+        Engine.TensorAddInPlace(_outputProjectionWeights, Engine.TensorMultiplyScalar(_outputProjectionWeightsGradient!, negLR));
+        Engine.TensorAddInPlace(_outputProjectionBias, Engine.TensorMultiplyScalar(_outputProjectionBiasGradient!, negLR));
 
         // Register trainable parameters for tape-based autodiff. The state-space core belongs here
         // with the projections: UpdateParameters above applies gradients to A, B, C, D and Delta, so

--- a/src/NeuralNetworks/Layers/SSM/S5Layer.cs
+++ b/src/NeuralNetworks/Layers/SSM/S5Layer.cs
@@ -945,21 +945,21 @@ public partial class S5Layer<T> : LayerBase<T>, IShapeContract
             throw new InvalidOperationException("Backward pass must be called before updating parameters.");
 
         T negLR = NumOps.Negate(learningRate);
-        _aReal = Engine.TensorAdd(_aReal, Engine.TensorMultiplyScalar(_aRealGradient, negLR));
-        _aImag = Engine.TensorAdd(_aImag, Engine.TensorMultiplyScalar(_aImagGradient!, negLR));
-        _bReal = Engine.TensorAdd(_bReal, Engine.TensorMultiplyScalar(_bRealGradient!, negLR));
-        _bImag = Engine.TensorAdd(_bImag, Engine.TensorMultiplyScalar(_bImagGradient!, negLR));
-        _cReal = Engine.TensorAdd(_cReal, Engine.TensorMultiplyScalar(_cRealGradient!, negLR));
-        _cImag = Engine.TensorAdd(_cImag, Engine.TensorMultiplyScalar(_cImagGradient!, negLR));
-        _dParam = Engine.TensorAdd(_dParam, Engine.TensorMultiplyScalar(_dParamGradient!, negLR));
-        _logDelta = Engine.TensorAdd(_logDelta, Engine.TensorMultiplyScalar(_logDeltaGradient!, negLR));
-        _inputProjectionWeights = Engine.TensorAdd(_inputProjectionWeights,
+        Engine.TensorAddInPlace(_aReal, Engine.TensorMultiplyScalar(_aRealGradient, negLR));
+        Engine.TensorAddInPlace(_aImag, Engine.TensorMultiplyScalar(_aImagGradient!, negLR));
+        Engine.TensorAddInPlace(_bReal, Engine.TensorMultiplyScalar(_bRealGradient!, negLR));
+        Engine.TensorAddInPlace(_bImag, Engine.TensorMultiplyScalar(_bImagGradient!, negLR));
+        Engine.TensorAddInPlace(_cReal, Engine.TensorMultiplyScalar(_cRealGradient!, negLR));
+        Engine.TensorAddInPlace(_cImag, Engine.TensorMultiplyScalar(_cImagGradient!, negLR));
+        Engine.TensorAddInPlace(_dParam, Engine.TensorMultiplyScalar(_dParamGradient!, negLR));
+        Engine.TensorAddInPlace(_logDelta, Engine.TensorMultiplyScalar(_logDeltaGradient!, negLR));
+        Engine.TensorAddInPlace(_inputProjectionWeights,
             Engine.TensorMultiplyScalar(_inputProjectionWeightsGradient!, negLR));
-        _inputProjectionBias = Engine.TensorAdd(_inputProjectionBias,
+        Engine.TensorAddInPlace(_inputProjectionBias,
             Engine.TensorMultiplyScalar(_inputProjectionBiasGradient!, negLR));
-        _outputProjectionWeights = Engine.TensorAdd(_outputProjectionWeights,
+        Engine.TensorAddInPlace(_outputProjectionWeights,
             Engine.TensorMultiplyScalar(_outputProjectionWeightsGradient!, negLR));
-        _outputProjectionBias = Engine.TensorAdd(_outputProjectionBias,
+        Engine.TensorAddInPlace(_outputProjectionBias,
             Engine.TensorMultiplyScalar(_outputProjectionBiasGradient!, negLR));
 
         // Register trainable parameters for tape-based autodiff

--- a/src/NeuralNetworks/Layers/SSM/TTTLayer.cs
+++ b/src/NeuralNetworks/Layers/SSM/TTTLayer.cs
@@ -690,20 +690,20 @@ public partial class TTTLayer<T> : LayerBase<T>, IShapeContract
             throw new InvalidOperationException("Backward pass must be called before updating parameters.");
 
         T negLR = NumOps.Negate(learningRate);
-        _queryWeights = Engine.TensorAdd(_queryWeights, Engine.TensorMultiplyScalar(_queryWeightsGradient, negLR));
-        _queryBias = Engine.TensorAdd(_queryBias, Engine.TensorMultiplyScalar(_queryBiasGradient!, negLR));
-        _keyWeights = Engine.TensorAdd(_keyWeights, Engine.TensorMultiplyScalar(_keyWeightsGradient!, negLR));
-        _keyBias = Engine.TensorAdd(_keyBias, Engine.TensorMultiplyScalar(_keyBiasGradient!, negLR));
-        _valueWeights = Engine.TensorAdd(_valueWeights, Engine.TensorMultiplyScalar(_valueWeightsGradient!, negLR));
-        _valueBias = Engine.TensorAdd(_valueBias, Engine.TensorMultiplyScalar(_valueBiasGradient!, negLR));
-        _innerWeightsInit = Engine.TensorAdd(_innerWeightsInit, Engine.TensorMultiplyScalar(_innerWeightsInitGradient!, negLR));
-        _etaScale = Engine.TensorAdd(_etaScale, Engine.TensorMultiplyScalar(_etaScaleGradient!, negLR));
-        _outputGateWeights = Engine.TensorAdd(_outputGateWeights, Engine.TensorMultiplyScalar(_outputGateWeightsGradient!, negLR));
-        _outputGateBias = Engine.TensorAdd(_outputGateBias, Engine.TensorMultiplyScalar(_outputGateBiasGradient!, negLR));
-        _outputProjectionWeights = Engine.TensorAdd(_outputProjectionWeights, Engine.TensorMultiplyScalar(_outputProjectionWeightsGradient!, negLR));
-        _outputProjectionBias = Engine.TensorAdd(_outputProjectionBias, Engine.TensorMultiplyScalar(_outputProjectionBiasGradient!, negLR));
-        _lnGamma = Engine.TensorAdd(_lnGamma, Engine.TensorMultiplyScalar(_lnGammaGradient!, negLR));
-        _lnBeta = Engine.TensorAdd(_lnBeta, Engine.TensorMultiplyScalar(_lnBetaGradient!, negLR));
+        Engine.TensorAddInPlace(_queryWeights, Engine.TensorMultiplyScalar(_queryWeightsGradient, negLR));
+        Engine.TensorAddInPlace(_queryBias, Engine.TensorMultiplyScalar(_queryBiasGradient!, negLR));
+        Engine.TensorAddInPlace(_keyWeights, Engine.TensorMultiplyScalar(_keyWeightsGradient!, negLR));
+        Engine.TensorAddInPlace(_keyBias, Engine.TensorMultiplyScalar(_keyBiasGradient!, negLR));
+        Engine.TensorAddInPlace(_valueWeights, Engine.TensorMultiplyScalar(_valueWeightsGradient!, negLR));
+        Engine.TensorAddInPlace(_valueBias, Engine.TensorMultiplyScalar(_valueBiasGradient!, negLR));
+        Engine.TensorAddInPlace(_innerWeightsInit, Engine.TensorMultiplyScalar(_innerWeightsInitGradient!, negLR));
+        Engine.TensorAddInPlace(_etaScale, Engine.TensorMultiplyScalar(_etaScaleGradient!, negLR));
+        Engine.TensorAddInPlace(_outputGateWeights, Engine.TensorMultiplyScalar(_outputGateWeightsGradient!, negLR));
+        Engine.TensorAddInPlace(_outputGateBias, Engine.TensorMultiplyScalar(_outputGateBiasGradient!, negLR));
+        Engine.TensorAddInPlace(_outputProjectionWeights, Engine.TensorMultiplyScalar(_outputProjectionWeightsGradient!, negLR));
+        Engine.TensorAddInPlace(_outputProjectionBias, Engine.TensorMultiplyScalar(_outputProjectionBiasGradient!, negLR));
+        Engine.TensorAddInPlace(_lnGamma, Engine.TensorMultiplyScalar(_lnGammaGradient!, negLR));
+        Engine.TensorAddInPlace(_lnBeta, Engine.TensorMultiplyScalar(_lnBetaGradient!, negLR));
 
         // Register trainable parameters for tape-based autodiff
         RegisterTrainableParameter(_queryWeights, PersistentTensorRole.Weights);

--- a/src/NeuralNetworks/Layers/SSM/TransNormerLLMLayer.cs
+++ b/src/NeuralNetworks/Layers/SSM/TransNormerLLMLayer.cs
@@ -504,17 +504,17 @@ public partial class TransNormerLLMLayer<T> : LayerBase<T>, IShapeContract
             throw new InvalidOperationException("Backward pass must be called before updating parameters.");
 
         T negLR = NumOps.Negate(learningRate);
-        _queryWeights = Engine.TensorAdd(_queryWeights, Engine.TensorMultiplyScalar(_queryWeightsGradient, negLR));
-        _keyWeights = Engine.TensorAdd(_keyWeights, Engine.TensorMultiplyScalar(_keyWeightsGradient!, negLR));
-        _valueWeights = Engine.TensorAdd(_valueWeights, Engine.TensorMultiplyScalar(_valueWeightsGradient!, negLR));
-        _queryNormScale = Engine.TensorAdd(_queryNormScale, Engine.TensorMultiplyScalar(_queryNormScaleGradient!, negLR));
-        _keyNormScale = Engine.TensorAdd(_keyNormScale, Engine.TensorMultiplyScalar(_keyNormScaleGradient!, negLR));
-        _gammas = Engine.TensorAdd(_gammas, Engine.TensorMultiplyScalar(_gammasGradient!, negLR));
-        _outputNormScale = Engine.TensorAdd(_outputNormScale, Engine.TensorMultiplyScalar(_outputNormScaleGradient!, negLR));
-        _outputGateWeights = Engine.TensorAdd(_outputGateWeights, Engine.TensorMultiplyScalar(_outputGateWeightsGradient!, negLR));
-        _outputGateBias = Engine.TensorAdd(_outputGateBias, Engine.TensorMultiplyScalar(_outputGateBiasGradient!, negLR));
-        _outputProjectionWeights = Engine.TensorAdd(_outputProjectionWeights, Engine.TensorMultiplyScalar(_outputProjectionWeightsGradient!, negLR));
-        _outputProjectionBias = Engine.TensorAdd(_outputProjectionBias, Engine.TensorMultiplyScalar(_outputProjectionBiasGradient!, negLR));
+        Engine.TensorAddInPlace(_queryWeights, Engine.TensorMultiplyScalar(_queryWeightsGradient, negLR));
+        Engine.TensorAddInPlace(_keyWeights, Engine.TensorMultiplyScalar(_keyWeightsGradient!, negLR));
+        Engine.TensorAddInPlace(_valueWeights, Engine.TensorMultiplyScalar(_valueWeightsGradient!, negLR));
+        Engine.TensorAddInPlace(_queryNormScale, Engine.TensorMultiplyScalar(_queryNormScaleGradient!, negLR));
+        Engine.TensorAddInPlace(_keyNormScale, Engine.TensorMultiplyScalar(_keyNormScaleGradient!, negLR));
+        Engine.TensorAddInPlace(_gammas, Engine.TensorMultiplyScalar(_gammasGradient!, negLR));
+        Engine.TensorAddInPlace(_outputNormScale, Engine.TensorMultiplyScalar(_outputNormScaleGradient!, negLR));
+        Engine.TensorAddInPlace(_outputGateWeights, Engine.TensorMultiplyScalar(_outputGateWeightsGradient!, negLR));
+        Engine.TensorAddInPlace(_outputGateBias, Engine.TensorMultiplyScalar(_outputGateBiasGradient!, negLR));
+        Engine.TensorAddInPlace(_outputProjectionWeights, Engine.TensorMultiplyScalar(_outputProjectionWeightsGradient!, negLR));
+        Engine.TensorAddInPlace(_outputProjectionBias, Engine.TensorMultiplyScalar(_outputProjectionBiasGradient!, negLR));
 
         // Clamp gammas to valid range
         for (int h = 0; h < _numHeads; h++)

--- a/src/NeuralNetworks/Layers/SeparableConvolutionalLayer.cs
+++ b/src/NeuralNetworks/Layers/SeparableConvolutionalLayer.cs
@@ -795,24 +795,27 @@ public partial class SeparableConvolutionalLayer<T> : LayerBase<T>, IShapeContra
         // Update depthwise kernels using Engine operations
         var dwL2 = Engine.TensorMultiplyScalar(_depthwiseKernels, l2RegularizationFactor);
         var dwGradWithL2 = Engine.TensorAdd(_depthwiseKernelsGradient, dwL2);
-        _depthwiseKernelsVelocity = Engine.TensorAdd(
-            Engine.TensorMultiplyScalar(_depthwiseKernelsVelocity, momentum),
-            Engine.TensorMultiplyScalar(dwGradWithL2, learningRate));
-        _depthwiseKernels = Engine.TensorSubtract(_depthwiseKernels, _depthwiseKernelsVelocity);
+        // In-place: momentum state must keep its own persistent storage. Rebinding the field to
+        // an Engine result hands it arena scratch that is recycled before the next step reads it.
+        Engine.TensorMultiplyScalarInPlace(_depthwiseKernelsVelocity, momentum);
+        Engine.TensorAddInPlace(_depthwiseKernelsVelocity, Engine.TensorMultiplyScalar(dwGradWithL2, learningRate));
+        Engine.TensorSubtractInPlace(_depthwiseKernels, _depthwiseKernelsVelocity);
 
         // Update pointwise kernels using Engine operations
         var pwL2 = Engine.TensorMultiplyScalar(_pointwiseKernels, l2RegularizationFactor);
         var pwGradWithL2 = Engine.TensorAdd(_pointwiseKernelsGradient, pwL2);
-        _pointwiseKernelsVelocity = Engine.TensorAdd(
-            Engine.TensorMultiplyScalar(_pointwiseKernelsVelocity, momentum),
-            Engine.TensorMultiplyScalar(pwGradWithL2, learningRate));
-        _pointwiseKernels = Engine.TensorSubtract(_pointwiseKernels, _pointwiseKernelsVelocity);
+        // In-place: momentum state must keep its own persistent storage. Rebinding the field to
+        // an Engine result hands it arena scratch that is recycled before the next step reads it.
+        Engine.TensorMultiplyScalarInPlace(_pointwiseKernelsVelocity, momentum);
+        Engine.TensorAddInPlace(_pointwiseKernelsVelocity, Engine.TensorMultiplyScalar(pwGradWithL2, learningRate));
+        Engine.TensorSubtractInPlace(_pointwiseKernels, _pointwiseKernelsVelocity);
 
         // Update biases using Engine operations (no L2 on biases)
-        _biasesVelocity = Engine.TensorAdd(
-            Engine.TensorMultiplyScalar(_biasesVelocity, momentum),
-            Engine.TensorMultiplyScalar(_biasesGradient, learningRate));
-        _biases = Engine.TensorSubtract(_biases, _biasesVelocity);
+        // In-place: momentum state must keep its own persistent storage. Rebinding the field to
+        // an Engine result hands it arena scratch that is recycled before the next step reads it.
+        Engine.TensorMultiplyScalarInPlace(_biasesVelocity, momentum);
+        Engine.TensorAddInPlace(_biasesVelocity, Engine.TensorMultiplyScalar(_biasesGradient, learningRate));
+        Engine.TensorSubtractInPlace(_biases, _biasesVelocity);
 
         // Invalidate GPU cache after parameter update
         Engine.InvalidatePersistentTensor(_depthwiseKernels);

--- a/src/NeuralNetworks/Layers/SpatialPoolerLayer.cs
+++ b/src/NeuralNetworks/Layers/SpatialPoolerLayer.cs
@@ -634,7 +634,7 @@ public partial class SpatialPoolerLayer<T> : LayerBase<T>, IShapeContract
         if (_connectionsGradient != null)
         {
             var delta = Engine.TensorMultiplyScalar(_connectionsGradient, learningRate);
-            Connections = Engine.TensorSubtract(Connections, delta);
+            Engine.TensorSubtractInPlace(Connections, delta);
 
             // Maintain connection constraints
             NormalizeConnections();

--- a/src/NeuralNetworks/Layers/SpatialTransformerLayer.cs
+++ b/src/NeuralNetworks/Layers/SpatialTransformerLayer.cs
@@ -919,16 +919,16 @@ public partial class SpatialTransformerLayer<T> : LayerBase<T>, IAuxiliaryLossLa
 
         // Update using Engine operations: w = w - lr * gradient
         var scaledW1Grad = Engine.TensorMultiplyScalar(_localizationWeights1Gradient, learningRate);
-        _localizationWeights1 = Engine.TensorSubtract(_localizationWeights1, scaledW1Grad);
+        Engine.TensorSubtractInPlace(_localizationWeights1, scaledW1Grad);
 
         var scaledB1Grad = Engine.TensorMultiplyScalar(_localizationBias1Gradient, learningRate);
-        _localizationBias1 = Engine.TensorSubtract(_localizationBias1, scaledB1Grad);
+        Engine.TensorSubtractInPlace(_localizationBias1, scaledB1Grad);
 
         var scaledW2Grad = Engine.TensorMultiplyScalar(_localizationWeights2Gradient, learningRate);
-        _localizationWeights2 = Engine.TensorSubtract(_localizationWeights2, scaledW2Grad);
+        Engine.TensorSubtractInPlace(_localizationWeights2, scaledW2Grad);
 
         var scaledB2Grad = Engine.TensorMultiplyScalar(_localizationBias2Gradient, learningRate);
-        _localizationBias2 = Engine.TensorSubtract(_localizationBias2, scaledB2Grad);
+        Engine.TensorSubtractInPlace(_localizationBias2, scaledB2Grad);
     }
 
     /// <summary>

--- a/src/NeuralNetworks/Layers/SpikingLayer.cs
+++ b/src/NeuralNetworks/Layers/SpikingLayer.cs
@@ -1636,14 +1636,14 @@ public partial class SpikingLayer<T> : LayerBase<T>, IShapeContract
     {
         // Update weights using Engine operations: w = w - lr * gradient
         var scaledWeightGradients = Engine.TensorMultiplyScalar(_weightGradients, learningRate);
-        _weights = Engine.TensorSubtract(_weights, scaledWeightGradients);
+        Engine.TensorSubtractInPlace(_weights, scaledWeightGradients);
 
         // Reset weight gradients for next batch
         _weightGradients.Fill(NumOps.Zero);
 
         // Update biases using Engine operations: b = b - lr * gradient
         var scaledBiasGradients = Engine.TensorMultiplyScalar(_biasGradients, learningRate);
-        _bias = Engine.TensorSubtract(_bias, scaledBiasGradients);
+        Engine.TensorSubtractInPlace(_bias, scaledBiasGradients);
 
         // Reset bias gradients for next batch
         _biasGradients.Fill(NumOps.Zero);

--- a/src/NeuralNetworks/Layers/SpiralConvLayer.cs
+++ b/src/NeuralNetworks/Layers/SpiralConvLayer.cs
@@ -1006,10 +1006,10 @@ public partial class SpiralConvLayer<T> : LayerBase<T>, IShapeContract
             throw new InvalidOperationException("Backward pass must be called before updating parameters.");
 
         var scaledWeightGrad = Engine.TensorMultiplyScalar(_weightsGradient, learningRate);
-        _weights = Engine.TensorSubtract(_weights, scaledWeightGrad);
+        Engine.TensorSubtractInPlace(_weights, scaledWeightGrad);
 
         var scaledBiasGrad = Engine.TensorMultiplyScalar(_biasesGradient, learningRate);
-        _biases = Engine.TensorSubtract(_biases, scaledBiasGrad);
+        Engine.TensorSubtractInPlace(_biases, scaledBiasGrad);
     }
 
     /// <summary>

--- a/src/NeuralNetworks/Layers/SqueezeAndExcitationLayer.cs
+++ b/src/NeuralNetworks/Layers/SqueezeAndExcitationLayer.cs
@@ -1257,10 +1257,10 @@ public partial class SqueezeAndExcitationLayer<T> : LayerBase<T>, IAuxiliaryLoss
         var w2Update = Engine.TensorMultiplyScalar(_weights2Gradient, learningRate);
         var b2Update = Engine.TensorMultiplyScalar(_bias2Gradient, learningRate);
 
-        _weights1 = Engine.TensorSubtract(_weights1, w1Update);
-        _bias1 = Engine.TensorSubtract(_bias1, b1Update);
-        _weights2 = Engine.TensorSubtract(_weights2, w2Update);
-        _bias2 = Engine.TensorSubtract(_bias2, b2Update);
+        Engine.TensorSubtractInPlace(_weights1, w1Update);
+        Engine.TensorSubtractInPlace(_bias1, b1Update);
+        Engine.TensorSubtractInPlace(_weights2, w2Update);
+        Engine.TensorSubtractInPlace(_bias2, b2Update);
     }
 
     /// <summary>

--- a/src/NeuralNetworks/Layers/SubpixelConvolutionalLayer.cs
+++ b/src/NeuralNetworks/Layers/SubpixelConvolutionalLayer.cs
@@ -1073,23 +1073,26 @@ public partial class SubpixelConvolutionalLayer<T> : LayerBase<T>, IShapeContrac
         T oneMinusMomentum = NumOps.Subtract(NumOps.One, _momentumFactor);
 
         // Update kernel momentum: momentum = momentum_factor * momentum + (1 - momentum_factor) * gradient
-        _kernelMomentum = Engine.TensorAdd(
-            Engine.TensorMultiplyScalar(_kernelMomentum, _momentumFactor),
-            Engine.TensorMultiplyScalar(_kernelGradients, oneMinusMomentum));
+        // In-place: see SeparableConvolutionalLayer. Momentum state is read on the NEXT step,
+        // so an arena-scratch buffer here corrupts the update rather than just the current value.
+        Engine.TensorMultiplyScalarInPlace(_kernelMomentum, _momentumFactor);
+        Engine.TensorAddInPlace(_kernelMomentum, Engine.TensorMultiplyScalar(_kernelGradients, oneMinusMomentum));
 
         // Update kernels with momentum and weight decay
         T lrTimesWd = NumOps.Multiply(learningRate, _weightDecay);
         var kernelUpdate = Engine.TensorMultiplyScalar(_kernelMomentum, learningRate);
         var weightDecayTerm = Engine.TensorMultiplyScalar(_kernels, lrTimesWd);
-        _kernels = Engine.TensorSubtract(Engine.TensorSubtract(_kernels, kernelUpdate), weightDecayTerm);
+        Engine.TensorSubtractInPlace(_kernels, kernelUpdate);
+        Engine.TensorSubtractInPlace(_kernels, weightDecayTerm);
 
         // Update bias momentum
-        _biasMomentum = Engine.TensorAdd(
-            Engine.TensorMultiplyScalar(_biasMomentum, _momentumFactor),
-            Engine.TensorMultiplyScalar(_biasGradients, oneMinusMomentum));
+        // In-place: see SeparableConvolutionalLayer. Momentum state is read on the NEXT step,
+        // so an arena-scratch buffer here corrupts the update rather than just the current value.
+        Engine.TensorMultiplyScalarInPlace(_biasMomentum, _momentumFactor);
+        Engine.TensorAddInPlace(_biasMomentum, Engine.TensorMultiplyScalar(_biasGradients, oneMinusMomentum));
 
         // Update biases with momentum (no weight decay for biases)
-        _biases = Engine.TensorSubtract(_biases, Engine.TensorMultiplyScalar(_biasMomentum, learningRate));
+        Engine.TensorSubtractInPlace(_biases, Engine.TensorMultiplyScalar(_biasMomentum, learningRate));
 
         // Invalidate GPU cache after parameter updates
         Engine.InvalidatePersistentTensor(_kernels);

--- a/src/NeuralNetworks/Layers/SynapticPlasticityLayer.cs
+++ b/src/NeuralNetworks/Layers/SynapticPlasticityLayer.cs
@@ -235,7 +235,7 @@ public partial class SynapticPlasticityLayer<T> : LayerBase<T>, IShapeContract
     /// were active in the recent past.
     /// </para>
     /// </remarks>
-    [AiDotNet.Attributes.TrainableParameter]
+    [Buffer]
     private Tensor<T> _presynapticTraces;
 
     /// <summary>
@@ -257,7 +257,7 @@ public partial class SynapticPlasticityLayer<T> : LayerBase<T>, IShapeContract
     /// input and output activity, which is crucial for spike-timing-dependent plasticity.
     /// </para>
     /// </remarks>
-    [AiDotNet.Attributes.TrainableParameter]
+    [Buffer]
     private Tensor<T> _postsynapticTraces;
 
     /// <summary>
@@ -279,7 +279,7 @@ public partial class SynapticPlasticityLayer<T> : LayerBase<T>, IShapeContract
     /// version of how biological neurons generate electrical impulses when sufficiently activated.
     /// </para>
     /// </remarks>
-    [AiDotNet.Attributes.TrainableParameter]
+    [Buffer]
     private Tensor<T> _presynapticSpikes;
 
     /// <summary>
@@ -301,7 +301,7 @@ public partial class SynapticPlasticityLayer<T> : LayerBase<T>, IShapeContract
     /// timing-dependent learning rules.
     /// </para>
     /// </remarks>
-    [AiDotNet.Attributes.TrainableParameter]
+    [Buffer]
     private Tensor<T> _postsynapticSpikes;
 
     /// <summary>
@@ -336,10 +336,13 @@ public partial class SynapticPlasticityLayer<T> : LayerBase<T>, IShapeContract
     private Tensor<T>? _lastInputGpu;
     [Scratch]
     private Tensor<T>? _lastOutputGpu;
+    [Scratch]
     private Tensor<T>? _presynapticTracesGpu;
+    [Scratch]
     private Tensor<T>? _postsynapticTracesGpu;
+    [Scratch]
     private Tensor<T>? _presynapticSpikesGpu;
-    [AiDotNet.Attributes.TrainableParameter]
+    [Scratch]
     private Tensor<T>? _postsynapticSpikesGpu;
 
     /// <inheritdoc/>
@@ -369,7 +372,7 @@ public partial class SynapticPlasticityLayer<T> : LayerBase<T>, IShapeContract
 
     public override void UpdateParameters(T learningRate)
     {
-        if (Engine is DirectGpuTensorEngine gpuEngine && _lastInputGpu != null)
+        if (Engine is DirectGpuTensorEngine gpuEngine && _lastInputGpu is { } lastInputGpu)
         {
             int size = GetInputShape()[0];
             float decay = (float)_traceDecay;
@@ -383,17 +386,28 @@ public partial class SynapticPlasticityLayer<T> : LayerBase<T>, IShapeContract
                 _postsynapticSpikesGpu = gpuEngine.ZerosGpu<T>([size]);
             }
 
+            var presynapticTracesGpu = _presynapticTracesGpu
+                ?? throw new InvalidOperationException("Presynaptic trace storage was not initialized.");
+            var postsynapticTracesGpu = _postsynapticTracesGpu
+                ?? throw new InvalidOperationException("Postsynaptic trace storage was not initialized.");
+            var presynapticSpikesGpu = _presynapticSpikesGpu
+                ?? throw new InvalidOperationException("Presynaptic spike storage was not initialized.");
+            var postsynapticSpikesGpu = _postsynapticSpikesGpu
+                ?? throw new InvalidOperationException("Postsynaptic spike storage was not initialized.");
+            var lastOutputGpu = _lastOutputGpu
+                ?? throw new InvalidOperationException("GPU forward output is unavailable.");
+
             // Update traces and detect spikes directly on GPU
-            gpuEngine.UpdateTracesGpu(_presynapticTracesGpu!, _presynapticSpikesGpu!, _lastInputGpu, decay, threshold);
-            gpuEngine.UpdateTracesGpu(_postsynapticTracesGpu!, _postsynapticSpikesGpu!, _lastOutputGpu!, decay, threshold);
+            gpuEngine.UpdateTracesGpu(presynapticTracesGpu, presynapticSpikesGpu, lastInputGpu, decay, threshold);
+            gpuEngine.UpdateTracesGpu(postsynapticTracesGpu, postsynapticSpikesGpu, lastOutputGpu, decay, threshold);
 
             // Execute STDP update kernel
             gpuEngine.StdpUpdateGpu(
                 _weights,
-                _presynapticTracesGpu!,
-                _postsynapticTracesGpu!,
-                _presynapticSpikesGpu!,
-                _postsynapticSpikesGpu!,
+                presynapticTracesGpu,
+                postsynapticTracesGpu,
+                presynapticSpikesGpu,
+                postsynapticSpikesGpu,
                 _stdpLtpRate, _stdpLtdRate, _homeostasisRate,
                 _minWeight, _maxWeight);
         }

--- a/src/NeuralNetworks/Layers/TimeEmbeddingLayer.cs
+++ b/src/NeuralNetworks/Layers/TimeEmbeddingLayer.cs
@@ -432,10 +432,10 @@ public partial class TimeEmbeddingLayer<T> : LayerBase<T>, IShapeContract
             _linear2WeightsGradient == null || _linear2BiasGradient == null)
             throw new InvalidOperationException("Backward pass must be called before updating parameters.");
 
-        _linear1Weights = Engine.TensorSubtract(_linear1Weights, Engine.TensorMultiplyScalar(_linear1WeightsGradient, learningRate));
-        _linear1Bias = Engine.TensorSubtract(_linear1Bias, Engine.TensorMultiplyScalar(_linear1BiasGradient, learningRate));
-        _linear2Weights = Engine.TensorSubtract(_linear2Weights, Engine.TensorMultiplyScalar(_linear2WeightsGradient, learningRate));
-        _linear2Bias = Engine.TensorSubtract(_linear2Bias, Engine.TensorMultiplyScalar(_linear2BiasGradient, learningRate));
+        Engine.TensorSubtractInPlace(_linear1Weights, Engine.TensorMultiplyScalar(_linear1WeightsGradient, learningRate));
+        Engine.TensorSubtractInPlace(_linear1Bias, Engine.TensorMultiplyScalar(_linear1BiasGradient, learningRate));
+        Engine.TensorSubtractInPlace(_linear2Weights, Engine.TensorMultiplyScalar(_linear2WeightsGradient, learningRate));
+        Engine.TensorSubtractInPlace(_linear2Bias, Engine.TensorMultiplyScalar(_linear2BiasGradient, learningRate));
 
         // Notify GPU that tensor data has changed
         Engine.InvalidatePersistentTensor(_linear1Weights);

--- a/src/NeuralNetworks/Tabular/CLSToken.cs
+++ b/src/NeuralNetworks/Tabular/CLSToken.cs
@@ -200,7 +200,7 @@ public partial class CLSToken<T>
     /// <param name="learningRate">The learning rate.</param>
     public void UpdateParameters(T learningRate)
     {
-        _clsEmbedding = Engine.TensorSubtract(_clsEmbedding,
+        Engine.TensorSubtractInPlace(_clsEmbedding,
             Engine.TensorMultiplyScalar(_clsGradient, learningRate));
     }
 

--- a/src/NeuralNetworks/Tabular/ColumnEmbedding.cs
+++ b/src/NeuralNetworks/Tabular/ColumnEmbedding.cs
@@ -190,7 +190,7 @@ public partial class ColumnEmbedding<T>
     {
         if (!_learnable) return;
 
-        _embeddings = Engine.TensorSubtract(_embeddings,
+        Engine.TensorSubtractInPlace(_embeddings,
             Engine.TensorMultiplyScalar(_embeddingGradients, learningRate));
     }
 

--- a/src/NeuralNetworks/Tabular/ContrastivePretraining.cs
+++ b/src/NeuralNetworks/Tabular/ContrastivePretraining.cs
@@ -396,9 +396,9 @@ public partial class ContrastivePretraining<T>
                 $"gradBias length ({gradBias.Length}) does not match projection bias length ({_projectionBias.Length}).");
         }
 
-        _projectionWeights = Engine.TensorSubtract(_projectionWeights,
+        Engine.TensorSubtractInPlace(_projectionWeights,
             Engine.TensorMultiplyScalar(gradWeights, learningRate));
-        _projectionBias = Engine.TensorSubtract(_projectionBias,
+        Engine.TensorSubtractInPlace(_projectionBias,
             Engine.TensorMultiplyScalar(gradBias, learningRate));
     }
 

--- a/src/NeuralNetworks/Tabular/TabTransformerBase.cs
+++ b/src/NeuralNetworks/Tabular/TabTransformerBase.cs
@@ -399,7 +399,7 @@ public abstract partial class TabTransformerBase<T> : IParameterSource<T>
         // Update column embeddings
         if (_columnEmbeddings != null && _columnEmbeddingsGrad != null)
         {
-            _columnEmbeddings = Engine.TensorSubtract(_columnEmbeddings,
+            Engine.TensorSubtractInPlace(_columnEmbeddings,
                 Engine.TensorMultiplyScalar(_columnEmbeddingsGrad, learningRate));
         }
 

--- a/src/NeuralRadianceFields/Models/GaussianSplatting.cs
+++ b/src/NeuralRadianceFields/Models/GaussianSplatting.cs
@@ -3351,6 +3351,16 @@ public partial class GaussianSplatting<T> : AiDotNet.NeuralNetworks.VectorModelL
         }
 
         MarkSpatialIndexDirty();
+
+        // Densification is a STRUCTURAL parameter change: this model's parameters are the
+        // Gaussians themselves (GetExtraTrainableTensors enumerates _gaussians), so pruning or
+        // splitting resizes the parameter surface exactly the way adding or removing a layer
+        // does. Without this the cached ParameterLayoutSnapshot keeps describing the previous
+        // cloud, so ParameterCount reports the pre-densification size while ApplyImageGradients
+        // publishes a gradient sized from the live list — and PublishFlatParameterGradients
+        // throws "Flat gradient length (224) must match ParameterCount (112)" on the very next
+        // training step. MarkSpatialIndexDirty above only invalidates the renderer's index.
+        InvalidateParameterCountCache();
     }
 
     protected override Tensor<T> PredictCore(Tensor<T> input)

--- a/src/NeuralRadianceFields/Models/GaussianSplatting.cs
+++ b/src/NeuralRadianceFields/Models/GaussianSplatting.cs
@@ -3261,6 +3261,10 @@ public partial class GaussianSplatting<T> : AiDotNet.NeuralNetworks.VectorModelL
         int cap = EffectiveMaxGaussianCount;
         if (_gaussians.Count >= cap)
         {
+            // Pruning above may have changed both the renderer's integer indices and the model's
+            // parameter surface even though no split can be added at the cap.
+            MarkSpatialIndexDirty();
+            InvalidateParameterCountCache();
             return;
         }
 

--- a/src/TimeSeries/AnomalyDetection/DeepANT.cs
+++ b/src/TimeSeries/AnomalyDetection/DeepANT.cs
@@ -651,8 +651,8 @@ internal partial class ConvLayerTensor<T> : NeuralNetworks.Layers.LayerBase<T>, 
     public override void UpdateParameters(T learningRate)
     {
         if (_kernelGradients is null || _biasGradients is null) return;
-        _kernels = Engine.TensorSubtract(_kernels, Engine.TensorMultiplyScalar<T>(_kernelGradients, learningRate));
-        _biases = Engine.TensorSubtract(_biases, Engine.TensorMultiplyScalar<T>(_biasGradients, learningRate));
+        Engine.TensorSubtractInPlace(_kernels, Engine.TensorMultiplyScalar<T>(_kernelGradients, learningRate));
+        Engine.TensorSubtractInPlace(_biases, Engine.TensorMultiplyScalar<T>(_biasGradients, learningRate));
         _kernelGradients = null;
         _biasGradients = null;
     }

--- a/tests/AiDotNet.Tests/Generators/ParameterUpdateInPlaceAnalyzerTests.cs
+++ b/tests/AiDotNet.Tests/Generators/ParameterUpdateInPlaceAnalyzerTests.cs
@@ -1,0 +1,195 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Xunit;
+
+namespace AiDotNet.Tests.Generators;
+
+/// <summary>Locks AIDN100 to current-instance trainable storage, including container slots.</summary>
+public sealed class ParameterUpdateInPlaceAnalyzerTests
+{
+    private const string Infrastructure = @"
+namespace AiDotNet.Attributes
+{
+    using System;
+    [AttributeUsage(AttributeTargets.Field)] public sealed class TrainableParameterAttribute : Attribute { }
+    [AttributeUsage(AttributeTargets.Field)] public sealed class FittedParameterAttribute : Attribute { }
+    [AttributeUsage(AttributeTargets.Field)] public sealed class FrozenParameterAttribute : Attribute { }
+    [AttributeUsage(AttributeTargets.Field)] public sealed class BufferAttribute : Attribute { }
+    [AttributeUsage(AttributeTargets.Field)] public sealed class ScratchAttribute : Attribute { }
+    [AttributeUsage(AttributeTargets.Field)] public sealed class ExternalStateAttribute : Attribute { }
+}
+public enum ParameterSlotRole { Trainable, LearnedState, Frozen, Buffer, Scratch, Alias, External }
+public sealed class Tensor<T> { }
+public sealed class TensorEngine
+{
+    public Tensor<T> TensorSubtract<T>(Tensor<T> left, Tensor<T> right) => left;
+}
+public abstract class LayerBase
+{
+    protected TensorEngine Engine { get; } = new TensorEngine();
+    protected void RegisterTrainableParameter(object value) { }
+    protected void RegisterBuffer(object value) { }
+    protected void RegisterParameterComponent(object value, ParameterSlotRole role) { }
+}";
+
+    private static ImmutableArray<MetadataReference> BaseReferences()
+    {
+        var references = new List<MetadataReference>();
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies())
+        {
+            if (assembly.IsDynamic || string.IsNullOrEmpty(assembly.Location) || !seen.Add(assembly.Location))
+                continue;
+            references.Add(MetadataReference.CreateFromFile(assembly.Location));
+        }
+        return references.ToImmutableArray();
+    }
+
+    private static async Task<ImmutableArray<Diagnostic>> RunAsync(string source)
+    {
+        var compilation = CSharpCompilation.Create(
+            "AiDotNet",
+            new[] { CSharpSyntaxTree.ParseText(Infrastructure), CSharpSyntaxTree.ParseText(source) },
+            BaseReferences(),
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+        return await compilation.WithAnalyzers(
+                ImmutableArray.Create<DiagnosticAnalyzer>(
+                    new AiDotNet.Generators.ParameterUpdateInPlaceAnalyzer()))
+            .GetAnalyzerDiagnosticsAsync();
+    }
+
+    [Fact]
+    public async Task CurrentInstanceTrainableField_IsRejected()
+    {
+        const string source = @"
+using AiDotNet.Attributes;
+public sealed class Subject : LayerBase
+{
+    [TrainableParameter] private Tensor<double> _weight = new Tensor<double>();
+    private Tensor<double> _gradient = new Tensor<double>();
+    public void UpdateParameters() => _weight = Engine.TensorSubtract(_weight, _gradient);
+}";
+
+        var diagnostic = Assert.Single((await RunAsync(source)).Where(item => item.Id == "AIDN100"));
+        Assert.Contains("_weight", diagnostic.GetMessage(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task TrainableArrayListAndDictionaryElements_AreRejected()
+    {
+        const string source = @"
+using System.Collections.Generic;
+using AiDotNet.Attributes;
+public sealed class Subject : LayerBase
+{
+    [TrainableParameter] private Tensor<double>[] _array = { new Tensor<double>() };
+    [TrainableParameter] private List<Tensor<double>> _list = new List<Tensor<double>> { new Tensor<double>() };
+    [TrainableParameter] private Dictionary<string, Tensor<double>> _map =
+        new Dictionary<string, Tensor<double>> { [""x""] = new Tensor<double>() };
+    private Tensor<double> _gradient = new Tensor<double>();
+
+    public void UpdateParameters()
+    {
+        _array[0] = Engine.TensorSubtract(_array[0], _gradient);
+        this._list[0] = Engine.TensorSubtract(_list[0], _gradient);
+        _map[""x""] = Engine.TensorSubtract(_map[""x""], _gradient);
+    }
+}";
+
+        Assert.Equal(3, (await RunAsync(source)).Count(item => item.Id == "AIDN100"));
+    }
+
+    [Fact]
+    public async Task ManuallyRegisteredTrainableContainer_IsRejected()
+    {
+        const string source = @"
+using System.Collections.Generic;
+public sealed class Subject : LayerBase
+{
+    private Dictionary<string, Tensor<double>> _map =
+        new Dictionary<string, Tensor<double>> { [""x""] = new Tensor<double>() };
+    private Tensor<double> _gradient = new Tensor<double>();
+    private void Configure() => RegisterTrainableParameter(_map);
+    public void UpdateParameters() =>
+        _map[""x""] = Engine.TensorSubtract(_map[""x""], _gradient);
+}";
+
+        Assert.Single((await RunAsync(source)).Where(item => item.Id == "AIDN100"));
+    }
+
+    [Fact]
+    public async Task UnrelatedNullGuard_DoesNotHideTrainableRebinding()
+    {
+        const string source = @"
+using AiDotNet.Attributes;
+public sealed class Subject : LayerBase
+{
+    [TrainableParameter] private Tensor<double> _weight = new Tensor<double>();
+    private Tensor<double> _gradient = new Tensor<double>();
+    private object _cache;
+    public void UpdateParameters()
+    {
+        if (_cache == null)
+            _weight = Engine.TensorSubtract(_weight, _gradient);
+    }
+}";
+
+        Assert.Single((await RunAsync(source)).Where(item => item.Id == "AIDN100"));
+    }
+
+    [Theory]
+    [InlineData("FittedParameter")]
+    [InlineData("FrozenParameter")]
+    [InlineData("Buffer")]
+    [InlineData("Scratch")]
+    [InlineData("ExternalState")]
+    public async Task NonTrainablePersistentOrScratchField_IsAllowed(string attribute)
+    {
+        string source = $@"
+using AiDotNet.Attributes;
+public sealed class Subject : LayerBase
+{{
+    [{attribute}] private Tensor<double> _state = new Tensor<double>();
+    private Tensor<double> _gradient = new Tensor<double>();
+    public void UpdateParameters() => _state = Engine.TensorSubtract(_state, _gradient);
+}}";
+
+        Assert.Empty((await RunAsync(source)).Where(item => item.Id == "AIDN100"));
+    }
+
+    [Fact]
+    public async Task AnotherInstancesTrainableField_IsAllowed()
+    {
+        const string source = @"
+using AiDotNet.Attributes;
+public sealed class Subject : LayerBase
+{
+    [TrainableParameter] private Tensor<double> _weight = new Tensor<double>();
+    private Tensor<double> _gradient = new Tensor<double>();
+    public void UpdateParameters(Subject other) =>
+        other._weight = Engine.TensorSubtract(other._weight, _gradient);
+}";
+
+        Assert.Empty((await RunAsync(source)).Where(item => item.Id == "AIDN100"));
+    }
+
+    [Fact]
+    public async Task UnclassifiedField_IsAllowed()
+    {
+        const string source = @"
+public sealed class Subject : LayerBase
+{
+    private Tensor<double> _state = new Tensor<double>();
+    private Tensor<double> _gradient = new Tensor<double>();
+    public void UpdateParameters() => _state = Engine.TensorSubtract(_state, _gradient);
+}";
+
+        Assert.Empty((await RunAsync(source)).Where(item => item.Id == "AIDN100"));
+    }
+}

--- a/tests/AiDotNet.Tests/IntegrationTests/DistributedTraining/DistributedTrainingDeepMathIntegrationTests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/DistributedTraining/DistributedTrainingDeepMathIntegrationTests.cs
@@ -914,6 +914,72 @@ public class DistributedTrainingDeepMathIntegrationTests
                 Assert.Equal(rank0Params[i], results[rank][i], ZeroTol);
     }
 
+    /// <summary>
+    /// A collective's pending-consumer count, not the number of currently initialized backends,
+    /// owns its payload. Rank 0 may finish before a joining worker has initialized.
+    /// </summary>
+    [Fact(Timeout = 120000)]
+    public async Task InMemoryBackend_Broadcast_SurvivesRootShutdownBeforePeerInitializes()
+    {
+        await Task.Yield();
+        string envId = Guid.NewGuid().ToString("N");
+        try
+        {
+            var root = new InMemoryCommunicationBackend<double>(rank: 0, worldSize: 2, environmentId: envId);
+            root.Initialize();
+            var expected = new Vector<double>(new[] { 1.25, -2.5, 4.75 });
+            var rootResult = root.Broadcast(expected, root: 0);
+            root.Shutdown();
+
+            var peer = new InMemoryCommunicationBackend<double>(rank: 1, worldSize: 2, environmentId: envId);
+            peer.Initialize();
+            var peerResult = peer.Broadcast(new Vector<double>(expected.Length), root: 0);
+            peer.Shutdown();
+
+            Assert.Equal(expected.ToArray(), rootResult.ToArray());
+            Assert.Equal(expected.ToArray(), peerResult.ToArray());
+        }
+        finally
+        {
+            InMemoryCommunicationBackend<double>.ClearEnvironment(envId);
+        }
+    }
+
+    /// <summary>
+    /// Reusing a quiescent environment from a rank that already participated starts a new session;
+    /// an abandoned payload from the old session must not be delivered to the new session's peer.
+    /// </summary>
+    [Fact(Timeout = 120000)]
+    public async Task InMemoryBackend_NewSessionWithSameEnvironment_DiscardsAbandonedBroadcast()
+    {
+        await Task.Yield();
+        string envId = Guid.NewGuid().ToString("N");
+        try
+        {
+            var abandonedRoot = new InMemoryCommunicationBackend<double>(rank: 0, worldSize: 2, environmentId: envId);
+            abandonedRoot.Initialize();
+            _ = abandonedRoot.Broadcast(new Vector<double>(new[] { -10.0, -20.0 }), root: 0);
+            abandonedRoot.Shutdown();
+
+            var currentRoot = new InMemoryCommunicationBackend<double>(rank: 0, worldSize: 2, environmentId: envId);
+            currentRoot.Initialize();
+            var expected = new Vector<double>(new[] { 10.0, 20.0 });
+            _ = currentRoot.Broadcast(expected, root: 0);
+            currentRoot.Shutdown();
+
+            var currentPeer = new InMemoryCommunicationBackend<double>(rank: 1, worldSize: 2, environmentId: envId);
+            currentPeer.Initialize();
+            var peerResult = currentPeer.Broadcast(new Vector<double>(expected.Length), root: 0);
+            currentPeer.Shutdown();
+
+            Assert.Equal(expected.ToArray(), peerResult.ToArray());
+        }
+        finally
+        {
+            InMemoryCommunicationBackend<double>.ClearEnvironment(envId);
+        }
+    }
+
     // ---- Pure data-parallel (single-step gradient path) invariants --------------------------------
     // Every DP optimizer below now performs the paper-faithful per-step gradient hook (backward-only
     // ComputeGradients -> AllReduce(Average) -> single ApplyGradients from the original params), the SAME

--- a/tests/AiDotNet.Tests/IntegrationTests/Inference/DefaultInferenceOptimizationEngagementTests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/Inference/DefaultInferenceOptimizationEngagementTests.cs
@@ -1,0 +1,87 @@
+using AiDotNet.Configuration;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tests.IntegrationTests.Inference;
+
+/// <summary>
+/// Pins the default inference-optimization contract — #1632's first checklist item, which asked
+/// for a test "proving what actually engages when the builder is left alone".
+///
+/// #1632 catalogued the inference stack as dormant: <c>_inferenceOptimizationConfig</c> defaulted
+/// to <c>null</c>, so nothing engaged unless the caller opted in with
+/// <c>ConfigureInferenceOptimizations()</c>. That default has since been flipped, which is a
+/// silent, easily-reverted one-line change: setting it back to <c>null</c> would return the whole
+/// stack to dormant with no test failing anywhere. These tests are that guard.
+///
+/// <para><b>Scope, stated honestly.</b> This pins the CONFIGURATION contract — which optimizations
+/// the builder resolves when untouched, and that opting out still works. It does not assert that
+/// each component executes inside a forward pass; that needs per-component instrumentation and is
+/// tracked separately on #1632.</para>
+/// </summary>
+public class DefaultInferenceOptimizationEngagementTests
+{
+    private static InferenceOptimizationConfig? ResolveDefault()
+    {
+        var builder = new AiModelBuilder<double, Tensor<double>, Tensor<double>>();
+        var view = (IConfiguredView<double, Tensor<double>, Tensor<double>>)builder;
+        return view.ConfiguredInferenceOptimizations;
+    }
+
+    [Fact]
+    public void UntouchedBuilder_ResolvesAnInferenceConfig_RatherThanLeavingTheStackDormant()
+    {
+        // The regression this guards: AiModelBuilder.cs previously left this null, so every model
+        // ran with the entire built-and-verified inference stack switched off.
+        Assert.NotNull(ResolveDefault());
+    }
+
+    [Fact]
+    public void UntouchedBuilder_EngagesTheDocumentedOptimizationSet()
+    {
+        var config = ResolveDefault();
+        Assert.NotNull(config);
+
+        // What IS on by default.
+        Assert.True(config!.EnableKVCache, "KV cache should be on by default.");
+        Assert.True(config.EnablePagedKVCache, "Paged KV cache should be on by default.");
+        Assert.True(config.EnableFlashAttention, "Flash attention should be on by default.");
+        Assert.True(config.EnableLayerFusion, "Layer fusion should be on by default.");
+        Assert.True(config.EnableBatching, "Batching should be on by default.");
+
+        // What is deliberately NOT on by default. Speculative decoding needs a draft model, so
+        // enabling it implicitly would either fail or silently do nothing. Asserting the negative
+        // keeps the documented default honest — #1632 assumed the whole set was uniformly off,
+        // and the truth is that this one component alone stays opt-in.
+        Assert.NotNull(config.SpeculativeDecoding);
+        Assert.False(config.SpeculativeDecoding!.Enabled,
+            "Speculative decoding requires a caller-supplied draft model and stays opt-in.");
+    }
+
+    [Fact]
+    public void ExplicitConfiguration_StillOverridesTheDefault()
+    {
+        // Control arm. If the default were pinned but no longer overridable, the two assertions
+        // above could pass while ConfigureInferenceOptimizations had become a no-op — which is the
+        // exact bug class AIDN090/091 was added for (a Configure* that stores and never reads).
+        var builder = new AiModelBuilder<double, Tensor<double>, Tensor<double>>()
+            .ConfigureInferenceOptimizations(new InferenceOptimizationConfig
+            {
+                EnableKVCache = false,
+                EnablePagedKVCache = false,
+                EnableFlashAttention = false,
+                EnableLayerFusion = false,
+                EnableBatching = false,
+            });
+
+        var view = (IConfiguredView<double, Tensor<double>, Tensor<double>>)builder;
+        var config = view.ConfiguredInferenceOptimizations;
+
+        Assert.NotNull(config);
+        Assert.False(config!.EnableKVCache);
+        Assert.False(config.EnablePagedKVCache);
+        Assert.False(config.EnableFlashAttention);
+        Assert.False(config.EnableLayerFusion);
+        Assert.False(config.EnableBatching);
+    }
+}

--- a/tests/AiDotNet.Tests/IntegrationTests/NeuralRadianceFields/GaussianSplattingDensificationFiresDuringTrainingTests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/NeuralRadianceFields/GaussianSplattingDensificationFiresDuringTrainingTests.cs
@@ -1,0 +1,121 @@
+using AiDotNet.LinearAlgebra;
+using AiDotNet.Models.Options;
+using AiDotNet.NeuralRadianceFields.Data;
+using AiDotNet.NeuralRadianceFields.Models;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tests.IntegrationTests.NeuralRadianceFields;
+
+/// <summary>
+/// Regression test for #1835 — densification must actually FIRE during a real training run.
+///
+/// The existing coverage does not establish this:
+///   * <c>GaussianSplattingDensificationTests</c> drives the internal
+///     <c>RunDensifyAndPruneForTest</c> hook, so it proves the split/prune maths and the
+///     schedule-window gates, but not that the training loop ever calls them.
+///   * <c>ImageTrainingPathTests.GaussianSplatting_TrainOnImageBatch_ReturnsFiniteLoss</c>
+///     explicitly sets <c>EnableDensification = false</c>.
+///
+/// So densification could be wired, configurable, serialized and unit-tested while never
+/// running during training, and every existing test would still pass. This test closes that
+/// gap by training through the real image-space path and asserting the cloud changed size.
+/// </summary>
+public class GaussianSplattingDensificationFiresDuringTrainingTests
+{
+    private static ImageView<float>[] BuildViews(int count = 2, int height = 4, int width = 4)
+    {
+        var views = new ImageView<float>[count];
+        for (int v = 0; v < count; v++)
+        {
+            var photo = new float[height * width * 3];
+            for (int i = 0; i < photo.Length; i++)
+            {
+                // Non-uniform target so the photometric loss produces a real gradient signal.
+                photo[i] = (i % 7) / 7.0f;
+            }
+
+            var pose = new float[] { 0f, 0f, v * -1f };
+            var rotation = new Matrix<float>(3, 3);
+            rotation[0, 0] = 1f;
+            rotation[1, 1] = 1f;
+            rotation[2, 2] = 1f;
+
+            views[v] = new ImageView<float>(
+                new Tensor<float>([height, width, 3], new Vector<float>(photo)),
+                new Vector<float>(pose),
+                rotation,
+                focalLength: 0f);
+        }
+
+        return views;
+    }
+
+    [Fact]
+    public void TrainOnImageBatch_WithDensificationEnabled_MutatesTheGaussianCloud()
+    {
+        var model = new GaussianSplatting<float>(new GaussianSplattingOptions
+        {
+            ShDegree = 0,
+            EnableSpatialIndex = false,
+            EnableDensification = true,
+            MaxGaussians = 64,
+
+            // Explicit window so the run does not depend on the short-run auto-scaling that
+            // #1835 added — this test is about whether the loop fires, not about scheduling.
+            DensificationStartIteration = 1,
+            DensificationEndIteration = 10_000,
+            DensificationInterval = 1,
+
+            // Paper-realistic prune threshold (0.005, Kerbl et al.) so prune does NOT empty the
+            // cloud, paired with a near-zero split threshold so any real gradient triggers a split.
+            // An emptied cloud would be a fixture artifact, not evidence about the training loop.
+            OpacityPruneThreshold = 0.005,
+            GradientNormThreshold = 1e-9,
+        });
+
+        int startCount = model.GaussianCount;
+        Assert.True(startCount > 0, "Fixture must start with a non-empty cloud to be meaningful.");
+
+        var loader = ImageTrainingDataLoaders.FromViews(BuildViews(), seed: 17);
+        for (int step = 0; step < 8; step++)
+        {
+            model.TrainOnImageBatch(loader, raysPerBatch: 4, optimizerOptions: null);
+        }
+
+        // The invariant is that the cloud CHANGED — split may grow it, prune may shrink it,
+        // and the ordering under the MaxGaussians cap decides which wins. A count that never
+        // moved means DensifyAndPrune was never reached from the training loop.
+        Assert.NotEqual(startCount, model.GaussianCount);
+    }
+
+    [Fact]
+    public void TrainOnImageBatch_WithDensificationDisabled_LeavesTheCloudUntouched()
+    {
+        // Control arm. Identical to the test above except EnableDensification = false. If this
+        // ALSO changed the count, the assertion above would be measuring ordinary training
+        // churn rather than densification, and would not discriminate.
+        var model = new GaussianSplatting<float>(new GaussianSplattingOptions
+        {
+            ShDegree = 0,
+            EnableSpatialIndex = false,
+            EnableDensification = false,
+            MaxGaussians = 64,
+            DensificationStartIteration = 1,
+            DensificationEndIteration = 10_000,
+            DensificationInterval = 1,
+            OpacityPruneThreshold = 0.005,
+            GradientNormThreshold = 1e-9,
+        });
+
+        int startCount = model.GaussianCount;
+
+        var loader = ImageTrainingDataLoaders.FromViews(BuildViews(), seed: 17);
+        for (int step = 0; step < 8; step++)
+        {
+            model.TrainOnImageBatch(loader, raysPerBatch: 4, optimizerOptions: null);
+        }
+
+        Assert.Equal(startCount, model.GaussianCount);
+    }
+}

--- a/tests/AiDotNet.Tests/IntegrationTests/NeuralRadianceFields/GaussianSplattingFacadeHyperparameterRoutingTests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/NeuralRadianceFields/GaussianSplattingFacadeHyperparameterRoutingTests.cs
@@ -1,0 +1,122 @@
+using System.Threading.Tasks;
+using AiDotNet.Data.Loaders;
+using AiDotNet.LinearAlgebra;
+using AiDotNet.Models.Options;
+using AiDotNet.NeuralRadianceFields.Models;
+using AiDotNet.Optimizers;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tests.IntegrationTests.NeuralRadianceFields;
+
+/// <summary>
+/// End-to-end regression test for #1833.
+///
+/// The existing unit tests (<c>GaussianSplattingHyperparameterAwareTests</c>) call
+/// <c>ApplyOptimizerHyperparameters</c> directly, which pins the derivation maths but NOT
+/// the thing #1833 actually reported: that going through the <c>AiModelBuilder</c> facade
+/// silently dropped the caller's <c>ConfigureOptimizer</c> settings. Those tests would keep
+/// passing even if the builder stopped invoking the hook entirely.
+///
+/// This test closes that gap by driving the real facade path — <c>ConfigureDataLoader</c> →
+/// <c>ConfigureModel</c> → <c>ConfigureOptimizer</c> → <c>BuildAsync</c> — and asserting the
+/// caller's learning rate reached the model's per-attribute schedule.
+/// </summary>
+public class GaussianSplattingFacadeHyperparameterRoutingTests
+{
+    // Deliberately distinct from every default in play, so a pass cannot be a coincidence:
+    //   - AdamOptimizerOptions default InitialLearningRate = 1e-3
+    //   - OptimizationAlgorithmOptions base default        = 0.01
+    //   - the 3DGS paper's canonical position anchor       = 1.6e-4
+    private const double CallerLearningRate = 8.0e-4;
+
+    // Kerbl et al. 2023 ratio: color = position * (2.5e-3 / 1.6e-4) = position * 15.625.
+    private const double ExpectedColorLearningRate = CallerLearningRate * 15.625;   // 0.0125
+
+    // Seeded into the model's options so they differ from BOTH the caller-derived values
+    // above AND the library defaults. If the facade never invokes the hook, these survive
+    // untouched and the assertions below fail — which is what makes this a real control.
+    private const double SeededPositionLearningRate = 0.05;
+    private const double SeededColorLearningRate = 0.2;
+
+    private static GaussianSplatting<double> BuildSeededModel()
+    {
+        var options = new GaussianSplattingOptions
+        {
+            EnableDensification = false,
+            EnableSpatialIndex = false,
+            UseSphericalHarmonics = false,
+            MaxGaussians = 8,
+            ShDegree = 0,
+            PositionLearningRate = SeededPositionLearningRate,
+            ColorLearningRate = SeededColorLearningRate,
+        };
+
+        var points = new Matrix<double>(4, 3);
+        var colors = new Matrix<double>(4, 3);
+        for (int i = 0; i < 4; i++)
+        {
+            for (int j = 0; j < 3; j++)
+            {
+                points[i, j] = 0.1 * (i + j);
+                colors[i, j] = 0.5;
+            }
+        }
+
+        return new GaussianSplatting<double>(options, points, colors);
+    }
+
+    [Fact(Timeout = 120000)]
+    public async Task BuildAsync_RoutesConfiguredLearningRate_IntoPerAttributeSchedule()
+    {
+        var model = BuildSeededModel();
+
+        // Control arm: before the build, the model still holds the seeded values. If this
+        // were already the derived value the test could not discriminate.
+        Assert.Equal(SeededPositionLearningRate, model.PositionLearningRate, precision: 12);
+        Assert.Equal(SeededColorLearningRate, model.ColorLearningRate, precision: 12);
+
+        var optimizer = new AdamOptimizer<double, Tensor<double>, Tensor<double>>(
+            model,
+            new AdamOptimizerOptions<double, Tensor<double>, Tensor<double>>
+            {
+                InitialLearningRate = CallerLearningRate,
+                MaxIterations = 1,
+            });
+
+        // GaussianSplatting's ray contract is [N, 6] in (3D position + 3D view direction)
+        // and [N, 4] out (RGBA). 30 rows so the loader's train/validation/test split leaves
+        // no empty shard — the input contract rejects a zero-length axis.
+        const int Rows = 30;
+        var features = new Tensor<double>([Rows, 6]);
+        var targets = new Tensor<double>([Rows, 6]);
+        for (int i = 0; i < Rows; i++)
+        {
+            for (int j = 0; j < 6; j++)
+            {
+                features[i, j] = 0.01 * (i + j);
+            }
+
+            for (int j = 0; j < 6; j++)
+            {
+                targets[i, j] = 0.02 * (i + j);
+            }
+        }
+
+        await new AiModelBuilder<double, Tensor<double>, Tensor<double>>()
+            .ConfigureDataLoader(DataLoaders.FromTensors(features, targets))
+            .ConfigureModel(model)
+            .ConfigureOptimizer(optimizer)
+            .BuildAsync();
+
+        // The caller's base LR became the position LR verbatim, and the remaining attributes
+        // were re-derived from it using the paper's ratios.
+        Assert.Equal(CallerLearningRate, model.PositionLearningRate, precision: 12);
+        Assert.Equal(ExpectedColorLearningRate, model.ColorLearningRate, precision: 10);
+
+        // Explicitly assert the seeded values did NOT survive — the failure mode #1833
+        // reported was the configured value being silently ignored.
+        Assert.NotEqual(SeededPositionLearningRate, model.PositionLearningRate);
+        Assert.NotEqual(SeededColorLearningRate, model.ColorLearningRate);
+    }
+}


### PR DESCRIPTION
Two v1 Tier-1 defects plus the tests that would have caught them, from a full re-audit of all 45 open issues against master.

## Closes #1842 — trainable parameters were bound to arena scratch

`Engine.*` results can come from the per-step `TensorArena`, which recycles its buffers when the step ends. Assigning one to a trainable-parameter field makes that scratch the weight, so the next step's allocations overwrite it and training silently produces NaN or garbage. Nothing throws — the numbers are just wrong.

```csharp
// before
_gamma = Engine.TensorSubtract(_gamma, delta);
// after (zero-allocation, writes through the parameter's own registered storage)
Engine.TensorSubtractInPlace(_gamma, delta);
```

The correct pattern was already sitting in the same method: layers with a `DirectGpuTensorEngine` branch called `SgdMomentumUpdateGpu(_gamma, ...)` **in place**, while the CPU branch beside it rebound the field.

**593 sites across 89 files:**
- **581** rewritten mechanically, where the assignment target was also the first argument.
- **6** momentum / weight-decay updates whose first argument was a *scaled copy*, converted to `TensorMultiplyScalarInPlace` + `TensorAddInPlace`. These matter most: momentum state is read on the **next** step, so scratch there corrupts the update rather than only the current value.
- **6** that a regex sweep structurally could not find, because they are `public void UpdateParameters` rather than `public override` — `CLSToken`, `ColumnEmbedding`, `ContrastivePretraining` (x2), `TabTransformerBase`, `SpatialPoolerLayer`. **The analyzer found these, not the search.**

### AIDN100 stops it coming back

The justification is the issue's own history: **~31 sites when reported → 40 at re-check → 593 when finally measured.** A population that *grows* while an issue is open is being copied from neighbouring layers, and prose does not hold that line.

`ParameterUpdateInPlaceAnalyzer` (`AIDN100`, `AiDotNet.ParameterAutomation`, **Error**) is deliberately narrow to sit at zero false positives — only inside `UpdateParameters`, only instance fields, never `[Scratch]`/`[Buffer]` storage, and never lazy initialization behind a null guard (including a *shared* guard allocating a group of buffers, which is what `SynapticPlasticityLayer` does).

Verified both ways, per the project rule that a rule must be shown to bite: the build is **clean at zero sites**, and reintroducing a single reassignment **fails the build**.

## Closes #2086 — a dead shard read as success

On a master push the analyzer runs in inventory mode, which has no baseline and therefore had no expected set of shards. A shard whose runner died before uploading was simply *absent*: counts were taken over whatever arrived, and the run reported

> `115 shards, 115 passed, 0 failed, 0 incomplete` — `Regression status: improved`

while `Integration D` had died. That ledger then became the baseline every later PR is measured against, so the blind spot propagated. Integration D reproduced deterministically on a clean rerun.

The baseline path already handled this correctly. This extends the same idea to inventory mode using the matrix the run actually dispatched — shards selection deliberately skipped are not in that matrix, so anything expected and absent *died*.

Three parts, because failing the run alone is not enough:
- Missing shards are recorded in `shards.csv` as `Missing` rather than omitted, and the summary names them.
- The run exits non-zero. The pre-existing `FailOnPolicy` gate only fired **when a baseline existed**, which is exactly why a baseline-establishing push could go green.
- The hole is stamped into `ledger.json`, and a baseline declaring one is refused. `find-test-baseline.ps1` intentionally does not filter candidates by run conclusion, so a failed run's ledger can still be adopted later — the artifact has to carry its own evidence.

## Also fixed: #2089 — densification crashed training on the next step

Found while verifying #1835. `EnableDensification` defaults to **true**, and densification resizes the parameter surface but only called `MarkSpatialIndexDirty()`, never `InvalidateParameterCountCache()`. So `ParameterCount` kept describing the previous cloud:

```
ArgumentException : Flat gradient length (224) must match ParameterCount (112)
```

224/14 and 112/14 are 16 and 8 Gaussians at `ShDegree = 0` — the split had doubled the cloud while the count still reported the old one. One line, plus regression tests with a control arm.

## Tests

- `GaussianSplattingFacadeHyperparameterRoutingTests` (#1833) — drives the real `BuildAsync` path and asserts the caller's LR lands. Seeded so it discriminates: the model starts at position `0.05` / color `0.2`, matching neither the library defaults nor the paper anchor, and the caller passes `8.0e-4`.
- `GaussianSplattingDensificationFiresDuringTrainingTests` (#2089) — trains with densification on and asserts the cloud changed, **plus a control arm with it off** asserting it did not, so the assertion cannot pass on ordinary training churn.
- `DefaultInferenceOptimizationEngagementTests` (#1632) — pins what actually engages on the default inference path, including the negative: **speculative decoding stays opt-in** while everything else is on. The issue assumed the set was uniformly off.
- `test-regression-analysis.tests.ps1` — six new assertions covering the complete case as a control arm, the incomplete case, the `Missing` row, the non-zero exit with no baseline, the ledger stamp, refusal of a holed baseline, and that omitting the expected set preserves previous behaviour.

## Verification

- Builds clean on **net10.0 and net471**.
- **Behaviour unchanged:** the same 1399-test batch reports **1359 passed / 3 failed / 37 skipped**, identical to a four-run baseline taken *before* the change. The 3 failures are the pre-existing FastSpeech2 divergence tracked in #2093, unrelated to this PR.
- Full `test-regression-analysis.tests.ps1` suite passes, including every pre-existing assertion.

## Not in this PR

The remaining v1 Tier 1 items are sized past the 100-file review cap and follow separately: **#1830** (74 files) and **#1928** (592 files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GYQycGHKxLFBqhEtPMHz29


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a code analysis rule that detects unsafe trainable-parameter reassignment during updates.
  * Inference optimization defaults now enable KV caching, paged caching, flash attention, layer fusion, and batching; speculative decoding remains opt-in.
  * Regression analysis now identifies missing shard results and reports incomplete baselines clearly.

* **Bug Fixes**
  * Improved training stability by preserving parameter and optimizer state during updates.
  * Fixed Gaussian-splatting training after densification changes parameter counts.
  * Improved distributed training session and broadcast handling.
  * Improved GPU-backed synaptic-plasticity state validation and handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->