### PR TITLE
fix(ci): certify healthy selective shard maps

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -2295,7 +2295,12 @@ jobs:
   sonarcloud:
     name: SonarCloud Analysis
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    # Sonar compiler instrumentation makes this repository-wide build materially slower than the
+    # ordinary artifact build. Runs 34168592804 and 34183645757 both reached the old 45-minute
+    # ceiling while Build (Release) was still active, then spent GitHub's shutdown grace period
+    # before being reported as cancelled at 55 minutes. Keep the memory-safe -m:2 build below and
+    # give successful analysis enough headroom; this is a maximum, not a fixed runner duration.
+    timeout-minutes: 90
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -678,7 +678,7 @@ jobs:
           # Normal PRs may consume only an audited/certified map. The forced full-coverage run is
           # different: it consumes the exact candidate named by its dispatch input so that the next
           # map invocation can audit that candidate against the complete outcome set.
-          rm -rf map map-probe
+          rm -rf map map-resolution.json
           run_id=''
           kind=''
           if [ "$FORCE_COVERAGE" = 'true' ]; then
@@ -701,29 +701,20 @@ jobs:
                 ;;
             esac
           else
-            # The newest completed map workflow is a revocation barrier. Never scan backward for
-            # an older certificate: a newer audit may have observed a selection miss, failed its
-            # integrity checks, or intentionally withheld certification. Reusing an older artifact
-            # in any of those states would silently reactivate a map invalidated by newer evidence.
-            if ! latest=$(gh run list --repo "$GITHUB_REPOSITORY" --workflow test-impact-map.yml \
-                 --branch master --status completed --limit 1 --json databaseId,conclusion 2>/dev/null); then
-              latest='[]'
-              echo '::warning::could not query the latest completed map workflow; selection will fail closed'
-            fi
-            candidate=$(printf '%s' "$latest" | jq -r '.[0].databaseId // empty')
-            latest_conclusion=$(printf '%s' "$latest" | jq -r '.[0].conclusion // empty')
-            if [ -n "$candidate" ] && [ "$latest_conclusion" = 'success' ]; then
-              if gh run download "$candidate" --repo "$GITHUB_REPOSITORY" \
-                   --name certified-shard-map --dir map-probe >/dev/null 2>&1; then
-                mv map-probe map
+            # The executable resolver makes the newest completed map workflow a revocation barrier.
+            # Its adversarial fixtures record every download attempt and prove that a newer failed
+            # or certificate-withholding run can never fall back to an older certificate.
+            if pwsh -NoProfile -File ./tools/TestImpact/Resolve-CertifiedShardMap.ps1 \
+                 -Repository "$GITHUB_REPOSITORY" -OutDirectory map \
+                 -ResultFile map-resolution.json; then
+              candidate=$(jq -r 'if .found then (.runId | tostring) else empty end' map-resolution.json)
+              if [ -n "$candidate" ]; then
                 run_id="$candidate"
                 kind='certified'
-              else
-                echo "::warning::latest completed map run $candidate has no usable certificate; refusing to fall back to an older map"
-                rm -rf map-probe
               fi
-            elif [ -n "$candidate" ]; then
-              echo "::warning::latest completed map run $candidate concluded '$latest_conclusion'; refusing to fall back to an older map"
+            else
+              echo '::warning::certified map resolver failed; selection will fail closed'
+              rm -rf map
             fi
           fi
 
@@ -760,6 +751,8 @@ jobs:
           if ($LASTEXITCODE -ne 0) { throw 'Measure-SelectionMiss self-test failed' }
           ./tools/TestImpact/Test-CertifiedShardMap.ps1 -SelfTest
           if ($LASTEXITCODE -ne 0) { throw 'Test-CertifiedShardMap self-test failed' }
+          ./tools/TestImpact/Resolve-CertifiedShardMap.ps1 -SelfTest
+          if ($LASTEXITCODE -ne 0) { throw 'Resolve-CertifiedShardMap self-test failed' }
           ./tools/TestImpact/Test-CiImpactWorkflow.ps1
           if ($LASTEXITCODE -ne 0) { throw 'CI impact workflow contract failed' }
           ./tools/TestImpact/Test-TestImpactEndToEnd.ps1

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -389,6 +389,9 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     needs: validation-source
+    outputs:
+      artifact_id: ${{ steps.upload-build-artifact.outputs.artifact-id }}
+      artifact_digest: ${{ steps.upload-build-artifact.outputs.artifact-digest }}
     timeout-minutes: 45
     permissions:
       contents: read
@@ -486,6 +489,7 @@ jobs:
           dotnet build tests/AiDotNet.Serving.Tests/AiDotNet.Serving.Tests.csproj -c Release --no-restore -m:4
 
       - name: Upload build artifacts
+        id: upload-build-artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
         # net471 is COMPILED in the step above and deliberately not shipped here. Compiling it
         # is the check -- it catches net471-only breakage a net10.0 build cannot see -- but no
@@ -753,6 +757,8 @@ jobs:
           if ($LASTEXITCODE -ne 0) { throw 'Test-CertifiedShardMap self-test failed' }
           ./tools/TestImpact/Resolve-CertifiedShardMap.ps1 -SelfTest
           if ($LASTEXITCODE -ne 0) { throw 'Resolve-CertifiedShardMap self-test failed' }
+          ./tools/TestImpact/Receive-RequiredArtifact.ps1 -SelfTest
+          if ($LASTEXITCODE -ne 0) { throw 'Receive-RequiredArtifact self-test failed' }
           ./tools/TestImpact/Test-CiImpactWorkflow.ps1
           if ($LASTEXITCODE -ne 0) { throw 'CI impact workflow contract failed' }
           ./tools/TestImpact/Test-TestImpactEndToEnd.ps1
@@ -1011,9 +1017,10 @@ jobs:
     needs: [build, validation-source, select-shards]
     # Forced coverage materially extends both test execution and post-test digest work. The live
     # all-shard experiment proved 50 minutes is too short: Generated Layers U passed every test at
-    # 47.9 minutes, then GitHub canceled the job before its digest step. Ordinary validation keeps
-    # each shard's existing ceiling; the isolated nightly run gets enough room to finish cleanly.
-    timeout-minutes: ${{ inputs.collect_coverage_everywhere && 90 || matrix.shard.timeout || 50 }}
+    # 47.9 minutes, then GitHub canceled the job before its digest step. Ordinary validation gets a
+    # 60-minute fallback so a bounded artifact retry cannot consume the test's execution budget;
+    # the isolated nightly run gets enough room to finish cleanly.
+    timeout-minutes: ${{ inputs.collect_coverage_everywhere && 90 || matrix.shard.timeout || 60 }}
     permissions:
       actions: read
       contents: read
@@ -1075,25 +1082,23 @@ jobs:
           restore-keys: |
             nuget-${{ runner.os }}-
 
-      - name: Download build artifacts
+      - name: Download required build artifact
         id: download-build-artifacts
-        continue-on-error: true
-        # CAPPED. build-output is ~1.5 GB and this step has hung on it: the
-        # Components/Adversarial/EndToEnd shard sat here for the full 45-minute job budget and was
-        # cancelled without running a single test, which reads downstream as an unmeasured shard
-        # rather than as a transfer that stalled. A cap converts that into a fast, clearly
-        # attributed first-attempt failure; the next step performs one bounded automatic retry.
-        timeout-minutes: 12
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v4
-        with:
-          name: build-output-${{ github.sha }}
-
-      - name: Retry build artifact download
-        if: steps.download-build-artifacts.outcome == 'failure'
-        timeout-minutes: 12
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v4
-        with:
-          name: build-output-${{ github.sha }}
+        timeout-minutes: 25
+        shell: pwsh
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        # Resolve by the immutable upload output, not by listing every artifact in a 100+ shard run.
+        # The receiver validates the archive digest and retries only transient transport responses
+        # with GitHub-compliant exponential backoff. Exhaustion remains a hard, untested-shard failure.
+        run: |
+          ./tools/TestImpact/Receive-RequiredArtifact.ps1 `
+            -Repository '${{ github.repository }}' `
+            -ArtifactId '${{ needs.build.outputs.artifact_id }}' `
+            -ExpectedDigest '${{ needs.build.outputs.artifact_digest }}' `
+            -Destination '.' `
+            -RunId '${{ github.run_id }}' `
+            -JobIndex '${{ strategy.job-index }}'
 
       - name: Restore dependencies
         run: dotnet restore ${{ matrix.shard.project }}
@@ -1651,7 +1656,7 @@ jobs:
 
       - name: Upload test-impact digest
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
-        if: always()
+        if: always() && steps.download-build-artifacts.outcome == 'success'
         continue-on-error: true
         with:
           name: impact-digest-${{ env.ARTIFACT_NAME }}
@@ -1661,7 +1666,7 @@ jobs:
 
       - name: Upload coverage + test results
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
-        if: always()
+        if: always() && steps.download-build-artifacts.outcome == 'success'
         continue-on-error: true  # Prevent transient GitHub artifact service issues from failing the job
         with:
           name: ${{ env.ARTIFACT_NAME }}
@@ -1681,7 +1686,7 @@ jobs:
       # the crash spelling, so the glob must cover both.
       - name: Upload crash evidence
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
-        if: always()
+        if: always() && steps.download-build-artifacts.outcome == 'success'
         continue-on-error: true
         with:
           name: crash-evidence-${{ github.sha }}-${{ strategy.job-index }}
@@ -1696,7 +1701,7 @@ jobs:
       # retains hang-sequence evidence that the coverage artifact intentionally omits.
       - name: Upload compact test diagnostics
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
-        if: always()
+        if: always() && steps.download-build-artifacts.outcome == 'success'
         continue-on-error: true
         with:
           name: ${{ env.TEST_RESULTS_ARTIFACT_NAME }}
@@ -1902,6 +1907,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build, validation-source]
     permissions:
+      actions: read
       contents: read
     # WHY THIS REMAINS SHARDED. The conformance sweep checks every model's declared shape contract
     # against a real Predict. Explicitly unavailable laws are now classified without construction,
@@ -1949,25 +1955,20 @@ jobs:
           restore-keys: |
             nuget-${{ runner.os }}-
 
-      - name: Download build artifacts
+      - name: Download required build artifact
         id: download-build-artifacts
-        continue-on-error: true
-        # CAPPED. build-output is ~1.5 GB and this step has hung on it: the
-        # Components/Adversarial/EndToEnd shard sat here for the full 45-minute job budget and was
-        # cancelled without running a single test, which reads downstream as an unmeasured shard
-        # rather than as a transfer that stalled. A cap converts that into a fast, clearly
-        # attributed first-attempt failure; the next step performs one bounded automatic retry.
-        timeout-minutes: 12
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v4
-        with:
-          name: build-output-${{ github.sha }}
-
-      - name: Retry build artifact download
-        if: steps.download-build-artifacts.outcome == 'failure'
-        timeout-minutes: 12
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v4
-        with:
-          name: build-output-${{ github.sha }}
+        timeout-minutes: 25
+        shell: pwsh
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          ./tools/TestImpact/Receive-RequiredArtifact.ps1 `
+            -Repository '${{ github.repository }}' `
+            -ArtifactId '${{ needs.build.outputs.artifact_id }}' `
+            -ExpectedDigest '${{ needs.build.outputs.artifact_digest }}' `
+            -Destination '.' `
+            -RunId '${{ github.run_id }}' `
+            -JobIndex '${{ strategy.job-index }}'
 
       - name: Restore test assets
         run: dotnet restore tests/AiDotNet.Tests/AiDotNetTests.csproj
@@ -2038,7 +2039,7 @@ jobs:
           exit "${dotnet_status}"
 
       - name: Upload window report
-        if: always()
+        if: always() && steps.download-build-artifacts.outcome == 'success'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
         with:
           name: model-shape-conformance-${{ matrix.offset }}-${{ github.sha }}

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -391,7 +391,8 @@ jobs:
     needs: validation-source
     outputs:
       artifact_id: ${{ steps.upload-build-artifact.outputs.artifact-id }}
-      artifact_digest: ${{ steps.upload-build-artifact.outputs.artifact-digest }}
+      # upload-artifact emits bare hexadecimal; normalize once at the producer boundary.
+      artifact_digest: ${{ format('sha256:{0}', steps.upload-build-artifact.outputs.artifact-digest) }}
     timeout-minutes: 45
     permissions:
       contents: read

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -701,19 +701,30 @@ jobs:
                 ;;
             esac
           else
-            candidates=$(gh run list --repo "$GITHUB_REPOSITORY" --workflow test-impact-map.yml \
-              --branch master --status success --limit 20 --json databaseId \
-              --jq '.[].databaseId' 2>/dev/null || true)
-            for candidate in $candidates; do
-              rm -rf map-probe
+            # The newest completed map workflow is a revocation barrier. Never scan backward for
+            # an older certificate: a newer audit may have observed a selection miss, failed its
+            # integrity checks, or intentionally withheld certification. Reusing an older artifact
+            # in any of those states would silently reactivate a map invalidated by newer evidence.
+            if ! latest=$(gh run list --repo "$GITHUB_REPOSITORY" --workflow test-impact-map.yml \
+                 --branch master --status completed --limit 1 --json databaseId,conclusion 2>/dev/null); then
+              latest='[]'
+              echo '::warning::could not query the latest completed map workflow; selection will fail closed'
+            fi
+            candidate=$(printf '%s' "$latest" | jq -r '.[0].databaseId // empty')
+            latest_conclusion=$(printf '%s' "$latest" | jq -r '.[0].conclusion // empty')
+            if [ -n "$candidate" ] && [ "$latest_conclusion" = 'success' ]; then
               if gh run download "$candidate" --repo "$GITHUB_REPOSITORY" \
                    --name certified-shard-map --dir map-probe >/dev/null 2>&1; then
                 mv map-probe map
                 run_id="$candidate"
                 kind='certified'
-                break
+              else
+                echo "::warning::latest completed map run $candidate has no usable certificate; refusing to fall back to an older map"
+                rm -rf map-probe
               fi
-            done
+            elif [ -n "$candidate" ]; then
+              echo "::warning::latest completed map run $candidate concluded '$latest_conclusion'; refusing to fall back to an older map"
+            fi
           fi
 
           if [ -z "$run_id" ]; then

--- a/.github/workflows/test-impact-map.yml
+++ b/.github/workflows/test-impact-map.yml
@@ -48,6 +48,10 @@ jobs:
         run: |
           ./tools/TestImpact/Test-CertifiedShardMap.ps1 -SelfTest
           if ($LASTEXITCODE -ne 0) { throw 'Test-CertifiedShardMap self-test failed' }
