### PR TITLE
fix: make disposing models and RL agents actually release what they own

### DIFF
--- a/src/Finance/Trading/Agents/FinRLAgent.cs
+++ b/src/Finance/Trading/Agents/FinRLAgent.cs
@@ -237,7 +237,29 @@ public partial class FinRLAgent<T> : TradingAgentBase<T>
         return innerMetadata;
     }
 
+    #endregion
 
+    #region Disposal
+
+    /// <summary>
+    /// Disposes the wrapped algorithm agent, which owns every network this wrapper trains.
+    /// </summary>
+    /// <remarks>
+    /// The wrapper builds no networks of its own; it delegates to the DQN/PPO/A2C/SAC agent it
+    /// constructed, so releasing that agent is what releases the networks. Repeated calls are
+    /// harmless because the inner agent's networks are released through a once-only guard.
+    /// </remarks>
+    public override void Dispose()
+    {
+        try
+        {
+            _innerAgent.Dispose();
+        }
+        finally
+        {
+            base.Dispose();
+        }
+    }
 
     #endregion
 }

--- a/src/Finance/Trading/Agents/FinancialA2CAgent.cs
+++ b/src/Finance/Trading/Agents/FinancialA2CAgent.cs
@@ -105,6 +105,8 @@ public partial class FinancialA2CAgent<T> : TradingAgentBase<T>, IGradientComput
 
         _actor = new NeuralNetwork<T>(actorArchitecture, lossFunction: TradingOptions.LossFunction ?? new MeanSquaredErrorLoss<T>());
         _critic = new NeuralNetwork<T>(criticArchitecture, lossFunction: TradingOptions.LossFunction ?? new MeanSquaredErrorLoss<T>());
+        Networks.Add(_actor);
+        Networks.Add(_critic);
         ReplayBuffer = new ReplayBuffer<T>(options.ReplayBufferSize, options.Seed);
     }
 

--- a/src/Finance/Trading/Agents/FinancialDQNAgent.cs
+++ b/src/Finance/Trading/Agents/FinancialDQNAgent.cs
@@ -108,6 +108,8 @@ public partial class FinancialDQNAgent<T> : TradingAgentBase<T>, IGradientComput
 
         _qNetwork = new NeuralNetwork<T>(architecture, lossFunction: TradingOptions.LossFunction ?? new MeanSquaredErrorLoss<T>());
         _targetNetwork = new NeuralNetwork<T>(architecture.CloneForModelConstruction(), lossFunction: TradingOptions.LossFunction ?? new MeanSquaredErrorLoss<T>());
+        Networks.Add(_qNetwork);
+        Networks.Add(_targetNetwork);
         ReplayBuffer = new ReplayBuffer<T>(options.ReplayBufferSize, options.Seed);
         UpdateTargetNetwork();
     }

--- a/src/Finance/Trading/Agents/FinancialPPOAgent.cs
+++ b/src/Finance/Trading/Agents/FinancialPPOAgent.cs
@@ -137,6 +137,8 @@ public partial class FinancialPPOAgent<T> : TradingAgentBase<T>, IGradientComput
 
         _actor = actor;
         _critic = critic;
+        Networks.Add(_actor);
+        Networks.Add(_critic);
         _trajectory = new Trajectory<T>();
         _nextStates = new List<Vector<T>>();
         _random = options.Seed.HasValue

--- a/src/Finance/Trading/Agents/FinancialSACAgent.cs
+++ b/src/Finance/Trading/Agents/FinancialSACAgent.cs
@@ -110,6 +110,11 @@ public partial class FinancialSACAgent<T> : TradingAgentBase<T>, IGradientComput
         _critic2 = new NeuralNetwork<T>(criticArchitecture.CloneForModelConstruction(), lossFunction: TradingOptions.LossFunction ?? new MeanSquaredErrorLoss<T>());
         _targetCritic1 = new NeuralNetwork<T>(criticArchitecture.CloneForModelConstruction(), lossFunction: TradingOptions.LossFunction ?? new MeanSquaredErrorLoss<T>());
         _targetCritic2 = new NeuralNetwork<T>(criticArchitecture.CloneForModelConstruction(), lossFunction: TradingOptions.LossFunction ?? new MeanSquaredErrorLoss<T>());
+        Networks.Add(_actor);
+        Networks.Add(_critic1);
+        Networks.Add(_critic2);
+        Networks.Add(_targetCritic1);
+        Networks.Add(_targetCritic2);
         ReplayBuffer = new ReplayBuffer<T>(options.ReplayBufferSize, options.Seed);
         
         UpdateTargetNetworks(1.0); // Hard sync at start

--- a/src/Finance/Trading/Agents/MarketMakingAgent.cs
+++ b/src/Finance/Trading/Agents/MarketMakingAgent.cs
@@ -139,6 +139,7 @@ public partial class MarketMakingAgent<T> : TradingAgentBase<T>, IGradientComput
         _architecture = architecture;
         EnsureMarketMakingLayers(architecture, options.StateSize, options.ActionSize);
         _policyNetwork = new NeuralNetwork<T>(architecture, lossFunction: TradingOptions.LossFunction ?? new MeanSquaredErrorLoss<T>());
+        Networks.Add(_policyNetwork);
         ReplayBuffer = new ReplayBuffer<T>(options.ReplayBufferSize, options.Seed);
     }
 

--- a/src/Finance/Trading/Agents/RecurrentPolicyAgent.cs
+++ b/src/Finance/Trading/Agents/RecurrentPolicyAgent.cs
@@ -253,7 +253,6 @@ public sealed partial class RecurrentPolicyAgent<T> : IPortfolioAgent<T>, IDispo
     /// call -- or the cell being released by another path -- is harmless. The head weights
     /// <c>_meanW</c>/<c>_meanB</c> are ordinary tensors with nothing to release.
     /// </remarks>
-    /// <exception cref="AggregateException">The cell threw from <c>Dispose</c>.</exception>
     public void Dispose()
     {
         if (_disposed) return;

--- a/src/Finance/Trading/Agents/RecurrentPolicyAgent.cs
+++ b/src/Finance/Trading/Agents/RecurrentPolicyAgent.cs
@@ -31,7 +31,7 @@ namespace AiDotNet.Finance.Trading.Agents;
 /// </para>
 /// </summary>
 /// <typeparam name="T">Element type (float/double).</typeparam>
-public sealed partial class RecurrentPolicyAgent<T> : IPortfolioAgent<T>
+public sealed partial class RecurrentPolicyAgent<T> : IPortfolioAgent<T>, IDisposable
 {
     private static readonly INumericOperations<T> NumOps = MathHelper.GetNumericOperations<T>();
     private static IEngine Engine => AiDotNetEngine.Current;
@@ -62,6 +62,7 @@ public sealed partial class RecurrentPolicyAgent<T> : IPortfolioAgent<T>
     private readonly List<T[]> _actions = new();
     private readonly List<double> _rewards = new();
     private bool _episodeDone;
+    private bool _disposed;
 
     public RecurrentPolicyAgent(
         int stateDim, int actionDim, int hidden = 32, double explorationSigma = 0.2,
@@ -242,5 +243,21 @@ public sealed partial class RecurrentPolicyAgent<T> : IPortfolioAgent<T>
         _actions.Clear();
         _rewards.Clear();
         _episodeDone = false;
+    }
+
+    /// <summary>
+    /// Releases the LSTM cell this agent owns (its pool-rented weights and registered engine state).
+    /// </summary>
+    /// <remarks>
+    /// Mirrors the RL agent bases: owned layers are released through the once-only guard, so a repeated
+    /// call -- or the cell being released by another path -- is harmless. The head weights
+    /// <c>_meanW</c>/<c>_meanB</c> are ordinary tensors with nothing to release.
+    /// </remarks>
+    /// <exception cref="AggregateException">The cell threw from <c>Dispose</c>.</exception>
+    public void Dispose()
+    {
+        if (_disposed) return;
+        _disposed = true;
+        DisposeOnceGuard.DisposeAll(new object?[] { _cell }, nameof(RecurrentPolicyAgent<T>));
     }
 }

--- a/src/Finance/Trading/Agents/TradingAgentBase.cs
+++ b/src/Finance/Trading/Agents/TradingAgentBase.cs
@@ -665,9 +665,10 @@ public abstract partial class TradingAgentBase<T> : ReinforcementLearningAgentBa
     /// hold the same instance, and calling this method again is harmless: disposal goes through
     /// the same process-wide once-only guard that <see cref="NeuralNetworkBase{T}"/> uses for its layers.
     /// A network whose <c>Dispose</c> throws does not stop the others from being released; every
-    /// failure is reported afterwards in one <see cref="AggregateException"/>.
+    /// failure is reported afterwards: a single failure is rethrown unchanged (same type and stack), two or
+    /// more together in one <see cref="AggregateException"/>.
     /// </remarks>
-    /// <exception cref="AggregateException">One or more networks threw from <c>Dispose</c>.</exception>
+    /// <exception cref="AggregateException">Two or more networks threw from <c>Dispose</c>.</exception>
     public override void Dispose()
     {
         try

--- a/src/Finance/Trading/Agents/TradingAgentBase.cs
+++ b/src/Finance/Trading/Agents/TradingAgentBase.cs
@@ -664,15 +664,15 @@ public abstract partial class TradingAgentBase<T> : ReinforcementLearningAgentBa
     /// Each network is released at most once, even when two of the agent's fields (or two agents)
     /// hold the same instance, and calling this method again is harmless: disposal goes through
     /// the same process-wide once-only guard that <see cref="NeuralNetworkBase{T}"/> uses for its layers.
+    /// A network whose <c>Dispose</c> throws does not stop the others from being released; every
+    /// failure is reported afterwards in one <see cref="AggregateException"/>.
     /// </remarks>
+    /// <exception cref="AggregateException">One or more networks threw from <c>Dispose</c>.</exception>
     public override void Dispose()
     {
         try
         {
-            foreach (var network in Networks)
-            {
-                DisposeOnceGuard.TryDispose(network);
-            }
+            DisposeOnceGuard.DisposeAll(Networks, GetType().Name);
         }
         finally
         {

--- a/src/Finance/Trading/Agents/TradingAgentBase.cs
+++ b/src/Finance/Trading/Agents/TradingAgentBase.cs
@@ -1,3 +1,4 @@
+using AiDotNet.Attributes;
 using AiDotNet.Finance.Interfaces;
 using AiDotNet.Interfaces;
 using AiDotNet.LinearAlgebra;
@@ -101,6 +102,27 @@ public abstract partial class TradingAgentBase<T> : ReinforcementLearningAgentBa
     /// Total number of trades executed.
     /// </summary>
     protected int _totalTrades;
+
+    /// <summary>
+    /// The neural networks this agent owns: policy, value, Q and target networks.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This mirrors <see cref="DeepReinforcementLearningAgentBase{T}"/>'s <c>Networks</c> list. A trading
+    /// agent derives from <see cref="ReinforcementLearningAgentBase{T}"/> directly, whose
+    /// <see cref="ReinforcementLearningAgentBase{T}.Dispose"/> releases nothing, so without this list a
+    /// disposed PPO/DQN/A2C/SAC agent left every network it had built -- with its pooled weight
+    /// buffers, GPU allocations and compiled training plans -- alive until the garbage collector ran.
+    /// Every concrete agent adds each network it constructs here, and <see cref="Dispose"/> releases them.
+    /// </para>
+    /// <para>
+    /// This is lifecycle bookkeeping only, not a parameter surface. The concrete agents' own fields
+    /// declare whether each network is trainable or a target buffer; registering this mixed-role
+    /// aggregate as trainable would alias the target networks under the wrong role.
+    /// </para>
+    /// </remarks>
+    [ExternalState]
+    protected readonly List<INeuralNetwork<T>> Networks = new List<INeuralNetwork<T>>();
 
     #endregion
 
@@ -633,6 +655,29 @@ public abstract partial class TradingAgentBase<T> : ReinforcementLearningAgentBa
     public override Dictionary<string, T> GetMetrics()
     {
         return GetTradingMetrics();
+    }
+
+    /// <summary>
+    /// Disposes the agent and every network it owns.
+    /// </summary>
+    /// <remarks>
+    /// Each network is released at most once, even when two of the agent's fields (or two agents)
+    /// hold the same instance, and calling this method again is harmless: disposal goes through
+    /// the same process-wide once-only guard that <see cref="NeuralNetworkBase{T}"/> uses for its layers.
+    /// </remarks>
+    public override void Dispose()
+    {
+        try
+        {
+            foreach (var network in Networks)
+            {
+                DisposeOnceGuard.TryDispose(network);
+            }
+        }
+        finally
+        {
+            base.Dispose();
+        }
     }
 
     #endregion

--- a/src/Finance/Trading/Evaluation/PortfolioAgentTraining.cs
+++ b/src/Finance/Trading/Evaluation/PortfolioAgentTraining.cs
@@ -176,15 +176,41 @@ public static class PortfolioExperimentRunner
             // Each experiment fully specifies its environment (reward + leverage + frictions), so the harness
             // sweeps all those axes, not just the objective.
             var trainEnv = experiment.BuildEnvironment<T>(trainAssetPrices, trainFeatureColumns, windowSize, initialCapital);
-            var agent = agentFactory(trainEnv.ObservationSpaceDimension, trainEnv.ActionSpaceSize);
-            PortfolioAgentTrainer.Train(agent, trainEnv, trainEpisodes);
 
-            // Evaluate the trained agent on the untouched holdout (greedy — no exploration). Reset the agent's
-            // per-episode state first so a recurrent policy starts the holdout with a clean hidden state rather
-            // than one carried over from the last training step.
-            agent.ResetEpisode();
-            var agentEnv = experiment.BuildEnvironment<T>(holdoutAssetPrices, holdoutFeatureColumns, windowSize, initialCapital);
-            var agentResult = PortfolioBacktest.Run(agentEnv, s => agent.SelectAction(s, explore: false));
+            // The factory builds a FRESH agent for this experiment and the runner never hands it back, so the
+            // runner is its only owner and releases it (a RecurrentPolicyAgent holds a pool-rented LSTM cell)
+            // once the experiment is done -- or fails.
+            var agent = agentFactory(trainEnv.ObservationSpaceDimension, trainEnv.ActionSpaceSize);
+            PortfolioBacktestResult agentResult;
+            try
+            {
+                PortfolioAgentTrainer.Train(agent, trainEnv, trainEpisodes);
+
+                // Evaluate the trained agent on the untouched holdout (greedy — no exploration). Reset the agent's
+                // per-episode state first so a recurrent policy starts the holdout with a clean hidden state rather
+                // than one carried over from the last training step.
+                agent.ResetEpisode();
+                var agentEnv = experiment.BuildEnvironment<T>(holdoutAssetPrices, holdoutFeatureColumns, windowSize, initialCapital);
+                agentResult = PortfolioBacktest.Run(agentEnv, s => agent.SelectAction(s, explore: false));
+            }
+            catch
+            {
+                // Release the agent without letting a secondary cleanup failure replace the reason the
+                // experiment failed: the caller needs the original exception.
+                try
+                {
+                    (agent as IDisposable)?.Dispose();
+                }
+                catch (Exception disposeEx) when (disposeEx is not OutOfMemoryException)
+                {
+                    System.Diagnostics.Trace.TraceWarning(
+                        $"PortfolioExperimentRunner: disposing the agent for '{experiment.Name}' after a failure also threw: {disposeEx.Message}");
+                }
+
+                throw;
+            }
+
+            (agent as IDisposable)?.Dispose();
 
             // The no-skill control on the SAME holdout environment (same frictions/leverage).
             var baseEnv = experiment.BuildEnvironment<T>(holdoutAssetPrices, holdoutFeatureColumns, windowSize, initialCapital);

--- a/src/Helpers/DisposeOnceGuard.cs
+++ b/src/Helpers/DisposeOnceGuard.cs
@@ -82,5 +82,44 @@ internal static class DisposeOnceGuard
         }
     }
 
+    /// <summary>
+    /// Disposes every <see cref="IDisposable"/> in <paramref name="owned"/> through <see cref="TryDispose"/>,
+    /// continuing past failures, then throws one <see cref="AggregateException"/> carrying every failure.
+    /// </summary>
+    /// <param name="owned">The resources to release; nulls and non-disposable entries are skipped.</param>
+    /// <param name="owner">Names the owner in the aggregate message.</param>
+    /// <remarks>
+    /// An owner that releases its resources in a plain loop leaks every resource after the first one whose
+    /// <c>Dispose</c> throws. Collecting the failures and reporting them together after the loop releases
+    /// everything that can be released, which is the library's convention for multi-resource disposal
+    /// (compare <c>DataPipeline</c>). Each instance is still disposed at most once, so the same resource
+    /// listed twice, or shared with another owner, is released a single time.
+    /// </remarks>
+    /// <exception cref="AggregateException">One or more resources threw from <c>Dispose</c>.</exception>
+    public static void DisposeAll(IEnumerable<object?> owned, string owner)
+    {
+        if (owned is null) return;
+
+        List<Exception>? failures = null;
+        foreach (var item in owned)
+        {
+            if (item is not IDisposable disposable) continue;
+            try
+            {
+                TryDispose(disposable);
+            }
+            catch (Exception ex) when (ex is not OutOfMemoryException)
+            {
+                failures ??= new List<Exception>();
+                failures.Add(ex);
+            }
+        }
+
+        if (failures is { Count: > 0 })
+        {
+            throw new AggregateException($"One or more resources owned by {owner} failed to dispose.", failures);
+        }
+    }
+
     private static readonly object _sentinel = new();
 }

--- a/src/Helpers/DisposeOnceGuard.cs
+++ b/src/Helpers/DisposeOnceGuard.cs
@@ -84,18 +84,28 @@ internal static class DisposeOnceGuard
 
     /// <summary>
     /// Disposes every <see cref="IDisposable"/> in <paramref name="owned"/> through <see cref="TryDispose"/>,
-    /// continuing past failures, then throws one <see cref="AggregateException"/> carrying every failure.
+    /// continuing past failures, then reports them: a single failure is rethrown unchanged, two or more are
+    /// thrown together as one <see cref="AggregateException"/>.
     /// </summary>
     /// <param name="owned">The resources to release; nulls and non-disposable entries are skipped.</param>
     /// <param name="owner">Names the owner in the aggregate message.</param>
     /// <remarks>
+    /// <para>
     /// An owner that releases its resources in a plain loop leaks every resource after the first one whose
-    /// <c>Dispose</c> throws. Collecting the failures and reporting them together after the loop releases
-    /// everything that can be released, which is the library's convention for multi-resource disposal
-    /// (compare <c>DataPipeline</c>). Each instance is still disposed at most once, so the same resource
-    /// listed twice, or shared with another owner, is released a single time.
+    /// <c>Dispose</c> throws. Collecting the failures and reporting them after the loop releases everything
+    /// that can be released. Each instance is still disposed at most once, so the same resource listed twice,
+    /// or shared with another owner, is released a single time.
+    /// </para>
+    /// <para>
+    /// Exactly one failure -- by far the common case -- is rethrown as the original exception through
+    /// <see cref="System.Runtime.ExceptionServices.ExceptionDispatchInfo"/>, keeping its type and the stack of the
+    /// code that threw it. A caller that caught a specific exception type from an owner's <c>Dispose</c> before
+    /// that owner started using this method therefore keeps working. Only two or more failures, which cannot be
+    /// reported as one exception without losing some, are wrapped in an <see cref="AggregateException"/> -- the
+    /// library's convention for multi-resource disposal (compare <c>DataPipeline</c>).
+    /// </para>
     /// </remarks>
-    /// <exception cref="AggregateException">One or more resources threw from <c>Dispose</c>.</exception>
+    /// <exception cref="AggregateException">Two or more resources threw from <c>Dispose</c>.</exception>
     public static void DisposeAll(IEnumerable<object?> owned, string owner)
     {
         if (owned is null) return;
@@ -115,10 +125,14 @@ internal static class DisposeOnceGuard
             }
         }
 
