### PR TITLE
fix(metadata): stop 290 models serializing their weights on every build

### DIFF
--- a/src/ComputerVision/OCR/EndToEnd/ABCNet.cs
+++ b/src/ComputerVision/OCR/EndToEnd/ABCNet.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using AiDotNet.Attributes;
@@ -820,7 +820,7 @@ public partial class ABCNet<T> : NeuralNetworkBase<T>, ICompositeLoss<T>
             { "BezierSampleWidth", _options.BezierSampleWidth },
             { "NumCharacterClasses", _options.NumCharacterClasses },
         },
-        ModelData = this.Serialize(),
+        ModelDataProvider = () => this.Serialize(),
     };
 
     /// <inheritdoc />

--- a/src/ComputerVision/Segmentation/Diffusion/DiffCutSegmentation.cs
+++ b/src/ComputerVision/Segmentation/Diffusion/DiffCutSegmentation.cs
@@ -1,4 +1,4 @@
-﻿using System.IO;
+using System.IO;
 using AiDotNet.Attributes;
 using AiDotNet.Enums;
 using AiDotNet.Helpers;
@@ -336,7 +336,7 @@ public partial class DiffCutSegmentation<T> : Common.SemanticSegmentationBase<T>
             { "UseNativeMode", _useNativeMode },
             { "NumLayers", Layers.Count }
         },
-        ModelData = SerializeForMetadata()
+        ModelDataProvider = () => SerializeForMetadata()
     };
 
     // Dispose of the ONNX session and the _disposed latch are handled by SegmentationModelBase.

--- a/src/ComputerVision/Segmentation/Diffusion/MedSegDiffV2Segmentation.cs
+++ b/src/ComputerVision/Segmentation/Diffusion/MedSegDiffV2Segmentation.cs
@@ -1,4 +1,4 @@
-﻿using System.IO;
+using System.IO;
 using AiDotNet.Attributes;
 using AiDotNet.Enums;
 using AiDotNet.Helpers;
@@ -258,7 +258,7 @@ public partial class MedSegDiffV2Segmentation<T> : Common.MedicalSegmentationBas
     public override ModelMetadata<T> GetModelMetadata() => new()
     {
         AdditionalInfo = new Dictionary<string, object> { { "ModelName", "MedSegDiffV2Segmentation" }, { "InputHeight", _height }, { "InputWidth", _width }, { "NumClasses", _numClasses }, { "UseNativeMode", _useNativeMode }, { "NumLayers", Layers.Count } },
-        ModelData = SerializeForMetadata()
+        ModelDataProvider = () => SerializeForMetadata()
     };
 
     // Dispose of the ONNX session and the _disposed latch are handled by SegmentationModelBase.

--- a/src/ComputerVision/Segmentation/Diffusion/ODISESegmentation.cs
+++ b/src/ComputerVision/Segmentation/Diffusion/ODISESegmentation.cs
@@ -1,4 +1,4 @@
-﻿using System.IO;
+using System.IO;
 using AiDotNet.Attributes;
 using AiDotNet.Enums;
 using AiDotNet.Helpers;
@@ -268,7 +268,7 @@ public partial class ODISESegmentation<T> : Common.PanopticSegmentationBase<T>
     public override ModelMetadata<T> GetModelMetadata() => new()
     {
         AdditionalInfo = new Dictionary<string, object> { { "ModelName", "ODISESegmentation" }, { "SegmentationType", "Panoptic" }, { "InputHeight", _height }, { "InputWidth", _width }, { "NumClasses", _numClasses }, { "UseNativeMode", _useNativeMode }, { "NumLayers", Layers.Count } },
-        ModelData = SerializeForMetadata()
+        ModelDataProvider = () => SerializeForMetadata()
     };
 
     // Dispose of the ONNX session and the _disposed latch are handled by SegmentationModelBase.

--- a/src/ComputerVision/Segmentation/Efficient/EdgeSAM.cs
+++ b/src/ComputerVision/Segmentation/Efficient/EdgeSAM.cs
@@ -1,4 +1,4 @@
-﻿using System.IO;
+using System.IO;
 using AiDotNet.Attributes;
 using AiDotNet.Enums;
 using AiDotNet.Helpers;
@@ -250,7 +250,7 @@ public partial class EdgeSAM<T> : Common.PromptableSegmentationBase<T>
     public override ModelMetadata<T> GetModelMetadata() => new()
     {
         AdditionalInfo = new Dictionary<string, object> { { "ModelName", "EdgeSAM" }, { "InputHeight", _height }, { "InputWidth", _width }, { "NumClasses", _numClasses }, { "UseNativeMode", _useNativeMode }, { "NumLayers", Layers.Count } },
-        ModelData = SerializeForMetadata()
+        ModelDataProvider = () => SerializeForMetadata()
     };
 
     // Dispose of the ONNX session and the _disposed latch are handled by SegmentationModelBase.

--- a/src/ComputerVision/Segmentation/Efficient/EfficientSAM.cs
+++ b/src/ComputerVision/Segmentation/Efficient/EfficientSAM.cs
@@ -1,4 +1,4 @@
-﻿using System.IO;
+using System.IO;
 using AiDotNet.Attributes;
 using AiDotNet.Enums;
 using AiDotNet.Helpers;
@@ -264,7 +264,7 @@ public partial class EfficientSAM<T> : Common.PromptableSegmentationBase<T>
     public override ModelMetadata<T> GetModelMetadata() => new()
     {
         AdditionalInfo = new Dictionary<string, object> { { "ModelName", "EfficientSAM" }, { "InputHeight", _height }, { "InputWidth", _width }, { "NumClasses", _numClasses }, { "UseNativeMode", _useNativeMode }, { "NumLayers", Layers.Count } },
-        ModelData = SerializeForMetadata()
+        ModelDataProvider = () => SerializeForMetadata()
     };
 
     /// <summary>

--- a/src/ComputerVision/Segmentation/Efficient/FastSAM.cs
+++ b/src/ComputerVision/Segmentation/Efficient/FastSAM.cs
@@ -1,4 +1,4 @@
-﻿using System.IO;
+using System.IO;
 using AiDotNet.Attributes;
 using AiDotNet.Enums;
 using AiDotNet.Helpers;
@@ -259,7 +259,7 @@ public partial class FastSAM<T> : Common.PromptableSegmentationBase<T>
     public override ModelMetadata<T> GetModelMetadata() => new()
     {
         AdditionalInfo = new Dictionary<string, object> { { "ModelName", "FastSAM" }, { "InputHeight", _height }, { "InputWidth", _width }, { "NumClasses", _numClasses }, { "UseNativeMode", _useNativeMode }, { "NumLayers", Layers.Count } },
-        ModelData = SerializeForMetadata()
+        ModelDataProvider = () => SerializeForMetadata()
     };
 
     /// <summary>

--- a/src/ComputerVision/Segmentation/Efficient/MobileSAM.cs
+++ b/src/ComputerVision/Segmentation/Efficient/MobileSAM.cs
@@ -1,4 +1,4 @@
-﻿using System.IO;
+using System.IO;
 using AiDotNet.Attributes;
 using AiDotNet.Enums;
 using AiDotNet.Helpers;
@@ -248,7 +248,7 @@ public partial class MobileSAM<T> : Common.PromptableSegmentationBase<T>
     public override ModelMetadata<T> GetModelMetadata() => new()
     {
         AdditionalInfo = new Dictionary<string, object> { { "ModelName", "MobileSAM" }, { "InputHeight", _height }, { "InputWidth", _width }, { "NumClasses", _numClasses }, { "UseNativeMode", _useNativeMode }, { "NumLayers", Layers.Count } },
-        ModelData = SerializeForMetadata()
+        ModelDataProvider = () => SerializeForMetadata()
     };
 
     /// <summary>

--- a/src/ComputerVision/Segmentation/Efficient/PIDNet.cs
+++ b/src/ComputerVision/Segmentation/Efficient/PIDNet.cs
@@ -1,4 +1,4 @@
-﻿using System.IO;
+using System.IO;
 using AiDotNet.Attributes;
 using AiDotNet.Enums;
 using AiDotNet.Helpers;
@@ -260,7 +260,7 @@ public partial class PIDNet<T> : Common.SemanticSegmentationBase<T>
     public override ModelMetadata<T> GetModelMetadata() => new()
     {
         AdditionalInfo = new Dictionary<string, object> { { "ModelName", "PIDNet" }, { "InputHeight", _height }, { "InputWidth", _width }, { "NumClasses", _numClasses }, { "ModelSize", _modelSize.ToString() }, { "UseNativeMode", _useNativeMode }, { "NumLayers", Layers.Count } },
-        ModelData = SerializeForMetadata()
+        ModelDataProvider = () => SerializeForMetadata()
     };
 
     // Dispose of the ONNX session and the _disposed latch are handled by SegmentationModelBase.

--- a/src/ComputerVision/Segmentation/Efficient/RepViTSAM.cs
+++ b/src/ComputerVision/Segmentation/Efficient/RepViTSAM.cs
@@ -1,4 +1,4 @@
-﻿using System.IO;
+using System.IO;
 using AiDotNet.Attributes;
 using AiDotNet.Enums;
 using AiDotNet.Helpers;
@@ -261,7 +261,7 @@ public partial class RepViTSAM<T> : Common.PromptableSegmentationBase<T>
     public override ModelMetadata<T> GetModelMetadata() => new()
     {
         AdditionalInfo = new Dictionary<string, object> { { "ModelName", "RepViTSAM" }, { "InputHeight", _height }, { "InputWidth", _width }, { "NumClasses", _numClasses }, { "UseNativeMode", _useNativeMode }, { "NumLayers", Layers.Count } },
-        ModelData = SerializeForMetadata()
+        ModelDataProvider = () => SerializeForMetadata()
     };
 
     /// <summary>

--- a/src/ComputerVision/Segmentation/Efficient/SlimSAM.cs
+++ b/src/ComputerVision/Segmentation/Efficient/SlimSAM.cs
@@ -1,4 +1,4 @@
-﻿using System.IO;
+using System.IO;
 using AiDotNet.Attributes;
 using AiDotNet.Enums;
 using AiDotNet.Helpers;
@@ -281,7 +281,7 @@ public partial class SlimSAM<T> : Common.PromptableSegmentationBase<T>
     public override ModelMetadata<T> GetModelMetadata() => new()
     {
         AdditionalInfo = new Dictionary<string, object> { { "ModelName", "SlimSAM" }, { "InputHeight", _height }, { "InputWidth", _width }, { "NumClasses", _numClasses }, { "UseNativeMode", _useNativeMode }, { "NumLayers", Layers.Count } },
-        ModelData = SerializeForMetadata()
+        ModelDataProvider = () => SerializeForMetadata()
     };
 
     /// <summary>

--- a/src/ComputerVision/Segmentation/Foundation/EoMT.cs
+++ b/src/ComputerVision/Segmentation/Foundation/EoMT.cs
@@ -1,4 +1,4 @@
-﻿using System.IO;
+using System.IO;
 using AiDotNet.Attributes;
 using AiDotNet.Enums;
 using AiDotNet.Helpers;
@@ -352,7 +352,7 @@ public partial class EoMT<T> : Common.PanopticSegmentationBase<T>
                 { "EmbedDim", _embedDim }, { "DecoderDim", _decoderDim },
                 { "UseNativeMode", _useNativeMode }, { "NumLayers", Layers.Count }
             },
-            ModelData = SerializeForMetadata()
+            ModelDataProvider = () => SerializeForMetadata()
         };
     }
 

--- a/src/ComputerVision/Segmentation/Foundation/Mask2Former.cs
+++ b/src/ComputerVision/Segmentation/Foundation/Mask2Former.cs
@@ -1,4 +1,4 @@
-﻿using System.IO;
+using System.IO;
 using AiDotNet.Attributes;
 using AiDotNet.Enums;
 using AiDotNet.Helpers;
@@ -432,7 +432,7 @@ public partial class Mask2Former<T> : Common.PanopticSegmentationBase<T>
                 { "ModelSize", _modelSize.ToString() }, { "DecoderDim", _decoderDim },
                 { "DropRate", _dropRate }, { "UseNativeMode", _useNativeMode }, { "NumLayers", Layers.Count }
             },
-            ModelData = SerializeForMetadata()
+            ModelDataProvider = () => SerializeForMetadata()
         };
     }
 

--- a/src/ComputerVision/Segmentation/Foundation/MaskDINO.cs
+++ b/src/ComputerVision/Segmentation/Foundation/MaskDINO.cs
@@ -1,4 +1,4 @@
-﻿using System.IO;
+using System.IO;
 using AiDotNet.Attributes;
 using AiDotNet.Enums;
 using AiDotNet.Helpers;
@@ -356,7 +356,7 @@ public partial class MaskDINO<T> : Common.PanopticSegmentationBase<T>
                 { "DecoderDim", _decoderDim }, { "UseNativeMode", _useNativeMode },
                 { "NumLayers", Layers.Count }
             },
-            ModelData = SerializeForMetadata()
+            ModelDataProvider = () => SerializeForMetadata()
         };
     }
 

--- a/src/ComputerVision/Segmentation/Foundation/MixedQueryTransformer.cs
+++ b/src/ComputerVision/Segmentation/Foundation/MixedQueryTransformer.cs
@@ -354,7 +354,7 @@ public partial class MixedQueryTransformer<T> : Common.PanopticSegmentationBase<
                 { "DecoderDim", _decoderDim }, { "UseNativeMode", _useNativeMode },
                 { "NumLayers", Layers.Count }
             },
-            ModelData = SerializeForMetadata()
+            ModelDataProvider = () => SerializeForMetadata()
         };
     }
 

--- a/src/ComputerVision/Segmentation/Foundation/OMGSeg.cs
+++ b/src/ComputerVision/Segmentation/Foundation/OMGSeg.cs
@@ -1,4 +1,4 @@
-﻿using System.IO;
+using System.IO;
 using AiDotNet.Attributes;
 using AiDotNet.Enums;
 using AiDotNet.Helpers;
@@ -349,7 +349,7 @@ public partial class OMGSeg<T> : Common.PanopticSegmentationBase<T>
                 { "DecoderDim", _decoderDim }, { "UseNativeMode", _useNativeMode },
                 { "NumLayers", Layers.Count }
             },
-            ModelData = SerializeForMetadata()
+            ModelDataProvider = () => SerializeForMetadata()
         };
     }
 

--- a/src/ComputerVision/Segmentation/Foundation/OneFormer.cs
+++ b/src/ComputerVision/Segmentation/Foundation/OneFormer.cs
@@ -1,4 +1,4 @@
-﻿using System.IO;
+using System.IO;
 using AiDotNet.Attributes;
 using AiDotNet.Enums;
 using AiDotNet.Helpers;
@@ -473,7 +473,7 @@ public partial class OneFormer<T> : Common.PanopticSegmentationBase<T>
                 { "ModelSize", _modelSize.ToString() }, { "DecoderDim", _decoderDim },
                 { "DropRate", _dropRate }, { "UseNativeMode", _useNativeMode }, { "NumLayers", Layers.Count }
             },
-            ModelData = SerializeForMetadata()
+            ModelDataProvider = () => SerializeForMetadata()
         };
     }
 

--- a/src/ComputerVision/Segmentation/Foundation/SAM.cs
+++ b/src/ComputerVision/Segmentation/Foundation/SAM.cs
@@ -415,7 +415,7 @@ public partial class SAM<T> : Common.PromptableSegmentationBase<T>
             { "NumLayers", Layers.Count },
             { "EncoderLayerEnd", _encoderLayerEnd }
         },
-        ModelData = SerializeForMetadata()
+        ModelDataProvider = () => SerializeForMetadata()
     };
 
     // Dispose is inherited: SegmentationModelBase already disposes _onnxSession and sets _disposed,

--- a/src/ComputerVision/Segmentation/Foundation/SAM21.cs
+++ b/src/ComputerVision/Segmentation/Foundation/SAM21.cs
@@ -1,4 +1,4 @@
-﻿using System.IO;
+using System.IO;
 using AiDotNet.Attributes;
 using AiDotNet.Enums;
 using AiDotNet.Helpers;
@@ -338,7 +338,7 @@ public partial class SAM21<T> : Common.PromptableSegmentationBase<T>
             { "NumLayers", Layers.Count },
             { "EncoderLayerEnd", _encoderLayerEnd }
         },
-        ModelData = SerializeForMetadata()
+        ModelDataProvider = () => SerializeForMetadata()
     };
 
     /// <summary>

--- a/src/ComputerVision/Segmentation/Foundation/SAMHQ.cs
+++ b/src/ComputerVision/Segmentation/Foundation/SAMHQ.cs
@@ -1,4 +1,4 @@
-﻿using System.IO;
+using System.IO;
 using AiDotNet.Attributes;
 using AiDotNet.Enums;
 using AiDotNet.Helpers;
@@ -362,7 +362,7 @@ public partial class SAMHQ<T> : Common.PromptableSegmentationBase<T>
                 { "ModelSize", _modelSize.ToString() }, { "DecoderDim", _decoderDim },
                 { "UseNativeMode", _useNativeMode }, { "NumLayers", Layers.Count }
             },
-            ModelData = SerializeForMetadata()
+            ModelDataProvider = () => SerializeForMetadata()
         };
     }
 

--- a/src/ComputerVision/Segmentation/Foundation/U2Seg.cs
+++ b/src/ComputerVision/Segmentation/Foundation/U2Seg.cs
@@ -1,4 +1,4 @@
-﻿using System.IO;
+using System.IO;
 using AiDotNet.Attributes;
 using AiDotNet.Enums;
 using AiDotNet.Helpers;
@@ -313,7 +313,7 @@ public partial class U2Seg<T> : Common.PanopticSegmentationBase<T>
                 { "DecoderDim", _decoderDim }, { "UseNativeMode", _useNativeMode },
                 { "NumLayers", Layers.Count }
             },
-            ModelData = SerializeForMetadata()
+            ModelDataProvider = () => SerializeForMetadata()
         };
     }
 

--- a/src/ComputerVision/Segmentation/Foundation/UNINEXT.cs
+++ b/src/ComputerVision/Segmentation/Foundation/UNINEXT.cs
@@ -1,4 +1,4 @@
-﻿using System.IO;
+using System.IO;
 using AiDotNet.Attributes;
 using AiDotNet.Enums;
 using AiDotNet.Helpers;
@@ -346,7 +346,7 @@ public partial class UNINEXT<T> : Common.PanopticSegmentationBase<T>
                 { "DecoderDim", _decoderDim }, { "UseNativeMode", _useNativeMode },
                 { "NumLayers", Layers.Count }
             },
-            ModelData = SerializeForMetadata()
+            ModelDataProvider = () => SerializeForMetadata()
         };
     }
 

--- a/src/ComputerVision/Segmentation/Foundation/XDecoder.cs
+++ b/src/ComputerVision/Segmentation/Foundation/XDecoder.cs
@@ -1,4 +1,4 @@
-﻿using System.IO;
+using System.IO;
 using AiDotNet.Attributes;
 using AiDotNet.Enums;
 using AiDotNet.Helpers;
@@ -384,7 +384,7 @@ public partial class XDecoder<T> : Common.PanopticSegmentationBase<T>
                 { "DecoderDim", _decoderDim }, { "UseNativeMode", _useNativeMode },
                 { "NumLayers", Layers.Count }
             },
-            ModelData = SerializeForMetadata()
+            ModelDataProvider = () => SerializeForMetadata()
         };
     }
 

--- a/src/ComputerVision/Segmentation/InstanceSegmentation/YOLO11Seg.cs
+++ b/src/ComputerVision/Segmentation/InstanceSegmentation/YOLO11Seg.cs
@@ -268,7 +268,7 @@ public partial class YOLO11Seg<T> : Common.InstanceSegmentationBase<T>
     public override ModelMetadata<T> GetModelMetadata() => new()
     {
         AdditionalInfo = new Dictionary<string, object> { { "ModelName", "YOLO11Seg" }, { "InputHeight", _height }, { "InputWidth", _width }, { "NumClasses", _numClasses }, { "ModelSize", _modelSize.ToString() }, { "UseNativeMode", _useNativeMode }, { "NumLayers", Layers.Count } },
-        ModelData = SerializeForMetadata()
+        ModelDataProvider = () => SerializeForMetadata()
     };
 
     // Dispose is inherited: SegmentationModelBase already disposes _onnxSession and sets _disposed,

--- a/src/ComputerVision/Segmentation/InstanceSegmentation/YOLO26Seg.cs
+++ b/src/ComputerVision/Segmentation/InstanceSegmentation/YOLO26Seg.cs
@@ -268,7 +268,7 @@ public partial class YOLO26Seg<T> : Common.InstanceSegmentationBase<T>
     public override ModelMetadata<T> GetModelMetadata() => new()
     {
         AdditionalInfo = new Dictionary<string, object> { { "ModelName", "YOLO26Seg" }, { "InputHeight", _height }, { "InputWidth", _width }, { "NumClasses", _numClasses }, { "ModelSize", _modelSize.ToString() }, { "UseNativeMode", _useNativeMode }, { "NumLayers", Layers.Count } },
-        ModelData = SerializeForMetadata()
+        ModelDataProvider = () => SerializeForMetadata()
     };
 
     /// <summary>

--- a/src/ComputerVision/Segmentation/InstanceSegmentation/YOLOv12Seg.cs
+++ b/src/ComputerVision/Segmentation/InstanceSegmentation/YOLOv12Seg.cs
@@ -1,4 +1,4 @@
-﻿using System.IO;
+using System.IO;
 using AiDotNet.Attributes;
 using AiDotNet.Augmentation.Image;
 using AiDotNet.Enums;
@@ -311,7 +311,7 @@ public partial class YOLOv12Seg<T> : Common.InstanceSegmentationBase<T>
     public override ModelMetadata<T> GetModelMetadata() => new()
     {
         AdditionalInfo = new Dictionary<string, object> { { "ModelName", "YOLOv12Seg" }, { "InputHeight", _height }, { "InputWidth", _width }, { "NumClasses", _numClasses }, { "ModelSize", _modelSize.ToString() }, { "UseNativeMode", _useNativeMode }, { "NumLayers", Layers.Count } },
-        ModelData = SerializeForMetadata()
+        ModelDataProvider = () => SerializeForMetadata()
     };
 
     // Dispose is inherited from SegmentationModelBase, which already disposes the ONNX session.

--- a/src/ComputerVision/Segmentation/InstanceSegmentation/YOLOv8Seg.cs
+++ b/src/ComputerVision/Segmentation/InstanceSegmentation/YOLOv8Seg.cs
@@ -303,7 +303,7 @@ public partial class YOLOv8Seg<T> : Common.InstanceSegmentationBase<T>
             { "UseNativeMode", _useNativeMode },
             { "NumLayers", Layers.Count }
         },
-        ModelData = SerializeForMetadata()
+        ModelDataProvider = () => SerializeForMetadata()
     };
 
     // Dispose is inherited from SegmentationModelBase, which already disposes the ONNX session.

--- a/src/ComputerVision/Segmentation/InstanceSegmentation/YOLOv9Seg.cs
+++ b/src/ComputerVision/Segmentation/InstanceSegmentation/YOLOv9Seg.cs
@@ -1,4 +1,4 @@
-﻿using System.IO;
+using System.IO;
 using AiDotNet.Attributes;
 using AiDotNet.Augmentation.Image;
 using AiDotNet.Enums;
@@ -275,7 +275,7 @@ public partial class YOLOv9Seg<T> : Common.InstanceSegmentationBase<T>
     public override ModelMetadata<T> GetModelMetadata() => new()
     {
         AdditionalInfo = new Dictionary<string, object> { { "ModelName", "YOLOv9Seg" }, { "InputHeight", _height }, { "InputWidth", _width }, { "NumClasses", _numClasses }, { "ModelSize", _modelSize.ToString() }, { "UseNativeMode", _useNativeMode }, { "NumLayers", Layers.Count } },
-        ModelData = SerializeForMetadata()
+        ModelDataProvider = () => SerializeForMetadata()
     };
 
     // Dispose is inherited from SegmentationModelBase, which already disposes the ONNX session.

--- a/src/ComputerVision/Segmentation/Interactive/SEEM.cs
+++ b/src/ComputerVision/Segmentation/Interactive/SEEM.cs
@@ -1,4 +1,4 @@
-﻿using System.IO;
+using System.IO;
 using AiDotNet.Attributes;
 using AiDotNet.Enums;
 using AiDotNet.Helpers;
@@ -293,7 +293,7 @@ public partial class SEEM<T> : Common.PromptableSegmentationBase<T>
     public override ModelMetadata<T> GetModelMetadata() => new()
     {
         AdditionalInfo = new Dictionary<string, object> { { "ModelName", "SEEM" }, { "InputHeight", _height }, { "InputWidth", _width }, { "NumClasses", _numClasses }, { "ModelSize", _modelSize.ToString() }, { "UseNativeMode", _useNativeMode }, { "NumLayers", Layers.Count } },
-        ModelData = SerializeForMetadata()
+        ModelDataProvider = () => SerializeForMetadata()
     };
 
     // Dispose is inherited from SegmentationModelBase, which already disposes the ONNX session.

