### PR TITLE
fix(metadata): stop model metadata from serializing the model eagerly (#1830)

### DIFF
--- a/src/Document/DocumentNeuralNetworkBase.cs
+++ b/src/Document/DocumentNeuralNetworkBase.cs
@@ -487,6 +487,15 @@ public abstract partial class DocumentNeuralNetworkBase<T> : NeuralNetworkBase<T
         {
             return Array.Empty<byte>();
         }
+        catch (AiDotNet.Exceptions.LicenseRequiredException)
+        {
+            // #1830: AiModelResult's constructor captures metadata for every model it wraps, so an
+            // eager serialization here turned AiModelBuilder.BuildAsync into a licensed operation and
+            // threw out of the primary training entry point on an expired trial. Degrade to empty
+            // model bytes exactly as NeuralNetworkBase.SerializeForMetadata already does -- metadata
+            // without the serialized weights is still useful, a failed build is not.
+            return Array.Empty<byte>();
+        }
     }
 
     protected void ValidateImageShape(Tensor<T> image)

--- a/src/Document/LayoutAware/LayoutXLM.cs
+++ b/src/Document/LayoutAware/LayoutXLM.cs
@@ -599,7 +599,7 @@ public partial class LayoutXLM<T> : DocumentNeuralNetworkBase<T>, ILayoutDetecto
                 { "use_native_mode", _useNativeMode },
                 { "total_parameters", totalParams }
             },
-            ModelData = totalParams > 50_000_000 ? Array.Empty<byte>() : this.Serialize()
+            ModelDataProvider = () => totalParams > 50_000_000 ? Array.Empty<byte>() : this.Serialize()
         };
     }
 

--- a/src/Finance/Base/FinancialModelBase.cs
+++ b/src/Finance/Base/FinancialModelBase.cs
@@ -711,7 +711,7 @@ public abstract partial class FinancialModelBase<T> : NeuralNetworkBase<T>, IFin
         return new ModelMetadata<T>
         {
             AdditionalInfo = additionalInfo,
-            ModelData = UseNativeMode ? this.Serialize() : Array.Empty<byte>()
+            ModelDataProvider = () => UseNativeMode ? this.Serialize() : Array.Empty<byte>()
         };
     }
 

--- a/src/Finance/Forecasting/Foundation/Chronos.cs
+++ b/src/Finance/Forecasting/Foundation/Chronos.cs
@@ -615,7 +615,7 @@ public partial class Chronos<T> : TimeSeriesFoundationModelBase<T>
                 { "UseNativeMode", _useNativeMode },
                 { "ParameterCount", GetParameterCount() }
             },
-            ModelData = _useNativeMode ? this.Serialize() : Array.Empty<byte>()
+            ModelDataProvider = () => _useNativeMode ? this.Serialize() : Array.Empty<byte>()
         };
     }
 

--- a/src/Finance/Forecasting/Foundation/ChronosBolt.cs
+++ b/src/Finance/Forecasting/Foundation/ChronosBolt.cs
@@ -444,7 +444,7 @@ public partial class ChronosBolt<T> : TimeSeriesFoundationModelBase<T>
                 { "UseNativeMode", _useNativeMode },
                 { "ParameterCount", GetParameterCount() }
             },
-            ModelData = _useNativeMode ? this.Serialize() : Array.Empty<byte>()
+            ModelDataProvider = () => _useNativeMode ? this.Serialize() : Array.Empty<byte>()
         };
     }
 

--- a/src/Finance/Forecasting/Foundation/FlowState.cs
+++ b/src/Finance/Forecasting/Foundation/FlowState.cs
@@ -281,7 +281,7 @@ public partial class FlowState<T> : TimeSeriesFoundationModelBase<T>
                 { "UseNativeMode", _useNativeMode },
                 { "ParameterCount", GetParameterCount() }
             },
-            ModelData = _useNativeMode ? this.Serialize() : Array.Empty<byte>()
+            ModelDataProvider = () => _useNativeMode ? this.Serialize() : Array.Empty<byte>()
         };
     }
 

--- a/src/Finance/Forecasting/Foundation/GPT4TS.cs
+++ b/src/Finance/Forecasting/Foundation/GPT4TS.cs
@@ -283,7 +283,7 @@ public partial class GPT4TS<T> : TimeSeriesFoundationModelBase<T>
                 { "UseNativeMode", _useNativeMode },
                 { "ParameterCount", GetParameterCount() }
             },
-            ModelData = _useNativeMode ? this.Serialize() : Array.Empty<byte>()
+            ModelDataProvider = () => _useNativeMode ? this.Serialize() : Array.Empty<byte>()
         };
     }
 

--- a/src/Finance/Forecasting/Foundation/Kairos.cs
+++ b/src/Finance/Forecasting/Foundation/Kairos.cs
@@ -276,7 +276,7 @@ public partial class Kairos<T> : TimeSeriesFoundationModelBase<T>
                 { "UseNativeMode", _useNativeMode },
                 { "ParameterCount", GetParameterCount() }
             },
-            ModelData = _useNativeMode ? this.Serialize() : Array.Empty<byte>()
+            ModelDataProvider = () => _useNativeMode ? this.Serialize() : Array.Empty<byte>()
         };
     }
 

--- a/src/Finance/Forecasting/Foundation/Kronos.cs
+++ b/src/Finance/Forecasting/Foundation/Kronos.cs
@@ -272,7 +272,7 @@ public partial class Kronos<T> : TimeSeriesFoundationModelBase<T>
                 { "UseNativeMode", _useNativeMode },
                 { "ParameterCount", GetParameterCount() }
             },
-            ModelData = _useNativeMode ? this.Serialize() : Array.Empty<byte>()
+            ModelDataProvider = () => _useNativeMode ? this.Serialize() : Array.Empty<byte>()
         };
     }
 

--- a/src/Finance/Forecasting/Foundation/LLMTime.cs
+++ b/src/Finance/Forecasting/Foundation/LLMTime.cs
@@ -295,7 +295,7 @@ public partial class LLMTime<T> : TimeSeriesFoundationModelBase<T>
                 { "UseNativeMode", _useNativeMode },
                 { "ParameterCount", GetParameterCount() }
             },
-            ModelData = _useNativeMode ? this.Serialize() : Array.Empty<byte>()
+            ModelDataProvider = () => _useNativeMode ? this.Serialize() : Array.Empty<byte>()
         };
     }
 

--- a/src/Finance/Forecasting/Foundation/LagLlama.cs
+++ b/src/Finance/Forecasting/Foundation/LagLlama.cs
@@ -606,7 +606,7 @@ public partial class LagLlama<T> : ForecastingModelBase<T>
                 { "UseNativeMode", _useNativeMode },
                 { "ParameterCount", GetParameterCount() }
             },
-            ModelData = _useNativeMode ? this.Serialize() : Array.Empty<byte>()
+            ModelDataProvider = () => _useNativeMode ? this.Serialize() : Array.Empty<byte>()
         };
     }
 

--- a/src/Finance/Forecasting/Foundation/MOIRAI.cs
+++ b/src/Finance/Forecasting/Foundation/MOIRAI.cs
@@ -802,7 +802,7 @@ public partial class MOIRAI<T> : TimeSeriesFoundationModelBase<T>
                 { "UseNativeMode", _useNativeMode },
                 { "ParameterCount", GetParameterCount() }
             },
-            ModelData = _useNativeMode ? this.Serialize() : Array.Empty<byte>()
+            ModelDataProvider = () => _useNativeMode ? this.Serialize() : Array.Empty<byte>()
         };
     }
 

--- a/src/Finance/Forecasting/Foundation/MOMENT.cs
+++ b/src/Finance/Forecasting/Foundation/MOMENT.cs
@@ -448,7 +448,7 @@ public partial class MOMENT<T> : TimeSeriesFoundationModelBase<T>
                 { "UseNativeMode", _useNativeMode },
                 { "ParameterCount", GetParameterCount() }
             },
-            ModelData = _useNativeMode ? this.Serialize() : Array.Empty<byte>()
+            ModelDataProvider = () => _useNativeMode ? this.Serialize() : Array.Empty<byte>()
         };
     }
 

--- a/src/Finance/Forecasting/Foundation/SimMTM.cs
+++ b/src/Finance/Forecasting/Foundation/SimMTM.cs
@@ -261,7 +261,7 @@ public partial class SimMTM<T> : TimeSeriesFoundationModelBase<T>
                 { "UseNativeMode", _useNativeMode },
                 { "ParameterCount", GetParameterCount() }
             },