-        if (failures is { Count: > 0 })
+        if (failures is null) return;
+
+        if (failures.Count == 1)
         {
-            throw new AggregateException($"One or more resources owned by {owner} failed to dispose.", failures);
+            System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture(failures[0]).Throw();
         }
+
+        throw new AggregateException($"{failures.Count} resources owned by {owner} failed to dispose.", failures);
     }
 
     private static readonly object _sentinel = new();

--- a/src/Models/ModelBase.cs
+++ b/src/Models/ModelBase.cs
@@ -570,6 +570,9 @@ public abstract partial class ModelBase<T, TInput, TOutput> : IFullModel<T, TInp
     /// </remarks>
     public void Dispose()
     {
+        // A repeated call must not re-enter a derived Dispose(bool) override: overrides do their
+        // own teardown before calling base, so only this entry point can keep that teardown to one run.
+        if (_disposed) return;
         Dispose(disposing: true);
         System.GC.SuppressFinalize(this);
     }

--- a/src/Models/Results/AiModelResult.cs
+++ b/src/Models/Results/AiModelResult.cs
@@ -7608,9 +7608,11 @@ public partial class AiModelResult<T, TInput, TOutput> : IFullModel<T, TInput, T
     /// <remarks>
     /// <para>
     /// Besides <see cref="Model"/>, a result can hold model instances nobody else references: the clone that
-    /// stateless inference optimizations rewrite (<see cref="_inferenceOptimizedNeuralModel"/>) and the extra
-    /// members of a deep ensemble. Each is released once; an instance that is <see cref="Model"/> itself is
-    /// released only as <see cref="Model"/>.
+    /// stateless inference optimizations rewrite (<see cref="_inferenceOptimizedNeuralModel"/>), the extra
+    /// members of a deep ensemble, and -- on the meta-learning path, where <see cref="Model"/> is the
+    /// meta-learner's base model -- the optimizer's separate <see cref="OptimizationResult"/> best solution.
+    /// Each is released exactly once, even when it is reachable along several of these paths; an instance that
+    /// is <see cref="Model"/> itself is released only as <see cref="Model"/>.
     /// </para>
     /// <para>
     /// The copies are released before <see cref="Model"/>. A copy-on-write clone shares the source's weight
@@ -7640,6 +7642,16 @@ public partial class AiModelResult<T, TInput, TOutput> : IFullModel<T, TInput, T
                 {
                     if (!ReferenceEquals(member, Model)) owned.Add(member);
                 }
+            }
+
+            // On the standard path BestSolution IS Model. On the meta-learning path Model is the meta-learner's
+            // BaseModel and BestSolution is a separate instance that only this result holds (OptimizationResult is
+            // never shared: WithParameters/DeepCopy deep-copy it and replace BestSolution). The once-only guard in
+            // DisposeAll keeps it to one release if it is also an ensemble member.
+            var bestSolution = OptimizationResult?.BestSolution;
+            if (bestSolution is not null && !ReferenceEquals(bestSolution, Model))
+            {
+                owned.Add(bestSolution);
             }
 
             owned.Add(Model);

--- a/src/Models/Results/AiModelResult.cs
+++ b/src/Models/Results/AiModelResult.cs
@@ -7511,6 +7511,9 @@ public partial class AiModelResult<T, TInput, TOutput> : IFullModel<T, TInput, T
     /// </remarks>
     public void Dispose()
     {
+        // A repeated call must not re-enter a derived Dispose(bool) override: overrides do their
+        // own teardown before calling base, so only this entry point can keep that teardown to one run.
+        if (_disposed) return;
         Dispose(disposing: true);
         System.GC.SuppressFinalize(this);
     }

--- a/src/Models/Results/AiModelResult.cs
+++ b/src/Models/Results/AiModelResult.cs
@@ -1074,6 +1074,14 @@ public partial class AiModelResult<T, TInput, TOutput> : IFullModel<T, TInput, T
     [JsonIgnore]
     private NeuralNetworkBase<T>? _inferenceOptimizedNeuralModel;
 
+    /// <summary>
+    /// True when <see cref="_inferenceOptimizedNeuralModel"/> is a copy this result made (the optimizer
+    /// cloned <see cref="Model"/> before rewriting it) rather than <see cref="Model"/> itself. Only an owned
+    /// copy is disposed with the result; the wrapped model is released through <see cref="Model"/>.
+    /// </summary>
+    [JsonIgnore]
+    private bool _ownsInferenceOptimizedNeuralModel;
+
     [JsonIgnore]
     private bool _inferenceOptimizationsInitialized;
 
@@ -3050,9 +3058,27 @@ public partial class AiModelResult<T, TInput, TOutput> : IFullModel<T, TInput, T
                     var statelessConfig = CreateStatelessInferenceConfig(InferenceOptimizationConfig);
                     var optimizer = new InferenceOptimizer<T>(statelessConfig);
                     var (optimizedModel, anyApplied) = optimizer.OptimizeForInference(model, cloneModel: true);
+                    bool isCopy = !ReferenceEquals(optimizedModel, model);
 
                     _inferenceOptimizer = optimizer;
-                    _inferenceOptimizedNeuralModel = anyApplied ? optimizedModel : null;
+                    if (anyApplied)
+                    {
+                        _inferenceOptimizedNeuralModel = optimizedModel;
+                        _ownsInferenceOptimizedNeuralModel = isCopy;
+                    }
+                    else
+                    {
+                        _inferenceOptimizedNeuralModel = null;
+                        _ownsInferenceOptimizedNeuralModel = false;
+
+                        // The optimizer cloned the model expecting to rewrite it, then found nothing to apply.
+                        // Nothing will ever use that clone again, so release it now instead of leaving its
+                        // layers' pooled buffers for the garbage collector.
+                        if (isCopy)
+                        {
+                            AiDotNet.Helpers.DisposeOnceGuard.TryDispose(optimizedModel);
+                        }
+                    }
                 }
             }
             catch (Exception ex)
@@ -3060,6 +3086,7 @@ public partial class AiModelResult<T, TInput, TOutput> : IFullModel<T, TInput, T
                 Console.WriteLine($"Warning: inference optimizations failed: {ex.Message}");
                 _inferenceOptimizer = null;
                 _inferenceOptimizedNeuralModel = null;
+                _ownsInferenceOptimizedNeuralModel = false;
             }
             finally
             {
@@ -3164,6 +3191,10 @@ public partial class AiModelResult<T, TInput, TOutput> : IFullModel<T, TInput, T
         // Session-local inference state (populated lazily when used).
         private InferenceOptimizer<T>? _sequenceOptimizer;
         private NeuralNetworkBase<T>? _sequenceOptimizedNeuralModel;
+
+        // True when _sequenceOptimizedNeuralModel is a copy this sequence made (a KV-cache clone or a
+        // Multi-LoRA clone) rather than the result's Model, which the sequence only borrows.
+        private bool _ownsSequenceModel;
         private volatile bool _sequenceInitialized;
         private readonly object _sequenceLock = new();
 
@@ -3283,7 +3314,7 @@ public partial class AiModelResult<T, TInput, TOutput> : IFullModel<T, TInput, T
                 }
 
                 _sequenceOptimizer = null;
-                _sequenceOptimizedNeuralModel = null;
+                ReleaseSequenceModel();
                 _sequenceInitialized = false;
             }
         }
@@ -3305,7 +3336,37 @@ public partial class AiModelResult<T, TInput, TOutput> : IFullModel<T, TInput, T
                 // Best-effort cleanup; disposal must not throw.
             }
 
+            lock (_sequenceLock)
+            {
+                try
+                {
+                    ReleaseSequenceModel();
+                }
+                catch (Exception ex)
+                {
+                    // Disposal must not throw (see above); the copy is unreachable either way.
+                    Console.WriteLine($"Warning: releasing the inference sequence's model copy failed: {ex.Message}");
+                }
+            }
+
             _disposed = true;
+        }
+
+        /// <summary>
+        /// Releases the sequence's model copy when the sequence made it, then forgets it. The result's own
+        /// <c>Model</c> -- which a sequence uses directly when no copy was needed -- is never released
+        /// here; the result owns it.
+        /// </summary>
+        private void ReleaseSequenceModel()
+        {
+            var copy = _sequenceOptimizedNeuralModel;
+            bool owned = _ownsSequenceModel;
+            _sequenceOptimizedNeuralModel = null;
+            _ownsSequenceModel = false;
+            if (owned && copy is not null && !ReferenceEquals(copy, _result.Model))
+            {
+                AiDotNet.Helpers.DisposeOnceGuard.TryDispose(copy);
+            }
         }
 
         // Exposed to AiDotNetTests via InternalsVisibleTo for integration verification without expanding the public API surface.
@@ -3332,6 +3393,7 @@ public partial class AiModelResult<T, TInput, TOutput> : IFullModel<T, TInput, T
                     return _sequenceOptimizedNeuralModel;
                 }
 
+                NeuralNetworkBase<T>? multiLoRACopy = null;
                 try
                 {
                     // Every sequence owns its optimizer and cache, but all sequences clone the same source
@@ -3351,6 +3413,7 @@ public partial class AiModelResult<T, TInput, TOutput> : IFullModel<T, TInput, T
                                 try
                                 {
                                     modelForSequence = (NeuralNetworkBase<T>)model.Clone();
+                                    multiLoRACopy = modelForSequence;
 
                                     // Shared with the serving batcher (AiDotNet.LoRA.LoRAAdapterSelection) so the
                                     // "switch every adapter layer to this task" logic lives in exactly one place.
@@ -3397,7 +3460,19 @@ public partial class AiModelResult<T, TInput, TOutput> : IFullModel<T, TInput, T
 
                             _sequenceOptimizer = optimizer;
                             // If Multi-LoRA was requested, keep the per-sequence model even when no other optimizations apply.
-                            _sequenceOptimizedNeuralModel = anyApplied || !ReferenceEquals(modelForSequence, model) ? optimizedModel : null;
+                            var kept = anyApplied || !ReferenceEquals(modelForSequence, model) ? optimizedModel : null;
+                            _sequenceOptimizedNeuralModel = kept;
+                            _ownsSequenceModel = kept is not null && !ReferenceEquals(kept, model);
+
+                            // A clone the optimizer made and then found nothing to apply to is never used.
+                            if (kept is null && !ReferenceEquals(optimizedModel, model))
+                            {
+                                AiDotNet.Helpers.DisposeOnceGuard.TryDispose(optimizedModel);
+                            }
+                            else if (multiLoRACopy is not null && !ReferenceEquals(multiLoRACopy, kept))
+                            {
+                                AiDotNet.Helpers.DisposeOnceGuard.TryDispose(multiLoRACopy);
+                            }
                         }
                     }
                 }
@@ -3406,6 +3481,14 @@ public partial class AiModelResult<T, TInput, TOutput> : IFullModel<T, TInput, T
                     Console.WriteLine($"Warning: inference session optimizations failed: {ex.Message}");
                     _sequenceOptimizer = null;
                     _sequenceOptimizedNeuralModel = null;
+                    _ownsSequenceModel = false;
+
+                    // A Multi-LoRA clone made before the failure has no other owner.
+                    if (multiLoRACopy is not null && !ReferenceEquals(multiLoRACopy, model))
+                    {
+                        try { AiDotNet.Helpers.DisposeOnceGuard.TryDispose(multiLoRACopy); }
+                        catch (Exception disposeEx) { Console.WriteLine($"Warning: releasing the Multi-LoRA copy failed: {disposeEx.Message}"); }
+                    }
                 }
                 finally
                 {
@@ -5848,7 +5931,7 @@ public partial class AiModelResult<T, TInput, TOutput> : IFullModel<T, TInput, T
                 // Reset transient runtime state (will be reinitialized lazily)
                 JitCompiledFunction = null;
                 _inferenceOptimizer = null;
-                _inferenceOptimizedNeuralModel = null;
+                ReleaseInferenceOptimizedModel();
                 _inferenceOptimizationsInitialized = false;
 
                 // Restore the model's internal state from the model-owned serialized payload when available.
@@ -7518,15 +7601,70 @@ public partial class AiModelResult<T, TInput, TOutput> : IFullModel<T, TInput, T
         System.GC.SuppressFinalize(this);
     }
 