--- a/src/ComputerVision/Segmentation/Interactive/SegGPT.cs
+++ b/src/ComputerVision/Segmentation/Interactive/SegGPT.cs
@@ -1,4 +1,4 @@
-﻿using System.IO;
+using System.IO;
 using AiDotNet.Attributes;
 using AiDotNet.Enums;
 using AiDotNet.Helpers;
@@ -278,7 +278,7 @@ public partial class SegGPT<T> : Common.PromptableSegmentationBase<T>
     public override ModelMetadata<T> GetModelMetadata() => new()
     {
         AdditionalInfo = new Dictionary<string, object> { { "ModelName", "SegGPT" }, { "InputHeight", _height }, { "InputWidth", _width }, { "NumClasses", _numClasses }, { "ModelSize", _modelSize.ToString() }, { "UseNativeMode", _useNativeMode }, { "NumLayers", Layers.Count } },
-        ModelData = SerializeForMetadata()
+        ModelDataProvider = () => SerializeForMetadata()
     };
 
     // Dispose is inherited from SegmentationModelBase, which already disposes the ONNX session.

--- a/src/ComputerVision/Segmentation/Mamba/VMamba.cs
+++ b/src/ComputerVision/Segmentation/Mamba/VMamba.cs
@@ -1,4 +1,4 @@
-﻿using System.IO;
+using System.IO;
 using AiDotNet.Attributes;
 using AiDotNet.Enums;
 using AiDotNet.Helpers;
@@ -274,7 +274,7 @@ public partial class VMamba<T> : Common.SemanticSegmentationBase<T>
     public override ModelMetadata<T> GetModelMetadata() => new()
     {
         AdditionalInfo = new Dictionary<string, object> { { "ModelName", "VMamba" }, { "InputHeight", _height }, { "InputWidth", _width }, { "NumClasses", _numClasses }, { "ModelSize", _modelSize.ToString() }, { "UseNativeMode", _useNativeMode }, { "NumLayers", Layers.Count } },
-        ModelData = SerializeForMetadata()
+        ModelDataProvider = () => SerializeForMetadata()
     };
 
     // Dispose is inherited from SegmentationModelBase, which already disposes the ONNX session.

--- a/src/ComputerVision/Segmentation/Mamba/ViMUNet.cs
+++ b/src/ComputerVision/Segmentation/Mamba/ViMUNet.cs
@@ -1,4 +1,4 @@
-﻿using System.IO;
+using System.IO;
 using AiDotNet.Attributes;
 using AiDotNet.Enums;
 using AiDotNet.Helpers;
@@ -267,7 +267,7 @@ public partial class ViMUNet<T> : Common.SemanticSegmentationBase<T>
     public override ModelMetadata<T> GetModelMetadata() => new()
     {
         AdditionalInfo = new Dictionary<string, object> { { "ModelName", "ViMUNet" }, { "InputHeight", _height }, { "InputWidth", _width }, { "NumClasses", _numClasses }, { "UseNativeMode", _useNativeMode }, { "NumLayers", Layers.Count } },
-        ModelData = SerializeForMetadata()
+        ModelDataProvider = () => SerializeForMetadata()
     };
 
     // Dispose is inherited from SegmentationModelBase, which already disposes the ONNX session.

--- a/src/ComputerVision/Segmentation/Mamba/VisionMamba.cs
+++ b/src/ComputerVision/Segmentation/Mamba/VisionMamba.cs
@@ -1,4 +1,4 @@
-﻿using System.IO;
+using System.IO;
 using AiDotNet.Attributes;
 using AiDotNet.Enums;
 using AiDotNet.Helpers;
@@ -275,7 +275,7 @@ public partial class VisionMamba<T> : Common.SemanticSegmentationBase<T>
     public override ModelMetadata<T> GetModelMetadata() => new()
     {
         AdditionalInfo = new Dictionary<string, object> { { "ModelName", "VisionMamba" }, { "InputHeight", _height }, { "InputWidth", _width }, { "NumClasses", _numClasses }, { "ModelSize", _modelSize.ToString() }, { "UseNativeMode", _useNativeMode }, { "NumLayers", Layers.Count } },
-        ModelData = SerializeForMetadata()
+        ModelDataProvider = () => SerializeForMetadata()
     };
 
     // Dispose is inherited from SegmentationModelBase, which already disposes the ONNX session.

--- a/src/ComputerVision/Segmentation/Medical/BiomedParse.cs
+++ b/src/ComputerVision/Segmentation/Medical/BiomedParse.cs
@@ -1,4 +1,4 @@
-﻿using System.IO;
+using System.IO;
 using AiDotNet.Attributes;
 using AiDotNet.Enums;
 using AiDotNet.Helpers;
@@ -304,7 +304,7 @@ public partial class BiomedParse<T> : Common.MedicalSegmentationBase<T>
     public override ModelMetadata<T> GetModelMetadata() => new()
     {
         AdditionalInfo = new Dictionary<string, object> { { "ModelName", "BiomedParse" }, { "InputHeight", _height }, { "InputWidth", _width }, { "NumClasses", _numClasses }, { "UseNativeMode", _useNativeMode }, { "NumLayers", Layers.Count } },
-        ModelData = SerializeForMetadata()
+        ModelDataProvider = () => SerializeForMetadata()
     };
 
     // Dispose is inherited from SegmentationModelBase, which already disposes the ONNX session.

--- a/src/ComputerVision/Segmentation/Medical/MedNeXt.cs
+++ b/src/ComputerVision/Segmentation/Medical/MedNeXt.cs
@@ -1,4 +1,4 @@
-﻿using System.IO;
+using System.IO;
 using AiDotNet.Attributes;
 using AiDotNet.Enums;
 using AiDotNet.Helpers;
@@ -278,7 +278,7 @@ public partial class MedNeXt<T> : Common.MedicalSegmentationBase<T>
     public override ModelMetadata<T> GetModelMetadata() => new()
     {
         AdditionalInfo = new Dictionary<string, object> { { "ModelName", "MedNeXt" }, { "InputHeight", _height }, { "InputWidth", _width }, { "NumClasses", _numClasses }, { "ModelSize", _modelSize.ToString() }, { "UseNativeMode", _useNativeMode }, { "NumLayers", Layers.Count } },
-        ModelData = SerializeForMetadata()
+        ModelDataProvider = () => SerializeForMetadata()
     };
 
     // Dispose is inherited from SegmentationModelBase, which already disposes the ONNX session.

--- a/src/ComputerVision/Segmentation/Medical/MedSAM.cs
+++ b/src/ComputerVision/Segmentation/Medical/MedSAM.cs
@@ -1,4 +1,4 @@
-﻿using System.IO;
+using System.IO;
 using AiDotNet.Attributes;
 using AiDotNet.Enums;
 using AiDotNet.Helpers;
@@ -373,7 +373,7 @@ public partial class MedSAM<T> : Common.MedicalSegmentationBase<T>
     public override ModelMetadata<T> GetModelMetadata() => new()
     {
         AdditionalInfo = new Dictionary<string, object> { { "ModelName", "MedSAM" }, { "InputHeight", _height }, { "InputWidth", _width }, { "NumClasses", _numClasses }, { "ModelSize", _modelSize.ToString() }, { "UseNativeMode", _useNativeMode }, { "NumLayers", Layers.Count } },
-        ModelData = SerializeForMetadata()
+        ModelDataProvider = () => SerializeForMetadata()
     };
 
     // Dispose is inherited from SegmentationModelBase, which already disposes the ONNX session.

--- a/src/ComputerVision/Segmentation/Medical/MedSAM2.cs
+++ b/src/ComputerVision/Segmentation/Medical/MedSAM2.cs
@@ -1,4 +1,4 @@
-﻿using System.IO;
+using System.IO;
 using AiDotNet.Attributes;
 using AiDotNet.Enums;
 using AiDotNet.Helpers;
@@ -351,7 +351,7 @@ public partial class MedSAM2<T> : Common.MedicalSegmentationBase<T>
     public override ModelMetadata<T> GetModelMetadata() => new()
     {
         AdditionalInfo = new Dictionary<string, object> { { "ModelName", "MedSAM2" }, { "InputHeight", _height }, { "InputWidth", _width }, { "NumClasses", _numClasses }, { "ModelSize", _modelSize.ToString() }, { "UseNativeMode", _useNativeMode }, { "NumLayers", Layers.Count } },
-        ModelData = SerializeForMetadata()
+        ModelDataProvider = () => SerializeForMetadata()
     };
 
     // Dispose is inherited from SegmentationModelBase, which already disposes the ONNX session.

--- a/src/ComputerVision/Segmentation/Medical/MedSegDiffV2.cs
+++ b/src/ComputerVision/Segmentation/Medical/MedSegDiffV2.cs
@@ -1,4 +1,4 @@
-﻿using System.IO;
+using System.IO;
 using AiDotNet.Attributes;
 using AiDotNet.Enums;
 using AiDotNet.Helpers;
@@ -260,7 +260,7 @@ public partial class MedSegDiffV2<T> : Common.MedicalSegmentationBase<T>
     public override ModelMetadata<T> GetModelMetadata() => new()
     {
         AdditionalInfo = new Dictionary<string, object> { { "ModelName", "MedSegDiffV2" }, { "InputHeight", _height }, { "InputWidth", _width }, { "NumClasses", _numClasses }, { "UseNativeMode", _useNativeMode }, { "NumLayers", Layers.Count } },
-        ModelData = SerializeForMetadata()
+        ModelDataProvider = () => SerializeForMetadata()
     };
 
     // Dispose is inherited: SegmentationModelBase already disposes _onnxSession and flips _disposed,

--- a/src/ComputerVision/Segmentation/Medical/NnUNet.cs
+++ b/src/ComputerVision/Segmentation/Medical/NnUNet.cs
@@ -1,4 +1,4 @@
-﻿using System.IO;
+using System.IO;
 using AiDotNet.Attributes;
 using AiDotNet.Enums;
 using AiDotNet.Helpers;
@@ -270,7 +270,7 @@ public partial class NnUNet<T> : Common.MedicalSegmentationBase<T>
     public override ModelMetadata<T> GetModelMetadata() => new()
     {
         AdditionalInfo = new Dictionary<string, object> { { "ModelName", "NnUNet" }, { "InputHeight", _height }, { "InputWidth", _width }, { "NumClasses", _numClasses }, { "ModelSize", _modelSize.ToString() }, { "UseNativeMode", _useNativeMode }, { "NumLayers", Layers.Count } },
-        ModelData = SerializeForMetadata()
+        ModelDataProvider = () => SerializeForMetadata()
     };
 
     // Dispose is inherited: SegmentationModelBase already disposes _onnxSession and flips _disposed,

--- a/src/ComputerVision/Segmentation/Medical/SegMamba.cs
+++ b/src/ComputerVision/Segmentation/Medical/SegMamba.cs
@@ -680,7 +680,7 @@ public partial class SegMamba<T> : Common.MedicalSegmentationBase<T>
     public override ModelMetadata<T> GetModelMetadata() => new()
     {
         AdditionalInfo = new Dictionary<string, object> { { "ModelName", "SegMamba" }, { "InChannels", _inChannels }, { "NumClasses", _numClasses }, { "UseNativeMode", _useNativeMode }, { "NumLayers", Layers.Count } },
-        ModelData = SerializeForMetadata()
+        ModelDataProvider = () => SerializeForMetadata()
     };
 
     // Dispose is inherited: SegmentationModelBase already disposes _onnxSession and flips _disposed,

--- a/src/ComputerVision/Segmentation/Medical/SwinUNETR.cs
+++ b/src/ComputerVision/Segmentation/Medical/SwinUNETR.cs
@@ -1,4 +1,4 @@
-﻿using System.IO;
+using System.IO;
 using AiDotNet.Attributes;
 using AiDotNet.Enums;
 using AiDotNet.Helpers;
@@ -339,7 +339,7 @@ public partial class SwinUNETR<T> : Common.MedicalSegmentationBase<T>
     public override ModelMetadata<T> GetModelMetadata() => new()
     {
         AdditionalInfo = new Dictionary<string, object> { { "ModelName", "SwinUNETR" }, { "InputHeight", _height }, { "InputWidth", _width }, { "NumClasses", _numClasses }, { "ModelSize", _modelSize.ToString() }, { "UseNativeMode", _useNativeMode }, { "NumLayers", Layers.Count } },
-        ModelData = SerializeForMetadata()
+        ModelDataProvider = () => SerializeForMetadata()
     };
 
     // Dispose is inherited: SegmentationModelBase already disposes _onnxSession and flips _disposed,

--- a/src/ComputerVision/Segmentation/Medical/TransUNet.cs
+++ b/src/ComputerVision/Segmentation/Medical/TransUNet.cs
@@ -1,4 +1,4 @@
-﻿using System.IO;
+using System.IO;
 using AiDotNet.Attributes;
 using AiDotNet.Enums;
 using AiDotNet.Helpers;
@@ -271,7 +271,7 @@ public partial class TransUNet<T> : Common.MedicalSegmentationBase<T>
     public override ModelMetadata<T> GetModelMetadata() => new()
     {
         AdditionalInfo = new Dictionary<string, object> { { "ModelName", "TransUNet" }, { "InputHeight", _height }, { "InputWidth", _width }, { "NumClasses", _numClasses }, { "ModelSize", _modelSize.ToString() }, { "UseNativeMode", _useNativeMode }, { "NumLayers", Layers.Count } },
-        ModelData = SerializeForMetadata()
+        ModelDataProvider = () => SerializeForMetadata()
     };
 
     // Dispose is inherited: SegmentationModelBase already disposes _onnxSession and flips _disposed,

--- a/src/ComputerVision/Segmentation/Medical/UMamba.cs
+++ b/src/ComputerVision/Segmentation/Medical/UMamba.cs
@@ -1,4 +1,4 @@
-﻿using System.IO;
+using System.IO;
 using AiDotNet.Attributes;
 using AiDotNet.Enums;
 using AiDotNet.Helpers;
@@ -259,7 +259,7 @@ public partial class UMamba<T> : Common.MedicalSegmentationBase<T>
     public override ModelMetadata<T> GetModelMetadata() => new()
     {
         AdditionalInfo = new Dictionary<string, object> { { "ModelName", "UMamba" }, { "InputHeight", _height }, { "InputWidth", _width }, { "NumClasses", _numClasses }, { "UseNativeMode", _useNativeMode }, { "NumLayers", Layers.Count } },
-        ModelData = SerializeForMetadata()
+        ModelDataProvider = () => SerializeForMetadata()
     };
 
     // Dispose is inherited: SegmentationModelBase already disposes _onnxSession and flips _disposed,

--- a/src/ComputerVision/Segmentation/Medical/UniverSeg.cs
+++ b/src/ComputerVision/Segmentation/Medical/UniverSeg.cs
@@ -1,4 +1,4 @@
-﻿using System.IO;
+using System.IO;
 using AiDotNet.Attributes;
 using AiDotNet.Enums;
 using AiDotNet.Helpers;
@@ -262,7 +262,7 @@ public partial class UniverSeg<T> : Common.MedicalSegmentationBase<T>
     public override ModelMetadata<T> GetModelMetadata() => new()
     {
         AdditionalInfo = new Dictionary<string, object> { { "ModelName", "UniverSeg" }, { "InputHeight", _height }, { "InputWidth", _width }, { "NumClasses", _numClasses }, { "UseNativeMode", _useNativeMode }, { "NumLayers", Layers.Count } },
-        ModelData = SerializeForMetadata()
+        ModelDataProvider = () => SerializeForMetadata()
     };
 
     // Dispose is inherited: SegmentationModelBase already disposes _onnxSession and flips _disposed,

--- a/src/ComputerVision/Segmentation/OpenVocabulary/CATSeg.cs
+++ b/src/ComputerVision/Segmentation/OpenVocabulary/CATSeg.cs
@@ -1,4 +1,4 @@
-﻿using System.IO;
+using System.IO;
 using AiDotNet.Attributes;
 using AiDotNet.Enums;
 using AiDotNet.Helpers;
@@ -274,7 +274,7 @@ public partial class CATSeg<T> : Common.OpenVocabSegmentationBase<T>
     public override ModelMetadata<T> GetModelMetadata() => new()
     {
         AdditionalInfo = new Dictionary<string, object> { { "ModelName", "CATSeg" }, { "InputHeight", _height }, { "InputWidth", _width }, { "NumClasses", _numClasses }, { "UseNativeMode", _useNativeMode }, { "NumLayers", Layers.Count } },
-        ModelData = SerializeForMetadata()
+        ModelDataProvider = () => SerializeForMetadata()
     };
 
     // Dispose is inherited: SegmentationModelBase already disposes _onnxSession and flips _disposed,

--- a/src/ComputerVision/Segmentation/OpenVocabulary/GroundedSAM2.cs
+++ b/src/ComputerVision/Segmentation/OpenVocabulary/GroundedSAM2.cs
@@ -1,4 +1,4 @@
-﻿using System.IO;
+using System.IO;
 using AiDotNet.Attributes;
 using AiDotNet.Enums;
 using AiDotNet.Helpers;
@@ -456,7 +456,7 @@ public partial class GroundedSAM2<T> : Common.OpenVocabSegmentationBase<T>
     public override ModelMetadata<T> GetModelMetadata() => new()
     {
         AdditionalInfo = new Dictionary<string, object> { { "ModelName", "GroundedSAM2" }, { "InputHeight", _height }, { "InputWidth", _width }, { "NumClasses", _numClasses }, { "UseNativeMode", _useNativeMode }, { "NumLayers", Layers.Count } },
-        ModelData = SerializeForMetadata()
+        ModelDataProvider = () => SerializeForMetadata()
     };
 
     // Dispose is inherited: SegmentationModelBase already disposes _onnxSession and flips _disposed,

--- a/src/ComputerVision/Segmentation/OpenVocabulary/MaskAdapter.cs
+++ b/src/ComputerVision/Segmentation/OpenVocabulary/MaskAdapter.cs
@@ -1,4 +1,4 @@
-﻿using System.IO;
+using System.IO;
 using AiDotNet.Attributes;
 using AiDotNet.Enums;
 using AiDotNet.Helpers;
@@ -271,7 +271,7 @@ public partial class MaskAdapter<T> : Common.OpenVocabSegmentationBase<T>
     public override ModelMetadata<T> GetModelMetadata() => new()
     {
         AdditionalInfo = new Dictionary<string, object> { { "ModelName", "MaskAdapter" }, { "InputHeight", _height }, { "InputWidth", _width }, { "NumClasses", _numClasses }, { "UseNativeMode", _useNativeMode }, { "NumLayers", Layers.Count } },
-        ModelData = SerializeForMetadata()
+        ModelDataProvider = () => SerializeForMetadata()
     };
 
     // Dispose is inherited: SegmentationModelBase already disposes _onnxSession and flips _disposed,

--- a/src/ComputerVision/Segmentation/OpenVocabulary/OpenVocabSAM.cs
+++ b/src/ComputerVision/Segmentation/OpenVocabulary/OpenVocabSAM.cs
@@ -1,4 +1,4 @@
-﻿using System.IO;
+using System.IO;
 using AiDotNet.Attributes;
 using AiDotNet.Enums;
 using AiDotNet.Helpers;
@@ -276,7 +276,7 @@ public partial class OpenVocabSAM<T> : Common.OpenVocabSegmentationBase<T>
     public override ModelMetadata<T> GetModelMetadata() => new()
     {
         AdditionalInfo = new Dictionary<string, object> { { "ModelName", "OpenVocabSAM" }, { "InputHeight", _height }, { "InputWidth", _width }, { "NumClasses", _numClasses }, { "UseNativeMode", _useNativeMode }, { "NumLayers", Layers.Count } },
-        ModelData = SerializeForMetadata()
+        ModelDataProvider = () => SerializeForMetadata()
     };
 
     /// <summary>

--- a/src/ComputerVision/Segmentation/OpenVocabulary/SAN.cs
+++ b/src/ComputerVision/Segmentation/OpenVocabulary/SAN.cs
@@ -1,4 +1,4 @@
-﻿using System.IO;
+using System.IO;
 using AiDotNet.Attributes;
 using AiDotNet.Enums;
 using AiDotNet.Helpers;
@@ -254,7 +254,7 @@ public partial class SAN<T> : Common.OpenVocabSegmentationBase<T>
     public override ModelMetadata<T> GetModelMetadata() => new()
     {
         AdditionalInfo = new Dictionary<string, object> { { "ModelName", "SAN" }, { "InputHeight", _height }, { "InputWidth", _width }, { "NumClasses", _numClasses }, { "UseNativeMode", _useNativeMode }, { "NumLayers", Layers.Count } },
-        ModelData = SerializeForMetadata()
+        ModelDataProvider = () => SerializeForMetadata()
     };
 
     // Dispose is inherited: SegmentationModelBase already disposes _onnxSession and flips _disposed,

--- a/src/ComputerVision/Segmentation/OpenVocabulary/SED.cs
+++ b/src/ComputerVision/Segmentation/OpenVocabulary/SED.cs
@@ -1,4 +1,4 @@
-﻿using System.IO;
+using System.IO;
 using AiDotNet.Attributes;
 using AiDotNet.Enums;
 using AiDotNet.Helpers;
@@ -252,7 +252,7 @@ public partial class SED<T> : Common.OpenVocabSegmentationBase<T>
     public override ModelMetadata<T> GetModelMetadata() => new()
     {
         AdditionalInfo = new Dictionary<string, object> { { "ModelName", "SED" }, { "InputHeight", _height }, { "InputWidth", _width }, { "NumClasses", _numClasses }, { "UseNativeMode", _useNativeMode }, { "NumLayers", Layers.Count } },
-        ModelData = SerializeForMetadata()
+        ModelDataProvider = () => SerializeForMetadata()
     };
     #endregion
 

--- a/src/ComputerVision/Segmentation/Panoptic/CUPS.cs
+++ b/src/ComputerVision/Segmentation/Panoptic/CUPS.cs
@@ -1,4 +1,4 @@
-﻿using System.IO;
+using System.IO;
 using AiDotNet.Attributes;
 using AiDotNet.Enums;
 using AiDotNet.Helpers;
@@ -270,7 +270,7 @@ public partial class CUPS<T> : Common.PanopticSegmentationBase<T>
     public override ModelMetadata<T> GetModelMetadata() => new()
     {
         AdditionalInfo = new Dictionary<string, object> { { "ModelName", "CUPS" }, { "InputHeight", _height }, { "InputWidth", _width }, { "NumClasses", _numClasses }, { "UseNativeMode", _useNativeMode }, { "NumLayers", Layers.Count } },
-        ModelData = SerializeForMetadata()
+        ModelDataProvider = () => SerializeForMetadata()
     };
     #endregion
 

--- a/src/ComputerVision/Segmentation/Panoptic/KMaXDeepLab.cs
+++ b/src/ComputerVision/Segmentation/Panoptic/KMaXDeepLab.cs
@@ -1,4 +1,4 @@
-﻿using System.IO;
+using System.IO;
 using AiDotNet.Attributes;
 using AiDotNet.Enums;
 using AiDotNet.Helpers;
@@ -265,7 +265,7 @@ public partial class KMaXDeepLab<T> : Common.PanopticSegmentationBase<T>
     public override ModelMetadata<T> GetModelMetadata() => new()
     {
         AdditionalInfo = new Dictionary<string, object> { { "ModelName", "KMaXDeepLab" }, { "InputHeight", _height }, { "InputWidth", _width }, { "NumClasses", _numClasses }, { "ModelSize", _modelSize.ToString() }, { "UseNativeMode", _useNativeMode }, { "NumLayers", Layers.Count } },
-        ModelData = SerializeForMetadata()
+        ModelDataProvider = () => SerializeForMetadata()
     };
     #endregion
 

--- a/src/ComputerVision/Segmentation/Panoptic/ODISE.cs
+++ b/src/ComputerVision/Segmentation/Panoptic/ODISE.cs
@@ -1,4 +1,4 @@
-﻿using System.IO;
+using System.IO;
 using AiDotNet.Attributes;
 using AiDotNet.Enums;
 using AiDotNet.Helpers;
@@ -441,7 +441,7 @@ public partial class ODISE<T> : Common.PanopticSegmentationBase<T>
     public override ModelMetadata<T> GetModelMetadata() => new()
     {
         AdditionalInfo = new Dictionary<string, object> { { "ModelName", "ODISE" }, { "InputHeight", _height }, { "InputWidth", _width }, { "NumClasses", _numClasses }, { "ModelSize", _modelSize.ToString() }, { "UseNativeMode", _useNativeMode }, { "NumLayers", Layers.Count } },
-        ModelData = SerializeForMetadata()
+        ModelDataProvider = () => SerializeForMetadata()
     };
     #endregion
 

--- a/src/ComputerVision/Segmentation/PointCloud/Concerto.cs
+++ b/src/ComputerVision/Segmentation/PointCloud/Concerto.cs
@@ -1,4 +1,4 @@
-﻿using System.IO;
+using System.IO;
 using AiDotNet.Attributes;
 using AiDotNet.Enums;
 using AiDotNet.Helpers;
