### PR TITLE
fix(ci): define Sonar validation mode in its job

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -2076,8 +2076,6 @@ jobs:
       - test-net10-sharded
       - validation-source
       - select-shards
-    env:
-      EFFECTIVE_REQUIRES_VALIDATION: ${{ (needs.validation-source.outputs.reuse == 'true' && needs.validation-source.outputs.reused_requires_validation) || needs.select-shards.outputs.requires_validation || 'true' }}
     permissions:
       actions: read
       contents: read
@@ -2344,6 +2342,8 @@ jobs:
       - test-net10-sharded
       - validation-source
       - select-shards
+    env:
+      EFFECTIVE_REQUIRES_VALIDATION: ${{ (needs.validation-source.outputs.reuse == 'true' && needs.validation-source.outputs.reused_requires_validation) || needs.select-shards.outputs.requires_validation || 'true' }}
 
     steps:
       - name: Report non-runtime validation

--- a/tools/TestImpact/Test-CiImpactWorkflow.ps1
+++ b/tools/TestImpact/Test-CiImpactWorkflow.ps1
@@ -167,6 +167,16 @@ Assert-Contract (-not $codeqlHeader.Contains(
 Assert-Contract ($codeqlHeader.Contains('always()') -and $codeqlHeader.Contains('!cancelled()')) `
     'CodeQL cannot publish its required result after a selector failure'
 
+# Every Sonar step parses this value with fromJSON. It must therefore be defined on the Sonar job,
+# not on a neighboring job where it is invisible and becomes a null template value at runtime.
+$sonarJob = Get-JobBlock -WorkflowText $validation -Job 'sonarcloud'
+$sonarHeader = Get-JobHeader -JobBlock $sonarJob
+$effectiveValidationEnvironment = 'EFFECTIVE_REQUIRES_VALIDATION: ${{ (needs.validation-source.outputs.reuse == ''true'' && needs.validation-source.outputs.reused_requires_validation) || needs.select-shards.outputs.requires_validation || ''true'' }}'
+Assert-Contract ($sonarHeader.Contains($effectiveValidationEnvironment)) `
+    'Sonar steps parse EFFECTIVE_REQUIRES_VALIDATION but the Sonar job does not define it'
+Assert-Contract (([Regex]::Matches($validation, '(?m)^      EFFECTIVE_REQUIRES_VALIDATION:')).Count -eq 1) `
+    'EFFECTIVE_REQUIRES_VALIDATION must be defined exactly once on the Sonar job'
+
 foreach ($job in @(
     'test-regression-analysis', 'sonarcloud', 'ci-test-analysis',
     'validation-gate', 'certify-expensive-validation', 'promote-ci-test-analysis',


### PR DESCRIPTION
## Root cause

SonarCloud Analysis parses `fromJSON(env.EFFECTIVE_REQUIRES_VALIDATION)` in every step, but the variable was accidentally declared on the neighboring `test-regression-analysis` job. Live canary runs 34400562933 and 34412223867 therefore failed immediately with `fromJSON(null)` before Sonar execution.

## Fix

- Move the typed effective-validation expression Executor to the Sonar job that consumes it.
- Require the exact declaration on the Sonar job in the checked-in workflow contract.
- Require exactly one declaration so it cannot silently drift back to an unrelated job.

## Proof

- All 15 TestImpact self-tests pass.
- PowerShell syntax passes.
- actionlint v1.7.12 passes both CI workflows.
- The workflow contract passes after the fix.
- The same contract executed against the pre-fix workflow fails with: `Sonar steps parse EFFECTIVE_REQUIRES_VALIDATION but the Sonar job does not define it`.
- Post-rebase workflow contract passes on current master.

A non-runtime canary will follow the merge to exercise the corrected Sonar environment and exact-tree reuse without launching the expensive validation graph.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected validation gating for SonarCloud analysis steps.
  * Prevented unused validation configuration from affecting regression analysis jobs.

* **Tests**
  * Added checks to verify validation configuration is defined in the correct workflow job and consumed consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->