### PR TITLE
fix(ci): reuse PR validation after merging behind master; re-run only affected shards

### DIFF
--- a/.github/PR2159_REVIEW_PROOF.md
+++ b/.github/PR2159_REVIEW_PROOF.md
@@ -1,0 +1,55 @@
+# PR #2159 review-fix evidence (2026-09-11)
+
+The integration commit `007e621f87405359018a809b988b252e41d0e792` is a
+direct descendant of collaborator head `7e4c25ff41fbd90b632556af384a148209f3304d`.
+Their selector, artifact-validation, compatibility, and deletion-test fixes were
+preserved. This is local executable proof, not a claim that a new hosted run has
+already completed.
+
+## Failure first
+
+The stronger workflow contract rejected the collaborator head's timeout budget:
+10 minutes for map resolution + 40 minutes waiting for evidence + 5 minutes of
+setup/fallback margin exceeds the 50-minute job. Map resolution is now bounded
+at 5 minutes. Seven negative controls reject missing or incorrect map-head
+arguments, comment-only arguments, renamed or comment-only step identity, and
+missing or excessive map timeouts.
+
+The other original review defects already had overlapping fixes in that parent;
+they are not represented here as failures still present on the parent.
+
+## Independently repeated results
+
+From the repository root:
+
+```powershell
+pwsh -NoProfile -File tools/TestImpact/Select-Shards.ps1 -SelfTest
+pwsh -NoProfile -File tools/TestImpact/Resolve-CiValidationReuse.ps1 -SelfTest
+pwsh -NoProfile -File tools/TestImpact/Test-ValidationReuseModes.ps1
+pwsh -NoProfile -File tools/TestImpact/Test-CiGateModes.ps1
+pwsh -NoProfile -File tools/TestImpact/Test-TestImpactEndToEnd.ps1
+```
+
+All passed. The final end-to-end command was independently repeated after
+integration, and executes the workflow and artifact-emission negative controls.
+Its real temporary Git repositories demonstrate both paths:
+
+| Change | Observed decision |
+| --- | --- |
+| Covered edit, including a PR behind master | 2 of 3 shards: Alpha and Always |
+| Documentation-only PR | 0 of 3 shards |
+| Landed runtime delta | Rerun Always; import Alpha from validated PR evidence |
+| Landed documentation delta | Reuse validation; no reruns |
+| Deleted test file | Retain the deleted file's routing evidence; successful process exit |
+| Invalid map or CI-selection control change | Require full validation |
+
+Eleven cases execute the production artifact-emission branch. Missing, expired,
+wrong-SHA, wrong-slug, or wrong-case imported evidence declines partial reuse;
+complete evidence permits it. Rerunning every shard needs no imported artifacts,
+and whole-result reuse retains its separate existing contract. Internal policy
+and invalid-input fixture modes use enums; string conversion occurs at the
+JSON/workflow boundary.
+
+These finite fixtures prove the reviewed wiring and decision rules. They do not
+claim an arbitrary repository edit can never require the full matrix, or that
+local fixtures substitute for reviewing the resulting GitHub checks.

--- a/.github/PR2159_REVIEW_PROOF.md
+++ b/.github/PR2159_REVIEW_PROOF.md
@@ -43,12 +43,24 @@ Its real temporary Git repositories demonstrate both paths:
 | Deleted test file | Retain the deleted file's routing evidence; successful process exit |
 | Invalid map or CI-selection control change | Require full validation |
 
-Eleven cases execute the production artifact-emission branch. Missing, expired,
+Twelve cases execute the production artifact-emission branch. Missing, expired,
 wrong-SHA, wrong-slug, or wrong-case imported evidence declines partial reuse;
 complete evidence permits it. Rerunning every shard needs no imported artifacts,
 and whole-result reuse retains its separate existing contract. Internal policy
 and invalid-input fixture modes use enums; string conversion occurs at the
 JSON/workflow boundary.
+
+## Empty-import follow-up
+
+Two stricter negative controls reproduced unnecessary import metadata when every
+PR shard was scheduled to rerun: one with no candidate artifacts and one with
+otherwise valid but unused artifacts. The shared output writer now clears the
+import run ID and SHA whenever the import list is empty. The rerun list and
+validation/quality decisions stay unchanged; the existing workflow's non-empty
+run-ID condition therefore cannot start an empty import's artifact download.
+Partial reuse with real imports and whole-result reuse retain their existing
+contracts. All five commands above and all 12 emission cases passed after this
+follow-up, including the real-Git PR and post-merge paths.
 
 These finite fixtures prove the reviewed wiring and decision rules. They do not
 claim an arbitrary repository edit can never require the full matrix, or that

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -175,7 +175,8 @@ jobs:
         continue-on-error: true
         # continue-on-error bounds the OUTCOME, not the duration: a stalled gh call here would eat
         # the job's margin before the resolver's own 40-minute wait even starts.
-        timeout-minutes: 10
+        # Leave 40 minutes for evidence and 5 minutes for checkout/setup and fallback reporting.
+        timeout-minutes: 5
         shell: pwsh
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -648,13 +648,21 @@ jobs:
         env:
           MAP_KIND: ${{ steps.map.outputs.kind }}
           MAP_RUN_ID: ${{ steps.map.outputs.run_id }}
-          PR_BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha }}
+          # NOT the event's base sha: that is the base branch as it stood when the pull request was
+          # opened, so for a pull request behind master it attributes every commit master
+          # has gained since to the pull request. The selector verifies the checked-out merge commit's
+          # second parent is this head and diffs against its first parent - the base actually tested.
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           $all = @(yq -o=json -I=0 '.shard' .github/test-shards.yml | ConvertFrom-Json)
           if ($all.Count -eq 0) {
             Write-Host '::error::.github/test-shards.yml yielded no shards'
             exit 1
           }