@@ -292,7 +292,7 @@ public partial class Concerto<T> : Common.SemanticSegmentationBase<T>
     public override ModelMetadata<T> GetModelMetadata() => new()
     {
         AdditionalInfo = new Dictionary<string, object> { { "ModelName", "Concerto" }, { "InputHeight", _height }, { "InputWidth", _width }, { "NumClasses", _numClasses }, { "ModelSize", _modelSize.ToString() }, { "UseNativeMode", _useNativeMode }, { "NumLayers", Layers.Count } },
-        ModelData = SerializeForMetadata()
+        ModelDataProvider = () => SerializeForMetadata()
     };
     #endregion
 

--- a/src/ComputerVision/Segmentation/PointCloud/PointTransformerV3.cs
+++ b/src/ComputerVision/Segmentation/PointCloud/PointTransformerV3.cs
@@ -1,4 +1,4 @@
-﻿using System.IO;
+using System.IO;
 using AiDotNet.Attributes;
 using AiDotNet.Enums;
 using AiDotNet.Helpers;
@@ -260,7 +260,7 @@ public partial class PointTransformerV3<T> : Common.SemanticSegmentationBase<T>
     public override ModelMetadata<T> GetModelMetadata() => new()
     {
         AdditionalInfo = new Dictionary<string, object> { { "ModelName", "PointTransformerV3" }, { "InputHeight", _height }, { "InputWidth", _width }, { "NumClasses", _numClasses }, { "ModelSize", _modelSize.ToString() }, { "UseNativeMode", _useNativeMode }, { "NumLayers", Layers.Count } },
-        ModelData = SerializeForMetadata()
+        ModelDataProvider = () => SerializeForMetadata()
     };
     #endregion
 

--- a/src/ComputerVision/Segmentation/PointCloud/Sonata.cs
+++ b/src/ComputerVision/Segmentation/PointCloud/Sonata.cs
@@ -1,4 +1,4 @@
-﻿using System.IO;
+using System.IO;
 using AiDotNet.Attributes;
 using AiDotNet.Enums;
 using AiDotNet.Helpers;
@@ -260,7 +260,7 @@ public partial class Sonata<T> : Common.SemanticSegmentationBase<T>
     public override ModelMetadata<T> GetModelMetadata() => new()
     {
         AdditionalInfo = new Dictionary<string, object> { { "ModelName", "Sonata" }, { "InputHeight", _height }, { "InputWidth", _width }, { "NumClasses", _numClasses }, { "ModelSize", _modelSize.ToString() }, { "UseNativeMode", _useNativeMode }, { "NumLayers", Layers.Count } },
-        ModelData = SerializeForMetadata()
+        ModelDataProvider = () => SerializeForMetadata()
     };
     #endregion
 

--- a/src/ComputerVision/Segmentation/Referring/GLaMM.cs
+++ b/src/ComputerVision/Segmentation/Referring/GLaMM.cs
@@ -1,4 +1,4 @@
-﻿using System.IO;
+using System.IO;
 using AiDotNet.Attributes;
 using AiDotNet.Enums;
 using AiDotNet.Helpers;
@@ -265,7 +265,7 @@ public partial class GLaMM<T> : Common.ReferringSegmentationBase<T>
     public override ModelMetadata<T> GetModelMetadata() => new()
     {
         AdditionalInfo = new Dictionary<string, object> { { "ModelName", "GLaMM" }, { "InputHeight", _height }, { "InputWidth", _width }, { "NumClasses", _numClasses }, { "UseNativeMode", _useNativeMode }, { "NumLayers", Layers.Count } },
-        ModelData = SerializeForMetadata()
+        ModelDataProvider = () => SerializeForMetadata()
     };
     // Dispose is inherited: SegmentationModelBase already disposes _onnxSession and latches
     // _disposed, and GLaMM owns no other unmanaged resource.

--- a/src/ComputerVision/Segmentation/Referring/LISA.cs
+++ b/src/ComputerVision/Segmentation/Referring/LISA.cs
@@ -1,4 +1,4 @@
-﻿using System.IO;
+using System.IO;
 using AiDotNet.Attributes;
 using AiDotNet.Enums;
 using AiDotNet.Helpers;
@@ -253,7 +253,7 @@ public partial class LISA<T> : Common.ReferringSegmentationBase<T>
     public override ModelMetadata<T> GetModelMetadata() => new()
     {
         AdditionalInfo = new Dictionary<string, object> { { "ModelName", "LISA" }, { "InputHeight", _height }, { "InputWidth", _width }, { "NumClasses", _numClasses }, { "UseNativeMode", _useNativeMode }, { "NumLayers", Layers.Count } },
-        ModelData = SerializeForMetadata()
+        ModelDataProvider = () => SerializeForMetadata()
     };
     // Dispose is inherited: SegmentationModelBase already disposes _onnxSession and latches
     // _disposed, and LISA owns no other unmanaged resource.

--- a/src/ComputerVision/Segmentation/Referring/OMGLLaVA.cs
+++ b/src/ComputerVision/Segmentation/Referring/OMGLLaVA.cs
@@ -1,4 +1,4 @@
-﻿using System.IO;
+using System.IO;
 using AiDotNet.Attributes;
 using AiDotNet.Enums;
 using AiDotNet.Helpers;
@@ -255,7 +255,7 @@ public partial class OMGLLaVA<T> : Common.ReferringSegmentationBase<T>
     public override ModelMetadata<T> GetModelMetadata() => new()
     {
         AdditionalInfo = new Dictionary<string, object> { { "ModelName", "OMGLLaVA" }, { "InputHeight", _height }, { "InputWidth", _width }, { "NumClasses", _numClasses }, { "UseNativeMode", _useNativeMode }, { "NumLayers", Layers.Count } },
-        ModelData = SerializeForMetadata()
+        ModelDataProvider = () => SerializeForMetadata()
     };
     // Dispose is inherited: SegmentationModelBase already disposes _onnxSession and latches
     // _disposed, and OMGLLaVA owns no other unmanaged resource.

--- a/src/ComputerVision/Segmentation/Referring/PixelLM.cs
+++ b/src/ComputerVision/Segmentation/Referring/PixelLM.cs
@@ -1,4 +1,4 @@
-﻿using System.IO;
+using System.IO;
 using AiDotNet.Attributes;
 using AiDotNet.Enums;
 using AiDotNet.Helpers;
@@ -300,7 +300,7 @@ public partial class PixelLM<T> : Common.ReferringSegmentationBase<T>
     public override ModelMetadata<T> GetModelMetadata() => new()
     {
         AdditionalInfo = new Dictionary<string, object> { { "ModelName", "PixelLM" }, { "InputHeight", _height }, { "InputWidth", _width }, { "NumClasses", _numClasses }, { "UseNativeMode", _useNativeMode }, { "NumLayers", Layers.Count } },
-        ModelData = SerializeForMetadata()
+        ModelDataProvider = () => SerializeForMetadata()
     };
     // Dispose is inherited: SegmentationModelBase already disposes _onnxSession and latches
     // _disposed, and PixelLM owns no other unmanaged resource.

--- a/src/ComputerVision/Segmentation/Referring/VideoLISA.cs
+++ b/src/ComputerVision/Segmentation/Referring/VideoLISA.cs
@@ -332,7 +332,7 @@ public partial class VideoLISA<T> : Common.ReferringSegmentationBase<T>
     public override ModelMetadata<T> GetModelMetadata() => new()
     {
         AdditionalInfo = new Dictionary<string, object> { { "ModelName", "VideoLISA" }, { "InputHeight", _height }, { "InputWidth", _width }, { "NumClasses", _numClasses }, { "UseNativeMode", _useNativeMode }, { "NumLayers", Layers.Count } },
-        ModelData = SerializeForMetadata()
+        ModelDataProvider = () => SerializeForMetadata()
     };
 
     #endregion

--- a/src/ComputerVision/Segmentation/Semantic/DiffCut.cs
+++ b/src/ComputerVision/Segmentation/Semantic/DiffCut.cs
@@ -1,4 +1,4 @@
-﻿using System.IO;
+using System.IO;
 using AiDotNet.Attributes;
 using AiDotNet.Enums;
 using AiDotNet.Helpers;
@@ -303,7 +303,7 @@ public partial class DiffCut<T> : Common.SemanticSegmentationBase<T>
                 { "NumClasses", _numClasses }, { "DecoderDim", _decoderDim }, { "DropRate", _dropRate },
                 { "UseNativeMode", _useNativeMode }, { "NumLayers", Layers.Count }
             },
-            ModelData = SerializeForMetadata()
+            ModelDataProvider = () => SerializeForMetadata()
         };
     }
 

--- a/src/ComputerVision/Segmentation/Semantic/DiffSeg.cs
+++ b/src/ComputerVision/Segmentation/Semantic/DiffSeg.cs
@@ -300,7 +300,7 @@ public partial class DiffSeg<T> : Common.SemanticSegmentationBase<T>
                 { "NumClasses", _numClasses }, { "DecoderDim", _decoderDim }, { "DropRate", _dropRate },
                 { "UseNativeMode", _useNativeMode }, { "NumLayers", Layers.Count }
             },
-            ModelData = SerializeForMetadata()
+            ModelDataProvider = () => SerializeForMetadata()
         };
     }
 

--- a/src/ComputerVision/Segmentation/Semantic/InternImage.cs
+++ b/src/ComputerVision/Segmentation/Semantic/InternImage.cs
@@ -1,4 +1,4 @@
-﻿using System.IO;
+using System.IO;
 using AiDotNet.Attributes;
 using AiDotNet.Enums;
 using AiDotNet.Helpers;
@@ -384,7 +384,7 @@ public partial class InternImage<T> : Common.SemanticSegmentationBase<T>
                 { "DecoderDim", _decoderDim }, { "DropRate", _dropRate },
                 { "UseNativeMode", _useNativeMode }, { "NumLayers", Layers.Count }
             },
-            ModelData = SerializeForMetadata()
+            ModelDataProvider = () => SerializeForMetadata()
         };
     }
 

--- a/src/ComputerVision/Segmentation/Semantic/SegFormer.cs
+++ b/src/ComputerVision/Segmentation/Semantic/SegFormer.cs
@@ -1,4 +1,4 @@
-﻿using System.IO;
+using System.IO;
 using AiDotNet.Attributes;
 using AiDotNet.Enums;
 using AiDotNet.Helpers;
@@ -579,7 +579,7 @@ public partial class SegFormer<T> : Common.SemanticSegmentationBase<T>
         return new ModelMetadata<T>
         {
             AdditionalInfo = additionalInfo,
-            ModelData = SerializeForMetadata()
+            ModelDataProvider = () => SerializeForMetadata()
         };
     }
 

--- a/src/ComputerVision/Segmentation/Semantic/SegNeXt.cs
+++ b/src/ComputerVision/Segmentation/Semantic/SegNeXt.cs
@@ -1,4 +1,4 @@
-﻿using System.IO;
+using System.IO;
 using AiDotNet.Attributes;
 using AiDotNet.Enums;
 using AiDotNet.Helpers;
@@ -502,7 +502,7 @@ public partial class SegNeXt<T> : Common.SemanticSegmentationBase<T>
         return new ModelMetadata<T>
         {
             AdditionalInfo = additionalInfo,
-            ModelData = SerializeForMetadata()
+            ModelDataProvider = () => SerializeForMetadata()
         };
     }
 

--- a/src/ComputerVision/Segmentation/Semantic/ViTAdapter.cs
+++ b/src/ComputerVision/Segmentation/Semantic/ViTAdapter.cs
@@ -1,4 +1,4 @@
-﻿using System.IO;
+using System.IO;
 using AiDotNet.Attributes;
 using AiDotNet.Enums;
 using AiDotNet.Helpers;
@@ -335,7 +335,7 @@ public partial class ViTAdapter<T> : Common.SemanticSegmentationBase<T>
                 { "EmbedDim", _embedDim }, { "DecoderDim", _decoderDim }, { "DropRate", _dropRate },
                 { "UseNativeMode", _useNativeMode }, { "NumLayers", Layers.Count }
             },
-            ModelData = SerializeForMetadata()
+            ModelDataProvider = () => SerializeForMetadata()
         };
     }
 

--- a/src/ComputerVision/Segmentation/Semantic/ViTCoMer.cs
+++ b/src/ComputerVision/Segmentation/Semantic/ViTCoMer.cs
@@ -1,4 +1,4 @@
-﻿using System.IO;
+using System.IO;
 using AiDotNet.Attributes;
 using AiDotNet.Enums;
 using AiDotNet.Helpers;
@@ -371,7 +371,7 @@ public partial class ViTCoMer<T> : Common.SemanticSegmentationBase<T>
                 { "EmbedDim", _embedDim }, { "DecoderDim", _decoderDim }, { "DropRate", _dropRate },
                 { "UseNativeMode", _useNativeMode }, { "NumLayers", Layers.Count }
             },
-            ModelData = SerializeForMetadata()
+            ModelDataProvider = () => SerializeForMetadata()
         };
     }
 

--- a/src/ComputerVision/Segmentation/Video/DEVA.cs
+++ b/src/ComputerVision/Segmentation/Video/DEVA.cs
@@ -1,4 +1,4 @@
-﻿using System.IO;
+using System.IO;
 using AiDotNet.Attributes;
 using AiDotNet.Enums;
 using AiDotNet.Helpers;
@@ -292,7 +292,7 @@ public partial class DEVA<T> : Common.VideoSegmentationBase<T>
     public override ModelMetadata<T> GetModelMetadata() => new()
     {
         AdditionalInfo = new Dictionary<string, object> { { "ModelName", "DEVA" }, { "InputHeight", _height }, { "InputWidth", _width }, { "NumClasses", _numClasses }, { "ModelSize", _modelSize.ToString() }, { "UseNativeMode", _useNativeMode }, { "NumLayers", Layers.Count } },
-        ModelData = SerializeForMetadata()
+        ModelDataProvider = () => SerializeForMetadata()
     };
 
     private IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>>? CreateOptimizerForClone()

--- a/src/ComputerVision/Segmentation/Video/EfficientTAM.cs
+++ b/src/ComputerVision/Segmentation/Video/EfficientTAM.cs
@@ -1,4 +1,4 @@
-﻿using System.IO;
+using System.IO;
 using AiDotNet.Attributes;
 using AiDotNet.Enums;
 using AiDotNet.Helpers;
@@ -352,7 +352,7 @@ public partial class EfficientTAM<T> : Common.VideoSegmentationBase<T>
     public override ModelMetadata<T> GetModelMetadata() => new()
     {
         AdditionalInfo = new Dictionary<string, object> { { "ModelName", "EfficientTAM" }, { "InputHeight", _height }, { "InputWidth", _width }, { "NumClasses", _numClasses }, { "ModelSize", _modelSize.ToString() }, { "UseNativeMode", _useNativeMode }, { "NumLayers", Layers.Count } },
-        ModelData = SerializeForMetadata()
+        ModelDataProvider = () => SerializeForMetadata()
     };
 
     #endregion

--- a/src/ComputerVision/Segmentation/Video/UniVS.cs
+++ b/src/ComputerVision/Segmentation/Video/UniVS.cs
@@ -1,4 +1,4 @@
-﻿using System.IO;
+using System.IO;
 using AiDotNet.Attributes;
 using AiDotNet.Enums;
 using AiDotNet.Helpers;
@@ -342,7 +342,7 @@ public partial class UniVS<T> : Common.VideoSegmentationBase<T>
     public override ModelMetadata<T> GetModelMetadata() => new()
     {
         AdditionalInfo = new Dictionary<string, object> { { "ModelName", "UniVS" }, { "InputHeight", _height }, { "InputWidth", _width }, { "NumClasses", _numClasses }, { "ModelSize", _modelSize.ToString() }, { "UseNativeMode", _useNativeMode }, { "NumLayers", Layers.Count } },
-        ModelData = SerializeForMetadata()
+        ModelDataProvider = () => SerializeForMetadata()
     };
 
 

--- a/src/Document/Analysis/PageSegmentation/DocBank.cs
+++ b/src/Document/Analysis/PageSegmentation/DocBank.cs
@@ -607,7 +607,7 @@ public partial class DocBank<T> : DocumentNeuralNetworkBase<T>, IPageSegmenter<T
                 { "use_text_features", _useTextFeatures },
                 { "use_native_mode", _useNativeMode }
             },
-            ModelData = SafeSerialize()
+            ModelDataProvider = () => SafeSerialize()
         };
     }
 

--- a/src/Document/Analysis/TableDetection/TableTransformer.cs
+++ b/src/Document/Analysis/TableDetection/TableTransformer.cs
@@ -1036,7 +1036,7 @@ public partial class TableTransformer<T> : DocumentNeuralNetworkBase<T>, ITableE
                 { "image_size", ImageSize },
                 { "use_native_mode", _useNativeMode }
             },
-            ModelData = SafeSerialize()
+            ModelDataProvider = () => SafeSerialize()
         };
     }
 

--- a/src/Document/GraphBased/DocGCN.cs
+++ b/src/Document/GraphBased/DocGCN.cs
@@ -482,7 +482,7 @@ public partial class DocGCN<T> : DocumentNeuralNetworkBase<T>, ILayoutDetector<T
                 { "max_nodes", _maxNodes },
                 { "use_native_mode", _useNativeMode }
             },
-            ModelData = SafeSerialize()
+            ModelDataProvider = () => SafeSerialize()
         };
     }
 

--- a/src/Document/GraphBased/LayoutGraph.cs
+++ b/src/Document/GraphBased/LayoutGraph.cs
@@ -1,4 +1,4 @@
-﻿using AiDotNet.Attributes;
+using AiDotNet.Attributes;
 using AiDotNet.Document.Interfaces;
 using AiDotNet.Document.Options;
 using AiDotNet.Enums;
@@ -484,7 +484,7 @@ public partial class LayoutGraph<T> : DocumentNeuralNetworkBase<T>, ILayoutDetec
                 { "max_nodes", _maxNodes },
                 { "use_native_mode", _useNativeMode }
             },
-            ModelData = SafeSerialize()
+            ModelDataProvider = () => SafeSerialize()
         };
     }
 

--- a/src/Document/GraphBased/PICK.cs
+++ b/src/Document/GraphBased/PICK.cs
@@ -429,7 +429,7 @@ public partial class PICK<T> : DocumentNeuralNetworkBase<T>, IFormUnderstanding<
                 { "num_entity_types", _numEntityTypes },
                 { "use_native_mode", _useNativeMode }
             },
-            ModelData = SafeSerialize()
+            ModelDataProvider = () => SafeSerialize()
         };
     }
 

--- a/src/Document/GraphBased/TRIE.cs
+++ b/src/Document/GraphBased/TRIE.cs
@@ -606,7 +606,7 @@ public partial class TRIE<T> : DocumentNeuralNetworkBase<T>, IFormUnderstanding<
                 { "image_size", ImageSize },
                 { "use_native_mode", _useNativeMode }
             },
-            ModelData = SafeSerialize()
+            ModelDataProvider = () => SafeSerialize()
         };
     }
 

--- a/src/Document/LayoutAware/DiT.cs
+++ b/src/Document/LayoutAware/DiT.cs
@@ -483,7 +483,7 @@ public partial class DiT<T> : DocumentNeuralNetworkBase<T>, ILayoutDetector<T>, 
                 { "model_size", _modelSize },
                 { "use_native_mode", _useNativeMode }
             },
-            ModelData = SafeSerialize()
+            ModelDataProvider = () => SafeSerialize()
         };
     }
 

--- a/src/Document/LayoutAware/DocFormer.cs
+++ b/src/Document/LayoutAware/DocFormer.cs
@@ -522,7 +522,7 @@ public partial class DocFormer<T> : DocumentNeuralNetworkBase<T>, ILayoutDetecto
                 { "num_classes", _numClasses },
                 { "use_native_mode", _useNativeMode }
             },
-            ModelData = SafeSerialize()
+            ModelDataProvider = () => SafeSerialize()
         };
     }
 

--- a/src/Document/LayoutAware/LayoutLM.cs
+++ b/src/Document/LayoutAware/LayoutLM.cs
@@ -424,7 +424,7 @@ public partial class LayoutLM<T> : DocumentNeuralNetworkBase<T>, ILayoutDetector
                 { "num_classes", _numClasses },
                 { "use_native_mode", _useNativeMode }
             },
-            ModelData = SafeSerialize()
+            ModelDataProvider = () => SafeSerialize()
         };
     }
 

--- a/src/Document/LayoutAware/LayoutLMv2.cs
+++ b/src/Document/LayoutAware/LayoutLMv2.cs
@@ -821,7 +821,7 @@ public partial class LayoutLMv2<T> : DocumentNeuralNetworkBase<T>, ILayoutDetect
                 { "num_classes", _numClasses },
                 { "use_native_mode", _useNativeMode }
             },
-            ModelData = SafeSerialize()
+            ModelDataProvider = () => SafeSerialize()
         };
     }
 

--- a/src/Document/LayoutAware/LayoutLMv3.cs
+++ b/src/Document/LayoutAware/LayoutLMv3.cs
@@ -1008,7 +1008,7 @@ public partial class LayoutLMv3<T> : DocumentNeuralNetworkBase<T>, ILayoutDetect
                 { "num_classes", _numClasses },
                 { "use_native_mode", _useNativeMode }
             },
-            ModelData = SafeSerialize()
+            ModelDataProvider = () => SafeSerialize()
         };
     }
 

--- a/src/Document/LayoutAware/LiLT.cs
+++ b/src/Document/LayoutAware/LiLT.cs
@@ -944,7 +944,7 @@ public partial class LiLT<T> : DocumentNeuralNetworkBase<T>, ILayoutDetector<T>,
                 { "text_backbone", _textBackbone },
                 { "use_native_mode", _useNativeMode }
             },
-            ModelData = SafeSerialize()
+            ModelDataProvider = () => SafeSerialize()
         };
     }
 

--- a/src/Document/OCR/TextDetection/CRAFT.cs
+++ b/src/Document/OCR/TextDetection/CRAFT.cs
@@ -447,7 +447,7 @@ public partial class CRAFT<T> : DocumentNeuralNetworkBase<T>, ITextDetector<T>
                 { "character_detection", true },
                 { "use_native_mode", _useNativeMode }
             },
-            ModelData = SafeSerialize()
+            ModelDataProvider = () => SafeSerialize()
         };
     }
 

--- a/src/Document/OCR/TextDetection/DBNet.cs
+++ b/src/Document/OCR/TextDetection/DBNet.cs
@@ -604,7 +604,7 @@ public partial class DBNet<T> : DocumentNeuralNetworkBase<T>, ITextDetector<T>
                 { "min_text_area", _minTextArea },
                 { "use_native_mode", _useNativeMode }
             },
-            ModelData = SafeSerialize()
+            ModelDataProvider = () => SafeSerialize()
         };
     }
 

--- a/src/Document/OCR/TextDetection/EAST.cs
+++ b/src/Document/OCR/TextDetection/EAST.cs
@@ -550,7 +550,7 @@ public partial class EAST<T> : DocumentNeuralNetworkBase<T>, ITextDetector<T>
                 { "image_size", ImageSize },
                 { "use_native_mode", _useNativeMode }
             },
-            ModelData = SafeSerialize()
+            ModelDataProvider = () => SafeSerialize()
         };
     }
 

--- a/src/Document/OCR/TextDetection/PSENet.cs
+++ b/src/Document/OCR/TextDetection/PSENet.cs
@@ -567,7 +567,7 @@ public partial class PSENet<T> : DocumentNeuralNetworkBase<T>, ITextDetector<T>
                 { "image_size", ImageSize },
                 { "use_native_mode", _useNativeMode }
             },
-            ModelData = SafeSerialize()
+            ModelDataProvider = () => SafeSerialize()
         };
     }
 

--- a/src/Document/OCR/TextRecognition/ABINet.cs
+++ b/src/Document/OCR/TextRecognition/ABINet.cs
@@ -1,4 +1,4 @@
-﻿using AiDotNet.Attributes;
+using AiDotNet.Attributes;
 using AiDotNet.Document.Interfaces;
 using AiDotNet.Document.Options;
 using AiDotNet.Enums;
@@ -643,7 +643,7 @@ public partial class ABINet<T> : DocumentNeuralNetworkBase<T>, ITextRecognizer<T
                 { "charset_size", _charset.Length },
                 { "use_native_mode", _useNativeMode }
             },
-            ModelData = SafeSerialize()
+            ModelDataProvider = () => SafeSerialize()
         };
     }
 

--- a/src/Document/OCR/TextRecognition/CRNN.cs
+++ b/src/Document/OCR/TextRecognition/CRNN.cs
@@ -557,7 +557,7 @@ public partial class CRNN<T> : DocumentNeuralNetworkBase<T>, ITextRecognizer<T>
                 { "image_width", ImageSize },
                 { "use_native_mode", _useNativeMode }
             },
-            ModelData = SafeSerialize()
+            ModelDataProvider = () => SafeSerialize()
         };
     }
 

--- a/src/Document/OCR/TextRecognition/SVTR.cs
+++ b/src/Document/OCR/TextRecognition/SVTR.cs
@@ -1,4 +1,4 @@
-﻿using AiDotNet.Attributes;
+using AiDotNet.Attributes;
 using AiDotNet.ActivationFunctions;
 using AiDotNet.Document.Interfaces;
 using AiDotNet.Document.Options;
