### PR TITLE
fix(neural-networks): refuse a second model on one architecture instead of aliasing it

### DIFF
--- a/src/Finance/Forecasting/Foundation/Chronos.cs
+++ b/src/Finance/Forecasting/Foundation/Chronos.cs
@@ -383,7 +383,7 @@ public partial class Chronos<T> : TimeSeriesFoundationModelBase<T>
         if (Architecture.Layers is not null && Architecture.Layers.Count > 0)
         {
             Layers.AddRange(Architecture.Layers);
-            ValidateCustomLayers(Layers);
+            ValidateCustomLayersWithOwnershipRollback(Layers);
             // Wire layer references for custom layers too
             ExtractLayerReferences();
         }

--- a/src/Finance/Forecasting/Foundation/LagLlama.cs
+++ b/src/Finance/Forecasting/Foundation/LagLlama.cs
@@ -357,7 +357,7 @@ public partial class LagLlama<T> : ForecastingModelBase<T>
         if (Architecture.Layers is not null && Architecture.Layers.Count > 0)
         {
             Layers.AddRange(Architecture.Layers);
-            ValidateCustomLayers(Layers);
+            ValidateCustomLayersWithOwnershipRollback(Layers);
             // Extract layer references so Forward/Backward work with custom layers
             ExtractLayerReferences();
         }

