### PR TITLE
feat(#2090): phase 2 — sequence models read their Options

### DIFF
--- a/.github/PR2128_REVIEW_PROOF.md
+++ b/.github/PR2128_REVIEW_PROOF.md
@@ -33,6 +33,8 @@ new constructor assignment. Its unread model `_learningRate` field was removed.
 checks pass on both sources. The deleted XLSTM/Hawk/Griffin rules were unreachable;
 their removal does not substitute a different live fixture. This is source-generator
 syntax/selection evidence, not semantic/runtime validation of synthetic models.
+The final generator runner also passes all 13 on `net8.0` and `net471`, with no
+skips (39 final passing executions across the three target frameworks).
 
 `CI_SHARD_INVENTORY.md` now records the actual cancelled run: one resolver job and
 **zero executed shards**, not the obsolete June pass list. The PowerShell example

--- a/.github/PR2128_REVIEW_PROOF.md
+++ b/.github/PR2128_REVIEW_PROOF.md
@@ -1,0 +1,62 @@
+# PR #2128 review evidence — 2026-09-11
+
+Reviewed starting head: `671836a347436f4b023ebe3f02a86ea333ad0686`.
+This record distinguishes focused local checks from hosted CI and actual model tests.
+
+## Options copy and validation
+
+The frozen options correction is `80e7540d69806c5e26de7a38b12c98932604d979`.
+The identical 347 tests against the original source on Linux reported **173 failed,
+174 passed**; after correction, **347 passed, zero failed, zero skipped**. Windows
+`net10.0`, `net8.0` and `net471` also passed all 347, independently repeated by
+the primary reviewer. See [the focused runner](../tests/AiDotNet.OptionsContractTests/README.md)
+for the exact source-linked build, commands and test scope.
+
+Two additional contracts verify all ten audio-base properties have value and
+beginner documentation and that the newly introduced vision-language base uses
+the same tower property names as the document base. With these included, the
+primary reviewer's three-framework run passed **349 tests per framework**, no skips:
+
+```powershell
+dotnet test tests/AiDotNet.OptionsContractTests/AiDotNet.OptionsContractTests.csproj -c Release --logger 'trx;LogFilePrefix=pr2128-options-root-shared-docs' --results-directory artifacts/options-contracts/independent
+```
+
+These are executable scalar-options/metadata contracts, not model training or
+GPU performance evidence. Existing default dimensions are pinned; Finch's
+pre-PR public options rate of `3e-4` is preserved rather than overwritten by a
+new constructor assignment. Its unread model `_learningRate` field was removed.
+
+## Generator and diagnostic controls
+
+[The generator runner](../tools/SequenceFixtureReview/README.md) reports **4 failed,
+9 passed before; 13 passed afterward**. All six effective constructor-fixture
+checks pass on both sources. The deleted XLSTM/Hawk/Griffin rules were unreachable;
+their removal does not substitute a different live fixture. This is source-generator
+syntax/selection evidence, not semantic/runtime validation of synthetic models.
+
+`CI_SHARD_INVENTORY.md` now records the actual cancelled run: one resolver job and
+**zero executed shards**, not the obsolete June pass list. The PowerShell example
+was parsed and exercised with ten controlled boundary cases: three invalid filters;
+executed, empty, skipped-only and missing reports; and changed test, AiDotNet or
+Tensors assemblies. It rejects invalid comparisons and restores the arena variable
+in all cases. These helper controls did not execute model tests. Arena-off success
+is explicitly not a root-cause diagnosis.
+
+## Adversarial and compatibility checks
+
+An independent review checked the generator cleanup, Finch field removal, new
+vision-base naming, documentation, and diagnostic example. It identified that
+hashing only the test DLL could compare changed production code; the example now
+checks the test, AiDotNet and Tensors assemblies, with a negative control for each.
+
+The request to rename `EagleOptions` was rejected as a breaking compatibility change:
+both public `EagleOptions` types already exist at merge-base
+`2a53ff3d4e27845773b4c9ad0a52b81f089613f7`. The language-model type was introduced
+in `e966541dd941ea7095157e434683dcff95c3711d` (#1231), not this PR. Existing callers
+can continue using their namespace qualification/alias. No existing public type
+is removed to address that pre-existing naming ambiguity.
+
+The core `src/AiDotNet.csproj` Release/`net10.0` build completed with **zero errors**
+and 2,775 existing warnings in 4m48s. This is not a full test-project/compatibility
+build or evidence that all CI shards pass. Actual sequence-model behavior and
+the final hosted/review readiness disposition need their own completed results.

--- a/.github/PR2128_REVIEW_PROOF.md
+++ b/.github/PR2128_REVIEW_PROOF.md
@@ -65,3 +65,24 @@ The core `src/AiDotNet.csproj` Release/`net10.0` build completed with **zero err
 and 2,775 existing warnings in 4m48s. This is not a full test-project/compatibility
 build or evidence that all CI shards pass. Actual sequence-model behavior and
 the final hosted/review readiness disposition need their own completed results.
+
+## Actual model and report behavior
+
+The subsequent [actual-model runner](../tests/AiDotNet.OptionsRuntimeContractTests/README.md)
+passed **63/63**, zero skipped, including a separate primary-reviewer replay.
+All 17 migrated models were constructed twice for each independent width/depth
+comparison. Assertions inspect real embedding tensors, physical blocks (including
+contained hybrid/RWKV7 stacks), and materialized parameter lengths, not only options
+returned by the model. For example, Mamba width 16 to 32 changes parameters from
+**3,728 to 10,624**; RWKV7 depth one to two changes **8,544 to 16,032**. Controls
+with unchanged real topology but edited options correctly fail the behavioral guard.
+
+The report measures **1,005 models and 977 gaps across 297 model types**. Restoring
+old discovery/report behavior fails four new guards; restoring the direct reflection
+read fails the open-generic enum control. A blanket metadata-flag replacement fails
+both constant-kind controls because it loses decimal/DateTime defaults. The accepted
+fix uses that flag only for the specific open-generic enum boxing exception.
+
+The runtime correction is commit `84b6752f7ad02187de5f8e917721dd95f94b5460`. This is
+construction/configuration and report evidence; it does not claim every training
+feature, every option, full GPU parity, or completion of the other migration PRs.

--- a/.github/PR2128_REVIEW_PROOF.md
+++ b/.github/PR2128_REVIEW_PROOF.md
@@ -113,3 +113,81 @@ Loaded binary SHA-256:
 - `AiDotNet.dll`: `5FFC1C04DE1D4BD5B58E4065F873667FEBA969C192C7084022DBAB52DC6285E4`
 
 This is the combined review filter on the full assembly, not an all-shards run.
+
+## Compatibility integration
+
+The full main test project also built both compatibility targets (`net8.0` and
+`net471`) with **zero errors and 13,445 repository warnings**, in 11m58s:
+
+```powershell
+dotnet build tests/AiDotNet.Tests/AiDotNetTests.csproj -c Release -p:CompatBuildOnly=true -m:1 -p:UseSharedCompilation=false -p:BuildInParallel=false -p:GeneratePackageOnBuild=false
+```
+
+The same 419-case filter then passed on each actual compatibility assembly:
+**419 passed, zero failed, zero skipped on net8.0 and on net471**. The three
+main-assembly targets therefore account for **1,257 passing executions**. These
+compatibility runs used the existing serial collection configuration and
+`AIDOTNET_FORCE_CPU=1`, `DOTNET_gcServer=0`, `COMPlus_gcServer=0`, with the command
+below for each target. Unlike the earlier net10 run, theory pre-enumeration and
+discovery diagnostics were left enabled; the reported 8s/10s test durations
+exclude full-assembly discovery and are not end-to-end timings.
+
+```powershell
+$filter = 'FullyQualifiedName~SequenceModelOptionsContractTests|FullyQualifiedName~SharedOptionsDocumentationContractTests|FullyQualifiedName~GeneratedSequenceFixtureContractTests|FullyQualifiedName~OptionsSurfaceRatchetTests|FullyQualifiedName~RWKV7LanguageModelTests.Model_Constructor_'
+dotnet vstest tests/AiDotNet.Tests/bin/Release/net8.0/AiDotNetTests.dll "/TestCaseFilter:$filter" '/Logger:trx;LogFileName=pr2128-full-net8-review.trx' '/ResultsDirectory:artifacts/options-runtime' -- RunConfiguration.MaxCpuCount=1
+dotnet vstest tests/AiDotNet.Tests/bin/Release/net471/AiDotNetTests.dll "/TestCaseFilter:$filter" '/Logger:trx;LogFileName=pr2128-full-net471-review.trx' '/ResultsDirectory:artifacts/options-runtime' -- RunConfiguration.MaxCpuCount=1
+```
+
+Loaded binary SHA-256:
+
+| Target | Assembly | SHA-256 |
+| --- | --- | --- |
+| net8.0 | AiDotNetTests.dll | `6B646534A41FE389158733B5D7B8CAAEA61484C1E8810845826D4E5F7A94E56E` |
+| net8.0 | AiDotNet.dll | `C3B431114E700958229EF0BAD10EDECBE161038C355119C2FD43796DA55B806D` |
+| net471 | AiDotNetTests.dll | `51EB9BE42199A0664CD2CE1ECBB9E9CE14BC55588C7E9F657C45A931BE280175` |
+| net471 | AiDotNet.dll | `342F97070EE8617B4D8ECE2BDF5AA093A8430D25A2930BCABF74BBF14C9ACD5D` |
+
+This closes local build/target compatibility for the review changes. It does not
+claim all model-family training tests, GPU execution, hosted CI, or the separate
+phase-3 migration are complete. In particular, phase 3 must migrate its new
+vision-base consumers to `VisionDim`/`VisionLayers` when integrating this branch;
+a text-clean merge alone is not semantic compatibility proof.
+
+## Final explicit fixture initialization and replay
+
+The last adversarial check found that .NET Framework excludes the automatic
+module initializer. Both actual-model fixture constructors now explicitly call
+the existing `TestModuleInitializer.EnsureInitialized()`; this makes focused CPU,
+threading and offline-licensing setup independent of other test classes. The
+focused runtime runner now targets all three frameworks and passed **63/63 per
+target**, zero skips. The entire existing RWKV7 unit fixture also passed **49/49
+per target**, zero skips, including forward/state/parameter tests outside the
+17 constructor cases. These overlapping counts are not added to the combined
+filter as if they were distinct tests.
+
+After those final two fixture edits, the main test project was rebuilt against
+the unchanged, already-built core and generator outputs on all three targets:
+**zero errors, 11,800 repository warnings, 5m55s**. The first no-restore attempt
+had only compatibility targets in its assets file and correctly failed NETSDK1005
+for net10.0; that invocation is not counted as build proof. The successful
+invocation restored the complete target set:
+
+```powershell
+dotnet build tests/AiDotNet.Tests/AiDotNetTests.csproj -c Release -m:1 -p:BuildProjectReferences=false -p:UseSharedCompilation=false -p:BuildInParallel=false -p:GeneratePackageOnBuild=false
+```
+
+The primary reviewer then reran the identical combined filter, applying the
+repository's output-only runner hardening on each target: **419 passed, zero
+failed, zero skipped on each of net10.0, net8.0 and net471**. Final TRXs are
+`artifacts/options-runtime/pr2128-final-full-net10.0.trx`,
+`pr2128-final-full-net8.0.trx` and `pr2128-final-full-net471.trx`. The successful
+build log is `artifacts/pr2128-final-restored-test-build.log`.
+
+Final main test-assembly SHA-256 values (superseding the earlier test hashes;
+the core hashes above are unchanged):
+
+| Target | AiDotNetTests.dll SHA-256 |
+| --- | --- |
+| net10.0 | `22311D91F676B2733A09365D5AE0CDD0764F5CABB8AE7909701D6BC2ED17DBDC` |
+| net8.0 | `5740BCE49D35FD7CED80800F4C64DB7E4AFA6A93692ECFDD03C24ECD882D2C60` |
+| net471 | `630CE96149E2CEE5CFF17A43FCDFF337C4FC8AC99C7B1FCE6B9C0568D3318546` |

--- a/.github/PR2128_REVIEW_PROOF.md
+++ b/.github/PR2128_REVIEW_PROOF.md
@@ -44,6 +44,9 @@ Tensors assemblies. It rejects invalid comparisons and restores the arena variab
 in all cases. These helper controls did not execute model tests. Arena-off success
 is explicitly not a root-cause diagnosis.
 
+Reproduce these documentation-only boundary controls with
+`pwsh -NoProfile -File .github/scripts/Test-ArenaComparisonExample.ps1`.
+
 ## Adversarial and compatibility checks
 
 An independent review checked the generator cleanup, Finch field removal, new

--- a/.github/PR2128_REVIEW_PROOF.md
+++ b/.github/PR2128_REVIEW_PROOF.md
@@ -86,3 +86,30 @@ fix uses that flag only for the specific open-generic enum boxing exception.
 The runtime correction is commit `84b6752f7ad02187de5f8e917721dd95f94b5460`. This is
 construction/configuration and report evidence; it does not claim every training
 feature, every option, full GPU parity, or completion of the other migration PRs.
+
+## Full test-project integration
+
+The actual `tests/AiDotNet.Tests/AiDotNetTests.csproj` Release/`net10.0` build
+completed in 6m59s with **zero errors and 6,819 repository warnings**. After applying
+the repository's output-only serial/Workstation-GC runner hardening, the combined
+review filter passed **419 tests, zero failed, zero skipped**, in eleven seconds:
+
+```powershell
+dotnet build tests/AiDotNet.Tests/AiDotNetTests.csproj -c Release -f net10.0 -m:1 -p:UseSharedCompilation=false -p:BuildInParallel=false -p:GeneratePackageOnBuild=false
+& ./.github/scripts/harden-xunit-runner.ps1 -RunnerJson tests/AiDotNet.Tests/bin/Release/net10.0/xunit.runner.json
+$env:AIDOTNET_FORCE_CPU = '1'
+dotnet test tests/AiDotNet.Tests/AiDotNetTests.csproj -c Release -f net10.0 --no-build --no-restore --filter 'FullyQualifiedName~SequenceModelOptionsContractTests|FullyQualifiedName~SharedOptionsDocumentationContractTests|FullyQualifiedName~GeneratedSequenceFixtureContractTests|FullyQualifiedName~OptionsSurfaceRatchetTests|FullyQualifiedName~RWKV7LanguageModelTests.Model_Constructor_' --logger 'trx;LogFileName=pr2128-full-test-assembly-review.trx' --results-directory artifacts/options-runtime
+```
+
+The 419 executions comprise 341 source-linked scalar-option cases, two shared
+documentation/naming cases, 13 generator cases and 63 runtime/report cases. Six
+additional emitted-XML documentation cases live in the standalone options runner
+and passed there on all three frameworks; they are not counted again as main
+test-assembly executions.
+
+Loaded binary SHA-256:
+
+- `AiDotNetTests.dll`: `EEC45FF7468B418BF26B952AB67D43C00AA6C07D7E53106C40A5646B134974CB`
+- `AiDotNet.dll`: `5FFC1C04DE1D4BD5B58E4065F873667FEBA969C192C7084022DBAB52DC6285E4`
+
+This is the combined review filter on the full assembly, not an all-shards run.

--- a/.github/scripts/Test-ArenaComparisonExample.ps1
+++ b/.github/scripts/Test-ArenaComparisonExample.ps1
@@ -1,0 +1,76 @@
+param([string] $DocumentPath = (Join-Path $PSScriptRoot '../../CI_SHARD_INVENTORY.md'))
+
+$ErrorActionPreference = 'Stop'
+$document = Microsoft.PowerShell.Management\Get-Content -LiteralPath $DocumentPath -Raw
+$fence = ([string][char]96) * 3
+$pattern = '(?s)' + [regex]::Escape($fence) + 'powershell\r?\n(?<code>.*?)' + [regex]::Escape($fence)
+$blocks = [regex]::Matches($document, $pattern)
+if ($blocks.Count -ne 2) { throw 'Expected exactly two PowerShell examples.' }
+$tokens = $null
+$parseErrors = $null
+[void][System.Management.Automation.Language.Parser]::ParseInput(
+    $blocks[1].Groups['code'].Value, [ref]$tokens, [ref]$parseErrors)
+if ($parseErrors.Count) { throw ($parseErrors | Out-String) }
+. ([scriptblock]::Create($blocks[1].Groups['code'].Value))
+
+$checks = 0
+foreach ($invalid in @('', ' ', 'FullyQualifiedName~<YourModelTests>')) {
+    $rejected = $false
+    try { Invoke-ArenaComparison -TestFilter $invalid -ErrorAction Stop }
+    catch [System.Management.Automation.ParameterBindingException] { $rejected = $true }
+    if (-not $rejected) { throw 'Invalid filter was accepted.' }
+    $checks++
+}
+
+# Boundary doubles deliberately do not execute dotnet or touch a real model binary.
+# This validates the documentation's control flow, not any model or arena behavior.
+enum ArenaFixture { Executed; Empty; Skipped; Missing; ChangedTest; ChangedLibrary; ChangedTensor }
+$script:fixture = [ArenaFixture]::Executed
+$script:hashCalls = 0
+function Get-FileHash {
+    param($LiteralPath, $Algorithm)
+    $script:hashCalls++
+    $name = Split-Path $LiteralPath -Leaf
+    $target = switch ($script:fixture) {
+        ([ArenaFixture]::ChangedTest) { 'AiDotNetTests.dll' }
+        ([ArenaFixture]::ChangedLibrary) { 'AiDotNet.dll' }
+        ([ArenaFixture]::ChangedTensor) { 'AiDotNet.Tensors.dll' }
+        default { '' }
+    }
+    [pscustomobject]@{ Hash = if ($name -eq $target -and $script:hashCalls -gt 3) { 'changed' } else { 'same' } }
+}
+function dotnet { $global:LASTEXITCODE = 0 }
+function Test-Path { param($LiteralPath); $script:fixture -ne [ArenaFixture]::Missing }
+function Get-Content {
+    param($LiteralPath, [switch]$Raw)
+    switch ($script:fixture) {
+        ([ArenaFixture]::Empty) { '<TestRun><Results /></TestRun>' }
+        ([ArenaFixture]::Skipped) { '<TestRun><Results><UnitTestResult outcome="NotExecuted" /></Results></TestRun>' }
+        default { '<TestRun><Results><UnitTestResult outcome="Passed" /></Results></TestRun>' }
+    }
+}
+
+$savedArena = [Environment]::GetEnvironmentVariable('AIDOTNET_INFERENCE_ARENA')
+foreach ($case in [Enum]::GetValues([ArenaFixture])) {
+    $script:fixture = $case
+    $script:hashCalls = 0
+    $rejected = $false
+    try {
+        $result = @(Invoke-ArenaComparison -TestFilter 'FullyQualifiedName~ActualFixture')
+        if ($case -eq [ArenaFixture]::Executed -and
+            ($result.Count -ne 2 -or $result[0].Arena -ne 1 -or $result[1].Arena -ne 0 -or
+             $result[0].Executed -ne 1 -or $result[1].Executed -ne 1)) {
+            throw 'Wrong comparison result.'
+        }
+    }
+    catch {
+        if ($case -eq [ArenaFixture]::Executed) { throw }
+        $rejected = $true
+    }
+    if ($case -ne [ArenaFixture]::Executed -and -not $rejected) { throw "Unsafe fixture accepted: $case" }
+    if ([Environment]::GetEnvironmentVariable('AIDOTNET_INFERENCE_ARENA') -cne $savedArena) {
+        throw "Arena setting was not restored for $case."
+    }
+    $checks++
+}
+Write-Host "Inventory helper: $checks validation/outcome/restoration controls passed; no model-test pass claim."

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Breaking Changes
 
+* Sequence language-model dimensions now belong on their model-specific options objects. In particular, `FalconMambaLanguageModel<T>` takes `FalconMambaOptions` as its second constructor argument, before `ILossFunction<T>`. Replace positional calls such as `new FalconMambaLanguageModel<float>(architecture, loss)` with `new FalconMambaLanguageModel<float>(architecture, lossFunction: loss)`, and move scalar dimensions into `options: new FalconMambaOptions { ... }`.
 * `TOTEMOptions<T>.CommitmentWeight` was removed from the forecasting configuration. TOTEM forecasting now consumes a separately trained, frozen tokenizer/codebook; configure commitment loss in that tokenizer-pretraining workflow rather than on the forecasting model.
 * `QuantileRegressionOptions<T>.LearningRate` was removed because quantile regression now uses an exact linear-program solver rather than gradient descent; there is no learning-rate replacement. `QuantileRegressionOptions<T>.MaxIterations` moved to `SolverOptions.MaxIterations`, alongside the other simplex controls.
 * `NeuralNetworkRegressionOptions<T, TInput, TOutput>.Optimizer` was replaced by `OptimizerFactory`. The factory receives the model it will optimize and creates one optimizer per model, preventing clones from sharing mutable optimizer state.

--- a/CI_SHARD_INVENTORY.md
+++ b/CI_SHARD_INVENTORY.md
@@ -1,0 +1,119 @@
+# AiDotNet CI Shard Failure Inventory & Work-Division Plan
+
+**Source of truth:** clean `Build & SonarCloud` run on `master` @ `01a4ddb4` (Tensors **0.102.12**), run id `28023414937`.
+**Result:** **44 pass / 19 fail / 1 cancelled** (`NeuralNetworks T-Z`, runner lost) of 64 test shards.
+**Generated:** 2026-06-23. Re-run the run and re-classify before locking assignments if master has moved.
+
+> **Already fixed (do not re-investigate):** the fp32 small-M GEMM `ArrayPool` host-crash that was aborting every CNN/diffusion shard wholesale — fixed in **Tensors #672 → 0.102.12**, on master via #1667. Verified locally: `ResNetNetworkTests` 56/56, `ConvolutionalNeuralNetworkTests` 21/21.
+
+---
+
+## TL;DR — the 19 failures are 4 distinct causes, not 19 model bugs
+
+| # | Root cause | Shards | One fix greens many? |
+|---|-----------|:------:|----------------------|
+| ① | **Stack overflow** (host crash, recursion) | 4 (+1 cancelled) | Likely yes — probably one shared recursion |
+| ② | **Inference arena corruption** (`#1661`, default-ON) | 3 (+~7 in ③) | **Yes — biggest lever** |
+| ③ | **Host killed mid-run** (arena-crash *or* OOM; log truncated) | 8 | Partly (triage → ② or ④/OOM) |
+| ④ | **Genuine per-model bugs** (training / clone / construction) | 4 | No — individual |
+
+The arena bug (②) and most of the silent diffusion deaths (③) are the **same root cause** in two manifestations: the arena recycles a tensor across denoise steps → wrong shape (`Input has N channels but layer expects M`). When that corruption is *caught* it's a `[FAIL]` (②); when it corrupts `ArrayPool` it's a **native host crash with no `[FAIL]` logged** (③).
+
+**Confirmed locally (this box, 32 GB):** `AIDOTNET_INFERENCE_ARENA=0` turns **DDPM 38/38** and **SyncDreamer** green (both fail with the arena on). That env var is the **key enabler for parallel work** — see below.
+
+---
+
+## Per-shard classification
+
+### ① Stack overflow — host crash (recursion bug)
+`Test host process crashed : Stack overflow.`
+
+- `ModelFamily - NeuralNetworks O-R`
+- `ModelFamily - NeuralNetworks S`
+- `ModelFamily - NeuralNetworks A-L`
+- `ModelFamily - Generated Layers A-M`
+- `ModelFamily - NeuralNetworks T-Z` — **cancelled** (runner lost mid-run; no reason logged). Given the other 3 NN ranges all stack-overflow, this is the likely cause; could also be OOM. Triage locally.
+
+*Almost certainly one shared recursion (a `Clone`/forward/property that calls itself). Find it once, likely fixes all five.*
+
+### ② Inference arena corruption (#1661) — confirmed
+Caught `Input has N channels but layer expects M` failures + arena signature in the log.
+
+| Shard | Failing model(s) |
+|---|---|
+| `ModelFamily - Diffusion A-C` | `ControlNetXSModelTests` (all 7) |
+| `ModelFamily - Diffusion Stable` | `StableSRModelTests` (all), `StableDiffusion3ModelTests.Predict_ShouldBeDeterministic` |
+| `ModelFamily - Diffusion Step-Sync` | `SUPIRModelTests` (all), `SyncDiffusionModelTests`, `Step1XEditModelTests` (training subset) |
+
+### ③ Host killed mid-run — arena-crash OR OOM (needs local triage)
+Shard died before xUnit logged any `[FAIL]` (`0 FAILs`, no crash reason captured). Diffusion-heavy → **leading hypothesis: arena escalating to a native pool-corruption crash** (DDPM lives in `03b`, SyncDreamer in `SA-SD` — both confirmed arena locally). Some may be genuine 16 GB-runner OOM.
+
+- `Unit - 03b Diffusion Models Control/DDPM/Preprocessor`  *(DDPM = arena, confirmed)*
+- `Unit - 03d Diffusion Models FastGen/Conditioner`
+- `ModelFamily - Diffusion D-I`
+- `ModelFamily - Diffusion J-M`
+- `ModelFamily - Diffusion N-R`
+- `ModelFamily - Diffusion SA-SD`  *(SyncDreamer = arena, confirmed)*
+- `ModelFamily - Diffusion SE-SP`
+- `Integration C`
+
+### ④ Genuine per-model bugs (NOT arena — these are training/clone/construction)
+Arena is inference-only; `GradientFlow` / `LossStrictlyDecreases` / `Training_*` failures are real model bugs.
+
+| Shard | Failing test(s) | Smell |
+|---|---|---|
+| `ModelFamily - NeuralNetworks M-N` | `NeuralTuringMachineTests` — `GradientFlow_ShouldBeNonZeroAndFinite`, `LossStrictlyDecreasesOnMemorizationTask`, `Training_ShouldChangeParameters` | tape/gradient no-op |
+| `ModelFamily - Generated Layers N-Z` | `TimeMachineTests` (training ×3), `WhisperTimestampedTests` (`Training_ShouldChangeParameters`, `DifferentInputs_AfterTraining`) | tape/gradient no-op |
+| `ModelFamily - Diffusion T-Z` | `TCDModelTests.Clone_ShouldProduceIdenticalOutput` | clone / stale weight-cache |
+| `Integration D` | `DefaultConstructionTests.AllDefaultConstructableModels_ShouldConstructWithoutException` | one model ctor throws |
+
+---
+
+## Work-division — 4 parallel streams (non-overlapping files)
+
+> **Enabler for everyone:** run your shard locally with **`AIDOTNET_INFERENCE_ARENA=0`** to strip out the arena corruption (②/③) so your area's *true* residual failures surface. No need to wait for Stream A to merge.
+>
+> ```
+> AIDOTNET_INFERENCE_ARENA=0 dotnet test tests/AiDotNet.Tests/AiDotNetTests.csproj -c Debug -f net10.0 \
+>   --filter "FullyQualifiedName~<YourModelTests>"
+> ```
+
+Tracked as **Epic #1673** with one GitHub issue per chunk:
+
+| Issue | Stream | Scope | Files (no conflict) | Owner |
+|---|---|---|---|---|
+| **#1668** | **A — Inference arena (#1661)** | Fix cross-step tensor recycling in the denoise loop (a layer's cross-forward cached buffer takes arena memory that `Reset()` recycles → shape aliasing). Or gate the arena off for diffusion denoise until the deep fix lands. **Greens ② + the diffusion half of ③ (~10 shards).** | `src/Diffusion/DiffusionModelBase.cs`, `src/NeuralNetworks/InferenceArenaSettings.cs`, Tensors arena | **Claude** (root-caused) |
+| **#1669** | **B — Stack overflow** | Find the recursion crashing the ① shards (`NeuralNetworks A-L/O-R/S/T-Z` + `Generated A-M`). Bisect which model self-recurses (`Clone`, `GetParameters`, property getters, forward). | offending NN/Generated model `.cs` | 1 dev |
+| **#1670** | **D — Training bugs** | NeuralTuringMachine + TimeMachine + WhisperTimestamped training/gradient no-op (likely shared sub-layer registration gap). | those 3 model `.cs` | 1 dev |
+| **#1671** | **D — Misc bugs** | TCD clone-equivalence + Integration-D default-construction. | TCD model `.cs`, the throwing ctor | 1 dev |
+| **#1672** | **C — OOM footprint** | Genuine 16 GB-runner OOM residual; test-scale variants. **Gated on #1668** (triage which ③ shards are truly OOM after the arena fix). | `tests/.../ModelFamilyTests/Base/*TestBase.cs`, model construction | 1 dev |
+
+### Sequencing
+1. **A and B first / concurrently** — they are *crash* causes that abort shards and mask everything else.
+2. **C and D in parallel now** using `AIDOTNET_INFERENCE_ARENA=0` locally (they don't need A merged to see their failures).
+3. After A + B land, **one CI re-run** gives the clean residual; reassign any surprises to D.
+
+### Triage step that splits ③ between A and C (parallelizable, ~1 shard each)
+For each ③ shard, run locally with `AIDOTNET_INFERENCE_ARENA=0`:
+- **Passes** → it was the arena → covered by **Stream A**.
+- **Still fails / OOMs** → **Stream C** (OOM) or **Stream D** (genuine), by signature.
+
+---
+
+## Reproduce / verify
+
+```bash
+# the clean inventory run
+gh run view 28023414937 --repo ooples/AiDotNet
+
+# a confirmed arena case (passes with arena off, fails with it on)
+AIDOTNET_INFERENCE_ARENA=0 dotnet test tests/AiDotNet.Tests/AiDotNetTests.csproj -c Debug -f net10.0 \
+  --filter "FullyQualifiedName~UnitTests.Diffusion.Models.DDPMModelTests"   # 38/38 with arena off
+
+# a stack-overflow shard (host crash)
+dotnet test tests/AiDotNet.Tests/AiDotNetTests.csproj -c Debug -f net10.0 \
+  --filter "FullyQualifiedName~ModelFamilyTests.NeuralNetworks"             # crashes: Stack overflow
+```
+
+## Pass list (44) — for reference, don't touch
+All non-listed shards passed, including: NN-Classic (ResNet/VGG/DenseNet), NN-Efficient, NN-VLM, all 13 `Unit` non-diffusion shards, `Integration A-B/E-G/H-L/M/N-O/P-Q/R/S/T-Z` (only C and D fail), Classification, Clustering/GP, Regression, TimeSeries, Code/Forecast/Segment/Survival, several `Diffusion Contracts` unit shards (`03a/03c1/03c2/03c4/03c5`), TopLevel, Serving.

--- a/CI_SHARD_INVENTORY.md
+++ b/CI_SHARD_INVENTORY.md
@@ -1,119 +1,102 @@
-# AiDotNet CI Shard Failure Inventory & Work-Division Plan
+# CI shard evidence for the sequence-options migration
 
-**Source of truth:** clean `Build & SonarCloud` run on `master` @ `01a4ddb4` (Tensors **0.102.12**), run id `28023414937`.
-**Result:** **44 pass / 19 fail / 1 cancelled** (`NeuralNetworks T-Z`, runner lost) of 64 test shards.
-**Generated:** 2026-06-23. Re-run the run and re-classify before locking assignments if master has moved.
+Snapshot checked on 2026-09-11. This document is an evidence record, not a claim
+that all shards are green or that an old failure classification remains current.
 
-> **Already fixed (do not re-investigate):** the fp32 small-M GEMM `ArrayPool` host-crash that was aborting every CNN/diffusion shard wholesale — fixed in **Tensors #672 → 0.102.12**, on master via #1667. Verified locally: `ResNetNetworkTests` 56/56, `ConvolutionalNeuralNetworkTests` 21/21.
+## Current recorded CI evidence
 
----
+| Field | Recorded value |
+| --- | --- |
+| PR | #2128 |
+| Tested head requested by the run | `671836a347436f4b023ebe3f02a86ea333ad0686` |
+| Dependency at that head | AiDotNet.Tensors 0.130.2, from `Directory.Packages.props` |
+| Workflow / attempt | Build & SonarCloud / attempt 1 |
+| Run | [34303995195](https://github.com/ooples/AiDotNet/actions/runs/34303995195) |
+| Created | 2026-09-09 02:38:07 UTC |
+| Conclusion | Cancelled |
+| Jobs returned by the paginated jobs API | 1 |
+| Only job | Resolve certified PR validation, job 102316758308, cancelled |
+| Observed test shards | 0 |
+| Current passing-shard list | None established by this run |
+| Current failing-test classification | Unknown: no shard results were produced |
+| Current work assignments derived from these results | None |
 
-## TL;DR — the 19 failures are 4 distinct causes, not 19 model bugs
+The source and dependency above describe that exact run, not a later review-fix
+commit. Subsequent fixes need their own local test evidence and/or completed CI
+results. Cancellation is neither a passing matrix nor evidence of a model defect.
 
-| # | Root cause | Shards | One fix greens many? |
-|---|-----------|:------:|----------------------|
-| ① | **Stack overflow** (host crash, recursion) | 4 (+1 cancelled) | Likely yes — probably one shared recursion |
-| ② | **Inference arena corruption** (`#1661`, default-ON) | 3 (+~7 in ③) | **Yes — biggest lever** |
-| ③ | **Host killed mid-run** (arena-crash *or* OOM; log truncated) | 8 | Partly (triage → ② or ④/OOM) |
-| ④ | **Genuine per-model bugs** (training / clone / construction) | 4 | No — individual |
+Recheck the run and every jobs page using:
 
-The arena bug (②) and most of the silent diffusion deaths (③) are the **same root cause** in two manifestations: the arena recycles a tensor across denoise steps → wrong shape (`Input has N channels but layer expects M`). When that corruption is *caught* it's a `[FAIL]` (②); when it corrupts `ArrayPool` it's a **native host crash with no `[FAIL]` logged** (③).
-
-**Confirmed locally (this box, 32 GB):** `AIDOTNET_INFERENCE_ARENA=0` turns **DDPM 38/38** and **SyncDreamer** green (both fail with the arena on). That env var is the **key enabler for parallel work** — see below.
-
----
-
-## Per-shard classification
-
-### ① Stack overflow — host crash (recursion bug)
-`Test host process crashed : Stack overflow.`
-
-- `ModelFamily - NeuralNetworks O-R`
-- `ModelFamily - NeuralNetworks S`
-- `ModelFamily - NeuralNetworks A-L`
-- `ModelFamily - Generated Layers A-M`
-- `ModelFamily - NeuralNetworks T-Z` — **cancelled** (runner lost mid-run; no reason logged). Given the other 3 NN ranges all stack-overflow, this is the likely cause; could also be OOM. Triage locally.
-
-*Almost certainly one shared recursion (a `Clone`/forward/property that calls itself). Find it once, likely fixes all five.*
-
-### ② Inference arena corruption (#1661) — confirmed
-Caught `Input has N channels but layer expects M` failures + arena signature in the log.
-
-| Shard | Failing model(s) |
-|---|---|
-| `ModelFamily - Diffusion A-C` | `ControlNetXSModelTests` (all 7) |
-| `ModelFamily - Diffusion Stable` | `StableSRModelTests` (all), `StableDiffusion3ModelTests.Predict_ShouldBeDeterministic` |
-| `ModelFamily - Diffusion Step-Sync` | `SUPIRModelTests` (all), `SyncDiffusionModelTests`, `Step1XEditModelTests` (training subset) |
-
-### ③ Host killed mid-run — arena-crash OR OOM (needs local triage)
-Shard died before xUnit logged any `[FAIL]` (`0 FAILs`, no crash reason captured). Diffusion-heavy → **leading hypothesis: arena escalating to a native pool-corruption crash** (DDPM lives in `03b`, SyncDreamer in `SA-SD` — both confirmed arena locally). Some may be genuine 16 GB-runner OOM.
-
-- `Unit - 03b Diffusion Models Control/DDPM/Preprocessor`  *(DDPM = arena, confirmed)*
-- `Unit - 03d Diffusion Models FastGen/Conditioner`
-- `ModelFamily - Diffusion D-I`
-- `ModelFamily - Diffusion J-M`
-- `ModelFamily - Diffusion N-R`
-- `ModelFamily - Diffusion SA-SD`  *(SyncDreamer = arena, confirmed)*
-- `ModelFamily - Diffusion SE-SP`
-- `Integration C`
-
-### ④ Genuine per-model bugs (NOT arena — these are training/clone/construction)
-Arena is inference-only; `GradientFlow` / `LossStrictlyDecreases` / `Training_*` failures are real model bugs.
-
-| Shard | Failing test(s) | Smell |
-|---|---|---|
-| `ModelFamily - NeuralNetworks M-N` | `NeuralTuringMachineTests` — `GradientFlow_ShouldBeNonZeroAndFinite`, `LossStrictlyDecreasesOnMemorizationTask`, `Training_ShouldChangeParameters` | tape/gradient no-op |
-| `ModelFamily - Generated Layers N-Z` | `TimeMachineTests` (training ×3), `WhisperTimestampedTests` (`Training_ShouldChangeParameters`, `DifferentInputs_AfterTraining`) | tape/gradient no-op |
-| `ModelFamily - Diffusion T-Z` | `TCDModelTests.Clone_ShouldProduceIdenticalOutput` | clone / stale weight-cache |
-| `Integration D` | `DefaultConstructionTests.AllDefaultConstructableModels_ShouldConstructWithoutException` | one model ctor throws |
-
----
-
-## Work-division — 4 parallel streams (non-overlapping files)
-
-> **Enabler for everyone:** run your shard locally with **`AIDOTNET_INFERENCE_ARENA=0`** to strip out the arena corruption (②/③) so your area's *true* residual failures surface. No need to wait for Stream A to merge.
->
-> ```
-> AIDOTNET_INFERENCE_ARENA=0 dotnet test tests/AiDotNet.Tests/AiDotNetTests.csproj -c Debug -f net10.0 \
->   --filter "FullyQualifiedName~<YourModelTests>"
-> ```
-
-Tracked as **Epic #1673** with one GitHub issue per chunk:
-
-| Issue | Stream | Scope | Files (no conflict) | Owner |
-|---|---|---|---|---|
-| **#1668** | **A — Inference arena (#1661)** | Fix cross-step tensor recycling in the denoise loop (a layer's cross-forward cached buffer takes arena memory that `Reset()` recycles → shape aliasing). Or gate the arena off for diffusion denoise until the deep fix lands. **Greens ② + the diffusion half of ③ (~10 shards).** | `src/Diffusion/DiffusionModelBase.cs`, `src/NeuralNetworks/InferenceArenaSettings.cs`, Tensors arena | **Claude** (root-caused) |
-| **#1669** | **B — Stack overflow** | Find the recursion crashing the ① shards (`NeuralNetworks A-L/O-R/S/T-Z` + `Generated A-M`). Bisect which model self-recurses (`Clone`, `GetParameters`, property getters, forward). | offending NN/Generated model `.cs` | 1 dev |
-| **#1670** | **D — Training bugs** | NeuralTuringMachine + TimeMachine + WhisperTimestamped training/gradient no-op (likely shared sub-layer registration gap). | those 3 model `.cs` | 1 dev |
-| **#1671** | **D — Misc bugs** | TCD clone-equivalence + Integration-D default-construction. | TCD model `.cs`, the throwing ctor | 1 dev |
-| **#1672** | **C — OOM footprint** | Genuine 16 GB-runner OOM residual; test-scale variants. **Gated on #1668** (triage which ③ shards are truly OOM after the arena fix). | `tests/.../ModelFamilyTests/Base/*TestBase.cs`, model construction | 1 dev |
-
-### Sequencing
-1. **A and B first / concurrently** — they are *crash* causes that abort shards and mask everything else.
-2. **C and D in parallel now** using `AIDOTNET_INFERENCE_ARENA=0` locally (they don't need A merged to see their failures).
-3. After A + B land, **one CI re-run** gives the clean residual; reassign any surprises to D.
-
-### Triage step that splits ③ between A and C (parallelizable, ~1 shard each)
-For each ③ shard, run locally with `AIDOTNET_INFERENCE_ARENA=0`:
-- **Passes** → it was the arena → covered by **Stream A**.
-- **Still fails / OOMs** → **Stream C** (OOM) or **Stream D** (genuine), by signature.
-
----
-
-## Reproduce / verify
-
-```bash
-# the clean inventory run
-gh run view 28023414937 --repo ooples/AiDotNet
-
-# a confirmed arena case (passes with arena off, fails with it on)
-AIDOTNET_INFERENCE_ARENA=0 dotnet test tests/AiDotNet.Tests/AiDotNetTests.csproj -c Debug -f net10.0 \
-  --filter "FullyQualifiedName~UnitTests.Diffusion.Models.DDPMModelTests"   # 38/38 with arena off
-
-# a stack-overflow shard (host crash)
-dotnet test tests/AiDotNet.Tests/AiDotNetTests.csproj -c Debug -f net10.0 \
-  --filter "FullyQualifiedName~ModelFamilyTests.NeuralNetworks"             # crashes: Stack overflow
+```powershell
+gh api repos/ooples/AiDotNet/actions/runs/34303995195
+gh api --paginate 'repos/ooples/AiDotNet/actions/runs/34303995195/jobs?per_page=100'
 ```
 
-## Pass list (44) — for reference, don't touch
-All non-listed shards passed, including: NN-Classic (ResNet/VGG/DenseNet), NN-Efficient, NN-VLM, all 13 `Unit` non-diffusion shards, `Integration A-B/E-G/H-L/M/N-O/P-Q/R/S/T-Z` (only C and D fail), Classification, Clustering/GP, Regression, TimeSeries, Code/Forecast/Segment/Survival, several `Diffusion Contracts` unit shards (`03a/03c1/03c2/03c4/03c5`), TopLevel, Serving.
+The previous June inventory (run 28023414937, head 01a4ddb4, Tensors 0.102.12) is
+[retained in Git history](https://github.com/ooples/AiDotNet/blob/671836a347436f4b023ebe3f02a86ea333ad0686/CI_SHARD_INVENTORY.md).
+Its reported 44/19/1 counts, pass list, root-cause claims, and owner assignments
+must not be used as the status of this branch.
+
+## Arena comparison: diagnostic evidence, not a verdict
+
+Disabling the inference arena changes allocation, recycling, and timing.
+A pass with the arena disabled suggests an interaction; it does not prove tensor
+aliasing, pool corruption, or OOM. A failure with it disabled does not exclude an
+arena-related defect. A killed host without a captured exception is unclassified.
+
+Compare the same built binary and test filter in separate processes, with all
+other settings unchanged. The helper below requires a real filter, rejects an
+empty/placeholder filter, and refuses to accept a run with zero executed tests.
+Build the Release/net10.0 test project first. Keep both TRXs, exit codes, the
+test/library/tensor assembly hashes, and any crash/resource evidence before
+assigning a root cause. Do not rebuild or change dependencies during comparison.
+
+```powershell
+function Invoke-ArenaComparison {
+    param(
+        [Parameter(Mandatory)]
+        [ValidateScript({ -not [string]::IsNullOrWhiteSpace($_) -and -not $_.Contains('<YourModelTests>') })]
+        [string] $TestFilter
+    )
+    $testProject = 'tests/AiDotNet.Tests/AiDotNetTests.csproj'
+    $binaryRoot = 'tests/AiDotNet.Tests/bin/Release/net10.0'
+    $binaryHashes = [ordered]@{}
+    foreach ($name in 'AiDotNetTests.dll', 'AiDotNet.dll', 'AiDotNet.Tensors.dll') {
+        $path = Join-Path $binaryRoot $name
+        $binaryHashes[$name] = (Get-FileHash -LiteralPath $path -Algorithm SHA256 -ErrorAction Stop).Hash
+    }
+    $resultsRoot = Join-Path ([IO.Path]::GetTempPath()) ('aidotnet-arena-comparison-' + [guid]::NewGuid().ToString('N'))
+    $previousArena = [Environment]::GetEnvironmentVariable('AIDOTNET_INFERENCE_ARENA')
+    try {
+        foreach ($arenaMode in 1, 0) {
+            [Environment]::SetEnvironmentVariable('AIDOTNET_INFERENCE_ARENA', [string]$arenaMode)
+            $reportName = "arena-$arenaMode.trx"
+            dotnet test $testProject -c Release -f net10.0 --no-build --no-restore --filter $TestFilter --logger "trx;LogFileName=$reportName" --results-directory $resultsRoot
+            $testExit = $LASTEXITCODE
+            $reportPath = Join-Path $resultsRoot $reportName
+            if (-not (Test-Path -LiteralPath $reportPath)) { throw "No test report was produced: $reportPath (exit $testExit)" }
+            [xml]$report = Get-Content -LiteralPath $reportPath -Raw -ErrorAction Stop
+            $executed = @($report.TestRun.Results.UnitTestResult | Where-Object { $_ -and $_.outcome -ne 'NotExecuted' })
+            if ($executed.Count -eq 0) { throw "No tests executed for filter '$TestFilter'." }
+            foreach ($name in $binaryHashes.Keys) {
+                $path = Join-Path $binaryRoot $name
+                if ((Get-FileHash -LiteralPath $path -Algorithm SHA256 -ErrorAction Stop).Hash -ne $binaryHashes[$name]) {
+                    throw "An assembly changed during comparison: $name"
+                }
+            }
+            [pscustomobject]@{ Arena = $arenaMode; ExitCode = $testExit; Executed = $executed.Count; AssemblySha256 = $binaryHashes; Report = $reportPath }
+        }
+    }
+    finally {
+        if ($null -eq $previousArena) {
+            Remove-Item Env:AIDOTNET_INFERENCE_ARENA -ErrorAction SilentlyContinue
+        } else {
+            [Environment]::SetEnvironmentVariable('AIDOTNET_INFERENCE_ARENA', $previousArena)
+        }
+    }
+}
+```
+
+Invoke the helper with `-TestFilter` set to the exact failing class or test from
+the current run. Do not replace production defaults, weaken assertions, or label
+a failure an arena bug solely because one side of this comparison passes.

--- a/src/AiDotNet.Generators/TestScaffoldGenerator.cs
+++ b/src/AiDotNet.Generators/TestScaffoldGenerator.cs
@@ -6548,22 +6548,6 @@ public class TestScaffoldGenerator : IIncrementalGenerator
                     "taskType: AiDotNet.Enums.NeuralNetworkTaskType.TextGeneration, " +
                     "inputSize: 32, outputSize: 128), new AiDotNet.NeuralNetworks.Options.Mamba2Options { VocabSize = 128, ModelDimension = 32, NumLayers = 2, StateDimension = 16, NumHeads = 4, MaxSequenceLength = 32 })";
             }
-            else if (model.ClassName == "XLSTMLanguageModel" && model.TypeParameterCount == 1)
-            {
-                // Float and iteration capping made the paper-default fixture fit the watchdog, but
-                // its 50,277-way embedding/head still reduced the memorization loss by only 0.75%
-                // in 15 steps (the invariant requires >1%). Exercise the same public
-                // embedding -> stacked ExtendedLSTM -> normalization -> LM-head construction path
-                // with two recurrent blocks at smoke width/vocabulary/context. Supplying no custom
-                // architecture layers deliberately preserves the model contract: InitializeLayers
-                // builds these defaults through LayerHelper, while production/user custom layers and
-                // all production constructor defaults remain untouched.
-                pinInitSeed = true;
-                constructorExpr = $"new {typeName}<double>(new AiDotNet.NeuralNetworks.NeuralNetworkArchitecture<double>(" +
-                    "inputType: AiDotNet.Enums.InputType.OneDimensional, " +
-                    "taskType: AiDotNet.Enums.NeuralNetworkTaskType.TextGeneration, " +
-                    "inputSize: 16, outputSize: 64), new AiDotNet.NeuralNetworks.Options.XLSTMOptions { VocabSize = 64, ModelDimension = 32, NumLayers = 2, NumHeads = 4, MaxSequenceLength = 16 })";
-            }
             else if (model.ClassName == "BloombergGPT" && model.TypeParameterCount == 1)
             {
                 // BloombergGPT's production defaults retain the finance-language-model vocabulary,
@@ -6966,7 +6950,7 @@ public class TestScaffoldGenerator : IIncrementalGenerator
                     "taskType: AiDotNet.Enums.NeuralNetworkTaskType.TextGeneration, " +
                     "inputSize: 32, outputSize: 128), new AiDotNet.NeuralNetworks.Options.FalconMambaOptions { VocabSize = 128, ModelDimension = 32, NumLayers = 1, StateDimension = 8, ExpandFactor = 2, MaxSequenceLength = 32 })";
             }
-            else if ((model.ClassName is "HawkLanguageModel" or "GLALanguageModel" or "GatedDeltaNetLanguageModel")
+            else if ((model.ClassName is "GLALanguageModel" or "GatedDeltaNetLanguageModel")
                      && model.TypeParameterCount == 1)
             {
                 // These recurrent language models retain their paper/default vocabulary, width,
@@ -6976,15 +6960,13 @@ public class TestScaffoldGenerator : IIncrementalGenerator
                 // Pin generated-test initialization because these recurrent gates otherwise draw
                 // from the process-shared RNG and the exact trajectory depends on sibling test order.
                 pinInitSeed = true;
-                // Hawk is purely recurrent and declares no head count; the other two do.
-                string headArgument = model.ClassName == "HawkLanguageModel" ? string.Empty : "NumHeads = 4, ";
                 string recurrentOptionsType = model.ClassName.Replace("LanguageModel", "Options");
                 constructorExpr = $"new {typeName}<double>(new AiDotNet.NeuralNetworks.NeuralNetworkArchitecture<double>(" +
                     "inputType: AiDotNet.Enums.InputType.OneDimensional, " +
                     "taskType: AiDotNet.Enums.NeuralNetworkTaskType.TextGeneration, " +
                     "inputSize: 32, outputSize: 128), " +
                     $"new AiDotNet.NeuralNetworks.Options.{recurrentOptionsType} {{ VocabSize = 128, " +
-                    $"ModelDimension = 32, NumLayers = 1, {headArgument}MaxSequenceLength = 32 }})";
+                    "ModelDimension = 32, NumLayers = 1, NumHeads = 4, MaxSequenceLength = 32 })";
             }
             else if (model.ClassName == "ZambaLanguageModel" && model.TypeParameterCount == 1)
             {
@@ -11417,23 +11399,21 @@ public class TestScaffoldGenerator : IIncrementalGenerator
                     $"taskType: {taskTypeExpr}, " +
                     $"{sizeExpr})";
 
-                // Paper-scale language models (Griffin/Hawk/RecurrentGemma) default to a 256k
-                // vocabulary, giving a foundation-sized embedding and language head. Keep the
+                // RecurrentGemma defaults to a 256k vocabulary, giving a foundation-sized
+                // embedding and language head. Keep the
                 // production defaults untouched and construct runnable generated fixtures through
                 // their public scale knobs. RecurrentGemma reached the timeout ladder's shrink rung
                 // even after FP32 and repetition/sample caps: its finite-difference invariant still
                 // exceeded 120 s when run after the rest of its class. Preserve the complete
                 // embedding -> RG-LRU -> normalization -> logits topology at one 32-wide recurrent
-                // block and a 256-token smoke vocabulary; Griffin/Hawk remain at the earlier vocab-
-                // only cap because their full-width fixtures already fit the gate.
+                // block and a 256-token smoke vocabulary. Griffin/Hawk use their dedicated
+                // bounded constructor rule above and never reach this fallback.
                 const string optionsNamespace = "AiDotNet.NeuralNetworks.Options.";
                 string scaleArgs = model.ClassName switch
                 {
                     "RecurrentGemmaLanguageModel" =>
                         ", new " + optionsNamespace + "RecurrentGemmaOptions { VocabSize = 256, "
                             + "ModelDimension = 32, NumLayers = 1, MaxSequenceLength = 128 }",
-                    "GriffinLanguageModel" => ", new " + optionsNamespace + "GriffinOptions { VocabSize = 4096 }",
-                    "HawkLanguageModel" => ", new " + optionsNamespace + "HawkOptions { VocabSize = 4096 }",
                     _ => ""
                 };
 

--- a/src/AiDotNet.Generators/TestScaffoldGenerator.cs
+++ b/src/AiDotNet.Generators/TestScaffoldGenerator.cs
@@ -5091,9 +5091,7 @@ public class TestScaffoldGenerator : IIncrementalGenerator
                 constructorExpr = $"new {typeName}<double>(new AiDotNet.NeuralNetworks.NeuralNetworkArchitecture<double>(" +
                     "inputType: AiDotNet.Enums.InputType.OneDimensional, " +
                     "taskType: AiDotNet.Enums.NeuralNetworkTaskType.TextGeneration, " +
-                    "inputSize: 4, outputSize: 64), " +
-                    "vocabSize: 64, modelDimension: 32, numLayers: 2, numHeads: 4, maxSeqLength: 16, " +
-                    "learningRate: 1e-5)";
+                    "inputSize: 4, outputSize: 64), new AiDotNet.NeuralNetworks.Options.FinchOptions { VocabSize = 64, ModelDimension = 32, NumLayers = 2, NumHeads = 4, MaxSequenceLength = 16, LearningRate = 1e-5 })";
             }
             else if (model.ClassName == "FlamingoNeuralNetwork" && model.TypeParameterCount == 1)
             {
@@ -6521,8 +6519,10 @@ public class TestScaffoldGenerator : IIncrementalGenerator
                 constructorExpr = $"new {typeName}<double>(new AiDotNet.NeuralNetworks.NeuralNetworkArchitecture<double>(" +
                     "inputType: AiDotNet.Enums.InputType.OneDimensional, " +
                     "taskType: AiDotNet.Enums.NeuralNetworkTaskType.TextGeneration, inputSize: 32, outputSize: 128), " +
-                    "vocabSize: 128, modelDimension: 32, numLayers: 1, maxSeqLength: 32, " +
-                    $"options: new AiDotNet.NeuralNetworks.Options.{recurrentOptionsType} {{ RecurrenceDimension = 40 }})";
+                    $"new AiDotNet.NeuralNetworks.Options.{recurrentOptionsType} {{ VocabSize = 128, " +
+                    "ModelDimension = 32, NumLayers = 1, MaxSequenceLength = 32, " +
+                    // NOT an interpolated segment, so a single brace is a single brace.
+                    "RecurrenceDimension = 40 })";
             }
             else if (model.ClassName == "DocGCN" && model.TypeParameterCount == 1)
             {
@@ -6976,12 +6976,15 @@ public class TestScaffoldGenerator : IIncrementalGenerator
                 // Pin generated-test initialization because these recurrent gates otherwise draw
                 // from the process-shared RNG and the exact trajectory depends on sibling test order.
                 pinInitSeed = true;
-                string headArgument = model.ClassName == "HawkLanguageModel" ? string.Empty : "numHeads: 4, ";
+                // Hawk is purely recurrent and declares no head count; the other two do.
+                string headArgument = model.ClassName == "HawkLanguageModel" ? string.Empty : "NumHeads = 4, ";
+                string recurrentOptionsType = model.ClassName.Replace("LanguageModel", "Options");
                 constructorExpr = $"new {typeName}<double>(new AiDotNet.NeuralNetworks.NeuralNetworkArchitecture<double>(" +
                     "inputType: AiDotNet.Enums.InputType.OneDimensional, " +
                     "taskType: AiDotNet.Enums.NeuralNetworkTaskType.TextGeneration, " +
-                    "inputSize: 32, outputSize: 128), vocabSize: 128, modelDimension: 32, " +
-                    $"numLayers: 1, {headArgument}maxSeqLength: 32)";
+                    "inputSize: 32, outputSize: 128), " +
+                    $"new AiDotNet.NeuralNetworks.Options.{recurrentOptionsType} {{ VocabSize = 128, " +
+                    $"ModelDimension = 32, NumLayers = 1, {headArgument}MaxSequenceLength = 32 }})";
             }
             else if (model.ClassName == "ZambaLanguageModel" && model.TypeParameterCount == 1)
             {
@@ -11423,11 +11426,14 @@ public class TestScaffoldGenerator : IIncrementalGenerator
                 // embedding -> RG-LRU -> normalization -> logits topology at one 32-wide recurrent
                 // block and a 256-token smoke vocabulary; Griffin/Hawk remain at the earlier vocab-
                 // only cap because their full-width fixtures already fit the gate.
+                const string optionsNamespace = "AiDotNet.NeuralNetworks.Options.";
                 string scaleArgs = model.ClassName switch
                 {
                     "RecurrentGemmaLanguageModel" =>
-                        ", vocabSize: 256, modelDimension: 32, numLayers: 1, maxSeqLength: 128",
-                    "GriffinLanguageModel" or "HawkLanguageModel" => ", vocabSize: 4096",
+                        ", new " + optionsNamespace + "RecurrentGemmaOptions { VocabSize = 256, "
+                            + "ModelDimension = 32, NumLayers = 1, MaxSequenceLength = 128 }",
+                    "GriffinLanguageModel" => ", new " + optionsNamespace + "GriffinOptions { VocabSize = 4096 }",
+                    "HawkLanguageModel" => ", new " + optionsNamespace + "HawkOptions { VocabSize = 4096 }",
                     _ => ""
                 };
 

--- a/src/AiDotNet.Generators/TestScaffoldGenerator.cs
+++ b/src/AiDotNet.Generators/TestScaffoldGenerator.cs
@@ -5081,8 +5081,7 @@ public class TestScaffoldGenerator : IIncrementalGenerator
                 constructorExpr = $"new {typeName}<double>(new AiDotNet.NeuralNetworks.NeuralNetworkArchitecture<double>(" +
                     "inputType: AiDotNet.Enums.InputType.OneDimensional, " +
                     "taskType: AiDotNet.Enums.NeuralNetworkTaskType.TextGeneration, " +
-                    "inputSize: 4, outputSize: 64), " +
-                    "vocabSize: 64, modelDimension: 32, numLayers: 2, numHeads: 4, maxSeqLength: 16)";
+                    "inputSize: 4, outputSize: 64), new AiDotNet.NeuralNetworks.Options.EagleOptions { VocabSize = 64, ModelDimension = 32, NumLayers = 2, NumHeads = 4, MaxSequenceLength = 16 })";
             }
             else if (model.ClassName == "FinchLanguageModel" && model.TypeParameterCount == 1)
             {
@@ -5633,8 +5632,9 @@ public class TestScaffoldGenerator : IIncrementalGenerator
                     "inputType: AiDotNet.Enums.InputType.OneDimensional, " +
                     "taskType: AiDotNet.Enums.NeuralNetworkTaskType.Regression, " +
                     "inputSize: 128, outputSize: 4), " +
-                    "vocabSize: 64, modelDimension: 32, numLayers: 1, numHeads: 4, maxSeqLength: 128, " +
-                    "options: new AiDotNet.NeuralNetworks.Options.XLSTMOptions { LearningRate = 3e-4 })";
+                    "new AiDotNet.NeuralNetworks.Options.XLSTMOptions { VocabSize = 64, " +
+                    "ModelDimension = 32, NumLayers = 1, NumHeads = 4, MaxSequenceLength = 128, " +
+                    "LearningRate = 3e-4 })";
             }
             else if (model.ClassName == "XTTSv2Clone" && model.TypeParameterCount == 1)
             {
@@ -6546,8 +6546,7 @@ public class TestScaffoldGenerator : IIncrementalGenerator
                 constructorExpr = $"new {typeName}<double>(new AiDotNet.NeuralNetworks.NeuralNetworkArchitecture<double>(" +
                     "inputType: AiDotNet.Enums.InputType.OneDimensional, " +
                     "taskType: AiDotNet.Enums.NeuralNetworkTaskType.TextGeneration, " +
-                    "inputSize: 32, outputSize: 128), vocabSize: 128, modelDimension: 32, " +
-                    "numLayers: 2, stateDimension: 16, numHeads: 4, maxSeqLength: 32)";
+                    "inputSize: 32, outputSize: 128), new AiDotNet.NeuralNetworks.Options.Mamba2Options { VocabSize = 128, ModelDimension = 32, NumLayers = 2, StateDimension = 16, NumHeads = 4, MaxSequenceLength = 32 })";
             }
             else if (model.ClassName == "XLSTMLanguageModel" && model.TypeParameterCount == 1)
             {
@@ -6563,8 +6562,7 @@ public class TestScaffoldGenerator : IIncrementalGenerator
                 constructorExpr = $"new {typeName}<double>(new AiDotNet.NeuralNetworks.NeuralNetworkArchitecture<double>(" +
                     "inputType: AiDotNet.Enums.InputType.OneDimensional, " +
                     "taskType: AiDotNet.Enums.NeuralNetworkTaskType.TextGeneration, " +
-                    "inputSize: 16, outputSize: 64), vocabSize: 64, modelDimension: 32, " +
-                    "numLayers: 2, numHeads: 4, maxSeqLength: 16)";
+                    "inputSize: 16, outputSize: 64), new AiDotNet.NeuralNetworks.Options.XLSTMOptions { VocabSize = 64, ModelDimension = 32, NumLayers = 2, NumHeads = 4, MaxSequenceLength = 16 })";
             }
             else if (model.ClassName == "BloombergGPT" && model.TypeParameterCount == 1)
             {
@@ -6966,8 +6964,7 @@ public class TestScaffoldGenerator : IIncrementalGenerator
                 constructorExpr = $"new {typeName}<double>(new AiDotNet.NeuralNetworks.NeuralNetworkArchitecture<double>(" +
                     "inputType: AiDotNet.Enums.InputType.OneDimensional, " +
                     "taskType: AiDotNet.Enums.NeuralNetworkTaskType.TextGeneration, " +
-                    "inputSize: 32, outputSize: 128), vocabSize: 128, modelDimension: 32, " +
-                    "numLayers: 1, stateDimension: 8, expandFactor: 2, maxSeqLength: 32)";
+                    "inputSize: 32, outputSize: 128), new AiDotNet.NeuralNetworks.Options.FalconMambaOptions { VocabSize = 128, ModelDimension = 32, NumLayers = 1, StateDimension = 8, ExpandFactor = 2, MaxSequenceLength = 32 })";
             }
             else if ((model.ClassName is "HawkLanguageModel" or "GLALanguageModel" or "GatedDeltaNetLanguageModel")
                      && model.TypeParameterCount == 1)
@@ -6995,8 +6992,7 @@ public class TestScaffoldGenerator : IIncrementalGenerator
                 constructorExpr = $"new {typeName}<double>(new AiDotNet.NeuralNetworks.NeuralNetworkArchitecture<double>(" +
                     "inputType: AiDotNet.Enums.InputType.OneDimensional, " +
                     "taskType: AiDotNet.Enums.NeuralNetworkTaskType.TextGeneration, " +
-                    "inputSize: 128, outputSize: 128), vocabSize: 128, modelDimension: 32, " +
-                    "numLayers: 2, stateDimension: 16, attentionInterval: 2, maxSeqLength: 128)";
+                    "inputSize: 128, outputSize: 128), new AiDotNet.NeuralNetworks.Options.ZambaOptions { VocabSize = 128, ModelDimension = 32, NumLayers = 2, StateDimension = 16, AttentionInterval = 2, MaxSequenceLength = 128 })";
             }
             else if (model.ClassName == "Zamba2LanguageModel" && model.TypeParameterCount == 1)
             {
@@ -7006,8 +7002,7 @@ public class TestScaffoldGenerator : IIncrementalGenerator
                 constructorExpr = $"new {typeName}<double>(new AiDotNet.NeuralNetworks.NeuralNetworkArchitecture<double>(" +
                     "inputType: AiDotNet.Enums.InputType.OneDimensional, " +
                     "taskType: AiDotNet.Enums.NeuralNetworkTaskType.TextGeneration, " +
-                    "inputSize: 128, outputSize: 128), vocabSize: 128, modelDimension: 32, " +
-                    "numLayers: 2, stateDimension: 16, numHeads: 4, attentionInterval: 2, maxSeqLength: 128)";
+                    "inputSize: 128, outputSize: 128), new AiDotNet.NeuralNetworks.Options.Zamba2Options { VocabSize = 128, ModelDimension = 32, NumLayers = 2, StateDimension = 16, NumHeads = 4, AttentionInterval = 2, MaxSequenceLength = 128 })";
             }
             else if (model.ClassName == "ChronosBolt" && model.TypeParameterCount == 1)
             {
@@ -9312,9 +9307,7 @@ public class TestScaffoldGenerator : IIncrementalGenerator
                 constructorExpr = $"new {typeName}<double>(new AiDotNet.NeuralNetworks.NeuralNetworkArchitecture<double>(" +
                     "inputType: AiDotNet.Enums.InputType.OneDimensional, " +
                     "taskType: AiDotNet.Enums.NeuralNetworkTaskType.TextGeneration, " +
-                    "inputSize: 8, outputSize: 16), " +
-                    "vocabSize: 16, modelDimension: 32, numLayers: 2, stateDimension: 8, " +
-                    "attentionInterval: 2, maxSeqLength: 8)";
+                    "inputSize: 8, outputSize: 16), new AiDotNet.NeuralNetworks.Options.JambaOptions { VocabSize = 16, ModelDimension = 32, NumLayers = 2, StateDimension = 8, AttentionInterval = 2, MaxSequenceLength = 8 })";
             }
             else if (IsValleCodecLMModel(model.ClassName) && model.TypeParameterCount == 1
                      && model.FullyQualifiedName.StartsWith("AiDotNet.TextToSpeech.", System.StringComparison.Ordinal))

--- a/src/Configuration/InferenceOptimizationConfig.cs
+++ b/src/Configuration/InferenceOptimizationConfig.cs
@@ -330,7 +330,7 @@ public class InferenceOptimizationConfig
     /// <summary>
     /// Validates the configuration and throws if any values are invalid.
     /// </summary>
-    /// <exception cref="ArgumentException">Thrown when configuration values are invalid.</exception>
+    /// <exception cref="InvalidOperationException">Thrown when configuration values are invalid.</exception>
     /// <remarks>
     /// <para><b>For Beginners:</b> Call this method to ensure your configuration is valid before use.
     ///

--- a/src/Configuration/InferenceOptimizationConfig.cs
+++ b/src/Configuration/InferenceOptimizationConfig.cs
@@ -330,7 +330,7 @@ public class InferenceOptimizationConfig
     /// <summary>
     /// Validates the configuration and throws if any values are invalid.
     /// </summary>
-    /// <exception cref="InvalidOperationException">Thrown when configuration values are invalid.</exception>
+    /// <exception cref="ArgumentException">Thrown when configuration values are invalid.</exception>
     /// <remarks>
     /// <para><b>For Beginners:</b> Call this method to ensure your configuration is valid before use.
     ///

--- a/src/Configuration/JitCompilationConfig.cs
+++ b/src/Configuration/JitCompilationConfig.cs
@@ -173,7 +173,7 @@ public sealed class JitCompilationConfig
     /// <summary>
     /// Validates the config and throws if settings are inconsistent.
     /// </summary>
-    /// <exception cref="InvalidOperationException">Thrown when values are out of range.</exception>
+    /// <exception cref="ArgumentException">Thrown when values are out of range.</exception>
     public void Validate()
     {
         // NaN passes both `< 0` and `>= 1` comparisons (NaN is unordered with

--- a/src/Configuration/JitCompilationConfig.cs
+++ b/src/Configuration/JitCompilationConfig.cs
@@ -173,7 +173,7 @@ public sealed class JitCompilationConfig
     /// <summary>
     /// Validates the config and throws if settings are inconsistent.
     /// </summary>
-    /// <exception cref="ArgumentException">Thrown when values are out of range.</exception>
+    /// <exception cref="InvalidOperationException">Thrown when values are out of range.</exception>
     public void Validate()
     {
         // NaN passes both `< 0` and `>= 1` comparisons (NaN is unordered with

--- a/src/Configuration/ProgramMetricAggregationOptions.cs
+++ b/src/Configuration/ProgramMetricAggregationOptions.cs
@@ -105,7 +105,7 @@ public sealed class ProgramMetricAggregationOptions
 
     /// <summary>Rejects a configuration that could not produce a defensible score.</summary>
     /// <exception cref="ArgumentOutOfRangeException"><see cref="Strategy"/> is undefined, or a numeric setting is not finite or is negative.</exception>
-    /// <exception cref="ArgumentException">
+    /// <exception cref="InvalidOperationException">
     /// A required setting is missing for the chosen strategy: an empty combined-score key, no positive weight, or a
     /// weighted metric with no reference value under the Chebyshev strategy.
     /// </exception>

--- a/src/Configuration/ProgramMetricAggregationOptions.cs
+++ b/src/Configuration/ProgramMetricAggregationOptions.cs
@@ -105,7 +105,7 @@ public sealed class ProgramMetricAggregationOptions
 
     /// <summary>Rejects a configuration that could not produce a defensible score.</summary>
     /// <exception cref="ArgumentOutOfRangeException"><see cref="Strategy"/> is undefined, or a numeric setting is not finite or is negative.</exception>
-    /// <exception cref="InvalidOperationException">
+    /// <exception cref="ArgumentException">
     /// A required setting is missing for the chosen strategy: an empty combined-score key, no positive weight, or a
     /// weighted metric with no reference value under the Chebyshev strategy.
     /// </exception>

--- a/src/Deployment/TensorRT/TensorRTConfiguration.cs
+++ b/src/Deployment/TensorRT/TensorRTConfiguration.cs
@@ -185,7 +185,7 @@ public class TensorRTConfiguration
     /// <summary>
     /// Validates the configuration and throws exceptions for invalid settings.
     /// </summary>
-    /// <exception cref="ArgumentException">Thrown when INT8 is enabled without calibration data</exception>
+    /// <exception cref="InvalidOperationException">Thrown when INT8 is enabled without calibration data</exception>
     /// <exception cref="FileNotFoundException">Thrown when calibration data path is specified but file doesn't exist</exception>
     public void Validate()
     {

--- a/src/Deployment/TensorRT/TensorRTConfiguration.cs
+++ b/src/Deployment/TensorRT/TensorRTConfiguration.cs
@@ -185,7 +185,7 @@ public class TensorRTConfiguration
     /// <summary>
     /// Validates the configuration and throws exceptions for invalid settings.
     /// </summary>
-    /// <exception cref="InvalidOperationException">Thrown when INT8 is enabled without calibration data</exception>
+    /// <exception cref="ArgumentException">Thrown when INT8 is enabled without calibration data</exception>
     /// <exception cref="FileNotFoundException">Thrown when calibration data path is specified but file doesn't exist</exception>
     public void Validate()
     {

--- a/src/Models/Options/AudioHyperparameterOptions.cs
+++ b/src/Models/Options/AudioHyperparameterOptions.cs
@@ -34,6 +34,8 @@ public abstract class AudioHyperparameterOptions : ModelHyperparameterOptions
     /// <summary>
     /// Gets or sets the audio sample rate in hertz.
     /// </summary>
+    /// <value>Zero in this base. The derived model supplies the positive sample rate
+    /// required by its training data and published configuration.</value>
     /// <remarks>
     /// <para><b>For Beginners:</b> How many measurements of the sound wave there are per
     /// second. 16000 is the speech standard, 44100 is CD quality. A model trained at one rate
@@ -45,6 +47,8 @@ public abstract class AudioHyperparameterOptions : ModelHyperparameterOptions
     /// <summary>
     /// Gets or sets the number of mel frequency bands in the spectrogram.
     /// </summary>
+    /// <value>Zero in this base. Models using mel features supply their published
+    /// band count; models that do not use mel features may leave this unused.</value>
     /// <remarks>
     /// <para><b>For Beginners:</b> The sound is split into this many frequency bands, spaced
     /// the way human hearing perceives pitch rather than evenly. 80 is near-universal for
@@ -55,6 +59,8 @@ public abstract class AudioHyperparameterOptions : ModelHyperparameterOptions
     /// <summary>
     /// Gets or sets the FFT window size, in samples, used to build each spectrogram frame.
     /// </summary>
+    /// <value>Zero in this base. A spectrogram-based model supplies the window size
+    /// from its signal-processing configuration.</value>
     /// <remarks>
     /// <para><b>For Beginners:</b> How big a slice of audio is analysed at once. Larger sees
     /// frequency more precisely but time less precisely, and vice versa — that trade-off is
@@ -65,6 +71,8 @@ public abstract class AudioHyperparameterOptions : ModelHyperparameterOptions
     /// <summary>
     /// Gets or sets the hop length, in samples, between consecutive spectrogram frames.
     /// </summary>
+    /// <value>Zero in this base. A spectrogram-based model supplies the frame spacing
+    /// matching its training configuration.</value>
     /// <remarks>
     /// <para><b>For Beginners:</b> How far the analysis window slides each step. Usually a
     /// quarter of <see cref="FftSize"/>, so the windows overlap and nothing falls between
@@ -75,27 +83,48 @@ public abstract class AudioHyperparameterOptions : ModelHyperparameterOptions
     /// <summary>
     /// Gets or sets the width of the model's main hidden representation.
     /// </summary>
+    /// <value>Zero in this base. The derived model supplies its architecture's hidden width.</value>
+    /// <remarks><para><b>For Beginners:</b> Each sound or text position is represented by
+    /// this many numbers inside the network. A wider representation usually requires
+    /// more memory and computation; use the width expected by pretrained weights.</para></remarks>
     public int HiddenDim { get; set; }
 
     /// <summary>
     /// Gets or sets the number of attention heads.
     /// </summary>
+    /// <value>Zero in this base. Models using attention supply their architecture's
+    /// head count; models without attention may leave it unused.</value>
+    /// <remarks><para><b>For Beginners:</b> Attention heads let the model compare several
+    /// relationships at once. The head count must be compatible with the hidden width
+    /// and the model's attention implementation.</para></remarks>
     public int NumHeads { get; set; }
 
     /// <summary>
     /// Gets or sets the number of encoder layers.
     /// </summary>
+    /// <value>Zero in this base. Models with an encoder supply the depth from their
+    /// architecture configuration.</value>
+    /// <remarks><para><b>For Beginners:</b> Encoder layers progressively interpret the
+    /// input sound or text. More layers add processing steps and increase computation;
+    /// pretrained weights require the matching depth.</para></remarks>
     public int NumEncoderLayers { get; set; }
 
     /// <summary>
     /// Gets or sets the number of decoder layers, for models that generate audio or text.
     /// </summary>
+    /// <value>Zero in this base. Models with a decoder supply the depth from their
+    /// architecture configuration.</value>
+    /// <remarks><para><b>For Beginners:</b> Decoder layers turn the encoded information
+    /// into the output representation. More layers increase computation; models without
+    /// a decoder do not consume this setting.</para></remarks>
     public int NumDecoderLayers { get; set; }
 
     /// <summary>
     /// Gets or sets the speaking-rate multiplier for synthesised speech. 1.0 is the model's
     /// natural pace.
     /// </summary>
+    /// <value>1.0, the shared neutral multiplier. A derived model may override it
+    /// according to its synthesis configuration.</value>
     /// <remarks>
     /// <para><b>For Beginners:</b> Above 1.0 talks faster, below 1.0 slower.</para>
     /// </remarks>
@@ -105,6 +134,8 @@ public abstract class AudioHyperparameterOptions : ModelHyperparameterOptions
     /// Gets or sets the BCP-47 language tag the model is configured for, or null when the
     /// model is language-agnostic.
     /// </summary>
+    /// <value>Null in this base, meaning no language tag is selected. A derived model
+    /// or caller can supply a tag supported by that model.</value>
     /// <remarks>
     /// <para><b>For Beginners:</b> "en" for English, "fr" for French. Multilingual models
     /// leave this null and detect the language themselves.</para>

--- a/src/Models/Options/AudioHyperparameterOptions.cs
+++ b/src/Models/Options/AudioHyperparameterOptions.cs
@@ -114,7 +114,7 @@ public abstract class AudioHyperparameterOptions : ModelHyperparameterOptions
     /// <summary>
     /// Throws if a signal parameter every audio model requires has been left unset.
     /// </summary>
-    /// <exception cref="InvalidOperationException">
+    /// <exception cref="ArgumentException">
     /// Thrown when a required value is zero or negative, which means the derived options class
     /// did not assign its model's published defaults.
     /// </exception>

--- a/src/Models/Options/AudioHyperparameterOptions.cs
+++ b/src/Models/Options/AudioHyperparameterOptions.cs
@@ -1,0 +1,125 @@
+namespace AiDotNet.Models.Options;
+
+/// <summary>
+/// Shared configuration for audio and speech models: text-to-speech, speech recognition,
+/// speech enhancement and denoising, audio classification and audio generation.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>For Beginners:</b> Audio models first turn a sound wave into a picture-like grid of
+/// numbers (a spectrogram) and then work on that. Most of the settings here describe how that
+/// conversion is done — how many samples per second the audio has, how finely it is chopped
+/// up in time, and how many frequency bands are kept. Each model's own options class ships
+/// the values from the paper that introduced it, so you do not normally set any of these.
+/// </para>
+/// <para>
+/// Derived options classes assign their paper's values in their parameterless constructor.
+/// See <see cref="ModelHyperparameterOptions"/> for why these properties are non-nullable.
+/// </para>
+/// <para>
+/// This base spans <c>src/TextToSpeech</c>, <c>src/SpeechRecognition</c> and <c>src/Audio</c>
+/// because they share the same signal parameters. It lives beside
+/// <see cref="DocumentNeuralNetworkOptions"/> rather than in any one of those areas for the
+/// same reason.
+/// </para>
+/// <para>
+/// <b>Naming.</b> The constructors being replaced use two names for each of two concepts —
+/// <c>hopLength</c> and <c>hopSize</c>, <c>fftSize</c> and <c>frameSize</c>. This base picks
+/// one of each (<see cref="HopLength"/>, <see cref="FftSize"/>), which is the usual naming in
+/// the audio literature and in librosa.
+/// </para>
+/// </remarks>
+public abstract class AudioHyperparameterOptions : ModelHyperparameterOptions
+{
+    /// <summary>
+    /// Gets or sets the audio sample rate in hertz.
+    /// </summary>
+    /// <remarks>
+    /// <para><b>For Beginners:</b> How many measurements of the sound wave there are per
+    /// second. 16000 is the speech standard, 44100 is CD quality. A model trained at one rate
+    /// will produce nonsense if fed audio at another, so this has to match the model, not your
+    /// source file — resample the audio instead of changing this.</para>
+    /// </remarks>
+    public int SampleRate { get; set; }
+
+    /// <summary>
+    /// Gets or sets the number of mel frequency bands in the spectrogram.
+    /// </summary>
+    /// <remarks>
+    /// <para><b>For Beginners:</b> The sound is split into this many frequency bands, spaced
+    /// the way human hearing perceives pitch rather than evenly. 80 is near-universal for
+    /// speech models.</para>
+    /// </remarks>
+    public int NumMels { get; set; }
+
+    /// <summary>
+    /// Gets or sets the FFT window size, in samples, used to build each spectrogram frame.
+    /// </summary>
+    /// <remarks>
+    /// <para><b>For Beginners:</b> How big a slice of audio is analysed at once. Larger sees
+    /// frequency more precisely but time less precisely, and vice versa — that trade-off is
+    /// unavoidable.</para>
+    /// </remarks>
+    public int FftSize { get; set; }
+
+    /// <summary>
+    /// Gets or sets the hop length, in samples, between consecutive spectrogram frames.
+    /// </summary>
+    /// <remarks>
+    /// <para><b>For Beginners:</b> How far the analysis window slides each step. Usually a
+    /// quarter of <see cref="FftSize"/>, so the windows overlap and nothing falls between
+    /// them.</para>
+    /// </remarks>
+    public int HopLength { get; set; }
+
+    /// <summary>
+    /// Gets or sets the width of the model's main hidden representation.
+    /// </summary>
+    public int HiddenDim { get; set; }
+
+    /// <summary>
+    /// Gets or sets the number of attention heads.
+    /// </summary>
+    public int NumHeads { get; set; }
+
+    /// <summary>
+    /// Gets or sets the number of encoder layers.
+    /// </summary>
+    public int NumEncoderLayers { get; set; }
+
+    /// <summary>
+    /// Gets or sets the number of decoder layers, for models that generate audio or text.
+    /// </summary>
+    public int NumDecoderLayers { get; set; }
+
+    /// <summary>
+    /// Gets or sets the speaking-rate multiplier for synthesised speech. 1.0 is the model's
+    /// natural pace.
+    /// </summary>
+    /// <remarks>
+    /// <para><b>For Beginners:</b> Above 1.0 talks faster, below 1.0 slower.</para>
+    /// </remarks>
+    public double SpeakingRate { get; set; } = 1.0;
+
+    /// <summary>
+    /// Gets or sets the BCP-47 language tag the model is configured for, or null when the
+    /// model is language-agnostic.
+    /// </summary>
+    /// <remarks>
+    /// <para><b>For Beginners:</b> "en" for English, "fr" for French. Multilingual models
+    /// leave this null and detect the language themselves.</para>
+    /// </remarks>
+    public string? Language { get; set; }
+
+    /// <summary>
+    /// Throws if a signal parameter every audio model requires has been left unset.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when a required value is zero or negative, which means the derived options class
+    /// did not assign its model's published defaults.
+    /// </exception>
+    protected void ValidateCore()
+    {
+        Require(SampleRate, nameof(SampleRate));
+    }
+}

--- a/src/Models/Options/DocumentNeuralNetworkOptions.cs
+++ b/src/Models/Options/DocumentNeuralNetworkOptions.cs
@@ -141,7 +141,7 @@ public class DocumentNeuralNetworkOptions : ModelHyperparameterOptions
     /// <summary>
     /// Throws if a dimension every document model requires has been left unset.
     /// </summary>
-    /// <exception cref="InvalidOperationException">
+    /// <exception cref="ArgumentException">
     /// Thrown when a required dimension is zero or negative, which means the derived options
     /// class did not assign its paper defaults.
     /// </exception>

--- a/src/Models/Options/DocumentNeuralNetworkOptions.cs
+++ b/src/Models/Options/DocumentNeuralNetworkOptions.cs
@@ -41,6 +41,33 @@ namespace AiDotNet.Models.Options;
 /// </remarks>
 public class DocumentNeuralNetworkOptions : ModelHyperparameterOptions
 {
+    /// <summary>Initializes the shared document settings with their defaults.</summary>
+    public DocumentNeuralNetworkOptions()
+    {
+    }
+
+    /// <summary>Copies every shared document setting and inherited model setting.</summary>
+    /// <param name="other">The source options.</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="other"/> is null.</exception>
+    protected DocumentNeuralNetworkOptions(DocumentNeuralNetworkOptions other) : base(other)
+    {
+        ImageSize = other.ImageSize;
+        ImageWidth = other.ImageWidth;
+        ImageHeight = other.ImageHeight;
+        PatchSize = other.PatchSize;
+        MaxSequenceLength = other.MaxSequenceLength;
+        VocabSize = other.VocabSize;
+        HiddenDim = other.HiddenDim;
+        NumHeads = other.NumHeads;
+        NumLayers = other.NumLayers;
+        NumEncoderLayers = other.NumEncoderLayers;
+        NumDecoderLayers = other.NumDecoderLayers;
+        VisionDim = other.VisionDim;
+        VisionLayers = other.VisionLayers;
+        BackboneChannels = other.BackboneChannels;
+        NumClasses = other.NumClasses;
+    }
+
     /// <summary>
     /// Gets or sets the side length, in pixels, of the page image the model expects.
     /// </summary>

--- a/src/Models/Options/DocumentNeuralNetworkOptions.cs
+++ b/src/Models/Options/DocumentNeuralNetworkOptions.cs
@@ -1,8 +1,153 @@
 namespace AiDotNet.Models.Options;
 
 /// <summary>
-/// Base configuration options for document neural network models.
+/// Shared configuration for document models: OCR and text recognition, layout analysis,
+/// document question answering, table and chart understanding, and document VQA.
 /// </summary>
-public class DocumentNeuralNetworkOptions : NeuralNetworkOptions
+/// <remarks>
+/// <para>
+/// <b>For Beginners:</b> Document models read scanned pages and photographs of documents.
+/// They need to know how large the page image is, how much text they can produce, and how
+/// big their internal representations are. Each model's own options class ships the values
+/// from the paper that introduced it, so you do not normally set any of these.
+/// </para>
+/// <para>
+/// Derived options classes assign their paper's values in their parameterless constructor:
+/// <code>
+/// public class TrOCROptions : DocumentNeuralNetworkOptions
+/// {
+///     public TrOCROptions()
+///     {
+///         ImageSize = 384;
+///         VocabSize = 50265;      // RoBERTa tokenizer
+///         HiddenDim = 768;
+///         NumDecoderLayers = 12;
+///     }
+/// }
+/// </code>
+/// See <see cref="ModelHyperparameterOptions"/> for why these properties are non-nullable.
+/// </para>
+/// <para>
+/// This class already sits at the root of every options class under
+/// <c>src/Document/Options</c> — all 29 of them derive from it — so adding the shared
+/// knobs here reaches the whole area without touching the leaves.
+/// </para>
+/// <para>
+/// <b>Not to be confused with <c>DocumentModelOptions&lt;T&gt;</c>,</b> an earlier and now
+/// abandoned attempt at the same idea: it takes a type parameter it never uses, follows the
+/// nullable + <c>Effective*</c> pattern this design moves away from, and nothing derives
+/// from it. It is left in place for now and removed when the document models are wired.
+/// </para>
+/// </remarks>
+public class DocumentNeuralNetworkOptions : ModelHyperparameterOptions
 {
+    /// <summary>
+    /// Gets or sets the side length, in pixels, of the page image the model expects.
+    /// </summary>
+    /// <remarks>
+    /// <para><b>For Beginners:</b> Scanned pages are resized to this many pixels on a side
+    /// before the model reads them. Document models use larger values than ordinary vision
+    /// models — 1024 rather than 224 — because small text has to stay legible.</para>
+    /// </remarks>
+    public int ImageSize { get; set; }
+
+    /// <summary>
+    /// Gets or sets the input image width in pixels, for models that expect a non-square page.
+    /// </summary>
+    /// <remarks>
+    /// <para><b>For Beginners:</b> A single line of text cropped from a page is wide and short,
+    /// so line-level recognition models use an explicit width and height rather than a square.</para>
+    /// </remarks>
+    public int ImageWidth { get; set; }
+
+    /// <summary>
+    /// Gets or sets the input image height in pixels, for models that expect a non-square page.
+    /// </summary>
+    public int ImageHeight { get; set; }
+
+    /// <summary>
+    /// Gets or sets the side length, in pixels, of each square patch the page is divided into.
+    /// </summary>
+    public int PatchSize { get; set; }
+
+    /// <summary>
+    /// Gets or sets the longest sequence, in tokens, the model reads or produces.
+    /// </summary>
+    public int MaxSequenceLength { get; set; }
+
+    /// <summary>
+    /// Gets or sets the number of distinct tokens the model's tokenizer covers.
+    /// </summary>
+    /// <remarks>
+    /// <para><b>For Beginners:</b> 30522 is the BERT vocabulary, 50265 RoBERTa's, and 250002
+    /// the multilingual XLM-R vocabulary used by models that read many languages.</para>
+    /// </remarks>
+    public int VocabSize { get; set; }
+
+    /// <summary>
+    /// Gets or sets the width of the model's main hidden representation.
+    /// </summary>
+    public int HiddenDim { get; set; }
+
+    /// <summary>
+    /// Gets or sets the number of attention heads.
+    /// </summary>
+    public int NumHeads { get; set; }
+
+    /// <summary>
+    /// Gets or sets the total number of stacked blocks, for models with a single stack.
+    /// </summary>
+    public int NumLayers { get; set; }
+
+    /// <summary>
+    /// Gets or sets the number of encoder layers, for encoder-decoder models.
+    /// </summary>
+    /// <remarks>
+    /// <para><b>For Beginners:</b> The encoder looks at the page; the decoder writes out the
+    /// text. They are usually different depths.</para>
+    /// </remarks>
+    public int NumEncoderLayers { get; set; }
+
+    /// <summary>
+    /// Gets or sets the number of decoder layers, for encoder-decoder models.
+    /// </summary>
+    public int NumDecoderLayers { get; set; }
+
+    /// <summary>
+    /// Gets or sets the width of the vision tower's hidden representation.
+    /// </summary>
+    public int VisionDim { get; set; }
+
+    /// <summary>
+    /// Gets or sets the number of layers in the vision tower.
+    /// </summary>
+    public int VisionLayers { get; set; }
+
+    /// <summary>
+    /// Gets or sets the channel width of the convolutional backbone, for detection-style
+    /// models such as text detectors.
+    /// </summary>
+    public int BackboneChannels { get; set; }
+
+    /// <summary>
+    /// Gets or sets the number of output categories, for classification models.
+    /// </summary>
+    /// <remarks>
+    /// <para><b>For Beginners:</b> A layout model that labels each region as title, paragraph,
+    /// table, figure and so on uses one class per label.</para>
+    /// </remarks>
+    public int NumClasses { get; set; }
+
+    /// <summary>
+    /// Throws if a dimension every document model requires has been left unset.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when a required dimension is zero or negative, which means the derived options
+    /// class did not assign its paper defaults.
+    /// </exception>
+    protected void ValidateCore()
+    {
+        Require(MaxSequenceLength, nameof(MaxSequenceLength));
+        Require(HiddenDim, nameof(HiddenDim));
+    }
 }

--- a/src/Models/Options/ModelHyperparameterOptions.cs
+++ b/src/Models/Options/ModelHyperparameterOptions.cs
@@ -38,12 +38,26 @@ public abstract class ModelHyperparameterOptions : NeuralNetworkOptions
     public double MaxGradNorm { get; set; } = 1.0;
 
     /// <summary>
+    /// The constructor parameter name reported when validation fails.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Every model takes its configuration as a parameter called <c>options</c>, so an invalid
+    /// value always reached the model that way. Naming it keeps the exception actionable and
+    /// keeps the contract these constructors already had before their scalar parameters moved
+    /// here.
+    /// </para>
+    /// </remarks>
+    protected const string OptionsParameterName = "options";
+
+    /// <summary>
     /// Throws when a required dimension has been left unset.
     /// </summary>
     /// <param name="value">The value to check.</param>
     /// <param name="propertyName">The name of the property being checked.</param>
-    /// <exception cref="InvalidOperationException">
-    /// Thrown when <paramref name="value"/> is zero or negative.
+    /// <exception cref="ArgumentException">
+    /// Thrown when <paramref name="value"/> is zero or negative. Reported against the
+    /// <c>options</c> parameter, because that is how an invalid value reaches a model.
     /// </exception>
     /// <remarks>
     /// <para>
@@ -56,10 +70,11 @@ public abstract class ModelHyperparameterOptions : NeuralNetworkOptions
     {
         if (value <= 0)
         {
-            throw new InvalidOperationException(
+            throw new ArgumentException(
                 $"{GetType().Name}.{propertyName} is {value}, but it must be greater than zero. "
                     + $"Set it explicitly, or ensure {GetType().Name}'s parameterless constructor "
-                    + "assigns its model's published default.");
+                    + "assigns its model's published default.",
+                OptionsParameterName);
         }
     }
 
@@ -68,17 +83,18 @@ public abstract class ModelHyperparameterOptions : NeuralNetworkOptions
     /// </summary>
     /// <param name="value">The value to check.</param>
     /// <param name="propertyName">The name of the property being checked.</param>
-    /// <exception cref="InvalidOperationException">
+    /// <exception cref="ArgumentException">
     /// Thrown when <paramref name="value"/> is not a finite number greater than zero.
     /// </exception>
     protected void Require(double value, string propertyName)
     {
         if (double.IsNaN(value) || double.IsInfinity(value) || value <= 0.0)
         {
-            throw new InvalidOperationException(
+            throw new ArgumentException(
                 $"{GetType().Name}.{propertyName} is {value.ToString(System.Globalization.CultureInfo.InvariantCulture)}, "
                     + "but it must be a finite number greater than zero. Set it explicitly, or ensure "
-                    + $"{GetType().Name}'s parameterless constructor assigns its model's published default.");
+                    + $"{GetType().Name}'s parameterless constructor assigns its model's published default.",
+                OptionsParameterName);
         }
     }
 }

--- a/src/Models/Options/ModelHyperparameterOptions.cs
+++ b/src/Models/Options/ModelHyperparameterOptions.cs
@@ -1,0 +1,84 @@
+namespace AiDotNet.Models.Options;
+
+/// <summary>
+/// Base class for the per-model-family hyperparameter options: the sizes and shapes that
+/// come from the paper a model was published in.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>For Beginners:</b> Every model in this library ships with the settings from the
+/// research paper that introduced it, so you can use a model without configuring anything.
+/// This class holds the settings that apply to nearly every model, and the family classes
+/// that derive from it add the ones specific to a kind of model.
+/// </para>
+/// <para>
+/// <b>Pattern.</b> Properties here are non-nullable, and each concrete options class assigns
+/// its published defaults in its parameterless constructor. This differs deliberately from
+/// the nullable + <c>GetEffectiveX()</c> pattern used for infrastructure configuration
+/// (telemetry, profiling, AutoML): <c>null</c> there means "decide at runtime from the data
+/// or the hardware", which is meaningful for a batch size and meaningless for a layer count.
+/// </para>
+/// <para>
+/// <b>Every property here must be read by the model that owns it.</b> A property nobody
+/// reads is worse than no property, because it advertises configurability that does not
+/// exist. The options-surface ratchet test enforces this.
+/// </para>
+/// </remarks>
+public abstract class ModelHyperparameterOptions : NeuralNetworkOptions
+{
+    /// <summary>
+    /// Gets or sets the maximum global gradient norm, above which gradients are rescaled
+    /// during training. Zero or negative disables clipping.
+    /// </summary>
+    /// <remarks>
+    /// <para><b>For Beginners:</b> During training the model adjusts itself based on how wrong
+    /// it was. Occasionally that correction is enormous and destabilises everything learned so
+    /// far. Gradient clipping caps the size of a single correction. 1.0 is the usual choice.</para>
+    /// </remarks>
+    public double MaxGradNorm { get; set; } = 1.0;
+
+    /// <summary>
+    /// Throws when a required dimension has been left unset.
+    /// </summary>
+    /// <param name="value">The value to check.</param>
+    /// <param name="propertyName">The name of the property being checked.</param>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when <paramref name="value"/> is zero or negative.
+    /// </exception>
+    /// <remarks>
+    /// <para>
+    /// Fails loudly rather than letting a zero-width dimension through. A zero produces layers
+    /// that appear to build and then misbehave a long way from the cause, which is far more
+    /// expensive to diagnose than an exception naming the property.
+    /// </para>
+    /// </remarks>
+    protected void Require(int value, string propertyName)
+    {
+        if (value <= 0)
+        {
+            throw new InvalidOperationException(
+                $"{GetType().Name}.{propertyName} is {value}, but it must be greater than zero. "
+                    + $"Set it explicitly, or ensure {GetType().Name}'s parameterless constructor "
+                    + "assigns its model's published default.");
+        }
+    }
+
+    /// <summary>
+    /// Throws when a required rate or ratio has been left unset.
+    /// </summary>
+    /// <param name="value">The value to check.</param>
+    /// <param name="propertyName">The name of the property being checked.</param>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when <paramref name="value"/> is not a finite number greater than zero.
+    /// </exception>
+    protected void Require(double value, string propertyName)
+    {
+        if (double.IsNaN(value) || double.IsInfinity(value) || value <= 0.0)
+        {
+            throw new InvalidOperationException(
+                $"{GetType().Name}.{propertyName} is {value.ToString(System.Globalization.CultureInfo.InvariantCulture)}, "
+                    + "but it must be a finite number greater than zero. Set it explicitly, or ensure "
+                    + $"{GetType().Name}'s parameterless constructor assigns its model's published default.");
+        }
+    }
+}

--- a/src/Models/Options/ModelHyperparameterOptions.cs
+++ b/src/Models/Options/ModelHyperparameterOptions.cs
@@ -26,10 +26,25 @@ namespace AiDotNet.Models.Options;
 /// </remarks>
 public abstract class ModelHyperparameterOptions : NeuralNetworkOptions
 {
+    /// <summary>Initializes the shared hyperparameters with their defaults.</summary>
+    protected ModelHyperparameterOptions()
+    {
+    }
+
+    /// <summary>Copies the shared hyperparameters and inherited model settings.</summary>
+    /// <param name="other">The source options.</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="other"/> is null.</exception>
+    protected ModelHyperparameterOptions(ModelHyperparameterOptions other) : base(other)
+    {
+        MaxGradNorm = other.MaxGradNorm;
+    }
+
     /// <summary>
     /// Gets or sets the maximum global gradient norm, above which gradients are rescaled
     /// during training. Zero or negative disables clipping.
     /// </summary>
+    /// <value>Defaults to 1.0, a library safeguard rather than a model-specific paper value.
+    /// Zero or a negative value disables clipping.</value>
     /// <remarks>
     /// <para><b>For Beginners:</b> During training the model adjusts itself based on how wrong
     /// it was. Occasionally that correction is enormous and destabilises everything learned so
@@ -94,6 +109,36 @@ public abstract class ModelHyperparameterOptions : NeuralNetworkOptions
                 $"{GetType().Name}.{propertyName} is {value.ToString(System.Globalization.CultureInfo.InvariantCulture)}, "
                     + "but it must be a finite number greater than zero. Set it explicitly, or ensure "
                     + $"{GetType().Name}'s parameterless constructor assigns its model's published default.",
+                OptionsParameterName);
+        }
+    }
+
+    /// <summary>Requires a finite, non-negative setting, allowing zero to disable a penalty.</summary>
+    /// <param name="value">The value to check.</param>
+    /// <param name="propertyName">The name of the property being checked.</param>
+    /// <exception cref="ArgumentException">Thrown when the value is non-finite or negative.</exception>
+    protected void RequireNonNegative(double value, string propertyName)
+    {
+        if (double.IsNaN(value) || double.IsInfinity(value) || value < 0.0)
+        {
+            throw new ArgumentException(
+                $"{GetType().Name}.{propertyName} must be a finite number greater than or equal to zero.",
+                OptionsParameterName);
+        }
+    }
+
+    /// <summary>Requires a finite decay coefficient in the half-open interval [0, 1).</summary>
+    /// <param name="value">The value to check.</param>
+    /// <param name="propertyName">The name of the property being checked.</param>
+    /// <exception cref="ArgumentException">Thrown when the value is non-finite or outside [0, 1).</exception>
+    /// <remarks>Adam bias correction divides by one minus a power of this coefficient;
+    /// a coefficient of exactly one is therefore invalid, while zero is supported.</remarks>
+    protected void RequireDecayCoefficient(double value, string propertyName)
+    {
+        if (double.IsNaN(value) || double.IsInfinity(value) || value < 0.0 || value >= 1.0)
+        {
+            throw new ArgumentException(
+                $"{GetType().Name}.{propertyName} must be a finite number greater than or equal to zero and less than one.",
                 OptionsParameterName);
         }
     }

--- a/src/Models/Options/ModelOptions.cs
+++ b/src/Models/Options/ModelOptions.cs
@@ -2,6 +2,24 @@ namespace AiDotNet.Models.Options;
 
 public abstract class ModelOptions
 {
+    /// <summary>Initializes the shared model settings with their defaults.</summary>
+    protected ModelOptions()
+    {
+    }
+
+    /// <summary>Copies the settings owned by this base class.</summary>
+    /// <param name="other">The source options.</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="other"/> is null.</exception>
+    protected ModelOptions(ModelOptions other)
+    {
+        if (other is null)
+        {
+            throw new ArgumentNullException(nameof(other));
+        }
+
+        Seed = other.Seed;
+    }
+
     /// <summary>
     /// Gets or sets the random seed for reproducibility.
     /// </summary>

--- a/src/Models/Options/NeuralNetworkOptions.cs
+++ b/src/Models/Options/NeuralNetworkOptions.cs
@@ -16,6 +16,19 @@ namespace AiDotNet.Models.Options;
 /// </remarks>
 public class NeuralNetworkOptions : ModelOptions
 {
+    /// <summary>Initializes the shared neural-network settings with their defaults.</summary>
+    public NeuralNetworkOptions()
+    {
+    }
+
+    /// <summary>Copies the shared neural-network and model settings.</summary>
+    /// <param name="other">The source options.</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="other"/> is null.</exception>
+    public NeuralNetworkOptions(NeuralNetworkOptions other) : base(other)
+    {
+        EncoderLayerCount = other.EncoderLayerCount;
+    }
+
     /// <summary>
     /// When providing custom layers via Architecture.Layers, specifies where the encoder ends
     /// and the decoder begins. If null, defaults to half the total layer count.

--- a/src/NeuralNetworks/EagleLanguageModel.cs
+++ b/src/NeuralNetworks/EagleLanguageModel.cs
@@ -69,13 +69,8 @@ public partial class EagleLanguageModel<T> : TokenLanguageModelLayoutBase<T>
 
     public EagleLanguageModel(
         NeuralNetworkArchitecture<T> architecture,
-        int vocabSize = 65536,
-        int modelDimension = 256,
-        int numLayers = 4,
-        int numHeads = 8,
-        int maxSeqLength = 512,
-        ILossFunction<T>? lossFunction = null,
-        EagleOptions? options = null)
+        EagleOptions? options = null,
+        ILossFunction<T>? lossFunction = null)
         : base(architecture,
             // Raw-logit LM head → cross-entropy-with-logits (fused log-softmax + NLL), not the
             // TextGeneration default CategoricalCrossEntropy (which log()s un-normalized logits and
@@ -83,12 +78,13 @@ public partial class EagleLanguageModel<T> : TokenLanguageModelLayoutBase<T>
             lossFunction ?? new AiDotNet.LossFunctions.CrossEntropyWithLogitsLoss<T>())
     {
         _options = options ?? new EagleOptions();
+        _options.Validate();
         Options = _options;
-        _vocabSize = vocabSize;
-        _modelDimension = modelDimension;
-        _numLayers = numLayers;
-        _numHeads = numHeads;
-        _maxSeqLength = maxSeqLength;
+        _vocabSize = _options.VocabSize;
+        _modelDimension = _options.ModelDimension;
+        _numLayers = _options.NumLayers;
+        _numHeads = _options.NumHeads;
+        _maxSeqLength = _options.MaxSequenceLength;
         InitializeLayers();
     }
 

--- a/src/NeuralNetworks/FalconMambaLanguageModel.cs
+++ b/src/NeuralNetworks/FalconMambaLanguageModel.cs
@@ -68,16 +68,10 @@ public partial class FalconMambaLanguageModel<T> : TokenLanguageModelLayoutBase<
 
     public FalconMambaLanguageModel(
         NeuralNetworkArchitecture<T> architecture,
-        int vocabSize = 65024,
-        int modelDimension = 256,
-        int numLayers = 4,
-        int stateDimension = 16,
-        int expandFactor = 2,
-        int maxSeqLength = 512,
-        ILossFunction<T>? lossFunction = null,
-        FalconMambaOptions? options = null)
+        FalconMambaOptions? options = null,
+        ILossFunction<T>? lossFunction = null)
         : base(architecture,
-            // The LM head (DenseLayer(vocabSize, activation: null) in
+            // The LM head (DenseLayer(_options.VocabSize, activation: null) in
             // CreateFalconMambaLayers) emits RAW LOGITS, so the default loss
             // must be the logits-domain cross-entropy (log_softmax + NLL,
             // PyTorch nn.CrossEntropyLoss semantics). The TextGeneration
@@ -88,13 +82,14 @@ public partial class FalconMambaLanguageModel<T> : TokenLanguageModelLayoutBase<
             lossFunction ?? new LossFunctions.CrossEntropyWithLogitsLoss<T>())
     {
         _options = options ?? new FalconMambaOptions();
+        _options.Validate();
         Options = _options;
-        _vocabSize = vocabSize;
-        _modelDimension = modelDimension;
-        _numLayers = numLayers;
-        _stateDimension = stateDimension;
-        _expandFactor = expandFactor;
-        _maxSeqLength = maxSeqLength;
+        _vocabSize = _options.VocabSize;
+        _modelDimension = _options.ModelDimension;
+        _numLayers = _options.NumLayers;
+        _stateDimension = _options.StateDimension;
+        _expandFactor = _options.ExpandFactor;
+        _maxSeqLength = _options.MaxSequenceLength;
         InitializeLayers();
     }
 

--- a/src/NeuralNetworks/FinchLanguageModel.cs
+++ b/src/NeuralNetworks/FinchLanguageModel.cs
@@ -71,14 +71,8 @@ public partial class FinchLanguageModel<T> : TokenLanguageModelLayoutBase<T>
 
     public FinchLanguageModel(
         NeuralNetworkArchitecture<T> architecture,
-        int vocabSize = 65536,
-        int modelDimension = 256,
-        int numLayers = 4,
-        int numHeads = 8,
-        int maxSeqLength = 512,
-        ILossFunction<T>? lossFunction = null,
         FinchOptions? options = null,
-        double learningRate = 0.001)
+        ILossFunction<T>? lossFunction = null)
         : base(architecture,
             // Raw-logit LM head → cross-entropy-with-logits (fused log-softmax + NLL), not the
             // TextGeneration default CategoricalCrossEntropy (which log()s un-normalized logits and
@@ -86,13 +80,14 @@ public partial class FinchLanguageModel<T> : TokenLanguageModelLayoutBase<T>
             lossFunction ?? new AiDotNet.LossFunctions.CrossEntropyWithLogitsLoss<T>())
     {
         _options = options ?? new FinchOptions();
+        _options.Validate();
         Options = _options;
-        _vocabSize = vocabSize;
-        _modelDimension = modelDimension;
-        _numLayers = numLayers;
-        _numHeads = numHeads;
-        _maxSeqLength = maxSeqLength;
-        _learningRate = learningRate;
+        _vocabSize = _options.VocabSize;
+        _modelDimension = _options.ModelDimension;
+        _numLayers = _options.NumLayers;
+        _numHeads = _options.NumHeads;
+        _maxSeqLength = _options.MaxSequenceLength;
+        _learningRate = _options.LearningRate;
         InitializeLayers();
     }
 

--- a/src/NeuralNetworks/FinchLanguageModel.cs
+++ b/src/NeuralNetworks/FinchLanguageModel.cs
@@ -50,7 +50,6 @@ public partial class FinchLanguageModel<T> : TokenLanguageModelLayoutBase<T>
     private readonly int _numLayers;
     private readonly int _numHeads;
     private readonly int _maxSeqLength;
-    private readonly double _learningRate;
 
     /// <inheritdoc />
     public override bool SupportsTraining => true;
@@ -87,7 +86,6 @@ public partial class FinchLanguageModel<T> : TokenLanguageModelLayoutBase<T>
         _numLayers = _options.NumLayers;
         _numHeads = _options.NumHeads;
         _maxSeqLength = _options.MaxSequenceLength;
-        _learningRate = _options.LearningRate;
         InitializeLayers();
     }
 

--- a/src/NeuralNetworks/GLALanguageModel.cs
+++ b/src/NeuralNetworks/GLALanguageModel.cs
@@ -66,24 +66,20 @@ public partial class GLALanguageModel<T> : TokenLanguageModelLayoutBase<T>
 
     public GLALanguageModel(
         NeuralNetworkArchitecture<T> architecture,
-        int vocabSize = 50277,
-        int modelDimension = 256,
-        int numLayers = 4,
-        int numHeads = 8,
-        int maxSeqLength = 512,
-        ILossFunction<T>? lossFunction = null,
         GLAOptions? options = null,
+        ILossFunction<T>? lossFunction = null,
         IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>>? optimizer = null)
         : base(architecture,
             lossFunction ?? new AiDotNet.LossFunctions.CrossEntropyWithLogitsLoss<T>())
     {
         _options = options ?? new GLAOptions();
+        _options.Validate();
         Options = _options;
-        _vocabSize = vocabSize;
-        _modelDimension = modelDimension;
-        _numLayers = numLayers;
-        _numHeads = numHeads;
-        _maxSeqLength = maxSeqLength;
+        _vocabSize = _options.VocabSize;
+        _modelDimension = _options.ModelDimension;
+        _numLayers = _options.NumLayers;
+        _numHeads = _options.NumHeads;
+        _maxSeqLength = _options.MaxSequenceLength;
         // THE PAPER'S RATE, NOT THE LIBRARY DEFAULT. Constructing AdamWOptimizer with no options
         // silently trained at InitialLearningRate = 1e-3, which is neither the published rate nor
         // something the caller could change short of building the whole optimizer themselves.

--- a/src/NeuralNetworks/GatedDeltaNetLanguageModel.cs
+++ b/src/NeuralNetworks/GatedDeltaNetLanguageModel.cs
@@ -66,24 +66,20 @@ public partial class GatedDeltaNetLanguageModel<T> : TokenLanguageModelLayoutBas
 
     public GatedDeltaNetLanguageModel(
         NeuralNetworkArchitecture<T> architecture,
-        int vocabSize = 50277,
-        int modelDimension = 256,
-        int numLayers = 4,
-        int numHeads = 8,
-        int maxSeqLength = 512,
-        ILossFunction<T>? lossFunction = null,
         GatedDeltaNetOptions? options = null,
+        ILossFunction<T>? lossFunction = null,
         IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>>? optimizer = null)
         : base(architecture,
             lossFunction ?? new AiDotNet.LossFunctions.CrossEntropyWithLogitsLoss<T>())
     {
         _options = options ?? new GatedDeltaNetOptions();
+        _options.Validate();
         Options = _options;
-        _vocabSize = vocabSize;
-        _modelDimension = modelDimension;
-        _numLayers = numLayers;
-        _numHeads = numHeads;
-        _maxSeqLength = maxSeqLength;
+        _vocabSize = _options.VocabSize;
+        _modelDimension = _options.ModelDimension;
+        _numLayers = _options.NumLayers;
+        _numHeads = _options.NumHeads;
+        _maxSeqLength = _options.MaxSequenceLength;
         // THE PAPER'S RATE, NOT THE LIBRARY DEFAULT. Constructing AdamWOptimizer with no options
         // silently trained at InitialLearningRate = 1e-3, which is neither the published rate nor
         // something the caller could change short of building the whole optimizer themselves.

--- a/src/NeuralNetworks/GriffinLanguageModel.cs
+++ b/src/NeuralNetworks/GriffinLanguageModel.cs
@@ -65,23 +65,20 @@ public partial class GriffinLanguageModel<T> : TokenLanguageModelLayoutBase<T>
 
     public GriffinLanguageModel(
         NeuralNetworkArchitecture<T> architecture,
-        int vocabSize = 256000,
-        int modelDimension = 2048,
-        int numLayers = 24,
-        int maxSeqLength = 2048,
-        ILossFunction<T>? lossFunction = null,
         GriffinOptions? options = null,
+        ILossFunction<T>? lossFunction = null,
         IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>>? optimizer = null)
         : base(architecture,
             lossFunction ?? new AiDotNet.LossFunctions.CrossEntropyWithLogitsLoss<T>())
     {
         _options = options ?? new GriffinOptions();
+        _options.Validate();
         Options = _options;
-        _vocabSize = vocabSize;
-        _modelDimension = modelDimension;
+        _vocabSize = _options.VocabSize;
+        _modelDimension = _options.ModelDimension;
         _recurrenceDimension = _options.RecurrenceDimension;
-        _numLayers = numLayers;
-        _maxSeqLength = maxSeqLength;
+        _numLayers = _options.NumLayers;
+        _maxSeqLength = _options.MaxSequenceLength;
         if (_recurrenceDimension <= 0)
             throw new ArgumentOutOfRangeException(nameof(options), "RecurrenceDimension must be positive.");
         _optimizer = optimizer ?? CreateDefaultOptimizer();

--- a/src/NeuralNetworks/HawkLanguageModel.cs
+++ b/src/NeuralNetworks/HawkLanguageModel.cs
@@ -81,12 +81,8 @@ public partial class HawkLanguageModel<T> : TokenLanguageModelLayoutBase<T>
 
     public HawkLanguageModel(
         NeuralNetworkArchitecture<T> architecture,
-        int vocabSize = 256000,
-        int modelDimension = 2048,
-        int numLayers = 24,
-        int maxSeqLength = 2048,
-        ILossFunction<T>? lossFunction = null,
         HawkOptions? options = null,
+        ILossFunction<T>? lossFunction = null,
         IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>>? optimizer = null)
         : base(architecture,
             // Hawk trains on next-token logits. Keep softmax fused with cross-entropy so
@@ -95,12 +91,13 @@ public partial class HawkLanguageModel<T> : TokenLanguageModelLayoutBase<T>
             lossFunction ?? new AiDotNet.LossFunctions.CrossEntropyWithLogitsLoss<T>())
     {
         _options = options ?? new HawkOptions();
+        _options.Validate();
         Options = _options;
-        _vocabSize = vocabSize;
-        _modelDimension = modelDimension;
+        _vocabSize = _options.VocabSize;
+        _modelDimension = _options.ModelDimension;
         _recurrenceDimension = _options.RecurrenceDimension;
-        _numLayers = numLayers;
-        _maxSeqLength = maxSeqLength;
+        _numLayers = _options.NumLayers;
+        _maxSeqLength = _options.MaxSequenceLength;
         if (_recurrenceDimension <= 0)
             throw new ArgumentOutOfRangeException(nameof(options), "RecurrenceDimension must be positive.");
         _optimizer = optimizer ?? CreateDefaultOptimizer();

--- a/src/NeuralNetworks/JambaLanguageModel.cs
+++ b/src/NeuralNetworks/JambaLanguageModel.cs
@@ -66,14 +66,8 @@ public partial class JambaLanguageModel<T> : TokenLanguageModelLayoutBase<T>
 
     public JambaLanguageModel(
         NeuralNetworkArchitecture<T> architecture,
-        int vocabSize = 65536,
-        int modelDimension = 256,
-        int numLayers = 8,
-        int stateDimension = 16,
-        int attentionInterval = 8,
-        int maxSeqLength = 512,
-        ILossFunction<T>? lossFunction = null,
-        JambaOptions? options = null)
+        JambaOptions? options = null,
+        ILossFunction<T>? lossFunction = null)
         : base(architecture,
             // The LM head emits raw vocabulary logits. Match PyTorch's
             // nn.CrossEntropyLoss contract by applying log-softmax inside
@@ -81,13 +75,14 @@ public partial class JambaLanguageModel<T> : TokenLanguageModelLayoutBase<T>
             lossFunction ?? new LossFunctions.CrossEntropyWithLogitsLoss<T>())
     {
         _options = options ?? new JambaOptions();
+        _options.Validate();
         Options = _options;
-        _vocabSize = vocabSize;
-        _modelDimension = modelDimension;
-        _numLayers = numLayers;
-        _stateDimension = stateDimension;
-        _attentionInterval = attentionInterval;
-        _maxSeqLength = maxSeqLength;
+        _vocabSize = _options.VocabSize;
+        _modelDimension = _options.ModelDimension;
+        _numLayers = _options.NumLayers;
+        _stateDimension = _options.StateDimension;
+        _attentionInterval = _options.AttentionInterval;
+        _maxSeqLength = _options.MaxSequenceLength;
         InitializeLayers();
     }
 

--- a/src/NeuralNetworks/Mamba2LanguageModel.cs
+++ b/src/NeuralNetworks/Mamba2LanguageModel.cs
@@ -67,14 +67,8 @@ public partial class Mamba2LanguageModel<T> : TokenLanguageModelLayoutBase<T>
 
     public Mamba2LanguageModel(
         NeuralNetworkArchitecture<T> architecture,
-        int vocabSize = 50277,
-        int modelDimension = 256,
-        int numLayers = 4,
-        int stateDimension = 64,
-        int numHeads = 8,
-        int maxSeqLength = 512,
-        ILossFunction<T>? lossFunction = null,
-        Mamba2Options? options = null)
+        Mamba2Options? options = null,
+        ILossFunction<T>? lossFunction = null)
         : base(architecture,
             // Mamba-2's LM head emits RAW LOGITS (DenseLayer with no activation, see
             // LayerHelper.CreateMamba2Layers), so the loss must be cross-entropy-with-logits (fused
@@ -86,13 +80,14 @@ public partial class Mamba2LanguageModel<T> : TokenLanguageModelLayoutBase<T>
             lossFunction ?? new AiDotNet.LossFunctions.CrossEntropyWithLogitsLoss<T>())
     {
         _options = options ?? new Mamba2Options();
+        _options.Validate();
         Options = _options;
-        _vocabSize = vocabSize;
-        _modelDimension = modelDimension;
-        _numLayers = numLayers;
-        _stateDimension = stateDimension;
-        _numHeads = numHeads;
-        _maxSeqLength = maxSeqLength;
+        _vocabSize = _options.VocabSize;
+        _modelDimension = _options.ModelDimension;
+        _numLayers = _options.NumLayers;
+        _stateDimension = _options.StateDimension;
+        _numHeads = _options.NumHeads;
+        _maxSeqLength = _options.MaxSequenceLength;
         InitializeLayers();
     }
 

--- a/src/NeuralNetworks/MambaLanguageModel.cs
+++ b/src/NeuralNetworks/MambaLanguageModel.cs
@@ -67,16 +67,19 @@ public partial class MambaLanguageModel<T> : TokenLanguageModelLayoutBase<T>
 
     #region Constructors
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MambaLanguageModel{T}"/> class.
+    /// </summary>
+    /// <param name="architecture">The network architecture. Supply custom layers here to
+    /// override the default topology.</param>
+    /// <param name="options">The model's configuration. When null, <see cref="MambaOptions"/>
+    /// supplies this model's shipped defaults.</param>
+    /// <param name="lossFunction">The training loss. When null, cross-entropy-with-logits is
+    /// used, which is what this model's raw-logit head requires.</param>
     public MambaLanguageModel(
         NeuralNetworkArchitecture<T> architecture,
-        int vocabSize = 50277,
-        int modelDimension = 256,
-        int numLayers = 4,
-        int stateDimension = 16,
-        int expandFactor = 2,
-        int maxSeqLength = 512,
-        ILossFunction<T>? lossFunction = null,
-        MambaOptions? options = null)
+        MambaOptions? options = null,
+        ILossFunction<T>? lossFunction = null)
         : base(architecture,
             // Mamba's LM head emits RAW LOGITS (DenseLayer with no activation, see
             // LayerHelper.CreateMambaLayers), so the loss must be cross-entropy-with-logits (fused
@@ -88,19 +91,15 @@ public partial class MambaLanguageModel<T> : TokenLanguageModelLayoutBase<T>
             // TensorClamp has ZERO gradient, so those classes get no training signal at all.
             lossFunction ?? new AiDotNet.LossFunctions.CrossEntropyWithLogitsLoss<T>())
     {
-        if (vocabSize <= 0) throw new ArgumentException($"Vocabulary size ({vocabSize}) must be positive.", nameof(vocabSize));
-        if (modelDimension <= 0) throw new ArgumentException($"Model dimension ({modelDimension}) must be positive.", nameof(modelDimension));
-        if (numLayers <= 0) throw new ArgumentException($"Number of layers ({numLayers}) must be positive.", nameof(numLayers));
-        if (stateDimension <= 0) throw new ArgumentException($"State dimension ({stateDimension}) must be positive.", nameof(stateDimension));
-
         _options = options ?? new MambaOptions();
+        _options.Validate();
         Options = _options;
-        _vocabSize = vocabSize;
-        _modelDimension = modelDimension;
-        _numLayers = numLayers;
-        _stateDimension = stateDimension;
-        _expandFactor = expandFactor;
-        _maxSeqLength = maxSeqLength;
+        _vocabSize = _options.VocabSize;
+        _modelDimension = _options.ModelDimension;
+        _numLayers = _options.NumLayers;
+        _stateDimension = _options.StateDimension;
+        _expandFactor = _options.ExpandFactor;
+        _maxSeqLength = _options.MaxSequenceLength;
         InitializeLayers();
     }
 

--- a/src/NeuralNetworks/Options/EagleOptions.cs
+++ b/src/NeuralNetworks/Options/EagleOptions.cs
@@ -32,6 +32,13 @@ public class EagleOptions : SequenceModelOptions
         MaxSequenceLength = 512;
     }
 
+    /// <summary>Initializes an instance by copying every declared and inherited setting.</summary>
+    /// <param name="other">The source options.</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="other"/> is null.</exception>
+    public EagleOptions(EagleOptions other) : base(other)
+    {
+    }
+
     /// <summary>
     /// Throws if a value this model requires has been left unset or is not positive.
     /// </summary>

--- a/src/NeuralNetworks/Options/EagleOptions.cs
+++ b/src/NeuralNetworks/Options/EagleOptions.cs
@@ -5,6 +5,41 @@ namespace AiDotNet.NeuralNetworks.Options;
 /// <summary>
 /// Configuration options for the EagleLanguageModel.
 /// </summary>
-public class EagleOptions : NeuralNetworkOptions
+public class EagleOptions : SequenceModelOptions
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="EagleOptions"/> class carrying
+    /// this model's shipped defaults.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>For Beginners:</b> You do not need to set any of these. They are the values the
+    /// model has always used, moved here from its constructor so they can be seen and
+    /// changed in one place.
+    /// </para>
+    /// <para>
+    /// Carried over unchanged. Whether each matches the published paper is verified, and
+    /// corrected where it does not, in a later phase of issue #2090 — kept separate so a
+    /// change in behaviour is never buried in a mechanical move.
+    /// </para>
+    /// </remarks>
+    public EagleOptions()
+    {
+        VocabSize = 65536;
+        ModelDimension = 256;
+        NumLayers = 4;
+        NumHeads = 8;
+        MaxSequenceLength = 512;
+    }
+
+    /// <summary>
+    /// Throws if a value this model requires has been left unset or is not positive.
+    /// </summary>
+    /// <exception cref="ArgumentException">
+    /// Thrown when a required dimension is zero or negative.
+    /// </exception>
+    public void Validate()
+    {
+        ValidateCore(requiresHeads: true, requiresState: false);
+    }
 }

--- a/src/NeuralNetworks/Options/EmbeddingModelOptions.cs
+++ b/src/NeuralNetworks/Options/EmbeddingModelOptions.cs
@@ -1,0 +1,88 @@
+using AiDotNet.Models.Options;
+
+namespace AiDotNet.NeuralNetworks.Options;
+
+/// <summary>
+/// Shared configuration for text embedding and retrieval models (BGE, ColBERT, SGPT,
+/// SPLADE, SimCSE, Instructor, Matryoshka, Word2Vec, GloVe, FastText).
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>For Beginners:</b> An embedding model turns a piece of text into a list of numbers so
+/// that similar texts end up with similar lists. Search engines use this to find documents
+/// that mean the same thing as your query even when they use different words. The settings
+/// here are the model's size, and each model's own options class ships the values from its
+/// paper.
+/// </para>
+/// <para>
+/// Derived options classes assign their paper's values in their parameterless constructor.
+/// See <see cref="ModelHyperparameterOptions"/> for why these properties are non-nullable.
+/// </para>
+/// <para>
+/// <b>Pooling strategy is deliberately absent.</b> Two unrelated <c>PoolingStrategy</c>
+/// enums exist in this codebase — one nested inside <c>TransformerEmbeddingNetwork&lt;T&gt;</c>
+/// and one in <c>AiDotNet.VisionLanguage.Encoders</c>. Choosing between them, or unifying
+/// them, is part of wiring the embedding models rather than of declaring this base, so the
+/// property is added then rather than guessed at now.
+/// </para>
+/// </remarks>
+public abstract class EmbeddingModelOptions : ModelHyperparameterOptions
+{
+    /// <summary>
+    /// Gets or sets the number of distinct tokens the model's tokenizer covers.
+    /// </summary>
+    /// <remarks>
+    /// <para><b>For Beginners:</b> 30522 is the BERT vocabulary, which many of these models
+    /// inherit.</para>
+    /// </remarks>
+    public int VocabSize { get; set; }
+
+    /// <summary>
+    /// Gets or sets the length of the vector the model produces for a piece of text.
+    /// </summary>
+    /// <remarks>
+    /// <para><b>For Beginners:</b> The size of the output "fingerprint". 768 is the usual
+    /// choice for base-sized models; larger means more nuance and more storage per document.</para>
+    /// </remarks>
+    public int EmbeddingDimension { get; set; }
+
+    /// <summary>
+    /// Gets or sets the longest text, in tokens, the model will encode. Longer inputs are
+    /// truncated.
+    /// </summary>
+    public int MaxSequenceLength { get; set; }
+
+    /// <summary>
+    /// Gets or sets the number of stacked transformer blocks.
+    /// </summary>
+    public int NumLayers { get; set; }
+
+    /// <summary>
+    /// Gets or sets the number of attention heads per block.
+    /// </summary>
+    public int NumHeads { get; set; }
+
+    /// <summary>
+    /// Gets or sets the width of the feed-forward sub-layer inside each block.
+    /// </summary>
+    /// <remarks>
+    /// <para><b>For Beginners:</b> Each block briefly widens its representation to do more
+    /// computation, then narrows it again. In BERT-base this is 3072, four times the 768-wide
+    /// representation.</para>
+    /// </remarks>
+    public int FeedForwardDim { get; set; }
+
+    /// <summary>
+    /// Throws if a dimension every embedding model requires has been left unset.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when a required dimension is zero or negative, which means the derived options
+    /// class did not assign its paper defaults.
+    /// </exception>
+    protected void ValidateCore()
+    {
+        Require(VocabSize, nameof(VocabSize));
+        Require(EmbeddingDimension, nameof(EmbeddingDimension));
+        Require(MaxSequenceLength, nameof(MaxSequenceLength));
+    }
+}

--- a/src/NeuralNetworks/Options/EmbeddingModelOptions.cs
+++ b/src/NeuralNetworks/Options/EmbeddingModelOptions.cs
@@ -75,7 +75,7 @@ public abstract class EmbeddingModelOptions : ModelHyperparameterOptions
     /// <summary>
     /// Throws if a dimension every embedding model requires has been left unset.
     /// </summary>
-    /// <exception cref="InvalidOperationException">
+    /// <exception cref="ArgumentException">
     /// Thrown when a required dimension is zero or negative, which means the derived options
     /// class did not assign its paper defaults.
     /// </exception>

--- a/src/NeuralNetworks/Options/FalconMambaOptions.cs
+++ b/src/NeuralNetworks/Options/FalconMambaOptions.cs
@@ -33,6 +33,13 @@ public class FalconMambaOptions : SequenceModelOptions
         MaxSequenceLength = 512;
     }
 
+    /// <summary>Initializes an instance by copying every declared and inherited setting.</summary>
+    /// <param name="other">The source options.</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="other"/> is null.</exception>
+    public FalconMambaOptions(FalconMambaOptions other) : base(other)
+    {
+    }
+
     /// <summary>
     /// Throws if a value this model requires has been left unset or is not positive.
     /// </summary>

--- a/src/NeuralNetworks/Options/FalconMambaOptions.cs
+++ b/src/NeuralNetworks/Options/FalconMambaOptions.cs
@@ -5,6 +5,43 @@ namespace AiDotNet.NeuralNetworks.Options;
 /// <summary>
 /// Configuration options for the FalconMambaLanguageModel.
 /// </summary>
-public class FalconMambaOptions : NeuralNetworkOptions
+public class FalconMambaOptions : SequenceModelOptions
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="FalconMambaOptions"/> class carrying
+    /// this model's shipped defaults.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>For Beginners:</b> You do not need to set any of these. They are the values the
+    /// model has always used, moved here from its constructor so they can be seen and
+    /// changed in one place.
+    /// </para>
+    /// <para>
+    /// Carried over unchanged. Whether each matches the published paper is verified, and
+    /// corrected where it does not, in a later phase of issue #2090 — kept separate so a
+    /// change in behaviour is never buried in a mechanical move.
+    /// </para>
+    /// </remarks>
+    public FalconMambaOptions()
+    {
+        VocabSize = 65024;
+        ModelDimension = 256;
+        NumLayers = 4;
+        StateDimension = 16;
+        ExpandFactor = 2;
+        MaxSequenceLength = 512;
+    }
+
+    /// <summary>
+    /// Throws if a value this model requires has been left unset or is not positive.
+    /// </summary>
+    /// <exception cref="ArgumentException">
+    /// Thrown when a required dimension is zero or negative.
+    /// </exception>
+    public void Validate()
+    {
+        ValidateCore(requiresHeads: false, requiresState: true);
+        Require(ExpandFactor, nameof(ExpandFactor));
+    }
 }

--- a/src/NeuralNetworks/Options/FinchOptions.cs
+++ b/src/NeuralNetworks/Options/FinchOptions.cs
@@ -5,10 +5,18 @@ namespace AiDotNet.NeuralNetworks.Options;
 /// <summary>
 /// Configuration options for the FinchLanguageModel.
 /// </summary>
-public class FinchOptions : NeuralNetworkOptions
+public class FinchOptions : SequenceModelOptions
 {
     /// <summary>Initializes a new instance with default values.</summary>
-    public FinchOptions() { }
+    public FinchOptions()
+    {
+        VocabSize = 65536;
+        ModelDimension = 256;
+        NumLayers = 4;
+        NumHeads = 8;
+        MaxSequenceLength = 512;
+        LearningRate = 0.001;
+    }
 
     /// <summary>Initializes a new instance by copying every property from another instance.</summary>
     /// <param name="other">The instance to copy from.</param>
@@ -26,6 +34,11 @@ public class FinchOptions : NeuralNetworkOptions
         WeightDecay = other.WeightDecay;
         EnableGradientClipping = other.EnableGradientClipping;
         MaxGradientNorm = other.MaxGradientNorm;
+        VocabSize = other.VocabSize;
+        ModelDimension = other.ModelDimension;
+        NumLayers = other.NumLayers;
+        NumHeads = other.NumHeads;
+        MaxSequenceLength = other.MaxSequenceLength;
     }
 
     /// <summary>Gets or sets the maximum (peak) learning rate.</summary>
@@ -88,4 +101,15 @@ public class FinchOptions : NeuralNetworkOptions
     /// <summary>Gets or sets the maximum gradient norm. See <see cref="EnableGradientClipping"/>.</summary>
     /// <value>Defaults to 1.0. NOT a paper value -- see the remark on the property above.</value>
     public double MaxGradientNorm { get; set; } = 1.0;
+
+    /// <summary>
+    /// Throws if a value this model requires has been left unset or is not positive.
+    /// </summary>
+    /// <exception cref="ArgumentException">
+    /// Thrown when a required dimension is zero or negative.
+    /// </exception>
+    public void Validate()
+    {
+        ValidateCore(requiresHeads: true, requiresState: false);
+    }
 }

--- a/src/NeuralNetworks/Options/FinchOptions.cs
+++ b/src/NeuralNetworks/Options/FinchOptions.cs
@@ -15,18 +15,13 @@ public class FinchOptions : SequenceModelOptions
         NumLayers = 4;
         NumHeads = 8;
         MaxSequenceLength = 512;
-        LearningRate = 0.001;
     }
 
     /// <summary>Initializes a new instance by copying every property from another instance.</summary>
     /// <param name="other">The instance to copy from.</param>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="other"/> is null.</exception>
-    public FinchOptions(FinchOptions other)
+    public FinchOptions(FinchOptions other) : base(other)
     {
-        if (other is null)
-            throw new ArgumentNullException(nameof(other));
-        Seed = other.Seed;
-        EncoderLayerCount = other.EncoderLayerCount;
         LearningRate = other.LearningRate;
         MinLearningRate = other.MinLearningRate;
         Beta1 = other.Beta1;
@@ -34,11 +29,6 @@ public class FinchOptions : SequenceModelOptions
         WeightDecay = other.WeightDecay;
         EnableGradientClipping = other.EnableGradientClipping;
         MaxGradientNorm = other.MaxGradientNorm;
-        VocabSize = other.VocabSize;
-        ModelDimension = other.ModelDimension;
-        NumLayers = other.NumLayers;
-        NumHeads = other.NumHeads;
-        MaxSequenceLength = other.MaxSequenceLength;
     }
 
     /// <summary>Gets or sets the maximum (peak) learning rate.</summary>

--- a/src/NeuralNetworks/Options/GLAOptions.cs
+++ b/src/NeuralNetworks/Options/GLAOptions.cs
@@ -5,12 +5,19 @@ namespace AiDotNet.NeuralNetworks.Options;
 /// <summary>
 /// Configuration options for the GLALanguageModel.
 /// </summary>
-public class GLAOptions : NeuralNetworkOptions
+public class GLAOptions : SequenceModelOptions
 {
     /// <summary>
     /// Initializes a new instance with default values.
     /// </summary>
-    public GLAOptions() { }
+    public GLAOptions()
+    {
+        VocabSize = 50277;
+        ModelDimension = 256;
+        NumLayers = 4;
+        NumHeads = 8;
+        MaxSequenceLength = 512;
+    }
 
     /// <summary>
     /// Initializes a new instance by copying every property from another instance.
@@ -34,6 +41,11 @@ public class GLAOptions : NeuralNetworkOptions
         Seed = other.Seed;
         EncoderLayerCount = other.EncoderLayerCount;
         LearningRate = other.LearningRate;
+        VocabSize = other.VocabSize;
+        ModelDimension = other.ModelDimension;
+        NumLayers = other.NumLayers;
+        NumHeads = other.NumHeads;
+        MaxSequenceLength = other.MaxSequenceLength;
     }
 
     /// <summary>
@@ -51,4 +63,15 @@ public class GLAOptions : NeuralNetworkOptions
     /// value the paper's authors used, so training here starts from the same recipe they published.</para>
     /// </remarks>
     public double LearningRate { get; set; } = 3e-4;
+
+    /// <summary>
+    /// Throws if a value this model requires has been left unset or is not positive.
+    /// </summary>
+    /// <exception cref="ArgumentException">
+    /// Thrown when a required dimension is zero or negative.
+    /// </exception>
+    public void Validate()
+    {
+        ValidateCore(requiresHeads: true, requiresState: false);
+    }
 }

--- a/src/NeuralNetworks/Options/GLAOptions.cs
+++ b/src/NeuralNetworks/Options/GLAOptions.cs
@@ -27,25 +27,13 @@ public class GLAOptions : SequenceModelOptions
     /// Thrown when <paramref name="other"/> is null.
     /// </exception>
     /// <remarks>
-    /// <see cref="LearningRate"/> IS COPIED HERE, AND MUST STAY COPIED. This constructor is what
-    /// <c>GLALanguageModel&lt;T&gt;.CreateNewInstance</c> calls, so a property
-    /// missing from it is not merely absent from the clone -- the clone silently reverts to the
-    /// default while the original keeps the configured value, and nothing reports the divergence.
-    /// A model cloned for evaluation would then train at a different rate than the one it was
-    /// cloned from.
+    /// Copies <see cref="LearningRate"/> here and delegates inherited settings to the base copy
+    /// constructor. Callers can derive a new configuration without silently reverting any value
+    /// to its default. This options-copy contract is independent of the generated model clone plan.
     /// </remarks>
-    public GLAOptions(GLAOptions other)
+    public GLAOptions(GLAOptions other) : base(other)
     {
-        if (other is null)
-            throw new ArgumentNullException(nameof(other));
-        Seed = other.Seed;
-        EncoderLayerCount = other.EncoderLayerCount;
         LearningRate = other.LearningRate;
-        VocabSize = other.VocabSize;
-        ModelDimension = other.ModelDimension;
-        NumLayers = other.NumLayers;
-        NumHeads = other.NumHeads;
-        MaxSequenceLength = other.MaxSequenceLength;
     }
 
     /// <summary>
@@ -56,8 +44,9 @@ public class GLAOptions : SequenceModelOptions
     /// <para>
     /// The model previously constructed <c>AdamWOptimizer</c> with no options at all, so it trained at
     /// the library-wide AdamW default of 1e-3 -- neither the published rate nor reachable by a caller
-    /// who passed <c>options</c> but let the optimizer default. Supplying your own optimizer still wins;
-    /// this value is only consulted when the model has to build one.
+    /// who passed <c>options</c> but let the optimizer default. A supplied optimizer still controls
+    /// the actual training rate; the stored options must nevertheless pass <see cref="Validate"/>,
+    /// including a finite, positive learning rate, before model construction.
     /// </para>
     /// <para><b>For Beginners:</b> How big a step the model takes each time it learns. The default is the
     /// value the paper's authors used, so training here starts from the same recipe they published.</para>
@@ -65,13 +54,15 @@ public class GLAOptions : SequenceModelOptions
     public double LearningRate { get; set; } = 3e-4;
 
     /// <summary>
-    /// Throws if a value this model requires has been left unset or is not positive.
+    /// Throws if a required model dimension or consumed training setting is invalid.
     /// </summary>
     /// <exception cref="ArgumentException">
-    /// Thrown when a required dimension is zero or negative.
+    /// Thrown when a required dimension is non-positive, or a consumed numeric setting is
+    /// non-finite or outside its supported range. The message identifies the invalid property.
     /// </exception>
     public void Validate()
     {
         ValidateCore(requiresHeads: true, requiresState: false);
+        Require(LearningRate, nameof(LearningRate));
     }
 }

--- a/src/NeuralNetworks/Options/GanOptions.cs
+++ b/src/NeuralNetworks/Options/GanOptions.cs
@@ -75,7 +75,7 @@ public abstract class GanOptions : ModelHyperparameterOptions
     /// <summary>
     /// Throws if a dimension every GAN requires has been left unset.
     /// </summary>
-    /// <exception cref="InvalidOperationException">
+    /// <exception cref="ArgumentException">
     /// Thrown when a required dimension is zero or negative, which means the derived options
     /// class did not assign its paper defaults.
     /// </exception>

--- a/src/NeuralNetworks/Options/GanOptions.cs
+++ b/src/NeuralNetworks/Options/GanOptions.cs
@@ -1,0 +1,88 @@
+using AiDotNet.Models.Options;
+
+namespace AiDotNet.NeuralNetworks.Options;
+
+/// <summary>
+/// Shared configuration for generative adversarial networks (DCGAN, WGAN, WGAN-GP, BigGAN,
+/// SAGAN, StyleGAN, ProgressiveGAN, InfoGAN, Pix2Pix, CycleGAN).
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>For Beginners:</b> A GAN trains two networks against each other. The generator invents
+/// images; the discriminator (sometimes called the critic) tries to tell real images from
+/// invented ones. Each gets better because the other does. The settings here describe how
+/// big each of the two networks is and how they are trained.
+/// </para>
+/// <para>
+/// Derived options classes assign their paper's values in their parameterless constructor.
+/// See <see cref="ModelHyperparameterOptions"/> for why these properties are non-nullable.
+/// </para>
+/// </remarks>
+public abstract class GanOptions : ModelHyperparameterOptions
+{
+    /// <summary>
+    /// Gets or sets the length of the random noise vector the generator starts from.
+    /// </summary>
+    /// <remarks>
+    /// <para><b>For Beginners:</b> The generator turns a list of random numbers into an image.
+    /// This is how many random numbers it starts with — the "seed idea" for one image. 100 and
+    /// 128 are common; StyleGAN uses 512.</para>
+    /// </remarks>
+    public int LatentSize { get; set; }
+
+    /// <summary>
+    /// Gets or sets the base channel count of the generator. Layers scale up from this.
+    /// </summary>
+    /// <remarks>
+    /// <para><b>For Beginners:</b> Roughly how wide the image-making network is. Bigger means
+    /// more detail and slower training.</para>
+    /// </remarks>
+    public int GeneratorChannels { get; set; }
+
+    /// <summary>
+    /// Gets or sets the base channel count of the discriminator or critic.
+    /// </summary>
+    public int DiscriminatorChannels { get; set; }
+
+    /// <summary>
+    /// Gets or sets the number of colour channels in the generated image.
+    /// </summary>
+    /// <remarks>
+    /// <para><b>For Beginners:</b> 3 for colour, 1 for greyscale.</para>
+    /// </remarks>
+    public int ImageChannels { get; set; } = 3;
+
+    /// <summary>
+    /// Gets or sets how many discriminator or critic updates run per generator update.
+    /// </summary>
+    /// <remarks>
+    /// <para><b>For Beginners:</b> Wasserstein GANs train the critic several times for each
+    /// time they train the generator, which keeps the two from getting out of step. The WGAN
+    /// paper uses 5. Models that update both once per step leave this unset.</para>
+    /// </remarks>
+    public int CriticIterations { get; set; }
+
+    /// <summary>
+    /// Gets or sets the learning rate the adversarial pair starts training at.
+    /// </summary>
+    /// <remarks>
+    /// <para><b>For Beginners:</b> How big a step the networks take when correcting themselves.
+    /// GANs are unusually sensitive to this; 0.0002 with the Adam optimizer is the value most
+    /// GAN papers settled on.</para>
+    /// </remarks>
+    public double InitialLearningRate { get; set; }
+
+    /// <summary>
+    /// Throws if a dimension every GAN requires has been left unset.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when a required dimension is zero or negative, which means the derived options
+    /// class did not assign its paper defaults.
+    /// </exception>
+    protected void ValidateCore()
+    {
+        Require(LatentSize, nameof(LatentSize));
+        Require(ImageChannels, nameof(ImageChannels));
+        Require(InitialLearningRate, nameof(InitialLearningRate));
+    }
+}

--- a/src/NeuralNetworks/Options/GatedDeltaNetOptions.cs
+++ b/src/NeuralNetworks/Options/GatedDeltaNetOptions.cs
@@ -5,12 +5,19 @@ namespace AiDotNet.NeuralNetworks.Options;
 /// <summary>
 /// Configuration options for the GatedDeltaNetLanguageModel.
 /// </summary>
-public class GatedDeltaNetOptions : NeuralNetworkOptions
+public class GatedDeltaNetOptions : SequenceModelOptions
 {
     /// <summary>
     /// Initializes a new instance with default values.
     /// </summary>
-    public GatedDeltaNetOptions() { }
+    public GatedDeltaNetOptions()
+    {
+        VocabSize = 50277;
+        ModelDimension = 256;
+        NumLayers = 4;
+        NumHeads = 8;
+        MaxSequenceLength = 512;
+    }
 
     /// <summary>
     /// Initializes a new instance by copying every property from another instance.
@@ -34,6 +41,11 @@ public class GatedDeltaNetOptions : NeuralNetworkOptions
         Seed = other.Seed;
         EncoderLayerCount = other.EncoderLayerCount;
         LearningRate = other.LearningRate;
+        VocabSize = other.VocabSize;
+        ModelDimension = other.ModelDimension;
+        NumLayers = other.NumLayers;
+        NumHeads = other.NumHeads;
+        MaxSequenceLength = other.MaxSequenceLength;
     }
 
     /// <summary>
@@ -51,4 +63,15 @@ public class GatedDeltaNetOptions : NeuralNetworkOptions
     /// value the paper's authors used, so training here starts from the same recipe they published.</para>
     /// </remarks>
     public double LearningRate { get; set; } = 3e-4;
+
+    /// <summary>
+    /// Throws if a value this model requires has been left unset or is not positive.
+    /// </summary>
+    /// <exception cref="ArgumentException">
+    /// Thrown when a required dimension is zero or negative.
+    /// </exception>
+    public void Validate()
+    {
+        ValidateCore(requiresHeads: true, requiresState: false);
+    }
 }

--- a/src/NeuralNetworks/Options/GatedDeltaNetOptions.cs
+++ b/src/NeuralNetworks/Options/GatedDeltaNetOptions.cs
@@ -27,25 +27,13 @@ public class GatedDeltaNetOptions : SequenceModelOptions
     /// Thrown when <paramref name="other"/> is null.
     /// </exception>
     /// <remarks>
-    /// <see cref="LearningRate"/> IS COPIED HERE, AND MUST STAY COPIED. This constructor is what
-    /// <c>GatedDeltaNetLanguageModel&lt;T&gt;.CreateNewInstance</c> calls, so a property
-    /// missing from it is not merely absent from the clone -- the clone silently reverts to the
-    /// default while the original keeps the configured value, and nothing reports the divergence.
-    /// A model cloned for evaluation would then train at a different rate than the one it was
-    /// cloned from.
+    /// Copies <see cref="LearningRate"/> here and delegates inherited settings to the base copy
+    /// constructor. Callers can derive a new configuration without silently reverting any value
+    /// to its default. This options-copy contract is independent of the generated model clone plan.
     /// </remarks>
-    public GatedDeltaNetOptions(GatedDeltaNetOptions other)
+    public GatedDeltaNetOptions(GatedDeltaNetOptions other) : base(other)
     {
-        if (other is null)
-            throw new ArgumentNullException(nameof(other));
-        Seed = other.Seed;
-        EncoderLayerCount = other.EncoderLayerCount;
         LearningRate = other.LearningRate;
-        VocabSize = other.VocabSize;
-        ModelDimension = other.ModelDimension;
-        NumLayers = other.NumLayers;
-        NumHeads = other.NumHeads;
-        MaxSequenceLength = other.MaxSequenceLength;
     }
 
     /// <summary>
@@ -56,8 +44,9 @@ public class GatedDeltaNetOptions : SequenceModelOptions
     /// <para>
     /// The model previously constructed <c>AdamWOptimizer</c> with no options at all, so it trained at
     /// the library-wide AdamW default of 1e-3 -- neither the published rate nor reachable by a caller
-    /// who passed <c>options</c> but let the optimizer default. Supplying your own optimizer still wins;
-    /// this value is only consulted when the model has to build one.
+    /// who passed <c>options</c> but let the optimizer default. A supplied optimizer still controls
+    /// the actual training rate; the stored options must nevertheless pass <see cref="Validate"/>,
+    /// including a finite, positive learning rate, before model construction.
     /// </para>
     /// <para><b>For Beginners:</b> How big a step the model takes each time it learns. The default is the
     /// value the paper's authors used, so training here starts from the same recipe they published.</para>
@@ -65,13 +54,15 @@ public class GatedDeltaNetOptions : SequenceModelOptions
     public double LearningRate { get; set; } = 3e-4;
 
     /// <summary>
-    /// Throws if a value this model requires has been left unset or is not positive.
+    /// Throws if a required model dimension or consumed training setting is invalid.
     /// </summary>
     /// <exception cref="ArgumentException">
-    /// Thrown when a required dimension is zero or negative.
+    /// Thrown when a required dimension is non-positive, or a consumed numeric setting is
+    /// non-finite or outside its supported range. The message identifies the invalid property.
     /// </exception>
     public void Validate()
     {
         ValidateCore(requiresHeads: true, requiresState: false);
+        Require(LearningRate, nameof(LearningRate));
     }
 }

--- a/src/NeuralNetworks/Options/GriffinOptions.cs
+++ b/src/NeuralNetworks/Options/GriffinOptions.cs
@@ -48,12 +48,9 @@ public class GriffinOptions : SequenceModelOptions
 
     /// <summary>Initializes an options instance by copying inherited configuration.</summary>
     /// <param name="other">The source options.</param>
-    public GriffinOptions(GriffinOptions other)
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="other"/> is null.</exception>
+    public GriffinOptions(GriffinOptions other) : base(other)
     {
-        if (other is null)
-            throw new ArgumentNullException(nameof(other));
-        Seed = other.Seed;
-        EncoderLayerCount = other.EncoderLayerCount;
         RecurrenceDimension = other.RecurrenceDimension;
         LearningRate = other.LearningRate;
         WeightDecay = other.WeightDecay;
@@ -62,20 +59,26 @@ public class GriffinOptions : SequenceModelOptions
         Epsilon = other.Epsilon;
         EnableGradientClipping = other.EnableGradientClipping;
         MaxGradientNorm = other.MaxGradientNorm;
-        VocabSize = other.VocabSize;
-        ModelDimension = other.ModelDimension;
-        NumLayers = other.NumLayers;
-        MaxSequenceLength = other.MaxSequenceLength;
     }
 
     /// <summary>
-    /// Throws if a value this model requires has been left unset or is not positive.
+    /// Throws if a required model dimension or consumed training setting is invalid.
     /// </summary>
     /// <exception cref="ArgumentException">
-    /// Thrown when a required dimension is zero or negative.
+    /// Thrown when a required dimension is non-positive, or a consumed numeric setting is
+    /// non-finite or outside its supported range. The message identifies the invalid property.
     /// </exception>
     public void Validate()
     {
         ValidateCore(requiresHeads: false, requiresState: false);
+        Require(LearningRate, nameof(LearningRate));
+        RequireNonNegative(WeightDecay, nameof(WeightDecay));
+        RequireDecayCoefficient(Beta1, nameof(Beta1));
+        RequireDecayCoefficient(Beta2, nameof(Beta2));
+        Require(Epsilon, nameof(Epsilon));
+        if (EnableGradientClipping)
+        {
+            Require(MaxGradientNorm, nameof(MaxGradientNorm));
+        }
     }
 }

--- a/src/NeuralNetworks/Options/GriffinOptions.cs
+++ b/src/NeuralNetworks/Options/GriffinOptions.cs
@@ -5,7 +5,7 @@ namespace AiDotNet.NeuralNetworks.Options;
 /// <summary>
 /// Configuration options for the GriffinLanguageModel.
 /// </summary>
-public class GriffinOptions : NeuralNetworkOptions
+public class GriffinOptions : SequenceModelOptions
 {
     /// <summary>
     /// Gets or sets the RG-LRU width. The default 2560 is the published 1.3B
@@ -38,7 +38,13 @@ public class GriffinOptions : NeuralNetworkOptions
     public double MaxGradientNorm { get; set; } = 1.0;
 
     /// <summary>Initializes an options instance with default values.</summary>
-    public GriffinOptions() { }
+    public GriffinOptions()
+    {
+        VocabSize = 256000;
+        ModelDimension = 2048;
+        NumLayers = 24;
+        MaxSequenceLength = 2048;
+    }
 
     /// <summary>Initializes an options instance by copying inherited configuration.</summary>
     /// <param name="other">The source options.</param>
@@ -56,5 +62,20 @@ public class GriffinOptions : NeuralNetworkOptions
         Epsilon = other.Epsilon;
         EnableGradientClipping = other.EnableGradientClipping;
         MaxGradientNorm = other.MaxGradientNorm;
+        VocabSize = other.VocabSize;
+        ModelDimension = other.ModelDimension;
+        NumLayers = other.NumLayers;
+        MaxSequenceLength = other.MaxSequenceLength;
+    }
+
+    /// <summary>
+    /// Throws if a value this model requires has been left unset or is not positive.
+    /// </summary>
+    /// <exception cref="ArgumentException">
+    /// Thrown when a required dimension is zero or negative.
+    /// </exception>
+    public void Validate()
+    {
+        ValidateCore(requiresHeads: false, requiresState: false);
     }
 }

--- a/src/NeuralNetworks/Options/HawkOptions.cs
+++ b/src/NeuralNetworks/Options/HawkOptions.cs
@@ -48,12 +48,9 @@ public class HawkOptions : SequenceModelOptions
 
     /// <summary>Initializes an options instance by copying inherited configuration.</summary>
     /// <param name="other">The source options.</param>
-    public HawkOptions(HawkOptions other)
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="other"/> is null.</exception>
+    public HawkOptions(HawkOptions other) : base(other)
     {
-        if (other is null)
-            throw new ArgumentNullException(nameof(other));
-        Seed = other.Seed;
-        EncoderLayerCount = other.EncoderLayerCount;
         RecurrenceDimension = other.RecurrenceDimension;
         LearningRate = other.LearningRate;
         WeightDecay = other.WeightDecay;
@@ -62,20 +59,26 @@ public class HawkOptions : SequenceModelOptions
         Epsilon = other.Epsilon;
         EnableGradientClipping = other.EnableGradientClipping;
         MaxGradientNorm = other.MaxGradientNorm;
-        VocabSize = other.VocabSize;
-        ModelDimension = other.ModelDimension;
-        NumLayers = other.NumLayers;
-        MaxSequenceLength = other.MaxSequenceLength;
     }
 
     /// <summary>
-    /// Throws if a value this model requires has been left unset or is not positive.
+    /// Throws if a required model dimension or consumed training setting is invalid.
     /// </summary>
     /// <exception cref="ArgumentException">
-    /// Thrown when a required dimension is zero or negative.
+    /// Thrown when a required dimension is non-positive, or a consumed numeric setting is
+    /// non-finite or outside its supported range. The message identifies the invalid property.
     /// </exception>
     public void Validate()
     {
         ValidateCore(requiresHeads: false, requiresState: false);
+        Require(LearningRate, nameof(LearningRate));
+        RequireNonNegative(WeightDecay, nameof(WeightDecay));
+        RequireDecayCoefficient(Beta1, nameof(Beta1));
+        RequireDecayCoefficient(Beta2, nameof(Beta2));
+        Require(Epsilon, nameof(Epsilon));
+        if (EnableGradientClipping)
+        {
+            Require(MaxGradientNorm, nameof(MaxGradientNorm));
+        }
     }
 }

--- a/src/NeuralNetworks/Options/HawkOptions.cs
+++ b/src/NeuralNetworks/Options/HawkOptions.cs
@@ -5,7 +5,7 @@ namespace AiDotNet.NeuralNetworks.Options;
 /// <summary>
 /// Configuration options for the HawkLanguageModel.
 /// </summary>
-public class HawkOptions : NeuralNetworkOptions
+public class HawkOptions : SequenceModelOptions
 {
     /// <summary>
     /// Gets or sets the RG-LRU width. The default 2560 is the published 1.3B
@@ -38,7 +38,13 @@ public class HawkOptions : NeuralNetworkOptions
     public double MaxGradientNorm { get; set; } = 1.0;
 
     /// <summary>Initializes an options instance with default values.</summary>
-    public HawkOptions() { }
+    public HawkOptions()
+    {
+        VocabSize = 256000;
+        ModelDimension = 2048;
+        NumLayers = 24;
+        MaxSequenceLength = 2048;
+    }
 
     /// <summary>Initializes an options instance by copying inherited configuration.</summary>
     /// <param name="other">The source options.</param>
@@ -56,5 +62,20 @@ public class HawkOptions : NeuralNetworkOptions
         Epsilon = other.Epsilon;
         EnableGradientClipping = other.EnableGradientClipping;
         MaxGradientNorm = other.MaxGradientNorm;
+        VocabSize = other.VocabSize;
+        ModelDimension = other.ModelDimension;
+        NumLayers = other.NumLayers;
+        MaxSequenceLength = other.MaxSequenceLength;
+    }
+
+    /// <summary>
+    /// Throws if a value this model requires has been left unset or is not positive.
+    /// </summary>
+    /// <exception cref="ArgumentException">
+    /// Thrown when a required dimension is zero or negative.
+    /// </exception>
+    public void Validate()
+    {
+        ValidateCore(requiresHeads: false, requiresState: false);
     }
 }

--- a/src/NeuralNetworks/Options/JambaOptions.cs
+++ b/src/NeuralNetworks/Options/JambaOptions.cs
@@ -5,6 +5,42 @@ namespace AiDotNet.NeuralNetworks.Options;
 /// <summary>
 /// Configuration options for the JambaLanguageModel.
 /// </summary>
-public class JambaOptions : NeuralNetworkOptions
+public class JambaOptions : SequenceModelOptions
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="JambaOptions"/> class carrying
+    /// this model's shipped defaults.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>For Beginners:</b> You do not need to set any of these. They are the values the
+    /// model has always used, moved here from its constructor so they can be seen and
+    /// changed in one place.
+    /// </para>
+    /// <para>
+    /// Carried over unchanged. Whether each matches the published paper is verified, and
+    /// corrected where it does not, in a later phase of issue #2090 — kept separate so a
+    /// change in behaviour is never buried in a mechanical move.
+    /// </para>
+    /// </remarks>
+    public JambaOptions()
+    {
+        VocabSize = 65536;
+        ModelDimension = 256;
+        NumLayers = 8;
+        StateDimension = 16;
+        AttentionInterval = 8;
+        MaxSequenceLength = 512;
+    }
+
+    /// <summary>
+    /// Throws if a value this model requires has been left unset or is not positive.
+    /// </summary>
+    /// <exception cref="ArgumentException">
+    /// Thrown when a required dimension is zero or negative.
+    /// </exception>
+    public void Validate()
+    {
+        ValidateCore(requiresHeads: false, requiresState: true);
+    }
 }

--- a/src/NeuralNetworks/Options/JambaOptions.cs
+++ b/src/NeuralNetworks/Options/JambaOptions.cs
@@ -3,8 +3,20 @@ using AiDotNet.Models.Options;
 namespace AiDotNet.NeuralNetworks.Options;
 
 /// <summary>
-/// Configuration options for the JambaLanguageModel.
+/// Configures the dimensions and attention spacing of the Jamba language model.
 /// </summary>
+/// <remarks>
+/// <para><b>For Beginners:</b> Jamba combines a compact recurrent memory with attention,
+/// which can look back at individual tokens. <see cref="SequenceModelOptions.AttentionInterval"/>
+/// controls how frequently this model inserts an attention block.</para>
+/// <para>Lieber et al., <i>Jamba: A Hybrid Transformer-Mamba Language Model</i> (2024),
+/// describe interleaved Transformer/Mamba layers and mixture-of-experts feed-forward layers.
+/// The original release has 52 billion total parameters and 12 billion active per token.
+/// These options expose the library's sequence dimensions, not the paper's complete MoE
+/// configuration. The existing 256-wide, eight-layer defaults remain small library defaults,
+/// not a reproduction of that checkpoint.</para>
+/// </remarks>
+/// <seealso href="https://arxiv.org/abs/2403.19887">Original Jamba paper.</seealso>
 public class JambaOptions : SequenceModelOptions
 {
     /// <summary>
@@ -33,14 +45,23 @@ public class JambaOptions : SequenceModelOptions
         MaxSequenceLength = 512;
     }
 
+    /// <summary>Initializes an instance by copying every declared and inherited setting.</summary>
+    /// <param name="other">The source options.</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="other"/> is null.</exception>
+    public JambaOptions(JambaOptions other) : base(other)
+    {
+    }
+
     /// <summary>
-    /// Throws if a value this model requires has been left unset or is not positive.
+    /// Throws if a required model dimension or consumed training setting is invalid.
     /// </summary>
     /// <exception cref="ArgumentException">
-    /// Thrown when a required dimension is zero or negative.
+    /// Thrown when a required dimension is non-positive, or a consumed numeric setting is
+    /// non-finite or outside its supported range. The message identifies the invalid property.
     /// </exception>
     public void Validate()
     {
         ValidateCore(requiresHeads: false, requiresState: true);
+        Require(AttentionInterval, nameof(AttentionInterval));
     }
 }

--- a/src/NeuralNetworks/Options/Mamba2Options.cs
+++ b/src/NeuralNetworks/Options/Mamba2Options.cs
@@ -5,6 +5,42 @@ namespace AiDotNet.NeuralNetworks.Options;
 /// <summary>
 /// Configuration options for the Mamba2LanguageModel.
 /// </summary>
-public class Mamba2Options : NeuralNetworkOptions
+public class Mamba2Options : SequenceModelOptions
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Mamba2Options"/> class carrying
+    /// this model's shipped defaults.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>For Beginners:</b> You do not need to set any of these. They are the values the
+    /// model has always used, moved here from its constructor so they can be seen and
+    /// changed in one place.
+    /// </para>
+    /// <para>
+    /// Carried over unchanged. Whether each matches the published paper is verified, and
+    /// corrected where it does not, in a later phase of issue #2090 — kept separate so a
+    /// change in behaviour is never buried in a mechanical move.
+    /// </para>
+    /// </remarks>
+    public Mamba2Options()
+    {
+        VocabSize = 50277;
+        ModelDimension = 256;
+        NumLayers = 4;
+        StateDimension = 64;
+        NumHeads = 8;
+        MaxSequenceLength = 512;
+    }
+
+    /// <summary>
+    /// Throws if a value this model requires has been left unset or is not positive.
+    /// </summary>
+    /// <exception cref="ArgumentException">
+    /// Thrown when a required dimension is zero or negative.
+    /// </exception>
+    public void Validate()
+    {
+        ValidateCore(requiresHeads: true, requiresState: true);
+    }
 }

--- a/src/NeuralNetworks/Options/Mamba2Options.cs
+++ b/src/NeuralNetworks/Options/Mamba2Options.cs
@@ -3,8 +3,20 @@ using AiDotNet.Models.Options;
 namespace AiDotNet.NeuralNetworks.Options;
 
 /// <summary>
-/// Configuration options for the Mamba2LanguageModel.
+/// Configures the dimensions, state width, and head count of the Mamba-2 language model.
 /// </summary>
+/// <remarks>
+/// <para><b>For Beginners:</b> Mamba-2 keeps a running summary instead of retaining an
+/// attention score for every earlier token. Its state width controls the size of that memory;
+/// its head count divides the internal computation into groups.</para>
+/// <para>Dao and Gu, <i>Transformers are SSMs: Generalized Models and Efficient Algorithms
+/// Through Structured State Space Duality</i> (2024), introduce the structured state-space
+/// duality formulation used by Mamba-2. Released configurations range from 130 million to
+/// 2.7 billion parameters. The existing 256-wide, four-layer defaults are the library's small
+/// configuration, not the dimensions of those pretrained checkpoints.</para>
+/// </remarks>
+/// <seealso href="https://arxiv.org/abs/2405.21060">Original Mamba-2 paper.</seealso>
+/// <seealso href="https://github.com/state-spaces/mamba">Authors' implementation and checkpoint roster.</seealso>
 public class Mamba2Options : SequenceModelOptions
 {
     /// <summary>
@@ -31,6 +43,13 @@ public class Mamba2Options : SequenceModelOptions
         StateDimension = 64;
         NumHeads = 8;
         MaxSequenceLength = 512;
+    }
+
+    /// <summary>Initializes an instance by copying every declared and inherited setting.</summary>
+    /// <param name="other">The source options.</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="other"/> is null.</exception>
+    public Mamba2Options(Mamba2Options other) : base(other)
+    {
     }
 
     /// <summary>

--- a/src/NeuralNetworks/Options/MambaOptions.cs
+++ b/src/NeuralNetworks/Options/MambaOptions.cs
@@ -3,8 +3,51 @@ using AiDotNet.Models.Options;
 namespace AiDotNet.NeuralNetworks.Options;
 
 /// <summary>
-/// Configuration options for the MambaLanguageModel.
+/// Configuration options for <see cref="MambaLanguageModel{T}"/>.
 /// </summary>
-public class MambaOptions : NeuralNetworkOptions
+/// <remarks>
+/// <para>
+/// <b>For Beginners:</b> Mamba is a language model that reads text left to right while
+/// carrying a compact running summary of everything it has seen, instead of re-reading the
+/// whole passage at every step the way a transformer does. That makes it fast on long text.
+/// You do not need to set anything here — the defaults come with the model.
+/// </para>
+/// <para>
+/// <b>Values are carried over unchanged from the constructor parameters they replace and are
+/// NOT yet the paper's.</b> Mamba-130M is 768 wide with 24 layers; the values below are the
+/// demo-sized ones this model has always shipped. Correcting them is a deliberate behavioural
+/// change, made in its own phase of issue #2090 so it is reviewed apart from this mechanical
+/// move.
+/// </para>
+/// </remarks>
+/// <seealso href="https://arxiv.org/abs/2312.00752">
+/// Mamba: Linear-Time Sequence Modeling with Selective State Spaces
+/// </seealso>
+public class MambaOptions : SequenceModelOptions
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MambaOptions"/> class with this model's
+    /// shipped defaults.
+    /// </summary>
+    public MambaOptions()
+    {
+        VocabSize = 50277;
+        ModelDimension = 256;
+        NumLayers = 4;
+        StateDimension = 16;
+        ExpandFactor = 2;
+        MaxSequenceLength = 512;
+    }
+
+    /// <summary>
+    /// Throws if a value this model requires has been left unset or is not positive.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when a required dimension is zero or negative.
+    /// </exception>
+    public void Validate()
+    {
+        ValidateCore(requiresHeads: false, requiresState: true);
+        Require(ExpandFactor, nameof(ExpandFactor));
+    }
 }

--- a/src/NeuralNetworks/Options/MambaOptions.cs
+++ b/src/NeuralNetworks/Options/MambaOptions.cs
@@ -42,7 +42,7 @@ public class MambaOptions : SequenceModelOptions
     /// <summary>
     /// Throws if a value this model requires has been left unset or is not positive.
     /// </summary>
-    /// <exception cref="InvalidOperationException">
+    /// <exception cref="ArgumentException">
     /// Thrown when a required dimension is zero or negative.
     /// </exception>
     public void Validate()

--- a/src/NeuralNetworks/Options/MambaOptions.cs
+++ b/src/NeuralNetworks/Options/MambaOptions.cs
@@ -39,6 +39,13 @@ public class MambaOptions : SequenceModelOptions
         MaxSequenceLength = 512;
     }
 
+    /// <summary>Initializes an instance by copying every declared and inherited setting.</summary>
+    /// <param name="other">The source options.</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="other"/> is null.</exception>
+    public MambaOptions(MambaOptions other) : base(other)
+    {
+    }
+
     /// <summary>
     /// Throws if a value this model requires has been left unset or is not positive.
     /// </summary>

--- a/src/NeuralNetworks/Options/RWKV4Options.cs
+++ b/src/NeuralNetworks/Options/RWKV4Options.cs
@@ -5,6 +5,40 @@ namespace AiDotNet.NeuralNetworks.Options;
 /// <summary>
 /// Configuration options for the RWKV4LanguageModel.
 /// </summary>
-public class RWKV4Options : NeuralNetworkOptions
+public class RWKV4Options : SequenceModelOptions
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RWKV4Options"/> class carrying
+    /// this model's shipped defaults.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>For Beginners:</b> You do not need to set any of these. They are the values the
+    /// model has always used, moved here from its constructor so they can be seen and
+    /// changed in one place.
+    /// </para>
+    /// <para>
+    /// Carried over unchanged. Whether each matches the published paper is verified, and
+    /// corrected where it does not, in a later phase of issue #2090 — kept separate so a
+    /// change in behaviour is never buried in a mechanical move.
+    /// </para>
+    /// </remarks>
+    public RWKV4Options()
+    {
+        VocabSize = 50277;
+        ModelDimension = 256;
+        NumLayers = 4;
+        MaxSequenceLength = 512;
+    }
+
+    /// <summary>
+    /// Throws if a value this model requires has been left unset or is not positive.
+    /// </summary>
+    /// <exception cref="ArgumentException">
+    /// Thrown when a required dimension is zero or negative.
+    /// </exception>
+    public void Validate()
+    {
+        ValidateCore(requiresHeads: false, requiresState: false);
+    }
 }

--- a/src/NeuralNetworks/Options/RWKV4Options.cs
+++ b/src/NeuralNetworks/Options/RWKV4Options.cs
@@ -31,6 +31,13 @@ public class RWKV4Options : SequenceModelOptions
         MaxSequenceLength = 512;
     }
 
+    /// <summary>Initializes an instance by copying every declared and inherited setting.</summary>
+    /// <param name="other">The source options.</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="other"/> is null.</exception>
+    public RWKV4Options(RWKV4Options other) : base(other)
+    {
+    }
+
     /// <summary>
     /// Throws if a value this model requires has been left unset or is not positive.
     /// </summary>

--- a/src/NeuralNetworks/Options/RWKV4Options.cs
+++ b/src/NeuralNetworks/Options/RWKV4Options.cs
@@ -5,6 +5,16 @@ namespace AiDotNet.NeuralNetworks.Options;
 /// <summary>
 /// Configuration options for the RWKV4LanguageModel.
 /// </summary>
+/// <remarks>
+/// <para><b>For Beginners:</b> RWKV-4 keeps a compact recurrent memory while training with
+/// parallel token operations. Width and layer count trade memory and compute for capacity.</para>
+/// <para>Peng et al., <i>RWKV: Reinventing RNNs for the Transformer Era</i> (2023), Table 2,
+/// report 169M (width 768, 12 layers), 1.5B (2048, 24), 7B (4096, 32), and 14B (5120, 40)
+/// configurations. Those are published sizing examples, not the defaults below: this library
+/// retains its existing width 256 and four layers for compatibility. Matching size alone does
+/// not reproduce pretrained weights or the full training recipe.</para>
+/// </remarks>
+/// <seealso href="https://arxiv.org/abs/2305.13048">Original RWKV paper.</seealso>
 public class RWKV4Options : SequenceModelOptions
 {
     /// <summary>

--- a/src/NeuralNetworks/Options/RWKV7Options.cs
+++ b/src/NeuralNetworks/Options/RWKV7Options.cs
@@ -5,6 +5,42 @@ namespace AiDotNet.NeuralNetworks.Options;
 /// <summary>
 /// Configuration options for the RWKV7LanguageModel.
 /// </summary>
-public class RWKV7Options : NeuralNetworkOptions
+public class RWKV7Options : SequenceModelOptions
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RWKV7Options"/> class carrying
+    /// this model's shipped defaults.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>For Beginners:</b> You do not need to set any of these. They are the values the
+    /// model has always used, moved here from its constructor so they can be seen and
+    /// changed in one place.
+    /// </para>
+    /// <para>
+    /// Carried over unchanged. Whether each matches the published paper is verified, and
+    /// corrected where it does not, in a later phase of issue #2090 — kept separate so a
+    /// change in behaviour is never buried in a mechanical move.
+    /// </para>
+    /// </remarks>
+    public RWKV7Options()
+    {
+        VocabSize = 65536;
+        ModelDimension = 256;
+        NumLayers = 4;
+        NumHeads = 4;
+        FfnMultiplier = 3.5;
+        MaxSequenceLength = 512;
+    }
+
+    /// <summary>
+    /// Throws if a value this model requires has been left unset or is not positive.
+    /// </summary>
+    /// <exception cref="ArgumentException">
+    /// Thrown when a required dimension is zero or negative.
+    /// </exception>
+    public void Validate()
+    {
+        ValidateCore(requiresHeads: true, requiresState: false);
+    }
 }

--- a/src/NeuralNetworks/Options/RWKV7Options.cs
+++ b/src/NeuralNetworks/Options/RWKV7Options.cs
@@ -33,14 +33,23 @@ public class RWKV7Options : SequenceModelOptions
         MaxSequenceLength = 512;
     }
 
+    /// <summary>Initializes an instance by copying every declared and inherited setting.</summary>
+    /// <param name="other">The source options.</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="other"/> is null.</exception>
+    public RWKV7Options(RWKV7Options other) : base(other)
+    {
+    }
+
     /// <summary>
-    /// Throws if a value this model requires has been left unset or is not positive.
+    /// Throws if a required model dimension or consumed training setting is invalid.
     /// </summary>
     /// <exception cref="ArgumentException">
-    /// Thrown when a required dimension is zero or negative.
+    /// Thrown when a required dimension is non-positive, or a consumed numeric setting is
+    /// non-finite or outside its supported range. The message identifies the invalid property.
     /// </exception>
     public void Validate()
     {
         ValidateCore(requiresHeads: true, requiresState: false);
+        Require(FfnMultiplier, nameof(FfnMultiplier));
     }
 }

--- a/src/NeuralNetworks/Options/RecurrentGemmaOptions.cs
+++ b/src/NeuralNetworks/Options/RecurrentGemmaOptions.cs
@@ -74,12 +74,9 @@ public class RecurrentGemmaOptions : SequenceModelOptions
 
     /// <summary>Initializes an options instance by copying another.</summary>
     /// <param name="other">The source options.</param>
-    public RecurrentGemmaOptions(RecurrentGemmaOptions other)
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="other"/> is null.</exception>
+    public RecurrentGemmaOptions(RecurrentGemmaOptions other) : base(other)
     {
-        if (other is null)
-            throw new ArgumentNullException(nameof(other));
-        Seed = other.Seed;
-        EncoderLayerCount = other.EncoderLayerCount;
         ScaleEmbeddingsBySqrtWidth = other.ScaleEmbeddingsBySqrtWidth;
         LearningRate = other.LearningRate;
         WeightDecay = other.WeightDecay;
@@ -88,20 +85,26 @@ public class RecurrentGemmaOptions : SequenceModelOptions
         Epsilon = other.Epsilon;
         EnableGradientClipping = other.EnableGradientClipping;
         MaxGradientNorm = other.MaxGradientNorm;
-        VocabSize = other.VocabSize;
-        ModelDimension = other.ModelDimension;
-        NumLayers = other.NumLayers;
-        MaxSequenceLength = other.MaxSequenceLength;
     }
 
     /// <summary>
-    /// Throws if a value this model requires has been left unset or is not positive.
+    /// Throws if a required model dimension or consumed training setting is invalid.
     /// </summary>
     /// <exception cref="ArgumentException">
-    /// Thrown when a required dimension is zero or negative.
+    /// Thrown when a required dimension is non-positive, or a consumed numeric setting is
+    /// non-finite or outside its supported range. The message identifies the invalid property.
     /// </exception>
     public void Validate()
     {
         ValidateCore(requiresHeads: false, requiresState: false);
+        Require(LearningRate, nameof(LearningRate));
+        RequireNonNegative(WeightDecay, nameof(WeightDecay));
+        RequireDecayCoefficient(Beta1, nameof(Beta1));
+        RequireDecayCoefficient(Beta2, nameof(Beta2));
+        Require(Epsilon, nameof(Epsilon));
+        if (EnableGradientClipping)
+        {
+            Require(MaxGradientNorm, nameof(MaxGradientNorm));
+        }
     }
 }

--- a/src/NeuralNetworks/Options/RecurrentGemmaOptions.cs
+++ b/src/NeuralNetworks/Options/RecurrentGemmaOptions.cs
@@ -13,7 +13,7 @@ namespace AiDotNet.NeuralNetworks.Options;
 /// so the model silently inherited whatever the base supplied.
 /// </para>
 /// </remarks>
-public class RecurrentGemmaOptions : NeuralNetworkOptions
+public class RecurrentGemmaOptions : SequenceModelOptions
 {
     /// <summary>
     /// Gets or sets whether the input embeddings are multiplied by the square root of the model width.
@@ -66,6 +66,10 @@ public class RecurrentGemmaOptions : NeuralNetworkOptions
         Epsilon = 1e-8;
         EnableGradientClipping = true;
         MaxGradientNorm = 1.0;
+        VocabSize = 256000;
+        ModelDimension = 256;
+        NumLayers = 4;
+        MaxSequenceLength = 512;
     }
 
     /// <summary>Initializes an options instance by copying another.</summary>
@@ -84,5 +88,20 @@ public class RecurrentGemmaOptions : NeuralNetworkOptions
         Epsilon = other.Epsilon;
         EnableGradientClipping = other.EnableGradientClipping;
         MaxGradientNorm = other.MaxGradientNorm;
+        VocabSize = other.VocabSize;
+        ModelDimension = other.ModelDimension;
+        NumLayers = other.NumLayers;
+        MaxSequenceLength = other.MaxSequenceLength;
+    }
+
+    /// <summary>
+    /// Throws if a value this model requires has been left unset or is not positive.
+    /// </summary>
+    /// <exception cref="ArgumentException">
+    /// Thrown when a required dimension is zero or negative.
+    /// </exception>
+    public void Validate()
+    {
+        ValidateCore(requiresHeads: false, requiresState: false);
     }
 }

--- a/src/NeuralNetworks/Options/SambaOptions.cs
+++ b/src/NeuralNetworks/Options/SambaOptions.cs
@@ -5,6 +5,42 @@ namespace AiDotNet.NeuralNetworks.Options;
 /// <summary>
 /// Configuration options for the SambaLanguageModel.
 /// </summary>
-public class SambaOptions : NeuralNetworkOptions
+public class SambaOptions : SequenceModelOptions
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SambaOptions"/> class carrying
+    /// this model's shipped defaults.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>For Beginners:</b> You do not need to set any of these. They are the values the
+    /// model has always used, moved here from its constructor so they can be seen and
+    /// changed in one place.
+    /// </para>
+    /// <para>
+    /// Carried over unchanged. Whether each matches the published paper is verified, and
+    /// corrected where it does not, in a later phase of issue #2090 — kept separate so a
+    /// change in behaviour is never buried in a mechanical move.
+    /// </para>
+    /// </remarks>
+    public SambaOptions()
+    {
+        VocabSize = 32000;
+        ModelDimension = 256;
+        NumLayers = 8;
+        StateDimension = 16;
+        AttentionInterval = 2;
+        MaxSequenceLength = 512;
+    }
+
+    /// <summary>
+    /// Throws if a value this model requires has been left unset or is not positive.
+    /// </summary>
+    /// <exception cref="ArgumentException">
+    /// Thrown when a required dimension is zero or negative.
+    /// </exception>
+    public void Validate()
+    {
+        ValidateCore(requiresHeads: false, requiresState: true);
+    }
 }

--- a/src/NeuralNetworks/Options/SambaOptions.cs
+++ b/src/NeuralNetworks/Options/SambaOptions.cs
@@ -3,8 +3,19 @@ using AiDotNet.Models.Options;
 namespace AiDotNet.NeuralNetworks.Options;
 
 /// <summary>
-/// Configuration options for the SambaLanguageModel.
+/// Configures the dimensions and attention spacing of the Samba language model.
 /// </summary>
+/// <remarks>
+/// <para><b>For Beginners:</b> Samba combines a running memory for older information with
+/// attention to recent tokens. Its attention interval controls how often recurrent blocks
+/// are interleaved with attention blocks.</para>
+/// <para>Ren et al., <i>Samba: Simple Hybrid State Space Models for Efficient Unlimited
+/// Context Language Modeling</i> (2024), combine Mamba with sliding-window attention and
+/// evaluate models up to 3.8 billion parameters. The existing 256-wide, eight-layer defaults
+/// are a small library configuration, not the published 3.8B checkpoint. These settings do
+/// not independently specify the paper's entire training recipe or attention-window policy.</para>
+/// </remarks>
+/// <seealso href="https://arxiv.org/abs/2406.07522">Original Samba paper.</seealso>
 public class SambaOptions : SequenceModelOptions
 {
     /// <summary>
@@ -33,14 +44,23 @@ public class SambaOptions : SequenceModelOptions
         MaxSequenceLength = 512;
     }
 
+    /// <summary>Initializes an instance by copying every declared and inherited setting.</summary>
+    /// <param name="other">The source options.</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="other"/> is null.</exception>
+    public SambaOptions(SambaOptions other) : base(other)
+    {
+    }
+
     /// <summary>
-    /// Throws if a value this model requires has been left unset or is not positive.
+    /// Throws if a required model dimension or consumed training setting is invalid.
     /// </summary>
     /// <exception cref="ArgumentException">
-    /// Thrown when a required dimension is zero or negative.
+    /// Thrown when a required dimension is non-positive, or a consumed numeric setting is
+    /// non-finite or outside its supported range. The message identifies the invalid property.
     /// </exception>
     public void Validate()
     {
         ValidateCore(requiresHeads: false, requiresState: true);
+        Require(AttentionInterval, nameof(AttentionInterval));
     }
 }

--- a/src/NeuralNetworks/Options/SequenceModelOptions.cs
+++ b/src/NeuralNetworks/Options/SequenceModelOptions.cs
@@ -39,6 +39,27 @@ namespace AiDotNet.NeuralNetworks.Options;
 /// </remarks>
 public abstract class SequenceModelOptions : ModelHyperparameterOptions
 {
+    /// <summary>Initializes the shared sequence settings with their defaults.</summary>
+    protected SequenceModelOptions()
+    {
+    }
+
+    /// <summary>Copies every shared sequence setting and inherited model setting.</summary>
+    /// <param name="other">The source options.</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="other"/> is null.</exception>
+    protected SequenceModelOptions(SequenceModelOptions other) : base(other)
+    {
+        VocabSize = other.VocabSize;
+        ModelDimension = other.ModelDimension;
+        NumLayers = other.NumLayers;
+        NumHeads = other.NumHeads;
+        StateDimension = other.StateDimension;
+        MaxSequenceLength = other.MaxSequenceLength;
+        AttentionInterval = other.AttentionInterval;
+        ExpandFactor = other.ExpandFactor;
+        FfnMultiplier = other.FfnMultiplier;
+    }
+
     /// <summary>
     /// Gets or sets the number of distinct tokens the model's embedding table covers.
     /// </summary>

--- a/src/NeuralNetworks/Options/SequenceModelOptions.cs
+++ b/src/NeuralNetworks/Options/SequenceModelOptions.cs
@@ -128,7 +128,7 @@ public abstract class SequenceModelOptions : ModelHyperparameterOptions
     /// </summary>
     /// <param name="requiresHeads">Whether this model uses attention heads.</param>
     /// <param name="requiresState">Whether this model uses a recurrent state dimension.</param>
-    /// <exception cref="InvalidOperationException">
+    /// <exception cref="ArgumentException">
     /// Thrown when a required dimension is zero or negative, which means the derived options
     /// class did not assign its paper defaults.
     /// </exception>

--- a/src/NeuralNetworks/Options/SequenceModelOptions.cs
+++ b/src/NeuralNetworks/Options/SequenceModelOptions.cs
@@ -1,0 +1,150 @@
+using AiDotNet.Models.Options;
+
+namespace AiDotNet.NeuralNetworks.Options;
+
+/// <summary>
+/// Shared configuration for sequence and language models (Mamba, RWKV, Jamba, Zamba,
+/// Griffin, Hawk, xLSTM, RecurrentGemma and relatives).
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>For Beginners:</b> These are the "size" settings of a language model — how many
+/// distinct tokens it knows, how wide each internal representation is, how many stacked
+/// blocks it has, and how far back it can look. You rarely need to change them: each
+/// model's own options class already ships the sizes from the paper that introduced it.
+/// </para>
+/// <para>
+/// Derived options classes assign their paper's values in their parameterless
+/// constructor. For example:
+/// <code>
+/// public class MambaOptions : SequenceModelOptions
+/// {
+///     public MambaOptions()
+///     {
+///         VocabSize = 50277;      // Mamba-130M
+///         ModelDimension = 768;
+///         NumLayers = 24;
+///     }
+/// }
+/// </code>
+/// </para>
+/// <para>
+/// Properties are non-nullable and defaulted by the derived class rather than nullable
+/// with a <c>GetEffectiveX()</c> fallback. A model's layer count has no runtime-dependent
+/// best value the way a batch size does — the right value is the paper's, and it is known
+/// statically. See the "Model Hyperparameter Options" section of the development
+/// guidelines. Infrastructure configuration (telemetry, profiling, AutoML) keeps the
+/// nullable pattern.
+/// </para>
+/// </remarks>
+public abstract class SequenceModelOptions : ModelHyperparameterOptions
+{
+    /// <summary>
+    /// Gets or sets the number of distinct tokens the model's embedding table covers.
+    /// </summary>
+    /// <remarks>
+    /// <para><b>For Beginners:</b> The size of the model's vocabulary — how many different
+    /// words or word-pieces it can represent. Fixed by the tokenizer the paper used, so
+    /// changing it means retraining from scratch.</para>
+    /// </remarks>
+    public int VocabSize { get; set; }
+
+    /// <summary>
+    /// Gets or sets the width of the model's hidden representation (often written d_model).
+    /// </summary>
+    /// <remarks>
+    /// <para><b>For Beginners:</b> How many numbers the model uses to describe each token
+    /// internally. Wider means more capacity and more memory.</para>
+    /// </remarks>
+    public int ModelDimension { get; set; }
+
+    /// <summary>
+    /// Gets or sets the number of stacked blocks in the model.
+    /// </summary>
+    /// <remarks>
+    /// <para><b>For Beginners:</b> Depth. Each layer refines what the previous one produced.</para>
+    /// </remarks>
+    public int NumLayers { get; set; }
+
+    /// <summary>
+    /// Gets or sets the number of attention heads, for models that use attention.
+    /// </summary>
+    /// <remarks>
+    /// <para><b>For Beginners:</b> Attention heads let the model look at several
+    /// relationships at once. Purely recurrent models (Mamba, RWKV) may leave this unset.</para>
+    /// </remarks>
+    public int NumHeads { get; set; }
+
+    /// <summary>
+    /// Gets or sets the width of the recurrent state, for state-space models.
+    /// </summary>
+    /// <remarks>
+    /// <para><b>For Beginners:</b> How much the model remembers as it walks through a
+    /// sequence. Used by Mamba-family models; attention-only models leave it unset.</para>
+    /// </remarks>
+    public int StateDimension { get; set; }
+
+    /// <summary>
+    /// Gets or sets the longest sequence, in tokens, the model is configured to process.
+    /// </summary>
+    /// <remarks>
+    /// <para><b>For Beginners:</b> The context window — how much text the model can consider
+    /// at once.</para>
+    /// </remarks>
+    public int MaxSequenceLength { get; set; }
+
+    /// <summary>
+    /// Gets or sets how often an attention block is interleaved among recurrent blocks,
+    /// in hybrid architectures such as Jamba, Samba and Zamba.
+    /// </summary>
+    /// <remarks>
+    /// <para><b>For Beginners:</b> Hybrid models mix two kinds of block. A value of 6 means
+    /// every sixth block uses attention and the rest are recurrent. Ignored by
+    /// non-hybrid models.</para>
+    /// </remarks>
+    public int AttentionInterval { get; set; }
+
+    /// <summary>
+    /// Gets or sets the inner-projection expansion factor used by state-space blocks.
+    /// </summary>
+    /// <remarks>
+    /// <para><b>For Beginners:</b> Mamba-style blocks temporarily widen their representation
+    /// before narrowing it again; this is the multiplier. The Mamba paper uses 2.</para>
+    /// </remarks>
+    public int ExpandFactor { get; set; }
+
+    /// <summary>
+    /// Gets or sets the feed-forward width as a multiple of <see cref="ModelDimension"/>,
+    /// for models that express it as a ratio (RWKV-7 uses 3.5).
+    /// </summary>
+    /// <remarks>
+    /// <para><b>For Beginners:</b> How much wider the model's internal "thinking" layer is
+    /// than its representation width.</para>
+    /// </remarks>
+    public double FfnMultiplier { get; set; }
+
+    /// <summary>
+    /// Throws if a dimension this model family requires has been left unset.
+    /// </summary>
+    /// <param name="requiresHeads">Whether this model uses attention heads.</param>
+    /// <param name="requiresState">Whether this model uses a recurrent state dimension.</param>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when a required dimension is zero or negative, which means the derived options
+    /// class did not assign its paper defaults.
+    /// </exception>
+    /// <remarks>
+    /// <para>
+    /// Fails loudly rather than silently constructing a zero-width model. A dimension of
+    /// zero produces layers that appear to build and then misbehave far from the cause.
+    /// </para>
+    /// </remarks>
+    protected void ValidateCore(bool requiresHeads, bool requiresState)
+    {
+        Require(VocabSize, nameof(VocabSize));
+        Require(ModelDimension, nameof(ModelDimension));
+        Require(NumLayers, nameof(NumLayers));
+        Require(MaxSequenceLength, nameof(MaxSequenceLength));
+        if (requiresHeads) Require(NumHeads, nameof(NumHeads));
+        if (requiresState) Require(StateDimension, nameof(StateDimension));
+    }
+}

--- a/src/NeuralNetworks/Options/VisionLanguageModelOptions.cs
+++ b/src/NeuralNetworks/Options/VisionLanguageModelOptions.cs
@@ -90,12 +90,12 @@ public abstract class VisionLanguageModelOptions : ModelHyperparameterOptions
     /// <para><b>For Beginners:</b> The part of the model that looks at pictures usually works
     /// at a different, larger size than the shared space where pictures and text meet.</para>
     /// </remarks>
-    public int VisionHiddenDim { get; set; }
+    public int VisionDim { get; set; }
 
     /// <summary>
     /// Gets or sets the number of layers in the vision tower.
     /// </summary>
-    public int NumVisionLayers { get; set; }
+    public int VisionLayers { get; set; }
 
     /// <summary>
     /// Throws if a dimension every vision-language model requires has been left unset.

--- a/src/NeuralNetworks/Options/VisionLanguageModelOptions.cs
+++ b/src/NeuralNetworks/Options/VisionLanguageModelOptions.cs
@@ -100,7 +100,7 @@ public abstract class VisionLanguageModelOptions : ModelHyperparameterOptions
     /// <summary>
     /// Throws if a dimension every vision-language model requires has been left unset.
     /// </summary>
-    /// <exception cref="InvalidOperationException">
+    /// <exception cref="ArgumentException">
     /// Thrown when a required dimension is zero or negative, which means the derived options
     /// class did not assign its paper defaults.
     /// </exception>

--- a/src/NeuralNetworks/Options/VisionLanguageModelOptions.cs
+++ b/src/NeuralNetworks/Options/VisionLanguageModelOptions.cs
@@ -1,0 +1,114 @@
+using AiDotNet.Models.Options;
+
+namespace AiDotNet.NeuralNetworks.Options;
+
+/// <summary>
+/// Shared configuration for vision-language and multimodal models (CLIP, BLIP, BLIP-2,
+/// Flamingo, LLaVA, ImageBind, GPT-4 Vision, VideoCLIP and relatives).
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>For Beginners:</b> These models read pictures and text together. The settings here
+/// describe how big the pictures are, how they get chopped into patches, how much text the
+/// model can read at once, and how wide its internal representations are. Each model's own
+/// options class ships the values from its paper, so you do not normally set any of them.
+/// </para>
+/// <para>
+/// Derived options classes assign their paper's values in their parameterless constructor.
+/// See <see cref="ModelHyperparameterOptions"/> for why these properties are non-nullable.
+/// </para>
+/// </remarks>
+public abstract class VisionLanguageModelOptions : ModelHyperparameterOptions
+{
+    /// <summary>
+    /// Gets or sets the width of the shared embedding space that images and text are
+    /// projected into.
+    /// </summary>
+    /// <remarks>
+    /// <para><b>For Beginners:</b> Both a picture and a sentence get turned into a list of
+    /// numbers of this length, so they can be compared to each other.</para>
+    /// </remarks>
+    public int EmbeddingDimension { get; set; }
+
+    /// <summary>
+    /// Gets or sets the longest text sequence, in tokens, the model is configured to process.
+    /// </summary>
+    public int MaxSequenceLength { get; set; }
+
+    /// <summary>
+    /// Gets or sets the side length, in pixels, of the square image the model expects.
+    /// </summary>
+    /// <remarks>
+    /// <para><b>For Beginners:</b> Input images are resized to this many pixels on each side —
+    /// 224 and 336 are the common choices.</para>
+    /// </remarks>
+    public int ImageSize { get; set; }
+
+    /// <summary>
+    /// Gets or sets the side length, in pixels, of each square patch the image is divided into.
+    /// </summary>
+    /// <remarks>
+    /// <para><b>For Beginners:</b> Vision transformers cut a picture into a grid of small
+    /// squares and treat each one like a word. A 224-pixel image with 16-pixel patches becomes
+    /// a 14 by 14 grid, so 196 "words".</para>
+    /// </remarks>
+    public int PatchSize { get; set; }
+
+    /// <summary>
+    /// Gets or sets the number of colour channels in the input image.
+    /// </summary>
+    /// <remarks>
+    /// <para><b>For Beginners:</b> 3 for ordinary colour images (red, green, blue).</para>
+    /// </remarks>
+    public int Channels { get; set; } = 3;
+
+    /// <summary>
+    /// Gets or sets the number of distinct tokens the text tokenizer covers.
+    /// </summary>
+    public int VocabSize { get; set; }
+
+    /// <summary>
+    /// Gets or sets the number of attention heads.
+    /// </summary>
+    public int NumHeads { get; set; }
+
+    /// <summary>
+    /// Gets or sets the width of the model's main hidden representation.
+    /// </summary>
+    public int HiddenDim { get; set; }
+
+    /// <summary>
+    /// Gets or sets the number of layers in the text encoder.
+    /// </summary>
+    public int NumEncoderLayers { get; set; }
+
+    /// <summary>
+    /// Gets or sets the width of the vision tower's hidden representation, which is often
+    /// wider than the shared embedding space.
+    /// </summary>
+    /// <remarks>
+    /// <para><b>For Beginners:</b> The part of the model that looks at pictures usually works
+    /// at a different, larger size than the shared space where pictures and text meet.</para>
+    /// </remarks>
+    public int VisionHiddenDim { get; set; }
+
+    /// <summary>
+    /// Gets or sets the number of layers in the vision tower.
+    /// </summary>
+    public int NumVisionLayers { get; set; }
+
+    /// <summary>
+    /// Throws if a dimension every vision-language model requires has been left unset.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when a required dimension is zero or negative, which means the derived options
+    /// class did not assign its paper defaults.
+    /// </exception>
+    protected void ValidateCore()
+    {
+        Require(EmbeddingDimension, nameof(EmbeddingDimension));
+        Require(MaxSequenceLength, nameof(MaxSequenceLength));
+        Require(ImageSize, nameof(ImageSize));
+        Require(Channels, nameof(Channels));
+    }
+}

--- a/src/NeuralNetworks/Options/XLSTMOptions.cs
+++ b/src/NeuralNetworks/Options/XLSTMOptions.cs
@@ -5,8 +5,43 @@ namespace AiDotNet.NeuralNetworks.Options;
 /// <summary>
 /// Configuration options for the XLSTMLanguageModel.
 /// </summary>
-public class XLSTMOptions : NeuralNetworkOptions
+public class XLSTMOptions : SequenceModelOptions
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="XLSTMOptions"/> class carrying
+    /// this model's shipped defaults.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>For Beginners:</b> You do not need to set any of these. They are the values the
+    /// model has always used, moved here from its constructor so they can be seen and
+    /// changed in one place.
+    /// </para>
+    /// <para>
+    /// Carried over unchanged. Whether each matches the published paper is verified, and
+    /// corrected where it does not, in a later phase of issue #2090 — kept separate so a
+    /// change in behaviour is never buried in a mechanical move.
+    /// </para>
+    /// </remarks>
+    public XLSTMOptions()
+    {
+        VocabSize = 50277;
+        ModelDimension = 256;
+        NumLayers = 4;
+        NumHeads = 8;
+        MaxSequenceLength = 512;
+    }
+
+    /// <summary>
+    /// Throws if a value this model requires has been left unset or is not positive.
+    /// </summary>
+    /// <exception cref="ArgumentException">
+    /// Thrown when a required dimension is zero or negative.
+    /// </exception>
+    public void Validate()
+    {
+        ValidateCore(requiresHeads: true, requiresState: false);
+    }
     /// <summary>
     /// AdamW learning rate. Defaults to 1e-3, the rate used for the xLSTM language models in
     /// Beck et al., 2024 (S4.1).

--- a/src/NeuralNetworks/Options/XLSTMOptions.cs
+++ b/src/NeuralNetworks/Options/XLSTMOptions.cs
@@ -3,8 +3,19 @@ using AiDotNet.Models.Options;
 namespace AiDotNet.NeuralNetworks.Options;
 
 /// <summary>
-/// Configuration options for the XLSTMLanguageModel.
+/// Configures the dimensions and default optimizer learning rate of the xLSTM language model.
 /// </summary>
+/// <remarks>
+/// <para><b>For Beginners:</b> xLSTM extends the familiar recurrent memory cell with more
+/// expressive gates and memory. Width, depth, and head count control the model's capacity;
+/// the learning rate controls the size of each training step.</para>
+/// <para>Beck et al., <i>xLSTM: Extended Long Short-Term Memory</i> (2024), introduce
+/// exponential gating, scalar-memory sLSTM, and matrix-memory mLSTM blocks. The original
+/// language-model experiments include 125M, 350M, 760M, and 1.3B configurations. These
+/// options retain the library's 256-wide, four-layer defaults rather than claiming checkpoint
+/// equivalence, and do not configure every block-mixture choice in the paper.</para>
+/// </remarks>
+/// <seealso href="https://arxiv.org/abs/2405.04517">Original xLSTM paper.</seealso>
 public class XLSTMOptions : SequenceModelOptions
 {
     /// <summary>
@@ -32,15 +43,25 @@ public class XLSTMOptions : SequenceModelOptions
         MaxSequenceLength = 512;
     }
 
+    /// <summary>Initializes an instance by copying every declared and inherited setting.</summary>
+    /// <param name="other">The source options.</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="other"/> is null.</exception>
+    public XLSTMOptions(XLSTMOptions other) : base(other)
+    {
+        LearningRate = other.LearningRate;
+    }
+
     /// <summary>
-    /// Throws if a value this model requires has been left unset or is not positive.
+    /// Throws if a required model dimension or consumed training setting is invalid.
     /// </summary>
     /// <exception cref="ArgumentException">
-    /// Thrown when a required dimension is zero or negative.
+    /// Thrown when a required dimension is non-positive, or a consumed numeric setting is
+    /// non-finite or outside its supported range. The message identifies the invalid property.
     /// </exception>
     public void Validate()
     {
         ValidateCore(requiresHeads: true, requiresState: false);
+        Require(LearningRate, nameof(LearningRate));
     }
     /// <summary>
     /// AdamW learning rate. Defaults to 1e-3, the rate used for the xLSTM language models in

--- a/src/NeuralNetworks/Options/Zamba2Options.cs
+++ b/src/NeuralNetworks/Options/Zamba2Options.cs
@@ -5,6 +5,43 @@ namespace AiDotNet.NeuralNetworks.Options;
 /// <summary>
 /// Configuration options for the Zamba2LanguageModel.
 /// </summary>
-public class Zamba2Options : NeuralNetworkOptions
+public class Zamba2Options : SequenceModelOptions
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Zamba2Options"/> class carrying
+    /// this model's shipped defaults.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>For Beginners:</b> You do not need to set any of these. They are the values the
+    /// model has always used, moved here from its constructor so they can be seen and
+    /// changed in one place.
+    /// </para>
+    /// <para>
+    /// Carried over unchanged. Whether each matches the published paper is verified, and
+    /// corrected where it does not, in a later phase of issue #2090 — kept separate so a
+    /// change in behaviour is never buried in a mechanical move.
+    /// </para>
+    /// </remarks>
+    public Zamba2Options()
+    {
+        VocabSize = 32000;
+        ModelDimension = 3584;
+        NumLayers = 81;
+        StateDimension = 64;
+        NumHeads = 32;
+        AttentionInterval = 6;
+        MaxSequenceLength = 4096;
+    }
+
+    /// <summary>
+    /// Throws if a value this model requires has been left unset or is not positive.
+    /// </summary>
+    /// <exception cref="ArgumentException">
+    /// Thrown when a required dimension is zero or negative.
+    /// </exception>
+    public void Validate()
+    {
+        ValidateCore(requiresHeads: true, requiresState: true);
+    }
 }

--- a/src/NeuralNetworks/Options/Zamba2Options.cs
+++ b/src/NeuralNetworks/Options/Zamba2Options.cs
@@ -34,14 +34,23 @@ public class Zamba2Options : SequenceModelOptions
         MaxSequenceLength = 4096;
     }
 
+    /// <summary>Initializes an instance by copying every declared and inherited setting.</summary>
+    /// <param name="other">The source options.</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="other"/> is null.</exception>
+    public Zamba2Options(Zamba2Options other) : base(other)
+    {
+    }
+
     /// <summary>
-    /// Throws if a value this model requires has been left unset or is not positive.
+    /// Throws if a required model dimension or consumed training setting is invalid.
     /// </summary>
     /// <exception cref="ArgumentException">
-    /// Thrown when a required dimension is zero or negative.
+    /// Thrown when a required dimension is non-positive, or a consumed numeric setting is
+    /// non-finite or outside its supported range. The message identifies the invalid property.
     /// </exception>
     public void Validate()
     {
         ValidateCore(requiresHeads: true, requiresState: true);
+        Require(AttentionInterval, nameof(AttentionInterval));
     }
 }

--- a/src/NeuralNetworks/Options/ZambaOptions.cs
+++ b/src/NeuralNetworks/Options/ZambaOptions.cs
@@ -3,8 +3,18 @@ using AiDotNet.Models.Options;
 namespace AiDotNet.NeuralNetworks.Options;
 
 /// <summary>
-/// Configuration options for the ZambaLanguageModel.
+/// Configures the dimensions and attention spacing of the Zamba language model.
 /// </summary>
+/// <remarks>
+/// <para><b>For Beginners:</b> Zamba uses a recurrent backbone for compact memory and adds
+/// attention periodically to recover token-level information. Width and depth determine
+/// model capacity, while the attention interval controls how often the two mechanisms mix.</para>
+/// <para>Glorioso et al., <i>Zamba: A Compact 7B SSM Hybrid Model</i> (2024), describe a
+/// seven-billion-parameter Mamba backbone with a shared attention module. These options
+/// retain the library's existing 3712-wide, 76-layer configuration. Matching those dimensions
+/// alone does not establish checkpoint, weight-sharing, or training-recipe equivalence.</para>
+/// </remarks>
+/// <seealso href="https://arxiv.org/abs/2405.16712">Original Zamba paper.</seealso>
 public class ZambaOptions : SequenceModelOptions
 {
     /// <summary>
@@ -33,14 +43,23 @@ public class ZambaOptions : SequenceModelOptions
         MaxSequenceLength = 4096;
     }
 
+    /// <summary>Initializes an instance by copying every declared and inherited setting.</summary>
+    /// <param name="other">The source options.</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="other"/> is null.</exception>
+    public ZambaOptions(ZambaOptions other) : base(other)
+    {
+    }
+
     /// <summary>
-    /// Throws if a value this model requires has been left unset or is not positive.
+    /// Throws if a required model dimension or consumed training setting is invalid.
     /// </summary>
     /// <exception cref="ArgumentException">
-    /// Thrown when a required dimension is zero or negative.
+    /// Thrown when a required dimension is non-positive, or a consumed numeric setting is
+    /// non-finite or outside its supported range. The message identifies the invalid property.
     /// </exception>
     public void Validate()
     {
         ValidateCore(requiresHeads: false, requiresState: true);
+        Require(AttentionInterval, nameof(AttentionInterval));
     }
 }

--- a/src/NeuralNetworks/Options/ZambaOptions.cs
+++ b/src/NeuralNetworks/Options/ZambaOptions.cs
@@ -5,6 +5,42 @@ namespace AiDotNet.NeuralNetworks.Options;
 /// <summary>
 /// Configuration options for the ZambaLanguageModel.
 /// </summary>
-public class ZambaOptions : NeuralNetworkOptions
+public class ZambaOptions : SequenceModelOptions
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ZambaOptions"/> class carrying
+    /// this model's shipped defaults.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>For Beginners:</b> You do not need to set any of these. They are the values the
+    /// model has always used, moved here from its constructor so they can be seen and
+    /// changed in one place.
+    /// </para>
+    /// <para>
+    /// Carried over unchanged. Whether each matches the published paper is verified, and
+    /// corrected where it does not, in a later phase of issue #2090 — kept separate so a
+    /// change in behaviour is never buried in a mechanical move.
+    /// </para>
+    /// </remarks>
+    public ZambaOptions()
+    {
+        VocabSize = 32000;
+        ModelDimension = 3712;
+        NumLayers = 76;
+        StateDimension = 16;
+        AttentionInterval = 6;
+        MaxSequenceLength = 4096;
+    }
+
+    /// <summary>
+    /// Throws if a value this model requires has been left unset or is not positive.
+    /// </summary>
+    /// <exception cref="ArgumentException">
+    /// Thrown when a required dimension is zero or negative.
+    /// </exception>
+    public void Validate()
+    {
+        ValidateCore(requiresHeads: false, requiresState: true);
+    }
 }

--- a/src/NeuralNetworks/RWKV4LanguageModel.cs
+++ b/src/NeuralNetworks/RWKV4LanguageModel.cs
@@ -93,23 +93,9 @@ public partial class RWKV4LanguageModel<T> : TokenLanguageModelLayoutBase<T>
     /// Creates an RWKV-4 language model using native library layers.
     /// </summary>
     /// <param name="architecture">The neural network architecture configuration.</param>
-    /// <param name="vocabSize">
-    /// Size of the token vocabulary. Typical: 50277 for RWKV-4 models (using the 20B tokenizer).
-    /// <para><b>For Beginners:</b> How many different words/tokens the model knows.</para>
-    /// </param>
-    /// <param name="modelDimension">
-    /// Model dimension (d_model). Default: 256.
-    /// <para><b>For Beginners:</b> Width of the hidden representation. RWKV-4 169M uses 768,
-    /// 1.5B uses 2048, 7B uses 4096, 14B uses 5120.</para>
-    /// </param>
-    /// <param name="numLayers">
-    /// Number of RWKV layers. Default: 4.
-    /// <para><b>For Beginners:</b> Depth of the network. RWKV-4 169M uses 12 layers,
-    /// 1.5B uses 24, 7B uses 32, 14B uses 40.</para>
-    /// </param>
-    /// <param name="maxSeqLength">Maximum sequence length. Default: 512.</param>
     /// <param name="lossFunction">Optional loss function for training. Defaults to cross-entropy for text generation.</param>
-    /// <param name="options">Optional RWKV-4 specific options.</param>
+    /// <param name="options">The model's vocabulary, hidden width, block count, context length,
+    /// and RWKV-4 settings. Null uses <see cref="RWKV4Options"/> defaults.</param>
     public RWKV4LanguageModel(
         NeuralNetworkArchitecture<T> architecture,
         RWKV4Options? options = null,

--- a/src/NeuralNetworks/RWKV4LanguageModel.cs
+++ b/src/NeuralNetworks/RWKV4LanguageModel.cs
@@ -112,12 +112,8 @@ public partial class RWKV4LanguageModel<T> : TokenLanguageModelLayoutBase<T>
     /// <param name="options">Optional RWKV-4 specific options.</param>
     public RWKV4LanguageModel(
         NeuralNetworkArchitecture<T> architecture,
-        int vocabSize = 50277,
-        int modelDimension = 256,
-        int numLayers = 4,
-        int maxSeqLength = 512,
-        ILossFunction<T>? lossFunction = null,
-        RWKV4Options? options = null)
+        RWKV4Options? options = null,
+        ILossFunction<T>? lossFunction = null)
         : base(
             architecture,
             // RWKV's LM head emits RAW LOGITS (DenseLayer with no activation), so the loss must be
@@ -129,21 +125,14 @@ public partial class RWKV4LanguageModel<T> : TokenLanguageModelLayoutBase<T>
             lossFunction ?? new AiDotNet.LossFunctions.CrossEntropyWithLogitsLoss<T>())
     {
         _options = options ?? new RWKV4Options();
+        _options.Validate();
         Options = _options;
 
-        if (vocabSize <= 0)
-            throw new ArgumentException($"Vocab size ({vocabSize}) must be positive.", nameof(vocabSize));
-        if (modelDimension <= 0)
-            throw new ArgumentException($"Model dimension ({modelDimension}) must be positive.", nameof(modelDimension));
-        if (numLayers <= 0)
-            throw new ArgumentException($"Number of layers ({numLayers}) must be positive.", nameof(numLayers));
-        if (maxSeqLength <= 0)
-            throw new ArgumentException($"Max sequence length ({maxSeqLength}) must be positive.", nameof(maxSeqLength));
 
-        _vocabSize = vocabSize;
-        _modelDimension = modelDimension;
-        _numLayers = numLayers;
-        _maxSeqLength = maxSeqLength;
+        _vocabSize = _options.VocabSize;
+        _modelDimension = _options.ModelDimension;
+        _numLayers = _options.NumLayers;
+        _maxSeqLength = _options.MaxSequenceLength;
 
         InitializeLayers();
     }

--- a/src/NeuralNetworks/RWKV7LanguageModel.cs
+++ b/src/NeuralNetworks/RWKV7LanguageModel.cs
@@ -71,14 +71,8 @@ public partial class RWKV7LanguageModel<T> : TokenLanguageModelLayoutBase<T>
 
     public RWKV7LanguageModel(
         NeuralNetworkArchitecture<T> architecture,
-        int vocabSize = 65536,
-        int modelDimension = 256,
-        int numLayers = 4,
-        int numHeads = 4,
-        double ffnMultiplier = 3.5,
-        int maxSeqLength = 512,
-        ILossFunction<T>? lossFunction = null,
-        RWKV7Options? options = null)
+        RWKV7Options? options = null,
+        ILossFunction<T>? lossFunction = null)
         : base(architecture,
             // RWKV-7's LM head emits RAW LOGITS (DenseLayer with no activation, see
             // LayerHelper.CreateRWKV7Layers), so the loss must be cross-entropy-with-logits (fused
@@ -93,20 +87,25 @@ public partial class RWKV7LanguageModel<T> : TokenLanguageModelLayoutBase<T>
             // normally, matching healthy sibling RWKV4.
             lossFunction ?? new AiDotNet.LossFunctions.CrossEntropyWithLogitsLoss<T>())
     {
-        if (vocabSize <= 0) throw new ArgumentException($"Vocabulary size ({vocabSize}) must be positive.", nameof(vocabSize));
-        if (modelDimension <= 0) throw new ArgumentException($"Model dimension ({modelDimension}) must be positive.", nameof(modelDimension));
-        if (numLayers <= 0) throw new ArgumentException($"Number of layers ({numLayers}) must be positive.", nameof(numLayers));
-        if (numHeads <= 0) throw new ArgumentException($"Number of heads ({numHeads}) must be positive.", nameof(numHeads));
-        if (modelDimension % numHeads != 0) throw new ArgumentException($"Model dimension ({modelDimension}) must be divisible by number of heads ({numHeads}).", nameof(modelDimension));
-
         _options = options ?? new RWKV7Options();
+        _options.Validate();
+
+        // Head-splitting requires an exact division, so this is checked after Validate() has
+        // established both values are positive.
+        if (_options.ModelDimension % _options.NumHeads != 0)
+        {
+            throw new ArgumentException(
+                $"Model dimension ({_options.ModelDimension}) must be divisible by number of heads ({_options.NumHeads}).",
+                nameof(options));
+        }
+
         Options = _options;
-        _vocabSize = vocabSize;
-        _modelDimension = modelDimension;
-        _numLayers = numLayers;
-        _numHeads = numHeads;
-        _ffnMultiplier = ffnMultiplier;
-        _maxSeqLength = maxSeqLength;
+        _vocabSize = _options.VocabSize;
+        _modelDimension = _options.ModelDimension;
+        _numLayers = _options.NumLayers;
+        _numHeads = _options.NumHeads;
+        _ffnMultiplier = _options.FfnMultiplier;
+        _maxSeqLength = _options.MaxSequenceLength;
         InitializeLayers();
     }
 

--- a/src/NeuralNetworks/RecurrentGemmaLanguageModel.cs
+++ b/src/NeuralNetworks/RecurrentGemmaLanguageModel.cs
@@ -64,12 +64,8 @@ public partial class RecurrentGemmaLanguageModel<T> : TokenLanguageModelLayoutBa
 
     public RecurrentGemmaLanguageModel(
         NeuralNetworkArchitecture<T> architecture,
-        int vocabSize = 256000,
-        int modelDimension = 256,
-        int numLayers = 4,
-        int maxSeqLength = 512,
-        ILossFunction<T>? lossFunction = null,
         RecurrentGemmaOptions? options = null,
+        ILossFunction<T>? lossFunction = null,
         IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>>? optimizer = null)
         : base(architecture,
             // The recurrent Gemma LM head emits raw logits. Use the paper-faithful
@@ -78,11 +74,12 @@ public partial class RecurrentGemmaLanguageModel<T> : TokenLanguageModelLayoutBa
             lossFunction ?? new AiDotNet.LossFunctions.CrossEntropyWithLogitsLoss<T>())
     {
         _options = options ?? new RecurrentGemmaOptions();
+        _options.Validate();
         Options = _options;
-        _vocabSize = vocabSize;
-        _modelDimension = modelDimension;
-        _numLayers = numLayers;
-        _maxSeqLength = maxSeqLength;
+        _vocabSize = _options.VocabSize;
+        _modelDimension = _options.ModelDimension;
+        _numLayers = _options.NumLayers;
+        _maxSeqLength = _options.MaxSequenceLength;
         _optimizer = optimizer ?? CreateDefaultOptimizer();
         InitializeLayers();
     }

--- a/src/NeuralNetworks/SambaLanguageModel.cs
+++ b/src/NeuralNetworks/SambaLanguageModel.cs
@@ -66,14 +66,8 @@ public partial class SambaLanguageModel<T> : TokenLanguageModelLayoutBase<T>
 
     public SambaLanguageModel(
         NeuralNetworkArchitecture<T> architecture,
-        int vocabSize = 32000,
-        int modelDimension = 256,
-        int numLayers = 8,
-        int stateDimension = 16,
-        int attentionInterval = 2,
-        int maxSeqLength = 512,
-        ILossFunction<T>? lossFunction = null,
-        SambaOptions? options = null)
+        SambaOptions? options = null,
+        ILossFunction<T>? lossFunction = null)
         : base(architecture,
             // Samba's LM head emits RAW LOGITS (DenseLayer with no activation, see
             // LayerHelper.CreateSambaLayers), so the loss must be cross-entropy-with-logits (fused
@@ -88,13 +82,14 @@ public partial class SambaLanguageModel<T> : TokenLanguageModelLayoutBase<T>
             lossFunction ?? new AiDotNet.LossFunctions.CrossEntropyWithLogitsLoss<T>())
     {
         _options = options ?? new SambaOptions();
+        _options.Validate();
         Options = _options;
-        _vocabSize = vocabSize;
-        _modelDimension = modelDimension;
-        _numLayers = numLayers;
-        _stateDimension = stateDimension;
-        _attentionInterval = attentionInterval;
-        _maxSeqLength = maxSeqLength;
+        _vocabSize = _options.VocabSize;
+        _modelDimension = _options.ModelDimension;
+        _numLayers = _options.NumLayers;
+        _stateDimension = _options.StateDimension;
+        _attentionInterval = _options.AttentionInterval;
+        _maxSeqLength = _options.MaxSequenceLength;
         InitializeLayers();
     }
 

--- a/src/NeuralNetworks/XLSTMLanguageModel.cs
+++ b/src/NeuralNetworks/XLSTMLanguageModel.cs
@@ -67,13 +67,8 @@ public partial class XLSTMLanguageModel<T> : TokenLanguageModelLayoutBase<T>
 
     public XLSTMLanguageModel(
         NeuralNetworkArchitecture<T> architecture,
-        int vocabSize = 50277,
-        int modelDimension = 256,
-        int numLayers = 4,
-        int numHeads = 8,
-        int maxSeqLength = 512,
-        ILossFunction<T>? lossFunction = null,
         XLSTMOptions? options = null,
+        ILossFunction<T>? lossFunction = null,
         IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>>? optimizer = null)
         : base(architecture,
             // xLSTM is a next-token language model and its LM head emits raw logits.
@@ -83,12 +78,13 @@ public partial class XLSTMLanguageModel<T> : TokenLanguageModelLayoutBase<T>
             lossFunction ?? new AiDotNet.LossFunctions.CrossEntropyWithLogitsLoss<T>())
     {
         _options = options ?? new XLSTMOptions();
+        _options.Validate();
         Options = _options;
-        _vocabSize = vocabSize;
-        _modelDimension = modelDimension;
-        _numLayers = numLayers;
-        _numHeads = numHeads;
-        _maxSeqLength = maxSeqLength;
+        _vocabSize = _options.VocabSize;
+        _modelDimension = _options.ModelDimension;
+        _numLayers = _options.NumLayers;
+        _numHeads = _options.NumHeads;
+        _maxSeqLength = _options.MaxSequenceLength;
         // xLSTM (Beck et al., 2024, S4.1) trains with AdamW. No optimizer was wired here at all, so
         // training fell through to the framework default and barely moved: across the memorization
         // task the loss drifted only 0.13% between one and two iterations, leaving the more-data

--- a/src/NeuralNetworks/Zamba2LanguageModel.cs
+++ b/src/NeuralNetworks/Zamba2LanguageModel.cs
@@ -69,15 +69,8 @@ public partial class Zamba2LanguageModel<T> : TokenLanguageModelLayoutBase<T>
 
     public Zamba2LanguageModel(
         NeuralNetworkArchitecture<T> architecture,
-        int vocabSize = 32000,
-        int modelDimension = 3584,
-        int numLayers = 81,
-        int stateDimension = 64,
-        int numHeads = 32,
-        int attentionInterval = 6,
-        int maxSeqLength = 4096,
-        ILossFunction<T>? lossFunction = null,
-        Zamba2Options? options = null)
+        Zamba2Options? options = null,
+        ILossFunction<T>? lossFunction = null)
         : base(architecture,
             // Zamba-2's LM head emits RAW LOGITS (DenseLayer with no activation, see
             // LayerHelper.CreateZamba2Layers), so the loss must be cross-entropy-with-logits (fused
@@ -89,14 +82,15 @@ public partial class Zamba2LanguageModel<T> : TokenLanguageModelLayoutBase<T>
             lossFunction ?? new AiDotNet.LossFunctions.CrossEntropyWithLogitsLoss<T>())
     {
         _options = options ?? new Zamba2Options();
+        _options.Validate();
         Options = _options;
-        _vocabSize = vocabSize;
-        _modelDimension = modelDimension;
-        _numLayers = numLayers;
-        _stateDimension = stateDimension;
-        _numHeads = numHeads;
-        _attentionInterval = attentionInterval;
-        _maxSeqLength = maxSeqLength;
+        _vocabSize = _options.VocabSize;
+        _modelDimension = _options.ModelDimension;
+        _numLayers = _options.NumLayers;
+        _stateDimension = _options.StateDimension;
+        _numHeads = _options.NumHeads;
+        _attentionInterval = _options.AttentionInterval;
+        _maxSeqLength = _options.MaxSequenceLength;
         InitializeLayers();
     }
 

--- a/src/NeuralNetworks/ZambaLanguageModel.cs
+++ b/src/NeuralNetworks/ZambaLanguageModel.cs
@@ -68,14 +68,8 @@ public partial class ZambaLanguageModel<T> : TokenLanguageModelLayoutBase<T>
 
     public ZambaLanguageModel(
         NeuralNetworkArchitecture<T> architecture,
-        int vocabSize = 32000,
-        int modelDimension = 3712,
-        int numLayers = 76,
-        int stateDimension = 16,
-        int attentionInterval = 6,
-        int maxSeqLength = 4096,
-        ILossFunction<T>? lossFunction = null,
-        ZambaOptions? options = null)
+        ZambaOptions? options = null,
+        ILossFunction<T>? lossFunction = null)
         : base(architecture,
             // Zamba's LM head emits RAW LOGITS (DenseLayer with no activation, see
             // LayerHelper.CreateZambaLayers), so the loss must be cross-entropy-with-logits (fused
@@ -87,13 +81,14 @@ public partial class ZambaLanguageModel<T> : TokenLanguageModelLayoutBase<T>
             lossFunction ?? new AiDotNet.LossFunctions.CrossEntropyWithLogitsLoss<T>())
     {
         _options = options ?? new ZambaOptions();
+        _options.Validate();
         Options = _options;
-        _vocabSize = vocabSize;
-        _modelDimension = modelDimension;
-        _numLayers = numLayers;
-        _stateDimension = stateDimension;
-        _attentionInterval = attentionInterval;
-        _maxSeqLength = maxSeqLength;
+        _vocabSize = _options.VocabSize;
+        _modelDimension = _options.ModelDimension;
+        _numLayers = _options.NumLayers;
+        _stateDimension = _options.StateDimension;
+        _attentionInterval = _options.AttentionInterval;
+        _maxSeqLength = _options.MaxSequenceLength;
         InitializeLayers();
     }
 

--- a/src/SpeechRecognition/ConformerFamily/ContextNetOptions.cs
+++ b/src/SpeechRecognition/ConformerFamily/ContextNetOptions.cs
@@ -119,7 +119,7 @@ public class ContextNetOptions : ModelOptions
     private static string[] GetDefaultVocabulary() => new[] { "<blank>", "<pad>", "<s>", "</s>", "<unk>", "|", "a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o", "p", "q", "r", "s", "t", "u", "v", "w", "x", "y", "z", "'", " " };
 
     /// <summary>Validates the configuration.</summary>
-    /// <exception cref="ArgumentException">The vocabulary and its declared size disagree.</exception>
+    /// <exception cref="InvalidOperationException">The vocabulary and its declared size disagree.</exception>
     /// <remarks>
     /// A size that does not match the token list is not recoverable at decode time: the output layer
     /// emits ids the vocabulary cannot name, and the only options left are to drop them silently or to

--- a/src/SpeechRecognition/ConformerFamily/ContextNetOptions.cs
+++ b/src/SpeechRecognition/ConformerFamily/ContextNetOptions.cs
@@ -119,7 +119,7 @@ public class ContextNetOptions : ModelOptions
     private static string[] GetDefaultVocabulary() => new[] { "<blank>", "<pad>", "<s>", "</s>", "<unk>", "|", "a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o", "p", "q", "r", "s", "t", "u", "v", "w", "x", "y", "z", "'", " " };
 
     /// <summary>Validates the configuration.</summary>
-    /// <exception cref="InvalidOperationException">The vocabulary and its declared size disagree.</exception>
+    /// <exception cref="ArgumentException">The vocabulary and its declared size disagree.</exception>
     /// <remarks>
     /// A size that does not match the token list is not recoverable at decode time: the output layer
     /// emits ids the vocabulary cannot name, and the only options left are to drop them silently or to

--- a/src/SpeechRecognition/ConformerFamily/RWKVTransducerOptions.cs
+++ b/src/SpeechRecognition/ConformerFamily/RWKVTransducerOptions.cs
@@ -165,7 +165,7 @@ public class RWKVTransducerOptions : ModelOptions
     private static string[] GetDefaultVocabulary() => new[] { "<blank>", "<pad>", "<s>", "</s>", "<unk>", "|", "a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o", "p", "q", "r", "s", "t", "u", "v", "w", "x", "y", "z", "'", " " };
 
     /// <summary>Validates the configuration.</summary>
-    /// <exception cref="InvalidOperationException">The vocabulary and its declared size disagree.</exception>
+    /// <exception cref="ArgumentException">The vocabulary and its declared size disagree.</exception>
     public void Validate()
     {
         if (Vocabulary is null || Vocabulary.Length == 0)

--- a/src/SpeechRecognition/ConformerFamily/RWKVTransducerOptions.cs
+++ b/src/SpeechRecognition/ConformerFamily/RWKVTransducerOptions.cs
@@ -165,7 +165,7 @@ public class RWKVTransducerOptions : ModelOptions
     private static string[] GetDefaultVocabulary() => new[] { "<blank>", "<pad>", "<s>", "</s>", "<unk>", "|", "a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o", "p", "q", "r", "s", "t", "u", "v", "w", "x", "y", "z", "'", " " };
 
     /// <summary>Validates the configuration.</summary>
-    /// <exception cref="ArgumentException">The vocabulary and its declared size disagree.</exception>
+    /// <exception cref="InvalidOperationException">The vocabulary and its declared size disagree.</exception>
     public void Validate()
     {
         if (Vocabulary is null || Vocabulary.Length == 0)

--- a/src/Video/Options/VideoHyperparameterOptions.cs
+++ b/src/Video/Options/VideoHyperparameterOptions.cs
@@ -1,0 +1,106 @@
+using AiDotNet.Models.Options;
+
+namespace AiDotNet.Video.Options;
+
+/// <summary>
+/// Shared configuration for video models: action recognition, segmentation, generation,
+/// super-resolution, frame interpolation, tracking, denoising, inpainting and depth.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>For Beginners:</b> Video models work on several frames at once rather than a single
+/// picture, so on top of the usual size settings they need to know how many frames they look
+/// at together. Each model's own options class ships the values from its paper, so you do not
+/// normally set any of these.
+/// </para>
+/// <para>
+/// Derived options classes assign their paper's values in their parameterless constructor.
+/// See <see cref="ModelHyperparameterOptions"/> for why these properties are non-nullable.
+/// </para>
+/// <para>
+/// <b>Not to be confused with <c>VideoModelOptions&lt;T&gt;</c>,</b> which is an earlier and
+/// now largely abandoned attempt at the same idea: it takes a type parameter it never uses,
+/// follows the nullable + <c>Effective*</c> pattern this design moves away from, and is
+/// derived from by exactly one of the 108 options classes under <c>src/Video/Options</c>
+/// (96 of them derive straight from <c>NeuralNetworkOptions</c> instead). It is left in place
+/// for now and removed when the video models are wired to this base.
+/// </para>
+/// </remarks>
+public abstract class VideoHyperparameterOptions : ModelHyperparameterOptions
+{
+    /// <summary>
+    /// Gets or sets the width of the model's main feature representation.
+    /// </summary>
+    /// <remarks>
+    /// <para><b>For Beginners:</b> How many numbers the model uses to describe what it sees at
+    /// each position. This is the most common size knob across the video models — wider
+    /// captures more, and costs proportionally more memory.</para>
+    /// </remarks>
+    public int NumFeatures { get; set; }
+
+    /// <summary>
+    /// Gets or sets the number of stacked blocks in the model.
+    /// </summary>
+    public int NumLayers { get; set; }
+
+    /// <summary>
+    /// Gets or sets how many consecutive frames the model processes together.
+    /// </summary>
+    /// <remarks>
+    /// <para><b>For Beginners:</b> A single frame cannot show motion. Models look at a short
+    /// stack of frames — commonly 8 or 16 — so they can tell a person sitting down from a
+    /// person standing up.</para>
+    /// </remarks>
+    public int NumFrames { get; set; }
+
+    /// <summary>
+    /// Gets or sets the width of the embedding produced for each token or patch.
+    /// </summary>
+    public int EmbedDim { get; set; }
+
+    /// <summary>
+    /// Gets or sets the number of attention heads.
+    /// </summary>
+    public int NumHeads { get; set; }
+
+    /// <summary>
+    /// Gets or sets the number of output categories, for classification models.
+    /// </summary>
+    /// <remarks>
+    /// <para><b>For Beginners:</b> Action-recognition models trained on the Kinetics-400
+    /// dataset predict one of 400 actions, so they use 400 here.</para>
+    /// </remarks>
+    public int NumClasses { get; set; }
+
+    /// <summary>
+    /// Gets or sets the upscaling factor, for super-resolution models.
+    /// </summary>
+    /// <remarks>
+    /// <para><b>For Beginners:</b> A factor of 4 turns a 480p video into roughly 1920p by
+    /// quadrupling each side.</para>
+    /// </remarks>
+    public int ScaleFactor { get; set; }
+
+    /// <summary>
+    /// Gets or sets the number of refinement passes, for models that iterate towards an
+    /// answer (optical flow, diffusion sampling).
+    /// </summary>
+    /// <remarks>
+    /// <para><b>For Beginners:</b> Some models improve their own answer repeatedly rather than
+    /// producing it in one go. More passes means better quality and slower inference.</para>
+    /// </remarks>
+    public int NumIterations { get; set; }
+
+    /// <summary>
+    /// Throws if a dimension every video model requires has been left unset.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when a required dimension is zero or negative, which means the derived options
+    /// class did not assign its paper defaults.
+    /// </exception>
+    protected void ValidateCore()
+    {
+        Require(NumFeatures, nameof(NumFeatures));
+        Require(NumFrames, nameof(NumFrames));
+    }
+}

--- a/src/Video/Options/VideoHyperparameterOptions.cs
+++ b/src/Video/Options/VideoHyperparameterOptions.cs
@@ -94,7 +94,7 @@ public abstract class VideoHyperparameterOptions : ModelHyperparameterOptions
     /// <summary>
     /// Throws if a dimension every video model requires has been left unset.
     /// </summary>
-    /// <exception cref="InvalidOperationException">
+    /// <exception cref="ArgumentException">
     /// Thrown when a required dimension is zero or negative, which means the derived options
     /// class did not assign its paper defaults.
     /// </exception>

--- a/tests/AiDotNet.OptionsContractTests/AiDotNet.OptionsContractTests.csproj
+++ b/tests/AiDotNet.OptionsContractTests/AiDotNet.OptionsContractTests.csproj
@@ -1,0 +1,30 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>net10.0;net8.0;net471</TargetFrameworks>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <LangVersion>latest</LangVersion>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <!-- Tests do not need public API docs, and MambaOptions' existing model cref is
+         outside this scalar-only project. Malformed XML warnings stay enabled. -->
+    <NoWarn>$(NoWarn);CS1591;CS1574</NoWarn>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" PrivateAssets="all" />
+  </ItemGroup>
+  <!-- Compile the real scalar-only options and their complete base chain. No model,
+       tensor package, generator, or replacement base implementation is involved. -->
+  <ItemGroup>
+    <Compile Include="../../src/Models/Options/ModelOptions.cs" Link="Production/ModelOptions.cs" />
+    <Compile Include="../../src/Models/Options/NeuralNetworkOptions.cs" Link="Production/NeuralNetworkOptions.cs" />
+    <Compile Include="../../src/Models/Options/ModelHyperparameterOptions.cs" Link="Production/ModelHyperparameterOptions.cs" />
+    <Compile Include="../../src/Models/Options/DocumentNeuralNetworkOptions.cs" Link="Production/DocumentNeuralNetworkOptions.cs" />
+    <Compile Include="../../src/NeuralNetworks/Options/SequenceModelOptions.cs" Link="Production/SequenceModelOptions.cs" />
+    <Compile Include="../../src/NeuralNetworks/Options/EagleOptions.cs;../../src/NeuralNetworks/Options/FalconMambaOptions.cs;../../src/NeuralNetworks/Options/FinchOptions.cs;../../src/NeuralNetworks/Options/GatedDeltaNetOptions.cs;../../src/NeuralNetworks/Options/GLAOptions.cs;../../src/NeuralNetworks/Options/GriffinOptions.cs;../../src/NeuralNetworks/Options/HawkOptions.cs;../../src/NeuralNetworks/Options/JambaOptions.cs;../../src/NeuralNetworks/Options/Mamba2Options.cs;../../src/NeuralNetworks/Options/MambaOptions.cs;../../src/NeuralNetworks/Options/RecurrentGemmaOptions.cs;../../src/NeuralNetworks/Options/RWKV4Options.cs;../../src/NeuralNetworks/Options/RWKV7Options.cs;../../src/NeuralNetworks/Options/SambaOptions.cs;../../src/NeuralNetworks/Options/XLSTMOptions.cs;../../src/NeuralNetworks/Options/Zamba2Options.cs;../../src/NeuralNetworks/Options/ZambaOptions.cs" Link="Production/%(Filename)%(Extension)" />
+    <Compile Include="../AiDotNet.Tests/UnitTests/Models/Options/SequenceModelOptionsContractTests.cs" Link="SequenceModelOptionsContractTests.cs" />
+  </ItemGroup>
+</Project>

--- a/tests/AiDotNet.OptionsContractTests/AiDotNet.OptionsContractTests.csproj
+++ b/tests/AiDotNet.OptionsContractTests/AiDotNet.OptionsContractTests.csproj
@@ -23,8 +23,11 @@
     <Compile Include="../../src/Models/Options/NeuralNetworkOptions.cs" Link="Production/NeuralNetworkOptions.cs" />
     <Compile Include="../../src/Models/Options/ModelHyperparameterOptions.cs" Link="Production/ModelHyperparameterOptions.cs" />
     <Compile Include="../../src/Models/Options/DocumentNeuralNetworkOptions.cs" Link="Production/DocumentNeuralNetworkOptions.cs" />
+    <Compile Include="../../src/Models/Options/AudioHyperparameterOptions.cs" Link="Production/AudioHyperparameterOptions.cs" />
+    <Compile Include="../../src/NeuralNetworks/Options/VisionLanguageModelOptions.cs" Link="Production/VisionLanguageModelOptions.cs" />
     <Compile Include="../../src/NeuralNetworks/Options/SequenceModelOptions.cs" Link="Production/SequenceModelOptions.cs" />
     <Compile Include="../../src/NeuralNetworks/Options/EagleOptions.cs;../../src/NeuralNetworks/Options/FalconMambaOptions.cs;../../src/NeuralNetworks/Options/FinchOptions.cs;../../src/NeuralNetworks/Options/GatedDeltaNetOptions.cs;../../src/NeuralNetworks/Options/GLAOptions.cs;../../src/NeuralNetworks/Options/GriffinOptions.cs;../../src/NeuralNetworks/Options/HawkOptions.cs;../../src/NeuralNetworks/Options/JambaOptions.cs;../../src/NeuralNetworks/Options/Mamba2Options.cs;../../src/NeuralNetworks/Options/MambaOptions.cs;../../src/NeuralNetworks/Options/RecurrentGemmaOptions.cs;../../src/NeuralNetworks/Options/RWKV4Options.cs;../../src/NeuralNetworks/Options/RWKV7Options.cs;../../src/NeuralNetworks/Options/SambaOptions.cs;../../src/NeuralNetworks/Options/XLSTMOptions.cs;../../src/NeuralNetworks/Options/Zamba2Options.cs;../../src/NeuralNetworks/Options/ZambaOptions.cs" Link="Production/%(Filename)%(Extension)" />
     <Compile Include="../AiDotNet.Tests/UnitTests/Models/Options/SequenceModelOptionsContractTests.cs" Link="SequenceModelOptionsContractTests.cs" />
+    <Compile Include="../AiDotNet.Tests/UnitTests/Models/Options/SharedOptionsDocumentationContractTests.cs" Link="SharedOptionsDocumentationContractTests.cs" />
   </ItemGroup>
 </Project>

--- a/tests/AiDotNet.OptionsContractTests/OptionsDocumentationTests.cs
+++ b/tests/AiDotNet.OptionsContractTests/OptionsDocumentationTests.cs
@@ -1,0 +1,46 @@
+using System.Xml.Linq;
+using AiDotNet.Models.Options;
+using AiDotNet.NeuralNetworks.Options;
+using Xunit;
+
+namespace AiDotNet.OptionsContractTests;
+
+public class OptionsDocumentationTests
+{
+    [Theory]
+    [InlineData(typeof(JambaOptions), "2403.19887")]
+    [InlineData(typeof(Mamba2Options), "2405.21060")]
+    [InlineData(typeof(SambaOptions), "2406.07522")]
+    [InlineData(typeof(XLSTMOptions), "2405.04517")]
+    [InlineData(typeof(ZambaOptions), "2405.16712")]
+    public void ClassDocumentation_IsEmittedWithBeginnerContextAndOriginalPaper(Type optionsType, string arxivId)
+    {
+        var member = DocumentationMember("T:" + optionsType.FullName);
+        Assert.False(string.IsNullOrWhiteSpace(member.Element("summary")?.Value));
+        var remarks = member.Element("remarks") ?? throw new InvalidOperationException("Missing class remarks.");
+        Assert.Contains("For Beginners:", remarks.Value);
+        Assert.Contains("library", remarks.Value);
+        Assert.Contains(member.Elements("seealso"), seeAlso =>
+            (string?)seeAlso.Attribute("href") == "https://arxiv.org/abs/" + arxivId);
+    }
+
+    [Fact]
+    public void MaxGradNorm_ValueDocumentsDefaultAndDisablePolicy()
+    {
+        var member = DocumentationMember("P:" + typeof(ModelHyperparameterOptions).FullName + "." + nameof(ModelHyperparameterOptions.MaxGradNorm));
+        var value = member.Element("value") ?? throw new InvalidOperationException("Missing property value documentation.");
+        Assert.Contains("1.0", value.Value);
+        Assert.Contains("library safeguard", value.Value);
+        Assert.Contains("Zero or a negative value disables clipping", value.Value);
+    }
+
+    private static XElement DocumentationMember(string memberName)
+    {
+        // .NET Framework shadow-copies assemblies, but not their adjacent XML docs.
+        // The application base remains the actual test output directory on every TFM.
+        var assemblyName = typeof(OptionsDocumentationTests).Assembly.GetName().Name
+            ?? throw new InvalidOperationException("The test assembly has no name.");
+        var document = XDocument.Load(Path.Combine(AppContext.BaseDirectory, assemblyName + ".xml"));
+        return Assert.Single(document.Descendants("member"), member => (string?)member.Attribute("name") == memberName);
+    }
+}

--- a/tests/AiDotNet.OptionsContractTests/README.md
+++ b/tests/AiDotNet.OptionsContractTests/README.md
@@ -1,0 +1,79 @@
+# Sequence options review proof (#2128)
+
+This focused project compiles the **actual 17 sequence options classes and their complete
+base chain**, plus `DocumentNeuralNetworkOptions`. It source-links the same behavioral test
+fixture included in the main AiDotNet test project. There are no replacement bases, model
+stubs, tensor packages, or generator changes in this runner. Its six additional documentation
+cases inspect the compiler-emitted XML, not copies of the source comments.
+
+## Reproduce
+
+From the repository root, run each target with a unique results file:
+
+```powershell
+dotnet test tests/AiDotNet.OptionsContractTests/AiDotNet.OptionsContractTests.csproj -c Release -f net10.0 --logger "trx;LogFileName=options-net10.trx" --results-directory artifacts/options-contracts
+dotnet test tests/AiDotNet.OptionsContractTests/AiDotNet.OptionsContractTests.csproj -c Release -f net8.0 --logger "trx;LogFileName=options-net8.trx" --results-directory artifacts/options-contracts
+dotnet test tests/AiDotNet.OptionsContractTests/AiDotNet.OptionsContractTests.csproj -c Release -f net471 --logger "trx;LogFileName=options-net471.trx" --results-directory artifacts/options-contracts
+```
+
+The .NET Framework target executes on Windows. Linux uses the first command in the
+official `mcr.microsoft.com/dotnet/sdk:10.0` container. Copy source into an isolated build
+directory, or redirect all build outputs; do not let Linux overwrite Windows `bin`/`obj`.
+
+## Before and after (2026-09-11)
+
+The full 347-case fixture was run against source archived from PR head
+`671836a347436f4b023ebe3f02a86ea333ad0686`, then against the fixes, in separate Linux build
+directories. Both used the same final test files and package versions.
+
+| Proof | Passed | Failed | Skipped |
+| --- | ---: | ---: | ---: |
+| Old source, Linux .NET 10 | 174 | 173 | 0 |
+| Fixed source, Linux .NET 10 | 347 | 0 | 0 |
+| Fixed source, Windows .NET 10 | 347 | 0 | 0 |
+| Fixed source, Windows .NET 8 | 347 | 0 | 0 |
+| Fixed source, Windows .NET Framework 4.7.1 | 347 | 0 | 0 |
+
+The old-source failures are 19 complete-copy cases, 13 missing-copy/default cases,
+13 missing-copy/null cases, 113 numeric-validation cases, eight hybrid-interval cases,
+one Finch default regression, five class-documentation cases, and one missing property
+`value` documentation case. Every old run executed its tests; none is a build-error proxy.
+Local TRXs are retained under `artifacts/options-contracts/linux` and
+`artifacts/options-contracts/final` (ignored build evidence, not checked-in generated data).
+
+### What the cases establish
+
+- Every public writable property, including inherited `Seed`, `EncoderLayerCount`,
+  `MaxGradNorm`, and all nine sequence properties, receives a non-default sentinel before
+  copying. The assertion reports **all** lost values. Copies remain independent when the
+  original is changed, preserve nullable defaults, and reject null as `other`.
+- Each invalid-value case first validates an untouched default instance, changes exactly
+  one property selected by a typed expression, and requires an exception identifying both
+  the `options` parameter and that exact type/property. An unrelated dimension error cannot
+  satisfy the test.
+- `Validate()` now checks the stored optimizer configuration even if a model caller supplies
+  a custom optimizer. This is a stricter configuration boundary than the former default-only
+  checks; a custom optimizer still controls actual training, but does not make an invalid
+  stored rate, beta, decay, epsilon, or enabled clipping threshold valid. The GLA/GatedDelta
+  rate documentation explicitly states this distinction.
+- Required rates/ratios reject zero, negatives, NaN, and both infinities. AdamW decay permits
+  zero; betas permit zero and the greatest representable double below one but reject one.
+  A disabled gradient clip does not require an otherwise unused threshold. Pure recurrent
+  models do not suddenly require attention-only properties.
+- All 17 shipped sequence-size configurations and the declared optimizer defaults are
+  guarded explicitly. Finch is the single intentional restoration: its options initializer
+  was `3e-4` at `671836a347^`; the migration added an overriding `0.001` assignment copied
+  from a model scalar that was stored only in an unread field.
+- The five requested class descriptions cite the original papers, explain the architecture
+  to beginners, and distinguish published model sizes from this library's shipped settings.
+  Emitted XML assertions ensure these comments belong to the classes, not their constructors.
+
+This is proof of the options copy/validation/documentation contracts, **not** proof of full
+model-family training, GPU execution, model checkpoint equivalence, or the CI shard selector.
+The new document-base constructor enables derived classes to chain to it; it does not claim
+that every existing document leaf has already been migrated to that copy pattern.
+
+The first draft of the documentation fixture used `Assembly.Location`; .NET Framework's
+shadow copying exposed that it could not find the adjacent XML (six explicit test failures).
+Using `AppContext.BaseDirectory` fixes that test precondition. Final runs above use unique
+TRX filenames and the corrected fixture; the earlier setup failures are not counted as green.

--- a/tests/AiDotNet.OptionsRuntimeContractTests/AiDotNet.OptionsRuntimeContractTests.csproj
+++ b/tests/AiDotNet.OptionsRuntimeContractTests/AiDotNet.OptionsRuntimeContractTests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFrameworks>net10.0;net8.0;net471</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <LangVersion>latest</LangVersion>

--- a/tests/AiDotNet.OptionsRuntimeContractTests/AiDotNet.OptionsRuntimeContractTests.csproj
+++ b/tests/AiDotNet.OptionsRuntimeContractTests/AiDotNet.OptionsRuntimeContractTests.csproj
@@ -1,0 +1,30 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <LangVersion>latest</LangVersion>
+    <IsTestProject>true</IsTestProject>
+    <IsPackable>false</IsPackable>
+    <!-- Preserve the existing test assembly's access for source-linked internal API tests. -->
+    <AssemblyName>AiDotNetTests</AssemblyName>
+    <!-- Existing source-linked RWKV tests have async signatures without awaits. -->
+    <NoWarn>$(NoWarn);CS1998</NoWarn>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" PrivateAssets="all" />
+    <ProjectReference Include="../../src/AiDotNet.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="../AiDotNet.Tests/GlobalUsings.cs" Link="GlobalUsings.cs" />
+    <Compile Include="../AiDotNet.Tests/ModuleInitializer.cs" Link="ModuleInitializer.cs" />
+    <Compile Include="../AiDotNet.Tests/Helpers/LicenseTestSupport.cs" Link="LicenseTestSupport.cs" />
+    <Compile Include="../AiDotNet.Tests/IntegrationTests/Configuration/OptionsSurfaceRatchetTests.cs" Link="OptionsSurfaceRatchetTests.cs" />
+    <Compile Include="../AiDotNet.Tests/UnitTests/NeuralNetworks/Layers/SSM/RWKV7LanguageModelTests.cs" Link="RWKV7LanguageModelTests.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="../AiDotNet.Tests/xunit.runner.json" Link="xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+</Project>

--- a/tests/AiDotNet.OptionsRuntimeContractTests/README.md
+++ b/tests/AiDotNet.OptionsRuntimeContractTests/README.md
@@ -28,6 +28,23 @@ visibility is widened. The source-linked fixtures also remain in the main test p
 partial assembly loads, empty censuses, and missing migrated models. `ReportRemainingGaps`
 writes the complete grouped report through xUnit output rather than discarding it.
 
+Both fixture constructors explicitly call `TestModuleInitializer.EnsureInitialized()`.
+The automatic module initializer is excluded on .NET Framework, so merely linking its source
+does not initialize a focused `net471` run. The explicit call preserves the same CPU/threading
+and offline-licensing setup without relying on another test class running first.
+
+The runner targets `net10.0`, `net8.0` and `net471`. After the final explicit-initialization
+correction, the primary reviewer ran the same 63-case filter on all three: **63 passed,
+zero failed, zero skipped per target** (189 passing executions). With all three core outputs
+already built, reproduce with:
+
+```powershell
+$env:AIDOTNET_FORCE_CPU = '1'
+$env:DOTNET_gcServer = '0'
+$env:COMPlus_gcServer = '0'
+dotnet test tests/AiDotNet.OptionsRuntimeContractTests/AiDotNet.OptionsRuntimeContractTests.csproj -c Release -m:1 -p:BuildProjectReferences=false -p:BuildInParallel=false -p:UseSharedCompilation=false --filter 'FullyQualifiedName~OptionsSurfaceRatchetTests|FullyQualifiedName~RWKV7LanguageModelTests.Model_Constructor_' --logger 'trx;LogFilePrefix=pr2128-runtime-explicit-init' --results-directory artifacts/options-runtime
+```
+
 ## Recorded local proof (2026-09-11)
 
 Against the current PR's Release/net10.0 core, the complete filter passed **63/63, zero skips**

--- a/tests/AiDotNet.OptionsRuntimeContractTests/README.md
+++ b/tests/AiDotNet.OptionsRuntimeContractTests/README.md
@@ -1,0 +1,75 @@
+# Actual-model options regression checks
+
+This runner references the real AiDotNet project and source-links the production test
+fixtures. It does not compile substitute models, replacement base classes, or a published
+older package in place of the PR's core library.
+
+The options cohort creates all 17 migrated sequence models at vocabulary 32, width 16/32,
+one/two blocks, and four tokens. Each comparison changes only width or depth. Assertions
+inspect the real embedding parameters, physical layers/contained hybrid blocks, and flattened
+parameter lengths after lazy initialization. The hybrid scheduler and RWKV7 stack are counted
+through their actual contained blocks, not their constant outer layer count. Models are disposed after every case. Separate
+negative controls prove an options object that advertises a changed depth cannot pass while
+the actual model remains unchanged. These are construction/topology checks, not a claim that
+all architecture features, training recipes, or GPU kernels have been validated.
+
+After building the current core for .NET 10, the narrow command is:
+
+```powershell
+$env:AIDOTNET_FORCE_CPU = '1'
+dotnet test tests/AiDotNet.OptionsRuntimeContractTests/AiDotNet.OptionsRuntimeContractTests.csproj -c Release -f net10.0 -p:BuildProjectReferences=false -p:GeneratePackageOnBuild=false --filter "FullyQualifiedName~OptionsSurfaceRatchetTests|FullyQualifiedName~RWKV7LanguageModelTests.Model_Constructor_" --logger "trx;LogFileName=options-runtime-net10.trx" --results-directory artifacts/options-runtime
+```
+
+The full RWKV fixture is compiled, but the filter executes only its constructor contracts.
+The runner source-links the repository's `ModuleInitializer.cs`, `LicenseTestSupport.cs`, and
+`xunit.runner.json`, retaining its CPU initialization, offline test licensing, and test scheduling.
+Its assembly name matches the main test assembly's existing internal-API access; no production
+visibility is widened. The source-linked fixtures also remain in the main test project. The discovery guard refuses
+partial assembly loads, empty censuses, and missing migrated models. `ReportRemainingGaps`
+writes the complete grouped report through xUnit output rather than discarding it.
+
+## Recorded local proof (2026-09-11)
+
+Against the current PR's Release/net10.0 core, the complete filter passed **63/63, zero skips**
+in four seconds of test execution. This is 34 actual-model comparisons, two unchanged-topology
+negative controls, ten census/report/metadata contracts, and 17 RWKV7 constructor cases.
+The census measured 1,005 concrete models and 977 gaps across 297 model types. Reapplying the
+old architecture/artifact name exclusions changed the census by exactly zero; the baseline
+constant remains 977.
+
+Examples from the real materialized-parameter comparisons:
+
+| Change | Before | After |
+| --- | ---: | ---: |
+| Mamba width 16 to 32 | 3,728 | 10,624 |
+| Jamba depth one to two | 3,760 | 5,136 |
+| RWKV7 depth one to two | 8,544 | 16,032 |
+| Eagle width 16 to 32 | 4,560 | 15,744 |
+
+The first runtime attempt was not green: 56 passed and four failed. Three failures exposed
+`ParameterInfo.HasDefaultValue` attempting to box an enum nested in an open generic model;
+one exposed the assertion's incorrect assumption that RWKV7 added an outer layer per block.
+The metadata fix preserves the normal reflection API and uses the `HasDefault` flag only
+after its specific open-generic-enum `ArgumentException`. It does not drop decimal or DateTime
+defaults encoded by attributes. See the runtime's [default-value implementation](https://raw.githubusercontent.com/dotnet/runtime/main/src/coreclr/System.Private.CoreLib/src/System/Reflection/RuntimeParameterInfo.cs)
+and the [metadata flag contract](https://learn.microsoft.com/en-us/dotnet/api/system.reflection.parameterattributes).
+
+Isolated test-source mutants referenced the same current core; the production/test worktree
+was not reverted for these controls:
+
+| Isolated mutation | Expected failures observed |
+| --- | --- |
+| Restore old silent partial/empty discovery and discarded report | 4 failed, 1 passed; each of the four new guards rejected the old behavior |
+| Restore direct `HasDefaultValue` without the narrow enum fallback | Open-generic control failed; closed-generic control passed |
+| Replace all default checks with only `HasDefault` | Both metadata controls failed, detecting lost attribute constants |
+
+The mutant runner was `artifacts/options-runtime/mutants/OptionsMutants.csproj`, with
+`BuildProjectReferences=false`, the same module initializer/licensing/xUnit configuration,
+and isolated test binaries. The guard mutation restored the former report body and omitted
+the new discovery failures. Metadata mutations changed only the `HasDefaultValue` helper;
+all assertions were unchanged. TRXs are under `artifacts/options-runtime`:
+`options-runtime-net10-corrected.trx`, `options-old-guards-mutant.trx`,
+`options-old-metadata-mutant.trx`, and `options-blanket-flags-mutant.trx`.
+
+This bounded proof does not assert full training convergence, GPU parity, every option's
+behavior, or completion of the remaining model-family migrations.

--- a/tests/AiDotNet.Tests/AiDotNetTests.csproj
+++ b/tests/AiDotNet.Tests/AiDotNetTests.csproj
@@ -55,6 +55,7 @@
     <!-- Keep the generator active as an analyzer and reference its assembly so the analyzer's
          diagnostics can also be exercised directly by the Roslyn contract tests below. -->
     <ProjectReference Include="..\..\src\AiDotNet.Generators\AiDotNet.Generators.csproj" OutputItemType="Analyzer" />
+    <EmbeddedResource Include="..\..\src\AiDotNet.Generators\TestScaffoldGenerator.cs" LogicalName="Review.TestScaffoldGenerator.cs" />
   </ItemGroup>
 
   <!-- Shared-compile the generator's Roslyn-free floatify helper so its (#1679) logic can be

--- a/tests/AiDotNet.Tests/Generators/GeneratedSequenceFixtureContractTests.cs
+++ b/tests/AiDotNet.Tests/Generators/GeneratedSequenceFixtureContractTests.cs
@@ -1,0 +1,164 @@
+using System;
+using System.Collections.Immutable;
+using System.IO;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Xunit;
+
+namespace AiDotNet.Tests.Generators;
+
+/// <summary>Checks the effective sequence fixtures, including rules that would otherwise be shadowed.</summary>
+public sealed class GeneratedSequenceFixtureContractTests
+{
+    public enum SequenceFixture
+    {
+        XLSTMLanguageModel,
+        GriffinLanguageModel,
+        HawkLanguageModel,
+        GLALanguageModel,
+        GatedDeltaNetLanguageModel,
+        RecurrentGemmaLanguageModel,
+    }
+
+    [Theory]
+    [InlineData(SequenceFixture.XLSTMLanguageModel, 64, 128, 4)]
+    [InlineData(SequenceFixture.GriffinLanguageModel, 128, 32, 128)]
+    [InlineData(SequenceFixture.HawkLanguageModel, 128, 32, 128)]
+    [InlineData(SequenceFixture.GLALanguageModel, 128, 32, 128)]
+    [InlineData(SequenceFixture.GatedDeltaNetLanguageModel, 128, 32, 128)]
+    [InlineData(SequenceFixture.RecurrentGemmaLanguageModel, 256, 128, 4)]
+    public void EffectiveFixturePreservesItsBoundedOptions(
+        SequenceFixture model, int vocabulary, int context, int outputSize)
+    {
+        ClassDeclarationSyntax fixture = GenerateFixture(model);
+        MethodDeclarationSyntax factory = Assert.Single(fixture.Members.OfType<MethodDeclarationSyntax>(),
+            method => method.Identifier.ValueText == "CreateNetwork");
+        ObjectCreationExpressionSyntax options = Assert.Single(factory.DescendantNodes()
+            .OfType<ObjectCreationExpressionSyntax>(), node => node.Initializer != null);
+        AssertAssignment(options, "VocabSize", vocabulary);
+        AssertAssignment(options, "ModelDimension", 32);
+        AssertAssignment(options, "NumLayers", 1);
+        AssertAssignment(options, "MaxSequenceLength", context);
+        if (model is SequenceFixture.GriffinLanguageModel or SequenceFixture.HawkLanguageModel)
+        {
+            AssertAssignment(options, "RecurrenceDimension", 40);
+            Assert.DoesNotContain(options.Initializer?.Expressions ?? default,
+                expression => expression is AssignmentExpressionSyntax assignment
+                    && assignment.Left.ToString() == "NumHeads");
+        }
+        else if (model != SequenceFixture.RecurrentGemmaLanguageModel)
+        {
+            AssertAssignment(options, "NumHeads", 4);
+        }
+
+        ObjectCreationExpressionSyntax architecture = Assert.Single(factory.DescendantNodes()
+            .OfType<ObjectCreationExpressionSyntax>(),
+            node => node.Type.ToString().Contains("NeuralNetworkArchitecture"));
+        Assert.NotNull(architecture.ArgumentList);
+        ArgumentSyntax output = Assert.Single(architecture.ArgumentList.Arguments,
+            argument => argument.NameColon?.Name.Identifier.ValueText == "outputSize");
+        Assert.Equal(outputSize, Assert.IsType<LiteralExpressionSyntax>(output.Expression).Token.Value);
+    }
+
+    [Theory]
+    [InlineData(SequenceFixture.XLSTMLanguageModel)]
+    [InlineData(SequenceFixture.GriffinLanguageModel)]
+    [InlineData(SequenceFixture.HawkLanguageModel)]
+    [InlineData(SequenceFixture.GLALanguageModel)]
+    [InlineData(SequenceFixture.GatedDeltaNetLanguageModel)]
+    public void SpecializedFixtureHasOneEffectiveConstructorRule(SequenceFixture model)
+    {
+        SyntaxNode generator = ReadGenerator();
+        Assert.Single(generator.DescendantNodes().OfType<IfStatementSyntax>(), branch =>
+            branch.Condition.DescendantNodesAndSelf().OfType<MemberAccessExpressionSyntax>()
+                .Any(access => access.Name.Identifier.ValueText == "ClassName")
+            && branch.Condition.DescendantNodesAndSelf().OfType<LiteralExpressionSyntax>()
+                .Any(literal => Equals(literal.Token.Value, model.ToString()))
+            && branch.Statement is BlockSyntax block
+            && block.Statements.OfType<ExpressionStatementSyntax>().Any(statement =>
+                statement.Expression is AssignmentExpressionSyntax assignment
+                && assignment.Left.ToString() == "constructorExpr"));
+    }
+
+    [Theory]
+    [InlineData(SequenceFixture.GriffinLanguageModel)]
+    [InlineData(SequenceFixture.HawkLanguageModel)]
+    public void SpecializedFixtureHasNoUnreachableScaleFallback(SequenceFixture model)
+    {
+        VariableDeclaratorSyntax scale = Assert.Single(ReadGenerator().DescendantNodes()
+            .OfType<VariableDeclaratorSyntax>(), variable => variable.Identifier.ValueText == "scaleArgs");
+        Assert.DoesNotContain(scale.DescendantNodes().OfType<SwitchExpressionArmSyntax>(), arm =>
+            arm.Pattern is ConstantPatternSyntax pattern
+            && pattern.Expression is LiteralExpressionSyntax literal
+            && Equals(literal.Token.Value, model.ToString()));
+    }
+
+    private static SyntaxNode ReadGenerator()
+    {
+        // Embedded by both test projects: inspect the actual generator source, not a copied rule.
+        using Stream stream = typeof(GeneratedSequenceFixtureContractTests).Assembly
+            .GetManifestResourceStream("Review.TestScaffoldGenerator.cs")
+            ?? throw new InvalidOperationException("The generator source contract resource is missing.");
+        using var reader = new StreamReader(stream);
+        return CSharpSyntaxTree.ParseText(reader.ReadToEnd()).GetRoot();
+    }
+
+    private static ClassDeclarationSyntax GenerateFixture(SequenceFixture model)
+    {
+        string models = """
+            using System;
+            namespace AiDotNet.Attributes
+            {
+                [AttributeUsage(AttributeTargets.Class)]
+                public sealed class ModelDomainAttribute : Attribute
+                { public ModelDomainAttribute(int domain) { } }
+            }
+            namespace AiDotNet.Tensors.LinearAlgebra { public class Tensor<T> { } }
+            namespace AiDotNet.Interfaces
+            {
+                public interface IFullModel<T, TInput, TOutput> { }
+                public interface INeuralNetworkModel<T> : IFullModel<T,
+                    AiDotNet.Tensors.LinearAlgebra.Tensor<T>, AiDotNet.Tensors.LinearAlgebra.Tensor<T>> { }
+            }
+            namespace AiDotNet.NeuralNetworks
+            {
+                public class NeuralNetworkArchitecture<T> { }
+                public abstract class NeuralNetworkBase<T> : AiDotNet.Interfaces.INeuralNetworkModel<T> { }
+            }
+            """;
+        // The enum is the closed fixture policy; its names become compiler symbols only here.
+        models += $"namespace AiDotNet.NeuralNetworks {{ [AiDotNet.Attributes.ModelDomain(0)] "
+            + $"public class {model}<T> : NeuralNetworkBase<T> {{ "
+            + $"public {model}(NeuralNetworkArchitecture<T> architecture) {{ }} }} }}";
+        var references = AppDomain.CurrentDomain.GetAssemblies()
+            .Where(assembly => !assembly.IsDynamic && !string.IsNullOrEmpty(assembly.Location))
+            .Where(assembly => assembly.GetName().Name is string name
+                && (name == "mscorlib" || name == "netstandard" || name == "System"
+                    || name.StartsWith("System.", StringComparison.Ordinal)))
+            .Select(assembly => assembly.Location).Distinct(StringComparer.Ordinal)
+            .Select(path => MetadataReference.CreateFromFile(path)).ToImmutableArray<MetadataReference>();
+        var compilation = CSharpCompilation.Create("AiDotNetTests",
+            new[] { CSharpSyntaxTree.ParseText(models) }, references,
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+        Assert.DoesNotContain(compilation.GetDiagnostics(), diagnostic => diagnostic.Severity == DiagnosticSeverity.Error);
+        GeneratorDriver driver = CSharpGeneratorDriver.Create(new AiDotNet.Generators.TestScaffoldGenerator());
+        var result = driver.RunGenerators(compilation).GetRunResult();
+        Assert.DoesNotContain(result.Diagnostics, diagnostic => diagnostic.Severity == DiagnosticSeverity.Error);
+        Assert.All(result.Results, generator => Assert.Null(generator.Exception));
+        var fixture = Assert.Single(result.GeneratedTrees.SelectMany(tree => tree.GetRoot()
+            .DescendantNodes().OfType<ClassDeclarationSyntax>()),
+            declaration => declaration.Identifier.ValueText == $"{model}Tests");
+        Assert.DoesNotContain(fixture.SyntaxTree.GetDiagnostics(), diagnostic => diagnostic.Severity == DiagnosticSeverity.Error);
+        return fixture;
+    }
+
+    private static void AssertAssignment(ObjectCreationExpressionSyntax options, string property, int expected)
+    {
+        Assert.NotNull(options.Initializer);
+        AssignmentExpressionSyntax assignment = Assert.Single(options.Initializer.Expressions
+            .OfType<AssignmentExpressionSyntax>(), expression => expression.Left.ToString() == property);
+        Assert.Equal(expected, Assert.IsType<LiteralExpressionSyntax>(assignment.Right).Token.Value);
+    }
+}

--- a/tests/AiDotNet.Tests/IntegrationTests/Configuration/OptionsSurfaceRatchetTests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/Configuration/OptionsSurfaceRatchetTests.cs
@@ -43,7 +43,7 @@ public class OptionsSurfaceRatchetTests
     /// add a property to that model's options class instead.
     /// </para>
     /// <para>
-    /// Phase 2 lowered this from 1067 to 1004 by migrating 11 sequence models (63 params).
+    /// Phase 2 lowered this from 1067 to 977 by migrating all 17 sequence models (90 params).
     /// Originally established by this test's first run against master on 2026-09-08. A file-based
     /// estimate of the three areas named in the #2090 spec put it at 806; this reflection
     /// measurement found 1067, because the defect also reaches models the file scan never
@@ -54,7 +54,7 @@ public class OptionsSurfaceRatchetTests
     /// models read them.
     /// </para>
     /// </remarks>
-    private const int Baseline = 1004;
+    private const int Baseline = 977;
 
     /// <summary>
     /// How far the measured count may sit below <see cref="Baseline"/> before the test insists

--- a/tests/AiDotNet.Tests/IntegrationTests/Configuration/OptionsSurfaceRatchetTests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/Configuration/OptionsSurfaceRatchetTests.cs
@@ -3,9 +3,14 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using System.Text;
+using AiDotNet.Enums;
 using AiDotNet.Models.Options;
 using AiDotNet.NeuralNetworks;
+using AiDotNet.NeuralNetworks.Layers;
+using AiDotNet.NeuralNetworks.Layers.SSM;
+using AiDotNet.NeuralNetworks.Options;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace AiDotNet.Tests.IntegrationTests.Configuration;
 
@@ -32,6 +37,10 @@ namespace AiDotNet.Tests.IntegrationTests.Configuration;
 /// </remarks>
 public class OptionsSurfaceRatchetTests
 {
+    private readonly ITestOutputHelper _output;
+
+    public OptionsSurfaceRatchetTests(ITestOutputHelper output) => _output = output;
+
     /// <summary>
     /// Number of tunable defaulted constructor parameters that have no correspondingly-named
     /// property on their model's options type.
@@ -72,23 +81,6 @@ public class OptionsSurfaceRatchetTests
             "modelIdentity", "modelPath", "name", "seed", "checkpointPath", "weightsPath",
         };
 
-    /// <summary>
-    /// Types that are not models in the sense this ratchet cares about: architecture
-    /// descriptors, whose topology knobs belong on the architecture per the design, and
-    /// compiled-model hosts, whose parameters describe an artifact rather than a model.
-    /// </summary>
-    private static readonly HashSet<string> ExcludedTypeNames =
-        new HashSet<string>(StringComparer.Ordinal)
-        {
-            "NeuralNetworkArchitecture",
-            "TransformerArchitecture",
-            "DualStreamArchitecture",
-            "TripleStreamArchitecture",
-            "AudioTextDualStreamArchitecture",
-            "CompiledModelHost",
-            "ChainedCompiledModelHost",
-        };
-
     [Fact]
     public void ModelConstructorParametersHaveOptionsEquivalents_DoesNotRegress()
     {
@@ -117,20 +109,44 @@ public class OptionsSurfaceRatchetTests
     /// Pins the fix rather than its shape: a property that exists but is ignored still leaves
     /// the model unconfigurable, which is the exact defect this work addresses.
     /// </summary>
-    /// <remarks>
-    /// <para>
-    /// Enabled in phase 2, when the first model family is wired to read its options. Until
-    /// then there is nothing for it to assert against — no model reads a value off its options
-    /// object, so every case would fail for the reason the ratchet above already records.
-    /// </para>
-    /// </remarks>
-    [Fact(Skip = "Enabled in phase 2 of #2090, when the first model family reads its options.")]
-    public void SettingAnOptionsPropertyChangesTheModel()
+    [Theory]
+    [MemberData(nameof(SequenceConfigurationCases))]
+    public void SettingAnOptionsPropertyChangesTheModel(SequenceFamily family, SequenceChange change)
     {
-        throw new NotImplementedException(
-            "Phase 2: for each migrated model, constructing it with a non-default Options value "
-                + "must produce a model whose GetOptions() returns that value and whose layer "
-                + "stack differs from the default-constructed one.");
+        var baseline = CreateSequenceModel(family, width: 16, depth: 1);
+        using var baselineModel = baseline.Model;
+        var changed = CreateSequenceModel(family,
+            width: change == SequenceChange.Width ? 32 : 16,
+            depth: change == SequenceChange.Depth ? 2 : 1);
+        using var changedModel = changed.Model;
+
+        var expectedModelType = RequiredSequenceModels[family].MakeGenericType(typeof(float));
+        Assert.Equal(expectedModelType, baselineModel.GetType());
+        Assert.Equal(expectedModelType, changedModel.GetType());
+        Assert.Same(baseline.Options, baselineModel.GetOptions());
+        Assert.Same(changed.Options, changedModel.GetOptions());
+        AssertMaterializedChange(baselineModel, changedModel, change);
+        _output.WriteLine($"{family}/{change}: materialized parameters {baselineModel.ParameterCount} -> "
+            + $"{changedModel.ParameterCount}; physical block/layer count {TopologySize(baselineModel)} -> {TopologySize(changedModel)}.");
+    }
+
+    [Theory]
+    [InlineData(SequenceFamily.Mamba)]
+    [InlineData(SequenceFamily.Jamba)]
+    public void BehavioralGuard_RejectsOptionsEchoWithoutTopologyChange(SequenceFamily family)
+    {
+        var baseline = CreateSequenceModel(family, width: 16, depth: 1);
+        using var baselineModel = baseline.Model;
+        var unchanged = CreateSequenceModel(family, width: 16, depth: 1);
+        using var unchangedModel = unchanged.Model;
+        // Real models with identical topology, but GetOptions now advertises another depth.
+        // This reproduces the false-proof shape without any replacement model or fake layer.
+        unchanged.Options.NumLayers = 2;
+        Assert.Same(unchanged.Options, unchangedModel.GetOptions());
+        Assert.Equal(2, Assert.IsAssignableFrom<SequenceModelOptions>(unchangedModel.GetOptions()).NumLayers);
+        var failure = Assert.ThrowsAny<Xunit.Sdk.XunitException>(() =>
+            AssertMaterializedChange(baselineModel, unchangedModel, SequenceChange.Depth));
+        Assert.Contains("Physical topology does not match", failure.Message);
     }
 
     /// <summary>
@@ -145,9 +161,163 @@ public class OptionsSurfaceRatchetTests
             .ThenBy(g => g.Key, StringComparer.Ordinal)
             .ToList();
 
-        // Not an assertion about the contents — this exists so the numbers are visible in the
-        // test output when a migration lands, without having to run the scanner by hand.
-        Assert.True(byType.Count >= 0);
+        _output.WriteLine($"Total gaps: {gaps.Count} across {byType.Count} model types; "
+            + $"scanned {GetModelTypes().Length} concrete models.");
+        foreach (var group in byType)
+        {
+            _output.WriteLine($"  {group.Key} ({group.Count()}) options={group.First().OptionsTypeName}: "
+                + string.Join(", ", group.Select(gap => gap.ParameterName)));
+        }
+        Assert.Equal(gaps.Count, byType.Sum(group => group.Count()));
+    }
+
+    [Fact]
+    public void GapReport_WritesTheMeasuredCountsAndEveryGroup()
+    {
+        var capture = new CapturingOutput();
+        new OptionsSurfaceRatchetTests(capture).ReportRemainingGaps();
+        var gaps = MeasureGaps();
+        var groups = gaps.GroupBy(gap => gap.TypeName).OrderByDescending(group => group.Count())
+            .ThenBy(group => group.Key, StringComparer.Ordinal).ToArray();
+        Assert.Equal(groups.Length + 1, capture.Lines.Count);
+        Assert.Equal($"Total gaps: {gaps.Count} across {groups.Length} model types; "
+            + $"scanned {GetModelTypes().Length} concrete models.", capture.Lines[0]);
+        for (var index = 0; index < groups.Length; index++)
+        {
+            Assert.Contains(groups[index].Key, capture.Lines[index + 1]);
+            Assert.All(groups[index], gap => Assert.Contains(gap.ParameterName, capture.Lines[index + 1]));
+        }
+    }
+
+    private sealed class CapturingOutput : ITestOutputHelper
+    {
+        public List<string> Lines { get; } = new();
+        public void WriteLine(string message) => Lines.Add(message);
+        public void WriteLine(string format, params object[] args) => Lines.Add(string.Format(format, args));
+    }
+
+    public enum SequenceFamily
+    {
+        Eagle, FalconMamba, Finch, GatedDeltaNet, GLA, Griffin, Hawk, Jamba,
+        Mamba2, Mamba, RecurrentGemma, RWKV4, RWKV7, Samba, XLSTM, Zamba2, Zamba
+    }
+
+    public enum SequenceChange { Width, Depth }
+
+    public static IEnumerable<object[]> SequenceConfigurationCases =>
+        from family in Enum.GetValues(typeof(SequenceFamily)).Cast<SequenceFamily>()
+        from change in Enum.GetValues(typeof(SequenceChange)).Cast<SequenceChange>()
+        select new object[] { family, change };
+
+    private static readonly IReadOnlyDictionary<SequenceFamily, Type> RequiredSequenceModels = new Dictionary<SequenceFamily, Type>
+    {
+        [SequenceFamily.Eagle] = typeof(EagleLanguageModel<>),
+        [SequenceFamily.FalconMamba] = typeof(FalconMambaLanguageModel<>),
+        [SequenceFamily.Finch] = typeof(FinchLanguageModel<>),
+        [SequenceFamily.GatedDeltaNet] = typeof(GatedDeltaNetLanguageModel<>),
+        [SequenceFamily.GLA] = typeof(GLALanguageModel<>),
+        [SequenceFamily.Griffin] = typeof(GriffinLanguageModel<>),
+        [SequenceFamily.Hawk] = typeof(HawkLanguageModel<>),
+        [SequenceFamily.Jamba] = typeof(JambaLanguageModel<>),
+        [SequenceFamily.Mamba2] = typeof(Mamba2LanguageModel<>),
+        [SequenceFamily.Mamba] = typeof(MambaLanguageModel<>),
+        [SequenceFamily.RecurrentGemma] = typeof(RecurrentGemmaLanguageModel<>),
+        [SequenceFamily.RWKV4] = typeof(RWKV4LanguageModel<>),
+        [SequenceFamily.RWKV7] = typeof(RWKV7LanguageModel<>),
+        [SequenceFamily.Samba] = typeof(SambaLanguageModel<>),
+        [SequenceFamily.XLSTM] = typeof(XLSTMLanguageModel<>),
+        [SequenceFamily.Zamba2] = typeof(Zamba2LanguageModel<>),
+        [SequenceFamily.Zamba] = typeof(ZambaLanguageModel<>)
+    };
+
+    [Fact]
+    public void SequenceCohort_CoversEveryMigratedOptionsType()
+    {
+        var optionsTypes = typeof(SequenceModelOptions).Assembly.GetTypes()
+            .Where(type => !type.IsAbstract && typeof(SequenceModelOptions).IsAssignableFrom(type))
+            .OrderBy(type => type.FullName, StringComparer.Ordinal).ToArray();
+        var consumedTypes = RequiredSequenceModels.Values.SelectMany(type => type.GetConstructors())
+            .SelectMany(constructor => constructor.GetParameters()).Select(parameter => parameter.ParameterType)
+            .Where(type => typeof(SequenceModelOptions).IsAssignableFrom(type)).Distinct()
+            .OrderBy(type => type.FullName, StringComparer.Ordinal).ToArray();
+        Assert.Equal(17, Enum.GetValues(typeof(SequenceFamily)).Length);
+        Assert.Equal(17, RequiredSequenceModels.Count);
+        Assert.Equal(Enum.GetValues(typeof(SequenceFamily)).Cast<SequenceFamily>().OrderBy(family => family),
+            RequiredSequenceModels.Keys.OrderBy(family => family));
+        Assert.Equal(optionsTypes, consumedTypes);
+        Assert.Equal(17, optionsTypes.Length);
+    }
+
+    private static (NeuralNetworkBase<float> Model, SequenceModelOptions Options) CreateSequenceModel(
+        SequenceFamily family, int width, int depth) => family switch
+        {
+            SequenceFamily.Eagle => Create(new EagleOptions(), (architecture, options) => new EagleLanguageModel<float>(architecture, options), width, depth),
+            SequenceFamily.FalconMamba => Create(new FalconMambaOptions(), (architecture, options) => new FalconMambaLanguageModel<float>(architecture, options), width, depth),
+            SequenceFamily.Finch => Create(new FinchOptions(), (architecture, options) => new FinchLanguageModel<float>(architecture, options), width, depth),
+            SequenceFamily.GatedDeltaNet => Create(new GatedDeltaNetOptions(), (architecture, options) => new GatedDeltaNetLanguageModel<float>(architecture, options), width, depth),
+            SequenceFamily.GLA => Create(new GLAOptions(), (architecture, options) => new GLALanguageModel<float>(architecture, options), width, depth),
+            SequenceFamily.Griffin => Create(new GriffinOptions { RecurrenceDimension = 16 }, (architecture, options) => new GriffinLanguageModel<float>(architecture, options), width, depth),
+            SequenceFamily.Hawk => Create(new HawkOptions { RecurrenceDimension = 16 }, (architecture, options) => new HawkLanguageModel<float>(architecture, options), width, depth),
+            SequenceFamily.Jamba => Create(new JambaOptions(), (architecture, options) => new JambaLanguageModel<float>(architecture, options), width, depth),
+            SequenceFamily.Mamba2 => Create(new Mamba2Options(), (architecture, options) => new Mamba2LanguageModel<float>(architecture, options), width, depth),
+            SequenceFamily.Mamba => Create(new MambaOptions(), (architecture, options) => new MambaLanguageModel<float>(architecture, options), width, depth),
+            SequenceFamily.RecurrentGemma => Create(new RecurrentGemmaOptions(), (architecture, options) => new RecurrentGemmaLanguageModel<float>(architecture, options), width, depth),
+            SequenceFamily.RWKV4 => Create(new RWKV4Options(), (architecture, options) => new RWKV4LanguageModel<float>(architecture, options), width, depth),
+            SequenceFamily.RWKV7 => Create(new RWKV7Options(), (architecture, options) => new RWKV7LanguageModel<float>(architecture, options), width, depth),
+            SequenceFamily.Samba => Create(new SambaOptions(), (architecture, options) => new SambaLanguageModel<float>(architecture, options), width, depth),
+            SequenceFamily.XLSTM => Create(new XLSTMOptions(), (architecture, options) => new XLSTMLanguageModel<float>(architecture, options), width, depth),
+            SequenceFamily.Zamba2 => Create(new Zamba2Options(), (architecture, options) => new Zamba2LanguageModel<float>(architecture, options), width, depth),
+            SequenceFamily.Zamba => Create(new ZambaOptions(), (architecture, options) => new ZambaLanguageModel<float>(architecture, options), width, depth),
+            _ => throw new ArgumentOutOfRangeException(nameof(family), family, "Unknown sequence family.")
+        };
+
+    private static (NeuralNetworkBase<float> Model, SequenceModelOptions Options) Create<TOptions>(TOptions options,
+        Func<NeuralNetworkArchitecture<float>, TOptions, NeuralNetworkBase<float>> construct, int width, int depth)
+        where TOptions : SequenceModelOptions
+    {
+        options.Seed = 42;
+        options.VocabSize = 32;
+        options.ModelDimension = width;
+        options.NumLayers = depth;
+        options.NumHeads = 2;
+        options.StateDimension = 8;
+        options.MaxSequenceLength = 4;
+        options.AttentionInterval = 2;
+        options.ExpandFactor = 2;
+        options.FfnMultiplier = 3.5;
+        var architecture = new NeuralNetworkArchitecture<float>(InputType.OneDimensional,
+            NeuralNetworkTaskType.TextGeneration, inputSize: 32, outputSize: 32);
+        return (construct(architecture, options), options);
+    }
+
+    private static int TopologySize(NeuralNetworkBase<float> model) => model.Layers.Sum(layer => layer switch
+    {
+        HybridBlockScheduler<float> scheduler => scheduler.NumBlocks,
+        Rwkv7Stack<float> stack => stack.Blocks.Count,
+        _ => 1
+    });
+
+    private static void AssertMaterializedChange(NeuralNetworkBase<float> baseline,
+        NeuralNetworkBase<float> changed, SequenceChange change)
+    {
+        Assert.InRange(baseline.LayerCount, 4, 8);
+        Assert.InRange(changed.LayerCount, 4, 8);
+        var baselineEmbedding = Assert.IsType<EmbeddingLayer<float>>(baseline.Layers[0]);
+        var changedEmbedding = Assert.IsType<EmbeddingLayer<float>>(changed.Layers[0]);
+        // Check an actual parameter tensor, not a model metadata/property echo.
+        Assert.Equal(32 * 16, baselineEmbedding.GetParameters().Length);
+        Assert.Equal(32 * (change == SequenceChange.Width ? 32 : 16), changedEmbedding.GetParameters().Length);
+        Assert.True(TopologySize(baseline) + (change == SequenceChange.Depth ? 1 : 0) == TopologySize(changed),
+            "Physical topology does not match the requested options change.");
+        // Count first so a broken configuration cannot trigger paper-scale flattening.
+        Assert.InRange(baseline.ParameterCount, 1, 1_000_000);
+        Assert.InRange(changed.ParameterCount, 1, 1_000_000);
+        var baselineParameters = baseline.GetParameters();
+        var changedParameters = changed.GetParameters();
+        Assert.Equal(baseline.ParameterCount, baselineParameters.Length);
+        Assert.Equal(changed.ParameterCount, changedParameters.Length);
+        Assert.True(changedParameters.Length > baselineParameters.Length,
+            $"Changing {change} must increase materialized parameters, not just the advertised options.");
     }
 
     private sealed class Gap
@@ -172,29 +342,52 @@ public class OptionsSurfaceRatchetTests
     /// the inheritance chain is the only approach that does.
     /// </para>
     /// </remarks>
-    private static IEnumerable<Type> GetModelTypes()
+    private static Type[] GetModelTypes(Func<Type[]>? loadTypes = null)
     {
         Type[] types;
         try
         {
-            types = typeof(NeuralNetworkBase<>).Assembly.GetTypes();
+            types = (loadTypes ?? typeof(NeuralNetworkBase<>).Assembly.GetTypes)();
         }
         catch (ReflectionTypeLoadException ex)
         {
-            // A type that fails to load cannot be measured, but the ones that did load still can.
-            types = ex.Types.Where(t => t != null).ToArray()!;
+            throw new InvalidOperationException("Cannot measure the options surface from a partially loaded assembly. "
+                + string.Join("; ", ex.LoaderExceptions.Where(error => error != null).Select(error => error?.Message)), ex);
         }
 
-        foreach (var type in types)
-        {
-            if (type == null || type.IsAbstract || type.IsInterface || !type.IsClass) continue;
-            if (!type.IsPublic && !type.IsNestedPublic) continue;
+        var models = types.Where(type => type.IsClass && !type.IsAbstract
+            && (type.IsPublic || type.IsNestedPublic) && DerivesFromNeuralNetworkBase(type)).ToArray();
+        if (models.Length == 0)
+            throw new InvalidOperationException("Model discovery returned no concrete neural-network models.");
+        var missing = RequiredSequenceModels.Values.Except(models).ToArray();
+        if (missing.Length > 0)
+            throw new InvalidOperationException("Model discovery omitted migrated sequence models: "
+                + string.Join(", ", missing.Select(type => type.FullName)));
+        return models;
+    }
 
-            string simpleName = StripArity(type.Name);
-            if (ExcludedTypeNames.Contains(simpleName)) continue;
+    [Fact]
+    public void ModelDiscovery_RejectsEmptyCensus()
+    {
+        var exception = Assert.Throws<InvalidOperationException>(() => GetModelTypes(() => Array.Empty<Type>()));
+        Assert.Contains("no concrete", exception.Message);
+    }
 
-            if (DerivesFromNeuralNetworkBase(type)) yield return type;
-        }
+    [Fact]
+    public void ModelDiscovery_RejectsIncompleteCohort()
+    {
+        var exception = Assert.Throws<InvalidOperationException>(() => GetModelTypes(() => new[] { typeof(RWKV7LanguageModel<>) }));
+        Assert.Contains(typeof(MambaLanguageModel<>).FullName ?? nameof(MambaLanguageModel<float>), exception.Message);
+    }
+
+    [Fact]
+    public void ModelDiscovery_DoesNotDiscardLoaderFailures()
+    {
+        var failure = new ReflectionTypeLoadException(new[] { typeof(RWKV7LanguageModel<>) },
+            new Exception[] { new TypeLoadException("Required model dependency could not load.") });
+        var exception = Assert.Throws<InvalidOperationException>(() => GetModelTypes(() => throw failure));
+        Assert.Same(failure, exception.InnerException);
+        Assert.Contains("Required model dependency could not load", exception.Message);
     }
 
     private static bool DerivesFromNeuralNetworkBase(Type type)
@@ -233,7 +426,7 @@ public class OptionsSurfaceRatchetTests
                         continue;
                     }
 
-                    if (!parameter.HasDefaultValue) continue;
+                    if (!HasDefaultValue(parameter)) continue;
                     if (parameter.Name == null) continue;
                     if (ExcludedParameterNames.Contains(parameter.Name)) continue;
                     if (!IsTunable(parameterType)) continue;
@@ -266,6 +459,76 @@ public class OptionsSurfaceRatchetTests
         }
 
         return gaps;
+    }
+
+    private static bool HasDefaultValue(ParameterInfo parameter)
+    {
+        try
+        {
+            return parameter.HasDefaultValue;
+        }
+        catch (ArgumentException) when (parameter.ParameterType.IsEnum && parameter.ParameterType.ContainsGenericParameters)
+        {
+            // The runtime attempts to box a nested enum from an open generic model. That is
+            // not a constructible runtime type. Enum defaults are metadata constants, so only
+            // this case can use the flag; decimal/DateTime attribute defaults keep the normal path.
+            return (parameter.Attributes & ParameterAttributes.HasDefault) != 0;
+        }
+    }
+
+    [Theory]
+    [InlineData(typeof(DefaultMetadataSample<>))]
+    [InlineData(typeof(DefaultMetadataSample<int>))]
+    public void DefaultMetadata_PreservesRequiredOptionalAndAttributeConstants(Type declaringType)
+    {
+        var method = declaringType.GetMethod(nameof(DefaultMetadataSample<int>.Sample));
+        Assert.NotNull(method);
+        var parameters = method.GetParameters();
+        Assert.Equal(new[] { false, false, false, true, true, true, true, true, true, true, true, true },
+            parameters.Select(HasDefaultValue));
+        // The decimal and DateTime controls specifically forbid a blanket HasDefault flag check.
+        Assert.Equal(ParameterAttributes.None, parameters[3].Attributes & ParameterAttributes.HasDefault);
+        Assert.Equal(ParameterAttributes.None, parameters[6].Attributes & ParameterAttributes.HasDefault);
+        Assert.Equal(new DateTime(1234), parameters[3].DefaultValue);
+        Assert.Equal(1.25m, parameters[6].DefaultValue);
+    }
+
+    public sealed class DefaultMetadataSample<T>
+    {
+        public enum NestedMode { Standard, Custom }
+
+        public static void Sample(int required,
+            [System.Runtime.InteropServices.Optional] int optionalWithoutDefault,
+            NestedMode requiredMode,
+            [System.Runtime.CompilerServices.DateTimeConstant(1234)] DateTime date,
+            NestedMode mode = NestedMode.Custom,
+            int number = 3,
+            decimal amount = 1.25m,
+            string? label = null,
+            bool enabled = true,
+            float fraction = 0.5f,
+            double ratio = 0.25,
+            long count = 4)
+        {
+        }
+    }
+
+    [Fact]
+    public void ModelDiscovery_ArchitectureAndArtifactExclusionsDoNotChangeTheCensus()
+    {
+        var nonModels = new[]
+        {
+            typeof(NeuralNetworkArchitecture<>), typeof(TransformerArchitecture<>),
+            typeof(DualStreamArchitecture<>), typeof(TripleStreamArchitecture<>),
+            typeof(AudioTextDualStreamArchitecture<>), typeof(CompiledModelHost<>), typeof(ChainedCompiledModelHost<>)
+        };
+        Assert.All(nonModels, type => Assert.False(DerivesFromNeuralNetworkBase(type)));
+        var models = GetModelTypes();
+        // Compare with the exact previous name exclusions as a migration control, not a discovery policy.
+        var oldExcludedNames = nonModels.Select(type => StripArity(type.Name)).ToArray();
+        var oldCensus = models.Where(type => !oldExcludedNames.Contains(StripArity(type.Name))).ToArray();
+        Assert.Equal(models, oldCensus);
+        _output.WriteLine($"Current and previous-exclusion census: {models.Length} models; excluded model delta: {models.Length - oldCensus.Length}.");
     }
 
     /// <summary>

--- a/tests/AiDotNet.Tests/IntegrationTests/Configuration/OptionsSurfaceRatchetTests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/Configuration/OptionsSurfaceRatchetTests.cs
@@ -39,7 +39,12 @@ public class OptionsSurfaceRatchetTests
 {
     private readonly ITestOutputHelper _output;
 
-    public OptionsSurfaceRatchetTests(ITestOutputHelper output) => _output = output;
+    public OptionsSurfaceRatchetTests(ITestOutputHelper output)
+    {
+        // .NET Framework does not invoke the assembly's module initializer.
+        TestModuleInitializer.EnsureInitialized();
+        _output = output;
+    }
 
     /// <summary>
     /// Number of tunable defaulted constructor parameters that have no correspondingly-named

--- a/tests/AiDotNet.Tests/IntegrationTests/Configuration/OptionsSurfaceRatchetTests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/Configuration/OptionsSurfaceRatchetTests.cs
@@ -1,0 +1,324 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using AiDotNet.Models.Options;
+using AiDotNet.NeuralNetworks;
+using Xunit;
+
+namespace AiDotNet.Tests.IntegrationTests.Configuration;
+
+/// <summary>
+/// Ratchet for the model configuration surface (issue #2090).
+/// </summary>
+/// <remarks>
+/// <para>
+/// Model options classes are meant to be the only user-facing configuration surface for
+/// model-specific parameters. Today most models take their tunable values as defaulted
+/// constructor parameters instead, and the options object they are handed is stored,
+/// returned by <c>GetOptions()</c>, and never read.
+/// </para>
+/// <para>
+/// This test counts the gap and refuses to let it grow. As each model family is migrated,
+/// <see cref="Baseline"/> comes down. It is deliberately a count rather than a whitelist:
+/// a whitelist gets appended to without thought, whereas a number that may only ever
+/// decrease forces the choice to be explicit.
+/// </para>
+/// <para>
+/// The count is computed by reflection rather than by scanning source, so it needs no
+/// documentation to exist and cannot be defeated by deleting doc comments.
+/// </para>
+/// </remarks>
+public class OptionsSurfaceRatchetTests
+{
+    /// <summary>
+    /// Number of tunable defaulted constructor parameters that have no correspondingly-named
+    /// property on their model's options type.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>Lower this number when you migrate a model family; never raise it.</b> If this test
+    /// fails saying the count went up, you added a tunable parameter to a model constructor —
+    /// add a property to that model's options class instead.
+    /// </para>
+    /// <para>
+    /// Established by this test's first run against master on 2026-09-08. A file-based
+    /// estimate of the three areas named in the #2090 spec put it at 806; this reflection
+    /// measurement found 1067, because the defect also reaches models the file scan never
+    /// examined — Tacotron2Model, TtsModel and VITSModel each carry 16-20 tunable parameters
+    /// against a generic OnnxModelOptions, and SpeechEmotionRecognizer takes 11 with no
+    /// options parameter at all. Those areas looked healthy when measured by whether their
+    /// Options classes declare properties, which is a different question from whether the
+    /// models read them.
+    /// </para>
+    /// </remarks>
+    private const int Baseline = 1067;
+
+    /// <summary>
+    /// How far the measured count may sit below <see cref="Baseline"/> before the test insists
+    /// the baseline be lowered. Keeps ordinary refactoring from being blocked by an
+    /// off-by-a-couple drift while still forcing real progress to be recorded.
+    /// </summary>
+    private const int Slack = 10;
+
+    /// <summary>
+    /// Constructor parameters that are collaborators or artifacts rather than hyperparameters.
+    /// </summary>
+    private static readonly HashSet<string> ExcludedParameterNames =
+        new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        {
+            "modelIdentity", "modelPath", "name", "seed", "checkpointPath", "weightsPath",
+        };
+
+    /// <summary>
+    /// Types that are not models in the sense this ratchet cares about: architecture
+    /// descriptors, whose topology knobs belong on the architecture per the design, and
+    /// compiled-model hosts, whose parameters describe an artifact rather than a model.
+    /// </summary>
+    private static readonly HashSet<string> ExcludedTypeNames =
+        new HashSet<string>(StringComparer.Ordinal)
+        {
+            "NeuralNetworkArchitecture",
+            "TransformerArchitecture",
+            "DualStreamArchitecture",
+            "TripleStreamArchitecture",
+            "AudioTextDualStreamArchitecture",
+            "CompiledModelHost",
+            "ChainedCompiledModelHost",
+        };
+
+    [Fact]
+    public void ModelConstructorParametersHaveOptionsEquivalents_DoesNotRegress()
+    {
+        var gaps = MeasureGaps();
+        int count = gaps.Count;
+
+        Assert.True(
+            count <= Baseline,
+            BuildFailureMessage(
+                $"The options-surface gap grew from {Baseline} to {count}.",
+                "A model constructor gained a tunable defaulted parameter. Put the value on that "
+                    + "model's Options class instead, and have the constructor read it.",
+                gaps));
+
+        Assert.True(
+            count >= Baseline - Slack,
+            BuildFailureMessage(
+                $"The options-surface gap fell from {Baseline} to {count}. That is the goal — "
+                    + $"now lower the Baseline constant in {nameof(OptionsSurfaceRatchetTests)} to {count}.",
+                "The baseline only descends deliberately, so that progress is recorded in the "
+                    + "diff rather than silently absorbed.",
+                gaps));
+    }
+
+    /// <summary>
+    /// Pins the fix rather than its shape: a property that exists but is ignored still leaves
+    /// the model unconfigurable, which is the exact defect this work addresses.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Enabled in phase 2, when the first model family is wired to read its options. Until
+    /// then there is nothing for it to assert against — no model reads a value off its options
+    /// object, so every case would fail for the reason the ratchet above already records.
+    /// </para>
+    /// </remarks>
+    [Fact(Skip = "Enabled in phase 2 of #2090, when the first model family reads its options.")]
+    public void SettingAnOptionsPropertyChangesTheModel()
+    {
+        throw new NotImplementedException(
+            "Phase 2: for each migrated model, constructing it with a non-default Options value "
+                + "must produce a model whose GetOptions() returns that value and whose layer "
+                + "stack differs from the default-constructed one.");
+    }
+
+    /// <summary>
+    /// Reports the current gap, so a migration PR can see exactly what remains.
+    /// </summary>
+    [Fact]
+    public void ReportRemainingGaps()
+    {
+        var gaps = MeasureGaps();
+        var byType = gaps.GroupBy(g => g.TypeName)
+            .OrderByDescending(g => g.Count())
+            .ThenBy(g => g.Key, StringComparer.Ordinal)
+            .ToList();
+
+        // Not an assertion about the contents — this exists so the numbers are visible in the
+        // test output when a migration lands, without having to run the scanner by hand.
+        Assert.True(byType.Count >= 0);
+    }
+
+    private sealed class Gap
+    {
+        public string TypeName { get; set; } = string.Empty;
+
+        public string ParameterName { get; set; } = string.Empty;
+
+        public string OptionsTypeName { get; set; } = string.Empty;
+    }
+
+    /// <summary>
+    /// Every concrete model type in the AiDotNet assembly, found by walking the base chain.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Most models do not name <c>NeuralNetworkBase&lt;T&gt;</c> directly: <c>BGE</c> derives
+    /// from <c>TransformerEmbeddingNetwork</c>, <c>MambaLanguageModel</c> from
+    /// <c>TokenLanguageModelLayoutBase</c>, <c>TrOCR</c> from
+    /// <c>DocumentNeuralNetworkBase</c>. A search of the source for the base name finds only a
+    /// handful of files, so no naming or path heuristic identifies models correctly — walking
+    /// the inheritance chain is the only approach that does.
+    /// </para>
+    /// </remarks>
+    private static IEnumerable<Type> GetModelTypes()
+    {
+        Type[] types;
+        try
+        {
+            types = typeof(NeuralNetworkBase<>).Assembly.GetTypes();
+        }
+        catch (ReflectionTypeLoadException ex)
+        {
+            // A type that fails to load cannot be measured, but the ones that did load still can.
+            types = ex.Types.Where(t => t != null).ToArray()!;
+        }
+
+        foreach (var type in types)
+        {
+            if (type == null || type.IsAbstract || type.IsInterface || !type.IsClass) continue;
+            if (!type.IsPublic && !type.IsNestedPublic) continue;
+
+            string simpleName = StripArity(type.Name);
+            if (ExcludedTypeNames.Contains(simpleName)) continue;
+
+            if (DerivesFromNeuralNetworkBase(type)) yield return type;
+        }
+    }
+
+    private static bool DerivesFromNeuralNetworkBase(Type type)
+    {
+        for (var current = type.BaseType; current != null; current = current.BaseType)
+        {
+            if (current.IsGenericType
+                && current.GetGenericTypeDefinition() == typeof(NeuralNetworkBase<>))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static List<Gap> MeasureGaps()
+    {
+        var gaps = new List<Gap>();
+
+        foreach (var model in GetModelTypes())
+        {
+            Type? optionsType = null;
+            var tunable = new Dictionary<string, ParameterInfo>(StringComparer.Ordinal);
+
+            foreach (var ctor in model.GetConstructors(BindingFlags.Public | BindingFlags.Instance))
+            {
+                foreach (var parameter in ctor.GetParameters())
+                {
+                    var parameterType = Nullable.GetUnderlyingType(parameter.ParameterType)
+                        ?? parameter.ParameterType;
+
+                    if (IsOptionsType(parameterType))
+                    {
+                        optionsType ??= parameterType;
+                        continue;
+                    }
+
+                    if (!parameter.HasDefaultValue) continue;
+                    if (parameter.Name == null) continue;
+                    if (ExcludedParameterNames.Contains(parameter.Name)) continue;
+                    if (!IsTunable(parameterType)) continue;
+
+                    // Union across overloads: the same knob offered by two constructors is one gap.
+                    if (!tunable.ContainsKey(parameter.Name)) tunable[parameter.Name] = parameter;
+                }
+            }
+
+            if (tunable.Count == 0) continue;
+
+            var optionsProperties = optionsType == null
+                ? new HashSet<string>(StringComparer.Ordinal)
+                : new HashSet<string>(
+                    optionsType.GetProperties(BindingFlags.Public | BindingFlags.Instance)
+                        .Select(p => p.Name),
+                    StringComparer.Ordinal);
+
+            foreach (var parameterName in tunable.Keys)
+            {
+                if (optionsProperties.Contains(ToPascalCase(parameterName))) continue;
+
+                gaps.Add(new Gap
+                {
+                    TypeName = StripArity(model.Name),
+                    ParameterName = parameterName,
+                    OptionsTypeName = optionsType == null ? "(no options parameter)" : StripArity(optionsType.Name),
+                });
+            }
+        }
+
+        return gaps;
+    }
+
+    /// <summary>
+    /// A parameter carries a hyperparameter when it is a scalar or an enum. Interfaces,
+    /// delegates and model classes are collaborators, not configuration.
+    /// </summary>
+    private static bool IsTunable(Type type)
+    {
+        if (type.IsEnum) return true;
+
+        return type == typeof(int) || type == typeof(long) || type == typeof(double)
+            || type == typeof(float) || type == typeof(bool) || type == typeof(decimal)
+            || type == typeof(string);
+    }
+
+    private static bool IsOptionsType(Type type)
+    {
+        if (typeof(ModelOptions).IsAssignableFrom(type)) return true;
+
+        // Some options classes predate the ModelOptions hierarchy and stand alone.
+        return type.Name.StartsWith("Options", StringComparison.Ordinal)
+            || StripArity(type.Name).EndsWith("Options", StringComparison.Ordinal);
+    }
+
+    private static string StripArity(string typeName)
+    {
+        int tick = typeName.IndexOf('`');
+        return tick < 0 ? typeName : typeName.Substring(0, tick);
+    }
+
+    private static string ToPascalCase(string parameterName)
+    {
+        if (parameterName.Length == 0) return parameterName;
+        return char.ToUpperInvariant(parameterName[0]) + parameterName.Substring(1);
+    }
+
+    private static string BuildFailureMessage(string headline, string guidance, List<Gap> gaps)
+    {
+        var message = new StringBuilder();
+        message.AppendLine(headline);
+        message.AppendLine(guidance);
+        message.AppendLine();
+        message.AppendLine("Largest remaining gaps:");
+
+        foreach (var group in gaps.GroupBy(g => g.TypeName)
+                     .OrderByDescending(g => g.Count())
+                     .ThenBy(g => g.Key, StringComparer.Ordinal)
+                     .Take(15))
+        {
+            message.AppendLine(
+                $"  {group.Key} ({group.Count()}) options={group.First().OptionsTypeName}: "
+                    + string.Join(", ", group.Select(g => g.ParameterName).Take(8)));
+        }
+
+        return message.ToString();
+    }
+}

--- a/tests/AiDotNet.Tests/IntegrationTests/Configuration/OptionsSurfaceRatchetTests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/Configuration/OptionsSurfaceRatchetTests.cs
@@ -43,7 +43,8 @@ public class OptionsSurfaceRatchetTests
     /// add a property to that model's options class instead.
     /// </para>
     /// <para>
-    /// Established by this test's first run against master on 2026-09-08. A file-based
+    /// Phase 2 lowered this from 1067 to 1004 by migrating 11 sequence models (63 params).
+    /// Originally established by this test's first run against master on 2026-09-08. A file-based
     /// estimate of the three areas named in the #2090 spec put it at 806; this reflection
     /// measurement found 1067, because the defect also reaches models the file scan never
     /// examined — Tacotron2Model, TtsModel and VITSModel each carry 16-20 tunable parameters
@@ -53,7 +54,7 @@ public class OptionsSurfaceRatchetTests
     /// models read them.
     /// </para>
     /// </remarks>
-    private const int Baseline = 1067;
+    private const int Baseline = 1004;
 
     /// <summary>
     /// How far the measured count may sit below <see cref="Baseline"/> before the test insists

--- a/tests/AiDotNet.Tests/IntegrationTests/NeuralNetworks/FusedOptimizerIntegrationTests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/NeuralNetworks/FusedOptimizerIntegrationTests.cs
@@ -1,4 +1,5 @@
 using System;
+using AiDotNet.NeuralNetworks.Options;
 using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
@@ -866,7 +867,7 @@ public class FusedOptimizerIntegrationTests
         public FusedRecurrentGemmaTestModel(
             NeuralNetworkArchitecture<float> architecture,
             int vocabSize)
-            : base(architecture, vocabSize: vocabSize)
+            : base(architecture, new RecurrentGemmaOptions { VocabSize = vocabSize })
         {
         }
 

--- a/tests/AiDotNet.Tests/IntegrationTests/NeuralNetworks/RecurrentGemmaTrainingRegressionTests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/NeuralNetworks/RecurrentGemmaTrainingRegressionTests.cs
@@ -1,4 +1,5 @@
 using AiDotNet.Enums;
+using AiDotNet.NeuralNetworks.Options;
 using AiDotNet.Interfaces;
 using AiDotNet.NeuralNetworks;
 using AiDotNet.Tests.ModelFamilyTests.Base;
@@ -28,12 +29,7 @@ public sealed class RecurrentGemmaTrainingRegressionTests
             taskType: NeuralNetworkTaskType.TextGeneration,
             inputSize: 2,
             outputSize: 8);
-        using var model = new RecurrentGemmaLanguageModel<float>(
-            architecture,
-            vocabSize: 8,
-            modelDimension: 4,
-            numLayers: 1,
-            maxSeqLength: 2);
+        using var model = new RecurrentGemmaLanguageModel<float>(architecture, new RecurrentGemmaOptions { VocabSize = 8, ModelDimension = 4, NumLayers = 1, MaxSequenceLength = 2 });
 
         var input = new Tensor<float>([1, 2]);
         input[0] = 1;
@@ -101,13 +97,11 @@ public sealed class RecurrentGemmaTrainingRegressionTests
         protected override int[] OutputShape => [4];
 
         protected override INeuralNetworkModel<float> CreateNetwork() =>
-            new RecurrentGemmaLanguageModel<float>(
-                new NeuralNetworkArchitecture<float>(
+            new RecurrentGemmaLanguageModel<float>(new NeuralNetworkArchitecture<float>(
                     inputType: InputType.OneDimensional,
                     taskType: NeuralNetworkTaskType.TextGeneration,
                     inputSize: 128,
-                    outputSize: 4),
-                vocabSize: 4096);
+                    outputSize: 4), new RecurrentGemmaOptions { VocabSize = 4096 });
 
         public (RecurrentGemmaLanguageModel<float> Model, Tensor<float> Input, Tensor<float> Target)
             CreateTrainingCase()

--- a/tests/AiDotNet.Tests/IntegrationTests/NeuralNetworks/RgLruFamilyFusedCompiledTrainingTests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/NeuralNetworks/RgLruFamilyFusedCompiledTrainingTests.cs
@@ -148,8 +148,10 @@ public sealed class RgLruFamilyFusedCompiledTrainingTests
     private sealed class TestableRecurrentGemma : RecurrentGemmaLanguageModel<double>, IFusedTrainingProbe
     {
         internal TestableRecurrentGemma(NeuralNetworkArchitecture<double> architecture)
-            : base(architecture, vocabSize: 128, modelDimension: 32,
-                numLayers: 1, maxSeqLength: 32)
+            : base(architecture, new RecurrentGemmaOptions
+            {
+                VocabSize = 128, ModelDimension = 32, NumLayers = 1, MaxSequenceLength = 32,
+            })
         {
         }
 
@@ -159,9 +161,11 @@ public sealed class RgLruFamilyFusedCompiledTrainingTests
     private sealed class TestableGriffin : GriffinLanguageModel<double>, IFusedTrainingProbe
     {
         internal TestableGriffin(NeuralNetworkArchitecture<double> architecture)
-            : base(architecture, vocabSize: 128, modelDimension: 32,
-                numLayers: 1, maxSeqLength: 32,
-                options: new GriffinOptions { RecurrenceDimension = 40 })
+            : base(architecture, new GriffinOptions
+            {
+                VocabSize = 128, ModelDimension = 32, NumLayers = 1, MaxSequenceLength = 32,
+                RecurrenceDimension = 40,
+            })
         {
         }
 
@@ -171,9 +175,11 @@ public sealed class RgLruFamilyFusedCompiledTrainingTests
     private sealed class TestableHawk : HawkLanguageModel<double>, IFusedTrainingProbe
     {
         internal TestableHawk(NeuralNetworkArchitecture<double> architecture)
-            : base(architecture, vocabSize: 128, modelDimension: 32,
-                numLayers: 1, maxSeqLength: 32,
-                options: new HawkOptions { RecurrenceDimension = 40 })
+            : base(architecture, new HawkOptions
+            {
+                VocabSize = 128, ModelDimension = 32, NumLayers = 1, MaxSequenceLength = 32,
+                RecurrenceDimension = 40,
+            })
         {
         }
 

--- a/tests/AiDotNet.Tests/UnitTests/Agentic/Local/RealModelLocalInferenceTests.cs
+++ b/tests/AiDotNet.Tests/UnitTests/Agentic/Local/RealModelLocalInferenceTests.cs
@@ -1,4 +1,5 @@
 using System;
+using AiDotNet.NeuralNetworks.Options;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -58,13 +59,7 @@ namespace AiDotNetTests.UnitTests.Agentic.Local
                 inputSize: Vocab,
                 outputSize: Vocab);
 
-            return new MambaLanguageModel<double>(
-                architecture,
-                vocabSize: Vocab,
-                modelDimension: 16,
-                numLayers: 1,
-                stateDimension: 4,
-                maxSeqLength: MaxSeq);
+            return new MambaLanguageModel<double>(architecture, new MambaOptions { VocabSize = Vocab, ModelDimension = 16, NumLayers = 1, StateDimension = 4, MaxSequenceLength = MaxSeq });
         }
 
         [Fact(Timeout = 120000)]
@@ -101,9 +96,7 @@ namespace AiDotNetTests.UnitTests.Agentic.Local
                     NeuralNetworkTaskType.TextGeneration,
                     inputSize: Vocab,
                     outputSize: Vocab);
-                var model = new MambaLanguageModel<double>(
-                    architecture, vocabSize: Vocab, modelDimension: 16, numLayers: 2,
-                    stateDimension: 4, maxSeqLength: MaxSeq);
+                var model = new MambaLanguageModel<double>(architecture, new MambaOptions { VocabSize = Vocab, ModelDimension = 16, NumLayers = 2, StateDimension = 4, MaxSequenceLength = MaxSeq });
 
                 var prompt = new[] { 3, 1, 4, 1 };
                 var generated = new[] { 5, 9, 2 };

--- a/tests/AiDotNet.Tests/UnitTests/Agentic/Local/WeightImporterTests.cs
+++ b/tests/AiDotNet.Tests/UnitTests/Agentic/Local/WeightImporterTests.cs
@@ -1,4 +1,5 @@
 using System;
+using AiDotNet.NeuralNetworks.Options;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -28,7 +29,7 @@ namespace AiDotNetTests.UnitTests.Agentic.Local
         {
             var arch = new NeuralNetworkArchitecture<double>(
                 InputType.OneDimensional, NeuralNetworkTaskType.TextGeneration, inputSize: 12, outputSize: 12);
-            return new MambaLanguageModel<double>(arch, vocabSize: 12, modelDimension: 8, numLayers: 1, stateDimension: 4, maxSeqLength: 8);
+            return new MambaLanguageModel<double>(arch, new MambaOptions { VocabSize = 12, ModelDimension = 8, NumLayers = 1, StateDimension = 4, MaxSequenceLength = 8 });
         }
 
         [Fact(Timeout = 120000)]
@@ -63,7 +64,7 @@ namespace AiDotNetTests.UnitTests.Agentic.Local
             // Mamba stack: EmbeddingLayer + MambaBlock x2 + LayerNorm + Dense head.
             var arch = new NeuralNetworkArchitecture<double>(
                 InputType.OneDimensional, NeuralNetworkTaskType.TextGeneration, inputSize: 12, outputSize: 12);
-            var model = new MambaLanguageModel<double>(arch, vocabSize: 12, modelDimension: 8, numLayers: 2, stateDimension: 4, maxSeqLength: 8);
+            var model = new MambaLanguageModel<double>(arch, new MambaOptions { VocabSize = 12, ModelDimension = 8, NumLayers = 2, StateDimension = 4, MaxSequenceLength = 8 });
 
             var segments = ModelParameterMap.Build(model);
             var names = segments.Select(s => s.Name).ToList();
@@ -124,7 +125,7 @@ namespace AiDotNetTests.UnitTests.Agentic.Local
         {
             var arch = new NeuralNetworkArchitecture<double>(
                 InputType.OneDimensional, NeuralNetworkTaskType.TextGeneration, inputSize: 12, outputSize: 12);
-            return new MambaLanguageModel<double>(arch, vocabSize: 12, modelDimension: 8, numLayers: 2, stateDimension: 4, maxSeqLength: 8);
+            return new MambaLanguageModel<double>(arch, new MambaOptions { VocabSize = 12, ModelDimension = 8, NumLayers = 2, StateDimension = 4, MaxSequenceLength = 8 });
         }
 
         [Fact(Timeout = 120000)]

--- a/tests/AiDotNet.Tests/UnitTests/Agentic/SelfImproving/LoRAFineTunerTests.cs
+++ b/tests/AiDotNet.Tests/UnitTests/Agentic/SelfImproving/LoRAFineTunerTests.cs
@@ -1,4 +1,5 @@
 using System;
+using AiDotNet.NeuralNetworks.Options;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -86,8 +87,7 @@ namespace AiDotNetTests.UnitTests.Agentic.SelfImproving
             {
                 var arch = new NeuralNetworkArchitecture<double>(
                     InputType.OneDimensional, NeuralNetworkTaskType.TextGeneration, inputSize: vocab, outputSize: vocab);
-                var model = new MambaLanguageModel<double>(
-                    arch, vocabSize: vocab, modelDimension: 16, numLayers: 1, stateDimension: 4, maxSeqLength: seqLen);
+                var model = new MambaLanguageModel<double>(arch, new MambaOptions { VocabSize = vocab, ModelDimension = 16, NumLayers = 1, StateDimension = 4, MaxSequenceLength = seqLen });
 
                 // A small, repetitive dataset so the tiny model has a clear pattern to fit.
                 var dataset = new FineTuningDataset(new[]

--- a/tests/AiDotNet.Tests/UnitTests/Models/Options/SequenceModelOptionsContractTests.cs
+++ b/tests/AiDotNet.Tests/UnitTests/Models/Options/SequenceModelOptionsContractTests.cs
@@ -1,0 +1,314 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+using AiDotNet.Models.Options;
+using AiDotNet.NeuralNetworks.Options;
+using Xunit;
+
+namespace AiDotNet.Tests.UnitTests.Models.Options;
+
+/// <summary>Exercises real options without allocating a model or relying on generated model fixtures.</summary>
+public class SequenceModelOptionsContractTests
+{
+    private static readonly Type[] SequenceTypes =
+    {
+        typeof(EagleOptions), typeof(FalconMambaOptions), typeof(FinchOptions),
+        typeof(GatedDeltaNetOptions), typeof(GLAOptions), typeof(GriffinOptions),
+        typeof(HawkOptions), typeof(JambaOptions), typeof(Mamba2Options), typeof(MambaOptions),
+        typeof(RecurrentGemmaOptions), typeof(RWKV4Options), typeof(RWKV7Options),
+        typeof(SambaOptions), typeof(XLSTMOptions), typeof(Zamba2Options), typeof(ZambaOptions)
+    };
+
+    public static IEnumerable<object[]> CopyTypes => SequenceTypes
+        .Concat(new[] { typeof(NeuralNetworkOptions), typeof(DocumentNeuralNetworkOptions) })
+        .Select(type => new object[] { type });
+
+    [Fact]
+    public void SequenceRoster_CoversEveryConcreteSequenceOptionsType()
+    {
+        var actual = typeof(SequenceModelOptions).Assembly.GetTypes()
+            .Where(type => !type.IsAbstract && typeof(SequenceModelOptions).IsAssignableFrom(type))
+            .OrderBy(type => type.FullName, StringComparer.Ordinal);
+        Assert.Equal(SequenceTypes.OrderBy(type => type.FullName, StringComparer.Ordinal), actual);
+    }
+
+    [Theory]
+    [MemberData(nameof(CopyTypes))]
+    public void CopyConstructor_PreservesEveryDeclaredAndInheritedProperty(Type optionsType)
+    {
+        var original = Create(optionsType);
+        var properties = WritableProperties(optionsType);
+        Assert.NotEmpty(properties);
+        for (var index = 0; index < properties.Length; index++)
+        {
+            var property = properties[index];
+            var sentinel = Sentinel(property.PropertyType, property.GetValue(original), index);
+            Assert.NotEqual(property.GetValue(original), sentinel);
+            property.SetValue(original, sentinel);
+        }
+
+        var copy = CopyConstructor(optionsType).Invoke(new[] { original });
+        Assert.NotSame(original, copy);
+        // Collect every omitted property, not just the first reset-to-default value.
+        var mismatches = properties.Where(property =>
+            !Equals(property.GetValue(original), property.GetValue(copy)))
+            .Select(property => $"{optionsType.Name}.{property.Name}").ToArray();
+        Assert.True(mismatches.Length == 0, "Copy lost: " + string.Join(", ", mismatches));
+
+        foreach (var property in properties)
+        {
+            var copiedValue = property.GetValue(copy);
+            property.SetValue(original, Sentinel(property.PropertyType, copiedValue, 100));
+            Assert.Equal(copiedValue, property.GetValue(copy));
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(CopyTypes))]
+    public void CopyConstructor_PreservesDefaultsIncludingNullableState(Type optionsType)
+    {
+        var original = Create(optionsType);
+        var copy = CopyConstructor(optionsType).Invoke(new[] { original });
+        Assert.All(WritableProperties(optionsType), property =>
+            Assert.Equal(property.GetValue(original), property.GetValue(copy)));
+    }
+
+    [Theory]
+    [MemberData(nameof(CopyTypes))]
+    public void CopyConstructor_RejectsNullAtTheSharedBaseBoundary(Type optionsType)
+    {
+        var exception = Assert.Throws<TargetInvocationException>(() =>
+            CopyConstructor(optionsType).Invoke(new object?[] { null }));
+        var argument = Assert.IsType<ArgumentNullException>(exception.InnerException);
+        Assert.Equal("other", argument.ParamName);
+    }
+
+    [Fact]
+    public void Finch_DefaultLearningRateRetainsThePreMigrationInitializer()
+    {
+        // 671836a347^ has an empty ctor and this 3e-4 initializer; the migration
+        // accidentally overwrote it with an unused model-constructor scalar default.
+        Assert.Equal(3e-4, new FinchOptions().LearningRate);
+    }
+
+    [Theory]
+    [InlineData(typeof(EagleOptions), 65536, 256, 4, 8, 0, 512, 0, 0, 0.0)]
+    [InlineData(typeof(FalconMambaOptions), 65024, 256, 4, 0, 16, 512, 0, 2, 0.0)]
+    [InlineData(typeof(FinchOptions), 65536, 256, 4, 8, 0, 512, 0, 0, 0.0)]
+    [InlineData(typeof(GatedDeltaNetOptions), 50277, 256, 4, 8, 0, 512, 0, 0, 0.0)]
+    [InlineData(typeof(GLAOptions), 50277, 256, 4, 8, 0, 512, 0, 0, 0.0)]
+    [InlineData(typeof(GriffinOptions), 256000, 2048, 24, 0, 0, 2048, 0, 0, 0.0)]
+    [InlineData(typeof(HawkOptions), 256000, 2048, 24, 0, 0, 2048, 0, 0, 0.0)]
+    [InlineData(typeof(JambaOptions), 65536, 256, 8, 0, 16, 512, 8, 0, 0.0)]
+    [InlineData(typeof(Mamba2Options), 50277, 256, 4, 8, 64, 512, 0, 0, 0.0)]
+    [InlineData(typeof(MambaOptions), 50277, 256, 4, 0, 16, 512, 0, 2, 0.0)]
+    [InlineData(typeof(RecurrentGemmaOptions), 256000, 256, 4, 0, 0, 512, 0, 0, 0.0)]
+    [InlineData(typeof(RWKV4Options), 50277, 256, 4, 0, 0, 512, 0, 0, 0.0)]
+    [InlineData(typeof(RWKV7Options), 65536, 256, 4, 4, 0, 512, 0, 0, 3.5)]
+    [InlineData(typeof(SambaOptions), 32000, 256, 8, 0, 16, 512, 2, 0, 0.0)]
+    [InlineData(typeof(XLSTMOptions), 50277, 256, 4, 8, 0, 512, 0, 0, 0.0)]
+    [InlineData(typeof(Zamba2Options), 32000, 3584, 81, 32, 64, 4096, 6, 0, 0.0)]
+    [InlineData(typeof(ZambaOptions), 32000, 3712, 76, 0, 16, 4096, 6, 0, 0.0)]
+    public void ShippedSequenceDefaults_RemainUnchanged(Type optionsType, int vocabulary, int width,
+        int layers, int heads, int state, int sequenceLength, int attentionInterval, int expansion, double ffn)
+    {
+        var options = Assert.IsAssignableFrom<SequenceModelOptions>(Create(optionsType));
+        Assert.Equal(new[] { vocabulary, width, layers, heads, state, sequenceLength, attentionInterval, expansion },
+            new[] { options.VocabSize, options.ModelDimension, options.NumLayers, options.NumHeads,
+                options.StateDimension, options.MaxSequenceLength, options.AttentionInterval, options.ExpandFactor });
+        Assert.Equal(ffn, options.FfnMultiplier);
+        Assert.Equal(1.0, options.MaxGradNorm);
+        Assert.Null(options.Seed);
+        Assert.Null(options.EncoderLayerCount);
+    }
+
+    [Fact]
+    public void ShippedOptimizerDefaults_RemainUnchanged()
+    {
+        var griffin = new GriffinOptions();
+        var hawk = new HawkOptions();
+        var gemma = new RecurrentGemmaOptions();
+        var finch = new FinchOptions();
+        Assert.Equal(2560, griffin.RecurrenceDimension);
+        Assert.Equal(2560, hawk.RecurrenceDimension);
+        Assert.True(gemma.ScaleEmbeddingsBySqrtWidth);
+        Assert.Equal(new[] { 1e-4, 0.01, 0.9, 0.999, 1e-8, 1.0 },
+            new[] { griffin.LearningRate, griffin.WeightDecay, griffin.Beta1, griffin.Beta2, griffin.Epsilon, griffin.MaxGradientNorm });
+        Assert.Equal(new[] { 1e-4, 0.01, 0.9, 0.999, 1e-8, 1.0 },
+            new[] { hawk.LearningRate, hawk.WeightDecay, hawk.Beta1, hawk.Beta2, hawk.Epsilon, hawk.MaxGradientNorm });
+        Assert.Equal(new[] { 1e-4, 0.01, 0.9, 0.999, 1e-8, 1.0 },
+            new[] { gemma.LearningRate, gemma.WeightDecay, gemma.Beta1, gemma.Beta2, gemma.Epsilon, gemma.MaxGradientNorm });
+        Assert.True(griffin.EnableGradientClipping);
+        Assert.True(hawk.EnableGradientClipping);
+        Assert.True(gemma.EnableGradientClipping);
+        Assert.Equal(new[] { 2e-5, 0.9, 0.99, 0.001, 1.0 },
+            new[] { finch.MinLearningRate, finch.Beta1, finch.Beta2, finch.WeightDecay, finch.MaxGradientNorm });
+        Assert.True(finch.EnableGradientClipping);
+        Assert.Equal(3e-4, new GLAOptions().LearningRate);
+        Assert.Equal(3e-4, new GatedDeltaNetOptions().LearningRate);
+        Assert.Equal(1e-3, new XLSTMOptions().LearningRate);
+    }
+
+    public static IEnumerable<object[]> RequiredIntegers()
+    {
+        foreach (var type in SequenceTypes)
+        {
+            foreach (var property in new[]
+            {
+                Property<SequenceModelOptions, int>(options => options.VocabSize),
+                Property<SequenceModelOptions, int>(options => options.ModelDimension),
+                Property<SequenceModelOptions, int>(options => options.NumLayers),
+                Property<SequenceModelOptions, int>(options => options.MaxSequenceLength)
+            })
+            {
+                yield return new object[] { type, property, 0 };
+                yield return new object[] { type, property, -1 };
+            }
+        }
+
+        foreach (var type in new[] { typeof(JambaOptions), typeof(SambaOptions), typeof(ZambaOptions), typeof(Zamba2Options) })
+        {
+            var property = Property<SequenceModelOptions, int>(options => options.AttentionInterval);
+            yield return new object[] { type, property, 0 };
+            yield return new object[] { type, property, -1 };
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(RequiredIntegers))]
+    public void RequiredDimension_RejectsExactlyTheInvalidProperty(Type optionsType, PropertyInfo property, int value)
+    {
+        AssertInvalid(optionsType, property, value);
+    }
+
+    public static IEnumerable<object[]> InvalidDoubles()
+    {
+        var positive = new[] { 0.0, -1.0, double.NaN, double.PositiveInfinity, double.NegativeInfinity };
+        foreach (var row in InvalidValues<GLAOptions>(options => options.LearningRate, positive)) yield return row;
+        foreach (var row in InvalidValues<GatedDeltaNetOptions>(options => options.LearningRate, positive)) yield return row;
+        foreach (var row in InvalidValues<XLSTMOptions>(options => options.LearningRate, positive)) yield return row;
+        foreach (var row in InvalidValues<RWKV7Options>(options => options.FfnMultiplier, positive)) yield return row;
+
+        foreach (var row in AdamWInvalidValues<GriffinOptions>(
+            options => options.LearningRate, options => options.WeightDecay, options => options.Beta1,
+            options => options.Beta2, options => options.Epsilon, options => options.MaxGradientNorm)) yield return row;
+        foreach (var row in AdamWInvalidValues<HawkOptions>(
+            options => options.LearningRate, options => options.WeightDecay, options => options.Beta1,
+            options => options.Beta2, options => options.Epsilon, options => options.MaxGradientNorm)) yield return row;
+        foreach (var row in AdamWInvalidValues<RecurrentGemmaOptions>(
+            options => options.LearningRate, options => options.WeightDecay, options => options.Beta1,
+            options => options.Beta2, options => options.Epsilon, options => options.MaxGradientNorm)) yield return row;
+    }
+
+    [Theory]
+    [MemberData(nameof(InvalidDoubles))]
+    public void ConsumedNumericOption_RejectsExactlyTheInvalidProperty(Type optionsType, PropertyInfo property, double value)
+    {
+        AssertInvalid(optionsType, property, value);
+    }
+
+    [Theory]
+    [InlineData(0.0)]
+    [InlineData(-1.0)]
+    [InlineData(double.NaN)]
+    [InlineData(double.PositiveInfinity)]
+    public void DisabledClipping_DoesNotRequireAnUnusedThreshold(double threshold)
+    {
+        new GriffinOptions { EnableGradientClipping = false, MaxGradientNorm = threshold }.Validate();
+        new HawkOptions { EnableGradientClipping = false, MaxGradientNorm = threshold }.Validate();
+        new RecurrentGemmaOptions { EnableGradientClipping = false, MaxGradientNorm = threshold }.Validate();
+    }
+
+    [Theory]
+    [InlineData(0.0)]
+    [InlineData(0.99999999999999989)]
+    public void AdamW_AllowsZeroDecayAndBothValidBetaEndpoints(double beta)
+    {
+        new GriffinOptions { Beta1 = beta, Beta2 = beta, WeightDecay = 0.0 }.Validate();
+        new HawkOptions { Beta1 = beta, Beta2 = beta, WeightDecay = 0.0 }.Validate();
+        new RecurrentGemmaOptions { Beta1 = beta, Beta2 = beta, WeightDecay = 0.0 }.Validate();
+    }
+
+    [Fact]
+    public void ModelSpecificValidation_DoesNotRequireUnusedSharedProperties()
+    {
+        // A pure state-space model has no attention heads/interval or FFN ratio.
+        new MambaOptions { NumHeads = 0, AttentionInterval = 0, FfnMultiplier = 0 }.Validate();
+        new RWKV4Options { NumHeads = 0, StateDimension = 0, ExpandFactor = 0 }.Validate();
+        // An interval larger than the stack is not zero/negative and stays supported.
+        new JambaOptions { AttentionInterval = int.MaxValue }.Validate();
+        new SambaOptions { AttentionInterval = int.MaxValue }.Validate();
+        new ZambaOptions { AttentionInterval = int.MaxValue }.Validate();
+        new Zamba2Options { AttentionInterval = int.MaxValue }.Validate();
+    }
+
+    private static IEnumerable<object[]> AdamWInvalidValues<TOptions>(
+        Expression<Func<TOptions, double>> learningRate,
+        Expression<Func<TOptions, double>> weightDecay,
+        Expression<Func<TOptions, double>> beta1,
+        Expression<Func<TOptions, double>> beta2,
+        Expression<Func<TOptions, double>> epsilon,
+        Expression<Func<TOptions, double>> maxGradientNorm)
+    {
+        var positive = new[] { 0.0, -1.0, double.NaN, double.PositiveInfinity, double.NegativeInfinity };
+        foreach (var expression in new[] { learningRate, epsilon, maxGradientNorm })
+            foreach (var row in InvalidValues(expression, positive)) yield return row;
+        foreach (var row in InvalidValues(weightDecay, new[] { -1.0, double.NaN, double.PositiveInfinity, double.NegativeInfinity }))
+            yield return row;
+        foreach (var expression in new[] { beta1, beta2 })
+            foreach (var row in InvalidValues(expression, new[] { -1.0, 1.0, 2.0, double.NaN, double.PositiveInfinity, double.NegativeInfinity }))
+                yield return row;
+    }
+
+    private static IEnumerable<object[]> InvalidValues<TOptions>(Expression<Func<TOptions, double>> expression, double[] values)
+    {
+        var property = Property(expression);
+        return values.Select(value => new object[] { typeof(TOptions), property, value });
+    }
+
+    private static PropertyInfo Property<TOptions, TValue>(Expression<Func<TOptions, TValue>> expression)
+    {
+        var member = Assert.IsAssignableFrom<MemberExpression>(expression.Body);
+        return Assert.IsAssignableFrom<PropertyInfo>(member.Member);
+    }
+
+    private static void AssertInvalid(Type optionsType, PropertyInfo property, object value)
+    {
+        var options = Create(optionsType);
+        var validate = optionsType.GetMethod(nameof(GLAOptions.Validate), Type.EmptyTypes)
+            ?? throw new InvalidOperationException($"{optionsType.Name} has no Validate method.");
+        // Prove the fixture starts valid: a different default cannot cause a false pass.
+        validate.Invoke(options, Array.Empty<object>());
+        property.SetValue(options, value);
+        var exception = Assert.Throws<TargetInvocationException>(() => validate.Invoke(options, Array.Empty<object>()));
+        var argument = Assert.IsAssignableFrom<ArgumentException>(exception.InnerException);
+        Assert.Equal("options", argument.ParamName);
+        Assert.Contains($"{optionsType.Name}.{property.Name}", argument.Message);
+    }
+
+    private static object Create(Type type) => Activator.CreateInstance(type)
+        ?? throw new InvalidOperationException($"Could not instantiate {type.Name}.");
+
+    private static ConstructorInfo CopyConstructor(Type type)
+    {
+        var constructor = type.GetConstructor(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic,
+            binder: null, types: new[] { type }, modifiers: null)
+            ?? throw new InvalidOperationException($"{type.Name} has no copy constructor.");
+        Assert.True(constructor.IsPublic || (type == typeof(DocumentNeuralNetworkOptions) && constructor.IsFamily));
+        return constructor;
+    }
+
+    private static PropertyInfo[] WritableProperties(Type type) => type.GetProperties(BindingFlags.Instance | BindingFlags.Public)
+        .Where(property => property.GetMethod?.IsPublic == true && property.SetMethod?.IsPublic == true)
+        .OrderBy(property => property.Name, StringComparer.Ordinal).ToArray();
+
+    private static object Sentinel(Type type, object? current, int index)
+    {
+        if (type == typeof(int) || type == typeof(int?)) return 370 + index;
+        if (type == typeof(double)) return 17.125 + index;
+        if (type == typeof(bool)) return !Equals(current, true);
+        throw new InvalidOperationException($"Add a non-default sentinel for new option value type {type}.");
+    }
+}

--- a/tests/AiDotNet.Tests/UnitTests/Models/Options/SharedOptionsDocumentationContractTests.cs
+++ b/tests/AiDotNet.Tests/UnitTests/Models/Options/SharedOptionsDocumentationContractTests.cs
@@ -1,0 +1,51 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Xml.Linq;
+using AiDotNet.Models.Options;
+using AiDotNet.NeuralNetworks.Options;
+using Xunit;
+
+namespace AiDotNet.Tests.UnitTests.Models.Options;
+
+public sealed class SharedOptionsDocumentationContractTests
+{
+    [Fact]
+    public void EveryDeclaredAudioOptionDocumentsValueAndBeginnerEffect()
+    {
+        Type type = typeof(AudioHyperparameterOptions);
+        // Framework test hosts may shadow-copy the assembly without its adjacent XML file.
+        string path = Path.Combine(AppContext.BaseDirectory, type.Assembly.GetName().Name + ".xml");
+        XDocument documentation = XDocument.Load(path);
+        PropertyInfo[] properties = type.GetProperties(BindingFlags.DeclaredOnly | BindingFlags.Public | BindingFlags.Instance);
+        Assert.Equal(10, properties.Length);
+        foreach (PropertyInfo property in properties)
+        {
+            string memberName = $"P:{type.FullName}.{property.Name}";
+            XElement member = Assert.Single(documentation.Descendants("member"),
+                element => (string?)element.Attribute("name") == memberName);
+            Assert.False(string.IsNullOrWhiteSpace(member.Element("value")?.Value), memberName);
+            Assert.Contains("For Beginners:", member.Element("remarks")?.Value ?? string.Empty);
+        }
+    }
+
+    [Fact]
+    public void VisionAndDocumentBasesUseTheSamePublicTowerNames()
+    {
+        Type vision = typeof(VisionLanguageModelOptions);
+        foreach (PropertyInfo property in typeof(DocumentNeuralNetworkOptions)
+                     .GetProperties(BindingFlags.Public | BindingFlags.Instance)
+                     .Where(property => property.Name == nameof(DocumentNeuralNetworkOptions.VisionDim)
+                         || property.Name == nameof(DocumentNeuralNetworkOptions.VisionLayers)))
+        {
+            PropertyInfo? corresponding = vision.GetProperty(property.Name);
+            Assert.NotNull(corresponding);
+            Assert.Equal(property.PropertyType, corresponding.PropertyType);
+        }
+        Assert.NotNull(vision.GetProperty(nameof(DocumentNeuralNetworkOptions.VisionDim)));
+        Assert.NotNull(vision.GetProperty(nameof(DocumentNeuralNetworkOptions.VisionLayers)));
+        Assert.Null(vision.GetProperty("VisionHiddenDim"));
+        Assert.Null(vision.GetProperty("NumVisionLayers"));
+    }
+}

--- a/tests/AiDotNet.Tests/UnitTests/NeuralNetworks/Layers/SSM/MambaLanguageModelTests.cs
+++ b/tests/AiDotNet.Tests/UnitTests/NeuralNetworks/Layers/SSM/MambaLanguageModelTests.cs
@@ -1,4 +1,5 @@
 using AiDotNet.Enums;
+using AiDotNet.NeuralNetworks.Options;
 using AiDotNet.Models;
 using AiDotNet.NeuralNetworks;
 using AiDotNet.NeuralNetworks.Layers.SSM;
@@ -43,9 +44,7 @@ public class MambaLanguageModelTests
     {
         await Task.Yield();
 
-        var model = new MambaLanguageModel<float>(
-            CreateArch(),
-            vocabSize: 100, modelDimension: 32, numLayers: 2, stateDimension: 8);
+        var model = new MambaLanguageModel<float>(CreateArch(), new MambaOptions { VocabSize = 100, ModelDimension = 32, NumLayers = 2, StateDimension = 8 });
 
         Assert.Equal(100, model.VocabSize);
         Assert.Equal(32, model.ModelDimension);
@@ -59,7 +58,7 @@ public class MambaLanguageModelTests
         await Task.Yield();
 
         Assert.Throws<ArgumentException>(() =>
-            new MambaLanguageModel<float>(CreateArch(1), vocabSize: 0));
+            new MambaLanguageModel<float>(CreateArch(1), new MambaOptions { VocabSize = 0 }));
     }
 
     [Fact(Timeout = 120000)]
@@ -68,7 +67,7 @@ public class MambaLanguageModelTests
         await Task.Yield();
 
         Assert.Throws<ArgumentException>(() =>
-            new MambaLanguageModel<float>(CreateArch(), vocabSize: 100, modelDimension: 0));
+            new MambaLanguageModel<float>(CreateArch(), new MambaOptions { VocabSize = 100, ModelDimension = 0 }));
     }
 
     [Fact(Timeout = 120000)]
@@ -77,7 +76,7 @@ public class MambaLanguageModelTests
         await Task.Yield();
 
         Assert.Throws<ArgumentException>(() =>
-            new MambaLanguageModel<float>(CreateArch(), vocabSize: 100, numLayers: 0));
+            new MambaLanguageModel<float>(CreateArch(), new MambaOptions { VocabSize = 100, NumLayers = 0 }));
     }
 
     [Fact(Timeout = 120000)]
@@ -86,7 +85,7 @@ public class MambaLanguageModelTests
         await Task.Yield();
 
         Assert.Throws<ArgumentException>(() =>
-            new MambaLanguageModel<float>(CreateArch(), vocabSize: 100, stateDimension: 0));
+            new MambaLanguageModel<float>(CreateArch(), new MambaOptions { VocabSize = 100, StateDimension = 0 }));
     }
 
     [Fact(Timeout = 120000)]
@@ -99,9 +98,7 @@ public class MambaLanguageModelTests
         int vocabSize = 50;
         int modelDim = 32;
 
-        var model = new MambaLanguageModel<float>(
-            CreateArch(vocabSize),
-            vocabSize, modelDim, numLayers: 2, stateDimension: 8, maxSeqLength: seqLen);
+        var model = new MambaLanguageModel<float>(CreateArch(vocabSize), new MambaOptions { VocabSize = vocabSize, ModelDimension = modelDim, NumLayers = 2, StateDimension = 8, MaxSequenceLength = seqLen });
 
         var input = CreateTokenInput(batchSize, seqLen, vocabSize);
         var output = model.Predict(input);
@@ -119,9 +116,7 @@ public class MambaLanguageModelTests
         int vocabSize = 50;
         int modelDim = 32;
 
-        var model = new MambaLanguageModel<float>(
-            CreateArch(vocabSize),
-            vocabSize, modelDim, numLayers: 2, stateDimension: 8, maxSeqLength: seqLen);
+        var model = new MambaLanguageModel<float>(CreateArch(vocabSize), new MambaOptions { VocabSize = vocabSize, ModelDimension = modelDim, NumLayers = 2, StateDimension = 8, MaxSequenceLength = seqLen });
 
         // One unbatched sequence of IDs. [1, seq] in, [1, seq, vocab] logits out.
         var input = CreateTokenInput(1, seqLen, vocabSize);
@@ -142,9 +137,7 @@ public class MambaLanguageModelTests
         int vocabSize = 30;
         int modelDim = 16;
 
-        var model = new MambaLanguageModel<float>(
-            CreateArch(vocabSize),
-            vocabSize, modelDim, numLayers: 2, stateDimension: 4, maxSeqLength: seqLen);
+        var model = new MambaLanguageModel<float>(CreateArch(vocabSize), new MambaOptions { VocabSize = vocabSize, ModelDimension = modelDim, NumLayers = 2, StateDimension = 4, MaxSequenceLength = seqLen });
 
         var input = CreateTokenInput(1, seqLen, vocabSize);
 
@@ -165,9 +158,7 @@ public class MambaLanguageModelTests
     {
         await Task.Yield();
 
-        var model = new MambaLanguageModel<float>(
-            CreateArch(50),
-            50, 32, numLayers: 2, stateDimension: 8, maxSeqLength: 4);
+        var model = new MambaLanguageModel<float>(CreateArch(50), new MambaOptions { VocabSize = 50, ModelDimension = 32, NumLayers = 2, StateDimension = 8, MaxSequenceLength = 4 });
 
         var params1 = model.GetParameters();
         Assert.True(params1.Length > 0);
@@ -188,8 +179,7 @@ public class MambaLanguageModelTests
     {
         await Task.Yield();
 
-        var model = new MambaLanguageModel<float>(
-            CreateArch(50), 50, 32, 2, 8, maxSeqLength: 4);
+        var model = new MambaLanguageModel<float>(CreateArch(50), new MambaOptions { VocabSize = 50, ModelDimension = 32, NumLayers = 2, StateDimension = 8, MaxSequenceLength = 4 });
         Assert.Throws<ArgumentException>(() => model.SetParameters(new Vector<float>(10)));
     }
 
@@ -202,12 +192,8 @@ public class MambaLanguageModelTests
         int vocabSize = 30;
         int modelDim = 16;
 
-        var model1 = new MambaLanguageModel<float>(
-            CreateArch(vocabSize),
-            vocabSize, modelDim, numLayers: 2, stateDimension: 4, maxSeqLength: seqLen);
-        var model2 = new MambaLanguageModel<float>(
-            CreateArch(vocabSize),
-            vocabSize, modelDim, numLayers: 2, stateDimension: 4, maxSeqLength: seqLen);
+        var model1 = new MambaLanguageModel<float>(CreateArch(vocabSize), new MambaOptions { VocabSize = vocabSize, ModelDimension = modelDim, NumLayers = 2, StateDimension = 4, MaxSequenceLength = seqLen });
+        var model2 = new MambaLanguageModel<float>(CreateArch(vocabSize), new MambaOptions { VocabSize = vocabSize, ModelDimension = modelDim, NumLayers = 2, StateDimension = 4, MaxSequenceLength = seqLen });
 
         model2.SetParameters(model1.GetParameters());
 
@@ -229,8 +215,7 @@ public class MambaLanguageModelTests
     {
         await Task.Yield();
 
-        var model = new MambaLanguageModel<float>(
-            CreateArch(30), 30, 16, 2, 4, maxSeqLength: 4);
+        var model = new MambaLanguageModel<float>(CreateArch(30), new MambaOptions { VocabSize = 30, ModelDimension = 16, NumLayers = 2, StateDimension = 4, MaxSequenceLength = 4 });
         var input = CreateTokenInput(1, 4, 30);
 
         model.Predict(input);
@@ -246,8 +231,7 @@ public class MambaLanguageModelTests
     {
         await Task.Yield();
 
-        var model = new MambaLanguageModel<float>(
-            CreateArch(30), 30, 16, 2, 4, maxSeqLength: 4);
+        var model = new MambaLanguageModel<float>(CreateArch(30), new MambaOptions { VocabSize = 30, ModelDimension = 16, NumLayers = 2, StateDimension = 4, MaxSequenceLength = 4 });
         Assert.True(model.SupportsTraining);
     }
 
@@ -256,8 +240,7 @@ public class MambaLanguageModelTests
     {
         await Task.Yield();
 
-        var model = new MambaLanguageModel<float>(
-            CreateArch(100), 100, 64, 4, 16, maxSeqLength: 32);
+        var model = new MambaLanguageModel<float>(CreateArch(100), new MambaOptions { VocabSize = 100, ModelDimension = 64, NumLayers = 4, StateDimension = 16, MaxSequenceLength = 32 });
         var metadata = model.GetModelMetadata();
 
 
@@ -278,9 +261,7 @@ public class MambaLanguageModelTests
         int seqLen = 4;
         int vocabSize = 30;
 
-        var model = new MambaLanguageModel<double>(
-            CreateDoubleArch(vocabSize),
-            vocabSize, 16, numLayers: 2, stateDimension: 4, maxSeqLength: seqLen);
+        var model = new MambaLanguageModel<double>(CreateDoubleArch(vocabSize), new MambaOptions { VocabSize = vocabSize, ModelDimension = 16, NumLayers = 2, StateDimension = 4, MaxSequenceLength = seqLen });
 
         var input = CreateTokenDoubleInput(1, seqLen, vocabSize);
         var output = model.Predict(input);
@@ -298,9 +279,7 @@ public class MambaLanguageModelTests
         int vocabSize = 20;
         int modelDim = 16;
 
-        var model = new MambaLanguageModel<float>(
-            CreateArch(vocabSize),
-            vocabSize, modelDim, numLayers: 4, stateDimension: 4, maxSeqLength: seqLen);
+        var model = new MambaLanguageModel<float>(CreateArch(vocabSize), new MambaOptions { VocabSize = vocabSize, ModelDimension = modelDim, NumLayers = 4, StateDimension = 4, MaxSequenceLength = seqLen });
 
         var input = CreateTokenInput(1, seqLen, vocabSize);
         var output = model.Predict(input);
@@ -332,9 +311,7 @@ public class MambaLanguageModelTests
         int vocabSize = 12;
         int modelDim = 16;
 
-        var model = new MambaLanguageModel<double>(
-            CreateDoubleArch(vocabSize),
-            vocabSize, modelDim, numLayers: 2, stateDimension: 8, maxSeqLength: seqLen);
+        var model = new MambaLanguageModel<double>(CreateDoubleArch(vocabSize), new MambaOptions { VocabSize = vocabSize, ModelDimension = modelDim, NumLayers = 2, StateDimension = 8, MaxSequenceLength = seqLen });
 
         var input = CreateTokenDoubleInput(1, seqLen, vocabSize, seed: 7);
 
@@ -369,9 +346,7 @@ public class MambaLanguageModelTests
         int vocabSize = 10;
         int modelDim = 16;
 
-        var model = new MambaLanguageModel<double>(
-            CreateDoubleArch(vocabSize),
-            vocabSize, modelDim, numLayers: 4, stateDimension: 4, maxSeqLength: seqLen);
+        var model = new MambaLanguageModel<double>(CreateDoubleArch(vocabSize), new MambaOptions { VocabSize = vocabSize, ModelDimension = modelDim, NumLayers = 4, StateDimension = 4, MaxSequenceLength = seqLen });
 
         var input = CreateTokenDoubleInput(1, seqLen, vocabSize, seed: 13);
 
@@ -408,8 +383,7 @@ public class MambaLanguageModelTests
             int vocabSize = 20;
             int modelDim = 16;
 
-            var model = new MambaLanguageModel<double>(
-                CreateDoubleArch(vocabSize), vocabSize, modelDim, numLayers: 2, stateDimension: 4, maxSeqLength: seqLen);
+            var model = new MambaLanguageModel<double>(CreateDoubleArch(vocabSize), new MambaOptions { VocabSize = vocabSize, ModelDimension = modelDim, NumLayers = 2, StateDimension = 4, MaxSequenceLength = seqLen });
 
             var input = CreateTokenDoubleInput(1, seqLen, vocabSize, seed: 5);
 

--- a/tests/AiDotNet.Tests/UnitTests/NeuralNetworks/Layers/SSM/RWKV7LanguageModelTests.cs
+++ b/tests/AiDotNet.Tests/UnitTests/NeuralNetworks/Layers/SSM/RWKV7LanguageModelTests.cs
@@ -244,39 +244,104 @@ public class RWKV7LanguageModelTests
         Assert.Equal(3.5, model.FFNMultiplier);
     }
 
-    [Fact(Timeout = 120000)]
-    public async Task Model_Constructor_ThrowsWhenVocabSizeNotPositive()
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public void Model_Constructor_ThrowsWhenVocabSizeNotPositive(int value)
     {
-        Assert.Throws<ArgumentException>(() =>
-            new RWKV7LanguageModel<float>(CreateArch(1), new RWKV7Options { VocabSize = 0 }));
+        var options = ValidConstructorOptions();
+        options.VocabSize = value;
+        AssertConstructorRejects(options, nameof(RWKV7Options.VocabSize));
     }
 
-    [Fact(Timeout = 120000)]
-    public async Task Model_Constructor_ThrowsWhenModelDimensionNotPositive()
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public void Model_Constructor_ThrowsWhenModelDimensionNotPositive(int value)
     {
-        Assert.Throws<ArgumentException>(() =>
-            new RWKV7LanguageModel<float>(CreateArch(), new RWKV7Options { VocabSize = 100, ModelDimension = 0 }));
+        var options = ValidConstructorOptions();
+        options.ModelDimension = value;
+        AssertConstructorRejects(options, nameof(RWKV7Options.ModelDimension));
     }
 
-    [Fact(Timeout = 120000)]
-    public async Task Model_Constructor_ThrowsWhenNumLayersNotPositive()
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public void Model_Constructor_ThrowsWhenNumLayersNotPositive(int value)
     {
-        Assert.Throws<ArgumentException>(() =>
-            new RWKV7LanguageModel<float>(CreateArch(), new RWKV7Options { VocabSize = 100, NumLayers = 0 }));
+        var options = ValidConstructorOptions();
+        options.NumLayers = value;
+        AssertConstructorRejects(options, nameof(RWKV7Options.NumLayers));
     }
 
-    [Fact(Timeout = 120000)]
-    public async Task Model_Constructor_ThrowsWhenNumHeadsNotPositive()
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public void Model_Constructor_ThrowsWhenNumHeadsNotPositive(int value)
     {
-        Assert.Throws<ArgumentException>(() =>
-            new RWKV7LanguageModel<float>(CreateArch(), new RWKV7Options { VocabSize = 100, NumHeads = 0 }));
+        var options = ValidConstructorOptions();
+        options.NumHeads = value;
+        AssertConstructorRejects(options, nameof(RWKV7Options.NumHeads));
     }
 
-    [Fact(Timeout = 120000)]
-    public async Task Model_Constructor_ThrowsWhenDimensionNotDivisibleByHeads()
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public void Model_Constructor_ThrowsWhenMaxSequenceLengthNotPositive(int value)
     {
-        Assert.Throws<ArgumentException>(() =>
-            new RWKV7LanguageModel<float>(CreateArch(), new RWKV7Options { VocabSize = 100, ModelDimension = 33, NumHeads = 4 }));
+        var options = ValidConstructorOptions();
+        options.MaxSequenceLength = value;
+        AssertConstructorRejects(options, nameof(RWKV7Options.MaxSequenceLength));
+    }
+
+    [Theory]
+    [InlineData(0.0)]
+    [InlineData(-1.0)]
+    [InlineData(double.NaN)]
+    [InlineData(double.PositiveInfinity)]
+    [InlineData(double.NegativeInfinity)]
+    public void Model_Constructor_ThrowsWhenFfnMultiplierInvalid(double value)
+    {
+        var options = ValidConstructorOptions();
+        options.FfnMultiplier = value;
+        AssertConstructorRejects(options, nameof(RWKV7Options.FfnMultiplier));
+    }
+
+    [Fact]
+    public void Model_Constructor_ThrowsWhenDimensionNotDivisibleByHeads()
+    {
+        var options = ValidConstructorOptions();
+        options.ModelDimension = 33;
+        options.NumHeads = 4;
+        var exception = Assert.Throws<ArgumentException>(() =>
+            new RWKV7LanguageModel<float>(CreateArch(), options));
+        Assert.Equal("options", exception.ParamName);
+        Assert.Contains("Model dimension (33)", exception.Message, StringComparison.Ordinal);
+        Assert.Contains("number of heads (4)", exception.Message, StringComparison.Ordinal);
+    }
+
+    private static RWKV7Options ValidConstructorOptions()
+    {
+        var options = new RWKV7Options
+        {
+            VocabSize = 100,
+            ModelDimension = 16,
+            NumLayers = 1,
+            NumHeads = 2,
+            MaxSequenceLength = 4,
+            FfnMultiplier = 3.5,
+            Seed = 42
+        };
+        options.Validate();
+        return options;
+    }
+
+    private static void AssertConstructorRejects(RWKV7Options options, string expectedProperty)
+    {
+        var exception = Assert.Throws<ArgumentException>(() =>
+            new RWKV7LanguageModel<float>(CreateArch(), options));
+        Assert.Equal("options", exception.ParamName);
+        Assert.Contains($"{nameof(RWKV7Options)}.{expectedProperty}", exception.Message, StringComparison.Ordinal);
     }
 
     [Fact(Timeout = 120000)]

--- a/tests/AiDotNet.Tests/UnitTests/NeuralNetworks/Layers/SSM/RWKV7LanguageModelTests.cs
+++ b/tests/AiDotNet.Tests/UnitTests/NeuralNetworks/Layers/SSM/RWKV7LanguageModelTests.cs
@@ -16,6 +16,12 @@ namespace AiDotNet.Tests.UnitTests.NeuralNetworks.Layers.SSM;
 /// </summary>
 public class RWKV7LanguageModelTests
 {
+    public RWKV7LanguageModelTests()
+    {
+        // Keep focused .NET Framework runs independent of other test classes.
+        TestModuleInitializer.EnsureInitialized();
+    }
+
     private static NeuralNetworkArchitecture<float> CreateArch(int vocabSize = 100)
     {
         return new NeuralNetworkArchitecture<float>(

--- a/tests/AiDotNet.Tests/UnitTests/NeuralNetworks/Layers/SSM/RWKV7LanguageModelTests.cs
+++ b/tests/AiDotNet.Tests/UnitTests/NeuralNetworks/Layers/SSM/RWKV7LanguageModelTests.cs
@@ -1,4 +1,5 @@
 using AiDotNet.Enums;
+using AiDotNet.NeuralNetworks.Options;
 using AiDotNet.Models;
 using AiDotNet.NeuralNetworks;
 using AiDotNet.NeuralNetworks.Layers.SSM;
@@ -234,9 +235,7 @@ public class RWKV7LanguageModelTests
     [Fact(Timeout = 120000)]
     public async Task Model_Constructor_ValidParameters_CreatesModel()
     {
-        var model = new RWKV7LanguageModel<float>(
-            CreateArch(),
-            vocabSize: 100, modelDimension: 32, numLayers: 2, numHeads: 4);
+        var model = new RWKV7LanguageModel<float>(CreateArch(), new RWKV7Options { VocabSize = 100, ModelDimension = 32, NumLayers = 2, NumHeads = 4 });
 
         Assert.Equal(100, model.VocabSize);
         Assert.Equal(32, model.ModelDimension);
@@ -249,42 +248,41 @@ public class RWKV7LanguageModelTests
     public async Task Model_Constructor_ThrowsWhenVocabSizeNotPositive()
     {
         Assert.Throws<ArgumentException>(() =>
-            new RWKV7LanguageModel<float>(CreateArch(1), vocabSize: 0));
+            new RWKV7LanguageModel<float>(CreateArch(1), new RWKV7Options { VocabSize = 0 }));
     }
 
     [Fact(Timeout = 120000)]
     public async Task Model_Constructor_ThrowsWhenModelDimensionNotPositive()
     {
         Assert.Throws<ArgumentException>(() =>
-            new RWKV7LanguageModel<float>(CreateArch(), vocabSize: 100, modelDimension: 0));
+            new RWKV7LanguageModel<float>(CreateArch(), new RWKV7Options { VocabSize = 100, ModelDimension = 0 }));
     }
 
     [Fact(Timeout = 120000)]
     public async Task Model_Constructor_ThrowsWhenNumLayersNotPositive()
     {
         Assert.Throws<ArgumentException>(() =>
-            new RWKV7LanguageModel<float>(CreateArch(), vocabSize: 100, numLayers: 0));
+            new RWKV7LanguageModel<float>(CreateArch(), new RWKV7Options { VocabSize = 100, NumLayers = 0 }));
     }
 
     [Fact(Timeout = 120000)]
     public async Task Model_Constructor_ThrowsWhenNumHeadsNotPositive()
     {
         Assert.Throws<ArgumentException>(() =>
-            new RWKV7LanguageModel<float>(CreateArch(), vocabSize: 100, numHeads: 0));
+            new RWKV7LanguageModel<float>(CreateArch(), new RWKV7Options { VocabSize = 100, NumHeads = 0 }));
     }
 
     [Fact(Timeout = 120000)]
     public async Task Model_Constructor_ThrowsWhenDimensionNotDivisibleByHeads()
     {
         Assert.Throws<ArgumentException>(() =>
-            new RWKV7LanguageModel<float>(CreateArch(), vocabSize: 100, modelDimension: 33, numHeads: 4));
+            new RWKV7LanguageModel<float>(CreateArch(), new RWKV7Options { VocabSize = 100, ModelDimension = 33, NumHeads = 4 }));
     }
 
     [Fact(Timeout = 120000)]
     public async Task Model_SupportsTraining_ReturnsTrue()
     {
-        var model = new RWKV7LanguageModel<float>(
-            CreateArch(30), 30, 16, 2, 2);
+        var model = new RWKV7LanguageModel<float>(CreateArch(30), new RWKV7Options { VocabSize = 30, ModelDimension = 16, NumLayers = 2, NumHeads = 2 });
         Assert.True(model.SupportsTraining);
     }
 
@@ -300,9 +298,7 @@ public class RWKV7LanguageModelTests
         int vocabSize = 50;
         int modelDim = 32;
 
-        var model = new RWKV7LanguageModel<float>(
-            CreateArch(vocabSize),
-            vocabSize, modelDim, numLayers: 2, numHeads: 4, maxSeqLength: seqLen);
+        var model = new RWKV7LanguageModel<float>(CreateArch(vocabSize), new RWKV7Options { VocabSize = vocabSize, ModelDimension = modelDim, NumLayers = 2, NumHeads = 4, MaxSequenceLength = seqLen });
 
         var input = CreateTokenInput(batchSize, seqLen, vocabSize);
         var output = model.Predict(input);
@@ -318,9 +314,7 @@ public class RWKV7LanguageModelTests
         int vocabSize = 50;
         int modelDim = 32;
 
-        var model = new RWKV7LanguageModel<float>(
-            CreateArch(vocabSize),
-            vocabSize, modelDim, numLayers: 2, numHeads: 4, maxSeqLength: seqLen);
+        var model = new RWKV7LanguageModel<float>(CreateArch(vocabSize), new RWKV7Options { VocabSize = vocabSize, ModelDimension = modelDim, NumLayers = 2, NumHeads = 4, MaxSequenceLength = seqLen });
 
         // One unbatched sequence of ids. [1, seq] in, [1, seq, vocab] logits out.
         var input = CreateTokenInput(1, seqLen, vocabSize);
@@ -336,9 +330,7 @@ public class RWKV7LanguageModelTests
         int seqLen = 4;
         int vocabSize = 20;
 
-        var model = new RWKV7LanguageModel<float>(
-            CreateArch(vocabSize),
-            vocabSize, 16, numLayers: 2, numHeads: 2, maxSeqLength: seqLen);
+        var model = new RWKV7LanguageModel<float>(CreateArch(vocabSize), new RWKV7Options { VocabSize = vocabSize, ModelDimension = 16, NumLayers = 2, NumHeads = 2, MaxSequenceLength = seqLen });
 
         var input = CreateTokenInput(1, seqLen, vocabSize);
         var output = model.Predict(input);
@@ -368,9 +360,7 @@ public class RWKV7LanguageModelTests
         int seqLen = 4;
         int vocabSize = 20;
 
-        var model = new RWKV7LanguageModel<float>(
-            CreateArch(vocabSize),
-            vocabSize, 16, numLayers: 2, numHeads: 2, maxSeqLength: seqLen);
+        var model = new RWKV7LanguageModel<float>(CreateArch(vocabSize), new RWKV7Options { VocabSize = vocabSize, ModelDimension = 16, NumLayers = 2, NumHeads = 2, MaxSequenceLength = seqLen });
 
         var input = CreateTokenInput(1, seqLen, vocabSize);
         var expected = CreateOneHotTarget(1, seqLen, vocabSize, seed: 99);
@@ -390,9 +380,7 @@ public class RWKV7LanguageModelTests
     [Fact(Timeout = 120000)]
     public async Task Model_GetParameters_SetParameters_RoundTrip()
     {
-        var model = new RWKV7LanguageModel<float>(
-            CreateArch(30),
-            30, 16, numLayers: 2, numHeads: 2, maxSeqLength: 4);
+        var model = new RWKV7LanguageModel<float>(CreateArch(30), new RWKV7Options { VocabSize = 30, ModelDimension = 16, NumLayers = 2, NumHeads = 2, MaxSequenceLength = 4 });
 
         var params1 = model.GetParameters();
         Assert.True(params1.Length > 0);
@@ -409,8 +397,7 @@ public class RWKV7LanguageModelTests
     [Fact(Timeout = 120000)]
     public async Task Model_SetParameters_ThrowsOnWrongLength()
     {
-        var model = new RWKV7LanguageModel<float>(
-            CreateArch(30), 30, 16, 2, 2, maxSeqLength: 4);
+        var model = new RWKV7LanguageModel<float>(CreateArch(30), new RWKV7Options { VocabSize = 30, ModelDimension = 16, NumLayers = 2, NumHeads = 2, MaxSequenceLength = 4 });
         Assert.Throws<ArgumentException>(() => model.SetParameters(new Vector<float>(10)));
     }
 
@@ -420,12 +407,8 @@ public class RWKV7LanguageModelTests
         int seqLen = 4;
         int vocabSize = 20;
 
-        var model1 = new RWKV7LanguageModel<float>(
-            CreateArch(vocabSize),
-            vocabSize, 16, numLayers: 2, numHeads: 2, maxSeqLength: seqLen);
-        var model2 = new RWKV7LanguageModel<float>(
-            CreateArch(vocabSize),
-            vocabSize, 16, numLayers: 2, numHeads: 2, maxSeqLength: seqLen);
+        var model1 = new RWKV7LanguageModel<float>(CreateArch(vocabSize), new RWKV7Options { VocabSize = vocabSize, ModelDimension = 16, NumLayers = 2, NumHeads = 2, MaxSequenceLength = seqLen });
+        var model2 = new RWKV7LanguageModel<float>(CreateArch(vocabSize), new RWKV7Options { VocabSize = vocabSize, ModelDimension = 16, NumLayers = 2, NumHeads = 2, MaxSequenceLength = seqLen });
 
         model2.SetParameters(model1.GetParameters());
 
@@ -449,8 +432,7 @@ public class RWKV7LanguageModelTests
     [Fact(Timeout = 120000)]
     public async Task Model_ResetState_AllowsReuse()
     {
-        var model = new RWKV7LanguageModel<float>(
-            CreateArch(20), 20, 16, 2, 2, maxSeqLength: 4);
+        var model = new RWKV7LanguageModel<float>(CreateArch(20), new RWKV7Options { VocabSize = 20, ModelDimension = 16, NumLayers = 2, NumHeads = 2, MaxSequenceLength = 4 });
         var input = CreateTokenInput(1, 4, 20);
 
         model.Predict(input);
@@ -468,8 +450,7 @@ public class RWKV7LanguageModelTests
     [Fact(Timeout = 120000)]
     public async Task Model_GetModelMetadata_ContainsExpectedKeys()
     {
-        var model = new RWKV7LanguageModel<float>(
-            CreateArch(100), 100, 64, 4, 8, maxSeqLength: 32);
+        var model = new RWKV7LanguageModel<float>(CreateArch(100), new RWKV7Options { VocabSize = 100, ModelDimension = 64, NumLayers = 4, NumHeads = 8, MaxSequenceLength = 32 });
         var metadata = model.GetModelMetadata();
 
 
@@ -495,9 +476,7 @@ public class RWKV7LanguageModelTests
         int seqLen = 4;
         int vocabSize = 20;
 
-        var model = new RWKV7LanguageModel<double>(
-            CreateDoubleArch(vocabSize),
-            vocabSize, 16, numLayers: 2, numHeads: 2, maxSeqLength: seqLen);
+        var model = new RWKV7LanguageModel<double>(CreateDoubleArch(vocabSize), new RWKV7Options { VocabSize = vocabSize, ModelDimension = 16, NumLayers = 2, NumHeads = 2, MaxSequenceLength = seqLen });
 
         var input = CreateTokenDoubleInput(1, seqLen, vocabSize);
         var output = model.Predict(input);
@@ -516,9 +495,7 @@ public class RWKV7LanguageModelTests
         int seqLen = 4;
         int vocabSize = 20;
 
-        var model = new RWKV7LanguageModel<float>(
-            CreateArch(vocabSize),
-            vocabSize, 16, numLayers: 4, numHeads: 2, maxSeqLength: seqLen);
+        var model = new RWKV7LanguageModel<float>(CreateArch(vocabSize), new RWKV7Options { VocabSize = vocabSize, ModelDimension = 16, NumLayers = 4, NumHeads = 2, MaxSequenceLength = seqLen });
 
         var input = CreateTokenInput(1, seqLen, vocabSize);
         var output = model.Predict(input);
@@ -602,14 +579,7 @@ public class RWKV7LanguageModelTests
             MaxSequenceLength = 8
         };
 
-        var model = new RWKV7LanguageModel<float>(
-            CreateArch(options.VocabSize),
-            options.VocabSize,
-            options.ModelDimension,
-            options.NumLayers,
-            options.NumHeads,
-            options.FFNMultiplier,
-            options.MaxSequenceLength);
+        var model = new RWKV7LanguageModel<float>(CreateArch(options.VocabSize), new RWKV7Options { VocabSize = options.VocabSize, ModelDimension = options.ModelDimension, NumLayers = options.NumLayers, NumHeads = options.NumHeads, FfnMultiplier = options.FFNMultiplier, MaxSequenceLength = options.MaxSequenceLength });
 
         Assert.Equal(options.VocabSize, model.VocabSize);
         Assert.Equal(options.ModelDimension, model.ModelDimension);

--- a/tools/SequenceFixtureReview/README.md
+++ b/tools/SequenceFixtureReview/README.md
@@ -1,0 +1,36 @@
+# Sequence scaffold review proof (#2128)
+
+The same 13 contracts run the real source generator with synthetic compiler inputs.
+At PR head `671836a347436f4b023ebe3f02a86ea333ad0686`, four structural checks fail
+and nine controls pass. After removing the unreachable XLSTM/Hawk rules and the
+shadowed Griffin/Hawk fallback arms, all 13 pass, with no skips.
+
+All six effective-fixture checks pass **before and after**: XLSTM, Griffin, Hawk,
+GLA, GatedDeltaNet and RecurrentGemma retain their bounded dimensions. This change
+does not select the previously unreachable XLSTM dimensions or change production
+model defaults, seeding, test tolerances, timeouts or iteration budgets.
+
+Run from the repository root:
+
+```powershell
+dotnet test tools/SequenceFixtureReview/SequenceFixtureReview.csproj -c Release --logger 'trx;LogFileName=sequence-generator-after.trx' --results-directory artifacts/sequence-generator
+```
+
+For a controlled original-head comparison, materialize that exact Git revision in
+a separate checkout, then point `GeneratorProjectPath` and `GeneratorSourcePath`
+at its generator project and `TestScaffoldGenerator.cs`. Both properties resolve
+relative to this review project unless absolute paths are provided. Keep the
+current contract test file unchanged. Run before/after sequentially because this
+project shares its output directory between arms.
+
+Recorded local reports: `artifacts/sequence-generator/sequence-generator-before.trx`
+(4 failed, 9 passed) and `sequence-generator-after-confirmed.trx` (13 passed).
+The baseline source was extracted directly with `git archive` from the head above;
+it was not reconstructed by selectively undoing fixes.
+
+These tests verify emitted syntax and unique constructor selection. Their model
+symbols are synthetic: they do **not** prove actual model construction, training,
+GPU execution, semantic compilation against every real constructor, or a passing
+CI shard. The separate real-model/options tests supply their own evidence. The
+contracts are also included in the normal test project; no generated leaf test
+was edited by hand.

--- a/tools/SequenceFixtureReview/README.md
+++ b/tools/SequenceFixtureReview/README.md
@@ -4,6 +4,9 @@ The same 13 contracts run the real source generator with synthetic compiler inpu
 At PR head `671836a347436f4b023ebe3f02a86ea333ad0686`, four structural checks fail
 and nine controls pass. After removing the unreachable XLSTM/Hawk rules and the
 shadowed Griffin/Hawk fallback arms, all 13 pass, with no skips.
+The final runner targets `net10.0`, `net8.0` and `net471`; all three passed the
+same 13 contracts locally (39 passing executions, zero skipped). The original
+failure-first comparison above was run on `net10.0`.
 
 All six effective-fixture checks pass **before and after**: XLSTM, Griffin, Hawk,
 GLA, GatedDeltaNet and RecurrentGemma retain their bounded dimensions. This change

--- a/tools/SequenceFixtureReview/SequenceFixtureReview.csproj
+++ b/tools/SequenceFixtureReview/SequenceFixtureReview.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <IsTestProject>true</IsTestProject>
+    <IsPackable>false</IsPackable>
+    <Nullable>enable</Nullable>
+    <GeneratorProjectPath Condition="'$(GeneratorProjectPath)' == ''">../../src/AiDotNet.Generators/AiDotNet.Generators.csproj</GeneratorProjectPath>
+    <GeneratorSourcePath Condition="'$(GeneratorSourcePath)' == ''">../../src/AiDotNet.Generators/TestScaffoldGenerator.cs</GeneratorSourcePath>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" PrivateAssets="all" />
+    <ProjectReference Include="$(GeneratorProjectPath)" />
+    <Compile Include="../../tests/AiDotNet.Tests/Generators/GeneratedSequenceFixtureContractTests.cs" Link="GeneratedSequenceFixtureContractTests.cs" />
+    <EmbeddedResource Include="$(GeneratorSourcePath)" LogicalName="Review.TestScaffoldGenerator.cs" />
+  </ItemGroup>
+</Project>

--- a/tools/SequenceFixtureReview/SequenceFixtureReview.csproj
+++ b/tools/SequenceFixtureReview/SequenceFixtureReview.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFrameworks>net10.0;net8.0;net471</TargetFrameworks>
+    <LangVersion>latest</LangVersion>
     <IsTestProject>true</IsTestProject>
     <IsPackable>false</IsPackable>
     <Nullable>enable</Nullable>


### PR DESCRIPTION
## Current review status — September 11, 2026

The review-fix head is `78d4c176b871d12ca4773a5c5d756999f6e96b09`. The evidence below supersedes the original migration notes retained below.

- Complete/null-checked options copies and consumed-setting validation now cover all 17 sequence families, including the six previously described as unchanged. Finch's pre-PR public learning-rate default is restored to `3e-4`.
- Actual model tests change width and depth independently and inspect real parameters and physical layers. The current census is **1,005 models, 977 remaining gaps across 297 model types**; this does not imply the later migration phases are complete.
- Duplicate generator rules are removed with unchanged-live-fixture controls. Stale shard claims are replaced with the actual cancelled-run observation, and the arena diagnostic no longer claims root-cause proof.
- FalconMamba's positional constructor change is documented. Existing public EagleOptions names are retained for compatibility; phase 3 must update its new vision-base consumers to `VisionDim`/`VisionLayers` when integrating this branch.

## Executed proof

[Reproducible commands, before/after results, artifact names, binary hashes and adversarial findings](https://github.com/ooples/AiDotNet/blob/78d4c176b871d12ca4773a5c5d756999f6e96b09/.github/PR2128_REVIEW_PROOF.md)

| Check | Before | Final local result |
| --- | --- | --- |
| Identical 347 options contracts | 173 failed / 174 passed on original source | 347 passed; expanded final suite **349 passed per target** |
| Generator contracts | 4 failed / 9 passed; all six live fixture checks already passed | **13 passed per target**, unchanged effective fixtures |
| Actual model/report/constructor contracts | Old report and metadata mutations are rejected; unchanged-topology controls reject options-only fake changes | **63 passed per target**, all 17 model families constructed |
| Combined review filter on full main test assembly | Not asserted as an all-shards baseline | **419 passed per target**, zero failures/skips |
| Complete existing RWKV7 unit fixture | Not claimed as a before/after defect count | **49 passed per target**, zero failures/skips |
| Full main test-project build | Final restore corrected an omitted-target assets-file invocation | **All three targets built, zero errors** |

“Per target” means `net10.0`, `net8.0` and `net471`. Final model fixtures explicitly initialize the shared CPU/test-licensing setup, including .NET Framework. The main combined filter has 1,257 passing executions across the three targets; overlapping focused runs are not additional distinct tests. Ten checked-in PowerShell helper boundary controls also pass.

These are **local build and targeted runtime proofs**, not a claim that every CI shard, training recipe, GPU path, or phase-3 ONNX configuration is validated. This is ready for review of the completed phase-2 changes; hosted checks and merge integration still have their own status.

<details>
<summary>Original migration notes (historical; superseded where corrected above)</summary>

Phase 2 of #2090. Builds on #2123 (phase 1). Spec in #2122.

**Ratchet: 1067 → 1004.** Eleven sequence models now take their configuration as an Options object instead of a list of scalar constructor parameters.

## The change, per model

```csharp
// before
new MambaLanguageModel<float>(arch, vocabSize: 100, modelDimension: 32,
                              numLayers: 2, stateDimension: 8)

// after
new MambaLanguageModel<float>(arch, new MambaOptions {
    VocabSize = 100, ModelDimension = 32, NumLayers = 2, StateDimension = 8 })
```

Each `XxxOptions` now derives from `SequenceModelOptions` and sets the model's defaults in its parameterless constructor. The constructor reads every value off `_options`.

**Values are carried over unchanged.** They were read straight out of each constructor signature by script, so nothing could drift in the move. Verifying them against the papers is phase 9 — deliberately separate, so a change in behaviour is never buried inside a mechanical one.

## Migrated (11)

`Mamba`, `Mamba2`, `FalconMamba`, `Zamba`, `Zamba2`, `Jamba`, `Samba`, `RWKV4`, `RWKV7`, `Eagle`, `XLSTM`

Six more — `Finch`, `GLA`, `GatedDeltaNet`, `Griffin`, `Hawk`, `RecurrentGemma` — were **skipped by the migration guard** because their Options classes already declare a constructor and need their defaults merged by hand rather than inserted. They are unchanged and still work.

## Exception contract

Validation throws `ArgumentException` naming `options`, not `InvalidOperationException`. That keeps the public contract these constructors already had, and **all 16 existing `Assert.Throws<ArgumentException>` tests pass unchanged** — which is the evidence, not the intent.

## Call sites

The compiler enumerated 106 errors across 6 files plus the source generator.

`TestScaffoldGenerator` needed 8 snippets updated, and the reason they exist is worth recording: it constructs these models at reduced "scaffold scale" *because the production defaults are too large for CI* — a 50,277-way LM head made one synthetic target 6.4M values and exhausted the runner. That is a legitimate use of the configuration surface, and it now goes through Options like everything else.

## Two bugs my own scripts introduced, and what caught them

- The first migration script **regenerated** each Options class and so destroyed 34 properties that 7 of the 16 already declared (`GriffinOptions.Beta1`, `RecurrentGemmaOptions.ScaleEmbeddingsBySqrtWidth`). The build caught it; the rewrite only ever inserts.
- Repointing RWKV7's divisibility check at `_options` moved it **above** the line that assigns `_options`. Reading the diff caught it.

A third, caught by `git status`: an exception-doc swap filtered on "has a `Validate()` method", which matched six unrelated files whose `Validate()` genuinely throws `InvalidOperationException`. Reverted in `c6b51c15e`.

## Verification

- `dotnet build src/AiDotNet.csproj -f net8.0` — 0 errors
- `dotnet build tests/AiDotNet.Tests -f net8.0` — 0 errors
- Ratchet + migrated model tests — **88 passed, 0 failed**

Refs #2090

🤖 Generated with [Claude Code](https://claude.com/claude-code)

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added shared configuration options for sequence, audio, video, embedding, document, vision-language, and GAN models.
  * Model settings can now be supplied through dedicated options objects, with built-in validation and sensible defaults.
* **Breaking Changes**
  * Several language-model constructors now use options objects instead of individual configuration parameters.
* **Documentation**
  * Added a CI shard inventory documenting test results, failure categories, and triage guidance.
* **Tests**
  * Added coverage to prevent regressions in options-based model configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->