@@ -682,7 +682,7 @@ public partial class SVTR<T> : DocumentNeuralNetworkBase<T>, ITextRecognizer<T>
                 { "layer_count", Layers.Count },
                 { "ctc_positions", _options.OutputCharacterPositions }
             },
-            ModelData = SafeSerialize()
+            ModelDataProvider = () => SafeSerialize()
         };
     }
 

--- a/src/Document/OCR/TextRecognition/TrOCR.cs
+++ b/src/Document/OCR/TextRecognition/TrOCR.cs
@@ -742,7 +742,7 @@ public partial class TrOCR<T> : DocumentNeuralNetworkBase<T>, ITextRecognizer<T>
                 { "image_size", ImageSize },
                 { "use_native_mode", _useNativeMode }
             },
-            ModelData = SafeSerialize()
+            ModelDataProvider = () => SafeSerialize()
         };
     }
 

--- a/src/Document/PixelToSequence/Dessurt.cs
+++ b/src/Document/PixelToSequence/Dessurt.cs
@@ -519,7 +519,7 @@ public partial class Dessurt<T> : DocumentNeuralNetworkBase<T>, IDocumentQA<T>
                 { "image_size", ImageSize },
                 { "use_native_mode", _useNativeMode }
             },
-            ModelData = SafeSerializeMaterializedModel()
+            ModelDataProvider = () => SafeSerializeMaterializedModel()
         };
     }
 

--- a/src/Document/PixelToSequence/Donut.cs
+++ b/src/Document/PixelToSequence/Donut.cs
@@ -1184,7 +1184,7 @@ public partial class Donut<T> : DocumentNeuralNetworkBase<T>, IOCRModel<T>, IDoc
                 { "use_native_mode", _useNativeMode },
                 { "ocr_free", IsOCRFree }
             },
-            ModelData = SafeSerializeMaterializedModel()
+            ModelDataProvider = () => SafeSerializeMaterializedModel()
         };
     }
 

--- a/src/Document/PixelToSequence/MATCHA.cs
+++ b/src/Document/PixelToSequence/MATCHA.cs
@@ -679,7 +679,7 @@ public partial class MATCHA<T> : DocumentNeuralNetworkBase<T>, IDocumentQA<T>, I
                 { "image_size", ImageSize },
                 { "use_native_mode", _useNativeMode }
             },
-            ModelData = SafeSerializeMaterializedModel()
+            ModelDataProvider = () => SafeSerializeMaterializedModel()
         };
     }
 

--- a/src/Document/PixelToSequence/Nougat.cs
+++ b/src/Document/PixelToSequence/Nougat.cs
@@ -680,7 +680,7 @@ public partial class Nougat<T> : DocumentNeuralNetworkBase<T>, IDocumentQA<T>
                 { "supports_latex", SupportsLatex },
                 { "use_native_mode", _useNativeMode }
             },
-            ModelData = SafeSerializeMaterializedModel()
+            ModelDataProvider = () => SafeSerializeMaterializedModel()
         };
     }
 

--- a/src/Document/PixelToSequence/Pix2Struct.cs
+++ b/src/Document/PixelToSequence/Pix2Struct.cs
@@ -503,7 +503,7 @@ public partial class Pix2Struct<T> : DocumentNeuralNetworkBase<T>, IDocumentQA<T
                 { "vocab_size", _vocabSize },
                 { "use_native_mode", _useNativeMode }
             },
-            ModelData = SafeSerializeMaterializedModel()
+            ModelDataProvider = () => SafeSerializeMaterializedModel()
         };
     }
 

--- a/src/Document/VisionLanguage/DocOwl.cs
+++ b/src/Document/VisionLanguage/DocOwl.cs
@@ -551,7 +551,7 @@ public partial class DocOwl<T> : DocumentNeuralNetworkBase<T>, IDocumentQA<T>, I
                 { "image_size", ImageSize },
                 { "use_native_mode", _useNativeMode }
             },
-            ModelData = SafeSerialize()
+            ModelDataProvider = () => SafeSerialize()
         };
     }
 

--- a/src/Document/VisionLanguage/InfographicVQA.cs
+++ b/src/Document/VisionLanguage/InfographicVQA.cs
@@ -492,7 +492,7 @@ public partial class InfographicVQA<T> : DocumentNeuralNetworkBase<T>, IDocument
                 { "image_size", ImageSize },
                 { "use_native_mode", _useNativeMode }
             },
-            ModelData = SafeSerialize()
+            ModelDataProvider = () => SafeSerialize()
         };
     }
 

--- a/src/Document/VisionLanguage/UDOP.cs
+++ b/src/Document/VisionLanguage/UDOP.cs
@@ -1,4 +1,4 @@
-﻿using AiDotNet.Attributes;
+using AiDotNet.Attributes;
 using AiDotNet.Document.Interfaces;
 using AiDotNet.Document.Options;
 using AiDotNet.Enums;
@@ -763,7 +763,7 @@ public partial class UDOP<T> : DocumentNeuralNetworkBase<T>, ILayoutDetector<T>,
                 { "num_classes", _numClasses },
                 { "use_native_mode", _useNativeMode }
             },
-            ModelData = SafeSerialize()
+            ModelDataProvider = () => SafeSerialize()
         };
     }
 

--- a/src/Finance/Forecasting/Foundation/CCDM.cs
+++ b/src/Finance/Forecasting/Foundation/CCDM.cs
@@ -280,7 +280,7 @@ public partial class CCDM<T> : TimeSeriesFoundationModelBase<T>
     public override ModelMetadata<T> GetModelMetadata() => new()
     {
         AdditionalInfo = new Dictionary<string, object> { { "NetworkType", "CCDM" }, { "ContextLength", _contextLength }, { "ForecastHorizon", _forecastHorizon }, { "HiddenDimension", _hiddenDimension }, { "DiffusionSteps", _diffusionSteps }, { "SigmaMin", _sigmaMin }, { "SigmaMax", _sigmaMax }, { "UseNativeMode", _useNativeMode } },
-        ModelData = _useNativeMode ? this.Serialize() : Array.Empty<byte>()
+        ModelDataProvider = () => _useNativeMode ? this.Serialize() : Array.Empty<byte>()
     };
 
 

--- a/src/Finance/Forecasting/Foundation/CSDI.cs
+++ b/src/Finance/Forecasting/Foundation/CSDI.cs
@@ -608,7 +608,7 @@ public partial class CSDI<T> : TimeSeriesFoundationModelBase<T>
             { "NumFeatures", _numFeatures }, { "HiddenDimension", _hiddenDimension },
             { "NumDiffusionSteps", _numDiffusionSteps }, { "UseNativeMode", _useNativeMode }
         },
-        ModelData = _useNativeMode ? this.Serialize() : Array.Empty<byte>()
+        ModelDataProvider = () => _useNativeMode ? this.Serialize() : Array.Empty<byte>()
     };
 
 

--- a/src/Finance/Forecasting/Foundation/MGTSD.cs
+++ b/src/Finance/Forecasting/Foundation/MGTSD.cs
@@ -589,7 +589,7 @@ public partial class MGTSD<T> : TimeSeriesFoundationModelBase<T>
     public override ModelMetadata<T> GetModelMetadata() => new()
     {
         AdditionalInfo = new Dictionary<string, object> { { "NetworkType", "MGTSD" }, { "ContextLength", _contextLength }, { "ForecastHorizon", _forecastHorizon }, { "HiddenDimension", _hiddenDimension }, { "DiffusionSteps", _diffusionSteps }, { "NumGranularities", _numGranularities }, { "GuidanceWeight", _guidanceWeight }, { "UseNativeMode", _useNativeMode } },
-        ModelData = _useNativeMode ? this.Serialize() : Array.Empty<byte>()
+        ModelDataProvider = () => _useNativeMode ? this.Serialize() : Array.Empty<byte>()
     };
 
 

--- a/src/Finance/Forecasting/Foundation/TSDiff.cs
+++ b/src/Finance/Forecasting/Foundation/TSDiff.cs
@@ -256,7 +256,7 @@ public partial class TSDiff<T> : TimeSeriesFoundationModelBase<T>
     public override ModelMetadata<T> GetModelMetadata() => new()
     {
         AdditionalInfo = new Dictionary<string, object> { { "NetworkType", "TSDiff" }, { "SequenceLength", _sequenceLength }, { "ForecastHorizon", _forecastHorizon }, { "HiddenDimension", _hiddenDimension }, { "NumDiffusionSteps", _numDiffusionSteps }, { "GuidanceScale", _guidanceScale }, { "UseNativeMode", _useNativeMode } },
-        ModelData = _useNativeMode ? this.Serialize() : Array.Empty<byte>()
+        ModelDataProvider = () => _useNativeMode ? this.Serialize() : Array.Empty<byte>()
     };
 
 

--- a/src/Finance/Forecasting/Foundation/TimeDiff.cs
+++ b/src/Finance/Forecasting/Foundation/TimeDiff.cs
@@ -279,7 +279,7 @@ public partial class TimeDiff<T> : TimeSeriesFoundationModelBase<T>
     public override ModelMetadata<T> GetModelMetadata() => new()
     {
         AdditionalInfo = new Dictionary<string, object> { { "NetworkType", "TimeDiff" }, { "ContextLength", _contextLength }, { "ForecastHorizon", _forecastHorizon }, { "HiddenDimension", _hiddenDimension }, { "DiffusionSteps", _diffusionSteps }, { "UseFutureMixup", _useFutureMixup }, { "UseAutoregressiveInit", _useAutoregressiveInit }, { "UseNativeMode", _useNativeMode } },
-        ModelData = _useNativeMode ? this.Serialize() : Array.Empty<byte>()
+        ModelDataProvider = () => _useNativeMode ? this.Serialize() : Array.Empty<byte>()
     };
 
 

--- a/src/NeuralNetworks/ACGAN.cs
+++ b/src/NeuralNetworks/ACGAN.cs
@@ -1,4 +1,4 @@
-﻿using System.IO;
+using System.IO;
 using AiDotNet.Attributes;
 using AiDotNet.Enums;
 using AiDotNet.Helpers;
@@ -740,7 +740,7 @@ public partial class ACGAN<T> : ImageGeneratorModelLayoutBase<T>
                 { "DiscriminatorParameters", Discriminator.GetParameterCount() },
                 { "NumClasses", _numClasses }
             },
-            ModelData = SerializeForMetadata()
+            ModelDataProvider = () => SerializeForMetadata()
         };
     }
 

--- a/src/NeuralNetworks/AttentionNetwork.cs
+++ b/src/NeuralNetworks/AttentionNetwork.cs
@@ -446,7 +446,7 @@ public partial class AttentionNetwork<T> : SequenceModelLayoutBase<T>, IAuxiliar
                 { "InputShape", new[] { _sequenceLength, _embeddingSize } },
                 { "OutputShape", Layers[Layers.Count - 1].GetOutputShape() }
             },
-            ModelData = SerializeForMetadata()
+            ModelDataProvider = () => SerializeForMetadata()
         };
     }
 

--- a/src/NeuralNetworks/Blip2NeuralNetwork.cs
+++ b/src/NeuralNetworks/Blip2NeuralNetwork.cs
@@ -2113,7 +2113,7 @@ public partial class Blip2NeuralNetwork<T> : MultimodalModelLayoutBase<T>, IBlip
                 { "TaskType", Architecture.TaskType.ToString() },
                 { "LayerCount", Layers.Count }
             },
-            ModelData = SerializeForMetadata()
+            ModelDataProvider = () => SerializeForMetadata()
         };
     }
 

--- a/src/NeuralNetworks/BlipNeuralNetwork.cs
+++ b/src/NeuralNetworks/BlipNeuralNetwork.cs
@@ -1567,7 +1567,7 @@ public partial class BlipNeuralNetwork<T> : MultimodalModelLayoutBase<T>, IBlipM
                 { "ParameterCount", ParameterCount },
                 { "UseNativeMode", _useNativeMode }
             },
-            ModelData = SerializeForMetadata()
+            ModelDataProvider = () => SerializeForMetadata()
         };
     }
 

--- a/src/NeuralNetworks/CapsuleNetwork.cs
+++ b/src/NeuralNetworks/CapsuleNetwork.cs
@@ -481,7 +481,7 @@ public partial class CapsuleNetwork<T> : ImageClassifierModelLayoutBase<T>, IAux
                 { "LayerCount", Layers.Count },
                 { "LayerTypes", Layers.Select(l => l.GetType().Name).ToArray() }
             },
-            ModelData = SerializeForMetadata()
+            ModelDataProvider = () => SerializeForMetadata()
         };
     }
 

--- a/src/NeuralNetworks/ConditionalGAN.cs
+++ b/src/NeuralNetworks/ConditionalGAN.cs
@@ -1,4 +1,4 @@
-﻿using System.IO;
+using System.IO;
 using AiDotNet.Attributes;
 using AiDotNet.Enums;
 using AiDotNet.Helpers;
@@ -876,7 +876,7 @@ public partial class ConditionalGAN<T> : GenerativeAdversarialNetwork<T>
                 { "DiscriminatorParameters", Discriminator.GetParameterCount() },
                 { "NumConditionClasses", _numConditionClasses }
             },
-            ModelData = SerializeForMetadata()
+            ModelDataProvider = () => SerializeForMetadata()
         };
     }
 

--- a/src/NeuralNetworks/ConvolutionalNeuralNetwork.cs
+++ b/src/NeuralNetworks/ConvolutionalNeuralNetwork.cs
@@ -575,7 +575,7 @@ public partial class ConvolutionalNeuralNetwork<T> : ImageClassifierModelLayoutB
                 { "LayerCount", Layers.Count },
                 { "LayerTypes", Layers.Select(l => l.GetType().Name).ToArray() }
             },
-            ModelData = SerializeForMetadata()
+            ModelDataProvider = () => SerializeForMetadata()
         };
     }
 

--- a/src/NeuralNetworks/CycleGAN.cs
+++ b/src/NeuralNetworks/CycleGAN.cs
@@ -1,4 +1,4 @@
-﻿using System.IO;
+using System.IO;
 using AiDotNet.Attributes;
 using AiDotNet.Enums;
 using AiDotNet.Helpers;
@@ -868,7 +868,7 @@ public partial class CycleGAN<T> : ImageTranslationModelLayoutBase<T>
                 { "CycleConsistencyLambda", NumOps.ToDouble(_cycleConsistencyLambda) },
                 { "IdentityLambda", NumOps.ToDouble(_identityLambda) }
             },
-            ModelData = SerializeForMetadata()
+            ModelDataProvider = () => SerializeForMetadata()
         };
     }
 

--- a/src/NeuralNetworks/DeepBeliefNetwork.cs
+++ b/src/NeuralNetworks/DeepBeliefNetwork.cs
@@ -1,4 +1,4 @@
-﻿using AiDotNet.Attributes;
+using AiDotNet.Attributes;
 using AiDotNet.Enums;
 using AiDotNet.Models.Options;
 using AiDotNet.NeuralNetworks.Options;
@@ -733,7 +733,7 @@ public partial class DeepBeliefNetwork<T> : VectorModelLayoutBase<T>
                 { "LearningRate", Convert.ToDouble(_learningRate) },
                 { "BatchSize", _batchSize }
             },
-            ModelData = SerializeForMetadata()
+            ModelDataProvider = () => SerializeForMetadata()
         };
     }
 }

--- a/src/NeuralNetworks/DeepBoltzmannMachine.cs
+++ b/src/NeuralNetworks/DeepBoltzmannMachine.cs
@@ -930,7 +930,7 @@ public partial class DeepBoltzmannMachine<T> : VectorModelLayoutBase<T>
                 { "Epochs", _epochs },
                 { "LearningRate", Convert.ToDouble(_learningRate) }
             },
-            ModelData = SerializeForMetadata()
+            ModelDataProvider = () => SerializeForMetadata()
         };
     }
 

--- a/src/NeuralNetworks/DeepQNetwork.cs
+++ b/src/NeuralNetworks/DeepQNetwork.cs
@@ -724,7 +724,7 @@ public partial class DeepQNetwork<T> : VectorModelLayoutBase<T>
                 { "ExplorationRate", Convert.ToDouble(_epsilon) },
                 { "ReplayBufferSize", _replayBuffer.Count }
             },
-            ModelData = SerializeForMetadata()
+            ModelDataProvider = () => SerializeForMetadata()
         };
     }
 

--- a/src/NeuralNetworks/DenseNetNetwork.cs
+++ b/src/NeuralNetworks/DenseNetNetwork.cs
@@ -380,7 +380,7 @@ public partial class DenseNetNetwork<T> : ImageClassifierModelLayoutBase<T>
                 { "LayerCount", Layers.Count },
                 { "ParameterCount", GetParameterCount() }
             },
-            ModelData = SerializeForMetadata()
+            ModelDataProvider = () => SerializeForMetadata()
         };
     }
 

--- a/src/NeuralNetworks/DifferentiableNeuralComputer.cs
+++ b/src/NeuralNetworks/DifferentiableNeuralComputer.cs
@@ -1,4 +1,4 @@
-﻿using AiDotNet.Tensors.Engines;
+using AiDotNet.Tensors.Engines;
 using AiDotNet.Attributes;
 using AiDotNet.Enums;
 using AiDotNet.Helpers;
@@ -1646,7 +1646,7 @@ public partial class DifferentiableNeuralComputer<T> : SequenceModelLayoutBase<T
                 { "LayerCount", Layers.Count },
                 { "ParameterCount", ParameterCount }
             },
-            ModelData = SerializeForMetadata()
+            ModelDataProvider = () => SerializeForMetadata()
         };
     }
 

--- a/src/NeuralNetworks/EagleLanguageModel.cs
+++ b/src/NeuralNetworks/EagleLanguageModel.cs
@@ -142,7 +142,7 @@ public partial class EagleLanguageModel<T> : TokenLanguageModelLayoutBase<T>
                 { "MaxSeqLength", _maxSeqLength },
                 { "LayerCount", Layers.Count }
             },
-            ModelData = SerializeForMetadata()
+            ModelDataProvider = () => SerializeForMetadata()
         };
     }
 

--- a/src/NeuralNetworks/EchoStateNetwork.cs
+++ b/src/NeuralNetworks/EchoStateNetwork.cs
@@ -1649,7 +1649,7 @@ public partial class EchoStateNetwork<T> : SequenceModelLayoutBase<T>
                 { "Regularization", Convert.ToDouble(_regularization) },
                 { "WarmupPeriod", _warmupPeriod }
             },
-            ModelData = SerializeForMetadata()
+            ModelDataProvider = () => SerializeForMetadata()
         };
     }
 

--- a/src/NeuralNetworks/EfficientNetNetwork.cs
+++ b/src/NeuralNetworks/EfficientNetNetwork.cs
@@ -411,7 +411,7 @@ public partial class EfficientNetNetwork<T> : ImageClassifierModelLayoutBase<T>
                 { "LayerCount", Layers.Count },
                 { "ParameterCount", GetParameterCount() }
             },
-            ModelData = SerializeForMetadata()
+            ModelDataProvider = () => SerializeForMetadata()
         };
     }
 

--- a/src/NeuralNetworks/ExtremeLearningMachine.cs
+++ b/src/NeuralNetworks/ExtremeLearningMachine.cs
@@ -368,7 +368,7 @@ public partial class ExtremeLearningMachine<T> : VectorModelLayoutBase<T>
                 { "LayerCount", Layers.Count },
                 { "ParameterCount", GetParameterCount() }
             },
-            ModelData = SerializeForMetadata()
+            ModelDataProvider = () => SerializeForMetadata()
         };
     }
 

--- a/src/NeuralNetworks/FalconMambaLanguageModel.cs
+++ b/src/NeuralNetworks/FalconMambaLanguageModel.cs
@@ -149,7 +149,7 @@ public partial class FalconMambaLanguageModel<T> : TokenLanguageModelLayoutBase<
                 { "MaxSeqLength", _maxSeqLength },
                 { "LayerCount", Layers.Count }
             },
-            ModelData = SerializeForMetadata()
+            ModelDataProvider = () => SerializeForMetadata()
         };
     }
 

--- a/src/NeuralNetworks/FeedForwardNeuralNetwork.cs
+++ b/src/NeuralNetworks/FeedForwardNeuralNetwork.cs
@@ -500,7 +500,7 @@ public partial class FeedForwardNeuralNetwork<T> : SequentialVectorModelLayoutBa
                 { "TaskType", Architecture.TaskType.ToString() },
                 { "ParameterCount", GetParameterCount() }
             },
-            ModelData = SerializeForMetadata()
+            ModelDataProvider = () => SerializeForMetadata()
         };
     }
 

--- a/src/NeuralNetworks/FinchLanguageModel.cs
+++ b/src/NeuralNetworks/FinchLanguageModel.cs
@@ -153,7 +153,7 @@ public partial class FinchLanguageModel<T> : TokenLanguageModelLayoutBase<T>
                 { "MaxSeqLength", _maxSeqLength },
                 { "LayerCount", Layers.Count }
             },
-            ModelData = SerializeForMetadata()
+            ModelDataProvider = () => SerializeForMetadata()
         };
     }
 

--- a/src/NeuralNetworks/FlamingoNeuralNetwork.cs
+++ b/src/NeuralNetworks/FlamingoNeuralNetwork.cs
@@ -1,4 +1,4 @@
-﻿using System.IO;
+using System.IO;
 using AiDotNet.ActivationFunctions;
 using AiDotNet.Attributes;
 using AiDotNet.Autodiff;
@@ -1197,7 +1197,7 @@ public partial class FlamingoNeuralNetwork<T> : MultimodalModelLayoutBase<T>, IF
                 { "ParameterCount", ParameterCount },
                 { "TaskType", Architecture.TaskType.ToString() }
             },
-            ModelData = SerializeForMetadata()
+            ModelDataProvider = () => SerializeForMetadata()
         };
     }
 

--- a/src/NeuralNetworks/GLALanguageModel.cs
+++ b/src/NeuralNetworks/GLALanguageModel.cs
@@ -166,7 +166,7 @@ public partial class GLALanguageModel<T> : TokenLanguageModelLayoutBase<T>
                 { "MaxSeqLength", _maxSeqLength },
                 { "LayerCount", Layers.Count }
             },
-            ModelData = SerializeForMetadata()
+            ModelDataProvider = () => SerializeForMetadata()
         };
     }
 

--- a/src/NeuralNetworks/GRUNeuralNetwork.cs
+++ b/src/NeuralNetworks/GRUNeuralNetwork.cs
@@ -332,7 +332,7 @@ public partial class GRUNeuralNetwork<T> : SequenceModelLayoutBase<T>
                 { "InputSize", Architecture.InputSize },
                 { "OutputSize", Architecture.OutputSize },
             },
-            ModelData = SerializeForMetadata()
+            ModelDataProvider = () => SerializeForMetadata()
         };
     }
 

--- a/src/NeuralNetworks/GatedDeltaNetLanguageModel.cs
+++ b/src/NeuralNetworks/GatedDeltaNetLanguageModel.cs
@@ -167,7 +167,7 @@ public partial class GatedDeltaNetLanguageModel<T> : TokenLanguageModelLayoutBas
                 { "MaxSeqLength", _maxSeqLength },
                 { "LayerCount", Layers.Count }
             },
-            ModelData = SerializeForMetadata()
+            ModelDataProvider = () => SerializeForMetadata()
         };
     }
 

--- a/src/NeuralNetworks/GenerativeAdversarialNetwork.cs
+++ b/src/NeuralNetworks/GenerativeAdversarialNetwork.cs
@@ -1,4 +1,4 @@
-﻿using AiDotNet.Attributes;
+using AiDotNet.Attributes;
 using AiDotNet.Enums;
 using AiDotNet.Models.Options;
 using AiDotNet.NeuralNetworks.Options;
@@ -1820,7 +1820,7 @@ public partial class GenerativeAdversarialNetwork<T> : ImageGeneratorModelLayout
                 { "DiscriminatorArchitecture", Discriminator.GetModelMetadata() },
                 { "OptimizationType", "Adam" }
             },
-            ModelData = SerializeForMetadata()
+            ModelDataProvider = () => SerializeForMetadata()
         };
     }
 

--- a/src/NeuralNetworks/GraphNeuralNetwork.cs
+++ b/src/NeuralNetworks/GraphNeuralNetwork.cs
@@ -1087,7 +1087,7 @@ public partial class GraphNeuralNetwork<T> : GraphModelLayoutBase<T>, IAuxiliary
                 { "ParameterCount", GetParameterCount() },
                 { "ActivationTypes", string.Join(", ", GetActivationTypes()) }
             },
-            ModelData = SerializeForMetadata()
+            ModelDataProvider = () => SerializeForMetadata()
         };
     }
 

--- a/src/NeuralNetworks/GriffinLanguageModel.cs
+++ b/src/NeuralNetworks/GriffinLanguageModel.cs
@@ -165,7 +165,7 @@ public partial class GriffinLanguageModel<T> : TokenLanguageModelLayoutBase<T>
                 { "MaxSeqLength", _maxSeqLength },
                 { "LayerCount", Layers.Count }
             },
-            ModelData = SerializeForMetadata()
+            ModelDataProvider = () => SerializeForMetadata()
         };
     }
 

