### PR TITLE
docs(ci): advance the delta-reuse proof branch (ci-proof harness, never merges to master)

### DIFF
--- a/docs/ci-proof-harness.md
+++ b/docs/ci-proof-harness.md
@@ -1,0 +1,3 @@
+# CI proof harness
+
+The `ci-proof/**` branches exercise the real post-merge push path for CI-routing changes before they reach master. This note exists so a proof branch can advance with a documentation-only commit, leaving an open canary pull request behind it.


### PR DESCRIPTION
Documentation-only commit for the ci-proof harness (#2159). Merging it into `ci-proof/delta-reuse` leaves canary #2160 behind its base. Its own landing push is up to date, so it should show exact-tree reuse; #2160's landing afterwards should show delta reuse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)