-    /// <summary>Disposes the contained model. Override + call base for additional cleanup.</summary>
+    /// <summary>
+    /// Disposes the contained model and every model copy this result made for itself. Override + call base for
+    /// additional cleanup.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Besides <see cref="Model"/>, a result can hold model instances nobody else references: the clone that
+    /// stateless inference optimizations rewrite (<see cref="_inferenceOptimizedNeuralModel"/>) and the extra
+    /// members of a deep ensemble. Each is released once; an instance that is <see cref="Model"/> itself is
+    /// released only as <see cref="Model"/>.
+    /// </para>
+    /// <para>
+    /// The copies are released before <see cref="Model"/>. A copy-on-write clone shares the source's weight
+    /// storage, and only the source holds the pooled array behind it; releasing the source first would hand
+    /// that storage back to the pool while the copy could still read it.
+    /// </para>
+    /// <para>
+    /// Every resource is released even if one of them throws; the failures are then reported together in one
+    /// <see cref="AggregateException"/>.
+    /// </para>
+    /// </remarks>
     protected virtual void Dispose(bool disposing)
     {
         if (_disposed) return;
         if (disposing)
         {
-            (Model as System.IDisposable)?.Dispose();
+            var owned = new List<object?>();
+            if (_ownsInferenceOptimizedNeuralModel && !ReferenceEquals(_inferenceOptimizedNeuralModel, Model))
+            {
+                owned.Add(_inferenceOptimizedNeuralModel);
+            }
+
+            if (_deepEnsembleModels is not null)
+            {
+                foreach (var member in _deepEnsembleModels)
+                {
+                    if (!ReferenceEquals(member, Model)) owned.Add(member);
+                }
+            }
+
+            owned.Add(Model);
+
+            _inferenceOptimizedNeuralModel = null;
+            _ownsInferenceOptimizedNeuralModel = false;
+            _disposed = true;
+            AiDotNet.Helpers.DisposeOnceGuard.DisposeAll(owned, nameof(AiModelResult<T, TInput, TOutput>));
+            return;
         }
         _disposed = true;
+    }
+
+    /// <summary>
+    /// Releases the stateless inference-optimized copy when this result made it, then forgets it.
+    /// </summary>
+    private void ReleaseInferenceOptimizedModel()
+    {
+        var copy = _inferenceOptimizedNeuralModel;
+        bool owned = _ownsInferenceOptimizedNeuralModel;
+        _inferenceOptimizedNeuralModel = null;
+        _ownsInferenceOptimizedNeuralModel = false;
+        if (owned && copy is not null && !ReferenceEquals(copy, Model))
+        {
+            AiDotNet.Helpers.DisposeOnceGuard.TryDispose(copy);
+        }
     }
 
 }

--- a/src/Models/Results/AiModelResult.cs
+++ b/src/Models/Results/AiModelResult.cs
@@ -7618,8 +7618,9 @@ public partial class AiModelResult<T, TInput, TOutput> : IFullModel<T, TInput, T
     /// that storage back to the pool while the copy could still read it.
     /// </para>
     /// <para>
-    /// Every resource is released even if one of them throws; the failures are then reported together in one
-    /// <see cref="AggregateException"/>.
+    /// Every resource is released even if one of them throws. A single failure is then rethrown unchanged
+    /// (same type and stack, as when only <see cref="Model"/> was disposed here); two or more are reported
+    /// together in one <see cref="AggregateException"/>.
     /// </para>
     /// </remarks>
     protected virtual void Dispose(bool disposing)

--- a/src/NeuralNetworks/Layers/LayerBase.cs
+++ b/src/NeuralNetworks/Layers/LayerBase.cs
@@ -9350,6 +9350,15 @@ public abstract class LayerBase<T> : ILayer<T>, ITrainableLayer<T>, IParameterSo
     /// </remarks>
     public void Dispose()
     {
+        // A repeated call must not re-enter a derived Dispose(bool) override. Overrides run their own
+        // teardown before calling base -- DenseLayer's, for one, re-invalidates the engine's GPU cache
+        // entry for _weights/_biases, tensors whose pooled storage the first call already handed back
+        // and a newer layer may now own. Only this entry point can keep that teardown to one run.
+        lock (_bufferRegistrationLock)
+        {
+            if (_disposed) return;
+        }
+
         Dispose(disposing: true);
         GC.SuppressFinalize(this);
     }

--- a/src/NeuralNetworks/NeuralNetworkBase.cs
+++ b/src/NeuralNetworks/NeuralNetworkBase.cs
@@ -18215,12 +18215,23 @@ public abstract partial class NeuralNetworkBase<T> : INeuralNetworkModel<T>, IIn
     /// </summary>
     /// <remarks>
     /// Ensures that the mixed-precision context is properly disposed if it was enabled.
+    /// Calling it more than once is harmless: only the first call tears anything down. That
+    /// holds for derived classes too, whose <see cref="Dispose(bool)"/> overrides are not
+    /// re-entered by a repeated call.
     /// </remarks>
     public void Dispose()
     {
+        if (_disposed) return;
         Dispose(true);
         GC.SuppressFinalize(this);
     }
+
+    /// <summary>
+    /// Set by the first <see cref="Dispose(bool)"/>. A repeated dispose must be a no-op: the
+    /// teardown invalidates the THREAD-GLOBAL tape-training caches, so re-running it on a long-
+    /// disposed network would evict the cache of whichever live model the thread trained since.
+    /// </summary>
+    private bool _disposed;
 
     /// <summary>
     /// Protected Dispose pattern implementation.
@@ -18237,6 +18248,9 @@ public abstract partial class NeuralNetworkBase<T> : INeuralNetworkModel<T>, IIn
     /// </remarks>
     protected virtual void Dispose(bool disposing)
     {
+        if (_disposed) return;
+        _disposed = true;
+
         if (disposing)
         {
             // Release inference plans plus training plans/caches before layer disposal.

--- a/src/ReinforcementLearning/Agents/CQLAgent.cs
+++ b/src/ReinforcementLearning/Agents/CQLAgent.cs
@@ -113,6 +113,13 @@ public partial class CQLAgent<T> : DeepReinforcementLearningAgentBase<T>, IGradi
         _targetQ1Network = CreateQNetwork();
         _targetQ2Network = CreateQNetwork();
 
+        // Register every network so DeepReinforcementLearningAgentBase.Dispose releases it.
+        Networks.Add(_policyNetwork);
+        Networks.Add(_q1Network);
+        Networks.Add(_q2Network);
+        Networks.Add(_targetQ1Network);
+        Networks.Add(_targetQ2Network);
+
         CopyNetworkWeights(_q1Network, _targetQ1Network);
         CopyNetworkWeights(_q2Network, _targetQ2Network);
 

--- a/src/ReinforcementLearning/Agents/DeepReinforcementLearningAgentBase.cs
+++ b/src/ReinforcementLearning/Agents/DeepReinforcementLearningAgentBase.cs
@@ -129,9 +129,10 @@ public abstract partial class DeepReinforcementLearningAgentBase<T> : Reinforcem
     /// Each network is released at most once, even when it is registered twice or shared with another
     /// owner, through the same once-only guard <see cref="NeuralNetworkBase{T}"/> uses for its layers.
     /// A network whose <c>Dispose</c> throws no longer stops the loop and leaks every network after it:
-    /// all are released first, then every failure is reported in one <see cref="AggregateException"/>.
+    /// all are released first. A single failure is then rethrown unchanged (same type and stack); two or more
+    /// are reported together in one <see cref="AggregateException"/>.
     /// </remarks>
-    /// <exception cref="AggregateException">One or more networks threw from <c>Dispose</c>.</exception>
+    /// <exception cref="AggregateException">Two or more networks threw from <c>Dispose</c>.</exception>
     public override void Dispose()
     {
         try

--- a/src/ReinforcementLearning/Agents/DeepReinforcementLearningAgentBase.cs
+++ b/src/ReinforcementLearning/Agents/DeepReinforcementLearningAgentBase.cs
@@ -123,18 +123,25 @@ public abstract partial class DeepReinforcementLearningAgentBase<T> : Reinforcem
     }
 
     /// <summary>
-    /// Disposes of resources used by the agent, including neural networks.
+    /// Disposes of resources used by the agent, including every network registered in <see cref="Networks"/>.
     /// </summary>
+    /// <remarks>
+    /// Each network is released at most once, even when it is registered twice or shared with another
+    /// owner, through the same once-only guard <see cref="NeuralNetworkBase{T}"/> uses for its layers.
+    /// A network whose <c>Dispose</c> throws no longer stops the loop and leaks every network after it:
+    /// all are released first, then every failure is reported in one <see cref="AggregateException"/>.
+    /// </remarks>
+    /// <exception cref="AggregateException">One or more networks threw from <c>Dispose</c>.</exception>
     public override void Dispose()
     {
-        foreach (var network in Networks)
+        try
         {
-            if (network is IDisposable disposable)
-            {
-                disposable.Dispose();
-            }
+            AiDotNet.Helpers.DisposeOnceGuard.DisposeAll(Networks, GetType().Name);
         }
-        base.Dispose();
+        finally
+        {
+            base.Dispose();
+        }
     }
 
     // ===== JIT Compilation Support =====

--- a/src/ReinforcementLearning/Agents/DuelingDQNAgent.cs
+++ b/src/ReinforcementLearning/Agents/DuelingDQNAgent.cs
@@ -316,7 +316,7 @@ public partial class DuelingDQNAgent<T> : DeepReinforcementLearningAgentBase<T>,
     /// <see cref="INeuralNetwork{T}"/>, so they cannot be registered in <c>Networks</c> and the base class
     /// never saw them: disposing this agent used to release none of their layers.
     /// </remarks>
-    /// <exception cref="AggregateException">One or more owned resources threw from <c>Dispose</c>.</exception>
+    /// <exception cref="AggregateException">Both networks threw from <c>Dispose</c>; a single failure is rethrown unchanged.</exception>
     public override void Dispose()
     {
         try
@@ -412,7 +412,7 @@ internal class DuelingNetwork<T> : IParameterSource<T>, IDisposable
     /// <summary>
     /// Releases every dense layer of the shared, value and advantage streams, each at most once.
     /// </summary>
-    /// <exception cref="AggregateException">One or more layers threw from <c>Dispose</c>.</exception>
+    /// <exception cref="AggregateException">Two or more layers threw from <c>Dispose</c>; a single failure is rethrown unchanged.</exception>
     public void Dispose()
     {
         AiDotNet.Helpers.DisposeOnceGuard.DisposeAll(

--- a/src/ReinforcementLearning/Agents/DuelingDQNAgent.cs
+++ b/src/ReinforcementLearning/Agents/DuelingDQNAgent.cs
@@ -307,12 +307,37 @@ public partial class DuelingDQNAgent<T> : DeepReinforcementLearningAgentBase<T>,
             Deserialize(data);
         }
     }
+
+    /// <summary>
+    /// Disposes the agent and both dueling networks it owns.
+    /// </summary>
+    /// <remarks>
+    /// The online and target networks are <see cref="DuelingNetwork{T}"/> instances rather than
+    /// <see cref="INeuralNetwork{T}"/>, so they cannot be registered in <c>Networks</c> and the base class
+    /// never saw them: disposing this agent used to release none of their layers.
+    /// </remarks>
+    /// <exception cref="AggregateException">One or more owned resources threw from <c>Dispose</c>.</exception>
+    public override void Dispose()
+    {
+        try
+        {
+            Helpers.DisposeOnceGuard.DisposeAll(new object?[] { _qNetwork, _targetNetwork }, GetType().Name);
+        }
+        finally
+        {
+            base.Dispose();
+        }
+    }
 }
 
 /// <summary>
 /// Custom dueling network architecture that separates value and advantage streams.
 /// </summary>
-internal class DuelingNetwork<T> : IParameterSource<T>
+/// <remarks>
+/// Owns its dense layers directly (it is not a <see cref="NeuralNetworkBase{T}"/>), so disposing it releases
+/// each of them through the same once-only guard a network uses for its layers.
+/// </remarks>
+internal class DuelingNetwork<T> : IParameterSource<T>, IDisposable
 {
     private readonly INumericOperations<T> _numOps;
     private readonly List<DenseLayer<T>> _sharedLayers;
@@ -382,6 +407,16 @@ internal class DuelingNetwork<T> : IParameterSource<T>
             prevSize = size;
         }
         _advantageLayers.Add(new DenseLayer<T>(actionSize, (IActivationFunction<T>)new IdentityActivation<T>())); // Output per-action advantages
+    }
+
+    /// <summary>
+    /// Releases every dense layer of the shared, value and advantage streams, each at most once.
+    /// </summary>
+    /// <exception cref="AggregateException">One or more layers threw from <c>Dispose</c>.</exception>
+    public void Dispose()
+    {
+        AiDotNet.Helpers.DisposeOnceGuard.DisposeAll(
+            _sharedLayers.Concat(_valueLayers).Concat(_advantageLayers), nameof(DuelingNetwork<T>));
     }
 
     public void EnsureInitialized()

--- a/src/ReinforcementLearning/Agents/IQLAgent.cs
+++ b/src/ReinforcementLearning/Agents/IQLAgent.cs
@@ -122,6 +122,13 @@ public partial class IQLAgent<T> : DeepReinforcementLearningAgentBase<T>, IGradi
         _q2Network = CreateQNetwork();
         _targetValueNetwork = CreateValueNetwork();
 
+        // Register every network so DeepReinforcementLearningAgentBase.Dispose releases it.
+        Networks.Add(_policyNetwork);
+        Networks.Add(_valueNetwork);
+        Networks.Add(_q1Network);
+        Networks.Add(_q2Network);
+        Networks.Add(_targetValueNetwork);
+
         CopyNetworkWeights(_valueNetwork, _targetValueNetwork);
 
         // Initialize offline buffer

--- a/src/ReinforcementLearning/Agents/QMIXAgent.cs
+++ b/src/ReinforcementLearning/Agents/QMIXAgent.cs
@@ -113,10 +113,6 @@ public partial class QMIXAgent<T> : DeepReinforcementLearningAgentBase<T>, IGrad
             Epsilon = 1e-8
         });
         _epsilon = options.EpsilonStart;
-        _agentNetworks = new List<INeuralNetwork<T>>();
-        _targetAgentNetworks = new List<INeuralNetwork<T>>();
-        _mixingNetwork = CreateMixingNetwork();
-        _targetMixingNetwork = CreateMixingNetwork();
         _replayBuffer = new UniformReplayBuffer<T, Vector<T>, Vector<T>>(_options.ReplayBufferSize);
         _stepCount = 0;
 
@@ -124,6 +120,11 @@ public partial class QMIXAgent<T> : DeepReinforcementLearningAgentBase<T>, IGrad
         InitializeReplayBuffer();
     }
 
