### PR TITLE
test(ci): prove mapped runtime selection

### DIFF
--- a/src/ActivationFunctions/GumbelSoftmaxActivation.cs
+++ b/src/ActivationFunctions/GumbelSoftmaxActivation.cs
@@ -71,7 +71,7 @@ public class GumbelSoftmaxActivation<T> : ActivationFunctionBase<T>
     /// </remarks>
     public GumbelSoftmaxActivation(double temperature = 1.0, int? seed = null)
     {
-        _temperature = NumOps.FromDouble(temperature);
+        _temperature = NumOps.FromDouble(temperature); // CI impact-routing canary: no behavior change.
         _random = seed.HasValue ? RandomHelper.CreateSeededRandom(seed.Value) : RandomHelper.CreateSecureRandom();
     }
 


### PR DESCRIPTION
Live acceptance canary for merged PR #2140.

This is a behavior-neutral comment on a source line covered by the certified production shard map.

Expected selector result:
- Integration A-B
- Integration D (always-run safety shard)
- 2 of 116 shards total

After the validation-only certificate is published, this PR will be merged to prove the exact-tree push path suppresses the build/test matrix.