--- a/src/NeuralNetworks/HTMNetwork.cs
+++ b/src/NeuralNetworks/HTMNetwork.cs
@@ -664,7 +664,7 @@ public partial class HTMNetwork<T> : VectorModelLayoutBase<T>
                 { "LayerCount", Layers.Count },
                 { "TotalParameters", GetParameterCount() }
             },
-            ModelData = SerializeForMetadata()
+            ModelDataProvider = () => SerializeForMetadata()
         };
     }
 

--- a/src/NeuralNetworks/HawkLanguageModel.cs
+++ b/src/NeuralNetworks/HawkLanguageModel.cs
@@ -184,7 +184,7 @@ public partial class HawkLanguageModel<T> : TokenLanguageModelLayoutBase<T>
                 { "MaxSeqLength", _maxSeqLength },
                 { "LayerCount", Layers.Count }
             },
-            ModelData = SerializeForMetadata()
+            ModelDataProvider = () => SerializeForMetadata()
         };
     }
 

--- a/src/NeuralNetworks/HopfieldNetwork.cs
+++ b/src/NeuralNetworks/HopfieldNetwork.cs
@@ -1,4 +1,4 @@
-﻿using AiDotNet.Attributes;
+using AiDotNet.Attributes;
 using AiDotNet.Enums;
 using AiDotNet.NeuralNetworks.Options;
 
@@ -560,7 +560,7 @@ public partial class HopfieldNetwork<T> : VectorModelLayoutBase<T>
                 { "Size", _size },
                 { "WeightMatrixShape", $"{_weights.Shape[0]}x{_weights.Shape[1]}" }
             },
-            ModelData = SerializeForMetadata()
+            ModelDataProvider = () => SerializeForMetadata()
         };
     }
 

--- a/src/NeuralNetworks/HyperbolicNeuralNetwork.cs
+++ b/src/NeuralNetworks/HyperbolicNeuralNetwork.cs
@@ -260,7 +260,7 @@ public partial class HyperbolicNeuralNetwork<T> : VectorModelLayoutBase<T>
                 { "TaskType", Architecture.TaskType.ToString() },
                 { "ParameterCount", GetParameterCount() }
             },
-            ModelData = SerializeForMetadata()
+            ModelDataProvider = () => SerializeForMetadata()
         };
     }
 

--- a/src/NeuralNetworks/ImageBindNeuralNetwork.cs
+++ b/src/NeuralNetworks/ImageBindNeuralNetwork.cs
@@ -1570,7 +1570,7 @@ public partial class ImageBindNeuralNetwork<T> : MultimodalModelLayoutBase<T>, I
                 { "SupportedModalities", _supportedModalities.Select(m => m.ToString()).ToList() },
                 { "UseNativeMode", _useNativeMode }
             },
-            ModelData = SerializeForMetadata()
+            ModelDataProvider = () => SerializeForMetadata()
         };
     }
 

--- a/src/NeuralNetworks/InfoGAN.cs
+++ b/src/NeuralNetworks/InfoGAN.cs
@@ -1,4 +1,4 @@
-﻿using System.IO;
+using System.IO;
 using AiDotNet.Attributes;
 using AiDotNet.Enums;
 using AiDotNet.Helpers;
@@ -934,7 +934,7 @@ public partial class InfoGAN<T> : ImageGeneratorModelLayoutBase<T>
                 { "LatentCodeSize", _latentCodeSize },
                 { "MutualInfoCoefficient", NumOps.ToDouble(_mutualInfoCoefficient) }
             },
-            ModelData = SerializeForMetadata()
+            ModelDataProvider = () => SerializeForMetadata()
         };
     }
 

--- a/src/NeuralNetworks/JambaLanguageModel.cs
+++ b/src/NeuralNetworks/JambaLanguageModel.cs
@@ -142,7 +142,7 @@ public partial class JambaLanguageModel<T> : TokenLanguageModelLayoutBase<T>
                 { "MaxSeqLength", _maxSeqLength },
                 { "LayerCount", Layers.Count }
             },
-            ModelData = SerializeForMetadata()
+            ModelDataProvider = () => SerializeForMetadata()
         };
     }
 

--- a/src/NeuralNetworks/LLaVANeuralNetwork.cs
+++ b/src/NeuralNetworks/LLaVANeuralNetwork.cs
@@ -1244,7 +1244,7 @@ public partial class LLaVANeuralNetwork<T> : MultimodalModelLayoutBase<T>, ILLaV
                 { "VocabularySize", _vocabularySize },
                 { "UseNativeMode", _useNativeMode }
             },
-            ModelData = SerializeForMetadata()
+            ModelDataProvider = () => SerializeForMetadata()
         };
     }
 

--- a/src/NeuralNetworks/LSTMNeuralNetwork.cs
+++ b/src/NeuralNetworks/LSTMNeuralNetwork.cs
@@ -1,4 +1,4 @@
-﻿using AiDotNet.Attributes;
+using AiDotNet.Attributes;
 using AiDotNet.Enums;
 using AiDotNet.NeuralNetworks.Options;
 
@@ -1800,7 +1800,7 @@ public partial class LSTMNeuralNetwork<T> : SequenceModelLayoutBase<T>
                 { "InputSize", Architecture.InputSize },
                 { "OutputSize", Architecture.OutputSize }
             },
-            ModelData = SerializeForMetadata()
+            ModelDataProvider = () => SerializeForMetadata()
         };
     }
 

--- a/src/NeuralNetworks/Mamba2LanguageModel.cs
+++ b/src/NeuralNetworks/Mamba2LanguageModel.cs
@@ -147,7 +147,7 @@ public partial class Mamba2LanguageModel<T> : TokenLanguageModelLayoutBase<T>
                 { "MaxSeqLength", _maxSeqLength },
                 { "LayerCount", Layers.Count }
             },
-            ModelData = SerializeForMetadata()
+            ModelDataProvider = () => SerializeForMetadata()
         };
     }
 

--- a/src/NeuralNetworks/MambaLanguageModel.cs
+++ b/src/NeuralNetworks/MambaLanguageModel.cs
@@ -155,7 +155,7 @@ public partial class MambaLanguageModel<T> : TokenLanguageModelLayoutBase<T>
                 { "MaxSeqLength", _maxSeqLength },
                 { "LayerCount", Layers.Count }
             },
-            ModelData = SerializeForMetadata()
+            ModelDataProvider = () => SerializeForMetadata()
         };
     }
 

--- a/src/NeuralNetworks/MeshCNN.cs
+++ b/src/NeuralNetworks/MeshCNN.cs
@@ -488,7 +488,7 @@ public partial class MeshCNN<T> : GraphModelLayoutBase<T>
                 { "DropoutRate", _options.DropoutRate },
                 { "LayerCount", Layers.Count }
             },
-            ModelData = SerializeForMetadata()
+            ModelDataProvider = () => SerializeForMetadata()
         };
     }
 }

--- a/src/NeuralNetworks/MixtureOfExpertsNeuralNetwork.cs
+++ b/src/NeuralNetworks/MixtureOfExpertsNeuralNetwork.cs
@@ -428,7 +428,7 @@ public partial class MixtureOfExpertsNeuralNetwork<T> : VectorModelLayoutBase<T>
                 { "TaskType", Architecture.TaskType.ToString() },
                 { "ParameterCount", GetParameterCount() }
             },
-            ModelData = SerializeForMetadata()
+            ModelDataProvider = () => SerializeForMetadata()
         };
     }
 

--- a/src/NeuralNetworks/MobileNetV2Network.cs
+++ b/src/NeuralNetworks/MobileNetV2Network.cs
@@ -391,7 +391,7 @@ public partial class MobileNetV2Network<T> : ImageClassifierModelLayoutBase<T>
                 { "LayerCount", Layers.Count },
                 { "ParameterCount", GetParameterCount() }
             },
-            ModelData = SerializeForMetadata()
+            ModelDataProvider = () => SerializeForMetadata()
         };
     }
 

--- a/src/NeuralNetworks/MobileNetV3Network.cs
+++ b/src/NeuralNetworks/MobileNetV3Network.cs
@@ -272,7 +272,7 @@ public partial class MobileNetV3Network<T> : ImageClassifierModelLayoutBase<T>
                 { "LayerCount", Layers.Count },
                 { "ParameterCount", GetParameterCount() }
             },
-            ModelData = SerializeForMetadata()
+            ModelDataProvider = () => SerializeForMetadata()
         };
     }
 

--- a/src/NeuralNetworks/NEAT.cs
+++ b/src/NeuralNetworks/NEAT.cs
@@ -1616,7 +1616,7 @@ public partial class NEAT<T> : VectorModelLayoutBase<T>
                 { "BestGenomeConnections", bestGenome.Connections.Count },
                 { "BestGenomeEnabledConnections", bestGenome.Connections.Count(c => c.IsEnabled) }
             },
-            ModelData = SerializeForMetadata()
+            ModelDataProvider = () => SerializeForMetadata()
         };
     }
 

--- a/src/NeuralNetworks/NeuralNetwork.cs
+++ b/src/NeuralNetworks/NeuralNetwork.cs
@@ -351,7 +351,7 @@ public partial class NeuralNetwork<T> : SequentialVectorModelLayoutBase<T>
                 { "HiddenLayerSizes", Architecture.GetHiddenLayerSizes() },
                 { "TaskType", Architecture.TaskType.ToString() }
             },
-            ModelData = SerializeForMetadata()
+            ModelDataProvider = () => SerializeForMetadata()
         };
     }
 

--- a/src/NeuralNetworks/NeuralTuringMachine.cs
+++ b/src/NeuralNetworks/NeuralTuringMachine.cs
@@ -2237,7 +2237,7 @@ public partial class NeuralTuringMachine<T> : SequenceModelLayoutBase<T>, IAuxil
                 { "TotalParameters", ParameterCount },
                 { "LayerCount", Layers.Count }
             },
-            ModelData = SerializeForMetadata()
+            ModelDataProvider = () => SerializeForMetadata()
         };
     }
 

--- a/src/NeuralNetworks/OccupancyNeuralNetwork.cs
+++ b/src/NeuralNetworks/OccupancyNeuralNetwork.cs
@@ -587,7 +587,7 @@ public partial class OccupancyNeuralNetwork<T> : VectorModelLayoutBase<T>
                 { "TotalParameters", ParameterCount },
                 { "HiddenLayerSizes", Architecture.GetHiddenLayerSizes() }
             },
-            ModelData = SerializeForMetadata()
+            ModelDataProvider = () => SerializeForMetadata()
         };
     }
 

--- a/src/NeuralNetworks/OctonionNeuralNetwork.cs
+++ b/src/NeuralNetworks/OctonionNeuralNetwork.cs
@@ -306,7 +306,7 @@ public partial class OctonionNeuralNetwork<T> : VectorModelLayoutBase<T>
                 { "TaskType", Architecture.TaskType.ToString() },
                 { "ParameterCount", GetParameterCount() }
             },
-            ModelData = SerializeForMetadata()
+            ModelDataProvider = () => SerializeForMetadata()
         };
     }
 

--- a/src/NeuralNetworks/Pix2Pix.cs
+++ b/src/NeuralNetworks/Pix2Pix.cs
@@ -1,4 +1,4 @@
-﻿using System.IO;
+using System.IO;
 using AiDotNet.Attributes;
 using AiDotNet.Enums;
 using AiDotNet.Helpers;
@@ -700,7 +700,7 @@ public partial class Pix2Pix<T> : ImageTranslationModelLayoutBase<T>
                 { "DiscriminatorParameters", Discriminator.GetParameterCount() },
                 { "L1Lambda", NumOps.ToDouble(_l1Lambda) }
             },
-            ModelData = SerializeForMetadata()
+            ModelDataProvider = () => SerializeForMetadata()
         };
     }
 

--- a/src/NeuralNetworks/QuantumNeuralNetwork.cs
+++ b/src/NeuralNetworks/QuantumNeuralNetwork.cs
@@ -316,7 +316,7 @@ public partial class QuantumNeuralNetwork<T> : VectorModelLayoutBase<T>
                 { "LayerTypes", Layers.Select(l => l.GetType().Name).ToArray() },
                 { "NumberOfQubits", _numQubits }
             },
-            ModelData = SerializeForMetadata()
+            ModelDataProvider = () => SerializeForMetadata()
         };
     }
 

--- a/src/NeuralNetworks/RWKV4LanguageModel.cs
+++ b/src/NeuralNetworks/RWKV4LanguageModel.cs
@@ -205,7 +205,7 @@ public partial class RWKV4LanguageModel<T> : TokenLanguageModelLayoutBase<T>
                 { "TotalParameters", ParameterCount },
                 { "LayerCount", Layers.Count }
             },
-            ModelData = SerializeForMetadata()
+            ModelDataProvider = () => SerializeForMetadata()
         };
     }
 

--- a/src/NeuralNetworks/RWKV7LanguageModel.cs
+++ b/src/NeuralNetworks/RWKV7LanguageModel.cs
@@ -161,7 +161,7 @@ public partial class RWKV7LanguageModel<T> : TokenLanguageModelLayoutBase<T>
                 { "MaxSeqLength", _maxSeqLength },
                 { "LayerCount", Layers.Count }
             },
-            ModelData = SerializeForMetadata()
+            ModelDataProvider = () => SerializeForMetadata()
         };
     }
 

--- a/src/NeuralNetworks/RadialBasisFunctionNetwork.cs
+++ b/src/NeuralNetworks/RadialBasisFunctionNetwork.cs
@@ -431,7 +431,7 @@ public partial class RadialBasisFunctionNetwork<T> : VectorModelLayoutBase<T>
                 { "OutputSize", _outputSize },
                 { "RadialBasisFunction", _radialBasisFunction.GetType().Name }
             },
-            ModelData = SerializeForMetadata()
+            ModelDataProvider = () => SerializeForMetadata()
         };
 
         return metadata;

--- a/src/NeuralNetworks/RecurrentGemmaLanguageModel.cs
+++ b/src/NeuralNetworks/RecurrentGemmaLanguageModel.cs
@@ -221,7 +221,7 @@ public partial class RecurrentGemmaLanguageModel<T> : TokenLanguageModelLayoutBa
                 { "MaxSeqLength", _maxSeqLength },
                 { "LayerCount", Layers.Count }
             },
-            ModelData = SerializeForMetadata()
+            ModelDataProvider = () => SerializeForMetadata()
         };
     }
 

--- a/src/NeuralNetworks/RecurrentNeuralNetwork.cs
+++ b/src/NeuralNetworks/RecurrentNeuralNetwork.cs
@@ -335,7 +335,7 @@ public partial class RecurrentNeuralNetwork<T> : SequenceModelLayoutBase<T>
                 { "InputShape", Architecture.GetInputShape() },
                 { "OutputShape", Architecture.GetOutputShape() },
             },
-            ModelData = SerializeForMetadata()
+            ModelDataProvider = () => SerializeForMetadata()
         };
 
         return metadata;

--- a/src/NeuralNetworks/ResNetNetwork.cs
+++ b/src/NeuralNetworks/ResNetNetwork.cs
@@ -582,7 +582,7 @@ public partial class ResNetNetwork<T> : ImageClassifierModelLayoutBase<T>
                 { "NumWeightLayers", _configuration.NumWeightLayers },
                 { "ZeroInitResidual", _configuration.ZeroInitResidual }
             },
-            ModelData = SerializeForMetadata()
+            ModelDataProvider = () => SerializeForMetadata()
         };
     }
 

--- a/src/NeuralNetworks/ResidualNeuralNetwork.cs
+++ b/src/NeuralNetworks/ResidualNeuralNetwork.cs
@@ -726,7 +726,7 @@ finally
                 { "InputSize", Architecture.CalculatedInputSize },
                 { "OutputSize", Architecture.CalculateOutputSize() }
             },
-            ModelData = SerializeForMetadata()
+            ModelDataProvider = () => SerializeForMetadata()
         };
     }
 

--- a/src/NeuralNetworks/RestrictedBoltzmannMachine.cs
+++ b/src/NeuralNetworks/RestrictedBoltzmannMachine.cs
@@ -1169,7 +1169,7 @@ public partial class RestrictedBoltzmannMachine<T> : VectorModelLayoutBase<T>, I
                 { "LearningRate", Convert.ToDouble(_learningRate) },
                 { "CDSteps", _cdSteps }
             },
-            ModelData = SerializeForMetadata()
+            ModelDataProvider = () => SerializeForMetadata()
         };
     }
 

--- a/src/NeuralNetworks/SambaLanguageModel.cs
+++ b/src/NeuralNetworks/SambaLanguageModel.cs
@@ -149,7 +149,7 @@ public partial class SambaLanguageModel<T> : TokenLanguageModelLayoutBase<T>
                 { "MaxSeqLength", _maxSeqLength },
                 { "LayerCount", Layers.Count }
             },
-            ModelData = SerializeForMetadata()
+            ModelDataProvider = () => SerializeForMetadata()
         };
     }
 

--- a/src/NeuralNetworks/SelfOrganizingMap.cs
+++ b/src/NeuralNetworks/SelfOrganizingMap.cs
@@ -361,7 +361,7 @@ public partial class SelfOrganizingMap<T> : VectorModelLayoutBase<T>
                 { "TotalEpochs", _totalEpochs },
                 { "CurrentEpoch", _currentEpoch }
             },
-            ModelData = SerializeForMetadata()
+            ModelDataProvider = () => SerializeForMetadata()
         };
     }
 

--- a/src/NeuralNetworks/SiameseNetwork.cs
+++ b/src/NeuralNetworks/SiameseNetwork.cs
@@ -1,4 +1,4 @@
-﻿global using AiDotNet.NeuralNetworks.Layers;
+global using AiDotNet.NeuralNetworks.Layers;
 
 using AiDotNet.Attributes;
 using AiDotNet.Enums;
@@ -673,7 +673,7 @@ public partial class SiameseNetwork<T> : DeclaredModelLayoutBase<T>, IAuxiliaryL
                 { "TotalParameters", GetParameterCount() },
                 { "InputShape", string.Join(",", Architecture.GetInputShape()) }
             },
-            ModelData = SerializeForMetadata()
+            ModelDataProvider = () => SerializeForMetadata()
         };
 
         return metadata;

--- a/src/NeuralNetworks/SparseNeuralNetwork.cs
+++ b/src/NeuralNetworks/SparseNeuralNetwork.cs
@@ -423,7 +423,7 @@ public partial class SparseNeuralNetwork<T> : VectorModelLayoutBase<T>
                 { "TaskType", Architecture.TaskType.ToString() },
                 { "ParameterCount", GetParameterCount() }
             },
-            ModelData = SerializeForMetadata()
+            ModelDataProvider = () => SerializeForMetadata()
         };
     }
 

--- a/src/NeuralNetworks/SpikingNeuralNetwork.cs
+++ b/src/NeuralNetworks/SpikingNeuralNetwork.cs
@@ -1211,7 +1211,7 @@ public partial class SpikingNeuralNetwork<T> : SequenceModelLayoutBase<T>
                 { "OutputSize", Architecture.OutputSize },
                 { "HiddenLayerSizes", Architecture.GetHiddenLayerSizes() }
             },
-            ModelData = SerializeForMetadata()
+            ModelDataProvider = () => SerializeForMetadata()
         };
     }
 

--- a/src/NeuralNetworks/SpiralNet.cs
+++ b/src/NeuralNetworks/SpiralNet.cs
@@ -603,7 +603,7 @@ public partial class SpiralNet<T> : GraphModelLayoutBase<T>
                 { "DropoutRate", _options.DropoutRate },
                 { "LayerCount", Layers.Count }
             },
-            ModelData = SerializeForMetadata()
+            ModelDataProvider = () => SerializeForMetadata()
         };
     }
 

--- a/src/NeuralNetworks/StyleGAN.cs
+++ b/src/NeuralNetworks/StyleGAN.cs
@@ -1,4 +1,4 @@
-﻿using System.IO;
+using System.IO;
 using AiDotNet.Attributes;
 using AiDotNet.Enums;
 using AiDotNet.Helpers;
@@ -870,7 +870,7 @@ public partial class StyleGAN<T> : ImageGeneratorModelLayoutBase<T>
                 { "IntermediateLatentSize", _intermediateLatentSize },
                 { "StyleMixingEnabled", _enableStyleMixing }
             },
-            ModelData = SerializeForMetadata()
+            ModelDataProvider = () => SerializeForMetadata()
         };
     }
 

--- a/src/NeuralNetworks/SyntheticData/AutoDiffTabGenerator.cs
+++ b/src/NeuralNetworks/SyntheticData/AutoDiffTabGenerator.cs
@@ -871,7 +871,7 @@ public partial class AutoDiffTabGenerator<T> : NeuralSyntheticTabularGeneratorBa
                 { "DenoiserLayerCount", Layers.Count },
                 { "DenoiserLayerTypes", Layers.Select(l => l.GetType().Name).ToArray() }
             },
-            ModelData = SerializeForMetadata()
+            ModelDataProvider = () => SerializeForMetadata()
         };
     }
 

--- a/src/NeuralNetworks/SyntheticData/CTABGANPlusGenerator.cs
+++ b/src/NeuralNetworks/SyntheticData/CTABGANPlusGenerator.cs
@@ -965,7 +965,7 @@ public partial class CTABGANPlusGenerator<T> : NeuralSyntheticTabularGeneratorBa
                 { "GeneratorLayerCount", Layers.Count },
                 { "GeneratorLayerTypes", Layers.Select(l => l.GetType().Name).ToArray() }
             },
-            ModelData = SerializeForMetadata()
+            ModelDataProvider = () => SerializeForMetadata()
         };
     }
 

--- a/src/NeuralNetworks/SyntheticData/CTGANGenerator.cs
+++ b/src/NeuralNetworks/SyntheticData/CTGANGenerator.cs
@@ -1,4 +1,4 @@
-﻿using AiDotNet.Attributes;
+using AiDotNet.Attributes;
 using AiDotNet.Autodiff;
 using AiDotNet.Enums;
 using AiDotNet.Helpers;
@@ -1453,7 +1453,7 @@ public partial class CTGANGenerator<T> : NeuralSyntheticTabularGeneratorBase<T>,
                 { "GeneratorLayerCount", Layers.Count },
                 { "GeneratorLayerTypes", Layers.Select(l => l.GetType().Name).ToArray() }
             },
-            ModelData = SerializeForMetadata()
+            ModelDataProvider = () => SerializeForMetadata()
         };
     }
 

--- a/src/NeuralNetworks/SyntheticData/CausalGANGenerator.cs
+++ b/src/NeuralNetworks/SyntheticData/CausalGANGenerator.cs
@@ -1389,7 +1389,7 @@ public partial class CausalGANGenerator<T> : NeuralSyntheticTabularGeneratorBase
                 { "GeneratorLayerCount", Layers.Count },
                 { "GeneratorLayerTypes", Layers.Select(l => l.GetType().Name).ToArray() }
             },
-            ModelData = SerializeForMetadata()
+            ModelDataProvider = () => SerializeForMetadata()
         };
     }
 

--- a/src/NeuralNetworks/SyntheticData/CopulaGANGenerator.cs
+++ b/src/NeuralNetworks/SyntheticData/CopulaGANGenerator.cs
@@ -1,4 +1,4 @@
-﻿using AiDotNet.Attributes;
+using AiDotNet.Attributes;
 using AiDotNet.Autodiff;
 using AiDotNet.Enums;
 using AiDotNet.Helpers;
@@ -1501,7 +1501,7 @@ public partial class CopulaGANGenerator<T> : NeuralSyntheticTabularGeneratorBase
                 { "GeneratorLayerCount", Layers.Count },
                 { "GeneratorLayerTypes", Layers.Select(l => l.GetType().Name).ToArray() }
             },
-            ModelData = SerializeForMetadata()
+            ModelDataProvider = () => SerializeForMetadata()
         };
     }
 

--- a/src/NeuralNetworks/SyntheticData/DPCTGANGenerator.cs
+++ b/src/NeuralNetworks/SyntheticData/DPCTGANGenerator.cs
@@ -1,4 +1,4 @@
-﻿using AiDotNet.Attributes;
+using AiDotNet.Attributes;
 using AiDotNet.Autodiff;
 using AiDotNet.Enums;
 using AiDotNet.Helpers;
@@ -1394,7 +1394,7 @@ public partial class DPCTGANGenerator<T> : NeuralSyntheticTabularGeneratorBase<T
                 { "GeneratorLayerCount", Layers.Count },
                 { "GeneratorLayerTypes", Layers.Select(l => l.GetType().Name).ToArray() }
             },
-            ModelData = SerializeForMetadata()
+            ModelDataProvider = () => SerializeForMetadata()
         };
     }
 

--- a/src/NeuralNetworks/SyntheticData/FinDiffGenerator.cs
+++ b/src/NeuralNetworks/SyntheticData/FinDiffGenerator.cs
@@ -1,4 +1,4 @@
-﻿using AiDotNet.Attributes;
+using AiDotNet.Attributes;
 using AiDotNet.Enums;
 using AiDotNet.Helpers;
 using AiDotNet.Interfaces;
