### PR TITLE
chore: make FinancialDQNAgent's exploration schedule and target sync real

### DIFF
--- a/src/Finance/Trading/Agents/FinancialDQNAgent.cs
+++ b/src/Finance/Trading/Agents/FinancialDQNAgent.cs
@@ -61,6 +61,19 @@ public partial class FinancialDQNAgent<T> : TradingAgentBase<T>, IGradientComput
     private readonly ReplayBuffer<T> ReplayBuffer;
     private readonly NeuralNetworkArchitecture<T> _architecture;
 
+    /// <summary>
+    /// Current exploration rate, decayed toward <c>EpsilonEnd</c> as training proceeds.
+    /// </summary>
+    /// <remarks>
+    /// Held as state because an exploration SCHEDULE is state. Reading <c>EpsilonStart</c> directly on every
+    /// action — which is what this did — pins the behaviour policy at its initial value forever: with the
+    /// default 1.0 the agent acts uniformly at random for an entire run and its learning curve is noise.
+    /// </remarks>
+    private double _epsilon;
+
+    /// <summary>Training updates applied, so the target sync can be a schedule rather than a coin flip.</summary>
+    private int _trainSteps;
+
     /// <inheritdoc/>
     public override ModelOptions GetOptions() => _options;
 
@@ -109,6 +122,7 @@ public partial class FinancialDQNAgent<T> : TradingAgentBase<T>, IGradientComput
         _qNetwork = new NeuralNetwork<T>(architecture, lossFunction: TradingOptions.LossFunction ?? new MeanSquaredErrorLoss<T>());
         _targetNetwork = new NeuralNetwork<T>(architecture.CloneForModelConstruction(), lossFunction: TradingOptions.LossFunction ?? new MeanSquaredErrorLoss<T>());
         ReplayBuffer = new ReplayBuffer<T>(options.ReplayBufferSize, options.Seed);
+        _epsilon = options.EpsilonStart;
         UpdateTargetNetwork();
     }
 
