### PR TITLE
fix(finance/rl): the DQN, A2C and SAC trading agents could not learn

### DIFF
--- a/.github/PR2100_REVIEW_PROOF.md
+++ b/.github/PR2100_REVIEW_PROOF.md
@@ -1,0 +1,47 @@
+# PR #2100 review-fix proof
+
+Baseline: `8c1a059c73254136c076a540ac5b82504e3e5499`.
+
+The whole existing `TradingAgentLearningTests` class was run against real
+AiDotNet source, its generators, the repository deterministic CPU initializer,
+and published AiDotNet.Tensors 0.130.3. A narrow temporary test project compiled
+that class and its normal global imports, not replacement agent implementations.
+This is not a full model-family or repository test-run claim.
+
+| Source | Observed result |
+| --- | --- |
+| Unchanged baseline, complete finance class | 8 passed, 3 failed, 0 skipped |
+| Fixed class with direct-update/invalid-update/mixed-replay controls | 11 passed, 0 failed/skipped, repeated |
+| Independent final repetition | 11 passed, 0 failed/skipped |
+
+The seeded A2C test fixes and verifies the actual policy parameters, then checks
+all 600 one-hot actions against the configured random stream. The old sampler
+ignored that stream. Sampling now reuses the seeded base-class random source,
+also avoiding per-draw secure-random creation.
+
+Two DQN regressions demonstrate actual online-weight changes while the old
+direct-update path left TrainingSteps at zero. Both direct gradients and replay
+now complete the same training step: one counter advance, epsilon update and
+scheduled target copy. Tests inspect real online and target parameters, prove
+staleness between copies, exact equality at copy boundaries, and no mutation or
+schedule advance for a rejected gradient. No tolerance was widened.
+
+The documentation thread was already addressed at the baseline: IsFinite,
+Softmax and SampleAction each have an attached summary/remarks block.
+
+For a normal repository checkout, the same checked-in cases run with:
+
+```powershell
+dotnet test tests/AiDotNet.Tests/AiDotNet.Tests.csproj -c Release -f net10.0 --filter FullyQualifiedName~TradingAgentLearningTests --logger "trx;LogFileName=finance-review.trx"
+```
+
+The independent bounded local execution used the temporary source-linked harness
+and preserved `before-full-finance.trx`, `after-review-fixes-final.trx`,
+`after-review-fixes-final-repeat.trx`, and `after-root-independent.trx`.
+Baseline AiDotNet.dll SHA-256:
+`CFC71687656A1E6C45B893AEEB149069571E6E20A9EBEAC1513B044D59F55F74`.
+Fixed AiDotNet.dll SHA-256:
+`63B0EC5F45EC39BB57D98BA6F6885180B33237FD5A9CCD25901E4FA28BFD6913`.
+Builds succeeded with existing analyzer warnings. No unpublished dependency,
+null-forgiving operator, public test hook, or new string-based policy mode was
+introduced.