-            ModelData = _useNativeMode ? this.Serialize() : Array.Empty<byte>()
+            ModelDataProvider = () => _useNativeMode ? this.Serialize() : Array.Empty<byte>()
         };
     }
 

--- a/src/Finance/Forecasting/Foundation/Sundial.cs
+++ b/src/Finance/Forecasting/Foundation/Sundial.cs
@@ -263,7 +263,7 @@ public partial class Sundial<T> : TimeSeriesFoundationModelBase<T>
                 { "UseNativeMode", _useNativeMode },
                 { "ParameterCount", GetParameterCount() }
             },
-            ModelData = _useNativeMode ? this.Serialize() : Array.Empty<byte>()
+            ModelDataProvider = () => _useNativeMode ? this.Serialize() : Array.Empty<byte>()
         };
     }
 

--- a/src/Finance/Forecasting/Foundation/TEST.cs
+++ b/src/Finance/Forecasting/Foundation/TEST.cs
@@ -267,7 +267,7 @@ public partial class TEST<T> : TimeSeriesFoundationModelBase<T>
                 { "UseNativeMode", _useNativeMode },
                 { "ParameterCount", GetParameterCount() }
             },
-            ModelData = _useNativeMode ? this.Serialize() : Array.Empty<byte>()
+            ModelDataProvider = () => _useNativeMode ? this.Serialize() : Array.Empty<byte>()
         };
     }
 

--- a/src/Finance/Forecasting/Foundation/TFC.cs
+++ b/src/Finance/Forecasting/Foundation/TFC.cs
@@ -572,7 +572,7 @@ public partial class TFC<T> : TimeSeriesFoundationModelBase<T>
                 { "UseNativeMode", _useNativeMode },
                 { "ParameterCount", GetParameterCount() }
             },
-            ModelData = _useNativeMode ? this.Serialize() : Array.Empty<byte>()
+            ModelDataProvider = () => _useNativeMode ? this.Serialize() : Array.Empty<byte>()
         };
     }
 

--- a/src/Finance/Forecasting/Foundation/TOTEM.cs
+++ b/src/Finance/Forecasting/Foundation/TOTEM.cs
@@ -444,7 +444,7 @@ public partial class TOTEM<T> : TimeSeriesFoundationModelBase<T>
                 { "UseNativeMode", _useNativeMode },
                 { "ParameterCount", GetParameterCount() }
             },
-            ModelData = _useNativeMode ? this.Serialize() : Array.Empty<byte>()
+            ModelDataProvider = () => _useNativeMode ? this.Serialize() : Array.Empty<byte>()
         };
     }
 

--- a/src/Finance/Forecasting/Foundation/TOTO.cs
+++ b/src/Finance/Forecasting/Foundation/TOTO.cs
@@ -312,7 +312,7 @@ public partial class TOTO<T> : TimeSeriesFoundationModelBase<T>
                 { "UseNativeMode", _useNativeMode },
                 { "ParameterCount", GetParameterCount() }
             },
-            ModelData = _useNativeMode ? this.Serialize() : Array.Empty<byte>()
+            ModelDataProvider = () => _useNativeMode ? this.Serialize() : Array.Empty<byte>()
         };
     }
 

--- a/src/Finance/Forecasting/Foundation/TS2Vec.cs
+++ b/src/Finance/Forecasting/Foundation/TS2Vec.cs
@@ -293,7 +293,7 @@ public partial class TS2Vec<T> : TimeSeriesFoundationModelBase<T>
                 { "UseNativeMode", _useNativeMode },
                 { "ParameterCount", GetParameterCount() }
             },
-            ModelData = _useNativeMode ? this.Serialize() : Array.Empty<byte>()
+            ModelDataProvider = () => _useNativeMode ? this.Serialize() : Array.Empty<byte>()
         };
     }
 

--- a/src/Finance/Forecasting/Foundation/TimeBridge.cs
+++ b/src/Finance/Forecasting/Foundation/TimeBridge.cs
@@ -274,7 +274,7 @@ public partial class TimeBridge<T> : TimeSeriesFoundationModelBase<T>
                 { "UseNativeMode", _useNativeMode },
                 { "ParameterCount", GetParameterCount() }
             },
-            ModelData = _useNativeMode ? this.Serialize() : Array.Empty<byte>()
+            ModelDataProvider = () => _useNativeMode ? this.Serialize() : Array.Empty<byte>()
         };
     }
 

--- a/src/Finance/Forecasting/Foundation/TimeGPT.cs
+++ b/src/Finance/Forecasting/Foundation/TimeGPT.cs
@@ -489,7 +489,7 @@ public partial class TimeGPT<T> : ForecastingModelBase<T>
                 { "UseNativeMode", _useNativeMode },
                 { "ParameterCount", GetParameterCount() }
             },
-            ModelData = _useNativeMode ? this.Serialize() : Array.Empty<byte>()
+            ModelDataProvider = () => _useNativeMode ? this.Serialize() : Array.Empty<byte>()
         };
     }
 

--- a/src/Finance/Forecasting/Foundation/TimeGrad.cs
+++ b/src/Finance/Forecasting/Foundation/TimeGrad.cs
@@ -345,7 +345,7 @@ public partial class TimeGrad<T> : TimeSeriesFoundationModelBase<T>
                 { "DenoisingNetworkDim", _denoisingNetworkDim },
                 { "UseNativeMode", _useNativeMode }
             },
-            ModelData = _useNativeMode ? this.Serialize() : Array.Empty<byte>()
+            ModelDataProvider = () => _useNativeMode ? this.Serialize() : Array.Empty<byte>()
         };
     }
 

--- a/src/Finance/Forecasting/Foundation/TimeLLM.cs
+++ b/src/Finance/Forecasting/Foundation/TimeLLM.cs
@@ -522,7 +522,7 @@ public partial class TimeLLM<T> : ForecastingModelBase<T>
                 { "UseNativeMode", _useNativeMode },
                 { "ParameterCount", GetParameterCount() }
             },
-            ModelData = _useNativeMode ? this.Serialize() : Array.Empty<byte>()
+            ModelDataProvider = () => _useNativeMode ? this.Serialize() : Array.Empty<byte>()
         };
     }
 

--- a/src/Finance/Forecasting/Foundation/TimeMAE.cs
+++ b/src/Finance/Forecasting/Foundation/TimeMAE.cs
@@ -280,7 +280,7 @@ public partial class TimeMAE<T> : TimeSeriesFoundationModelBase<T>
                 { "UseNativeMode", _useNativeMode },
                 { "ParameterCount", GetParameterCount() }
             },
-            ModelData = _useNativeMode ? this.Serialize() : Array.Empty<byte>()
+            ModelDataProvider = () => _useNativeMode ? this.Serialize() : Array.Empty<byte>()
         };
     }
 

--- a/src/Finance/Forecasting/Foundation/TimeMoE.cs
+++ b/src/Finance/Forecasting/Foundation/TimeMoE.cs
@@ -270,7 +270,7 @@ public partial class TimeMoE<T> : TimeSeriesFoundationModelBase<T>
                 { "UseNativeMode", _useNativeMode },
                 { "ParameterCount", GetParameterCount() }
             },
-            ModelData = _useNativeMode ? this.Serialize() : Array.Empty<byte>()
+            ModelDataProvider = () => _useNativeMode ? this.Serialize() : Array.Empty<byte>()
         };
     }
 

--- a/src/Finance/Forecasting/Foundation/Timer.cs
+++ b/src/Finance/Forecasting/Foundation/Timer.cs
@@ -604,7 +604,7 @@ public partial class Timer<T> : TimeSeriesFoundationModelBase<T>
                 { "UseNativeMode", _useNativeMode },
                 { "ParameterCount", GetParameterCount() }
             },
-            ModelData = _useNativeMode ? this.Serialize() : Array.Empty<byte>()
+            ModelDataProvider = () => _useNativeMode ? this.Serialize() : Array.Empty<byte>()
         };
     }
 

--- a/src/Finance/Forecasting/Foundation/TimesFM.cs
+++ b/src/Finance/Forecasting/Foundation/TimesFM.cs
@@ -620,7 +620,7 @@ public partial class TimesFM<T> : TimeSeriesFoundationModelBase<T>
                 { "UsePretrainedWeights", _usePretrainedWeights },
                 { "ParameterCount", GetParameterCount() }
             },
-            ModelData = _useNativeMode ? this.Serialize() : Array.Empty<byte>()
+            ModelDataProvider = () => _useNativeMode ? this.Serialize() : Array.Empty<byte>()
         };
     }
 