@@ -124,7 +138,7 @@ public partial class FinancialDQNAgent<T> : TradingAgentBase<T>, IGradientComput
     /// </remarks>
     public override Vector<T> SelectAction(Vector<T> state, bool training = true)
     {
-        if (training && RandomHelper.CreateSecureRandom().NextDouble() < TradingOptions.EpsilonStart)
+        if (training && RandomHelper.CreateSecureRandom().NextDouble() < _epsilon)
         {
             var action = new Vector<T>(TradingOptions.ActionSize);
             int randomAction = RandomHelper.CreateSecureRandom().Next(TradingOptions.ActionSize);
@@ -224,12 +238,35 @@ public partial class FinancialDQNAgent<T> : TradingAgentBase<T>, IGradientComput
         var expected = new Tensor<T>([n, actionCount], expectedData);
         _qNetwork.Train(states, expected);
 
-        if (RandomHelper.CreateSecureRandom().Next(TradingOptions.TargetUpdateFrequency) == 0)
+        // A SCHEDULE, NOT A COIN FLIP. This drew Next(TargetUpdateFrequency) == 0 on every update, so with the
+        // default frequency of 1000 and a few hundred updates per run the target network synced roughly 0.6
+        // times PER RUN, at random moments. Deterministic counting makes "every N updates" mean what it says,
+        // and makes two runs with the same seed comparable.
+        _trainSteps++;
+        if (_trainSteps % Math.Max(1, TradingOptions.TargetUpdateFrequency) == 0)
         {
             UpdateTargetNetwork();
         }
 
+        // Decay toward the floor, matching DoubleDQNAgent's schedule so the two agents anneal identically.
+        _epsilon = Math.Max(TradingOptions.EpsilonEnd, _epsilon * TradingOptions.EpsilonDecay);
+
         return NumOps.Zero;
+    }
+
+    /// <summary>
+    /// Adds the current exploration rate to the reported metrics.
+    /// </summary>
+    /// <remarks>
+    /// Without this there is no way to tell an agent that annealed from one that never explored: both report
+    /// the same rewards, and the difference lives only in a private field. Matches DoubleDQNAgent, which
+    /// already publishes "Epsilon".
+    /// </remarks>
+    public override Dictionary<string, T> GetTradingMetrics()
+    {
+        var metrics = base.GetTradingMetrics();
+        metrics["Epsilon"] = NumOps.FromDouble(_epsilon);
+        return metrics;
     }
 
     /// <summary>

--- a/tests/AiDotNet.Tests/IntegrationTests/Finance/FinancialDqnExplorationScheduleTests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/Finance/FinancialDqnExplorationScheduleTests.cs
@@ -1,0 +1,120 @@
+using System;
+using AiDotNet.Finance.Trading.Agents;
+using AiDotNet.Helpers;
+using AiDotNet.Models.Options;
+using Xunit;
+
+namespace AiDotNet.Tests.IntegrationTests.Finance;
+
+/// <summary>
+/// FinancialDQNAgent had an exploration schedule that never ran and a target sync that was a coin flip.
+///
+/// <para><c>SelectAction</c> compared against <c>TradingOptions.EpsilonStart</c> — the INITIAL value — on every
+/// call, so the behaviour policy never annealed. With the default 1.0 the agent acts uniformly at random for an
+/// entire run, which makes its learning curve noise. Separately, the target network synced on
+/// <c>Next(TargetUpdateFrequency) == 0</c>; at the default 1000 over a few hundred updates that is roughly
+/// 0.6 syncs per run, at random moments.</para>
+///
+/// <para>Measured downstream: across 235 production bake-off runs this agent completed a maximum of ONE round
+/// trip, ever. <c>EpsilonEnd</c> and <c>EpsilonDecay</c> existed on the options the whole time and nothing
+/// read them.</para>
+/// </summary>
+public class FinancialDqnExplorationScheduleTests
+{
+    [Fact]
+    public void Epsilon_decays_toward_the_floor_instead_of_staying_at_its_initial_value()
+    {
+        var agent = Agent(epsilonStart: 1.0, epsilonEnd: 0.05, epsilonDecay: 0.5);
+        var before = Epsilon(agent);
+
+        // Each update applies one decay step: 1.0 -> 0.5 -> 0.25 -> ... floored at EpsilonEnd.
+        for (var i = 0; i < 6; i++)
+        {
+            Train(agent);
+        }
+
+        var after = Epsilon(agent);
+        Assert.Equal(1.0, before, precision: 6);
+        Assert.True(after < before, $"epsilon did not decay: {before} -> {after}");
+        Assert.Equal(0.05, after, precision: 6);
+    }
+
+    [Fact]
+    public void Epsilon_never_falls_below_the_configured_floor()
+    {
+        // The floor is what keeps a converged policy still exploring a little. Decaying past it would make the
+        // agent greedy forever, which is the opposite failure to the one being fixed.
+        var agent = Agent(epsilonStart: 0.5, epsilonEnd: 0.1, epsilonDecay: 0.1);
+        for (var i = 0; i < 20; i++)
+        {
+            Train(agent);
+        }
+
+        Assert.Equal(0.1, Epsilon(agent), precision: 6);
+    }
+
+    [Fact]
+    public void A_schedule_that_asks_for_no_decay_is_honoured()
+    {
+        // EpsilonDecay = 1.0 means "hold the rate". It must not be mistaken for "no schedule configured" and
+        // silently annealed anyway.
+        var agent = Agent(epsilonStart: 0.3, epsilonEnd: 0.01, epsilonDecay: 1.0);
+        for (var i = 0; i < 5; i++)
+        {
+            Train(agent);
+        }
+
+        Assert.Equal(0.3, Epsilon(agent), precision: 6);
+    }
+
+    [Fact]
+    public void The_exploration_rate_is_reported_so_the_curve_can_be_seen()
+    {
+        // Without a published metric an agent that annealed and one that never explored report identical
+        // rewards, and the difference lives only in a private field.
+        var agent = Agent(epsilonStart: 0.8, epsilonEnd: 0.02, epsilonDecay: 0.5);
+        Train(agent);
+
+        var metrics = agent.GetTradingMetrics();
+        Assert.True(metrics.ContainsKey("Epsilon"), "the agent does not report its exploration rate");
+        Assert.Equal(0.4, Convert.ToDouble(metrics["Epsilon"]), precision: 6);
+    }
+
+    private static FinancialDQNAgent<double> Agent(double epsilonStart, double epsilonEnd, double epsilonDecay)
+    {
+        var options = new FinancialDQNAgentOptions<double>
+        {
+            StateSize = 4,
+            ActionSize = 3,
+            EpsilonStart = epsilonStart,
+            EpsilonEnd = epsilonEnd,
+            EpsilonDecay = epsilonDecay,
+            BatchSize = 2,
+            ReplayBufferSize = 32,
+        };
+
+        // Built through the same helper the existing trading-agent tests use, so this exercises the shape the
+        // suite already trusts rather than a second, divergent construction path.
+        return new FinancialDQNAgent<double>(FinanceTestHelpers.CreateArchitecture<double>(4, 3), options);
+    }
+
+    /// <summary>Drives one training update through the public surface, which is what advances the schedule.</summary>
+    private static void Train(FinancialDQNAgent<double> agent)
+    {
+        var numOps = MathHelper.GetNumericOperations<double>();
+        var state = FinanceTestHelpers.CreateRandomVector<double>(4, seed: 123);
+        var next = FinanceTestHelpers.CreateRandomVector<double>(4, seed: 321);
+
+        for (var i = 0; i < 4; i++)
+        {
+            agent.StoreTradingExperience(
+                state, agent.SelectTradingAction(state, training: true),
+                numOps.FromDouble(0.01), next, done: false, pnl: numOps.FromDouble(0.02));
+        }
+
+        _ = agent.TrainOnExperiences();
+    }
+
+    private static double Epsilon(FinancialDQNAgent<double> agent) =>
+        Convert.ToDouble(agent.GetTradingMetrics()["Epsilon"]);
+}


### PR DESCRIPTION
Two defects in the same agent, both of which make its learning curve noise.

## 1. The exploration schedule never ran

`SelectAction` compared against `TradingOptions.EpsilonStart` — the **initial** value — on every call:

```csharp
if (training && RandomHelper.CreateSecureRandom().NextDouble() < TradingOptions.EpsilonStart)
```

`EpsilonEnd` and `EpsilonDecay` existed on `TradingAgentOptions` the whole time and nothing read them. With the default `EpsilonStart = 1.0` the behaviour policy is **100% uniform random for an entire run**, so nothing the network learns ever influences what the agent does, and the recorded rewards measure the random policy rather than the learned one.

Now decayed per update toward the floor, matching `DoubleDQNAgent` exactly (`_epsilon = Math.Max(EpsilonEnd, _epsilon * EpsilonDecay)`) so the two agents anneal identically rather than each having their own idea of a schedule.

## 2. The target sync was a coin flip

```csharp
if (RandomHelper.CreateSecureRandom().Next(TradingOptions.TargetUpdateFrequency) == 0)
```

At the default frequency of 1000, over a few hundred updates per run, that fires roughly **0.6 times per run** — and at random moments, so two runs with the same seed diverge. "Every N updates" now means what it says: a counter and `_trainSteps % N == 0`.

The target *network* itself is already a proper clone; this is the schedule deciding when it is refreshed.

## 3. The rate is now reported

`GetTradingMetrics` publishes `"Epsilon"`, as `DoubleDQNAgent` already does. Without it, an agent that annealed and one that never explored report identical rewards and the difference lives only in a private field — which is much of why this went unnoticed.

## Why this surfaced now

A downstream platform audited its RL bake-off and found **0 of 992 evaluations eligible**. Per-agent round-trip counts, 235 runs each:

| Agent | Mean round-trips | **Max** |
|---|---:|---:|
| IQL | 20.9 | 151 |
| PPO | 17.3 | 313 |
| A2C | 15.5 | 314 |
| SAC | 6.6 | 314 |
| **DQN** | **0.7** | **1** |

DQN never completed more than a single round trip in 235 runs. With a behaviour policy that is uniformly random and a target network refreshed ~0.6 times per run, that is the expected outcome rather than a surprise.

## Tests

`tests/AiDotNet.Tests/IntegrationTests/Finance/FinancialDqnExplorationScheduleTests.cs` — 4 new:

- decay actually happens, and reaches the floor
- the floor is respected and never undershot
- `EpsilonDecay = 1.0` is honoured as "hold the rate", not mistaken for "unconfigured"
- the rate is published so the curve can be plotted

Built through `FinanceTestHelpers` / `FinanceModelTestFactory`'s own construction path, so they exercise the shape the existing suite already trusts rather than a second, divergent one.

**Teeth verified:** removing the decay line fails 3 of 4, with `epsilon did not decay: 1 -> 1`.

## Scope

Deliberately limited to `FinancialDQNAgent`. `DoubleDQNAgent` already implements both correctly and is the reference this now matches — the goal is to remove a divergence, not introduce a third convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017otuSGr3GdmvPoYLbiaWR2


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Exploration now gradually decreases during training, down to the configured minimum.
  * Target-network updates occur at consistent training intervals.
  * Trading metrics now report the current exploration rate.

* **Tests**
  * Added coverage for exploration decay, minimum limits, no-decay settings, and metric reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->