### PR TITLE
feat(models): declare paper training recipes, batch 3 (#1928)

### DIFF
--- a/src/Audio/Classification/AudioSep.cs
+++ b/src/Audio/Classification/AudioSep.cs
@@ -1,3 +1,4 @@
+using AiDotNet.LearningRateSchedulers;
 using AiDotNet.Attributes;
 using AiDotNet.Audio.Features;
 using AiDotNet.Diffusion.Audio;
@@ -66,6 +67,9 @@ namespace AiDotNet.Audio.Classification;
 [ModelComplexity(ModelComplexity.High)]
 [ModelInput(typeof(Tensor<>), typeof(Tensor<>))]
 [ResearchPaper("Separate Anything You Describe", "https://arxiv.org/abs/2308.05037", Year = 2024, Authors = "Xubo Liu, Qiuqiang Kong, Yan Zhao, Haohe Liu, Yi Yuan, Yuzhuo Liu, Rui Xia, Yuxuan Wang, Mark D. Plumbley, Wenwu Wang")]
+[PaperOptimizer(OptimizerKind.Adam, LearningRate = 1e-3, ReferenceBatchSize = 96,
+                Source = "Liu et al. 2023, Sec. 4.1: an Adam optimizer with a learning rate of 1e-3 and "
+                        + "a batch size of 96.")]
 public partial class AudioSep<T> : AudioClassifierBase<T>, IAudioEventDetector<T>
 {
     #region Fields
@@ -111,7 +115,9 @@ public partial class AudioSep<T> : AudioClassifierBase<T>, IAudioEventDetector<T
     {
         _options = options ?? new AudioSepOptions();
         _useNativeMode = true;
-        _optimizer = optimizer ?? new AdamWOptimizer<T, Tensor<T>, Tensor<T>>(this);
+        _optimizer = optimizer
+    ?? PaperOptimizerFactory.CreateFor<T, Tensor<T>, Tensor<T>>(this)
+    ?? new AdamWOptimizer<T, Tensor<T>, Tensor<T>>(this);
         base.SampleRate = _options.SampleRate;
         base.NumMels = _options.NumMels;
         ClassLabels = _options.CustomLabels ?? AudioSetLabels;

--- a/src/Audio/Classification/EAT.cs
+++ b/src/Audio/Classification/EAT.cs
@@ -1,3 +1,4 @@
+using AiDotNet.LearningRateSchedulers;
 using AiDotNet.Attributes;
 using AiDotNet.Audio.Features;
 using AiDotNet.Diffusion.Audio;
@@ -57,6 +58,23 @@ namespace AiDotNet.Audio.Classification;
 [ModelComplexity(ModelComplexity.High)]
 [ModelInput(typeof(Tensor<>), typeof(Tensor<>))]
 [ResearchPaper("EAT: Self-Supervised Pre-Training with Efficient Audio Transformer", "https://arxiv.org/abs/2401.03497", Year = 2024, Authors = "Wenxi Chen, Yuzhe Liang, Ziyang Ma, Zhisheng Zheng, Xie Chen")]
+[PaperOptimizer(OptimizerKind.AdamW, LearningRate = 5e-4, Beta1 = 0.9, Beta2 = 0.95,
+                WeightDecay = 0.05, ReferenceBatchSize = 12, MinLearningRate = 1e-6,
+                Schedule = LearningRateSchedulerType.CosineAnnealing,
+                Phase = TrainingPhase.PreTraining,
+                Source = "Chen et al. 2024, Appendix A.1 Table 4: AdamW with beta1 0.9 and beta2 0.95, "
+                        + "weight decay 0.05, a cosine schedule, a peak learning rate of 0.0005 decaying "
+                        + "to a minimum of 0.000001, and a batch size of 12 over 10 epochs of AS-2M. The "
+                        + "body text calls it Adam while citing Loshchilov and Hutter 2017, which is the "
+                        + "AdamW paper, and the appendix table names AdamW outright. The step and "
+                        + "warm-up rows of that table cannot be assigned to their columns from the "
+                        + "extracted text, so no warm-up length is declared.")]
+[PaperOptimizer(OptimizerKind.AdamW, LearningRate = 5e-5,
+                Phase = TrainingPhase.FineTuning,
+                Provenance = RecipeProvenance.PerDataset,
+                Source = "Chen et al. 2024, Appendix A.1 Table 4: fine-tuning uses a peak learning rate "
+                        + "of 0.00005 on AS-2M, AS-20K and ESC-50, and 0.0002 on SPC-2. The value "
+                        + "declared here is the one shared by three of the four datasets.")]
 public partial class EAT<T> : AudioClassifierBase<T>, IAudioEventDetector<T>
 {
     #region Fields
@@ -101,7 +119,9 @@ public partial class EAT<T> : AudioClassifierBase<T>, IAudioEventDetector<T>
     {
         _options = options ?? new EATOptions();
         _useNativeMode = true;
-        _optimizer = optimizer ?? new AdamWOptimizer<T, Tensor<T>, Tensor<T>>(this);
+        _optimizer = optimizer
+    ?? PaperOptimizerFactory.CreateFor<T, Tensor<T>, Tensor<T>>(this)
+    ?? new AdamWOptimizer<T, Tensor<T>, Tensor<T>>(this);
         base.SampleRate = _options.SampleRate; base.NumMels = _options.NumMels;
         ClassLabels = _options.CustomLabels ?? AudioSetLabels;
         _melSpectrogram = new MelSpectrogram<T>(_options.SampleRate, _options.NumMels, _options.FftSize, _options.HopLength, _options.FMin, _options.FMax, logMel: true);

--- a/src/Audio/Classification/HTSAT.cs
+++ b/src/Audio/Classification/HTSAT.cs
@@ -1,3 +1,4 @@
+using AiDotNet.LearningRateSchedulers;
 using AiDotNet.Attributes;
 using AiDotNet.Audio.Features;
 using AiDotNet.Diffusion.Audio;
@@ -62,6 +63,18 @@ namespace AiDotNet.Audio.Classification;
 [ModelComplexity(ModelComplexity.High)]
 [ModelInput(typeof(Tensor<>), typeof(Tensor<>))]
 [ResearchPaper("HTS-AT: A Hierarchical Token-Semantic Audio Transformer for Sound Classification and Detection", "https://arxiv.org/abs/2202.00874", Year = 2022, Authors = "Ke Chen, Xingjian Du, Bilei Zhu, Zejun Ma, Taylor Berg-Kirkpatrick, Shlomo Dubnov")]
+[PaperOptimizer(OptimizerKind.AdamW, Beta1 = 0.9, Beta2 = 0.999, Epsilon = 1e-8,
+                WeightDecay = 0.05, ReferenceBatchSize = 128, DecayRate = 0.5,
+                StepSize = 10, Schedule = LearningRateSchedulerType.Step,
+                ScheduleStepMode = SchedulerStepMode.StepPerEpoch,
+                Source = "Chen et al. 2022, Sec. 3.1.1: AdamW with beta1 0.9, beta2 0.999, eps 1e-8 and "
+                        + "a decay of 0.05, at a batch size of 128, warming up over three epochs and "
+                        + "then halving the learning rate every ten epochs. No learning rate is "
+                        + "declared: the paper's warm-up values of 0.05, 0.1 and 0.2 are far above any "
+                        + "workable absolute AdamW rate, and halving from 0.2 returns to 0.05 in exactly "
+                        + "two steps as the paper describes, so they read as multipliers on a base rate "
+                        + "the paper does not state. The halving schedule itself is scale free and is "
+                        + "declared.")]
 public partial class HTSAT<T> : AudioClassifierBase<T>, IAudioEventDetector<T>
 {
     #region Fields
@@ -129,7 +142,9 @@ public partial class HTSAT<T> : AudioClassifierBase<T>, IAudioEventDetector<T>
     {
         _options = options ?? new HTSATOptions();
         _useNativeMode = true;
-        _optimizer = optimizer ?? new AdamWOptimizer<T, Tensor<T>, Tensor<T>>(this);
+        _optimizer = optimizer
+    ?? PaperOptimizerFactory.CreateFor<T, Tensor<T>, Tensor<T>>(this)
+    ?? new AdamWOptimizer<T, Tensor<T>, Tensor<T>>(this);
         base.SampleRate = _options.SampleRate;
         base.NumMels = _options.NumMels;
         ClassLabels = _options.CustomLabels ?? AudioSetLabels;

--- a/src/Audio/Effects/AudioSuperResolution.cs
+++ b/src/Audio/Effects/AudioSuperResolution.cs
@@ -1,3 +1,4 @@
+using AiDotNet.LearningRateSchedulers;
 using AiDotNet.Attributes;
 using AiDotNet.Enums;
 using AiDotNet.Helpers;
@@ -53,6 +54,13 @@ namespace AiDotNet.Audio.Effects;
 [ModelComplexity(ModelComplexity.Medium)]
 [ModelInput(typeof(Tensor<>), typeof(Tensor<>))]
 [ResearchPaper("Audio Super Resolution using Neural Networks", "https://arxiv.org/abs/1708.00853", Year = 2017, Authors = "Volodymyr Kuleshov, S. Zayd Enam, Stefano Ermon")]
+[PaperOptimizer(OptimizerKind.Adam, LearningRate = 1e-4,
+                Source = "Kuleshov et al. 2017, Sec. 4.1: the ADAM optimizer with a learning rate of "
+                        + "1e-4, trained for 400 epochs on patches of length 6000. The model builds its "
+                        + "own AdamW optimizer at a caller-supplied rate that already defaults to this "
+                        + "1e-4, so the hand-built optimizer is verified against this record rather than "
+                        + "replaced -- routing it would discard a rate the caller set. The report notes "
+                        + "the paper says Adam where the model uses AdamW.")]
 public partial class AudioSuperResolution<T> : AudioNeuralNetworkBase<T>, IAudioEnhancer<T>
 {
     #region Fields
@@ -112,11 +120,12 @@ public partial class AudioSuperResolution<T> : AudioNeuralNetworkBase<T>, IAudio
     {
         _options = options ?? new AudioSuperResolutionOptions();
         _useNativeMode = true;
-        _optimizer = optimizer ?? new AdamWOptimizer<T, Tensor<T>, Tensor<T>>(this,
-            new AdamWOptimizerOptions<T, Tensor<T>, Tensor<T>>
-            {
-                InitialLearningRate = _options.LearningRate
-            });
+        _optimizer = optimizer ?? PaperOptimizerFactory.VerifyHandBuilt(this,
+            new AdamWOptimizer<T, Tensor<T>, Tensor<T>>(this,
+                new AdamWOptimizerOptions<T, Tensor<T>, Tensor<T>>
+                {
+                    InitialLearningRate = _options.LearningRate
+                }));
         base.SampleRate = _options.OutputSampleRate;
         InitializeLayers();
     }

--- a/src/Audio/Emotion/Emotion2Vec.cs
+++ b/src/Audio/Emotion/Emotion2Vec.cs
@@ -1,3 +1,4 @@
+using AiDotNet.LearningRateSchedulers;
 using AiDotNet.Attributes;
 using AiDotNet.Enums;
 using AiDotNet.Helpers;
@@ -46,6 +47,12 @@ namespace AiDotNet.Audio.Emotion;
 [ModelComplexity(ModelComplexity.High)]
 [ModelInput(typeof(Tensor<>), typeof(Tensor<>))]
 [ResearchPaper("emotion2vec: Self-Supervised Pre-Training for Speech Emotion Representation", "https://arxiv.org/abs/2312.15185", Year = 2023, Authors = "Ziyang Ma, Zhisheng Zheng, Jiaxin Ye, Jinchao Li, Zhifu Gao, Shiliang Zhang, Xie Chen")]
+[PaperOptimizer(OptimizerKind.Adam, LearningRate = 7.5e-5, WeightDecay = 0.01,
+                WarmupFraction = 0.05,
+                Schedule = LearningRateSchedulerType.CosineAnnealing,
+                Source = "Ma et al. 2023, Sec. 3.1: Adam with a learning rate of 7.5e-5 and a weight "
+                        + "decay of 1e-2, under a cosine learning rate scheduler with a linear warm-up "
+                        + "over 5 percent of training.")]
 public partial class Emotion2Vec<T> : AudioClassifierBase<T>, IEmotionRecognizer<T>
 {
     #region Fields
@@ -89,7 +96,9 @@ public partial class Emotion2Vec<T> : AudioClassifierBase<T>, IEmotionRecognizer
     {
         _options = options ?? new Emotion2VecOptions();
         _useNativeMode = true;
-        _optimizer = optimizer ?? new AdamWOptimizer<T, Tensor<T>, Tensor<T>>(this);
+        _optimizer = optimizer
+    ?? PaperOptimizerFactory.CreateFor<T, Tensor<T>, Tensor<T>>(this)
+    ?? new AdamWOptimizer<T, Tensor<T>, Tensor<T>>(this);
         base.SampleRate = _options.SampleRate;
         InitializeLayers();
     }

--- a/src/Audio/Foundations/Data2Vec2.cs
+++ b/src/Audio/Foundations/Data2Vec2.cs
@@ -1,3 +1,4 @@
+using AiDotNet.LearningRateSchedulers;
 using AiDotNet.Attributes;
 using AiDotNet.Enums;
 using AiDotNet.Helpers;
@@ -43,6 +44,16 @@ namespace AiDotNet.Audio.Foundations;
 [ModelComplexity(ModelComplexity.High)]
 [ModelInput(typeof(Tensor<>), typeof(Tensor<>))]
 [ResearchPaper("data2vec 2.0: Highly Efficient Self-Supervised Learning for Vision, Speech and Text", "https://arxiv.org/abs/2212.07525", Year = 2023, Authors = "Alexei Baevski, Arun Babu, Wei-Ning Hsu, Michael Auli")]
+[PaperOptimizer(OptimizerKind.Adam, LearningRate = 7.5e-4, Beta1 = 0.9, Beta2 = 0.98,
+                WeightDecay = 0.01, WarmupSteps = 8000,
+                Schedule = LearningRateSchedulerType.CosineAnnealing,
+                Phase = TrainingPhase.PreTraining,
+                Source = "Baevski et al. 2023, Table 9, Base Librispeech speech pre-training: Adam with "
+                        + "beta1 0.9 and beta2 0.98, a learning rate of 7.5e-4, weight decay 0.01, a "
+                        + "cosine schedule and 8,000 warmup updates over 400,000 updates. No reference "
+                        + "batch size is declared because the paper gives the batch in seconds of audio "
+                        + "(62.5 per GPU, 1,000 total) rather than in examples, and the linear scaling "
+                        + "rule compares example counts.")]
 public partial class Data2Vec2<T> : AudioNeuralNetworkBase<T>, IAudioFoundationModel<T>
 {
     /// <inheritdoc />
@@ -100,7 +111,9 @@ public partial class Data2Vec2<T> : AudioNeuralNetworkBase<T>, IAudioFoundationM
     {
         _options = options ?? new Data2Vec2Options();
         _useNativeMode = true;
-        _optimizer = optimizer ?? new AdamWOptimizer<T, Tensor<T>, Tensor<T>>(this);
+        _optimizer = optimizer
+    ?? PaperOptimizerFactory.CreateFor<T, Tensor<T>, Tensor<T>>(this)
+    ?? new AdamWOptimizer<T, Tensor<T>, Tensor<T>>(this);
         base.SampleRate = _options.SampleRate;
         InitializeLayers();
     }

--- a/src/ComputerVision/Segmentation/Common/SegmentationModelBase.cs
+++ b/src/ComputerVision/Segmentation/Common/SegmentationModelBase.cs
@@ -210,8 +210,24 @@ public abstract partial class SegmentationModelBase<T> : NeuralNetworkBase<T>, I
     /// default, so an undeclared model is unaffected.
     /// </remarks>
     protected virtual IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>> CreateDefaultOptimizer()
-        => PaperOptimizerFactory.CreateFor<T, Tensor<T>, Tensor<T>>(this)
-        ?? CreateAdamWOptimizer(DefaultLearningRate, DefaultWeightDecay);
+    {
+        // Only let the recipe BUILD when it states a learning rate. Many papers name an
+        // optimizer and its decay without a rate, and building from such a recipe silently
+        // replaces this model's own DefaultLearningRate -- which derived models override, often
+        // from caller-supplied options -- with the generic optimizer default. VisionMamba diverged
+        // exactly that way: loss 5.0 to 91.9, because its configured rate was discarded.
+        var recipe = PaperOptimizerFactory.Find(this);
+        if (recipe is not null && !double.IsNaN(recipe.LearningRate))
+        {
+            var built = PaperOptimizerFactory.CreateFor<T, Tensor<T>, Tensor<T>>(this);
+            if (built is not null) return built;
+        }
+
+        // Otherwise keep this model's own optimizer and let the declaration check it, so the
+        // paper is still recorded and any disagreement is still reported.
+        return PaperOptimizerFactory.VerifyHandBuilt(
+            this, CreateAdamWOptimizer(DefaultLearningRate, DefaultWeightDecay));
+    }
 
     /// <summary>
     /// Gets the base learning rate for the model's default AdamW training recipe.

--- a/src/ComputerVision/Segmentation/Foundation/UNINEXT.cs
+++ b/src/ComputerVision/Segmentation/Foundation/UNINEXT.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using AiDotNet.LearningRateSchedulers;
+using System.IO;
 using AiDotNet.Attributes;
 using AiDotNet.Enums;
 using AiDotNet.Helpers;
@@ -62,6 +63,8 @@ namespace AiDotNet.ComputerVision.Segmentation.Foundation;
 [ModelComplexity(ModelComplexity.High)]
 [ModelInput(typeof(Tensor<>), typeof(Tensor<>))]
 [ResearchPaper("Universal Instance Perception as Object Discovery and Retrieval", "https://arxiv.org/abs/2303.06674", Year = 2023, Authors = "Yan et al.")]
+[PaperOptimizer(OptimizerKind.AdamW, WeightDecay = 0.05,
+                Source = "Yan et al. 2023: AdamW with a weight decay of 0.05. No learning rate is declared because the paper states none in its training description.")]
 public partial class UNINEXT<T> : Common.PanopticSegmentationBase<T>
 {
     private readonly UNINEXTOptions _options;

--- a/src/ComputerVision/Segmentation/Foundation/XDecoder.cs
+++ b/src/ComputerVision/Segmentation/Foundation/XDecoder.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using AiDotNet.LearningRateSchedulers;
+using System.IO;
 using AiDotNet.Attributes;
 using AiDotNet.Enums;
 using AiDotNet.Helpers;
@@ -62,6 +63,9 @@ namespace AiDotNet.ComputerVision.Segmentation.Foundation;
 [ModelComplexity(ModelComplexity.High)]
 [ModelInput(typeof(Tensor<>), typeof(Tensor<>))]
 [ResearchPaper("Generalized Decoding for Pixel, Image, and Language", "https://arxiv.org/abs/2212.11270", Year = 2023, Authors = "Zou et al.")]
+[PaperOptimizer(OptimizerKind.AdamW, LearningRate = 1e-4,
+                Phase = TrainingPhase.PreTraining,
+                Source = "Zou et al. 2023: AdamW in pretraining with an initial learning rate of 1e-4.")]
 public partial class XDecoder<T> : Common.PanopticSegmentationBase<T>
 {
     private readonly XDecoderOptions _options;

--- a/src/ComputerVision/Segmentation/Mamba/VMamba.cs
+++ b/src/ComputerVision/Segmentation/Mamba/VMamba.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using AiDotNet.LearningRateSchedulers;
+using System.IO;
 using AiDotNet.Attributes;
 using AiDotNet.Enums;
 using AiDotNet.Helpers;
@@ -55,8 +56,28 @@ namespace AiDotNet.ComputerVision.Segmentation.Mamba;
 [ModelComplexity(ModelComplexity.Medium)]
 [ModelInput(typeof(Tensor<>), typeof(Tensor<>))]
 [ResearchPaper("VMamba: Visual State Space Model", "https://arxiv.org/abs/2401.10166", Year = 2024, Authors = "Liu et al.")]
+[PaperOptimizer(OptimizerKind.AdamW, Beta1 = 0.9, Beta2 = 0.999, LearningRate = 1e-3,
+                WeightDecay = 0.05, MinLearningRate = 0, ReferenceBatchSize = 1024,
+                WarmupFraction = 0.0667,
+                Phase = TrainingPhase.PreTraining,
+                Schedule = LearningRateSchedulerType.CosineAnnealing,
+                Source = "Liu et al. 2024: AdamW with betas (0.9, 0.999), an initial learning rate of 1e-3, weight decay 0.05 and a cosine decay scheduler, trained from scratch for 300 epochs with a 20-epoch warm-up at a batch size of 1024.")]
+[PaperOptimizer(OptimizerKind.AdamW, LearningRate = 6e-5,
+                Phase = TrainingPhase.FineTuning,
+                Source = "Liu et al. 2024: downstream training sets the learning rate to 6e-5.")]
 public partial class VMamba<T> : Common.SemanticSegmentationBase<T>
 {
+    /// <summary>Keeps this model's own optimizer and has the declaration verify it.</summary>
+    /// <remarks>
+    /// The paper trains for 300 epochs at 1e-3 with a batch of 1024. Neither form of that rate
+    /// suits a short run: applied as stated it diverges, and scaled linearly to a small batch it
+    /// is 3.1e-5, which moves the weights too little to register over ten steps. The record keeps
+    /// both numbers because they are what the paper says; the run keeps a rate that trains, and
+    /// the report states the difference rather than the declaration being trimmed to match.
+    /// </remarks>
+    protected override IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>> CreateDefaultOptimizer()
+        => PaperOptimizerFactory.VerifyHandBuilt(
+            this, CreateAdamWOptimizer(DefaultLearningRate, DefaultWeightDecay));
     private readonly VMambaOptions _options;
     public override ModelOptions GetOptions() => _options;
     protected override double DefaultLearningRate => _options.LearningRate;

--- a/src/ComputerVision/Segmentation/Mamba/ViMUNet.cs
+++ b/src/ComputerVision/Segmentation/Mamba/ViMUNet.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using AiDotNet.LearningRateSchedulers;
+using System.IO;
 using AiDotNet.Attributes;
 using AiDotNet.Enums;
 using AiDotNet.Helpers;
@@ -56,6 +57,9 @@ namespace AiDotNet.ComputerVision.Segmentation.Mamba;
 [ModelComplexity(ModelComplexity.Medium)]
 [ModelInput(typeof(Tensor<>), typeof(Tensor<>))]
 [ResearchPaper("ViM-UNet: Vision Mamba for Biomedical Segmentation", "https://arxiv.org/abs/2404.07705", Year = 2024, Authors = "Archit and Pape")]
+[PaperOptimizer(OptimizerKind.Adam, LearningRate = 1e-4, DecayRate = 0.1,
+                Schedule = LearningRateSchedulerType.ReduceOnPlateau,
+                Source = "Archit and Pape 2024: Adam with an initial learning rate of 1e-4 and reduction on plateau, over 100k iterations. The reduction factor is not stated, so the library default of 0.1 applies and is declared explicitly.")]
 public partial class ViMUNet<T> : Common.SemanticSegmentationBase<T>
 {
     private readonly ViMUNetOptions _options;

--- a/src/ComputerVision/Segmentation/Mamba/VisionMamba.cs
+++ b/src/ComputerVision/Segmentation/Mamba/VisionMamba.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using AiDotNet.LearningRateSchedulers;
+using System.IO;
 using AiDotNet.Attributes;
 using AiDotNet.Enums;
 using AiDotNet.Helpers;
@@ -55,6 +56,12 @@ namespace AiDotNet.ComputerVision.Segmentation.Mamba;
 [ModelComplexity(ModelComplexity.Medium)]
 [ModelInput(typeof(Tensor<>), typeof(Tensor<>))]
 [ResearchPaper("Vision Mamba: Efficient Visual Representation Learning with Bidirectional State Space Model", "https://arxiv.org/abs/2401.09417", Year = 2024, Authors = "Zhu et al.")]
+[PaperOptimizer(OptimizerKind.AdamW, Beta1 = 0.9, WeightDecay = 0.05,
+                ReferenceBatchSize = 1024, Phase = TrainingPhase.PreTraining,
+                Source = "Zhu et al. 2024: AdamW with a momentum of 0.9 -- which for an Adam-family optimizer is beta1, the first-moment coefficient, not the SGD momentum term -- a total batch size of 1024 and a weight decay of 0.05 when training on 224-pixel images.")]
+[PaperOptimizer(OptimizerKind.AdamW, LearningRate = 1e-5, WeightDecay = 1e-8,
+                Phase = TrainingPhase.FineTuning,
+                Source = "Zhu et al. 2024: fine-tuning at long sequence length uses a constant learning rate of 1e-5 and a weight decay of 1e-8.")]
 public partial class VisionMamba<T> : Common.SemanticSegmentationBase<T>
 {
     private readonly VisionMambaOptions _options;

--- a/src/ComputerVision/Segmentation/Medical/MedSAM2.cs
+++ b/src/ComputerVision/Segmentation/Medical/MedSAM2.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using AiDotNet.LearningRateSchedulers;
+using System.IO;
 using AiDotNet.Attributes;
 using AiDotNet.Enums;
 using AiDotNet.Helpers;
@@ -56,6 +57,9 @@ namespace AiDotNet.ComputerVision.Segmentation.Medical;
 [ModelComplexity(ModelComplexity.High)]
 [ModelInput(typeof(Tensor<>), typeof(Tensor<>))]
 [ResearchPaper("Medical SAM 2: Segment Medical Images As Video Via Segment Anything Model 2", "https://arxiv.org/abs/2408.00874", Year = 2024, Authors = "Zhu et al.")]
+[PaperOptimizer(OptimizerKind.AdamW, Beta1 = 0.9, Beta2 = 0.999, MinLearningRate = 0,
+                Schedule = LearningRateSchedulerType.CosineAnnealing,
+                Source = "Zhu et al. 2024: AdamW with beta1 0.9 and beta2 0.999, a linear learning rate warmup followed by cosine decay. Neither the peak rate nor the warmup length is stated, so neither is declared.")]
 public partial class MedSAM2<T> : Common.MedicalSegmentationBase<T>
 {
     private readonly MedSAM2Options _options;

--- a/src/ComputerVision/Segmentation/Medical/SegMamba.cs
+++ b/src/ComputerVision/Segmentation/Medical/SegMamba.cs
@@ -1,3 +1,4 @@
+using AiDotNet.LearningRateSchedulers;
 using System.IO;
 using AiDotNet.ActivationFunctions;
 using AiDotNet.Attributes;
@@ -56,6 +57,9 @@ namespace AiDotNet.ComputerVision.Segmentation.Medical;
 [ModelComplexity(ModelComplexity.High)]
 [ModelInput(typeof(Tensor<>), typeof(Tensor<>))]
 [ResearchPaper("SegMamba: Long-range Sequential Modeling Mamba For 3D Medical Image Segmentation", "https://arxiv.org/abs/2401.13560", Year = 2024, Authors = "Xing et al.")]
+[PaperOptimizer(OptimizerKind.Sgd, LearningRate = 1e-2, MinLearningRate = 1e-5,
+                Schedule = LearningRateSchedulerType.Polynomial, DecayRate = 1.0,
+                Source = "Xing et al. 2024: SGD with a polynomial learning rate scheduler, an initial rate of 1e-2 and a decay of 1e-5. The polynomial power is not stated, so the linear power of 1 is used and declared.")]
 public partial class SegMamba<T> : Common.MedicalSegmentationBase<T>
 {
     /// <inheritdoc />

--- a/src/ComputerVision/Segmentation/Medical/SwinUNETR.cs
+++ b/src/ComputerVision/Segmentation/Medical/SwinUNETR.cs
@@ -58,6 +58,9 @@ namespace AiDotNet.ComputerVision.Segmentation.Medical;
 [ModelComplexity(ModelComplexity.High)]
 [ModelInput(typeof(Tensor<>), typeof(Tensor<>))]
 [ResearchPaper("Swin UNETR: Swin Transformers for Semantic Segmentation of Brain Tumors in MRI Images", "https://arxiv.org/abs/2201.01266", Year = 2022, Authors = "Ali Hatamizadeh, Vishwesh Nath, Yucheng Tang, Dong Yang, Holger R. Roth, Daguang Xu")]
+[PaperOptimizer(OptimizerKind.AdamW, MinLearningRate = 0,
+                Schedule = LearningRateSchedulerType.CosineAnnealing,
+                Source = "Tang et al. 2022: 800 epochs with a linear warmup and a cosine annealing scheduler. The paper states neither the peak rate nor the warmup length here, so neither is declared.")]
 public partial class SwinUNETR<T> : Common.MedicalSegmentationBase<T>
 {
     /// <inheritdoc />

--- a/src/ComputerVision/Segmentation/OpenVocabulary/CATSeg.cs
+++ b/src/ComputerVision/Segmentation/OpenVocabulary/CATSeg.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using AiDotNet.LearningRateSchedulers;
+using System.IO;
 using AiDotNet.Attributes;
 using AiDotNet.Enums;
 using AiDotNet.Helpers;
@@ -58,6 +59,8 @@ namespace AiDotNet.ComputerVision.Segmentation.OpenVocabulary;
 [ModelComplexity(ModelComplexity.Medium)]
 [ModelInput(typeof(Tensor<>), typeof(Tensor<>))]
 [ResearchPaper("CAT-Seg: Cost Aggregation for Open-Vocabulary Semantic Segmentation", "https://arxiv.org/abs/2303.11797", Year = 2024, Authors = "Cho et al.")]
+[PaperOptimizer(OptimizerKind.AdamW, LearningRate = 2e-4, WeightDecay = 1e-4,
+                Source = "Cho et al. 2024: AdamW at a learning rate of 2e-4 for the model and 2e-6 for the CLIP backbone, with weight decay 1e-4. The backbone rate is not applied here because this model builds one optimizer over all parameters; applying two would need per-parameter-group rates.")]
 public partial class CATSeg<T> : Common.OpenVocabSegmentationBase<T>
 {
     private readonly CATSegOptions _options;

--- a/src/Finance/Forecasting/Foundation/CCDM.cs
+++ b/src/Finance/Forecasting/Foundation/CCDM.cs
@@ -1,3 +1,4 @@
+using AiDotNet.LearningRateSchedulers;
 using System.IO;
 using AiDotNet.Attributes;
 using AiDotNet.Enums;
@@ -58,6 +59,9 @@ namespace AiDotNet.Finance.Forecasting.Foundation;
 [ModelComplexity(ModelComplexity.High)]
 [ResearchPaper("Diffusion Variational Autoencoder for Tackling Stochasticity in Multi-Step Regression Stock Price Prediction", "https://arxiv.org/abs/2309.00073")]
     [ModelInput(typeof(Tensor<>), typeof(Tensor<>))]
+[PaperOptimizer(OptimizerKind.Adam, LearningRate = 5e-4, ReferenceBatchSize = 16,
+                Source = "Li et al. 2023, Sec. 4: the Adam optimizer with an initial learning rate of "
+                        + "5e-4, a batch size of 16, trained for 20 epochs per stock.")]
 public partial class CCDM<T> : TimeSeriesFoundationModelBase<T>
 {
     #region Fields
@@ -132,7 +136,9 @@ public partial class CCDM<T> : TimeSeriesFoundationModelBase<T>
         // bubbling up a bare InvalidCastException on first Train().
         options ??= new CCDMOptions<T>(); _options = options; Options = _options;
         _useNativeMode = false; OnnxModelPath = onnxModelPath; OnnxSession = new InferenceSession(onnxModelPath);
-        _optimizer = optimizer ?? new AdamOptimizer<T, Tensor<T>, Tensor<T>>(this); _lossFunction = lossFunction ?? new MeanSquaredErrorLoss<T>();
+        _optimizer = optimizer
+    ?? PaperOptimizerFactory.CreateFor<T, Tensor<T>, Tensor<T>>(this)
+    ?? new AdamOptimizer<T, Tensor<T>, Tensor<T>>(this); _lossFunction = lossFunction ?? new MeanSquaredErrorLoss<T>();
         CopyOptionsToFields(options);
     }
 
@@ -142,7 +148,9 @@ public partial class CCDM<T> : TimeSeriesFoundationModelBase<T>
     {
         options ??= new CCDMOptions<T>(); _options = options; Options = _options;
         _useNativeMode = true; OnnxSession = null; OnnxModelPath = null;
-        _optimizer = optimizer ?? new AdamOptimizer<T, Tensor<T>, Tensor<T>>(this); _lossFunction = lossFunction ?? new MeanSquaredErrorLoss<T>();
+        _optimizer = optimizer
+    ?? PaperOptimizerFactory.CreateFor<T, Tensor<T>, Tensor<T>>(this)
+    ?? new AdamOptimizer<T, Tensor<T>, Tensor<T>>(this); _lossFunction = lossFunction ?? new MeanSquaredErrorLoss<T>();
         CopyOptionsToFields(options); InitializeLayers();
     }
 

--- a/src/Finance/Forecasting/Foundation/Kronos.cs
+++ b/src/Finance/Forecasting/Foundation/Kronos.cs
@@ -1,3 +1,4 @@
+using AiDotNet.LearningRateSchedulers;
 using System.IO;
 using AiDotNet.Attributes;
 using AiDotNet.Enums;
@@ -63,6 +64,14 @@ namespace AiDotNet.Finance.Forecasting.Foundation;
 [ModelComplexity(ModelComplexity.High)]
 [ResearchPaper("Kronos: A Foundation Model for the Language of Financial Markets", "https://arxiv.org/abs/2508.02739")]
     [ModelInput(typeof(Tensor<>), typeof(Tensor<>))]
+[PaperOptimizer(OptimizerKind.AdamW, LearningRate = 5e-4, ReferenceBatchSize = 256,
+                MinLearningRate = 0,
+                Schedule = LearningRateSchedulerType.CosineAnnealing,
+                Source = "Shi et al. 2025, Sec. 4: all models are trained with a batch size of 256 and "
+                        + "a learning rate of 5e-4, under a cosine learning rate schedule with a linear "
+                        + "warm-up phase. The paper writes Adam in one place and AdamW with the "
+                        + "Loshchilov and Hutter 2017 citation in another; the citation settles it as "
+                        + "AdamW. The warm-up length is not stated, so none is declared.")]
 public partial class Kronos<T> : TimeSeriesFoundationModelBase<T>
 {
     #region Fields
@@ -149,7 +158,9 @@ public partial class Kronos<T> : TimeSeriesFoundationModelBase<T>
         OnnxModelPath = onnxModelPath;
         OnnxSession = new InferenceSession(onnxModelPath);
 
-        _optimizer = optimizer ?? new AdamOptimizer<T, Tensor<T>, Tensor<T>>(this);
+        _optimizer = optimizer
+    ?? PaperOptimizerFactory.CreateFor<T, Tensor<T>, Tensor<T>>(this)
+    ?? new AdamOptimizer<T, Tensor<T>, Tensor<T>>(this);
         _lossFunction = lossFunction ?? new MeanSquaredErrorLoss<T>();
 
         CopyOptionsToFields(options);
@@ -173,7 +184,9 @@ public partial class Kronos<T> : TimeSeriesFoundationModelBase<T>
         OnnxSession = null;
         OnnxModelPath = null;
 
-        _optimizer = optimizer ?? new AdamOptimizer<T, Tensor<T>, Tensor<T>>(this);
+        _optimizer = optimizer
+    ?? PaperOptimizerFactory.CreateFor<T, Tensor<T>, Tensor<T>>(this)
+    ?? new AdamOptimizer<T, Tensor<T>, Tensor<T>>(this);
         _lossFunction = lossFunction ?? new MeanSquaredErrorLoss<T>();
 
         CopyOptionsToFields(options);

--- a/src/Finance/Forecasting/Foundation/MGTSD.cs
+++ b/src/Finance/Forecasting/Foundation/MGTSD.cs
@@ -1,3 +1,4 @@
+using AiDotNet.LearningRateSchedulers;
 using System.IO;
 using AiDotNet.Attributes;
 using AiDotNet.Enums;
@@ -61,6 +62,9 @@ namespace AiDotNet.Finance.Forecasting.Foundation;
 [ModelComplexity(ModelComplexity.High)]
 [ModelInput(typeof(Tensor<>), typeof(Tensor<>))]
 [ResearchPaper("MG-TSD: Multi-Granularity Time Series Diffusion Models with Guided Learning Process", "https://arxiv.org/abs/2403.05751", Year = 2024, Authors = "Xinyao Fan, Yueying Wu, Chang Xu, Yuhao Huang, Weiqing Liu, Jiang Bian")]
+[PaperOptimizer(OptimizerKind.Adam, LearningRate = 1e-5, ReferenceBatchSize = 128,
+                Source = "Fan et al. 2024, Sec. 4: the Adam optimizer with a fixed learning rate of "
+                        + "1e-5 over 30 epochs, at a batch size of 128 on the Solar dataset.")]
 public partial class MGTSD<T> : TimeSeriesFoundationModelBase<T>
 {
     #region Fields
@@ -137,7 +141,9 @@ public partial class MGTSD<T> : TimeSeriesFoundationModelBase<T>
         if (!File.Exists(onnxModelPath)) throw new FileNotFoundException($"ONNX model not found: {onnxModelPath}");
         options = ResolveOptions(architecture, options); _options = options; Options = _options;
         _useNativeMode = false; OnnxModelPath = onnxModelPath; OnnxSession = new InferenceSession(onnxModelPath);
-        _optimizer = optimizer ?? new AdamOptimizer<T, Tensor<T>, Tensor<T>>(this); _lossFunction = lossFunction ?? new MeanSquaredErrorLoss<T>();
+        _optimizer = optimizer
+    ?? PaperOptimizerFactory.CreateFor<T, Tensor<T>, Tensor<T>>(this)
+    ?? new AdamOptimizer<T, Tensor<T>, Tensor<T>>(this); _lossFunction = lossFunction ?? new MeanSquaredErrorLoss<T>();
         CopyOptionsToFields(options);
     }
 

--- a/src/Finance/Forecasting/Foundation/MOIRAI.cs
+++ b/src/Finance/Forecasting/Foundation/MOIRAI.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using AiDotNet.LearningRateSchedulers;
+using System.IO;
 using AiDotNet.Attributes;
 using AiDotNet.Enums;
 using AiDotNet.Finance.Interfaces;
@@ -77,6 +78,13 @@ namespace AiDotNet.Finance.Forecasting.Foundation;
 [ModelComplexity(ModelComplexity.High)]
 [ModelInput(typeof(Tensor<>), typeof(Tensor<>))]
 [ResearchPaper("Unified Training of Universal Time Series Forecasting Transformers", "https://arxiv.org/abs/2402.02592", Year = 2024, Authors = "Gerald Woo, Chenghao Liu, Akshat Kumar, Caiming Xiong, Silvio Savarese, Doyen Sahoo")]
+[PaperOptimizer(OptimizerKind.AdamW, LearningRate = 1e-3, Beta1 = 0.9, Beta2 = 0.98,
+                WeightDecay = 0.1, ReferenceBatchSize = 256, WarmupSteps = 10000,
+                MinLearningRate = 0,
+                Schedule = LearningRateSchedulerType.CosineAnnealing,
+                Source = "Woo et al. 2024, Sec. 5: AdamW with a learning rate of 1e-3, weight decay "
+                        + "1e-1, beta1 0.9 and beta2 0.98, warming up over the first 10,000 steps and "
+                        + "cosine annealing thereafter, at a batch size of 256.")]
 public partial class MOIRAI<T> : TimeSeriesFoundationModelBase<T>
 {
     #region Execution Mode
@@ -316,7 +324,9 @@ public partial class MOIRAI<T> : TimeSeriesFoundationModelBase<T>
         OnnxModelPath = onnxModelPath;
         OnnxSession = new InferenceSession(onnxModelPath);
 
-        _optimizer = optimizer ?? new AdamOptimizer<T, Tensor<T>, Tensor<T>>(this);
+        _optimizer = optimizer
+    ?? PaperOptimizerFactory.CreateFor<T, Tensor<T>, Tensor<T>>(this)
+    ?? new AdamOptimizer<T, Tensor<T>, Tensor<T>>(this);
         _lossFunction = lossFunction ?? new MeanSquaredErrorLoss<T>();
 
         _contextLength = options.ContextLength;

--- a/src/Finance/Forecasting/Foundation/MOMENT.cs
+++ b/src/Finance/Forecasting/Foundation/MOMENT.cs
@@ -1,3 +1,4 @@
+using AiDotNet.LearningRateSchedulers;
 using System.IO;
 using AiDotNet.Attributes;
 using AiDotNet.Enums;
@@ -87,6 +88,15 @@ namespace AiDotNet.Finance.Forecasting.Foundation;
 [ModelComplexity(ModelComplexity.High)]
 [ModelInput(typeof(Tensor<>), typeof(Tensor<>))]
 [ResearchPaper("MOMENT: A Family of Open Time-Series Foundation Models", "https://arxiv.org/abs/2402.03885", Year = 2024, Authors = "Mononito Goswami, Konrad Szafer, Arjun Choudhry, Yifu Cai, Shuo Li, Artur Dubrawski")]
+[PaperOptimizer(OptimizerKind.AdamW, LearningRate = 1e-4, Beta1 = 0.9, Beta2 = 0.999,
+                WeightDecay = 0.05, ReferenceBatchSize = 2048, MinLearningRate = 1e-5,
+                MaxGradientNorm = 5.0,
+                Schedule = LearningRateSchedulerType.CosineAnnealing,
+                Source = "Goswami et al. 2024, Sec. 4: Adam with decoupled weight decay of 0.05, beta1 "
+                        + "0.9 and beta2 0.999, gradients clipped at 5.0, a batch size of 2048, and a "
+                        + "cosine schedule running from an initial learning rate of 1e-4 to a final "
+                        + "1e-5. Declared as AdamW because the paper's decay is the decoupled form it "
+                        + "cites Loshchilov and Hutter for.")]
 public partial class MOMENT<T> : TimeSeriesFoundationModelBase<T>
 {
     #region Execution Mode
@@ -238,7 +248,9 @@ public partial class MOMENT<T> : TimeSeriesFoundationModelBase<T>
         OnnxModelPath = onnxModelPath;
         OnnxSession = new InferenceSession(onnxModelPath);
 
-        _optimizer = optimizer ?? new AdamOptimizer<T, Tensor<T>, Tensor<T>>(this);
+        _optimizer = optimizer
+    ?? PaperOptimizerFactory.CreateFor<T, Tensor<T>, Tensor<T>>(this)
+    ?? new AdamOptimizer<T, Tensor<T>, Tensor<T>>(this);
         _lossFunction = lossFunction ?? new MeanSquaredErrorLoss<T>();
 
         CopyOptionsToFields(options);
@@ -273,7 +285,9 @@ public partial class MOMENT<T> : TimeSeriesFoundationModelBase<T>
         OnnxSession = null;
         OnnxModelPath = null;
 
-        _optimizer = optimizer ?? new AdamOptimizer<T, Tensor<T>, Tensor<T>>(this);
+        _optimizer = optimizer
+    ?? PaperOptimizerFactory.CreateFor<T, Tensor<T>, Tensor<T>>(this)
+    ?? new AdamOptimizer<T, Tensor<T>, Tensor<T>>(this);
         _lossFunction = lossFunction ?? new MeanSquaredErrorLoss<T>();
 
         CopyOptionsToFields(options);

--- a/src/Finance/Forecasting/Foundation/TEST.cs
+++ b/src/Finance/Forecasting/Foundation/TEST.cs
@@ -1,3 +1,4 @@
+using AiDotNet.LearningRateSchedulers;
 using System.IO;
 using AiDotNet.Attributes;
 using AiDotNet.Enums;
@@ -62,6 +63,11 @@ namespace AiDotNet.Finance.Forecasting.Foundation;
 [ModelComplexity(ModelComplexity.High)]
 [ResearchPaper("TEST: Text Prototype Aligned Embedding for Time Series", "https://arxiv.org/abs/2308.08241")]
     [ModelInput(typeof(Tensor<>), typeof(Tensor<>))]
+[PaperOptimizer(OptimizerKind.Adam, LearningRate = 0.001, Beta1 = 0.9, Beta2 = 0.999,
+                Provenance = RecipeProvenance.Stated,
+                Source = "Sun et al. 2023, Sec. 4: Adam with a learning rate of 0.001 and decay rates "
+                        + "of (0.9, 0.999). The paper notes explicitly that no hyperparameter "
+                        + "optimization was performed on the encoder hyperparameters.")]
 public partial class TEST<T> : TimeSeriesFoundationModelBase<T>
 {
     #region Fields
@@ -140,7 +146,9 @@ public partial class TEST<T> : TimeSeriesFoundationModelBase<T>
         OnnxModelPath = onnxModelPath;
         OnnxSession = new InferenceSession(onnxModelPath);
 
-        _optimizer = optimizer ?? new AdamOptimizer<T, Tensor<T>, Tensor<T>>(this);
+        _optimizer = optimizer
+    ?? PaperOptimizerFactory.CreateFor<T, Tensor<T>, Tensor<T>>(this)
+    ?? new AdamOptimizer<T, Tensor<T>, Tensor<T>>(this);
         _lossFunction = lossFunction ?? new MeanSquaredErrorLoss<T>();
 
         CopyOptionsToFields(options);
@@ -164,7 +172,9 @@ public partial class TEST<T> : TimeSeriesFoundationModelBase<T>
         OnnxSession = null;
         OnnxModelPath = null;
 
-        _optimizer = optimizer ?? new AdamOptimizer<T, Tensor<T>, Tensor<T>>(this);
+        _optimizer = optimizer
+    ?? PaperOptimizerFactory.CreateFor<T, Tensor<T>, Tensor<T>>(this)
+    ?? new AdamOptimizer<T, Tensor<T>, Tensor<T>>(this);
         _lossFunction = lossFunction ?? new MeanSquaredErrorLoss<T>();
 
         CopyOptionsToFields(options);

--- a/src/Finance/Forecasting/Foundation/TFC.cs
+++ b/src/Finance/Forecasting/Foundation/TFC.cs
@@ -1,3 +1,4 @@
+using AiDotNet.LearningRateSchedulers;
 using System.IO;
 using AiDotNet.Attributes;
 using AiDotNet.Enums;
@@ -63,6 +64,15 @@ namespace AiDotNet.Finance.Forecasting.Foundation;
 [ModelComplexity(ModelComplexity.High)]
 [ModelInput(typeof(Tensor<>), typeof(Tensor<>))]
 [ResearchPaper("Self-Supervised Contrastive Pre-Training For Time Series via Time-Frequency Consistency", "https://arxiv.org/abs/2206.08496", Year = 2022, Authors = "Xiang Zhang, Ziyuan Zhao, Theodoros Tsiligkaridis, Marinka Zitnik")]
+[PaperOptimizer(OptimizerKind.Adam, LearningRate = 0.0003, WeightDecay = 0.0005,
+                Phase = TrainingPhase.PreTraining,
+                Source = "Zhang et al. 2022, Sec. 5: pre-training uses Adam with a learning rate of "
+                        + "0.0003 and a 2-norm penalty coefficient of 0.0005, declared here as the "
+                        + "weight decay.")]
+[PaperOptimizer(OptimizerKind.Adam, ReferenceBatchSize = 16,
+                Phase = TrainingPhase.FineTuning,
+                Source = "Zhang et al. 2022, Sec. 5: fine-tuning uses a batch size of 16 over 20 to 80 "
+                        + "epochs. No learning rate is stated for this stage, so none is declared.")]
 public partial class TFC<T> : TimeSeriesFoundationModelBase<T>
 {
     #region Fields
@@ -172,7 +182,9 @@ public partial class TFC<T> : TimeSeriesFoundationModelBase<T>
         OnnxModelPath = onnxModelPath;
         OnnxSession = new InferenceSession(onnxModelPath);
 
-        _optimizer = optimizer ?? new AdamOptimizer<T, Tensor<T>, Tensor<T>>(this);
+        _optimizer = optimizer
+    ?? PaperOptimizerFactory.CreateFor<T, Tensor<T>, Tensor<T>>(this)
+    ?? new AdamOptimizer<T, Tensor<T>, Tensor<T>>(this);
         _lossFunction = lossFunction ?? new MeanSquaredErrorLoss<T>();
 
         CopyOptionsToFields(options);
@@ -196,7 +208,9 @@ public partial class TFC<T> : TimeSeriesFoundationModelBase<T>
         OnnxSession = null;
         OnnxModelPath = null;
 
-        _optimizer = optimizer ?? new AdamOptimizer<T, Tensor<T>, Tensor<T>>(this);
+        _optimizer = optimizer
+    ?? PaperOptimizerFactory.CreateFor<T, Tensor<T>, Tensor<T>>(this)
+    ?? new AdamOptimizer<T, Tensor<T>, Tensor<T>>(this);
         _lossFunction = lossFunction ?? new MeanSquaredErrorLoss<T>();
 
         CopyOptionsToFields(options);

--- a/src/Finance/Forecasting/Foundation/TimeDiff.cs
+++ b/src/Finance/Forecasting/Foundation/TimeDiff.cs
@@ -1,3 +1,4 @@
+using AiDotNet.LearningRateSchedulers;
 using System.IO;
 using AiDotNet.Attributes;
 using AiDotNet.Enums;
@@ -60,6 +61,9 @@ namespace AiDotNet.Finance.Forecasting.Foundation;
 [ModelComplexity(ModelComplexity.High)]
 [ModelInput(typeof(Tensor<>), typeof(Tensor<>))]
 [ResearchPaper("Non-autoregressive Conditional Diffusion Models for Time Series Prediction", "https://arxiv.org/abs/2306.05043", Year = 2023, Authors = "Lifeng Shen, James Kwok")]
+[PaperOptimizer(OptimizerKind.Adam, LearningRate = 1e-3, ReferenceBatchSize = 64,
+                Source = "Shen and Kwok 2023, Sec. 5: Adam with a learning rate of 1e-3 and a batch "
+                        + "size of 64, trained with early stopping for a maximum of 100 epochs.")]
 public partial class TimeDiff<T> : TimeSeriesFoundationModelBase<T>
 {
     #region Fields
@@ -135,7 +139,9 @@ public partial class TimeDiff<T> : TimeSeriesFoundationModelBase<T>
         OnnxModelPath = onnxModelPath;
         OnnxSession = new InferenceSession(onnxModelPath);
 
-        _optimizer = optimizer ?? new AdamOptimizer<T, Tensor<T>, Tensor<T>>(this);
+        _optimizer = optimizer
+    ?? PaperOptimizerFactory.CreateFor<T, Tensor<T>, Tensor<T>>(this)
+    ?? new AdamOptimizer<T, Tensor<T>, Tensor<T>>(this);
         _lossFunction = lossFunction ?? new MeanSquaredErrorLoss<T>();
 
         CopyOptionsToFields(options);
@@ -153,7 +159,9 @@ public partial class TimeDiff<T> : TimeSeriesFoundationModelBase<T>
         OnnxSession = null;
         OnnxModelPath = null;
 
-        _optimizer = optimizer ?? new AdamOptimizer<T, Tensor<T>, Tensor<T>>(this);
+        _optimizer = optimizer
+    ?? PaperOptimizerFactory.CreateFor<T, Tensor<T>, Tensor<T>>(this)
+    ?? new AdamOptimizer<T, Tensor<T>, Tensor<T>>(this);
         _lossFunction = lossFunction ?? new MeanSquaredErrorLoss<T>();
 
         CopyOptionsToFields(options);

--- a/src/Finance/Forecasting/Foundation/TimeMoE.cs
+++ b/src/Finance/Forecasting/Foundation/TimeMoE.cs
@@ -1,3 +1,4 @@
+using AiDotNet.LearningRateSchedulers;
 using System.IO;
 using AiDotNet.Attributes;
 using AiDotNet.Enums;
@@ -64,6 +65,13 @@ namespace AiDotNet.Finance.Forecasting.Foundation;
 [ModelComplexity(ModelComplexity.High)]
 [ModelInput(typeof(Tensor<>), typeof(Tensor<>))]
 [ResearchPaper("Time-MoE: Billion-Scale Time Series Foundation Models with Mixture of Experts", "https://arxiv.org/abs/2409.16040", Year = 2025, Authors = "Xiaoming Shi, Shiyu Wang, Yuqi Nie, Dianqi Li, Zhou Ye, Qingsong Wen, Ming Jin")]
+[PaperOptimizer(OptimizerKind.AdamW, LearningRate = 1e-3, Beta1 = 0.9, Beta2 = 0.95,
+                WeightDecay = 0.1, ReferenceBatchSize = 1024, WarmupSteps = 10000,
+                MinLearningRate = 0,
+                Schedule = LearningRateSchedulerType.CosineAnnealing,
+                Source = "Shi et al. 2024, Sec. 4.1: AdamW with a learning rate of 1e-3, weight decay "
+                        + "1e-1, beta1 0.9 and beta2 0.95, trained for 100,000 steps at a batch size of "
+                        + "1024.")]
 public partial class TimeMoE<T> : TimeSeriesFoundationModelBase<T>
 {
     #region Fields
@@ -142,7 +150,9 @@ public partial class TimeMoE<T> : TimeSeriesFoundationModelBase<T>
         OnnxModelPath = onnxModelPath;
         OnnxSession = new InferenceSession(onnxModelPath);
 
-        _optimizer = optimizer ?? new AdamOptimizer<T, Tensor<T>, Tensor<T>>(this);
+        _optimizer = optimizer
+    ?? PaperOptimizerFactory.CreateFor<T, Tensor<T>, Tensor<T>>(this)
+    ?? new AdamOptimizer<T, Tensor<T>, Tensor<T>>(this);
         _lossFunction = lossFunction ?? new MeanSquaredErrorLoss<T>();
 
         CopyOptionsToFields(options);
@@ -166,7 +176,9 @@ public partial class TimeMoE<T> : TimeSeriesFoundationModelBase<T>
         OnnxSession = null;
         OnnxModelPath = null;
 
-        _optimizer = optimizer ?? new AdamOptimizer<T, Tensor<T>, Tensor<T>>(this);
+        _optimizer = optimizer
+    ?? PaperOptimizerFactory.CreateFor<T, Tensor<T>, Tensor<T>>(this)
+    ?? new AdamOptimizer<T, Tensor<T>, Tensor<T>>(this);
         _lossFunction = lossFunction ?? new MeanSquaredErrorLoss<T>();
 
         CopyOptionsToFields(options);

--- a/src/NeuralNetworks/FlamingoNeuralNetwork.cs
+++ b/src/NeuralNetworks/FlamingoNeuralNetwork.cs
@@ -1,4 +1,6 @@
-﻿using System.IO;
+﻿using AiDotNet.Optimizers;
+using AiDotNet.LearningRateSchedulers;
+using System.IO;
 using AiDotNet.ActivationFunctions;
 using AiDotNet.Attributes;
 using AiDotNet.Autodiff;
@@ -55,6 +57,16 @@ namespace AiDotNet.NeuralNetworks;
 [ModelComplexity(ModelComplexity.High)]
 [ModelInput(typeof(Tensor<>), typeof(Tensor<>))]
 [ResearchPaper("Flamingo: a Visual Language Model for Few-Shot Learning", "https://arxiv.org/abs/2204.14198", Year = 2022, Authors = "Jean-Baptiste Alayrac, Jeff Donahue, Pauline Luc, Antoine Miech, Iain Barr, Yana Hasson, Karel Lenc, Arthur Mensch, Katie Millican, Malcolm Reynolds, Roman Ring, Eliza Rutherford, Serkan Cabi, Tengda Han, Zhitao Gong, Sina Samangooei, Marianne Monteiro, Jacob Menick, Sebastian Borgeaud, Andrew Brock, Aida Nematzadeh, Sahand Sharifzadeh, Mikolaj Binkowski, Ricardo Barreira, Oriol Vinyals, Andrew Zisserman, Karen Simonyan")]
+[PaperOptimizer(OptimizerKind.AdamW, LearningRate = 1e-4, WeightDecay = 0.1,
+                WarmupSteps = 5000, MaxGradientNorm = 1.0,
+                Schedule = LearningRateSchedulerType.LinearWarmup,
+                PostWarmupDecay = LinearWarmupScheduler.DecayMode.Constant,
+                Source = "Alayrac et al. 2022, Sec. 3.4: AdamW with global norm clipping of 1 and a "
+                        + "weight decay of 0.1 on the trainable parameters other than the Perceiver "
+                        + "Resampler, which uses none. The learning rate rises linearly from 0 to 1e-4 "
+                        + "over the first 5000 steps and is then held constant -- the paper states it "
+                        + "observed no improvement from decaying it, so the constant tail is the stated "
+                        + "choice rather than an omission.")]
 public partial class FlamingoNeuralNetwork<T> : MultimodalModelLayoutBase<T>, IFlamingoModel<T>
 {
     private readonly FlamingoOptions _options;
@@ -223,7 +235,8 @@ public partial class FlamingoNeuralNetwork<T> : MultimodalModelLayoutBase<T>, IF
             // Tokenizer is required for ONNX mode - must match the language model backbone
             Guard.NotNull(tokenizer);
             _tokenizer = tokenizer;
-            _optimizer = optimizer ?? new AdamOptimizer<T, Tensor<T>, Tensor<T>>(this);
+            _optimizer = optimizer ?? PaperOptimizerFactory.VerifyHandBuilt(this,
+            new AdamOptimizer<T, Tensor<T>, Tensor<T>>(this));
             _lossFunction = lossFunction ?? new CrossEntropyWithLogitsLoss<T>();
             InitializeLayers();
         }

--- a/src/NeuralNetworks/GLALanguageModel.cs
+++ b/src/NeuralNetworks/GLALanguageModel.cs
@@ -1,3 +1,4 @@
+using AiDotNet.LearningRateSchedulers;
 using AiDotNet.Attributes;
 using AiDotNet.Enums;
 using AiDotNet.Helpers;
@@ -37,6 +38,11 @@ namespace AiDotNet.NeuralNetworks;
 [ModelComplexity(ModelComplexity.High)]
 [ModelInput(typeof(Tensor<>), typeof(Tensor<>))]
 [ResearchPaper("Gated Linear Attention Transformers with Hardware-Efficient Training", "https://arxiv.org/abs/2312.06635", Year = 2024, Authors = "Songlin Yang, Bailin Wang, Yikang Shen, Rameswar Panda, Yoon Kim")]
+[PaperOptimizer(OptimizerKind.AdamW, LearningRate = 3e-4, WeightDecay = 0.01,
+                MinLearningRate = 0, MaxGradientNorm = 1.0,
+                Schedule = LearningRateSchedulerType.CosineAnnealing,
+                Source = "Yang et al. 2024, Sec. 5: AdamW with a maximum learning rate of 3e-4, a "
+                        + "weight decay of 0.01 and gradient clipping of 1.0, under a cosine schedule.")]
 public partial class GLALanguageModel<T> : TokenLanguageModelLayoutBase<T>
 {
     private readonly GLAOptions _options;
@@ -87,12 +93,13 @@ public partial class GLALanguageModel<T> : TokenLanguageModelLayoutBase<T>
         // THE PAPER'S RATE, NOT THE LIBRARY DEFAULT. Constructing AdamWOptimizer with no options
         // silently trained at InitialLearningRate = 1e-3, which is neither the published rate nor
         // something the caller could change short of building the whole optimizer themselves.
-        _optimizer = optimizer ?? new AdamWOptimizer<T, Tensor<T>, Tensor<T>>(
-            this,
-            new AdamWOptimizerOptions<T, Tensor<T>, Tensor<T>>
-            {
-                InitialLearningRate = _options.LearningRate,
-            });
+        _optimizer = optimizer ?? PaperOptimizerFactory.VerifyHandBuilt(this,
+            new AdamWOptimizer<T, Tensor<T>, Tensor<T>>(
+                this,
+                new AdamWOptimizerOptions<T, Tensor<T>, Tensor<T>>
+                {
+                    InitialLearningRate = _options.LearningRate,
+                }));
         InitializeLayers();
     }
 

--- a/src/NeuralNetworks/GatedDeltaNetLanguageModel.cs
+++ b/src/NeuralNetworks/GatedDeltaNetLanguageModel.cs
@@ -1,3 +1,4 @@
+using AiDotNet.LearningRateSchedulers;
 using AiDotNet.Attributes;
 using AiDotNet.Enums;
 using AiDotNet.Helpers;
@@ -37,6 +38,11 @@ namespace AiDotNet.NeuralNetworks;
 [ModelComplexity(ModelComplexity.High)]
 [ModelInput(typeof(Tensor<>), typeof(Tensor<>))]
 [ResearchPaper("Gated Delta Networks: Improving Mamba2 with Delta Rule", "https://arxiv.org/abs/2412.06464", Year = 2024, Authors = "Songlin Yang, Jan Kautz, Ali Hatamizadeh")]
+[PaperOptimizer(OptimizerKind.AdamW, LearningRate = 4e-4, WeightDecay = 0.1,
+                MinLearningRate = 0, MaxGradientNorm = 1.0,
+                Schedule = LearningRateSchedulerType.CosineAnnealing,
+                Source = "Yang et al. 2024, Sec. 5: AdamW with a peak learning rate of 4e-4, a weight "
+                        + "decay of 0.1 and gradient clipping of 1.0, under a cosine schedule.")]
 public partial class GatedDeltaNetLanguageModel<T> : TokenLanguageModelLayoutBase<T>
 {
     private readonly GatedDeltaNetOptions _options;
@@ -87,12 +93,13 @@ public partial class GatedDeltaNetLanguageModel<T> : TokenLanguageModelLayoutBas
         // THE PAPER'S RATE, NOT THE LIBRARY DEFAULT. Constructing AdamWOptimizer with no options
         // silently trained at InitialLearningRate = 1e-3, which is neither the published rate nor
         // something the caller could change short of building the whole optimizer themselves.
-        _optimizer = optimizer ?? new AdamWOptimizer<T, Tensor<T>, Tensor<T>>(
-            this,
-            new AdamWOptimizerOptions<T, Tensor<T>, Tensor<T>>
-            {
-                InitialLearningRate = _options.LearningRate,
-            });
+        _optimizer = optimizer ?? PaperOptimizerFactory.VerifyHandBuilt(this,
+            new AdamWOptimizer<T, Tensor<T>, Tensor<T>>(
+                this,
+                new AdamWOptimizerOptions<T, Tensor<T>, Tensor<T>>
+                {
+                    InitialLearningRate = _options.LearningRate,
+                }));
         InitializeLayers();
     }
 

--- a/src/NeuralNetworks/Pix2Pix.cs
+++ b/src/NeuralNetworks/Pix2Pix.cs
@@ -1,4 +1,6 @@
-﻿using System.IO;
+﻿using AiDotNet.Optimizers;
+using AiDotNet.LearningRateSchedulers;
+using System.IO;
 using AiDotNet.Attributes;
 using AiDotNet.Enums;
 using AiDotNet.Helpers;
@@ -58,6 +60,15 @@ namespace AiDotNet.NeuralNetworks;
 [ModelComplexity(ModelComplexity.High)]
 [ModelInput(typeof(Tensor<>), typeof(Tensor<>))]
 [ResearchPaper("Image-to-Image Translation with Conditional Adversarial Networks", "https://arxiv.org/abs/1611.07004", Year = 2017, Authors = "Phillip Isola, Jun-Yan Zhu, Tinghui Zhou, Alexei A. Efros")]
+[PaperOptimizer(OptimizerKind.Adam, LearningRate = 0.0002, Beta1 = 0.5, Beta2 = 0.999,
+                ReferenceBatchSize = 1,
+                Source = "Isola et al. 2017, Sec. 3.3: minibatch SGD with the Adam solver at a learning "
+                        + "rate of 0.0002 and momentum parameters beta1 0.5 and beta2 0.999, trained for "
+                        + "200 epochs at batch size 1. The beta1 of 0.5 is well below the usual 0.9 and "
+                        + "is the paper value. Both optimizers are verified against this record "
+                        + "rather than built from it: the model builds one for the generator and "
+                        + "one for the discriminator, each targeting a sub-model rather than this "
+                        + "one, so a factory-built optimizer would carry the wrong parameters.")]
 public partial class Pix2Pix<T> : ImageTranslationModelLayoutBase<T>
 {
 
@@ -218,8 +229,10 @@ public partial class Pix2Pix<T> : ImageTranslationModelLayoutBase<T>
         _lossFunction = lossFunction ?? NeuralNetworkHelper<T>.GetDefaultLossFunction(NeuralNetworkTaskType.Generative);
 
         // Initialize optimizers (default to Adam if not provided)
-        _generatorOptimizer = generatorOptimizer ?? new AdamOptimizer<T, Tensor<T>, Tensor<T>>(Generator);
-        _discriminatorOptimizer = discriminatorOptimizer ?? new AdamOptimizer<T, Tensor<T>, Tensor<T>>(Discriminator);
+        _generatorOptimizer = generatorOptimizer ?? PaperOptimizerFactory.VerifyHandBuilt(this,
+            new AdamOptimizer<T, Tensor<T>, Tensor<T>>(Generator));
+        _discriminatorOptimizer = discriminatorOptimizer ?? PaperOptimizerFactory.VerifyHandBuilt(this,
+            new AdamOptimizer<T, Tensor<T>, Tensor<T>>(Discriminator));
 
         InitializeLayers();
     }

--- a/src/NeuralNetworks/SpiralNet.cs
+++ b/src/NeuralNetworks/SpiralNet.cs
@@ -1,3 +1,5 @@
+using AiDotNet.Optimizers;
+using AiDotNet.LearningRateSchedulers;
 using AiDotNet.Attributes;
 using AiDotNet.Enums;
 using AiDotNet.Helpers;
@@ -56,6 +58,11 @@ namespace AiDotNet.NeuralNetworks;
 [ModelComplexity(ModelComplexity.High)]
 [ModelInput(typeof(Tensor<>), typeof(Tensor<>))]
 [ResearchPaper("SpiralNet++: A Fast and Highly Efficient Mesh Convolution Operator", "https://arxiv.org/abs/1911.05856", Year = 2019, Authors = "Shunwang Gong, Lei Chen, Michael Bronstein, Stefanos Zafeiriou")]
+[PaperOptimizer(OptimizerKind.Adam, LearningRate = 0.001, ReferenceBatchSize = 32,
+                DecayRate = 0.99, Schedule = LearningRateSchedulerType.Exponential,
+                ScheduleStepMode = SchedulerStepMode.StepPerEpoch,
+                Source = "Gong et al. 2019, Sec. 4: Adam for 300 epochs with a learning rate of 0.001 "
+                        + "and a learning rate decay of 0.99 per epoch, at a batch size of 32.")]
 public partial class SpiralNet<T> : GraphModelLayoutBase<T>
 {
     /// <summary>
@@ -144,7 +151,9 @@ public partial class SpiralNet<T> : GraphModelLayoutBase<T>
         // start and trip Training_ShouldReduceLoss even though training works.
         // The larger step produces a clear, noise-robust decrease while staying
         // well within the single-step stability bound.
-        _optimizer = optimizer ?? new AdamOptimizer<T, Tensor<T>, Tensor<T>>(
+        _optimizer = optimizer
+            ?? PaperOptimizerFactory.CreateFor<T, Tensor<T>, Tensor<T>>(this)
+            ?? new AdamOptimizer<T, Tensor<T>, Tensor<T>>(
             this,
             new Models.Options.AdamOptimizerOptions<T, Tensor<T>, Tensor<T>> { InitialLearningRate = 5e-3 });
         _spiralIndicesPerLevel = [];

--- a/src/NeuralNetworks/XLSTMLanguageModel.cs
+++ b/src/NeuralNetworks/XLSTMLanguageModel.cs
@@ -1,3 +1,4 @@
+using AiDotNet.LearningRateSchedulers;
 using AiDotNet.Attributes;
 using AiDotNet.Enums;
 using AiDotNet.Helpers;
@@ -38,6 +39,14 @@ namespace AiDotNet.NeuralNetworks;
 [ModelComplexity(ModelComplexity.High)]
 [ModelInput(typeof(Tensor<>), typeof(Tensor<>))]
 [ResearchPaper("xLSTM: Extended Long Short-Term Memory", "https://arxiv.org/abs/2405.04517", Year = 2024, Authors = "Maximilian Beck, Korbinian Poppel, Markus Spanring, Andreas Auer, Oleksandra Prudnikova, Michael Kopp, Gunter Klambauer, Johannes Brandstetter, Sepp Hochreiter")]
+[PaperOptimizer(OptimizerKind.AdamW, LearningRate = 1e-3, Beta1 = 0.9, Beta2 = 0.99,
+                WeightDecay = 0.1, ReferenceBatchSize = 256, WarmupSteps = 4000,
+                MinLearningRate = 0,
+                Schedule = LearningRateSchedulerType.CosineAnnealing,
+                Source = "Beck et al. 2024, Sec. 4: AdamW with beta1 0.9, beta2 0.99 and a weight decay "
+                        + "of 0.1, a maximum learning rate of 1e-3, 4k steps of linear warm-up then "
+                        + "cosine decay over 50k steps in total, at a batch size of 256 and context "
+                        + "length 512.")]
 public partial class XLSTMLanguageModel<T> : TokenLanguageModelLayoutBase<T>
 {
     private readonly XLSTMOptions _options;
@@ -93,11 +102,12 @@ public partial class XLSTMLanguageModel<T> : TokenLanguageModelLayoutBase<T>
         // training fell through to the framework default and barely moved: across the memorization
         // task the loss drifted only 0.13% between one and two iterations, leaving the more-data
         // invariant inside its own noise floor.
-        _optimizer = optimizer ?? new AdamWOptimizer<T, Tensor<T>, Tensor<T>>(this,
-            new AiDotNet.Models.Options.AdamWOptimizerOptions<T, Tensor<T>, Tensor<T>>
-            {
-                InitialLearningRate = _options.LearningRate,
-            });
+        _optimizer = optimizer ?? PaperOptimizerFactory.VerifyHandBuilt(this,
+            new AdamWOptimizer<T, Tensor<T>, Tensor<T>>(this,
+                new AiDotNet.Models.Options.AdamWOptimizerOptions<T, Tensor<T>, Tensor<T>>
+                {
+                    InitialLearningRate = _options.LearningRate,
+                }));
         InitializeLayers();
     }
 

--- a/src/Optimizers/PaperOptimizerFactory.cs
+++ b/src/Optimizers/PaperOptimizerFactory.cs
@@ -814,7 +814,12 @@ internal static class PaperOptimizerFactory
 
         try
         {
-            var ramp = new LinearWarmupScheduler(baseRate, warmupSteps);
+            // warmupInitLr defaults to 0, which makes the very first step a no-op: the update is
+            // multiplied by a rate of exactly zero and the parameters come back bit-identical.
+            // The two other places that build a warmup already start it one increment in, and
+            // this one has to as well -- a model that only gets a few steps otherwise never moves.
+            var ramp = new LinearWarmupScheduler(
+                baseRate, warmupSteps, warmupInitLr: FirstWarmupRate(baseRate, warmupSteps));
             return new SequentialLRScheduler([ramp, scheduler], [warmupSteps]);
         }
         catch (Exception)

--- a/src/SpeechRecognition/Foundation/BESTRQ.cs
+++ b/src/SpeechRecognition/Foundation/BESTRQ.cs
@@ -1,3 +1,5 @@
+using AiDotNet.LearningRateSchedulers;
+using AiDotNet.Enums;
 using AiDotNet.Attributes;
 using AiDotNet.Audio;
 using AiDotNet.Helpers;
@@ -43,6 +45,10 @@ namespace AiDotNet.SpeechRecognition.Foundation;
 [ModelComplexity(ModelComplexity.Medium)]
 [ModelInput(typeof(Tensor<>), typeof(Tensor<>))]
 [ResearchPaper("Self-supervised Learning with Random-Projection Quantizer for Speech Recognition", "https://arxiv.org/abs/2202.01855", Year = 2022, Authors = "Chiu et al.")]
+[PaperOptimizer(OptimizerKind.Adam, LearningRate = 0.004, WarmupSteps = 25000,
+                Source = "Chiu et al. 2022, Sec. 4: the Adam optimizer with a 0.004 peak learning rate "
+                        + "and 25000 warmup steps. The separate constant 1e-4 at batch size 256 in the "
+                        + "same section trains the quantizer, not this model.")]
 public partial class BESTRQ<T> : AudioNeuralNetworkBase<T>, ISpeechRecognizer<T>
 {
     /// <inheritdoc />
@@ -64,7 +70,9 @@ public partial class BESTRQ<T> : AudioNeuralNetworkBase<T>, ISpeechRecognizer<T>
     public bool SupportsWordTimestamps => false;
 
     public BESTRQ(NeuralNetworkArchitecture<T> architecture, string modelPath, BESTRQOptions? options = null) : base(architecture) { _options = options ?? new BESTRQOptions(); _useNativeMode = false; base.SampleRate = _options.SampleRate; base.NumMels = _options.NumMels; if (string.IsNullOrWhiteSpace(modelPath)) throw new ArgumentException("Model path required.", nameof(modelPath)); if (!File.Exists(modelPath)) throw new FileNotFoundException($"ONNX model not found: {modelPath}", modelPath); _options.ModelPath = modelPath; OnnxEncoder = new OnnxModel<T>(modelPath, _options.OnnxOptions); SupportedLanguages = new[] { "en" }; InitializeLayers(); }
-    public BESTRQ(NeuralNetworkArchitecture<T> architecture, BESTRQOptions? options = null, IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>>? optimizer = null) : base(architecture) { _options = options ?? new BESTRQOptions(); _useNativeMode = true; _optimizer = optimizer ?? new AdamWOptimizer<T, Tensor<T>, Tensor<T>>(this); base.SampleRate = _options.SampleRate; base.NumMels = _options.NumMels; SupportedLanguages = new[] { "en" }; InitializeLayers(); }
+    public BESTRQ(NeuralNetworkArchitecture<T> architecture, BESTRQOptions? options = null, IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>>? optimizer = null) : base(architecture) { _options = options ?? new BESTRQOptions(); _useNativeMode = true; _optimizer = optimizer
+        ?? PaperOptimizerFactory.CreateFor<T, Tensor<T>, Tensor<T>>(this)
+        ?? new AdamWOptimizer<T, Tensor<T>, Tensor<T>>(this); base.SampleRate = _options.SampleRate; base.NumMels = _options.NumMels; SupportedLanguages = new[] { "en" }; InitializeLayers(); }
 
     /// <summary>
     /// Transcribes audio using BEST-RQ's random-projection quantizer encoder with CTC.

--- a/src/SpeechRecognition/Foundation/Data2VecASR.cs
+++ b/src/SpeechRecognition/Foundation/Data2VecASR.cs
@@ -1,4 +1,6 @@
-﻿using AiDotNet.Attributes;
+﻿using AiDotNet.LearningRateSchedulers;
+using AiDotNet.Enums;
+using AiDotNet.Attributes;
 using AiDotNet.Audio;
 using AiDotNet.Helpers;
 using AiDotNet.Interfaces;
@@ -43,6 +45,15 @@ namespace AiDotNet.SpeechRecognition.Foundation;
 [ModelComplexity(ModelComplexity.Medium)]
 [ModelInput(typeof(Tensor<>), typeof(Tensor<>))]
 [ResearchPaper("data2vec: A General Framework for Self-Supervised Learning in Speech, Vision and Language", "https://arxiv.org/abs/2202.03555", Year = 2022, Authors = "Baevski et al.")]
+[PaperOptimizer(OptimizerKind.Adam, WarmupFraction = 0.03, HoldFraction = 0.9,
+                MinLearningRate = 0, Schedule = LearningRateSchedulerType.TriStage,
+                Source = "Baevski et al. 2022, Sec. 4: speech pre-training uses a tri-stage scheduler "
+                        + "that linearly warms the learning rate over the first 3 percent of updates, "
+                        + "holds it for 90 percent and linearly decays it over the remaining 7, training "
+                        + "the Base model for 400K updates. No reference batch size is declared because "
+                        + "the paper gives the batch as 63 minutes of audio rather than as a count of "
+                        + "examples. The 0.002 and 0.001 rates elsewhere in the paper belong to its "
+                        + "ViT-B and ViT-L vision models, not to this speech model.")]
 public partial class Data2VecASR<T> : AudioNeuralNetworkBase<T>, ISpeechRecognizer<T>
 {
     private readonly Data2VecASROptions _options; public override ModelOptions GetOptions() => _options;
@@ -52,7 +63,9 @@ public partial class Data2VecASR<T> : AudioNeuralNetworkBase<T>, ISpeechRecogniz
     public bool SupportsWordTimestamps => false;
 
     public Data2VecASR(NeuralNetworkArchitecture<T> architecture, string modelPath, Data2VecASROptions? options = null) : base(architecture) { _options = options ?? new Data2VecASROptions(); _useNativeMode = false; base.SampleRate = _options.SampleRate; base.NumMels = _options.NumMels; if (string.IsNullOrWhiteSpace(modelPath)) throw new ArgumentException("Model path required.", nameof(modelPath)); if (!File.Exists(modelPath)) throw new FileNotFoundException($"ONNX model not found: {modelPath}", modelPath); _options.ModelPath = modelPath; OnnxEncoder = new OnnxModel<T>(modelPath, _options.OnnxOptions); SupportedLanguages = new[] { "en" }; InitializeLayers(); }
-    public Data2VecASR(NeuralNetworkArchitecture<T> architecture, Data2VecASROptions? options = null, IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>>? optimizer = null) : base(architecture) { _options = options ?? new Data2VecASROptions(); _useNativeMode = true; _optimizer = optimizer ?? new AdamWOptimizer<T, Tensor<T>, Tensor<T>>(this); base.SampleRate = _options.SampleRate; base.NumMels = _options.NumMels; SupportedLanguages = new[] { "en" }; InitializeLayers(); }
+    public Data2VecASR(NeuralNetworkArchitecture<T> architecture, Data2VecASROptions? options = null, IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>>? optimizer = null) : base(architecture) { _options = options ?? new Data2VecASROptions(); _useNativeMode = true; _optimizer = optimizer
+        ?? PaperOptimizerFactory.CreateFor<T, Tensor<T>, Tensor<T>>(this)
+        ?? new AdamWOptimizer<T, Tensor<T>, Tensor<T>>(this); base.SampleRate = _options.SampleRate; base.NumMels = _options.NumMels; SupportedLanguages = new[] { "en" }; InitializeLayers(); }
 
     /// <summary>
     /// Transcribes audio using data2vec's continuous SSL encoder with CTC decoding.

--- a/src/SpeechRecognition/Foundation/SPIRAL.cs
+++ b/src/SpeechRecognition/Foundation/SPIRAL.cs
@@ -1,4 +1,6 @@
-﻿using AiDotNet.Attributes;
+﻿using AiDotNet.LearningRateSchedulers;
+using AiDotNet.Enums;
+using AiDotNet.Attributes;
 using AiDotNet.Audio;
 using AiDotNet.Helpers;
 using AiDotNet.Interfaces;
@@ -43,6 +45,12 @@ namespace AiDotNet.SpeechRecognition.Foundation;
 [ModelComplexity(ModelComplexity.Medium)]
 [ModelInput(typeof(Tensor<>), typeof(Tensor<>))]
 [ResearchPaper("SPIRAL: Self-supervised Perturbation-Invariant Representation Learning for Speech Pre-Training", "https://arxiv.org/abs/2201.10207", Year = 2022, Authors = "Huang et al.")]
+[PaperOptimizer(OptimizerKind.Adam, LearningRate = 3e-3, ReferenceBatchSize = 384,
+                WarmupFraction = 0.08,
+                Source = "Huang et al. 2022, Sec. 4.1: pre-training optimizes with Adam, warming the "
+                        + "learning rate over the first 8 percent of updates to a peak of 3e-3, with the "
+                        + "BASE model trained at a batch size of 24 per GPU across 16 GPUs for 200k "
+                        + "steps -- 384 in total, which is what the reference batch records.")]
 public partial class SPIRAL<T> : AudioNeuralNetworkBase<T>, ISpeechRecognizer<T>
 {
     private readonly SPIRALOptions _options; public override ModelOptions GetOptions() => _options;
@@ -52,7 +60,9 @@ public partial class SPIRAL<T> : AudioNeuralNetworkBase<T>, ISpeechRecognizer<T>
     public bool SupportsWordTimestamps => false;
 
     public SPIRAL(NeuralNetworkArchitecture<T> architecture, string modelPath, SPIRALOptions? options = null) : base(architecture) { _options = options ?? new SPIRALOptions(); _useNativeMode = false; base.SampleRate = _options.SampleRate; base.NumMels = _options.NumMels; if (string.IsNullOrWhiteSpace(modelPath)) throw new ArgumentException("Model path required.", nameof(modelPath)); if (!File.Exists(modelPath)) throw new FileNotFoundException($"ONNX model not found: {modelPath}", modelPath); _options.ModelPath = modelPath; OnnxEncoder = new OnnxModel<T>(modelPath, _options.OnnxOptions); SupportedLanguages = new[] { "en" }; InitializeLayers(); }
-    public SPIRAL(NeuralNetworkArchitecture<T> architecture, SPIRALOptions? options = null, IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>>? optimizer = null) : base(architecture) { _options = options ?? new SPIRALOptions(); _useNativeMode = true; _optimizer = optimizer ?? new AdamWOptimizer<T, Tensor<T>, Tensor<T>>(this); base.SampleRate = _options.SampleRate; base.NumMels = _options.NumMels; SupportedLanguages = new[] { "en" }; InitializeLayers(); }
+    public SPIRAL(NeuralNetworkArchitecture<T> architecture, SPIRALOptions? options = null, IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>>? optimizer = null) : base(architecture) { _options = options ?? new SPIRALOptions(); _useNativeMode = true; _optimizer = optimizer
+        ?? PaperOptimizerFactory.CreateFor<T, Tensor<T>, Tensor<T>>(this)
+        ?? new AdamWOptimizer<T, Tensor<T>, Tensor<T>>(this); base.SampleRate = _options.SampleRate; base.NumMels = _options.NumMels; SupportedLanguages = new[] { "en" }; InitializeLayers(); }
 
     /// <summary>
     /// Transcribes audio using SPIRAL's perturbation-invariant SSL encoder with CTC.

--- a/src/SpeechRecognition/Foundation/UniSpeech.cs
+++ b/src/SpeechRecognition/Foundation/UniSpeech.cs
@@ -1,4 +1,6 @@
-﻿using AiDotNet.Attributes;
+﻿using AiDotNet.LearningRateSchedulers;
+using AiDotNet.Enums;
+using AiDotNet.Attributes;
 using AiDotNet.Audio;
 using AiDotNet.Helpers;
 using AiDotNet.Interfaces;
@@ -43,6 +45,21 @@ namespace AiDotNet.SpeechRecognition.Foundation;
 [ModelComplexity(ModelComplexity.Medium)]
 [ModelInput(typeof(Tensor<>), typeof(Tensor<>))]
 [ResearchPaper("UniSpeech: Unified Speech Representation Learning with Labeled and Unlabeled Data", "https://arxiv.org/abs/2101.07597", Year = 2021, Authors = "Wang et al.")]
+[PaperOptimizer(OptimizerKind.Adam, LearningRate = 5e-4, WarmupFraction = 0.1,
+                MinLearningRate = 0, Schedule = LearningRateSchedulerType.LinearWarmup,
+                PostWarmupDecay = LinearWarmupScheduler.DecayMode.Linear,
+                Phase = TrainingPhase.PreTraining,
+                Source = "Wang et al. 2021, Sec. 3: Adam with the learning rate warmed up over the "
+                        + "first 10 percent of updates to a peak of 5e-4 for the Base model, then "
+                        + "linearly decayed over a total of 250k updates. The Large model uses 1e-3.")]
+[PaperOptimizer(OptimizerKind.Adam, LearningRate = 2e-5, WarmupFraction = 0.1,
+                HoldFraction = 0.4, MinLearningRate = 0,
+                Schedule = LearningRateSchedulerType.TriStage,
+                Phase = TrainingPhase.FineTuning,
+                Source = "Wang et al. 2021, Sec. 3: fine-tuning warms up over 2k updates to 2e-5, holds "
+                        + "it constant for 8k updates and then linearly decays over 10k -- a 20k run "
+                        + "whose three stages are the 10 percent, 40 percent and 50 percent declared "
+                        + "here.")]
 public partial class UniSpeech<T> : AudioNeuralNetworkBase<T>, ISpeechRecognizer<T>
 {
     private readonly UniSpeechOptions _options; public override ModelOptions GetOptions() => _options;
@@ -52,7 +69,9 @@ public partial class UniSpeech<T> : AudioNeuralNetworkBase<T>, ISpeechRecognizer
     public bool SupportsWordTimestamps => false;
 
     public UniSpeech(NeuralNetworkArchitecture<T> architecture, string modelPath, UniSpeechOptions? options = null) : base(architecture) { _options = options ?? new UniSpeechOptions(); _useNativeMode = false; base.SampleRate = _options.SampleRate; base.NumMels = _options.NumMels; if (string.IsNullOrWhiteSpace(modelPath)) throw new ArgumentException("Model path required.", nameof(modelPath)); if (!File.Exists(modelPath)) throw new FileNotFoundException($"ONNX model not found: {modelPath}", modelPath); _options.ModelPath = modelPath; OnnxEncoder = new OnnxModel<T>(modelPath, _options.OnnxOptions); SupportedLanguages = new[] { "en" }; InitializeLayers(); }
-    public UniSpeech(NeuralNetworkArchitecture<T> architecture, UniSpeechOptions? options = null, IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>>? optimizer = null) : base(architecture) { _options = options ?? new UniSpeechOptions(); _useNativeMode = true; _optimizer = optimizer ?? new AdamWOptimizer<T, Tensor<T>, Tensor<T>>(this); base.SampleRate = _options.SampleRate; base.NumMels = _options.NumMels; SupportedLanguages = new[] { "en" }; InitializeLayers(); }
+    public UniSpeech(NeuralNetworkArchitecture<T> architecture, UniSpeechOptions? options = null, IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>>? optimizer = null) : base(architecture) { _options = options ?? new UniSpeechOptions(); _useNativeMode = true; _optimizer = optimizer
+        ?? PaperOptimizerFactory.CreateFor<T, Tensor<T>, Tensor<T>>(this)
+        ?? new AdamWOptimizer<T, Tensor<T>, Tensor<T>>(this); base.SampleRate = _options.SampleRate; base.NumMels = _options.NumMels; SupportedLanguages = new[] { "en" }; InitializeLayers(); }
 
     /// <summary>
     /// Transcribes audio using UniSpeech's unified SSL/supervised encoder with CTC.

--- a/src/SpeechRecognition/Foundation/W2vBERT.cs
+++ b/src/SpeechRecognition/Foundation/W2vBERT.cs
@@ -1,4 +1,6 @@
-﻿using AiDotNet.Attributes;
+﻿using AiDotNet.LearningRateSchedulers;
+using AiDotNet.Enums;
+using AiDotNet.Attributes;
 using AiDotNet.Audio;
 using AiDotNet.Helpers;
 using AiDotNet.Interfaces;
@@ -43,6 +45,14 @@ namespace AiDotNet.SpeechRecognition.Foundation;
 [ModelComplexity(ModelComplexity.Medium)]
 [ModelInput(typeof(Tensor<>), typeof(Tensor<>))]
 [ResearchPaper("w2v-BERT: Combining Contrastive Learning and Masked Language Modeling for Self-Supervised Speech Pre-Training", "https://arxiv.org/abs/2108.06209", Year = 2021, Authors = "Chung et al.")]
+[PaperOptimizer(OptimizerKind.Adam, LearningRate = 2e-3, ReferenceBatchSize = 2048,
+                WarmupSteps = 25000, Schedule = LearningRateSchedulerType.Noam,
+                Provenance = RecipeProvenance.DerivedFromCitedWork,
+                Source = "Chung et al. 2021, Sec. 4: w2v-BERT XL trains at a batch size of 2048 with "
+                        + "Adam under the transformer learning rate schedule of its reference, a peak "
+                        + "learning rate of 2e-3 and 25k warm-up steps. The schedule shape comes from "
+                        + "the cited work rather than being restated here, which is what the provenance "
+                        + "records.")]
 public partial class W2vBERT<T> : AudioNeuralNetworkBase<T>, ISpeechRecognizer<T>
 {
     private readonly W2vBERTOptions _options; public override ModelOptions GetOptions() => _options;
@@ -52,7 +62,9 @@ public partial class W2vBERT<T> : AudioNeuralNetworkBase<T>, ISpeechRecognizer<T
     public bool SupportsWordTimestamps => false;
 
     public W2vBERT(NeuralNetworkArchitecture<T> architecture, string modelPath, W2vBERTOptions? options = null) : base(architecture) { _options = options ?? new W2vBERTOptions(); _useNativeMode = false; base.SampleRate = _options.SampleRate; base.NumMels = _options.NumMels; if (string.IsNullOrWhiteSpace(modelPath)) throw new ArgumentException("Model path required.", nameof(modelPath)); if (!File.Exists(modelPath)) throw new FileNotFoundException($"ONNX model not found: {modelPath}", modelPath); _options.ModelPath = modelPath; OnnxEncoder = new OnnxModel<T>(modelPath, _options.OnnxOptions); SupportedLanguages = new[] { "en" }; InitializeLayers(); }
-    public W2vBERT(NeuralNetworkArchitecture<T> architecture, W2vBERTOptions? options = null, IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>>? optimizer = null) : base(architecture) { _options = options ?? new W2vBERTOptions(); _useNativeMode = true; _optimizer = optimizer ?? new AdamWOptimizer<T, Tensor<T>, Tensor<T>>(this); base.SampleRate = _options.SampleRate; base.NumMels = _options.NumMels; SupportedLanguages = new[] { "en" }; InitializeLayers(); }
+    public W2vBERT(NeuralNetworkArchitecture<T> architecture, W2vBERTOptions? options = null, IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>>? optimizer = null) : base(architecture) { _options = options ?? new W2vBERTOptions(); _useNativeMode = true; _optimizer = optimizer
+        ?? PaperOptimizerFactory.CreateFor<T, Tensor<T>, Tensor<T>>(this)
+        ?? new AdamWOptimizer<T, Tensor<T>, Tensor<T>>(this); base.SampleRate = _options.SampleRate; base.NumMels = _options.NumMels; SupportedLanguages = new[] { "en" }; InitializeLayers(); }
 
     /// <summary>
     /// Transcribes audio using w2v-BERT's dual-objective SSL encoder with CTC.

--- a/src/SpeechRecognition/LLMIntegrated/GraniteSpeech.cs
+++ b/src/SpeechRecognition/LLMIntegrated/GraniteSpeech.cs
@@ -1,3 +1,5 @@
+using AiDotNet.LearningRateSchedulers;
+using AiDotNet.Enums;
 using AiDotNet.Attributes;
 using AiDotNet.Audio;
 using AiDotNet.Helpers;
@@ -42,6 +44,19 @@ namespace AiDotNet.SpeechRecognition.LLMIntegrated;
 [ModelComplexity(ModelComplexity.Medium)]
 [ModelInput(typeof(Tensor<>), typeof(Tensor<>))]
 [ResearchPaper("Granite-speech: open-source speech-aware LLMs with strong English ASR capabilities", "https://arxiv.org/abs/2505.08699", Year = 2025, Authors = "IBM Research")]
+[PaperOptimizer(OptimizerKind.AdamW, LearningRate = 5e-4, ReferenceBatchSize = 256,
+                MinLearningRate = 5e-6, Schedule = LearningRateSchedulerType.Cyclic,
+                CyclicPolicy = CyclicLRScheduler.CyclicMode.Triangular,
+                Phase = TrainingPhase.PreTraining,
+                Source = "Saon et al. 2025, Sec. 4: the acoustic encoder trains for 20 epochs at a "
+                        + "batch size of 256 utterances under a triangular learning rate schedule that "
+                        + "ramps from 5e-5 to 5e-4 over the first 6 epochs and decays to 5e-6 "
+                        + "thereafter.")]
+[PaperOptimizer(OptimizerKind.AdamW, LearningRate = 1e-4, ReferenceBatchSize = 128,
+                WarmupSteps = 1000, Phase = TrainingPhase.FineTuning,
+                Source = "Saon et al. 2025, Sec. 4: the speech-aware LLM stage trains over three epochs "
+                        + "and 660000 updates at a peak learning rate of 1e-4 with a 1000-step warm-up, "
+                        + "at a batch size of 128 utterances.")]
 public partial class GraniteSpeech<T> : AudioNeuralNetworkBase<T>, ISpeechRecognizer<T>
 {
     private readonly GraniteSpeechOptions _options; public override ModelOptions GetOptions() => _options;
@@ -51,7 +66,9 @@ public partial class GraniteSpeech<T> : AudioNeuralNetworkBase<T>, ISpeechRecogn
     public bool SupportsWordTimestamps => false;
 
     public GraniteSpeech(NeuralNetworkArchitecture<T> architecture, string modelPath, GraniteSpeechOptions? options = null) : base(architecture) { _options = options ?? new GraniteSpeechOptions(); _useNativeMode = false; base.SampleRate = _options.SampleRate; base.NumMels = _options.NumMels; if (string.IsNullOrWhiteSpace(modelPath)) throw new ArgumentException("Model path required.", nameof(modelPath)); if (!File.Exists(modelPath)) throw new FileNotFoundException($"ONNX model not found: {modelPath}", modelPath); _options.ModelPath = modelPath; OnnxEncoder = new OnnxModel<T>(modelPath, _options.OnnxOptions); SupportedLanguages = new[] { "en" }; InitializeLayers(); }
-    public GraniteSpeech(NeuralNetworkArchitecture<T> architecture, GraniteSpeechOptions? options = null, IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>>? optimizer = null) : base(architecture) { _options = options ?? new GraniteSpeechOptions(); _useNativeMode = true; _optimizer = optimizer ?? new AdamWOptimizer<T, Tensor<T>, Tensor<T>>(this); base.SampleRate = _options.SampleRate; base.NumMels = _options.NumMels; SupportedLanguages = new[] { "en" }; InitializeLayers(); }
+    public GraniteSpeech(NeuralNetworkArchitecture<T> architecture, GraniteSpeechOptions? options = null, IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>>? optimizer = null) : base(architecture) { _options = options ?? new GraniteSpeechOptions(); _useNativeMode = true; _optimizer = optimizer
+        ?? PaperOptimizerFactory.CreateFor<T, Tensor<T>, Tensor<T>>(this)
+        ?? new AdamWOptimizer<T, Tensor<T>, Tensor<T>>(this); base.SampleRate = _options.SampleRate; base.NumMels = _options.NumMels; SupportedLanguages = new[] { "en" }; InitializeLayers(); }
 
     /// <summary>
     /// Transcribes audio using Granite's speech encoder + enterprise LLM decoder.

--- a/src/SpeechRecognition/LLMIntegrated/SALM.cs
+++ b/src/SpeechRecognition/LLMIntegrated/SALM.cs
@@ -1,3 +1,5 @@
+using AiDotNet.LearningRateSchedulers;
+using AiDotNet.Enums;
 using AiDotNet.Attributes;
 using AiDotNet.Audio;
 using AiDotNet.Helpers;
@@ -42,6 +44,12 @@ namespace AiDotNet.SpeechRecognition.LLMIntegrated;
 [ModelComplexity(ModelComplexity.Medium)]
 [ModelInput(typeof(Tensor<>), typeof(Tensor<>))]
 [ResearchPaper("SALM: Speech-augmented Language Model with In-context Learning for Speech Recognition", "https://arxiv.org/abs/2310.09424", Year = 2024, Authors = "Chen et al.")]
+[PaperOptimizer(OptimizerKind.Adam, LearningRate = 1e-4, WeightDecay = 1e-3,
+                WarmupSteps = 2000, MinLearningRate = 0, MaxGradientNorm = 5.0,
+                Schedule = LearningRateSchedulerType.CosineAnnealing,
+                Source = "Chen et al. 2023, Sec. 4: the Adam optimizer with a learning rate of 1e-4 and "
+                        + "a weight decay of 1e-3, cosine annealing with 2000 warm-up steps, and "
+                        + "gradients clipped to 5.0.")]
 public partial class SALM<T> : AudioNeuralNetworkBase<T>, ISpeechRecognizer<T>
 {
     private readonly SALMOptions _options; public override ModelOptions GetOptions() => _options;
@@ -56,7 +64,9 @@ public partial class SALM<T> : AudioNeuralNetworkBase<T>, ISpeechRecognizer<T>
     // to MeanSquaredErrorLoss, which this model silently inherited, so it was descending MSE on token
     // LOGITS — an objective the paper never uses. The head emits raw logits, so use the fused
     // log-softmax/NLL form, as the other logit-head models here do.
-    public SALM(NeuralNetworkArchitecture<T> architecture, SALMOptions? options = null, IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>>? optimizer = null) : base(architecture, new AiDotNet.LossFunctions.CrossEntropyWithLogitsLoss<T>()) { _options = options ?? new SALMOptions(); _useNativeMode = true; _optimizer = optimizer ?? new AdamWOptimizer<T, Tensor<T>, Tensor<T>>(this); base.SampleRate = _options.SampleRate; base.NumMels = _options.NumMels; SupportedLanguages = new[] { "en" }; InitializeLayers(); }
+    public SALM(NeuralNetworkArchitecture<T> architecture, SALMOptions? options = null, IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>>? optimizer = null) : base(architecture, new AiDotNet.LossFunctions.CrossEntropyWithLogitsLoss<T>()) { _options = options ?? new SALMOptions(); _useNativeMode = true; _optimizer = optimizer
+        ?? PaperOptimizerFactory.CreateFor<T, Tensor<T>, Tensor<T>>(this)
+        ?? new AdamWOptimizer<T, Tensor<T>, Tensor<T>>(this); base.SampleRate = _options.SampleRate; base.NumMels = _options.NumMels; SupportedLanguages = new[] { "en" }; InitializeLayers(); }
 
     /// <summary>
     /// Transcribes audio using SALM's in-context learning approach.

--- a/src/SpeechRecognition/LLMIntegrated/SambaASR.cs
+++ b/src/SpeechRecognition/LLMIntegrated/SambaASR.cs
@@ -1,3 +1,5 @@
+using AiDotNet.LearningRateSchedulers;
+using AiDotNet.Enums;
 using AiDotNet.Attributes;
 using AiDotNet.Audio;
 using AiDotNet.Helpers;
@@ -41,6 +43,14 @@ namespace AiDotNet.SpeechRecognition.LLMIntegrated;
 [ModelComplexity(ModelComplexity.Medium)]
 [ModelInput(typeof(Tensor<>), typeof(Tensor<>))]
 [ResearchPaper("SAMBA-ASR: State-of-the-Art Speech Recognition Leveraging Structured State-Space Models", "https://arxiv.org/abs/2501.02832", Year = 2025, Authors = "Yadav et al.")]
+[PaperOptimizer(OptimizerKind.AdamW, LearningRate = 1e-4, Epsilon = 1e-8,
+                WeightDecay = 0.01, ReferenceBatchSize = 256, MinLearningRate = 0,
+                DecayRate = 1.0, Schedule = LearningRateSchedulerType.Polynomial,
+                Source = "Bhatia et al. 2025, Sec. 6 and Table 1: AdamW with gradient norm clipping and "
+                        + "a linear learning rate decay, a batch size of 256 over 80 epochs, an initial "
+                        + "learning rate of 1e-4, a weight decay of 0.01 and an Adam epsilon of 1e-8. "
+                        + "The linear decay is declared as a polynomial schedule of power 1, which is "
+                        + "the same curve.")]
 public partial class SambaASR<T> : AudioNeuralNetworkBase<T>, ISpeechRecognizer<T>
 {
     private readonly SambaASROptions _options; public override ModelOptions GetOptions() => _options;
@@ -50,7 +60,9 @@ public partial class SambaASR<T> : AudioNeuralNetworkBase<T>, ISpeechRecognizer<
     public bool SupportsWordTimestamps => false;
 
     public SambaASR(NeuralNetworkArchitecture<T> architecture, string modelPath, SambaASROptions? options = null) : base(architecture) { _options = options ?? new SambaASROptions(); _useNativeMode = false; base.SampleRate = _options.SampleRate; base.NumMels = _options.NumMels; if (string.IsNullOrWhiteSpace(modelPath)) throw new ArgumentException("Model path required.", nameof(modelPath)); if (!File.Exists(modelPath)) throw new FileNotFoundException($"ONNX model not found: {modelPath}", modelPath); _options.ModelPath = modelPath; OnnxEncoder = new OnnxModel<T>(modelPath, _options.OnnxOptions); SupportedLanguages = new[] { "en" }; InitializeLayers(); }
-    public SambaASR(NeuralNetworkArchitecture<T> architecture, SambaASROptions? options = null, IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>>? optimizer = null) : base(architecture) { _options = options ?? new SambaASROptions(); _useNativeMode = true; _optimizer = optimizer ?? new AdamWOptimizer<T, Tensor<T>, Tensor<T>>(this); base.SampleRate = _options.SampleRate; base.NumMels = _options.NumMels; SupportedLanguages = new[] { "en" }; InitializeLayers(); }
+    public SambaASR(NeuralNetworkArchitecture<T> architecture, SambaASROptions? options = null, IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>>? optimizer = null) : base(architecture) { _options = options ?? new SambaASROptions(); _useNativeMode = true; _optimizer = optimizer
+        ?? PaperOptimizerFactory.CreateFor<T, Tensor<T>, Tensor<T>>(this)
+        ?? new AdamWOptimizer<T, Tensor<T>, Tensor<T>>(this); base.SampleRate = _options.SampleRate; base.NumMels = _options.NumMels; SupportedLanguages = new[] { "en" }; InitializeLayers(); }
 
     /// <summary>
     /// Transcribes audio using Mamba SSM encoder with CTC decoding.

--- a/src/TextToSpeech/Classic/AdaSpeech.cs
+++ b/src/TextToSpeech/Classic/AdaSpeech.cs
@@ -1,3 +1,5 @@
+using AiDotNet.LearningRateSchedulers;
+using AiDotNet.Enums;
 using AiDotNet.Attributes;
 using AiDotNet.Helpers;
 using AiDotNet.Interfaces;
@@ -48,6 +50,10 @@ namespace AiDotNet.TextToSpeech.Classic;
     Year = 2021,
     Authors = "Chen et al."
 )]
+[PaperOptimizer(OptimizerKind.Adam, Beta1 = 0.9, Beta2 = 0.98, Epsilon = 1e-9,
+                Source = "Chen et al. 2021, Sec. 4.1: the Adam optimizer with beta1 0.9, beta2 0.98 and "
+                        + "epsilon 1e-9. The paper states no learning rate in its training description, "
+                        + "so none is declared.")]
 public partial class AdaSpeech<T> : TtsModelBase<T>, IAcousticModel<T>
 {
     private readonly AdaSpeechOptions _options;
@@ -100,14 +106,15 @@ public partial class AdaSpeech<T> : TtsModelBase<T>, IAcousticModel<T>
         // 1e-3 default with beta2 = 0.999, epsilon = 1e-8 and a decoupled weight decay of
         // 0.01 that no paper here specifies. Ten times the intended rate is enough to blow
         // the first step into a region training cannot recover from.
-        _optimizer = optimizer ?? new AdamOptimizer<T, Tensor<T>, Tensor<T>>(this,
-            new AdamOptimizerOptions<T, Tensor<T>, Tensor<T>>
-            {
-                InitialLearningRate = _options.LearningRate,
-                Beta1 = 0.9,
-                Beta2 = 0.98,
-                Epsilon = 1e-9
-            });
+        _optimizer = optimizer ?? PaperOptimizerFactory.VerifyHandBuilt(this,
+            new AdamOptimizer<T, Tensor<T>, Tensor<T>>(this,
+                new AdamOptimizerOptions<T, Tensor<T>, Tensor<T>>
+                {
+                    InitialLearningRate = _options.LearningRate,
+                    Beta1 = 0.9,
+                    Beta2 = 0.98,
+                    Epsilon = 1e-9
+                }));
         base.SampleRate = _options.SampleRate;
         base.MelChannels = _options.MelChannels;
         base.HopSize = _options.HopSize;

--- a/src/TextToSpeech/Classic/AdaSpeech2.cs
+++ b/src/TextToSpeech/Classic/AdaSpeech2.cs
@@ -1,3 +1,5 @@
+using AiDotNet.LearningRateSchedulers;
+using AiDotNet.Enums;
 using AiDotNet.Attributes;
 using AiDotNet.Helpers;
 using AiDotNet.Interfaces;
@@ -48,6 +50,10 @@ namespace AiDotNet.TextToSpeech.Classic;
     Year = 2021,
     Authors = "Yan et al."
 )]
+[PaperOptimizer(OptimizerKind.Adam, Beta1 = 0.9, Beta2 = 0.98, Epsilon = 1e-9,
+                Source = "Yan et al. 2021, Sec. 3: the Adam optimizer with beta1 0.9, beta2 0.98 and "
+                        + "epsilon 1e-9. The paper states no learning rate in its training description, "
+                        + "so none is declared.")]
 public partial class AdaSpeech2<T> : TtsModelBase<T>, IAcousticModel<T>
 {
     private readonly AdaSpeech2Options _options;
@@ -91,7 +97,9 @@ public partial class AdaSpeech2<T> : TtsModelBase<T>, IAcousticModel<T>
     {
         _options = options ?? new AdaSpeech2Options();
         _useNativeMode = true;
-        _optimizer = optimizer ?? new AdamWOptimizer<T, Tensor<T>, Tensor<T>>(this);
+        _optimizer = optimizer
+    ?? PaperOptimizerFactory.CreateFor<T, Tensor<T>, Tensor<T>>(this)
+    ?? new AdamWOptimizer<T, Tensor<T>, Tensor<T>>(this);
         base.SampleRate = _options.SampleRate;
         base.MelChannels = _options.MelChannels;
         base.HopSize = _options.HopSize;

--- a/src/TextToSpeech/Classic/AlignTTS.cs
+++ b/src/TextToSpeech/Classic/AlignTTS.cs
@@ -1,3 +1,5 @@
+using AiDotNet.LearningRateSchedulers;
+using AiDotNet.Enums;
 using AiDotNet.Attributes;
 using AiDotNet.Helpers;
 using AiDotNet.Interfaces;
@@ -48,6 +50,21 @@ namespace AiDotNet.TextToSpeech.Classic;
     Year = 2020,
     Authors = "Zeng et al."
 )]
+[PaperOptimizer(OptimizerKind.Adam, Beta1 = 0.9, Beta2 = 0.98, Epsilon = 1e-9,
+                ReferenceBatchSize = 32, Schedule = LearningRateSchedulerType.Noam,
+                Phase = TrainingPhase.PreTraining,
+                Provenance = RecipeProvenance.DerivedFromCitedWork,
+                Source = "Zeng et al. 2020, Sec. 4.1: Adam with beta1 0.9, beta2 0.98 and epsilon 1e-9, "
+                        + "at a batch size of 16 samples on each of 2 GPUs, for 40K steps in the first "
+                        + "two training stages. The schedule is not restated -- the paper adopts the one "
+                        + "from its reference [18], Vaswani et al. 2017, which is the "
+                        + "inverse-square-root schedule with warmup declared here as Noam; the "
+                        + "provenance records that it comes from the cited work rather than from this "
+                        + "paper.")]
+[PaperOptimizer(OptimizerKind.Adam, LearningRate = 1e-4,
+                Phase = TrainingPhase.FineTuning,
+                Source = "Zeng et al. 2020, Sec. 4.1: fine-tuning the whole model uses a fixed learning "
+                        + "rate of 1e-4 over 80K steps.")]
 public partial class AlignTTS<T> : TtsModelBase<T>, IAcousticModel<T>
 {
     private readonly AlignTTSOptions _options;
@@ -99,14 +116,15 @@ public partial class AlignTTS<T> : TtsModelBase<T>, IAcousticModel<T>
         // 1e-3 default with beta2 = 0.999, epsilon = 1e-8 and a decoupled weight decay of
         // 0.01 that no paper here specifies. Ten times the intended rate is enough to blow
         // the first step into a region training cannot recover from.
-        _optimizer = optimizer ?? new AdamOptimizer<T, Tensor<T>, Tensor<T>>(this,
-            new AdamOptimizerOptions<T, Tensor<T>, Tensor<T>>
-            {
-                InitialLearningRate = _options.LearningRate,
-                Beta1 = 0.9,
-                Beta2 = 0.98,
-                Epsilon = 1e-9
-            });
+        _optimizer = optimizer ?? PaperOptimizerFactory.VerifyHandBuilt(this,
+            new AdamOptimizer<T, Tensor<T>, Tensor<T>>(this,
+                new AdamOptimizerOptions<T, Tensor<T>, Tensor<T>>
+                {
+                    InitialLearningRate = _options.LearningRate,
+                    Beta1 = 0.9,
+                    Beta2 = 0.98,
+                    Epsilon = 1e-9
+                }));
         base.SampleRate = _options.SampleRate;
         base.MelChannels = _options.MelChannels;
         base.HopSize = _options.HopSize;

--- a/src/TextToSpeech/Classic/FastSpeech.cs
+++ b/src/TextToSpeech/Classic/FastSpeech.cs
@@ -1,3 +1,5 @@
+using AiDotNet.LearningRateSchedulers;
+using AiDotNet.Enums;
 using AiDotNet.Attributes;
 using AiDotNet.Helpers;
 using AiDotNet.Interfaces;
@@ -49,6 +51,14 @@ namespace AiDotNet.TextToSpeech.Classic;
     Year = 2019,
     Authors = "Ren et al."
 )]
+[PaperOptimizer(OptimizerKind.Adam, Beta1 = 0.9, Beta2 = 0.98, Epsilon = 1e-9,
+                Schedule = LearningRateSchedulerType.Noam,
+                Provenance = RecipeProvenance.DerivedFromCitedWork,
+                Source = "Ren et al. 2019, Sec. 4.2: Adam with beta1 0.9, beta2 0.98 and epsilon 1e-9, "
+                        + "following the learning rate schedule of its reference [25], Vaswani et al. "
+                        + "2017 -- the inverse-square-root schedule with warmup declared here as Noam. "
+                        + "The paper restates neither the peak rate nor the warmup length, so the "
+                        + "provenance records that the schedule comes from the cited work.")]
 public partial class FastSpeech<T> : TtsModelBase<T>, IAcousticModel<T>
 {
     private readonly FastSpeechOptions _options;
@@ -93,7 +103,9 @@ public partial class FastSpeech<T> : TtsModelBase<T>, IAcousticModel<T>
     {
         _options = options ?? new FastSpeechOptions();
         _useNativeMode = true;
-        _optimizer = optimizer ?? new AdamWOptimizer<T, Tensor<T>, Tensor<T>>(this);
+        _optimizer = optimizer
+    ?? PaperOptimizerFactory.CreateFor<T, Tensor<T>, Tensor<T>>(this)
+    ?? new AdamWOptimizer<T, Tensor<T>, Tensor<T>>(this);
         base.SampleRate = _options.SampleRate;
         base.MelChannels = _options.MelChannels;
         base.HopSize = _options.HopSize;

--- a/src/TextToSpeech/Classic/GradTTS.cs
+++ b/src/TextToSpeech/Classic/GradTTS.cs
@@ -1,3 +1,5 @@
+using AiDotNet.LearningRateSchedulers;
+using AiDotNet.Enums;
 using AiDotNet.Attributes;
 using AiDotNet.Helpers;
 using AiDotNet.Interfaces;
@@ -49,6 +51,8 @@ namespace AiDotNet.TextToSpeech.Classic;
     Year = 2021,
     Authors = "Popov et al."
 )]
+[PaperOptimizer(OptimizerKind.Adam, LearningRate = 0.0001,
+                Source = "Popov et al. 2021, Sec. 4: Adam with the learning rate set to 0.0001.")]
 public partial class GradTTS<T> : TtsModelBase<T>, IAcousticModel<T>
 {
     private readonly GradTTSOptions _options;
@@ -93,7 +97,9 @@ public partial class GradTTS<T> : TtsModelBase<T>, IAcousticModel<T>
     {
         _options = options ?? new GradTTSOptions();
         _useNativeMode = true;
-        _optimizer = optimizer ?? new AdamWOptimizer<T, Tensor<T>, Tensor<T>>(this);
+        _optimizer = optimizer
+    ?? PaperOptimizerFactory.CreateFor<T, Tensor<T>, Tensor<T>>(this)
+    ?? new AdamWOptimizer<T, Tensor<T>, Tensor<T>>(this);
         base.SampleRate = _options.SampleRate;
         base.MelChannels = _options.MelChannels;
         base.HopSize = _options.HopSize;

--- a/src/TextToSpeech/Classic/PortaSpeech.cs
+++ b/src/TextToSpeech/Classic/PortaSpeech.cs
@@ -1,3 +1,5 @@
+using AiDotNet.LearningRateSchedulers;
+using AiDotNet.Enums;
 using AiDotNet.Attributes;
 using AiDotNet.Helpers;
 using AiDotNet.Interfaces;
@@ -49,6 +51,13 @@ namespace AiDotNet.TextToSpeech.Classic;
     Year = 2021,
     Authors = "Ren et al."
 )]
+[PaperOptimizer(OptimizerKind.Adam, Beta1 = 0.9, Beta2 = 0.98, Epsilon = 1e-9,
+                Schedule = LearningRateSchedulerType.Noam,
+                Provenance = RecipeProvenance.DerivedFromCitedWork,
+                Source = "Ren et al. 2021, Sec. 4.1: Adam with beta1 0.9, beta2 0.98 and epsilon 1e-9, "
+                        + "following the learning rate schedule of its reference [35], Vaswani et al. "
+                        + "2017, which is the inverse-square-root schedule with warmup declared here as "
+                        + "Noam. Training runs 320k steps to convergence.")]
 public partial class PortaSpeech<T> : TtsModelBase<T>, IAcousticModel<T>
 {
     private readonly PortaSpeechOptions _options;
@@ -264,15 +273,16 @@ public partial class PortaSpeech<T> : TtsModelBase<T>, IAcousticModel<T>
     {
         if (_options.WeightDecay > 0.0)
         {
-            return new AdamWOptimizer<T, Tensor<T>, Tensor<T>>(
-                this,
-                new AdamWOptimizerOptions<T, Tensor<T>, Tensor<T>>
-                {
-                    InitialLearningRate = _options.LearningRate,
-                    WeightDecay = _options.WeightDecay,
-                    UseAdaptiveBetas = false,
-                    UseAMSGrad = false,
-                });
+            return PaperOptimizerFactory.VerifyHandBuilt(this,
+            new AdamWOptimizer<T, Tensor<T>, Tensor<T>>(
+                    this,
+                    new AdamWOptimizerOptions<T, Tensor<T>, Tensor<T>>
+                    {
+                        InitialLearningRate = _options.LearningRate,
+                        WeightDecay = _options.WeightDecay,
+                        UseAdaptiveBetas = false,
+                        UseAMSGrad = false,
+                    }));
         }
 
         return new AdamOptimizer<T, Tensor<T>, Tensor<T>>(

--- a/src/TextToSpeech/Classic/ProDiff.cs
+++ b/src/TextToSpeech/Classic/ProDiff.cs
@@ -1,3 +1,4 @@
+using AiDotNet.Enums;
 using AiDotNet.Attributes;
 using AiDotNet.Helpers;
 using AiDotNet.Interfaces;
@@ -50,6 +51,10 @@ namespace AiDotNet.TextToSpeech.Classic;
     Year = 2022,
     Authors = "Huang et al."
 )]
+[PaperOptimizer(OptimizerKind.Adam, Beta1 = 0.9, Beta2 = 0.98, Epsilon = 1e-9,
+                ReferenceBatchSize = 64,
+                Source = "Huang et al. 2022, Sec. 4.1: the Adam optimizer with beta1 0.9, beta2 0.98 "
+                        + "and epsilon 1e-9, trained for 200,000 steps at a batch size of 64 sentences.")]
 public partial class ProDiff<T> : TtsModelBase<T>, IAcousticModel<T>
 {
     private readonly ProDiffOptions _options;
@@ -303,23 +308,24 @@ public partial class ProDiff<T> : TtsModelBase<T>, IAcousticModel<T>
 
         if (_options.WeightDecay > 0.0)
         {
-            return new AdamWOptimizer<T, Tensor<T>, Tensor<T>>(
-                this,
-                new AdamWOptimizerOptions<T, Tensor<T>, Tensor<T>>
-                {
-                    InitialLearningRate = scheduler.CurrentLearningRate,
-                    Beta1 = _options.OptimizerBeta1,
-                    Beta2 = _options.OptimizerBeta2,
-                    Epsilon = _options.OptimizerEpsilon,
-                    WeightDecay = _options.WeightDecay,
-                    EnableGradientClipping = clipGradients,
-                    MaxGradientNorm = maxGradientNorm,
-                    UseAdaptiveLearningRate = false,
-                    UseAdaptiveBetas = false,
-                    UseAMSGrad = false,
-                    LearningRateScheduler = scheduler,
-                    SchedulerStepMode = SchedulerStepMode.StepPerBatch,
-                });
+            return PaperOptimizerFactory.VerifyHandBuilt(this,
+            new AdamWOptimizer<T, Tensor<T>, Tensor<T>>(
+                    this,
+                    new AdamWOptimizerOptions<T, Tensor<T>, Tensor<T>>
+                    {
+                        InitialLearningRate = scheduler.CurrentLearningRate,
+                        Beta1 = _options.OptimizerBeta1,
+                        Beta2 = _options.OptimizerBeta2,
+                        Epsilon = _options.OptimizerEpsilon,
+                        WeightDecay = _options.WeightDecay,
+                        EnableGradientClipping = clipGradients,
+                        MaxGradientNorm = maxGradientNorm,
+                        UseAdaptiveLearningRate = false,
+                        UseAdaptiveBetas = false,
+                        UseAMSGrad = false,
+                        LearningRateScheduler = scheduler,
+                        SchedulerStepMode = SchedulerStepMode.StepPerBatch,
+                    }));
         }
 
         return new AdamOptimizer<T, Tensor<T>, Tensor<T>>(

--- a/src/TextToSpeech/Classic/SpeedySpeech.cs
+++ b/src/TextToSpeech/Classic/SpeedySpeech.cs
@@ -1,3 +1,5 @@
+using AiDotNet.LearningRateSchedulers;
+using AiDotNet.Enums;
 using AiDotNet.Attributes;
 using AiDotNet.Helpers;
 using AiDotNet.Interfaces;
@@ -49,6 +51,12 @@ namespace AiDotNet.TextToSpeech.Classic;
     Year = 2020,
     Authors = "Vainer and Durnov"
 )]
+[PaperOptimizer(OptimizerKind.Adam, LearningRate = 0.002, MaxGradientNorm = 1.0,
+                Schedule = LearningRateSchedulerType.ReduceOnPlateau,
+                Source = "Vainer and Dusek 2020, Sec. 4: the Adam optimizer with its default "
+                        + "parameters, gradient clipping at 1, and a base learning rate of 0.002. The "
+                        + "paper tried inverse-square-root decay and reduce-on-plateau and settled on "
+                        + "reduce-on-plateau.")]
 public partial class SpeedySpeech<T> : TtsModelBase<T>, IAcousticModel<T>
 {
     private readonly SpeedySpeechOptions _options;
@@ -97,13 +105,14 @@ public partial class SpeedySpeech<T> : TtsModelBase<T>, IAcousticModel<T>
         // AdamWOptimizer(this) silently takes AdamWOptimizerOptions' global 1e-3 default and drops
         // SpeedySpeechOptions.LearningRate (1e-4, inherited from TtsModelOptions) — a 10x over-rate,
         // and not the paper's rate either (Vainer & Dusek 2020 train SpeedySpeech with Adam at 1e-4).
-        _optimizer = optimizer ?? new AdamWOptimizer<T, Tensor<T>, Tensor<T>>(
-            this,
-            new AdamWOptimizerOptions<T, Tensor<T>, Tensor<T>>
-            {
-                InitialLearningRate = _options.LearningRate,
-                WeightDecay = _options.WeightDecay,
-            });
+        _optimizer = optimizer ?? PaperOptimizerFactory.VerifyHandBuilt(this,
+            new AdamWOptimizer<T, Tensor<T>, Tensor<T>>(
+                this,
+                new AdamWOptimizerOptions<T, Tensor<T>, Tensor<T>>
+                {
+                    InitialLearningRate = _options.LearningRate,
+                    WeightDecay = _options.WeightDecay,
+                }));
         base.SampleRate = _options.SampleRate;
         base.MelChannels = _options.MelChannels;
         base.HopSize = _options.HopSize;

--- a/src/TextToSpeech/CodecBased/NaturalSpeech2.cs
+++ b/src/TextToSpeech/CodecBased/NaturalSpeech2.cs
@@ -1,3 +1,5 @@
+using AiDotNet.LearningRateSchedulers;
+using AiDotNet.Enums;
 using AiDotNet.Attributes;
 using AiDotNet.Helpers;
 using AiDotNet.Interfaces;
@@ -50,6 +52,12 @@ namespace AiDotNet.TextToSpeech.CodecBased;
     Year = 2023,
     Authors = "Shen et al."
 )]
+[PaperOptimizer(OptimizerKind.AdamW, LearningRate = 5e-4, WarmupSteps = 32000,
+                Schedule = LearningRateSchedulerType.Noam,
+                Source = "Shen et al. 2023, Sec. 5.1: AdamW with a 5e-4 learning rate and 32k warmup "
+                        + "steps following the inverse square root schedule, declared here as Noam. The "
+                        + "separate 2e-4 Adam setting in the same section belongs to the audio codec, "
+                        + "which follows SoundStream, not to this model.")]
 public partial class NaturalSpeech2<T> : TtsModelBase<T>, IEndToEndTts<T>
 {
     private readonly NaturalSpeech2Options _options;
@@ -102,7 +110,9 @@ public partial class NaturalSpeech2<T> : TtsModelBase<T>, IEndToEndTts<T>
     {
         _options = options ?? new NaturalSpeech2Options();
         _useNativeMode = true;
-        _optimizer = optimizer ?? new AdamWOptimizer<T, Tensor<T>, Tensor<T>>(this);
+        _optimizer = optimizer
+    ?? PaperOptimizerFactory.CreateFor<T, Tensor<T>, Tensor<T>>(this)
+    ?? new AdamWOptimizer<T, Tensor<T>, Tensor<T>>(this);
         base.SampleRate = _options.SampleRate;
         base.MelChannels = _options.MelChannels;
         base.HopSize = _options.HopSize;

--- a/src/TextToSpeech/CodecBased/NaturalSpeech3.cs
+++ b/src/TextToSpeech/CodecBased/NaturalSpeech3.cs
@@ -1,3 +1,5 @@
+using AiDotNet.LearningRateSchedulers;
+using AiDotNet.Enums;
 using AiDotNet.Attributes;
 using AiDotNet.Helpers;
 using AiDotNet.Interfaces;
@@ -40,6 +42,13 @@ namespace AiDotNet.TextToSpeech.CodecBased;
     Year = 2024,
     Authors = "Ju et al."
 )]
+[PaperOptimizer(OptimizerKind.AdamW, LearningRate = 1e-4, Beta1 = 0.9, Beta2 = 0.98,
+                WarmupSteps = 5000, Schedule = LearningRateSchedulerType.Noam,
+                Source = "Ju et al. 2024, Sec. 5.1: AdamW with a learning rate of 1e-4, beta1 0.9 and "
+                        + "beta2 0.98, and 5K warmup steps following the inverse square root schedule, "
+                        + "declared here as Noam. No reference batch size is declared because the paper "
+                        + "gives the batch as 10K frames of latent vectors per GPU rather than as a "
+                        + "count of examples.")]
 public partial class NaturalSpeech3<T> : TtsModelBase<T>, IEndToEndTts<T>
 {
     private readonly NaturalSpeech3Options _options;
@@ -81,7 +90,9 @@ public partial class NaturalSpeech3<T> : TtsModelBase<T>, IEndToEndTts<T>
     {
         _options = options ?? new NaturalSpeech3Options();
         _useNativeMode = true;
-        _optimizer = optimizer ?? new AdamWOptimizer<T, Tensor<T>, Tensor<T>>(this);
+        _optimizer = optimizer
+    ?? PaperOptimizerFactory.CreateFor<T, Tensor<T>, Tensor<T>>(this)
+    ?? new AdamWOptimizer<T, Tensor<T>, Tensor<T>>(this);
         base.SampleRate = _options.SampleRate;
         base.MelChannels = _options.MelChannels;
         base.HopSize = _options.HopSize;

--- a/src/Video/ActionRecognition/SlowFast.cs
+++ b/src/Video/ActionRecognition/SlowFast.cs
@@ -1,3 +1,5 @@
+using AiDotNet.Optimizers;
+using AiDotNet.LearningRateSchedulers;
 using System.IO;
 using AiDotNet.ActivationFunctions;
 using AiDotNet.Attributes;
@@ -63,6 +65,15 @@ namespace AiDotNet.Video.ActionRecognition;
     Direction = TensorLayoutDirection.Input, BatchOptional = true)]
 [TensorLayout(TensorAxis.Batch, TensorAxis.Classes,
     Direction = TensorLayoutDirection.Output, BatchOptional = true)]
+[PaperOptimizer(OptimizerKind.SgdMomentum, LearningRate = 1.6, WeightDecay = 1e-4,
+                Momentum = 0.9, ReferenceBatchSize = 1024, WarmupSteps = 1000,
+                MinLearningRate = 0,
+                Schedule = LearningRateSchedulerType.CosineAnnealing,
+                Source = "Feichtenhofer et al. 2019, Sec. 4.1: synchronized SGD with a momentum of 0.9, "
+                        + "a weight decay of 1e-4 and a mini-batch of 1024 clips, under a half-period "
+                        + "cosine decay from a base learning rate of 1.6, with linear warm-up over the "
+                        + "first 1k iterations. The AVA experiments instead warm up over 8k iterations "
+                        + "and use a weight decay of 1e-7.")]
 public partial class SlowFast<T> : NeuralNetworkBase<T>
 {
     private readonly SlowFastOptions _options;
@@ -231,7 +242,8 @@ public partial class SlowFast<T> : NeuralNetworkBase<T>
         _imageSize = architecture.InputHeight > 0 ? architecture.InputHeight : 224;
 
         _lossFunction = lossFunction ?? new CrossEntropyWithLogitsLoss<T>();
-        _optimizer = optimizer ?? new AdamOptimizer<T, Tensor<T>, Tensor<T>>(this);
+        _optimizer = optimizer ?? PaperOptimizerFactory.VerifyHandBuilt(this,
+            new AdamOptimizer<T, Tensor<T>, Tensor<T>>(this));
         SetBaseTrainOptimizer(_optimizer);
         _probabilityActivation = probabilityActivation ?? new SoftmaxActivation<T>();
         _customFastLayers = customFastLayers;

--- a/src/Video/ActionRecognition/TimeSformer.cs
+++ b/src/Video/ActionRecognition/TimeSformer.cs
@@ -1,3 +1,5 @@
+using AiDotNet.Optimizers;
+using AiDotNet.LearningRateSchedulers;
 using System.IO;
 using AiDotNet.Attributes;
 using AiDotNet.Enums;
@@ -78,6 +80,13 @@ namespace AiDotNet.Video.ActionRecognition;
     Direction = TensorLayoutDirection.Input, BatchOptional = true)]
 [TensorLayout(TensorAxis.Batch, TensorAxis.Classes,
     Direction = TensorLayoutDirection.Output, BatchOptional = true)]
+[PaperOptimizer(OptimizerKind.SgdMomentum, LearningRate = 0.005, WeightDecay = 1e-4,
+                Momentum = 0.9, ReferenceBatchSize = 16, DecayRate = 0.1,
+                Milestones = [11, 14], Schedule = LearningRateSchedulerType.MultiStep,
+                ScheduleStepMode = SchedulerStepMode.StepPerEpoch,
+                Source = "Bertasius et al. 2021, Sec. 4: synchronized SGD with a momentum of 0.9, a "
+                        + "weight decay of 0.0001 and a batch size of 16, trained for 15 epochs from an "
+                        + "initial learning rate of 0.005 that is divided by 10 at epochs 11 and 14.")]
 public partial class TimeSformer<T> : NeuralNetworkBase<T>
 {
     private readonly TimeSformerOptions _options;
@@ -216,7 +225,8 @@ public partial class TimeSformer<T> : NeuralNetworkBase<T>
         _attentionType = attentionType;
 
         _lossFunction = lossFunction ?? new CrossEntropyWithLogitsLoss<T>();
-        _optimizer = optimizer ?? new AdamOptimizer<T, Tensor<T>, Tensor<T>>(this);
+        _optimizer = optimizer ?? PaperOptimizerFactory.VerifyHandBuilt(this,
+            new AdamOptimizer<T, Tensor<T>, Tensor<T>>(this));
 
         InitializeLayers();
     }

--- a/src/Video/Denoising/BSVD.cs
+++ b/src/Video/Denoising/BSVD.cs
@@ -1,3 +1,4 @@
+using AiDotNet.LearningRateSchedulers;
 using System.IO;
 using AiDotNet.Attributes;
 using AiDotNet.Enums;
@@ -51,6 +52,9 @@ namespace AiDotNet.Video.Denoising;
     "https://arxiv.org/abs/2207.06937",
     Year = 2022,
     Authors = "Chenyang Qi, Junming Chen, Xin Yang, Qifeng Chen")]
+[PaperOptimizer(OptimizerKind.Adam, LearningRate = 1e-3, ReferenceBatchSize = 16,
+                Source = "Qi et al. 2022, Appendix A.5: Adam at an initial learning rate of 1e-3, "
+                        + "optimized for 700,000 iterations with clips at a batch size of 16.")]
 public partial class BSVD<T> : VideoDenoisingBase<T>
 {
     private readonly BSVDOptions _options;
@@ -90,27 +94,28 @@ public partial class BSVD<T> : VideoDenoisingBase<T>
     {
         _options = options ?? new BSVDOptions();
         _useNativeMode = true;
-        _optimizer = optimizer ?? new AdamOptimizer<T, Tensor<T>, Tensor<T>>(
-            this,
-            new AdamOptimizerOptions<T, Tensor<T>, Tensor<T>>
-            {
-                InitialLearningRate = _options.LearningRate,
-                // Optimizer settings taken from the reference implementation's training config
-                // (ChenyangQiQi/BSVD, options/train/bsvd_c64_unblind.yml), not guessed:
-                //   optim_g: Adam, lr 1e-3, betas [0.9, 0.99], weight_decay 0
-                //   use_grad_clip: 5
-                // beta2 = 0.99 rather than the 0.999 default adapts the second moment about ten
-                // times faster, which materially shortens Adam's early-step overshoot; combined
-                // with the grad-norm bound it is what keeps the first iterations well-behaved.
-                Beta1 = _options.AdamBeta1,
-                Beta2 = _options.AdamBeta2,
-                Epsilon = 1e-8,
-                UseAdaptiveLearningRate = false,
-                UseAdaptiveBetas = false,
-                UseAMSGrad = false,
-                EnableGradientClipping = true,
-                MaxGradientNorm = _options.GradientClipNorm
-            });
+        _optimizer = optimizer ?? PaperOptimizerFactory.VerifyHandBuilt(this,
+            new AdamOptimizer<T, Tensor<T>, Tensor<T>>(
+                this,
+                new AdamOptimizerOptions<T, Tensor<T>, Tensor<T>>
+                {
+                    InitialLearningRate = _options.LearningRate,
+                    // Optimizer settings taken from the reference implementation's training config
+                    // (ChenyangQiQi/BSVD, options/train/bsvd_c64_unblind.yml), not guessed:
+                    //   optim_g: Adam, lr 1e-3, betas [0.9, 0.99], weight_decay 0
+                    //   use_grad_clip: 5
+                    // beta2 = 0.99 rather than the 0.999 default adapts the second moment about ten
+                    // times faster, which materially shortens Adam's early-step overshoot; combined
+                    // with the grad-norm bound it is what keeps the first iterations well-behaved.
+                    Beta1 = _options.AdamBeta1,
+                    Beta2 = _options.AdamBeta2,
+                    Epsilon = 1e-8,
+                    UseAdaptiveLearningRate = false,
+                    UseAdaptiveBetas = false,
+                    UseAMSGrad = false,
+                    EnableGradientClipping = true,
+                    MaxGradientNorm = _options.GradientClipNorm
+                }));
         IsBlindDenoising = true;
         InitializeLayers();
     }

--- a/src/Video/Denoising/FastDVDNet.cs
+++ b/src/Video/Denoising/FastDVDNet.cs
@@ -1,4 +1,6 @@
-﻿using System.IO;
+﻿using AiDotNet.Optimizers;
+using AiDotNet.LearningRateSchedulers;
+using System.IO;
 using AiDotNet.Attributes;
 using AiDotNet.Enums;
 using AiDotNet.Extensions;
@@ -58,6 +60,14 @@ namespace AiDotNet.Video.Denoising;
     "https://arxiv.org/abs/1907.01361",
     Year = 2020,
     Authors = "Matias Tassano, Julie Delon, Thomas Veit")]
+[PaperOptimizer(OptimizerKind.Adam, LearningRate = 1e-3, ReferenceBatchSize = 96,
+                DecayRate = 0.1, Milestones = [50, 60],
+                Schedule = LearningRateSchedulerType.MultiStep,
+                ScheduleStepMode = SchedulerStepMode.StepPerEpoch,
+                Source = "Tassano et al. 2020, Sec. 4: the ADAM algorithm with its other "
+                        + "hyper-parameters at their defaults, a mini-batch size of 96 over 80 epochs, "
+                        + "and a learning rate starting at 1e-3 for the first 50 epochs then changing to "
+                        + "1e-4 for the following 10.")]
 public partial class FastDVDNet<T> : VideoDenoisingBase<T>
 {
     private readonly FastDVDNetOptions _options;
@@ -121,19 +131,20 @@ public partial class FastDVDNet<T> : VideoDenoisingBase<T>
         _imageWidth = architecture.InputWidth > 0 ? architecture.InputWidth : 854;
 
         _lossFunction = lossFunction ?? new MeanSquaredErrorLoss<T>();
-        _optimizer = optimizer ?? new AdamOptimizer<T, Tensor<T>, Tensor<T>>(
-            this,
-            new Models.Options.AdamOptimizerOptions<T, Tensor<T>, Tensor<T>>
-            {
-                // The official train_fastdvdnet.py uses torch.optim.Adam at 1e-3.
-                InitialLearningRate = _options.LearningRate,
-                Beta1 = 0.9,
-                Beta2 = 0.999,
-                Epsilon = 1e-8,
-                UseAdaptiveLearningRate = false,
-                UseAdaptiveBetas = false,
-                UseAMSGrad = false
-            });
+        _optimizer = optimizer ?? PaperOptimizerFactory.VerifyHandBuilt(this,
+            new AdamOptimizer<T, Tensor<T>, Tensor<T>>(
+                this,
+                new Models.Options.AdamOptimizerOptions<T, Tensor<T>, Tensor<T>>
+                {
+                    // The official train_fastdvdnet.py uses torch.optim.Adam at 1e-3.
+                    InitialLearningRate = _options.LearningRate,
+                    Beta1 = 0.9,
+                    Beta2 = 0.999,
+                    Epsilon = 1e-8,
+                    UseAdaptiveLearningRate = false,
+                    UseAdaptiveBetas = false,
+                    UseAMSGrad = false
+                }));
 
         InitializeLayers();
     }

--- a/src/Video/Denoising/FloRNN.cs
+++ b/src/Video/Denoising/FloRNN.cs
@@ -1,3 +1,4 @@
+using AiDotNet.LearningRateSchedulers;
 using System.IO;
 using AiDotNet.Attributes;
 using AiDotNet.Enums;
@@ -50,6 +51,8 @@ namespace AiDotNet.Video.Denoising;
     "https://arxiv.org/abs/2204.05532",
     Year = 2022,
     Authors = "Junyi Li, Xiaohe Wu, Zhenxing Niu, Wangmeng Zuo")]
+[PaperOptimizer(OptimizerKind.Adam, LearningRate = 1e-4,
+                Source = "Li et al. 2022, Sec. 4.1: Adam with an initial learning rate of 1e-4.")]
 public partial class FloRNN<T> : VideoDenoisingBase<T>
 {
     private readonly FloRNNOptions _options;
@@ -98,18 +101,19 @@ public partial class FloRNN<T> : VideoDenoisingBase<T>
         _useNativeMode = true;
         // The released FloRNN training script uses torch.optim.Adam at 1e-4
         // with Adam's standard fixed moments (train_models/sRGB_train.py).
-        _optimizer = optimizer ?? new AdamOptimizer<T, Tensor<T>, Tensor<T>>(
-            this,
-            new Models.Options.AdamOptimizerOptions<T, Tensor<T>, Tensor<T>>
-            {
-                InitialLearningRate = _options.LearningRate,
-                Beta1 = 0.9,
-                Beta2 = 0.999,
-                Epsilon = 1e-8,
-                UseAdaptiveLearningRate = false,
-                UseAdaptiveBetas = false,
-                UseAMSGrad = false
-            });
+        _optimizer = optimizer ?? PaperOptimizerFactory.VerifyHandBuilt(this,
+            new AdamOptimizer<T, Tensor<T>, Tensor<T>>(
+                this,
+                new Models.Options.AdamOptimizerOptions<T, Tensor<T>, Tensor<T>>
+                {
+                    InitialLearningRate = _options.LearningRate,
+                    Beta1 = 0.9,
+                    Beta2 = 0.999,
+                    Epsilon = 1e-8,
+                    UseAdaptiveLearningRate = false,
+                    UseAdaptiveBetas = false,
+                    UseAMSGrad = false
+                }));
         InitializeLayers();
     }
 

--- a/src/Video/Denoising/ShiftNet.cs
+++ b/src/Video/Denoising/ShiftNet.cs
@@ -1,3 +1,4 @@
+using AiDotNet.LearningRateSchedulers;
 using System.IO;
 using AiDotNet.Attributes;
 using AiDotNet.Enums;
@@ -70,6 +71,11 @@ namespace AiDotNet.Video.Denoising;
     "https://arxiv.org/abs/2206.10810",
     Year = 2023,
     Authors = "Dasong Li, Xiaoyu Shi, Yi Zhang, Ka Chun Cheung, Simon See, Xiaogang Wang, Hongwei Qin, Hongsheng Li")]
+[PaperOptimizer(OptimizerKind.Adam, LearningRate = 4e-4, ReferenceBatchSize = 8,
+                MinLearningRate = 1e-7,
+                Schedule = LearningRateSchedulerType.CosineAnnealing,
+                Source = "Li et al. 2022, Sec. 4.1: the Adam optimizer with the learning rate decreased "
+                        + "from 4e-4 to 1e-7 by cosine annealing, at a batch size of 8 over 750 epochs.")]
 public partial class ShiftNet<T> : VideoDenoisingBase<T>
 {
     private readonly ShiftNetOptions _options;

--- a/src/Video/Denoising/UDVD.cs
+++ b/src/Video/Denoising/UDVD.cs
@@ -1,3 +1,4 @@
+using AiDotNet.LearningRateSchedulers;
 using System.IO;
 using AiDotNet.Attributes;
 using AiDotNet.Enums;
@@ -55,6 +56,12 @@ namespace AiDotNet.Video.Denoising;
     "https://arxiv.org/abs/2011.15045",
     Year = 2021,
     Authors = "Dev Yashpal Sheth, Sreyas Mohan, Joshua L. Vincent, Ramon Manzorro, Peter A. Crozier, Mitesh M. Khapra, Eero P. Simoncelli, Carlos Fernandez-Granda")]
+[PaperOptimizer(OptimizerKind.Adam, LearningRate = 1e-4, DecayRate = 0.5,
+                Milestones = [20, 25, 30],
+                Schedule = LearningRateSchedulerType.MultiStep,
+                ScheduleStepMode = SchedulerStepMode.StepPerEpoch,
+                Source = "Sheth et al. 2021, Optimization Details: Adam from a starting learning rate "
+                        + "of 1e-4, halved at epochs 20, 25 and 30 over a total of 40 epochs.")]
 public partial class UDVD<T> : VideoDenoisingBase<T>
 {
     private readonly UDVDOptions _options;
@@ -99,12 +106,13 @@ public partial class UDVD<T> : VideoDenoisingBase<T>
         // The paper/released training recipe uses Adam at 1e-4. Merely storing an optimizer is not
         // sufficient: Train must also pass this instance into TrainWithTape (see below), otherwise
         // the base trainer silently falls back to its generic optimizer and UDVD diverges.
-        _optimizer = optimizer ?? new AdamOptimizer<T, Tensor<T>, Tensor<T>>(
-            this,
-            new AdamOptimizerOptions<T, Tensor<T>, Tensor<T>>
-            {
-                InitialLearningRate = _options.LearningRate,
-            });
+        _optimizer = optimizer ?? PaperOptimizerFactory.VerifyHandBuilt(this,
+            new AdamOptimizer<T, Tensor<T>, Tensor<T>>(
+                this,
+                new AdamOptimizerOptions<T, Tensor<T>, Tensor<T>>
+                {
+                    InitialLearningRate = _options.LearningRate,
+                }));
         IsBlindDenoising = true;
         InitializeLayers();
     }

--- a/src/Video/Depth/DepthAnythingV2.cs
+++ b/src/Video/Depth/DepthAnythingV2.cs
@@ -1,3 +1,5 @@
+using AiDotNet.Optimizers;
+using AiDotNet.LearningRateSchedulers;
 using System.IO;
 using AiDotNet.Attributes;
 using AiDotNet.Enums;
@@ -69,6 +71,11 @@ namespace AiDotNet.Video.Depth;
     Direction = TensorLayoutDirection.Input, BatchOptional = true)]
 [TensorLayout(TensorAxis.Batch, TensorAxis.Height, TensorAxis.Width,
     Direction = TensorLayoutDirection.Output, BatchOptional = true)]
+[PaperOptimizer(OptimizerKind.Adam,
+                Source = "Yang et al. 2024, Sec. 4: the Adam optimizer. No single learning rate is "
+                        + "declared because the paper sets 5e-6 for the encoder and 5e-5 for the "
+                        + "decoder, and this model builds one optimizer over both, so neither rate would "
+                        + "be correct for all of it.")]
 public partial class DepthAnythingV2<T> : NeuralNetworkBase<T>
 {
     private readonly DepthAnythingV2Options _options;

--- a/src/Video/Depth/MiDaS.cs
+++ b/src/Video/Depth/MiDaS.cs
@@ -1,4 +1,6 @@
-﻿using System.IO;
+﻿using AiDotNet.Optimizers;
+using AiDotNet.LearningRateSchedulers;
+using System.IO;
 using AiDotNet.Attributes;
 using AiDotNet.Enums;
 using AiDotNet.Helpers;
@@ -64,6 +66,9 @@ namespace AiDotNet.Video.Depth;
     Direction = TensorLayoutDirection.Input, BatchOptional = true)]
 [TensorLayout(TensorAxis.Batch, TensorAxis.Height, TensorAxis.Width,
     Direction = TensorLayoutDirection.Output, BatchOptional = true)]
+[PaperOptimizer(OptimizerKind.Adam, LearningRate = 1e-4,
+                Source = "Ranftl et al. 2020, Sec. 5: Adam with a learning rate of 1e-4 for randomly "
+                        + "initialized layers.")]
 public partial class MiDaS<T> : NeuralNetworkBase<T>
 {
     private readonly MiDaSOptions _options;
@@ -142,7 +147,9 @@ public partial class MiDaS<T> : NeuralNetworkBase<T>
         _variant = variant;
 
         _lossFunction = lossFunction ?? new ScaleInvariantDepthLoss<T>();
-        _optimizer = optimizer ?? new AdamOptimizer<T, Tensor<T>, Tensor<T>>(this);
+        _optimizer = optimizer
+    ?? PaperOptimizerFactory.CreateFor<T, Tensor<T>, Tensor<T>>(this)
+    ?? new AdamOptimizer<T, Tensor<T>, Tensor<T>>(this);
 
         InitializeLayers();
     }

--- a/src/Video/Enhancement/StreamDiffVSR.cs
+++ b/src/Video/Enhancement/StreamDiffVSR.cs
@@ -1,3 +1,4 @@
+using AiDotNet.LearningRateSchedulers;
 using AiDotNet.Attributes;
 using AiDotNet.Enums;
 using AiDotNet.Helpers;
@@ -54,6 +55,11 @@ namespace AiDotNet.Video.Enhancement;
     "https://arxiv.org/abs/2512.23709",
     Year = 2025,
     Authors = "Hau-Shiang Shiu, Chin-Yang Lin, Zhixiang Wang, Chi-Wei Hsiao, Po-Fan Yu, Yu-Chih Chen, Yu-Lun Liu")]
+[PaperOptimizer(OptimizerKind.AdamW, LearningRate = 5e-5, Beta1 = 0.9, Beta2 = 0.999,
+                WeightDecay = 0.01, ReferenceBatchSize = 16,
+                Schedule = LearningRateSchedulerType.Constant,
+                Source = "Stream-DiffVSR: AdamW with beta1 0.9, beta2 0.999 and a weight decay of 0.01, "
+                        + "at a batch size of 16 and a constant learning rate of 5e-5.")]
 public partial class StreamDiffVSR<T> : VideoSuperResolutionBase<T>
 {
     #region Fields
@@ -99,17 +105,18 @@ public partial class StreamDiffVSR<T> : VideoSuperResolutionBase<T>
         // SetBaseTrainOptimizer call and no GetOrCreateBaseOptimizer override — so training silently
         // used the base class's lazily-created Adam and this field was dead. The measured symptom was
         // the memorization probe rising monotonically (0.256 -> 0.471) instead of descending.
-        _optimizer = optimizer ?? new AdamWOptimizer<T, Tensor<T>, Tensor<T>>(
-            this,
-            new AiDotNet.Models.Options.AdamWOptimizerOptions<T, Tensor<T>, Tensor<T>>
-            {
-                InitialLearningRate = _options.LearningRate,
-                Beta1 = _options.AdamBeta1,
-                Beta2 = _options.AdamBeta2,
-                WeightDecay = _options.WeightDecay,
-                EnableGradientClipping = true,
-                MaxGradientNorm = 1.0
-            });
+        _optimizer = optimizer ?? PaperOptimizerFactory.VerifyHandBuilt(this,
+            new AdamWOptimizer<T, Tensor<T>, Tensor<T>>(
+                this,
+                new AiDotNet.Models.Options.AdamWOptimizerOptions<T, Tensor<T>, Tensor<T>>
+                {
+                    InitialLearningRate = _options.LearningRate,
+                    Beta1 = _options.AdamBeta1,
+                    Beta2 = _options.AdamBeta2,
+                    WeightDecay = _options.WeightDecay,
+                    EnableGradientClipping = true,
+                    MaxGradientNorm = 1.0
+                }));
         SetBaseTrainOptimizer(_optimizer);
         ScaleFactor = _options.ScaleFactor;
         InitializeLayers();

--- a/src/VisionLanguage/Document/GOTOCR2.cs
+++ b/src/VisionLanguage/Document/GOTOCR2.cs
@@ -1,3 +1,5 @@
+using AiDotNet.LearningRateSchedulers;
+using AiDotNet.Enums;
 using AiDotNet.Attributes;
 using AiDotNet.Extensions;
 using AiDotNet.Helpers;
@@ -57,6 +59,13 @@ namespace AiDotNet.VisionLanguage.Document;
     Year = 2024,
     Authors = "Wei et al."
 )]
+[PaperOptimizer(OptimizerKind.AdamW, LearningRate = 1e-4, ReferenceBatchSize = 128,
+                MinLearningRate = 0,
+                Schedule = LearningRateSchedulerType.CosineAnnealing,
+                Phase = TrainingPhase.PreTraining,
+                Source = "Wei et al. 2024, Sec. 3.3: the AdamW optimizer with a cosine annealing "
+                        + "scheduler and a start learning rate of 1e-4, at a global batch size of 128 "
+                        + "over 3 epochs of pre-training.")]
 public partial class GOTOCR2<T> : VisionLanguageModelBase<T>, IDocumentUnderstandingModel<T>
 {
     private readonly GOTOCR2Options _options;
@@ -100,7 +109,9 @@ public partial class GOTOCR2<T> : VisionLanguageModelBase<T>, IDocumentUnderstan
     {
         _options = options ?? new GOTOCR2Options();
         _useNativeMode = true;
-        _optimizer = optimizer ?? new AdamWOptimizer<T, Tensor<T>, Tensor<T>>(this);
+        _optimizer = optimizer
+    ?? PaperOptimizerFactory.CreateFor<T, Tensor<T>, Tensor<T>>(this)
+    ?? new AdamWOptimizer<T, Tensor<T>, Tensor<T>>(this);
         base.ImageSize = _options.ImageSize;
         base.ImageChannels = 3;
         base.EmbeddingDim = _options.DecoderDim;

--- a/src/VisionLanguage/Document/LayoutLMv3.cs
+++ b/src/VisionLanguage/Document/LayoutLMv3.cs
@@ -1,3 +1,5 @@
+using AiDotNet.LearningRateSchedulers;
+using AiDotNet.Enums;
 using AiDotNet.Attributes;
 using AiDotNet.Extensions;
 using AiDotNet.Helpers;
@@ -58,6 +60,13 @@ namespace AiDotNet.VisionLanguage.Document;
     Year = 2022,
     Authors = "Huang et al."
 )]
+[PaperOptimizer(OptimizerKind.Adam, LearningRate = 1e-4, WeightDecay = 0.05,
+                ReferenceBatchSize = 2048, WarmupFraction = 0.048,
+                Schedule = LearningRateSchedulerType.LinearWarmup,
+                Source = "Huang et al. 2022, Sec. 3.4: Adam with a batch size of 2,048 for 500,000 "
+                        + "steps, a learning rate of 1e-4 for the BASE model and a linear warmup over "
+                        + "the first 4.8 percent of steps. The paper states no post-warmup decay, so "
+                        + "none is declared. The LARGE model uses 1e-5.")]
 public partial class LayoutLMv3<T> : VisionLanguageModelBase<T>, IDocumentUnderstandingModel<T>
 {
     private readonly LayoutLMv3Options _options;
@@ -101,7 +110,9 @@ public partial class LayoutLMv3<T> : VisionLanguageModelBase<T>, IDocumentUnders
     {
         _options = options ?? new LayoutLMv3Options();
         _useNativeMode = true;
-        _optimizer = optimizer ?? new AdamWOptimizer<T, Tensor<T>, Tensor<T>>(this);
+        _optimizer = optimizer
+    ?? PaperOptimizerFactory.CreateFor<T, Tensor<T>, Tensor<T>>(this)
+    ?? new AdamWOptimizer<T, Tensor<T>, Tensor<T>>(this);
         base.ImageSize = _options.ImageSize;
         base.ImageChannels = 3;
         base.EmbeddingDim = _options.DecoderDim;

--- a/src/VisionLanguage/Document/MPLUGDocOwl15.cs
+++ b/src/VisionLanguage/Document/MPLUGDocOwl15.cs
@@ -1,3 +1,5 @@
+using AiDotNet.LearningRateSchedulers;
+using AiDotNet.Enums;
 using AiDotNet.Attributes;
 using AiDotNet.Extensions;
 using AiDotNet.Helpers;
@@ -59,6 +61,14 @@ namespace AiDotNet.VisionLanguage.Document;
     Year = 2024,
     Authors = "Hu et al."
 )]
+[PaperOptimizer(OptimizerKind.AdamW, LearningRate = 1e-4, ReferenceBatchSize = 1024,
+                Phase = TrainingPhase.PreTraining,
+                Source = "Hu et al. 2024, Sec. 4.1: unified structure learning on DocStruct4M runs "
+                        + "12,000 iterations with a learning rate of 1e-4 and a batch size of 1,024.")]
+[PaperOptimizer(OptimizerKind.AdamW, LearningRate = 2e-5, ReferenceBatchSize = 256,
+                Phase = TrainingPhase.FineTuning,
+                Source = "Hu et al. 2024, Sec. 4.1: multi-task fine-tuning runs 6,500 iterations with a "
+                        + "batch size of 256 and a learning rate of 2e-5.")]
 public partial class MPLUGDocOwl15<T> : VisionLanguageModelBase<T>, IDocumentUnderstandingModel<T>
 {
     private readonly MPLUGDocOwl15Options _options;
@@ -102,7 +112,9 @@ public partial class MPLUGDocOwl15<T> : VisionLanguageModelBase<T>, IDocumentUnd
     {
         _options = options ?? new MPLUGDocOwl15Options();
         _useNativeMode = true;
-        _optimizer = optimizer ?? new AdamWOptimizer<T, Tensor<T>, Tensor<T>>(this);
+        _optimizer = optimizer
+    ?? PaperOptimizerFactory.CreateFor<T, Tensor<T>, Tensor<T>>(this)
+    ?? new AdamWOptimizer<T, Tensor<T>, Tensor<T>>(this);
         base.ImageSize = _options.ImageSize;
         base.ImageChannels = 3;
         base.EmbeddingDim = _options.DecoderDim;

--- a/src/VisionLanguage/Document/MPLUGDocOwl2.cs
+++ b/src/VisionLanguage/Document/MPLUGDocOwl2.cs
@@ -1,3 +1,5 @@
+using AiDotNet.LearningRateSchedulers;
+using AiDotNet.Enums;
 using AiDotNet.Attributes;
 using AiDotNet.Extensions;
 using AiDotNet.Helpers;
@@ -59,6 +61,10 @@ namespace AiDotNet.VisionLanguage.Document;
     Year = 2024,
     Authors = "Hu et al."
 )]
+[PaperOptimizer(OptimizerKind.AdamW, LearningRate = 1e-4, ReferenceBatchSize = 1024,
+                Phase = TrainingPhase.PreTraining,
+                Source = "Hu et al. 2024, Sec. 4.1: the first stage trains for 12k steps with a batch "
+                        + "size of 1,024 and a learning rate of 1e-4.")]
 public partial class MPLUGDocOwl2<T> : VisionLanguageModelBase<T>, IDocumentUnderstandingModel<T>
 {
     private readonly MPLUGDocOwl2Options _options;
@@ -102,7 +108,9 @@ public partial class MPLUGDocOwl2<T> : VisionLanguageModelBase<T>, IDocumentUnde
     {
         _options = options ?? new MPLUGDocOwl2Options();
         _useNativeMode = true;
-        _optimizer = optimizer ?? new AdamWOptimizer<T, Tensor<T>, Tensor<T>>(this);
+        _optimizer = optimizer
+    ?? PaperOptimizerFactory.CreateFor<T, Tensor<T>, Tensor<T>>(this)
+    ?? new AdamWOptimizer<T, Tensor<T>, Tensor<T>>(this);
         base.ImageSize = _options.ImageSize;
         base.ImageChannels = 3;
         base.EmbeddingDim = _options.DecoderDim;

--- a/src/VisionLanguage/Document/Nougat.cs
+++ b/src/VisionLanguage/Document/Nougat.cs
@@ -1,3 +1,5 @@
+using AiDotNet.LearningRateSchedulers;
+using AiDotNet.Enums;
 using AiDotNet.Attributes;
 using AiDotNet.Extensions;
 using AiDotNet.Helpers;
@@ -58,6 +60,10 @@ namespace AiDotNet.VisionLanguage.Document;
     Year = 2023,
     Authors = "Blecher et al."
 )]
+[PaperOptimizer(OptimizerKind.AdamW, LearningRate = 5e-5, ReferenceBatchSize = 192,
+                Source = "Blecher et al. 2023, Sec. 4: an AdamW optimizer trained for 3 epochs at an "
+                        + "effective batch size of 192, with an initial learning rate of 5e-5 that is "
+                        + "reduced by a fixed factor during training.")]
 public partial class Nougat<T> : VisionLanguageModelBase<T>, IDocumentUnderstandingModel<T>
 {
     private readonly NougatOptions _options;
@@ -101,7 +107,9 @@ public partial class Nougat<T> : VisionLanguageModelBase<T>, IDocumentUnderstand
     {
         _options = options ?? new NougatOptions();
         _useNativeMode = true;
-        _optimizer = optimizer ?? new AdamWOptimizer<T, Tensor<T>, Tensor<T>>(this);
+        _optimizer = optimizer
+    ?? PaperOptimizerFactory.CreateFor<T, Tensor<T>, Tensor<T>>(this)
+    ?? new AdamWOptimizer<T, Tensor<T>, Tensor<T>>(this);
         base.ImageSize = _options.ImageSize;
         base.ImageChannels = 3;
         base.EmbeddingDim = _options.DecoderDim;

--- a/src/VisionLanguage/Document/Pix2Struct.cs
+++ b/src/VisionLanguage/Document/Pix2Struct.cs
@@ -1,3 +1,5 @@
+using AiDotNet.LearningRateSchedulers;
+using AiDotNet.Enums;
 using AiDotNet.Attributes;
 using AiDotNet.Extensions;
 using AiDotNet.Helpers;
@@ -58,6 +60,12 @@ namespace AiDotNet.VisionLanguage.Document;
     Year = 2023,
     Authors = "Lee et al."
 )]
+[PaperOptimizer(OptimizerKind.Adafactor, LearningRate = 0.01, ReferenceBatchSize = 2048,
+                WarmupSteps = 1000, MinLearningRate = 0,
+                Schedule = LearningRateSchedulerType.CosineAnnealing,
+                Source = "Lee et al. 2023, Sec. 3: optimized using Adafactor, with a linear warmup of "
+                        + "1000 steps to a peak learning rate of 0.01 followed by cosine decay to 0, at "
+                        + "a batch size of 2048.")]
 public partial class Pix2Struct<T> : VisionLanguageModelBase<T>, IDocumentUnderstandingModel<T>
 {
     private readonly Pix2StructOptions _options;
@@ -101,7 +109,9 @@ public partial class Pix2Struct<T> : VisionLanguageModelBase<T>, IDocumentUnders
     {
         _options = options ?? new Pix2StructOptions();
         _useNativeMode = true;
-        _optimizer = optimizer ?? new AdamWOptimizer<T, Tensor<T>, Tensor<T>>(this);
+        _optimizer = optimizer
+    ?? PaperOptimizerFactory.CreateFor<T, Tensor<T>, Tensor<T>>(this)
+    ?? new AdamWOptimizer<T, Tensor<T>, Tensor<T>>(this);
         base.ImageSize = _options.ImageSize;
         base.ImageChannels = 3;
         base.EmbeddingDim = _options.DecoderDim;

--- a/src/VisionLanguage/Document/TextMonkey.cs
+++ b/src/VisionLanguage/Document/TextMonkey.cs
@@ -1,3 +1,5 @@
+using AiDotNet.LearningRateSchedulers;
+using AiDotNet.Enums;
 using AiDotNet.Attributes;
 using AiDotNet.Extensions;
 using AiDotNet.Helpers;
@@ -59,6 +61,17 @@ namespace AiDotNet.VisionLanguage.Document;
     Year = 2024,
     Authors = "Liu et al."
 )]
+[PaperOptimizer(OptimizerKind.AdamW, LearningRate = 1e-5, ReferenceBatchSize = 128,
+                WarmupSteps = 150, MinLearningRate = 0,
+                Schedule = LearningRateSchedulerType.CosineAnnealing,
+                Phase = TrainingPhase.PreTraining,
+                Source = "Liu et al. 2024, Sec. 4.1: AdamW at a learning rate of 1e-5 for the initial "
+                        + "stage under a cosine schedule, with a 150-step warmup and batches of 128.")]
+[PaperOptimizer(OptimizerKind.AdamW, LearningRate = 5e-6, MinLearningRate = 0,
+                Schedule = LearningRateSchedulerType.CosineAnnealing,
+                Phase = TrainingPhase.FineTuning,
+                Source = "Liu et al. 2024, Sec. 4.1: the subsequent stage reduces the learning rate to "
+                        + "5e-6, otherwise as the initial stage.")]
 public partial class TextMonkey<T> : VisionLanguageModelBase<T>, IDocumentUnderstandingModel<T>
 {
     private readonly TextMonkeyOptions _options;
@@ -102,7 +115,9 @@ public partial class TextMonkey<T> : VisionLanguageModelBase<T>, IDocumentUnders
     {
         _options = options ?? new TextMonkeyOptions();
         _useNativeMode = true;
-        _optimizer = optimizer ?? new AdamWOptimizer<T, Tensor<T>, Tensor<T>>(this);
+        _optimizer = optimizer
+    ?? PaperOptimizerFactory.CreateFor<T, Tensor<T>, Tensor<T>>(this)
+    ?? new AdamWOptimizer<T, Tensor<T>, Tensor<T>>(this);
         base.ImageSize = _options.ImageSize;
         base.ImageChannels = 3;
         base.EmbeddingDim = _options.DecoderDim;

--- a/src/VisionLanguage/Document/UReader.cs
+++ b/src/VisionLanguage/Document/UReader.cs
@@ -1,3 +1,5 @@
+using AiDotNet.LearningRateSchedulers;
+using AiDotNet.Enums;
 using AiDotNet.Attributes;
 using AiDotNet.Extensions;
 using AiDotNet.Helpers;
@@ -59,6 +61,13 @@ namespace AiDotNet.VisionLanguage.Document;
     Year = 2024,
     Authors = "Ye et al."
 )]
+[PaperOptimizer(OptimizerKind.Unspecified, LearningRate = 1e-4,
+                ReferenceBatchSize = 1024, WarmupSteps = 36, MinLearningRate = 0,
+                Schedule = LearningRateSchedulerType.CosineAnnealing,
+                Source = "Ye et al. 2023, Sec. 4.1: a linear warmup of 36 steps to a learning rate of "
+                        + "1e-4, followed by cosine decay to 0, at a batch size of 1024. The optimizer "
+                        + "is left unspecified because the paper never names one -- declaring a kind "
+                        + "here would attribute a choice the authors did not state.")]
 public partial class UReader<T> : VisionLanguageModelBase<T>, IDocumentUnderstandingModel<T>
 {
     private readonly UReaderOptions _options;
@@ -102,7 +111,9 @@ public partial class UReader<T> : VisionLanguageModelBase<T>, IDocumentUnderstan
     {
         _options = options ?? new UReaderOptions();
         _useNativeMode = true;
-        _optimizer = optimizer ?? new AdamWOptimizer<T, Tensor<T>, Tensor<T>>(this);
+        _optimizer = optimizer
+    ?? PaperOptimizerFactory.CreateFor<T, Tensor<T>, Tensor<T>>(this)
+    ?? new AdamWOptimizer<T, Tensor<T>, Tensor<T>>(this);
         base.ImageSize = _options.ImageSize;
         base.ImageChannels = 3;
         base.EmbeddingDim = _options.DecoderDim;

--- a/src/VisionLanguage/Editing/EmuEdit.cs
+++ b/src/VisionLanguage/Editing/EmuEdit.cs
@@ -1,3 +1,5 @@
+using AiDotNet.LearningRateSchedulers;
+using AiDotNet.Enums;
 using AiDotNet.Attributes;
 using AiDotNet.Extensions;
 using AiDotNet.Helpers;
@@ -57,6 +59,12 @@ namespace AiDotNet.VisionLanguage.Editing;
     Year = 2024,
     Authors = "Sheynin et al."
 )]
+[PaperOptimizer(OptimizerKind.Adam, LearningRate = 2e-5, ReferenceBatchSize = 512,
+                WarmupSteps = 2000, MinLearningRate = 0,
+                Schedule = LearningRateSchedulerType.CosineAnnealing,
+                Source = "Sheynin et al. 2023, Sec. 4: the Adam optimizer at a learning rate of 2e-5 "
+                        + "with a cosine decay schedule and a linear warmup of 2,000 iterations, at a "
+                        + "batch size of 512.")]
 public partial class EmuEdit<T> : VisionLanguageModelBase<T>, IImageEditingVLM<T>
 {
     private readonly EmuEditOptions _options;
@@ -100,7 +108,9 @@ public partial class EmuEdit<T> : VisionLanguageModelBase<T>, IImageEditingVLM<T
     {
         _options = options ?? new EmuEditOptions();
         _useNativeMode = true;
-        _optimizer = optimizer ?? new AdamWOptimizer<T, Tensor<T>, Tensor<T>>(this);
+        _optimizer = optimizer
+    ?? PaperOptimizerFactory.CreateFor<T, Tensor<T>, Tensor<T>>(this)
+    ?? new AdamWOptimizer<T, Tensor<T>, Tensor<T>>(this);
         base.ImageSize = _options.ImageSize;
         base.ImageChannels = 3;
         base.EmbeddingDim = _options.DecoderDim;

--- a/src/VisionLanguage/Editing/MGIE.cs
+++ b/src/VisionLanguage/Editing/MGIE.cs
@@ -1,3 +1,5 @@
+using AiDotNet.LearningRateSchedulers;
+using AiDotNet.Enums;
 using AiDotNet.Attributes;
 using AiDotNet.Extensions;
 using AiDotNet.Helpers;
@@ -58,6 +60,12 @@ namespace AiDotNet.VisionLanguage.Editing;
     Year = 2024,
     Authors = "Fu et al."
 )]
+[PaperOptimizer(OptimizerKind.AdamW, ReferenceBatchSize = 128,
+                Source = "Fu et al. 2024, Sec. 4: AdamW at a batch size of 128. No single learning rate "
+                        + "is declared because the paper gives one per component -- 5e-4 for the "
+                        + "multimodal language model and 1e-4 for the editing head -- and this model "
+                        + "builds one optimizer over both, so neither rate would be correct for all of "
+                        + "it.")]
 public partial class MGIE<T> : VisionLanguageModelBase<T>, IImageEditingVLM<T>
 {
     private readonly MGIEOptions _options;
@@ -101,7 +109,9 @@ public partial class MGIE<T> : VisionLanguageModelBase<T>, IImageEditingVLM<T>
     {
         _options = options ?? new MGIEOptions();
         _useNativeMode = true;
-        _optimizer = optimizer ?? new AdamWOptimizer<T, Tensor<T>, Tensor<T>>(this);
+        _optimizer = optimizer
+    ?? PaperOptimizerFactory.CreateFor<T, Tensor<T>, Tensor<T>>(this)
+    ?? new AdamWOptimizer<T, Tensor<T>, Tensor<T>>(this);
         base.ImageSize = _options.ImageSize;
         base.ImageChannels = 3;
         base.EmbeddingDim = _options.DecoderDim;

--- a/src/VisionLanguage/Editing/SmartEdit.cs
+++ b/src/VisionLanguage/Editing/SmartEdit.cs
@@ -1,3 +1,5 @@
+using AiDotNet.LearningRateSchedulers;
+using AiDotNet.Enums;
 using AiDotNet.Attributes;
 using AiDotNet.Extensions;
 using AiDotNet.Helpers;
@@ -58,6 +60,11 @@ namespace AiDotNet.VisionLanguage.Editing;
     Year = 2024,
     Authors = "Huang et al."
 )]
+[PaperOptimizer(OptimizerKind.AdamW, LearningRate = 2e-4, WeightDecay = 0,
+                Phase = TrainingPhase.PreTraining,
+                Source = "Huang et al. 2023, Sec. 4.1: the first stage of training uses AdamW with a "
+                        + "learning rate of 2e-4 and a weight decay of 0. The zero weight decay is the "
+                        + "paper value rather than an omission.")]
 public partial class SmartEdit<T> : VisionLanguageModelBase<T>, IImageEditingVLM<T>
 {
     private readonly SmartEditOptions _options;
@@ -101,7 +108,9 @@ public partial class SmartEdit<T> : VisionLanguageModelBase<T>, IImageEditingVLM
     {
         _options = options ?? new SmartEditOptions();
         _useNativeMode = true;
-        _optimizer = optimizer ?? new AdamWOptimizer<T, Tensor<T>, Tensor<T>>(this);
+        _optimizer = optimizer
+    ?? PaperOptimizerFactory.CreateFor<T, Tensor<T>, Tensor<T>>(this)
+    ?? new AdamWOptimizer<T, Tensor<T>, Tensor<T>>(this);
         base.ImageSize = _options.ImageSize;
         base.ImageChannels = 3;
         base.EmbeddingDim = _options.DecoderDim;

--- a/src/VisionLanguage/Encoders/ALIGN.cs
+++ b/src/VisionLanguage/Encoders/ALIGN.cs
@@ -1,3 +1,5 @@
+using AiDotNet.LearningRateSchedulers;
+using AiDotNet.Enums;
 using AiDotNet.Attributes;
 using AiDotNet.Helpers;
 using AiDotNet.Interfaces;
@@ -70,6 +72,13 @@ namespace AiDotNet.VisionLanguage.Encoders;
     Year = 2021,
     Authors = "Jia et al."
 )]
+[PaperOptimizer(OptimizerKind.Lamb, LearningRate = 1e-3, WeightDecay = 1e-5,
+                WarmupSteps = 10000, MinLearningRate = 0,
+                Schedule = LearningRateSchedulerType.LinearWarmup,
+                PostWarmupDecay = LinearWarmupScheduler.DecayMode.Linear,
+                Source = "Jia et al. 2021, Sec. 4.1: the LAMB optimizer with a weight decay ratio of "
+                        + "1e-5, warming the learning rate up linearly from zero to 1e-3 over 10k steps "
+                        + "and then decaying it linearly to zero over 1.2M steps.")]
 public partial class ALIGN<T> : VisionLanguageModelBase<T>, IContrastiveVisionLanguageModel<T>
 {
     /// <inheritdoc />
@@ -146,7 +155,9 @@ public partial class ALIGN<T> : VisionLanguageModelBase<T>, IContrastiveVisionLa
         _options = options ?? new ALIGNOptions();
         SyncImageSizeWithArchitecture();
         _useNativeMode = true;
-        _optimizer = optimizer ?? new AdamWOptimizer<T, Tensor<T>, Tensor<T>>(this);
+        _optimizer = optimizer
+    ?? PaperOptimizerFactory.CreateFor<T, Tensor<T>, Tensor<T>>(this)
+    ?? new AdamWOptimizer<T, Tensor<T>, Tensor<T>>(this);
         base.ImageSize = _options.ImageSize;
         base.ImageChannels = 3;
         base.EmbeddingDim = _options.VisionEmbeddingDim;

--- a/src/VisionLanguage/Encoders/BiomedCLIP.cs
+++ b/src/VisionLanguage/Encoders/BiomedCLIP.cs
@@ -1,3 +1,5 @@
+using AiDotNet.LearningRateSchedulers;
+using AiDotNet.Enums;
 using AiDotNet.Attributes;
 using AiDotNet.Helpers;
 using AiDotNet.Interfaces;
@@ -65,6 +67,15 @@ namespace AiDotNet.VisionLanguage.Encoders;
     Year = 2023,
     Authors = "Zhang et al."
 )]
+[PaperOptimizer(OptimizerKind.AdamW, LearningRate = 5e-4, Beta1 = 0.9, Beta2 = 0.98,
+                Epsilon = 1e-6, WeightDecay = 0.2, ReferenceBatchSize = 4096,
+                WarmupSteps = 2000, MinLearningRate = 0,
+                Schedule = LearningRateSchedulerType.CosineAnnealing,
+                Source = "Zhang et al. 2023, Supplementary Table 9: AdamW with a peak learning rate of "
+                        + "5.0e-4, weight decay 0.2, momentum beta1 0.9 and beta2 0.98, eps 1.0e-6, "
+                        + "cosine decay over 32 epochs with 2000 warmup steps, at a batch size of 4k. A "
+                        + "separate ablation raises the batch from 4k to 64k during training; the "
+                        + "constant-4k setting is the one declared.")]
 public partial class BiomedCLIP<T> : VisionLanguageModelBase<T>, IContrastiveVisionLanguageModel<T>
 {
     // NO SHAPE CONTRACT, and the reason is measured rather than assumed.
@@ -150,6 +161,7 @@ public partial class BiomedCLIP<T> : VisionLanguageModelBase<T>, IContrastiveVis
         // the test framework's default fixed-target regression contract.
         _optimizer =
             optimizer
+            ?? PaperOptimizerFactory.CreateFor<T, Tensor<T>, Tensor<T>>(this)
             ?? new AdamWOptimizer<T, Tensor<T>, Tensor<T>>(
                 this,
                 new Models.Options.AdamWOptimizerOptions<T, Tensor<T>, Tensor<T>>

--- a/src/VisionLanguage/Encoders/CLIPA.cs
+++ b/src/VisionLanguage/Encoders/CLIPA.cs
@@ -1,3 +1,5 @@
+using AiDotNet.LearningRateSchedulers;
+using AiDotNet.Enums;
 using AiDotNet.Attributes;
 using AiDotNet.Helpers;
 using AiDotNet.Interfaces;
@@ -63,6 +65,20 @@ namespace AiDotNet.VisionLanguage.Encoders;
     Year = 2023,
     Authors = "Li et al."
 )]
+[PaperOptimizer(OptimizerKind.AdamW, LearningRate = 8e-6, Beta1 = 0.9, Beta2 = 0.95,
+                WeightDecay = 0.2, WarmupSteps = 1600, MinLearningRate = 0,
+                Schedule = LearningRateSchedulerType.CosineAnnealing,
+                Source = "Li et al. 2023, config table: AdamW with momentum (0.9, 0.95) read as beta1 "
+                        + "and beta2, a base learning rate of 8e-6 decaying by cosine to a minimum of 0, "
+                        + "1600 warm-up steps and a weight decay of 0.2, at a batch size of 32768. The "
+                        + "batch is deliberately not declared as a scaling reference: the paper reports "
+                        + "a base learning rate and says it follows FLIP, whose convention multiplies "
+                        + "such a rate by batch/256, but this paper never states that formula, so the "
+                        + "rate is recorded exactly as written and left unscaled rather than being "
+                        + "adjusted by a convention borrowed from a cited work. The model keeps its own "
+                        + "optimizer and is verified against this record rather than built from it: 8e-6 "
+                        + "is a paper-scale rate over billions of samples, and applying it here leaves "
+                        + "the loss flat over the handful of steps a conformance run performs.")]
 public partial class CLIPA<T> : VisionLanguageModelBase<T>, IContrastiveVisionLanguageModel<T>
 {
     // NO SHAPE CONTRACT, for the same measured reason as BiomedCLIP.
@@ -126,7 +142,8 @@ public partial class CLIPA<T> : VisionLanguageModelBase<T>, IContrastiveVisionLa
         _options = options ?? new CLIPAOptions();
         SyncImageSizeWithArchitecture();
         _useNativeMode = true;
-        _optimizer = optimizer ?? new AdamWOptimizer<T, Tensor<T>, Tensor<T>>(this);
+        _optimizer = optimizer ?? PaperOptimizerFactory.VerifyHandBuilt(this,
+            new AdamWOptimizer<T, Tensor<T>, Tensor<T>>(this));
         base.ImageSize = _options.ImageSize;
         base.ImageChannels = 3;
         base.EmbeddingDim = _options.VisionEmbeddingDim;

--- a/src/VisionLanguage/Encoders/DINOv2.cs
+++ b/src/VisionLanguage/Encoders/DINOv2.cs
@@ -1,3 +1,5 @@
+using AiDotNet.LearningRateSchedulers;
+using AiDotNet.Enums;
 using AiDotNet.Attributes;
 using AiDotNet.Helpers;
 using AiDotNet.Interfaces;
@@ -56,6 +58,13 @@ namespace AiDotNet.VisionLanguage.Encoders;
     Year = 2024,
     Authors = "Oquab et al."
 )]
+[PaperOptimizer(OptimizerKind.AdamW, LearningRate = 1e-3, ReferenceBatchSize = 2048,
+                WarmupSteps = 100000, MinLearningRate = 0,
+                Schedule = LearningRateSchedulerType.CosineAnnealing,
+                Source = "Oquab et al. 2023, Table 16: AdamW with a learning rate of 1e-3 and a batch "
+                        + "size of 2048 for the S, B and L models, warming up over 100k iterations; the "
+                        + "g model uses 3.5e-4 at a batch of 3072. No weight decay is declared because "
+                        + "the paper schedules it on a cosine of its own rather than holding one value.")]
 public partial class DINOv2<T> : VisionLanguageModelBase<T>, IVisualEncoder<T>
 {
     private readonly DINOv2Options _options;
@@ -110,7 +119,9 @@ public partial class DINOv2<T> : VisionLanguageModelBase<T>, IVisualEncoder<T>
             _options = new DINOv2Options(_options) { ImageSize = architecture.InputHeight };
         }
         _useNativeMode = true;
-        _optimizer = optimizer ?? new AdamWOptimizer<T, Tensor<T>, Tensor<T>>(this);
+        _optimizer = optimizer
+    ?? PaperOptimizerFactory.CreateFor<T, Tensor<T>, Tensor<T>>(this)
+    ?? new AdamWOptimizer<T, Tensor<T>, Tensor<T>>(this);
         base.ImageSize = _options.ImageSize;
         base.ImageChannels = 3;
         base.EmbeddingDim = _options.EmbeddingDim;

--- a/src/VisionLanguage/Encoders/DINOv3.cs
+++ b/src/VisionLanguage/Encoders/DINOv3.cs
@@ -1,3 +1,5 @@
+using AiDotNet.LearningRateSchedulers;
+using AiDotNet.Enums;
 using AiDotNet.Attributes;
 using AiDotNet.Helpers;
 using AiDotNet.Interfaces;
@@ -58,6 +60,14 @@ namespace AiDotNet.VisionLanguage.Encoders;
     Year = 2025,
     Authors = "Oriane Siméoni et al. (Meta AI Research)"
 )]
+[PaperOptimizer(OptimizerKind.AdamW, LearningRate = 4e-4, WeightDecay = 0.04,
+                ReferenceBatchSize = 4096, WarmupSteps = 100000, EmaDecay = 0.999,
+                LayerwiseLearningRateDecay = 0.98,
+                Schedule = LearningRateSchedulerType.Constant,
+                Source = "Simeoni et al. 2025, Sec. 4: AdamW at a total batch size of 4096 images, a "
+                        + "constant learning rate of 0.0004 with a warmup of 100k iterations, a weight "
+                        + "decay of 0.04, a per-layer learning rate decay factor of 0.98 and an EMA "
+                        + "factor of 0.999.")]
 public partial class DINOv3<T> : VisionLanguageModelBase<T>, IVisualEncoder<T>
 {
     private readonly DINOv3Options _options;
@@ -112,7 +122,9 @@ public partial class DINOv3<T> : VisionLanguageModelBase<T>, IVisualEncoder<T>
             _options = new DINOv3Options(_options) { ImageSize = architecture.InputHeight };
         }
         _useNativeMode = true;
-        _optimizer = optimizer ?? new AdamWOptimizer<T, Tensor<T>, Tensor<T>>(this);
+        _optimizer = optimizer
+    ?? PaperOptimizerFactory.CreateFor<T, Tensor<T>, Tensor<T>>(this)
+    ?? new AdamWOptimizer<T, Tensor<T>, Tensor<T>>(this);
         base.ImageSize = _options.ImageSize;
         base.ImageChannels = 3;
         base.EmbeddingDim = _options.EmbeddingDim;

--- a/src/VisionLanguage/Encoders/DeCLIP.cs
+++ b/src/VisionLanguage/Encoders/DeCLIP.cs
@@ -1,3 +1,5 @@
+using AiDotNet.LearningRateSchedulers;
+using AiDotNet.Enums;
 using AiDotNet.Attributes;
 using AiDotNet.Helpers;
 using AiDotNet.Interfaces;
@@ -51,6 +53,13 @@ namespace AiDotNet.VisionLanguage.Encoders;
     Year = 2022,
     Authors = "Li et al."
 )]
+[PaperOptimizer(OptimizerKind.Sgd, LearningRate = 0.2, ReferenceBatchSize = 10240,
+                WarmupFraction = 0.03125, MinLearningRate = 0,
+                Schedule = LearningRateSchedulerType.CosineAnnealing,
+                Source = "Li et al. 2021, Sec. 4.1: FP16 SGD at a batch size of 10,240, starting from a "
+                        + "learning rate of 0.01 and increasing linearly to 0.2 over the first of 32 "
+                        + "epochs, then following a cosine schedule. The warmup is declared as the "
+                        + "fraction 1/32 because the paper gives it in epochs rather than steps.")]
 public partial class DeCLIP<T> : VisionLanguageModelBase<T>, IContrastiveVisionLanguageModel<T>
 {
     private readonly DeCLIPOptions _options;
@@ -107,7 +116,9 @@ public partial class DeCLIP<T> : VisionLanguageModelBase<T>, IContrastiveVisionL
         _options = options ?? new DeCLIPOptions();
         SyncImageSizeWithArchitecture();
         _useNativeMode = true;
-        _optimizer = optimizer ?? new AdamWOptimizer<T, Tensor<T>, Tensor<T>>(this);
+        _optimizer = optimizer
+    ?? PaperOptimizerFactory.CreateFor<T, Tensor<T>, Tensor<T>>(this)
+    ?? new AdamWOptimizer<T, Tensor<T>, Tensor<T>>(this);
         base.ImageSize = _options.ImageSize;
         base.ImageChannels = 3;
         base.EmbeddingDim = _options.VisionEmbeddingDim;

--- a/src/VisionLanguage/Encoders/EVACLIP.cs
+++ b/src/VisionLanguage/Encoders/EVACLIP.cs
@@ -1,3 +1,5 @@
+using AiDotNet.LearningRateSchedulers;
+using AiDotNet.Enums;
 using AiDotNet.Attributes;
 using AiDotNet.Helpers;
 using AiDotNet.Interfaces;
@@ -57,6 +59,15 @@ namespace AiDotNet.VisionLanguage.Encoders;
     Year = 2023,
     Authors = "Sun et al."
 )]
+[PaperOptimizer(OptimizerKind.Lamb, Beta1 = 0.9, Beta2 = 0.98, WeightDecay = 0.05,
+                ReferenceBatchSize = 32768, WarmupSteps = 2000, MinLearningRate = 0,
+                Schedule = LearningRateSchedulerType.CosineAnnealing,
+                Source = "Sun et al. 2023, Sec. 3: the LAMB optimizer with a weight decay of 0.05, "
+                        + "beta1 0.9 and beta2 0.98, a 2000-step warm-up and a cosine schedule, at a "
+                        + "batch size of 32768. No single learning rate is declared because the paper "
+                        + "sets 2e-4 for the vision encoder and 2e-5 for the text encoder, and this "
+                        + "model builds one optimizer over both, so neither rate would be correct for "
+                        + "all of it.")]
 public partial class EVACLIP<T> : VisionLanguageModelBase<T>, IContrastiveVisionLanguageModel<T>
 {
     private readonly EVACLIPOptions _options;
@@ -113,7 +124,9 @@ public partial class EVACLIP<T> : VisionLanguageModelBase<T>, IContrastiveVision
         _options = options ?? new EVACLIPOptions();
         SyncImageSizeWithArchitecture();
         _useNativeMode = true;
-        _optimizer = optimizer ?? new AdamWOptimizer<T, Tensor<T>, Tensor<T>>(this);
+        _optimizer = optimizer
+    ?? PaperOptimizerFactory.CreateFor<T, Tensor<T>, Tensor<T>>(this)
+    ?? new AdamWOptimizer<T, Tensor<T>, Tensor<T>>(this);
         base.ImageSize = _options.ImageSize;
         base.ImageChannels = 3;
         base.EmbeddingDim = _options.VisionEmbeddingDim;

--- a/src/VisionLanguage/Encoders/Florence2.cs
+++ b/src/VisionLanguage/Encoders/Florence2.cs
@@ -1,3 +1,5 @@
+using AiDotNet.LearningRateSchedulers;
+using AiDotNet.Enums;
 using AiDotNet.Attributes;
 using AiDotNet.Helpers;
 using AiDotNet.Interfaces;
@@ -60,6 +62,11 @@ namespace AiDotNet.VisionLanguage.Encoders;
     Year = 2024,
     Authors = "Xiao et al."
 )]
+[PaperOptimizer(OptimizerKind.AdamW, MinLearningRate = 0,
+                Schedule = LearningRateSchedulerType.CosineAnnealing,
+                Source = "Xiao et al. 2023, Sec. 4.1: AdamW with cosine learning rate decay. The paper "
+                        + "states neither a peak rate nor a batch size in its training description, so "
+                        + "neither is declared.")]
 public partial class Florence2<T> : VisionLanguageModelBase<T>, IVisualEncoder<T>
 {
     private readonly Florence2Options _options;
@@ -107,12 +114,13 @@ public partial class Florence2<T> : VisionLanguageModelBase<T>, IVisualEncoder<T
         // the first un-warmed steps and loss RISES (observed: 16.6 -> 64.6 in one step).
         // ViT/transformer fine-tuning uses 1e-4..1e-5, so pin the conservative stable
         // end (1e-5) as the paper-faithful default — matching the sibling SigLIP2 encoder.
-        _optimizer = optimizer ?? new AdamWOptimizer<T, Tensor<T>, Tensor<T>>(
-            this,
-            new Models.Options.AdamWOptimizerOptions<T, Tensor<T>, Tensor<T>>
-            {
-                InitialLearningRate = 1e-5,
-            });
+        _optimizer = optimizer ?? PaperOptimizerFactory.VerifyHandBuilt(this,
+            new AdamWOptimizer<T, Tensor<T>, Tensor<T>>(
+                this,
+                new Models.Options.AdamWOptimizerOptions<T, Tensor<T>, Tensor<T>>
+                {
+                    InitialLearningRate = 1e-5,
+                }));
         base.ImageSize = _options.ImageSize;
         base.ImageChannels = 3;
         base.EmbeddingDim = _options.EmbeddingDim;

--- a/src/VisionLanguage/Encoders/LiT.cs
+++ b/src/VisionLanguage/Encoders/LiT.cs
@@ -1,3 +1,5 @@
+using AiDotNet.LearningRateSchedulers;
+using AiDotNet.Enums;
 using AiDotNet.Attributes;
 using AiDotNet.Helpers;
 using AiDotNet.Interfaces;
@@ -58,6 +60,10 @@ namespace AiDotNet.VisionLanguage.Encoders;
     Year = 2022,
     Authors = "Zhai et al."
 )]
+[PaperOptimizer(OptimizerKind.Adafactor, LearningRate = 0.001, Beta1 = 0.9,
+                Beta2 = 0.999,
+                Source = "Zhai et al. 2022, Sec. 4: the AdaFactor optimizer at a learning rate of 0.001 "
+                        + "with the default beta1 of 0.9 and beta2 of 0.999.")]
 public partial class LiT<T> : VisionLanguageModelBase<T>, IContrastiveVisionLanguageModel<T>
 {
     private readonly LiTOptions _options;
@@ -118,7 +124,9 @@ public partial class LiT<T> : VisionLanguageModelBase<T>, IContrastiveVisionLang
         _options = options ?? new LiTOptions();
         SyncImageSizeWithArchitecture();
         _useNativeMode = true;
-        _optimizer = optimizer ?? new AdamWOptimizer<T, Tensor<T>, Tensor<T>>(this);
+        _optimizer = optimizer
+    ?? PaperOptimizerFactory.CreateFor<T, Tensor<T>, Tensor<T>>(this)
+    ?? new AdamWOptimizer<T, Tensor<T>, Tensor<T>>(this);
         base.ImageSize = _options.ImageSize;
         base.ImageChannels = 3;
         base.EmbeddingDim = _options.VisionEmbeddingDim;

--- a/src/VisionLanguage/Encoders/MedCLIP.cs
+++ b/src/VisionLanguage/Encoders/MedCLIP.cs
@@ -1,3 +1,4 @@
+using AiDotNet.LearningRateSchedulers;
 using AiDotNet.Attributes;
 using AiDotNet.ActivationFunctions;
 using AiDotNet.Enums;
@@ -58,6 +59,13 @@ namespace AiDotNet.VisionLanguage.Encoders;
     Year = 2022,
     Authors = "Wang et al."
 )]
+[PaperOptimizer(OptimizerKind.Unspecified, LearningRate = 5e-5, WeightDecay = 1e-4,
+                ReferenceBatchSize = 100, WarmupFraction = 0.1,
+                Source = "Wang et al. 2022, Sec. 4.1: a learning rate of 5e-5, batch size 100, weight "
+                        + "decay 1e-4, 10 epochs and a learning rate warmup ratio of 0.1. The optimizer "
+                        + "is left unspecified because the paper never names one -- the only optimizer "
+                        + "it mentions is the SGD used for its logistic-regression evaluation, which is "
+                        + "not how the model itself is trained.")]
 public partial class MedCLIP<T> : VisionLanguageModelBase<T>, IContrastiveVisionLanguageModel<T>
 {
     private const int MedClipExtrasFormatVersion = 1;
@@ -123,17 +131,18 @@ public partial class MedCLIP<T> : VisionLanguageModelBase<T>, IContrastiveVision
         // instead of silently falling back to AdamW's generic 1e-3 / 1e-2 defaults.
         _optimizer =
             optimizer
-            ?? new AdamWOptimizer<T, Tensor<T>, Tensor<T>>(
-                this,
-                new Models.Options.AdamWOptimizerOptions<T, Tensor<T>, Tensor<T>>
-                {
-                    InitialLearningRate = _options.LearningRate,
-                    Beta1 = 0.9,
-                    Beta2 = 0.999,
-                    Epsilon = 1e-8,
-                    WeightDecay = _options.WeightDecay,
-                }
-            );
+            ?? PaperOptimizerFactory.VerifyHandBuilt(this,
+            new AdamWOptimizer<T, Tensor<T>, Tensor<T>>(
+                    this,
+                    new Models.Options.AdamWOptimizerOptions<T, Tensor<T>, Tensor<T>>
+                    {
+                        InitialLearningRate = _options.LearningRate,
+                        Beta1 = 0.9,
+                        Beta2 = 0.999,
+                        Epsilon = 1e-8,
+                        WeightDecay = _options.WeightDecay,
+                    }
+                ));
         base.ImageSize = _options.ImageSize;
         base.ImageChannels = 3;
         base.EmbeddingDim = _options.ProjectionDim;

--- a/src/VisionLanguage/Encoders/MetaCLIP.cs
+++ b/src/VisionLanguage/Encoders/MetaCLIP.cs
@@ -1,3 +1,5 @@
+using AiDotNet.LearningRateSchedulers;
+using AiDotNet.Enums;
 using AiDotNet.Attributes;
 using AiDotNet.Helpers;
 using AiDotNet.Interfaces;
@@ -37,6 +39,12 @@ namespace AiDotNet.VisionLanguage.Encoders;
     Year = 2023,
     Authors = "Xu et al."
 )]
+[PaperOptimizer(OptimizerKind.Unspecified, LearningRate = 5e-4,
+                ReferenceBatchSize = 32768,
+                Source = "Xu et al. 2023, Sec. 5: a learning rate of 5e-4 at a batch size of 32768. The "
+                        + "paper never names an optimizer in its training description -- it follows the "
+                        + "OpenCLIP setup -- so none is declared rather than attributing a choice it did "
+                        + "not state.")]
 public partial class MetaCLIP<T> : VisionLanguageModelBase<T>, IContrastiveVisionLanguageModel<T>
 {
     private readonly MetaCLIPOptions _options;
@@ -93,7 +101,9 @@ public partial class MetaCLIP<T> : VisionLanguageModelBase<T>, IContrastiveVisio
         _options = options ?? new MetaCLIPOptions();
         SyncImageSizeWithArchitecture();
         _useNativeMode = true;
-        _optimizer = optimizer ?? new AdamWOptimizer<T, Tensor<T>, Tensor<T>>(this);
+        _optimizer = optimizer
+    ?? PaperOptimizerFactory.CreateFor<T, Tensor<T>, Tensor<T>>(this)
+    ?? new AdamWOptimizer<T, Tensor<T>, Tensor<T>>(this);
         base.ImageSize = _options.ImageSize;
         base.ImageChannels = 3;
         base.EmbeddingDim = _options.VisionEmbeddingDim;

--- a/src/VisionLanguage/Encoders/RADIOv25.cs
+++ b/src/VisionLanguage/Encoders/RADIOv25.cs
@@ -1,3 +1,5 @@
+using AiDotNet.LearningRateSchedulers;
+using AiDotNet.Enums;
 using AiDotNet.Attributes;
 using AiDotNet.Helpers;
 using AiDotNet.Interfaces;
@@ -56,6 +58,12 @@ namespace AiDotNet.VisionLanguage.Encoders;
     Year = 2025,
     Authors = "Ranzinger et al."
 )]
+[PaperOptimizer(OptimizerKind.AdamW, LearningRate = 0.001, WeightDecay = 0,
+                ReferenceBatchSize = 1024, MinLearningRate = 0,
+                Schedule = LearningRateSchedulerType.CosineAnnealing,
+                Source = "Ranzinger et al. 2023, Sec. 4: AdamW at a batch size of 1024 with a cosine "
+                        + "annealing schedule and a base learning rate of 0.001, with a weight decay of "
+                        + "0. The zero weight decay is the paper value rather than an omission.")]
 public partial class RADIOv25<T> : VisionLanguageModelBase<T>, IVisualEncoder<T>
 {
     private readonly RADIOv25Options _options;
@@ -110,7 +118,9 @@ public partial class RADIOv25<T> : VisionLanguageModelBase<T>, IVisualEncoder<T>
             _options = new RADIOv25Options(_options) { ImageSize = architecture.InputHeight };
         }
         _useNativeMode = true;
-        _optimizer = optimizer ?? new AdamWOptimizer<T, Tensor<T>, Tensor<T>>(this);
+        _optimizer = optimizer
+    ?? PaperOptimizerFactory.CreateFor<T, Tensor<T>, Tensor<T>>(this)
+    ?? new AdamWOptimizer<T, Tensor<T>, Tensor<T>>(this);
         base.ImageSize = _options.ImageSize;
         base.ImageChannels = 3;
         base.EmbeddingDim = _options.EmbeddingDim;

--- a/src/VisionLanguage/Encoders/RegionCLIP.cs
+++ b/src/VisionLanguage/Encoders/RegionCLIP.cs
@@ -1,3 +1,5 @@
+using AiDotNet.LearningRateSchedulers;
+using AiDotNet.Enums;
 using AiDotNet.Attributes;
 using AiDotNet.ActivationFunctions;
 using AiDotNet.Helpers;
@@ -54,6 +56,9 @@ namespace AiDotNet.VisionLanguage.Encoders;
     Year = 2022,
     Authors = "Zhong et al."
 )]
+[PaperOptimizer(OptimizerKind.Sgd, LearningRate = 0.002, ReferenceBatchSize = 96,
+                Source = "Zhong et al. 2021, Sec. 4.1: SGD with an image batch of 96, an initial "
+                        + "learning rate of 0.002 and a maximum of 600k iterations.")]
 public partial class RegionCLIP<T> : VisionLanguageModelBase<T>, IContrastiveVisionLanguageModel<T>
 {
     private readonly RegionCLIPOptions _options;
@@ -110,13 +115,14 @@ public partial class RegionCLIP<T> : VisionLanguageModelBase<T>, IContrastiveVis
         _options = options ?? new RegionCLIPOptions();
         SyncImageSizeWithArchitecture();
         _useNativeMode = true;
-        _optimizer = optimizer ?? new StochasticGradientDescentOptimizer<T, Tensor<T>, Tensor<T>>(
-            this,
-            new StochasticGradientDescentOptimizerOptions<T, Tensor<T>, Tensor<T>>
-            {
-                InitialLearningRate = _options.LearningRate,
-                UseAdaptiveLearningRate = false,
-            });
+        _optimizer = optimizer ?? PaperOptimizerFactory.VerifyHandBuilt(this,
+            new StochasticGradientDescentOptimizer<T, Tensor<T>, Tensor<T>>(
+                this,
+                new StochasticGradientDescentOptimizerOptions<T, Tensor<T>, Tensor<T>>
+                {
+                    InitialLearningRate = _options.LearningRate,
+                    UseAdaptiveLearningRate = false,
+                }));
         base.ImageSize = _options.ImageSize;
         base.ImageChannels = 3;
         base.EmbeddingDim = _options.VisionEmbeddingDim;

--- a/src/VisionLanguage/Encoders/RemoteCLIP.cs
+++ b/src/VisionLanguage/Encoders/RemoteCLIP.cs
@@ -1,3 +1,5 @@
+using AiDotNet.LearningRateSchedulers;
+using AiDotNet.Enums;
 using AiDotNet.Attributes;
 using AiDotNet.Helpers;
 using AiDotNet.Interfaces;
@@ -53,6 +55,13 @@ namespace AiDotNet.VisionLanguage.Encoders;
     Year = 2023,
     Authors = "Liu et al."
 )]
+[PaperOptimizer(OptimizerKind.Unspecified, ReferenceBatchSize = 256, MinLearningRate = 0,
+                Schedule = LearningRateSchedulerType.CosineAnnealing,
+                Source = "Liu et al. 2023, Sec. 4.1: cosine annealing at a batch size of 256 for the "
+                        + "ResNet-50 and ViT-Base-32 backbones. No learning rate is declared because the "
+                        + "paper gives one per backbone -- 7e-5, 4e-5 and 1e-4 for ResNet-50, "
+                        + "ViT-Base-32 and ViT-Large-14 -- and no optimizer is declared because the only "
+                        + "one named is the SGD used for its logistic-regression evaluation.")]
 public partial class RemoteCLIP<T> : VisionLanguageModelBase<T>, IContrastiveVisionLanguageModel<T>
 {
     private readonly RemoteCLIPOptions _options;
@@ -109,13 +118,14 @@ public partial class RemoteCLIP<T> : VisionLanguageModelBase<T>, IContrastiveVis
         _options = options ?? new RemoteCLIPOptions();
         SyncImageSizeWithArchitecture();
         _useNativeMode = true;
-        _optimizer = optimizer ?? new AdamWOptimizer<T, Tensor<T>, Tensor<T>>(
-            this,
-            new AdamWOptimizerOptions<T, Tensor<T>, Tensor<T>>
-            {
-                InitialLearningRate = _options.LearningRate,
-                WeightDecay = _options.WeightDecay,
-            });
+        _optimizer = optimizer ?? PaperOptimizerFactory.VerifyHandBuilt(this,
+            new AdamWOptimizer<T, Tensor<T>, Tensor<T>>(
+                this,
+                new AdamWOptimizerOptions<T, Tensor<T>, Tensor<T>>
+                {
+                    InitialLearningRate = _options.LearningRate,
+                    WeightDecay = _options.WeightDecay,
+                }));
         base.ImageSize = _options.ImageSize;
         base.ImageChannels = 3;
         base.EmbeddingDim = _options.VisionEmbeddingDim;

--- a/src/VisionLanguage/Encoders/SigLIP2.cs
+++ b/src/VisionLanguage/Encoders/SigLIP2.cs
@@ -1,3 +1,5 @@
+using AiDotNet.LearningRateSchedulers;
+using AiDotNet.Enums;
 using AiDotNet.Attributes;
 using AiDotNet.Helpers;
 using AiDotNet.Interfaces;
@@ -97,6 +99,19 @@ namespace AiDotNet.VisionLanguage.Encoders;
     Year = 2025,
     Authors = "Tschannen et al."
 )]
+[PaperOptimizer(OptimizerKind.AdamW, LearningRate = 1e-3, WeightDecay = 1e-4,
+                ReferenceBatchSize = 32768, WarmupSteps = 20000, MinLearningRate = 0,
+                MaxGradientNorm = 1.0,
+                Schedule = LearningRateSchedulerType.CosineAnnealing,
+                Source = "Tschannen et al. 2025, Sec. 3: a learning rate of 1e-3, decoupled weight "
+                        + "decay of 1e-4 and gradient clipping to norm 1, at a batch size of 32k under a "
+                        + "cosine schedule with 20k warmup steps. The paper names Adam, but the weight "
+                        + "decay it specifies is decoupled, which is AdamW; declaring Adam here would "
+                        + "apply the decay as coupled L2 instead. The model keeps its own "
+                        + "optimizer rather than being built from this record: building one "
+                        + "from the recipe snapshots a parameter buffer inside the "
+                        + "constructor, where this model reports 64 parameters against the 50 "
+                        + "it trains with, and the buffer is rejected on the first step.")]
 public partial class SigLIP2<T> : VisionLanguageModelBase<T>, IContrastiveVisionLanguageModel<T>
 {
     #region Fields
@@ -184,13 +199,14 @@ public partial class SigLIP2<T> : VisionLanguageModelBase<T>, IContrastiveVision
         // Gradient clipping (norm 1.0) is on by AdamW default.
         _optimizer =
             optimizer
-            ?? new AdamWOptimizer<T, Tensor<T>, Tensor<T>>(
-                this,
-                new Models.Options.AdamWOptimizerOptions<T, Tensor<T>, Tensor<T>>
-                {
-                    InitialLearningRate = 1e-5,
-                }
-            );
+            ?? PaperOptimizerFactory.VerifyHandBuilt(this,
+            new AdamWOptimizer<T, Tensor<T>, Tensor<T>>(
+                    this,
+                    new Models.Options.AdamWOptimizerOptions<T, Tensor<T>, Tensor<T>>
+                    {
+                        InitialLearningRate = 1e-5,
+                    }
+                ));
         base.ImageSize = _options.ImageSize;
         base.ImageChannels = 3;
         base.EmbeddingDim = _options.VisionEmbeddingDim;

--- a/tests/AiDotNet.Tests/UnitTests/Optimizers/AdafactorTests.cs
+++ b/tests/AiDotNet.Tests/UnitTests/Optimizers/AdafactorTests.cs
@@ -85,7 +85,7 @@ public class AdafactorTests
             Assert.True(Math.Abs(updated[i] - 1.0) <= 0.1 + 1e-9,
                 $"a gradient of 1e6 moved the weight by {Math.Abs(updated[i] - 1.0)}, which is more "
                 + "than one clipped step; the update clipping is not bounding the step");
-            Assert.True(double.IsFinite(updated[i]));
+            Assert.True(!double.IsNaN(updated[i]) && !double.IsInfinity(updated[i]));
         }
     }
 
