### PR TITLE
fix(video): route VideoMAE pretraining through its decoder and declare TimeSformer's clip input

### DIFF
--- a/src/Helpers/LayerHelper.cs
+++ b/src/Helpers/LayerHelper.cs
@@ -9368,8 +9368,9 @@ public static partial class LayerHelper<T>
         // 3D patch embedding (spatiotemporal)
         yield return new ConvolutionalLayer<T>(numFeatures, patchSize, patchSize, 0, new ReLUActivation<T>() as IActivationFunction<T>);
 
-        // Transformer encoder blocks (12 blocks)
-        for (int i = 0; i < 12; i++)
+        // Transformer encoder blocks. The model addresses every slice of this list through
+        // VideoMAELayerLayout, so the counts here must come from the same place.
+        for (int i = 0; i < AiDotNet.Video.ActionRecognition.VideoMAELayerLayout.EncoderBlockCount; i++)
         {
             yield return new ConvolutionalLayer<T>(numFeatures, 3, 1, 1, new ReLUActivation<T>() as IActivationFunction<T>);
         }
@@ -9390,7 +9391,7 @@ public static partial class LayerHelper<T>
         // Note: In a real VideoMAE implementation, the decoder would receive encoder features
         // and upsample back to original resolution. This factory provides encoder + classifier;
         // full reconstruction with unpatching is handled by the VideoMAE model class.
-        for (int i = 0; i < 4; i++)
+        for (int i = 0; i < AiDotNet.Video.ActionRecognition.VideoMAELayerLayout.DecoderBlockCount; i++)
         {
             yield return new ConvolutionalLayer<T>(numFeatures, 3, 1, 1, new ReLUActivation<T>() as IActivationFunction<T>);
         }

--- a/src/Video/ActionRecognition/TimeSformer.cs
+++ b/src/Video/ActionRecognition/TimeSformer.cs
@@ -89,6 +89,9 @@ public partial class TimeSformer<T> : NeuralNetworkBase<T>
 
     private readonly bool _useNativeMode;
 
+    /// <summary>Default clip length (frames), as in the TimeSformer paper's 8-frame clips.</summary>
+    private const int DefaultNumFrames = 8;
+
     #endregion
 
     #region ONNX Mode Fields
@@ -164,14 +167,22 @@ public partial class TimeSformer<T> : NeuralNetworkBase<T>
     /// <param name="patchSize">Patch size for tokenization (default: 16).</param>
     /// <param name="attentionType">Type of space-time attention (default: DividedSpaceTime).</param>
     /// <summary>
-    /// Initializes a new instance with default architecture settings.
+    /// Initializes a new instance with default architecture settings (8-frame 224x224 RGB clips, 400 classes).
     /// </summary>
+    /// <remarks>
+    /// The declared input is the clip the model is built for, <c>[8, 3, 224, 224]</c>
+    /// (<see cref="Enums.InputType.FourDimensional"/> with <c>inputFrames</c> equal to the default
+    /// <c>numFrames</c>). It used to be <see cref="Enums.InputType.ThreeDimensional"/>, i.e. a single
+    /// <c>[3, 224, 224]</c> frame, so everything that sizes an input from <c>GetInputShape()</c> — the
+    /// auto-batching rank check among them — treated a one-frame image as this video model's input.
+    /// </remarks>
     public TimeSformer()
         : this(new NeuralNetworkArchitecture<T>(
-            inputType: Enums.InputType.ThreeDimensional,
+            inputType: Enums.InputType.FourDimensional,
             taskType: Enums.NeuralNetworkTaskType.MultiClassClassification,
             inputHeight: 224, inputWidth: 224, inputDepth: 3,
-            outputSize: 400))
+            outputSize: 400,
+            inputFrames: DefaultNumFrames))
     {
     }
 
@@ -183,7 +194,7 @@ public partial class TimeSformer<T> : NeuralNetworkBase<T>
         int embedDim = 768,
         int numHeads = 12,
         int numLayers = 12,
-        int numFrames = 8,
+        int numFrames = DefaultNumFrames,
         int patchSize = 16,
         AttentionType attentionType = AttentionType.DividedSpaceTime,
         TimeSformerOptions? options = null)

--- a/src/Video/ActionRecognition/TimeSformer.cs
+++ b/src/Video/ActionRecognition/TimeSformer.cs
@@ -154,19 +154,6 @@ public partial class TimeSformer<T> : NeuralNetworkBase<T>
     #region Constructors
 
     /// <summary>
-    /// Creates a TimeSformer model using native layers for training and inference.
-    /// </summary>
-    /// <param name="architecture">Architecture for the video encoder.</param>
-    /// <param name="numClasses">Number of output classes for classification.</param>
-    /// <param name="optimizer">Optional optimizer for training. Default: Adam.</param>
-    /// <param name="lossFunction">Optional loss function. Default: CrossEntropy.</param>
-    /// <param name="embedDim">Embedding dimension (default: 768).</param>
-    /// <param name="numHeads">Number of attention heads (default: 12).</param>
-    /// <param name="numLayers">Number of transformer layers (default: 12).</param>
-    /// <param name="numFrames">Number of frames to process (default: 8).</param>
-    /// <param name="patchSize">Patch size for tokenization (default: 16).</param>
-    /// <param name="attentionType">Type of space-time attention (default: DividedSpaceTime).</param>
-    /// <summary>
     /// Initializes a new instance with default architecture settings (8-frame 224x224 RGB clips, 400 classes).
     /// </summary>
     /// <remarks>
@@ -186,6 +173,24 @@ public partial class TimeSformer<T> : NeuralNetworkBase<T>
     {
     }
 
+    /// <summary>
+    /// Creates a TimeSformer model using native layers for training and inference.
+    /// </summary>
+    /// <param name="architecture">Architecture for the video encoder.</param>
+    /// <param name="numClasses">Number of output classes for classification.</param>
+    /// <param name="optimizer">Optional optimizer for training. Default: Adam.</param>
+    /// <param name="lossFunction">Optional loss function. Default: CrossEntropy.</param>
+    /// <param name="embedDim">Embedding dimension (default: 768).</param>
+    /// <param name="numHeads">Number of attention heads (default: 12).</param>
+    /// <param name="numLayers">Number of transformer layers (default: 12).</param>
+    /// <param name="numFrames">Number of frames per clip (default: 8). When the architecture declares a
+    /// frame count (<see cref="NeuralNetworkArchitecture{T}.InputFrames"/> &gt; 0) that count is used, as for
+    /// VideoMAE; passing a different non-default value throws, since the two would describe different
+    /// clips. The frame count sizes the positional table and is the group size the divided space-time
+    /// blocks fall back to when they are run without an explicit frame count.</param>
+    /// <param name="patchSize">Patch size for tokenization (default: 16).</param>
+    /// <param name="attentionType">Type of space-time attention (default: DividedSpaceTime).</param>
+    /// <param name="options">Optional configuration options.</param>
     public TimeSformer(
         NeuralNetworkArchitecture<T> architecture,
         int numClasses = 400,
@@ -220,7 +225,7 @@ public partial class TimeSformer<T> : NeuralNetworkBase<T>
         _embedDim = embedDim;
         _numHeads = numHeads;
         _numLayers = numLayers;
-        _numFrames = numFrames;
+        _numFrames = VideoClipFrameCount.Resolve(architecture, numFrames, DefaultNumFrames);
         _patchSize = patchSize;
         _imageSize = architecture.InputHeight > 0 ? architecture.InputHeight : 224;
         _numClasses = numClasses;
@@ -260,7 +265,7 @@ public partial class TimeSformer<T> : NeuralNetworkBase<T>
         _embedDim = embedDim;
         _numHeads = 12;
         _numLayers = 12;
-        _numFrames = 8;
+        _numFrames = VideoClipFrameCount.Resolve(architecture, DefaultNumFrames, DefaultNumFrames);
         _patchSize = 16;
         _imageSize = architecture.InputHeight > 0 ? architecture.InputHeight : 224;
         _numClasses = numClasses;
@@ -293,14 +298,28 @@ public partial class TimeSformer<T> : NeuralNetworkBase<T>
         if (videoFrames is null)
             throw new ArgumentNullException(nameof(videoFrames));
 
-        if (_useNativeMode)
-        {
-            return Forward(videoFrames);
-        }
-        else
+        if (!_useNativeMode)
         {
             return PredictOnnx(videoFrames);
         }
+
+        var probabilities = Forward(videoFrames);
+
+        // Unbatched in, unbatched out. TokenizeVideo treats a [T, C, H, W] clip (or a single [C, H, W]
+        // frame) as a batch of one, so the head emits [1, NumClasses]. This method documents
+        // [NumClasses] for that input, the model's output layout is batch-optional, and the base
+        // PredictCore squeezes the unit batch it adds - so return the unbatched vector here too. Only
+        // the tokenized path is squeezed: a caller-supplied layer stack receives the input unchanged, so
+        // its leading axis is whatever the caller gave it.
+        if (_usesTokenizedNativePath
+            && videoFrames.Rank < 5
+            && probabilities.Rank == 2
+            && probabilities.Shape[0] == 1)
+        {
+            return probabilities.Reshape([probabilities.Shape[1]]);
+        }
+
+        return probabilities;
     }
 
     /// <summary>
@@ -398,31 +417,15 @@ public partial class TimeSformer<T> : NeuralNetworkBase<T>
         return new Tensor<T>(outputShape, new Vector<T>(outputData));
     }
 
-    private Tensor<T> Softmax(Tensor<T> logits)
-    {
-        var result = new Tensor<T>(logits._shape);
-        double maxVal = double.MinValue;
-
-        for (int i = 0; i < logits.Length; i++)
-        {
-            double val = Convert.ToDouble(logits.Data.Span[i]);
-            if (val > maxVal) maxVal = val;
-        }
-
-        double sum = 0;
-        for (int i = 0; i < logits.Length; i++)
-        {
-            sum += Math.Exp(Convert.ToDouble(logits.Data.Span[i]) - maxVal);
-        }
-
-        for (int i = 0; i < logits.Length; i++)
-        {
-            double prob = Math.Exp(Convert.ToDouble(logits.Data.Span[i]) - maxVal) / sum;
-            result.Data.Span[i] = NumOps.FromDouble(prob);
-        }
-
-        return result;
-    }
+    /// <summary>
+    /// Softmax over the class axis (the last one), independently for every clip in the batch.
+    /// </summary>
+    /// <remarks>
+    /// This used to normalise over EVERY element of the logits tensor, so for a batch of B clips the
+    /// B x NumClasses probabilities summed to 1 in total instead of 1 per clip: each clip's
+    /// "probabilities" were scaled by how confident the other clips in the batch happened to be.
+    /// </remarks>
+    private Tensor<T> Softmax(Tensor<T> logits) => Engine.Softmax(logits);
 
     /// <inheritdoc/>
     protected override Tensor<T> PredictCore(Tensor<T> input)

--- a/src/Video/ActionRecognition/VideoMAE.cs
+++ b/src/Video/ActionRecognition/VideoMAE.cs
@@ -265,26 +265,11 @@ public partial class VideoMAE<T> : NeuralNetworkBase<T>
     /// ignored it and always used <c>numFrames</c> (default 16), so an architecture declaring 8-frame
     /// clips produced a model reporting and masking for 16. An explicit <c>numFrames</c> that disagrees
     /// with the declared count is rejected rather than silently overridden. The parameter's default
-    /// value cannot be told apart from an explicit 16, so it defers to the architecture.
+    /// value cannot be told apart from an explicit 16, so it defers to the architecture. The rule lives
+    /// in <see cref="VideoClipFrameCount"/>, shared with TimeSformer.
     /// </remarks>
     private static int ResolveNumFrames(NeuralNetworkArchitecture<T> architecture, int numFrames)
-    {
-        int declared = architecture.InputFrames;
-        if (declared <= 0)
-        {
-            return numFrames;
-        }
-
-        if (numFrames != declared && numFrames != DefaultNumFrames)
-        {
-            throw new ArgumentException(
-                $"numFrames ({numFrames}) conflicts with the architecture's declared InputFrames ({declared}). " +
-                "Pass the same value, or omit numFrames to use the architecture's frame count.",
-                nameof(numFrames));
-        }
-
-        return declared;
-    }
+        => VideoClipFrameCount.Resolve(architecture, numFrames, DefaultNumFrames);
 
     #endregion
 

--- a/src/Video/ActionRecognition/VideoMAE.cs
+++ b/src/Video/ActionRecognition/VideoMAE.cs
@@ -98,6 +98,12 @@ public partial class VideoMAE<T> : NeuralNetworkBase<T>
     private readonly Random _random = RandomHelper.CreateSecureRandom();
     private bool _disposed;
 
+    /// <summary>
+    /// Default clip length (frames) when neither the caller nor the architecture declares one — the
+    /// 16-frame clips of the VideoMAE paper.
+    /// </summary>
+    private const int DefaultNumFrames = 16;
+
     #endregion
 
     #region Properties
@@ -158,7 +164,9 @@ public partial class VideoMAE<T> : NeuralNetworkBase<T>
     /// <param name="optimizer">Optional optimizer for training.</param>
     /// <param name="lossFunction">Optional loss function (default: CrossEntropyLoss).</param>
     /// <param name="numClasses">The number of action classes for classification.</param>
-    /// <param name="numFrames">The number of video frames to process.</param>
+    /// <param name="numFrames">The number of video frames per clip. When the architecture declares a
+    /// frame count (<see cref="NeuralNetworkArchitecture{T}.InputFrames"/> &gt; 0) that count is used; passing a
+    /// different non-default value throws, since the two would describe different clips.</param>
     /// <param name="numFeatures">The embedding dimension.</param>
     /// <param name="maskRatio">The masking ratio for pretraining (default: 0.9).</param>
     /// <remarks>
@@ -172,7 +180,7 @@ public partial class VideoMAE<T> : NeuralNetworkBase<T>
         IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>>? optimizer = null,
         ILossFunction<T>? lossFunction = null,
         int numClasses = 400,
-        int numFrames = 16,
+        int numFrames = DefaultNumFrames,
         int numFeatures = 768,
         double maskRatio = 0.9,
         VideoMAEOptions? options = null)
@@ -185,7 +193,7 @@ public partial class VideoMAE<T> : NeuralNetworkBase<T>
         _width = architecture.InputWidth > 0 ? architecture.InputWidth : 224;
         _channels = architecture.InputDepth > 0 ? architecture.InputDepth : 3;
         _numClasses = numClasses;
-        _numFrames = numFrames;
+        _numFrames = ResolveNumFrames(architecture, numFrames);
         _numFeatures = numFeatures;
         _patchSize = 16;
         _tubeletSize = 2;
@@ -203,7 +211,9 @@ public partial class VideoMAE<T> : NeuralNetworkBase<T>
     /// <param name="architecture">The neural network architecture configuration.</param>
     /// <param name="onnxModelPath">Path to the ONNX model file.</param>
     /// <param name="numClasses">The number of action classes for classification.</param>
-    /// <param name="numFrames">The number of video frames to process.</param>
+    /// <param name="numFrames">The number of video frames per clip. When the architecture declares a
+    /// frame count (<see cref="NeuralNetworkArchitecture{T}.InputFrames"/> &gt; 0) that count is used; passing a
+    /// different non-default value throws, since the two would describe different clips.</param>
     /// <remarks>
     /// <para>
     /// <b>For Beginners:</b> This constructor loads a pre-trained VideoMAE model from ONNX format.
@@ -214,7 +224,7 @@ public partial class VideoMAE<T> : NeuralNetworkBase<T>
         NeuralNetworkArchitecture<T> architecture,
         string onnxModelPath,
         int numClasses = 400,
-        int numFrames = 16,
+        int numFrames = DefaultNumFrames,
         VideoMAEOptions? options = null)
         : base(architecture, new CrossEntropyWithLogitsLoss<T>())
     {
@@ -230,7 +240,7 @@ public partial class VideoMAE<T> : NeuralNetworkBase<T>
         _width = architecture.InputWidth > 0 ? architecture.InputWidth : 224;
         _channels = architecture.InputDepth > 0 ? architecture.InputDepth : 3;
         _numClasses = numClasses;
-        _numFrames = numFrames;
+        _numFrames = ResolveNumFrames(architecture, numFrames);
         _numFeatures = 768;
         _patchSize = 16;
         _tubeletSize = 2;
@@ -243,6 +253,37 @@ public partial class VideoMAE<T> : NeuralNetworkBase<T>
         catch (Exception ex) { throw new InvalidOperationException($"Failed to load ONNX model: {ex.Message}", ex); }
 
         InitializeLayers();
+    }
+
+    /// <summary>
+    /// Resolves the clip length from the architecture and the <c>numFrames</c> constructor argument.
+    /// </summary>
+    /// <remarks>
+    /// The architecture is the model's declared input contract (<c>GetInputShape()</c> is
+    /// <c>[InputFrames, C, H, W]</c> for a temporal-video architecture), so a frame count it declares
+    /// wins — the same rule BSVD applies to <c>Architecture.InputFrames</c>. Previously the constructors
+    /// ignored it and always used <c>numFrames</c> (default 16), so an architecture declaring 8-frame
+    /// clips produced a model reporting and masking for 16. An explicit <c>numFrames</c> that disagrees
+    /// with the declared count is rejected rather than silently overridden. The parameter's default
+    /// value cannot be told apart from an explicit 16, so it defers to the architecture.
+    /// </remarks>
+    private static int ResolveNumFrames(NeuralNetworkArchitecture<T> architecture, int numFrames)
+    {
+        int declared = architecture.InputFrames;
+        if (declared <= 0)
+        {
+            return numFrames;
+        }
+
+        if (numFrames != declared && numFrames != DefaultNumFrames)
+        {
+            throw new ArgumentException(
+                $"numFrames ({numFrames}) conflicts with the architecture's declared InputFrames ({declared}). " +
+                "Pass the same value, or omit numFrames to use the architecture's frame count.",
+                nameof(numFrames));
+        }
+
+        return declared;
     }
 
     #endregion
