### PR TITLE
fix(ci): checkout validation reuse resolver

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -148,6 +148,9 @@ jobs:
             echo 'execute_quality=true'
           } >> "$GITHUB_OUTPUT"
 
+      - name: Checkout validation reuse policy
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v4
+
       - name: Resolve exact-tree PR run
         id: resolve
         continue-on-error: true

--- a/tools/TestImpact/Test-CiImpactWorkflow.ps1
+++ b/tools/TestImpact/Test-CiImpactWorkflow.ps1
@@ -189,6 +189,15 @@ Assert-Contract ($resolver.Contains('steps.resolve.outputs.reuse_scope || steps.
 $resolveStep = Get-StepBlock -JobBlock $resolver -Step 'Resolve exact-tree PR run'
 Assert-Contract ([bool] $resolveStep) `
     'the exact-tree resolver step is absent'
+$resolverCheckoutStep = Get-StepBlock -JobBlock $resolver -Step 'Checkout validation reuse policy'
+Assert-Contract ([bool] $resolverCheckoutStep) `
+    'validation-source invokes a repository script without checking out the tested tree'
+Assert-Contract ($resolverCheckoutStep.Contains('uses: actions/checkout@')) `
+    'validation-source checkout step does not use actions/checkout'
+Assert-Contract ([bool] $resolverCheckoutStep -and [bool] $resolveStep -and
+    $resolver.IndexOf($resolverCheckoutStep, [StringComparison]::Ordinal) -lt
+    $resolver.IndexOf($resolveStep, [StringComparison]::Ordinal)) `
+    'validation-source invokes the exact-tree resolver before checking out its script'
 Assert-Contract ($resolveStep.Contains('continue-on-error: true')) `
     'an unexpected resolver failure blocks dependents instead of retaining fail-closed defaults'
 Assert-Contract ($resolveStep.Contains('./tools/TestImpact/Resolve-CiValidationReuse.ps1')) `


### PR DESCRIPTION
## Root cause

The post-merge canary run 34406825041 proved that validation-source invoked ./tools/TestImpact/Resolve-CiValidationReuse.ps1 before the repository had been checked out. The command failed as not recognized, and the intentional fail-closed fallback enabled the full build/test graph.

## Fix

- Check out the repository before executing the validation-reuse resolver.
- Extend the checked-in workflow contract test to require that checkout and require it to precede resolver execution.
- Audit every active workflow job that invokes tools/TestImpact; this was the only missing checkout.

## Local proof

- All 15 deterministic TestImpact self-tests pass.
- CI workflow contract passes with 10 expensive jobs gated.
- All TestImpact PowerShell files parse successfully.
- actionlint v1.7.12 passes sonarcloud.yml and test-impact-map.yml.
- Repository-wide workflow audit reports zero TestImpact script jobs without checkout.
- git diff --check passes.

## Live proof plan

Per the approved fast path, merge this locally proven workflow correction, then rerun the mapped-source canary and verify the resulting master push starts zero build/test/model-validation jobs while rerunning quality checks.