### PR TITLE
test(ci): delta-reuse proof canary 1 (ci-proof harness, never merges to master)

### DIFF
--- a/src/Finance/Trading/Agents/FinancialA2CAgent.cs
+++ b/src/Finance/Trading/Agents/FinancialA2CAgent.cs
@@ -12,6 +12,7 @@ using AiDotNet.ReinforcementLearning.ReplayBuffers;
 using AiDotNet.Validation;
 using AiDotNet.LossFunctions;
 
+// ci-proof canary (delta-reuse harness): a comment-only change to a runtime file. Never merged to master.
 namespace AiDotNet.Finance.Trading.Agents;
 
 /// <summary>


### PR DESCRIPTION
Proof canary for #2159, per the ci-proof harness you chose. Targets `ci-proof/delta-reuse` (#2159's code on master's base), never master.

Plan: this PR validates a comment-only edit to `src/Finance/Trading/Agents/FinancialA2CAgent.cs`, which should select that file's owning shards plus always-run. A docs-only PR is then merged into the proof branch so this one is behind. Merging this PR afterwards must show the push run doing **delta Reuse** (0 shards re-run), where exact-tree reuse would have re-run the full matrix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)