+    // The constructor used to build a first pair of mixing networks here and then call this method, which
+    // built a second pair and registered only that one; the first pair was dropped without ever being
+    // disposed. This method is now the only place the networks are created.
+    [System.Diagnostics.CodeAnalysis.MemberNotNull(
+        nameof(_agentNetworks), nameof(_targetAgentNetworks), nameof(_mixingNetwork), nameof(_targetMixingNetwork))]
     private void InitializeNetworks()
     {
         _agentNetworks = new List<INeuralNetwork<T>>();

--- a/src/ReinforcementLearning/Agents/TD3Agent.cs
+++ b/src/ReinforcementLearning/Agents/TD3Agent.cs
@@ -128,6 +128,14 @@ public partial class TD3Agent<T> : DeepReinforcementLearningAgentBase<T>, IGradi
         _targetCritic1Network = CreateCriticNetwork();
         _targetCritic2Network = CreateCriticNetwork();
 
+        // Register every network so DeepReinforcementLearningAgentBase.Dispose releases it.
+        Networks.Add(_actorNetwork);
+        Networks.Add(_targetActorNetwork);
+        Networks.Add(_critic1Network);
+        Networks.Add(_critic2Network);
+        Networks.Add(_targetCritic1Network);
+        Networks.Add(_targetCritic2Network);
+
         CopyNetworkWeights(_critic1Network, _targetCritic1Network);
         CopyNetworkWeights(_critic2Network, _targetCritic2Network);
 

--- a/src/TimeSeries/TimeSeriesModelBase.cs
+++ b/src/TimeSeries/TimeSeriesModelBase.cs
@@ -2847,6 +2847,9 @@ public abstract partial class TimeSeriesModelBase<T> : ITimeSeriesModel<T>, ICon
     /// <inheritdoc/>
     public void Dispose()
     {
+        // A repeated call must not re-enter a derived Dispose(bool) override: overrides do their
+        // own teardown before calling base, so only this entry point can keep that teardown to one run.
+        if (_disposed) return;
         Dispose(disposing: true);
         System.GC.SuppressFinalize(this);
     }

--- a/tests/AiDotNet.Tests/UnitTests/Finance/PortfolioExperimentRunnerDisposalTests.cs
+++ b/tests/AiDotNet.Tests/UnitTests/Finance/PortfolioExperimentRunnerDisposalTests.cs
@@ -1,0 +1,137 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using AiDotNet.Finance.Trading.Agents;
+using AiDotNet.Finance.Trading.Evaluation;
+using AiDotNet.Finance.Trading.Rewards;
+using AiDotNet.Helpers;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tests.UnitTests.Finance;
+
+/// <summary>
+/// <see cref="PortfolioExperimentRunner"/> creates a fresh agent per experiment through the caller's factory, uses
+/// it, and never hands it back, so the runner is the only owner and must release it -- on success and when
+/// training or evaluation throws. Before this, every <see cref="RecurrentPolicyAgent{T}"/> it built kept its LSTM
+/// cell (pool-rented weights) until the garbage collector ran.
+/// </summary>
+public sealed class PortfolioExperimentRunnerDisposalTests
+{
+    private static double[] Ramp(double start, double step, int n)
+    {
+        var a = new double[n];
+        for (int i = 0; i < n; i++) a[i] = start + i * step;
+        return a;
+    }
+
+    private static readonly List<double[]> Prices = new() { Ramp(100, 2, 40), Ramp(100, 1, 40) };
+
+    private static List<PortfolioExperiment> TwoExperiments() => new()
+    {
+        new("a", new TotalReturnReward()),
+        new("b", new TotalReturnReward()),
+    };
+
+    [Fact]
+    public void Every_recurrent_agent_the_runner_creates_is_disposed()
+    {
+        var created = new List<RecurrentPolicyAgent<double>>();
+
+        var outcomes = PortfolioExperimentRunner.Run<double>(
+            Prices, null, Prices, null, windowSize: 5, initialCapital: 100_000,
+            TwoExperiments(),
+            agentFactory: (stateDim, actionDim) =>
+            {
+                var agent = new RecurrentPolicyAgent<double>(stateDim, actionDim, hidden: 4, seed: created.Count);
+                created.Add(agent);
+                return agent;
+            },
+            trainEpisodes: 1);
+
+        Assert.Equal(2, outcomes.Count);
+        Assert.Equal(2, created.Count);
+        foreach (var agent in created)
+        {
+            var cell = Assert.IsAssignableFrom<IDisposable>(
+                typeof(RecurrentPolicyAgent<double>)
+                    .GetField("_cell", BindingFlags.Instance | BindingFlags.NonPublic)
+                    ?.GetValue(agent));
+            // False means the cell was already released through the once-only guard, i.e. the agent was disposed.
+            Assert.False(DisposeOnceGuard.TryDispose(cell), "An agent the runner created was never disposed.");
+        }
+    }
+
+    [Fact]
+    public void An_agent_whose_training_throws_is_still_disposed_and_the_failure_surfaces()
+    {
+        var created = new List<SpyAgent>();
+
+        var thrown = Assert.Throws<InvalidOperationException>(() => PortfolioExperimentRunner.Run<double>(
+            Prices, null, Prices, null, windowSize: 5, initialCapital: 100_000,
+            TwoExperiments(),
+            agentFactory: (_, actionDim) =>
+            {
+                // The first experiment's agent is healthy; the second one fails during training.
+                var agent = new SpyAgent(actionDim, failTraining: created.Count == 1, failDispose: false);
+                created.Add(agent);
+                return agent;
+            },
+            trainEpisodes: 1));
+
+        Assert.Equal(SpyAgent.TrainingFailure, thrown.Message);
+        Assert.Equal(2, created.Count);
+        Assert.All(created, a => Assert.Equal(1, a.DisposeCalls));
+    }
+
+    [Fact]
+    public void A_dispose_failure_does_not_mask_the_training_failure()
+    {
+        SpyAgent? created = null;
+
+        var thrown = Assert.Throws<InvalidOperationException>(() => PortfolioExperimentRunner.Run<double>(
+            Prices, null, Prices, null, windowSize: 5, initialCapital: 100_000,
+            new List<PortfolioExperiment> { new("only", new TotalReturnReward()) },
+            agentFactory: (_, actionDim) => created = new SpyAgent(actionDim, failTraining: true, failDispose: true),
+            trainEpisodes: 1));
+
+        // The caller sees why the run failed, not the secondary cleanup failure.
+        Assert.Equal(SpyAgent.TrainingFailure, thrown.Message);
+        Assert.Equal(1, Assert.IsType<SpyAgent>(created).DisposeCalls);
+    }
+
+    private sealed class SpyAgent : IPortfolioAgent<double>, IDisposable
+    {
+        public const string TrainingFailure = "simulated training failure";
+        private readonly int _actionDim;
+        private readonly bool _failTraining;
+        private readonly bool _failDispose;
+
+        public SpyAgent(int actionDim, bool failTraining, bool failDispose)
+        {
+            _actionDim = actionDim;
+            _failTraining = failTraining;
+            _failDispose = failDispose;
+        }
+
+        public int DisposeCalls { get; private set; }
+
+        public Vector<double> SelectAction(Vector<double> state, bool explore) => new(new double[_actionDim]);
+
+        public void StoreExperience(Vector<double> s, Vector<double> a, double r, Vector<double> n, bool d)
+        {
+        }
+
+        public double Train() => _failTraining ? throw new InvalidOperationException(TrainingFailure) : 0.0;
+
+        public void ResetEpisode()
+        {
+        }
+
+        public void Dispose()
+        {
+            DisposeCalls++;
+            if (_failDispose) throw new NotSupportedException("simulated dispose failure");
+        }
+    }
+}

--- a/tests/AiDotNet.Tests/UnitTests/Finance/RecurrentPolicyAgentDisposalTests.cs
+++ b/tests/AiDotNet.Tests/UnitTests/Finance/RecurrentPolicyAgentDisposalTests.cs
@@ -1,0 +1,33 @@
+using System;
+using System.Reflection;
+using AiDotNet.Finance.Trading.Agents;
+using AiDotNet.Helpers;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tests.UnitTests.Finance;
+
+/// <summary>
+/// <see cref="RecurrentPolicyAgent{T}"/> owns an LSTM cell layer -- pool-rented weights and a registered
+/// engine state -- but was not disposable, so a caller had no way to release it short of the garbage collector.
+/// </summary>
+public sealed class RecurrentPolicyAgentDisposalTests
+{
+    [Fact]
+    public void Dispose_releases_the_recurrent_cell_it_owns()
+    {
+        var agent = new RecurrentPolicyAgent<double>(stateDim: 3, actionDim: 2, hidden: 4, seed: 1);
+        _ = agent.SelectAction(new Vector<double>(new[] { 0.1, 0.2, 0.3 }), explore: false);
+        var cell = Assert.IsAssignableFrom<IDisposable>(
+            typeof(RecurrentPolicyAgent<double>)
+                .GetField("_cell", BindingFlags.Instance | BindingFlags.NonPublic)
+                ?.GetValue(agent));
+
+        var disposable = Assert.IsAssignableFrom<IDisposable>(agent);
+        disposable.Dispose();
+
+        // False means the cell was already released through the once-only guard.
+        Assert.False(DisposeOnceGuard.TryDispose(cell), "The agent's LSTM cell was still live after the agent was disposed.");
+        Assert.Null(Record.Exception(() => disposable.Dispose()));
+    }
+}

--- a/tests/AiDotNet.Tests/UnitTests/Finance/TradingAgentDisposalTests.cs
+++ b/tests/AiDotNet.Tests/UnitTests/Finance/TradingAgentDisposalTests.cs
@@ -1,0 +1,168 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using AiDotNet.Finance.Trading.Agents;
+using AiDotNet.Helpers;
+using AiDotNet.Interfaces;
+using AiDotNet.Models.Options;
+using AiDotNet.NeuralNetworks;
+using AiDotNet.ReinforcementLearning.Agents;
+using Xunit;
+
+namespace AiDotNet.Tests.UnitTests.Finance;
+
+/// <summary>
+/// Disposing a trading agent must release every network it built.
+///
+/// <para>The trading agents derive from <see cref="ReinforcementLearningAgentBase{T}"/> directly rather than
+/// from <see cref="DeepReinforcementLearningAgentBase{T}"/>, and the plain base's <c>Dispose</c> only suppressed
+/// finalization. So a disposed PPO/DQN/A2C/SAC agent left its policy, value, Q and target networks — their
+/// pooled weight buffers, GPU allocations and compiled training plans — alive until the garbage collector
+/// ran, while the caller believed it had released them.</para>
+///
+/// <para>The networks are found by reflecting over the agent's own fields rather than through any list the
+/// agent maintains, so the test also fails if a future network field is added and never registered for
+/// disposal. A network's release is observed on its layers: <see cref="NeuralNetworkBase{T}"/> cascades
+/// disposal into each layer through <see cref="DisposeOnceGuard"/>, so the guard refusing a layer means
+/// that layer was already released by its network.</para>
+/// </summary>
+public class TradingAgentDisposalTests
+{
+    private const int StateSize = 4;
+    private const int ActionSize = 3;
+
+    private static NeuralNetworkArchitecture<double> Arch(int inputs, int outputs)
+        => new(inputFeatures: inputs, outputSize: outputs);
+
+    public static IEnumerable<object[]> Agents()
+    {
+        yield return new object[] { "PPO" };
+        yield return new object[] { "DQN" };
+        yield return new object[] { "A2C" };
+        yield return new object[] { "SAC" };
+        yield return new object[] { "MarketMaking" };
+        yield return new object[] { "FinRL-DQN" };
+        yield return new object[] { "FinRL-PPO" };
+    }
+
+    private static TradingAgentBase<double> Create(string kind) => kind switch
+    {
+        "PPO" => new FinancialPPOAgent<double>(
+            Arch(StateSize, ActionSize), Arch(StateSize, 1),
+            new FinancialPPOAgentOptions<double> { StateSize = StateSize, ActionSize = ActionSize, ContinuousActions = false }),
+        "DQN" => new FinancialDQNAgent<double>(
+            Arch(StateSize, ActionSize),
+            new FinancialDQNAgentOptions<double> { StateSize = StateSize, ActionSize = ActionSize }),
+        "A2C" => new FinancialA2CAgent<double>(
+            Arch(StateSize, ActionSize), Arch(StateSize, 1),
+            new FinancialA2CAgentOptions<double> { StateSize = StateSize, ActionSize = ActionSize }),
+        // SAC's critics score a (state, action) pair.
+        "SAC" => new FinancialSACAgent<double>(
+            Arch(StateSize, ActionSize), Arch(StateSize + ActionSize, 1),
+            new FinancialSACAgentOptions<double> { StateSize = StateSize, ActionSize = ActionSize }),
+        "MarketMaking" => new MarketMakingAgent<double>(
+            new MarketMakingOptions<double> { StateSize = StateSize, ActionSize = ActionSize }),
+        "FinRL-DQN" => new FinRLAgent<double>(
+            Arch(StateSize, ActionSize),
+            new TradingAgentOptions<double> { StateSize = StateSize, ActionSize = ActionSize },
+            FinRLAlgorithm.DQN),
+        "FinRL-PPO" => new FinRLAgent<double>(
+            Arch(StateSize, ActionSize),
+            new TradingAgentOptions<double> { StateSize = StateSize, ActionSize = ActionSize },
+            FinRLAlgorithm.PPO,
+            Arch(StateSize, 1)),
+        _ => throw new ArgumentOutOfRangeException(nameof(kind), kind, null),
+    };
+
+    /// <summary>
+    /// Every network reachable from the agent's instance fields, including the networks of an agent it wraps
+    /// (FinRL delegates to an inner DQN/PPO/A2C/SAC agent). Distinct by reference.
+    /// </summary>
+    private static List<INeuralNetwork<double>> OwnedNetworks(object agent)
+    {
+        var found = new List<INeuralNetwork<double>>();
+        Collect(agent, found, new List<object>());
+        return found;
+    }
+
+    private static void Collect(object owner, List<INeuralNetwork<double>> found, List<object> visited)
+    {
+        if (visited.Any(v => ReferenceEquals(v, owner))) return;
+        visited.Add(owner);
+
+        for (var type = owner.GetType(); type is not null && type != typeof(object); type = type.BaseType)
+        {
+            foreach (var field in type.GetFields(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.DeclaredOnly))
+            {
+                var value = field.GetValue(owner);
+                switch (value)
+                {
+                    case INeuralNetwork<double> network:
+                        if (!found.Any(n => ReferenceEquals(n, network))) found.Add(network);
+                        break;
+                    case IEnumerable<INeuralNetwork<double>> networks:
+                        foreach (var n in networks)
+                        {
+                            if (n is not null && !found.Any(f => ReferenceEquals(f, n))) found.Add(n);
+                        }
+                        break;
+                    case ReinforcementLearningAgentBase<double> inner:
+                        Collect(inner, found, visited);
+                        break;
+                }
+            }
+        }
+    }
+
+    private static List<ILayer<double>> LayersOf(INeuralNetwork<double> network)
+    {
+        var networkBase = Assert.IsAssignableFrom<NeuralNetworkBase<double>>(network);
+        return networkBase.Layers.ToList();
+    }
+
+    [Theory]
+    [MemberData(nameof(Agents))]
+    public void Dispose_releases_every_network_the_agent_owns(string kind)
+    {
+        var agent = Create(kind);
+        var networks = OwnedNetworks(agent);
+
+        // Guard against a vacuous pass: each agent really does own networks with layers to release.
+        Assert.NotEmpty(networks);
+        foreach (var network in networks)
+        {
+            Assert.NotEmpty(LayersOf(network));
+        }
+
+        agent.Dispose();
+
+        foreach (var network in networks)
+        {
+            var layers = LayersOf(network);
+            for (var i = 0; i < layers.Count; i++)
+            {
+                // TryDispose returns false only when the layer was already released through the guard,
+                // which is exactly what a network's own Dispose cascade does. Returning true means this
+                // probe was the first to dispose the layer: the agent never released its network.
+                var layer = Assert.IsAssignableFrom<IDisposable>(layers[i]);
+                Assert.False(
+                    DisposeOnceGuard.TryDispose(layer),
+                    $"{kind}: layer {i} ({layers[i].GetType().Name}) of a {network.GetType().Name} owned by " +
+                    $"{agent.GetType().Name} was still live after the agent was disposed.");
+            }
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(Agents))]
+    public void Disposing_an_agent_twice_is_harmless(string kind)
+    {
+        var agent = Create(kind);
+
+        agent.Dispose();
+        var second = Record.Exception(() => agent.Dispose());
+
+        Assert.Null(second);
+    }
+}

--- a/tests/AiDotNet.Tests/UnitTests/Finance/TradingAgentSharedNetworkDisposalTests.cs
+++ b/tests/AiDotNet.Tests/UnitTests/Finance/TradingAgentSharedNetworkDisposalTests.cs
@@ -1,0 +1,93 @@
+using System;
+using AiDotNet.Finance.Trading.Agents;
+using AiDotNet.Models;
+using AiDotNet.Models.Options;
+using AiDotNet.NeuralNetworks;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tests.UnitTests.Finance;
+
+/// <summary>
+/// A network registered more than once with a trading agent -- two fields holding one instance -- is torn
+/// down exactly once when the agent is disposed, and a later direct dispose of that network does not tear it
+/// down again.
+/// </summary>
+public partial class TradingAgentSharedNetworkDisposalTests
+{
+    [Fact]
+    public void A_network_held_by_two_fields_is_torn_down_exactly_once()
+    {
+        var shared = new CountingNetwork();
+        var agent = new TwoFieldsOneNetworkAgent(shared);
+
+        agent.Dispose();
+        agent.Dispose();
+
+        Assert.Equal(1, shared.DisposeCalls);
+    }
+
+    [Fact]
+    public void Disposing_the_network_again_after_its_agent_is_a_no_op()
+    {
+        var shared = new CountingNetwork();
+        var agent = new TwoFieldsOneNetworkAgent(shared);
+
+        agent.Dispose();
+        shared.Dispose();
+
+        Assert.Equal(1, shared.DisposeCalls);
+    }
+
+    private sealed partial class CountingNetwork : NeuralNetwork<double>
+    {
+        public CountingNetwork()
+            : base(new NeuralNetworkArchitecture<double>(inputFeatures: 2, outputSize: 2))
+        {
+        }
+
+        public int DisposeCalls { get; private set; }
+
+        protected override void Dispose(bool disposing)
+        {
+            DisposeCalls++;
+            base.Dispose(disposing);
+        }
+    }
+
+    /// <summary>An agent whose online and "target" fields alias one network, as a buggy agent might.</summary>
+    private sealed partial class TwoFieldsOneNetworkAgent : TradingAgentBase<double>
+    {
+        private readonly CountingNetwork _online;
+        private readonly CountingNetwork _target;
+
+        public TwoFieldsOneNetworkAgent(CountingNetwork network)
+            : base(new TradingAgentOptions<double> { StateSize = 2, ActionSize = 2 })
+        {
+            _online = network;
+            _target = network;
+            Networks.Add(_online);
+            Networks.Add(_target);
+        }
+
+        public override int FeatureCount => 2;
+
+        public override Vector<double> SelectAction(Vector<double> state, bool training = true)
+            => new Vector<double>(2);
+
+        public override void StoreExperience(
+            Vector<double> state, Vector<double> action, double reward, Vector<double> nextState, bool done)
+        {
+        }
+
+        public override double Train() => 0.0;
+
+        public override ModelMetadata<double> GetModelMetadata() => new ModelMetadata<double> { FeatureCount = 2 };
+
+        public override byte[] Serialize() => Array.Empty<byte>();
+
+        public override void Deserialize(byte[] data)
+        {
+        }
+    }
+}

--- a/tests/AiDotNet.Tests/UnitTests/Helpers/DisposeOnceGuardDisposeAllTests.cs
+++ b/tests/AiDotNet.Tests/UnitTests/Helpers/DisposeOnceGuardDisposeAllTests.cs
@@ -1,0 +1,78 @@
+using System;
+using AiDotNet.Helpers;
+using Xunit;
+
+namespace AiDotNet.Tests.UnitTests.Helpers;
+
+/// <summary>
+/// <see cref="DisposeOnceGuard.DisposeAll"/> releases every resource, then reports failures without changing
+/// what a caller could catch before: one failure is rethrown as the ORIGINAL exception (type and stack preserved),
+/// and only two or more are wrapped in an <see cref="AggregateException"/>.
+/// </summary>
+public sealed class DisposeOnceGuardDisposeAllTests
+{
+    private sealed class DistinctDisposeException : Exception
+    {
+        public DistinctDisposeException(string message) : base(message)
+        {
+        }
+    }
+
+    private sealed class Resource : IDisposable
+    {
+        private readonly string? _failure;
+        public Resource(string? failure = null) => _failure = failure;
+        public int DisposeCalls { get; private set; }
+
+        public void Dispose()
+        {
+            DisposeCalls++;
+            if (_failure is not null) ThrowFromDispose(_failure);
+        }
+
+        private static void ThrowFromDispose(string message) => throw new DistinctDisposeException(message);
+    }
+
+    [Fact]
+    public void A_single_failure_is_rethrown_unchanged_after_every_resource_is_released()
+    {
+        var before = new Resource();
+        var failing = new Resource("only failure");
+        var after = new Resource();
+
+        var thrown = Assert.Throws<DistinctDisposeException>(
+            () => DisposeOnceGuard.DisposeAll(new object?[] { before, failing, after }, "owner"));
+
+        Assert.Equal("only failure", thrown.Message);
+        // The stack still points at the code that threw, not only at the rethrow site.
+        Assert.Contains("ThrowFromDispose", thrown.StackTrace ?? string.Empty);
+        Assert.Equal(1, before.DisposeCalls);
+        Assert.Equal(1, failing.DisposeCalls);
+        Assert.Equal(1, after.DisposeCalls);
+    }
+
+    [Fact]
+    public void Two_failures_are_wrapped_in_one_aggregate_after_every_resource_is_released()
+    {
+        var first = new Resource("first");
+        var healthy = new Resource();
+        var second = new Resource("second");
+
+        var thrown = Assert.Throws<AggregateException>(
+            () => DisposeOnceGuard.DisposeAll(new object?[] { first, healthy, second }, "owner"));
+
+        Assert.Equal(new[] { "first", "second" }, new[] { thrown.InnerExceptions[0].Message, thrown.InnerExceptions[1].Message });
+        Assert.All(thrown.InnerExceptions, e => Assert.IsType<DistinctDisposeException>(e));
+        Assert.Equal(1, healthy.DisposeCalls);
+    }
+
+    [Fact]
+    public void No_failure_throws_nothing_and_releases_each_resource_once()
+    {
+        var shared = new Resource();
+
+        DisposeOnceGuard.DisposeAll(new object?[] { shared, null, "not disposable", shared }, "owner");
+
+        Assert.Equal(1, shared.DisposeCalls);
+    }
+}

--- a/tests/AiDotNet.Tests/UnitTests/Models/AiModelResultDerivedCopyDisposalTests.cs
+++ b/tests/AiDotNet.Tests/UnitTests/Models/AiModelResultDerivedCopyDisposalTests.cs
@@ -1,0 +1,156 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using AiDotNet.Configuration;
+using AiDotNet.Enums;
+using AiDotNet.Helpers;
+using AiDotNet.Interfaces;
+using AiDotNet.Models.Options;
+using AiDotNet.Models.Results;
+using AiDotNet.NeuralNetworks;
+using AiDotNet.NeuralNetworks.Layers;
+using AiDotNet.Preprocessing;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tests.UnitTests.Models;
+
+/// <summary>
+/// The model copies an <see cref="AiModelResult{T,TInput,TOutput}"/> makes for itself are released with it.
+///
+/// <para>With inference optimizations configured, the first <c>Predict</c> clones the model and rewrites the
+/// clone for inference, and every inference sequence clones it again for its own KV cache. Neither copy was
+/// ever disposed: <c>AiModelResult.Dispose</c> released only the wrapped <c>Model</c>, and
+/// <c>InferenceSequence.Dispose</c> only cleared its cache, so each copy's layers -- pooled weight buffers,
+/// compiled plans -- lived until the garbage collector ran.</para>
+/// </summary>
+[Collection(AiDotNet.Tests.TestInfrastructure.DiagnosticsEnvironmentCollection.Name)]
+public class AiModelResultDerivedCopyDisposalTests
+{
+    private const int SequenceLength = 1;
+    private const int EmbeddingDimension = 8;
+    private const int HeadCount = 2;
+    private const int FlatSize = SequenceLength * EmbeddingDimension;
+
+    [Fact]
+    public void Dispose_releases_the_inference_optimized_copy_and_the_model()
+    {
+        var model = CreateAttentionModel();
+        var result = CreateResult(model, new InferenceOptimizationConfig
+        {
+            EnableFlashAttention = true,
+            EnableKVCache = false,
+            EnablePagedKVCache = false,
+        });
+
+        _ = result.Predict(Token());
+        // Premise: Predict really did build a separate optimized copy.
+        var copy = Assert.IsAssignableFrom<NeuralNetworkBase<float>>(
+            ReadField(result, "_inferenceOptimizedNeuralModel"));
+        Assert.NotSame(model, copy);
+
+        result.Dispose();
+
+        AssertAllLayersReleased(copy, "the inference-optimized copy");
+        AssertAllLayersReleased(model, "the wrapped model");
+    }
+
+    [Fact]
+    public void Disposing_a_sequence_releases_the_copy_it_made_but_not_the_model()
+    {
+        var model = CreateAttentionModel();
+        var result = CreateResult(model, new InferenceOptimizationConfig
+        {
+            EnableFlashAttention = false,
+            EnableKVCache = true,
+            EnablePagedKVCache = false,
+            AttentionMasking = AttentionMaskingMode.Auto,
+        });
+
+        var session = result.BeginInferenceSession();
+        var sequence = session.CreateSequence();
+        _ = sequence.Predict(Token());
+        var copy = Assert.IsAssignableFrom<NeuralNetworkBase<float>>(
+            ReadField(sequence, "_sequenceOptimizedNeuralModel"));
+        Assert.NotSame(model, copy);
+
+        sequence.Dispose();
+        session.Dispose();
+
+        AssertAllLayersReleased(copy, "the sequence's copy");
+
+        // The sequence only borrowed the model; the result still owns it and it must still work.
+        Assert.NotNull(result.Predict(Token()));
+        result.Dispose();
+    }
+
+    [Fact]
+    public void Dispose_releases_deep_ensemble_members_and_the_model_once()
+    {
+        // The builder trains the extra ensemble members for this result and hands them over; nothing else holds them.
+        var model = new NeuralNetwork<float>(new NeuralNetworkArchitecture<float>(inputFeatures: 4, outputSize: 2));
+        var member = new NeuralNetwork<float>(new NeuralNetworkArchitecture<float>(inputFeatures: 4, outputSize: 2));
+        var result = new AiModelResult<float, Tensor<float>, Tensor<float>> { Model = model };
+        result.SetDeepEnsembleModels(new List<IFullModel<float, Tensor<float>, Tensor<float>>> { model, member });
+
+        result.Dispose();
+
+        AssertAllLayersReleased(member, "a deep-ensemble member");
+        AssertAllLayersReleased(model, "the wrapped model");
+    }
+
+    private static void AssertAllLayersReleased(NeuralNetworkBase<float> network, string what)
+    {
+        Assert.NotEmpty(network.Layers);
+        foreach (var layer in network.Layers)
+        {
+            Assert.False(
+                DisposeOnceGuard.TryDispose(Assert.IsAssignableFrom<IDisposable>(layer)),
+                $"A {layer.GetType().Name} of {what} was still live after disposal.");
+        }
+    }
+
+    private static object? ReadField(object owner, string name)
+        => owner.GetType().GetField(name, BindingFlags.Instance | BindingFlags.NonPublic)?.GetValue(owner);
+
+    private static AiModelResult<float, Tensor<float>, Tensor<float>> CreateResult(
+        NeuralNetworkBase<float> model, InferenceOptimizationConfig config)
+        => new(new AiModelResultOptions<float, Tensor<float>, Tensor<float>>
+        {
+            OptimizationResult = new OptimizationResult<float, Tensor<float>, Tensor<float>> { BestSolution = model },
+            PreprocessingInfo = new PreprocessingInfo<float, Tensor<float>, Tensor<float>>(),
+            InferenceOptimizationConfig = config,
+        });
+
+    private static NeuralNetworkBase<float> CreateAttentionModel()
+    {
+        var layers = new List<ILayer<float>>
+        {
+            new InputLayer<float>(FlatSize),
+            new ReshapeLayer<float>(new[] { SequenceLength, EmbeddingDimension }),
+            new MultiHeadAttentionLayer<float>(HeadCount, EmbeddingDimension / HeadCount,
+                activationFunction: new AiDotNet.ActivationFunctions.IdentityActivation<float>()),
+            new FlattenLayer<float>(),
+            new DenseLayer<float>(FlatSize, activationFunction: new AiDotNet.ActivationFunctions.IdentityActivation<float>()),
+        };
+
+        var model = new NeuralNetwork<float>(new NeuralNetworkArchitecture<float>(
+            inputType: InputType.OneDimensional,
+            taskType: NeuralNetworkTaskType.TextGeneration,
+            complexity: NetworkComplexity.Simple,
+            inputSize: FlatSize,
+            outputSize: FlatSize,
+            layers: layers));
+
+        // Materialize the lazy attention weights on the source before anything clones it.
+        _ = model.Predict(new Tensor<float>(new[] { 1, FlatSize }));
+        return model;
+    }
+
+    private static Tensor<float> Token()
+    {
+        var t = new Tensor<float>(new[] { 1, FlatSize });
+        for (var i = 0; i < t.Length; i++) t[i] = 1.0f + i * 0.01f;
+        return t;
+    }
+}

--- a/tests/AiDotNet.Tests/UnitTests/Models/AiModelResultDerivedCopyDisposalTests.cs
+++ b/tests/AiDotNet.Tests/UnitTests/Models/AiModelResultDerivedCopyDisposalTests.cs
@@ -25,7 +25,7 @@ namespace AiDotNet.Tests.UnitTests.Models;
 /// compiled plans -- lived until the garbage collector ran.</para>
 /// </summary>
 [Collection(AiDotNet.Tests.TestInfrastructure.DiagnosticsEnvironmentCollection.Name)]
-public class AiModelResultDerivedCopyDisposalTests
+public partial class AiModelResultDerivedCopyDisposalTests
 {
     private const int SequenceLength = 1;
     private const int EmbeddingDimension = 8;
@@ -97,6 +97,71 @@ public class AiModelResultDerivedCopyDisposalTests
 
         AssertAllLayersReleased(member, "a deep-ensemble member");
         AssertAllLayersReleased(model, "the wrapped model");
+    }
+
+    private static AiModelResult<float, Tensor<float>, Tensor<float>> CreateMetaLearningResult(
+        NeuralNetwork<float> baseModel, NeuralNetwork<float> best)
+    {
+        var metaLearner = new AiDotNet.MetaLearning.Algorithms.MAMLAlgorithm<float, Tensor<float>, Tensor<float>>(
+            new AiDotNet.MetaLearning.Options.MAMLOptions<float, Tensor<float>, Tensor<float>>(baseModel)
+            {
+                LossFunction = new AiDotNet.LossFunctions.MeanSquaredErrorLoss<float>(),
+            });
+        return new AiModelResult<float, Tensor<float>, Tensor<float>>(new AiModelResultOptions<float, Tensor<float>, Tensor<float>>
+        {
+            MetaLearner = metaLearner,
+            MetaTrainingResult = new MetaTrainingResult<float>(
+                new Vector<float>(new[] { 1.0f }), new Vector<float>(new[] { 0.0f }), TimeSpan.Zero),
+            OptimizationResult = new OptimizationResult<float, Tensor<float>, Tensor<float>> { BestSolution = best },
+        });
+    }
+
+    [Fact]
+    public void Meta_learning_result_releases_the_optimizers_separate_best_solution()
+    {
+        // On the meta-learning path Model is the meta-learner's BaseModel, while the optimizer's BestSolution is a
+        // different instance that only this result holds -- previously neither Dispose path reached it.
+        var baseModel = new NeuralNetwork<float>(new NeuralNetworkArchitecture<float>(inputFeatures: 4, outputSize: 2));
+        var best = new CountingNetwork();
+        var result = CreateMetaLearningResult(baseModel, best);
+
+        // Premise: this really is the case where the two differ.
+        Assert.NotSame(best, result.Model);
+
+        result.Dispose();
+        result.Dispose();
+
+        Assert.Equal(1, best.DisposeCalls);
+        AssertAllLayersReleased(best, "the optimizer's best solution");
+    }
+
+    [Fact]
+    public void A_best_solution_that_is_also_an_ensemble_member_is_released_once()
+    {
+        var baseModel = new NeuralNetwork<float>(new NeuralNetworkArchitecture<float>(inputFeatures: 4, outputSize: 2));
+        var best = new CountingNetwork();
+        var result = CreateMetaLearningResult(baseModel, best);
+
+        // The builder puts the best solution first in a deep ensemble, so both disposal paths can reach it.
+        result.SetDeepEnsembleModels(new List<IFullModel<float, Tensor<float>, Tensor<float>>> { best });
+        result.Dispose();
+
+        Assert.Equal(1, best.DisposeCalls);
+    }
+
+    private sealed partial class CountingNetwork : NeuralNetwork<float>
+    {
+        public CountingNetwork() : base(new NeuralNetworkArchitecture<float>(inputFeatures: 4, outputSize: 2))
+        {
+        }
+
+        public int DisposeCalls { get; private set; }
+
+        protected override void Dispose(bool disposing)
+        {
+            DisposeCalls++;
+            base.Dispose(disposing);
+        }
     }
 
     private static void AssertAllLayersReleased(NeuralNetworkBase<float> network, string what)

--- a/tests/AiDotNet.Tests/UnitTests/NeuralNetworks/LayerDisposeIdempotencyTests.cs
+++ b/tests/AiDotNet.Tests/UnitTests/NeuralNetworks/LayerDisposeIdempotencyTests.cs
@@ -1,0 +1,90 @@
+using System;
+using AiDotNet.ActivationFunctions;
+using AiDotNet.Helpers;
+using AiDotNet.NeuralNetworks.Layers;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tests.UnitTests.NeuralNetworks;
+
+/// <summary>
+/// A second <c>Dispose</c> of a layer must not re-run the layer's own teardown.
+///
+/// <para><see cref="LayerBase{T}"/> guarded its own <c>Dispose(bool)</c>, but its public <c>Dispose()</c>
+/// re-entered every override on each call, and overrides do their teardown before calling base.
+/// <see cref="DenseLayer{T}"/>'s override, for one, re-invalidates the engine's cached GPU copy of
+/// <c>_weights</c>/<c>_biases</c> -- tensors whose pooled storage the first dispose already returned and a
+/// newer layer may now own.</para>
+/// </summary>
+public partial class LayerDisposeIdempotencyTests
+{
+    private static CountingDenseLayer MaterializedLayer()
+    {
+        var layer = new CountingDenseLayer();
+        // Resolve the lazy input shape so the weights are really rented from the pool.
+        _ = layer.Forward(new Tensor<double>(new[] { 1, 4 }));
+        return layer;
+    }
+
+    [Fact]
+    public void Repeated_direct_disposes_run_the_teardown_and_return_the_buffers_once()
+    {
+        var layer = MaterializedLayer();
+
+        layer.Dispose();
+        layer.Dispose();
+        layer.Dispose();
+
+        Assert.Equal(1, layer.DisposeCalls);
+        Assert.Equal(1, layer.PooledReturns);
+    }
+
+    [Fact]
+    public void Guard_then_direct_dispose_tears_down_once()
+    {
+        var layer = MaterializedLayer();
+
+        Assert.True(DisposeOnceGuard.TryDispose(layer));
+        Assert.False(DisposeOnceGuard.TryDispose(layer));
+        layer.Dispose();
+
+        Assert.Equal(1, layer.DisposeCalls);
+        Assert.Equal(1, layer.PooledReturns);
+    }
+
+    [Fact]
+    public void Direct_then_guard_dispose_tears_down_once()
+    {
+        var layer = MaterializedLayer();
+
+        layer.Dispose();
+        // The guard has not seen this layer, so it forwards the call -- which must now be a no-op.
+        DisposeOnceGuard.TryDispose(layer);
+
+        Assert.Equal(1, layer.DisposeCalls);
+        Assert.Equal(1, layer.PooledReturns);
+    }
+
+    private sealed partial class CountingDenseLayer : DenseLayer<double>
+    {
+        public CountingDenseLayer() : base(3, (AiDotNet.Interfaces.IActivationFunction<double>)new IdentityActivation<double>())
+        {
+        }
+
+        public int DisposeCalls { get; private set; }
+
+        public int PooledReturns { get; private set; }
+
+        protected override void Dispose(bool disposing)
+        {
+            DisposeCalls++;
+            base.Dispose(disposing);
+        }
+
+        protected override void ReturnPooledParameters()
+        {
+            PooledReturns++;
+            base.ReturnPooledParameters();
+        }
+    }
+}

--- a/tests/AiDotNet.Tests/UnitTests/NeuralNetworks/ModelDisposeIdempotencyTests.cs
+++ b/tests/AiDotNet.Tests/UnitTests/NeuralNetworks/ModelDisposeIdempotencyTests.cs
@@ -1,0 +1,186 @@
+using System;
+using AiDotNet.Helpers;
+using AiDotNet.Models;
+using AiDotNet.Models.Options;
+using AiDotNet.Models.Results;
+using AiDotNet.NeuralNetworks;
+using AiDotNet.Tensors.LinearAlgebra;
+using AiDotNet.TimeSeries;
+using AiDotNet.Training;
+using Xunit;
+
+namespace AiDotNet.Tests.UnitTests.NeuralNetworks;
+
+/// <summary>
+/// A second <c>Dispose</c> of a model must be a no-op.
+///
+/// <para>Callers routinely dispose the same model twice without knowing it: an <see cref="AiModelResult{T,TInput,TOutput}"/>
+/// disposes the model it wraps, and the code that configured that model disposes it as well. Before the fix,
+/// <see cref="NeuralNetworkBase{T}.Dispose()"/> had no disposed flag, so every repeated call re-ran the whole
+/// teardown. That teardown is not local to the model: <see cref="TapeTrainingStep{T}.InvalidateCache"/> clears
+/// the THREAD-GLOBAL parameter cache, so re-disposing a long-dead network silently evicted the cache of whatever
+/// live model the thread had trained since. Derived <c>Dispose(bool)</c> overrides also ran their own teardown
+/// again, releasing sub-models and sessions a second time.</para>
+/// </summary>
+public partial class ModelDisposeIdempotencyTests
+{
+    private static NeuralNetwork<double> Network()
+        => new(new NeuralNetworkArchitecture<double>(inputFeatures: 4, outputSize: 2));
+
+    [Fact]
+    public void Redisposing_a_dead_network_does_not_evict_a_live_models_training_cache()
+    {
+        var dead = Network();
+        var live = Network();
+        live.MaterializeParameters();
+
+        dead.Dispose();
+
+        // Premise: the live model's parameter walk is cached on this thread, so asking twice returns
+        // the very same list.
+        var cached = TapeTrainingStep<double>.CollectParameters(live.Layers);
+        Assert.Same(cached, TapeTrainingStep<double>.CollectParameters(live.Layers));
+
+        dead.Dispose();
+
+        Assert.Same(cached, TapeTrainingStep<double>.CollectParameters(live.Layers));
+    }
+
+    [Fact]
+    public void First_dispose_still_tears_down_the_training_cache_and_releases_every_layer()
+    {
+        var disposed = Network();
+        var live = Network();
+        live.MaterializeParameters();
+        var cached = TapeTrainingStep<double>.CollectParameters(live.Layers);
+        Assert.Same(cached, TapeTrainingStep<double>.CollectParameters(live.Layers));
+
+        disposed.Dispose();
+
+        // The first dispose keeps its existing, deliberately conservative behaviour: it invalidates the
+        // thread's tape cache (a stale plan over returned buffers is worse than one recomputation) ...
+        Assert.NotSame(cached, TapeTrainingStep<double>.CollectParameters(live.Layers));
+
+        // ... and it cascades into every layer through the once-only guard, which therefore refuses them now.
+        Assert.NotEmpty(disposed.Layers);
+        foreach (var layer in disposed.Layers)
+        {
+            Assert.False(DisposeOnceGuard.TryDispose(Assert.IsAssignableFrom<IDisposable>(layer)));
+        }
+
+        Assert.Null(Record.Exception(() => disposed.Dispose()));
+    }
+
+    [Fact]
+    public void A_derived_networks_teardown_runs_once_across_repeated_disposes()
+    {
+        var network = new CountingNetwork(new NeuralNetworkArchitecture<double>(inputFeatures: 4, outputSize: 2));
+
+        network.Dispose();
+        network.Dispose();
+        network.Dispose();
+
+        Assert.Equal(1, network.DisposeCalls);
+    }
+
+    [Fact]
+    public void Disposing_a_result_and_then_the_model_it_wraps_tears_the_model_down_once()
+    {
+        // The downstream pattern: dispose the AiModelResult (which disposes its Model), then dispose the model
+        // that was configured into the builder -- the same instance.
+        var model = new CountingNetwork(new NeuralNetworkArchitecture<double>(inputFeatures: 4, outputSize: 2));
+        var result = new AiModelResult<double, Tensor<double>, Tensor<double>> { Model = model };
+
+        result.Dispose();
+        result.Dispose();
+        model.Dispose();
+
+        Assert.Equal(1, model.DisposeCalls);
+    }
+
+    [Fact]
+    public void A_derived_ModelBase_teardown_runs_once_across_repeated_disposes()
+    {
+        var model = new CountingVectorModel(new Vector<double>(new[] { 1.0, 2.0 }));
+
+        model.Dispose();
+        model.Dispose();
+
+        Assert.Equal(1, model.DisposeCalls);
+    }
+
+    [Fact]
+    public void A_derived_TimeSeriesModelBase_teardown_runs_once_across_repeated_disposes()
+    {
+        var model = new CountingArimaModel();
+
+        model.Dispose();
+        model.Dispose();
+
+        Assert.Equal(1, model.DisposeCalls);
+    }
+
+    [Fact]
+    public void A_derived_AiModelResult_teardown_runs_once_across_repeated_disposes()
+    {
+        var result = new CountingResult();
+
+        result.Dispose();
+        result.Dispose();
+
+        Assert.Equal(1, result.DisposeCalls);
+    }
+
+    private sealed partial class CountingNetwork : NeuralNetwork<double>
+    {
+        public CountingNetwork(NeuralNetworkArchitecture<double> architecture) : base(architecture)
+        {
+        }
+
+        public int DisposeCalls { get; private set; }
+
+        protected override void Dispose(bool disposing)
+        {
+            // The common override shape: own teardown first, then base.
+            DisposeCalls++;
+            base.Dispose(disposing);
+        }
+    }
+
+    private sealed partial class CountingVectorModel : VectorModel<double>
+    {
+        public CountingVectorModel(Vector<double> coefficients) : base(coefficients)
+        {
+        }
+
+        public int DisposeCalls { get; private set; }
+
+        protected override void Dispose(bool disposing)
+        {
+            DisposeCalls++;
+            base.Dispose(disposing);
+        }
+    }
+
+    private sealed partial class CountingArimaModel : ARIMAModel<double>
+    {
+        public int DisposeCalls { get; private set; }
+
+        protected override void Dispose(bool disposing)
+        {
+            DisposeCalls++;
+            base.Dispose(disposing);
+        }
+    }
+
+    private sealed partial class CountingResult : AiModelResult<double, Tensor<double>, Tensor<double>>
+    {
+        public int DisposeCalls { get; private set; }
+
+        protected override void Dispose(bool disposing)
+        {
+            DisposeCalls++;
+            base.Dispose(disposing);
+        }
+    }
+}

--- a/tests/AiDotNet.Tests/UnitTests/ReinforcementLearning/AgentDisposalFailureTests.cs
+++ b/tests/AiDotNet.Tests/UnitTests/ReinforcementLearning/AgentDisposalFailureTests.cs
@@ -14,9 +14,10 @@ namespace AiDotNet.Tests.UnitTests.ReinforcementLearning;
 /// One network failing to dispose must not leave the agent's other networks alive.
 ///
 /// <para>Both agent bases disposed their networks in a plain loop, so the first network whose Dispose threw
-/// ended the loop and every network after it was never released. Both now release every network and then
-/// report all failures together as an <see cref="AggregateException"/>, the library's convention for
-/// multi-resource disposal (see <c>DataPipeline</c>).</para>
+/// ended the loop and every network after it was never released. Both now release every network first. A
+/// single failure is then rethrown unchanged -- same type, original stack -- so a caller that caught a specific
+/// exception type from <c>Dispose</c> keeps working; two or more failures are reported together as an
+/// <see cref="AggregateException"/>, the library's convention for multi-resource disposal.</para>
 /// </summary>
 public partial class AgentDisposalFailureTests
 {
@@ -27,10 +28,12 @@ public partial class AgentDisposalFailureTests
         var healthy = new CountingNetwork();
         var agent = new TwoNetworkDeepAgent(failing, healthy);
 
-        var thrown = Assert.Throws<AggregateException>(() => agent.Dispose());
+        // Exactly one failure: the original exception, unwrapped, with the stack of the code that threw it.
+        var thrown = Assert.Throws<InvalidOperationException>(() => agent.Dispose());
 
         Assert.Equal(1, healthy.DisposeCalls);
-        Assert.Contains(thrown.InnerExceptions, e => e is InvalidOperationException && e.Message == ThrowingNetwork.Message);
+        Assert.Equal(ThrowingNetwork.Message, thrown.Message);
+        Assert.Contains(nameof(ThrowingNetwork), thrown.StackTrace ?? string.Empty);
     }
 
     [Fact]
@@ -40,10 +43,43 @@ public partial class AgentDisposalFailureTests
         var healthy = new CountingNetwork();
         var agent = new TwoNetworkTradingAgent(failing, healthy);
 
-        var thrown = Assert.Throws<AggregateException>(() => agent.Dispose());
+        // Exactly one failure: the original exception, unwrapped, with the stack of the code that threw it.
+        var thrown = Assert.Throws<InvalidOperationException>(() => agent.Dispose());
 
         Assert.Equal(1, healthy.DisposeCalls);
-        Assert.Contains(thrown.InnerExceptions, e => e is InvalidOperationException && e.Message == ThrowingNetwork.Message);
+        Assert.Equal(ThrowingNetwork.Message, thrown.Message);
+        Assert.Contains(nameof(ThrowingNetwork), thrown.StackTrace ?? string.Empty);
+    }
+
+    [Fact]
+    public void Two_failures_are_reported_together_after_every_network_is_released()
+    {
+        var first = new ThrowingNetwork();
+        var second = new ThrowingNetwork();
+        var agent = new TwoNetworkDeepAgent(first, second);
+
+        var thrown = Assert.Throws<AggregateException>(() => agent.Dispose());
+
+        Assert.Equal(2, thrown.InnerExceptions.Count);
+        Assert.All(thrown.InnerExceptions, e => Assert.IsType<InvalidOperationException>(e));
+    }
+
+    [Fact]
+    public void A_caller_catching_the_specific_exception_type_still_catches_it()
+    {
+        var agent = new TwoNetworkTradingAgent(new ThrowingNetwork(), new CountingNetwork());
+
+        bool caught = false;
+        try
+        {
+            agent.Dispose();
+        }
+        catch (InvalidOperationException)
+        {
+            caught = true;
+        }
+
+        Assert.True(caught);
     }
 
     [Fact]