--- a/src/Finance/Forecasting/Foundation/TinyTimeMixers.cs
+++ b/src/Finance/Forecasting/Foundation/TinyTimeMixers.cs
@@ -353,7 +353,7 @@ public partial class TinyTimeMixers<T> : TimeSeriesFoundationModelBase<T>
                 { "NumFeatures", _numFeatures },
                 { "ParameterCount", GetParameterCount() }
             },
-            ModelData = _useNativeMode ? this.Serialize() : Array.Empty<byte>()
+            ModelDataProvider = () => _useNativeMode ? this.Serialize() : Array.Empty<byte>()
         };
     }
 

--- a/src/Finance/Forecasting/Foundation/UniTS.cs
+++ b/src/Finance/Forecasting/Foundation/UniTS.cs
@@ -512,7 +512,7 @@ public partial class UniTS<T> : ForecastingModelBase<T>
                 { "UseNativeMode", _useNativeMode },
                 { "ParameterCount", GetParameterCount() }
             },
-            ModelData = _useNativeMode ? this.Serialize() : Array.Empty<byte>()
+            ModelDataProvider = () => _useNativeMode ? this.Serialize() : Array.Empty<byte>()
         };
     }
 

--- a/src/Finance/Forecasting/Foundation/VisionTS.cs
+++ b/src/Finance/Forecasting/Foundation/VisionTS.cs
@@ -333,7 +333,7 @@ public partial class VisionTS<T> : TimeSeriesFoundationModelBase<T>
                 { "UseNativeMode", _useNativeMode },
                 { "ParameterCount", GetParameterCount() }
             },
-            ModelData = _useNativeMode ? this.Serialize() : Array.Empty<byte>()
+            ModelDataProvider = () => _useNativeMode ? this.Serialize() : Array.Empty<byte>()
         };
     }
 

--- a/src/Finance/Forecasting/Foundation/YingLong.cs
+++ b/src/Finance/Forecasting/Foundation/YingLong.cs
@@ -291,7 +291,7 @@ public partial class YingLong<T> : TimeSeriesFoundationModelBase<T>
                 { "UseNativeMode", _useNativeMode },
                 { "ParameterCount", GetParameterCount() }
             },
-            ModelData = _useNativeMode ? this.Serialize() : Array.Empty<byte>()
+            ModelDataProvider = () => _useNativeMode ? this.Serialize() : Array.Empty<byte>()
         };
     }
 

--- a/src/Finance/Forecasting/Neural/DeepFactor.cs
+++ b/src/Finance/Forecasting/Neural/DeepFactor.cs
@@ -562,7 +562,7 @@ public partial class DeepFactor<T> : ForecastingModelBase<T>
                 { "UseNativeMode", _useNativeMode },
                 { "ParameterCount", GetParameterCount() }
             },
-            ModelData = _useNativeMode ? this.Serialize() : Array.Empty<byte>()
+            ModelDataProvider = () => _useNativeMode ? this.Serialize() : Array.Empty<byte>()
         };
     }
 

--- a/src/Finance/Forecasting/Neural/DeepState.cs
+++ b/src/Finance/Forecasting/Neural/DeepState.cs
@@ -556,7 +556,7 @@ public partial class DeepState<T> : ForecastingModelBase<T>
                 { "UseNativeMode", _useNativeMode },
                 { "ParameterCount", GetParameterCount() }
             },
-            ModelData = _useNativeMode ? this.Serialize() : Array.Empty<byte>()
+            ModelDataProvider = () => _useNativeMode ? this.Serialize() : Array.Empty<byte>()
         };
     }
 

--- a/src/Finance/Forecasting/Neural/LSTNet.cs
+++ b/src/Finance/Forecasting/Neural/LSTNet.cs
@@ -591,7 +591,7 @@ public partial class LSTNet<T> : ForecastingModelBase<T>
                 { "UseNativeMode", _useNativeMode },
                 { "ParameterCount", GetParameterCount() }
             },
-            ModelData = _useNativeMode ? this.Serialize() : Array.Empty<byte>()
+            ModelDataProvider = () => _useNativeMode ? this.Serialize() : Array.Empty<byte>()
         };
     }
 

--- a/src/Finance/Forecasting/Neural/MQCNN.cs
+++ b/src/Finance/Forecasting/Neural/MQCNN.cs
@@ -737,7 +737,7 @@ public partial class MQCNN<T> : ForecastingModelBase<T>
                 { "UseNativeMode", _useNativeMode },
                 { "ParameterCount", GetParameterCount() }
             },
-            ModelData = _useNativeMode ? this.Serialize() : Array.Empty<byte>()
+            ModelDataProvider = () => _useNativeMode ? this.Serialize() : Array.Empty<byte>()
         };
     }
 

--- a/src/Finance/Forecasting/Neural/NBEATSFinance.cs
+++ b/src/Finance/Forecasting/Neural/NBEATSFinance.cs
@@ -588,7 +588,7 @@ public partial class NBEATSFinance<T> : ForecastingModelBase<T>
                 { "UseNativeMode", _useNativeMode },
                 { "ParameterCount", GetParameterCount() }
             },
-            ModelData = _useNativeMode ? this.Serialize() : Array.Empty<byte>()
+            ModelDataProvider = () => _useNativeMode ? this.Serialize() : Array.Empty<byte>()
         };
     }
 

--- a/src/Finance/Forecasting/Neural/NHiTSFinance.cs
+++ b/src/Finance/Forecasting/Neural/NHiTSFinance.cs
@@ -653,7 +653,7 @@ public partial class NHiTSFinance<T> : ForecastingModelBase<T>
                 { "UseNativeMode", _useNativeMode },
                 { "ParameterCount", GetParameterCount() }
             },
-            ModelData = _useNativeMode ? this.Serialize() : Array.Empty<byte>()
+            ModelDataProvider = () => _useNativeMode ? this.Serialize() : Array.Empty<byte>()
         };
     }
 

--- a/src/Finance/Forecasting/Neural/TCN.cs
+++ b/src/Finance/Forecasting/Neural/TCN.cs
@@ -536,7 +536,7 @@ public partial class TCN<T> : ForecastingModelBase<T>
                 { "UseNativeMode", _useNativeMode },
                 { "ParameterCount", GetParameterCount() }
             },
-            ModelData = _useNativeMode ? this.Serialize() : Array.Empty<byte>()
+            ModelDataProvider = () => _useNativeMode ? this.Serialize() : Array.Empty<byte>()
         };
     }
 

--- a/src/Finance/Forecasting/Neural/WaveNet.cs
+++ b/src/Finance/Forecasting/Neural/WaveNet.cs
@@ -469,7 +469,7 @@ public partial class WaveNet<T> : ForecastingModelBase<T>
                 { "UseNativeMode", _useNativeMode },
                 { "ParameterCount", GetParameterCount() }
             },
-            ModelData = _useNativeMode ? this.Serialize() : Array.Empty<byte>()
+            ModelDataProvider = () => _useNativeMode ? this.Serialize() : Array.Empty<byte>()
         };
     }
 

--- a/src/Finance/Forecasting/StateSpace/Mamba.cs
+++ b/src/Finance/Forecasting/StateSpace/Mamba.cs
@@ -500,7 +500,7 @@ public partial class Mamba<T> : ForecastingModelBase<T>
                 { "UseNativeMode", _useNativeMode },
                 { "ParameterCount", GetParameterCount() }
             },
-            ModelData = _useNativeMode ? this.Serialize() : Array.Empty<byte>()
+            ModelDataProvider = () => _useNativeMode ? this.Serialize() : Array.Empty<byte>()
         };
     }
 

--- a/src/Finance/Forecasting/StateSpace/Mamba2.cs
+++ b/src/Finance/Forecasting/StateSpace/Mamba2.cs
@@ -280,7 +280,7 @@ public partial class Mamba2<T> : ForecastingModelBase<T>
                 { "UseNativeMode", _useNativeMode },
                 { "ParameterCount", GetParameterCount() }
             },
-            ModelData = _useNativeMode ? this.Serialize() : Array.Empty<byte>()
+            ModelDataProvider = () => _useNativeMode ? this.Serialize() : Array.Empty<byte>()
         };
     }
 

--- a/src/Finance/Forecasting/StateSpace/RWKVForecaster.cs
+++ b/src/Finance/Forecasting/StateSpace/RWKVForecaster.cs
@@ -370,7 +370,7 @@ public partial class RWKVForecaster<T> : ForecastingModelBase<T>
                 { "UseNativeMode", _useNativeMode },
                 { "ParameterCount", GetParameterCount() }
             },
