### PR TITLE
test(ci): verify non-runtime routing

### DIFF
--- a/ci-proof/nonruntime-routing-canary.md
+++ b/ci-proof/nonruntime-routing-canary.md
@@ -1,0 +1,6 @@
+# Non-runtime CI routing canary
+
+This documentation-only file exercises the permanent `ci-proof/**` workflow trigger. Its pull
+request must skip build, test, parameter, and model validation. After merge, the exact-tree
+certificate must prevent that validation from being repeated on `master` while required quality
+checks retain their independently typed execution decision.


### PR DESCRIPTION
## Purpose

Final live canary for the merged selector/reuse and Sonar environment fixes.

This adds only a proof document under ci-proof, which is intentionally non-runtime.

## Required PR proof

- validation resolver succeeds;
- selector reports requires_validation=false;
- Build, compatibility build, all 116 test shards, parameter sweeps, model-shape windows, regression analysis, aggregate analysis, and size check start zero runners;
- Sonar's non-runtime step succeeds with the now-defined typed environment;
- validation-only certificate is published without waiting for CodeQL.

## Required merge proof

The exact-tree master run reuses the certificate with execute_validation=false. No expensive validation jobs may start; quality remains independently controlled.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added guidance describing expected CI routing behavior for pull requests and post-merge validation.
  - Documented preservation of independently entered quality-check decisions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->