--- a/tests/AiDotNet.Tests/UnitTests/ReinforcementLearning/AgentDisposalFailureTests.cs
+++ b/tests/AiDotNet.Tests/UnitTests/ReinforcementLearning/AgentDisposalFailureTests.cs
@@ -1,0 +1,147 @@
+using System;
+using System.Linq;
+using AiDotNet.Finance.Trading.Agents;
+using AiDotNet.Models;
+using AiDotNet.Models.Options;
+using AiDotNet.NeuralNetworks;
+using AiDotNet.ReinforcementLearning.Agents;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tests.UnitTests.ReinforcementLearning;
+
+/// <summary>
+/// One network failing to dispose must not leave the agent's other networks alive.
+///
+/// <para>Both agent bases disposed their networks in a plain loop, so the first network whose Dispose threw
+/// ended the loop and every network after it was never released. Both now release every network and then
+/// report all failures together as an <see cref="AggregateException"/>, the library's convention for
+/// multi-resource disposal (see <c>DataPipeline</c>).</para>
+/// </summary>
+public partial class AgentDisposalFailureTests
+{
+    [Fact]
+    public void Deep_agent_releases_every_network_even_when_one_throws()
+    {
+        var failing = new ThrowingNetwork();
+        var healthy = new CountingNetwork();
+        var agent = new TwoNetworkDeepAgent(failing, healthy);
+
+        var thrown = Assert.Throws<AggregateException>(() => agent.Dispose());
+
+        Assert.Equal(1, healthy.DisposeCalls);
+        Assert.Contains(thrown.InnerExceptions, e => e is InvalidOperationException && e.Message == ThrowingNetwork.Message);
+    }
+
+    [Fact]
+    public void Trading_agent_releases_every_network_even_when_one_throws()
+    {
+        var failing = new ThrowingNetwork();
+        var healthy = new CountingNetwork();
+        var agent = new TwoNetworkTradingAgent(failing, healthy);
+
+        var thrown = Assert.Throws<AggregateException>(() => agent.Dispose());
+
+        Assert.Equal(1, healthy.DisposeCalls);
+        Assert.Contains(thrown.InnerExceptions, e => e is InvalidOperationException && e.Message == ThrowingNetwork.Message);
+    }
+
+    [Fact]
+    public void Deep_agent_releases_a_network_registered_twice_exactly_once()
+    {
+        var shared = new CountingNetwork();
+        var agent = new TwoNetworkDeepAgent(shared, shared);
+
+        agent.Dispose();
+        agent.Dispose();
+
+        Assert.Equal(1, shared.DisposeCalls);
+    }
+
+    private static NeuralNetworkArchitecture<double> Arch() => new(inputFeatures: 2, outputSize: 2);
+
+    private sealed partial class ThrowingNetwork : NeuralNetwork<double>
+    {
+        public const string Message = "simulated dispose failure";
+
+        public ThrowingNetwork() : base(Arch())
+        {
+        }
+
+        protected override void Dispose(bool disposing) => throw new InvalidOperationException(Message);
+    }
+
+    private sealed partial class CountingNetwork : NeuralNetwork<double>
+    {
+        public CountingNetwork() : base(Arch())
+        {
+        }
+
+        public int DisposeCalls { get; private set; }
+
+        protected override void Dispose(bool disposing)
+        {
+            DisposeCalls++;
+            base.Dispose(disposing);
+        }
+    }
+
+    // The failing network is registered FIRST: a loop that stops at the first failure never reaches the second.
+    private sealed partial class TwoNetworkDeepAgent : DeepReinforcementLearningAgentBase<double>
+    {
+        public TwoNetworkDeepAgent(NeuralNetwork<double> first, NeuralNetwork<double> second)
+            : base(new ReinforcementLearningOptions<double>())
+        {
+            Networks.Add(first);
+            Networks.Add(second);
+        }
+
+        public override int FeatureCount => 2;
+
+        public override Vector<double> SelectAction(Vector<double> state, bool training = true) => new Vector<double>(2);
+
+        public override void StoreExperience(
+            Vector<double> state, Vector<double> action, double reward, Vector<double> nextState, bool done)
+        {
+        }
+
+        public override double Train() => 0.0;
+
+        public override ModelMetadata<double> GetModelMetadata() => new ModelMetadata<double> { FeatureCount = 2 };
+
+        public override byte[] Serialize() => Array.Empty<byte>();
+
+        public override void Deserialize(byte[] data)
+        {
+        }
+    }
+
+    private sealed partial class TwoNetworkTradingAgent : TradingAgentBase<double>
+    {
+        public TwoNetworkTradingAgent(NeuralNetwork<double> first, NeuralNetwork<double> second)
+            : base(new TradingAgentOptions<double> { StateSize = 2, ActionSize = 2 })
+        {
+            Networks.Add(first);
+            Networks.Add(second);
+        }
+
+        public override int FeatureCount => 2;
+
+        public override Vector<double> SelectAction(Vector<double> state, bool training = true) => new Vector<double>(2);
+
+        public override void StoreExperience(
+            Vector<double> state, Vector<double> action, double reward, Vector<double> nextState, bool done)
+        {
+        }
+
+        public override double Train() => 0.0;
+
+        public override ModelMetadata<double> GetModelMetadata() => new ModelMetadata<double> { FeatureCount = 2 };
+
+        public override byte[] Serialize() => Array.Empty<byte>();
+
+        public override void Deserialize(byte[] data)
+        {
+        }
+    }
+}