-            ModelData = _useNativeMode ? this.Serialize() : Array.Empty<byte>()
+            ModelDataProvider = () => _useNativeMode ? this.Serialize() : Array.Empty<byte>()
         };
     }
 

--- a/src/Finance/Forecasting/Transformers/Autoformer.cs
+++ b/src/Finance/Forecasting/Transformers/Autoformer.cs
@@ -480,7 +480,7 @@ public partial class Autoformer<T> : ForecastingModelBase<T>
                 { "UseNativeMode", _useNativeMode },
                 { "ParameterCount", GetParameterCount() }
             },
-            ModelData = _useNativeMode ? this.Serialize() : Array.Empty<byte>()
+            ModelDataProvider = () => _useNativeMode ? this.Serialize() : Array.Empty<byte>()
         };
     }
 

--- a/src/Finance/Forecasting/Transformers/Crossformer.cs
+++ b/src/Finance/Forecasting/Transformers/Crossformer.cs
@@ -473,7 +473,7 @@ public partial class Crossformer<T> : ForecastingModelBase<T>
                 { "UseNativeMode", _useNativeMode },
                 { "ParameterCount", GetParameterCount() }
             },
-            ModelData = _useNativeMode ? this.Serialize() : Array.Empty<byte>()
+            ModelDataProvider = () => _useNativeMode ? this.Serialize() : Array.Empty<byte>()
         };
     }
 

--- a/src/Finance/Forecasting/Transformers/FEDformer.cs
+++ b/src/Finance/Forecasting/Transformers/FEDformer.cs
@@ -597,7 +597,7 @@ public partial class FEDformer<T> : ForecastingModelBase<T>
                 { "UseNativeMode", _useNativeMode },
                 { "ParameterCount", GetParameterCount() }
             },
-            ModelData = _useNativeMode ? this.Serialize() : Array.Empty<byte>()
+            ModelDataProvider = () => _useNativeMode ? this.Serialize() : Array.Empty<byte>()
         };
     }
 

--- a/src/Finance/Forecasting/Transformers/ITransformer.cs
+++ b/src/Finance/Forecasting/Transformers/ITransformer.cs
@@ -644,7 +644,7 @@ public partial class ITransformer<T> : ForecastingModelBase<T>
                 { "UseNativeMode", _useNativeMode },
                 { "ParameterCount", GetParameterCount() }
             },
-            ModelData = _useNativeMode ? this.Serialize() : Array.Empty<byte>()
+            ModelDataProvider = () => _useNativeMode ? this.Serialize() : Array.Empty<byte>()
         };
     }
 

--- a/src/Finance/Forecasting/Transformers/Informer.cs
+++ b/src/Finance/Forecasting/Transformers/Informer.cs
@@ -449,7 +449,7 @@ public partial class Informer<T> : ForecastingModelBase<T>
                 { "UseNativeMode", _useNativeMode },
                 { "ParameterCount", GetParameterCount() }
             },
-            ModelData = _useNativeMode ? this.Serialize() : Array.Empty<byte>()
+            ModelDataProvider = () => _useNativeMode ? this.Serialize() : Array.Empty<byte>()
         };
     }
 

--- a/src/Finance/Forecasting/Transformers/TFT.cs
+++ b/src/Finance/Forecasting/Transformers/TFT.cs
@@ -525,7 +525,7 @@ public partial class TFT<T> : ForecastingModelBase<T>
                 { "UseNativeMode", _useNativeMode },
                 { "ParameterCount", GetParameterCount() }
             },
-            ModelData = _useNativeMode ? this.Serialize() : Array.Empty<byte>()
+            ModelDataProvider = () => _useNativeMode ? this.Serialize() : Array.Empty<byte>()
         };
     }
 

--- a/src/Finance/Forecasting/Transformers/TimesNet.cs
+++ b/src/Finance/Forecasting/Transformers/TimesNet.cs
@@ -600,7 +600,7 @@ public partial class TimesNet<T> : ForecastingModelBase<T>
                 { "UseNativeMode", _useNativeMode },
                 { "ParameterCount", GetParameterCount() }
             },
-            ModelData = _useNativeMode ? this.Serialize() : Array.Empty<byte>()
+            ModelDataProvider = () => _useNativeMode ? this.Serialize() : Array.Empty<byte>()
         };
     }
 

--- a/src/Models/ModelMetadata.cs
+++ b/src/Models/ModelMetadata.cs
@@ -251,7 +251,80 @@ public class ModelMetadata<T>
     /// load the file and deserialize the model data to recreate the working model.
     /// </para>
     /// </remarks>
-    public byte[] ModelData { get; set; } = Array.Empty<byte>();
+    /// <remarks>
+    /// <para>
+    /// <b>Materialized on read.</b> Reading this property runs the deferred provider set through
+    /// <see cref="ModelDataProvider"/> (if any) exactly once and caches the result. Assigning a
+    /// byte array directly still works and simply discards any pending provider.
+    /// </para>
+    /// <para>
+    /// The laziness is load-bearing, not an optimization (#1830). Serializing a model is a
+    /// licensed persistence operation, and <c>AiModelResult</c>'s constructor captures metadata
+    /// for EVERY model it wraps. When the bytes were produced eagerly inside
+    /// <c>GetModelMetadata</c>, simply calling <c>AiModelBuilder.BuildAsync</c> ran a serialization
+    /// the caller never asked for, so an expired trial threw <c>LicenseRequiredException</c> out of
+    /// the primary training entry point. Deferring the work moves the licence check to the moment
+    /// a caller actually reads the bytes -- which is a genuine persistence action -- without
+    /// weakening the guard, since the read still goes through <c>Serialize()</c>.
+    /// </para>
+    /// </remarks>
+    public byte[] ModelData
+    {
+        get
+        {
+            var provider = _modelDataProvider;
+            if (provider is not null)
+            {
+                // Cleared BEFORE invoking so a provider that throws (an expired licence is the
+                // expected case) is not retried on every subsequent read, and so a provider that
+                // re-enters this getter cannot recurse.
+                _modelDataProvider = null;
+                _modelData = provider();
+            }
+
+            return _modelData ?? Array.Empty<byte>();
+        }
+        set
+        {
+            _modelData = value;
+            _modelDataProvider = null;
+        }
+    }
+
+    /// <summary>
+    /// Sets a deferred producer for <see cref="ModelData"/>, so the bytes are not computed until
+    /// something actually reads them.
+    /// </summary>
+    /// <remarks>
+    /// Declared <c>init</c>-only so it can be used inside the object initializer that model
+    /// implementations already return, turning <c>ModelData = this.Serialize()</c> into
+    /// <c>ModelDataProvider = () =&gt; this.Serialize()</c> without restructuring the method. Use
+    /// <see cref="SetModelDataProvider"/> when the metadata object already exists.
+    /// </remarks>
+    public Func<byte[]>? ModelDataProvider
+    {
+        init => _modelDataProvider = value;
+    }
+
+    /// <summary>
+    /// Sets a deferred producer for <see cref="ModelData"/> on an already-constructed instance.
+    /// </summary>
+    /// <param name="provider">Produces the serialized bytes on first read. May be <c>null</c> to clear.</param>
+    public void SetModelDataProvider(Func<byte[]>? provider)
+    {
+        _modelDataProvider = provider;
+        if (provider is not null) _modelData = null;
+    }
+
+    /// <summary>True when bytes are available without running a deferred serialization.</summary>
+    /// <remarks>
+    /// Lets infrastructure report or copy metadata without forcing a licensed serialization it did
+    /// not ask for. <c>ModelData.Length == 0</c> cannot answer this: it materializes the provider.
+    /// </remarks>
+    public bool IsModelDataMaterialized => _modelDataProvider is null;
+
+    private byte[]? _modelData = Array.Empty<byte>();
+    private Func<byte[]>? _modelDataProvider;
 
     /// <summary>
     /// Gets or sets the importance of each feature in the model.