+          ./tools/TestImpact/Measure-SelectionMiss.ps1 -SelfTest
+          if ($LASTEXITCODE -ne 0) { throw 'Measure-SelectionMiss self-test failed' }
+          ./tools/TestImpact/New-ShardMapCertificate.ps1 -SelfTest
+          if ($LASTEXITCODE -ne 0) { throw 'New-ShardMapCertificate self-test failed' }
           ./tools/TestImpact/Test-CiImpactWorkflow.ps1
           if ($LASTEXITCODE -ne 0) { throw 'CI impact workflow contract failed' }
           ./tools/TestImpact/Test-TestImpactEndToEnd.ps1
@@ -350,6 +354,7 @@ jobs:
           New-Item -ItemType Directory -Path $auditTools -Force | Out-Null
           Copy-Item tools/TestImpact/Select-Shards.ps1 (Join-Path $auditTools 'Select-Shards.ps1')
           Copy-Item tools/TestImpact/Measure-SelectionMiss.ps1 (Join-Path $auditTools 'Measure-SelectionMiss.ps1')
+          Copy-Item tools/TestImpact/New-ShardMapCertificate.ps1 (Join-Path $auditTools 'New-ShardMapCertificate.ps1')
 
           # HEAD must be the audited tree; the selector diffs from the prior map commit to HEAD.
           & git checkout --quiet '${{ steps.source.outputs.sha }}'
@@ -362,38 +367,23 @@ jobs:
           $a = Get-Content audit.json -Raw | ConvertFrom-Json
           $verdict = if ($a.Escalated) { 'would have escalated - nothing skipped' }
                      elseif ($a.MissCount -gt 0) { "**$($a.MissCount) MISSED**: $($a.Missed -join ', ')" }
-                     elseif ($a.Failed -eq 0) { 'no failure opportunity; miss safety was not exercised' }
+                     elseif ($a.Failed -eq 0) { 'complete clean matrix; zero observed misses' }
                      else { 'no misses' }
           "### Selection audit`n`n- map in effect: ${{ steps.source.outputs.map_run_id }}`n- would run $($a.WouldRun)/$($a.TotalShards), skip $($a.WouldSkip)`n- $($a.Failed) shard(s) failed`n- $verdict" |
             Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8
 
-          # Escalation is safe, but it proves only the fallback. Certification authorizes actual
-          # reduction, so require both a non-escalated plan that would skip work and at least one
-          # failing shard that gave the audit a real opportunity to observe a selection miss.
-          if ($auditExit -eq 0 -and -not [bool] $a.Escalated -and
-              [int] $a.WouldSkip -gt 0 -and [int] $a.Failed -gt 0) {
-            $previousMap = Get-Content prevmap/shard-map.json -Raw | ConvertFrom-Json
-            New-Item -ItemType Directory -Path certified-map -Force | Out-Null
-            Copy-Item -LiteralPath prevmap/shard-map.json -Destination certified-map/shard-map.json
-            [ordered]@{
-              schemaVersion = 1
-              candidateMapRunId = [long] '${{ steps.source.outputs.map_run_id }}'
-              candidateMapSha = [string] $previousMap.sha
-              auditSourceRunId = [long] '${{ steps.source.outputs.run_id }}'
-              auditSourceSha = '${{ steps.source.outputs.sha }}'
-              certificationRunId = [long] $env:GITHUB_RUN_ID
-              escalated = [bool] $a.Escalated
-              wouldRun = [int] $a.WouldRun
-              wouldSkip = [int] $a.WouldSkip
-              failedShards = [int] $a.Failed
-              missCount = [int] $a.MissCount
-            } | ConvertTo-Json -Depth 4 | Set-Content certified-map/certification.json -Encoding utf8
-            "certified=true" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
-          }
-          else {
-            "certified=false" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
-            Write-Host 'candidate did not exercise both failure detection and reduction - not certifying it'
-          }
+          # The shipping policy is executable outside YAML. It validates the exact map universe,
+          # source outcomes and audit counts before producing either file in the certified pair.
+          & (Join-Path $auditTools 'New-ShardMapCertificate.ps1') `
+              -MapFile prevmap/shard-map.json -AuditFile audit.json -OutcomesFile outcomes.json `
+              -CandidateMapRunId ([long] '${{ steps.source.outputs.map_run_id }}') `
+              -AuditSourceRunId ([long] '${{ steps.source.outputs.run_id }}') `
+              -AuditSourceSha '${{ steps.source.outputs.sha }}' `
+              -CertificationRunId ([long] $env:GITHUB_RUN_ID) -OutDirectory certified-map
+          if ($LASTEXITCODE -ne 0) { throw "certificate policy exited $LASTEXITCODE" }
+          $certified = Test-Path -LiteralPath certified-map/certification.json
+          "certified=$($certified.ToString().ToLowerInvariant())" |
+            Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
           exit $auditExit
 
       - name: Upload certified map

--- a/.github/workflows/test-impact-map.yml
+++ b/.github/workflows/test-impact-map.yml
@@ -379,13 +379,6 @@ jobs:
           $auditExit = $LASTEXITCODE
 
           $a = Get-Content audit.json -Raw | ConvertFrom-Json
-          $verdict = if ($a.Escalated) { 'would have escalated - nothing skipped' }
-                     elseif ($a.MissCount -gt 0) { "**$($a.MissCount) MISSED**: $($a.Missed -join ', ')" }
-                     elseif ($a.Failed -eq 0) { 'complete clean matrix; zero observed misses' }
-                     else { 'no misses' }
-          "### Selection audit`n`n- map in effect: ${{ steps.source.outputs.map_run_id }}`n- would run $($a.WouldRun)/$($a.TotalShards), skip $($a.WouldSkip)`n- $($a.Failed) shard(s) failed`n- $verdict" |
-            Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8
-
           # The shipping policy is executable outside YAML. It validates the exact map universe,
           # source outcomes and audit counts before producing either file in the certified pair.
           & (Join-Path $auditTools 'New-ShardMapCertificate.ps1') `
@@ -398,6 +391,13 @@ jobs:
           $certified = Test-Path -LiteralPath certified-map/certification.json
           "certified=$($certified.ToString().ToLowerInvariant())" |
             Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+
+          $verdict = if ($a.Escalated) { 'would have escalated - nothing skipped' }
+                     elseif ($a.MissCount -gt 0) { "**$($a.MissCount) MISSED**: $($a.Missed -join ', ')" }
+                     elseif ($a.Failed -eq 0) { 'complete clean matrix; zero observed misses' }
+                     else { 'no misses' }
+          "### Selection audit`n`n- map in effect: ${{ steps.source.outputs.map_run_id }}`n- would run $($a.WouldRun)/$($a.TotalShards), skip $($a.WouldSkip)`n- $($a.Failed) shard(s) failed`n- $verdict" |
+            Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8
 
           # Not certifying is the whole ballgame: the PR selector accepts only certified-shard-map,
           # so with no certificate every pull request runs the complete matrix. This step still exits

--- a/.github/workflows/test-impact-map.yml
+++ b/.github/workflows/test-impact-map.yml
@@ -246,15 +246,29 @@ jobs:
             if ([string] $j.conclusion -ne 'success') { [void] $failedShards.Add($name.Substring($i + 4)) }
           }
           $pruned = 0
+          $prunedShards = @()
           foreach ($f in $carried) {
             $shard = [string] (Get-Content $f.FullName -Raw | ConvertFrom-Json).shard
             if ($failedShards.Contains($shard)) {
               Write-Host "pruning carried digest for failed shard '$shard' - it becomes always-run"
               Remove-Item -LiteralPath $f.FullName -Force
               $pruned++
+              $prunedShards += $shard
             }
           }
           Write-Host "carried digests: $($carried.Count), pruned: $pruned"
+
+          # A pruned shard does not merely become always-run: every file that ONLY it covered drops
+          # out of the map, so any PR touching those files escalates to the complete matrix, and the
+          # nightly audit escalates too and therefore never certifies. One failed shard is enough to
+          # disable selective CI repo-wide, and it previously did so for days while this step still
+          # reported success. Say it loudly rather than in a Write-Host nobody reads.
+          if ($pruned -gt 0) {
+            $list = ($prunedShards | Sort-Object) -join ', '
+            Write-Host "::warning::shard map degraded - pruned $pruned failed shard(s): $list. Files covered only by these shards are now unmapped, so PRs touching them escalate to the complete matrix."
+            "### Shard map degraded`n`n$pruned shard(s) failed in source run ${{ steps.source.outputs.run_id }} and were pruned from the map: **$list**.`n`nEach becomes always-run, and any file covered only by them is now unmapped, so PRs touching those files escalate to the complete matrix. Fix the failing shard(s) to restore selective CI." |
+              Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8
+          }
 
       - name: Build the map
         if: steps.source.outputs.found == 'true'
@@ -384,6 +398,16 @@ jobs:
           $certified = Test-Path -LiteralPath certified-map/certification.json
           "certified=$($certified.ToString().ToLowerInvariant())" |
             Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+
