### PR TITLE
ci(release): use NuGet trusted publishing

### DIFF
--- a/.github/AUTOMATED_RELEASE_SETUP.md
+++ b/.github/AUTOMATED_RELEASE_SETUP.md
@@ -10,33 +10,38 @@ This directory contains an automated release pipeline template that provides:
 - **NuGet Publishing** to nuget.org
 - **100% Automated** - no manual version bumps needed
 
-## Why a Template?
+## Release Workflow
 
-GitHub security policies prevent automated tools from directly modifying workflow files in `.github/workflows/`. This template must be manually installed by a repository maintainer with appropriate permissions.
+The installed workflow is `.github/workflows/release-please.yml`. It maintains a rolling Release PR and publishes only after a maintainer merges that Release PR.
 
-## Installation
+## Prerequisites
 
-### Step 1: Copy the Workflow File
+### Step 1: Configure NuGet Trusted Publishing
 
-```bash
-# From the repository root
-cp .github/AUTOMATED_RELEASE_WORKFLOW.yml .github/workflows/release.yml
-```
+Create a trusted-publishing policy at [nuget.org](https://www.nuget.org/account/trustedpublishing) with these exact GitHub Actions values:
 
-### Step 2: Verify Required Secrets
+| Field | Value |
+|-------|-------|
+| Owner | `ooples` |
+| Repository | `AiDotNet` |
+| Workflow file | `release-please.yml` |
+| Environment | Leave blank |
 
-Ensure the following secrets are configured in your repository:
+Enter only the workflow filename, not `.github/workflows/release-please.yml`. The policy is case-sensitive and must authorize every package published by this workflow. `NuGet/login` exchanges the job's GitHub OIDC identity for a short-lived API key; no long-lived NuGet API key is stored in GitHub.
 
-| Secret | Required | Description |
-|--------|----------|-------------|
-| `NUGET_API_KEY` | Optional | NuGet API key for publishing packages. If not set, publishing will be skipped. |
-| `GITHUB_TOKEN` | Automatic | Automatically provided by GitHub Actions |
+Publishing fails closed if the policy does not match or NuGet does not issue a temporary key. See [NuGet trusted publishing](https://learn.microsoft.com/en-us/nuget/nuget-org/trusted-publishing).
 
-To add the NuGet API key:
-1. Go to Repository Settings → Secrets and variables → Actions
-2. Click "New repository secret"
-3. Name: `NUGET_API_KEY`
-4. Value: Your NuGet API key from https://www.nuget.org/account/apikeys
+### Step 2: Verify Repository Secrets and Variables
+
+| Name | Kind | Required | Description |
+|------|------|----------|-------------|
+| `AIDOTNET_BUILD_KEY` | Secret | Required for a release | Strong-name/integrity build key injected only into the unprivileged build job |
+| `AUTOFIX_PAT` | Secret | Recommended | Lets release-please-created events trigger the normal protected CI workflows |
+| `GITHUB_TOKEN` | Automatic | Automatic | Used by GitHub Actions; do not create it manually |
+| `AIDOTNET_LICENSE_PUBLIC_KEY_JSON` | Variable or secret | Optional | Overrides the committed public license-verification key during a key rotation |
+| `AIDOTNET_LICENSE_REVOCATION_JSON` | Variable or secret | Optional | Injects the signed license revocation list |
+
+Configure repository secrets and variables under Repository Settings → Secrets and variables → Actions.
 
 ### Step 3: Review Branch Configuration
 
@@ -52,13 +57,9 @@ on:
 
 If your default branch has a different name, update this in the workflow file.
 
-### Step 4: Commit and Push
+### Step 4: Verify the Installed Workflow
 
-```bash
-git add .github/workflows/release.yml
-git commit -m "feat(ci): Enable automated release pipeline"
-git push origin main
-```
+Confirm that `.github/workflows/release-please.yml` is present on the protected default branch and that GitHub Actions is enabled. The trusted-publishing policy must continue to name `release-please.yml` if the workflow is renamed.
 
 ## How It Works
 
@@ -78,22 +79,20 @@ The workflow analyzes commit messages since the last git tag:
 
 ### Workflow Jobs
 
-1. **version-and-build**
-   - Parses commits and determines version
-   - Creates git tag
-   - Builds and tests project
-   - Creates NuGet package
-   - Verifies target frameworks (net462, net8.0)
-   - Uploads package artifact
+1. **release-please**
+   - Maintains the rolling Release PR
+   - Creates the version tag and GitHub release only when that PR is merged
 
-2. **publish-nuget**
-   - Publishes to NuGet.org (if `NUGET_API_KEY` is set)
-   - Handles duplicate versions gracefully with `--skip-duplicate`
+2. **build-release**
+   - Checks out the immutable release tag
+   - Builds, signs, packs, and verifies all NuGet packages without OIDC permission
+   - Uploads the verified packages as an immutable, one-day workflow artifact
 
-3. **github-release**
-   - Creates GitHub Release
-   - Attaches NuGet package
-   - Includes generated changelog
+3. **publish**
+   - Downloads the exact artifact ID produced by `build-release`
+   - Uses `NuGet/login` and OIDC to obtain a short-lived NuGet API key
+   - Publishes the verified packages and attaches them to the GitHub release
+   - Has no source checkout, build scripts, signing key, or package mutation steps
 
 ### Changelog Format
 
@@ -124,29 +123,15 @@ The workflow generates categorized changelogs:
 
 ## Testing the Workflow
 
-### Option 1: Push a Test Commit
+Workflow syntax, action pins, permission boundaries, and artifact handoff should be validated in the pull request before merge. A normal push to `main` or `master` updates the rolling Release PR but does not publish a package.
 
-```bash
-git commit --allow-empty -m "feat: Test automated release pipeline"
-git push origin main
-```
+The complete OIDC exchange can only be proven by merging a release-please Release PR because the publish jobs require `release_created == 'true'`, an immutable release tag, and a matching NuGet trusted-publishing policy. For that release run, verify:
 
-This will trigger the workflow and create version 0.1.0 (or next MINOR bump).
-
-### Option 2: Manual Workflow Trigger
-
-If you want to test without creating a release, you can add workflow_dispatch trigger:
-
-```yaml
-on:
-  push:
-    branches:
-      - main
-      - master
-  workflow_dispatch:  # Add this for manual testing
-```
-
-Then trigger it from Actions → Automated Release Pipeline → Run workflow.
+1. `build-release` succeeds without `id-token: write`.
+2. `publish` downloads the artifact ID emitted by `build-release`.
+3. `NuGet/login` issues a temporary key without a repository NuGet secret.
+4. Every expected package appears on nuget.org and on the GitHub release.
+5. The temporary key is never printed and is unavailable to build steps.
 
 ## Conventional Commits
 
@@ -189,23 +174,20 @@ After installation, verify the workflow is working:
 
 1. **Check Workflow File**
    ```bash
-   ls -la .github/workflows/release.yml
+   ls -la .github/workflows/release-please.yml
    ```
 
 2. **View in GitHub**
-   - Go to Actions tab in your repository
-   - Look for "Automated Release Pipeline" workflow
+   - Go to the repository Actions tab
+   - Look for the "Release Please" workflow
 
-3. **Test with a Commit**
-   ```bash
-   git commit --allow-empty -m "feat: test automated release"
-   git push origin main
-   ```
+3. **Verify a Normal Push**
+   - Confirm a conventional commit updates the rolling Release PR without publishing
 
-4. **Monitor Execution**
+4. **Verify the Next Deliberate Release**
    - Go to Actions tab
-   - Click on the running workflow
-   - Watch logs for each job
+   - Merge the reviewed release-please Release PR
+   - Confirm `release-please`, `build-release`, and `publish` complete in sequence
 
 ## Troubleshooting
 
@@ -214,7 +196,7 @@ After installation, verify the workflow is working:
 **Problem**: Pushed to main but workflow didn't run.
 
 **Solutions**:
-- Verify `.github/workflows/release.yml` exists (not in .github/)
+- Verify `.github/workflows/release-please.yml` exists
 - Check branch name matches workflow trigger (main vs master)
 - Ensure GitHub Actions are enabled in repository settings
 
@@ -232,19 +214,20 @@ After installation, verify the workflow is working:
 **Problem**: Package not published to NuGet.
 
 **Solutions**:
-- Verify `NUGET_API_KEY` secret is configured
-- Check API key has not expired
+- Verify the NuGet trusted-publishing policy uses owner `ooples`, repository `AiDotNet`, workflow file `release-please.yml`, and a blank environment
+- Verify the policy authorizes every package produced by the release
+- Confirm the `publish` job has `id-token: write` and `NuGet/login` issued a temporary key
 - Ensure package version doesn't already exist on NuGet
 - Review NuGet publish logs in workflow
 
 ### TFM Verification Fails
 
-**Problem**: "Missing net462 lib in package" error.
+**Problem**: A required target-framework assembly is missing from the package.
 
 **Solutions**:
 - Verify `src/AiDotNet.csproj` has:
   ```xml
-  <TargetFrameworks>net8.0;net462</TargetFrameworks>
+  <TargetFrameworks>net10.0;net471</TargetFrameworks>
   ```
 - Ensure project builds successfully for both targets locally:
   ```bash
@@ -264,7 +247,7 @@ After installation, verify the workflow is working:
 
 - [VERSIONING.md](VERSIONING.md) - Detailed versioning guide
 - [CONVENTIONAL_COMMITS_GUIDE.md](CONVENTIONAL_COMMITS_GUIDE.md) - Commit message guide
-- [AUTOMATED_RELEASE_WORKFLOW.yml](AUTOMATED_RELEASE_WORKFLOW.yml) - Workflow template
+- [workflows/release-please.yml](workflows/release-please.yml) - Installed release workflow
 
 ## Support
 
@@ -281,7 +264,7 @@ If you encounter issues:
 
 To update the workflow:
 
-1. Modify `.github/workflows/release.yml`
+1. Modify `.github/workflows/release-please.yml`
 2. Test changes on a feature branch first
 3. Merge to main when verified
 
@@ -294,13 +277,14 @@ on:
   workflow_dispatch:  # Only manual triggers
 ```
 
-Or delete/rename `.github/workflows/release.yml`.
+Or delete/rename `.github/workflows/release-please.yml` and update the NuGet trusted-publishing policy before re-enabling releases.
 
 ## Security Considerations
 
-- **Secrets**: Never commit `NUGET_API_KEY` or other secrets to the repository
-- **Permissions**: The workflow uses minimal required permissions (contents: write)
-- **Dependencies**: GitHub Actions are pinned to specific versions (e.g., `@v4`)
+- **OIDC**: NuGet credentials are short-lived and exist only in the minimal `publish` job
+- **Isolation**: Build, signing, pack, and verification steps have no `id-token: write` permission
+- **Permissions**: Each job declares only the GitHub and OIDC permissions it needs
+- **Dependencies**: GitHub Actions are pinned to full commit SHAs
 - **Validation**: All inputs are validated before creating releases
 
 ## Benefits
@@ -316,10 +300,10 @@ After installation, you get:
 
 ## Next Steps
 
-1. Install the workflow using instructions above
+1. Create and verify the NuGet trusted-publishing policy described above
 2. Review [CONVENTIONAL_COMMITS_GUIDE.md](CONVENTIONAL_COMMITS_GUIDE.md)
 3. Update team documentation with commit message requirements
-4. Test with a feature commit
-5. Monitor first few releases to ensure everything works correctly
+4. Validate workflow syntax and permissions in a pull request
+5. Monitor the next deliberate release and confirm all expected NuGet packages and GitHub assets
 
 Happy releasing! 🚀

--- a/.github/AUTOMATED_RELEASE_SETUP.md
+++ b/.github/AUTOMATED_RELEASE_SETUP.md
@@ -27,7 +27,7 @@ Create a trusted-publishing policy at [nuget.org](https://www.nuget.org/account/
 | Workflow file | `release-please.yml` |
 | Environment | Leave blank |
 
-Enter only the workflow filename, not `.github/workflows/release-please.yml`. The policy is case-sensitive and must authorize every package published by this workflow. `NuGet/login` exchanges the job's GitHub OIDC identity for a short-lived API key; no long-lived NuGet API key is stored in GitHub.
+Enter only the workflow filename, not `.github/workflows/release-please.yml`. NuGet matches the owner, repository, workflow file, and environment values case-insensitively. The policy must authorize every package published by this workflow. `NuGet/login` exchanges the job's GitHub OIDC identity for a short-lived API key; no long-lived NuGet API key is stored in GitHub.
 
 Publishing fails closed if the policy does not match or NuGet does not issue a temporary key. See [NuGet trusted publishing](https://learn.microsoft.com/en-us/nuget/nuget-org/trusted-publishing).
 
@@ -86,7 +86,7 @@ The workflow analyzes commit messages since the last git tag:
 2. **build-release**
    - Checks out the immutable release tag
    - Builds, signs, packs, and verifies all NuGet packages without OIDC permission
-   - Uploads the verified packages as an immutable, one-day workflow artifact
+   - Uploads the verified packages as an immutable, 30-day workflow artifact so a failed publish job can be retried without rebuilding packages
 
 3. **publish**
    - Downloads the exact artifact ID produced by `build-release`
@@ -227,9 +227,9 @@ After installation, verify the workflow is working:
 **Solutions**:
 - Verify `src/AiDotNet.csproj` has:
   ```xml
-  <TargetFrameworks>net10.0;net471</TargetFrameworks>
+  <TargetFrameworks>net10.0;net8.0;net471</TargetFrameworks>
   ```
-- Ensure project builds successfully for both targets locally:
+- Ensure project builds successfully for all targets locally:
   ```bash
   dotnet build src/AiDotNet.csproj -c Release
   ```

--- a/.github/VERSIONING.md
+++ b/.github/VERSIONING.md
@@ -236,6 +236,7 @@ Permissions are scoped by job:
 
 The workflow verifies that NuGet packages contain these target frameworks:
 - `net471` (.NET Framework 4.7.1)
+- `net8.0` (.NET 8)
 - `net10.0` (.NET 10)
 
 ## Best Practices
@@ -280,7 +281,7 @@ Look for `feat:`, `fix:`, etc. prefixes.
 
 **Solution:** Check `AiDotNet.csproj` has:
 ```xml
-<TargetFrameworks>net10.0;net471</TargetFrameworks>
+<TargetFrameworks>net10.0;net8.0;net471</TargetFrameworks>
 ```
 
 ## Manual Version Override (Emergency)

--- a/.github/VERSIONING.md
+++ b/.github/VERSIONING.md
@@ -195,46 +195,48 @@ The release workflow triggers automatically on:
 
 ### Jobs
 
-1. **version-and-build**
-   - Analyzes commits and determines version
-   - Creates git tag
-   - Builds project
-   - Runs tests
-   - Creates NuGet package
-   - Verifies target frameworks (net462, net8.0)
+1. **release-please**
+   - Analyzes commits and maintains the rolling Release PR
+   - Creates the version tag and GitHub release when that PR is merged
 
-2. **publish-nuget** (conditional)
-   - Runs if `NUGET_API_KEY` secret is configured
-   - Publishes package to nuget.org
-   - Handles version conflicts gracefully
+2. **build-release** (conditional on a created release)
+   - Checks out the immutable release tag
+   - Builds, signs, packs, and verifies every package without OIDC access
+   - Uploads the verified packages as an immutable workflow artifact
 
-3. **github-release**
-   - Creates GitHub Release
-   - Attaches NuGet package as artifact
-   - Includes generated changelog
+3. **publish** (conditional on a successful release build)
+   - Downloads the exact artifact ID emitted by `build-release`
+   - Exchanges the job's GitHub OIDC identity for a short-lived NuGet API key
+   - Publishes the verified packages and attaches them to the GitHub release
 
 ## Configuration
 
-### Required Secrets
+### NuGet Trusted-Publishing Policy
 
-| Secret | Description |
-|--------|-------------|
-| `NUGET_API_KEY` | NuGet API key for publishing packages (optional) |
+NuGet publishing does not use a long-lived repository API key. Configure the policy at [nuget.org](https://www.nuget.org/account/trustedpublishing) with owner `ooples`, repository `AiDotNet`, workflow file `release-please.yml`, and no environment. Enter only the filename. See [NuGet trusted publishing](https://learn.microsoft.com/en-us/nuget/nuget-org/trusted-publishing).
+
+### Required Secrets and Variables
+
+| Name | Description |
+|------|-------------|
+| `AIDOTNET_BUILD_KEY` | Required build-signing/integrity key; available only to `build-release` |
+| `AUTOFIX_PAT` | Recommended PAT that lets release-please-created events trigger protected CI |
 | `GITHUB_TOKEN` | Automatically provided by GitHub Actions |
+| `AIDOTNET_LICENSE_PUBLIC_KEY_JSON` | Optional variable/secret used during a public-key rotation |
+| `AIDOTNET_LICENSE_REVOCATION_JSON` | Optional variable/secret containing the signed revocation list |
 
 ### Permissions
 
-The workflow requires these permissions:
-- `contents: write` - Create tags and releases
-- `issues: write` - Comment on related issues
-- `pull-requests: write` - Comment on related PRs
-- `id-token: write` - OIDC token generation
+Permissions are scoped by job:
+- `release-please`: `contents: write`, `pull-requests: write`, and `issues: write` to maintain the Release PR, labels, tag, and release
+- `build-release`: `contents: read` only, with no OIDC permission
+- `publish`: `contents: write` for release assets and `id-token: write` for NuGet trusted publishing
 
 ## Target Frameworks
 
 The workflow verifies that NuGet packages contain these target frameworks:
-- `net462` (.NET Framework 4.6.2)
-- `net8.0` (.NET 8.0)
+- `net471` (.NET Framework 4.7.1)
+- `net10.0` (.NET 10)
 
 ## Best Practices
 
@@ -278,7 +280,7 @@ Look for `feat:`, `fix:`, etc. prefixes.
 
 **Solution:** Check `AiDotNet.csproj` has:
 ```xml
-<TargetFrameworks>net8.0;net462</TargetFrameworks>
+<TargetFrameworks>net10.0;net471</TargetFrameworks>
 ```
 
 ## Manual Version Override (Emergency)

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -57,6 +57,9 @@ jobs:
 
   publish:
     name: Build, pack, publish NuGet
+    permissions:
+      contents: write
+      id-token: write
     runs-on: ubuntu-latest
     needs: release-please
     if: needs.release-please.outputs.release_created == 'true'
@@ -188,15 +191,28 @@ jobs:
         shell: pwsh
         run: ./scripts/Verify-NuGetGenerator.ps1 -PackagePath "out/AiDotNet.${{ needs.release-please.outputs.version }}.nupkg"
 
+      - name: Authenticate to NuGet with trusted publishing
+        id: nuget-login
+        uses: NuGet/login@8d196754b4036150537f80ac539e15c2f1028841 # v1.2.0
+        with:
+          user: ooples
+
       - name: Push to NuGet
+        env:
+          NUGET_API_KEY: ${{ steps.nuget-login.outputs.NUGET_API_KEY }}
         run: |
+          set -euo pipefail
+          if [ -z "$NUGET_API_KEY" ]; then
+            echo "::error::NuGet trusted publishing did not issue a temporary API key."
+            exit 1
+          fi
           shopt -s nullglob
           pkgs=(out/*.nupkg)
           [ ${#pkgs[@]} -gt 0 ] || { echo "Error: No .nupkg files found in out/"; exit 1; }
           for pkg in "${pkgs[@]}"; do
             echo "Publishing $pkg to NuGet..."
             dotnet nuget push "$pkg" \
-              --api-key ${{ secrets.NUGET_API_KEY }} \
+              --api-key "$NUGET_API_KEY" \
               --source https://api.nuget.org/v3/index.json \
               --skip-duplicate
           done

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -166,7 +166,7 @@ jobs:
           [ -f "$main" ] || { echo "Error: core package $main not found"; exit 1; }
 
           files=$(unzip -Z1 "$main")
-          for tfm in net471 net10.0; do
+          for tfm in net471 net8.0 net10.0; do
             echo "$files" | grep -qE "^lib/${tfm}/.+[.]dll$" || { echo "Error: Missing ${tfm} lib in $main"; exit 1; }
             echo "Found ${tfm} in $(basename "$main")"
           done
@@ -198,7 +198,7 @@ jobs:
           name: release-packages-${{ needs.release-please.outputs.tag_name }}
           path: out/*.nupkg
           if-no-files-found: error
-          retention-days: 1
+          retention-days: 30
           compression-level: 0
 
   publish:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -7,8 +7,8 @@ name: Release Please
 #      last release into a rolling "Release PR" (version bump + CHANGELOG). NO release is cut yet —
 #      merges just keep updating that one PR, so a burst of merged PRs bundles into a single version.
 #   2. When a maintainer merges the Release PR, release-please creates the git tag (v<version>) and
-#      the GitHub release. Only then does the `publish` job run: it builds, packs, pushes to NuGet,
-#      and attaches the .nupkg to the release.
+#      the GitHub release. Only then do `build-release` and `publish` run: the first builds and
+#      verifies packages without OIDC access, and the second publishes only those artifacts.
 #
 # This gives deliberate, atomic, batched releases instead of one release per merged PR.
 
@@ -19,8 +19,7 @@ on:
       - main
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 # Serialize (never cancel): a release cut / PR update must finish. Runs are cheap when they only
 # update the Release PR, and must be atomic when they actually publish.
@@ -34,10 +33,10 @@ jobs:
     runs-on: ubuntu-latest
     # Scope issues:write (label mutations) to this job only, following least-privilege —
     # a job-level permissions block OVERRIDES the workflow default, so contents/pull-requests
-    # are re-declared here; the publish job keeps the workflow-level contents:write it needs.
+    # are re-declared here; every other job declares only its own narrower permissions.
     permissions:
-      contents: write
-      pull-requests: write
+      contents: write # Required to create release commits, tags, and GitHub releases.
+      pull-requests: write # Required to create and update the rolling Release PR.
       issues: write # release-please creates/applies the `autorelease:` labels via the Issues API
     outputs:
       release_created: ${{ steps.rp.outputs.release_created }}
@@ -55,15 +54,16 @@ jobs:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
 
-  publish:
-    name: Build, pack, publish NuGet
+  build-release:
+    name: Build and verify release packages
     permissions:
-      contents: write
-      id-token: write
+      contents: read # Required to check out the release tag.
     runs-on: ubuntu-latest
     needs: release-please
     if: needs.release-please.outputs.release_created == 'true'
     timeout-minutes: 25
+    outputs:
+      package-artifact-id: ${{ steps.upload-packages.outputs.artifact-id }}
     steps:
       - name: Free up disk space
         run: |
@@ -190,6 +190,37 @@ jobs:
       - name: Verify PackageReference consumer gets generated factories automatically
         shell: pwsh
         run: ./scripts/Verify-NuGetGenerator.ps1 -PackagePath "out/AiDotNet.${{ needs.release-please.outputs.version }}.nupkg"
+
+      - name: Upload verified release packages
+        id: upload-packages
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: release-packages-${{ needs.release-please.outputs.tag_name }}
+          path: out/*.nupkg
+          if-no-files-found: error
+          retention-days: 1
+          compression-level: 0
+
+  publish:
+    name: Publish verified packages
+    permissions:
+      contents: write # Required for gh release upload.
+      id-token: write # Required for NuGet trusted publishing.
+    runs-on: ubuntu-latest
+    needs: [release-please, build-release]
+    if: needs.release-please.outputs.release_created == 'true'
+    timeout-minutes: 10
+    steps:
+      - name: Setup .NET
+        uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
+        with:
+          dotnet-version: 10.0.x
+
+      - name: Download verified release packages
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v7.0.0
+        with:
+          artifact-ids: ${{ needs.build-release.outputs.package-artifact-id }}
+          path: out
 
       - name: Authenticate to NuGet with trusted publishing
         id: nuget-login


### PR DESCRIPTION
## Summary
- exchange GitHub OIDC for a short-lived NuGet credential in the release publish job
- scope `id-token: write` to the job that publishes while preserving release-asset upload access
- fail closed when NuGet does not return a temporary credential
- remove the active workflow's dependency on the long-lived `NUGET_API_KEY` secret

## Local proof
- `actionlint v1.7.12 .github/workflows/release-please.yml` (checksum-verified binary): passed
- semantic contract: job-scoped OIDC, pinned `NuGet/login` v1.2.0, login-before-push, exact output wiring, empty-token rejection, quoted token use, and no `secrets.NUGET_API_KEY`: 7/7 passed
- `git diff --check`: passed

## Required nuget.org policy before merge
- Owner: `ooples`
- Repository: `AiDotNet`
- Workflow file: `release-please.yml`
- Environment: leave blank

The publish path is release-only, so the first real OIDC exchange is intentionally exercised by the next release after this workflow and its matching nuget.org policy are both active.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated package publishing to use secure, short-lived authentication.
  * Added safeguards to stop publishing when authentication credentials are unavailable.
  * Separated release building and publishing into distinct stages using verified, immutable artifacts.
  * Reduced workflow permissions and strengthened job-level security controls.
  * Expanded package verification to cover supported target frameworks.

* **Documentation**
  * Updated release setup and versioning guides for the revised publishing process.
  * Added guidance for trusted publishing, artifact verification, troubleshooting, and supported target frameworks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->