--- a/src/Models/ModelMetadata.cs
+++ b/src/Models/ModelMetadata.cs
@@ -272,22 +272,29 @@ public class ModelMetadata<T>
     {
         get
         {
-            var provider = _modelDataProvider;
-            if (provider is not null)
+            lock (_modelDataSync)
             {
-                // Cleared BEFORE invoking so a provider that throws (an expired licence is the
-                // expected case) is not retried on every subsequent read, and so a provider that
-                // re-enters this getter cannot recurse.
-                _modelDataProvider = null;
-                _modelData = provider();
-            }
+                var provider = _modelDataProvider;
+                if (provider is not null)
+                {
+                    // Clear before invoking so a provider that throws is not retried and a
+                    // provider that re-enters this getter cannot recurse. The lock is deliberately
+                    // held across invocation: concurrent readers wait for the one materialization
+                    // attempt instead of observing the temporary empty state.
+                    _modelDataProvider = null;
+                    _modelData = provider();
+                }
 
-            return _modelData ?? Array.Empty<byte>();
+                return _modelData ?? Array.Empty<byte>();
+            }
         }
         set
         {
-            _modelData = value;
-            _modelDataProvider = null;
+            lock (_modelDataSync)
+            {
+                _modelData = value;
+                _modelDataProvider = null;
+            }
         }
     }
 
@@ -301,19 +308,29 @@ public class ModelMetadata<T>
     /// <c>ModelDataProvider = () =&gt; this.Serialize()</c> without restructuring the method. Use
     /// <see cref="SetModelDataProvider"/> when the metadata object already exists.
     /// </remarks>
-    public Func<byte[]>? ModelDataProvider
+    internal Func<byte[]>? ModelDataProvider
     {
-        init => _modelDataProvider = value;
+        init
+        {
+            lock (_modelDataSync)
+            {
+                _modelDataProvider = value;
+                if (value is not null) _modelData = null;
+            }
+        }
     }
 
     /// <summary>
     /// Sets a deferred producer for <see cref="ModelData"/> on an already-constructed instance.
     /// </summary>
     /// <param name="provider">Produces the serialized bytes on first read. May be <c>null</c> to clear.</param>
-    public void SetModelDataProvider(Func<byte[]>? provider)
+    internal void SetModelDataProvider(Func<byte[]>? provider)
     {
-        _modelDataProvider = provider;
-        if (provider is not null) _modelData = null;
+        lock (_modelDataSync)
+        {
+            _modelDataProvider = provider;
+            if (provider is not null) _modelData = null;
+        }
     }
 
     /// <summary>True when bytes are available without running a deferred serialization.</summary>
@@ -321,8 +338,18 @@ public class ModelMetadata<T>
     /// Lets infrastructure report or copy metadata without forcing a licensed serialization it did
     /// not ask for. <c>ModelData.Length == 0</c> cannot answer this: it materializes the provider.
     /// </remarks>
-    public bool IsModelDataMaterialized => _modelDataProvider is null;
+    public bool IsModelDataMaterialized
+    {
+        get
+        {
+            lock (_modelDataSync)
+            {
+                return _modelDataProvider is null;
+            }
+        }
+    }
 
+    private readonly object _modelDataSync = new object();
     private byte[]? _modelData = Array.Empty<byte>();
     private Func<byte[]>? _modelDataProvider;
 

--- a/src/NeuralNetworks/LiquidStateMachine.cs
+++ b/src/NeuralNetworks/LiquidStateMachine.cs
@@ -513,7 +513,7 @@ public partial class LiquidStateMachine<T> : SequenceModelLayoutBase<T>
                 { "LayerCount", Layers.Count },
                 { "ParameterCount", GetParameterCount() }
             },
-            ModelData = Serialize()
+            ModelDataProvider = () => Serialize()
         };
     }
 

--- a/src/NeuralNetworks/UnifiedMultimodalNetwork.cs
+++ b/src/NeuralNetworks/UnifiedMultimodalNetwork.cs
@@ -1210,7 +1210,7 @@ public partial class UnifiedMultimodalNetwork<T> : MultimodalModelLayoutBase<T>,
                 { "LayerCount", Layers.Count },
                 { "ParameterCount", GetParameterCount() }
             },
-            ModelData = this.Serialize()
+            ModelDataProvider = () => this.Serialize()
         };
     }
 

--- a/src/PhysicsInformed/NeuralOperators/DeepOperatorNetwork.cs
+++ b/src/PhysicsInformed/NeuralOperators/DeepOperatorNetwork.cs
@@ -841,7 +841,7 @@ namespace AiDotNet.PhysicsInformed.NeuralOperators
                     { "TrunkModel", _trunkNet.GetType().Name },
                     { "ParameterCount", GetParameterCount() }
                 },
-                ModelData = Serialize()
+                ModelDataProvider = () => Serialize()
             };
         }
 

--- a/src/PhysicsInformed/NeuralOperators/FourierNeuralOperator.cs
+++ b/src/PhysicsInformed/NeuralOperators/FourierNeuralOperator.cs
@@ -771,7 +771,7 @@ namespace AiDotNet.PhysicsInformed.NeuralOperators
                     { "SpatialDimensions", _spatialDimensions },
                     { "ParameterCount", GetParameterCount() }
                 },
-                ModelData = Serialize()
+                ModelDataProvider = () => Serialize()
             };
         }
 

--- a/src/PhysicsInformed/NeuralOperators/GraphNeuralOperator.cs
+++ b/src/PhysicsInformed/NeuralOperators/GraphNeuralOperator.cs
@@ -390,7 +390,7 @@ namespace AiDotNet.PhysicsInformed.NeuralOperators
                     { "HiddenDimension", _hiddenDim },
                     { "ParameterCount", GetParameterCount() }
                 },
-                ModelData = Serialize()
+                ModelDataProvider = () => Serialize()
             };
         }
 

--- a/src/PhysicsInformed/PINNs/DeepRitzMethod.cs
+++ b/src/PhysicsInformed/PINNs/DeepRitzMethod.cs
@@ -485,7 +485,7 @@ namespace AiDotNet.PhysicsInformed.PINNs
                     { "HasBoundaryConditions", _boundaryCheck != null && _boundaryValue != null },
                     { "ParameterCount", GetParameterCount() }
                 },
-                ModelData = Serialize()
+                ModelDataProvider = () => Serialize()
             };
         }
 

--- a/src/PhysicsInformed/PINNs/InverseProblemPINN.cs
+++ b/src/PhysicsInformed/PINNs/InverseProblemPINN.cs
@@ -813,7 +813,7 @@ namespace AiDotNet.PhysicsInformed.PINNs
                     { "IdentifiedParameters", paramDict },
                     { "Regularization", _options.Regularization.ToString() }
                 },
-                ModelData = Serialize()
+                ModelDataProvider = () => Serialize()
             };
         }
 

--- a/src/PhysicsInformed/PINNs/InverseProblemPINN.cs
+++ b/src/PhysicsInformed/PINNs/InverseProblemPINN.cs
@@ -798,23 +798,41 @@ namespace AiDotNet.PhysicsInformed.PINNs
         /// <inheritdoc/>
         public override ModelMetadata<T> GetModelMetadata()
         {
-            var paramDict = new Dictionary<string, object>();
-            for (int i = 0; i < _parameters.Length; i++)
-            {
-                paramDict[_inverseProblem.ParameterNames[i]] = _parameters[i]!;
-            }
-
-            return new ModelMetadata<T>
+            var metadata = new ModelMetadata<T>
             {
                 AdditionalInfo = new Dictionary<string, object>
                 {
                     { "NetworkType", "InverseProblemPINN" },
                     { "NumberOfParameters", _inverseProblem.NumberOfParameters },
-                    { "IdentifiedParameters", paramDict },
+                    { "IdentifiedParameters", GetIdentifiedParameterSnapshot() },
                     { "Regularization", _options.Regularization.ToString() }
-                },
-                ModelDataProvider = () => Serialize()
+                }
             };
+
+            metadata.SetModelDataProvider(() =>
+            {
+                byte[] modelData = Serialize();
+                metadata.AdditionalInfo["IdentifiedParameters"] = GetIdentifiedParameterSnapshot();
+                return modelData;
+            });
+            return metadata;
+        }
+
+        private Dictionary<string, object> GetIdentifiedParameterSnapshot()
+        {
+            var paramDict = new Dictionary<string, object>();
+            for (int i = 0; i < _parameters.Length; i++)
+            {
+                object? value = _parameters[i];
+                if (value is null)
+                {
+                    throw new InvalidOperationException(
+                        $"Identified parameter '{_inverseProblem.ParameterNames[i]}' cannot be null.");
+                }
+                paramDict[_inverseProblem.ParameterNames[i]] = value;
+            }
+
+            return paramDict;
         }
 
         /// <inheritdoc/>

--- a/src/PhysicsInformed/PINNs/MultiScalePINN.cs
+++ b/src/PhysicsInformed/PINNs/MultiScalePINN.cs
@@ -724,7 +724,7 @@ namespace AiDotNet.PhysicsInformed.PINNs
                     { "PDEName", _multiScalePDE.Name },
                     { "ParameterCount", ParameterCount }
                 },