+          # Not certifying is the whole ballgame: the PR selector accepts only certified-shard-map,
+          # so with no certificate every pull request runs the complete matrix. This step still exits
+          # successfully and the upload below is merely 'skipped', which is precisely how a repo-wide
+          # CI regression stayed invisible across several attempted fixes. Announce it.
+          if (-not $certified) {
+            Write-Host "::warning::no certified shard map produced - $verdict. Until a candidate certifies, every pull request runs the complete shard matrix."
+            "### No certified shard map`n`nCertification was skipped: $verdict.`n`nThe pull-request selector accepts only a certified-shard-map artifact, so until a candidate certifies **every pull request runs the complete shard matrix**." |
+              Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8
+          }
           exit $auditExit
 
       - name: Upload certified map

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -353,12 +353,13 @@
          deterministic CPU execution, and compiled-lifetime fixes from AiDotNet.Tensors #1005 and
          #1006. Bumped 0.130.0 to 0.130.2 for dynamic compiled-mask rebinding (#1007) and typed
          empty-graph capture limitations (#1009), which let the builder distinguish deterministic
-         unsupported graphs from retryable failures. Keep the managed and native packages on the
-         same release. -->
-    <PackageVersion Include="AiDotNet.Native.OneDNN" Version="0.130.2" />
-    <PackageVersion Include="AiDotNet.Native.OpenBLAS" Version="0.130.2" />
-    <PackageVersion Include="AiDotNet.Tensors" Version="0.130.2" />
-    <PackageVersion Include="AiDotNet.Native.CLBlast" Version="0.130.2" />
+         unsupported graphs from retryable failures. Bumped 0.130.2 to 0.130.3 for the copy-on-write
+         read-contract and shared engine-surface fixes in #1012. Keep the managed and native packages
+         on the same release. -->
+    <PackageVersion Include="AiDotNet.Native.OneDNN" Version="0.130.3" />
+    <PackageVersion Include="AiDotNet.Native.OpenBLAS" Version="0.130.3" />
+    <PackageVersion Include="AiDotNet.Tensors" Version="0.130.3" />
+    <PackageVersion Include="AiDotNet.Native.CLBlast" Version="0.130.3" />
     <!-- Microsoft / .NET -->
     <PackageVersion Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageVersion Include="Microsoft.Data.Sqlite" Version="10.0.11" />

--- a/tools/TestImpact/Measure-SelectionMiss.ps1
+++ b/tools/TestImpact/Measure-SelectionMiss.ps1
@@ -88,14 +88,19 @@ function Get-SelectionMiss {
     foreach ($s in $wouldSkip) { [void] $skip.Add([string] $s) }
     $missed = @($Failed | Where-Object { $skip.Contains([string] $_) } | Sort-Object -Unique)
 
+    $wouldRunShards = @($WouldRun)
+    if ($Escalated) { $wouldRunShards = @($AllShards) }
+
     return [pscustomobject]@{
-        Escalated  = $Escalated
-        TotalShards = $AllShards.Count
-        WouldRun   = $(if ($Escalated) { $AllShards.Count } else { @($WouldRun).Count })
-        WouldSkip  = $wouldSkip.Count
-        Failed     = @($Failed).Count
-        Missed     = $missed
-        MissCount  = $missed.Count
+        Escalated      = $Escalated
+        TotalShards    = $AllShards.Count
+        WouldRun       = $wouldRunShards.Count
+        WouldSkip      = $wouldSkip.Count
+        WouldRunShards = $wouldRunShards
+        WouldSkipShards = $wouldSkip
+        Failed         = @($Failed).Count
+        Missed         = $missed
+        MissCount      = $missed.Count
     }
 }
 
@@ -112,6 +117,8 @@ if ($SelfTest) {
     $r = Get-SelectionMiss -AllShards $all -WouldRun @('A', 'B') -Failed @('C') -Escalated $false
     Assert-True ($r.MissCount -eq 1) 'a failure in a skipped shard must be reported as a miss'
     Assert-True ($r.Missed -contains 'C') 'the missed shard must be named'
+    Assert-True (($r.WouldRunShards -join ',') -eq 'A,B') 'selected shard identities were not preserved'
+    Assert-True (($r.WouldSkipShards -join ',') -eq 'C,D') 'skipped shard identities were not preserved'
 
     # 2. A failure in a shard selection would have RUN is not a miss. Without this the audit could
     #    report every failure as a miss and still pass check 1, which would make it useless.
@@ -127,6 +134,7 @@ if ($SelfTest) {
     Assert-True ($r.MissCount -eq 0) 'an escalated run cannot miss'
     Assert-True ($r.WouldSkip -eq 0) 'an escalated run skips nothing'
     Assert-True ($r.WouldRun -eq 4) 'an escalated run runs everything'
+    Assert-True (($r.WouldRunShards -join ',') -eq 'A,B,C,D') 'an escalated run did not record the full selected universe'
 
     # 5. A green run misses nothing regardless of how much it skipped.
     $r = Get-SelectionMiss -AllShards $all -WouldRun @('A') -Failed @() -Escalated $false
@@ -189,7 +197,7 @@ if ($result.MissCount -gt 0) {
     Write-Host "::error::selection would have SKIPPED $($result.MissCount) shard(s) that failed:"
     foreach ($m in $result.Missed) { Write-Host "  MISSED: $m" }
 } elseif ($result.Failed -eq 0) {
-    Write-Host 'audit: no failure opportunity in this full run; selection volume was measured but miss safety was not exercised'
+    Write-Host 'audit: complete clean matrix; zero observed selection misses'
 } else {
     Write-Host 'audit: no misses'
 }

--- a/tools/TestImpact/New-ShardMapCertificate.ps1
+++ b/tools/TestImpact/New-ShardMapCertificate.ps1
@@ -1,0 +1,274 @@
+<#
+.SYNOPSIS
+    Produces a run-bound certificate for a complete, zero-miss shard-map audit.
+
+.DESCRIPTION
+    Keeps the certification decision out of workflow YAML so the shipping policy can be exercised
+    directly. A complete clean matrix is eligible: correctness of the miss detector is covered by
+    adversarial tests, while the real audit establishes the exact shard universe and whether the
+    selector would reduce it. Requiring CI to fail before a map can be certified deadlocks a healthy
+    repository in full-matrix mode.
+#>
+[CmdletBinding(DefaultParameterSetName = 'Build')]
+param(
+    [Parameter(Mandatory, ParameterSetName = 'Build')] [string] $MapFile,
+    [Parameter(Mandatory, ParameterSetName = 'Build')] [string] $AuditFile,
+    [Parameter(Mandatory, ParameterSetName = 'Build')] [string] $OutcomesFile,
+    [Parameter(Mandatory, ParameterSetName = 'Build')] [long] $CandidateMapRunId,
+    [Parameter(Mandatory, ParameterSetName = 'Build')] [long] $AuditSourceRunId,
+    [Parameter(Mandatory, ParameterSetName = 'Build')] [string] $AuditSourceSha,
+    [Parameter(Mandatory, ParameterSetName = 'Build')] [long] $CertificationRunId,
+    [Parameter(Mandatory, ParameterSetName = 'Build')] [string] $OutDirectory,
+    [Parameter(Mandatory, ParameterSetName = 'SelfTest')] [switch] $SelfTest
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+function ConvertTo-RequiredInteger {
+    param($Value, [string] $Name, [long] $Minimum = 0)
+
+    $isInteger = $Value -is [byte] -or $Value -is [sbyte] -or
+        $Value -is [int16] -or $Value -is [uint16] -or
+        $Value -is [int32] -or $Value -is [uint32] -or
+        $Value -is [int64] -or $Value -is [uint64]
+    if (-not $isInteger) { throw "$Name must be an integer" }
+    $number = [long] $Value
+    if ($number -lt $Minimum) { throw "$Name must be at least $Minimum" }
+    return $number
+}
+
+function Get-CertificationDecision {
+    param(
+        [Parameter(Mandatory)] $Map,
+        [Parameter(Mandatory)] $Audit,
+        [Parameter(Mandatory)] [AllowEmptyCollection()] [object[]] $Outcomes,
+        [Parameter(Mandatory)] [long] $MapRunId,
+        [Parameter(Mandatory)] [long] $SourceRunId,
+        [Parameter(Mandatory)] [string] $SourceSha,
+        [Parameter(Mandatory)] [long] $CertificateRunId
+    )
+
+    foreach ($name in 'schemaVersion', 'sha', 'knownShards', 'alwaysRun') {
+        if (-not $Map.PSObject.Properties[$name]) { throw "map is missing $name" }
+    }
+    foreach ($name in 'Escalated', 'TotalShards', 'WouldRun', 'WouldSkip',
+        'WouldRunShards', 'WouldSkipShards', 'Failed', 'Missed', 'MissCount') {
+        if (-not $Audit.PSObject.Properties[$name]) { throw "audit is missing $name" }
+    }
+    if ((ConvertTo-RequiredInteger $Map.schemaVersion 'map schemaVersion' 1) -ne 1) {
+        throw "unsupported map schemaVersion $($Map.schemaVersion)"
+    }
+    $mapSha = [string] $Map.sha
+    if ($mapSha -cnotmatch '^[0-9a-f]{40}$') { throw 'map sha must be a lowercase 40-character Git SHA' }
+    if ($SourceSha -cnotmatch '^[0-9a-f]{40}$') { throw 'audit source sha must be a lowercase 40-character Git SHA' }
+    [void] (ConvertTo-RequiredInteger $MapRunId 'candidate map run id' 1)
+    [void] (ConvertTo-RequiredInteger $SourceRunId 'audit source run id' 1)
+    [void] (ConvertTo-RequiredInteger $CertificateRunId 'certification run id' 1)
+    if ($Map.knownShards -isnot [array] -or $Map.alwaysRun -isnot [array]) {
+        throw 'map knownShards and alwaysRun must be arrays'
+    }
+    if ($Audit.Escalated -isnot [bool]) { throw 'audit Escalated must be a JSON boolean' }
+    if ($Audit.WouldRunShards -isnot [array] -or $Audit.WouldSkipShards -isnot [array] -or
+        $Audit.Missed -isnot [array]) {
+        throw 'audit shard partitions and Missed must be JSON arrays'
+    }
+
+    $universe = [System.Collections.Generic.HashSet[string]]::new([StringComparer]::Ordinal)
+    foreach ($nameValue in @($Map.knownShards) + @($Map.alwaysRun)) {
+        $name = [string] $nameValue
+        if ([string]::IsNullOrWhiteSpace($name)) { throw 'map contains an empty shard name' }
+        if (-not $universe.Add($name)) { throw "map contains duplicate or overlapping shard '$name'" }
+    }
+    if ($universe.Count -lt 2) { throw 'map must contain at least two shards to prove reduction' }
+
+    $outcomeNames = [System.Collections.Generic.HashSet[string]]::new([StringComparer]::Ordinal)
+    $failed = 0
+    foreach ($outcome in $Outcomes) {
+        if (-not $outcome.PSObject.Properties['shard'] -or -not $outcome.PSObject.Properties['outcome']) {
+            throw 'every outcome must contain shard and outcome'
+        }
+        $name = [string] $outcome.shard
+        if (-not $universe.Contains($name)) { throw "outcome names unknown shard '$name'" }
+        if (-not $outcomeNames.Add($name)) { throw "duplicate outcome for shard '$name'" }
+        $conclusion = [string] $outcome.outcome
+        if ($conclusion -notin @('success', 'failure')) {
+            throw "shard '$name' has unauditable outcome '$conclusion'"
+        }
+        if ($conclusion -eq 'failure') { $failed++ }
+    }
+    if ($outcomeNames.Count -ne $universe.Count) {
+        $missing = @($universe | Where-Object { -not $outcomeNames.Contains($_) } | Sort-Object)
+        throw "outcomes do not cover the map shard universe (missing: $($missing -join ', '))"
+    }
+
+    $runNames = [System.Collections.Generic.HashSet[string]]::new([StringComparer]::Ordinal)
+    foreach ($nameValue in @($Audit.WouldRunShards)) {
+        $name = [string] $nameValue
+        if (-not $universe.Contains($name)) { throw "audit WouldRunShards names unknown shard '$name'" }
+        if (-not $runNames.Add($name)) { throw "audit WouldRunShards contains duplicate '$name'" }
+    }
+    $skipNames = [System.Collections.Generic.HashSet[string]]::new([StringComparer]::Ordinal)
+    foreach ($nameValue in @($Audit.WouldSkipShards)) {
+        $name = [string] $nameValue
+        if (-not $universe.Contains($name)) { throw "audit WouldSkipShards names unknown shard '$name'" }
+        if ($runNames.Contains($name)) { throw "audit shard partitions overlap at '$name'" }
+        if (-not $skipNames.Add($name)) { throw "audit WouldSkipShards contains duplicate '$name'" }
+    }
+    if ($runNames.Count + $skipNames.Count -ne $universe.Count) {
+        throw 'audit shard partitions do not cover the map shard universe'
+    }
+
+    $total = ConvertTo-RequiredInteger $Audit.TotalShards 'audit TotalShards' 1
+    $wouldRun = ConvertTo-RequiredInteger $Audit.WouldRun 'audit WouldRun'
+    $wouldSkip = ConvertTo-RequiredInteger $Audit.WouldSkip 'audit WouldSkip'
+    $auditFailed = ConvertTo-RequiredInteger $Audit.Failed 'audit Failed'
+    $missCount = ConvertTo-RequiredInteger $Audit.MissCount 'audit MissCount'
+    if ($total -ne $universe.Count) { throw 'audit TotalShards does not match the map shard universe' }
+    if ($auditFailed -ne $failed) { throw 'audit Failed does not match the source outcomes' }
+    if ($missCount -ne @($Audit.Missed).Count) { throw 'audit MissCount does not match audit Missed' }
+    if ($wouldRun + $wouldSkip -ne $total) {
+        throw 'audit WouldRun plus WouldSkip must equal TotalShards'
+    }
+    if ($wouldRun -ne $runNames.Count -or $wouldSkip -ne $skipNames.Count) {
+        throw 'audit shard partition counts do not match their shard arrays'
+    }
+    if ([bool] $Audit.Escalated -and ($runNames.Count -ne $universe.Count -or $skipNames.Count -ne 0)) {
+        throw 'an escalated audit must run the complete shard universe'
+    }
+
+    $expectedMissed = @($Outcomes |
+        Where-Object { [string] $_.outcome -eq 'failure' -and $skipNames.Contains([string] $_.shard) } |
+        ForEach-Object { [string] $_.shard } | Sort-Object)
+    $reportedMissed = @($Audit.Missed | ForEach-Object { [string] $_ } | Sort-Object)
+    if (($expectedMissed -join "`n") -cne ($reportedMissed -join "`n")) {
+        throw 'audit Missed does not equal the failed shards in WouldSkipShards'
+    }
+    if ($missCount -ne $expectedMissed.Count) {
+        throw 'audit MissCount does not match the recomputed selection misses'
+    }
+
+    $eligible = -not [bool] $Audit.Escalated -and $missCount -eq 0 -and
+        $wouldRun -gt 0 -and $wouldSkip -gt 0
+    $certificate = $null
+    if ($eligible) {
+        $certificate = [pscustomobject] [ordered]@{
+            schemaVersion = 2
+            candidateMapRunId = $MapRunId
+            candidateMapSha = $mapSha
+            auditSourceRunId = $SourceRunId
+            auditSourceSha = $SourceSha
+            certificationRunId = $CertificateRunId
+            escalated = $false
+            auditedShards = $total
+            wouldRun = $wouldRun
+            wouldSkip = $wouldSkip
+            failedShards = $failed
+            missCount = 0
+        }
+    }
+    return [pscustomobject]@{ Eligible = $eligible; Certificate = $certificate }
+}
+
+if ($SelfTest) {
+    $failures = [System.Collections.Generic.List[string]]::new()
+    function Assert-True { param([bool] $Condition, [string] $What)
+        if (-not $Condition) { [void] $failures.Add($What) } }
+    function Assert-Rejected { param([scriptblock] $Action, [string] $What)
+        $rejected = $false
+        try { & $Action | Out-Null } catch { $rejected = $true }
+        Assert-True $rejected $What
+    }
+
+    $sha = '0123456789abcdef0123456789abcdef01234567'
+    $map = [pscustomobject]@{ schemaVersion = 1; sha = $sha; knownShards = @('A', 'B'); alwaysRun = @('Always') }
+    $outcomes = @(
+        [pscustomobject]@{ shard = 'A'; outcome = 'success' },
+        [pscustomobject]@{ shard = 'B'; outcome = 'success' },
+        [pscustomobject]@{ shard = 'Always'; outcome = 'success' }
+    )
+    $audit = [pscustomobject]@{
+        Escalated = $false; TotalShards = 3; WouldRun = 2; WouldSkip = 1
+        WouldRunShards = @('A', 'Always'); WouldSkipShards = @('B')
+        Failed = 0; Missed = @(); MissCount = 0
+    }
+    $decision = Get-CertificationDecision $map $audit $outcomes 10 11 $sha 12
+    Assert-True $decision.Eligible 'a complete clean reduction audit was not certifiable'
+    Assert-True ($decision.Certificate.failedShards -eq 0) 'a clean certificate did not record zero failures'
+
+    $failedOutcomes = @($outcomes | ForEach-Object { $_.PSObject.Copy() })
+    $failedOutcomes[0].outcome = 'failure'
+    $failureAudit = $audit.PSObject.Copy(); $failureAudit.Failed = 1
+    $decision = Get-CertificationDecision $map $failureAudit $failedOutcomes 10 11 $sha 12
+    Assert-True $decision.Eligible 'a zero-miss audit with a selected failure was not certifiable'
+
+    $skippedFailureOutcomes = @($outcomes | ForEach-Object { $_.PSObject.Copy() })
+    $skippedFailureOutcomes[1].outcome = 'failure'
+    $missAudit = $audit.PSObject.Copy(); $missAudit.Failed = 1; $missAudit.Missed = @('B'); $missAudit.MissCount = 1
+    $decision = Get-CertificationDecision $map $missAudit $skippedFailureOutcomes 10 11 $sha 12
+    Assert-True (-not $decision.Eligible) 'an audit with a skipped failure was certifiable'
+    $falseZeroMiss = $missAudit.PSObject.Copy(); $falseZeroMiss.Missed = @(); $falseZeroMiss.MissCount = 0
+    Assert-Rejected { Get-CertificationDecision $map $falseZeroMiss $skippedFailureOutcomes 10 11 $sha 12 } `
+        'a false zero-miss report whose counts still balanced was accepted'
+    $escalated = $audit.PSObject.Copy(); $escalated.Escalated = $true; $escalated.WouldRun = 3; $escalated.WouldSkip = 0
+    $escalated.WouldRunShards = @('A', 'B', 'Always'); $escalated.WouldSkipShards = @()
+    $decision = Get-CertificationDecision $map $escalated $outcomes 10 11 $sha 12
+    Assert-True (-not $decision.Eligible) 'an escalated audit was certifiable'
+    $noReduction = $audit.PSObject.Copy(); $noReduction.WouldRun = 3; $noReduction.WouldSkip = 0
+    $noReduction.WouldRunShards = @('A', 'B', 'Always'); $noReduction.WouldSkipShards = @()
+    $decision = Get-CertificationDecision $map $noReduction $outcomes 10 11 $sha 12
+    Assert-True (-not $decision.Eligible) 'an audit that skips nothing was certifiable'
+
+    Assert-Rejected { Get-CertificationDecision $map $audit @($outcomes[0..1]) 10 11 $sha 12 } `
+        'incomplete outcomes were accepted'
+    $duplicate = @($outcomes | ForEach-Object { $_.PSObject.Copy() }); $duplicate[2].shard = 'A'
+    Assert-Rejected { Get-CertificationDecision $map $audit $duplicate 10 11 $sha 12 } `
+        'duplicate outcomes were accepted'
+    $badCount = $audit.PSObject.Copy(); $badCount.TotalShards = 4
+    Assert-Rejected { Get-CertificationDecision $map $badCount $outcomes 10 11 $sha 12 } `
+        'an audit count outside the map universe was accepted'
+    $stringBoolean = $audit.PSObject.Copy(); $stringBoolean.Escalated = 'false'
+    Assert-Rejected { Get-CertificationDecision $map $stringBoolean $outcomes 10 11 $sha 12 } `
+        'a string audit boolean was accepted'
+    $stringCount = $audit.PSObject.Copy(); $stringCount.TotalShards = '3'
+    Assert-Rejected { Get-CertificationDecision $map $stringCount $outcomes 10 11 $sha 12 } `
+        'a string audit count was accepted'
+    $overlap = $audit.PSObject.Copy(); $overlap.WouldSkipShards = @('A')
+    Assert-Rejected { Get-CertificationDecision $map $overlap $outcomes 10 11 $sha 12 } `
+        'overlapping selected and skipped shard arrays were accepted'
+    $impossibleFailureCount = $audit.PSObject.Copy(); $impossibleFailureCount.Failed = 3
+    $threeFailures = @($outcomes | ForEach-Object { $_.PSObject.Copy() })
+    $threeFailures[0].outcome = 'failure'; $threeFailures[1].outcome = 'failure'; $threeFailures[2].outcome = 'failure'
+    Assert-Rejected { Get-CertificationDecision $map $impossibleFailureCount $threeFailures 10 11 $sha 12 } `
+        'a zero-miss audit with more failures than selected shards was accepted'
+
+    if ($failures.Count -gt 0) {
+        Write-Host 'New-ShardMapCertificate self-test FAILED:'
+        foreach ($failure in $failures) { Write-Host "  - $failure" }
+        exit 1
+    }
+    Write-Host 'New-ShardMapCertificate self-test passed.'
+    exit 0
+}
+
+$mapObject = Get-Content -LiteralPath $MapFile -Raw | ConvertFrom-Json
+$auditObject = Get-Content -LiteralPath $AuditFile -Raw | ConvertFrom-Json
+$outcomeObjects = @(Get-Content -LiteralPath $OutcomesFile -Raw | ConvertFrom-Json)
+$decision = Get-CertificationDecision -Map $mapObject -Audit $auditObject -Outcomes $outcomeObjects `
+    -MapRunId $CandidateMapRunId -SourceRunId $AuditSourceRunId -SourceSha $AuditSourceSha `
+    -CertificateRunId $CertificationRunId
+
+if (-not $decision.Eligible) {
+    Write-Host 'candidate did not complete a zero-miss reduction audit - not certifying it'
+    exit 0
+}
+
+$certificatePath = Join-Path $OutDirectory 'certification.json'
+$mapPath = Join-Path $OutDirectory 'shard-map.json'
+if ((Test-Path -LiteralPath $certificatePath) -or (Test-Path -LiteralPath $mapPath)) {
+    throw "refusing to overwrite an existing certification in $OutDirectory"
+}
+New-Item -ItemType Directory -Path $OutDirectory -Force | Out-Null
+Copy-Item -LiteralPath $MapFile -Destination $mapPath
+$decision.Certificate | ConvertTo-Json -Depth 4 | Set-Content -LiteralPath $certificatePath -Encoding utf8
+Write-Host "certified shard map from run $CandidateMapRunId after complete audit run $AuditSourceRunId"

--- a/tools/TestImpact/Receive-RequiredArtifact.ps1
+++ b/tools/TestImpact/Receive-RequiredArtifact.ps1
@@ -217,7 +217,7 @@ try {
 
         Write-Host "Downloading required artifact $ArtifactId directly (attempt $attempt/$MaxAttempts)."
         $statusText = @(& $curl.Source `
-            --silent --show-error --location --fail-with-body `
+            --silent --show-error --location --proto-redir '=https' --fail-with-body `
             --connect-timeout 30 --max-time 300 `
             --output $archivePath --dump-header $headersPath --write-out '%{http_code}' `
             --header 'Accept: application/vnd.github+json' `

--- a/tools/TestImpact/Receive-RequiredArtifact.ps1
+++ b/tools/TestImpact/Receive-RequiredArtifact.ps1
@@ -138,6 +138,14 @@ function Get-SmallResponseBody {
     return [string] (Get-Content -LiteralPath $Path -Raw)
 }
 
+function Get-CurlApplicationPath {
+    # Ubuntu exposes the same executable through /usr/bin and /bin. Property enumeration on the
+    # unbounded Get-Command result joins both paths into one invalid invocation target.
+    $command = Get-Command curl -CommandType Application -ErrorAction Stop |
+        Select-Object -First 1
+    return [string] $command.Source
+}
+
 if ($SelfTest) {
     $secondary = '{"message":"You have exceeded a secondary rate limit. Please wait."}'
     Assert-True ((Get-ArtifactRequestDisposition 22 403 $secondary) -eq
@@ -172,6 +180,12 @@ if ($SelfTest) {
     Assert-True ((Get-RetryDelaySeconds -FailedAttempt 1 -WorkflowRunId 100 -MatrixJobIndex 7 `
         -RetryAfterSeconds 180) -ge 180) 'Retry-After was shortened'
 
+    $curlApplicationPath = Get-CurlApplicationPath
+    Assert-True (-not [string]::IsNullOrWhiteSpace($curlApplicationPath)) `
+        'curl application resolution returned no executable path'
+    Assert-True (Test-Path -LiteralPath $curlApplicationPath -PathType Leaf) `
+        'curl application resolution did not return one executable'
+
     $digestFixture = Join-Path ([IO.Path]::GetTempPath()) `
         ("aidotnet-artifact-digest-" + [guid]::NewGuid().ToString('N'))
     try {
@@ -197,7 +211,7 @@ if ([string]::IsNullOrWhiteSpace($env:GITHUB_TOKEN)) {
     throw 'GITHUB_TOKEN is required to download a workflow artifact by ID'
 }
 
-$curl = Get-Command curl -CommandType Application -ErrorAction Stop
+$curlApplicationPath = Get-CurlApplicationPath
 $destinationPath = [IO.Path]::GetFullPath($Destination)
 [IO.Directory]::CreateDirectory($destinationPath) | Out-Null
 
@@ -216,7 +230,7 @@ try {
         }
 
         Write-Host "Downloading required artifact $ArtifactId directly (attempt $attempt/$MaxAttempts)."
-        $statusText = @(& $curl.Source `
+        $statusText = @(& $curlApplicationPath `
             --silent --show-error --location --proto-redir '=https' --fail-with-body `
             --connect-timeout 30 --max-time 300 `
             --output $archivePath --dump-header $headersPath --write-out '%{http_code}' `

--- a/tools/TestImpact/Receive-RequiredArtifact.ps1
+++ b/tools/TestImpact/Receive-RequiredArtifact.ps1
@@ -1,0 +1,269 @@
+<#
+.SYNOPSIS
+    Downloads one required GitHub Actions artifact by immutable ID.
+
+.DESCRIPTION
+    actions/download-artifact resolves an artifact name by listing every artifact in the workflow
+    run. Large matrices make those concurrent ListArtifacts calls hit GitHub's secondary rate limit.
+    This script consumes the artifact ID and digest emitted by actions/upload-artifact instead, uses
+    the supported REST archive endpoint directly, and validates the downloaded archive before it is
+    extracted.
+
+    Transient responses use bounded exponential backoff with deterministic jitter. A permission or
+    identity error fails immediately, and exhausting the retry budget remains a hard failure: callers
+    must never report an untested shard as successful.
+#>
+[CmdletBinding(DefaultParameterSetName = 'Download')]
+param(
+    [Parameter(Mandatory, ParameterSetName = 'Download')]
+    [ValidatePattern('^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$')]
+    [string] $Repository,
+
+    [Parameter(Mandatory, ParameterSetName = 'Download')]
+    [ValidateRange(1, [long]::MaxValue)]
+    [long] $ArtifactId,
+
+    [Parameter(Mandatory, ParameterSetName = 'Download')]
+    [ValidatePattern('^sha256:[0-9a-fA-F]{64}$')]
+    [string] $ExpectedDigest,
+
+    [Parameter(Mandatory, ParameterSetName = 'Download')]
+    [string] $Destination,
+
+    [Parameter(Mandatory, ParameterSetName = 'Download')]
+    [ValidateRange(1, [long]::MaxValue)]
+    [long] $RunId,
+
+    [Parameter(Mandatory, ParameterSetName = 'Download')]
+    [ValidateRange(0, [int]::MaxValue)]
+    [int] $JobIndex,
+
+    [Parameter(ParameterSetName = 'Download')]
+    [ValidateRange(1, 5)]
+    [int] $MaxAttempts = 3,
+
+    [Parameter(Mandatory, ParameterSetName = 'SelfTest')]
+    [switch] $SelfTest
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+# curl's exit code is input to the retry policy, not a PowerShell exception. Pin this preference so
+# future runner-image defaults cannot bypass classification before the response is inspected.
+$PSNativeCommandUseErrorActionPreference = $false
+
+enum ArtifactRequestDisposition {
+    Success
+    Retry
+    Fail
+}
+
+function Assert-True {
+    param([bool] $Condition, [string] $Message)
+    if (-not $Condition) { throw $Message }
+}
+
+function Get-ArtifactRequestDisposition {
+    param(
+        [int] $CurlExitCode,
+        [int] $HttpStatus,
+        [AllowEmptyString()] [string] $ResponseBody,
+        [ValidateRange(0, [int]::MaxValue)] [int] $RetryAfterSeconds = 0
+    )
+
+    if ($CurlExitCode -eq 0 -and $HttpStatus -eq 200) {
+        return [ArtifactRequestDisposition]::Success
+    }
+
+    if ($HttpStatus -eq 403 -and ($RetryAfterSeconds -gt 0 -or
+        $ResponseBody.Contains('secondary rate limit', [StringComparison]::OrdinalIgnoreCase))) {
+        return [ArtifactRequestDisposition]::Retry
+    }
+
+    # A connection reset or partial transfer can occur after the archive endpoint has returned 200.
+    # curl reports that through its exit code; treating the HTTP status alone as terminal would turn
+    # a recoverable truncated download into a hard failure before digest validation can run.
+    if ($CurlExitCode -ne 0 -and $HttpStatus -ge 200 -and $HttpStatus -le 399) {
+        return [ArtifactRequestDisposition]::Retry
+    }
+
+    if ($HttpStatus -in @(0, 408, 425, 429) -or ($HttpStatus -ge 500 -and $HttpStatus -le 599)) {
+        return [ArtifactRequestDisposition]::Retry
+    }
+
+    return [ArtifactRequestDisposition]::Fail
+}
+
+function Get-RetryAfterSeconds {
+    param([AllowEmptyString()] [string] $Headers)
+
+    $matches = [Regex]::Matches($Headers, '(?im)^retry-after:\s*(?<seconds>\d+)\s*\r?$')
+    if ($matches.Count -eq 0) { return 0 }
+
+    $seconds = 0
+    if (-not [int]::TryParse($matches[$matches.Count - 1].Groups['seconds'].Value, [ref] $seconds)) {
+        return 0
+    }
+    return $seconds
+}
+
+function Get-RetryDelaySeconds {
+    param(
+        [ValidateRange(1, 4)] [int] $FailedAttempt,
+        [ValidateRange(1, [long]::MaxValue)] [long] $WorkflowRunId,
+        [ValidateRange(0, [int]::MaxValue)] [int] $MatrixJobIndex,
+        [ValidateRange(0, [int]::MaxValue)] [int] $RetryAfterSeconds
+    )
+
+    # GitHub requires at least one minute after a secondary limit. The run and matrix identities
+    # spread simultaneous failures across a 31-second window so retries do not form another burst.
+    $minimum = 60 * (1 -shl ($FailedAttempt - 1))
+    $jitter = [int] ((($WorkflowRunId % 31) + (($MatrixJobIndex % 31) * 17)) % 31)
+    return [math]::Max($minimum, $RetryAfterSeconds) + $jitter
+}
+
+function Test-ArtifactDigest {
+    param([string] $Path, [string] $Expected)
+
+    $actual = 'sha256:' + (Get-FileHash -LiteralPath $Path -Algorithm SHA256).Hash.ToLowerInvariant()
+    return $actual.Equals($Expected.ToLowerInvariant(), [StringComparison]::Ordinal)
+}
+
+function Get-SmallResponseBody {
+    param([string] $Path)
+
+    if (-not (Test-Path -LiteralPath $Path)) { return '' }
+    $file = Get-Item -LiteralPath $Path
+    if ($file.Length -gt 65536) { return '' }
+    return [string] (Get-Content -LiteralPath $Path -Raw)
+}
+
+if ($SelfTest) {
+    $secondary = '{"message":"You have exceeded a secondary rate limit. Please wait."}'
+    Assert-True ((Get-ArtifactRequestDisposition 22 403 $secondary) -eq
+        [ArtifactRequestDisposition]::Retry) 'a secondary-limit 403 was not classified as transient'
+    Assert-True ((Get-ArtifactRequestDisposition 22 403 '{"message":"Forbidden"}' 17) -eq
+        [ArtifactRequestDisposition]::Retry) 'a Retry-After 403 was not classified as transient'
+    Assert-True ((Get-ArtifactRequestDisposition 22 403 '' 17) -eq
+        [ArtifactRequestDisposition]::Retry) 'a Retry-After 403 was not classified as transient'
+    Assert-True ((Get-ArtifactRequestDisposition 22 403 '{"message":"Resource not accessible"}') -eq
+        [ArtifactRequestDisposition]::Fail) 'a permission 403 was incorrectly classified as transient'
+    Assert-True ((Get-ArtifactRequestDisposition 22 429 '') -eq
+        [ArtifactRequestDisposition]::Retry) 'HTTP 429 was not classified as transient'
+    Assert-True ((Get-ArtifactRequestDisposition 22 503 '') -eq
+        [ArtifactRequestDisposition]::Retry) 'HTTP 503 was not classified as transient'
+    Assert-True ((Get-ArtifactRequestDisposition 18 200 '') -eq
+        [ArtifactRequestDisposition]::Retry) 'a partial HTTP 200 transfer was not classified as transient'
+    Assert-True ((Get-ArtifactRequestDisposition 22 404 '') -eq
+        [ArtifactRequestDisposition]::Fail) 'HTTP 404 was incorrectly classified as transient'
+    Assert-True ((Get-ArtifactRequestDisposition 0 200 '') -eq
+        [ArtifactRequestDisposition]::Success) 'HTTP 200 was not classified as success'
+
+    $headers = "HTTP/2 403`r`nretry-after: 17`r`n`r`nHTTP/2 403`r`nRetry-After: 93`r`n"
+    Assert-True ((Get-RetryAfterSeconds $headers) -eq 93) 'the final Retry-After header was not honored'
+    Assert-True ((Get-RetryAfterSeconds '') -eq 0) 'missing Retry-After did not return zero'
+
+    $first = Get-RetryDelaySeconds -FailedAttempt 1 -WorkflowRunId 100 -MatrixJobIndex 7 `
+        -RetryAfterSeconds 0
+    $second = Get-RetryDelaySeconds -FailedAttempt 2 -WorkflowRunId 100 -MatrixJobIndex 7 `
+        -RetryAfterSeconds 0
+    Assert-True ($first -ge 60 -and $first -le 90) 'first retry violated the one-minute minimum'
+    Assert-True ($second -ge 120 -and $second -le 150) 'second retry is not exponential'
+    Assert-True ((Get-RetryDelaySeconds -FailedAttempt 1 -WorkflowRunId 100 -MatrixJobIndex 7 `
+        -RetryAfterSeconds 180) -ge 180) 'Retry-After was shortened'
+
+    $digestFixture = Join-Path ([IO.Path]::GetTempPath()) `
+        ("aidotnet-artifact-digest-" + [guid]::NewGuid().ToString('N'))
+    try {
+        [IO.File]::WriteAllText($digestFixture, 'abc', [Text.UTF8Encoding]::new($false))
+        Assert-True (Test-ArtifactDigest $digestFixture `
+            'sha256:ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad') `
+            'artifact SHA-256 validation rejected known content'
+        Assert-True (-not (Test-ArtifactDigest $digestFixture `
+            'sha256:ca7816bf8f01cfea414140de5dae2223b00361a396177a9cbb410ff61f20015ad')) `
+            'artifact SHA-256 validation accepted a mismatched digest'
+    }
+    finally {
+        if (Test-Path -LiteralPath $digestFixture) {
+            Remove-Item -LiteralPath $digestFixture -Force
+        }
+    }
+
+    Write-Host 'Required artifact transport self-test passed.'
+    exit 0
+}
+
+if ([string]::IsNullOrWhiteSpace($env:GITHUB_TOKEN)) {
+    throw 'GITHUB_TOKEN is required to download a workflow artifact by ID'
+}
+
+$curl = Get-Command curl -CommandType Application -ErrorAction Stop
+$destinationPath = [IO.Path]::GetFullPath($Destination)
+[IO.Directory]::CreateDirectory($destinationPath) | Out-Null
+
+$temporaryDirectory = Join-Path ([IO.Path]::GetTempPath()) `
+    ("aidotnet-required-artifact-" + [guid]::NewGuid().ToString('N'))
+$archivePath = Join-Path $temporaryDirectory 'artifact.zip'
+$headersPath = Join-Path $temporaryDirectory 'headers.txt'
+[IO.Directory]::CreateDirectory($temporaryDirectory) | Out-Null
+
+try {
+    $url = "https://api.github.com/repos/$Repository/actions/artifacts/$ArtifactId/zip"
+
+    for ($attempt = 1; $attempt -le $MaxAttempts; $attempt++) {
+        foreach ($path in @($archivePath, $headersPath)) {
+            if (Test-Path -LiteralPath $path) { Remove-Item -LiteralPath $path -Force }
+        }
+
+        Write-Host "Downloading required artifact $ArtifactId directly (attempt $attempt/$MaxAttempts)."
+        $statusText = @(& $curl.Source `
+            --silent --show-error --location --fail-with-body `
+            --connect-timeout 30 --max-time 300 `
+            --output $archivePath --dump-header $headersPath --write-out '%{http_code}' `
+            --header 'Accept: application/vnd.github+json' `
+            --header "Authorization: Bearer $env:GITHUB_TOKEN" `
+            --header 'X-GitHub-Api-Version: 2022-11-28' `
+            --user-agent 'AiDotNet-CI-artifact-transport' `
+            $url)
+        $curlExitCode = $LASTEXITCODE
+        $statusValue = ($statusText -join '').Trim()
+        $httpStatus = 0
+        [void] [int]::TryParse($statusValue, [ref] $httpStatus)
+        $responseBody = Get-SmallResponseBody $archivePath
+        $headerText = if (Test-Path -LiteralPath $headersPath) {
+            [string] (Get-Content -LiteralPath $headersPath -Raw)
+        }
+        else { '' }
+        $retryAfter = Get-RetryAfterSeconds $headerText
+        $disposition = Get-ArtifactRequestDisposition -CurlExitCode $curlExitCode `
+            -HttpStatus $httpStatus -ResponseBody $responseBody -RetryAfterSeconds $retryAfter
+
+        if ($disposition -eq [ArtifactRequestDisposition]::Success) {
+            if (-not (Test-ArtifactDigest -Path $archivePath -Expected $ExpectedDigest)) {
+                throw "artifact $ArtifactId failed SHA-256 validation"
+            }
+
+            [IO.Compression.ZipFile]::ExtractToDirectory($archivePath, $destinationPath, $true)
+            Write-Host "Required artifact $ArtifactId passed digest validation and was extracted."
+            exit 0
+        }
+
+        if ($disposition -eq [ArtifactRequestDisposition]::Fail -or $attempt -eq $MaxAttempts) {
+            $detail = if ($responseBody) { $responseBody } else { 'no response body' }
+            throw "required artifact $ArtifactId download failed (curl=$curlExitCode, HTTP=$httpStatus): $detail"
+        }
+
+        $delay = Get-RetryDelaySeconds -FailedAttempt $attempt -WorkflowRunId $RunId `
+            -MatrixJobIndex $JobIndex -RetryAfterSeconds $retryAfter
+        Write-Host "Transient artifact response (curl=$curlExitCode, HTTP=$httpStatus); retrying after $delay seconds."
+        Start-Sleep -Seconds $delay
+    }
+}
+finally {
+    foreach ($path in @($archivePath, $headersPath)) {
+        if (Test-Path -LiteralPath $path) { Remove-Item -LiteralPath $path -Force }
+    }
+    if (Test-Path -LiteralPath $temporaryDirectory) {
+        Remove-Item -LiteralPath $temporaryDirectory -Force
+    }
+}

--- a/tools/TestImpact/Resolve-CertifiedShardMap.ps1
+++ b/tools/TestImpact/Resolve-CertifiedShardMap.ps1
@@ -1,0 +1,224 @@
+<#
+.SYNOPSIS
+    Downloads the certified shard map, if and only if the newest completed map run certified one.
+
+.DESCRIPTION
+    The newest completed Test impact map run is a revocation boundary. A failed run or a successful
+    run without a certified-shard-map artifact invalidates every older certificate. Keeping that
+    policy here, rather than embedded in workflow YAML, lets adversarial fixtures execute the exact
+    decision code and record every attempted artifact download.
+#>
+[CmdletBinding(DefaultParameterSetName = 'Resolve')]
+param(
+    [Parameter(Mandatory, ParameterSetName = 'Resolve')] [string] $Repository,
+    [Parameter(Mandatory, ParameterSetName = 'Resolve')] [string] $OutDirectory,
+    [Parameter(Mandatory, ParameterSetName = 'Resolve')] [string] $ResultFile,
+    [Parameter(Mandatory, ParameterSetName = 'SelfTest')] [switch] $SelfTest
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+enum CertifiedShardMapResolutionStatus {
+    Found
+    NoCompletedRun
+    LatestRunFailed
+    CertificateUnavailable
+}
+
+function Resolve-CertifiedShardMapRun {
+    param(
+        [Parameter(Mandatory)] [AllowEmptyCollection()] [object[]] $Runs,
+        [Parameter(Mandatory)] [scriptblock] $DownloadCertificate
+    )
+
+    $targetRuns = [System.Collections.Generic.List[object]]::new()
+    foreach ($run in $Runs) {
+        if (-not $run.PSObject.Properties['workflowName'] -or
+            [string] $run.workflowName -cne 'Test impact map') {
+            continue
+        }
+        foreach ($property in 'databaseId', 'conclusion', 'createdAt', 'status') {
+            if (-not $run.PSObject.Properties[$property]) {
+                throw "map run is missing $property"
+            }
+        }
+        if ([string] $run.status -cne 'completed') { continue }
+
+        $runId = 0L
+        if (-not [long]::TryParse([string] $run.databaseId, [ref] $runId) -or $runId -lt 1) {
+            throw 'map run databaseId must be a positive integer'
+        }
+        $createdAt = [DateTimeOffset]::MinValue
+        if (-not [DateTimeOffset]::TryParse(
+            [string] $run.createdAt,
+            [Globalization.CultureInfo]::InvariantCulture,
+            [Globalization.DateTimeStyles]::AssumeUniversal,
+            [ref] $createdAt)) {
+            throw "map run $runId has an invalid createdAt timestamp"
+        }
+        [void] $targetRuns.Add([pscustomobject]@{
+            RunId = $runId
+            Conclusion = [string] $run.conclusion
+            CreatedAt = $createdAt
+        })
+    }
+
+    $latest = @($targetRuns | Sort-Object CreatedAt, RunId -Descending | Select-Object -First 1)
+    if ($latest.Count -eq 0) {
+        return [pscustomobject]@{
+            Status = [CertifiedShardMapResolutionStatus]::NoCompletedRun
+            RunId = 0L
+        }
+    }
+
+    $candidate = $latest[0]
+    if ($candidate.Conclusion -cne 'success') {
+        return [pscustomobject]@{
+            Status = [CertifiedShardMapResolutionStatus]::LatestRunFailed
+            RunId = [long] $candidate.RunId
+        }
+    }
+
+    $downloaded = [bool] (& $DownloadCertificate ([long] $candidate.RunId))
+    if (-not $downloaded) {
+        return [pscustomobject]@{
+            Status = [CertifiedShardMapResolutionStatus]::CertificateUnavailable
+            RunId = [long] $candidate.RunId
+        }
+    }
+
+    return [pscustomobject]@{
+        Status = [CertifiedShardMapResolutionStatus]::Found
+        RunId = [long] $candidate.RunId
+    }
+}
+
+if ($SelfTest) {
+    $failures = [System.Collections.Generic.List[string]]::new()
+    function Assert-True {
+        param([bool] $Condition, [string] $What)
+        if (-not $Condition) { [void] $failures.Add($What) }
+    }
+    function New-Run {
+        param(
+            [long] $Id,
+            [string] $Conclusion,
+            [string] $CreatedAt,
+            [string] $WorkflowName = 'Test impact map',
+            [string] $Status = 'completed'
+        )
+        return [pscustomobject]@{
+            databaseId = $Id
+            conclusion = $Conclusion
+            createdAt = $CreatedAt
+            workflowName = $WorkflowName
+            status = $Status
+        }
+    }
+
+    $runs = @(
+        (New-Run 100 'success' '2026-09-08T01:00:00Z'),
+        (New-Run 300 'success' '2026-09-08T03:00:00Z' 'Build & SonarCloud'),
+        (New-Run 200 'failure' '2026-09-08T02:00:00Z')
+    )
+    $attempts = [System.Collections.Generic.List[long]]::new()
+    $result = Resolve-CertifiedShardMapRun -Runs $runs -DownloadCertificate {
+        param([long] $RunId)
+        [void] $attempts.Add($RunId)
+        return $true
+    }
+    Assert-True ($result.Status -eq [CertifiedShardMapResolutionStatus]::LatestRunFailed) `
+        'an older certificate survived a newer failed map run'
+    Assert-True ($attempts.Count -eq 0) `
+        'the resolver attempted a certificate download after the newest map run failed'
+
+    $runs = @(
+        (New-Run 100 'success' '2026-09-08T01:00:00Z'),
+        (New-Run 201 'success' '2026-09-08T02:00:00Z')
+    )
+    $attempts = [System.Collections.Generic.List[long]]::new()
+    $result = Resolve-CertifiedShardMapRun -Runs $runs -DownloadCertificate {
+        param([long] $RunId)
+        [void] $attempts.Add($RunId)
+        return $false
+    }
+    Assert-True ($result.Status -eq [CertifiedShardMapResolutionStatus]::CertificateUnavailable) `
+        'a successful map run without a certificate did not revoke older evidence'
+    Assert-True (($attempts -join ',') -ceq '201') `
+        'the resolver probed an older certificate after the newest artifact was unavailable'
+
+    $attempts = [System.Collections.Generic.List[long]]::new()
+    $result = Resolve-CertifiedShardMapRun -Runs $runs -DownloadCertificate {
+        param([long] $RunId)
+        [void] $attempts.Add($RunId)
+        return $RunId -eq 201
+    }
+    Assert-True ($result.Status -eq [CertifiedShardMapResolutionStatus]::Found -and
+        $result.RunId -eq 201) 'the newest certified map was not selected'
+    Assert-True (($attempts -join ',') -ceq '201') `
+        'selecting a valid newest certificate attempted more than one download'
+
+    $attempts = [System.Collections.Generic.List[long]]::new()
+    $result = Resolve-CertifiedShardMapRun -Runs @(
+        (New-Run 400 'success' '2026-09-08T04:00:00Z' 'Build & SonarCloud')
+    ) -DownloadCertificate {
+        param([long] $RunId)
+        [void] $attempts.Add($RunId)
+        return $true
+    }
+    Assert-True ($result.Status -eq [CertifiedShardMapResolutionStatus]::NoCompletedRun) `
+        'an unrelated workflow was accepted as a map workflow'
+    Assert-True ($attempts.Count -eq 0) 'an unrelated workflow triggered an artifact download'
+
+    if ($failures.Count -gt 0) {
+        Write-Host 'Resolve-CertifiedShardMap self-test FAILED:'
+        foreach ($failure in $failures) { Write-Host "  - $failure" }
+        exit 1
+    }
+    Write-Host 'Resolve-CertifiedShardMap self-test passed.'
+    exit 0
+}
+
+if (Test-Path -LiteralPath $OutDirectory) {
+    throw "refusing to mix a certified map into existing directory $OutDirectory"
+}
+if (Test-Path -LiteralPath $ResultFile) {
+    throw "refusing to overwrite existing result file $ResultFile"
+}
+
+$runsJson = & gh run list --repo $Repository --workflow test-impact-map.yml --branch master `
+    --status completed --limit 20 --json databaseId,conclusion,createdAt,workflowName,status 2>$null
+if ($LASTEXITCODE -ne 0) {
+    throw 'could not query completed Test impact map workflow runs'
+}
+$runs = @($runsJson | ConvertFrom-Json)
+$resolution = Resolve-CertifiedShardMapRun -Runs $runs -DownloadCertificate {
+    param([long] $RunId)
+    & gh run download $RunId --repo $Repository --name certified-shard-map `
+        --dir $OutDirectory *> $null
+    return $LASTEXITCODE -eq 0
+}
+
+$found = $resolution.Status -eq [CertifiedShardMapResolutionStatus]::Found
+[ordered]@{
+    found = $found
+    runId = [long] $resolution.RunId
+    status = $resolution.Status.ToString()
+} | ConvertTo-Json -Depth 3 | Set-Content -LiteralPath $ResultFile -Encoding utf8
+
+switch ($resolution.Status) {
+    ([CertifiedShardMapResolutionStatus]::Found) {
+        Write-Host "using certified shard map from latest completed map run $($resolution.RunId)"
+    }
+    ([CertifiedShardMapResolutionStatus]::NoCompletedRun) {
+        Write-Host '::warning::no completed Test impact map workflow exists; selection will fail closed'
+    }
+    ([CertifiedShardMapResolutionStatus]::LatestRunFailed) {
+        Write-Host "::warning::latest completed map run $($resolution.RunId) failed; refusing to fall back to an older map"
+    }
+    ([CertifiedShardMapResolutionStatus]::CertificateUnavailable) {
+        Write-Host "::warning::latest completed map run $($resolution.RunId) has no usable certificate; refusing to fall back to an older map"
+    }
+}
+exit 0

--- a/tools/TestImpact/Test-CertifiedShardMap.ps1
+++ b/tools/TestImpact/Test-CertifiedShardMap.ps1
@@ -1,6 +1,6 @@
 <#
 .SYNOPSIS
-    Validates that a shard map carries a failure-bearing, zero-miss audit certificate from its run.
+    Validates that a shard map carries a complete, zero-miss audit certificate from its run.
 #>
 [CmdletBinding(DefaultParameterSetName = 'Validate')]
 param(
@@ -15,32 +15,32 @@ $ErrorActionPreference = 'Stop'
 
 function ConvertTo-RequiredInteger {
     param([object] $Value, [string] $Name, [long] $Minimum = 0)
-    $parsed = 0L
-    if ($null -eq $Value -or -not [long]::TryParse(
-        [string] $Value,
-        [Globalization.NumberStyles]::Integer,
-        [Globalization.CultureInfo]::InvariantCulture,
-        [ref] $parsed)) {
-        throw "$Name must be an integer"
-    }
-    if ($parsed -lt $Minimum) { throw "$Name must be at least $Minimum" }
-    return $parsed
+    $isInteger = $Value -is [byte] -or $Value -is [sbyte] -or
+        $Value -is [int16] -or $Value -is [uint16] -or
+        $Value -is [int32] -or $Value -is [uint32] -or
+        $Value -is [int64] -or $Value -is [uint64]
+    if (-not $isInteger) { throw "$Name must be a JSON integer" }
+    $number = [long] $Value
+    if ($number -lt $Minimum) { throw "$Name must be at least $Minimum" }
+    return $number
 }
 
 function Assert-CertifiedShardMap {
     param([object] $Map, [object] $Certificate, [long] $ExpectedCertificationRunId)
 
-    foreach ($name in 'schemaVersion', 'sha') {
+    foreach ($name in 'schemaVersion', 'sha', 'knownShards', 'alwaysRun') {
         if (-not $Map.PSObject.Properties[$name]) { throw "map is missing $name" }
     }
     foreach ($name in 'schemaVersion', 'candidateMapRunId', 'candidateMapSha',
         'auditSourceRunId', 'auditSourceSha', 'certificationRunId', 'escalated',
-        'wouldRun', 'wouldSkip', 'failedShards', 'missCount') {
+        'auditedShards', 'wouldRun', 'wouldSkip', 'failedShards', 'missCount') {
         if (-not $Certificate.PSObject.Properties[$name]) { throw "certificate is missing $name" }
     }
 
+    $mapSchema = ConvertTo-RequiredInteger -Value $Map.schemaVersion -Name 'map schemaVersion' -Minimum 1
+    if ($mapSchema -ne 1) { throw "unsupported map schema $mapSchema" }
     $schema = ConvertTo-RequiredInteger -Value $Certificate.schemaVersion -Name 'certificate schemaVersion' -Minimum 1
-    if ($schema -ne 1) { throw "unsupported certification schema $schema" }
+    if ($schema -ne 2) { throw "unsupported certification schema $schema" }
     $actualRun = ConvertTo-RequiredInteger -Value $Certificate.certificationRunId -Name 'certificationRunId' -Minimum 1
     if ($actualRun -ne $ExpectedCertificationRunId) {
         throw "certificate belongs to run $actualRun, not artifact run $ExpectedCertificationRunId"
@@ -51,9 +51,34 @@ function Assert-CertifiedShardMap {
     if ($misses -ne 0) { throw "certificate records $misses selection miss(es)" }
     if ($Certificate.escalated -isnot [bool]) { throw 'escalated must be a JSON boolean' }
     if ([bool] $Certificate.escalated) { throw 'certificate records an escalated plan, not reduction' }
-    [void] (ConvertTo-RequiredInteger -Value $Certificate.wouldRun -Name 'wouldRun' -Minimum 1)
-    [void] (ConvertTo-RequiredInteger -Value $Certificate.wouldSkip -Name 'wouldSkip' -Minimum 1)
-    [void] (ConvertTo-RequiredInteger -Value $Certificate.failedShards -Name 'failedShards' -Minimum 1)
+    $audited = ConvertTo-RequiredInteger -Value $Certificate.auditedShards -Name 'auditedShards' -Minimum 2
+    if ($Map.knownShards -isnot [array] -or $Map.alwaysRun -isnot [array]) {
+        throw 'map knownShards and alwaysRun must be arrays'
+    }
+    $mapShards = [System.Collections.Generic.HashSet[string]]::new([StringComparer]::Ordinal)
+    foreach ($nameValue in @($Map.knownShards) + @($Map.alwaysRun)) {
+        $name = [string] $nameValue
+        if ([string]::IsNullOrWhiteSpace($name)) { throw 'map contains an empty shard name' }
+        if (-not $mapShards.Add($name)) { throw "map contains duplicate or overlapping shard '$name'" }
+    }
+    $mapShardCount = @($Map.knownShards).Count + @($Map.alwaysRun).Count
+    if ($audited -ne $mapShardCount) {
+        throw "auditedShards ($audited) does not cover the map shard universe ($mapShardCount)"
+    }
+    $wouldRun = ConvertTo-RequiredInteger -Value $Certificate.wouldRun -Name 'wouldRun' -Minimum 1
+    $wouldSkip = ConvertTo-RequiredInteger -Value $Certificate.wouldSkip -Name 'wouldSkip' -Minimum 1
+    if ($wouldRun + $wouldSkip -ne $audited) {
+        throw "wouldRun ($wouldRun) plus wouldSkip ($wouldSkip) must equal auditedShards ($audited)"
+    }
+    # A clean complete matrix is valid evidence. Requiring a naturally occurring failure made
+    # certification depend on CI being red, so a healthy repository could never enable selection.
+    # The miss detector's adversarial tests prove that a skipped failure is rejected; this field
+    # records what the real full-matrix audit observed and must be a non-negative integer.
+    $failed = ConvertTo-RequiredInteger -Value $Certificate.failedShards -Name 'failedShards'
+    if ($failed -gt $audited) { throw "failedShards ($failed) exceeds auditedShards ($audited)" }
+    if ($failed -gt $wouldRun) {
+        throw "failedShards ($failed) exceeds wouldRun ($wouldRun) despite a zero-miss certificate"
+    }
 
     $mapSha = [string] $Map.sha
     $candidateSha = [string] $Certificate.candidateMapSha
@@ -79,18 +104,24 @@ if ($SelfTest) {
     }
 
     $sha = '0123456789abcdef0123456789abcdef01234567'
-    $map = [pscustomobject]@{ schemaVersion = 1; sha = $sha }
-    $certificate = [pscustomobject]@{
+    $map = [pscustomobject]@{
         schemaVersion = 1
+        sha = $sha
+        knownShards = @('Alpha', 'Beta')
+        alwaysRun = @('Always')
+    }
+    $certificate = [pscustomobject]@{
+        schemaVersion = 2
         candidateMapRunId = 10
         candidateMapSha = $sha
         auditSourceRunId = 11
         auditSourceSha = '89abcdef0123456789abcdef0123456789abcdef'
         certificationRunId = 12
         escalated = $false
+        auditedShards = 3
         wouldRun = 2
         wouldSkip = 1
-        failedShards = 1
+        failedShards = 0
         missCount = 0
     }
     try {
@@ -106,6 +137,9 @@ if ($SelfTest) {
     $bad = $certificate.PSObject.Copy(); $bad.certificationRunId = 99
     Assert-Rejection { Assert-CertifiedShardMap $map $bad 12 } `
         'a certificate from another run was accepted' 'certificate belongs to run'
+    $bad = $certificate.PSObject.Copy(); $bad.certificationRunId = '12'
+    Assert-Rejection { Assert-CertifiedShardMap $map $bad 12 } `
+        'a string certification run id was accepted' 'must be a JSON integer'
     $bad = $certificate.PSObject.Copy(); $bad.candidateMapSha = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
     Assert-Rejection { Assert-CertifiedShardMap $map $bad 12 } `
         'a certificate for another map was accepted' 'different source commits'
@@ -118,9 +152,31 @@ if ($SelfTest) {
     $bad = $certificate.PSObject.Copy(); $bad.wouldSkip = 0
     Assert-Rejection { Assert-CertifiedShardMap $map $bad 12 } `
         'a plan that skipped nothing was accepted as reduction proof' 'wouldSkip must be at least 1'
-    $bad = $certificate.PSObject.Copy(); $bad.failedShards = 0
+    $bad = $certificate.PSObject.Copy(); $bad.auditedShards = 4
     Assert-Rejection { Assert-CertifiedShardMap $map $bad 12 } `
-        'a certificate without a failure opportunity was accepted' 'failedShards must be at least 1'
+        'a certificate that did not audit the full map universe was accepted' 'does not cover the map shard universe'
+    $bad = $certificate.PSObject.Copy(); $bad.wouldRun = 1
+    Assert-Rejection { Assert-CertifiedShardMap $map $bad 12 } `
+        'a certificate whose selection did not partition the audited matrix was accepted' 'must equal auditedShards'
+    $bad = $certificate.PSObject.Copy(); $bad.failedShards = -1
+    Assert-Rejection { Assert-CertifiedShardMap $map $bad 12 } `
+        'a certificate with a negative failure count was accepted' 'failedShards must be at least 0'
+    $withObservedFailure = $certificate.PSObject.Copy(); $withObservedFailure.failedShards = 1
+    try {
+        Assert-CertifiedShardMap -Map $map -Certificate $withObservedFailure -ExpectedCertificationRunId 12
+    }
+    catch {
+        [void] $failures.Add("a valid certificate with an observed failure was rejected: $($_.Exception.Message)")
+    }
+    $bad = $certificate.PSObject.Copy(); $bad.failedShards = 4
+    Assert-Rejection { Assert-CertifiedShardMap $map $bad 12 } `
+        'a certificate with more failures than audited shards was accepted' 'exceeds auditedShards'
+    $bad = $certificate.PSObject.Copy(); $bad.failedShards = 3
+    Assert-Rejection { Assert-CertifiedShardMap $map $bad 12 } `
+        'a zero-miss certificate with more failures than selected shards was accepted' 'exceeds wouldRun'
+    $badMap = $map.PSObject.Copy(); $badMap.schemaVersion = 2
+    Assert-Rejection { Assert-CertifiedShardMap $badMap $certificate 12 } `
+        'a map with an unsupported schema was accepted' 'unsupported map schema'
     $badMap = $map.PSObject.Copy(); $badMap.sha = $sha.ToUpperInvariant()
     $bad = $certificate.PSObject.Copy(); $bad.candidateMapSha = $badMap.sha
     Assert-Rejection { Assert-CertifiedShardMap $badMap $bad 12 } `

--- a/tools/TestImpact/Test-CiImpactWorkflow.ps1
+++ b/tools/TestImpact/Test-CiImpactWorkflow.ps1
@@ -189,6 +189,17 @@ Assert-Contract ($validation.Contains('candidate-shard-map')) `
 Assert-Contract ($validation -match '(?s)if \[ "\$FORCE_COVERAGE" = ''true'' \].*?--name candidate-shard-map.*?else.*?--name certified-shard-map') `
     'candidate and certified artifacts are not separated at the execution boundary'
 
+# A later map audit is also a revocation boundary. If it fails or withholds certification after a
+# miss, selection must fail closed instead of scanning backward until an older certificate happens
+# to download successfully.
+$mapDownload = Get-StepBlock -JobBlock $selectorJob -Step 'Download the shard map'
+Assert-Contract ($mapDownload -match '(?s)--branch master\s+--status completed\s+--limit 1\s+--json databaseId,conclusion') `
+    'PR selection does not treat the newest completed map workflow as the certification barrier'
+Assert-Contract (-not $mapDownload.Contains('for candidate in $candidates')) `
+    'PR selection can scan backward and reactivate an older invalidated certificate'
+Assert-Contract ($mapDownload.Contains('refusing to fall back to an older map')) `
+    'missing or failed newest-map certification does not announce its fail-closed behavior'
+
 # The map builder publishes a new candidate, but only the previous candidate that was exercised by
 # a complete coverage run may become certified. Reusing one artifact name for both states recreates
 # the original unproven-rollout bug.

--- a/tools/TestImpact/Test-CiImpactWorkflow.ps1
+++ b/tools/TestImpact/Test-CiImpactWorkflow.ps1
@@ -171,8 +171,8 @@ $buildHeader = Get-JobHeader -JobBlock $buildJob
 $buildUpload = Get-StepBlock -JobBlock $buildJob -Step 'Upload build artifacts'
 Assert-Contract ($buildHeader.Contains('artifact_id: ${{ steps.upload-build-artifact.outputs.artifact-id }}')) `
     'build does not expose the immutable artifact ID to its consumers'
-Assert-Contract ($buildHeader.Contains('artifact_digest: ${{ steps.upload-build-artifact.outputs.artifact-digest }}')) `
-    'build does not expose the upload digest to its consumers'
+Assert-Contract ($buildHeader.Contains("artifact_digest: `${{ format('sha256:{0}', steps.upload-build-artifact.outputs.artifact-digest) }}")) `
+    'build does not expose the upload digest in the receiver''s canonical SHA-256 form'
 Assert-Contract ($buildUpload.Contains('id: upload-build-artifact')) `
     'the build artifact upload has no stable step identity for its outputs'
 

--- a/tools/TestImpact/Test-CiImpactWorkflow.ps1
+++ b/tools/TestImpact/Test-CiImpactWorkflow.ps1
@@ -17,7 +17,8 @@
 param(
     [string] $ValidationWorkflow = '.github/workflows/sonarcloud.yml',
     [string] $MapWorkflow = '.github/workflows/test-impact-map.yml',
-    [string] $CertifiedMapResolver = 'tools/TestImpact/Resolve-CertifiedShardMap.ps1'
+    [string] $CertifiedMapResolver = 'tools/TestImpact/Resolve-CertifiedShardMap.ps1',
+    [string] $RequiredArtifactReceiver = 'tools/TestImpact/Receive-RequiredArtifact.ps1'
 )
 
 Set-StrictMode -Version Latest
@@ -104,6 +105,7 @@ function Get-ContinuedShellCommand {
 $validation = Get-Content -LiteralPath $ValidationWorkflow -Raw
 $map = Get-Content -LiteralPath $MapWorkflow -Raw
 $certifiedMapResolverText = Get-Content -LiteralPath $CertifiedMapResolver -Raw
+$requiredArtifactReceiverText = Get-Content -LiteralPath $RequiredArtifactReceiver -Raw
 
 # Every job in this list consumes meaningful runner time. Dependency-based incidental skipping is
 # not enough: a dependency can be removed during a refactor while the job remains runnable. Each
@@ -157,6 +159,75 @@ Assert-Contract ([bool] $selfTestStep) `
     'select-shards no longer runs the impact tooling self-tests'
 Assert-Contract (-not $selfTestStep.Contains('continue-on-error: true')) `
     'checked-in impact tooling can fail its self-tests while CI remains green'
+Assert-Contract ($selfTestStep.Contains('./tools/TestImpact/Receive-RequiredArtifact.ps1 -SelfTest')) `
+    'the required-artifact transport policy is not executed against its self-tests'
+
+# A 100+ shard fan-out must not resolve the same build artifact by name in every job. That path calls
+# ListArtifacts concurrently and GitHub responds with a secondary-rate-limit 403. The build publishes
+# the immutable ID and digest once; both consumer matrices use the tested direct receiver, retain hard
+# failure on exhaustion, and suppress output uploads when their prerequisite never arrived.
+$buildJob = Get-JobBlock -WorkflowText $validation -Job 'build'
+$buildHeader = Get-JobHeader -JobBlock $buildJob
+$buildUpload = Get-StepBlock -JobBlock $buildJob -Step 'Upload build artifacts'
+Assert-Contract ($buildHeader.Contains('artifact_id: ${{ steps.upload-build-artifact.outputs.artifact-id }}')) `
+    'build does not expose the immutable artifact ID to its consumers'
+Assert-Contract ($buildHeader.Contains('artifact_digest: ${{ steps.upload-build-artifact.outputs.artifact-digest }}')) `
+    'build does not expose the upload digest to its consumers'
+Assert-Contract ($buildUpload.Contains('id: upload-build-artifact')) `
+    'the build artifact upload has no stable step identity for its outputs'
+
+Assert-Contract ($requiredArtifactReceiverText.Contains('enum ArtifactRequestDisposition')) `
+    'artifact retry state is represented by strings instead of a closed type'
+Assert-Contract ($requiredArtifactReceiverText.Contains('actions/artifacts/$ArtifactId/zip')) `
+    'required artifact transport does not use the immutable-ID archive endpoint'
+Assert-Contract (-not $requiredArtifactReceiverText.Contains('ArtifactService/ListArtifacts')) `
+    'required artifact transport still performs the rate-limited artifact-list lookup'
+Assert-Contract ($requiredArtifactReceiverText.Contains('Test-ArtifactDigest')) `
+    'direct artifact transport does not validate the upload digest before extraction'
+Assert-Contract ($requiredArtifactReceiverText.Contains('secondary rate limit')) `
+    'artifact transport does not distinguish transient throttling from a permission denial'
+Assert-Contract ($requiredArtifactReceiverText.Contains('Start-Sleep -Seconds $delay')) `
+    'artifact transport retries immediately instead of applying its tested backoff policy'
+Assert-Contract ($requiredArtifactReceiverText.Contains('$PSNativeCommandUseErrorActionPreference = $false')) `
+    'native-command error handling can bypass the typed artifact retry policy'
+
+$artifactConsumers = @('test-net10-sharded', 'model-shape-conformance-windows')
+foreach ($job in $artifactConsumers) {
+    $consumer = Get-JobBlock -WorkflowText $validation -Job $job
+    $header = Get-JobHeader -JobBlock $consumer
+    $download = Get-StepBlock -JobBlock $consumer -Step 'Download required build artifact'
+    Assert-Contract ([bool] $download) `
+        "artifact consumer '$job' does not use the required-artifact transport"
+    Assert-Contract ($download.Contains('./tools/TestImpact/Receive-RequiredArtifact.ps1')) `
+        "artifact consumer '$job' bypasses the tested receiver"
+    Assert-Contract ($download.Contains("-ArtifactId '`${{ needs.build.outputs.artifact_id }}'")) `
+        "artifact consumer '$job' does not bind the immutable build artifact ID"
+    Assert-Contract ($download.Contains("-ExpectedDigest '`${{ needs.build.outputs.artifact_digest }}'")) `
+        "artifact consumer '$job' does not bind the build artifact digest"
+    Assert-Contract (-not $download.Contains('continue-on-error: true')) `
+        "artifact consumer '$job' can pass without its required build output"
+    Assert-Contract ($download.Contains('timeout-minutes: 25')) `
+        "artifact consumer '$job' does not reserve the bounded retry and extraction budget"
+    Assert-Contract (-not $consumer.Contains('Retry build artifact download')) `
+        "artifact consumer '$job' retains the immediate retry that caused repeated 403 responses"
+    Assert-Contract ($header -match '(?m)^      actions: read\s*$') `
+        "artifact consumer '$job' lacks actions:read for the archive endpoint"
+}
+
+$testConsumer = Get-JobBlock -WorkflowText $validation -Job 'test-net10-sharded'
+foreach ($stepName in @(
+    'Upload test-impact digest',
+    'Upload coverage + test results',
+    'Upload crash evidence',
+    'Upload compact test diagnostics')) {
+    $upload = Get-StepBlock -JobBlock $testConsumer -Step $stepName
+    Assert-Contract ($upload.Contains("if: always() && steps.download-build-artifacts.outcome == 'success'")) `
+        "'$stepName' can amplify an artifact-service failure after the required download failed"
+}
+$shapeConsumer = Get-JobBlock -WorkflowText $validation -Job 'model-shape-conformance-windows'
+$shapeUpload = Get-StepBlock -JobBlock $shapeConsumer -Step 'Upload window report'
+Assert-Contract ($shapeUpload.Contains("if: always() && steps.download-build-artifacts.outcome == 'success'")) `
+    'shape-conformance can upload after its required build artifact was unavailable'
 
 $promotion = Get-JobBlock -WorkflowText $validation -Job 'promote-ci-test-analysis'
 Assert-Contract ($promotion.Contains("needs.validation-source.outputs.reuse == 'true'")) `

--- a/tools/TestImpact/Test-CiImpactWorkflow.ps1
+++ b/tools/TestImpact/Test-CiImpactWorkflow.ps1
@@ -223,10 +223,27 @@ Assert-Contract ($map.Contains("candidate_ready: `${{ steps.source.outputs.found
     'map workflow does not expose whether this invocation produced a candidate'
 Assert-Contract ($map.Contains("if: steps.audit.outputs.certified == 'true'")) `
     'certified artifact upload is not gated by the audit decision'
-Assert-Contract ($map.Contains("(Join-Path `$auditTools 'New-ShardMapCertificate.ps1')")) `
+$mapBuildJob = Get-JobBlock -WorkflowText $map -Job 'build-map'
+$auditStep = Get-StepBlock -JobBlock $mapBuildJob -Step 'Audit selection against the source run'
+$auditRead = '$a = Get-Content audit.json -Raw | ConvertFrom-Json'
+$certificateInvocation = "& (Join-Path `$auditTools 'New-ShardMapCertificate.ps1')"
+$auditReadIndex = $auditStep.IndexOf($auditRead, [StringComparison]::Ordinal)
+$certificateIndex = $auditStep.IndexOf($certificateInvocation, [StringComparison]::Ordinal)
+Assert-Contract ($certificateIndex -ge 0) `
     'the workflow does not execute the tested certification policy'
-Assert-Contract (-not ($map -match '\$a\.Failed -gt 0')) `
-    'map certification still depends on a naturally occurring shard failure'
+Assert-Contract ($auditReadIndex -ge 0 -and $certificateIndex -gt $auditReadIndex) `
+    'the workflow invokes certification before loading the audited result'
+Assert-Contract ($auditStep -match "(?m)^          $([Regex]::Escape($certificateInvocation))") `
+    'the certificate invocation is nested under a conditional instead of running at audit scope'
+if ($auditReadIndex -ge 0 -and $certificateIndex -gt $auditReadIndex) {
+    $beforeCertificate = $auditStep.Substring(
+        $auditReadIndex + $auditRead.Length,
+        $certificateIndex - ($auditReadIndex + $auditRead.Length))
+    Assert-Contract (-not ($beforeCertificate -match '(?m)^\s*(?:if|elseif|switch|foreach|while|do|return|exit)\b')) `
+        'control flow between audit loading and certification can bypass certificate generation'
+    Assert-Contract (-not $beforeCertificate.Contains('$a.Failed')) `
+        'certificate generation is gated on the observed shard failure count'
+}
 Assert-Contract ($map -match "if \[ '.*needs\.build-map\.result.*' = 'success' \] && \[ '.*candidate_ready.*' = 'true' \]") `
     'coverage dispatch can cite the current map run when no candidate was produced'
 

--- a/tools/TestImpact/Test-CiImpactWorkflow.ps1
+++ b/tools/TestImpact/Test-CiImpactWorkflow.ps1
@@ -16,7 +16,8 @@
 [CmdletBinding()]
 param(
     [string] $ValidationWorkflow = '.github/workflows/sonarcloud.yml',
-    [string] $MapWorkflow = '.github/workflows/test-impact-map.yml'
+    [string] $MapWorkflow = '.github/workflows/test-impact-map.yml',
+    [string] $CertifiedMapResolver = 'tools/TestImpact/Resolve-CertifiedShardMap.ps1'
 )
 
 Set-StrictMode -Version Latest
@@ -102,6 +103,7 @@ function Get-ContinuedShellCommand {
 
 $validation = Get-Content -LiteralPath $ValidationWorkflow -Raw
 $map = Get-Content -LiteralPath $MapWorkflow -Raw
+$certifiedMapResolverText = Get-Content -LiteralPath $CertifiedMapResolver -Raw
 
 # Every job in this list consumes meaningful runner time. Dependency-based incidental skipping is
 # not enough: a dependency can be removed during a refactor while the job remains runnable. Each
@@ -182,23 +184,25 @@ Assert-Contract ($gate -match '(?s)if \[ "\$REUSED_VALIDATION" = "true" \].*?pro
 # authorization boundary now; no second switch may silently restore the full matrix.
 Assert-Contract (-not $validation.Contains('TEST_IMPACT_MODE')) `
     'TEST_IMPACT_MODE shadow/enforce switching is still present'
-Assert-Contract ($validation.Contains('certified-shard-map')) `
+Assert-Contract ($certifiedMapResolverText.Contains('--name certified-shard-map')) `
     'PR selection does not consume a certified map artifact'
 Assert-Contract ($validation.Contains('candidate-shard-map')) `
     'coverage audit runs do not consume an explicit candidate map artifact'
-Assert-Contract ($validation -match '(?s)if \[ "\$FORCE_COVERAGE" = ''true'' \].*?--name candidate-shard-map.*?else.*?--name certified-shard-map') `
+Assert-Contract (
+    $validation -match '(?s)if \[ "\$FORCE_COVERAGE" = ''true'' \].*?--name candidate-shard-map.*?else' -and
+    $certifiedMapResolverText.Contains('--name certified-shard-map')) `
     'candidate and certified artifacts are not separated at the execution boundary'
 
 # A later map audit is also a revocation boundary. If it fails or withholds certification after a
 # miss, selection must fail closed instead of scanning backward until an older certificate happens
 # to download successfully.
 $mapDownload = Get-StepBlock -JobBlock $selectorJob -Step 'Download the shard map'
-Assert-Contract ($mapDownload -match '(?s)--branch master\s+--status completed\s+--limit 1\s+--json databaseId,conclusion') `
-    'PR selection does not treat the newest completed map workflow as the certification barrier'
-Assert-Contract (-not $mapDownload.Contains('for candidate in $candidates')) `
-    'PR selection can scan backward and reactivate an older invalidated certificate'
-Assert-Contract ($mapDownload.Contains('refusing to fall back to an older map')) `
-    'missing or failed newest-map certification does not announce its fail-closed behavior'
+Assert-Contract ($mapDownload.Contains('./tools/TestImpact/Resolve-CertifiedShardMap.ps1')) `
+    'PR selection bypasses the executable certified-map resolver'
+Assert-Contract ($mapDownload.Contains('-ResultFile map-resolution.json')) `
+    'PR selection does not consume the resolver decision explicitly'
+Assert-Contract ($validation.Contains('./tools/TestImpact/Resolve-CertifiedShardMap.ps1 -SelfTest')) `
+    'the certified-map revocation policy is not executed against its adversarial fixtures'
 
 # The map builder publishes a new candidate, but only the previous candidate that was exercised by
 # a complete coverage run may become certified. Reusing one artifact name for both states recreates

--- a/tools/TestImpact/Test-CiImpactWorkflow.ps1
+++ b/tools/TestImpact/Test-CiImpactWorkflow.ps1
@@ -180,6 +180,8 @@ Assert-Contract ($requiredArtifactReceiverText.Contains('enum ArtifactRequestDis
     'artifact retry state is represented by strings instead of a closed type'
 Assert-Contract ($requiredArtifactReceiverText.Contains('actions/artifacts/$ArtifactId/zip')) `
     'required artifact transport does not use the immutable-ID archive endpoint'
+Assert-Contract ($requiredArtifactReceiverText.Contains("--proto-redir '=https'")) `
+    'required artifact transport permits a redirect to downgrade from HTTPS'
 Assert-Contract (-not $requiredArtifactReceiverText.Contains('ArtifactService/ListArtifacts')) `
     'required artifact transport still performs the rate-limited artifact-list lookup'
 Assert-Contract ($requiredArtifactReceiverText.Contains('Test-ArtifactDigest')) `

--- a/tools/TestImpact/Test-CiImpactWorkflow.ps1
+++ b/tools/TestImpact/Test-CiImpactWorkflow.ps1
@@ -198,14 +198,20 @@ Assert-Contract ($map.Contains('name: certified-shard-map')) `
     'map workflow does not publish certified-shard-map'
 Assert-Contract ($map.Contains('certification.json')) `
     'certified map artifact has no provenance record'
+Assert-Contract ($map.Contains('./tools/TestImpact/Measure-SelectionMiss.ps1 -SelfTest')) `
+    'map certification can run without first proving that skipped failures are detected'
+Assert-Contract ($map.Contains('./tools/TestImpact/New-ShardMapCertificate.ps1 -SelfTest')) `
+    'the shipping certification policy is not tested before use'
 Assert-Contract ($map.Contains('found=false')) `
     'automatic no-source bootstrap is still represented as a workflow failure'
 Assert-Contract ($map.Contains("candidate_ready: `${{ steps.source.outputs.found }}")) `
     'map workflow does not expose whether this invocation produced a candidate'
 Assert-Contract ($map.Contains("if: steps.audit.outputs.certified == 'true'")) `
     'certified artifact upload is not gated by the audit decision'
-Assert-Contract ($map -match '(?s)if \(\$auditExit -eq 0.*?\$a\.WouldSkip -gt 0.*?\$a\.Failed -gt 0\)') `
-    'map certification does not require a real failing-shard opportunity as well as reduction'
+Assert-Contract ($map.Contains("(Join-Path `$auditTools 'New-ShardMapCertificate.ps1')")) `
+    'the workflow does not execute the tested certification policy'
+Assert-Contract (-not ($map -match '\$a\.Failed -gt 0')) `
+    'map certification still depends on a naturally occurring shard failure'
 Assert-Contract ($map -match "if \[ '.*needs\.build-map\.result.*' = 'success' \] && \[ '.*candidate_ready.*' = 'true' \]") `
     'coverage dispatch can cite the current map run when no candidate was produced'
 

--- a/tools/TestImpact/Test-TestImpactEndToEnd.ps1
+++ b/tools/TestImpact/Test-TestImpactEndToEnd.ps1
@@ -9,6 +9,8 @@ Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
 $selector = Join-Path $PSScriptRoot 'Select-Shards.ps1'
+$missMeasurer = Join-Path $PSScriptRoot 'Measure-SelectionMiss.ps1'
+$certificateWriter = Join-Path $PSScriptRoot 'New-ShardMapCertificate.ps1'
 $certificateValidator = Join-Path $PSScriptRoot 'Test-CertifiedShardMap.ps1'
 $tempRoot = [IO.Path]::GetFullPath([IO.Path]::GetTempPath())
 $fixture = Join-Path $tempRoot ("aidotnet-impact-e2e-" + [guid]::NewGuid().ToString('N'))
@@ -37,7 +39,7 @@ function Assert-CertificateRejected {
 
     $message = $null
     try {
-        & $certificateValidator -MapFile shard-map.json -CertificateFile $CertificateFile `
+        & $certificateValidator -MapFile certified/shard-map.json -CertificateFile $CertificateFile `
             -CertificationRunId 102
     }
     catch { $message = [string] $_.Exception.Message }
@@ -83,23 +85,35 @@ try {
             }
         }
         $map | ConvertTo-Json -Depth 8 | Set-Content -LiteralPath shard-map.json -Encoding utf8
+        @(
+            [ordered]@{ shard = 'Alpha'; outcome = 'success' },
+            [ordered]@{ shard = 'Beta'; outcome = 'success' },
+            [ordered]@{ shard = 'Always'; outcome = 'success' }
+        ) | ConvertTo-Json -Depth 3 | Set-Content -LiteralPath outcomes.json -Encoding utf8
         [ordered]@{
-            schemaVersion = 1
-            candidateMapRunId = 100
-            candidateMapSha = $baseSha
-            auditSourceRunId = 101
-            auditSourceSha = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
-            certificationRunId = 102
-            escalated = $false
-            wouldRun = 2
-            wouldSkip = 1
-            failedShards = 1
-            missCount = 0
-        } | ConvertTo-Json -Depth 5 | Set-Content -LiteralPath certification.json -Encoding utf8
+            Escalated = $false
+            TotalShards = 3
+            WouldRun = 2
+            WouldSkip = 1
+            WouldRunShards = @('Alpha', 'Always')
+            WouldSkipShards = @('Beta')
+            Failed = 0
+            Missed = @()
+            MissCount = 0
+        } | ConvertTo-Json -Depth 3 | Set-Content -LiteralPath audit.json -Encoding utf8
+
+        & $certificateWriter -MapFile shard-map.json -AuditFile audit.json -OutcomesFile outcomes.json `
+            -CandidateMapRunId 100 -AuditSourceRunId 101 `
+            -AuditSourceSha 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' `
+            -CertificationRunId 102 -OutDirectory certified
+        if ($LASTEXITCODE -ne 0 -or -not (Test-Path -LiteralPath certified/certification.json)) {
+            throw 'the real certification policy did not produce a certificate for the clean complete audit'
+        }
 
         $global:LASTEXITCODE = 97
         try {
-            & $certificateValidator -MapFile shard-map.json -CertificateFile certification.json `
+            & $certificateValidator -MapFile certified/shard-map.json `
+                -CertificateFile certified/certification.json `
                 -CertificationRunId 102
             if ($LASTEXITCODE -ne 0) {
                 throw "validator returned exit code $LASTEXITCODE"
@@ -113,7 +127,7 @@ try {
             Set-Content -LiteralPath src/Feature.cs -Encoding utf8
         Invoke-Git add src/Feature.cs
         Invoke-Git commit --quiet -m narrow-change
-        & $selector -MapFile shard-map.json -ExpectedShards @('Alpha', 'Beta', 'Always') `
+        & $selector -MapFile certified/shard-map.json -ExpectedShards @('Alpha', 'Beta', 'Always') `
             -OutFile selection.json
         $selection = Get-Content selection.json -Raw | ConvertFrom-Json
         Assert-True (-not [bool] $selection.escalate) 'a covered one-line edit escalated'
@@ -122,28 +136,63 @@ try {
         Assert-True ($selection.shards -contains 'Always') 'the always-run shard was omitted'
         Assert-True (-not ($selection.shards -contains 'Beta')) 'an unaffected shard was selected'
 
+        # Prove the real selector -> miss measurement -> certificate chain in both directions. A
+        # failure in Alpha was selected and therefore remains certifiable; the same failure in Beta
+        # was skipped and must make Measure-SelectionMiss fail and suppress certificate creation.
+        @(
+            [ordered]@{ shard = 'Alpha'; outcome = 'failure' },
+            [ordered]@{ shard = 'Beta'; outcome = 'success' },
+            [ordered]@{ shard = 'Always'; outcome = 'success' }
+        ) | ConvertTo-Json -Depth 3 | Set-Content -LiteralPath selected-failure-outcomes.json -Encoding utf8
+        & $missMeasurer -SelectorPath $selector -MapFile certified/shard-map.json `
+            -OutcomesFile selected-failure-outcomes.json -OutFile selected-failure-audit.json
+        Assert-True ($LASTEXITCODE -eq 0) 'a selected shard failure was incorrectly reported as a miss'
+        & $certificateWriter -MapFile certified/shard-map.json -AuditFile selected-failure-audit.json `
+            -OutcomesFile selected-failure-outcomes.json -CandidateMapRunId 100 `
+            -AuditSourceRunId 101 -AuditSourceSha 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' `
+            -CertificationRunId 103 -OutDirectory selected-failure-certified
+        Assert-True ($LASTEXITCODE -eq 0 -and
+            (Test-Path -LiteralPath selected-failure-certified/certification.json)) `
+            'the end-to-end chain rejected a complete audit whose only failure was selected'
+
+        @(
+            [ordered]@{ shard = 'Alpha'; outcome = 'success' },
+            [ordered]@{ shard = 'Beta'; outcome = 'failure' },
+            [ordered]@{ shard = 'Always'; outcome = 'success' }
+        ) | ConvertTo-Json -Depth 3 | Set-Content -LiteralPath missed-failure-outcomes.json -Encoding utf8
+        & $missMeasurer -SelectorPath $selector -MapFile certified/shard-map.json `
+            -OutcomesFile missed-failure-outcomes.json -OutFile missed-failure-audit.json
+        Assert-True ($LASTEXITCODE -eq 1) 'a skipped shard failure did not fail the miss audit'
+        & $certificateWriter -MapFile certified/shard-map.json -AuditFile missed-failure-audit.json `
+            -OutcomesFile missed-failure-outcomes.json -CandidateMapRunId 100 `
+            -AuditSourceRunId 101 -AuditSourceSha 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' `
+            -CertificationRunId 104 -OutDirectory missed-failure-certified
+        Assert-True ($LASTEXITCODE -eq 0 -and
+            -not (Test-Path -LiteralPath missed-failure-certified/certification.json)) `
+            'the end-to-end chain certified a map after selection skipped a failing shard'
+
         New-Item -ItemType Directory -Path .github/workflows -Force | Out-Null
         'name: changed-ci' | Set-Content -LiteralPath .github/workflows/fixture.yml -Encoding utf8
         Invoke-Git add .github/workflows/fixture.yml
         Invoke-Git commit --quiet -m infrastructure-change
-        & $selector -MapFile shard-map.json -ExpectedShards @('Alpha', 'Beta', 'Always') `
+        & $selector -MapFile certified/shard-map.json -ExpectedShards @('Alpha', 'Beta', 'Always') `
             -OutFile infrastructure-selection.json
         $infrastructure = Get-Content infrastructure-selection.json -Raw | ConvertFrom-Json
         Assert-True ([bool] $infrastructure.escalate) 'a workflow edit did not fail closed to the full matrix'
 
-        $badCertificate = Get-Content certification.json -Raw | ConvertFrom-Json
+        $badCertificate = Get-Content certified/certification.json -Raw | ConvertFrom-Json
         $badCertificate.missCount = 1
         $badCertificate | ConvertTo-Json -Depth 5 | Set-Content bad-certification.json -Encoding utf8
         Assert-CertificateRejected -CertificateFile bad-certification.json `
             -ExpectedPattern 'selection miss' `
             -What 'a certificate recording a selection miss was accepted'
 
-        $badCertificate = Get-Content certification.json -Raw | ConvertFrom-Json
-        $badCertificate.failedShards = 0
-        $badCertificate | ConvertTo-Json -Depth 5 | Set-Content no-failure-certification.json -Encoding utf8
-        Assert-CertificateRejected -CertificateFile no-failure-certification.json `
-            -ExpectedPattern 'failedShards must be at least 1' `
-            -What 'a certificate without a failure opportunity was accepted'
+        $badCertificate = Get-Content certified/certification.json -Raw | ConvertFrom-Json
+        $badCertificate.failedShards = -1
+        $badCertificate | ConvertTo-Json -Depth 5 | Set-Content negative-failure-certification.json -Encoding utf8
+        Assert-CertificateRejected -CertificateFile negative-failure-certification.json `
+            -ExpectedPattern 'failedShards must be at least 0' `
+            -What 'a certificate with a negative failure count was accepted'
     }
     finally {
         Pop-Location

--- a/tools/TestImpact/Test-TestImpactEndToEnd.ps1
+++ b/tools/TestImpact/Test-TestImpactEndToEnd.ps1
@@ -154,6 +154,11 @@ try {
         Assert-True ($LASTEXITCODE -eq 0 -and
             (Test-Path -LiteralPath selected-failure-certified/certification.json)) `
             'the end-to-end chain rejected a complete audit whose only failure was selected'
+        & $certificateValidator -MapFile selected-failure-certified/shard-map.json `
+            -CertificateFile selected-failure-certified/certification.json `
+            -CertificationRunId 103
+        Assert-True ($LASTEXITCODE -eq 0) `
+            'the validator rejected a generated certificate with a selected failure'
 
         @(
             [ordered]@{ shard = 'Alpha'; outcome = 'success' },

--- a/tools/TestImpact/Test-TestImpactEndToEnd.ps1
+++ b/tools/TestImpact/Test-TestImpactEndToEnd.ps1
@@ -165,9 +165,14 @@ try {
             [ordered]@{ shard = 'Beta'; outcome = 'failure' },
             [ordered]@{ shard = 'Always'; outcome = 'success' }
         ) | ConvertTo-Json -Depth 3 | Set-Content -LiteralPath missed-failure-outcomes.json -Encoding utf8
-        & $missMeasurer -SelectorPath $selector -MapFile certified/shard-map.json `
-            -OutcomesFile missed-failure-outcomes.json -OutFile missed-failure-audit.json
-        Assert-True ($LASTEXITCODE -eq 1) 'a skipped shard failure did not fail the miss audit'
+        $expectedMissOutput = @(& $missMeasurer -SelectorPath $selector `
+            -MapFile certified/shard-map.json -OutcomesFile missed-failure-outcomes.json `
+            -OutFile missed-failure-audit.json 6>&1)
+        $expectedMissExit = $LASTEXITCODE
+        foreach ($line in $expectedMissOutput) {
+            Write-Host (('[expected miss] ' + [string] $line) -replace '::error::', '')
+        }
+        Assert-True ($expectedMissExit -eq 1) 'a skipped shard failure did not fail the miss audit'
         & $certificateWriter -MapFile certified/shard-map.json -AuditFile missed-failure-audit.json `
             -OutcomesFile missed-failure-outcomes.json -CandidateMapRunId 100 `
             -AuditSourceRunId 101 -AuditSourceSha 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' `
@@ -180,8 +185,13 @@ try {
         'name: changed-ci' | Set-Content -LiteralPath .github/workflows/fixture.yml -Encoding utf8
         Invoke-Git add .github/workflows/fixture.yml
         Invoke-Git commit --quiet -m infrastructure-change
-        & $selector -MapFile certified/shard-map.json -ExpectedShards @('Alpha', 'Beta', 'Always') `
-            -OutFile infrastructure-selection.json
+        $expectedEscalationOutput = @(& $selector -MapFile certified/shard-map.json `
+            -ExpectedShards @('Alpha', 'Beta', 'Always') -OutFile infrastructure-selection.json 6>&1)
+        $expectedEscalationExit = $LASTEXITCODE
+        foreach ($line in $expectedEscalationOutput) {
+            Write-Host (('[expected escalation] ' + [string] $line) -replace '::warning::', '')
+        }
+        Assert-True ($expectedEscalationExit -eq 0) 'an infrastructure edit made the selector fail'
         $infrastructure = Get-Content infrastructure-selection.json -Raw | ConvertFrom-Json
         Assert-True ([bool] $infrastructure.escalate) 'a workflow edit did not fail closed to the full matrix'
 


### PR DESCRIPTION
## Root cause

PR #2072 produced only `candidate-shard-map` artifacts, while PR selection accepts only `certified-shard-map`. Certification also required a naturally failing shard, so a healthy complete matrix could never certify a map. Every PR therefore failed closed to all 116 shards.

## Fix

- move certificate creation into a directly testable policy script
- certify a healthy, complete, non-escalated zero-miss audit
- verify the exact selected/skipped shard identities, not just aggregate counts
- reject missing, duplicate, unknown, overlapping, cancelled, or skipped outcomes
- bind the map, audited source, and artifact to typed run IDs and lowercase Git SHAs
- exercise the real selector -> audit -> certificate -> validator path end to end

The separate push-to-master exact-tree reuse path is intentionally unchanged: it is already live-proven on master/release runs 33961808681 and 34075658280, where the resolver succeeded and Build, compatibility pack, shard selection, and CodeQL were skipped.

## Proof

- all six TestImpact self-tests pass
- adversarial skipped-failure test rejects certification
- end-to-end covered edit selects 2/3 shards
- workflow edit escalates to the complete matrix
- CI workflow contract passes for all 11 expensive jobs
- reuse/full/default CI Gate mode proof passes
- both workflow YAML files pass yaml-lint

## Rollout behavior

The first coverage run after merge still performs the complete audit. A successful audit publishes the first certified map; subsequent PRs can then run only affected shards. Live reduced-PR proof is necessarily post-merge because current master cannot consume an artifact produced by untrusted PR code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated certification for validated shard maps with complete coverage and reduced test execution.
  * Added reliable artifact retrieval with digest validation and retry handling.
  * Added workflow warnings and summaries when shard selection is degraded or certification is unavailable.

* **Bug Fixes**
  * Strengthened certificate validation for coverage, partitioning, failure counts, and schema consistency.
  * Certified maps now resolve only from the latest completed workflow run, failing closed when unavailable.
  * Extended analysis workflow time limits for slower builds.

* **Tests**
  * Expanded contract, self-test, and end-to-end coverage for certification, artifact handling, shard selection, and rejection scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->