@@ -647,7 +647,7 @@ public partial class FinDiffGenerator<T> : NeuralSyntheticTabularGeneratorBase<T
                 { "LayerCount", Layers.Count },
                 { "LayerTypes", Layers.Select(l => l.GetType().Name).ToArray() }
             },
-            ModelData = SerializeForMetadata()
+            ModelDataProvider = () => SerializeForMetadata()
         };
     }
 

--- a/src/NeuralNetworks/SyntheticData/TVAEGenerator.cs
+++ b/src/NeuralNetworks/SyntheticData/TVAEGenerator.cs
@@ -794,7 +794,7 @@ public partial class TVAEGenerator<T> : NeuralSyntheticTabularGeneratorBase<T>, 
                 { "DecoderLayerCount", _decoderLayers.Count },
                 { "EncoderLayerTypes", Layers.Select(l => l.GetType().Name).ToArray() }
             },
-            ModelData = SerializeForMetadata()
+            ModelDataProvider = () => SerializeForMetadata()
         };
     }
 

--- a/src/NeuralNetworks/SyntheticData/TabDDPMGenerator.cs
+++ b/src/NeuralNetworks/SyntheticData/TabDDPMGenerator.cs
@@ -1136,7 +1136,7 @@ public partial class TabDDPMGenerator<T> : NeuralSyntheticTabularGeneratorBase<T
                 { "DenoiserLayerCount", Layers.Count },
                 { "DenoiserLayerTypes", Layers.Select(l => l.GetType().Name).ToArray() }
             },
-            ModelData = SerializeForMetadata()
+            ModelDataProvider = () => SerializeForMetadata()
         };
     }
 

--- a/src/NeuralNetworks/SyntheticData/TabFlowGenerator.cs
+++ b/src/NeuralNetworks/SyntheticData/TabFlowGenerator.cs
@@ -1,4 +1,4 @@
-﻿using AiDotNet.Attributes;
+using AiDotNet.Attributes;
 using AiDotNet.Enums;
 using AiDotNet.Helpers;
 using AiDotNet.Interfaces;
@@ -697,7 +697,7 @@ public partial class TabFlowGenerator<T> : NeuralSyntheticTabularGeneratorBase<T
                 { "LayerCount", Layers.Count },
                 { "LayerTypes", Layers.Select(l => l.GetType().Name).ToArray() }
             },
-            ModelData = SerializeForMetadata()
+            ModelDataProvider = () => SerializeForMetadata()
         };
     }
 

--- a/src/NeuralNetworks/SyntheticData/TabSynGenerator.cs
+++ b/src/NeuralNetworks/SyntheticData/TabSynGenerator.cs
@@ -1104,7 +1104,7 @@ public partial class TabSynGenerator<T> : NeuralSyntheticTabularGeneratorBase<T>
                 { "EncoderLayerCount", Layers.Count },
                 { "EncoderLayerTypes", Layers.Select(l => l.GetType().Name).ToArray() }
             },
-            ModelData = SerializeForMetadata()
+            ModelDataProvider = () => SerializeForMetadata()
         };
     }
 

--- a/src/NeuralNetworks/Tabular/AutoIntNetwork.cs
+++ b/src/NeuralNetworks/Tabular/AutoIntNetwork.cs
@@ -1,4 +1,4 @@
-﻿using AiDotNet.Attributes;
+using AiDotNet.Attributes;
 using AiDotNet.Enums;
 using AiDotNet.Helpers;
 using AiDotNet.Models.Options;
@@ -217,7 +217,7 @@ public partial class AutoIntNetwork<T> : TabularNeuralNetworkBase<T>
                 { "LayerCount", Layers.Count },
                 { "LayerTypes", Layers.Select(l => l.GetType().Name).ToArray() }
             },
-            ModelData = SerializeForMetadata()
+            ModelDataProvider = () => SerializeForMetadata()
         };
     }
 

--- a/src/NeuralNetworks/Tabular/FTTransformerNetwork.cs
+++ b/src/NeuralNetworks/Tabular/FTTransformerNetwork.cs
@@ -253,7 +253,7 @@ public partial class FTTransformerNetwork<T> : TabularNeuralNetworkBase<T>
                 { "LayerCount", Layers.Count },
                 { "LayerTypes", Layers.Select(l => l.GetType().Name).ToArray() }
             },
-            ModelData = SerializeForMetadata()
+            ModelDataProvider = () => SerializeForMetadata()
         };
     }
 

--- a/src/NeuralNetworks/Tabular/GANDALFNetwork.cs
+++ b/src/NeuralNetworks/Tabular/GANDALFNetwork.cs
@@ -363,7 +363,7 @@ public partial class GANDALFNetwork<T> : TabularNeuralNetworkBase<T>
                 { "LayerCount", Layers.Count },
                 { "LayerTypes", Layers.Select(l => l.GetType().Name).ToArray() }
             },
-            ModelData = SerializeForMetadata()
+            ModelDataProvider = () => SerializeForMetadata()
         };
     }
 

--- a/src/NeuralNetworks/Tabular/MambularNetwork.cs
+++ b/src/NeuralNetworks/Tabular/MambularNetwork.cs
@@ -211,7 +211,7 @@ public partial class MambularNetwork<T> : TabularNeuralNetworkBase<T>
                 { "LayerCount", Layers.Count },
                 { "LayerTypes", Layers.Select(l => l.GetType().Name).ToArray() }
             },
-            ModelData = SerializeForMetadata()
+            ModelDataProvider = () => SerializeForMetadata()
         };
     }
 

--- a/src/NeuralNetworks/Tabular/NODENetwork.cs
+++ b/src/NeuralNetworks/Tabular/NODENetwork.cs
@@ -258,7 +258,7 @@ public partial class NODENetwork<T> : TabularNeuralNetworkBase<T>
                 { "LayerCount", Layers.Count },
                 { "LayerTypes", Layers.Select(l => l.GetType().Name).ToArray() }
             },
-            ModelData = SerializeForMetadata()
+            ModelDataProvider = () => SerializeForMetadata()
         };
     }
 

--- a/src/NeuralNetworks/Tabular/SAINTNetwork.cs
+++ b/src/NeuralNetworks/Tabular/SAINTNetwork.cs
@@ -388,7 +388,7 @@ public partial class SAINTNetwork<T> : TabularNeuralNetworkBase<T>
                 { "LayerCount", Layers.Count },
                 { "LayerTypes", Layers.Select(l => l.GetType().Name).ToArray() }
             },
-            ModelData = SerializeForMetadata()
+            ModelDataProvider = () => SerializeForMetadata()
         };
     }
 

--- a/src/NeuralNetworks/Tabular/TabDPTNetwork.cs
+++ b/src/NeuralNetworks/Tabular/TabDPTNetwork.cs
@@ -224,7 +224,7 @@ public partial class TabDPTNetwork<T> : TabularNeuralNetworkBase<T>
                 { "LayerCount", Layers.Count },
                 { "LayerTypes", Layers.Select(l => l.GetType().Name).ToArray() }
             },
-            ModelData = SerializeForMetadata()
+            ModelDataProvider = () => SerializeForMetadata()
         };
     }
 

--- a/src/NeuralNetworks/Tabular/TabMNetwork.cs
+++ b/src/NeuralNetworks/Tabular/TabMNetwork.cs
@@ -198,7 +198,7 @@ public partial class TabMNetwork<T> : TabularNeuralNetworkBase<T>
                 { "LayerCount", Layers.Count },
                 { "LayerTypes", Layers.Select(l => l.GetType().Name).ToArray() }
             },
-            ModelData = SerializeForMetadata()
+            ModelDataProvider = () => SerializeForMetadata()
         };
     }
 

--- a/src/NeuralNetworks/Tabular/TabNetNetwork.cs
+++ b/src/NeuralNetworks/Tabular/TabNetNetwork.cs
@@ -210,7 +210,7 @@ public partial class TabNetNetwork<T> : TabularNeuralNetworkBase<T>
                 { "LayerCount", Layers.Count },
                 { "LayerTypes", Layers.Select(l => l.GetType().Name).ToArray() }
             },
-            ModelData = SerializeForMetadata()
+            ModelDataProvider = () => SerializeForMetadata()
         };
     }
 

--- a/src/NeuralNetworks/Tabular/TabPFNNetwork.cs
+++ b/src/NeuralNetworks/Tabular/TabPFNNetwork.cs
@@ -226,7 +226,7 @@ public partial class TabPFNNetwork<T> : TabularNeuralNetworkBase<T>
                 { "LayerCount", Layers.Count },
                 { "LayerTypes", Layers.Select(l => l.GetType().Name).ToArray() }
             },
-            ModelData = SerializeForMetadata()
+            ModelDataProvider = () => SerializeForMetadata()
         };
     }
 

--- a/src/NeuralNetworks/Tabular/TabRNetwork.cs
+++ b/src/NeuralNetworks/Tabular/TabRNetwork.cs
@@ -222,7 +222,7 @@ public partial class TabRNetwork<T> : TabularNeuralNetworkBase<T>
                 { "LayerCount", Layers.Count },
                 { "LayerTypes", Layers.Select(l => l.GetType().Name).ToArray() }
             },
-            ModelData = SerializeForMetadata()
+            ModelDataProvider = () => SerializeForMetadata()
         };
     }
 

--- a/src/NeuralNetworks/Tabular/TabTransformerNetwork.cs
+++ b/src/NeuralNetworks/Tabular/TabTransformerNetwork.cs
@@ -411,7 +411,7 @@ public partial class TabTransformerNetwork<T> : TabularNeuralNetworkBase<T>
                 { "LayerCount", Layers.Count },
                 { "LayerTypes", Layers.Select(l => l.GetType().Name).ToArray() }
             },
-            ModelData = SerializeForMetadata()
+            ModelDataProvider = () => SerializeForMetadata()
         };
     }
 

--- a/src/NeuralNetworks/Transformer.cs
+++ b/src/NeuralNetworks/Transformer.cs
@@ -1059,7 +1059,7 @@ public partial class Transformer<T> : TokenLanguageModelLayoutBase<T>, IAuxiliar
                 { "LossFunction", LossFunction.GetType().Name },
                 { "Optimizer", _optimizer.GetType().Name }
             },
-            ModelData = SerializeForMetadata()
+            ModelDataProvider = () => SerializeForMetadata()
         };
     }
 

--- a/src/NeuralNetworks/UNet3D.cs
+++ b/src/NeuralNetworks/UNet3D.cs
@@ -293,7 +293,7 @@ public partial class UNet3D<T> : VolumetricModelLayoutBase<T>
                 { "LayerCount", Layers.Count },
                 { "LayerTypes", Layers.Select(l => l.GetType().Name).ToArray() }
             },
-            ModelData = SerializeForMetadata()
+            ModelDataProvider = () => SerializeForMetadata()
         };
     }
 

--- a/src/NeuralNetworks/VGGNetwork.cs
+++ b/src/NeuralNetworks/VGGNetwork.cs
@@ -458,7 +458,7 @@ public partial class VGGNetwork<T> : ImageClassifierModelLayoutBase<T>
                 { "NumWeightLayers", _configuration.NumWeightLayers },
                 { "DropoutRate", _configuration.DropoutRate }
             },
-            ModelData = SerializeForMetadata()
+            ModelDataProvider = () => SerializeForMetadata()
         };
     }
 

--- a/src/NeuralNetworks/VariationalAutoencoder.cs
+++ b/src/NeuralNetworks/VariationalAutoencoder.cs
@@ -826,7 +826,7 @@ public partial class VariationalAutoencoder<T> : VectorModelLayoutBase<T>, IAuxi
                 { "EncoderLayers", Layers.Take(Layers.Count / 2).Select(l => l.GetType().Name).ToArray() },
                 { "DecoderLayers", Layers.Skip(Layers.Count / 2).Select(l => l.GetType().Name).ToArray() }
             },
-            ModelData = SerializeForMetadata()
+            ModelDataProvider = () => SerializeForMetadata()
         };
     }
 

--- a/src/NeuralNetworks/VideoCLIPNeuralNetwork.cs
+++ b/src/NeuralNetworks/VideoCLIPNeuralNetwork.cs
@@ -1596,7 +1596,7 @@ public partial class VideoCLIPNeuralNetwork<T> : MultimodalModelLayoutBase<T>, I
                 { "VocabularySize", _vocabularySize },
                 { "UseNativeMode", _useNativeMode }
             },
-            ModelData = SerializeForMetadata()
+            ModelDataProvider = () => SerializeForMetadata()
         };
     }
 

--- a/src/NeuralNetworks/VisionMambaModel.cs
+++ b/src/NeuralNetworks/VisionMambaModel.cs
@@ -373,7 +373,7 @@ public partial class VisionMambaModel<T> : ImageClassifierModelLayoutBase<T>
                 { "NumPatches", _numPatches },
                 { "LayerCount", Layers.Count }
             },
-            ModelData = SerializeForMetadata()
+            ModelDataProvider = () => SerializeForMetadata()
         };
     }
 

--- a/src/NeuralNetworks/VoxelCNN.cs
+++ b/src/NeuralNetworks/VoxelCNN.cs
@@ -340,7 +340,7 @@ public partial class VoxelCNN<T> : VolumetricModelLayoutBase<T>
                 { "LayerCount", Layers.Count },
                 { "LayerTypes", Layers.Select(l => l.GetType().Name).ToArray() }
             },
-            ModelData = SerializeForMetadata()
+            ModelDataProvider = () => SerializeForMetadata()
         };
     }
 

--- a/src/NeuralNetworks/WGAN.cs
+++ b/src/NeuralNetworks/WGAN.cs
@@ -641,7 +641,7 @@ public partial class WGAN<T> : ImageGeneratorModelLayoutBase<T>
                 { "WeightClipValue", _weightClipValue },
                 { "CriticIterations", _criticIterations }
             },
-            ModelData = SerializeForMetadata()
+            ModelDataProvider = () => SerializeForMetadata()
         };
     }
 

--- a/src/NeuralNetworks/WGANGP.cs
+++ b/src/NeuralNetworks/WGANGP.cs
@@ -1024,7 +1024,7 @@ public partial class WGANGP<T> : ImageGeneratorModelLayoutBase<T>
                 { "GradientPenaltyCoefficient", _gradientPenaltyCoefficient },
                 { "CriticIterations", _criticIterations }
             },
-            ModelData = SerializeForMetadata()
+            ModelDataProvider = () => SerializeForMetadata()
         };
     }
 

--- a/src/NeuralNetworks/XLSTMLanguageModel.cs
+++ b/src/NeuralNetworks/XLSTMLanguageModel.cs
@@ -165,7 +165,7 @@ public partial class XLSTMLanguageModel<T> : TokenLanguageModelLayoutBase<T>
                 { "MaxSeqLength", _maxSeqLength },
                 { "LayerCount", Layers.Count }
             },
-            ModelData = SerializeForMetadata()
+            ModelDataProvider = () => SerializeForMetadata()
         };
     }
 

--- a/src/NeuralNetworks/Zamba2LanguageModel.cs
+++ b/src/NeuralNetworks/Zamba2LanguageModel.cs
@@ -148,7 +148,7 @@ public partial class Zamba2LanguageModel<T> : TokenLanguageModelLayoutBase<T>
                 { "MaxSeqLength", _maxSeqLength },
                 { "LayerCount", Layers.Count }
             },
-            ModelData = SerializeForMetadata()
+            ModelDataProvider = () => SerializeForMetadata()
         };
     }
 

--- a/src/NeuralNetworks/ZambaLanguageModel.cs
+++ b/src/NeuralNetworks/ZambaLanguageModel.cs
@@ -144,7 +144,7 @@ public partial class ZambaLanguageModel<T> : TokenLanguageModelLayoutBase<T>
                 { "MaxSeqLength", _maxSeqLength },
                 { "LayerCount", Layers.Count }
             },
-            ModelData = SerializeForMetadata()
+            ModelDataProvider = () => SerializeForMetadata()
         };
     }
 

--- a/src/NeuralRadianceFields/Models/GaussianSplatting.cs
+++ b/src/NeuralRadianceFields/Models/GaussianSplatting.cs
@@ -2553,7 +2553,7 @@ public partial class GaussianSplatting<T> : AiDotNet.NeuralNetworks.VectorModelL
             },
             // License-safe metadata bytes — see NeRF.GetModelMetadata for the
             // same rationale. Fixes #1826.
-            ModelData = SerializeForMetadata()
+            ModelDataProvider = () => SerializeForMetadata()
         };
     }
 

--- a/src/NeuralRadianceFields/Models/InstantNGP.cs
+++ b/src/NeuralRadianceFields/Models/InstantNGP.cs
@@ -1,4 +1,4 @@
-﻿#pragma warning disable CS0649, CS0414, CS0169
+#pragma warning disable CS0649, CS0414, CS0169
 using AiDotNet.ActivationFunctions;
 using AiDotNet.Helpers;
 using AiDotNet.Interfaces;
@@ -1828,7 +1828,7 @@ public partial class InstantNGP<T> : AiDotNet.NeuralNetworks.VectorModelLayoutBa
             },
             // License-safe metadata bytes — see NeRF.GetModelMetadata for the
             // same rationale. Fixes #1826.
-            ModelData = SerializeForMetadata()
+            ModelDataProvider = () => SerializeForMetadata()
         };
     }
 

--- a/src/NeuralRadianceFields/Models/NeRF.cs
+++ b/src/NeuralRadianceFields/Models/NeRF.cs
@@ -1404,7 +1404,7 @@ public partial class NeRF<T> : AiDotNet.NeuralNetworks.VectorModelLayoutBase<T>,
             // throws LicenseRequiredException on the very first facade Build,
             // even when the caller has no intention of saving the model.
             // Matches Transformer.GetModelMetadata. Fixes #1826.
-            ModelData = SerializeForMetadata()
+            ModelDataProvider = () => SerializeForMetadata()
         };
     }
 

--- a/src/PointCloud/Models/DGCNN.cs
+++ b/src/PointCloud/Models/DGCNN.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Linq;
 using AiDotNet.ActivationFunctions;
 using AiDotNet.Autodiff;
@@ -523,7 +523,7 @@ public partial class DGCNN<T> : NeuralNetworkBase<T>, IPointCloudModel<T>, IPoin
                 { "TotalLayers", Layers.Count },
                 { "TaskType", Architecture.TaskType.ToString() }
             },
-            ModelData = SerializeForMetadata()
+            ModelDataProvider = () => SerializeForMetadata()
         };
     }
 

--- a/src/PointCloud/Models/PointNet.cs
+++ b/src/PointCloud/Models/PointNet.cs
@@ -416,7 +416,7 @@ public partial class PointNet<T> : NeuralNetworkBase<T>, IPointCloudModel<T>, IP
                 { "TotalLayers", Layers.Count },
                 { "TaskType", Architecture.TaskType.ToString() }
             },
-            ModelData = SerializeForMetadata()
+            ModelDataProvider = () => SerializeForMetadata()
         };
     }
 

--- a/src/PointCloud/Models/PointNetPlusPlus.cs
+++ b/src/PointCloud/Models/PointNetPlusPlus.cs
@@ -1,4 +1,4 @@
-﻿using AiDotNet.Helpers;
+using AiDotNet.Helpers;
 using System.Collections.Generic;
 using System.Linq;
 using AiDotNet.ActivationFunctions;
@@ -585,7 +585,7 @@ public partial class PointNetPlusPlus<T> : NeuralNetworkBase<T>, IPointCloudMode
                 { "TotalLayers", Layers.Count },
                 { "TaskType", Architecture.TaskType.ToString() }
             },
-            ModelData = SerializeForMetadata()
+            ModelDataProvider = () => SerializeForMetadata()
         };
     }
 

--- a/src/ProgramSynthesis/Engines/CodeModelBase.cs
+++ b/src/ProgramSynthesis/Engines/CodeModelBase.cs
@@ -130,7 +130,7 @@ public abstract class CodeModelBase<T> : NeuralNetworkBase<T>, ICodeModel<T>
         return new ModelMetadata<T>
         {
             AdditionalInfo = info,
-            ModelData = Serialize()
+            ModelDataProvider = () => Serialize()
         };
     }
 

--- a/src/Safety/Adversarial/AdversarialImageEvaluator.cs
+++ b/src/Safety/Adversarial/AdversarialImageEvaluator.cs
@@ -1,4 +1,4 @@
-﻿using System.IO;
+using System.IO;
 using AiDotNet.ActivationFunctions;
 using AiDotNet.Attributes;
 using AiDotNet.Enums;
@@ -345,7 +345,7 @@ public partial class AdversarialImageEvaluator<T> : NeuralNetworkBase<T>, IImage
             { "InputShape", Architecture.GetInputShape() },
             { "OutputShape", Architecture.GetOutputShape() },
         },
-        ModelData = SerializeForMetadata(),
+        ModelDataProvider = () => SerializeForMetadata(),
     };
 
     /// <inheritdoc />

--- a/src/SpeechRecognition/WhisperFamily/WhisperTimestamped.cs
+++ b/src/SpeechRecognition/WhisperFamily/WhisperTimestamped.cs
@@ -136,7 +136,7 @@ public partial class WhisperTimestamped<T> : AudioNeuralNetworkBase<T>, ISpeechR
             FeatureCount = _options.NumMels,
             Complexity = _options.NumEncoderLayers + _options.NumDecoderLayers,
             AdditionalInfo = additionalInfo,
-            ModelData = SerializeForMetadata(),
+            ModelDataProvider = () => SerializeForMetadata(),
         };
     }
 

--- a/src/TextToSpeech/CodecBased/VALLE.cs
+++ b/src/TextToSpeech/CodecBased/VALLE.cs
@@ -324,7 +324,7 @@ public partial class VALLE<T> : TtsModelBase<T>, ICodecTts<T>
                 ["MaxTextLength"] = _options.MaxTextLength,
                 ["LayerCount"] = Layers.Count,
             },
-            ModelData = SerializeForMetadata(),
+            ModelDataProvider = () => SerializeForMetadata(),
         };
     }
 

--- a/src/TextToSpeech/CodecBased/VALLE2.cs
+++ b/src/TextToSpeech/CodecBased/VALLE2.cs
@@ -219,7 +219,7 @@ public partial class VALLE2<T> : TtsModelBase<T>, ICodecTts<T>
                 ["MaxTextLength"] = _options.MaxTextLength,
                 ["LayerCount"] = Layers.Count,
             },
-            ModelData = SerializeForMetadata(),
+            ModelDataProvider = () => SerializeForMetadata(),
         };
     }
 

--- a/src/TextToSpeech/CodecBased/VALLEX.cs
+++ b/src/TextToSpeech/CodecBased/VALLEX.cs
@@ -336,7 +336,7 @@ public partial class VALLEX<T> : TtsModelBase<T>, ICodecTts<T>
                 ["MaxTextLength"] = _options.MaxTextLength,
                 ["LayerCount"] = Layers.Count,
             },
-            ModelData = SerializeForMetadata(),
+            ModelDataProvider = () => SerializeForMetadata(),
         };
     }
 

--- a/src/TextToSpeech/StyleEmotion/EmotiVoice.cs
+++ b/src/TextToSpeech/StyleEmotion/EmotiVoice.cs
@@ -267,7 +267,7 @@ public partial class EmotiVoice<T> : TtsModelBase<T>, IEndToEndTts<T>
                 ["MaxTextLength"] = _options.MaxTextLength,
                 ["ParameterCount"] = ParameterCount,
             },
-            ModelData = SerializeForMetadata(),
+            ModelDataProvider = () => SerializeForMetadata(),
         };
     }
 

--- a/src/TextToSpeech/VoiceCloning/VALLEXClone.cs
+++ b/src/TextToSpeech/VoiceCloning/VALLEXClone.cs
@@ -314,7 +314,7 @@ public partial class VALLEXClone<T> : TtsModelBase<T>, ICodecTts<T>, IVoiceClone
                 ["MaxTextLength"] = _options.MaxTextLength,
                 ["LayerCount"] = Layers.Count,
             },
-            ModelData = SerializeForMetadata(),
+            ModelDataProvider = () => SerializeForMetadata(),
         };
     }
 

--- a/src/TimeSeries/ARIMAModel.cs
+++ b/src/TimeSeries/ARIMAModel.cs
@@ -714,7 +714,7 @@ public partial class ARIMAModel<T> : TimeSeriesModelBase<T>
                 // Additional settings from options
                 { "LagOrder", _arimaOptions.LagOrder }
             },
-            ModelData = SerializeForMetadata()
+            ModelDataProvider = () => SerializeForMetadata()
         };
 
         return metadata;

--- a/src/TimeSeries/ARIMAXModel.cs
+++ b/src/TimeSeries/ARIMAXModel.cs
@@ -682,7 +682,7 @@ public partial class ARIMAXModel<T> : TimeSeriesModelBase<T>, IExogenousForecast
                 { "ExogenousVariables", arimaxOptions.ExogenousVariables },
                 { "DecompositionType", arimaxOptions.DecompositionType }
             },
-            ModelData = SerializeForMetadata()
+            ModelDataProvider = () => SerializeForMetadata()
         };
 
         return metadata;

--- a/src/TimeSeries/ARMAModel.cs
+++ b/src/TimeSeries/ARMAModel.cs
@@ -602,7 +602,7 @@ public partial class ARMAModel<T> : TimeSeriesModelBase<T>
                 { "MaxIterations", armaOptions.MaxIterations },
                 { "Tolerance", armaOptions.Tolerance }
             },