-                ModelData = Serialize()
+                ModelDataProvider = () => Serialize()
             };
         }
 

--- a/src/PhysicsInformed/PINNs/PhysicsInformedNeuralNetwork.cs
+++ b/src/PhysicsInformed/PINNs/PhysicsInformedNeuralNetwork.cs
@@ -630,7 +630,7 @@ namespace AiDotNet.PhysicsInformed.PINNs
                     { "HasInitialCondition", _initialCondition != null },
                     { "ParameterCount", GetParameterCount() }
                 },
-                ModelData = Serialize()
+                ModelDataProvider = () => Serialize()
             };
         }
 

--- a/src/PhysicsInformed/PINNs/VariationalPINN.cs
+++ b/src/PhysicsInformed/PINNs/VariationalPINN.cs
@@ -535,7 +535,7 @@ namespace AiDotNet.PhysicsInformed.PINNs
                     { "TestFunctions", _numTestFunctions },
                     { "ParameterCount", GetParameterCount() }
                 },
-                ModelData = Serialize()
+                ModelDataProvider = () => Serialize()
             };
         }
 

--- a/src/PhysicsInformed/ScientificML/HamiltonianNeuralNetwork.cs
+++ b/src/PhysicsInformed/ScientificML/HamiltonianNeuralNetwork.cs
@@ -482,7 +482,7 @@ namespace AiDotNet.PhysicsInformed.ScientificML
                     { "StateDimension", _stateDim },
                     { "ParameterCount", GetParameterCount() }
                 },
-                ModelData = Serialize()
+                ModelDataProvider = () => Serialize()
             };
         }
 

--- a/src/PhysicsInformed/ScientificML/LagrangianNeuralNetwork.cs
+++ b/src/PhysicsInformed/ScientificML/LagrangianNeuralNetwork.cs
@@ -317,7 +317,7 @@ namespace AiDotNet.PhysicsInformed.ScientificML
                     { "ConfigurationDimension", _configurationDim },
                     { "ParameterCount", GetParameterCount() }
                 },
-                ModelData = Serialize()
+                ModelDataProvider = () => Serialize()
             };
         }
 

--- a/src/PhysicsInformed/ScientificML/UniversalDifferentialEquations.cs
+++ b/src/PhysicsInformed/ScientificML/UniversalDifferentialEquations.cs
@@ -402,7 +402,7 @@ namespace AiDotNet.PhysicsInformed.ScientificML
                     { "StateDimension", _stateDim },
                     { "ParameterCount", GetParameterCount() }
                 },
-                ModelData = Serialize()
+                ModelDataProvider = () => Serialize()
             };
         }
 

--- a/src/ProgramSynthesis/Engines/NeuralProgramSynthesizer.cs
+++ b/src/ProgramSynthesis/Engines/NeuralProgramSynthesizer.cs
@@ -678,7 +678,7 @@ public partial class NeuralProgramSynthesizer<T> : TokenLanguageModelLayoutBase<
                 { "LossFunction", LossFunction.GetType().Name },
                 { "Optimizer", _optimizer.GetType().Name }
             },
-            ModelData = Serialize()
+            ModelDataProvider = () => Serialize()
         };
     }
 

--- a/src/TextToSpeech/Latest/MegaTTS2.cs
+++ b/src/TextToSpeech/Latest/MegaTTS2.cs
@@ -198,7 +198,7 @@ public partial class MegaTTS2<T> : TtsModelBase<T>, IEndToEndTts<T>
         m.AdditionalInfo["LayerCount"] = Layers.Count;
         if (_useNativeMode)
         {
-            m.ModelData = this.Serialize();
+            m.SetModelDataProvider(() => this.Serialize());
         }
         return m;
     }

--- a/src/Video/ActionRecognition/TimeSformer.cs
+++ b/src/Video/ActionRecognition/TimeSformer.cs
@@ -639,7 +639,7 @@ public partial class TimeSformer<T> : NeuralNetworkBase<T>
         return new ModelMetadata<T>
         {
             AdditionalInfo = additionalInfo,
-            ModelData = _useNativeMode ? this.Serialize() : []
+            ModelDataProvider = () => _useNativeMode ? this.Serialize() : []
         };
     }
 

--- a/src/Video/Enhancement/BasicVSRPlusPlus.cs
+++ b/src/Video/Enhancement/BasicVSRPlusPlus.cs
@@ -944,7 +944,7 @@ public partial class BasicVSRPlusPlus<T> : VideoSuperResolutionBase<T>
         return new ModelMetadata<T>
         {
             AdditionalInfo = additionalInfo,
-            ModelData = _useNativeMode ? this.Serialize() : Array.Empty<byte>()
+            ModelDataProvider = () => _useNativeMode ? this.Serialize() : Array.Empty<byte>()
         };
     }
 

--- a/src/Video/Enhancement/DualXVSR.cs
+++ b/src/Video/Enhancement/DualXVSR.cs
@@ -175,7 +175,7 @@ public partial class DualXVSR<T> : VideoSuperResolutionBase<T>
             Name = _useNativeMode ? "DualXVSR-Native" : "DualXVSR-ONNX",
             Description = $"DualX-VSR {_options.Variant} dual axial spatial-temporal transformer VSR (2025)",
             Complexity = _options.NumAxialBlocks,
-            ModelData = _useNativeMode ? this.Serialize() : []
+            ModelDataProvider = () => _useNativeMode ? this.Serialize() : []
         };
         m.AdditionalInfo["Variant"] = _options.Variant.ToString();
         m.AdditionalInfo["NumFeatures"] = _options.NumFeatures.ToString();

--- a/src/Video/Generation/AnimateDiff.cs
+++ b/src/Video/Generation/AnimateDiff.cs
@@ -490,7 +490,7 @@ public partial class AnimateDiff<T> : NeuralNetworkBase<T>
         return new ModelMetadata<T>
         {
             AdditionalInfo = additionalInfo,
-            ModelData = _useNativeMode ? this.Serialize() : Array.Empty<byte>()
+            ModelDataProvider = () => _useNativeMode ? this.Serialize() : Array.Empty<byte>()
         };
     }
 

--- a/src/Video/Generation/CogVideo.cs
+++ b/src/Video/Generation/CogVideo.cs
@@ -795,7 +795,7 @@ public partial class CogVideo<T> : NeuralNetworkBase<T>
         return new ModelMetadata<T>
         {
             AdditionalInfo = additionalInfo,
-            ModelData = _useNativeMode ? this.Serialize() : Array.Empty<byte>()
+            ModelDataProvider = () => _useNativeMode ? this.Serialize() : Array.Empty<byte>()
         };
     }
 

--- a/src/Video/RealESRGAN.cs
+++ b/src/Video/RealESRGAN.cs
@@ -1011,7 +1011,7 @@ public partial class RealESRGAN<T> : VideoSuperResolutionBase<T>
         return new ModelMetadata<T>
         {
             AdditionalInfo = additionalInfo,
-            ModelData = _useNativeMode ? this.Serialize() : Array.Empty<byte>()
+            ModelDataProvider = () => _useNativeMode ? this.Serialize() : Array.Empty<byte>()
         };
     }
 

--- a/src/Video/Restoration/VRT.cs
+++ b/src/Video/Restoration/VRT.cs
@@ -495,7 +495,7 @@ public partial class VRT<T> : VideoSuperResolutionBase<T>
         return new ModelMetadata<T>
         {
             AdditionalInfo = additionalInfo,
-            ModelData = _useNativeMode ? this.Serialize() : Array.Empty<byte>()
+            ModelDataProvider = () => _useNativeMode ? this.Serialize() : Array.Empty<byte>()
         };
     }
 

--- a/src/Video/Segmentation/Cutie.cs
+++ b/src/Video/Segmentation/Cutie.cs
@@ -909,7 +909,7 @@ public partial class Cutie<T> : NeuralNetworkBase<T>
         return new ModelMetadata<T>
         {
             AdditionalInfo = additionalInfo,
-            ModelData = _useNativeMode ? this.Serialize() : Array.Empty<byte>()
+            ModelDataProvider = () => _useNativeMode ? this.Serialize() : Array.Empty<byte>()
         };
     }
 

--- a/src/Video/Segmentation/XMem.cs
+++ b/src/Video/Segmentation/XMem.cs
@@ -792,7 +792,7 @@ public partial class XMem<T> : NeuralNetworkBase<T>
         return new ModelMetadata<T>
         {
             AdditionalInfo = additionalInfo,
-            ModelData = _useNativeMode ? this.Serialize() : Array.Empty<byte>()
+            ModelDataProvider = () => _useNativeMode ? this.Serialize() : Array.Empty<byte>()
         };
     }
 