@@ -137,7 +137,7 @@ public class AdafactorTests
 
         for (int i = 0; i < parameters.Length; i++)
         {
-            Assert.True(double.IsFinite(parameters[i]), $"parameter {i} became {parameters[i]}");
+            Assert.True(!double.IsNaN(parameters[i]) && !double.IsInfinity(parameters[i]), $"parameter {i} became {parameters[i]}");
         }
     }
 

--- a/tests/AiDotNet.Tests/UnitTests/Optimizers/ScheduleFreeAdamWTests.cs
+++ b/tests/AiDotNet.Tests/UnitTests/Optimizers/ScheduleFreeAdamWTests.cs
@@ -103,7 +103,7 @@ public class ScheduleFreeAdamWTests
 
         for (int i = 0; i < parameters.Length; i++)
         {
-            Assert.True(double.IsFinite(parameters[i]), $"parameter {i} became {parameters[i]}");
+            Assert.True(!double.IsNaN(parameters[i]) && !double.IsInfinity(parameters[i]), $"parameter {i} became {parameters[i]}");
         }
     }
 

--- a/tests/AiDotNet.Tests/UnitTests/Optimizers/ScheduleValidationMatchesTheBuilderTests.cs
+++ b/tests/AiDotNet.Tests/UnitTests/Optimizers/ScheduleValidationMatchesTheBuilderTests.cs
@@ -47,7 +47,7 @@ public class ScheduleValidationMatchesTheBuilderTests
     {
         var inconsistent = new List<string>();
 
-        foreach (LearningRateSchedulerType schedule in Enum.GetValues<LearningRateSchedulerType>())
+        foreach (LearningRateSchedulerType schedule in ((LearningRateSchedulerType[])Enum.GetValues(typeof(LearningRateSchedulerType))))
         {
             var recipe = FullySpecified(schedule);
 
@@ -103,7 +103,7 @@ public class ScheduleValidationMatchesTheBuilderTests
     {
         // The other half of the contract: silently accepting an unmappable schedule would let a
         // model declare one and train at a constant rate with nothing saying so.
-        var unmappable = Enum.GetValues<LearningRateSchedulerType>()
+        var unmappable = ((LearningRateSchedulerType[])Enum.GetValues(typeof(LearningRateSchedulerType)))
             .Where(schedule => !HasBuilderArm(schedule))
             .ToList();
 

--- a/tests/AiDotNet.Tests/UnitTests/Optimizers/WarmupNeverStartsAtZeroTests.cs
+++ b/tests/AiDotNet.Tests/UnitTests/Optimizers/WarmupNeverStartsAtZeroTests.cs
@@ -76,6 +76,29 @@ public class WarmupNeverStartsAtZeroTests
     }
 
     [Fact]
+    public void AWarmupComposedInFrontOfAnotherScheduleAlsoStartsAbleToMove()
+    {
+        // The two tests above use wav2vec 2.0, which declares LinearWarmup -- a schedule that ramps
+        // on its own, so the factory hands it back untouched and never composes anything. That left
+        // the OTHER path unguarded: when a paper warms up in front of a schedule that does not ramp
+        // (cosine, here), the factory wraps the two in sequence, and that wrapper was building its
+        // ramp with the default initial rate of zero. Every model declaring "warmup then cosine"
+        // therefore spent its first step multiplying the update by exactly zero, which showed up as
+        // bit-identical parameters after training rather than as a slow start.
+        var model = new Data2Vec2<double>(
+            new NeuralNetworkArchitecture<double>(inputFeatures: 1, outputSize: 32));
+
+        var built = PaperOptimizerFactory.CreateFor<double, Tensor<double>, Tensor<double>>(model);
+        var scheduler = SchedulerOf(built);
+
+        Assert.NotNull(scheduler);
+        Assert.True(scheduler.GetLearningRateAtStep(0) > 0,
+            "a warmup composed in front of another schedule must also move on its first step");
+        Assert.True(scheduler.GetLearningRateAtStep(0) < scheduler.GetLearningRateAtStep(4),
+            "and it must still be a ramp rather than a flat rate");
+    }
+
+    [Fact]
     public void ARunWithNoRoomToDecayHoldsThePeakAndSaysSo()
     {
         // A decay needs a horizon. Without one, decaySteps goes negative and every post-warmup step


### PR DESCRIPTION
Continues #1928. **Stacked on #2103**, which is stacked on #2098 — they merge in that order.

Same rules as the earlier batches: every value read from the paper PDF, `Source` required and analyzer-enforced, a model that already implements its paper keeps its optimizer and has the declaration *verify* it, and anything the paper does not state is left undeclared with the omission written into the `Source`.

## What is different from batch 2 onward

The recipe is now a **complete record** rather than a single flat row. A declaration is keyed by phase, component and variant; it can say a value was searched rather than prescribed; and it carries EMA decay, layer-wise decay, early stopping and gradient accumulation. The application of that record is a separate policy that reports every difference between what the paper says and what the run uses — so a value is never dropped from the record because it is inconvenient to apply.

That design was derived from a survey of 122 papers and validated against 30 held-out ones, rather than extended a field at a time.

## Method

Papers are triaged in bulk first. Roughly 60% state no training recipe at all, and those are marked `no-recipe-stated` with the reason — `NotDeclared` is the honest report for a model whose paper never said, and recording it stops the paper being fetched again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GYQycGHKxLFBqhEtPMHz29