--- a/src/Finance/Forecasting/Foundation/MOIRAI.cs
+++ b/src/Finance/Forecasting/Foundation/MOIRAI.cs
@@ -466,7 +466,7 @@ public partial class MOIRAI<T> : TimeSeriesFoundationModelBase<T>
         if (Architecture.Layers is not null && Architecture.Layers.Count > 0)
         {
             Layers.AddRange(Architecture.Layers);
-            ValidateCustomLayers(Layers);
+            ValidateCustomLayersWithOwnershipRollback(Layers);
         }
         else if (_useNativeMode)
         {

--- a/src/Finance/Forecasting/Foundation/MOMENT.cs
+++ b/src/Finance/Forecasting/Foundation/MOMENT.cs
@@ -306,7 +306,7 @@ public partial class MOMENT<T> : TimeSeriesFoundationModelBase<T>
         if (Architecture.Layers is not null && Architecture.Layers.Count > 0)
         {
             Layers.AddRange(Architecture.Layers);
-            ValidateCustomLayers(Layers);
+            ValidateCustomLayersWithOwnershipRollback(Layers);
         }
         else if (_useNativeMode)
         {

--- a/src/Finance/Forecasting/Foundation/TimeGPT.cs
+++ b/src/Finance/Forecasting/Foundation/TimeGPT.cs
@@ -376,7 +376,7 @@ public partial class TimeGPT<T> : ForecastingModelBase<T>
         if (Architecture.Layers is not null && Architecture.Layers.Count > 0)
         {
             Layers.AddRange(Architecture.Layers);
-            ValidateCustomLayers(Layers);
+            ValidateCustomLayersWithOwnershipRollback(Layers);
         }
         else if (_useNativeMode)
         {

--- a/src/Finance/Forecasting/Foundation/TimeLLM.cs
+++ b/src/Finance/Forecasting/Foundation/TimeLLM.cs
@@ -406,7 +406,7 @@ public partial class TimeLLM<T> : ForecastingModelBase<T>
         if (Architecture.Layers is not null && Architecture.Layers.Count > 0)
         {
             Layers.AddRange(Architecture.Layers);
-            ValidateCustomLayers(Layers);
+            ValidateCustomLayersWithOwnershipRollback(Layers);
         }
         else if (_useNativeMode)
         {

--- a/src/Finance/Forecasting/Foundation/Timer.cs
+++ b/src/Finance/Forecasting/Foundation/Timer.cs
@@ -450,7 +450,7 @@ public partial class Timer<T> : TimeSeriesFoundationModelBase<T>
         if (Architecture.Layers is not null && Architecture.Layers.Count > 0)
         {
             Layers.AddRange(Architecture.Layers);
-            ValidateCustomLayers(Layers);
+            ValidateCustomLayersWithOwnershipRollback(Layers);
         }
         else if (_useNativeMode)
         {

--- a/src/Finance/Forecasting/Foundation/TimesFM.cs
+++ b/src/Finance/Forecasting/Foundation/TimesFM.cs
@@ -404,7 +404,7 @@ public partial class TimesFM<T> : TimeSeriesFoundationModelBase<T>
         if (Architecture.Layers is not null && Architecture.Layers.Count > 0)
         {
             Layers.AddRange(Architecture.Layers);
-            ValidateCustomLayers(Layers);
+            ValidateCustomLayersWithOwnershipRollback(Layers);
         }
         else if (_useNativeMode)
         {

--- a/src/Finance/Forecasting/Foundation/TinyTimeMixers.cs
+++ b/src/Finance/Forecasting/Foundation/TinyTimeMixers.cs
@@ -252,7 +252,7 @@ public partial class TinyTimeMixers<T> : TimeSeriesFoundationModelBase<T>
         if (Architecture.Layers is not null && Architecture.Layers.Count > 0)
         {
             Layers.AddRange(Architecture.Layers);
-            ValidateCustomLayers(Layers);
+            ValidateCustomLayersWithOwnershipRollback(Layers);
         }
         else if (_useNativeMode)
         {

--- a/src/Finance/Forecasting/Foundation/UniTS.cs
+++ b/src/Finance/Forecasting/Foundation/UniTS.cs
@@ -397,7 +397,7 @@ public partial class UniTS<T> : ForecastingModelBase<T>
         if (Architecture.Layers is not null && Architecture.Layers.Count > 0)
         {
             Layers.AddRange(Architecture.Layers);
-            ValidateCustomLayers(Layers);
+            ValidateCustomLayersWithOwnershipRollback(Layers);
         }
         else if (_useNativeMode)
         {

--- a/src/Finance/Forecasting/Neural/DeepAR.cs
+++ b/src/Finance/Forecasting/Neural/DeepAR.cs
@@ -343,7 +343,7 @@ public partial class DeepAR<T> : ForecastingModelBase<T>
         if (Architecture.Layers is not null && Architecture.Layers.Count > 0)
         {
             Layers.AddRange(Architecture.Layers);
-            ValidateCustomLayers(Layers);
+            ValidateCustomLayersWithOwnershipRollback(Layers);
             ExtractLayerReferences();
         }
         else if (UseNativeMode)

--- a/src/Finance/Forecasting/Neural/DeepFactor.cs
+++ b/src/Finance/Forecasting/Neural/DeepFactor.cs
@@ -369,7 +369,7 @@ public partial class DeepFactor<T> : ForecastingModelBase<T>
         if (Architecture.Layers is not null && Architecture.Layers.Count > 0)
         {
             Layers.AddRange(Architecture.Layers);
-            ValidateCustomLayers(Layers);
+            ValidateCustomLayersWithOwnershipRollback(Layers);
             ExtractLayerReferences();
         }
         else if (_useNativeMode)

--- a/src/Finance/Forecasting/Neural/DeepState.cs
+++ b/src/Finance/Forecasting/Neural/DeepState.cs
@@ -369,7 +369,7 @@ public partial class DeepState<T> : ForecastingModelBase<T>
         if (Architecture.Layers is not null && Architecture.Layers.Count > 0)
         {
             Layers.AddRange(Architecture.Layers);
-            ValidateCustomLayers(Layers);
+            ValidateCustomLayersWithOwnershipRollback(Layers);
             // Wire layer references for custom layers too
             ExtractLayerReferences();
         }

--- a/src/Finance/Forecasting/Neural/LSTNet.cs
+++ b/src/Finance/Forecasting/Neural/LSTNet.cs
@@ -405,7 +405,7 @@ public partial class LSTNet<T> : ForecastingModelBase<T>
         if (Architecture.Layers is not null && Architecture.Layers.Count > 0)
         {
             Layers.AddRange(Architecture.Layers);
-            ValidateCustomLayers(Layers);
+            ValidateCustomLayersWithOwnershipRollback(Layers);
         }
         else if (_useNativeMode)
         {

--- a/src/Finance/Forecasting/Neural/MQCNN.cs
+++ b/src/Finance/Forecasting/Neural/MQCNN.cs
@@ -361,7 +361,7 @@ public partial class MQCNN<T> : ForecastingModelBase<T>
         if (Architecture.Layers is not null && Architecture.Layers.Count > 0)
         {
             Layers.AddRange(Architecture.Layers);
-            ValidateCustomLayers(Layers);
+            ValidateCustomLayersWithOwnershipRollback(Layers);
         }
         else if (_useNativeMode)
         {

--- a/src/Finance/Forecasting/Neural/NBEATSFinance.cs
+++ b/src/Finance/Forecasting/Neural/NBEATSFinance.cs
@@ -329,7 +329,7 @@ public partial class NBEATSFinance<T> : ForecastingModelBase<T>
         if (Architecture.Layers is not null && Architecture.Layers.Count > 0)
         {
             Layers.AddRange(Architecture.Layers);
-            ValidateCustomLayers(Layers);
+            ValidateCustomLayersWithOwnershipRollback(Layers);
             ExtractLayerReferences();
         }
         else if (_useNativeMode)

--- a/src/Finance/Forecasting/Neural/NHiTSFinance.cs
+++ b/src/Finance/Forecasting/Neural/NHiTSFinance.cs
@@ -316,7 +316,7 @@ public partial class NHiTSFinance<T> : ForecastingModelBase<T>
         if (Architecture.Layers is not null && Architecture.Layers.Count > 0)
         {
             Layers.AddRange(Architecture.Layers);
-            ValidateCustomLayers(Layers);
+            ValidateCustomLayersWithOwnershipRollback(Layers);
             ExtractLayerReferences();
         }
         else if (_useNativeMode)

--- a/src/Finance/Forecasting/Neural/TCN.cs
+++ b/src/Finance/Forecasting/Neural/TCN.cs
@@ -345,7 +345,7 @@ public partial class TCN<T> : ForecastingModelBase<T>
         if (Architecture.Layers is not null && Architecture.Layers.Count > 0)
         {
             Layers.AddRange(Architecture.Layers);
-            ValidateCustomLayers(Layers);
+            ValidateCustomLayersWithOwnershipRollback(Layers);
         }
         else if (_useNativeMode)
         {

--- a/src/Finance/Forecasting/Neural/WaveNet.cs
+++ b/src/Finance/Forecasting/Neural/WaveNet.cs
@@ -293,7 +293,7 @@ public partial class WaveNet<T> : ForecastingModelBase<T>
         if (Architecture.Layers is not null && Architecture.Layers.Count > 0)
         {
             Layers.AddRange(Architecture.Layers);
-            ValidateCustomLayers(Layers);
+            ValidateCustomLayersWithOwnershipRollback(Layers);
         }
         else if (_useNativeMode)
         {

--- a/src/Finance/Forecasting/StateSpace/Hippo.cs
+++ b/src/Finance/Forecasting/StateSpace/Hippo.cs
@@ -335,7 +335,7 @@ public partial class Hippo<T> : ForecastingModelBase<T>
         {
             _useCustomLayerStack = true;
             Layers.AddRange(Architecture.Layers);
-            ValidateCustomLayers(Layers);
+            ValidateCustomLayersWithOwnershipRollback(Layers);
         }
         else if (_useNativeMode)
         {

--- a/src/Finance/Forecasting/StateSpace/Mamba.cs
+++ b/src/Finance/Forecasting/StateSpace/Mamba.cs
@@ -375,7 +375,7 @@ public partial class Mamba<T> : ForecastingModelBase<T>
         if (Architecture.Layers is not null && Architecture.Layers.Count > 0)
         {
             Layers.AddRange(Architecture.Layers);
-            ValidateCustomLayers(Layers);
+            ValidateCustomLayersWithOwnershipRollback(Layers);
             ExtractLayerReferences();
         }
         else if (_useNativeMode)

--- a/src/Finance/Forecasting/StateSpace/Mamba2.cs
+++ b/src/Finance/Forecasting/StateSpace/Mamba2.cs
@@ -198,7 +198,7 @@ public partial class Mamba2<T> : ForecastingModelBase<T>
         if (Architecture.Layers is not null && Architecture.Layers.Count > 0)
         {
             Layers.AddRange(Architecture.Layers);
-            ValidateCustomLayers(Layers);
+            ValidateCustomLayersWithOwnershipRollback(Layers);
             ExtractLayerReferences();
         }
         else if (_useNativeMode)

--- a/src/Finance/Forecasting/StateSpace/RWKVForecaster.cs
+++ b/src/Finance/Forecasting/StateSpace/RWKVForecaster.cs
@@ -260,7 +260,7 @@ public partial class RWKVForecaster<T> : ForecastingModelBase<T>
         if (Architecture.Layers is not null && Architecture.Layers.Count > 0)
         {
             Layers.AddRange(Architecture.Layers);
-            ValidateCustomLayers(Layers);
+            ValidateCustomLayersWithOwnershipRollback(Layers);
             ExtractLayerReferences();
         }
         else if (_useNativeMode)

--- a/src/Finance/Forecasting/StateSpace/S4.cs
+++ b/src/Finance/Forecasting/StateSpace/S4.cs
@@ -320,7 +320,7 @@ public partial class S4<T> : ForecastingModelBase<T>
         if (Architecture.Layers is not null && Architecture.Layers.Count > 0)
         {
             Layers.AddRange(Architecture.Layers);
-            ValidateCustomLayers(Layers);
+            ValidateCustomLayersWithOwnershipRollback(Layers);
         }
         else if (_useNativeMode)
         {

--- a/src/Finance/Forecasting/StateSpace/TimeMachine.cs
+++ b/src/Finance/Forecasting/StateSpace/TimeMachine.cs
@@ -309,7 +309,7 @@ public partial class TimeMachine<T> : ForecastingModelBase<T>
         if (Architecture.Layers is not null && Architecture.Layers.Count > 0)
         {
             Layers.AddRange(Architecture.Layers);
-            ValidateCustomLayers(Layers);
+            ValidateCustomLayersWithOwnershipRollback(Layers);
         }
         else if (_useNativeMode)
         {

--- a/src/Finance/Forecasting/Transformers/Autoformer.cs
+++ b/src/Finance/Forecasting/Transformers/Autoformer.cs
@@ -316,7 +316,7 @@ public partial class Autoformer<T> : ForecastingModelBase<T>
         if (Architecture.Layers is not null && Architecture.Layers.Count > 0)
         {
             Layers.AddRange(Architecture.Layers);
-            ValidateCustomLayers(Layers);
+            ValidateCustomLayersWithOwnershipRollback(Layers);
         }
         else if (_useNativeMode)
         {

--- a/src/Finance/Forecasting/Transformers/Crossformer.cs
+++ b/src/Finance/Forecasting/Transformers/Crossformer.cs
@@ -337,7 +337,7 @@ public partial class Crossformer<T> : ForecastingModelBase<T>
         if (Architecture.Layers is not null && Architecture.Layers.Count > 0)
         {
             Layers.AddRange(Architecture.Layers);
-            ValidateCustomLayers(Layers);
+            ValidateCustomLayersWithOwnershipRollback(Layers);
         }
         else if (_useNativeMode)
         {

--- a/src/Finance/Forecasting/Transformers/ETSformer.cs
+++ b/src/Finance/Forecasting/Transformers/ETSformer.cs
@@ -332,7 +332,7 @@ public partial class ETSformer<T> : ForecastingModelBase<T>
         if (Architecture.Layers is not null && Architecture.Layers.Count > 0)
         {
             Layers.AddRange(Architecture.Layers);
-            ValidateCustomLayers(Layers);
+            ValidateCustomLayersWithOwnershipRollback(Layers);
         }
         else if (_useNativeMode)
         {

--- a/src/Finance/Forecasting/Transformers/FEDformer.cs
+++ b/src/Finance/Forecasting/Transformers/FEDformer.cs
@@ -449,7 +449,7 @@ public partial class FEDformer<T> : ForecastingModelBase<T>
         if (Architecture.Layers is not null && Architecture.Layers.Count > 0)
         {
             Layers.AddRange(Architecture.Layers);
-            ValidateCustomLayers(Layers);
+            ValidateCustomLayersWithOwnershipRollback(Layers);
         }
         else if (_useNativeMode)
         {

--- a/src/Finance/Forecasting/Transformers/ITransformer.cs
+++ b/src/Finance/Forecasting/Transformers/ITransformer.cs
@@ -453,7 +453,7 @@ public partial class ITransformer<T> : ForecastingModelBase<T>
         if (Architecture.Layers is not null && Architecture.Layers.Count > 0)
         {
             Layers.AddRange(Architecture.Layers);
-            ValidateCustomLayers(Layers);
+            ValidateCustomLayersWithOwnershipRollback(Layers);
         }
         else if (_useNativeMode)
         {

--- a/src/Finance/Forecasting/Transformers/Informer.cs
+++ b/src/Finance/Forecasting/Transformers/Informer.cs
@@ -303,7 +303,7 @@ public partial class Informer<T> : ForecastingModelBase<T>
         if (Architecture.Layers is not null && Architecture.Layers.Count > 0)
         {
             Layers.AddRange(Architecture.Layers);
-            ValidateCustomLayers(Layers);
+            ValidateCustomLayersWithOwnershipRollback(Layers);
         }
         else if (_useNativeMode)
         {

--- a/src/Finance/Forecasting/Transformers/NonStationaryTransformer.cs
+++ b/src/Finance/Forecasting/Transformers/NonStationaryTransformer.cs
@@ -448,7 +448,7 @@ public partial class NonStationaryTransformer<T> : ForecastingModelBase<T>
         if (Architecture.Layers is not null && Architecture.Layers.Count > 0)
         {
             Layers.AddRange(Architecture.Layers);
-            ValidateCustomLayers(Layers);
+            ValidateCustomLayersWithOwnershipRollback(Layers);
         }
         else if (_useNativeMode)
         {

--- a/src/Finance/Forecasting/Transformers/PatchTST.cs
+++ b/src/Finance/Forecasting/Transformers/PatchTST.cs
@@ -389,7 +389,7 @@ public partial class PatchTST<T> : ForecastingModelBase<T>
         {
             // Use the layers provided by the user
             Layers.AddRange(Architecture.Layers);
-            ValidateCustomLayers(Layers);
+            ValidateCustomLayersWithOwnershipRollback(Layers);
         }
         else if (UseNativeMode)
         {

--- a/src/Finance/Forecasting/Transformers/TFT.cs
+++ b/src/Finance/Forecasting/Transformers/TFT.cs
@@ -379,7 +379,7 @@ public partial class TFT<T> : ForecastingModelBase<T>
         if (Architecture.Layers is not null && Architecture.Layers.Count > 0)
         {
             Layers.AddRange(Architecture.Layers);
-            ValidateCustomLayers(Layers);
+            ValidateCustomLayersWithOwnershipRollback(Layers);
         }
         else if (_useNativeMode)
         {

--- a/src/Finance/Forecasting/Transformers/TSMixer.cs
+++ b/src/Finance/Forecasting/Transformers/TSMixer.cs
@@ -374,7 +374,7 @@ public partial class TSMixer<T> : ForecastingModelBase<T>
         if (Architecture.Layers is not null && Architecture.Layers.Count > 0)
         {
             Layers.AddRange(Architecture.Layers);
-            ValidateCustomLayers(Layers);
+            ValidateCustomLayersWithOwnershipRollback(Layers);
             // Always extract layer references even for custom layers
             ExtractLayerReferences();
         }

--- a/src/Finance/Forecasting/Transformers/TimesNet.cs
+++ b/src/Finance/Forecasting/Transformers/TimesNet.cs
@@ -349,7 +349,7 @@ public partial class TimesNet<T> : ForecastingModelBase<T>
         if (Architecture.Layers is not null && Architecture.Layers.Count > 0)
         {
             Layers.AddRange(Architecture.Layers);
-            ValidateCustomLayers(Layers);
+            ValidateCustomLayersWithOwnershipRollback(Layers);
         }
         else if (_useNativeMode)
         {

--- a/src/Finance/Graph/DCRNN.cs
+++ b/src/Finance/Graph/DCRNN.cs
@@ -394,7 +394,7 @@ public partial class DCRNN<T> : ForecastingModelBase<T>
         if (Architecture.Layers is not null && Architecture.Layers.Count > 0)
         {
             Layers.AddRange(Architecture.Layers);
-            ValidateCustomLayers(Layers);
+            ValidateCustomLayersWithOwnershipRollback(Layers);
             ExtractLayerReferences();
         }
         else if (_useNativeMode)

--- a/src/Finance/Graph/GraphWaveNet.cs
+++ b/src/Finance/Graph/GraphWaveNet.cs
@@ -486,7 +486,7 @@ public partial class GraphWaveNet<T> : ForecastingModelBase<T>
         if (Architecture.Layers is not null && Architecture.Layers.Count > 0)
         {
             Layers.AddRange(Architecture.Layers);
-            ValidateCustomLayers(Layers);
+            ValidateCustomLayersWithOwnershipRollback(Layers);
         }
         else if (_useNativeMode)
         {

--- a/src/Finance/Graph/MTGNN.cs
+++ b/src/Finance/Graph/MTGNN.cs
@@ -462,7 +462,7 @@ public partial class MTGNN<T> : ForecastingModelBase<T>
         if (Architecture.Layers is not null && Architecture.Layers.Count > 0)
         {
             Layers.AddRange(Architecture.Layers);
-            ValidateCustomLayers(Layers);
+            ValidateCustomLayersWithOwnershipRollback(Layers);
         }
         else if (_useNativeMode)
         {

--- a/src/Finance/Graph/RelationalGCN.cs
+++ b/src/Finance/Graph/RelationalGCN.cs
@@ -379,7 +379,7 @@ public partial class RelationalGCN<T> : ForecastingModelBase<T>
         if (Architecture.Layers is not null && Architecture.Layers.Count > 0)
         {
             Layers.AddRange(Architecture.Layers);
-            ValidateCustomLayers(Layers);
+            ValidateCustomLayersWithOwnershipRollback(Layers);
         }
         else if (_useNativeMode)
         {

--- a/src/Finance/Graph/STGNN.cs
+++ b/src/Finance/Graph/STGNN.cs
@@ -324,7 +324,7 @@ public partial class STGNN<T> : ForecastingModelBase<T>
         if (Architecture.Layers is not null && Architecture.Layers.Count > 0)
         {
             Layers.AddRange(Architecture.Layers);
-            ValidateCustomLayers(Layers);
+            ValidateCustomLayersWithOwnershipRollback(Layers);
         }
         else if (_useNativeMode)
         {

--- a/src/Finance/Graph/TemporalGCN.cs
+++ b/src/Finance/Graph/TemporalGCN.cs
@@ -343,7 +343,7 @@ public partial class TemporalGCN<T> : ForecastingModelBase<T>
         if (Architecture.Layers is not null && Architecture.Layers.Count > 0)
         {
             Layers.AddRange(Architecture.Layers);
-            ValidateCustomLayers(Layers);
+            ValidateCustomLayersWithOwnershipRollback(Layers);
         }
         else if (_useNativeMode)
         {

--- a/src/Finance/NLP/FinBERT.cs
+++ b/src/Finance/NLP/FinBERT.cs
@@ -286,7 +286,7 @@ public partial class FinBERT<T> : FinancialNLPModelBase<T>
         if (Architecture.Layers is not null && Architecture.Layers.Count > 0)
         {
             Layers.AddRange(Architecture.Layers);
-            ValidateCustomLayers(Layers);
+            ValidateCustomLayersWithOwnershipRollback(Layers);
         }
         else if (_useNativeMode)
         {

--- a/src/Finance/Probabilistic/CSDI.cs
+++ b/src/Finance/Probabilistic/CSDI.cs
@@ -321,7 +321,7 @@ public partial class CSDI<T> : ForecastingModelBase<T>
         if (Architecture.Layers is not null && Architecture.Layers.Count > 0)
         {
             Layers.AddRange(Architecture.Layers);
-            ValidateCustomLayers(Layers);
+            ValidateCustomLayersWithOwnershipRollback(Layers);
         }
         else if (_useNativeMode)
         {

--- a/src/Finance/Probabilistic/DiffusionTS.cs
+++ b/src/Finance/Probabilistic/DiffusionTS.cs
@@ -352,7 +352,7 @@ public partial class DiffusionTS<T> : ForecastingModelBase<T>
         if (Architecture.Layers is not null && Architecture.Layers.Count > 0)
         {
             Layers.AddRange(Architecture.Layers);
-            ValidateCustomLayers(Layers);
+            ValidateCustomLayersWithOwnershipRollback(Layers);
         }
         else if (_useNativeMode)
         {

--- a/src/Finance/Probabilistic/ScoreGrad.cs
+++ b/src/Finance/Probabilistic/ScoreGrad.cs
@@ -336,7 +336,7 @@ public partial class ScoreGrad<T> : ForecastingModelBase<T>
         if (Architecture.Layers is not null && Architecture.Layers.Count > 0)
         {
             Layers.AddRange(Architecture.Layers);
-            ValidateCustomLayers(Layers);
+            ValidateCustomLayersWithOwnershipRollback(Layers);
         }
         else if (_useNativeMode)
         {

--- a/src/Finance/Probabilistic/TSDiff.cs
+++ b/src/Finance/Probabilistic/TSDiff.cs
@@ -337,7 +337,7 @@ public partial class TSDiff<T> : ForecastingModelBase<T>
         if (Architecture.Layers is not null && Architecture.Layers.Count > 0)
         {
             Layers.AddRange(Architecture.Layers);
-            ValidateCustomLayers(Layers);
+            ValidateCustomLayersWithOwnershipRollback(Layers);
         }
         else if (_useNativeMode)
         {

--- a/src/Finance/Probabilistic/TimeGrad.cs
+++ b/src/Finance/Probabilistic/TimeGrad.cs
@@ -320,7 +320,7 @@ public partial class TimeGrad<T> : ForecastingModelBase<T>
         if (Architecture.Layers is not null && Architecture.Layers.Count > 0)
         {
             Layers.AddRange(Architecture.Layers);
-            ValidateCustomLayers(Layers);
+            ValidateCustomLayersWithOwnershipRollback(Layers);
         }
         else if (_useNativeMode)
         {

--- a/src/Finance/Volatility/NeuralGARCH.cs
+++ b/src/Finance/Volatility/NeuralGARCH.cs
@@ -167,7 +167,7 @@ public partial class NeuralGARCH<T> : FinancialModelBase<T>, IVolatilityModel<T>
         if (Architecture.Layers is not null && Architecture.Layers.Count > 0)
         {
             Layers.AddRange(Architecture.Layers);
-            ValidateCustomLayers(Layers);
+            ValidateCustomLayersWithOwnershipRollback(Layers);
         }
         else if (UseNativeMode)
         {

--- a/src/Finance/Volatility/RealizedVolatilityTransformer.cs
+++ b/src/Finance/Volatility/RealizedVolatilityTransformer.cs
@@ -166,7 +166,7 @@ public partial class RealizedVolatilityTransformer<T> : FinancialModelBase<T>, I
         if (Architecture.Layers is not null && Architecture.Layers.Count > 0)
         {
             Layers.AddRange(Architecture.Layers);
-            ValidateCustomLayers(Layers);
+            ValidateCustomLayersWithOwnershipRollback(Layers);
         }
         else if (UseNativeMode)
         {

--- a/src/Helpers/DeserializationHelper.cs
+++ b/src/Helpers/DeserializationHelper.cs
@@ -3584,7 +3584,7 @@ public static class DeserializationHelper
         {
             try
             {
-                lb.ResolveFromShape(inputShape);
+                lb.ResolveFromPublishedShape(inputShape);
             }
             catch (Exception ex) when (ex is ArgumentException || ex is InvalidOperationException)
             {

--- a/src/Models/CloneEngine.cs
+++ b/src/Models/CloneEngine.cs
@@ -514,19 +514,13 @@ public static class CloneEngine
         // constructor argument makes the reconstructed parent share those owned objects before its
         // parameter state is even restored. Let the blueprint produce an independent structural
         // copy; parameter tensors remain the responsibility of the parent's copy-on-write path.
+        // A failed configuration clone is not permission to return the mutable source object: the
+        // constructor consumes that reference before any later copy-on-write preflight can reject
+        // it. In particular, returning an owned NeuralNetworkArchitecture here either aliases its
+        // layers or trips its second-owner guard. Preserve the failure at this value boundary.
         if (value is IConfigurationCloneable configuration)
         {
-            try
-            {
-                return configuration.CloneConfiguration();
-            }
-            catch (Exception)
-            {
-                // Preserve the established fallback for a consumer-defined configuration that
-                // cannot be reconstructed. The parent's copy-on-write identity check will reject
-                // unsafe sharing and route to the eager serialization clone instead.
-                return value;
-            }
+            return configuration.CloneConfiguration();
         }
 
         // Noise schedulers are mutable model components even though they are not IFullModel and do

--- a/src/NeuralNetworks/Autoencoder.cs
+++ b/src/NeuralNetworks/Autoencoder.cs
@@ -286,7 +286,7 @@ public partial class Autoencoder<T> : VectorModelLayoutBase<T>, IAuxiliaryLossLa
         {
             // Use the layers provided by the user
             Layers.AddRange(Architecture.Layers);
-            ValidateCustomLayers(Layers);
+            ValidateCustomLayersWithOwnershipRollback(Layers);
         }
         else
         {

--- a/src/NeuralNetworks/EchoStateNetwork.cs
+++ b/src/NeuralNetworks/EchoStateNetwork.cs
@@ -988,7 +988,7 @@ public partial class EchoStateNetwork<T> : SequenceModelLayoutBase<T>
         {
             // Use the layers provided by the user
             Layers.AddRange(Architecture.Layers);
-            ValidateCustomLayers(Layers);
+            ValidateCustomLayersWithOwnershipRollback(Layers);
         }
         else
         {

--- a/src/NeuralNetworks/Layers/LayerBase.cs
+++ b/src/NeuralNetworks/Layers/LayerBase.cs
@@ -3504,7 +3504,9 @@ public abstract class LayerBase<T> : ILayer<T>, ITrainableLayer<T>, IParameterSo
         {
             ResolveFromShape(publishedShape);
         }
-        catch (Exception ex) when (ex is ArgumentException || ex is InvalidOperationException)
+        catch (Exception ex) when (
+            (ex is ArgumentException || ex is InvalidOperationException)
+            && !IsShapeResolved)
         {
             ResolveFromShape(LayerCloning.WithBatchAxis(publishedShape));
         }

--- a/src/NeuralNetworks/Layers/LayerBase.cs
+++ b/src/NeuralNetworks/Layers/LayerBase.cs
@@ -3472,6 +3472,45 @@ public abstract class LayerBase<T> : ILayer<T>, ITrainableLayer<T>, IParameterSo
     }
 
     /// <summary>
+    /// Resolves a reconstructed layer from the shape that the source layer published through
+    /// <see cref="GetInputShape"/>.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// A published layer shape normally describes one sample, while <see cref="ResolveFromShape"/>
+    /// deliberately accepts the tensor shape seen by the first forward. Those are not interchangeable
+    /// for a batch-aware structural layer. A resolved <see cref="FlattenLayer{T}"/>, for example,
+    /// publishes <c>[channels, height, width]</c>; replaying that directly makes it interpret channels
+    /// as the batch and silently flatten only height by width.
+    /// </para>
+    /// <para>
+    /// <see cref="IBatchAwareShapeContract"/> is the type-safe declaration that the distinction changes
+    /// the layer's result, so those layers receive an explicit singleton batch. Other layers retain the
+    /// established bare-first behavior, with a batched retry for layers such as Conv1D whose forward
+    /// requires a batch even though their published shape omits it.
+    /// </para>
+    /// </remarks>
+    internal void ResolveFromPublishedShape(int[] publishedShape)
+    {
+        if (publishedShape is null) throw new ArgumentNullException(nameof(publishedShape));
+
+        if (this is IBatchAwareShapeContract)
+        {
+            ResolveFromShape(LayerCloning.WithBatchAxis(publishedShape));
+            return;
+        }
+
+        try
+        {
+            ResolveFromShape(publishedShape);
+        }
+        catch (Exception ex) when (ex is ArgumentException || ex is InvalidOperationException)
+        {
+            ResolveFromShape(LayerCloning.WithBatchAxis(publishedShape));
+        }
+    }
+
+    /// <summary>
     /// A tensor that carries <paramref name="shape"/> for shape resolution, without paying for the
     /// storage that shape implies.
     /// </summary>
@@ -6260,24 +6299,7 @@ public abstract class LayerBase<T> : ILayer<T>, ITrainableLayer<T>, IParameterSo
         }
         else if (savedShape is not null && !IsShapeResolved)
         {
-            // The saved shape is what the layer PUBLISHED for itself, and a layer may publish one
-            // sample while its forward requires the batch axis: Conv1DLayer resolves to
-            // [channels, time] and then rejects anything that is not [B, C, T], so restoring it
-            // from its own declaration threw at its own shape. Offer the batched form too rather
-            // than relaxing the layer's rank check, which is deliberate and documented. Same
-            // try-batched-then-bare that CompleteShapeOnlyResolutionIfPending and
-            // LayerCloning.ProbeShapes already use for exactly this split.
-            try
-            {
-                ResolveFromShape(savedShape);
-            }
-            catch (ArgumentException)
-            {
-                var batched = new int[savedShape.Length + 1];
-                batched[0] = 1;
-                System.Array.Copy(savedShape, 0, batched, 1, savedShape.Length);
-                ResolveFromShape(batched);
-            }
+            ResolveFromPublishedShape(savedShape);
         }
 
         if (IsShapeResolved)

--- a/src/NeuralNetworks/NeuralNetworkArchitecture.cs
+++ b/src/NeuralNetworks/NeuralNetworkArchitecture.cs
@@ -1236,6 +1236,66 @@ public class NeuralNetworkArchitecture<T> : IConfigurationCloneable
     object IConfigurationCloneable.CloneConfiguration() => CloneForModelConstruction();
 
     /// <summary>
+    /// The model that has taken ownership of this architecture's layer objects, if any.
+    /// </summary>
+    /// <remarks>
+    /// Weak so an architecture can never keep a model alive. A collected owner leaves the architecture
+    /// claimable again, which is correct: the layers it holds are no longer reachable through a live model.
+    /// </remarks>
+    private WeakReference<object>? _owner;
+
+    /// <summary>
+    /// Records that <paramref name="model"/> is about to use this architecture's layer objects, and refuses a
+    /// SECOND model trying to do the same.
+    /// </summary>
+    /// <remarks>
+    /// <para>Models built on this architecture take its layers BY REFERENCE - <c>InitializeLayers</c> does
+    /// <c>Layers.AddRange(Architecture.Layers)</c>, in 800-odd model types. Two models constructed from one
+    /// architecture instance therefore do not merely start from the same weights, they own the same mutable
+    /// layer objects, and training either one trains both.</para>
+    ///
+    /// <para>That is silent, and its worst case is a reinforcement-learning target network: the target IS the
+    /// online network, so the temporal-difference target is read from the network being updated in the same
+    /// batch, and a twin-critic minimum reduces to <c>min(Q, Q)</c>. Nothing throws, nothing warns, and the
+    /// resulting training curves look entirely ordinary. <see cref="CloneForModelConstruction"/> is the
+    /// remedy and the finance agents already call it - but nothing made the mistake impossible to repeat, and
+    /// the next model with a target network would repeat it exactly as quietly.</para>
+    ///
+    /// <para>Only architectures that CARRY layers are claimed. When <see cref="Layers"/> is empty each model
+    /// builds its own from the default factory, so there is nothing to share and reuse is perfectly safe -
+    /// that is the common case and it stays unaffected.</para>
+    /// </remarks>
+    internal void ClaimForModel(object model)
+    {
+        if (Layers.Count == 0)
+        {
+            return;
+        }
+
+        if (_owner is null)
+        {
+            _owner = new WeakReference<object>(model);
+            return;
+        }
+
+        // The same model re-initialising itself - deserialization and lazy shape resolution both re-enter
+        // InitializeLayers on an existing instance - is not a second owner.
+        if (!_owner.TryGetTarget(out var existing) || ReferenceEquals(existing, model))
+        {
+            _owner.SetTarget(model);
+            return;
+        }
+
+        throw new InvalidOperationException(
+            $"This {nameof(NeuralNetworkArchitecture<T>)} already belongs to a {existing.GetType().Name} and "
+            + "carries explicit layers, which models take BY REFERENCE. Constructing a second model from it "
+            + "would give both models the same mutable layers, so training either would train both - the "
+            + "failure that makes a reinforcement-learning target network silently equal to its online "
+            + $"network. Build the second model from {nameof(CloneForModelConstruction)}() so it gets "
+            + "independent layers.");
+    }
+
+    /// <summary>
     /// Creates an independent architecture for another model that must not share this instance's
     /// mutable layer objects.
     /// </summary>

--- a/src/NeuralNetworks/NeuralNetworkArchitecture.cs
+++ b/src/NeuralNetworks/NeuralNetworkArchitecture.cs
@@ -1304,6 +1304,25 @@ public class NeuralNetworkArchitecture<T> : IConfigurationCloneable
     }
 
     /// <summary>
+    /// Releases a provisional layer-graph claim after the claiming model rejects the graph.
+    /// </summary>
+    /// <param name="model">The model whose claim should be released.</param>
+    /// <remarks>
+    /// Reference identity prevents a failed or stale constructor from releasing a newer model's claim.
+    /// The same lock as <see cref="ClaimForModel"/> makes release-versus-claim ordering atomic.
+    /// </remarks>
+    internal void ReleaseForModel(object model)
+    {
+        lock (_ownerSync)
+        {
+            if (_owner is not null && _owner.TryGetTarget(out var existing) && ReferenceEquals(existing, model))
+            {
+                _owner = null;
+            }
+        }
+    }
+
+    /// <summary>
     /// Creates an independent architecture for another model that must not share this instance's
     /// mutable layer objects.
     /// </summary>

--- a/src/NeuralNetworks/NeuralNetworkArchitecture.cs
+++ b/src/NeuralNetworks/NeuralNetworkArchitecture.cs
@@ -1245,6 +1245,11 @@ public class NeuralNetworkArchitecture<T> : IConfigurationCloneable
     private WeakReference<object>? _owner;
 
     /// <summary>
+    /// Serializes ownership decisions for the mutable layer graph.
+    /// </summary>
+    private readonly object _ownerSync = new();
+
+    /// <summary>
     /// Records that <paramref name="model"/> is about to use this architecture's layer objects, and refuses a
     /// SECOND model trying to do the same.
     /// </summary>
@@ -1267,32 +1272,35 @@ public class NeuralNetworkArchitecture<T> : IConfigurationCloneable
     /// </remarks>
     internal void ClaimForModel(object model)
     {
-        if (Layers.Count == 0)
+        lock (_ownerSync)
         {
-            return;
-        }
+            if (Layers.Count == 0)
+            {
+                return;
+            }
 
-        if (_owner is null)
-        {
-            _owner = new WeakReference<object>(model);
-            return;
-        }
+            if (_owner is null)
+            {
+                _owner = new WeakReference<object>(model);
+                return;
+            }
 
-        // The same model re-initialising itself - deserialization and lazy shape resolution both re-enter
-        // InitializeLayers on an existing instance - is not a second owner.
-        if (!_owner.TryGetTarget(out var existing) || ReferenceEquals(existing, model))
-        {
-            _owner.SetTarget(model);
-            return;
-        }
+            // The same model re-initialising itself - deserialization and lazy shape resolution both re-enter
+            // InitializeLayers on an existing instance - is not a second owner.
+            if (!_owner.TryGetTarget(out var existing) || ReferenceEquals(existing, model))
+            {
+                _owner.SetTarget(model);
+                return;
+            }
 
-        throw new InvalidOperationException(
-            $"This {nameof(NeuralNetworkArchitecture<T>)} already belongs to a {existing.GetType().Name} and "
-            + "carries explicit layers, which models take BY REFERENCE. Constructing a second model from it "
-            + "would give both models the same mutable layers, so training either would train both - the "
-            + "failure that makes a reinforcement-learning target network silently equal to its online "
-            + $"network. Build the second model from {nameof(CloneForModelConstruction)}() so it gets "
-            + "independent layers.");
+            throw new InvalidOperationException(
+                $"This {nameof(NeuralNetworkArchitecture<T>)} already belongs to a {existing.GetType().Name} and "
+                + "carries explicit layers, which models take BY REFERENCE. Constructing a second model from it "
+                + "would give both models the same mutable layers, so training either would train both - the "
+                + "failure that makes a reinforcement-learning target network silently equal to its online "
+                + $"network. Build the second model from {nameof(CloneForModelConstruction)}() so it gets "
+                + "independent layers.");
+        }
     }
 
     /// <summary>

--- a/src/NeuralNetworks/NeuralNetworkBase.cs
+++ b/src/NeuralNetworks/NeuralNetworkBase.cs
@@ -581,6 +581,10 @@ public abstract partial class NeuralNetworkBase<T> : INeuralNetworkModel<T>, IIn
     protected NeuralNetworkBase(NeuralNetworkArchitecture<T> architecture, ILossFunction<T> lossFunction, double maxGradNorm = 1.0)
     {
         Architecture = architecture;
+        // Refuse a second model on the same architecture instance BEFORE any layers are taken by reference.
+        // Every model type in the library reaches this constructor, so this is the one place the sharing can
+        // be caught for all of them.
+        architecture.ClaimForModel(this);
         // Begin a deterministic per-layer initialization-seed sequence for this
         // model's construction BEFORE the derived constructor builds its layers.
         // Each LayerBase<T> constructor pulls a seed from this scope so weight

--- a/src/NeuralNetworks/NeuralNetworkBase.cs
+++ b/src/NeuralNetworks/NeuralNetworkBase.cs
@@ -4006,14 +4006,75 @@ public abstract partial class NeuralNetworkBase<T> : INeuralNetworkModel<T>, IIn
     /// <remarks>
     /// <b>For Beginners:</b> Not all combinations of layers make a valid neural network. This method checks that
     /// the layers can properly connect to each other (like making sure puzzle pieces fit together).
+    /// Derived implementations may add model-specific checks. Their initialization path must enter through
+    /// <see cref="ValidateCustomLayersWithOwnershipRollback"/> so failures after the base checks also release
+    /// the provisional architecture claim.
     /// </remarks>
     /// <exception cref="ArgumentException">Thrown when the layer configuration is invalid.</exception>
     protected virtual void ValidateCustomLayers(List<ILayer<T>> layers)
     {
-        ValidateCustomLayersInternal(layers);
+        try
+        {
+            ValidateCustomLayersInternalCore(layers);
+        }
+        catch
+        {
+            RollbackRejectedCustomLayers();
+            throw;
+        }
     }
 
+    /// <summary>
+    /// Runs a model-specific custom-layer validator inside the architecture ownership transaction.
+    /// </summary>
+    /// <param name="layers">The layers to validate.</param>
+    /// <remarks>
+    /// Derived models that override <see cref="ValidateCustomLayers"/> call this non-virtual entry point from
+    /// initialization. It catches failures thrown after the base validator returns while preserving the existing
+    /// protected virtual extension point for downstream models.
+    /// </remarks>
+    protected void ValidateCustomLayersWithOwnershipRollback(List<ILayer<T>> layers)
+    {
+        try
+        {
+            ValidateCustomLayers(layers);
+        }
+        catch
+        {
+            RollbackRejectedCustomLayers();
+            throw;
+        }
+    }
+
+    /// <summary>
+    /// Validates only the common layer contracts while preserving the ownership transaction.
+    /// </summary>
+    /// <param name="layers">The layers to validate.</param>
     protected void ValidateCustomLayersInternal(List<ILayer<T>> layers)
+    {
+        try
+        {
+            ValidateCustomLayersInternalCore(layers);
+        }
+        catch
+        {
+            RollbackRejectedCustomLayers();
+            throw;
+        }
+    }
+
+    private void RollbackRejectedCustomLayers()
+    {
+        // Validation is the commit point for a caller-supplied layer graph. Until it succeeds, the
+        // ownership claim is provisional. Drop this model's references before releasing the claim so
+        // an immediate corrected construction can take the graph without ever overlapping owners.
+        _layers.Clear();
+        InvalidateParameterCountCache();
+        Architecture.ReleaseForModel(this);
+        Volatile.Write(ref _architectureLayerOwnershipEstablished, 0);
+    }
+
+    private void ValidateCustomLayersInternalCore(List<ILayer<T>> layers)
     {
         if (layers == null || layers.Count == 0)
         {

--- a/src/NeuralNetworks/NeuralNetworkBase.cs
+++ b/src/NeuralNetworks/NeuralNetworkBase.cs
@@ -137,6 +137,16 @@ public abstract partial class NeuralNetworkBase<T> : INeuralNetworkModel<T>, IIn
     /// </remarks>
     private readonly List<ILayer<T>> _layers;
 
+    /// <summary>
+    /// Indicates that this model has crossed the architecture-layer ownership boundary.
+    /// </summary>
+    /// <remarks>
+    /// Keeps the ownership guard off inference and training hot paths after the first layer-collection
+    /// access. A competing first access may repeat the idempotent same-model claim, but neither access can
+    /// return the collection until the architecture's atomic claim has completed.
+    /// </remarks>
+    private int _architectureLayerOwnershipEstablished;
+
 
     /// <summary>
     /// Gets the collection of layers that make up this neural network (read-only access).
@@ -150,7 +160,24 @@ public abstract partial class NeuralNetworkBase<T> : INeuralNetworkModel<T>, IIn
     /// Use AddLayerToCollection() or RemoveLayerFromCollection() instead to ensure proper cache invalidation.
     /// </para>
     /// </remarks>
-    public List<ILayer<T>> Layers => _layers;
+    public List<ILayer<T>> Layers
+    {
+        get
+        {
+            // Claim only at the first point where this model can take references to the architecture's
+            // mutable layers. Claiming in the base constructor poisoned the architecture when a derived
+            // constructor rejected its configuration before touching Layers; a corrected construction
+            // then looked like an illegal second owner. The getter is evaluated before Add/AddRange can
+            // capture anything, while ClaimForModel's lock still makes competing captures atomic.
+            if (Volatile.Read(ref _architectureLayerOwnershipEstablished) == 0)
+            {
+                Architecture.ClaimForModel(this);
+                Volatile.Write(ref _architectureLayerOwnershipEstablished, 1);
+            }
+
+            return _layers;
+        }
+    }
 
     /// <summary>
     /// Moves the whole model — every layer's parameters and buffers — to the given device, the model-level
@@ -581,10 +608,6 @@ public abstract partial class NeuralNetworkBase<T> : INeuralNetworkModel<T>, IIn
     protected NeuralNetworkBase(NeuralNetworkArchitecture<T> architecture, ILossFunction<T> lossFunction, double maxGradNorm = 1.0)
     {
         Architecture = architecture;
-        // Refuse a second model on the same architecture instance BEFORE any layers are taken by reference.
-        // Every model type in the library reaches this constructor, so this is the one place the sharing can
-        // be caught for all of them.
-        architecture.ClaimForModel(this);
         // Begin a deterministic per-layer initialization-seed sequence for this
         // model's construction BEFORE the derived constructor builds its layers.
         // Each LayerBase<T> constructor pulls a seed from this scope so weight

--- a/src/NeuralNetworks/NeuralNetworkBase.cs
+++ b/src/NeuralNetworks/NeuralNetworkBase.cs
@@ -147,6 +147,12 @@ public abstract partial class NeuralNetworkBase<T> : INeuralNetworkModel<T>, IIn
     /// </remarks>
     private int _architectureLayerOwnershipEstablished;
 
+    /// <summary>
+    /// Tracks nested validation entry points so one failed validation chain rolls back its provisional
+    /// architecture claim exactly once at the outer transaction boundary.
+    /// </summary>
+    private int _customLayerValidationDepth;
+
 
     /// <summary>
     /// Gets the collection of layers that make up this neural network (read-only access).
@@ -4013,15 +4019,7 @@ public abstract partial class NeuralNetworkBase<T> : INeuralNetworkModel<T>, IIn
     /// <exception cref="ArgumentException">Thrown when the layer configuration is invalid.</exception>
     protected virtual void ValidateCustomLayers(List<ILayer<T>> layers)
     {
-        try
-        {
-            ValidateCustomLayersInternalCore(layers);
-        }
-        catch
-        {
-            RollbackRejectedCustomLayers();
-            throw;
-        }
+        ValidateWithOwnershipRollback(() => ValidateCustomLayersInternalCore(layers));
     }
 
     /// <summary>
@@ -4035,15 +4033,7 @@ public abstract partial class NeuralNetworkBase<T> : INeuralNetworkModel<T>, IIn
     /// </remarks>
     protected void ValidateCustomLayersWithOwnershipRollback(List<ILayer<T>> layers)
     {
-        try
-        {
-            ValidateCustomLayers(layers);
-        }
-        catch
-        {
-            RollbackRejectedCustomLayers();
-            throw;
-        }
+        ValidateWithOwnershipRollback(() => ValidateCustomLayers(layers));
     }
 
     /// <summary>
@@ -4052,14 +4042,28 @@ public abstract partial class NeuralNetworkBase<T> : INeuralNetworkModel<T>, IIn
     /// <param name="layers">The layers to validate.</param>
     protected void ValidateCustomLayersInternal(List<ILayer<T>> layers)
     {
+        ValidateWithOwnershipRollback(() => ValidateCustomLayersInternalCore(layers));
+    }
+
+    private void ValidateWithOwnershipRollback(Action validate)
+    {
+        bool ownsRollback = _customLayerValidationDepth++ == 0;
         try
         {
-            ValidateCustomLayersInternalCore(layers);
+            validate();
         }
         catch
         {
-            RollbackRejectedCustomLayers();
+            if (ownsRollback)
+            {
+                RollbackRejectedCustomLayers();
+            }
+
             throw;
+        }
+        finally
+        {
+            _customLayerValidationDepth--;
         }
     }
 

--- a/src/NeuralNetworks/SyntheticData/AuxLayerSerialization.cs
+++ b/src/NeuralNetworks/SyntheticData/AuxLayerSerialization.cs
@@ -91,7 +91,7 @@ internal static class AuxLayerSerialization
         var layer = factory(inputShape, outputShape);
         if (inputShape.Length > 0 && inputShape[0] > 0 && layer is LayerBase<T> resolvable)
         {
-            resolvable.ResolveFromShape(inputShape);
+            resolvable.ResolveFromPublishedShape(inputShape);
         }
 
         ReadLayerState(reader, layer);

--- a/src/NeuralNetworks/Transformer.cs
+++ b/src/NeuralNetworks/Transformer.cs
@@ -366,7 +366,7 @@ public partial class Transformer<T> : TokenLanguageModelLayoutBase<T>, IAuxiliar
         {
             // Use the layers provided by the user
             Layers.AddRange(Architecture.Layers);
-            ValidateCustomLayers(Layers);
+            ValidateCustomLayersWithOwnershipRollback(Layers);
         }
         else
         {

--- a/src/NeuralNetworks/VariationalAutoencoder.cs
+++ b/src/NeuralNetworks/VariationalAutoencoder.cs
@@ -256,7 +256,7 @@ public partial class VariationalAutoencoder<T> : VectorModelLayoutBase<T>, IAuxi
         {
             // Use the layers provided by the user
             Layers.AddRange(Architecture.Layers);
-            ValidateCustomLayers(Layers);
+            ValidateCustomLayersWithOwnershipRollback(Layers);
         }
         else
         {

--- a/tests/AiDotNet.Tests/IntegrationTests/NeuralNetworks/LazyLayerResolvedShapeRoundTripTests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/NeuralNetworks/LazyLayerResolvedShapeRoundTripTests.cs
@@ -1,4 +1,5 @@
 using System.IO;
+using AiDotNet.Attributes;
 using AiDotNet.LinearAlgebra;
 using AiDotNet.NeuralNetworks.Layers;
 using Xunit;
@@ -134,5 +135,46 @@ public class LazyLayerResolvedShapeRoundTripTests
         var layer = new Conv1DLayer<double>(outputChannels: 4, kernelSize: 3);
         layer.SetTrainingMode(false);
         Assert.Throws<System.ArgumentException>(() => layer.Forward(Ramp([2, 8])));
+    }
+
+    [Fact]
+    public void PublishedShapeReplay_PropagatesFailureAfterShapeResolution()
+    {
+        using var layer = new ResolvesThenThrowsLayer();
+
+        var exception = Assert.Throws<InvalidOperationException>(
+            () => layer.ResolveFromPublishedShape([4]));
+
+        Assert.Equal(ResolvesThenThrowsLayer.FailureMessage, exception.Message);
+        Assert.True(layer.IsShapeResolved);
+        Assert.Equal(1, layer.FirstForwardCalls);
+    }
+
+    [ElementWiseShape]
+    private sealed class ResolvesThenThrowsLayer : LayerBase<double>
+    {
+        internal const string FailureMessage = "Initialization failed after resolving the shape.";
+
+        internal ResolvesThenThrowsLayer() : base([-1], [-1])
+        {
+        }
+
+        internal int FirstForwardCalls { get; private set; }
+
+        protected override void OnFirstForward(Tensor<double> input)
+        {
+            FirstForwardCalls++;
+            int features = input.Shape[input.Rank - 1];
+            ResolveShapes([features], [features]);
+            throw new InvalidOperationException(FailureMessage);
+        }
+
+        protected override Tensor<double> ForwardTraced(Tensor<double> input) => input;
+
+        public override bool SupportsTraining => false;
+
+        public override void ResetState()
+        {
+        }
     }
 }

--- a/tests/AiDotNet.Tests/IntegrationTests/VisionLanguage/VisionLanguagePatchSizingReviewRegressionIntegrationTests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/VisionLanguage/VisionLanguagePatchSizingReviewRegressionIntegrationTests.cs
@@ -18,23 +18,25 @@ public class VisionLanguagePatchSizingReviewRegressionIntegrationTests
     public async Task InstructionTunedModels_WithNonDivisibleTokenBudgets_RoundPatchSizeUp()
     {
         await Task.Yield();
-        var architecture = CreateArchitectureWithCustomLayers();
-
-        AssertPatchSizeIsEight(() => new DeepSeekVL<double>(architecture, CreateOptions<DeepSeekVLOptions>()));
-        AssertPatchSizeIsEight(() => new DeepSeekVL2<double>(architecture, CreateOptions<DeepSeekVL2Options>()));
-        AssertPatchSizeIsEight(() => new Gemma3<double>(architecture, CreateOptions<Gemma3Options>()));
-        AssertPatchSizeIsEight(() => new InternVL<double>(architecture, CreateOptions<InternVLOptions>()));
-        AssertPatchSizeIsEight(() => new InternVL2<double>(architecture, CreateOptions<InternVL2Options>()));
-        AssertPatchSizeIsEight(() => new InternVL25<double>(architecture, CreateOptions<InternVL25Options>()));
-        AssertPatchSizeIsEight(() => new InternVL3<double>(architecture, CreateOptions<InternVL3Options>()));
-        AssertPatchSizeIsEight(() => new Llama32Vision<double>(architecture, CreateOptions<Llama32VisionOptions>()));
-        AssertPatchSizeIsEight(() => new Phi3Vision<double>(architecture, CreateOptions<Phi3VisionOptions>()));
-        AssertPatchSizeIsEight(() => new Phi4Multimodal<double>(architecture, CreateOptions<Phi4MultimodalOptions>()));
+        AssertPatchSizeIsEight(architecture => new DeepSeekVL<double>(architecture, CreateOptions<DeepSeekVLOptions>()));
+        AssertPatchSizeIsEight(architecture => new DeepSeekVL2<double>(architecture, CreateOptions<DeepSeekVL2Options>()));
+        AssertPatchSizeIsEight(architecture => new Gemma3<double>(architecture, CreateOptions<Gemma3Options>()));
+        AssertPatchSizeIsEight(architecture => new InternVL<double>(architecture, CreateOptions<InternVLOptions>()));
+        AssertPatchSizeIsEight(architecture => new InternVL2<double>(architecture, CreateOptions<InternVL2Options>()));
+        AssertPatchSizeIsEight(architecture => new InternVL25<double>(architecture, CreateOptions<InternVL25Options>()));
+        AssertPatchSizeIsEight(architecture => new InternVL3<double>(architecture, CreateOptions<InternVL3Options>()));
+        AssertPatchSizeIsEight(architecture => new Llama32Vision<double>(architecture, CreateOptions<Llama32VisionOptions>()));
+        AssertPatchSizeIsEight(architecture => new Phi3Vision<double>(architecture, CreateOptions<Phi3VisionOptions>()));
+        AssertPatchSizeIsEight(architecture => new Phi4Multimodal<double>(architecture, CreateOptions<Phi4MultimodalOptions>()));
     }
 
-    private static void AssertPatchSizeIsEight<TModel>(Func<TModel> factory) where TModel : IDisposable
+    private static void AssertPatchSizeIsEight<TModel>(Func<NeuralNetworkArchitecture<double>, TModel> factory)
+        where TModel : IDisposable
     {
-        using var model = factory();
+        // An architecture carrying explicit layers is a single-owner blueprint. Build a fresh graph for
+        // every model under test; reusing one here would either alias mutable layers or reuse layers that
+        // the preceding model disposed, neither of which is part of the patch-size behavior under test.
+        using var model = factory(CreateArchitectureWithCustomLayers());
         Assert.Equal(8, InvokeComputePatchSize(model));
     }
 
@@ -42,18 +44,16 @@ public class VisionLanguagePatchSizingReviewRegressionIntegrationTests
     public async Task InstructionTunedModels_WithInvalidVisualSizingOptions_RejectBeforeLayerInitialization()
     {
         await Task.Yield();
-        var architecture = CreateArchitectureWithCustomLayers();
-
-        AssertInvalidSizingRejected(() => new DeepSeekVL<double>(architecture, CreateOptions<DeepSeekVLOptions>(imageSize: 0)), "imageSize");
-        AssertInvalidSizingRejected(() => new DeepSeekVL2<double>(architecture, CreateOptions<DeepSeekVL2Options>(imageSize: 0)), "imageSize");
-        AssertInvalidSizingRejected(() => new Gemma3<double>(architecture, CreateOptions<Gemma3Options>(imageSize: 0)), "imageSize");
-        AssertInvalidSizingRejected(() => new InternVL<double>(architecture, CreateOptions<InternVLOptions>(imageSize: 0)), "imageSize");
-        AssertInvalidSizingRejected(() => new InternVL2<double>(architecture, CreateOptions<InternVL2Options>(imageSize: 0)), "imageSize");
-        AssertInvalidSizingRejected(() => new InternVL25<double>(architecture, CreateOptions<InternVL25Options>(maxVisualTokens: 0)), "maxVisualTokens");
-        AssertInvalidSizingRejected(() => new InternVL3<double>(architecture, CreateOptions<InternVL3Options>(maxVisualTokens: 0)), "maxVisualTokens");
-        AssertInvalidSizingRejected(() => new Llama32Vision<double>(architecture, CreateOptions<Llama32VisionOptions>(maxVisualTokens: 0)), "maxVisualTokens");
-        AssertInvalidSizingRejected(() => new Phi3Vision<double>(architecture, CreateOptions<Phi3VisionOptions>(maxVisualTokens: 0)), "maxVisualTokens");
-        AssertInvalidSizingRejected(() => new Phi4Multimodal<double>(architecture, CreateOptions<Phi4MultimodalOptions>(maxVisualTokens: 0)), "maxVisualTokens");
+        AssertInvalidSizingRejected(architecture => new DeepSeekVL<double>(architecture, CreateOptions<DeepSeekVLOptions>(imageSize: 0)), "imageSize");
+        AssertInvalidSizingRejected(architecture => new DeepSeekVL2<double>(architecture, CreateOptions<DeepSeekVL2Options>(imageSize: 0)), "imageSize");
+        AssertInvalidSizingRejected(architecture => new Gemma3<double>(architecture, CreateOptions<Gemma3Options>(imageSize: 0)), "imageSize");
+        AssertInvalidSizingRejected(architecture => new InternVL<double>(architecture, CreateOptions<InternVLOptions>(imageSize: 0)), "imageSize");
+        AssertInvalidSizingRejected(architecture => new InternVL2<double>(architecture, CreateOptions<InternVL2Options>(imageSize: 0)), "imageSize");
+        AssertInvalidSizingRejected(architecture => new InternVL25<double>(architecture, CreateOptions<InternVL25Options>(maxVisualTokens: 0)), "maxVisualTokens");
+        AssertInvalidSizingRejected(architecture => new InternVL3<double>(architecture, CreateOptions<InternVL3Options>(maxVisualTokens: 0)), "maxVisualTokens");
+        AssertInvalidSizingRejected(architecture => new Llama32Vision<double>(architecture, CreateOptions<Llama32VisionOptions>(maxVisualTokens: 0)), "maxVisualTokens");
+        AssertInvalidSizingRejected(architecture => new Phi3Vision<double>(architecture, CreateOptions<Phi3VisionOptions>(maxVisualTokens: 0)), "maxVisualTokens");
+        AssertInvalidSizingRejected(architecture => new Phi4Multimodal<double>(architecture, CreateOptions<Phi4MultimodalOptions>(maxVisualTokens: 0)), "maxVisualTokens");
     }
 
     private static TOptions CreateOptions<TOptions>(int imageSize = 31, int maxVisualTokens = 16)
@@ -96,12 +96,15 @@ public class VisionLanguagePatchSizingReviewRegressionIntegrationTests
     {
         var method = model.GetType().GetMethod("ComputePatchSize", BindingFlags.Instance | BindingFlags.NonPublic);
         Assert.NotNull(method);
-        return (int)method!.Invoke(model, Array.Empty<object>())!;
+        return (int)method.Invoke(model, Array.Empty<object>());
     }
 
-    private static void AssertInvalidSizingRejected(Action createModel, string expectedParamName)
+    private static void AssertInvalidSizingRejected(
+        Action<NeuralNetworkArchitecture<double>> createModel,
+        string expectedParamName)
     {
-        var ex = Assert.Throws<ArgumentOutOfRangeException>(createModel);
+        var ex = Assert.Throws<ArgumentOutOfRangeException>(
+            () => createModel(CreateArchitectureWithCustomLayers()));
         Assert.Equal(expectedParamName, ex.ParamName);
     }
 }

--- a/tests/AiDotNet.Tests/UnitTests/NeuralNetworks/ArchitectureSharingGuardTests.cs
+++ b/tests/AiDotNet.Tests/UnitTests/NeuralNetworks/ArchitectureSharingGuardTests.cs
@@ -1,0 +1,126 @@
+using System;
+using AiDotNet.Helpers;
+using AiDotNet.NeuralNetworks;
+using Xunit;
+
+namespace AiDotNet.Tests.UnitTests.NeuralNetworks;
+
+/// <summary>
+/// Models take an architecture's layers BY REFERENCE, so one architecture instance may build one model.
+///
+/// <para><c>InitializeLayers</c> does <c>Layers.AddRange(Architecture.Layers)</c> — the pattern appears in
+/// 800-odd model types. Two models built from one architecture instance therefore own the same mutable layer
+/// objects, and training either one trains both.</para>
+///
+/// <para>That is silent, and the failure it produces is not obviously a failure. Its worst case is a
+/// reinforcement-learning target network: the target IS the online network, so the temporal-difference target
+/// is read from the network being updated in the same batch, and a twin-critic minimum reduces to
+/// <c>min(Q, Q)</c>. The training curves look ordinary throughout. The finance agents already avoid this by
+/// cloning, but nothing made the mistake impossible to repeat.</para>
+/// </summary>
+public class ArchitectureSharingGuardTests
+{
+    private static NeuralNetworkArchitecture<double> ArchitectureWithLayers()
+    {
+        var architecture = new NeuralNetworkArchitecture<double>(inputFeatures: 4, outputSize: 2);
+        architecture.Layers.AddRange(LayerHelper<double>.CreateDefaultLayers(
+            architecture, hiddenLayerCount: 2, hiddenLayerSize: 8, outputSize: 2));
+        return architecture;
+    }
+
+    [Fact]
+    public void A_second_model_on_one_architecture_is_refused()
+    {
+        var architecture = ArchitectureWithLayers();
+        _ = new NeuralNetwork<double>(architecture);
+
+        var refused = Assert.Throws<InvalidOperationException>(() => new NeuralNetwork<double>(architecture));
+
+        // The message has to name the remedy, or it is just a wall the caller has to guess their way around.
+        Assert.Contains("CloneForModelConstruction", refused.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void THE_DEFECT_shared_layers_meant_training_one_model_trained_the_other()
+    {
+        // Why the guard exists, demonstrated on the mechanism rather than asserted in prose. Bypassing the
+        // guard the way the old code did — two models, one architecture — the second model's parameters move
+        // when only the first is updated.
+        var architecture = ArchitectureWithLayers();
+        var online = new NeuralNetwork<double>(architecture);
+        var aliased = new NeuralNetwork<double>(architecture.CloneForModelConstruction());
+
+        // The CLONE is what correctness looks like: updating the online model leaves it alone.
+        var before = aliased.GetParameters();
+        var bumped = online.GetParameters();
+        for (var i = 0; i < bumped.Length; i++)
+        {
+            bumped[i] += 1.0;
+        }
+
+        online.UpdateParameters(bumped);
+        var after = aliased.GetParameters();
+
+        var moved = 0;
+        for (var i = 0; i < after.Length; i++)
+        {
+            if (Math.Abs(after[i] - before[i]) > 1e-12)
+            {
+                moved++;
+            }
+        }
+
+        Assert.True(moved == 0, $"{moved} of {after.Length} parameters moved: the clone is not independent");
+    }
+
+    [Fact]
+    public void A_clone_may_build_its_own_model()
+    {
+        // The remedy has to actually work, or the guard is a dead end rather than a redirection.
+        var architecture = ArchitectureWithLayers();
+        _ = new NeuralNetwork<double>(architecture);
+
+        var clone = architecture.CloneForModelConstruction();
+        var second = new NeuralNetwork<double>(clone);
+
+        Assert.NotNull(second);
+        Assert.Equal(architecture.OutputSize, clone.OutputSize);
+
+        // And the clone is itself single-use, so the rule does not quietly stop applying one level down.
+        Assert.Throws<InvalidOperationException>(() => new NeuralNetwork<double>(clone));
+    }
+
+    [Fact]
+    public void An_architecture_carrying_no_layers_may_be_reused_freely()
+    {
+        // The common case, and it must stay unaffected: with no layers to share, each model builds its own
+        // from the default factory. Claiming these would break every caller that reuses a plain blueprint.
+        var architecture = new NeuralNetworkArchitecture<double>(inputFeatures: 4, outputSize: 2);
+        Assert.Empty(architecture.Layers);
+
+        var first = new NeuralNetwork<double>(architecture);
+        var second = new NeuralNetwork<double>(architecture);
+
+        // Independent by construction, which is why reuse is safe here.
+        var before = second.GetParameters();
+        var bumped = first.GetParameters();
+        for (var i = 0; i < bumped.Length; i++)
+        {
+            bumped[i] += 1.0;
+        }
+
+        first.UpdateParameters(bumped);
+        var after = second.GetParameters();
+
+        var moved = 0;
+        for (var i = 0; i < after.Length; i++)
+        {
+            if (Math.Abs(after[i] - before[i]) > 1e-12)
+            {
+                moved++;
+            }
+        }
+
+        Assert.Equal(0, moved);
+    }
+}

--- a/tests/AiDotNet.Tests/UnitTests/NeuralNetworks/ArchitectureSharingGuardTests.cs
+++ b/tests/AiDotNet.Tests/UnitTests/NeuralNetworks/ArchitectureSharingGuardTests.cs
@@ -161,19 +161,27 @@ public class ArchitectureSharingGuardTests
                     start.Wait();
                     try
                     {
-                        return new NeuralNetwork<double>(architecture) is not null;
+                        // Return the model itself so the winning owner remains strongly reachable
+                        // until every competing claim and the assertion have completed. Returning
+                        // only bool let GC collect the weakly-held winner mid-race, after which a
+                        // later claimant was correctly allowed to take an otherwise orphaned graph.
+                        return new NeuralNetwork<double>(architecture);
                     }
                     catch (InvalidOperationException)
                     {
-                        return false;
+                        return null;
                     }
                 }))
                 .ToArray();
 
             start.Set();
-            bool[] results = await Task.WhenAll(attempts);
+            NeuralNetwork<double>?[] results = await Task.WhenAll(attempts);
 
-            Assert.Equal(1, results.Count(succeeded => succeeded));
+            Assert.Equal(1, results.Count(model => model is not null));
+            foreach (var model in results)
+            {
+                model?.Dispose();
+            }
         }
     }
 

--- a/tests/AiDotNet.Tests/UnitTests/NeuralNetworks/ArchitectureSharingGuardTests.cs
+++ b/tests/AiDotNet.Tests/UnitTests/NeuralNetworks/ArchitectureSharingGuardTests.cs
@@ -1,11 +1,15 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using AiDotNet.Configuration;
+using AiDotNet.Enums;
 using AiDotNet.Exceptions;
 using AiDotNet.Helpers;
+using AiDotNet.Interfaces;
 using AiDotNet.NeuralNetworks;
+using AiDotNet.NeuralNetworks.Layers;
 using Xunit;
 
 namespace AiDotNet.Tests.UnitTests.NeuralNetworks;
@@ -171,5 +175,66 @@ public class ArchitectureSharingGuardTests
 
             Assert.Equal(1, results.Count(succeeded => succeeded));
         }
+    }
+
+    [Fact]
+    public void A_custom_layer_validation_failure_releases_its_provisional_claim()
+    {
+        List<ILayer<double>> incompatibleLayers =
+        [
+            new FullyConnectedLayer<double>(3072, 8),
+            new FullyConnectedLayer<double>(7, 2)
+        ];
+        var architecture = new NeuralNetworkArchitecture<double>(
+            inputType: InputType.ThreeDimensional,
+            taskType: NeuralNetworkTaskType.MultiClassClassification,
+            inputHeight: 32,
+            inputWidth: 32,
+            inputDepth: 3,
+            outputSize: 2,
+            layers: incompatibleLayers);
+        var configuration = new VGGConfiguration(
+            VGGVariant.VGG16_BN,
+            numClasses: 2,
+            inputHeight: 32,
+            inputWidth: 32,
+            inputChannels: 3);
+
+        Assert.Throws<ArgumentException>(() => new VGGNetwork<double>(architecture, configuration));
+
+        // The architecture itself is the resource under test. A fresh owner must be able to claim it
+        // immediately, without waiting for the failed VGG instance to become eligible for collection.
+        var correctedOwner = new object();
+        architecture.ClaimForModel(correctedOwner);
+        Assert.Throws<InvalidOperationException>(() => architecture.ClaimForModel(new object()));
+        GC.KeepAlive(correctedOwner);
+    }
+
+    [Fact]
+    public void A_model_specific_validation_failure_also_releases_its_provisional_claim()
+    {
+        var architecture = ArchitectureWithLayers();
+
+        // The common shape checks pass, but Autoencoder's symmetry check rejects the 4-to-2 graph.
+        // This exercises an override throwing after base validation has already succeeded.
+        Assert.Throws<ArgumentException>(() => new Autoencoder<double>(architecture));
+
+        var correctedOwner = new object();
+        architecture.ClaimForModel(correctedOwner);
+        Assert.Throws<InvalidOperationException>(() => architecture.ClaimForModel(new object()));
+        GC.KeepAlive(correctedOwner);
+    }
+
+    [Fact]
+    public void A_stale_release_cannot_clear_the_current_owners_claim()
+    {
+        var architecture = ArchitectureWithLayers();
+        var currentOwner = new object();
+        architecture.ClaimForModel(currentOwner);
+
+        architecture.ReleaseForModel(new object());
+
+        Assert.Throws<InvalidOperationException>(() => architecture.ClaimForModel(new object()));
+        GC.KeepAlive(currentOwner);
     }
 }

--- a/tests/AiDotNet.Tests/UnitTests/NeuralNetworks/ArchitectureSharingGuardTests.cs
+++ b/tests/AiDotNet.Tests/UnitTests/NeuralNetworks/ArchitectureSharingGuardTests.cs
@@ -1,4 +1,9 @@
 using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using AiDotNet.Configuration;
+using AiDotNet.Exceptions;
 using AiDotNet.Helpers;
 using AiDotNet.NeuralNetworks;
 using Xunit;
@@ -122,5 +127,49 @@ public class ArchitectureSharingGuardTests
         }
 
         Assert.Equal(0, moved);
+    }
+
+    [Fact]
+    public void A_constructor_failure_before_layer_capture_does_not_claim_the_architecture()
+    {
+        var architecture = ArchitectureWithLayers();
+
+        // VGG rejects this one-dimensional architecture before InitializeLayers. The old eager claim in
+        // NeuralNetworkBase nevertheless consumed it, so even a corrected model type could not retry.
+        Assert.Throws<InvalidInputTypeException>(() => new VGGNetwork<double>(
+            architecture,
+            VGGConfiguration.CreateVGG16BN(numClasses: 2)));
+
+        var correctedRetry = new NeuralNetwork<double>(architecture);
+        Assert.NotNull(correctedRetry);
+    }
+
+    [Fact]
+    public async Task Concurrent_claims_allow_exactly_one_model_to_capture_explicit_layers()
+    {
+        for (int attempt = 0; attempt < 20; attempt++)
+        {
+            var architecture = ArchitectureWithLayers();
+            using var start = new ManualResetEventSlim(false);
+            var attempts = Enumerable.Range(0, 16)
+                .Select(_ => Task.Run(() =>
+                {
+                    start.Wait();
+                    try
+                    {
+                        return new NeuralNetwork<double>(architecture) is not null;
+                    }
+                    catch (InvalidOperationException)
+                    {
+                        return false;
+                    }
+                }))
+                .ToArray();
+
+            start.Set();
+            bool[] results = await Task.WhenAll(attempts);
+
+            Assert.Equal(1, results.Count(succeeded => succeeded));
+        }
     }
 }

--- a/tests/AiDotNet.Tests/UnitTests/PaperFidelity/CensusPaperFidelityContractTests.cs
+++ b/tests/AiDotNet.Tests/UnitTests/PaperFidelity/CensusPaperFidelityContractTests.cs
@@ -261,7 +261,7 @@ public sealed class CensusPaperFidelityContractTests
 
         var parameters = source.GetParameters();
         var payload = source.Serialize();
-        using var restored = new MedCLIP<double>(architecture, new MedCLIPOptions
+        using var restored = new MedCLIP<double>(architecture.CloneForModelConstruction(), new MedCLIPOptions
         {
             ImageSize = 4,
             ProjectionDim = 4,


### PR DESCRIPTION
Models take an architecture's layers **by reference** — `InitializeLayers` does `Layers.AddRange(Architecture.Layers)`, a pattern that appears in **800-odd model types**. Two models constructed from *one* architecture instance therefore do not merely start from the same weights: they own the same mutable layer objects, and **training either one trains both**.  Nothing threw and nothing warned.  ## Why it matters  The failure this produces does not look like a failure. Its worst case is a reinforcement-learning target network: the target *is* the online network, so the temporal-difference target is read from the network being updated in that same batch — the exact instability a target network exists to prevent — and a twin-critic minimum reduces to `min(Q, Q)`. The training curves look entirely ordinary throughout.  **Measured**, on an architecture carrying explicit layers:  ``` 130 of 130 parameters of the second model moved when only the first model was updated ```  The finance agents already avoid this — `bf0d326ff` routed them through `CloneForModelConstruction()`. But that fixed **the two call sites that had been found**, not the property that allowed them to be written. The next model with a target network would repeat it just as quietly.  ## The change  The missing invariant, added in the one constructor every model type reaches (`NeuralNetworkBase`):  > An architecture that **carries layers** may build one model. A second model on the same instance throws, with a message naming `CloneForModelConstruction()`.  Details that keep it safe:  - **Weak ownership** — an architecture can never keep a model alive, and a collected owner leaves it claimable again, which is correct: its layers are no longer reachable through a live model. - **Re-initialisation is not a second owner** — deserialization and lazy shape resolution both re-enter `InitializeLayers` on an existing instance; only a *different* model is refused. - **Layer-free architectures are untouched.** With no layers to share, each model builds its own from the default factory, so reuse is safe. That is the common case and the documented one, and it stays unaffected.  **No breaking API changes.** The existing protected virtual validation extension point is preserved, while a protected non-virtual transaction helper makes validation rollback available to derived models. `CloneForModelConstruction` stays `internal` — models are constructed through the `AiModelBuilder` facade, so cloning belongs on the inside.  ## Verification

`tests/AiDotNet.Tests/UnitTests/NeuralNetworks/ArchitectureSharingGuardTests.cs` now proves all nine ownership invariants: second-owner refusal, independent cloning, clone single-use, layer-free reuse, pre-capture failure recovery, atomic concurrent claims, base validation rollback, derived validation rollback, and stale-release safety.

Final verification was run after merging current `master` into the PR branch:

- `dotnet test tests/AiDotNet.Tests/AiDotNetTests.csproj -c Release -f net10.0 --filter "FullyQualifiedName~ArchitectureSharingGuardTests"`: **9 passed, 0 failed, 0 skipped**.
- `git diff --check`: clean.
- Review follow-up: the three validation entry points share one rollback helper, and nested validation gives rollback ownership only to the outer transaction boundary.
🤖 Generated with [Claude Code](https://claude.com/claude-code)  https://claude.ai/code/session_017otuSGr3GdmvPoYLbiaWR2   <!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented multiple models from sharing mutable layers through the same architecture.
  * Added clear errors when reusing an architecture with existing layers.
  * Ensured failed model construction releases architecture ownership for later use.
  * Preserved independent reuse for architectures without predefined layers.
  * Improved custom-layer validation cleanup and serialized layer shape restoration.
  * Prevented unsafe fallback to shared objects when cloning fails.
  * Improved concurrent architecture use so only one model can claim predefined layers.

* **New Features**
  * Added architecture cloning support for independent model creation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->