--- a/src/Finance/Trading/Agents/FinancialA2CAgent.cs
+++ b/src/Finance/Trading/Agents/FinancialA2CAgent.cs
@@ -120,7 +120,7 @@ public partial class FinancialA2CAgent<T> : TradingAgentBase<T>, IGradientComput
     /// </remarks>
     public override Vector<T> SelectAction(Vector<T> state, bool training = true)
     {
-        var probs = _actor.Predict(Tensor<T>.FromVector(state)).ToVector();
+        var probs = Softmax(_actor.Predict(Tensor<T>.FromVector(state)).ToVector());
         
         if (training)
         {
@@ -154,6 +154,79 @@ public partial class FinancialA2CAgent<T> : TradingAgentBase<T>, IGradientComput
     /// <b>For Beginners:</b> In the FinancialA2CAgent model, SampleAction performs a supporting step in the workflow. It keeps the FinancialA2CAgent architecture pipeline consistent.
     /// </para>
     /// </remarks>
+    /// <summary>
+    /// Turns the actor's raw outputs into a probability distribution.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The actor is built with <see cref="NeuralNetworkTaskType.Regression"/>, so its output layer carries an
+    /// identity activation and produces UNBOUNDED REALS. Those used to be fed straight into the inverse-CDF
+    /// sampler as if they were probabilities, and they are not: a negative output makes the running cumulative
+    /// non-monotonic, so an action can be skipped entirely, and when the outputs sum to less than 1 the loop
+    /// falls off the end and returns the LAST index every time. Exploration therefore collapsed onto the first
+    /// or last action and never sampled the interior ones - for a trading agent whose middle action is "hold",
+    /// it could not choose to do nothing. PPO does this correctly; A2C did not.
+    /// </para>
+    /// <para>
+    /// Shifted by the maximum before exponentiating, the standard guard against overflow on a large logit,
+    /// which changes nothing about the result.
+    /// </para>
+    /// <para>
+    /// <b>For Beginners:</b> Softmax turns any list of numbers into positive values that add up to 1, so they
+    /// can be read as "how likely is each choice".
+    /// </para>
+    /// </remarks>
+    /// <summary>Finite check that also compiles on net471, where <c>double.IsFinite</c> does not exist.</summary>
+    private static bool IsFinite(double value) => !double.IsNaN(value) && !double.IsInfinity(value);
+
+    private Vector<T> Softmax(Vector<T> logits)
+    {
+        var result = new Vector<T>(logits.Length);
+        if (logits.Length == 0)
+        {
+            return result;
+        }
+
+        double max = double.NegativeInfinity;
+        for (int i = 0; i < logits.Length; i++)
+        {
+            var value = NumOps.ToDouble(logits[i]);
+            if (IsFinite(value) && value > max)
+            {
+                max = value;
+            }
+        }
+
+        if (!IsFinite(max))
+        {
+            // Every output was NaN or infinite. A uniform distribution is the honest answer: the network has
+            // said nothing, and returning one action with certainty would be inventing a preference.
+            var uniform = 1.0 / logits.Length;
+            for (int i = 0; i < result.Length; i++)
+            {
+                result[i] = NumOps.FromDouble(uniform);
+            }
+
+            return result;
+        }
+
+        double sum = 0;
+        var exponentials = new double[logits.Length];
+        for (int i = 0; i < logits.Length; i++)
+        {
+            var value = NumOps.ToDouble(logits[i]);
+            exponentials[i] = IsFinite(value) ? Math.Exp(value - max) : 0.0;
+            sum += exponentials[i];
+        }
+
+        for (int i = 0; i < result.Length; i++)
+        {
+            result[i] = NumOps.FromDouble(sum > 0 ? exponentials[i] / sum : 1.0 / logits.Length);
+        }
+
+        return result;
+    }
+
     private int SampleAction(Vector<T> probabilities)
     {
         double r = RandomHelper.CreateSecureRandom().NextDouble();

--- a/src/Finance/Trading/Agents/FinancialA2CAgent.cs
+++ b/src/Finance/Trading/Agents/FinancialA2CAgent.cs
@@ -229,7 +229,7 @@ public partial class FinancialA2CAgent<T> : TradingAgentBase<T>, IGradientComput
     /// </remarks>
     private int SampleAction(Vector<T> probabilities)
     {
-        double r = RandomHelper.CreateSecureRandom().NextDouble();
+        double r = Random.NextDouble();
         double cumulative = 0;
         for (int i = 0; i < probabilities.Length; i++)
         {

--- a/src/Finance/Trading/Agents/FinancialA2CAgent.cs
+++ b/src/Finance/Trading/Agents/FinancialA2CAgent.cs
@@ -146,14 +146,9 @@ public partial class FinancialA2CAgent<T> : TradingAgentBase<T>, IGradientComput
         return result;
     }
 
-    /// <summary>
-    /// Executes SampleAction for the FinancialA2CAgent.
-    /// </summary>
-    /// <remarks>
-    /// <para>
-    /// <b>For Beginners:</b> In the FinancialA2CAgent model, SampleAction performs a supporting step in the workflow. It keeps the FinancialA2CAgent architecture pipeline consistent.
-    /// </para>
-    /// </remarks>
+    /// <summary>Finite check that also compiles on net471, where <c>double.IsFinite</c> does not exist.</summary>
+    private static bool IsFinite(double value) => !double.IsNaN(value) && !double.IsInfinity(value);
+
     /// <summary>
     /// Turns the actor's raw outputs into a probability distribution.
     /// </summary>
@@ -176,9 +171,6 @@ public partial class FinancialA2CAgent<T> : TradingAgentBase<T>, IGradientComput
     /// can be read as "how likely is each choice".
     /// </para>
     /// </remarks>
-    /// <summary>Finite check that also compiles on net471, where <c>double.IsFinite</c> does not exist.</summary>
-    private static bool IsFinite(double value) => !double.IsNaN(value) && !double.IsInfinity(value);
-
     private Vector<T> Softmax(Vector<T> logits)
     {
         var result = new Vector<T>(logits.Length);
@@ -227,6 +219,14 @@ public partial class FinancialA2CAgent<T> : TradingAgentBase<T>, IGradientComput
         return result;
     }
 
+    /// <summary>
+    /// Executes SampleAction for the FinancialA2CAgent.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>For Beginners:</b> In the FinancialA2CAgent model, SampleAction performs a supporting step in the workflow. It keeps the FinancialA2CAgent architecture pipeline consistent.
+    /// </para>
+    /// </remarks>
     private int SampleAction(Vector<T> probabilities)
     {
         double r = RandomHelper.CreateSecureRandom().NextDouble();

--- a/src/Finance/Trading/Agents/FinancialDQNAgent.cs
+++ b/src/Finance/Trading/Agents/FinancialDQNAgent.cs
@@ -61,6 +61,11 @@ public partial class FinancialDQNAgent<T> : TradingAgentBase<T>, IGradientComput
     private readonly ReplayBuffer<T> ReplayBuffer;
     private readonly NeuralNetworkArchitecture<T> _architecture;
 
+    /// <summary>Current exploration rate, decayed from EpsilonStart toward EpsilonEnd on every training step.</summary>
+    private double _epsilon;
+
+
+
     /// <inheritdoc/>
     public override ModelOptions GetOptions() => _options;
 
@@ -109,8 +114,23 @@ public partial class FinancialDQNAgent<T> : TradingAgentBase<T>, IGradientComput
         _qNetwork = new NeuralNetwork<T>(architecture, lossFunction: TradingOptions.LossFunction ?? new MeanSquaredErrorLoss<T>());
         _targetNetwork = new NeuralNetwork<T>(architecture.CloneForModelConstruction(), lossFunction: TradingOptions.LossFunction ?? new MeanSquaredErrorLoss<T>());
         ReplayBuffer = new ReplayBuffer<T>(options.ReplayBufferSize, options.Seed);
+        _epsilon = TradingOptions.EpsilonStart;
         UpdateTargetNetwork();
     }
+
+    /// <summary>
+    /// Current exploration rate. Starts at <c>EpsilonStart</c> and decays toward <c>EpsilonEnd</c>.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>For Beginners:</b> Epsilon is how often the agent ignores what it has learned and tries something at
+    /// random. It should start high (explore) and fall (exploit what you found). Exposed so a training loop can
+    /// record the curve and confirm that is actually happening.
+    /// </para>
+    /// </remarks>
+    public double Epsilon => _epsilon;
+
+
 
     #endregion
 
@@ -124,7 +144,14 @@ public partial class FinancialDQNAgent<T> : TradingAgentBase<T>, IGradientComput
     /// </remarks>
     public override Vector<T> SelectAction(Vector<T> state, bool training = true)
     {
-        if (training && RandomHelper.CreateSecureRandom().NextDouble() < TradingOptions.EpsilonStart)
+        // Compares against the CURRENT epsilon, not EpsilonStart.
+        //
+        // This read TradingOptions.EpsilonStart directly. EpsilonStart defaults to 1.0 and nothing ever
+        // decayed it - EpsilonEnd and EpsilonDecay were declared, validated against each other, and read by
+        // nobody - so the behaviour policy was 100% uniform random for the entire run. Every "learning curve"
+        // it produced was the return of a random policy, and the network's own Q-values were never once acted
+        // on during training.
+        if (training && RandomHelper.CreateSecureRandom().NextDouble() < _epsilon)
         {
             var action = new Vector<T>(TradingOptions.ActionSize);
             int randomAction = RandomHelper.CreateSecureRandom().Next(TradingOptions.ActionSize);
@@ -224,7 +251,22 @@ public partial class FinancialDQNAgent<T> : TradingAgentBase<T>, IGradientComput
         var expected = new Tensor<T>([n, actionCount], expectedData);
         _qNetwork.Train(states, expected);
 
-        if (RandomHelper.CreateSecureRandom().Next(TradingOptions.TargetUpdateFrequency) == 0)
+        // The inherited counter, which every other agent advances in its own Train() and which the state
+        // generator serialises. This agent never advanced it at all, so nothing downstream could tell how much
+        // training had happened.
+        TrainingSteps++;
+
+        // Decay epsilon toward EpsilonEnd. Multiplicative, matching what EpsilonDecay (0.995) means and what
+        // the reference DQNAgent already does.
+        _epsilon = Math.Max(TradingOptions.EpsilonEnd, _epsilon * TradingOptions.EpsilonDecay);
+
+        // Sync the target network on a DETERMINISTIC schedule.
+        //
+        // This was `rng.Next(TargetUpdateFrequency) == 0` - a coin flip with probability 1/N per step, not
+        // "every N steps". At the default N = 1000 a 600-step run expects 0.6 syncs, so the target network
+        // usually held its initial random weights for the whole run and the TD target was noise. It is also
+        // unreproducible: two runs with the same seed synced at different steps.
+        if (TrainingSteps % Math.Max(1, TradingOptions.TargetUpdateFrequency) == 0)
         {
             UpdateTargetNetwork();
         }

--- a/src/Finance/Trading/Agents/FinancialDQNAgent.cs
+++ b/src/Finance/Trading/Agents/FinancialDQNAgent.cs
@@ -58,6 +58,17 @@ public partial class FinancialDQNAgent<T> : TradingAgentBase<T>, IGradientComput
     private readonly INeuralNetwork<T> _qNetwork;
     [Buffer]
     private readonly INeuralNetwork<T> _targetNetwork;
+
+    /// <summary>How many times the target network has been synchronised from the online network.</summary>
+    /// <remarks>
+    /// Reported through <see cref="GetTradingMetrics"/> because the synchronisation SCHEDULE is not otherwise
+    /// observable from outside, and it is the single change with the largest effect on whether this agent
+    /// learns at all. The previous condition was <c>rng.Next(TargetUpdateFrequency) == 0</c> - a coin flip
+    /// giving roughly 0.6 expected syncs across an entire run, so the TD target was computed from the network
+    /// being updated in the same batch. A regression to that form changes no other observable behaviour, so
+    /// without this counter every existing assertion would keep passing while learning quietly broke again.
+    /// </remarks>
+    private int _targetSyncCount;
     private readonly ReplayBuffer<T> ReplayBuffer;
     private readonly NeuralNetworkArchitecture<T> _architecture;
 
@@ -287,6 +298,12 @@ public partial class FinancialDQNAgent<T> : TradingAgentBase<T>, IGradientComput
     {
         var metrics = base.GetTradingMetrics();
         metrics["Epsilon"] = NumOps.FromDouble(_epsilon);
+        metrics["TargetSyncCount"] = NumOps.FromDouble(_targetSyncCount);
+        // Reported alongside the sync count so the SCHEDULE can be checked, not just the total: with both,
+        // TargetSyncCount == 1 + TrainingSteps / TargetUpdateFrequency is an exact identity under the
+        // deterministic condition, and a probabilistic one cannot satisfy it. The 1 is the synchronisation
+        // the constructor performs so the two networks start equal.
+        metrics["TrainingSteps"] = NumOps.FromDouble(TrainingSteps);
         return metrics;
     }
 
@@ -301,6 +318,7 @@ public partial class FinancialDQNAgent<T> : TradingAgentBase<T>, IGradientComput
     private void UpdateTargetNetwork()
     {
         _targetNetwork.UpdateParameters(_qNetwork.GetParameters());
+        _targetSyncCount++;
     }
 
     /// <summary>

--- a/src/Finance/Trading/Agents/FinancialDQNAgent.cs
+++ b/src/Finance/Trading/Agents/FinancialDQNAgent.cs
@@ -261,10 +261,16 @@ public partial class FinancialDQNAgent<T> : TradingAgentBase<T>, IGradientComput
 
         var expected = new Tensor<T>([n, actionCount], expectedData);
         _qNetwork.Train(states, expected);
+        CompleteTrainingStep();
 
-        // The inherited counter, which every other agent advances in its own Train() and which the state
-        // generator serialises. This agent never advanced it at all, so nothing downstream could tell how much
-        // training had happened.
+        return NumOps.Zero;
+    }
+
+    /// <summary>
+    /// Advances the shared exploration and target-network schedule after a successful online update.
+    /// </summary>
+    private void CompleteTrainingStep()
+    {
         TrainingSteps++;
 
         // Decay epsilon toward EpsilonEnd. Multiplicative, matching what EpsilonDecay (0.995) means and what
@@ -282,7 +288,6 @@ public partial class FinancialDQNAgent<T> : TradingAgentBase<T>, IGradientComput
             UpdateTargetNetwork();
         }
 
-        return NumOps.Zero;
     }
 
     /// <summary>
@@ -450,7 +455,7 @@ public partial class FinancialDQNAgent<T> : TradingAgentBase<T>, IGradientComput
     public void ApplyGradients(Vector<T> gradients, T learningRate)
     {
         _qNetwork.ApplyGradients(gradients, learningRate);
-        UpdateTargetNetwork();
+        CompleteTrainingStep();
     }
 
     #endregion

--- a/src/Finance/Trading/Agents/FinancialDQNAgent.cs
+++ b/src/Finance/Trading/Agents/FinancialDQNAgent.cs
@@ -275,6 +275,22 @@ public partial class FinancialDQNAgent<T> : TradingAgentBase<T>, IGradientComput
     }
 
     /// <summary>
+    /// Publishes the current exploration rate alongside the trading metrics.
+    /// </summary>
+    /// <remarks>
+    /// The <see cref="Epsilon"/> property already exposes this to anything holding the concrete agent. A
+    /// consumer that collects metrics generically - a bake-off harness recording one row per agent, which is
+    /// how this defect was found - only sees the dictionary, and there an agent that annealed and one that
+    /// never explored are indistinguishable. DoubleDQNAgent already publishes "Epsilon"; this matches it.
+    /// </remarks>
+    public override Dictionary<string, T> GetTradingMetrics()
+    {
+        var metrics = base.GetTradingMetrics();
+        metrics["Epsilon"] = NumOps.FromDouble(_epsilon);
+        return metrics;
+    }
+
+    /// <summary>
     /// Executes UpdateTargetNetwork for the FinancialDQNAgent.
     /// </summary>
     /// <remarks>

--- a/src/Finance/Trading/Agents/FinancialSACAgent.cs
+++ b/src/Finance/Trading/Agents/FinancialSACAgent.cs
@@ -55,6 +55,15 @@ public partial class FinancialSACAgent<T> : TradingAgentBase<T>, IGradientComput
 
     #region Fields
 
+    /// <summary>
+    /// Half-width of the symmetric exploration noise added to the actor's output during training.
+    /// </summary>
+    /// <remarks>
+    /// Preserves the previous magnitude (the old noise spanned 0.1) while centring it on zero, so this changes
+    /// the BIAS without changing how far the agent explores.
+    /// </remarks>
+    private const double ExplorationNoiseScale = 0.05;
+
     private readonly TradingAgentOptions<T> _options;
     private readonly INeuralNetwork<T> _actor;
     private readonly INeuralNetwork<T> _critic1;
@@ -134,7 +143,17 @@ public partial class FinancialSACAgent<T> : TradingAgentBase<T>, IGradientComput
             // Stochastic policy (simplified with noise)
             var noise = new Vector<T>(action.Length);
             for (int i = 0; i < noise.Length; i++)
-                noise[i] = NumOps.FromDouble(RandomHelper.CreateSecureRandom().NextDouble() * 0.1);
+            {
+                // ZERO-MEAN, symmetric about the actor's output.
+                //
+                // This was `NextDouble() * 0.1`: uniform on [0, 0.1), so its mean is +0.05 and it is NEVER
+                // negative. Every exploratory action was pushed in one direction, which for a trading agent
+                // whose action is a signed position means it explored only the long side - and the bias does
+                // not average out over a run, it accumulates into the experience the critics learn from.
+                // Exploration noise has to be centred on the policy it explores around, or it is not
+                // exploration, it is a drift.
+                noise[i] = NumOps.FromDouble(((RandomHelper.CreateSecureRandom().NextDouble() * 2.0) - 1.0) * ExplorationNoiseScale);
+            }
             
             return action.Add(noise);
         }

--- a/src/Finance/Trading/Agents/FinancialSACAgent.cs
+++ b/src/Finance/Trading/Agents/FinancialSACAgent.cs
@@ -142,6 +142,13 @@ public partial class FinancialSACAgent<T> : TradingAgentBase<T>, IGradientComput
         {
             // Stochastic policy (simplified with noise)
             var noise = new Vector<T>(action.Length);
+            // One generator for the whole vector, not one per element. CreateSecureRandom builds a
+            // cryptographic generator, which costs far more than the single NextDouble draw it was
+            // serving, and SelectAction runs every training step - so this was constructing ActionSize
+            // generators per step. Exploration noise is not a security-sensitive value, and drawing
+            // every element from one generator is no less random than drawing each from its own.
+            var noiseSource = RandomHelper.CreateSecureRandom();
+
             for (int i = 0; i < noise.Length; i++)
             {
                 // ZERO-MEAN, symmetric about the actor's output.
@@ -152,7 +159,7 @@ public partial class FinancialSACAgent<T> : TradingAgentBase<T>, IGradientComput
                 // not average out over a run, it accumulates into the experience the critics learn from.
                 // Exploration noise has to be centred on the policy it explores around, or it is not
                 // exploration, it is a drift.
-                noise[i] = NumOps.FromDouble(((RandomHelper.CreateSecureRandom().NextDouble() * 2.0) - 1.0) * ExplorationNoiseScale);
+                noise[i] = NumOps.FromDouble(((noiseSource.NextDouble() * 2.0) - 1.0) * ExplorationNoiseScale);
             }
             
             return action.Add(noise);

--- a/tests/AiDotNet.Tests/IntegrationTests/Finance/TradingAgentLearningTests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/Finance/TradingAgentLearningTests.cs
@@ -1,0 +1,217 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using AiDotNet.Finance.Trading.Agents;
+using AiDotNet.Helpers;
+using AiDotNet.LinearAlgebra;
+using AiDotNet.Enums;
+using AiDotNet.Models.Options;
+using AiDotNet.NeuralNetworks;
+using Xunit;
+
+namespace AiDotNet.Tests.IntegrationTests.Finance;
+
+/// <summary>
+/// These agents could not learn a policy, for reasons independent of any environment they were given.
+///
+/// <para>DQN's behaviour policy was 100% uniform random for the entire run and its target network almost never
+/// synced; A2C treated unbounded regression outputs as a probability distribution, so exploration collapsed
+/// onto the first or last action; and SAC's exploration noise had a positive mean, so every exploratory action
+/// was pushed one way. Each is asserted here directly rather than inferred from a learning curve, because a
+/// learning curve produced by a uniformly random policy looks like noise either way.</para>
+/// </summary>
+public class TradingAgentLearningTests
+{
+    private const int StateSize = 10;
+    private const int ActionSize = 3;
+
+    /// <summary>The ACTOR: state in, one output per action.</summary>
+    private static NeuralNetworkArchitecture<double> Actor() => Architecture(StateSize, ActionSize);
+
+    /// <summary>The CRITIC: a value function, so ONE output. SAC's critic is a Q-network and takes the action
+    /// alongside the state, which is why its input is state + action wide.</summary>
+    private static NeuralNetworkArchitecture<double> Critic(bool takesAction = false) =>
+        Architecture(takesAction ? StateSize + ActionSize : StateSize, 1);
+
+    private static NeuralNetworkArchitecture<double> Architecture(int inputSize, int outputSize) =>
+        new(
+            inputType: InputType.OneDimensional,
+            taskType: NeuralNetworkTaskType.Regression,
+            complexity: NetworkComplexity.Simple,
+            inputSize: inputSize,
+            outputSize: outputSize);
+
+    private static Vector<double> State(int seed)
+    {
+        var random = new Random(seed);
+        var state = new Vector<double>(StateSize);
+        for (var i = 0; i < StateSize; i++)
+        {
+            state[i] = (random.NextDouble() * 2.0) - 1.0;
+        }
+
+        return state;
+    }
+
+    private static void TrainSteps(FinancialDQNAgent<double> agent, int steps)
+    {
+        var numOps = MathHelper.GetNumericOperations<double>();
+        for (var step = 0; step < steps; step++)
+        {
+            var state = State(step);
+            var action = agent.SelectTradingAction(state, training: true);
+            agent.StoreTradingExperience(
+                state, action, numOps.FromDouble(0.01), State(step + 1), done: false, pnl: numOps.FromDouble(0.01));
+            _ = agent.TrainOnExperiences();
+        }
+    }
+
+    [Fact]
+    public void Dqn_epsilon_decays_from_start_toward_end()
+    {
+        // THE DEFECT. SelectAction compared against TradingOptions.EpsilonStart, which defaults to 1.0 and was
+        // never decayed - EpsilonEnd and EpsilonDecay were declared, validated against each other, and read by
+        // nobody. The behaviour policy was uniform random for the whole run, so the network's own Q-values were
+        // never once acted on during training.
+        var options = new FinancialDQNAgentOptions<double>
+        {
+            StateSize = StateSize,
+            ActionSize = ActionSize,
+            EpsilonStart = 1.0,
+            EpsilonEnd = 0.05,
+            EpsilonDecay = 0.9,
+            BatchSize = 4,
+            TargetUpdateFrequency = 10,
+        };
+
+        using var agent = new FinancialDQNAgent<double>(Actor(), options);
+
+        Assert.Equal(1.0, agent.Epsilon, 9);
+
+        TrainSteps(agent, 40);
+
+        Assert.True(agent.Epsilon < 1.0, $"epsilon never moved from EpsilonStart (still {agent.Epsilon})");
+        Assert.True(agent.Epsilon >= options.EpsilonEnd, $"epsilon fell below EpsilonEnd ({agent.Epsilon})");
+    }
+
+    [Fact]
+    public void Dqn_epsilon_is_monotonically_non_increasing()
+    {
+        var options = new FinancialDQNAgentOptions<double>
+        {
+            StateSize = StateSize,
+            ActionSize = ActionSize,
+            EpsilonStart = 1.0,
+            EpsilonEnd = 0.01,
+            EpsilonDecay = 0.95,
+            BatchSize = 4,
+            TargetUpdateFrequency = 10,
+        };
+
+        using var agent = new FinancialDQNAgent<double>(Actor(), options);
+        var curve = new List<double> { agent.Epsilon };
+        for (var i = 0; i < 30; i++)
+        {
+            TrainSteps(agent, 1);
+            curve.Add(agent.Epsilon);
+        }
+
+        for (var i = 1; i < curve.Count; i++)
+        {
+            Assert.True(curve[i] <= curve[i - 1], $"epsilon rose at step {i}: {curve[i - 1]} -> {curve[i]}");
+        }
+
+        Assert.True(curve[^1] < curve[0]);
+    }
+
+    [Fact]
+    public void A2c_samples_from_a_real_distribution_rather_than_falling_through()
+    {
+        // THE DEFECT. The actor is built with NeuralNetworkTaskType.Regression, so its outputs are unbounded
+        // reals with an identity activation - and they were fed straight into an inverse-CDF sampler as if they
+        // were probabilities:
+        //
+        //     cumulative += probs[i];  if (r < cumulative) return i;   ... return LAST index
+        //
+        // A freshly initialised network produces small outputs that do not sum to 1, so the running cumulative
+        // rarely reaches a uniform r in [0,1) and the loop FALLS OFF THE END - returning the last action almost
+        // every time. A negative output additionally makes the cumulative non-monotonic, so an action can be
+        // skipped entirely. Exploration was therefore all but deterministic on the last tier, and a trading
+        // agent whose middle action is "hold" could not choose to do nothing.
+        //
+        // A FIXED state is used deliberately: varying it per sample lets different states land on different
+        // actions and hides the fall-through behind that variation. With one state, sampling either explores
+        // or it does not.
+        var options = new FinancialA2CAgentOptions<double>
+        {
+            StateSize = StateSize,
+            ActionSize = ActionSize,
+            Seed = 4242,
+        };
+
+        using var agent = new FinancialA2CAgent<double>(Actor(), Critic(), options);
+
+        var state = State(11);
+        var counts = new int[ActionSize];
+        const int samples = 600;
+        for (var i = 0; i < samples; i++)
+        {
+            var action = agent.SelectTradingAction(state, training: true);
+            for (var a = 0; a < action.Length; a++)
+            {
+                if (action[a] != 0.0)
+                {
+                    counts[a]++;
+                }
+            }
+        }
+
+        var share = counts.Select(c => (double)c / samples).ToArray();
+        var dominant = share.Max();
+
+        Assert.True(
+            dominant < 0.95,
+            $"one action took {dominant:P0} of {samples} draws from a SINGLE state "
+            + $"({string.Join(", ", share.Select((v, i) => $"a{i}={v:P0}"))}) - that is the sampler falling "
+            + "through, not sampling");
+
+        // And every action must be reachable at all.
+        Assert.All(counts, c => Assert.True(c > 0, $"an action was never chosen in {samples} draws"));
+    }
+
+    [Fact]
+    public void Sac_exploration_noise_is_centred_on_the_policy()
+    {
+        // THE DEFECT. The noise was `NextDouble() * 0.1` - uniform on [0, 0.1), mean +0.05, never negative. For
+        // an agent whose action is a signed position that means it explored only the long side, and the bias
+        // does not average out over a run: it accumulates into the experience the critics learn from.
+        var options = new FinancialSACAgentOptions<double>
+        {
+            StateSize = StateSize,
+            ActionSize = ActionSize,
+            Seed = 909,
+        };
+
+        using var agent = new FinancialSACAgent<double>(Actor(), Critic(takesAction: true), options);
+
+        var state = State(7);
+        var deterministic = agent.SelectTradingAction(state, training: false);
+
+        var deltas = new List<double>();
+        for (var i = 0; i < 800; i++)
+        {
+            var explored = agent.SelectTradingAction(state, training: true);
+            for (var a = 0; a < explored.Length; a++)
+            {
+                deltas.Add(explored[a] - deterministic[a]);
+            }
+        }
+
+        Assert.Contains(deltas, d => d < 0);   // it can explore DOWNWARD at all
+        Assert.Contains(deltas, d => d > 0);
+
+        // Symmetric: the mean perturbation is near zero, not near the old +0.05.
+        var mean = deltas.Average();
+        Assert.True(Math.Abs(mean) < 0.01, $"exploration noise has a mean of {mean:F4}; it must be centred on the policy");
+    }
+}

--- a/tests/AiDotNet.Tests/IntegrationTests/Finance/TradingAgentLearningTests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/Finance/TradingAgentLearningTests.cs
@@ -1,8 +1,10 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using AiDotNet.Finance.Trading.Agents;
 using AiDotNet.Helpers;
+using AiDotNet.Interfaces;
 using AiDotNet.LinearAlgebra;
 using AiDotNet.Enums;
 using AiDotNet.Models.Options;
@@ -39,7 +41,7 @@ public class TradingAgentLearningTests
             taskType: NeuralNetworkTaskType.Regression,
             complexity: NetworkComplexity.Simple,
             inputSize: inputSize,
-            outputSize: outputSize);
+            outputSize: outputSize) { RandomSeed = 271828 };
 
     private static Vector<double> State(int seed)
     {
@@ -159,6 +161,74 @@ public class TradingAgentLearningTests
         Assert.Equal(0.3, agent.Epsilon, 9);
     }
 
+    [Theory]
+    [InlineData(2)]
+    [InlineData(5)]
+    public void Dqn_direct_gradients_share_the_training_and_target_schedule(int frequency)
+    {
+        var options = new FinancialDQNAgentOptions<double>
+        {
+            StateSize = StateSize,
+            ActionSize = ActionSize,
+            BatchSize = 1,
+            TargetUpdateFrequency = frequency,
+            EpsilonStart = 0.8,
+            EpsilonEnd = 0.01,
+            EpsilonDecay = 0.5,
+            Seed = 99,
+        };
+        using var agent = new FinancialDQNAgent<double>(Actor(), options);
+        var onlineField = typeof(FinancialDQNAgent<double>).GetField("_qNetwork", BindingFlags.NonPublic | BindingFlags.Instance)
+            ?? throw new InvalidOperationException("The online-network regression probe must observe the actual online network.");
+        var online = Assert.IsAssignableFrom<INeuralNetwork<double>>(onlineField.GetValue(agent));
+        var targetField = typeof(FinancialDQNAgent<double>).GetField("_targetNetwork", BindingFlags.NonPublic | BindingFlags.Instance)
+            ?? throw new InvalidOperationException("The target-network regression probe must observe the actual target network.");
+        var target = Assert.IsAssignableFrom<INeuralNetwork<double>>(targetField.GetValue(agent));
+        var initial = online.GetParameters().ToArray();
+        Assert.NotEmpty(initial);
+        Assert.Equal(initial, target.GetParameters().ToArray());
+
+        // A rejected update must not consume a training step or alter either network.
+        Assert.Throws<ArgumentException>(() => agent.ApplyGradients(new Vector<double>(1), 0.01));
+        Assert.Equal(0.0, agent.GetTradingMetrics()["TrainingSteps"]);
+        Assert.Equal(1.0, agent.GetTradingMetrics()["TargetSyncCount"]);
+        Assert.Equal(options.EpsilonStart, agent.Epsilon);
+        Assert.Equal(initial, online.GetParameters().ToArray());
+        Assert.Equal(initial, target.GetParameters().ToArray());
+
+        for (var step = 1; step <= frequency + 1; step++)
+        {
+            var onlineBefore = online.GetParameters().ToArray();
+            var targetBefore = target.GetParameters().ToArray();
+            agent.ApplyGradients(new Vector<double>(Enumerable.Repeat(0.25, initial.Length).ToArray()), 0.01);
+            var onlineAfter = online.GetParameters().ToArray();
+            Assert.False(onlineBefore.SequenceEqual(onlineAfter), "the direct update must really change the online weights");
+            var metrics = agent.GetTradingMetrics();
+            Assert.Equal((double)step, metrics["TrainingSteps"]);
+            Assert.Equal((double)(1 + step / frequency), metrics["TargetSyncCount"]);
+            Assert.Equal(Math.Max(options.EpsilonEnd, options.EpsilonStart * Math.Pow(options.EpsilonDecay, step)), agent.Epsilon, 12);
+            if (step % frequency == 0)
+            {
+                Assert.Equal(onlineAfter, target.GetParameters().ToArray());
+            }
+            else
+            {
+                Assert.Equal(targetBefore, target.GetParameters().ToArray());
+                Assert.False(onlineAfter.SequenceEqual(target.GetParameters().ToArray()));
+            }
+        }
+
+        // A replay update must advance the same schedule, not restart a second counter.
+        var targetBeforeReplay = target.GetParameters().ToArray();
+        TrainSteps(agent, 1);
+        var completed = frequency + 2;
+        Assert.Equal((double)completed, agent.GetTradingMetrics()["TrainingSteps"]);
+        Assert.Equal((double)(1 + completed / frequency), agent.GetTradingMetrics()["TargetSyncCount"]);
+        Assert.Equal(
+            completed % frequency == 0 ? online.GetParameters().ToArray() : targetBeforeReplay,
+            target.GetParameters().ToArray());
+    }
+
     [Fact]
     public void Dqn_publishes_the_exploration_rate_in_its_trading_metrics()
     {
@@ -239,19 +309,18 @@ public class TradingAgentLearningTests
         {
             StateSize = StateSize,
             ActionSize = ActionSize,
-            // NOTE: this seed does NOT make the sampling below deterministic. It reaches ReplayBuffer
-            // only; SampleAction draws from RandomHelper.CreateSecureRandom(), and Actor() leaves
-            // architecture.RandomSeed unset, so the initial policy varies between runs too. That is the
-            // gap E6.7 tracks - seeding is persisted as a determinism claim the agents do not honour.
-            //
-            // Hence the assertion below is a TOLERANCE on the dominant share rather than a check that
-            // every action was drawn: the latter would be flaky against a policy that legitimately
-            // assigns one action a small probability. The tolerance still fails the defect this test
-            // exists for, where sampling collapsed onto a single tier.
             Seed = 4242,
         };
 
         using var agent = new FinancialA2CAgent<double>(Actor(), Critic(), options);
+
+        // Fix the actual policy, not merely its initialization seed: zero logits give a known
+        // uniform distribution. A direct-logit sampler would fall through to the last action.
+        var parameters = agent.GetParameters();
+        Assert.True(parameters.Length > 0);
+        agent.SetParameters(new Vector<double>(new double[parameters.Length]));
+        Assert.All(agent.GetParameters().ToArray(), value => Assert.Equal(0.0, value));
+        var expectedRandom = RandomHelper.CreateSeededRandom(4242);
 
         var state = State(11);
         var counts = new int[ActionSize];
@@ -259,6 +328,9 @@ public class TradingAgentLearningTests
         for (var i = 0; i < samples; i++)
         {
             var action = agent.SelectTradingAction(state, training: true);
+            var expectedAction = (int)(expectedRandom.NextDouble() * ActionSize);
+            Assert.Equal(1.0, action[expectedAction]);
+            Assert.Equal(1.0, action.ToArray().Sum());
             for (var a = 0; a < action.Length; a++)
             {
                 if (action[a] != 0.0)

--- a/tests/AiDotNet.Tests/IntegrationTests/Finance/TradingAgentLearningTests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/Finance/TradingAgentLearningTests.cs
@@ -94,6 +94,48 @@ public class TradingAgentLearningTests
         Assert.True(agent.Epsilon >= options.EpsilonEnd, $"epsilon fell below EpsilonEnd ({agent.Epsilon})");
     }
 
+    [Theory]
+    [InlineData(5)]
+    [InlineData(10)]
+    [InlineData(25)]
+    public void Dqn_synchronises_its_target_network_on_an_exact_schedule(int frequency)
+    {
+        // THE FIX WITH THE LARGEST EFFECT ON LEARNING, AND NOTHING ASSERTED IT.
+        //
+        // The condition was `rng.Next(TargetUpdateFrequency) == 0`: a coin flip with probability 1/N per
+        // step rather than a schedule, giving roughly 0.6 expected syncs across an entire run. The TD target
+        // was therefore computed from the very network being updated in the same batch, which is the thing a
+        // target network exists to prevent.
+        //
+        // TargetUpdateFrequency = 10 appeared in four tests as CONFIGURATION and no test observed what it
+        // did, so a regression to the coin flip would have left every assertion in this file passing.
+        //
+        // Counting syncs alone would not discriminate either: a coin flip with p = 1/N also averages
+        // steps/N syncs. What separates them is EXACTNESS - the deterministic condition satisfies the
+        // identity below on every run, and a probabilistic one satisfies it only by chance.
+        var options = new FinancialDQNAgentOptions<double>
+        {
+            StateSize = StateSize,
+            ActionSize = ActionSize,
+            BatchSize = 4,
+            TargetUpdateFrequency = frequency,
+        };
+
+        using var agent = new FinancialDQNAgent<double>(Actor(), options);
+
+        // Before any training the constructor has synced once, so the two networks start equal.
+        Assert.Equal(1.0, agent.GetTradingMetrics()["TargetSyncCount"], 9);
+
+        TrainSteps(agent, 120);
+
+        var metrics = agent.GetTradingMetrics();
+        var trainingSteps = (int)metrics["TrainingSteps"];
+        var syncs = (int)metrics["TargetSyncCount"];
+
+        Assert.True(trainingSteps > frequency, $"only {trainingSteps} training steps; too few to cross the schedule");
+        Assert.Equal(1 + (trainingSteps / frequency), syncs);
+    }
+
     [Fact]
     public void Dqn_epsilon_decay_of_one_holds_the_rate_instead_of_annealing()
     {
@@ -197,6 +239,15 @@ public class TradingAgentLearningTests
         {
             StateSize = StateSize,
             ActionSize = ActionSize,
+            // NOTE: this seed does NOT make the sampling below deterministic. It reaches ReplayBuffer
+            // only; SampleAction draws from RandomHelper.CreateSecureRandom(), and Actor() leaves
+            // architecture.RandomSeed unset, so the initial policy varies between runs too. That is the
+            // gap E6.7 tracks - seeding is persisted as a determinism claim the agents do not honour.
+            //
+            // Hence the assertion below is a TOLERANCE on the dominant share rather than a check that
+            // every action was drawn: the latter would be flaky against a policy that legitimately
+            // assigns one action a small probability. The tolerance still fails the defect this test
+            // exists for, where sampling collapsed onto a single tier.
             Seed = 4242,
         };
 

--- a/tests/AiDotNet.Tests/IntegrationTests/Finance/TradingAgentLearningTests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/Finance/TradingAgentLearningTests.cs
@@ -95,6 +95,57 @@ public class TradingAgentLearningTests
     }
 
     [Fact]
+    public void Dqn_epsilon_decay_of_one_holds_the_rate_instead_of_annealing()
+    {
+        // EpsilonDecay = 1.0 is a legitimate configuration meaning "hold the exploration rate". It must not be
+        // mistaken for "no schedule configured" and annealed anyway - a fixed-epsilon run is how you isolate
+        // whether exploration or learning is the thing that changed.
+        var options = new FinancialDQNAgentOptions<double>
+        {
+            StateSize = StateSize,
+            ActionSize = ActionSize,
+            EpsilonStart = 0.3,
+            EpsilonEnd = 0.01,
+            EpsilonDecay = 1.0,
+            BatchSize = 4,
+            TargetUpdateFrequency = 10,
+        };
+
+        using var agent = new FinancialDQNAgent<double>(Actor(), options);
+        TrainSteps(agent, 20);
+
+        Assert.Equal(0.3, agent.Epsilon, 9);
+    }
+
+    [Fact]
+    public void Dqn_publishes_the_exploration_rate_in_its_trading_metrics()
+    {
+        // The Epsilon property serves anything holding the concrete agent. A harness that collects metrics
+        // GENERICALLY - one row per agent, which is how this defect was found downstream - sees only the
+        // dictionary, and there an agent that annealed and one that never explored look identical.
+        var options = new FinancialDQNAgentOptions<double>
+        {
+            StateSize = StateSize,
+            ActionSize = ActionSize,
+            EpsilonStart = 0.8,
+            EpsilonEnd = 0.02,
+            EpsilonDecay = 0.5,
+            BatchSize = 4,
+            TargetUpdateFrequency = 10,
+        };
+
+        // Enough steps to fill the replay buffer and apply real updates: below BatchSize nothing trains, so
+        // nothing decays, and the assertion below would be vacuous rather than wrong.
+        using var agent = new FinancialDQNAgent<double>(Actor(), options);
+        TrainSteps(agent, 20);
+
+        var metrics = agent.GetTradingMetrics();
+        Assert.True(metrics.ContainsKey("Epsilon"), "the agent does not publish its exploration rate");
+        Assert.Equal(agent.Epsilon, Convert.ToDouble(metrics["Epsilon"]), 9);
+        Assert.True(agent.Epsilon < 0.8, "epsilon did not decay, so the published value proves nothing");
+    }
+
+    [Fact]
     public void Dqn_epsilon_is_monotonically_non_increasing()
     {
         var options = new FinancialDQNAgentOptions<double>


### PR DESCRIPTION
## Three defects that stop these agents learning at all

Found while auditing an RL trading stack built on these agents, where a six-model bake-off turned out to be measuring preprocessing and luck rather than skill. Each of these alone prevents the agent it affects from learning a policy, independently of any environment it is given.

### DQN explored uniformly at random for the entire run

`SelectAction` compared against `TradingAgentOptions.EpsilonStart`, which defaults to **1.0**. `EpsilonEnd` and `EpsilonDecay` were declared, validated against each other in `Validate()`, and read by **nobody** — nothing ever decayed epsilon.

So the behaviour policy was 100% random from first step to last, the network's own Q-values were **never once acted on** during training, and every "learning curve" it produced was the return of a random policy.

It now tracks a current epsilon and decays it multiplicatively toward `EpsilonEnd` — what `EpsilonDecay` (0.995) means, and what the reference `DQNAgent` already does.

### DQN's target network almost never synced

```csharp
if (RandomHelper.CreateSecureRandom().Next(TradingOptions.TargetUpdateFrequency) == 0)
```

That is a coin flip with probability 1/N per step, not *"every N steps"*. At the default `N = 1000`, a 600-step run expects **0.6 syncs** — so the target network usually held its initial random weights for the whole run and the TD target was noise. It was also unreproducible: two runs with the same seed synced at different steps.

Now `TrainingSteps % N == 0`.

`FinancialDQNAgent` also **never advanced the inherited `TrainingSteps` counter**, which every other agent (`DQNAgent`, `DoubleDQNAgent`, `A2CAgent`, `DDPGAgent`, `FinancialPPOAgent`) increments in its own `Train()` and which the state generator serialises — so nothing downstream could tell how much training had happened. It now drives both the epsilon schedule and the target sync from that counter.

### A2C sampled from something that was not a distribution

The actor is built with `NeuralNetworkTaskType.Regression`, so its output layer carries an identity activation and produces **unbounded reals** — and those went straight into an inverse-CDF sampler as if they were probabilities:

```csharp
cumulative += probs[i];  if (r < cumulative) return i;
...
return probabilities.Length - 1;   // fall-through
```

A freshly initialised network produces small outputs that do not sum to 1, so the running cumulative rarely reaches a uniform `r ∈ [0,1)` and the loop **falls off the end**. Measured on a single fixed state:

```
one action took 100% of 600 draws from a SINGLE state (a0=0%, a1=0%, a2=100%)
```

A negative output additionally makes the cumulative non-monotonic, so an action can be skipped entirely. For a trading agent whose middle action is "hold", it could not choose to do nothing.

A softmax is now applied before sampling — which is what `FinancialPPOAgent` already does.

### SAC's exploration noise was biased in one direction

```csharp
noise[i] = NumOps.FromDouble(RandomHelper.CreateSecureRandom().NextDouble() * 0.1);
```

Uniform on `[0, 0.1)`: mean **+0.05**, never negative. For an agent whose action is a signed position that means it explored **only the long side** — and the bias does not average out over a run, it accumulates into the experience the critics learn from.

The noise is now symmetric about the actor's output with the same magnitude, so this changes the **bias** without changing how far the agent explores.

## Already fixed upstream

Worth noting for anyone tracking the same audit: the target-network **aliasing** defect (`Layers.AddRange(Architecture.Layers)` making the online and target networks one object, and SAC's four critics one network) is **already fixed on master** — both now use `CloneForModelConstruction()`. Only the sync *schedule* remained.

## Tests

Four, each asserting the behaviour **directly** rather than inferring it from a learning curve — because a curve produced by a uniformly random policy looks like noise either way.

All four fail on the unfixed agents. The two that can compile against them (A2C, SAC) were verified doing so; the DQN pair cannot compile at all without the `Epsilon` accessor.

## API surface

Nothing changes except the addition of `FinancialDQNAgent.Epsilon`, which exists so a training loop can record the curve and confirm the schedule is actually running.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017otuSGr3GdmvPoYLbiaWR2


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved A2C action selection with stable probability calculations and safer handling of invalid model outputs.
  - DQN agents now gradually reduce exploration during training, synchronize target models predictably, and report exploration metrics.
  - SAC agents now use balanced, zero-centered exploration noise to avoid consistently favoring higher actions.

- **Tests**
  - Added coverage for exploration-rate behavior, target synchronization, action sampling, probability handling, and unbiased SAC exploration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->