--- a/src/Video/Understanding/InternVideo2.cs
+++ b/src/Video/Understanding/InternVideo2.cs
@@ -496,7 +496,7 @@ public partial class InternVideo2<T> : NeuralNetworkBase<T>
         return new ModelMetadata<T>
         {
             AdditionalInfo = additionalInfo,
-            ModelData = _useNativeMode ? this.Serialize() : Array.Empty<byte>()
+            ModelDataProvider = () => _useNativeMode ? this.Serialize() : Array.Empty<byte>()
         };
     }
 

--- a/tests/AiDotNet.Tests/UnitTests/Models/ModelMetadataLazyModelDataTests.cs
+++ b/tests/AiDotNet.Tests/UnitTests/Models/ModelMetadataLazyModelDataTests.cs
@@ -1,0 +1,125 @@
+using System;
+using AiDotNet.Models;
+using Xunit;
+
+namespace AiDotNet.Tests.UnitTests.Models;
+
+/// <summary>
+/// Regression tests for #1830 — <see cref="ModelMetadata{T}.ModelData"/> must not be produced
+/// until something actually reads it.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Serializing a model is a licensed persistence operation, and <c>AiModelResult</c>'s constructor
+/// captures metadata for EVERY model it wraps (<c>AiModelResult.cs:1710</c>,
+/// <c>ModelMetaData = Model?.GetModelMetadata() ?? new()</c>). While model implementations built
+/// the bytes eagerly — <c>ModelData = this.Serialize()</c> inside an object initializer — merely
+/// calling <c>AiModelBuilder.BuildAsync</c> ran a serialization the caller never asked for, so an
+/// expired trial threw <c>LicenseRequiredException</c> out of the primary training entry point.
+/// </para>
+/// <para>
+/// Deferring is strictly better than catching the exception, which is what the pre-existing
+/// <c>SerializeForMetadata</c> wrapper does: it also stops every build from serializing the whole
+/// model and discarding the bytes unread, and it lets the licence error surface at the point a
+/// caller genuinely asks for the weights instead of silently yielding an empty array.
+/// </para>
+/// </remarks>
+public class ModelMetadataLazyModelDataTests
+{
+    [Fact]
+    public void ModelDataProvider_IsNotInvokedUntilModelDataIsRead()
+    {
+        int invocations = 0;
+        var metadata = new ModelMetadata<double>
+        {
+            ModelDataProvider = () => { invocations++; return new byte[] { 1, 2, 3 }; },
+        };
+
+        // The whole point: constructing metadata must not serialize.
+        Assert.Equal(0, invocations);
+        Assert.False(metadata.IsModelDataMaterialized);
+
+        // Reading other properties must not either — infrastructure inspects metadata freely.
+        Assert.NotNull(metadata.AdditionalInfo);
+        Assert.Equal(0, invocations);
+
+        Assert.Equal(new byte[] { 1, 2, 3 }, metadata.ModelData);
+        Assert.Equal(1, invocations);
+        Assert.True(metadata.IsModelDataMaterialized);
+    }
+
+    [Fact]
+    public void ModelData_IsMaterializedOnlyOnce()
+    {
+        int invocations = 0;
+        var metadata = new ModelMetadata<double>
+        {
+            ModelDataProvider = () => { invocations++; return new byte[] { 7 }; },
+        };
+
+        _ = metadata.ModelData;
+        _ = metadata.ModelData;
+        _ = metadata.ModelData;
+
+        Assert.Equal(1, invocations);
+    }
+
+    [Fact]
+    public void AThrowingProvider_IsNotRetriedOnEveryRead()
+    {
+        // An expired licence is the expected failure, and it is raised from Serialize() deep inside
+        // the provider. Retrying on each read would turn one licence check into an unbounded number
+        // of them, and would re-throw from property getters that callers treat as cheap.
+        int invocations = 0;
+        var metadata = new ModelMetadata<double>
+        {
+            ModelDataProvider = () => { invocations++; throw new InvalidOperationException("boom"); },
+        };
+
+        Assert.Throws<InvalidOperationException>(() => metadata.ModelData);
+        Assert.Equal(1, invocations);
+
+        // Second read does not run the provider again; the metadata is simply empty.
+        Assert.Empty(metadata.ModelData);
+        Assert.Equal(1, invocations);
+    }
+
+    [Fact]
+    public void DirectAssignment_StillWorksAndDiscardsAPendingProvider()
+    {
+        // Back-compat: `ModelData = bytes` is the long-standing shape and must keep working.
+        int invocations = 0;
+        var metadata = new ModelMetadata<double>
+        {
+            ModelDataProvider = () => { invocations++; return new byte[] { 9, 9 }; },
+        };
+
+        metadata.ModelData = new byte[] { 4, 5 };
+
+        Assert.Equal(new byte[] { 4, 5 }, metadata.ModelData);
+        Assert.Equal(0, invocations);
+        Assert.True(metadata.IsModelDataMaterialized);
+    }
+
+    [Fact]
+    public void SetModelDataProvider_DefersOnAnAlreadyConstructedInstance()
+    {
+        // The statement form, used where the metadata object already exists (e.g. MegaTTS2).
+        int invocations = 0;
+        var metadata = new ModelMetadata<double>();
+        metadata.SetModelDataProvider(() => { invocations++; return new byte[] { 8 }; });
+
+        Assert.Equal(0, invocations);
+        Assert.Equal(new byte[] { 8 }, metadata.ModelData);
+        Assert.Equal(1, invocations);
+    }
+
+    [Fact]
+    public void DefaultMetadata_HasEmptyModelDataAndIsMaterialized()
+    {
+        var metadata = new ModelMetadata<double>();
+
+        Assert.Empty(metadata.ModelData);
+        Assert.True(metadata.IsModelDataMaterialized);
+    }
+}

--- a/tests/AiDotNet.Tests/UnitTests/Models/ModelMetadataLazyModelDataTests.cs
+++ b/tests/AiDotNet.Tests/UnitTests/Models/ModelMetadataLazyModelDataTests.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Threading;
+using System.Threading.Tasks;
 using AiDotNet.Models;
 using Xunit;
 
@@ -120,6 +122,76 @@ public class ModelMetadataLazyModelDataTests
         var metadata = new ModelMetadata<double>();
 
         Assert.Empty(metadata.ModelData);
+        Assert.True(metadata.IsModelDataMaterialized);
+    }
+
+    [Fact(Timeout = 10000)]
+    public async Task ConcurrentReaders_WaitForOneMaterializationAndReceiveTheSameBytes()
+    {
+        int invocations = 0;
+        using var providerEntered = new ManualResetEventSlim();
+        using var releaseProvider = new ManualResetEventSlim();
+        using var secondReaderStarted = new ManualResetEventSlim();
+        var expected = new byte[] { 3, 1, 4 };
+        var metadata = new ModelMetadata<double>
+        {
+            ModelDataProvider = () =>
+            {
+                Interlocked.Increment(ref invocations);
+                providerEntered.Set();
+                releaseProvider.Wait();
+                return expected;
+            },
+        };
+
+        Task<byte[]> firstRead = Task.Run(() => metadata.ModelData);
+        Assert.True(providerEntered.Wait(TimeSpan.FromSeconds(5)));
+        Task<byte[]> secondRead = Task.Run(() =>
+        {
+            secondReaderStarted.Set();
+            return metadata.ModelData;
+        });
+        Assert.True(secondReaderStarted.Wait(TimeSpan.FromSeconds(5)));
+
+        releaseProvider.Set();
+        byte[][] results = await Task.WhenAll(firstRead, secondRead);
+
+        Assert.Equal(1, invocations);
+        Assert.All(results, result => Assert.Same(expected, result));
+        Assert.True(metadata.IsModelDataMaterialized);
+    }
+
+    [Fact(Timeout = 10000)]
+    public async Task ConcurrentReaders_WaitWhenTheProviderThrows()
+    {
+        int invocations = 0;
+        using var providerEntered = new ManualResetEventSlim();
+        using var releaseProvider = new ManualResetEventSlim();
+        using var secondReaderStarted = new ManualResetEventSlim();
+        var metadata = new ModelMetadata<double>
+        {
+            ModelDataProvider = () =>
+            {
+                Interlocked.Increment(ref invocations);
+                providerEntered.Set();
+                releaseProvider.Wait();
+                throw new InvalidOperationException("boom");
+            },
+        };
+
+        Task<byte[]> firstRead = Task.Run(() => metadata.ModelData);
+        Assert.True(providerEntered.Wait(TimeSpan.FromSeconds(5)));
+        Task<byte[]> secondRead = Task.Run(() =>
+        {
+            secondReaderStarted.Set();
+            return metadata.ModelData;
+        });
+        Assert.True(secondReaderStarted.Wait(TimeSpan.FromSeconds(5)));
+
+        releaseProvider.Set();
+        await Assert.ThrowsAsync<InvalidOperationException>(async () => await firstRead);
+        Assert.Empty(await secondRead);
+        Assert.Equal(1, invocations);
         Assert.True(metadata.IsModelDataMaterialized);
     }
 }

