### PR TITLE
fix(ci): honor timing noise at the history envelope boundary

### DIFF
--- a/tools/ModelPerfProbe/Program.cs
+++ b/tools/ModelPerfProbe/Program.cs
@@ -408,12 +408,13 @@ internal static class Program
                 if (timing && series.Count >= MinimumSeriesPoints)
                 {
                     double envelope = series.Max(point => point.Value);
-                    if (current <= envelope)
+                    if (current - envelope <= noiseFloor)
                     {
                         diagnostics.Add(Diagnostic.Warning(record.Fixture, metric,
                             $"moved {ratio:F2}x ({previous:F2} -> {current:F2}), but {current:F2} is "
-                            + $"inside the {series.Count}-run envelope this fixture has already "
-                            + $"occupied on this environment (max {envelope:F2}); the baseline drew a "
+                            + $"inside the {series.Count}-run envelope this fixture has already occupied "
+                            + $"on this environment plus the metric's {noiseFloor:F2} noise floor "
+                            + $"(max {envelope:F2}); the baseline drew a "
                             + "low point rather than this run regressing"));
                         continue;
                     }
@@ -675,6 +676,22 @@ internal static class Program
         if (!comparisonDiagnostics.Any(d => d.Metric == TimingMetric
                 && d.Message.Contains("envelope", StringComparison.Ordinal)))
             return Fail("suppressing on the envelope must still report why");
+
+        // A measured envelope is not an exact floating-point boundary. EchoStateNetwork's train
+        // step had already occupied 83.0062 ms on the same runner model; a later 83.1867 ms sample
+        // failed because it exceeded that maximum by 0.1805 ms despite timing's 25 ms noise floor.
+        // The tolerance must apply at the envelope edge just as it does at the baseline edge.
+        comparisonDiagnostics.Clear();
+        CompareBaseline(
+            [TimingRun(477.4)],
+            TimingPoint("eeeeeee", 5, 48.0, 100_000_000),
+            new Options(),
+            comparisonDiagnostics,
+            dispersed);
+        if (comparisonDiagnostics.Any(d => d.Severity == "error" && d.Metric == TimingMetric)
+            || !comparisonDiagnostics.Any(d => d.Metric == TimingMetric
+                && d.Message.Contains("noise floor", StringComparison.Ordinal)))
+            return Fail("a timing value within the noise floor of its measured envelope must not be an error");
 
         // StreamDiffVSR's real numbers: 2765.9 is 2.5x above everything the fixture has ever done.
         BaselineDocument[] tight =


### PR DESCRIPTION
## Root cause

The model-performance gate already treats a timing result inside a fixture's measured history envelope as runner variance. However, it treated the envelope's floating-point maximum as an exact boundary instead of applying the timing metric's existing absolute noise floor.

PR #2097 exposed the defect on `EchoStateNetworkTests`: the same AMD EPYC 7763 history already contained an 83.0062 ms train step, while the new run measured 83.1867 ms. A 0.1805 ms edge difference turned a previously occupied high mode into a hard failure even though timing's measured noise floor is 25 ms.

## Fix

Apply the metric's existing absolute noise floor at the historical-envelope boundary, matching the gate's baseline-boundary semantics. The diagnostic remains a warning, so high-mode movement stays visible.

The allowance remains timing-only. Allocation and memory still use exact latest baselines, and timing beyond `envelope + noiseFloor` remains a hard failure.

## Proof

- `dotnet run --project tools/ModelPerfProbe/ModelPerfProbe.csproj -c Release -- --self-test`: passed.
- Replayed the exact failed #2097 artifact and its 12-run history through the fixed probe:
  - before: 862/862 fixtures, 1 error, 22 warnings;
  - after: 862/862 fixtures, 0 errors, 23 warnings;
  - ESN is reported as within the seven-run envelope plus the 25 ms timing noise floor.
- Existing adversarial self-test still requires a timing result materially above every historical value to fail.

This PR changes only `tools/ModelPerfProbe/Program.cs`.