@@ -314,8 +355,9 @@ public partial class VideoMAE<T> : NeuralNetworkBase<T>
             video = AddBatchDimension5D(video);
         }
 
-        // Create tube mask
-        var mask = CreateTubeMask(video.Shape[0]);
+        // Create the tube mask on this clip's own patch grid (one spatial mask per clip, shared by
+        // every tubelet).
+        var mask = CreateTubeMask(video.Shape[0], video.Shape[3] / _patchSize, video.Shape[4] / _patchSize);
 
         // Encode visible patches
         var visibleFeatures = EncodeVisiblePatches(video, mask);
@@ -483,8 +525,8 @@ public partial class VideoMAE<T> : NeuralNetworkBase<T>
         // classification logits and saturating the softmax so the output stops
         // responding to input changes.
         var features = patchEmbedded;
-        int encoderLayerCount = Math.Min(13, Layers.Count);
-        for (int i = 1; i < encoderLayerCount; i++)
+        int encoderLayerCount = Math.Min(VideoMAELayerLayout.EncoderEndIndex, Layers.Count);
+        for (int i = VideoMAELayerLayout.FirstEncoderBlockIndex; i < encoderLayerCount; i++)
         {
             features = Layers[i].Forward(features);
         }
@@ -581,8 +623,9 @@ public partial class VideoMAE<T> : NeuralNetworkBase<T>
 
     private Tensor<T> ClassificationForward(Tensor<T> features)
     {
-        // Classification head layers are at indices 13 and 14
-        if (_useNativeMode && Layers.Count > 15)
+        // Classification head: feature-reduce conv, (global pool), classifier Dense — see
+        // VideoMAELayerLayout for the indices.
+        if (_useNativeMode && Layers.Count > VideoMAELayerLayout.ClassifierIndex)
         {
             // features: [B, C, 1, 1] pooled per-video embedding from EncodeVideo.
             // Apply the 1x1 feature-reduce conv (Layers[13], Conv+ReLU on the
@@ -594,11 +637,11 @@ public partial class VideoMAE<T> : NeuralNetworkBase<T>
             // inputs nor train (constant output, zero gradient). Layers[15] emits
             // logits (identity activation); ClassifyAction softmaxes for inference
             // and training uses CrossEntropyWithLogitsLoss.
-            var reduced = Layers[13].Forward(features);
+            var reduced = Layers[VideoMAELayerLayout.FeatureReduceIndex].Forward(features);
             int batch = reduced.Shape[0];
             int channels = reduced.Shape[1];
             var flat = Engine.Reshape(reduced, new[] { batch, channels });
-            return Layers[15].Forward(flat);
+            return Layers[VideoMAELayerLayout.ClassifierIndex].Forward(flat);
         }
 
         // In ONNX mode, this is handled by RunOnnxInference
@@ -630,19 +673,35 @@ public partial class VideoMAE<T> : NeuralNetworkBase<T>
         return new Tensor<T>(outputTensor.Dimensions.ToArray(), new Vector<T>(outputData));
     }
 