--- a/tests/AiDotNet.Tests/UnitTests/ReinforcementLearning/DeepAgentDisposalTests.cs
+++ b/tests/AiDotNet.Tests/UnitTests/ReinforcementLearning/DeepAgentDisposalTests.cs
@@ -1,0 +1,200 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using AiDotNet.Helpers;
+using AiDotNet.Interfaces;
+using AiDotNet.NeuralNetworks;
+using AiDotNet.ReinforcementLearning.Agents;
+using Xunit;
+
+namespace AiDotNet.Tests.UnitTests.ReinforcementLearning;
+
+/// <summary>
+/// Disposing any deep RL agent must release every network it owns, each exactly once.
+///
+/// <para><see cref="DeepReinforcementLearningAgentBase{T}.Dispose"/> releases what the agent registered in
+/// <c>Networks</c>, and nothing else. CQL, IQL and TD3 never registered theirs, and DuelingDQN's networks are
+/// not <see cref="INeuralNetwork{T}"/> at all, so disposing those agents released nothing. QMIX built its
+/// mixing networks twice and dropped the first pair unregistered.</para>
+///
+/// <para>The agents are discovered by reflection over the library, so a new agent is covered without editing
+/// this file, and each agent's networks are found by reflecting over its own fields, so a network field that
+/// is never registered fails here.</para>
+/// </summary>
+public class DeepAgentDisposalTests
+{
+    public static IEnumerable<object[]> DeepAgentTypes()
+        => typeof(DeepReinforcementLearningAgentBase<>).Assembly.GetTypes()
+            .Where(t => t.IsClass && !t.IsAbstract && t.IsGenericTypeDefinition && t.GetGenericArguments().Length == 1)
+            .Where(t =>
+            {
+                try { return typeof(DeepReinforcementLearningAgentBase<double>).IsAssignableFrom(t.MakeGenericType(typeof(double))); }
+                catch (ArgumentException) { return false; } // generic constraint not satisfied by double
+            })
+            .OrderBy(t => t.FullName, StringComparer.Ordinal)
+            .Select(t => new object[] { t.Name });
+
+    private static DeepReinforcementLearningAgentBase<double> Create(string typeName)
+    {
+        var definition = typeof(DeepReinforcementLearningAgentBase<>).Assembly.GetTypes()
+            .Single(t => t.IsGenericTypeDefinition && t.Name == typeName
+                         && typeof(DeepReinforcementLearningAgentBase<double>).IsAssignableFrom(t.MakeGenericType(typeof(double))));
+        return Assert.IsAssignableFrom<DeepReinforcementLearningAgentBase<double>>(
+            Activator.CreateInstance(definition.MakeGenericType(typeof(double))));
+    }
+
+    [Fact]
+    public void Discovery_finds_every_deep_agent()
+    {
+        // Guard against the theory silently running over nothing.
+        var names = DeepAgentTypes().Select(row => (string)row[0]).ToList();
+        Assert.True(names.Count >= 20, $"Only {names.Count} deep agents discovered: {string.Join(", ", names)}");
+        foreach (var expected in new[] { "CQLAgent`1", "IQLAgent`1", "TD3Agent`1", "MADDPGAgent`1", "QMIXAgent`1", "DuelingDQNAgent`1" })
+        {
+            Assert.Contains(expected, names);
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(DeepAgentTypes))]
+    public void Every_network_field_is_registered_exactly_once(string typeName)
+    {
+        var agent = Create(typeName);
+        var registered = RegisteredNetworks(agent);
+
+        var duplicates = registered.GroupBy(n => n, ReferenceComparer.Instance).Where(g => g.Count() > 1).ToList();
+        Assert.True(duplicates.Count == 0, $"{typeName} registers {duplicates.Count} network(s) more than once.");
+
+        foreach (var (fieldName, network) in NetworkFields(agent))
+        {
+            Assert.True(
+                registered.Any(r => ReferenceEquals(r, network)),
+                $"{typeName}.{fieldName} holds a {network.GetType().Name} that is not registered in Networks, " +
+                "so disposing the agent never releases it.");
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(DeepAgentTypes))]
+    public void Dispose_releases_every_layer_the_agent_owns(string typeName)
+    {
+        var agent = Create(typeName);
+        var layers = OwnedLayers(agent);
+        Assert.NotEmpty(layers);
+
+        agent.Dispose();
+
+        for (var i = 0; i < layers.Count; i++)
+        {
+            var (owner, layer) = layers[i];
+            // False means the layer was already released through the once-only guard -- what a network's
+            // (or a DuelingNetwork's) Dispose cascade does. True means this probe released it first.
+            Assert.False(
+                DisposeOnceGuard.TryDispose(layer),
+                $"{typeName}: a {layer.GetType().Name} owned via {owner} was still live after the agent was disposed.");
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(DeepAgentTypes))]
+    public void Disposing_an_agent_twice_is_harmless(string typeName)
+    {
+        var agent = Create(typeName);
+        agent.Dispose();
+        Assert.Null(Record.Exception(() => agent.Dispose()));
+    }
+
+    private static List<INeuralNetwork<double>> RegisteredNetworks(DeepReinforcementLearningAgentBase<double> agent)
+    {
+        var value = typeof(DeepReinforcementLearningAgentBase<double>)
+            .GetField("Networks", BindingFlags.Instance | BindingFlags.NonPublic)
+            ?.GetValue(agent);
+        return Assert.IsAssignableFrom<IEnumerable<INeuralNetwork<double>>>(value).ToList();
+    }
+
+    /// <summary>Every network held by a field declared on the concrete agent, directly or in a collection.</summary>
+    private static IEnumerable<(string Field, INeuralNetwork<double> Network)> NetworkFields(object agent)
+    {
+        for (var type = agent.GetType(); type is not null && type != typeof(DeepReinforcementLearningAgentBase<double>); type = type.BaseType)
+        {
+            foreach (var field in type.GetFields(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.DeclaredOnly))
+            {
+                switch (field.GetValue(agent))
+                {
+                    case INeuralNetwork<double> network:
+                        yield return (field.Name, network);
+                        break;
+                    case IEnumerable<INeuralNetwork<double>> networks:
+                        foreach (var n in networks.Where(n => n is not null)) yield return (field.Name + "[]", n);
+                        break;
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Every layer the agent owns: the layers of each network it holds, and the layers of any other
+    /// parameter-owning component (DuelingDQN's DuelingNetwork holds its DenseLayers directly).
+    /// </summary>
+    internal static List<(string Owner, IDisposable Layer)> OwnedLayers(object agent)
+    {
+        var found = new List<(string, IDisposable)>();
+        var visited = new List<object>();
+        Walk(agent, agent.GetType().Name, found, visited, depth: 0);
+        return found;
+    }
+
+    private static void Walk(object owner, string path, List<(string, IDisposable)> found, List<object> visited, int depth)
+    {
+        if (depth > 4 || visited.Any(v => ReferenceEquals(v, owner))) return;
+        visited.Add(owner);
+
+        for (var type = owner.GetType(); type is not null && type != typeof(object); type = type.BaseType)
+        {
+            foreach (var field in type.GetFields(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.DeclaredOnly))
+            {
+                Visit(field.GetValue(owner), path + "." + field.Name, found, visited, depth);
+            }
+        }
+    }
+
+    private static void Visit(object? value, string path, List<(string, IDisposable)> found, List<object> visited, int depth)
+    {
+        switch (value)
+        {
+            case null:
+            case string:
+                return;
+            case NeuralNetworkBase<double> network:
+                foreach (var layer in network.Layers) Add(layer, path, found);
+                return;
+            case ILayer<double> layer:
+                Add(layer, path, found);
+                return;
+            case IEnumerable sequence when value is not ReinforcementLearningAgentBase<double>:
+                var index = 0;
+                foreach (var item in sequence) Visit(item, $"{path}[{index++}]", found, visited, depth + 1);
+                return;
+            case IParameterSource<double> component when value is not ReinforcementLearningAgentBase<double>:
+                Walk(component, path, found, visited, depth + 1);
+                return;
+        }
+    }
+
+    private static void Add(ILayer<double> layer, string path, List<(string, IDisposable)> found)
+    {
+        if (layer is IDisposable disposable && !found.Any(f => ReferenceEquals(f.Item2, disposable)))
+        {
+            found.Add((path, disposable));
+        }
+    }
+
+    private sealed class ReferenceComparer : IEqualityComparer<object>
+    {
+        public static readonly ReferenceComparer Instance = new();
+        public new bool Equals(object? x, object? y) => ReferenceEquals(x, y);
+        public int GetHashCode(object obj) => System.Runtime.CompilerServices.RuntimeHelpers.GetHashCode(obj);
+    }
+}


### PR DESCRIPTION
## Summary

Disposing a model or an RL agent in this library was, in several places, either a no-op or unsafe. This branch makes ownership explicit and disposal idempotent across the model bases, the RL/trading agents, `AiModelResult` and `LayerBase`.

Ten commits, all on top of `3185b41f1`: 31 files, +1839 / -26. Every fix ships with a regression test that **fails on the code as it was** and passes after. 104 disposal tests now pass; the surrounding suites are unchanged.

| # | Commit | Area |
|---|---|---|
| 1 | `ac580d34` | `NeuralNetworkBase.Dispose` idempotent; public-entry guard on `ModelBase`, `TimeSeriesModelBase`, `AiModelResult` |
| 2 | `2b66dc69` | Trading agents release their networks |
| 3 | `41abacdc` | One failing network no longer skips the rest (both agent bases) |
| 4 | `5a441065` | Every deep RL agent registers its networks (CQL, IQL, TD3, DuelingDQN, QMIX) |
| 5 | `557c7197` | `AiModelResult` releases the model copies it makes |
| 6 | `9d5850da` | `RecurrentPolicyAgent` releases its LSTM cell |
| 7 | `a415224a` | A repeated layer `Dispose` no longer re-runs derived teardown |
| 8 | `202e60b4` | A lone disposal failure is rethrown unchanged; aggregate only for 2+ |
| 9 | `032f26ce` | `PortfolioExperimentRunner` disposes every agent it creates |
| 10 | `0270f363` | Meta-learning result releases the optimizer's separate `BestSolution` |

## Why this matters

A downstream app (OoplesFinance) now disposes the models and RL agents it trains, expecting pooled weight buffers, GPU allocations and compiled training plans to come back promptly rather than at the next GC. On this code that expectation was wrong in both directions:

* **No-op:** disposing a PPO/DQN/A2C/SAC trading agent released *nothing* — the base `Dispose` only called `GC.SuppressFinalize`. The same held for CQL, IQL, TD3 and DuelingDQN, and for every model copy an `AiModelResult` builds for itself.
* **Unsafe:** the app disposes both an `AiModelResult` (which disposes its inner `Model`) and the model it configured — often the same instance. A second `Dispose` re-ran the whole teardown, and that teardown is not local: `TapeTrainingStep<T>.InvalidateCache()` clears a **thread-global** cache, so re-disposing a long-dead network evicted the cache of whatever live model that thread had trained since.

## Per-area detail

Line numbers are at the base commit `3185b41f1`.

### 1. `NeuralNetworkBase.Dispose` was not idempotent (`ac580d34`)

**Root cause:** `src/NeuralNetworks/NeuralNetworkBase.cs:18238` — `Dispose(bool)` had no disposed flag. Each call re-ran `CompiledTapeTrainingStep.InvalidateIfOwnedBy`, `TapeTrainingStep.InvalidateCache()` (`:18260`, thread-global), `_compileHost.Dispose()`, the layer cascade and the memory-management / mixed-precision teardown. `ModelBase.cs:571`, `TimeSeries/TimeSeriesModelBase.cs:2848` and `Models/Results/AiModelResult.cs:7512` guarded their own `Dispose(bool)` but their public `Dispose()` still re-entered *derived* overrides on every call, and overrides do their own teardown before calling base.

**Change:** a private `_disposed` flag checked and set at the top of `NeuralNetworkBase.Dispose(bool)`; all four public `Dispose()` entry points return early once disposed. First-call behaviour is untouched.

| | Before | After |
|---|---|---|
| 2nd `Dispose()` of a network | full teardown re-runs | no-op |
| Live model's tape cache after re-disposing another network | evicted | intact |
| Derived `Dispose(bool)` across 3 calls (e.g. `Blip2NeuralNetwork` disposing sub-models) | runs 3× | runs 1× |
| `AiModelResult.Dispose()` then `model.Dispose()` (same instance) | teardown 2× | 1× |

### 2. Trading agents never released their networks (`2b66dc69`)

**Root cause:** `src/Finance/Trading/Agents/TradingAgentBase.cs:47` derives from `ReinforcementLearningAgentBase<T>`, whose `Dispose` (`src/ReinforcementLearning/Agents/ReinforcementLearningAgentBase.cs:809`) only suppresses finalization, and `TradingAgentBase` had no override and no record of its networks. `FinRLAgent.cs:53` wraps an inner agent it constructs and never released it either.

**Change:** `TradingAgentBase` gains the ownership model `DeepReinforcementLearningAgentBase` already uses — a protected `[ExternalState] Networks` list that each concrete agent fills in its constructor — plus a `Dispose` override that releases every entry through `DisposeOnceGuard` (the once-only guard `NeuralNetworkBase` already uses for layers). `FinRLAgent.Dispose` releases the inner agent.

| Agent | Networks before | Networks after |
|---|---|---|
| `FinancialPPOAgent` | 0 of 2 released | 2 of 2 |
| `FinancialDQNAgent` | 0 of 2 | 2 of 2 |
| `FinancialA2CAgent` | 0 of 2 | 2 of 2 |
| `FinancialSACAgent` | 0 of 5 | 5 of 5 |
| `MarketMakingAgent` | 0 of 1 | 1 of 1 |
| `FinRLAgent` | 0 (inner agent leaked) | inner agent released |

Replay buffers, trajectories and the Adam optimizers these agents hold are not `IDisposable`, so there is nothing else to release.

### 3. One failing network skipped all the others (`41abacdc`)

**Root cause:** `DeepReinforcementLearningAgentBase.cs:128` disposed `Networks` in a plain loop; the first `Dispose` that threw ended the loop and leaked every network after it. `TradingAgentBase` inherited the same shape.

**Change:** new internal helper `DisposeOnceGuard.DisposeAll(owned, owner)` — releases each item at most once, continues past failures, then reports them. Both bases use it; `base.Dispose()` still runs in a `finally`.

### 4. Deep RL agents that never registered their networks (`5a441065`)

**Root cause:** `DeepReinforcementLearningAgentBase.Dispose` releases only what an agent puts in `Networks`.

* `CQLAgent.cs:110-114`, `IQLAgent.cs:119-123`, `TD3Agent.cs:121-129` construct 5, 5 and 6 networks and register none.
* `DuelingDQNAgent` holds `DuelingNetwork<T>` (`DuelingDQNAgent.cs:315`), which is `IParameterSource<T>` only — not an `INeuralNetwork<T>`, so it could not be registered, and it owns its `DenseLayer`s directly.
* `QMIXAgent.cs:118-119` built a pair of mixing networks in the constructor and then called `InitializeNetworks`, which built and registered a *second* pair at `:131-132`. The first pair was dropped undisposed.

**Change:** CQL/IQL/TD3 register each network once; `DuelingNetwork` is now `IDisposable` (releases its shared/value/advantage dense layers) and `DuelingDQNAgent` overrides `Dispose`; QMIX's duplicate construction is removed (`[MemberNotNull]` on `InitializeNetworks` keeps nullability satisfied).

| Agent | Before | After |
|---|---|---|
| `CQLAgent` | 0 of 5 networks released | 5 of 5 |
| `IQLAgent` | 0 of 5 | 5 of 5 |
| `TD3Agent` | 0 of 6 | 6 of 6 |
| `DuelingDQNAgent` | 0 of 2 (all dense layers leaked) | 2 of 2 |
| `QMIXAgent` | 1 extra mixing pair built and leaked | built once |

### 5. `AiModelResult` never released the copies it makes (`557c7197`, `0270f363`)

**Root cause:** `Models/Results/AiModelResult.cs:7519` released only `Model`. The result also holds model instances nobody else references:

* the clone stateless inference optimizations rewrite — `:3055` (`_inferenceOptimizedNeuralModel`);
* a clone the optimizer made and then had nothing to apply to, dropped on the spot at the same line;
* the per-sequence KV-cache / Multi-LoRA clone at `:3400`, which `InferenceSequence.Dispose` (`:3292`) never released — it only cleared the cache;
* extra deep-ensemble members, trained by the builder for this result (`AiModelBuilder.Internals.cs:1444`);
* on the meta-learning path (`:1679`, `Model = options.MetaLearner.BaseModel`) the optimizer's `OptimizationResult.BestSolution`, a separate instance.

**Change:** ownership is recorded when each copy is created (`_ownsInferenceOptimizedNeuralModel`, `_ownsSequenceModel`), so a "copy" that is `Model` itself is only released as `Model`, and a sequence never releases the result's `Model`. Copies are released **before** `Model`: a copy-on-write clone shares the source's weight storage and only the source holds the pooled array behind it. `Deserialize` now releases the old copy instead of dropping it. Everything is released through `DisposeOnceGuard.DisposeAll`, so an instance reachable by two paths (best solution that is also an ensemble member) is released once.

| Held instance | Before | After |
|---|---|---|
| Inference-optimized clone | never disposed | disposed with the result |
| Optimizer clone with nothing applied | dropped, GC only | disposed immediately |
| Per-sequence clone | never disposed | disposed with the sequence |
| Deep-ensemble members | never disposed | disposed with the result |
| Meta-learning `BestSolution` | never disposed | disposed with the result, once |

### 6. `RecurrentPolicyAgent` was not disposable (`9d5850da`)

**Root cause:** `src/Finance/Trading/Agents/RecurrentPolicyAgent.cs:34` implements only `IPortfolioAgent<T>` while owning a `DeepARLstmCellTape<T>` layer (pool-rented weights, registered engine state). Callers had no way to release it.

**Change:** it implements `IDisposable` following the agent bases — the cell is released through `DisposeOnceGuard.DisposeAll`, repeated calls are no-ops. The head tensors `_meanW`/`_meanB` are ordinary tensors with nothing to release.

### 7. Repeated layer `Dispose` re-ran derived teardown (`a415224a`)

**Root cause:** `src/NeuralNetworks/Layers/LayerBase.cs:9351` — `Dispose()` called `Dispose(true)` unconditionally. `LayerBase.Dispose(bool)` guarded its own work, but derived overrides run their teardown *before* calling base. `DenseLayer.cs:1767` re-invalidates the engine's GPU cache entry for `_weights`/`_biases` — tensors whose pooled storage the first call already returned and a newer layer may now own.

**Change:** `Dispose()` returns early once disposed, reading the flag under the same lock `Dispose(bool)` sets it under.

| | Before | After |
|---|---|---|
| `DenseLayer` override across 3 disposes | 3× (3 GPU-cache invalidations of returned storage) | 1× |
| `ReturnPooledParameters` | 1× (already guarded) | 1× |
| Guard-then-direct and direct-then-guard | teardown 2× | 1× |

### 8. Exception-type compatibility (`202e60b4`)

**Root cause:** the new `DisposeAll` wrapped *every* failure in an `AggregateException`, including a single one. That changed what callers could catch from `Dispose` — `AiModelResult.Dispose` used to call `Model.Dispose()` directly, so a caller catching, say, `InvalidOperationException` stopped catching it.

**Change:** exactly one failure is rethrown through `ExceptionDispatchInfo`, preserving type and the original stack; only two or more are wrapped in an `AggregateException` (the library's convention for multi-resource disposal, cf. `DataPipeline.cs:387`).

### 9. `PortfolioExperimentRunner` leaked every agent it built (`032f26ce`)

**Root cause:** `src/Finance/Trading/Evaluation/PortfolioAgentTraining.cs:179` — the runner builds a fresh agent per experiment through the caller's factory, trains and evaluates it, and never hands it back or disposes it. Each `RecurrentPolicyAgent` kept its pool-rented LSTM cell until GC.

**Change:** each `IDisposable` agent is disposed after its holdout evaluation and also when training or evaluation throws; on that path a `Dispose` failure is traced and swallowed so the original failure is what the caller sees.

## Agent audit (complete)

**20 agents deriving from `DeepReinforcementLearningAgentBase`** — all checked, each now registers every network it owns:

`A2C`, `A3C`, `CQL`\*, `DDPG`, `DQN`, `DecisionTransformer`, `DoubleDQN`, `Dreamer`, `DuelingDQN`\*, `IQL`\*, `MADDPG`, `MuZero`, `PPO`, `QMIX`\*, `REINFORCE`, `RainbowDQN`, `SAC`, `TD3`\*, `TRPO`, `WorldModels`.  (\* = was broken, fixed here. `MADDPG` and `QMIX` already registered their per-agent networks — an earlier report of mine that MADDPG was broken was wrong.)

**6 agents deriving from `TradingAgentBase`** (which derives from `ReinforcementLearningAgentBase`, not the deep base): `FinancialPPOAgent`, `FinancialDQNAgent`, `FinancialA2CAgent`, `FinancialSACAgent`, `MarketMakingAgent`, `FinRLAgent` — all were broken, all fixed.

**29 agents deriving from `ReinforcementLearningAgentBase` directly** — checked, none owns disposable state (tables, matrices, `Random`), so nothing to release:

`DoubleQLearning`, `DynaQ`, `DynaQPlus`, `EpsilonGreedyBandit`, `EveryVisitMonteCarlo`, `ExpectedSARSA`, `FirstVisitMonteCarlo`, `GradientBandit`, `LinearQLearning`, `LinearSARSA`, `LSPI`, `LSTD`, `ModifiedPolicyIteration`, `MonteCarloExploringStarts`, `NStepQLearning`, `NStepSARSA`, `OffPolicyMonteCarlo`, `OnPolicyMonteCarlo`, `PolicyIteration`, `PrioritizedSweeping`, `QLambda`, `SARSA`, `SARSALambda`, `TabularActorCritic`, `TabularQLearning`, `ThompsonSampling`, `UCBBandit`, `ValueIteration`, `WatkinsQLambda`.

**Policies** (`PolicyBase` and its 6 subclasses) receive their networks through the constructor, so they are non-owning and correctly do not dispose them.

## Test evidence

Ten new test classes, 104 tests. Each was run against the unfixed code first.

| Test class | Covers | Before | After |
|---|---|---|---|
| `ModelDisposeIdempotencyTests` | double dispose of network / `ModelBase` / `TimeSeriesModelBase` / `AiModelResult`, thread-global cache | 6 fail | pass |
| `TradingAgentDisposalTests` | 7 trading-agent configurations, networks found by reflecting over fields | 7 fail | pass |
| `TradingAgentSharedNetworkDisposalTests` | one network held by two fields | (needs the new API) | pass |
| `DeepAgentDisposalTests` | all 20 deep agents, discovered by reflection | 7 fail | pass |
| `AgentDisposalFailureTests` | failure during disposal, both bases | 4 fail | pass |
| `AiModelResultDerivedCopyDisposalTests` | inference copy, sequence copy, ensemble, meta-learning best solution | 3 fail | pass |
| `RecurrentPolicyAgentDisposalTests` | agent releases its LSTM cell | 1 fail | pass |
| `LayerDisposeIdempotencyTests` | `DenseLayer` teardown and pooled returns exactly once | 3 fail | pass |
| `DisposeOnceGuardDisposeAllTests` | 1 failure rethrown unchanged, 2+ aggregated, none | 1 fail | pass |
| `PortfolioExperimentRunnerDisposalTests` | runner disposes agents on success and failure paths | 3 fail | pass |

Two tests in `TradingAgentSharedNetworkDisposalTests` exercise the new `Networks` API and therefore could not compile against the old code; they are noted as such rather than claimed as fails-before.

**Surrounding suites** (net10.0, `--no-build`, before → after):

| Suite | Before | After |
|---|---|---|
| Anything matching `Dispos`, RL integration + unit, Finance unit, architecture-sharing / copy-on-write / compiled-host | 515 pass | 515 pass |
| All RL agent tests (RL namespaces, generated `*AgentTests`, `FinanceTradingAgentsIntegrationTests`) | 550 pass | 550 pass |
| Inference, `AiModelResult`, layer unit tests, `AllLayersCloneTests` | 360 pass | 360 pass |
| Finance integration + NeuralNetworks unit | 2027 pass, 1 fail, 3 skip | 2027 pass, 1 fail, 3 skip |

The single failure is `QuantumStateEncodingRegressionTests.QuantumLayer_GpuPrescaling_MatchesCpuForZeroAndSmallestNormalRows`, a GPU test that fails identically on `master`.

**Builds:** `dotnet build src/AiDotNet.csproj -c Release` compiles net10.0, net8.0 and net471 with 0 errors. The set of source warnings is byte-identical before and after (1717 unique net10.0 warnings).

**Checked, no bug found:** because copies are now disposed, I probed whether disposing a model corrupts a live copy-on-write clone of it — cloned a network, disposed the source, then built and trained 20 same-shaped networks to churn the pool. The clone's outputs and parameters were unchanged (max delta 0).

## Behaviour changes a caller could see

1. **Disposing an agent now actually releases its networks.** Code that disposed a PPO/DQN/A2C/SAC/MarketMaking/FinRL, CQL, IQL, TD3 or DuelingDQN agent and kept using its networks afterwards relied on the no-op and will now fail. `FinRLAgent.Dispose` also disposes the inner agent it created.
2. **Double `Dispose` is a no-op** on `NeuralNetworkBase`, `ModelBase`, `TimeSeriesModelBase`, `AiModelResult` and `LayerBase` — derived `Dispose(bool)` overrides are no longer re-entered through the public entry point. A subclass that relied on its override running twice changes behaviour.
3. **Disposal failures:** exactly one failure propagates unchanged (type and stack preserved); **two or more** are wrapped in an `AggregateException`. This applies to both agent bases, `DuelingDQNAgent`, `DuelingNetwork`, `RecurrentPolicyAgent` and `AiModelResult.Dispose`.
4. **`AiModelResult.Dispose` releases more than `Model`:** the inference-optimized copy, per-sequence copies, deep-ensemble members and — on the meta-learning path or after `Deserialize` — `OptimizationResult.BestSolution`. If any of those instances is also held elsewhere, it is now disposed. `InferenceSequence.Dispose` releases the copy it made (it keeps its documented never-throw contract).
5. **`PortfolioExperimentRunner.Run` disposes each agent it creates.** If an agent's `Dispose` throws after a successful holdout run, `Run` now throws instead of returning results. On the failure path the original exception still wins.
6. **`QMIXAgent` builds its mixing networks once** instead of twice. Layer initialization draws differ, so a QMIX agent's initial weights may differ from before for the same options.
7. **New API surface (all additive):** `protected readonly List<INeuralNetwork<T>> Networks` on `TradingAgentBase` (an external subclass with a member of that name would now get a hiding warning); `RecurrentPolicyAgent<T> : IDisposable`; `DuelingNetwork<T> : IDisposable` (internal type); `internal DisposeOnceGuard.DisposeAll`. **No existing public signature changed** — in particular `TradingAgentBase.EnsureDefaultLayers` is untouched on this branch.
8. `AiModelResult` gains two private ownership flags; they are `[JsonIgnore]` and do not affect the serialized payload.

## Blast radius / file map

**Source (21 files, +~330 lines)**

* Disposal infrastructure: `src/Helpers/DisposeOnceGuard.cs`
* Model bases: `src/NeuralNetworks/NeuralNetworkBase.cs`, `src/Models/ModelBase.cs`, `src/TimeSeries/TimeSeriesModelBase.cs`, `src/NeuralNetworks/Layers/LayerBase.cs`
* Results: `src/Models/Results/AiModelResult.cs`
* RL: `src/ReinforcementLearning/Agents/{DeepReinforcementLearningAgentBase,CQLAgent,IQLAgent,TD3Agent,DuelingDQNAgent,QMIXAgent}.cs`
* Finance: `src/Finance/Trading/Agents/{TradingAgentBase,FinancialPPOAgent,FinancialDQNAgent,FinancialA2CAgent,FinancialSACAgent,MarketMakingAgent,FinRLAgent,RecurrentPolicyAgent}.cs`, `src/Finance/Trading/Evaluation/PortfolioAgentTraining.cs`

The four public `Dispose()` entry points are the widest-reaching change: they sit under ~672 `Dispose(bool)` overrides in `src`. Their first-call behaviour is unchanged; only repeated calls differ.

**Tests (10 new files, +1389 lines)** under `tests/AiDotNet.Tests/UnitTests/{NeuralNetworks,Finance,ReinforcementLearning,Models,Helpers}`. No existing test file was modified except the round-2 `AgentDisposalFailureTests`, updated in commit 8 for the new single-failure contract.

## What this does not do

* **Paged KV cache:** a sequence's `InferenceOptimizer` holds a `PagedKVCache<T>` that is never disposed. Its `Dispose` only clears managed bookkeeping, so the GC reclaims it; `InferenceOptimizer` itself is not `IDisposable`. Left as is deliberately.
* **`FeedforwardPolicyAgent`:** owns no disposable state (plain tensors and an Adam optimizer), so it stays non-disposable.
* **Layer subclasses called through `Dispose(bool)` directly** still re-run their own teardown; only the public `Dispose()` path is guarded.
* **`OptimizationResult.BestSolution` sharing:** the fix assumes the result is its only owner, which holds today (`WithParameters`/`DeepCopy` deep-copy the result and replace `BestSolution`).
* **No thread-safety guarantees were added:** disposing concurrently with a prediction on another thread is still the caller's responsibility.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017otuSGr3GdmvPoYLbiaWR2