-            ModelData = SerializeForMetadata()
+            ModelDataProvider = () => SerializeForMetadata()
         };
         return metadata;
     }

--- a/src/TimeSeries/ARModel.cs
+++ b/src/TimeSeries/ARModel.cs
@@ -526,7 +526,7 @@ public partial class ARModel<T> : TimeSeriesModelBase<T>
                 { "MaxIterations", arOptions.MaxIterations },
                 { "Tolerance", arOptions.Tolerance }
             },
-            ModelData = SerializeForMetadata()
+            ModelDataProvider = () => SerializeForMetadata()
         };
         return metadata;
     }

--- a/src/TimeSeries/BayesianStructuralTimeSeriesModel.cs
+++ b/src/TimeSeries/BayesianStructuralTimeSeriesModel.cs
@@ -1,4 +1,4 @@
-﻿using AiDotNet.Attributes;
+using AiDotNet.Attributes;
 using AiDotNet.Autodiff;
 using AiDotNet.Enums;
 
@@ -1317,7 +1317,7 @@ public partial class BayesianStructuralTimeSeriesModel<T> : TimeSeriesModelBase<
                 { "RidgeParameter", bstsOptions.RidgeParameter },
                 { "RegressionDecompositionType", bstsOptions.RegressionDecompositionType.ToString() }
             },
-            ModelData = SerializeForMetadata()
+            ModelDataProvider = () => SerializeForMetadata()
         };
         return metadata;
     }

--- a/src/TimeSeries/DynamicRegressionWithARIMAErrors.cs
+++ b/src/TimeSeries/DynamicRegressionWithARIMAErrors.cs
@@ -1602,7 +1602,7 @@ public partial class DynamicRegressionWithARIMAErrors<T> : TimeSeriesModelBase<T
                 { "DecompositionType", options.DecompositionType },
                 { "Regularization", options.Regularization?.GetType().Name ?? "None" }
             },
-            ModelData = SerializeForMetadata()
+            ModelDataProvider = () => SerializeForMetadata()
         };
 
         return metadata;

--- a/src/TimeSeries/ExponentialSmoothingModel.cs
+++ b/src/TimeSeries/ExponentialSmoothingModel.cs
@@ -760,7 +760,7 @@ public partial class ExponentialSmoothingModel<T> : TimeSeriesModelBase<T>
                 { "UseSeasonal", EsOptions.UseSeasonal },
                 { "SeasonalPeriod", EsOptions.SeasonalPeriod }
             },
-            ModelData = SerializeForMetadata()
+            ModelDataProvider = () => SerializeForMetadata()
         };
 
         return metadata;

--- a/src/TimeSeries/GARCHModel.cs
+++ b/src/TimeSeries/GARCHModel.cs
@@ -1023,7 +1023,7 @@ public partial class GARCHModel<T> : TimeSeriesModelBase<T>
                 { "GARCHOrder", _garchOptions.GARCHOrder },
                 { "UseMeanModel", _meanModel != null },
             },
-            ModelData = SerializeForMetadata()
+            ModelDataProvider = () => SerializeForMetadata()
         };
         return metadata;
     }

--- a/src/TimeSeries/InterventionAnalysisModel.cs
+++ b/src/TimeSeries/InterventionAnalysisModel.cs
@@ -790,7 +790,7 @@ public partial class InterventionAnalysisModel<T> : TimeSeriesModelBase<T>
                 { "MAOrder", _iaOptions.MAOrder },
                 { "InterventionCount", _iaOptions.Interventions.Count },
             },
-            ModelData = SerializeForMetadata()
+            ModelDataProvider = () => SerializeForMetadata()
         };
 
         return metadata;

--- a/src/TimeSeries/MAModel.cs
+++ b/src/TimeSeries/MAModel.cs
@@ -1061,7 +1061,7 @@ public partial class MAModel<T> : TimeSeriesModelBase<T>
                 // Add specific coefficient values for inspection
                 { "MACoefficients", _maCoefficients.Select(c => Convert.ToDouble(c)).ToArray() }
             },
-            ModelData = SerializeForMetadata()
+            ModelDataProvider = () => SerializeForMetadata()
         };
 
         return metadata;

--- a/src/TimeSeries/NeuralNetworkARIMAModel.cs
+++ b/src/TimeSeries/NeuralNetworkARIMAModel.cs
@@ -902,7 +902,7 @@ public partial class NeuralNetworkARIMAModel<T> : TimeSeriesModelBase<T>
                 { "AR Parameters", _arParameters },
                 { "MA Parameters", _maParameters }
             },
-            ModelData = SerializeForMetadata()
+            ModelDataProvider = () => SerializeForMetadata()
         };
 
         return metaData;

--- a/src/TimeSeries/ProphetModel.cs
+++ b/src/TimeSeries/ProphetModel.cs
@@ -1,4 +1,4 @@
-﻿using AiDotNet.Attributes;
+using AiDotNet.Attributes;
 using AiDotNet.Autodiff;
 using AiDotNet.Enums;
 using AiDotNet.Helpers;
@@ -1219,7 +1219,9 @@ public partial class ProphetModel<T, TInput, TOutput> : TimeSeriesModelBase<T>
         metadata.AdditionalInfo["StateSize"] = GetStateSize();
 
         // Include serialized model data
-        metadata.ModelData = SerializeForMetadata();
+        // Deferred: the metadata object already exists here, so this is the
+        // SetModelDataProvider form of ModelDataProvider = () => ... (#2096).
+        metadata.SetModelDataProvider(() => SerializeForMetadata());
 
         return metadata;
     }

--- a/src/TimeSeries/SARIMAModel.cs
+++ b/src/TimeSeries/SARIMAModel.cs
@@ -994,7 +994,7 @@ public partial class SARIMAModel<T> : TimeSeriesModelBase<T>
                 { "MaxIterations", _sarimaOptions.MaxIterations },
                 { "Tolerance", _sarimaOptions.Tolerance }
             },
-            ModelData = SerializeForMetadata()
+            ModelDataProvider = () => SerializeForMetadata()
         };
 
         return metadata;

--- a/src/TimeSeries/STLDecomposition.cs
+++ b/src/TimeSeries/STLDecomposition.cs
@@ -1,4 +1,4 @@
-﻿using AiDotNet.Attributes;
+using AiDotNet.Attributes;
 using AiDotNet.Autodiff;
 using AiDotNet.Enums;
 
@@ -1021,7 +1021,7 @@ public partial class STLDecomposition<T> : TimeSeriesModelBase<T>
                 { "SeasonalStrength", Convert.ToDouble(CalculateSeasonalStrength()) },
                 { "TrendStrength", Convert.ToDouble(CalculateTrendStrength()) }
             },
-            ModelData = SerializeForMetadata()
+            ModelDataProvider = () => SerializeForMetadata()
         };
 
         return metadata;

--- a/src/TimeSeries/SpectralAnalysisModel.cs
+++ b/src/TimeSeries/SpectralAnalysisModel.cs
@@ -1,4 +1,4 @@
-﻿using AiDotNet.Attributes;
+using AiDotNet.Attributes;
 using AiDotNet.Autodiff;
 using AiDotNet.Enums;
 
@@ -601,7 +601,9 @@ public partial class SpectralAnalysisModel<T> : TimeSeriesModelBase<T>
         }
 
         // Add the serialized model data
-        metadata.ModelData = SerializeForMetadata();
+        // Deferred: the metadata object already exists here, so this is the
+        // SetModelDataProvider form of ModelDataProvider = () => ... (#2096).
+        metadata.SetModelDataProvider(() => SerializeForMetadata());
 
         return metadata;
     }

--- a/src/TimeSeries/StateSpaceModel.cs
+++ b/src/TimeSeries/StateSpaceModel.cs
@@ -1,4 +1,4 @@
-﻿using AiDotNet.Attributes;
+using AiDotNet.Attributes;
 using AiDotNet.Autodiff;
 using AiDotNet.Enums;
 
@@ -705,7 +705,7 @@ public partial class StateSpaceModel<T> : TimeSeriesModelBase<T>
                 { "ProcessNoiseDimensions", $"{_processNoise.Rows}x{_processNoise.Columns}" },
                 { "ObservationNoiseDimensions", $"{_observationNoise.Rows}x{_observationNoise.Columns}" }
             },
-            ModelData = SerializeForMetadata()
+            ModelDataProvider = () => SerializeForMetadata()
         };
 
         return metadata;

--- a/src/TimeSeries/TBATSModel.cs
+++ b/src/TimeSeries/TBATSModel.cs
@@ -1,4 +1,4 @@
-﻿using AiDotNet.Attributes;
+using AiDotNet.Attributes;
 using AiDotNet.Autodiff;
 using AiDotNet.Enums;
 using Newtonsoft.Json;
@@ -1187,7 +1187,7 @@ public partial class TBATSModel<T> : TimeSeriesModelBase<T>
                 { "LastLevel", _level.Length > 0 ? Convert.ToDouble(_level[_level.Length - 1]) : 0 },
                 { "LastTrend", _trend.Length > 0 ? Convert.ToDouble(_trend[_trend.Length - 1]) : 0 }
             },
-            ModelData = SerializeForMetadata()
+            ModelDataProvider = () => SerializeForMetadata()
         };
 
         return metadata;

--- a/src/TimeSeries/TransferFunctionModel.cs
+++ b/src/TimeSeries/TransferFunctionModel.cs
@@ -682,7 +682,7 @@ public partial class TransferFunctionModel<T> : TimeSeriesModelBase<T>
                 { "ResidualsMean", _residuals.Length > 0 ? Convert.ToDouble(_residuals.Mean()) : 0.0 },
                 { "ResidualsStdDev", _residuals.Length > 0 ? Convert.ToDouble(_residuals.StandardDeviation()) : 0.0 }
             },
-            ModelData = SerializeForMetadata()
+            ModelDataProvider = () => SerializeForMetadata()
         };
 
         return metadata;

--- a/src/TimeSeries/UnobservedComponentsModel.cs
+++ b/src/TimeSeries/UnobservedComponentsModel.cs
@@ -1790,7 +1790,7 @@ public partial class UnobservedComponentsModel<T, TInput, TOutput> : TimeSeriesM
                 { "SeasonalAmplitude", _seasonal.Length > 0 ? Convert.ToDouble(NumOps.Subtract(_seasonal.Max(), _seasonal.Min())) : 0.0 },
                 { "IrregularStdDev", _irregular.Length > 0 ? Convert.ToDouble(_irregular.StandardDeviation()) : 0.0 }
             },
-            ModelData = SerializeForMetadata()
+            ModelDataProvider = () => SerializeForMetadata()
         };
 
         return metadata;

--- a/src/TimeSeries/VectorAutoRegressionModel.cs
+++ b/src/TimeSeries/VectorAutoRegressionModel.cs
@@ -1218,7 +1218,7 @@ public partial class VectorAutoRegressionModel<T> : TimeSeriesModelBase<T>, IMul
                 { "NumberOfObservations", _residuals.Rows + _varOptions.Lag },
                 { "NumberOfParameters", _varOptions.OutputDimension * (_varOptions.OutputDimension * _varOptions.Lag + 1) }
             },
-            ModelData = SerializeForMetadata()
+            ModelDataProvider = () => SerializeForMetadata()
         };
 
         // Add residual statistics if available

--- a/src/Video/ActionRecognition/SlowFast.cs
+++ b/src/Video/ActionRecognition/SlowFast.cs
@@ -685,7 +685,7 @@ public partial class SlowFast<T> : NeuralNetworkBase<T>
             { "Alpha", _alpha },
             { "UseNativeMode", _useNativeMode }
         },
-        ModelData = _useNativeMode ? this.Serialize() : []
+        ModelDataProvider = () => _useNativeMode ? this.Serialize() : []
     };
 
     /// <summary>

--- a/src/Video/ActionRecognition/VideoMAE.cs
+++ b/src/Video/ActionRecognition/VideoMAE.cs
@@ -914,7 +914,7 @@ public partial class VideoMAE<T> : NeuralNetworkBase<T>
         return new ModelMetadata<T>
         {
             AdditionalInfo = additionalInfo,
-            ModelData = SerializeForMetadata()
+            ModelDataProvider = () => SerializeForMetadata()
         };
     }
 

--- a/src/Video/Denoising/BSVD.cs
+++ b/src/Video/Denoising/BSVD.cs
@@ -263,7 +263,7 @@ public partial class BSVD<T> : VideoDenoisingBase<T>
                 { "BufferDim", _options.BufferDim },
                 { "NumLevels", _options.NumLevels }
             },
-            ModelData = SerializeForMetadata()
+            ModelDataProvider = () => SerializeForMetadata()
         };
     }
 

--- a/src/Video/Denoising/FastDVDNet.cs
+++ b/src/Video/Denoising/FastDVDNet.cs
@@ -1,4 +1,4 @@
-﻿using System.IO;
+using System.IO;
 using AiDotNet.Attributes;
 using AiDotNet.Enums;
 using AiDotNet.Extensions;
@@ -442,7 +442,7 @@ public partial class FastDVDNet<T> : VideoDenoisingBase<T>
             { "ModelName", "FastDVDNet" }, { "NumFeatures", _numFeatures },
             { "NumInputFrames", _numInputFrames }
         },
-        ModelData = _useNativeMode ? this.Serialize() : []
+        ModelDataProvider = () => _useNativeMode ? this.Serialize() : []
     };
 
 

--- a/src/Video/Denoising/FloRNN.cs
+++ b/src/Video/Denoising/FloRNN.cs
@@ -170,7 +170,7 @@ public partial class FloRNN<T> : VideoDenoisingBase<T>
                 { "HiddenDim", _options.HiddenDim },
                 { "NumFlowScales", _options.NumFlowScales }
             },
-            ModelData = SerializeForMetadata()
+            ModelDataProvider = () => SerializeForMetadata()
         };
     }
 

--- a/src/Video/Denoising/LiteDVDNet.cs
+++ b/src/Video/Denoising/LiteDVDNet.cs
@@ -274,7 +274,7 @@ public partial class LiteDVDNet<T> : VideoDenoisingBase<T>
                 { "TemporalWindowSize", _options.TemporalWindowSize },
                 { "ExpansionFactor", _options.ExpansionFactor }
             },
-            ModelData = SerializeForMetadata()
+            ModelDataProvider = () => SerializeForMetadata()
         };
     }
 

--- a/src/Video/Denoising/ShiftNet.cs
+++ b/src/Video/Denoising/ShiftNet.cs
@@ -186,7 +186,7 @@ public partial class ShiftNet<T> : VideoDenoisingBase<T>
                 { "NumShifts", _options.NumShifts },
                 { "ShiftRadius", _options.ShiftRadius }
             },
-            ModelData = SerializeForMetadata()
+            ModelDataProvider = () => SerializeForMetadata()
         };
     }
 

--- a/src/Video/Denoising/UDVD.cs
+++ b/src/Video/Denoising/UDVD.cs
@@ -163,7 +163,7 @@ public partial class UDVD<T> : VideoDenoisingBase<T>
                 { "NumResBlocks", _options.NumResBlocks },
                 { "TemporalBufferSize", _options.TemporalBufferSize }
             },
-            ModelData = SerializeForMetadata()
+            ModelDataProvider = () => SerializeForMetadata()
         };
     }
 

--- a/src/Video/Depth/DepthAnythingV2.cs
+++ b/src/Video/Depth/DepthAnythingV2.cs
@@ -644,7 +644,7 @@ public partial class DepthAnythingV2<T> : NeuralNetworkBase<T>
         return new ModelMetadata<T>
         {
             AdditionalInfo = additionalInfo,
-            ModelData = SerializeForMetadata()
+            ModelDataProvider = () => SerializeForMetadata()
         };
     }
 

--- a/src/Video/Depth/MiDaS.cs
+++ b/src/Video/Depth/MiDaS.cs
@@ -1,4 +1,4 @@
-﻿using System.IO;
+using System.IO;
 using AiDotNet.Attributes;
 using AiDotNet.Enums;
 using AiDotNet.Helpers;
@@ -350,7 +350,7 @@ public partial class MiDaS<T> : NeuralNetworkBase<T>
             { "Variant", _variant.ToString() },
             { "UseNativeMode", _useNativeMode }
         },
-        ModelData = _useNativeMode ? this.Serialize() : []
+        ModelDataProvider = () => _useNativeMode ? this.Serialize() : []
     };
 
 

--- a/src/Video/Enhancement/EDVR.cs
+++ b/src/Video/Enhancement/EDVR.cs
@@ -1,4 +1,4 @@
-﻿using System.IO;
+using System.IO;
 using AiDotNet.Attributes;
 using AiDotNet.Enums;
 using AiDotNet.Helpers;
@@ -300,7 +300,7 @@ public partial class EDVR<T> : VideoSuperResolutionBase<T>
             { "ModelName", "EDVR" }, { "NumFeatures", _numFeatures }, { "NumFrames", _numFrames },
             { "NumBlocks", _numBlocks }, { "ScaleFactor", _scaleFactor }, { "UseNativeMode", _useNativeMode }
         },
-        ModelData = _useNativeMode ? this.Serialize() : []
+        ModelDataProvider = () => _useNativeMode ? this.Serialize() : []
     };
 
 

--- a/src/Video/FrameInterpolation/FILM.cs
+++ b/src/Video/FrameInterpolation/FILM.cs
@@ -606,7 +606,7 @@ public partial class FILM<T> : FrameInterpolationBase<T>
                 { "InputWidth", _width },
                 { "NumScales", _numScales }
             },
-            ModelData = SerializeForMetadata()
+            ModelDataProvider = () => SerializeForMetadata()
         };
     }
 

--- a/src/Video/FrameInterpolation/RIFE.cs
+++ b/src/Video/FrameInterpolation/RIFE.cs
@@ -944,7 +944,7 @@ public partial class RIFE<T> : FrameInterpolationBase<T>
         return new ModelMetadata<T>
         {
             AdditionalInfo = additionalInfo,
-            ModelData = SerializeForMetadata()
+            ModelDataProvider = () => SerializeForMetadata()
         };
     }
 

--- a/src/Video/FrameInterpolation/ToonCrafter.cs
+++ b/src/Video/FrameInterpolation/ToonCrafter.cs
@@ -189,7 +189,7 @@ public partial class ToonCrafter<T> : FrameInterpolationBase<T>
                 { "GuidanceScale", _options.GuidanceScale },
                 { "Complexity", _options.NumDiffusionSteps * _options.NumResBlocks }
             },
-            ModelData = SerializeForMetadata()
+            ModelDataProvider = () => SerializeForMetadata()
         };
     }
 

--- a/src/Video/FrameInterpolation/UPRNet.cs
+++ b/src/Video/FrameInterpolation/UPRNet.cs
@@ -516,7 +516,7 @@ public partial class UPRNet<T> : FrameInterpolationBase<T>
             ["RecurrentSharing"] = "one shared motion estimator and synthesis network across levels",
             ["Warp"] = "normalized forward soft splat"
         },
-        ModelData = SerializeForMetadata()
+        ModelDataProvider = () => SerializeForMetadata()
     };
 
     /// <inheritdoc />

--- a/src/Video/FrameInterpolation/VFIMamba.cs
+++ b/src/Video/FrameInterpolation/VFIMamba.cs
@@ -192,7 +192,7 @@ public partial class VFIMamba<T> : FrameInterpolationBase<T>
                 { "NumStages", _options.NumStages },
                 { "Complexity", _options.NumMambaBlocks * _options.NumStages }
             },
-            ModelData = SerializeForMetadata()
+            ModelDataProvider = () => SerializeForMetadata()
         };
     }
 

--- a/src/Video/FrameInterpolation/VFIT.cs
+++ b/src/Video/FrameInterpolation/VFIT.cs
@@ -189,7 +189,7 @@ public partial class VFIT<T> : FrameInterpolationBase<T>
                 { "NumHeads", _options.NumHeads },
                 { "Complexity", _options.NumTemporalLayers * _options.NumSpatialLayers }
             },
-            ModelData = SerializeForMetadata()
+            ModelDataProvider = () => SerializeForMetadata()
         };
     }
 

--- a/src/Video/FrameInterpolation/VFIformer.cs
+++ b/src/Video/FrameInterpolation/VFIformer.cs
@@ -210,7 +210,7 @@ public partial class VFIformer<T> : FrameInterpolationBase<T>
                 { "NumDeformablePoints", _options.NumDeformablePoints },
                 { "Complexity", _options.NumEncoderLayers * _options.NumDecoderLayers }
             },
-            ModelData = SerializeForMetadata()
+            ModelDataProvider = () => SerializeForMetadata()
         };
     }
 

--- a/src/Video/FrameInterpolation/XVFI.cs
+++ b/src/Video/FrameInterpolation/XVFI.cs
@@ -196,7 +196,7 @@ public partial class XVFI<T> : FrameInterpolationBase<T>
                 { "UseComplementaryFlow", _options.UseComplementaryFlow },
                 { "Complexity", _options.NumPyramidLevels * _options.NumResBlocks }
             },
-            ModelData = SerializeForMetadata()
+            ModelDataProvider = () => SerializeForMetadata()
         };
     }
 

--- a/src/Video/Generation/OpenSora.cs
+++ b/src/Video/Generation/OpenSora.cs
@@ -1,4 +1,4 @@
-﻿using System.IO;
+using System.IO;
 using AiDotNet.Attributes;
 using AiDotNet.Enums;
 using AiDotNet.Extensions;
@@ -1175,7 +1175,7 @@ public partial class OpenSora<T> : NeuralNetworkBase<T>
             { "NumLayers", _numLayers },
             { "GuidanceScale", _guidanceScale }
         },
-        ModelData = SerializeForMetadata()
+        ModelDataProvider = () => SerializeForMetadata()
     };
 
 

--- a/src/Video/Generation/StableVideoDiffusion.cs
+++ b/src/Video/Generation/StableVideoDiffusion.cs
@@ -1197,7 +1197,7 @@ public partial class StableVideoDiffusion<T> : NeuralNetworkBase<T>
         return new ModelMetadata<T>
         {
             AdditionalInfo = additionalInfo,
-            ModelData = SerializeForMetadata()
+            ModelDataProvider = () => SerializeForMetadata()
         };
     }
 

--- a/src/Video/Inpainting/AVID.cs
+++ b/src/Video/Inpainting/AVID.cs
@@ -197,7 +197,7 @@ public partial class AVID<T> : VideoInpaintingBase<T>
                 { "NumResBlocks", _options.NumResBlocks },
                 { "NumHeads", _options.NumHeads }
             },
-            ModelData = SerializeForMetadata()
+            ModelDataProvider = () => SerializeForMetadata()
         };
     }
 

--- a/src/Video/Inpainting/E2FGVI.cs
+++ b/src/Video/Inpainting/E2FGVI.cs
@@ -1,4 +1,4 @@
-﻿using System.IO;
+using System.IO;
 using AiDotNet.Attributes;
 using AiDotNet.Enums;
 using AiDotNet.Helpers;
@@ -797,7 +797,7 @@ public partial class E2FGVI<T> : VideoInpaintingBase<T>
             { "InputHeight", _height },
             { "InputWidth", _width }
         },
-        ModelData = SerializeForMetadata()
+        ModelDataProvider = () => SerializeForMetadata()
     };
 
 

--- a/src/Video/Inpainting/FlowLens.cs
+++ b/src/Video/Inpainting/FlowLens.cs
@@ -204,7 +204,7 @@ public partial class FlowLens<T> : VideoInpaintingBase<T>
                 { "NumLevels", _options.NumLevels },
                 { "NumResBlocks", _options.NumResBlocks }
             },
-            ModelData = SerializeForMetadata()
+            ModelDataProvider = () => SerializeForMetadata()
         };
     }
 

--- a/src/Video/Inpainting/FuseFormer.cs
+++ b/src/Video/Inpainting/FuseFormer.cs
@@ -198,7 +198,7 @@ public partial class FuseFormer<T> : VideoInpaintingBase<T>
                 { "NumHeads", _options.NumHeads },
                 { "PatchSize", _options.PatchSize }
             },
-            ModelData = SerializeForMetadata()
+            ModelDataProvider = () => SerializeForMetadata()
         };
     }
 

--- a/src/Video/Inpainting/ProPainter.cs
+++ b/src/Video/Inpainting/ProPainter.cs
@@ -1000,7 +1000,7 @@ public partial class ProPainter<T> : VideoInpaintingBase<T>
         return new ModelMetadata<T>
         {
             AdditionalInfo = additionalInfo,
-            ModelData = SerializeForMetadata()
+            ModelDataProvider = () => SerializeForMetadata()
         };
     }
 

--- a/src/Video/Inpainting/STTN.cs
+++ b/src/Video/Inpainting/STTN.cs
@@ -198,7 +198,7 @@ public partial class STTN<T> : VideoInpaintingBase<T>
                 { "NumHeads", _options.NumHeads },
                 { "NumScales", _options.NumScales }
             },
-            ModelData = SerializeForMetadata()
+            ModelDataProvider = () => SerializeForMetadata()
         };
     }
 

