### PR TITLE
test(ci): live-proof non-runtime routing

### DIFF
--- a/.github/AUTOMATED_RELEASE_SETUP.md
+++ b/.github/AUTOMATED_RELEASE_SETUP.md
@@ -323,3 +323,5 @@ After installation, you get:
 5. Monitor first few releases to ensure everything works correctly
 
 Happy releasing! 🚀
+
+<!-- CI routing live-proof fixture. -->

--- a/.github/VERSIONING.md
+++ b/.github/VERSIONING.md
@@ -305,3 +305,5 @@ Check the current version:
 - [Conventional Commits Specification](https://www.conventionalcommits.org/)
 - [Semantic Versioning](https://semver.org/)
 - [Keep a Changelog](https://keepachangelog.com/)
+
+<!-- CI routing live-proof fixture. -->

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -206,3 +206,5 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh release upload "${{ needs.release-please.outputs.tag_name }}" out/*.nupkg --clobber
+
+# CI routing live-proof fixture.

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -118,6 +118,9 @@ jobs:
       pr_number: ${{ steps.resolve.outputs.pr_number || steps.defaults.outputs.pr_number }}
       tested_sha: ${{ steps.resolve.outputs.tested_sha || steps.defaults.outputs.tested_sha }}
       reuse: ${{ steps.resolve.outputs.reuse || steps.defaults.outputs.reuse }}
+      # Whether the reusable PR run produced runtime/test artifacts. Schema-v1 certificates are
+      # conservatively treated as true; schema-v2 non-runtime certificates explicitly emit false.
+      reused_requires_validation: ${{ steps.resolve.outputs.reused_requires_validation || steps.defaults.outputs.reused_requires_validation }}
       # JSON boolean, consumed through fromJSON at every expensive job boundary. A missing or
       # malformed value fails the workflow instead of accidentally authorizing a skip.
       execute_expensive: ${{ steps.resolve.outputs.execute_expensive || steps.defaults.outputs.execute_expensive }}
@@ -132,6 +135,7 @@ jobs:
             echo 'pr_number='
             echo 'tested_sha='
             echo 'reuse=false'
+            echo 'reused_requires_validation=true'
             echo 'execute_expensive=true'
           } >> "$GITHUB_OUTPUT"
 
@@ -223,10 +227,10 @@ jobs:
               "repos/${GITHUB_REPOSITORY}/actions/runs/${run_id}/artifacts?per_page=100" 2>/dev/null || true)
             [ -n "$artifacts_json" ] || continue
 
-            # A pull_request run keys this artifact by the PR head; a merge_group run keys it by
-            # the queue commit. There is exactly one analysis artifact per run, and the downloaded
-            # payload plus certificate are both bound to tested_sha below, so discovery need not
-            # guess which event produced the candidate.
+            # A pull_request run keys these artifacts by the PR head; a merge_group run keys them
+            # by the queue commit. A schema-v2 certificate records whether runtime validation was
+            # required. Non-runtime runs deliberately have no analysis or coverage artifacts;
+            # runtime runs must still provide both and bind their analysis to the same tested SHA.
             analysis_id=$(jq -r '
               [.[] | .artifacts[]? |
                 select(.expired == false and (.name | startswith("ci-test-analysis-")))]
@@ -238,18 +242,9 @@ jobs:
               | sort_by(.created_at) | reverse | .[0].id // empty
             ' <<< "$artifacts_json")
             coverage_count=$(jq '[.[] | .artifacts[]? | select(.expired == false and (.name | startswith("coverage-")))] | length' <<< "$artifacts_json")
-            if [ -z "$analysis_id" ] || [ -z "$certificate_id" ] || [ "$coverage_count" -eq 0 ]; then
+            if [ -z "$certificate_id" ]; then
               continue
             fi
-
-            archive="$RUNNER_TEMP/ci-test-analysis-${run_id}.zip"
-            if ! gh api "repos/${GITHUB_REPOSITORY}/actions/artifacts/${analysis_id}/zip" > "$archive"; then
-              continue
-            fi
-            entry=$(unzip -Z1 "$archive" | awk '/(^|\/)ci-test-analysis\.json$/ { print; exit }')
-            [ -n "$entry" ] || continue
-            tested_sha=$(unzip -p "$archive" "$entry" | jq -r '.source.commitSha // empty')
-            [ -n "$tested_sha" ] || continue
 
             certificate_archive="$RUNNER_TEMP/ci-validation-certificate-${run_id}.zip"
             if ! gh api "repos/${GITHUB_REPOSITORY}/actions/artifacts/${certificate_id}/zip" > "$certificate_archive"; then
@@ -257,12 +252,32 @@ jobs:
             fi
             certificate_entry=$(unzip -Z1 "$certificate_archive" | awk '/(^|\/)validation-certificate\.json$/ { print; exit }')
             [ -n "$certificate_entry" ] || continue
-            if ! unzip -p "$certificate_archive" "$certificate_entry" | jq -e \
-                 --arg run "$run_id" --arg sha "$tested_sha" \
-                 '.schemaVersion == 1 and (.runId | tostring) == $run and .testedSha == $sha and
-                  (.event == "pull_request" or .event == "merge_group") and .ciGateConclusion == "success"' \
-                 >/dev/null; then
+            certificate_json=$(unzip -p "$certificate_archive" "$certificate_entry")
+            if ! jq -e --arg run "$run_id" '
+                 ((.schemaVersion == 1) or
+                  (.schemaVersion == 2 and (.requiresValidation | type) == "boolean")) and
+                 (.runId | tostring) == $run and
+                 (.testedSha | type) == "string" and (.testedSha | length) == 40 and
+                 (.event == "pull_request" or .event == "merge_group") and
+                 .ciGateConclusion == "success"
+               ' <<< "$certificate_json" >/dev/null; then
               continue
+            fi
+            tested_sha=$(jq -r '.testedSha' <<< "$certificate_json")
+            requires_validation=$(jq -r 'if .schemaVersion == 1 then true else .requiresValidation end' <<< "$certificate_json")
+
+            if [ "$requires_validation" = 'true' ]; then
+              if [ -z "$analysis_id" ] || [ "$coverage_count" -eq 0 ]; then
+                continue
+              fi
+              archive="$RUNNER_TEMP/ci-test-analysis-${run_id}.zip"
+              if ! gh api "repos/${GITHUB_REPOSITORY}/actions/artifacts/${analysis_id}/zip" > "$archive"; then
+                continue
+              fi
+              entry=$(unzip -Z1 "$archive" | awk '/(^|\/)ci-test-analysis\.json$/ { print; exit }')
+              [ -n "$entry" ] || continue
+              analysis_sha=$(unzip -p "$archive" "$entry" | jq -r '.source.commitSha // empty')
+              [ "$analysis_sha" = "$tested_sha" ] || continue
             fi
             tested_tree=$(gh api "repos/${GITHUB_REPOSITORY}/git/commits/${tested_sha}" --jq '.tree.sha' 2>/dev/null || true)
 
@@ -272,6 +287,7 @@ jobs:
                 echo "pr_number=$pr_number"
                 echo "tested_sha=$tested_sha"
                 echo 'reuse=true'
+                echo "reused_requires_validation=$requires_validation"
                 echo 'execute_expensive=false'
               } >> "$GITHUB_OUTPUT"
               echo "Reusing PR #${pr_number} run ${run_id}; tested tree ${tested_tree} exactly matches master." >> "$GITHUB_STEP_SUMMARY"
@@ -316,12 +332,14 @@ jobs:
   codeql:
     name: CodeQL Analysis
     runs-on: ubuntu-latest
-    needs: validation-source
+    needs: [validation-source, select-shards]
     # The traced net10 build takes about 31 minutes on generated-source-heavy PRs. The #2032
     # analysis was still running when the 60-minute ceiling cancelled it, while master's #2026
     # baseline completed in 57:48. Give extraction, SARIF generation, and upload enough margin
     # for normal hosted-runner variance without hiding a genuinely hung job.
     timeout-minutes: 75
+    # CodeQL remains mandatory even for non-runtime changes because the active Main ruleset
+    # requires a CodeQL result for the candidate commit. This is one job, not a model/test matrix.
     if: "${{ fromJSON(needs.validation-source.outputs.execute_expensive) && (github.event.pull_request.draft != true) && !startsWith(github.head_ref, 'release-please--') && !(github.event_name == 'push' && startsWith(github.event.head_commit.message, 'chore(master): release')) }}"
     permissions:
       contents: read
@@ -388,7 +406,7 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
-    needs: validation-source
+    needs: [validation-source, select-shards]
     outputs:
       artifact_id: ${{ steps.upload-build-artifact.outputs.artifact-id }}
       # upload-artifact emits bare hexadecimal; normalize once at the producer boundary.
@@ -396,7 +414,7 @@ jobs:
     timeout-minutes: 45
     permissions:
       contents: read
-    if: "${{ fromJSON(needs.validation-source.outputs.execute_expensive) && (github.event.pull_request.draft != true) && !startsWith(github.head_ref, 'release-please--') && !(github.event_name == 'push' && startsWith(github.event.head_commit.message, 'chore(master): release')) }}"
+    if: "${{ fromJSON(needs.validation-source.outputs.execute_expensive) && fromJSON(needs.select-shards.outputs.requires_validation) && (github.event.pull_request.draft != true) && !startsWith(github.head_ref, 'release-please--') && !(github.event_name == 'push' && startsWith(github.event.head_commit.message, 'chore(master): release')) }}"
 
     steps:
       - name: Checkout code
@@ -529,8 +547,8 @@ jobs:
     timeout-minutes: 45
     permissions:
       contents: read
-    needs: validation-source
-    if: "${{ fromJSON(needs.validation-source.outputs.execute_expensive) && (github.event.pull_request.draft != true) && !startsWith(github.head_ref, 'release-please--') && !(github.event_name == 'push' && startsWith(github.event.head_commit.message, 'chore(master): release')) }}"
+    needs: [validation-source, select-shards]
+    if: "${{ fromJSON(needs.validation-source.outputs.execute_expensive) && fromJSON(needs.select-shards.outputs.requires_validation) && (github.event.pull_request.draft != true) && !startsWith(github.head_ref, 'release-please--') && !(github.event_name == 'push' && startsWith(github.event.head_commit.message, 'chore(master): release')) }}"
 
     steps:
       - name: Checkout code
@@ -656,6 +674,9 @@ jobs:
     outputs:
       matrix: ${{ steps.select.outputs.matrix }}
       escalated: ${{ steps.select.outputs.escalated }}
+      # JSON boolean. Every expensive job consumes it through fromJSON; false is the deliberate
+      # non-runtime path, while absent/malformed output prevents those jobs from being authorized.
+      requires_validation: ${{ steps.select.outputs.requires_validation }}
       # Slugs of the shards deliberately not run, for the regression analyzer. It treats any
       # baseline shard with no current artifact as Incomplete and fails the policy on it - which
       # is right for a host that died and wrong for a shard we chose to skip.
@@ -766,6 +787,8 @@ jobs:
           if ($LASTEXITCODE -ne 0) { throw 'Test-impact end-to-end proof failed' }
           ./tools/TestImpact/Test-CiGateModes.ps1
           if ($LASTEXITCODE -ne 0) { throw 'CI Gate mode proof failed' }
+          ./tools/TestImpact/Test-ValidationReuseModes.ps1
+          if ($LASTEXITCODE -ne 0) { throw 'Validation reuse mode proof failed' }
 
       - name: Select
         id: select
@@ -773,6 +796,7 @@ jobs:
         env:
           MAP_KIND: ${{ steps.map.outputs.kind }}
           MAP_RUN_ID: ${{ steps.map.outputs.run_id }}
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
         run: |
           $all = @(yq -o=json -I=0 '.shard' .github/test-shards.yml | ConvertFrom-Json)
           if ($all.Count -eq 0) {
@@ -791,6 +815,7 @@ jobs:
           Write-Host "shard list: $($all.Count) shard(s)"
 
           $escalate = $true
+          $requiresValidation = $true
           $selected = @()
 
           # Two independent reasons to refuse to reduce, reported separately so the log says which
@@ -826,24 +851,52 @@ jobs:
           elseif (-not $eventCanReduce) {
             Write-Host "event is '${{ github.event_name }}', not a pull request - running the full matrix"
           }
-          elseif ($mapCertified) {
-            # No base ref: the diff is taken from the map's own commit, which is the only
-            # reference whose line numbers the map's ranges are expressed in.
-            & ./tools/TestImpact/Select-Shards.ps1 `
-                -MapFile map/shard-map.json `
-                -ExpectedShards @($all.name) `
-                -OutFile selection.json
-            $result = Get-Content selection.json -Raw | ConvertFrom-Json
-            $escalate = [bool] $result.escalate
-            $selected = @($result.shards)
-          }
           else {
-            Write-Host '::warning::no certified shard map - running the full matrix'
+            # Non-runtime classification depends only on the PR's exact base-to-head path set, so
+            # documentation and independent workflow changes do not fall back to full CI merely
+            # because a coverage artifact is missing or expired. Any classification uncertainty
+            # remains true and continues into the certified-map path below.
+            $pathRequiresValidation = $true
+            try {
+              & ./tools/TestImpact/Select-Shards.ps1 -ClassifyOnly `
+                  -BaseSha $env:PR_BASE_SHA -OutFile path-classification.json
+              if ($LASTEXITCODE -ne 0) { throw "path classifier exited $LASTEXITCODE" }
+              $pathResult = Get-Content path-classification.json -Raw | ConvertFrom-Json
+              $pathRequiresValidation = [bool] $pathResult.requiresValidation
+            }
+            catch {
+              Write-Host "::warning::path classification unavailable ($($_.Exception.Message)) - runtime validation remains required"
+            }
+
+            if (-not $pathRequiresValidation) {
+              $escalate = $false
+              $requiresValidation = $false
+              $selected = @()
+            }
+            elseif ($mapCertified) {
+              # No base ref: coverage selection diffs from the map's own commit, which is the only
+              # reference whose line numbers the map's ranges are expressed in.
+              & ./tools/TestImpact/Select-Shards.ps1 `
+                  -MapFile map/shard-map.json `
+                  -ExpectedShards @($all.name) `
+                  -OutFile selection.json
+              $result = Get-Content selection.json -Raw | ConvertFrom-Json
+              $escalate = [bool] $result.escalate
+              $requiresValidation = [bool] $result.requiresValidation
+              $selected = @($result.shards)
+            }
+            else {
+              Write-Host '::warning::no certified shard map - running the full matrix'
+            }
           }
 
           if ($escalate) {
             $matrixShards = $all
             Write-Host "escalated: running all $($all.Count) shard(s)"
+          }
+          elseif (-not $requiresValidation) {
+            $matrixShards = @()
+            Write-Host 'non-runtime-only change: model and test validation is not required'
           }
           else {
             $wanted = [System.Collections.Generic.HashSet[string]]::new(
@@ -866,9 +919,9 @@ jobs:
             }
           }
 
-          # Empty is uncertainty, not permission to run nothing. Preserve the fail-safe contract
-          # even if a future selector regression reaches this second line of defence.
-          if ($matrixShards.Count -eq 0) {
+          # Empty is authorized only by the selector's explicit typed decision. A mapped selection
+          # that unexpectedly becomes empty still fails safe to the complete matrix.
+          if ($requiresValidation -and $matrixShards.Count -eq 0) {
             Write-Host '::warning::shard selection produced an empty matrix - running the full matrix'
             $matrixShards = $all
             $escalate = $true
@@ -889,8 +942,11 @@ jobs:
           "skipped=$(ConvertTo-Json -InputObject @($skipped) -Depth 3 -Compress)" |
             Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
           "escalated=$($escalate.ToString().ToLowerInvariant())" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+          "requires_validation=$($requiresValidation.ToString().ToLowerInvariant())" |
+            Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
 
           $summary = if ($escalate) { "Running the full matrix ($($all.Count) shards)." }
+                     elseif (-not $requiresValidation) { 'Non-runtime-only change; no model or test jobs required.' }
                      else { "Selected **$($matrixShards.Count)** of $($all.Count) shards from coverage." }
           "### Shard selection`n`n$summary" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8
 
@@ -1025,7 +1081,7 @@ jobs:
     permissions:
       actions: read
       contents: read
-    if: "${{ fromJSON(needs.validation-source.outputs.execute_expensive) && (github.event.pull_request.draft != true) && !startsWith(github.head_ref, 'release-please--') && !(github.event_name == 'push' && startsWith(github.event.head_commit.message, 'chore(master): release')) }}"
+    if: "${{ fromJSON(needs.validation-source.outputs.execute_expensive) && fromJSON(needs.select-shards.outputs.requires_validation) && (github.event.pull_request.draft != true) && !startsWith(github.head_ref, 'release-please--') && !(github.event_name == 'push' && startsWith(github.event.head_commit.message, 'chore(master): release')) }}"
     strategy:
       fail-fast: false
       max-parallel: ${{ inputs.collect_coverage_everywhere && 12 || 20 }}
@@ -1715,7 +1771,7 @@ jobs:
   parameter-enumeration-sweep:
     name: Parameter sweep (${{ matrix.label }})
     runs-on: ubuntu-latest
-    needs: validation-source
+    needs: [validation-source, select-shards]
     # LEAST PRIVILEGE, DECLARED. With no permissions block this job inherited the workflow
     # or repository default token scope, which on a repository defaulting to read/write hands
     # a job that only checks out, builds and uploads an artifact the ability to push commits.
@@ -1734,7 +1790,7 @@ jobs:
     # entirely -- on a push github.head_ref is empty, so this job ran on release
     # commits while every other job skipped, building the whole solution and
     # holding a runner for up to 60 minutes to do it.
-    if: "${{ fromJSON(needs.validation-source.outputs.execute_expensive) && (github.event.pull_request.draft != true) && !startsWith(github.head_ref, 'release-please--') && !(github.event_name == 'push' && startsWith(github.event.head_commit.message, 'chore(master): release')) }}"
+    if: "${{ fromJSON(needs.validation-source.outputs.execute_expensive) && fromJSON(needs.select-shards.outputs.requires_validation) && (github.event.pull_request.draft != true) && !startsWith(github.head_ref, 'release-please--') && !(github.event_name == 'push' && startsWith(github.event.head_commit.message, 'chore(master): release')) }}"
     # NO continue-on-error. It made the guards below decorative: the step printed
     # `::error::Sweep harness failed to START` and exited 1, and the job was marked
     # green anyway -- the loud failure those guards promise could never be heard.
@@ -1906,7 +1962,7 @@ jobs:
   model-shape-conformance-windows:
     name: Model shape conformance (offset ${{ matrix.offset }})
     runs-on: ubuntu-latest
-    needs: [build, validation-source]
+    needs: [build, validation-source, select-shards]
     permissions:
       actions: read
       contents: read
@@ -1920,7 +1976,7 @@ jobs:
     # every concrete contract runs in a bounded child process and must agree with Predict. That makes
     # a window containing only honest declines valid while preserving strict failure for a mismatch,
     # crash, timeout, or unconstructable claimed contract.
-    if: "${{ fromJSON(needs.validation-source.outputs.execute_expensive) && (github.event.pull_request.draft != true) && !startsWith(github.head_ref, 'release-please--') && !(github.event_name == 'push' && startsWith(github.event.head_commit.message, 'chore(master): release')) }}"
+    if: "${{ fromJSON(needs.validation-source.outputs.execute_expensive) && fromJSON(needs.select-shards.outputs.requires_validation) && (github.event.pull_request.draft != true) && !startsWith(github.head_ref, 'release-please--') && !(github.event_name == 'push' && startsWith(github.event.head_commit.message, 'chore(master): release')) }}"
     strategy:
       fail-fast: false
       matrix:
@@ -2057,7 +2113,7 @@ jobs:
     name: Test regression analysis
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    if: "${{ always() && fromJSON(needs.validation-source.outputs.execute_expensive) && (github.event.pull_request.draft != true) && !startsWith(github.head_ref, 'release-please--') && !(github.event_name == 'push' && startsWith(github.event.head_commit.message, 'chore(master): release')) }}"
+    if: "${{ always() && fromJSON(needs.validation-source.outputs.execute_expensive) && fromJSON(needs.select-shards.outputs.requires_validation) && (github.event.pull_request.draft != true) && !startsWith(github.head_ref, 'release-please--') && !(github.event_name == 'push' && startsWith(github.event.head_commit.message, 'chore(master): release')) }}"
     needs:
       - build
       - test-net10-sharded
@@ -2312,8 +2368,8 @@ jobs:
       contents: read
     # always() is load-bearing, not cosmetic. Without it a single red shard fails the
     # test-net10-sharded matrix, Actions SKIPS this job for having a failed `needs`, and because
-    # "SonarCloud Analysis" is the ONLY required status check in the `Main` ruleset, a skipped
-    # check leaves the gate unsatisfied and every PR reads BLOCKED. That made "all 158 shards
+    # "SonarCloud Analysis" remains a required status check in the `Main` ruleset, a skipped check
+    # leaves the gate unsatisfied and every PR reads BLOCKED. That made "all 158 shards
     # green" the de facto merge bar via a `needs:` edge rather than a stated policy.
     #
     # SonarCloud is code-quality analysis, not a test gate. It consumes coverage from this
@@ -2321,31 +2377,41 @@ jobs:
     # master push does not repeat the PR analysis; the scheduled full run refreshes default-branch
     # analysis independently. Test outcomes are gated explicitly by `ci-gate` below.
     #
-    # The build IS still required: without its artifacts the analysis would be meaningless.
-    if: "${{ always() && fromJSON(needs.validation-source.outputs.execute_expensive) && needs.build.result == 'success' && (github.event.pull_request.draft != true) && !startsWith(github.head_ref, 'release-please--') && !(github.event_name == 'push' && startsWith(github.event.head_commit.message, 'chore(master): release')) }}"
+    # The required check remains a lightweight successful job for non-runtime changes. Runtime
+    # analysis still requires the build; every expensive step below consumes the same typed flag.
+    if: "${{ always() && fromJSON(needs.validation-source.outputs.execute_expensive) && (!fromJSON(needs.select-shards.outputs.requires_validation || 'true') || needs.build.result == 'success') && (github.event.pull_request.draft != true) && !startsWith(github.head_ref, 'release-please--') && !(github.event_name == 'push' && startsWith(github.event.head_commit.message, 'chore(master): release')) }}"
     needs:
       - build
       - test-net10-sharded
       - validation-source
+      - select-shards
 
     steps:
+      - name: Report non-runtime validation
+        if: ${{ !fromJSON(needs.select-shards.outputs.requires_validation || 'true') }}
+        run: echo 'Non-runtime-only change; the required SonarCloud check succeeds without analysis.'
+
       - name: Set up JDK 17
+        if: ${{ fromJSON(needs.select-shards.outputs.requires_validation || 'true') }}
         uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c # v4
         with:
           java-version: 17
           distribution: 'zulu'
 
       - name: Checkout code
+        if: ${{ fromJSON(needs.select-shards.outputs.requires_validation || 'true') }}
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v4
         with:
           fetch-depth: 0
 
       - name: Setup .NET 10.0
+        if: ${{ fromJSON(needs.select-shards.outputs.requires_validation || 'true') }}
         uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
         with:
           dotnet-version: '10.0.x'
 
       - name: Cache NuGet packages
+        if: ${{ fromJSON(needs.select-shards.outputs.requires_validation || 'true') }}
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v4
         with:
           path: ~/.nuget/packages
@@ -2354,6 +2420,7 @@ jobs:
             nuget-${{ runner.os }}-
 
       - name: Cache SonarCloud packages
+        if: ${{ fromJSON(needs.select-shards.outputs.requires_validation || 'true') }}
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v4
         with:
           path: ~/.sonar/cache
@@ -2361,6 +2428,7 @@ jobs:
           restore-keys: ${{ runner.os }}-sonar
 
       - name: Cache SonarCloud scanner
+        if: ${{ fromJSON(needs.select-shards.outputs.requires_validation || 'true') }}
         id: cache-sonar-scanner
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v4
         with:
@@ -2369,13 +2437,14 @@ jobs:
           restore-keys: ${{ runner.os }}-sonar-scanner
 
       - name: Install SonarCloud scanner
-        if: steps.cache-sonar-scanner.outputs.cache-hit != 'true'
+        if: ${{ fromJSON(needs.select-shards.outputs.requires_validation || 'true') && steps.cache-sonar-scanner.outputs.cache-hit != 'true' }}
         shell: pwsh
         run: |
           New-Item -Path ${{ runner.temp }}/scanner -ItemType Directory -Force
           dotnet tool update dotnet-sonarscanner --tool-path ${{ runner.temp }}/scanner
 
       - name: Download current-run coverage artifacts
+        if: ${{ fromJSON(needs.select-shards.outputs.requires_validation || 'true') }}
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v4
         with:
           pattern: coverage-${{ github.sha }}-*
@@ -2383,13 +2452,14 @@ jobs:
           merge-multiple: true
 
       - name: Restore dependencies
+        if: ${{ fromJSON(needs.select-shards.outputs.requires_validation || 'true') }}
         run: dotnet restore
 
       - name: Begin SonarCloud analysis
         # For very large PRs (e.g., repo-wide formatting), Sonar's "new code" metrics are
         # dominated by line churn and can fail the quality gate (e.g., new coverage) despite
         # no semantic changes. Skip PR-mode analysis in that case.
-        if: github.event_name != 'pull_request' || github.event.pull_request.changed_files <= 250
+        if: ${{ fromJSON(needs.select-shards.outputs.requires_validation || 'true') && (github.event_name != 'pull_request' || github.event.pull_request.changed_files <= 250) }}
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -2425,6 +2495,7 @@ jobs:
           & "${{ runner.temp }}/scanner/dotnet-sonarscanner" begin @params
 
       - name: Build source generator first
+        if: ${{ fromJSON(needs.select-shards.outputs.requires_validation || 'true') }}
         run: dotnet build src/AiDotNet.Generators/AiDotNet.Generators.csproj -c Release --no-restore
 
       - name: Build (Release)
@@ -2432,10 +2503,11 @@ jobs:
         # Match the memory-safe project concurrency used by the artifact build. Sonar's
         # compiler instrumentation only increases the need to avoid four large csc
         # processes competing inside the 16-GB runner.
+        if: ${{ fromJSON(needs.select-shards.outputs.requires_validation || 'true') }}
         run: dotnet build -c Release --no-restore -m:2
 
       - name: End SonarCloud analysis
-        if: github.event_name != 'pull_request' || github.event.pull_request.changed_files <= 250
+        if: ${{ fromJSON(needs.select-shards.outputs.requires_validation || 'true') && (github.event_name != 'pull_request' || github.event.pull_request.changed_files <= 250) }}
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         shell: pwsh
@@ -2450,10 +2522,10 @@ jobs:
 
   # Artifact size analysis
   size-check:
-    if: "${{ fromJSON(needs.validation-source.outputs.execute_expensive) && !startsWith(github.head_ref, 'release-please--') && !(github.event_name == 'push' && startsWith(github.event.head_commit.message, 'chore(master): release')) }}"
+    if: "${{ fromJSON(needs.validation-source.outputs.execute_expensive) && fromJSON(needs.select-shards.outputs.requires_validation) && !startsWith(github.head_ref, 'release-please--') && !(github.event_name == 'push' && startsWith(github.event.head_commit.message, 'chore(master): release')) }}"
     name: Artifact Size Check
     runs-on: ubuntu-latest
-    needs: [build, validation-source]
+    needs: [build, validation-source, select-shards]
     timeout-minutes: 10
 
     steps:
@@ -2516,10 +2588,11 @@ jobs:
     name: Test analysis (aggregate)
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    if: "${{ always() && fromJSON(needs.validation-source.outputs.execute_expensive) && (github.event.pull_request.draft != true) && !startsWith(github.head_ref, 'release-please--') && !(github.event_name == 'push' && startsWith(github.event.head_commit.message, 'chore(master): release')) }}"
+    if: "${{ always() && fromJSON(needs.validation-source.outputs.execute_expensive) && fromJSON(needs.select-shards.outputs.requires_validation) && (github.event.pull_request.draft != true) && !startsWith(github.head_ref, 'release-please--') && !(github.event_name == 'push' && startsWith(github.event.head_commit.message, 'chore(master): release')) }}"
     needs:
       - test-net10-sharded
       - validation-source
+      - select-shards
     permissions:
       actions: read
       contents: read
@@ -2647,7 +2720,7 @@ jobs:
     name: Publish certified test baseline
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    if: "${{ always() && github.event_name == 'push' && needs.validation-source.outputs.reuse == 'true' }}"
+    if: "${{ always() && github.event_name == 'push' && needs.validation-source.outputs.reuse == 'true' && fromJSON(needs.validation-source.outputs.reused_requires_validation) }}"
     needs:
       - validation-source
     permissions:
@@ -2756,14 +2829,20 @@ jobs:
           SONAR_RESULT: ${{ needs.sonarcloud.result }}
           SOURCE_RESULT: ${{ needs.validation-source.result }}
           REUSED_VALIDATION: ${{ needs.validation-source.outputs.reuse }}
+          REUSED_REQUIRES_VALIDATION: ${{ needs.validation-source.outputs.reused_requires_validation }}
+          REQUIRES_VALIDATION: ${{ needs.select-shards.outputs.requires_validation }}
         run: |
           set -euo pipefail
 
           {
             echo "## CI Gate"
             echo ""
-            if [ "$REUSED_VALIDATION" = "true" ]; then
+            if [ "$REUSED_VALIDATION" = "true" ] && [ "$REUSED_REQUIRES_VALIDATION" = "false" ]; then
+              echo "Mode: certified non-runtime PR reused for an identical master tree."
+            elif [ "$REUSED_VALIDATION" = "true" ]; then
               echo "Mode: certified PR results reused for an identical master tree."
+            elif [ "$REQUIRES_VALIDATION" = "false" ]; then
+              echo "Mode: non-runtime-only change; model and test validation suppressed."
             else
               echo "Mode: full validation executed for this commit."
             fi
@@ -2789,33 +2868,36 @@ jobs:
           failed=0
           required=("validation-source:$SOURCE_RESULT")
           if [ "$REUSED_VALIDATION" = "true" ]; then
-            required+=("promote-ci-test-analysis:$PROMOTION_RESULT")
+            if [ "$REUSED_REQUIRES_VALIDATION" != "false" ]; then
+              required+=("promote-ci-test-analysis:$PROMOTION_RESULT")
+            fi
           else
-            required+=(
-              "codeql:$CODEQL_RESULT"
-              "build:$BUILD_RESULT"
-              "build-compat:$BUILD_COMPAT_RESULT"
-              "select-shards:$SELECT_RESULT"
-              "parameter-enumeration-sweep:$PARAMETER_SWEEP_RESULT"
-              "model-shape-conformance-windows:$MODEL_SHAPE_RESULT"
-              "size-check:$SIZE_CHECK_RESULT"
-              "sonarcloud:$SONAR_RESULT"
-            )
-            # The exact-base regression analyzer is authoritative when it could recover the
-            # baseline ledger. This lets known master failures remain informational while still
-            # failing on PR-new unique failures. If the exact baseline is unavailable, require the
-            # raw shard matrix as the fail-closed fallback.
-            required+=("test-regression-analysis:$REGRESSION_ANALYSIS_RESULT" "ci-test-analysis:$AGGREGATE_ANALYSIS_RESULT")
-            if [ "$VERDICT_ENFORCED" != "true" ]; then
-              required+=("test-net10-sharded:$TESTS_RESULT")
+            required+=("select-shards:$SELECT_RESULT" "codeql:$CODEQL_RESULT" "sonarcloud:$SONAR_RESULT")
+            if [ "$REQUIRES_VALIDATION" != "false" ]; then
+              required+=(
+                "build:$BUILD_RESULT"
+                "build-compat:$BUILD_COMPAT_RESULT"
+                "parameter-enumeration-sweep:$PARAMETER_SWEEP_RESULT"
+                "model-shape-conformance-windows:$MODEL_SHAPE_RESULT"
+                "size-check:$SIZE_CHECK_RESULT"
+              )
+              # The exact-base regression analyzer is authoritative when it could recover the
+              # baseline ledger. This lets known master failures remain informational while still
+              # failing on PR-new unique failures. If the exact baseline is unavailable, require the
+              # raw shard matrix as the fail-closed fallback.
+              required+=("test-regression-analysis:$REGRESSION_ANALYSIS_RESULT" "ci-test-analysis:$AGGREGATE_ANALYSIS_RESULT")
+              if [ "$VERDICT_ENFORCED" != "true" ]; then
+                required+=("test-net10-sharded:$TESTS_RESULT")
+              fi
             fi
           fi
 
           for pair in "${required[@]}"; do
             job="${pair%%:*}"
             result="${pair#*:}"
-            # Skipped work is excluded only in certified-reuse mode above. Every job selected for
-            # the active mode must report success; a skipped required job still fails closed.
+            # Skipped work is excluded only by the certified-reuse and explicit non-runtime modes
+            # above. Every job selected for the active mode must report success; a skipped required
+            # job still fails closed.
             if [ "$result" != "success" ]; then
               echo "::error title=CI Gate::Required job '$job' reported '$result' (expected 'success')."
               failed=1
@@ -2838,7 +2920,7 @@ jobs:
     name: Publish certified validation proof
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    needs: ci-gate
+    needs: [ci-gate, select-shards]
     if: "${{ always() && needs.ci-gate.result == 'success' && (github.event_name == 'pull_request' || github.event_name == 'merge_group') }}"
     permissions:
       contents: read
@@ -2849,6 +2931,8 @@ jobs:
 
       - name: Write validation certificate
         shell: bash
+        env:
+          REQUIRES_VALIDATION: ${{ needs.select-shards.outputs.requires_validation }}
         run: |
           set -euo pipefail
           tree=$(git rev-parse 'HEAD^{tree}')
@@ -2857,12 +2941,14 @@ jobs:
             --arg testedSha "$GITHUB_SHA" \
             --arg testedTree "$tree" \
             --arg event "$GITHUB_EVENT_NAME" \
+            --argjson requiresValidation "$REQUIRES_VALIDATION" \
             '{
-              schemaVersion: 1,
+              schemaVersion: 2,
               runId: $runId,
               testedSha: $testedSha,
               testedTree: $testedTree,
               event: $event,
+              requiresValidation: $requiresValidation,
               ciGateConclusion: "success"
             }' > validation-certificate.json
 

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -340,7 +340,7 @@ jobs:
     timeout-minutes: 75
     # CodeQL remains mandatory even for non-runtime changes because the active Main ruleset
     # requires a CodeQL result for the candidate commit. This is one job, not a model/test matrix.
-    if: "${{ fromJSON(needs.validation-source.outputs.execute_expensive) && (github.event.pull_request.draft != true) && !startsWith(github.head_ref, 'release-please--') && !(github.event_name == 'push' && startsWith(github.event.head_commit.message, 'chore(master): release')) }}"
+    if: "${{ always() && !cancelled() && fromJSON(needs.validation-source.outputs.execute_expensive) && (github.event.pull_request.draft != true) && !startsWith(github.head_ref, 'release-please--') && !(github.event_name == 'push' && startsWith(github.event.head_commit.message, 'chore(master): release')) }}"
     permissions:
       contents: read
       security-events: write

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -804,6 +804,19 @@ jobs:
             exit 1
           }
 
+          function Read-RequiredJsonBoolean {
+            param(
+              [Parameter(Mandatory)] [object] $Object,
+              [Parameter(Mandatory)] [string] $PropertyName
+            )
+
+            $property = $Object.PSObject.Properties[$PropertyName]
+            if ($null -eq $property -or $property.Value -isnot [bool]) {
+              throw "selector output property '$PropertyName' must be a JSON boolean"
+            }
+            return [bool] $property.Value
+          }
+
           # `name` is the key selection and the map both index on, and the regression analyzer keys
           # on its slug. Duplicates already escalate through the count check further down, but with
           # a message about missing shards that points nowhere near the real cause.
@@ -862,7 +875,8 @@ jobs:
                   -BaseSha $env:PR_BASE_SHA -OutFile path-classification.json
               if ($LASTEXITCODE -ne 0) { throw "path classifier exited $LASTEXITCODE" }
               $pathResult = Get-Content path-classification.json -Raw | ConvertFrom-Json
-              $pathRequiresValidation = [bool] $pathResult.requiresValidation
+              $pathRequiresValidation = Read-RequiredJsonBoolean `
+                  -Object $pathResult -PropertyName 'requiresValidation'
             }
             catch {
               Write-Host "::warning::path classification unavailable ($($_.Exception.Message)) - runtime validation remains required"
@@ -876,14 +890,35 @@ jobs:
             elseif ($mapCertified) {
               # No base ref: coverage selection diffs from the map's own commit, which is the only
               # reference whose line numbers the map's ranges are expressed in.
-              & ./tools/TestImpact/Select-Shards.ps1 `
-                  -MapFile map/shard-map.json `
-                  -ExpectedShards @($all.name) `
-                  -OutFile selection.json
-              $result = Get-Content selection.json -Raw | ConvertFrom-Json
-              $escalate = [bool] $result.escalate
-              $requiresValidation = [bool] $result.requiresValidation
-              $selected = @($result.shards)
+              try {
+                & ./tools/TestImpact/Select-Shards.ps1 `
+                    -MapFile map/shard-map.json `
+                    -ExpectedShards @($all.name) `
+                    -OutFile selection.json
+                if ($LASTEXITCODE -ne 0) { throw "shard selector exited $LASTEXITCODE" }
+                $result = Get-Content selection.json -Raw | ConvertFrom-Json
+                $selectionEscalated = Read-RequiredJsonBoolean `
+                    -Object $result -PropertyName 'escalate'
+                $selectionRequiresValidation = Read-RequiredJsonBoolean `
+                    -Object $result -PropertyName 'requiresValidation'
+                if (-not $selectionRequiresValidation) {
+                  throw 'shard selector contradicted the exact-path runtime decision'
+                }
+                $shardsProperty = $result.PSObject.Properties['shards']
+                if ($null -eq $shardsProperty -or $shardsProperty.Value -isnot [System.Array] -or
+                    @($shardsProperty.Value | Where-Object { $_ -isnot [string] }).Count -gt 0) {
+                  throw "selector output property 'shards' must be a JSON string array"
+                }
+                $escalate = $selectionEscalated
+                $requiresValidation = $true
+                $selected = @($shardsProperty.Value)
+              }
+              catch {
+                Write-Host "::warning::shard selection output unavailable or invalid ($($_.Exception.Message)) - running the full matrix"
+                $escalate = $true
+                $requiresValidation = $true
+                $selected = @()
+              }
             }
             else {
               Write-Host '::warning::no certified shard map - running the full matrix'

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -2113,7 +2113,7 @@ jobs:
     name: Test regression analysis
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    if: "${{ always() && fromJSON(needs.validation-source.outputs.execute_expensive) && fromJSON(needs.select-shards.outputs.requires_validation) && (github.event.pull_request.draft != true) && !startsWith(github.head_ref, 'release-please--') && !(github.event_name == 'push' && startsWith(github.event.head_commit.message, 'chore(master): release')) }}"
+    if: "${{ always() && !cancelled() && fromJSON(needs.validation-source.outputs.execute_expensive) && fromJSON(needs.select-shards.outputs.requires_validation) && (github.event.pull_request.draft != true) && !startsWith(github.head_ref, 'release-please--') && !(github.event_name == 'push' && startsWith(github.event.head_commit.message, 'chore(master): release')) }}"
     needs:
       - build
       - test-net10-sharded
@@ -2379,7 +2379,7 @@ jobs:
     #
     # The required check remains a lightweight successful job for non-runtime changes. Runtime
     # analysis still requires the build; every expensive step below consumes the same typed flag.
-    if: "${{ always() && fromJSON(needs.validation-source.outputs.execute_expensive) && (!fromJSON(needs.select-shards.outputs.requires_validation || 'true') || needs.build.result == 'success') && (github.event.pull_request.draft != true) && !startsWith(github.head_ref, 'release-please--') && !(github.event_name == 'push' && startsWith(github.event.head_commit.message, 'chore(master): release')) }}"
+    if: "${{ always() && !cancelled() && fromJSON(needs.validation-source.outputs.execute_expensive) && (!fromJSON(needs.select-shards.outputs.requires_validation || 'true') || needs.build.result == 'success') && (github.event.pull_request.draft != true) && !startsWith(github.head_ref, 'release-please--') && !(github.event_name == 'push' && startsWith(github.event.head_commit.message, 'chore(master): release')) }}"
     needs:
       - build
       - test-net10-sharded
@@ -2588,7 +2588,7 @@ jobs:
     name: Test analysis (aggregate)
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    if: "${{ always() && fromJSON(needs.validation-source.outputs.execute_expensive) && fromJSON(needs.select-shards.outputs.requires_validation) && (github.event.pull_request.draft != true) && !startsWith(github.head_ref, 'release-please--') && !(github.event_name == 'push' && startsWith(github.event.head_commit.message, 'chore(master): release')) }}"
+    if: "${{ always() && !cancelled() && fromJSON(needs.validation-source.outputs.execute_expensive) && fromJSON(needs.select-shards.outputs.requires_validation) && (github.event.pull_request.draft != true) && !startsWith(github.head_ref, 'release-please--') && !(github.event_name == 'push' && startsWith(github.event.head_commit.message, 'chore(master): release')) }}"
     needs:
       - test-net10-sharded
       - validation-source
@@ -2720,7 +2720,7 @@ jobs:
     name: Publish certified test baseline
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    if: "${{ always() && github.event_name == 'push' && needs.validation-source.outputs.reuse == 'true' && fromJSON(needs.validation-source.outputs.reused_requires_validation) }}"
+    if: "${{ always() && !cancelled() && github.event_name == 'push' && needs.validation-source.outputs.reuse == 'true' && fromJSON(needs.validation-source.outputs.reused_requires_validation) }}"
     needs:
       - validation-source
     permissions:
@@ -2795,7 +2795,7 @@ jobs:
     name: CI Gate
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    if: "${{ always() && (github.event.pull_request.draft != true) && !startsWith(github.head_ref, 'release-please--') && !(github.event_name == 'push' && startsWith(github.event.head_commit.message, 'chore(master): release')) }}"
+    if: "${{ always() && !cancelled() && (github.event.pull_request.draft != true) && !startsWith(github.head_ref, 'release-please--') && !(github.event_name == 'push' && startsWith(github.event.head_commit.message, 'chore(master): release')) }}"
     needs:
       - validation-source
       - codeql
@@ -2921,7 +2921,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     needs: [ci-gate, select-shards]
-    if: "${{ always() && needs.ci-gate.result == 'success' && (github.event_name == 'pull_request' || github.event_name == 'merge_group') }}"
+    if: "${{ always() && !cancelled() && needs.ci-gate.result == 'success' && (github.event_name == 'pull_request' || github.event_name == 'merge_group') }}"
     permissions:
       contents: read
 

--- a/.github/workflows/test-impact-map.yml
+++ b/.github/workflows/test-impact-map.yml
@@ -58,6 +58,8 @@ jobs:
           if ($LASTEXITCODE -ne 0) { throw 'Test-impact end-to-end proof failed' }
           ./tools/TestImpact/Test-CiGateModes.ps1
           if ($LASTEXITCODE -ne 0) { throw 'CI Gate mode proof failed' }
+          ./tools/TestImpact/Test-ValidationReuseModes.ps1
+          if ($LASTEXITCODE -ne 0) { throw 'Validation reuse mode proof failed' }
 
       - name: Find a complete marked coverage run
         id: source

--- a/tools/TestImpact/Select-Shards.ps1
+++ b/tools/TestImpact/Select-Shards.ps1
@@ -20,40 +20,102 @@
 param(
     [Parameter(Mandatory, ParameterSetName = 'Select')] [string] $MapFile,
     [Parameter(Mandatory, ParameterSetName = 'Select')] [string[]] $ExpectedShards,
-    [Parameter(ParameterSetName = 'Select')] [string] $OutFile,
+    [Parameter(ParameterSetName = 'Select')]
+    [Parameter(ParameterSetName = 'Classify')] [string] $OutFile,
+    [Parameter(Mandatory, ParameterSetName = 'Classify')] [switch] $ClassifyOnly,
+    [Parameter(Mandatory, ParameterSetName = 'Classify')] [string] $BaseSha,
     [Parameter(Mandatory, ParameterSetName = 'SelfTest')] [switch] $SelfTest
 )
 
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
-$script:SharedInfrastructure = @(
-    '.github/',
+enum ChangedPathImpact {
+    NonRuntime
+    MapCandidate
+    FullValidation
+}
+
+$script:SharedInfrastructureFiles = @(
     'Directory.Build.props', 'Directory.Build.targets', 'Directory.Packages.props',
-    'global.json', 'nuget.config', 'NuGet.config',
-    '.editorconfig'
+    'global.json', 'nuget.config', 'NuGet.config', '.editorconfig'
+)
+$script:FullValidationPaths = @(
+    '.github/test-shards.yml',
+    '.github/test-shard-changes.json',
+    '.github/workflows/sonarcloud.yml',
+    '.github/workflows/test-impact-map.yml',
+    '.github/workflows/ci-shard-closure-policy.yml'
+)
+$script:FullValidationDirectories = @('.github/actions/', '.github/scripts/', 'tools/TestImpact/')
+$script:NonRuntimeWorkflowPaths = @(
+    '.github/workflows/azure-functions-deploy.yml',
+    '.github/workflows/cancel-on-pr-close.yml',
+    '.github/workflows/ci-website.yml',
+    '.github/workflows/codacy.yml',
+    '.github/workflows/commitlint-fix.yml',
+    '.github/workflows/commitlint.yml',
+    '.github/workflows/copilot-review-gate.yml',
+    '.github/workflows/deploy-serving.yml',
+    '.github/workflows/deploy-website.yml',
+    '.github/workflows/docs-wiki.yml',
+    '.github/workflows/docs.yml',
+    '.github/workflows/dotnet-format-autofix.yml',
+    '.github/workflows/heavy-timeout-nightly.yml',
+    '.github/workflows/model-performance-census.yml',
+    '.github/workflows/pr-title-lint.yml',
+    '.github/workflows/release-please.yml',
+    '.github/workflows/samples.yml'
 )
 
 function Test-SharedInfrastructure {
     param([string] $Path)
-    # Two kinds of entry, matched differently on purpose:
-    #
-    #   trailing '/'  a directory - prefix match
-    #   otherwise     a config FILE NAME - matched by basename at ANY depth, because MSBuild and
-    #                 NuGet apply Directory.Build.props / Directory.Packages.props / nuget.config
-    #                 per-directory, so src/Directory.Build.props changes what a subtree compiles
-    #                 just as surely as the root one (and src/Directory.Build.props exists here).
-    #
-    # An earlier revision used StartsWith for everything, which missed those nested files AND
-    # escalated on unrelated look-alikes such as Directory.Packages.props.backup.
-    $name = [System.IO.Path]::GetFileName($Path)
-    foreach ($entry in $script:SharedInfrastructure) {
-        if ($entry.EndsWith('/')) {
-            if ($Path.StartsWith($entry, [StringComparison]::OrdinalIgnoreCase)) { return $true }
-        }
-        elseif ($name -ieq $entry) { return $true }
+    $normalized = $Path.Replace('\', '/')
+    $name = [System.IO.Path]::GetFileName($normalized)
+    foreach ($entry in $script:SharedInfrastructureFiles) {
+        # MSBuild and NuGet apply these names per-directory, so a nested file is just as capable of
+        # changing compilation as the root one. Exact basename matching keeps lookalike suffixes out.
+        if ($name -ieq $entry) { return $true }
+    }
+    foreach ($entry in $script:FullValidationPaths) {
+        if ($normalized.Equals($entry, [StringComparison]::OrdinalIgnoreCase)) { return $true }
+    }
+    foreach ($entry in $script:FullValidationDirectories) {
+        if ($normalized.StartsWith($entry, [StringComparison]::OrdinalIgnoreCase)) { return $true }
     }
     return $false
+}
+
+function Get-ChangedPathImpact {
+    param([Parameter(Mandatory)] [string] $Path)
+
+    $normalized = $Path.Replace('\', '/')
+    if (Test-SharedInfrastructure -Path $normalized) {
+        return [ChangedPathImpact]::FullValidation
+    }
+
+    # Markdown cannot alter a build or runtime. Known independent workflows have their own triggers
+    # and jobs; changing one cannot alter this validation workflow. This is an allowlist so a newly
+    # added or renamed workflow remains full-validation until its independence is reviewed.
+    if ([System.IO.Path]::GetExtension($normalized).Equals('.md', [StringComparison]::OrdinalIgnoreCase)) {
+        return [ChangedPathImpact]::NonRuntime
+    }
+    if ($normalized.StartsWith('.github/workflows/', [StringComparison]::OrdinalIgnoreCase)) {
+        foreach ($entry in $script:NonRuntimeWorkflowPaths) {
+            if ($normalized.Equals($entry, [StringComparison]::OrdinalIgnoreCase)) {
+                return [ChangedPathImpact]::NonRuntime
+            }
+        }
+        return [ChangedPathImpact]::FullValidation
+    }
+
+    # Unknown GitHub configuration can affect analysis, generated reports, or a required check. It
+    # is intentionally not eligible for coverage-map reduction until classified explicitly.
+    if ($normalized.StartsWith('.github/', [StringComparison]::OrdinalIgnoreCase)) {
+        return [ChangedPathImpact]::FullValidation
+    }
+
+    return [ChangedPathImpact]::MapCandidate
 }
 
 function Test-RangeOverlap {
@@ -241,16 +303,48 @@ function Select-ImpactedShards {
     )
 
     $selected = [System.Collections.Generic.HashSet[string]]::new([StringComparer]::Ordinal)
-    foreach ($shard in @($Map.alwaysRun)) { [void] $selected.Add([string] $shard) }
+    $mappedPaths = [System.Collections.Generic.List[string]]::new()
     $reasons = [System.Collections.Generic.List[string]]::new()
     $escalate = $false
 
     foreach ($path in ($Changed.Keys | Sort-Object)) {
-        if (Test-SharedInfrastructure -Path $path) {
-            $escalate = $true
-            [void] $reasons.Add("shared infrastructure: $path")
-            continue
+        $impact = Get-ChangedPathImpact -Path $path
+        switch ($impact) {
+            ([ChangedPathImpact]::NonRuntime) { continue }
+            ([ChangedPathImpact]::FullValidation) {
+                $escalate = $true
+                [void] $reasons.Add("validation infrastructure or unknown GitHub configuration: $path")
+                continue
+            }
+            ([ChangedPathImpact]::MapCandidate) {
+                [void] $mappedPaths.Add([string] $path)
+            }
         }
+    }
+
+    if ($Changed.Count -eq 0) {
+        return [pscustomobject]@{
+            Escalate          = $true
+            RequiresValidation = $true
+            Reasons           = @('changed path set was empty')
+            Shards            = @()
+        }
+    }
+
+    # A non-runtime-only change is a deliberate empty selection, distinct from a selector failure.
+    # Keep that state typed here and expose only a JSON boolean at the workflow boundary.
+    if ($mappedPaths.Count -eq 0) {
+        return [pscustomobject]@{
+            Escalate          = $escalate
+            RequiresValidation = $escalate
+            Reasons           = $reasons
+            Shards            = @()
+        }
+    }
+
+    foreach ($shard in @($Map.alwaysRun)) { [void] $selected.Add([string] $shard) }
+
+    foreach ($path in $mappedPaths) {
 
         $entry = $Map.files.PSObject.Properties[$path]
         if (-not $entry) {
@@ -300,9 +394,10 @@ function Select-ImpactedShards {
     }
 
     return [pscustomobject]@{
-        Escalate = $escalate
-        Reasons  = $reasons
-        Shards   = @($selected | Sort-Object)
+        Escalate           = $escalate
+        RequiresValidation = $true
+        Reasons            = $reasons
+        Shards             = @($selected | Sort-Object)
     }
 }
 
@@ -339,6 +434,7 @@ if ($SelfTest) {
 
     $r = Select-ImpactedShards -Map $map -Changed @{ 'src/Covered.cs' = @(12, 14) }
     Assert-True (-not $r.Escalate) 'a mapped, fully covered change must not escalate'
+    Assert-True $r.RequiresValidation 'a mapped change must require validation'
     Assert-True ($r.Shards -contains 'Alpha') 'a change on Alpha lines must select Alpha'
     Assert-True (-not ($r.Shards -contains 'Beta')) 'a change outside Beta lines must not select Beta'
     Assert-True ($r.Shards -contains 'HeavyNoCoverage') 'always-run shards must always be selected'
@@ -350,11 +446,47 @@ if ($SelfTest) {
     foreach ($change in @(
         @{ Path = 'src/Unmapped.cs'; Why = 'an unmapped file must escalate' },
         @{ Path = 'Directory.Packages.props'; Why = 'dependency infrastructure must escalate' },
-        @{ Path = '.github/workflows/ci.yml'; Why = 'workflow infrastructure must escalate' }
+        @{ Path = '.github/workflows/sonarcloud.yml'; Why = 'the validation workflow must escalate' },
+        @{ Path = '.github/workflows/test-impact-map.yml'; Why = 'the map workflow must escalate' },
+        @{ Path = '.github/workflows/ci-shard-closure-policy.yml'; Why = 'the closure policy must escalate' },
+        @{ Path = '.github/test-shards.yml'; Why = 'the shard manifest must escalate' },
+        @{ Path = '.github/test-shard-changes.json'; Why = 'the shard history must escalate' },
+        @{ Path = '.github/scripts/analyze-test-results.ps1'; Why = 'CI analysis scripts must escalate' },
+        @{ Path = '.github/actions/local/action.yml'; Why = 'local actions must escalate' },
+        @{ Path = 'tools/TestImpact/Select-Shards.ps1'; Why = 'impact tooling must escalate' },
+        @{ Path = '.github/dependabot.yml'; Why = 'unknown GitHub configuration must escalate' },
+        @{ Path = '.github/workflows/release-please.yml.backup'; Why = 'workflow lookalikes must escalate' },
+        @{ Path = '.github/workflows/new-unknown.yml'; Why = 'unknown workflows must escalate' }
     )) {
         $r = Select-ImpactedShards -Map $map -Changed @{ $change.Path = @(1, 2) }
         Assert-True $r.Escalate $change.Why
+        Assert-True $r.RequiresValidation "$($change.Why) and require validation"
     }
+
+    # The exact counterexample that exposed the original defect: two GitHub-hosted documentation
+    # files plus an independent release workflow must not instantiate the model/test graph.
+    $r = Select-ImpactedShards -Map $map -Changed @{
+        '.github/AUTOMATED_RELEASE_SETUP.md' = @(1, 2)
+        '.github/VERSIONING.md' = @(1, 2)
+        '.github/workflows/release-please.yml' = @(1, 2)
+    }
+    Assert-True (-not $r.Escalate) 'the PR #2118 path set must not escalate'
+    Assert-True (-not $r.RequiresValidation) 'the PR #2118 path set must suppress runtime validation'
+    Assert-True (@($r.Shards).Count -eq 0) 'the PR #2118 path set must select zero shards'
+
+    $r = Select-ImpactedShards -Map $map -Changed @{
+        'src/Covered.cs' = @(12, 14)
+        '.github/workflows/release-please.yml' = @(1, 2)
+        'docs/usage.md' = @(1, 2)
+    }
+    Assert-True (-not $r.Escalate) 'non-runtime files mixed with a covered edit must stay reducible'
+    Assert-True $r.RequiresValidation 'a mixed change containing source must require validation'
+    Assert-True ($r.Shards -contains 'Alpha') 'a mixed change must retain the mapped shard'
+    Assert-True ($r.Shards -contains 'HeavyNoCoverage') 'a mixed change must retain always-run shards'
+
+    $r = Select-ImpactedShards -Map $map -Changed @{}
+    Assert-True $r.Escalate 'an empty changed path set must fail closed'
+    Assert-True $r.RequiresValidation 'an empty changed path set must require validation'
 
     foreach ($edge in @(10, 20)) {
         $r = Select-ImpactedShards -Map $map -Changed @{ 'src/Covered.cs' = @($edge, $edge) }
@@ -433,8 +565,9 @@ if ($SelfTest) {
     $r = Select-ImpactedShards -Map $map -Changed @{ 'Directory.Packages.props.backup' = @(1, 2) }
     Assert-True (-not ($r.Reasons -join ';').Contains('shared infrastructure')) `
         'a look-alike suffix must not match shared infrastructure'
-    $r = Select-ImpactedShards -Map $map -Changed @{ '.github/workflows/anything.yml' = @(1, 2) }
-    Assert-True $r.Escalate 'the .github/ directory prefix still escalates'
+    $r = Select-ImpactedShards -Map $map -Changed @{ '.github/workflows/docs.yml' = @(1, 2) }
+    Assert-True (-not $r.Escalate -and -not $r.RequiresValidation) `
+        'an independent YAML workflow must be classified as non-runtime'
 
     # 15. Hunk BODY content must be inert. A removed line whose text begins with '-- ' renders as
     #     '--- ...', byte-identical to an old-file header; the pre-fix parser nulled $current on it
@@ -482,11 +615,50 @@ if ($SelfTest) {
 
 # ---------------------------------------------------------------- selection
 
+if ($ClassifyOnly) {
+    $requiresValidation = $true
+    $reason = 'classification-failed'
+    $changedFiles = @()
+    try {
+        & git cat-file -e "$BaseSha^{commit}" 2>$null
+        if ($LASTEXITCODE -ne 0) { throw "base commit '$BaseSha' is not present in this checkout" }
+        # A source-to-Markdown rename must report both the deleted source path and added Markdown
+        # path; otherwise looking only at the destination could incorrectly authorize no CI.
+        $changedFiles = @(& git -c core.quotepath=false diff --no-renames --name-only $BaseSha HEAD --)
+        if ($LASTEXITCODE -ne 0) { throw "git diff --name-only from '$BaseSha' failed" }
+        $changedFiles = @($changedFiles | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
+        if ($changedFiles.Count -eq 0) {
+            $reason = 'changed-path-set-empty'
+        }
+        else {
+            $requiresValidation = [bool] @(
+                $changedFiles | Where-Object {
+                    (Get-ChangedPathImpact -Path ([string] $_)) -ne [ChangedPathImpact]::NonRuntime
+                }
+            ).Count
+            $reason = $(if ($requiresValidation) { 'runtime-or-unknown' } else { 'non-runtime-only' })
+        }
+    }
+    catch {
+        Write-Host "::warning::path classification failed, so runtime validation remains required: $($_.Exception.Message)"
+    }
+
+    $result = [pscustomobject]@{
+        requiresValidation = $requiresValidation
+        reason = $reason
+        changedPaths = @($changedFiles)
+    }
+    if ($OutFile) { $result | ConvertTo-Json -Depth 5 -Compress | Set-Content -LiteralPath $OutFile -Encoding utf8 }
+    exit 0
+}
+
 function Exit-Escalated {
     param([Parameter(Mandatory)] [string] $Reason, [string] $Message)
 
     if ($Message) { Write-Host "::warning::$Message" }
-    $result = [pscustomobject]@{ escalate = $true; reason = $Reason; reasons = @(); shards = @() }
+    $result = [pscustomobject]@{
+        escalate = $true; requiresValidation = $true; reason = $Reason; reasons = @(); shards = @()
+    }
     if ($OutFile) { $result | ConvertTo-Json -Depth 5 -Compress | Set-Content -LiteralPath $OutFile -Encoding utf8 }
     exit 0
 }
@@ -527,10 +699,13 @@ try {
     }
 
     $result = [pscustomobject]@{
-        escalate = $selection.Escalate
-        reason   = $(if ($selection.Escalate) { 'impact-unknown' } else { 'selected' })
-        reasons  = $selection.Reasons
-        shards   = $selection.Shards
+        escalate          = $selection.Escalate
+        requiresValidation = $selection.RequiresValidation
+        reason            = $(if ($selection.Escalate) { 'impact-unknown' }
+                              elseif (-not $selection.RequiresValidation) { 'non-runtime-only' }
+                              else { 'selected' })
+        reasons           = $selection.Reasons
+        shards            = $selection.Shards
     }
     if ($OutFile) { $result | ConvertTo-Json -Depth 5 -Compress | Set-Content -LiteralPath $OutFile -Encoding utf8 }
 }

--- a/tools/TestImpact/Test-CiGateModes.ps1
+++ b/tools/TestImpact/Test-CiGateModes.ps1
@@ -145,8 +145,8 @@ try {
         -Tests skipped -Verdict false -RequiresValidation false -Sonar failure -ExpectedExit 1
     Invoke-GateCase -Name non_runtime_selector_failure -Reuse false -Promotion skipped -CodeQL skipped `
         -Tests skipped -Verdict false -RequiresValidation false -Select failure -ExpectedExit 1
-    Invoke-GateCase -Name missing_runtime_decision_fails_closed -Reuse false -Promotion skipped -CodeQL failure `
-        -Tests success -Verdict true -RequiresValidation '' -ExpectedExit 1
+    Invoke-GateCase -Name missing_runtime_decision_fails_closed -Reuse false -Promotion skipped -CodeQL success `
+        -Tests skipped -Verdict false -RequiresValidation '' -ExpectedExit 1
     Invoke-GateCase -Name source_failure_blocks_reuse -Source failure -Reuse true `
         -Promotion success -CodeQL skipped -Tests skipped -Verdict false -ExpectedExit 1
     Invoke-GateCase -Name source_failure_blocks_full -Source failure -Reuse false `

--- a/tools/TestImpact/Test-CiGateModes.ps1
+++ b/tools/TestImpact/Test-CiGateModes.ps1
@@ -1,6 +1,6 @@
 <#
 .SYNOPSIS
-    Executes the checked-in CI Gate Bash body in full-validation and exact-reuse modes.
+    Executes the checked-in CI Gate Bash body in full-validation, non-runtime, and exact-reuse modes.
 #>
 [CmdletBinding()]
 param([string] $Workflow = '.github/workflows/sonarcloud.yml')
@@ -66,6 +66,10 @@ try {
             [string] $CodeQL,
             [string] $Tests,
             [string] $Verdict,
+            [string] $RequiresValidation = 'true',
+            [string] $ReusedRequiresValidation = 'true',
+            [string] $Select = 'success',
+            [string] $Sonar = 'success',
             [int] $ExpectedExit
         )
 
@@ -74,7 +78,7 @@ try {
             'SELECT_RESULT', 'TESTS_RESULT', 'PARAMETER_SWEEP_RESULT', 'MODEL_SHAPE_RESULT',
             'REGRESSION_ANALYSIS_RESULT', 'VERDICT_ENFORCED', 'AGGREGATE_ANALYSIS_RESULT',
             'SIZE_CHECK_RESULT', 'PROMOTION_RESULT', 'SONAR_RESULT', 'REUSED_VALIDATION',
-            'GITHUB_STEP_SUMMARY'
+            'REQUIRES_VALIDATION', 'REUSED_REQUIRES_VALIDATION', 'GITHUB_STEP_SUMMARY'
         )
         $savedEnvironment = @{}
         foreach ($variableName in $environmentNames) {
@@ -88,7 +92,7 @@ try {
             $env:BUILD_RESULT = 'success'
             $env:BUILD_COMPAT_RESULT = 'success'
             $env:CODEQL_RESULT = $CodeQL
-            $env:SELECT_RESULT = 'success'
+            $env:SELECT_RESULT = $Select
             $env:TESTS_RESULT = $Tests
             $env:PARAMETER_SWEEP_RESULT = 'success'
             $env:MODEL_SHAPE_RESULT = 'success'
@@ -97,8 +101,10 @@ try {
             $env:AGGREGATE_ANALYSIS_RESULT = 'success'
             $env:SIZE_CHECK_RESULT = 'success'
             $env:PROMOTION_RESULT = $Promotion
-            $env:SONAR_RESULT = 'success'
+            $env:SONAR_RESULT = $Sonar
             $env:REUSED_VALIDATION = $Reuse
+            $env:REQUIRES_VALIDATION = $RequiresValidation
+            $env:REUSED_REQUIRES_VALIDATION = $ReusedRequiresValidation
             $env:GITHUB_STEP_SUMMARY = Join-Path $fixture "$Name-summary.md"
 
             & $bash $script 2>&1 | Out-Null
@@ -121,6 +127,8 @@ try {
         -Tests skipped -Verdict false -ExpectedExit 0
     Invoke-GateCase -Name reuse_missing_promotion -Reuse true -Promotion skipped -CodeQL skipped `
         -Tests skipped -Verdict false -ExpectedExit 1
+    Invoke-GateCase -Name reuse_non_runtime_success -Reuse true -ReusedRequiresValidation false `
+        -Promotion skipped -CodeQL skipped -Tests skipped -Verdict false -ExpectedExit 0
     Invoke-GateCase -Name full_success -Reuse false -Promotion skipped -CodeQL success `
         -Tests success -Verdict true -ExpectedExit 0
     Invoke-GateCase -Name full_codeql_failure -Reuse false -Promotion skipped -CodeQL failure `
@@ -129,6 +137,16 @@ try {
         -Tests failure -Verdict true -ExpectedExit 0
     Invoke-GateCase -Name full_unenforced_test_failure -Reuse false -Promotion skipped -CodeQL success `
         -Tests failure -Verdict false -ExpectedExit 1
+    Invoke-GateCase -Name non_runtime_success -Reuse false -Promotion skipped -CodeQL success `
+        -Tests skipped -Verdict false -RequiresValidation false -ExpectedExit 0
+    Invoke-GateCase -Name non_runtime_codeql_failure -Reuse false -Promotion skipped -CodeQL failure `
+        -Tests skipped -Verdict false -RequiresValidation false -ExpectedExit 1
+    Invoke-GateCase -Name non_runtime_sonar_failure -Reuse false -Promotion skipped -CodeQL success `
+        -Tests skipped -Verdict false -RequiresValidation false -Sonar failure -ExpectedExit 1
+    Invoke-GateCase -Name non_runtime_selector_failure -Reuse false -Promotion skipped -CodeQL skipped `
+        -Tests skipped -Verdict false -RequiresValidation false -Select failure -ExpectedExit 1
+    Invoke-GateCase -Name missing_runtime_decision_fails_closed -Reuse false -Promotion skipped -CodeQL failure `
+        -Tests success -Verdict true -RequiresValidation '' -ExpectedExit 1
     Invoke-GateCase -Name source_failure_blocks_reuse -Source failure -Reuse true `
         -Promotion success -CodeQL skipped -Tests skipped -Verdict false -ExpectedExit 1
     Invoke-GateCase -Name source_failure_blocks_full -Source failure -Reuse false `
@@ -159,5 +177,5 @@ if ($failures.Count -gt 0) {
     exit 1
 }
 
-Write-Host 'CI Gate mode proof passed (reuse/full/default success and failure controls).'
+Write-Host 'CI Gate mode proof passed (reuse/full/non-runtime/default success and failure controls).'
 exit 0

--- a/tools/TestImpact/Test-CiImpactWorkflow.ps1
+++ b/tools/TestImpact/Test-CiImpactWorkflow.ps1
@@ -151,9 +151,12 @@ foreach ($job in $expensiveJobs) {
 # The active repository ruleset requires a CodeQL result for the candidate commit, even when no
 # runtime files changed. Keep it as one mandatory job while suppressing every model/test matrix.
 $codeqlJob = Get-JobBlock -WorkflowText $validation -Job 'codeql'
-Assert-Contract (-not (Get-JobHeader -JobBlock $codeqlJob).Contains(
+$codeqlHeader = Get-JobHeader -JobBlock $codeqlJob
+Assert-Contract (-not $codeqlHeader.Contains(
         'fromJSON(needs.select-shards.outputs.requires_validation')) `
     'CodeQL can be skipped even though the Main ruleset requires its result'
+Assert-Contract ($codeqlHeader.Contains('always()') -and $codeqlHeader.Contains('!cancelled()')) `
+    'CodeQL cannot publish its required result after a selector failure'
 
 $resolver = Get-JobBlock -WorkflowText $validation -Job 'validation-source'
 Assert-Contract ($resolver.Contains('steps.resolve.outputs.execute_expensive || steps.defaults.outputs.execute_expensive')) `

--- a/tools/TestImpact/Test-CiImpactWorkflow.ps1
+++ b/tools/TestImpact/Test-CiImpactWorkflow.ps1
@@ -202,8 +202,16 @@ Assert-Contract ($selectStep.Contains('-ClassifyOnly')) `
     'non-runtime classification still depends on a coverage map being available'
 Assert-Contract ($selectStep.Contains('-BaseSha $env:PR_BASE_SHA')) `
     'non-runtime classification does not use the exact PR base-to-head path set'
-Assert-Contract ($selectStep.Contains('$requiresValidation = [bool] $result.requiresValidation')) `
-    'the selector does not consume the path classifier boolean'
+Assert-Contract ($selectStep.Contains('$pathRequiresValidation = Read-RequiredJsonBoolean')) `
+    'the selector does not validate and consume the path classifier boolean'
+Assert-Contract ($selectStep.Contains('$selectionEscalated = Read-RequiredJsonBoolean')) `
+    'the selector does not validate the map escalation decision'
+Assert-Contract ($selectStep.Contains('$selectionRequiresValidation = Read-RequiredJsonBoolean')) `
+    'the selector does not validate the map runtime-validation decision'
+Assert-Contract ($selectStep.Contains("throw 'shard selector contradicted the exact-path runtime decision'")) `
+    'the map selector can suppress validation after the exact-path classifier required it'
+Assert-Contract ($selectStep.Contains("selector output property 'shards' must be a JSON string array")) `
+    'the selector does not validate the selected shard payload type'
 Assert-Contract ($selectStep.Contains('requires_validation=$($requiresValidation.ToString().ToLowerInvariant())')) `
     'the selector does not emit the runtime-validation decision as a JSON boolean'
 Assert-Contract ($selectStep.Contains('if ($requiresValidation -and $matrixShards.Count -eq 0)')) `

--- a/tools/TestImpact/Test-CiImpactWorkflow.ps1
+++ b/tools/TestImpact/Test-CiImpactWorkflow.ps1
@@ -17,6 +17,7 @@
 param(
     [string] $ValidationWorkflow = '.github/workflows/sonarcloud.yml',
     [string] $MapWorkflow = '.github/workflows/test-impact-map.yml',
+    [string] $Selector = 'tools/TestImpact/Select-Shards.ps1',
     [string] $CertifiedMapResolver = 'tools/TestImpact/Resolve-CertifiedShardMap.ps1',
     [string] $RequiredArtifactReceiver = 'tools/TestImpact/Receive-RequiredArtifact.ps1'
 )
@@ -104,17 +105,17 @@ function Get-ContinuedShellCommand {
 
 $validation = Get-Content -LiteralPath $ValidationWorkflow -Raw
 $map = Get-Content -LiteralPath $MapWorkflow -Raw
+$selectorText = Get-Content -LiteralPath $Selector -Raw
 $certifiedMapResolverText = Get-Content -LiteralPath $CertifiedMapResolver -Raw
 $requiredArtifactReceiverText = Get-Content -LiteralPath $RequiredArtifactReceiver -Raw
 
 # Every job in this list consumes meaningful runner time. Dependency-based incidental skipping is
-# not enough: a dependency can be removed during a refactor while the job remains runnable. Each
-# job must explicitly depend on validation-source and consume its JSON boolean decision.
+# not enough: each job must explicitly consume both independent typed decisions -- whether exact
+# PR validation is reusable, and whether this change can affect runtime/model/test behavior.
 $expensiveJobs = @(
     'codeql',
     'build',
     'build-compat',
-    'select-shards',
     'test-net10-sharded',
     'parameter-enumeration-sweep',
     'model-shape-conformance-windows',
@@ -132,13 +133,27 @@ foreach ($job in $expensiveJobs) {
         "expensive job '$job' has no job-level header before its steps"
     Assert-Contract (Test-JobDependency -JobHeader $header -Dependency 'validation-source') `
         "expensive job '$job' does not explicitly depend on validation-source"
+    Assert-Contract (Test-JobDependency -JobHeader $header -Dependency 'select-shards') `
+        "expensive job '$job' does not explicitly depend on select-shards"
     $jobIf = [Regex]::Match($header, '(?m)^    if:\s*(?<value>[^\r\n]+)\s*$')
     Assert-Contract $jobIf.Success `
         "expensive job '$job' has no job-level execution condition"
     Assert-Contract ($jobIf.Success -and
         $jobIf.Groups['value'].Value.Contains('fromJSON(needs.validation-source.outputs.execute_expensive)')) `
         "expensive job '$job' does not consume the typed execute_expensive decision"
+    if ($job -ne 'codeql') {
+        Assert-Contract ($jobIf.Success -and
+            $jobIf.Groups['value'].Value.Contains('fromJSON(needs.select-shards.outputs.requires_validation')) `
+            "expensive job '$job' does not consume the typed requires_validation decision"
+    }
 }
+
+# The active repository ruleset requires a CodeQL result for the candidate commit, even when no
+# runtime files changed. Keep it as one mandatory job while suppressing every model/test matrix.
+$codeqlJob = Get-JobBlock -WorkflowText $validation -Job 'codeql'
+Assert-Contract (-not (Get-JobHeader -JobBlock $codeqlJob).Contains(
+        'fromJSON(needs.select-shards.outputs.requires_validation')) `
+    'CodeQL can be skipped even though the Main ruleset requires its result'
 
 $resolver = Get-JobBlock -WorkflowText $validation -Job 'validation-source'
 Assert-Contract ($resolver.Contains('steps.resolve.outputs.execute_expensive || steps.defaults.outputs.execute_expensive')) `
@@ -154,6 +169,13 @@ Assert-Contract ($resolveStep.Contains('continue-on-error: true')) `
     'an unexpected resolver failure blocks dependents instead of retaining fail-closed defaults'
 
 $selectorJob = Get-JobBlock -WorkflowText $validation -Job 'select-shards'
+$selectorHeader = Get-JobHeader -JobBlock $selectorJob
+Assert-Contract (Test-JobDependency -JobHeader $selectorHeader -Dependency 'validation-source') `
+    'select-shards does not depend on validation-source'
+Assert-Contract ($selectorHeader.Contains('fromJSON(needs.validation-source.outputs.execute_expensive)')) `
+    'select-shards does not consume the typed execute_expensive decision'
+Assert-Contract ($selectorHeader.Contains('requires_validation: ${{ steps.select.outputs.requires_validation }}')) `
+    'select-shards does not publish its typed runtime-validation decision'
 $selfTestStep = Get-StepBlock -JobBlock $selectorJob -Step 'Verify the impact tooling'
 Assert-Contract ([bool] $selfTestStep) `
     'select-shards no longer runs the impact tooling self-tests'
@@ -161,6 +183,23 @@ Assert-Contract (-not $selfTestStep.Contains('continue-on-error: true')) `
     'checked-in impact tooling can fail its self-tests while CI remains green'
 Assert-Contract ($selfTestStep.Contains('./tools/TestImpact/Receive-RequiredArtifact.ps1 -SelfTest')) `
     'the required-artifact transport policy is not executed against its self-tests'
+Assert-Contract ($selfTestStep.Contains('./tools/TestImpact/Test-ValidationReuseModes.ps1')) `
+    'the post-merge certificate modes are not exercised by primary CI'
+$selectStep = Get-StepBlock -JobBlock $selectorJob -Step 'Select'
+Assert-Contract ($selectStep.Contains('-ClassifyOnly')) `
+    'non-runtime classification still depends on a coverage map being available'
+Assert-Contract ($selectStep.Contains('-BaseSha $env:PR_BASE_SHA')) `
+    'non-runtime classification does not use the exact PR base-to-head path set'
+Assert-Contract ($selectStep.Contains('$requiresValidation = [bool] $result.requiresValidation')) `
+    'the selector does not consume the path classifier boolean'
+Assert-Contract ($selectStep.Contains('requires_validation=$($requiresValidation.ToString().ToLowerInvariant())')) `
+    'the selector does not emit the runtime-validation decision as a JSON boolean'
+Assert-Contract ($selectStep.Contains('if ($requiresValidation -and $matrixShards.Count -eq 0)')) `
+    'the empty-matrix fallback cannot distinguish an authorized non-runtime result from uncertainty'
+Assert-Contract ($selectorText.Contains('enum ChangedPathImpact')) `
+    'changed-path control flow is not represented by a closed enum'
+Assert-Contract ($selectorText.Contains('diff --no-renames --name-only')) `
+    'path classification can hide the source side of a rename'
 
 # A 100+ shard fan-out must not resolve the same build artifact by name in every job. That path calls
 # ListArtifacts concurrently and GitHub responds with a secondary-rate-limit 403. The build publishes
@@ -234,24 +273,65 @@ Assert-Contract ($shapeUpload.Contains("if: always() && steps.download-build-art
 $promotion = Get-JobBlock -WorkflowText $validation -Job 'promote-ci-test-analysis'
 Assert-Contract ($promotion.Contains("needs.validation-source.outputs.reuse == 'true'")) `
     'certified artifact promotion is not restricted to exact-tree reuse'
+Assert-Contract ($promotion.Contains('fromJSON(needs.validation-source.outputs.reused_requires_validation)')) `
+    'non-runtime reuse can still attempt to promote test artifacts that do not exist'
 
 $validationCertificate = Get-JobBlock -WorkflowText $validation -Job 'certify-validation'
 Assert-Contract ($validationCertificate.Contains("needs.ci-gate.result == 'success'")) `
     'validation certificate can be published before the required CI Gate succeeds'
+Assert-Contract ((Test-JobDependency -JobHeader (Get-JobHeader -JobBlock $validationCertificate) `
+        -Dependency 'select-shards')) `
+    'validation certificate cannot bind the runtime-validation decision'
+Assert-Contract ($validationCertificate.Contains('schemaVersion: 2')) `
+    'validation certificate schema does not include the runtime-validation decision'
+Assert-Contract ($validationCertificate.Contains('requiresValidation: $requiresValidation')) `
+    'validation certificate omits the runtime-validation decision'
 Assert-Contract ($validationCertificate.Contains('ci-validation-certificate-')) `
     'validation certificate is not published as a distinct artifact'
 Assert-Contract ($resolver.Contains('ci-validation-certificate-')) `
     'exact-tree resolver does not require the CI Gate validation certificate'
+Assert-Contract ($resolver.Contains('reused_requires_validation: ${{ steps.resolve.outputs.reused_requires_validation || steps.defaults.outputs.reused_requires_validation }}')) `
+    'exact-tree resolver does not publish the reused validation scope'
+Assert-Contract ($resolver.Contains('if .schemaVersion == 1 then true else .requiresValidation end')) `
+    'legacy certificates are not conservatively treated as full runtime validation'
+Assert-Contract ($resolver -match '(?s)if \[ "\$requires_validation" = ''true'' \]; then.*?analysis_id.*?coverage_count') `
+    'runtime certificates no longer require analysis and coverage artifacts'
 
 $gate = Get-JobBlock -WorkflowText $validation -Job 'ci-gate'
-foreach ($job in $expensiveJobs) {
+foreach ($job in @('select-shards') + $expensiveJobs) {
     Assert-Contract ($gate -match "(?m)^\s+- $([Regex]::Escape($job))\s*$") `
         "CI Gate does not depend on expensive job '$job', so its failure cannot block validation"
 }
 Assert-Contract ($gate -match 'required=\("validation-source:\$SOURCE_RESULT"\)') `
     'the reuse-aware gate must start with only validation-source as universally required'
-Assert-Contract ($gate -match '(?s)if \[ "\$REUSED_VALIDATION" = "true" \].*?promote-ci-test-analysis.*?else.*?build:\$BUILD_RESULT.*?sonarcloud:\$SONAR_RESULT') `
+Assert-Contract ($gate -match '(?s)if \[ "\$REUSED_VALIDATION" = "true" \].*?promote-ci-test-analysis.*?else.*?sonarcloud:\$SONAR_RESULT.*?build:\$BUILD_RESULT') `
     'the gate does not exclude build and SonarCloud from certified-reuse mode'
+Assert-Contract ($gate.Contains('REQUIRES_VALIDATION: ${{ needs.select-shards.outputs.requires_validation }}')) `
+    'CI Gate does not consume the runtime-validation decision'
+Assert-Contract ($gate.Contains('REUSED_REQUIRES_VALIDATION: ${{ needs.validation-source.outputs.reused_requires_validation }}')) `
+    'CI Gate does not consume the reused validation scope'
+Assert-Contract ($gate -match '(?s)if \[ "\$REUSED_VALIDATION" = "true" \]; then.*?REUSED_REQUIRES_VALIDATION.*?promote-ci-test-analysis') `
+    'CI Gate cannot reuse a non-runtime certificate without requiring absent test artifacts'
+Assert-Contract ($gate -match '(?s)required\+=\("select-shards:\$SELECT_RESULT" "codeql:\$CODEQL_RESULT" "sonarcloud:\$SONAR_RESULT"\).*?if \[ "\$REQUIRES_VALIDATION" != "false" \].*?build:\$BUILD_RESULT') `
+    'CI Gate does not allow a successful selector to suppress expensive jobs for non-runtime changes'
+Assert-Contract ($gate.Contains('Mode: non-runtime-only change; model and test validation suppressed.')) `
+    'CI Gate does not report the non-runtime validation mode'
+
+# SonarCloud Analysis is still a required repository status. Its job must succeed cheaply for a
+# non-runtime PR, but no setup, cache, download, restore, scanner, or build step may execute there.
+$sonarJob = Get-JobBlock -WorkflowText $validation -Job 'sonarcloud'
+Assert-Contract ($sonarJob.Contains('- name: Report non-runtime validation')) `
+    'the required SonarCloud status has no lightweight non-runtime success path'
+foreach ($stepName in @(
+    'Set up JDK 17', 'Checkout code', 'Setup .NET 10.0', 'Cache NuGet packages',
+    'Cache SonarCloud packages', 'Cache SonarCloud scanner', 'Install SonarCloud scanner',
+    'Download current-run coverage artifacts', 'Restore dependencies', 'Begin SonarCloud analysis',
+    'Build source generator first', 'Build (Release)', 'End SonarCloud analysis'
+)) {
+    $step = Get-StepBlock -JobBlock $sonarJob -Step $stepName
+    Assert-Contract ($step.Contains('fromJSON(needs.select-shards.outputs.requires_validation')) `
+        "SonarCloud step '$stepName' can run for a non-runtime change"
+}
 
 # A repository variable left the shipped feature permanently in shadow mode. Certification is the
 # authorization boundary now; no second switch may silently restore the full matrix.
@@ -290,6 +370,8 @@ Assert-Contract ($map.Contains('./tools/TestImpact/Measure-SelectionMiss.ps1 -Se
     'map certification can run without first proving that skipped failures are detected'
 Assert-Contract ($map.Contains('./tools/TestImpact/New-ShardMapCertificate.ps1 -SelfTest')) `
     'the shipping certification policy is not tested before use'
+Assert-Contract ($map.Contains('./tools/TestImpact/Test-ValidationReuseModes.ps1')) `
+    'the map workflow does not exercise post-merge certificate modes'
 Assert-Contract ($map.Contains('found=false')) `
     'automatic no-source bootstrap is still represented as a workflow failure'
 Assert-Contract ($map.Contains("candidate_ready: `${{ steps.source.outputs.found }}")) `

--- a/tools/TestImpact/Test-CiImpactWorkflow.ps1
+++ b/tools/TestImpact/Test-CiImpactWorkflow.ps1
@@ -158,6 +158,15 @@ Assert-Contract (-not $codeqlHeader.Contains(
 Assert-Contract ($codeqlHeader.Contains('always()') -and $codeqlHeader.Contains('!cancelled()')) `
     'CodeQL cannot publish its required result after a selector failure'
 
+foreach ($job in @(
+    'test-regression-analysis', 'sonarcloud', 'ci-test-analysis',
+    'promote-ci-test-analysis', 'ci-gate', 'certify-validation'
+)) {
+    $header = Get-JobHeader -JobBlock (Get-JobBlock -WorkflowText $validation -Job $job)
+    Assert-Contract ($header.Contains('always()') -and $header.Contains('!cancelled()')) `
+        "job '$job' can keep an explicitly canceled run alive"
+}
+
 $resolver = Get-JobBlock -WorkflowText $validation -Job 'validation-source'
 Assert-Contract ($resolver.Contains('steps.resolve.outputs.execute_expensive || steps.defaults.outputs.execute_expensive')) `
     'validation-source does not publish execute_expensive'

--- a/tools/TestImpact/Test-TestImpactEndToEnd.ps1
+++ b/tools/TestImpact/Test-TestImpactEndToEnd.ps1
@@ -181,9 +181,37 @@ try {
             -not (Test-Path -LiteralPath missed-failure-certified/certification.json)) `
             'the end-to-end chain certified a map after selection skipped a failing shard'
 
+        # Return to the certified map's exact tree so this diff is precisely the three-file #2118
+        # counterexample, not accidentally mixed with the covered source edit used above.
+        Invoke-Git checkout --quiet --detach $baseSha
         New-Item -ItemType Directory -Path .github/workflows -Force | Out-Null
-        'name: changed-ci' | Set-Content -LiteralPath .github/workflows/fixture.yml -Encoding utf8
-        Invoke-Git add .github/workflows/fixture.yml
+        'release setup' | Set-Content -LiteralPath .github/AUTOMATED_RELEASE_SETUP.md -Encoding utf8
+        'versioning' | Set-Content -LiteralPath .github/VERSIONING.md -Encoding utf8
+        'name: release-please' | Set-Content -LiteralPath .github/workflows/release-please.yml -Encoding utf8
+        Invoke-Git add .github/AUTOMATED_RELEASE_SETUP.md .github/VERSIONING.md `
+            .github/workflows/release-please.yml
+        Invoke-Git commit --quiet -m non-runtime-change
+        & $selector -ClassifyOnly -BaseSha $baseSha -OutFile non-runtime-classification.json
+        Assert-True ($LASTEXITCODE -eq 0) 'the map-independent #2118 classifier failed'
+        $nonRuntimeClassification = Get-Content non-runtime-classification.json -Raw | ConvertFrom-Json
+        Assert-True (-not [bool] $nonRuntimeClassification.requiresValidation) `
+            'the map-independent #2118 classifier required runtime validation'
+        Assert-True (@($nonRuntimeClassification.changedPaths).Count -eq 3) `
+            'the map-independent #2118 classifier did not inspect exactly three paths'
+        & $selector -MapFile certified/shard-map.json `
+            -ExpectedShards @('Alpha', 'Beta', 'Always') -OutFile non-runtime-selection.json
+        Assert-True ($LASTEXITCODE -eq 0) 'the exact #2118 path set made the selector fail'
+        $nonRuntime = Get-Content non-runtime-selection.json -Raw | ConvertFrom-Json
+        Assert-True (-not [bool] $nonRuntime.escalate) 'the exact #2118 path set escalated'
+        Assert-True (-not [bool] $nonRuntime.requiresValidation) `
+            'the exact #2118 path set did not suppress runtime validation'
+        Assert-True (@($nonRuntime.shards).Count -eq 0) `
+            'the exact #2118 path set selected model/test shards'
+
+        # A real validation-control-plane edit mixed into the same otherwise non-runtime change set
+        # must reverse that decision and fail closed to full validation.
+        'name: changed-main-ci' | Set-Content -LiteralPath .github/workflows/sonarcloud.yml -Encoding utf8
+        Invoke-Git add .github/workflows/sonarcloud.yml
         Invoke-Git commit --quiet -m infrastructure-change
         $expectedEscalationOutput = @(& $selector -MapFile certified/shard-map.json `
             -ExpectedShards @('Alpha', 'Beta', 'Always') -OutFile infrastructure-selection.json 6>&1)
@@ -193,7 +221,29 @@ try {
         }
         Assert-True ($expectedEscalationExit -eq 0) 'an infrastructure edit made the selector fail'
         $infrastructure = Get-Content infrastructure-selection.json -Raw | ConvertFrom-Json
-        Assert-True ([bool] $infrastructure.escalate) 'a workflow edit did not fail closed to the full matrix'
+        Assert-True ([bool] $infrastructure.escalate) `
+            'the main validation workflow did not fail closed to the full matrix'
+        Assert-True ([bool] $infrastructure.requiresValidation) `
+            'the main validation workflow did not require runtime validation'
+
+        & $selector -ClassifyOnly -BaseSha 'ffffffffffffffffffffffffffffffffffffffff' `
+            -OutFile invalid-base-classification.json
+        $invalidBase = Get-Content invalid-base-classification.json -Raw | ConvertFrom-Json
+        Assert-True ([bool] $invalidBase.requiresValidation) `
+            'an unresolvable PR base authorized the non-runtime path'
+
+        # --no-renames is a safety boundary: source renamed to a Markdown destination must expose
+        # both paths, not classify from only the apparently harmless destination suffix.
+        Invoke-Git checkout --quiet --detach $baseSha
+        New-Item -ItemType Directory -Path docs -Force | Out-Null
+        Invoke-Git mv src/Feature.cs docs/Feature.md
+        Invoke-Git commit --quiet -m source-to-markdown-rename
+        & $selector -ClassifyOnly -BaseSha $baseSha -OutFile rename-classification.json
+        $renameClassification = Get-Content rename-classification.json -Raw | ConvertFrom-Json
+        Assert-True ([bool] $renameClassification.requiresValidation) `
+            'a source-to-Markdown rename incorrectly suppressed runtime validation'
+        Assert-True (@($renameClassification.changedPaths).Count -eq 2) `
+            'source-to-Markdown rename classification did not expose both sides'
 
         $badCertificate = Get-Content certified/certification.json -Raw | ConvertFrom-Json
         $badCertificate.missCount = 1
@@ -236,5 +286,5 @@ if ($failures.Count -gt 0) {
     exit 1
 }
 
-Write-Host 'Test-impact end-to-end proof passed: certified covered edit selected 2/3; CI edit escalated.'
+Write-Host 'Test-impact end-to-end proof passed: covered edit selected 2/3; #2118 selected none; CI control edit escalated.'
 exit 0

--- a/tools/TestImpact/Test-ValidationReuseModes.ps1
+++ b/tools/TestImpact/Test-ValidationReuseModes.ps1
@@ -99,7 +99,7 @@ esac
 exit "${PIPESTATUS[0]}"
 '@
     [IO.File]::WriteAllText($jqPath, $jqStub, [Text.UTF8Encoding]::new($false))
-    & $bash -lc "chmod +x '$($ghPath.Replace('\', '/'))' '$($jqPath.Replace('\', '/'))'"
+    & $bash -lc "chmod +x '$($ghPath.Replace('\', '/'))' '$($jqPath.Replace('\', '/'))' '$($resolverScript.Replace('\', '/'))'"
     if ($LASTEXITCODE -ne 0) { throw 'Could not make the command fixtures executable.' }
 
     function New-ProofZip {

--- a/tools/TestImpact/Test-ValidationReuseModes.ps1
+++ b/tools/TestImpact/Test-ValidationReuseModes.ps1
@@ -1,0 +1,227 @@
+<#
+.SYNOPSIS
+    Executes the checked-in exact-tree resolver against full and non-runtime certificate fixtures.
+#>
+[CmdletBinding()]
+param([string] $Workflow = '.github/workflows/sonarcloud.yml')
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$lines = Get-Content -LiteralPath $Workflow
+$nameLine = ($lines | Select-String -SimpleMatch '- name: Resolve exact-tree PR run' |
+    Select-Object -First 1).LineNumber
+if (-not $nameLine) { throw 'Resolve exact-tree PR run step is absent.' }
+
+$runLine = 0
+$indent = 0
+$stepIndent = $lines[$nameLine - 1].Length - $lines[$nameLine - 1].TrimStart().Length
+for ($i = $nameLine; $i -le $lines.Count; $i++) {
+    $current = $lines[$i - 1]
+    $currentIndent = $current.Length - $current.TrimStart().Length
+    if ($i -gt $nameLine -and $current.Trim() -and $currentIndent -le $stepIndent) { break }
+    if ($current -match '^(\s*)run:\s*\|') {
+        $runLine = $i
+        $indent = $Matches[1].Length
+        break
+    }
+}
+if (-not $runLine) { throw 'Exact-tree resolver run block is absent.' }
+
+$body = [System.Collections.Generic.List[string]]::new()
+for ($i = $runLine + 1; $i -le $lines.Count; $i++) {
+    $line = $lines[$i - 1]
+    $lineIndent = $line.Length - $line.TrimStart().Length
+    if ($line.Trim() -and $lineIndent -le $indent) { break }
+    [void] $body.Add($(if ($line.Length -ge $indent + 2) { $line.Substring($indent + 2) } else { '' }))
+}
+
+$bash = if ($IsWindows) {
+    $candidate = Join-Path $env:ProgramFiles 'Git\bin\bash.exe'
+    if (-not (Test-Path -LiteralPath $candidate)) { throw 'Git Bash is required for this proof on Windows.' }
+    $candidate
+}
+else { (Get-Command bash -ErrorAction Stop).Source }
+
+$tempRoot = [IO.Path]::GetFullPath([IO.Path]::GetTempPath())
+$fixture = Join-Path $tempRoot ("aidotnet-validation-reuse-" + [guid]::NewGuid().ToString('N'))
+$failures = [System.Collections.Generic.List[string]]::new()
+$fixtureFailure = $null
+
+try {
+    New-Item -ItemType Directory -Path $fixture -Force | Out-Null
+    $bin = Join-Path $fixture 'bin'
+    $runnerTemp = Join-Path $fixture 'runner'
+    $binPosix = if ($IsWindows) {
+        '/' + $bin.Substring(0, 1).ToLowerInvariant() + $bin.Substring(2).Replace('\', '/')
+    }
+    else { $bin }
+    New-Item -ItemType Directory -Path $bin, $runnerTemp -Force | Out-Null
+    $resolverScript = Join-Path $fixture 'resolver.sh'
+    [IO.File]::WriteAllText($resolverScript, ($body -join "`n"), [Text.UTF8Encoding]::new($false))
+
+    $ghStub = @'
+#!/usr/bin/env bash
+set -euo pipefail
+args="$*"
+printf '%s\n' "$args" >> "$PROOF_GH_LOG"
+case "$args" in
+  *"/commits/${GITHUB_SHA}/pulls"*)
+    printf '[{"number":9,"merged_at":"2026-01-01T00:00:00Z","merge_commit_sha":"%s","head":{"sha":"%s"}}]\n' "$GITHUB_SHA" "$PROOF_HEAD_SHA"
+    ;;
+  *"/actions/workflows/sonarcloud.yml/runs"*)
+    if [[ "$args" == *"--jq"* ]]; then printf '0\n';
+    elif [[ "$args" == *"event=merge_group"* ]]; then printf '{"workflow_runs":[]}\n';
+    else printf '{"workflow_runs":[{"id":123,"conclusion":"success"}]}\n'; fi
+    ;;
+  *"/actions/runs/123"*)
+    if [[ "$PROOF_MODE" == 'non-runtime' ]]; then
+      printf '[{"artifacts":[{"id":11,"name":"ci-validation-certificate-proof","expired":false,"created_at":"2026-01-01T00:00:00Z"}]}]\n'
+    else
+      printf '[{"artifacts":[{"id":11,"name":"ci-validation-certificate-proof","expired":false,"created_at":"2026-01-01T00:00:00Z"},{"id":12,"name":"ci-test-analysis-proof","expired":false,"created_at":"2026-01-01T00:00:00Z"},{"id":13,"name":"coverage-proof","expired":false,"created_at":"2026-01-01T00:00:00Z"}]}]\n'
+    fi
+    ;;
+  *"/actions/artifacts/11/zip"*) cat "$PROOF_CERTIFICATE_ZIP" ;;
+  *"/actions/artifacts/12/zip"*) cat "$PROOF_ANALYSIS_ZIP" ;;
+  *"/git/commits/"*) printf '%s\n' "$PROOF_TREE_SHA" ;;
+  *) printf 'unexpected gh invocation: %s\n' "$args" >&2; exit 1 ;;
+esac
+'@
+    $ghPath = Join-Path $bin 'gh'
+    [IO.File]::WriteAllText($ghPath, $ghStub, [Text.UTF8Encoding]::new($false))
+    $realJq = [string] (& $bash -lc 'command -v jq')
+    $realJq = $realJq.Trim()
+    if (-not $realJq) { throw 'jq is required for the validation reuse proof.' }
+    $jqPath = Join-Path $bin 'jq'
+    $jqStub = @'
+#!/usr/bin/env bash
+"$PROOF_REAL_JQ" "$@" | tr -d '\r'
+exit "${PIPESTATUS[0]}"
+'@
+    [IO.File]::WriteAllText($jqPath, $jqStub, [Text.UTF8Encoding]::new($false))
+    & $bash -lc "chmod +x '$($ghPath.Replace('\', '/'))' '$($jqPath.Replace('\', '/'))'"
+    if ($LASTEXITCODE -ne 0) { throw 'Could not make the command fixtures executable.' }
+
+    function New-ProofZip {
+        param([string] $Directory, [string] $FileName, [string] $Json, [string] $ZipPath)
+        if (Test-Path -LiteralPath $Directory) { Remove-Item -LiteralPath $Directory -Recurse -Force }
+        New-Item -ItemType Directory -Path $Directory -Force | Out-Null
+        [IO.File]::WriteAllText((Join-Path $Directory $FileName), $Json, [Text.UTF8Encoding]::new($false))
+        if (Test-Path -LiteralPath $ZipPath) { Remove-Item -LiteralPath $ZipPath -Force }
+        Compress-Archive -LiteralPath (Join-Path $Directory $FileName) -DestinationPath $ZipPath
+    }
+
+    function Invoke-ReuseCase {
+        param(
+            [string] $Name,
+            [bool] $RequiresValidation,
+            [bool] $IncludeRuntimeArtifacts,
+            [bool] $ExpectReuse
+        )
+
+        $testedSha = '1111111111111111111111111111111111111111'
+        $certificateDirectory = Join-Path $fixture "$Name-certificate"
+        $analysisDirectory = Join-Path $fixture "$Name-analysis"
+        $certificateZip = Join-Path $fixture "$Name-certificate.zip"
+        $analysisZip = Join-Path $fixture "$Name-analysis.zip"
+        $certificate = [ordered]@{
+            schemaVersion = 2
+            runId = '123'
+            testedSha = $testedSha
+            testedTree = 'proof-tree'
+            event = 'pull_request'
+            requiresValidation = $RequiresValidation
+            ciGateConclusion = 'success'
+        } | ConvertTo-Json -Compress
+        $analysis = [ordered]@{ source = [ordered]@{ commitSha = $testedSha } } |
+            ConvertTo-Json -Depth 3 -Compress
+        New-ProofZip -Directory $certificateDirectory -FileName validation-certificate.json `
+            -Json $certificate -ZipPath $certificateZip
+        New-ProofZip -Directory $analysisDirectory -FileName ci-test-analysis.json `
+            -Json $analysis -ZipPath $analysisZip
+
+        $output = Join-Path $fixture "$Name-output.txt"
+        $summary = Join-Path $fixture "$Name-summary.md"
+        $ghLog = Join-Path $fixture "$Name-gh.log"
+        $environmentNames = @(
+            'GITHUB_EVENT_NAME', 'GITHUB_REPOSITORY', 'GITHUB_SHA', 'GITHUB_OUTPUT',
+            'GITHUB_STEP_SUMMARY', 'RUNNER_TEMP', 'GH_TOKEN', 'REUSE_WAIT_MINUTES',
+            'PROOF_HEAD_SHA', 'PROOF_TREE_SHA', 'PROOF_MODE', 'PROOF_CERTIFICATE_ZIP',
+            'PROOF_ANALYSIS_ZIP', 'PROOF_GH_LOG', 'PROOF_REAL_JQ', 'PROOF_BIN'
+        )
+        $savedEnvironment = @{}
+        foreach ($variableName in $environmentNames) {
+            $savedEnvironment[$variableName] = [Environment]::GetEnvironmentVariable(
+                $variableName, [EnvironmentVariableTarget]::Process)
+        }
+        try {
+            $env:GITHUB_EVENT_NAME = 'push'
+            $env:GITHUB_REPOSITORY = 'ooples/AiDotNet'
+            $env:GITHUB_SHA = '2222222222222222222222222222222222222222'
+            $env:GITHUB_OUTPUT = $output.Replace('\', '/')
+            $env:GITHUB_STEP_SUMMARY = $summary.Replace('\', '/')
+            $env:RUNNER_TEMP = $runnerTemp.Replace('\', '/')
+            $env:GH_TOKEN = 'fixture-token'
+            $env:REUSE_WAIT_MINUTES = '0'
+            $env:PROOF_HEAD_SHA = '3333333333333333333333333333333333333333'
+            $env:PROOF_TREE_SHA = 'proof-tree'
+            $env:PROOF_MODE = $(if ($IncludeRuntimeArtifacts) { 'runtime' } else { 'non-runtime' })
+            $env:PROOF_CERTIFICATE_ZIP = $certificateZip.Replace('\', '/')
+            $env:PROOF_ANALYSIS_ZIP = $analysisZip.Replace('\', '/')
+            $env:PROOF_GH_LOG = $ghLog.Replace('\', '/')
+            $env:PROOF_REAL_JQ = $realJq
+            $env:PROOF_BIN = $binPosix
+            $resolverOutput = @(& $bash -c 'export PATH="$PROOF_BIN:$PATH"; exec "$1"' `
+                proof $resolverScript.Replace('\', '/') 2>&1)
+            if ($LASTEXITCODE -ne 0) { [void] $failures.Add("$Name resolver exited $LASTEXITCODE") }
+        }
+        finally {
+            foreach ($variableName in $environmentNames) {
+                [Environment]::SetEnvironmentVariable(
+                    $variableName, $savedEnvironment[$variableName], [EnvironmentVariableTarget]::Process)
+            }
+        }
+
+        $outputs = if (Test-Path -LiteralPath $output) { Get-Content -LiteralPath $output -Raw } else { '' }
+        $summaryText = if (Test-Path -LiteralPath $summary) { Get-Content -LiteralPath $summary -Raw } else { '' }
+        $ghCalls = if (Test-Path -LiteralPath $ghLog) { (Get-Content -LiteralPath $ghLog) -join ' | ' } else { '' }
+        $reused = $outputs -match '(?m)^reuse=true$'
+        if ($reused -ne $ExpectReuse) {
+            [void] $failures.Add("$Name expected reuse=$ExpectReuse, got reuse=$reused; resolver output: $($resolverOutput -join ' | '); summary: $summaryText; outputs: $outputs; gh: $ghCalls")
+        }
+        if ($ExpectReuse) {
+            $expectedScope = $RequiresValidation.ToString().ToLowerInvariant()
+            if ($outputs -notmatch "(?m)^reused_requires_validation=$expectedScope$") {
+                [void] $failures.Add("$Name did not publish reused_requires_validation=$expectedScope")
+            }
+        }
+    }
+
+    Invoke-ReuseCase -Name non_runtime_without_test_artifacts -RequiresValidation $false `
+        -IncludeRuntimeArtifacts $false -ExpectReuse $true
+    Invoke-ReuseCase -Name runtime_with_test_artifacts -RequiresValidation $true `
+        -IncludeRuntimeArtifacts $true -ExpectReuse $true
+    Invoke-ReuseCase -Name runtime_without_test_artifacts -RequiresValidation $true `
+        -IncludeRuntimeArtifacts $false -ExpectReuse $false
+}
+catch {
+    $fixtureFailure = $_
+    throw
+}
+finally {
+    $resolvedFixture = [IO.Path]::GetFullPath($fixture)
+    if ($resolvedFixture.StartsWith($tempRoot, [StringComparison]::OrdinalIgnoreCase) -and
+        (Split-Path -Leaf $resolvedFixture).StartsWith('aidotnet-validation-reuse-', [StringComparison]::Ordinal)) {
+        Remove-Item -LiteralPath $resolvedFixture -Recurse -Force -ErrorAction SilentlyContinue
+    }
+    elseif ($null -eq $fixtureFailure) { throw "refusing to remove unexpected fixture path '$resolvedFixture'" }
+}
+
+if ($failures.Count -gt 0) {
+    Write-Host 'Validation reuse mode proof FAILED:'
+    foreach ($failure in $failures) { Write-Host "  - $failure" }
+    exit 1
+}
+
+Write-Host 'Validation reuse mode proof passed (non-runtime certificate reuses without test artifacts; runtime certificate requires them).'
+exit 0


### PR DESCRIPTION
This is a disposable live proof for #2126. Relative to its base it changes exactly the same path set as PR #2118:

- `.github/AUTOMATED_RELEASE_SETUP.md`
- `.github/VERSIONING.md`
- `.github/workflows/release-please.yml`

Expected Build & SonarCloud graph:

- Resolve certified PR validation: runs
- Select shards: runs and emits `requires_validation=false`, `matrix=[]`
- CodeQL: runs because the active Main ruleset requires CodeQL
- SonarCloud Analysis: lightweight required-status path only
- CI Gate and validation certificate: run
- Build, compat build, parameter sweeps, all model-conformance windows, all test shards, regression analysis, aggregate analysis, and size check: skipped with no matrix fan-out

The PR will be closed after the live graph is captured.