### PR TITLE
fix(ci): build each project once for net10.0 in SonarCloud so analysis can finish

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -2469,12 +2469,50 @@ jobs:
         run: dotnet build src/AiDotNet.Generators/AiDotNet.Generators.csproj -c Release --no-restore
 
       - name: Build (Release)
-        # Windows-only MSBuild flags dropped — file-locking workarounds not needed on Linux.
-        # Match the memory-safe project concurrency used by the artifact build. Sonar's
-        # compiler instrumentation only increases the need to avoid four large csc
-        # processes competing inside the 16-GB runner.
+        # ONE FRAMEWORK, EVERY PROJECT. `dotnet build` of the whole solution compiled every
+        # project for every target framework under Sonar's analyzers - the main library and the
+        # test project three times each (net10.0, net8.0, net471). It never finished: no master
+        # commit since 09-01 completed an analysis; every attempt died or timed out inside this
+        # step (55 minutes under the old limit, 95 under this one; 88364e91's runner died at 66).
+        # The artifact build compiles the same core for net10.0 in about 7 minutes.
+        #
+        # Every shipped and test project targets net10.0, so each is built once for it and every
+        # project is still analysed. The net8.0/net471 builds remain the build-compat job's
+        # responsibility; Sonar no longer reports issues that exist only in their conditional code.
+        # The generator targets netstandard2.0 by necessity (it loads into the compiler) and was
+        # already built above. A project that stops targeting net10.0 fails this step on purpose,
+        # so it cannot silently drop out of analysis.
+        #
+        # -m:2 matches the memory-safe project concurrency of the artifact build: Sonar's compiler
+        # instrumentation only increases the need to avoid large csc processes competing inside
+        # the 16-GB runner.
         if: ${{ fromJSON(env.EFFECTIVE_REQUIRES_VALIDATION) }}