--- a/src/Video/Matting/RVM.cs
+++ b/src/Video/Matting/RVM.cs
@@ -1,4 +1,4 @@
-﻿using System.IO;
+using System.IO;
 using AiDotNet.Attributes;
 using AiDotNet.Enums;
 using AiDotNet.Helpers;
@@ -372,7 +372,7 @@ public partial class RVM<T> : NeuralNetworkBase<T>
             { "ModelName", "RVM" }, { "NumFeatures", _numFeatures },
             { "ImageHeight", _imageHeight }, { "ImageWidth", _imageWidth }
         },
-        ModelData = _useNativeMode ? this.Serialize() : []
+        ModelDataProvider = () => _useNativeMode ? this.Serialize() : []
     };
 
 

--- a/src/Video/Motion/DKM.cs
+++ b/src/Video/Motion/DKM.cs
@@ -209,7 +209,7 @@ public partial class DKM<T> : OpticalFlowBase<T>
                 { "NumFeatures", _numFeatures },
                 { "NumLayers", _numLayers }
             },
-            ModelData = SerializeForMetadata()
+            ModelDataProvider = () => SerializeForMetadata()
         };
     }
 

--- a/src/Video/Motion/DPFlow.cs
+++ b/src/Video/Motion/DPFlow.cs
@@ -248,7 +248,7 @@ public partial class DPFlow<T> : OpticalFlowBase<T>
                 { "NumFeatures", _numFeatures },
                 { "NumLayers", _numLayers }
             },
-            ModelData = SerializeForMetadata()
+            ModelDataProvider = () => SerializeForMetadata()
         };
     }
 

--- a/src/Video/Motion/FlowDiffuser.cs
+++ b/src/Video/Motion/FlowDiffuser.cs
@@ -209,7 +209,7 @@ public partial class FlowDiffuser<T> : OpticalFlowBase<T>
                 { "NumFeatures", _numFeatures },
                 { "NumLayers", _numLayers }
             },
-            ModelData = SerializeForMetadata()
+            ModelDataProvider = () => SerializeForMetadata()
         };
     }
 

--- a/src/Video/Motion/FlowFormer.cs
+++ b/src/Video/Motion/FlowFormer.cs
@@ -1,4 +1,4 @@
-﻿using System.IO;
+using System.IO;
 using AiDotNet.Attributes;
 using AiDotNet.Enums;
 using AiDotNet.Helpers;
@@ -346,7 +346,7 @@ public partial class FlowFormer<T> : OpticalFlowBase<T>
             { "ModelName", "FlowFormer" }, { "EmbedDim", _embedDim },
             { "NumLayers", _numLayers }, { "NumIterations", _numIterations }
         },
-        ModelData = _useNativeMode ? this.Serialize() : []
+        ModelDataProvider = () => _useNativeMode ? this.Serialize() : []
     };
 
 

--- a/src/Video/Motion/FlowFormerPlusPlus.cs
+++ b/src/Video/Motion/FlowFormerPlusPlus.cs
@@ -218,7 +218,7 @@ public partial class FlowFormerPlusPlus<T> : OpticalFlowBase<T>
                 { "NumFeatures", _numFeatures },
                 { "NumLayers", _numLayers }
             },
-            ModelData = SerializeForMetadata()
+            ModelDataProvider = () => SerializeForMetadata()
         };
     }
 

--- a/src/Video/Motion/GMFlow.cs
+++ b/src/Video/Motion/GMFlow.cs
@@ -670,7 +670,7 @@ public partial class GMFlow<T> : OpticalFlowBase<T>
             { "InputWidth", _width },
             { "NumTransformerLayers", _numTransformerLayers }
         },
-        ModelData = SerializeForMetadata()
+        ModelDataProvider = () => SerializeForMetadata()
     };
 
 

--- a/src/Video/Motion/MemFlow.cs
+++ b/src/Video/Motion/MemFlow.cs
@@ -217,7 +217,7 @@ public partial class MemFlow<T> : OpticalFlowBase<T>
                 { "NumFeatures", _numFeatures },
                 { "NumLayers", _numLayers }
             },
-            ModelData = SerializeForMetadata()
+            ModelDataProvider = () => SerializeForMetadata()
         };
     }
 

--- a/src/Video/Motion/NeuFlowV2.cs
+++ b/src/Video/Motion/NeuFlowV2.cs
@@ -210,7 +210,7 @@ public partial class NeuFlowV2<T> : OpticalFlowBase<T>
                 { "NumFeatures", _numFeatures },
                 { "NumLayers", _numLayers }
             },
-            ModelData = SerializeForMetadata()
+            ModelDataProvider = () => SerializeForMetadata()
         };
     }
 

--- a/src/Video/Motion/RAFT.cs
+++ b/src/Video/Motion/RAFT.cs
@@ -715,7 +715,7 @@ public partial class RAFT<T> : OpticalFlowBase<T>
         return new ModelMetadata<T>
         {
             AdditionalInfo = additionalInfo,
-            ModelData = SerializeForMetadata()
+            ModelDataProvider = () => SerializeForMetadata()
         };
     }
 

--- a/src/Video/Motion/RAPIDFlow.cs
+++ b/src/Video/Motion/RAPIDFlow.cs
@@ -428,7 +428,7 @@ public partial class RAPIDFlow<T> : OpticalFlowBase<T>
                 { "Level3Channels", Level3Channels },
                 { "NumRefinementIterations", _numRefinementIterations }
             },
-            ModelData = SerializeForMetadata()
+            ModelDataProvider = () => SerializeForMetadata()
         };
     }
 

--- a/src/Video/Motion/RPKNet.cs
+++ b/src/Video/Motion/RPKNet.cs
@@ -212,7 +212,7 @@ public partial class RPKNet<T> : OpticalFlowBase<T>
                 { "NumFeatures", _numFeatures },
                 { "NumLayers", _numLayers }
             },
-            ModelData = SerializeForMetadata()
+            ModelDataProvider = () => SerializeForMetadata()
         };
     }
 

--- a/src/Video/Motion/RoMa.cs
+++ b/src/Video/Motion/RoMa.cs
@@ -197,7 +197,7 @@ public partial class RoMa<T> : OpticalFlowBase<T>
                 { "NumFeatures", _numFeatures },
                 { "NumLayers", _numLayers }
             },
-            ModelData = SerializeForMetadata()
+            ModelDataProvider = () => SerializeForMetadata()
         };
     }
 

--- a/src/Video/Motion/SEARAFT.cs
+++ b/src/Video/Motion/SEARAFT.cs
@@ -200,7 +200,7 @@ public partial class SEARAFT<T> : OpticalFlowBase<T>
                 { "NumFeatures", _numFeatures },
                 { "NumLayers", _numLayers }
             },
-            ModelData = SerializeForMetadata()
+            ModelDataProvider = () => SerializeForMetadata()
         };
     }
 

--- a/src/Video/Motion/SKFlow.cs
+++ b/src/Video/Motion/SKFlow.cs
@@ -197,7 +197,7 @@ public partial class SKFlow<T> : OpticalFlowBase<T>
                 { "NumFeatures", _numFeatures },
                 { "NumLayers", _numLayers }
             },
-            ModelData = SerializeForMetadata()
+            ModelDataProvider = () => SerializeForMetadata()
         };
     }
 

--- a/src/Video/Motion/UFM.cs
+++ b/src/Video/Motion/UFM.cs
@@ -225,7 +225,7 @@ public partial class UFM<T> : OpticalFlowBase<T>
                 { "NumFeatures", _numFeatures },
                 { "NumLayers", _numLayers }
             },
-            ModelData = SerializeForMetadata()
+            ModelDataProvider = () => SerializeForMetadata()
         };
     }
 

--- a/src/Video/Motion/UniMatch.cs
+++ b/src/Video/Motion/UniMatch.cs
@@ -207,7 +207,7 @@ public partial class UniMatch<T> : OpticalFlowBase<T>
                 { "NumFeatures", _numFeatures },
                 { "NumLayers", _numLayers }
             },
-            ModelData = SerializeForMetadata()
+            ModelDataProvider = () => SerializeForMetadata()
         };
     }
 

--- a/src/Video/Motion/VideoFlow.cs
+++ b/src/Video/Motion/VideoFlow.cs
@@ -211,7 +211,7 @@ public partial class VideoFlow<T> : OpticalFlowBase<T>
                 { "NumFeatures", _numFeatures },
                 { "NumLayers", _numLayers }
             },
-            ModelData = SerializeForMetadata()
+            ModelDataProvider = () => SerializeForMetadata()
         };
     }
 

--- a/src/Video/Segmentation/SAM2.cs
+++ b/src/Video/Segmentation/SAM2.cs
@@ -1718,7 +1718,7 @@ public partial class SAM2<T> : NeuralNetworkBase<T>
         return new ModelMetadata<T>
         {
             AdditionalInfo = additionalInfo,
-            ModelData = SerializeForMetadata()
+            ModelDataProvider = () => SerializeForMetadata()
         };
     }
 

--- a/src/Video/Stabilization/DIFRINT.cs
+++ b/src/Video/Stabilization/DIFRINT.cs
@@ -1,4 +1,4 @@
-﻿using System.IO;
+using System.IO;
 using AiDotNet.Attributes;
 using AiDotNet.Enums;
 using AiDotNet.Helpers;
@@ -582,7 +582,7 @@ public partial class DIFRINT<T> : VideoStabilizationBase<T>
         {
             { "ModelName", "DIFRINT" }, { "NumFeatures", _numFeatures }, { "NumIterations", _numIterations }
         },
-        ModelData = _useNativeMode ? this.Serialize() : []
+        ModelDataProvider = () => _useNativeMode ? this.Serialize() : []
     };
 
 

--- a/src/Video/Stabilization/DUT.cs
+++ b/src/Video/Stabilization/DUT.cs
@@ -163,7 +163,7 @@ public partial class DUT<T> : VideoStabilizationBase<T>
                 { "NumResBlocks", _options.NumResBlocks },
                 { "TemporalWindowSize", _options.TemporalWindowSize }
             },
-            ModelData = SerializeForMetadata()
+            ModelDataProvider = () => SerializeForMetadata()
         };
     }
 

--- a/src/Video/Stabilization/FuSta.cs
+++ b/src/Video/Stabilization/FuSta.cs
@@ -166,7 +166,7 @@ public partial class FuSta<T> : VideoStabilizationBase<T>
                 { "NumResBlocks", _options.NumResBlocks },
                 { "NumHeads", _options.NumHeads }
             },
-            ModelData = SerializeForMetadata()
+            ModelDataProvider = () => SerializeForMetadata()
         };
     }
 

--- a/src/Video/Stabilization/GaVS.cs
+++ b/src/Video/Stabilization/GaVS.cs
@@ -164,7 +164,7 @@ public partial class GaVS<T> : VideoStabilizationBase<T>
                 { "GazeHiddenDim", _options.GazeHiddenDim },
                 { "SmoothingWindow", _options.SmoothingWindow }
             },
-            ModelData = SerializeForMetadata()
+            ModelDataProvider = () => SerializeForMetadata()
         };
     }
 

--- a/src/Video/Stabilization/PWStableNet.cs
+++ b/src/Video/Stabilization/PWStableNet.cs
@@ -162,7 +162,7 @@ public partial class PWStableNet<T> : VideoStabilizationBase<T>
                 { "GridSize", _options.GridSize },
                 { "NumResBlocks", _options.NumResBlocks }
             },
-            ModelData = SerializeForMetadata()
+            ModelDataProvider = () => SerializeForMetadata()
         };
     }
 

--- a/src/Video/Stabilization/StabStitch.cs
+++ b/src/Video/Stabilization/StabStitch.cs
@@ -162,7 +162,7 @@ public partial class StabStitch<T> : VideoStabilizationBase<T>
                 { "MeshGridRows", _options.MeshGridRows },
                 { "MeshGridCols", _options.MeshGridCols }
             },
-            ModelData = SerializeForMetadata()
+            ModelDataProvider = () => SerializeForMetadata()
         };
     }
 

--- a/src/Video/Stabilization/ThreeDMF.cs
+++ b/src/Video/Stabilization/ThreeDMF.cs
@@ -162,7 +162,7 @@ public partial class ThreeDMF<T> : VideoStabilizationBase<T>
                 { "NumMotionIters", _options.NumMotionIters },
                 { "NumResBlocks", _options.NumResBlocks }
             },
-            ModelData = SerializeForMetadata()
+            ModelDataProvider = () => SerializeForMetadata()
         };
     }
 

--- a/src/Video/Tracking/ByteTrack.cs
+++ b/src/Video/Tracking/ByteTrack.cs
@@ -397,7 +397,7 @@ public partial class ByteTrack<T> : NeuralNetworkBase<T>
             { "ModelName", "ByteTrack" }, { "NumClasses", _numClasses },
             { "HighThreshold", _highThreshold }, { "LowThreshold", _lowThreshold }
         },
-        ModelData = _useNativeMode ? this.Serialize() : []
+        ModelDataProvider = () => _useNativeMode ? this.Serialize() : []
     };
 
 

--- a/src/Video/Understanding/VideoCLIP.cs
+++ b/src/Video/Understanding/VideoCLIP.cs
@@ -1154,7 +1154,7 @@ public partial class VideoCLIP<T> : NeuralNetworkBase<T>
         return new ModelMetadata<T>
         {
             AdditionalInfo = additionalInfo,
-            ModelData = SerializeForMetadata()
+            ModelDataProvider = () => SerializeForMetadata()
         };
     }
 

--- a/tests/AiDotNet.Tests/UnitTests/Models/EagerModelDataAssignmentGuardTests.cs
+++ b/tests/AiDotNet.Tests/UnitTests/Models/EagerModelDataAssignmentGuardTests.cs
@@ -1,0 +1,127 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using Xunit;
+
+namespace AiDotNet.Tests.UnitTests.Models;
+
+/// <summary>
+/// No shipped model may build its metadata bytes eagerly (#2096, #1830).
+/// </summary>
+/// <remarks>
+/// <para>
+/// <see cref="AiDotNet.Models.ModelMetadata{T}"/> materializes <c>ModelData</c> on first read via
+/// <c>ModelDataProvider</c>, but nothing stops a model from assigning <c>ModelData</c> directly
+/// again. That is precisely how this drifted: #1830 fixed the sites that existed then, and 290 more
+/// were either missed or added afterwards, including 15 in the crash-risk form
+/// <c>ModelData = this.Serialize()</c> that #1830 was specifically about.
+/// </para>
+/// <para>
+/// The existing <c>ModelMetadataLazyModelDataTests</c> prove the mechanism defers correctly. They
+/// cannot prove the models use it, and a per-model behavioural test would cover only the models
+/// someone remembered to list. Reading the source is the only check that scales to every model and
+/// catches the next one added.
+/// </para>
+/// <para>
+/// Serializing is not merely wasted work. <c>Serialize()</c> runs
+/// <c>ModelPersistenceGuard.EnforceBeforeSerialize()</c>, so an eager assignment makes
+/// <c>AiModelBuilder.BuildAsync</c> a licensed operation; and where the call is wrapped to swallow
+/// the licence error, the caller receives an empty array indistinguishable from a model that
+/// genuinely has no weights.
+/// </para>
+/// </remarks>
+public class EagerModelDataAssignmentGuardTests
+{
+    /// <summary>
+    /// Assignments of the form <c>ModelData = ...Serialize...</c> at the start of a line.
+    /// </summary>
+    /// <remarks>
+    /// Anchored at line start so <c>SerializedModelData</c> and similar names cannot match, and
+    /// comment lines are filtered separately so the prose in ModelMetadata.cs that quotes the old
+    /// pattern is not read as code.
+    /// </remarks>
+    private static readonly Regex EagerAssignment = new(
+        @"^[ \t]*ModelData[ \t]*=[ \t]*(?<rhs>.+)$",
+        RegexOptions.Compiled);
+
+    private static readonly Regex Serializes = new(
+        @"\b(Serialize|SerializeForMetadata|SafeSerialize|SafeSerializeMaterializedModel)[ \t]*\(",
+        RegexOptions.Compiled);
+
+    [Fact]
+    public void NoShippedModelAssignsModelDataEagerly()
+    {
+        string sourceRoot = LocateSourceRoot();
+        var files = Directory.GetFiles(sourceRoot, "*.cs", SearchOption.AllDirectories);
+
+        // Non-vacuity: an empty or tiny scan must fail rather than report success. Without this a
+        // wrong path would make the whole guard pass while checking nothing.
+        Assert.True(
+            files.Length > 500,
+            $"Only {files.Length} source files found under '{sourceRoot}'; the scan is not reaching "
+            + "the library and this guard would pass without checking anything.");
+
+        var offenders = new List<string>();
+
+        foreach (string file in files)
+        {
+            string[] lines = File.ReadAllLines(file);
+            for (int i = 0; i < lines.Length; i++)
+            {
+                string trimmed = lines[i].TrimStart();
+                if (trimmed.StartsWith("//", StringComparison.Ordinal)
+                    || trimmed.StartsWith("*", StringComparison.Ordinal))
+                {
+                    continue;
+                }
+
+                Match match = EagerAssignment.Match(lines[i]);
+                if (!match.Success || !Serializes.IsMatch(match.Groups["rhs"].Value))
+                {
+                    continue;
+                }
+
+                offenders.Add(
+                    $"{Path.GetRelativePath(sourceRoot, file).Replace('\\', '/')}:{i + 1}  {trimmed}");
+            }
+        }
+
+        Assert.True(
+            offenders.Count == 0,
+            $"{offenders.Count} site(s) still serialize into ModelData eagerly. Every AiModelResult "
+            + "construction captures metadata for the model it wraps, so each of these serializes a "
+            + "full model on every BuildAsync and discards the bytes unread. Use "
+            + "'ModelDataProvider = () => <expr>' instead, which produces the bytes on first read:"
+            + Environment.NewLine
+            + string.Join(Environment.NewLine, offenders.Take(25))
+            + (offenders.Count > 25 ? $"{Environment.NewLine}... and {offenders.Count - 25} more" : string.Empty));
+    }
+
+    /// <summary>
+    /// The library's <c>src</c> directory, found by walking up to the solution file.
+    /// </summary>
+    /// <remarks>
+    /// Throws rather than skipping when the tree cannot be found. A guard that quietly opts out
+    /// when it cannot see the source is the same silent pass it exists to prevent.
+    /// </remarks>
+    private static string LocateSourceRoot()
+    {
+        var current = new DirectoryInfo(AppContext.BaseDirectory);
+        while (current is not null)
+        {
+            string candidate = Path.Combine(current.FullName, "src");
+            if (File.Exists(Path.Combine(current.FullName, "AiDotNet.sln")) && Directory.Exists(candidate))
+            {
+                return candidate;
+            }
+
+            current = current.Parent;
+        }
+
+        throw new DirectoryNotFoundException(
+            $"Could not find AiDotNet.sln walking up from '{AppContext.BaseDirectory}', so the "
+            + "source tree this guard reads is unavailable.");
+    }
+}

--- a/tests/AiDotNet.Tests/UnitTests/Models/EagerModelDataAssignmentGuardTests.cs
+++ b/tests/AiDotNet.Tests/UnitTests/Models/EagerModelDataAssignmentGuardTests.cs
@@ -35,15 +35,26 @@ namespace AiDotNet.Tests.UnitTests.Models;
 public class EagerModelDataAssignmentGuardTests
 {
     /// <summary>
-    /// Assignments of the form <c>ModelData = ...Serialize...</c> at the start of a line.
+    /// Assignments to <c>ModelData</c>, whether in an object initializer or through an instance.
     /// </summary>
     /// <remarks>
-    /// Anchored at line start so <c>SerializedModelData</c> and similar names cannot match, and
-    /// comment lines are filtered separately so the prose in ModelMetadata.cs that quotes the old
-    /// pattern is not read as code.
+    /// <para>
+    /// Two forms, because catching only the first leaves a hole exactly where the next regression
+    /// would land: <c>ModelData = ...</c> at the start of a line is the object-initializer form all
+    /// 290 converted sites used, and <c>something.ModelData = ...</c> is the post-construction form
+    /// several base classes already use for their JSON config blobs. None of those serialize weights
+    /// today, but nothing stopped one from being written that way, and a guard blind to it would
+    /// report success.
+    /// </para>
+    /// <para>
+    /// <c>SerializedModelData</c> cannot match either branch: the first is anchored at line start,
+    /// and the second requires the dot to sit immediately before <c>ModelData</c>. Comment lines are
+    /// filtered separately so the prose in ModelMetadata.cs that quotes the old pattern is not read
+    /// as code.
+    /// </para>
     /// </remarks>
     private static readonly Regex EagerAssignment = new(
-        @"^[ \t]*ModelData[ \t]*=[ \t]*(?<rhs>.+)$",
+        @"(?:^[ \t]*|\.)ModelData[ \t]*=[ \t]*(?<rhs>.+)$",
         RegexOptions.Compiled);
 
     private static readonly Regex Serializes = new(


### PR DESCRIPTION
Closes #2096.

## The defect

`AiModelResult`'s constructor captures metadata for **every** model it wraps, and these models built the bytes eagerly inside the object initializer they return from `GetModelMetadata`:

```csharp
ModelData = SerializeForMetadata()
```

So every `AiModelBuilder.BuildAsync` ran a full weight serialization the caller never asked for and discarded it unread. On a 661M-parameter model that is a complete serialization per build.

## Scope — larger and more severe than the issue states

#2096 describes 191 sites of one form. The real count on master is **292**, in five:

| count | form |
|---|---|
| 250 | `ModelData = SerializeForMetadata()` |
| 23 | `ModelData = SafeSerialize()` |
| 5 | `ModelData = SafeSerializeMaterializedModel()` |
| 12 | `ModelData = _useNativeMode ? this.Serialize() : []` / `Array.Empty<byte>()` |
| 2 | `metadata.ModelData = SerializeForMetadata();` (post-construction) |

Those 12, plus ABCNet's plain `ModelData = this.Serialize()`, are **not** the benign category the issue assumes. `Serialize()` runs `ModelPersistenceGuard.EnforceBeforeSerialize()`, so they still made `BuildAsync` a licensed operation and threw `LicenseRequiredException` out of the primary training entry point on an expired trial — the #1830 defect, in files PR #2095 did not reach.

Where the call is wrapped instead, the licence failure is invisible twice: `SerializeForMetadata` and `SafeSerialize` both catch `LicenseRequiredException` and return an empty array, so `ModelData` is indistinguishable from a model that genuinely has no weights. Deferring moves the check to the moment someone actually asks for the bytes — a real persistence action — without weakening the guard.

## The change

The mechanism already exists from #2095: `ModelMetadata<T>.ModelData` materializes on first read via an `init`-only `ModelDataProvider`. Every site becomes:

```diff
- ModelData = SerializeForMetadata()
+ ModelDataProvider = () => SerializeForMetadata()
```

The two post-construction sites use `SetModelDataProvider(() => ...)` instead, since `init`-only cannot be assigned after construction.

## Behaviour change, stated precisely

This is **not** a pure no-op, and it is worth being exact about the one observable difference.

The bytes are now produced when `ModelData` is first read rather than when `GetModelMetadata()` is called. For the overwhelmingly common case — build a model, read `ModelData` — the result is byte-for-byte what it was, produced once and cached.

It differs if the model is **mutated between metadata capture and the first read**:

```csharp
var md = model.GetModelMetadata();
model.Train(moreData);        // model changes
var bytes = md.ModelData;     // now reflects the TRAINED model, previously the pre-training one
```

That tradeoff is inherent to deferral and was already accepted when #2095 introduced `ModelDataProvider` and converted its sites; this PR applies the same semantics to the rest, so the library is at least now consistent about it. The alternative — keeping the eager path — is what makes `BuildAsync` licensed and serializes a full model per build.

Also, a licence failure that previously surfaced (or was swallowed) during `GetModelMetadata` now surfaces at the read. That is the intended correction, not a side effect.

## Why a guard test

`ModelMetadataLazyModelDataTests` (from #2095) proves the *mechanism* defers. Nothing proved the *models use it*, which is exactly how 292 sites drifted after #1830 converted the ones that existed at the time.

`EagerModelDataAssignmentGuardTests` reads the source tree and fails on any remaining eager assignment, so it catches the next model added rather than only today's set. It is built not to pass vacuously: it asserts it scanned more than 500 files, and throws rather than skipping when it cannot find `AiDotNet.sln`.

It matches both the object-initializer form and the `something.ModelData = ...` form. That second branch is not hypothetical — it is what caught `ProphetModel.cs:1222` and `SpectralAnalysisModel.cs:604`, which the first pass of this PR missed. `SerializedModelData` cannot match either branch, and `JsonConvert.SerializeObject(...)` config blobs are correctly not flagged.

## Verification

- Library builds clean, **0 errors**, across all changed files
- Guard, `ModelMetadataLazyModelDataTests` and `ModelHelperIntegrationTests` pass
- **Non-vacuous**: reintroducing a single eager assignment in `MiDaS.cs` fails the guard, naming `Video/Depth/MiDaS.cs:353`

## What this does not do

It does not change what `ModelData` returns for an unmutated model, the serialization format, or whether a genuine read is licence-checked. It moves the work from build time to first read.