--- a/tests/AiDotNet.Tests/UnitTests/PhysicsInformed/MultiScaleAndInverseProblemTests.cs
+++ b/tests/AiDotNet.Tests/UnitTests/PhysicsInformed/MultiScaleAndInverseProblemTests.cs
@@ -8,6 +8,7 @@ using AiDotNet.NeuralNetworks;
 using AiDotNet.PhysicsInformed.Interfaces;
 using AiDotNet.PhysicsInformed.PINNs;
 using AiDotNet.Tensors.LinearAlgebra;
+using Moq;
 using Xunit;
 using System.Threading.Tasks;
 
@@ -327,6 +328,60 @@ namespace AiDotNet.Tests.UnitTests.PhysicsInformed
             // Assert
             Assert.Single(initialParams);
             Assert.Equal(5.0, initialParams[0]); // Should match initial guess
+        }
+
+        [Fact(Timeout = 60000)]
+        public async Task InverseProblemPINN_DeferredModelDataRefreshesIdentifiedParameters()
+        {
+            await Task.Yield();
+            var observations = new List<(double[] location, double[] value)>
+            {
+                (new double[] { 0.5, 0.1 }, new double[] { 0.8 })
+            };
+            var inverseProblem = new DiffusionParameterIdentification(observations, initialGuess: 5.0);
+            var boundaryConditions = new IBoundaryCondition<double>[]
+            {
+                new SimpleDirichletBC(position: 0.0, value: 1.0)
+            };
+            var architecture = new NeuralNetworkArchitecture<double>(
+                inputType: InputType.OneDimensional,
+                taskType: NeuralNetworkTaskType.Regression,
+                inputSize: 2,
+                outputSize: 1);
+            var optimizer = new Mock<IGradientBasedOptimizer<double, Tensor<double>, Tensor<double>>>();
+            var pinn = new InverseProblemPINN<double>(
+                architecture,
+                inverseProblem,
+                boundaryConditions,
+                numCollocationPoints: 10,
+                optimizer: optimizer.Object);
+
+            var metadata = pinn.GetModelMetadata();
+            var captured = Assert.IsType<Dictionary<string, object>>(
+                metadata.AdditionalInfo["IdentifiedParameters"]);
+            Assert.Equal(5.0, Assert.IsType<double>(captured["diffusion_coefficient"]));
+
+            pinn.Solve(epochs: 1, learningRate: 0.001, verbose: false);
+            double updatedCoefficient = pinn.Parameters[0];
+            Assert.NotEqual(5.0, updatedCoefficient);
+
+            byte[] modelData = metadata.ModelData;
+            var refreshed = Assert.IsType<Dictionary<string, object>>(
+                metadata.AdditionalInfo["IdentifiedParameters"]);
+            Assert.Equal(updatedCoefficient, Assert.IsType<double>(refreshed["diffusion_coefficient"]));
+
+            var restoredArchitecture = new NeuralNetworkArchitecture<double>(
+                inputType: InputType.OneDimensional,
+                taskType: NeuralNetworkTaskType.Regression,
+                inputSize: 2,
+                outputSize: 1);
+            var restored = new InverseProblemPINN<double>(
+                restoredArchitecture,
+                inverseProblem,
+                boundaryConditions,
+                numCollocationPoints: 10);
+            restored.Deserialize(modelData);
+            Assert.Equal(updatedCoefficient, restored.Parameters[0]);
         }
 
         #endregion


### PR DESCRIPTION
Closes #1830. Second of the v1 Tier-1 items from the audit; PR #2094 carries the first.

## The defect

`AiModelResult`'s constructor captures metadata for **every** model it wraps:

```csharp
// AiModelResult.cs:1710
ModelMetaData = Model?.GetModelMetadata() ?? new();
```

and model implementations built the bytes eagerly, inside an object initializer:

```csharp
ModelData = UseNativeMode ? this.Serialize() : Array.Empty<byte>()
```

`Serialize()` is a licensed persistence operation — every model base calls `ModelPersistenceGuard.EnforceBeforeSerialize()` (37 call sites). So simply calling `AiModelBuilder.BuildAsync` ran a full model serialization the caller never asked for, and an expired trial threw `LicenseRequiredException` **out of the primary training entry point**.

## The fix: materialize on read

`ModelMetadata<T>.ModelData` is now produced on first read. The type gains:

- `ModelDataProvider` — `init`-only, so it drops straight into the object initializer models already return
- `SetModelDataProvider(...)` — for instances that already exist
- `IsModelDataMaterialized` — lets infrastructure inspect metadata without forcing the work. `ModelData.Length == 0` cannot answer that question, because reading it materializes.

Direct assignment (`ModelData = bytes`) still works and discards any pending provider, so the long-standing shape is unaffected.

**Deferring beats catching the exception**, which is what the pre-existing `SerializeForMetadata` wrapper does:

- it stops every build serializing the whole model and discarding the bytes unread — a real cost at foundation scale, not a micro-optimization;
- the licence error surfaces where a caller genuinely asks for the weights, instead of silently yielding an empty array that looks like a successful empty model.

A throwing provider is cleared **before** invocation, so an expired licence is not re-thrown from every subsequent property read and a re-entrant provider cannot recurse.

## Scope, and what the investigation corrected

The issue said "14+ models"; the 2026-08-14 note said "20+". Both undercounted, and the reason is instructive — three different serialization wrappers are in play, and they are **not** equivalent:

| Wrapper | Catches | Exposed to this bug? | Sites |
|---|---|---|---:|
| direct `this.Serialize()` | nothing | **yes** | 74 |
| `SafeSerialize()` | `OutOfMemoryException` only | **yes** | 23 |
| `SafeSerializeMaterializedModel()` | delegates to `SafeSerialize` | **yes** | 5 |
| `SerializeForMetadata()` | **`LicenseRequiredException`** | no — already crash-safe | 191 |

So the true exposed set was 74 direct sites plus the 28 `SafeSerialize` callers — not 191, and not 14.

**74 call sites converted:** 73 object initializers to `ModelDataProvider`, and `MegaTTS2`'s statement form to `SetModelDataProvider`.

**The 28 `SafeSerialize` callers are fixed by one edit**, because `SafeSerialize` is declared exactly once, in `DocumentNeuralNetworkBase`. It now also degrades on `LicenseRequiredException`, matching what `NeuralNetworkBase.SerializeForMetadata` already does — metadata without the serialized weights is still useful; a failed build is not.

## Not in this PR

The 191 `SerializeForMetadata` sites are crash-safe already, but they still serialize the entire model on every build and throw the bytes away unread. Converting them to the same provider is a clear follow-up — deliberately left out to stay inside the 100-file review limit.

## Tests

`ModelMetadataLazyModelDataTests` — six assertions, each pinning a property that would otherwise be easy to regress:

- the provider is **not** invoked on construction, nor when other metadata properties are read
- it runs exactly once across repeated reads
- a throwing provider is not retried on every read
- direct assignment still works and discards a pending provider
- `SetModelDataProvider` defers on an already-constructed instance
- default metadata is empty and already materialized

## Verification

- Builds clean on **net10.0 and net471**.
- New tests: **6/6 pass**.
- **Behaviour unchanged:** the same 1399-test batch reports **1359 passed / 3 failed / 37 skipped**, identical to the baseline. The 3 failures are the pre-existing FastSpeech2 divergence tracked in #2093, unrelated to this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GYQycGHKxLFBqhEtPMHz29


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Model metadata now generates serialized model data on demand, reducing unnecessary work and memory usage.
  * Serialized data is cached after first access and remains consistent across subsequent reads.
  * Native and ONNX model behavior remains supported, with ONNX metadata providing empty model data.

* **Bug Fixes**
  * Serialization now safely returns empty model data when a required license is unavailable or memory limits prevent serialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->