-        run: dotnet build -c Release --no-restore -m:2
+        shell: pwsh
+        run: |
+          $projects = @(dotnet sln AiDotNet.sln list | Select-Object -Skip 2 |
+            ForEach-Object { $_.Trim().Replace('\', '/') } | Where-Object { $_ })
+          if ($projects.Count -eq 0) { throw 'AiDotNet.sln lists no projects' }
+          foreach ($project in $projects) {
+            $evaluated = dotnet msbuild $project -getProperty:TargetFrameworks -getProperty:TargetFramework | Out-String
+            if ($LASTEXITCODE -ne 0) { throw "could not evaluate the target frameworks of $project" }
+            $properties = ($evaluated | ConvertFrom-Json).Properties
+            $frameworks = @(("$($properties.TargetFrameworks);$($properties.TargetFramework)").Split(';') |
+              Where-Object { $_ })
+            if ($frameworks -contains 'net10.0') {
+              Write-Host "::group::$project (net10.0 of $($frameworks -join ', '))"
+              dotnet build $project -c Release --no-restore -m:2 -f net10.0
+            }
+            elseif ($project -eq 'src/AiDotNet.Generators/AiDotNet.Generators.csproj') {
+              Write-Host "::group::$project (analyzer, $($frameworks -join ', '))"
+              dotnet build $project -c Release --no-restore -m:2
+            }
+            else {
+              throw "$project targets $($frameworks -join ', ') and not net10.0; decide how Sonar should analyse it"
+            }
+            $exit = $LASTEXITCODE
+            Write-Host '::endgroup::'
+            if ($exit -ne 0) { throw "Sonar-instrumented build of $project failed with exit code $exit" }
+          }
 
       - name: End SonarCloud analysis
         if: ${{ fromJSON(env.EFFECTIVE_REQUIRES_VALIDATION) && (github.event_name != 'pull_request' || github.event.pull_request.changed_files <= 250) }}

--- a/tools/TestImpact/Test-CiImpactWorkflow.ps1
+++ b/tools/TestImpact/Test-CiImpactWorkflow.ps1
@@ -528,6 +528,16 @@ foreach ($stepName in @(
     Assert-Contract ($step.Contains('fromJSON(env.EFFECTIVE_REQUIRES_VALIDATION')) `
         "SonarCloud step '$stepName' can run for a non-runtime change"
 }
+# The Sonar build must compile each project once for net10.0. The whole-solution build compiled the
+# library and tests for three frameworks under analyzers and never finished inside the job limit.
+$sonarBuild = Get-StepBlock -JobBlock $sonarJob -Step 'Build (Release)'
+Assert-Contract ($sonarBuild.Contains('dotnet build $project -c Release --no-restore -m:2 -f net10.0') -and
+        $sonarBuild.Contains('dotnet sln AiDotNet.sln list')) `
+    'the Sonar build is not scoped to one net10.0 compile per solution project'
+Assert-Contract (-not [Regex]::IsMatch($sonarBuild, '(?m)^\s*(run:\s*)?dotnet build -c Release')) `
+    'the Sonar build compiles the whole solution for every target framework again'
+Assert-Contract ($sonarBuild.Contains('and not net10.0; decide how Sonar should analyse it')) `
+    'a project that stops targeting net10.0 can silently drop out of Sonar analysis'
 $certifiedCoverage = Get-StepBlock -JobBlock $sonarJob -Step 'Download certified coverage artifacts'
 Assert-Contract ($certifiedCoverage.Contains("needs.validation-source.outputs.reuse == 'true'")) `
     'a quality-only landed run cannot consume the certified PR coverage'


### PR DESCRIPTION
## Summary

**SonarCloud has not completed an analysis on any master commit since 09-01.** Every attempt failed, was cancelled or timed out inside one step, `Build (Release)`. SonarCloud Analysis is a required status, so **no runtime PR or master commit can currently reach a green `CI Gate`**. Canaries #2160 and #2162 and PR #2156 all hit this today.

This PR builds each project once, for net10.0, instead of every project for every target framework. Every project is still analysed.

## Evidence

Sonar check runs on master (first-parent), most recent first:

| Commit | Sonar result | Duration |
|---|---|---|
| `88364e91` | failure | 66 min (runner died inside `Build (Release)`) |
| `8decd96c` | cancelled | 24.5 min |
| `2a53ff3d`, `a22d7e78`, `2a8ca6b2` | cancelled | 55.0 min each (the old limit) |
| `3b4dc7c0`, `7f0807c4`, `3a8b668c`, `e0553749` | failure | 3–7 min |
| everything else since 09-01 | skipped / cancelled before starting | — |

On pull requests today: runs 34570307967 (#2160) and 34571137140 (#2162) were both **cancelled at exactly 95.0 min**, still inside `Build (Release)`. That step started at 09:14:42, and the step before it, "Build source generator first", took 34 s.

## Why the step can't finish

```yaml
run: dotnet build -c Release --no-restore -m:2
```

That builds the **whole solution**: 19 projects, each for **every** target framework, with Sonar's compiler analyzers attached, at 2 projects in parallel. Evaluated with MSBuild:

| Project | Target frameworks | Compiles under the old step |
|---|---|---|
| `src/AiDotNet.csproj` (the library) | net10.0; net8.0; net471 | **3** |
| `tests/AiDotNet.Tests/AiDotNetTests.csproj` | net10.0; net8.0; net471 | **3** |
| Dashboard, Privacy.HE, Storage.Sqlite | net10.0; net8.0; net471 | 3 each |
| AiDotNetBenchmarkTests, testconsole, Storage.Elasticsearch | net10.0; net471 | 2 each |
| 10 others | net10.0 | 1 each |
| `src/AiDotNet.Generators` | netstandard2.0 (analyzer) | 1 |

For comparison, the artifact `Build` job compiles the same core for net10.0 in **7.0 minutes** (#2162's run).

## The change

The Sonar step now enumerates `AiDotNet.sln` and evaluates each project's frameworks with `dotnet msbuild -getProperty`:

- If the project targets net10.0, it's built **once, for net10.0**, at the same memory-safe `-m:2`.
- The generator is built as the netstandard2.0 analyzer it must be.
- Anything else **fails the step on purpose**: `<project> targets … and not net10.0; decide how Sonar should analyse it`. A project can't silently drop out of analysis.

Every project is still analysed. What changes is that issues existing **only** in net8.0/net471 conditional code are no longer reported by Sonar. Those frameworks are still compiled by the separate `build-compat` job, so a break there still fails CI. This is the scope you chose.

## Verification

- **Local, the step's exact script on `origin/master`:** all 19 projects built with exit 0 (18 for net10.0, the generator as an analyzer). That run was incremental on a warm tree, so it proves correctness, not CI timing.
- **Routing dry run:** each project evaluated to the expected framework and command (table above).
- **Contract** (`Test-CiImpactWorkflow.ps1`): the Sonar build must enumerate the solution and build `-f net10.0` per project, must not contain a whole-solution `dotnet build -c Release`, and must fail loudly on a project without net10.0.
- **In CI:** this PR's own SonarCloud job runs the new step (pull-request workflows use the merge ref's workflow). Its duration and result are the real-world proof, and I'll post them here.

## Merge order

1. **This PR.**
2. **#2156** (selection fix). Its Sonar job would keep timing out without this, so its `CI Gate` can't go green first.
3. **#2159** (post-merge delta reuse). It builds on #2156.

This PR edits the validation workflow, so its own run is a full matrix by design.

## What this does not do

- It doesn't touch the 90-minute job limit. With the build down to one framework per project it should finish well inside it, and the first run here will show by how much.
- It doesn't change what the `build` or `build-compat` jobs compile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017otuSGr3GdmvPoYLbiaWR2


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **CI Improvements**
  - SonarCloud analysis now builds and evaluates each solution project individually.
  - Projects are checked for required .NET 10 targeting, and incompatible projects or failed builds stop the analysis instead of being silently skipped.
  - Added automated validation to ensure the CI workflow maintains this build behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->