### PR TITLE
feat(#2090): phase 4 — embedding, retrieval and GAN families

### DIFF
--- a/CI_SHARD_INVENTORY.md
+++ b/CI_SHARD_INVENTORY.md
@@ -1,0 +1,119 @@
+# AiDotNet CI Shard Failure Inventory & Work-Division Plan
+
+**Source of truth:** clean `Build & SonarCloud` run on `master` @ `01a4ddb4` (Tensors **0.102.12**), run id `28023414937`.
+**Result:** **44 pass / 19 fail / 1 cancelled** (`NeuralNetworks T-Z`, runner lost) of 64 test shards.
+**Generated:** 2026-06-23. Re-run the run and re-classify before locking assignments if master has moved.
+
+> **Already fixed (do not re-investigate):** the fp32 small-M GEMM `ArrayPool` host-crash that was aborting every CNN/diffusion shard wholesale — fixed in **Tensors #672 → 0.102.12**, on master via #1667. Verified locally: `ResNetNetworkTests` 56/56, `ConvolutionalNeuralNetworkTests` 21/21.
+
+---
+
+## TL;DR — the 19 failures are 4 distinct causes, not 19 model bugs
+
+| # | Root cause | Shards | One fix greens many? |
+|---|-----------|:------:|----------------------|
+| ① | **Stack overflow** (host crash, recursion) | 4 (+1 cancelled) | Likely yes — probably one shared recursion |
+| ② | **Inference arena corruption** (`#1661`, default-ON) | 3 (+~7 in ③) | **Yes — biggest lever** |
+| ③ | **Host killed mid-run** (arena-crash *or* OOM; log truncated) | 8 | Partly (triage → ② or ④/OOM) |
+| ④ | **Genuine per-model bugs** (training / clone / construction) | 4 | No — individual |
+
+The arena bug (②) and most of the silent diffusion deaths (③) are the **same root cause** in two manifestations: the arena recycles a tensor across denoise steps → wrong shape (`Input has N channels but layer expects M`). When that corruption is *caught* it's a `[FAIL]` (②); when it corrupts `ArrayPool` it's a **native host crash with no `[FAIL]` logged** (③).
+
+**Confirmed locally (this box, 32 GB):** `AIDOTNET_INFERENCE_ARENA=0` turns **DDPM 38/38** and **SyncDreamer** green (both fail with the arena on). That env var is the **key enabler for parallel work** — see below.
+
+---
+
+## Per-shard classification
+
+### ① Stack overflow — host crash (recursion bug)
+`Test host process crashed : Stack overflow.`
+
+- `ModelFamily - NeuralNetworks O-R`
+- `ModelFamily - NeuralNetworks S`
+- `ModelFamily - NeuralNetworks A-L`
+- `ModelFamily - Generated Layers A-M`
+- `ModelFamily - NeuralNetworks T-Z` — **cancelled** (runner lost mid-run; no reason logged). Given the other 3 NN ranges all stack-overflow, this is the likely cause; could also be OOM. Triage locally.
+
+*Almost certainly one shared recursion (a `Clone`/forward/property that calls itself). Find it once, likely fixes all five.*
+
+### ② Inference arena corruption (#1661) — confirmed
+Caught `Input has N channels but layer expects M` failures + arena signature in the log.
+
+| Shard | Failing model(s) |
+|---|---|
+| `ModelFamily - Diffusion A-C` | `ControlNetXSModelTests` (all 7) |
+| `ModelFamily - Diffusion Stable` | `StableSRModelTests` (all), `StableDiffusion3ModelTests.Predict_ShouldBeDeterministic` |
+| `ModelFamily - Diffusion Step-Sync` | `SUPIRModelTests` (all), `SyncDiffusionModelTests`, `Step1XEditModelTests` (training subset) |
+
+### ③ Host killed mid-run — arena-crash OR OOM (needs local triage)
+Shard died before xUnit logged any `[FAIL]` (`0 FAILs`, no crash reason captured). Diffusion-heavy → **leading hypothesis: arena escalating to a native pool-corruption crash** (DDPM lives in `03b`, SyncDreamer in `SA-SD` — both confirmed arena locally). Some may be genuine 16 GB-runner OOM.
+
+- `Unit - 03b Diffusion Models Control/DDPM/Preprocessor`  *(DDPM = arena, confirmed)*
+- `Unit - 03d Diffusion Models FastGen/Conditioner`
+- `ModelFamily - Diffusion D-I`
+- `ModelFamily - Diffusion J-M`
+- `ModelFamily - Diffusion N-R`
+- `ModelFamily - Diffusion SA-SD`  *(SyncDreamer = arena, confirmed)*
+- `ModelFamily - Diffusion SE-SP`
+- `Integration C`
+
+### ④ Genuine per-model bugs (NOT arena — these are training/clone/construction)
+Arena is inference-only; `GradientFlow` / `LossStrictlyDecreases` / `Training_*` failures are real model bugs.
+
+| Shard | Failing test(s) | Smell |
+|---|---|---|
+| `ModelFamily - NeuralNetworks M-N` | `NeuralTuringMachineTests` — `GradientFlow_ShouldBeNonZeroAndFinite`, `LossStrictlyDecreasesOnMemorizationTask`, `Training_ShouldChangeParameters` | tape/gradient no-op |
+| `ModelFamily - Generated Layers N-Z` | `TimeMachineTests` (training ×3), `WhisperTimestampedTests` (`Training_ShouldChangeParameters`, `DifferentInputs_AfterTraining`) | tape/gradient no-op |
+| `ModelFamily - Diffusion T-Z` | `TCDModelTests.Clone_ShouldProduceIdenticalOutput` | clone / stale weight-cache |
+| `Integration D` | `DefaultConstructionTests.AllDefaultConstructableModels_ShouldConstructWithoutException` | one model ctor throws |
+
+---
+
+## Work-division — 4 parallel streams (non-overlapping files)
+
+> **Enabler for everyone:** run your shard locally with **`AIDOTNET_INFERENCE_ARENA=0`** to strip out the arena corruption (②/③) so your area's *true* residual failures surface. No need to wait for Stream A to merge.
+>
+> ```
+> AIDOTNET_INFERENCE_ARENA=0 dotnet test tests/AiDotNet.Tests/AiDotNetTests.csproj -c Debug -f net10.0 \
+>   --filter "FullyQualifiedName~<YourModelTests>"
+> ```
+
+Tracked as **Epic #1673** with one GitHub issue per chunk:
+
+| Issue | Stream | Scope | Files (no conflict) | Owner |
+|---|---|---|---|---|
+| **#1668** | **A — Inference arena (#1661)** | Fix cross-step tensor recycling in the denoise loop (a layer's cross-forward cached buffer takes arena memory that `Reset()` recycles → shape aliasing). Or gate the arena off for diffusion denoise until the deep fix lands. **Greens ② + the diffusion half of ③ (~10 shards).** | `src/Diffusion/DiffusionModelBase.cs`, `src/NeuralNetworks/InferenceArenaSettings.cs`, Tensors arena | **Claude** (root-caused) |
+| **#1669** | **B — Stack overflow** | Find the recursion crashing the ① shards (`NeuralNetworks A-L/O-R/S/T-Z` + `Generated A-M`). Bisect which model self-recurses (`Clone`, `GetParameters`, property getters, forward). | offending NN/Generated model `.cs` | 1 dev |
+| **#1670** | **D — Training bugs** | NeuralTuringMachine + TimeMachine + WhisperTimestamped training/gradient no-op (likely shared sub-layer registration gap). | those 3 model `.cs` | 1 dev |
+| **#1671** | **D — Misc bugs** | TCD clone-equivalence + Integration-D default-construction. | TCD model `.cs`, the throwing ctor | 1 dev |
+| **#1672** | **C — OOM footprint** | Genuine 16 GB-runner OOM residual; test-scale variants. **Gated on #1668** (triage which ③ shards are truly OOM after the arena fix). | `tests/.../ModelFamilyTests/Base/*TestBase.cs`, model construction | 1 dev |
+
+### Sequencing
+1. **A and B first / concurrently** — they are *crash* causes that abort shards and mask everything else.
+2. **C and D in parallel now** using `AIDOTNET_INFERENCE_ARENA=0` locally (they don't need A merged to see their failures).
+3. After A + B land, **one CI re-run** gives the clean residual; reassign any surprises to D.
+
+### Triage step that splits ③ between A and C (parallelizable, ~1 shard each)
+For each ③ shard, run locally with `AIDOTNET_INFERENCE_ARENA=0`:
+- **Passes** → it was the arena → covered by **Stream A**.
+- **Still fails / OOMs** → **Stream C** (OOM) or **Stream D** (genuine), by signature.
+
+---
+
+## Reproduce / verify
+
+```bash
+# the clean inventory run
+gh run view 28023414937 --repo ooples/AiDotNet
+
+# a confirmed arena case (passes with arena off, fails with it on)
+AIDOTNET_INFERENCE_ARENA=0 dotnet test tests/AiDotNet.Tests/AiDotNetTests.csproj -c Debug -f net10.0 \
+  --filter "FullyQualifiedName~UnitTests.Diffusion.Models.DDPMModelTests"   # 38/38 with arena off
+
+# a stack-overflow shard (host crash)
+dotnet test tests/AiDotNet.Tests/AiDotNetTests.csproj -c Debug -f net10.0 \
+  --filter "FullyQualifiedName~ModelFamilyTests.NeuralNetworks"             # crashes: Stack overflow
+```
+
+## Pass list (44) — for reference, don't touch
+All non-listed shards passed, including: NN-Classic (ResNet/VGG/DenseNet), NN-Efficient, NN-VLM, all 13 `Unit` non-diffusion shards, `Integration A-B/E-G/H-L/M/N-O/P-Q/R/S/T-Z` (only C and D fail), Classification, Clustering/GP, Regression, TimeSeries, Code/Forecast/Segment/Survival, several `Diffusion Contracts` unit shards (`03a/03c1/03c2/03c4/03c5`), TopLevel, Serving.

--- a/src/AiDotNet.Generators/TestScaffoldGenerator.cs
+++ b/src/AiDotNet.Generators/TestScaffoldGenerator.cs
@@ -4280,7 +4280,8 @@ public class TestScaffoldGenerator : IIncrementalGenerator
                     "inputType: AiDotNet.Enums.InputType.OneDimensional, " +
                     "taskType: AiDotNet.Enums.NeuralNetworkTaskType.MultiClassClassification, " +
                     "inputSize: 32, outputSize: 128), " +
-                    "vocabSize: 128, bucketSize: 1024, embeddingDimension: 16, maxTokens: 32)";
+                    "options: new AiDotNet.NeuralNetworks.Options.FastTextOptions { VocabSize = 128, " +
+                    "BucketSize = 1024, EmbeddingDimension = 16, MaxSequenceLength = 32 })";
             }
             else if (model.ClassName is "FunASRNano" or "HuBERTASR" or "InterCTC" or "RobustConformer" or "SALM"
                     or "SpeakerDiarizedASR" or "SPIRAL"

--- a/src/AiDotNet.Generators/TestScaffoldGenerator.cs
+++ b/src/AiDotNet.Generators/TestScaffoldGenerator.cs
@@ -5106,10 +5106,11 @@ public class TestScaffoldGenerator : IIncrementalGenerator
                     "inputType: AiDotNet.Enums.InputType.ThreeDimensional, " +
                     "taskType: AiDotNet.Enums.NeuralNetworkTaskType.Regression, " +
                     "inputHeight: 32, inputWidth: 32, inputDepth: 3, outputSize: 4) { RandomSeed = 1337 }, " +
-                    "embeddingDimension: 64, maxSequenceLength: 16, imageSize: 32, channels: 3, " +
-                    "numPerceiverTokens: 4, maxImagesInContext: 1, visionHiddenDim: 64, lmHiddenDim: 64, " +
-                    "numVisionLayers: 1, numLmLayers: 1, numHeads: 2, vocabularySize: 64, " +
-                    "numPerceiverLayers: 1, learningRate: 1e-5)";
+                    "options: new AiDotNet.NeuralNetworks.Options.FlamingoOptions { EmbeddingDimension = 64, " +
+                    "MaxSequenceLength = 16, ImageSize = 32, Channels = 3, NumPerceiverTokens = 4, " +
+                    "MaxImagesInContext = 1, VisionHiddenDim = 64, LmHiddenDim = 64, " +
+                    "NumVisionLayers = 1, NumLmLayers = 1, NumHeads = 2, VocabSize = 64, " +
+                    "NumPerceiverLayers = 1, LearningRate = 1e-5 })";
             }
             else if (model.ClassName == "FinMA" && model.TypeParameterCount == 1)
             {
@@ -7156,10 +7157,10 @@ public class TestScaffoldGenerator : IIncrementalGenerator
                     "inputType: AiDotNet.Enums.InputType.ThreeDimensional, " +
                     "taskType: AiDotNet.Enums.NeuralNetworkTaskType.Regression, " +
                     "inputHeight: 32, inputWidth: 32, inputDepth: 3, outputSize: 4), " +
-                    "imageSize: 32, channels: 3, patchSize: 8, vocabularySize: 64, " +
-                    "maxSequenceLength: 8, embeddingDimension: 4, hiddenDim: 32, " +
-                    "numEncoderLayers: 1, numHeads: 4, audioSampleRate: 16000, " +
-                    "audioMaxDuration: 1, imuTimesteps: 8, numVideoFrames: 2)";
+                    "options: new AiDotNet.NeuralNetworks.Options.ImageBindOptions { ImageSize = 32, Channels = 3, " +
+                    "PatchSize = 8, VocabSize = 64, MaxSequenceLength = 8, EmbeddingDimension = 4, " +
+                    "HiddenDim = 32, NumEncoderLayers = 1, NumHeads = 4, AudioSampleRate = 16000, " +
+                    "AudioMaxDuration = 1, ImuTimesteps = 8, NumVideoFrames = 2 })";
             }
             else if (model.ClassName == "NemotronSpeech" && model.TypeParameterCount == 1)
             {
@@ -9193,9 +9194,10 @@ public class TestScaffoldGenerator : IIncrementalGenerator
                     "inputType: AiDotNet.Enums.InputType.ThreeDimensional, " +
                     "taskType: AiDotNet.Enums.NeuralNetworkTaskType.Regression, " +
                     "inputHeight: 112, inputWidth: 112, inputDepth: 3, outputSize: 4), " +
-                    "imageSize: 112, channels: 3, patchSize: 14, vocabularySize: 32, " +
-                    "maxSequenceLength: 16, embeddingDimension: 32, visionHiddenDim: 32, " +
-                    "numVisionLayers: 2, numLmLayers: 2, numHeads: 4)";
+                    "options: new AiDotNet.NeuralNetworks.Options.LLaVAOptions { ImageSize = 112, Channels = 3, " +
+                    "PatchSize = 14, VocabSize = 32, MaxSequenceLength = 16, " +
+                    "EmbeddingDimension = 32, VisionHiddenDim = 32, NumVisionLayers = 2, " +
+                    "NumLmLayers = 2, NumHeads = 4 })";
             }
             else if (model.ClassName == "VideoLLaVA" && model.TypeParameterCount == 1)
             {

--- a/src/AiDotNet.Generators/TestScaffoldGenerator.cs
+++ b/src/AiDotNet.Generators/TestScaffoldGenerator.cs
@@ -5091,9 +5091,7 @@ public class TestScaffoldGenerator : IIncrementalGenerator
                 constructorExpr = $"new {typeName}<double>(new AiDotNet.NeuralNetworks.NeuralNetworkArchitecture<double>(" +
                     "inputType: AiDotNet.Enums.InputType.OneDimensional, " +
                     "taskType: AiDotNet.Enums.NeuralNetworkTaskType.TextGeneration, " +
-                    "inputSize: 4, outputSize: 64), " +
-                    "vocabSize: 64, modelDimension: 32, numLayers: 2, numHeads: 4, maxSeqLength: 16, " +
-                    "learningRate: 1e-5)";
+                    "inputSize: 4, outputSize: 64), new AiDotNet.NeuralNetworks.Options.FinchOptions { VocabSize = 64, ModelDimension = 32, NumLayers = 2, NumHeads = 4, MaxSequenceLength = 16, LearningRate = 1e-5 })";
             }
             else if (model.ClassName == "FlamingoNeuralNetwork" && model.TypeParameterCount == 1)
             {
@@ -6521,8 +6519,10 @@ public class TestScaffoldGenerator : IIncrementalGenerator
                 constructorExpr = $"new {typeName}<double>(new AiDotNet.NeuralNetworks.NeuralNetworkArchitecture<double>(" +
                     "inputType: AiDotNet.Enums.InputType.OneDimensional, " +
                     "taskType: AiDotNet.Enums.NeuralNetworkTaskType.TextGeneration, inputSize: 32, outputSize: 128), " +
-                    "vocabSize: 128, modelDimension: 32, numLayers: 1, maxSeqLength: 32, " +
-                    $"options: new AiDotNet.NeuralNetworks.Options.{recurrentOptionsType} {{ RecurrenceDimension = 40 }})";
+                    $"new AiDotNet.NeuralNetworks.Options.{recurrentOptionsType} {{ VocabSize = 128, " +
+                    "ModelDimension = 32, NumLayers = 1, MaxSequenceLength = 32, " +
+                    // NOT an interpolated segment, so a single brace is a single brace.
+                    "RecurrenceDimension = 40 })";
             }
             else if (model.ClassName == "DocGCN" && model.TypeParameterCount == 1)
             {
@@ -6976,12 +6976,15 @@ public class TestScaffoldGenerator : IIncrementalGenerator
                 // Pin generated-test initialization because these recurrent gates otherwise draw
                 // from the process-shared RNG and the exact trajectory depends on sibling test order.
                 pinInitSeed = true;
-                string headArgument = model.ClassName == "HawkLanguageModel" ? string.Empty : "numHeads: 4, ";
+                // Hawk is purely recurrent and declares no head count; the other two do.
+                string headArgument = model.ClassName == "HawkLanguageModel" ? string.Empty : "NumHeads = 4, ";
+                string recurrentOptionsType = model.ClassName.Replace("LanguageModel", "Options");
                 constructorExpr = $"new {typeName}<double>(new AiDotNet.NeuralNetworks.NeuralNetworkArchitecture<double>(" +
                     "inputType: AiDotNet.Enums.InputType.OneDimensional, " +
                     "taskType: AiDotNet.Enums.NeuralNetworkTaskType.TextGeneration, " +
-                    "inputSize: 32, outputSize: 128), vocabSize: 128, modelDimension: 32, " +
-                    $"numLayers: 1, {headArgument}maxSeqLength: 32)";
+                    "inputSize: 32, outputSize: 128), " +
+                    $"new AiDotNet.NeuralNetworks.Options.{recurrentOptionsType} {{ VocabSize = 128, " +
+                    $"ModelDimension = 32, NumLayers = 1, {headArgument}MaxSequenceLength = 32 }})";
             }
             else if (model.ClassName == "ZambaLanguageModel" && model.TypeParameterCount == 1)
             {
@@ -11423,11 +11426,14 @@ public class TestScaffoldGenerator : IIncrementalGenerator
                 // embedding -> RG-LRU -> normalization -> logits topology at one 32-wide recurrent
                 // block and a 256-token smoke vocabulary; Griffin/Hawk remain at the earlier vocab-
                 // only cap because their full-width fixtures already fit the gate.
+                const string optionsNamespace = "AiDotNet.NeuralNetworks.Options.";
                 string scaleArgs = model.ClassName switch
                 {
                     "RecurrentGemmaLanguageModel" =>
-                        ", vocabSize: 256, modelDimension: 32, numLayers: 1, maxSeqLength: 128",
-                    "GriffinLanguageModel" or "HawkLanguageModel" => ", vocabSize: 4096",
+                        ", new " + optionsNamespace + "RecurrentGemmaOptions { VocabSize = 256, "
+                            + "ModelDimension = 32, NumLayers = 1, MaxSequenceLength = 128 }",
+                    "GriffinLanguageModel" => ", new " + optionsNamespace + "GriffinOptions { VocabSize = 4096 }",
+                    "HawkLanguageModel" => ", new " + optionsNamespace + "HawkOptions { VocabSize = 4096 }",
                     _ => ""
                 };
 

--- a/src/AiDotNet.Generators/TestScaffoldGenerator.cs
+++ b/src/AiDotNet.Generators/TestScaffoldGenerator.cs
@@ -5081,8 +5081,7 @@ public class TestScaffoldGenerator : IIncrementalGenerator
                 constructorExpr = $"new {typeName}<double>(new AiDotNet.NeuralNetworks.NeuralNetworkArchitecture<double>(" +
                     "inputType: AiDotNet.Enums.InputType.OneDimensional, " +
                     "taskType: AiDotNet.Enums.NeuralNetworkTaskType.TextGeneration, " +
-                    "inputSize: 4, outputSize: 64), " +
-                    "vocabSize: 64, modelDimension: 32, numLayers: 2, numHeads: 4, maxSeqLength: 16)";
+                    "inputSize: 4, outputSize: 64), new AiDotNet.NeuralNetworks.Options.EagleOptions { VocabSize = 64, ModelDimension = 32, NumLayers = 2, NumHeads = 4, MaxSequenceLength = 16 })";
             }
             else if (model.ClassName == "FinchLanguageModel" && model.TypeParameterCount == 1)
             {
@@ -5633,8 +5632,9 @@ public class TestScaffoldGenerator : IIncrementalGenerator
                     "inputType: AiDotNet.Enums.InputType.OneDimensional, " +
                     "taskType: AiDotNet.Enums.NeuralNetworkTaskType.Regression, " +
                     "inputSize: 128, outputSize: 4), " +
-                    "vocabSize: 64, modelDimension: 32, numLayers: 1, numHeads: 4, maxSeqLength: 128, " +
-                    "options: new AiDotNet.NeuralNetworks.Options.XLSTMOptions { LearningRate = 3e-4 })";
+                    "new AiDotNet.NeuralNetworks.Options.XLSTMOptions { VocabSize = 64, " +
+                    "ModelDimension = 32, NumLayers = 1, NumHeads = 4, MaxSequenceLength = 128, " +
+                    "LearningRate = 3e-4 })";
             }
             else if (model.ClassName == "XTTSv2Clone" && model.TypeParameterCount == 1)
             {
@@ -6546,8 +6546,7 @@ public class TestScaffoldGenerator : IIncrementalGenerator
                 constructorExpr = $"new {typeName}<double>(new AiDotNet.NeuralNetworks.NeuralNetworkArchitecture<double>(" +
                     "inputType: AiDotNet.Enums.InputType.OneDimensional, " +
                     "taskType: AiDotNet.Enums.NeuralNetworkTaskType.TextGeneration, " +
-                    "inputSize: 32, outputSize: 128), vocabSize: 128, modelDimension: 32, " +
-                    "numLayers: 2, stateDimension: 16, numHeads: 4, maxSeqLength: 32)";
+                    "inputSize: 32, outputSize: 128), new AiDotNet.NeuralNetworks.Options.Mamba2Options { VocabSize = 128, ModelDimension = 32, NumLayers = 2, StateDimension = 16, NumHeads = 4, MaxSequenceLength = 32 })";
             }
             else if (model.ClassName == "XLSTMLanguageModel" && model.TypeParameterCount == 1)
             {
@@ -6563,8 +6562,7 @@ public class TestScaffoldGenerator : IIncrementalGenerator
                 constructorExpr = $"new {typeName}<double>(new AiDotNet.NeuralNetworks.NeuralNetworkArchitecture<double>(" +
                     "inputType: AiDotNet.Enums.InputType.OneDimensional, " +
                     "taskType: AiDotNet.Enums.NeuralNetworkTaskType.TextGeneration, " +
-                    "inputSize: 16, outputSize: 64), vocabSize: 64, modelDimension: 32, " +
-                    "numLayers: 2, numHeads: 4, maxSeqLength: 16)";
+                    "inputSize: 16, outputSize: 64), new AiDotNet.NeuralNetworks.Options.XLSTMOptions { VocabSize = 64, ModelDimension = 32, NumLayers = 2, NumHeads = 4, MaxSequenceLength = 16 })";
             }
             else if (model.ClassName == "BloombergGPT" && model.TypeParameterCount == 1)
             {
@@ -6966,8 +6964,7 @@ public class TestScaffoldGenerator : IIncrementalGenerator
                 constructorExpr = $"new {typeName}<double>(new AiDotNet.NeuralNetworks.NeuralNetworkArchitecture<double>(" +
                     "inputType: AiDotNet.Enums.InputType.OneDimensional, " +
                     "taskType: AiDotNet.Enums.NeuralNetworkTaskType.TextGeneration, " +
-                    "inputSize: 32, outputSize: 128), vocabSize: 128, modelDimension: 32, " +
-                    "numLayers: 1, stateDimension: 8, expandFactor: 2, maxSeqLength: 32)";
+                    "inputSize: 32, outputSize: 128), new AiDotNet.NeuralNetworks.Options.FalconMambaOptions { VocabSize = 128, ModelDimension = 32, NumLayers = 1, StateDimension = 8, ExpandFactor = 2, MaxSequenceLength = 32 })";
             }
             else if ((model.ClassName is "HawkLanguageModel" or "GLALanguageModel" or "GatedDeltaNetLanguageModel")
                      && model.TypeParameterCount == 1)
@@ -6995,8 +6992,7 @@ public class TestScaffoldGenerator : IIncrementalGenerator
                 constructorExpr = $"new {typeName}<double>(new AiDotNet.NeuralNetworks.NeuralNetworkArchitecture<double>(" +
                     "inputType: AiDotNet.Enums.InputType.OneDimensional, " +
                     "taskType: AiDotNet.Enums.NeuralNetworkTaskType.TextGeneration, " +
-                    "inputSize: 128, outputSize: 128), vocabSize: 128, modelDimension: 32, " +
-                    "numLayers: 2, stateDimension: 16, attentionInterval: 2, maxSeqLength: 128)";
+                    "inputSize: 128, outputSize: 128), new AiDotNet.NeuralNetworks.Options.ZambaOptions { VocabSize = 128, ModelDimension = 32, NumLayers = 2, StateDimension = 16, AttentionInterval = 2, MaxSequenceLength = 128 })";
             }
             else if (model.ClassName == "Zamba2LanguageModel" && model.TypeParameterCount == 1)
             {
@@ -7006,8 +7002,7 @@ public class TestScaffoldGenerator : IIncrementalGenerator
                 constructorExpr = $"new {typeName}<double>(new AiDotNet.NeuralNetworks.NeuralNetworkArchitecture<double>(" +
                     "inputType: AiDotNet.Enums.InputType.OneDimensional, " +
                     "taskType: AiDotNet.Enums.NeuralNetworkTaskType.TextGeneration, " +
-                    "inputSize: 128, outputSize: 128), vocabSize: 128, modelDimension: 32, " +
-                    "numLayers: 2, stateDimension: 16, numHeads: 4, attentionInterval: 2, maxSeqLength: 128)";
+                    "inputSize: 128, outputSize: 128), new AiDotNet.NeuralNetworks.Options.Zamba2Options { VocabSize = 128, ModelDimension = 32, NumLayers = 2, StateDimension = 16, NumHeads = 4, AttentionInterval = 2, MaxSequenceLength = 128 })";
             }
             else if (model.ClassName == "ChronosBolt" && model.TypeParameterCount == 1)
             {
@@ -9312,9 +9307,7 @@ public class TestScaffoldGenerator : IIncrementalGenerator
                 constructorExpr = $"new {typeName}<double>(new AiDotNet.NeuralNetworks.NeuralNetworkArchitecture<double>(" +
                     "inputType: AiDotNet.Enums.InputType.OneDimensional, " +
                     "taskType: AiDotNet.Enums.NeuralNetworkTaskType.TextGeneration, " +
-                    "inputSize: 8, outputSize: 16), " +
-                    "vocabSize: 16, modelDimension: 32, numLayers: 2, stateDimension: 8, " +
-                    "attentionInterval: 2, maxSeqLength: 8)";
+                    "inputSize: 8, outputSize: 16), new AiDotNet.NeuralNetworks.Options.JambaOptions { VocabSize = 16, ModelDimension = 32, NumLayers = 2, StateDimension = 8, AttentionInterval = 2, MaxSequenceLength = 8 })";
             }
             else if (IsValleCodecLMModel(model.ClassName) && model.TypeParameterCount == 1
                      && model.FullyQualifiedName.StartsWith("AiDotNet.TextToSpeech.", System.StringComparison.Ordinal))

--- a/src/Configuration/InferenceOptimizationConfig.cs
+++ b/src/Configuration/InferenceOptimizationConfig.cs
@@ -330,7 +330,7 @@ public class InferenceOptimizationConfig
     /// <summary>
     /// Validates the configuration and throws if any values are invalid.
     /// </summary>
-    /// <exception cref="ArgumentException">Thrown when configuration values are invalid.</exception>
+    /// <exception cref="InvalidOperationException">Thrown when configuration values are invalid.</exception>
     /// <remarks>
     /// <para><b>For Beginners:</b> Call this method to ensure your configuration is valid before use.
     ///

--- a/src/Configuration/InferenceOptimizationConfig.cs
+++ b/src/Configuration/InferenceOptimizationConfig.cs
@@ -330,7 +330,7 @@ public class InferenceOptimizationConfig
     /// <summary>
     /// Validates the configuration and throws if any values are invalid.
     /// </summary>
-    /// <exception cref="InvalidOperationException">Thrown when configuration values are invalid.</exception>
+    /// <exception cref="ArgumentException">Thrown when configuration values are invalid.</exception>
     /// <remarks>
     /// <para><b>For Beginners:</b> Call this method to ensure your configuration is valid before use.
     ///

--- a/src/Configuration/JitCompilationConfig.cs
+++ b/src/Configuration/JitCompilationConfig.cs
@@ -173,7 +173,7 @@ public sealed class JitCompilationConfig
     /// <summary>
     /// Validates the config and throws if settings are inconsistent.
     /// </summary>
-    /// <exception cref="InvalidOperationException">Thrown when values are out of range.</exception>
+    /// <exception cref="ArgumentException">Thrown when values are out of range.</exception>
     public void Validate()
     {
         // NaN passes both `< 0` and `>= 1` comparisons (NaN is unordered with

--- a/src/Configuration/JitCompilationConfig.cs
+++ b/src/Configuration/JitCompilationConfig.cs
@@ -173,7 +173,7 @@ public sealed class JitCompilationConfig
     /// <summary>
     /// Validates the config and throws if settings are inconsistent.
     /// </summary>
-    /// <exception cref="ArgumentException">Thrown when values are out of range.</exception>
+    /// <exception cref="InvalidOperationException">Thrown when values are out of range.</exception>
     public void Validate()
     {
         // NaN passes both `< 0` and `>= 1` comparisons (NaN is unordered with

--- a/src/Configuration/ProgramMetricAggregationOptions.cs
+++ b/src/Configuration/ProgramMetricAggregationOptions.cs
@@ -105,7 +105,7 @@ public sealed class ProgramMetricAggregationOptions
 
     /// <summary>Rejects a configuration that could not produce a defensible score.</summary>
     /// <exception cref="ArgumentOutOfRangeException"><see cref="Strategy"/> is undefined, or a numeric setting is not finite or is negative.</exception>
-    /// <exception cref="ArgumentException">
+    /// <exception cref="InvalidOperationException">
     /// A required setting is missing for the chosen strategy: an empty combined-score key, no positive weight, or a
     /// weighted metric with no reference value under the Chebyshev strategy.
     /// </exception>

--- a/src/Configuration/ProgramMetricAggregationOptions.cs
+++ b/src/Configuration/ProgramMetricAggregationOptions.cs
@@ -105,7 +105,7 @@ public sealed class ProgramMetricAggregationOptions
 
     /// <summary>Rejects a configuration that could not produce a defensible score.</summary>
     /// <exception cref="ArgumentOutOfRangeException"><see cref="Strategy"/> is undefined, or a numeric setting is not finite or is negative.</exception>
-    /// <exception cref="InvalidOperationException">
+    /// <exception cref="ArgumentException">
     /// A required setting is missing for the chosen strategy: an empty combined-score key, no positive weight, or a
     /// weighted metric with no reference value under the Chebyshev strategy.
     /// </exception>

--- a/src/Deployment/TensorRT/TensorRTConfiguration.cs
+++ b/src/Deployment/TensorRT/TensorRTConfiguration.cs
@@ -185,7 +185,7 @@ public class TensorRTConfiguration
     /// <summary>
     /// Validates the configuration and throws exceptions for invalid settings.
     /// </summary>
-    /// <exception cref="ArgumentException">Thrown when INT8 is enabled without calibration data</exception>
+    /// <exception cref="InvalidOperationException">Thrown when INT8 is enabled without calibration data</exception>
     /// <exception cref="FileNotFoundException">Thrown when calibration data path is specified but file doesn't exist</exception>
     public void Validate()
     {

--- a/src/Deployment/TensorRT/TensorRTConfiguration.cs
+++ b/src/Deployment/TensorRT/TensorRTConfiguration.cs
@@ -185,7 +185,7 @@ public class TensorRTConfiguration
     /// <summary>
     /// Validates the configuration and throws exceptions for invalid settings.
     /// </summary>
-    /// <exception cref="InvalidOperationException">Thrown when INT8 is enabled without calibration data</exception>
+    /// <exception cref="ArgumentException">Thrown when INT8 is enabled without calibration data</exception>
     /// <exception cref="FileNotFoundException">Thrown when calibration data path is specified but file doesn't exist</exception>
     public void Validate()
     {

--- a/src/Enums/EmbeddingPoolingStrategy.cs
+++ b/src/Enums/EmbeddingPoolingStrategy.cs
@@ -1,0 +1,53 @@
+namespace AiDotNet.Enums;
+
+/// <summary>
+/// How a text embedding model collapses a sequence of token representations into a single
+/// vector for the whole piece of text.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>For Beginners:</b> An embedding model produces one vector per token — one per word-piece
+/// of your sentence. To compare two sentences you need a single vector for each, so the token
+/// vectors are combined ("pooled"). This chooses how.
+/// </para>
+/// <para>
+/// This was previously nested inside <c>TransformerEmbeddingNetwork&lt;T&gt;</c>. A type nested
+/// in a generic class is a distinct type for every type argument, so
+/// <c>TransformerEmbeddingNetwork&lt;float&gt;.PoolingStrategy</c> and the <c>double</c> one
+/// were unrelated types, and neither could be named from a non-generic options class. Promoting
+/// it here makes it usable as configuration, which is what it always described.
+/// </para>
+/// <para>
+/// Not to be confused with <c>AiDotNet.VisionLanguage.Encoders.PoolingStrategy</c>, which pools
+/// image patches and offers a different set of choices.
+/// </para>
+/// </remarks>
+public enum EmbeddingPoolingStrategy
+{
+    /// <summary>
+    /// Averages all token representations across the sequence.
+    /// </summary>
+    /// <remarks>
+    /// <para><b>For Beginners:</b> The usual choice, and the one most sentence-embedding models
+    /// are trained with. Every token contributes equally.</para>
+    /// </remarks>
+    Mean,
+
+    /// <summary>
+    /// Takes the maximum value across all sequence positions for each dimension.
+    /// </summary>
+    /// <remarks>
+    /// <para><b>For Beginners:</b> Keeps the strongest signal for each feature rather than the
+    /// average, so a single distinctive word can dominate.</para>
+    /// </remarks>
+    Max,
+
+    /// <summary>
+    /// Uses the representation of the first token, typically the [CLS] token.
+    /// </summary>
+    /// <remarks>
+    /// <para><b>For Beginners:</b> BERT-style models prepend a special token whose final
+    /// representation is trained to summarise the whole sequence. This uses that.</para>
+    /// </remarks>
+    ClsToken
+}

--- a/src/Models/Options/AudioHyperparameterOptions.cs
+++ b/src/Models/Options/AudioHyperparameterOptions.cs
@@ -114,7 +114,7 @@ public abstract class AudioHyperparameterOptions : ModelHyperparameterOptions
     /// <summary>
     /// Throws if a signal parameter every audio model requires has been left unset.
     /// </summary>
-    /// <exception cref="InvalidOperationException">
+    /// <exception cref="ArgumentException">
     /// Thrown when a required value is zero or negative, which means the derived options class
     /// did not assign its model's published defaults.
     /// </exception>

--- a/src/Models/Options/AudioHyperparameterOptions.cs
+++ b/src/Models/Options/AudioHyperparameterOptions.cs
@@ -1,0 +1,125 @@
+namespace AiDotNet.Models.Options;
+
+/// <summary>
+/// Shared configuration for audio and speech models: text-to-speech, speech recognition,
+/// speech enhancement and denoising, audio classification and audio generation.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>For Beginners:</b> Audio models first turn a sound wave into a picture-like grid of
+/// numbers (a spectrogram) and then work on that. Most of the settings here describe how that
+/// conversion is done — how many samples per second the audio has, how finely it is chopped
+/// up in time, and how many frequency bands are kept. Each model's own options class ships
+/// the values from the paper that introduced it, so you do not normally set any of these.
+/// </para>
+/// <para>
+/// Derived options classes assign their paper's values in their parameterless constructor.
+/// See <see cref="ModelHyperparameterOptions"/> for why these properties are non-nullable.
+/// </para>
+/// <para>
+/// This base spans <c>src/TextToSpeech</c>, <c>src/SpeechRecognition</c> and <c>src/Audio</c>
+/// because they share the same signal parameters. It lives beside
+/// <see cref="DocumentNeuralNetworkOptions"/> rather than in any one of those areas for the
+/// same reason.
+/// </para>
+/// <para>
+/// <b>Naming.</b> The constructors being replaced use two names for each of two concepts —
+/// <c>hopLength</c> and <c>hopSize</c>, <c>fftSize</c> and <c>frameSize</c>. This base picks
+/// one of each (<see cref="HopLength"/>, <see cref="FftSize"/>), which is the usual naming in
+/// the audio literature and in librosa.
+/// </para>
+/// </remarks>
+public abstract class AudioHyperparameterOptions : ModelHyperparameterOptions
+{
+    /// <summary>
+    /// Gets or sets the audio sample rate in hertz.
+    /// </summary>
+    /// <remarks>
+    /// <para><b>For Beginners:</b> How many measurements of the sound wave there are per
+    /// second. 16000 is the speech standard, 44100 is CD quality. A model trained at one rate
+    /// will produce nonsense if fed audio at another, so this has to match the model, not your
+    /// source file — resample the audio instead of changing this.</para>
+    /// </remarks>
+    public int SampleRate { get; set; }
+
+    /// <summary>
+    /// Gets or sets the number of mel frequency bands in the spectrogram.
+    /// </summary>
+    /// <remarks>
+    /// <para><b>For Beginners:</b> The sound is split into this many frequency bands, spaced
+    /// the way human hearing perceives pitch rather than evenly. 80 is near-universal for
+    /// speech models.</para>
+    /// </remarks>
+    public int NumMels { get; set; }
+
+    /// <summary>
+    /// Gets or sets the FFT window size, in samples, used to build each spectrogram frame.
+    /// </summary>
+    /// <remarks>
+    /// <para><b>For Beginners:</b> How big a slice of audio is analysed at once. Larger sees
+    /// frequency more precisely but time less precisely, and vice versa — that trade-off is
+    /// unavoidable.</para>
+    /// </remarks>
+    public int FftSize { get; set; }
+
+    /// <summary>
+    /// Gets or sets the hop length, in samples, between consecutive spectrogram frames.
+    /// </summary>
+    /// <remarks>
+    /// <para><b>For Beginners:</b> How far the analysis window slides each step. Usually a
+    /// quarter of <see cref="FftSize"/>, so the windows overlap and nothing falls between
+    /// them.</para>
+    /// </remarks>
+    public int HopLength { get; set; }
+
+    /// <summary>
+    /// Gets or sets the width of the model's main hidden representation.
+    /// </summary>
+    public int HiddenDim { get; set; }
+
+    /// <summary>
+    /// Gets or sets the number of attention heads.
+    /// </summary>
+    public int NumHeads { get; set; }
+
+    /// <summary>
+    /// Gets or sets the number of encoder layers.
+    /// </summary>
+    public int NumEncoderLayers { get; set; }
+
+    /// <summary>
+    /// Gets or sets the number of decoder layers, for models that generate audio or text.
+    /// </summary>
+    public int NumDecoderLayers { get; set; }
+
+    /// <summary>
+    /// Gets or sets the speaking-rate multiplier for synthesised speech. 1.0 is the model's
+    /// natural pace.
+    /// </summary>
+    /// <remarks>
+    /// <para><b>For Beginners:</b> Above 1.0 talks faster, below 1.0 slower.</para>
+    /// </remarks>
+    public double SpeakingRate { get; set; } = 1.0;
+
+    /// <summary>
+    /// Gets or sets the BCP-47 language tag the model is configured for, or null when the
+    /// model is language-agnostic.
+    /// </summary>
+    /// <remarks>
+    /// <para><b>For Beginners:</b> "en" for English, "fr" for French. Multilingual models
+    /// leave this null and detect the language themselves.</para>
+    /// </remarks>
+    public string? Language { get; set; }
+
+    /// <summary>
+    /// Throws if a signal parameter every audio model requires has been left unset.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when a required value is zero or negative, which means the derived options class
+    /// did not assign its model's published defaults.
+    /// </exception>
+    protected void ValidateCore()
+    {
+        Require(SampleRate, nameof(SampleRate));
+    }
+}

--- a/src/Models/Options/DocumentNeuralNetworkOptions.cs
+++ b/src/Models/Options/DocumentNeuralNetworkOptions.cs
@@ -141,7 +141,7 @@ public class DocumentNeuralNetworkOptions : ModelHyperparameterOptions
     /// <summary>
     /// Throws if a dimension every document model requires has been left unset.
     /// </summary>
-    /// <exception cref="InvalidOperationException">
+    /// <exception cref="ArgumentException">
     /// Thrown when a required dimension is zero or negative, which means the derived options
     /// class did not assign its paper defaults.
     /// </exception>

--- a/src/Models/Options/DocumentNeuralNetworkOptions.cs
+++ b/src/Models/Options/DocumentNeuralNetworkOptions.cs
@@ -1,8 +1,153 @@
 namespace AiDotNet.Models.Options;
 
 /// <summary>
-/// Base configuration options for document neural network models.
+/// Shared configuration for document models: OCR and text recognition, layout analysis,
+/// document question answering, table and chart understanding, and document VQA.
 /// </summary>
-public class DocumentNeuralNetworkOptions : NeuralNetworkOptions
+/// <remarks>
+/// <para>
+/// <b>For Beginners:</b> Document models read scanned pages and photographs of documents.
+/// They need to know how large the page image is, how much text they can produce, and how
+/// big their internal representations are. Each model's own options class ships the values
+/// from the paper that introduced it, so you do not normally set any of these.
+/// </para>
+/// <para>
+/// Derived options classes assign their paper's values in their parameterless constructor:
+/// <code>
+/// public class TrOCROptions : DocumentNeuralNetworkOptions
+/// {
+///     public TrOCROptions()
+///     {
+///         ImageSize = 384;
+///         VocabSize = 50265;      // RoBERTa tokenizer
+///         HiddenDim = 768;
+///         NumDecoderLayers = 12;
+///     }
+/// }
+/// </code>
+/// See <see cref="ModelHyperparameterOptions"/> for why these properties are non-nullable.
+/// </para>
+/// <para>
+/// This class already sits at the root of every options class under
+/// <c>src/Document/Options</c> — all 29 of them derive from it — so adding the shared
+/// knobs here reaches the whole area without touching the leaves.
+/// </para>
+/// <para>
+/// <b>Not to be confused with <c>DocumentModelOptions&lt;T&gt;</c>,</b> an earlier and now
+/// abandoned attempt at the same idea: it takes a type parameter it never uses, follows the
+/// nullable + <c>Effective*</c> pattern this design moves away from, and nothing derives
+/// from it. It is left in place for now and removed when the document models are wired.
+/// </para>
+/// </remarks>
+public class DocumentNeuralNetworkOptions : ModelHyperparameterOptions
 {
+    /// <summary>
+    /// Gets or sets the side length, in pixels, of the page image the model expects.
+    /// </summary>
+    /// <remarks>
+    /// <para><b>For Beginners:</b> Scanned pages are resized to this many pixels on a side
+    /// before the model reads them. Document models use larger values than ordinary vision
+    /// models — 1024 rather than 224 — because small text has to stay legible.</para>
+    /// </remarks>
+    public int ImageSize { get; set; }
+
+    /// <summary>
+    /// Gets or sets the input image width in pixels, for models that expect a non-square page.
+    /// </summary>
+    /// <remarks>
+    /// <para><b>For Beginners:</b> A single line of text cropped from a page is wide and short,
+    /// so line-level recognition models use an explicit width and height rather than a square.</para>
+    /// </remarks>
+    public int ImageWidth { get; set; }
+
+    /// <summary>
+    /// Gets or sets the input image height in pixels, for models that expect a non-square page.
+    /// </summary>
+    public int ImageHeight { get; set; }
+
+    /// <summary>
+    /// Gets or sets the side length, in pixels, of each square patch the page is divided into.
+    /// </summary>
+    public int PatchSize { get; set; }
+
+    /// <summary>
+    /// Gets or sets the longest sequence, in tokens, the model reads or produces.
+    /// </summary>
+    public int MaxSequenceLength { get; set; }
+
+    /// <summary>
+    /// Gets or sets the number of distinct tokens the model's tokenizer covers.
+    /// </summary>
+    /// <remarks>
+    /// <para><b>For Beginners:</b> 30522 is the BERT vocabulary, 50265 RoBERTa's, and 250002
+    /// the multilingual XLM-R vocabulary used by models that read many languages.</para>
+    /// </remarks>
+    public int VocabSize { get; set; }
+
+    /// <summary>
+    /// Gets or sets the width of the model's main hidden representation.
+    /// </summary>
+    public int HiddenDim { get; set; }
+
+    /// <summary>
+    /// Gets or sets the number of attention heads.
+    /// </summary>
+    public int NumHeads { get; set; }
+
+    /// <summary>
+    /// Gets or sets the total number of stacked blocks, for models with a single stack.
+    /// </summary>
+    public int NumLayers { get; set; }
+
+    /// <summary>
+    /// Gets or sets the number of encoder layers, for encoder-decoder models.
+    /// </summary>
+    /// <remarks>
+    /// <para><b>For Beginners:</b> The encoder looks at the page; the decoder writes out the
+    /// text. They are usually different depths.</para>
+    /// </remarks>
+    public int NumEncoderLayers { get; set; }
+
+    /// <summary>
+    /// Gets or sets the number of decoder layers, for encoder-decoder models.
+    /// </summary>
+    public int NumDecoderLayers { get; set; }
+
+    /// <summary>
+    /// Gets or sets the width of the vision tower's hidden representation.
+    /// </summary>
+    public int VisionDim { get; set; }
+
+    /// <summary>
+    /// Gets or sets the number of layers in the vision tower.
+    /// </summary>
+    public int VisionLayers { get; set; }
+
+    /// <summary>
+    /// Gets or sets the channel width of the convolutional backbone, for detection-style
+    /// models such as text detectors.
+    /// </summary>
+    public int BackboneChannels { get; set; }
+
+    /// <summary>
+    /// Gets or sets the number of output categories, for classification models.
+    /// </summary>
+    /// <remarks>
+    /// <para><b>For Beginners:</b> A layout model that labels each region as title, paragraph,
+    /// table, figure and so on uses one class per label.</para>
+    /// </remarks>
+    public int NumClasses { get; set; }
+
+    /// <summary>
+    /// Throws if a dimension every document model requires has been left unset.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when a required dimension is zero or negative, which means the derived options
+    /// class did not assign its paper defaults.
+    /// </exception>
+    protected void ValidateCore()
+    {
+        Require(MaxSequenceLength, nameof(MaxSequenceLength));
+        Require(HiddenDim, nameof(HiddenDim));
+    }
 }

--- a/src/Models/Options/ModelHyperparameterOptions.cs
+++ b/src/Models/Options/ModelHyperparameterOptions.cs
@@ -38,12 +38,26 @@ public abstract class ModelHyperparameterOptions : NeuralNetworkOptions
     public double MaxGradNorm { get; set; } = 1.0;
 
     /// <summary>
+    /// The constructor parameter name reported when validation fails.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Every model takes its configuration as a parameter called <c>options</c>, so an invalid
+    /// value always reached the model that way. Naming it keeps the exception actionable and
+    /// keeps the contract these constructors already had before their scalar parameters moved
+    /// here.
+    /// </para>
+    /// </remarks>
+    protected const string OptionsParameterName = "options";
+
+    /// <summary>
     /// Throws when a required dimension has been left unset.
     /// </summary>
     /// <param name="value">The value to check.</param>
     /// <param name="propertyName">The name of the property being checked.</param>
-    /// <exception cref="InvalidOperationException">
-    /// Thrown when <paramref name="value"/> is zero or negative.
+    /// <exception cref="ArgumentException">
+    /// Thrown when <paramref name="value"/> is zero or negative. Reported against the
+    /// <c>options</c> parameter, because that is how an invalid value reaches a model.
     /// </exception>
     /// <remarks>
     /// <para>
@@ -56,10 +70,11 @@ public abstract class ModelHyperparameterOptions : NeuralNetworkOptions
     {
         if (value <= 0)
         {
-            throw new InvalidOperationException(
+            throw new ArgumentException(
                 $"{GetType().Name}.{propertyName} is {value}, but it must be greater than zero. "
                     + $"Set it explicitly, or ensure {GetType().Name}'s parameterless constructor "
-                    + "assigns its model's published default.");
+                    + "assigns its model's published default.",
+                OptionsParameterName);
         }
     }
 
@@ -68,17 +83,18 @@ public abstract class ModelHyperparameterOptions : NeuralNetworkOptions
     /// </summary>
     /// <param name="value">The value to check.</param>
     /// <param name="propertyName">The name of the property being checked.</param>
-    /// <exception cref="InvalidOperationException">
+    /// <exception cref="ArgumentException">
     /// Thrown when <paramref name="value"/> is not a finite number greater than zero.
     /// </exception>
     protected void Require(double value, string propertyName)
     {
         if (double.IsNaN(value) || double.IsInfinity(value) || value <= 0.0)
         {
-            throw new InvalidOperationException(
+            throw new ArgumentException(
                 $"{GetType().Name}.{propertyName} is {value.ToString(System.Globalization.CultureInfo.InvariantCulture)}, "
                     + "but it must be a finite number greater than zero. Set it explicitly, or ensure "
-                    + $"{GetType().Name}'s parameterless constructor assigns its model's published default.");
+                    + $"{GetType().Name}'s parameterless constructor assigns its model's published default.",
+                OptionsParameterName);
         }
     }
 }

--- a/src/Models/Options/ModelHyperparameterOptions.cs
+++ b/src/Models/Options/ModelHyperparameterOptions.cs
@@ -1,0 +1,84 @@
+namespace AiDotNet.Models.Options;
+
+/// <summary>
+/// Base class for the per-model-family hyperparameter options: the sizes and shapes that
+/// come from the paper a model was published in.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>For Beginners:</b> Every model in this library ships with the settings from the
+/// research paper that introduced it, so you can use a model without configuring anything.
+/// This class holds the settings that apply to nearly every model, and the family classes
+/// that derive from it add the ones specific to a kind of model.
+/// </para>
+/// <para>
+/// <b>Pattern.</b> Properties here are non-nullable, and each concrete options class assigns
+/// its published defaults in its parameterless constructor. This differs deliberately from
+/// the nullable + <c>GetEffectiveX()</c> pattern used for infrastructure configuration
+/// (telemetry, profiling, AutoML): <c>null</c> there means "decide at runtime from the data
+/// or the hardware", which is meaningful for a batch size and meaningless for a layer count.
+/// </para>
+/// <para>
+/// <b>Every property here must be read by the model that owns it.</b> A property nobody
+/// reads is worse than no property, because it advertises configurability that does not
+/// exist. The options-surface ratchet test enforces this.
+/// </para>
+/// </remarks>
+public abstract class ModelHyperparameterOptions : NeuralNetworkOptions
+{
+    /// <summary>
+    /// Gets or sets the maximum global gradient norm, above which gradients are rescaled
+    /// during training. Zero or negative disables clipping.
+    /// </summary>
+    /// <remarks>
+    /// <para><b>For Beginners:</b> During training the model adjusts itself based on how wrong
+    /// it was. Occasionally that correction is enormous and destabilises everything learned so
+    /// far. Gradient clipping caps the size of a single correction. 1.0 is the usual choice.</para>
+    /// </remarks>
+    public double MaxGradNorm { get; set; } = 1.0;
+
+    /// <summary>
+    /// Throws when a required dimension has been left unset.
+    /// </summary>
+    /// <param name="value">The value to check.</param>
+    /// <param name="propertyName">The name of the property being checked.</param>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when <paramref name="value"/> is zero or negative.
+    /// </exception>
+    /// <remarks>
+    /// <para>
+    /// Fails loudly rather than letting a zero-width dimension through. A zero produces layers
+    /// that appear to build and then misbehave a long way from the cause, which is far more
+    /// expensive to diagnose than an exception naming the property.
+    /// </para>
+    /// </remarks>
+    protected void Require(int value, string propertyName)
+    {
+        if (value <= 0)
+        {
+            throw new InvalidOperationException(
+                $"{GetType().Name}.{propertyName} is {value}, but it must be greater than zero. "
+                    + $"Set it explicitly, or ensure {GetType().Name}'s parameterless constructor "
+                    + "assigns its model's published default.");
+        }
+    }
+
+    /// <summary>
+    /// Throws when a required rate or ratio has been left unset.
+    /// </summary>
+    /// <param name="value">The value to check.</param>
+    /// <param name="propertyName">The name of the property being checked.</param>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when <paramref name="value"/> is not a finite number greater than zero.
+    /// </exception>
+    protected void Require(double value, string propertyName)
+    {
+        if (double.IsNaN(value) || double.IsInfinity(value) || value <= 0.0)
+        {
+            throw new InvalidOperationException(
+                $"{GetType().Name}.{propertyName} is {value.ToString(System.Globalization.CultureInfo.InvariantCulture)}, "
+                    + "but it must be a finite number greater than zero. Set it explicitly, or ensure "
+                    + $"{GetType().Name}'s parameterless constructor assigns its model's published default.");
+        }
+    }
+}

--- a/src/NeuralNetworks/AudioVisualCorrespondenceNetwork.cs
+++ b/src/NeuralNetworks/AudioVisualCorrespondenceNetwork.cs
@@ -182,24 +182,21 @@ public partial class AudioVisualCorrespondenceNetwork<T> : MultimodalModelLayout
     /// <param name="lossFunction">Loss function for training.</param>
     public AudioVisualCorrespondenceNetwork(
         NeuralNetworkArchitecture<T> architecture,
-        int embeddingDimension = DEFAULT_EMBEDDING_DIM,
-        int audioSampleRate = DEFAULT_SAMPLE_RATE,
-        double videoFrameRate = DEFAULT_FRAME_RATE,
-        int numEncoderLayers = 6,
+        AudioVisualCorrespondenceOptions? options = null,
         IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>>? optimizer = null,
-        ILossFunction<T>? lossFunction = null,
-        AudioVisualCorrespondenceOptions? options = null)
+        ILossFunction<T>? lossFunction = null)
         : base(architecture, lossFunction ?? new MeanSquaredErrorLoss<T>(), 1.0)
     {
         _options = options ?? new AudioVisualCorrespondenceOptions();
+        _options.Validate();
         Options = _options;
 
-        _embeddingDimension = embeddingDimension;
-        _audioSampleRate = audioSampleRate;
-        _audioFrontEnd = CreateAudioFrontEnd(audioSampleRate);
-        _videoFrameRate = videoFrameRate;
-        _numEncoderLayers = numEncoderLayers;
-        _hiddenDim = embeddingDimension * 4;
+        _embeddingDimension = _options.EmbeddingDimension;
+        _audioSampleRate = _options.AudioSampleRate;
+        _audioFrontEnd = CreateAudioFrontEnd(_options.AudioSampleRate);
+        _videoFrameRate = _options.VideoFrameRate;
+        _numEncoderLayers = _options.NumEncoderLayers;
+        _hiddenDim = _options.EmbeddingDimension * 4;
 
         // Paper-faithful learning rate. Arandjelovic & Zisserman 2017
         // "Look, Listen and Learn" (arXiv 1705.08168) §4: SGD with momentum

--- a/src/NeuralNetworks/AudioVisualEventLocalizationNetwork.cs
+++ b/src/NeuralNetworks/AudioVisualEventLocalizationNetwork.cs
@@ -166,30 +166,26 @@ public partial class AudioVisualEventLocalizationNetwork<T> : MultimodalModelLay
     /// </summary>
     public AudioVisualEventLocalizationNetwork(
         NeuralNetworkArchitecture<T> architecture,
-        int embeddingDimension = DEFAULT_EMBEDDING_DIM,
-        double temporalResolution = DEFAULT_TEMPORAL_RESOLUTION,
-        int numEncoderLayers = 6,
+        AudioVisualEventLocalizationOptions? options = null,
         IEnumerable<string>? eventCategories = null,
         IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>>? optimizer = null,
         ILossFunction<T>? lossFunction = null,
-        int? seed = null,
-        AudioVisualEventLocalizationOptions? options = null,
-        int audioEmbeddingFullyConnectedWidth = VGGishAudioEmbedding<double>.PaperFullyConnectedWidth,
-        int audioEmbeddingSize = VGGishAudioEmbedding<double>.PaperEmbeddingSize)
+        int? seed = null)
         : base(architecture, lossFunction ?? new CrossEntropyWithLogitsLoss<T>(), 1.0)
     {
         _options = options ?? new AudioVisualEventLocalizationOptions();
+        _options.Validate();
         Options = _options;
 
         _numOps = MathHelper.GetNumericOperations<T>();
-        _embeddingDimension = embeddingDimension;
-        _temporalResolution = temporalResolution;
-        _numEncoderLayers = numEncoderLayers;
+        _embeddingDimension = _options.EmbeddingDimension;
+        _temporalResolution = _options.TemporalResolution;
+        _numEncoderLayers = _options.NumEncoderLayers;
         // Published VGGish widths by default. Exposed because the published network is ~67M
         // parameters, which is right for fidelity and wrong for a fixture; a caller can shrink it
         // without a second implementation existing.
-        _audioEmbeddingFullyConnectedWidth = audioEmbeddingFullyConnectedWidth;
-        _audioEmbeddingSize = audioEmbeddingSize;
+        _audioEmbeddingFullyConnectedWidth = _options.AudioEmbeddingFullyConnectedWidth;
+        _audioEmbeddingSize = _options.AudioEmbeddingSize;
         _random = seed.HasValue ? RandomHelper.CreateSeededRandom(seed.Value) : RandomHelper.CreateSeededRandom(42);
         _lossFunction = lossFunction ?? new CrossEntropyWithLogitsLoss<T>();
         _optimizer = optimizer ?? new Optimizers.AdamOptimizer<T, Tensor<T>, Tensor<T>>(this);

--- a/src/NeuralNetworks/AudioVisualEventLocalizationNetwork.cs
+++ b/src/NeuralNetworks/AudioVisualEventLocalizationNetwork.cs
@@ -174,8 +174,8 @@ public partial class AudioVisualEventLocalizationNetwork<T> : MultimodalModelLay
         ILossFunction<T>? lossFunction = null,
         int? seed = null,
         AudioVisualEventLocalizationOptions? options = null,
-        int audioEmbeddingFullyConnectedWidth = VGGishAudioEmbedding<T>.PaperFullyConnectedWidth,
-        int audioEmbeddingSize = VGGishAudioEmbedding<T>.PaperEmbeddingSize)
+        int audioEmbeddingFullyConnectedWidth = VGGishAudioEmbedding<double>.PaperFullyConnectedWidth,
+        int audioEmbeddingSize = VGGishAudioEmbedding<double>.PaperEmbeddingSize)
         : base(architecture, lossFunction ?? new CrossEntropyWithLogitsLoss<T>(), 1.0)
     {
         _options = options ?? new AudioVisualEventLocalizationOptions();
@@ -444,7 +444,7 @@ public partial class AudioVisualEventLocalizationNetwork<T> : MultimodalModelLay
 
         int frames = mel.Shape[mel.Shape.Length - 2];
         int mels = mel.Shape[mel.Shape.Length - 1];
-        int patchFrames = VGGishAudioEmbedding<T>.PaperPatchFrames;
+        int patchFrames = VGGishAudioEmbedding<double>.PaperPatchFrames;
         int segments = Math.Max(1, frames / patchFrames);
 
         var melSpan = mel.Data.Span;

--- a/src/NeuralNetworks/BGE.cs
+++ b/src/NeuralNetworks/BGE.cs
@@ -98,28 +98,21 @@ namespace AiDotNet.NeuralNetworks
     }
 
     public BGE(
-            NeuralNetworkArchitecture<T> architecture,
-            ITokenizer? tokenizer = null,
-            IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>>? optimizer = null,
-            int vocabSize = 30522,
-            int embeddingDimension = 768,
-            int maxSequenceLength = 512,
-            int numLayers = 12,
-            int numHeads = 12,
-            int feedForwardDim = 3072,
-            PoolingStrategy poolingStrategy = PoolingStrategy.ClsToken,
-            ILossFunction<T>? lossFunction = null,
-            double maxGradNorm = 1.0,
-            BGEOptions? options = null)
-            : base(architecture, tokenizer, optimizer, vocabSize, embeddingDimension, maxSequenceLength, numLayers, numHeads, feedForwardDim, poolingStrategy, lossFunction, maxGradNorm)
+        NeuralNetworkArchitecture<T> architecture,
+        BGEOptions? options = null,
+        ITokenizer? tokenizer = null,
+        IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>>? optimizer = null,
+        ILossFunction<T>? lossFunction = null)
+            : base(architecture, options, tokenizer, optimizer, lossFunction)
         {
-            _options = options ?? new BGEOptions();
+        _options = options ?? new BGEOptions();
+        _options.Validate();
             Options = _options;
 
-            _vocabSize = vocabSize;
-            _numLayers = numLayers;
-            _numHeads = numHeads;
-            _feedForwardDim = feedForwardDim;
+            _vocabSize = _options.VocabSize;
+            _numLayers = _options.NumLayers;
+            _numHeads = _options.NumHeads;
+            _feedForwardDim = _options.FeedForwardDim;
 
             InitializeLayersCore(false);
         }

--- a/src/NeuralNetworks/BigGAN.cs
+++ b/src/NeuralNetworks/BigGAN.cs
@@ -105,13 +105,11 @@ public partial class BigGAN<T> : GenerativeAdversarialNetwork<T>
         int imageChannels,
         int imageHeight,
         int imageWidth,
-        int generatorChannels = 96,
-        int discriminatorChannels = 96,
-        ILossFunction<T>? lossFunction = null,
-        BigGANOptions? options = null)
+        BigGANOptions? options = null,
+        ILossFunction<T>? lossFunction = null)
         : base(
-            CreateBigGANGeneratorArchitecture(latentSize, imageChannels, imageHeight, imageWidth, generatorChannels),
-            CreateBigGANDiscriminatorArchitecture(imageChannels, imageHeight, imageWidth, discriminatorChannels),
+            CreateBigGANGeneratorArchitecture(latentSize, imageChannels, imageHeight, imageWidth, (options?.GeneratorChannels ?? 96)),
+            CreateBigGANDiscriminatorArchitecture(imageChannels, imageHeight, imageWidth, (options?.DiscriminatorChannels ?? 96)),
             InputType.ThreeDimensional,
             generatorOptimizer: null,
             discriminatorOptimizer: null,
@@ -120,6 +118,8 @@ public partial class BigGAN<T> : GenerativeAdversarialNetwork<T>
             defaultGeneratorOptimizerOptions: CreateAdamOptimizerOptions(0.0001, 0.0, 0.999),
             defaultDiscriminatorOptimizerOptions: CreateAdamOptimizerOptions(0.0004, 0.0, 0.999))
     {
+        _options = options ?? new BigGANOptions();
+        _options.Validate();
         if (latentSize <= 0)
             throw new ArgumentOutOfRangeException(nameof(latentSize), latentSize, "Latent size must be positive.");
         if (numClasses <= 0)
@@ -127,7 +127,6 @@ public partial class BigGAN<T> : GenerativeAdversarialNetwork<T>
         if (classEmbeddingDim <= 0)
             throw new ArgumentOutOfRangeException(nameof(classEmbeddingDim), classEmbeddingDim, "Class embedding dimension must be positive.");
 
-        _options = options ?? new BigGANOptions();
         Options = _options;
         _latentSize = latentSize;
         _numClasses = numClasses;
@@ -135,8 +134,8 @@ public partial class BigGAN<T> : GenerativeAdversarialNetwork<T>
         _imageChannels = imageChannels;
         _imageHeight = imageHeight;
         _imageWidth = imageWidth;
-        _generatorChannels = generatorChannels;
-        _discriminatorChannels = discriminatorChannels;
+        _generatorChannels = _options.GeneratorChannels;
+        _discriminatorChannels = _options.DiscriminatorChannels;
         TruncationThreshold = 1.0;
         UseTruncation = false;
         UseSpectralNormalization = true;
@@ -166,23 +165,12 @@ public partial class BigGAN<T> : GenerativeAdversarialNetwork<T>
     public BigGAN(
         NeuralNetworkArchitecture<T> generatorArchitecture,
         NeuralNetworkArchitecture<T> discriminatorArchitecture,
-        int latentSize = 120,
-        int numClasses = 1000,
-        int classEmbeddingDim = 128,
-        int imageChannels = 3,
-        int imageHeight = 128,
-        int imageWidth = 128,
-        int generatorChannels = 96,
-        int discriminatorChannels = 96,
-        InputType inputType = InputType.TwoDimensional,
-        ILossFunction<T>? lossFunction = null,
-        double initialLearningRate = 0.0001,
-        BigGANOptions? options = null)
-        : this(latentSize, numClasses, classEmbeddingDim,
-               imageChannels > 0 ? imageChannels : (discriminatorArchitecture.InputDepth > 0 ? discriminatorArchitecture.InputDepth : 3),
-               imageHeight > 0 ? imageHeight : (discriminatorArchitecture.InputHeight > 0 ? discriminatorArchitecture.InputHeight : 128),
-               imageWidth > 0 ? imageWidth : (discriminatorArchitecture.InputWidth > 0 ? discriminatorArchitecture.InputWidth : 128),
-               generatorChannels, discriminatorChannels, lossFunction, options)
+        BigGANOptions? options = null,
+        ILossFunction<T>? lossFunction = null)
+        : this((options?.LatentSize ?? 120), (options?.NumClasses ?? 1000), (options?.ClassEmbeddingDim ?? 128),
+               (options?.ImageChannels ?? 3) > 0 ? (options?.ImageChannels ?? 3) : (discriminatorArchitecture.InputDepth > 0 ? discriminatorArchitecture.InputDepth : 3),
+               (options?.ImageHeight ?? 128) > 0 ? (options?.ImageHeight ?? 128) : (discriminatorArchitecture.InputHeight > 0 ? discriminatorArchitecture.InputHeight : 128),
+               (options?.ImageWidth ?? 128) > 0 ? (options?.ImageWidth ?? 128) : (discriminatorArchitecture.InputWidth > 0 ? discriminatorArchitecture.InputWidth : 128), lossFunction: lossFunction, options: options)
     {
     }
 

--- a/src/NeuralNetworks/Blip2NeuralNetwork.cs
+++ b/src/NeuralNetworks/Blip2NeuralNetwork.cs
@@ -349,7 +349,6 @@ public partial class Blip2NeuralNetwork<T> : MultimodalModelLayoutBase<T>, IBlip
         string languageModelPath,
         ITokenizer tokenizer,
         Blip2Options? options = null,
-        LanguageModelBackbone languageModelBackbone = LanguageModelBackbone.OPT,
         IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>>? optimizer = null,
         ILossFunction<T>? lossFunction = null)
         : base(architecture,
@@ -357,6 +356,7 @@ public partial class Blip2NeuralNetwork<T> : MultimodalModelLayoutBase<T>, IBlip
                1.0)
     {
         _options = options ?? new Blip2Options();
+        _options.Validate();
         _options.Validate();
         Options = _options;
 
@@ -378,7 +378,7 @@ public partial class Blip2NeuralNetwork<T> : MultimodalModelLayoutBase<T>, IBlip
         _visionEncoderPath = visionEncoderPath;
         _qformerPath = qformerPath;
         _languageModelPath = languageModelPath;
-        _languageModelBackbone = languageModelBackbone;
+        _languageModelBackbone = _options.LanguageModelBackbone;
         _embeddingDimension = _options.EmbeddingDimension;
         _maxSequenceLength = _options.MaxSequenceLength;
         _imageSize = _options.ImageSize;
@@ -462,7 +462,6 @@ public partial class Blip2NeuralNetwork<T> : MultimodalModelLayoutBase<T>, IBlip
     public Blip2NeuralNetwork(
         NeuralNetworkArchitecture<T> architecture,
         Blip2Options? options = null,
-        LanguageModelBackbone languageModelBackbone = LanguageModelBackbone.OPT,
         ITokenizer? tokenizer = null,
         IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>>? optimizer = null,
         ILossFunction<T>? lossFunction = null)
@@ -471,6 +470,7 @@ public partial class Blip2NeuralNetwork<T> : MultimodalModelLayoutBase<T>, IBlip
                1.0)
     {
         _options = options ?? new Blip2Options();
+        _options.Validate();
         _options.Validate();
         if (_options.ImageSize % _options.PatchSize != 0)
             throw new ArgumentException(
@@ -493,10 +493,10 @@ public partial class Blip2NeuralNetwork<T> : MultimodalModelLayoutBase<T>, IBlip
         _patchSize = _options.PatchSize;
         _vocabularySize = _options.VocabSize;
         _numLmDecoderLayers = _options.NumLmDecoderLayers;
-        _languageModelBackbone = languageModelBackbone;
+        _languageModelBackbone = _options.LanguageModelBackbone;
 
         // Use factory to create appropriate tokenizer for the backbone, or use provided tokenizer
-        _tokenizer = tokenizer ?? Tokenization.LanguageModelTokenizerFactory.CreateForBackbone(languageModelBackbone);
+        _tokenizer = tokenizer ?? Tokenization.LanguageModelTokenizerFactory.CreateForBackbone(_options.LanguageModelBackbone);
         _optimizer = optimizer ?? new AdamOptimizer<T, Tensor<T>, Tensor<T>>(this);
         _lossFunction = lossFunction ?? new ContrastiveLoss<T>();
 

--- a/src/NeuralNetworks/Blip2NeuralNetwork.cs
+++ b/src/NeuralNetworks/Blip2NeuralNetwork.cs
@@ -348,18 +348,16 @@ public partial class Blip2NeuralNetwork<T> : MultimodalModelLayoutBase<T>, IBlip
         string qformerPath,
         string languageModelPath,
         ITokenizer tokenizer,
+        Blip2Options? options = null,
         LanguageModelBackbone languageModelBackbone = LanguageModelBackbone.OPT,
-        int embeddingDimension = 256,
-        int maxSequenceLength = 32,
-        int imageSize = 224,
         IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>>? optimizer = null,
-        ILossFunction<T>? lossFunction = null,
-        Blip2Options? options = null)
+        ILossFunction<T>? lossFunction = null)
         : base(architecture,
                lossFunction ?? new ContrastiveLoss<T>(),
                1.0)
     {
         _options = options ?? new Blip2Options();
+        _options.Validate();
         Options = _options;
 
         // Validate ONNX model paths
@@ -381,9 +379,9 @@ public partial class Blip2NeuralNetwork<T> : MultimodalModelLayoutBase<T>, IBlip
         _qformerPath = qformerPath;
         _languageModelPath = languageModelPath;
         _languageModelBackbone = languageModelBackbone;
-        _embeddingDimension = embeddingDimension;
-        _maxSequenceLength = maxSequenceLength;
-        _imageSize = imageSize;
+        _embeddingDimension = _options.EmbeddingDimension;
+        _maxSequenceLength = _options.MaxSequenceLength;
+        _imageSize = _options.ImageSize;
         _qformerHiddenDim = 768;
         _numQformerLayers = 12;
         _numHeads = 12;
@@ -463,54 +461,38 @@ public partial class Blip2NeuralNetwork<T> : MultimodalModelLayoutBase<T>, IBlip
     /// </remarks>
     public Blip2NeuralNetwork(
         NeuralNetworkArchitecture<T> architecture,
-        int imageSize = 224,
-        int channels = 3,
-        int patchSize = 14,
-        int vocabularySize = 30522,
-        int maxSequenceLength = 32,
-        int embeddingDimension = 256,
-        int qformerHiddenDim = 768,
-        int visionHiddenDim = 1408,
-        int lmHiddenDim = 2560,
-        int numQformerLayers = 12,
-        int numQueryTokens = 32,
-        int numHeads = 12,
-        int numLmDecoderLayers = 6,
+        Blip2Options? options = null,
         LanguageModelBackbone languageModelBackbone = LanguageModelBackbone.OPT,
         ITokenizer? tokenizer = null,
         IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>>? optimizer = null,
-        ILossFunction<T>? lossFunction = null,
-        Blip2Options? options = null)
+        ILossFunction<T>? lossFunction = null)
         : base(architecture,
                lossFunction ?? new ContrastiveLoss<T>(),
                1.0)
     {
-        if (patchSize <= 0)
-            throw new ArgumentOutOfRangeException(nameof(patchSize), "patchSize must be positive.");
-        if (imageSize <= 0)
-            throw new ArgumentOutOfRangeException(nameof(imageSize), "imageSize must be positive.");
-        if (imageSize % patchSize != 0)
-            throw new ArgumentException(
-                $"imageSize ({imageSize}) must be evenly divisible by patchSize ({patchSize}); " +
-                $"got remainder {imageSize % patchSize}.",
-                nameof(imageSize));
-
         _options = options ?? new Blip2Options();
+        _options.Validate();
+        if (_options.ImageSize % _options.PatchSize != 0)
+            throw new ArgumentException(
+                $"_options.ImageSize ({_options.ImageSize}) must be evenly divisible by _options.PatchSize ({_options.PatchSize}); " +
+                $"got remainder {_options.ImageSize % _options.PatchSize}.",
+                nameof(_options.ImageSize));
+
         Options = _options;
 
         _useNativeMode = true;
-        _embeddingDimension = embeddingDimension;
-        _maxSequenceLength = maxSequenceLength;
-        _imageSize = imageSize;
-        _qformerHiddenDim = qformerHiddenDim;
-        _visionHiddenDim = visionHiddenDim;
-        _lmHiddenDim = lmHiddenDim;
-        _numQformerLayers = numQformerLayers;
-        _numHeads = numHeads;
-        _numQueryTokens = numQueryTokens;
-        _patchSize = patchSize;
-        _vocabularySize = vocabularySize;
-        _numLmDecoderLayers = numLmDecoderLayers;
+        _embeddingDimension = _options.EmbeddingDimension;
+        _maxSequenceLength = _options.MaxSequenceLength;
+        _imageSize = _options.ImageSize;
+        _qformerHiddenDim = _options.QformerHiddenDim;
+        _visionHiddenDim = _options.VisionHiddenDim;
+        _lmHiddenDim = _options.LmHiddenDim;
+        _numQformerLayers = _options.NumQformerLayers;
+        _numHeads = _options.NumHeads;
+        _numQueryTokens = _options.NumQueryTokens;
+        _patchSize = _options.PatchSize;
+        _vocabularySize = _options.VocabSize;
+        _numLmDecoderLayers = _options.NumLmDecoderLayers;
         _languageModelBackbone = languageModelBackbone;
 
         // Use factory to create appropriate tokenizer for the backbone, or use provided tokenizer
@@ -518,7 +500,7 @@ public partial class Blip2NeuralNetwork<T> : MultimodalModelLayoutBase<T>, IBlip
         _optimizer = optimizer ?? new AdamOptimizer<T, Tensor<T>, Tensor<T>>(this);
         _lossFunction = lossFunction ?? new ContrastiveLoss<T>();
 
-        InitializeNativeLayers(channels);
+        InitializeNativeLayers(_options.Channels);
     }
 
     #endregion

--- a/src/NeuralNetworks/BlipNeuralNetwork.cs
+++ b/src/NeuralNetworks/BlipNeuralNetwork.cs
@@ -289,17 +289,15 @@ public partial class BlipNeuralNetwork<T> : MultimodalModelLayoutBase<T>, IBlipM
         string textEncoderPath,
         string textDecoderPath,
         ITokenizer tokenizer,
-        int embeddingDimension = 256,
-        int maxSequenceLength = 35,
-        int imageSize = 384,
+        BlipOptions? options = null,
         IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>>? optimizer = null,
-        ILossFunction<T>? lossFunction = null,
-        BlipOptions? options = null)
+        ILossFunction<T>? lossFunction = null)
         : base(architecture,
                lossFunction ?? new ContrastiveLoss<T>(),
                1.0)
     {
         _options = options ?? new BlipOptions();
+        _options.Validate();
         Options = _options;
 
         // Validate ONNX model paths
@@ -320,9 +318,9 @@ public partial class BlipNeuralNetwork<T> : MultimodalModelLayoutBase<T>, IBlipM
         _visionEncoderPath = visionEncoderPath;
         _textEncoderPath = textEncoderPath;
         _textDecoderPath = textDecoderPath;
-        _embeddingDimension = embeddingDimension;
-        _maxSequenceLength = maxSequenceLength;
-        _imageSize = imageSize;
+        _embeddingDimension = _options.EmbeddingDimension;
+        _maxSequenceLength = _options.MaxSequenceLength;
+        _imageSize = _options.ImageSize;
         _hiddenDim = 768;
         _numLayers = 12;
         _numHeads = 12;
@@ -396,39 +394,29 @@ public partial class BlipNeuralNetwork<T> : MultimodalModelLayoutBase<T>, IBlipM
     /// </remarks>
     public BlipNeuralNetwork(
         NeuralNetworkArchitecture<T> architecture,
-        int imageSize = 384,
-        int channels = 3,
-        int patchSize = 16,
-        int vocabularySize = 30522,
-        int maxSequenceLength = 35,
-        int embeddingDimension = 256,
-        int hiddenDim = 768,
-        int numEncoderLayers = 12,
-        int numDecoderLayers = 12,
-        int numHeads = 12,
-        int mlpDim = 3072,
+        BlipOptions? options = null,
         ITokenizer? tokenizer = null,
         IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>>? optimizer = null,
-        ILossFunction<T>? lossFunction = null,
-        BlipOptions? options = null)
+        ILossFunction<T>? lossFunction = null)
         : base(architecture,
                lossFunction ?? new ContrastiveLoss<T>(),
                1.0)
     {
         _options = options ?? new BlipOptions();
+        _options.Validate();
         Options = _options;
 
         _useNativeMode = true;
-        _embeddingDimension = embeddingDimension;
-        _maxSequenceLength = maxSequenceLength;
-        _imageSize = imageSize;
-        _hiddenDim = hiddenDim;
-        _numLayers = numEncoderLayers;
-        _numDecoderLayers = numDecoderLayers;
-        _numHeads = numHeads;
-        _mlpDim = mlpDim;
-        _patchSize = patchSize;
-        _vocabularySize = vocabularySize;
+        _embeddingDimension = _options.EmbeddingDimension;
+        _maxSequenceLength = _options.MaxSequenceLength;
+        _imageSize = _options.ImageSize;
+        _hiddenDim = _options.HiddenDim;
+        _numLayers = _options.NumEncoderLayers;
+        _numDecoderLayers = _options.NumDecoderLayers;
+        _numHeads = _options.NumHeads;
+        _mlpDim = _options.MlpDim;
+        _patchSize = _options.PatchSize;
+        _vocabularySize = _options.VocabSize;
 
         // Create simple tokenizer if not provided
         _tokenizer = tokenizer ?? CreateDefaultTokenizer();

--- a/src/NeuralNetworks/ClipModelLoader.cs
+++ b/src/NeuralNetworks/ClipModelLoader.cs
@@ -212,9 +212,12 @@ public static class ClipModelLoader
             downloadedFiles[config.ImageEncoderFile],
             downloadedFiles[config.TextEncoderFile],
             tokenizer,
-            embeddingDimension: config.EmbeddingDimension,
-            maxSequenceLength: config.MaxSequenceLength,
-            imageSize: config.ImageSize
+            options: new AiDotNet.NeuralNetworks.Options.ClipOptions
+            {
+                EmbeddingDimension = config.EmbeddingDimension,
+                MaxSequenceLength = config.MaxSequenceLength,
+                ImageSize = config.ImageSize,
+            }
         );
     }
 
@@ -274,9 +277,12 @@ public static class ClipModelLoader
             imageEncoderPath,
             textEncoderPath,
             tokenizer,
-            embeddingDimension: config.EmbeddingDimension,
-            maxSequenceLength: config.MaxSequenceLength,
-            imageSize: config.ImageSize
+            options: new AiDotNet.NeuralNetworks.Options.ClipOptions
+            {
+                EmbeddingDimension = config.EmbeddingDimension,
+                MaxSequenceLength = config.MaxSequenceLength,
+                ImageSize = config.ImageSize,
+            }
         );
     }
 

--- a/src/NeuralNetworks/ClipNeuralNetwork.cs
+++ b/src/NeuralNetworks/ClipNeuralNetwork.cs
@@ -98,14 +98,12 @@ public partial class ClipNeuralNetwork<T> : MultimodalModelLayoutBase<T>, IMulti
         string imageEncoderPath,
         string textEncoderPath,
         ITokenizer tokenizer,
-        ILossFunction<T>? lossFunction = null,
-        int embeddingDimension = 512,
-        int maxSequenceLength = 77,
-        int imageSize = 224,
-        ClipOptions? options = null)
+        ClipOptions? options = null,
+        ILossFunction<T>? lossFunction = null)
         : base(architecture, lossFunction ?? new MeanSquaredErrorLoss<T>())
     {
         _options = options ?? new ClipOptions();
+        _options.Validate();
         Options = _options;
 
         if (string.IsNullOrWhiteSpace(imageEncoderPath))
@@ -123,9 +121,9 @@ public partial class ClipNeuralNetwork<T> : MultimodalModelLayoutBase<T>, IMulti
 
         _imageEncoderPath = imageEncoderPath;
         _textEncoderPath = textEncoderPath;
-        _embeddingDimension = embeddingDimension;
-        _maxSequenceLength = maxSequenceLength;
-        _imageSize = imageSize;
+        _embeddingDimension = _options.EmbeddingDimension;
+        _maxSequenceLength = _options.MaxSequenceLength;
+        _imageSize = _options.ImageSize;
 
         using (var sessionOptions = new SessionOptions())
         {

--- a/src/NeuralNetworks/ColBERT.cs
+++ b/src/NeuralNetworks/ColBERT.cs
@@ -95,28 +95,22 @@ namespace AiDotNet.NeuralNetworks
         /// Initializes a new instance of the ColBERT model.
         /// </summary>
         public ColBERT(
-            NeuralNetworkArchitecture<T> architecture,
-            ITokenizer? tokenizer = null,
-            IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>>? optimizer = null,
-            int vocabSize = 30522,
-            int outputDimension = 128,
-            int maxSequenceLength = 512,
-            int numLayers = 12,
-            int numHeads = 12,
-            int feedForwardDim = 3072,
-            ILossFunction<T>? lossFunction = null,
-            double maxGradNorm = 1.0,
-            ColBERTOptions? options = null)
-            : base(architecture, tokenizer, optimizer, vocabSize, 768, maxSequenceLength, numLayers, numHeads, feedForwardDim, PoolingStrategy.Mean, lossFunction, maxGradNorm)
+        NeuralNetworkArchitecture<T> architecture,
+        ColBERTOptions? options = null,
+        ITokenizer? tokenizer = null,
+        IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>>? optimizer = null,
+        ILossFunction<T>? lossFunction = null)
+            : base(architecture, options, tokenizer, optimizer, lossFunction)
         {
-            _options = options ?? new ColBERTOptions();
+        _options = options ?? new ColBERTOptions();
+        _options.Validate();
             Options = _options;
 
-            _outputDim = outputDimension;
-            _vocabSize = vocabSize;
-            _numLayers = numLayers;
-            _numHeads = numHeads;
-            _feedForwardDim = feedForwardDim;
+            _outputDim = _options.OutputDimension;
+            _vocabSize = _options.VocabSize;
+            _numLayers = _options.NumLayers;
+            _numHeads = _options.NumHeads;
+            _feedForwardDim = _options.FeedForwardDim;
             _tokenizer = tokenizer ?? Tokenization.LanguageModelTokenizerFactory.CreateForBackbone(LanguageModelBackbone.OPT);
 
             InitializeLayersCore(false);

--- a/src/NeuralNetworks/CycleGAN.cs
+++ b/src/NeuralNetworks/CycleGAN.cs
@@ -274,18 +274,17 @@ public partial class CycleGAN<T> : ImageTranslationModelLayoutBase<T>
         NeuralNetworkArchitecture<T> discriminatorA,
         NeuralNetworkArchitecture<T> discriminatorB,
         InputType inputType,
+        CycleGANOptions? options = null,
         IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>>? generatorAtoBOptimizer = null,
         IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>>? generatorBtoAOptimizer = null,
         IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>>? discriminatorAOptimizer = null,
         IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>>? discriminatorBOptimizer = null,
-        ILossFunction<T>? lossFunction = null,
-        double cycleConsistencyLambda = 10.0,
-        double identityLambda = 5.0,
-        CycleGANOptions? options = null)
+        ILossFunction<T>? lossFunction = null)
         : base(CreateCycleGANArchitecture(generatorAtoB, inputType),
                lossFunction ?? NeuralNetworkHelper<T>.GetDefaultLossFunction(NeuralNetworkTaskType.Generative))
     {
         _options = options ?? new CycleGANOptions();
+        _options.Validate();
         Options = _options;
 
         // Validate constructor inputs
@@ -305,17 +304,17 @@ public partial class CycleGAN<T> : ImageTranslationModelLayoutBase<T>
         {
             throw new ArgumentNullException(nameof(discriminatorB), "Discriminator B architecture cannot be null.");
         }
-        if (cycleConsistencyLambda < 0)
+        if (_options.CycleConsistencyLambda < 0)
         {
-            throw new ArgumentOutOfRangeException(nameof(cycleConsistencyLambda), cycleConsistencyLambda, "Cycle consistency lambda must be non-negative.");
+            throw new ArgumentOutOfRangeException(nameof(_options.CycleConsistencyLambda), _options.CycleConsistencyLambda, "Cycle consistency lambda must be non-negative.");
         }
-        if (identityLambda < 0)
+        if (_options.IdentityLambda < 0)
         {
-            throw new ArgumentOutOfRangeException(nameof(identityLambda), identityLambda, "Identity lambda must be non-negative.");
+            throw new ArgumentOutOfRangeException(nameof(_options.IdentityLambda), _options.IdentityLambda, "Identity lambda must be non-negative.");
         }
 
-        _cycleConsistencyLambda = NumOps.FromDouble(cycleConsistencyLambda);
-        _identityLambda = NumOps.FromDouble(identityLambda);
+        _cycleConsistencyLambda = NumOps.FromDouble(_options.CycleConsistencyLambda);
+        _identityLambda = NumOps.FromDouble(_options.IdentityLambda);
 
         GeneratorAtoB = CreateNetworkForInputType(generatorAtoB, inputType);
         GeneratorBtoA = CreateNetworkForInputType(generatorBtoA, inputType);

--- a/src/NeuralNetworks/DCGAN.cs
+++ b/src/NeuralNetworks/DCGAN.cs
@@ -78,15 +78,11 @@ public partial class DCGAN<T> : GenerativeAdversarialNetwork<T>
     /// <param name="options">Optional DCGAN options.</param>
     public DCGAN(
         NeuralNetworkArchitecture<T> architecture,
-        int latentSize = 100,
-        int generatorFeatureMaps = 64,
-        int discriminatorFeatureMaps = 64,
         DCGANOptions? options = null)
-        : this(latentSize,
+        : this((options?.LatentSize ?? 100),
                architecture.InputDepth > 0 ? architecture.InputDepth : 3,
                architecture.InputHeight > 0 ? architecture.InputHeight : 64,
                architecture.InputWidth > 0 ? architecture.InputWidth : 64,
-               generatorFeatureMaps, discriminatorFeatureMaps,
                lossFunction: null, options: options)
     {
     }
@@ -126,13 +122,11 @@ public partial class DCGAN<T> : GenerativeAdversarialNetwork<T>
         int imageChannels,
         int imageHeight,
         int imageWidth,
-        int generatorFeatureMaps = 64,
-        int discriminatorFeatureMaps = 64,
-        ILossFunction<T>? lossFunction = null,
-        DCGANOptions? options = null)
+        DCGANOptions? options = null,
+        ILossFunction<T>? lossFunction = null)
         : base(
-            CreateDCGANGeneratorArchitecture(latentSize, imageChannels, imageHeight, imageWidth, generatorFeatureMaps),
-            CreateDCGANDiscriminatorArchitecture(imageChannels, imageHeight, imageWidth, discriminatorFeatureMaps),
+            CreateDCGANGeneratorArchitecture(latentSize, imageChannels, imageHeight, imageWidth, (options?.GeneratorChannels ?? 64)),
+            CreateDCGANDiscriminatorArchitecture(imageChannels, imageHeight, imageWidth, (options?.DiscriminatorChannels ?? 64)),
             InputType.ThreeDimensional,
             generatorOptimizer: null,
             discriminatorOptimizer: null,
@@ -159,6 +153,7 @@ public partial class DCGAN<T> : GenerativeAdversarialNetwork<T>
             defaultDiscriminatorOptimizerOptions: CreateAdamOptimizerOptions(0.0002, 0.5))
     {
         _options = options ?? new DCGANOptions();
+        _options.Validate();
         Options = _options;
         // Remember construction params so CreateNewInstance can rebuild a
         // fresh DCGAN with identical architecture rather than going through
@@ -171,8 +166,8 @@ public partial class DCGAN<T> : GenerativeAdversarialNetwork<T>
         _imageChannels = imageChannels;
         _imageHeight = imageHeight;
         _imageWidth = imageWidth;
-        _generatorFeatureMaps = generatorFeatureMaps;
-        _discriminatorFeatureMaps = discriminatorFeatureMaps;
+        _generatorFeatureMaps = _options.GeneratorChannels;
+        _discriminatorFeatureMaps = _options.DiscriminatorChannels;
 
         // DCGAN paper Adam (Radford et al. 2016 §4: lr=2e-4, β1=0.5) on the optimizer the
         // networks ACTUALLY train through — NeuralNetworkBase.GetOrCreateBaseOptimizer,

--- a/src/NeuralNetworks/EagleLanguageModel.cs
+++ b/src/NeuralNetworks/EagleLanguageModel.cs
@@ -69,13 +69,8 @@ public partial class EagleLanguageModel<T> : TokenLanguageModelLayoutBase<T>
 
     public EagleLanguageModel(
         NeuralNetworkArchitecture<T> architecture,
-        int vocabSize = 65536,
-        int modelDimension = 256,
-        int numLayers = 4,
-        int numHeads = 8,
-        int maxSeqLength = 512,
-        ILossFunction<T>? lossFunction = null,
-        EagleOptions? options = null)
+        EagleOptions? options = null,
+        ILossFunction<T>? lossFunction = null)
         : base(architecture,
             // Raw-logit LM head → cross-entropy-with-logits (fused log-softmax + NLL), not the
             // TextGeneration default CategoricalCrossEntropy (which log()s un-normalized logits and
@@ -83,12 +78,13 @@ public partial class EagleLanguageModel<T> : TokenLanguageModelLayoutBase<T>
             lossFunction ?? new AiDotNet.LossFunctions.CrossEntropyWithLogitsLoss<T>())
     {
         _options = options ?? new EagleOptions();
+        _options.Validate();
         Options = _options;
-        _vocabSize = vocabSize;
-        _modelDimension = modelDimension;
-        _numLayers = numLayers;
-        _numHeads = numHeads;
-        _maxSeqLength = maxSeqLength;
+        _vocabSize = _options.VocabSize;
+        _modelDimension = _options.ModelDimension;
+        _numLayers = _options.NumLayers;
+        _numHeads = _options.NumHeads;
+        _maxSeqLength = _options.MaxSequenceLength;
         InitializeLayers();
     }
 

--- a/src/NeuralNetworks/FalconMambaLanguageModel.cs
+++ b/src/NeuralNetworks/FalconMambaLanguageModel.cs
@@ -68,16 +68,10 @@ public partial class FalconMambaLanguageModel<T> : TokenLanguageModelLayoutBase<
 
     public FalconMambaLanguageModel(
         NeuralNetworkArchitecture<T> architecture,
-        int vocabSize = 65024,
-        int modelDimension = 256,
-        int numLayers = 4,
-        int stateDimension = 16,
-        int expandFactor = 2,
-        int maxSeqLength = 512,
-        ILossFunction<T>? lossFunction = null,
-        FalconMambaOptions? options = null)
+        FalconMambaOptions? options = null,
+        ILossFunction<T>? lossFunction = null)
         : base(architecture,
-            // The LM head (DenseLayer(vocabSize, activation: null) in
+            // The LM head (DenseLayer(_options.VocabSize, activation: null) in
             // CreateFalconMambaLayers) emits RAW LOGITS, so the default loss
             // must be the logits-domain cross-entropy (log_softmax + NLL,
             // PyTorch nn.CrossEntropyLoss semantics). The TextGeneration
@@ -88,13 +82,14 @@ public partial class FalconMambaLanguageModel<T> : TokenLanguageModelLayoutBase<
             lossFunction ?? new LossFunctions.CrossEntropyWithLogitsLoss<T>())
     {
         _options = options ?? new FalconMambaOptions();
+        _options.Validate();
         Options = _options;
-        _vocabSize = vocabSize;
-        _modelDimension = modelDimension;
-        _numLayers = numLayers;
-        _stateDimension = stateDimension;
-        _expandFactor = expandFactor;
-        _maxSeqLength = maxSeqLength;
+        _vocabSize = _options.VocabSize;
+        _modelDimension = _options.ModelDimension;
+        _numLayers = _options.NumLayers;
+        _stateDimension = _options.StateDimension;
+        _expandFactor = _options.ExpandFactor;
+        _maxSeqLength = _options.MaxSequenceLength;
         InitializeLayers();
     }
 

--- a/src/NeuralNetworks/FastText.cs
+++ b/src/NeuralNetworks/FastText.cs
@@ -132,25 +132,21 @@ namespace AiDotNet.NeuralNetworks
         /// <param name="lossFunction">Optional loss function. Defaults to Binary Cross Entropy.</param>
         /// <param name="maxGradNorm">Maximum gradient norm for stability (default: 1.0).</param>
     public FastText(
-            NeuralNetworkArchitecture<T> architecture,
-            ITokenizer? tokenizer = null,
-            IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>>? optimizer = null,
-            int vocabSize = 10000,
-            int bucketSize = 2000000,
-            int embeddingDimension = 100,
-            int maxTokens = 512,
-            ILossFunction<T>? lossFunction = null,
-            double maxGradNorm = 1.0,
-            FastTextOptions? options = null)
-            : base(architecture, lossFunction ?? new CategoricalCrossEntropyLoss<T>(), maxGradNorm)
+        NeuralNetworkArchitecture<T> architecture,
+        FastTextOptions? options = null,
+        ITokenizer? tokenizer = null,
+        IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>>? optimizer = null,
+        ILossFunction<T>? lossFunction = null)
+            : base(architecture, lossFunction ?? new CategoricalCrossEntropyLoss<T>(), options?.MaxGradNorm ?? 1.0)
         {
-            _options = options ?? new FastTextOptions();
+        _options = options ?? new FastTextOptions();
+        _options.Validate();
             Options = _options;
             _tokenizer = tokenizer;
-            _vocabSize = vocabSize;
-            _bucketSize = bucketSize;
-            _embeddingDimension = embeddingDimension;
-            _maxTokens = maxTokens;
+            _vocabSize = _options.VocabSize;
+            _bucketSize = _options.BucketSize;
+            _embeddingDimension = _options.EmbeddingDimension;
+            _maxTokens = _options.MaxSequenceLength;
             // FastText's head is a vocab-wide SoftmaxActivation; its training objective is
             // the multinomial cross-entropy over classes (Joulin et al. 2016 "Bag of Tricks"
             // minimizes softmax NLL). The previous BinaryCrossEntropyLoss treats each of the

--- a/src/NeuralNetworks/FinchLanguageModel.cs
+++ b/src/NeuralNetworks/FinchLanguageModel.cs
@@ -71,14 +71,8 @@ public partial class FinchLanguageModel<T> : TokenLanguageModelLayoutBase<T>
 
     public FinchLanguageModel(
         NeuralNetworkArchitecture<T> architecture,
-        int vocabSize = 65536,
-        int modelDimension = 256,
-        int numLayers = 4,
-        int numHeads = 8,
-        int maxSeqLength = 512,
-        ILossFunction<T>? lossFunction = null,
         FinchOptions? options = null,
-        double learningRate = 0.001)
+        ILossFunction<T>? lossFunction = null)
         : base(architecture,
             // Raw-logit LM head → cross-entropy-with-logits (fused log-softmax + NLL), not the
             // TextGeneration default CategoricalCrossEntropy (which log()s un-normalized logits and
@@ -86,13 +80,14 @@ public partial class FinchLanguageModel<T> : TokenLanguageModelLayoutBase<T>
             lossFunction ?? new AiDotNet.LossFunctions.CrossEntropyWithLogitsLoss<T>())
     {
         _options = options ?? new FinchOptions();
+        _options.Validate();
         Options = _options;
-        _vocabSize = vocabSize;
-        _modelDimension = modelDimension;
-        _numLayers = numLayers;
-        _numHeads = numHeads;
-        _maxSeqLength = maxSeqLength;
-        _learningRate = learningRate;
+        _vocabSize = _options.VocabSize;
+        _modelDimension = _options.ModelDimension;
+        _numLayers = _options.NumLayers;
+        _numHeads = _options.NumHeads;
+        _maxSeqLength = _options.MaxSequenceLength;
+        _learningRate = _options.LearningRate;
         InitializeLayers();
     }
 

--- a/src/NeuralNetworks/FlamingoNeuralNetwork.cs
+++ b/src/NeuralNetworks/FlamingoNeuralNetwork.cs
@@ -171,6 +171,7 @@ public partial class FlamingoNeuralNetwork<T> : MultimodalModelLayoutBase<T>, IF
     {
         _options = options ?? new FlamingoOptions();
         _options.Validate();
+        _options.Validate();
         Options = _options;
         if (string.IsNullOrWhiteSpace(visionEncoderPath))
             throw new ArgumentException("Vision encoder path cannot be null or empty.", nameof(visionEncoderPath));
@@ -237,13 +238,13 @@ public partial class FlamingoNeuralNetwork<T> : MultimodalModelLayoutBase<T>, IF
     public FlamingoNeuralNetwork(
         NeuralNetworkArchitecture<T> architecture,
         FlamingoOptions? options = null,
-        LanguageModelBackbone languageModelBackbone = LanguageModelBackbone.Chinchilla,
         ITokenizer? tokenizer = null,
         IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>>? optimizer = null,
         ILossFunction<T>? lossFunction = null)
         : base(architecture, lossFunction ?? new CrossEntropyWithLogitsLoss<T>(), 1.0)
     {
         _options = options ?? new FlamingoOptions();
+        _options.Validate();
         _options.Validate();
         // Validated here, at the public entry point, rather than where it is first used. ConvertToTensor
         // divides by the channel count, and InitializeNativeLayers sizes the patch embedding from it, so
@@ -269,12 +270,12 @@ public partial class FlamingoNeuralNetwork<T> : MultimodalModelLayoutBase<T>, IF
         _numHeads = _options.NumHeads;
         _patchSize = 14;
         _vocabularySize = _options.VocabSize;
-        _languageModelBackbone = languageModelBackbone;
+        _languageModelBackbone = _options.LanguageModelBackbone;
         _numPerceiverLayers = _options.NumPerceiverLayers;
         _learningRate = _options.LearningRate;
 
         // Use factory to create appropriate tokenizer for the backbone, or use provided tokenizer
-        _tokenizer = tokenizer ?? Tokenization.LanguageModelTokenizerFactory.CreateForBackbone(languageModelBackbone);
+        _tokenizer = tokenizer ?? Tokenization.LanguageModelTokenizerFactory.CreateForBackbone(_options.LanguageModelBackbone);
         _optimizer = optimizer ?? new AdamOptimizer<T, Tensor<T>, Tensor<T>>(
             this,
             new AiDotNet.Models.Options.AdamOptimizerOptions<T, Tensor<T>, Tensor<T>>

--- a/src/NeuralNetworks/FlamingoNeuralNetwork.cs
+++ b/src/NeuralNetworks/FlamingoNeuralNetwork.cs
@@ -164,17 +164,13 @@ public partial class FlamingoNeuralNetwork<T> : MultimodalModelLayoutBase<T>, IF
         string visionEncoderPath,
         string languageModelPath,
         ITokenizer tokenizer,
-        int embeddingDimension = 768,
-        int maxSequenceLength = 2048,
-        int imageSize = 224,
-        int numPerceiverTokens = 64,
-        int maxImagesInContext = 5,
+        FlamingoOptions? options = null,
         IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>>? optimizer = null,
-        ILossFunction<T>? lossFunction = null,
-        FlamingoOptions? options = null)
+        ILossFunction<T>? lossFunction = null)
         : base(architecture, lossFunction ?? new CrossEntropyWithLogitsLoss<T>(), 1.0)
     {
         _options = options ?? new FlamingoOptions();
+        _options.Validate();
         Options = _options;
         if (string.IsNullOrWhiteSpace(visionEncoderPath))
             throw new ArgumentException("Vision encoder path cannot be null or empty.", nameof(visionEncoderPath));
@@ -188,11 +184,11 @@ public partial class FlamingoNeuralNetwork<T> : MultimodalModelLayoutBase<T>, IF
         _useNativeMode = false;
         _visionEncoderPath = visionEncoderPath;
         _languageModelPath = languageModelPath;
-        _embeddingDimension = embeddingDimension;
-        _maxSequenceLength = maxSequenceLength;
-        _imageSize = imageSize;
-        _numPerceiverTokens = numPerceiverTokens;
-        _maxImagesInContext = maxImagesInContext;
+        _embeddingDimension = _options.EmbeddingDimension;
+        _maxSequenceLength = _options.MaxSequenceLength;
+        _imageSize = _options.ImageSize;
+        _numPerceiverTokens = _options.NumPerceiverTokens;
+        _maxImagesInContext = _options.MaxImagesInContext;
         _visionHiddenDim = 1024;
         _lmHiddenDim = 2048;
         _numVisionLayers = 24;
@@ -240,55 +236,42 @@ public partial class FlamingoNeuralNetwork<T> : MultimodalModelLayoutBase<T>, IF
     /// </summary>
     public FlamingoNeuralNetwork(
         NeuralNetworkArchitecture<T> architecture,
-        int embeddingDimension = 768,
-        int maxSequenceLength = 2048,
-        int imageSize = 224,
-        int channels = 3,
-        int numPerceiverTokens = 64,
-        int maxImagesInContext = 5,
-        int visionHiddenDim = 1024,
-        int lmHiddenDim = 2048,
-        int numVisionLayers = 24,
-        int numLmLayers = 32,
-        int numHeads = 16,
-        int vocabularySize = 32000,
+        FlamingoOptions? options = null,
         LanguageModelBackbone languageModelBackbone = LanguageModelBackbone.Chinchilla,
-        int numPerceiverLayers = 6,
         ITokenizer? tokenizer = null,
         IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>>? optimizer = null,
-        ILossFunction<T>? lossFunction = null,
-        FlamingoOptions? options = null,
-        double learningRate = 1e-3)
+        ILossFunction<T>? lossFunction = null)
         : base(architecture, lossFunction ?? new CrossEntropyWithLogitsLoss<T>(), 1.0)
     {
+        _options = options ?? new FlamingoOptions();
+        _options.Validate();
         // Validated here, at the public entry point, rather than where it is first used. ConvertToTensor
         // divides by the channel count, and InitializeNativeLayers sizes the patch embedding from it, so
         // a zero or negative value surfaces as a DivideByZeroException or an invalid tensor shape from
         // somewhere well downstream of the argument that caused it.
-        if (channels <= 0)
+        if (_options.Channels <= 0)
         {
             throw new ArgumentOutOfRangeException(
-                nameof(channels), channels, "The channel count must be positive.");
+                nameof(_options.Channels), _options.Channels, "The channel count must be positive.");
         }
 
-        _options = options ?? new FlamingoOptions();
         Options = _options;
         _useNativeMode = true;
-        _embeddingDimension = embeddingDimension;
-        _maxSequenceLength = maxSequenceLength;
-        _imageSize = imageSize;
-        _numPerceiverTokens = numPerceiverTokens;
-        _maxImagesInContext = maxImagesInContext;
-        _visionHiddenDim = visionHiddenDim;
-        _lmHiddenDim = lmHiddenDim;
-        _numVisionLayers = numVisionLayers;
-        _numLmLayers = numLmLayers;
-        _numHeads = numHeads;
+        _embeddingDimension = _options.EmbeddingDimension;
+        _maxSequenceLength = _options.MaxSequenceLength;
+        _imageSize = _options.ImageSize;
+        _numPerceiverTokens = _options.NumPerceiverTokens;
+        _maxImagesInContext = _options.MaxImagesInContext;
+        _visionHiddenDim = _options.VisionHiddenDim;
+        _lmHiddenDim = _options.LmHiddenDim;
+        _numVisionLayers = _options.NumVisionLayers;
+        _numLmLayers = _options.NumLmLayers;
+        _numHeads = _options.NumHeads;
         _patchSize = 14;
-        _vocabularySize = vocabularySize;
+        _vocabularySize = _options.VocabSize;
         _languageModelBackbone = languageModelBackbone;
-        _numPerceiverLayers = numPerceiverLayers;
-        _learningRate = learningRate;
+        _numPerceiverLayers = _options.NumPerceiverLayers;
+        _learningRate = _options.LearningRate;
 
         // Use factory to create appropriate tokenizer for the backbone, or use provided tokenizer
         _tokenizer = tokenizer ?? Tokenization.LanguageModelTokenizerFactory.CreateForBackbone(languageModelBackbone);
@@ -296,13 +279,13 @@ public partial class FlamingoNeuralNetwork<T> : MultimodalModelLayoutBase<T>, IF
             this,
             new AiDotNet.Models.Options.AdamOptimizerOptions<T, Tensor<T>, Tensor<T>>
             {
-                InitialLearningRate = learningRate,
+                InitialLearningRate = _options.LearningRate,
                 MaxGradientNorm = 1.0
             });
         _lossFunction = lossFunction ?? new CrossEntropyWithLogitsLoss<T>();
 
-        _channels = channels;
-        InitializeNativeLayers(channels);
+        _channels = _options.Channels;
+        InitializeNativeLayers(_options.Channels);
     }
 
     /// <inheritdoc/>

--- a/src/NeuralNetworks/GLALanguageModel.cs
+++ b/src/NeuralNetworks/GLALanguageModel.cs
@@ -66,24 +66,20 @@ public partial class GLALanguageModel<T> : TokenLanguageModelLayoutBase<T>
 
     public GLALanguageModel(
         NeuralNetworkArchitecture<T> architecture,
-        int vocabSize = 50277,
-        int modelDimension = 256,
-        int numLayers = 4,
-        int numHeads = 8,
-        int maxSeqLength = 512,
-        ILossFunction<T>? lossFunction = null,
         GLAOptions? options = null,
+        ILossFunction<T>? lossFunction = null,
         IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>>? optimizer = null)
         : base(architecture,
             lossFunction ?? new AiDotNet.LossFunctions.CrossEntropyWithLogitsLoss<T>())
     {
         _options = options ?? new GLAOptions();
+        _options.Validate();
         Options = _options;
-        _vocabSize = vocabSize;
-        _modelDimension = modelDimension;
-        _numLayers = numLayers;
-        _numHeads = numHeads;
-        _maxSeqLength = maxSeqLength;
+        _vocabSize = _options.VocabSize;
+        _modelDimension = _options.ModelDimension;
+        _numLayers = _options.NumLayers;
+        _numHeads = _options.NumHeads;
+        _maxSeqLength = _options.MaxSequenceLength;
         // THE PAPER'S RATE, NOT THE LIBRARY DEFAULT. Constructing AdamWOptimizer with no options
         // silently trained at InitialLearningRate = 1e-3, which is neither the published rate nor
         // something the caller could change short of building the whole optimizer themselves.

--- a/src/NeuralNetworks/GatedDeltaNetLanguageModel.cs
+++ b/src/NeuralNetworks/GatedDeltaNetLanguageModel.cs
@@ -66,24 +66,20 @@ public partial class GatedDeltaNetLanguageModel<T> : TokenLanguageModelLayoutBas
 
     public GatedDeltaNetLanguageModel(
         NeuralNetworkArchitecture<T> architecture,
-        int vocabSize = 50277,
-        int modelDimension = 256,
-        int numLayers = 4,
-        int numHeads = 8,
-        int maxSeqLength = 512,
-        ILossFunction<T>? lossFunction = null,
         GatedDeltaNetOptions? options = null,
+        ILossFunction<T>? lossFunction = null,
         IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>>? optimizer = null)
         : base(architecture,
             lossFunction ?? new AiDotNet.LossFunctions.CrossEntropyWithLogitsLoss<T>())
     {
         _options = options ?? new GatedDeltaNetOptions();
+        _options.Validate();
         Options = _options;
-        _vocabSize = vocabSize;
-        _modelDimension = modelDimension;
-        _numLayers = numLayers;
-        _numHeads = numHeads;
-        _maxSeqLength = maxSeqLength;
+        _vocabSize = _options.VocabSize;
+        _modelDimension = _options.ModelDimension;
+        _numLayers = _options.NumLayers;
+        _numHeads = _options.NumHeads;
+        _maxSeqLength = _options.MaxSequenceLength;
         // THE PAPER'S RATE, NOT THE LIBRARY DEFAULT. Constructing AdamWOptimizer with no options
         // silently trained at InitialLearningRate = 1e-3, which is neither the published rate nor
         // something the caller could change short of building the whole optimizer themselves.

--- a/src/NeuralNetworks/GloVe.cs
+++ b/src/NeuralNetworks/GloVe.cs
@@ -213,23 +213,20 @@ namespace AiDotNet.NeuralNetworks
         /// decide how many words it should know and how detailed its "dictionary" should be.
         /// </remarks>
         public GloVe(
-            NeuralNetworkArchitecture<T> architecture,
-            ITokenizer? tokenizer = null,
-            IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>>? optimizer = null,
-            int vocabSize = 10000,
-            int embeddingDimension = 100,
-            int maxTokens = 512,
-            ILossFunction<T>? lossFunction = null,
-            double maxGradNorm = 1.0,
-            GloVeOptions? options = null)
-            : base(architecture, lossFunction ?? new MeanSquaredErrorLoss<T>(), maxGradNorm)
+        NeuralNetworkArchitecture<T> architecture,
+        GloVeOptions? options = null,
+        ITokenizer? tokenizer = null,
+        IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>>? optimizer = null,
+        ILossFunction<T>? lossFunction = null)
+            : base(architecture, lossFunction ?? new MeanSquaredErrorLoss<T>(), options?.MaxGradNorm ?? 1.0)
         {
-            _options = options ?? new GloVeOptions();
+        _options = options ?? new GloVeOptions();
+        _options.Validate();
             Options = _options;
             _tokenizer = tokenizer;
-            _vocabSize = vocabSize;
-            _embeddingDimension = embeddingDimension;
-            _maxTokens = maxTokens;
+            _vocabSize = _options.VocabSize;
+            _embeddingDimension = _options.EmbeddingDimension;
+            _maxTokens = _options.MaxSequenceLength;
             _lossFunction = lossFunction ?? new MeanSquaredErrorLoss<T>();
             // Paper-faithful default: Pennington et al. 2014, Section 4.4
             // ("Model Analysis: Vector Length and Context Size") — "we use

--- a/src/NeuralNetworks/Gpt4VisionNeuralNetwork.cs
+++ b/src/NeuralNetworks/Gpt4VisionNeuralNetwork.cs
@@ -178,17 +178,12 @@ public partial class Gpt4VisionNeuralNetwork<T> : MultimodalModelLayoutBase<T>, 
         string visionEncoderPath,
         string languageModelPath,
         ITokenizer tokenizer,
-        int embeddingDimension = 4096,
-        int visionEmbeddingDim = 1024,
-        int maxSequenceLength = 2048,
-        int contextWindowSize = 128000,
-        int imageSize = 336,
-        int maxImagesPerRequest = 10,
-        ILossFunction<T>? lossFunction = null,
-        Gpt4VisionOptions? options = null)
+        Gpt4VisionOptions? options = null,
+        ILossFunction<T>? lossFunction = null)
         : base(architecture, lossFunction ?? new CrossEntropyWithLogitsLoss<T>(), 1.0)
     {
         _options = options ?? new Gpt4VisionOptions();
+        _options.Validate();
         Options = _options;
         // Validate ONNX model paths
         if (string.IsNullOrWhiteSpace(visionEncoderPath))
@@ -205,16 +200,16 @@ public partial class Gpt4VisionNeuralNetwork<T> : MultimodalModelLayoutBase<T>, 
         _languageModelPath = languageModelPath;
         Guard.NotNull(tokenizer);
         _tokenizer = tokenizer;
-        _embeddingDimension = embeddingDimension;
-        _visionEmbeddingDim = visionEmbeddingDim;
-        _maxSequenceLength = maxSequenceLength;
-        _contextWindowSize = contextWindowSize;
-        _imageSize = imageSize;
-        _maxImagesPerRequest = maxImagesPerRequest;
+        _embeddingDimension = _options.EmbeddingDimension;
+        _visionEmbeddingDim = _options.VisionEmbeddingDim;
+        _maxSequenceLength = _options.MaxSequenceLength;
+        _contextWindowSize = _options.ContextWindowSize;
+        _imageSize = _options.ImageSize;
+        _maxImagesPerRequest = _options.MaxImagesPerRequest;
         _maxImageResolution = (2048, 2048);
         _supportedDetailLevels = new List<string> { "low", "high", "auto" };
         _vocabularySize = 128256;
-        _hiddenDim = embeddingDimension;
+        _hiddenDim = _options.EmbeddingDimension;
         _numVisionLayers = 24;
         _numLanguageLayers = 32;
         _numHeads = 32;
@@ -229,39 +224,28 @@ public partial class Gpt4VisionNeuralNetwork<T> : MultimodalModelLayoutBase<T>, 
     public Gpt4VisionNeuralNetwork(
         NeuralNetworkArchitecture<T> architecture,
         ITokenizer tokenizer,
-        int embeddingDimension = 4096,
-        int visionEmbeddingDim = 1024,
-        int maxSequenceLength = 2048,
-        int contextWindowSize = 128000,
-        int imageSize = 336,
-        int hiddenDim = 4096,
-        int numVisionLayers = 24,
-        int numLanguageLayers = 32,
-        int numHeads = 32,
-        int patchSize = 14,
-        int vocabularySize = 128256,
-        int maxImagesPerRequest = 10,
-        ILossFunction<T>? lossFunction = null,
-        Gpt4VisionOptions? options = null)
+        Gpt4VisionOptions? options = null,
+        ILossFunction<T>? lossFunction = null)
         : base(architecture, lossFunction ?? new CrossEntropyWithLogitsLoss<T>(), 1.0)
     {
         _options = options ?? new Gpt4VisionOptions();
+        _options.Validate();
         Options = _options;
         _useNativeMode = true;
         Guard.NotNull(tokenizer);
         _tokenizer = tokenizer;
-        _embeddingDimension = embeddingDimension;
-        _visionEmbeddingDim = visionEmbeddingDim;
-        _maxSequenceLength = maxSequenceLength;
-        _contextWindowSize = contextWindowSize;
-        _imageSize = imageSize;
-        _hiddenDim = hiddenDim;
-        _numVisionLayers = numVisionLayers;
-        _numLanguageLayers = numLanguageLayers;
-        _numHeads = numHeads;
-        _patchSize = patchSize;
-        _vocabularySize = vocabularySize;
-        _maxImagesPerRequest = maxImagesPerRequest;
+        _embeddingDimension = _options.EmbeddingDimension;
+        _visionEmbeddingDim = _options.VisionEmbeddingDim;
+        _maxSequenceLength = _options.MaxSequenceLength;
+        _contextWindowSize = _options.ContextWindowSize;
+        _imageSize = _options.ImageSize;
+        _hiddenDim = _options.HiddenDim;
+        _numVisionLayers = _options.NumVisionLayers;
+        _numLanguageLayers = _options.NumLanguageLayers;
+        _numHeads = _options.NumHeads;
+        _patchSize = _options.PatchSize;
+        _vocabularySize = _options.VocabSize;
+        _maxImagesPerRequest = _options.MaxImagesPerRequest;
         _maxImageResolution = (2048, 2048);
         _supportedDetailLevels = new List<string> { "low", "high", "auto" };
 

--- a/src/NeuralNetworks/GriffinLanguageModel.cs
+++ b/src/NeuralNetworks/GriffinLanguageModel.cs
@@ -65,23 +65,20 @@ public partial class GriffinLanguageModel<T> : TokenLanguageModelLayoutBase<T>
 
     public GriffinLanguageModel(
         NeuralNetworkArchitecture<T> architecture,
-        int vocabSize = 256000,
-        int modelDimension = 2048,
-        int numLayers = 24,
-        int maxSeqLength = 2048,
-        ILossFunction<T>? lossFunction = null,
         GriffinOptions? options = null,
+        ILossFunction<T>? lossFunction = null,
         IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>>? optimizer = null)
         : base(architecture,
             lossFunction ?? new AiDotNet.LossFunctions.CrossEntropyWithLogitsLoss<T>())
     {
         _options = options ?? new GriffinOptions();
+        _options.Validate();
         Options = _options;
-        _vocabSize = vocabSize;
-        _modelDimension = modelDimension;
+        _vocabSize = _options.VocabSize;
+        _modelDimension = _options.ModelDimension;
         _recurrenceDimension = _options.RecurrenceDimension;
-        _numLayers = numLayers;
-        _maxSeqLength = maxSeqLength;
+        _numLayers = _options.NumLayers;
+        _maxSeqLength = _options.MaxSequenceLength;
         if (_recurrenceDimension <= 0)
             throw new ArgumentOutOfRangeException(nameof(options), "RecurrenceDimension must be positive.");
         _optimizer = optimizer ?? CreateDefaultOptimizer();

--- a/src/NeuralNetworks/HawkLanguageModel.cs
+++ b/src/NeuralNetworks/HawkLanguageModel.cs
@@ -81,12 +81,8 @@ public partial class HawkLanguageModel<T> : TokenLanguageModelLayoutBase<T>
 
     public HawkLanguageModel(
         NeuralNetworkArchitecture<T> architecture,
-        int vocabSize = 256000,
-        int modelDimension = 2048,
-        int numLayers = 24,
-        int maxSeqLength = 2048,
-        ILossFunction<T>? lossFunction = null,
         HawkOptions? options = null,
+        ILossFunction<T>? lossFunction = null,
         IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>>? optimizer = null)
         : base(architecture,
             // Hawk trains on next-token logits. Keep softmax fused with cross-entropy so
@@ -95,12 +91,13 @@ public partial class HawkLanguageModel<T> : TokenLanguageModelLayoutBase<T>
             lossFunction ?? new AiDotNet.LossFunctions.CrossEntropyWithLogitsLoss<T>())
     {
         _options = options ?? new HawkOptions();
+        _options.Validate();
         Options = _options;
-        _vocabSize = vocabSize;
-        _modelDimension = modelDimension;
+        _vocabSize = _options.VocabSize;
+        _modelDimension = _options.ModelDimension;
         _recurrenceDimension = _options.RecurrenceDimension;
-        _numLayers = numLayers;
-        _maxSeqLength = maxSeqLength;
+        _numLayers = _options.NumLayers;
+        _maxSeqLength = _options.MaxSequenceLength;
         if (_recurrenceDimension <= 0)
             throw new ArgumentOutOfRangeException(nameof(options), "RecurrenceDimension must be positive.");
         _optimizer = optimizer ?? CreateDefaultOptimizer();

--- a/src/NeuralNetworks/ImageBindNeuralNetwork.cs
+++ b/src/NeuralNetworks/ImageBindNeuralNetwork.cs
@@ -182,16 +182,13 @@ public partial class ImageBindNeuralNetwork<T> : MultimodalModelLayoutBase<T>, I
         string textEncoderPath,
         string audioEncoderPath,
         ITokenizer tokenizer,
-        int embeddingDimension = 1024,
-        int maxSequenceLength = 77,
-        int imageSize = 224,
-        int audioSampleRate = 16000,
+        ImageBindOptions? options = null,
         IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>>? optimizer = null,
-        ILossFunction<T>? lossFunction = null,
-        ImageBindOptions? options = null)
+        ILossFunction<T>? lossFunction = null)
         : base(architecture, lossFunction ?? new CrossEntropyWithLogitsLoss<T>(), 1.0)
     {
         _options = options ?? new ImageBindOptions();
+        _options.Validate();
         Options = _options;
         if (string.IsNullOrWhiteSpace(imageEncoderPath))
             throw new ArgumentException("Image encoder path cannot be null or empty.", nameof(imageEncoderPath));
@@ -210,10 +207,10 @@ public partial class ImageBindNeuralNetwork<T> : MultimodalModelLayoutBase<T>, I
         _imageEncoderPath = imageEncoderPath;
         _textEncoderPath = textEncoderPath;
         _audioEncoderPath = audioEncoderPath;
-        _embeddingDimension = embeddingDimension;
-        _maxSequenceLength = maxSequenceLength;
-        _imageSize = imageSize;
-        _audioSampleRate = audioSampleRate;
+        _embeddingDimension = _options.EmbeddingDimension;
+        _maxSequenceLength = _options.MaxSequenceLength;
+        _imageSize = _options.ImageSize;
+        _audioSampleRate = _options.AudioSampleRate;
         _audioMaxDuration = 10; // 10 seconds max
         _patchSize = 14;
         _hiddenDim = 1280;
@@ -261,40 +258,28 @@ public partial class ImageBindNeuralNetwork<T> : MultimodalModelLayoutBase<T>, I
     /// </summary>
     public ImageBindNeuralNetwork(
         NeuralNetworkArchitecture<T> architecture,
-        int imageSize = 224,
-        int channels = 3,
-        int patchSize = 14,
-        int vocabularySize = 49408,
-        int maxSequenceLength = 77,
-        int embeddingDimension = 1024,
-        int hiddenDim = 1280,
-        int numEncoderLayers = 32,
-        int numHeads = 16,
-        int audioSampleRate = 16000,
-        int audioMaxDuration = 10,
-        int imuTimesteps = 2000,
-        int numVideoFrames = 2,
+        ImageBindOptions? options = null,
         ITokenizer? tokenizer = null,
         IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>>? optimizer = null,
-        ILossFunction<T>? lossFunction = null,
-        ImageBindOptions? options = null)
+        ILossFunction<T>? lossFunction = null)
         : base(architecture, lossFunction ?? new CrossEntropyWithLogitsLoss<T>(), 1.0)
     {
         _options = options ?? new ImageBindOptions();
+        _options.Validate();
         Options = _options;
         _useNativeMode = true;
-        _embeddingDimension = embeddingDimension;
-        _maxSequenceLength = maxSequenceLength;
-        _imageSize = imageSize;
-        _hiddenDim = hiddenDim;
-        _numEncoderLayers = numEncoderLayers;
-        _numHeads = numHeads;
-        _patchSize = patchSize;
-        _vocabularySize = vocabularySize;
-        _audioSampleRate = audioSampleRate;
-        _audioMaxDuration = audioMaxDuration;
-        _imuTimesteps = imuTimesteps;
-        _numVideoFrames = numVideoFrames;
+        _embeddingDimension = _options.EmbeddingDimension;
+        _maxSequenceLength = _options.MaxSequenceLength;
+        _imageSize = _options.ImageSize;
+        _hiddenDim = _options.HiddenDim;
+        _numEncoderLayers = _options.NumEncoderLayers;
+        _numHeads = _options.NumHeads;
+        _patchSize = _options.PatchSize;
+        _vocabularySize = _options.VocabSize;
+        _audioSampleRate = _options.AudioSampleRate;
+        _audioMaxDuration = _options.AudioMaxDuration;
+        _imuTimesteps = _options.ImuTimesteps;
+        _numVideoFrames = _options.NumVideoFrames;
 
         _supportedModalities = new List<ModalityType>
         {
@@ -306,7 +291,7 @@ public partial class ImageBindNeuralNetwork<T> : MultimodalModelLayoutBase<T>, I
         _optimizer = optimizer ?? new AdamOptimizer<T, Tensor<T>, Tensor<T>>(this);
         _lossFunction = lossFunction ?? new CrossEntropyWithLogitsLoss<T>();
 
-        InitializeNativeLayers(channels);
+        InitializeNativeLayers(_options.Channels);
     }
 
     #endregion

--- a/src/NeuralNetworks/InfoGAN.cs
+++ b/src/NeuralNetworks/InfoGAN.cs
@@ -269,11 +269,8 @@ public partial class InfoGAN<T> : ImageGeneratorModelLayoutBase<T>
     /// <param name="options">Optional InfoGAN options.</param>
     public InfoGAN(
         NeuralNetworkArchitecture<T> architecture,
-        int latentCodeSize = 10,
-        double mutualInfoCoefficient = 1.0,
         InfoGANOptions? options = null)
-        : this(architecture, architecture, architecture, latentCodeSize, architecture.InputType,
-               mutualInfoCoefficient: mutualInfoCoefficient, options: options)
+        : this(architecture, architecture, architecture, options?.LatentCodeSize ?? 10, architecture.InputType, options: options)
     {
     }
 
@@ -328,16 +325,16 @@ public partial class InfoGAN<T> : ImageGeneratorModelLayoutBase<T>
         NeuralNetworkArchitecture<T> qNetworkArchitecture,
         int latentCodeSize,
         InputType inputType,
+        InfoGANOptions? options = null,
         IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>>? generatorOptimizer = null,
         IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>>? discriminatorOptimizer = null,
         IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>>? qNetworkOptimizer = null,
-        ILossFunction<T>? lossFunction = null,
-        double mutualInfoCoefficient = 1.0,
-        InfoGANOptions? options = null)
+        ILossFunction<T>? lossFunction = null)
         : base(CreateInfoGANArchitecture(generatorArchitecture, discriminatorArchitecture, inputType),
                lossFunction ?? NeuralNetworkHelper<T>.GetDefaultLossFunction(generatorArchitecture.TaskType))
     {
         _options = options ?? new InfoGANOptions();
+        _options.Validate();
         Options = _options;
         if (generatorArchitecture is null)
             throw new ArgumentNullException(nameof(generatorArchitecture));
@@ -347,11 +344,11 @@ public partial class InfoGAN<T> : ImageGeneratorModelLayoutBase<T>
             throw new ArgumentNullException(nameof(qNetworkArchitecture));
         if (latentCodeSize <= 0)
             throw new ArgumentOutOfRangeException(nameof(latentCodeSize), latentCodeSize, "Latent code size must be positive.");
-        if (mutualInfoCoefficient < 0)
-            throw new ArgumentOutOfRangeException(nameof(mutualInfoCoefficient), mutualInfoCoefficient, "Mutual information coefficient must be non-negative.");
+        if (_options.MutualInfoCoefficient < 0)
+            throw new ArgumentOutOfRangeException(nameof(_options.MutualInfoCoefficient), _options.MutualInfoCoefficient, "Mutual information coefficient must be non-negative.");
 
         _latentCodeSize = latentCodeSize;
-        _mutualInfoCoefficient = NumOps.FromDouble(mutualInfoCoefficient);
+        _mutualInfoCoefficient = NumOps.FromDouble(_options.MutualInfoCoefficient);
 
         Generator = CreateBackboneForArchitecture(generatorArchitecture);
         Discriminator = CreateBackboneForArchitecture(discriminatorArchitecture);

--- a/src/NeuralNetworks/InstructorEmbedding.cs
+++ b/src/NeuralNetworks/InstructorEmbedding.cs
@@ -62,7 +62,7 @@ namespace AiDotNet.NeuralNetworks
         private int _numLayers;
         private int _numHeads;
         private int _feedForwardDim;
-        private PoolingStrategy _poolingStrategy;
+        private EmbeddingPoolingStrategy _poolingStrategy;
 
         #endregion
 
@@ -84,28 +84,21 @@ namespace AiDotNet.NeuralNetworks
         /// Initializes a new instance of the InstructorEmbedding model.
         /// </summary>
         public InstructorEmbedding(
-            NeuralNetworkArchitecture<T> architecture,
-            ITokenizer? tokenizer = null,
-            IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>>? optimizer = null,
-            int vocabSize = 30522,
-            int embeddingDimension = 768,
-            int maxSequenceLength = 512,
-            int numLayers = 12,
-            int numHeads = 12,
-            int feedForwardDim = 3072,
-            PoolingStrategy poolingStrategy = PoolingStrategy.Mean,
-            ILossFunction<T>? lossFunction = null,
-            double maxGradNorm = 1.0,
-            InstructorEmbeddingOptions? options = null)
-            : base(architecture, tokenizer, optimizer, vocabSize, embeddingDimension, maxSequenceLength, numLayers, numHeads, feedForwardDim, poolingStrategy, lossFunction, maxGradNorm)
+        NeuralNetworkArchitecture<T> architecture,
+        InstructorEmbeddingOptions? options = null,
+        ITokenizer? tokenizer = null,
+        IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>>? optimizer = null,
+        ILossFunction<T>? lossFunction = null)
+            : base(architecture, options, tokenizer, optimizer, lossFunction)
         {
-            _options = options ?? new InstructorEmbeddingOptions();
+        _options = options ?? new InstructorEmbeddingOptions();
+        _options.Validate();
             Options = _options;
-            _vocabSize = vocabSize;
-            _numLayers = numLayers;
-            _numHeads = numHeads;
-            _feedForwardDim = feedForwardDim;
-            _poolingStrategy = poolingStrategy;
+            _vocabSize = _options.VocabSize;
+            _numLayers = _options.NumLayers;
+            _numHeads = _options.NumHeads;
+            _feedForwardDim = _options.FeedForwardDim;
+            _poolingStrategy = _options.EmbeddingPoolingStrategy;
 
             InitializeLayersCore(false);
         }

--- a/src/NeuralNetworks/JambaLanguageModel.cs
+++ b/src/NeuralNetworks/JambaLanguageModel.cs
@@ -66,14 +66,8 @@ public partial class JambaLanguageModel<T> : TokenLanguageModelLayoutBase<T>
 
     public JambaLanguageModel(
         NeuralNetworkArchitecture<T> architecture,
-        int vocabSize = 65536,
-        int modelDimension = 256,
-        int numLayers = 8,
-        int stateDimension = 16,
-        int attentionInterval = 8,
-        int maxSeqLength = 512,
-        ILossFunction<T>? lossFunction = null,
-        JambaOptions? options = null)
+        JambaOptions? options = null,
+        ILossFunction<T>? lossFunction = null)
         : base(architecture,
             // The LM head emits raw vocabulary logits. Match PyTorch's
             // nn.CrossEntropyLoss contract by applying log-softmax inside
@@ -81,13 +75,14 @@ public partial class JambaLanguageModel<T> : TokenLanguageModelLayoutBase<T>
             lossFunction ?? new LossFunctions.CrossEntropyWithLogitsLoss<T>())
     {
         _options = options ?? new JambaOptions();
+        _options.Validate();
         Options = _options;
-        _vocabSize = vocabSize;
-        _modelDimension = modelDimension;
-        _numLayers = numLayers;
-        _stateDimension = stateDimension;
-        _attentionInterval = attentionInterval;
-        _maxSeqLength = maxSeqLength;
+        _vocabSize = _options.VocabSize;
+        _modelDimension = _options.ModelDimension;
+        _numLayers = _options.NumLayers;
+        _stateDimension = _options.StateDimension;
+        _attentionInterval = _options.AttentionInterval;
+        _maxSeqLength = _options.MaxSequenceLength;
         InitializeLayers();
     }
 

--- a/src/NeuralNetworks/LLaVANeuralNetwork.cs
+++ b/src/NeuralNetworks/LLaVANeuralNetwork.cs
@@ -165,17 +165,15 @@ public partial class LLaVANeuralNetwork<T> : MultimodalModelLayoutBase<T>, ILLaV
         string visionEncoderPath,
         string languageModelPath,
         ITokenizer tokenizer,
+        LLaVAOptions? options = null,
         LanguageModelBackbone languageModelBackbone = LanguageModelBackbone.LLaMA,
         string visionEncoderType = "clip-vit-l",
-        int embeddingDimension = 4096,
-        int maxSequenceLength = 2048,
-        int imageSize = 336,
         IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>>? optimizer = null,
-        ILossFunction<T>? lossFunction = null,
-        LLaVAOptions? options = null)
+        ILossFunction<T>? lossFunction = null)
         : base(architecture, lossFunction ?? new CrossEntropyWithLogitsLoss<T>(), 1.0)
     {
         _options = options ?? new LLaVAOptions();
+        _options.Validate();
         Options = _options;
         if (string.IsNullOrWhiteSpace(visionEncoderPath))
             throw new ArgumentException("Vision encoder path cannot be null or empty.", nameof(visionEncoderPath));
@@ -191,13 +189,13 @@ public partial class LLaVANeuralNetwork<T> : MultimodalModelLayoutBase<T>, ILLaV
         _languageModelPath = languageModelPath;
         _languageModelBackbone = languageModelBackbone;
         _visionEncoderType = visionEncoderType.ToLowerInvariant();
-        _embeddingDimension = embeddingDimension;
-        _maxSequenceLength = maxSequenceLength;
-        _imageSize = imageSize;
+        _embeddingDimension = _options.EmbeddingDimension;
+        _maxSequenceLength = _options.MaxSequenceLength;
+        _imageSize = _options.ImageSize;
         _patchSize = 14;
-        _numVisualTokens = (imageSize / _patchSize) * (imageSize / _patchSize);
+        _numVisualTokens = (_options.ImageSize / _patchSize) * (_options.ImageSize / _patchSize);
         _visionHiddenDim = 1024;
-        _lmHiddenDim = embeddingDimension;
+        _lmHiddenDim = _options.EmbeddingDimension;
         _numVisionLayers = 24;
         _numLmLayers = 32;
         _numHeads = 16;
@@ -240,47 +238,38 @@ public partial class LLaVANeuralNetwork<T> : MultimodalModelLayoutBase<T>, ILLaV
     /// </remarks>
     public LLaVANeuralNetwork(
         NeuralNetworkArchitecture<T> architecture,
-        int imageSize = 336,
-        int channels = 3,
-        int patchSize = 14,
-        int vocabularySize = 32000,
-        int maxSequenceLength = 2048,
-        int embeddingDimension = 4096,
-        int visionHiddenDim = 1024,
-        int numVisionLayers = 24,
-        int numLmLayers = 32,
-        int numHeads = 16,
+        LLaVAOptions? options = null,
         LanguageModelBackbone languageModelBackbone = LanguageModelBackbone.LLaMA,
         string visionEncoderType = "clip-vit-l",
         ITokenizer? tokenizer = null,
         IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>>? optimizer = null,
-        ILossFunction<T>? lossFunction = null,
-        LLaVAOptions? options = null)
+        ILossFunction<T>? lossFunction = null)
         : base(architecture, lossFunction ?? new CrossEntropyWithLogitsLoss<T>(), 1.0)
     {
         _options = options ?? new LLaVAOptions();
+        _options.Validate();
         Options = _options;
         _useNativeMode = true;
-        _embeddingDimension = embeddingDimension;
-        _maxSequenceLength = maxSequenceLength;
-        _imageSize = imageSize;
-        _visionHiddenDim = visionHiddenDim;
-        _lmHiddenDim = embeddingDimension;
-        _numVisionLayers = numVisionLayers;
-        _numLmLayers = numLmLayers;
-        _numHeads = numHeads;
-        _patchSize = patchSize;
-        _vocabularySize = vocabularySize;
+        _embeddingDimension = _options.EmbeddingDimension;
+        _maxSequenceLength = _options.MaxSequenceLength;
+        _imageSize = _options.ImageSize;
+        _visionHiddenDim = _options.VisionHiddenDim;
+        _lmHiddenDim = _options.EmbeddingDimension;
+        _numVisionLayers = _options.NumVisionLayers;
+        _numLmLayers = _options.NumLmLayers;
+        _numHeads = _options.NumHeads;
+        _patchSize = _options.PatchSize;
+        _vocabularySize = _options.VocabSize;
         _languageModelBackbone = languageModelBackbone;
         _visionEncoderType = visionEncoderType.ToLowerInvariant();
-        _numVisualTokens = (imageSize / patchSize) * (imageSize / patchSize);
+        _numVisualTokens = (_options.ImageSize / _options.PatchSize) * (_options.ImageSize / _options.PatchSize);
 
         // Use factory to create appropriate tokenizer for the backbone, or use provided tokenizer
         _tokenizer = tokenizer ?? Tokenization.LanguageModelTokenizerFactory.CreateForBackbone(languageModelBackbone);
         _optimizer = optimizer ?? new AdamOptimizer<T, Tensor<T>, Tensor<T>>(this);
         _lossFunction = lossFunction ?? new CrossEntropyWithLogitsLoss<T>();
 
-        InitializeNativeLayers(channels);
+        InitializeNativeLayers(_options.Channels);
     }
 
     #endregion

--- a/src/NeuralNetworks/LLaVANeuralNetwork.cs
+++ b/src/NeuralNetworks/LLaVANeuralNetwork.cs
@@ -166,13 +166,12 @@ public partial class LLaVANeuralNetwork<T> : MultimodalModelLayoutBase<T>, ILLaV
         string languageModelPath,
         ITokenizer tokenizer,
         LLaVAOptions? options = null,
-        LanguageModelBackbone languageModelBackbone = LanguageModelBackbone.LLaMA,
-        string visionEncoderType = "clip-vit-l",
         IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>>? optimizer = null,
         ILossFunction<T>? lossFunction = null)
         : base(architecture, lossFunction ?? new CrossEntropyWithLogitsLoss<T>(), 1.0)
     {
         _options = options ?? new LLaVAOptions();
+        _options.Validate();
         _options.Validate();
         Options = _options;
         if (string.IsNullOrWhiteSpace(visionEncoderPath))
@@ -187,8 +186,8 @@ public partial class LLaVANeuralNetwork<T> : MultimodalModelLayoutBase<T>, ILLaV
         _useNativeMode = false;
         _visionEncoderPath = visionEncoderPath;
         _languageModelPath = languageModelPath;
-        _languageModelBackbone = languageModelBackbone;
-        _visionEncoderType = visionEncoderType.ToLowerInvariant();
+        _languageModelBackbone = _options.LanguageModelBackbone;
+        _visionEncoderType = _options.VisionEncoderType.ToLowerInvariant();
         _embeddingDimension = _options.EmbeddingDimension;
         _maxSequenceLength = _options.MaxSequenceLength;
         _imageSize = _options.ImageSize;
@@ -239,14 +238,13 @@ public partial class LLaVANeuralNetwork<T> : MultimodalModelLayoutBase<T>, ILLaV
     public LLaVANeuralNetwork(
         NeuralNetworkArchitecture<T> architecture,
         LLaVAOptions? options = null,
-        LanguageModelBackbone languageModelBackbone = LanguageModelBackbone.LLaMA,
-        string visionEncoderType = "clip-vit-l",
         ITokenizer? tokenizer = null,
         IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>>? optimizer = null,
         ILossFunction<T>? lossFunction = null)
         : base(architecture, lossFunction ?? new CrossEntropyWithLogitsLoss<T>(), 1.0)
     {
         _options = options ?? new LLaVAOptions();
+        _options.Validate();
         _options.Validate();
         Options = _options;
         _useNativeMode = true;
@@ -260,12 +258,12 @@ public partial class LLaVANeuralNetwork<T> : MultimodalModelLayoutBase<T>, ILLaV
         _numHeads = _options.NumHeads;
         _patchSize = _options.PatchSize;
         _vocabularySize = _options.VocabSize;
-        _languageModelBackbone = languageModelBackbone;
-        _visionEncoderType = visionEncoderType.ToLowerInvariant();
+        _languageModelBackbone = _options.LanguageModelBackbone;
+        _visionEncoderType = _options.VisionEncoderType.ToLowerInvariant();
         _numVisualTokens = (_options.ImageSize / _options.PatchSize) * (_options.ImageSize / _options.PatchSize);
 
         // Use factory to create appropriate tokenizer for the backbone, or use provided tokenizer
-        _tokenizer = tokenizer ?? Tokenization.LanguageModelTokenizerFactory.CreateForBackbone(languageModelBackbone);
+        _tokenizer = tokenizer ?? Tokenization.LanguageModelTokenizerFactory.CreateForBackbone(_options.LanguageModelBackbone);
         _optimizer = optimizer ?? new AdamOptimizer<T, Tensor<T>, Tensor<T>>(this);
         _lossFunction = lossFunction ?? new CrossEntropyWithLogitsLoss<T>();
 

--- a/src/NeuralNetworks/Mamba2LanguageModel.cs
+++ b/src/NeuralNetworks/Mamba2LanguageModel.cs
@@ -67,14 +67,8 @@ public partial class Mamba2LanguageModel<T> : TokenLanguageModelLayoutBase<T>
 
     public Mamba2LanguageModel(
         NeuralNetworkArchitecture<T> architecture,
-        int vocabSize = 50277,
-        int modelDimension = 256,
-        int numLayers = 4,
-        int stateDimension = 64,
-        int numHeads = 8,
-        int maxSeqLength = 512,
-        ILossFunction<T>? lossFunction = null,
-        Mamba2Options? options = null)
+        Mamba2Options? options = null,
+        ILossFunction<T>? lossFunction = null)
         : base(architecture,
             // Mamba-2's LM head emits RAW LOGITS (DenseLayer with no activation, see
             // LayerHelper.CreateMamba2Layers), so the loss must be cross-entropy-with-logits (fused
@@ -86,13 +80,14 @@ public partial class Mamba2LanguageModel<T> : TokenLanguageModelLayoutBase<T>
             lossFunction ?? new AiDotNet.LossFunctions.CrossEntropyWithLogitsLoss<T>())
     {
         _options = options ?? new Mamba2Options();
+        _options.Validate();
         Options = _options;
-        _vocabSize = vocabSize;
-        _modelDimension = modelDimension;
-        _numLayers = numLayers;
-        _stateDimension = stateDimension;
-        _numHeads = numHeads;
-        _maxSeqLength = maxSeqLength;
+        _vocabSize = _options.VocabSize;
+        _modelDimension = _options.ModelDimension;
+        _numLayers = _options.NumLayers;
+        _stateDimension = _options.StateDimension;
+        _numHeads = _options.NumHeads;
+        _maxSeqLength = _options.MaxSequenceLength;
         InitializeLayers();
     }
 

--- a/src/NeuralNetworks/MambaLanguageModel.cs
+++ b/src/NeuralNetworks/MambaLanguageModel.cs
@@ -67,16 +67,19 @@ public partial class MambaLanguageModel<T> : TokenLanguageModelLayoutBase<T>
 
     #region Constructors
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MambaLanguageModel{T}"/> class.
+    /// </summary>
+    /// <param name="architecture">The network architecture. Supply custom layers here to
+    /// override the default topology.</param>
+    /// <param name="options">The model's configuration. When null, <see cref="MambaOptions"/>
+    /// supplies this model's shipped defaults.</param>
+    /// <param name="lossFunction">The training loss. When null, cross-entropy-with-logits is
+    /// used, which is what this model's raw-logit head requires.</param>
     public MambaLanguageModel(
         NeuralNetworkArchitecture<T> architecture,
-        int vocabSize = 50277,
-        int modelDimension = 256,
-        int numLayers = 4,
-        int stateDimension = 16,
-        int expandFactor = 2,
-        int maxSeqLength = 512,
-        ILossFunction<T>? lossFunction = null,
-        MambaOptions? options = null)
+        MambaOptions? options = null,
+        ILossFunction<T>? lossFunction = null)
         : base(architecture,
             // Mamba's LM head emits RAW LOGITS (DenseLayer with no activation, see
             // LayerHelper.CreateMambaLayers), so the loss must be cross-entropy-with-logits (fused
@@ -88,19 +91,15 @@ public partial class MambaLanguageModel<T> : TokenLanguageModelLayoutBase<T>
             // TensorClamp has ZERO gradient, so those classes get no training signal at all.
             lossFunction ?? new AiDotNet.LossFunctions.CrossEntropyWithLogitsLoss<T>())
     {
-        if (vocabSize <= 0) throw new ArgumentException($"Vocabulary size ({vocabSize}) must be positive.", nameof(vocabSize));
-        if (modelDimension <= 0) throw new ArgumentException($"Model dimension ({modelDimension}) must be positive.", nameof(modelDimension));
-        if (numLayers <= 0) throw new ArgumentException($"Number of layers ({numLayers}) must be positive.", nameof(numLayers));
-        if (stateDimension <= 0) throw new ArgumentException($"State dimension ({stateDimension}) must be positive.", nameof(stateDimension));
-
         _options = options ?? new MambaOptions();
+        _options.Validate();
         Options = _options;
-        _vocabSize = vocabSize;
-        _modelDimension = modelDimension;
-        _numLayers = numLayers;
-        _stateDimension = stateDimension;
-        _expandFactor = expandFactor;
-        _maxSeqLength = maxSeqLength;
+        _vocabSize = _options.VocabSize;
+        _modelDimension = _options.ModelDimension;
+        _numLayers = _options.NumLayers;
+        _stateDimension = _options.StateDimension;
+        _expandFactor = _options.ExpandFactor;
+        _maxSeqLength = _options.MaxSequenceLength;
         InitializeLayers();
     }
 

--- a/src/NeuralNetworks/MatryoshkaEmbedding.cs
+++ b/src/NeuralNetworks/MatryoshkaEmbedding.cs
@@ -86,28 +86,21 @@ namespace AiDotNet.NeuralNetworks
         /// Initializes a new instance of the MatryoshkaEmbedding model.
         /// </summary>
         public MatryoshkaEmbedding(
-            NeuralNetworkArchitecture<T> architecture,
-            ITokenizer? tokenizer = null,
-            IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>>? optimizer = null,
-            int vocabSize = 30522,
-            int maxEmbeddingDimension = 1536,
-            int[]? nestedDimensions = null,
-            int maxSequenceLength = 512,
-            int numLayers = 12,
-            int numHeads = 12,
-            int feedForwardDim = 3072,
-            PoolingStrategy poolingStrategy = PoolingStrategy.ClsToken,
-            ILossFunction<T>? lossFunction = null,
-            double maxGradNorm = 1.0,
-            MatryoshkaEmbeddingOptions? options = null)
-            : base(architecture, tokenizer, optimizer, vocabSize, maxEmbeddingDimension, maxSequenceLength, numLayers, numHeads, feedForwardDim, poolingStrategy, lossFunction, maxGradNorm)
+        NeuralNetworkArchitecture<T> architecture,
+        MatryoshkaEmbeddingOptions? options = null,
+        ITokenizer? tokenizer = null,
+        IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>>? optimizer = null,
+        int[]? nestedDimensions = null,
+        ILossFunction<T>? lossFunction = null)
+            : base(architecture, options, tokenizer, optimizer, lossFunction)
         {
-            _options = options ?? new MatryoshkaEmbeddingOptions();
+        _options = options ?? new MatryoshkaEmbeddingOptions();
+        _options.Validate();
             Options = _options;
-            _vocabSize = vocabSize;
-            _numLayers = numLayers;
-            _numHeads = numHeads;
-            _feedForwardDim = feedForwardDim;
+            _vocabSize = _options.VocabSize;
+            _numLayers = _options.NumLayers;
+            _numHeads = _options.NumHeads;
+            _feedForwardDim = _options.FeedForwardDim;
             _nestedDimensions = nestedDimensions ?? new[] { 64, 128, 256, 512, 768, 1024, 1536 };
 
             InitializeLayersCore(false);

--- a/src/NeuralNetworks/Options/AudioVisualCorrespondenceOptions.cs
+++ b/src/NeuralNetworks/Options/AudioVisualCorrespondenceOptions.cs
@@ -28,6 +28,14 @@ public class AudioVisualCorrespondenceOptions : VisionLanguageModelOptions
         AudioSampleRate = 16000; // DEFAULT_SAMPLE_RATE
         VideoFrameRate = 25.0; // DEFAULT_FRAME_RATE
         NumEncoderLayers = 6;
+        EmbeddingDimension = 512; // DEFAULT_EMBEDDING_DIM
+        AudioSampleRate = 16000; // DEFAULT_SAMPLE_RATE
+        VideoFrameRate = 25.0; // DEFAULT_FRAME_RATE
+        NumEncoderLayers = 6;
+        EmbeddingDimension = 512; // DEFAULT_EMBEDDING_DIM
+        AudioSampleRate = 16000; // DEFAULT_SAMPLE_RATE
+        VideoFrameRate = 25.0; // DEFAULT_FRAME_RATE
+        NumEncoderLayers = 6;
     }
 
 

--- a/src/NeuralNetworks/Options/AudioVisualCorrespondenceOptions.cs
+++ b/src/NeuralNetworks/Options/AudioVisualCorrespondenceOptions.cs
@@ -5,6 +5,50 @@ namespace AiDotNet.NeuralNetworks.Options;
 /// <summary>
 /// Configuration options for the AudioVisualCorrespondenceNetwork.
 /// </summary>
-public class AudioVisualCorrespondenceOptions : NeuralNetworkOptions
+public class AudioVisualCorrespondenceOptions : VisionLanguageModelOptions
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AudioVisualCorrespondenceOptions"/> class carrying
+    /// this model's shipped defaults.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>For Beginners:</b> You do not need to set any of these. They are the values this
+    /// model has always used, moved here from its constructor so they can be seen and
+    /// changed in one place.
+    /// </para>
+    /// <para>
+    /// Carried over unchanged. Whether each matches the published paper is verified, and
+    /// corrected where it does not, in a later phase of issue #2090.
+    /// </para>
+    /// </remarks>
+    public AudioVisualCorrespondenceOptions()
+    {
+        EmbeddingDimension = 512; // DEFAULT_EMBEDDING_DIM
+        AudioSampleRate = 16000; // DEFAULT_SAMPLE_RATE
+        VideoFrameRate = 25.0; // DEFAULT_FRAME_RATE
+        NumEncoderLayers = 6;
+    }
+
+
+    /// <summary>
+    /// Gets or sets the audio sample rate.
+    /// </summary>
+    public int AudioSampleRate { get; set; }
+
+    /// <summary>
+    /// Gets or sets the video frame rate.
+    /// </summary>
+    public double VideoFrameRate { get; set; }
+
+    /// <summary>
+    /// Throws if a value this model requires has been left unset or is not positive.
+    /// </summary>
+    /// <exception cref="ArgumentException">
+    /// Thrown when a required dimension is zero or negative.
+    /// </exception>
+    public void Validate()
+    {
+        ValidateCore();
+    }
 }

--- a/src/NeuralNetworks/Options/AudioVisualEventLocalizationOptions.cs
+++ b/src/NeuralNetworks/Options/AudioVisualEventLocalizationOptions.cs
@@ -29,6 +29,16 @@ public class AudioVisualEventLocalizationOptions : VisionLanguageModelOptions
         NumEncoderLayers = 6;
         AudioEmbeddingFullyConnectedWidth = VGGishAudioEmbedding<double>.PaperFullyConnectedWidth;
         AudioEmbeddingSize = VGGishAudioEmbedding<double>.PaperEmbeddingSize;
+        EmbeddingDimension = 512; // DEFAULT_EMBEDDING_DIM
+        TemporalResolution = 0.1; // DEFAULT_TEMPORAL_RESOLUTION
+        NumEncoderLayers = 6;
+        AudioEmbeddingFullyConnectedWidth = VGGishAudioEmbedding<double>.PaperFullyConnectedWidth;
+        AudioEmbeddingSize = VGGishAudioEmbedding<double>.PaperEmbeddingSize;
+        EmbeddingDimension = 512; // DEFAULT_EMBEDDING_DIM
+        TemporalResolution = 0.1; // DEFAULT_TEMPORAL_RESOLUTION
+        NumEncoderLayers = 6;
+        AudioEmbeddingFullyConnectedWidth = VGGishAudioEmbedding<double>.PaperFullyConnectedWidth;
+        AudioEmbeddingSize = VGGishAudioEmbedding<double>.PaperEmbeddingSize;
     }
 
     /// <summary>

--- a/src/NeuralNetworks/Options/AudioVisualEventLocalizationOptions.cs
+++ b/src/NeuralNetworks/Options/AudioVisualEventLocalizationOptions.cs
@@ -5,10 +5,60 @@ namespace AiDotNet.NeuralNetworks.Options;
 /// <summary>
 /// Configuration options for the AudioVisualEventLocalizationNetwork.
 /// </summary>
-public class AudioVisualEventLocalizationOptions : NeuralNetworkOptions
+public class AudioVisualEventLocalizationOptions : VisionLanguageModelOptions
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AudioVisualEventLocalizationOptions"/> class carrying
+    /// this model's shipped defaults.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>For Beginners:</b> You do not need to set any of these. They are the values this
+    /// model has always used, moved here from its constructor so they can be seen and
+    /// changed in one place.
+    /// </para>
+    /// <para>
+    /// Carried over unchanged. Whether each matches the published paper is verified, and
+    /// corrected where it does not, in a later phase of issue #2090.
+    /// </para>
+    /// </remarks>
+    public AudioVisualEventLocalizationOptions()
+    {
+        EmbeddingDimension = 512; // DEFAULT_EMBEDDING_DIM
+        TemporalResolution = 0.1; // DEFAULT_TEMPORAL_RESOLUTION
+        NumEncoderLayers = 6;
+        AudioEmbeddingFullyConnectedWidth = VGGishAudioEmbedding<double>.PaperFullyConnectedWidth;
+        AudioEmbeddingSize = VGGishAudioEmbedding<double>.PaperEmbeddingSize;
+    }
+
     /// <summary>
     /// Gets or sets the learning rate for gradient descent parameter updates. Default: 0.001.
     /// </summary>
     public double LearningRate { get; set; } = 0.001;
+
+    /// <summary>
+    /// Gets or sets the temporal resolution.
+    /// </summary>
+    public double TemporalResolution { get; set; }
+
+    /// <summary>
+    /// Gets or sets the audio embedding fully connected width.
+    /// </summary>
+    public int AudioEmbeddingFullyConnectedWidth { get; set; }
+
+    /// <summary>
+    /// Gets or sets the audio embedding size.
+    /// </summary>
+    public int AudioEmbeddingSize { get; set; }
+
+    /// <summary>
+    /// Throws if a value this model requires has been left unset or is not positive.
+    /// </summary>
+    /// <exception cref="ArgumentException">
+    /// Thrown when a required dimension is zero or negative.
+    /// </exception>
+    public void Validate()
+    {
+        ValidateCore();
+    }
 }

--- a/src/NeuralNetworks/Options/BGEOptions.cs
+++ b/src/NeuralNetworks/Options/BGEOptions.cs
@@ -5,6 +5,32 @@ namespace AiDotNet.NeuralNetworks.Options;
 /// <summary>
 /// Configuration options for the BGE (BAAI General Embedding) model.
 /// </summary>
-public class BGEOptions : NeuralNetworkOptions
+public class BGEOptions : TransformerEmbeddingOptions
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="BGEOptions"/> class carrying
+    /// this model's shipped defaults.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>For Beginners:</b> You do not need to set any of these. They are the values this
+    /// model has always used, moved here from its constructor so they can be seen and
+    /// changed in one place.
+    /// </para>
+    /// <para>
+    /// Carried over unchanged. Whether each matches the published paper is verified, and
+    /// corrected where it does not, in a later phase of issue #2090.
+    /// </para>
+    /// </remarks>
+    public BGEOptions()
+    {
+        VocabSize = 30522;
+        EmbeddingDimension = 768;
+        MaxSequenceLength = 512;
+        NumLayers = 12;
+        NumHeads = 12;
+        FeedForwardDim = 3072;
+        EmbeddingPoolingStrategy = EmbeddingPoolingStrategy.ClsToken;
+        MaxGradNorm = 1.0;
+    }
 }

--- a/src/NeuralNetworks/Options/BigGANOptions.cs
+++ b/src/NeuralNetworks/Options/BigGANOptions.cs
@@ -5,6 +5,71 @@ namespace AiDotNet.NeuralNetworks.Options;
 /// <summary>
 /// Configuration options for the BigGAN neural network.
 /// </summary>
-public class BigGANOptions : NeuralNetworkOptions
+public class BigGANOptions : GanOptions
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="BigGANOptions"/> class carrying
+    /// this model's shipped defaults.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>For Beginners:</b> You do not need to set any of these. They are the values this
+    /// model has always used, moved here from its constructor so they can be seen and
+    /// changed in one place.
+    /// </para>
+    /// <para>
+    /// Carried over unchanged. Whether each matches the published paper is verified, and
+    /// corrected where it does not, in a later phase of issue #2090.
+    /// </para>
+    /// </remarks>
+    public BigGANOptions()
+    {
+        GeneratorChannels = 96;
+        DiscriminatorChannels = 96;
+        LatentSize = 120;
+        NumClasses = 1000;
+        ClassEmbeddingDim = 128;
+        ImageChannels = 3;
+        ImageHeight = 128;
+        ImageWidth = 128;
+        InputType = InputType.TwoDimensional;
+        InitialLearningRate = 0.0001;
+    }
+
+
+    /// <summary>
+    /// Gets or sets the num classes.
+    /// </summary>
+    public int NumClasses { get; set; }
+
+    /// <summary>
+    /// Gets or sets the class embedding dim.
+    /// </summary>
+    public int ClassEmbeddingDim { get; set; }
+
+    /// <summary>
+    /// Gets or sets the image height.
+    /// </summary>
+    public int ImageHeight { get; set; }
+
+    /// <summary>
+    /// Gets or sets the image width.
+    /// </summary>
+    public int ImageWidth { get; set; }
+
+    /// <summary>
+    /// Gets or sets the input type.
+    /// </summary>
+    public InputType InputType { get; set; }
+
+    /// <summary>
+    /// Throws if a value this model requires has been left unset or is not positive.
+    /// </summary>
+    /// <exception cref="ArgumentException">
+    /// Thrown when a required dimension is zero or negative.
+    /// </exception>
+    public void Validate()
+    {
+        ValidateCore();
+    }
 }

--- a/src/NeuralNetworks/Options/Blip2Options.cs
+++ b/src/NeuralNetworks/Options/Blip2Options.cs
@@ -37,6 +37,7 @@ public class Blip2Options : VisionLanguageModelOptions
         NumQueryTokens = 32;
         NumHeads = 12;
         NumLmDecoderLayers = 6;
+        LanguageModelBackbone = LanguageModelBackbone.OPT;
     }
 
 
@@ -75,4 +76,9 @@ public class Blip2Options : VisionLanguageModelOptions
     {
         ValidateCore();
     }
+
+    /// <summary>
+    /// Gets or sets the language model backbone.
+    /// </summary>
+    public LanguageModelBackbone LanguageModelBackbone { get; set; }
 }

--- a/src/NeuralNetworks/Options/Blip2Options.cs
+++ b/src/NeuralNetworks/Options/Blip2Options.cs
@@ -5,6 +5,74 @@ namespace AiDotNet.NeuralNetworks.Options;
 /// <summary>
 /// Configuration options for the Blip2NeuralNetwork.
 /// </summary>
-public class Blip2Options : NeuralNetworkOptions
+public class Blip2Options : VisionLanguageModelOptions
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Blip2Options"/> class carrying
+    /// this model's shipped defaults.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>For Beginners:</b> You do not need to set any of these. They are the values this
+    /// model has always used, moved here from its constructor so they can be seen and
+    /// changed in one place.
+    /// </para>
+    /// <para>
+    /// Carried over unchanged. Whether each matches the published paper is verified, and
+    /// corrected where it does not, in a later phase of issue #2090.
+    /// </para>
+    /// </remarks>
+    public Blip2Options()
+    {
+        EmbeddingDimension = 256;
+        MaxSequenceLength = 32;
+        ImageSize = 224;
+        Channels = 3;
+        PatchSize = 14;
+        VocabSize = 30522;
+        QformerHiddenDim = 768;
+        VisionHiddenDim = 1408;
+        LmHiddenDim = 2560;
+        NumQformerLayers = 12;
+        NumQueryTokens = 32;
+        NumHeads = 12;
+        NumLmDecoderLayers = 6;
+    }
+
+
+    /// <summary>
+    /// Gets or sets the qformer hidden dim.
+    /// </summary>
+    public int QformerHiddenDim { get; set; }
+
+    /// <summary>
+    /// Gets or sets the lm hidden dim.
+    /// </summary>
+    public int LmHiddenDim { get; set; }
+
+    /// <summary>
+    /// Gets or sets the num qformer layers.
+    /// </summary>
+    public int NumQformerLayers { get; set; }
+
+    /// <summary>
+    /// Gets or sets the num query tokens.
+    /// </summary>
+    public int NumQueryTokens { get; set; }
+
+    /// <summary>
+    /// Gets or sets the num lm decoder layers.
+    /// </summary>
+    public int NumLmDecoderLayers { get; set; }
+
+    /// <summary>
+    /// Throws if a value this model requires has been left unset or is not positive.
+    /// </summary>
+    /// <exception cref="ArgumentException">
+    /// Thrown when a required dimension is zero or negative.
+    /// </exception>
+    public void Validate()
+    {
+        ValidateCore();
+    }
 }

--- a/src/NeuralNetworks/Options/BlipOptions.cs
+++ b/src/NeuralNetworks/Options/BlipOptions.cs
@@ -5,6 +5,57 @@ namespace AiDotNet.NeuralNetworks.Options;
 /// <summary>
 /// Configuration options for the BlipNeuralNetwork.
 /// </summary>
-public class BlipOptions : NeuralNetworkOptions
+public class BlipOptions : VisionLanguageModelOptions
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="BlipOptions"/> class carrying
+    /// this model's shipped defaults.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>For Beginners:</b> You do not need to set any of these. They are the values this
+    /// model has always used, moved here from its constructor so they can be seen and
+    /// changed in one place.
+    /// </para>
+    /// <para>
+    /// Carried over unchanged. Whether each matches the published paper is verified, and
+    /// corrected where it does not, in a later phase of issue #2090.
+    /// </para>
+    /// </remarks>
+    public BlipOptions()
+    {
+        EmbeddingDimension = 256;
+        MaxSequenceLength = 35;
+        ImageSize = 384;
+        Channels = 3;
+        PatchSize = 16;
+        VocabSize = 30522;
+        HiddenDim = 768;
+        NumEncoderLayers = 12;
+        NumDecoderLayers = 12;
+        NumHeads = 12;
+        MlpDim = 3072;
+    }
+
+
+    /// <summary>
+    /// Gets or sets the num decoder layers.
+    /// </summary>
+    public int NumDecoderLayers { get; set; }
+
+    /// <summary>
+    /// Gets or sets the mlp dim.
+    /// </summary>
+    public int MlpDim { get; set; }
+
+    /// <summary>
+    /// Throws if a value this model requires has been left unset or is not positive.
+    /// </summary>
+    /// <exception cref="ArgumentException">
+    /// Thrown when a required dimension is zero or negative.
+    /// </exception>
+    public void Validate()
+    {
+        ValidateCore();
+    }
 }

--- a/src/NeuralNetworks/Options/ClipOptions.cs
+++ b/src/NeuralNetworks/Options/ClipOptions.cs
@@ -5,6 +5,39 @@ namespace AiDotNet.NeuralNetworks.Options;
 /// <summary>
 /// Configuration options for the ClipNeuralNetwork.
 /// </summary>
-public class ClipOptions : NeuralNetworkOptions
+public class ClipOptions : VisionLanguageModelOptions
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ClipOptions"/> class carrying
+    /// this model's shipped defaults.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>For Beginners:</b> You do not need to set any of these. They are the values this
+    /// model has always used, moved here from its constructor so they can be seen and
+    /// changed in one place.
+    /// </para>
+    /// <para>
+    /// Carried over unchanged. Whether each matches the published paper is verified, and
+    /// corrected where it does not, in a later phase of issue #2090.
+    /// </para>
+    /// </remarks>
+    public ClipOptions()
+    {
+        EmbeddingDimension = 512;
+        MaxSequenceLength = 77;
+        ImageSize = 224;
+    }
+
+
+    /// <summary>
+    /// Throws if a value this model requires has been left unset or is not positive.
+    /// </summary>
+    /// <exception cref="ArgumentException">
+    /// Thrown when a required dimension is zero or negative.
+    /// </exception>
+    public void Validate()
+    {
+        ValidateCore();
+    }
 }

--- a/src/NeuralNetworks/Options/ColBERTOptions.cs
+++ b/src/NeuralNetworks/Options/ColBERTOptions.cs
@@ -5,6 +5,37 @@ namespace AiDotNet.NeuralNetworks.Options;
 /// <summary>
 /// Configuration options for the ColBERT model.
 /// </summary>
-public class ColBERTOptions : NeuralNetworkOptions
+public class ColBERTOptions : TransformerEmbeddingOptions
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ColBERTOptions"/> class carrying
+    /// this model's shipped defaults.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>For Beginners:</b> You do not need to set any of these. They are the values this
+    /// model has always used, moved here from its constructor so they can be seen and
+    /// changed in one place.
+    /// </para>
+    /// <para>
+    /// Carried over unchanged. Whether each matches the published paper is verified, and
+    /// corrected where it does not, in a later phase of issue #2090.
+    /// </para>
+    /// </remarks>
+    public ColBERTOptions()
+    {
+        VocabSize = 30522;
+        OutputDimension = 128;
+        MaxSequenceLength = 512;
+        NumLayers = 12;
+        NumHeads = 12;
+        FeedForwardDim = 3072;
+        MaxGradNorm = 1.0;
+    }
+
+
+    /// <summary>
+    /// Gets or sets the output dimension.
+    /// </summary>
+    public int OutputDimension { get; set; }
 }

--- a/src/NeuralNetworks/Options/CycleGANOptions.cs
+++ b/src/NeuralNetworks/Options/CycleGANOptions.cs
@@ -5,6 +5,48 @@ namespace AiDotNet.NeuralNetworks.Options;
 /// <summary>
 /// Configuration options for the CycleGAN neural network.
 /// </summary>
-public class CycleGANOptions : NeuralNetworkOptions
+public class CycleGANOptions : GanOptions
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CycleGANOptions"/> class carrying
+    /// this model's shipped defaults.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>For Beginners:</b> You do not need to set any of these. They are the values this
+    /// model has always used, moved here from its constructor so they can be seen and
+    /// changed in one place.
+    /// </para>
+    /// <para>
+    /// Carried over unchanged. Whether each matches the published paper is verified, and
+    /// corrected where it does not, in a later phase of issue #2090.
+    /// </para>
+    /// </remarks>
+    public CycleGANOptions()
+    {
+        CycleConsistencyLambda = 10.0;
+        IdentityLambda = 5.0;
+    }
+
+
+    /// <summary>
+    /// Gets or sets the cycle consistency lambda.
+    /// </summary>
+    public double CycleConsistencyLambda { get; set; }
+
+    /// <summary>
+    /// Gets or sets the identity lambda.
+    /// </summary>
+    public double IdentityLambda { get; set; }
+
+    /// <summary>
+    /// Throws if a value this model requires has been left unset or is not positive.
+    /// </summary>
+    /// <exception cref="ArgumentException">
+    /// Thrown when a required dimension is zero or negative.
+    /// </exception>
+    public void Validate()
+    {
+        ValidateCore();
+    }
 }

--- a/src/NeuralNetworks/Options/DCGANOptions.cs
+++ b/src/NeuralNetworks/Options/DCGANOptions.cs
@@ -5,6 +5,39 @@ namespace AiDotNet.NeuralNetworks.Options;
 /// <summary>
 /// Configuration options for the DCGAN (Deep Convolutional GAN) model.
 /// </summary>
-public class DCGANOptions : NeuralNetworkOptions
+public class DCGANOptions : GanOptions
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DCGANOptions"/> class carrying
+    /// this model's shipped defaults.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>For Beginners:</b> You do not need to set any of these. They are the values this
+    /// model has always used, moved here from its constructor so they can be seen and
+    /// changed in one place.
+    /// </para>
+    /// <para>
+    /// Carried over unchanged. Whether each matches the published paper is verified, and
+    /// corrected where it does not, in a later phase of issue #2090.
+    /// </para>
+    /// </remarks>
+    public DCGANOptions()
+    {
+        LatentSize = 100;
+        GeneratorChannels = 64;
+        DiscriminatorChannels = 64;
+    }
+
+
+    /// <summary>
+    /// Throws if a value this model requires has been left unset or is not positive.
+    /// </summary>
+    /// <exception cref="ArgumentException">
+    /// Thrown when a required dimension is zero or negative.
+    /// </exception>
+    public void Validate()
+    {
+        ValidateCore();
+    }
 }

--- a/src/NeuralNetworks/Options/EagleOptions.cs
+++ b/src/NeuralNetworks/Options/EagleOptions.cs
@@ -5,6 +5,41 @@ namespace AiDotNet.NeuralNetworks.Options;
 /// <summary>
 /// Configuration options for the EagleLanguageModel.
 /// </summary>
-public class EagleOptions : NeuralNetworkOptions
+public class EagleOptions : SequenceModelOptions
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="EagleOptions"/> class carrying
+    /// this model's shipped defaults.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>For Beginners:</b> You do not need to set any of these. They are the values the
+    /// model has always used, moved here from its constructor so they can be seen and
+    /// changed in one place.
+    /// </para>
+    /// <para>
+    /// Carried over unchanged. Whether each matches the published paper is verified, and
+    /// corrected where it does not, in a later phase of issue #2090 — kept separate so a
+    /// change in behaviour is never buried in a mechanical move.
+    /// </para>
+    /// </remarks>
+    public EagleOptions()
+    {
+        VocabSize = 65536;
+        ModelDimension = 256;
+        NumLayers = 4;
+        NumHeads = 8;
+        MaxSequenceLength = 512;
+    }
+
+    /// <summary>
+    /// Throws if a value this model requires has been left unset or is not positive.
+    /// </summary>
+    /// <exception cref="ArgumentException">
+    /// Thrown when a required dimension is zero or negative.
+    /// </exception>
+    public void Validate()
+    {
+        ValidateCore(requiresHeads: true, requiresState: false);
+    }
 }

--- a/src/NeuralNetworks/Options/EmbeddingModelOptions.cs
+++ b/src/NeuralNetworks/Options/EmbeddingModelOptions.cs
@@ -1,0 +1,88 @@
+using AiDotNet.Models.Options;
+
+namespace AiDotNet.NeuralNetworks.Options;
+
+/// <summary>
+/// Shared configuration for text embedding and retrieval models (BGE, ColBERT, SGPT,
+/// SPLADE, SimCSE, Instructor, Matryoshka, Word2Vec, GloVe, FastText).
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>For Beginners:</b> An embedding model turns a piece of text into a list of numbers so
+/// that similar texts end up with similar lists. Search engines use this to find documents
+/// that mean the same thing as your query even when they use different words. The settings
+/// here are the model's size, and each model's own options class ships the values from its
+/// paper.
+/// </para>
+/// <para>
+/// Derived options classes assign their paper's values in their parameterless constructor.
+/// See <see cref="ModelHyperparameterOptions"/> for why these properties are non-nullable.
+/// </para>
+/// <para>
+/// <b>Pooling strategy is deliberately absent.</b> Two unrelated <c>PoolingStrategy</c>
+/// enums exist in this codebase — one nested inside <c>TransformerEmbeddingNetwork&lt;T&gt;</c>
+/// and one in <c>AiDotNet.VisionLanguage.Encoders</c>. Choosing between them, or unifying
+/// them, is part of wiring the embedding models rather than of declaring this base, so the
+/// property is added then rather than guessed at now.
+/// </para>
+/// </remarks>
+public abstract class EmbeddingModelOptions : ModelHyperparameterOptions
+{
+    /// <summary>
+    /// Gets or sets the number of distinct tokens the model's tokenizer covers.
+    /// </summary>
+    /// <remarks>
+    /// <para><b>For Beginners:</b> 30522 is the BERT vocabulary, which many of these models
+    /// inherit.</para>
+    /// </remarks>
+    public int VocabSize { get; set; }
+
+    /// <summary>
+    /// Gets or sets the length of the vector the model produces for a piece of text.
+    /// </summary>
+    /// <remarks>
+    /// <para><b>For Beginners:</b> The size of the output "fingerprint". 768 is the usual
+    /// choice for base-sized models; larger means more nuance and more storage per document.</para>
+    /// </remarks>
+    public int EmbeddingDimension { get; set; }
+
+    /// <summary>
+    /// Gets or sets the longest text, in tokens, the model will encode. Longer inputs are
+    /// truncated.
+    /// </summary>
+    public int MaxSequenceLength { get; set; }
+
+    /// <summary>
+    /// Gets or sets the number of stacked transformer blocks.
+    /// </summary>
+    public int NumLayers { get; set; }
+
+    /// <summary>
+    /// Gets or sets the number of attention heads per block.
+    /// </summary>
+    public int NumHeads { get; set; }
+
+    /// <summary>
+    /// Gets or sets the width of the feed-forward sub-layer inside each block.
+    /// </summary>
+    /// <remarks>
+    /// <para><b>For Beginners:</b> Each block briefly widens its representation to do more
+    /// computation, then narrows it again. In BERT-base this is 3072, four times the 768-wide
+    /// representation.</para>
+    /// </remarks>
+    public int FeedForwardDim { get; set; }
+
+    /// <summary>
+    /// Throws if a dimension every embedding model requires has been left unset.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when a required dimension is zero or negative, which means the derived options
+    /// class did not assign its paper defaults.
+    /// </exception>
+    protected void ValidateCore()
+    {
+        Require(VocabSize, nameof(VocabSize));
+        Require(EmbeddingDimension, nameof(EmbeddingDimension));
+        Require(MaxSequenceLength, nameof(MaxSequenceLength));
+    }
+}

--- a/src/NeuralNetworks/Options/EmbeddingModelOptions.cs
+++ b/src/NeuralNetworks/Options/EmbeddingModelOptions.cs
@@ -19,7 +19,7 @@ namespace AiDotNet.NeuralNetworks.Options;
 /// See <see cref="ModelHyperparameterOptions"/> for why these properties are non-nullable.
 /// </para>
 /// <para>
-/// <b>Pooling strategy is deliberately absent.</b> Two unrelated <c>PoolingStrategy</c>
+/// <b>Pooling strategy is deliberately absent.</b> Two unrelated <c>EmbeddingPoolingStrategy</c>
 /// enums exist in this codebase — one nested inside <c>TransformerEmbeddingNetwork&lt;T&gt;</c>
 /// and one in <c>AiDotNet.VisionLanguage.Encoders</c>. Choosing between them, or unifying
 /// them, is part of wiring the embedding models rather than of declaring this base, so the

--- a/src/NeuralNetworks/Options/EmbeddingModelOptions.cs
+++ b/src/NeuralNetworks/Options/EmbeddingModelOptions.cs
@@ -75,7 +75,7 @@ public abstract class EmbeddingModelOptions : ModelHyperparameterOptions
     /// <summary>
     /// Throws if a dimension every embedding model requires has been left unset.
     /// </summary>
-    /// <exception cref="InvalidOperationException">
+    /// <exception cref="ArgumentException">
     /// Thrown when a required dimension is zero or negative, which means the derived options
     /// class did not assign its paper defaults.
     /// </exception>

--- a/src/NeuralNetworks/Options/FalconMambaOptions.cs
+++ b/src/NeuralNetworks/Options/FalconMambaOptions.cs
@@ -5,6 +5,43 @@ namespace AiDotNet.NeuralNetworks.Options;
 /// <summary>
 /// Configuration options for the FalconMambaLanguageModel.
 /// </summary>
-public class FalconMambaOptions : NeuralNetworkOptions
+public class FalconMambaOptions : SequenceModelOptions
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="FalconMambaOptions"/> class carrying
+    /// this model's shipped defaults.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>For Beginners:</b> You do not need to set any of these. They are the values the
+    /// model has always used, moved here from its constructor so they can be seen and
+    /// changed in one place.
+    /// </para>
+    /// <para>
+    /// Carried over unchanged. Whether each matches the published paper is verified, and
+    /// corrected where it does not, in a later phase of issue #2090 — kept separate so a
+    /// change in behaviour is never buried in a mechanical move.
+    /// </para>
+    /// </remarks>
+    public FalconMambaOptions()
+    {
+        VocabSize = 65024;
+        ModelDimension = 256;
+        NumLayers = 4;
+        StateDimension = 16;
+        ExpandFactor = 2;
+        MaxSequenceLength = 512;
+    }
+
+    /// <summary>
+    /// Throws if a value this model requires has been left unset or is not positive.
+    /// </summary>
+    /// <exception cref="ArgumentException">
+    /// Thrown when a required dimension is zero or negative.
+    /// </exception>
+    public void Validate()
+    {
+        ValidateCore(requiresHeads: false, requiresState: true);
+        Require(ExpandFactor, nameof(ExpandFactor));
+    }
 }

--- a/src/NeuralNetworks/Options/FastTextOptions.cs
+++ b/src/NeuralNetworks/Options/FastTextOptions.cs
@@ -5,6 +5,46 @@ namespace AiDotNet.NeuralNetworks.Options;
 /// <summary>
 /// Configuration options for the FastText model.
 /// </summary>
-public class FastTextOptions : NeuralNetworkOptions
+public class FastTextOptions : EmbeddingModelOptions
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="FastTextOptions"/> class carrying
+    /// this model's shipped defaults.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>For Beginners:</b> You do not need to set any of these. They are the values this
+    /// model has always used, moved here from its constructor so they can be seen and
+    /// changed in one place.
+    /// </para>
+    /// <para>
+    /// Carried over unchanged. Whether each matches the published paper is verified, and
+    /// corrected where it does not, in a later phase of issue #2090.
+    /// </para>
+    /// </remarks>
+    public FastTextOptions()
+    {
+        VocabSize = 10000;
+        BucketSize = 2000000;
+        EmbeddingDimension = 100;
+        MaxSequenceLength = 512;
+        MaxGradNorm = 1.0;
+    }
+
+
+    /// <summary>
+    /// Gets or sets the bucket size.
+    /// </summary>
+    public int BucketSize { get; set; }
+
+    /// <summary>
+    /// Throws if a value this model requires has been left unset or is not positive.
+    /// </summary>
+    /// <exception cref="ArgumentException">
+    /// Thrown when a required dimension is zero or negative.
+    /// </exception>
+    public void Validate()
+    {
+        ValidateCore();
+    }
 }

--- a/src/NeuralNetworks/Options/FinchOptions.cs
+++ b/src/NeuralNetworks/Options/FinchOptions.cs
@@ -5,10 +5,18 @@ namespace AiDotNet.NeuralNetworks.Options;
 /// <summary>
 /// Configuration options for the FinchLanguageModel.
 /// </summary>
-public class FinchOptions : NeuralNetworkOptions
+public class FinchOptions : SequenceModelOptions
 {
     /// <summary>Initializes a new instance with default values.</summary>
-    public FinchOptions() { }
+    public FinchOptions()
+    {
+        VocabSize = 65536;
+        ModelDimension = 256;
+        NumLayers = 4;
+        NumHeads = 8;
+        MaxSequenceLength = 512;
+        LearningRate = 0.001;
+    }
 
     /// <summary>Initializes a new instance by copying every property from another instance.</summary>
     /// <param name="other">The instance to copy from.</param>
@@ -26,6 +34,11 @@ public class FinchOptions : NeuralNetworkOptions
         WeightDecay = other.WeightDecay;
         EnableGradientClipping = other.EnableGradientClipping;
         MaxGradientNorm = other.MaxGradientNorm;
+        VocabSize = other.VocabSize;
+        ModelDimension = other.ModelDimension;
+        NumLayers = other.NumLayers;
+        NumHeads = other.NumHeads;
+        MaxSequenceLength = other.MaxSequenceLength;
     }
 
     /// <summary>Gets or sets the maximum (peak) learning rate.</summary>
@@ -88,4 +101,15 @@ public class FinchOptions : NeuralNetworkOptions
     /// <summary>Gets or sets the maximum gradient norm. See <see cref="EnableGradientClipping"/>.</summary>
     /// <value>Defaults to 1.0. NOT a paper value -- see the remark on the property above.</value>
     public double MaxGradientNorm { get; set; } = 1.0;
+
+    /// <summary>
+    /// Throws if a value this model requires has been left unset or is not positive.
+    /// </summary>
+    /// <exception cref="ArgumentException">
+    /// Thrown when a required dimension is zero or negative.
+    /// </exception>
+    public void Validate()
+    {
+        ValidateCore(requiresHeads: true, requiresState: false);
+    }
 }

--- a/src/NeuralNetworks/Options/FlamingoOptions.cs
+++ b/src/NeuralNetworks/Options/FlamingoOptions.cs
@@ -5,6 +5,80 @@ namespace AiDotNet.NeuralNetworks.Options;
 /// <summary>
 /// Configuration options for the FlamingoNeuralNetwork.
 /// </summary>
-public class FlamingoOptions : NeuralNetworkOptions
+public class FlamingoOptions : VisionLanguageModelOptions
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="FlamingoOptions"/> class carrying
+    /// this model's shipped defaults.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>For Beginners:</b> You do not need to set any of these. They are the values this
+    /// model has always used, moved here from its constructor so they can be seen and
+    /// changed in one place.
+    /// </para>
+    /// <para>
+    /// Carried over unchanged. Whether each matches the published paper is verified, and
+    /// corrected where it does not, in a later phase of issue #2090.
+    /// </para>
+    /// </remarks>
+    public FlamingoOptions()
+    {
+        EmbeddingDimension = 768;
+        MaxSequenceLength = 2048;
+        ImageSize = 224;
+        NumPerceiverTokens = 64;
+        MaxImagesInContext = 5;
+        Channels = 3;
+        VisionHiddenDim = 1024;
+        LmHiddenDim = 2048;
+        NumVisionLayers = 24;
+        NumLmLayers = 32;
+        NumHeads = 16;
+        VocabSize = 32000;
+        NumPerceiverLayers = 6;
+        LearningRate = 1e-3;
+    }
+
+
+    /// <summary>
+    /// Gets or sets the num perceiver tokens.
+    /// </summary>
+    public int NumPerceiverTokens { get; set; }
+
+    /// <summary>
+    /// Gets or sets the max images in context.
+    /// </summary>
+    public int MaxImagesInContext { get; set; }
+
+    /// <summary>
+    /// Gets or sets the lm hidden dim.
+    /// </summary>
+    public int LmHiddenDim { get; set; }
+
+    /// <summary>
+    /// Gets or sets the num lm layers.
+    /// </summary>
+    public int NumLmLayers { get; set; }
+
+    /// <summary>
+    /// Gets or sets the num perceiver layers.
+    /// </summary>
+    public int NumPerceiverLayers { get; set; }
+
+    /// <summary>
+    /// Gets or sets the learning rate.
+    /// </summary>
+    public double LearningRate { get; set; }
+
+    /// <summary>
+    /// Throws if a value this model requires has been left unset or is not positive.
+    /// </summary>
+    /// <exception cref="ArgumentException">
+    /// Thrown when a required dimension is zero or negative.
+    /// </exception>
+    public void Validate()
+    {
+        ValidateCore();
+    }
 }

--- a/src/NeuralNetworks/Options/FlamingoOptions.cs
+++ b/src/NeuralNetworks/Options/FlamingoOptions.cs
@@ -38,6 +38,7 @@ public class FlamingoOptions : VisionLanguageModelOptions
         VocabSize = 32000;
         NumPerceiverLayers = 6;
         LearningRate = 1e-3;
+        LanguageModelBackbone = LanguageModelBackbone.Chinchilla;
     }
 
 
@@ -81,4 +82,9 @@ public class FlamingoOptions : VisionLanguageModelOptions
     {
         ValidateCore();
     }
+
+    /// <summary>
+    /// Gets or sets the language model backbone.
+    /// </summary>
+    public LanguageModelBackbone LanguageModelBackbone { get; set; }
 }

--- a/src/NeuralNetworks/Options/GLAOptions.cs
+++ b/src/NeuralNetworks/Options/GLAOptions.cs
@@ -5,12 +5,19 @@ namespace AiDotNet.NeuralNetworks.Options;
 /// <summary>
 /// Configuration options for the GLALanguageModel.
 /// </summary>
-public class GLAOptions : NeuralNetworkOptions
+public class GLAOptions : SequenceModelOptions
 {
     /// <summary>
     /// Initializes a new instance with default values.
     /// </summary>
-    public GLAOptions() { }
+    public GLAOptions()
+    {
+        VocabSize = 50277;
+        ModelDimension = 256;
+        NumLayers = 4;
+        NumHeads = 8;
+        MaxSequenceLength = 512;
+    }
 
     /// <summary>
     /// Initializes a new instance by copying every property from another instance.
@@ -34,6 +41,11 @@ public class GLAOptions : NeuralNetworkOptions
         Seed = other.Seed;
         EncoderLayerCount = other.EncoderLayerCount;
         LearningRate = other.LearningRate;
+        VocabSize = other.VocabSize;
+        ModelDimension = other.ModelDimension;
+        NumLayers = other.NumLayers;
+        NumHeads = other.NumHeads;
+        MaxSequenceLength = other.MaxSequenceLength;
     }
 
     /// <summary>
@@ -51,4 +63,15 @@ public class GLAOptions : NeuralNetworkOptions
     /// value the paper's authors used, so training here starts from the same recipe they published.</para>
     /// </remarks>
     public double LearningRate { get; set; } = 3e-4;
+
+    /// <summary>
+    /// Throws if a value this model requires has been left unset or is not positive.
+    /// </summary>
+    /// <exception cref="ArgumentException">
+    /// Thrown when a required dimension is zero or negative.
+    /// </exception>
+    public void Validate()
+    {
+        ValidateCore(requiresHeads: true, requiresState: false);
+    }
 }

--- a/src/NeuralNetworks/Options/GanOptions.cs
+++ b/src/NeuralNetworks/Options/GanOptions.cs
@@ -75,7 +75,7 @@ public abstract class GanOptions : ModelHyperparameterOptions
     /// <summary>
     /// Throws if a dimension every GAN requires has been left unset.
     /// </summary>
-    /// <exception cref="InvalidOperationException">
+    /// <exception cref="ArgumentException">
     /// Thrown when a required dimension is zero or negative, which means the derived options
     /// class did not assign its paper defaults.
     /// </exception>

--- a/src/NeuralNetworks/Options/GanOptions.cs
+++ b/src/NeuralNetworks/Options/GanOptions.cs
@@ -1,0 +1,88 @@
+using AiDotNet.Models.Options;
+
+namespace AiDotNet.NeuralNetworks.Options;
+
+/// <summary>
+/// Shared configuration for generative adversarial networks (DCGAN, WGAN, WGAN-GP, BigGAN,
+/// SAGAN, StyleGAN, ProgressiveGAN, InfoGAN, Pix2Pix, CycleGAN).
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>For Beginners:</b> A GAN trains two networks against each other. The generator invents
+/// images; the discriminator (sometimes called the critic) tries to tell real images from
+/// invented ones. Each gets better because the other does. The settings here describe how
+/// big each of the two networks is and how they are trained.
+/// </para>
+/// <para>
+/// Derived options classes assign their paper's values in their parameterless constructor.
+/// See <see cref="ModelHyperparameterOptions"/> for why these properties are non-nullable.
+/// </para>
+/// </remarks>
+public abstract class GanOptions : ModelHyperparameterOptions
+{
+    /// <summary>
+    /// Gets or sets the length of the random noise vector the generator starts from.
+    /// </summary>
+    /// <remarks>
+    /// <para><b>For Beginners:</b> The generator turns a list of random numbers into an image.
+    /// This is how many random numbers it starts with — the "seed idea" for one image. 100 and
+    /// 128 are common; StyleGAN uses 512.</para>
+    /// </remarks>
+    public int LatentSize { get; set; }
+
+    /// <summary>
+    /// Gets or sets the base channel count of the generator. Layers scale up from this.
+    /// </summary>
+    /// <remarks>
+    /// <para><b>For Beginners:</b> Roughly how wide the image-making network is. Bigger means
+    /// more detail and slower training.</para>
+    /// </remarks>
+    public int GeneratorChannels { get; set; }
+
+    /// <summary>
+    /// Gets or sets the base channel count of the discriminator or critic.
+    /// </summary>
+    public int DiscriminatorChannels { get; set; }
+
+    /// <summary>
+    /// Gets or sets the number of colour channels in the generated image.
+    /// </summary>
+    /// <remarks>
+    /// <para><b>For Beginners:</b> 3 for colour, 1 for greyscale.</para>
+    /// </remarks>
+    public int ImageChannels { get; set; } = 3;
+
+    /// <summary>
+    /// Gets or sets how many discriminator or critic updates run per generator update.
+    /// </summary>
+    /// <remarks>
+    /// <para><b>For Beginners:</b> Wasserstein GANs train the critic several times for each
+    /// time they train the generator, which keeps the two from getting out of step. The WGAN
+    /// paper uses 5. Models that update both once per step leave this unset.</para>
+    /// </remarks>
+    public int CriticIterations { get; set; }
+
+    /// <summary>
+    /// Gets or sets the learning rate the adversarial pair starts training at.
+    /// </summary>
+    /// <remarks>
+    /// <para><b>For Beginners:</b> How big a step the networks take when correcting themselves.
+    /// GANs are unusually sensitive to this; 0.0002 with the Adam optimizer is the value most
+    /// GAN papers settled on.</para>
+    /// </remarks>
+    public double InitialLearningRate { get; set; }
+
+    /// <summary>
+    /// Throws if a dimension every GAN requires has been left unset.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when a required dimension is zero or negative, which means the derived options
+    /// class did not assign its paper defaults.
+    /// </exception>
+    protected void ValidateCore()
+    {
+        Require(LatentSize, nameof(LatentSize));
+        Require(ImageChannels, nameof(ImageChannels));
+        Require(InitialLearningRate, nameof(InitialLearningRate));
+    }
+}

--- a/src/NeuralNetworks/Options/GanOptions.cs
+++ b/src/NeuralNetworks/Options/GanOptions.cs
@@ -70,7 +70,11 @@ public abstract class GanOptions : ModelHyperparameterOptions
     /// GANs are unusually sensitive to this; 0.0002 with the Adam optimizer is the value most
     /// GAN papers settled on.</para>
     /// </remarks>
-    public double InitialLearningRate { get; set; }
+    /// <value>
+    /// Defaults to 0.0002, the Adam learning rate the DCGAN paper settled on and which most
+    /// later GAN papers inherited.
+    /// </value>
+    public double InitialLearningRate { get; set; } = 0.0002;
 
     /// <summary>
     /// Throws if a dimension every GAN requires has been left unset.
@@ -81,8 +85,10 @@ public abstract class GanOptions : ModelHyperparameterOptions
     /// </exception>
     protected void ValidateCore()
     {
-        Require(LatentSize, nameof(LatentSize));
+        // Only the channel count is universal. LatentSize stays a REQUIRED constructor
+        // argument on several of these models (DCGAN, BigGAN, SAGAN, ProgressiveGAN build their
+        // generator architecture from it before an instance exists), so it is legitimately unset
+        // on those options objects; and InitialLearningRate carries a default above.
         Require(ImageChannels, nameof(ImageChannels));
-        Require(InitialLearningRate, nameof(InitialLearningRate));
     }
 }

--- a/src/NeuralNetworks/Options/GatedDeltaNetOptions.cs
+++ b/src/NeuralNetworks/Options/GatedDeltaNetOptions.cs
@@ -5,12 +5,19 @@ namespace AiDotNet.NeuralNetworks.Options;
 /// <summary>
 /// Configuration options for the GatedDeltaNetLanguageModel.
 /// </summary>
-public class GatedDeltaNetOptions : NeuralNetworkOptions
+public class GatedDeltaNetOptions : SequenceModelOptions
 {
     /// <summary>
     /// Initializes a new instance with default values.
     /// </summary>
-    public GatedDeltaNetOptions() { }
+    public GatedDeltaNetOptions()
+    {
+        VocabSize = 50277;
+        ModelDimension = 256;
+        NumLayers = 4;
+        NumHeads = 8;
+        MaxSequenceLength = 512;
+    }
 
     /// <summary>
     /// Initializes a new instance by copying every property from another instance.
@@ -34,6 +41,11 @@ public class GatedDeltaNetOptions : NeuralNetworkOptions
         Seed = other.Seed;
         EncoderLayerCount = other.EncoderLayerCount;
         LearningRate = other.LearningRate;
+        VocabSize = other.VocabSize;
+        ModelDimension = other.ModelDimension;
+        NumLayers = other.NumLayers;
+        NumHeads = other.NumHeads;
+        MaxSequenceLength = other.MaxSequenceLength;
     }
 
     /// <summary>
@@ -51,4 +63,15 @@ public class GatedDeltaNetOptions : NeuralNetworkOptions
     /// value the paper's authors used, so training here starts from the same recipe they published.</para>
     /// </remarks>
     public double LearningRate { get; set; } = 3e-4;
+
+    /// <summary>
+    /// Throws if a value this model requires has been left unset or is not positive.
+    /// </summary>
+    /// <exception cref="ArgumentException">
+    /// Thrown when a required dimension is zero or negative.
+    /// </exception>
+    public void Validate()
+    {
+        ValidateCore(requiresHeads: true, requiresState: false);
+    }
 }

--- a/src/NeuralNetworks/Options/GloVeOptions.cs
+++ b/src/NeuralNetworks/Options/GloVeOptions.cs
@@ -5,6 +5,40 @@ namespace AiDotNet.NeuralNetworks.Options;
 /// <summary>
 /// Configuration options for the GloVe model.
 /// </summary>
-public class GloVeOptions : NeuralNetworkOptions
+public class GloVeOptions : EmbeddingModelOptions
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="GloVeOptions"/> class carrying
+    /// this model's shipped defaults.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>For Beginners:</b> You do not need to set any of these. They are the values this
+    /// model has always used, moved here from its constructor so they can be seen and
+    /// changed in one place.
+    /// </para>
+    /// <para>
+    /// Carried over unchanged. Whether each matches the published paper is verified, and
+    /// corrected where it does not, in a later phase of issue #2090.
+    /// </para>
+    /// </remarks>
+    public GloVeOptions()
+    {
+        VocabSize = 10000;
+        EmbeddingDimension = 100;
+        MaxSequenceLength = 512;
+        MaxGradNorm = 1.0;
+    }
+
+
+    /// <summary>
+    /// Throws if a value this model requires has been left unset or is not positive.
+    /// </summary>
+    /// <exception cref="ArgumentException">
+    /// Thrown when a required dimension is zero or negative.
+    /// </exception>
+    public void Validate()
+    {
+        ValidateCore();
+    }
 }

--- a/src/NeuralNetworks/Options/Gpt4VisionOptions.cs
+++ b/src/NeuralNetworks/Options/Gpt4VisionOptions.cs
@@ -5,6 +5,68 @@ namespace AiDotNet.NeuralNetworks.Options;
 /// <summary>
 /// Configuration options for the Gpt4VisionNeuralNetwork.
 /// </summary>
-public class Gpt4VisionOptions : NeuralNetworkOptions
+public class Gpt4VisionOptions : VisionLanguageModelOptions
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Gpt4VisionOptions"/> class carrying
+    /// this model's shipped defaults.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>For Beginners:</b> You do not need to set any of these. They are the values this
+    /// model has always used, moved here from its constructor so they can be seen and
+    /// changed in one place.
+    /// </para>
+    /// <para>
+    /// Carried over unchanged. Whether each matches the published paper is verified, and
+    /// corrected where it does not, in a later phase of issue #2090.
+    /// </para>
+    /// </remarks>
+    public Gpt4VisionOptions()
+    {
+        EmbeddingDimension = 4096;
+        VisionEmbeddingDim = 1024;
+        MaxSequenceLength = 2048;
+        ContextWindowSize = 128000;
+        ImageSize = 336;
+        MaxImagesPerRequest = 10;
+        HiddenDim = 4096;
+        NumVisionLayers = 24;
+        NumLanguageLayers = 32;
+        NumHeads = 32;
+        PatchSize = 14;
+        VocabSize = 128256;
+    }
+
+
+    /// <summary>
+    /// Gets or sets the vision embedding dim.
+    /// </summary>
+    public int VisionEmbeddingDim { get; set; }
+
+    /// <summary>
+    /// Gets or sets the context window size.
+    /// </summary>
+    public int ContextWindowSize { get; set; }
+
+    /// <summary>
+    /// Gets or sets the max images per request.
+    /// </summary>
+    public int MaxImagesPerRequest { get; set; }
+
+    /// <summary>
+    /// Gets or sets the num language layers.
+    /// </summary>
+    public int NumLanguageLayers { get; set; }
+
+    /// <summary>
+    /// Throws if a value this model requires has been left unset or is not positive.
+    /// </summary>
+    /// <exception cref="ArgumentException">
+    /// Thrown when a required dimension is zero or negative.
+    /// </exception>
+    public void Validate()
+    {
+        ValidateCore();
+    }
 }

--- a/src/NeuralNetworks/Options/GriffinOptions.cs
+++ b/src/NeuralNetworks/Options/GriffinOptions.cs
@@ -5,7 +5,7 @@ namespace AiDotNet.NeuralNetworks.Options;
 /// <summary>
 /// Configuration options for the GriffinLanguageModel.
 /// </summary>
-public class GriffinOptions : NeuralNetworkOptions
+public class GriffinOptions : SequenceModelOptions
 {
     /// <summary>
     /// Gets or sets the RG-LRU width. The default 2560 is the published 1.3B
@@ -38,7 +38,13 @@ public class GriffinOptions : NeuralNetworkOptions
     public double MaxGradientNorm { get; set; } = 1.0;
 
     /// <summary>Initializes an options instance with default values.</summary>
-    public GriffinOptions() { }
+    public GriffinOptions()
+    {
+        VocabSize = 256000;
+        ModelDimension = 2048;
+        NumLayers = 24;
+        MaxSequenceLength = 2048;
+    }
 
     /// <summary>Initializes an options instance by copying inherited configuration.</summary>
     /// <param name="other">The source options.</param>
@@ -56,5 +62,20 @@ public class GriffinOptions : NeuralNetworkOptions
         Epsilon = other.Epsilon;
         EnableGradientClipping = other.EnableGradientClipping;
         MaxGradientNorm = other.MaxGradientNorm;
+        VocabSize = other.VocabSize;
+        ModelDimension = other.ModelDimension;
+        NumLayers = other.NumLayers;
+        MaxSequenceLength = other.MaxSequenceLength;
+    }
+
+    /// <summary>
+    /// Throws if a value this model requires has been left unset or is not positive.
+    /// </summary>
+    /// <exception cref="ArgumentException">
+    /// Thrown when a required dimension is zero or negative.
+    /// </exception>
+    public void Validate()
+    {
+        ValidateCore(requiresHeads: false, requiresState: false);
     }
 }

--- a/src/NeuralNetworks/Options/HawkOptions.cs
+++ b/src/NeuralNetworks/Options/HawkOptions.cs
@@ -5,7 +5,7 @@ namespace AiDotNet.NeuralNetworks.Options;
 /// <summary>
 /// Configuration options for the HawkLanguageModel.
 /// </summary>
-public class HawkOptions : NeuralNetworkOptions
+public class HawkOptions : SequenceModelOptions
 {
     /// <summary>
     /// Gets or sets the RG-LRU width. The default 2560 is the published 1.3B
@@ -38,7 +38,13 @@ public class HawkOptions : NeuralNetworkOptions
     public double MaxGradientNorm { get; set; } = 1.0;
 
     /// <summary>Initializes an options instance with default values.</summary>
-    public HawkOptions() { }
+    public HawkOptions()
+    {
+        VocabSize = 256000;
+        ModelDimension = 2048;
+        NumLayers = 24;
+        MaxSequenceLength = 2048;
+    }
 
     /// <summary>Initializes an options instance by copying inherited configuration.</summary>
     /// <param name="other">The source options.</param>
@@ -56,5 +62,20 @@ public class HawkOptions : NeuralNetworkOptions
         Epsilon = other.Epsilon;
         EnableGradientClipping = other.EnableGradientClipping;
         MaxGradientNorm = other.MaxGradientNorm;
+        VocabSize = other.VocabSize;
+        ModelDimension = other.ModelDimension;
+        NumLayers = other.NumLayers;
+        MaxSequenceLength = other.MaxSequenceLength;
+    }
+
+    /// <summary>
+    /// Throws if a value this model requires has been left unset or is not positive.
+    /// </summary>
+    /// <exception cref="ArgumentException">
+    /// Thrown when a required dimension is zero or negative.
+    /// </exception>
+    public void Validate()
+    {
+        ValidateCore(requiresHeads: false, requiresState: false);
     }
 }

--- a/src/NeuralNetworks/Options/ImageBindOptions.cs
+++ b/src/NeuralNetworks/Options/ImageBindOptions.cs
@@ -5,6 +5,69 @@ namespace AiDotNet.NeuralNetworks.Options;
 /// <summary>
 /// Configuration options for the ImageBindNeuralNetwork.
 /// </summary>
-public class ImageBindOptions : NeuralNetworkOptions
+public class ImageBindOptions : VisionLanguageModelOptions
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ImageBindOptions"/> class carrying
+    /// this model's shipped defaults.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>For Beginners:</b> You do not need to set any of these. They are the values this
+    /// model has always used, moved here from its constructor so they can be seen and
+    /// changed in one place.
+    /// </para>
+    /// <para>
+    /// Carried over unchanged. Whether each matches the published paper is verified, and
+    /// corrected where it does not, in a later phase of issue #2090.
+    /// </para>
+    /// </remarks>
+    public ImageBindOptions()
+    {
+        EmbeddingDimension = 1024;
+        MaxSequenceLength = 77;
+        ImageSize = 224;
+        AudioSampleRate = 16000;
+        Channels = 3;
+        PatchSize = 14;
+        VocabSize = 49408;
+        HiddenDim = 1280;
+        NumEncoderLayers = 32;
+        NumHeads = 16;
+        AudioMaxDuration = 10;
+        ImuTimesteps = 2000;
+        NumVideoFrames = 2;
+    }
+
+
+    /// <summary>
+    /// Gets or sets the audio sample rate.
+    /// </summary>
+    public int AudioSampleRate { get; set; }
+
+    /// <summary>
+    /// Gets or sets the audio max duration.
+    /// </summary>
+    public int AudioMaxDuration { get; set; }
+
+    /// <summary>
+    /// Gets or sets the imu timesteps.
+    /// </summary>
+    public int ImuTimesteps { get; set; }
+
+    /// <summary>
+    /// Gets or sets the num video frames.
+    /// </summary>
+    public int NumVideoFrames { get; set; }
+
+    /// <summary>
+    /// Throws if a value this model requires has been left unset or is not positive.
+    /// </summary>
+    /// <exception cref="ArgumentException">
+    /// Thrown when a required dimension is zero or negative.
+    /// </exception>
+    public void Validate()
+    {
+        ValidateCore();
+    }
 }

--- a/src/NeuralNetworks/Options/InfoGANOptions.cs
+++ b/src/NeuralNetworks/Options/InfoGANOptions.cs
@@ -5,6 +5,48 @@ namespace AiDotNet.NeuralNetworks.Options;
 /// <summary>
 /// Configuration options for the InfoGAN neural network.
 /// </summary>
-public class InfoGANOptions : NeuralNetworkOptions
+public class InfoGANOptions : GanOptions
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="InfoGANOptions"/> class carrying
+    /// this model's shipped defaults.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>For Beginners:</b> You do not need to set any of these. They are the values this
+    /// model has always used, moved here from its constructor so they can be seen and
+    /// changed in one place.
+    /// </para>
+    /// <para>
+    /// Carried over unchanged. Whether each matches the published paper is verified, and
+    /// corrected where it does not, in a later phase of issue #2090.
+    /// </para>
+    /// </remarks>
+    public InfoGANOptions()
+    {
+        LatentCodeSize = 10;
+        MutualInfoCoefficient = 1.0;
+    }
+
+
+    /// <summary>
+    /// Gets or sets the latent code size.
+    /// </summary>
+    public int LatentCodeSize { get; set; }
+
+    /// <summary>
+    /// Gets or sets the mutual info coefficient.
+    /// </summary>
+    public double MutualInfoCoefficient { get; set; }
+
+    /// <summary>
+    /// Throws if a value this model requires has been left unset or is not positive.
+    /// </summary>
+    /// <exception cref="ArgumentException">
+    /// Thrown when a required dimension is zero or negative.
+    /// </exception>
+    public void Validate()
+    {
+        ValidateCore();
+    }
 }

--- a/src/NeuralNetworks/Options/InstructorEmbeddingOptions.cs
+++ b/src/NeuralNetworks/Options/InstructorEmbeddingOptions.cs
@@ -5,6 +5,32 @@ namespace AiDotNet.NeuralNetworks.Options;
 /// <summary>
 /// Configuration options for the Instructor Embedding model.
 /// </summary>
-public class InstructorEmbeddingOptions : NeuralNetworkOptions
+public class InstructorEmbeddingOptions : TransformerEmbeddingOptions
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="InstructorEmbeddingOptions"/> class carrying
+    /// this model's shipped defaults.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>For Beginners:</b> You do not need to set any of these. They are the values this
+    /// model has always used, moved here from its constructor so they can be seen and
+    /// changed in one place.
+    /// </para>
+    /// <para>
+    /// Carried over unchanged. Whether each matches the published paper is verified, and
+    /// corrected where it does not, in a later phase of issue #2090.
+    /// </para>
+    /// </remarks>
+    public InstructorEmbeddingOptions()
+    {
+        VocabSize = 30522;
+        EmbeddingDimension = 768;
+        MaxSequenceLength = 512;
+        NumLayers = 12;
+        NumHeads = 12;
+        FeedForwardDim = 3072;
+        EmbeddingPoolingStrategy = EmbeddingPoolingStrategy.Mean;
+        MaxGradNorm = 1.0;
+    }
 }

--- a/src/NeuralNetworks/Options/JambaOptions.cs
+++ b/src/NeuralNetworks/Options/JambaOptions.cs
@@ -5,6 +5,42 @@ namespace AiDotNet.NeuralNetworks.Options;
 /// <summary>
 /// Configuration options for the JambaLanguageModel.
 /// </summary>
-public class JambaOptions : NeuralNetworkOptions
+public class JambaOptions : SequenceModelOptions
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="JambaOptions"/> class carrying
+    /// this model's shipped defaults.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>For Beginners:</b> You do not need to set any of these. They are the values the
+    /// model has always used, moved here from its constructor so they can be seen and
+    /// changed in one place.
+    /// </para>
+    /// <para>
+    /// Carried over unchanged. Whether each matches the published paper is verified, and
+    /// corrected where it does not, in a later phase of issue #2090 — kept separate so a
+    /// change in behaviour is never buried in a mechanical move.
+    /// </para>
+    /// </remarks>
+    public JambaOptions()
+    {
+        VocabSize = 65536;
+        ModelDimension = 256;
+        NumLayers = 8;
+        StateDimension = 16;
+        AttentionInterval = 8;
+        MaxSequenceLength = 512;
+    }
+
+    /// <summary>
+    /// Throws if a value this model requires has been left unset or is not positive.
+    /// </summary>
+    /// <exception cref="ArgumentException">
+    /// Thrown when a required dimension is zero or negative.
+    /// </exception>
+    public void Validate()
+    {
+        ValidateCore(requiresHeads: false, requiresState: true);
+    }
 }

--- a/src/NeuralNetworks/Options/LLaVAOptions.cs
+++ b/src/NeuralNetworks/Options/LLaVAOptions.cs
@@ -34,6 +34,8 @@ public class LLaVAOptions : VisionLanguageModelOptions
         NumVisionLayers = 24;
         NumLmLayers = 32;
         NumHeads = 16;
+        LanguageModelBackbone = LanguageModelBackbone.LLaMA;
+        VisionEncoderType = "clip-vit-l";
     }
 
 
@@ -52,4 +54,14 @@ public class LLaVAOptions : VisionLanguageModelOptions
     {
         ValidateCore();
     }
+
+    /// <summary>
+    /// Gets or sets the language model backbone.
+    /// </summary>
+    public LanguageModelBackbone LanguageModelBackbone { get; set; }
+
+    /// <summary>
+    /// Gets or sets the vision encoder type.
+    /// </summary>
+    public string VisionEncoderType { get; set; }
 }

--- a/src/NeuralNetworks/Options/LLaVAOptions.cs
+++ b/src/NeuralNetworks/Options/LLaVAOptions.cs
@@ -5,6 +5,51 @@ namespace AiDotNet.NeuralNetworks.Options;
 /// <summary>
 /// Configuration options for the LLaVANeuralNetwork.
 /// </summary>
-public class LLaVAOptions : NeuralNetworkOptions
+public class LLaVAOptions : VisionLanguageModelOptions
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="LLaVAOptions"/> class carrying
+    /// this model's shipped defaults.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>For Beginners:</b> You do not need to set any of these. They are the values this
+    /// model has always used, moved here from its constructor so they can be seen and
+    /// changed in one place.
+    /// </para>
+    /// <para>
+    /// Carried over unchanged. Whether each matches the published paper is verified, and
+    /// corrected where it does not, in a later phase of issue #2090.
+    /// </para>
+    /// </remarks>
+    public LLaVAOptions()
+    {
+        EmbeddingDimension = 4096;
+        MaxSequenceLength = 2048;
+        ImageSize = 336;
+        Channels = 3;
+        PatchSize = 14;
+        VocabSize = 32000;
+        VisionHiddenDim = 1024;
+        NumVisionLayers = 24;
+        NumLmLayers = 32;
+        NumHeads = 16;
+    }
+
+
+    /// <summary>
+    /// Gets or sets the num lm layers.
+    /// </summary>
+    public int NumLmLayers { get; set; }
+
+    /// <summary>
+    /// Throws if a value this model requires has been left unset or is not positive.
+    /// </summary>
+    /// <exception cref="ArgumentException">
+    /// Thrown when a required dimension is zero or negative.
+    /// </exception>
+    public void Validate()
+    {
+        ValidateCore();
+    }
 }

--- a/src/NeuralNetworks/Options/Mamba2Options.cs
+++ b/src/NeuralNetworks/Options/Mamba2Options.cs
@@ -5,6 +5,42 @@ namespace AiDotNet.NeuralNetworks.Options;
 /// <summary>
 /// Configuration options for the Mamba2LanguageModel.
 /// </summary>
-public class Mamba2Options : NeuralNetworkOptions
+public class Mamba2Options : SequenceModelOptions
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Mamba2Options"/> class carrying
+    /// this model's shipped defaults.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>For Beginners:</b> You do not need to set any of these. They are the values the
+    /// model has always used, moved here from its constructor so they can be seen and
+    /// changed in one place.
+    /// </para>
+    /// <para>
+    /// Carried over unchanged. Whether each matches the published paper is verified, and
+    /// corrected where it does not, in a later phase of issue #2090 — kept separate so a
+    /// change in behaviour is never buried in a mechanical move.
+    /// </para>
+    /// </remarks>
+    public Mamba2Options()
+    {
+        VocabSize = 50277;
+        ModelDimension = 256;
+        NumLayers = 4;
+        StateDimension = 64;
+        NumHeads = 8;
+        MaxSequenceLength = 512;
+    }
+
+    /// <summary>
+    /// Throws if a value this model requires has been left unset or is not positive.
+    /// </summary>
+    /// <exception cref="ArgumentException">
+    /// Thrown when a required dimension is zero or negative.
+    /// </exception>
+    public void Validate()
+    {
+        ValidateCore(requiresHeads: true, requiresState: true);
+    }
 }

--- a/src/NeuralNetworks/Options/MambaOptions.cs
+++ b/src/NeuralNetworks/Options/MambaOptions.cs
@@ -3,8 +3,51 @@ using AiDotNet.Models.Options;
 namespace AiDotNet.NeuralNetworks.Options;
 
 /// <summary>
-/// Configuration options for the MambaLanguageModel.
+/// Configuration options for <see cref="MambaLanguageModel{T}"/>.
 /// </summary>
-public class MambaOptions : NeuralNetworkOptions
+/// <remarks>
+/// <para>
+/// <b>For Beginners:</b> Mamba is a language model that reads text left to right while
+/// carrying a compact running summary of everything it has seen, instead of re-reading the
+/// whole passage at every step the way a transformer does. That makes it fast on long text.
+/// You do not need to set anything here — the defaults come with the model.
+/// </para>
+/// <para>
+/// <b>Values are carried over unchanged from the constructor parameters they replace and are
+/// NOT yet the paper's.</b> Mamba-130M is 768 wide with 24 layers; the values below are the
+/// demo-sized ones this model has always shipped. Correcting them is a deliberate behavioural
+/// change, made in its own phase of issue #2090 so it is reviewed apart from this mechanical
+/// move.
+/// </para>
+/// </remarks>
+/// <seealso href="https://arxiv.org/abs/2312.00752">
+/// Mamba: Linear-Time Sequence Modeling with Selective State Spaces
+/// </seealso>
+public class MambaOptions : SequenceModelOptions
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MambaOptions"/> class with this model's
+    /// shipped defaults.
+    /// </summary>
+    public MambaOptions()
+    {
+        VocabSize = 50277;
+        ModelDimension = 256;
+        NumLayers = 4;
+        StateDimension = 16;
+        ExpandFactor = 2;
+        MaxSequenceLength = 512;
+    }
+
+    /// <summary>
+    /// Throws if a value this model requires has been left unset or is not positive.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when a required dimension is zero or negative.
+    /// </exception>
+    public void Validate()
+    {
+        ValidateCore(requiresHeads: false, requiresState: true);
+        Require(ExpandFactor, nameof(ExpandFactor));
+    }
 }

--- a/src/NeuralNetworks/Options/MambaOptions.cs
+++ b/src/NeuralNetworks/Options/MambaOptions.cs
@@ -42,7 +42,7 @@ public class MambaOptions : SequenceModelOptions
     /// <summary>
     /// Throws if a value this model requires has been left unset or is not positive.
     /// </summary>
-    /// <exception cref="InvalidOperationException">
+    /// <exception cref="ArgumentException">
     /// Thrown when a required dimension is zero or negative.
     /// </exception>
     public void Validate()

--- a/src/NeuralNetworks/Options/MatryoshkaEmbeddingOptions.cs
+++ b/src/NeuralNetworks/Options/MatryoshkaEmbeddingOptions.cs
@@ -5,6 +5,38 @@ namespace AiDotNet.NeuralNetworks.Options;
 /// <summary>
 /// Configuration options for the Matryoshka Embedding model.
 /// </summary>
-public class MatryoshkaEmbeddingOptions : NeuralNetworkOptions
+public class MatryoshkaEmbeddingOptions : TransformerEmbeddingOptions
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MatryoshkaEmbeddingOptions"/> class carrying
+    /// this model's shipped defaults.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>For Beginners:</b> You do not need to set any of these. They are the values this
+    /// model has always used, moved here from its constructor so they can be seen and
+    /// changed in one place.
+    /// </para>
+    /// <para>
+    /// Carried over unchanged. Whether each matches the published paper is verified, and
+    /// corrected where it does not, in a later phase of issue #2090.
+    /// </para>
+    /// </remarks>
+    public MatryoshkaEmbeddingOptions()
+    {
+        VocabSize = 30522;
+        MaxEmbeddingDimension = 1536;
+        MaxSequenceLength = 512;
+        NumLayers = 12;
+        NumHeads = 12;
+        FeedForwardDim = 3072;
+        EmbeddingPoolingStrategy = EmbeddingPoolingStrategy.ClsToken;
+        MaxGradNorm = 1.0;
+    }
+
+
+    /// <summary>
+    /// Gets or sets the max embedding dimension.
+    /// </summary>
+    public int MaxEmbeddingDimension { get; set; }
 }

--- a/src/NeuralNetworks/Options/Pix2PixOptions.cs
+++ b/src/NeuralNetworks/Options/Pix2PixOptions.cs
@@ -5,6 +5,42 @@ namespace AiDotNet.NeuralNetworks.Options;
 /// <summary>
 /// Configuration options for the Pix2Pix neural network.
 /// </summary>
-public class Pix2PixOptions : NeuralNetworkOptions
+public class Pix2PixOptions : GanOptions
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Pix2PixOptions"/> class carrying
+    /// this model's shipped defaults.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>For Beginners:</b> You do not need to set any of these. They are the values this
+    /// model has always used, moved here from its constructor so they can be seen and
+    /// changed in one place.
+    /// </para>
+    /// <para>
+    /// Carried over unchanged. Whether each matches the published paper is verified, and
+    /// corrected where it does not, in a later phase of issue #2090.
+    /// </para>
+    /// </remarks>
+    public Pix2PixOptions()
+    {
+        L1Lambda = 100.0;
+    }
+
+
+    /// <summary>
+    /// Gets or sets the l1 lambda.
+    /// </summary>
+    public double L1Lambda { get; set; }
+
+    /// <summary>
+    /// Throws if a value this model requires has been left unset or is not positive.
+    /// </summary>
+    /// <exception cref="ArgumentException">
+    /// Thrown when a required dimension is zero or negative.
+    /// </exception>
+    public void Validate()
+    {
+        ValidateCore();
+    }
 }

--- a/src/NeuralNetworks/Options/ProgressiveGANOptions.cs
+++ b/src/NeuralNetworks/Options/ProgressiveGANOptions.cs
@@ -5,6 +5,58 @@ namespace AiDotNet.NeuralNetworks.Options;
 /// <summary>
 /// Configuration options for the ProgressiveGAN.
 /// </summary>
-public class ProgressiveGANOptions : NeuralNetworkOptions
+public class ProgressiveGANOptions : GanOptions
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ProgressiveGANOptions"/> class carrying
+    /// this model's shipped defaults.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>For Beginners:</b> You do not need to set any of these. They are the values this
+    /// model has always used, moved here from its constructor so they can be seen and
+    /// changed in one place.
+    /// </para>
+    /// <para>
+    /// Carried over unchanged. Whether each matches the published paper is verified, and
+    /// corrected where it does not, in a later phase of issue #2090.
+    /// </para>
+    /// </remarks>
+    public ProgressiveGANOptions()
+    {
+        MaxResolutionLevel = 6;
+        GeneratorChannels = 512;
+        LatentSize = 512;
+        ImageChannels = 3;
+        InputType = InputType.TwoDimensional;
+        InitialLearningRate = 0.001; // DefaultLearningRate
+        LearningRateDecay = 0.9999; // DefaultLearningRateDecay
+    }
+
+
+    /// <summary>
+    /// Gets or sets the max resolution level.
+    /// </summary>
+    public int MaxResolutionLevel { get; set; }
+
+    /// <summary>
+    /// Gets or sets the input type.
+    /// </summary>
+    public InputType InputType { get; set; }
+
+    /// <summary>
+    /// Gets or sets the learning rate decay.
+    /// </summary>
+    public double LearningRateDecay { get; set; }
+
+    /// <summary>
+    /// Throws if a value this model requires has been left unset or is not positive.
+    /// </summary>
+    /// <exception cref="ArgumentException">
+    /// Thrown when a required dimension is zero or negative.
+    /// </exception>
+    public void Validate()
+    {
+        ValidateCore();
+    }
 }

--- a/src/NeuralNetworks/Options/RWKV4Options.cs
+++ b/src/NeuralNetworks/Options/RWKV4Options.cs
@@ -5,6 +5,40 @@ namespace AiDotNet.NeuralNetworks.Options;
 /// <summary>
 /// Configuration options for the RWKV4LanguageModel.
 /// </summary>
-public class RWKV4Options : NeuralNetworkOptions
+public class RWKV4Options : SequenceModelOptions
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RWKV4Options"/> class carrying
+    /// this model's shipped defaults.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>For Beginners:</b> You do not need to set any of these. They are the values the
+    /// model has always used, moved here from its constructor so they can be seen and
+    /// changed in one place.
+    /// </para>
+    /// <para>
+    /// Carried over unchanged. Whether each matches the published paper is verified, and
+    /// corrected where it does not, in a later phase of issue #2090 — kept separate so a
+    /// change in behaviour is never buried in a mechanical move.
+    /// </para>
+    /// </remarks>
+    public RWKV4Options()
+    {
+        VocabSize = 50277;
+        ModelDimension = 256;
+        NumLayers = 4;
+        MaxSequenceLength = 512;
+    }
+
+    /// <summary>
+    /// Throws if a value this model requires has been left unset or is not positive.
+    /// </summary>
+    /// <exception cref="ArgumentException">
+    /// Thrown when a required dimension is zero or negative.
+    /// </exception>
+    public void Validate()
+    {
+        ValidateCore(requiresHeads: false, requiresState: false);
+    }
 }

--- a/src/NeuralNetworks/Options/RWKV7Options.cs
+++ b/src/NeuralNetworks/Options/RWKV7Options.cs
@@ -5,6 +5,42 @@ namespace AiDotNet.NeuralNetworks.Options;
 /// <summary>
 /// Configuration options for the RWKV7LanguageModel.
 /// </summary>
-public class RWKV7Options : NeuralNetworkOptions
+public class RWKV7Options : SequenceModelOptions
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RWKV7Options"/> class carrying
+    /// this model's shipped defaults.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>For Beginners:</b> You do not need to set any of these. They are the values the
+    /// model has always used, moved here from its constructor so they can be seen and
+    /// changed in one place.
+    /// </para>
+    /// <para>
+    /// Carried over unchanged. Whether each matches the published paper is verified, and
+    /// corrected where it does not, in a later phase of issue #2090 — kept separate so a
+    /// change in behaviour is never buried in a mechanical move.
+    /// </para>
+    /// </remarks>
+    public RWKV7Options()
+    {
+        VocabSize = 65536;
+        ModelDimension = 256;
+        NumLayers = 4;
+        NumHeads = 4;
+        FfnMultiplier = 3.5;
+        MaxSequenceLength = 512;
+    }
+
+    /// <summary>
+    /// Throws if a value this model requires has been left unset or is not positive.
+    /// </summary>
+    /// <exception cref="ArgumentException">
+    /// Thrown when a required dimension is zero or negative.
+    /// </exception>
+    public void Validate()
+    {
+        ValidateCore(requiresHeads: true, requiresState: false);
+    }
 }

--- a/src/NeuralNetworks/Options/RecurrentGemmaOptions.cs
+++ b/src/NeuralNetworks/Options/RecurrentGemmaOptions.cs
@@ -13,7 +13,7 @@ namespace AiDotNet.NeuralNetworks.Options;
 /// so the model silently inherited whatever the base supplied.
 /// </para>
 /// </remarks>
-public class RecurrentGemmaOptions : NeuralNetworkOptions
+public class RecurrentGemmaOptions : SequenceModelOptions
 {
     /// <summary>
     /// Gets or sets whether the input embeddings are multiplied by the square root of the model width.
@@ -66,6 +66,10 @@ public class RecurrentGemmaOptions : NeuralNetworkOptions
         Epsilon = 1e-8;
         EnableGradientClipping = true;
         MaxGradientNorm = 1.0;
+        VocabSize = 256000;
+        ModelDimension = 256;
+        NumLayers = 4;
+        MaxSequenceLength = 512;
     }
 
     /// <summary>Initializes an options instance by copying another.</summary>
@@ -84,5 +88,20 @@ public class RecurrentGemmaOptions : NeuralNetworkOptions
         Epsilon = other.Epsilon;
         EnableGradientClipping = other.EnableGradientClipping;
         MaxGradientNorm = other.MaxGradientNorm;
+        VocabSize = other.VocabSize;
+        ModelDimension = other.ModelDimension;
+        NumLayers = other.NumLayers;
+        MaxSequenceLength = other.MaxSequenceLength;
+    }
+
+    /// <summary>
+    /// Throws if a value this model requires has been left unset or is not positive.
+    /// </summary>
+    /// <exception cref="ArgumentException">
+    /// Thrown when a required dimension is zero or negative.
+    /// </exception>
+    public void Validate()
+    {
+        ValidateCore(requiresHeads: false, requiresState: false);
     }
 }

--- a/src/NeuralNetworks/Options/SAGANOptions.cs
+++ b/src/NeuralNetworks/Options/SAGANOptions.cs
@@ -5,6 +5,65 @@ namespace AiDotNet.NeuralNetworks.Options;
 /// <summary>
 /// Configuration options for the SAGAN neural network.
 /// </summary>
-public class SAGANOptions : NeuralNetworkOptions
+public class SAGANOptions : GanOptions
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SAGANOptions"/> class carrying
+    /// this model's shipped defaults.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>For Beginners:</b> You do not need to set any of these. They are the values this
+    /// model has always used, moved here from its constructor so they can be seen and
+    /// changed in one place.
+    /// </para>
+    /// <para>
+    /// Carried over unchanged. Whether each matches the published paper is verified, and
+    /// corrected where it does not, in a later phase of issue #2090.
+    /// </para>
+    /// </remarks>
+    public SAGANOptions()
+    {
+        NumClasses = 0;
+        GeneratorChannels = 64;
+        DiscriminatorChannels = 64;
+        LatentSize = 128;
+        ImageChannels = 3;
+        ImageHeight = 64;
+        ImageWidth = 64;
+        InputType = InputType.TwoDimensional;
+        InitialLearningRate = 0.0001;
+    }
+
+
+    /// <summary>
+    /// Gets or sets the num classes.
+    /// </summary>
+    public int NumClasses { get; set; }
+
+    /// <summary>
+    /// Gets or sets the image height.
+    /// </summary>
+    public int ImageHeight { get; set; }
+
+    /// <summary>
+    /// Gets or sets the image width.
+    /// </summary>
+    public int ImageWidth { get; set; }
+
+    /// <summary>
+    /// Gets or sets the input type.
+    /// </summary>
+    public InputType InputType { get; set; }
+
+    /// <summary>
+    /// Throws if a value this model requires has been left unset or is not positive.
+    /// </summary>
+    /// <exception cref="ArgumentException">
+    /// Thrown when a required dimension is zero or negative.
+    /// </exception>
+    public void Validate()
+    {
+        ValidateCore();
+    }
 }

--- a/src/NeuralNetworks/Options/SGPTOptions.cs
+++ b/src/NeuralNetworks/Options/SGPTOptions.cs
@@ -5,6 +5,30 @@ namespace AiDotNet.NeuralNetworks.Options;
 /// <summary>
 /// Configuration options for the SGPT model.
 /// </summary>
-public class SGPTOptions : NeuralNetworkOptions
+public class SGPTOptions : TransformerEmbeddingOptions
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SGPTOptions"/> class carrying
+    /// this model's shipped defaults.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>For Beginners:</b> You do not need to set any of these. They are the values this
+    /// model has always used, moved here from its constructor so they can be seen and
+    /// changed in one place.
+    /// </para>
+    /// <para>
+    /// Carried over unchanged. Whether each matches the published paper is verified, and
+    /// corrected where it does not, in a later phase of issue #2090.
+    /// </para>
+    /// </remarks>
+    public SGPTOptions()
+    {
+        VocabSize = 50257;
+        MaxSequenceLength = 1024;
+        NumLayers = 12;
+        FeedForwardDim = 3072;
+        EmbeddingPoolingStrategy = EmbeddingPoolingStrategy.Mean;
+        MaxGradNorm = 1.0;
+    }
 }

--- a/src/NeuralNetworks/Options/SPLADEOptions.cs
+++ b/src/NeuralNetworks/Options/SPLADEOptions.cs
@@ -5,6 +5,31 @@ namespace AiDotNet.NeuralNetworks.Options;
 /// <summary>
 /// Configuration options for the SPLADE model.
 /// </summary>
-public class SPLADEOptions : NeuralNetworkOptions
+public class SPLADEOptions : TransformerEmbeddingOptions
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SPLADEOptions"/> class carrying
+    /// this model's shipped defaults.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>For Beginners:</b> You do not need to set any of these. They are the values this
+    /// model has always used, moved here from its constructor so they can be seen and
+    /// changed in one place.
+    /// </para>
+    /// <para>
+    /// Carried over unchanged. Whether each matches the published paper is verified, and
+    /// corrected where it does not, in a later phase of issue #2090.
+    /// </para>
+    /// </remarks>
+    public SPLADEOptions()
+    {
+        VocabSize = 30522;
+        EmbeddingDimension = 768;
+        MaxSequenceLength = 512;
+        NumLayers = 12;
+        NumHeads = 12;
+        FeedForwardDim = 3072;
+        MaxGradNorm = 1.0;
+    }
 }

--- a/src/NeuralNetworks/Options/SambaOptions.cs
+++ b/src/NeuralNetworks/Options/SambaOptions.cs
@@ -5,6 +5,42 @@ namespace AiDotNet.NeuralNetworks.Options;
 /// <summary>
 /// Configuration options for the SambaLanguageModel.
 /// </summary>
-public class SambaOptions : NeuralNetworkOptions
+public class SambaOptions : SequenceModelOptions
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SambaOptions"/> class carrying
+    /// this model's shipped defaults.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>For Beginners:</b> You do not need to set any of these. They are the values the
+    /// model has always used, moved here from its constructor so they can be seen and
+    /// changed in one place.
+    /// </para>
+    /// <para>
+    /// Carried over unchanged. Whether each matches the published paper is verified, and
+    /// corrected where it does not, in a later phase of issue #2090 — kept separate so a
+    /// change in behaviour is never buried in a mechanical move.
+    /// </para>
+    /// </remarks>
+    public SambaOptions()
+    {
+        VocabSize = 32000;
+        ModelDimension = 256;
+        NumLayers = 8;
+        StateDimension = 16;
+        AttentionInterval = 2;
+        MaxSequenceLength = 512;
+    }
+
+    /// <summary>
+    /// Throws if a value this model requires has been left unset or is not positive.
+    /// </summary>
+    /// <exception cref="ArgumentException">
+    /// Thrown when a required dimension is zero or negative.
+    /// </exception>
+    public void Validate()
+    {
+        ValidateCore(requiresHeads: false, requiresState: true);
+    }
 }

--- a/src/NeuralNetworks/Options/SequenceModelOptions.cs
+++ b/src/NeuralNetworks/Options/SequenceModelOptions.cs
@@ -128,7 +128,7 @@ public abstract class SequenceModelOptions : ModelHyperparameterOptions
     /// </summary>
     /// <param name="requiresHeads">Whether this model uses attention heads.</param>
     /// <param name="requiresState">Whether this model uses a recurrent state dimension.</param>
-    /// <exception cref="InvalidOperationException">
+    /// <exception cref="ArgumentException">
     /// Thrown when a required dimension is zero or negative, which means the derived options
     /// class did not assign its paper defaults.
     /// </exception>

--- a/src/NeuralNetworks/Options/SequenceModelOptions.cs
+++ b/src/NeuralNetworks/Options/SequenceModelOptions.cs
@@ -1,0 +1,150 @@
+using AiDotNet.Models.Options;
+
+namespace AiDotNet.NeuralNetworks.Options;
+
+/// <summary>
+/// Shared configuration for sequence and language models (Mamba, RWKV, Jamba, Zamba,
+/// Griffin, Hawk, xLSTM, RecurrentGemma and relatives).
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>For Beginners:</b> These are the "size" settings of a language model — how many
+/// distinct tokens it knows, how wide each internal representation is, how many stacked
+/// blocks it has, and how far back it can look. You rarely need to change them: each
+/// model's own options class already ships the sizes from the paper that introduced it.
+/// </para>
+/// <para>
+/// Derived options classes assign their paper's values in their parameterless
+/// constructor. For example:
+/// <code>
+/// public class MambaOptions : SequenceModelOptions
+/// {
+///     public MambaOptions()
+///     {
+///         VocabSize = 50277;      // Mamba-130M
+///         ModelDimension = 768;
+///         NumLayers = 24;
+///     }
+/// }
+/// </code>
+/// </para>
+/// <para>
+/// Properties are non-nullable and defaulted by the derived class rather than nullable
+/// with a <c>GetEffectiveX()</c> fallback. A model's layer count has no runtime-dependent
+/// best value the way a batch size does — the right value is the paper's, and it is known
+/// statically. See the "Model Hyperparameter Options" section of the development
+/// guidelines. Infrastructure configuration (telemetry, profiling, AutoML) keeps the
+/// nullable pattern.
+/// </para>
+/// </remarks>
+public abstract class SequenceModelOptions : ModelHyperparameterOptions
+{
+    /// <summary>
+    /// Gets or sets the number of distinct tokens the model's embedding table covers.
+    /// </summary>
+    /// <remarks>
+    /// <para><b>For Beginners:</b> The size of the model's vocabulary — how many different
+    /// words or word-pieces it can represent. Fixed by the tokenizer the paper used, so
+    /// changing it means retraining from scratch.</para>
+    /// </remarks>
+    public int VocabSize { get; set; }
+
+    /// <summary>
+    /// Gets or sets the width of the model's hidden representation (often written d_model).
+    /// </summary>
+    /// <remarks>
+    /// <para><b>For Beginners:</b> How many numbers the model uses to describe each token
+    /// internally. Wider means more capacity and more memory.</para>
+    /// </remarks>
+    public int ModelDimension { get; set; }
+
+    /// <summary>
+    /// Gets or sets the number of stacked blocks in the model.
+    /// </summary>
+    /// <remarks>
+    /// <para><b>For Beginners:</b> Depth. Each layer refines what the previous one produced.</para>
+    /// </remarks>
+    public int NumLayers { get; set; }
+
+    /// <summary>
+    /// Gets or sets the number of attention heads, for models that use attention.
+    /// </summary>
+    /// <remarks>
+    /// <para><b>For Beginners:</b> Attention heads let the model look at several
+    /// relationships at once. Purely recurrent models (Mamba, RWKV) may leave this unset.</para>
+    /// </remarks>
+    public int NumHeads { get; set; }
+
+    /// <summary>
+    /// Gets or sets the width of the recurrent state, for state-space models.
+    /// </summary>
+    /// <remarks>
+    /// <para><b>For Beginners:</b> How much the model remembers as it walks through a
+    /// sequence. Used by Mamba-family models; attention-only models leave it unset.</para>
+    /// </remarks>
+    public int StateDimension { get; set; }
+
+    /// <summary>
+    /// Gets or sets the longest sequence, in tokens, the model is configured to process.
+    /// </summary>
+    /// <remarks>
+    /// <para><b>For Beginners:</b> The context window — how much text the model can consider
+    /// at once.</para>
+    /// </remarks>
+    public int MaxSequenceLength { get; set; }
+
+    /// <summary>
+    /// Gets or sets how often an attention block is interleaved among recurrent blocks,
+    /// in hybrid architectures such as Jamba, Samba and Zamba.
+    /// </summary>
+    /// <remarks>
+    /// <para><b>For Beginners:</b> Hybrid models mix two kinds of block. A value of 6 means
+    /// every sixth block uses attention and the rest are recurrent. Ignored by
+    /// non-hybrid models.</para>
+    /// </remarks>
+    public int AttentionInterval { get; set; }
+
+    /// <summary>
+    /// Gets or sets the inner-projection expansion factor used by state-space blocks.
+    /// </summary>
+    /// <remarks>
+    /// <para><b>For Beginners:</b> Mamba-style blocks temporarily widen their representation
+    /// before narrowing it again; this is the multiplier. The Mamba paper uses 2.</para>
+    /// </remarks>
+    public int ExpandFactor { get; set; }
+
+    /// <summary>
+    /// Gets or sets the feed-forward width as a multiple of <see cref="ModelDimension"/>,
+    /// for models that express it as a ratio (RWKV-7 uses 3.5).
+    /// </summary>
+    /// <remarks>
+    /// <para><b>For Beginners:</b> How much wider the model's internal "thinking" layer is
+    /// than its representation width.</para>
+    /// </remarks>
+    public double FfnMultiplier { get; set; }
+
+    /// <summary>
+    /// Throws if a dimension this model family requires has been left unset.
+    /// </summary>
+    /// <param name="requiresHeads">Whether this model uses attention heads.</param>
+    /// <param name="requiresState">Whether this model uses a recurrent state dimension.</param>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when a required dimension is zero or negative, which means the derived options
+    /// class did not assign its paper defaults.
+    /// </exception>
+    /// <remarks>
+    /// <para>
+    /// Fails loudly rather than silently constructing a zero-width model. A dimension of
+    /// zero produces layers that appear to build and then misbehave far from the cause.
+    /// </para>
+    /// </remarks>
+    protected void ValidateCore(bool requiresHeads, bool requiresState)
+    {
+        Require(VocabSize, nameof(VocabSize));
+        Require(ModelDimension, nameof(ModelDimension));
+        Require(NumLayers, nameof(NumLayers));
+        Require(MaxSequenceLength, nameof(MaxSequenceLength));
+        if (requiresHeads) Require(NumHeads, nameof(NumHeads));
+        if (requiresState) Require(StateDimension, nameof(StateDimension));
+    }
+}

--- a/src/NeuralNetworks/Options/SimCSEOptions.cs
+++ b/src/NeuralNetworks/Options/SimCSEOptions.cs
@@ -5,6 +5,45 @@ namespace AiDotNet.NeuralNetworks.Options;
 /// <summary>
 /// Configuration options for the SimCSE model.
 /// </summary>
-public class SimCSEOptions : NeuralNetworkOptions
+public class SimCSEOptions : TransformerEmbeddingOptions
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SimCSEOptions"/> class carrying
+    /// this model's shipped defaults.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>For Beginners:</b> You do not need to set any of these. They are the values this
+    /// model has always used, moved here from its constructor so they can be seen and
+    /// changed in one place.
+    /// </para>
+    /// <para>
+    /// Carried over unchanged. Whether each matches the published paper is verified, and
+    /// corrected where it does not, in a later phase of issue #2090.
+    /// </para>
+    /// </remarks>
+    public SimCSEOptions()
+    {
+        Type = SimCSEType.Unsupervised;
+        VocabSize = 30522;
+        EmbeddingDimension = 768;
+        MaxSequenceLength = 512;
+        NumLayers = 12;
+        NumHeads = 12;
+        FeedForwardDim = 3072;
+        DropoutRate = 0.1;
+        EmbeddingPoolingStrategy = EmbeddingPoolingStrategy.ClsToken;
+        MaxGradNorm = 1.0;
+    }
+
+
+    /// <summary>
+    /// Gets or sets the type.
+    /// </summary>
+    public SimCSEType Type { get; set; }
+
+    /// <summary>
+    /// Gets or sets the dropout rate.
+    /// </summary>
+    public double DropoutRate { get; set; }
 }

--- a/src/NeuralNetworks/Options/StyleGANOptions.cs
+++ b/src/NeuralNetworks/Options/StyleGANOptions.cs
@@ -5,6 +5,49 @@ namespace AiDotNet.NeuralNetworks.Options;
 /// <summary>
 /// Configuration options for the StyleGAN neural network.
 /// </summary>
-public class StyleGANOptions : NeuralNetworkOptions
+public class StyleGANOptions : GanOptions
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="StyleGANOptions"/> class carrying
+    /// this model's shipped defaults.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>For Beginners:</b> You do not need to set any of these. They are the values this
+    /// model has always used, moved here from its constructor so they can be seen and
+    /// changed in one place.
+    /// </para>
+    /// <para>
+    /// Carried over unchanged. Whether each matches the published paper is verified, and
+    /// corrected where it does not, in a later phase of issue #2090.
+    /// </para>
+    /// </remarks>
+    public StyleGANOptions()
+    {
+        InitialLearningRate = 0.001;
+        EnableStyleMixing = true;
+        StyleMixingProbability = 0.9;
+    }
+
+
+    /// <summary>
+    /// Gets or sets the enable style mixing.
+    /// </summary>
+    public bool EnableStyleMixing { get; set; }
+
+    /// <summary>
+    /// Gets or sets the style mixing probability.
+    /// </summary>
+    public double StyleMixingProbability { get; set; }
+
+    /// <summary>
+    /// Throws if a value this model requires has been left unset or is not positive.
+    /// </summary>
+    /// <exception cref="ArgumentException">
+    /// Thrown when a required dimension is zero or negative.
+    /// </exception>
+    public void Validate()
+    {
+        ValidateCore();
+    }
 }

--- a/src/NeuralNetworks/Options/TransformerEmbeddingOptions.cs
+++ b/src/NeuralNetworks/Options/TransformerEmbeddingOptions.cs
@@ -5,6 +5,49 @@ namespace AiDotNet.NeuralNetworks.Options;
 /// <summary>
 /// Configuration options for the TransformerEmbeddingNetwork.
 /// </summary>
-public class TransformerEmbeddingOptions : NeuralNetworkOptions
+public class TransformerEmbeddingOptions : EmbeddingModelOptions
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TransformerEmbeddingOptions"/> class carrying
+    /// this model's shipped defaults.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>For Beginners:</b> You do not need to set any of these. They are the values this
+    /// model has always used, moved here from its constructor so they can be seen and
+    /// changed in one place.
+    /// </para>
+    /// <para>
+    /// Carried over unchanged. Whether each matches the published paper is verified, and
+    /// corrected where it does not, in a later phase of issue #2090.
+    /// </para>
+    /// </remarks>
+    public TransformerEmbeddingOptions()
+    {
+        VocabSize = 30522;
+        EmbeddingDimension = 768;
+        MaxSequenceLength = 512;
+        NumLayers = 12;
+        NumHeads = 12;
+        FeedForwardDim = 3072;
+        EmbeddingPoolingStrategy = EmbeddingPoolingStrategy.Mean;
+        MaxGradNorm = 1.0;
+    }
+
+
+    /// <summary>
+    /// Gets or sets the pooling strategy.
+    /// </summary>
+    public EmbeddingPoolingStrategy EmbeddingPoolingStrategy { get; set; }
+
+    /// <summary>
+    /// Throws if a value this model requires has been left unset or is not positive.
+    /// </summary>
+    /// <exception cref="ArgumentException">
+    /// Thrown when a required dimension is zero or negative.
+    /// </exception>
+    public void Validate()
+    {
+        ValidateCore();
+    }
 }

--- a/src/NeuralNetworks/Options/UnifiedMultimodalNetworkOptions.cs
+++ b/src/NeuralNetworks/Options/UnifiedMultimodalNetworkOptions.cs
@@ -27,6 +27,12 @@ public class UnifiedMultimodalNetworkOptions : VisionLanguageModelOptions
         EmbeddingDimension = 768; // DEFAULT_EMBEDDING_DIM
         MaxSequenceLength = 2048; // DEFAULT_MAX_SEQ_LEN
         NumTransformerLayers = 12; // DEFAULT_NUM_LAYERS
+        EmbeddingDimension = 768; // DEFAULT_EMBEDDING_DIM
+        MaxSequenceLength = 2048; // DEFAULT_MAX_SEQ_LEN
+        NumTransformerLayers = 12; // DEFAULT_NUM_LAYERS
+        EmbeddingDimension = 768; // DEFAULT_EMBEDDING_DIM
+        MaxSequenceLength = 2048; // DEFAULT_MAX_SEQ_LEN
+        NumTransformerLayers = 12; // DEFAULT_NUM_LAYERS
     }
 
 

--- a/src/NeuralNetworks/Options/UnifiedMultimodalNetworkOptions.cs
+++ b/src/NeuralNetworks/Options/UnifiedMultimodalNetworkOptions.cs
@@ -5,6 +5,44 @@ namespace AiDotNet.NeuralNetworks.Options;
 /// <summary>
 /// Configuration options for the UnifiedMultimodalNetwork.
 /// </summary>
-public class UnifiedMultimodalNetworkOptions : NeuralNetworkOptions
+public class UnifiedMultimodalNetworkOptions : VisionLanguageModelOptions
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="UnifiedMultimodalNetworkOptions"/> class carrying
+    /// this model's shipped defaults.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>For Beginners:</b> You do not need to set any of these. They are the values this
+    /// model has always used, moved here from its constructor so they can be seen and
+    /// changed in one place.
+    /// </para>
+    /// <para>
+    /// Carried over unchanged. Whether each matches the published paper is verified, and
+    /// corrected where it does not, in a later phase of issue #2090.
+    /// </para>
+    /// </remarks>
+    public UnifiedMultimodalNetworkOptions()
+    {
+        EmbeddingDimension = 768; // DEFAULT_EMBEDDING_DIM
+        MaxSequenceLength = 2048; // DEFAULT_MAX_SEQ_LEN
+        NumTransformerLayers = 12; // DEFAULT_NUM_LAYERS
+    }
+
+
+    /// <summary>
+    /// Gets or sets the num transformer layers.
+    /// </summary>
+    public int NumTransformerLayers { get; set; }
+
+    /// <summary>
+    /// Throws if a value this model requires has been left unset or is not positive.
+    /// </summary>
+    /// <exception cref="ArgumentException">
+    /// Thrown when a required dimension is zero or negative.
+    /// </exception>
+    public void Validate()
+    {
+        ValidateCore();
+    }
 }

--- a/src/NeuralNetworks/Options/VideoCLIPOptions.cs
+++ b/src/NeuralNetworks/Options/VideoCLIPOptions.cs
@@ -5,6 +5,80 @@ namespace AiDotNet.NeuralNetworks.Options;
 /// <summary>
 /// Configuration options for the VideoCLIPNeuralNetwork.
 /// </summary>
-public class VideoCLIPOptions : NeuralNetworkOptions
+public class VideoCLIPOptions : VisionLanguageModelOptions
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="VideoCLIPOptions"/> class carrying
+    /// this model's shipped defaults.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>For Beginners:</b> You do not need to set any of these. They are the values this
+    /// model has always used, moved here from its constructor so they can be seen and
+    /// changed in one place.
+    /// </para>
+    /// <para>
+    /// Carried over unchanged. Whether each matches the published paper is verified, and
+    /// corrected where it does not, in a later phase of issue #2090.
+    /// </para>
+    /// </remarks>
+    public VideoCLIPOptions()
+    {
+        NumFrames = 8;
+        FrameRate = 1.0;
+        EmbeddingDimension = 512;
+        MaxSequenceLength = 77;
+        ImageSize = 224;
+        Channels = 3;
+        PatchSize = 16;
+        VocabSize = 49408;
+        VisionHiddenDim = 768;
+        TextHiddenDim = 512;
+        NumFrameEncoderLayers = 12;
+        NumTemporalLayers = 4;
+        NumTextLayers = 12;
+        NumHeads = 12;
+    }
+
+
+    /// <summary>
+    /// Gets or sets the num frames.
+    /// </summary>
+    public int NumFrames { get; set; }
+
+    /// <summary>
+    /// Gets or sets the frame rate.
+    /// </summary>
+    public double FrameRate { get; set; }
+
+    /// <summary>
+    /// Gets or sets the text hidden dim.
+    /// </summary>
+    public int TextHiddenDim { get; set; }
+
+    /// <summary>
+    /// Gets or sets the num frame encoder layers.
+    /// </summary>
+    public int NumFrameEncoderLayers { get; set; }
+
+    /// <summary>
+    /// Gets or sets the num temporal layers.
+    /// </summary>
+    public int NumTemporalLayers { get; set; }
+
+    /// <summary>
+    /// Gets or sets the num text layers.
+    /// </summary>
+    public int NumTextLayers { get; set; }
+
+    /// <summary>
+    /// Throws if a value this model requires has been left unset or is not positive.
+    /// </summary>
+    /// <exception cref="ArgumentException">
+    /// Thrown when a required dimension is zero or negative.
+    /// </exception>
+    public void Validate()
+    {
+        ValidateCore();
+    }
 }

--- a/src/NeuralNetworks/Options/VideoCLIPOptions.cs
+++ b/src/NeuralNetworks/Options/VideoCLIPOptions.cs
@@ -38,6 +38,7 @@ public class VideoCLIPOptions : VisionLanguageModelOptions
         NumTemporalLayers = 4;
         NumTextLayers = 12;
         NumHeads = 12;
+        TemporalAggregation = TemporalAggregationType.TemporalTransformer;
     }
 
 
@@ -81,4 +82,9 @@ public class VideoCLIPOptions : VisionLanguageModelOptions
     {
         ValidateCore();
     }
+
+    /// <summary>
+    /// Gets or sets the temporal aggregation.
+    /// </summary>
+    public TemporalAggregationType TemporalAggregation { get; set; }
 }

--- a/src/NeuralNetworks/Options/VisionLanguageModelOptions.cs
+++ b/src/NeuralNetworks/Options/VisionLanguageModelOptions.cs
@@ -100,7 +100,7 @@ public abstract class VisionLanguageModelOptions : ModelHyperparameterOptions
     /// <summary>
     /// Throws if a dimension every vision-language model requires has been left unset.
     /// </summary>
-    /// <exception cref="InvalidOperationException">
+    /// <exception cref="ArgumentException">
     /// Thrown when a required dimension is zero or negative, which means the derived options
     /// class did not assign its paper defaults.
     /// </exception>

--- a/src/NeuralNetworks/Options/VisionLanguageModelOptions.cs
+++ b/src/NeuralNetworks/Options/VisionLanguageModelOptions.cs
@@ -1,0 +1,114 @@
+using AiDotNet.Models.Options;
+
+namespace AiDotNet.NeuralNetworks.Options;
+
+/// <summary>
+/// Shared configuration for vision-language and multimodal models (CLIP, BLIP, BLIP-2,
+/// Flamingo, LLaVA, ImageBind, GPT-4 Vision, VideoCLIP and relatives).
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>For Beginners:</b> These models read pictures and text together. The settings here
+/// describe how big the pictures are, how they get chopped into patches, how much text the
+/// model can read at once, and how wide its internal representations are. Each model's own
+/// options class ships the values from its paper, so you do not normally set any of them.
+/// </para>
+/// <para>
+/// Derived options classes assign their paper's values in their parameterless constructor.
+/// See <see cref="ModelHyperparameterOptions"/> for why these properties are non-nullable.
+/// </para>
+/// </remarks>
+public abstract class VisionLanguageModelOptions : ModelHyperparameterOptions
+{
+    /// <summary>
+    /// Gets or sets the width of the shared embedding space that images and text are
+    /// projected into.
+    /// </summary>
+    /// <remarks>
+    /// <para><b>For Beginners:</b> Both a picture and a sentence get turned into a list of
+    /// numbers of this length, so they can be compared to each other.</para>
+    /// </remarks>
+    public int EmbeddingDimension { get; set; }
+
+    /// <summary>
+    /// Gets or sets the longest text sequence, in tokens, the model is configured to process.
+    /// </summary>
+    public int MaxSequenceLength { get; set; }
+
+    /// <summary>
+    /// Gets or sets the side length, in pixels, of the square image the model expects.
+    /// </summary>
+    /// <remarks>
+    /// <para><b>For Beginners:</b> Input images are resized to this many pixels on each side —
+    /// 224 and 336 are the common choices.</para>
+    /// </remarks>
+    public int ImageSize { get; set; }
+
+    /// <summary>
+    /// Gets or sets the side length, in pixels, of each square patch the image is divided into.
+    /// </summary>
+    /// <remarks>
+    /// <para><b>For Beginners:</b> Vision transformers cut a picture into a grid of small
+    /// squares and treat each one like a word. A 224-pixel image with 16-pixel patches becomes
+    /// a 14 by 14 grid, so 196 "words".</para>
+    /// </remarks>
+    public int PatchSize { get; set; }
+
+    /// <summary>
+    /// Gets or sets the number of colour channels in the input image.
+    /// </summary>
+    /// <remarks>
+    /// <para><b>For Beginners:</b> 3 for ordinary colour images (red, green, blue).</para>
+    /// </remarks>
+    public int Channels { get; set; } = 3;
+
+    /// <summary>
+    /// Gets or sets the number of distinct tokens the text tokenizer covers.
+    /// </summary>
+    public int VocabSize { get; set; }
+
+    /// <summary>
+    /// Gets or sets the number of attention heads.
+    /// </summary>
+    public int NumHeads { get; set; }
+
+    /// <summary>
+    /// Gets or sets the width of the model's main hidden representation.
+    /// </summary>
+    public int HiddenDim { get; set; }
+
+    /// <summary>
+    /// Gets or sets the number of layers in the text encoder.
+    /// </summary>
+    public int NumEncoderLayers { get; set; }
+
+    /// <summary>
+    /// Gets or sets the width of the vision tower's hidden representation, which is often
+    /// wider than the shared embedding space.
+    /// </summary>
+    /// <remarks>
+    /// <para><b>For Beginners:</b> The part of the model that looks at pictures usually works
+    /// at a different, larger size than the shared space where pictures and text meet.</para>
+    /// </remarks>
+    public int VisionHiddenDim { get; set; }
+
+    /// <summary>
+    /// Gets or sets the number of layers in the vision tower.
+    /// </summary>
+    public int NumVisionLayers { get; set; }
+
+    /// <summary>
+    /// Throws if a dimension every vision-language model requires has been left unset.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when a required dimension is zero or negative, which means the derived options
+    /// class did not assign its paper defaults.
+    /// </exception>
+    protected void ValidateCore()
+    {
+        Require(EmbeddingDimension, nameof(EmbeddingDimension));
+        Require(MaxSequenceLength, nameof(MaxSequenceLength));
+        Require(ImageSize, nameof(ImageSize));
+        Require(Channels, nameof(Channels));
+    }
+}

--- a/src/NeuralNetworks/Options/VisionMambaOptions.cs
+++ b/src/NeuralNetworks/Options/VisionMambaOptions.cs
@@ -5,6 +5,75 @@ namespace AiDotNet.NeuralNetworks.Options;
 /// <summary>
 /// Configuration options for the VisionMambaLanguageModel.
 /// </summary>
-public class VisionMambaOptions : NeuralNetworkOptions
+public class VisionMambaOptions : SequenceModelOptions
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="VisionMambaOptions"/> class carrying
+    /// this model's shipped defaults.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>For Beginners:</b> You do not need to set any of these. They are the values this
+    /// model has always used, moved here from its constructor so they can be seen and
+    /// changed in one place.
+    /// </para>
+    /// <para>
+    /// Carried over unchanged. Whether each matches the published paper is verified, and
+    /// corrected where it does not, in a later phase of issue #2090.
+    /// </para>
+    /// </remarks>
+    public VisionMambaOptions()
+    {
+        ImageHeight = 224;
+        ImageWidth = 224;
+        PatchSize = 16;
+        Channels = 3;
+        ModelDimension = 192;
+        NumLayers = 4;
+        NumClasses = 10;
+        StateDimension = 16;
+        ScanPattern = VisionScanPattern.Bidirectional;
+    }
+
+
+    /// <summary>
+    /// Gets or sets the image height.
+    /// </summary>
+    public int ImageHeight { get; set; }
+
+    /// <summary>
+    /// Gets or sets the image width.
+    /// </summary>
+    public int ImageWidth { get; set; }
+
+    /// <summary>
+    /// Gets or sets the patch size.
+    /// </summary>
+    public int PatchSize { get; set; }
+
+    /// <summary>
+    /// Gets or sets the channels.
+    /// </summary>
+    public int Channels { get; set; }
+
+    /// <summary>
+    /// Gets or sets the num classes.
+    /// </summary>
+    public int NumClasses { get; set; }
+
+    /// <summary>
+    /// Gets or sets the scan pattern.
+    /// </summary>
+    public VisionScanPattern ScanPattern { get; set; }
+
+    /// <summary>
+    /// Throws if a value this model requires has been left unset or is not positive.
+    /// </summary>
+    /// <exception cref="ArgumentException">
+    /// Thrown when a required dimension is zero or negative.
+    /// </exception>
+    public void Validate()
+    {
+        ValidateCore(requiresHeads: false, requiresState: true);
+    }
 }

--- a/src/NeuralNetworks/Options/WGANGPOptions.cs
+++ b/src/NeuralNetworks/Options/WGANGPOptions.cs
@@ -5,11 +5,13 @@ namespace AiDotNet.NeuralNetworks.Options;
 /// <summary>
 /// Configuration options for the WGANGP neural network.
 /// </summary>
-public class WGANGPOptions : NeuralNetworkOptions
+public class WGANGPOptions : GanOptions
 {
     /// <summary>Initializes the paper defaults.</summary>
     public WGANGPOptions()
     {
+        GradientPenaltyCoefficient = 10.0;
+        CriticIterations = 5;
     }
 
     /// <summary>Initializes an independent copy of another configuration.</summary>
@@ -23,6 +25,8 @@ public class WGANGPOptions : NeuralNetworkOptions
         LearningRate = other.LearningRate;
         Beta1 = other.Beta1;
         Beta2 = other.Beta2;
+        CriticIterations = other.CriticIterations;
+        GradientPenaltyCoefficient = other.GradientPenaltyCoefficient;
     }
 
     /// <summary>Gets or sets Adam's learning rate (Algorithm 1 default: 1e-4).</summary>
@@ -33,4 +37,20 @@ public class WGANGPOptions : NeuralNetworkOptions
 
     /// <summary>Gets or sets Adam's second-moment decay (Algorithm 1 default: 0.9).</summary>
     public double Beta2 { get; set; } = 0.9;
+
+    /// <summary>
+    /// Gets or sets the gradient penalty coefficient.
+    /// </summary>
+    public double GradientPenaltyCoefficient { get; set; }
+
+    /// <summary>
+    /// Throws if a value this model requires has been left unset or is not positive.
+    /// </summary>
+    /// <exception cref="ArgumentException">
+    /// Thrown when a required dimension is zero or negative.
+    /// </exception>
+    public void Validate()
+    {
+        ValidateCore();
+    }
 }

--- a/src/NeuralNetworks/Options/WGANOptions.cs
+++ b/src/NeuralNetworks/Options/WGANOptions.cs
@@ -5,6 +5,43 @@ namespace AiDotNet.NeuralNetworks.Options;
 /// <summary>
 /// Configuration options for the WGAN neural network.
 /// </summary>
-public class WGANOptions : NeuralNetworkOptions
+public class WGANOptions : GanOptions
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="WGANOptions"/> class carrying
+    /// this model's shipped defaults.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>For Beginners:</b> You do not need to set any of these. They are the values this
+    /// model has always used, moved here from its constructor so they can be seen and
+    /// changed in one place.
+    /// </para>
+    /// <para>
+    /// Carried over unchanged. Whether each matches the published paper is verified, and
+    /// corrected where it does not, in a later phase of issue #2090.
+    /// </para>
+    /// </remarks>
+    public WGANOptions()
+    {
+        WeightClipValue = 0.01;
+        CriticIterations = 5;
+    }
+
+
+    /// <summary>
+    /// Gets or sets the weight clip value.
+    /// </summary>
+    public double WeightClipValue { get; set; }
+
+    /// <summary>
+    /// Throws if a value this model requires has been left unset or is not positive.
+    /// </summary>
+    /// <exception cref="ArgumentException">
+    /// Thrown when a required dimension is zero or negative.
+    /// </exception>
+    public void Validate()
+    {
+        ValidateCore();
+    }
 }

--- a/src/NeuralNetworks/Options/Word2VecOptions.cs
+++ b/src/NeuralNetworks/Options/Word2VecOptions.cs
@@ -5,6 +5,52 @@ namespace AiDotNet.NeuralNetworks.Options;
 /// <summary>
 /// Configuration options for the Word2Vec model.
 /// </summary>
-public class Word2VecOptions : NeuralNetworkOptions
+public class Word2VecOptions : EmbeddingModelOptions
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Word2VecOptions"/> class carrying
+    /// this model's shipped defaults.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>For Beginners:</b> You do not need to set any of these. They are the values this
+    /// model has always used, moved here from its constructor so they can be seen and
+    /// changed in one place.
+    /// </para>
+    /// <para>
+    /// Carried over unchanged. Whether each matches the published paper is verified, and
+    /// corrected where it does not, in a later phase of issue #2090.
+    /// </para>
+    /// </remarks>
+    public Word2VecOptions()
+    {
+        VocabSize = 10000;
+        EmbeddingDimension = 100;
+        WindowSize = 5;
+        MaxSequenceLength = 512;
+        Type = Word2VecType.SkipGram;
+        MaxGradNorm = 1.0;
+    }
+
+
+    /// <summary>
+    /// Gets or sets the window size.
+    /// </summary>
+    public int WindowSize { get; set; }
+
+    /// <summary>
+    /// Gets or sets the type.
+    /// </summary>
+    public Word2VecType Type { get; set; }
+
+    /// <summary>
+    /// Throws if a value this model requires has been left unset or is not positive.
+    /// </summary>
+    /// <exception cref="ArgumentException">
+    /// Thrown when a required dimension is zero or negative.
+    /// </exception>
+    public void Validate()
+    {
+        ValidateCore();
+    }
 }

--- a/src/NeuralNetworks/Options/XLSTMOptions.cs
+++ b/src/NeuralNetworks/Options/XLSTMOptions.cs
@@ -5,8 +5,43 @@ namespace AiDotNet.NeuralNetworks.Options;
 /// <summary>
 /// Configuration options for the XLSTMLanguageModel.
 /// </summary>
-public class XLSTMOptions : NeuralNetworkOptions
+public class XLSTMOptions : SequenceModelOptions
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="XLSTMOptions"/> class carrying
+    /// this model's shipped defaults.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>For Beginners:</b> You do not need to set any of these. They are the values the
+    /// model has always used, moved here from its constructor so they can be seen and
+    /// changed in one place.
+    /// </para>
+    /// <para>
+    /// Carried over unchanged. Whether each matches the published paper is verified, and
+    /// corrected where it does not, in a later phase of issue #2090 — kept separate so a
+    /// change in behaviour is never buried in a mechanical move.
+    /// </para>
+    /// </remarks>
+    public XLSTMOptions()
+    {
+        VocabSize = 50277;
+        ModelDimension = 256;
+        NumLayers = 4;
+        NumHeads = 8;
+        MaxSequenceLength = 512;
+    }
+
+    /// <summary>
+    /// Throws if a value this model requires has been left unset or is not positive.
+    /// </summary>
+    /// <exception cref="ArgumentException">
+    /// Thrown when a required dimension is zero or negative.
+    /// </exception>
+    public void Validate()
+    {
+        ValidateCore(requiresHeads: true, requiresState: false);
+    }
     /// <summary>
     /// AdamW learning rate. Defaults to 1e-3, the rate used for the xLSTM language models in
     /// Beck et al., 2024 (S4.1).

--- a/src/NeuralNetworks/Options/Zamba2Options.cs
+++ b/src/NeuralNetworks/Options/Zamba2Options.cs
@@ -5,6 +5,43 @@ namespace AiDotNet.NeuralNetworks.Options;
 /// <summary>
 /// Configuration options for the Zamba2LanguageModel.
 /// </summary>
-public class Zamba2Options : NeuralNetworkOptions
+public class Zamba2Options : SequenceModelOptions
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Zamba2Options"/> class carrying
+    /// this model's shipped defaults.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>For Beginners:</b> You do not need to set any of these. They are the values the
+    /// model has always used, moved here from its constructor so they can be seen and
+    /// changed in one place.
+    /// </para>
+    /// <para>
+    /// Carried over unchanged. Whether each matches the published paper is verified, and
+    /// corrected where it does not, in a later phase of issue #2090 — kept separate so a
+    /// change in behaviour is never buried in a mechanical move.
+    /// </para>
+    /// </remarks>
+    public Zamba2Options()
+    {
+        VocabSize = 32000;
+        ModelDimension = 3584;
+        NumLayers = 81;
+        StateDimension = 64;
+        NumHeads = 32;
+        AttentionInterval = 6;
+        MaxSequenceLength = 4096;
+    }
+
+    /// <summary>
+    /// Throws if a value this model requires has been left unset or is not positive.
+    /// </summary>
+    /// <exception cref="ArgumentException">
+    /// Thrown when a required dimension is zero or negative.
+    /// </exception>
+    public void Validate()
+    {
+        ValidateCore(requiresHeads: true, requiresState: true);
+    }
 }

--- a/src/NeuralNetworks/Options/ZambaOptions.cs
+++ b/src/NeuralNetworks/Options/ZambaOptions.cs
@@ -5,6 +5,42 @@ namespace AiDotNet.NeuralNetworks.Options;
 /// <summary>
 /// Configuration options for the ZambaLanguageModel.
 /// </summary>
-public class ZambaOptions : NeuralNetworkOptions
+public class ZambaOptions : SequenceModelOptions
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ZambaOptions"/> class carrying
+    /// this model's shipped defaults.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>For Beginners:</b> You do not need to set any of these. They are the values the
+    /// model has always used, moved here from its constructor so they can be seen and
+    /// changed in one place.
+    /// </para>
+    /// <para>
+    /// Carried over unchanged. Whether each matches the published paper is verified, and
+    /// corrected where it does not, in a later phase of issue #2090 — kept separate so a
+    /// change in behaviour is never buried in a mechanical move.
+    /// </para>
+    /// </remarks>
+    public ZambaOptions()
+    {
+        VocabSize = 32000;
+        ModelDimension = 3712;
+        NumLayers = 76;
+        StateDimension = 16;
+        AttentionInterval = 6;
+        MaxSequenceLength = 4096;
+    }
+
+    /// <summary>
+    /// Throws if a value this model requires has been left unset or is not positive.
+    /// </summary>
+    /// <exception cref="ArgumentException">
+    /// Thrown when a required dimension is zero or negative.
+    /// </exception>
+    public void Validate()
+    {
+        ValidateCore(requiresHeads: false, requiresState: true);
+    }
 }

--- a/src/NeuralNetworks/Pix2Pix.cs
+++ b/src/NeuralNetworks/Pix2Pix.cs
@@ -187,15 +187,15 @@ public partial class Pix2Pix<T> : ImageTranslationModelLayoutBase<T>
         NeuralNetworkArchitecture<T> generatorArchitecture,
         NeuralNetworkArchitecture<T> discriminatorArchitecture,
         InputType inputType,
+        Pix2PixOptions? options = null,
         IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>>? generatorOptimizer = null,
         IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>>? discriminatorOptimizer = null,
-        ILossFunction<T>? lossFunction = null,
-        double l1Lambda = 100.0,
-        Pix2PixOptions? options = null)
+        ILossFunction<T>? lossFunction = null)
         : base(CreatePix2PixArchitecture(generatorArchitecture, inputType),
                lossFunction ?? NeuralNetworkHelper<T>.GetDefaultLossFunction(NeuralNetworkTaskType.Generative))
     {
         _options = options ?? new Pix2PixOptions();
+        _options.Validate();
         Options = _options;
         if (generatorArchitecture is null)
         {
@@ -205,12 +205,12 @@ public partial class Pix2Pix<T> : ImageTranslationModelLayoutBase<T>
         {
             throw new ArgumentNullException(nameof(discriminatorArchitecture), "Discriminator architecture cannot be null.");
         }
-        if (l1Lambda < 0)
+        if (_options.L1Lambda < 0)
         {
-            throw new ArgumentOutOfRangeException(nameof(l1Lambda), l1Lambda, "L1 lambda must be non-negative.");
+            throw new ArgumentOutOfRangeException(nameof(_options.L1Lambda), _options.L1Lambda, "L1 lambda must be non-negative.");
         }
 
-        _l1Lambda = NumOps.FromDouble(l1Lambda);
+        _l1Lambda = NumOps.FromDouble(_options.L1Lambda);
 
         Generator = new ConvolutionalNeuralNetwork<T>(generatorArchitecture);
         Discriminator = new ConvolutionalNeuralNetwork<T>(discriminatorArchitecture);

--- a/src/NeuralNetworks/ProgressiveGAN.cs
+++ b/src/NeuralNetworks/ProgressiveGAN.cs
@@ -99,13 +99,11 @@ public partial class ProgressiveGAN<T> : GenerativeAdversarialNetwork<T>
     public ProgressiveGAN(
         int latentSize,
         int imageChannels,
-        int maxResolutionLevel = 6,
-        int baseFeatureMaps = 512,
-        ILossFunction<T>? lossFunction = null,
-        ProgressiveGANOptions? options = null)
+        ProgressiveGANOptions? options = null,
+        ILossFunction<T>? lossFunction = null)
         : base(
-            CreateProgressiveGANGeneratorArchitecture(latentSize, imageChannels, 4 * (1 << Math.Max(0, maxResolutionLevel)), baseFeatureMaps),
-            CreateProgressiveGANDiscriminatorArchitecture(imageChannels, 4 * (1 << Math.Max(0, maxResolutionLevel)), baseFeatureMaps),
+            CreateProgressiveGANGeneratorArchitecture(latentSize, imageChannels, 4 * (1 << Math.Max(0, (options?.MaxResolutionLevel ?? 6))), (options?.GeneratorChannels ?? 512)),
+            CreateProgressiveGANDiscriminatorArchitecture(imageChannels, 4 * (1 << Math.Max(0, (options?.MaxResolutionLevel ?? 6))), (options?.GeneratorChannels ?? 512)),
             InputType.ThreeDimensional,
             generatorOptimizer: null,
             discriminatorOptimizer: null,
@@ -114,24 +112,23 @@ public partial class ProgressiveGAN<T> : GenerativeAdversarialNetwork<T>
             defaultGeneratorOptimizerOptions: CreateAdamOptimizerOptions(DefaultLearningRate, 0.0, 0.99),
             defaultDiscriminatorOptimizerOptions: CreateAdamOptimizerOptions(DefaultLearningRate, 0.0, 0.99))
     {
+        _options = options ?? new ProgressiveGANOptions();
+        _options.Validate();
         if (latentSize <= 0)
             throw new ArgumentOutOfRangeException(nameof(latentSize), latentSize, "Latent size must be positive.");
         if (imageChannels <= 0)
             throw new ArgumentOutOfRangeException(nameof(imageChannels), imageChannels, "Image channels must be positive.");
-        if (maxResolutionLevel < 0)
-            throw new ArgumentOutOfRangeException(nameof(maxResolutionLevel), maxResolutionLevel, "Max resolution level must be non-negative.");
-        if (baseFeatureMaps <= 0)
-            throw new ArgumentOutOfRangeException(nameof(baseFeatureMaps), baseFeatureMaps, "Base feature maps must be positive.");
+        if (_options.MaxResolutionLevel < 0)
+            throw new ArgumentOutOfRangeException(nameof(_options.MaxResolutionLevel), _options.MaxResolutionLevel, "Max resolution level must be non-negative.");
 
-        _options = options ?? new ProgressiveGANOptions();
         Options = _options;
         _latentSize = latentSize;
         _imageChannels = imageChannels;
-        _maxResolutionLevel = maxResolutionLevel;
-        _baseFeatureMaps = baseFeatureMaps;
+        _maxResolutionLevel = _options.MaxResolutionLevel;
+        _baseFeatureMaps = _options.GeneratorChannels;
         // The network is built directly at the target resolution, so report the
         // current level as the max (GetCurrentResolution then matches the output).
-        CurrentResolutionLevel = maxResolutionLevel;
+        CurrentResolutionLevel = _options.MaxResolutionLevel;
         Alpha = 1.0;
         UseMinibatchStdDev = true;
         UsePixelNormalization = true;
@@ -158,18 +155,10 @@ public partial class ProgressiveGAN<T> : GenerativeAdversarialNetwork<T>
     public ProgressiveGAN(
         NeuralNetworkArchitecture<T> generatorArchitecture,
         NeuralNetworkArchitecture<T> discriminatorArchitecture,
-        int latentSize = 512,
-        int imageChannels = 3,
-        int maxResolutionLevel = 6,
-        int baseFeatureMaps = 512,
-        InputType inputType = InputType.TwoDimensional,
-        ILossFunction<T>? lossFunction = null,
-        double initialLearningRate = DefaultLearningRate,
-        double learningRateDecay = DefaultLearningRateDecay,
-        ProgressiveGANOptions? options = null)
-        : this(latentSize,
-               imageChannels > 0 ? imageChannels : (discriminatorArchitecture.InputDepth > 0 ? discriminatorArchitecture.InputDepth : 3),
-               maxResolutionLevel, baseFeatureMaps, lossFunction, options)
+        ProgressiveGANOptions? options = null,
+        ILossFunction<T>? lossFunction = null)
+        : this((options?.LatentSize ?? 512),
+               (options?.ImageChannels ?? 3) > 0 ? (options?.ImageChannels ?? 3) : (discriminatorArchitecture.InputDepth > 0 ? discriminatorArchitecture.InputDepth : 3), lossFunction: lossFunction, options: options)
     {
     }
 

--- a/src/NeuralNetworks/RWKV4LanguageModel.cs
+++ b/src/NeuralNetworks/RWKV4LanguageModel.cs
@@ -112,12 +112,8 @@ public partial class RWKV4LanguageModel<T> : TokenLanguageModelLayoutBase<T>
     /// <param name="options">Optional RWKV-4 specific options.</param>
     public RWKV4LanguageModel(
         NeuralNetworkArchitecture<T> architecture,
-        int vocabSize = 50277,
-        int modelDimension = 256,
-        int numLayers = 4,
-        int maxSeqLength = 512,
-        ILossFunction<T>? lossFunction = null,
-        RWKV4Options? options = null)
+        RWKV4Options? options = null,
+        ILossFunction<T>? lossFunction = null)
         : base(
             architecture,
             // RWKV's LM head emits RAW LOGITS (DenseLayer with no activation), so the loss must be
@@ -129,21 +125,14 @@ public partial class RWKV4LanguageModel<T> : TokenLanguageModelLayoutBase<T>
             lossFunction ?? new AiDotNet.LossFunctions.CrossEntropyWithLogitsLoss<T>())
     {
         _options = options ?? new RWKV4Options();
+        _options.Validate();
         Options = _options;
 
-        if (vocabSize <= 0)
-            throw new ArgumentException($"Vocab size ({vocabSize}) must be positive.", nameof(vocabSize));
-        if (modelDimension <= 0)
-            throw new ArgumentException($"Model dimension ({modelDimension}) must be positive.", nameof(modelDimension));
-        if (numLayers <= 0)
-            throw new ArgumentException($"Number of layers ({numLayers}) must be positive.", nameof(numLayers));
-        if (maxSeqLength <= 0)
-            throw new ArgumentException($"Max sequence length ({maxSeqLength}) must be positive.", nameof(maxSeqLength));
 
-        _vocabSize = vocabSize;
-        _modelDimension = modelDimension;
-        _numLayers = numLayers;
-        _maxSeqLength = maxSeqLength;
+        _vocabSize = _options.VocabSize;
+        _modelDimension = _options.ModelDimension;
+        _numLayers = _options.NumLayers;
+        _maxSeqLength = _options.MaxSequenceLength;
 
         InitializeLayers();
     }

--- a/src/NeuralNetworks/RWKV7LanguageModel.cs
+++ b/src/NeuralNetworks/RWKV7LanguageModel.cs
@@ -71,14 +71,8 @@ public partial class RWKV7LanguageModel<T> : TokenLanguageModelLayoutBase<T>
 
     public RWKV7LanguageModel(
         NeuralNetworkArchitecture<T> architecture,
-        int vocabSize = 65536,
-        int modelDimension = 256,
-        int numLayers = 4,
-        int numHeads = 4,
-        double ffnMultiplier = 3.5,
-        int maxSeqLength = 512,
-        ILossFunction<T>? lossFunction = null,
-        RWKV7Options? options = null)
+        RWKV7Options? options = null,
+        ILossFunction<T>? lossFunction = null)
         : base(architecture,
             // RWKV-7's LM head emits RAW LOGITS (DenseLayer with no activation, see
             // LayerHelper.CreateRWKV7Layers), so the loss must be cross-entropy-with-logits (fused
@@ -93,20 +87,25 @@ public partial class RWKV7LanguageModel<T> : TokenLanguageModelLayoutBase<T>
             // normally, matching healthy sibling RWKV4.
             lossFunction ?? new AiDotNet.LossFunctions.CrossEntropyWithLogitsLoss<T>())
     {
-        if (vocabSize <= 0) throw new ArgumentException($"Vocabulary size ({vocabSize}) must be positive.", nameof(vocabSize));
-        if (modelDimension <= 0) throw new ArgumentException($"Model dimension ({modelDimension}) must be positive.", nameof(modelDimension));
-        if (numLayers <= 0) throw new ArgumentException($"Number of layers ({numLayers}) must be positive.", nameof(numLayers));
-        if (numHeads <= 0) throw new ArgumentException($"Number of heads ({numHeads}) must be positive.", nameof(numHeads));
-        if (modelDimension % numHeads != 0) throw new ArgumentException($"Model dimension ({modelDimension}) must be divisible by number of heads ({numHeads}).", nameof(modelDimension));
-
         _options = options ?? new RWKV7Options();
+        _options.Validate();
+
+        // Head-splitting requires an exact division, so this is checked after Validate() has
+        // established both values are positive.
+        if (_options.ModelDimension % _options.NumHeads != 0)
+        {
+            throw new ArgumentException(
+                $"Model dimension ({_options.ModelDimension}) must be divisible by number of heads ({_options.NumHeads}).",
+                nameof(options));
+        }
+
         Options = _options;
-        _vocabSize = vocabSize;
-        _modelDimension = modelDimension;
-        _numLayers = numLayers;
-        _numHeads = numHeads;
-        _ffnMultiplier = ffnMultiplier;
-        _maxSeqLength = maxSeqLength;
+        _vocabSize = _options.VocabSize;
+        _modelDimension = _options.ModelDimension;
+        _numLayers = _options.NumLayers;
+        _numHeads = _options.NumHeads;
+        _ffnMultiplier = _options.FfnMultiplier;
+        _maxSeqLength = _options.MaxSequenceLength;
         InitializeLayers();
     }
 

--- a/src/NeuralNetworks/RecurrentGemmaLanguageModel.cs
+++ b/src/NeuralNetworks/RecurrentGemmaLanguageModel.cs
@@ -64,12 +64,8 @@ public partial class RecurrentGemmaLanguageModel<T> : TokenLanguageModelLayoutBa
 
     public RecurrentGemmaLanguageModel(
         NeuralNetworkArchitecture<T> architecture,
-        int vocabSize = 256000,
-        int modelDimension = 256,
-        int numLayers = 4,
-        int maxSeqLength = 512,
-        ILossFunction<T>? lossFunction = null,
         RecurrentGemmaOptions? options = null,
+        ILossFunction<T>? lossFunction = null,
         IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>>? optimizer = null)
         : base(architecture,
             // The recurrent Gemma LM head emits raw logits. Use the paper-faithful
@@ -78,11 +74,12 @@ public partial class RecurrentGemmaLanguageModel<T> : TokenLanguageModelLayoutBa
             lossFunction ?? new AiDotNet.LossFunctions.CrossEntropyWithLogitsLoss<T>())
     {
         _options = options ?? new RecurrentGemmaOptions();
+        _options.Validate();
         Options = _options;
-        _vocabSize = vocabSize;
-        _modelDimension = modelDimension;
-        _numLayers = numLayers;
-        _maxSeqLength = maxSeqLength;
+        _vocabSize = _options.VocabSize;
+        _modelDimension = _options.ModelDimension;
+        _numLayers = _options.NumLayers;
+        _maxSeqLength = _options.MaxSequenceLength;
         _optimizer = optimizer ?? CreateDefaultOptimizer();
         InitializeLayers();
     }

--- a/src/NeuralNetworks/SAGAN.cs
+++ b/src/NeuralNetworks/SAGAN.cs
@@ -108,15 +108,12 @@ public partial class SAGAN<T> : GenerativeAdversarialNetwork<T>
         int imageChannels,
         int imageHeight,
         int imageWidth,
-        int numClasses = 0,
-        int generatorChannels = 64,
-        int discriminatorChannels = 64,
+        SAGANOptions? options = null,
         int[]? attentionLayers = null,
-        ILossFunction<T>? lossFunction = null,
-        SAGANOptions? options = null)
+        ILossFunction<T>? lossFunction = null)
         : base(
-            CreateSAGANGeneratorArchitecture(latentSize, imageChannels, imageHeight, imageWidth, generatorChannels),
-            CreateSAGANDiscriminatorArchitecture(imageChannels, imageHeight, imageWidth, discriminatorChannels),
+            CreateSAGANGeneratorArchitecture(latentSize, imageChannels, imageHeight, imageWidth, (options?.GeneratorChannels ?? 64)),
+            CreateSAGANDiscriminatorArchitecture(imageChannels, imageHeight, imageWidth, (options?.DiscriminatorChannels ?? 64)),
             InputType.ThreeDimensional,
             generatorOptimizer: null,
             discriminatorOptimizer: null,
@@ -132,14 +129,15 @@ public partial class SAGAN<T> : GenerativeAdversarialNetwork<T>
             defaultDiscriminatorOptimizerOptions: CreateAdamOptimizerOptions(0.0004, 0.0, 0.9))
     {
         _options = options ?? new SAGANOptions();
+        _options.Validate();
         Options = _options;
         _latentSize = latentSize;
-        _numClasses = numClasses;
+        _numClasses = _options.NumClasses;
         _imageChannels = imageChannels;
         _imageHeight = imageHeight;
         _imageWidth = imageWidth;
-        _generatorChannels = generatorChannels;
-        _discriminatorChannels = discriminatorChannels;
+        _generatorChannels = _options.GeneratorChannels;
+        _discriminatorChannels = _options.DiscriminatorChannels;
         _attentionLayers = attentionLayers ?? [2, 3];
         UseSpectralNormalization = true;
     }
@@ -167,23 +165,13 @@ public partial class SAGAN<T> : GenerativeAdversarialNetwork<T>
     public SAGAN(
         NeuralNetworkArchitecture<T> generatorArchitecture,
         NeuralNetworkArchitecture<T> discriminatorArchitecture,
-        int latentSize = 128,
-        int imageChannels = 3,
-        int imageHeight = 64,
-        int imageWidth = 64,
-        int numClasses = 0,
-        int generatorChannels = 64,
-        int discriminatorChannels = 64,
+        SAGANOptions? options = null,
         int[]? attentionLayers = null,
-        InputType inputType = InputType.TwoDimensional,
-        ILossFunction<T>? lossFunction = null,
-        double initialLearningRate = 0.0001,
-        SAGANOptions? options = null)
-        : this(latentSize,
-               imageChannels > 0 ? imageChannels : (discriminatorArchitecture.InputDepth > 0 ? discriminatorArchitecture.InputDepth : 3),
-               imageHeight > 0 ? imageHeight : (discriminatorArchitecture.InputHeight > 0 ? discriminatorArchitecture.InputHeight : 64),
-               imageWidth > 0 ? imageWidth : (discriminatorArchitecture.InputWidth > 0 ? discriminatorArchitecture.InputWidth : 64),
-               numClasses, generatorChannels, discriminatorChannels, attentionLayers, lossFunction, options)
+        ILossFunction<T>? lossFunction = null)
+        : this((options?.LatentSize ?? 128),
+               (options?.ImageChannels ?? 3) > 0 ? (options?.ImageChannels ?? 3) : (discriminatorArchitecture.InputDepth > 0 ? discriminatorArchitecture.InputDepth : 3),
+               (options?.ImageHeight ?? 64) > 0 ? (options?.ImageHeight ?? 64) : (discriminatorArchitecture.InputHeight > 0 ? discriminatorArchitecture.InputHeight : 64),
+               (options?.ImageWidth ?? 64) > 0 ? (options?.ImageWidth ?? 64) : (discriminatorArchitecture.InputWidth > 0 ? discriminatorArchitecture.InputWidth : 64), attentionLayers: attentionLayers, lossFunction: lossFunction, options: options)
     {
     }
 
@@ -196,14 +184,11 @@ public partial class SAGAN<T> : GenerativeAdversarialNetwork<T>
     /// <param name="options">Optional SAGAN options.</param>
     public SAGAN(
         NeuralNetworkArchitecture<T> architecture,
-        int latentSize = 128,
-        int numClasses = 0,
         SAGANOptions? options = null)
-        : this(latentSize,
+        : this((options?.LatentSize ?? 128),
                architecture.InputDepth > 0 ? architecture.InputDepth : 3,
                architecture.InputHeight > 0 ? architecture.InputHeight : 64,
-               architecture.InputWidth > 0 ? architecture.InputWidth : 64,
-               numClasses, options: options)
+               architecture.InputWidth > 0 ? architecture.InputWidth : 64, options: options)
     {
     }
 

--- a/src/NeuralNetworks/SGPT.cs
+++ b/src/NeuralNetworks/SGPT.cs
@@ -100,27 +100,22 @@ namespace AiDotNet.NeuralNetworks
         /// <param name="lossFunction">Optional loss function.</param>
         /// <param name="maxGradNorm">Maximum gradient norm for stability (default: 1.0).</param>
         public SGPT(
-            NeuralNetworkArchitecture<T> architecture,
-            ITokenizer? tokenizer = null,
-            IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>>? optimizer = null,
-            int vocabSize = 50257,
-            [ModelDimensionRole(ModelDimensionRole.AttentionDimension)] int embeddingDimension = 768,
-            int maxSequenceLength = 1024,
-            int numLayers = 12,
-            [ModelDimensionRole(ModelDimensionRole.AttentionHeadCount)] int numHeads = 12,
-            int feedForwardDim = 3072,
-            PoolingStrategy poolingStrategy = PoolingStrategy.Mean,
-            ILossFunction<T>? lossFunction = null,
-            double maxGradNorm = 1.0,
-            SGPTOptions? options = null)
-            : base(architecture, tokenizer, optimizer, vocabSize, embeddingDimension, maxSequenceLength, numLayers, numHeads, feedForwardDim, poolingStrategy, lossFunction, maxGradNorm)
+        NeuralNetworkArchitecture<T> architecture,
+        SGPTOptions? options = null,
+        ITokenizer? tokenizer = null,
+        IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>>? optimizer = null,
+        [ModelDimensionRole(ModelDimensionRole.AttentionDimension)] int embeddingDimension = 768,
+        [ModelDimensionRole(ModelDimensionRole.AttentionHeadCount)] int numHeads = 12,
+        ILossFunction<T>? lossFunction = null)
+            : base(architecture, options, tokenizer, optimizer, lossFunction)
         {
-            _options = options ?? new SGPTOptions();
+        _options = options ?? new SGPTOptions();
+        _options.Validate();
             Options = _options;
-            _vocabSize = vocabSize;
-            _numLayers = numLayers;
+            _vocabSize = _options.VocabSize;
+            _numLayers = _options.NumLayers;
             _numHeads = numHeads;
-            _feedForwardDim = feedForwardDim;
+            _feedForwardDim = _options.FeedForwardDim;
 
             InitializeLayersCore(false);
         }

--- a/src/NeuralNetworks/SPLADE.cs
+++ b/src/NeuralNetworks/SPLADE.cs
@@ -88,27 +88,21 @@ namespace AiDotNet.NeuralNetworks
     }
 
     public SPLADE(
-            NeuralNetworkArchitecture<T> architecture,
-            ITokenizer? tokenizer = null,
-            IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>>? optimizer = null,
-            int vocabSize = 30522,
-            int embeddingDimension = 768,
-            int maxSequenceLength = 512,
-            int numLayers = 12,
-            int numHeads = 12,
-            int feedForwardDim = 3072,
-            ILossFunction<T>? lossFunction = null,
-            double maxGradNorm = 1.0,
-            SPLADEOptions? options = null)
-            : base(architecture, tokenizer, optimizer, vocabSize, embeddingDimension, maxSequenceLength, numLayers, numHeads, feedForwardDim, PoolingStrategy.Max, lossFunction, maxGradNorm)
+        NeuralNetworkArchitecture<T> architecture,
+        SPLADEOptions? options = null,
+        ITokenizer? tokenizer = null,
+        IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>>? optimizer = null,
+        ILossFunction<T>? lossFunction = null)
+            : base(architecture, options, tokenizer, optimizer, lossFunction)
         {
-            _options = options ?? new SPLADEOptions();
+        _options = options ?? new SPLADEOptions();
+        _options.Validate();
             Options = _options;
 
-            _vocabSize = vocabSize;
-            _numLayers = numLayers;
-            _numHeads = numHeads;
-            _feedForwardDim = feedForwardDim;
+            _vocabSize = _options.VocabSize;
+            _numLayers = _options.NumLayers;
+            _numHeads = _options.NumHeads;
+            _feedForwardDim = _options.FeedForwardDim;
             _tokenizer = tokenizer ?? Tokenization.LanguageModelTokenizerFactory.CreateForBackbone(LanguageModelBackbone.OPT);
 
             InitializeLayersCore(false);

--- a/src/NeuralNetworks/SambaLanguageModel.cs
+++ b/src/NeuralNetworks/SambaLanguageModel.cs
@@ -66,14 +66,8 @@ public partial class SambaLanguageModel<T> : TokenLanguageModelLayoutBase<T>
 
     public SambaLanguageModel(
         NeuralNetworkArchitecture<T> architecture,
-        int vocabSize = 32000,
-        int modelDimension = 256,
-        int numLayers = 8,
-        int stateDimension = 16,
-        int attentionInterval = 2,
-        int maxSeqLength = 512,
-        ILossFunction<T>? lossFunction = null,
-        SambaOptions? options = null)
+        SambaOptions? options = null,
+        ILossFunction<T>? lossFunction = null)
         : base(architecture,
             // Samba's LM head emits RAW LOGITS (DenseLayer with no activation, see
             // LayerHelper.CreateSambaLayers), so the loss must be cross-entropy-with-logits (fused
@@ -88,13 +82,14 @@ public partial class SambaLanguageModel<T> : TokenLanguageModelLayoutBase<T>
             lossFunction ?? new AiDotNet.LossFunctions.CrossEntropyWithLogitsLoss<T>())
     {
         _options = options ?? new SambaOptions();
+        _options.Validate();
         Options = _options;
-        _vocabSize = vocabSize;
-        _modelDimension = modelDimension;
-        _numLayers = numLayers;
-        _stateDimension = stateDimension;
-        _attentionInterval = attentionInterval;
-        _maxSeqLength = maxSeqLength;
+        _vocabSize = _options.VocabSize;
+        _modelDimension = _options.ModelDimension;
+        _numLayers = _options.NumLayers;
+        _stateDimension = _options.StateDimension;
+        _attentionInterval = _options.AttentionInterval;
+        _maxSeqLength = _options.MaxSequenceLength;
         InitializeLayers();
     }
 

--- a/src/NeuralNetworks/SimCSE.cs
+++ b/src/NeuralNetworks/SimCSE.cs
@@ -85,31 +85,22 @@ namespace AiDotNet.NeuralNetworks
         /// Initializes a new instance of the SimCSE model.
         /// </summary>
         public SimCSE(
-            NeuralNetworkArchitecture<T> architecture,
-            ITokenizer? tokenizer = null,
-            IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>>? optimizer = null,
-            SimCSEType type = SimCSEType.Unsupervised,
-            int vocabSize = 30522,
-            int embeddingDimension = 768,
-            int maxSequenceLength = 512,
-            int numLayers = 12,
-            int numHeads = 12,
-            int feedForwardDim = 3072,
-            double dropoutRate = 0.1,
-            PoolingStrategy poolingStrategy = PoolingStrategy.ClsToken,
-            ILossFunction<T>? lossFunction = null,
-            double maxGradNorm = 1.0,
-            SimCSEOptions? options = null)
-            : base(architecture, tokenizer, optimizer, vocabSize, embeddingDimension, maxSequenceLength, numLayers, numHeads, feedForwardDim, poolingStrategy, lossFunction, maxGradNorm)
+        NeuralNetworkArchitecture<T> architecture,
+        SimCSEOptions? options = null,
+        ITokenizer? tokenizer = null,
+        IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>>? optimizer = null,
+        ILossFunction<T>? lossFunction = null)
+            : base(architecture, options, tokenizer, optimizer, lossFunction)
         {
-            _options = options ?? new SimCSEOptions();
+        _options = options ?? new SimCSEOptions();
+        _options.Validate();
             Options = _options;
-            _simCseType = type;
-            _dropoutRate = dropoutRate;
-            _vocabSize = vocabSize;
-            _numLayers = numLayers;
-            _numHeads = numHeads;
-            _feedForwardDim = feedForwardDim;
+            _simCseType = _options.Type;
+            _dropoutRate = _options.DropoutRate;
+            _vocabSize = _options.VocabSize;
+            _numLayers = _options.NumLayers;
+            _numHeads = _options.NumHeads;
+            _feedForwardDim = _options.FeedForwardDim;
 
             InitializeLayersCore(false);
         }

--- a/src/NeuralNetworks/StyleGAN.cs
+++ b/src/NeuralNetworks/StyleGAN.cs
@@ -249,15 +249,13 @@ public partial class StyleGAN<T> : ImageGeneratorModelLayoutBase<T>
         int latentSize,
         int intermediateLatentSize,
         InputType inputType,
-        ILossFunction<T>? lossFunction = null,
-        double initialLearningRate = 0.001,
-        bool enableStyleMixing = true,
-        double styleMixingProbability = 0.9,
-        StyleGANOptions? options = null)
+        StyleGANOptions? options = null,
+        ILossFunction<T>? lossFunction = null)
         : base(CreateStyleGANArchitecture(latentSize, discriminatorArchitecture, inputType),
                lossFunction ?? NeuralNetworkHelper<T>.GetDefaultLossFunction(NeuralNetworkTaskType.Generative))
     {
         _options = options ?? new StyleGANOptions();
+        _options.Validate();
         Options = _options;
 
         // Input validation
@@ -286,21 +284,21 @@ public partial class StyleGAN<T> : ImageGeneratorModelLayoutBase<T>
             throw new ArgumentOutOfRangeException(nameof(intermediateLatentSize), intermediateLatentSize, "Intermediate latent size must be positive.");
         }
 
-        if (initialLearningRate <= 0)
+        if (_options.InitialLearningRate <= 0)
         {
-            throw new ArgumentOutOfRangeException(nameof(initialLearningRate), initialLearningRate, "Initial learning rate must be positive.");
+            throw new ArgumentOutOfRangeException(nameof(_options.InitialLearningRate), _options.InitialLearningRate, "Initial learning rate must be positive.");
         }
 
-        if (styleMixingProbability < 0 || styleMixingProbability > 1)
+        if (_options.StyleMixingProbability < 0 || _options.StyleMixingProbability > 1)
         {
-            throw new ArgumentOutOfRangeException(nameof(styleMixingProbability), styleMixingProbability, "Style mixing probability must be in range [0, 1].");
+            throw new ArgumentOutOfRangeException(nameof(_options.StyleMixingProbability), _options.StyleMixingProbability, "Style mixing probability must be in range [0, 1].");
         }
 
         _latentSize = latentSize;
         _intermediateLatentSize = intermediateLatentSize;
-        _enableStyleMixing = enableStyleMixing;
-        _styleMixingProbability = NumOps.FromDouble(styleMixingProbability);
-        _initialLearningRate = initialLearningRate;
+        _enableStyleMixing = _options.EnableStyleMixing;
+        _styleMixingProbability = NumOps.FromDouble(_options.StyleMixingProbability);
+        _initialLearningRate = _options.InitialLearningRate;
 
         // Initialize MappingNetwork optimizer state
         _mappingMomentum = Vector<T>.Empty();

--- a/src/NeuralNetworks/TransformerEmbeddingNetwork.cs
+++ b/src/NeuralNetworks/TransformerEmbeddingNetwork.cs
@@ -81,7 +81,7 @@ namespace AiDotNet.NeuralNetworks
         /// <summary>
         /// The strategy used to pool token-level representations into a single vector.
         /// </summary>
-        private PoolingStrategy _poolingStrategy;
+        private EmbeddingPoolingStrategy _poolingStrategy;
 
         /// <summary>
         /// The total number of transformer encoder layers in the stack.
@@ -123,27 +123,6 @@ namespace AiDotNet.NeuralNetworks
         /// <inheritdoc/>
         public int MaxTokens => _maxSequenceLength;
 
-        /// <summary>
-        /// Defines the available pooling strategies for creating a single sentence embedding.
-        /// </summary>
-        public enum PoolingStrategy
-        {
-            /// <summary>
-            /// Averages all token representations across the sequence.
-            /// </summary>
-            Mean,
-
-            /// <summary>
-            /// Takes the maximum value across all sequence positions for each dimension.
-            /// </summary>
-            Max,
-
-            /// <summary>
-            /// Uses the representation of the first token (typically the [CLS] token).
-            /// </summary>
-            ClsToken
-        }
-
         #endregion
 
         #region Constructors
@@ -176,32 +155,25 @@ namespace AiDotNet.NeuralNetworks
         /// <param name="lossFunction">Optional loss function.</param>
         /// <param name="maxGradNorm">Maximum gradient norm for stability (default: 1.0).</param>
         public TransformerEmbeddingNetwork(
-            NeuralNetworkArchitecture<T> architecture,
-            ITokenizer? tokenizer = null,
-            IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>>? optimizer = null,
-            int vocabSize = 30522,
-            int embeddingDimension = 768,
-            int maxSequenceLength = 512,
-            int numLayers = 12,
-            int numHeads = 12,
-            int feedForwardDim = 3072,
-            PoolingStrategy poolingStrategy = PoolingStrategy.Mean,
-            ILossFunction<T>? lossFunction = null,
-            double maxGradNorm = 1.0,
-            TransformerEmbeddingOptions? options = null)
-            : base(architecture, lossFunction ?? new MeanSquaredErrorLoss<T>(), maxGradNorm)
+        NeuralNetworkArchitecture<T> architecture,
+        TransformerEmbeddingOptions? options = null,
+        ITokenizer? tokenizer = null,
+        IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>>? optimizer = null,
+        ILossFunction<T>? lossFunction = null)
+            : base(architecture, lossFunction ?? new MeanSquaredErrorLoss<T>(), options?.MaxGradNorm ?? 1.0)
         {
-            _options = options ?? new TransformerEmbeddingOptions();
+        _options = options ?? new TransformerEmbeddingOptions();
+        _options.Validate();
             Options = _options;
 
             _tokenizer = tokenizer;
-            _vocabSize = vocabSize;
-            _embeddingDimension = embeddingDimension;
-            _maxSequenceLength = maxSequenceLength;
-            _poolingStrategy = poolingStrategy;
-            _numLayers = numLayers;
-            _numHeads = numHeads;
-            _feedForwardDim = feedForwardDim;
+            _vocabSize = _options.VocabSize;
+            _embeddingDimension = _options.EmbeddingDimension;
+            _maxSequenceLength = _options.MaxSequenceLength;
+            _poolingStrategy = _options.EmbeddingPoolingStrategy;
+            _numLayers = _options.NumLayers;
+            _numHeads = _options.NumHeads;
+            _feedForwardDim = _options.FeedForwardDim;
             _lossFunction = lossFunction ?? new MeanSquaredErrorLoss<T>();
             // Paper-faithful LR: SBERT (Reimers & Gurevych 2019) and SGPT
             // (Muennighoff 2022) fine-tune sentence-embedding transformers at
@@ -368,20 +340,20 @@ namespace AiDotNet.NeuralNetworks
 
             Vector<T> result;
 
-            if (_poolingStrategy == PoolingStrategy.ClsToken)
+            if (_poolingStrategy == EmbeddingPoolingStrategy.ClsToken)
             {
                 // Extract first row [dim] using Engine-friendly bulk copy
                 var clsData = new T[dim];
                 seq2D.Data.Span.Slice(0, dim).CopyTo(clsData);
                 result = new Vector<T>(clsData);
             }
-            else if (_poolingStrategy == PoolingStrategy.Mean)
+            else if (_poolingStrategy == EmbeddingPoolingStrategy.Mean)
             {
                 // Engine-accelerated mean reduction along sequence axis (axis 0)
                 var meanTensor = Engine.ReduceMean(seq2D, [0], keepDims: false);
                 result = meanTensor.Reshape(dim).ToVector();
             }
-            else if (_poolingStrategy == PoolingStrategy.Max)
+            else if (_poolingStrategy == EmbeddingPoolingStrategy.Max)
             {
                 // Engine-accelerated max reduction along sequence axis (axis 0)
                 var maxTensor = Engine.ReduceMax(seq2D, [0], keepDims: false, out _);
@@ -479,7 +451,7 @@ namespace AiDotNet.NeuralNetworks
                     { "EmbeddingDimension", _embeddingDimension },
                     { "NumLayers", _numLayers },
                     { "NumHeads", _numHeads },
-                    { "PoolingStrategy", _poolingStrategy.ToString() }
+                    { "EmbeddingPoolingStrategy", _poolingStrategy.ToString() }
                 }
             };
         }

--- a/src/NeuralNetworks/UnifiedMultimodalNetwork.cs
+++ b/src/NeuralNetworks/UnifiedMultimodalNetwork.cs
@@ -138,22 +138,20 @@ public partial class UnifiedMultimodalNetwork<T> : MultimodalModelLayoutBase<T>,
     /// </summary>
     public UnifiedMultimodalNetwork(
         NeuralNetworkArchitecture<T> architecture,
-        int embeddingDimension = DEFAULT_EMBEDDING_DIM,
-        int maxSequenceLength = DEFAULT_MAX_SEQ_LEN,
-        int numTransformerLayers = DEFAULT_NUM_LAYERS,
+        UnifiedMultimodalNetworkOptions? options = null,
         IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>>? optimizer = null,
         ILossFunction<T>? lossFunction = null,
-        int? seed = null,
-        UnifiedMultimodalNetworkOptions? options = null)
+        int? seed = null)
         : base(architecture, lossFunction ?? new CrossEntropyWithLogitsLoss<T>(), 1.0)
     {
         _options = options ?? new UnifiedMultimodalNetworkOptions();
+        _options.Validate();
         Options = _options;
 
         _numOps = MathHelper.GetNumericOperations<T>();
-        _embeddingDimension = embeddingDimension;
-        _maxSequenceLength = maxSequenceLength;
-        _numTransformerLayers = numTransformerLayers;
+        _embeddingDimension = _options.EmbeddingDimension;
+        _maxSequenceLength = _options.MaxSequenceLength;
+        _numTransformerLayers = _options.NumTransformerLayers;
         _random = seed.HasValue ? RandomHelper.CreateSeededRandom(seed.Value) : RandomHelper.CreateSeededRandom(42);
         _lossFunction = lossFunction ?? new CrossEntropyWithLogitsLoss<T>();
         // AdamW (decoupled weight decay) is the canonical optimizer for multimodal transformers:

--- a/src/NeuralNetworks/VideoCLIPNeuralNetwork.cs
+++ b/src/NeuralNetworks/VideoCLIPNeuralNetwork.cs
@@ -164,18 +164,14 @@ public partial class VideoCLIPNeuralNetwork<T> : MultimodalModelLayoutBase<T>, I
         string videoEncoderPath,
         string textEncoderPath,
         ITokenizer tokenizer,
-        int numFrames = 8,
-        double frameRate = 1.0,
+        VideoCLIPOptions? options = null,
         TemporalAggregationType temporalAggregation = TemporalAggregationType.TemporalTransformer,
-        int embeddingDimension = 512,
-        int maxSequenceLength = 77,
-        int imageSize = 224,
         IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>>? optimizer = null,
-        ILossFunction<T>? lossFunction = null,
-        VideoCLIPOptions? options = null)
+        ILossFunction<T>? lossFunction = null)
         : base(architecture, lossFunction ?? new CosineSimilarityLoss<T>(), 1.0)
     {
         _options = options ?? new VideoCLIPOptions();
+        _options.Validate();
         Options = _options;
 
         if (string.IsNullOrWhiteSpace(videoEncoderPath))
@@ -190,12 +186,12 @@ public partial class VideoCLIPNeuralNetwork<T> : MultimodalModelLayoutBase<T>, I
         _useNativeMode = false;
         _videoEncoderPath = videoEncoderPath;
         _textEncoderPath = textEncoderPath;
-        _numFrames = numFrames;
-        _frameRate = frameRate;
+        _numFrames = _options.NumFrames;
+        _frameRate = _options.FrameRate;
         _temporalAggregation = temporalAggregation;
-        _embeddingDimension = embeddingDimension;
-        _maxSequenceLength = maxSequenceLength;
-        _imageSize = imageSize;
+        _embeddingDimension = _options.EmbeddingDimension;
+        _maxSequenceLength = _options.MaxSequenceLength;
+        _imageSize = _options.ImageSize;
         _patchSize = 16;
         _visionHiddenDim = 768;
         _textHiddenDim = 512;
@@ -233,51 +229,38 @@ public partial class VideoCLIPNeuralNetwork<T> : MultimodalModelLayoutBase<T>, I
     /// </summary>
     public VideoCLIPNeuralNetwork(
         NeuralNetworkArchitecture<T> architecture,
-        int imageSize = 224,
-        int channels = 3,
-        int patchSize = 16,
-        int vocabularySize = 49408,
-        int maxSequenceLength = 77,
-        int embeddingDimension = 512,
-        int visionHiddenDim = 768,
-        int textHiddenDim = 512,
-        int numFrameEncoderLayers = 12,
-        int numTemporalLayers = 4,
-        int numTextLayers = 12,
-        int numHeads = 12,
-        int numFrames = 8,
-        double frameRate = 1.0,
+        VideoCLIPOptions? options = null,
         TemporalAggregationType temporalAggregation = TemporalAggregationType.TemporalTransformer,
         ITokenizer? tokenizer = null,
         IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>>? optimizer = null,
-        ILossFunction<T>? lossFunction = null,
-        VideoCLIPOptions? options = null)
+        ILossFunction<T>? lossFunction = null)
         : base(architecture, lossFunction ?? new CosineSimilarityLoss<T>(), 1.0)
     {
         _options = options ?? new VideoCLIPOptions();
+        _options.Validate();
         Options = _options;
 
         _useNativeMode = true;
-        _embeddingDimension = embeddingDimension;
-        _maxSequenceLength = maxSequenceLength;
-        _imageSize = imageSize;
-        _visionHiddenDim = visionHiddenDim;
-        _textHiddenDim = textHiddenDim;
-        _numFrameEncoderLayers = numFrameEncoderLayers;
-        _numTemporalLayers = numTemporalLayers;
-        _numTextLayers = numTextLayers;
-        _numHeads = numHeads;
-        _patchSize = patchSize;
-        _vocabularySize = vocabularySize;
-        _numFrames = numFrames;
-        _frameRate = frameRate;
+        _embeddingDimension = _options.EmbeddingDimension;
+        _maxSequenceLength = _options.MaxSequenceLength;
+        _imageSize = _options.ImageSize;
+        _visionHiddenDim = _options.VisionHiddenDim;
+        _textHiddenDim = _options.TextHiddenDim;
+        _numFrameEncoderLayers = _options.NumFrameEncoderLayers;
+        _numTemporalLayers = _options.NumTemporalLayers;
+        _numTextLayers = _options.NumTextLayers;
+        _numHeads = _options.NumHeads;
+        _patchSize = _options.PatchSize;
+        _vocabularySize = _options.VocabSize;
+        _numFrames = _options.NumFrames;
+        _frameRate = _options.FrameRate;
         _temporalAggregation = temporalAggregation;
 
         _tokenizer = tokenizer ?? Tokenization.ClipTokenizerFactory.CreateSimple();
         _optimizer = optimizer ?? new AdamOptimizer<T, Tensor<T>, Tensor<T>>(this);
         _lossFunction = lossFunction ?? new CosineSimilarityLoss<T>();
 
-        InitializeNativeLayers(channels);
+        InitializeNativeLayers(_options.Channels);
     }
 
     #endregion

--- a/src/NeuralNetworks/VideoCLIPNeuralNetwork.cs
+++ b/src/NeuralNetworks/VideoCLIPNeuralNetwork.cs
@@ -165,12 +165,12 @@ public partial class VideoCLIPNeuralNetwork<T> : MultimodalModelLayoutBase<T>, I
         string textEncoderPath,
         ITokenizer tokenizer,
         VideoCLIPOptions? options = null,
-        TemporalAggregationType temporalAggregation = TemporalAggregationType.TemporalTransformer,
         IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>>? optimizer = null,
         ILossFunction<T>? lossFunction = null)
         : base(architecture, lossFunction ?? new CosineSimilarityLoss<T>(), 1.0)
     {
         _options = options ?? new VideoCLIPOptions();
+        _options.Validate();
         _options.Validate();
         Options = _options;
 
@@ -188,7 +188,7 @@ public partial class VideoCLIPNeuralNetwork<T> : MultimodalModelLayoutBase<T>, I
         _textEncoderPath = textEncoderPath;
         _numFrames = _options.NumFrames;
         _frameRate = _options.FrameRate;
-        _temporalAggregation = temporalAggregation;
+        _temporalAggregation = _options.TemporalAggregation;
         _embeddingDimension = _options.EmbeddingDimension;
         _maxSequenceLength = _options.MaxSequenceLength;
         _imageSize = _options.ImageSize;
@@ -230,13 +230,13 @@ public partial class VideoCLIPNeuralNetwork<T> : MultimodalModelLayoutBase<T>, I
     public VideoCLIPNeuralNetwork(
         NeuralNetworkArchitecture<T> architecture,
         VideoCLIPOptions? options = null,
-        TemporalAggregationType temporalAggregation = TemporalAggregationType.TemporalTransformer,
         ITokenizer? tokenizer = null,
         IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>>? optimizer = null,
         ILossFunction<T>? lossFunction = null)
         : base(architecture, lossFunction ?? new CosineSimilarityLoss<T>(), 1.0)
     {
         _options = options ?? new VideoCLIPOptions();
+        _options.Validate();
         _options.Validate();
         Options = _options;
 
@@ -254,7 +254,7 @@ public partial class VideoCLIPNeuralNetwork<T> : MultimodalModelLayoutBase<T>, I
         _vocabularySize = _options.VocabSize;
         _numFrames = _options.NumFrames;
         _frameRate = _options.FrameRate;
-        _temporalAggregation = temporalAggregation;
+        _temporalAggregation = _options.TemporalAggregation;
 
         _tokenizer = tokenizer ?? Tokenization.ClipTokenizerFactory.CreateSimple();
         _optimizer = optimizer ?? new AdamOptimizer<T, Tensor<T>, Tensor<T>>(this);

--- a/src/NeuralNetworks/VisionMambaModel.cs
+++ b/src/NeuralNetworks/VisionMambaModel.cs
@@ -145,54 +145,42 @@ public partial class VisionMambaModel<T> : ImageClassifierModelLayoutBase<T>
 
     public VisionMambaModel(
         NeuralNetworkArchitecture<T> architecture,
-        int imageHeight = 224,
-        int imageWidth = 224,
-        int patchSize = 16,
-        int channels = 3,
-        int modelDimension = 192,
-        int numLayers = 4,
-        int numClasses = 10,
-        int stateDimension = 16,
-        VisionScanPattern scanPattern = VisionScanPattern.Bidirectional,
-        ILossFunction<T>? lossFunction = null,
-        VisionMambaOptions? options = null)
+        VisionMambaOptions? options = null,
+        ILossFunction<T>? lossFunction = null)
         : base(architecture,
             lossFunction ?? NeuralNetworkHelper<T>.GetDefaultLossFunction(NeuralNetworkTaskType.ImageClassification))
     {
-        if (imageHeight <= 0) throw new ArgumentException($"Image height ({imageHeight}) must be positive.", nameof(imageHeight));
-        if (imageWidth <= 0) throw new ArgumentException($"Image width ({imageWidth}) must be positive.", nameof(imageWidth));
-        if (patchSize <= 0) throw new ArgumentException($"Patch size ({patchSize}) must be positive.", nameof(patchSize));
-        if (imageHeight % patchSize != 0) throw new ArgumentException($"Image height ({imageHeight}) must be divisible by patch size ({patchSize}).", nameof(imageHeight));
-        if (imageWidth % patchSize != 0) throw new ArgumentException($"Image width ({imageWidth}) must be divisible by patch size ({patchSize}).", nameof(imageWidth));
-        if (numClasses <= 0) throw new ArgumentException($"Number of classes ({numClasses}) must be positive.", nameof(numClasses));
-
         _options = options ?? new VisionMambaOptions();
-        Options = _options;
-        _imageHeight = imageHeight;
-        _imageWidth = imageWidth;
-        _patchSize = patchSize;
-        _channels = channels;
-        _modelDimension = modelDimension;
-        _numLayers = numLayers;
-        _numClasses = numClasses;
-        _stateDimension = stateDimension;
-        _scanPattern = scanPattern;
+        _options.Validate();
+        if (_options.ImageHeight % _options.PatchSize != 0) throw new ArgumentException($"Image height ({_options.ImageHeight}) must be divisible by patch size ({_options.PatchSize}).", nameof(_options.ImageHeight));
+        if (_options.ImageWidth % _options.PatchSize != 0) throw new ArgumentException($"Image width ({_options.ImageWidth}) must be divisible by patch size ({_options.PatchSize}).", nameof(_options.ImageWidth));
 
-        _numPatchesH = imageHeight / patchSize;
-        _numPatchesW = imageWidth / patchSize;
+        Options = _options;
+        _imageHeight = _options.ImageHeight;
+        _imageWidth = _options.ImageWidth;
+        _patchSize = _options.PatchSize;
+        _channels = _options.Channels;
+        _modelDimension = _options.ModelDimension;
+        _numLayers = _options.NumLayers;
+        _numClasses = _options.NumClasses;
+        _stateDimension = _options.StateDimension;
+        _scanPattern = _options.ScanPattern;
+
+        _numPatchesH = _options.ImageHeight / _options.PatchSize;
+        _numPatchesW = _options.ImageWidth / _options.PatchSize;
         _numPatches = _numPatchesH * _numPatchesW;
-        _mambaInputDim = scanPattern == VisionScanPattern.Bidirectional
-            ? modelDimension * 2
-            : modelDimension;
+        _mambaInputDim = _options.ScanPattern == VisionScanPattern.Bidirectional
+            ? _options.ModelDimension * 2
+            : _options.ModelDimension;
 
         // Initialize patch embedding weights
-        int patchDim = patchSize * patchSize * channels;
-        _patchProjectionWeights = new Tensor<T>(new[] { patchDim, modelDimension });
-        _patchProjectionBias = new Tensor<T>(new[] { modelDimension });
+        int patchDim = _options.PatchSize * _options.PatchSize * _options.Channels;
+        _patchProjectionWeights = new Tensor<T>(new[] { patchDim, _options.ModelDimension });
+        _patchProjectionBias = new Tensor<T>(new[] { _options.ModelDimension });
         InitializeTensor(_patchProjectionWeights);
         _patchProjectionBias.Fill(NumOps.Zero);
 
-        _positionalEmbedding = new Tensor<T>(new[] { _numPatches, modelDimension });
+        _positionalEmbedding = new Tensor<T>(new[] { _numPatches, _options.ModelDimension });
         InitializeTensor(_positionalEmbedding, scale: 0.02);
 
         // Final norm
@@ -200,9 +188,9 @@ public partial class VisionMambaModel<T> : ImageClassifierModelLayoutBase<T>
         _finalNormGamma.Fill(NumOps.One);
 
         // Classification head
-        _classifierWeights = new Tensor<T>(new[] { _mambaInputDim, numClasses });
+        _classifierWeights = new Tensor<T>(new[] { _mambaInputDim, _options.NumClasses });
         InitializeTensor(_classifierWeights);
-        _classifierBias = new Tensor<T>(new[] { numClasses });
+        _classifierBias = new Tensor<T>(new[] { _options.NumClasses });
         _classifierBias.Fill(NumOps.Zero);
 
         InitializeLayers();

--- a/src/NeuralNetworks/WGAN.cs
+++ b/src/NeuralNetworks/WGAN.cs
@@ -241,16 +241,15 @@ public partial class WGAN<T> : ImageGeneratorModelLayoutBase<T>
         NeuralNetworkArchitecture<T> generatorArchitecture,
         NeuralNetworkArchitecture<T> criticArchitecture,
         InputType inputType,
+        WGANOptions? options = null,
         IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>>? generatorOptimizer = null,
         IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>>? criticOptimizer = null,
-        ILossFunction<T>? lossFunction = null,
-        double weightClipValue = 0.01,
-        int criticIterations = 5,
-        WGANOptions? options = null)
+        ILossFunction<T>? lossFunction = null)
         : base(CreateWGANArchitecture(generatorArchitecture, criticArchitecture, inputType),
                lossFunction ?? new WassersteinLoss<T>())
     {
         _options = options ?? new WGANOptions();
+        _options.Validate();
         Options = _options;
 
         if (generatorArchitecture is null)
@@ -281,17 +280,17 @@ public partial class WGAN<T> : ImageGeneratorModelLayoutBase<T>
                 nameof(criticArchitecture));
         }
 
-        if (weightClipValue <= 0)
+        if (_options.WeightClipValue <= 0)
         {
-            throw new ArgumentOutOfRangeException(nameof(weightClipValue), weightClipValue, "Weight clip value must be positive.");
+            throw new ArgumentOutOfRangeException(nameof(_options.WeightClipValue), _options.WeightClipValue, "Weight clip value must be positive.");
         }
-        if (criticIterations <= 0)
+        if (_options.CriticIterations <= 0)
         {
-            throw new ArgumentOutOfRangeException(nameof(criticIterations), criticIterations, "Critic iterations must be positive.");
+            throw new ArgumentOutOfRangeException(nameof(_options.CriticIterations), _options.CriticIterations, "Critic iterations must be positive.");
         }
 
-        _weightClipValue = weightClipValue;
-        _criticIterations = criticIterations;
+        _weightClipValue = _options.WeightClipValue;
+        _criticIterations = _options.CriticIterations;
 
         Generator = CreateNetworkForInputType(generatorArchitecture, inputType);
         Critic = CreateNetworkForInputType(criticArchitecture, inputType);

--- a/src/NeuralNetworks/WGANGP.cs
+++ b/src/NeuralNetworks/WGANGP.cs
@@ -208,12 +208,8 @@ public partial class WGANGP<T> : ImageGeneratorModelLayoutBase<T>
     /// <param name="options">Optional WGAN-GP options.</param>
     public WGANGP(
         NeuralNetworkArchitecture<T> architecture,
-        double gradientPenaltyCoefficient = 10.0,
-        int criticIterations = 5,
         WGANGPOptions? options = null)
-        : this(architecture, CreateDefaultCriticArchitecture(architecture), architecture.InputType,
-               gradientPenaltyCoefficient: gradientPenaltyCoefficient,
-               criticIterations: criticIterations, options: options)
+        : this(architecture, CreateDefaultCriticArchitecture(architecture), architecture.InputType, options: options)
     {
     }
 
@@ -248,16 +244,15 @@ public partial class WGANGP<T> : ImageGeneratorModelLayoutBase<T>
         NeuralNetworkArchitecture<T> generatorArchitecture,
         NeuralNetworkArchitecture<T> criticArchitecture,
         InputType inputType,
+        WGANGPOptions? options = null,
         IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>>? generatorOptimizer = null,
         IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>>? criticOptimizer = null,
-        ILossFunction<T>? lossFunction = null,
-        double gradientPenaltyCoefficient = 10.0,
-        int criticIterations = 5,
-        WGANGPOptions? options = null)
+        ILossFunction<T>? lossFunction = null)
         : base(CreateWGANGPArchitecture(generatorArchitecture, criticArchitecture, inputType),
                lossFunction ?? NeuralNetworkHelper<T>.GetDefaultLossFunction(generatorArchitecture.TaskType))
     {
         _options = options ?? new WGANGPOptions();
+        _options.Validate();
         Options = _options;
 
         // Input validation
@@ -275,17 +270,17 @@ public partial class WGANGP<T> : ImageGeneratorModelLayoutBase<T>
                 $"WGAN-GP critic output size must be 1 (an unrestricted Wasserstein score), but was {criticArchitecture.OutputSize}.",
                 nameof(criticArchitecture));
         }
-        if (gradientPenaltyCoefficient <= 0)
+        if (_options.GradientPenaltyCoefficient <= 0)
         {
-            throw new ArgumentOutOfRangeException(nameof(gradientPenaltyCoefficient), gradientPenaltyCoefficient, "Gradient penalty coefficient must be positive.");
+            throw new ArgumentOutOfRangeException(nameof(_options.GradientPenaltyCoefficient), _options.GradientPenaltyCoefficient, "Gradient penalty coefficient must be positive.");
         }
-        if (criticIterations <= 0)
+        if (_options.CriticIterations <= 0)
         {
-            throw new ArgumentOutOfRangeException(nameof(criticIterations), criticIterations, "Critic iterations must be positive.");
+            throw new ArgumentOutOfRangeException(nameof(_options.CriticIterations), _options.CriticIterations, "Critic iterations must be positive.");
         }
 
-        _gradientPenaltyCoefficient = gradientPenaltyCoefficient;
-        _criticIterations = criticIterations;
+        _gradientPenaltyCoefficient = _options.GradientPenaltyCoefficient;
+        _criticIterations = _options.CriticIterations;
 
         Generator = CreateNetworkForArchitecture(generatorArchitecture);
         Critic = CreateNetworkForArchitecture(EnsureDefaultCriticLayers(criticArchitecture));

--- a/src/NeuralNetworks/Word2Vec.cs
+++ b/src/NeuralNetworks/Word2Vec.cs
@@ -186,28 +186,23 @@ namespace AiDotNet.NeuralNetworks
         /// learning strategy it should use (type).
         /// </remarks>
         public Word2Vec(
-            NeuralNetworkArchitecture<T> architecture,
-            ITokenizer? tokenizer = null,
-            IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>>? optimizer = null,
-            int vocabSize = 10000,
-            int embeddingDimension = 100,
-            int windowSize = 5,
-            int maxTokens = 512,
-            Word2VecType type = Word2VecType.SkipGram,
-            ILossFunction<T>? lossFunction = null,
-            double maxGradNorm = 1.0,
-            Word2VecOptions? options = null)
-            : base(architecture, lossFunction ?? new BinaryCrossEntropyLoss<T>(), maxGradNorm)
+        NeuralNetworkArchitecture<T> architecture,
+        Word2VecOptions? options = null,
+        ITokenizer? tokenizer = null,
+        IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>>? optimizer = null,
+        ILossFunction<T>? lossFunction = null)
+            : base(architecture, lossFunction ?? new BinaryCrossEntropyLoss<T>(), options?.MaxGradNorm ?? 1.0)
         {
-            _options = options ?? new Word2VecOptions();
+        _options = options ?? new Word2VecOptions();
+        _options.Validate();
             Options = _options;
 
             _tokenizer = tokenizer;
-            _vocabSize = vocabSize;
-            _embeddingDimension = embeddingDimension;
-            _windowSize = windowSize;
-            _maxTokens = maxTokens;
-            _type = type;
+            _vocabSize = _options.VocabSize;
+            _embeddingDimension = _options.EmbeddingDimension;
+            _windowSize = _options.WindowSize;
+            _maxTokens = _options.MaxSequenceLength;
+            _type = _options.Type;
             _lossFunction = lossFunction ?? new BinaryCrossEntropyLoss<T>();
             // Mikolov et al. 2013 (the Word2Vec paper) explicitly use stochastic
             // gradient descent with an initial learning rate of 0.025 (linear

--- a/src/NeuralNetworks/XLSTMLanguageModel.cs
+++ b/src/NeuralNetworks/XLSTMLanguageModel.cs
@@ -67,13 +67,8 @@ public partial class XLSTMLanguageModel<T> : TokenLanguageModelLayoutBase<T>
 
     public XLSTMLanguageModel(
         NeuralNetworkArchitecture<T> architecture,
-        int vocabSize = 50277,
-        int modelDimension = 256,
-        int numLayers = 4,
-        int numHeads = 8,
-        int maxSeqLength = 512,
-        ILossFunction<T>? lossFunction = null,
         XLSTMOptions? options = null,
+        ILossFunction<T>? lossFunction = null,
         IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>>? optimizer = null)
         : base(architecture,
             // xLSTM is a next-token language model and its LM head emits raw logits.
@@ -83,12 +78,13 @@ public partial class XLSTMLanguageModel<T> : TokenLanguageModelLayoutBase<T>
             lossFunction ?? new AiDotNet.LossFunctions.CrossEntropyWithLogitsLoss<T>())
     {
         _options = options ?? new XLSTMOptions();
+        _options.Validate();
         Options = _options;
-        _vocabSize = vocabSize;
-        _modelDimension = modelDimension;
-        _numLayers = numLayers;
-        _numHeads = numHeads;
-        _maxSeqLength = maxSeqLength;
+        _vocabSize = _options.VocabSize;
+        _modelDimension = _options.ModelDimension;
+        _numLayers = _options.NumLayers;
+        _numHeads = _options.NumHeads;
+        _maxSeqLength = _options.MaxSequenceLength;
         // xLSTM (Beck et al., 2024, S4.1) trains with AdamW. No optimizer was wired here at all, so
         // training fell through to the framework default and barely moved: across the memorization
         // task the loss drifted only 0.13% between one and two iterations, leaving the more-data

--- a/src/NeuralNetworks/Zamba2LanguageModel.cs
+++ b/src/NeuralNetworks/Zamba2LanguageModel.cs
@@ -69,15 +69,8 @@ public partial class Zamba2LanguageModel<T> : TokenLanguageModelLayoutBase<T>
 
     public Zamba2LanguageModel(
         NeuralNetworkArchitecture<T> architecture,
-        int vocabSize = 32000,
-        int modelDimension = 3584,
-        int numLayers = 81,
-        int stateDimension = 64,
-        int numHeads = 32,
-        int attentionInterval = 6,
-        int maxSeqLength = 4096,
-        ILossFunction<T>? lossFunction = null,
-        Zamba2Options? options = null)
+        Zamba2Options? options = null,
+        ILossFunction<T>? lossFunction = null)
         : base(architecture,
             // Zamba-2's LM head emits RAW LOGITS (DenseLayer with no activation, see
             // LayerHelper.CreateZamba2Layers), so the loss must be cross-entropy-with-logits (fused
@@ -89,14 +82,15 @@ public partial class Zamba2LanguageModel<T> : TokenLanguageModelLayoutBase<T>
             lossFunction ?? new AiDotNet.LossFunctions.CrossEntropyWithLogitsLoss<T>())
     {
         _options = options ?? new Zamba2Options();
+        _options.Validate();
         Options = _options;
-        _vocabSize = vocabSize;
-        _modelDimension = modelDimension;
-        _numLayers = numLayers;
-        _stateDimension = stateDimension;
-        _numHeads = numHeads;
-        _attentionInterval = attentionInterval;
-        _maxSeqLength = maxSeqLength;
+        _vocabSize = _options.VocabSize;
+        _modelDimension = _options.ModelDimension;
+        _numLayers = _options.NumLayers;
+        _stateDimension = _options.StateDimension;
+        _numHeads = _options.NumHeads;
+        _attentionInterval = _options.AttentionInterval;
+        _maxSeqLength = _options.MaxSequenceLength;
         InitializeLayers();
     }
 

--- a/src/NeuralNetworks/ZambaLanguageModel.cs
+++ b/src/NeuralNetworks/ZambaLanguageModel.cs
@@ -68,14 +68,8 @@ public partial class ZambaLanguageModel<T> : TokenLanguageModelLayoutBase<T>
 
     public ZambaLanguageModel(
         NeuralNetworkArchitecture<T> architecture,
-        int vocabSize = 32000,
-        int modelDimension = 3712,
-        int numLayers = 76,
-        int stateDimension = 16,
-        int attentionInterval = 6,
-        int maxSeqLength = 4096,
-        ILossFunction<T>? lossFunction = null,
-        ZambaOptions? options = null)
+        ZambaOptions? options = null,
+        ILossFunction<T>? lossFunction = null)
         : base(architecture,
             // Zamba's LM head emits RAW LOGITS (DenseLayer with no activation, see
             // LayerHelper.CreateZambaLayers), so the loss must be cross-entropy-with-logits (fused
@@ -87,13 +81,14 @@ public partial class ZambaLanguageModel<T> : TokenLanguageModelLayoutBase<T>
             lossFunction ?? new AiDotNet.LossFunctions.CrossEntropyWithLogitsLoss<T>())
     {
         _options = options ?? new ZambaOptions();
+        _options.Validate();
         Options = _options;
-        _vocabSize = vocabSize;
-        _modelDimension = modelDimension;
-        _numLayers = numLayers;
-        _stateDimension = stateDimension;
-        _attentionInterval = attentionInterval;
-        _maxSeqLength = maxSeqLength;
+        _vocabSize = _options.VocabSize;
+        _modelDimension = _options.ModelDimension;
+        _numLayers = _options.NumLayers;
+        _stateDimension = _options.StateDimension;
+        _attentionInterval = _options.AttentionInterval;
+        _maxSeqLength = _options.MaxSequenceLength;
         InitializeLayers();
     }
 

--- a/src/SpeechRecognition/ConformerFamily/ContextNetOptions.cs
+++ b/src/SpeechRecognition/ConformerFamily/ContextNetOptions.cs
@@ -119,7 +119,7 @@ public class ContextNetOptions : ModelOptions
     private static string[] GetDefaultVocabulary() => new[] { "<blank>", "<pad>", "<s>", "</s>", "<unk>", "|", "a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o", "p", "q", "r", "s", "t", "u", "v", "w", "x", "y", "z", "'", " " };
 
     /// <summary>Validates the configuration.</summary>
-    /// <exception cref="ArgumentException">The vocabulary and its declared size disagree.</exception>
+    /// <exception cref="InvalidOperationException">The vocabulary and its declared size disagree.</exception>
     /// <remarks>
     /// A size that does not match the token list is not recoverable at decode time: the output layer
     /// emits ids the vocabulary cannot name, and the only options left are to drop them silently or to

--- a/src/SpeechRecognition/ConformerFamily/ContextNetOptions.cs
+++ b/src/SpeechRecognition/ConformerFamily/ContextNetOptions.cs
@@ -119,7 +119,7 @@ public class ContextNetOptions : ModelOptions
     private static string[] GetDefaultVocabulary() => new[] { "<blank>", "<pad>", "<s>", "</s>", "<unk>", "|", "a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o", "p", "q", "r", "s", "t", "u", "v", "w", "x", "y", "z", "'", " " };
 
     /// <summary>Validates the configuration.</summary>
-    /// <exception cref="InvalidOperationException">The vocabulary and its declared size disagree.</exception>
+    /// <exception cref="ArgumentException">The vocabulary and its declared size disagree.</exception>
     /// <remarks>
     /// A size that does not match the token list is not recoverable at decode time: the output layer
     /// emits ids the vocabulary cannot name, and the only options left are to drop them silently or to

--- a/src/SpeechRecognition/ConformerFamily/RWKVTransducerOptions.cs
+++ b/src/SpeechRecognition/ConformerFamily/RWKVTransducerOptions.cs
@@ -165,7 +165,7 @@ public class RWKVTransducerOptions : ModelOptions
     private static string[] GetDefaultVocabulary() => new[] { "<blank>", "<pad>", "<s>", "</s>", "<unk>", "|", "a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o", "p", "q", "r", "s", "t", "u", "v", "w", "x", "y", "z", "'", " " };
 
     /// <summary>Validates the configuration.</summary>
-    /// <exception cref="InvalidOperationException">The vocabulary and its declared size disagree.</exception>
+    /// <exception cref="ArgumentException">The vocabulary and its declared size disagree.</exception>
     public void Validate()
     {
         if (Vocabulary is null || Vocabulary.Length == 0)

--- a/src/SpeechRecognition/ConformerFamily/RWKVTransducerOptions.cs
+++ b/src/SpeechRecognition/ConformerFamily/RWKVTransducerOptions.cs
@@ -165,7 +165,7 @@ public class RWKVTransducerOptions : ModelOptions
     private static string[] GetDefaultVocabulary() => new[] { "<blank>", "<pad>", "<s>", "</s>", "<unk>", "|", "a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o", "p", "q", "r", "s", "t", "u", "v", "w", "x", "y", "z", "'", " " };
 
     /// <summary>Validates the configuration.</summary>
-    /// <exception cref="ArgumentException">The vocabulary and its declared size disagree.</exception>
+    /// <exception cref="InvalidOperationException">The vocabulary and its declared size disagree.</exception>
     public void Validate()
     {
         if (Vocabulary is null || Vocabulary.Length == 0)

--- a/src/Video/Options/VideoHyperparameterOptions.cs
+++ b/src/Video/Options/VideoHyperparameterOptions.cs
@@ -1,0 +1,106 @@
+using AiDotNet.Models.Options;
+
+namespace AiDotNet.Video.Options;
+
+/// <summary>
+/// Shared configuration for video models: action recognition, segmentation, generation,
+/// super-resolution, frame interpolation, tracking, denoising, inpainting and depth.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>For Beginners:</b> Video models work on several frames at once rather than a single
+/// picture, so on top of the usual size settings they need to know how many frames they look
+/// at together. Each model's own options class ships the values from its paper, so you do not
+/// normally set any of these.
+/// </para>
+/// <para>
+/// Derived options classes assign their paper's values in their parameterless constructor.
+/// See <see cref="ModelHyperparameterOptions"/> for why these properties are non-nullable.
+/// </para>
+/// <para>
+/// <b>Not to be confused with <c>VideoModelOptions&lt;T&gt;</c>,</b> which is an earlier and
+/// now largely abandoned attempt at the same idea: it takes a type parameter it never uses,
+/// follows the nullable + <c>Effective*</c> pattern this design moves away from, and is
+/// derived from by exactly one of the 108 options classes under <c>src/Video/Options</c>
+/// (96 of them derive straight from <c>NeuralNetworkOptions</c> instead). It is left in place
+/// for now and removed when the video models are wired to this base.
+/// </para>
+/// </remarks>
+public abstract class VideoHyperparameterOptions : ModelHyperparameterOptions
+{
+    /// <summary>
+    /// Gets or sets the width of the model's main feature representation.
+    /// </summary>
+    /// <remarks>
+    /// <para><b>For Beginners:</b> How many numbers the model uses to describe what it sees at
+    /// each position. This is the most common size knob across the video models — wider
+    /// captures more, and costs proportionally more memory.</para>
+    /// </remarks>
+    public int NumFeatures { get; set; }
+
+    /// <summary>
+    /// Gets or sets the number of stacked blocks in the model.
+    /// </summary>
+    public int NumLayers { get; set; }
+
+    /// <summary>
+    /// Gets or sets how many consecutive frames the model processes together.
+    /// </summary>
+    /// <remarks>
+    /// <para><b>For Beginners:</b> A single frame cannot show motion. Models look at a short
+    /// stack of frames — commonly 8 or 16 — so they can tell a person sitting down from a
+    /// person standing up.</para>
+    /// </remarks>
+    public int NumFrames { get; set; }
+
+    /// <summary>
+    /// Gets or sets the width of the embedding produced for each token or patch.
+    /// </summary>
+    public int EmbedDim { get; set; }
+
+    /// <summary>
+    /// Gets or sets the number of attention heads.
+    /// </summary>
+    public int NumHeads { get; set; }
+
+    /// <summary>
+    /// Gets or sets the number of output categories, for classification models.
+    /// </summary>
+    /// <remarks>
+    /// <para><b>For Beginners:</b> Action-recognition models trained on the Kinetics-400
+    /// dataset predict one of 400 actions, so they use 400 here.</para>
+    /// </remarks>
+    public int NumClasses { get; set; }
+
+    /// <summary>
+    /// Gets or sets the upscaling factor, for super-resolution models.
+    /// </summary>
+    /// <remarks>
+    /// <para><b>For Beginners:</b> A factor of 4 turns a 480p video into roughly 1920p by
+    /// quadrupling each side.</para>
+    /// </remarks>
+    public int ScaleFactor { get; set; }
+
+    /// <summary>
+    /// Gets or sets the number of refinement passes, for models that iterate towards an
+    /// answer (optical flow, diffusion sampling).
+    /// </summary>
+    /// <remarks>
+    /// <para><b>For Beginners:</b> Some models improve their own answer repeatedly rather than
+    /// producing it in one go. More passes means better quality and slower inference.</para>
+    /// </remarks>
+    public int NumIterations { get; set; }
+
+    /// <summary>
+    /// Throws if a dimension every video model requires has been left unset.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when a required dimension is zero or negative, which means the derived options
+    /// class did not assign its paper defaults.
+    /// </exception>
+    protected void ValidateCore()
+    {
+        Require(NumFeatures, nameof(NumFeatures));
+        Require(NumFrames, nameof(NumFrames));
+    }
+}

--- a/src/Video/Options/VideoHyperparameterOptions.cs
+++ b/src/Video/Options/VideoHyperparameterOptions.cs
@@ -94,7 +94,7 @@ public abstract class VideoHyperparameterOptions : ModelHyperparameterOptions
     /// <summary>
     /// Throws if a dimension every video model requires has been left unset.
     /// </summary>
-    /// <exception cref="InvalidOperationException">
+    /// <exception cref="ArgumentException">
     /// Thrown when a required dimension is zero or negative, which means the derived options
     /// class did not assign its paper defaults.
     /// </exception>

--- a/tests/AiDotNet.Tests/IntegrationTests/Configuration/OptionsSurfaceRatchetTests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/Configuration/OptionsSurfaceRatchetTests.cs
@@ -43,7 +43,7 @@ public class OptionsSurfaceRatchetTests
     /// add a property to that model's options class instead.
     /// </para>
     /// <para>
-    /// Phase 2 lowered this from 1067 to 1004 by migrating 11 sequence models (63 params).
+    /// Phase 2 lowered this from 1067 to 977 by migrating all 17 sequence models (90 params).
     /// Originally established by this test's first run against master on 2026-09-08. A file-based
     /// estimate of the three areas named in the #2090 spec put it at 806; this reflection
     /// measurement found 1067, because the defect also reaches models the file scan never
@@ -54,7 +54,7 @@ public class OptionsSurfaceRatchetTests
     /// models read them.
     /// </para>
     /// </remarks>
-    private const int Baseline = 1004;
+    private const int Baseline = 977;
 
     /// <summary>
     /// How far the measured count may sit below <see cref="Baseline"/> before the test insists

--- a/tests/AiDotNet.Tests/IntegrationTests/Configuration/OptionsSurfaceRatchetTests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/Configuration/OptionsSurfaceRatchetTests.cs
@@ -46,7 +46,7 @@ public class OptionsSurfaceRatchetTests
     /// Phase 2 took this from 1067 to 977 (17 sequence models, 90 params); phase 3 to 875
     /// (11 vision-language models, 102 params), then 861 once enum- and string-typed
     /// parameters were migrated too and VisionMambaModel was picked up; phase 4a to 782
-    /// (11 embedding and retrieval models, 77 params).
+    /// (11 embedding and retrieval models, 77 params); phase 4b to 741 (10 GANs, 41 params).
     /// Originally established by this test's first run against master on 2026-09-08. A file-based
     /// estimate of the three areas named in the #2090 spec put it at 806; this reflection
     /// measurement found 1067, because the defect also reaches models the file scan never
@@ -57,7 +57,7 @@ public class OptionsSurfaceRatchetTests
     /// models read them.
     /// </para>
     /// </remarks>
-    private const int Baseline = 782;
+    private const int Baseline = 741;
 
     /// <summary>
     /// How far the measured count may sit below <see cref="Baseline"/> before the test insists

--- a/tests/AiDotNet.Tests/IntegrationTests/Configuration/OptionsSurfaceRatchetTests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/Configuration/OptionsSurfaceRatchetTests.cs
@@ -43,7 +43,8 @@ public class OptionsSurfaceRatchetTests
     /// add a property to that model's options class instead.
     /// </para>
     /// <para>
-    /// Phase 2 lowered this from 1067 to 977 by migrating all 17 sequence models (90 params).
+    /// Phase 2 took this from 1067 to 977 (17 sequence models, 90 params); phase 3 to 875
+    /// (11 vision-language models, 102 params).
     /// Originally established by this test's first run against master on 2026-09-08. A file-based
     /// estimate of the three areas named in the #2090 spec put it at 806; this reflection
     /// measurement found 1067, because the defect also reaches models the file scan never
@@ -54,7 +55,7 @@ public class OptionsSurfaceRatchetTests
     /// models read them.
     /// </para>
     /// </remarks>
-    private const int Baseline = 977;
+    private const int Baseline = 875;
 
     /// <summary>
     /// How far the measured count may sit below <see cref="Baseline"/> before the test insists

--- a/tests/AiDotNet.Tests/IntegrationTests/Configuration/OptionsSurfaceRatchetTests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/Configuration/OptionsSurfaceRatchetTests.cs
@@ -1,0 +1,324 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using AiDotNet.Models.Options;
+using AiDotNet.NeuralNetworks;
+using Xunit;
+
+namespace AiDotNet.Tests.IntegrationTests.Configuration;
+
+/// <summary>
+/// Ratchet for the model configuration surface (issue #2090).
+/// </summary>
+/// <remarks>
+/// <para>
+/// Model options classes are meant to be the only user-facing configuration surface for
+/// model-specific parameters. Today most models take their tunable values as defaulted
+/// constructor parameters instead, and the options object they are handed is stored,
+/// returned by <c>GetOptions()</c>, and never read.
+/// </para>
+/// <para>
+/// This test counts the gap and refuses to let it grow. As each model family is migrated,
+/// <see cref="Baseline"/> comes down. It is deliberately a count rather than a whitelist:
+/// a whitelist gets appended to without thought, whereas a number that may only ever
+/// decrease forces the choice to be explicit.
+/// </para>
+/// <para>
+/// The count is computed by reflection rather than by scanning source, so it needs no
+/// documentation to exist and cannot be defeated by deleting doc comments.
+/// </para>
+/// </remarks>
+public class OptionsSurfaceRatchetTests
+{
+    /// <summary>
+    /// Number of tunable defaulted constructor parameters that have no correspondingly-named
+    /// property on their model's options type.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>Lower this number when you migrate a model family; never raise it.</b> If this test
+    /// fails saying the count went up, you added a tunable parameter to a model constructor —
+    /// add a property to that model's options class instead.
+    /// </para>
+    /// <para>
+    /// Established by this test's first run against master on 2026-09-08. A file-based
+    /// estimate of the three areas named in the #2090 spec put it at 806; this reflection
+    /// measurement found 1067, because the defect also reaches models the file scan never
+    /// examined — Tacotron2Model, TtsModel and VITSModel each carry 16-20 tunable parameters
+    /// against a generic OnnxModelOptions, and SpeechEmotionRecognizer takes 11 with no
+    /// options parameter at all. Those areas looked healthy when measured by whether their
+    /// Options classes declare properties, which is a different question from whether the
+    /// models read them.
+    /// </para>
+    /// </remarks>
+    private const int Baseline = 1067;
+
+    /// <summary>
+    /// How far the measured count may sit below <see cref="Baseline"/> before the test insists
+    /// the baseline be lowered. Keeps ordinary refactoring from being blocked by an
+    /// off-by-a-couple drift while still forcing real progress to be recorded.
+    /// </summary>
+    private const int Slack = 10;
+
+    /// <summary>
+    /// Constructor parameters that are collaborators or artifacts rather than hyperparameters.
+    /// </summary>
+    private static readonly HashSet<string> ExcludedParameterNames =
+        new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        {
+            "modelIdentity", "modelPath", "name", "seed", "checkpointPath", "weightsPath",
+        };
+
+    /// <summary>
+    /// Types that are not models in the sense this ratchet cares about: architecture
+    /// descriptors, whose topology knobs belong on the architecture per the design, and
+    /// compiled-model hosts, whose parameters describe an artifact rather than a model.
+    /// </summary>
+    private static readonly HashSet<string> ExcludedTypeNames =
+        new HashSet<string>(StringComparer.Ordinal)
+        {
+            "NeuralNetworkArchitecture",
+            "TransformerArchitecture",
+            "DualStreamArchitecture",
+            "TripleStreamArchitecture",
+            "AudioTextDualStreamArchitecture",
+            "CompiledModelHost",
+            "ChainedCompiledModelHost",
+        };
+
+    [Fact]
+    public void ModelConstructorParametersHaveOptionsEquivalents_DoesNotRegress()
+    {
+        var gaps = MeasureGaps();
+        int count = gaps.Count;
+
+        Assert.True(
+            count <= Baseline,
+            BuildFailureMessage(
+                $"The options-surface gap grew from {Baseline} to {count}.",
+                "A model constructor gained a tunable defaulted parameter. Put the value on that "
+                    + "model's Options class instead, and have the constructor read it.",
+                gaps));
+
+        Assert.True(
+            count >= Baseline - Slack,
+            BuildFailureMessage(
+                $"The options-surface gap fell from {Baseline} to {count}. That is the goal — "
+                    + $"now lower the Baseline constant in {nameof(OptionsSurfaceRatchetTests)} to {count}.",
+                "The baseline only descends deliberately, so that progress is recorded in the "
+                    + "diff rather than silently absorbed.",
+                gaps));
+    }
+
+    /// <summary>
+    /// Pins the fix rather than its shape: a property that exists but is ignored still leaves
+    /// the model unconfigurable, which is the exact defect this work addresses.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Enabled in phase 2, when the first model family is wired to read its options. Until
+    /// then there is nothing for it to assert against — no model reads a value off its options
+    /// object, so every case would fail for the reason the ratchet above already records.
+    /// </para>
+    /// </remarks>
+    [Fact(Skip = "Enabled in phase 2 of #2090, when the first model family reads its options.")]
+    public void SettingAnOptionsPropertyChangesTheModel()
+    {
+        throw new NotImplementedException(
+            "Phase 2: for each migrated model, constructing it with a non-default Options value "
+                + "must produce a model whose GetOptions() returns that value and whose layer "
+                + "stack differs from the default-constructed one.");
+    }
+
+    /// <summary>
+    /// Reports the current gap, so a migration PR can see exactly what remains.
+    /// </summary>
+    [Fact]
+    public void ReportRemainingGaps()
+    {
+        var gaps = MeasureGaps();
+        var byType = gaps.GroupBy(g => g.TypeName)
+            .OrderByDescending(g => g.Count())
+            .ThenBy(g => g.Key, StringComparer.Ordinal)
+            .ToList();
+
+        // Not an assertion about the contents — this exists so the numbers are visible in the
+        // test output when a migration lands, without having to run the scanner by hand.
+        Assert.True(byType.Count >= 0);
+    }
+
+    private sealed class Gap
+    {
+        public string TypeName { get; set; } = string.Empty;
+
+        public string ParameterName { get; set; } = string.Empty;
+
+        public string OptionsTypeName { get; set; } = string.Empty;
+    }
+
+    /// <summary>
+    /// Every concrete model type in the AiDotNet assembly, found by walking the base chain.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Most models do not name <c>NeuralNetworkBase&lt;T&gt;</c> directly: <c>BGE</c> derives
+    /// from <c>TransformerEmbeddingNetwork</c>, <c>MambaLanguageModel</c> from
+    /// <c>TokenLanguageModelLayoutBase</c>, <c>TrOCR</c> from
+    /// <c>DocumentNeuralNetworkBase</c>. A search of the source for the base name finds only a
+    /// handful of files, so no naming or path heuristic identifies models correctly — walking
+    /// the inheritance chain is the only approach that does.
+    /// </para>
+    /// </remarks>
+    private static IEnumerable<Type> GetModelTypes()
+    {
+        Type[] types;
+        try
+        {
+            types = typeof(NeuralNetworkBase<>).Assembly.GetTypes();
+        }
+        catch (ReflectionTypeLoadException ex)
+        {
+            // A type that fails to load cannot be measured, but the ones that did load still can.
+            types = ex.Types.Where(t => t != null).ToArray()!;
+        }
+
+        foreach (var type in types)
+        {
+            if (type == null || type.IsAbstract || type.IsInterface || !type.IsClass) continue;
+            if (!type.IsPublic && !type.IsNestedPublic) continue;
+
+            string simpleName = StripArity(type.Name);
+            if (ExcludedTypeNames.Contains(simpleName)) continue;
+
+            if (DerivesFromNeuralNetworkBase(type)) yield return type;
+        }
+    }
+
+    private static bool DerivesFromNeuralNetworkBase(Type type)
+    {
+        for (var current = type.BaseType; current != null; current = current.BaseType)
+        {
+            if (current.IsGenericType
+                && current.GetGenericTypeDefinition() == typeof(NeuralNetworkBase<>))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static List<Gap> MeasureGaps()
+    {
+        var gaps = new List<Gap>();
+
+        foreach (var model in GetModelTypes())
+        {
+            Type? optionsType = null;
+            var tunable = new Dictionary<string, ParameterInfo>(StringComparer.Ordinal);
+
+            foreach (var ctor in model.GetConstructors(BindingFlags.Public | BindingFlags.Instance))
+            {
+                foreach (var parameter in ctor.GetParameters())
+                {
+                    var parameterType = Nullable.GetUnderlyingType(parameter.ParameterType)
+                        ?? parameter.ParameterType;
+
+                    if (IsOptionsType(parameterType))
+                    {
+                        optionsType ??= parameterType;
+                        continue;
+                    }
+
+                    if (!parameter.HasDefaultValue) continue;
+                    if (parameter.Name == null) continue;
+                    if (ExcludedParameterNames.Contains(parameter.Name)) continue;
+                    if (!IsTunable(parameterType)) continue;
+
+                    // Union across overloads: the same knob offered by two constructors is one gap.
+                    if (!tunable.ContainsKey(parameter.Name)) tunable[parameter.Name] = parameter;
+                }
+            }
+
+            if (tunable.Count == 0) continue;
+
+            var optionsProperties = optionsType == null
+                ? new HashSet<string>(StringComparer.Ordinal)
+                : new HashSet<string>(
+                    optionsType.GetProperties(BindingFlags.Public | BindingFlags.Instance)
+                        .Select(p => p.Name),
+                    StringComparer.Ordinal);
+
+            foreach (var parameterName in tunable.Keys)
+            {
+                if (optionsProperties.Contains(ToPascalCase(parameterName))) continue;
+
+                gaps.Add(new Gap
+                {
+                    TypeName = StripArity(model.Name),
+                    ParameterName = parameterName,
+                    OptionsTypeName = optionsType == null ? "(no options parameter)" : StripArity(optionsType.Name),
+                });
+            }
+        }
+
+        return gaps;
+    }
+
+    /// <summary>
+    /// A parameter carries a hyperparameter when it is a scalar or an enum. Interfaces,
+    /// delegates and model classes are collaborators, not configuration.
+    /// </summary>
+    private static bool IsTunable(Type type)
+    {
+        if (type.IsEnum) return true;
+
+        return type == typeof(int) || type == typeof(long) || type == typeof(double)
+            || type == typeof(float) || type == typeof(bool) || type == typeof(decimal)
+            || type == typeof(string);
+    }
+
+    private static bool IsOptionsType(Type type)
+    {
+        if (typeof(ModelOptions).IsAssignableFrom(type)) return true;
+
+        // Some options classes predate the ModelOptions hierarchy and stand alone.
+        return type.Name.StartsWith("Options", StringComparison.Ordinal)
+            || StripArity(type.Name).EndsWith("Options", StringComparison.Ordinal);
+    }
+
+    private static string StripArity(string typeName)
+    {
+        int tick = typeName.IndexOf('`');
+        return tick < 0 ? typeName : typeName.Substring(0, tick);
+    }
+
+    private static string ToPascalCase(string parameterName)
+    {
+        if (parameterName.Length == 0) return parameterName;
+        return char.ToUpperInvariant(parameterName[0]) + parameterName.Substring(1);
+    }
+
+    private static string BuildFailureMessage(string headline, string guidance, List<Gap> gaps)
+    {
+        var message = new StringBuilder();
+        message.AppendLine(headline);
+        message.AppendLine(guidance);
+        message.AppendLine();
+        message.AppendLine("Largest remaining gaps:");
+
+        foreach (var group in gaps.GroupBy(g => g.TypeName)
+                     .OrderByDescending(g => g.Count())
+                     .ThenBy(g => g.Key, StringComparer.Ordinal)
+                     .Take(15))
+        {
+            message.AppendLine(
+                $"  {group.Key} ({group.Count()}) options={group.First().OptionsTypeName}: "
+                    + string.Join(", ", group.Select(g => g.ParameterName).Take(8)));
+        }
+
+        return message.ToString();
+    }
+}

--- a/tests/AiDotNet.Tests/IntegrationTests/Configuration/OptionsSurfaceRatchetTests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/Configuration/OptionsSurfaceRatchetTests.cs
@@ -43,7 +43,8 @@ public class OptionsSurfaceRatchetTests
     /// add a property to that model's options class instead.
     /// </para>
     /// <para>
-    /// Established by this test's first run against master on 2026-09-08. A file-based
+    /// Phase 2 lowered this from 1067 to 1004 by migrating 11 sequence models (63 params).
+    /// Originally established by this test's first run against master on 2026-09-08. A file-based
     /// estimate of the three areas named in the #2090 spec put it at 806; this reflection
     /// measurement found 1067, because the defect also reaches models the file scan never
     /// examined — Tacotron2Model, TtsModel and VITSModel each carry 16-20 tunable parameters
@@ -53,7 +54,7 @@ public class OptionsSurfaceRatchetTests
     /// models read them.
     /// </para>
     /// </remarks>
-    private const int Baseline = 1067;
+    private const int Baseline = 1004;
 
     /// <summary>
     /// How far the measured count may sit below <see cref="Baseline"/> before the test insists

--- a/tests/AiDotNet.Tests/IntegrationTests/Configuration/OptionsSurfaceRatchetTests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/Configuration/OptionsSurfaceRatchetTests.cs
@@ -45,7 +45,8 @@ public class OptionsSurfaceRatchetTests
     /// <para>
     /// Phase 2 took this from 1067 to 977 (17 sequence models, 90 params); phase 3 to 875
     /// (11 vision-language models, 102 params), then 861 once enum- and string-typed
-    /// parameters were migrated too and VisionMambaModel was picked up.
+    /// parameters were migrated too and VisionMambaModel was picked up; phase 4a to 782
+    /// (11 embedding and retrieval models, 77 params).
     /// Originally established by this test's first run against master on 2026-09-08. A file-based
     /// estimate of the three areas named in the #2090 spec put it at 806; this reflection
     /// measurement found 1067, because the defect also reaches models the file scan never
@@ -56,7 +57,7 @@ public class OptionsSurfaceRatchetTests
     /// models read them.
     /// </para>
     /// </remarks>
-    private const int Baseline = 861;
+    private const int Baseline = 782;
 
     /// <summary>
     /// How far the measured count may sit below <see cref="Baseline"/> before the test insists

--- a/tests/AiDotNet.Tests/IntegrationTests/Configuration/OptionsSurfaceRatchetTests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/Configuration/OptionsSurfaceRatchetTests.cs
@@ -44,7 +44,8 @@ public class OptionsSurfaceRatchetTests
     /// </para>
     /// <para>
     /// Phase 2 took this from 1067 to 977 (17 sequence models, 90 params); phase 3 to 875
-    /// (11 vision-language models, 102 params).
+    /// (11 vision-language models, 102 params), then 861 once enum- and string-typed
+    /// parameters were migrated too and VisionMambaModel was picked up.
     /// Originally established by this test's first run against master on 2026-09-08. A file-based
     /// estimate of the three areas named in the #2090 spec put it at 806; this reflection
     /// measurement found 1067, because the defect also reaches models the file scan never
@@ -55,7 +56,7 @@ public class OptionsSurfaceRatchetTests
     /// models read them.
     /// </para>
     /// </remarks>
-    private const int Baseline = 875;
+    private const int Baseline = 861;
 
     /// <summary>
     /// How far the measured count may sit below <see cref="Baseline"/> before the test insists

--- a/tests/AiDotNet.Tests/IntegrationTests/NeuralNetworks/AdvancedNeuralNetworkModelsIntegrationTests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/NeuralNetworks/AdvancedNeuralNetworkModelsIntegrationTests.cs
@@ -1,4 +1,5 @@
 using AiDotNet.ActivationFunctions;
+using AiDotNet.NeuralNetworks.Options;
 using AiDotNet.AutoML.SearchSpace;
 using AiDotNet.Configuration;
 using AiDotNet.Enums;
@@ -4292,10 +4293,7 @@ public class AdvancedNeuralNetworkModelsIntegrationTests
             inputSize: 256,
             outputSize: 128);
 
-        var avNet = new AudioVisualCorrespondenceNetwork<float>(
-            architecture,
-            embeddingDimension: 64,
-            numEncoderLayers: 2);
+        var avNet = new AudioVisualCorrespondenceNetwork<float>(architecture, options: new AudioVisualCorrespondenceOptions { EmbeddingDimension = 64, NumEncoderLayers = 2 });
 
         // Combined audio-visual input
         var input = CreateRandomTensor([1, 256]);
@@ -4320,7 +4318,7 @@ public class AdvancedNeuralNetworkModelsIntegrationTests
             inputSize: 256,
             outputSize: 128);
 
-        var avNet = new AudioVisualCorrespondenceNetwork<float>(architecture, embeddingDimension: 64, numEncoderLayers: 2);
+        var avNet = new AudioVisualCorrespondenceNetwork<float>(architecture, options: new AudioVisualCorrespondenceOptions { EmbeddingDimension = 64, NumEncoderLayers = 2 });
 
         // Act
         int parameterCount = (int)avNet.ParameterCount;
@@ -4345,11 +4343,7 @@ public class AdvancedNeuralNetworkModelsIntegrationTests
             inputSize: 256,
             outputSize: 10);  // 10 event classes
 
-        var avelNet = new AudioVisualEventLocalizationNetwork<float>(
-            architecture,
-            embeddingDimension: 64,
-            numEncoderLayers: 2,
-            eventCategories: new[] { "speech", "music", "noise", "silence", "ambient" });
+        var avelNet = new AudioVisualEventLocalizationNetwork<float>(architecture, eventCategories: new[] { "speech", "music", "noise", "silence", "ambient" }, options: new AudioVisualEventLocalizationOptions { EmbeddingDimension = 64, NumEncoderLayers = 2 });
 
         var input = CreateRandomTensor([1, 256]);
 
@@ -4373,7 +4367,7 @@ public class AdvancedNeuralNetworkModelsIntegrationTests
             inputSize: 256,
             outputSize: 10);
 
-        var avelNet = new AudioVisualEventLocalizationNetwork<float>(architecture, embeddingDimension: 64, numEncoderLayers: 2);
+        var avelNet = new AudioVisualEventLocalizationNetwork<float>(architecture, options: new AudioVisualEventLocalizationOptions { EmbeddingDimension = 64, NumEncoderLayers = 2 });
 
         // Act
         int parameterCount = (int)avelNet.ParameterCount;
@@ -4397,19 +4391,7 @@ public class AdvancedNeuralNetworkModelsIntegrationTests
             inputSize: 256,
             outputSize: 10);
 
-        var blip = new BlipNeuralNetwork<float>(
-            architecture,
-            imageSize: 64,
-            channels: 3,
-            patchSize: 8,
-            vocabularySize: 1000,
-            maxSequenceLength: 16,
-            embeddingDimension: 64,
-            hiddenDim: 128,
-            numEncoderLayers: 2,
-            numDecoderLayers: 2,
-            numHeads: 4,
-            mlpDim: 256);
+        var blip = new BlipNeuralNetwork<float>(architecture, options: new BlipOptions { ImageSize = 64, Channels = 3, PatchSize = 8, VocabSize = 1000, MaxSequenceLength = 16, EmbeddingDimension = 64, HiddenDim = 128, NumEncoderLayers = 2, NumDecoderLayers = 2, NumHeads = 4, MlpDim = 256 });
 
         // Use image-like input: [channels, height, width] = [3, 64, 64]
         var input = CreateRandomTensor([3, 64, 64]);
@@ -4433,15 +4415,7 @@ public class AdvancedNeuralNetworkModelsIntegrationTests
             inputSize: 256,
             outputSize: 10);
 
-        var blip = new BlipNeuralNetwork<float>(
-            architecture,
-            imageSize: 64,
-            patchSize: 8,
-            embeddingDimension: 64,
-            hiddenDim: 128,
-            numEncoderLayers: 2,
-            numDecoderLayers: 2,
-            numHeads: 4);
+        var blip = new BlipNeuralNetwork<float>(architecture, options: new BlipOptions { ImageSize = 64, PatchSize = 8, EmbeddingDimension = 64, HiddenDim = 128, NumEncoderLayers = 2, NumDecoderLayers = 2, NumHeads = 4 });
 
         // Act
         int parameterCount = (int)blip.ParameterCount;
@@ -4461,21 +4435,7 @@ public class AdvancedNeuralNetworkModelsIntegrationTests
             inputSize: 256,
             outputSize: 10);
 
-        var blip2 = new Blip2NeuralNetwork<float>(
-            architecture,
-            imageSize: 56,
-            channels: 3,
-            patchSize: 14,
-            vocabularySize: 1000,
-            maxSequenceLength: 16,
-            embeddingDimension: 64,
-            qformerHiddenDim: 128,
-            visionHiddenDim: 128,
-            lmHiddenDim: 128,
-            numQformerLayers: 2,
-            numQueryTokens: 8,
-            numHeads: 4,
-            numLmDecoderLayers: 2);
+        var blip2 = new Blip2NeuralNetwork<float>(architecture, options: new Blip2Options { ImageSize = 56, Channels = 3, PatchSize = 14, VocabSize = 1000, MaxSequenceLength = 16, EmbeddingDimension = 64, QformerHiddenDim = 128, VisionHiddenDim = 128, LmHiddenDim = 128, NumQformerLayers = 2, NumQueryTokens = 8, NumHeads = 4, NumLmDecoderLayers = 2 });
 
         // Use image-like input: [channels, height, width]
         var input = CreateRandomTensor([3, 56, 56]);
@@ -4499,15 +4459,7 @@ public class AdvancedNeuralNetworkModelsIntegrationTests
             inputSize: 256,
             outputSize: 10);
 
-        var blip2 = new Blip2NeuralNetwork<float>(
-            architecture,
-            imageSize: 56,
-            patchSize: 14,
-            embeddingDimension: 64,
-            qformerHiddenDim: 128,
-            numQformerLayers: 2,
-            numQueryTokens: 8,
-            numHeads: 4);
+        var blip2 = new Blip2NeuralNetwork<float>(architecture, options: new Blip2Options { ImageSize = 56, PatchSize = 14, EmbeddingDimension = 64, QformerHiddenDim = 128, NumQformerLayers = 2, NumQueryTokens = 8, NumHeads = 4 });
 
         // Act
         int parameterCount = (int)blip2.ParameterCount;
@@ -4527,21 +4479,7 @@ public class AdvancedNeuralNetworkModelsIntegrationTests
             inputSize: 256,
             outputSize: 10);
 
-        var flamingo = new FlamingoNeuralNetwork<float>(
-            architecture,
-            embeddingDimension: 64,
-            maxSequenceLength: 32,
-            imageSize: 56,
-            channels: 3,
-            numPerceiverTokens: 8,
-            maxImagesInContext: 2,
-            visionHiddenDim: 64,
-            lmHiddenDim: 128,
-            numVisionLayers: 2,
-            numLmLayers: 2,
-            numHeads: 4,
-            vocabularySize: 1000,
-            numPerceiverLayers: 2);
+        var flamingo = new FlamingoNeuralNetwork<float>(architecture, options: new FlamingoOptions { EmbeddingDimension = 64, MaxSequenceLength = 32, ImageSize = 56, Channels = 3, NumPerceiverTokens = 8, MaxImagesInContext = 2, VisionHiddenDim = 64, LmHiddenDim = 128, NumVisionLayers = 2, NumLmLayers = 2, NumHeads = 4, VocabSize = 1000, NumPerceiverLayers = 2 });
 
         // Use image-like input
         var input = CreateRandomTensor([3, 56, 56]);
@@ -4565,15 +4503,7 @@ public class AdvancedNeuralNetworkModelsIntegrationTests
             inputSize: 256,
             outputSize: 10);
 
-        var flamingo = new FlamingoNeuralNetwork<float>(
-            architecture,
-            embeddingDimension: 64,
-            imageSize: 56,
-            visionHiddenDim: 64,
-            lmHiddenDim: 128,
-            numVisionLayers: 2,
-            numLmLayers: 2,
-            numHeads: 4);
+        var flamingo = new FlamingoNeuralNetwork<float>(architecture, options: new FlamingoOptions { EmbeddingDimension = 64, ImageSize = 56, VisionHiddenDim = 64, LmHiddenDim = 128, NumVisionLayers = 2, NumLmLayers = 2, NumHeads = 4 });
 
         // Act
         int parameterCount = (int)flamingo.ParameterCount;
@@ -4593,18 +4523,7 @@ public class AdvancedNeuralNetworkModelsIntegrationTests
             inputSize: 256,
             outputSize: 10);
 
-        var llava = new LLaVANeuralNetwork<float>(
-            architecture,
-            imageSize: 56,
-            channels: 3,
-            patchSize: 14,
-            vocabularySize: 1000,
-            maxSequenceLength: 32,
-            embeddingDimension: 128,
-            visionHiddenDim: 64,
-            numVisionLayers: 2,
-            numLmLayers: 2,
-            numHeads: 4);
+        var llava = new LLaVANeuralNetwork<float>(architecture, options: new LLaVAOptions { ImageSize = 56, Channels = 3, PatchSize = 14, VocabSize = 1000, MaxSequenceLength = 32, EmbeddingDimension = 128, VisionHiddenDim = 64, NumVisionLayers = 2, NumLmLayers = 2, NumHeads = 4 });
 
         // Use image-like input
         var input = CreateRandomTensor([3, 56, 56]);
@@ -4628,15 +4547,7 @@ public class AdvancedNeuralNetworkModelsIntegrationTests
             inputSize: 256,
             outputSize: 10);
 
-        var llava = new LLaVANeuralNetwork<float>(
-            architecture,
-            imageSize: 56,
-            patchSize: 14,
-            embeddingDimension: 128,
-            visionHiddenDim: 64,
-            numVisionLayers: 2,
-            numLmLayers: 2,
-            numHeads: 4);
+        var llava = new LLaVANeuralNetwork<float>(architecture, options: new LLaVAOptions { ImageSize = 56, PatchSize = 14, EmbeddingDimension = 128, VisionHiddenDim = 64, NumVisionLayers = 2, NumLmLayers = 2, NumHeads = 4 });
 
         // Act
         int parameterCount = (int)llava.ParameterCount;
@@ -4656,21 +4567,7 @@ public class AdvancedNeuralNetworkModelsIntegrationTests
             inputSize: 256,
             outputSize: 10);
 
-        var imageBind = new ImageBindNeuralNetwork<float>(
-            architecture,
-            imageSize: 56,
-            channels: 3,
-            patchSize: 14,
-            vocabularySize: 1000,
-            maxSequenceLength: 16,
-            embeddingDimension: 64,
-            hiddenDim: 128,
-            numEncoderLayers: 2,
-            numHeads: 4,
-            audioSampleRate: 16000,
-            audioMaxDuration: 2,
-            imuTimesteps: 100,
-            numVideoFrames: 2);
+        var imageBind = new ImageBindNeuralNetwork<float>(architecture, options: new ImageBindOptions { ImageSize = 56, Channels = 3, PatchSize = 14, VocabSize = 1000, MaxSequenceLength = 16, EmbeddingDimension = 64, HiddenDim = 128, NumEncoderLayers = 2, NumHeads = 4, AudioSampleRate = 16000, AudioMaxDuration = 2, ImuTimesteps = 100, NumVideoFrames = 2 });
 
         // Use image-like input
         var input = CreateRandomTensor([3, 56, 56]);
@@ -4694,14 +4591,7 @@ public class AdvancedNeuralNetworkModelsIntegrationTests
             inputSize: 256,
             outputSize: 10);
 
-        var imageBind = new ImageBindNeuralNetwork<float>(
-            architecture,
-            imageSize: 56,
-            patchSize: 14,
-            embeddingDimension: 64,
-            hiddenDim: 128,
-            numEncoderLayers: 2,
-            numHeads: 4);
+        var imageBind = new ImageBindNeuralNetwork<float>(architecture, options: new ImageBindOptions { ImageSize = 56, PatchSize = 14, EmbeddingDimension = 64, HiddenDim = 128, NumEncoderLayers = 2, NumHeads = 4 });
 
         // Act
         int parameterCount = (int)imageBind.ParameterCount;
@@ -4722,22 +4612,7 @@ public class AdvancedNeuralNetworkModelsIntegrationTests
             inputSize: 256,
             outputSize: 10);
 
-        var videoCLIP = new VideoCLIPNeuralNetwork<float>(
-            architecture,
-            imageSize: 56,
-            channels: 3,
-            patchSize: 14,
-            vocabularySize: 1000,
-            maxSequenceLength: 16,
-            embeddingDimension: 64,
-            visionHiddenDim: 128,
-            textHiddenDim: 64,
-            numFrameEncoderLayers: 2,
-            numTemporalLayers: 2,
-            numTextLayers: 2,
-            numHeads: 4,
-            numFrames: 4,
-            frameRate: 1.0);
+        var videoCLIP = new VideoCLIPNeuralNetwork<float>(architecture, options: new VideoCLIPOptions { ImageSize = 56, Channels = 3, PatchSize = 14, VocabSize = 1000, MaxSequenceLength = 16, EmbeddingDimension = 64, VisionHiddenDim = 128, TextHiddenDim = 64, NumFrameEncoderLayers = 2, NumTemporalLayers = 2, NumTextLayers = 2, NumHeads = 4, NumFrames = 4, FrameRate = 1.0 });
 
         // Use video-like input: [frames, channels, height, width]
         var input = CreateRandomTensor([4, 3, 56, 56]);
@@ -4762,18 +4637,7 @@ public class AdvancedNeuralNetworkModelsIntegrationTests
             inputSize: 256,
             outputSize: 10);
 
-        var videoCLIP = new VideoCLIPNeuralNetwork<float>(
-            architecture,
-            imageSize: 56,
-            patchSize: 14,
-            embeddingDimension: 64,
-            visionHiddenDim: 128,
-            textHiddenDim: 64,
-            numFrameEncoderLayers: 2,
-            numTemporalLayers: 2,
-            numTextLayers: 2,
-            numHeads: 4,
-            numFrames: 4);
+        var videoCLIP = new VideoCLIPNeuralNetwork<float>(architecture, options: new VideoCLIPOptions { ImageSize = 56, PatchSize = 14, EmbeddingDimension = 64, VisionHiddenDim = 128, TextHiddenDim = 64, NumFrameEncoderLayers = 2, NumTemporalLayers = 2, NumTextLayers = 2, NumHeads = 4, NumFrames = 4 });
 
         // Act
         int parameterCount = (int)videoCLIP.ParameterCount;
@@ -4794,12 +4658,7 @@ public class AdvancedNeuralNetworkModelsIntegrationTests
             inputSize: 256,
             outputSize: 10);
 
-        var unified = new UnifiedMultimodalNetwork<float>(
-            architecture,
-            embeddingDimension: 64,
-            maxSequenceLength: 32,
-            numTransformerLayers: 2,
-            seed: 42);
+        var unified = new UnifiedMultimodalNetwork<float>(architecture, seed: 42, options: new UnifiedMultimodalNetworkOptions { EmbeddingDimension = 64, MaxSequenceLength = 32, NumTransformerLayers = 2 });
 
         // Use simple 2D input
         var input = CreateRandomTensor([1, 64]);
@@ -4824,11 +4683,7 @@ public class AdvancedNeuralNetworkModelsIntegrationTests
             inputSize: 256,
             outputSize: 10);
 
-        var unified = new UnifiedMultimodalNetwork<float>(
-            architecture,
-            embeddingDimension: 64,
-            maxSequenceLength: 32,
-            numTransformerLayers: 2);
+        var unified = new UnifiedMultimodalNetwork<float>(architecture, options: new UnifiedMultimodalNetworkOptions { EmbeddingDimension = 64, MaxSequenceLength = 32, NumTransformerLayers = 2 });
 
         // Act
         int parameterCount = (int)unified.ParameterCount;
@@ -4851,21 +4706,7 @@ public class AdvancedNeuralNetworkModelsIntegrationTests
         // Create a simple tokenizer for testing
         var tokenizer = AiDotNet.Tokenization.ClipTokenizerFactory.CreateSimple();
 
-        var gpt4v = new Gpt4VisionNeuralNetwork<float>(
-            architecture,
-            tokenizer,
-            embeddingDimension: 128,
-            visionEmbeddingDim: 64,
-            maxSequenceLength: 32,
-            contextWindowSize: 256,
-            imageSize: 56,
-            hiddenDim: 128,
-            numVisionLayers: 2,
-            numLanguageLayers: 2,
-            numHeads: 4,
-            patchSize: 14,
-            vocabularySize: 1000,
-            maxImagesPerRequest: 2);
+        var gpt4v = new Gpt4VisionNeuralNetwork<float>(architecture, tokenizer, options: new Gpt4VisionOptions { EmbeddingDimension = 128, VisionEmbeddingDim = 64, MaxSequenceLength = 32, ContextWindowSize = 256, ImageSize = 56, HiddenDim = 128, NumVisionLayers = 2, NumLanguageLayers = 2, NumHeads = 4, PatchSize = 14, VocabSize = 1000, MaxImagesPerRequest = 2 });
 
         // Use image-like input
         var input = CreateRandomTensor([3, 56, 56]);
@@ -4891,17 +4732,7 @@ public class AdvancedNeuralNetworkModelsIntegrationTests
 
         var tokenizer = AiDotNet.Tokenization.ClipTokenizerFactory.CreateSimple();
 
-        var gpt4v = new Gpt4VisionNeuralNetwork<float>(
-            architecture,
-            tokenizer,
-            embeddingDimension: 128,
-            visionEmbeddingDim: 64,
-            imageSize: 56,
-            hiddenDim: 128,
-            numVisionLayers: 2,
-            numLanguageLayers: 2,
-            numHeads: 4,
-            patchSize: 14);
+        var gpt4v = new Gpt4VisionNeuralNetwork<float>(architecture, tokenizer, options: new Gpt4VisionOptions { EmbeddingDimension = 128, VisionEmbeddingDim = 64, ImageSize = 56, HiddenDim = 128, NumVisionLayers = 2, NumLanguageLayers = 2, NumHeads = 4, PatchSize = 14 });
 
         // Act
         int parameterCount = (int)gpt4v.ParameterCount;

--- a/tests/AiDotNet.Tests/IntegrationTests/NeuralNetworks/AdvancedNeuralNetworkModelsIntegrationTests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/NeuralNetworks/AdvancedNeuralNetworkModelsIntegrationTests.cs
@@ -1709,8 +1709,7 @@ public class AdvancedNeuralNetworkModelsIntegrationTests
             imageChannels: 1,
             imageHeight: 8,
             imageWidth: 8,
-            generatorFeatureMaps: 8,
-            discriminatorFeatureMaps: 8);
+            options: new DCGANOptions { GeneratorChannels = 8, DiscriminatorChannels = 8 });
 
         // Per Radford et al. 2015 §3, DCGAN's generator input is the latent
         // noise vector of size `latentSize`. The generator's first Dense layer
@@ -1738,8 +1737,7 @@ public class AdvancedNeuralNetworkModelsIntegrationTests
             imageChannels: 1,
             imageHeight: 8,
             imageWidth: 8,
-            generatorFeatureMaps: 8,
-            discriminatorFeatureMaps: 8);
+            options: new DCGANOptions { GeneratorChannels = 8, DiscriminatorChannels = 8 });
 
         // Act
         var generatorParams = dcgan.Generator.GetParameterCount();
@@ -2394,14 +2392,17 @@ public class AdvancedNeuralNetworkModelsIntegrationTests
         var biggan = new BigGAN<float>(
             generatorArchitecture,
             discriminatorArchitecture,
-            latentSize: 16,
-            numClasses: 10,
-            classEmbeddingDim: 8,
-            imageChannels: 1,
-            imageHeight: 8,
-            imageWidth: 8,
-            generatorChannels: 8,
-            discriminatorChannels: 8);
+            options: new BigGANOptions
+            {
+                LatentSize = 16,
+                NumClasses = 10,
+                ClassEmbeddingDim = 8,
+                ImageChannels = 1,
+                ImageHeight = 8,
+                ImageWidth = 8,
+                GeneratorChannels = 8,
+                DiscriminatorChannels = 8,
+            });
 
         // BigGAN expects 2D latent code [batch, latent_size]
         var noiseInput = CreateRandomTensor([1, 16]);
@@ -2443,12 +2444,15 @@ public class AdvancedNeuralNetworkModelsIntegrationTests
         var biggan = new BigGAN<float>(
             generatorArchitecture,
             discriminatorArchitecture,
-            latentSize: 16,
-            numClasses: 10,
-            classEmbeddingDim: 8,
-            imageChannels: 1,
-            imageHeight: 8,
-            imageWidth: 8);
+            options: new BigGANOptions
+            {
+                LatentSize = 16,
+                NumClasses = 10,
+                ClassEmbeddingDim = 8,
+                ImageChannels = 1,
+                ImageHeight = 8,
+                ImageWidth = 8,
+            });
 
         // Act
         int parameterCount = (int)biggan.ParameterCount;
@@ -2660,10 +2664,13 @@ public class AdvancedNeuralNetworkModelsIntegrationTests
         var progressiveGan = new ProgressiveGAN<float>(
             generatorArchitecture,
             discriminatorArchitecture,
-            latentSize: 16,
-            imageChannels: 1,
-            maxResolutionLevel: 2, // 16x16 max
-            baseFeatureMaps: 8);
+            options: new ProgressiveGANOptions
+            {
+                LatentSize = 16,
+                ImageChannels = 1,
+                MaxResolutionLevel = 2, // 16x16 max
+                GeneratorChannels = 8,
+            });
 
         var noiseInput = CreateRandomTensor([16]);
 
@@ -2702,10 +2709,13 @@ public class AdvancedNeuralNetworkModelsIntegrationTests
         var progressiveGan = new ProgressiveGAN<float>(
             generatorArchitecture,
             discriminatorArchitecture,
-            latentSize: 16,
-            imageChannels: 1,
-            maxResolutionLevel: 2,
-            baseFeatureMaps: 8);
+            options: new ProgressiveGANOptions
+            {
+                LatentSize = 16,
+                ImageChannels = 1,
+                MaxResolutionLevel = 2,
+                GeneratorChannels = 8,
+            });
 
         // Act
         int parameterCount = (int)progressiveGan.ParameterCount;
@@ -2741,12 +2751,15 @@ public class AdvancedNeuralNetworkModelsIntegrationTests
         var sagan = new SAGAN<float>(
             generatorArchitecture,
             discriminatorArchitecture,
-            latentSize: 16,
-            imageChannels: 1,
-            imageHeight: 8,
-            imageWidth: 8,
-            generatorChannels: 8,
-            discriminatorChannels: 8);
+            options: new SAGANOptions
+            {
+                LatentSize = 16,
+                ImageChannels = 1,
+                ImageHeight = 8,
+                ImageWidth = 8,
+                GeneratorChannels = 8,
+                DiscriminatorChannels = 8,
+            });
 
         var noiseInput = CreateRandomTensor([16]);
 
@@ -2787,10 +2800,13 @@ public class AdvancedNeuralNetworkModelsIntegrationTests
         var sagan = new SAGAN<float>(
             generatorArchitecture,
             discriminatorArchitecture,
-            latentSize: 16,
-            imageChannels: 1,
-            imageHeight: 8,
-            imageWidth: 8);
+            options: new SAGANOptions
+            {
+                LatentSize = 16,
+                ImageChannels = 1,
+                ImageHeight = 8,
+                ImageWidth = 8,
+            });
 
         // Act
         int parameterCount = (int)sagan.ParameterCount;

--- a/tests/AiDotNet.Tests/IntegrationTests/NeuralNetworks/FusedOptimizerIntegrationTests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/NeuralNetworks/FusedOptimizerIntegrationTests.cs
@@ -1,4 +1,5 @@
 using System;
+using AiDotNet.NeuralNetworks.Options;
 using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
@@ -866,7 +867,7 @@ public class FusedOptimizerIntegrationTests
         public FusedRecurrentGemmaTestModel(
             NeuralNetworkArchitecture<float> architecture,
             int vocabSize)
-            : base(architecture, vocabSize: vocabSize)
+            : base(architecture, new RecurrentGemmaOptions { VocabSize = vocabSize })
         {
         }
 

--- a/tests/AiDotNet.Tests/IntegrationTests/NeuralNetworks/MissingModelsIntegrationTests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/NeuralNetworks/MissingModelsIntegrationTests.cs
@@ -1,4 +1,5 @@
 using System;
+using AiDotNet.NeuralNetworks.Options;
 using System.IO;
 using AiDotNet.Data.Structures;
 using AiDotNet.Diffusion;
@@ -75,14 +76,7 @@ public class MissingModelsIntegrationTests
                 outputSize: embeddingDim);
 
             // Invalid ONNX models should throw during construction
-            Assert.ThrowsAny<Exception>(() => new ClipNeuralNetwork<float>(
-                architecture,
-                imagePath,
-                textPath,
-                tokenizer,
-                embeddingDimension: embeddingDim,
-                maxSequenceLength: 8,
-                imageSize: imageSize));
+            Assert.ThrowsAny<Exception>(() => new ClipNeuralNetwork<float>(architecture, imagePath, textPath, tokenizer, options: new ClipOptions { EmbeddingDimension = embeddingDim, MaxSequenceLength = 8, ImageSize = imageSize }));
         }
         finally
         {

--- a/tests/AiDotNet.Tests/IntegrationTests/NeuralNetworks/RecurrentGemmaTrainingRegressionTests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/NeuralNetworks/RecurrentGemmaTrainingRegressionTests.cs
@@ -1,4 +1,5 @@
 using AiDotNet.Enums;
+using AiDotNet.NeuralNetworks.Options;
 using AiDotNet.Interfaces;
 using AiDotNet.NeuralNetworks;
 using AiDotNet.Tests.ModelFamilyTests.Base;
@@ -28,12 +29,7 @@ public sealed class RecurrentGemmaTrainingRegressionTests
             taskType: NeuralNetworkTaskType.TextGeneration,
             inputSize: 2,
             outputSize: 8);
-        using var model = new RecurrentGemmaLanguageModel<float>(
-            architecture,
-            vocabSize: 8,
-            modelDimension: 4,
-            numLayers: 1,
-            maxSeqLength: 2);
+        using var model = new RecurrentGemmaLanguageModel<float>(architecture, new RecurrentGemmaOptions { VocabSize = 8, ModelDimension = 4, NumLayers = 1, MaxSequenceLength = 2 });
 
         var input = new Tensor<float>([1, 2]);
         input[0] = 1;
@@ -101,13 +97,11 @@ public sealed class RecurrentGemmaTrainingRegressionTests
         protected override int[] OutputShape => [4];
 
         protected override INeuralNetworkModel<float> CreateNetwork() =>
-            new RecurrentGemmaLanguageModel<float>(
-                new NeuralNetworkArchitecture<float>(
+            new RecurrentGemmaLanguageModel<float>(new NeuralNetworkArchitecture<float>(
                     inputType: InputType.OneDimensional,
                     taskType: NeuralNetworkTaskType.TextGeneration,
                     inputSize: 128,
-                    outputSize: 4),
-                vocabSize: 4096);
+                    outputSize: 4), new RecurrentGemmaOptions { VocabSize = 4096 });
 
         public (RecurrentGemmaLanguageModel<float> Model, Tensor<float> Input, Tensor<float> Target)
             CreateTrainingCase()

--- a/tests/AiDotNet.Tests/IntegrationTests/NeuralNetworks/RgLruFamilyFusedCompiledTrainingTests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/NeuralNetworks/RgLruFamilyFusedCompiledTrainingTests.cs
@@ -148,8 +148,10 @@ public sealed class RgLruFamilyFusedCompiledTrainingTests
     private sealed class TestableRecurrentGemma : RecurrentGemmaLanguageModel<double>, IFusedTrainingProbe
     {
         internal TestableRecurrentGemma(NeuralNetworkArchitecture<double> architecture)
-            : base(architecture, vocabSize: 128, modelDimension: 32,
-                numLayers: 1, maxSeqLength: 32)
+            : base(architecture, new RecurrentGemmaOptions
+            {
+                VocabSize = 128, ModelDimension = 32, NumLayers = 1, MaxSequenceLength = 32,
+            })
         {
         }
 
@@ -159,9 +161,11 @@ public sealed class RgLruFamilyFusedCompiledTrainingTests
     private sealed class TestableGriffin : GriffinLanguageModel<double>, IFusedTrainingProbe
     {
         internal TestableGriffin(NeuralNetworkArchitecture<double> architecture)
-            : base(architecture, vocabSize: 128, modelDimension: 32,
-                numLayers: 1, maxSeqLength: 32,
-                options: new GriffinOptions { RecurrenceDimension = 40 })
+            : base(architecture, new GriffinOptions
+            {
+                VocabSize = 128, ModelDimension = 32, NumLayers = 1, MaxSequenceLength = 32,
+                RecurrenceDimension = 40,
+            })
         {
         }
 
@@ -171,9 +175,11 @@ public sealed class RgLruFamilyFusedCompiledTrainingTests
     private sealed class TestableHawk : HawkLanguageModel<double>, IFusedTrainingProbe
     {
         internal TestableHawk(NeuralNetworkArchitecture<double> architecture)
-            : base(architecture, vocabSize: 128, modelDimension: 32,
-                numLayers: 1, maxSeqLength: 32,
-                options: new HawkOptions { RecurrenceDimension = 40 })
+            : base(architecture, new HawkOptions
+            {
+                VocabSize = 128, ModelDimension = 32, NumLayers = 1, MaxSequenceLength = 32,
+                RecurrenceDimension = 40,
+            })
         {
         }
 

--- a/tests/AiDotNet.Tests/IntegrationTests/NeuralNetworks/TransformerEmbeddingNetworkTests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/NeuralNetworks/TransformerEmbeddingNetworkTests.cs
@@ -1,4 +1,5 @@
 using System;
+using AiDotNet.NeuralNetworks.Options;
 using System.Collections.Generic;
 using System.Linq;
 using AiDotNet.Enums;
@@ -57,15 +58,7 @@ namespace AiDotNetTests.IntegrationTests.NeuralNetworks
             );
             var tokenizer = new MockTokenizer();
 
-            var model = new TransformerEmbeddingNetwork<double>(
-                architecture,
-                tokenizer,
-                optimizer: null,
-                vocabSize: vocabSize,
-                embeddingDimension: embeddingDim,
-                numLayers: 2,
-                numHeads: 4,
-                feedForwardDim: 128);
+            var model = new TransformerEmbeddingNetwork<double>(architecture, tokenizer: tokenizer, optimizer: null, options: new TransformerEmbeddingOptions { VocabSize = vocabSize, EmbeddingDimension = embeddingDim, NumLayers = 2, NumHeads = 4, FeedForwardDim = 128 });
 
             // Act
             var embedding = model.Embed("hello world");
@@ -90,14 +83,7 @@ namespace AiDotNetTests.IntegrationTests.NeuralNetworks
             var tokenizer = new MockTokenizer();
             var texts = new List<string> { "text 1", "text 2", "text 3" };
 
-            var model = new TransformerEmbeddingNetwork<double>(
-                architecture,
-                tokenizer,
-                optimizer: null,
-                vocabSize: vocabSize,
-                embeddingDimension: embeddingDim,
-                numLayers: 1,
-                numHeads: 2);
+            var model = new TransformerEmbeddingNetwork<double>(architecture, tokenizer: tokenizer, optimizer: null, options: new TransformerEmbeddingOptions { VocabSize = vocabSize, EmbeddingDimension = embeddingDim, NumLayers = 1, NumHeads = 2 });
 
             // Act
             var embeddings = model.EmbedBatch(texts);
@@ -122,15 +108,7 @@ namespace AiDotNetTests.IntegrationTests.NeuralNetworks
             );
             var tokenizer = new MockTokenizer();
 
-            var model = new TransformerEmbeddingNetwork<double>(
-                architecture,
-                tokenizer,
-                optimizer: null,
-                vocabSize: vocabSize,
-                embeddingDimension: embeddingDim,
-                numLayers: 1,
-                numHeads: 2,
-                poolingStrategy: TransformerEmbeddingNetwork<double>.PoolingStrategy.ClsToken);
+            var model = new TransformerEmbeddingNetwork<double>(architecture, tokenizer: tokenizer, optimizer: null, options: new TransformerEmbeddingOptions { VocabSize = vocabSize, EmbeddingDimension = embeddingDim, NumLayers = 1, NumHeads = 2, EmbeddingPoolingStrategy = EmbeddingPoolingStrategy.ClsToken });
 
             // Act
             var embedding = model.Embed("test");

--- a/tests/AiDotNet.Tests/ModelFamilyTests/NeuralNetworks/AudioVisualEventLocalizationNetworkTests.cs
+++ b/tests/AiDotNet.Tests/ModelFamilyTests/NeuralNetworks/AudioVisualEventLocalizationNetworkTests.cs
@@ -1,4 +1,5 @@
 using AiDotNet.Interfaces;
+using AiDotNet.NeuralNetworks.Options;
 using AiDotNet.NeuralNetworks;
 using AiDotNet.Tests.ModelFamilyTests.Base;
 
@@ -19,12 +20,9 @@ public class AudioVisualEventLocalizationNetworkTests : NeuralNetworkModelTestBa
     private const int FixtureEmbeddingSize = 32;
 
     protected override INeuralNetworkModel<float> CreateNetwork()
-        => new AudioVisualEventLocalizationNetwork<float>(
-            new NeuralNetworkArchitecture<float>(
+        => new AudioVisualEventLocalizationNetwork<float>(new NeuralNetworkArchitecture<float>(
                 inputType: AiDotNet.Enums.InputType.OneDimensional,
                 taskType: AiDotNet.Enums.NeuralNetworkTaskType.BinaryClassification,
                 inputSize: 512,
-                outputSize: 1),
-            audioEmbeddingFullyConnectedWidth: FixtureEmbeddingWidth,
-            audioEmbeddingSize: FixtureEmbeddingSize);
+                outputSize: 1), options: new AudioVisualEventLocalizationOptions { AudioEmbeddingFullyConnectedWidth = FixtureEmbeddingWidth, AudioEmbeddingSize = FixtureEmbeddingSize });
 }

--- a/tests/AiDotNet.Tests/ModelFamilyTests/NeuralNetworks/BigGANTests.cs
+++ b/tests/AiDotNet.Tests/ModelFamilyTests/NeuralNetworks/BigGANTests.cs
@@ -1,4 +1,5 @@
 using AiDotNet.Interfaces;
+using AiDotNet.NeuralNetworks.Options;
 using AiDotNet.NeuralNetworks;
 using AiDotNet.Tests.ModelFamilyTests.Base;
 
@@ -17,13 +18,5 @@ public class BigGANTests : GANModelTestBase<float>
     protected override int[] OutputShape => [1, 8, 8];
 
     protected override INeuralNetworkModel<float> CreateNetwork()
-        => new BigGAN<float>(
-            latentSize: 16,
-            numClasses: 10,
-            classEmbeddingDim: 8,
-            imageChannels: 1,
-            imageHeight: 8,
-            imageWidth: 8,
-            generatorChannels: 8,
-            discriminatorChannels: 8);
+        => new BigGAN<float>(latentSize: 16, numClasses: 10, classEmbeddingDim: 8, imageChannels: 1, imageHeight: 8, imageWidth: 8, options: new BigGANOptions { GeneratorChannels = 8, DiscriminatorChannels = 8 });
 }

--- a/tests/AiDotNet.Tests/ModelFamilyTests/NeuralNetworks/ProgressiveGANTests.cs
+++ b/tests/AiDotNet.Tests/ModelFamilyTests/NeuralNetworks/ProgressiveGANTests.cs
@@ -1,4 +1,5 @@
 using AiDotNet.Interfaces;
+using AiDotNet.NeuralNetworks.Options;
 using AiDotNet.NeuralNetworks;
 using AiDotNet.Tests.ModelFamilyTests.Base;
 
@@ -18,9 +19,5 @@ public class ProgressiveGANTests : GANModelTestBase<float>
     protected override int[] OutputShape => [1, 8, 8];
 
     protected override INeuralNetworkModel<float> CreateNetwork()
-        => new ProgressiveGAN<float>(
-            latentSize: 16,
-            imageChannels: 1,
-            maxResolutionLevel: 1,
-            baseFeatureMaps: 8);
+        => new ProgressiveGAN<float>(latentSize: 16, imageChannels: 1, options: new ProgressiveGANOptions { MaxResolutionLevel = 1, GeneratorChannels = 8 });
 }

--- a/tests/AiDotNet.Tests/ModelFamilyTests/NeuralNetworks/SAGANTests.cs
+++ b/tests/AiDotNet.Tests/ModelFamilyTests/NeuralNetworks/SAGANTests.cs
@@ -1,4 +1,5 @@
 using AiDotNet.Interfaces;
+using AiDotNet.NeuralNetworks.Options;
 using AiDotNet.NeuralNetworks;
 using AiDotNet.Tests.ModelFamilyTests.Base;
 
@@ -17,11 +18,5 @@ public class SAGANTests : GANModelTestBase<float>
     protected override int[] OutputShape => [1, 8, 8];
 
     protected override INeuralNetworkModel<float> CreateNetwork()
-        => new SAGAN<float>(
-            latentSize: 16,
-            imageChannels: 1,
-            imageHeight: 8,
-            imageWidth: 8,
-            generatorChannels: 8,
-            discriminatorChannels: 8);
+        => new SAGAN<float>(latentSize: 16, imageChannels: 1, imageHeight: 8, imageWidth: 8, options: new SAGANOptions { GeneratorChannels = 8, DiscriminatorChannels = 8 });
 }

--- a/tests/AiDotNet.Tests/ModelFamilyTests/NeuralNetworks/VideoCLIPNeuralNetworkTests.cs
+++ b/tests/AiDotNet.Tests/ModelFamilyTests/NeuralNetworks/VideoCLIPNeuralNetworkTests.cs
@@ -108,8 +108,8 @@ public class VideoCLIPNeuralNetworkTests : NeuralNetworkModelTestBase<float>
                 NumHeads = 4,                // Paper: 12 (ViT-B attention heads)
                 NumFrames = 4,               // Paper: 8 (sampled frames per video)
                 FrameRate = 1.0,             // Paper: 1 FPS sampling
+                TemporalAggregation = TemporalAggregationType.TemporalTransformer,
             },
-            temporalAggregation: TemporalAggregationType.TemporalTransformer,
             optimizer: new AdamOptimizer<float, Tensor<float>, Tensor<float>>(null, optimizerOptions),
             lossFunction: new CosineSimilarityLoss<float>());
 

--- a/tests/AiDotNet.Tests/ModelFamilyTests/NeuralNetworks/VideoCLIPNeuralNetworkTests.cs
+++ b/tests/AiDotNet.Tests/ModelFamilyTests/NeuralNetworks/VideoCLIPNeuralNetworkTests.cs
@@ -1,4 +1,5 @@
 using AiDotNet.Enums;
+using AiDotNet.NeuralNetworks.Options;
 using AiDotNet.Interfaces;
 using AiDotNet.LossFunctions;
 using AiDotNet.Models.Options;
@@ -91,20 +92,23 @@ public class VideoCLIPNeuralNetworkTests : NeuralNetworkModelTestBase<float>
         // measures actual embedding alignment.
         var model = new VideoCLIPNeuralNetwork<float>(
             architecture,
-            imageSize: 32,              // Paper: 224 (ViT-B/16 input resolution)
-            channels: 3,                // Paper: 3 RGB channels
-            patchSize: 16,              // Paper: 16 (ViT-B/16 patch size)
-            vocabularySize: 49408,      // Paper: 49408 BPE tokens (CLIP tokenizer)
-            maxSequenceLength: 77,      // Paper: 77 (CLIP text encoder max length)
-            embeddingDimension: 64,     // Paper: 512 (joint embedding space)
-            visionHiddenDim: 128,       // Paper: 768 (ViT-B hidden dim)
-            textHiddenDim: 64,          // Paper: 512 (CLIP text encoder hidden dim)
-            numFrameEncoderLayers: 2,   // Paper: 12 (ViT-B depth)
-            numTemporalLayers: 2,       // Paper: 4 (temporal transformer depth)
-            numTextLayers: 2,           // Paper: 12 (CLIP text encoder depth)
-            numHeads: 4,                // Paper: 12 (ViT-B attention heads)
-            numFrames: 4,               // Paper: 8 (sampled frames per video)
-            frameRate: 1.0,             // Paper: 1 FPS sampling
+            options: new VideoCLIPOptions
+            {
+                ImageSize = 32,              // Paper: 224 (ViT-B/16 input resolution)
+                Channels = 3,                // Paper: 3 RGB channels
+                PatchSize = 16,              // Paper: 16 (ViT-B/16 patch size)
+                VocabSize = 49408,           // Paper: 49408 BPE tokens (CLIP tokenizer)
+                MaxSequenceLength = 77,      // Paper: 77 (CLIP text encoder max length)
+                EmbeddingDimension = 64,     // Paper: 512 (joint embedding space)
+                VisionHiddenDim = 128,       // Paper: 768 (ViT-B hidden dim)
+                TextHiddenDim = 64,          // Paper: 512 (CLIP text encoder hidden dim)
+                NumFrameEncoderLayers = 2,   // Paper: 12 (ViT-B depth)
+                NumTemporalLayers = 2,       // Paper: 4 (temporal transformer depth)
+                NumTextLayers = 2,           // Paper: 12 (CLIP text encoder depth)
+                NumHeads = 4,                // Paper: 12 (ViT-B attention heads)
+                NumFrames = 4,               // Paper: 8 (sampled frames per video)
+                FrameRate = 1.0,             // Paper: 1 FPS sampling
+            },
             temporalAggregation: TemporalAggregationType.TemporalTransformer,
             optimizer: new AdamOptimizer<float, Tensor<float>, Tensor<float>>(null, optimizerOptions),
             lossFunction: new CosineSimilarityLoss<float>());

--- a/tests/AiDotNet.Tests/UnitTests/Agentic/Local/RealModelLocalInferenceTests.cs
+++ b/tests/AiDotNet.Tests/UnitTests/Agentic/Local/RealModelLocalInferenceTests.cs
@@ -1,4 +1,5 @@
 using System;
+using AiDotNet.NeuralNetworks.Options;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -58,13 +59,7 @@ namespace AiDotNetTests.UnitTests.Agentic.Local
                 inputSize: Vocab,
                 outputSize: Vocab);
 
-            return new MambaLanguageModel<double>(
-                architecture,
-                vocabSize: Vocab,
-                modelDimension: 16,
-                numLayers: 1,
-                stateDimension: 4,
-                maxSeqLength: MaxSeq);
+            return new MambaLanguageModel<double>(architecture, new MambaOptions { VocabSize = Vocab, ModelDimension = 16, NumLayers = 1, StateDimension = 4, MaxSequenceLength = MaxSeq });
         }
 
         [Fact(Timeout = 120000)]
@@ -101,9 +96,7 @@ namespace AiDotNetTests.UnitTests.Agentic.Local
                     NeuralNetworkTaskType.TextGeneration,
                     inputSize: Vocab,
                     outputSize: Vocab);
-                var model = new MambaLanguageModel<double>(
-                    architecture, vocabSize: Vocab, modelDimension: 16, numLayers: 2,
-                    stateDimension: 4, maxSeqLength: MaxSeq);
+                var model = new MambaLanguageModel<double>(architecture, new MambaOptions { VocabSize = Vocab, ModelDimension = 16, NumLayers = 2, StateDimension = 4, MaxSequenceLength = MaxSeq });
 
                 var prompt = new[] { 3, 1, 4, 1 };
                 var generated = new[] { 5, 9, 2 };

--- a/tests/AiDotNet.Tests/UnitTests/Agentic/Local/WeightImporterTests.cs
+++ b/tests/AiDotNet.Tests/UnitTests/Agentic/Local/WeightImporterTests.cs
@@ -1,4 +1,5 @@
 using System;
+using AiDotNet.NeuralNetworks.Options;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -28,7 +29,7 @@ namespace AiDotNetTests.UnitTests.Agentic.Local
         {
             var arch = new NeuralNetworkArchitecture<double>(
                 InputType.OneDimensional, NeuralNetworkTaskType.TextGeneration, inputSize: 12, outputSize: 12);
-            return new MambaLanguageModel<double>(arch, vocabSize: 12, modelDimension: 8, numLayers: 1, stateDimension: 4, maxSeqLength: 8);
+            return new MambaLanguageModel<double>(arch, new MambaOptions { VocabSize = 12, ModelDimension = 8, NumLayers = 1, StateDimension = 4, MaxSequenceLength = 8 });
         }
 
         [Fact(Timeout = 120000)]
@@ -63,7 +64,7 @@ namespace AiDotNetTests.UnitTests.Agentic.Local
             // Mamba stack: EmbeddingLayer + MambaBlock x2 + LayerNorm + Dense head.
             var arch = new NeuralNetworkArchitecture<double>(
                 InputType.OneDimensional, NeuralNetworkTaskType.TextGeneration, inputSize: 12, outputSize: 12);
-            var model = new MambaLanguageModel<double>(arch, vocabSize: 12, modelDimension: 8, numLayers: 2, stateDimension: 4, maxSeqLength: 8);
+            var model = new MambaLanguageModel<double>(arch, new MambaOptions { VocabSize = 12, ModelDimension = 8, NumLayers = 2, StateDimension = 4, MaxSequenceLength = 8 });
 
             var segments = ModelParameterMap.Build(model);
             var names = segments.Select(s => s.Name).ToList();
@@ -124,7 +125,7 @@ namespace AiDotNetTests.UnitTests.Agentic.Local
         {
             var arch = new NeuralNetworkArchitecture<double>(
                 InputType.OneDimensional, NeuralNetworkTaskType.TextGeneration, inputSize: 12, outputSize: 12);
-            return new MambaLanguageModel<double>(arch, vocabSize: 12, modelDimension: 8, numLayers: 2, stateDimension: 4, maxSeqLength: 8);
+            return new MambaLanguageModel<double>(arch, new MambaOptions { VocabSize = 12, ModelDimension = 8, NumLayers = 2, StateDimension = 4, MaxSequenceLength = 8 });
         }
 
         [Fact(Timeout = 120000)]

--- a/tests/AiDotNet.Tests/UnitTests/Agentic/SelfImproving/LoRAFineTunerTests.cs
+++ b/tests/AiDotNet.Tests/UnitTests/Agentic/SelfImproving/LoRAFineTunerTests.cs
@@ -1,4 +1,5 @@
 using System;
+using AiDotNet.NeuralNetworks.Options;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -86,8 +87,7 @@ namespace AiDotNetTests.UnitTests.Agentic.SelfImproving
             {
                 var arch = new NeuralNetworkArchitecture<double>(
                     InputType.OneDimensional, NeuralNetworkTaskType.TextGeneration, inputSize: vocab, outputSize: vocab);
-                var model = new MambaLanguageModel<double>(
-                    arch, vocabSize: vocab, modelDimension: 16, numLayers: 1, stateDimension: 4, maxSeqLength: seqLen);
+                var model = new MambaLanguageModel<double>(arch, new MambaOptions { VocabSize = vocab, ModelDimension = 16, NumLayers = 1, StateDimension = 4, MaxSequenceLength = seqLen });
 
                 // A small, repetitive dataset so the tiny model has a clear pattern to fit.
                 var dataset = new FineTuningDataset(new[]

--- a/tests/AiDotNet.Tests/UnitTests/NeuralNetworks/Blip2NeuralNetworkTests.cs
+++ b/tests/AiDotNet.Tests/UnitTests/NeuralNetworks/Blip2NeuralNetworkTests.cs
@@ -1,4 +1,5 @@
 using System;
+using AiDotNet.NeuralNetworks.Options;
 using System.IO;
 using AiDotNet.Enums;
 using AiDotNet.NeuralNetworks;
@@ -161,10 +162,7 @@ public class Blip2NeuralNetworkTests
 
         // Act & Assert
         var exception = Assert.Throws<ArgumentException>(() =>
-            new Blip2NeuralNetwork<float>(
-                architecture,
-                imageSize: 224,
-                patchSize: 15)); // 224 not divisible by 15
+            new Blip2NeuralNetwork<float>(architecture, options: new Blip2Options { ImageSize = 224, PatchSize = 15 })); // 224 not divisible by 15
 
         Assert.Contains("divisible", exception.Message);
     }
@@ -176,10 +174,7 @@ public class Blip2NeuralNetworkTests
         var architecture = CreateBasicArchitecture();
 
         // Act
-        var network = new Blip2NeuralNetwork<float>(
-            architecture,
-            numQueryTokens: 32,
-            languageModelBackbone: LanguageModelBackbone.OPT);
+        var network = new Blip2NeuralNetwork<float>(architecture, languageModelBackbone: LanguageModelBackbone.OPT, options: new Blip2Options { NumQueryTokens = 32 });
 
         // Assert
         Assert.Equal(32, network.NumQueryTokens);
@@ -207,10 +202,7 @@ public class Blip2NeuralNetworkTests
         var architecture = CreateBasicArchitecture();
 
         // Act
-        var network = new Blip2NeuralNetwork<float>(
-            architecture,
-            imageSize: 384,
-            patchSize: 16); // 384 is divisible by 16
+        var network = new Blip2NeuralNetwork<float>(architecture, options: new Blip2Options { ImageSize = 384, PatchSize = 16 }); // 384 is divisible by 16
 
         // Assert
         Assert.NotNull(network);
@@ -223,9 +215,7 @@ public class Blip2NeuralNetworkTests
         var architecture = CreateBasicArchitecture();
 
         // Act
-        var network = new Blip2NeuralNetwork<float>(
-            architecture,
-            numQueryTokens: 64);
+        var network = new Blip2NeuralNetwork<float>(architecture, options: new Blip2Options { NumQueryTokens = 64 });
 
         // Assert
         Assert.Equal(64, network.NumQueryTokens);
@@ -284,20 +274,7 @@ public class Blip2NeuralNetworkTests
     {
         // Arrange - use small dimensions to avoid OOM during Serialize()
         var architecture = CreateBasicArchitecture();
-        var network = new Blip2NeuralNetwork<float>(
-            architecture,
-            imageSize: 28,
-            patchSize: 14,
-            vocabularySize: 64,
-            embeddingDimension: 16,
-            qformerHiddenDim: 32,
-            visionHiddenDim: 32,
-            lmHiddenDim: 32,
-            numQformerLayers: 1,
-            numQueryTokens: 32,
-            numHeads: 2,
-            numLmDecoderLayers: 1,
-            languageModelBackbone: LanguageModelBackbone.FlanT5);
+        var network = new Blip2NeuralNetwork<float>(architecture, languageModelBackbone: LanguageModelBackbone.FlanT5, options: new Blip2Options { ImageSize = 28, PatchSize = 14, VocabSize = 64, EmbeddingDimension = 16, QformerHiddenDim = 32, VisionHiddenDim = 32, LmHiddenDim = 32, NumQformerLayers = 1, NumQueryTokens = 32, NumHeads = 2, NumLmDecoderLayers = 1 });
 
         // Act
         var metadata = network.GetModelMetadata();
@@ -313,18 +290,7 @@ public class Blip2NeuralNetworkTests
     {
         // Arrange - use small dimensions to avoid OOM during Serialize()
         var architecture = CreateBasicArchitecture();
-        var network = new Blip2NeuralNetwork<float>(
-            architecture,
-            imageSize: 28,
-            patchSize: 14,
-            vocabularySize: 64,
-            embeddingDimension: 16,
-            qformerHiddenDim: 48,
-            visionHiddenDim: 32,
-            lmHiddenDim: 32,
-            numQformerLayers: 2,
-            numHeads: 2,
-            numLmDecoderLayers: 1);
+        var network = new Blip2NeuralNetwork<float>(architecture, options: new Blip2Options { ImageSize = 28, PatchSize = 14, VocabSize = 64, EmbeddingDimension = 16, QformerHiddenDim = 48, VisionHiddenDim = 32, LmHiddenDim = 32, NumQformerLayers = 2, NumHeads = 2, NumLmDecoderLayers = 1 });
 
         // Act
         var metadata = network.GetModelMetadata();
@@ -367,18 +333,7 @@ public class Blip2NeuralNetworkTests
     private static Blip2NeuralNetwork<float> CreateSmallBlip2Network(
         NeuralNetworkArchitecture<float> architecture)
     {
-        return new Blip2NeuralNetwork<float>(
-            architecture,
-            imageSize: 28,
-            patchSize: 14,
-            vocabularySize: 64,
-            embeddingDimension: 16,
-            qformerHiddenDim: 32,
-            visionHiddenDim: 32,
-            lmHiddenDim: 32,
-            numQformerLayers: 1,
-            numHeads: 2,
-            numLmDecoderLayers: 1);
+        return new Blip2NeuralNetwork<float>(architecture, options: new Blip2Options { ImageSize = 28, PatchSize = 14, VocabSize = 64, EmbeddingDimension = 16, QformerHiddenDim = 32, VisionHiddenDim = 32, LmHiddenDim = 32, NumQformerLayers = 1, NumHeads = 2, NumLmDecoderLayers = 1 });
     }
 
     #endregion

--- a/tests/AiDotNet.Tests/UnitTests/NeuralNetworks/Blip2NeuralNetworkTests.cs
+++ b/tests/AiDotNet.Tests/UnitTests/NeuralNetworks/Blip2NeuralNetworkTests.cs
@@ -174,7 +174,11 @@ public class Blip2NeuralNetworkTests
         var architecture = CreateBasicArchitecture();
 
         // Act
-        var network = new Blip2NeuralNetwork<float>(architecture, languageModelBackbone: LanguageModelBackbone.OPT, options: new Blip2Options { NumQueryTokens = 32 });
+        var network = new Blip2NeuralNetwork<float>(architecture, options: new Blip2Options
+        {
+            LanguageModelBackbone = LanguageModelBackbone.OPT,
+            NumQueryTokens = 32,
+        });
 
         // Assert
         Assert.Equal(32, network.NumQueryTokens);
@@ -274,7 +278,7 @@ public class Blip2NeuralNetworkTests
     {
         // Arrange - use small dimensions to avoid OOM during Serialize()
         var architecture = CreateBasicArchitecture();
-        var network = new Blip2NeuralNetwork<float>(architecture, languageModelBackbone: LanguageModelBackbone.FlanT5, options: new Blip2Options { ImageSize = 28, PatchSize = 14, VocabSize = 64, EmbeddingDimension = 16, QformerHiddenDim = 32, VisionHiddenDim = 32, LmHiddenDim = 32, NumQformerLayers = 1, NumQueryTokens = 32, NumHeads = 2, NumLmDecoderLayers = 1 });
+        var network = new Blip2NeuralNetwork<float>(architecture, options: new Blip2Options { LanguageModelBackbone = LanguageModelBackbone.FlanT5, ImageSize = 28, PatchSize = 14, VocabSize = 64, EmbeddingDimension = 16, QformerHiddenDim = 32, VisionHiddenDim = 32, LmHiddenDim = 32, NumQformerLayers = 1, NumQueryTokens = 32, NumHeads = 2, NumLmDecoderLayers = 1 });
 
         // Act
         var metadata = network.GetModelMetadata();

--- a/tests/AiDotNet.Tests/UnitTests/NeuralNetworks/ClipNeuralNetworkTests.cs
+++ b/tests/AiDotNet.Tests/UnitTests/NeuralNetworks/ClipNeuralNetworkTests.cs
@@ -1,4 +1,5 @@
 using System;
+using AiDotNet.NeuralNetworks.Options;
 using System.IO;
 using AiDotNet.Enums;
 using AiDotNet.NeuralNetworks;
@@ -94,12 +95,7 @@ public class ClipNeuralNetworkTests
         // Note: Path validation happens before dimension validation
         // So FileNotFoundException is thrown because the file doesn't exist
         Assert.Throws<FileNotFoundException>(() =>
-            new ClipNeuralNetwork<float>(
-                architecture,
-                "image.onnx",
-                "text.onnx",
-                tokenizer,
-                embeddingDimension: 0));
+            new ClipNeuralNetwork<float>(architecture, "image.onnx", "text.onnx", tokenizer, options: new ClipOptions { EmbeddingDimension = 0 }));
     }
 
     [Fact(Timeout = 120000)]
@@ -111,12 +107,7 @@ public class ClipNeuralNetworkTests
 
         // Note: Path validation happens before this validation
         Assert.Throws<FileNotFoundException>(() =>
-            new ClipNeuralNetwork<float>(
-                architecture,
-                "image.onnx",
-                "text.onnx",
-                tokenizer,
-                maxSequenceLength: -1));
+            new ClipNeuralNetwork<float>(architecture, "image.onnx", "text.onnx", tokenizer, options: new ClipOptions { MaxSequenceLength = -1 }));
     }
 
     [Fact(Timeout = 120000)]
@@ -128,12 +119,7 @@ public class ClipNeuralNetworkTests
 
         // Note: Path validation happens before this validation
         Assert.Throws<FileNotFoundException>(() =>
-            new ClipNeuralNetwork<float>(
-                architecture,
-                "image.onnx",
-                "text.onnx",
-                tokenizer,
-                imageSize: -1));
+            new ClipNeuralNetwork<float>(architecture, "image.onnx", "text.onnx", tokenizer, options: new ClipOptions { ImageSize = -1 }));
     }
 
     /// <summary>

--- a/tests/AiDotNet.Tests/UnitTests/NeuralNetworks/FusedTrainingArenaBoundednessTests.cs
+++ b/tests/AiDotNet.Tests/UnitTests/NeuralNetworks/FusedTrainingArenaBoundednessTests.cs
@@ -19,6 +19,7 @@
 // per step (measured on SimCSE); post-fix it is flat from ~step 10 on.
 
 using AiDotNet.Enums;
+using AiDotNet.NeuralNetworks.Options;
 using AiDotNet.NeuralNetworks;
 using AiDotNet.Tensors.Helpers;
 using AiDotNet.Tensors.LinearAlgebra;
@@ -67,13 +68,7 @@ public class FusedTrainingArenaBoundednessTests
             taskType: NeuralNetworkTaskType.Regression,
             inputSize: dim,
             outputSize: dim);
-        var model = new SimCSE<float>(
-            arch,
-            embeddingDimension: dim,
-            maxSequenceLength: 256,
-            numLayers: 8,
-            numHeads: 8,
-            feedForwardDim: 1024);
+        var model = new SimCSE<float>(arch, options: new SimCSEOptions { EmbeddingDimension = dim, MaxSequenceLength = 256, NumLayers = 8, NumHeads = 8, FeedForwardDim = 1024 });
 
         // Default route: let the autotuner pick the eager/fused path (NOT streaming).
         // ForceOff guarantees we exercise the fused-optimizer path the fix touches.

--- a/tests/AiDotNet.Tests/UnitTests/NeuralNetworks/GANs/GenerativeAdversarialNetworkTests.cs
+++ b/tests/AiDotNet.Tests/UnitTests/NeuralNetworks/GANs/GenerativeAdversarialNetworkTests.cs
@@ -1,4 +1,5 @@
 using AiDotNet.Enums;
+using AiDotNet.NeuralNetworks.Options;
 using AiDotNet.Interfaces;
 using AiDotNet.LossFunctions;
 using AiDotNet.NeuralNetworks;
@@ -164,13 +165,7 @@ public class GenerativeAdversarialNetworkTests
     public async Task DCGAN_Constructor_WithCustomFeatureMaps_InitializesCorrectly()
     {
         // Arrange & Act
-        var dcgan = new DCGAN<double>(
-            latentSize: 128,
-            imageChannels: 1,
-            imageHeight: 32,
-            imageWidth: 32,
-            generatorFeatureMaps: 128,
-            discriminatorFeatureMaps: 128);
+        var dcgan = new DCGAN<double>(latentSize: 128, imageChannels: 1, imageHeight: 32, imageWidth: 32, options: new DCGANOptions { GeneratorChannels = 128, DiscriminatorChannels = 128 });
 
         // Assert
         Assert.NotNull(dcgan);
@@ -343,11 +338,7 @@ public class GenerativeAdversarialNetworkTests
         var discArch = CreateThreeDimensionalDiscriminatorArchitecture();
 
         // Act
-        var pix2pix = new Pix2Pix<double>(
-            generatorArchitecture: genArch,
-            discriminatorArchitecture: discArch,
-            inputType: InputType.ThreeDimensional,
-            l1Lambda: 50.0);
+        var pix2pix = new Pix2Pix<double>(generatorArchitecture: genArch, discriminatorArchitecture: discArch, inputType: InputType.ThreeDimensional, options: new Pix2PixOptions { L1Lambda = 50.0 });
 
         // Assert
         Assert.NotNull(pix2pix);
@@ -383,10 +374,13 @@ public class GenerativeAdversarialNetworkTests
         var sagan = new SAGAN<double>(
             generatorArchitecture: genArch,
             discriminatorArchitecture: discArch,
-            latentSize: 128,
-            imageChannels: 3,
-            imageHeight: 32,
-            imageWidth: 32);
+            options: new SAGANOptions
+            {
+                LatentSize = 128,
+                ImageChannels = 3,
+                ImageHeight = 32,
+                ImageWidth = 32,
+            });
 
         // Assert
         Assert.NotNull(sagan);
@@ -403,14 +397,7 @@ public class GenerativeAdversarialNetworkTests
         var discArch = CreateThreeDimensionalDiscriminatorArchitecture();
 
         // Act
-        var sagan = new SAGAN<double>(
-            generatorArchitecture: genArch,
-            discriminatorArchitecture: discArch,
-            latentSize: 128,
-            imageChannels: 3,
-            imageHeight: 32,
-            imageWidth: 32,
-            numClasses: 10);
+        var sagan = new SAGAN<double>(generatorArchitecture: genArch, discriminatorArchitecture: discArch, options: new SAGANOptions { LatentSize = 128, ImageChannels = 3, ImageHeight = 32, ImageWidth = 32, NumClasses = 10 });
 
         // Assert
         Assert.NotNull(sagan);
@@ -423,7 +410,7 @@ public class GenerativeAdversarialNetworkTests
         // Arrange
         var genArch = CreateThreeDimensionalGeneratorArchitecture();
         var discArch = CreateThreeDimensionalDiscriminatorArchitecture();
-        var sagan = new SAGAN<double>(genArch, discArch, 128, 3, 32, 32);
+        var sagan = new SAGAN<double>(genArch, discArch, new SAGANOptions { LatentSize = 128, ImageChannels = 3, ImageHeight = 32, ImageWidth = 32 });
 
         // Act
         var metadata = sagan.GetModelMetadata();
@@ -463,11 +450,7 @@ public class GenerativeAdversarialNetworkTests
         var criticArch = CreateThreeDimensionalDiscriminatorArchitecture();
 
         // Act
-        var wgan = new WGAN<double>(
-            generatorArchitecture: genArch,
-            criticArchitecture: criticArch,
-            inputType: InputType.ThreeDimensional,
-            weightClipValue: 0.02);
+        var wgan = new WGAN<double>(generatorArchitecture: genArch, criticArchitecture: criticArch, inputType: InputType.ThreeDimensional, options: new WGANOptions { WeightClipValue = 0.02 });
 
         // Assert
         Assert.NotNull(wgan);
@@ -536,11 +519,7 @@ public class GenerativeAdversarialNetworkTests
         var criticArch = CreateThreeDimensionalDiscriminatorArchitecture();
 
         // Act
-        var wgangp = new WGANGP<double>(
-            generatorArchitecture: genArch,
-            criticArchitecture: criticArch,
-            inputType: InputType.ThreeDimensional,
-            gradientPenaltyCoefficient: 15.0);
+        var wgangp = new WGANGP<double>(generatorArchitecture: genArch, criticArchitecture: criticArch, inputType: InputType.ThreeDimensional, options: new WGANGPOptions { GradientPenaltyCoefficient = 15.0 });
 
         // Assert
         Assert.NotNull(wgangp);
@@ -716,14 +695,7 @@ public class GenerativeAdversarialNetworkTests
         var discBArch = CreateThreeDimensionalDiscriminatorArchitecture();
 
         // Act
-        var cyclegan = new CycleGAN<double>(
-            generatorAtoB: genAtoBArch,
-            generatorBtoA: genBtoAArch,
-            discriminatorA: discAArch,
-            discriminatorB: discBArch,
-            inputType: InputType.ThreeDimensional,
-            cycleConsistencyLambda: 15.0,
-            identityLambda: 7.5);
+        var cyclegan = new CycleGAN<double>(generatorAtoB: genAtoBArch, generatorBtoA: genBtoAArch, discriminatorA: discAArch, discriminatorB: discBArch, inputType: InputType.ThreeDimensional, options: new CycleGANOptions { CycleConsistencyLambda = 15.0, IdentityLambda = 7.5 });
 
         // Assert
         Assert.NotNull(cyclegan);
@@ -871,12 +843,15 @@ public class GenerativeAdversarialNetworkTests
         var biggan = new BigGAN<double>(
             generatorArchitecture: genArch,
             discriminatorArchitecture: discArch,
-            latentSize: 128,
-            numClasses: 100,
-            imageChannels: 3,
-            imageHeight: 32,
-            imageWidth: 32,
-            inputType: InputType.OneDimensional);
+            options: new BigGANOptions
+            {
+                LatentSize = 128,
+                NumClasses = 100,
+                ImageChannels = 3,
+                ImageHeight = 32,
+                ImageWidth = 32,
+                InputType = InputType.OneDimensional,
+            });
 
         // Assert
         Assert.NotNull(biggan);
@@ -890,7 +865,7 @@ public class GenerativeAdversarialNetworkTests
         // Arrange
         var genArch = CreateThreeDimensionalGeneratorArchitecture();
         var discArch = CreateThreeDimensionalDiscriminatorArchitecture();
-        var biggan = new BigGAN<double>(genArch, discArch, 128, 100, 128, 3, 32, 32, inputType: InputType.OneDimensional);
+        var biggan = new BigGAN<double>(genArch, discArch, new BigGANOptions { LatentSize = 128, NumClasses = 100, ClassEmbeddingDim = 128, ImageChannels = 3, ImageHeight = 32, ImageWidth = 32, InputType = InputType.OneDimensional });
 
         // Act
         var metadata = biggan.GetModelMetadata();
@@ -914,9 +889,7 @@ public class GenerativeAdversarialNetworkTests
         var proggan = new ProgressiveGAN<double>(
             generatorArchitecture: genArch,
             discriminatorArchitecture: discArch,
-            latentSize: 512,
-            imageChannels: 3,
-            inputType: InputType.ThreeDimensional);
+            options: new ProgressiveGANOptions { LatentSize = 512, ImageChannels = 3, InputType = InputType.ThreeDimensional });
 
         // Assert
         Assert.NotNull(proggan);
@@ -930,7 +903,7 @@ public class GenerativeAdversarialNetworkTests
         // Arrange
         var genArch = CreateThreeDimensionalGeneratorArchitecture();
         var discArch = CreateThreeDimensionalDiscriminatorArchitecture();
-        var proggan = new ProgressiveGAN<double>(genArch, discArch, 512, 3, inputType: InputType.ThreeDimensional);
+        var proggan = new ProgressiveGAN<double>(genArch, discArch, new ProgressiveGANOptions { LatentSize = 512, ImageChannels = 3, InputType = InputType.ThreeDimensional });
 
         // Act
         var metadata = proggan.GetModelMetadata();

--- a/tests/AiDotNet.Tests/UnitTests/NeuralNetworks/Layers/SSM/MambaLanguageModelTests.cs
+++ b/tests/AiDotNet.Tests/UnitTests/NeuralNetworks/Layers/SSM/MambaLanguageModelTests.cs
@@ -1,4 +1,5 @@
 using AiDotNet.Enums;
+using AiDotNet.NeuralNetworks.Options;
 using AiDotNet.Models;
 using AiDotNet.NeuralNetworks;
 using AiDotNet.NeuralNetworks.Layers.SSM;
@@ -43,9 +44,7 @@ public class MambaLanguageModelTests
     {
         await Task.Yield();
 
-        var model = new MambaLanguageModel<float>(
-            CreateArch(),
-            vocabSize: 100, modelDimension: 32, numLayers: 2, stateDimension: 8);
+        var model = new MambaLanguageModel<float>(CreateArch(), new MambaOptions { VocabSize = 100, ModelDimension = 32, NumLayers = 2, StateDimension = 8 });
 
         Assert.Equal(100, model.VocabSize);
         Assert.Equal(32, model.ModelDimension);
@@ -59,7 +58,7 @@ public class MambaLanguageModelTests
         await Task.Yield();
 
         Assert.Throws<ArgumentException>(() =>
-            new MambaLanguageModel<float>(CreateArch(1), vocabSize: 0));
+            new MambaLanguageModel<float>(CreateArch(1), new MambaOptions { VocabSize = 0 }));
     }
 
     [Fact(Timeout = 120000)]
@@ -68,7 +67,7 @@ public class MambaLanguageModelTests
         await Task.Yield();
 
         Assert.Throws<ArgumentException>(() =>
-            new MambaLanguageModel<float>(CreateArch(), vocabSize: 100, modelDimension: 0));
+            new MambaLanguageModel<float>(CreateArch(), new MambaOptions { VocabSize = 100, ModelDimension = 0 }));
     }
 
     [Fact(Timeout = 120000)]
@@ -77,7 +76,7 @@ public class MambaLanguageModelTests
         await Task.Yield();
 
         Assert.Throws<ArgumentException>(() =>
-            new MambaLanguageModel<float>(CreateArch(), vocabSize: 100, numLayers: 0));
+            new MambaLanguageModel<float>(CreateArch(), new MambaOptions { VocabSize = 100, NumLayers = 0 }));
     }
 
     [Fact(Timeout = 120000)]
@@ -86,7 +85,7 @@ public class MambaLanguageModelTests
         await Task.Yield();
 
         Assert.Throws<ArgumentException>(() =>
-            new MambaLanguageModel<float>(CreateArch(), vocabSize: 100, stateDimension: 0));
+            new MambaLanguageModel<float>(CreateArch(), new MambaOptions { VocabSize = 100, StateDimension = 0 }));
     }
 
     [Fact(Timeout = 120000)]
@@ -99,9 +98,7 @@ public class MambaLanguageModelTests
         int vocabSize = 50;
         int modelDim = 32;
 
-        var model = new MambaLanguageModel<float>(
-            CreateArch(vocabSize),
-            vocabSize, modelDim, numLayers: 2, stateDimension: 8, maxSeqLength: seqLen);
+        var model = new MambaLanguageModel<float>(CreateArch(vocabSize), new MambaOptions { VocabSize = vocabSize, ModelDimension = modelDim, NumLayers = 2, StateDimension = 8, MaxSequenceLength = seqLen });
 
         var input = CreateTokenInput(batchSize, seqLen, vocabSize);
         var output = model.Predict(input);
@@ -119,9 +116,7 @@ public class MambaLanguageModelTests
         int vocabSize = 50;
         int modelDim = 32;
 
-        var model = new MambaLanguageModel<float>(
-            CreateArch(vocabSize),
-            vocabSize, modelDim, numLayers: 2, stateDimension: 8, maxSeqLength: seqLen);
+        var model = new MambaLanguageModel<float>(CreateArch(vocabSize), new MambaOptions { VocabSize = vocabSize, ModelDimension = modelDim, NumLayers = 2, StateDimension = 8, MaxSequenceLength = seqLen });
 
         // One unbatched sequence of IDs. [1, seq] in, [1, seq, vocab] logits out.
         var input = CreateTokenInput(1, seqLen, vocabSize);
@@ -142,9 +137,7 @@ public class MambaLanguageModelTests
         int vocabSize = 30;
         int modelDim = 16;
 
-        var model = new MambaLanguageModel<float>(
-            CreateArch(vocabSize),
-            vocabSize, modelDim, numLayers: 2, stateDimension: 4, maxSeqLength: seqLen);
+        var model = new MambaLanguageModel<float>(CreateArch(vocabSize), new MambaOptions { VocabSize = vocabSize, ModelDimension = modelDim, NumLayers = 2, StateDimension = 4, MaxSequenceLength = seqLen });
 
         var input = CreateTokenInput(1, seqLen, vocabSize);
 
@@ -165,9 +158,7 @@ public class MambaLanguageModelTests
     {
         await Task.Yield();
 
-        var model = new MambaLanguageModel<float>(
-            CreateArch(50),
-            50, 32, numLayers: 2, stateDimension: 8, maxSeqLength: 4);
+        var model = new MambaLanguageModel<float>(CreateArch(50), new MambaOptions { VocabSize = 50, ModelDimension = 32, NumLayers = 2, StateDimension = 8, MaxSequenceLength = 4 });
 
         var params1 = model.GetParameters();
         Assert.True(params1.Length > 0);
@@ -188,8 +179,7 @@ public class MambaLanguageModelTests
     {
         await Task.Yield();
 
-        var model = new MambaLanguageModel<float>(
-            CreateArch(50), 50, 32, 2, 8, maxSeqLength: 4);
+        var model = new MambaLanguageModel<float>(CreateArch(50), new MambaOptions { VocabSize = 50, ModelDimension = 32, NumLayers = 2, StateDimension = 8, MaxSequenceLength = 4 });
         Assert.Throws<ArgumentException>(() => model.SetParameters(new Vector<float>(10)));
     }
 
@@ -202,12 +192,8 @@ public class MambaLanguageModelTests
         int vocabSize = 30;
         int modelDim = 16;
 
-        var model1 = new MambaLanguageModel<float>(
-            CreateArch(vocabSize),
-            vocabSize, modelDim, numLayers: 2, stateDimension: 4, maxSeqLength: seqLen);
-        var model2 = new MambaLanguageModel<float>(
-            CreateArch(vocabSize),
-            vocabSize, modelDim, numLayers: 2, stateDimension: 4, maxSeqLength: seqLen);
+        var model1 = new MambaLanguageModel<float>(CreateArch(vocabSize), new MambaOptions { VocabSize = vocabSize, ModelDimension = modelDim, NumLayers = 2, StateDimension = 4, MaxSequenceLength = seqLen });
+        var model2 = new MambaLanguageModel<float>(CreateArch(vocabSize), new MambaOptions { VocabSize = vocabSize, ModelDimension = modelDim, NumLayers = 2, StateDimension = 4, MaxSequenceLength = seqLen });
 
         model2.SetParameters(model1.GetParameters());
 
@@ -229,8 +215,7 @@ public class MambaLanguageModelTests
     {
         await Task.Yield();
 
-        var model = new MambaLanguageModel<float>(
-            CreateArch(30), 30, 16, 2, 4, maxSeqLength: 4);
+        var model = new MambaLanguageModel<float>(CreateArch(30), new MambaOptions { VocabSize = 30, ModelDimension = 16, NumLayers = 2, StateDimension = 4, MaxSequenceLength = 4 });
         var input = CreateTokenInput(1, 4, 30);
 
         model.Predict(input);
@@ -246,8 +231,7 @@ public class MambaLanguageModelTests
     {
         await Task.Yield();
 
-        var model = new MambaLanguageModel<float>(
-            CreateArch(30), 30, 16, 2, 4, maxSeqLength: 4);
+        var model = new MambaLanguageModel<float>(CreateArch(30), new MambaOptions { VocabSize = 30, ModelDimension = 16, NumLayers = 2, StateDimension = 4, MaxSequenceLength = 4 });
         Assert.True(model.SupportsTraining);
     }
 
@@ -256,8 +240,7 @@ public class MambaLanguageModelTests
     {
         await Task.Yield();
 
-        var model = new MambaLanguageModel<float>(
-            CreateArch(100), 100, 64, 4, 16, maxSeqLength: 32);
+        var model = new MambaLanguageModel<float>(CreateArch(100), new MambaOptions { VocabSize = 100, ModelDimension = 64, NumLayers = 4, StateDimension = 16, MaxSequenceLength = 32 });
         var metadata = model.GetModelMetadata();
 
 
@@ -278,9 +261,7 @@ public class MambaLanguageModelTests
         int seqLen = 4;
         int vocabSize = 30;
 
-        var model = new MambaLanguageModel<double>(
-            CreateDoubleArch(vocabSize),
-            vocabSize, 16, numLayers: 2, stateDimension: 4, maxSeqLength: seqLen);
+        var model = new MambaLanguageModel<double>(CreateDoubleArch(vocabSize), new MambaOptions { VocabSize = vocabSize, ModelDimension = 16, NumLayers = 2, StateDimension = 4, MaxSequenceLength = seqLen });
 
         var input = CreateTokenDoubleInput(1, seqLen, vocabSize);
         var output = model.Predict(input);
@@ -298,9 +279,7 @@ public class MambaLanguageModelTests
         int vocabSize = 20;
         int modelDim = 16;
 
-        var model = new MambaLanguageModel<float>(
-            CreateArch(vocabSize),
-            vocabSize, modelDim, numLayers: 4, stateDimension: 4, maxSeqLength: seqLen);
+        var model = new MambaLanguageModel<float>(CreateArch(vocabSize), new MambaOptions { VocabSize = vocabSize, ModelDimension = modelDim, NumLayers = 4, StateDimension = 4, MaxSequenceLength = seqLen });
 
         var input = CreateTokenInput(1, seqLen, vocabSize);
         var output = model.Predict(input);
@@ -332,9 +311,7 @@ public class MambaLanguageModelTests
         int vocabSize = 12;
         int modelDim = 16;
 
-        var model = new MambaLanguageModel<double>(
-            CreateDoubleArch(vocabSize),
-            vocabSize, modelDim, numLayers: 2, stateDimension: 8, maxSeqLength: seqLen);
+        var model = new MambaLanguageModel<double>(CreateDoubleArch(vocabSize), new MambaOptions { VocabSize = vocabSize, ModelDimension = modelDim, NumLayers = 2, StateDimension = 8, MaxSequenceLength = seqLen });
 
         var input = CreateTokenDoubleInput(1, seqLen, vocabSize, seed: 7);
 
@@ -369,9 +346,7 @@ public class MambaLanguageModelTests
         int vocabSize = 10;
         int modelDim = 16;
 
-        var model = new MambaLanguageModel<double>(
-            CreateDoubleArch(vocabSize),
-            vocabSize, modelDim, numLayers: 4, stateDimension: 4, maxSeqLength: seqLen);
+        var model = new MambaLanguageModel<double>(CreateDoubleArch(vocabSize), new MambaOptions { VocabSize = vocabSize, ModelDimension = modelDim, NumLayers = 4, StateDimension = 4, MaxSequenceLength = seqLen });
 
         var input = CreateTokenDoubleInput(1, seqLen, vocabSize, seed: 13);
 
@@ -408,8 +383,7 @@ public class MambaLanguageModelTests
             int vocabSize = 20;
             int modelDim = 16;
 
-            var model = new MambaLanguageModel<double>(
-                CreateDoubleArch(vocabSize), vocabSize, modelDim, numLayers: 2, stateDimension: 4, maxSeqLength: seqLen);
+            var model = new MambaLanguageModel<double>(CreateDoubleArch(vocabSize), new MambaOptions { VocabSize = vocabSize, ModelDimension = modelDim, NumLayers = 2, StateDimension = 4, MaxSequenceLength = seqLen });
 
             var input = CreateTokenDoubleInput(1, seqLen, vocabSize, seed: 5);
 

--- a/tests/AiDotNet.Tests/UnitTests/NeuralNetworks/Layers/SSM/RWKV7LanguageModelTests.cs
+++ b/tests/AiDotNet.Tests/UnitTests/NeuralNetworks/Layers/SSM/RWKV7LanguageModelTests.cs
@@ -1,4 +1,5 @@
 using AiDotNet.Enums;
+using AiDotNet.NeuralNetworks.Options;
 using AiDotNet.Models;
 using AiDotNet.NeuralNetworks;
 using AiDotNet.NeuralNetworks.Layers.SSM;
@@ -234,9 +235,7 @@ public class RWKV7LanguageModelTests
     [Fact(Timeout = 120000)]
     public async Task Model_Constructor_ValidParameters_CreatesModel()
     {
-        var model = new RWKV7LanguageModel<float>(
-            CreateArch(),
-            vocabSize: 100, modelDimension: 32, numLayers: 2, numHeads: 4);
+        var model = new RWKV7LanguageModel<float>(CreateArch(), new RWKV7Options { VocabSize = 100, ModelDimension = 32, NumLayers = 2, NumHeads = 4 });
 
         Assert.Equal(100, model.VocabSize);
         Assert.Equal(32, model.ModelDimension);
@@ -249,42 +248,41 @@ public class RWKV7LanguageModelTests
     public async Task Model_Constructor_ThrowsWhenVocabSizeNotPositive()
     {
         Assert.Throws<ArgumentException>(() =>
-            new RWKV7LanguageModel<float>(CreateArch(1), vocabSize: 0));
+            new RWKV7LanguageModel<float>(CreateArch(1), new RWKV7Options { VocabSize = 0 }));
     }
 
     [Fact(Timeout = 120000)]
     public async Task Model_Constructor_ThrowsWhenModelDimensionNotPositive()
     {
         Assert.Throws<ArgumentException>(() =>
-            new RWKV7LanguageModel<float>(CreateArch(), vocabSize: 100, modelDimension: 0));
+            new RWKV7LanguageModel<float>(CreateArch(), new RWKV7Options { VocabSize = 100, ModelDimension = 0 }));
     }
 
     [Fact(Timeout = 120000)]
     public async Task Model_Constructor_ThrowsWhenNumLayersNotPositive()
     {
         Assert.Throws<ArgumentException>(() =>
-            new RWKV7LanguageModel<float>(CreateArch(), vocabSize: 100, numLayers: 0));
+            new RWKV7LanguageModel<float>(CreateArch(), new RWKV7Options { VocabSize = 100, NumLayers = 0 }));
     }
 
     [Fact(Timeout = 120000)]
     public async Task Model_Constructor_ThrowsWhenNumHeadsNotPositive()
     {
         Assert.Throws<ArgumentException>(() =>
-            new RWKV7LanguageModel<float>(CreateArch(), vocabSize: 100, numHeads: 0));
+            new RWKV7LanguageModel<float>(CreateArch(), new RWKV7Options { VocabSize = 100, NumHeads = 0 }));
     }
 
     [Fact(Timeout = 120000)]
     public async Task Model_Constructor_ThrowsWhenDimensionNotDivisibleByHeads()
     {
         Assert.Throws<ArgumentException>(() =>
-            new RWKV7LanguageModel<float>(CreateArch(), vocabSize: 100, modelDimension: 33, numHeads: 4));
+            new RWKV7LanguageModel<float>(CreateArch(), new RWKV7Options { VocabSize = 100, ModelDimension = 33, NumHeads = 4 }));
     }
 
     [Fact(Timeout = 120000)]
     public async Task Model_SupportsTraining_ReturnsTrue()
     {
-        var model = new RWKV7LanguageModel<float>(
-            CreateArch(30), 30, 16, 2, 2);
+        var model = new RWKV7LanguageModel<float>(CreateArch(30), new RWKV7Options { VocabSize = 30, ModelDimension = 16, NumLayers = 2, NumHeads = 2 });
         Assert.True(model.SupportsTraining);
     }
 
@@ -300,9 +298,7 @@ public class RWKV7LanguageModelTests
         int vocabSize = 50;
         int modelDim = 32;
 
-        var model = new RWKV7LanguageModel<float>(
-            CreateArch(vocabSize),
-            vocabSize, modelDim, numLayers: 2, numHeads: 4, maxSeqLength: seqLen);
+        var model = new RWKV7LanguageModel<float>(CreateArch(vocabSize), new RWKV7Options { VocabSize = vocabSize, ModelDimension = modelDim, NumLayers = 2, NumHeads = 4, MaxSequenceLength = seqLen });
 
         var input = CreateTokenInput(batchSize, seqLen, vocabSize);
         var output = model.Predict(input);
@@ -318,9 +314,7 @@ public class RWKV7LanguageModelTests
         int vocabSize = 50;
         int modelDim = 32;
 
-        var model = new RWKV7LanguageModel<float>(
-            CreateArch(vocabSize),
-            vocabSize, modelDim, numLayers: 2, numHeads: 4, maxSeqLength: seqLen);
+        var model = new RWKV7LanguageModel<float>(CreateArch(vocabSize), new RWKV7Options { VocabSize = vocabSize, ModelDimension = modelDim, NumLayers = 2, NumHeads = 4, MaxSequenceLength = seqLen });
 
         // One unbatched sequence of ids. [1, seq] in, [1, seq, vocab] logits out.
         var input = CreateTokenInput(1, seqLen, vocabSize);
@@ -336,9 +330,7 @@ public class RWKV7LanguageModelTests
         int seqLen = 4;
         int vocabSize = 20;
 
-        var model = new RWKV7LanguageModel<float>(
-            CreateArch(vocabSize),
-            vocabSize, 16, numLayers: 2, numHeads: 2, maxSeqLength: seqLen);
+        var model = new RWKV7LanguageModel<float>(CreateArch(vocabSize), new RWKV7Options { VocabSize = vocabSize, ModelDimension = 16, NumLayers = 2, NumHeads = 2, MaxSequenceLength = seqLen });
 
         var input = CreateTokenInput(1, seqLen, vocabSize);
         var output = model.Predict(input);
@@ -368,9 +360,7 @@ public class RWKV7LanguageModelTests
         int seqLen = 4;
         int vocabSize = 20;
 
-        var model = new RWKV7LanguageModel<float>(
-            CreateArch(vocabSize),
-            vocabSize, 16, numLayers: 2, numHeads: 2, maxSeqLength: seqLen);
+        var model = new RWKV7LanguageModel<float>(CreateArch(vocabSize), new RWKV7Options { VocabSize = vocabSize, ModelDimension = 16, NumLayers = 2, NumHeads = 2, MaxSequenceLength = seqLen });
 
         var input = CreateTokenInput(1, seqLen, vocabSize);
         var expected = CreateOneHotTarget(1, seqLen, vocabSize, seed: 99);
@@ -390,9 +380,7 @@ public class RWKV7LanguageModelTests
     [Fact(Timeout = 120000)]
     public async Task Model_GetParameters_SetParameters_RoundTrip()
     {
-        var model = new RWKV7LanguageModel<float>(
-            CreateArch(30),
-            30, 16, numLayers: 2, numHeads: 2, maxSeqLength: 4);
+        var model = new RWKV7LanguageModel<float>(CreateArch(30), new RWKV7Options { VocabSize = 30, ModelDimension = 16, NumLayers = 2, NumHeads = 2, MaxSequenceLength = 4 });
 
         var params1 = model.GetParameters();
         Assert.True(params1.Length > 0);
@@ -409,8 +397,7 @@ public class RWKV7LanguageModelTests
     [Fact(Timeout = 120000)]
     public async Task Model_SetParameters_ThrowsOnWrongLength()
     {
-        var model = new RWKV7LanguageModel<float>(
-            CreateArch(30), 30, 16, 2, 2, maxSeqLength: 4);
+        var model = new RWKV7LanguageModel<float>(CreateArch(30), new RWKV7Options { VocabSize = 30, ModelDimension = 16, NumLayers = 2, NumHeads = 2, MaxSequenceLength = 4 });
         Assert.Throws<ArgumentException>(() => model.SetParameters(new Vector<float>(10)));
     }
 
@@ -420,12 +407,8 @@ public class RWKV7LanguageModelTests
         int seqLen = 4;
         int vocabSize = 20;
 
-        var model1 = new RWKV7LanguageModel<float>(
-            CreateArch(vocabSize),
-            vocabSize, 16, numLayers: 2, numHeads: 2, maxSeqLength: seqLen);
-        var model2 = new RWKV7LanguageModel<float>(
-            CreateArch(vocabSize),
-            vocabSize, 16, numLayers: 2, numHeads: 2, maxSeqLength: seqLen);
+        var model1 = new RWKV7LanguageModel<float>(CreateArch(vocabSize), new RWKV7Options { VocabSize = vocabSize, ModelDimension = 16, NumLayers = 2, NumHeads = 2, MaxSequenceLength = seqLen });
+        var model2 = new RWKV7LanguageModel<float>(CreateArch(vocabSize), new RWKV7Options { VocabSize = vocabSize, ModelDimension = 16, NumLayers = 2, NumHeads = 2, MaxSequenceLength = seqLen });
 
         model2.SetParameters(model1.GetParameters());
 
@@ -449,8 +432,7 @@ public class RWKV7LanguageModelTests
     [Fact(Timeout = 120000)]
     public async Task Model_ResetState_AllowsReuse()
     {
-        var model = new RWKV7LanguageModel<float>(
-            CreateArch(20), 20, 16, 2, 2, maxSeqLength: 4);
+        var model = new RWKV7LanguageModel<float>(CreateArch(20), new RWKV7Options { VocabSize = 20, ModelDimension = 16, NumLayers = 2, NumHeads = 2, MaxSequenceLength = 4 });
         var input = CreateTokenInput(1, 4, 20);
 
         model.Predict(input);
@@ -468,8 +450,7 @@ public class RWKV7LanguageModelTests
     [Fact(Timeout = 120000)]
     public async Task Model_GetModelMetadata_ContainsExpectedKeys()
     {
-        var model = new RWKV7LanguageModel<float>(
-            CreateArch(100), 100, 64, 4, 8, maxSeqLength: 32);
+        var model = new RWKV7LanguageModel<float>(CreateArch(100), new RWKV7Options { VocabSize = 100, ModelDimension = 64, NumLayers = 4, NumHeads = 8, MaxSequenceLength = 32 });
         var metadata = model.GetModelMetadata();
 
 
@@ -495,9 +476,7 @@ public class RWKV7LanguageModelTests
         int seqLen = 4;
         int vocabSize = 20;
 
-        var model = new RWKV7LanguageModel<double>(
-            CreateDoubleArch(vocabSize),
-            vocabSize, 16, numLayers: 2, numHeads: 2, maxSeqLength: seqLen);
+        var model = new RWKV7LanguageModel<double>(CreateDoubleArch(vocabSize), new RWKV7Options { VocabSize = vocabSize, ModelDimension = 16, NumLayers = 2, NumHeads = 2, MaxSequenceLength = seqLen });
 
         var input = CreateTokenDoubleInput(1, seqLen, vocabSize);
         var output = model.Predict(input);
@@ -516,9 +495,7 @@ public class RWKV7LanguageModelTests
         int seqLen = 4;
         int vocabSize = 20;
 
-        var model = new RWKV7LanguageModel<float>(
-            CreateArch(vocabSize),
-            vocabSize, 16, numLayers: 4, numHeads: 2, maxSeqLength: seqLen);
+        var model = new RWKV7LanguageModel<float>(CreateArch(vocabSize), new RWKV7Options { VocabSize = vocabSize, ModelDimension = 16, NumLayers = 4, NumHeads = 2, MaxSequenceLength = seqLen });
 
         var input = CreateTokenInput(1, seqLen, vocabSize);
         var output = model.Predict(input);
@@ -602,14 +579,7 @@ public class RWKV7LanguageModelTests
             MaxSequenceLength = 8
         };
 
-        var model = new RWKV7LanguageModel<float>(
-            CreateArch(options.VocabSize),
-            options.VocabSize,
-            options.ModelDimension,
-            options.NumLayers,
-            options.NumHeads,
-            options.FFNMultiplier,
-            options.MaxSequenceLength);
+        var model = new RWKV7LanguageModel<float>(CreateArch(options.VocabSize), new RWKV7Options { VocabSize = options.VocabSize, ModelDimension = options.ModelDimension, NumLayers = options.NumLayers, NumHeads = options.NumHeads, FfnMultiplier = options.FFNMultiplier, MaxSequenceLength = options.MaxSequenceLength });
 
         Assert.Equal(options.VocabSize, model.VocabSize);
         Assert.Equal(options.ModelDimension, model.ModelDimension);

--- a/tests/AiDotNet.Tests/UnitTests/NeuralNetworks/Layers/SSM/VisionMambaModelTests.cs
+++ b/tests/AiDotNet.Tests/UnitTests/NeuralNetworks/Layers/SSM/VisionMambaModelTests.cs
@@ -1,4 +1,5 @@
 using AiDotNet.Enums;
+using AiDotNet.NeuralNetworks.Options;
 using AiDotNet.Models;
 using AiDotNet.NeuralNetworks;
 using AiDotNet.NeuralNetworks.Layers.SSM;
@@ -41,10 +42,7 @@ public class VisionMambaModelTests
     [Fact(Timeout = 120000)]
     public async Task Constructor_ValidParameters_CreatesModel()
     {
-        var model = new VisionMambaModel<float>(
-            CreateArch(),
-            imageHeight: 32, imageWidth: 32, patchSize: 8,
-            channels: 3, modelDimension: 32, numLayers: 2, numClasses: 10);
+        var model = new VisionMambaModel<float>(CreateArch(), options: new VisionMambaOptions { ImageHeight = 32, ImageWidth = 32, PatchSize = 8, Channels = 3, ModelDimension = 32, NumLayers = 2, NumClasses = 10 });
 
         Assert.Equal(32, model.ImageHeight);
         Assert.Equal(32, model.ImageWidth);
@@ -60,22 +58,21 @@ public class VisionMambaModelTests
     public async Task Constructor_ThrowsWhenImageNotDivisibleByPatch()
     {
         Assert.Throws<ArgumentException>(() =>
-            new VisionMambaModel<float>(CreateArch(30, 32), imageHeight: 30, imageWidth: 32, patchSize: 8));
+            new VisionMambaModel<float>(CreateArch(30, 32), options: new VisionMambaOptions { ImageHeight = 30, ImageWidth = 32, PatchSize = 8 }));
     }
 
     [Fact(Timeout = 120000)]
     public async Task Constructor_ThrowsWhenImageHeightNotPositive()
     {
         Assert.Throws<ArgumentException>(() =>
-            new VisionMambaModel<float>(CreateArch(1, 32), imageHeight: 0, imageWidth: 32, patchSize: 8));
+            new VisionMambaModel<float>(CreateArch(1, 32), options: new VisionMambaOptions { ImageHeight = 0, ImageWidth = 32, PatchSize = 8 }));
     }
 
     [Fact(Timeout = 120000)]
     public async Task Constructor_ThrowsWhenNumClassesNotPositive()
     {
         Assert.Throws<ArgumentException>(() =>
-            new VisionMambaModel<float>(CreateArch(16, 16, numClasses: 1),
-                imageHeight: 16, imageWidth: 16, patchSize: 4, numClasses: 0));
+            new VisionMambaModel<float>(CreateArch(16, 16, numClasses: 1), options: new VisionMambaOptions { ImageHeight = 16, ImageWidth = 16, PatchSize = 4, NumClasses = 0 }));
     }
 
     [Theory]
@@ -91,11 +88,7 @@ public class VisionMambaModelTests
         int patchSize = 4;
         int numClasses = 5;
 
-        var model = new VisionMambaModel<float>(
-            CreateArch(height, width, channels, numClasses),
-            height, width, patchSize, channels,
-            modelDimension: 16, numLayers: 2, numClasses: numClasses,
-            stateDimension: 4, scanPattern: pattern);
+        var model = new VisionMambaModel<float>(CreateArch(height, width, channels, numClasses), options: new VisionMambaOptions { ImageHeight = height, ImageWidth = width, PatchSize = patchSize, Channels = channels, ModelDimension = 16, NumLayers = 2, NumClasses = numClasses, StateDimension = 4, ScanPattern = pattern });
 
         var input = CreateRandomTensor(new[] { batchSize, channels, height, width });
         var output = model.Predict(input);
@@ -113,11 +106,7 @@ public class VisionMambaModelTests
         int patchSize = 4;
         int numClasses = 5;
 
-        var model = new VisionMambaModel<float>(
-            CreateArch(height, width, channels, numClasses),
-            height, width, patchSize, channels,
-            modelDimension: 16, numLayers: 2, numClasses: numClasses,
-            stateDimension: 4);
+        var model = new VisionMambaModel<float>(CreateArch(height, width, channels, numClasses), options: new VisionMambaOptions { ImageHeight = height, ImageWidth = width, PatchSize = patchSize, Channels = channels, ModelDimension = 16, NumLayers = 2, NumClasses = numClasses, StateDimension = 4 });
 
         var input = CreateRandomTensor(new[] { channels, height, width });
         var output = model.Predict(input);
@@ -137,11 +126,7 @@ public class VisionMambaModelTests
         int patchSize = 4;
         int numClasses = 3;
 
-        var model = new VisionMambaModel<float>(
-            CreateArch(height, width, channels, numClasses),
-            height, width, patchSize, channels,
-            modelDimension: 16, numLayers: 2, numClasses: numClasses,
-            stateDimension: 4);
+        var model = new VisionMambaModel<float>(CreateArch(height, width, channels, numClasses), options: new VisionMambaOptions { ImageHeight = height, ImageWidth = width, PatchSize = patchSize, Channels = channels, ModelDimension = 16, NumLayers = 2, NumClasses = numClasses, StateDimension = 4 });
 
         var input = CreateRandomTensor(new[] { 1, channels, height, width });
         var expected = new Tensor<float>(new[] { 1, numClasses });
@@ -158,9 +143,7 @@ public class VisionMambaModelTests
     [Fact(Timeout = 120000)]
     public async Task GetParameters_SetParameters_RoundTrip()
     {
-        var model = new VisionMambaModel<float>(
-            CreateArch(16, 16, 1, 3),
-            16, 16, 4, 1, modelDimension: 16, numLayers: 2, numClasses: 3, stateDimension: 4);
+        var model = new VisionMambaModel<float>(CreateArch(16, 16, 1, 3), options: new VisionMambaOptions { ImageHeight = 16, ImageWidth = 16, PatchSize = 4, Channels = 1, ModelDimension = 16, NumLayers = 2, NumClasses = 3, StateDimension = 4 });
 
         var params1 = model.GetParameters();
         Assert.True(params1.Length > 0);
@@ -178,9 +161,7 @@ public class VisionMambaModelTests
     [Fact(Timeout = 120000)]
     public async Task SetParameters_ThrowsOnWrongLength()
     {
-        var model = new VisionMambaModel<float>(
-            CreateArch(16, 16, 1, 3),
-            16, 16, 4, 1, modelDimension: 16, numLayers: 2, numClasses: 3, stateDimension: 4);
+        var model = new VisionMambaModel<float>(CreateArch(16, 16, 1, 3), options: new VisionMambaOptions { ImageHeight = 16, ImageWidth = 16, PatchSize = 4, Channels = 1, ModelDimension = 16, NumLayers = 2, NumClasses = 3, StateDimension = 4 });
 
         Assert.Throws<ArgumentException>(() => model.SetParameters(new Vector<float>(10)));
     }
@@ -188,19 +169,14 @@ public class VisionMambaModelTests
     [Fact(Timeout = 120000)]
     public async Task SupportsTraining_ReturnsTrue()
     {
-        var model = new VisionMambaModel<float>(
-            CreateArch(16, 16, 1, 3),
-            16, 16, 4, 1, modelDimension: 16, numLayers: 2, numClasses: 3, stateDimension: 4);
+        var model = new VisionMambaModel<float>(CreateArch(16, 16, 1, 3), options: new VisionMambaOptions { ImageHeight = 16, ImageWidth = 16, PatchSize = 4, Channels = 1, ModelDimension = 16, NumLayers = 2, NumClasses = 3, StateDimension = 4 });
         Assert.True(model.SupportsTraining);
     }
 
     [Fact(Timeout = 120000)]
     public async Task GetModelMetadata_ContainsExpectedKeys()
     {
-        var model = new VisionMambaModel<float>(
-            CreateArch(32, 32, 3, 10),
-            32, 32, 8, 3, modelDimension: 64, numLayers: 4, numClasses: 10,
-            scanPattern: VisionScanPattern.CrossScan);
+        var model = new VisionMambaModel<float>(CreateArch(32, 32, 3, 10), options: new VisionMambaOptions { ImageHeight = 32, ImageWidth = 32, PatchSize = 8, Channels = 3, ModelDimension = 64, NumLayers = 4, NumClasses = 10, ScanPattern = VisionScanPattern.CrossScan });
 
         var metadata = model.GetModelMetadata();
 
@@ -217,9 +193,7 @@ public class VisionMambaModelTests
     [Fact(Timeout = 120000)]
     public async Task ResetState_AllowsReuse()
     {
-        var model = new VisionMambaModel<float>(
-            CreateArch(16, 16, 1, 3),
-            16, 16, 4, 1, modelDimension: 16, numLayers: 2, numClasses: 3, stateDimension: 4);
+        var model = new VisionMambaModel<float>(CreateArch(16, 16, 1, 3), options: new VisionMambaOptions { ImageHeight = 16, ImageWidth = 16, PatchSize = 4, Channels = 1, ModelDimension = 16, NumLayers = 2, NumClasses = 3, StateDimension = 4 });
 
         var input = CreateRandomTensor(new[] { 1, 1, 16, 16 });
         var output1 = model.Predict(input);
@@ -243,11 +217,7 @@ public class VisionMambaModelTests
     public async Task DifferentImageSizes_Work()
     {
         // Rectangular image
-        var model = new VisionMambaModel<float>(
-            CreateArch(32, 16, 1, 5),
-            imageHeight: 32, imageWidth: 16, patchSize: 8,
-            channels: 1, modelDimension: 16, numLayers: 2, numClasses: 5,
-            stateDimension: 4, scanPattern: VisionScanPattern.Continuous);
+        var model = new VisionMambaModel<float>(CreateArch(32, 16, 1, 5), options: new VisionMambaOptions { ImageHeight = 32, ImageWidth = 16, PatchSize = 8, Channels = 1, ModelDimension = 16, NumLayers = 2, NumClasses = 5, StateDimension = 4, ScanPattern = VisionScanPattern.Continuous });
 
         Assert.Equal(8, model.NumPatches); // (32/8) * (16/8) = 4*2 = 8
 
@@ -261,9 +231,7 @@ public class VisionMambaModelTests
     [Fact(Timeout = 120000)]
     public async Task Predict_Double_ProducesValidOutput()
     {
-        var model = new VisionMambaModel<double>(
-            CreateDoubleArch(),
-            16, 16, 4, 1, modelDimension: 16, numLayers: 2, numClasses: 3, stateDimension: 4);
+        var model = new VisionMambaModel<double>(CreateDoubleArch(), options: new VisionMambaOptions { ImageHeight = 16, ImageWidth = 16, PatchSize = 4, Channels = 1, ModelDimension = 16, NumLayers = 2, NumClasses = 3, StateDimension = 4 });
 
         var input = CreateRandomDoubleTensor(new[] { 1, 1, 16, 16 });
         var output = model.Predict(input);


### PR DESCRIPTION
Phase 4 of #2090. Follows #2130 (phase 3). Spec in #2122.

**Ratchet: 875 → 741.** Three groups land here: enum/string parameters that earlier phases skipped, the 11 embedding and retrieval models, and the 10 GANs.

| step | models | params | ratchet |
|---|---:|---:|---:|
| enum/string parameters + `VisionMambaModel` | — | 14 | 875 → 861 |
| embedding & retrieval | 11 | 77 | 861 → 782 |
| GAN family | 10 | 41 | 782 → **741** |

## `PoolingStrategy` is promoted out of a generic type

This is the collision phase 1 deliberately deferred. `PoolingStrategy` was nested inside `TransformerEmbeddingNetwork<T>`, and **a type nested in a generic class is a distinct type per type argument** — `TransformerEmbeddingNetwork<float>.PoolingStrategy` and the `<double>` one were unrelated types, and neither could be named from a non-generic options class. It was never usable as configuration, which is exactly what it describes.

It becomes `AiDotNet.Enums.EmbeddingPoolingStrategy`. Renamed rather than moved as-is, because `src/VisionLanguage/Encoders` has its own unrelated `PoolingStrategy` with different members.

## Options inheritance now mirrors model inheritance

Seven embedding models derive from `TransformerEmbeddingNetwork<T>` and forward through `: base(...)`. Their options classes had to derive from `TransformerEmbeddingOptions` rather than straight from `EmbeddingModelOptions` — otherwise a derived model cannot pass its own options to base at all.

## Three assumptions the GANs broke

1. **Not every model has an architecture parameter.** The GAN primary constructors take explicit image dimensions and build their generator and discriminator architectures from them.
2. **A constructor may delegate with `: this(...)`**, not only `: base(...)`, and such a constructor is public and carries movable parameters of its own.
3. **A moved value may be used *inside* the initializer**: `: base(CreateDCGANGeneratorArchitecture(latentSize, ..., generatorFeatureMaps), ...)`. Dropping the identifier is wrong — the expression needs the value. `options` is in scope in an initializer, so it becomes `(options?.GeneratorChannels ?? 64)`, carrying the same default. And a name defaulted in one constructor but *required* in another (DCGAN's `latentSize`) must be supplied there, not dropped.

## What the tests caught that the build did not

`GanOptions.ValidateCore` required `LatentSize` and `InitialLearningRate`. **30 GAN tests failed.** `LatentSize` stays a required *constructor* argument on the four models that build architectures from it, so it is legitimately unset on those options objects; and most GANs never had an `InitialLearningRate` parameter at all. It now carries the DCGAN paper's 0.0002 as a default, and only `ImageChannels` is required.

Worth noting against the ratchet itself: it counts a parameter as covered when the options class has a matching **name**, so a model whose constructor still takes the parameter can score as migrated. `UnifiedMultimodalNetwork` did exactly that in phase 3. The skipped behavioural assertion is what closes that hole.

## Verification

- `dotnet build src/AiDotNet.csproj -f net8.0` — 0 errors
- `dotnet build tests/AiDotNet.Tests -f net8.0` — 0 errors
- GAN suite — **57 passed, 0 failed**; embedding suite — 37 passed
- Ratchet — passing at **741**

Refs #2090

🤖 Generated with [Claude Code](https://claude.com/claude-code)