-    private bool[,,] CreateTubeMask(int batchSize)
+    /// <summary>
+    /// Creates a tube mask on the model's configured patch grid.
+    /// </summary>
+    internal bool[,,] CreateTubeMask(int batchSize)
+        => CreateTubeMask(batchSize, _height / _patchSize, _width / _patchSize);
+
+    /// <summary>
+    /// Creates a tube mask: one random spatial mask per clip, shared by every tubelet of that clip.
+    /// </summary>
+    /// <remarks>
+    /// Tube masking (Tong et al. 2022, Sec. 3.3; <c>TubeMaskingGenerator</c> in the reference code) masks
+    /// <c>int(maskRatio * patchesPerFrame)</c> spatial positions and extends each through time, so the
+    /// masked fraction of the whole clip equals <c>maskRatio</c> regardless of its length. The mask is
+    /// indexed <c>[clip, patchRow, patchCol]</c> and applied to every tubelet, so the masked count must be
+    /// computed from the SPATIAL patch count. It used to be computed from
+    /// <c>numTubelets * patchesPerFrame</c> while sampling from only <c>patchesPerFrame</c> indices, so
+    /// for any clip with two or more tubelets <c>Take(numMasked)</c> took every index and the encoder saw
+    /// nothing at all.
+    /// </remarks>
+    internal bool[,,] CreateTubeMask(int batchSize, int patchesH, int patchesW)
     {
-        int numTubelets = _numFrames / _tubeletSize;
-        int patchesH = _height / _patchSize;
-        int patchesW = _width / _patchSize;
-        int totalPatches = numTubelets * patchesH * patchesW;
-        int numMasked = (int)(totalPatches * _maskRatio);
+        int spatialPatches = patchesH * patchesW;
+        int numMasked = (int)(spatialPatches * _maskRatio);
 
         var mask = new bool[batchSize, patchesH, patchesW];
 
         for (int b = 0; b < batchSize; b++)
         {
-            var indices = Enumerable.Range(0, patchesH * patchesW).OrderBy(_ => _random.Next()).Take(numMasked).ToHashSet();
+            var indices = Enumerable.Range(0, spatialPatches).OrderBy(_ => _random.Next()).Take(numMasked).ToHashSet();
 
             for (int h = 0; h < patchesH; h++)
             {
@@ -701,8 +760,8 @@ public partial class VideoMAE<T> : NeuralNetworkBase<T>
         // classification logits and saturating the softmax so the output stops
         // responding to input changes.
         var features = patchEmbedded;
-        int encoderLayerCount = Math.Min(13, Layers.Count);
-        for (int i = 1; i < encoderLayerCount; i++)
+        int encoderLayerCount = Math.Min(VideoMAELayerLayout.EncoderEndIndex, Layers.Count);
+        for (int i = VideoMAELayerLayout.FirstEncoderBlockIndex; i < encoderLayerCount; i++)
         {
             features = Layers[i].Forward(features);
         }
@@ -710,90 +769,132 @@ public partial class VideoMAE<T> : NeuralNetworkBase<T>
         return features;
     }
 
-    private Tensor<T> DecodeForReconstruction(Tensor<T> features)
+    /// <summary>
+    /// Runs the reconstruction decoder blocks and the reconstruction head over encoder features.
+    /// </summary>
+    /// <param name="features">Encoder features [B * numTubelets, numFeatures, patchesH, patchesW].</param>
+    /// <returns>Per-patch pixel predictions [B * numTubelets, channels * tubeletSize * P * P, patchesH, patchesW].</returns>
+    /// <remarks>
+    /// The decoder slice is addressed through <see cref="VideoMAELayerLayout"/>. It used to start at a
+    /// hard-coded index 15 — the classifier's <c>DenseLayer</c> — so pretraining pushed the encoder maps
+    /// through the class head, ran three of the four decoder blocks, used the fourth as the "head", and
+    /// never reached the real reconstruction head (whose output is the only one sized to a tubelet patch).
+    /// </remarks>
+    internal Tensor<T> DecodeForReconstruction(Tensor<T> features)
     {
-        // Decoder blocks start at index 15 (after classification head)
         var decoded = features;
-        int decoderStartIdx = 15;
 
-        if (_useNativeMode && Layers.Count > decoderStartIdx + 4)
+        if (_useNativeMode && Layers.Count > VideoMAELayerLayout.ReconstructionHeadIndex)
         {
-            for (int i = 0; i < 4; i++)
+            for (int i = VideoMAELayerLayout.FirstDecoderBlockIndex; i < VideoMAELayerLayout.ReconstructionHeadIndex; i++)
             {
-                decoded = Layers[decoderStartIdx + i].Forward(decoded);
+                decoded = Layers[i].Forward(decoded);
                 decoded = ApplyGELU(decoded);
             }
 
-            // Reconstruction head
-            if (Layers.Count > decoderStartIdx + 4)
-            {
-                decoded = Layers[decoderStartIdx + 4].Forward(decoded);
-            }
+            decoded = Layers[VideoMAELayerLayout.ReconstructionHeadIndex].Forward(decoded);
         }
 
         return decoded;
     }
 
-    private T ComputeReconstructionLoss(Tensor<T> reconstructed, Tensor<T> original, bool[,,] mask)
+    /// <summary>
+    /// Mean squared error between the predicted and the true pixels of the MASKED tubelet patches.
+    /// </summary>
+    /// <param name="reconstructed">Reconstruction-head output
+    /// [B * numTubelets, channels * tubeletSize * P * P, patchesH, patchesW].</param>
+    /// <param name="original">The clip [B, T, C, H, W].</param>
+    /// <param name="mask">Tube mask [B, patchesH, patchesW] (true = masked), shared by all tubelets.</param>
+    /// <remarks>
+    /// <para>
+    /// VideoMAE (Tong et al. 2022, Sec. 3.3) reconstructs each masked tubelet patch — the
+    /// <c>tubeletSize x P x P</c> pixels of every channel at that position — and averages the squared
+    /// error over masked patches only. Prediction channel <c>((ts * C + c) * P + y) * P + x</c> at patch
+    /// <c>(ph, pw)</c> of tubelet <c>t</c> is compared with pixel
+    /// <c>original[b, t * tubeletSize + ts, c, ph * P + y, pw * P + x]</c>; the <c>(ts, c)</c> order matches
+    /// how <see cref="PatchEmbed"/> folds a tubelet into the embedding conv's channels.
+    /// </para>
+    /// <para>
+    /// The previous loss treated the head's leading axis (<c>B * numTubelets</c>) as the clip batch and
+    /// compared channel <c>c</c> at patch <c>(h, w)</c> with the frame-average of pixel <c>(h, w)</c> of
+    /// channel <c>c % C</c> — not the patch's pixels at all — and read past the end of the clip as soon
+    /// as a clip had two or more tubelets (IndexOutOfRange from <see cref="PretrainMAE"/>).
+    /// </para>
+    /// <para>
+    /// The target is raw pixels. The reference implementation's optional per-patch target normalisation
+    /// (<c>normlize_target</c>) is not applied.
+    /// </para>
+    /// </remarks>
+    internal T ComputeReconstructionLoss(Tensor<T> reconstructed, Tensor<T> original, bool[,,] mask)
     {
+        if (original.Rank != 5)
+        {
+            throw new ArgumentException("The original clip must be [B, T, C, H, W].", nameof(original));
+        }
+
+        int batchSize = original.Shape[0];
+        int numFrames = original.Shape[1];
+        int channels = original.Shape[2];
+        int numTubelets = numFrames / _tubeletSize;
+        int patch = _patchSize;
+        int patchDim = channels * _tubeletSize * patch * patch;
+        int patchesH = mask.GetLength(1);
+        int patchesW = mask.GetLength(2);
+
+        if (reconstructed.Rank != 4
+            || reconstructed.Shape[0] != batchSize * numTubelets
+            || reconstructed.Shape[1] != patchDim
+            || reconstructed.Shape[2] != patchesH
+            || reconstructed.Shape[3] != patchesW)
+        {
+            throw new InvalidOperationException(
+                $"Reconstruction shape [{string.Join(", ", reconstructed.Shape.ToArray())}] does not match the " +
+                $"expected per-patch prediction [{batchSize * numTubelets}, {patchDim}, {patchesH}, {patchesW}] " +
+                "for this clip and mask.");
+        }
+
+        if (mask.GetLength(0) != batchSize
+            || patchesH * patch > original.Shape[3]
+            || patchesW * patch > original.Shape[4])
+        {
+            throw new ArgumentException("The mask does not match the clip's batch size and patch grid.", nameof(mask));
+        }
+
         T loss = NumOps.Zero;
         int count = 0;
 
-        int batchSize = reconstructed.Shape[0];
-        int channels = reconstructed.Shape[1];
-        int height = reconstructed.Shape[2];
-        int width = reconstructed.Shape[3];
-
-        // Handle both 4D [B,C,H,W] and 5D [B,T,C,H,W] original tensors
-        bool is5D = original.Rank == 5;
-        int origChannels = is5D ? original.Shape[2] : original.Shape[1];
-        int origHeight = is5D ? original.Shape[3] : original.Shape[2];
-        int origWidth = is5D ? original.Shape[4] : original.Shape[3];
-        int numFrames = is5D ? original.Shape[1] : 1;
-
         for (int b = 0; b < batchSize; b++)
         {
-            for (int h = 0; h < height; h++)
+            for (int ph = 0; ph < patchesH; ph++)
             {
-                for (int w = 0; w < width; w++)
+                for (int pw = 0; pw < patchesW; pw++)
                 {
-                    int maskB = b % mask.GetLength(0);
-                    int maskH = h % mask.GetLength(1);
-                    int maskW = w % mask.GetLength(2);
-
-                    if (mask[maskB, maskH, maskW])
+                    if (!mask[b, ph, pw])
                     {
-                        for (int c = 0; c < channels; c++)
+                        continue;
+                    }
+
+                    for (int t = 0; t < numTubelets; t++)
+                    {
+                        int row = b * numTubelets + t;
+                        for (int ts = 0; ts < _tubeletSize; ts++)
                         {
-                            // Map reconstructed position to original position
-                            int origH = h % origHeight;
-                            int origW = w % origWidth;
-                            int origC = c % origChannels;
-
-                            // Get original value - average over all frames if 5D
-                            T origVal;
-                            if (is5D)
+                            int frame = t * _tubeletSize + ts;
+                            for (int c = 0; c < channels; c++)
                             {
-                                // Average over all frames for proper temporal reconstruction loss
-                                T sum = NumOps.Zero;
-                                for (int t = 0; t < numFrames; t++)
+                                for (int y = 0; y < patch; y++)
                                 {
-                                    int idx = b * numFrames * origChannels * origHeight * origWidth +
-                                              t * origChannels * origHeight * origWidth +
-                                              origC * origHeight * origWidth +
-                                              origH * origWidth + origW;
-                                    sum = NumOps.Add(sum, original.Data.Span[idx]);
+                                    for (int x = 0; x < patch; x++)
+                                    {
+                                        int channel = (((ts * channels) + c) * patch + y) * patch + x;
+                                        T diff = NumOps.Subtract(
+                                            reconstructed[row, channel, ph, pw],
+                                            original[b, frame, c, ph * patch + y, pw * patch + x]);
+                                        loss = NumOps.Add(loss, NumOps.Multiply(diff, diff));
+                                        count++;
+                                    }
                                 }
-                                origVal = NumOps.Divide(sum, NumOps.FromDouble(numFrames));
                             }
-                            else
-                            {
-                                origVal = original[b, origC, origH, origW];
-                            }
-
-                            T diff = NumOps.Subtract(reconstructed[b, c, h, w], origVal);
-                            loss = NumOps.Add(loss, NumOps.Multiply(diff, diff));
-                            count++;
                         }
                     }
                 }

--- a/src/Video/ActionRecognition/VideoMAE.cs
+++ b/src/Video/ActionRecognition/VideoMAE.cs
@@ -38,6 +38,14 @@ namespace AiDotNet.Video.ActionRecognition;
 /// - Joint space-time attention mechanism
 /// </para>
 /// <para>
+/// <b>Pretraining:</b> call <see cref="PretrainMAE"/> repeatedly on unlabeled clips; each call is one
+/// optimizer step on the masked-patch reconstruction loss (per-patch normalised pixel targets by default,
+/// see <see cref="VideoMAEOptions.NormalizeTarget"/>). Then fine-tune the classifier with <c>Train</c>.
+/// The encoder here is a convolutional stand-in for the paper's ViT: masked patches are kept at zero
+/// through every encoder block (the sparse-convolution form of dropping them), and the decoder is a small
+/// convolutional stack with a per-patch pixel head.
+/// </para>
+/// <para>
 /// <b>Reference:</b> Tong et al., "VideoMAE: Masked Autoencoders are Data-Efficient Learners for Self-Supervised Video Pre-Training"
 /// NeurIPS 2022.
 /// </para>
@@ -323,10 +331,27 @@ public partial class VideoMAE<T> : NeuralNetworkBase<T>
     }
 
     /// <summary>
-    /// Performs masked autoencoder pretraining on a video.
+    /// Performs one masked-autoencoder pretraining step on a video clip: masks it, reconstructs the
+    /// masked tubelet patches, and updates the encoder, decoder and reconstruction head to reduce the
+    /// reconstruction error.
     /// </summary>
     /// <param name="video">Video tensor [T, C, H, W] or [B, T, C, H, W].</param>
-    /// <returns>Reconstruction loss.</returns>
+    /// <returns>This step's reconstruction loss, measured before the weight update.</returns>
+    /// <remarks>
+    /// <para>
+    /// Call this repeatedly over unlabeled clips to pretrain (Tong et al. 2022, Sec. 3), then fine-tune
+    /// with <see cref="Train(Tensor{T}, Tensor{T})"/>. Each call samples a new tube mask at the configured mask ratio, runs the
+    /// masked encoder and the reconstruction decoder on the autodiff tape, takes the mean squared error
+    /// over the masked patches only (against per-patch normalised pixels by default - see
+    /// <see cref="VideoMAEOptions.NormalizeTarget"/>), and applies one optimizer step through the
+    /// library's standard caller-owned-tape training path. The optimizer is the one passed to the
+    /// constructor, or the model's default Adam.
+    /// </para>
+    /// <para>
+    /// It used to compute the loss and return it without back-propagating or updating anything, so
+    /// "pretraining" never changed a weight.
+    /// </para>
+    /// </remarks>
     public T PretrainMAE(Tensor<T> video)
     {
         if (!_useNativeMode)
@@ -334,26 +359,42 @@ public partial class VideoMAE<T> : NeuralNetworkBase<T>
             throw new InvalidOperationException("Pretraining is not supported in ONNX mode.");
         }
 
-        bool hasBatch = video.Rank == 5;
-        if (!hasBatch)
+        if (video is null)
         {
-            video = AddBatchDimension5D(video);
+            throw new ArgumentNullException(nameof(video));
         }
+
+        if (video.Rank != 4 && video.Rank != 5)
+        {
+            throw new ArgumentException("PretrainMAE expects a clip [T, C, H, W] or a batch of clips [B, T, C, H, W].", nameof(video));
+        }
+
+        // The clip is data, not a parameter, so promoting it with a copy costs no gradient path.
+        var clip = video.Rank == 5 ? video : AddBatchDimension5D(video);
 
         // Create the tube mask on this clip's own patch grid (one spatial mask per clip, shared by
         // every tubelet).
-        var mask = CreateTubeMask(video.Shape[0], video.Shape[3] / _patchSize, video.Shape[4] / _patchSize);
+        var mask = CreateTubeMask(clip.Shape[0], clip.Shape[3] / _patchSize, clip.Shape[4] / _patchSize);
 
-        // Encode visible patches
-        var visibleFeatures = EncodeVisiblePatches(video, mask);
-
-        // Decode to reconstruct full video
-        var reconstruction = DecodeForReconstruction(visibleFeatures);
-
-        // Compute reconstruction loss on masked patches
-        T loss = ComputeReconstructionLoss(reconstruction, video, mask);
-
-        return loss;
+        bool wasTraining = IsTrainingMode;
+        SetTrainingMode(true);
+        try
+        {
+            // The forward and the loss are recorded on this tape; BackwardAndStepOnPrecomputedLoss runs
+            // backward over it and applies the optimizer step, the same entry point the library's other
+            // custom-objective models (NeRF, TVAE, TabDDPM, the GANs) train through.
+            using var tape = new AiDotNet.Tensors.Engines.Autodiff.GradientTape<T>();
+            var reconstruction = DecodeForReconstruction(EncodeVisiblePatches(clip, mask));
+            var loss = ReconstructionObjective(reconstruction, clip, mask);
+            return BackwardAndStepOnPrecomputedLoss(tape, loss, _optimizer);
+        }
+        finally
+        {
+            if (!wasTraining)
+            {
+                SetTrainingMode(false);
+            }
+        }
     }
 
     /// <summary>
@@ -700,38 +741,58 @@ public partial class VideoMAE<T> : NeuralNetworkBase<T>
         return mask;
     }
 
-    private Tensor<T> EncodeVisiblePatches(Tensor<T> video, bool[,,] mask)
+    /// <summary>
+    /// Runs the pretraining encoder over only the VISIBLE tubelet patches of a clip.
+    /// </summary>
+    /// <param name="video">The clip [B, T, C, H, W].</param>
+    /// <param name="mask">Tube mask [B, patchesH, patchesW] (true = masked), shared by all tubelets.</param>
+    /// <returns>Encoder features [B * numTubelets, numFeatures, patchesH, patchesW], exactly zero at
+    /// every masked patch.</returns>
+    /// <remarks>
+    /// <para>
+    /// The paper's encoder drops masked tokens and runs its transformer on the visible ones only
+    /// (Tong et al. 2022, Sec. 3.3), so masked patches contribute nothing to it. This model's encoder is
+    /// a stack of 3x3 convolutions over the patch grid, which cannot drop grid positions: a convolution
+    /// needs the whole grid. It is made sparse the way masked-image-modelling work on convolutional
+    /// encoders does it (SparK, Tian et al. 2023; ConvNeXt V2's FCMAE, Woo et al. 2023): the binary
+    /// visibility mask is applied to the patch embedding and again after EVERY encoder block. A masked
+    /// position then holds exactly zero at every block input, so it adds nothing to its visible
+    /// neighbours (the same as zero padding), and it never accumulates a value of its own.
+    /// </para>
+    /// <para>
+    /// Previously the mask was applied once, to the embedding, by writing zeros into it in place. Two
+    /// defects followed. The 3x3 blocks immediately refilled every masked position from its visible
+    /// neighbours plus the block's bias, so from the second block on the encoder was processing masked
+    /// positions as ordinary tokens. And the in-place write was invisible to the autodiff tape, so the
+    /// backward pass still routed gradient through the embedding's masked outputs into the
+    /// patch-embedding weights - weighted by the masked patches' own pixels, i.e. the very content the
+    /// model is meant to predict without seeing. Both masks here are recorded multiplies, so the
+    /// masked positions receive neither a value nor a gradient.
+    /// </para>
+    /// <para>
+    /// The decoder receives these features with zeros at the masked positions; the paper's learned mask
+    /// token is not added (it would be a new parameter), so a masked position enters the decoder as a
+    /// fixed zero "mask token" and the decoder's convolutions fill it from the visible context.
+    /// </para>
+    /// </remarks>
+    internal Tensor<T> EncodeVisiblePatches(Tensor<T> video, bool[,,] mask)
     {
         var patchEmbedded = PatchEmbed(video);
 
-        // Apply mask (zero out masked patches)
-        // Note: patchEmbedded has shape [B * numTubelets, C, H, W] while mask has shape [B, patchesH, patchesW]
+        // patchEmbedded is [B * numTubelets, F, patchesH, patchesW]; mask is [B, patchesH, patchesW].
         int batchSize = video.Shape[0];
         int numTubelets = video.Shape[1] / _tubeletSize;
-        int channels = patchEmbedded.Shape[1];
-        int height = patchEmbedded.Shape[2];
-        int width = patchEmbedded.Shape[3];
-
-        for (int b = 0; b < batchSize; b++)
+        if (mask.GetLength(0) != batchSize
+            || mask.GetLength(1) != patchEmbedded.Shape[2]
+            || mask.GetLength(2) != patchEmbedded.Shape[3])
         {
-            for (int t = 0; t < numTubelets; t++)
-            {
-                int tubeletIdx = b * numTubelets + t;
-                for (int h = 0; h < height; h++)
-                {
-                    for (int w = 0; w < width; w++)
-                    {
-                        if (mask[b, h % mask.GetLength(1), w % mask.GetLength(2)])
-                        {
-                            for (int c = 0; c < channels; c++)
-                            {
-                                patchEmbedded[tubeletIdx, c, h, w] = NumOps.Zero;
-                            }
-                        }
-                    }
-                }
-            }
+            throw new ArgumentException(
+                $"The mask [{mask.GetLength(0)}, {mask.GetLength(1)}, {mask.GetLength(2)}] does not match the clip's " +
+                $"batch size {batchSize} and patch grid [{patchEmbedded.Shape[2]}, {patchEmbedded.Shape[3]}].",
+                nameof(mask));
         }
+
+        var visible = BuildPatchMask(mask, numTubelets, patchEmbedded.Shape[1], keepMasked: false);
 
         // Apply encoder blocks. Each Layers[i] is a shape-preserving
         // Conv(numFeatures, 3, 1, 1) whose built-in ReLU records on the autodiff
@@ -744,14 +805,59 @@ public partial class VideoMAE<T> : NeuralNetworkBase<T>
         // magnitude grow monotonically across the 12-block stack, blowing up the
         // classification logits and saturating the softmax so the output stops
         // responding to input changes.
-        var features = patchEmbedded;
+        var features = Engine.TensorMultiply(patchEmbedded, visible);
         int encoderLayerCount = Math.Min(VideoMAELayerLayout.EncoderEndIndex, Layers.Count);
         for (int i = VideoMAELayerLayout.FirstEncoderBlockIndex; i < encoderLayerCount; i++)
         {
-            features = Layers[i].Forward(features);
+            features = Engine.TensorMultiply(Layers[i].Forward(features), visible);
         }
 
         return features;
+    }
+
+    /// <summary>
+    /// Expands a tube mask to a 0/1 tensor over a per-tubelet feature or prediction map.
+    /// </summary>
+    /// <param name="mask">Tube mask [B, patchesH, patchesW] (true = masked).</param>
+    /// <param name="numTubelets">Tubelets per clip.</param>
+    /// <param name="channels">Channel extent of the map the result multiplies.</param>
+    /// <param name="keepMasked">True for 1 at masked patches (the loss), false for 1 at visible patches
+    /// (the encoder).</param>
+    /// <returns>A [B * numTubelets, channels, patchesH, patchesW] constant.</returns>
+    private Tensor<T> BuildPatchMask(bool[,,] mask, int numTubelets, int channels, bool keepMasked)
+    {
+        int batchSize = mask.GetLength(0);
+        int patchesH = mask.GetLength(1);
+        int patchesW = mask.GetLength(2);
+        int plane = patchesH * patchesW;
+
+        var result = new Tensor<T>([batchSize * numTubelets, channels, patchesH, patchesW]);
+        var span = result.Data.Span;
+        for (int b = 0; b < batchSize; b++)
+        {
+            for (int t = 0; t < numTubelets; t++)
+            {
+                int rowOffset = (b * numTubelets + t) * channels * plane;
+                for (int ph = 0; ph < patchesH; ph++)
+                {
+                    for (int pw = 0; pw < patchesW; pw++)
+                    {
+                        if (mask[b, ph, pw] != keepMasked)
+                        {
+                            continue;
+                        }
+
+                        int position = ph * patchesW + pw;
+                        for (int c = 0; c < channels; c++)
+                        {
+                            span[rowOffset + c * plane + position] = NumOps.One;
+                        }
+                    }
+                }
+            }
+        }
+
+        return result;
     }
 
     /// <summary>
@@ -760,10 +866,20 @@ public partial class VideoMAE<T> : NeuralNetworkBase<T>
     /// <param name="features">Encoder features [B * numTubelets, numFeatures, patchesH, patchesW].</param>
     /// <returns>Per-patch pixel predictions [B * numTubelets, channels * tubeletSize * P * P, patchesH, patchesW].</returns>
     /// <remarks>
+    /// <para>
     /// The decoder slice is addressed through <see cref="VideoMAELayerLayout"/>. It used to start at a
     /// hard-coded index 15 — the classifier's <c>DenseLayer</c> — so pretraining pushed the encoder maps
     /// through the class head, ran three of the four decoder blocks, used the fourth as the "head", and
     /// never reached the real reconstruction head (whose output is the only one sized to a tubelet patch).
+    /// </para>
+    /// <para>
+    /// Each decoder block is a Conv(numFeatures, 3, 1, 1) with its own ReLU, and nothing else is applied
+    /// between blocks. A second, <c>Tensor.Transform</c>-based GELU used to be stacked on every block's
+    /// output. Transform records no autodiff node, so it severed the tape after every block: a
+    /// reconstruction loss could reach the head and nothing before it - no decoder block, no encoder
+    /// block, no patch embedding. It was also numerically redundant (GELU of a ReLU output is a mild
+    /// squash of a non-negative value). The encoder had the identical defect and was fixed the same way.
+    /// </para>
     /// </remarks>
     internal Tensor<T> DecodeForReconstruction(Tensor<T> features)
     {
@@ -774,7 +890,6 @@ public partial class VideoMAE<T> : NeuralNetworkBase<T>
             for (int i = VideoMAELayerLayout.FirstDecoderBlockIndex; i < VideoMAELayerLayout.ReconstructionHeadIndex; i++)
             {
                 decoded = Layers[i].Forward(decoded);
-                decoded = ApplyGELU(decoded);
             }
 
             decoded = Layers[VideoMAELayerLayout.ReconstructionHeadIndex].Forward(decoded);
@@ -784,7 +899,7 @@ public partial class VideoMAE<T> : NeuralNetworkBase<T>
     }
 
     /// <summary>
-    /// Mean squared error between the predicted and the true pixels of the MASKED tubelet patches.
+    /// Mean squared error between the predicted and the target pixels of the MASKED tubelet patches.
     /// </summary>
     /// <param name="reconstructed">Reconstruction-head output
     /// [B * numTubelets, channels * tubeletSize * P * P, patchesH, patchesW].</param>
@@ -806,11 +921,28 @@ public partial class VideoMAE<T> : NeuralNetworkBase<T>
     /// as a clip had two or more tubelets (IndexOutOfRange from <see cref="PretrainMAE"/>).
     /// </para>
     /// <para>
-    /// The target is raw pixels. The reference implementation's optional per-patch target normalisation
-    /// (<c>normlize_target</c>) is not applied.
+    /// The target is the per-patch normalised pixels by default and the raw pixels when
+    /// <see cref="VideoMAEOptions.NormalizeTarget"/> is off; see <see cref="BuildReconstructionTarget"/>.
+    /// This is the value of the same objective <see cref="PretrainMAE"/> differentiates.
     /// </para>
     /// </remarks>
     internal T ComputeReconstructionLoss(Tensor<T> reconstructed, Tensor<T> original, bool[,,] mask)
+    {
+        using var _ = new AiDotNet.Tensors.Engines.Autodiff.NoGradScope<T>();
+        var loss = ReconstructionObjective(reconstructed, original, mask);
+        return loss.Length > 0 ? loss.Data.Span[0] : NumOps.Zero;
+    }
+
+    /// <summary>
+    /// The masked-patch reconstruction objective as a scalar tensor on the autodiff tape.
+    /// </summary>
+    /// <remarks>
+    /// Expressed as engine operations (subtract, square, multiply by a 0/1 masked-patch tensor, sum, scale)
+    /// so that, recorded on a tape, it back-propagates into the reconstruction head, the decoder, the
+    /// encoder and the patch embedding. The squared error of a VISIBLE patch is multiplied by zero, so it
+    /// contributes neither loss nor gradient.
+    /// </remarks>
+    private Tensor<T> ReconstructionObjective(Tensor<T> reconstructed, Tensor<T> original, bool[,,] mask)
     {
         if (original.Rank != 5)
         {
@@ -845,38 +977,134 @@ public partial class VideoMAE<T> : NeuralNetworkBase<T>
             throw new ArgumentException("The mask does not match the clip's batch size and patch grid.", nameof(mask));
         }
 
-        T loss = NumOps.Zero;
-        int count = 0;
-
+        int maskedPatches = 0;
         for (int b = 0; b < batchSize; b++)
         {
             for (int ph = 0; ph < patchesH; ph++)
             {
                 for (int pw = 0; pw < patchesW; pw++)
                 {
-                    if (!mask[b, ph, pw])
+                    if (mask[b, ph, pw])
                     {
-                        continue;
+                        maskedPatches++;
                     }
+                }
+            }
+        }
 
-                    for (int t = 0; t < numTubelets; t++)
+        // Every masked patch contributes patchDim values in each of the clip's tubelets.
+        long count = (long)maskedPatches * numTubelets * patchDim;
+
+        var target = BuildReconstructionTarget(original, patchesH, patchesW);
+        var maskedOnly = BuildPatchMask(mask, numTubelets, patchDim, keepMasked: true);
+
+        var diff = Engine.TensorSubtract(reconstructed, target);
+        var squaredMasked = Engine.TensorMultiply(Engine.TensorMultiply(diff, diff), maskedOnly);
+        var allAxes = Enumerable.Range(0, squaredMasked.Rank).ToArray();
+        var total = Engine.ReduceSum(squaredMasked, allAxes, keepDims: false);
+
+        // With nothing masked the objective is an honest zero (and so is every gradient).
+        return Engine.TensorMultiplyScalar(total, NumOps.FromDouble(1.0 / Math.Max(1L, count)));
+    }
+
+    /// <summary>
+    /// The per-patch reconstruction target for a clip, laid out like the reconstruction head's output.
+    /// </summary>
+    /// <param name="original">The clip [B, T, C, H, W].</param>
+    /// <param name="patchesH">Patch rows.</param>
+    /// <param name="patchesW">Patch columns.</param>
+    /// <returns>[B * numTubelets, C * tubeletSize * P * P, patchesH, patchesW]: channel
+    /// <c>((ts * C + c) * P + y) * P + x</c> at patch <c>(ph, pw)</c> of tubelet <c>t</c> holds pixel
+    /// <c>original[b, t * tubeletSize + ts, c, ph * P + y, pw * P + x]</c>, normalised or raw.</returns>
+    /// <remarks>
+    /// <para>
+    /// With <see cref="VideoMAEOptions.NormalizeTarget"/> on (the default, as in the paper), every channel
+    /// of every tubelet patch is normalised over its own <c>tubeletSize x P x P</c> pixels:
+    /// <c>(x - mean) / (std + 1e-6)</c> with the unbiased standard deviation. This is the reference
+    /// implementation's <c>normlize_target=True</c> (VideoMAE <c>engine_for_pretraining.py</c>: a
+    /// <c>b (t h w) (p0 p1 p2) c</c> view normalised over the <c>p0 p1 p2</c> axis), which the paper
+    /// inherits from MAE (He et al. 2022, Sec. 4), where it improves representation quality. With it off,
+    /// the target is the raw pixels.
+    /// </para>
+    /// </remarks>
+    private Tensor<T> BuildReconstructionTarget(Tensor<T> original, int patchesH, int patchesW)
+    {
+        if (original.Rank != 5)
+        {
+            throw new ArgumentException("The original clip must be [B, T, C, H, W].", nameof(original));
+        }
+
+        int batchSize = original.Shape[0];
+        int numTubelets = original.Shape[1] / _tubeletSize;
+        int channels = original.Shape[2];
+        int patch = _patchSize;
+        int patchDim = channels * _tubeletSize * patch * patch;
+        int pixelsPerPatchChannel = _tubeletSize * patch * patch;
+        bool normalize = _options.NormalizeTarget;
+
+        var target = new Tensor<T>([batchSize * numTubelets, patchDim, patchesH, patchesW]);
+        var destination = target.Data.Span;
+        int plane = patchesH * patchesW;
+        var values = new double[pixelsPerPatchChannel];
+
+        for (int b = 0; b < batchSize; b++)
+        {
+            for (int t = 0; t < numTubelets; t++)
+            {
+                int row = b * numTubelets + t;
+                for (int ph = 0; ph < patchesH; ph++)
+                {
+                    for (int pw = 0; pw < patchesW; pw++)
                     {
-                        int row = b * numTubelets + t;
-                        for (int ts = 0; ts < _tubeletSize; ts++)
+                        for (int c = 0; c < channels; c++)
                         {
-                            int frame = t * _tubeletSize + ts;
-                            for (int c = 0; c < channels; c++)
+                            int k = 0;
+                            for (int ts = 0; ts < _tubeletSize; ts++)
+                            {
+                                int frame = t * _tubeletSize + ts;
+                                for (int y = 0; y < patch; y++)
+                                {
+                                    for (int x = 0; x < patch; x++)
+                                    {
+                                        values[k++] = NumOps.ToDouble(
+                                            original[b, frame, c, ph * patch + y, pw * patch + x]);
+                                    }
+                                }
+                            }
+
+                            double mean = 0.0;
+                            double scale = 1.0;
+                            if (normalize)
+                            {
+                                for (int i = 0; i < values.Length; i++)
+                                {
+                                    mean += values[i];
+                                }
+                                mean /= values.Length;
+
+                                double sumSquares = 0.0;
+                                for (int i = 0; i < values.Length; i++)
+                                {
+                                    double d = values[i] - mean;
+                                    sumSquares += d * d;
+                                }
+
+                                double unbiasedVariance = values.Length > 1 ? sumSquares / (values.Length - 1) : 0.0;
+                                scale = 1.0 / (Math.Sqrt(unbiasedVariance) + 1e-6);
+                            }
+
+                            k = 0;
+                            for (int ts = 0; ts < _tubeletSize; ts++)
                             {
                                 for (int y = 0; y < patch; y++)
                                 {
                                     for (int x = 0; x < patch; x++)
                                     {
                                         int channel = (((ts * channels) + c) * patch + y) * patch + x;
-                                        T diff = NumOps.Subtract(
-                                            reconstructed[row, channel, ph, pw],
-                                            original[b, frame, c, ph * patch + y, pw * patch + x]);
-                                        loss = NumOps.Add(loss, NumOps.Multiply(diff, diff));
-                                        count++;
+                                        double value = normalize ? (values[k] - mean) * scale : values[k];
+                                        destination[(row * patchDim + channel) * plane + ph * patchesW + pw] =
+                                            NumOps.FromDouble(value);
+                                        k++;
                                     }
                                 }
                             }
@@ -886,7 +1114,7 @@ public partial class VideoMAE<T> : NeuralNetworkBase<T>
             }
         }
 
-        return count > 0 ? NumOps.Divide(loss, NumOps.FromDouble(count)) : NumOps.Zero;
+        return target;
     }
 
     private Tensor<T> GlobalAveragePool(Tensor<T> input)
@@ -905,17 +1133,6 @@ public partial class VideoMAE<T> : NeuralNetworkBase<T>
         var reshaped = Engine.Reshape(input, new[] { batchSize, channels, height * width });
         var meanBC = Engine.ReduceMean(reshaped, new[] { 2 }, keepDims: false);  // [B, C]
         return Engine.Reshape(meanBC, new[] { batchSize, channels, 1, 1 });
-    }
-
-    private Tensor<T> ApplyGELU(Tensor<T> input)
-    {
-        return input.Transform((v, _) =>
-        {
-            double x = Convert.ToDouble(v);
-            double c = Math.Sqrt(2.0 / Math.PI);
-            double gelu = 0.5 * x * (1.0 + Math.Tanh(c * (x + 0.044715 * x * x * x)));
-            return NumOps.FromDouble(gelu);
-        });
     }
 
     private Tensor<T> ApplySoftmax(Tensor<T> input)

--- a/src/Video/ActionRecognition/VideoMAELayerLayout.cs
+++ b/src/Video/ActionRecognition/VideoMAELayerLayout.cs
@@ -1,0 +1,57 @@
+namespace AiDotNet.Video.ActionRecognition;
+
+/// <summary>
+/// Index map of the default VideoMAE layer stack built by
+/// <see cref="AiDotNet.Helpers.LayerHelper{T}.CreateDefaultVideoMAELayers"/>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// VideoMAE does not run its <c>Layers</c> list as one sequential chain: the classification forward, the
+/// pretraining encoder and the reconstruction decoder each pick out their own slice of it. Those slices
+/// used to be addressed with bare numbers in the model while the factory built the list from loop counts,
+/// so the two could drift apart silently — and did: the decoder was addressed as starting at index 15,
+/// which is the classifier's <c>DenseLayer</c>, so pretraining ran the encoder features through the class
+/// head and never reached the reconstruction head. Both the factory and the model now read the layout
+/// from here.
+/// </para>
+/// <para>
+/// Layout: <c>[patch-embed | encoder blocks | feature-reduce conv, global pool, classifier |
+/// decoder blocks | reconstruction head]</c>.
+/// </para>
+/// </remarks>
+internal static class VideoMAELayerLayout
+{
+    /// <summary>Number of encoder blocks in the default stack.</summary>
+    public const int EncoderBlockCount = 12;
+
+    /// <summary>Number of reconstruction-decoder blocks in the default stack.</summary>
+    public const int DecoderBlockCount = 4;
+
+    /// <summary>The tubelet patch-embedding convolution.</summary>
+    public const int PatchEmbedIndex = 0;
+
+    /// <summary>First encoder block.</summary>
+    public const int FirstEncoderBlockIndex = PatchEmbedIndex + 1;
+
+    /// <summary>One past the last encoder block.</summary>
+    public const int EncoderEndIndex = FirstEncoderBlockIndex + EncoderBlockCount;
+
+    /// <summary>The 1x1 feature-reduce convolution at the start of the classification head.</summary>
+    public const int FeatureReduceIndex = EncoderEndIndex;
+
+    /// <summary>The classification head's global pooling layer (not on the model's forward path; the
+    /// model pools per tubelet itself).</summary>
+    public const int GlobalPoolIndex = FeatureReduceIndex + 1;
+
+    /// <summary>The final classification <c>DenseLayer</c> (raw logits).</summary>
+    public const int ClassifierIndex = GlobalPoolIndex + 1;
+
+    /// <summary>First reconstruction-decoder block.</summary>
+    public const int FirstDecoderBlockIndex = ClassifierIndex + 1;
+
+    /// <summary>The reconstruction head, which predicts every pixel of a tubelet patch.</summary>
+    public const int ReconstructionHeadIndex = FirstDecoderBlockIndex + DecoderBlockCount;
+
+    /// <summary>Total number of layers in the default stack.</summary>
+    public const int LayerCount = ReconstructionHeadIndex + 1;
+}

--- a/src/Video/Enhancement/BasicVSRPlusPlus.cs
+++ b/src/Video/Enhancement/BasicVSRPlusPlus.cs
@@ -446,8 +446,10 @@ public partial class BasicVSRPlusPlus<T> : VideoSuperResolutionBase<T>
     /// <summary>
     /// Enhances a sequence of video frames using temporal super-resolution.
     /// </summary>
-    /// <param name="frames">Input frames tensor with shape [numFrames, channels, height, width].</param>
-    /// <returns>Enhanced frames tensor with shape [numFrames, channels, height*scale, width*scale].</returns>
+    /// <param name="frames">Input frames tensor with shape [numFrames, channels, height, width], or a single
+    /// frame [channels, height, width].</param>
+    /// <returns>Enhanced frames tensor with shape [numFrames, channels, height*scale, width*scale], or
+    /// [channels, height*scale, width*scale] for a single frame.</returns>
     /// <remarks>
     /// <para>
     /// <b>For Beginners:</b> Pass your low-resolution video frames as a 4D tensor:
@@ -458,6 +460,13 @@ public partial class BasicVSRPlusPlus<T> : VideoSuperResolutionBase<T>
     /// SaveVideoFrames(hrFrames, "output_4x.mp4");
     /// </code>
     /// </para>
+    /// <para>
+    /// A single frame <c>[C, H, W]</c> - the shape this model's own default architecture declares - is
+    /// the degenerate one-frame clip of the super-resolution family contract: it is upscaled as a clip of
+    /// length one (no neighbours, so no propagation) and returned without the frame axis. It used to be
+    /// read as a clip of <c>C</c> two-dimensional "frames", so the model could not run on its own declared
+    /// input shape.
+    /// </para>
     /// </remarks>
     public Tensor<T> EnhanceVideo(Tensor<T> frames)
     {
@@ -466,6 +475,14 @@ public partial class BasicVSRPlusPlus<T> : VideoSuperResolutionBase<T>
 
         if (_useNativeMode)
         {
+            if (frames.Rank == 3)
+            {
+                // Recorded reshapes, so training through a single frame keeps its gradient path.
+                var clip = Engine.Reshape(frames, [1, frames.Shape[0], frames.Shape[1], frames.Shape[2]]);
+                var enhanced = EnhanceVideoNative(clip);
+                return Engine.Reshape(enhanced, [enhanced.Shape[1], enhanced.Shape[2], enhanced.Shape[3]]);
+            }
+
             return EnhanceVideoNative(frames);
         }
         else

--- a/src/Video/Generation/OpenSora.cs
+++ b/src/Video/Generation/OpenSora.cs
@@ -345,10 +345,25 @@ public partial class OpenSora<T> : NeuralNetworkBase<T>
     /// <summary>
     /// Performs a single denoising prediction step on the input latents.
     /// </summary>
-    /// <param name="input">Input latent tensor [B, C, H, W].</param>
-    /// <returns>Predicted denoised output.</returns>
+    /// <param name="input">Input latent tensor [B, C, H, W], or a single latent [C, H, W].</param>
+    /// <returns>Predicted denoised output, in the input's shape.</returns>
+    /// <remarks>
+    /// A single latent <c>[C, H, W]</c> - the shape this model's default architecture declares - is
+    /// denoised as a batch of one and returned without the batch axis, the same promotion the model
+    /// already applies to single images elsewhere (see <c>AddBatchDimension</c>). The denoiser indexes
+    /// axis 3 of its features, so a rank-3 latent used to throw IndexOutOfRange.
+    /// </remarks>
     protected override Tensor<T> PredictCore(Tensor<T> input)
     {
+        if (input is null)
+            throw new ArgumentNullException(nameof(input));
+
+        if (input.Rank == 3)
+        {
+            var denoised = PredictCore(AddBatchDimension(input));
+            return denoised.Reshape([denoised.Shape[1], denoised.Shape[2], denoised.Shape[3]]);
+        }
+
         // Create default time embedding at t=0.5 (mid-point)
         var timeEmbed = CreateTimeEmbedding(0.5);
 

--- a/src/Video/Inpainting/ProPainter.cs
+++ b/src/Video/Inpainting/ProPainter.cs
@@ -261,6 +261,19 @@ public partial class ProPainter<T> : VideoInpaintingBase<T>
         // inference through RunImagePath makes Predict reflect the learned weights, exactly as
         // ForwardForTraining does, so the two agree. The flow/warp/blend branch of InpaintFrame is
         // a non-differentiable, dead pathway and is intentionally omitted here too.
+        if (input is null)
+            throw new ArgumentNullException(nameof(input));
+
+        // A single frame [C, H, W] - the shape this model's default architecture declares - is the
+        // one-frame clip: frames are reconstructed independently (the image path treats the frame axis
+        // as its batch), so it runs as [1, C, H, W] and comes back without that axis. The image path
+        // reads axis 3, so a rank-3 frame used to throw IndexOutOfRange.
+        if (input.Rank == 3)
+        {
+            var frame = RunReconstruction(Engine.Reshape(input, [1, input.Shape[0], input.Shape[1], input.Shape[2]]));
+            return Engine.Reshape(frame, [frame.Shape[1], frame.Shape[2], frame.Shape[3]]);
+        }
+
         return RunReconstruction(input);
     }
 

--- a/src/Video/Motion/RAFT.cs
+++ b/src/Video/Motion/RAFT.cs
@@ -264,8 +264,31 @@ public partial class RAFT<T> : OpticalFlowBase<T>
     }
 
     /// <inheritdoc/>
+    /// <remarks>
+    /// Takes a stacked frame pair <c>[batch, 2*channels, height, width]</c> or, unbatched,
+    /// <c>[2*channels, height, width]</c> - the two forms the inherited <see cref="OpticalFlowBase{T}"/>
+    /// input layout declares. The unbatched pair is promoted to a batch of one and the unit batch axis is
+    /// removed from the flow, so it returns <c>[2, height, width]</c>. It used to index <c>Shape[3]</c> of
+    /// whatever it was given, so an unbatched pair threw IndexOutOfRange.
+    /// </remarks>
     protected override Tensor<T> PredictCore(Tensor<T> input)
     {
+        if (input is null)
+            throw new ArgumentNullException(nameof(input));
+
+        if (input.Rank == 3)
+        {
+            var flow = PredictCore(PromoteToBatchedTensor(input));
+            return flow.Rank == 4 && flow.Shape[0] == 1
+                ? Engine.Reshape(flow, [flow.Shape[1], flow.Shape[2], flow.Shape[3]])
+                : flow;
+        }
+
+        if (input.Rank != 4)
+            throw new ArgumentException(
+                "RAFT expects a stacked frame pair [2*channels, height, width] or [batch, 2*channels, height, width], "
+                + $"got rank {input.Rank}.", nameof(input));
+
         var frame1 = SliceChannels(input, 0, _channels);
         var frame2 = SliceChannels(input, _channels, _channels * 2);
         var flowIterations = ForwardIterative(frame1, frame2);

--- a/src/Video/OpticalFlowBase.cs
+++ b/src/Video/OpticalFlowBase.cs
@@ -40,12 +40,13 @@ namespace AiDotNet.Video;
 /// </para>
 /// </remarks>
 [TensorLayout(TensorAxis.Batch, TensorAxis.Channels, TensorAxis.Height, TensorAxis.Width,
-    Direction = TensorLayoutDirection.Input,
+    Direction = TensorLayoutDirection.Input, BatchOptional = true,
     Note = "A frame PAIR stacked on the channel axis, so this axis is 2*channels. PredictCore "
-         + "rejects an odd channel count for exactly that reason.")]
+         + "rejects an odd channel count for exactly that reason. An unbatched pair [2*C, H, W] is "
+         + "promoted to a batch of one.")]
 [TensorLayout(TensorAxis.Batch, TensorAxis.Channels, TensorAxis.Height, TensorAxis.Width,
-    Direction = TensorLayoutDirection.Output,
-    Note = "A flow field: two channels, dx and dy, at the input resolution.")]
+    Direction = TensorLayoutDirection.Output, BatchOptional = true,
+    Note = "A flow field: two channels, dx and dy, at the input resolution. Unbatched in, unbatched out.")]
 public abstract partial class OpticalFlowBase<T> : VideoNeuralNetworkBase<T>, IShapeContract
 {
     /// <summary>
@@ -53,10 +54,11 @@ public abstract partial class OpticalFlowBase<T> : VideoNeuralNetworkBase<T>, IS
     /// </summary>
     /// <remarks>
     /// <para>
-    /// Read from <see cref="PredictCore"/> rather than probed. It requires rank 4
+    /// Read from <see cref="PredictCore"/> rather than probed. It takes rank 4
     /// <c>[batch, 2*channels, height, width]</c> - two frames stacked on the channel axis, which is
     /// why it rejects an odd channel count - and returns one flow field per sample at the input
-    /// resolution.
+    /// resolution. A rank-3 <c>[2*channels, height, width]</c> pair is the same contract without the
+    /// batch axis, and returns <c>[2, height, width]</c>.
     /// </para>
     /// <para>
     /// The channel axis is <c>Fixed(2)</c> and NOT derived from the input's, which is the whole point
@@ -71,6 +73,16 @@ public abstract partial class OpticalFlowBase<T> : VideoNeuralNetworkBase<T>, IS
     /// </remarks>
     public virtual IReadOnlyList<OutputAxisContract>? OutputAxesFor(int inputRank)
     {
+        if (inputRank == 3)
+        {
+            return
+            [
+                new OutputAxisContract(TensorAxis.Channels, AxisRelation.Fixed(2)),
+                new OutputAxisContract(TensorAxis.Height, AxisRelation.Same(TensorAxis.Height)),
+                new OutputAxisContract(TensorAxis.Width, AxisRelation.Same(TensorAxis.Width)),
+            ];
+        }
+
         if (inputRank != 4) return null;
         return
         [
@@ -324,11 +336,50 @@ public abstract partial class OpticalFlowBase<T> : VideoNeuralNetworkBase<T>, IS
     }
 
     /// <inheritdoc />
+    /// <remarks>
+    /// <para>
+    /// Accepts a stacked frame pair either batched, <c>[batch, 2*channels, height, width]</c>, or as a
+    /// single unbatched sample, <c>[2*channels, height, width]</c>. The unbatched form is what most of the
+    /// family's architectures declare (<c>InputType.ThreeDimensional</c> with <c>InputDepth</c> equal to
+    /// the stacked pair's channel count, so <c>GetInputShape()</c> is <c>[2*channels, H, W]</c>). It is
+    /// promoted to a batch of one with the shared <see cref="NeuralNetworkBase{T}.PromoteToBatchedTensor"/>
+    /// helper and the unit batch axis is removed from the result - unbatched in, unbatched out, the same
+    /// rule the base <c>PredictCore</c> applies to every model that inherits it.
+    /// </para>
+    /// <para>
+    /// This used to reject every rank-3 input with "Input must be rank 4", so every pair-declaring model
+    /// that relies on this method failed <c>Predict</c> on a tensor of its own declared input shape.
+    /// </para>
+    /// </remarks>
     protected override Tensor<T> PredictCore(Tensor<T> input)
     {
+        if (input is null)
+            throw new ArgumentNullException(nameof(input));
+
+        if (input.Rank == 3)
+        {
+            var flow = PredictBatchedPair(PromoteToBatchedTensor(input));
+            if (flow.Rank != 4 || flow.Shape[0] != 1)
+                return flow;
+
+            // Engine.Reshape (not a raw copy) so the squeeze stays on the tape: PredictCore is
+            // deliberately differentiable with respect to the frames (see the narrow below).
+            return Engine.Reshape(flow, [flow.Shape[1], flow.Shape[2], flow.Shape[3]]);
+        }
+
+        return PredictBatchedPair(input);
+    }
+
+    /// <summary>
+    /// Estimates flow for a batched stacked pair <c>[batch, 2*channels, height, width]</c>.
+    /// </summary>
+    private Tensor<T> PredictBatchedPair(Tensor<T> input)
+    {
         // For optical flow, input should contain two frames stacked [batch, 2*channels, height, width]
-        if (input.Rank < 4)
-            throw new ArgumentException($"Input must be rank 4 [batch, 2*channels, height, width], got rank {input.Rank}.", nameof(input));
+        if (input.Rank != 4)
+            throw new ArgumentException(
+                "Input must be rank 3 [2*channels, height, width] or rank 4 [batch, 2*channels, height, width], "
+                + $"got rank {input.Rank}.", nameof(input));
         if (input.Shape[1] % 2 != 0)
             throw new ArgumentException($"Input channel dimension must be even (two frames stacked), got {input.Shape[1]}.", nameof(input));
         int batch = input.Shape[0];

--- a/src/Video/Options/VideoMAEOptions.cs
+++ b/src/Video/Options/VideoMAEOptions.cs
@@ -7,4 +7,25 @@ namespace AiDotNet.Video.Options;
 /// </summary>
 public class VideoMAEOptions : NeuralNetworkOptions
 {
+    /// <summary>
+    /// Gets or sets whether masked-autoencoder pretraining reconstructs per-patch NORMALISED pixels
+    /// rather than raw pixels. Default: <c>true</c>, the paper's setting.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// When on, <c>PretrainMAE</c>'s target for each channel of each masked tubelet patch is that patch's
+    /// pixels standardised over its own <c>tubeletSize x 16 x 16</c> values, <c>(x - mean) / (std + 1e-6)</c>
+    /// with the unbiased standard deviation. This is the VideoMAE reference implementation's
+    /// <c>normlize_target=True</c> default (Tong et al. 2022), carried over from MAE (He et al. 2022,
+    /// Sec. 4), where predicting normalised patches improves the learned representation: the model
+    /// spends its capacity on local structure rather than on each patch's brightness and contrast.
+    /// </para>
+    /// <para>
+    /// When off, the target is the raw pixel values. Classification (<c>Predict</c>/<c>Train</c>) is not
+    /// affected either way.
+    /// </para>
+    /// <para><b>For Beginners:</b> Leave this on unless you need the reconstruction loss in raw pixel
+    /// units (for example, to compare against an older raw-pixel run).</para>
+    /// </remarks>
+    public bool NormalizeTarget { get; set; } = true;
 }

--- a/src/Video/Understanding/VideoCLIP.cs
+++ b/src/Video/Understanding/VideoCLIP.cs
@@ -179,15 +179,26 @@ public partial class VideoCLIP<T> : NeuralNetworkBase<T>
 
     #region Constructors
 
+    /// <summary>Default clip length (frames) when neither the caller nor the architecture declares one.</summary>
+    private const int DefaultNumFrames = 32;
+
     /// <summary>
-    /// Initializes a new instance with default architecture settings.
+    /// Initializes a new instance with default architecture settings (32-frame 224x224 RGB clips).
     /// </summary>
+    /// <remarks>
+    /// The declared input is the clip the model encodes, <c>[32, 3, 224, 224]</c>
+    /// (<see cref="Enums.InputType.FourDimensional"/> with <c>inputFrames</c> equal to the default
+    /// <c>numFrames</c>), matching the model's <c>[Frames, Channels, Height, Width]</c> input layout. It used
+    /// to be <see cref="Enums.InputType.ThreeDimensional"/>, i.e. a single <c>[3, 224, 224]</c> frame, which
+    /// <see cref="EncodeVideo"/> cannot take: a tensor of the model's own declared input shape failed Predict.
+    /// </remarks>
     public VideoCLIP()
         : this(new NeuralNetworkArchitecture<T>(
-            inputType: Enums.InputType.ThreeDimensional,
+            inputType: Enums.InputType.FourDimensional,
             taskType: Enums.NeuralNetworkTaskType.MultiClassClassification,
             inputHeight: 224, inputWidth: 224, inputDepth: 3,
-            outputSize: 400))
+            outputSize: 400,
+            inputFrames: DefaultNumFrames))
     {
     }
 
@@ -195,7 +206,9 @@ public partial class VideoCLIP<T> : NeuralNetworkBase<T>
     /// Initializes a new instance of the VideoCLIP class.
     /// </summary>
     /// <param name="architecture">The neural network architecture configuration.</param>
-    /// <param name="numFrames">Number of video frames to process.</param>
+    /// <param name="numFrames">Number of video frames per clip (default: 32). When the architecture declares a
+    /// frame count (<see cref="NeuralNetworkArchitecture{T}.InputFrames"/> &gt; 0) that count is used, as for
+    /// VideoMAE and TimeSformer; passing a different non-default value throws.</param>
     /// <param name="embeddingDim">Dimension of the shared embedding space.</param>
     /// <param name="textMaxLength">Maximum text sequence length.</param>
     /// <param name="vocabSize">Vocabulary size for text encoding.</param>
@@ -217,7 +230,7 @@ public partial class VideoCLIP<T> : NeuralNetworkBase<T>
     /// </remarks>
     public VideoCLIP(
         NeuralNetworkArchitecture<T> architecture,
-        int numFrames = 32,
+        int numFrames = DefaultNumFrames,
         int embeddingDim = 512,
         int textMaxLength = 77,
         int vocabSize = 49408,
@@ -235,7 +248,7 @@ public partial class VideoCLIP<T> : NeuralNetworkBase<T>
         _height = architecture.InputHeight > 0 ? architecture.InputHeight : 224;
         _width = architecture.InputWidth > 0 ? architecture.InputWidth : 224;
         _channels = architecture.InputDepth > 0 ? architecture.InputDepth : 3;
-        _numFrames = numFrames;
+        _numFrames = VideoClipFrameCount.Resolve(architecture, numFrames, DefaultNumFrames);
         _embeddingDim = embeddingDim;
         _textMaxLength = textMaxLength;
         _vocabSize = vocabSize;
@@ -1117,6 +1130,32 @@ public partial class VideoCLIP<T> : NeuralNetworkBase<T>
     #endregion
 
     #region Abstract Implementation
+
+    /// <summary>
+    /// The shape the lazy layers are resolved from ahead of the first forward: ONE frame,
+    /// <c>[1, C, H, W]</c>.
+    /// </summary>
+    /// <remarks>
+    /// The layer stack runs per frame (the spatial encoder consumes frames, not clips), so the
+    /// architecture-driven lazy-shape walk must start from a frame. It used to get exactly that by
+    /// accident: the default architecture declared a single <c>[3, 224, 224]</c> frame. Now that it declares
+    /// the clip Predict takes, <c>[Frames, C, H, W]</c>, the base walk would start from a rank-5 tensor the
+    /// first convolution rejects, leave the stack unresolved until the first forward, and under-report
+    /// <c>ParameterCount</c> until then (38.0M instead of 211.1M for the default model) - the count that
+    /// memory decisions such as weight streaming are gated on.
+    /// </remarks>
+    protected override int[]? TryGetArchitectureInputShape()
+    {
+        if (Architecture.IsLayerOnly)
+        {
+            return base.TryGetArchitectureInputShape();
+        }
+
+        int channels = Architecture.InputDepth > 0 ? Architecture.InputDepth : 3;
+        int height = Architecture.InputHeight > 0 ? Architecture.InputHeight : 224;
+        int width = Architecture.InputWidth > 0 ? Architecture.InputWidth : 224;
+        return [1, channels, height, width];
+    }
 
     /// <inheritdoc/>
     protected override void InitializeLayers()

--- a/src/Video/VideoClipFrameCount.cs
+++ b/src/Video/VideoClipFrameCount.cs
@@ -1,0 +1,53 @@
+using AiDotNet.NeuralNetworks;
+
+namespace AiDotNet.Video;
+
+/// <summary>
+/// The one rule for reconciling a clip model's <c>numFrames</c> constructor argument with the frame count
+/// its architecture declares.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The architecture is the model's declared input contract: for a temporal-video architecture
+/// <c>GetInputShape()</c> is <c>[InputFrames, C, H, W]</c>, and the auto-batching rank check, generated
+/// fixtures and serving all size their inputs from it. So a frame count the architecture declares
+/// (<see cref="NeuralNetworkArchitecture{T}.InputFrames"/> &gt; 0) wins - the rule BSVD already applies. An
+/// explicit <c>numFrames</c> that disagrees with it is rejected rather than silently overridden, since the
+/// two would describe different clips.
+/// </para>
+/// <para>
+/// Limitation: a parameter's default value cannot be told apart from the same value passed explicitly, so
+/// passing exactly the default defers to the architecture instead of throwing.
+/// </para>
+/// </remarks>
+internal static class VideoClipFrameCount
+{
+    /// <summary>Resolves the clip length a model should be built for.</summary>
+    /// <param name="architecture">The model's architecture.</param>
+    /// <param name="numFrames">The <c>numFrames</c> constructor argument.</param>
+    /// <param name="defaultNumFrames">That argument's default value.</param>
+    /// <returns>The architecture's declared frame count when it declares one; otherwise <paramref name="numFrames"/>.</returns>
+    /// <exception cref="ArgumentException">An explicit, non-default <paramref name="numFrames"/> conflicts
+    /// with the architecture's declared frame count.</exception>
+    internal static int Resolve<T>(NeuralNetworkArchitecture<T> architecture, int numFrames, int defaultNumFrames)
+    {
+        if (architecture is null)
+            throw new ArgumentNullException(nameof(architecture));
+
+        int declared = architecture.InputFrames;
+        if (declared <= 0)
+        {
+            return numFrames;
+        }
+
+        if (numFrames != declared && numFrames != defaultNumFrames)
+        {
+            throw new ArgumentException(
+                $"numFrames ({numFrames}) conflicts with the architecture's declared InputFrames ({declared}). " +
+                "Pass the same value, or omit numFrames to use the architecture's frame count.",
+                nameof(numFrames));
+        }
+
+        return declared;
+    }
+}

--- a/tests/AiDotNet.Tests/UnitTests/Video/ActionRecognition/TimeSformerDeclaredInputTests.cs
+++ b/tests/AiDotNet.Tests/UnitTests/Video/ActionRecognition/TimeSformerDeclaredInputTests.cs
@@ -1,0 +1,58 @@
+using System;
+using System.Linq;
+using AiDotNet.Enums;
+using AiDotNet.Tensors.LinearAlgebra;
+using AiDotNet.Video.ActionRecognition;
+using Xunit;
+
+namespace AiDotNet.Tests.UnitTests.Video.ActionRecognition;
+
+/// <summary>
+/// Pins that TimeSformer's declared input (<c>Architecture.GetInputShape()</c>) is the video clip the model
+/// is built for, and that the model accepts an input of exactly that shape.
+/// </summary>
+public class TimeSformerDeclaredInputTests
+{
+    private static Tensor<float> Random(int[] shape, int seed)
+    {
+        var rng = new System.Random(seed);
+        var t = new Tensor<float>(shape);
+        var span = t.Data.Span;
+        for (int i = 0; i < span.Length; i++)
+        {
+            span[i] = (float)rng.NextDouble();
+        }
+        return t;
+    }
+
+    private static void AssertIsAProbabilityVector(Tensor<float> probs, int classes)
+    {
+        Assert.Equal(classes, probs.Length);
+        double sum = 0;
+        var span = probs.Data.Span;
+        for (int i = 0; i < span.Length; i++)
+        {
+            Assert.False(float.IsNaN(span[i]) || float.IsInfinity(span[i]), $"probability {i} was {span[i]}");
+            sum += span[i];
+        }
+        Assert.Equal(1.0, sum, 3);
+    }
+
+    [Fact]
+    public void DefaultConstructor_DeclaresAnEightFrameClip_AndPredictAcceptsIt()
+    {
+        var model = new TimeSformer<float>();
+
+        // The default model is built for 8-frame 224x224 RGB clips (numFrames = 8 sizes the divided
+        // space-time blocks and the positional table). It used to declare InputType.ThreeDimensional,
+        // i.e. a single [3, 224, 224] frame, so anything that sizes an input from the declared shape
+        // (the auto-batching rank check, generated fixtures, serving) fed it a one-frame "video".
+        var declared = model.Architecture.GetInputShape();
+        Assert.Equal(InputType.FourDimensional, model.Architecture.InputType);
+        Assert.Equal(new[] { 8, 3, 224, 224 }, declared);
+
+        var probs = model.Predict(Random(declared, seed: 3));
+
+        AssertIsAProbabilityVector(probs, classes: 400);
+    }
+}

--- a/tests/AiDotNet.Tests/UnitTests/Video/ActionRecognition/TimeSformerFrameCountTests.cs
+++ b/tests/AiDotNet.Tests/UnitTests/Video/ActionRecognition/TimeSformerFrameCountTests.cs
@@ -1,0 +1,154 @@
+using System;
+using System.Linq;
+using AiDotNet.Enums;
+using AiDotNet.NeuralNetworks;
+using AiDotNet.NeuralNetworks.Layers;
+using AiDotNet.Tensors.LinearAlgebra;
+using AiDotNet.Video.ActionRecognition;
+using Xunit;
+
+namespace AiDotNet.Tests.UnitTests.Video.ActionRecognition;
+
+/// <summary>
+/// TimeSformer must build for the clip length its architecture declares, and follow the library's
+/// unbatched-in / unbatched-out and per-sample-softmax conventions.
+/// </summary>
+/// <remarks>
+/// The frame count sizes the positional table (<c>frames * patches + 1</c> tokens) and is the group size the
+/// divided space-time blocks fall back to when run without an explicit frame count. The constructor used to
+/// take it from <c>numFrames</c> (default 8) and ignore <c>Architecture.InputFrames</c>, so a 16-frame
+/// architecture built an 8-frame model: it reported 8, grouped by 8, and could not run its own declared
+/// clip. The rule is VideoMAE's: the architecture wins, a conflicting explicit value throws.
+/// </remarks>
+public class TimeSformerFrameCountTests
+{
+    private const int Size = 32;
+    private const int Patch = 16;
+    private const int Classes = 5;
+
+    private static NeuralNetworkArchitecture<double> ClipArchitecture(int frames) => new(
+        inputType: InputType.FourDimensional,
+        taskType: NeuralNetworkTaskType.MultiClassClassification,
+        inputFrames: frames, inputDepth: 3, inputHeight: Size, inputWidth: Size,
+        outputSize: Classes);
+
+    private static TimeSformer<double> Small(NeuralNetworkArchitecture<double> architecture, int? numFrames = null)
+        => numFrames is int frames
+            ? new TimeSformer<double>(architecture, numClasses: Classes, embedDim: 16, numHeads: 2, numLayers: 1,
+                numFrames: frames, patchSize: Patch)
+            : new TimeSformer<double>(architecture, numClasses: Classes, embedDim: 16, numHeads: 2, numLayers: 1,
+                patchSize: Patch);
+
+    private static Tensor<double> Random(int[] shape, int seed)
+    {
+        var rng = new System.Random(seed);
+        var t = new Tensor<double>(shape);
+        var span = t.Data.Span;
+        for (int i = 0; i < span.Length; i++)
+        {
+            span[i] = rng.NextDouble();
+        }
+        return t;
+    }
+
+    [Fact]
+    public void Constructor_UsesTheFrameCountDeclaredByTheArchitecture()
+    {
+        var model = Small(ClipArchitecture(frames: 16));
+
+        Assert.Equal(16, model.NumFrames);
+        Assert.Equal(16, model.GetModelMetadata().AdditionalInfo["NumFrames"]);
+
+        // Every divided space-time block is built for the same clip length.
+        var blocks = model.Layers.OfType<TimeSformerBlockLayer<double>>().ToList();
+        Assert.NotEmpty(blocks);
+        Assert.All(blocks, block => Assert.Equal("16", block.GetMetadata()["NumFrames"]));
+    }
+
+    [Fact]
+    public void Predict_OnTheDeclaredSixteenFrameClip_Succeeds()
+    {
+        var model = Small(ClipArchitecture(frames: 16));
+
+        // [16, 3, 32, 32] -> 16 frames x 4 patches + CLS = 65 tokens, which the 16-frame model's positional
+        // table is sized for. Unbatched in, so one unbatched probability vector out.
+        var probabilities = model.Predict(Random(model.Architecture.GetInputShape(), seed: 1));
+
+        Assert.Equal(new[] { Classes }, probabilities.Shape.ToArray());
+    }
+
+    [Fact]
+    public void BlockPlainForward_GroupsTokensByTheDeclaredFrameCount()
+    {
+        var model = Small(ClipArchitecture(frames: 16));
+        var block = model.Layers.OfType<TimeSformerBlockLayer<double>>().First();
+
+        // A 16-frame clip's tokens: 1 CLS + 16 frames x 4 patches, 16 wide.
+        var tokens = Random([1, 1 + 16 * 4, 16], seed: 2);
+
+        // The frame-count-less Forward (used by anything that runs the layer on its own) must group the
+        // patch tokens into the same 16 frames the tokenizer produced, not the default 8.
+        var plain = block.Forward(tokens);
+        var explicitSixteen = block.Forward(tokens, 16);
+
+        Assert.Equal(explicitSixteen.Length, plain.Length);
+        for (int i = 0; i < plain.Length; i++)
+        {
+            Assert.Equal(explicitSixteen.Data.Span[i], plain.Data.Span[i], 12);
+        }
+    }
+
+    [Fact]
+    public void Constructor_ConflictingExplicitFrameCount_Throws()
+    {
+        var ex = Assert.Throws<ArgumentException>(() => Small(ClipArchitecture(frames: 16), numFrames: 4));
+        Assert.Equal("numFrames", ex.ParamName);
+    }
+
+    [Fact]
+    public void Constructor_WithoutADeclaredFrameCount_KeepsTheNumFramesArgument()
+    {
+        var arch = new NeuralNetworkArchitecture<double>(
+            inputType: InputType.ThreeDimensional,
+            taskType: NeuralNetworkTaskType.MultiClassClassification,
+            inputDepth: 3, inputHeight: Size, inputWidth: Size, outputSize: Classes);
+
+        Assert.Equal(4, Small(arch, numFrames: 4).NumFrames);
+    }
+
+    [Fact]
+    public void Predict_UnbatchedClip_ReturnsAnUnbatchedProbabilityVector()
+    {
+        var model = Small(ClipArchitecture(frames: 4));
+
+        // Classify documents [NumClasses] for a [T, C, H, W] clip, the output layout is batch-optional,
+        // and the base PredictCore squeezes the batch it adds. It returned [1, NumClasses].
+        var probabilities = model.Predict(Random([4, 3, Size, Size], seed: 3));
+
+        Assert.Equal(new[] { Classes }, probabilities.Shape.ToArray());
+    }
+
+    [Fact]
+    public void Predict_Batch_NormalisesEachClipSeparately()
+    {
+        var model = Small(ClipArchitecture(frames: 4));
+
+        var probabilities = model.Predict(Random([3, 4, 3, Size, Size], seed: 4));
+
+        // One probability vector per clip. The softmax used to run over the WHOLE [B, NumClasses] tensor,
+        // so the three rows summed to 1 together instead of each summing to 1.
+        Assert.Equal(new[] { 3, Classes }, probabilities.Shape.ToArray());
+        for (int b = 0; b < 3; b++)
+        {
+            double sum = 0;
+            for (int c = 0; c < Classes; c++)
+            {
+                double p = probabilities[b, c];
+                Assert.InRange(p, 0.0, 1.0);
+                sum += p;
+            }
+
+            Assert.Equal(1.0, sum, 9);
+        }
+    }
+}

--- a/tests/AiDotNet.Tests/UnitTests/Video/ActionRecognition/VideoMAEPretrainingFidelityTests.cs
+++ b/tests/AiDotNet.Tests/UnitTests/Video/ActionRecognition/VideoMAEPretrainingFidelityTests.cs
@@ -1,0 +1,298 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using AiDotNet.Enums;
+using AiDotNet.NeuralNetworks;
+using AiDotNet.Tensors.LinearAlgebra;
+using AiDotNet.Video.ActionRecognition;
+using AiDotNet.Video.Options;
+using Xunit;
+
+namespace AiDotNet.Tests.UnitTests.Video.ActionRecognition;
+
+/// <summary>
+/// VideoMAE masked-autoencoder pretraining against the paper (Tong et al. 2022): it must actually train,
+/// its encoder must not see or process masked patches, gradients must reach every layer on the
+/// reconstruction path, and the target must be per-patch normalised pixels by default.
+/// </summary>
+/// <remarks>
+/// Layer indices follow the default stack: 0 patch-embed, 1-12 encoder blocks, 13 feature-reduce conv,
+/// 14 pool, 15 classifier, 16-19 decoder blocks, 20 reconstruction head.
+/// </remarks>
+public class VideoMAEPretrainingFidelityTests
+{
+    private const int PatchSize = 16;
+    private const int TubeletSize = 2;
+    private const int Channels = 3;
+    private const int Frames = 4;
+    private const int Size = 32;
+
+    private static NeuralNetworkArchitecture<double> VideoArch() => new(
+        inputType: InputType.FourDimensional,
+        taskType: NeuralNetworkTaskType.MultiClassClassification,
+        inputFrames: Frames,
+        inputDepth: Channels,
+        inputHeight: Size,
+        inputWidth: Size,
+        outputSize: 4);
+
+    private static VideoMAE<double> Model(double maskRatio = 0.5, VideoMAEOptions? options = null)
+        => new(VideoArch(), numClasses: 4, numFrames: Frames, numFeatures: 16, maskRatio: maskRatio, options: options);
+
+    private static Tensor<double> RandomClip(int seed)
+    {
+        var rng = new Random(seed);
+        var clip = new Tensor<double>([1, Frames, Channels, Size, Size]);
+        var span = clip.Data.Span;
+        for (int i = 0; i < span.Length; i++)
+        {
+            span[i] = rng.NextDouble();
+        }
+        return clip;
+    }
+
+    private static double[] LayerParameters(VideoMAE<double> model, int index)
+        => model.Layers[index].GetParameters().ToArray();
+
+    private static bool Changed(double[] before, double[] after)
+        => before.Length != after.Length || before.Where((v, i) => v != after[i]).Any();
+
+    /// <summary>
+    /// A clip whose every 16x16 patch repeats one random pattern (per frame and channel), so every masked
+    /// patch has the same reconstruction target whatever the mask - a fixed clip the model can
+    /// demonstrably learn in a few dozen steps, independent of which patches each step masks.
+    /// </summary>
+    private static Tensor<double> TiledClip(int seed)
+    {
+        var rng = new Random(seed);
+        var tile = new double[Frames, Channels, PatchSize, PatchSize];
+        for (int f = 0; f < Frames; f++)
+            for (int c = 0; c < Channels; c++)
+                for (int y = 0; y < PatchSize; y++)
+                    for (int x = 0; x < PatchSize; x++)
+                        tile[f, c, y, x] = rng.NextDouble();
+
+        var clip = new Tensor<double>([1, Frames, Channels, Size, Size]);
+        for (int f = 0; f < Frames; f++)
+            for (int c = 0; c < Channels; c++)
+                for (int y = 0; y < Size; y++)
+                    for (int x = 0; x < Size; x++)
+                        clip[0, f, c, y, x] = tile[f, c, y % PatchSize, x % PatchSize];
+        return clip;
+    }
+
+    [Fact]
+    public void PretrainMAE_UpdatesTheWeights_AndTheLossFallsOverStepsOnAFixedClip()
+    {
+        var model = Model();
+        var clip = TiledClip(seed: 21);
+
+        // Materialise the lazy decoder layers so their parameters exist to compare.
+        model.PretrainMAE(clip);
+        var headBefore = LayerParameters(model, VideoMAELayerLayout.ReconstructionHeadIndex);
+
+        var losses = new List<double>();
+        for (int step = 0; step < 60; step++)
+        {
+            losses.Add(model.PretrainMAE(clip));
+        }
+
+        // PretrainMAE used to compute the loss and return it, without back-propagating or stepping an
+        // optimizer: the weights never moved and the loss only varied with the random mask.
+        Assert.True(Changed(headBefore, LayerParameters(model, VideoMAELayerLayout.ReconstructionHeadIndex)),
+            "the reconstruction head did not change across 60 pretraining steps");
+
+        // Default Adam (lr 1e-3) on per-patch normalised targets: the loss starts near 1 (the target's
+        // variance) and falls steadily; measured 0.994 -> 0.893 over the first 40 steps.
+        double early = losses.Take(5).Average();
+        double late = losses.Skip(losses.Count - 5).Average();
+        Assert.True(late < 0.85 * early,
+            $"pretraining did not reduce the reconstruction loss on a fixed clip: first five steps averaged {early:G6}, "
+            + $"last five {late:G6} (all: {string.Join(", ", losses.Select(l => l.ToString("G4")))})");
+    }
+
+    [Fact]
+    public void PretrainMAE_ReachesEveryLayerOnTheReconstructionPath_AndNothingElse()
+    {
+        var model = Model();
+        var clip = RandomClip(seed: 22);
+
+        model.PretrainMAE(clip); // materialise lazy layers
+        var before = Enumerable.Range(0, model.Layers.Count).Select(i => LayerParameters(model, i)).ToArray();
+
+        model.PretrainMAE(clip);
+
+        // Patch embedding, all 12 encoder blocks, all 4 decoder blocks and the head are on the
+        // reconstruction path, so one step must move each of them. The decoder used to stack a
+        // Transform-based GELU after every block, which records no autodiff node: the loss reached the
+        // head and nothing before it.
+        var onPath = new List<int> { VideoMAELayerLayout.PatchEmbedIndex };
+        onPath.AddRange(Enumerable.Range(VideoMAELayerLayout.FirstEncoderBlockIndex, VideoMAELayerLayout.EncoderBlockCount));
+        onPath.AddRange(Enumerable.Range(VideoMAELayerLayout.FirstDecoderBlockIndex, VideoMAELayerLayout.DecoderBlockCount));
+        onPath.Add(VideoMAELayerLayout.ReconstructionHeadIndex);
+
+        var unchanged = onPath.Where(i => !Changed(before[i], LayerParameters(model, i))).ToList();
+        Assert.True(unchanged.Count == 0,
+            $"layers on the reconstruction path received no update: [{string.Join(", ", unchanged)}]");
+
+        // The classification head is not on the pretraining path and must be left alone.
+        foreach (int i in new[] { VideoMAELayerLayout.FeatureReduceIndex, VideoMAELayerLayout.ClassifierIndex })
+        {
+            Assert.False(Changed(before[i], LayerParameters(model, i)), $"classification-head layer {i} changed during pretraining");
+        }
+    }
+
+    [Fact]
+    public void EncodeVisiblePatches_LeavesEveryMaskedPatchEmpty_ThroughTheWholeEncoder()
+    {
+        var model = Model();
+        var clip = RandomClip(seed: 23);
+        int patches = Size / PatchSize;
+        int numTubelets = Frames / TubeletSize;
+
+        // Patches (0, 1) and (1, 0) masked; (0, 0) and (1, 1) visible.
+        var mask = new bool[1, patches, patches];
+        mask[0, 0, 1] = true;
+        mask[0, 1, 0] = true;
+
+        var features = model.EncodeVisiblePatches(clip, mask);
+        Assert.Equal(new[] { numTubelets, 16, patches, patches }, features.Shape.ToArray());
+
+        // The paper's encoder never processes masked tokens. The masked positions used to be zeroed once,
+        // at the embedding, and then refilled by every 3x3 block from their visible neighbours and the
+        // block bias, so the encoder processed them like any other token.
+        bool anyVisibleNonZero = false;
+        for (int t = 0; t < numTubelets; t++)
+        {
+            for (int c = 0; c < 16; c++)
+            {
+                for (int ph = 0; ph < patches; ph++)
+                {
+                    for (int pw = 0; pw < patches; pw++)
+                    {
+                        double v = features[t, c, ph, pw];
+                        if (mask[0, ph, pw])
+                        {
+                            Assert.True(v == 0.0, $"masked patch ({ph}, {pw}) of tubelet {t} channel {c} holds {v}");
+                        }
+                        else if (v != 0.0)
+                        {
+                            anyVisibleNonZero = true;
+                        }
+                    }
+                }
+            }
+        }
+
+        Assert.True(anyVisibleNonZero, "every visible feature was zero, so the check above proves nothing");
+    }
+
+    [Fact]
+    public void PretrainMAE_WithEveryPatchMasked_TeachesTheEncoderNothing()
+    {
+        // With every patch masked the encoder sees no content at all, so no gradient may reach the patch
+        // embedding or any encoder block. The masked embeddings used to be zeroed by an in-place write the
+        // tape never saw, so backward still carried gradient through them into the patch-embedding
+        // weights, weighted by the masked patches' own pixels - the content the model is meant to predict
+        // without seeing. The head, which learns to predict from nothing, must still move.
+        var model = Model(maskRatio: 1.0);
+        var clip = RandomClip(seed: 24);
+
+        model.PretrainMAE(clip); // materialise lazy layers
+        var before = Enumerable.Range(0, model.Layers.Count).Select(i => LayerParameters(model, i)).ToArray();
+
+        model.PretrainMAE(clip);
+
+        for (int i = VideoMAELayerLayout.PatchEmbedIndex; i < VideoMAELayerLayout.EncoderEndIndex; i++)
+        {
+            Assert.False(Changed(before[i], LayerParameters(model, i)), $"encoder layer {i} learned from fully masked input");
+        }
+
+        Assert.True(Changed(before[VideoMAELayerLayout.ReconstructionHeadIndex],
+            LayerParameters(model, VideoMAELayerLayout.ReconstructionHeadIndex)), "the reconstruction head did not train");
+    }
+
+    /// <summary>
+    /// The paper's per-patch normalised target, computed independently of the model: for each channel of
+    /// each tubelet patch, (x - mean) / (unbiased std + 1e-6) over its tubeletSize x P x P pixels, laid out
+    /// like the head's output.
+    /// </summary>
+    private static Tensor<double> NormalisedTarget(Tensor<double> clip)
+    {
+        int numTubelets = Frames / TubeletSize;
+        int patches = Size / PatchSize;
+        int patchDim = Channels * TubeletSize * PatchSize * PatchSize;
+        var target = new Tensor<double>([numTubelets, patchDim, patches, patches]);
+
+        for (int t = 0; t < numTubelets; t++)
+            for (int ph = 0; ph < patches; ph++)
+                for (int pw = 0; pw < patches; pw++)
+                    for (int c = 0; c < Channels; c++)
+                    {
+                        var values = new List<double>();
+                        for (int ts = 0; ts < TubeletSize; ts++)
+                            for (int y = 0; y < PatchSize; y++)
+                                for (int x = 0; x < PatchSize; x++)
+                                    values.Add(clip[0, t * TubeletSize + ts, c, ph * PatchSize + y, pw * PatchSize + x]);
+
+                        double mean = values.Average();
+                        double std = Math.Sqrt(values.Sum(v => (v - mean) * (v - mean)) / (values.Count - 1));
+
+                        for (int ts = 0; ts < TubeletSize; ts++)
+                            for (int y = 0; y < PatchSize; y++)
+                                for (int x = 0; x < PatchSize; x++)
+                                {
+                                    int channel = (((ts * Channels) + c) * PatchSize + y) * PatchSize + x;
+                                    double v = clip[0, t * TubeletSize + ts, c, ph * PatchSize + y, pw * PatchSize + x];
+                                    target[t, channel, ph, pw] = (v - mean) / (std + 1e-6);
+                                }
+                    }
+
+        return target;
+    }
+
+    [Fact]
+    public void ComputeReconstructionLoss_ByDefault_TargetsPerPatchNormalisedPixels()
+    {
+        var model = Model();
+        var clip = RandomClip(seed: 25);
+        int patches = Size / PatchSize;
+
+        var mask = new bool[1, patches, patches];
+        mask[0, 1, 1] = true;
+
+        // The paper (and its reference code's default normlize_target=True) reconstructs each patch's
+        // pixels normalised by that patch's own mean and standard deviation. The target used to be the
+        // raw pixels, with no option to normalise.
+        var normalised = NormalisedTarget(clip);
+        Assert.Equal(0.0, model.ComputeReconstructionLoss(normalised, clip, mask), 10);
+
+        // Raw pixels are therefore NOT a perfect prediction under the default.
+        var raw = new Tensor<double>(normalised.Shape.ToArray());
+        int numTubelets = Frames / TubeletSize;
+        for (int t = 0; t < numTubelets; t++)
+            for (int ts = 0; ts < TubeletSize; ts++)
+                for (int c = 0; c < Channels; c++)
+                    for (int y = 0; y < PatchSize; y++)
+                        for (int x = 0; x < PatchSize; x++)
+                            for (int ph = 0; ph < patches; ph++)
+                                for (int pw = 0; pw < patches; pw++)
+                                {
+                                    int channel = (((ts * Channels) + c) * PatchSize + y) * PatchSize + x;
+                                    raw[t, channel, ph, pw] = clip[0, t * TubeletSize + ts, c, ph * PatchSize + y, pw * PatchSize + x];
+                                }
+
+        Assert.True(model.ComputeReconstructionLoss(raw, clip, mask) > 0.1,
+            "raw pixels scored as a perfect prediction, so the default target is not normalised");
+
+        // Opting out restores the raw-pixel target exactly.
+        var rawModel = Model(options: new VideoMAEOptions { NormalizeTarget = false });
+        Assert.Equal(0.0, rawModel.ComputeReconstructionLoss(raw, clip, mask), 12);
+    }
+
+    [Fact]
+    public void Options_NormalizeTarget_DefaultsToThePapersChoice()
+    {
+        Assert.True(new VideoMAEOptions().NormalizeTarget);
+    }
+}

--- a/tests/AiDotNet.Tests/UnitTests/Video/ActionRecognition/VideoMAEPretrainingTests.cs
+++ b/tests/AiDotNet.Tests/UnitTests/Video/ActionRecognition/VideoMAEPretrainingTests.cs
@@ -1,0 +1,213 @@
+using System;
+using System.Linq;
+using AiDotNet.Enums;
+using AiDotNet.NeuralNetworks;
+using AiDotNet.Tensors.LinearAlgebra;
+using AiDotNet.Video.ActionRecognition;
+using Xunit;
+
+namespace AiDotNet.Tests.UnitTests.Video.ActionRecognition;
+
+/// <summary>
+/// Regression tests for VideoMAE's masked-autoencoder pretraining path and its frame-count wiring.
+/// </summary>
+/// <remarks>
+/// VideoMAE's default layer stack is laid out as
+/// <c>[patch-embed | 12 encoder blocks | reduce-conv, pool, classifier | 4 decoder blocks | reconstruction head]</c>.
+/// These tests pin the three places where the model's own bookkeeping disagreed with that layout or with
+/// the paper: the decoder started one slot early (on the classifier), the tube mask sized its masked count
+/// from tubelets x spatial patches while sampling only spatial patches (so every patch was masked once a
+/// clip had two or more tubelets), and the architecture's declared frame count was ignored.
+/// </remarks>
+public class VideoMAEPretrainingTests
+{
+    private const int PatchSize = 16;
+    private const int TubeletSize = 2;
+    private const int Channels = 3;
+
+    private static NeuralNetworkArchitecture<double> VideoArch(int frames, int size, int classes = 4) => new(
+        inputType: InputType.FourDimensional,
+        taskType: NeuralNetworkTaskType.MultiClassClassification,
+        inputFrames: frames,
+        inputDepth: Channels,
+        inputHeight: size,
+        inputWidth: size,
+        outputSize: classes);
+
+    private static Tensor<double> RandomClip(int frames, int size, int seed)
+    {
+        var rng = new Random(seed);
+        var clip = new Tensor<double>([1, frames, Channels, size, size]);
+        var span = clip.Data.Span;
+        for (int i = 0; i < span.Length; i++)
+        {
+            span[i] = rng.NextDouble();
+        }
+        return clip;
+    }
+
+    [Fact]
+    public void DecodeForReconstruction_RunsTheDecoderBlocksAndReconstructionHead_NotTheClassifier()
+    {
+        const int frames = 4;
+        const int size = 32;
+        const int features = 16;
+        var model = new VideoMAE<double>(VideoArch(frames, size), numClasses: 4, numFrames: frames, numFeatures: features);
+
+        int numTubelets = frames / TubeletSize;
+        int patches = size / PatchSize;
+
+        // Encoder output layout: one [numFeatures, patchesH, patchesW] map per (clip, tubelet).
+        var encoded = new Tensor<double>([numTubelets, features, patches, patches]);
+        var rng = new Random(7);
+        var span = encoded.Data.Span;
+        for (int i = 0; i < span.Length; i++)
+        {
+            span[i] = rng.NextDouble();
+        }
+
+        var reconstruction = model.DecodeForReconstruction(encoded);
+
+        // The reconstruction head predicts every pixel of a tubelet patch: channels * tubeletSize * P * P
+        // values per patch position. Starting the decoder on the classifier's Dense layer instead produced
+        // a numClasses- or numFeatures-wide map (the head, the last layer, was never reached).
+        Assert.Equal(
+            new[] { numTubelets, Channels * TubeletSize * PatchSize * PatchSize, patches, patches },
+            reconstruction.Shape.ToArray());
+    }
+
+    [Fact]
+    public void PretrainMAE_OnAMultiTubeletClip_ReturnsAFinitePositiveLoss()
+    {
+        const int frames = 4;
+        const int size = 32;
+        var model = new VideoMAE<double>(VideoArch(frames, size), numClasses: 4, numFrames: frames, numFeatures: 16, maskRatio: 0.5);
+
+        double loss = model.PretrainMAE(RandomClip(frames, size, seed: 11));
+
+        Assert.False(double.IsNaN(loss) || double.IsInfinity(loss), $"loss was {loss}");
+        Assert.True(loss > 0.0, $"reconstruction loss of a random clip against an untrained decoder must be positive, was {loss}");
+    }
+
+    [Fact]
+    public void ComputeReconstructionLoss_ComparesEachMaskedTubeletPatchWithItsOwnPixels()
+    {
+        const int frames = 4;
+        const int size = 32;
+        var model = new VideoMAE<double>(VideoArch(frames, size), numClasses: 4, numFrames: frames, numFeatures: 8);
+        var clip = RandomClip(frames, size, seed: 13);
+
+        int numTubelets = frames / TubeletSize;
+        int patches = size / PatchSize;
+        int patchDim = Channels * TubeletSize * PatchSize * PatchSize;
+
+        // Only patch (0, 1) is masked.
+        var mask = new bool[1, patches, patches];
+        mask[0, 0, 1] = true;
+
+        // The exact per-patch target: channel ((ts * C + c) * P + y) * P + x of tubelet t at patch (ph, pw)
+        // is pixel [t * tubeletSize + ts, c, ph * P + y, pw * P + x] -- the same (ts, c) fold PatchEmbed uses.
+        var perfect = new Tensor<double>([numTubelets, patchDim, patches, patches]);
+        for (int t = 0; t < numTubelets; t++)
+            for (int ts = 0; ts < TubeletSize; ts++)
+                for (int c = 0; c < Channels; c++)
+                    for (int y = 0; y < PatchSize; y++)
+                        for (int x = 0; x < PatchSize; x++)
+                            for (int ph = 0; ph < patches; ph++)
+                                for (int pw = 0; pw < patches; pw++)
+                                {
+                                    int channel = (((ts * Channels) + c) * PatchSize + y) * PatchSize + x;
+                                    perfect[t, channel, ph, pw] = clip[0, t * TubeletSize + ts, c, ph * PatchSize + y, pw * PatchSize + x];
+                                }
+
+        Assert.Equal(0.0, model.ComputeReconstructionLoss(perfect, clip, mask), 12);
+
+        // Off by 1 on the masked patch only -> MSE exactly 1; errors on VISIBLE patches must not count.
+        var shifted = perfect.Clone();
+        for (int t = 0; t < numTubelets; t++)
+            for (int ch = 0; ch < patchDim; ch++)
+            {
+                shifted[t, ch, 0, 1] = shifted[t, ch, 0, 1] + 1.0;
+                shifted[t, ch, 1, 0] = shifted[t, ch, 1, 0] + 5.0; // visible: ignored
+            }
+
+        Assert.Equal(1.0, model.ComputeReconstructionLoss(shifted, clip, mask), 12);
+    }
+
+    [Theory]
+    [InlineData(16, 64, 0.75, 12)]  // 8 tubelets, 4x4 = 16 spatial patches -> 12 masked
+    [InlineData(4, 64, 0.5, 8)]     // 2 tubelets, 16 patches -> 8 masked
+    [InlineData(16, 224, 0.9, 176)] // paper default: 8 tubelets, 14x14 = 196 patches -> int(0.9 * 196) = 176
+    public void CreateTubeMask_MasksTheConfiguredFractionOfSpatialPatches_ForMultiTubeletClips(
+        int frames, int size, double maskRatio, int expectedMaskedPerClip)
+    {
+        var model = new VideoMAE<double>(VideoArch(frames, size), numClasses: 4, numFrames: frames, numFeatures: 8, maskRatio: maskRatio);
+
+        const int batch = 3;
+        var mask = model.CreateTubeMask(batch);
+
+        int patches = size / PatchSize;
+        Assert.Equal(batch, mask.GetLength(0));
+        Assert.Equal(patches, mask.GetLength(1));
+        Assert.Equal(patches, mask.GetLength(2));
+
+        // Tube masking (Tong et al. 2022, Sec. 3.3): ONE spatial mask per clip, shared by every tubelet,
+        // with the ratio applied to the per-frame patch count. The old code computed the masked count from
+        // numTubelets * spatialPatches but sampled only spatialPatches indices, so any clip with 2+
+        // tubelets had every patch masked (nothing visible to the encoder).
+        for (int b = 0; b < batch; b++)
+        {
+            int masked = 0;
+            for (int h = 0; h < patches; h++)
+            {
+                for (int w = 0; w < patches; w++)
+                {
+                    if (mask[b, h, w])
+                    {
+                        masked++;
+                    }
+                }
+            }
+            Assert.Equal(expectedMaskedPerClip, masked);
+        }
+    }
+
+    [Fact]
+    public void Constructor_UsesTheFrameCountDeclaredByTheArchitecture()
+    {
+        var model = new VideoMAE<double>(VideoArch(frames: 8, size: 32), numClasses: 4, numFeatures: 8);
+
+        Assert.Equal(8, model.NumFrames);
+        Assert.Equal(8, model.GetModelMetadata().AdditionalInfo["NumFrames"]);
+    }
+
+    [Fact]
+    public void Constructor_AgreeingExplicitFrameCount_IsAccepted()
+    {
+        var model = new VideoMAE<double>(VideoArch(frames: 4, size: 32), numClasses: 4, numFrames: 4, numFeatures: 8);
+
+        Assert.Equal(4, model.NumFrames);
+    }
+
+    [Fact]
+    public void Constructor_ConflictingExplicitFrameCount_Throws()
+    {
+        var ex = Assert.Throws<ArgumentException>(() =>
+            new VideoMAE<double>(VideoArch(frames: 8, size: 32), numClasses: 4, numFrames: 4, numFeatures: 8));
+
+        Assert.Equal("numFrames", ex.ParamName);
+    }
+
+    [Fact]
+    public void Constructor_WithoutADeclaredFrameCount_KeepsTheNumFramesArgument()
+    {
+        var arch = new NeuralNetworkArchitecture<double>(
+            inputType: InputType.ThreeDimensional,
+            taskType: NeuralNetworkTaskType.MultiClassClassification,
+            inputDepth: Channels, inputHeight: 32, inputWidth: 32, outputSize: 4);
+
+        var model = new VideoMAE<double>(arch, numClasses: 4, numFrames: 6, numFeatures: 8);
+
+        Assert.Equal(6, model.NumFrames);
+    }
+}

--- a/tests/AiDotNet.Tests/UnitTests/Video/ActionRecognition/VideoMAEPretrainingTests.cs
+++ b/tests/AiDotNet.Tests/UnitTests/Video/ActionRecognition/VideoMAEPretrainingTests.cs
@@ -94,7 +94,10 @@ public class VideoMAEPretrainingTests
     {
         const int frames = 4;
         const int size = 32;
-        var model = new VideoMAE<double>(VideoArch(frames, size), numClasses: 4, numFrames: frames, numFeatures: 8);
+        // Raw-pixel target, so the exact per-pixel correspondence is checkable by hand. The default
+        // (per-patch normalised) target is pinned in VideoMAEPretrainingFidelityTests.
+        var model = new VideoMAE<double>(VideoArch(frames, size), numClasses: 4, numFrames: frames, numFeatures: 8,
+            options: new AiDotNet.Video.Options.VideoMAEOptions { NormalizeTarget = false });
         var clip = RandomClip(frames, size, seed: 13);
 
         int numTubelets = frames / TubeletSize;

--- a/tests/AiDotNet.Tests/UnitTests/Video/Motion/OpticalFlowDeclaredInputTests.cs
+++ b/tests/AiDotNet.Tests/UnitTests/Video/Motion/OpticalFlowDeclaredInputTests.cs
@@ -1,0 +1,149 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using AiDotNet.Enums;
+using AiDotNet.NeuralNetworks;
+using AiDotNet.Tensors.LinearAlgebra;
+using AiDotNet.Video;
+using AiDotNet.Video.Motion;
+using Xunit;
+
+namespace AiDotNet.Tests.UnitTests.Video.Motion;
+
+/// <summary>
+/// Optical-flow models must predict on a tensor of their own declared input shape.
+/// </summary>
+/// <remarks>
+/// <para>
+/// These models declare their input through the architecture as <c>InputType.ThreeDimensional</c> with
+/// <c>InputDepth = 6</c> - a frame PAIR stacked on the channel axis - so <c>GetInputShape()</c> is the
+/// unbatched <c>[6, H, W]</c>. Their shared <see cref="OpticalFlowBase{T}"/> <c>PredictCore</c> rejected
+/// every rank-3 input with "Input must be rank 4" instead of adding the batch axis, so none of them could
+/// run on the shape it advertises.
+/// </para>
+/// <para>
+/// A small spatial size and a narrow, shallow stack keep this cheap; the defect is independent of both.
+/// </para>
+/// </remarks>
+public class OpticalFlowDeclaredInputTests
+{
+    private const int Size = 16;
+
+    private static NeuralNetworkArchitecture<double> PairArchitecture(int depth = 6) => new(
+        inputType: InputType.ThreeDimensional,
+        taskType: NeuralNetworkTaskType.Regression,
+        inputHeight: Size, inputWidth: Size, inputDepth: depth,
+        outputSize: 2);
+
+    private static readonly Dictionary<string, Func<OpticalFlowBase<double>>> PairDeclaringModels = new()
+    {
+        ["DKM"] = () => new DKM<double>(PairArchitecture(), numFeatures: 8, numLayers: 2),
+        ["DPFlow"] = () => new DPFlow<double>(PairArchitecture(), numFeatures: 8, numLayers: 2),
+        ["FlowDiffuser"] = () => new FlowDiffuser<double>(PairArchitecture(), numFeatures: 8, numLayers: 2),
+        ["FlowFormerPlusPlus"] = () => new FlowFormerPlusPlus<double>(PairArchitecture(), numFeatures: 8, numLayers: 2),
+        ["MemFlow"] = () => new MemFlow<double>(PairArchitecture(), numFeatures: 8, numLayers: 2),
+        ["NeuFlowV2"] = () => new NeuFlowV2<double>(PairArchitecture(), numFeatures: 8, numLayers: 2),
+        ["RoMa"] = () => new RoMa<double>(PairArchitecture(), numFeatures: 8, numLayers: 2),
+        ["RPKNet"] = () => new RPKNet<double>(PairArchitecture(), numFeatures: 8, numLayers: 2),
+        ["SEARAFT"] = () => new SEARAFT<double>(PairArchitecture(), numFeatures: 8, numLayers: 2),
+        ["SKFlow"] = () => new SKFlow<double>(PairArchitecture(), numFeatures: 8, numLayers: 2),
+        ["UFM"] = () => new UFM<double>(PairArchitecture(), numFeatures: 8, numLayers: 2),
+        ["UniMatch"] = () => new UniMatch<double>(PairArchitecture(), numFeatures: 8, numLayers: 2),
+        ["VideoFlow"] = () => new VideoFlow<double>(PairArchitecture(), numFeatures: 8, numLayers: 2),
+    };
+
+    public static IEnumerable<object[]> PairDeclaringModelNames()
+        => PairDeclaringModels.Keys.Select(name => new object[] { name });
+
+    private static Tensor<double> Random(int[] shape, int seed)
+    {
+        var rng = new System.Random(seed);
+        var t = new Tensor<double>(shape);
+        var span = t.Data.Span;
+        for (int i = 0; i < span.Length; i++)
+        {
+            span[i] = rng.NextDouble();
+        }
+        return t;
+    }
+
+    private static Tensor<double> WithBatchAxis(Tensor<double> unbatched)
+    {
+        var shape = new int[unbatched.Rank + 1];
+        shape[0] = 1;
+        for (int i = 0; i < unbatched.Rank; i++) shape[i + 1] = unbatched.Shape[i];
+        var batched = new Tensor<double>(shape);
+        unbatched.Data.Span.CopyTo(batched.Data.Span);
+        return batched;
+    }
+
+    private static void AssertSameValues(Tensor<double> expected, Tensor<double> actual)
+    {
+        Assert.Equal(expected.Length, actual.Length);
+        var e = expected.Data.Span;
+        var a = actual.Data.Span;
+        for (int i = 0; i < e.Length; i++)
+        {
+            Assert.Equal(e[i], a[i], 10);
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(PairDeclaringModelNames))]
+    public void Predict_OnTheDeclaredInputShape_ReturnsAnUnbatchedFlowField(string modelName)
+    {
+        var model = PairDeclaringModels[modelName]();
+
+        int[] declared = model.GetArchitecture().GetInputShape();
+        Assert.Equal(new[] { 6, Size, Size }, declared);
+
+        var pair = Random(declared, seed: 5);
+        var flow = model.Predict(pair);
+
+        // Unbatched in, unbatched out: one [dx, dy] field at the input resolution.
+        Assert.Equal(new[] { 2, Size, Size }, flow.Shape.ToArray());
+
+        // And it is the SAME field the batched form produces for that one sample - the promotion adds
+        // an axis, it does not change the computation.
+        var batchedFlow = model.Predict(WithBatchAxis(pair));
+        Assert.Equal(new[] { 1, 2, Size, Size }, batchedFlow.Shape.ToArray());
+        AssertSameValues(batchedFlow, flow);
+    }
+
+    [Fact]
+    public void RAPIDFlow_PredictsOnAnUnbatchedFramePair()
+    {
+        // RAPIDFlow is the family's exception: its architecture's InputDepth is the PER-FRAME channel count
+        // (3), so its declared shape [3, H, W] describes one frame rather than the pair Predict takes (see
+        // the TestScaffoldGenerator note on RAPIDFlow). What the shared base owes it is the same as every
+        // other member: an unbatched pair [2*3, H, W] must be accepted, not rejected for its rank.
+        var model = new RAPIDFlow<double>(PairArchitecture(depth: 3), numRefinementIterations: 1);
+
+        var pair = Random([6, Size, Size], seed: 7);
+        var flow = model.Predict(pair);
+
+        Assert.Equal(new[] { 2, Size, Size }, flow.Shape.ToArray());
+        AssertSameValues(model.Predict(WithBatchAxis(pair)), flow);
+    }
+
+    [Fact]
+    public void RAFT_PredictsOnAnUnbatchedFramePair()
+    {
+        // RAFT overrides PredictCore but inherits the family's batch-optional input layout, so it owes the
+        // same unbatched pair [2*C, H, W]. It indexed Shape[3] unconditionally and threw IndexOutOfRange.
+        const int size = 32;
+        var model = new RAFT<double>(
+            new NeuralNetworkArchitecture<double>(
+                inputType: InputType.ThreeDimensional,
+                taskType: NeuralNetworkTaskType.Regression,
+                inputHeight: size, inputWidth: size, inputDepth: 3,
+                outputSize: 2),
+            numFeatures: 16, correlationLevels: 2, correlationRadius: 1, numIterations: 1);
+
+        var pair = Random([6, size, size], seed: 9);
+        var flow = model.Predict(pair);
+
+        Assert.Equal(new[] { 2, size, size }, flow.Shape.ToArray());
+        AssertSameValues(model.Predict(WithBatchAxis(pair)), flow);
+    }
+}

--- a/tests/AiDotNet.Tests/UnitTests/Video/VideoModelDeclaredInputTests.cs
+++ b/tests/AiDotNet.Tests/UnitTests/Video/VideoModelDeclaredInputTests.cs
@@ -1,0 +1,213 @@
+using System;
+using System.Linq;
+using AiDotNet.Enums;
+using AiDotNet.NeuralNetworks;
+using AiDotNet.Tensors.LinearAlgebra;
+using AiDotNet.Video.Enhancement;
+using AiDotNet.Video.Generation;
+using AiDotNet.Video.Inpainting;
+using AiDotNet.Video.Options;
+using AiDotNet.Video.Understanding;
+using Xunit;
+
+namespace AiDotNet.Tests.UnitTests.Video;
+
+/// <summary>
+/// Video models must run on a tensor of their own declared input shape (<c>GetInputShape()</c>).
+/// </summary>
+/// <remarks>
+/// <para>
+/// Each case here failed that probe for a model-specific reason, and each was judged on which side was
+/// wrong:
+/// </para>
+/// <list type="bullet">
+/// <item>BasicVSR++, OpenSora and ProPainter declare a single <c>[C, H, W]</c> frame or latent, which is a
+/// valid input under their own contracts (a one-frame clip; a single latent; a one-frame clip), but their
+/// Predict indexed a fourth axis it never added. Predict was wrong.</item>
+/// <item>VideoCLIP's input layout is <c>[Frames, C, H, W]</c> and it owns a clip length (<c>numFrames</c>),
+/// but its default architecture declared a single <c>[3, 224, 224]</c> frame. The declaration was
+/// wrong.</item>
+/// </list>
+/// </remarks>
+public class VideoModelDeclaredInputTests
+{
+    private static NeuralNetworkArchitecture<double> FrameArchitecture(int size) => new(
+        inputType: InputType.ThreeDimensional,
+        taskType: NeuralNetworkTaskType.Regression,
+        inputHeight: size, inputWidth: size, inputDepth: 3,
+        outputSize: 2);
+
+    private static Tensor<T> Random<T>(int[] shape, int seed, Func<double, T> convert)
+    {
+        var rng = new System.Random(seed);
+        var t = new Tensor<T>(shape);
+        var span = t.Data.Span;
+        for (int i = 0; i < span.Length; i++)
+        {
+            span[i] = convert(rng.NextDouble());
+        }
+        return t;
+    }
+
+    private static Tensor<double> Random(int[] shape, int seed) => Random(shape, seed, v => v);
+
+    private static Tensor<double> WithLeadingAxis(Tensor<double> tensor)
+    {
+        var shape = new int[tensor.Rank + 1];
+        shape[0] = 1;
+        for (int i = 0; i < tensor.Rank; i++) shape[i + 1] = tensor.Shape[i];
+        var result = new Tensor<double>(shape);
+        tensor.Data.Span.CopyTo(result.Data.Span);
+        return result;
+    }
+
+    private static void AssertSameValues(Tensor<double> expected, Tensor<double> actual)
+    {
+        Assert.Equal(expected.Length, actual.Length);
+        var e = expected.Data.Span;
+        var a = actual.Data.Span;
+        for (int i = 0; i < e.Length; i++)
+        {
+            Assert.Equal(e[i], a[i], 10);
+        }
+    }
+
+    [Fact]
+    public void BasicVSRPlusPlus_UpscalesItsDeclaredSingleFrame_AsAOneFrameClip()
+    {
+        const int size = 32;
+        var model = new BasicVSRPlusPlus<double>(
+            FrameArchitecture(size), scaleFactor: 2, numFeatures: 8, numResidualBlocks: 1, numPropagations: 1);
+
+        int[] declared = model.GetArchitecture().GetInputShape();
+        Assert.Equal(new[] { 3, size, size }, declared);
+
+        // It used to read [C, H, W] as a clip of C two-dimensional frames and fail inside the feature
+        // extractor / flow estimator.
+        var frame = Random(declared, seed: 1);
+        var upscaled = model.Predict(frame);
+
+        Assert.Equal(new[] { 3, size * 2, size * 2 }, upscaled.Shape.ToArray());
+
+        // Exactly the one-frame clip [1, C, H, W], without its frame axis.
+        var clip = model.Predict(WithLeadingAxis(frame));
+        Assert.Equal(new[] { 1, 3, size * 2, size * 2 }, clip.Shape.ToArray());
+        AssertSameValues(clip, upscaled);
+    }
+
+    [Fact]
+    public void OpenSora_DenoisesItsDeclaredSingleLatent()
+    {
+        const int size = 16;
+        var model = new OpenSora<double>(
+            new NeuralNetworkArchitecture<double>(
+                inputType: InputType.ThreeDimensional,
+                taskType: NeuralNetworkTaskType.Generative,
+                inputHeight: size, inputWidth: size, inputDepth: 3,
+                outputSize: size * size * 3),
+            numFrames: 2, hiddenDim: 32, numLayers: 1, numInferenceSteps: 4);
+
+        int[] declared = model.GetArchitecture().GetInputShape();
+        Assert.Equal(new[] { 3, size, size }, declared);
+
+        // The denoiser indexed axis 3 of its features, so a rank-3 latent threw IndexOutOfRange.
+        var latent = Random(declared, seed: 2);
+        var denoised = model.Predict(latent);
+
+        Assert.Equal(new[] { 3, size, size }, denoised.Shape.ToArray());
+        AssertSameValues(model.Predict(WithLeadingAxis(latent)), denoised);
+    }
+
+    [Fact]
+    public void ProPainter_ReconstructsItsDeclaredSingleFrame_AsAOneFrameClip()
+    {
+        const int size = 16;
+        var model = new ProPainter<double>(FrameArchitecture(size), numFeatures: 8, numTransformerBlocks: 1, numHeads: 2);
+
+        int[] declared = model.GetArchitecture().GetInputShape();
+        Assert.Equal(new[] { 3, size, size }, declared);
+
+        // The image path read axis 3, so a rank-3 frame threw IndexOutOfRange.
+        var frame = Random(declared, seed: 3);
+        var reconstructed = model.Predict(frame);
+
+        Assert.Equal(3, reconstructed.Rank);
+        Assert.Equal(new[] { size, size }, reconstructed.Shape.ToArray().Skip(1).ToArray());
+        AssertSameValues(model.Predict(WithLeadingAxis(frame)), reconstructed);
+    }
+
+    [Fact]
+    public void VideoCLIP_DefaultConstructor_DeclaresTheClipItEncodes()
+    {
+        using var model = new VideoCLIP<float>();
+
+        // Its input layout is [Frames, C, H, W] and its default clip is 32 frames; it used to declare a
+        // single [3, 224, 224] frame (InputType.ThreeDimensional), which EncodeVideo cannot take.
+        Assert.Equal(InputType.FourDimensional, model.GetArchitecture().InputType);
+        Assert.Equal(new[] { 32, 3, 224, 224 }, model.GetArchitecture().GetInputShape());
+        Assert.Equal(32, model.NumFrames);
+    }
+
+    private static VideoCLIP<float> SmallVideoCLIP(NeuralNetworkArchitecture<float> architecture, int? numFrames = null)
+    {
+        var options = new VideoCLIPVideoOptions
+        {
+            HiddenDimension = 32,
+            NumSpatialBlocks = 1,
+            NumTemporalBlocks = 1,
+            NumTextBlocks = 1,
+            WarmupSteps = 0,
+        };
+
+        return numFrames is int frames
+            ? new VideoCLIP<float>(architecture, numFrames: frames, embeddingDim: 4, textMaxLength: 8, vocabSize: 64, options: options)
+            : new VideoCLIP<float>(architecture, embeddingDim: 4, textMaxLength: 8, vocabSize: 64, options: options);
+    }
+
+    private static NeuralNetworkArchitecture<float> ClipArchitecture(int frames) => new(
+        inputType: InputType.FourDimensional,
+        taskType: NeuralNetworkTaskType.MultiClassClassification,
+        inputFrames: frames, inputDepth: 3, inputHeight: 32, inputWidth: 32,
+        outputSize: 4);
+
+    [Fact]
+    public void VideoCLIP_TakesTheArchitecturesFrameCount_AndPredictsOnTheDeclaredClip()
+    {
+        using var model = SmallVideoCLIP(ClipArchitecture(frames: 4));
+
+        Assert.Equal(4, model.NumFrames);
+        Assert.Equal(4, model.GetModelMetadata().AdditionalInfo["NumFrames"]);
+
+        int[] declared = model.GetArchitecture().GetInputShape();
+        Assert.Equal(new[] { 4, 3, 32, 32 }, declared);
+
+        var embedding = model.Predict(Random(declared, seed: 4, v => (float)v));
+        Assert.Equal(4, embedding.Length); // one embeddingDim-wide vector for the one clip
+    }
+
+    [Fact]
+    public void VideoCLIP_DeclaringTheClip_DoesNotChangeTheResolvedLayerStack()
+    {
+        // The layer stack runs per frame, and its lazy layers are resolved ahead of the first forward
+        // from the architecture's declared input. Declaring the clip [Frames, C, H, W] instead of one frame
+        // must not leave the stack unresolved: ParameterCount at construction (which weight-streaming and
+        // other memory decisions read) has to match the one-frame declaration's.
+        var frameArchitecture = new NeuralNetworkArchitecture<float>(
+            inputType: InputType.ThreeDimensional,
+            taskType: NeuralNetworkTaskType.MultiClassClassification,
+            inputDepth: 3, inputHeight: 32, inputWidth: 32, outputSize: 4);
+
+        using var declaredAsFrame = SmallVideoCLIP(frameArchitecture, numFrames: 4);
+        using var declaredAsClip = SmallVideoCLIP(ClipArchitecture(frames: 4));
+
+        Assert.True(declaredAsFrame.ParameterCount > 0);
+        Assert.Equal(declaredAsFrame.ParameterCount, declaredAsClip.ParameterCount);
+    }
+
+    [Fact]
+    public void VideoCLIP_ConflictingExplicitFrameCount_Throws()
+    {
+        var ex = Assert.Throws<ArgumentException>(() => SmallVideoCLIP(ClipArchitecture(frames: 4), numFrames: 8));
+        Assert.Equal("numFrames", ex.ParamName);
+    }
+}


### PR DESCRIPTION
## Summary

Five real bugs in VideoMAE's pretraining path and TimeSformer's declared input, found while diagnosing a never-run test failure (the one-frame VideoMAE crash, fixed separately in the never-run-tests PR). VideoMAE's masked-autoencoder pretraining **decoded with the classifier layer**, **masked 100% of the clip** for any clip longer than one tubelet, and **its loss crashed on every multi-tubelet clip**. So `PretrainMAE` couldn't run on any realistic input. VideoMAE also ignored the frame count its architecture declared, and TimeSformer declared a one-frame input for a model built for 8-frame clips.

## Root causes and fixes

Line numbers are in the unfixed `master` files.

| # | Bug | Evidence (unfixed) | Fix |
|---|---|---|---|
| 1 | `DecodeForReconstruction` started at hard-coded layer **15** (`VideoMAE.cs:717`). The factory (`LayerHelper.cs:9356-9401`) builds 21 layers: 0 patch-embed, 1-12 encoder, 13 reduce-conv, 14 pool, **15 classifier Dense**, 16-19 decoder, 20 reconstruction head. Pretraining ran the classifier, three decoder blocks, and decoder block 4 as the "head"; the real head was never reached. | output `[2,16,2,4]`; correct is `[2,1536,2,2]` | New `VideoMAELayerLayout.cs`: one definition of the indices, read by the factory, the encoder loop, the classifier head and the decoder. |
| 2 | `CreateTubeMask` (`:638-645`) sized `numMasked` from tubelets × spatial patches but sampled spatial indices only, so 2+ tubelets meant everything was masked. | 196/196 masked at ratio 0.9; 16/16 at 0.75 and at 0.5 | The ratio applies to the spatial patch count, as in the paper's tube masking (176/196 at 0.9); one spatial mask per clip, shared by all its tubelets, built on the clip's own patch grid. |
| 3 | `ComputeReconstructionLoss` (`:737-804`) treated the head's B×tubelets axis as the clip batch: IndexOutOfRange on any clip with 2+ tubelets, and compared against frame-averaged single pixels instead of the patch's pixels. Found while fixing 1. | `PretrainMAE` threw on every multi-tubelet clip | MSE on raw pixels over **masked** tubelet patches only; channel order matches how `PatchEmbed` folds frames into channels; shapes validated instead of indices silently wrapped. |
| 4 | Both constructors (`:188`, `:233`) set `_numFrames = numFrames` without reading `Architecture.InputFrames`. | an 8-frame architecture reported 16 frames | `ResolveNumFrames`: the architecture's count wins (the rule BSVD, the only other `src/Video` model reading `InputFrames`, uses); an explicit conflicting `numFrames` throws. Limitation: an explicit 16 can't be told from the default, so it defers to the architecture. |
| 5 | `TimeSformer()` (`TimeSformer.cs:171`) declared `ThreeDimensional`, so `GetInputShape()` was `[3,224,224]`: one frame. Predict ran, tokenizing it as a one-frame clip, so this was a wrong contract rather than a crash. | declared shape `[3,224,224]` | `FourDimensional`, `inputFrames: 8` → `[8,3,224,224]`. |

**Why `LayerHelper.cs` changed** (it's shared by many models): only two loop bounds inside `CreateDefaultVideoMAELayers` changed, `12` → `VideoMAELayerLayout.EncoderBlockCount` and `4` → `DecoderBlockCount`, so the factory and the model read one definition. Only `VideoMAE.cs` calls that method (checked across `src` and `tests`); no other `LayerHelper` method is touched. Both are compile-time constants with the same values, so the compiled method is unchanged. Parameter counts confirm it: default VideoMAE 65,788,816 and small config 161,348, identical before and after. As a check, `LayerHelper`, `SlowFast`, `DepthAnythingV2` and `ArchitectureSharingGuard` tests ran: 164 passed, 0 failed, 3 skipped.

## Tests

New `VideoMAEPretrainingTests` and `TimeSformerDeclaredInputTests` (11). **Against the unfixed source 9 fail:**
- decoder output shape
- masked count in 3 cases (176 vs 196, 12 vs 16, 8 vs 16)
- `PretrainMAE`, and an exact-value loss test (IndexOutOfRange)
- the architecture's frame count (16 vs 8)
- the conflicting-count throw (nothing thrown)
- TimeSformer's input type (ThreeDimensional)

The other 2 are guards that should pass either way. **All 11 pass after.**

| Suite | Before | After |
|---|---|---|
| Generated VideoMAE | 31 pass, 1 skip | 31 pass, 1 skip |
| Generated TimeSformer | 42 pass, 1 skip | 42 pass, 1 skip |
| `TracedChainValidation` | 3 pass, 1 fail | 3 pass, 1 fail |
| New | – | 11 pass |

The one `TracedChainValidation(VideoMAE)` failure is the separate one-frame default-constructor crash, fixed in the never-run-tests PR; this branch deliberately keeps clear of those lines to avoid a conflict (nearest hunk 8 lines away). Clone keeps the parameter count and `NumFrames`; serialize still works; TimeSformer's parameter count is unchanged (113,541,120).

## What this does not do (being fixed in follow-up PRs, not left)

- 14 optical-flow models fail Predict on their own declared shape ("Input must be rank 4"). Their shape is right; `OpticalFlowBase.PredictCore` doesn't add the batch dimension.
- TimeSformer still ignores `Architecture.InputFrames`. It doesn't visibly fail, but `NumFrames` and metadata misreport the count.
- VideoMAE pretraining is still not paper-faithful:
  - `PretrainMAE` computes a loss but never updates weights.
  - Masked tokens are zeroed rather than dropped.
  - The decoder stacks a GELU on ReLU convolutions.
  - There is no per-patch target normalisation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017otuSGr3GdmvPoYLbiaWR2