+          # Test sources are never instrumented, so the coverage map cannot route them; the selector
+          # routes them through these same filters instead.
+          ConvertTo-Json -InputObject @($all | Select-Object name, project, filter) -Depth 3 |
+            Set-Content -LiteralPath shard-manifest.json -Encoding utf8
 
           function Read-RequiredJsonBoolean {
             param(
@@ -724,7 +732,7 @@ jobs:
             $pathRequiresValidation = $true
             try {
               & ./tools/TestImpact/Select-Shards.ps1 -ClassifyOnly `
-                  -BaseSha $env:PR_BASE_SHA -OutFile path-classification.json
+                  -PullRequestHeadSha $env:PR_HEAD_SHA -OutFile path-classification.json
               if ($LASTEXITCODE -ne 0) { throw "path classifier exited $LASTEXITCODE" }
               $pathResult = Get-Content path-classification.json -Raw | ConvertFrom-Json
               $pathRequiresValidation = Read-RequiredJsonBoolean `
@@ -740,12 +748,14 @@ jobs:
               $selected = @()
             }
             elseif ($mapCertified) {
-              # No base ref: coverage selection diffs from the map's own commit, which is the only
-              # reference whose line numbers the map's ranges are expressed in.
+              # Line ranges still come from the map's own commit, the only reference whose line
+              # numbers the map's ranges are expressed in; the pull request head only decides WHICH
+              # paths are this pull request's change.
               try {
                 & ./tools/TestImpact/Select-Shards.ps1 `
                     -MapFile map/shard-map.json `
-                    -BaseSha $env:PR_BASE_SHA `
+                    -PullRequestHeadSha $env:PR_HEAD_SHA `
+                    -ShardManifestFile shard-manifest.json `
                     -ExpectedShards @($all.name) `
                     -OutFile selection.json
                 if ($LASTEXITCODE -ne 0) { throw "shard selector exited $LASTEXITCODE" }

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -130,6 +130,13 @@ jobs:
       # graph while still rerunning CodeQL and Sonar; only a complete certificate suppresses both.
       execute_validation: ${{ steps.resolve.outputs.execute_validation || steps.defaults.outputs.execute_validation }}
       execute_quality: ${{ steps.resolve.outputs.execute_quality || steps.defaults.outputs.execute_quality }}
+      # Delta reuse. Reuse: nothing re-runs (reuse=true above). Partial: re-run partial_shards only
+      # and import import_shards' artifacts from run import_run_id (tested commit import_sha).
+      delta_mode: ${{ steps.resolve.outputs.delta_mode || steps.defaults.outputs.delta_mode }}
+      partial_shards: ${{ steps.resolve.outputs.partial_shards || steps.defaults.outputs.partial_shards }}
+      import_run_id: ${{ steps.resolve.outputs.import_run_id || steps.defaults.outputs.import_run_id }}
+      import_sha: ${{ steps.resolve.outputs.import_sha || steps.defaults.outputs.import_sha }}
+      import_shards: ${{ steps.resolve.outputs.import_shards || steps.defaults.outputs.import_shards }}
 
     steps:
       - name: Initialize fail-closed validation decision
@@ -146,10 +153,46 @@ jobs:
             echo 'reused_requires_validation=true'
             echo 'execute_validation=true'
             echo 'execute_quality=true'
+            echo 'delta_mode='
+            echo 'partial_shards=[]'
+            echo 'import_run_id='
+            echo 'import_sha='
+            echo 'import_shards=[]'
           } >> "$GITHUB_OUTPUT"
 
       - name: Checkout validation reuse policy
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v4
+        with:
+          # Delta reuse rebuilds the pull request's validated tree from its merge parents and diffs
+          # the landed commit against it in the certified map's line coordinates, which needs the
+          # map commit and both parents in history.
+          # Quoted: in an expression '&& 0 ||' treats 0 as false and would always yield 1.
+          fetch-depth: ${{ github.event_name == 'push' && '0' || '1' }}
+
+      - name: Resolve certified shard map for delta reuse
+        id: delta-map
+        if: github.event_name == 'push'
+        continue-on-error: true
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # Delta reuse selects over the base branch's later commits with the same audited map that
+          # pull-request selection uses. Any failure here leaves both inputs unset, and reuse stays
+          # exact-tree only - the pre-existing, fail-closed behaviour.
+          & ./tools/TestImpact/Resolve-CertifiedShardMap.ps1 -Repository '${{ github.repository }}' `
+              -OutDirectory delta-map -ResultFile delta-map-resolution.json -MapBranch master
+          if ($LASTEXITCODE -ne 0) { throw "certified map resolver exited $LASTEXITCODE" }
+          $resolution = Get-Content delta-map-resolution.json -Raw | ConvertFrom-Json
+          if (-not $resolution.found) { throw 'no certified map is available' }
+          & ./tools/TestImpact/Test-CertifiedShardMap.ps1 -MapFile delta-map/shard-map.json `
+              -CertificateFile delta-map/certification.json -CertificationRunId ([long] $resolution.runId)
+          if ($LASTEXITCODE -ne 0) { throw "certified map provenance is invalid (exit $LASTEXITCODE)" }
+          $all = @(yq -o=json -I=0 '.shard' .github/test-shards.yml | ConvertFrom-Json)
+          ConvertTo-Json -InputObject @($all | Select-Object name, project, filter) -Depth 3 |
+            Set-Content -LiteralPath delta-shard-manifest.json -Encoding utf8
+          'map_file=delta-map/shard-map.json' | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+          'manifest_file=delta-shard-manifest.json' | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
 
       - name: Resolve exact-tree PR run
         id: resolve
@@ -164,6 +207,8 @@ jobs:
             -EventName '${{ github.event_name }}' `
             -ExpectedBaseBranch '${{ github.ref_name }}' `
             -GitHubOutput $env:GITHUB_OUTPUT `
+            -MapFile '${{ steps.delta-map.outputs.map_file }}' `
+            -ShardManifestFile '${{ steps.delta-map.outputs.manifest_file }}' `
             -WaitMinutes 40
 
       - name: Report resolver fallback
@@ -549,7 +594,10 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           INPUT_MAP_RUN_ID: ${{ inputs.test_impact_map_run_id }}
           FORCE_COVERAGE: ${{ inputs.collect_coverage_everywhere }}
-          MAP_BRANCH: ${{ github.base_ref || 'master' }}
+          # Maps are only ever built on master. A ci-proof/** branch is master plus the CI change under
+          # test, so a canary into it must select with master's map; looking for maps built on the
+          # proof branch found none and sent every canary to the full matrix, proving nothing.
+          MAP_BRANCH: ${{ startsWith(github.base_ref, 'ci-proof/') && 'master' || github.base_ref || 'master' }}
         run: |
           # Normal PRs may consume only an audited/certified map. The forced full-coverage run is
           # different: it consumes the exact candidate named by its dispatch input so that the next
@@ -653,6 +701,10 @@ jobs:
           # has gained since to the pull request. The selector verifies the checked-out merge commit's
           # second parent is this head and diffs against its first parent - the base actually tested.
           PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          # Post-merge delta reuse (validation-source): re-run only these, import these.
+          DELTA_MODE: ${{ needs.validation-source.outputs.delta_mode }}
+          PARTIAL_SHARDS: ${{ needs.validation-source.outputs.partial_shards }}
+          IMPORT_SHARDS: ${{ needs.validation-source.outputs.import_shards }}
         run: |
           $all = @(yq -o=json -I=0 '.shard' .github/test-shards.yml | ConvertFrom-Json)
           if ($all.Count -eq 0) {
@@ -696,11 +748,21 @@ jobs:
           # pull request", which is the kind of misleading-but-green log this feature keeps
           # producing when a condition is collapsed.
           #
-          # Only pull requests may reduce. Pushes, merge groups, schedules and dispatches run the
-          # full matrix. Exact-tree master reuse is handled independently by validation-source;
-          # selecting a master delta here would create a second, weaker reuse mechanism.
+          # Pull requests reduce by selecting over their own change. A push reduces only through
+          # validation-source's delta decision: it has already rebuilt the tree the pull request
+          # validated, selected over what the base branch added since, and named the overlap to
+          # re-run. This step never selects a master delta itself, so there is one reuse mechanism.
+          # Merge groups, schedules and dispatches always run the full matrix.
           $selectorTrusted = '${{ steps.selftest.outcome }}' -eq 'success'
           $eventCanReduce  = '${{ github.event_name }}' -eq 'pull_request'
+          function ConvertFrom-ShardList([string] $Json) {
+            if ([string]::IsNullOrWhiteSpace($Json)) { return @() }
+            return @($Json | ConvertFrom-Json | ForEach-Object { [string] $_ } | Where-Object { $_ })
+          }
+          $partialShards = @(ConvertFrom-ShardList $env:PARTIAL_SHARDS)
+          $importShards = @(ConvertFrom-ShardList $env:IMPORT_SHARDS)
+          $deltaPartial = '${{ github.event_name }}' -eq 'push' -and $env:DELTA_MODE -ceq 'Partial' -and
+            $partialShards.Count -gt 0
           $mapCertified = $false
 
           if ($env:MAP_KIND -eq 'certified' -and (Test-Path map/shard-map.json) -and
@@ -720,6 +782,21 @@ jobs:
 
           if (-not $selectorTrusted) {
             Write-Host '::error::the impact tooling failed its own self-test - running the full matrix.'
+            $deltaPartial = $false
+          }
+          elseif ($deltaPartial) {
+            $knownNames = [System.Collections.Generic.HashSet[string]]::new([string[]] @($all.name), [System.StringComparer]::Ordinal)
+            $unknown = @(@($partialShards) + @($importShards) | Where-Object { -not $knownNames.Contains($_) })
+            if ($unknown.Count -gt 0) {
+              Write-Host "::warning::delta plan names shard(s) absent from test-shards.yml: $($unknown -join ', ') - running the full matrix"
+              $deltaPartial = $false
+            }
+            else {
+              $escalate = $false
+              $requiresValidation = $true
+              $selected = @($partialShards)
+              Write-Host "post-merge delta: re-running $($partialShards.Count) shard(s) the base branch's later commits reach; importing $($importShards.Count) from the pull request run"
+            }
           }
           elseif (-not $eventCanReduce) {
             Write-Host "event is '${{ github.event_name }}', not a pull request - running the full matrix"
@@ -829,6 +906,11 @@ jobs:
           # shard key - it reads it back from shard-metadata.json.
           $running = [System.Collections.Generic.HashSet[string]]::new(
               [string[]] @($matrixShards.name), [System.StringComparer]::Ordinal)
+          # A delta-imported shard is not skipped: its pull-request results are imported as this
+          # run's own, so the regression analysis must see them, not an approved removal.
+          if ($deltaPartial -and -not $escalate) {
+            foreach ($name in $importShards) { [void] $running.Add($name) }
+          }
           $skipped = @(
             $all |
               Where-Object { -not $running.Contains([string] $_.name) } |
@@ -2110,6 +2192,30 @@ jobs:
           path: current-test-results
           merge-multiple: false
 
+      # Post-merge delta reuse: the shards this run did not re-run are the pull request's results,
+      # so the landed commit's ledger covers every shard the pull request validated.
+      - name: Download pull-request shard results for delta import
+        if: needs.validation-source.outputs.import_run_id != ''
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v4
+        with:
+          pattern: coverage-${{ needs.validation-source.outputs.import_sha }}-*
+          path: delta-import-staging
+          merge-multiple: false
+          repository: ${{ github.repository }}
+          run-id: ${{ needs.validation-source.outputs.import_run_id }}
+          github-token: ${{ github.token }}
+
+      - name: Import pull-request shard results
+        if: needs.validation-source.outputs.import_run_id != ''
+        shell: pwsh
+        env:
+          IMPORT_SHA: ${{ needs.validation-source.outputs.import_sha }}
+          IMPORT_SHARDS: ${{ needs.validation-source.outputs.import_shards }}
+        run: |
+          ./tools/TestImpact/Import-PullRequestShardArtifacts.ps1 -StagingDirectory delta-import-staging `
+            -DestinationDirectory current-test-results -ArtifactPrefix coverage `
+            -ImportSha $env:IMPORT_SHA -ImportShardsJson $env:IMPORT_SHARDS
+
       - name: Determine comparison base
         id: comparison
         shell: pwsh
@@ -2431,6 +2537,28 @@ jobs:
           path: TestResults
           merge-multiple: true
 
+      - name: Download pull-request coverage for delta import
+        if: ${{ fromJSON(env.EFFECTIVE_REQUIRES_VALIDATION) && needs.validation-source.outputs.import_run_id != '' }}
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v4
+        with:
+          github-token: ${{ github.token }}
+          repository: ${{ github.repository }}
+          run-id: ${{ needs.validation-source.outputs.import_run_id }}
+          pattern: coverage-${{ needs.validation-source.outputs.import_sha }}-*
+          path: delta-import-staging
+          merge-multiple: false
+
+      - name: Import pull-request coverage
+        if: ${{ fromJSON(env.EFFECTIVE_REQUIRES_VALIDATION) && needs.validation-source.outputs.import_run_id != '' }}
+        shell: pwsh
+        env:
+          IMPORT_SHA: ${{ needs.validation-source.outputs.import_sha }}
+          IMPORT_SHARDS: ${{ needs.validation-source.outputs.import_shards }}
+        run: |
+          ./tools/TestImpact/Import-PullRequestShardArtifacts.ps1 -StagingDirectory delta-import-staging `
+            -DestinationDirectory TestResults/delta-imported -ArtifactPrefix coverage `
+            -ImportSha $env:IMPORT_SHA -ImportShardsJson $env:IMPORT_SHARDS
+
       - name: Restore dependencies
         if: ${{ fromJSON(env.EFFECTIVE_REQUIRES_VALIDATION) }}
         run: dotnet restore
@@ -2596,6 +2724,28 @@ jobs:
         with:
           pattern: test-results-${{ github.sha }}-*
           path: TestDiagnostics
+
+      - name: Download pull-request diagnostics for delta import
+        if: needs.validation-source.outputs.import_run_id != ''
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v4
+        with:
+          pattern: test-results-${{ needs.validation-source.outputs.import_sha }}-*
+          path: delta-import-staging
+          merge-multiple: false
+          repository: ${{ github.repository }}
+          run-id: ${{ needs.validation-source.outputs.import_run_id }}
+          github-token: ${{ github.token }}
+
+      - name: Import pull-request diagnostics
+        if: needs.validation-source.outputs.import_run_id != ''
+        shell: pwsh
+        env:
+          IMPORT_SHA: ${{ needs.validation-source.outputs.import_sha }}
+          IMPORT_SHARDS: ${{ needs.validation-source.outputs.import_shards }}
+        run: |
+          ./tools/TestImpact/Import-PullRequestShardArtifacts.ps1 -StagingDirectory delta-import-staging `
+            -DestinationDirectory TestDiagnostics -ArtifactPrefix test-results `
+            -ImportSha $env:IMPORT_SHA -ImportShardsJson $env:IMPORT_SHARDS
 
       - name: Collect shard states and latest merged baseline
         shell: pwsh

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -163,6 +163,7 @@ jobs:
       - name: Checkout validation reuse policy
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v4
         with:
+          persist-credentials: false
           # Delta reuse rebuilds the pull request's validated tree from its merge parents and diffs
           # the landed commit against it in the certified map's line coordinates, which needs the
           # map commit and both parents in history.
@@ -2199,7 +2200,7 @@ jobs:
       # Post-merge delta reuse: the shards this run did not re-run are the pull request's results,
       # so the landed commit's ledger covers every shard the pull request validated.
       - name: Download pull-request shard results for delta import
-        if: needs.validation-source.outputs.import_run_id != ''
+        if: needs.validation-source.outputs.import_run_id != '' && needs.select-shards.outputs.escalated == 'false'
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v4
         with:
           pattern: coverage-${{ needs.validation-source.outputs.import_sha }}-*
@@ -2210,7 +2211,7 @@ jobs:
           github-token: ${{ github.token }}
 
       - name: Import pull-request shard results
-        if: needs.validation-source.outputs.import_run_id != ''
+        if: needs.validation-source.outputs.import_run_id != '' && needs.select-shards.outputs.escalated == 'false'
         shell: pwsh
         env:
           IMPORT_SHA: ${{ needs.validation-source.outputs.import_sha }}
@@ -2542,7 +2543,7 @@ jobs:
           merge-multiple: true
 
       - name: Download pull-request coverage for delta import
-        if: ${{ fromJSON(env.EFFECTIVE_REQUIRES_VALIDATION) && needs.validation-source.outputs.import_run_id != '' }}
+        if: ${{ fromJSON(env.EFFECTIVE_REQUIRES_VALIDATION) && needs.validation-source.outputs.import_run_id != '' && needs.select-shards.outputs.escalated == 'false' }}
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v4
         with:
           github-token: ${{ github.token }}
@@ -2553,7 +2554,7 @@ jobs:
           merge-multiple: false
 
       - name: Import pull-request coverage
-        if: ${{ fromJSON(env.EFFECTIVE_REQUIRES_VALIDATION) && needs.validation-source.outputs.import_run_id != '' }}
+        if: ${{ fromJSON(env.EFFECTIVE_REQUIRES_VALIDATION) && needs.validation-source.outputs.import_run_id != '' && needs.select-shards.outputs.escalated == 'false' }}
         shell: pwsh
         env:
           IMPORT_SHA: ${{ needs.validation-source.outputs.import_sha }}
@@ -2730,7 +2731,7 @@ jobs:
           path: TestDiagnostics
 
       - name: Download pull-request diagnostics for delta import
-        if: needs.validation-source.outputs.import_run_id != ''
+        if: needs.validation-source.outputs.import_run_id != '' && needs.select-shards.outputs.escalated == 'false'
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v4
         with:
           pattern: test-results-${{ needs.validation-source.outputs.import_sha }}-*
@@ -2741,7 +2742,7 @@ jobs:
           github-token: ${{ github.token }}
 
       - name: Import pull-request diagnostics
-        if: needs.validation-source.outputs.import_run_id != ''
+        if: needs.validation-source.outputs.import_run_id != '' && needs.select-shards.outputs.escalated == 'false'
         shell: pwsh
         env:
           IMPORT_SHA: ${{ needs.validation-source.outputs.import_sha }}

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -173,6 +173,9 @@ jobs:
         id: delta-map
         if: github.event_name == 'push'
         continue-on-error: true
+        # continue-on-error bounds the OUTCOME, not the duration: a stalled gh call here would eat
+        # the job's margin before the resolver's own 40-minute wait even starts.
+        timeout-minutes: 10
         shell: pwsh
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/test-impact-map.yml
+++ b/.github/workflows/test-impact-map.yml
@@ -371,6 +371,14 @@ jobs:
           & git checkout --quiet $sourceSha
           if ($LASTEXITCODE -ne 0) { throw 'checkout of audited commit failed - refusing to audit the wrong tree' }
 
+          # The audited tree's own shard filters, so replayed test-source routing is exactly what a pull
+          # request on that tree receives. Without it every test-source change escalates and the routing
+          # heuristic would never be measured against a complete matrix.
+          $auditManifest = Join-Path $env:RUNNER_TEMP 'audit-shard-manifest.json'
+          $auditShards = @(yq -o=json -I=0 '.shard' .github/test-shards.yml | ConvertFrom-Json)
+          ConvertTo-Json -InputObject @($auditShards | Select-Object name, project, filter) -Depth 3 |
+            Set-Content -LiteralPath $auditManifest -Encoding utf8
+
           $audit = $null
           $auditExit = 0
           $basis = ''
@@ -383,7 +391,8 @@ jobs:
             & (Join-Path $auditTools 'Measure-SelectionMiss.ps1') `
                 -SelectorPath (Join-Path $auditTools 'Select-Shards.ps1') `
                 -MapFile prevmap/shard-map.json -OutcomesFile outcomes.json `
-                -CurrentChangeBaseSha $sourceSha -OutFile historical-audit.json
+                -CurrentChangeBaseSha $sourceSha -ShardManifestFile $auditManifest `
+                -OutFile historical-audit.json
             $auditExit = $LASTEXITCODE
             & (Join-Path $auditTools 'New-ShardMapCertificate.ps1') `
                 -MapFile prevmap/shard-map.json -AuditFile historical-audit.json `
@@ -416,7 +425,8 @@ jobs:
             & (Join-Path $auditTools 'Measure-SelectionMiss.ps1') `
                 -SelectorPath (Join-Path $auditTools 'Select-Shards.ps1') `
                 -MapFile shard-map.json -OutcomesFile outcomes.json `
-                -CurrentChangeBaseSha $sourceSha -OutFile fresh-audit.json
+                -CurrentChangeBaseSha $sourceSha -ShardManifestFile $auditManifest `
+                -OutFile fresh-audit.json
             $auditExit = $LASTEXITCODE
             & (Join-Path $auditTools 'New-ShardMapCertificate.ps1') `
                 -MapFile shard-map.json -AuditFile fresh-audit.json -OutcomesFile outcomes.json `

--- a/tools/TestImpact/Import-PullRequestShardArtifacts.ps1
+++ b/tools/TestImpact/Import-PullRequestShardArtifacts.ps1
@@ -1,0 +1,121 @@
+<#
+.SYNOPSIS
+    Copies the pull request run's per-shard artifacts for the shards a partial post-merge run did
+    not re-run, so the landed commit's ledger, analysis and coverage still cover every shard the
+    pull request validated.
+
+.DESCRIPTION
+    Delta reuse (Resolve-CiValidationReuse.ps1) re-runs only the shards the base branch's later
+    commits could have affected and takes the rest from the pull request's run. Every consumer that
+    reads per-shard artifacts - the regression ledger, the aggregate analysis, Sonar's coverage -
+    must see those imported shards too, or the landed commit would be recorded as having validated
+    only the handful that re-ran.
+
+    The staging directory holds the pull request run's artifacts downloaded one folder per
+    artifact, named '<prefix>-<tested sha>-<slug>'. Exactly the listed shards are copied; a listed
+    shard with no artifact is an error, because the evidence the reuse decision relied on is then
+    missing and the landed commit cannot claim it.
+
+.PARAMETER DestinationDirectory
+    Each imported artifact keeps its own folder beneath this directory, exactly as a download with
+    merge-multiple: false lays it out. Consumers that merge artifacts (Sonar) import into a
+    subfolder their recursive glob already covers: every coverage artifact carries a root-level
+    shard-metadata.json, so merging imports into one folder would collide by construction.
+#>
+[CmdletBinding(DefaultParameterSetName = 'Import')]
+param(
+    [Parameter(Mandatory, ParameterSetName = 'Import')] [string] $StagingDirectory,
+    [Parameter(Mandatory, ParameterSetName = 'Import')] [string] $DestinationDirectory,
+    [Parameter(Mandatory, ParameterSetName = 'Import')] [ValidateSet('coverage', 'test-results')] [string] $ArtifactPrefix,
+    [Parameter(Mandatory, ParameterSetName = 'Import')] [string] $ImportSha,
+    [Parameter(Mandatory, ParameterSetName = 'Import')] [string] $ImportShardsJson,
+    [Parameter(Mandatory, ParameterSetName = 'SelfTest')] [switch] $SelfTest
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+function ConvertTo-ShardSlug {
+    # Identical to the test job's artifact naming.
+    param([Parameter(Mandatory)] [string] $Name)
+    return $Name -replace '[\\/:*?"<>|\s-]+', '_'
+}
+
+function Copy-ImportedShards {
+    param(
+        [Parameter(Mandatory)] [string] $Staging,
+        [Parameter(Mandatory)] [string] $Destination,
+        [Parameter(Mandatory)] [string] $Prefix,
+        [Parameter(Mandatory)] [string] $Sha,
+        [Parameter(Mandatory)] [AllowEmptyCollection()] [string[]] $Shards
+    )
+
+    if ($Sha -notmatch '^[0-9a-f]{40}$') { throw "import sha '$Sha' is not a lowercase 40-character Git SHA" }
+    New-Item -ItemType Directory -Path $Destination -Force | Out-Null
+    $missing = [System.Collections.Generic.List[string]]::new()
+    $copied = [System.Collections.Generic.List[string]]::new()
+    foreach ($shard in $Shards) {
+        $folderName = "$Prefix-$Sha-$(ConvertTo-ShardSlug $shard)"
+        $source = Join-Path $Staging $folderName
+        if (-not (Test-Path -LiteralPath $source -PathType Container)) {
+            [void] $missing.Add($shard)
+            continue
+        }
+        $target = Join-Path $Destination $folderName
+        if (Test-Path -LiteralPath $target) { throw "refusing to overwrite '$target' with an imported shard" }
+        Copy-Item -LiteralPath $source -Destination $target -Recurse
+        [void] $copied.Add($shard)
+    }
+    return [pscustomobject]@{ Copied = @($copied); Missing = @($missing) }
+}
+
+if ($SelfTest) {
+    $failures = [System.Collections.Generic.List[string]]::new()
+    function Assert-True { param([bool] $Condition, [string] $What) if (-not $Condition) { [void] $failures.Add($What) } }
+    $sha = '0123456789abcdef0123456789abcdef01234567'
+    $root = Join-Path ([System.IO.Path]::GetTempPath()) ("import-shards-" + [guid]::NewGuid().ToString('N'))
+    try {
+        foreach ($slug in @('Integration_E_G', 'Unit_10_RL', 'Integration_D')) {
+            $folder = Join-Path $root "staging/coverage-$sha-$slug/$slug"
+            New-Item -ItemType Directory -Path $folder -Force | Out-Null
+            "<coverage $slug/>" | Set-Content -LiteralPath (Join-Path $folder 'coverage.opencover.xml')
+        }
+        $r = Copy-ImportedShards -Staging "$root/staging" -Destination "$root/per" -Prefix coverage -Sha $sha `
+            -Shards @('Integration E-G', 'Unit - 10 RL')
+        Assert-True ((@($r.Copied) -join ',') -eq 'Integration E-G,Unit - 10 RL') 'the listed shards were not all copied'
+        Assert-True (Test-Path "$root/per/coverage-$sha-Integration_E_G/Integration_E_G/coverage.opencover.xml") `
+            'the per-artifact layout lost the artifact folder'
+        Assert-True (-not (Test-Path "$root/per/coverage-$sha-Integration_D")) `
+            'a re-run shard was imported from the pull request, shadowing the fresh result'
+
+        $r = Copy-ImportedShards -Staging "$root/staging" -Destination "$root/missing" -Prefix coverage -Sha $sha `
+            -Shards @('Integration E-G', 'ModelFamily - Audio')
+        Assert-True ((@($r.Missing) -join ',') -eq 'ModelFamily - Audio') 'a listed shard with no artifact was not reported missing'
+
+        New-Item -ItemType Directory -Path "$root/clash/coverage-$sha-Integration_E_G" -Force | Out-Null
+        $threw = $false
+        try { Copy-ImportedShards -Staging "$root/staging" -Destination "$root/clash" -Prefix coverage -Sha $sha -Shards @('Integration E-G') | Out-Null }
+        catch { $threw = $true }
+        Assert-True $threw 'an import that would overwrite this run''s own output was allowed'
+    }
+    finally {
+        Remove-Item -LiteralPath $root -Recurse -Force -ErrorAction SilentlyContinue
+    }
+    if ($failures.Count -gt 0) {
+        Write-Host 'Import-PullRequestShardArtifacts self-test FAILED:'
+        foreach ($f in $failures) { Write-Host "  - $f" }
+        exit 1
+    }
+    Write-Host 'Import-PullRequestShardArtifacts self-test passed.'
+    exit 0
+}
+
+$shards = @($ImportShardsJson | ConvertFrom-Json | ForEach-Object { [string] $_ } | Where-Object { $_ })
+$result = Copy-ImportedShards -Staging $StagingDirectory -Destination $DestinationDirectory -Prefix $ArtifactPrefix `
+    -Sha $ImportSha -Shards $shards
+Write-Host "imported $($result.Copied.Count) pull-request shard artifact(s) into $DestinationDirectory"
+foreach ($shard in $result.Copied) { Write-Host "  $shard" }
+if ($result.Missing.Count -gt 0) {
+    throw "the pull request run has no $ArtifactPrefix artifact for: $($result.Missing -join ', '). Reuse relied on these results, so their absence cannot be papered over."
+}
+exit 0

--- a/tools/TestImpact/Measure-SelectionMiss.ps1
+++ b/tools/TestImpact/Measure-SelectionMiss.ps1
@@ -48,6 +48,11 @@
     from the map SHA; this second boundary prevents already-merged selector-control edits from
     being mistaken for edits in every later pull request.
 
+.PARAMETER ShardManifestFile
+    Optional { name, project, filter } manifest passed through to the selector, so the audit replays
+    the same test-source routing pull requests receive. Without it test-source changes escalate
+    and the routing heuristic would never be measured.
+
 .PARAMETER OutFile
     Optional path for the JSON report.
 #>
@@ -57,6 +62,7 @@ param(
     [Parameter(Mandatory, ParameterSetName = 'Measure')] [string] $OutcomesFile,
     [Parameter(ParameterSetName = 'Measure')] [string] $SelectorPath = "$PSScriptRoot/Select-Shards.ps1",
     [Parameter(ParameterSetName = 'Measure')] [string] $CurrentChangeBaseSha,
+    [Parameter(ParameterSetName = 'Measure')] [string] $ShardManifestFile,
     [Parameter(ParameterSetName = 'Measure')] [string] $OutFile,
     [Parameter(Mandatory, ParameterSetName = 'SelfTest')] [switch] $SelfTest
 )
@@ -195,6 +201,9 @@ $selectorArguments = @{
 }
 if ($CurrentChangeBaseSha) {
     $selectorArguments.BaseSha = $CurrentChangeBaseSha
+}
+if ($ShardManifestFile) {
+    $selectorArguments.ShardManifestFile = $ShardManifestFile
 }
 & $SelectorPath @selectorArguments | Out-Null
 $selection = Get-Content -LiteralPath $selectionFile -Raw | ConvertFrom-Json

--- a/tools/TestImpact/Resolve-CiValidationReuse.ps1
+++ b/tools/TestImpact/Resolve-CiValidationReuse.ps1
@@ -148,9 +148,13 @@ function ConvertTo-CertificateEvidence {
             if ([string] $Certificate.gateConclusion -cne 'success') {
                 throw 'schema-v3 certificate did not pass its gate'
             }
+            if ($Certificate.scope -isnot [string]) {
+                throw 'schema-v3 certificate scope must be a named JSON string'
+            }
             $scopeText = [string] $Certificate.scope
             if (-not [Enum]::TryParse[CiValidationReuseScope]($scopeText, $false, [ref] $scope) -or
-                $scope -eq [CiValidationReuseScope]::None) {
+                -not [Enum]::IsDefined([CiValidationReuseScope], $scope) -or
+                $scope -eq [CiValidationReuseScope]::None -or $scope.ToString() -cne $scopeText) {
                 throw "schema-v3 certificate has unsupported scope '$scopeText'"
             }
             $testedTree = [string] $Certificate.testedTree
@@ -181,7 +185,7 @@ function Select-BestCiEvidence {
     param([Parameter(Mandatory)] [AllowEmptyCollection()] [object[]] $Evidence)
 
     $eligible = @($Evidence | Where-Object {
-        $_.TreeMatches -and
+        $_.CertificateTreeMatches -and $_.TreeMatches -and
         (-not $_.RequiresValidation -or ($_.HasAnalysis -and $_.HasCoverage -and $_.HasLedger))
     })
     if ($eligible.Count -eq 0) { return $null }
@@ -445,6 +449,11 @@ if ($SelfTest) {
     $badScope = $partialJson.PSObject.Copy(); $badScope.scope = 'AlmostComplete'
     Assert-Rejected { ConvertTo-CertificateEvidence $badScope 10 } `
         'an unknown certificate scope was accepted'
+    foreach ($invalidScope in @('999', '-1', '1', '2', 'validation', ' Validation ', 1, 2)) {
+        $numericScope = $partialJson.PSObject.Copy(); $numericScope.scope = $invalidScope
+        Assert-Rejected { ConvertTo-CertificateEvidence $numericScope 10 } `
+            "a non-canonical certificate scope was accepted: '$invalidScope' ($($invalidScope.GetType().Name))"
+    }
     Assert-Rejected { ConvertTo-CertificateEvidence $partialJson 99 } `
         'a certificate bound to another run was accepted'
     $stringRunId = $partialJson.PSObject.Copy(); $stringRunId.runId = '10'
@@ -453,7 +462,7 @@ if ($SelfTest) {
 
     $partialCandidate = [pscustomobject]@{
         Scope = [CiValidationReuseScope]::Validation; RunId = 10; CreatedAt = '2026-01-01T00:00:00Z'
-        TreeMatches = $true; RequiresValidation = $true; HasAnalysis = $true
+        CertificateTreeMatches = $true; TreeMatches = $true; RequiresValidation = $true; HasAnalysis = $true
         HasCoverage = $true; HasLedger = $true
     }
     $completeCandidate = $partialCandidate.PSObject.Copy()
@@ -545,13 +554,14 @@ if ($PlanDelta) {
     $plan = Invoke-DeltaPlan -BaseSha $TestedBaseSha -HeadSha $TestedHeadSha -ExpectedTree $TestedTree `
         -PullRequestShards $shards -Map $MapFile -Manifest $ShardManifestFile -Selector $SelectorPath
     $result = if ($plan -is [string]) {
-        [pscustomobject]@{ mode = 'None'; why = $plan; rerun = @(); import = @(); tree = ''; routes = @() }
+        [pscustomobject]@{ mode = 'None'; why = $plan; reason = ''; rerun = @(); import = @(); tree = ''; routes = @() }
     }
     else {
         [pscustomobject]@{
             mode = $plan.Decision.Mode.ToString(); why = $plan.Decision.Why
             rerun = @($plan.Decision.Rerun); import = @($plan.Decision.Import)
             tree = $plan.Tree; routes = @(Get-OptionalArray $plan.Selection 'routes')
+            reason = if ($plan.Selection.PSObject.Properties['reason']) { [string] $plan.Selection.reason } else { '' }
         }
     }
     $result | ConvertTo-Json -Depth 5 | Set-Content -LiteralPath $OutFile -Encoding utf8
@@ -660,8 +670,10 @@ do {
 
             $testedTree = [string] (& gh api "repos/$Repository/git/commits/$($parsed.TestedSha)" --jq '.tree.sha' 2>$null)
             if ($LASTEXITCODE -ne 0 -or $testedTree -cnotmatch '^[0-9a-f]{40}$') { continue }
-            $treeMatches = $testedTree -ceq $masterTree -and
-                (-not $parsed.TestedTree -or $parsed.TestedTree -ceq $testedTree)
+            # Certificate consistency is independent of whether the base moved after validation.
+            # A forged/inconsistent certificate must never become an eligible delta candidate.
+            $certificateTreeMatches = -not $parsed.TestedTree -or $parsed.TestedTree -ceq $testedTree
+            $treeMatches = $testedTree -ceq $masterTree
 
             $analysisArtifacts = @($artifacts | Where-Object {
                 ([string] $_.name).StartsWith('ci-test-analysis-', [StringComparison]::Ordinal)
@@ -698,6 +710,7 @@ do {
                 Event = [string] $run.event
                 HeadSha = [string] $run.head_sha
                 TreeMatches = $treeMatches
+                CertificateTreeMatches = $certificateTreeMatches
                 RequiresValidation = $parsed.RequiresValidation
                 HasAnalysis = $hasAnalysis
                 HasCoverage = $coverageCount -gt 0
@@ -757,7 +770,7 @@ function Get-DeltaPlan {
 }
 
 $deltaCandidates = @($evidence | Where-Object {
-    $_.Event -ceq 'pull_request' -and -not $_.TreeMatches -and
+    $_.CertificateTreeMatches -and $_.Event -ceq 'pull_request' -and -not $_.TreeMatches -and
     (-not $_.RequiresValidation -or ($_.HasAnalysis -and $_.HasCoverage -and $_.HasLedger))
 } | Sort-Object @{ Expression = { [DateTimeOffset] $_.CreatedAt }; Descending = $true },
                 @{ Expression = { [long] $_.RunId }; Descending = $true })

--- a/tools/TestImpact/Resolve-CiValidationReuse.ps1
+++ b/tools/TestImpact/Resolve-CiValidationReuse.ps1
@@ -287,6 +287,39 @@ function Invoke-DeltaPlan {
     return [pscustomobject]@{ Decision = $decision; Tree = $tree; Selection = $selection }
 }
 
+function Get-MissingImportArtifacts {
+    <#
+        Pure: which per-shard artifacts a partial re-run would import but the pull request run does
+        not have. Every consumer imports by exact name (Import-PullRequestShardArtifacts.ps1), and a
+        missing one fails that consumer - so a partial plan that relies on it must be declined up front
+        and the landed commit validated in full instead.
+    #>
+    param(
+        [Parameter(Mandatory)] [AllowEmptyCollection()] [string[]] $ArtifactNames,
+        [Parameter(Mandatory)] [string] $TestedSha,
+        [Parameter(Mandatory)] [AllowEmptyCollection()] [string[]] $Shards
+    )
+    $present = [System.Collections.Generic.HashSet[string]]::new([string[]] $ArtifactNames, [StringComparer]::Ordinal)
+    $missing = [System.Collections.Generic.List[string]]::new()
+    foreach ($shard in $Shards) {
+        $slug = $shard -replace '[\\/:*?"<>|\s-]+', '_'
+        foreach ($prefix in @('coverage', 'test-results')) {
+            $name = "$prefix-$TestedSha-$slug"
+            if (-not $present.Contains($name)) { [void] $missing.Add($name) }
+        }
+    }
+    return $missing.ToArray()
+}
+
+function Get-OptionalArray {
+    <# A property that may be absent (older selector output) read as an array, under StrictMode. #>
+    param($Object, [string] $Name)
+    if ($null -eq $Object) { return }
+    $property = $Object.PSObject.Properties[$Name]
+    if ($null -eq $property -or $null -eq $property.Value) { return }
+    return @($property.Value)
+}
+
 function Get-ShardFromJobName {
     <# 'Tests (net10.0) - Unit - 01 Activation' -> 'Unit - 01 Activation'; anything else -> $null. #>
     param([string] $JobName)
@@ -450,6 +483,25 @@ if ($SelfTest) {
     Assert-True ($null -eq (Get-ShardFromJobName 'Build')) 'a non-test job was read as a shard'
     Assert-True ($null -eq (Get-ShardFromJobName 'Tests')) 'a malformed test job name was read as a shard'
 
+    # A partial re-run imports both artifacts of every imported shard by exact name.
+    $tested = '0123456789abcdef0123456789abcdef01234567'
+    $names = @("coverage-$tested-Integration_E_G", "test-results-$tested-Integration_E_G",
+        "coverage-$tested-ModelFamily_Generated_Layers_F")
+    $missing = @(Get-MissingImportArtifacts -ArtifactNames $names -TestedSha $tested `
+        -Shards @('Integration E-G', 'ModelFamily - Generated Layers F'))
+    Assert-True (($missing -join ',') -ceq "test-results-$tested-ModelFamily_Generated_Layers_F") `
+        'a missing per-shard import artifact was not reported'
+    Assert-True (@(Get-MissingImportArtifacts -ArtifactNames $names -TestedSha $tested -Shards @('Integration E-G')).Count -eq 0) `
+        'a shard with both artifacts was reported missing'
+    Assert-True (@(Get-MissingImportArtifacts -ArtifactNames @() -TestedSha $tested -Shards @()).Count -eq 0) `
+        'an empty import list reported missing artifacts'
+
+    # Selector output read under StrictMode must tolerate an absent property.
+    Assert-True (@(Get-OptionalArray ([pscustomobject]@{ escalate = $true }) 'routes').Count -eq 0) `
+        'an absent routes property was not read as empty'
+    Assert-True ((@(Get-OptionalArray ([pscustomobject]@{ routes = @('a', 'b') }) 'routes') -join ',') -ceq 'a,b') `
+        'a present routes property was not read back'
+
     if ($failures.Count -gt 0) {
         Write-Host 'Resolve-CiValidationReuse self-test FAILED:'
         foreach ($failure in $failures) { Write-Host "  - $failure" }
@@ -473,7 +525,7 @@ if ($PlanDelta) {
         [pscustomobject]@{
             mode = $plan.Decision.Mode; why = $plan.Decision.Why
             rerun = @($plan.Decision.Rerun); import = @($plan.Decision.Import)
-            tree = $plan.Tree; routes = @($plan.Selection.routes)
+            tree = $plan.Tree; routes = @(Get-OptionalArray $plan.Selection 'routes')
         }
     }
     $result | ConvertTo-Json -Depth 5 | Set-Content -LiteralPath $OutFile -Encoding utf8
@@ -616,6 +668,7 @@ do {
                 CreatedAt = $createdAt
                 TestedSha = $parsed.TestedSha
                 TestedTree = $testedTree
+                ArtifactNames = @($artifacts | ForEach-Object { [string] $_.name })
                 Event = [string] $run.event
                 HeadSha = [string] $run.head_sha
                 TreeMatches = $treeMatches
@@ -697,8 +750,8 @@ if ($deltaCandidates.Count -gt 0 -and $MapFile -and $ShardManifestFile -and
     else {
         $decision = $plan.Decision
         Write-Host "delta from PR #$prNumber run $($candidate.RunId) (tree $($plan.Tree)): $($decision.Mode) - $($decision.Why)"
-        foreach ($route in @($plan.Selection.routes)) { Write-Host "  delta route: $route" }
-        foreach ($reason in @($plan.Selection.reasons)) { Write-Host "  delta reason: $reason" }
+        foreach ($route in @(Get-OptionalArray $plan.Selection 'routes')) { Write-Host "  delta route: $route" }
+        foreach ($reason in @(Get-OptionalArray $plan.Selection 'reasons')) { Write-Host "  delta reason: $reason" }
 
         if ($decision.Mode -ceq 'Reuse') {
             # Never Complete: CodeQL and Sonar analysed a different tree.
@@ -708,14 +761,26 @@ if ($deltaCandidates.Count -gt 0 -and $MapFile -and $ShardManifestFile -and
                 -DeltaMode 'Reuse' -ImportShards @($decision.Import) -Summary $summary
             exit 0
         }
+        $missingImports = @()
         if ($decision.Mode -ceq 'Partial') {
+            $missingImports = @(Get-MissingImportArtifacts -ArtifactNames @($candidate.ArtifactNames) `
+                -TestedSha $candidate.TestedSha -Shards @($decision.Import))
+        }
+        if ($decision.Mode -ceq 'Partial' -and $missingImports.Count -gt 0) {
+            # Every consumer imports these by exact name and fails on a missing one, so relying on
+            # them would turn a reuse decision into a red landed commit. Validate in full instead.
+            Write-Host "::notice::delta reuse declined: PR #$prNumber run $($candidate.RunId) lacks $($missingImports.Count) artifact(s) a partial re-run would import: $($missingImports -join ', ')"
+        }
+        elseif ($decision.Mode -ceq 'Partial') {
             $summary = "Re-running $($decision.Rerun.Count) shard(s) and importing $($decision.Import.Count) from PR #$prNumber run $($candidate.RunId): $($decision.Why).`n`nRe-run: $($decision.Rerun -join ', ')"
             Write-ReuseDecision -DecisionScope None -PrNumber $prNumber -DeltaMode 'Partial' `
                 -PartialShards @($decision.Rerun) -ImportRunId $candidate.RunId `
                 -ImportSha $candidate.TestedSha -ImportShards @($decision.Import) -Summary $summary
             exit 0
         }
-        Write-Host "::notice::delta reuse declined: $($decision.Why)"
+        if ($decision.Mode -ceq 'None') {
+            Write-Host "::notice::delta reuse declined: $($decision.Why)"
+        }
     }
 }
 

--- a/tools/TestImpact/Resolve-CiValidationReuse.ps1
+++ b/tools/TestImpact/Resolve-CiValidationReuse.ps1
@@ -63,6 +63,12 @@ enum CiValidationReuseScope {
     Complete
 }
 
+enum CiDeltaReuseMode {
+    None
+    Reuse
+    Partial
+}
+
 function ConvertTo-RequiredBooleanProperty {
     param($Object, [string] $Name)
     if (-not $Object.PSObject.Properties[$Name] -or $Object.$Name -isnot [bool]) {
@@ -203,11 +209,11 @@ function Get-DeltaReuseDecision {
     foreach ($shard in $PullRequestShards) { if ($shard) { [void] $pullRequest.Add([string] $shard) } }
 
     if ($SelectionEscalated) {
-        return [pscustomobject]@{ Mode = 'None'; Rerun = @(); Import = @()
+        return [pscustomobject]@{ Mode = [CiDeltaReuseMode]::None; Rerun = @(); Import = @()
             Why = 'the change since the validated tree needs the full matrix' }
     }
     if (-not $SelectionRequiresValidation) {
-        return [pscustomobject]@{ Mode = 'Reuse'; Rerun = @(); Import = @($pullRequest)
+        return [pscustomobject]@{ Mode = [CiDeltaReuseMode]::Reuse; Rerun = @(); Import = @($pullRequest)
             Why = 'the change since the validated tree is non-runtime' }
     }
 
@@ -215,17 +221,17 @@ function Get-DeltaReuseDecision {
     foreach ($shard in $DeltaShards) { if ($shard) { [void] $delta.Add([string] $shard) } }
     # An empty selection for a runtime delta is a selector anomaly, never permission to skip.
     if ($delta.Count -eq 0) {
-        return [pscustomobject]@{ Mode = 'None'; Rerun = @(); Import = @()
+        return [pscustomobject]@{ Mode = [CiDeltaReuseMode]::None; Rerun = @(); Import = @()
             Why = 'the selector returned no shards for a runtime change' }
     }
 
     $rerun = @($pullRequest | Where-Object { $delta.Contains($_) })
     $import = @($pullRequest | Where-Object { -not $delta.Contains($_) })
     if ($rerun.Count -eq 0) {
-        return [pscustomobject]@{ Mode = 'Reuse'; Rerun = @(); Import = $import
+        return [pscustomobject]@{ Mode = [CiDeltaReuseMode]::Reuse; Rerun = @(); Import = $import
             Why = 'the change since the validated tree reaches none of the shards the pull request ran' }
     }
-    return [pscustomobject]@{ Mode = 'Partial'; Rerun = $rerun; Import = $import
+    return [pscustomobject]@{ Mode = [CiDeltaReuseMode]::Partial; Rerun = $rerun; Import = $import
         Why = "the change since the validated tree reaches $($rerun.Count) of the $($pullRequest.Count) shard(s) the pull request ran" }
 }
 
@@ -287,6 +293,19 @@ function Invoke-DeltaPlan {
     return [pscustomobject]@{ Decision = $decision; Tree = $tree; Selection = $selection }
 }
 
+function Get-UnexpiredArtifactNames {
+    <# Keep the API metadata boundary testable: only positively nonexpired, named artifacts
+       can satisfy an import. Missing or malformed metadata is never proof of availability. #>
+    param([Parameter(Mandatory)] [AllowEmptyCollection()] [object[]] $Artifacts)
+    foreach ($artifact in $Artifacts) {
+        if ($null -ne $artifact -and $artifact.PSObject.Properties['name'] -and
+            $artifact.name -is [string] -and $artifact.PSObject.Properties['expired'] -and
+            $artifact.expired -is [bool] -and -not $artifact.expired) {
+            $artifact.name
+        }
+    }
+}
+
 function Get-MissingImportArtifacts {
     <#
         Pure: which per-shard artifacts a partial re-run would import but the pull request run does
@@ -337,7 +356,7 @@ function Write-ReuseDecision {
         [string] $TestedSha = '',
         [bool] $RequiresValidation = $true,
         [string] $Summary = '',
-        [string] $DeltaMode = '',
+        [Nullable[CiDeltaReuseMode]] $DeltaMode = $null,
         [string[]] $PartialShards = @(),
         [long] $ImportRunId = 0,
         [string] $ImportSha = '',
@@ -456,27 +475,27 @@ if ($SelfTest) {
     # ---- Delta reuse decisions. ----------------------------------------------------------------
     $pr = @('Integration D', 'Integration E-G', 'Unit - 10 RL')
     $d = Get-DeltaReuseDecision -SelectionEscalated $true -SelectionRequiresValidation $true -DeltaShards @() -PullRequestShards $pr
-    Assert-True ($d.Mode -ceq 'None') 'a delta that needs the full matrix was reused'
+    Assert-True ($d.Mode -eq [CiDeltaReuseMode]::None) 'a delta that needs the full matrix was reused'
     $d = Get-DeltaReuseDecision -SelectionEscalated $false -SelectionRequiresValidation $false -DeltaShards @() -PullRequestShards $pr
-    Assert-True ($d.Mode -ceq 'Reuse' -and @($d.Rerun).Count -eq 0) 'a non-runtime delta was not reused outright'
+    Assert-True ($d.Mode -eq [CiDeltaReuseMode]::Reuse -and @($d.Rerun).Count -eq 0) 'a non-runtime delta was not reused outright'
     $d = Get-DeltaReuseDecision -SelectionEscalated $false -SelectionRequiresValidation $true `
         -DeltaShards @('Unit - 02 Data', 'ModelFamily - Audio') -PullRequestShards $pr
-    Assert-True ($d.Mode -ceq 'Reuse') 'a delta reaching none of the pull request''s shards was not reused'
+    Assert-True ($d.Mode -eq [CiDeltaReuseMode]::Reuse) 'a delta reaching none of the pull request''s shards was not reused'
     Assert-True (((@($d.Import) | Sort-Object) -join ',') -eq ((@($pr) | Sort-Object) -join ',')) `
         'a full delta reuse did not account for every pull-request shard'
     $d = Get-DeltaReuseDecision -SelectionEscalated $false -SelectionRequiresValidation $true `
         -DeltaShards @('Integration D', 'Unit - 02 Data') -PullRequestShards $pr
-    Assert-True ($d.Mode -ceq 'Partial') 'an overlapping delta did not produce a partial re-run'
+    Assert-True ($d.Mode -eq [CiDeltaReuseMode]::Partial) 'an overlapping delta did not produce a partial re-run'
     Assert-True ((@($d.Rerun) -join ',') -ceq 'Integration D') 'a partial re-run included shards outside the overlap'
     Assert-True ((@($d.Import) -join ',') -ceq 'Integration E-G,Unit - 10 RL') `
         'a partial re-run did not import exactly the pull request''s other shards'
     Assert-True (-not (@($d.Rerun) -contains 'Unit - 02 Data')) `
         'a shard only the base branch''s own commits reach was re-run for this pull request'
     $d = Get-DeltaReuseDecision -SelectionEscalated $false -SelectionRequiresValidation $true -DeltaShards @() -PullRequestShards $pr
-    Assert-True ($d.Mode -ceq 'None') 'an empty selection for a runtime delta was treated as permission to skip'
+    Assert-True ($d.Mode -eq [CiDeltaReuseMode]::None) 'an empty selection for a runtime delta was treated as permission to skip'
     $d = Get-DeltaReuseDecision -SelectionEscalated $false -SelectionRequiresValidation $true `
         -DeltaShards @('integration d') -PullRequestShards $pr
-    Assert-True ($d.Mode -ceq 'Reuse') 'shard names were matched ignoring case'
+    Assert-True ($d.Mode -eq [CiDeltaReuseMode]::Reuse) 'shard names were matched ignoring case'
 
     Assert-True ((Get-ShardFromJobName 'Tests (net10.0) - Unit - 01 Activation/Attention') -ceq 'Unit - 01 Activation/Attention') `
         'a test job name did not yield its shard'
@@ -523,7 +542,7 @@ if ($PlanDelta) {
     }
     else {
         [pscustomobject]@{
-            mode = $plan.Decision.Mode; why = $plan.Decision.Why
+            mode = $plan.Decision.Mode.ToString(); why = $plan.Decision.Why
             rerun = @($plan.Decision.Rerun); import = @($plan.Decision.Import)
             tree = $plan.Tree; routes = @(Get-OptionalArray $plan.Selection 'routes')
         }
@@ -668,7 +687,7 @@ do {
                 CreatedAt = $createdAt
                 TestedSha = $parsed.TestedSha
                 TestedTree = $testedTree
-                ArtifactNames = @($artifacts | ForEach-Object { [string] $_.name })
+                ArtifactNames = @(Get-UnexpiredArtifactNames -Artifacts $artifacts)
                 Event = [string] $run.event
                 HeadSha = [string] $run.head_sha
                 TreeMatches = $treeMatches
@@ -753,32 +772,32 @@ if ($deltaCandidates.Count -gt 0 -and $MapFile -and $ShardManifestFile -and
         foreach ($route in @(Get-OptionalArray $plan.Selection 'routes')) { Write-Host "  delta route: $route" }
         foreach ($reason in @(Get-OptionalArray $plan.Selection 'reasons')) { Write-Host "  delta reason: $reason" }
 
-        if ($decision.Mode -ceq 'Reuse') {
+        if ($decision.Mode -eq [CiDeltaReuseMode]::Reuse) {
             # Never Complete: CodeQL and Sonar analysed a different tree.
             $summary = "Reusing Validation evidence from PR #$prNumber run $($candidate.RunId) across the base branch's later commits: $($decision.Why)."
             Write-ReuseDecision -DecisionScope Validation -RunId $candidate.RunId -PrNumber $prNumber `
                 -TestedSha $candidate.TestedSha -RequiresValidation $candidate.RequiresValidation `
-                -DeltaMode 'Reuse' -ImportShards @($decision.Import) -Summary $summary
+                -DeltaMode ([CiDeltaReuseMode]::Reuse) -ImportShards @($decision.Import) -Summary $summary
             exit 0
         }
         $missingImports = @()
-        if ($decision.Mode -ceq 'Partial') {
+        if ($decision.Mode -eq [CiDeltaReuseMode]::Partial) {
             $missingImports = @(Get-MissingImportArtifacts -ArtifactNames @($candidate.ArtifactNames) `
                 -TestedSha $candidate.TestedSha -Shards @($decision.Import))
         }
-        if ($decision.Mode -ceq 'Partial' -and $missingImports.Count -gt 0) {
+        if ($decision.Mode -eq [CiDeltaReuseMode]::Partial -and $missingImports.Count -gt 0) {
             # Every consumer imports these by exact name and fails on a missing one, so relying on
             # them would turn a reuse decision into a red landed commit. Validate in full instead.
             Write-Host "::notice::delta reuse declined: PR #$prNumber run $($candidate.RunId) lacks $($missingImports.Count) artifact(s) a partial re-run would import: $($missingImports -join ', ')"
         }
-        elseif ($decision.Mode -ceq 'Partial') {
+        elseif ($decision.Mode -eq [CiDeltaReuseMode]::Partial) {
             $summary = "Re-running $($decision.Rerun.Count) shard(s) and importing $($decision.Import.Count) from PR #$prNumber run $($candidate.RunId): $($decision.Why).`n`nRe-run: $($decision.Rerun -join ', ')"
-            Write-ReuseDecision -DecisionScope None -PrNumber $prNumber -DeltaMode 'Partial' `
+            Write-ReuseDecision -DecisionScope None -PrNumber $prNumber -DeltaMode ([CiDeltaReuseMode]::Partial) `
                 -PartialShards @($decision.Rerun) -ImportRunId $candidate.RunId `
                 -ImportSha $candidate.TestedSha -ImportShards @($decision.Import) -Summary $summary
             exit 0
         }
-        if ($decision.Mode -ceq 'None') {
+        if ($decision.Mode -eq [CiDeltaReuseMode]::None) {
             Write-Host "::notice::delta reuse declined: $($decision.Why)"
         }
     }

--- a/tools/TestImpact/Resolve-CiValidationReuse.ps1
+++ b/tools/TestImpact/Resolve-CiValidationReuse.ps1
@@ -1,12 +1,31 @@
 <#
 .SYNOPSIS
-    Resolves exact-tree CI evidence for a landed pull request.
+    Resolves CI evidence for a landed pull request: exact-tree reuse, or delta reuse when the pull
+    request was behind its base branch.
 
 .DESCRIPTION
     A Validation certificate suppresses build/test/model validation but deliberately reruns
     CodeQL and Sonar. A Complete certificate suppresses both stages. Every runtime certificate
     additionally requires the immutable analysis, outcome-ledger, and coverage artifacts that the
     landed run must promote. Missing, malformed, stale, or tree-mismatched evidence fails closed.
+
+    DELTA REUSE. A pull request merged while behind its base branch lands a tree that differs from
+    the one its run validated - by exactly the commits the base branch gained in between (Δ).
+    Exact-tree matching can never reuse that, which is why nearly every merge re-ran the full
+    matrix. With a certified map, Δ is selected like any other change:
+
+      * Δ needs the full matrix (a CI-control, build or unmappable edit)  -> run everything.
+      * Δ touches no shard the pull request ran                          -> reuse its results.
+      * Δ touches some of the pull request's shards                      -> re-run only those,
+        and import the pull request's artifacts for the rest, so the landed commit's ledger,
+        analysis and coverage still describe every shard the pull request validated.
+
+    A shard Δ affects but the pull request did not run was validated by the commits that make up Δ,
+    each on its own run, and this pull request's change does not reach it; that is the same premise
+    pull-request selection itself rests on, and the nightly miss audit measures it.
+
+    Delta reuse is at most Validation-scoped: CodeQL and Sonar analysed a different tree, so they
+    always run again on the landed one.
 #>
 [CmdletBinding(DefaultParameterSetName = 'Resolve')]
 param(
@@ -16,6 +35,22 @@ param(
     [Parameter(Mandatory, ParameterSetName = 'Resolve')] [string] $ExpectedBaseBranch,
     [Parameter(Mandatory, ParameterSetName = 'Resolve')] [string] $GitHubOutput,
     [Parameter(ParameterSetName = 'Resolve')] [ValidateRange(0, 120)] [int] $WaitMinutes = 40,
+    # Delta reuse inputs. Without a certified map there is nothing to select with, and an
+    # exact-tree mismatch keeps failing closed exactly as before.
+    [Parameter(ParameterSetName = 'Resolve')]
+    [Parameter(Mandatory, ParameterSetName = 'PlanDelta')] [string] $MapFile,
+    [Parameter(ParameterSetName = 'Resolve')]
+    [Parameter(Mandatory, ParameterSetName = 'PlanDelta')] [string] $ShardManifestFile,
+    [Parameter(ParameterSetName = 'Resolve')]
+    [Parameter(ParameterSetName = 'PlanDelta')] [string] $SelectorPath = "$PSScriptRoot/Select-Shards.ps1",
+    # Offline delta planning against the checked-out landed commit, for tests and diagnosis:
+    # the tested merge commit's parents and tree, and the shards its run executed.
+    [Parameter(Mandatory, ParameterSetName = 'PlanDelta')] [switch] $PlanDelta,
+    [Parameter(Mandatory, ParameterSetName = 'PlanDelta')] [string] $TestedBaseSha,
+    [Parameter(Mandatory, ParameterSetName = 'PlanDelta')] [string] $TestedHeadSha,
+    [Parameter(Mandatory, ParameterSetName = 'PlanDelta')] [string] $TestedTree,
+    [Parameter(Mandatory, ParameterSetName = 'PlanDelta')] [AllowEmptyString()] [string] $PullRequestShardsJson,
+    [Parameter(Mandatory, ParameterSetName = 'PlanDelta')] [string] $OutFile,
     [Parameter(Mandatory, ParameterSetName = 'SelfTest')] [switch] $SelfTest
 )
 
@@ -151,6 +186,116 @@ function Select-BestCiEvidence {
         Select-Object -First 1)[0]
 }
 
+function Get-DeltaReuseDecision {
+    <#
+        Pure: the landed commit's validation plan from the selector's verdict on Δ and the shards
+        the pull request's run executed. Mode is Reuse (nothing to re-run), Partial (re-run Rerun,
+        import Import from the pull request run) or None (run the full matrix).
+    #>
+    param(
+        [Parameter(Mandatory)] [bool] $SelectionEscalated,
+        [Parameter(Mandatory)] [bool] $SelectionRequiresValidation,
+        [Parameter(Mandatory)] [AllowEmptyCollection()] [string[]] $DeltaShards,
+        [Parameter(Mandatory)] [AllowEmptyCollection()] [string[]] $PullRequestShards
+    )
+
+    $pullRequest = [System.Collections.Generic.SortedSet[string]]::new([StringComparer]::Ordinal)
+    foreach ($shard in $PullRequestShards) { if ($shard) { [void] $pullRequest.Add([string] $shard) } }
+
+    if ($SelectionEscalated) {
+        return [pscustomobject]@{ Mode = 'None'; Rerun = @(); Import = @()
+            Why = 'the change since the validated tree needs the full matrix' }
+    }
+    if (-not $SelectionRequiresValidation) {
+        return [pscustomobject]@{ Mode = 'Reuse'; Rerun = @(); Import = @($pullRequest)
+            Why = 'the change since the validated tree is non-runtime' }
+    }
+
+    $delta = [System.Collections.Generic.HashSet[string]]::new([StringComparer]::Ordinal)
+    foreach ($shard in $DeltaShards) { if ($shard) { [void] $delta.Add([string] $shard) } }
+    # An empty selection for a runtime delta is a selector anomaly, never permission to skip.
+    if ($delta.Count -eq 0) {
+        return [pscustomobject]@{ Mode = 'None'; Rerun = @(); Import = @()
+            Why = 'the selector returned no shards for a runtime change' }
+    }
+
+    $rerun = @($pullRequest | Where-Object { $delta.Contains($_) })
+    $import = @($pullRequest | Where-Object { -not $delta.Contains($_) })
+    if ($rerun.Count -eq 0) {
+        return [pscustomobject]@{ Mode = 'Reuse'; Rerun = @(); Import = $import
+            Why = 'the change since the validated tree reaches none of the shards the pull request ran' }
+    }
+    return [pscustomobject]@{ Mode = 'Partial'; Rerun = $rerun; Import = $import
+        Why = "the change since the validated tree reaches $($rerun.Count) of the $($pullRequest.Count) shard(s) the pull request ran" }
+}
+
+function Resolve-ValidatedTree {
+    <#
+        Rebuilds the tree a pull-request run validated from its merge commit's two parents, and
+        returns it only if it is byte-identical to the tree GitHub reports for that commit.
+
+        The tested merge commit itself is usually unreachable once the pull request merges (its
+        refs/pull/N/merge ref moves or is removed), so it cannot be relied on to be fetchable. Its
+        parents - the base-branch commit and the pull request head - remain reachable. A
+        conflicting rebuild, or any tree difference, returns $null: delta reuse then fails closed.
+    #>
+    param(
+        [Parameter(Mandatory)] [string] $BaseSha,
+        [Parameter(Mandatory)] [string] $HeadSha,
+        [Parameter(Mandatory)] [string] $ExpectedTree
+    )
+
+    $output = @(& git merge-tree --write-tree --no-messages $BaseSha $HeadSha 2>$null)
+    if ($LASTEXITCODE -ne 0 -or $output.Count -eq 0) { return $null }
+    $tree = ([string] $output[0]).Trim()
+    if ($tree -cne $ExpectedTree) { return $null }
+    return $tree
+}
+
+function Invoke-DeltaPlan {
+    <#
+        Everything delta reuse decides from Git alone: rebuild the validated tree from the tested
+        merge commit's parents, select over what the checked-out landed commit adds to it, and
+        intersect with the shards the pull request ran. Returns a failure string, or the plan.
+    #>
+    param(
+        [Parameter(Mandatory)] [string] $BaseSha,
+        [Parameter(Mandatory)] [string] $HeadSha,
+        [Parameter(Mandatory)] [string] $ExpectedTree,
+        [Parameter(Mandatory)] [AllowEmptyCollection()] [string[]] $PullRequestShards,
+        [Parameter(Mandatory)] [string] $Map,
+        [Parameter(Mandatory)] [string] $Manifest,
+        [Parameter(Mandatory)] [string] $Selector
+    )
+
+    $tree = Resolve-ValidatedTree -BaseSha $BaseSha -HeadSha $HeadSha -ExpectedTree $ExpectedTree
+    if ($null -eq $tree) { return "the validated tree $ExpectedTree could not be rebuilt exactly from its parents" }
+
+    $expectedShards = @(Get-Content -LiteralPath $Manifest -Raw | ConvertFrom-Json | ForEach-Object { [string] $_.name })
+    $selectionFile = Join-Path ([System.IO.Path]::GetTempPath()) "delta-selection-$PID-$([guid]::NewGuid().ToString('N')).json"
+    try {
+        & $Selector -MapFile $Map -DeltaFromTree $tree -ShardManifestFile $Manifest `
+            -ExpectedShards $expectedShards -OutFile $selectionFile | Out-Host
+        if ($LASTEXITCODE -ne 0 -or -not (Test-Path -LiteralPath $selectionFile)) { return 'the delta selector failed' }
+        $selection = Get-Content -LiteralPath $selectionFile -Raw | ConvertFrom-Json
+    }
+    finally { Remove-Item -LiteralPath $selectionFile -ErrorAction SilentlyContinue }
+
+    $decision = Get-DeltaReuseDecision -SelectionEscalated ([bool] $selection.escalate) `
+        -SelectionRequiresValidation ([bool] $selection.requiresValidation) `
+        -DeltaShards @($selection.shards) -PullRequestShards $PullRequestShards
+    return [pscustomobject]@{ Decision = $decision; Tree = $tree; Selection = $selection }
+}
+
+function Get-ShardFromJobName {
+    <# 'Tests (net10.0) - Unit - 01 Activation' -> 'Unit - 01 Activation'; anything else -> $null. #>
+    param([string] $JobName)
+    if (-not $JobName.StartsWith('Tests (', [StringComparison]::Ordinal)) { return $null }
+    $separator = $JobName.IndexOf(') - ', [StringComparison]::Ordinal)
+    if ($separator -lt 0) { return $null }
+    return $JobName.Substring($separator + 4)
+}
+
 function Write-ReuseDecision {
     param(
         [Parameter(Mandatory)] [CiValidationReuseScope] $DecisionScope,
@@ -158,7 +303,12 @@ function Write-ReuseDecision {
         [long] $PrNumber = 0,
         [string] $TestedSha = '',
         [bool] $RequiresValidation = $true,
-        [string] $Summary = ''
+        [string] $Summary = '',
+        [string] $DeltaMode = '',
+        [string[]] $PartialShards = @(),
+        [long] $ImportRunId = 0,
+        [string] $ImportSha = '',
+        [string[]] $ImportShards = @()
     )
 
     $reuse = $DecisionScope -ne [CiValidationReuseScope]::None
@@ -172,7 +322,12 @@ function Write-ReuseDecision {
         "reuse_quality=$($reuseQuality.ToString().ToLowerInvariant())",
         "reused_requires_validation=$($RequiresValidation.ToString().ToLowerInvariant())",
         "execute_validation=$(((-not $reuse)).ToString().ToLowerInvariant())",
-        "execute_quality=$(((-not $reuseQuality)).ToString().ToLowerInvariant())"
+        "execute_quality=$(((-not $reuseQuality)).ToString().ToLowerInvariant())",
+        "delta_mode=$DeltaMode",
+        "partial_shards=$(ConvertTo-Json -InputObject @($PartialShards) -Compress)",
+        "import_run_id=$(if ($ImportRunId -gt 0) { $ImportRunId } else { '' })",
+        "import_sha=$ImportSha",
+        "import_shards=$(ConvertTo-Json -InputObject @($ImportShards) -Compress)"
     )
     $lines | Out-File -LiteralPath $GitHubOutput -Append -Encoding utf8
     if ($Summary -and $env:GITHUB_STEP_SUMMARY) {
@@ -265,12 +420,64 @@ if ($SelfTest) {
     Assert-True ($null -ne (Select-BestCiEvidence @($nonRuntime))) `
         'non-runtime evidence incorrectly required test artifacts'
 
+    # ---- Delta reuse decisions. ----------------------------------------------------------------
+    $pr = @('Integration D', 'Integration E-G', 'Unit - 10 RL')
+    $d = Get-DeltaReuseDecision -SelectionEscalated $true -SelectionRequiresValidation $true -DeltaShards @() -PullRequestShards $pr
+    Assert-True ($d.Mode -ceq 'None') 'a delta that needs the full matrix was reused'
+    $d = Get-DeltaReuseDecision -SelectionEscalated $false -SelectionRequiresValidation $false -DeltaShards @() -PullRequestShards $pr
+    Assert-True ($d.Mode -ceq 'Reuse' -and @($d.Rerun).Count -eq 0) 'a non-runtime delta was not reused outright'
+    $d = Get-DeltaReuseDecision -SelectionEscalated $false -SelectionRequiresValidation $true `
+        -DeltaShards @('Unit - 02 Data', 'ModelFamily - Audio') -PullRequestShards $pr
+    Assert-True ($d.Mode -ceq 'Reuse') 'a delta reaching none of the pull request''s shards was not reused'
+    Assert-True (((@($d.Import) | Sort-Object) -join ',') -eq ((@($pr) | Sort-Object) -join ',')) `
+        'a full delta reuse did not account for every pull-request shard'
+    $d = Get-DeltaReuseDecision -SelectionEscalated $false -SelectionRequiresValidation $true `
+        -DeltaShards @('Integration D', 'Unit - 02 Data') -PullRequestShards $pr
+    Assert-True ($d.Mode -ceq 'Partial') 'an overlapping delta did not produce a partial re-run'
+    Assert-True ((@($d.Rerun) -join ',') -ceq 'Integration D') 'a partial re-run included shards outside the overlap'
+    Assert-True ((@($d.Import) -join ',') -ceq 'Integration E-G,Unit - 10 RL') `
+        'a partial re-run did not import exactly the pull request''s other shards'
+    Assert-True (-not (@($d.Rerun) -contains 'Unit - 02 Data')) `
+        'a shard only the base branch''s own commits reach was re-run for this pull request'
+    $d = Get-DeltaReuseDecision -SelectionEscalated $false -SelectionRequiresValidation $true -DeltaShards @() -PullRequestShards $pr
+    Assert-True ($d.Mode -ceq 'None') 'an empty selection for a runtime delta was treated as permission to skip'
+    $d = Get-DeltaReuseDecision -SelectionEscalated $false -SelectionRequiresValidation $true `
+        -DeltaShards @('integration d') -PullRequestShards $pr
+    Assert-True ($d.Mode -ceq 'Reuse') 'shard names were matched ignoring case'
+
+    Assert-True ((Get-ShardFromJobName 'Tests (net10.0) - Unit - 01 Activation/Attention') -ceq 'Unit - 01 Activation/Attention') `
+        'a test job name did not yield its shard'
+    Assert-True ($null -eq (Get-ShardFromJobName 'Build')) 'a non-test job was read as a shard'
+    Assert-True ($null -eq (Get-ShardFromJobName 'Tests')) 'a malformed test job name was read as a shard'
+
     if ($failures.Count -gt 0) {
         Write-Host 'Resolve-CiValidationReuse self-test FAILED:'
         foreach ($failure in $failures) { Write-Host "  - $failure" }
         exit 1
     }
     Write-Host 'Resolve-CiValidationReuse self-test passed.'
+    exit 0
+}
+
+if ($PlanDelta) {
+    $shards = @()
+    if (-not [string]::IsNullOrWhiteSpace($PullRequestShardsJson)) {
+        $shards = @($PullRequestShardsJson | ConvertFrom-Json | ForEach-Object { [string] $_ } | Where-Object { $_ })
+    }
+    $plan = Invoke-DeltaPlan -BaseSha $TestedBaseSha -HeadSha $TestedHeadSha -ExpectedTree $TestedTree `
+        -PullRequestShards $shards -Map $MapFile -Manifest $ShardManifestFile -Selector $SelectorPath
+    $result = if ($plan -is [string]) {
+        [pscustomobject]@{ mode = 'None'; why = $plan; rerun = @(); import = @(); tree = ''; routes = @() }
+    }
+    else {
+        [pscustomobject]@{
+            mode = $plan.Decision.Mode; why = $plan.Decision.Why
+            rerun = @($plan.Decision.Rerun); import = @($plan.Decision.Import)
+            tree = $plan.Tree; routes = @($plan.Selection.routes)
+        }
+    }
+    $result | ConvertTo-Json -Depth 5 | Set-Content -LiteralPath $OutFile -Encoding utf8
+    Write-Host "delta plan: $($result.mode) - $($result.why)"
     exit 0
 }
 
@@ -408,6 +615,9 @@ do {
                 PrNumber = $prNumber
                 CreatedAt = $createdAt
                 TestedSha = $parsed.TestedSha
+                TestedTree = $testedTree
+                Event = [string] $run.event
+                HeadSha = [string] $run.head_sha
                 TreeMatches = $treeMatches
                 RequiresValidation = $parsed.RequiresValidation
                 HasAnalysis = $hasAnalysis
@@ -430,6 +640,84 @@ do {
     Write-Host "PR #$prNumber validation is still in flight; waiting for reusable evidence."
     Start-Sleep -Seconds 60
 } while ($true)
+
+# ---------------------------------------------------------------- delta reuse
+# No exact-tree evidence. The pull request was validated on a base branch that has since moved on;
+# decide from the certified map whether that movement can have changed any result it certified.
+
+function Get-DeltaPlan {
+    param([Parameter(Mandatory)] $Candidate)
+
+    $commit = Invoke-GhJson @('api', "repos/$Repository/git/commits/$($Candidate.TestedSha)")
+    $parents = @($commit.parents | ForEach-Object { [string] $_.sha })
+    if ($parents.Count -ne 2) { return "the validated commit is not a two-parent pull-request merge" }
+    if ($parents[1] -cne $Candidate.HeadSha) { return "the validated commit's second parent is not the pull request head" }
+
+    foreach ($sha in $parents) {
+        & git cat-file -e "$sha^{commit}" 2>$null
+        if ($LASTEXITCODE -eq 0) { continue }
+        & git fetch --quiet --no-tags origin $sha 2>$null
+        if ($sha -ceq $parents[1]) { & git fetch --quiet --no-tags origin "refs/pull/$prNumber/head" 2>$null }
+        & git cat-file -e "$sha^{commit}" 2>$null
+        if ($LASTEXITCODE -ne 0) { return "commit $sha is not available to rebuild the validated tree" }
+    }
+    $pullRequestShards = @()
+    if ($Candidate.RequiresValidation) {
+        $jobPages = @(Invoke-GhJson @('api', '--paginate', '--slurp',
+            "repos/$Repository/actions/runs/$($Candidate.RunId)/jobs?per_page=100"))
+        $pullRequestShards = @($jobPages | ForEach-Object { $_.jobs } |
+            Where-Object { [string] $_.conclusion -in @('success', 'failure') } |
+            ForEach-Object { Get-ShardFromJobName ([string] $_.name) } |
+            Where-Object { $_ } | Sort-Object -Unique)
+        # A runtime certificate with no executed shard is not evidence of anything to reuse.
+        if ($pullRequestShards.Count -eq 0) { return 'the validated run executed no test shards' }
+    }
+
+    return Invoke-DeltaPlan -BaseSha $parents[0] -HeadSha $parents[1] -ExpectedTree $Candidate.TestedTree `
+        -PullRequestShards $pullRequestShards -Map $MapFile -Manifest $ShardManifestFile -Selector $SelectorPath
+}
+
+$deltaCandidates = @($evidence | Where-Object {
+    $_.Event -ceq 'pull_request' -and -not $_.TreeMatches -and
+    (-not $_.RequiresValidation -or ($_.HasAnalysis -and $_.HasCoverage -and $_.HasLedger))
+} | Sort-Object @{ Expression = { [DateTimeOffset] $_.CreatedAt }; Descending = $true },
+                @{ Expression = { [long] $_.RunId }; Descending = $true })
+
+if ($deltaCandidates.Count -gt 0 -and $MapFile -and $ShardManifestFile -and
+    (Test-Path -LiteralPath $MapFile) -and (Test-Path -LiteralPath $ShardManifestFile)) {
+    # The newest validated state is the closest to what landed, so it leaves the smallest delta.
+    $candidate = $deltaCandidates[0]
+    $plan = $null
+    try { $plan = Get-DeltaPlan -Candidate $candidate }
+    catch { $plan = "delta planning failed: $($_.Exception.Message)" }
+
+    if ($plan -is [string]) {
+        Write-Host "::notice::delta reuse unavailable for PR #$prNumber run $($candidate.RunId): $plan"
+    }
+    else {
+        $decision = $plan.Decision
+        Write-Host "delta from PR #$prNumber run $($candidate.RunId) (tree $($plan.Tree)): $($decision.Mode) - $($decision.Why)"
+        foreach ($route in @($plan.Selection.routes)) { Write-Host "  delta route: $route" }
+        foreach ($reason in @($plan.Selection.reasons)) { Write-Host "  delta reason: $reason" }
+
+        if ($decision.Mode -ceq 'Reuse') {
+            # Never Complete: CodeQL and Sonar analysed a different tree.
+            $summary = "Reusing Validation evidence from PR #$prNumber run $($candidate.RunId) across the base branch's later commits: $($decision.Why)."
+            Write-ReuseDecision -DecisionScope Validation -RunId $candidate.RunId -PrNumber $prNumber `
+                -TestedSha $candidate.TestedSha -RequiresValidation $candidate.RequiresValidation `
+                -DeltaMode 'Reuse' -ImportShards @($decision.Import) -Summary $summary
+            exit 0
+        }
+        if ($decision.Mode -ceq 'Partial') {
+            $summary = "Re-running $($decision.Rerun.Count) shard(s) and importing $($decision.Import.Count) from PR #$prNumber run $($candidate.RunId): $($decision.Why).`n`nRe-run: $($decision.Rerun -join ', ')"
+            Write-ReuseDecision -DecisionScope None -PrNumber $prNumber -DeltaMode 'Partial' `
+                -PartialShards @($decision.Rerun) -ImportRunId $candidate.RunId `
+                -ImportSha $candidate.TestedSha -ImportShards @($decision.Import) -Summary $summary
+            exit 0
+        }
+        Write-Host "::notice::delta reuse declined: $($decision.Why)"
+    }
+}
 
 Write-ReuseDecision -DecisionScope None -PrNumber $prNumber `
     -Summary "No exact-tree validation evidence is reusable for PR #$prNumber; current-run validation is required."

--- a/tools/TestImpact/Resolve-CiValidationReuse.ps1
+++ b/tools/TestImpact/Resolve-CiValidationReuse.ps1
@@ -363,6 +363,13 @@ function Write-ReuseDecision {
         [string[]] $ImportShards = @()
     )
 
+    # Empty imports must not authorize the workflow's coverage-artifact download. Keep this
+    # output invariant here so partial reruns and whole-result reuse cannot emit stale metadata.
+    if ($ImportShards.Count -eq 0) {
+        $ImportRunId = 0
+        $ImportSha = ''
+    }
+
     $reuse = $DecisionScope -ne [CiValidationReuseScope]::None
     $reuseQuality = $DecisionScope -eq [CiValidationReuseScope]::Complete
     $lines = @(

--- a/tools/TestImpact/ReviewFixtureCleanup.ps1
+++ b/tools/TestImpact/ReviewFixtureCleanup.ps1
@@ -1,0 +1,35 @@
+<# Shared cleanup boundary for the local test-impact review fixtures. #>
+Set-StrictMode -Version Latest
+
+function Remove-ReviewFixtureDirectory {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)] [string] $LiteralPath,
+        [Parameter(Mandatory)] [ValidatePattern('^aidotnet-[a-z0-9-]+-$')] [string] $ExpectedLeafPrefix,
+        [switch] $ThrowOnUnsafePath
+    )
+
+    $resolved = [IO.Path]::GetFullPath($LiteralPath)
+    $tempRoot = [IO.Path]::GetFullPath([IO.Path]::GetTempPath())
+    $separators = [char[]] @([IO.Path]::DirectorySeparatorChar, [IO.Path]::AltDirectorySeparatorChar)
+    $prefix = $tempRoot.TrimEnd($separators) + [IO.Path]::DirectorySeparatorChar
+    $comparison = if ([IO.Path]::DirectorySeparatorChar -eq '\') { [StringComparison]::OrdinalIgnoreCase } else { [StringComparison]::Ordinal }
+    $safe = $resolved.StartsWith($prefix, $comparison) -and
+        [IO.Path]::GetFileName($resolved).StartsWith($ExpectedLeafPrefix, [StringComparison]::Ordinal)
+    # Do not traverse a linked ancestor on the way to an otherwise correctly named fixture.
+    $ancestor = $resolved
+    while ($safe -and $ancestor.StartsWith($prefix, $comparison)) {
+        if (Test-Path -LiteralPath $ancestor) {
+            $item = Get-Item -LiteralPath $ancestor -Force
+            if (($item.Attributes -band [IO.FileAttributes]::ReparsePoint) -ne 0) { $safe = $false }
+        }
+        $ancestor = [IO.Path]::GetDirectoryName($ancestor)
+    }
+    if (-not $safe) {
+        $message = "refusing to remove unexpected fixture path '$resolved'"
+        if ($ThrowOnUnsafePath) { throw $message }
+        Write-Warning $message
+        return
+    }
+    Remove-Item -LiteralPath $resolved -Recurse -Force -ErrorAction SilentlyContinue
+}

--- a/tools/TestImpact/Select-Shards.ps1
+++ b/tools/TestImpact/Select-Shards.ps1
@@ -18,6 +18,23 @@
     always-run shards. Ordinary PR selection must not pass this switch: an unexpectedly empty PR
     diff remains a fail-closed full-matrix decision.
 
+.PARAMETER PullRequestHeadSha
+    The pull request's head commit. The checkout must be GitHub's merge of that head onto the base
+    branch; its first parent is then the exact base this run validates against, and only the
+    paths the merge changes relative to it are this pull request's change. Mutually exclusive
+    with BaseSha.
+
+.PARAMETER BaseSha
+    An explicit base for the current change. The nightly audit passes the audited commit itself,
+    so every map-to-HEAD path is replayed as one change and only selection-control edits are
+    treated as historical. Pull requests must use PullRequestHeadSha instead: the event's
+    base.sha is stale whenever the pull request is behind its base branch.
+
+.PARAMETER ShardManifestFile
+    JSON array of { name, project, filter } for every shard (the converted test-shards.yml).
+    Test sources are never in the coverage map, so without this every test-file change escalates;
+    with it they are routed to the shards whose filters select their tests.
+
 .PARAMETER SelfTest
     Runs the built-in adversarial checks and exits.
 #>
@@ -26,8 +43,11 @@ param(
     [Parameter(Mandatory, ParameterSetName = 'Select')] [string] $MapFile,
     [Parameter(Mandatory, ParameterSetName = 'Select')] [string[]] $ExpectedShards,
     [Parameter(ParameterSetName = 'Select')] [switch] $AuditUnchangedMap,
+    [Parameter(ParameterSetName = 'Select')] [string] $ShardManifestFile,
     [Parameter(ParameterSetName = 'Select')]
-    [Parameter(Mandatory, ParameterSetName = 'Classify')] [string] $BaseSha,
+    [Parameter(ParameterSetName = 'Classify')] [string] $BaseSha,
+    [Parameter(ParameterSetName = 'Select')]
+    [Parameter(ParameterSetName = 'Classify')] [string] $PullRequestHeadSha,
     [Parameter(ParameterSetName = 'Select')]
     [Parameter(ParameterSetName = 'Classify')] [string] $OutFile,
     [Parameter(Mandatory, ParameterSetName = 'Classify')] [switch] $ClassifyOnly,
@@ -57,7 +77,11 @@ $script:SelectionControlPaths = @(
     '.github/workflows/test-impact-map.yml',
     '.github/workflows/ci-shard-closure-policy.yml'
 )
-$script:FullValidationDirectories = @('.github/actions/', '.github/scripts/')
+# Build-time code: the source generators the test project loads as an analyzer. It runs inside the
+# compiler, so runtime coverage never records it, yet one edit can rewrite thousands of generated
+# test classes across every ModelFamily shard. No coverage-derived routing can bound that.
+$script:BuildTimeDirectories = @('src/AiDotNet.Generators/')
+$script:FullValidationDirectories = @('.github/actions/', '.github/scripts/') + $script:BuildTimeDirectories
 $script:SelectionControlDirectories = @('tools/TestImpact/')
 $script:NonRuntimeWorkflowPaths = @(
     '.github/workflows/azure-functions-deploy.yml',
@@ -322,17 +346,64 @@ function Get-ChangedRanges {
     return ConvertTo-ChangedRanges -DiffLines $diff -ChangedFiles $changedFiles
 }
 
+function Get-DirectoryOwners {
+    <#
+        The shards that execute any mapped file in the nearest directory of Path that has one, never
+        climbing above a two-segment root such as 'src/Finance'. A brand-new source file has no
+        coverage of its own, but the code beside it does; climbing to 'src/' itself would stop
+        meaning anything, so an orphan with no mapped neighbour below that depth still escalates.
+    #>
+    param([Parameter(Mandatory)] $Map, [Parameter(Mandatory)] [string] $Path)
+
+    $segments = @(([string] $Path).Replace('\', '/').Split('/'))
+    for ($depth = $segments.Count - 1; $depth -ge 2; $depth--) {
+        $directory = ($segments[0..($depth - 1)] -join '/') + '/'
+        $owners = [System.Collections.Generic.SortedSet[string]]::new([StringComparer]::Ordinal)
+        foreach ($property in $Map.files.PSObject.Properties) {
+            if (-not $property.Name.StartsWith($directory, [StringComparison]::OrdinalIgnoreCase)) { continue }
+            foreach ($occurrence in @($property.Value)) {
+                [void] $owners.Add([string] $Map.knownShards[[int] $occurrence.s])
+            }
+        }
+        if ($owners.Count -gt 0) {
+            return [pscustomobject]@{ Directory = $directory.TrimEnd('/'); Shards = @($owners) }
+        }
+    }
+    return $null
+}
+
+function Format-LineRanges {
+    param([AllowEmptyCollection()] [object[]] $Ranges)
+    return (@($Ranges | ForEach-Object { "$($_[0])-$($_[1])" }) -join ', ')
+}
+
 function Select-ImpactedShards {
+    <#
+        CurrentPaths is the change being validated. With -ScopeToCurrentPaths, only those paths are
+        selected for: Changed still supplies their line ranges in the MAP's coordinates, but a file
+        that differs from the map only because master moved on since the map was built belongs to
+        commits that were validated when they landed, not to this pull request.
+
+        Without the switch (the nightly audit, which replays everything since the map as one
+        change) CurrentPaths only decides whether a selection-control edit is current.
+
+        TestRoutes carries the precomputed routing for test sources the coverage map cannot index;
+        see Get-TestFileRoutes. Every selected shard is recorded in Routes with the reason it was
+        selected, so a log reader can see why a shard runs without re-deriving it.
+    #>
     param(
         [Parameter(Mandatory)] $Map,
         [Parameter(Mandatory)] [hashtable] $Changed,
         [AllowEmptyCollection()] [string[]] $CurrentPaths = @(),
+        [switch] $ScopeToCurrentPaths,
+        [hashtable] $TestRoutes = @{},
         [switch] $AuditUnchangedMap
     )
 
     $selected = [System.Collections.Generic.HashSet[string]]::new([StringComparer]::Ordinal)
     $mappedPaths = [System.Collections.Generic.List[string]]::new()
     $reasons = [System.Collections.Generic.List[string]]::new()
+    $routes = [System.Collections.Generic.List[string]]::new()
     $escalate = $false
     $currentPathSet = [System.Collections.Generic.HashSet[string]]::new([StringComparer]::OrdinalIgnoreCase)
     $effectiveCurrentPaths = if ($PSBoundParameters.ContainsKey('CurrentPaths')) {
@@ -342,10 +413,42 @@ function Select-ImpactedShards {
         @($Changed.Keys)
     }
     foreach ($currentPath in $effectiveCurrentPaths) {
-        [void] $currentPathSet.Add(([string] $currentPath).Replace('\', '/'))
+        if (-not [string]::IsNullOrWhiteSpace([string] $currentPath)) {
+            [void] $currentPathSet.Add(([string] $currentPath).Replace('\', '/'))
+        }
+    }
+
+    if ($ScopeToCurrentPaths) {
+        # Scoping discards every path outside the pull request, so an empty pull-request path set
+        # would otherwise discard everything and read as a deliberate non-runtime result.
+        if ($currentPathSet.Count -eq 0) {
+            return [pscustomobject]@{
+                Escalate           = $true
+                RequiresValidation = $true
+                Reasons            = @("the pull request's own changed path set was empty")
+                Shards             = @()
+                Routes             = @()
+            }
+        }
+
+        # A pull-request path whose content equals the map's own copy has no map-to-HEAD hunks, yet
+        # it still differs from the merge base (master changed it after the map and this pull
+        # request reverted that). Its effect cannot be expressed in the map's line numbers.
+        $changedPathSet = [System.Collections.Generic.HashSet[string]]::new([StringComparer]::OrdinalIgnoreCase)
+        foreach ($key in $Changed.Keys) { [void] $changedPathSet.Add(([string] $key).Replace('\', '/')) }
+        foreach ($currentPath in ($currentPathSet | Sort-Object)) {
+            if ((Get-ChangedPathImpact -Path $currentPath) -eq [ChangedPathImpact]::NonRuntime) { continue }
+            if (-not $changedPathSet.Contains($currentPath)) {
+                $escalate = $true
+                [void] $reasons.Add("changed by this pull request but identical to the map's copy, so its effect has no map line numbers: $currentPath")
+            }
+        }
     }
 
     foreach ($path in ($Changed.Keys | Sort-Object)) {
+        if ($ScopeToCurrentPaths -and -not $currentPathSet.Contains(([string] $path).Replace('\', '/'))) {
+            continue
+        }
         $impact = Get-ChangedPathImpact -Path $path
         switch ($impact) {
             ([ChangedPathImpact]::NonRuntime) { continue }
@@ -383,6 +486,7 @@ function Select-ImpactedShards {
                     RequiresValidation = $true
                     Reasons            = @('map and audited tree are unchanged')
                     Shards             = @($selected | Sort-Object)
+                    Routes             = @($selected | Sort-Object | ForEach-Object { "$_ <= is always run" })
                 }
             }
         }
@@ -392,6 +496,7 @@ function Select-ImpactedShards {
             RequiresValidation = $true
             Reasons             = @('changed path set was empty')
             Shards              = @()
+            Routes              = @()
         }
     }
 
@@ -403,17 +508,53 @@ function Select-ImpactedShards {
             RequiresValidation = $escalate
             Reasons           = $reasons
             Shards            = @()
+            Routes            = @()
         }
     }
 
-    foreach ($shard in @($Map.alwaysRun)) { [void] $selected.Add([string] $shard) }
+    foreach ($shard in @($Map.alwaysRun)) {
+        [void] $selected.Add([string] $shard)
+        [void] $routes.Add("$shard <= is always run")
+    }
 
     foreach ($path in $mappedPaths) {
 
         $entry = $Map.files.PSObject.Properties[$path]
         if (-not $entry) {
-            $escalate = $true
-            [void] $reasons.Add("not executed by any mapped shard: $path")
+            if ($TestRoutes.ContainsKey($path)) {
+                # Test sources are never instrumented, so the map can never index them. Their owning
+                # shards come from the manifest's own filters instead; see Get-TestFileRoutes.
+                $route = $TestRoutes[$path]
+                if ($route.Routable) {
+                    foreach ($shard in @($route.Shards)) {
+                        [void] $selected.Add([string] $shard)
+                        [void] $routes.Add("$shard <= runs tests affected by $path ($($route.Why))")
+                    }
+                }
+                else {
+                    $escalate = $true
+                    [void] $reasons.Add("$($route.Why): $path")
+                }
+                continue
+            }
+
+            # An unmapped source file - normally one this pull request adds - has no coverage of its
+            # own. Only C# is routed to its directory's owners: an unmapped project, props or data
+            # file can change how everything builds or loads, which no neighbour's coverage bounds.
+            $directoryOwners = $null
+            if ($path.EndsWith('.cs', [StringComparison]::OrdinalIgnoreCase) -and
+                -not $path.StartsWith('tests/', [StringComparison]::OrdinalIgnoreCase)) {
+                $directoryOwners = Get-DirectoryOwners -Map $Map -Path $path
+            }
+            if ($null -eq $directoryOwners) {
+                $escalate = $true
+                [void] $reasons.Add("not executed by any mapped shard: $path")
+                continue
+            }
+            foreach ($shard in @($directoryOwners.Shards)) {
+                [void] $selected.Add([string] $shard)
+                [void] $routes.Add("$shard <= executes mapped files in $($directoryOwners.Directory), beside the unmapped source $path")
+            }
             continue
         }
 
@@ -425,9 +566,12 @@ function Select-ImpactedShards {
         }
 
         $covered = [bool[]]::new([int] ($hunks.Count / 2))
+        $fileOwners = [System.Collections.Generic.SortedSet[string]]::new([StringComparer]::Ordinal)
+        $hitsByShard = [ordered]@{}
         foreach ($occurrence in @($entry.Value)) {
             $ranges = @($occurrence.r)
             $shardName = [string] $Map.knownShards[[int] $occurrence.s]
+            [void] $fileOwners.Add($shardName)
             for ($h = 0; $h + 1 -lt $hunks.Count; $h += 2) {
                 $hit = $false
                 for ($i = 0; $i + 1 -lt $ranges.Count; $i += 2) {
@@ -440,14 +584,30 @@ function Select-ImpactedShards {
                 if ($hit) {
                     $covered[[int] ($h / 2)] = $true
                     [void] $selected.Add($shardName)
+                    if (-not $hitsByShard.Contains($shardName)) {
+                        $hitsByShard[$shardName] = [System.Collections.Generic.List[object]]::new()
+                    }
+                    [void] $hitsByShard[$shardName].Add(@($hunks[$h], $hunks[$h + 1]))
                 }
             }
         }
+        foreach ($shardName in $hitsByShard.Keys) {
+            [void] $routes.Add("$shardName <= executes changed lines $(Format-LineRanges $hitsByShard[$shardName]) of $path")
+        }
 
+        # A changed range no shard executes is routed to every shard that executes ANY line of the
+        # same file. Most such ranges are not dead code: they are declarations coverage never
+        # records (fields, attributes, braces between methods) or the insertion point of new code,
+        # whose effect reaches tests only through the file's executed members. This is the
+        # heuristic the nightly miss audit exists to check.
+        $uncovered = [System.Collections.Generic.List[object]]::new()
         for ($h = 0; $h + 1 -lt $hunks.Count; $h += 2) {
-            if (-not $covered[[int] ($h / 2)]) {
-                $escalate = $true
-                [void] $reasons.Add("changed range $($hunks[$h])-$($hunks[$h + 1]) is not executed by any mapped shard: $path")
+            if (-not $covered[[int] ($h / 2)]) { [void] $uncovered.Add(@($hunks[$h], $hunks[$h + 1])) }
+        }
+        if ($uncovered.Count -gt 0) {
+            foreach ($shardName in $fileOwners) {
+                [void] $selected.Add($shardName)
+                [void] $routes.Add("$shardName <= executes $path, whose changed lines $(Format-LineRanges $uncovered) no shard executes")
             }
         }
     }
@@ -462,7 +622,631 @@ function Select-ImpactedShards {
         RequiresValidation = $true
         Reasons            = $reasons
         Shards             = @($selected | Sort-Object)
+        Routes             = @($routes)
     }
+}
+
+# ------------------------------------------------------------- test routing
+
+function ConvertTo-TestFilter {
+    <#
+        Parses a VSTest filter into an expression tree. VSTest's grammar: conditions
+        Property(=|!=|~|!~)Value joined by '&' and '|', '&' binding tighter, with parentheses.
+        Whitespace around tokens is insignificant (folded YAML inserts it at line breaks).
+        Anything outside that grammar throws, and the caller then routes nothing - it escalates.
+    #>
+    param([Parameter(Mandatory)] [string] $Text)
+
+    if ($Text.Contains('\')) { throw 'escaped filter characters are not supported' }
+    $tokens = [System.Collections.Generic.List[string]]::new()
+    foreach ($match in [regex]::Matches($Text, '[()&|]|[^()&|]+')) {
+        $value = $match.Value.Trim()
+        if ($value.Length -gt 0) { [void] $tokens.Add($value) }
+    }
+
+    function Read-Or {
+        $items = [System.Collections.Generic.List[object]]::new()
+        [void] $items.Add((Read-And))
+        while ($script:filterPosition -lt $tokens.Count -and $tokens[$script:filterPosition] -eq '|') {
+            $script:filterPosition++
+            [void] $items.Add((Read-And))
+        }
+        if ($items.Count -eq 1) { return $items[0] }
+        return [pscustomobject]@{ Kind = 'Or'; Items = @($items) }
+    }
+    function Read-And {
+        $items = [System.Collections.Generic.List[object]]::new()
+        [void] $items.Add((Read-Factor))
+        while ($script:filterPosition -lt $tokens.Count -and $tokens[$script:filterPosition] -eq '&') {
+            $script:filterPosition++
+            [void] $items.Add((Read-Factor))
+        }
+        if ($items.Count -eq 1) { return $items[0] }
+        return [pscustomobject]@{ Kind = 'And'; Items = @($items) }
+    }
+    function Read-Factor {
+        if ($script:filterPosition -ge $tokens.Count) { throw 'filter ended where a condition was expected' }
+        $token = $tokens[$script:filterPosition]
+        if ($token -eq '(') {
+            $script:filterPosition++
+            $inner = Read-Or
+            if ($script:filterPosition -ge $tokens.Count -or $tokens[$script:filterPosition] -ne ')') {
+                throw 'unbalanced parenthesis in filter'
+            }
+            $script:filterPosition++
+            return $inner
+        }
+        if ($token -in @(')', '&', '|')) { throw "unexpected '$token' in filter" }
+        if ($token -notmatch '^(?<p>[A-Za-z][\w.]*)\s*(?<op>!=|!~|=|~)\s*(?<v>\S(?:.*\S)?)$') {
+            throw "unparseable filter condition '$token'"
+        }
+        $script:filterPosition++
+        return [pscustomobject]@{ Kind = 'Condition'; Property = $Matches.p; Operator = $Matches.op; Value = $Matches.v }
+    }
+
+    $script:filterPosition = 0
+    $tree = Read-Or
+    if ($script:filterPosition -ne $tokens.Count) { throw "unexpected '$($tokens[$script:filterPosition])' in filter" }
+    return $tree
+}
+
+# Three-valued results. Unknown means "this test might match", so a shard is skipped only when its
+# filter is definitely false for every test the changed file can contain.
+$script:FilterFalse = 0
+$script:FilterTrue = 1
+$script:FilterUnknown = 2
+
+function Invert-FilterResult {
+    param([int] $Value)
+    if ($Value -eq $script:FilterUnknown) { return $script:FilterUnknown }
+    return 1 - $Value
+}
+
+function Test-OpenSuffixCanComplete {
+    <#
+        Whether Prefix followed by some unknown suffix can contain (or, with -Exact, equal) Value.
+        AnySuffix admits any text; otherwise the suffix is one method identifier, which contains no
+        '.' or '+', so a namespace or class term that is not already in the prefix cannot appear.
+    #>
+    param([string] $Prefix, [string] $Value, [bool] $AnySuffix, [switch] $Exact)
+
+    for ($k = 0; $k -le $Value.Length; $k++) {
+        $head = $Value.Substring(0, $k)
+        $tail = $Value.Substring($k)
+        $headFits = if ($Exact) { $Prefix.Equals($head, [StringComparison]::OrdinalIgnoreCase) }
+                    else { $Prefix.EndsWith($head, [StringComparison]::OrdinalIgnoreCase) }
+        if (-not $headFits) { continue }
+        if ($AnySuffix -or $tail -match '^\w*$') { return $true }
+    }
+    return $false
+}
+
+function Test-FilterStringCondition {
+    <#
+        Actual is either a test's complete fully qualified name, or - when PrefixOnly - the known
+        start of names whose remainder cannot be read from this file (inherited tests, or a test
+        whose declaration could not be read). Each comparison is made both ordinally and ignoring
+        case; if the two disagree the result is Unknown, so neither VSTest casing behaviour can
+        make a matching test look excluded.
+    #>
+    param([string] $Actual, [bool] $PrefixOnly, [bool] $AnySuffix, [string] $Operator, [string] $Value)
+
+    $negated = $Operator.StartsWith('!')
+    if ($Operator.EndsWith('~')) {
+        $ordinal = $Actual.Contains($Value, [StringComparison]::Ordinal)
+        $ignoreCase = $Actual.Contains($Value, [StringComparison]::OrdinalIgnoreCase)
+        $result = if ($ordinal) { $script:FilterTrue }
+                  elseif ($ignoreCase) { $script:FilterUnknown }
+                  elseif ($PrefixOnly -and (Test-OpenSuffixCanComplete -Prefix $Actual -Value $Value -AnySuffix $AnySuffix)) {
+                      $script:FilterUnknown
+                  }
+                  else { $script:FilterFalse }
+    }
+    else {
+        if ($PrefixOnly) {
+            $result = if (Test-OpenSuffixCanComplete -Prefix $Actual -Value $Value -AnySuffix $AnySuffix -Exact) {
+                          $script:FilterUnknown
+                      }
+                      else { $script:FilterFalse }
+        }
+        else {
+            $ordinal = $Actual.Equals($Value, [StringComparison]::Ordinal)
+            $ignoreCase = $Actual.Equals($Value, [StringComparison]::OrdinalIgnoreCase)
+            $result = if ($ordinal) { $script:FilterTrue }
+                      elseif ($ignoreCase) { $script:FilterUnknown }
+                      else { $script:FilterFalse }
+        }
+    }
+    if ($negated) { return Invert-FilterResult $result }
+    return $result
+}
+
+function Test-TestFilter {
+    param([Parameter(Mandatory)] $Node, [Parameter(Mandatory)] $Candidate)
+
+    switch ($Node.Kind) {
+        'And' {
+            $sawUnknown = $false
+            foreach ($item in $Node.Items) {
+                $value = Test-TestFilter -Node $item -Candidate $Candidate
+                if ($value -eq $script:FilterFalse) { return $script:FilterFalse }
+                if ($value -eq $script:FilterUnknown) { $sawUnknown = $true }
+            }
+            if ($sawUnknown) { return $script:FilterUnknown }
+            return $script:FilterTrue
+        }
+        'Or' {
+            $sawUnknown = $false
+            foreach ($item in $Node.Items) {
+                $value = Test-TestFilter -Node $item -Candidate $Candidate
+                if ($value -eq $script:FilterTrue) { return $script:FilterTrue }
+                if ($value -eq $script:FilterUnknown) { $sawUnknown = $true }
+            }
+            if ($sawUnknown) { return $script:FilterUnknown }
+            return $script:FilterFalse
+        }
+        'Condition' {
+            if ($Node.Property -ieq 'FullyQualifiedName') {
+                return Test-FilterStringCondition -Actual $Candidate.Fqn -PrefixOnly $Candidate.PrefixOnly -AnySuffix $Candidate.AnySuffix `
+                    -Operator $Node.Operator -Value $Node.Value
+            }
+            if ($Node.Property -ieq 'Category') {
+                # Categories are known only as the union over the whole file, so a category that
+                # appears somewhere in the file may or may not be on this particular test.
+                if ($null -eq $Candidate.Categories) { return $script:FilterUnknown }
+                $present = $false
+                foreach ($category in $Candidate.Categories) {
+                    $hit = if ($Node.Operator.EndsWith('~')) {
+                        $category.Contains($Node.Value, [StringComparison]::OrdinalIgnoreCase)
+                    } else {
+                        $category.Equals($Node.Value, [StringComparison]::OrdinalIgnoreCase)
+                    }
+                    if ($hit) { $present = $true; break }
+                }
+                if ($present) { return $script:FilterUnknown }
+                if ($Node.Operator.StartsWith('!')) { return $script:FilterTrue }
+                return $script:FilterFalse
+            }
+            # Any other property is not modelled, so it can never be what excludes a test.
+            return $script:FilterUnknown
+        }
+        default { throw "unknown filter node '$($Node.Kind)'" }
+    }
+}
+
+function ConvertTo-CodeOnlyCSharp {
+    <#
+        Blanks the CONTENT of comments, strings and character literals (newlines are kept, so
+        offsets and line numbers survive), leaving only code. Brace matching and declaration
+        matching then cannot be fooled by '{' in a string or 'class X' in a comment.
+    #>
+    param([Parameter(Mandatory)] [AllowEmptyString()] [string] $Text)
+
+    $pattern = '(?s)//[^\n]*|/\*.*?\*/|\$*(?<q>"{3,}).*?\k<q>|(?:\$@|@\$|@)"(?:[^"]|"")*"|\$?"(?:[^"\\\n]|\\.)*"|''(?:[^''\\\n]|\\.){1,10}'''
+    $builder = [System.Text.StringBuilder]::new($Text.Length)
+    $last = 0
+    foreach ($match in [regex]::Matches($Text, $pattern)) {
+        [void] $builder.Append($Text, $last, $match.Index - $last)
+        [void] $builder.Append(($match.Value -replace '[^\r\n]', ' '))
+        $last = $match.Index + $match.Length
+    }
+    [void] $builder.Append($Text, $last, $Text.Length - $last)
+    return $builder.ToString()
+}
+
+function Get-CSharpTestShape {
+    <#
+        Reads, from one C# test source, what VSTest filters can see: every test's fully qualified
+        name, the Category traits the file can carry, and the top-level types other files could
+        reference. Returns ParseError instead of guessing when the braces do not balance.
+    #>
+    param([Parameter(Mandatory)] [AllowEmptyString()] [string] $Text)
+
+    $code = ConvertTo-CodeOnlyCSharp -Text $Text
+    $shape = [pscustomobject]@{
+        Types          = [System.Collections.Generic.List[object]]::new()
+        Tests          = [System.Collections.Generic.List[object]]::new()
+        Categories     = $null
+        Hazard         = $null
+        ParseError     = $null
+    }
+
+    # Brace pairs by position.
+    $open = [System.Collections.Generic.Stack[int]]::new()
+    $closeOf = @{}
+    foreach ($brace in [regex]::Matches($code, '[{}]')) {
+        if ($brace.Value -eq '{') { $open.Push($brace.Index); continue }
+        if ($open.Count -eq 0) { $shape.ParseError = 'unbalanced braces'; return $shape }
+        $closeOf[$open.Pop()] = $brace.Index
+    }
+    if ($open.Count -ne 0) { $shape.ParseError = 'unbalanced braces'; return $shape }
+
+    function Get-BodyRange([int] $From) {
+        # The first '{' after a declaration opens its body, unless a ';' ends the declaration first.
+        for ($k = $From; $k -lt $code.Length; $k++) {
+            if ($code[$k] -eq ';') { return $null }
+            if ($code[$k] -eq '{') { return @($k, [int] $closeOf[$k]) }
+        }
+        return $null
+    }
+
+    $namespaces = [System.Collections.Generic.List[object]]::new()
+    $fileNamespace = ''
+    foreach ($match in [regex]::Matches($code, '(?m)^[ \t]*namespace\s+(?<n>[A-Za-z_][\w.]*)\s*(?<t>[;{])')) {
+        if ($match.Groups['t'].Value -eq ';') { $fileNamespace = $match.Groups['n'].Value; continue }
+        $start = $match.Groups['t'].Index
+        [void] $namespaces.Add([pscustomobject]@{ Name = $match.Groups['n'].Value; Start = $start; End = [int] $closeOf[$start] })
+    }
+
+    $typePattern = '\b(?<kind>class|struct|interface|enum|record(?:\s+(?:class|struct))?)\s+(?<name>[A-Za-z_]\w*)'
+    foreach ($match in [regex]::Matches($code, $typePattern)) {
+        # 'where T : class where U : new()' puts a keyword where a type name would be.
+        if ($match.Groups['name'].Value -cin @('where', 'new', 'class', 'struct', 'unmanaged', 'notnull')) { continue }
+        $body = Get-BodyRange ($match.Index + $match.Length)
+        $header = if ($null -ne $body) { $code.Substring($match.Index + $match.Length, $body[0] - $match.Index - $match.Length) } else { '' }
+        $lineStart = $code.LastIndexOf("`n", [Math]::Max(0, $match.Index - 1)) + 1
+        $modifiers = $code.Substring($lineStart, $match.Index - $lineStart)
+
+        # The base list follows the name, after any type parameters and primary constructor, and
+        # before any constraint clause. Interfaces are recognised by the I-prefix convention; any
+        # other base is a class whose tests and traits this type inherits from elsewhere.
+        $baseText = [regex]::Replace($header, '<[^<>]*>', '')
+        while ($baseText -match '\([^()]*\)') { $baseText = [regex]::Replace($baseText, '\([^()]*\)', '') }
+        $baseText = ($baseText -split '\bwhere\b')[0]
+        $hasClassBase = $false
+        $colon = $baseText.IndexOf(':')
+        if ($colon -ge 0) {
+            foreach ($base in $baseText.Substring($colon + 1).Split(',')) {
+                $baseName = ($base.Trim() -split '\.')[-1]
+                if ($baseName -and $baseName -cnotmatch '^I[A-Z]') { $hasClassBase = $true }
+            }
+        }
+
+        [void] $shape.Types.Add([pscustomobject]@{
+            Name         = $match.Groups['name'].Value
+            Kind         = ($match.Groups['kind'].Value -split '\s+')[0]
+            Start        = $match.Index
+            BodyStart    = if ($null -ne $body) { $body[0] } else { -1 }
+            BodyEnd      = if ($null -ne $body) { $body[1] } else { -1 }
+            FileLocal    = $modifiers -match '\bfile\b'
+            IsAbstract   = $modifiers -match '\babstract\b'
+            HasClassBase = $hasClassBase
+            Parent       = $null
+            Namespace    = $fileNamespace
+        })
+    }
+
+    # Nesting and namespaces by containment.
+    foreach ($type in $shape.Types) {
+        $innermost = $null
+        foreach ($candidate in $shape.Types) {
+            if ($candidate -eq $type -or $candidate.BodyStart -lt 0) { continue }
+            if ($type.Start -gt $candidate.BodyStart -and $type.Start -lt $candidate.BodyEnd) {
+                if ($null -eq $innermost -or $candidate.BodyStart -gt $innermost.BodyStart) { $innermost = $candidate }
+            }
+        }
+        $type.Parent = $innermost
+        foreach ($namespace in $namespaces) {
+            if ($type.Start -gt $namespace.Start -and $type.Start -lt $namespace.End) { $type.Namespace = $namespace.Name }
+        }
+    }
+
+    function Get-TypeChain($Type) {
+        $names = [System.Collections.Generic.List[string]]::new()
+        for ($t = $Type; $null -ne $t; $t = $t.Parent) { $names.Insert(0, $t.Name) }
+        return ($names -join '+')
+    }
+    function Get-TypePrefix($Type) {
+        $chain = Get-TypeChain $Type
+        if ($Type.Namespace) { return "$($Type.Namespace).$chain" }
+        return $chain
+    }
+
+    # Test methods: an attribute list naming a *Fact or *Theory attribute, then the method whose
+    # parameter list is the next '(' - its name is the last identifier before it. An attribute
+    # list only starts a declaration, so it must follow a line start, '{', '}', ';' or ']'.
+    foreach ($attribute in [regex]::Matches($code, '\[(?<body>[^\[\]]*)\]')) {
+        $isTest = $false
+        foreach ($part in $attribute.Groups['body'].Value.Split(',')) {
+            if ($part.Trim() -match '^(?:[\w.]+\.)?\w*(?:Fact|Theory)(?:Attribute)?\s*(?:\(|$)') { $isTest = $true }
+        }
+        if (-not $isTest) { continue }
+        $before = $code.Substring(0, $attribute.Index).TrimEnd(' ', "`t")
+        if ($before.Length -gt 0 -and $before[-1] -notin @("`n", "`r", '{', '}', ';', ']')) { continue }
+
+        $after = $attribute.Index + $attribute.Length
+        $owner = $null
+        foreach ($type in $shape.Types) {
+            if ($type.BodyStart -lt 0) { continue }
+            if ($after -gt $type.BodyStart -and $after -lt $type.BodyEnd) {
+                if ($null -eq $owner -or $type.BodyStart -gt $owner.BodyStart) { $owner = $type }
+            }
+        }
+
+        # Skip any further attribute lists (bracket depth counted, so '[InlineData(new[] { 1 })]'
+        # is one list), then read the name before the parameter list.
+        $position = $after
+        while ($true) {
+            while ($position -lt $code.Length -and [char]::IsWhiteSpace($code[$position])) { $position++ }
+            if ($position -ge $code.Length -or $code[$position] -ne '[') { break }
+            $depth = 0
+            do {
+                if ($code[$position] -eq '[') { $depth++ } elseif ($code[$position] -eq ']') { $depth-- }
+                $position++
+            } while ($depth -gt 0 -and $position -lt $code.Length)
+        }
+        $method = $null
+        $paren = $code.IndexOf('(', $position)
+        if ($paren -ge 0) {
+            $signature = [regex]::Replace($code.Substring($position, $paren - $position), '<[^<>]*>\s*$', '')
+            if ($signature -notmatch '[;{}=\[\]]' -and $signature -match '(?<m>[A-Za-z_]\w*)\s*$') { $method = $Matches.m }
+        }
+
+        # A test whose name cannot be read still exists. It is kept as an open-ended candidate so a
+        # filter naming its method can never be what makes its shard look unaffected.
+        if ($null -eq $owner) {
+            [void] $shape.Tests.Add([pscustomobject]@{ Fqn = $(if ($fileNamespace) { "$fileNamespace." } else { '' }); PrefixOnly = $true; AnySuffix = $true })
+        }
+        elseif ($null -eq $method) {
+            [void] $shape.Tests.Add([pscustomobject]@{ Fqn = "$(Get-TypePrefix $owner)."; PrefixOnly = $true; AnySuffix = $false })
+        }
+        else {
+            [void] $shape.Tests.Add([pscustomobject]@{ Fqn = "$(Get-TypePrefix $owner).$method"; PrefixOnly = $false; AnySuffix = $false })
+        }
+    }
+
+    # A class with a class base can inherit tests whose method names live in another file.
+    foreach ($type in $shape.Types) {
+        if ($type.Kind -in @('class', 'record') -and $type.HasClassBase) {
+            [void] $shape.Tests.Add([pscustomobject]@{ Fqn = "$(Get-TypePrefix $type)."; PrefixOnly = $true; AnySuffix = $false })
+        }
+    }
+
+    # Categories are knowable only when every Category trait is a literal and no class inherits
+    # traits from a base declared elsewhere.
+    $categories = [System.Collections.Generic.HashSet[string]]::new([StringComparer]::OrdinalIgnoreCase)
+    $categoriesKnown = -not @($shape.Types | Where-Object { $_.HasClassBase }).Count
+    foreach ($trait in [regex]::Matches($Text, '\bTrait(?:Attribute)?\s*\(\s*"(?i:category)"\s*,\s*(?<v>[^)]*)\)')) {
+        $value = $trait.Groups['v'].Value.Trim()
+        if ($value -match '^"(?<c>[^"]*)"$') { [void] $categories.Add($Matches.c) }
+        else { $categoriesKnown = $false }
+    }
+    if ($categoriesKnown) { $shape.Categories = @($categories) }
+
+    # Constructs that reach tests without naming this file's types, which reference search cannot
+    # follow: extension methods, global usings, assembly-level attributes, module initializers, and
+    # xUnit collection definitions (bound by string name).
+    $hazards = [ordered]@{
+        'declares extension methods'           = '\(\s*this\s+[A-Za-z_]'
+        'declares global usings'               = '(?m)^\s*global\s+using\b'
+        'declares assembly-level attributes'   = '\[\s*assembly\s*:'
+        'declares a module initializer'        = '\bModuleInitializer\b'
+        'declares an xUnit collection definition' = '\bCollectionDefinition\b'
+    }
+    foreach ($hazard in $hazards.Keys) {
+        if ($code -match $hazards[$hazard]) { $shape.Hazard = $hazard; break }
+    }
+    # An abstract class is a base by construction, and the scaffold generator derives test classes
+    # from bases whose names it can compose at build time. Those derived classes are not in the
+    # tree, so reference search cannot find them.
+    if (-not $shape.Hazard -and @($shape.Types | Where-Object { $_.IsAbstract }).Count -gt 0) {
+        $shape.Hazard = 'declares an abstract class, which build-time generated test classes may derive from'
+    }
+    return $shape
+}
+
+function Get-ShardProjectDirectory {
+    param([Parameter(Mandatory)] $Shard)
+    $project = ([string] $Shard.project).Replace('\', '/')
+    $slash = $project.LastIndexOf('/')
+    if ($slash -lt 0) { return '' }
+    return $project.Substring(0, $slash + 1)
+}
+
+function Get-TestProjectDirectory {
+    param([Parameter(Mandatory)] [string] $Path, [Parameter(Mandatory)] [AllowEmptyCollection()] [object[]] $Manifest)
+
+    $best = $null
+    foreach ($shard in $Manifest) {
+        $directory = Get-ShardProjectDirectory -Shard $shard
+        if ($directory -and $Path.StartsWith($directory, [StringComparison]::OrdinalIgnoreCase) -and
+            ($null -eq $best -or $directory.Length -gt $best.Length)) {
+            $best = $directory
+        }
+    }
+    return $best
+}
+
+function Get-TestFileRoutes {
+    <#
+        Routes changed test sources to the shards whose manifest filters select their tests.
+
+        A test file affects the tests it declares and, through its types, every test file that uses
+        them: a base class, fixture or helper changes the behaviour of its consumers. So routing
+        follows the transitive closure of files that name this file's top-level types, and unions
+        the shards that select any test in that closure. Constructs whose consumers cannot be found
+        by name (see Get-CSharpTestShape hazards), a closure too wide to be selective, a file whose
+        text cannot be parsed, and tests no shard filter selects all return Routable = $false,
+        which the selector turns into an escalation.
+
+        FindBuildTimeReferences reports which of a file's type names build-time code (the source
+        generators) mentions: tests the generator emits exist only inside the compiler, so a type
+        they depend on cannot be routed by reading the tree.
+
+        ReadFile, FindReferrers and FindBuildTimeReferences are injected so the self-test can
+        exercise routing without a repository; in production they read HEAD and use git grep.
+    #>
+    param(
+        [Parameter(Mandatory)] [AllowEmptyCollection()] [string[]] $Paths,
+        [Parameter(Mandatory)] [AllowEmptyCollection()] [object[]] $Manifest,
+        [Parameter(Mandatory)] [scriptblock] $ReadFile,
+        [Parameter(Mandatory)] [scriptblock] $FindReferrers,
+        [Parameter(Mandatory)] [scriptblock] $FindBuildTimeReferences,
+        [int] $MaximumClosure = 200
+    )
+
+    $filters = @{}
+    foreach ($shard in $Manifest) {
+        try { $filters[[string] $shard.name] = ConvertTo-TestFilter -Text ([string] $shard.filter) }
+        catch { $filters[[string] $shard.name] = $null }
+    }
+
+    $routes = @{}
+    foreach ($path in $Paths) {
+        $normalized = $path.Replace('\', '/')
+        $projectDirectory = Get-TestProjectDirectory -Path $normalized -Manifest $Manifest
+        if ($null -eq $projectDirectory) {
+            $routes[$path] = [pscustomobject]@{ Routable = $false; Shards = @(); Why = 'test source belongs to no project any shard runs' }
+            continue
+        }
+        $projectShards = @($Manifest | Where-Object { (Get-ShardProjectDirectory -Shard $_) -ieq $projectDirectory })
+
+        $visited = [System.Collections.Generic.HashSet[string]]::new([StringComparer]::OrdinalIgnoreCase)
+        $queue = [System.Collections.Generic.Queue[string]]::new()
+        [void] $visited.Add($normalized)
+        $queue.Enqueue($normalized)
+        $candidates = [System.Collections.Generic.List[object]]::new()
+        $failure = $null
+        $ownTests = 0
+        $ownReferrers = 0
+
+        while ($queue.Count -gt 0 -and $null -eq $failure) {
+            $file = $queue.Dequeue()
+            $text = & $ReadFile $file
+            if ($null -eq $text) { $failure = "cannot read test source $file"; break }
+            $shape = Get-CSharpTestShape -Text $text
+            if ($shape.ParseError) { $failure = "cannot parse test source $file ($($shape.ParseError))"; break }
+            if ($shape.Hazard) { $failure = "test source $file $($shape.Hazard), whose consumers cannot be found by name"; break }
+
+            foreach ($test in $shape.Tests) {
+                [void] $candidates.Add([pscustomobject]@{ Fqn = $test.Fqn; PrefixOnly = $test.PrefixOnly; AnySuffix = $test.AnySuffix; Categories = $shape.Categories })
+            }
+            if ($file -ieq $normalized) { $ownTests = $shape.Tests.Count }
+
+            $names = @($shape.Types | Where-Object { $null -eq $_.Parent -and -not $_.FileLocal } |
+                ForEach-Object { $_.Name } | Sort-Object -Unique)
+            if ($names.Count -eq 0) { continue }
+            $generated = @(& $FindBuildTimeReferences $names)
+            if ($generated.Count -gt 0) {
+                $failure = "test source $file declares $($generated -join ', '), which a source generator references, so tests generated at build time may depend on it"
+                break
+            }
+            foreach ($referrer in @(& $FindReferrers $names $projectDirectory)) {
+                $referrerPath = ([string] $referrer).Replace('\', '/')
+                if ($referrerPath -ieq $file) { continue }
+                if ($file -ieq $normalized) { $ownReferrers++ }
+                if ($visited.Add($referrerPath)) {
+                    if ($visited.Count -gt $MaximumClosure) {
+                        $failure = "test source is shared by more than $MaximumClosure test files"
+                        break
+                    }
+                    $queue.Enqueue($referrerPath)
+                }
+            }
+        }
+
+        if ($null -ne $failure) {
+            $routes[$path] = [pscustomobject]@{ Routable = $false; Shards = @(); Why = $failure }
+            continue
+        }
+        if ($ownTests -eq 0 -and $ownReferrers -eq 0) {
+            $routes[$path] = [pscustomobject]@{ Routable = $false; Shards = @(); Why = 'test support source declares no tests and no test file names its types' }
+            continue
+        }
+
+        $shards = [System.Collections.Generic.SortedSet[string]]::new([StringComparer]::Ordinal)
+        $unparsed = $false
+        foreach ($shard in $projectShards) {
+            $filter = $filters[[string] $shard.name]
+            if ($null -eq $filter) { $unparsed = $true; break }
+            foreach ($candidate in $candidates) {
+                if ((Test-TestFilter -Node $filter -Candidate $candidate) -ne $script:FilterFalse) {
+                    [void] $shards.Add([string] $shard.name)
+                    break
+                }
+            }
+        }
+        if ($unparsed) {
+            $routes[$path] = [pscustomobject]@{ Routable = $false; Shards = @(); Why = 'a shard filter for this test project cannot be parsed' }
+        }
+        elseif ($shards.Count -eq 0) {
+            $routes[$path] = [pscustomobject]@{ Routable = $false; Shards = @(); Why = 'no shard filter selects any test this source affects' }
+        }
+        else {
+            $closure = $visited.Count - 1
+            $why = if ($closure -gt 0) { "its filter selects tests in this file or in $closure test file(s) that use it" }
+                   else { 'its filter selects tests in this file' }
+            $routes[$path] = [pscustomobject]@{ Routable = $true; Shards = @($shards); Why = $why }
+        }
+    }
+    return $routes
+}
+
+function Get-GitFileText {
+    param([Parameter(Mandatory)] [string] $Path, [Parameter(Mandatory)] [AllowEmptyCollection()] [string[]] $Revisions)
+    foreach ($revision in $Revisions) {
+        if ([string]::IsNullOrWhiteSpace($revision)) { continue }
+        $lines = @(& git -c core.quotepath=false show "${revision}:$Path" 2>$null)
+        if ($LASTEXITCODE -eq 0) { return ($lines -join "`n") }
+    }
+    return $null
+}
+
+function Find-GitReferrers {
+    param([Parameter(Mandatory)] [string[]] $Names, [Parameter(Mandatory)] [string] $Directory)
+    $arguments = @('-c', 'core.quotepath=false', 'grep', '-l', '-w', '-F')
+    foreach ($name in $Names) { $arguments += @('-e', $name) }
+    $arguments += @('HEAD', '--', ":(glob)$Directory**/*.cs")
+    $output = @(& git @arguments 2>$null)
+    # git grep exits 1 when nothing matches, which is an answer, not a failure.
+    if ($LASTEXITCODE -gt 1) { throw "git grep for test-type references failed with exit code $LASTEXITCODE" }
+    return @($output | ForEach-Object { ([string] $_) -replace '^HEAD:', '' })
+}
+
+function Find-GitBuildTimeReferences {
+    <#
+        Which of Names build-time code mentions. One search per name keeps the answer exact; the
+        lists are short (a file's top-level types) and git grep over the generator tree is fast.
+    #>
+    param([Parameter(Mandatory)] [string[]] $Names)
+    # An empty pathspec would search the whole repository and implicate every type there is.
+    $directories = @($script:BuildTimeDirectories | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
+    if ($directories.Count -eq 0) { throw 'no build-time directories are configured' }
+    $found = [System.Collections.Generic.List[string]]::new()
+    foreach ($name in $Names) {
+        $arguments = @('-c', 'core.quotepath=false', 'grep', '-q', '-w', '-F', '-e', $name, 'HEAD', '--')
+        $arguments += $directories
+        & git @arguments 2>$null
+        if ($LASTEXITCODE -eq 0) { [void] $found.Add($name) }
+        elseif ($LASTEXITCODE -gt 1) { throw "git grep for build-time references failed with exit code $LASTEXITCODE" }
+    }
+    return @($found)
+}
+
+function Resolve-PullRequestBase {
+    <#
+        The pull_request event's base.sha is the base branch as it was when the pull request was
+        opened or last retargeted - not what GitHub merged it onto for this run. For a pull request
+        behind master it attributes every commit master has gained since to the pull request.
+
+        The checked-out merge ref is authoritative: its first parent IS the base this run tests
+        against, and its second parent is the pull request head. Both are verified, so a checkout
+        that is not the expected two-parent merge fails closed rather than guessing.
+    #>
+    param([Parameter(Mandatory)] [string] $PullRequestHeadSha)
+
+    if ($PullRequestHeadSha -notmatch '^(?:[0-9a-fA-F]{40}|[0-9a-fA-F]{64})$') {
+        throw "pull request head '$PullRequestHeadSha' is not a complete Git object id"
+    }
+    $parents = @((& git rev-list --parents -n 1 HEAD) -split '\s+' | Where-Object { $_ })
+    if ($LASTEXITCODE -ne 0) { throw 'cannot read the checked-out commit' }
+    if ($parents.Count -ne 3) {
+        throw "the checkout is not a two-parent pull-request merge commit ($($parents.Count - 1) parent(s))"
+    }
+    if (-not $parents[2].Equals($PullRequestHeadSha, [StringComparison]::OrdinalIgnoreCase)) {
+        throw "the merge commit's second parent $($parents[2]) is not the pull request head $PullRequestHeadSha"
+    }
+    return $parents[1]
 }
 
 # ---------------------------------------------------------------- self-test
@@ -503,9 +1287,17 @@ if ($SelfTest) {
     Assert-True (-not ($r.Shards -contains 'Beta')) 'a change outside Beta lines must not select Beta'
     Assert-True ($r.Shards -contains 'HeavyNoCoverage') 'always-run shards must always be selected'
 
+    # An unexecuted range in a mapped file routes to every shard that executes the file. Before this
+    # it escalated, and #2100's field declarations and between-method insertions - lines coverage
+    # never records - sent a four-file pull request to all 116 shards.
     $r = Select-ImpactedShards -Map $map -Changed @{ 'src/Covered.cs' = @(12, 14, 50, 60) }
-    Assert-True $r.Escalate 'mixed covered and uncovered hunks must escalate'
-    Assert-True ($r.Shards -contains 'Alpha') 'covered hunks are still reported before escalation'
+    Assert-True (-not $r.Escalate) 'an unexecuted range in a mapped file escalated instead of routing to its owners'
+    Assert-True ($r.Shards -contains 'Alpha' -and $r.Shards -contains 'Beta') `
+        'an unexecuted range was not routed to every shard executing the file'
+    Assert-True (@($r.Routes | Where-Object { $_ -like 'Beta <= executes src/Covered.cs, whose changed lines 50-60*' }).Count -eq 1) `
+        'the owner route did not record which lines no shard executes'
+    Assert-True (@($r.Routes | Where-Object { $_ -like 'Alpha <= executes changed lines 12-14 of src/Covered.cs' }).Count -eq 1) `
+        'a covered hit did not record the lines that selected it'
 
     foreach ($change in @(
         @{ Path = 'src/Unmapped.cs'; Why = 'an unmapped file must escalate' },
@@ -518,6 +1310,7 @@ if ($SelfTest) {
         @{ Path = '.github/scripts/analyze-test-results.ps1'; Why = 'CI analysis scripts must escalate' },
         @{ Path = '.github/actions/local/action.yml'; Why = 'local actions must escalate' },
         @{ Path = 'tools/TestImpact/Select-Shards.ps1'; Why = 'impact tooling must escalate' },
+        @{ Path = 'src/AiDotNet.Generators/TestScaffoldGenerator.cs'; Why = 'build-time source generators must escalate' },
         @{ Path = '.github/dependabot.yml'; Why = 'unknown GitHub configuration must escalate' },
         @{ Path = '.github/workflows/release-please.yml.backup'; Why = 'workflow lookalikes must escalate' },
         @{ Path = '.github/workflows/new-unknown.yml'; Why = 'unknown workflows must escalate' }
@@ -586,8 +1379,220 @@ if ($SelfTest) {
     }
     foreach ($edge in @(9, 21)) {
         $r = Select-ImpactedShards -Map $map -Changed @{ 'src/Covered.cs' = @($edge, $edge) }
-        Assert-True $r.Escalate "unexecuted boundary line $edge must escalate"
+        Assert-True (-not $r.Escalate -and $r.Shards -contains 'Alpha' -and $r.Shards -contains 'Beta') `
+            "unexecuted boundary line $edge was not routed to the file's owners"
+        Assert-True (@($r.Routes | Where-Object { $_ -like 'Alpha <= executes changed lines*' }).Count -eq 0) `
+            "unexecuted boundary line $edge was reported as executed"
     }
+
+    # ---- A pull request BEHIND its base branch (the #2100 shape). -------------------------------
+    # The map-to-HEAD delta holds master's own later commits (a selector-control edit and an
+    # unmapped source file) as well as the pull request's one covered edit.
+    $behind = @{
+        'src/Covered.cs' = @(12, 14)
+        'tools/TestImpact/Select-Shards.ps1' = @(1, 2)
+        'src/Finance/MasterOnly.cs' = @(1, 5)
+        '.github/workflows/sonarcloud.yml' = @(1, 2)
+    }
+    # Reproduction: the stale event base.sha made every path current, and it escalated.
+    $r = Select-ImpactedShards -Map $map -Changed $behind -CurrentPaths @($behind.Keys)
+    Assert-True $r.Escalate 'fixture error: the stale-base reproduction did not escalate'
+    # Fixed: the merge commit's first parent limits the change to the pull request's own path.
+    $r = Select-ImpactedShards -Map $map -Changed $behind -CurrentPaths @('src/Covered.cs') -ScopeToCurrentPaths
+    Assert-True (-not $r.Escalate) 'a pull request behind master escalated on master''s own later commits'
+    Assert-True ((@($r.Shards) -join ',') -eq 'Alpha,HeavyNoCoverage') `
+        'a pull request behind master did not select exactly its own covering shard plus always-run'
+    Assert-True (-not (@($r.Routes) -match 'MasterOnly')) 'master''s later source file influenced the pull request'
+
+    # Scoping must still escalate a control edit that IS in the pull request.
+    $r = Select-ImpactedShards -Map $map -Changed $behind `
+        -CurrentPaths @('src/Covered.cs', 'tools/TestImpact/Select-Shards.ps1') -ScopeToCurrentPaths
+    Assert-True $r.Escalate 'a selector edit inside a behind pull request did not escalate'
+
+    # An empty pull-request path set must never read as a non-runtime change.
+    $r = Select-ImpactedShards -Map $map -Changed $behind -CurrentPaths @() -ScopeToCurrentPaths
+    Assert-True ($r.Escalate -and $r.RequiresValidation) 'an empty pull-request path set suppressed validation'
+
+    # A pull-request path with no map-to-HEAD hunks cannot be placed in map coordinates.
+    $r = Select-ImpactedShards -Map $map -Changed @{ 'src/Covered.cs' = @(12, 14) } `
+        -CurrentPaths @('src/Covered.cs', 'src/SingleRange.cs') -ScopeToCurrentPaths
+    Assert-True $r.Escalate 'a pull-request path absent from the map delta did not escalate'
+
+    # ---- Unmapped sources. ------------------------------------------------------------------------
+    $deepMap = @{
+        schemaVersion = 1; sha = '0123456789abcdef0123456789abcdef01234567'
+        knownShards = @('Alpha', 'Beta', 'Gamma'); alwaysRun = @()
+        files = @{
+            'src/Finance/Agents/Dqn.cs' = @( @{ s = 0; r = @(1, 9) } )
+            'src/Finance/Agents/Sac.cs' = @( @{ s = 1; r = @(1, 9) } )
+            'src/Finance/Data/Feed.cs' = @( @{ s = 2; r = @(1, 9) } )
+        }
+    } | ConvertTo-Json -Depth 8 -Compress | ConvertFrom-Json
+    $r = Select-ImpactedShards -Map $deepMap -Changed @{ 'src/Finance/Agents/NewAgent.cs' = @(1, 40) }
+    Assert-True (-not $r.Escalate -and (@($r.Shards) -join ',') -eq 'Alpha,Beta') `
+        'a new source file was not routed to exactly the owners of its own directory'
+    $r = Select-ImpactedShards -Map $deepMap -Changed @{ 'src/Finance/Brand/New/Deep.cs' = @(1, 4) }
+    Assert-True (-not $r.Escalate -and (@($r.Shards) -join ',') -eq 'Alpha,Beta,Gamma') `
+        'a new source file with no mapped sibling did not climb to its nearest mapped ancestor'
+    $r = Select-ImpactedShards -Map $deepMap -Changed @{ 'src/Orphan/Thing.cs' = @(1, 4) }
+    Assert-True $r.Escalate 'a new source file with no mapped neighbour below the root escalated nothing'
+    $r = Select-ImpactedShards -Map $deepMap -Changed @{ 'src/Finance/Agents/agents.json' = @(1, 4) }
+    Assert-True $r.Escalate 'an unmapped non-C# file inside a mapped directory was routed instead of escalating'
+    $r = Select-ImpactedShards -Map $deepMap -Changed @{ 'src/Finance/Agents/Finance.csproj' = @(1, 4) }
+    Assert-True $r.Escalate 'an unmapped project file was routed instead of escalating'
+
+    # ---- Test sources, routed through precomputed manifest routes. --------------------------------
+    $r = Select-ImpactedShards -Map $map -Changed @{ 'tests/P/FooTests.cs' = @(1, 30) } -TestRoutes @{
+        'tests/P/FooTests.cs' = [pscustomobject]@{ Routable = $true; Shards = @('Beta'); Why = 'filter selects tests in this source' }
+    }
+    Assert-True (-not $r.Escalate -and (@($r.Shards) -join ',') -eq 'Beta,HeavyNoCoverage') `
+        'a routable test source did not select exactly its owning shard plus always-run'
+    $r = Select-ImpactedShards -Map $map -Changed @{ 'tests/P/Helpers.cs' = @(1, 30) } -TestRoutes @{
+        'tests/P/Helpers.cs' = [pscustomobject]@{ Routable = $false; Shards = @(); Why = 'declares extension methods' }
+    }
+    Assert-True ($r.Escalate -and ($r.Reasons -join ';') -like '*declares extension methods*') `
+        'an unroutable test source did not escalate with its reason'
+    $r = Select-ImpactedShards -Map $map -Changed @{ 'tests/P/FooTests.cs' = @(1, 30) }
+    Assert-True $r.Escalate 'a test source with no route (no manifest) did not fail closed'
+
+    # ---- VSTest filter grammar and three-valued evaluation. ---------------------------------------
+    function New-Candidate([string] $Fqn, [bool] $PrefixOnly = $false, $Categories = @(), [bool] $AnySuffix = $false) {
+        [pscustomobject]@{ Fqn = $Fqn; PrefixOnly = $PrefixOnly; AnySuffix = $AnySuffix; Categories = $Categories }
+    }
+    $f = ConvertTo-TestFilter "Category!=GPU&Category!=Stress& `n (FullyQualifiedName~UnitTests.Alpha|`n FullyQualifiedName~UnitTests.Beta)"
+    Assert-True ((Test-TestFilter $f (New-Candidate 'X.UnitTests.Beta.C.M')) -eq $script:FilterTrue) `
+        'a folded multi-line filter did not match its second alternative'
+    Assert-True ((Test-TestFilter $f (New-Candidate 'X.UnitTests.Gamma.C.M')) -eq $script:FilterFalse) `
+        'a filter matched a test outside every alternative'
+    Assert-True ((Test-TestFilter $f (New-Candidate 'X.UnitTests.Alpha.C.M' $false @('GPU'))) -eq $script:FilterUnknown) `
+        'a category present somewhere in the file was treated as definitely on this test'
+    Assert-True ((Test-TestFilter $f (New-Candidate 'X.UnitTests.Alpha.C.M' $false $null)) -eq $script:FilterUnknown) `
+        'unknown categories were treated as known'
+    $f = ConvertTo-TestFilter 'A=1|B=2&FullyQualifiedName~Nope'
+    Assert-True ($f.Kind -eq 'Or' -and $f.Items[1].Kind -eq 'And') "'&' did not bind tighter than '|'"
+    $f = ConvertTo-TestFilter 'FullyQualifiedName~Contracts.A&FullyQualifiedName!~Skip'
+    Assert-True ((Test-TestFilter $f (New-Candidate 'N.Contracts.' $true)) -eq $script:FilterUnknown) `
+        'an inherited test with an unknown method name was excluded by a method-level filter'
+    Assert-True ((Test-TestFilter $f (New-Candidate 'N.Contracts.Skip' $true)) -eq $script:FilterFalse) `
+        'a known prefix containing an excluded term was not excluded'
+    # The unknown part of an inherited test is ONE method identifier, so it cannot supply a
+    # namespace term the prefix lacks - but it can finish a term the prefix ends in.
+    $f = ConvertTo-TestFilter 'FullyQualifiedName~P.Alpha'
+    Assert-True ((Test-TestFilter $f (New-Candidate 'P.Beta.BTests.' $true)) -eq $script:FilterFalse) `
+        'an inherited test was treated as able to acquire a namespace from its method name'
+    Assert-True ((Test-TestFilter $f (New-Candidate 'X.P.' $true)) -eq $script:FilterUnknown) `
+        'a method name completing a term the prefix ends in was ruled out'
+    Assert-True ((Test-TestFilter $f (New-Candidate 'N.' $true @() $true)) -eq $script:FilterUnknown) `
+        'a test whose class could not be read was ruled out by a namespace term'
+    Assert-True ((Test-TestFilter (ConvertTo-TestFilter 'FullyQualifiedName~alpha') (New-Candidate 'X.Alpha.M')) -eq $script:FilterUnknown) `
+        'a case-only match was decided instead of left unknown'
+    Assert-True ((Test-TestFilter (ConvertTo-TestFilter 'Category=Playground') (New-Candidate 'X.Y.M')) -eq $script:FilterFalse) `
+        'a positive category filter matched a file with no categories'
+    foreach ($bad in @('FullyQualifiedName~A&', '(FullyQualifiedName~A', 'FullyQualifiedName', 'A=\(x\)')) {
+        Assert-Throws { ConvertTo-TestFilter $bad } "malformed filter '$bad' was accepted"
+    }
+
+    # ---- C# test-shape parsing. -------------------------------------------------------------------
+    $source = @'
+using Xunit;
+namespace AiDotNet.Tests.IntegrationTests.Finance;
+
+// public class CommentedOut { [Fact] public void Ghost() {} }
+[Trait("Category", "Slow")]
+public class TradingTests : IClassFixture<Fixture>
+{
+    private const string Braces = "{ class Fake { ";
+    private readonly char _brace = '}';
+
+    [Fact]
+    public void Learns() { var s = $"{1}"; }
+
+    [Theory]
+    [InlineData(new[] { 1, 2 })]
+    public async Task Converges<T>(int[] x) { await Task.Yield(); }
+
+    public class Nested
+    {
+        [Fact, Trait("Category", "Nested")]
+        public void Inner() { }
+    }
+}
+
+internal sealed class Helper { }
+file class Private { }
+'@
+    $shape = Get-CSharpTestShape -Text $source
+    Assert-True ($null -eq $shape.ParseError) "valid C# was reported unparseable: $($shape.ParseError)"
+    $fqns = @($shape.Tests | Where-Object { -not $_.PrefixOnly } | ForEach-Object Fqn | Sort-Object)
+    $expectedFqns = @('AiDotNet.Tests.IntegrationTests.Finance.TradingTests+Nested.Inner',
+        'AiDotNet.Tests.IntegrationTests.Finance.TradingTests.Converges',
+        'AiDotNet.Tests.IntegrationTests.Finance.TradingTests.Learns') | Sort-Object
+    Assert-True (($fqns -join ',') -eq ($expectedFqns -join ',')) "test names were misread: $($fqns -join ',')"
+    Assert-True (@($shape.Tests | Where-Object PrefixOnly).Count -eq 0) 'an interface base was treated as an inherited class'
+    Assert-True ((@($shape.Categories | Sort-Object) -join ',') -eq 'Nested,Slow') 'literal categories were not collected'
+    $topLevel = @($shape.Types | Where-Object { $null -eq $_.Parent -and -not $_.FileLocal } | ForEach-Object Name | Sort-Object)
+    Assert-True (($topLevel -join ',') -eq 'Helper,TradingTests') `
+        "referenceable top-level types were misread: $($topLevel -join ',')"
+
+    $shape = Get-CSharpTestShape -Text "namespace N { public class D : ModelContractBase<int> { } }"
+    Assert-True (@($shape.Tests | Where-Object { $_.PrefixOnly -and $_.Fqn -eq 'N.D.' }).Count -eq 1) `
+        'a class with a class base did not expose its inherited tests as open-ended'
+    Assert-True ($null -eq $shape.Categories) 'categories inherited from a base class were treated as known'
+
+    $shape = Get-CSharpTestShape -Text "namespace N { public static class X { public static int Twice(this int v) => v * 2; } }"
+    Assert-True ($shape.Hazard -eq 'declares extension methods') 'extension methods were not flagged'
+    $shape = Get-CSharpTestShape -Text "namespace N { public class X { "
+    Assert-True ([bool] $shape.ParseError) 'unbalanced braces were not reported'
+
+    # ---- Routing with injected file reads and reference search. -----------------------------------
+    $manifest = @(
+        [pscustomobject]@{ name = 'Alpha'; project = 'tests/P/P.csproj'; filter = 'FullyQualifiedName~P.Alpha' },
+        [pscustomobject]@{ name = 'Beta'; project = 'tests/P/P.csproj'; filter = 'FullyQualifiedName~P.Beta' },
+        [pscustomobject]@{ name = 'Other'; project = 'tests/Q/Q.csproj'; filter = 'FullyQualifiedName~P' }
+    )
+    $files = @{
+        'tests/P/Alpha/ATests.cs' = 'namespace P.Alpha; public class ATests { [Fact] public void A() { } }'
+        'tests/P/Shared/Base.cs'  = 'namespace P.Shared; public class Base { [Fact] public void Common() { } }'
+        'tests/P/Shared/Abstract.cs' = 'namespace P.Shared; public abstract class ShapeBase { [Fact] public void Common() { } }'
+        'tests/P/Shared/GenBase.cs' = 'namespace P.Shared; public class LayerHarness { }'
+        'tests/P/Beta/BTests.cs'  = 'namespace P.Beta; public class BTests : Base { }'
+        'tests/P/Shared/Ext.cs'   = 'namespace P.Shared; public static class Ext { public static int X(this int v) => v; }'
+        'tests/P/Shared/Unused.cs' = 'namespace P.Shared; public class Unused { }'
+    }
+    $referrers = @{ 'Base' = @('tests/P/Beta/BTests.cs'); 'ATests' = @(); 'BTests' = @(); 'Unused' = @() }
+    $read = { param($path) $files[$path] }
+    $find = { param($names, $directory) @($names | ForEach-Object { $referrers[$_] } | Where-Object { $_ }) }
+    $generatorNames = @('LayerHarness')
+    $findGenerated = { param($names) @($names | Where-Object { $generatorNames -contains $_ }) }
+    $routed = Get-TestFileRoutes -Paths @('tests/P/Alpha/ATests.cs', 'tests/P/Shared/Base.cs', 'tests/P/Shared/Ext.cs',
+        'tests/P/Shared/Unused.cs', 'tests/Z/Stray.cs', 'tests/P/Shared/Abstract.cs', 'tests/P/Shared/GenBase.cs') `
+        -Manifest $manifest -ReadFile $read -FindReferrers $find -FindBuildTimeReferences $findGenerated
+    Assert-True ($routed['tests/P/Alpha/ATests.cs'].Routable -and
+        (@($routed['tests/P/Alpha/ATests.cs'].Shards) -join ',') -eq 'Alpha') `
+        'a self-contained test file was not routed to exactly its own shard'
+    Assert-True ($routed['tests/P/Shared/Base.cs'].Routable -and
+        (@($routed['tests/P/Shared/Base.cs'].Shards) -join ',') -eq 'Beta') `
+        'a base class was not routed to the shard running its derived tests (and not its own namespace)'
+    Assert-True (-not $routed['tests/P/Shared/Ext.cs'].Routable) 'an extension-method helper was routed'
+    Assert-True (-not $routed['tests/P/Shared/Unused.cs'].Routable) 'a support file with no tests and no consumers was routed'
+    Assert-True (-not $routed['tests/Z/Stray.cs'].Routable) 'a test file outside every shard project was routed'
+    Assert-True (-not $routed['tests/P/Shared/Abstract.cs'].Routable) `
+        'an abstract test base was routed although build-time generated classes may derive from it'
+    Assert-True (-not $routed['tests/P/Shared/GenBase.cs'].Routable -and
+        $routed['tests/P/Shared/GenBase.cs'].Why -like '*source generator references*') `
+        'a test type a source generator references was routed by reading only the tree'
+    $wide = Get-TestFileRoutes -Paths @('tests/P/Shared/Base.cs') -Manifest $manifest -ReadFile $read `
+        -FindReferrers $find -FindBuildTimeReferences $findGenerated -MaximumClosure 1
+    Assert-True (-not $wide['tests/P/Shared/Base.cs'].Routable) 'a closure wider than the limit was routed'
+
+    # An empty build-time pathspec would make git grep search the whole repository.
+    $configuredBuildTime = $script:BuildTimeDirectories
+    try {
+        $script:BuildTimeDirectories = @()
+        Assert-Throws { Find-GitBuildTimeReferences -Names @('Anything') } `
+            'an empty build-time directory list searched the whole repository instead of failing'
+    }
+    finally { $script:BuildTimeDirectories = $configuredBuildTime }
 
     # Faithful to real git: every hunk header is followed by its body lines. An earlier revision
     # used header-only fixtures, which real git never emits - and which masked the forged-header
@@ -712,6 +1717,9 @@ if ($ClassifyOnly) {
     $reason = 'classification-failed'
     $changedFiles = @()
     try {
+        if ($PullRequestHeadSha -and $BaseSha) { throw 'pass PullRequestHeadSha or BaseSha, not both' }
+        if ($PullRequestHeadSha) { $BaseSha = Resolve-PullRequestBase -PullRequestHeadSha $PullRequestHeadSha }
+        if (-not $BaseSha) { throw 'classification needs PullRequestHeadSha or BaseSha' }
         & git cat-file -e "$BaseSha^{commit}" 2>$null
         if ($LASTEXITCODE -ne 0) { throw "base commit '$BaseSha' is not present in this checkout" }
         # A source-to-Markdown rename must report both the deleted source path and added Markdown
@@ -738,6 +1746,7 @@ if ($ClassifyOnly) {
     $result = [pscustomobject]@{
         requiresValidation = $requiresValidation
         reason = $reason
+        baseSha = [string] $BaseSha
         changedPaths = @($changedFiles)
     }
     if ($OutFile) { $result | ConvertTo-Json -Depth 5 -Compress | Set-Content -LiteralPath $OutFile -Encoding utf8 }
@@ -779,14 +1788,48 @@ if ($LASTEXITCODE -ne 0) {
 try {
     $changed = Get-ChangedRanges -MapSha $mapSha
     $currentPaths = @($changed.Keys)
+    $scopeToPullRequest = $false
+    if ($PullRequestHeadSha -and $BaseSha) { throw 'pass PullRequestHeadSha or BaseSha, not both' }
+    if ($PullRequestHeadSha) {
+        $BaseSha = Resolve-PullRequestBase -PullRequestHeadSha $PullRequestHeadSha
+        $scopeToPullRequest = $true
+        Write-Host "pull request base (merge commit's first parent): $BaseSha"
+    }
     if ($BaseSha) {
         & git cat-file -e "$BaseSha^{commit}"
         if ($LASTEXITCODE -ne 0) { throw "base commit '$BaseSha' is not present in this checkout" }
         $currentPaths = @(& git -c core.quotepath=false diff --no-renames --name-only $BaseSha HEAD --)
         if ($LASTEXITCODE -ne 0) { throw "git diff --name-only from current base '$BaseSha' failed" }
+        $currentPaths = @($currentPaths | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
     }
-    Write-Host "changed files: $($changed.Count)"
+    Write-Host "changed files since the map: $($changed.Count); changed by the current change: $($currentPaths.Count)"
+
+    # Test sources the map cannot index, among the paths selection will actually consider.
+    $testRoutes = @{}
+    if ($ShardManifestFile) {
+        $manifest = @(Get-Content -LiteralPath $ShardManifestFile -Raw | ConvertFrom-Json)
+        $manifestNames = @($manifest | ForEach-Object { [string] $_.name } | Sort-Object)
+        if (($manifestNames -join "`n") -cne (@($ExpectedShards | Sort-Object) -join "`n")) {
+            throw 'the shard manifest does not describe exactly the expected shards'
+        }
+        $currentSet = [System.Collections.Generic.HashSet[string]]::new([string[]] $currentPaths, [StringComparer]::OrdinalIgnoreCase)
+        $testPaths = @($changed.Keys | Where-Object {
+            $candidate = [string] $_
+            (-not $scopeToPullRequest -or $currentSet.Contains($candidate)) -and
+            $candidate.StartsWith('tests/', [StringComparison]::OrdinalIgnoreCase) -and
+            $candidate.EndsWith('.cs', [StringComparison]::OrdinalIgnoreCase) -and
+            (Get-ChangedPathImpact -Path $candidate) -eq [ChangedPathImpact]::MapCandidate -and
+            -not $map.files.PSObject.Properties[$candidate]
+        })
+        $revisions = @('HEAD', $BaseSha, $mapSha)
+        $testRoutes = Get-TestFileRoutes -Paths $testPaths -Manifest $manifest `
+            -ReadFile { param($path) Get-GitFileText -Path $path -Revisions $revisions } `
+            -FindReferrers { param($names, $directory) Find-GitReferrers -Names $names -Directory $directory } `
+            -FindBuildTimeReferences { param($names) Find-GitBuildTimeReferences -Names $names }
+    }
+
     $selection = Select-ImpactedShards -Map $map -Changed $changed -CurrentPaths $currentPaths `
+        -ScopeToCurrentPaths:$scopeToPullRequest -TestRoutes $testRoutes `
         -AuditUnchangedMap:$AuditUnchangedMap
 
     if ($selection.Escalate) {
@@ -795,7 +1838,13 @@ try {
     }
     else {
         Write-Host "selected $($selection.Shards.Count) of $($ExpectedShards.Count) shard(s)"
-        foreach ($shard in $selection.Shards) { Write-Host "  $shard" }
+        foreach ($shard in $selection.Shards) {
+            Write-Host "  $shard"
+            $why = @($selection.Routes | Where-Object { $_.StartsWith("$shard <= ", [StringComparison]::Ordinal) } |
+                ForEach-Object { $_.Substring($shard.Length + 4) })
+            foreach ($line in @($why | Select-Object -First 5)) { Write-Host "      because it $line" }
+            if ($why.Count -gt 5) { Write-Host "      ... and $($why.Count - 5) more reason(s)" }
+        }
     }
 
     $result = [pscustomobject]@{
@@ -805,6 +1854,7 @@ try {
                               elseif (-not $selection.RequiresValidation) { 'non-runtime-only' }
                               else { 'selected' })
         reasons           = $selection.Reasons
+        routes            = @($selection.Routes)
         shards            = $selection.Shards
     }
     if ($OutFile) { $result | ConvertTo-Json -Depth 5 -Compress | Set-Content -LiteralPath $OutFile -Encoding utf8 }

--- a/tools/TestImpact/Select-Shards.ps1
+++ b/tools/TestImpact/Select-Shards.ps1
@@ -346,6 +346,26 @@ function Get-ChangedRanges {
     return ConvertTo-ChangedRanges -DiffLines $diff -ChangedFiles $changedFiles
 }
 
+function New-DirectoryOwnerIndex {
+    param([Parameter(Mandatory)] $Map)
+
+    $index = [System.Collections.Generic.Dictionary[string, System.Collections.Generic.SortedSet[string]]]::new(
+        [StringComparer]::OrdinalIgnoreCase)
+    foreach ($property in $Map.files.PSObject.Properties) {
+        $segments = @($property.Name.Replace('\', '/').Split('/'))
+        for ($depth = $segments.Count - 1; $depth -ge 2; $depth--) {
+            $directory = ($segments[0..($depth - 1)] -join '/') + '/'
+            if (-not $index.ContainsKey($directory)) {
+                $index[$directory] = [System.Collections.Generic.SortedSet[string]]::new([StringComparer]::Ordinal)
+            }
+            foreach ($occurrence in @($property.Value)) {
+                [void] $index[$directory].Add([string] $Map.knownShards[[int] $occurrence.s])
+            }
+        }
+    }
+    return ,$index
+}
+
 function Get-DirectoryOwners {
     <#
         The shards that execute any mapped file in the nearest directory of Path that has one, never
@@ -353,20 +373,17 @@ function Get-DirectoryOwners {
         coverage of its own, but the code beside it does; climbing to 'src/' itself would stop
         meaning anything, so an orphan with no mapped neighbour below that depth still escalates.
     #>
-    param([Parameter(Mandatory)] $Map, [Parameter(Mandatory)] [string] $Path)
+    param(
+        [Parameter(Mandatory)]
+        [System.Collections.Generic.Dictionary[string, System.Collections.Generic.SortedSet[string]]] $Index,
+        [Parameter(Mandatory)] [string] $Path
+    )
 
     $segments = @(([string] $Path).Replace('\', '/').Split('/'))
     for ($depth = $segments.Count - 1; $depth -ge 2; $depth--) {
         $directory = ($segments[0..($depth - 1)] -join '/') + '/'
-        $owners = [System.Collections.Generic.SortedSet[string]]::new([StringComparer]::Ordinal)
-        foreach ($property in $Map.files.PSObject.Properties) {
-            if (-not $property.Name.StartsWith($directory, [StringComparison]::OrdinalIgnoreCase)) { continue }
-            foreach ($occurrence in @($property.Value)) {
-                [void] $owners.Add([string] $Map.knownShards[[int] $occurrence.s])
-            }
-        }
-        if ($owners.Count -gt 0) {
-            return [pscustomobject]@{ Directory = $directory.TrimEnd('/'); Shards = @($owners) }
+        if ($Index.ContainsKey($directory) -and $Index[$directory].Count -gt 0) {
+            return [pscustomobject]@{ Directory = $directory.TrimEnd('/'); Shards = @($Index[$directory]) }
         }
     }
     return $null
@@ -404,6 +421,9 @@ function Select-ImpactedShards {
     $mappedPaths = [System.Collections.Generic.List[string]]::new()
     $reasons = [System.Collections.Generic.List[string]]::new()
     $routes = [System.Collections.Generic.List[string]]::new()
+    # Per invocation and lazy: mapped changes pay no indexing cost, and selecting a
+    # different map in the same process cannot reuse another map's directory owners.
+    $directoryOwnerIndex = $null
     $escalate = $false
     $currentPathSet = [System.Collections.Generic.HashSet[string]]::new([StringComparer]::OrdinalIgnoreCase)
     $effectiveCurrentPaths = if ($PSBoundParameters.ContainsKey('CurrentPaths')) {
@@ -544,7 +564,8 @@ function Select-ImpactedShards {
             $directoryOwners = $null
             if ($path.EndsWith('.cs', [StringComparison]::OrdinalIgnoreCase) -and
                 -not $path.StartsWith('tests/', [StringComparison]::OrdinalIgnoreCase)) {
-                $directoryOwners = Get-DirectoryOwners -Map $Map -Path $path
+                if ($null -eq $directoryOwnerIndex) { $directoryOwnerIndex = New-DirectoryOwnerIndex -Map $Map }
+                $directoryOwners = Get-DirectoryOwners -Index $directoryOwnerIndex -Path $path
             }
             if ($null -eq $directoryOwners) {
                 $escalate = $true
@@ -1440,6 +1461,39 @@ if ($SelfTest) {
     Assert-True $r.Escalate 'an unmapped non-C# file inside a mapped directory was routed instead of escalating'
     $r = Select-ImpactedShards -Map $deepMap -Changed @{ 'src/Finance/Agents/Finance.csproj' = @(1, 4) }
     Assert-True $r.Escalate 'an unmapped project file was routed instead of escalating'
+
+    # Count full-map accesses rather than using a timing threshold. Three unmapped paths
+    # need three direct file lookups and one shared directory projection, independent of depth.
+    $countedMap = [pscustomobject]@{
+        knownShards = $deepMap.knownShards; alwaysRun = @()
+        BackingFiles = $deepMap.files; FileReads = 0
+    }
+    $countedMap | Add-Member -MemberType ScriptProperty -Name files -Value {
+        $this.FileReads++
+        return $this.BackingFiles
+    }
+    $r = Select-ImpactedShards -Map $countedMap -Changed @{
+        'src/Finance/Agents/NewOne.cs' = @(1, 4)
+        'src/Finance/Agents/NewTwo.cs' = @(1, 4)
+        'src/Finance/Brand/New/Deep.cs' = @(1, 4)
+    }
+    Assert-True (-not $r.Escalate -and (@($r.Shards) -join ',') -ceq 'Alpha,Beta,Gamma') `
+        'a shared directory projection changed the selected owners'
+    Assert-True ($countedMap.FileReads -eq 4) `
+        "directory ownership repeatedly enumerated the map ($($countedMap.FileReads) accesses instead of 4)"
+    $countedMap.FileReads = 0
+    $r = Select-ImpactedShards -Map $countedMap -Changed @{ 'src/Finance/Agents/Dqn.cs' = @(1, 2) }
+    Assert-True ($countedMap.FileReads -eq 1) `
+        'a directly mapped change unnecessarily built the directory projection'
+
+    $otherMap = $deepMap | ConvertTo-Json -Depth 8 | ConvertFrom-Json
+    $otherMap.knownShards = @('OtherAlpha', 'OtherBeta', 'OtherGamma')
+    $r = Select-ImpactedShards -Map $otherMap -Changed @{ 'src/Finance/Agents/NewAgent.cs' = @(1, 4) }
+    Assert-True (-not $r.Escalate -and (@($r.Shards) -join ',') -ceq 'OtherAlpha,OtherBeta') `
+        'directory ownership leaked between maps selected in the same process'
+    $r = Select-ImpactedShards -Map $deepMap -Changed @{ 'src/Finance/Agents/NewAgent.cs' = @(1, 4) }
+    Assert-True ((@($r.Shards) -join ',') -ceq 'Alpha,Beta') `
+        'returning to the original map retained another map''s directory owners'
 
     # ---- Test sources, routed through precomputed manifest routes. --------------------------------
     $r = Select-ImpactedShards -Map $map -Changed @{ 'tests/P/FooTests.cs' = @(1, 30) } -TestRoutes @{

--- a/tools/TestImpact/Select-Shards.ps1
+++ b/tools/TestImpact/Select-Shards.ps1
@@ -1770,6 +1770,26 @@ file class Private { }
     Assert-True (($topLevel -join ',') -eq 'Helper,TradingTests') `
         "referenceable top-level types were misread: $($topLevel -join ',')"
 
+    foreach ($kind in @('class', 'record', 'record class')) {
+        $shape = Get-CSharpTestShape -Text "namespace N; [Obsolete] public abstract`n$kind Base { }"
+        Assert-True (@($shape.Types | Where-Object IsAbstract).Count -eq 1 -and $shape.Hazard -like '*abstract class*') `
+            "multiline abstract $kind lost the generated-base hazard"
+        $shape = Get-CSharpTestShape -Text "namespace N; file`n$kind Local { }"
+        Assert-True (@($shape.Types | Where-Object FileLocal).Count -eq 1) `
+            "multiline file $kind was considered externally referenceable"
+    }
+    $shape = Get-CSharpTestShape -Text @'
+namespace N;
+public abstract class Earlier { }
+file class EarlierLocal { }
+[Trait("abstract", "file")]
+public /* abstract file */
+class Current { }
+'@
+    $current = @($shape.Types | Where-Object Name -EQ 'Current')
+    Assert-True ($current.Count -eq 1 -and -not $current[0].IsAbstract -and -not $current[0].FileLocal) `
+        'a declaration inherited modifiers from earlier types, an attribute, or a comment'
+
     $shape = Get-CSharpTestShape -Text "namespace N { public class D : ModelContractBase<int> { } }"
     Assert-True (@($shape.Tests | Where-Object { $_.PrefixOnly -and $_.Fqn -eq 'N.D.' }).Count -eq 1) `
         'a class with a class base did not expose its inherited tests as open-ended'
@@ -1801,6 +1821,7 @@ file class Private { }
         'tests/P/Alpha/ATests.cs' = 'namespace P.Alpha; public class ATests { [Fact] public void A() { } }'
         'tests/P/Shared/Base.cs'  = 'namespace P.Shared; public class Base { [Fact] public void Common() { } }'
         'tests/P/Shared/Abstract.cs' = 'namespace P.Shared; public abstract class ShapeBase { [Fact] public void Common() { } }'
+        'tests/P/Alpha/MultilineAbstract.cs' = "namespace P.Alpha; public abstract`nclass MultilineBase { [Fact] public void Common() { } }"
         'tests/P/Shared/GenBase.cs' = 'namespace P.Shared; public class LayerHarness { }'
         'tests/P/Beta/BTests.cs'  = 'namespace P.Beta; public class BTests : Base { }'
         'tests/P/Shared/Ext.cs'   = 'namespace P.Shared; public static class Ext { public static int X(this int v) => v; }'
@@ -1812,7 +1833,8 @@ file class Private { }
     $generatorNames = @('LayerHarness')
     $findGenerated = { param($names) @($names | Where-Object { $generatorNames -contains $_ }) }
     $routed = Get-TestFileRoutes -Paths @('tests/P/Alpha/ATests.cs', 'tests/P/Shared/Base.cs', 'tests/P/Shared/Ext.cs',
-        'tests/P/Shared/Unused.cs', 'tests/Z/Stray.cs', 'tests/P/Shared/Abstract.cs', 'tests/P/Shared/GenBase.cs') `
+        'tests/P/Shared/Unused.cs', 'tests/Z/Stray.cs', 'tests/P/Shared/Abstract.cs', 'tests/P/Shared/GenBase.cs',
+        'tests/P/Alpha/MultilineAbstract.cs') `
         -Manifest $manifest -ReadFile $read -FindReferrers $find -FindBuildTimeReferences $findGenerated
     Assert-True ($routed['tests/P/Alpha/ATests.cs'].Routable -and
         (@($routed['tests/P/Alpha/ATests.cs'].Shards) -join ',') -eq 'Alpha') `
@@ -1825,6 +1847,9 @@ file class Private { }
     Assert-True (-not $routed['tests/Z/Stray.cs'].Routable) 'a test file outside every shard project was routed'
     Assert-True (-not $routed['tests/P/Shared/Abstract.cs'].Routable) `
         'an abstract test base was routed although build-time generated classes may derive from it'
+    Assert-True (-not $routed['tests/P/Alpha/MultilineAbstract.cs'].Routable -and
+        $routed['tests/P/Alpha/MultilineAbstract.cs'].Why -like '*abstract class*') `
+        'a multiline abstract base was restricted to its namespace instead of escalating for generated descendants'
     Assert-True (-not $routed['tests/P/Shared/GenBase.cs'].Routable -and
         $routed['tests/P/Shared/GenBase.cs'].Why -like '*source generator references*') `
         'a test type a source generator references was routed by reading only the tree'

--- a/tools/TestImpact/Select-Shards.ps1
+++ b/tools/TestImpact/Select-Shards.ps1
@@ -905,8 +905,11 @@ function Get-CSharpTestShape {
         if ($match.Groups['name'].Value -cin @('where', 'new', 'class', 'struct', 'unmanaged', 'notnull')) { continue }
         $body = Get-BodyRange ($match.Index + $match.Length)
         $header = if ($null -ne $body) { $code.Substring($match.Index + $match.Length, $body[0] - $match.Index - $match.Length) } else { '' }
-        $lineStart = $code.LastIndexOf("`n", [Math]::Max(0, $match.Index - 1)) + 1
-        $modifiers = $code.Substring($lineStart, $match.Index - $lineStart)
+        # Modifiers run back to the end of the previous declaration or attribute list, not to the
+        # line start: 'public abstract' written on the line above 'class' is still one declaration,
+        # and reading only the keyword's line missed the abstract-base and file-local hazards.
+        $boundary = if ($match.Index -gt 0) { $code.LastIndexOfAny([char[]] ';{}]', $match.Index - 1) } else { -1 }
+        $modifiers = $code.Substring($boundary + 1, $match.Index - $boundary - 1)
 
         # The base list follows the name, after any type parameters and primary constructor, and
         # before any constraint clause. Interfaces are recognised by the I-prefix convention; any
@@ -1598,6 +1601,17 @@ file class Private { }
     $shape = Get-CSharpTestShape -Text "namespace N { public class X { "
     Assert-True ([bool] $shape.ParseError) 'unbalanced braces were not reported'
 
+    # Modifiers on the line ABOVE the keyword belong to the same declaration.
+    $shape = Get-CSharpTestShape -Text "namespace N;`n[Serializable]`npublic`n    abstract`nclass Base { [Fact] public void A() { } }`nfile`nclass Hidden { }"
+    Assert-True (@($shape.Types | Where-Object { $_.Name -eq 'Base' -and $_.IsAbstract }).Count -eq 1) `
+        'an abstract modifier on the line above the class keyword was missed'
+    Assert-True ([bool] $shape.Hazard) 'a multi-line abstract base escaped the abstract-base hazard'
+    Assert-True (@($shape.Types | Where-Object { $_.Name -eq 'Hidden' -and $_.FileLocal }).Count -eq 1) `
+        'a file modifier on the line above the class keyword was missed'
+    $shape = Get-CSharpTestShape -Text "namespace N;`npublic abstract int Unrelated;`npublic class Concrete { }"
+    Assert-True (@($shape.Types | Where-Object { $_.Name -eq 'Concrete' -and -not $_.IsAbstract }).Count -eq 1) `
+        'a modifier from the PREVIOUS declaration leaked onto the next type'
+
     # ---- Routing with injected file reads and reference search. -----------------------------------
     $manifest = @(
         [pscustomobject]@{ name = 'Alpha'; project = 'tests/P/P.csproj'; filter = 'FullyQualifiedName~P.Alpha' },
@@ -1811,8 +1825,9 @@ function Exit-Escalated {
     param([Parameter(Mandatory)] [string] $Reason, [string] $Message)
 
     if ($Message) { Write-Host "::warning::$Message" }
+    # Same shape as a successful selection, routes included: consumers read it under StrictMode.
     $result = [pscustomobject]@{
-        escalate = $true; requiresValidation = $true; reason = $Reason; reasons = @(); shards = @()
+        escalate = $true; requiresValidation = $true; reason = $Reason; reasons = @(); routes = @(); shards = @()
     }
     if ($OutFile) { $result | ConvertTo-Json -Depth 5 -Compress | Set-Content -LiteralPath $OutFile -Encoding utf8 }
     exit 0
@@ -1917,3 +1932,9 @@ catch {
     Exit-Escalated -Reason 'selection-failed' `
         -Message "shard selection failed, so the full matrix will run: $($_.Exception.Message)"
 }
+
+# Explicit, because falling off the end leaves the script's exit code as whatever the LAST native
+# command returned. Test-source routing runs git grep, which exits 1 when nothing matches - for
+# example the type names of a test file this pull request deletes - and callers read a nonzero exit
+# as a selector failure and run the full matrix, discarding a valid selection.
+exit 0

--- a/tools/TestImpact/Select-Shards.ps1
+++ b/tools/TestImpact/Select-Shards.ps1
@@ -30,6 +30,12 @@
     treated as historical. Pull requests must use PullRequestHeadSha instead: the event's
     base.sha is stale whenever the pull request is behind its base branch.
 
+.PARAMETER DeltaFromTree
+    A Git tree that was already validated. Selection is scoped to the paths that differ between
+    it and HEAD - the change a landed commit adds on top of what a pull request run tested. Used
+    by post-merge reuse to decide which of the pull request's shards master's own later commits
+    could have affected. Mutually exclusive with PullRequestHeadSha and BaseSha.
+
 .PARAMETER ShardManifestFile
     JSON array of { name, project, filter } for every shard (the converted test-shards.yml).
     Test sources are never in the coverage map, so without this every test-file change escalates;
@@ -44,6 +50,7 @@ param(
     [Parameter(Mandatory, ParameterSetName = 'Select')] [string[]] $ExpectedShards,
     [Parameter(ParameterSetName = 'Select')] [switch] $AuditUnchangedMap,
     [Parameter(ParameterSetName = 'Select')] [string] $ShardManifestFile,
+    [Parameter(ParameterSetName = 'Select')] [string] $DeltaFromTree,
     [Parameter(ParameterSetName = 'Select')]
     [Parameter(ParameterSetName = 'Classify')] [string] $BaseSha,
     [Parameter(ParameterSetName = 'Select')]
@@ -270,28 +277,25 @@ function Assert-ShardMap {
     }
 }
 
-function ConvertTo-ChangedRanges {
+function ConvertTo-DiffHunks {
     <#
-        Parses zero-context hunks in the map commit's coordinates. ChangedFiles is authoritative:
-        rename-only, binary and mode-only changes do not necessarily have an @@ header, but they
-        must still reach the fail-safe selector.
-    #>
-    param(
-        [AllowEmptyCollection()] [string[]] $DiffLines,
-        [AllowEmptyCollection()] [string[]] $ChangedFiles = @()
-    )
+        Parses zero-context hunks into { OldStart, OldCount, NewStart, NewCount } per file, keyed by
+        the new path (the old one for a deletion).
 
-    $changed = @{}
+        Hunk BODY lines are counted, and headers are only recognised while none is pending, because
+        diff body lines are raw file content behind a one-character prefix, and content can forge any
+        header: a REMOVED line whose text begins with '-- ' is rendered '--- ...', byte-identical to
+        an old-file header. Reproduced with real git: deleting the line '-- remove me' emitted
+        '--- remove me', the old parser took it as a header, nulled the current file, and silently
+        dropped every later hunk of that file - under-selection with no escalation. A zero-context
+        hunk '@@ -a,n +b,m @@' is followed by exactly n+m body lines (plus uncounted '\ No newline'
+        markers), so counting them makes body content inert no matter what it says.
+    #>
+    param([AllowEmptyCollection()] [string[]] $DiffLines)
+
+    $hunks = @{}
     $current = $null
     $deletedPath = $null
-    # Hunk BODY lines still pending. Headers are only recognised while this is zero, because diff
-    # body lines are raw file content behind a one-character prefix, and content can forge any
-    # header: a REMOVED line whose text begins with '-- ' is rendered '--- ...', byte-identical to
-    # an old-file header. Reproduced with real git: deleting the line '-- remove me' emitted
-    # '--- remove me', the old parser took it as a header, nulled $current, and silently dropped
-    # every later hunk of that file - under-selection with no escalation. A zero-context hunk
-    # '@@ -a,n +b,m @@' is followed by exactly n+m body lines (plus uncounted '\ No newline'
-    # markers), so counting them makes body content inert no matter what it says.
     $pendingBody = 0
     foreach ($line in $DiffLines) {
         if ($pendingBody -gt 0) {
@@ -308,24 +312,49 @@ function ConvertTo-ChangedRanges {
             $current = if ($to -eq '/dev/null') { $deletedPath } else { $to -replace '^b/', '' }
         }
         elseif ($line.StartsWith('@@') -and $line -match '^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@') {
-            $start = [int] $Matches[1]
-            $count = if ($Matches[2]) { [int] $Matches[2] } else { 1 }
+            $oldStart = [int] $Matches[1]
+            $oldCount = if ($Matches[2]) { [int] $Matches[2] } else { 1 }
+            $newStart = [int] $Matches[3]
             $newCount = if ($Matches[4]) { [int] $Matches[4] } else { 1 }
-            $pendingBody = $count + $newCount
+            $pendingBody = $oldCount + $newCount
             if ($current) {
-                if (-not $changed.ContainsKey($current)) {
-                    $changed[$current] = [System.Collections.Generic.List[int]]::new()
+                if (-not $hunks.ContainsKey($current)) {
+                    $hunks[$current] = [System.Collections.Generic.List[object]]::new()
                 }
-                if ($count -gt 0) {
-                    [void] $changed[$current].Add($start)
-                    [void] $changed[$current].Add($start + $count - 1)
-                }
-                else {
-                    [void] $changed[$current].Add([Math]::Max(1, $start))
-                    [void] $changed[$current].Add([Math]::Max(1, $start + 1))
-                }
+                [void] $hunks[$current].Add([int[]] @($oldStart, $oldCount, $newStart, $newCount))
             }
         }
+    }
+    return $hunks
+}
+
+function ConvertTo-ChangedRanges {
+    <#
+        The OLD side of each zero-context hunk as flat start/end pairs. A pure insertion has no old
+        lines, so it is recorded as the two old lines it sits between. ChangedFiles is authoritative:
+        rename-only, binary and mode-only changes do not necessarily have an @@ header, but they must
+        still reach the fail-safe selector.
+    #>
+    param(
+        [AllowEmptyCollection()] [string[]] $DiffLines,
+        [AllowEmptyCollection()] [string[]] $ChangedFiles = @()
+    )
+
+    $changed = @{}
+    $hunks = ConvertTo-DiffHunks -DiffLines $DiffLines
+    foreach ($path in $hunks.Keys) {
+        $ranges = [System.Collections.Generic.List[int]]::new()
+        foreach ($hunk in $hunks[$path]) {
+            if ($hunk[1] -gt 0) {
+                [void] $ranges.Add($hunk[0])
+                [void] $ranges.Add($hunk[0] + $hunk[1] - 1)
+            }
+            else {
+                [void] $ranges.Add([Math]::Max(1, $hunk[0]))
+                [void] $ranges.Add([Math]::Max(1, $hunk[0] + 1))
+            }
+        }
+        $changed[$path] = $ranges
     }
 
     foreach ($path in $ChangedFiles) {
@@ -336,6 +365,156 @@ function ConvertTo-ChangedRanges {
     return $changed
 }
 
+function Convert-RangesThroughHunks {
+    <#
+        Carries line ranges expressed in a LATER version of a file back to an EARLIER one, through
+        the zero-context hunks of earlier -> later (old = earlier, new = later).
+
+        Selection needs a change's lines in the map commit's numbering. For a pull request that is
+        behind master, or a landed commit measured against the tree its pull request validated, the
+        change is naturally expressed against a base the map does not describe; diffing the map
+        against HEAD instead would sweep in every edit master made to the same file since the map.
+        This carries the change's own ranges back instead.
+
+        It never narrows what a line can affect: a later line that is unchanged since the earlier
+        version maps to its exact earlier line; one inside a changed region maps to the WHOLE earlier
+        region it replaced (or, where nothing was replaced, the two earlier lines it sits between);
+        and a range touching the spot where earlier lines were deleted also takes the deleted lines.
+    #>
+    param(
+        [Parameter(Mandatory)] [AllowEmptyCollection()] [int[]] $Ranges,
+        [Parameter(Mandatory)] [AllowEmptyCollection()] [object[]] $Hunks
+    )
+
+    if ($Hunks.Count -eq 0) { return , ([int[]] $Ranges) }
+
+    # Alternating segments: Same (a later run of lines with an exact earlier counterpart) and
+    # Changed (a later run, possibly empty, that replaced an earlier run, possibly empty).
+    $segments = [System.Collections.Generic.List[object]]::new()
+    $oldConsumed = 0
+    $newConsumed = 0
+    foreach ($hunk in @($Hunks | Sort-Object { $_[0] }, { $_[2] })) {
+        $oldStart, $oldCount, $newStart, $newCount = $hunk
+        $oldBefore = if ($oldCount -gt 0) { $oldStart - 1 } else { $oldStart }
+        $newBefore = if ($newCount -gt 0) { $newStart - 1 } else { $newStart }
+        $same = $oldBefore - $oldConsumed
+        if ($same -ne ($newBefore - $newConsumed)) {
+            throw 'inconsistent diff hunks: unchanged runs differ in length'
+        }
+        if ($same -gt 0) {
+            [void] $segments.Add([pscustomobject]@{ Kind = 'Same'; NewFrom = $newConsumed + 1; NewTo = $newBefore; Offset = $oldConsumed - $newConsumed })
+        }
+        [void] $segments.Add([pscustomobject]@{
+            Kind = 'Changed'; NewFrom = $newStart; NewTo = $newStart + $newCount - 1
+            OldFrom = $oldStart; OldTo = $oldStart + $oldCount - 1; NewCount = $newCount; OldCount = $oldCount
+        })
+        $oldConsumed = $oldBefore + $oldCount
+        $newConsumed = $newBefore + $newCount
+    }
+    [void] $segments.Add([pscustomobject]@{ Kind = 'Same'; NewFrom = $newConsumed + 1; NewTo = [int]::MaxValue; Offset = $oldConsumed - $newConsumed })
+
+    $result = [System.Collections.Generic.List[int]]::new()
+    for ($i = 0; $i + 1 -lt $Ranges.Count; $i += 2) {
+        $from = [int] $Ranges[$i]
+        $to = [int] $Ranges[$i + 1]
+        foreach ($segment in $segments) {
+            if ($segment.Kind -eq 'Same') {
+                $a = [Math]::Max($from, $segment.NewFrom)
+                $b = [Math]::Min($to, $segment.NewTo)
+                if ($a -le $b) {
+                    [void] $result.Add($a + $segment.Offset)
+                    [void] $result.Add($b + $segment.Offset)
+                }
+                continue
+            }
+            # A Changed segment with later lines is hit when the range overlaps them. One with none
+            # is a deletion: '@@ -a,n +b,0 @@' removed earlier lines from between later lines b and
+            # b + 1, so it is hit when the range touches either of those two neighbours.
+            $hit = if ($segment.NewCount -gt 0) {
+                $from -le $segment.NewTo -and $to -ge $segment.NewFrom
+            } else {
+                $from -le $segment.NewFrom + 1 -and $to -ge $segment.NewFrom
+            }
+            if (-not $hit) { continue }
+            if ($segment.OldCount -gt 0) {
+                [void] $result.Add($segment.OldFrom)
+                [void] $result.Add($segment.OldTo)
+            }
+            else {
+                [void] $result.Add([Math]::Max(1, $segment.OldFrom))
+                [void] $result.Add([Math]::Max(1, $segment.OldFrom + 1))
+            }
+        }
+    }
+    return , ([int[]] $result.ToArray())
+}
+
+function Test-RangesTouchIntroducedLines {
+    <#
+        Whether any range reaches later lines that did not exist in the earlier version (the new
+        side of a hunk). Such a line's earlier home is unknown from the diff alone: if the base
+        branch MOVED code since the map, the moved lines appear as fresh insertions, and carrying a
+        change to them back would land on the insertion point instead of the code's mapped lines.
+    #>
+    param(
+        [Parameter(Mandatory)] [AllowEmptyCollection()] [int[]] $Ranges,
+        [Parameter(Mandatory)] [AllowEmptyCollection()] [object[]] $Hunks
+    )
+    foreach ($hunk in $Hunks) {
+        if ($hunk[3] -le 0) { continue }
+        $newFrom = $hunk[2]
+        $newTo = $hunk[2] + $hunk[3] - 1
+        for ($i = 0; $i + 1 -lt $Ranges.Count; $i += 2) {
+            if ($Ranges[$i] -le $newTo -and $Ranges[$i + 1] -ge $newFrom) { return $true }
+        }
+    }
+    return $false
+}
+
+function Get-ScopedChangedRanges {
+    <#
+        The change from Base to HEAD, for exactly Paths, in the map commit's line numbers: the
+        change's own old-side ranges, carried back through map -> Base. Base may be a commit or a
+        tree (post-merge delta reuse compares against a rebuilt tree).
+    #>
+    param(
+        [Parameter(Mandatory)] [string] $MapSha,
+        [Parameter(Mandatory)] [string] $Base,
+        [Parameter(Mandatory)] [AllowEmptyCollection()] [string[]] $Paths
+    )
+
+    $changed = @{}
+    if ($Paths.Count -eq 0) { return $changed }
+    $changeDiff = @(& git -c core.quotepath=false --literal-pathspecs diff --no-renames --no-ext-diff -U0 $Base HEAD -- @Paths)
+    if ($LASTEXITCODE -ne 0) { throw "git diff from '$Base' failed" }
+    $ownRanges = ConvertTo-ChangedRanges -DiffLines $changeDiff -ChangedFiles $Paths
+    $mapDiff = @(& git -c core.quotepath=false --literal-pathspecs diff --no-renames --no-ext-diff -U0 $MapSha $Base -- @Paths)
+    if ($LASTEXITCODE -ne 0) { throw "git diff from the map commit '$MapSha' to '$Base' failed" }
+    $mapHunks = ConvertTo-DiffHunks -DiffLines $mapDiff
+
+    $sweep = [System.Collections.Generic.List[string]]::new()
+    foreach ($path in $ownRanges.Keys) {
+        $ranges = [int[]] @($ownRanges[$path])
+        # Two statements: an if-expression yielding @() unrolls to $null.
+        $hunks = @()
+        if ($mapHunks.ContainsKey($path)) { $hunks = @($mapHunks[$path]) }
+        $changed[$path] = [System.Collections.Generic.List[int]]::new([int[]] (Convert-RangesThroughHunks -Ranges $ranges -Hunks $hunks))
+        if (Test-RangesTouchIntroducedLines -Ranges $ranges -Hunks $hunks) { [void] $sweep.Add($path) }
+    }
+
+    # Where the change reaches lines the base branch introduced since the map, their mapped origin
+    # is unknowable from this diff, so add back everything map -> HEAD changed in that file: the
+    # original, broader behaviour, which sees a move as the deletion of the mapped lines.
+    if ($sweep.Count -gt 0) {
+        $sweepDiff = @(& git -c core.quotepath=false --literal-pathspecs diff --no-renames --no-ext-diff -U0 $MapSha HEAD -- @($sweep))
+        if ($LASTEXITCODE -ne 0) { throw "git diff from the map commit '$MapSha' to HEAD failed" }
+        $sweepRanges = ConvertTo-ChangedRanges -DiffLines $sweepDiff
+        foreach ($path in $sweep) {
+            if ($sweepRanges.ContainsKey($path)) { $changed[$path].AddRange([int[]] @($sweepRanges[$path])) }
+        }
+    }
+    return $changed
+}
 function Get-ChangedRanges {
     param([string] $MapSha)
 
@@ -1653,6 +1832,96 @@ file class Private { }
         -FindReferrers $find -FindBuildTimeReferences $findGenerated -MaximumClosure 1
     Assert-True (-not $wide['tests/P/Shared/Base.cs'].Routable) 'a closure wider than the limit was routed'
 
+    # ---- Carrying a change's ranges back to the map's numbering. -------------------------------
+    # Hand-checked cases first. map -> base: line 4 replaced (4 -> 4), 2 lines inserted after 7,
+    # line 12 deleted.
+    $hunks = @([int[]] @(4, 1, 4, 1), [int[]] @(7, 0, 8, 2), [int[]] @(12, 1, 13, 0))
+    Assert-True (((Convert-RangesThroughHunks -Ranges @(2, 2) -Hunks $hunks) -join ',') -eq '2,2') 'an unchanged early line moved'
+    Assert-True (((Convert-RangesThroughHunks -Ranges @(10, 10) -Hunks $hunks) -join ',') -eq '8,8') 'a line after an insertion did not shift back'
+    Assert-True (((Convert-RangesThroughHunks -Ranges @(8, 8) -Hunks $hunks) -join ',') -eq '7,8') 'an inserted line did not map to its insertion point'
+    Assert-True (((Convert-RangesThroughHunks -Ranges @(4, 4) -Hunks $hunks) -join ',') -eq '4,4') 'a replaced line did not map to what it replaced'
+    # Map line 12 was deleted from between base lines 13 and 14: both neighbours take it, and the
+    # line before them (base 12 = map 10) does not. An off-by-one here once shifted the pair to 12/13.
+    Assert-True (((Convert-RangesThroughHunks -Ranges @(13, 13) -Hunks $hunks) -join ',') -match '(^|,)12,12(,|$)') 'a change before a deletion lost the deleted line'
+    Assert-True (((Convert-RangesThroughHunks -Ranges @(14, 14) -Hunks $hunks) -join ',') -match '(^|,)12,12(,|$)') 'a change after a deletion lost the deleted line'
+    Assert-True (((Convert-RangesThroughHunks -Ranges @(12, 12) -Hunks $hunks) -join ',') -eq '10,10') 'a change two lines from a deletion took the deleted line'
+    Assert-True (((Convert-RangesThroughHunks -Ranges @(20, 20) -Hunks $hunks) -join ',') -eq '19,19') 'a line after a deletion did not shift forward'
+    Assert-True (Test-RangesTouchIntroducedLines -Ranges @(9, 9) -Hunks $hunks) 'a change on an introduced line was not flagged'
+    Assert-True (-not (Test-RangesTouchIntroducedLines -Ranges @(2, 2) -Hunks $hunks)) 'a change on a mapped line was flagged'
+
+    # Then a property check against real git diffs. Every line is a unique token, so "the same
+    # code" is unambiguous: whenever a change touches a base line whose token exists in the map, the
+    # map line holding that token must be inside the carried-back ranges. Edits include MOVES,
+    # which git shows as delete + insert - the case the introduced-line sweep exists for.
+    $propertyRoot = Join-Path ([System.IO.Path]::GetTempPath()) ("carry-ranges-" + [guid]::NewGuid().ToString('N'))
+    New-Item -ItemType Directory -Path $propertyRoot -Force | Out-Null
+    try {
+        $random = [System.Random]::new(20260911)
+        function New-EditedLines([string[]] $Lines, [string] $Tag, [int] $Edits) {
+            $list = [System.Collections.Generic.List[string]]::new([string[]] $Lines)
+            for ($e = 0; $e -lt $Edits; $e++) {
+                $at = $random.Next([Math]::Max(1, $list.Count))
+                switch ($random.Next(4)) {
+                    0 { if ($list.Count -gt 3) { $list.RemoveAt($at) } }
+                    1 { $list.Insert($at, "$Tag$e-$($random.Next(100000))") }
+                    2 { if ($list.Count -gt 0) { $list[$at] = "$Tag$e-$($random.Next(100000))" } }
+                    3 { if ($list.Count -gt 3) { $moved = $list[$at]; $list.RemoveAt($at); $list.Insert($random.Next($list.Count + 1), $moved) } }
+                }
+            }
+            return , ([string[]] $list.ToArray())
+        }
+        function Get-FileHunks([string] $From, [string] $To) {
+            $diff = @(& git diff --no-index --no-renames --no-ext-diff -U0 -- $From $To 2>$null)
+            $parsed = ConvertTo-DiffHunks -DiffLines $diff
+            if ($parsed.Count -eq 0) { return }
+            # Emits each hunk (an int[4]) separately; callers collect them with @().
+            return @($parsed.Values)[0]
+        }
+
+        $violations = 0
+        for ($trial = 0; $trial -lt 120; $trial++) {
+            $mapLines = [string[]] @(1..25 | ForEach-Object { "m$_" })
+            $baseLines = New-EditedLines $mapLines 'b' ($random.Next(1, 5))
+            $headLines = New-EditedLines $baseLines 'h' ($random.Next(1, 4))
+            $mapFile = Join-Path $propertyRoot "map.txt"; $baseFile = Join-Path $propertyRoot "base.txt"; $headFile = Join-Path $propertyRoot "head.txt"
+            [System.IO.File]::WriteAllText($mapFile, ($mapLines -join "`n") + "`n")
+            [System.IO.File]::WriteAllText($baseFile, ($baseLines -join "`n") + "`n")
+            [System.IO.File]::WriteAllText($headFile, ($headLines -join "`n") + "`n")
+
+            $own = @(Get-FileHunks $baseFile $headFile)
+            if ($own.Count -eq 0) { continue }
+            $ownRanges = [System.Collections.Generic.List[int]]::new()
+            foreach ($h in $own) {
+                if ($h[1] -gt 0) { $ownRanges.Add($h[0]); $ownRanges.Add($h[0] + $h[1] - 1) }
+                else { $ownRanges.Add([Math]::Max(1, $h[0])); $ownRanges.Add([Math]::Max(1, $h[0] + 1)) }
+            }
+            $mapToBase = @(Get-FileHunks $mapFile $baseFile)
+            $carried = [System.Collections.Generic.List[int]]::new([int[]] (Convert-RangesThroughHunks -Ranges $ownRanges.ToArray() -Hunks $mapToBase))
+            if (Test-RangesTouchIntroducedLines -Ranges $ownRanges.ToArray() -Hunks $mapToBase) {
+                foreach ($h in @(Get-FileHunks $mapFile $headFile)) {
+                    if ($h[1] -gt 0) { $carried.Add($h[0]); $carried.Add($h[0] + $h[1] - 1) }
+                    else { $carried.Add([Math]::Max(1, $h[0])); $carried.Add([Math]::Max(1, $h[0] + 1)) }
+                }
+            }
+
+            foreach ($h in $own) {
+                $touched = if ($h[1] -gt 0) { @($h[0]..($h[0] + $h[1] - 1)) } else { @($h[0], ($h[0] + 1)) }
+                foreach ($baseLine in $touched) {
+                    if ($baseLine -lt 1 -or $baseLine -gt $baseLines.Count) { continue }
+                    $mapLine = [Array]::IndexOf($mapLines, $baseLines[$baseLine - 1]) + 1
+                    if ($mapLine -lt 1) { continue }
+                    $inside = $false
+                    for ($c = 0; $c + 1 -lt $carried.Count; $c += 2) {
+                        if ($mapLine -ge $carried[$c] -and $mapLine -le $carried[$c + 1]) { $inside = $true; break }
+                    }
+                    if (-not $inside) { $violations++ }
+                }
+            }
+        }
+        Assert-True ($violations -eq 0) "carrying ranges back to the map dropped $violations mapped line(s) a change touched"
+    }
+    finally { Remove-Item -LiteralPath $propertyRoot -Recurse -Force -ErrorAction SilentlyContinue }
+
     # An empty build-time pathspec would make git grep search the whole repository.
     $configuredBuildTime = $script:BuildTimeDirectories
     try {
@@ -1858,20 +2127,40 @@ try {
     $changed = Get-ChangedRanges -MapSha $mapSha
     $currentPaths = @($changed.Keys)
     $scopeToPullRequest = $false
-    if ($PullRequestHeadSha -and $BaseSha) { throw 'pass PullRequestHeadSha or BaseSha, not both' }
+    if (@(@($PullRequestHeadSha, $BaseSha, $DeltaFromTree) | Where-Object { $_ }).Count -gt 1) {
+        throw 'pass at most one of PullRequestHeadSha, BaseSha and DeltaFromTree'
+    }
     if ($PullRequestHeadSha) {
         $BaseSha = Resolve-PullRequestBase -PullRequestHeadSha $PullRequestHeadSha
         $scopeToPullRequest = $true
         Write-Host "pull request base (merge commit's first parent): $BaseSha"
     }
+    if ($DeltaFromTree) {
+        # A tree, not a commit: the validated pull-request merge commit may no longer be fetchable,
+        # but its tree can be rebuilt and compared exactly; see Resolve-CiValidationReuse.ps1.
+        if ($DeltaFromTree -notmatch '^(?:[0-9a-fA-F]{40}|[0-9a-fA-F]{64})$') {
+            throw "delta tree '$DeltaFromTree' is not a complete Git object id"
+        }
+        & git cat-file -e "$DeltaFromTree^{tree}" 2>$null
+        if ($LASTEXITCODE -ne 0) { throw "delta tree '$DeltaFromTree' is not present in this checkout" }
+        $BaseSha = $DeltaFromTree
+        $scopeToPullRequest = $true
+        Write-Host "delta from validated tree: $DeltaFromTree"
+    }
     if ($BaseSha) {
-        & git cat-file -e "$BaseSha^{commit}"
-        if ($LASTEXITCODE -ne 0) { throw "base commit '$BaseSha' is not present in this checkout" }
+        $baseKind = if ($DeltaFromTree) { 'tree' } else { 'commit' }
+        & git cat-file -e "$BaseSha^{$baseKind}"
+        if ($LASTEXITCODE -ne 0) { throw "base $baseKind '$BaseSha' is not present in this checkout" }
         $currentPaths = @(& git -c core.quotepath=false diff --no-renames --name-only $BaseSha HEAD --)
         if ($LASTEXITCODE -ne 0) { throw "git diff --name-only from current base '$BaseSha' failed" }
         $currentPaths = @($currentPaths | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
     }
     Write-Host "changed files since the map: $($changed.Count); changed by the current change: $($currentPaths.Count)"
+    if ($scopeToPullRequest) {
+        # The change's own ranges, carried back to the map's numbering. The map-to-HEAD ranges above
+        # would also sweep in every edit the base branch made to the same files since the map.
+        $changed = Get-ScopedChangedRanges -MapSha $mapSha -Base $BaseSha -Paths $currentPaths
+    }
 
     # Test sources the map cannot index, among the paths selection will actually consider.
     $testRoutes = @{}

--- a/tools/TestImpact/Test-CertificateEvidenceReview.ps1
+++ b/tools/TestImpact/Test-CertificateEvidenceReview.ps1
@@ -1,0 +1,69 @@
+<# Execute the production tree-binding assignments and exact/delta eligibility branches offline. #>
+[CmdletBinding()]
+param()
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+$tokens = $null
+$errors = $null
+$ast = [System.Management.Automation.Language.Parser]::ParseFile(
+    (Join-Path $PSScriptRoot 'Resolve-CiValidationReuse.ps1'), [ref] $tokens, [ref] $errors)
+if ($errors.Count -ne 0) { throw 'The certificate resolver does not parse.' }
+foreach ($declaration in $ast.EndBlock.Statements | Where-Object {
+    $_ -is [System.Management.Automation.Language.FunctionDefinitionAst] -or
+    $_ -is [System.Management.Automation.Language.TypeDefinitionAst]
+}) { . ([scriptblock]::Create($declaration.Extent.Text)) }
+$bindings = @($ast.FindAll({ param($node)
+    $node -is [System.Management.Automation.Language.AssignmentStatementAst] -and
+    $node.Left -is [System.Management.Automation.Language.VariableExpressionAst] -and
+    $node.Left.VariablePath.UserPath -in @('certificateTreeMatches', 'treeMatches')
+}, $true) | Sort-Object { $_.Extent.StartOffset })
+if (@($bindings | Where-Object { $_.Left.VariablePath.UserPath -eq 'treeMatches' }).Count -ne 1) {
+    throw 'Expected exactly one production landed-tree binding.'
+}
+$delta = @($ast.EndBlock.Statements | Where-Object {
+    $_ -is [System.Management.Automation.Language.AssignmentStatementAst] -and
+    $_.Left -is [System.Management.Automation.Language.VariableExpressionAst] -and
+    $_.Left.VariablePath.UserPath -eq 'deltaCandidates'
+})
+if ($delta.Count -ne 1) { throw 'Expected exactly one production delta eligibility branch.' }
+$failures = [Collections.Generic.List[string]]::new()
+$cases = 0
+$artifactCases = @(foreach ($analysis in @($true, $false)) {
+    foreach ($coverage in @($true, $false)) {
+        foreach ($ledger in @($true, $false)) {
+            [pscustomobject]@{ Analysis = $analysis; Coverage = $coverage; Ledger = $ledger }
+        }
+    }
+})
+foreach ($certificateMatches in @($true, $false)) {
+    foreach ($landedMatches in @($true, $false)) {
+        foreach ($requiresRuntime in @($true, $false)) {
+            foreach ($artifacts in $artifactCases) {
+                $cases++
+                $testedTree = '0123456789abcdef0123456789abcdef01234567'
+                $otherTree = '1123456789abcdef0123456789abcdef01234567'
+                $masterTree = if ($landedMatches) { $testedTree } else { $otherTree }
+                $parsed = [pscustomobject]@{ TestedTree = $(if ($certificateMatches) { $testedTree } else { $otherTree }) }
+                $certificateTreeMatches = $true
+                foreach ($binding in $bindings) { . ([scriptblock]::Create($binding.Extent.Text)) }
+                $evidence = @([pscustomobject]@{
+                    Scope = [CiValidationReuseScope]::Validation; Event = 'pull_request'
+                    RunId = 1; CreatedAt = '2026-01-01T00:00:00Z'
+                    TreeMatches = $treeMatches; CertificateTreeMatches = $certificateTreeMatches
+                    RequiresValidation = $requiresRuntime
+                    HasAnalysis = $artifacts.Analysis; HasCoverage = $artifacts.Coverage; HasLedger = $artifacts.Ledger
+                })
+                $best = Select-BestCiEvidence $evidence
+                . ([scriptblock]::Create($delta[0].Extent.Text))
+                $artifactsComplete = -not $requiresRuntime -or ($artifacts.Analysis -and $artifacts.Coverage -and $artifacts.Ledger)
+                $expectedExact = $certificateMatches -and $landedMatches -and $artifactsComplete
+                $expectedDelta = $certificateMatches -and -not $landedMatches -and $artifactsComplete
+                if (($null -ne $best) -ne $expectedExact -or ($deltaCandidates.Count -gt 0) -ne $expectedDelta) {
+                    [void] $failures.Add("certificate=$certificateMatches landed=$landedMatches runtime=$requiresRuntime artifacts=$artifacts exact=$($null -ne $best) delta=$($deltaCandidates.Count)")
+                }
+            }
+        }
+    }
+}
+if ($failures.Count -gt 0) { throw "Certificate eligibility failures: $($failures -join '; ')" }
+Write-Host "Certificate evidence review: $cases exact/delta production eligibility cases passed."

--- a/tools/TestImpact/Test-CiImpactWorkflow.ps1
+++ b/tools/TestImpact/Test-CiImpactWorkflow.ps1
@@ -251,8 +251,23 @@ Assert-Contract (-not $selectStep.Contains('-AuditUnchangedMap')) `
     'ordinary PR selection was given the audit-only unchanged-map capability'
 Assert-Contract ($selectStep.Contains('-ClassifyOnly')) `
     'non-runtime classification still depends on a coverage map being available'
-Assert-Contract ($selectStep.Contains('-BaseSha $env:PR_BASE_SHA')) `
+Assert-Contract ($selectStep.Contains('-ClassifyOnly `') -and
+        $selectStep.Contains('-PullRequestHeadSha $env:PR_HEAD_SHA -OutFile path-classification.json')) `
     'non-runtime classification does not use the exact PR base-to-head path set'
+Assert-Contract ($selectStep.Contains('PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}')) `
+    'the selector is not given the pull request head it must verify as the merge commit''s second parent'
+# The event base.sha is the base branch as it was when the pull request was opened. For a pull
+# request behind master it made every commit master gained since look like part of the pull
+# request: on #2100 it attributed 16 merged CI-control files to a 4-file change, escalating 116 shards.
+Assert-Contract (-not $selectStep.Contains('pull_request.base.sha') -and -not $selectStep.Contains('-BaseSha')) `
+    'pull-request selection reads the stale event base.sha instead of the merge commit''s first parent'
+Assert-Contract ($selectorText.Contains('function Resolve-PullRequestBase') -and
+        $selectorText.Contains('$parents.Count -ne 3') -and
+        $selectorText.Contains('$parents[2].Equals($PullRequestHeadSha')) `
+    'the selector does not verify the checkout is the two-parent merge of the pull request head'
+Assert-Contract ($selectStep.Contains('-ShardManifestFile shard-manifest.json') -and
+        $selectStep.Contains('Set-Content -LiteralPath shard-manifest.json')) `
+    'test sources are not routed through the shard manifest, so every test edit escalates'
 Assert-Contract ($selectStep.Contains('$pathRequiresValidation = Read-RequiredJsonBoolean')) `
     'the selector does not validate and consume the path classifier boolean'
 Assert-Contract ($selectStep.Contains('$selectionEscalated = Read-RequiredJsonBoolean')) `
@@ -612,6 +627,9 @@ Assert-Contract ($auditStep.Contains('-MapFile shard-map.json')) `
     'fresh coverage certification does not audit the candidate map that was just measured'
 Assert-Contract ($auditStep.Contains('-CurrentChangeBaseSha $sourceSha')) `
     'historically merged selector-control changes still wedge every later selection audit'
+Assert-Contract ($auditStep.Contains('-ShardManifestFile $auditManifest') -and
+        $auditStep.Contains("yq -o=json -I=0 '.shard' .github/test-shards.yml")) `
+    'the nightly audit does not replay test-source routing, so its misses are never measured'
 Assert-Contract ($auditStep.Contains('if ([int] $historicalDecision.missCount -gt 0)')) `
     'a historical selection miss can be hidden by fresh-coverage fallback'
 Assert-Contract ($auditStep.Contains('(-not $certified -and $auditExit -eq 0)')) `

--- a/tools/TestImpact/Test-CiImpactWorkflow.ps1
+++ b/tools/TestImpact/Test-CiImpactWorkflow.ps1
@@ -107,6 +107,55 @@ function Get-ContinuedShellCommand {
     return @($commands)
 }
 
+function Test-MapSelectorPullRequestScope {
+    param([string] $Step)
+
+    # Parse individual PowerShell invocations rather than searching the whole step:
+    # the classifier's argument, a comment, or a different variable proves nothing
+    # about the map-backed command that actually emits the selected shard matrix.
+    $lines = [regex]::Split($Step, '\r?\n')
+    $mapCommands = [System.Collections.Generic.List[System.Management.Automation.Language.CommandAst]]::new()
+    for ($i = 0; $i -lt $lines.Count; $i++) {
+        if ($lines[$i] -notmatch '^\s*&\s+\./tools/TestImpact/Select-Shards\.ps1\b') { continue }
+        $parts = [System.Collections.Generic.List[string]]::new()
+        do {
+            $line = $lines[$i]
+            [void] $parts.Add($line)
+            $continued = $line.TrimEnd().EndsWith('`', [StringComparison]::Ordinal)
+            if ($continued) { $i++ }
+        } while ($continued -and $i -lt $lines.Count)
+        $tokens = $null; $parseErrors = $null
+        $ast = [System.Management.Automation.Language.Parser]::ParseInput(
+            ($parts -join "`n"), [ref] $tokens, [ref] $parseErrors)
+        if ($parseErrors.Count -gt 0) { return $false }
+        foreach ($command in $ast.FindAll({ param($node)
+            $node -is [System.Management.Automation.Language.CommandAst]
+        }, $true)) {
+            if ($command.GetCommandName() -cne './tools/TestImpact/Select-Shards.ps1') { continue }
+            if (@($command.CommandElements | Where-Object {
+                $_ -is [System.Management.Automation.Language.CommandParameterAst] -and $_.ParameterName -ceq 'MapFile'
+            }).Count -gt 0) { [void] $mapCommands.Add($command) }
+        }
+    }
+    if ($mapCommands.Count -ne 1) { return $false }
+    $elements = $mapCommands[0].CommandElements
+    $arguments = @{}
+    for ($i = 1; $i -lt $elements.Count; $i++) {
+        $element = $elements[$i]
+        if ($element -isnot [System.Management.Automation.Language.CommandParameterAst] -or
+            $element.ParameterName -cnotin @('MapFile', 'PullRequestHeadSha')) { continue }
+        if ($arguments.ContainsKey($element.ParameterName)) { return $false }
+        $value = $element.Argument
+        if ($null -eq $value -and $i + 1 -lt $elements.Count) { $value = $elements[$i + 1] }
+        $arguments[$element.ParameterName] = $value
+    }
+    return $arguments.ContainsKey('MapFile') -and $arguments.ContainsKey('PullRequestHeadSha') -and
+        $arguments.MapFile -is [System.Management.Automation.Language.StringConstantExpressionAst] -and
+        $arguments.MapFile.Value -ceq 'map/shard-map.json' -and
+        $arguments.PullRequestHeadSha -is [System.Management.Automation.Language.VariableExpressionAst] -and
+        $arguments.PullRequestHeadSha.VariablePath.UserPath -ceq 'env:PR_HEAD_SHA'
+}
+
 $validation = Get-Content -LiteralPath $ValidationWorkflow -Raw
 $map = Get-Content -LiteralPath $MapWorkflow -Raw
 $selectorText = Get-Content -LiteralPath $Selector -Raw
@@ -261,6 +310,8 @@ Assert-Contract ($selectStep.Contains('PR_HEAD_SHA: ${{ github.event.pull_reques
 # request: on #2100 it attributed 16 merged CI-control files to a 4-file change, escalating 116 shards.
 Assert-Contract (-not $selectStep.Contains('pull_request.base.sha') -and -not $selectStep.Contains('-BaseSha')) `
     'pull-request selection reads the stale event base.sha instead of the merge commit''s first parent'
+Assert-Contract (Test-MapSelectorPullRequestScope -Step $selectStep) `
+    'the map-backed selector does not scope its change to the pull request head'
 Assert-Contract ($selectorText.Contains('function Resolve-PullRequestBase') -and
         $selectorText.Contains('$parents.Count -ne 3') -and
         $selectorText.Contains('$parents[2].Equals($PullRequestHeadSha')) `

--- a/tools/TestImpact/Test-CiImpactWorkflow.ps1
+++ b/tools/TestImpact/Test-CiImpactWorkflow.ps1
@@ -355,6 +355,50 @@ Assert-Contract ($selectStep.Contains('runWithoutInstrumentationShardNames = @($
 Assert-Contract ($selectStep.Contains('coverage_run_without_instrumentation=$(ConvertTo-Json')) `
     'the typed coverage decision is not transported to the shard jobs'
 
+# ---- Post-merge delta reuse. A pull request merged while behind master lands a tree its run never
+# validated, so exact-tree reuse never matched and nearly every merge re-ran all 116 shards.
+$sourceJob = Get-JobBlock -WorkflowText $validation -Job 'validation-source'
+$sourceHeader = Get-JobHeader -JobBlock $sourceJob
+Assert-Contract ($sourceJob.Contains("fetch-depth: `${{ github.event_name == 'push' && '0' || '1' }}") -and
+        -not $sourceJob.Contains("== 'push' && 0 ||")) `
+    'validation-source lacks the history to rebuild the validated tree and diff it in map coordinates'
+$deltaMapStep = Get-StepBlock -JobBlock $sourceJob -Step 'Resolve certified shard map for delta reuse'
+Assert-Contract ([bool] $deltaMapStep -and $deltaMapStep.Contains('continue-on-error: true') -and
+        $deltaMapStep.Contains('Resolve-CertifiedShardMap.ps1') -and $deltaMapStep.Contains('Test-CertifiedShardMap.ps1')) `
+    'delta reuse does not select with an audited map, or a map failure can fail the push instead of disabling delta reuse'
+$resolveStep = Get-StepBlock -JobBlock $sourceJob -Step 'Resolve exact-tree PR run'
+Assert-Contract ($resolveStep.Contains("-MapFile '`${{ steps.delta-map.outputs.map_file }}'") -and
+        $resolveStep.Contains("-ShardManifestFile '`${{ steps.delta-map.outputs.manifest_file }}'")) `
+    'the reuse resolver is not given the delta-reuse map and manifest'
+foreach ($output in @('delta_mode', 'partial_shards', 'import_run_id', 'import_sha', 'import_shards')) {
+    Assert-Contract ($sourceHeader.Contains("${output}: `${{ steps.resolve.outputs.$output || steps.defaults.outputs.$output }}")) `
+        "validation-source does not publish the fail-closed delta output '$output'"
+}
+Assert-Contract ($validationReuseResolverText.Contains('function Resolve-ValidatedTree') -and
+        $validationReuseResolverText.Contains('$tree -cne $ExpectedTree')) `
+    'delta reuse does not require the rebuilt tree to equal the validated tree exactly'
+Assert-Contract ($validationReuseResolverText.Contains("-DecisionScope Validation -RunId `$candidate.RunId")) `
+    'delta reuse can claim Complete scope although CodeQL and Sonar analysed a different tree'
+Assert-Contract ($selectStep.Contains('$deltaPartial') -and $selectStep.Contains('PARTIAL_SHARDS: ${{ needs.validation-source.outputs.partial_shards }}')) `
+    'a partial post-merge re-run does not reduce the shard matrix'
+$mapStep = Get-StepBlock -JobBlock $selectorJob -Step 'Download the shard map'
+Assert-Contract ($mapStep.Contains("MAP_BRANCH: `${{ startsWith(github.base_ref, 'ci-proof/') && 'master' || github.base_ref || 'master' }}")) `
+    'a canary into a ci-proof/** branch looks for maps built on that branch, finds none, and cannot prove selection'
+Assert-Contract (-not $selectStep.Contains('-DeltaFromTree')) `
+    'the select step computes its own master delta - a second, unaudited reuse mechanism'
+Assert-Contract ($selectStep.Contains('foreach ($name in $importShards) { [void] $running.Add($name) }')) `
+    'imported shards are reported to regression analysis as deliberately skipped'
+foreach ($consumer in @(
+        @{ Job = 'test-regression-analysis'; Prefix = 'coverage' },
+        @{ Job = 'ci-test-analysis'; Prefix = 'test-results' },
+        @{ Job = 'sonarcloud'; Prefix = 'coverage' })) {
+    $consumerJob = Get-JobBlock -WorkflowText $validation -Job $consumer.Job
+    Assert-Contract ($consumerJob.Contains('Import-PullRequestShardArtifacts.ps1') -and
+            $consumerJob.Contains("-ArtifactPrefix $($consumer.Prefix)") -and
+            $consumerJob.Contains('run-id: ${{ needs.validation-source.outputs.import_run_id }}')) `
+        "$($consumer.Job) does not import the pull request's results for shards a partial run did not re-run"
+}
+
 # A 100+ shard fan-out must not resolve the same build artifact by name in every job. That path calls
 # ListArtifacts concurrently and GitHub responds with a secondary-rate-limit 403. The build publishes
 # the immutable ID and digest once; both consumer matrices use the tested direct receiver, retain hard

--- a/tools/TestImpact/Test-CiImpactWorkflow.ps1
+++ b/tools/TestImpact/Test-CiImpactWorkflow.ps1
@@ -363,12 +363,20 @@ Assert-Contract ($sourceJob.Contains("fetch-depth: `${{ github.event_name == 'pu
         -not $sourceJob.Contains("== 'push' && 0 ||")) `
     'validation-source lacks the history to rebuild the validated tree and diff it in map coordinates'
 $deltaMapStep = Get-StepBlock -JobBlock $sourceJob -Step 'Resolve certified shard map for delta reuse'
-Assert-Contract ($deltaMapStep -match '(?m)^\s+id:\s*delta-map\s*$' -and $deltaMapStep.Contains('timeout-minutes: 10')) `
-    'the delta-map step lost the id its outputs are read through, or its duration bound'
+Assert-Contract ([regex]::Matches($deltaMapStep, '(?m)^        id: delta-map[ \t]*(?:#[^\r\n]*)?\r?$').Count -eq 1 -and
+        [regex]::Matches($deltaMapStep, '(?m)^        id:').Count -eq 1) `
+    'the delta-map step lacks the exact unique identity consumed by the reuse resolver'
 Assert-Contract ([bool] $deltaMapStep -and $deltaMapStep.Contains('continue-on-error: true') -and
         $deltaMapStep.Contains('Resolve-CertifiedShardMap.ps1') -and $deltaMapStep.Contains('Test-CertifiedShardMap.ps1')) `
     'delta reuse does not select with an audited map, or a map failure can fail the push instead of disabling delta reuse'
 $resolveStep = Get-StepBlock -JobBlock $sourceJob -Step 'Resolve exact-tree PR run'
+$mapTimeout = [regex]::Match($deltaMapStep, '(?m)^        timeout-minutes: (?<minutes>[1-9][0-9]*)[ \t]*\r?$')
+$jobTimeout = [regex]::Match($sourceHeader, '(?m)^    timeout-minutes: (?<minutes>[1-9][0-9]*)[ \t]*\r?$')
+$evidenceWait = [regex]::Match($resolveStep, '(?m)^            -WaitMinutes (?<minutes>[0-9]+)[ \t]*\r?$')
+Assert-Contract ($mapTimeout.Success -and $jobTimeout.Success -and $evidenceWait.Success -and
+        [int] $mapTimeout.Groups['minutes'].Value + [int] $evidenceWait.Groups['minutes'].Value + 5 -le
+            [int] $jobTimeout.Groups['minutes'].Value) `
+    'delta-map resolution is not bounded within the job budget with resolver-wait and setup headroom'
 Assert-Contract ($resolveStep.Contains("-MapFile '`${{ steps.delta-map.outputs.map_file }}'") -and
         $resolveStep.Contains("-ShardManifestFile '`${{ steps.delta-map.outputs.manifest_file }}'")) `
     'the reuse resolver is not given the delta-reuse map and manifest'

--- a/tools/TestImpact/Test-CiImpactWorkflow.ps1
+++ b/tools/TestImpact/Test-CiImpactWorkflow.ps1
@@ -363,6 +363,8 @@ Assert-Contract ($sourceJob.Contains("fetch-depth: `${{ github.event_name == 'pu
         -not $sourceJob.Contains("== 'push' && 0 ||")) `
     'validation-source lacks the history to rebuild the validated tree and diff it in map coordinates'
 $deltaMapStep = Get-StepBlock -JobBlock $sourceJob -Step 'Resolve certified shard map for delta reuse'
+Assert-Contract ($deltaMapStep -match '(?m)^\s+id:\s*delta-map\s*$' -and $deltaMapStep.Contains('timeout-minutes: 10')) `
+    'the delta-map step lost the id its outputs are read through, or its duration bound'
 Assert-Contract ([bool] $deltaMapStep -and $deltaMapStep.Contains('continue-on-error: true') -and
         $deltaMapStep.Contains('Resolve-CertifiedShardMap.ps1') -and $deltaMapStep.Contains('Test-CertifiedShardMap.ps1')) `
     'delta reuse does not select with an audited map, or a map failure can fail the push instead of disabling delta reuse'

--- a/tools/TestImpact/Test-CiImpactWorkflow.ps1
+++ b/tools/TestImpact/Test-CiImpactWorkflow.ps1
@@ -67,6 +67,23 @@ function Get-JobHeader {
     return $JobBlock.Substring(0, $steps.Index)
 }
 
+function Test-CheckoutCredentialsDisabled {
+    param([string] $Step)
+
+    # This contract deliberately accepts the workflow's block-mapping form only.
+    # Limit inputs to the one active `with` mapping and its direct children:
+    # comments, another step property, and nested block-scalar text are not inputs.
+    $withHeaders = [regex]::Matches($Step, '(?m)^        with:[^\r\n]*\r?$')
+    if ($withHeaders.Count -ne 1) { return $false }
+    $withBlock = [regex]::Match($Step,
+        '(?ms)^        with:[ \t]*(?:#[^\r\n]*)?\r?\n(?<inputs>.*?)(?=^ {0,8}\S|\z)')
+    if (-not $withBlock.Success) { return $false }
+    $credentials = [regex]::Matches($withBlock.Groups['inputs'].Value,
+        '(?m)^          ["'']?persist-credentials["'']?:[ \t]*(?<value>[^\r\n]*)\r?$')
+    return $credentials.Count -eq 1 -and
+        $credentials[0].Groups['value'].Value -cmatch '^false[ \t]*(?:#.*)?$'
+}
+
 function Test-JobDependency {
     param([string] $JobHeader, [string] $Dependency)
 
@@ -253,6 +270,8 @@ Assert-Contract ([bool] $resolverCheckoutStep) `
     'validation-source invokes a repository script without checking out the tested tree'
 Assert-Contract ($resolverCheckoutStep.Contains('uses: actions/checkout@')) `
     'validation-source checkout step does not use actions/checkout'
+Assert-Contract (Test-CheckoutCredentialsDisabled -Step $resolverCheckoutStep) `
+    'validation-source persists checkout credentials although it only reads Git history'
 Assert-Contract ([bool] $resolverCheckoutStep -and [bool] $resolveStep -and
     $resolver.IndexOf($resolverCheckoutStep, [StringComparison]::Ordinal) -lt
     $resolver.IndexOf($resolveStep, [StringComparison]::Ordinal)) `
@@ -399,14 +418,33 @@ Assert-Contract (-not $selectStep.Contains('-DeltaFromTree')) `
 Assert-Contract ($selectStep.Contains('foreach ($name in $importShards) { [void] $running.Add($name) }')) `
     'imported shards are reported to regression analysis as deliberately skipped'
 foreach ($consumer in @(
-        @{ Job = 'test-regression-analysis'; Prefix = 'coverage' },
-        @{ Job = 'ci-test-analysis'; Prefix = 'test-results' },
-        @{ Job = 'sonarcloud'; Prefix = 'coverage' })) {
+        @{ Job = 'test-regression-analysis'; Prefix = 'coverage'; Download = 'Download pull-request shard results for delta import'; Import = 'Import pull-request shard results' },
+        @{ Job = 'ci-test-analysis'; Prefix = 'test-results'; Download = 'Download pull-request diagnostics for delta import'; Import = 'Import pull-request diagnostics' },
+        @{ Job = 'sonarcloud'; Prefix = 'coverage'; Download = 'Download pull-request coverage for delta import'; Import = 'Import pull-request coverage' })) {
     $consumerJob = Get-JobBlock -WorkflowText $validation -Job $consumer.Job
-    Assert-Contract ($consumerJob.Contains('Import-PullRequestShardArtifacts.ps1') -and
-            $consumerJob.Contains("-ArtifactPrefix $($consumer.Prefix)") -and
-            $consumerJob.Contains('run-id: ${{ needs.validation-source.outputs.import_run_id }}')) `
-        "$($consumer.Job) does not import the pull request's results for shards a partial run did not re-run"
+    $downloadStep = Get-StepBlock -JobBlock $consumerJob -Step $consumer.Download
+    $importStep = Get-StepBlock -JobBlock $consumerJob -Step $consumer.Import
+    $downloadInputs = [regex]::Match($downloadStep,
+        '(?m)^        with:\r?\n(?<fields>(?:^          [^\r\n]*(?:\r?\n|\z))*)').Groups['fields'].Value
+    $expectedRunId = [regex]::Escape('          run-id: ${{ needs.validation-source.outputs.import_run_id }}')
+    $expectedPattern = [regex]::Escape("          pattern: $($consumer.Prefix)-`${{ needs.validation-source.outputs.import_sha }}-*")
+    Assert-Contract ($downloadStep -match '(?m)^        uses: actions/download-artifact@[^\s#]+(?:[ \t]+#[^\r\n]*)?[ \t]*\r?$' -and
+            $downloadInputs -match ('(?m)^' + $expectedRunId + '[ \t]*\r?$') -and
+            $downloadInputs -match ('(?m)^' + $expectedPattern + '[ \t]*\r?$') -and
+            $downloadInputs -match '(?m)^          path: delta-import-staging[ \t]*\r?$') `
+        "$($consumer.Job) delta download is not bound to the matching PR artifacts"
+    $expectedInvocation = '(?m)^        run: \|\r?\n' +
+        '          \./tools/TestImpact/Import-PullRequestShardArtifacts\.ps1 -StagingDirectory delta-import-staging `\r?\n' +
+        '            -DestinationDirectory [^\s]+ -ArtifactPrefix ' + [regex]::Escape($consumer.Prefix) + ' `\r?\n'
+    Assert-Contract ($importStep -match $expectedInvocation) `
+        "$($consumer.Job) delta importer is not bound to its matching download"
+    foreach ($step in @($downloadStep, $importStep)) {
+        $condition = [regex]::Match($step, '(?m)^        if: (?<expression>[^\r\n]+)').Groups['expression'].Value
+        $expectedCondition = "needs.validation-source.outputs.import_run_id != '' && needs.select-shards.outputs.escalated == 'false'"
+        if ($consumer.Job -ceq 'sonarcloud') { $expectedCondition = "`${{ fromJSON(env.EFFECTIVE_REQUIRES_VALIDATION) && $expectedCondition }}" }
+        Assert-Contract ($condition.Trim() -ceq $expectedCondition) `
+            "$($consumer.Job) delta import is not disabled after selector escalation"
+    }
 }
 
 # A 100+ shard fan-out must not resolve the same build artifact by name in every job. That path calls

--- a/tools/TestImpact/Test-CiImpactWorkflowReview.ps1
+++ b/tools/TestImpact/Test-CiImpactWorkflowReview.ps1
@@ -19,15 +19,45 @@ if ([regex]::Matches($workflow, $mapHeadLine).Count -ne 1) {
 $cases = @(
     [pscustomobject]@{
         Name = 'map-head-removed'
+        Reason = 'map-backed selector.*pull.request'
         Content = [regex]::Replace($workflow, $mapHeadLine, '')
     },
     [pscustomobject]@{
         Name = 'map-head-wrong-variable'
+        Reason = 'map-backed selector.*pull.request'
         Content = [regex]::Replace($workflow, $mapHeadLine, '                    -PullRequestHeadSha $env:WRONG_HEAD_SHA `')
     },
     [pscustomobject]@{
         Name = 'map-head-only-in-comment'
+        Reason = 'map-backed selector.*pull.request'
         Content = [regex]::Replace($workflow, $mapHeadLine, '                    # -PullRequestHeadSha $env:PR_HEAD_SHA `')
+    },
+    [pscustomobject]@{
+        Name = 'delta-map-id-renamed'
+        Reason = 'delta.map step.*identity'
+        Content = $workflow.Replace('        id: delta-map', '        id: wrong-delta-map')
+    },
+    [pscustomobject]@{
+        Name = 'delta-map-id-only-in-comment'
+        Reason = 'delta.map step.*identity'
+        Content = $workflow.Replace('        id: delta-map', '        # id: delta-map')
+    }
+)
+$deltaMapPattern = '(?ms)^      - name: Resolve certified shard map for delta reuse\r?\n.*?(?=^      - name:|\z)'
+$deltaMapMatch = [regex]::Match($workflow, $deltaMapPattern)
+if (-not $deltaMapMatch.Success) { throw 'The fixture must identify the delta-map step.' }
+$unboundedMapStep = [regex]::Replace($deltaMapMatch.Value, '(?m)^        timeout-minutes:[^\r\n]*\r?\n', '')
+$cases += @(
+    [pscustomobject]@{
+        Name = 'delta-map-timeout-removed'
+        Reason = 'delta.map.*bounded|delta.map.*budget'
+        Content = $workflow.Replace($deltaMapMatch.Value, $unboundedMapStep)
+    },
+    [pscustomobject]@{
+        Name = 'delta-map-timeout-consumes-job'
+        Reason = 'delta.map.*bounded|delta.map.*budget'
+        Content = $workflow.Replace($deltaMapMatch.Value, $unboundedMapStep.Replace(
+            '        id: delta-map', "        id: delta-map`n        timeout-minutes: 50"))
     }
 )
 
@@ -48,9 +78,9 @@ try {
             Set-Content -LiteralPath $path -Value $case.Content -Encoding utf8
             $output = @(& pwsh -NoProfile -File $contractPath -ValidationWorkflow $path 2>&1)
             if ($LASTEXITCODE -eq 0) {
-                [void] $failures.Add("$($case.Name): unsafe map-backed PR scoping passed the workflow contract")
+                [void] $failures.Add("$($case.Name): unsafe workflow wiring passed the contract")
             }
-            elseif (($output -join [Environment]::NewLine) -notmatch 'map-backed selector.*pull.request') {
+            elseif (($output -join [Environment]::NewLine) -notmatch $case.Reason) {
                 [void] $failures.Add("$($case.Name): rejected for an unrelated reason: $($output -join [Environment]::NewLine)")
             }
             else {

--- a/tools/TestImpact/Test-CiImpactWorkflowReview.ps1
+++ b/tools/TestImpact/Test-CiImpactWorkflowReview.ps1
@@ -1,0 +1,77 @@
+<#
+.SYNOPSIS
+    Proves workflow contract checks reject unsafe wiring, not just the checked-in happy path.
+#>
+[CmdletBinding()]
+param()
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$repositoryRoot = [IO.Path]::GetFullPath((Join-Path $PSScriptRoot '../..'))
+$workflowPath = Join-Path $repositoryRoot '.github/workflows/sonarcloud.yml'
+$contractPath = Join-Path $PSScriptRoot 'Test-CiImpactWorkflow.ps1'
+$workflow = Get-Content -LiteralPath $workflowPath -Raw
+$mapHeadLine = '(?m)^[ \t]+-PullRequestHeadSha \$env:PR_HEAD_SHA `[ \t]*\r?$'
+if ([regex]::Matches($workflow, $mapHeadLine).Count -ne 1) {
+    throw 'The fixture must identify exactly one map-backed PR-head argument, excluding the classifier.'
+}
+$cases = @(
+    [pscustomobject]@{
+        Name = 'map-head-removed'
+        Content = [regex]::Replace($workflow, $mapHeadLine, '')
+    },
+    [pscustomobject]@{
+        Name = 'map-head-wrong-variable'
+        Content = [regex]::Replace($workflow, $mapHeadLine, '                    -PullRequestHeadSha $env:WRONG_HEAD_SHA `')
+    },
+    [pscustomobject]@{
+        Name = 'map-head-only-in-comment'
+        Content = [regex]::Replace($workflow, $mapHeadLine, '                    # -PullRequestHeadSha $env:PR_HEAD_SHA `')
+    }
+)
+
+$tempRoot = [IO.Path]::GetFullPath([IO.Path]::GetTempPath())
+$fixture = Join-Path $tempRoot ('aidotnet-ci-contract-review-' + [guid]::NewGuid().ToString('N'))
+$failures = [System.Collections.Generic.List[string]]::new()
+try {
+    New-Item -ItemType Directory -Path $fixture | Out-Null
+    Push-Location $repositoryRoot
+    try {
+        $baseline = @(& pwsh -NoProfile -File $contractPath 2>&1)
+        if ($LASTEXITCODE -ne 0) { throw "The unmodified workflow must pass first: $($baseline -join [Environment]::NewLine)" }
+        foreach ($case in $cases) {
+            if (-not $case.Content.Contains('-PullRequestHeadSha $env:PR_HEAD_SHA -OutFile path-classification.json')) {
+                throw 'A map-scoping negative control accidentally changed the classifier.'
+            }
+            $path = Join-Path $fixture ($case.Name + '.yml')
+            Set-Content -LiteralPath $path -Value $case.Content -Encoding utf8
+            $output = @(& pwsh -NoProfile -File $contractPath -ValidationWorkflow $path 2>&1)
+            if ($LASTEXITCODE -eq 0) {
+                [void] $failures.Add("$($case.Name): unsafe map-backed PR scoping passed the workflow contract")
+            }
+            elseif (($output -join [Environment]::NewLine) -notmatch 'map-backed selector.*pull.request') {
+                [void] $failures.Add("$($case.Name): rejected for an unrelated reason: $($output -join [Environment]::NewLine)")
+            }
+            else {
+                Write-Host "Rejected unsafe workflow: $($case.Name)"
+            }
+        }
+    }
+    finally { Pop-Location }
+}
+finally {
+    $resolvedFixture = [IO.Path]::GetFullPath($fixture)
+    $expectedPrefix = $tempRoot.TrimEnd([IO.Path]::DirectorySeparatorChar) + [IO.Path]::DirectorySeparatorChar
+    if ($resolvedFixture.StartsWith($expectedPrefix, [StringComparison]::OrdinalIgnoreCase) -and
+        [IO.Path]::GetFileName($resolvedFixture).StartsWith('aidotnet-ci-contract-review-', [StringComparison]::Ordinal)) {
+        Remove-Item -LiteralPath $resolvedFixture -Recurse -Force -ErrorAction SilentlyContinue
+    }
+}
+
+if ($failures.Count -gt 0) {
+    foreach ($failure in $failures) { Write-Host $failure }
+    exit 1
+}
+Write-Host "Workflow review controls passed: baseline accepted, $($cases.Count) unsafe mutations rejected."
+exit 0

--- a/tools/TestImpact/Test-CiImpactWorkflowReview.ps1
+++ b/tools/TestImpact/Test-CiImpactWorkflowReview.ps1
@@ -7,6 +7,7 @@ param()
 
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
+. (Join-Path $PSScriptRoot 'ReviewFixtureCleanup.ps1')
 
 $repositoryRoot = [IO.Path]::GetFullPath((Join-Path $PSScriptRoot '../..'))
 $workflowPath = Join-Path $repositoryRoot '.github/workflows/sonarcloud.yml'
@@ -44,6 +45,25 @@ $cases = @(
     }
 )
 $deltaMapPattern = '(?ms)^      - name: Resolve certified shard map for delta reuse\r?\n.*?(?=^      - name:|\z)'
+$checkoutPattern = '(?ms)^      - name: Checkout validation reuse policy\r?\n.*?(?=^      - name:|\z)'
+$checkout = [regex]::Match($workflow, $checkoutPattern).Value
+$credentialInput = '          persist-credentials: false'
+if (-not $checkout.Contains($credentialInput)) { throw 'Missing checkout credential input for negative controls.' }
+foreach ($mutation in @(
+    @{ Name = 'checkout-credentials-comment-decoy'; Value = "          persist-credentials: true`n          # persist-credentials: false" },
+    @{ Name = 'checkout-credentials-comment-only'; Value = '          # persist-credentials: false' },
+    @{ Name = 'checkout-credentials-duplicate'; Value = "          persist-credentials: false`n          persist-credentials: true" },
+    @{ Name = 'checkout-credentials-duplicate-false'; Value = "$credentialInput`n$credentialInput" },
+    @{ Name = 'checkout-credentials-outside-with'; Value = "        env:`n$credentialInput" },
+    @{ Name = 'checkout-credentials-nested-decoy'; Value = "          unused: |`n            persist-credentials: false" },
+    @{ Name = 'checkout-credentials-duplicate-with'; Value = "        with:`n$credentialInput" }
+)) {
+    $cases += [pscustomobject]@{
+        Name = $mutation.Name
+        Reason = 'validation-source persists checkout credentials'
+        Content = $workflow.Replace($checkout, $checkout.Replace($credentialInput, $mutation.Value))
+    }
+}
 $deltaMapMatch = [regex]::Match($workflow, $deltaMapPattern)
 if (-not $deltaMapMatch.Success) { throw 'The fixture must identify the delta-map step.' }
 $unboundedMapStep = [regex]::Replace($deltaMapMatch.Value, '(?m)^        timeout-minutes:[^\r\n]*\r?\n', '')
@@ -58,9 +78,76 @@ $cases += @(
         Reason = 'delta.map.*bounded|delta.map.*budget'
         Content = $workflow.Replace($deltaMapMatch.Value, $unboundedMapStep.Replace(
             '        id: delta-map', "        id: delta-map`n        timeout-minutes: 50"))
+    },
+    [pscustomobject]@{
+        Name = 'resolver-wait-consumes-job'
+        Reason = 'delta.map.*budget'
+        Content = [regex]::Replace($workflow, '(?m)^            -WaitMinutes [0-9]+[ \t]*\r?$', '            -WaitMinutes 45')
+    },
+    [pscustomobject]@{
+        Name = 'resolver-job-budget-shrunk'
+        Reason = 'delta.map.*budget'
+        Content = [regex]::Replace($workflow, '(?ms)(^  validation-source:\r?\n.*?^    timeout-minutes:) [0-9]+', '${1} 45')
     }
 )
 
+$importGate = "needs.validation-source.outputs.import_run_id != '' && needs.select-shards.outputs.escalated == 'false'"
+foreach ($stepName in @('Download pull-request shard results for delta import', 'Import pull-request shard results',
+        'Download pull-request diagnostics for delta import', 'Import pull-request diagnostics',
+        'Download pull-request coverage for delta import', 'Import pull-request coverage')) {
+    $stepPattern = '(?ms)^      - name: ' + [regex]::Escape($stepName) + '\r?\n.*?(?=^      - name:|\z)'
+    $stepBlock = [regex]::Match($workflow, $stepPattern).Value
+    if (-not $stepBlock.Contains($importGate)) { throw "Missing complete import gate on $stepName" }
+    $cases += [pscustomobject]@{
+        Name = ($stepName -replace ' ', '-') + '-escalation-guard-removed'
+        Reason = 'delta import.*escalation'
+        Content = $workflow.Replace($stepBlock, $stepBlock.Replace($importGate, "needs.validation-source.outputs.import_run_id != ''"))
+    }
+    $cases += [pscustomobject]@{
+        Name = ($stepName -replace ' ', '-') + '-guard-disjoined'
+        Reason = 'delta import.*escalation'
+        Content = $workflow.Replace($stepBlock, $stepBlock.Replace($importGate, $importGate.Replace(' && ', ' || ')))
+    }
+}
+foreach ($pair in @(
+        @{ Download = 'Download pull-request shard results for delta import'; Import = 'Import pull-request shard results' },
+        @{ Download = 'Download pull-request diagnostics for delta import'; Import = 'Import pull-request diagnostics' },
+        @{ Download = 'Download pull-request coverage for delta import'; Import = 'Import pull-request coverage' })) {
+    $downloadPattern = '(?ms)^      - name: ' + [regex]::Escape($pair.Download) + '\r?\n.*?(?=^      - name:|\z)'
+    $download = [regex]::Match($workflow, $downloadPattern).Value
+    $runId = '          run-id: ${{ needs.validation-source.outputs.import_run_id }}'
+    if (-not $download.Contains($runId)) { throw 'Missing source-bound download run id.' }
+    # Put the right text in the importer's comment, in the SAME job: a job-wide Contains passes.
+    $mutated = $workflow.Replace($download, $download.Replace($runId, '          run-id: 1'))
+    $mutated = $mutated.Replace('      - name: ' + $pair.Import,
+        '      - name: ' + $pair.Import + "`n        # run-id: `${{ needs.validation-source.outputs.import_run_id }}")
+    $cases += [pscustomobject]@{
+        Name = ($pair.Download -replace ' ', '-') + '-run-id-decoy'
+        Reason = 'delta download.*matching PR artifacts'
+        Content = $mutated
+    }
+    foreach ($field in @('uses', 'run-id', 'pattern', 'path')) {
+        $fieldPattern = '(?m)^(?<indent> +)' + $field + ': (?<value>[^\r\n]+)\r?$'
+        $fieldMatch = [regex]::Match($download, $fieldPattern)
+        if (-not $fieldMatch.Success) { throw "Missing download field $field for a comment decoy." }
+        $replacement = $fieldMatch.Groups['indent'].Value + $field + ': wrong-value' + "`n" +
+            $fieldMatch.Groups['indent'].Value + '# ' + $field + ': ' + $fieldMatch.Groups['value'].Value
+        $cases += [pscustomobject]@{
+            Name = ($pair.Download -replace ' ', '-') + '-' + $field + '-same-step-comment-decoy'
+            Reason = 'delta download.*matching PR artifacts'
+            Content = $workflow.Replace($download, $download.Replace($fieldMatch.Value, $replacement))
+        }
+    }
+    $importPattern = '(?ms)^      - name: ' + [regex]::Escape($pair.Import) + '\r?\n.*?(?=^      - name:|\z)'
+    $import = [regex]::Match($workflow, $importPattern).Value
+    $invocation = '          ./tools/TestImpact/Import-PullRequestShardArtifacts.ps1'
+    if (-not $import.Contains($invocation)) { throw 'Missing importer invocation for a comment decoy.' }
+    $cases += [pscustomobject]@{
+        Name = ($pair.Import -replace ' ', '-') + '-invocation-commented'
+        Reason = 'delta importer.*matching download'
+        Content = $workflow.Replace($import, $import.Replace($invocation, '          # ./tools/TestImpact/Import-PullRequestShardArtifacts.ps1'))
+    }
+}
 $tempRoot = [IO.Path]::GetFullPath([IO.Path]::GetTempPath())
 $fixture = Join-Path $tempRoot ('aidotnet-ci-contract-review-' + [guid]::NewGuid().ToString('N'))
 $failures = [System.Collections.Generic.List[string]]::new()
@@ -71,6 +158,7 @@ try {
         $baseline = @(& pwsh -NoProfile -File $contractPath 2>&1)
         if ($LASTEXITCODE -ne 0) { throw "The unmodified workflow must pass first: $($baseline -join [Environment]::NewLine)" }
         foreach ($case in $cases) {
+            if ($case.Content -ceq $workflow) { throw "$($case.Name): negative control did not mutate the workflow" }
             if (-not $case.Content.Contains('-PullRequestHeadSha $env:PR_HEAD_SHA -OutFile path-classification.json')) {
                 throw 'A map-scoping negative control accidentally changed the classifier.'
             }
@@ -91,12 +179,7 @@ try {
     finally { Pop-Location }
 }
 finally {
-    $resolvedFixture = [IO.Path]::GetFullPath($fixture)
-    $expectedPrefix = $tempRoot.TrimEnd([IO.Path]::DirectorySeparatorChar) + [IO.Path]::DirectorySeparatorChar
-    if ($resolvedFixture.StartsWith($expectedPrefix, [StringComparison]::OrdinalIgnoreCase) -and
-        [IO.Path]::GetFileName($resolvedFixture).StartsWith('aidotnet-ci-contract-review-', [StringComparison]::Ordinal)) {
-        Remove-Item -LiteralPath $resolvedFixture -Recurse -Force -ErrorAction SilentlyContinue
-    }
+    Remove-ReviewFixtureDirectory -LiteralPath $fixture -ExpectedLeafPrefix 'aidotnet-ci-contract-review-'
 }
 
 if ($failures.Count -gt 0) {

--- a/tools/TestImpact/Test-CiValidationReuseReview.ps1
+++ b/tools/TestImpact/Test-CiValidationReuseReview.ps1
@@ -1,0 +1,164 @@
+<#
+.SYNOPSIS
+    Exercises the production delta-reuse emission branch against incomplete artifact inventories.
+.DESCRIPTION
+    Git/selection is covered by Test-TestImpactEndToEnd. This fixture substitutes only that plan
+    and GitHub's artifact inventory, then executes the checked-in decision/output branch and its
+    real helpers in a child process. No GitHub calls, workflow runs, or remote artifacts are needed.
+#>
+[CmdletBinding()]
+param()
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+enum InvalidArtifactCase {
+    Expired
+    WrongSha
+    WrongSlug
+    WrongCase
+}
+
+enum DeltaEmissionExpectation {
+    Decline
+    PartialWithImports
+    PartialWithoutImports
+    WholeResultReuse
+}
+
+$resolverPath = Join-Path $PSScriptRoot 'Resolve-CiValidationReuse.ps1'
+$tokens = $null
+$parseErrors = $null
+$ast = [System.Management.Automation.Language.Parser]::ParseFile($resolverPath, [ref] $tokens, [ref] $parseErrors)
+if ($parseErrors.Count -gt 0) { throw 'The reuse resolver must parse before its production branch is tested.' }
+$declarations = @($ast.EndBlock.Statements | Where-Object {
+    $_ -is [System.Management.Automation.Language.FunctionDefinitionAst] -or
+    $_ -is [System.Management.Automation.Language.TypeDefinitionAst]
+} | ForEach-Object { $_.Extent.Text })
+$branches = @($ast.EndBlock.Statements | Where-Object {
+    $_ -is [System.Management.Automation.Language.IfStatementAst] -and
+    $_.Extent.Text.StartsWith('if ($deltaCandidates.Count', [StringComparison]::Ordinal)
+})
+if ($branches.Count -ne 1) { throw 'The fixture must execute exactly one production delta-emission branch.' }
+
+$sha = '0123456789abcdef0123456789abcdef01234567'
+$otherSha = '1123456789abcdef0123456789abcdef01234567'
+$valid = @(
+    [pscustomobject]@{ name = "test-results-$sha-Integration_E_G"; expired = $false },
+    [pscustomobject]@{ name = "coverage-$sha-Integration_E_G"; expired = $false },
+    [pscustomobject]@{ name = "test-results-$sha-Unit_10_RL"; expired = $false },
+    [pscustomobject]@{ name = "coverage-$sha-Unit_10_RL"; expired = $false }
+)
+$cases = [System.Collections.Generic.List[object]]::new()
+[void] $cases.Add([pscustomobject]@{ Name = 'complete-imports'; Artifacts = $valid
+    Expectation = [DeltaEmissionExpectation]::PartialWithImports; Delta = @('Integration D') })
+foreach ($missing in 0..3) {
+    [void] $cases.Add([pscustomobject]@{ Name = "missing-$missing"
+        Expectation = [DeltaEmissionExpectation]::Decline; Delta = @('Integration D')
+        Artifacts = @(for ($i = 0; $i -lt $valid.Count; $i++) { if ($i -ne $missing) { $valid[$i] } }) })
+}
+foreach ($invalid in [Enum]::GetValues[InvalidArtifactCase]()) {
+    $artifacts = @($valid | ForEach-Object { $_.PSObject.Copy() })
+    switch ($invalid) {
+        ([InvalidArtifactCase]::Expired) { $artifacts[0].expired = $true }
+        ([InvalidArtifactCase]::WrongSha) { $artifacts[0].name = "test-results-$otherSha-Integration_E_G" }
+        ([InvalidArtifactCase]::WrongSlug) { $artifacts[0].name = "test-results-$sha-Integration_D" }
+        ([InvalidArtifactCase]::WrongCase) { $artifacts[0].name = "test-results-$sha-integration_e_g" }
+    }
+    [void] $cases.Add([pscustomobject]@{ Name = $invalid.ToString(); Artifacts = $artifacts
+        Expectation = [DeltaEmissionExpectation]::Decline; Delta = @('Integration D') })
+}
+[void] $cases.Add([pscustomobject]@{ Name = 'all-shards-rerun'; Artifacts = @()
+    Expectation = [DeltaEmissionExpectation]::PartialWithoutImports
+    Delta = @('Integration D', 'Integration E-G', 'Unit - 10 RL') })
+[void] $cases.Add([pscustomobject]@{ Name = 'full-reuse-preserved'; Artifacts = @()
+    Expectation = [DeltaEmissionExpectation]::WholeResultReuse; Delta = @('Unrelated') })
+
+$setup = @'
+param([string] $CasePath, [string] $GitHubOutput, [string] $MapFile, [string] $ShardManifestFile)
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+$env:GITHUB_STEP_SUMMARY = ''
+'@
+$fixturePlan = @'
+$case = Get-Content -LiteralPath $CasePath -Raw | ConvertFrom-Json
+$prNumber = 42
+$candidateEvidence = [pscustomobject]@{
+    RunId = 123; TestedSha = '0123456789abcdef0123456789abcdef01234567'
+    RequiresValidation = $true; ArtifactNames = @(Get-UnexpiredArtifactNames -Artifacts @($case.Artifacts))
+}
+$deltaCandidates = @($candidateEvidence)
+$fixtureDecision = Get-DeltaReuseDecision -SelectionEscalated $false -SelectionRequiresValidation $true `
+    -DeltaShards @($case.Delta) -PullRequestShards @('Integration D', 'Integration E-G', 'Unit - 10 RL')
+$fixturePlan = [pscustomobject]@{
+    Decision = $fixtureDecision; Tree = 'fixture-tree'
+    Selection = [pscustomobject]@{ routes = @(); reasons = @() }
+}
+function Get-DeltaPlan { param($Candidate) return $fixturePlan }
+'@
+$fallback = 'Write-ReuseDecision -DecisionScope None -PrNumber $prNumber'
+$scriptText = @($setup) + $declarations + @($fixturePlan, $branches[0].Extent.Text, $fallback)
+$tempRoot = [IO.Path]::GetFullPath([IO.Path]::GetTempPath())
+$fixture = Join-Path $tempRoot ('aidotnet-reuse-review-' + [guid]::NewGuid().ToString('N'))
+$failures = [System.Collections.Generic.List[string]]::new()
+try {
+    New-Item -ItemType Directory -Path $fixture | Out-Null
+    $scriptPath = Join-Path $fixture 'production-emission.ps1'
+    $mapPath = Join-Path $fixture 'map.json'
+    $manifestPath = Join-Path $fixture 'manifest.json'
+    Set-Content -LiteralPath $scriptPath -Value ($scriptText -join [Environment]::NewLine) -Encoding utf8
+    '{}' | Set-Content -LiteralPath $mapPath -Encoding utf8
+    '[]' | Set-Content -LiteralPath $manifestPath -Encoding utf8
+    foreach ($case in $cases) {
+        $casePath = Join-Path $fixture ($case.Name + '.json')
+        $outputPath = Join-Path $fixture ($case.Name + '.outputs')
+        $case | ConvertTo-Json -Depth 5 | Set-Content -LiteralPath $casePath -Encoding utf8
+        $output = @(& pwsh -NoProfile -File $scriptPath -CasePath $casePath -GitHubOutput $outputPath `
+            -MapFile $mapPath -ShardManifestFile $manifestPath 2>&1)
+        if ($LASTEXITCODE -ne 0) { throw "$($case.Name): production emission failed: $($output -join [Environment]::NewLine)" }
+        $values = @{}
+        foreach ($line in Get-Content -LiteralPath $outputPath) {
+            $parts = $line -split '=', 2
+            $values[$parts[0]] = $parts[1]
+        }
+        if ($case.Expectation -eq [DeltaEmissionExpectation]::Decline) {
+            if ($values.delta_mode -or $values.import_run_id -or $values.import_sha -or
+                $values.import_shards -cne '[]' -or $values.partial_shards -cne '[]' -or
+                $values.execute_validation -cne 'true' -or $values.reuse_scope -cne 'None') {
+                [void] $failures.Add("$($case.Name): missing imported evidence still authorized reuse: $($values | ConvertTo-Json -Compress)")
+            }
+        }
+        elseif ($case.Expectation -eq [DeltaEmissionExpectation]::WholeResultReuse) {
+            if ($values.delta_mode -cne 'Reuse' -or $values.reuse_scope -cne 'Validation' -or
+                $values.execute_validation -cne 'false' -or $values.execute_quality -cne 'true') {
+                [void] $failures.Add('whole-result delta reuse changed despite not importing per-shard artifacts')
+            }
+        }
+        else {
+            $expectedImport = if ($case.Expectation -eq [DeltaEmissionExpectation]::PartialWithoutImports) { '[]' } else { '["Integration E-G","Unit - 10 RL"]' }
+            $expectedRerun = if ($case.Expectation -eq [DeltaEmissionExpectation]::PartialWithoutImports) {
+                '["Integration D","Integration E-G","Unit - 10 RL"]'
+            } else { '["Integration D"]' }
+            if ($values.delta_mode -cne 'Partial' -or $values.import_run_id -cne '123' -or
+                $values.import_sha -cne $sha -or $values.import_shards -cne $expectedImport -or
+                $values.partial_shards -cne $expectedRerun -or
+                $values.execute_validation -cne 'true' -or $values.execute_quality -cne 'true') {
+                [void] $failures.Add("$($case.Name): valid partial reuse was not preserved")
+            }
+        }
+    }
+}
+finally {
+    $resolved = [IO.Path]::GetFullPath($fixture)
+    $prefix = $tempRoot.TrimEnd([IO.Path]::DirectorySeparatorChar) + [IO.Path]::DirectorySeparatorChar
+    if ($resolved.StartsWith($prefix, [StringComparison]::OrdinalIgnoreCase) -and
+        [IO.Path]::GetFileName($resolved).StartsWith('aidotnet-reuse-review-', [StringComparison]::Ordinal)) {
+        Remove-Item -LiteralPath $resolved -Recurse -Force -ErrorAction SilentlyContinue
+    }
+}
+if ($failures.Count -gt 0) {
+    foreach ($failure in $failures) { Write-Host $failure }
+    exit 1
+}
+Write-Host "Delta artifact review controls passed: $($cases.Count) production emission cases."
+exit 0

--- a/tools/TestImpact/Test-CiValidationReuseReview.ps1
+++ b/tools/TestImpact/Test-CiValidationReuseReview.ps1
@@ -71,6 +71,9 @@ foreach ($invalid in [Enum]::GetValues[InvalidArtifactCase]()) {
 [void] $cases.Add([pscustomobject]@{ Name = 'all-shards-rerun'; Artifacts = @()
     Expectation = [DeltaEmissionExpectation]::PartialWithoutImports
     Delta = @('Integration D', 'Integration E-G', 'Unit - 10 RL') })
+[void] $cases.Add([pscustomobject]@{ Name = 'all-shards-rerun-with-unused-artifacts'; Artifacts = $valid
+    Expectation = [DeltaEmissionExpectation]::PartialWithoutImports
+    Delta = @('Integration D', 'Integration E-G', 'Unit - 10 RL') })
 [void] $cases.Add([pscustomobject]@{ Name = 'full-reuse-preserved'; Artifacts = @()
     Expectation = [DeltaEmissionExpectation]::WholeResultReuse; Delta = @('Unrelated') })
 
@@ -136,11 +139,13 @@ try {
         }
         else {
             $expectedImport = if ($case.Expectation -eq [DeltaEmissionExpectation]::PartialWithoutImports) { '[]' } else { '["Integration E-G","Unit - 10 RL"]' }
+            $expectedImportRunId = if ($case.Expectation -eq [DeltaEmissionExpectation]::PartialWithoutImports) { '' } else { '123' }
+            $expectedImportSha = if ($case.Expectation -eq [DeltaEmissionExpectation]::PartialWithoutImports) { '' } else { $sha }
             $expectedRerun = if ($case.Expectation -eq [DeltaEmissionExpectation]::PartialWithoutImports) {
                 '["Integration D","Integration E-G","Unit - 10 RL"]'
             } else { '["Integration D"]' }
-            if ($values.delta_mode -cne 'Partial' -or $values.import_run_id -cne '123' -or
-                $values.import_sha -cne $sha -or $values.import_shards -cne $expectedImport -or
+            if ($values.delta_mode -cne 'Partial' -or $values.import_run_id -cne $expectedImportRunId -or
+                $values.import_sha -cne $expectedImportSha -or $values.import_shards -cne $expectedImport -or
                 $values.partial_shards -cne $expectedRerun -or
                 $values.execute_validation -cne 'true' -or $values.execute_quality -cne 'true') {
                 [void] $failures.Add("$($case.Name): valid partial reuse was not preserved")

--- a/tools/TestImpact/Test-ReviewFixtureCleanup.ps1
+++ b/tools/TestImpact/Test-ReviewFixtureCleanup.ps1
@@ -21,8 +21,8 @@ foreach ($unsafePath in $unsafePaths) {
     }
     if (-not $rejected) { throw "Unsafe fixture cleanup was accepted: $unsafePath" }
 }
-New-Item -ItemType Directory -Path $fixture | Out-Null
 try {
+    New-Item -ItemType Directory -Path $fixture | Out-Null
     'owned fixture' | Set-Content -LiteralPath (Join-Path $fixture 'marker.txt')
     Remove-ReviewFixtureDirectory -LiteralPath $fixture -ExpectedLeafPrefix 'aidotnet-cleanup-review-' -ThrowOnUnsafePath
     if (Test-Path -LiteralPath $fixture) { throw 'The owned fixture was not removed.' }
@@ -36,8 +36,8 @@ $targetLeaf = 'aidotnet-cleanup-review-child'
 $sentinelChild = Join-Path $sentinel $targetLeaf
 $marker = Join-Path $sentinelChild 'marker.txt'
 $markerText = 'a linked ancestor must not allow deleting this sentinel'
-New-Item -ItemType Directory -Path $linkFixture, $sentinelChild | Out-Null
 try {
+    New-Item -ItemType Directory -Path $linkFixture, $sentinelChild | Out-Null
     $markerText | Set-Content -LiteralPath $marker
     # Junctions need no symlink privilege on Windows; Unix uses a directory symlink.
     $linkType = if ([IO.Path]::DirectorySeparatorChar -eq '\') { 'Junction' } else { 'SymbolicLink' }

--- a/tools/TestImpact/Test-ReviewFixtureCleanup.ps1
+++ b/tools/TestImpact/Test-ReviewFixtureCleanup.ps1
@@ -1,0 +1,75 @@
+[CmdletBinding()]
+param()
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+. (Join-Path $PSScriptRoot 'ReviewFixtureCleanup.ps1')
+
+$tempRoot = [IO.Path]::GetFullPath([IO.Path]::GetTempPath())
+$fixture = Join-Path $tempRoot ('aidotnet-cleanup-review-' + [guid]::NewGuid().ToString('N'))
+$unsafePaths = @(
+    $tempRoot,
+    (Join-Path ($tempRoot.TrimEnd([char[]] @('/', '\')) + '-sibling') 'aidotnet-cleanup-review-forged'),
+    (Join-Path $tempRoot 'wrong-prefix'),
+    (Join-Path $tempRoot '../aidotnet-cleanup-review-escaped')
+)
+foreach ($unsafePath in $unsafePaths) {
+    $rejected = $false
+    try { Remove-ReviewFixtureDirectory -LiteralPath $unsafePath -ExpectedLeafPrefix 'aidotnet-cleanup-review-' -ThrowOnUnsafePath }
+    catch {
+        if ($_.Exception.Message -notlike 'refusing to remove unexpected fixture path*') { throw }
+        $rejected = $true
+    }
+    if (-not $rejected) { throw "Unsafe fixture cleanup was accepted: $unsafePath" }
+}
+New-Item -ItemType Directory -Path $fixture | Out-Null
+try {
+    'owned fixture' | Set-Content -LiteralPath (Join-Path $fixture 'marker.txt')
+    Remove-ReviewFixtureDirectory -LiteralPath $fixture -ExpectedLeafPrefix 'aidotnet-cleanup-review-' -ThrowOnUnsafePath
+    if (Test-Path -LiteralPath $fixture) { throw 'The owned fixture was not removed.' }
+}
+finally { Remove-ReviewFixtureDirectory -LiteralPath $fixture -ExpectedLeafPrefix 'aidotnet-cleanup-review-' }
+
+$linkFixture = Join-Path $tempRoot ('aidotnet-cleanup-review-link-' + [guid]::NewGuid().ToString('N'))
+$sentinel = Join-Path $tempRoot ('aidotnet-cleanup-review-sentinel-' + [guid]::NewGuid().ToString('N'))
+$link = Join-Path $linkFixture 'linked-ancestor'
+$targetLeaf = 'aidotnet-cleanup-review-child'
+$sentinelChild = Join-Path $sentinel $targetLeaf
+$marker = Join-Path $sentinelChild 'marker.txt'
+$markerText = 'a linked ancestor must not allow deleting this sentinel'
+New-Item -ItemType Directory -Path $linkFixture, $sentinelChild | Out-Null
+try {
+    $markerText | Set-Content -LiteralPath $marker
+    # Junctions need no symlink privilege on Windows; Unix uses a directory symlink.
+    $linkType = if ([IO.Path]::DirectorySeparatorChar -eq '\') { 'Junction' } else { 'SymbolicLink' }
+    New-Item -ItemType $linkType -Path $link -Target $sentinel -ErrorAction Stop | Out-Null
+    if (((Get-Item -LiteralPath $link -Force).Attributes -band [IO.FileAttributes]::ReparsePoint) -eq 0) {
+        throw 'The fixture did not create a real reparse-point ancestor.'
+    }
+    $rejected = $false
+    try {
+        Remove-ReviewFixtureDirectory -LiteralPath (Join-Path $link $targetLeaf) `
+            -ExpectedLeafPrefix 'aidotnet-cleanup-review-' -ThrowOnUnsafePath
+    }
+    catch {
+        if ($_.Exception.Message -notlike 'refusing to remove unexpected fixture path*') { throw }
+        $rejected = $true
+    }
+    if (-not $rejected) { throw 'Cleanup accepted a reparse-point ancestor.' }
+    if (-not (Test-Path -LiteralPath $marker) -or (Get-Content -LiteralPath $marker -Raw).TrimEnd() -cne $markerText) {
+        throw 'Cleanup changed or removed the linked sentinel.'
+    }
+}
+finally {
+    # Unlink only the exact link (never recurse through it), then clean the two
+    # validated, independently owned temporary roots through the production guard.
+    if (Test-Path -LiteralPath $link) {
+        $linkItem = Get-Item -LiteralPath $link -Force
+        if (($linkItem.Attributes -band [IO.FileAttributes]::ReparsePoint) -eq 0) {
+            throw 'Refusing to unlink an unexpected non-reparse fixture.'
+        }
+        Remove-Item -LiteralPath $link -Force -ErrorAction Stop
+    }
+    Remove-ReviewFixtureDirectory -LiteralPath $linkFixture -ExpectedLeafPrefix 'aidotnet-cleanup-review-' -ThrowOnUnsafePath
+    Remove-ReviewFixtureDirectory -LiteralPath $sentinel -ExpectedLeafPrefix 'aidotnet-cleanup-review-' -ThrowOnUnsafePath
+}
+Write-Host 'Review fixture cleanup: four unsafe paths and a real linked ancestor rejected; sentinel preserved; owned fixtures removed.'

--- a/tools/TestImpact/Test-TestImpactEndToEnd.ps1
+++ b/tools/TestImpact/Test-TestImpactEndToEnd.ps1
@@ -8,6 +8,11 @@ param()
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
+foreach ($review in 'Test-CertificateEvidenceReview', 'Test-ReviewFixtureCleanup') {
+    & pwsh -NoProfile -File (Join-Path $PSScriptRoot "$review.ps1")
+    if ($LASTEXITCODE -ne 0) { throw "$review failed." }
+}
+
 enum InvalidMapFixture {
     Missing
     Malformed

--- a/tools/TestImpact/Test-TestImpactEndToEnd.ps1
+++ b/tools/TestImpact/Test-TestImpactEndToEnd.ps1
@@ -8,8 +8,17 @@ param()
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
+enum InvalidMapFixture {
+    Missing
+    Malformed
+    Unresolvable
+}
+
 & (Join-Path $PSScriptRoot 'Test-CiImpactWorkflowReview.ps1')
 if ($LASTEXITCODE -ne 0) { throw 'Workflow review negative controls failed.' }
+
+& (Join-Path $PSScriptRoot 'Test-CiValidationReuseReview.ps1')
+if ($LASTEXITCODE -ne 0) { throw 'Delta reuse artifact review controls failed.' }
 
 $selector = Join-Path $PSScriptRoot 'Select-Shards.ps1'
 $coverageSelector = Join-Path $PSScriptRoot 'Select-CoverageShards.ps1'
@@ -484,9 +493,9 @@ try {
         # reuse must rebuild the validated tree from its parents and decide from what master added.
         $testedTree = ((Invoke-Git rev-parse "$testedMergeSha^{tree}") | Out-String).Trim()
         $pullRequestShards = '["Alpha","Always"]'
-        function Invoke-DeltaPlanFixture([string] $Name, [string] $Tree = $testedTree) {
+        function Invoke-DeltaPlanFixture([string] $Name, [string] $Tree = $testedTree, [string] $MapPath = 'certified/shard-map.json') {
             & $reuseResolver -PlanDelta -TestedBaseSha $masterSha -TestedHeadSha $prHeadSha -TestedTree $Tree `
-                -PullRequestShardsJson $pullRequestShards -MapFile certified/shard-map.json `
+                -PullRequestShardsJson $pullRequestShards -MapFile $MapPath `
                 -ShardManifestFile shard-manifest.json -SelectorPath $selector -OutFile "$Name.json" 6>$null
             return Get-Content "$Name.json" -Raw | ConvertFrom-Json
         }
@@ -505,6 +514,48 @@ try {
         Assert-True ((@($plan.import) -join ',') -ceq 'Alpha') `
             "the partial re-run did not import the untouched pull-request shard: import=$(@($plan.import) -join ',')"
         Assert-True ($plan.tree -ceq $testedTree) 'the validated tree was not rebuilt exactly from its parents'
+        Write-Host "Post-merge runtime delta: mode=$($plan.mode); rerun=$(@($plan.rerun) -join ','); import=$(@($plan.import) -join ',')"
+
+        # Every fail-closed selector result has the same JSON shape. The delta resolver uses
+        # StrictMode and must return an explicit full-matrix plan, not throw on missing routes.
+        foreach ($invalidMapKind in [Enum]::GetValues[InvalidMapFixture]()) {
+            $invalidMap = $invalidMapKind.ToString().ToLowerInvariant() + '-map.json'
+            if ($invalidMapKind -eq [InvalidMapFixture]::Malformed) {
+                '{ not valid JSON' | Set-Content -LiteralPath $invalidMap -Encoding utf8
+            }
+            elseif ($invalidMapKind -eq [InvalidMapFixture]::Unresolvable) {
+                $unresolvableMap = Get-Content certified/shard-map.json -Raw | ConvertFrom-Json
+                $unresolvableMap.sha = '1111111111111111111111111111111111111111'
+                $unresolvableMap | ConvertTo-Json -Depth 8 | Set-Content -LiteralPath $invalidMap -Encoding utf8
+            }
+            $invalidName = 'delta-' + $invalidMap.Replace('.json', '')
+            $invalidPlan = $null
+            try { $invalidPlan = Invoke-DeltaPlanFixture $invalidName $testedTree $invalidMap }
+            catch { [void] $failures.Add("${invalidMap}: selector fallback threw instead of planning full validation: $($_.Exception.Message)") }
+            if ($null -ne $invalidPlan) {
+                Assert-True ($invalidPlan.mode -ceq 'None' -and @($invalidPlan.routes).Count -eq 0 -and
+                    @($invalidPlan.rerun).Count -eq 0 -and @($invalidPlan.import).Count -eq 0) `
+                    "$invalidMap did not produce the explicit empty-route, full-validation plan"
+            }
+        }
+
+        # A deleted test has no remaining HEAD referrers. git grep legitimately returns 1, but the
+        # selector has successfully routed the deleted source from its tested revision. That
+        # native status must not leak into the selector's process-level success contract.
+        Invoke-Git checkout --quiet --detach $testedMergeSha
+        Invoke-Git rm --quiet -- tests/Proj/UnitTests/Alpha/NewAlphaTests.cs
+        Invoke-Git commit --quiet -m delete-tested-alpha-test
+        & git grep -l -w -F -e NewAlphaTests HEAD -- ':(glob)tests/Proj/**/*.cs' 2>$null
+        Assert-True ($LASTEXITCODE -eq 1) 'the deleted-test fixture did not exercise a real no-match git grep'
+        & $selector -MapFile certified/shard-map.json -BaseSha $testedMergeSha `
+            -ShardManifestFile shard-manifest.json -ExpectedShards $shardNames -OutFile deleted-test-selection.json 6>$null
+        Assert-True ($LASTEXITCODE -eq 0) 'a successful deleted-test selection leaked the no-match git grep exit code'
+        $deleted = Get-Content deleted-test-selection.json -Raw | ConvertFrom-Json
+        Assert-True (-not [bool] $deleted.escalate -and (@($deleted.shards) -join ',') -ceq 'Alpha,Always') `
+            'the deleted test did not keep its original Alpha route and always-run shard'
+        $plan = Invoke-DeltaPlanFixture 'delta-deleted-test'
+        Assert-True ($plan.mode -ceq 'Partial' -and (@($plan.rerun) -join ',') -ceq 'Alpha,Always') `
+            "a valid deleted-test delta failed planning after git grep found no referrers: $($plan.why)"
 
         # (b) Master adds only documentation: nothing the pull request certified can have changed.
         Invoke-Git checkout --quiet --detach $masterSha
@@ -515,6 +566,7 @@ try {
         Invoke-Git merge --quiet --no-ff --no-edit $prHeadSha
         $plan = Invoke-DeltaPlanFixture 'delta-reuse'
         Assert-True ($plan.mode -ceq 'Reuse') "a documentation-only master delta was not reused outright: $($plan.mode) - $($plan.why)"
+        Write-Host "Post-merge documentation delta: mode=$($plan.mode); rerun count=$(@($plan.rerun).Count)"
 
         # (c) Master changes CI control: the full matrix, whatever the pull request ran.
         Invoke-Git checkout --quiet --detach $masterSha
@@ -571,5 +623,5 @@ if ($failures.Count -gt 0) {
     exit 1
 }
 
-Write-Host 'Test-impact end-to-end proof passed: covered edit selected 2/3; #2118 selected none; CI control edit escalated; behind-master PR with a new test selected 2/3 instead of escalating.'
+Write-Host 'Test-impact end-to-end proof passed: covered edit and behind-master PR selected 2/3; #2118 selected none; post-merge runtime delta reran Always and imported Alpha; documentation delta reused; control/invalid-map deltas required full validation; deleted-test delta retained its route and succeeded.'
 exit 0

--- a/tools/TestImpact/Test-TestImpactEndToEnd.ps1
+++ b/tools/TestImpact/Test-TestImpactEndToEnd.ps1
@@ -8,6 +8,9 @@ param()
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
+& (Join-Path $PSScriptRoot 'Test-CiImpactWorkflowReview.ps1')
+if ($LASTEXITCODE -ne 0) { throw 'Workflow review negative controls failed.' }
+
 $selector = Join-Path $PSScriptRoot 'Select-Shards.ps1'
 $coverageSelector = Join-Path $PSScriptRoot 'Select-CoverageShards.ps1'
 $missMeasurer = Join-Path $PSScriptRoot 'Measure-SelectionMiss.ps1'

--- a/tools/TestImpact/Test-TestImpactEndToEnd.ps1
+++ b/tools/TestImpact/Test-TestImpactEndToEnd.ps1
@@ -427,6 +427,55 @@ try {
         Assert-True ([bool] (Get-Content non-merge-selection.json -Raw | ConvertFrom-Json).escalate) `
             'a checkout that is not a merge commit was trusted as a pull-request merge'
 
+        # A pull request that DELETES a test file: no file at HEAD names its types, so the reference
+        # search's git grep exits 1. The selector must still exit 0 - callers read a nonzero exit as
+        # a selector failure and throw away the (valid) selection for the full matrix.
+        # Its own small repository, because the file must exist in the MAP's commit for its deletion
+        # to be a map-coordinate change at all.
+        $deletionRepo = Join-Path $fixture 'deletion-repo'
+        New-Item -ItemType Directory -Path (Join-Path $deletionRepo 'tests/Proj/UnitTests/Alpha') -Force | Out-Null
+        Push-Location $deletionRepo
+        try {
+            Invoke-Git init --quiet
+            Invoke-Git config user.email 'ci-impact-fixture@example.invalid'
+            Invoke-Git config user.name 'CI impact fixture'
+            Invoke-Git config commit.gpgSign false
+            Invoke-Git config core.hooksPath $disabledHooks
+            @('namespace Proj.UnitTests.Alpha;', 'public class DoomedTests', '{', '    [Fact]',
+              '    public void Works() { }', '}') |
+                Set-Content -LiteralPath tests/Proj/UnitTests/Alpha/DoomedTests.cs -Encoding utf8
+            Invoke-Git add .
+            Invoke-Git commit --quiet -m map-commit
+            $deletionBase = ((Invoke-Git rev-parse HEAD) | Out-String).Trim()
+            Invoke-Git rm --quiet tests/Proj/UnitTests/Alpha/DoomedTests.cs
+            Invoke-Git commit --quiet -m delete-a-test-file
+            $deletingHeadSha = ((Invoke-Git rev-parse HEAD) | Out-String).Trim()
+            Invoke-Git checkout --quiet --detach $deletionBase
+            Invoke-Git commit --quiet --allow-empty -m base-moves-on
+            Invoke-Git merge --quiet --no-ff --no-edit $deletingHeadSha
+            [ordered]@{
+                schemaVersion = 1; sha = $deletionBase; knownShards = @('Alpha', 'Beta'); alwaysRun = @('Always')
+                files = [ordered]@{ 'src/Placeholder.cs' = @([ordered]@{ s = 1; r = @(1, 1) }) }
+            } | ConvertTo-Json -Depth 8 | Set-Content -LiteralPath deletion-map.json -Encoding utf8
+            $global:LASTEXITCODE = 99
+            & $selector -MapFile deletion-map.json -PullRequestHeadSha $deletingHeadSha `
+                -ShardManifestFile ../shard-manifest.json -ExpectedShards $shardNames `
+                -OutFile deleted-test-selection.json 6>$null
+            $deletedExit = $LASTEXITCODE
+            $deletedTest = Get-Content deleted-test-selection.json -Raw | ConvertFrom-Json
+        }
+        finally { Pop-Location }
+        Assert-True (-not [bool] $deletedTest.escalate -and $deletedTest.shards -contains 'Alpha') `
+            "deleting a test file was not routed to its shard: $(@($deletedTest.reasons) -join '; ')"
+        Assert-True ($deletedExit -eq 0) `
+            "a valid selection exited $deletedExit, which the workflow reads as a selector failure"
+
+        # Every result shape - escalations included - carries routes; consumers read it under StrictMode.
+        & $selector -MapFile absent-map.json -ExpectedShards $shardNames -OutFile escalated-selection.json 6>$null
+        $escalated = Get-Content escalated-selection.json -Raw | ConvertFrom-Json
+        Assert-True ([bool] $escalated.escalate -and $null -ne $escalated.PSObject.Properties['routes']) `
+            'an escalated selection result has no routes property'
+
         $badCertificate = Get-Content certified/certification.json -Raw | ConvertFrom-Json
         $badCertificate.missCount = 1
         $badCertificate | ConvertTo-Json -Depth 5 | Set-Content bad-certification.json -Encoding utf8

--- a/tools/TestImpact/Test-TestImpactEndToEnd.ps1
+++ b/tools/TestImpact/Test-TestImpactEndToEnd.ps1
@@ -339,6 +339,91 @@ try {
         Assert-True (@($renameSelection.shards).Count -eq 3) `
             'normal shard selection did not retain both mapped source shards and always-run validation'
 
+        # ---- A pull request BEHIND master, through a real GitHub-shaped merge commit. -------------
+        # Master gains a selector-control commit after the pull request branched from the map's
+        # commit. The event's base.sha still names that old commit, which is exactly how #2100 was
+        # charged with 16 merged CI-control files and escalated to all 116 shards.
+        Invoke-Git checkout --quiet --detach $baseSha
+        New-Item -ItemType Directory -Path tools/TestImpact -Force | Out-Null
+        'merged selector fix' | Set-Content -LiteralPath tools/TestImpact/Merged.ps1 -Encoding utf8
+        Invoke-Git add tools/TestImpact/Merged.ps1
+        Invoke-Git commit --quiet -m master-moves-on
+        $masterSha = ((Invoke-Git rev-parse HEAD) | Out-String).Trim()
+
+        Invoke-Git checkout --quiet --detach $baseSha
+        @('one', 'alpha behind', 'three', 'beta unchanged', 'five') |
+            Set-Content -LiteralPath src/Feature.cs -Encoding utf8
+        New-Item -ItemType Directory -Path tests/Proj/UnitTests/Alpha -Force | Out-Null
+        @(
+            'using Xunit;',
+            'namespace Proj.UnitTests.Alpha;',
+            'public class NewAlphaTests',
+            '{',
+            '    [Fact]',
+            '    public void Works() { }',
+            '}'
+        ) | Set-Content -LiteralPath tests/Proj/UnitTests/Alpha/NewAlphaTests.cs -Encoding utf8
+        Invoke-Git add src/Feature.cs tests/Proj/UnitTests/Alpha/NewAlphaTests.cs
+        Invoke-Git commit --quiet -m pull-request-change
+        $prHeadSha = ((Invoke-Git rev-parse HEAD) | Out-String).Trim()
+
+        # refs/pull/N/merge: base-branch tip first, pull request head second.
+        Invoke-Git checkout --quiet --detach $masterSha
+        Invoke-Git merge --quiet --no-ff --no-edit $prHeadSha
+        @(
+            [ordered]@{ name = 'Alpha'; project = 'tests/Proj/Proj.csproj'; filter = 'FullyQualifiedName~UnitTests.Alpha' },
+            [ordered]@{ name = 'Beta'; project = 'tests/Proj/Proj.csproj'; filter = 'FullyQualifiedName~UnitTests.Beta' },
+            [ordered]@{ name = 'Always'; project = 'tests/Proj/Proj.csproj'; filter = 'Category=Heavy' }
+        ) | ConvertTo-Json -Depth 3 | Set-Content -LiteralPath shard-manifest.json -Encoding utf8
+        $shardNames = @('Alpha', 'Beta', 'Always')
+
+        # Reproduction first: the stale base, exactly as the workflow used to pass it.
+        $staleOutput = @(& $selector -MapFile certified/shard-map.json -BaseSha $baseSha `
+            -ExpectedShards $shardNames -OutFile behind-stale-selection.json 6>&1)
+        foreach ($line in $staleOutput) {
+            Write-Host (('[expected escalation, stale base] ' + [string] $line) -replace '::warning::', '')
+        }
+        $stale = Get-Content behind-stale-selection.json -Raw | ConvertFrom-Json
+        Assert-True ([bool] $stale.escalate -and (@($stale.reasons) -join ';') -like '*tools/TestImpact/Merged.ps1*') `
+            'reproduction failed: the stale base did not charge master''s merged control file to the pull request'
+        & $selector -ClassifyOnly -BaseSha $baseSha -OutFile behind-stale-classification.json
+        $staleClassification = Get-Content behind-stale-classification.json -Raw | ConvertFrom-Json
+        Assert-True (@($staleClassification.changedPaths).Count -eq 3) `
+            'reproduction failed: the stale base did not report master''s file as a pull-request path'
+
+        # Fixed: the merge commit's first parent.
+        & $selector -ClassifyOnly -PullRequestHeadSha $prHeadSha -OutFile behind-classification.json
+        $behindClassification = Get-Content behind-classification.json -Raw | ConvertFrom-Json
+        Assert-True ((@($behindClassification.changedPaths | Sort-Object) -join ',') -eq
+            'src/Feature.cs,tests/Proj/UnitTests/Alpha/NewAlphaTests.cs') `
+            'a behind pull request was classified on paths other than its own'
+        Assert-True ([string] $behindClassification.baseSha -eq $masterSha) `
+            'classification did not use the merge commit''s first parent as the base'
+        & $selector -MapFile certified/shard-map.json -PullRequestHeadSha $prHeadSha `
+            -ShardManifestFile shard-manifest.json -ExpectedShards $shardNames -OutFile behind-selection.json
+        Assert-True ($LASTEXITCODE -eq 0) 'selection for a behind pull request failed'
+        $behind = Get-Content behind-selection.json -Raw | ConvertFrom-Json
+        Assert-True (-not [bool] $behind.escalate) `
+            "a behind pull request still escalated: $(@($behind.reasons) -join '; ')"
+        Assert-True ((@($behind.shards) -join ',') -eq 'Alpha,Always') `
+            "a behind pull request did not select exactly its covering/new-test shard and always-run (a strict 2/3): $(@($behind.shards) -join ',')"
+        Assert-True (@($behind.routes | Where-Object { $_ -like 'Alpha <= runs tests affected by tests/Proj/UnitTests/Alpha/NewAlphaTests.cs*' }).Count -eq 1) `
+            'the new test file was not routed to Alpha through its filter'
+
+        # The head must be the merge commit's second parent, and the checkout must be a merge.
+        & $selector -MapFile certified/shard-map.json -PullRequestHeadSha $masterSha `
+            -ShardManifestFile shard-manifest.json -ExpectedShards $shardNames -OutFile wrong-head-selection.json 6>$null
+        $wrongHead = Get-Content wrong-head-selection.json -Raw | ConvertFrom-Json
+        Assert-True ([bool] $wrongHead.escalate) 'a head that is not the merge commit''s second parent was trusted'
+        & $selector -ClassifyOnly -PullRequestHeadSha $masterSha -OutFile wrong-head-classification.json 6>$null
+        Assert-True ([bool] (Get-Content wrong-head-classification.json -Raw | ConvertFrom-Json).requiresValidation) `
+            'classification trusted a head that is not the merge commit''s second parent'
+        Invoke-Git checkout --quiet --detach $prHeadSha
+        & $selector -MapFile certified/shard-map.json -PullRequestHeadSha $prHeadSha `
+            -ShardManifestFile shard-manifest.json -ExpectedShards $shardNames -OutFile non-merge-selection.json 6>$null
+        Assert-True ([bool] (Get-Content non-merge-selection.json -Raw | ConvertFrom-Json).escalate) `
+            'a checkout that is not a merge commit was trusted as a pull-request merge'
+
         $badCertificate = Get-Content certified/certification.json -Raw | ConvertFrom-Json
         $badCertificate.missCount = 1
         $badCertificate | ConvertTo-Json -Depth 5 | Set-Content bad-certification.json -Encoding utf8
@@ -380,5 +465,5 @@ if ($failures.Count -gt 0) {
     exit 1
 }
 
-Write-Host 'Test-impact end-to-end proof passed: covered edit selected 2/3; #2118 selected none; CI control edit escalated.'
+Write-Host 'Test-impact end-to-end proof passed: covered edit selected 2/3; #2118 selected none; CI control edit escalated; behind-master PR with a new test selected 2/3 instead of escalating.'
 exit 0

--- a/tools/TestImpact/Test-TestImpactEndToEnd.ps1
+++ b/tools/TestImpact/Test-TestImpactEndToEnd.ps1
@@ -16,6 +16,7 @@ $coverageSelector = Join-Path $PSScriptRoot 'Select-CoverageShards.ps1'
 $missMeasurer = Join-Path $PSScriptRoot 'Measure-SelectionMiss.ps1'
 $certificateWriter = Join-Path $PSScriptRoot 'New-ShardMapCertificate.ps1'
 $certificateValidator = Join-Path $PSScriptRoot 'Test-CertifiedShardMap.ps1'
+$reuseResolver = Join-Path $PSScriptRoot 'Resolve-CiValidationReuse.ps1'
 $tempRoot = [IO.Path]::GetFullPath([IO.Path]::GetTempPath())
 $fixture = Join-Path $tempRoot ("aidotnet-impact-e2e-" + [guid]::NewGuid().ToString('N'))
 $failures = [System.Collections.Generic.List[string]]::new()
@@ -373,6 +374,7 @@ try {
         # refs/pull/N/merge: base-branch tip first, pull request head second.
         Invoke-Git checkout --quiet --detach $masterSha
         Invoke-Git merge --quiet --no-ff --no-edit $prHeadSha
+        $testedMergeSha = ((Invoke-Git rev-parse HEAD) | Out-String).Trim()
         @(
             [ordered]@{ name = 'Alpha'; project = 'tests/Proj/Proj.csproj'; filter = 'FullyQualifiedName~UnitTests.Alpha' },
             [ordered]@{ name = 'Beta'; project = 'tests/Proj/Proj.csproj'; filter = 'FullyQualifiedName~UnitTests.Beta' },
@@ -475,6 +477,58 @@ try {
         $escalated = Get-Content escalated-selection.json -Raw | ConvertFrom-Json
         Assert-True ([bool] $escalated.escalate -and $null -ne $escalated.PSObject.Properties['routes']) `
             'an escalated selection result has no routes property'
+
+        # ---- Post-merge DELTA reuse, from the same pull request. --------------------------------
+        # The pull request was validated as $testedMergeSha and its run executed Alpha and Always.
+        # Before it lands, master gains more commits. Exact-tree reuse can never match now; delta
+        # reuse must rebuild the validated tree from its parents and decide from what master added.
+        $testedTree = ((Invoke-Git rev-parse "$testedMergeSha^{tree}") | Out-String).Trim()
+        $pullRequestShards = '["Alpha","Always"]'
+        function Invoke-DeltaPlanFixture([string] $Name, [string] $Tree = $testedTree) {
+            & $reuseResolver -PlanDelta -TestedBaseSha $masterSha -TestedHeadSha $prHeadSha -TestedTree $Tree `
+                -PullRequestShardsJson $pullRequestShards -MapFile certified/shard-map.json `
+                -ShardManifestFile shard-manifest.json -SelectorPath $selector -OutFile "$Name.json" 6>$null
+            return Get-Content "$Name.json" -Raw | ConvertFrom-Json
+        }
+
+        # (a) Master edits a line only Beta executes. Δ selects Beta + Always; the pull request ran
+        #     Alpha + Always, so only Always is re-run and Alpha's results are imported.
+        Invoke-Git checkout --quiet --detach $masterSha
+        @('one', 'alpha before', 'three', 'beta changed on master', 'five') |
+            Set-Content -LiteralPath src/Feature.cs -Encoding utf8
+        Invoke-Git commit --quiet -am master-runtime-change
+        Invoke-Git merge --quiet --no-ff --no-edit $prHeadSha
+        $plan = Invoke-DeltaPlanFixture 'delta-partial'
+        Assert-True ($plan.mode -ceq 'Partial') "an overlapping master delta did not plan a partial re-run: $($plan.mode) - $($plan.why)"
+        Assert-True ((@($plan.rerun) -join ',') -ceq 'Always') `
+            "the partial re-run was not exactly the overlap: rerun=$(@($plan.rerun) -join ','); routes=$(@($plan.routes) -join ' | ')"
+        Assert-True ((@($plan.import) -join ',') -ceq 'Alpha') `
+            "the partial re-run did not import the untouched pull-request shard: import=$(@($plan.import) -join ',')"
+        Assert-True ($plan.tree -ceq $testedTree) 'the validated tree was not rebuilt exactly from its parents'
+
+        # (b) Master adds only documentation: nothing the pull request certified can have changed.
+        Invoke-Git checkout --quiet --detach $masterSha
+        New-Item -ItemType Directory -Path docs -Force | Out-Null
+        'release notes' | Set-Content -LiteralPath docs/notes.md -Encoding utf8
+        Invoke-Git add docs/notes.md
+        Invoke-Git commit --quiet -m master-docs-change
+        Invoke-Git merge --quiet --no-ff --no-edit $prHeadSha
+        $plan = Invoke-DeltaPlanFixture 'delta-reuse'
+        Assert-True ($plan.mode -ceq 'Reuse') "a documentation-only master delta was not reused outright: $($plan.mode) - $($plan.why)"
+
+        # (c) Master changes CI control: the full matrix, whatever the pull request ran.
+        Invoke-Git checkout --quiet --detach $masterSha
+        'later selector change' | Set-Content -LiteralPath tools/TestImpact/Later.ps1 -Encoding utf8
+        Invoke-Git add tools/TestImpact/Later.ps1
+        Invoke-Git commit --quiet -m master-control-change
+        Invoke-Git merge --quiet --no-ff --no-edit $prHeadSha
+        $plan = Invoke-DeltaPlanFixture 'delta-control'
+        Assert-True ($plan.mode -ceq 'None') 'a master delta containing a CI-control edit was reused'
+
+        # (d) A tree that the parents do not rebuild to is never trusted.
+        $plan = Invoke-DeltaPlanFixture 'delta-wrong-tree' (((Invoke-Git rev-parse "$baseSha^{tree}") | Out-String).Trim())
+        Assert-True ($plan.mode -ceq 'None' -and $plan.why -like '*could not be rebuilt*') `
+            'a validated tree that its parents do not rebuild to was trusted'
 
         $badCertificate = Get-Content certified/certification.json -Raw | ConvertFrom-Json
         $badCertificate.missCount = 1

--- a/tools/TestImpact/Test-ValidationReuseModes.ps1
+++ b/tools/TestImpact/Test-ValidationReuseModes.ps1
@@ -15,6 +15,8 @@ $resolver = Join-Path $PSScriptRoot 'Resolve-CiValidationReuse.ps1'
 if ($LASTEXITCODE -ne 0) { throw 'CI validation certificate self-test failed' }
 & $resolver -SelfTest
 if ($LASTEXITCODE -ne 0) { throw 'CI validation reuse self-test failed' }
+& (Join-Path $PSScriptRoot 'Import-PullRequestShardArtifacts.ps1') -SelfTest
+if ($LASTEXITCODE -ne 0) { throw 'pull-request shard artifact import self-test failed' }
 
-Write-Host 'Validation reuse mode proof passed (typed partial/complete scopes and fail-closed artifacts/tree checks).'
+Write-Host 'Validation reuse mode proof passed (typed partial/complete scopes, fail-closed artifacts/tree checks, delta decisions and shard imports).'
 exit 0


### PR DESCRIPTION
> **Depends on #2156.** This branch is built on it, so until #2156 merges this PR also shows its commit (`840169605`). Merge #2156 first; the only new commit here is `be69f8095`.

## Summary

After a PR passes, **merging it into master used to re-run the full 116-shard matrix**, unless the PR happened to be exactly up to date. This PR makes the master push reuse the PR's validation across whatever master gained in between, re-running only the shards those intervening commits could have affected.

**On real data:** #2100 was validated on master `88364e91`. If it landed on today's master (`1c8647e2`), where master has since gained #2118's docs and release-workflow change:

| | Master push runs |
|---|---|
| **Before**: exact-tree reuse (trees differ) | **116 / 116 shards**, plus build, sweep, shape conformance, CodeQL, Sonar |
| **After**: delta reuse | **0 shards.** The PR's results are reused; CodeQL and Sonar still run on the landed tree |

The validated tree was rebuilt byte-for-byte (`3add6444…`) from the tested merge commit's parents. That confirms `git merge-tree --write-tree` reproduces GitHub's test merge for a real PR.

## Why exact-tree reuse almost never fired

`Resolve-CiValidationReuse.ps1` reused a PR's certificate only when `tree(PR tested commit) == tree(landed commit)`. That holds only if nothing else merged between the PR's last CI run and its own merge. With many PRs open, it almost never holds. Of 12 recent master push runs, 2 reused, 11 were cancelled by the next merge, and the rest ran everything (e.g. run 34279678108: 100 jobs, ~3h).

## How delta reuse decides

The landed commit `L` equals the PR's validated tree `T` plus exactly what master gained since, called **Δ**.

1. **Rebuild `T`.** The tested merge commit is usually unfetchable once its `refs/pull/N/merge` ref moves, but its parents (the old master tip and the PR head) are still reachable. `git merge-tree --write-tree base head` must reproduce the tree GitHub reports for the tested commit exactly. A conflict or any difference means a full run (fail closed).
2. **Select over Δ** with the same certified map, test routing and hazards as PR selection (`Select-Shards -DeltaFromTree <T>`).
3. **Decide:**

| Δ selection | Master push |
|---|---|
| Needs the full matrix (CI-control, build, unmappable) | Full run, as before |
| Non-runtime | **Reuse**: 0 shards |
| Reaches none of the shards the PR ran | **Reuse**: 0 shards |
| Reaches some of them | **Partial**: re-run only `Δ ∩ PR shards`, and import the PR run's per-shard artifacts for the rest |

Reuse is **never Complete-scoped**: CodeQL and Sonar analysed `T`, not `L`, so they always run again. A shard Δ affects that the PR didn't run was validated by the commits that make up Δ, each on its own run. This PR's change doesn't reach that shard, which is the same premise PR selection rests on, and the nightly miss audit measures it.

**Partial runs stay complete.** The regression ledger, aggregate analysis and Sonar coverage for `L` are built from fresh results for re-run shards plus the PR run's artifacts (`coverage-<T>-<slug>`, `test-results-<T>-<slug>`) for the rest, via `Import-PullRequestShardArtifacts.ps1`. A missing artifact for a shard reuse relied on fails the job, because that evidence can't be claimed. Imported shards are not reported as "skipped" to the regression analysis.

## Selection precision (PR mode as well)

With a change expressed against a base the map doesn't describe, #2156 took ranges from `map → HEAD` for the change's files. That also sweeps in every edit master made to the *same* files since the map. Now the change's own ranges are **carried back to the map's line numbers through `map → base`** (`Convert-RangesThroughHunks`):

- An unchanged line maps exactly.
- A line inside a changed region maps to the whole region it replaced, or to the insertion point.
- A change beside a deletion also takes the deleted lines.
- **Moves.** Git shows a move as delete + insert, so a line master introduced since the map has an unknown mapped origin. Wherever the change reaches such a line, the old `map → HEAD` sweep for that file is added back.

**Checked by a 120-trial property test over real `git diff` output**, with random deletes, inserts, replaces and moves. Every map line whose content a change touches must be inside the carried-back ranges: 0 violations. **The test fails on each of three mutants:** sweep removed (5 lines dropped), offset sign flipped (125 dropped), and a deletion-neighbour off-by-one I introduced and then fixed while writing this.

## Proof

| | |
|---|---|
| Real data | #2100 simulated landing on today's master: tree rebuilt exactly, plan **Reuse**, 0/116 |
| Real-git end-to-end (`Test-TestImpactEndToEnd.ps1`) | From the behind-master fixture, master then gains (a) a runtime edit only Beta executes → **Partial**: re-run exactly `Always`, import `Alpha`; (b) docs only → **Reuse**; (c) a CI-control edit → **None** (full); (d) a tree its parents don't rebuild to → **None** |
| Unit | Decision table (escalation, non-runtime, disjoint, overlap, empty-selection anomaly, ordinal names), job-name parsing, artifact import (exact shards, missing reported, never overwrites fresh output) |
| Contracts (`Test-CiImpactWorkflow.ps1`) | Full history on push; audited map for delta; fail-closed defaults for every new output; exact tree equality; never Complete scope; the select step never computes its own delta; all three consumers import; ci-proof canaries use master's map; quoted `fetch-depth` |
| **Post-merge reuse on a behind PR, in real CI** | ⏳ Running next through the `ci-proof/**` harness, as you chose. Results will be posted on this PR. |

All twelve impact-tooling suites pass locally (pwsh 7.6).

## Two harness and CI fixes found along the way

- **The `ci-proof/**` harness could never prove selection.** A canary into a proof branch looked for maps built on that branch; maps are only built on master, so every canary ran the full matrix. It now uses master's map.
- **`fetch-depth: ${{ github.event_name == 'push' && 0 || 1 }}` always evaluates to 1.** In GitHub expressions `0` is falsy. Caught in review before it shipped; it now uses quoted literals, and a contract rejects the unquoted form.

## Files

| File | Change |
|---|---|
| `tools/TestImpact/Resolve-CiValidationReuse.ps1` | Delta planning (`Resolve-ValidatedTree`, `Invoke-DeltaPlan`, `Get-DeltaReuseDecision`), new outputs, offline `-PlanDelta` mode for tests and diagnosis |
| `tools/TestImpact/Select-Shards.ps1` | `-DeltaFromTree`; hunk parser (`ConvertTo-DiffHunks`); range carry-back plus the moved-code sweep; property test |
| `tools/TestImpact/Import-PullRequestShardArtifacts.ps1` | New: exact-shard artifact import with a self-test |
| `.github/workflows/sonarcloud.yml` | `validation-source`: full history on push, audited map and manifest, new outputs. `select-shards`: partial matrix on push; imports not reported as skipped; ci-proof map branch. Imports in regression analysis, aggregate analysis and Sonar |
| `tools/TestImpact/Test-CiImpactWorkflow.ps1`, `Test-TestImpactEndToEnd.ps1`, `Test-ValidationReuseModes.ps1` | Contracts, end-to-end delta scenarios, import self-test wiring |

## What this deliberately does not do

- **Master runs cancelled by the next merge.** The `build-<ref>` concurrency group still cancels an in-flight master run when another PR merges. With reuse, master runs are mostly seconds, not hours, so far fewer are cancelled, but cancellation itself is unchanged.
- **Regression baseline lookup** still uses the event `base.sha` (see #2156). Now that master runs will complete, switching it to the merge parent becomes viable. That's a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017otuSGr3GdmvPoYLbiaWR2


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - CI validation now supports pull requests that merge while behind the target branch.
  - Post-merge checks can reuse existing validation results and artifacts, rerunning only affected test shards when appropriate.
  - Test-impact analysis uses the pull request’s actual test configuration and reports clearer selection reasons.
  - Coverage, diagnostics, and test results are imported for reused shards to provide complete validation reporting.
  - Validation now uses certified test-shard mappings for more consistent test routing.

- **Bug Fixes**
  - Improved shard selection accuracy for source, test, and generated-code changes.
  - Prevented incorrectly skipped shards during partial validation runs.
  - Added safeguards to reject incomplete or invalid artifact reuse.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
## Timed dependency review — 2026-09-12

Implemented in b5e7cc18afd3de970a3a7c226bf1af4c5188073d, with partial-fixture setup cleanup in a41278f1e8e50a96ebbe3a4366b8246d45f90175.

- Certificate/tree consistency safeguards now live in this dependency, not only #2173. Noncanonical enum scopes are rejected.
- All six delta download/import steps refuse imports after selector escalation. Contracts inspect the actual named steps and checkout inputs, not comment text.
- Local proof: resolver self-test passed; 64 production certificate eligibility cases passed; 46 unsafe workflow mutations rejected; 12 artifact emission cases passed; real Windows junction cleanup rejected the linked ancestor and preserved its sentinel.
- Real-Git fixture: covered and behind-master PRs selected 2/3 shards; docs selected zero; post-merge runtime delta reran Always and imported Alpha; documentation delta reused with zero reruns; invalid-map/control changes required full validation.
- After the final cleanup movement, its focused test passed again. No .NET build was needed.

This is local executable proof, not a claim that the new hosted run is green. #2156 remains a merge-order dependency with failed runtime checks. Ready for review does not mean ready to merge.
