### PR TITLE
test(ci): verify post-merge validation reuse

### DIFF
--- a/src/ActivationFunctions/GumbelSoftmaxActivation.cs
+++ b/src/ActivationFunctions/GumbelSoftmaxActivation.cs
@@ -71,7 +71,7 @@ public class GumbelSoftmaxActivation<T> : ActivationFunctionBase<T>
     /// </remarks>
     public GumbelSoftmaxActivation(double temperature = 1.0, int? seed = null)
     {
-        _temperature = NumOps.FromDouble(temperature); // CI impact-routing canary: no behavior change.
+        _temperature = NumOps.FromDouble(temperature); // CI impact-routing post-fix canary: no behavior change.
         _random = seed.HasValue ? RandomHelper.CreateSeededRandom(seed.Value) : RandomHelper.CreateSecureRandom();
     }
 


### PR DESCRIPTION
## Purpose

Behavior-neutral mapped-source canary for the validation-reuse checkout fix in #2142.

## Required proof before merge

- validation-source executes successfully with the checked-out resolver;
- selector consumes certified map run 34400050763;
- the 116-shard matrix is reduced to the mapped shards for this one source file;
- selected shards and fixed invariant jobs pass;
- a typed Validation-scope certificate is published.

## Required proof after merge

The exact-tree master push must reuse the PR certificate, report execute_validation=false and execute_quality=true, start zero build/test/parameter/model/regression runners, and rerun CodeQL/Sonar.